### PR TITLE
fix(types): give Instant/Duration/IO::Path/IO::Handle/Cool correct catalog ancestry (ADR-0051 P1)

### DIFF
--- a/docs/adr/0051-type-ancestry-has-one-oracle-and-an-unresolved-method-throws.md
+++ b/docs/adr/0051-type-ancestry-has-one-oracle-and-an-unresolved-method-throws.md
@@ -249,7 +249,7 @@ regressions instead of one data gap.
 
 Each phase is independently landable and independently valuable.
 
-- **P1 — Rakudo-verify and complete the catalog, and make `.^mro` read it. LANDED (PR TBD, 2026-08-20).**
+- **P1 — Rakudo-verify and complete the catalog, and make `.^mro` read it. LANDED (PR #6754, 2026-08-20).**
   Added `Cool`, `Instant`, `Duration`, `IO::Path`, and `IO::Handle` rows to `builtin_type_catalog`
   (`src/builtins/builtin_type_catalog.rs`), each Rakudo-verified (`.^mro`/`.^roles`) on 2026-08-20.
   Re-pointed `classhow_mro_names`'s unregistered-type branch (`src/runtime/methods_classhow_mro.rs`)

--- a/docs/adr/0051-type-ancestry-has-one-oracle-and-an-unresolved-method-throws.md
+++ b/docs/adr/0051-type-ancestry-has-one-oracle-and-an-unresolved-method-throws.md
@@ -1,6 +1,6 @@
 # ADR-0051: Type ancestry has one oracle, and an unresolved method throws instead of stringifying
 
-- Status: Proposed (design complete; implementation not started)
+- Status: Accepted (P1 landed; P2/P4/P5 not started)
 - Date: 2026-08-20
 - Supersedes: none
 - Related: [ADR-0019](0019-compiled-declarations-and-unified-method-dispatch.md) (§2 "One registry owns
@@ -249,26 +249,39 @@ regressions instead of one data gap.
 
 Each phase is independently landable and independently valuable.
 
-- **P1 — Rakudo-verify and complete the catalog, and make `.^mro` read it.** Add `Instant`,
-  `Duration`, `IO::Path`, `IO::Handle`, and `Cool` rows to `builtin_type_catalog`; correct any other
-  divergence a full sweep finds. Re-point `classhow_mro_names`
-  (`src/runtime/methods_classhow_mro.rs:12-23`) at the catalog, deleting `builtin_type_parents`
-  (source 3) — its only non-test caller. `IO::Path` additionally needs its bootstrap `ClassDef`
-  (`src/runtime/runtime_init.rs:678`) to stop declaring `parents: vec![]` / `mro: ["IO::Path"]`;
-  `compute_class_mro`'s existing `parent == "Cool"` arm (`registry.rs:750`) already linearizes it.
-  Pin with a test that asserts, for every catalog type, that `.^mro` equals the Rakudo chain
-  (extend `tmp/mro_sweep.p6`'s comparison into a `t/` test with the raku answers baked in).
-  *Alone this fixes the `Match`/`Instant`/`Duration`/`IO::Path` `.^mro` and `~~ Cool` divergences —
-  user-visible on its own, no gate involved.*
+- **P1 — Rakudo-verify and complete the catalog, and make `.^mro` read it. LANDED (PR TBD, 2026-08-20).**
+  Added `Cool`, `Instant`, `Duration`, `IO::Path`, and `IO::Handle` rows to `builtin_type_catalog`
+  (`src/builtins/builtin_type_catalog.rs`), each Rakudo-verified (`.^mro`/`.^roles`) on 2026-08-20.
+  Re-pointed `classhow_mro_names`'s unregistered-type branch (`src/runtime/methods_classhow_mro.rs`)
+  at the catalog and deleted `builtin_type_parents` (source 3) — confirmed it had no non-test caller
+  left. `IO::Path`'s bootstrap `ClassDef` (`src/runtime/runtime_init.rs`) now declares
+  `parents: vec!["Cool".to_string()]` with `mro` left empty (the standard "not yet computed"
+  convention); `Registry::compute_class_mro`'s existing `parent == "Cool"` arm linearizes the rest,
+  matching the pattern already used for every ordinary registered class. `IO::Handle` needed no
+  `ClassDef` change — Rakudo's own `IO::Handle.^mro` does NOT include `Cool` (verified
+  2026-08-20: `(IO::Handle Any Mu)`), only `IO::Path` does among the two.
+  Pinned by `t/adr0051-builtin-type-cool-ancestry.t` (`.^mro`, `~~ Cool`, and a representative
+  Cool-method call for each of the five types, plus `Match`/`Pair`/a plain class as
+  unaffected/negative controls, all dual-oracle verified against a real `raku`) and by new unit
+  tests in `builtin_type_catalog.rs`'s own test module.
+  *This alone fixes the `Match`/`Instant`/`Duration`/`IO::Path` `.^mro` and `~~ Cool` divergences —
+  user-visible on its own, no gate involved.* Verified: `Instant.^mro`/`Duration.^mro`/`IO::Path.^mro`
+  now match raku exactly (previously all three dead-ended at `[Type, Any, Mu]`, no `Cool`).
 
-  **Expect introspection counts to move, and check them deliberately.** Giving `IO::Path` a `Cool`
-  ancestor makes all ~90 `("Cool", …)` rows in `native_method_row_table.rs` visible to
-  `IO::Path.^can`/`.^methods` (Rakudo-correct — raku's `IO::Path.^can("chars")` is 1 where mutsu's
-  is 0), and enables `Cool::`-qualified coercion, which `methods_qualified.rs:87` gates on
-  `class_mro` containing `Cool`. `is_builtin_type_method` (`methods_classhow_lookup.rs:412-440`)
-  carries a comment recording a *past regression of exactly this shape* — a `Pair.^can(<cool
-  coercion>)` false positive caused by an unconditional `[type_name, "Cool", "Any", "Mu"]` ancestor
-  list. Re-read that comment before touching source 12.
+  **Introspection counts moved, and were checked deliberately.** Giving `IO::Path` a `Cool`
+  ancestor now makes the `("Cool", …)` rows in `native_method_row_table.rs` visible to
+  `IO::Path.^can`/`.^methods` (Rakudo-correct — `IO::Path.^can("chars")` is now 1 in mutsu, matching
+  raku, where it was 0 before). `is_builtin_type_method` (`methods_classhow_lookup.rs:412-440`)'s
+  comment records the past regression this could repeat: an unconditional
+  `[type_name, "Cool", "Any", "Mu"]` ancestor guess once made `Pair.^can(<cool coercion>)` a false
+  positive, because `Pair` genuinely does NOT inherit `Cool` in Rakudo. That function reads real
+  ancestors via `class_mro_readonly` first and only falls back to the unconditional guess when the
+  registry has no MRO at all for the type — P1 does not touch that fallback or `Pair`'s (unchanged,
+  `Cool`-free) catalog row, and `t/native-int-coerce-methods-are-cool-only.t` plus the new
+  regression test's `Pair` assertions both still pass, confirming the false-positive shape did not
+  reappear.
+
+- P2/P4/P5 below are unchanged from the original design and remain not started.
 
 - **P2 — Collapse the remaining sources onto the catalog.** Delete `Registry::builtin_mro_table`
   and the three hardcoded narrowness chains (sources 7-9); re-point `class_mro_readonly`,

--- a/src/builtins/builtin_type_catalog.rs
+++ b/src/builtins/builtin_type_catalog.rs
@@ -1,22 +1,23 @@
-//! Single static builtin-type MRO/roles catalog (ADR-0019 Phase E box E1a).
+//! Single static builtin-type MRO/roles catalog (ADR-0019 Phase E box E1a;
+//! promoted to the single ancestry oracle by ADR-0051 P1).
 //!
-//! Replaces (for the E1 classifier only — see `crate::runtime::receiver_class`) the
-//! four divergent builtin MRO tables surveyed in
-//! `todo/deep/adr0019-e1-typeid-receiver-owner.md`:
-//! [`super::builtin_type_methods::builtin_type_parents`],
+//! Originally replaced (for the E1 classifier only — see
+//! `crate::runtime::receiver_class`) four divergent builtin MRO tables surveyed
+//! in `todo/deep/adr0019-e1-typeid-receiver-owner.md`. One of those,
+//! `builtin_type_methods::builtin_type_parents`, has since been deleted
+//! (ADR-0051 P1): `classhow_mro_names` (`crate::runtime::methods_classhow_mro`)
+//! now reads this catalog directly instead. The other legacy tables —
 //! `Registry::builtin_mro_table` (`crate::runtime::registry`),
 //! `Interpreter::builtin_type_mro_chain` (`crate::runtime::methods_call_helpers`), and
-//! `builtin_type_distance`'s inline table (`crate::runtime::resolution_method`). Those
-//! four tables are left untouched by E1a (zero behavior change); this catalog is
-//! consulted only by the new shadow-mode classifier.
+//! `builtin_type_distance`'s inline table (`crate::runtime::resolution_method`) —
+//! are collapsed onto this catalog in ADR-0051 P2, not yet done.
 //!
-//! **Authority is raku, not the union of the four existing tables.** Every row below
+//! **Authority is raku, not the union of the legacy tables.** Every row below
 //! was captured from `raku -e 'say <Type>.^mro.map(*.^name); say <Type>.^roles.map(*.^name)'`
-//! (Rakudo 2026.06, this workstation) on 2026-08-10 — see
-//! `builtin_type_info_matches_raku` for the row-by-row pin. Known divergences from the
-//! four existing (possibly-wrong) mutsu tables are intentional and are *not* fixed in
-//! those tables here (E1a is shadow-only); they are called out in the E1a PR's
-//! accepted-mismatch ledger and are E1b's job to flip live.
+//! (Rakudo 2026.06, this workstation) on 2026-08-10 (and 2026-08-20 for the
+//! ADR-0051 P1 additions) — see `builtin_type_info_matches_raku` for the
+//! row-by-row pin. Known divergences from the legacy (possibly-wrong) mutsu
+//! tables are intentional and not yet fixed in those tables (P2's job).
 //!
 //! `roles` and `mro` are kept separate deliberately: `.^mro` in raku never contains a
 //! role, and role membership (`Positional`/`Associative`/`Callable`/`Numeric`/`Real`/
@@ -58,6 +59,11 @@ macro_rules! row {
 /// [`crate::runtime::utils::value_type_name`] or the four legacy MRO tables. Ordered
 /// roughly by family for reviewability; lookup is by name via [`builtin_type_info`].
 static CATALOG: &[BuiltinTypeInfo] = &[
+    // ---- Cool itself (ADR-0051 P1): previously registered nowhere -- `.^mro`
+    // for it was correct only by accident of `classhow_mro_names`' unregistered-
+    // type fallback (`vec![class_name]` plus the unconditional Any/Mu append).
+    // raku: `Cool.^mro` is `Cool, Any, Mu`; `Cool.^roles` is empty.
+    row!("Cool", mro: ["Cool", "Any", "Mu"], roles: [], owner: ""),
     // ---- Core Cool-derived scalars ----
     row!("Int", mro: ["Int", "Cool", "Any", "Mu"], roles: ["Real", "Numeric"], owner: "Int"),
     row!("Num", mro: ["Num", "Cool", "Any", "Mu"], roles: ["Real", "Numeric"], owner: "Num"),
@@ -432,6 +438,35 @@ static CATALOG: &[BuiltinTypeInfo] = &[
         roles: [],
         owner: "",
     ),
+    // ---- Temporal (ADR-0051 P1): `Instant`/`Duration` genuinely ARE `Cool` in
+    // raku (verified 2026-08-10/20: `Instant.^mro`/`Duration.^mro` are
+    // `(<Type> Cool Any Mu)`, `.^roles` is `(Real Numeric)`), but had no catalog
+    // row at all -- `receiver_class.rs`'s best-effort `[name, Any, Mu]` fallback
+    // was standing in for them, which is why `Instant ~~ Cool` (source 4's
+    // hand-verified allowlist) already answered `True` while `Instant.^mro`
+    // (this catalog, before this row existed) omitted `Cool` entirely.
+    row!(
+        "Instant",
+        mro: ["Instant", "Cool", "Any", "Mu"],
+        roles: ["Real", "Numeric"],
+        owner: "",
+    ),
+    row!(
+        "Duration",
+        mro: ["Duration", "Cool", "Any", "Mu"],
+        roles: ["Real", "Numeric"],
+        owner: "",
+    ),
+    // ---- IO::Path / IO::Handle (ADR-0051 P1) ----
+    // raku: `IO::Path.^mro` is `IO::Path, Cool, Any, Mu` (`.^roles` is `(IO)`),
+    // genuinely `Cool` -- unlike `IO::Handle`, which does NOT inherit `Cool`
+    // (`IO::Handle.^mro` is `IO::Handle, Any, Mu`, `.^roles` is empty). Both
+    // were previously registered ClassDefs read by `classhow_mro_names`'
+    // registry branch (not this catalog), so a catalog-only fix does not by
+    // itself correct `.^mro`; `IO::Path`'s bootstrap `ClassDef` in
+    // `runtime_init.rs` is fixed alongside this row.
+    row!("IO::Path", mro: ["IO::Path", "Cool", "Any", "Mu"], roles: ["IO"], owner: ""),
+    row!("IO::Handle", mro: ["IO::Handle", "Any", "Mu"], roles: [], owner: ""),
     // ---- IO::Spec family (Registry::builtin_mro_table; matches raku exactly) ----
     row!("IO::Spec", mro: ["IO::Spec", "Any", "Mu"], roles: [], owner: ""),
     row!(
@@ -625,6 +660,36 @@ mod tests {
             builtin_type_info("CArray").unwrap().mro,
             &["CArray", "Any", "Mu"]
         );
+    }
+
+    #[test]
+    fn adr0051_p1_rows_match_raku_exactly() {
+        // Pins the five rows added for ADR-0051 P1 against `raku -e
+        // 'say <Type>.^mro.map(*.^name); say <Type>.^roles.map(*.^name)'`
+        // (Rakudo 2026.06, verified 2026-08-20).
+        assert_eq!(
+            builtin_type_info("Cool").unwrap().mro,
+            &["Cool", "Any", "Mu"]
+        );
+        assert!(builtin_type_info("Cool").unwrap().roles.is_empty());
+
+        let instant = builtin_type_info("Instant").unwrap();
+        assert_eq!(instant.mro, &["Instant", "Cool", "Any", "Mu"]);
+        assert_eq!(instant.roles, &["Real", "Numeric"]);
+
+        let duration = builtin_type_info("Duration").unwrap();
+        assert_eq!(duration.mro, &["Duration", "Cool", "Any", "Mu"]);
+        assert_eq!(duration.roles, &["Real", "Numeric"]);
+
+        // `IO::Path` IS Cool; `IO::Handle` is NOT -- the two must not be
+        // conflated (this is the divergence the ADR calls out explicitly).
+        let io_path = builtin_type_info("IO::Path").unwrap();
+        assert_eq!(io_path.mro, &["IO::Path", "Cool", "Any", "Mu"]);
+        assert_eq!(io_path.roles, &["IO"]);
+
+        let io_handle = builtin_type_info("IO::Handle").unwrap();
+        assert_eq!(io_handle.mro, &["IO::Handle", "Any", "Mu"]);
+        assert!(io_handle.roles.is_empty());
     }
 
     #[test]

--- a/src/builtins/builtin_type_methods.rs
+++ b/src/builtins/builtin_type_methods.rs
@@ -224,28 +224,6 @@ pub(crate) fn builtin_type_attr_has_accessor(type_name: &str, _attr_name: &str) 
     matches!(type_name, "DateTime")
 }
 
-/// The built-in MRO (parent chain) for `type_name`, up to but not including
-/// `Any`/`Mu` (those are appended by the caller). Returns an empty slice for
-/// types with no modelled built-in hierarchy.
-pub(crate) fn builtin_type_parents(type_name: &str) -> &'static [&'static str] {
-    match type_name {
-        "Int" => &["Int", "Cool"],
-        "Num" => &["Num", "Cool"],
-        "Rat" | "FatRat" => &["Rat", "Cool"],
-        "Complex" => &["Complex", "Cool"],
-        "Str" => &["Str", "Cool"],
-        "Bool" => &["Bool", "Int", "Cool"],
-        "Array" => &["Array", "List", "Cool"],
-        "List" => &["List", "Cool"],
-        "Hash" => &["Hash", "Map", "Cool"],
-        "Map" => &["Map", "Cool"],
-        "Range" => &["Range", "Cool"],
-        "Seq" => &["Seq", "Cool"],
-        "Pair" => &["Pair"],
-        _ => &[],
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -400,24 +378,28 @@ mod tests {
     #[test]
     fn unmodelled_type_has_no_methods() {
         assert!(builtin_type_method_names("NoSuchType").is_empty());
-        assert!(builtin_type_parents("NoSuchType").is_empty());
     }
 
     #[test]
     fn every_builtin_mro_parent_resolves_to_a_known_chain() {
-        // Each parent named in a built-in MRO must itself be a type the registry
-        // recognises (either modelled here or a higher base like Cool/Map), so a
-        // walk never dead-ends on an unknown name.
+        // Each parent named in a built-in MRO (ADR-0051 P1: read from the
+        // catalog, the single source of truth for built-in type ancestry) must
+        // itself be a type the registry recognises (either modelled here or a
+        // higher base like Cool/Map), so a walk never dead-ends on an unknown
+        // name.
         let known = |name: &str| {
             matches!(name, "Cool" | "Map" | "Any" | "Mu")
-                || !builtin_type_parents(name).is_empty()
+                || crate::builtins::builtin_type_catalog::builtin_type_info(name).is_some()
                 || !builtin_type_method_names(name).is_empty()
         };
         for ty in [
             "Int", "Num", "Rat", "FatRat", "Complex", "Str", "Bool", "Array", "List", "Hash",
             "Map", "Range", "Seq", "Pair",
         ] {
-            for parent in builtin_type_parents(ty) {
+            let Some(info) = crate::builtins::builtin_type_catalog::builtin_type_info(ty) else {
+                continue;
+            };
+            for parent in info.mro {
                 assert!(known(parent), "MRO parent `{parent}` of `{ty}` is unknown");
             }
         }

--- a/src/runtime/methods_classhow_mro.rs
+++ b/src/runtime/methods_classhow_mro.rs
@@ -15,16 +15,15 @@ impl Interpreter {
                 .map(|s| s.resolve())
                 .collect()
         } else {
-            // Built-in type hierarchies for types that are not user-defined classes.
-            // Any/Mu are appended unconditionally below, so the table lists the
-            // chain up to (but not including) Any. The parent chains live in the
-            // single source of truth `builtins::builtin_type_methods`.
-            let builtin =
-                crate::builtins::builtin_type_methods::builtin_type_parents(class_name.as_str());
-            if builtin.is_empty() {
-                vec![class_name.clone()]
-            } else {
-                builtin.iter().map(|s| s.to_string()).collect()
+            // Built-in type hierarchies for types that are not user-defined
+            // classes. `builtin_type_catalog` (ADR-0051 P1) is the single source
+            // of truth for built-in type ancestry; its rows already include the
+            // full chain up to and including `Any`/`Mu` (the unconditional
+            // append below is a no-op for a catalog hit -- it only fires for a
+            // name the catalog does not model).
+            match crate::builtins::builtin_type_catalog::builtin_type_info(class_name.as_str()) {
+                Some(info) => info.mro.iter().map(|s| s.to_string()).collect(),
+                None => vec![class_name.clone()],
             }
         };
         // A grammar's MRO threads through Grammar -> Match -> Capture -> Cool.

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -678,7 +678,17 @@ impl Interpreter {
         classes.insert(
             "IO::Path".to_string(),
             ClassDef {
-                parents: Vec::new(),
+                // ADR-0051 P1: `IO::Path` genuinely IS `Cool` in raku
+                // (`IO::Path.^mro` is `IO::Path, Cool, Any, Mu`) -- the previous
+                // `parents: vec![]` / `mro: sym_mro(&["IO::Path"])` made `.^mro`
+                // dead-end at itself (worse, `class_mro_readonly` returns the
+                // cached `mro` field directly for a registered class, so leaving
+                // it non-empty here permanently short-circuited recomputation).
+                // Declaring the real parent and leaving `mro` empty lets
+                // `Registry::compute_class_mro`'s ordinary linearization compute
+                // and cache the correct `[IO::Path, Cool, Any, Mu]` chain the
+                // same way every other class gets its MRO.
+                parents: vec!["Cool".to_string()],
                 attributes: Vec::new(),
                 native_methods: [
                     "Str",
@@ -748,7 +758,10 @@ impl Interpreter {
                 .iter()
                 .map(|s| s.to_string())
                 .collect(),
-                mro: sym_mro(&["IO::Path"]),
+                // Left empty deliberately (ADR-0051 P1) -- see the `parents`
+                // comment above. `Registry::compute_class_mro` computes and
+                // caches `[IO::Path, Cool, Any, Mu]` here on first use.
+                mro: [].into(),
                 attribute_types: HashMap::new(),
                 attribute_smileys: HashMap::new(),
                 attribute_built: HashMap::new(),

--- a/t/adr0051-builtin-type-cool-ancestry.t
+++ b/t/adr0051-builtin-type-cool-ancestry.t
@@ -1,0 +1,72 @@
+use v6;
+use Test;
+
+# ADR-0051 P1: `builtin_type_catalog` becomes the single ancestry oracle for
+# built-in types, and `classhow_mro_names` (`.^mro`) is re-pointed at it
+# instead of the deleted `builtin_type_parents` table. `Instant`, `Duration`,
+# and `IO::Path` genuinely ARE `Cool` in Rakudo (`.^mro` includes it, and
+# `~~ Cool` answers True); mutsu's ancestry data previously omitted `Cool` from
+# all three -- for `Instant`/`Duration` this was even self-contradictory,
+# since `~~ Cool` already answered True (a separate hand-verified allowlist)
+# while `.^mro` disagreed with itself in the same process.
+#
+# `IO::Handle` and `Cool` itself are pinned as negative/identity controls:
+# `IO::Handle` does NOT inherit `Cool` in Rakudo (unlike its `IO::Path`
+# sibling -- the two must not be conflated), and `Cool.^mro` is `(Cool Any
+# Mu)` with no further ancestor.
+#
+# Every assertion below was dual-oracle verified against a real `raku`
+# (Rakudo 2026.06) on 2026-08-20.
+
+sub mro-names($type) { $type.^mro.map(*.^name).list }
+
+# --- Instant ---
+is-deeply mro-names(Instant), <Instant Cool Any Mu>, 'Instant.^mro includes Cool';
+ok Instant ~~ Cool, 'Instant ~~ Cool';
+ok +Instant.^can('abs'), 'Instant.^can("abs") is non-zero (Cool method visible)';
+my $i = now;
+ok $i.abs ~~ Instant, 'Instant.abs (a Cool/Real method) works and keeps the type';
+
+# --- Duration ---
+is-deeply mro-names(Duration), <Duration Cool Any Mu>, 'Duration.^mro includes Cool';
+ok Duration ~~ Cool, 'Duration ~~ Cool';
+ok +Duration.^can('abs'), 'Duration.^can("abs") is non-zero (Cool method visible)';
+my $d = now - now;
+ok $d.abs ~~ Duration, 'Duration.abs (a Cool/Real method) works and keeps the type';
+
+# --- IO::Path ---
+is-deeply mro-names(IO::Path), <IO::Path Cool Any Mu>, 'IO::Path.^mro includes Cool';
+ok IO::Path ~~ Cool, 'IO::Path ~~ Cool';
+ok +IO::Path.^can('chars'), 'IO::Path.^can("chars") is non-zero (Cool method visible)';
+my $p = "t/adr0051-builtin-type-cool-ancestry.t".IO;
+ok $p.chars > 0, 'IO::Path.chars (a Cool string-coercion method) works';
+
+# --- IO::Handle: negative control, does NOT inherit Cool ---
+is-deeply mro-names(IO::Handle), <IO::Handle Any Mu>, 'IO::Handle.^mro has no Cool';
+nok IO::Handle ~~ Cool, 'IO::Handle does NOT ~~ Cool';
+is +IO::Handle.^can('chars'), 0, 'IO::Handle.^can("chars") is zero (no Cool ancestor)';
+
+# --- Cool itself: identity control ---
+is-deeply mro-names(Cool), <Cool Any Mu>, 'Cool.^mro is (Cool Any Mu)';
+ok Cool ~~ Cool, 'Cool ~~ Cool';
+ok +Cool.^can('chars'), 'Cool.^can("chars") is non-zero (its own method)';
+
+# --- Match: pre-existing catalog row, must still be right after the re-point ---
+is-deeply mro-names(Match), <Match Capture Cool Any Mu>, 'Match.^mro is unaffected';
+ok Match ~~ Cool, 'Match ~~ Cool';
+
+# --- Pair: must NOT gain Cool -- the exact false-positive shape a past
+# regression hit (see `is_builtin_type_method`'s comment in
+# `methods_classhow_lookup.rs`), pinned here so a future ancestry change
+# cannot silently reintroduce it.
+is-deeply mro-names(Pair), <Pair Any Mu>, 'Pair.^mro has no Cool (unaffected regression guard)';
+nok Pair.new('a', 1) ~~ Cool, 'a Pair does NOT ~~ Cool';
+is +Pair.new('a', 1).^can('int8'), 0, 'Pair.^can("int8") stays zero (no Cool coercion leak)';
+
+# --- Plain class: still not Cool (P4's gate is out of scope for P1, but the
+# ancestry data itself must not regress a plain class into Cool).
+class G { }
+is-deeply mro-names(G), <G Any Mu>, 'a plain class has no Cool ancestor';
+nok G ~~ Cool, 'a plain class does NOT ~~ Cool';
+
+done-testing;


### PR DESCRIPTION
## Summary

Implements Phase P1 of ADR-0051 (`docs/adr/0051-type-ancestry-has-one-oracle-and-an-unresolved-method-throws.md`).

- Adds Rakudo-verified `builtin_type_catalog` rows for `Cool`, `Instant`, `Duration`, `IO::Path`, and `IO::Handle` (`.^mro`/`.^roles` each checked against a real `raku`).
- Re-points `classhow_mro_names`'s unregistered-type branch (`src/runtime/methods_classhow_mro.rs`) at the catalog instead of the deleted `builtin_type_parents` table (`src/builtins/builtin_type_methods.rs`), confirmed to have no non-test caller left.
- Fixes `IO::Path`'s bootstrap `ClassDef` (`src/runtime/runtime_init.rs`) to declare `parents: ["Cool"]` with `mro` left empty (the standard "not yet computed" convention), letting `Registry::compute_class_mro`'s existing `parent == "Cool"` arm linearize the chain the normal way. `IO::Handle` needed no `ClassDef` change since raku's `IO::Handle.^mro` does **not** include `Cool`.

Before this PR, `Instant.^mro`, `Duration.^mro`, and `IO::Path.^mro` all dead-ended at `[Type, Any, Mu]` -- missing `Cool` -- while `~~ Cool` for `Instant`/`Duration` already answered `True` via a separate, independently-maintained allowlist. That self-contradiction (same process, same type, two different answers) is gone after this PR.

P2 (collapsing the remaining ~9 ancestry tables onto this catalog) and P4 (the dispatch gate that makes an unresolved method throw instead of stringifying, e.g. `class G {}; G.new.uc`) are explicitly out of scope here, per the ADR.

## Regression check (past-regression shape)

`is_builtin_type_method` (`src/runtime/methods_classhow_lookup.rs:412-440`) carries a comment recording a past regression: an unconditional `[type_name, "Cool", "Any", "Mu"]` ancestor guess once made `Pair.^can(<cool coercion method>)` a false positive, because `Pair` genuinely does NOT inherit `Cool` in Rakudo. This PR does not touch that fallback or `Pair`'s catalog row (unchanged, still `Cool`-free); `t/native-int-coerce-methods-are-cool-only.t` and the new regression test's `Pair`/plain-class negative controls all still pass, confirming the false-positive shape did not reappear.

## Test plan

- [x] `cargo build`, `cargo clippy -- -D warnings`, `cargo fmt --check` all clean.
- [x] New test `t/adr0051-builtin-type-cool-ancestry.t` (25 assertions: `.^mro`, `~~ Cool`, and a representative Cool-method call for each of the 5 types, plus `Match`/`Pair`/a plain class as unaffected/negative controls) -- dual-oracle verified against a real `raku` (25/25 pass there too) and passes under mutsu.
- [x] New unit tests in `builtin_type_catalog.rs` pinning the 5 new rows.
- [x] Full `make test` (`t/` suite, 3275 files / 30438 tests): only pre-existing failure is `t/compunit-can-install.t` test 4, which is an **environment quirk unrelated to this change** -- this container's non-root user can `mkdir` directly at `/` (verified directly), which breaks that test's "a fake root path is non-writable" assumption. That test never touches type ancestry/MRO/Cool.
- [x] Targeted roast: all whitelisted `roast/S32-io/*.t` (IO::Path/IO::Handle heavy, 31+17 files), `roast/S02-types/instants-and-durations.t`, and the `S12-class`/`S12-introspection`/`S12-enums` files touching `.^mro`/`.^can` -- all pass.
- [x] `t/handles-wildcard-builtin-methods.t`, `t/can-ok-cool-bridging-methods.t`, `t/instant-duration-do-real.t`, `t/datetime-regressions.t`, `t/date-subclass-methods.t`, `t/augment-builtin-datetime.t` all still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)