### PR TITLE
fix(adr0049): decay Nil to the container default at element store (slices 0-2)

### DIFF
--- a/docs/adr/0049-nil-decays-to-the-container-default-at-the-element-store.md
+++ b/docs/adr/0049-nil-decays-to-the-container-default-at-the-element-store.md
@@ -1,6 +1,6 @@
 # ADR-0049: `Nil` decays to the *container's* default at the element store, and stops being a hole sentinel
 
-- **Status**: Proposed (design complete; implementation not started)
+- **Status**: Accepted (Slices 0-2 implemented; see "Implementation status" below)
 - **Date**: 2026-08-20
 - **Deciders**: tokuhirom, Claude
 - **Related**: [ADR-0040](0040-array-hash-elements-are-itemized-at-the-store.md) (the same Raku model —
@@ -570,4 +570,67 @@ follow-up ticket once slice 5 lands.
 
 ---
 
-*This ADR is Proposed. If the mechanism judgment changes later, supersede it rather than rewriting it.*
+## 8. Implementation status (2026-08-20)
+
+Slices 0-2 landed:
+
+- **Slice 0** (acceptance oracle): `t/nil-element-store-decay.t`, pinning all 29 §1.3 rows plus all 13
+  §1.4 invariants (16 assertions, since I13 bundles four checks) -- 45 assertions total, dual-oracled
+  against `raku` while writing the file. Two rows are `todo`-marked and stay open past this PR (see
+  below); every other row and invariant is a live, non-`todo` assertion.
+- **Slice 1** (the dropped element): `exec_make_array_no_flatten_op`'s `ValueView::Nil => {}` drop
+  (`src/vm/vm_data_ops.rs`) is gone -- a bare `Nil` is now a real element that decays like any other,
+  fixing row 19 (`[Nil,].elems` is `1`, not a silently-dropped `0`).
+- **Slice 2** (construction): a single new `Interpreter::decay_nil_container_elements` helper
+  (`src/vm/vm_data_ops.rs`) calls `typed_container_default` once per freshly-built container and
+  rewrites any `Nil` element/value in place (a no-op when the default comes back `Nil`, i.e. a `List`
+  or other non-container). Wired into `exec_make_array_op`, `exec_make_array_no_flatten_op`,
+  `exec_make_hash_op`, `exec_make_hash_from_pairs_op` (`src/vm/vm_data_ops.rs`),
+  `try_native_array_construct`'s and `try_native_hash_construct`'s untyped/typed return paths
+  (`src/runtime/methods_aggregate_ctor.rs`, called after `tag_container_metadata` so the decay target
+  is typed), and the two parameterized `Array[T].new`/`Hash[V,K].new` re-implementations
+  (`src/runtime/methods_object_dispatch_new.rs`). `build_hash_from_items_with_key_coercion` and
+  `coerce_to_hash` (`src/runtime/utils/coerce_containers.rs`) are free functions with no `&mut self`
+  to call `typed_container_default` from; since neither ever sees a pre-existing typed/`is default(...)`
+  container at the point a bare literal is built, a small `decay_nil_hash_value` helper hardcodes the
+  same `Any` answer `typed_container_default` would compute there, applied only at genuine
+  pair-value inserts (not at the separate odd-trailing-key-with-no-value fallback, which is a
+  pre-existing, out-of-scope divergence from raku's actual "Odd number of elements" die). The shaped
+  (`:shape(...)`) branches of the two `Array`-constructing functions were deliberately left untouched
+  in this slice, to avoid interacting with the shaped-array hole/`initialized` tracking; no acceptance
+  row exercises a shaped-array `Nil` element.
+- **Bonus, not required by the plan:** rows 27 and 28 (the two type-check divergences) turned out to
+  already flip correctly as a side effect of slices 1-2, with no slice 3 needed. `[Nil]`'s own
+  construction now decays to `[Any]` *before* `my Int @a = [Nil]` ever assigns it, so the existing
+  (unmodified) element type check at the assignment site sees a plain `Any`/`Int` mismatch and dies --
+  the same message raku produces. Symmetrically, `my %h{Int} = 1 => Nil` no longer dies, because the
+  `Nil` *value* decays to the hash's `Any` value-type default before any check runs (the `Int`
+  constraint there is on the key, which was never the problem).
+- **Two rows stay open**, both `todo`-marked in the slice-0 test with a comment pointing at their
+  territory:
+  - **Row 25** (`%h.AT-KEY("missing")` on a genuinely absent key still returns raw `Value::NIL`) is
+    slice 5's job (§2 part 5, §5.2) -- `AT-KEY` has no missing-key compensation at all yet. (Row 26,
+    the same method on a key holding a *decayed* value, already passes: the map genuinely contains
+    `Any` now, so no compensation is even needed.)
+  - **Row 29** (`my @d is default(42) = [Nil]; @d[0]` reads back `42` instead of `Any`) is not slice 3
+    or slice 5's territory as originally scoped -- measurement found the culprit is
+    `resolve_array_entry`'s read chokepoint (`src/vm/vm_var_ops.rs`), which unconditionally substitutes
+    a non-`Nil` container default for *any* in-range `Package("Any")` element, without consulting
+    `ArrayData::initialized`. That is exactly the "different bug in the same family... deserve[ing] its
+    own probe" §5.2 already flagged for the array-side rewrites at `vm_var_ops.rs:139`/`:145` (these
+    are those two lines) -- confirmed by direct measurement rather than assumed, so it is recorded here
+    as a dedicated follow-up rather than folded into slice 3 or 5.
+- **Verification**: `cargo clippy -- -D warnings` and `cargo fmt --check` clean; full local `make test`
+  and the regression pins ADR §4 slice 0 named (`t/nil-list-holes.t`, `t/typed-array-hole-adverbs.t`,
+  `t/nil-any-identity.t`, `t/is-eqv.t`, `t/array-slice-oob.t`, `t/pair-subscript-exists.t`,
+  `t/uninit-scalar-any.t`, `t/typecheck-expected-nil.t`, `t/shared-var-nil-redeclared-mask.t`) all pass
+  unchanged; no whitelisted roast file references a `Nil` array/hash literal at all (confirming §1.8).
+- **Next**: slice 3 (retire the narrow assignment-site fixups and unify onto `typed_container_default`;
+  note row 27 already dies correctly, so slice 3's own acceptance bar is now "no regression", not "make
+  it die"), slice 4 (mutation sites), slice 5 (retire the `Nil` hole sentinel, plus the two `todo` rows
+  above), and slice 6 (sweep, close out, `git mv` the originating `todo/deep/` finding to `news/`).
+
+---
+
+*This ADR is Accepted for slices 0-2. If the mechanism judgment for later slices changes, supersede
+rather than rewriting.*

--- a/src/runtime/methods_aggregate_ctor.rs
+++ b/src/runtime/methods_aggregate_ctor.rs
@@ -306,6 +306,10 @@ impl Interpreter {
             };
             result = self.tag_container_metadata(result, info);
         }
+        // ADR-0049 slice 2: decay a `Nil` argument to the constructed array's
+        // own default (untyped -> `Any`, typed -> the tagged element type
+        // above) -- `Array.new(Nil)[0].WHAT` is `(Any)`, not `Nil`.
+        result = self.decay_nil_container_elements(result);
         Ok(result)
     }
 
@@ -429,9 +433,13 @@ impl Interpreter {
             } else {
                 crate::runtime::utils::set_hash_original_keys(result, original_keys)
             };
-            return Ok(self.tag_container_metadata(result, info));
+            let result = self.tag_container_metadata(result, info);
+            // ADR-0049 slice 2: decay a `Nil` value to the tagged element type.
+            return Ok(self.decay_nil_container_elements(result));
         }
-        Ok(result)
+        // ADR-0049 slice 2: an untyped `Hash.new`/`Map.new` decays a `Nil`
+        // value to `Any` (`Hash.new("a", Nil)<a>.WHAT` is `(Any)`).
+        Ok(self.decay_nil_container_elements(result))
     }
 
     /// VM fast-path wrapper: build an aggregate (`Array`/`List`/`Positional`/

--- a/src/runtime/methods_object_dispatch_new.rs
+++ b/src/runtime/methods_object_dispatch_new.rs
@@ -1379,7 +1379,9 @@ impl Interpreter {
                             }),
                         },
                     );
-                    return Ok(result);
+                    // ADR-0049 slice 2: decay a `Nil` argument to the tagged
+                    // element type (e.g. `Array[Int].new(Nil)[0].WHAT` is `(Int)`).
+                    return Ok(self.decay_nil_container_elements(result));
                 }
                 if matches!(base_class_name, "Hash" | "Map") {
                     let mut flat = Vec::new();
@@ -1428,7 +1430,10 @@ impl Interpreter {
                         key_type,
                         declared_type: Some(class_name.resolve()),
                     };
-                    return Ok(self.tag_container_metadata(result, info));
+                    let result = self.tag_container_metadata(result, info);
+                    // ADR-0049 slice 2: decay a `Nil` value to the tagged
+                    // element type.
+                    return Ok(self.decay_nil_container_elements(result));
                 }
             }
             // Not `if let ... else`: the role branch is skipped entirely while

--- a/src/runtime/utils/coerce_containers.rs
+++ b/src/runtime/utils/coerce_containers.rs
@@ -11,6 +11,21 @@ pub(crate) fn hash_pair_keys(key: &Value) -> Vec<Value> {
     }
 }
 
+/// ADR-0049 slice 2: a Hash value is a `Scalar` container, so a stored `Nil`
+/// decays to `Any` (an untyped hash's own default -- these builders never see
+/// a pre-existing typed/`is default(...)` container to decay against, so
+/// `Any` is exactly what `Interpreter::typed_container_default` would compute
+/// here anyway). Applied only at genuine pair-value inserts, not at the
+/// separate odd-trailing-key fallback (a pre-existing, out-of-scope
+/// divergence unrelated to this ADR).
+fn decay_nil_hash_value(v: Value) -> Value {
+    if v.is_nil() {
+        Value::package(crate::symbol::Symbol::intern("Any"))
+    } else {
+        v
+    }
+}
+
 pub(crate) fn coerce_to_hash(value: Value) -> Value {
     let mix_weight_value = crate::value::mix_weight_to_value;
     let value = value.into_descalarized();
@@ -43,10 +58,10 @@ pub(crate) fn coerce_to_hash(value: Value) -> Value {
                     // `ContainerRef`; storing into a Hash decontainerizes (copies
                     // the value), matching Raku (`%h = k => $v; $v = 2` leaves
                     // `%h<k>` unchanged).
-                    map.insert(k.clone(), v.deref_container());
+                    map.insert(k.clone(), decay_nil_hash_value(v.deref_container()));
                     i += 1;
                 } else if let ValueView::ValuePair(k, v) = flat[i].view() {
-                    let dv = v.deref_container();
+                    let dv = decay_nil_hash_value(v.deref_container());
                     for kk in hash_pair_keys(k) {
                         let str_key = kk.to_string_value();
                         if !matches!(kk.view(), ValueView::Str(_)) {
@@ -80,10 +95,10 @@ pub(crate) fn coerce_to_hash(value: Value) -> Value {
             let mut i = 0;
             while i < items.len() {
                 if let ValueView::Pair(k, v) = items[i].view() {
-                    map.insert(k.clone(), v.deref_container());
+                    map.insert(k.clone(), decay_nil_hash_value(v.deref_container()));
                     i += 1;
                 } else if let ValueView::ValuePair(k, v) = items[i].view() {
-                    let dv = v.deref_container();
+                    let dv = decay_nil_hash_value(v.deref_container());
                     for kk in hash_pair_keys(k) {
                         let str_key = kk.to_string_value();
                         if !matches!(kk.view(), ValueView::Str(_)) {
@@ -111,13 +126,13 @@ pub(crate) fn coerce_to_hash(value: Value) -> Value {
         }
         ValueView::Pair(k, v) => {
             let mut map = HashMap::new();
-            map.insert(k.clone(), v.deref_container());
+            map.insert(k.clone(), decay_nil_hash_value(v.deref_container()));
             Value::hash(map)
         }
         ValueView::ValuePair(k, v) => {
             let mut map = HashMap::new();
             let mut original_keys: HashMap<String, Value> = HashMap::new();
-            let dv = v.deref_container();
+            let dv = decay_nil_hash_value(v.deref_container());
             for kk in hash_pair_keys(k) {
                 let str_key = kk.to_string_value();
                 if !matches!(kk.view(), ValueView::Str(_)) {
@@ -278,7 +293,7 @@ where
     while let Some(item) = iter.next() {
         match item.view() {
             ValueView::Pair(key, boxed_val) => {
-                map.insert(key.clone(), boxed_val.clone());
+                map.insert(key.clone(), decay_nil_hash_value(boxed_val.clone()));
             }
             // A bare (non-itemized) hash in list context flattens into its
             // key=>value pairs (`%m = (%h,)` / `%(%h,)`). A hash sourced from a
@@ -308,6 +323,7 @@ where
             // storing the value under each of its members (`%h<a> == %h<b> == 1`),
             // matching Rakudo. Every other non-Str key stringifies as usual.
             ValueView::ValuePair(key, boxed_val) => {
+                let boxed_val = decay_nil_hash_value(boxed_val.clone());
                 for kk in hash_pair_keys(key) {
                     let (str_key, record_original) = encode_key(&kk)?;
                     if record_original {
@@ -338,7 +354,7 @@ where
                 if record_original {
                     original_keys.insert(str_key.clone(), item.clone());
                 }
-                map.insert(str_key, value);
+                map.insert(str_key, decay_nil_hash_value(value));
             }
         }
     }

--- a/src/vm/vm_data_ops.rs
+++ b/src/vm/vm_data_ops.rs
@@ -1,6 +1,48 @@
 use super::*;
 
 impl Interpreter {
+    /// ADR-0049 (slices 1-2): a real `Array`/`Hash` element is a `Scalar`
+    /// container, and a `Scalar` cannot hold `Nil` -- storing `Nil` into one
+    /// restores the *owning container's own* default (`is default(...)` ->
+    /// native element zero -> declared element type object -> `Any`, exactly
+    /// `Interpreter::typed_container_default`). Call this once per container
+    /// right after it is fully built (and, for a typed/`.new` construction,
+    /// after `tag_container_metadata` has attached its type info), so a
+    /// nested literal decays inside-out (`[[Nil]] eqv [[Any]]` — ADR-0049
+    /// S1.5): the inner array's own construction op already ran this hook
+    /// before the outer one sees it.
+    ///
+    /// A no-op for anything `typed_container_default` cannot decay -- `List`,
+    /// `Seq`, and other non-container values, whose elements are not
+    /// `Scalar`s and legitimately keep a stored `Nil` (ADR-0049 S1.4 I1-I3).
+    pub(crate) fn decay_nil_container_elements(&mut self, mut value: Value) -> Value {
+        let default = self.typed_container_default(&value);
+        if default.is_nil() {
+            return value;
+        }
+        let decayed_array = value
+            .with_array_mut(|items, _kind| {
+                let data = crate::gc::Gc::make_mut(items);
+                for item in data.items_mut() {
+                    if item.is_nil() {
+                        *item = default.clone();
+                    }
+                }
+            })
+            .is_some();
+        if !decayed_array {
+            value.with_hash_mut(|items| {
+                let data = crate::gc::Gc::make_mut(items);
+                for v in data.map.values_mut() {
+                    if v.is_nil() {
+                        *v = default.clone();
+                    }
+                }
+            });
+        }
+        value
+    }
+
     pub(super) fn exec_make_array_op(
         &mut self,
         code: &CompiledCode,
@@ -138,11 +180,17 @@ impl Interpreter {
                 _ => elems.push(val),
             }
         }
-        if is_real_array {
-            self.stack.push(Value::real_array(elems));
+        let result = if is_real_array {
+            Value::real_array(elems)
         } else {
-            self.stack.push(Value::array(elems));
-        }
+            Value::array(elems)
+        };
+        // ADR-0049: decay a stored `Nil` element to the array's own default.
+        // A no-op for the `List` (non-real) branch above, since
+        // `typed_container_default` returns `Nil` (meaning "no decay") for a
+        // non-real-array container.
+        let result = self.decay_nil_container_elements(result);
+        self.stack.push(result);
         Ok(())
     }
 
@@ -157,12 +205,15 @@ impl Interpreter {
         for val in raw {
             match val.view() {
                 ValueView::Slip(items) => elems.extend(items.iter().cloned()),
-                // Nil in list context contributes nothing (same as value_to_list).
-                ValueView::Nil => {}
+                // ADR-0049 slice 1: a bare `Nil` is a real element here, not a
+                // List-context no-op -- it decays to the array's own default
+                // below (`[Nil,].elems` is `1`, not a silently dropped `0`).
                 _ => elems.push(val),
             }
         }
-        self.stack.push(Value::real_array(elems));
+        let result = Value::real_array(elems);
+        let result = self.decay_nil_container_elements(result);
+        self.stack.push(result);
     }
 
     pub(super) fn exec_make_hash_op(&mut self, n: u32) -> Result<(), RuntimeError> {
@@ -182,7 +233,8 @@ impl Interpreter {
             let val = pair[1].clone();
             map.insert(key, val);
         }
-        self.stack.push(Value::hash(map));
+        let result = self.decay_nil_container_elements(Value::hash(map));
+        self.stack.push(result);
         Ok(())
     }
 
@@ -211,7 +263,8 @@ impl Interpreter {
                 }
             }
         }
-        self.stack.push(Value::hash(map));
+        let result = self.decay_nil_container_elements(Value::hash(map));
+        self.stack.push(result);
     }
 
     /// Box the local scalar variable `name` into a shared `ContainerRef` cell and

--- a/t/nil-element-store-decay.t
+++ b/t/nil-element-store-decay.t
@@ -1,0 +1,212 @@
+use v6;
+use Test;
+
+# ADR-0049: `Nil` decays to the *container's* default at the element store,
+# and stops being a hole sentinel (docs/adr/0049-nil-decays-to-the-container-
+# default-at-the-element-store.md).
+#
+# This file is the acceptance oracle from ADR-0049 SS1.3/1.4: the 29 rows
+# where mutsu diverged from raku on `main` (227e38e4f, 2026-08-20) PLUS the 13
+# invariants mutsu already got right (dual-oracled against `raku` again while
+# writing this file). Slices 1-2 (this PR) fix the construction-site decay; a
+# `# TODO: ADR-0049 ...` comment marks each row still expected to diverge, so
+# later slices have a live regression net instead of a silently-omitted case.
+#
+# The invariant half is the important other side: it is what stops a later
+# slice from "fixing" the divergence by purging `Nil` from Lists or from hole
+# materialization -- `Nil` legitimately survives in a `List`/`Seq`/slurpy, and
+# `.List` on an array hole is *supposed* to read back as `Nil`.
+
+plan 45;
+
+# === SS1.3 divergent rows (29) ===
+
+# 01: a Nil literal element decays to Any at its own construction.
+my @row01 = [Nil];
+ok @row01 eqv [Nil], 'row 01: my @b = [Nil]; @b eqv [Nil]';
+
+# 02: [Nil] eqv [Any] directly.
+ok [Nil] eqv [Any], 'row 02: [Nil] eqv [Any]';
+
+# 03: reading the decayed element back gives the Any type object.
+is [Nil][0].WHAT, Any, 'row 03: [Nil][0].WHAT';
+
+# 04: binding an anonymous literal preserves the decay.
+my @row04 := [Nil];
+is @row04[0].WHAT, Any, 'row 04: my @a := [Nil]; @a[0].WHAT';
+
+# 05: passing an anonymous literal straight to a sub keeps the decay.
+sub row05(@x) { @x[0].WHAT }
+is row05([Nil]), Any, 'row 05: sub f(@x){@x[0].WHAT}; f([Nil])';
+
+# 06: a scalar-bound anonymous literal is unaffected by the itemization.
+my $row06 = [Nil];
+is $row06[0].WHAT, Any, 'row 06: my $c = [Nil]; $c[0].WHAT';
+
+# 07: a deliberately-stored Nil element (decayed to Any) still :exists.
+ok ([Nil,1][0]:exists), 'row 07: [Nil,1][0]:exists';
+
+# 08: :v on the decayed element yields the Any type object.
+is ([Nil,1][0]:v), Any, 'row 08: [Nil,1][0]:v';
+
+# 09: .head on a real array reads the decayed store, not a raw Nil.
+is [Nil,1].head.WHAT, Any, 'row 09: [Nil,1].head.WHAT';
+
+# 10: .map sees the decayed element too -- no reader-side compensation needed.
+is [Nil,1].map({.WHAT}).head, Any, 'row 10: [Nil,1].map({.WHAT}).head';
+
+# 11/12/13: .sort/.reverse/.flat all read the already-decayed store.
+is [Nil,1].sort.raku, '(Any, 1).Seq', 'row 11: [Nil,1].sort.raku';
+is [Nil,1].reverse.raku, '(1, Any).Seq', 'row 12: [Nil,1].reverse.raku';
+is [Nil,1].flat.raku, '(Any, 1).Seq', 'row 13: [Nil,1].flat.raku';
+
+# 14: .clone copies the already-decayed element.
+is [Nil,1].clone[0].WHAT, Any, 'row 14: [Nil,1].clone[0].WHAT';
+
+# 15: nested literal construction decays inside-out (ADR-0049 SS1.5).
+ok [[Nil]] eqv [[Any]], 'row 15: [[Nil]] eqv [[Any]]';
+
+# 16/17: Array.new(Nil) decays at its own untyped construction.
+is Array.new(Nil)[0].WHAT, Any, 'row 16: Array.new(Nil)[0].WHAT';
+ok (Array.new(Nil)[0]:exists), 'row 17: Array.new(Nil)[0]:exists';
+
+# 18: .List materializing a *real* (decayed) element is now correct --
+# previously this was "right answer for a hole, wrong answer for a value"
+# (ADR-0049 SS1.3 row 18 commentary).
+is [Nil].List.raku, '(Any,)', 'row 18: [Nil].List.raku';
+
+# 19: THE data-loss bug (slice 1) -- a trailing-comma literal no longer drops
+# its Nil element.
+is [Nil,].elems, 1, 'row 19: [Nil,].elems (was silently dropped to 0)';
+
+# 20/21: hash-literal and list-assign construction both decay the pair value.
+ok {a=>Nil} eqv {a=>Any}, 'row 20: {a=>Nil} eqv {a=>Any}';
+my %row21 = a=>Nil;
+ok %row21 eqv {a=>Any}, 'row 21: my %g = a=>Nil; %g eqv {a=>Any}';
+
+# 22/23: .values / .pairs read the decayed store, not a raw stored Nil.
+is {a=>Nil}.values.head.WHAT, Any, 'row 22: {a=>Nil}.values.head.WHAT';
+is {a=>Nil}.pairs.head.value.WHAT, Any, 'row 23: {a=>Nil}.pairs.head.value.WHAT';
+
+# 24: a nested array-valued hash entry decays too (inside-out, same as row 15).
+ok {a=>[Nil]} eqv {a=>[Any]}, 'row 24: {a=>[Nil]} eqv {a=>[Any]}';
+
+# 25: TODO -- .AT-KEY on a genuinely-*missing* key still returns the raw
+# `Value::NIL` sentinel; this is the read-side compensator gap ADR-0049 SS1.6
+# assigns to slice 5 ("AT-KEY has no compensation at all").
+{
+    todo 'row 25: AT-KEY on a missing key has no compensation yet (ADR-0049 slice 5)';
+    my %row25;
+    is %row25.AT-KEY("missing").WHAT, Any, 'row 25: my %h; %h.AT-KEY("missing").WHAT';
+}
+
+# 26: AT-KEY on a key that holds a *decayed* (not missing) value already works
+# from slices 1-2 -- the map genuinely contains Any now, so no missing-key
+# compensation is even needed.
+my %row26 = a=>Nil;
+is %row26.AT-KEY("a").WHAT, Any, 'row 26: my %n = a=>Nil; %n.AT-KEY("a").WHAT';
+
+# 27: an untyped `[Nil]` literal now decays to `[Any]` at its own
+# construction (slice 2), so assigning it to a typed `Int @a` hits the
+# ordinary element type check and dies -- exactly like raku. (ADR-0049 SS4
+# slice 3 called this "the single most visible behaviour change"; it in fact
+# already falls out of slices 1-2, because the literal no longer hands the
+# assignment site a raw `Nil` to special-case leniently.)
+{
+    my $died = False;
+    my $message = '';
+    try {
+        my Int @row27 = [Nil];
+        CATCH { default { $died = True; $message = .message } }
+    }
+    ok $died && $message.contains('Int') && $message.contains('Any'),
+        'row 27: my Int @a = [Nil] dies with an Int/Any type-check message';
+}
+
+# 28: `my %h{Int} = 1 => Nil` no longer dies -- the `Nil` *value* decays to
+# the hash's `Any` value-type default before any type check sees it (the
+# `Int` constraint here is on the *key*, which is unaffected).
+{
+    my $died = False;
+    try {
+        my %row28{Int} = 1 => Nil;
+        CATCH { default { $died = True } }
+    }
+    ok !$died, 'row 28: my %h{Int} = 1 => Nil does not die';
+}
+
+# 29: TODO -- decay is per-container (the *inner* `[Nil]` literal decays to
+# its own `Any`, not the *outer* variable's `is default(42)`), but the
+# existing read-side `resolve_array_entry` chokepoint
+# (src/vm/vm_var_ops.rs) unconditionally substitutes a non-Nil container
+# default for ANY in-range `Package("Any")` element -- including one that is
+# a genuinely-stored value, not a hole. ADR-0049 SS5.2 flags this exact
+# rewrite as "a *different* bug in the same family ... deserve[ing] its own
+# probe rather than being swept in" to this ADR, so it stays open past
+# slices 1-2.
+{
+    todo 'row 29: per-container decay vs is-default read-side rewrite (ADR-0049 SS5.2 follow-up)';
+    my @row29 is default(42) = [Nil];
+    is @row29[0], Any, 'row 29: my @d is default(42) = [Nil]; @d[0]';
+}
+
+# === SS1.4 invariants (13 rows, 16 assertions -- I13 bundles 4 checks) ===
+# These must stay green forever: they are the regression net that stops a
+# later slice from purging Nil out of Lists or out of hole materialization.
+
+# I1: a List element holding a literal Nil is unaffected by the store-decay
+# rule (only real Array/Hash elements are containers). `.WHAT` on `Nil`
+# itself is `Nil`, not a type object -- verified identical on raku and mutsu.
+ok (1,Nil,2)[1].WHAT =:= Nil, 'I1: (1,Nil,2)[1].WHAT -- a List element stays Nil';
+
+# I2: eqv on two Lists holding literal Nil.
+ok (1,Nil,2) eqv (1,Nil,2), 'I2: (1,Nil,2) eqv (1,Nil,2)';
+
+# I3: a slurpy `*@x` is List-backed, so it keeps a literal Nil too.
+sub inv03(*@x) { @x[0].WHAT }
+ok inv03(Nil,1) =:= Nil, 'I3: sub s(*@x){@x[0].WHAT}; s(Nil,1)';
+
+# I4: an autovivification-gap array materializes its holes as Nil via .List.
+my @inv04; @inv04[2] = 5;
+is @inv04.List.raku, '(Nil, Nil, 5)', 'I4: my @a; @a[2]=5; @a.List.raku';
+
+# I5: a direct element read on the same gap still vivifies to Any.
+is @inv04[0].WHAT, Any, 'I5: my @a; @a[2]=5; @a[0].WHAT';
+
+# I6: the same gap does not :exist.
+nok (@inv04[0]:exists), 'I6: my @a; @a[2]=5; @a[0]:exists is False';
+
+# I7: an untyped `my @n = 1, Nil, 3` list-assign already decays -- and,
+# crucially, answers :exists the SAME way row 07's `[Nil, 1]` literal does
+# (ADR-0049's sharpest statement of the pre-fix defect).
+my @inv07 = 1, Nil, 3;
+ok (@inv07[1]:exists), 'I7: my @n = 1, Nil, 3; @n[1]:exists';
+
+# I8: :v on that same decayed element is Any.
+is (@inv07[1]:v), Any, 'I8: my @n = 1, Nil, 3; @n[1]:v';
+
+# I9: an explicitly `:delete`d slot does not :exist (a real hole, not a
+# decayed value -- must stay distinguishable from row 07/I7 above).
+my @inv09 = 1, 2, 3; @inv09[1]:delete;
+nok (@inv09[1]:exists), 'I9: my @d=1,2,3; @d[1]:delete; @d[1]:exists is False';
+
+# I10: assigning a literal Nil to an existing untyped element still decays to
+# the array's own Any default.
+my @inv10 = 1, 2, 3; @inv10[1] = Nil;
+ok @inv10 eqv [1, Any, 3], 'I10: my @z=1,2,3; @z[1]=Nil; @z eqv [1,Any,3]';
+
+# I11: assigning Nil to a typed-array element decays to the declared type
+# object, not Any.
+my Int @inv11 = 1, 2; @inv11[0] = Nil;
+is @inv11.raku, 'Array[Int].new(Int, 2)', 'I11: my Int @t=1,2; @t[0]=Nil; @t.raku';
+
+# I12: a typed-array *literal* list-assign decays its Nil elements the same
+# way.
+my Int @inv12 = 1, Nil, 3;
+is @inv12.raku, 'Array[Int].new(1, Int, 3)', 'I12: my Int @a=1,Nil,3; @a.raku';
+
+# I13: elems/gist/.Slip on a decayed one-Nil / two-element literal.
+is [Nil].elems, 1, 'I13a: [Nil].elems';
+is [1,Nil].elems, 2, 'I13b: [1,Nil].elems';
+is [Nil].gist, '[(Any)]', 'I13c: [Nil].gist';
+is [Nil].Slip.raku, 'slip(Any,)', 'I13d: [Nil].Slip.raku';


### PR DESCRIPTION
## Summary

Implements ADR-0049 slices 0-2 (`docs/adr/0049-nil-decays-to-the-container-default-at-the-element-store.md`).

An `Array`/`Hash` element is a `Scalar` container, and a `Scalar` cannot hold `Nil`. mutsu already implemented "assigning `Nil` restores the container default" at ~20 assignment sites, but at zero construction sites -- and one construction site actively dropped the element (`[Nil,].elems` was `0`, not `1`).

- **Slice 0** -- `t/nil-element-store-decay.t`: the acceptance oracle, pinning all 29 raku-vs-mutsu divergent rows from the ADR's §1.3 table plus the 13 already-agreeing §1.4 invariants (45 assertions total, dual-oracled against `raku`). Two rows stay `todo`-marked (not silently omitted), each with a comment naming the specific out-of-scope mechanism:
  - row 25: `AT-KEY` on a genuinely-missing key has no compensation yet (slice 5's job).
  - row 29: a *different*, previously-unflagged bug -- `resolve_array_entry`'s read chokepoint unconditionally substitutes a container's `is default(...)` value for any in-range `Package("Any")` element, ignoring `ArrayData::initialized`. Confirmed by direct measurement (not assumed from the ADR's phasing table, which had predicted this row would turn green). Recorded as a dedicated follow-up in the ADR's new "Implementation status" section.
- **Slice 1** -- `exec_make_array_no_flatten_op`'s `ValueView::Nil => {}` drop is gone; a bare `Nil` is now a real element that decays like any other stored `Nil`.
- **Slice 2** -- a new `Interpreter::decay_nil_container_elements` helper calls `typed_container_default` once per freshly-built container and rewrites any `Nil` element/value in place (a no-op for `List`/non-container values, since `typed_container_default` returns `Nil` there). Wired into `exec_make_array_op`, `exec_make_hash_op`, `exec_make_hash_from_pairs_op` (`src/vm/vm_data_ops.rs`), `try_native_array_construct`/`try_native_hash_construct` (`src/runtime/methods_aggregate_ctor.rs`, called after `tag_container_metadata` so the target is typed), and the two parameterized `Array[T].new`/`Hash[V,K].new` re-implementations (`src/runtime/methods_object_dispatch_new.rs`). `build_hash_from_items_with_key_coercion`/`coerce_to_hash` (`src/runtime/utils/coerce_containers.rs`) are free functions with no `&mut self`; since neither ever sees a pre-existing typed container at the point a bare literal is built, they decay directly to `Any` at genuine pair-value inserts (not at the pre-existing, out-of-scope odd-trailing-key-with-no-value fallback).
- **Bonus, not required by the plan**: rows 27/28 (the two type-check divergences ADR-0049 slice 3 was expected to fix) already flip correctly as a side effect of slices 1-2 alone -- `[Nil]`'s own construction now decays to `[Any]` *before* `my Int @a = [Nil]` assigns it, so the existing (unmodified) element type check does the rest; symmetrically `my %h{Int} = 1 => Nil` no longer dies.
- ADR-0049's status updated to Accepted with a new "Implementation status" section recording what landed and what's next (slices 3-6).

Explicitly out of scope (per the task): slice 3 (typed-array death via the narrow assignment-site fixups) and slice 5 (sentinel retirement) are not implemented here, though row 27's die already falls out for free. `coerce_to_array` is deliberately untouched (stays type-blind, as its own comment states -- that's slice 3/4 territory).

## Test plan

- [x] New test: `t/nil-element-store-decay.t` -- 45/45 pass (2 as expected `todo`), dual-checked against `raku` too (all 45 pass there, with rows 25/29 reported as "TODO passed" as expected).
- [x] Regression pins named in ADR §4 slice 0 all still pass unchanged: `t/nil-list-holes.t`, `t/typed-array-hole-adverbs.t`, `t/nil-any-identity.t`, `t/is-eqv.t`, `t/array-slice-oob.t`, `t/pair-subscript-exists.t`, `t/uninit-scalar-any.t`, `t/typecheck-expected-nil.t`, `t/shared-var-nil-redeclared-mask.t`.
- [x] `cargo clippy -- -D warnings` and `cargo fmt --check` clean.
- [x] Full local `make test` (3275 files): only pre-existing failure is `t/compunit-can-install.t` test 4, an environment artifact of this sandbox running with a writable `/` for a non-root user (unrelated to any file touched here; not in `flaky-tests.txt`).
- [x] No whitelisted roast file references a `Nil` array/hash literal at all (confirms ADR §1.8); `make roast` delegated to CI per project convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)