### PR TITLE
fix: argument-list interpolation is a call-site property (ADR-0054 Slices 1-2)

### DIFF
--- a/docs/adr/0054-argument-list-interpolation-is-a-call-site-property.md
+++ b/docs/adr/0054-argument-list-interpolation-is-a-call-site-property.md
@@ -1,6 +1,6 @@
 # ADR-0054: Argument-list interpolation is a call-site property — retire blind Slip flattening
 
-- Status: Proposed (design complete; implementation not started)
+- Status: Accepted (Slices 1-2 implemented; Slices 3-6 remain)
 - Date: 2026-08-20
 - Origin: `todo/deep/blind-slip-flattening-in-fixed-arity-calls.md`
   (re-verified reproducing on `main` @ `b1a9bb8a5`, 2026-08-20; the
@@ -369,10 +369,55 @@ on the old behaviour via a compiled trampoline.
 
 ## 7. Implementation status
 
-- [ ] Slice 0 pins
-- [ ] Slice 1 compiler descriptor
-- [ ] Slice 2 function path
-- [ ] Slice 3 method / hyper paths
+- [x] Slice 0 pins — folded into the Slice 1/2 PR: `t/slip-arg-flatten.t` was
+  already the regression net; `t/slip-value-argument-is-one-argument.t` adds
+  the fixed-arity-callee matrix (§2.1/§2.2) this ADR set out to fix.
+- [x] Slice 1 compiler descriptor — `add_arg_sources_constant`
+  (`src/compiler/mod.rs`) gains the third entry shape (`Value::TRUE`) for a
+  `|EXPR` position; the `has_slip` branch in
+  `src/compiler/expr_call.rs` now feeds it instead of hardcoding `None`.
+  `decode_arg_slip_positions` (`src/vm/vm_call_helpers.rs`) decodes the
+  positions. Method/`CallOnValue`/`CallOnCodeVar` emission sites already called
+  `add_arg_sources_constant` unconditionally, so they picked up the new shape
+  for free; the four opcodes that don't carry `arg_sources_idx` yet
+  (`CallMethodDynamic`, `CallMethodDynamicMut`, `HyperMethodCall`,
+  `HyperMethodCallDynamic`) still don't — that part of Slice 3 is unstarted.
+- [x] Slice 2 function path — `spread_call_args_by_syntax`
+  (`src/vm/vm_call_helpers.rs`) replaces `flatten_call_args` (deleted) at the
+  three named sites (`vm_call_func_ops.rs`'s `CallFunc`/`CallOnValue`/
+  `CallOnCodeVar` handlers) **and** `exec_exec_call_op`'s `ExecCall` handler
+  (`vm_call_exec_ops.rs`), which had its own hand-duplicated blind-flatten loop
+  not mentioned by name in §4 but is the same mechanism (§1.2's consumer
+  table lists it alongside `CallFunc`) and is what a bare listop-style
+  statement call compiles to when the callee isn't in the statement-call
+  allowlist. The `val`-name special case and the length-mismatch
+  "lengths disagree -> drop the whole table" fallback are gone from these four
+  sites, replaced by the lockstep expansion `spread_call_args_by_syntax`
+  builds directly (one narrow post-sanitize length re-check remains in
+  `exec_call_on_code_var_op`, guarding only against the synthetic
+  callsite-line marker `sanitize_call_args_owned` can strip — not a
+  slip-alignment concern). `preserve_empty_slip_arg` itself is NOT deleted:
+  it's still called from the method paths (Slice 3), so removing it now would
+  break the build; it becomes single-caller once Slice 3 lands.
+  A latent dependency on the old *wider-than-spec* behaviour turned up in the
+  builtin `grep`/`map` listops (`src/runtime/builtins_collection_mapgrep.rs`):
+  both relied on the call op to have already flattened a Slip-valued list
+  argument, since their own item-flattening `match` had no `Slip` arm. Per
+  §2.3 a `Slip` must still flatten into their slurpy `+@list` regardless of
+  call-site syntax, so both now flatten a `Slip` argument unconditionally
+  (ahead of the `single_arg_rule` gate, since Slip flattening is not subject
+  to that rule) — this is a Slice 2 fix, not a regression of §2.3.
+  Acceptance verified: §2.1 and §2.2's function/listop/code-variable rows now
+  match `raku` (dual-oracle checked); `t/slip-arg-flatten.t` and every "must
+  stay green" file in §6 stay green without the allow-list.
+- [ ] Slice 3 method / hyper paths — next up. `vm_call_method_ops.rs:557`,
+  `vm_call_method_mut_ops.rs:49,372,579`, `vm_hyper_method_ops.rs:502` still
+  use `append_flattened_call_arg` unconditionally (blind value-shape
+  inference); `CallMethodDynamic`/`CallMethodDynamicMut`/`HyperMethodCall`/
+  `HyperMethodCallDynamic` still lack `arg_sources_idx`. The method row of
+  `t/slip-value-argument-is-one-argument.t` (`C.m(maybe(0))`) is pinned
+  `todo` pending this slice — dual-oracle confirmed it already passes under
+  `raku`.
 - [ ] Slice 4 constant collapse + cache gate
 - [ ] Slice 5 compiler dodge cleanup
 - [ ] Slice 6 internal-caller audit

--- a/src/compiler/expr_binary.rs
+++ b/src/compiler/expr_binary.rs
@@ -331,14 +331,26 @@ impl Compiler {
             && !name.starts_with(char::is_uppercase)
         {
             // Compile the slip arg (the capture variable) into a Slip value;
-            // CallFunc flattens it into the argument list.
+            // CallFunc spreads it via `arg_sources_idx` (ADR-0054: argument-list
+            // interpolation is a call-site property, not inferred from the
+            // runtime Slip shape). This mirrors the `|EXPR` handling in
+            // `compile_expr_call_inner` -- build the same synthetic
+            // `Expr::Unary { op: Pipe, .. }` so `add_arg_sources_constant`
+            // marks position 0 with the `|` sentinel (`Value::TRUE`) instead of
+            // leaving `arg_sources_idx: None`, which would make the spread-only
+            // call op treat the whole Slip as a single argument.
+            let slip_marker = Expr::Unary {
+                op: TokenKind::Pipe,
+                expr: Box::new(right.clone()),
+            };
+            let arg_sources_idx = self.add_arg_sources_constant(std::slice::from_ref(&slip_marker));
             self.compile_expr(right);
             self.code.emit(OpCode::MakeSlip);
             let name_idx = self.code.add_constant(Value::str(name.clone()));
             self.code.emit(OpCode::CallFunc {
                 name_idx,
                 arity: 1,
-                arg_sources_idx: None,
+                arg_sources_idx,
             });
             return;
         }

--- a/src/compiler/expr_call.rs
+++ b/src/compiler/expr_call.rs
@@ -1526,21 +1526,17 @@ impl Compiler {
                 return;
             }
             // Check for capture slip args (|c)
-            let has_slip = args.iter().any(|arg| {
-                matches!(
-                    arg,
-                    Expr::Unary {
-                        op: TokenKind::Pipe,
-                        ..
-                    }
-                )
-            });
+            let has_slip = args.iter().any(Self::is_slip_interpolation_arg);
             if has_slip {
                 // `|EXPR` interpolates into the argument list: MakeSlip builds
                 // the Slip and CallFunc spreads it, so any number of `|` args mix
                 // freely with the other arguments.
-                // `arg_sources_idx` stays None: spreading changes the argument
-                // count, so a positional source list could not stay aligned.
+                // ADR-0054: `arg_sources_idx` records the `|` positions
+                // (alongside any other args' rw sources) instead of being
+                // forced to None -- CallFunc's dispatch
+                // (`spread_call_args_by_syntax`) spreads exactly these
+                // positions, not every Slip-shaped runtime value.
+                let arg_sources_idx = self.add_arg_sources_constant(args);
                 for arg in args {
                     if let Expr::Unary {
                         op: TokenKind::Pipe,
@@ -1557,7 +1553,7 @@ impl Compiler {
                 self.code.emit(OpCode::CallFunc {
                     name_idx,
                     arity: args.len() as u32,
-                    arg_sources_idx: None,
+                    arg_sources_idx,
                 });
             } else {
                 let arity = args.len() as u32;

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -2256,14 +2256,27 @@ impl Compiler {
     fn compile_slurpy_out_args(&mut self, exprs: &[Expr]) {
         for expr in exprs {
             self.compile_expr(expr);
-            let is_pipe = matches!(
-                expr,
-                Expr::Unary { op, .. } if *op == crate::token_kind::TokenKind::Pipe
-            );
-            if !is_pipe {
+            if !Self::is_slip_interpolation_arg(expr) {
                 self.code.emit(OpCode::DeSlip);
             }
         }
+    }
+
+    /// Whether `expr` is a `|EXPR` argument-list interpolation marker.
+    ///
+    /// ADR-0054: this is the ONLY thing that makes an argument spread into
+    /// the caller's argument list. A `Slip` VALUE an ordinary argument
+    /// merely evaluates to (`f(@a.Slip)`) is one argument, not a spread
+    /// request — the compiler is the only place that can tell the two
+    /// apart, since by the time the VM sees the value the `|` is gone.
+    pub(super) fn is_slip_interpolation_arg(expr: &Expr) -> bool {
+        matches!(
+            expr,
+            Expr::Unary {
+                op: TokenKind::Pipe,
+                ..
+            }
+        )
     }
 
     fn positional_arg_source_name(expr: &Expr) -> Option<String> {
@@ -2329,6 +2342,17 @@ impl Compiler {
     fn add_arg_sources_constant(&mut self, args: &[Expr]) -> Option<u32> {
         let mut entries = Vec::with_capacity(args.len());
         for arg in args {
+            if Self::is_slip_interpolation_arg(arg) {
+                // ADR-0054 S1/S2 (third entry shape): a `|EXPR` position
+                // spreads into zero or more runtime arguments, so it carries
+                // no single traceable rw source -- mark it with a sentinel
+                // distinct from "no source" (`NIL`), `Str(name)` and
+                // `Pair(name, Int(slot))`. `decode_arg_sources` returns these
+                // positions so a call op can spread by call-site syntax
+                // instead of the argument's runtime Slip-shape.
+                entries.push(Value::TRUE);
+                continue;
+            }
             if let Expr::DoStmt(stmt) = arg
                 && let Stmt::VarDecl {
                     name,

--- a/src/runtime/builtins_collection_mapgrep.rs
+++ b/src/runtime/builtins_collection_mapgrep.rs
@@ -28,6 +28,13 @@ impl Interpreter {
         // `Digest::RIPEMD`'s `map -> [&a,$b,@c,$d] {...}, (...), (...)` bind.
         let single_arg_rule = args.len() <= 2;
         for (idx, arg) in args.iter().skip(1).enumerate() {
+            // ADR-0054 S2: a `Slip` ALWAYS flattens into a slurpy list
+            // context, regardless of `single_arg_rule` -- see the identical
+            // note in `builtin_grep`.
+            if let ValueView::Slip(items) = arg.view() {
+                list_items.extend(items.iter().cloned());
+                continue;
+            }
             if !single_arg_rule {
                 list_items.push(arg.clone());
                 continue;
@@ -156,6 +163,17 @@ impl Interpreter {
         // as `map` above: two or more list arguments are two or more elements.
         let single_arg_rule = args.len() <= 2;
         for arg in args.iter().skip(1) {
+            // ADR-0054 S2: a `Slip` ALWAYS flattens into a slurpy list
+            // context (`+@list`), regardless of how many other list
+            // arguments were given -- unlike Array/Seq, this is not gated by
+            // `single_arg_rule`. Call-site `|EXPR` spreading no longer
+            // pre-flattens an ordinary (non-`|`) Slip-valued argument before
+            // grep ever sees it, so grep must flatten it here itself, same
+            // as slurpy signature binding already does for user subs (§2.3).
+            if let ValueView::Slip(items) = arg.view() {
+                list_items.extend(items.iter().cloned());
+                continue;
+            }
             if !single_arg_rule {
                 list_items.push(arg.clone());
                 continue;

--- a/src/vm/vm_call_exec_ops.rs
+++ b/src/vm/vm_call_exec_ops.rs
@@ -17,26 +17,14 @@ impl Interpreter {
         }
         let start = self.stack.len() - arity;
         let raw_args: Vec<Value> = self.stack.drain(start..).collect();
-        // Flatten any Slip values in the argument list (from |capture slipping)
-        let mut args = Vec::new();
-        for arg in raw_args {
-            match arg.view() {
-                ValueView::Slip(items) => {
-                    for item in items.iter() {
-                        match item.view() {
-                            ValueView::Capture { positional, named } => {
-                                args.extend(positional.iter().cloned());
-                                for (k, v) in named.iter() {
-                                    args.push(Value::pair(k.clone(), v.clone()));
-                                }
-                            }
-                            _ => args.push(item.clone()),
-                        }
-                    }
-                }
-                _ => args.push(arg),
-            }
-        }
+        // ADR-0054 S2: spread only the positions the caller wrote as
+        // `|EXPR` -- decided by call-site syntax, not by a value merely
+        // evaluating to a Slip (e.g. `show maybe(0);` as a bare statement,
+        // where `maybe`'s tail `if` didn't fire and returned an Empty Slip,
+        // must pass exactly one argument).
+        let decoded_sources = self.decode_arg_sources(code, arg_sources_idx);
+        let (args, arg_sources) =
+            Self::spread_call_args_by_syntax(code, raw_args, arg_sources_idx, decoded_sources);
         // NativeCall: a statement-level call to an `is native(...)` sub compiles
         // to `ExecCall` (a bare call statement whose value is sunk), not
         // `CallFunc` — but only `CallFunc`'s handler checked `native_call_specs`.
@@ -74,12 +62,6 @@ impl Interpreter {
                 return Ok(());
             }
         }
-        let arg_sources = self.decode_arg_sources(code, arg_sources_idx);
-        let arg_sources = if arg_sources.as_ref().is_some_and(|s| s.len() != args.len()) {
-            None
-        } else {
-            arg_sources
-        };
         let args = self.normalize_call_args_for_target(&name, args);
         let (args, callsite_line) = self.sanitize_call_args_owned(args);
         // Auto-FETCH Proxy args for statement-level calls (same as CallFunc)

--- a/src/vm/vm_call_func_ops.rs
+++ b/src/vm/vm_call_func_ops.rs
@@ -776,20 +776,12 @@ impl Interpreter {
         }
         let start = self.stack.len() - arity;
         let raw_args: Vec<Value> = self.stack.drain(start..).collect();
-        // Flatten any Slip-valued argument (`|capture` slipping, or an ordinary
-        // argument that evaluated to a Slip).
-        let args = Self::flatten_call_args(&name, raw_args);
-        let arg_sources = self.decode_arg_sources(code, arg_sources_idx);
-        let arg_sources = if arg_sources.as_ref().is_some_and(|sources| {
-            sources.len() != args.len()
-                && !(args.is_empty()
-                    && sources.len() == 1
-                    && sources.first().is_some_and(|name| name.is_some()))
-        }) {
-            None
-        } else {
-            arg_sources
-        };
+        // ADR-0054 S2: spread only the positions the caller wrote as
+        // `|EXPR` -- decided by call-site syntax, not by a value merely
+        // evaluating to a Slip (`f(@a.Slip)` stays one argument).
+        let decoded_sources = self.decode_arg_sources(code, arg_sources_idx);
+        let (args, arg_sources) =
+            Self::spread_call_args_by_syntax(code, raw_args, arg_sources_idx, decoded_sources);
         let args = self.normalize_call_args_for_target(&name, args);
         let (args, callsite_line) = self.sanitize_call_args_owned(args);
         // Don't auto-FETCH Proxy args for control flow builtins that must preserve containers,
@@ -992,17 +984,11 @@ impl Interpreter {
         }
         let start = self.stack.len() - arity;
         let raw_args: Vec<Value> = self.stack.drain(start..).collect();
-        // Flatten any Slip values in the argument list (from |capture slipping)
-        let mut args = Vec::new();
-        for arg in raw_args {
-            Self::append_flattened_call_arg(&mut args, arg, false);
-        }
-        let arg_sources = self.decode_arg_sources(code, arg_sources_idx);
-        let arg_sources = if arg_sources.as_ref().is_some_and(|s| s.len() != args.len()) {
-            None
-        } else {
-            arg_sources
-        };
+        // ADR-0054 S2: spread only the `|EXPR` positions, decided by
+        // call-site syntax rather than a value's runtime Slip-shape.
+        let decoded_sources = self.decode_arg_sources(code, arg_sources_idx);
+        let (args, arg_sources) =
+            Self::spread_call_args_by_syntax(code, raw_args, arg_sources_idx, decoded_sources);
         let target = self.stack.pop().ok_or_else(|| {
             RuntimeError::new("Interpreter stack underflow in CallOnValue target".to_string())
         })?;
@@ -1057,19 +1043,23 @@ impl Interpreter {
         }
         let start = self.stack.len() - arity;
         let raw_args: Vec<Value> = self.stack.drain(start..).collect();
-        // Flatten any Slip values in the argument list (from |capture slipping)
-        let mut args = Vec::new();
-        for arg in raw_args {
-            Self::append_flattened_call_arg(&mut args, arg, false);
-        }
+        // ADR-0054 S2: spread only the `|EXPR` positions, decided by
+        // call-site syntax rather than a value's runtime Slip-shape.
+        let decoded_sources = self.decode_arg_sources(code, arg_sources_idx);
+        let (args, arg_sources) =
+            Self::spread_call_args_by_syntax(code, raw_args, arg_sources_idx, decoded_sources);
         let (args, callsite_line) = self.sanitize_call_args_owned(args);
-        loan_env!(self, set_pending_callsite_line(callsite_line));
-        let arg_sources = self.decode_arg_sources(code, arg_sources_idx);
+        // `sanitize_call_args_owned` may drop a synthetic callsite-line
+        // marker pair, shortening `args` by one relative to the just-aligned
+        // `arg_sources` -- re-check length here (mirrors the pre-ADR-0054
+        // guard) rather than in `spread_call_args_by_syntax`, which aligns
+        // against the pre-sanitize argument list.
         let arg_sources = if arg_sources.as_ref().is_some_and(|s| s.len() != args.len()) {
             None
         } else {
             arg_sources
         };
+        loan_env!(self, set_pending_callsite_line(callsite_line));
         // resolve_code_var handles pseudo-package stripping internally
         let mut target = loan_env!(self, resolve_code_var(&name));
         // A `&`-sigil binding may live only in this frame's LOCAL SLOT, never in

--- a/src/vm/vm_call_helpers.rs
+++ b/src/vm/vm_call_helpers.rs
@@ -97,7 +97,8 @@ impl Interpreter {
     /// The light-call / OTF caches bind the *compiled* arity directly against
     /// the stack, but a Slip argument spreads into the argument list and so
     /// changes that arity. Flattening lives on the slow dispatch path
-    /// (`flatten_call_args`), so a call carrying one must skip those caches.
+    /// (`spread_call_args_by_syntax`), so a call carrying one must skip those
+    /// caches.
     pub(super) fn stack_args_have_slip(&self, arity: usize) -> bool {
         self.stack.len() >= arity
             && self.stack[self.stack.len() - arity..]
@@ -138,25 +139,51 @@ impl Interpreter {
         out
     }
 
-    /// Flatten every Slip-valued argument of a call into the argument list.
+    /// Spread a call's raw arguments by call-site syntax (ADR-0054 S1/S2),
+    /// not by a value's runtime Slip-shape: only a position the compiler
+    /// recorded as `|EXPR` (`decode_arg_slip_positions`) spreads. Every other
+    /// argument -- including one that merely evaluated to a Slip
+    /// (`f(@a.Slip)`) -- stays exactly one argument, matching Raku (a `Slip`
+    /// is an ordinary `List` subtype, not a request to spread). This
+    /// replaces the old runtime-value-shape inference
+    /// (`append_flattened_call_arg` applied unconditionally to every
+    /// argument), which could not distinguish `f(|@a)` from `f(@a.Slip)`.
     ///
-    /// `|EXPR` compiles to `MakeSlip` + an ordinary argument, so this is what
-    /// makes argument-list interpolation happen, for any number of `|` args.
-    /// It also spreads a Slip that an ordinary argument merely evaluated to
-    /// (`f(@a.Slip)`) — Rakudo keeps that one intact until slurpy binding, so
-    /// this is wider than the spec; it is long-standing mutsu behaviour and
-    /// changing it is out of scope here.
-    pub(super) fn flatten_call_args(name: &str, raw_args: Vec<Value>) -> Vec<Value> {
-        // val() uses capture semantics (Mu |) — preserve Slip as a single arg.
-        if name == "val" {
-            return raw_args;
-        }
-        let preserve_empty_slip = Self::preserve_empty_slip_arg(name);
+    /// `decoded_sources` (from `decode_arg_sources`, over the SAME
+    /// pre-flatten positions as `arg_sources_idx`) is expanded in lockstep
+    /// with the returned args, so the two never desync: a spread position
+    /// has no single traceable rw source, so every runtime argument it
+    /// expands into gets `None` there.
+    pub(super) fn spread_call_args_by_syntax(
+        code: &CompiledCode,
+        raw_args: Vec<Value>,
+        arg_sources_idx: Option<u32>,
+        decoded_sources: Option<Vec<Option<String>>>,
+    ) -> (Vec<Value>, Option<Vec<Option<String>>>) {
+        let Some(slip_at) = Self::decode_arg_slip_positions(code, arg_sources_idx) else {
+            // No `|` argument recorded at this call site: nothing spreads.
+            return (raw_args, decoded_sources);
+        };
         let mut args = Vec::with_capacity(raw_args.len());
-        for arg in raw_args {
-            Self::append_flattened_call_arg(&mut args, arg, preserve_empty_slip);
+        let mut sources: Vec<Option<String>> = Vec::with_capacity(raw_args.len());
+        let mut has_source = false;
+        for (i, arg) in raw_args.into_iter().enumerate() {
+            if slip_at.contains(&i) {
+                let before = args.len();
+                Self::append_flattened_call_arg(&mut args, arg, false);
+                sources.extend(std::iter::repeat_n(None, args.len() - before));
+            } else {
+                let name = decoded_sources
+                    .as_ref()
+                    .and_then(|s| s.get(i))
+                    .cloned()
+                    .flatten();
+                has_source |= name.is_some();
+                args.push(arg);
+                sources.push(name);
+            }
         }
-        args
+        (args, if has_source { Some(sources) } else { None })
     }
 
     /// Auto-FETCH any Proxy values in function call arguments.
@@ -171,6 +198,12 @@ impl Interpreter {
         Ok(out)
     }
 
+    /// Decode the per-argument-position rw-source names baked by
+    /// `add_arg_sources_constant`. A `|EXPR` position (ADR-0054) is encoded
+    /// there as `Value::TRUE` rather than a name -- it falls through the
+    /// match below to `None` here, same as `NIL`; use
+    /// [`Self::decode_arg_slip_positions`] to recover which positions those
+    /// are.
     pub(super) fn decode_arg_sources(
         &mut self,
         code: &CompiledCode,
@@ -206,6 +239,34 @@ impl Interpreter {
             self.pending_call_arg_source_slots.insert(name, slot);
         }
         Some(names)
+    }
+
+    /// Positions this call wrote as `|EXPR` (ADR-0054 S1/S2), decoded from the
+    /// same descriptor array `decode_arg_sources` reads (a `|` position is
+    /// encoded there as `Value::TRUE`, distinct from `NIL` / `Str(name)` /
+    /// `Pair(name, Int(slot))`). Positions are pre-flatten: they index the
+    /// compiled argument list, i.e. exactly the arity the call op carries,
+    /// before any position's value is spread into zero or more runtime
+    /// arguments. `None` when there is no descriptor or no `|` argument.
+    pub(super) fn decode_arg_slip_positions(
+        code: &CompiledCode,
+        arg_sources_idx: Option<u32>,
+    ) -> Option<Vec<usize>> {
+        let idx = arg_sources_idx?;
+        let ValueView::Array(items, ..) = code.constants[idx as usize].view() else {
+            return None;
+        };
+        let positions: Vec<usize> = items
+            .iter()
+            .enumerate()
+            .filter(|(_, item)| matches!(item.view(), ValueView::Bool(true)))
+            .map(|(i, _)| i)
+            .collect();
+        if positions.is_empty() {
+            None
+        } else {
+            Some(positions)
+        }
     }
 
     pub(super) fn unwrap_var_ref_value(value: Value) -> Value {

--- a/t/slip-value-argument-is-one-argument.t
+++ b/t/slip-value-argument-is-one-argument.t
@@ -1,0 +1,75 @@
+use Test;
+
+# ADR-0054: argument-list interpolation is a call-site property, decided by
+# `|EXPR` syntax, never by a value's runtime Slip-shape. `t/slip-arg-flatten.t`
+# already pins this rule for the statement-call path and for callees with a
+# slurpy/list parameter; every case there binds into a slurpy, so it cannot
+# see a FIXED-arity callee mis-flatten. This file covers exactly that gap:
+# a routine whose tail conditional does not fire evaluates to `Empty` (a
+# `Slip`), and passing that result along as a plain (non-`|`) argument to a
+# fixed-arity routine must stay ONE argument, across the function, listop,
+# code-variable and method call forms (all dual-oracle verified against
+# `raku` first; see docs/adr/0054-argument-list-interpolation-is-a-call-site-property.md).
+
+sub maybe($x) { if $x { 42 } }
+
+# --- the dominant real-world shape: a non-firing tail `if` ---
+
+sub show($a) { $a.elems }
+
+# Function-call form (`f(...)`) -- compiles to CallFunc.
+is show(maybe(0)), 0, 'function call: Slip result of a non-firing if is one argument';
+
+# Listop-style form (no parens) -- a plain user sub still compiles through
+# the same Expr::Call path as the parenthesized form (Stmt::Call/ExecCall is
+# reserved for a narrow builtin/imported-function allowlist), so this is a
+# second observation of the same fix rather than a different mechanism --
+# kept as its own case because the ADR's motivating table lists it
+# separately.
+{
+    my $r = show maybe(0);
+    is $r, 0, 'listop-style call: Slip result of a non-firing if is one argument';
+}
+
+# Code-variable form (`&c(...)`) -- compiles to CallOnCodeVar.
+{
+    my &c = &show;
+    is c(maybe(0)), 0, 'code-variable call: Slip result of a non-firing if is one argument';
+}
+
+# --- the full §2.2 matrix for a fixed-arity callee ---
+
+sub g($a) { $a.elems }
+
+is g(Empty), 0, 'g(Empty): the empty Slip is one argument';
+{
+    my $r = g Empty;
+    is $r, 0, 'g Empty (listop-style): the empty Slip is one argument';
+}
+is g(().Slip), 0, 'g(().Slip): an ordinary Slip-valued argument is one argument';
+
+my @s = (1, 2);
+is g(@s.Slip), 2, 'g(@s.Slip): a non-empty Slip-valued argument stays one argument ($a.elems == 2)';
+
+my &gc = &g;
+is gc(Empty), 0, 'code-variable call: g(Empty) is one argument';
+is gc(@s.Slip), 2, 'code-variable call: g(@s.Slip) stays one argument';
+
+# --- `|EXPR` still spreads correctly (the OTHER half of the same rule) ---
+
+sub g2($a, $b) { "$a-$b" }
+is g2(|(1, 2)), '1-2', '|(...) spreads into a fixed 2-arity callee';
+is g2(|@s), '1-2', '|@array spreads into a fixed 2-arity callee';
+
+sub k(*@a) { @a.elems }
+is k(|@s), 2, '|@array spreads into a slurpy callee';
+is k(@s.Slip), 2, '@array.Slip flattens into a slurpy callee (slurpy binding is call-site independent, §2.3)';
+
+# --- method-call form: not yet fixed (ADR-0054 Slice 3) ---
+class C { method m($a) { $a.elems } }
+{
+    todo 'method dispatch does not yet spread by call-site syntax -- ADR-0054 Slice 3';
+    lives-ok { C.m(maybe(0)) }, 'method call: Slip result of a non-firing if is one argument';
+}
+
+done-testing;


### PR DESCRIPTION
## Summary
- Implements Slices 1-2 of [ADR-0054](docs/adr/0054-argument-list-interpolation-is-a-call-site-property.md): argument-list interpolation (`|EXPR`) is decided by call-site syntax, never by whether an argument's runtime value happens to be Slip-shaped.
- Slice 1 (encoding, no behaviour change): `add_arg_sources_constant` gains a third per-position entry shape (`Value::TRUE`) for a `|EXPR` position, emitted from the compiler's has-slip branch instead of forcing `arg_sources_idx: None`; `decode_arg_slip_positions` decodes it VM-side.
- Slice 2 (the fix): `spread_call_args_by_syntax` replaces the deleted `flatten_call_args` at the function/listop/code-variable call sites (`CallFunc`, `ExecCall`, `CallOnValue`, `CallOnCodeVar`) — only the recorded `|` positions spread; an ordinary argument that merely evaluates to a Slip (`f(@a.Slip)`) now stays exactly one argument, matching `raku`. The rw-source list is expanded in lockstep instead of being dropped on a length mismatch.
- Fixing this exposed a latent dependency in the builtin `grep`/`map` listops on the old wider-than-spec flattening (their own list-building logic had no `Slip` arm); both now flatten a `Slip` argument unconditionally, matching Raku's slurpy-independence rule (ADR §2.3).
- Method/hyper call dispatch (Slice 3) is unchanged in this PR — still uses the old blind inference — tracked in the ADR's updated implementation-status section and pinned as a `todo` case in the new test.

## Test plan
- [x] New `t/slip-value-argument-is-one-argument.t` (14 cases, dual-oracle verified against `raku`): function/listop-style/code-variable call forms for the `sub maybe($x) { if $x {...} }` shape, the full `g(Empty)`/`g(@s.Slip)`/`|(...)` matrix, and a `todo`-marked method-call case for Slice 3.
- [x] `t/slip-arg-flatten.t` (29 cases, the existing regression net) stays green.
- [x] All "must stay green" files from the ADR's test plan verified locally: `t/capture-slip.t`, `t/hash-spread-slip.t`, `t/multi-slip-otf.t`, `t/say-slip-nonflatten.t`, `t/await-slip-flatten.t`, `t/tail-stmt-call-named-value.t`, `t/pair-positional-arg.t`, `t/slip-array-of-pairs-is-positional.t`, `t/andthen-orelse-instance-rhs.t`, `t/andthen-roast-regressions.t`, `t/reduce-notandthen.t`, `t/hyper-method-slip-result.t`.
- [x] `make test` (full `t/` + `cargo test`): 853 Rust unit tests pass, 0 failed; only pre-existing/environment-specific `t/compunit-can-install.t` fails (this container owns `/`, unrelated to this change).
- [x] 30 whitelisted roast files touching `Slip`/splat verified locally on a release build (`MUTSU_FUDGE=1`): all pass.
- [x] `cargo clippy -- -D warnings` and `cargo fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
