### PR TITLE
docs(adr): fold the cross-thread-store container collision into ADR-0039

### DIFF
--- a/docs/adr/0039-container-lexicals-resolve-lexically.md
+++ b/docs/adr/0039-container-lexicals-resolve-lexically.md
@@ -6,7 +6,9 @@
   ADR-0024 (mainline lexicals for named subs — the scalar half of this bug),
   ADR-0025 (cell boxing must be value-kind-blind — slice 3 defers `@`/`%`),
   ADR-0010 (cross-thread lexical sharing scope — the `__mutsu_atomic_*` lanes)
-- Addresses: `todo/deep/module-file-scope-array-and-hash-still-share-the-caller.md`
+- Addresses: `todo/deep/module-file-scope-array-and-hash-still-share-the-caller.md`,
+  `todo/deep/shared-store-bare-name-collision-across-unrelated-frames.md`
+  (the cross-thread-store axis of the same root cause — see §8, added 2026-08-20)
 
 ## 1. Context
 
@@ -377,3 +379,163 @@ most plausibly because the test's `@vars` is method-local and never live across
 a `_push_vars` call. Treat it as a stale example, not as evidence of a fix: the
 §1.1 and §1.2 repros are the live ones, and §6's matrix replaces it as the
 acceptance measure.
+
+## 8. Addendum (2026-08-20): the cross-thread-store axis is the same bug
+
+This section folds `todo/deep/shared-store-bare-name-collision-across-unrelated-frames.md`
+into this ADR. It adds no new *decision* — §4's decision already covers it —
+but it adds evidence, a third sigil skip to lift, an exclusion §4.1's list
+misses, and one requirement slice 2 would otherwise get wrong. It is an
+amendment to a `Proposed`, unimplemented design, not a revision of a decided
+one.
+
+### 8.1 What the deep ticket claimed, and what is left of it
+
+The ticket's headline was that `shared_vars` is *"a **process-global** map keyed
+by bare name"*, so two frames anywhere in the program that happen to use the
+same variable name read each other's values, and that the fix is the store's
+**keying** — a per-lineage store.
+
+Both halves are now stale:
+
+- **The keying fix already shipped.** ADR-0010 replaced the one process-wide
+  `Arc<RwLock<HashMap<..>>>` with the lineage-chained `SharedStore`
+  (`src/runtime/shared_store.rs:55-61`, own/parent/root). Sibling isolation
+  works: `await (^3).map: -> $n { start { my @w = ($n,); ... } }` gives each
+  worker its own `@w` (verified against `raku`).
+- **The ticket's own driving instance is gone.** Its multi-param-`for` repro,
+  its `while --$i` scalar repro, and the three downstream tickets it named
+  (`supply-block-lexical-leaks-through-thread-lane`,
+  `cue-loop-lexical-shared-lane-residue`,
+  `for-multi-param-array-hash-shadow-clobbers-outer-container`) are all
+  resolved; `t/http-session-inmemory.rakutest` is no longer blocked on it.
+
+What survives is narrower and sharper than "the store is bare-name keyed", and
+it is not a keying problem at all.
+
+### 8.2 Measured on `52631889f` (2026-08-20)
+
+**Scalars are clean.** Ten shapes were probed — a callee's `while --$i`
+countdown, a callee that spawns and *then* writes its `my $i`, `is copy`
+parameters, `for`-loop parameters, a Nil-valued reader, a live-valued reader —
+and every one matches `raku`.
+
+**Containers diverge, and only when a thread has been spawned.** Two live
+shapes:
+
+```raku
+# (a) a callee's sub-local container escapes into an unrelated caller
+sub work($tag) {
+    my @items = ($tag,);
+    await start { 1 };          # remove this line and mutsu is correct
+    @items.push("$tag-2");
+}
+my @items = <x y z>;
+work('A');  say @items.raku;    # raku: [x y z]        mutsu: [A A-2]
+@items.push('MINE');            # raku: [x y z MINE]   mutsu: [A A-2 MINE]
+work('B');  say @items.raku;    # raku: [x y z MINE]   mutsu: [B B-2]
+```
+
+```raku
+# (b) a non-slurpy @/% PARAMETER escapes the call
+sub takes(@list is copy) { await start { 1 }; @list.push('R') }
+my @list = <x y z>;
+takes(<p q>);
+say @list.raku;                 # raku: [x y z]        mutsu: [p q R]
+```
+
+Both reproduce with `%` identically, and (a) reproduces through a `use`d module
+(the module's routine-local `@parts` overwrites the consumer's `@parts`) — the
+mirror image of §1.1, where the consumer overwrote the module. Neither needs
+concurrency: one `await start { 1 }` anywhere in the process arms the lane, and
+the collision is then deterministic and repeats on every call. The `Supply`/tap
+driver does **not** arm it; `start`/`Promise` do.
+
+**The scalar/container split is the proof.** The two lanes share the polluted
+store; they differ only in *how a read resolves the name*. A scalar reads its
+slot (`GetLocal`) and consults the store only when the slot holds `Nil`
+(`vm/vm_var_assign_local_get.rs:256,268`). A container has a slot but nothing
+reads it (§1.3), so `GetLocal`'s `@`/`%` arm consults the store
+**unconditionally** — no `is_thread_clone()` gate, no staleness test
+(`vm/vm_var_assign_local_get.rs:155-161`) — and `sync_shared_vars_to_env`
+writes every dirty store key straight into `env` under the bare name
+(`runtime/runtime_shared_vars.rs:646-648`), where the container read path will
+find it. So the store is not the defect; **by-name container resolution is**,
+exactly as §1.2 concluded from a module with no threads in it. The store is
+simply a second population route into the same by-name namespace.
+
+### 8.3 Why the mask does not save containers: a third sigil skip
+
+§1.3 lists the compile-time sigil exclusions. The thread lane has its own, and
+it is what makes §8.2 fire:
+
+- `block_captured_scalars` (`runtime/runtime_thread.rs:20-22`) `continue`s on
+  `@`/`%`/`&` when scanning a spawned block's free variables, so a container is
+  never in `captured_scalars`.
+- `clone_for_thread`'s post-seed retain
+  (`runtime/runtime_thread.rs:352-356`) keeps a `thread_redeclared_vars` entry
+  only if the name is in `captured_scalars`, `thread_decl_in_flight`, or
+  `thread_param_shadow_vars`.
+
+So **every spawn silently unmasks every container `my`**, after which
+`set_shared_var_sym`'s write gate (`runtime_shared_vars.rs:495-497`), the
+`GetLocal` container arm, and the `sync_shared_vars_to_env` filter (`:587`) all
+stop protecting it. `container_name_is_redeclared`
+(`runtime_shared_vars.rs:238-242`) — consulted at nine sites specifically to
+keep a re-declared container frame-local — is asking a set the spawn just
+emptied. This is the same `@`/`%` skip ADR-0024 and ADR-0025 defer and §4.1
+step 2 lifts, in a third place.
+
+Repro (b) is a *fourth*: `mask_thread_redeclared_params`
+(`runtime_shared_vars.rs:304-311`) deliberately never masks a **non-slurpy**
+`@`/`%` parameter, only scalars and `*@`/`*%`. A container parameter therefore
+has no per-call shadow at all.
+
+### 8.4 What this adds to §4
+
+1. **Slice 1's exclusion list gains one entry and one non-entry.** Non-slurpy
+   `@`/`%` *parameters* (repro (b)) are a distinct binding form from the file-
+   scope `my` slice 1 targets; they are **out of scope for slice 1** and belong
+   to slice 2, which is where parameters get slots. Record them, do not patch
+   `mask_thread_redeclared_params` — widening a bare-name mask is more of the
+   mechanism §4.2 is trying to delete.
+2. **Slice 2 acquires a hard requirement §4.2 does not state.** Once
+   `Expr::ArrayVar` emits `GetLocal(slot)`, the store-writeback path
+   (`sync_shared_vars_to_env`, which writes `env` only) can no longer reach the
+   reader. The sharing that *must* survive —
+   `my @a; await start { @a.push(1) }; say @a` and its `%h` twin, both correct
+   today — would silently stop working. The precedent to follow is the scalar
+   one already in the tree: `pending_caller_var_writeback` /
+   `apply_pending_rw_writeback` (`runtime_shared_vars.rs:652-671`), which drains
+   a synced cross-thread name to the owning caller's *slot* at the `await` call
+   site. Containers need the same drain, keyed by binding rather than by name.
+   **Write the bn9-shaped pin (shared push, shared hash key-set, sibling
+   isolation) as part of slice 1's corpus**, per §4.3's second argument, so
+   slice 2 cannot regress it unnoticed.
+3. **Slice 2's deletion list gains four members.** These exist only because
+   containers resolve by name and should be *removed*, not carried forward:
+   `container_name_is_redeclared` and its nine call sites; the ungated `@`/`%`
+   store preference in `GetLocal` (`vm_var_assign_local_get.rs:155-161`); the
+   `is_thread_clone()`-gated twin in `get_env_with_main_alias_inner`
+   (`vm_env_helpers.rs:840-846`); and the `@`/`%` exemptions carved into the
+   dynamic-variable filters of `clone_for_thread` (`runtime_thread.rs:241-243`)
+   and `sync_shared_vars_to_env` (`runtime_shared_vars.rs:600-604`). The
+   `__mutsu_atomic_*` lanes are **not** on this list — ADR-0010 established that
+   they are process-wide primitives, not lexical sharing, and they stay.
+4. **The ticket's proposed fix is rejected outright.** "Re-key the store" is
+   both done (ADR-0010) and insufficient: §8.2 (a) collides two frames of one
+   thread inside one lineage, so no keying discipline short of per-frame keys —
+   i.e. slots — removes it. This is the same conclusion §5 reached about
+   compile-time alpha-renaming.
+
+### 8.5 Exposure
+
+No whitelisted roast test and no bundled battery is currently blocked by this;
+the ticket's Cro session-test instance was resolved by unrelated fixes and Cro's
+own test suite is not vendored. That is a statement about which shapes appear in
+the corpus, not about severity: the failure mode is a *silent wrong value* in a
+container after any `start`/`Promise` in the process, it repeats on every call,
+and any thread-using program with two same-named containers hits it. Treat §8.2
+(a) and (b) as acceptance pins for §6 alongside the module and mainline
+matrices, and keep the deep ticket open until slice 2 lands — slice 1 alone does
+not close it, because §8.2's containers are routine-local, not file-scope.

--- a/todo/deep/shared-store-bare-name-collision-across-unrelated-frames.md
+++ b/todo/deep/shared-store-bare-name-collision-across-unrelated-frames.md
@@ -1,144 +1,112 @@
-# Two unrelated frames sharing a variable name collide through the global store
+# Two unrelated frames sharing a container name collide through the cross-thread store
 
-Once any thread has been spawned, a plain lexical write goes through
-`set_env_plain_lexical` → `set_shared_var_sym` into `shared_vars`, a
-**process-global map keyed by bare name**. Two frames that merely happen to use
-the same variable name — in unrelated files, at unrelated times — then read each
-other's values.
+**Status 2026-08-20: still live, but re-scoped. Design is owned by
+[ADR-0039 §8](../../docs/adr/0039-container-lexicals-resolve-lexically.md).**
+This file is now the *evidence* record; do not start work from the original
+proposal below, which is superseded.
 
-This is the clearest real-code instance found so far, in Cro's
-`t/http-session-inmemory.rakutest`:
+## Where this stands
 
-```raku
-given Cro::HTTP::Client.new(:cookie-jar) -> $client {
-    for 1..5 -> $i {
-        given await $client.get("$url/hits") {
-            is await(.body-text), "Visit $i",
-                "Session cookie being sent makes state work (request $i)";
-        }
-    }
-}
-```
+Re-measured on `52631889f`. Two of the three claims this ticket was built on
+have expired, and the third has narrowed to a single sigil.
 
-Instrumented (`note` before and after the request):
+- **"The store is a process-global map" — fixed.** ADR-0010 shipped the
+  lineage-chained `SharedStore` (`src/runtime/shared_store.rs:55-61`). Sibling
+  spawns no longer see each other's lexicals; verified against `raku` with three
+  concurrent workers each declaring `my @w`.
+- **"Re-key the store" (this ticket's proposed fix) — rejected.** It is both
+  already done and insufficient: the live repro below collides two frames of
+  *one* thread inside *one* lineage. No keying discipline short of per-frame
+  keys — that is, slots — removes it. ADR-0039 §8.4 records the rejection.
+- **Scalars — clean.** Ten shapes were probed (a callee's `while --$i`
+  countdown, a callee that spawns and then writes its `my $i`, `is copy`
+  parameters, `for` parameters, Nil-valued and live-valued readers). All match
+  `raku`. The `thread_redeclared_vars` mask plus the Nil-gated `GetLocal` pull
+  cover the scalar lane.
+- **Containers (`@`/`%`) — still broken.** This is the whole of what is left.
 
-```
-[T] loop top i=1
-[T] after get i=4        <-- the request rewrote the loop variable
-[T] in given i=4
-not ok 3 - Session cookie being sent makes state work (request 4)
-[T] loop top i=2
-[T] after get i=4
-...
-```
+## The live repro
 
-Every iteration reports `request 4`, and only the iteration where the body
-really is `Visit 4` passes.
-
-## Update 2026-08-08: the concrete Cro instance was a multi-param `for` loop
-
-The instrumentation below was re-run on current `main` and identified the
-writer exactly: **`Cro.rakumod`'s `for @components-in.kv -> $i, $comp`** (the
-pipeline compose), not the HPACK `while` loop originally guessed. A
-multi-parameter `for` binds its parameters with a plain `Stmt::Assign`
-(`build_for_bind_stmts`), which reaches `set_shared_var_sym` and publishes each
-per-iteration value under the bare name — while a *single*-param loop binds
-natively and is exempt. Minimal repro (no Cro, no modules):
+Deterministic, no modules, no concurrency — one `await start { 1 }` anywhere in
+the process is enough to arm the lane, and the collision then repeats on every
+call.
 
 ```raku
-sub compose(@components) {
-    my $last;
-    for @components.kv -> $i, $comp { $last = $i + $comp }
+sub work($tag) {
+    my @items = ($tag,);
+    await start { 1 };          # delete this line and mutsu is correct
+    @items.push("$tag-2");
 }
-await start { 1 };
-for 1..5 -> $i {
-    compose([10, 20, 30, 40, 50]);
-    await start { 1 };
-    say "loop i=$i";     # raku: 1..5;  mutsu (before the fix): 1,4,4,4,4
-}
+my @items = <x y z>;
+work('A');  say @items.raku;    # raku: [x y z]        mutsu: [A A-2]
+@items.push('MINE');            # raku: [x y z MINE]   mutsu: [A A-2 MINE]
+work('B');  say @items.raku;    # raku: [x y z MINE]   mutsu: [B B-2]
 ```
 
-Fixed by masking a multi-param loop's names out of the bare-name lane for the
-loop's duration (the rule `exec_set_var_dynamic_op` already applies to a `my`
-re-declaration) — `src/vm/vm_for_loop_body.rs`, pinned by
-`t/for-multi-param-shared-lane.t`. `t/http-session-inmemory.rakutest`'s
-tests 3-7 still fail after it, but with a *different* wrong value (`-1`, the
-HPACK Huffman `while --$i >= 0` residue) reaching the frame through the **`env`
-axis, not the store** — no `SharedStore` write or pull for `i` happens any more.
-So the remaining leak on this file is a plain env-key collision, and this
-ticket's store-keying redesign is no longer what blocks it.
+A second, independent shape — a **non-slurpy `@`/`%` parameter** escaping its
+call, because `mask_thread_redeclared_params`
+(`src/runtime/runtime_shared_vars.rs:304-311`) masks only scalars and slurpies:
 
-**Update (same day, resolved for this file).** That env-key collision was
-chased to the end and fixed in two more steps, neither of which touched the
-store: a loop body's `my` outliving its block
-(`t/loop-body-my-does-not-outlive-the-block.t`), and `check_method_wrap_chain`
-writing back every lexical a wrapper merely *captured*
-(`t/method-wrap-writeback-only-mutations.t`). `t/http-session-inmemory.rakutest`
-is now 10/13; the three remaining failures are the concurrent-client pair and
-session expiration, which are unrelated to this ticket. The store-keying
-redesign proposed below therefore has **no known blocked test driving it** —
-re-measure before starting it.
-
-Related, still open and single-threaded (no store involved):
-`todo/tickets/for-multi-param-array-hash-shadow-clobbers-outer-container.md` —
-a multi-param loop variable with no local slot in its frame writes a *global*
-of the same name (`sub f() { for <a b>.kv -> $j, $u {} }` clobbers an outer
-`my $j`). Same root cause (the bind is an assignment, not a declaration); the
-real fix is making it a per-iteration declaration, which is entangled with the
-§1.4 shadow-slot campaign.
-
-## Mechanism, measured
-
-`Env::insert`/`insert_sym` were instrumented behind an env var to print a
-backtrace on every write to the key `i`. During the request, an unrelated
-`while`-loop somewhere in the Cro/dependency stack counts a variable of its own
-called `$i` down from 13:
-
-```
-[CLOBBER] insert(str) i = 12
-   1: runtime_shared_vars::set_shared_var_sym
-   2: vm_env_helpers::set_env_with_main_alias_sym
-   3: vm_env_helpers::set_env_with_main_alias
-   4: vm_misc_coerce::exec_pre_decrement_op_inner
-   …
-  10: vm_control_ops::exec_while_loop_op_inner
+```raku
+sub takes(@list is copy) { await start { 1 }; @list.push('R') }
+my @list = <x y z>;
+takes(<p q>);
+say @list.raku;                 # raku: [x y z]        mutsu: [p q R]
 ```
 
-Each `--$i` lands in the global map, and the test's own `$i` — an ordinary `for`
-loop variable in a different file — reads the last value written there.
+Both reproduce identically with `%`, and the first also reproduces through a
+`use`d module (the module routine's local `@parts` overwrites the consumer's
+`@parts` — the mirror image of
+`todo/deep/module-file-scope-array-and-hash-still-share-the-caller.md`, where
+the consumer overwrites the module). A `Supply`/tap driver does not arm the
+lane; `start` and `Promise` do.
 
-## Why this is the architectural issue, not a local bug
+## Root cause, restated
 
-`session-shared-store-bare-name-collision` (2026-07-17) root-caused the same map
-for zef: `clone_for_thread` migrates *every* lexical into it by bare name, and
-the `thread_redeclared_vars` mask does not help because each spawned thread has
-its own `Interpreter` (and its own mask) while the map is a single
-`Arc<RwLock<HashMap<String, _>>>` for the whole process. The recorded conclusion
-was that the fix is the store's **keying** — a per-lineage store where
-`clone_for_thread` gives the child a store that inherits from the parent's and
-writes back on join — and that it needs an ADR first.
+Not the store's keying — **by-name container resolution**, which is
+ADR-0039's root cause reached through a second population route.
 
-Related open tickets, all downstream of the same map:
+The scalar and container lanes share the same polluted store and differ only in
+how a read resolves the name. A scalar reads its slot and consults the store
+only when the slot holds `Nil` (`src/vm/vm_var_assign_local_get.rs:256,268`). A
+container has a slot that nothing ever reads, so `GetLocal`'s `@`/`%` arm
+consults the store unconditionally — no `is_thread_clone()` gate, no staleness
+test (`src/vm/vm_var_assign_local_get.rs:155-161`) — and
+`sync_shared_vars_to_env` writes every dirty store key into `env` under the bare
+name (`src/runtime/runtime_shared_vars.rs:646-648`), where that read finds it.
 
-- `todo/tickets/supply-block-lexical-leaks-through-thread-lane.md` — a supply
-  block's `my` reaching the caller when a thread drives the emit;
-- `todo/tickets/cue-loop-lexical-shared-lane-residue.md`.
+What defeats the guard is a **third instance of the `@`/`%` sigil skip** that
+ADR-0024 and ADR-0025 already defer and ADR-0039 §4.1 lifts:
+`block_captured_scalars` (`src/runtime/runtime_thread.rs:20-22`) skips
+`@`/`%`/`&`, so a container is never in `captured_scalars`, so
+`clone_for_thread`'s retain (`src/runtime/runtime_thread.rs:352-356`) drops the
+container's `thread_redeclared_vars` entry at **every** spawn. After that,
+`container_name_is_redeclared` (`src/runtime/runtime_shared_vars.rs:238-242`) —
+consulted at nine sites precisely to keep a re-declared container frame-local —
+is querying a set the spawn just emptied.
 
-## Why it matters now
+## What to do
 
-It is what remains between mutsu and Cro's session tests: with the
-five client-side fixes of 2026-08-08 landed,
-`t/http-session-inmemory.rakutest` runs 13 tests and passes 6, and the failures
-that are left are this collision (tests 3-7) plus the concurrent-client pair
-(8-9), which is the same map under two clients at once.
+Nothing standalone. ADR-0039 §8 folds this in and records what it adds to that
+ADR's plan: the parameter shape belongs to slice 2 (do **not** widen
+`mask_thread_redeclared_params` — that grows the mechanism slice 2 deletes);
+slice 2 must add a container counterpart to the scalar
+`pending_caller_var_writeback` drain, or `my @a; await start { @a.push(1) }`
+(correct today) silently breaks; and four by-name container mechanisms become
+deletable rather than carried forward.
 
-## Reproducing
+Keep this file open until ADR-0039 **slice 2** lands. Slice 1 alone does not
+close it — the containers above are routine-local and parameter-bound, not
+file-scope.
 
-```
-bash tmp/run-session-test.sh          # the instrumentable copy of the test
-MUTSU_DEBUG_CLOBBER=i bash tmp/run-session-test.sh
-```
+## Exposure
 
-The second form needs the temporary hook in `Env::insert`/`insert_sym` described
-above — note that the String-keyed `insert` does **not** route through
-`insert_sym`, so both have to be hooked.
+No whitelisted roast test and no bundled battery is blocked today. The ticket's
+original driver, Cro's `t/http-session-inmemory.rakutest`, was resolved by
+unrelated fixes and Cro's test suite is not vendored. The three downstream
+tickets this file named — `supply-block-lexical-leaks-through-thread-lane`,
+`cue-loop-lexical-shared-lane-residue`, and
+`for-multi-param-array-hash-shadow-clobbers-outer-container` — are all resolved.
+That is a statement about which shapes the corpus happens to contain, not about
+severity: the failure mode is a silent wrong container value in any program that
+spawns a thread and reuses a container name.


### PR DESCRIPTION
Picks up `todo/deep/shared-store-bare-name-collision-across-unrelated-frames.md`. Design only — no code changes.

## What the re-measurement found (`52631889f`)

Two of the ticket's three premises have expired, and the third narrowed to one sigil.

- **"The store is a process-global map keyed by bare name" — fixed.** ADR-0010 shipped the lineage-chained `SharedStore` (`src/runtime/shared_store.rs:55-61`). Three concurrent workers each declaring `my @w` are correctly isolated.
- **The ticket's proposed fix ("re-key the store") — rejected.** It is both already done and insufficient: the live repro collides two frames of *one* thread inside *one* lineage, so no keying discipline short of per-frame keys (i.e. slots) removes it.
- **Scalars — clean.** Ten shapes probed (callee `while --$i` countdown, callee that spawns then writes its `my $i`, `is copy` params, `for` params, Nil-valued and live-valued readers). All match `raku`.
- **Containers (`@`/`%`) — still broken.** This is all that is left.

## The live repro

```raku
sub work($tag) {
    my @items = ($tag,);
    await start { 1 };          # delete this line and mutsu is correct
    @items.push("$tag-2");
}
my @items = <x y z>;
work('A');  say @items.raku;    # raku: [x y z]        mutsu: [A A-2]
@items.push('MINE');            # raku: [x y z MINE]   mutsu: [A A-2 MINE]
work('B');  say @items.raku;    # raku: [x y z MINE]   mutsu: [B B-2]
```

A second, independent shape — a non-slurpy `@`/`%` **parameter** escaping its call:

```raku
sub takes(@list is copy) { await start { 1 }; @list.push('R') }
my @list = <x y z>;
takes(<p q>);
say @list.raku;                 # raku: [x y z]        mutsu: [p q R]
```

Both reproduce identically with `%`, and the first also reproduces through a `use`d module — the mirror image of ADR-0039 §1.1, where the *consumer* overwrites the module. One `await start { 1 }` anywhere in the process arms the lane; the collision is then deterministic and repeats on every call.

## Root cause: this is ADR-0039, not a store problem

The scalar and container lanes share the same polluted store and differ only in how a read resolves the name. A scalar reads its slot and consults the store only when the slot holds `Nil` (`vm_var_assign_local_get.rs:256,268`). A container has a slot that nothing reads (ADR-0039 §1.3), so `GetLocal`'s `@`/`%` arm consults the store **unconditionally** (`vm_var_assign_local_get.rs:155-161`), and `sync_shared_vars_to_env` writes every dirty store key into `env` under the bare name (`runtime_shared_vars.rs:646-648`).

The guard fails because of a **third instance of the `@`/`%` sigil skip** that ADR-0024 and ADR-0025 already defer: `block_captured_scalars` (`runtime_thread.rs:20-22`) skips `@`/`%`/`&`, so a container is never in `captured_scalars`, so `clone_for_thread`'s retain (`runtime_thread.rs:352-356`) drops every container's `thread_redeclared_vars` entry at **every** spawn. `container_name_is_redeclared` is then querying a set the spawn just emptied.

## Medium chosen: addendum, not a new ADR

ADR-0039 (`Proposed`, unimplemented) already owns "containers must resolve lexically". Adding §8 amends a design before implementation rather than revising a decision, and avoids two competing designs for one mechanism — the drift `docs/adr/README.md` warns about. §8 adds:

1. A **fourth hole** for the exclusion list: non-slurpy `@`/`%` parameters are never masked (`mask_thread_redeclared_params:304-311`). Assigned to slice 2 — do **not** widen that mask, it grows the mechanism slice 2 deletes.
2. A **hard requirement slice 2 would otherwise get wrong**: once `Expr::ArrayVar` emits `GetLocal(slot)`, the store writeback (which writes `env` only) can no longer reach the reader, so `my @a; await start { @a.push(1) }` — correct today — silently breaks. The precedent is the scalar `pending_caller_var_writeback` / `apply_pending_rw_writeback` drain; containers need the same, keyed by binding.
3. Four by-name container mechanisms that become **deletable** rather than carried forward (`container_name_is_redeclared` + 9 call sites, the two store preferences, the two dynamic-var `@`/`%` exemptions). The `__mutsu_atomic_*` lanes stay — ADR-0010 established they are process-wide primitives, not lexical sharing.

## Ticket disposition

The deep ticket is rewritten as the evidence record and **stays open** until ADR-0039 **slice 2** lands — slice 1 alone does not close it, because these containers are routine-local and parameter-bound, not file-scope. Its three downstream tickets are all confirmed resolved.

No whitelisted roast test or bundled battery is blocked today (the Cro session-test driver was resolved by unrelated fixes; Cro's suite is not vendored) — a statement about corpus coverage, not severity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)