### PR TITLE
feat(compiler): reject placeholders in non-signature-capable blocks (ADR-0048 Phase 2)

### DIFF
--- a/docs/adr/0048-placeholder-scope-is-a-block-invocation-contract.md
+++ b/docs/adr/0048-placeholder-scope-is-a-block-invocation-contract.md
@@ -338,6 +338,47 @@ both backwards for `role` (over-rejects) and `module` (accepts). Classify
      the roast file staying whitelisted and a new case in
      `t/placeholder-scope-rejecting.t` asserting `repeat` still *accepts* a
      placeholder.
+   - **A method's implicit `*%_` (leftover named args) must stay usable
+     inside a nested `NoSignature` block, and the first CI run of this PR
+     broke exactly that.** `t/placeholder-named-in-method-do.t` already pins
+     that `%_` is valid anywhere in a method body, including nested in a
+     signature-less `do {}` — `compile_do_block_expr` has always exempted
+     `self.lexically_in_method && ph == "%_"` from its stray-placeholder
+     check. `Compiler::emit_block_placeholder_die` (the helper this phase
+     reuses for every other `NoSignature` construct) had no such exemption,
+     so `try {}`/`loop {}`/... newly rejected a legitimate `%_` inside a
+     method. This broke every DBIish battery test at once: `DBIish::
+     CommonTesting.connect-or-skip` (a method) calls `DBIish.connect(
+     $driver-name, |%_)` inside a `try {}`, so the bundled-library gate's
+     "Bundled-library test suites" CI job failed with every DBIish backend
+     collapsing to `ok=2/109` (including SQLite, which needs no live
+     server — proving it was not a service-availability issue) and the gate
+     reporting `REGRESSION` against the whitelist for every whitelisted
+     DBIish file. Root-caused by reproducing locally: `%_`/`@^`/`$^` weren't
+     even considered during the original `roast`/`modules`/`vendor` scan
+     above, because that scan only grepped for the caret sigil forms
+     (`$^`/`@^`/`%^`) — it missed the *implicit slurpy* placeholder forms
+     (`@_`/`%_`), which `collect_unattached_placeholders` also recognizes.
+     Fixed by adding the same `lexically_in_method && ph == "%_"` exemption
+     to `emit_block_placeholder_die` itself (so every call site gets it for
+     free), plus a parallel exemption in `supply_method_call`
+     (`src/parser/primary/ident/supply.rs`), which checks
+     `collect_unattached_placeholders` directly at *parse* time (no
+     `Compiler`/`lexically_in_method` available yet) rather than through the
+     shared helper — that one exempts `%_` unconditionally rather than only
+     inside a method, a deliberate (documented in that file) narrower gap:
+     `supply { %_ }` outside a method should reject per `raku` but no longer
+     does, versus the alternative of `supply { %_ }` inside a method
+     wrongly degrading into an eagerly-run `DoBlock` and breaking `supply`'s
+     async semantics. `@_` is not exempted anywhere (only a method gets an
+     implicit `*%_`, never `*@_`). Pinned by four new cases in
+     `t/placeholder-scope-rejecting.t` (method-context `%_` accepted inside
+     `try`/`loop`/`supply`, and non-method-context `%_` inside `try` still
+     rejecting) and by re-running the DBIish/SQLite battery files locally
+     (`44-sqlite-memory.rakutest` 108/109 — matching the pre-existing
+     baseline — and `25-mysql-common.rakutest`/`34-pg-types.rakutest`
+     gracefully SKIPping all subtests again, both previously collapsed to
+     `ok=2/109`).
    - **The oracle change alone was not sufficient.** `placeholder_body_kind`/
      `placeholder_body_kind_expr` reclassifying these to `NoSignature` only
      changes what the *shallow walks* (parameter collection, order/redeclare

--- a/docs/adr/0048-placeholder-scope-is-a-block-invocation-contract.md
+++ b/docs/adr/0048-placeholder-scope-is-a-block-invocation-contract.md
@@ -309,7 +309,7 @@ both backwards for `role` (over-rejects) and `module` (accepts). Classify
      `PlaceholderBodyKind::NoSignature` in `src/ast.rs` for the full
      explanation. Giving `do {}` a real `NoSignature` classification is left
      to whichever later phase untangles this interaction.
-2. **Rejecting set. LANDED (2026-08-21).** Flipped `loop` (headerless and
+2. **Rejecting set. LANDED (PR #6820, 2026-08-21).** Flipped `loop` (headerless and
    C-style — `repeat: false`), `try`, `react`, `once`, `default`, standalone
    `CATCH`/`CONTROL`, every `Stmt::Phaser` kind (`BEGIN`/`CHECK`/`INIT`/
    `ENTER`/`LEAVE`/`KEEP`/`UNDO`/`END`/`PRE`/`POST`), `gather`, and

--- a/docs/adr/0048-placeholder-scope-is-a-block-invocation-contract.md
+++ b/docs/adr/0048-placeholder-scope-is-a-block-invocation-contract.md
@@ -1,6 +1,6 @@
 # ADR-0048: Placeholder scope is a per-construct block-invocation contract, not a per-AST-arm boundary flag
 
-- Status: Accepted (P1 landed; P2-P5 not started)
+- Status: Accepted (P1, P2 landed; P3-P5 not started)
 - Date: 2026-08-20
 - Supersedes the framing of: `todo/deep/placeholder-scope-loop-while-block-boundaries.md`
   (and, transitively, the retired `todo/tickets/placeholder-scope-while-loop-not-a-boundary.md`)
@@ -309,15 +309,109 @@ both backwards for `role` (over-rejects) and `module` (accepts). Classify
      `PlaceholderBodyKind::NoSignature` in `src/ast.rs` for the full
      explanation. Giving `do {}` a real `NoSignature` classification is left
      to whichever later phase untangles this interaction.
-2. **Rejecting set.** Flip `loop`/`try`/`react`/`once`/`default`/phasers/
-   statement prefixes/`module` to `NoSignature`, reusing
-   `placeholder_scope_error("block", ph)`. Expect battery/roast fallout here.
+2. **Rejecting set. LANDED (2026-08-21).** Flipped `loop` (headerless and
+   C-style — `repeat: false`), `try`, `react`, `once`, `default`, standalone
+   `CATCH`/`CONTROL`, every `Stmt::Phaser` kind (`BEGIN`/`CHECK`/`INIT`/
+   `ENTER`/`LEAVE`/`KEEP`/`UNDO`/`END`/`PRE`/`POST`), `gather`, and
+   `module`/`package`/`grammar` (all three `PackageKind`s, not just `module`
+   — raku rejects all three identically) to reject with the same
+   `placeholder_scope_error("block", ph)`/`X::Placeholder::Block`
+   `do {}`'s existing rejection uses, via the shared
+   `Compiler::emit_block_placeholder_die` helper.
+   - **`repeat {} while/until` (`repeat: true`) is a same-AST-variant sibling
+     that must NOT be included, and an initial pass of this phase wrongly
+     lumped it in with `loop {}` before a roast-corpus scan caught it.**
+     `Stmt::Loop`'s `repeat: bool` field distinguishes headerless/C-style
+     `loop {}` from `repeat {} while/until` — both compile through the same
+     AST variant, but per the evidence table above, only the former is
+     `NoSignature`; `repeat` is signature-capable
+     (`ArgSupply::ConditionAfterFirstPass`, D4/Phase 4's territory) and
+     `raku` does not reject a placeholder inside one. This is exactly what
+     `roast/S04-statements/repeat.t`'s "placeholders and 'repeat while' mix"
+     subtest (from `old-issue-tracker/issues/1283`) pins — a corpus scan of
+     `roast/`/`modules/`/`vendor/` for `$^`/`@^`/`%^` usage directly inside
+     any of this phase's rejecting constructs turned up exactly this one
+     real hit (every other match was either legitimate — inside a nested
+     signature-capable block/closure/`where` — or already correctly
+     unaffected). Fixed by narrowing the `emit_block_placeholder_die` guard
+     (and the oracle classification) to `repeat: false` only; pinned by both
+     the roast file staying whitelisted and a new case in
+     `t/placeholder-scope-rejecting.t` asserting `repeat` still *accepts* a
+     placeholder.
+   - **The oracle change alone was not sufficient.** `placeholder_body_kind`/
+     `placeholder_body_kind_expr` reclassifying these to `NoSignature` only
+     changes what the *shallow walks* (parameter collection, order/redeclare
+     checks) do; it does not by itself make the compiler *reject* anything.
+     Landing this phase meant separately wiring `emit_block_placeholder_die`
+     (or the `collect_unattached_placeholders` check it wraps) into every
+     concrete place each construct's body is actually compiled — which, for
+     several of these constructs, turned out to be more than one place:
+     `BEGIN`/phasers in particular are compiled from up to 6 different call
+     sites (statement position via `compile_stmt`, tail/value position via
+     `compile_check_phaser_value` from three different callers, a top-level
+     mainline *hoisting* pre-pass in `run_toplevel_begin_phasers` that
+     bypasses the compiler's `Stmt::Phaser` wrapper entirely by pre-running
+     the unwrapped body through the tree-walk-era `eval_block_value`, and
+     `ENTER`/`LEAVE`/`KEEP`/`UNDO`/`PRE`/`POST` extraction inside
+     `compile_phaser_block_scope`/`compile_pre_phasers`/
+     `compile_post_phasers`). The fix pushes the check down into the
+     lowest-level shared primitives (`compile_check_phaser`,
+     `compile_check_phaser_value`, `compile_pre_phasers`,
+     `compile_post_phasers`, the `compile_phaser_block_scope` ENTER/LEAVE/
+     KEEP/UNDO loops, plus disqualifying a placeholder-bearing body from
+     top-level `BEGIN` hoisting) rather than guarding every call site
+     individually.
+   - **The statement-prefix group that desugars its body into a real closure
+     at PARSE time (`start`, `sink`, `supply`, `lazy`, `eager`) cannot be
+     classified via the oracle at all.** By the time `placeholder_body_kind_
+     expr` would run, `make_anon_sub` (for `start`/`sink`, via
+     `Expr::Call`) or the dedicated `supply`/`.lazy`/`Eager` builders have
+     already consumed a bare `{ $^c }` block's placeholder as that closure's
+     *own* signature parameter (`Expr::AnonSubParams`/`Expr::Lambda`), so
+     there is no `NoSignature`-shaped body left to classify — this is
+     exactly why Phase 1 kept `Expr::DoBlock` `Transparent` instead of
+     `NoSignature` (see the long note on `PlaceholderBodyKind::NoSignature`
+     in `src/ast.rs`), and the same interaction applies to this whole group.
+     Each of these five is instead rejected at its own compiler/parser call
+     site by re-deriving the same signal `make_anon_sub` used
+     (`collect_unattached_placeholders` on the closure's still-intact body)
+     and swapping in an `Expr::DoBlock`/direct
+     `emit_block_placeholder_die` call instead of compiling the closure:
+     `sink`/`start` in `src/compiler/expr_call.rs`, `.lazy`/`Eager` in
+     `src/compiler/expr.rs`, `supply` in
+     `src/parser/primary/ident/supply.rs` (the only one of the five handled
+     at parse time rather than compile time, because `supply {}` always
+     builds its own fixed-parameter `Expr::Lambda`, never an
+     `AnonSubParams`, so the placeholder is otherwise never looked at again).
+     `quietly {}` already had this exact `AnonSub`/`AnonSubParams` → `DoBlock`
+     pattern pre-existing (which is how it was already correct per the
+     evidence table); Phase 2 only had to extend `sink`'s matching arm to
+     cover `AnonSubParams` the same way.
+   - **Known gaps left for a follow-up, not blocking this phase:**
+     `race { }` (the bare, non-`for` statement-prefix form) has no dedicated
+     AST construct in mutsu at all — `race` parses as an ordinary bareword —
+     so it is unaddressed. `FIRST`/`NEXT`/`LAST`/`CLOSE` loop-scoped phasers
+     and a `CLOSE` phaser nested inside a `supply {}` block are extracted by
+     `expand_loop_phasers`/`rewrite_supply_stmt` into synthetic
+     `Stmt::Block`/closure shapes before ever reaching a `Stmt::Phaser`-typed
+     check, so a placeholder inside one of those specific four kinds still
+     leaks rather than rejecting. `PRE {}`/`POST {}` at the true top-level
+     mainline are not enforced by mutsu at all yet (a pre-existing gap
+     unrelated to this ADR — `PRE { False }` at the mainline does not die
+     either) so the placeholder check is correspondingly untestable there;
+     `t/placeholder-scope-rejecting.t` pins the sub-body form instead, where
+     `PRE`/`POST` are enforced and share the same primitive.
+   - Verified via a new `t/placeholder-scope-rejecting.t` (22 cases, one per
+     construct/kind) and a clean run of the full local `t/` suite (30788
+     tests; the only failure was the pre-existing, environment-specific
+     `t/compunit-can-install.t` test 4 already noted under Phase 1).
 3. **Shared bind emitter + arity error (D3).** Fixes multi-placeholder
    `if`/`given`, and `when` / bare `{}` via `ArgSupply::None`; retires the two
    ad-hoc bare-block strings.
 4. **`while`/`until`/`repeat` raw-condition supply (D4) and the signature
    clash (D5).**
-5. **Role/module classification (D7).**
+5. **Role classification (D7).** (`module`/`package`/`grammar` — the other
+   half of D7 — already landed in Phase 2 above.)
 
 ## Verification
 

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -2275,14 +2275,16 @@ pub(crate) enum PlaceholderBodyKind {
     /// No block of its own: descend, placeholders belong to the enclosing
     /// scope. Covers statement MODIFIERS (`if`/`for`/`given` with
     /// `is_statement_modifier: true`, which have no block at all — mirroring
-    /// the `For`/`Given` modifier rule below), and also `while`/`loop`/
-    /// `react`/bare `{}`-family statements/`when`/WhateverCode closures,
-    /// which mutsu currently (WRONGLY, per ADR-0048's raku audit) treats the
-    /// same way: they leak their placeholders to the enclosing scope instead
-    /// of raising `X::Placeholder::Block` or binding their own arity. Phase 1
-    /// is a pure refactor of the existing (partly wrong) behaviour into one
-    /// table; the wrong entries are corrected by ADR-0048's later phases, not
-    /// here.
+    /// the `For`/`Given` modifier rule below), and also `while`/bare
+    /// `{}`-family statements/`when`/`RoleDecl`/WhateverCode closures, which
+    /// mutsu currently (WRONGLY, per ADR-0048's raku audit) treats the same
+    /// way: they leak their placeholders to the enclosing scope (or, for
+    /// `RoleDecl`, over-reject) instead of matching raku's rule. Phase 1 was
+    /// a pure refactor of the existing (partly wrong) behaviour into one
+    /// table; Phase 2 corrected `loop`/`react`/`default`/`Catch`/`Control`/
+    /// `Phaser` (moved to `NoSignature`, see below); the remaining wrong
+    /// entries are corrected by ADR-0048's later phases (D3 for `when`/bare
+    /// `{}`'s *arity*, D7 for `RoleDecl`), not here.
     Transparent,
     /// A boundary that takes a signature; the construct supplies `ArgSupply`
     /// when it invokes its body. `if`/`elsif`/`unless`/`with`/`without`
@@ -2298,12 +2300,24 @@ pub(crate) enum PlaceholderBodyKind {
     /// classification.
     Signature(ArgSupply),
     /// A boundary that may not take a signature at all: a placeholder used
-    /// directly inside it is `X::Placeholder::Block`. No construct classifies
-    /// as this in Phase 1 (see the `DoBlock` note below); ADR-0048 Phase 2
-    /// moves `do {}` and more constructs (`loop`, `try`, `react`, `once`,
-    /// `default`, phasers, statement prefixes, `module`) into this variant,
-    /// reusing the `placeholder_scope_error("block", ph)` helper `do {}`'s
-    /// existing (separately-implemented) rejection already uses.
+    /// directly inside it is `X::Placeholder::Block`. `class`/`RoleDecl`
+    /// bodies fall to this variant via the catch-all below (RoleDecl is a
+    /// deliberate Phase-1 over-reject, corrected only in Phase 5/D7).
+    /// ADR-0048 Phase 2 moved `loop`, `try`, `react`, `once`, `default`,
+    /// `CATCH`/`CONTROL` (standalone, and `Stmt::Phaser`'s BEGIN/CHECK/INIT/
+    /// ENTER/END/PRE/POST kinds), `gather`, and `module`/`package`/`grammar`
+    /// into this variant too, each reusing the same
+    /// `placeholder_scope_error("block", ph)` helper `do {}`'s existing
+    /// (separately-implemented) rejection already used. The statement-prefix
+    /// group that desugars its body into a real closure at PARSE time
+    /// (`start`, `sink`, `supply`, `lazy`, `eager`) cannot be classified here
+    /// at all — by the time this oracle runs the placeholder has already been
+    /// consumed as that closure's own signature — so Phase 2 rejects those at
+    /// their compiler call sites instead (see the `emit_block_placeholder_die`
+    /// call sites in `src/compiler/expr_call.rs`/`expr.rs`/`supply.rs`), not
+    /// via this table. `race { }` (the bare, non-`for` statement-prefix form)
+    /// has no dedicated AST construct in mutsu at all yet — `race` parses as
+    /// an ordinary bareword, so it is left unaddressed by Phase 2.
     ///
     /// `do {}` (`Expr::DoBlock`) is *not* classified `NoSignature` here even
     /// though it already rejects a stray placeholder at runtime: that
@@ -2343,21 +2357,36 @@ pub(crate) fn placeholder_body_kind(stmt: &Stmt) -> PlaceholderBodyKind {
             ..
         } => PlaceholderBodyKind::Transparent,
         Stmt::For { .. } => PlaceholderBodyKind::Signature(ArgSupply::Elements),
-        Stmt::Loop { .. } | Stmt::React { .. } => PlaceholderBodyKind::Transparent,
+        // ADR-0048 Phase 2: `loop {}` (headerless and C-style) does not take
+        // a signature in raku — flip from the Phase-1 (wrong) `Transparent`
+        // classification to `NoSignature` via the catch-all below. `repeat
+        // {} while/until` (`repeat: true`) is a DIFFERENT construct that
+        // stays `Transparent` here: per the ADR's evidence table it IS
+        // signature-capable (`ArgSupply::ConditionAfterFirstPass` — `Mu` on
+        // the first pass, then the condition value), so it belongs with D4
+        // (Phase 4), not this rejecting set. Verified against `raku`:
+        // `repeat while $b < 10 { $tracker = $^a; $b++ }` does NOT reject
+        // `$^a` (pins `roast/S04-statements/repeat.t`'s "placeholders and
+        // 'repeat while' mix" subtest, which would otherwise regress).
+        Stmt::Loop { repeat: true, .. } => PlaceholderBodyKind::Transparent,
+        // `loop {}` (`repeat: false`, both headerless and C-style) and
+        // `react {}` fall through to the `NoSignature` catch-all below.
         // The `whenever` body is its own block scope, supplied the emitted
         // value (aliased as the topic) — but mutsu's shallow walks never
         // descend into it today (only the `supply` header is collected in
         // this scope), so this classification's practical effect in Phase 1
         // is identical to `NoSignature`: a boundary, body not visited here.
         Stmt::Whenever { .. } => PlaceholderBodyKind::Signature(ArgSupply::Topic),
-        Stmt::Block(_)
-        | Stmt::SyntheticBlock(_)
-        | Stmt::Default(_)
-        | Stmt::Catch(_)
-        | Stmt::Control(_)
-        | Stmt::RoleDecl { .. }
-        | Stmt::Phaser { .. }
-        | Stmt::When { .. } => PlaceholderBodyKind::Transparent,
+        // `Default`/`Catch`/`Control`/`Phaser` do not take a signature in
+        // raku either — ADR-0048 Phase 2 flips them to `NoSignature` via the
+        // catch-all below. `Block`/`SyntheticBlock` (the bare `{}` statement,
+        // D6) and `When` (D3) stay `Transparent`/pending later phases;
+        // `RoleDecl` stays `Transparent` too (a deliberate Phase-1
+        // over-reject via its own `emit_block_placeholder_die` call site —
+        // correcting it is Phase 5/D7, not here).
+        Stmt::Block(_) | Stmt::SyntheticBlock(_) | Stmt::RoleDecl { .. } | Stmt::When { .. } => {
+            PlaceholderBodyKind::Transparent
+        }
         Stmt::Given {
             is_statement_modifier: true,
             ..
@@ -2392,13 +2421,17 @@ pub(crate) fn placeholder_body_kind_expr(expr: &Expr) -> PlaceholderBodyKind {
         Expr::AnonSub { .. } | Expr::AnonSubParams { .. } | Expr::Lambda { .. } => {
             PlaceholderBodyKind::Signature(ArgSupply::CallerArgs)
         }
-        Expr::Block(_) | Expr::Gather(_) => PlaceholderBodyKind::Transparent,
+        // The bare `{}` term (D6, Phase 3) stays `Transparent`. `Gather`
+        // (`gather {}`) does NOT — ADR-0048 Phase 2 flips it to `NoSignature`
+        // via the catch-all below (raku: a placeholder inside `gather {}` is
+        // `X::Placeholder::Block`, not the enclosing block's own param).
+        Expr::Block(_) => PlaceholderBodyKind::Transparent,
         // Not `NoSignature` — see the long note on `PlaceholderBodyKind::NoSignature`
         // above: the chained-comparison desugar's synthetic `DoBlock` relies
         // on this leak to attach `$^p` to the enclosing block.
         Expr::DoBlock { .. } => PlaceholderBodyKind::Transparent,
-        Expr::Try { .. } => PlaceholderBodyKind::Transparent,
-        Expr::PhaserExpr { .. } | Expr::Once { .. } => PlaceholderBodyKind::Transparent,
+        // `Try`/`PhaserExpr`/`Once` do not take a signature in raku — ADR-0048
+        // Phase 2 flips them to `NoSignature` via the catch-all below.
         _ => PlaceholderBodyKind::NoSignature,
     }
 }

--- a/src/compiler/expr.rs
+++ b/src/compiler/expr.rs
@@ -540,6 +540,24 @@ impl Compiler {
                     self.compile_expr_method_generic(target, name, args, &None, false);
                 }
             }
+            // ADR-0048 Phase 2: `lazy {}` does not take a signature in raku.
+            // `lazy EXPR` parses to `EXPR.lazy` (see `parser/expr/postfix/
+            // loop_.rs`), so a bare `{ $^c }` operand reaches here as
+            // `target` already parsed into `AnonSubParams` — same shape and
+            // same reasoning as `Expr::Eager` above.
+            Expr::MethodCall {
+                target, name, args, ..
+            } if name.resolve().as_str() == "lazy"
+                && args.is_empty()
+                && matches!(target.as_ref(), Expr::AnonSubParams { .. }) =>
+            {
+                let Expr::AnonSubParams { body, .. } = target.as_ref() else {
+                    unreachable!()
+                };
+                if !self.emit_block_placeholder_die(body) {
+                    self.compile_expr_method_generic(target, name, args, &None, false);
+                }
+            }
             // Method call on non-variable target (no writeback needed)
             Expr::MethodCall {
                 target,
@@ -800,6 +818,11 @@ impl Compiler {
                 let op_idx = self.code.add_constant(Value::str(op.clone()));
                 self.code.emit(OpCode::Reduction(op_idx));
             }
+            // ADR-0048 Phase 2: a phaser-as-expression / `once {}` body does
+            // not take a signature in raku, same as its statement-form
+            // sibling.
+            Expr::PhaserExpr { body, .. } | Expr::Once { body }
+                if self.emit_block_placeholder_die(body) => {}
             // Phaser expression (INIT/CHECK/END as rvalue)
             Expr::PhaserExpr { kind, body } => {
                 self.compile_expr_phaser(kind, body);
@@ -825,6 +848,11 @@ impl Compiler {
             | Expr::InfixFunc { .. } => {
                 self.compile_expr_op(expr);
             }
+            // ADR-0048 Phase 2: `try {}` does not take a signature in raku.
+            // Only the try's OWN main body is checked here; a nested
+            // `CATCH`/`CONTROL` phaser body is checked separately inside
+            // `compile_try_region` after it is extracted.
+            Expr::Try { body, .. } if self.emit_block_placeholder_die(body) => {}
             Expr::Try { body, catch } => {
                 self.compile_try(body, catch);
             }
@@ -836,6 +864,10 @@ impl Compiler {
             Expr::DoStmt(stmt) => {
                 self.compile_expr_do_stmt(stmt);
             }
+            // ADR-0048 Phase 2: `gather {}` does not take a signature in raku
+            // (unlike the bare `{}` term/routine bodies): a `$^c` inside it
+            // is `X::Placeholder::Block`.
+            Expr::Gather(body) if self.emit_block_placeholder_die(body) => {}
             Expr::Gather(_) => {
                 if let Expr::Gather(body) = expr {
                     let idx = self.code.add_stmt(Stmt::Block(body.clone()));
@@ -848,7 +880,22 @@ impl Compiler {
                     self.code.emit(OpCode::MakeGather(idx, Some(cc_idx)));
                 }
             }
+            // ADR-0048 Phase 2: `eager {}` does not take a signature in raku.
+            // A bare `{ $^c }` operand is parsed (at parse time, before this
+            // oracle ever runs) directly into `Expr::AnonSubParams` with the
+            // placeholder already consumed as that closure's own parameter —
+            // so this cannot be caught via `placeholder_body_kind_expr`
+            // (there is no `Expr::Eager`-shaped body left to classify by the
+            // time compilation reaches it). Detect the same shape here
+            // instead: `inner`'s own body still literally contains the caret
+            // reference, so re-deriving it with `collect_unattached_placeholders`
+            // reconstructs the same signal `make_anon_sub` used at parse time.
             Expr::Eager(inner) => {
+                if let Expr::AnonSubParams { body, .. } = inner.as_ref()
+                    && self.emit_block_placeholder_die(body)
+                {
+                    return;
+                }
                 self.compile_expr(inner);
                 self.code.emit(OpCode::Eager);
             }

--- a/src/compiler/expr_call.rs
+++ b/src/compiler/expr_call.rs
@@ -1190,7 +1190,16 @@ impl Compiler {
         // sink: evaluate the expression (including calling blocks), discard result, push Nil
         else if name == "sink" && args.len() == 1 {
             match &args[0] {
-                Expr::AnonSub { body, .. } => {
+                // ADR-0048 Phase 2: `sink {}` does not take a signature in
+                // raku. A bare `{ $^c }` argument was parsed (before this
+                // point) directly into `AnonSubParams` with the placeholder
+                // already consumed as that closure's own parameter — mirror
+                // the plain `AnonSub` arm below (both route through
+                // `DoBlock`, which rejects a stray placeholder in its body)
+                // instead of falling to the generic `_` arm, which would
+                // compile it as a genuine arity-N closure and merely sink the
+                // closure *value* itself.
+                Expr::AnonSub { body, .. } | Expr::AnonSubParams { body, .. } => {
                     // sink { ... } -- execute the block body inline via do block
                     let do_block = Expr::DoBlock {
                         body: body.clone(),
@@ -1212,6 +1221,26 @@ impl Compiler {
                     self.code.emit(OpCode::LoadNil);
                 }
             }
+        }
+        // ADR-0048 Phase 2: `start {}` does not take a signature in raku. A
+        // bare `{ $^c }` argument was parsed (before this point) directly
+        // into `AnonSubParams` with the placeholder already consumed as that
+        // closure's own parameter, so `placeholder_body_kind_expr` never
+        // sees a `start`-shaped body to classify. Detect the same shape here
+        // instead — `body` still literally contains the caret reference, so
+        // re-deriving it with `collect_unattached_placeholders` reconstructs
+        // the signal `make_anon_sub` used at parse time — and die immediately
+        // rather than falling through to the generic `CallFunc` path below,
+        // which would otherwise compile it as a genuine arity-N closure and
+        // hand it to a thread. Only fires when a placeholder is actually
+        // present; a normal `start { ... }` (no placeholder, or an explicit
+        // `sub { ... }`/named closure argument, which stays `Expr::AnonSub`/
+        // some other shape) falls through unchanged.
+        else if name == "start"
+            && args.len() == 1
+            && let Expr::AnonSubParams { body, .. } = &args[0]
+            && self.emit_block_placeholder_die(body)
+        {
         }
         // quietly: suppress warnings raised while evaluating the expression, but
         // run it INLINE in the current scope (so `quietly my $x = ...` leaks $x),

--- a/src/compiler/expr_closure.rs
+++ b/src/compiler/expr_closure.rs
@@ -45,9 +45,19 @@ impl Compiler {
     /// signature-capable block), emit an `X::Placeholder::Block` die and return
     /// true. Used for class/role bodies, which do not take a signature.
     pub(super) fn emit_block_placeholder_die(&mut self, body: &[Stmt]) -> bool {
+        // A method always carries an implicit `*%_` (leftover named args),
+        // so `%_` is a valid lexical ANYWHERE in the method body -- including
+        // directly inside a nested NoSignature block (`try {}`, `loop {}`,
+        // ...), not just `do {}`. Mirrors the same exemption in
+        // `compile_do_block_expr` (`src/compiler/helpers_do_expr.rs`); see
+        // `t/placeholder-named-in-method-do.t` and the ADR-0048 Phase 2 fix
+        // this comment documents (DBIish's `DBIish::CommonTesting.
+        // connect-or-skip` calls `DBIish.connect($driver-name, |%_)` inside a
+        // `try {}`, which regressed without this exemption). `@_` is NOT
+        // exempted -- only a METHOD gets an implicit `*%_`, never `*@_`.
         if let Some(ph) = crate::ast::collect_unattached_placeholders(body)
             .into_iter()
-            .next()
+            .find(|ph| !(self.lexically_in_method && ph == "%_"))
         {
             let err = crate::method_signature_shared::placeholder_scope_error("block", &ph);
             let idx = self.code.add_constant(err);

--- a/src/compiler/helpers_control_flow.rs
+++ b/src/compiler/helpers_control_flow.rs
@@ -647,6 +647,25 @@ impl Compiler {
                 }
             }
         }
+        // ADR-0048 Phase 2: a standalone `CATCH {}`/`CONTROL {}` phaser body
+        // does not take a signature in raku. Checked here (after extraction
+        // from `body`, for both a genuine `try {}` and any other block that
+        // merely contains one of these phasers) rather than at the
+        // `Stmt::Catch`/`Stmt::Control` catch-all no-op arm in
+        // `compile_stmt`, since that arm is only reached for an orphan
+        // phaser this extraction never sees.
+        if let Some(ref catch_body) = catch_stmts
+            && self.emit_block_placeholder_die(catch_body)
+        {
+            self.pop_dynamic_scope_lexical(saved);
+            return;
+        }
+        if let Some(ref control_body) = control_stmts
+            && self.emit_block_placeholder_die(control_body)
+        {
+            self.pop_dynamic_scope_lexical(saved);
+            return;
+        }
         let has_explicit_catch = catch_stmts.is_some();
         let resume_safe = control_stmts
             .as_deref()

--- a/src/compiler/helpers_phasers.rs
+++ b/src/compiler/helpers_phasers.rs
@@ -4,6 +4,13 @@ impl Compiler {
     /// Compile a CHECK phaser body wrapped in error-catching logic.
     /// If the body throws, the error is wrapped in X::Comp::BeginTime.
     pub(super) fn compile_check_phaser(&mut self, body: &[Stmt]) {
+        // ADR-0048 Phase 2: BEGIN/CHECK do not take a signature in raku. This
+        // is the shared primitive both statement-position phaser kinds route
+        // through (see `stmt.rs`'s `Stmt::Phaser` arms), so the check lives
+        // here rather than at every caller.
+        if self.emit_block_placeholder_die(body) {
+            return;
+        }
         let start_idx = self.code.emit(OpCode::CheckPhaserStart { end_ip: 0 });
         // A `CATCH` in the phaser body handles that body's exceptions, including
         // ones thrown from a call inside it. Compiled inline into the enclosing
@@ -46,6 +53,15 @@ impl Compiler {
     /// true compile time (see `Compiler::compile_phaser_expr`), so it evaluates
     /// once at first use instead of once during parsing.
     pub(super) fn compile_check_phaser_value(&mut self, body: &[Stmt]) {
+        // ADR-0048 Phase 2: BEGIN does not take a signature in raku, whether
+        // in statement or (this function's) value/tail position — this is
+        // the shared primitive every tail-position `BEGIN` call site routes
+        // through (`helpers_block_inline.rs`, `helpers_control_flow.rs`,
+        // `helpers_sub_body.rs`), so the check lives here rather than at
+        // every caller.
+        if self.emit_block_placeholder_die(body) {
+            return;
+        }
         // Compiled exactly like the rvalue form (`Expr::PhaserExpr`), so a
         // statement-position `BEGIN` and an expression-position one share both
         // the value and the run-once contract: `BeginOnceExpr` memoizes the

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -3301,6 +3301,14 @@ impl Compiler {
                 body,
             } = s
             {
+                // ADR-0048 Phase 2: `ENTER {}` does not take a signature in
+                // raku. This function is the only place an ENTER body is
+                // compiled (extracted from the enclosing block's statement
+                // list before `compile_stmt` ever sees the wrapping
+                // `Stmt::Phaser`), so the check lives here.
+                if self.emit_block_placeholder_die(body) {
+                    continue;
+                }
                 if last_is_enter && i == last_idx {
                     // Compile so the body's final statement leaves its value on the
                     // stack, then move it onto the ENTER-result stack.
@@ -3409,8 +3417,12 @@ impl Compiler {
                         self.code.patch_leave_guard_next(pg);
                     }
                     let guard_idx = self.code.emit(OpCode::LeaveGuard { next: 0 });
-                    for inner in body {
-                        self.compile_stmt(inner);
+                    // ADR-0048 Phase 2: `LEAVE {}`/`KEEP {}` do not take a
+                    // signature in raku.
+                    if !self.emit_block_placeholder_die(body) {
+                        for inner in body {
+                            self.compile_stmt(inner);
+                        }
                     }
                     prev_guard = Some(guard_idx);
                 }
@@ -3430,8 +3442,12 @@ impl Compiler {
                         self.code.patch_leave_guard_next(pg);
                     }
                     let guard_idx = self.code.emit(OpCode::LeaveGuard { next: 0 });
-                    for inner in body {
-                        self.compile_stmt(inner);
+                    // ADR-0048 Phase 2: `LEAVE {}`/`UNDO {}` do not take a
+                    // signature in raku.
+                    if !self.emit_block_placeholder_die(body) {
+                        for inner in body {
+                            self.compile_stmt(inner);
+                        }
                     }
                     prev_guard = Some(guard_idx);
                 }

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -2599,6 +2599,22 @@ impl Compiler {
                     self.code.emit(OpCode::RestoreForParam);
                 }
             }
+            // ADR-0048 Phase 2: `loop {}` (headerless and C-style) does not
+            // take a signature in raku. `repeat: true` (`repeat {}
+            // while/until`) is deliberately EXCLUDED here — it is a
+            // different, signature-capable construct (D4/Phase 4; see the
+            // oracle's doc comment on `Stmt::Loop { repeat: true, .. }` in
+            // `src/ast.rs`) — matching real `raku`, which does NOT reject a
+            // placeholder in a `repeat` body
+            // (`roast/S04-statements/repeat.t`'s "placeholders and 'repeat
+            // while' mix" subtest). Guard placed before both real
+            // `Stmt::Loop` arms (this one and the repeat-loop arm further
+            // below), mirroring the existing `ClassDecl`/`RoleDecl` pattern.
+            Stmt::Loop {
+                body,
+                repeat: false,
+                ..
+            } if self.emit_block_placeholder_die(body) => {}
             // C-style loop (non-repeat, no phasers)
             Stmt::Loop {
                 init,
@@ -3149,6 +3165,12 @@ impl Compiler {
                 }
                 self.code.patch_body_end(when_idx);
             }
+            // ADR-0048 Phase 2: `default {}` does not take a signature in
+            // raku (`$^c` used directly inside one is `X::Placeholder::Block`,
+            // even though `default` itself binds the topic). Guard placed
+            // before the real `Stmt::Default` arm below, mirroring the
+            // existing `ClassDecl`/`RoleDecl` pattern.
+            Stmt::Default(body) if self.emit_block_placeholder_die(body) => {}
             Stmt::Default(body) => {
                 let default_idx = self.code.emit(OpCode::Default { body_end: 0 });
                 let block_local_idx = Self::branch_declares_block_local(body).then(|| {
@@ -3314,6 +3336,8 @@ impl Compiler {
                 self.code.emit(OpCode::Take);
             }
 
+            // ADR-0048 Phase 2: `react {}` does not take a signature in raku.
+            Stmt::React { body } if self.emit_block_placeholder_die(body) => {}
             // --- React: event loop scope ---
             Stmt::React { body } => {
                 let idx = self.code.emit(OpCode::ReactScope { body_end: 0 });
@@ -3323,6 +3347,9 @@ impl Compiler {
                 self.code.patch_body_end(idx);
             }
 
+            // ADR-0048 Phase 2: `module`/`package`/`grammar` bodies do not
+            // take a signature in raku (unlike `role`, D7/Phase 5).
+            Stmt::Package { body, .. } if self.emit_block_placeholder_die(body) => {}
             // --- Package scope ---
             Stmt::Package {
                 name,
@@ -3424,6 +3451,16 @@ impl Compiler {
                 }
             }
 
+            // ADR-0048 Phase 2: no phaser body takes a signature in raku
+            // (`$^c` inside `BEGIN`/`ENTER`/`LEAVE`/`CONTROL`/`CATCH`/... is
+            // `X::Placeholder::Block`). This covers every `Stmt::Phaser` kind
+            // that reaches `compile_stmt` directly (BEGIN/CHECK/INIT/ENTER at
+            // top level/END/PRE/POST, per the arms below); LEAVE/KEEP/UNDO/
+            // FIRST/NEXT/LAST/CLOSE are extracted and compiled elsewhere
+            // (`helpers_block_inline.rs`, `expand_loop_phasers`) before ever
+            // reaching this match, so they are not covered by this guard —
+            // left as a known gap for a follow-up.
+            Stmt::Phaser { body, .. } if self.emit_block_placeholder_die(body) => {}
             // --- Phaser (BEGIN/CHECK/INIT) ---
             // These are extracted before compilation by extract_check_init_phasers()
             // and run in the correct order. If one remains (e.g. inside a sub body),
@@ -4388,6 +4425,14 @@ impl Compiler {
                 body,
             } = s
             {
+                // ADR-0048 Phase 2: `PRE {}` does not take a signature in
+                // raku. This helper is the only place a PRE body is compiled
+                // (extracted from the enclosing block's statement list by
+                // `compile_phaser_block_scope` before `compile_stmt` ever
+                // sees the wrapping `Stmt::Phaser`), so the check lives here.
+                if compiler.emit_block_placeholder_die(body) {
+                    continue;
+                }
                 // Compile the PRE body as a block expression that produces a value
                 for (i, inner) in body.iter().enumerate() {
                     if i == body.len() - 1 {
@@ -4421,6 +4466,11 @@ impl Compiler {
                 body,
             } = s
             {
+                // ADR-0048 Phase 2: `POST {}` does not take a signature in
+                // raku — same reasoning as `compile_pre_phasers` above.
+                if compiler.emit_block_placeholder_die(body) {
+                    continue;
+                }
                 for (i, inner) in body.iter().enumerate() {
                     if i == body.len() - 1 {
                         match inner {

--- a/src/parser/primary/ident/supply.rs
+++ b/src/parser/primary/ident/supply.rs
@@ -15,7 +15,24 @@ pub(crate) fn supply_method_call(body: Vec<Stmt>) -> Expr {
     // `X::Placeholder::Block`, instead of building the on-demand Lambda
     // (which would otherwise silently let `$^c` read `Any` at runtime, since
     // nothing ever binds it).
-    if !crate::ast::collect_unattached_placeholders(&body).is_empty() {
+    //
+    // `%_` (a method's implicit `*%_` for leftover named args) is exempted
+    // from this parse-time check even outside a method: a legitimate
+    // `supply { ...; %_ ... }` inside a method body (e.g. DBIish-style
+    // `method connect-or-skip { supply { ...|%_... } }`) must still build the
+    // real on-demand Lambda, not degrade to an eagerly-run `DoBlock` that
+    // breaks `supply`'s async semantics. Whether `%_` is genuinely valid here
+    // depends on `self.lexically_in_method`, which does not exist yet at
+    // parse time -- `compile_do_block_expr`'s own `%_`-in-method check is the
+    // real enforcement for the (rare) non-method case where this exemption is
+    // too permissive, since a stray `Expr::DoBlock` produced by *this* check
+    // for a genuine `$^`/`@_` placeholder still reaches that check normally.
+    // `@_` is NOT exempted here -- only a METHOD gets an implicit `*%_`,
+    // never `*@_`.
+    if crate::ast::collect_unattached_placeholders(&body)
+        .into_iter()
+        .any(|ph| ph != "%_")
+    {
         return Expr::DoBlock { body, label: None };
     }
     // Each `supply { ... }` block gets a UNIQUE emitter variable name. The

--- a/src/parser/primary/ident/supply.rs
+++ b/src/parser/primary/ident/supply.rs
@@ -5,6 +5,19 @@ use crate::symbol::Symbol;
 static SUPPLY_EMITTER_COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
 
 pub(crate) fn supply_method_call(body: Vec<Stmt>) -> Expr {
+    // ADR-0048 Phase 2: `supply {}` does not take a signature in raku. Unlike
+    // `start`/`sink` (which wrap their body via `make_anon_sub`, consuming a
+    // stray placeholder as that closure's own parameter), `supply {}` always
+    // builds its own `Expr::Lambda` below with a fixed (non-placeholder)
+    // parameter — the emitter — so a `$^c` written in the source body is
+    // still literally present here. Detect it directly and hand back a
+    // `DoBlock`, whose compiler already rejects a stray placeholder with
+    // `X::Placeholder::Block`, instead of building the on-demand Lambda
+    // (which would otherwise silently let `$^c` read `Any` at runtime, since
+    // nothing ever binds it).
+    if !crate::ast::collect_unattached_placeholders(&body).is_empty() {
+        return Expr::DoBlock { body, label: None };
+    }
     // Each `supply { ... }` block gets a UNIQUE emitter variable name. The
     // emitter is bound as the on-demand lambda's parameter and `emit` is
     // rewritten to `$emitter.emit(...)`. A shared name would be clobbered when

--- a/src/runtime/run_prelude.rs
+++ b/src/runtime/run_prelude.rs
@@ -564,6 +564,16 @@ impl Interpreter {
         if has_decl {
             return false;
         }
+        // ADR-0048 Phase 2: a top-level BEGIN whose body uses a `$^name`
+        // placeholder must reach the normal compile path (which rejects it
+        // with `X::Placeholder::Block`) rather than being pre-run here via
+        // `eval_block_value` — that re-entrant evaluator compiles `body`
+        // directly (the `Stmt::Phaser` wrapper this check normally hangs off
+        // is already gone by the time it runs), so it would silently accept
+        // the placeholder as an ordinary bareword instead of rejecting it.
+        if !crate::ast::collect_unattached_placeholders(body).is_empty() {
+            return false;
+        }
         let debug = format!("{body:?}");
         !debug.contains("BareWord(") && !debug.contains("Call")
     }

--- a/t/placeholder-scope-rejecting.t
+++ b/t/placeholder-scope-rejecting.t
@@ -1,0 +1,95 @@
+use Test;
+
+plan 22;
+
+# ADR-0048 Phase 2: constructs whose body may NOT take a signature.
+# `raku` gives the exact same `X::Placeholder::Block` for all of these
+# ("Placeholder variable '$^c' may not be used here because the surrounding
+# block does not take a signature."), verified against real `raku` when this
+# ADR was written (docs/adr/0048-placeholder-scope-is-a-block-invocation-contract.md,
+# "Constructs whose body may not take a signature"). Each case here pins one
+# row of that table.
+
+throws-like 'loop { $^c; last }', X::Placeholder::Block,
+    'loop {} (headerless) rejects a placeholder';
+
+throws-like 'loop (my $i = 0; $i < 3; $i++) { $^c }', X::Placeholder::Block,
+    'loop {} (C-style) rejects a placeholder';
+
+# `repeat {} while/until` is NOT part of this phase's rejecting set -- unlike
+# headerless/C-style `loop {}`, raku's own evidence table classifies it as
+# signature-capable (Mu on the first pass, then the condition value; ADR-0048
+# D4/Phase 4 implements the actual binding later). Pin the accepting behavior
+# here so a future change does not accidentally lump it in with `loop {}` --
+# `raku` itself does not reject this
+# (roast/S04-statements/repeat.t's "placeholders and 'repeat while' mix").
+{
+    my $b = 1;
+    my $tracker;
+    repeat while $b < 10 {
+        $tracker = $^a;
+        $b++;
+    }
+    ok $tracker === True, 'repeat/while still accepts a placeholder (not part of this phase)';
+}
+
+throws-like 'try { $^c }', X::Placeholder::Block,
+    'try {} rejects a placeholder';
+
+throws-like 'react { $^c; done }', X::Placeholder::Block,
+    'react {} rejects a placeholder';
+
+throws-like 'once { $^c }', X::Placeholder::Block,
+    'once {} rejects a placeholder';
+
+throws-like 'given 1 { default { $^c } }', X::Placeholder::Block,
+    'default {} rejects a placeholder';
+
+throws-like 'try { die "x"; CATCH { $^c } }', X::Placeholder::Block,
+    'standalone CATCH {} rejects a placeholder';
+
+throws-like 'try { die "x"; CONTROL { $^c } }', X::Placeholder::Block,
+    'standalone CONTROL {} rejects a placeholder';
+
+throws-like 'BEGIN { $^c }', X::Placeholder::Block,
+    'BEGIN {} rejects a placeholder (mainline, hoisted)';
+
+throws-like 'sub f { BEGIN { $^c } }; f()', X::Placeholder::Block,
+    'BEGIN {} rejects a placeholder (routine tail position)';
+
+throws-like 'CHECK { $^c }', X::Placeholder::Block,
+    'CHECK {} rejects a placeholder';
+
+throws-like 'INIT { $^c }', X::Placeholder::Block,
+    'INIT {} rejects a placeholder';
+
+# PRE {}/POST {} at the true mainline are not currently enforced at all by
+# mutsu (a pre-existing gap unrelated to ADR-0048 -- `PRE { False }` at the
+# mainline does not die), so this pins the sub-body form instead, where PRE
+# is enforced and reaches the same `compile_pre_phasers` primitive.
+throws-like 'sub f { PRE { $^c }; 1 }; f()', X::Placeholder::Block,
+    'PRE {} rejects a placeholder (sub body)';
+
+throws-like 'my @r = gather { $^c; take 1 }', X::Placeholder::Block,
+    'gather {} rejects a placeholder';
+
+throws-like 'module M { $^c }', X::Placeholder::Block,
+    'module {} rejects a placeholder';
+
+throws-like 'package P { $^c }', X::Placeholder::Block,
+    'package {} rejects a placeholder';
+
+throws-like 'grammar G { $^c }', X::Placeholder::Block,
+    'grammar {} rejects a placeholder';
+
+throws-like 'supply { $^c }', X::Placeholder::Block,
+    'supply {} rejects a placeholder';
+
+throws-like 'start { $^c }', X::Placeholder::Block,
+    'start {} rejects a placeholder';
+
+throws-like 'sink { $^c }', X::Placeholder::Block,
+    'sink {} rejects a placeholder';
+
+throws-like 'my $x = lazy { $^c; 1 }; $x[0]', X::Placeholder::Block,
+    'lazy {} rejects a placeholder';

--- a/t/placeholder-scope-rejecting.t
+++ b/t/placeholder-scope-rejecting.t
@@ -1,6 +1,6 @@
 use Test;
 
-plan 22;
+plan 26;
 
 # ADR-0048 Phase 2: constructs whose body may NOT take a signature.
 # `raku` gives the exact same `X::Placeholder::Block` for all of these
@@ -93,3 +93,50 @@ throws-like 'sink { $^c }', X::Placeholder::Block,
 
 throws-like 'my $x = lazy { $^c; 1 }; $x[0]', X::Placeholder::Block,
     'lazy {} rejects a placeholder';
+
+# A method always carries an implicit `*%_` (leftover named args), so `%_` is
+# a valid lexical ANYWHERE in the method body -- including directly inside a
+# nested NoSignature block, not just `do {}` (see
+# t/placeholder-named-in-method-do.t for the do{}-specific pin). This
+# regressed during ADR-0048 Phase 2 development: DBIish's
+# `DBIish::CommonTesting.connect-or-skip` calls
+# `DBIish.connect($driver-name, |%_)` inside a `try {}`, and an
+# over-broad rejection there took down every DBIish battery test (`ok=2/109`
+# across every backend, including SQLite which needs no live server) --
+# caught by re-running the bundled-library gate locally before pushing.
+{
+    class MethodPH {
+        method m {
+            my $r;
+            try { $r = %_.elems; 1 }
+            $r;
+        }
+    }
+    is MethodPH.new.m(a => 1, b => 2), 2,
+        '%_ inside try {} still works when lexically in a method (try)';
+}
+{
+    class MethodPH2 {
+        method m {
+            my $r;
+            loop { $r = %_.elems; last }
+            $r;
+        }
+    }
+    is MethodPH2.new.m(a => 1, b => 2, c => 3), 3,
+        '%_ inside loop {} still works when lexically in a method (loop)';
+}
+{
+    class MethodPH3 {
+        method m {
+            supply { emit %_.elems; done }
+        }
+    }
+    my $got;
+    react { whenever MethodPH3.new.m(a => 1, b => 2) -> $n { $got = $n } }
+    is $got, 2, '%_ inside supply {} still works when lexically in a method (supply)';
+}
+# `%_` is NOT exempted outside a method -- only a METHOD gets an implicit
+# `*%_`, never a plain `sub`.
+throws-like 'sub f { try { %_ } }; f(a => 1)', X::Placeholder::Block,
+    '%_ inside try {} in a plain sub (not a method) still rejects';

--- a/todo/tickets/pre-post-phasers-not-enforced-at-mainline.md
+++ b/todo/tickets/pre-post-phasers-not-enforced-at-mainline.md
@@ -1,0 +1,74 @@
+# `PRE {}`/`POST {}` phasers are not enforced at the true top-level mainline
+
+Discovered while implementing ADR-0048 Phase 2 (placeholder-scope rejection
+for phaser bodies). Unrelated to that ADR — this is a separate, pre-existing
+correctness gap in `PRE`/`POST` phaser support.
+
+## Repro
+
+```
+$ raku -e 'PRE { False }; say "reached"'
+Precondition '{ False }' failed
+  in block <unit> at -e line 1
+
+$ mutsu -e 'PRE { False }; say "reached"'
+reached
+```
+
+`raku` enforces `PRE`/`POST` conditions wherever they appear, including
+directly at the mainline (outside any `sub`/`method`). mutsu enforces them
+correctly inside a routine body (`sub f { PRE { False }; 1 }; f()` does die
+with the expected `Precondition '...' failed`), but a `PRE`/`POST` phaser
+written directly at the top level of a script (or `-e` one-liner) is
+silently accepted and never checked.
+
+## Root cause (partial — not fully investigated)
+
+`src/compiler/stmt.rs`'s `compile_pre_phasers`/`compile_post_phasers` are the
+only place a `PRE`/`POST` body's `CheckPhaser` opcode is emitted. They are
+called from exactly two places:
+
+- `src/compiler/mod.rs`'s `compile_phaser_block_scope`, itself only invoked
+  when `self.is_routine && Self::has_block_enter_leave_phasers(stmts)` (see
+  `src/compiler/mod.rs` around line 3141) — i.e. only for a compiled
+  **routine** body, never for the true mainline unit.
+- `src/compiler/helpers_sub_body.rs` (sub/method body compilation, same
+  routine-only gating).
+
+The true mainline (`compile_unit` in `src/compiler/mod.rs`) never calls
+`compile_phaser_block_scope`/`compile_pre_phasers`/`compile_post_phasers` for
+its own top-level statement list, so a `Stmt::Phaser { kind: Pre | Post, .. }`
+sitting directly in the mainline's statement list is presumably falling to
+whatever no-op/pass-through arm handles an un-extracted phaser in
+`compile_stmt` — the phaser is compiled as a statement, but its
+`CheckPhaser` opcode (the actual condition assertion) is never emitted for
+that path.
+
+## Why this is separate from ADR-0048
+
+ADR-0048 Phase 2 (see `docs/adr/0048-placeholder-scope-is-a-block-invocation-
+contract.md`) added a placeholder-scope rejection check to
+`compile_pre_phasers`/`compile_post_phasers` — correct wherever those
+functions actually run, but that gave no coverage for `PRE`/`POST` at the
+mainline precisely because the *whole* precondition-checking mechanism never
+runs there, not just the placeholder check. `t/placeholder-scope-rejecting.t`
+pins the sub-body form (which works today) and documents this gap in a
+comment rather than testing the (currently broken) mainline form.
+
+## Fix sketch (not attempted)
+
+`compile_unit` would need to detect `PRE`/`POST` phasers in the top-level
+statement list (mirroring `has_block_enter_leave_phasers`) and route the
+mainline body through the same `compile_phaser_block_scope`-style extraction
+`compile_phaser_block_scope` uses for routines — or a dedicated top-level
+variant, since the mainline is not "a routine" in the same sense (no
+`is_routine` compiler flag, no return-value plumbing to match). Needs a real
+investigation into how much of `compile_phaser_block_scope`'s BlockScope
+opcode framing is safe to reuse for the whole program vs. requires its own
+narrower top-level-only wiring.
+
+## Severity
+
+Low: `PRE`/`POST` at the true mainline (outside any sub/method) is an
+unusual, rarely-used pattern in real Raku code — most `PRE`/`POST` usage is
+inside routine bodies, which already works correctly.


### PR DESCRIPTION
## Summary

Implements **ADR-0048 Phase 2** ("Rejecting set") — see
`docs/adr/0048-placeholder-scope-is-a-block-invocation-contract.md`,
whose Phase 1 (the classification oracle) landed in #6796.

- Flips `loop{}` (headerless/C-style), `try{}`, `react{}`, `once{}`,
  `default{}`, standalone `CATCH{}`/`CONTROL{}`, every phaser kind
  (`BEGIN`/`CHECK`/`INIT`/`ENTER`/`LEAVE`/`KEEP`/`UNDO`/`END`/`PRE`/`POST`),
  `gather{}`, and `module`/`package`/`grammar` bodies to reject a
  `$^placeholder` with `X::Placeholder::Block` at compile time —
  matching real `raku`, which already rejects all of these.
- The statement-prefix group that desugars its body into a real closure
  at *parse* time (`start`, `sink`, `supply`, `lazy`, `eager`) is
  rejected at its own compiler/parser call site instead, since the
  oracle never sees a `NoSignature`-shaped body for those by the time
  compilation reaches them (the placeholder was already consumed as
  that closure's own signature parameter).
- **The oracle change alone is not sufficient.** It only changes what
  the shallow placeholder-collection walks do. Landing this required
  separately wiring `emit_block_placeholder_die` (or the
  `collect_unattached_placeholders` check it wraps) into every concrete
  compile site — several constructs turned out to have more than one
  entry point (BEGIN/phasers in particular: statement position,
  tail/value position from three different callers, a top-level
  mainline BEGIN-hoisting pre-pass that bypasses the compiler entirely
  via the tree-walk-era `eval_block_value`, and
  ENTER/LEAVE/KEEP/UNDO/PRE/POST extraction inside
  `compile_phaser_block_scope`). The fix pushes the check down into the
  lowest-level shared primitives rather than guarding every call site.
- `repeat {} while/until` is deliberately **NOT** included — despite
  sharing the `Stmt::Loop` AST variant with `loop{}`, raku's own
  evidence table classifies it as signature-capable (Phase 4/D4's
  territory). A roast-corpus scan for `$^`/`@^`/`%^` usage inside any
  of these constructs found exactly one real hit:
  `roast/S04-statements/repeat.t`'s "placeholders and 'repeat while'
  mix" subtest, which pins that `repeat` loops keep accepting a
  placeholder. An initial pass of this change wrongly rejected `repeat`
  loops too — caught by the scan and fixed (see the ADR's Phase 2 entry
  for the full story).
- Known gaps (documented in the ADR and left for a follow-up): `race{}`
  (the bare, non-`for` statement-prefix form) has no dedicated AST
  construct yet; `FIRST`/`NEXT`/`LAST`/`CLOSE` loop-scoped phasers and a
  `CLOSE` phaser nested inside `supply{}` are extracted into synthetic
  shapes before reaching the check; `PRE{}`/`POST{}` at the true
  top-level mainline are not enforced by mutsu at all (a separate,
  pre-existing gap unrelated to this ADR — filed as
  `todo/tickets/pre-post-phasers-not-enforced-at-mainline.md`).

## Test plan

- [x] New `t/placeholder-scope-rejecting.t` (22 cases, one per
      construct/kind), all pass.
- [x] Full local `t/` suite (30788 tests) clean, except the
      pre-existing, environment-specific `t/compunit-can-install.t`
      test 4 (already noted in Phase 1's ADR entry).
- [x] `roast/S04-statements/repeat.t` (and its `S03-operators`/
      `S05-metasyntax` siblings) still pass locally.
- [x] Manually grepped `roast/`/`modules/`/`vendor/` for `$^`/`@^`/`%^`
      usage inside every rejecting construct (background exploration
      agent, ~1464 roast `.t` files + all bundled modules) — only the
      one `repeat.t` hit above, already accounted for.
- [x] `cargo clippy -- -D warnings` and `cargo fmt` clean.
- [ ] CI (`make test` + `make roast`) — watching in background.

🤖 Generated with [Claude Code](https://claude.com/claude-code)