### PR TITLE
feat(rakuast): ADR-0033 Phase 2 -- classify Whatever leaves as value vs priming argument

### DIFF
--- a/docs/adr/0033-whatever-priming-leaf-and-derived-scope.md
+++ b/docs/adr/0033-whatever-priming-leaf-and-derived-scope.md
@@ -1,8 +1,7 @@
 # ADR-0033: Whatever-priming is a leaf property plus a derived scope — defer `WhateverCode` construction out of the parser
 
-- **Status**: Phase 1 shipped (2026-08-19). Phase 2 designed in implementable detail
-  (2026-08-20, see "Phase 2 detailed design" below) but not implemented; Phases 3-4 not
-  started — see "Outcome" below.
+- **Status**: Phase 1 shipped (2026-08-19). Phase 2 shipped (2026-08-20, see "Phase 2
+  outcome" below). Phases 3-4 not started.
 - **Scope**: Owns the `WhateverCode` item of
   [`todo/deep/rakuast-remaining.md`](../../todo/deep/rakuast-remaining.md) — both its
   read-direction half ("`* + 1` has no `.AST`") and its lowering half ("`EVAL` of a
@@ -464,6 +463,74 @@ that actually changes `&&`/`||`/`//`/ternary priming results) is a separate, hig
 change that deserves its own PR and its own `t/whatever-thunky-operators.t`. Phases 2/3
 (RakuAST read/write for `* + 1`) remain open items in
 [`todo/deep/rakuast-remaining.md`](../../todo/deep/rakuast-remaining.md).
+
+## Phase 2 outcome (2026-08-20)
+
+Implemented exactly per "Phase 2 detailed design" below. `src/whatever_curry/mark.rs` adds
+`mark_program(&mut stmts)`, a single top-down walk invoked once from
+`parser::parse_program` right after a program parses. It rewrites every `Expr::Whatever`
+leaf to `Expr::WhateverArg` unless the leaf's immediate syntactic parent is one of the
+value positions in section 2.1's table (comma operand, range/series endpoint, `xx`
+operand, assignment/bind RHS, call/method argument, whole-slice subscript, non-currying
+pseudo-method target, bareword-pair value, or a bare `*` standing alone as a whole
+statement/grouping); everything else becomes `Argument`. The predicates are genuinely
+scope-independent, not derived from `contains_whatever`/`should_wrap_whatevercode` (the
+`1 x *` and `* Z 1`/`* X 1` counter-examples from section 2.1 are both classified
+`Argument` correctly even though mutsu plants no `WhateverCurry` scope for them).
+
+`crate::parser::is_whatever` widened to `matches!(expr, Expr::Whatever | Expr::WhateverArg)`
+per section 2.2's invariant; the four remaining variant-literal `matches!(&**left/right,
+Expr::Whatever)` tests in the `x`/`xx` arms (`whatever.rs`) now go through it. Verified by
+construction (every scope/arity predicate is built on this one helper) and by the full
+`t/*whatever*.t` (35 files) + `roast/S02-types/{whatever,hyperwhatever}.t` +
+`roast/S03-operators/composition.t` + `roast/S12-subset/{multi-dispatch,subtypes,
+type-subset}.t` sweep passing unchanged.
+
+`src/rakuast/mod.rs` gained `RakuAstClass::WhateverCodeArgument`
+(`"RakuAST::WhateverCode::Argument"`, bare `.new`) and `RakuAstClass::TermHyperWhatever`
+(`"RakuAST::Term::HyperWhatever"`, bare `.new`); `WhateverCodeArgument` was added explicitly
+to the `semantic_ancestors`/`semantic_type_object_ancestors` TERM set (the section 2.4 trap:
+its printed name does not start with `RakuAST::Term::`, so the name-prefix rule would
+otherwise silently make `~~ RakuAST::Term` false). `src/rakuast/convert.rs` gained arms for
+`Expr::WhateverArg` (-> `WhateverCodeArgument`), `Expr::HyperWhatever` (-> `TermHyperWhatever`,
+a read-direction-only bonus per section 2.4 — priming for `**` stays out of scope), and
+`Expr::WhateverCurry(body)` (-> `convert_expr(body)`, no wrapper node, matching Rakudo's
+scope-free tree).
+
+Section 2.5's three remaining eager-closure sites were converted to plant
+`Expr::WhateverCurry` instead of building a `Lambda` by hand: `* ~~ Type` and `Type ~~ *`
+(`src/parser/expr/precedence/comparison.rs`, covering `~~` and `!~~` both). This required
+re-checking the SmartMatch/BangTilde asymmetry the ADR's section 2.5 called out:
+`count_whatever`/`replace_whatever_numbered`/`replace_whatever_single`
+(`src/whatever_curry/{build,replace}.rs`) only counted/substituted the *left* operand
+(the historical "Whatever on the RHS is runtime-autoprimed, not curried" rule for a
+*compound* RHS); they now also count/substitute a *bare* right-hand placeholder, which is
+exactly what the newly-planted `X ~~ *` marker needs. This incidentally fixed a latent
+mutsu bug: `$_ ~~ *`'s closure previously replaced the *outer* `$_` too (so the closure
+ignored the caller's dynamic topic), where raku's `-> $a { $_ ~~ $a }` reads the outer
+topic on the left and only primes the right — verified against raku
+(`$_ = 10; ($_ ~~ *)(3)` is `False`, i.e. `10 ~~ 3`, in both). The compound-assignment
+family (`* += 1`) stays a boundary, per section 2.5's own scoping (needs a
+`MetaInfix::Assign` class mutsu lacks — an operator-cluster-wide gap, not Whatever-specific).
+
+Two adjacent RakuAST rendering bugs surfaced (and were fixed) because this section's
+`~~`/`!~~`/`=>` constructs no longer die at the `.AST` boundary before reaching them:
+`token_kind_to_op_name` (`src/compiler/helpers_ops.rs`) rendered `!~~` as the internal
+two-tilde string `"!~"` and `=>` via its `{:?}` Debug fallback (`"FatArrow"`) — neither
+is reachable from the compiled-bytecode dispatch path (`!~~`/`~~` compile via the
+dedicated `OpCode::SmartMatchExpr`, never through the generic `InfixFunc` fallback that
+calls this function), so fixing the strings to `"!~~"` / `"=>"` (and the reverse
+`op_name_to_token_kind` lowering table) is display-only and safe.
+
+Section 2.6's two divergences (chained comparison, `* .= lc`) are left exactly as
+documented — not attempted.
+
+New dual-oracle test: `t/rakuast-whatever-code.t` (68 assertions), passing verbatim under
+both `target/debug/mutsu` and the system `raku`. Covers every row of section 2.7's test
+plan except `[*]` (excluded with an inline comment: mutsu currently parses a standalone
+`[*]` as the `[*]`-reduction metaoperator over an empty list — a pre-existing,
+Whatever-unrelated parse ambiguity with no `*` node in the tree to classify either way —
+while raku renders `Term::Whatever`; out of scope for this ADR).
 
 ## Phase 2 detailed design (added 2026-08-20)
 

--- a/news/2026-08/adr0033-phase2-whatever-leaf-split.md
+++ b/news/2026-08/adr0033-phase2-whatever-leaf-split.md
@@ -1,0 +1,54 @@
+# ADR-0033 Phase 2: `*` leaf classification, `Q[* + 1].AST` now works
+
+`Q[* + 1].AST` used to error with "`.AST` does not yet support this construct:
+WhateverCurry(...)" because mutsu's parser had no way to tell Rakudo's converter
+that a `*` was a Whatever-priming *argument* (`RakuAST::WhateverCode::Argument`)
+rather than a `Whatever` *value* (`RakuAST::Term::Whatever`) — both parsed to
+the same `Expr::Whatever` AST node. ADR-0033 Phase 1 (2026-08-19) had already
+added an inert `Expr::WhateverArg` sibling variant and deferred WhateverCode
+closure construction out of the parser into the compiler; Phase 2 makes that
+sibling variant real.
+
+A new post-parse pass, `src/whatever_curry/mark.rs`'s `mark_program`, walks
+every freshly-parsed program once and reclassifies each `Expr::Whatever` leaf
+to `Expr::WhateverArg` unless its immediate syntactic parent is one of the
+*value* positions measured against the system `raku` (a comma operand, a
+range/series endpoint, an `xx` operand, an assignment/bind RHS, a call/method
+argument, a whole-slice subscript `@a[*]`, a non-currying pseudo-method target
+like `*.WHAT`, a bareword pair value, or a bare `*` standing alone). The rule
+is deliberately syntactic and scope-independent, not derived from mutsu's
+existing "does this subtree curry" predicates — `1 x *` and `* Z 1` are both
+`WhateverCode::Argument` in raku even though mutsu plants no priming scope for
+either, which a scope-derived classifier would get wrong.
+
+The change is a pure annotation: outside `src/rakuast/`, `Expr::WhateverArg`
+and `Expr::Whatever` stay indistinguishable (`crate::parser::is_whatever`
+treats them identically, and both compile to the same `LoadConst(Value::WHATEVER)`),
+so a misclassified leaf can only produce a wrong `.AST` gist, never a wrong
+program result. `src/rakuast/mod.rs` gained `RakuAST::WhateverCode::Argument`
+and, as a read-direction bonus, `RakuAST::Term::HyperWhatever` for `**`.
+
+Along the way, three remaining hand-built WhateverCode closures (`* ~~ Type`,
+`Type ~~ *`, and their `!~~` negation) were converted to plant the same
+`Expr::WhateverCurry` marker as every other Whatever construct, which required
+re-checking (and generalizing) the smartmatch-specific arity/substitution
+logic that historically only looked at the left operand. That conversion
+surfaced and fixed two adjacent RakuAST rendering bugs (`!~~` and `=>` were
+rendering as mutsu's internal dispatch strings, `"!~"` and `"FatArrow"`) and
+one latent runtime bug: `$_ ~~ *`'s generated closure previously replaced the
+*outer* `$_` too, so it ignored the caller's dynamic topic — raku's actual
+semantics read the outer `$_` on the left and only prime the right (verified:
+`$_ = 10; ($_ ~~ *)(3)` is `False`, i.e. `10 ~~ 3`, in both raku and mutsu now).
+
+Pinned by a new dual-oracle `t/rakuast-whatever-code.t` (68 assertions),
+passing verbatim under both `target/debug/mutsu` and the system `raku`. The
+full `t/*whatever*.t` suite (35 files), `t/rakuast-*.t` (88 files), and the
+relevant roast whitelist entries (`S02-types/{whatever,hyperwhatever}.t`,
+`S03-operators/composition.t`, `S12-subset/{multi-dispatch,subtypes,
+type-subset}.t`) all stayed green.
+
+Phase 4 — the thunk-barrier priming *correctness* fix (mutsu currently primes
+straight through `&&`/`||`/`//`/ternary, so `(1..10).grep(* > 3 && * < 8)`
+silently returns the wrong list) — is the next highest-payoff slice; Phase 2's
+leaf split is its prerequisite. See
+[`docs/adr/0033-whatever-priming-leaf-and-derived-scope.md`](../../docs/adr/0033-whatever-priming-leaf-and-derived-scope.md).

--- a/src/compiler/expr.rs
+++ b/src/compiler/expr.rs
@@ -52,10 +52,13 @@ impl Compiler {
                 let idx = self.code.add_constant(Value::WHATEVER);
                 self.code.emit(OpCode::LoadConst(idx));
             }
-            // Not yet produced by the parser (ADR-0033 Phase 1 defers only the
-            // closure-building step; leaf-splitting into a real `WhateverArg`
-            // producer is Phase 2/4). Compile identically to a bare `Whatever`
-            // so the arm is reachable-but-harmless until then.
+            // A `*` marked as a priming argument by the post-parse classifier
+            // (`src/whatever_curry/mark.rs`, ADR-0033 Phase 2). This is a pure
+            // read-direction annotation for RakuAST (`.AST` renders it as
+            // `RakuAST::WhateverCode::Argument`) — it must keep compiling
+            // identically to a bare `Whatever` so runtime behaviour is
+            // unchanged (`(1 x *).WHAT` still autoprimes at runtime even
+            // though the classifier marks that `*` `WhateverArg`).
             Expr::WhateverArg => {
                 let idx = self.code.add_constant(Value::WHATEVER);
                 self.code.emit(OpCode::LoadConst(idx));

--- a/src/compiler/expr_call.rs
+++ b/src/compiler/expr_call.rs
@@ -816,8 +816,8 @@ impl Compiler {
                 && let Expr::Binary { left, op, right } = body.as_ref()
                 && *op == TokenKind::Plus
                 && let delta = match (left.as_ref(), right.as_ref()) {
-                    (Expr::Whatever, rhs) => Some(rhs.clone()),
-                    (lhs, Expr::Whatever) => Some(lhs.clone()),
+                    (lhs, rhs) if crate::parser::is_whatever(lhs) => Some(rhs.clone()),
+                    (lhs, rhs) if crate::parser::is_whatever(rhs) => Some(lhs.clone()),
                     _ => None,
                 }
                 && let Some(delta) = delta

--- a/src/compiler/helpers_ops.rs
+++ b/src/compiler/helpers_ops.rs
@@ -27,7 +27,15 @@ pub(crate) fn token_kind_to_op_name(op: &TokenKind) -> String {
         TokenKind::OrOr => "||".to_string(),
         TokenKind::XorXor => "^^".to_string(),
         TokenKind::SmartMatch => "~~".to_string(),
-        TokenKind::BangTilde => "!~".to_string(),
+        // `!~~` compiles via the dedicated `OpCode::SmartMatchExpr` path
+        // (`compiler/expr_binary.rs`'s `SmartMatch | BangTilde` arm, which
+        // always returns before reaching the generic `InfixFunc` fallback
+        // that calls this function), so this string is read only by
+        // `RakuAST::Infix` rendering (ADR-0033 Phase 2 section 2.5) and by
+        // any other operator-name display -- it must be the real raku
+        // operator spelling, not mutsu's old (wrong) two-tilde name.
+        TokenKind::BangTilde => "!~~".to_string(),
+        TokenKind::FatArrow => "=>".to_string(),
         TokenKind::LtEqGt => "<=>".to_string(),
         TokenKind::EqEqEq => "===".to_string(),
         TokenKind::BangEqEqEq => "!===".to_string(),
@@ -109,9 +117,8 @@ pub(crate) fn op_name_to_token_kind(name: &str) -> Option<TokenKind> {
         "!" => TokenKind::Bang,
         "?" => TokenKind::Question,
         "~~" => TokenKind::SmartMatch,
-        // `x => 5` — the pair constructor renders with its Debug name (there is
-        // no `=>` spelling in `token_kind_to_op_name`).
-        "FatArrow" => TokenKind::FatArrow,
+        "!~~" => TokenKind::BangTilde,
+        "=>" => TokenKind::FatArrow,
         // Any remaining operator name is a named infix (`x`, `xx`, `eq`, `ne`,
         // `lt`/`gt`/`le`/`ge`, `cmp`, `leg`, `div`, `mod`, ...), which mutsu
         // represents with a generic `Ident` token (the inverse of

--- a/src/parser/expr/precedence/comparison.rs
+++ b/src/parser/expr/precedence/comparison.rs
@@ -333,20 +333,18 @@ pub(crate) fn comparison_expr_mode(input: &str, mode: ExprMode) -> PResult<'_, E
             if matches!(&left, Expr::Whatever) {
                 let lhs_text = input[..input.len() - rest.len()].trim_start();
                 if !lhs_text.starts_with('(') {
+                    // ADR-0033 Phase 2 section 2.5: plant a `WhateverCurry`
+                    // marker over the un-curried `* ~~ Type` body instead of
+                    // eagerly building the closure, so `.AST` can render the
+                    // leaf as `RakuAST::WhateverCode::Argument`. `build_closure`
+                    // reproduces the same `Lambda { param: "_", .. }` closure
+                    // this used to construct by hand.
                     let sm_expr = Expr::Binary {
-                        left: Box::new(Expr::Var("_".to_string())),
+                        left: Box::new(left),
                         op: op.token_kind(),
                         right: Box::new(right),
                     };
-                    return Ok((
-                        r,
-                        Expr::Lambda {
-                            param: "_".to_string(),
-                            body: vec![crate::ast::Stmt::Expr(sm_expr)],
-                            is_whatever_code: true,
-                            param_sigilless: false,
-                        },
-                    ));
+                    return Ok((r, Expr::WhateverCurry(Box::new(sm_expr))));
                 }
             }
             // Bare `X ~~ *` autoprimes to a WhateverCode `-> $a { X ~~ $a }`.
@@ -359,20 +357,14 @@ pub(crate) fn comparison_expr_mode(input: &str, mode: ExprMode) -> PResult<'_, E
             if matches!(&right, Expr::Whatever) {
                 let rhs_text = rhs_start[..rhs_start.len() - r.len()].trim_start();
                 if !rhs_text.starts_with('(') {
+                    // ADR-0033 Phase 2 section 2.5: same deferral as the LHS
+                    // case above, for `X ~~ *`.
                     let sm_expr = Expr::Binary {
                         left: Box::new(left),
                         op: op.token_kind(),
-                        right: Box::new(Expr::Var("_".to_string())),
+                        right: Box::new(right),
                     };
-                    return Ok((
-                        r,
-                        Expr::Lambda {
-                            param: "_".to_string(),
-                            body: vec![crate::ast::Stmt::Expr(sm_expr)],
-                            is_whatever_code: true,
-                            param_sigilless: false,
-                        },
-                    ));
+                    return Ok((r, Expr::WhateverCurry(Box::new(sm_expr))));
                 }
             }
         }

--- a/src/parser/expr/whatever.rs
+++ b/src/parser/expr/whatever.rs
@@ -55,8 +55,8 @@ pub(crate) fn should_wrap_whatevercode(expr: &Expr) -> bool {
             op: TokenKind::Ident(name),
             left,
             right,
-        } if ((name == "x" || name == "xx") && matches!(&**right, Expr::Whatever))
-            || (name == "xx" && matches!(&**left, Expr::Whatever)) =>
+        } if ((name == "x" || name == "xx") && is_whatever(right))
+            || (name == "xx" && is_whatever(left)) =>
         {
             false
         }
@@ -107,8 +107,8 @@ fn contains_xx_with_bare_whatever(expr: &Expr) -> bool {
             // point — so an enclosing postfix (`(* xx 3).elems`) must not wrap the
             // whole chain into a WhateverCode either. (`x`/`xx` with a right `*` was
             // already exempt; string `* x 2` DOES curry, so only `xx` exempts left.)
-            ((name == "xx" || name == "x") && matches!(&**right, Expr::Whatever))
-                || (name == "xx" && matches!(&**left, Expr::Whatever))
+            ((name == "xx" || name == "x") && is_whatever(right))
+                || (name == "xx" && is_whatever(left))
                 || contains_xx_with_bare_whatever(left)
                 || contains_xx_with_bare_whatever(right)
         }
@@ -135,8 +135,13 @@ fn contains_xx_with_bare_whatever(expr: &Expr) -> bool {
     }
 }
 
+/// True for a bare `*` leaf — either a `Whatever` *value* or a `WhateverArg`
+/// *priming argument* (ADR-0033 Phase 2). Outside `src/rakuast/`, the two are
+/// deliberately indistinguishable: every scope/arity predicate built on this
+/// helper must keep computing exactly what it computes today regardless of
+/// which leaf the classifier in `src/whatever_curry/mark.rs` produced.
 pub(crate) fn is_whatever(expr: &Expr) -> bool {
-    matches!(expr, Expr::Whatever)
+    matches!(expr, Expr::Whatever | Expr::WhateverArg)
 }
 
 /// True when `expr` is an already-planted WhateverCurry marker (produced by a

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -381,7 +381,12 @@ pub(crate) fn parse_program(input: &str) -> Result<(Vec<Stmt>, Option<String>), 
         (input, None)
     };
     let result = match stmt::program(source) {
-        Ok((rest, stmts)) => {
+        Ok((rest, mut stmts)) => {
+            // ADR-0033 Phase 2: classify every `*` leaf as a value
+            // (`Expr::Whatever`) or a priming argument (`Expr::WhateverArg`)
+            // now that the whole program tree exists. Pure annotation --
+            // behaviour-preserving by construction (section 2.2's invariant).
+            crate::whatever_curry::mark::mark_program(&mut stmts);
             let rest_trimmed = rest.trim();
             if !rest_trimmed.is_empty() {
                 let consumed = source.len() - rest.len();

--- a/src/rakuast/convert.rs
+++ b/src/rakuast/convert.rs
@@ -824,11 +824,26 @@ fn convert_expr(expr: &Expr) -> Result<RakuAstNode, RuntimeError> {
                 ],
             })
         }
-        // The `*` whatever term.
+        // The `*` whatever term (a *value*, not a priming argument).
         Expr::Whatever => Ok(RakuAstNode {
             class: RakuAstClass::TermWhatever,
             fields: Vec::new(),
         }),
+        // A `*` that participates in Whatever-priming (ADR-0033 Phase 2): the
+        // left operand of `* + 1` is `WhateverCode::Argument`, not `Term::Whatever`.
+        Expr::WhateverArg => Ok(RakuAstNode {
+            class: RakuAstClass::WhateverCodeArgument,
+            fields: Vec::new(),
+        }),
+        // `**` — read direction only; priming for `**` is out of scope (ADR-0033 §1).
+        Expr::HyperWhatever => Ok(RakuAstNode {
+            class: RakuAstClass::TermHyperWhatever,
+            fields: Vec::new(),
+        }),
+        // A `WhateverCurry` marker carries no RakuAST node of its own — Rakudo's
+        // tree has no priming-scope wrapper (ADR-0033 §5); the scope is derived
+        // structurally at lowering. Convert straight through to the body.
+        Expr::WhateverCurry(body) => convert_expr(body),
         // `do { … }` -> `StatementPrefix::Do(Block)`. A labelled do stays the boundary.
         Expr::DoBlock { body, label } => {
             if label.is_some() {
@@ -1104,7 +1119,11 @@ fn convert_expr(expr: &Expr) -> Result<RakuAstNode, RuntimeError> {
             ..
         } => {
             if *is_whatever_code {
-                return Err(unsupported("Whatever-code closure"));
+                // ADR-0033 Phase 2 §2.5: reachable only from the still-eager
+                // `* += 1` / `* -= 2` compound-assignment autoprime path (it
+                // needs a `MetaInfix::Assign` class mutsu lacks; a separate,
+                // operator-cluster-wide slice, not Whatever-specific).
+                return Err(unsupported("Whatever-code closure (compound assignment)"));
             }
             pointy_block_from_lambda(param, body)
         }
@@ -1116,8 +1135,11 @@ fn convert_expr(expr: &Expr) -> Result<RakuAstNode, RuntimeError> {
             return_type,
             ..
         } => {
-            if *is_rw || *is_whatever_code || return_type.is_some() {
-                return Err(unsupported("`is rw` / Whatever / typed pointy block"));
+            if *is_whatever_code {
+                return Err(unsupported("Whatever-code closure (compound assignment)"));
+            }
+            if *is_rw || return_type.is_some() {
+                return Err(unsupported("`is rw` / typed pointy block"));
             }
             pointy_block(param_defs, body)
         }

--- a/src/rakuast/mod.rs
+++ b/src/rakuast/mod.rs
@@ -139,6 +139,12 @@ pub enum RakuAstClass {
     CircumfixArrayComposer,
     // Phase 2 slice 34: the `*` whatever term.
     TermWhatever,
+    // ADR-0033 Phase 2: a `*` that participates in Whatever-priming
+    // (`* + 1`'s left operand) vs a bare Whatever value.
+    WhateverCodeArgument,
+    // ADR-0033 Phase 2: the `**` hyper-whatever term (read direction only —
+    // `**` is out of scope for priming, see the ADR's §1).
+    TermHyperWhatever,
     // Phase 2 slice 35: fat-arrow pairs (`a => 1`).
     FatArrow,
     // Phase 2 slice 36: the `do` statement prefix.
@@ -224,6 +230,8 @@ impl RakuAstClass {
             ParameterSlurpyUnflattened => "RakuAST::Parameter::Slurpy::Unflattened",
             CircumfixArrayComposer => "RakuAST::Circumfix::ArrayComposer",
             TermWhatever => "RakuAST::Term::Whatever",
+            WhateverCodeArgument => "RakuAST::WhateverCode::Argument",
+            TermHyperWhatever => "RakuAST::Term::HyperWhatever",
             FatArrow => "RakuAST::FatArrow",
             StatementPrefixDo => "RakuAST::StatementPrefix::Do",
             StatementPrefixTry => "RakuAST::StatementPrefix::Try",
@@ -236,7 +244,13 @@ impl RakuAstClass {
     /// (`RakuAST::Assignment.new`), unlike the generic `.new()` (e.g. an empty
     /// `StatementList` still prints `RakuAST::StatementList.new()`).
     pub fn empty_parens_omitted(self) -> bool {
-        matches!(self, RakuAstClass::Assignment | RakuAstClass::TermWhatever)
+        matches!(
+            self,
+            RakuAstClass::Assignment
+                | RakuAstClass::TermWhatever
+                | RakuAstClass::WhateverCodeArgument
+                | RakuAstClass::TermHyperWhatever
+        )
     }
 
     /// Whether the node renders as a bare class name with no constructor call at
@@ -291,7 +305,13 @@ impl RakuAstClass {
             | Block
             | PointyBlock
             | CallName
-            | CallNameWithoutParentheses => TERM,
+            | CallNameWithoutParentheses
+            // `RakuAST::WhateverCode::Argument` does not start with
+            // `RakuAST::Term::`, so it does not get Term/Expression for free
+            // from the name-prefix rule in `type_object_isa` — it must be
+            // listed explicitly (ADR-0033 Phase 2 §2.4). Measured MRO:
+            // `Argument, Term, Termish, Expression, ..., Node`.
+            | WhateverCodeArgument => TERM,
             ApplyInfix | ApplyPrefix | ApplyPostfix | ApplyListInfix | Ternary => EXPR,
             _ => &[],
         }
@@ -379,7 +399,10 @@ fn semantic_type_object_ancestors(class_name: &str) -> &'static [&'static str] {
         | "RakuAST::Block"
         | "RakuAST::PointyBlock"
         | "RakuAST::Call::Name"
-        | "RakuAST::Call::Name::WithoutParentheses" => TERM,
+        | "RakuAST::Call::Name::WithoutParentheses"
+        // Same "not RakuAST::Term::"-prefixed" gap as the instance-level
+        // `semantic_ancestors` above.
+        | "RakuAST::WhateverCode::Argument" => TERM,
         "RakuAST::ApplyInfix"
         | "RakuAST::ApplyPrefix"
         | "RakuAST::ApplyPostfix"
@@ -480,6 +503,8 @@ const RAKUAST_CLASSES: &[RakuAstClass] = &[
     RakuAstClass::ParameterSlurpyUnflattened,
     RakuAstClass::CircumfixArrayComposer,
     RakuAstClass::TermWhatever,
+    RakuAstClass::WhateverCodeArgument,
+    RakuAstClass::TermHyperWhatever,
     RakuAstClass::FatArrow,
     RakuAstClass::StatementPrefixDo,
     RakuAstClass::StatementPrefixTry,

--- a/src/whatever_curry/build.rs
+++ b/src/whatever_curry/build.rs
@@ -167,12 +167,17 @@ pub(crate) fn count_whatever(expr: &Expr) -> usize {
             op: TokenKind::DotDotDot | TokenKind::DotDotDotCaret,
             ..
         } => 0,
-        // SmartMatch/BangTilde: Whatever on RHS is handled at runtime; only count LHS.
+        // SmartMatch/BangTilde: a *compound* Whatever on the RHS is left for
+        // runtime autoprime (not curried), so only LHS counts in general. But
+        // the RHS-autoprime forms `X ~~ *` / `X !~~ *` (ADR-0033 Phase 2 section
+        // 2.5) plant a `WhateverCurry` directly over this Binary with a *bare*
+        // placeholder on the right, and that placeholder must be counted too —
+        // it is the only one when the LHS has none (`Int ~~ *`).
         Expr::Binary {
             op: TokenKind::SmartMatch | TokenKind::BangTilde,
             left,
-            ..
-        } => count_whatever(left),
+            right,
+        } => count_whatever(left) + usize::from(is_whatever(right)),
         Expr::Binary { left, right, .. } => count_whatever(left) + count_whatever(right),
         Expr::Unary { expr, .. } | Expr::PostfixOp { expr, .. } => count_whatever(expr),
         Expr::MethodCall { target, .. }

--- a/src/whatever_curry/mark/expr.rs
+++ b/src/whatever_curry/mark/expr.rs
@@ -1,0 +1,278 @@
+//! Expression-level recursion for the `*` leaf classifier (see `super`'s
+//! module doc). This is where the section 2.1 leaf-classification table
+//! actually lives: each arm below picks, for its own operand positions,
+//! whether a nested `*` stays a value (`mark_value_leaf`) or becomes an
+//! argument (the default `mark_expr` recursion, which converts a bare
+//! `Expr::Whatever` it reaches directly).
+
+use super::{mark_opt_value_leaf, mark_stmts, mark_value_leaf};
+use crate::ast::Expr;
+use crate::token_kind::TokenKind;
+
+fn is_flipflop(name: &str) -> bool {
+    matches!(
+        name,
+        "ff" | "fff" | "^ff" | "ff^" | "^ff^" | "^fff" | "fff^" | "^fff^"
+    )
+}
+
+/// The six non-currying pseudo-methods: `*.WHAT` evaluates eagerly on the
+/// `Whatever` value itself rather than curried, so their target is a value
+/// position (`*.WHICH` / `*.abs` are ordinary methods and DO curry).
+fn is_noncurrying_pseudo_method(name: &str) -> bool {
+    matches!(name, "WHAT" | "WHO" | "HOW" | "WHERE" | "DEFINITE" | "VAR")
+}
+
+pub(super) fn mark_expr(expr: &mut Expr) {
+    match expr {
+        Expr::Whatever => *expr = Expr::WhateverArg,
+        // Already classified (re-running mark_expr should never happen in
+        // practice, but stay idempotent) or out of scope for priming (`**`).
+        Expr::WhateverArg | Expr::HyperWhatever => {}
+        // A marker's un-curried body is exactly the "argument" role: recurse
+        // straight through, no wrapper of its own.
+        Expr::WhateverCurry(inner) => mark_expr(inner),
+        Expr::Grouped(inner) => mark_expr(inner),
+        // Comma-list positions: `1, *, 2`, `[*]`, `\(*, 1)`.
+        Expr::ArrayLiteral(items) | Expr::BracketArray(items, _) | Expr::CaptureLiteral(items) => {
+            for item in items {
+                mark_value_leaf(item);
+            }
+        }
+        Expr::Binary { left, op, right } => match op {
+            // Range/series endpoints: `1..*` / `1..*-1`, `1,2...*`.
+            TokenKind::DotDot
+            | TokenKind::DotDotCaret
+            | TokenKind::CaretDotDot
+            | TokenKind::CaretDotDotCaret
+            | TokenKind::DotDotDot
+            | TokenKind::DotDotDotCaret => {
+                mark_value_leaf(left);
+                mark_value_leaf(right);
+            }
+            // `xx` replicates its operand as a value; `x` (string repeat)
+            // curries both operands instead (`1 x *` is `Argument` even
+            // though mutsu plants no `WhateverCurry` there — ADR-0033
+            // section 2.1's scope-independence example) and so takes the
+            // default arm below.
+            TokenKind::Ident(name) if name == "xx" => {
+                mark_value_leaf(left);
+                mark_value_leaf(right);
+            }
+            _ => {
+                mark_expr(left);
+                mark_expr(right);
+            }
+        },
+        Expr::Unary { expr, .. } | Expr::PostfixOp { expr, .. } => mark_expr(expr),
+        Expr::MethodCall {
+            target, name, args, ..
+        } => {
+            if is_noncurrying_pseudo_method(name.resolve().as_str()) {
+                mark_value_leaf(target);
+            } else {
+                mark_expr(target);
+            }
+            for a in args {
+                mark_value_leaf(a);
+            }
+        }
+        Expr::DynamicMethodCall {
+            target,
+            name_expr,
+            args,
+            ..
+        } => {
+            mark_expr(target);
+            mark_expr(name_expr);
+            for a in args {
+                mark_value_leaf(a);
+            }
+        }
+        Expr::HyperMethodCall { target, args, .. } => {
+            mark_expr(target);
+            for a in args {
+                mark_value_leaf(a);
+            }
+        }
+        Expr::HyperMethodCallDynamic {
+            target,
+            name_expr,
+            args,
+            ..
+        } => {
+            mark_expr(target);
+            mark_expr(name_expr);
+            for a in args {
+                mark_value_leaf(a);
+            }
+        }
+        // `*(1)` invokes the bare Whatever *value* (dies at runtime — no
+        // CALL-ME); only a compound target (`(*+1)(5)`) curries.
+        Expr::CallOn { target, args } => {
+            mark_value_leaf(target);
+            for a in args {
+                mark_value_leaf(a);
+            }
+        }
+        // Whole-slice subscript: `@a[*]` is a value, `@a[*-1]` is compound.
+        Expr::Index { target, index, .. } => {
+            mark_expr(target);
+            mark_value_leaf(index);
+        }
+        Expr::MultiDimIndex { target, dimensions } => {
+            mark_expr(target);
+            for d in dimensions {
+                mark_value_leaf(d);
+            }
+        }
+        Expr::MultiDimIndexAssign {
+            target,
+            dimensions,
+            value,
+        } => {
+            mark_expr(target);
+            for d in dimensions {
+                mark_value_leaf(d);
+            }
+            mark_value_leaf(value);
+        }
+        Expr::IndexAssign {
+            target,
+            index,
+            value,
+            ..
+        } => {
+            mark_expr(target);
+            mark_value_leaf(index);
+            mark_value_leaf(value);
+        }
+        Expr::Ternary {
+            cond,
+            then_expr,
+            else_expr,
+        } => {
+            mark_expr(cond);
+            mark_expr(then_expr);
+            mark_expr(else_expr);
+        }
+        // `($x = *)` / `($x := *)` in expression position.
+        Expr::AssignExpr { expr, .. } => mark_value_leaf(expr),
+        Expr::Call { args, .. } | Expr::UserRoutineCall { args, .. } => {
+            for a in args {
+                mark_value_leaf(a);
+            }
+        }
+        // A non-bareword `=>` pair value is a call/method-argument-like
+        // value position (`"k" => *` — but only the bareword-key form
+        // reaches this arm via `PositionalPair`; a plain quoted-key pair is
+        // already planted in a `WhateverCurry` by the parser and recurses
+        // via the generic `Expr::WhateverCurry` arm instead).
+        Expr::PositionalPair(inner) => match inner.as_mut() {
+            Expr::Binary {
+                op: TokenKind::FatArrow,
+                right,
+                ..
+            } => mark_value_leaf(right),
+            other => mark_expr(other),
+        },
+        Expr::InfixFunc {
+            name, left, right, ..
+        } => {
+            if is_flipflop(name) {
+                mark_value_leaf(left);
+                for r in right {
+                    mark_value_leaf(r);
+                }
+            } else {
+                mark_expr(left);
+                for r in right {
+                    mark_expr(r);
+                }
+            }
+        }
+        Expr::HyperOp { left, right, .. } | Expr::HyperFuncOp { left, right, .. } => {
+            mark_expr(left);
+            mark_expr(right);
+        }
+        // Z/X/R meta-operators: a Whatever operand is always `Argument`
+        // (measured), even for Z/X where mutsu plants no `WhateverCurry`.
+        Expr::MetaOp { left, right, .. } => {
+            mark_expr(left);
+            mark_expr(right);
+        }
+        Expr::Reduction { expr, .. } => mark_expr(expr),
+        Expr::Feed { source, sink, .. } => {
+            mark_expr(source);
+            mark_expr(sink);
+        }
+        Expr::Hash(pairs) => {
+            for (_, value) in pairs {
+                mark_opt_value_leaf(value);
+            }
+        }
+        Expr::DoBlock { body, .. }
+        | Expr::Block(body)
+        | Expr::AnonSub { body, .. }
+        | Expr::Gather(body)
+        | Expr::AnonSubParams { body, .. }
+        | Expr::Lambda { body, .. }
+        | Expr::PhaserExpr { body, .. }
+        | Expr::Once { body } => mark_stmts(body),
+        Expr::Try { body, catch } => {
+            mark_stmts(body);
+            if let Some(catch) = catch {
+                mark_stmts(catch);
+            }
+        }
+        Expr::DoStmt(stmt) => super::stmt::mark_stmt(stmt),
+        Expr::Exists { target, arg, .. } => {
+            mark_expr(target);
+            if let Some(arg) = arg {
+                mark_expr(arg);
+            }
+        }
+        Expr::ZenSlice(inner)
+        | Expr::Eager(inner)
+        | Expr::Itemize(inner)
+        | Expr::DeitemizeForBind(inner)
+        | Expr::IndirectTypeLookup(inner) => mark_expr(inner),
+        Expr::IndirectCodeLookup { package, .. } => mark_expr(package),
+        Expr::SymbolicDeref { expr, .. } => mark_expr(expr),
+        Expr::SymbolicDerefAssign { expr, value, .. } => {
+            mark_expr(expr);
+            mark_value_leaf(value);
+        }
+        Expr::IndirectTypeLookupAssign { expr, value } => {
+            mark_expr(expr);
+            mark_value_leaf(value);
+        }
+        Expr::HyperSlice { target, .. } => mark_expr(target),
+        Expr::StringInterpolation(parts) => {
+            for p in parts {
+                mark_expr(p);
+            }
+        }
+        // Terminal / irrelevant to Whatever-priming: no `Expr` children (or
+        // children that cannot syntactically hold a bare `*`, e.g. regex/
+        // substitution literals whose pattern is stored as raw text).
+        Expr::Literal(_)
+        | Expr::LiteralSrc(_, _)
+        | Expr::BareWord(_)
+        | Expr::HeredocInterpolation(_, _)
+        | Expr::Var(_)
+        | Expr::CaptureVar(_)
+        | Expr::ArrayVar(_)
+        | Expr::HashVar(_)
+        | Expr::CodeVar(_)
+        | Expr::EnvIndex(_)
+        | Expr::MatchRegex(_)
+        | Expr::Subst { .. }
+        | Expr::NonDestructiveSubst { .. }
+        | Expr::Transliterate { .. }
+        | Expr::RoutineMagic
+        | Expr::BlockMagic
+        | Expr::ControlFlow { .. }
+        | Expr::PseudoStash(_) => {}
+    }
+}

--- a/src/whatever_curry/mark/mod.rs
+++ b/src/whatever_curry/mark/mod.rs
@@ -1,0 +1,75 @@
+//! Post-parse `*` leaf classifier (ADR-0033 Phase 2).
+//!
+//! Rewrites every `Expr::Whatever` in a freshly-parsed program to
+//! `Expr::WhateverArg` unless its immediate syntactic parent puts it in one of
+//! the *value* positions Rakudo's `RakuAST::Term::Whatever` occupies (measured
+//! in the ADR's section 2.1 table: a comma operand, a range/series endpoint, an
+//! `xx` operand, an assignment/bind RHS, a call/method argument, a whole-slice
+//! subscript, a non-currying pseudo-method target, a bareword pair value, or a
+//! bare `*` standing alone as a whole statement/grouping). Everything else is
+//! `WhateverCode::Argument`.
+//!
+//! This is a **pure annotation**: per the ADR's section 2.2 invariant, nothing
+//! outside `src/rakuast/` may branch on which of the two leaf variants a `*`
+//! got — `crate::parser::is_whatever` treats them identically, so a
+//! misclassification here can only produce a wrong `.AST` gist, never a wrong
+//! program result. The rule is intentionally syntactic and scope-independent
+//! (section 2.1): it does not ask "does this subtree curry" (`x`'s `1 x *`
+//! curries nothing structurally yet is still `Argument`; a Z/X meta-op operand
+//! is never wrapped in a `WhateverCurry` yet is still `Argument`).
+//!
+//! This module is deliberately the seed of the `plant()` scope-authority
+//! function ADR-0033's section 4 calls for (Phase 4): same top-down traversal,
+//! same parent-context switch — one phase later it also decides where a
+//! priming *scope* begins, not just how a leaf renders.
+//!
+//! Split into `stmt.rs` (statement-level recursion) and `expr.rs`
+//! (expression-level recursion, where the actual leaf-classification table
+//! lives) to stay under the repo's 500-line-per-file convention.
+
+mod expr;
+mod stmt;
+
+use crate::ast::{Expr, Stmt};
+
+/// Entry point, invoked once from `parser::parse_program` after a program
+/// parses successfully.
+pub(crate) fn mark_program(stmts: &mut [Stmt]) {
+    mark_stmts(stmts);
+}
+
+fn mark_stmts(stmts: &mut [Stmt]) {
+    for stmt in stmts {
+        stmt::mark_stmt(stmt);
+    }
+}
+
+/// A `*` reached through this call stays a value (`Term::Whatever`) if it is
+/// exactly a bare `Expr::Whatever` leaf; anything else (including an
+/// already-planted `WhateverCurry`) recurses normally, so a *compound*
+/// expression occupying the same syntactic slot (`1..*-1`, `@a[*-1]`) still
+/// gets its inner `*` classified as `Argument`.
+fn mark_value_leaf(expr: &mut Expr) {
+    if matches!(expr, Expr::Whatever) {
+        return;
+    }
+    expr::mark_expr(expr);
+}
+
+fn mark_opt_expr(expr: &mut Option<Expr>) {
+    if let Some(e) = expr {
+        expr::mark_expr(e);
+    }
+}
+
+fn mark_opt_value_leaf(expr: &mut Option<Expr>) {
+    if let Some(e) = expr {
+        mark_value_leaf(e);
+    }
+}
+
+fn mark_opt_box_expr(expr: &mut Option<Box<Expr>>) {
+    if let Some(e) = expr {
+        expr::mark_expr(e);
+    }
+}

--- a/src/whatever_curry/mark/stmt.rs
+++ b/src/whatever_curry/mark/stmt.rs
@@ -1,0 +1,183 @@
+//! Statement-level recursion for the `*` leaf classifier (see `super`'s module
+//! doc). Most of this file exists to reach every `Expr` a statement can embed;
+//! the interesting classification table lives in `expr.rs`.
+
+use super::{mark_opt_box_expr, mark_opt_expr, mark_opt_value_leaf, mark_stmts, mark_value_leaf};
+use crate::ast::{CallArg, Stmt};
+
+pub(super) fn mark_stmt(stmt: &mut Stmt) {
+    match stmt {
+        // A bare `*` standing alone as a whole statement (`*;`, a proto's
+        // `{*}` body) stays a value; anything else recurses as normal.
+        Stmt::Expr(e) => mark_value_leaf(e),
+        Stmt::VarDecl {
+            expr,
+            custom_traits,
+            where_constraint,
+            ..
+        } => {
+            // `my $x = *` / `my $x := *` — assignment/bind RHS.
+            mark_value_leaf(expr);
+            for (_, arg) in custom_traits {
+                mark_opt_expr(arg);
+            }
+            mark_opt_box_expr(where_constraint);
+        }
+        Stmt::Assign { expr, .. } => mark_value_leaf(expr),
+        Stmt::Return(e) | Stmt::Die(e) | Stmt::Fail(e) | Stmt::Take(e, _) | Stmt::Goto(e) => {
+            super::expr::mark_expr(e);
+        }
+        Stmt::Say(args) | Stmt::Put(args) | Stmt::Print(args) | Stmt::Note(args) => {
+            for a in args {
+                mark_value_leaf(a);
+            }
+        }
+        Stmt::Call { args, .. } => {
+            for a in args {
+                mark_call_arg(a);
+            }
+        }
+        Stmt::For { iterable, body, .. } => {
+            super::expr::mark_expr(iterable);
+            mark_stmts(body);
+        }
+        Stmt::If {
+            cond,
+            then_branch,
+            else_branch,
+            ..
+        } => {
+            super::expr::mark_expr(cond);
+            mark_stmts(then_branch);
+            mark_stmts(else_branch);
+        }
+        Stmt::While { cond, body, .. } => {
+            super::expr::mark_expr(cond);
+            mark_stmts(body);
+        }
+        Stmt::Loop {
+            init,
+            cond,
+            step,
+            body,
+            ..
+        } => {
+            if let Some(init) = init {
+                mark_stmt(init);
+            }
+            mark_opt_expr(cond);
+            mark_opt_expr(step);
+            mark_stmts(body);
+        }
+        Stmt::Given { topic, body, .. } => {
+            super::expr::mark_expr(topic);
+            mark_stmts(body);
+        }
+        Stmt::When { cond, body } => {
+            super::expr::mark_expr(cond);
+            mark_stmts(body);
+        }
+        Stmt::Whenever { supply, body, .. } => {
+            super::expr::mark_expr(supply);
+            mark_stmts(body);
+        }
+        Stmt::Subtest { name, body } => {
+            super::expr::mark_expr(name);
+            mark_stmts(body);
+        }
+        Stmt::Label { stmt, .. } => mark_stmt(stmt),
+        Stmt::Let { index, value, .. } => {
+            if let Some(index) = index {
+                super::expr::mark_expr(index);
+            }
+            if let Some(value) = value {
+                mark_value_leaf(value);
+            }
+        }
+        Stmt::TempMethodAssign {
+            method_args, value, ..
+        } => {
+            for a in method_args {
+                mark_value_leaf(a);
+            }
+            mark_value_leaf(value);
+        }
+        Stmt::HasDecl {
+            default,
+            is_default,
+            where_constraint,
+            unknown_traits,
+            ..
+        } => {
+            mark_opt_value_leaf(default);
+            mark_opt_value_leaf(is_default);
+            mark_opt_box_expr(where_constraint);
+            for (_, _, arg) in unknown_traits {
+                mark_opt_expr(arg);
+            }
+        }
+        Stmt::SubsetDecl { predicate, .. } => mark_opt_expr(predicate),
+        Stmt::DoesDecl { args, .. } => {
+            if let Some(args) = args {
+                for a in args {
+                    super::expr::mark_expr(a);
+                }
+            }
+        }
+        Stmt::EnumDecl { variants, .. } => {
+            for (_, value) in variants {
+                mark_opt_expr(value);
+            }
+        }
+        Stmt::Use { arg, condition, .. } => {
+            mark_opt_expr(arg);
+            mark_opt_box_expr(condition);
+        }
+        Stmt::No { arg, .. } => mark_opt_expr(arg),
+        // Body-only statements: recurse into the block, nothing else to mark.
+        Stmt::Block(body)
+        | Stmt::SyntheticBlock(body)
+        | Stmt::React { body }
+        | Stmt::Default(body)
+        | Stmt::Catch(body)
+        | Stmt::Control(body)
+        | Stmt::Phaser { body, .. }
+        | Stmt::Package { body, .. }
+        | Stmt::SubDecl { body, .. }
+        | Stmt::TokenDecl { body, .. }
+        | Stmt::RuleDecl { body, .. }
+        | Stmt::MethodDecl { body, .. }
+        | Stmt::RoleDecl { body, .. }
+        | Stmt::ClassDecl { body, .. }
+        | Stmt::AugmentClass { body, .. }
+        | Stmt::ProtoDecl { body, .. } => mark_stmts(body),
+        // Declarations/markers/control-flow with no expression payload
+        // relevant to Whatever-priming (or genuinely rare enough that a
+        // missed leaf here is only a cosmetic `.AST` gap, never a runtime
+        // behaviour change — see the module doc's safety invariant).
+        Stmt::MarkReadonly(_)
+        | Stmt::MarkBoundContainer(_)
+        | Stmt::MarkBind
+        | Stmt::MarkSigillessReadonly(_)
+        | Stmt::MarkSigilless(_)
+        | Stmt::ProtoToken { .. }
+        | Stmt::Need { .. }
+        | Stmt::Import { .. }
+        | Stmt::Last(_)
+        | Stmt::Next(_)
+        | Stmt::Redo(_)
+        | Stmt::Proceed
+        | Stmt::Succeed
+        | Stmt::ReactDone
+        | Stmt::SupplyBodyDone
+        | Stmt::TrustsDecl { .. }
+        | Stmt::SetLine(_) => {}
+    }
+}
+
+fn mark_call_arg(arg: &mut CallArg) {
+    match arg {
+        CallArg::Positional(e) | CallArg::Slip(e) | CallArg::Invocant(e) => mark_value_leaf(e),
+        CallArg::Named { value, .. } => mark_opt_value_leaf(value),
+    }
+}

--- a/src/whatever_curry/mod.rs
+++ b/src/whatever_curry/mod.rs
@@ -25,6 +25,7 @@
 //! No runtime behaviour changes.
 
 mod build;
+pub(crate) mod mark;
 mod replace;
 
 pub(crate) use build::{build_closure, make_wc_param};

--- a/src/whatever_curry/replace.rs
+++ b/src/whatever_curry/replace.rs
@@ -71,15 +71,22 @@ pub(crate) fn replace_whatever_numbered(expr: &Expr, counter: &mut usize) -> Exp
                 right: Box::new(replace_whatever_numbered(right, counter)),
             }
         }
-        // SmartMatch: only replace Whatever on LHS; RHS is handled at runtime.
+        // SmartMatch/BangTilde: a compound RHS Whatever is left untouched (it's
+        // handled at runtime, not curried), but the RHS-autoprime forms `X ~~ *`
+        // / `X !~~ *` (ADR-0033 Phase 2 section 2.5) have a bare placeholder on
+        // the right that must be replaced too.
         Expr::Binary {
             left,
-            op: op @ TokenKind::SmartMatch,
+            op: op @ (TokenKind::SmartMatch | TokenKind::BangTilde),
             right,
         } => Expr::Binary {
             left: Box::new(replace_whatever_numbered(left, counter)),
             op: op.clone(),
-            right: right.clone(),
+            right: if is_whatever(right) {
+                Box::new(replace_whatever_numbered(right, counter))
+            } else {
+                right.clone()
+            },
         },
         Expr::Binary { left, op, right } => Expr::Binary {
             left: Box::new(replace_whatever_numbered(left, counter)),
@@ -196,15 +203,20 @@ pub(crate) fn replace_whatever_single(expr: &Expr) -> Expr {
     match expr {
         e if is_whatever(e) => Expr::Var("_".to_string()),
         Expr::WhateverCurry(inner) => replace_whatever_single(inner),
-        // SmartMatch: only replace Whatever on LHS; RHS is handled at runtime.
+        // SmartMatch/BangTilde: see the matching arm in
+        // `replace_whatever_numbered` above.
         Expr::Binary {
             left,
-            op: op @ TokenKind::SmartMatch,
+            op: op @ (TokenKind::SmartMatch | TokenKind::BangTilde),
             right,
         } => Expr::Binary {
             left: Box::new(replace_whatever_single(left)),
             op: op.clone(),
-            right: right.clone(),
+            right: if is_whatever(right) {
+                Box::new(replace_whatever_single(right))
+            } else {
+                right.clone()
+            },
         },
         Expr::Binary { left, op, right } => Expr::Binary {
             left: Box::new(replace_whatever_single(left)),

--- a/t/rakuast-whatever-code.t
+++ b/t/rakuast-whatever-code.t
@@ -1,0 +1,90 @@
+use v6;
+use experimental :rakuast;
+use Test;
+
+# ADR-0033 Phase 2: `*` leaf classification.
+#
+# `RakuAST::Term::Whatever` is a `*` that stays a `Whatever` *value*;
+# `RakuAST::WhateverCode::Argument` is a `*` that participates in
+# Whatever-priming (`* + 1` curries; `1, *, 2` does not). The rule is
+# syntactic and scope-independent (measured against the system `raku`, see
+# docs/adr/0033-whatever-priming-leaf-and-derived-scope.md section 2.1) — this
+# file is a dual-oracle test (ADR-0011 convention) and passes under BOTH
+# mutsu and raku.
+#
+# Over-marking a value leaf as `Argument` is invisible at runtime (both
+# variants compile identically outside src/rakuast/), so the "value leaf"
+# half below is the ONLY detector for that class of bug — do not remove it.
+
+plan 68;
+
+my @a = 1, 2, 3;
+
+# --- Argument leaves (participate in priming) --------------------------
+
+for (
+    '* + 1', '* + *', '*.abs', '*.WHICH', '1..*-1', '@a[* - 1]',
+    '-*', '?*', '*++', '* x 2', '1 x *',
+    '* ~~ Int', 'Int ~~ *', '$_ ~~ *', '* !~~ Int',
+    '"k" => *', '(1, 2).map(* + 1)', '(* - 1) o (* * 2)',
+) -> $src {
+    my $gist = EVAL(qq[Q[{$src}].AST.gist]);
+    ok $gist.contains('RakuAST::WhateverCode::Argument'),
+        "$src -- '*' renders as WhateverCode::Argument";
+    nok $gist.contains('RakuAST::Term::Whatever'),
+        "$src -- no stray Term::Whatever leaf";
+}
+
+# --- Value leaves (regression guard for over-marking) -------------------
+
+for (
+    '1, *, 2', '1..*', '1, 2 ... *', 'my $x = *', '* xx 2', '1 xx *',
+    '@a[*]', '*(1)', '*.WHAT', '(a => *)', 'say *',
+) -> $src {
+    my $gist = EVAL(qq[Q[{$src}].AST.gist]);
+    ok $gist.contains('RakuAST::Term::Whatever'),
+        "$src -- '*' stays a Term::Whatever value";
+    nok $gist.contains('RakuAST::WhateverCode::Argument'),
+        "$src -- not over-marked as an Argument";
+}
+
+# `[*]` is deliberately excluded above: mutsu currently parses a standalone
+# `[*]` as the `[*]`-reduction metaoperator applied to an empty list (a
+# pre-existing, Whatever-unrelated parse ambiguity -- there is no `*` node in
+# that tree at all to classify either way), while raku's `.AST` renders it as
+# a bare `Term::Whatever`. Out of scope for this ADR.
+
+# --- Hierarchy ------------------------------------------------------------
+
+my $arg = Q[* + 1].AST.statements[0].expression.left;
+is $arg.^name, 'RakuAST::WhateverCode::Argument', 'left operand of * + 1 is WhateverCode::Argument';
+ok $arg ~~ RakuAST::Term, 'WhateverCode::Argument isa Term';
+ok $arg ~~ RakuAST::Expression, 'WhateverCode::Argument isa Expression';
+ok $arg ~~ RakuAST::Node, 'WhateverCode::Argument isa Node';
+
+# --- ** (HyperWhatever): read direction only, priming out of scope --------
+
+is Q[**].AST.statements[0].expression.^name, 'RakuAST::Term::HyperWhatever',
+    '** is Term::HyperWhatever';
+ok Q[**].AST.statements[0].expression ~~ RakuAST::Term, 'Term::HyperWhatever isa Term';
+
+# --- Full gist sanity check for the headline example -----------------------
+
+is Q[* + 1].AST.gist, q:to/END/.chomp, '* + 1 full gist';
+RakuAST::StatementList.new(
+  RakuAST::Statement::Expression.new(
+    expression => RakuAST::ApplyInfix.new(
+      left  => RakuAST::WhateverCode::Argument.new,
+      infix => RakuAST::Infix.new("+"),
+      right => RakuAST::IntLiteral.new(1)
+    )
+  )
+)
+END
+
+# --- Runtime no-change guard: the rendering split must not alter results --
+
+is (* + 1)(5), 6, 'WhateverCode still callable after leaf-splitting';
+is (1 x *).WHAT.^name, 'WhateverCode', '1 x * still autoprimes at runtime';
+my $sm = (Int ~~ *);
+is $sm(5), False, 'Int ~~ * still evaluates correctly at runtime';

--- a/todo/deep/rakuast-remaining.md
+++ b/todo/deep/rakuast-remaining.md
@@ -52,9 +52,10 @@ an explicit design:
 - `constant`
 - associative subscripts
 - `CATCH` blocks
-- WhateverCode such as `* + 1` — **Phase 1 (deferral) shipped; Phase 2 (RakuAST read /
-  the leaf split) designed in implementable detail and ready to pick up; Phases 3-4
-  (RakuAST write, thunk-barrier correctness fix) not started — see
+- WhateverCode such as `* + 1` — **Phase 1 (deferral) and Phase 2 (RakuAST read / the
+  leaf split) shipped: `Q[* + 1].AST` works now. Phase 4 (the thunk-barrier priming
+  correctness fix — the highest-payoff remaining slice, see below) is next; Phase 3
+  (RakuAST write / `EVAL`) not started — see
   [ADR-0033](../../docs/adr/0033-whatever-priming-leaf-and-derived-scope.md)**
 - code-block interpolation
 - regexes
@@ -63,7 +64,7 @@ Pick these deliberately by user impact rather than treating them as another
 cadence of mechanical slices. Lower through the existing internal AST and
 compiler; do not add a second execution engine.
 
-### Designed, Phase 1 shipped, Phase 2 ready to implement: WhateverCode (ADR-0033)
+### Phases 1-2 shipped, Phase 4 is the next highest-payoff slice: WhateverCode (ADR-0033)
 
 `* + 1` was picked first because it is the highest-frequency construct on the list
 (`.map(* + 1)`, `.grep(* > 3)`, `@a[* - 1]`) and because investigating it surfaced a
@@ -88,15 +89,28 @@ roast suites. See the ADR's own Outcome section for the full list of latent-bug 
 this deferral surfaced along the way.
 
 Phase 2 — the *leaf* half (`Expr::WhateverArg` → `RakuAST::WhateverCode::Argument`) —
-was designed in implementable detail on 2026-08-20 and is the next unit of work; see
-the ADR's "Phase 2 detailed design" section. It carries a raku-measured leaf
-classification table, a behaviour-preserving-by-construction invariant (in Phase 2 the
-new leaf variant is a pure annotation: every consumer outside `src/rakuast/` treats it
-identically to `Expr::Whatever`), the converter/metadata edits, the conversion of the
-three remaining eager autoprime sites, and a dual-oracle test plan. `Q[* + 1].AST` still
-errors until it lands. Phase 3 (RakuAST write / `EVAL`) and Phase 4 (the thunky-operator
-priming correctness fix, which is still live and still produces silently wrong results
-for `(1..10).grep(* > 3 && * < 8)`) remain designed only at the ADR's outline level.
+shipped 2026-08-20 (same day as its design): `src/whatever_curry/mark.rs` classifies
+every `*` leaf post-parse per the ADR's raku-measured table, `Q[* + 1].AST` now renders
+correctly, and the change was verified behaviour-preserving by construction (`is_whatever`
+treats both leaf variants identically everywhere outside `src/rakuast/`) plus a new
+dual-oracle `t/rakuast-whatever-code.t` (68 assertions, passes verbatim under mutsu and
+the system raku). See the ADR's "Phase 2 outcome" section for the full change list,
+including two adjacent RakuAST operator-name rendering bugs (`!~~`, `=>`) it fixed along
+the way and one latent runtime bug it fixed as a side effect (`$_ ~~ *` previously
+shadowed the caller's topic instead of reading it dynamically).
+
+**Phase 4 (the thunk-barrier priming correctness fix) is now the highest-payoff remaining
+slice** — it is a genuine, user-visible correctness bug independent of RakuAST
+(`(1..10).grep(* > 3 && * < 8)` silently returns the wrong list, `5 6` instead of raku's
+`1 2 3 4 5 6 7`), not merely a `.AST` gap, and Phase 2's leaf split is its prerequisite
+(the ADR's `plant()` scope authority needs to read the classified leaves). See the ADR's
+"Phasing" section for the exact scope (thunk barriers: `&&`/`||`/`//`/`and`/`or`/
+`andthen`/`orelse`/`notandthen`/ternary) and its "Phase-4 prerequisite" section (the
+chained-comparison `&&`-duplication trap that must be resolved first, e.g. via a new
+`Expr::ChainedCompare` node). Phase 3 (RakuAST write / `EVAL` of a hand-constructed
+`WhateverCode::Argument` tree) remains designed only at the ADR's outline level and has
+no roast/correctness payoff of its own (RakuAST has zero roast dependents, ADR-0011
+ANALYSIS §7-9) — pick it up after Phase 4, not before.
 
 The remaining items on both lists above are still undesigned.
 


### PR DESCRIPTION
## Summary

Implements ADR-0033 Phase 2 (design landed in #6714): `Q[* + 1].AST` used to
error because the parser had no way to tell the RakuAST converter that a `*`
is a Whatever-priming *argument* (`RakuAST::WhateverCode::Argument`) rather
than a plain `Whatever` *value* (`RakuAST::Term::Whatever`) -- both parsed to
the same `Expr::Whatever` node.

- New `src/whatever_curry/mark::mark_program`, a post-parse pass invoked once
  from `parser::parse_program`, reclassifies each `Expr::Whatever` leaf to
  `Expr::WhateverArg` unless its immediate syntactic parent is a *value*
  position (comma operand, range/series endpoint, `xx` operand,
  assignment/bind RHS, call/method argument, whole-slice subscript,
  non-currying pseudo-method target, bareword pair value, or a bare `*`
  standing alone). The rule is syntactic and scope-independent per the ADR's
  section 2.1 (not derived from mutsu's "does this subtree curry" predicates
  -- `1 x *` and `* Z 1` are `Argument` even though mutsu plants no priming
  scope for either).
- Pure annotation: `crate::parser::is_whatever` widened to treat
  `Expr::Whatever`/`Expr::WhateverArg` identically everywhere outside
  `src/rakuast/`; both still compile to `LoadConst(Value::WHATEVER)`. A
  misclassified leaf can only produce a wrong `.AST` gist, never a wrong
  program result.
- `src/rakuast/mod.rs` gained `RakuAST::WhateverCode::Argument` (explicitly
  added to the `Term`/`Expression` semantic-ancestor set, since its printed
  name does not start with `RakuAST::Term::`) and, as a read-direction bonus,
  `RakuAST::Term::HyperWhatever` for `**`.
- Converted the three remaining eager WhateverCode closures (`* ~~ Type`,
  `Type ~~ *`, `!~~`) to plant `Expr::WhateverCurry` instead of hand-building
  a `Lambda`, which required generalizing the smartmatch
  arity/substitution logic (`whatever_curry::{build,replace}`) beyond its
  historical left-operand-only assumption.
- That conversion surfaced two adjacent RakuAST rendering bugs, fixed in the
  same PR: `!~~` and `=>` were rendering as mutsu's internal dispatch
  strings (`"!~"`, `"FatArrow"`) instead of the real raku spelling
  (`token_kind_to_op_name` -- confirmed unreachable from the compiled
  bytecode dispatch path, so display-only and safe to fix). It also fixed one
  latent runtime bug: `$_ ~~ *`'s generated closure previously replaced the
  *outer* `$_` too, so it ignored the caller's dynamic topic; raku's actual
  semantics read the outer `$_` on the left and only prime the right
  (verified: `$_ = 10; ($_ ~~ *)(3)` is `False`, i.e. `10 ~~ 3`, in both raku
  and mutsu now).
- Section 2.6's two documented divergences (chained comparison, `* .= lc`)
  are left untouched, as scoped.
- Docs: ADR-0033 status updated to "Phase 1 + Phase 2 shipped", a "Phase 2
  outcome" section added; `todo/deep/rakuast-remaining.md` updated to point
  at Phase 4 (thunk-barrier priming correctness -- a genuine, user-visible
  bug independent of RakuAST, e.g. `(1..10).grep(* > 3 && * < 8)` silently
  returns the wrong list) as the next highest-payoff slice; news entry added.

## Test plan

- [x] New dual-oracle `t/rakuast-whatever-code.t` (68 assertions) -- passes
      verbatim under both `target/debug/mutsu` and the system `raku`.
- [x] `t/*whatever*.t` (35 files) and `t/rakuast-*.t` (89 files incl. the new
      test) all green.
- [x] `roast/S02-types/{whatever,hyperwhatever}.t`,
      `roast/S03-operators/composition.t`,
      `roast/S12-subset/{multi-dispatch,subtypes,type-subset}.t` all green.
- [x] Full local `make test` (cargo test + the entire `t/` TAP suite, 3265
      files / 30293 tests): green except one pre-existing, environment-caused
      failure unrelated to this change --
      `t/compunit-can-install.t`'s "prefix under a non-writable root cannot
      install" assumes `/` is non-writable, which is false in this
      non-root-but-`/`-writable container (`touch /probe` succeeds); CI runs
      as a normal GitHub Actions user where this holds.
- [x] `cargo build`, `cargo clippy -- -D warnings`, `cargo fmt --check` all
      clean.
- [ ] CI (`make roast`) -- watching in background.

🤖 Generated with [Claude Code](https://claude.com/claude-code)