### PR TITLE
fix(types): route container type-constraint reads through embedded metadata (ADR-0042 slice 1)

### DIFF
--- a/docs/adr/0042-type-constraints-belong-to-the-container-not-to-a-name.md
+++ b/docs/adr/0042-type-constraints-belong-to-the-container-not-to-a-name.md
@@ -1,6 +1,7 @@
 # ADR-0042: A type constraint belongs to the container, not to a name — retiring the `var_type_constraints` side table
 
-- Status: Proposed (design complete; implementation not started)
+- Status: Partially Implemented — Slice 1 landed 2026-08-20 (see §10). Slices 2
+  and 3 not started.
 - Date: 2026-08-20
 - Related: ADR-0013 (container interior mutability), ADR-0024 (mainline lexicals —
   the same by-name/lexical split for scalar *values*),
@@ -334,3 +335,59 @@ It is therefore not a live bug but a **mechanism that should not exist**: the
 save/restore is a workaround for the unscoped map, carrying the latent
 promotion defect noted in §5.3. It is recorded here as part of slice 3's
 deletion list, not as a failing shape to fix.
+
+## 10. Slice 1 status (landed 2026-08-20)
+
+All four §5.1 steps landed as specified, with two adjustments discovered
+during implementation:
+
+- **Extra fix, not in the original four steps:** `set_var_type_constraint_routine_scoped`
+  (`src/runtime/runtime_var_meta.rs`) only ever registered the env-scoped
+  `__mutsu_type::name` (value type) entry, never `__mutsu_hash_key_type::name`
+  (key type). Step 3 (dropping `%` from `emit_set_var_type`'s sigil
+  exclusion) routes a key-only object hash declared inside a routine/block
+  (`my %h{Int}`, empty `value_type`) through this SCOPED path for the first
+  time — and losing the key-type registration there silently dropped key-type
+  enforcement for exactly that shape (measured: `sub f { my %h{Int}; %h{1} =
+  "a"; %h{"bad"} = "b" }` stopped dying). Fixed by also registering
+  `__mutsu_hash_key_type::name` there. A second, related fix: three
+  `var_type_constraint_fast(name).is_some() || ... || var_hash_key_constraint_fast(name)`
+  bailout checks (`try_shared_hash_element_assign`, `try_fast_hash_element_assign`,
+  `try_fast_hash_delete`) were routed through a single
+  `container_type_metadata(&current).is_some()` check instead of
+  `element_constraint_for` — `element_constraint_for` filters out an empty
+  `value_type`, which is exactly what a key-only object hash has, so it alone
+  would have reintroduced the same gap at the read side. `container_type_metadata`
+  (true iff `value_type` OR `key_type` OR `declared_type` is set) does not.
+  `var_hash_key_constraint_fast` is now dead code (no remaining callers) and
+  was removed.
+- **One step (a §5.1-step-4 extension) was prototyped and reverted.** An
+  attempt to also fix the "outer-first shadow" shape (see the new finding
+  below) by extending `loop_local_saved_env` (the mechanism
+  `pop_loop_local_scope` already uses to restore a shadowed outer binding's
+  bare-name value) to snapshot/restore the `__mutsu_type::`/
+  `__mutsu_hash_key_type::` metadata keys too was implemented and measured to
+  have **no effect** on that shape — proving its root cause is at the VALUE
+  layer (the container's own embedded metadata gets corrupted), not the
+  name-keyed metadata layer this ADR's slice 1 targets. Reverted to keep
+  slice 1 scoped to its four specified, verified-effective steps.
+
+**Verified green**, `raku`-oracled: the §2.2 container matrix (all 7 shapes:
+routine/block/if/while/for/`my Int %h`/`my %h{Int}`), the §2.1 `if`/`unless`/
+`else` scalar rows, the §3 alias probe (7/7 shapes), and the §3.1 `state`
+container gap. Pinned in `t/typed-constraint-scope-matrix.t` and
+`t/state-typed-container-alias.t`. Zero regressions across the 62 pre-existing
+`t/*typed*` files and the `S02-types`/`S09-typed-arrays` roast whitelist
+(19 files, 4824 tests).
+
+**New finding, NOT fixed by slice 1 and NOT one of its four steps:** a
+DIFFERENT, deeper, pre-existing bug — present on `main` before slice 1 and
+unaffected by it — where a typed declaration that SHADOWS an already-existing
+outer binding of the same name (as opposed to being a fresh, non-shadowing
+declaration) corrupts the outer binding's own value in place, for BOTH
+scalars and containers, across EVERY branch/loop construct measured —
+`if`/`unless`/`else` are affected exactly as much as `while`/`loop`/`repeat`/
+`for`, contradicting this ADR's own §2.1 prediction that step 4 would fix the
+former. Root cause and fix direction: `todo/deep/scoped-type-declaration-tags-the-shadowed-outer-value.md`.
+Pinned (as expected-failing `# TODO` assertions) in
+`t/typed-constraint-shadow-leak-unfixed.t`.

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -2170,29 +2170,35 @@ impl Compiler {
     }
 
     /// Emit the declaration-time type-constraint registration op for a
-    /// `my TYPE $x`-family declaration. A SCALAR `my`/`state` lexically inside
-    /// a routine, or directly inside a plain `{ ... }` block (see
+    /// `my TYPE $x`-family declaration. A `my`/`state` declaration lexically
+    /// inside a routine, or directly inside a plain `{ ... }` block (see
     /// `lexically_in_block`), gets `SetVarTypeScoped` — env-only
     /// registration, exactly like a typed parameter — so its constraint dies
     /// with the frame/block instead of leaking onto a same-named variable
     /// elsewhere through the global name-keyed store
     /// (`todo/deep/bare-name-type-constraint-store-is-scope-blind.md`).
-    /// Everything else keeps the both-store `SetVarType`: `@`/`%` containers
-    /// (their element/key metadata is consulted through the global map by the
-    /// push/subscript fast paths), `our` (package-scoped, outlives the frame),
-    /// dynamics (`$*x`, read cross-frame by design), an anonymous scalar
-    /// (`my T $`, name `__ANON_STATE__` — stored via `SetGlobal`/`GetGlobal`
-    /// rather than a local slot, immediately consumed into a
-    /// `WrapTypedContainer` cell, so there is no per-declaration slot for a
-    /// block/frame exit to scope; going through the env-only opcode here
-    /// starved that read of the global-map registration it depends on — see
+    ///
+    /// ADR-0042 slice 1: `@`/`%` containers now use the same scoped opcode as
+    /// scalars. Their element/key metadata is embedded directly on the
+    /// container VALUE (`ArrayData`/`HashData`) by the mutation chokepoints
+    /// (`element_constraint_for` / `container_type_metadata`), not read
+    /// through the global map at the hot push/subscript paths any more — the
+    /// global-map registration this doc comment used to require for those
+    /// paths is no longer their source of truth, so containers no longer need
+    /// to be excluded from scoping. `&` (routines are not scoped this way)
+    /// stays excluded. Everything else keeps the both-store `SetVarType`:
+    /// `our` (package-scoped, outlives the frame), dynamics (`$*x`, read
+    /// cross-frame by design), an anonymous scalar (`my T $`, name
+    /// `__ANON_STATE__` — stored via `SetGlobal`/`GetGlobal` rather than a
+    /// local slot, immediately consumed into a `WrapTypedContainer` cell, so
+    /// there is no per-declaration slot for a block/frame exit to scope;
+    /// going through the env-only opcode here starved that read of the
+    /// global-map registration it depends on — see
     /// `t/pair-typed-value-container.t`), and mainline declarations outside
     /// any block (no frame/scope to scope to).
     fn emit_set_var_type(&mut self, name: &str, name_idx: u32, tc_idx: u32, is_our: bool) {
         let scoped = !is_our
             && (self.is_routine || self.lexically_in_routine || self.lexically_in_block)
-            && !name.starts_with('@')
-            && !name.starts_with('%')
             && !name.starts_with('&')
             && !name.starts_with('*')
             && name != "__ANON_STATE__"

--- a/src/runtime/runtime_var_meta.rs
+++ b/src/runtime/runtime_var_meta.rs
@@ -110,6 +110,20 @@ impl Interpreter {
             format!("__mutsu_type::{}", name),
             Value::str(info.value_type),
         );
+        // ADR-0042 slice 1: an object-hash's key type (`my %h{Int}`) must be
+        // scoped the same way its value type is. `var_hash_key_constraint`
+        // checks this env-scoped key first, so registering it here is what
+        // lets the container-tagging step right after `SetVarTypeScoped`
+        // (`exec_set_var_type`) embed the key type onto the freshly-declared
+        // hash. Without it a key-only object hash declared inside a routine
+        // (now scoped since step 3 stopped excluding `%` from the scoped
+        // opcode) silently lost key-type enforcement.
+        let hash_key_meta_key = format!("__mutsu_hash_key_type::{}", name);
+        if let Some(key_type) = info.key_type {
+            self.env.insert(hash_key_meta_key, Value::str(key_type));
+        } else {
+            self.env.remove(&hash_key_meta_key);
+        }
         self.env_type_constraint_seen = true;
     }
 
@@ -528,15 +542,5 @@ impl Interpreter {
         let tc = self.self_attr_type_constraint(bare)?;
         let (_, key_type) = crate::runtime::types::split_object_hash_constraint(&tc);
         key_type.map(str::to_string)
-    }
-
-    /// Fast check for hash key constraint — only checks the HashMap,
-    /// skipping the `format!("__mutsu_hash_key_type::...")` + env lookup.
-    /// Object-hash attributes still have to take the slow path, so they are
-    /// resolved through the class registry here too (only for `%`-sigil
-    /// attribute names, which never appear on the hot local-variable path).
-    pub(crate) fn var_hash_key_constraint_fast(&self, name: &str) -> bool {
-        self.var_hash_key_constraints.contains_key(name)
-            || self.attr_hash_key_constraint(name).is_some()
     }
 }

--- a/src/vm/vm_control_ops.rs
+++ b/src/vm/vm_control_ops.rs
@@ -341,6 +341,20 @@ impl Interpreter {
                 continue;
             }
             self.env_mut().remove_sym(*sym);
+            // ADR-0042 slice 1 step 4: also strip the env-scoped
+            // type-constraint metadata keys (`__mutsu_type::<name>`,
+            // `__mutsu_hash_key_type::<name>`) so a block-local typed
+            // declaration — now including `@`/`%` containers, since slice 1
+            // step 3 stopped excluding them from the scoped opcode — does not
+            // leak its constraint onto a same-named variable read after this
+            // branch exits. Mirrors the prefix-stripping restore
+            // `exec_block_scope_op` already does for genuine `{ ... }`
+            // blocks.
+            sym.with_str(|s| {
+                self.env_mut().remove(&format!("__mutsu_type::{}", s));
+                self.env_mut()
+                    .remove(&format!("__mutsu_hash_key_type::{}", s));
+            });
             for &idx in &owned_slots {
                 if idx < self.locals.len() && code.local_sym(idx) == Some(*sym) {
                     self.locals[idx] = Value::NIL;

--- a/src/vm/vm_data_push_ops.rs
+++ b/src/vm/vm_data_push_ops.rs
@@ -6,6 +6,12 @@ impl Interpreter {
     /// Storing Nil into a fresh array element resets it to the element
     /// default: Any for untyped arrays, the element type object for typed
     /// (`my Int @a; @a.push(Nil)` stores `Int`). Slips convert per element.
+    ///
+    /// ADR-0042 slice 1: reads the constraint via `element_constraint_for`,
+    /// which prefers the metadata embedded on the target array's own value
+    /// over the (scope-blind) name-keyed `var_type_constraints` map — the
+    /// same value-carrying accessor every other container mutation site in
+    /// this ADR routes through.
     fn push_nil_to_elem_default(&mut self, target_name: &str, val: Value) -> Value {
         let has_nil = match val.view() {
             ValueView::Slip(items) => items.iter().any(Value::is_nil),
@@ -14,10 +20,8 @@ impl Interpreter {
         if !has_nil {
             return val;
         }
-        let default = match self
-            .var_type_constraint_fast(target_name)
-            .map(|s| s.to_string())
-        {
+        let target = self.env().get(target_name).cloned().unwrap_or(Value::NIL);
+        let default = match self.element_constraint_for(target_name, &target) {
             Some(c) => {
                 let nominal = loan_env!(self, nominal_type_object_name_for_constraint(&c));
                 Value::package(crate::symbol::Symbol::intern(&nominal))
@@ -303,15 +307,18 @@ impl Interpreter {
 
     /// Type-check a pushed value (or every element of a pushed `Slip`) against
     /// the declared element type of `target_name`. A no-op for an untyped array.
+    ///
+    /// ADR-0042 slice 1: constraint comes from `element_constraint_for`
+    /// (container-embedded metadata first, name-keyed map as fallback) rather
+    /// than the map-only `var_type_constraint_fast` — this is the hot
+    /// `@a.push` chokepoint the ADR names for the bench-CI watch.
     fn check_push_element_type(
         &mut self,
         target_name: &str,
         val: &Value,
     ) -> Result<(), RuntimeError> {
-        let Some(type_name) = self
-            .var_type_constraint_fast(target_name)
-            .map(|s| s.to_string())
-        else {
+        let target = self.env().get(target_name).cloned().unwrap_or(Value::NIL);
+        let Some(type_name) = self.element_constraint_for(target_name, &target) else {
             return Ok(());
         };
         // Owned clone of the Slip backing (a view guard's borrow cannot
@@ -358,8 +365,13 @@ impl Interpreter {
     }
 
     /// The native integer element type of the array variable `name`, if any.
+    ///
+    /// ADR-0042 slice 1: routed through `element_constraint_for` (see
+    /// `check_push_element_type`) instead of the map-only
+    /// `var_type_constraint_fast`.
     pub(crate) fn native_int_element_constraint(&mut self, name: &str) -> Option<String> {
-        let constraint = self.var_type_constraint_fast(name)?.to_string();
+        let target = self.env().get(name).cloned().unwrap_or(Value::NIL);
+        let constraint = self.element_constraint_for(name, &target)?;
         crate::runtime::native_types::is_native_int_type(&constraint).then_some(constraint)
     }
 

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -877,11 +877,25 @@ impl Interpreter {
                 // The remaining special cases (typed/readonly anon scalar, fatal-mode
                 // Failure explosion, `:=` container write-through, capture RHS) are
                 // excluded by the guards and fall through to the general path.
+                // ADR-0042 slice 1: route the constraint check through
+                // `element_constraint_for` (container-embedded metadata
+                // first, name-keyed map as fallback) like the other mutation
+                // chokepoints in this ADR's table, for mechanical
+                // consistency. `__ANON_STATE__` is always a scalar, so this
+                // falls straight through to the name-keyed lookup — the
+                // scalar cell-carried `of` is ADR-0042 slice 2. The name
+                // comparison stays first so a non-`__ANON_STATE__` SetGlobal
+                // (the overwhelming majority) never pays the env lookup.
                 if name_str == "__ANON_STATE__"
                     && !raw_mode
                     && !is_rebind
                     && !self.fatal_mode
-                    && self.var_type_constraint_fast(name_str).is_none()
+                    && {
+                        let anon_state_val =
+                            self.env().get(name_str).cloned().unwrap_or(Value::NIL);
+                        self.element_constraint_for(name_str, &anon_state_val)
+                            .is_none()
+                    }
                     && !self.is_readonly(name_str)
                     // A `VarRef` RHS (a `:=` bind of `$` to a variable) must reach
                     // the general path, which is where the wrapper is unwrapped and

--- a/src/vm/vm_misc_assign.rs
+++ b/src/vm/vm_misc_assign.rs
@@ -68,16 +68,18 @@ impl Interpreter {
         if name.starts_with('%') || name.starts_with('@') {
             self.clear_all_ro_index(&name);
         }
-        if name.starts_with('%')
-            && self
-                .var_type_constraint_fast(&name)
+        // ADR-0042 slice 1: read the target hash's own embedded metadata via
+        // `element_constraint_for` instead of the scope-blind name-keyed map.
+        if name.starts_with('%') {
+            let current = self.get_env_with_main_alias(&name);
+            let is_mix = current
+                .as_ref()
+                .and_then(|v| self.element_constraint_for(&name, v))
                 .and_then(|s| Self::quant_hash_trait_from_constraint(s.as_str()))
-                == Some("Mix")
-            && self
-                .get_env_with_main_alias(&name)
-                .is_some_and(|current| !current.is_nil())
-        {
-            return Err(RuntimeError::assignment_ro(None));
+                == Some("Mix");
+            if is_mix && current.is_some_and(|current| !current.is_nil()) {
+                return Err(RuntimeError::assignment_ro(None));
+            }
         }
         if name.starts_with('&') && !name.contains("::") {
             let bare = name.trim_start_matches('&');

--- a/src/vm/vm_misc_scope.rs
+++ b/src/vm/vm_misc_scope.rs
@@ -203,7 +203,7 @@ impl Interpreter {
             // detach a backing node shared with the initializer so a later
             // `@foo[0]++` on the state var does not reach the source array
             // (`(state @foo) = @bar`, S04-declarations/state.t).
-            let coerced = if name.starts_with('@') {
+            let mut coerced = if name.starts_with('@') {
                 runtime::coerce_to_array(init_val).detach_shared_container()
             } else if name.starts_with('%') {
                 self.coerce_object_to_hash(init_val)
@@ -211,6 +211,35 @@ impl Interpreter {
             } else {
                 init_val
             };
+            // ADR-0042 slice 1 §3.1: a `state Int @a` container is boxed into
+            // a `ContainerRef` cell unconditionally below (Track B slice 3),
+            // but until now nothing tagged the ARRAY/HASH inside that cell
+            // with its own `ContainerTypeInfo` the way a plain `my Int @a`
+            // does — so enforcement worked only through the bare name `@a`
+            // and not through a differently-named alias (`my @x := @a;
+            // @x.push("s")`). Embed the declared constraint on the value
+            // itself before it is wrapped, exactly like `my`'s
+            // `register_var_container_type_metadata`.
+            if (name.starts_with('@') || name.starts_with('%'))
+                && let Some(value_type) = self.var_type_constraint(name)
+            {
+                let info = crate::runtime::ContainerTypeInfo {
+                    declared_type: if name.starts_with('@')
+                        && crate::runtime::native_types::is_native_array_element_type(&value_type)
+                    {
+                        Some(format!("array[{value_type}]"))
+                    } else {
+                        None
+                    },
+                    value_type,
+                    key_type: if name.starts_with('%') {
+                        self.var_hash_key_constraint(name)
+                    } else {
+                        None
+                    },
+                };
+                coerced = self.tag_container_metadata(coerced, info);
+            }
             // Track B slice 3: a `state @a` / `state %h` aggregate lives in a
             // shared `ContainerRef` cell in ALL modes, not just under an active
             // thread context. Every closure created in the declaring routine

--- a/src/vm/vm_var_assign_coerce.rs
+++ b/src/vm/vm_var_assign_coerce.rs
@@ -159,13 +159,17 @@ impl Interpreter {
         name: &str,
         value: Value,
     ) -> Result<Value, RuntimeError> {
-        if let Some(constraint) = self.var_type_constraint_fast(name).cloned()
+        // ADR-0042 slice 1: read the target hash's own embedded metadata via
+        // `element_constraint_for` instead of the scope-blind name-keyed map.
+        let current = self.env().get(name).cloned();
+        if let Some(constraint) = current
+            .as_ref()
+            .and_then(|v| self.element_constraint_for(name, v))
             && let Some(trait_name) = Self::quant_hash_trait_from_constraint(&constraint)
         {
             // Only coerce if the variable IS a QuantHash container (declared via `is`),
             // not when the constraint is a value type (declared via `of`).
             // Check: if the current value is already a QuantHash, it's an `is` trait.
-            let current = self.env().get(name).cloned();
             let is_quanthash_container = matches!(
                 current.as_ref().map(Value::view),
                 Some(ValueView::Bag(_, _) | ValueView::Mix(_, _) | ValueView::Set(_, _))

--- a/src/vm/vm_var_assign_element.rs
+++ b/src/vm/vm_var_assign_element.rs
@@ -52,13 +52,27 @@ impl Interpreter {
             return None;
         }
         // Reject when type/key constraints, defaults, readonly, or bound indices
-        // exist — those need the full assignment path's healing.
-        if self.var_type_constraint_fast(var_name).is_some()
-            || self.var_default(var_name).is_some()
-            || self.var_hash_key_constraint_fast(var_name)
-            || self.is_readonly(var_name)
+        // exist — those need the full assignment path's healing. ADR-0042
+        // slice 1: the type/key-constraint check reads the target hash's own
+        // embedded metadata (`container_type_metadata`, true iff `value_type`
+        // OR `key_type` OR `declared_type` is set — a key-only object hash
+        // like `my %h{Int}` has an empty `value_type`, so `element_constraint_for`
+        // alone would miss it) instead of the scope-blind name-keyed map.
+        // Scoped tightly: `current` must NOT stay alive past this check — it
+        // holds a clone of the hash's Arc, and the fast-path commit below
+        // (through `assign_hash_elem_to_shared_var`) needs to see this
+        // variable's TRUE reference count, not one inflated by our own
+        // temporary clone (see the `try_fast_hash_element_assign` comment
+        // below, where this exact shape tripped its `strong_count > 2`
+        // external-binding guard).
         {
-            return None;
+            let current = self.env().get(var_name).cloned().unwrap_or(Value::NIL);
+            if self.container_type_metadata(&current).is_some()
+                || self.var_default(var_name).is_some()
+                || self.is_readonly(var_name)
+            {
+                return None;
+            }
         }
         {
             let bound_key = format!("__mutsu_bound_index::{}", var_name);
@@ -127,12 +141,22 @@ impl Interpreter {
             return None;
         }
         // Reject typed / defaulted / shaped / readonly / bound arrays — those need
-        // the full path's native-fill, hole, and shape handling.
-        if self.var_type_constraint_fast(var_name).is_some()
-            || self.var_default(var_name).is_some()
-            || self.is_readonly(var_name)
+        // the full path's native-fill, hole, and shape handling. ADR-0042
+        // slice 1: the type-constraint check reads the target array's own
+        // embedded metadata via `element_constraint_for` instead of the
+        // scope-blind name-keyed map. Scoped tightly: `current` holds a clone
+        // of the array's Arc and must not stay alive into the commit below,
+        // which needs the variable's TRUE reference count (see the
+        // `try_fast_hash_element_assign` comment for the bug this shape
+        // caused when the clone lived too long).
         {
-            return None;
+            let current = self.env().get(var_name).cloned().unwrap_or(Value::NIL);
+            if self.element_constraint_for(var_name, &current).is_some()
+                || self.var_default(var_name).is_some()
+                || self.is_readonly(var_name)
+            {
+                return None;
+            }
         }
         {
             let shaped_key = format!("__mutsu_shaped_array_dims::{}", var_name);
@@ -230,14 +254,31 @@ impl Interpreter {
         if matches!(val_ref.view(), ValueView::Nil) {
             return None;
         }
-        // Check that no type constraints, key constraints, or defaults exist
-        // Use fast lookups that avoid format! allocations
-        if self.var_type_constraint_fast(var_name).is_some()
-            || self.var_default(var_name).is_some()
-            || self.var_hash_key_constraint_fast(var_name)
-            || self.is_readonly(var_name)
+        // Check that no type constraints, key constraints, or defaults exist.
+        // ADR-0042 slice 1: reads the target hash's own embedded metadata
+        // (see the `try_shared_hash_element_assign` comment above for why
+        // `container_type_metadata` rather than `element_constraint_for`) —
+        // the `has_type_meta()` check further below is a second,
+        // container-only belt-and-suspenders check on the SAME embedded
+        // metadata, kept for its extra strong-count/local-slot bookkeeping.
+        //
+        // Scoped tightly in its own block: `current` clones the hash's Arc,
+        // and the `strong_count` check a few lines below (the "does an
+        // external binding exist" heuristic) counts EVERY live Arc clone —
+        // including this temporary one, if it were still alive. An
+        // unscoped `let current = ...` here made every hash-element
+        // assignment whose value's rvalue-itemization is observed by
+        // surrounding code (`my @z = (%a<x> = ...)`) see `strong_count == 3`
+        // instead of 2, permanently falling off the fast path and losing its
+        // itemization (`t/hash-key-single-itemize.t`).
         {
-            return None;
+            let current = self.env().get(var_name).cloned().unwrap_or(Value::NIL);
+            if self.container_type_metadata(&current).is_some()
+                || self.var_default(var_name).is_some()
+                || self.is_readonly(var_name)
+            {
+                return None;
+            }
         }
         // Reject if any bound indices exist for this variable
         // (e.g. `%h<a> := $foo` makes element writes propagate to $foo)

--- a/src/vm/vm_var_delete_ops.rs
+++ b/src/vm/vm_var_delete_ops.rs
@@ -110,8 +110,22 @@ impl Interpreter {
         ) {
             return None;
         }
-        if self.var_type_constraint_fast(var_name).is_some() || self.is_readonly(var_name) {
-            return None;
+        // ADR-0042 slice 1: read the target hash's own embedded metadata
+        // instead of the scope-blind name-keyed map. `container_type_metadata`
+        // (true iff `value_type` OR `key_type` OR `declared_type` is set)
+        // rather than `element_constraint_for` so a key-only object hash
+        // (`my %h{Int}`, empty `value_type`) still bails to the slow path.
+        // Scoped tightly: `current` clones the hash's Arc, and the
+        // `strong_count` check below (the "does an external binding exist"
+        // heuristic) counts every live clone — an unscoped `current` here
+        // inflated it by one and permanently disabled this fast path (see
+        // the identical bug fixed in `try_fast_hash_element_assign`,
+        // `vm_var_assign_element.rs`).
+        {
+            let current = self.env().get(var_name).cloned().unwrap_or(Value::NIL);
+            if self.container_type_metadata(&current).is_some() || self.is_readonly(var_name) {
+                return None;
+            }
         }
         // A `:=`-bound-to-literal key must clear its read-only marker on delete;
         // route it to the slow path (which calls `unmark_ro_indices`) so a later

--- a/t/state-typed-container-alias.t
+++ b/t/state-typed-container-alias.t
@@ -1,0 +1,43 @@
+use v6;
+use Test;
+
+# ADR-0042 slice 1 §3.1: a `state Int @a` container is boxed into a shared
+# `ContainerRef` cell unconditionally (Track B slice 3), but until now
+# nothing tagged the ARRAY/HASH inside that cell with its own
+# `ContainerTypeInfo` the way a plain `my Int @a` does -- so enforcement
+# worked only through the bare declared name `@a` and not through a
+# differently-named alias. Companion to t/state-typed-scalar.t (the scalar
+# state case) and t/typed-constraint-scope-matrix.t's §3 alias probe (the
+# non-state container case).
+#
+# Expected values verified against raku.
+
+plan 4;
+
+sub direct-array() {
+    state Int @a;
+    @a.push("bad");
+}
+dies-ok { direct-array() }, 'state Int @a enforces directly';
+
+sub alias-array() {
+    state Int @a;
+    my @x := @a;
+    @x.push("bad");
+}
+dies-ok { alias-array() }, 'state Int @a enforces through a differently-named alias';
+
+sub direct-hash() {
+    state Int %h;
+    %h<k> = "bad";
+}
+dies-ok { direct-hash() }, 'state Int %h enforces directly';
+
+sub alias-hash() {
+    state Int %h;
+    my %y := %h;
+    %y<k> = "bad";
+}
+dies-ok { alias-hash() }, 'state Int %h enforces through a differently-named alias';
+
+done-testing;

--- a/t/typed-constraint-scope-matrix.t
+++ b/t/typed-constraint-scope-matrix.t
@@ -1,0 +1,141 @@
+use v6;
+use Test;
+
+# ADR-0042 slice 1: a bare-name type-constraint map is the wrong architecture
+# for containers -- enforcement now reads the constraint carried on the
+# container VALUE itself (`ArrayData`/`HashData`'s `value_type`/`key_type`),
+# not a separate name-keyed side table that is scope-blind. This file pins:
+#
+#   §2.2 the container matrix: a typed `@`/`%` declared in some inner scope
+#   must not poison a same-named UNTYPED container used after that scope has
+#   exited.
+#
+#   §2.1 the scalar matrix's `if`/`unless`/`else` rows: slice 1 step 4 taught
+#   `BlockLocalScope`'s exit cleanup to also strip the env-scoped
+#   `__mutsu_type::`/`__mutsu_hash_key_type::` metadata keys, mirroring what
+#   the genuine-block path (`BlockScope`) already did.
+#
+# Expected values verified against `raku` (every row here passes there).
+
+
+# --- §2.2: container matrix (all 7 shapes must be green) ---
+
+{
+    sub inner { my Int @a; @a.push(5); }
+    sub outer { inner(); my @a; @a.push("x"); @a[*-1] }
+    is outer(), "x", 'container: routine-scoped my Int @a does not poison a later routine-local @a';
+}
+
+{
+    sub via-block {
+        { my Int @a; @a.push(5); }
+        my @a; @a.push("x"); @a[*-1]
+    }
+    is via-block(), "x", 'container: bare-block-scoped my Int @a does not poison a later @a';
+}
+
+{
+    sub via-if {
+        if True { my Int @a; @a.push(5); }
+        my @a; @a.push("x"); @a[*-1]
+    }
+    is via-if(), "x", 'container: if-branch my Int @a does not poison a later @a';
+}
+
+{
+    sub via-while {
+        my $i = 0;
+        while $i < 1 { my Int @a; @a.push(5); $i++; }
+        my @a; @a.push("x"); @a[*-1]
+    }
+    is via-while(), "x", 'container: while-body my Int @a does not poison a later @a';
+}
+
+{
+    sub via-for {
+        for 1..1 { my Int @a; @a.push(5); }
+        my @a; @a.push("x"); @a[*-1]
+    }
+    is via-for(), "x", 'container: for-body my Int @a does not poison a later @a';
+}
+
+{
+    sub via-hash {
+        { my Int %h; %h<a> = 5; }
+        my %h; %h<a> = "x"; %h<a>
+    }
+    is via-hash(), "x", 'container: block-scoped my Int %h does not poison a later %h';
+}
+
+{
+    sub via-objhash {
+        { my %h{Int}; %h{1} = "a"; }
+        my %h; %h<a> = "x"; %h<a>
+    }
+    is via-objhash(), "x", 'container: block-scoped my %h{Int} does not poison a later %h';
+}
+
+# --- §2.1: if/unless/else scalar rows (now fixed by BlockLocalScope cleanup) ---
+
+{
+    sub via-if-scalar {
+        if True { my Str $x = "a"; }
+        my $x; $x = 42; $x
+    }
+    is via-if-scalar(), 42, 'scalar: if-branch my Str $x does not poison a later $x';
+}
+
+{
+    sub via-unless-scalar {
+        unless False { my Str $x = "a"; }
+        my $x; $x = 42; $x
+    }
+    is via-unless-scalar(), 42, 'scalar: unless-branch my Str $x does not poison a later $x';
+}
+
+{
+    sub via-else-scalar {
+        if False { } else { my Str $x = "a"; }
+        my $x; $x = 42; $x
+    }
+    is via-else-scalar(), 42, 'scalar: else-branch my Str $x does not poison a later $x';
+}
+
+# --- §3: alias probe -- enforcement reads the CONTAINER, not the name ---
+# For every typed-container declaration shape, a differently-named bound
+# alias still enforces. This is what proves enforcement reads the value's
+# own embedded metadata and not the (scope-blind) name map.
+
+{
+    my Int @a1;
+    my @x1 := @a1;
+    dies-ok { @x1.push("bad") }, 'alias: fresh Int @a enforced through a differently-named alias';
+}
+
+{
+    my Int @a2 = 1, 2;
+    my @x2 := @a2;
+    dies-ok { @x2.push("bad") }, 'alias: initializer-typed @a enforced through alias';
+}
+
+{
+    my Int @a3;
+    @a3 = 1, 2;
+    my @x3 := @a3;
+    dies-ok { @x3.push("bad") }, 'alias: whole-assigned Int @a enforced through alias';
+}
+
+{
+    my Int %h1;
+    my %y1 := %h1;
+    dies-ok { %y1<k> = "bad" }, 'alias: my Int %h enforced through a differently-named alias';
+}
+
+{
+    my %h2{Int};
+    my %y2 := %h2;
+    %y2{1} = 5;
+    dies-ok { %y2{"bad"} = 5 }, 'alias: my %h{Int} key type enforced through alias';
+}
+
+done-testing;

--- a/t/typed-constraint-shadow-leak-unfixed.t
+++ b/t/typed-constraint-shadow-leak-unfixed.t
@@ -1,0 +1,124 @@
+use v6;
+use Test;
+
+# ADR-0042 slice 1 did NOT fix every type-constraint scope leak -- only the
+# "fresh-after" shape covered by t/typed-constraint-scope-matrix.t (a typed
+# `my` inside a branch/loop, then a FRESH untyped `my` of the same name
+# declared AFTER that scope exits).
+#
+# This file pins the shapes that are still broken, so a future slice has a
+# clear before/after instead of the leak silently going untested. Two
+# residuals, both recorded in
+# todo/deep/scoped-type-declaration-tags-the-shadowed-outer-value.md:
+#
+# 1. The "outer-first shadow" shape: an outer untyped variable declared
+#    BEFORE the inner typed declaration, which SHADOWS it, then reused
+#    (not re-declared) after the branch/loop exits. Root cause:
+#    `exec_set_var_type` tags whatever value currently sits in `env` under
+#    the declared name at the moment the type-constraint op runs, which --
+#    since the type op runs before the shadowing declaration's own
+#    value-store op -- is still the OUTER value. This corrupts the outer
+#    CONTAINER'S OWN embedded metadata (not just a name-keyed side table),
+#    so it survives regardless of how the name-keyed metadata is scoped.
+#    Confirmed present identically before and after slice 1's four steps,
+#    and confirmed to affect if/unless/else EQUALLY to while/loop/repeat/for
+#    -- contradicting the ADR's own prediction that step 4
+#    (`BlockLocalScope` exit cleanup) would fix if/unless/else here too.
+#    Expected values verified against raku (raku accepts every row below).
+#
+# 2. while/loop/repeat/for bodies compile through
+#    `compile_body_with_implicit_try`, which emits no scope-boundary opcode
+#    at all (§2.1's original finding, orthogonal to residual 1) -- so even
+#    the "fresh-after" shape that IS fixed for if/unless/else could regress
+#    for loop bodies once a genuine fresh-after loop-body repro is found.
+#    No such repro is known today (every fresh-after loop-body shape tried
+#    during the slice-1 session already passed, both before and after slice
+#    1), so residual 2 has no live assertion here -- only residual 1 is
+#    pinned below, covering both branches and loops via the shadow shape.
+#
+# TODO: ADR-0042 slice 2/3 -- see the todo/deep file for the fix direction
+# (retiming `exec_set_var_type`'s tagging relative to the declaration's own
+# value-store, or giving it an explicit "this is a fresh declaration, not a
+# retag" signal). Do not delete these `todo`-marked assertions when they
+# start failing -- flip them to `dies-ok`/positive assertions and move this
+# file's header to record what fixed them.
+
+# `if`/`unless`/`else`: ADR-0042 predicted these would be fixed by slice 1
+# step 4. They are not, for this specific (shadow, not fresh-after) shape.
+{
+    my $x;
+    if True { my Str $x = "a"; }
+    todo "ADR-0042 slice 1 does not fix the outer-first shadow shape (see todo/deep)";
+    lives-ok { $x = 42 }, 'if-branch shadow: outer $x usable after the branch (TODO)';
+}
+
+{
+    my $x;
+    unless False { my Str $x = "a"; }
+    todo "ADR-0042 slice 1 does not fix the outer-first shadow shape (see todo/deep)";
+    lives-ok { $x = 42 }, 'unless-branch shadow: outer $x usable after the branch (TODO)';
+}
+
+{
+    my $x;
+    if False { } else { my Str $x = "a"; }
+    todo "ADR-0042 slice 1 does not fix the outer-first shadow shape (see todo/deep)";
+    lives-ok { $x = 42 }, 'else-branch shadow: outer $x usable after the branch (TODO)';
+}
+
+# while/loop/repeat/for: the ADR predicted these stay broken. They do.
+{
+    my $x;
+    my $i = 0;
+    while $i < 1 { my Str $x = "a"; $i++; }
+    todo "ADR-0042 slice 1 does not reach while-body shadow (see todo/deep)";
+    lives-ok { $x = 42 }, 'while-body shadow: outer $x usable after the loop (TODO)';
+}
+
+{
+    my $x;
+    loop (my $i = 0; $i < 1; $i++) { my Str $x = "a"; }
+    todo "ADR-0042 slice 1 does not reach C-style-loop-body shadow (see todo/deep)";
+    lives-ok { $x = 42 }, 'C-style-loop-body shadow: outer $x usable after the loop (TODO)';
+}
+
+{
+    my $x;
+    my $i = 0;
+    repeat { my Str $x = "a"; $i++; } while $i < 1;
+    todo "ADR-0042 slice 1 does not reach repeat-body shadow (see todo/deep)";
+    lives-ok { $x = 42 }, 'repeat-body shadow: outer $x usable after the loop (TODO)';
+}
+
+{
+    my $x;
+    for 1..1 { my Str $x = "a"; }
+    todo "ADR-0042 slice 1 does not reach for-body shadow (see todo/deep)";
+    lives-ok { $x = 42 }, 'for-body shadow: outer $x usable after the loop (TODO)';
+}
+
+# The container twin of the same shadow shape (§2.2 of the ADR): also
+# unfixed, for both branches and loops.
+{
+    my @a;
+    if True { my Int @a; @a.push(5); }
+    todo "ADR-0042 slice 1 does not fix the outer-first container shadow shape (see todo/deep)";
+    lives-ok { @a.push("x") }, 'if-branch container shadow: outer @a usable after the branch (TODO)';
+}
+
+{
+    my @a;
+    my $i = 0;
+    while $i < 1 { my Int @a; @a.push(5); $i++; }
+    todo "ADR-0042 slice 1 does not reach while-body container shadow (see todo/deep)";
+    lives-ok { @a.push("x") }, 'while-body container shadow: outer @a usable after the loop (TODO)';
+}
+
+{
+    my @a;
+    for 1..1 { my Int @a; @a.push(5); }
+    todo "ADR-0042 slice 1 does not reach for-body container shadow (see todo/deep)";
+    lives-ok { @a.push("x") }, 'for-body container shadow: outer @a usable after the loop (TODO)';
+}
+
+done-testing;

--- a/t/typed-lexical-constraint-block-scoped.t
+++ b/t/typed-lexical-constraint-block-scoped.t
@@ -9,10 +9,20 @@ use Test;
 # which covers the routine-scoped half of the same fix.
 #
 # Scope: this covers only a genuine source `{ ... }` block (compiled to
-# `OpCode::BlockScope`). An `if`/`while`/`for`/C-style-loop BODY with a
-# block-local `my` compiles through two different, still-unfixed paths
-# (`OpCode::BlockLocalScope`, and plain inlining for a `while`/loop body with
-# no topic rebind) — see the todo file for the remaining gap.
+# `OpCode::BlockScope`). The `if`/`unless`/`else` branch-body half
+# (`OpCode::BlockLocalScope`) is now ALSO fixed, for the "fresh-after" shape
+# (a typed `my` inside the branch, then a FRESH untyped `my` of the same name
+# declared after the branch exits) — see ADR-0042 slice 1 (step 4) and
+# t/typed-constraint-scope-matrix.t, which pins it (plus the ADR's container
+# matrix). `while`/`for`/C-style-loop bodies (no scope-boundary opcode at
+# all) remain unfixed for that same "fresh-after" shape in principle, though
+# no live fresh-after repro is known for them either (every one tried during
+# the ADR-0042 slice-1 session already passed). A SEPARATE, deeper "outer-first
+# shadow" shape (an outer variable declared BEFORE the inner typed shadow,
+# then reused after it exits) is unfixed for EVERY branch/loop construct
+# including if/unless/else — see
+# todo/deep/scoped-type-declaration-tags-the-shadowed-outer-value.md and
+# t/typed-constraint-shadow-leak-unfixed.t.
 
 plan 7;
 

--- a/todo/deep/scoped-type-declaration-tags-the-shadowed-outer-value.md
+++ b/todo/deep/scoped-type-declaration-tags-the-shadowed-outer-value.md
@@ -1,0 +1,148 @@
+# A scoped `my TYPE $x`/`my TYPE @a` declaration that SHADOWS an existing outer binding tags the OUTER value, not just the name
+
+## Found while
+
+Implementing ADR-0042 slice 1 (`docs/adr/0042-type-constraints-belong-to-the-container-not-to-a-name.md`).
+Slice 1's four mechanical steps (container-side constraint reads, `state`
+container tagging, dropping `@`/`%` from the scoped-opcode sigil exclusion,
+and `BlockLocalScope` exit cleanup of `__mutsu_type::`/`__mutsu_hash_key_type::`
+keys) all landed and verified green against the ADR's own §2.2 container
+matrix (7/7), the §3 alias probe (7/7), and the §3.1 `state` container gap
+(2/2) — see `t/typed-constraint-scope-matrix.t` and
+`t/state-typed-container-alias.t`. This finding is a SEPARATE, deeper bug
+discovered while probing a related but distinct shape: not "declare typed
+inside a scope, then declare a FRESH untyped variable after the scope
+exits" (the ADR's §2 matrix, now fixed), but "an outer variable ALREADY
+EXISTS (untyped) before the inner scope runs, and the inner scope's typed
+declaration of the SAME name SHADOWS it, then the branch/loop exits and the
+(never re-declared) outer variable is reused."
+
+## Repro
+
+```raku
+sub via-if {
+    my $x;                      # outer, untyped, declared FIRST
+    if True { my Str $x = "a"; } # inner SHADOWS the outer $x
+    $x = 42;                    # raku: fine. mutsu: dies (Str constraint leaked)
+}
+via-if();
+```
+
+`raku` accepts this (`$x = 42` succeeds). mutsu throws:
+```
+Type check failed in assignment to $x; expected Str but got Int (42)
+```
+
+The exact same shape reproduces for containers:
+
+```raku
+sub via-if {
+    my @a;                            # outer, untyped, declared FIRST
+    if True { my Int @a; @a.push(5); } # inner SHADOWS the outer @a
+    @a.push("x");                     # raku: fine. mutsu: dies
+}
+via-if();
+```
+
+**Verified present on `main` BEFORE ADR-0042 slice 1 too** (checked via
+`git stash` back to the pre-slice-1 tree) — this is not a regression
+introduced by slice 1, and slice 1 does not change its behavior either way
+(confirmed both before and after slice 1's four steps produce the identical
+failure).
+
+**Affects `if`/`unless`/`else` branches EQUALLY, not just `while`/`loop`/
+`repeat`/`for` bodies.** This is the important correction to the ADR's own
+framing: ADR-0042 §2.1 predicted that slice 1's `BlockLocalScope` exit
+cleanup (step 4) would turn the `if`/`unless`/`else` SCALAR rows green while
+leaving `while`/`loop`/`repeat`/`for` broken (no scope wrapper to hook).
+Measured directly (`tmp/tc-scalar-matrix2b.raku` during the slice-1 session,
+not checked in): for THIS shadow shape specifically, `if`/`unless`/`else`
+leak exactly as much as `while`/`loop`/`repeat`/`for` — step 4 does not
+close it for branches either. The two ADR matrices (§2's "fresh-after"
+matrix vs. this "outer-first shadow" matrix) are genuinely different bugs
+that happen to look similar in prose.
+
+## Root cause
+
+`exec_set_var_type` (`src/vm/vm_var_type_ops.rs`) — the handler shared by
+both `SetVarType` and `SetVarTypeScoped` — tags whatever value is CURRENTLY
+bound to the declared name in `env` at the moment the type-constraint op
+runs:
+
+```rust
+} else if let Some(value) = self.get_env_with_main_alias(&name) {
+    let info = ContainerTypeInfo { value_type: ..., key_type: ..., .. };
+    let tagged = self.tag_container_metadata(value, info);
+    self.set_env_with_main_alias(&name, tagged.clone());
+    self.update_local_if_exists(code, &name, &tagged);
+}
+```
+
+For a scalar, the sibling branch just above does the same thing more subtly
+(seeds a Nil-valued binding with the type object).
+
+The compiler emits the type-constraint op (`SetVarType`/`SetVarTypeScoped`)
+BEFORE the declaration's own `SetLocalDecl`/value-store op (confirmed via
+`--dump-bytecode`: `SetVarTypeScoped` at a lower instruction index than the
+following `SetLocalDecl` for the same declaration). So when a SHADOWING
+inner declaration's type op runs, the inner declaration's OWN value has not
+been created yet — `get_env_with_main_alias(&name)` still returns the OUTER
+variable's value (env is bare-name-keyed, not scope-keyed), and this code
+directly mutates/tags THAT value in place (for a uniquely-owned container,
+`tag_container_metadata`'s `Arc::make_mut`/`Gc::make_mut` COW mutates the
+existing `ArrayData`/`HashData` rather than cloning it, since nothing forces
+a clone at refcount 1).
+
+The corruption is therefore on the **VALUE itself**, not on the name-keyed
+`__mutsu_type::`/`var_type_constraints` metadata. This is why ADR-0042
+slice 1's fixes — which are entirely about routing metadata READS through
+`element_constraint_for`/`container_type_metadata` (the container's own
+embedded metadata) instead of the scope-blind name map — cannot touch this
+bug: the container's own embedded metadata is exactly what got corrupted.
+A metadata-key snapshot/restore fix was prototyped during the slice-1
+session (extending `loop_local_saved_env`, the existing shadow-restore
+mechanism used by `pop_loop_local_scope`, to also snapshot/restore
+`__mutsu_type::name`/`__mutsu_hash_key_type::name`) and empirically verified
+to NOT fix this shape — confirming the bug is at the value layer, not the
+name layer.
+
+## Why this is large / deep
+
+Fixing it correctly means `exec_set_var_type`'s container-tagging (and the
+scalar Nil-seeding) must not run against "whatever is currently in `env`
+under this name" when the declaration is about to REPLACE that binding with
+its own fresh value — i.e., the tagging needs to happen AFTER the
+declaration's own `SetLocalDecl`/store op, against the declaration's own
+value, not before it against whatever might still be bound to the shared
+bare-name env key. That likely means either:
+
+- Reordering the compiler's emission so the type-constraint op runs AFTER
+  the value-store op for a declaration with an initializer (checking every
+  emission site — `expr_block.rs`, `helpers_ast_utils.rs`, `stmt.rs`, per
+  the callers of `emit_set_var_type` found during slice 1), which needs care
+  around the "if value is Nil, seed it now" scalar branch (a bare `my Str
+  $x;` with no initializer relies on the CURRENT ordering to seed the type
+  object before any read can observe Nil).
+- Or giving `exec_set_var_type` an explicit flag/signal for "this constraint
+  belongs to a declaration that is about to own a NEW value, don't touch
+  whatever's currently bound" — distinguishing a genuine `my TYPE $x`/`my
+  TYPE @a` from the other callers of the same opcode (`our`, type
+  re-declaration on an existing binding, etc., where tagging the CURRENT
+  value is exactly the intended behavior).
+
+Both directions touch a hot, widely-shared VM function and need the same
+`raku`-verified matrix (fresh-after AND shadow, for scalars AND containers,
+across `if`/`unless`/`else`/`while`/`loop`/`repeat`/`for`) to avoid trading
+one leak for a different regression. This is genuinely ADR-0042 slice-2/3
+adjacent territory (the ADR's own slice 2 gives scalars a cell-carried `of`,
+which may incidentally close the scalar half of this bug as a side effect of
+no longer needing `exec_set_var_type`'s Nil-seeding hack at all — worth
+re-checking once slice 2 lands) but is NOT itself one of slice 1's four
+mechanical steps, and is out of scope for that PR.
+
+## Minimal repro files (not checked in — recreate from the snippets above)
+
+- `tmp/tc-scalar-matrix2b.raku` — per-shape check (`if`/`unless`/`else`/
+  `while`/`loop`/`repeat`/`for`), all shadow-then-reuse, dies on every row.
+- `tmp/tc-container-matrix2b.raku` — the container twin (`if`/`while`/`for`),
+  same result.


### PR DESCRIPTION
## Summary

Implements **ADR-0042 slice 1** (`docs/adr/0042-type-constraints-belong-to-the-container-not-to-a-name.md`, merged in #6734): a container's element/key type constraint is now read from the constraint metadata embedded on the value itself (`ArrayData`/`HashData`'s `value_type`/`key_type`) instead of the scope-blind, bare-name-keyed `var_type_constraints` side table.

The four mechanical steps from the ADR's §5.1:

1. **Route the ten container mutation chokepoints** (push element check, Nil-default, native-int wrap, the three element-assign fast-path bailouts, `:delete`, the Mix RO check, QuantHash coercion, the `__ANON_STATE__` guard) through `element_constraint_for`/`container_type_metadata` instead of `var_type_constraint_fast`.
2. **Tag `state` containers** with their `ContainerTypeInfo` at declaration, closing the one measured gap (§3.1) where a `state Int @a` was enforced by bare name but not through a differently-named alias.
3. **Drop `@`/`%`** from `emit_set_var_type`'s scoped-opcode sigil exclusion, so a typed container declared inside a routine/block registers env-scoped like a scalar.
4. **Teach `BlockLocalScope`'s exit cleanup** to also strip the `__mutsu_type::`/`__mutsu_hash_key_type::` env-scoped metadata keys, mirroring what `BlockScope`'s exit already did.

## Two regressions found and fixed along the way

- `set_var_type_constraint_routine_scoped` only ever registered the value type, never the key type — step 3 routes a key-only object hash (`my %h{Int}`) through this path for the first time, and the missing registration silently dropped key-type enforcement for that shape. Fixed by also registering `__mutsu_hash_key_type::name`, and by routing three hash-element fast-path bailouts through `container_type_metadata` (true iff value type OR key type OR declared type is set) rather than `element_constraint_for` (which filters out an empty value type).
- Three hash-element fast paths held a temporary `Value` clone of the target hash alive across their own `strong_count > 2` "external binding" heuristic further down the same function — inflating the count by one and permanently falling off the fast path. This silently broke rvalue itemization for `%h<k> = ...` used inside a larger expression (`t/hash-key-single-itemize.t`, `t/dot-eq.t`). Fixed by scoping the clone tightly to a block.

## Verification (raku-oracled)

- ADR's container matrix: 7/7 shapes green (routine/block/if/while/for/`my Int %h`/`my %h{Int}`).
- ADR's `if`/`unless`/`else` scalar rows: green.
- ADR's alias-enforcement probe: 7/7 shapes (a differently-named alias still enforces, proving enforcement reads the container, not the name).
- `state` container alias gap (§3.1): closed, 2/2.
- Zero regressions across 62 pre-existing `t/*typed*` files and the `S02-types`/`S09-typed-arrays` roast whitelist (19 files, 4824 tests).
- `make test`: only pre-existing failure is `t/compunit-can-install.t` (permission-dependent, environment-specific, confirmed identical on `main`).

## Known residual, NOT fixed by this slice

A separate, deeper, **pre-existing** bug (confirmed present on `main` before this change and unaffected by it) where a typed declaration that SHADOWS an already-existing outer binding of the same name corrupts the outer binding's own value in place — affecting `if`/`unless`/`else` exactly as much as `while`/`loop`/`repeat`/`for`. Root cause and fix direction recorded in `todo/deep/scoped-type-declaration-tags-the-shadowed-outer-value.md`; pinned as expected-failing `# TODO` assertions in `t/typed-constraint-shadow-leak-unfixed.t` so a future slice has a clear before/after.

ADR-0042's Status and a new §10 are updated to record slice 1 as landed.

## Test plan

- [x] `cargo build && cargo clippy -- -D warnings && cargo fmt --check` all clean
- [x] New tests: `t/typed-constraint-scope-matrix.t`, `t/state-typed-container-alias.t`, `t/typed-constraint-shadow-leak-unfixed.t`
- [x] Existing typed-constraint suite (62 files) + roast `S02-types`/`S09-typed-arrays` (19 files, 4824 tests): all green
- [x] `make test`: only the pre-existing, environment-specific `compunit-can-install.t` failure
- [ ] CI (`make test` + `make roast`) — watching

🤖 Generated with [Claude Code](https://claude.com/claude-code)