### PR TITLE
ci: parallelize battery-testsuite.sh across batteries

### DIFF
--- a/scripts/battery-testsuite.sh
+++ b/scripts/battery-testsuite.sh
@@ -16,6 +16,7 @@
 #   BATTERIES_LOCK        manifest path (default: batteries.lock)
 #   BATTERIES_WHITELIST   baseline path (default: batteries-whitelist.txt)
 #   BATTERIES_EXCLUDE     exclusion list (default: batteries-exclude.txt)
+#   BATTERIES_JOBS        batteries to fetch+run concurrently (default: 4)
 #
 # The path overrides exist so the gate itself can be exercised against a
 # scratch manifest/baseline (e.g. to verify that a regression really does fail)
@@ -24,6 +25,17 @@
 # Exit status: 0 if every whitelisted file passes (gate mode) or the whitelist
 # was rewritten (update mode); non-zero if a whitelisted file regressed or setup
 # failed.
+#
+# Parallelism is across batteries only, never within one: each battery (fetch +
+# its whole file list) runs in its own background job, bounded by
+# BATTERIES_JOBS, but the files inside one battery still run one at a time, in
+# their original order — same as before this was parallelized. Upstream test
+# suites are written assuming a single serial `prove`/`zef test` run from their
+# own checkout and some write fixture output to fixed relative paths (e.g. a
+# scratch DB file); running two files of the SAME suite concurrently could
+# collide on such a path. Running two DIFFERENT batteries concurrently never
+# collides — they fetch into separate clone directories under $WORK — so that
+# axis is free to parallelize.
 set -u
 
 cd "$(dirname "$0")/.."
@@ -114,10 +126,128 @@ is_excluded() {
     | grep -qxF "$(printf '%s\t%s' "$1" "$2")"
 }
 
-rm -rf "$WORK"
-mkdir -p "$WORK"
+sanitize_name() {
+  printf '%s' "$1" | tr -c 'A-Za-z0-9._-' '_'
+}
 
-# Accumulate the freshly-observed pass set (for --update) and the gate verdict.
+rm -rf "$WORK"
+mkdir -p "$WORK/logs"
+
+BATTERIES_JOBS="${BATTERIES_JOBS:-4}"
+
+# --- run one whole battery (fetch + every one of its test files, in order) ---
+#
+# Writes two files instead of touching any shared state directly, so this can
+# run as a background job: $WORK/logs/<name>.log is the human-readable
+# transcript (identical in content/order to the old serial output for this
+# battery), and $WORK/logs/<name>.summary is one machine-readable line per
+# processed file (`PASS`/`FAIL`/`EXCLUDED`<TAB>name<TAB>base) plus a
+# `SETUP_FAILED` sentinel line when fetch or the glob failed. The dispatch loop
+# below reads both back, in the battery's original lock-file order, after all
+# jobs finish — so final stdout and the gate verdict are byte-for-byte the same
+# shape as the old fully-serial run, just computed concurrently.
+process_battery() {
+  local name="$1" bundled_lib="$2" test_url="$3" commit="$4" test_glob="$5" extra_includes="$6"
+  local san log summary
+  san="$(sanitize_name "$name")"
+  log="$WORK/logs/$san.log"
+  summary="$WORK/logs/$san.summary"
+  : > "$log"
+  : > "$summary"
+
+  {
+    echo "=== battery: $name (commit ${commit:0:12}) ==="
+
+    local clone="$WORK/$san"
+    if ! fetch_commit "$clone" "$test_url" "$commit"; then
+      echo "SETUP_FAILED" >> "$summary"
+      return
+    fi
+
+    # Build the -I list: the bundled library first, then any extra includes
+    # ({clone} expands to the fetched repo root; `-` means none). A `-`
+    # bundled_lib means the battery is provided NATIVELY by the interpreter —
+    # no library dir to include; the upstream suite still runs against the
+    # native implementation. (No current battery uses this; kept for future
+    # use.)
+    local inc=()
+    if [ "$bundled_lib" != "-" ]; then
+      inc=(-I "$ROOT/$bundled_lib")
+    fi
+    if [ "$extra_includes" != "-" ]; then
+      local extras=()
+      IFS=',' read -r -a extras <<< "$extra_includes"
+      local e
+      for e in "${extras[@]}"; do
+        e="${e//\{clone\}/$clone}"
+        case "$e" in
+          /*) inc+=(-I "$e") ;;
+          *)  inc+=(-I "$ROOT/$e") ;;
+        esac
+      done
+    fi
+
+    # test_glob may be a comma-separated list (a suite that mixes extensions,
+    # e.g. Cro::HTTP's t/*.rakutest plus one legacy t/*.t) — same convention as
+    # extra_includes above.
+    shopt -s nullglob
+    local files=()
+    local globs=()
+    IFS=',' read -r -a globs <<< "$test_glob"
+    local g
+    for g in "${globs[@]}"; do
+      files+=("$clone"/$g)
+    done
+    shopt -u nullglob
+    if [ "${#files[@]}" -eq 0 ]; then
+      echo "  warning: no test files matched '$test_glob'" >&2
+      echo "SETUP_FAILED" >> "$summary"
+      return
+    fi
+
+    local f base rel verdict rc
+    for f in "${files[@]}"; do
+      base="$(basename "$f")"
+      # Address the test relative to its own repo — run_one runs it from there.
+      rel="${f#"$clone"/}"
+      # Excluded files are not run at all, in either mode: their verdict
+      # depends on something outside this repository (see
+      # batteries-exclude.txt), so they can neither block a release nor enter
+      # the baseline.
+      if is_excluded "$name" "$base"; then
+        printf '  %-40s %s\n' "$base" "SKIP(excluded)"
+        printf 'EXCLUDED\t%s\t%s\n' "$name" "$base" >> "$summary"
+        continue
+      fi
+      verdict="$(run_one "$clone" "${inc[@]}" "$rel")"
+      rc=$?
+      printf '  %-40s %s\n' "$base" "$verdict"
+      if [ "$rc" -eq 0 ]; then
+        printf 'PASS\t%s\t%s\n' "$name" "$base" >> "$summary"
+      else
+        printf 'FAIL\t%s\t%s\n' "$name" "$base" >> "$summary"
+      fi
+    done
+  } > "$log" 2>&1
+}
+
+# Dispatch every battery as a background job, at most BATTERIES_JOBS at a time.
+mapfile -t ROWS < <(lock_rows)
+running=0
+for row in "${ROWS[@]}"; do
+  IFS=$'\t' read -r name bundled_lib test_url commit test_glob extra_includes <<< "$row"
+  [ -n "$name" ] || continue
+  process_battery "$name" "$bundled_lib" "$test_url" "$commit" "$test_glob" "$extra_includes" &
+  running=$((running + 1))
+  if [ "$running" -ge "$BATTERIES_JOBS" ]; then
+    wait -n
+    running=$((running - 1))
+  fi
+done
+wait
+
+# Accumulate the freshly-observed pass set (for --update) and the gate verdict,
+# by replaying each battery's log/summary in its original lock-file order.
 NEW_WHITELIST="$(mktemp)"
 REGRESSED=0
 SETUP_FAILED=0
@@ -125,82 +255,37 @@ TOTAL_PASS=0
 TOTAL_FILES=0
 TOTAL_EXCLUDED=0
 
-while IFS=$'\t' read -r name bundled_lib test_url commit test_glob extra_includes; do
+for row in "${ROWS[@]}"; do
+  IFS=$'\t' read -r name bundled_lib test_url commit test_glob extra_includes <<< "$row"
   [ -n "$name" ] || continue
-  echo "=== battery: $name (commit ${commit:0:12}) ==="
+  san="$(sanitize_name "$name")"
+  cat "$WORK/logs/$san.log"
 
-  clone="$WORK/$(printf '%s' "$name" | tr -c 'A-Za-z0-9._-' '_')"
-  if ! fetch_commit "$clone" "$test_url" "$commit"; then
-    SETUP_FAILED=1
-    continue
-  fi
-
-  # Build the -I list: the bundled library first, then any extra includes
-  # ({clone} expands to the fetched repo root; `-` means none). A `-`
-  # bundled_lib means the battery is provided NATIVELY by the interpreter —
-  # no library dir to include; the upstream suite still runs against the
-  # native implementation. (No current battery uses this; kept for future
-  # use.)
-  inc=()
-  if [ "$bundled_lib" != "-" ]; then
-    inc=(-I "$ROOT/$bundled_lib")
-  fi
-  if [ "$extra_includes" != "-" ]; then
-    IFS=',' read -r -a extras <<< "$extra_includes"
-    for e in "${extras[@]}"; do
-      e="${e//\{clone\}/$clone}"
-      case "$e" in
-        /*) inc+=(-I "$e") ;;
-        *)  inc+=(-I "$ROOT/$e") ;;
-      esac
-    done
-  fi
-
-  # test_glob may be a comma-separated list (a suite that mixes extensions,
-  # e.g. Cro::HTTP's t/*.rakutest plus one legacy t/*.t) — same convention as
-  # extra_includes below.
-  shopt -s nullglob
-  files=()
-  IFS=',' read -r -a globs <<< "$test_glob"
-  for g in "${globs[@]}"; do
-    files+=("$clone"/$g)
-  done
-  shopt -u nullglob
-  if [ "${#files[@]}" -eq 0 ]; then
-    echo "  warning: no test files matched '$test_glob'" >&2
-    SETUP_FAILED=1
-    continue
-  fi
-
-  for f in "${files[@]}"; do
-    base="$(basename "$f")"
-    # Address the test relative to its own repo — run_one runs it from there.
-    rel="${f#"$clone"/}"
-    # Excluded files are not run at all, in either mode: their verdict depends
-    # on something outside this repository (see batteries-exclude.txt), so they
-    # can neither block a release nor enter the baseline.
-    if is_excluded "$name" "$base"; then
-      printf '  %-40s %s\n' "$base" "SKIP(excluded)"
-      TOTAL_EXCLUDED=$((TOTAL_EXCLUDED + 1))
-      continue
-    fi
-    TOTAL_FILES=$((TOTAL_FILES + 1))
-    verdict="$(run_one "$clone" "${inc[@]}" "$rel")"
-    rc=$?
-    printf '  %-40s %s\n' "$base" "$verdict"
-    if [ "$rc" -eq 0 ]; then
-      TOTAL_PASS=$((TOTAL_PASS + 1))
-      printf '%s\t%s\n' "$name" "$base" >> "$NEW_WHITELIST"
-    fi
-    # Gate: a file listed in the whitelist MUST pass.
-    if [ "$MODE" = "gate" ] && [ -f "$WHITELIST" ] \
-       && grep -qxF "$(printf '%s\t%s' "$name" "$base")" "$WHITELIST" \
-       && [ "$rc" -ne 0 ]; then
-      echo "  REGRESSION: whitelisted $name/$base no longer passes" >&2
-      REGRESSED=1
-    fi
-  done
-done < <(lock_rows)
+  while IFS=$'\t' read -r kind fname fbase; do
+    case "$kind" in
+      SETUP_FAILED)
+        SETUP_FAILED=1
+        ;;
+      EXCLUDED)
+        TOTAL_EXCLUDED=$((TOTAL_EXCLUDED + 1))
+        ;;
+      PASS|FAIL)
+        TOTAL_FILES=$((TOTAL_FILES + 1))
+        if [ "$kind" = "PASS" ]; then
+          TOTAL_PASS=$((TOTAL_PASS + 1))
+          printf '%s\t%s\n' "$fname" "$fbase" >> "$NEW_WHITELIST"
+        fi
+        # Gate: a file listed in the whitelist MUST pass.
+        if [ "$MODE" = "gate" ] && [ -f "$WHITELIST" ] \
+           && grep -qxF "$(printf '%s\t%s' "$fname" "$fbase")" "$WHITELIST" \
+           && [ "$kind" != "PASS" ]; then
+          echo "  REGRESSION: whitelisted $fname/$fbase no longer passes" >&2
+          REGRESSED=1
+        fi
+        ;;
+    esac
+  done < "$WORK/logs/$san.summary"
+done
 
 LC_ALL=C sort -o "$NEW_WHITELIST" "$NEW_WHITELIST"
 


### PR DESCRIPTION
## Summary
- Follow-up to #6800. The "Bundled-library test suites" CI step (`scripts/battery-testsuite.sh`) ran all 36 bundled batteries fully serially -- fetch each upstream repo, then run its whole test file list -- and took ~6.5 min in a recent CI run, the job's second-biggest cost after the TAP suite.
- Parallelize ACROSS batteries only (bounded by a new `BATTERIES_JOBS`, default 4, matching the `-j4` pattern already used for roast/TAP): each battery's fetch + its own file list still runs sequentially, in its original order, inside one background job. Files WITHIN the same battery are never parallelized against each other, since upstream suites assume a single serial `prove`/`zef test` run from their own checkout and some write fixture output to fixed relative paths -- two files of the SAME suite could collide if run concurrently. Two different batteries never collide (separate clone directories), so that axis is safe to parallelize.
- Each battery now writes its transcript + per-file verdicts to `tmp/battery-testsuite/logs/<name>.{log,summary}` instead of updating shared counters directly (unsafe from a background job), then the main loop replays both back in the lock file's original order after all jobs finish -- so final stdout, the whitelist, and the gate verdict are the same shape as before.

## Test plan
- [x] A scratch-lock smoke test (7 small batteries: Base64, Digest, Digest::HMAC, Slangify, Slang::Tuxic, CBOR::Simple, Log::Timeline) confirms output ordering, gate pass, `--update` whitelist regeneration, and regression detection (artificially whitelisting a failing file) all match the pre-parallelization behavior.
- [x] Full run against the real `batteries.lock`/`batteries-whitelist.txt`/`batteries-exclude.txt`: `GATE PASSED` (247/271 pass, 2 excluded, no regressions) in 2:36 wallclock, versus the ~6:30 serial baseline.
- [ ] CI green on this PR (the `test` job's "Bundled-library test suites" step is the actual target environment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)