### PR TITLE
feat(vm): EVAL context frame classifies the snippet's return (ADR-0037 Slices 2-3)

### DIFF
--- a/docs/adr/0037-eval-context-frame-owns-the-return-target.md
+++ b/docs/adr/0037-eval-context-frame-owns-the-return-target.md
@@ -440,7 +440,7 @@ the push/pop is a plain `Vec<RoutineFrame>` operation with no `Env` clone, as
 §4 predicted. A bench-CI-measured wall-clock verdict (the §4 guard) is
 pending the next `bench-history.tsv` row past this change's merge commit.
 
-**Slices 2-3 landed (2026-08-21, PR #6821).** Slice 2:
+**Slices 2-3 landed (2026-08-21, PR #6828).** Slice 2:
 `caller_frame_enclosing_routine()` (`src/runtime/accessors_stack.rs`) walks
 `routine_stack` from `caller_frame_package`'s same frame down past any block
 frames to the nearest actual routine, and the `CALLER::`/`CALLERS::` stamp

--- a/docs/adr/0037-eval-context-frame-owns-the-return-target.md
+++ b/docs/adr/0037-eval-context-frame-owns-the-return-target.md
@@ -1,8 +1,8 @@
 # ADR-0037: `EVAL ..., context => $frame` — the context frame owns the return target, and the routine chain must be dispatch-path-independent
 
-- Status: Partially implemented — Slice 1 landed (see "Implementation status"
-  below); Slices 2-4 (the `context`-driven return classification and
-  targeting itself) are next
+- Status: Partially implemented — Slices 1-3 landed (see "Implementation
+  status" below); Slice 4 (targeting a live context routine) and Slice 5
+  (residue/end-to-end sweep) are next
 - Date: 2026-08-20
 - Origin: `todo/deep/eval-context-frame-owns-the-return-target.md`
 - Related: [ADR-0035](0035-method-calls-observe-caller-frames.md) (same family —
@@ -440,6 +440,72 @@ the push/pop is a plain `Vec<RoutineFrame>` operation with no `Env` clone, as
 §4 predicted. A bench-CI-measured wall-clock verdict (the §4 guard) is
 pending the next `bench-history.tsv` row past this change's merge commit.
 
-**Slices 2-4 (the `context`-driven return classification and targeting) are
-not started.** They build on Slice 1's now-sound `routine_stack` but are
+**Slices 2-3 landed (2026-08-21, PR #6821).** Slice 2:
+`caller_frame_enclosing_routine()` (`src/runtime/accessors_stack.rs`) walks
+`routine_stack` from `caller_frame_package`'s same frame down past any block
+frames to the nearest actual routine, and the `CALLER::`/`CALLERS::` stamp
+site (`src/vm/vm_var_assign_local.rs`) now stamps its `package::name` onto the
+pseudo-stash as `__mutsu_origin_routine`
+(`Interpreter::stamp_stash_origin_routine`, `src/runtime/accessors_stash.rs`)
+beside the existing `__mutsu_origin_package` — same invisible-attribute
+convention, absent entirely when the captured frame is a mainline. A reader,
+`eval_context_routine`, sits beside `eval_context_package`.
+
+Slice 3: `builtin_eval` (`src/runtime/builtins_eval_misc.rs`) reads that
+identity via a new `classify_eval_context_routine` helper into an
+`EvalContextRoutineState` (`Mainline` / `Live` / `Dead`, `src/runtime/mod.rs`),
+walking `routine_stack` for a `package::name` match to decide liveness —
+sound only because Slice 1 made every dispatch path push a frame. The
+classification is threaded through a new `pending_eval_context_routine` field
+(save/restore around the `EVAL` call, mirroring `pending_eval_sigilless`)
+into `compile_block_value_opts`'s `in_routine` derivation (via a shared
+`eval_unit_in_routine()` helper) **and** into `carrier_compile_ctx_key`, so
+the carrier-compile cache cannot serve a unit compiled under a different
+classification. `Live` is treated exactly like the ambient
+"an enclosing routine exists" answer (Slice 4's job is to additionally target
+that specific frame — not implemented yet, so a `Live` classification today
+just keeps the pre-ADR-0037 non-local-return behavior). `Mainline` and `Dead`
+both compile `is_routine = false`, but `Dead` additionally sets a new
+`Compiler::eval_context_dead_routine` flag, which rides a second `bool` added
+to `OpCode::ReturnFromNonRoutine` so the thrown `X::ControlFlow::Return`
+carries `out-of-dynamic-scope: True`.
+
+That flag also drove a small, independently-useful correction to
+`RuntimeError::controlflow_return()`: its message was hardcoded to "Attempt
+to return outside of any Routine" regardless of `out_of_dynamic_scope`, but
+`raku` uses a second, fuller wording ("Attempt to return outside of
+immediately-enclosing Routine (i.e. `return` execution is outside the dynamic
+scope of the Routine where `return` was used)") whenever a routine genuinely
+was the target at some point and is no longer live — verified directly
+against `raku` for both the plain "no routine at all" case and a `-> { return
+5 }` closure called after its defining routine returned. The message now
+branches on the flag, which also correctly changes the wording for the two
+pre-existing `out_of_dynamic_scope: true` call sites (`io_env.rs`'s
+`render_gist_value`, `vm_run_loop.rs`'s top-level escaping-signal
+conversion) — checked against the tests that pin the old wording
+(`t/exception-messages.t`, `t/try-catch-tail-statement-sink.t`) and confirmed
+none of them exercise an `out_of_dynamic_scope: true` path.
+
+Verified directly against `raku -e` for all three rows the ADR's §2.3 table
+assigns to these slices: §1.1(a)'s mainline-context probe (`thrower saw:
+X::ControlFlow::Return`, `thrower-end`, `still alive`) and a dead-routine
+probe modeled on §1.1(c) (`Attempt to return outside of
+immediately-enclosing Routine ...`) both match mutsu's output exactly, and
+the uncontextualized `sub f() { EVAL 'return 1'; return 2 }` still answers
+`1`. Pins: `t/eval-context-caller-routine-attr.t` (new — the hidden-attribute
+invisibility pin for Slice 2, and confirms `t/eval-context-package.t` is
+unaffected). The ADR's own acceptance gate,
+`MUTSU_REAL_TEST=1 prove -e target/debug/mutsu t/throws-like-gather-sink.t`,
+now reaches 4/4 (previously aborted after subtest 1). Full local `t/` suite
+(30847 tests) green; targeted roast re-runs on both debug and release
+binaries (`roast/S04-statements/return.t` test 15 specifically,
+`roast/S32-exceptions/misc.t`, `roast/S02-types/WHICH.t`,
+`roast/6.c/S02-names/SETTING-6c.t`, `roast/S02-names/{SETTING-6e,caller}.t`,
+`roast/S03-binding/scalars.t`, `roast/S04-statements/goto.t`,
+`roast/S06-signature/definite-return.t`) all green; `cargo clippy -- -D
+warnings` and `cargo fmt` clean.
+
+**Slice 4 (targeting a live context routine) and Slice 5 (residue and
+end-to-end sweep) are not started.** They build on Slice 1's now-sound
+`routine_stack` and Slice 2-3's classification/identity machinery but are
 independent follow-up work.

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -1252,6 +1252,15 @@ pub(crate) struct Compiler {
     /// Used to decide whether `return` in a non-routine block should perform
     /// a non-local return (via CX::Return) or throw X::ControlFlow::Return.
     pub(crate) lexically_in_routine: bool,
+    /// ADR-0037 §2.3: set only for an EVAL unit whose `context => $ctx` named
+    /// a routine that had already exited the dynamic call stack when the
+    /// `EVAL` ran (decided once, at EVAL entry, by `builtin_eval`). Only
+    /// meaningful together with `is_routine == false` — it makes the emitted
+    /// `ReturnFromNonRoutine` throw `X::ControlFlow::Return` with
+    /// `out-of-dynamic-scope` set and rakudo's fuller wording, instead of the
+    /// plain "no routine at all" message, matching raku's dead-context
+    /// probe (ADR-0037 §1.1(c)).
+    pub(crate) eval_context_dead_routine: bool,
     /// Whether we are directly compiling the body statements of a plain
     /// `Stmt::Block` that emits `OpCode::BlockScope` (see the `Stmt::Block`
     /// arm in `stmt.rs`). That opcode snapshots `env` before the body and
@@ -1552,6 +1561,7 @@ impl Compiler {
             callframe_block_depth: 0,
             is_routine: false,
             lexically_in_routine: false,
+            eval_context_dead_routine: false,
             lexically_in_block: false,
             lexically_in_method: false,
             bind_vardecl: false,

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -2868,8 +2868,10 @@ impl Compiler {
                 if self.is_routine {
                     self.code.emit(OpCode::Return);
                 } else {
-                    self.code
-                        .emit(OpCode::ReturnFromNonRoutine(self.lexically_in_routine));
+                    self.code.emit(OpCode::ReturnFromNonRoutine(
+                        self.lexically_in_routine,
+                        self.eval_context_dead_routine,
+                    ));
                 }
             }
             Stmt::Die(expr) => {

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -1898,14 +1898,22 @@ pub(crate) enum OpCode {
     // -- Functions --
     Return,
     /// Return used outside a routine.
-    /// The `bool` payload is `true` if the op is lexically nested inside a
-    /// routine (a closure/block in a sub) — in that case `return` should
+    /// The first `bool` payload is `true` if the op is lexically nested inside
+    /// a routine (a closure/block in a sub) — in that case `return` should
     /// perform a non-local return up to the enclosing routine, and only
     /// become an `X::ControlFlow::Return` exception when no enclosing routine
     /// is on the dynamic call stack (out-of-dynamic-scope).
     /// When `false`, the op is at top level with no lexical routine and
     /// throws `X::ControlFlow::Return` directly.
-    ReturnFromNonRoutine(bool),
+    ///
+    /// The second `bool` (only meaningful when the first is `false`) is
+    /// ADR-0037 §2.3's dead-routine-context classification: `EVAL ..., context
+    /// => $ctx` where `$ctx` names a routine that already exited the dynamic
+    /// call stack decides this *eagerly*, at EVAL entry, rather than by
+    /// unwinding a real signal — so the `X::ControlFlow::Return` thrown here
+    /// still needs `out-of-dynamic-scope` set and rakudo's fuller wording,
+    /// exactly like a signal that genuinely escaped every frame.
+    ReturnFromNonRoutine(bool, bool),
     RegisterDecl(u32),
     RegisterEnum(u32),
     AugmentClass(u32),

--- a/src/runtime/accessors_stack.rs
+++ b/src/runtime/accessors_stack.rs
@@ -134,6 +134,30 @@ impl Interpreter {
         "GLOBAL".to_string()
     }
 
+    /// `package::name` of the routine that dynamically encloses the frame
+    /// `CALLER::` names — walking down past any *block* frames (a bare
+    /// `{ ... }`, a `for` body, a closure) starting at `caller_frame_package`'s
+    /// same frame (`routine_stack[len - 2]`) to the nearest actual routine
+    /// (`is_block == false`). `None` when no routine encloses it at all: the
+    /// frame `CALLER::` names is the mainline, or (with fewer than two frames
+    /// live) there is no caller frame to walk from in the first place.
+    ///
+    /// This is ADR-0037 §2.2's control-flow identity, stamped onto the
+    /// pseudo-stash alongside the package so `EVAL ..., context => $ctx` can
+    /// later classify the snippet's `return` (§2.3) instead of only naming
+    /// its package (`caller_frame_package`, `stamp_stash_origin_package`).
+    pub(crate) fn caller_frame_enclosing_routine(&self) -> Option<String> {
+        let len = self.routine_stack.len();
+        if len < 2 {
+            return None;
+        }
+        self.routine_stack[..len - 1]
+            .iter()
+            .rev()
+            .find(|f| !f.is_block)
+            .map(|f| format!("{}::{}", f.package, f.name))
+    }
+
     /// The file the code currently executing was *defined* in — the module path
     /// for a routine that came from a `use`d module, the script otherwise.
     ///

--- a/src/runtime/accessors_stash.rs
+++ b/src/runtime/accessors_stash.rs
@@ -40,6 +40,15 @@ impl Interpreter {
     /// `EVAL $code, context => $stash` reads it back (`eval_context_package`).
     pub(crate) const STASH_ORIGIN_PACKAGE_ATTR: &str = "__mutsu_origin_package";
 
+    /// Attribute a pseudo-stash carries to remember the *control-flow*
+    /// identity (`package::name`) of the routine that dynamically encloses the
+    /// frame the stash was taken from — ADR-0037 §2.2. Same invisibility
+    /// convention as `STASH_ORIGIN_PACKAGE_ATTR`: an attribute, not a
+    /// `symbols` member, so `.keys`/`.gist` never see it. Absent (not
+    /// inserted at all) when the captured frame is a mainline, which
+    /// `eval_context_routine` treats identically to "key not found".
+    pub(crate) const STASH_ORIGIN_ROUTINE_ATTR: &str = "__mutsu_origin_routine";
+
     /// Stamp `origin` onto a pseudo-stash value. `CALLER::` names the frame that
     /// was current *where the stash was taken*, which is not recoverable later:
     /// `Test.rakumod` writes `my $ctx = CALLER::` in `throws-like` and uses it
@@ -49,6 +58,23 @@ impl Interpreter {
         if let ValueView::Instance { attributes, .. } = stash.view() {
             attributes.insert(
                 Self::STASH_ORIGIN_PACKAGE_ATTR.to_string(),
+                Value::str(origin.to_string()),
+            );
+        }
+    }
+
+    /// Stamp the frame's control-flow identity (see
+    /// `caller_frame_enclosing_routine`) onto a pseudo-stash value, beside the
+    /// package `stamp_stash_origin_package` already records. `None` (a
+    /// mainline frame) stamps nothing, matching how `eval_context_routine`
+    /// reads a missing attribute back as "no enclosing routine".
+    pub(crate) fn stamp_stash_origin_routine(stash: &Value, origin: Option<&str>) {
+        let Some(origin) = origin else {
+            return;
+        };
+        if let ValueView::Instance { attributes, .. } = stash.view() {
+            attributes.insert(
+                Self::STASH_ORIGIN_ROUTINE_ATTR.to_string(),
                 Value::str(origin.to_string()),
             );
         }
@@ -75,6 +101,26 @@ impl Interpreter {
             ValueView::Package(sym) => {
                 let name = sym.resolve().to_string();
                 (!Self::is_pseudo_package_name(&name)).then_some(name)
+            }
+            _ => None,
+        }
+    }
+
+    /// The `package::name` of the routine an `EVAL ..., context => $ctx`'s
+    /// `return` should be classified against (ADR-0037 §2.3), or `None` when
+    /// the context says nothing about one — either it is not a stamped
+    /// pseudo-stash at all, or `CALLER::` was captured from a mainline (no
+    /// enclosing routine; see `stamp_stash_origin_routine`).
+    pub(crate) fn eval_context_routine(ctx: &Value) -> Option<String> {
+        match ctx.view() {
+            ValueView::Instance {
+                class_name,
+                attributes,
+                ..
+            } if class_name == "Stash" => {
+                let map = attributes.as_map();
+                map.get(Self::STASH_ORIGIN_ROUTINE_ATTR)
+                    .map(|v| v.to_string_value())
             }
             _ => None,
         }

--- a/src/runtime/builtins_eval_misc.rs
+++ b/src/runtime/builtins_eval_misc.rs
@@ -319,23 +319,68 @@ impl Interpreter {
         // caller and not after whichever module called EVAL. Without this a
         // `throws-like 'class Foo { ... }', X::...` written against the real
         // `Test` module reports `Test::Foo`.
-        let saved_package = Self::named_value(args, "context")
-            .and_then(|ctx| Self::eval_context_package(&ctx))
+        let context_arg = Self::named_value(args, "context");
+        let saved_package = context_arg
+            .as_ref()
+            .and_then(Self::eval_context_package)
             .map(|pkg| {
                 let saved = self.current_package();
                 self.set_current_package(pkg);
                 saved
             });
+        // ADR-0037 §2.3: classify what the snippet's `return` should do from
+        // `$ctx`'s stamped routine identity (§2.2), once, here at EVAL entry
+        // -- not at the `return` itself, since the snippet runs synchronously
+        // inside this call so no frame below it can disappear in between.
+        // `None` (no `context` argument at all) leaves
+        // `compile_block_value_opts`'s ambient classification untouched.
+        let saved_context_routine = context_arg.as_ref().map(|ctx| {
+            let state = self.classify_eval_context_routine(ctx);
+            self.pending_eval_context_routine.replace(state)
+        });
         let check_only = Self::named_value(args, "check").is_some_and(|v| v.truthy());
         let result = if check_only {
             self.eval_eval_string_check_only(&code)
         } else {
             self.eval_eval_string(&code)
         };
+        if let Some(saved) = saved_context_routine {
+            self.pending_eval_context_routine = saved;
+        }
         if let Some(saved) = saved_package {
             self.set_current_package(saved);
         }
         result
+    }
+
+    /// ADR-0037 §2.3: classify `ctx`'s (an `EVAL ..., context => $ctx`
+    /// argument) routine identity into what the EVAL unit's `return` should
+    /// do. `Mainline` both when `ctx` carries no routine identity at all
+    /// (`eval_context_routine` returns `None` — either `ctx` is not a stamped
+    /// pseudo-stash, or `CALLER::` named the mainline) and when it does but
+    /// no live frame matches it (checked against `Dead` below only when a key
+    /// IS present, so this covers the "not a frame-derived context" case,
+    /// e.g. `context => SomePackage`, exactly like a bare package name has no
+    /// dynamic-scope identity of its own).
+    ///
+    /// Liveness is a walk of `routine_stack` comparing `package::name`
+    /// against the recorded key -- sound only because ADR-0037 Slice 1 made
+    /// every sub dispatch path push a routine frame; a re-entrant same-named
+    /// routine is indistinguishable by that key and resolves to the
+    /// innermost live frame, matching `return`'s own lexical semantics.
+    fn classify_eval_context_routine(&self, ctx: &Value) -> EvalContextRoutineState {
+        let Some(key) = Self::eval_context_routine(ctx) else {
+            return EvalContextRoutineState::Mainline;
+        };
+        let live = self
+            .routine_stack
+            .iter()
+            .any(|f| !f.is_block && format!("{}::{}", f.package, f.name) == key);
+        if live {
+            EvalContextRoutineState::Live
+        } else {
+            EvalContextRoutineState::Dead
+        }
     }
 
     pub(super) fn builtin_dd(&mut self, args: &[Value]) -> Result<Value, RuntimeError> {

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -158,6 +158,31 @@ type ProtectBlockCacheEntry = (
 );
 type ProtectBlockCache = HashMap<u64, ProtectBlockCacheEntry>;
 
+/// ADR-0037 §2.3: how `EVAL ..., context => $ctx`'s `return` classifies,
+/// derived once at EVAL entry from the routine identity `CALLER::` stamped
+/// on `$ctx` (`Interpreter::eval_context_routine`). Liveness is decided at
+/// entry rather than at each `return`, because the snippet runs synchronously
+/// inside the `EVAL` call so no frame below it can disappear in between (see
+/// the ADR's §2.3 rationale).
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum EvalContextRoutineState {
+    /// `$ctx` named a mainline (no routine dynamically encloses the captured
+    /// frame): the snippet's `return` throws `X::ControlFlow::Return` right
+    /// at the `return` site, matching raku's §1.1(a) probe.
+    Mainline,
+    /// `$ctx` named a routine that is still live on the dynamic call stack:
+    /// an enclosing routine exists, same as the ambient (no-`context`)
+    /// classification. Targeting *that specific* frame past any intervening
+    /// routines (raku's §1.1(b) probe) is ADR-0037 Slice 4, not implemented
+    /// by this classification alone.
+    Live,
+    /// `$ctx` named a routine that has already exited the dynamic call
+    /// stack: throws `X::ControlFlow::Return` right at the `return` site,
+    /// with `out-of-dynamic-scope` set and rakudo's fuller wording, matching
+    /// raku's §1.1(c) probe.
+    Dead,
+}
+
 /// The ambient interpreter state `compile_block_value_opts` folds into a
 /// fresh `Compiler` before compiling a carrier block's body (`is_routine`/
 /// `lexically_in_routine`, the enclosing package scope, sigilless/placeholder
@@ -182,6 +207,14 @@ struct CarrierCompileCtxKey {
     sigilless: Vec<String>,
     placeholder_params: Vec<String>,
     distribution: Option<Value>,
+    /// ADR-0037 §2.3's classification (only ever set when `is_eval_unit`),
+    /// which affects the compiled bytecode beyond what `in_routine` alone
+    /// captures: a `Mainline` and a `Dead` classification both compile
+    /// `in_routine == false`, but a `Dead` unit's `return` additionally
+    /// carries the out-of-dynamic-scope wording (`Compiler::
+    /// eval_context_dead_routine`). Must stay in the key or the cache could
+    /// serve a unit compiled under the wrong classification.
+    eval_context_routine: Option<EvalContextRoutineState>,
 }
 
 /// Per-`SubData.id` cache of `(context, compiled)` pairs for
@@ -1426,6 +1459,17 @@ pub struct Interpreter {
     /// bound in env, seeded into `compile_block_value_opts`'s fresh compiler
     /// so its stray-placeholder checks know they are attached.
     pending_eval_placeholder_params: Vec<String>,
+    /// ADR-0037 §2.3: how `EVAL ..., context => $ctx` should classify the
+    /// snippet's `return`, computed once by `builtin_eval` from `$ctx`'s
+    /// stamped routine identity (`Interpreter::eval_context_routine`) and
+    /// consumed by `compile_block_value_opts`/`carrier_compile_ctx_key` while
+    /// compiling the EVAL unit's mainline. `None` means either no `context`
+    /// argument was passed at all, or it carried no routine identity — both
+    /// leave the ambient `enclosing_routine_exists()`-driven classification
+    /// unchanged. Saved/restored around the `EVAL` call (mirrors
+    /// `pending_eval_sigilless`), since a nested EVAL sets and restores its
+    /// own.
+    pending_eval_context_routine: Option<EvalContextRoutineState>,
     /// Set right before the interpret path evaluates the body of a `supply { … }`
     /// block, and consumed by the very next `eval_block_value_inner` so the
     /// freshly compiled chunk carries `CompiledCode::is_supply_block_body`.

--- a/src/runtime/resolution_eval.rs
+++ b/src/runtime/resolution_eval.rs
@@ -85,6 +85,20 @@ impl Interpreter {
         result
     }
 
+    /// ADR-0037 §2.3: `in_routine` for an EVAL unit's mainline. Prefers the
+    /// classification `builtin_eval` derived from an explicit `context => `
+    /// argument's stamped routine identity; falls back to the ambient
+    /// `enclosing_routine_exists()` when no `context` argument drove one (the
+    /// unchanged, pre-ADR-0037 behavior — `sub f() { EVAL 'return 1' }` still
+    /// returns from `f`).
+    fn eval_unit_in_routine(&self) -> bool {
+        match self.pending_eval_context_routine {
+            Some(EvalContextRoutineState::Live) => true,
+            Some(EvalContextRoutineState::Mainline) | Some(EvalContextRoutineState::Dead) => false,
+            None => self.enclosing_routine_exists(),
+        }
+    }
+
     /// Compile a block with `eval_block_value`'s compiler context (routine
     /// scope, `$?PACKAGE`/`$?DISTRIBUTION`) without executing it. Pure
     /// compilation — touches no `env`, runs no user code — so the VM can call it
@@ -126,12 +140,16 @@ impl Interpreter {
         // routine being run — including an anonymous `sub`, which pushes a
         // block frame — so narrowing it would turn their `return` into a throw.
         let in_routine = if is_eval_unit {
-            self.enclosing_routine_exists()
+            self.eval_unit_in_routine()
         } else {
             !self.routine_stack.is_empty()
         };
         compiler.is_routine = in_routine;
         compiler.lexically_in_routine = in_routine;
+        // ADR-0037 §2.3: only meaningful together with `is_routine == false`
+        // — see the field's doc comment on `Compiler`.
+        compiler.eval_context_dead_routine = is_eval_unit
+            && self.pending_eval_context_routine == Some(EvalContextRoutineState::Dead);
         // Let a nested closure in this body recognize the enclosing routine's
         // sigilless parameters (`\attr`) as lexical captures rather than
         // barewords. The fresh compiler otherwise has no signature context.
@@ -215,7 +233,7 @@ impl Interpreter {
     /// keep them matching so the cache actually helps.
     fn carrier_compile_ctx_key(&self, is_eval_unit: bool) -> CarrierCompileCtxKey {
         let in_routine = if is_eval_unit {
-            self.enclosing_routine_exists()
+            self.eval_unit_in_routine()
         } else {
             !self.routine_stack.is_empty()
         };
@@ -236,6 +254,11 @@ impl Interpreter {
             sigilless: self.pending_eval_sigilless.clone(),
             placeholder_params: self.pending_eval_placeholder_params.clone(),
             distribution,
+            eval_context_routine: if is_eval_unit {
+                self.pending_eval_context_routine
+            } else {
+                None
+            },
         }
     }
 

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -2840,6 +2840,7 @@ impl Interpreter {
             closure_env_overrides: HashMap::new(),
             pending_eval_sigilless: Vec::new(),
             pending_eval_placeholder_params: Vec::new(),
+            pending_eval_context_routine: None,
             pending_supply_block_body: false,
             pending_supply_emitter_sym: None,
             pending_supply_authoritative_free_vars: Vec::new(),

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -522,6 +522,7 @@ impl Interpreter {
             closure_env_overrides: self.closure_env_overrides.clone(),
             pending_eval_sigilless: Vec::new(),
             pending_eval_placeholder_params: Vec::new(),
+            pending_eval_context_routine: None,
             pending_supply_block_body: false,
             pending_supply_emitter_sym: None,
             pending_supply_authoritative_free_vars: Vec::new(),

--- a/src/value/error_typed.rs
+++ b/src/value/error_typed.rs
@@ -380,9 +380,28 @@ impl RuntimeError {
         Self::typed("X::Syntax::Malformed", attrs)
     }
 
-    /// X::ControlFlow::Return - Return outside of routine
+    /// X::ControlFlow::Return - Return outside of routine.
+    ///
+    /// rakudo uses two different wordings depending on whether a routine ever
+    /// dynamically enclosed the `return` at all. Verified against `raku`
+    /// (ADR-0037 §1.1(c)): a `return` with *no* lexically-enclosing routine
+    /// (`out_of_dynamic_scope == false`) reports "Attempt to return outside of
+    /// any Routine"; a `return` whose lexical target routine WAS on the
+    /// dynamic call stack at some point but is not anymore
+    /// (`out_of_dynamic_scope == true` — a signal that escaped every frame, or
+    /// an `EVAL ..., context => $ctx` whose `$ctx` names a routine that has
+    /// already returned) reports the fuller "Attempt to return outside of
+    /// immediately-enclosing Routine (i.e. `return` execution is outside the
+    /// dynamic scope of the Routine where `return` was used)".
     pub(crate) fn controlflow_return(out_of_dynamic_scope: bool) -> Self {
-        let msg = "Attempt to return outside of any Routine".to_string();
+        let msg = if out_of_dynamic_scope {
+            "Attempt to return outside of immediately-enclosing Routine (i.e. \
+             `return` execution is outside the dynamic scope of the Routine \
+             where `return` was used)"
+                .to_string()
+        } else {
+            "Attempt to return outside of any Routine".to_string()
+        };
         let mut attrs = HashMap::new();
         attrs.insert("message".to_string(), Value::str(msg.clone()));
         attrs.insert(

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -4170,7 +4170,7 @@ impl Interpreter {
                 }
                 return Err(RuntimeError::return_signal(val));
             }
-            OpCode::ReturnFromNonRoutine(lexically_in_routine) => {
+            OpCode::ReturnFromNonRoutine(lexically_in_routine, out_of_dynamic_scope) => {
                 let val = self.stack.pop().unwrap_or(Value::NIL);
                 if *lexically_in_routine {
                     // Closure/block lexically inside a routine: propagate a
@@ -4181,10 +4181,12 @@ impl Interpreter {
                     // `X::ControlFlow::Return` with `out-of-dynamic-scope`.
                     return Err(RuntimeError::return_signal(val));
                 }
-                // No lexical routine at all (e.g. top-level `return`): throw
-                // X::ControlFlow::Return directly.
+                // No lexical routine at all (e.g. top-level `return`), or
+                // (ADR-0037 §2.3) an `EVAL ..., context => $ctx` whose `$ctx`
+                // named a routine that had already exited when the EVAL ran:
+                // throw X::ControlFlow::Return directly, right here.
                 let _ = val;
-                return Err(RuntimeError::controlflow_return(false));
+                return Err(RuntimeError::controlflow_return(*out_of_dynamic_scope));
             }
 
             // -- Environment variable access --

--- a/src/vm/vm_var_assign_local.rs
+++ b/src/vm/vm_var_assign_local.rs
@@ -452,8 +452,10 @@ impl Interpreter {
             // needs the package of the frame it was taken from — which is gone
             // by the time EVAL runs. Record it on the value itself.
             let origin = self.caller_frame_package();
+            let origin_routine = self.caller_frame_enclosing_routine();
             let stash = loan_env!(self, package_stash_value(kind));
             Self::stamp_stash_origin_package(&stash, &origin);
+            Self::stamp_stash_origin_routine(&stash, origin_routine.as_deref());
             self.stack.push(stash);
             return;
         }

--- a/t/eval-context-caller-routine-attr.t
+++ b/t/eval-context-caller-routine-attr.t
@@ -1,0 +1,51 @@
+use v6;
+use Test;
+
+plan 6;
+
+# ADR-0037 Slice 2: `CALLER::` now stamps a second hidden attribute
+# (`__mutsu_origin_routine`, alongside the existing `__mutsu_origin_package`)
+# recording the control-flow identity of the routine that dynamically
+# encloses the captured frame. Same invisibility convention as the existing
+# package stamp: it is an *attribute* on the pseudo-stash Instance, not a
+# `symbols` member, so `.keys`/`.gist`/`.raku` must never expose it.
+
+sub inner() {
+    my $c = CALLER::;
+    $c;
+}
+sub outer() {
+    inner();
+}
+my $ctx = outer();
+
+is $ctx.keys.sort.join(','), '',
+    'CALLER:: pseudo-stash exposes no keys (both hidden origin attrs stay invisible)';
+unlike $ctx.gist, /mutsu_origin/,
+    '.gist does not mention the hidden origin-routine attribute';
+unlike $ctx.raku, /mutsu_origin/,
+    '.raku does not mention the hidden origin-routine attribute';
+
+# A mainline-captured CALLER:: (no enclosing routine) must also stay
+# key-less/gist-clean -- it simply stamps no origin-routine attribute at all.
+sub thrower() {
+    my $c = CALLER::; # names the mainline: no enclosing routine
+    $c;
+}
+my $mainline-ctx = thrower();
+is $mainline-ctx.keys.sort.join(','), '',
+    'a mainline-captured CALLER:: also exposes no keys';
+unlike $mainline-ctx.gist, /mutsu_origin/,
+    'a mainline-captured CALLER:: .gist stays clean too';
+
+# The existing package-context mechanism (t/eval-context-package.t) must be
+# completely unaffected by adding the parallel routine-identity stamp.
+sub run-in-context($code) {
+    my $ctx = CALLER::;
+    EVAL $code, context => $ctx;
+}
+sub caller-of-run() {
+    run-in-context('my class StampCheck { }; StampCheck.^name');
+}
+is caller-of-run(), 'StampCheck',
+    'context => CALLER:: package classification is unaffected by the routine stamp';


### PR DESCRIPTION
## Summary

Implements Slices 2-3 of [ADR-0037](docs/adr/0037-eval-context-frame-owns-the-return-target.md) (Slice 1, the `routine_stack` faithfulness prerequisite, already landed).

`EVAL $code, context => $ctx` compiles the snippet as if it stood at `$ctx`'s frame, but a `return` inside the snippet still resolved against whatever routine happened to lexically enclose the `EVAL` call, not the context frame — wrong per rakudo (measured in the ADR).

- **Slice 2** — stamp the frame's control-flow identity onto `CALLER::`/`CALLERS::`: `caller_frame_enclosing_routine()` walks `routine_stack` past any block frames to the nearest actual routine, and its `package::name` is stamped as a new hidden attribute (`__mutsu_origin_routine`, beside the existing `__mutsu_origin_package`) on the pseudo-stash, read back by `eval_context_routine`.
- **Slice 3** — `context` classifies the EVAL unit's `return`: `builtin_eval` derives an `EvalContextRoutineState` (`Mainline` / `Live` / `Dead`) from that identity by walking `routine_stack` for a live match, and threads it into `compile_block_value_opts`'s `in_routine` derivation and into `carrier_compile_ctx_key` (so the carrier-compile cache can't serve a unit compiled under a different classification). `Mainline`/`Dead` both compile `is_routine = false`; `Dead` additionally sets a new `Compiler::eval_context_dead_routine` flag (a new second `bool` on `OpCode::ReturnFromNonRoutine`) so the thrown `X::ControlFlow::Return` carries `out-of-dynamic-scope: True` and rakudo's fuller wording — verified directly against `raku`. This also fixed `RuntimeError::controlflow_return()`'s message, previously hardcoded regardless of `out_of_dynamic_scope`.

Slices 4 (targeting a live context routine) and 5 (residue/end-to-end sweep) are follow-up work, out of scope here.

## Test plan

- [x] `MUTSU_REAL_TEST=1 prove -e target/debug/mutsu t/throws-like-gather-sink.t` reaches 4/4 (the ADR's acceptance gate; previously aborted after subtest 1)
- [x] New pin `t/eval-context-caller-routine-attr.t` (hidden-attribute invisibility, mirrors the existing `__mutsu_origin_package` convention)
- [x] `t/eval-context-package.t` unaffected
- [x] Verified against `raku -e` for the mainline-context and dead-routine-context probes from ADR §1.1(a)/(c); uncontextualized `EVAL 'return 1'` behavior unchanged
- [x] Full local `t/` suite (30847 tests) green
- [x] Targeted roast re-runs (debug + release binaries): `roast/S04-statements/return.t` (test 15), `roast/S32-exceptions/misc.t`, `roast/S32-exceptions/misc2.t`, `roast/S02-types/WHICH.t`, `roast/6.c/S02-names/SETTING-6c.t`, `roast/S02-names/{SETTING-6e,caller}.t`, `roast/S03-binding/scalars.t`, `roast/S04-statements/goto.t`, `roast/S06-signature/definite-return.t`
- [x] `cargo clippy -- -D warnings` and `cargo fmt` clean
- [ ] CI (`make test` + `make roast`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)