### PR TITLE
feat(vm): itemize array/hash elements at the mutation-site store (ADR-0040 slices 0-1)

### DIFF
--- a/docs/adr/0040-array-hash-elements-are-itemized-at-the-store.md
+++ b/docs/adr/0040-array-hash-elements-are-itemized-at-the-store.md
@@ -569,12 +569,39 @@ applied to whatever `splice` already decides to keep as one element (which corre
 discrete `Range` argument, pinned in the acceptance test) without touching that unrelated flattening
 decision, to keep this PR's blast radius scoped to itemization.
 
+**A companion bug in `.pick`/`.roll`/`.head`/`.tail`'s generic fallback was found by CI**
+(`roast/integration/advent2010-day11.t` died mid-run: `%next-step{$a ~ $b}.roll.key` threw "No such
+method 'key' for invocant of type 'Hash'"). `value_to_list` (`src/runtime/utils/list.rs`) has two
+call-site shapes that need opposite answers to the same question, "does this value expand to its
+elements": when `val` is being flattened as an ELEMENT of some OTHER container (its primary, correct
+job, and the one every store-site hook in this ADR relies on), itemization must stop it from
+expanding — but `.pick`/`.roll`'s generic fallback (`dispatch_core_range.rs`) and `.head`/`.tail`'s
+non-`Array` fallback call `value_to_list(target)` where `target` IS THE RECEIVER, to decompose it
+into ITS OWN elements — a question itemization has no say in, since it was never itemized as an
+element of anything here. A nested-autovivified `%next-step{$a~$b}` (now itemized by Slice 1)
+exposed the gap: `value_to_list` treated it as one opaque item and `.roll` "rolled" the whole hash
+instead of one of its pairs. Fixed with a new sibling, `value_to_list_for_receiver` (same file),
+that strips the receiver's own itemization (`descalarize` + de-itemize `Array`/`Hash`) before
+decomposing — used at every `value_to_list(target)` call in `dispatch_core_range.rs` where `target`
+is confirmed to be the method's own receiver (left the two sites where `target` was already
+narrowed to a bare `Range`/`GenericRange` by an outer match unchanged, since those can never be a
+Scalar-wrapped receiver). `.roll`/`.pick` also gained a dedicated `Hash` arm for `.roll` (mirroring
+the one `.pick` already had), rather than relying on the fallback at all for the common case.
+Pinned in `t/element-store-itemization.t`'s new CI-regression section (itemized Hash/Array elements
+via `.pick`/`.roll`/`.head`/`.tail`).
+
+A `roast/integration/deep-recursion-initing-native-array.t` stack overflow observed locally under a
+**debug** build is unrelated and pre-existing (reproduces identically on `main`, unaffected by this
+PR); it passes under the **release** build CI actually uses for `make roast` (confirmed both on
+`main` and on this branch), matching the documented debug-vs-release roast guidance.
+
 **Verification**: `cargo clippy -- -D warnings` and `cargo fmt --check` clean. Full local `t/` suite
-(3322 files) passes unchanged. Targeted whitelisted roast batches — `S32-array/*` (all 21
+(3328 files) passes unchanged. Targeted whitelisted roast batches — `S32-array/*` (all 21
 whitelisted files, including `push`/`unshift`/`splice`/`create`/`delete*`/`multislice-6e`),
 `S32-hash/*` (all 17 whitelisted files), `S09-typed-arrays/*` (9 files, including the native/shaped
-variants), and `S02-types/{array,array_extending,array_ref,assigning-refs,autovivification,
-flattening,hash,hash_ref,list,multi_dimensional_array}.t` — all pass unchanged.
+variants), `S02-types/{array,array_extending,array_ref,assigning-refs,autovivification,
+flattening,hash,hash_ref,list,multi_dimensional_array}.t`, `S32-list/{pick,roll}.t`, and **all 119
+whitelisted `roast/integration/*.t` files** (release build) — all pass.
 
 ---
 

--- a/docs/adr/0040-array-hash-elements-are-itemized-at-the-store.md
+++ b/docs/adr/0040-array-hash-elements-are-itemized-at-the-store.md
@@ -1,6 +1,6 @@
 # ADR-0040: Array and Hash elements are itemized at the *store*, not compensated at the read
 
-- **Status**: Proposed (design complete; implementation not started)
+- **Status**: Accepted (Slices 0-1 implemented; see "Implementation status" below)
 - **Date**: 2026-08-20
 - **Deciders**: tokuhirom, Claude
 - **Related**: [ADR-0013](0013-container-interior-mutability-cellvalue.md) §5 open question 3 / §7 (the
@@ -477,5 +477,105 @@ approximates each separately. Recorded here so a future reader can see the whole
 
 ---
 
-*This ADR is Proposed. If the mechanism judgment changes later, supersede it rather than rewriting
-it.*
+## 8. Implementation status (2026-08-21)
+
+Slices 0-1 landed in full, including every mutation-site shape named in §2/§4's Slice 1
+description (element assign, autovivification — both single- and nested-level — and
+`push`/`unshift`/`append`/`prepend`/`splice` for a real `Array` or `Hash`).
+
+- **Slice 0** (acceptance oracle): `t/element-store-itemization.t` — the full §1.3 divergence
+  matrix (rows 01-25, dual-oracled against `raku`), the §1.6 agreeing-source rows, the §2.3 arity
+  invariants (`push(1,2)` / `append((5,4))` stay 2 bare elements), the §2 negatives
+  (`Pair`/`Set`/`Int` elements stay unwrapped), a native-array safety check, and a dedicated
+  section for every mutation-site shape this slice fixes: single-index element assign
+  (rows 19-22), the hash equivalent (`%h<k> = [1,2]`), `unshift`/`prepend`/multi-arg `push`, nested
+  array/hash autovivification (`@a[5][0] = 1`, `%h<a><b> = 1`), `Hash.push`, and reference-shared
+  push (`@a.push(@b)`) including that `@b` read directly stays bare while `@a[0]` is itemized, and
+  that a later mutation of `@b` still propagates through the shared cell. 46 assertions total; rows
+  01-18, 23 (construction-site itemization, Slice 2) and 24 (`.VAR` reflection, Slice 3) stay
+  `todo`-marked.
+
+- **Slice 1** (the mutation sites), in two composed layers:
+
+  1. **`Interpreter::itemize_value`** (`src/vm/vm_run_loop.rs:942`), the pre-existing narrower
+     sibling of `Value::item()` already shipped for the bind-side half (`itemize_scalar_store`, same
+     shape — it rewrites `Array`/`Hash`/`Seq`/`Mixin` in place, leaving every scalar `ValueView`
+     discriminant byte-identical), is applied at the dozens of individual per-element leaf-store
+     sites inside the ~3200-line `vm_var_assign_index_named.rs` machinery (both fast paths in
+     `src/vm/vm_var_assign_element.rs`, `native_store_val`'s computation, `hash_insert_through`
+     calls, and the "autovivify a fresh Nil/missing container" branches) and at every push/append/
+     unshift/prepend fast-path per-element store (`src/vm/vm_data_push_ops.rs`'s `ArrayPush` opcode,
+     and the second, independent fast path `try_native_array_mut`/`native_array_storage_mut` in
+     `src/vm/vm_call_method_mut_ops.rs` that serves the multi-arg/captured-closure call shapes
+     `unshift` reaches exclusively — `unshift` has no dedicated VM opcode).
+  2. **`Value::itemize_for_element_store`** (`src/value/value_methods_a.rs`), a new sibling gated on
+     the ADR's own §2 "What" list (`Array`, `Hash`, `Seq`, and every `Range` shape — the one kind
+     `itemize_value` does not cover, since nothing needed it for the bind-side half), delegates to
+     `Value::item()` for those kinds and is a no-op otherwise. Used at the sites discovered/added
+     during implementation that were not already covered by (1): the single hook at the top of
+     `exec_index_assign_expr_named_op_seeded` (gated on a plain `Int`/`Str` index, so a slice
+     assign's whole RHS list is never itemized as one unit); the two nested-autovivification
+     construction sites in `exec_index_assign_expr_nested_op`
+     (`vm_var_assign_index_named.rs`, both the array-outer and hash-outer arms); `hash_push_insert`
+     (`src/runtime/methods_mut_hash.rs`, the `Hash.push`/`.append` chokepoint); `flatten_append_args`
+     (`src/runtime/mod.rs`, the one-arg-rule choke point shared by ~13 append/prepend call sites) and
+     `normalize_push_unshift_args`/`normalize_push_args_for_copy` (`src/runtime/methods_mut.rs`,
+     `src/runtime/methods_call_helpers.rs` — see the reversal note below); and the discrete-element
+     branch of `splice`'s replacement-argument loop (`src/runtime/methods_mut_dispatch.rs`).
+
+  Both helpers apply itemization strictly *after* each site's own one-arg-rule/Slip-flattening
+  decision, never before — `push(1,2)` still adds two bare elements, `append((5,4))` still flattens
+  to two bare elements, and only the per-element result is itemized (§2 part 3, verified by the
+  arity-invariant rows).
+
+**The reversal `normalize_push_unshift_args`/`normalize_push_args_for_copy` needed** (§2 part 3's
+"one counter-current"): both used to *strip* an incoming `Scalar` wrapper / itemized-`Array` kind on
+the way into `push`/`unshift`, because under the old read-side-compensated model any incoming
+itemization was a leftover to discard before storing. Under the store-side model that is exactly
+backwards, so both now itemize the final per-element value instead of stripping it.
+
+**Nested autovivification (`@a[5][0] = 1`, `%h<a><b> = 1`) is covered.** The freshly-autovivified
+intermediate container itself becomes a real stored element of the outer array/hash, so it itemizes
+the same way any other element store does — `@a[5].raku` is `$[1]` and `%h<a>.raku` is `${:b(1)}`,
+matching raku. Deeper (3+-level) chained assignment
+(`exec_index_assign_deep_nested_op`/`exec_index_assign_generic_op`) was not separately audited; no
+acceptance row exercises it, and it is left for a follow-up slice if a gap surfaces.
+
+**Reference-shared push (`@a.push(@b)`) needed a representation choice, not just a hook call.**
+Naively itemizing the *cell's* contents (flipping the shared `ArrayData`'s own `ArrayKind` tag) was
+tried first and is wrong: `@a[0]` and `@b` share the exact same `ContainerRef` cell, so mutating the
+cell's own kind tag makes `@b` itself (read directly, not through the pushed element) also render
+itemized — contradicting raku, where `@b.raku` stays bare while `@a[0].raku` is `$[1, 2]`. The fix
+instead wraps the `ContainerRef` *itself* in an outer `Value::Scalar` (`Value::container_ref(cell)
+.item()`, in `src/vm/vm_data_push_ops.rs`'s `value_source_idx` branch) — the same "wrap anything
+that is not Array/Hash in a Scalar" arm `Value::item()` already has, so the shared cell's own content
+is untouched and only the pushed element's own wrapper carries the itemization. This introduced a
+new `Value::Scalar(Box(ContainerRef(_)))` shape that the pre-existing method-dispatch decontainerize
+step (`src/vm/vm_call_method_ops.rs`, `exec_call_method_op_impl`) did not know about — it only
+recognized a *bare* `ContainerRef` invocant — so `@a[0].elems` (and every other non-rendering method)
+initially regressed to `1` instead of decontainerizing through to the aliased array's real element
+count (caught by the pre-existing `t/native-callmethod-push.t` and `t/push-array-reference.t`, not by
+this ADR's own pin file). Fixed by widening that same decont step to also see through a
+`Scalar`-wrapped `ContainerRef`, **except** for `raku`/`gist`/`perl` (mirroring the pre-existing `VAR`
+exception for a bare `ContainerRef`) — those three must keep the `Scalar` wrapper intact, since the
+itemization they need to render lives only in that outer wrapper.
+
+**A pre-existing, unrelated `splice` arity bug was found and filed separately, not fixed here**
+(`todo/tickets/splice-multi-arg-array-incorrectly-flattens.md`): `splice`'s replacement-argument
+handling flattens *every* `Array`/`List` argument unconditionally, where raku only flattens an
+`Array`/`List` argument when it is the sole replacement argument (the same one-arg rule
+`push`/`append`/`unshift`/`prepend` already implement correctly). This ADR's itemization hook is
+applied to whatever `splice` already decides to keep as one element (which correctly reaches a
+discrete `Range` argument, pinned in the acceptance test) without touching that unrelated flattening
+decision, to keep this PR's blast radius scoped to itemization.
+
+**Verification**: `cargo clippy -- -D warnings` and `cargo fmt --check` clean. Full local `t/` suite
+(3322 files) passes unchanged. Targeted whitelisted roast batches — `S32-array/*` (all 21
+whitelisted files, including `push`/`unshift`/`splice`/`create`/`delete*`/`multislice-6e`),
+`S32-hash/*` (all 17 whitelisted files), `S09-typed-arrays/*` (9 files, including the native/shaped
+variants), and `S02-types/{array,array_extending,array_ref,assigning-refs,autovivification,
+flattening,hash,hash_ref,list,multi_dimensional_array}.t` — all pass unchanged.
+
+---
+
+*If the mechanism judgment changes later, supersede this ADR rather than rewriting it.*

--- a/news/2026-08/element-store-itemization-slices-0-1.md
+++ b/news/2026-08/element-store-itemization-slices-0-1.md
@@ -1,0 +1,43 @@
+# Array/Hash elements itemize at the mutation-site store (ADR-0040 slices 0-1)
+
+Raku's model is that every `Array`/`Hash` element *is* a `Scalar` container: reading it back gives
+one item in list context, and it renders itemized (`$["a", "b"]`, not `["a", "b"]`). mutsu already
+itemized values bound to a plain `$`-sigiled parameter (`news/2026-08/param-bind-itemization.md`),
+but stored array/hash elements themselves stayed bare, so `my @a; @a.push([7,8]); say @a[0].raku`
+printed `[7, 8]` instead of raku's `$[7, 8]`.
+
+[ADR-0040](../../docs/adr/0040-array-hash-elements-are-itemized-at-the-store.md) decided to fix this
+at the element *store* rather than compensating in readers — itemizing an aggregate value the
+instant it is written into a real `Array`/`Hash` element, using the existing `Value::item()`
+itemization primitive (or its narrower, allocation-free `ValueView`-preserving sibling
+`Interpreter::itemize_value`, used at the majority of sites). Because the itemization flag rides on
+the same shared backing (`Gc<ArrayData>` / `Gc<HashData>`), and every list-context flattening
+decision point already consults it, a value itemized once at the store stays itemized through
+`map`/`grep`/`sort`/`head`/`pairs`/slices/the implicit topic with no changes needed to any of those
+producers.
+
+Slices 0-1 land the full set of mutation sites: element assign (`@a[i] = v`, `%h<k> = v`), single-
+and nested-level autovivification (`@a[5][0] = 1` now itemizes the freshly-created `@a[5]`;
+`%h<a><b> = 1` likewise), and `push`/`unshift`/`append`/`prepend`/`splice`, always applied *after*
+each site's own one-arg-rule/Slip-flattening decision so arity never changes — `push(1,2)` still
+adds two bare elements, `push([1,2])` still adds one itemized element.
+
+Reference-shared push (`@a.push(@b)`, which shares a live `ContainerRef` cell with the source
+variable) needed its own representation choice: the shared cell's own content stays untouched (so
+`@b` read directly still renders bare), and only the *pushed element's own* wrapper carries the
+itemization — `@a[0].raku` is `$[1, 2]` while `@b.raku` stays `[1, 2]`, matching raku exactly, and a
+later `@b.push(3)` still propagates through the shared cell to `@a[0]`. This introduced a new
+`Scalar(ContainerRef(_))` value shape that method dispatch's decontainerize step did not know about,
+fixed by widening it to see through that shape for every method except the renderers
+(`raku`/`gist`/`perl`), which need the wrapper intact to render the `$`.
+
+A pre-existing, unrelated `splice` arity bug was found and filed separately rather than fixed here
+(`todo/tickets/splice-multi-arg-array-incorrectly-flattens.md`) to keep this change's blast radius
+scoped to itemization.
+
+The acceptance oracle, `t/element-store-itemization.t`, pins the full ADR-0040 §1.3 divergence
+matrix (dual-oracled against `raku`) plus the invariants that must never move — an `Array`'s own
+`.raku` still de-itemizes its elements, `Pair`/`Set`/`Int` elements stay unwrapped, and the arity
+rules are unaffected. Rows that depend on itemizing at *construction* time (list-assign, literal
+construction) or on `.VAR` reflection stay `todo`-marked for ADR-0040 slices 2-3, which are follow-up
+work.

--- a/news/2026-08/element-store-itemization-slices-0-1.md
+++ b/news/2026-08/element-store-itemization-slices-0-1.md
@@ -35,6 +35,14 @@ A pre-existing, unrelated `splice` arity bug was found and filed separately rath
 (`todo/tickets/splice-multi-arg-array-incorrectly-flattens.md`) to keep this change's blast radius
 scoped to itemization.
 
+CI caught a genuine companion bug this change exposed: `.pick`/`.roll`'s generic fallback decomposed
+a value into elements using the *same* itemization-respecting `value_to_list` the store sites rely
+on — correct when a value is flattened as an element of some other container, but wrong when the
+value is the *receiver itself* (`%h<a>.roll` needs one of `%h<a>`'s own pairs, regardless of whether
+`%h<a>` is itemized). A new sibling, `value_to_list_for_receiver`, strips the receiver's own
+itemization first; `roast/integration/advent2010-day11.t`, which builds a nested Markov-chain hash
+and rolls from it, now passes again.
+
 The acceptance oracle, `t/element-store-itemization.t`, pins the full ADR-0040 §1.3 divergence
 matrix (dual-oracled against `raku`) plus the invariants that must never move — an `Array`'s own
 `.raku` still de-itemizes its elements, `Pair`/`Set`/`Int` elements stay unwrapped, and the arity

--- a/src/builtins/methods_0arg/dispatch_core_range.rs
+++ b/src/builtins/methods_0arg/dispatch_core_range.rs
@@ -135,7 +135,10 @@ pub(super) fn dispatch(
                 }
             }
             _ => {
-                let items = runtime::value_to_list(target);
+                // ADR-0040: decompose the RECEIVER into its own elements,
+                // ignoring its own itemization (see
+                // `value_to_list_for_receiver`'s doc comment).
+                let items = runtime::value_to_list_for_receiver(target);
                 Some(Ok(items.first().cloned().unwrap_or(Value::NIL)))
             }
         }),
@@ -146,7 +149,7 @@ pub(super) fn dispatch(
             ValueView::Instance { .. } => return None,
             ValueView::Array(items, ..) => Some(Ok(items.last().cloned().unwrap_or(Value::NIL))),
             _ => {
-                let items = runtime::value_to_list(target);
+                let items = runtime::value_to_list_for_receiver(target);
                 Some(Ok(items.last().cloned().unwrap_or(Value::NIL)))
             }
         }),
@@ -194,7 +197,9 @@ pub(super) fn dispatch(
                 let items = if crate::runtime::utils::is_shaped_array(target) {
                     crate::runtime::utils::shaped_array_leaves(target)
                 } else {
-                    runtime::value_to_list(target)
+                    // ADR-0040: decompose the RECEIVER into its own
+                    // elements, ignoring its own itemization.
+                    runtime::value_to_list_for_receiver(target)
                 };
                 if items.is_empty() {
                     Some(Ok(Value::NIL))
@@ -230,6 +235,27 @@ pub(super) fn dispatch(
                 }
                 return Some(Some(Ok(items.typed_key(keys[idx]))));
             }
+            // ADR-0040: a Hash is decomposed into its OWN key-value pairs
+            // here regardless of the hash's own itemization flag -- `.roll`
+            // is called ON this hash as the receiver, not flattened as an
+            // element of some other container, so the itemization axis
+            // (which governs the latter) does not apply. Mirrors `.pick`'s
+            // own dedicated `ValueView::Hash` arm above; `value_to_list`
+            // below would otherwise treat an itemized Hash (e.g. one
+            // produced by nested autovivification, `%h<a><b>++`) as a
+            // single opaque item and "roll" the whole hash instead of one
+            // of its pairs.
+            if let ValueView::Hash(items) = target.view() {
+                if items.is_empty() {
+                    return Some(Some(Ok(Value::NIL)));
+                }
+                let mut idx = (crate::builtins::rng::builtin_rand() * items.len() as f64) as usize;
+                if idx >= items.len() {
+                    idx = items.len() - 1;
+                }
+                let (key, value) = items.iter().nth(idx).expect("index in range");
+                return Some(Some(Ok(items.typed_pair(key, value.clone()))));
+            }
             // Try efficient range sampling first
             if let Some(v) = sample_one_from_range(target) {
                 return Some(Some(Ok(v)));
@@ -237,7 +263,9 @@ pub(super) fn dispatch(
             let items = if crate::runtime::utils::is_shaped_array(target) {
                 crate::runtime::utils::shaped_array_leaves(target)
             } else {
-                runtime::value_to_list(target)
+                // ADR-0040: decompose the RECEIVER into its own elements,
+                // ignoring its own itemization.
+                runtime::value_to_list_for_receiver(target)
             };
             if items.is_empty() {
                 Some(Some(Ok(Value::NIL)))

--- a/src/runtime/methods_call_helpers.rs
+++ b/src/runtime/methods_call_helpers.rs
@@ -247,10 +247,15 @@ impl Interpreter {
         };
         match method {
             "push" | "append" | "unshift" | "prepend" => {
+                // ADR-0040 slice 1: itemize per element, after the
+                // one-arg-rule flattening decision.
                 let vals: Vec<Value> = match method {
                     "push" | "unshift" => Self::normalize_push_args_for_copy(args),
                     _ => flatten_append_args(args),
-                };
+                }
+                .into_iter()
+                .map(Self::itemize_value)
+                .collect();
                 let front = matches!(method, "unshift" | "prepend");
                 target.with_array_inplace(|data, _| {
                     if front {
@@ -343,17 +348,13 @@ impl Interpreter {
     }
 
     /// Normalize push/unshift arguments (unwrap Scalar containers, deitemize).
+    /// ADR-0040 slice 1: the by-value-invocant push/unshift counterpart of
+    /// `Interpreter::normalize_push_unshift_args` (`methods_mut.rs`) — same
+    /// reversal, same reason: itemize the stored element instead of
+    /// stripping an incoming itemization.
     pub(super) fn normalize_push_args_for_copy(args: Vec<Value>) -> Vec<Value> {
         args.into_iter()
-            .map(|arg| {
-                // Unwrap a Scalar container; Array (itemized or not) and all other
-                // values pass through unchanged.
-                if let ValueView::Scalar(inner) = arg.view() {
-                    inner.clone()
-                } else {
-                    arg
-                }
-            })
+            .map(Value::itemize_for_element_store)
             .collect()
     }
 

--- a/src/runtime/methods_mut.rs
+++ b/src/runtime/methods_mut.rs
@@ -174,29 +174,26 @@ impl Interpreter {
         }
     }
 
+    /// ADR-0040 slice 1: this used to STRIP an incoming Scalar wrapper /
+    /// itemized-Array kind on the way into push/unshift, because mutsu did
+    /// not itemize at the store and any incoming itemization was thus a
+    /// leftover to discard. Under the store-side model that is exactly
+    /// backwards: an aggregate handed to push/unshift as a single element
+    /// (the one-arg rule) must become the STORED element's itemization, so
+    /// this now itemizes instead of stripping — the one counter-current the
+    /// ADR names (§2 part 3).
     fn normalize_push_unshift_arg(arg: Value) -> Value {
-        match arg.view() {
-            ValueView::Scalar(inner) => inner.clone(),
-            ValueView::Array(items, kind) if kind.is_itemized() => {
-                Value::array_with_kind(items.clone(), kind.decontainerize())
-            }
-            _ => arg,
-        }
+        arg.itemize_for_element_store()
     }
 
     pub(crate) fn normalize_push_unshift_args(args: Vec<Value>) -> Vec<Value> {
-        let needs_normalize = args.iter().any(|arg| match arg.view() {
-            ValueView::Scalar(_) => true,
-            ValueView::Array(_, kind) => kind.is_itemized(),
-            ValueView::Slip(_) => true,
-            _ => false,
-        });
-        if !needs_normalize {
-            return args;
-        }
         args.into_iter()
             .flat_map(|arg| match arg.view() {
-                ValueView::Slip(items) => items.to_vec(),
+                ValueView::Slip(items) => items
+                    .iter()
+                    .cloned()
+                    .map(Self::normalize_push_unshift_arg)
+                    .collect::<Vec<_>>(),
                 _ => vec![Self::normalize_push_unshift_arg(arg)],
             })
             .collect()

--- a/src/runtime/methods_mut_dispatch.rs
+++ b/src/runtime/methods_mut_dispatch.rs
@@ -764,6 +764,13 @@ impl Interpreter {
                     let normalized_args = Self::normalize_push_unshift_args(args);
                     self.check_container_element_types(&key, &target, &normalized_args)?;
                     let normalized_args = nil_to_elem_default(self, normalized_args);
+                    // ADR-0040 slice 1: itemize per element, after the
+                    // one-arg-rule flattening decision, so a single pushed
+                    // aggregate becomes one itemized element.
+                    let normalized_args: Vec<Value> = normalized_args
+                        .into_iter()
+                        .map(Self::itemize_value)
+                        .collect();
                     let result = self.push_to_shared_var(&key, normalized_args, &target);
                     self.reattach_array_type_metadata(&key, &saved_meta);
                     return Ok(result);
@@ -780,6 +787,10 @@ impl Interpreter {
                     let flat_values = flatten_append_args(args);
                     self.check_container_element_types(&key, &target, &flat_values)?;
                     let flat_values = nil_to_elem_default(self, flat_values);
+                    // ADR-0040 slice 1: itemize per element, after the
+                    // one-arg-rule flattening decision.
+                    let flat_values: Vec<Value> =
+                        flat_values.into_iter().map(Self::itemize_value).collect();
                     // ADR-0039 slice 1: `key` may be a compunit unit-lexical
                     // `@`/`%` (module file-scope, or a mainline named sub's
                     // captured free variable), whose authoritative storage is a
@@ -823,6 +834,12 @@ impl Interpreter {
                     let normalized_args = Self::normalize_push_unshift_args(args);
                     self.check_container_element_types(&key, &target, &normalized_args)?;
                     let normalized_args = nil_to_elem_default(self, normalized_args);
+                    // ADR-0040 slice 1: itemize per element, after the
+                    // one-arg-rule flattening decision.
+                    let normalized_args: Vec<Value> = normalized_args
+                        .into_iter()
+                        .map(Self::itemize_value)
+                        .collect();
                     // ADR-0039 slice 1: see the twin comment on the `append`
                     // arm above — `env_root_descended_mut` is required here for
                     // the same reason.
@@ -858,6 +875,10 @@ impl Interpreter {
                     );
                     let flat_values = flatten_append_args(args);
                     self.check_container_element_types(&key, &target, &flat_values)?;
+                    // ADR-0040 slice 1: itemize per element, after the
+                    // one-arg-rule flattening decision.
+                    let flat_values: Vec<Value> =
+                        flat_values.into_iter().map(Self::itemize_value).collect();
                     // ADR-0039 slice 1: see the twin comment on the `append`
                     // arm above.
                     let result = if let Some(slot) = self.env_root_descended_mut(&key)
@@ -1030,7 +1051,18 @@ impl Interpreter {
                                 ValueView::Array(arr, ..) => {
                                     new_items.extend(arr.iter().cloned());
                                 }
-                                _ => new_items.push(arg.clone()),
+                                // ADR-0040 slice 1: a replacement arg kept
+                                // whole (not flattened above) becomes one
+                                // stored element, itemized like any other
+                                // element store. NOTE: the Array arm above
+                                // has a pre-existing, unrelated arity bug —
+                                // see todo/tickets/splice-multi-arg-array-
+                                // incorrectly-flattens.md — this only
+                                // itemizes whatever this function already
+                                // decides to keep as one element (e.g. a
+                                // Range discrete arg, which is unaffected by
+                                // that bug).
+                                _ => new_items.push(arg.clone().itemize_for_element_store()),
                             }
                         }
                         let removed: Vec<Value> = items.drain(start..end).collect();

--- a/src/runtime/methods_mut_hash.rs
+++ b/src/runtime/methods_mut_hash.rs
@@ -99,6 +99,10 @@ impl Interpreter {
         value: Value,
         is_push: bool,
     ) {
+        // ADR-0040 slice 1: itemize the value at the store, same as a plain
+        // `%h<k> = v` element assign (`%h.push('a' => [1,2]); %h<a>.raku` is
+        // `$[1, 2]` in raku, not `[1, 2]`).
+        let value = value.itemize_for_element_store();
         if let Some(existing) = hash.get(&key) {
             let new_val = match existing.view() {
                 ValueView::Array(arr, ..) => {

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -60,8 +60,16 @@ pub(crate) fn phaser_prepost_error(is_pre: bool, condition: &str) -> RuntimeErro
 /// Flatten arguments for `append` using Raku's "one-arg rule":
 /// if exactly one non-itemized Array/List argument is passed, its elements
 /// are flattened into the result. With multiple arguments, each is appended as-is.
+///
+/// ADR-0040 slice 1: the returned `Vec<Value>` is the final, post-flattening
+/// per-element list for every call site (~13 of them) that extends a real
+/// Array with it, so each element is itemized here — after the one-arg-rule
+/// decision above, never before it (an itemized single Array argument must
+/// stay itemized and NOT flatten: `!kind.is_itemized()` already guards that;
+/// a flattened element that is itself an aggregate, e.g.
+/// `@x.append(([1,2],[3,4]))`, itemizes too, matching raku).
 pub(crate) fn flatten_append_args(args: Vec<Value>) -> Vec<Value> {
-    if args.len() == 1 {
+    let flattened = if args.len() == 1 {
         match args[0].view() {
             ValueView::Array(vals, kind) if !kind.is_itemized() => vals.to_vec(),
             ValueView::Seq(vals) => vals.to_vec(),
@@ -84,7 +92,11 @@ pub(crate) fn flatten_append_args(args: Vec<Value>) -> Vec<Value> {
         }
     } else {
         args
-    }
+    };
+    flattened
+        .into_iter()
+        .map(Value::itemize_for_element_store)
+        .collect()
 }
 
 /// Split a string by commas while respecting bracket/paren depth.

--- a/src/runtime/utils/list.rs
+++ b/src/runtime/utils/list.rs
@@ -538,6 +538,28 @@ pub(crate) fn value_to_list(val: &Value) -> Vec<Value> {
     }
 }
 
+/// Decompose a method-call RECEIVER into its own elements, ignoring the
+/// receiver's own itemization (a `Scalar` wrapper, an itemized `ArrayKind`,
+/// or a hash's itemized flag). `value_to_list`'s itemization checks answer
+/// "does this value flatten when it is an ELEMENT of some other container"
+/// (ADR-0040) — a different question from "what are MY OWN elements",
+/// which is what `.pick`/`.roll`/`.hyper`/`.race`/etc. need when `val` is
+/// the receiver they were called on. Reusing `value_to_list` unmodified for
+/// that purpose silently "rolls"/"picks" the whole itemized value instead
+/// of one of its elements (e.g. `%h<a>.roll` on a nested-autovivified,
+/// itemized `%h<a>` returned the Hash itself instead of a random Pair).
+pub(crate) fn value_to_list_for_receiver(val: &Value) -> Vec<Value> {
+    let bare = val.descalarize();
+    let bare = match bare.view() {
+        ValueView::Array(items, kind) if kind.is_itemized() => {
+            Value::array_with_kind(items.clone(), kind.decontainerize())
+        }
+        ValueView::Hash(_) if bare.hash_is_itemized() => bare.clone().with_hash_itemized(false),
+        _ => bare.clone(),
+    };
+    value_to_list(&bare)
+}
+
 /// True when a subscript range dimension has no usable finite end: `1..*` /
 /// `1^..Inf` style (a Whatever end lowers to `Inf`, and an integer-range end of
 /// `i64::MAX` is the same thing forced through an int range). Expanding such a

--- a/src/value/value_methods_a.rs
+++ b/src/value/value_methods_a.rs
@@ -391,6 +391,35 @@ impl Value {
         }
     }
 
+    /// ADR-0040: itemize a value about to be stored into a real `Array`/
+    /// `Hash` element, for the value kinds whose "one-item-ness" is actually
+    /// observable there — `Array`, `List` (both the `ValueView::Array`
+    /// variant, discriminated by `ArrayKind`), `Hash`, `Seq`, and every
+    /// `Range` shape. Every other kind (`Int`, `Str`, `Pair`, `Set`, `Bag`,
+    /// `Mix`, `Nil`, `Bool`, instances, …) is returned unchanged.
+    ///
+    /// `Value::item()` itself would ALSO wrap those other kinds in a
+    /// `Scalar` box — behaviorally a no-op (the renderer/flattening
+    /// chokepoints already treat a Scalar-wrapped scalar identically to the
+    /// bare value: `docs/adr/0040-array-hash-elements-are-itemized-at-the-store.md`
+    /// §1.4/§2), but calling it unconditionally on every stored element
+    /// would heap-allocate a `Box` for every plain `Int`/`Str` array/hash
+    /// element — a real cost on this hot per-element store path. Gating on
+    /// kind here keeps the fix to the value kinds the ADR actually measured.
+    pub fn itemize_for_element_store(self) -> Value {
+        match self.view() {
+            ValueView::Array(..)
+            | ValueView::Hash(_)
+            | ValueView::Seq(_)
+            | ValueView::Range(..)
+            | ValueView::RangeExcl(..)
+            | ValueView::RangeExclStart(..)
+            | ValueView::RangeExclBoth(..)
+            | ValueView::GenericRange { .. } => self.item(),
+            _ => self,
+        }
+    }
+
     /// Read through a `ContainerRef` and apply `f` to the inner value WITHOUT
     /// cloning it. Non-ContainerRef values are passed to `f` as-is. This is the
     /// canonical non-cloning ContainerRef-read chokepoint (the ContainerRef axis of

--- a/src/vm/vm_call_method_mut_ops.rs
+++ b/src/vm/vm_call_method_mut_ops.rs
@@ -2791,17 +2791,28 @@ impl Interpreter {
         // metadata-tagged target, so the result is always the untyped `Any`
         // default -- exactly what the old hardcoded `nil_elems_to_any` call
         // produced here, now sourced from the one shared decay helper.
+        // ADR-0040 slice 1: itemize per element, after the one-arg-rule
+        // flattening decision (and after Nil-decay), so a single pushed
+        // aggregate becomes one itemized element.
         let mut precomputed_args = match method {
             // `@a.push`/`.unshift` compile to `ArrayPush`/(unshift opcode)
             // only for a single-arg call on a *local* array; the
             // captured-closure and multi-arg forms reach here as
             // `CallMethodMut`. Mirror the opcode's env-bound branch
             // (`normalize_push_unshift_args` then extend/insert).
-            "push" | "unshift" => Some(self.decay_nil_vec_elements(
-                crate::runtime::Interpreter::normalize_push_unshift_args(args.to_vec()),
-            )),
+            "push" | "unshift" => Some(
+                self.decay_nil_vec_elements(
+                    crate::runtime::Interpreter::normalize_push_unshift_args(args.to_vec()),
+                )
+                .into_iter()
+                .map(Self::itemize_value)
+                .collect::<Vec<_>>(),
+            ),
             "append" | "prepend" => Some(
-                self.decay_nil_vec_elements(crate::runtime::flatten_append_args(args.to_vec())),
+                self.decay_nil_vec_elements(crate::runtime::flatten_append_args(args.to_vec()))
+                    .into_iter()
+                    .map(Self::itemize_value)
+                    .collect::<Vec<_>>(),
             ),
             _ => None,
         };
@@ -2930,9 +2941,14 @@ impl Interpreter {
                 return None;
             }
             Some(match method {
+                // ADR-0040 slice 1: itemize per element, after the
+                // one-arg-rule flattening decision.
                 "push" => {
                     let norm =
-                        crate::runtime::Interpreter::normalize_push_unshift_args(args.to_vec());
+                        crate::runtime::Interpreter::normalize_push_unshift_args(args.to_vec())
+                            .into_iter()
+                            .map(crate::runtime::Interpreter::itemize_value)
+                            .collect::<Vec<_>>();
                     crate::gc::Gc::make_mut(arc_items).extend(norm);
                     Value::array_with_kind(
                         crate::gc::Gc::clone(arc_items),
@@ -2940,7 +2956,10 @@ impl Interpreter {
                     )
                 }
                 "append" => {
-                    let flat = crate::runtime::flatten_append_args(args.to_vec());
+                    let flat = crate::runtime::flatten_append_args(args.to_vec())
+                        .into_iter()
+                        .map(crate::runtime::Interpreter::itemize_value)
+                        .collect::<Vec<_>>();
                     crate::gc::Gc::make_mut(arc_items).extend(flat);
                     Value::array_with_kind(
                         crate::gc::Gc::clone(arc_items),
@@ -2949,7 +2968,10 @@ impl Interpreter {
                 }
                 "unshift" => {
                     let norm =
-                        crate::runtime::Interpreter::normalize_push_unshift_args(args.to_vec());
+                        crate::runtime::Interpreter::normalize_push_unshift_args(args.to_vec())
+                            .into_iter()
+                            .map(crate::runtime::Interpreter::itemize_value)
+                            .collect::<Vec<_>>();
                     let items = crate::gc::Gc::make_mut(arc_items);
                     for (i, v) in norm.into_iter().enumerate() {
                         items.insert(i, v);
@@ -2960,7 +2982,10 @@ impl Interpreter {
                     )
                 }
                 "prepend" => {
-                    let flat = crate::runtime::flatten_append_args(args.to_vec());
+                    let flat = crate::runtime::flatten_append_args(args.to_vec())
+                        .into_iter()
+                        .map(crate::runtime::Interpreter::itemize_value)
+                        .collect::<Vec<_>>();
                     let items = crate::gc::Gc::make_mut(arc_items);
                     for (i, v) in flat.into_iter().enumerate() {
                         items.insert(i, v);

--- a/src/vm/vm_call_method_ops.rs
+++ b/src/vm/vm_call_method_ops.rs
@@ -578,20 +578,42 @@ impl Interpreter {
         // is the one introspection method that wants the container itself, and
         // `^name`/`WHAT` right after a `.VAR` report the container type (raku:
         // `$obj.attr.VAR.^name` is "Scalar", not the inner value's type).
-        let target = if matches!(target.view(), ValueView::ContainerRef(_)) && method != "VAR" {
-            if args.is_empty() && matches!(method, "^name" | "WHAT") {
-                crate::vm::vm_stats::record_dispatch_entry_intercept(
-                    "callmethod",
-                    "containerref-scalar-meta",
-                );
-                self.stack.push(if method == "^name" {
-                    Value::str("Scalar".to_string())
-                } else {
-                    Value::package(crate::symbol::Symbol::intern("Scalar"))
-                });
-                return Ok(());
+        let target = if method != "VAR" {
+            match target.view() {
+                ValueView::ContainerRef(_) => {
+                    if args.is_empty() && matches!(method, "^name" | "WHAT") {
+                        crate::vm::vm_stats::record_dispatch_entry_intercept(
+                            "callmethod",
+                            "containerref-scalar-meta",
+                        );
+                        self.stack.push(if method == "^name" {
+                            Value::str("Scalar".to_string())
+                        } else {
+                            Value::package(crate::symbol::Symbol::intern("Scalar"))
+                        });
+                        return Ok(());
+                    }
+                    target.deref_container()
+                }
+                // ADR-0040 slice 1: a reference-pushed element
+                // (`@a.push(@b)`; `@a[0]` is `$`-itemized around a shared
+                // `ContainerRef` alias, i.e. `Scalar(ContainerRef(cell))`)
+                // is transparent to MOST method dispatch the same way a bare
+                // `ContainerRef` is — `@a[0].elems` must see `@b`'s live
+                // element count, not treat the wrapper as one item. But
+                // unlike the bare-`ContainerRef` case above, the itemization
+                // itself lives ONLY in this outer `Scalar` — stripping it
+                // before a renderer (`raku`/`gist`/`perl`) runs would lose
+                // the very `$` the wrapper exists to produce, so those three
+                // keep the Scalar wrapper intact (mirrors the `VAR`
+                // exception above).
+                ValueView::Scalar(inner)
+                    if inner.is_container_ref() && !matches!(method, "raku" | "gist" | "perl") =>
+                {
+                    inner.deref_container()
+                }
+                _ => target,
             }
-            target.deref_container()
         } else {
             target
         };

--- a/src/vm/vm_data_push_ops.rs
+++ b/src/vm/vm_data_push_ops.rs
@@ -93,9 +93,14 @@ impl Interpreter {
                     ValueView::Array(..)
                 );
                 if is_cell_array {
-                    let items = match val.view() {
-                        ValueView::Slip(items) => items.to_vec(),
-                        _ => vec![val],
+                    // ADR-0040 slice 1: itemize per element, after Slip
+                    // expansion, so arity is unaffected and only the stored
+                    // value gains the Scalar-container property.
+                    let items: Vec<Value> = match val.view() {
+                        ValueView::Slip(items) => {
+                            items.iter().cloned().map(Self::itemize_value).collect()
+                        }
+                        _ => vec![Self::itemize_value(val)],
                     };
                     let mut guard = cell.lock().unwrap_or_else(|e| e.into_inner());
                     (*guard).with_array_mut(|arc, _| {
@@ -129,9 +134,12 @@ impl Interpreter {
                 && !self.container_name_is_redeclared(target_name)
                 && (self.is_thread_clone() || self.array_name_is_shared(target_name))
             {
-                let items = match val.view() {
-                    ValueView::Slip(items) => items.to_vec(),
-                    _ => vec![val],
+                // ADR-0040 slice 1: itemize per element, after Slip expansion.
+                let items: Vec<Value> = match val.view() {
+                    ValueView::Slip(items) => {
+                        items.iter().cloned().map(Self::itemize_value).collect()
+                    }
+                    _ => vec![Self::itemize_value(val)],
                 };
                 let result = self.shared_array_extend(target_name, items, false);
                 self.stack.push(result);
@@ -186,7 +194,16 @@ impl Interpreter {
                 self.update_local_if_exists(code, &src_name, &cell_val);
                 cell
             });
-            val = Value::container_ref(cell);
+            // ADR-0040 slice 1: the pushed ELEMENT (read back via `@a[i]`)
+            // is itemized -- `@a.push(@b); @a[0].raku` is `$[1, 2]` in
+            // raku, not `[1, 2]` -- even though `@b` read directly stays
+            // bare (`@b.raku` is `[1, 2]`). Wrapping the shared `ContainerRef`
+            // itself in an outer `Scalar` (rather than flipping the cell's
+            // own inner `ArrayKind`) keeps the two readers independent: the
+            // cell's content is untouched, so `@b`'s own binding (which
+            // reads the bare `ContainerRef` directly) is unaffected, while
+            // `@a[i]`'s element holds the Scalar-wrapped alias.
+            val = Value::container_ref(cell).item();
         }
 
         // Empty (empty Slip) means nothing to push -- return the array as-is.
@@ -236,14 +253,15 @@ impl Interpreter {
                 // Container identity (§3): write through the shared backing
                 // node so by-value holders of the same array observe the push.
                 let mut val_slot = Some(val);
+                // ADR-0040 slice 1: itemize per element, after Slip expansion.
                 let pushed = inner
                     .with_array_inplace(|data, _| {
                         let val = val_slot.take().expect("push value present");
                         match val.view() {
-                            ValueView::Slip(slip_items) => {
-                                data.items_mut().extend(slip_items.iter().cloned())
-                            }
-                            _ => data.items_mut().push(val),
+                            ValueView::Slip(slip_items) => data
+                                .items_mut()
+                                .extend(slip_items.iter().cloned().map(Self::itemize_value)),
+                            _ => data.items_mut().push(Self::itemize_value(val)),
                         }
                     })
                     .is_some();
@@ -267,15 +285,16 @@ impl Interpreter {
         // Container identity (§3): append through the shared backing node —
         // no COW, no local-slot zeroing dance — so every by-value holder of
         // the same array (a `(0, @a)` capture, an element) sees the push.
+        // ADR-0040 slice 1: itemize per element, after Slip expansion.
         let target = self.env().get(target_name).cloned();
         let pushed = target.as_ref().and_then(|v| {
             v.with_array_inplace(|data, _| {
                 let val = val_slot.take().expect("push value present");
                 match val.view() {
-                    ValueView::Slip(slip_items) => {
-                        data.items_mut().extend(slip_items.iter().cloned())
-                    }
-                    _ => data.items_mut().push(val),
+                    ValueView::Slip(slip_items) => data
+                        .items_mut()
+                        .extend(slip_items.iter().cloned().map(Self::itemize_value)),
+                    _ => data.items_mut().push(Self::itemize_value(val)),
                 }
             })
         });
@@ -285,8 +304,14 @@ impl Interpreter {
                 let val = val_slot.take().expect("push value present");
                 // Auto-vivify: create new array
                 let arr = match val.view() {
-                    ValueView::Slip(slip_items) => Value::real_array(slip_items.to_vec()),
-                    _ => Value::real_array(vec![val]),
+                    ValueView::Slip(slip_items) => Value::real_array(
+                        slip_items
+                            .iter()
+                            .cloned()
+                            .map(Self::itemize_value)
+                            .collect(),
+                    ),
+                    _ => Value::real_array(vec![Self::itemize_value(val)]),
                 };
                 self.env_mut().insert(target_name.to_string(), arr.clone());
                 arr

--- a/src/vm/vm_var_assign_element.rs
+++ b/src/vm/vm_var_assign_element.rs
@@ -85,9 +85,11 @@ impl Interpreter {
         // Commit: pop idx then val and write through the shared cell.
         let idx = self.stack.pop().unwrap();
         let val = self.stack.pop().unwrap();
+        // ADR-0040 slice 1: a real Hash element is a Scalar container, so an
+        // aggregate stored into it itemizes (`%h{$k} = [1,2]` -> `$[1, 2]`).
         match loan_env!(
             self,
-            assign_hash_elem_to_shared_var(&var_name, key, val.clone())
+            assign_hash_elem_to_shared_var(&var_name, key, Self::itemize_value(val.clone()))
         ) {
             Some(_) => {
                 self.stack.push(val);
@@ -169,9 +171,10 @@ impl Interpreter {
         // Commit: pop idx then val and write through the shared cell.
         let idx_val = self.stack.pop().unwrap();
         let val = self.stack.pop().unwrap();
+        // ADR-0040 slice 1: same itemize-at-store as the hash twin above.
         match loan_env!(
             self,
-            assign_array_elem_to_shared_var(&var_name, idx, val.clone())
+            assign_array_elem_to_shared_var(&var_name, idx, Self::itemize_value(val.clone()))
         ) {
             Some(_) => {
                 self.stack.push(val);
@@ -350,10 +353,13 @@ impl Interpreter {
                 }
                 if let Some(entry) = self.env_mut().get_mut(var_name) {
                     entry.with_hash_mut(|hash| {
+                        // ADR-0040 slice 1: itemize the stored value, not the
+                        // rvalue pushed below (that push is a pre-existing,
+                        // separate scalar-context-itemization concern).
                         Value::hash_insert_through(
                             &mut crate::gc::Gc::make_mut(hash).map,
                             key.clone(),
-                            val.clone(),
+                            Self::itemize_value(val.clone()),
                         );
                     });
                 }
@@ -417,7 +423,8 @@ impl Interpreter {
                 let val = self.stack.pop().unwrap();
                 let key = idx.to_string_value();
                 let mut map = std::collections::HashMap::new();
-                map.insert(key.clone(), val.clone());
+                // ADR-0040 slice 1: itemize the stored value.
+                map.insert(key.clone(), Self::itemize_value(val.clone()));
                 self.env_mut()
                     .insert(var_name.to_string(), Value::hash(map));
                 // Sync OS environment when %*ENV is modified
@@ -511,6 +518,32 @@ impl Interpreter {
         // A lazy `@`-array must reify its prefix before an element assignment
         // (`@a[i] = v`) — the assign machinery needs a materialized backing. (L2)
         self.reify_lazy_array_slot(Self::const_str(code, name_idx))?;
+        // ADR-0040 slice 1: itemize the rvalue BEFORE any of the fast/slow
+        // dispatch paths below run, so every element-assign destination (the
+        // shared-var fast paths, the plain-hash fast path, and the full slow
+        // path in vm_var_assign_index_named.rs) stores the same already-
+        // itemized value — a single hook rather than patching each of the
+        // dozens of `items_mut()[i] = ...` sites those paths contain.
+        // Gated on a plain `Int`/`Str` index — the same "simple single
+        // index" shape `elem_share_mark` below already tests — because a
+        // complex index (`Array`/`Range`/`Junction`/`Whatever`/`Slip`/...)
+        // may be a SLICE assignment (`@a[0,1] = (1,2),(3,4)`), whose
+        // per-target element needs its OWN store-time itemization applied
+        // deeper in the slow path, not a single itemization of the whole
+        // RHS list here.
+        {
+            let stack_len = self.stack.len();
+            if stack_len >= 2
+                && matches!(
+                    self.stack[stack_len - 1].view(),
+                    ValueView::Int(_) | ValueView::Str(_)
+                )
+            {
+                let slot = &mut self.stack[stack_len - 2];
+                let old = std::mem::replace(slot, Value::NIL);
+                *slot = old.itemize_for_element_store();
+            }
+        }
         // Slice 2b: `@aoa[i] = @row` / `%h<k> = @row` was compiled as a `:=` bind
         // (so the bind machinery installs a shared `ContainerRef` cell and
         // promotes the source) plus a `MarkElementShare` flag. Capture which

--- a/src/vm/vm_var_assign_index_named.rs
+++ b/src/vm/vm_var_assign_index_named.rs
@@ -1883,7 +1883,10 @@ impl Interpreter {
                 }
                 // Native integer arrays store the wrapped value (`-1` -> `255` in a
                 // uint8 array); the assignment expression still yields the original.
-                let native_store_val = self.wrap_native_int_for_var(&var_name, val.clone());
+                // ADR-0040 slice 1: itemize after native-wrapping (a no-op for a
+                // native scalar; itemize_value only touches Array/Hash/Seq/Mixin).
+                let native_store_val =
+                    Self::itemize_value(self.wrap_native_int_for_var(&var_name, val.clone()));
                 // Resolve GenericRange with WhateverCode endpoints (e.g. @a[*-4 .. *-1] = ...)
                 let resolved_idx;
                 let idx_for_slice = if let ValueView::GenericRange { .. } = idx.view() {
@@ -2203,9 +2206,16 @@ impl Interpreter {
                             } else if elem_is_value_share {
                                 // Slice 2b: replace the `=`-shared cell rather than
                                 // write through it, so the source stays unaffected.
-                                hd.map.insert(key.clone(), val.clone());
+                                // ADR-0040 slice 1: itemize the stored value.
+                                hd.map
+                                    .insert(key.clone(), Self::itemize_value(val.clone()));
                             } else {
-                                Value::hash_insert_through(&mut hd.map, key.clone(), val.clone());
+                                // ADR-0040 slice 1: itemize the stored value.
+                                Value::hash_insert_through(
+                                    &mut hd.map,
+                                    key.clone(),
+                                    Self::itemize_value(val.clone()),
+                                );
                             }
                             // For object hashes, store the original key object in
                             // the embedded `original_keys` map (COW-stable). Skip
@@ -2450,11 +2460,12 @@ impl Interpreter {
                             && let Some(i) = Self::index_to_usize(&idx)
                         {
                             let mut arr = vec![Value::package(Symbol::intern("Any")); i + 1];
-                            arr[i] = val.clone();
+                            // ADR-0040 slice 1: itemize the stored value.
+                            arr[i] = Self::itemize_value(val.clone());
                             *container = Value::real_array_initialized_at(arr, i);
                         } else {
                             let mut hash = std::collections::HashMap::new();
-                            hash.insert(key.clone(), val.clone());
+                            hash.insert(key.clone(), Self::itemize_value(val.clone()));
                             let mut hash_val = Value::hash(hash);
                             if use_which {
                                 let mut orig = HashMap::new();
@@ -2470,12 +2481,13 @@ impl Interpreter {
                         && let Some(i) = Self::index_to_usize(&idx)
                     {
                         let mut arr = vec![Value::package(Symbol::intern("Any")); i + 1];
-                        arr[i] = val.clone();
+                        // ADR-0040 slice 1: itemize the stored value.
+                        arr[i] = Self::itemize_value(val.clone());
                         self.env_mut()
                             .insert(var_name.clone(), Value::real_array_initialized_at(arr, i));
                     } else {
                         let mut hash = std::collections::HashMap::new();
-                        hash.insert(key.clone(), val.clone());
+                        hash.insert(key.clone(), Self::itemize_value(val.clone()));
                         let mut hash_val = Value::hash(hash);
                         if use_which {
                             let mut orig = HashMap::new();
@@ -3006,11 +3018,17 @@ impl Interpreter {
                         ValueView::Array(..) | ValueView::Hash(..) | ValueView::ContainerRef(_)
                     );
                     if needs_viv {
-                        arr[inner_i] = if outer_positional {
+                        // ADR-0040 slice 1: the freshly-autovivified intermediate
+                        // container itself becomes a real stored element of
+                        // `arr`, so it itemizes just like any other Array/Hash
+                        // element store (`@a[5][0] = 1` autovivifies `@a[5]`,
+                        // and `@a[5].raku` is `$[1]` in raku, not `[1]`).
+                        arr[inner_i] = (if outer_positional {
                             Value::real_array(Vec::new())
                         } else {
                             Value::hash(std::collections::HashMap::new())
-                        };
+                        })
+                        .itemize_for_element_store();
                     }
                     // A bound element holds a shared cell: write through it so the
                     // mutation reaches the aliased container (`@h[i] := @inner;
@@ -3079,12 +3097,15 @@ impl Interpreter {
                         unsafe { crate::value::gc_contents_mut(outer_hash) };
                     // Vivify the missing entry as Array if the OUTER (second) subscript
                     // is positional (e.g. `%h<key>[42] = ...`), otherwise as Hash.
+                    // ADR-0040 slice 1: itemized at the store, same as the
+                    // array-outer-container arm above.
                     let inner_val = oh.entry(inner_key).or_insert_with(|| {
-                        if outer_positional {
+                        (if outer_positional {
                             Value::real_array(Vec::new())
                         } else {
                             Value::hash(std::collections::HashMap::new())
-                        }
+                        })
+                        .itemize_for_element_store()
                     });
                     Self::assign_into_nested_container(inner_val, &outer_key, val.clone())?;
                     Ok(())

--- a/t/element-store-itemization.t
+++ b/t/element-store-itemization.t
@@ -1,0 +1,263 @@
+use v6;
+use Test;
+
+# ADR-0040: Array and Hash elements are itemized at the *store*, not
+# compensated at the read (docs/adr/0040-array-hash-elements-are-itemized-
+# at-the-store.md).
+#
+# This file is the acceptance oracle from ADR-0040 SS1.3 (the 25-row
+# divergence matrix, measured on `main` 52631889f 2026-08-20) plus SS1.6's
+# agreeing rows, the SS2 arity invariants, and the SS2 negative (non-)
+# itemization list. Slice 1 (this PR) fixes the *mutation* sites only --
+# element assign, autovivification, and push/unshift/append/prepend for a
+# real Array/Hash -- so rows 19-22 (plus a few Slice-1-specific extras below
+# them) turn green. Rows 01-18, 23, 24 stay `todo`-marked: they depend on
+# itemizing at *construction* (list-assign, literal construction), which is
+# Slice 2's job. Row 25 (and the SS1.6 rows) are invariants that must NOT
+# move -- they are what stops a later slice from "fixing" the divergence by
+# over-itemizing.
+
+# === SS1.3 divergent rows (25) ===
+# Rows 01-18, 23, 24 are read/construction-side and still diverge (Slice 2/3).
+
+my @c = [<a b>],[<c d>];
+my %h = a => [1,2];
+sub takes(*@a) { @a.elems }
+
+{
+    todo 'row 01: construction-side itemization is ADR-0040 slice 2';
+    is @c[0].raku, '$["a", "b"]', 'row 01: my @c = [<a b>],[<c d>]; @c[0].raku';
+}
+{
+    todo 'row 02: construction-side itemization is ADR-0040 slice 2';
+    is %h<a>.raku, '$[1, 2]', 'row 02: my %h = a => [1,2]; %h<a>.raku';
+}
+{
+    todo 'row 03: construction-side itemization is ADR-0040 slice 2';
+    is @c[0,1].raku, '($["a", "b"], $["c", "d"])', 'row 03: @c[0,1].raku';
+}
+{
+    todo 'row 04: construction-side itemization is ADR-0040 slice 2';
+    is @c.head.raku, '$["a", "b"]', 'row 04: @c.head.raku';
+}
+{
+    todo 'row 05: construction-side itemization is ADR-0040 slice 2';
+    is @c.tail.raku, '$["c", "d"]', 'row 05: @c.tail.raku';
+}
+{
+    todo 'row 06: construction-side itemization is ADR-0040 slice 2';
+    is @c.first(*.so).raku, '$["a", "b"]', 'row 06: @c.first(*.so).raku';
+}
+{
+    todo 'row 07: construction-side itemization is ADR-0040 slice 2';
+    is @c.sort.raku, '($["a", "b"], $["c", "d"]).Seq', 'row 07: @c.sort.raku';
+}
+{
+    todo 'row 08: construction-side itemization is ADR-0040 slice 2';
+    is @c.reverse.raku, '($["c", "d"], $["a", "b"]).Seq', 'row 08: @c.reverse.raku';
+}
+{
+    todo 'row 09: construction-side itemization is ADR-0040 slice 2';
+    is @c.map({$_}).raku, '($["a", "b"], $["c", "d"]).Seq', 'row 09: @c.map({$_}).raku';
+}
+{
+    todo 'row 10: construction-side itemization is ADR-0040 slice 2';
+    is @c.pairs[0].value.raku, '$["a", "b"]', 'row 10: @c.pairs[0].value.raku';
+}
+{
+    todo 'row 11: construction-side itemization is ADR-0040 slice 2';
+    is @c.Slip.raku, 'slip($["a", "b"], $["c", "d"])', 'row 11: @c.Slip.raku';
+}
+{
+    todo 'row 12: construction-side itemization is ADR-0040 slice 2';
+    is takes(@c[0]), 1, 'row 12: takes(@c[0])';
+}
+{
+    todo 'row 13: construction-side itemization is ADR-0040 slice 2';
+    is takes(%h<a>), 1, 'row 13: takes(%h<a>)';
+}
+{
+    todo 'row 14: construction-side itemization is ADR-0040 slice 2';
+    is takes(@c.head), 1, 'row 14: takes(@c.head)';
+}
+{
+    todo 'row 15: construction-side itemization is ADR-0040 slice 2';
+    my $n;
+    for @c { $n = takes($_) }
+    is $n, 1, 'row 15: for @c { takes($_) }';
+}
+{
+    todo 'row 16: construction-side itemization is ADR-0040 slice 2';
+    is (my @z = @c[0]).elems, 1, 'row 16: (my @z = @c[0]).elems';
+}
+{
+    todo 'row 17: construction-side itemization is ADR-0040 slice 2';
+    is [@c[0]].elems, 1, 'row 17: [@c[0]].elems';
+}
+{
+    todo 'row 18: construction-side itemization is ADR-0040 slice 2';
+    is join('|', @c[0]), 'a b', "row 18: join('|', \@c[0])";
+}
+
+# --- rows 19-22: the mutation sites (Slice 1, THIS PR) ---
+
+{
+    my @a = 1, 2;
+    @a[0] = (7, 8);
+    is @a[0].raku, '$(7, 8)', 'row 19: @a[0] = (7,8); @a[0].raku';
+}
+{
+    my @a = 1, 2;
+    @a.push([7, 8]);
+    is @a[2].raku, '$[7, 8]', 'row 20: @a.push([7,8]); @a[2].raku';
+}
+{
+    my @a;
+    @a[3] = [7, 8];
+    is @a[3].raku, '$[7, 8]', 'row 21: my @a; @a[3] = [7,8]; @a[3].raku';
+}
+{
+    my @a;
+    @a.append([7, 8], [9, 0]);
+    is @a[0].raku, '$[7, 8]', 'row 22: @a.append([7,8],[9,0]); @a[0].raku';
+    is @a.elems, 2, 'row 22: @a.append([7,8],[9,0]); @a.elems is 2';
+}
+
+{
+    todo 'row 23: construction-side itemization is ADR-0040 slice 2';
+    my @a23 = (1..3), (4..6);
+    is takes(@a23[0]), 1, 'row 23: my @a = (1..3),(4..6); takes(@a[0])';
+}
+{
+    todo 'row 24: .VAR reflection is ADR-0040 slice 3';
+    my @l := 1, (1, 2), [3, 4];
+    is "{@l[1].VAR.^name} {@l[2].VAR.^name}", 'List Array',
+        'row 24: @l[1].VAR.^name, @l[2].VAR.^name';
+}
+
+# row 25: the invariant. An Array's OWN .raku de-itemizes its elements --
+# this must NOT move, or a later slice has over-itemized.
+is @c.raku, '[["a", "b"], ["c", "d"]]', 'row 25: @c.raku stays bare (invariant)';
+
+# === SS1.6 agreeing rows (must stay agreeing) ===
+
+{
+    my $n1;
+    for ((1, 2), (3, 4)) { $n1 = takes($_) }
+    is $n1, 2, 'SS1.6: List literal source, implicit topic, stays 2';
+}
+{
+    my $n2;
+    for (([1, 2], [3, 4])) { $n2 = takes($_) }
+    is $n2, 2, 'SS1.6: List of Array literals, implicit topic, stays 2';
+}
+{
+    my $n3;
+    for @c -> $v { $n3 = takes($v) }
+    is $n3, 1, 'SS1.6: real Array source, pointy param, stays 1 (bind-side)';
+}
+
+# === Slice 1 extras: the other mutation sites this PR fixes ===
+
+{
+    my %h2;
+    %h2<a> = [1, 2];
+    is %h2<a>.raku, '$[1, 2]', 'slice 1: %h<a> = [1,2]; %h<a>.raku';
+}
+{
+    my @u = 1, 2;
+    @u.unshift([9, 9]);
+    is @u[0].raku, '$[9, 9]', 'slice 1: @u.unshift([9,9]); @u[0].raku';
+}
+{
+    my @p = 1, 2;
+    @p.prepend([8, 8]);
+    is @p[0].raku, '8', 'slice 1: @p.prepend([8,8]) flattens (one-arg rule)';
+    is @p.elems, 4, 'slice 1: @p.prepend([8,8]) flattens to 4 elements';
+}
+{
+    my @b2 = 1, 2;
+    @b2.push(1, [2, 3]);
+    is @b2[3].raku, '$[2, 3]', 'slice 1: multi-arg push itemizes only the aggregate';
+}
+
+# === arity invariants (must NOT change) ===
+
+{
+    my @p1;
+    @p1.push(1, 2);
+    is @p1.elems, 2, 'arity: push(1,2) is 2 elements';
+}
+{
+    my @a2;
+    @a2.append((5, 4));
+    is @a2.elems, 2, 'arity: append((5,4)) is 2 elements';
+}
+
+# === SS2 negatives: must NOT be wrapped ===
+
+{
+    my @a3;
+    @a3[0] = (a => 1);
+    is @a3[0].raku, ':a(1)', 'negative: a Pair element stays unwrapped';
+}
+{
+    my @a4;
+    @a4[0] = Set.new(1, 2);
+    is @a4[0].raku, 'Set.new(1,2)', 'negative: a Set element stays unwrapped';
+}
+{
+    my @a5;
+    @a5[0] = 5;
+    is @a5[0].raku, '5', 'negative: an Int element stays unwrapped';
+}
+
+# === native-array safety (must not corrupt native storage) ===
+
+{
+    my int @n;
+    @n.push(5);
+    is @n[0], 5, 'native: int @n.push(5) stores a plain native Int';
+}
+
+# === further Slice 1 mutation sites: nested autovivification, Hash.push,
+# and reference-shared push all itemize too ===
+
+{
+    # Nested autovivification: `@a[5][0] = 1` autovivifies `@a[5]` as a
+    # fresh Array, and that freshly-stored intermediate element itemizes
+    # like any other Array/Hash element store.
+    my @a6;
+    @a6[5][0] = 1;
+    is @a6[5].raku, '$[1]', 'slice 1: @a[5][0] = 1; @a[5].raku';
+}
+{
+    # Nested hash autovivification: `%h<a><b> = 1` autovivifies `%h<a>` as
+    # a fresh Hash, itemized the same way.
+    my %h4;
+    %h4<a><b> = 1;
+    is %h4<a>.raku, '${:b(1)}', 'slice 1: %h<a><b> = 1; %h<a>.raku';
+}
+{
+    # Hash.push (the slow-path method dispatch, not the `%h<k> = v` opcode)
+    # itemizes the pushed pair's value the same way.
+    my %h3;
+    %h3.push('a' => [1, 2]);
+    is %h3<a>.raku, '$[1, 2]', 'slice 1: %h.push(pair) itemizes the pushed value';
+}
+{
+    # Reference-shared push (`@a.push(@b)`, a NAMED array): raku's
+    # non-flattening `**@values` slurpy stores the container itself, kept
+    # live-aliased, AND itemized on the pushed element -- while `@b` read
+    # directly stays bare (the two readers of the shared cell disagree on
+    # itemization, matching raku exactly).
+    my @b3 = (1, 2);
+    my @a7;
+    @a7.push(@b3);
+    is @a7[0].raku, '$[1, 2]', 'slice 1: @a.push(@b) (reference-shared); @a[0].raku';
+    is @b3.raku, '[1, 2]', 'slice 1: @b itself stays bare after the reference push';
+    @b3.push(3);
+    is @a7[0].raku, '$[1, 2, 3]', 'slice 1: mutating @b propagates through the shared cell';
+}
+
+done-testing;

--- a/t/element-store-itemization.t
+++ b/t/element-store-itemization.t
@@ -260,4 +260,50 @@ is @c.raku, '[["a", "b"], ["c", "d"]]', 'row 25: @c.raku stays bare (invariant)'
     is @a7[0].raku, '$[1, 2, 3]', 'slice 1: mutating @b propagates through the shared cell';
 }
 
+# === CI regression (roast/integration/advent2010-day11.t crashed): an
+# itemized element must decompose into its OWN elements for `.pick`/`.roll`/
+# `.head`/`.tail`, not be treated as a single opaque item. Itemization
+# governs how a value flattens as an ELEMENT of some OTHER container; it
+# must not change how a value decomposes when it is itself the receiver of
+# one of these methods. ===
+
+{
+    # Nested-autovivified Hash element (`%h<a><b>++`): `.roll` on it must
+    # roll one of ITS OWN pairs, not return the whole (itemized) hash.
+    my %outer;
+    %outer{"x"}{"y"}++;
+    my $rolled = %outer{"x"}.roll;
+    is $rolled.WHAT, Pair, 'roll on itemized Hash element returns a Pair';
+    is $rolled.raku, ':y(1)', 'roll on itemized Hash element rolls its own pair';
+}
+
+{
+    # Same for `.pick` on an itemized Hash element.
+    my %outer2;
+    %outer2{"x"}{"y"}++;
+    my $picked = %outer2{"x"}.pick;
+    is $picked.WHAT, Pair, 'pick on itemized Hash element returns a Pair';
+}
+
+{
+    # Itemized Array element (`@a.push([1,2,3])`): `.roll`/`.pick` must
+    # return one of its own elements, not the whole itemized array.
+    my @a;
+    @a.push([1, 2, 3]);
+    my $rolled = @a[0].roll;
+    is $rolled.WHAT, Int, 'roll on itemized Array element returns an element';
+    ok (1 <= $rolled <= 3), 'roll on itemized Array element is in range';
+    my $picked = @a[0].pick;
+    is $picked.WHAT, Int, 'pick on itemized Array element returns an element';
+}
+
+{
+    # `.head`/`.tail` on an itemized Array element likewise decompose into
+    # elements, not the whole itemized array.
+    my @a2;
+    @a2.push([1, 2, 3]);
+    is @a2[0].head, 1, 'head on itemized Array element returns its first element';
+    is @a2[0].tail, 3, 'tail on itemized Array element returns its last element';
+}
+
 done-testing;

--- a/todo/tickets/splice-multi-arg-array-incorrectly-flattens.md
+++ b/todo/tickets/splice-multi-arg-array-incorrectly-flattens.md
@@ -1,0 +1,86 @@
+# `.splice()` incorrectly flattens an Array/List replacement arg even when it is not the sole replacement arg
+
+Discovered while implementing ADR-0040 Slices 0-1 (element-store itemization) and
+writing its acceptance oracle, `t/element-store-itemization.t`.
+
+## Root cause
+
+`do_splice` (`src/runtime/methods_mut_dispatch.rs`, inside the `"splice"` match arm) builds
+the replacement-element list with:
+
+```rust
+for arg in args.iter().skip(2) {
+    match arg.view() {
+        ValueView::Array(arr, ..) => {
+            new_items.extend(arr.iter().cloned());
+        }
+        _ => new_items.push(arg.clone()),
+    }
+}
+```
+
+This flattens **every** `Array`/`List`-kind argument unconditionally, regardless of how many
+replacement arguments were passed. But raku's `splice` follows the same "one-arg rule" as
+`push`/`append`/`unshift`/`prepend`: an `Array`/`List` argument flattens only when it is the
+**sole** replacement argument; when there are multiple replacement arguments, each one
+(including an `Array`/`List`) becomes exactly one element.
+
+## Repro
+
+```
+my @a = 1,2,3;
+@a.splice(1,1,"x",[7,8]);
+say @a.raku;
+```
+
+- raku: `[1, "x", [7, 8], 3]` (4 elements: `[7,8]` is kept as ONE element)
+- mutsu: `[1, "x", 7, 8, 3]` (5 elements: `[7,8]` flattens even though `"x"` is also present)
+
+Also reproduces with two Array/List args and no leading scalar:
+
+```
+my @a = 1,2,3;
+@a.splice(1,1,[7,8],[9,0]);
+say @a.elems;
+```
+
+- raku: `4` (each array kept as one element)
+- mutsu: `6` (both arrays flattened)
+
+Additionally, a *single* replacement Array/List argument flattens in raku **unconditionally**,
+even when it is already itemized (`$[7,8]`) — this differs from `push`/`append`'s one-arg rule,
+where an itemized single argument does NOT flatten (`t/append-one-arg-rule.t`). So `splice`'s
+correct rule is not simply "reuse `flatten_append_args`" — it needs its own one-arg-rule variant
+that ignores itemization for the single-arg flatten decision, but still keeps non-flattened
+elements (the multi-arg case) itemized per ADR-0040.
+
+## Why this is a separate ticket
+
+This is a pre-existing arity/flattening bug, orthogonal to ADR-0040's element-store
+itemization work (`docs/adr/0040-array-hash-elements-are-itemized-at-the-store.md`). ADR-0040
+Slice 1 applies itemization to whatever `do_splice` decides is a single kept-whole element (the
+`_ => new_items.push(...)` branch, which already correctly handles non-Array discrete args like
+a `Range` — see `t/element-store-itemization.t`'s M3 row); it deliberately does not touch the
+Array-flattening decision logic above, to keep the itemization PR's blast radius scoped to
+itemization only.
+
+## Suggested fix
+
+Replace the per-arg-independent flattening loop with a one-arg-rule check scoped to
+`args[2..]` as a whole (mirroring `flatten_append_args`, `src/runtime/mod.rs:63-88`, but with
+splice's own "flatten even if itemized" quirk for the single-arg case):
+
+```rust
+let post = &args[2..];
+if post.len() == 1 {
+    // flatten unconditionally (Array/List/Seq/Hash/Range), regardless of itemization
+} else {
+    // each arg becomes exactly one element (itemized per ADR-0040 where applicable)
+}
+```
+
+Needs a `raku -e` sweep of the single-arg case across Array/List/itemized-Array/Seq/Hash/Range
+to confirm which of those still flatten unconditionally for `splice` specifically (this ticket
+only measured Array/List), then a regression test file (`t/splice-arg-flatten-rule.t` or
+similar) covering both the arity and (once ADR-0040 lands) the itemization of kept-whole
+elements.


### PR DESCRIPTION
## Summary

Implements Slices 0-1 of [ADR-0040](docs/adr/0040-array-hash-elements-are-itemized-at-the-store.md) ("Array/Hash elements are itemized at the store"). Raku's model is that every `Array`/`Hash` element **is** a `Scalar` container: reading it back gives one item in list context and renders itemized (`$["a", "b"]`). mutsu stored elements bare, so `my @a; @a.push([7,8]); say @a[0].raku` printed `[7, 8]` instead of raku's `$[7, 8]`.

This fixes it at the element *store* rather than compensating in readers:

- **Element assign** (`@a[i] = v`, `%h<k> = v`), single- and **nested-level autovivification** (`@a[5][0] = 1` now itemizes the freshly-created `@a[5]`; `%h<a><b> = 1` likewise).
- **`push`/`unshift`/`append`/`prepend`/`splice`**, always applied *after* each site's own one-arg-rule/Slip-flattening decision so arity never changes — `push(1,2)` still adds two bare elements, `push([1,2])` still adds one itemized element.
- **`Hash.push`** and **reference-shared push** (`@a.push(@b)`) — the latter needed a dedicated representation: the shared `ContainerRef` cell's own content stays untouched (so `@b` read directly still renders bare), and only the *pushed element's own* wrapper carries the itemization, matching raku exactly (`@a[0].raku` is `$[1, 2]` while `@b.raku` stays `[1, 2]`, and a later `@b.push(3)` still propagates through the shared cell).

A pre-existing, unrelated `splice` arity bug was found and filed separately (`todo/tickets/splice-multi-arg-array-incorrectly-flattens.md`) rather than fixed here, to keep this PR's blast radius scoped to itemization.

`t/element-store-itemization.t` is the acceptance oracle: the full ADR-0040 §1.3 divergence matrix (dual-oracled against `raku`) plus the invariants that must never move (an `Array`'s own `.raku` still de-itemizes its elements, `Pair`/`Set`/`Int` elements stay unwrapped, arity is unaffected). Rows that depend on itemizing at *construction* time (list-assign, literal construction) or on `.VAR` reflection stay `todo`-marked for ADR-0040 slices 2-3, explicitly out of scope for this PR.

Full write-up (including the representation subtlety for reference-shared push and the method-dispatch decontainerize fix it required) is in the ADR's new "Implementation status" section and `news/2026-08/element-store-itemization-slices-0-1.md`.

## Test plan

- [x] `cargo build`, `cargo clippy -- -D warnings`, `cargo fmt --check` all clean.
- [x] `t/element-store-itemization.t` — 46/46 assertions pass.
- [x] The full ADR-0040 regression net (must-stay-green + de-itemization-consumer groups, 18 files / 200 assertions) — all pass unchanged.
- [x] Full local `t/` suite (3322 files) — `Result: PASS`.
- [x] Targeted whitelisted roast batches: `S32-array/*` (21 files), `S32-hash/*` (17 files), `S09-typed-arrays/*` (9 files), `S02-types/{array,array_extending,array_ref,assigning-refs,autovivification,flattening,hash,hash_ref,list,multi_dimensional_array}.t` — all pass unchanged.
- [ ] CI (`make test` + `make roast`) — watching in the background.

🤖 Generated with [Claude Code](https://claude.com/claude-code)