### PR TITLE
docs: survey TOML parser battery slot, select Config::TOML

### DIFF
--- a/BATTERIES.md
+++ b/BATTERIES.md
@@ -65,6 +65,14 @@ this order:
 - **Proven behaviour on mutsu** — does it load and run today, or how far is it?
   A candidate that already `use`s cleanly beats a "better" one that needs a
   multi-session core campaign just to load.
+- **Maintainer stewardship** — a distribution published under
+  `auth<zef:raku-community-modules>` is preferred among otherwise-comparable
+  candidates: that org is a curated, actively-maintained home for ecosystem
+  modules (already the source of `HTTP::HPACK`, `IO::Path::ChildSecure`,
+  `JSON::JWT`, `Cro::*`, `DBIish`, and others in this bundle), so a module
+  living there is less likely to be a single-author dead project. It is a
+  tiebreaker, not a hard gate — do not let it override a real license or
+  "proven behaviour on mutsu" problem.
 - **API fit and idiom** — a clean, Raku-idiomatic public API that downstream
   code (and other batteries) can build on.
 - **Use-case coverage** — the guiding yardstick is **"a small web blog can be
@@ -274,6 +282,7 @@ make a real `https://` request using nothing but the shipped binary.
 | Web framework | `Cro::HTTP` v0.8.13 + `Cro::Core` v0.8.10 + `Cro::TLS` v0.8.10 (`zef:cro`) | Adopted | Artistic-2.0 | **Working** — vendored + zero-config `use`; the complete upstream suites pass against the bundled copy, matching raku (Cro::Core 9/9, Cro::HTTP 35/35, Cro::TLS included). The de facto ecosystem standard (61 dependents); chosen over Humming-Bird/Air/Web::App/6 others by a measured survey. HTTP/1.1, HTTP/2, WebSocket, routing, middleware, sessions, and auth all work — see the record for what remains (a real listening-socket TLS gap and two logging-library gaps, both in supporting dependencies, not Cro itself) | [cro-http.md](docs/batteries/cro-http.md) |
 | Slang activation | `Slangify` (`zef:lizmat`) + `Slang::Tuxic` (`zef:raku-community-modules`) | Bundled (verbatim) | Artistic-2.0 ×2 | **Working** — the upstream modules run verbatim (ADR-0026): a `use` of a slang-activating module executes it at parse time in a sub-interpreter with a compile-time `$*LANG`; Slangify's inner `&EXPORT` and its `define_slang` registration run for real, and the overridden grammar-rule names map onto parser modes (unknown rule = hard error). `Slang::Tuxic`'s upstream suite passes 8/8 (gated); Slangify's own test needs the `identifier`/`name` overrides (not yet in the map, fails loudly). Unblocks the `Text::CSV` campaign | [slang-tuxic.md](docs/batteries/slang-tuxic.md) |
 | Database (SQLite) | `DBIish` (`zef:raku-community-modules`) + `NativeLibs` + `NativeHelpers::Blob` | Adopted | BSD-2-Clause / Artistic-2.0 / Artistic-2.0 | **Working** — vendored + zero-config `use`; a real SQLite database can be opened, queried, and written to. 5 of 9 generic/SQLite upstream test files pass cleanly (gated); 4 remain partially blocked on a missing `Any.Int`/`.Num`/`Str.Buf` coercion family — see the record. Full upstream parity already holds against live PostgreSQL/MySQL (not gated — needs a server). Needs system `libsqlite3` at runtime | [database.md](docs/batteries/database.md) |
+| TOML config parser/writer | `Config::TOML` v0.1.3 + `Crane` v0.1.2 (both `zef:raku-community-modules`) | **Selected, not yet bundled** | Unlicense ×2 | Won the field (license, 0-net-dep chain, maintainer stewardship, richest upstream suite: 17 files) over `TOML` (7 dependents but requires raw `nqp::` op support — out of scope) and `TOML::Thumb` (single narrow blocker, runner-up). Currently 0/17 under mutsu: blocked on one general parser gap, `todo/tickets/token-method-bare-colon-adverb-name-not-supported.md` (bare-identifier `token`/`method` multi-dispatch names, e.g. `token gap:spacer {...}`) | [toml.md](docs/batteries/toml.md) |
 
 Other modules with a proven working record (Template::Mustache, HTTP::Parser,
 HTTP::Server::Tiny, NativeCall MVP, the Zef CLI) are tracked in `PLAN.md` §1 and

--- a/docs/batteries/selection-method.md
+++ b/docs/batteries/selection-method.md
@@ -50,14 +50,18 @@ For each candidate collect, in this order:
 | --- | --- | --- |
 | License | `META6.json` `license`, cross-checked against a shipped `LICENSE`/`LICENCE` and the README | hard gate |
 | Runtime deps | `depends` (note: a `{test => …}` structure means **zero** runtime deps) | §2's second criterion; a 0-dep dist is dramatically cheaper to bundle |
-| Version + release date | `rea.json` `version` / `release-date` | is it maintained, or abandoned in 2018? |
+| **Version + release date** | `rea.json` `version` / `release-date` | is it maintained, or abandoned years ago? **Always state this explicitly in the record's final decision, not just the metrics table** — a stale release is a leading indicator of deeper problems, not just neglect: the TOML survey (`docs/batteries/toml.md`) found the one candidate last released in 2021 (5 years old) was also the one written directly against raw `nqp::` ops, a coding style essentially unseen in current-era modules and a near-guaranteed mutsu parser/interpreter gap. Check the age *before* spending time on the mutsu run, since it predicts where the mutsu run is likely to fail. |
+| **Maintainer org** | the `auth<...>` field of `dist` / the dist name in `rea.json` | per BATTERIES.md §2, `auth<zef:raku-community-modules>` is a preference tiebreaker among otherwise-comparable candidates — that org is a curated, actively-maintained home, distinct from a single-author dist that may be unmaintained. Note it in the record even when it doesn't change the winner. |
 | **Dependents** | count dists in the index whose `depends` names it | ecosystem standing — far better evidence than stars or opinion |
 | raku result | run its own suite under `raku` | the baseline |
 | **mutsu result** | run its own suite under mutsu | the actual decision input |
 
 The dependents count is the one people skip and it is often decisive: for the
 template slot it separated `Template::Mustache` (11 dependents, incl. `Bailador`,
-`Documentable`, `Pod::To::HTML`) from candidates with 0.
+`Documentable`, `Pod::To::HTML`) from candidates with 0. Do not let a high
+dependents count alone win the slot, though — the TOML survey's highest-dependents
+candidate (7 dependents) was also its oldest and its only one requiring raw
+`nqp::` support, so "proven behaviour on mutsu" still overrode it.
 
 ## 3. Run both suites
 

--- a/docs/batteries/toml.md
+++ b/docs/batteries/toml.md
@@ -1,0 +1,175 @@
+# Battery: TOML parser — `Config::TOML`
+
+**Slot:** TOML config-file parser/writer · **Selected:** `Config::TOML`
+v0.1.3 (`auth<zef:raku-community-modules>`, Unlicense) + its dependency
+`Crane` v0.1.2 (same auth, Unlicense) · **Kind:** Selected, not yet bundled
+(blocked on mutsu core work) · **Yardstick:**
+[BATTERIES.md §2](../../BATTERIES.md#2-selection-criteria) — license (hard
+gate) → dependency weight → maintainer stewardship → proven behaviour on
+mutsu → API fit → "a small web blog can be written with the bundle alone"
+
+Procedure: [selection-method.md](selection-method.md).
+
+## Status: selected, not yet bundled
+
+**Every credible candidate failed 0% under mutsu when first measured.** The
+survey's real output is therefore a work list, exactly as
+[selection-method.md §5](selection-method.md#5-expect-the-answer-to-be-fix-mutsu-first)
+predicts. `Config::TOML` won the field on criteria, but shipping it means
+fixing the mutsu bug it exposes first — see
+[Why it currently fails on mutsu](#why-it-currently-fails-on-mutsu) below.
+
+```raku
+use Config::TOML;
+my %config = from-toml('example.toml'.IO.slurp);   # not yet runnable on mutsu
+```
+
+## The field
+
+Enumerated from the local REA + fez indices (14,834 dist names), filtered on
+`toml` in name/description/tags.
+
+| Candidate | Version | Released | License | auth | Runtime deps | Dependents¹ | raku | **mutsu** |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| **`Config::TOML`** (+`Crane`) | 0.1.3 / 0.1.2 | 2024-11-12 | Unlicense / Unlicense | `zef:raku-community-modules` (both) | 1 (`Crane`, itself 0-dep) | 0 / 1 (`Crane`←`Config::TOML`) | **17/17** | **0/17** |
+| `TOML` | 3 | 2021-05-01 | Artistic-2.0 | `zef:tony-o` | **0** | **7** (highest — `AI::Gator`, `Clu`, `Hey`, `LLM::DWIM`, `TooLoo`, `Zeco`, `App::SerializerPerf`) | 5/5 | **0/5** |
+| `TOML::Thumb` | 0.2 | 2021-07-26 | MIT | `zef:JRaspass` | **0** | 0 | ~clean² | **0/2** |
+| `Config::Parser::toml` | 1.0.4 | 2023-08-29 | **AGPL-3.0-only** | `zef:tyil` | 2 (`Config::TOML`, `Config`) | — | — | — |
+| `Config::DataLang::Refine` | 0.7.6 | 2024-04-05 | Artistic-2.0 | — | 2 (`Config::TOML`, `JSON::Fast`) | — | — | — |
+
+¹ Distributions in the local REA+fez indices whose `depends` names the
+candidate, same methodology as [templates.md](templates.md).
+² 194 assertions across `valid.t`/`invalid.t`; 18 are the upstream author's own
+`# TODO 'not yet implemented'` markers (non-fatal under TAP), everything else
+passes.
+
+## Ruled out before measuring
+
+- **`Config::Parser::toml`** — **AGPL-3.0-only** (an earlier 1.0.1-1.0.3 line
+  was plain GPL-3.0). Copyleft; disqualified by the hard license gate
+  ([BATTERIES.md §4](../../BATTERIES.md#4-license-policy)) before any other
+  criterion was even checked.
+- **`Config::DataLang::Refine`** — not a TOML parser itself, a refinement
+  layer that sits *on top of* `Config::TOML`'s already-parsed output
+  (whitespace/comment/type-coercion post-processing for config values). Out of
+  scope for "the TOML parser slot"; worth a look later as a companion
+  convenience once the parser itself is bundled.
+
+## Why `TOML` (tony-o) was passed over despite the most dependents
+
+`TOML` (`zef:tony-o`, v3, 2021-05-01) leads every ecosystem-standing metric —
+Artistic-2.0, zero runtime deps, and by far the most dependents (7, vs. 0 for
+every other candidate). It is healthy under raku (5/5, including a round-trip
+encoder test). But its implementation (`TOML::NQP.rakumod`) is written
+directly against **raw `nqp::` ops** (`use nqp;` + calls like
+`nqp::ordat($t, $pos)`), a low-level coding style essentially unseen in
+current-era Raku modules — consistent with the module's age (its last release
+is now 5 years old). mutsu's parser cannot parse a `nqp::`-op-laden module at
+all:
+
+```
+Failed to parse module 'TOML::NQP': Confused. parse error ...
+```
+
+Supporting arbitrary `nqp::` op syntax in general is not a bounded fix for
+this one module — it is the same class of problem as `NativeCall`'s "needs
+`QAST:from<NQP>`, MoarVM dispatch programs, and 61 missing `nqp::` ops" case
+(`todo/deep/nativecall-cannot-be-vendored.md`), which CLAUDE.md already
+documents as **measured and not currently retirable**. Per
+[BATTERIES.md §2](../../BATTERIES.md#2-selection-criteria), "proven behaviour
+on mutsu" — "a candidate that already `use`s cleanly beats a 'better' one
+that needs a multi-session core campaign just to load" — overrides the
+dependents-count lead here. This is intentionally **excluded** from the
+core-work queue below; revisit only if mutsu ever undertakes a general
+NQP-op-support campaign for independent reasons.
+
+## Why `TOML::Thumb` was runner-up, not the winner
+
+`TOML::Thumb` (`zef:JRaspass`, MIT, 0 deps) is the best-scoped candidate by
+"proven behaviour on mutsu": its entire suite is blocked by exactly **one**
+narrow, well-understood core gap — see
+`todo/tickets/dateish-role-not-registered-as-composable.md`. It lost to
+`Config::TOML` on the newly-added **maintainer stewardship** criterion
+(user decision, 2026-08-22 — see
+[BATTERIES.md §2](../../BATTERIES.md#2-selection-criteria) and
+[selection-method.md](selection-method.md)): `zef:JRaspass` is a single-author
+dist with 0 dependents, versus `Config::TOML` (+ its own dependency `Crane`)
+both being `auth<zef:raku-community-modules>` — the curated org already behind
+most of this bundle's other Adopted entries (`HTTP::HPACK`,
+`IO::Path::ChildSecure`, `JSON::JWT`, `Cro::*`, `DBIish`, ...). `Config::TOML`
+also ships by far the most thorough upstream suite of the field (17 files vs.
+2), giving the eventual battery-testsuite gate much more real coverage.
+Keep `TOML::Thumb`'s ticket open regardless — its gap is general (any module
+defining a `Dateish`-compatible type hits it) and worth fixing on its own
+merits.
+
+## Why it currently fails on mutsu
+
+All 17 of `Config::TOML`'s upstream test files fail to load. The apparent
+first symptom is a confusing, mis-line-numbered parse error:
+
+```
+===SORRY!=== Error while compiling t/special-cases/04-string-literal-keys.rakutest
+expected statement: expected use statement or import statement or no statement or need statement or unit statement or ...
+at t/special-cases/04-string-literal-keys.rakutest:28
+```
+
+— but line 28 does not exist meaningfully in that 59-line test file; it is
+actually line 28 of `Config::TOML::Parser::Actions.rakumod`, reached via `use`
+at compile time. **Root cause, fully bisected**:
+`Config::TOML::Parser::Actions` and `::Grammar` declare dozens of
+`method`/`token` **multi-dispatch variants named with a bare identifier
+adverb** (`method string-basic-char:common (...)`, `token gap:spacer {...}`,
+`token string:basic {...}` — 48 such methods in `Actions.rakumod` alone, plus
+a matching set of `token`s in `Grammar.rakumod`), as opposed to the more
+familiar `NAME:sym<literal>` spelling. mutsu's parser does not recognize this
+bare-adverb spelling — filed as
+`todo/tickets/token-method-bare-colon-adverb-name-not-supported.md`, with two
+standalone minimal repros (one for `method`, one for `token` inside a
+`grammar`) that reproduce independently of `Config::TOML` entirely. This is a
+**general parser gap**, not TOML-specific — fixing it is a real interpreter
+improvement per [BATTERIES.md §1](../../BATTERIES.md#1-adoption-policy--community-first-adopt-as-is)
+rung 2 ("grow mutsu's core, not the library"), and is the entire blocker for
+this slot.
+
+## Provenance (for when the blocker clears)
+
+Per [BATTERIES.md §3](../../BATTERIES.md#3-vendoring-and-resolution). Not yet
+vendored — no `modules/` tree or `batteries.lock` entry exists for this slot
+yet, per the "Selected, not yet bundled" convention in
+[BATTERIES.md §7](../../BATTERIES.md#7-bundle-index).
+
+| Module | Upstream | Pinned version | auth |
+| --- | --- | --- | --- |
+| `Config::TOML` | <https://github.com/raku-community-modules/Config-TOML> | v0.1.3 | `zef:raku-community-modules` |
+| `Crane` (dependency) | <https://github.com/raku-community-modules/Crane> | v0.1.2 | `zef:raku-community-modules` |
+
+When vendoring: `lib/` + `META6.json` + `LICENSE`/`UNLICENSE` + `README.md`
+for both modules, excluding upstream `t/`, `run-tests`, `dist.ini`,
+`Changes`-adjacent CI config, per the standard recipe.
+
+## Security updates
+
+Per [BATTERIES.md §6](../../BATTERIES.md#6-security-updates-and-independent-updatability),
+once bundled, the vendored copy is the lowest-priority source; `mzef install
+Config::TOML` (or `Crane`) shadows it without a mutsu release.
+
+## License
+
+**Unlicense** (public domain equivalent) for both `Config::TOML` and `Crane`
+— declared in each `META6.json`, shipped as `UNLICENSE` in each checkout.
+Permissive; passes [BATTERIES.md §4](../../BATTERIES.md#4-license-policy)
+cleanly (no provisional-exception caveat needed, unlike `Encode`).
+
+## Next steps
+
+1. Land `todo/tickets/token-method-bare-colon-adverb-name-not-supported.md`.
+2. Re-run `Config::TOML` + `Crane`'s upstream suites (fetch per the REA
+   `source-url`s above, or from a fresh `tmp/toml-survey/` per
+   [selection-method.md](selection-method.md)'s procedure) and see how much
+   of 0/17 clears.
+3. If it reaches a workable state, vendor per
+   [BATTERIES.md §3](../../BATTERIES.md#3-vendoring-and-resolution), add the
+   `batteries.lock` entries, run `scripts/battery-testsuite.sh --update`, and
+   promote this record's status line + the [bundle index](../../BATTERIES.md#7-bundle-index)
+   row from "Selected, not yet bundled" to "Working".

--- a/todo/tickets/dateish-role-not-registered-as-composable.md
+++ b/todo/tickets/dateish-role-not-registered-as-composable.md
@@ -1,0 +1,87 @@
+# `class Foo does Dateish { ... }` rejected — `Dateish` is not a registered composable role
+
+## Symptom
+
+```raku
+class Time::Local does Dateish {
+    has $.hour;
+}
+say "ok";
+```
+
+Under `raku`: `ok` (Raku's `Dateish` is a real role — `Date` and `DateTime`
+both `does Dateish` themselves, and it can be composed into a user class).
+Under mutsu (`target/debug/mutsu`):
+
+```
+X::InvalidType: Invalid typename 'Dateish'
+```
+
+## Root cause
+
+`src/runtime/registration_class_decl.rs`'s `BUILTIN_PARENT_TYPES` list already
+contains `"Date"` and `"DateTime"` (so `class Date::Local is Date {}` — real
+inheritance — works), but **not** `"Dateish"`. The validation error comes from
+`src/runtime/registration_class_validate.rs` (~line 228-239): a `does` parent
+is checked against `self.registry().classes`, `BUILTIN_TYPES` (=
+`BUILTIN_PARENT_TYPES`), `self.registry().roles`, and `self.registry().enum_types`
+— `Dateish` matches none of these, so it hits the `X::InvalidType` branch.
+
+Note `Dateish` **is** already recognized in several other places as an isa-check
+target (it is not a total unknown to the interpreter):
+
+- `src/value/types_isa.rs:267` — `"Dateish" => matches!(...)` for `Date`/`DateTime`
+- `src/runtime/utils/type_constraints.rs:202`, `src/vm/vm_value_helpers.rs:398`,
+  `src/vm/vm_misc_ops.rs:75` — treated as a valid type-constraint name
+- `src/runtime/methods_instance_ops.rs:2667` — part of a method-dispatch
+  fallback chain (`["Dateish", "Real", "Numeric", "Cool", "Any"]`)
+
+So the gap is narrow: `Dateish` is wired in as a *recognized type name* for
+matching/dispatch purposes, but not as an actual **composable role** a
+user-defined class can `does`. Fixing this needs two parts:
+
+1. Add `"Dateish"` to `BUILTIN_PARENT_TYPES` (or the equivalent role-registry
+   check) so `does Dateish` passes class validation.
+2. Decide what a `does Dateish`-composed class actually gets: real Raku's
+   `Dateish` role declares required methods (`daycount`, `year`, `month`,
+   `day`, `formatter`, `truncated-to`, `later`, `earlier`, ...) that the
+   composing class must supply (or that have defaults building on
+   `daycount`). Check whether TOML::Thumb's `Time::Local` (which only
+   implements `!formatter` — a *private* method, likely not what the role
+   requires) actually satisfies the real role's contract in Rakudo, or
+   whether Raku's role-composition rules are lenient here for some other
+   reason, before assuming a minimal stub registration is sufficient.
+
+## Why this matters
+
+Found while surveying candidates for mutsu's TOML-parser battery slot
+(`docs/batteries/toml.md`, 2026-08-22). `TOML::Thumb` (`zef:JRaspass`, MIT,
+zero runtime deps) was runner-up to the winning `Config::TOML` candidate —
+it is small, well-scoped, and its own upstream suite is otherwise clean
+(18 known gaps are explicitly `# TODO` and non-fatal). This one role-
+registration gap is the **entire** blocker for its whole test suite
+(`invalid.t`, `valid.t`) loading at all under mutsu:
+
+```
+X::InvalidType: Invalid typename 'Dateish'
+  in block <unit> at ./TOML/Thumb.rakumod line 7
+```
+
+This is also a general gap (not TOML::Thumb-specific): any module that
+defines its own `Dateish`-compatible date/time-of-day type hits the same
+wall, since `Dateish` is Raku's documented public extension point for
+"acts like a date" (see `raku-doc/doc/Type/Dateish.rakudoc` if present, or
+the upstream Rakudo source for the role's actual method contract).
+
+## Next steps
+
+1. Read `Dateish`'s real method contract (Rakudo source or
+   `raku-doc/doc/Type/Dateish.rakudoc`) to know exactly what a composing
+   class must supply.
+2. Register `Dateish` as a real composable role (not just a matched type
+   name) with that contract, defaulting derived methods (`Str`, comparison
+   operators, etc.) the way `Date`/`DateTime` already do internally.
+3. Re-run `TOML::Thumb`'s two upstream test files
+   (`tmp/toml-survey/toml-thumb/{valid,invalid}.t` if the scratch survey
+   directory still exists, or re-fetch per `docs/batteries/toml.md`) to see
+   how far this one fix takes the suite.

--- a/todo/tickets/token-method-bare-colon-adverb-name-not-supported.md
+++ b/todo/tickets/token-method-bare-colon-adverb-name-not-supported.md
@@ -1,0 +1,99 @@
+# `token`/`rule`/`method` declarations named `name:adverb` (bare identifier, not `:sym<...>`) misparse
+
+## Symptom
+
+Raku lets a multi-dispatch `token`/`rule`/`regex`/`method` variant be named
+with a **bare identifier** after the colon, not just the usual `:sym<literal>`
+form:
+
+```raku
+grammar G {
+    token TOP { <gap>+ }
+    proto token gap {*}
+    token gap:spacer { \s }
+    token gap:comment { '#' \N* }
+}
+say G.parse("  ##comment") ?? "matched" !! "no match";
+```
+
+Under `raku`: `matched`. Under mutsu (`target/debug/mutsu`):
+
+```
+No such method 'gap' for invocant of type 'Match'
+  in block <unit> at ... line 7
+```
+
+The same bare-adverb form on a plain `method` (not inside a grammar)
+misparses even more visibly — the body appears to execute **immediately at
+class-composition time** instead of being registered as a method:
+
+```raku
+class Foo {
+    method bar:common ($x) {
+        say "common: $x";
+    }
+}
+say "parsed ok";
+```
+
+mutsu prints `Use of Nil in string context` + `common: ` (the body ran with
+`$x` bound to `Nil`) before `parsed ok`; raku prints only `parsed ok` (the
+method is registered, not called, since nothing calls `.bar:common` here).
+
+## Root cause (not yet traced into the parser internals)
+
+mutsu's declaration parser only recognizes the `NAME:sym<LITERAL>` spelling
+for a colon-qualified multi/token name (used pervasively for grammar
+alternation dispatch and operator overloading, e.g. `token sym<+> {...}` /
+`method infix:<+> (...)`). The **bare-identifier** adverb form
+(`NAME:ADVERB`, no angle brackets, `ADVERB` itself just another identifier)
+is a distinct, also-legal spelling that Raku's real grammar accepts — see
+`raku-doc/doc/Language/grammars.rakudoc` (`token gap:sym<...>` is documented
+but confirm whether the bare-identifier spelling is documented explicitly, or
+grep Rakudo's own `Grammar.nqp`/`Actions.nqp` for `token gap:comment`-style
+uses; **CBOR::Simple** and other vendored grammars use the `:sym<>` form more
+than the bare form, so this specific spelling may be under-exercised in
+mutsu's own test suite). Confirm with `raku --target=ast` for both spellings
+before implementing, and check `src/parser/stmt/sub/` (method/token
+declaration parsing) for where `:sym<...>` is special-cased — the bare form
+likely needs the same treatment.
+
+## Why this matters
+
+This is the actual root cause behind **all 17 upstream test files failing**
+for the `Config::TOML` battery-slot survey (see `docs/batteries/toml.md`).
+`Config::TOML::Parser::Grammar` and `Config::TOML::Parser::Actions` (from
+`raku-community-modules/Config-TOML`, the winning candidate for mutsu's TOML
+parser slot) declare **48** `method NAME:ADVERB (...)` action methods and a
+matching set of `token NAME:ADVERB {...}` grammar alternatives, entirely in
+the bare-identifier style (`token string:basic {...}`, `token gap:spacer
+{...}`, `method string-basic-char:common (...)`, ...). None of them parse
+correctly, which is why the whole module fails to load/run under mutsu even
+though every individual TOML-parsing rule is otherwise unremarkable.
+
+This is a general grammar/OO parsing gap, not specific to TOML — any grammar
+or Actions class using this idiom (a common, natural way to name alternation
+variants when there's no obvious short literal to hang a `:sym<>` off) will
+hit the same wall.
+
+## Discovered via
+
+The TOML battery-slot survey (`docs/batteries/toml.md`, 2026-08-22): the
+`Config::TOML` candidate scored best on license/maintainer-org/dependents but
+failed 0/17 under mutsu. Bisected the failure from the confusing top-level
+symptom (`expected statement ... at <file>:28`, where 28 is a line number
+*inside `Config/TOML/Parser/Actions.rakumod`*, not the user's script — a
+separate line-number-misattribution wrinkle worth noting but not the root
+cause) down to the two minimal repros above.
+
+## Next steps
+
+1. Confirm the exact accepted grammar for a colon-qualified declaration name
+   in real Raku (`raku --target=ast`) — is the adverb allowed to be *any*
+   bare identifier, or only specific known adverbs?
+2. Find where mutsu's parser handles `:sym<...>` for `token`/`rule`/`regex`/
+   `method` declarations and extend it to also accept a bare identifier after
+   the colon.
+3. Re-run this file's two repros, then re-run the `Config::TOML` /
+   `Crane` survey (`docs/batteries/toml.md`'s worked commands) to see how much
+   of the 0/17 clears.


### PR DESCRIPTION
## Summary
- Surveys the TOML-parser battery slot per `docs/batteries/selection-method.md`, measuring every candidate under both `raku` and mutsu (not from memory/stale prose).
- Selects `Config::TOML` (+ `Crane`, both `auth<zef:raku-community-modules>`) as the winning candidate — wins on license, dependency weight, the new maintainer-stewardship criterion, and upstream suite coverage (17 files) — but records it as **Selected, not yet bundled**: it is currently 0/17 under mutsu.
- Files two `todo/tickets/` entries for the general mutsu bugs the survey exposed, each with a standalone minimal repro:
  - `token-method-bare-colon-adverb-name-not-supported.md` — the actual blocker for `Config::TOML` (48 `method NAME:ADVERB (...)` / `token NAME:ADVERB {...}` bare-identifier multi-dispatch names don't parse). This is a general grammar/OO parsing gap, not TOML-specific.
  - `dateish-role-not-registered-as-composable.md` — the sole blocker for runner-up `TOML::Thumb` (`does Dateish` rejected; `Dateish` is recognized for isa-checks but not registered as an actual composable role).
- `TOML` (`zef:tony-o`) has the most ecosystem dependents (7) but is written directly against raw `nqp::` ops (5-year-old release); supporting that is out of scope, on the same footing as the already-documented NativeCall situation — explicitly excluded from the work queue rather than silently dropped.
- `Config::Parser::toml` is disqualified outright (AGPL-3.0-only, a hard license gate).
- Updates `BATTERIES.md` §2 and `selection-method.md`'s procedure per user process feedback during the survey: call out release-date staleness as a leading indicator (predicts deeper compatibility problems, not just neglect), and add a maintainer-stewardship tiebreaker preferring `auth<zef:raku-community-modules>` candidates.
- Adds a "Selected, not yet bundled" row to the `BATTERIES.md` §7 bundle index.

## Test plan
- [x] Docs-only change; `ci-docs-only.sh` should classify this as docs-only and skip the four heavy CI jobs.
- [x] `cargo fmt`/`clippy` pre-commit hooks ran clean (no Rust files touched).
- [x] Verified all repros (`token gap:spacer {...}`, `method bar:common (...)`, `does Dateish`) independently against both `raku` and `target/debug/mutsu`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)