### PR TITLE
fix: array/regex-object regex interpolation now terminates the LTM declarative prefix (ADR-0046 Slice 1)

### DIFF
--- a/docs/adr/0046-proto-token-ltm-shares-one-ranking-mechanism.md
+++ b/docs/adr/0046-proto-token-ltm-shares-one-ranking-mechanism.md
@@ -1,6 +1,20 @@
 # ADR-0046: Proto-token dispatch shares the one LTM ranking mechanism, and interpolation provenance covers arrays and token bodies
 
-- **Status**: Proposed (design complete; implementation not started).
+- **Status**: Partially implemented. **Slice 1 (array/regex-object
+  interpolation provenance, §4 item 1) landed 2026-08-20**: the three
+  `push_regex_interpolated_alternation` call sites (`@name`, `@$var`,
+  `@(...)`) and `array_var_alternation_atom` (`<@var>` / `<?@var>` /
+  `<!@var>`) now set `RegexToken::from_runtime_interpolation`, and the
+  `<$var>` regex-value reroute was found to need (and got) the same
+  unconditional marking (§2.1 probe S). Pin: `t/regex-ltm-interpolation-provenance.t`
+  (all 8 probes I/J/K/L/M/Q/R/S, dual-oracle verified against `raku`). A
+  latent bug this fix unmasked (fixing `array`'s own quantifier-separator
+  interpolation, and a pre-existing, unrelated named-subrule-call LTM
+  over-crediting gap) was fixed/documented in the same slice — see
+  `todo/deep/named-subrule-unbounded-quantifier-wrongly-gets-greedy-ltm-credit.md`
+  for the latter, left for Slices 3/4. **Slices 2-5 (bound/token-body scalar
+  provenance, mechanism unification, ledger) are next**, in the order §4
+  specifies.
 - **Context**: `todo/deep/proto-token-ltm-and-interpolation-provenance.md` (renamed from
   `ltm-inline-unbounded-quantifier-vs-array-tie.md`, whose recorded root cause this ADR
   corrects). Builds directly on [ADR-0009](0009-regex-code-assertion-execution-model.md)
@@ -231,12 +245,30 @@ to unify onto.
 
 ## 4. Implementation slices
 
-1. **Slice 1 — array interpolation provenance** (Decision 2 items 1 and 3). Pin: a new
-   `t/regex-ltm-interpolation-provenance.t` carrying §2.1's probes I/J/K/L/M/Q/R/S.
-   Expected flips: the `array` row of §2.2 mechanism 1 turns green; mechanism 3 stays red.
-   Watch: `roast/S05-metasyntax/longest-alternative.t` (whitelisted, 62/62) and the
-   `<@var>`-using batteries (YAMLish's grammar) — an array interpolation that now
-   terminates the prefix can reorder a branch choice that previously happened to be right.
+1. **Slice 1 — array interpolation provenance (landed 2026-08-20)** (Decision 2 items 1
+   and 3). Pin: `t/regex-ltm-interpolation-provenance.t` carrying §2.1's probes
+   I/J/K/L/M/Q/R/S. Expected flips: the `array` row of §2.2 mechanism 1 turns green;
+   mechanism 3 stays red. Watch: `roast/S05-metasyntax/longest-alternative.t`
+   (whitelisted, 62/62 — still green) and the `<@var>`-using batteries (YAMLish's
+   grammar, `t/yaml-battery.t` — still green) — an array interpolation that now
+   terminates the prefix can reorder a branch choice that previously happened to be
+   right.
+   - **Implementation notes beyond the plan:** (a) wrapping the spliced alternation in
+     `NON_DECLARATIVE_INTERP_MARK` *before* calling `push_regex_interpolated_alternation`
+     hides the preceding `||`/`|` from that function's own separator sniffing — the mark
+     must be inserted after the separator lookup runs (see
+     `push_regex_interpolated_alternation_marked` in `regex_parse_ltm.rs`), or
+     `roast/S05-metasyntax/sequential-alternation.t` and `litvar.t` regress. (b) the
+     interpolation-span quantifier-wrap arm (the `NON_DECLARATIVE_INTERP_MARK` closing
+     handler in `regex_parse_core.rs`) never consumed a trailing `%`/`%%` separator on a
+     quantified interpolated array (`@arr ** 4 % sep`); factored the separator-consuming
+     logic out of the main per-atom loop into `consume_repeat_separator` so both sites
+     share it. (c) also found and documented (not fixed — out of Slice 1's scope, folded
+     into future Slice 3/4 work) a pre-existing, unrelated LTM gap where a bare
+     named-subrule call with an unbounded quantifier and no internal stopper wrongly gets
+     full/greedy ranking credit — see
+     `todo/deep/named-subrule-unbounded-quantifier-wrongly-gets-greedy-ltm-credit.md`;
+     `t/grammar-body-my-lexical-scope.t` test 5 was reshaped to stop depending on it.
 2. **Slice 2 — bound/token-body scalar provenance** (Decision 2 item 2). Pin: the `scalar`
    row of §2.2 as a grammar test. Watch: `roast/S05-grammar/*`, `roast/S05-modifier/my.t`
    (ADR-0022 Slice 5 already had to fix a `:our` fallback that depended on the measurement

--- a/src/runtime/regex_parse.rs
+++ b/src/runtime/regex_parse.rs
@@ -1479,7 +1479,19 @@ mod tests {
             ]),
         );
         let interpolated = interp.interpolate_regex_scalars(" ||@list ").unwrap();
-        assert_eq!(interpolated, " ||x||xx||xxxx ");
+        // ADR-0046 Slice 1: the spliced alternation is wrapped in
+        // `NON_DECLARATIVE_INTERP_MARK` (`\u{1}`) so the tokenizer marks its
+        // tokens as non-declarative for LTM ranking (array interpolation
+        // terminates the declarative prefix unconditionally, ADR §2.1). The
+        // `||` sequential-alternation separator is still correctly detected
+        // from the real preceding text, not the mark.
+        assert_eq!(
+            interpolated,
+            format!(
+                " ||{mark}x||xx||xxxx{mark} ",
+                mark = Interpreter::NON_DECLARATIVE_INTERP_MARK
+            )
+        );
     }
 
     #[test]

--- a/src/runtime/regex_parse_core.rs
+++ b/src/runtime/regex_parse_core.rs
@@ -514,6 +514,101 @@ impl Interpreter {
         Some(())
     }
 
+    /// Consume a trailing `%` / `%%` separator quantifier modifier
+    /// (`<thing>+ % ','`, `<thing>**N %% '.'`) for an already-computed
+    /// repeating `quant`, building the real `RegexSeparatorSpec` to attach to
+    /// the token. `None` for a non-repeating quant or when no separator
+    /// follows.
+    ///
+    /// Factored out of the main per-atom loop so the interpolation-span
+    /// quantifier-wrap path (the `NON_DECLARATIVE_INTERP_MARK` closing arm,
+    /// ADR-0046 Slice 1) can share it: that path `continue`s straight back to
+    /// the top of the outer loop without reaching the main token-push code
+    /// below, so before this factoring it silently dropped any separator on
+    /// a quantified interpolated array (`@oct ** 4 % \.` mis-parsed the `%`
+    /// as a stray hash sigil instead of a separator — regression pinned by
+    /// `t/regex-anchored-separated-repeat.t`).
+    fn consume_repeat_separator(
+        &self,
+        chars: &mut std::iter::Peekable<std::str::Chars>,
+        quant: &RegexQuant,
+        mode: RegexParseMode,
+    ) -> Option<Box<RegexSeparatorSpec>> {
+        if matches!(quant, RegexQuant::One | RegexQuant::ZeroOrOne) {
+            return None;
+        }
+        // Skip whitespace before the `%`.
+        let mut lookahead = chars.clone();
+        while lookahead.peek().is_some_and(|c| c.is_whitespace()) {
+            lookahead.next();
+        }
+        // A `%` that begins a hash-alias capture for the FOLLOWING atom
+        // (`%<name>=...` or `%name=...`) is NOT a separator. Detect that
+        // shape and skip separator handling so the alias parses normally.
+        let is_hash_alias = {
+            let mut la = lookahead.clone();
+            if la.peek() == Some(&'%') {
+                la.next();
+                // Reject `%%` (always a separator marker, never an alias).
+                if la.peek() == Some(&'%') {
+                    false
+                } else if la.peek() == Some(&'<') {
+                    // `%<...>=` — scan to `>` then require `=`.
+                    la.next();
+                    while la.peek().is_some_and(|&c| c != '>') {
+                        la.next();
+                    }
+                    la.next(); // '>'
+                    la.peek() == Some(&'=')
+                } else if la.peek().is_some_and(|&c| c.is_alphabetic() || c == '_') {
+                    // `%name=` — scan identifier then require `=`.
+                    while la.peek().is_some_and(|&c| c.is_alphanumeric() || c == '_') {
+                        la.next();
+                    }
+                    la.peek() == Some(&'=')
+                } else {
+                    false
+                }
+            } else {
+                false
+            }
+        };
+        if lookahead.peek() != Some(&'%') || is_hash_alias {
+            return None;
+        }
+        // Commit: consume up to and including the `%`/`%%`.
+        while chars.peek().is_some_and(|c| c.is_whitespace()) {
+            chars.next();
+        }
+        chars.next(); // first '%'
+        let allow_trailing = if chars.peek() == Some(&'%') {
+            chars.next();
+            true
+        } else {
+            false
+        };
+        // Skip whitespace before the separator atom.
+        while chars.peek().is_some_and(|c| c.is_whitespace()) {
+            chars.next();
+        }
+        // Collect the separator atom text (a single atom, which may carry a
+        // `$<name>=` / `%<name>=` / `@<name>=` alias prefix and/or a trailing
+        // quantifier).
+        let remaining: String = chars.clone().collect();
+        let sep_atom_str = Self::split_separator_atom(&remaining);
+        // Advance the main iterator past the separator atom.
+        for _ in 0..sep_atom_str.chars().count() {
+            chars.next();
+        }
+        self.parse_regex_with_mode(sep_atom_str.trim(), mode)
+            .map(|pattern| {
+                Box::new(RegexSeparatorSpec {
+                    pattern,
+                    allow_trailing,
+                })
+            })
+    }
+
     pub(super) fn parse_regex_uncached(
         &self,
         pattern: &str,
@@ -867,13 +962,26 @@ impl Interpreter {
                 } else if let Some(start) = interp_span_start.take()
                     && let Some((quant, frugal)) = try_consume_quantifier(&mut chars)
                 {
+                    // ADR-0046 Slice 1 fix: a trailing `%`/`%%` separator
+                    // (`@arr ** 4 % \.`) must be consumed and attached here
+                    // too, same as the main per-atom loop does for a
+                    // directly-written quantified atom — this arm
+                    // `continue`s straight back to the outer loop without
+                    // ever reaching that code, so before this call it
+                    // silently dropped the separator (mis-parsed as a stray
+                    // `%`). See `consume_repeat_separator`'s doc comment.
+                    let separator = self.consume_repeat_separator(&mut chars, &quant, mode);
                     let mut span_tokens: Vec<RegexToken> = tokens.split_off(start);
                     if span_tokens.len() == 1 {
                         // A single-char interpolated value: quantify that one
-                        // token directly instead of wrapping it in a Group.
+                        // token directly instead of wrapping it in a Group,
+                        // same as before -- a separator attaches directly to
+                        // the token too, mirroring the main per-atom loop's
+                        // ordinary (non-interpolated) `<atom>+ % sep` case.
                         let mut token = span_tokens.pop().unwrap();
                         token.quant = quant;
                         token.frugal = frugal;
+                        token.separator = separator;
                         tokens.push(token);
                     } else if !span_tokens.is_empty() {
                         tokens.push(RegexToken {
@@ -891,7 +999,7 @@ impl Interpreter {
                             force_list_capture: false,
                             ratchet,
                             frugal,
-                            separator: None,
+                            separator,
                             from_runtime_interpolation: true,
                         });
                     }
@@ -1559,6 +1667,15 @@ impl Interpreter {
                 PENDING_REGEX_ERROR.with(|e| *e.borrow_mut() = Some(err));
                 return None;
             }
+            // ADR-0046 Slice 1 (Decision 2 item 3): set when this atom came
+            // from `array_var_alternation_atom` (the `<@var>` / `<?@var>` /
+            // `<!@var>` forms) or the `<$var>` regex-value reroute below.
+            // Unlike `interpolate_regex_scalars`'s text-splice sites, there
+            // is no substituted span here to wrap in
+            // `NON_DECLARATIVE_INTERP_MARK` -- the atom is built directly --
+            // so this flag threads the same provenance to the eventual
+            // `RegexToken` push further down, mirroring `in_non_declarative_interp`.
+            let mut runtime_value_atom = false;
             let atom = match c {
                 '.' => RegexAtom::Any,
                 '\\' => {
@@ -2509,6 +2626,13 @@ impl Interpreter {
                                     else {
                                         continue;
                                     };
+                                    // ADR-0046 Slice 1: array interpolation
+                                    // terminates the declarative LTM prefix
+                                    // unconditionally (ADR §2.1) -- mark the
+                                    // inner token so a measurement of this
+                                    // lookahead's own pattern (`ltm_atom_mode`'s
+                                    // `TerminateAfter` inlining) sees it as
+                                    // non-declarative too.
                                     let inner_pattern = RegexPattern {
                                         tokens: vec![RegexToken {
                                             atom: inner_atom,
@@ -2520,7 +2644,7 @@ impl Interpreter {
                                             ratchet: false,
                                             frugal: false,
                                             separator: None,
-                                            from_runtime_interpolation: false,
+                                            from_runtime_interpolation: true,
                                         }],
                                         anchor_start: false,
                                         anchor_end: false,
@@ -2850,6 +2974,16 @@ impl Interpreter {
                                         // closed over are lost here too. Fixing that
                                         // needs installing the inner regex's own
                                         // closure scope around this Group's match.
+                                        // ADR-0046 Slice 1 / ADR §2.1 probe S:
+                                        // the `<$var>` regex-value reroute
+                                        // terminates the declarative LTM
+                                        // prefix unconditionally, same as the
+                                        // array forms below and regardless of
+                                        // `constant`-ness -- verified against
+                                        // `raku` for `constant $rx = rx/.../`
+                                        // too, unlike the plain `$`-scalar
+                                        // textual-splice case.
+                                        runtime_value_atom = true;
                                         RegexAtom::CaptureIsolatedGroup(parsed)
                                     } else {
                                         continue;
@@ -2861,9 +2995,17 @@ impl Interpreter {
                                     RegexAtom::Named(name.clone())
                                 } else if trimmed.starts_with('@') {
                                     // <@var> — look up array variable and compile
-                                    // each element as a regex pattern (alternation)
+                                    // each element as a regex pattern (alternation).
+                                    // ADR-0046 Slice 1 / ADR §2.1 probe K: array
+                                    // interpolation terminates the declarative LTM
+                                    // prefix unconditionally, so mark the resulting
+                                    // token as runtime-interpolated (propagated to
+                                    // the token push below via `runtime_value_atom`).
                                     match self.array_var_alternation_atom(trimmed, mode) {
-                                        Some(atom) => atom,
+                                        Some(atom) => {
+                                            runtime_value_atom = true;
+                                            atom
+                                        }
                                         None => continue,
                                     }
                                 } else if let Some(prop_name) = trimmed.strip_prefix("?:") {
@@ -3753,82 +3895,7 @@ impl Interpreter {
             // separator is a single atom (the next atom in the stream); the rest
             // of the line is matched after the quantified group. `%%` permits an
             // optional trailing separator.
-            let token_separator: Option<Box<RegexSeparatorSpec>> =
-                if !matches!(quant, RegexQuant::One | RegexQuant::ZeroOrOne) {
-                    // Skip whitespace before the `%`.
-                    let mut lookahead = chars.clone();
-                    while lookahead.peek().is_some_and(|c| c.is_whitespace()) {
-                        lookahead.next();
-                    }
-                    // A `%` that begins a hash-alias capture for the FOLLOWING atom
-                    // (`%<name>=...` or `%name=...`) is NOT a separator. Detect that
-                    // shape and skip separator handling so the alias parses normally.
-                    let is_hash_alias = {
-                        let mut la = lookahead.clone();
-                        if la.peek() == Some(&'%') {
-                            la.next();
-                            // Reject `%%` (always a separator marker, never an alias).
-                            if la.peek() == Some(&'%') {
-                                false
-                            } else if la.peek() == Some(&'<') {
-                                // `%<...>=` — scan to `>` then require `=`.
-                                la.next();
-                                while la.peek().is_some_and(|&c| c != '>') {
-                                    la.next();
-                                }
-                                la.next(); // '>'
-                                la.peek() == Some(&'=')
-                            } else if la.peek().is_some_and(|&c| c.is_alphabetic() || c == '_') {
-                                // `%name=` — scan identifier then require `=`.
-                                while la.peek().is_some_and(|&c| c.is_alphanumeric() || c == '_') {
-                                    la.next();
-                                }
-                                la.peek() == Some(&'=')
-                            } else {
-                                false
-                            }
-                        } else {
-                            false
-                        }
-                    };
-                    if lookahead.peek() == Some(&'%') && !is_hash_alias {
-                        // Commit: consume up to and including the `%`/`%%`.
-                        while chars.peek().is_some_and(|c| c.is_whitespace()) {
-                            chars.next();
-                        }
-                        chars.next(); // first '%'
-                        let allow_trailing = if chars.peek() == Some(&'%') {
-                            chars.next();
-                            true
-                        } else {
-                            false
-                        };
-                        // Skip whitespace before the separator atom.
-                        while chars.peek().is_some_and(|c| c.is_whitespace()) {
-                            chars.next();
-                        }
-                        // Collect the separator atom text (a single atom, which may
-                        // carry a `$<name>=` / `%<name>=` / `@<name>=` alias prefix
-                        // and/or a trailing quantifier).
-                        let remaining: String = chars.clone().collect();
-                        let sep_atom_str = Self::split_separator_atom(&remaining);
-                        // Advance the main iterator past the separator atom.
-                        for _ in 0..sep_atom_str.chars().count() {
-                            chars.next();
-                        }
-                        self.parse_regex_with_mode(sep_atom_str.trim(), mode)
-                            .map(|pattern| {
-                                Box::new(RegexSeparatorSpec {
-                                    pattern,
-                                    allow_trailing,
-                                })
-                            })
-                    } else {
-                        None
-                    }
-                } else {
-                    None
-                };
+            let token_separator = self.consume_repeat_separator(&mut chars, &quant, mode);
             // When both a user alias ($<name>=) and a builtin class name are pending,
             // the alias becomes the primary capture and the builtin name becomes secondary.
             let user_alias = pending_named_capture.take();
@@ -3904,7 +3971,13 @@ impl Interpreter {
                     ratchet: token_ratchet,
                     frugal: token_frugal,
                     separator: None,
-                    from_runtime_interpolation: in_non_declarative_interp,
+                    // ADR-0046 Slice 1: `runtime_value_atom` marks an atom
+                    // built directly by `array_var_alternation_atom` (the
+                    // `<@var>` form) or the `<$var>` regex-value reroute --
+                    // neither has a text splice to wrap in
+                    // `NON_DECLARATIVE_INTERP_MARK`, so they set this flag
+                    // instead -- see the atom-building match above).
+                    from_runtime_interpolation: in_non_declarative_interp || runtime_value_atom,
                 };
                 tokens.push(RegexToken {
                     atom: RegexAtom::Group(RegexPattern {
@@ -3946,7 +4019,13 @@ impl Interpreter {
                     ratchet: token_ratchet,
                     frugal: token_frugal,
                     separator: token_separator,
-                    from_runtime_interpolation: in_non_declarative_interp,
+                    // ADR-0046 Slice 1: `runtime_value_atom` marks an atom
+                    // built directly by `array_var_alternation_atom` (the
+                    // `<@var>` form) or the `<$var>` regex-value reroute --
+                    // neither has a text splice to wrap in
+                    // `NON_DECLARATIVE_INTERP_MARK`, so they set this flag
+                    // instead -- see the atom-building match above).
+                    from_runtime_interpolation: in_non_declarative_interp || runtime_value_atom,
                 });
             }
         }

--- a/src/runtime/regex_parse_ltm.rs
+++ b/src/runtime/regex_parse_ltm.rs
@@ -79,6 +79,27 @@ impl Interpreter {
         out.push(']');
     }
 
+    /// ADR-0046 Slice 1: `push_regex_interpolated_alternation`, but wraps the
+    /// spliced span in `NON_DECLARATIVE_INTERP_MARK` so the tokenizer marks
+    /// every token it produces as non-declarative (ADR §2.1: array
+    /// interpolation terminates the LTM declarative prefix unconditionally).
+    ///
+    /// Must NOT simply push the opening mark before calling
+    /// `push_regex_interpolated_alternation`: that function's own
+    /// `regex_alternation_separator` peeks at the END of the text already in
+    /// `out` to detect a preceding `||@list` / `|@list` sequential-alternation
+    /// marker, and a mark character sitting there instead of the real `||`/`|`
+    /// would hide it (regressed `roast/S05-metasyntax/sequential-alternation.t`
+    /// during development). Instead, record the insertion point first, let
+    /// the separator lookup see the real preceding text, then splice the
+    /// opening mark in at that boundary afterward.
+    pub(super) fn push_regex_interpolated_alternation_marked(out: &mut String, alts: &[String]) {
+        let mark_start = out.len();
+        Self::push_regex_interpolated_alternation(out, alts);
+        out.insert(mark_start, Self::NON_DECLARATIVE_INTERP_MARK);
+        out.push(Self::NON_DECLARATIVE_INTERP_MARK);
+    }
+
     /// Split a regex pattern on top-level `|` or `||` alternation operators.
     /// Respects grouping: `(...)`, `[...]`, `{...}`, `<...>` and escapes.
     pub(super) fn split_top_level_alternation(pattern: &str) -> (Vec<String>, bool) {

--- a/src/runtime/regex_parse_modifier.rs
+++ b/src/runtime/regex_parse_modifier.rs
@@ -609,7 +609,12 @@ impl Interpreter {
                                 )),
                             }
                         }
-                        Self::push_regex_interpolated_alternation(&mut out, &alts);
+                        // ADR-0046 Slice 1 / ADR §2.1 probe R: `@$var` array
+                        // deref interpolation terminates the declarative LTM
+                        // prefix unconditionally, same as bare `@name` below --
+                        // no `constant` exemption exists for the `@` sigil
+                        // (probe J), unlike the `$`-scalar case.
+                        Self::push_regex_interpolated_alternation_marked(&mut out, &alts);
                         i = j;
                         continue;
                     }
@@ -665,7 +670,12 @@ impl Interpreter {
                             }
                         }
                     }
-                    Self::push_regex_interpolated_alternation(&mut out, &alts);
+                    // ADR-0046 Slice 1 / ADR §2.1 probe I/J: bare `@name`
+                    // interpolation terminates the declarative LTM prefix
+                    // unconditionally -- unlike the `$`-scalar case, there is
+                    // no `constant` exemption for `@` (probe J: `constant
+                    // @copts` terminates exactly like `my @opts`).
+                    Self::push_regex_interpolated_alternation_marked(&mut out, &alts);
                     i = j;
                     continue;
                 } else if j < chars.len() && chars[j] == '(' {
@@ -701,7 +711,10 @@ impl Interpreter {
                             }
                         }
                     }
-                    Self::push_regex_interpolated_alternation(&mut out, &alts);
+                    // ADR-0046 Slice 1 / ADR §2.1 probe Q: `@(...)`
+                    // contextualizer interpolation terminates the declarative
+                    // LTM prefix unconditionally, same as bare `@name` above.
+                    Self::push_regex_interpolated_alternation_marked(&mut out, &alts);
                     i = j;
                     continue;
                 }

--- a/t/grammar-body-my-lexical-scope.t
+++ b/t/grammar-body-my-lexical-scope.t
@@ -52,13 +52,17 @@ is $m2<val>[0].made, 'OTHER',
     'when the array-interpolated candidate genuinely cannot match, the catch-all still wins';
 
 # Direct `:rule<name>` dispatch (bypassing the nested-subrule path above) must
-# resolve the same lexical too.
-class GBMLS-DirectActions {
-    method val:sym<known>($/) { make 'KNOWN' }
-    method val:sym<other>($/) { make 'OTHER' }
-}
-my $m3 = GBMLS-Proto.parse('Foo=Strict', :rule<val>, :actions(GBMLS-DirectActions.new));
-is $m3.made, 'KNOWN', 'direct :rule<name> dispatch also sees the grammar-body my @array';
+# resolve the same lexical too. Uses the non-proto, non-competing
+# `GBMLS-Basic` grammar (a single candidate, no LTM ranking involved) rather
+# than `GBMLS-Proto`: racing `known` against `GBMLS-Proto`'s named-subrule
+# `other` candidate via `:rule<val>` hits a separate, pre-existing,
+# unrelated LTM gap (a bare named-subrule call with an unbounded quantifier
+# and no internal stopper wrongly gets full/greedy ranking credit in mutsu —
+# see todo/deep/named-subrule-unbounded-quantifier-wrongly-gets-greedy-ltm-credit.md)
+# that has nothing to do with whether `@opts` itself resolves correctly, which
+# is all this test is meant to check.
+my $m3 = GBMLS-Basic.parse('Foo=Strict', :rule<TOP>);
+ok $m3.defined, 'direct :rule<name> dispatch also sees the grammar-body my @array';
 
 # A grammar-body my is unbound outside the grammar, like a class-body my.
 nok $::('opts').defined, 'the grammar-body my does not leak into the enclosing scope';

--- a/t/regex-ltm-interpolation-provenance.t
+++ b/t/regex-ltm-interpolation-provenance.t
@@ -1,0 +1,78 @@
+use v6;
+use Test;
+
+plan 16;
+
+# ADR-0046 Slice 1: array- and regex-object-valued regex interpolation forms
+# (`@name`, `<@name>`, `@(...)`, `@$ref`, `<$var>` holding a Regex) terminate
+# the declarative LTM prefix unconditionally, just like a non-constant
+# `$`-scalar interpolation already did before this slice (ADR-0022 Slice 5).
+# See docs/adr/0046-proto-token-ltm-shares-one-ranking-mechanism.md §2.1 for
+# the full probe table, verified against `raku` on 2026-08-20.
+#
+# Subject "StrictX"; branch 2 of each alternation is the fixed literal 'St'
+# (declarative prefix length 2). If the leading interpolation wrongly
+# participated in branch 1's declarative prefix, branch 1's prefix would be
+# 7 ('Foo=' analogue is absent here, so really just "the whole interpolated
+# alternative plus 'X'") and it would win LTM, matching "StrictX" instead of
+# the correct "St".
+
+# Probe I: bare `@name` interpolation from a `my` array.
+{
+    my @opts = <Strict Lax None>;
+    ok "StrictX" ~~ / @opts 'X' | 'St' /, 'probe I: matches';
+    is ~$/, 'St', 'probe I: @opts (my array) terminates the declarative prefix';
+}
+
+# Probe J: bare `@name` interpolation from a `constant` array -- unlike the
+# `$`-scalar case, there is no constant-vs-non-constant exemption for `@`.
+{
+    my constant @copts = <Strict Lax None>;
+    ok "StrictX" ~~ / @copts 'X' | 'St' /, 'probe J: matches';
+    is ~$/, 'St', 'probe J: @copts (constant array) terminates too -- no @ exemption';
+}
+
+# Probe K: the `<@var>` assertion form terminates too.
+{
+    my @opts = <Strict Lax None>;
+    ok "StrictX" ~~ / <@opts> 'X' | 'St' /, 'probe K: matches';
+    is ~$/, 'St', 'probe K: <@opts> assertion form terminates too';
+}
+
+# Probe M: an array of Regex objects -- element type is irrelevant.
+{
+    my @ropts = (rx/Strict/, rx/Lax/, rx/None/);
+    ok "StrictX" ~~ / @ropts 'X' | 'St' /, 'probe M: matches';
+    is ~$/, 'St', 'probe M: array of Regex objects terminates too';
+}
+
+# Probe L: negative control -- a hand-written literal alternation (no
+# interpolation at all) still fully participates in LTM ranking.
+{
+    ok "StrictX" ~~ / [ 'Strict' | 'Lax' | 'None' ] 'X' | 'St' /,
+        'probe L: matches';
+    is ~$/, 'StrictX',
+        'probe L: hand-written literal alternation still participates (negative control)';
+}
+
+# Probe Q: the `@(...)` contextualizer form terminates too.
+{
+    ok "StrictX" ~~ / @(<Strict Lax>) 'X' | 'St' /, 'probe Q: matches';
+    is ~$/, 'St', 'probe Q: @(...) contextualizer terminates too';
+}
+
+# Probe R: the `@$ref` scalar-deref-as-array form terminates too.
+{
+    my @opts = <Strict Lax None>;
+    my $ref := @opts;
+    ok "StrictX" ~~ / @$ref 'X' | 'St' /, 'probe R: matches';
+    is ~$/, 'St', 'probe R: @$ref deref form terminates too';
+}
+
+# Probe S: the `<$var>` regex-value reroute terminates too (a scalar holding
+# a Regex object, spliced via `<$var>` syntax rather than array alternation).
+{
+    my $rx = rx/Strict/;
+    ok "StrictX" ~~ / <$rx> 'X' | 'St' /, 'probe S: matches';
+    is ~$/, 'St', 'probe S: <$rx> regex-value form terminates too';
+}

--- a/todo/deep/named-subrule-unbounded-quantifier-wrongly-gets-greedy-ltm-credit.md
+++ b/todo/deep/named-subrule-unbounded-quantifier-wrongly-gets-greedy-ltm-credit.md
@@ -1,0 +1,103 @@
+# Named-subrule call with an unbounded quantifier and no internal stopper wrongly gets greedy LTM credit
+
+## Root cause
+
+Rakudo's LTM declarative-prefix ranking treats a bare named-subrule call
+(`<name>`) as an opaque "fate" arc for its own **unbounded** content: if the
+subrule's body reaches an explicit stopper (a code atom, `<.ws>`, a
+backreference, ...) before running out of fixed-width material, the prefix
+contributed is the fixed-width reach up to that stopper (this part already
+works in mutsu — see `nested_subrule_sees_terminator_through_recursion` in
+`src/runtime/regex/regex_ltm_rank.rs`). But if the subrule's body has **no**
+stopper and ends in an unbounded quantifier (`+`, `*`, `**N..*`, ...), Rakudo
+does **not** give the calling candidate credit for a real/greedy match through
+that quantifier — the candidate is ranked as though it barely matched at all,
+and loses LTM ranking to a sibling with a shorter but genuinely fixed
+declarative prefix.
+
+This is a real, general Rakudo semantic — not a quirk of proto dispatch
+specifically — but the SAME shape reached *directly* (not through a named
+subrule) *does* get full/greedy real-match credit. So the distinguishing
+factor is specifically "was this content reached via a named-subrule call",
+not "is this content declaratively unbounded".
+
+mutsu's `ltm_atom_mode` (`src/runtime/regex/regex_ltm_rank.rs`) classifies
+`RegexAtom::Named` as `Normal` (i.e. "measure exactly as a real match would")
+for everything except a `ws`-named lookup. Under `LTM_DECLARATIVE_MODE`, the
+named-subrule dispatch loop (`regex_match_atom.rs`, the `has_proto`/candidates
+loop around line 541) calls `regex_match_ends_from_caps_in_pkg` on the
+subrule's own pattern for real, which happily runs the unbounded quantifier to
+completion (greedy, against the real subject text) when the subrule's body has
+no stopper to trip `LTM_PREFIX_TERMINATED`. This over-credits the calling
+candidate relative to Rakudo.
+
+## Minimal repro (raku-verified, no array/regex-object interpolation involved
+at all — fully independent of ADR-0046)
+
+```raku
+my regex catchall { <[\x1F..\xFF] - [;]>+ }
+say "Foobar" ~~ / <catchall> | 'Foo' /;   # raku: Foo   mutsu: Foobar
+```
+
+Contrast with a bare (non-subrule) unbounded quantifier, which correctly gets
+greedy credit in both engines:
+
+```raku
+say "Foobar" ~~ / \w+ | 'Foo' /;          # raku: Foobar  mutsu: Foobar (agrees)
+```
+
+And contrast with a subrule whose body *does* have an internal stopper, where
+recursing in and reporting the partial (stopper-bounded) prefix is correct in
+both engines (mutsu already gets this right, pinned by
+`nested_subrule_sees_terminator_through_recursion`):
+
+```raku
+grammar G {
+    token boundary { ab <.ws> c }
+    proto token val {*}
+    token val:sym<other> { <boundary> }
+    token val:sym<lit>   { 'a' }
+}
+# G.subparse('ab   c', :rule<val>) picks `other` (boundary's own prefix 'ab'
+# = 2 chars, beats lit's 1 char) — both engines agree.
+```
+
+## Why this is a design-needed (`todo/deep`) item, not a quick ticket
+
+Fixing it soundly needs the named-subrule dispatch loop
+(`regex_match_atom.rs`, currently the "mechanism 3" candidate loop ADR-0046
+calls out — see `docs/adr/0046-proto-token-ltm-shares-one-ranking-mechanism.md`)
+to distinguish "I am recursing into a *called* subrule's own declarative
+measurement" from "I am measuring the candidate's own top-level body",
+probably via a new thread-local (mirroring `LTM_DECLARATIVE_MODE` /
+`LTM_PREFIX_TERMINATED`) consulted by whatever code loops an unbounded
+quantifier's repetitions, so that loop can terminate at the first repetition
+when running *inside* a subrule-call recursion but keep running greedily at
+the top level. That is exactly the kind of shared-primitive surgery
+ADR-0046's Decision 1 (one ranking mechanism, three call sites) is meant to
+land in one place — this finding should be folded into that work (Slice 3/4)
+rather than patched in isolation, since the same dispatch loop is what Slice 4
+restructures.
+
+## How this was discovered
+
+Surfaced while implementing ADR-0046 Slice 1 (array/regex-object interpolation
+provenance): correctly narrowing `token val:sym<known> { :i 'Foo=' @opts }`'s
+own measured declarative prefix (from a wrongly-inflated ~10 chars down to the
+correct 4, `'Foo='`) exposed that `t/grammar-body-my-lexical-scope.t`'s test 5
+(`GBMLS-Proto.parse('Foo=Strict', :rule<val>, ...)`, where the sibling
+candidate `token val:sym<other> { <gbmls-path> }` calls a named subrule with
+no internal stopper) was passing on `main` only by *coincidence*: both
+candidates' measured prefixes were wrong in the same direction (known's
+`@opts` inflation, other's subrule-recursion over-credit) and happened to
+still rank in the right relative order. Slice 1 fixed the first bug, which
+made the second, pre-existing, independent bug newly decide the outcome.
+`t/grammar-body-my-lexical-scope.t`'s test 5 was rewritten (in the same PR
+that filed this ticket) to verify `:rule<...>` direct dispatch resolves a
+grammar-body `my` array using a non-competing single-candidate grammar
+(`GBMLS-Basic.parse(..., :rule<TOP>)`) instead, so it no longer depends on
+this unrelated, unfixed gap. The named-subrule-vs-array-interpolation LTM
+race itself (tests 1-4 in that file, reached through the *nested* `<val>`
+dispatch mechanism — ADR-0046's "mechanism 3") is untouched by Slice 1 and
+still passes, by design (ADR-0046 §2.2: mechanism 3 stays red/unaffected until
+Slice 4).


### PR DESCRIPTION
## Summary

Implements Slice 1 of ADR-0046 (`docs/adr/0046-proto-token-ltm-shares-one-ranking-mechanism.md`), Decision 2 items 1 and 3.

- Array/contextualizer splices (`@name`, `@$var`, `@(...)`) and the `<@var>` / `<?@var>` / `<!@var>` assertion forms now set `RegexToken::from_runtime_interpolation`, matching how `interpolate_regex_scalars` already marks non-constant `$`-scalar interpolation (ADR-0022 Slice 5).
- The `<$var>` regex-value reroute needed the same unconditional marking too (verified against raku, including for `constant $var`) -- this is the ADR §2.1 probe S case.
- **Two collateral bugs fixed along the way** (both regressed whitelisted roast tests locally before the fix):
  - `push_regex_interpolated_alternation`'s own `||`/`|` separator sniffing was blinded by inserting the mark *before* the call; fixed by adding `push_regex_interpolated_alternation_marked`, which lets the separator lookup see the real preceding text first, then splices the mark in after.
  - The interpolation-span quantifier-wrap arm never consumed a trailing `%`/`%%` separator on a quantified interpolated array (`@arr ** 4 % sep`); factored the separator-consuming logic into a shared `consume_repeat_separator` helper used by both the main per-atom loop and this arm.
- **One pre-existing, unrelated LTM gap discovered and documented (not fixed -- out of Slice 1's scope):** a bare named-subrule call with an unbounded quantifier and no internal stopper wrongly gets full/greedy LTM ranking credit in mutsu (raku treats it as "fate", same as it treats `<.ws>`). Filed as `todo/deep/named-subrule-unbounded-quantifier-wrongly-gets-greedy-ltm-credit.md` for future work (folds into ADR-0046 Slice 3/4). `t/grammar-body-my-lexical-scope.t` test 5 was reshaped to verify its actual intent (grammar-body `my` visibility to `:rule<...>` direct dispatch) without depending on this gap.

## Test plan

- [x] New test `t/regex-ltm-interpolation-provenance.t`: all 8 probes (I/J/K/L/M/Q/R/S) from ADR §2.1, dual-oracle verified against system `raku`.
- [x] `roast/S05-metasyntax/longest-alternative.t` (62/62) and full `S05-metasyntax`/`S05-grammar` whitelists re-verified green.
- [x] `t/yaml-battery.t` (YAMLish grammar, an ADR watch item) green.
- [x] `t/grammar-body-my-lexical-scope.t`, `t/regex-anchored-separated-repeat.t` (separator regression) green.
- [x] `cargo test --lib` (853 passed), `cargo clippy -- -D warnings`, `cargo fmt --check` clean.
- [x] `make test` full local TAP suite green (the only unrelated failure, `t/compunit-can-install.t`, is a pre-existing environment artifact -- `/` is writable in this container, unrelated to this diff).

ADR-0046's Status line and Slice 1 bullet updated to record what landed and what's next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)