### PR TITLE
docs: survey compression/archive battery slot

### DIFF
--- a/docs/batteries/compression.md
+++ b/docs/batteries/compression.md
@@ -1,0 +1,282 @@
+# Battery survey: Data compression and archiving
+
+**Slot:** stream compression (zlib/gzip, bzip2, lzma/xz, zstd) and archive
+formats (zip, tar) · **Status:** **no candidate bundled — survey only**
+(2026-08-22) · **Yardstick:**
+[BATTERIES.md §2](../../BATTERIES.md#2-selection-criteria) — license (hard
+gate) → dependency weight → proven behaviour on mutsu → API fit ·
+**Procedure:** [selection-method.md](selection-method.md)
+
+Flagged as gap #4 in
+[python-stdlib-comparison.md](python-stdlib-comparison.md)'s "Data
+Compression and Archiving" section: Python's `zlib`/`gzip`/`bz2`/`lzma` and
+`zipfile`/`tarfile` have no mutsu equivalent at all. This is the first pass
+at the slot.
+
+## A note on the no-native-dependency rule
+
+The CSV survey ([csv.md](csv.md)) disqualified candidates with a native/C
+dependency outright, because that slot had healthy pure-Raku alternatives.
+That rule does **not** transfer here (user decision, 2026-08-22): a pure-Raku
+compression codec is rare and slow, so essentially every credible candidate
+in this field is a NativeCall binding to a standard system library
+(`libz`, `libbz2`, `liblzma`, `libarchive`) — architecturally the same shape
+as the already-bundled `OpenSSL` (binds system `libssl`/`libcrypto`) and
+`DBIish` (binds system `libsqlite3`). All four of those system libraries are
+present on this survey machine (`ldconfig -p`: `libz.so`, `liblzma.so`,
+`libbz2.so`, `libarchive.so`, all versioned + unversioned symlinks). Native
+dependency alone is therefore not a disqualifier in this slot; a *niche* or
+*build-from-source* native dependency still is (see `Compress::Snappy`,
+`Compress::Brotli` below).
+
+## The field
+
+Enumerated from `~/.zef/store/{rea,fez}/*.json` by filtering name/description
+on `zip|gzip|gz|bzip2|bz2|lzma|xz|zlib|tar|archive|compress|deflate|inflate`.
+`fez.json` (7,810 dists) carried a strict subset of what `rea.json` (14,834
+dists) has for this slot — none of the codec bindings below are on fez at
+all, only reachable through the REA mirror — so `rea.json` is the field of
+record here, consistent with selection-method.md's own note that it is "the
+more useful of the two." Perl 5 CPAN dists that leaked into the REA index by
+name collision (`Bundle-Compress-Zlib`, `IO-Compress-Lzma`, etc. — tagged
+`['perl_5']`) are excluded; they are not Raku modules. General-purpose tools
+that merely touch archives as one feature among many (`Sparrowdo::Archive`,
+`WebService::HazIP`) are excluded as not slot candidates.
+
+**No Raku `lzma`/`xz` binding exists in the ecosystem at all** — the only hit
+for that keyword is the Perl 5 `IO-Compress-Lzma` false-positive. `zstd` has
+exactly one candidate. This means the slot's realistic ceiling today is
+zlib/gzip + bzip2 + zip/tar via libarchive (which itself supports xz/lzma
+*archive* filters internally, covering that gap indirectly for archives, just
+not for standalone `.xz` streams).
+
+### Compression codecs
+
+| Candidate | Version | Released | License | Runtime deps | GitHub | Dependents¹ | raku | **mutsu** |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| **`Compress::Zlib::Raw`** | 1.0.1 | 2018-04-26 | MIT² | none | [retupmoca/P6-Compress-Zlib-Raw](https://github.com/retupmoca/P6-Compress-Zlib-Raw) — ★3, last push 2024-03-22, not archived | 3 | **1/1** (7 tests) | **1/1** ✅ (7/7) |
+| **`Compress::Zlib`** | 1.1.0 | 2019-03-11 | MIT² | `Compress::Zlib::Raw` | [retupmoca/P6-Compress-Zlib](https://github.com/retupmoca/P6-Compress-Zlib) — ★4, last push 2022-03-16, not archived | 9 | **3/3** (18 tests) | **0/3** ❌ — 2 distinct blockers, see below |
+| **`Compress::Bzip2::Raw`** | 0.2.2 | 2021-03-31 | Artistic-2.0 | none | [Altai-man/perl6-Compress-Bzip2-Raw](https://github.com/Altai-man/perl6-Compress-Bzip2-Raw) — ★1, last push 2023-09-16, not archived | 1 | **1/1** (9 tests) | **1/1** ✅ (9/9) |
+| **`Compress::Bzip2`** | 0.4.1 | 2021-03-31 | Artistic-2.0 | `Compress::Bzip2::Raw` | [Altai-man/perl6-Compress-Bzip2](https://github.com/Altai-man/perl6-Compress-Bzip2) — ★2, last push 2023-09-16, not archived | 3 | **1/1** (10 tests) | **0/1** ❌ — parse failure, see below |
+| `Compress::Zstd` | 0.0.3 | 2019-09-12 | Artistic-2.0 | none | [timo/Compress-Zstd](https://github.com/timo/Compress-Zstd) — ★0, last push 2019-09-12, not archived | 0 | **2/2**³ (12 tests) | not measured⁴ |
+| `Compress::Snappy` | 0.0.3 | — | MIT² | `NativeCall` | [avuserow/perl6-compress-snappy](https://github.com/avuserow/perl6-compress-snappy) — ★5, last push 2022-06-29, not archived | 0 | **0/3**⁵ | not measured⁵ |
+| `Compress::Brotli` | 0.1.0 | 2017-05-14 | Artistic-2.0 (README only)⁶ | `NativeCall`, `LibraryMake` | [sylvarant/Compress-Brotli](https://github.com/sylvarant/Compress-Brotli) — ★0, last push 2017-05-14, not archived | 0 | **0/2**⁶ | not measured⁶ |
+
+¹ Distributions in the local REA index whose `depends` names the candidate —
+same method as [csv.md](csv.md)/[templates.md](templates.md).
+² Declared `license: None` in `META6.json`, but a `LICENSE` file **is**
+shipped and states MIT unambiguously — cross-checked and treated as MIT per
+selection-method.md's "cross-checked against a shipped LICENSE" rule; this is
+a META6.json omission, not an actual license gap (contrast with
+`Compress::Brotli` below, which has no `LICENSE` file at all).
+³ `01-basic.t` passes fully (6/6). `02-compressor.t` also completes fully
+(6/6) but takes >30s wall-clock on its two "really-big" (8 MB) round-trip
+cases — confirmed to pass at a 60s timeout. Functional, just slow to gate at
+the standard 30s budget.
+⁴ Not measured under mutsu — 0 dependents, and the raku suite's own slowness
+means a from-scratch mutsu run risked eating the survey's time budget for a
+marginal candidate. A future pass should measure it; nothing here suggests
+it would behave differently from the other zlib/bzip2 codecs architecturally.
+⁵ The system ships `libsnappy.so.1` (confirmed via `ldconfig -p`) but not the
+unversioned `libsnappy.so` dev symlink NativeCall's `is native('snappy')`
+resolution wants — `libsnappy-dev` is not installed on this survey machine.
+This is an **environment gap, not a raku/mutsu bug**: `raku`'s own run fails
+identically (`Cannot locate native library 'libsnappy.so'`) before reaching
+any test logic, so the mutsu run was not attempted. Whether it would work
+under mutsu once the dev package is installed is unknown.
+⁶ No `LICENSE` file and `license: None` in `META6.json`; the README carries
+an Artistic-2.0 badge and text, which is *weaker* evidence than a shipped
+`LICENSE` file (same tier as `CSV::Parser` in [csv.md](csv.md), not a hard
+gate but a real weakness). Separately, and more decisively: unlike every
+other candidate here, `Compress::Brotli` is not a simple `is native('brotli')`
+binding — it needs a `LibraryMake`-driven build step to compile its own
+native shim against brotli's dev headers, which are not installed on this
+machine, so `use Compress::Brotli` fails under raku itself
+(`Could not find LibraryMake`) before reaching any Brotli-specific code. Not
+measured under mutsu for the same reason as `Compress::Snappy` — dead on
+raku, so a mutsu run would tell us nothing. Also the stalest candidate in the
+field (last commit 2017-05-14, 9 years old).
+
+### Archive formats (zip / tar)
+
+| Candidate | Version | Released | License | Runtime deps | GitHub | Dependents¹ | raku | **mutsu** |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| **`Archive::Libarchive::Raw`** | 0.1.5 | 2023-01-28 | Artistic-2.0 | `NativeCall` | [frithnanth/perl6-Archive-Libarchive-Raw](https://github.com/frithnanth/perl6-Archive-Libarchive-Raw) — ★4, **last push 2025-04-29**, not archived | 2 | **6/6** (119 tests)⁷ | **1/6** ❌ — one general NativeCall bug, see below |
+| **`Archive::Libarchive`** | 0.0.17 | 2023-01-19 | Artistic-2.0 | `Archive::Libarchive::Raw`, `NativeHelpers::Blob` | [frithnanth/perl6-Archive-Libarchive](https://github.com/frithnanth/perl6-Archive-Libarchive) — ★5, **last push 2025-04-29**, not archived | 4 | **6/6** (45 tests)⁷ | **1/6** ❌ — inherits the Raw blocker |
+| **`Archive::SimpleZip`** | 0.8.0 | 2023-09-16 | Artistic-2.0 | `Compress::Zlib`(::Raw), `IO::Glob`, `CompUnit::Util` | [pmqs/Archive-SimpleZip](https://github.com/pmqs/Archive-SimpleZip) — ★1, last push 2023-09-16, not archived | 0 | **3/3** (38 tests)⁷ | **0/1** ❌ — parse failure, see below |
+| `LibZip` | * (2019) | 2019-09-29 | MIT | `NativeHelpers::Blob` | [azawawi/perl6-libzip](https://github.com/azawawi/perl6-libzip) — ★2, last push 2019-09-29, not archived | 0 | **1/1** (2 tests)⁸ | **0/1** ❌ — parse failure, see below |
+| `IO-Archive` | 0.0.5 | 2024-06-22 | Artistic-2.0 (README only) | `Archive::Libarchive`, `Archive::Libarchive::Constants`, `MONKEY-TYPING` | [ssotka/IO-Archive](https://github.com/ssotka/IO-Archive) — ★1, last push 2024-06-22, not archived | 0 | **1/1** (1 test)⁹ | not measured⁹ |
+| `Archive::Tar::PP` | v0.0.1 | 2021-05-19 | **none declared anywhere** | none | [tony-o/perl6-archive-tar-pp](https://github.com/tony-o/perl6-archive-tar-pp) — ★1, last push 2021-05-19, not archived | 0 | **4/4**¹⁰ (26 tests) | **1/4**¹⁰ — disqualified on license regardless |
+
+¹ Same method as above.
+⁷ Excludes the author-only `99-meta.rakutest`/`meta.t` files, which need the
+unbundled `Test::META` module (dist-metadata QA, not functionality) — same
+waiver as `Text::CSV`'s `99_meta.t` in [csv.md](csv.md).
+⁸ The entire shipped test suite is two trivial assertions (`use` succeeds;
+`.new` succeeds) — no round-trip coverage of actual zip read/write. A much
+weaker depth signal than every other candidate in this table.
+⁹ `IO-Archive`'s own suite is a single `use-ok` line — it is a thin
+convenience wrapper adding `IO::Path` integration on top of
+`Archive::Libarchive` (its hard dependency), so it inherits that dependency's
+mutsu blocker below regardless. Not separately measured under mutsu given
+the near-zero marginal information a `use-ok`-only file would add.
+¹⁰ Pure Raku, zero runtime dependencies, and functionally the healthiest
+archive candidate under raku short of `Archive::Libarchive` (`00-use.t`,
+`01-pax.t`, `03-refuse.t`, `04-peek.t` all pass; `02-gittar.t` needs a `git`
+binary in the test environment, not attempted; `05-write-peek.t` not
+attempted). Included for completeness only — see "Ruled out" below, it is
+disqualified on license before the mutsu number matters. The one file
+measured under mutsu (`00-use.t`) passes; the others hit two more mutsu bugs
+(`Index out of range` in tar-header buffer parsing, and an unsupported
+`nqp::stat` op) — not filed as tickets since the module itself cannot be
+bundled regardless of mutsu status, but noted here in case another
+pure-Raku, tar-header-parsing module surfaces the same shapes later.
+
+**Also found, not a slot candidate:** `IO::Path::AutoDecompress`
+([lizmat/IO-Path-AutoDecompress](https://github.com/lizmat/IO-Path-AutoDecompress)
+— ★1, last push 2026-04-23, the most recently active repo in this whole
+survey) — shells out to the external `gunzip`/`bunzip2`/`7z` **binaries** via
+`run()` rather than binding any library, and is read-only (decompression only,
+no write/compress side at all). Not evaluated further: it is a convenience
+shim over external tools, not a codec/archive library, and a `run()`-based
+design means it inherits whatever gzip/bzip2/7z binaries happen to be on the
+host `PATH` rather than the deterministic system libraries this slot is meant
+to target.
+
+## What blocks mutsu today
+
+Every ergonomic (non-`::Raw`) candidate in both tables is blocked by a real,
+reproducible mutsu bug — the low-level `::Raw`/`Bzip2::Raw` 1:1 C bindings
+work perfectly, but the moment a higher-level Raku wrapper adds its own logic
+on top, something breaks. Four distinct, independently-filed bugs:
+
+1. **[`nativecall-local-sub-shadows-imported-same-name.md`](../../todo/tickets/nativecall-local-sub-shadows-imported-same-name.md)**
+   — `Compress::Zlib.pm6` declares its own `sub compress(Blob $data, Int
+   $level = 6)`, which should shadow the 4-arg `sub compress(...)` imported
+   from `Compress::Zlib::Raw` (Raku's own-file-declaration-shadows-import
+   rule). mutsu resolves the *imported* symbol instead, so every call
+   fails with an arity mismatch (`NativeCall: 'compress' expects 4
+   argument(s), got 1`). Blocks `Compress::Zlib` entirely (0/3 files).
+2. **[`nativecall-sizeof-cstruct-repr-unsupported.md`](../../todo/tickets/nativecall-sizeof-cstruct-repr-unsupported.md)**
+   — `nativesizeof()` on a `class ... is repr('CStruct')` reports the class
+   as `P6opaque` instead of recognizing its `CStruct` repr. A second,
+   independent `Compress::Zlib` blocker (its streaming API, `t/02-stream.t`/
+   `t/03-wrap.t`) — fixing bug 1 alone will not unblock these two files.
+3. **[`nativecall-cpointer-repr-typed-param-returns-whatever.md`](../../todo/tickets/nativecall-cpointer-repr-typed-param-returns-whatever.md)**
+   — passing a `repr('CPointer')`-typed value (an opaque native handle) as
+   an argument to a *second* native call makes that call return `Whatever`
+   instead of running and returning its declared type. This is the single
+   blocker for the entire `Archive::Libarchive`/`Archive::Libarchive::Raw`
+   pair — everything past the trivial `use`/version-string tests fails this
+   way (1/6 files vs raku's 6/6). **This is the highest-leverage fix in this
+   survey**: `Archive::Libarchive` is otherwise the strongest candidate found
+   (Artistic-2.0, actively maintained — last push 2025-04-29, more recent
+   than any other candidate in either table — 4 dependents, and covers
+   zip/tar/gzip/bzip2/xz uniformly through one library).
+4. Two parser failures, each real but not yet root-caused to a minimal
+   repro — **[`compress-bzip2-ternary-parse-after-dynamic-export.md`](../../todo/tickets/compress-bzip2-ternary-parse-after-dynamic-export.md)**
+   (a `?? BAREWORD !! BAREWORD` ternary misparses as a bareword-swallows-`!!`
+   listop call, in a file whose constants come from a dynamic `sub EXPORT`
+   built via `MY::` package introspection rather than static `is export`
+   tags — blocks `Compress::Bzip2`, 0/1) and
+   **[`archive-simplezip-samewith-placeholder-slurpy-parse.md`](../../todo/tickets/archive-simplezip-samewith-placeholder-slurpy-parse.md)**
+   (a `.map:` block combining a `$^a` placeholder, `samewith(...)`
+   redispatch, and a forwarded `|c` slurpy capture, followed by `;
+   ++ $count` — blocks `Archive::SimpleZip`, 0/1). A third, lower-priority
+   parse bug — **[`libzip-nativecall-callback-signature-type-parse.md`](../../todo/tickets/libzip-nativecall-callback-signature-type-parse.md)**
+   (an anonymous `&(Pointer, Pointer, int64, int32 --> int64)` callback
+   signature type used as a NativeCall parameter type) — blocks `LibZip`,
+   0/1, but `LibZip` has 0 dependents and the thinnest test suite in the
+   field, so this is not a priority pick.
+
+None of these four bugs are compression/archive-specific — they are general
+NativeCall and parser gaps that happened to surface here, in the same spirit
+as the CSV survey's shared heredoc-in-sub-body bug ([csv.md](csv.md)). Fixing
+bug 3 in particular would likely also help any other NativeCall binding that
+threads an opaque CPointer handle through a chain of calls (a very common
+NativeCall idiom — file handles, DB connections, compiled-regex handles, …),
+not just `Archive::Libarchive`.
+
+## Ruled out before a full measurement
+
+- **`Archive::Tar::PP`** (v0.0.1, `tony-o`) — **no license declared
+  anywhere**: `META6.json`'s `license` field is absent, no `LICENSE`/
+  `LICENCE` file is shipped, and the README makes no mention of licensing
+  terms either. Per selection-method.md's hard gate, this disqualifies it
+  outright — the same precedent that dropped `HTML::Template`/
+  `Text::Template` from the template slot and `Text::CSV::LibCSV` from the
+  CSV slot. A genuine pity: it is otherwise the most promising pure-Raku,
+  zero-dependency tar candidate found, healthy under raku (4/4 files
+  measured). If its author ever adds a license statement, it is worth a
+  fresh look — but not before.
+- **`Compress::Brotli`** (0.1.0, `sylvarant`) — weakest license evidence in
+  the field (README-only, no `LICENSE` file) *and* fails to even load under
+  `raku` on this machine (`Could not find LibraryMake` — it needs a
+  build-time compile step against brotli's dev headers, not installed here),
+  *and* the stalest repository found (last commit 2017). Any one of these
+  would deprioritize it; together they rule it out without a mutsu
+  measurement being useful.
+- **`Compress::Snappy`** (0.0.3, `avuserow`) — blocked in this environment
+  by a missing `libsnappy-dev` package (the runtime `.so.1` is present, the
+  unversioned dev symlink NativeCall wants is not), so `raku` itself cannot
+  load it here. Not a license or architecture problem — if `libsnappy-dev`
+  were installed this candidate would likely be viable; re-survey if snappy
+  support specifically becomes a priority.
+- **`IO::Path::AutoDecompress`** (`lizmat`) — shells out to external
+  `gunzip`/`bunzip2`/`7z` binaries via `run()` rather than binding a
+  library, and is read-only. Out of scope for a codec/archive library slot;
+  see the field notes above.
+- **`IO-Archive`** (0.0.5, `ssotka`) — a one-file, `use-ok`-only convenience
+  wrapper over `Archive::Libarchive`. Its own test suite gives no additional
+  signal beyond its dependency's, and it would inherit that dependency's
+  mutsu blocker regardless. Not a distinct option from `Archive::Libarchive`
+  itself.
+- **`LibZip`** (`azawawi`, MIT) — thinnest test suite in the field (2 trivial
+  assertions, no real read/write round-trip coverage) and 0 dependents;
+  `Archive::Libarchive`/`Archive::SimpleZip` are both better-tested zip
+  options. Kept in the table because it did surface a distinct parser bug
+  worth recording, not as a candidate to prioritize.
+
+## Recommendation
+
+**No candidate is ready to bundle today.** The pattern here is the "expect
+the answer to be 'fix mutsu first'" case selection-method.md calls out as
+normal: every credible codec/archive candidate is healthy under raku, and the
+low-level `::Raw` C bindings (`Compress::Zlib::Raw`, `Compress::Bzip2::Raw`)
+already pass 100% under mutsu — but every higher-level, ergonomic wrapper on
+top of them hits a real mutsu bug before its own suite can run. This is not a
+field-selection problem; it is an interpreter-readiness problem, and this
+survey's real output is the four filed bugs above, not a winner.
+
+If/when those are fixed, the shape of a future decision:
+
+1. **For stream compression**, `Compress::Zlib` (zlib/gzip, 9 dependents,
+   MIT) and `Compress::Bzip2` (bzip2, 3 dependents, Artistic-2.0) are both
+   well-tested, actively-reasonable candidates once bugs 1+2 (Zlib) and bug 4
+   (Bzip2) are fixed. There is no live `lzma`/`xz` candidate in the
+   ecosystem at all — that part of the Python gap (`lzma`) cannot be closed
+   by adopting an existing module; only `Archive::Libarchive`'s internal xz
+   support (for *archives*, not raw `.xz` streams) touches it.
+2. **For archive formats**, `Archive::Libarchive` is the strongest
+   candidate by a wide margin: it is the only one of the two ecosystems
+   (zip *and* tar, via libarchive's format/filter abstraction) rather than a
+   zip-only or tar-only tool, it is Artistic-2.0, has the most dependents (4)
+   and by far the most recent upstream activity (last push 2025-04-29 — no
+   other candidate in either table was touched after 2024), and is blocked
+   by exactly one bug (bug 3 above) rather than the two-or-more each codec
+   candidate needs. `Archive::SimpleZip` is a credible zip-only fallback if
+   `Archive::Libarchive` turns out to need more than bug 3 once actually
+   attempted, but it is architecturally weaker (needs a 4-dist dependency
+   chain: `Compress::Zlib` + `::Raw` + `IO::Glob` + `CompUnit::Util`, versus
+   `Archive::Libarchive`'s 2-dist chain) and has its own separate parser
+   blocker (bug 4b) to clear too.
+3. Whoever next picks up NativeCall work should treat **bug 3
+   (`nativecall-cpointer-repr-typed-param-returns-whatever.md`)** as the
+   highest-leverage single fix in this survey — it is both the sole blocker
+   for the strongest archive candidate and a general pattern (opaque
+   CPointer handle threaded through a call chain) likely to recur in other
+   NativeCall-based batteries, not just this slot.
+
+Re-run this survey (or at least re-measure the four filed bugs) before acting
+on any of the above — per selection-method.md, a readiness claim nobody just
+re-measured is not evidence.

--- a/docs/batteries/selection-method.md
+++ b/docs/batteries/selection-method.md
@@ -42,6 +42,50 @@ Together they carry ~2500 distinct distribution names. Filter on name,
 the maintenance signal, and `source-url`, which points at a tarball you can fetch
 directly (no `git clone` guessing at repository names).
 
+### Resolving the GitHub URL
+
+`rea.json`'s `source-url` is a REA mirror tarball link (`raw.githubusercontent.com/raku/REA/...`),
+**not** the upstream repository — do not report it as "the GitHub URL". To find the
+real one:
+
+1. **Prefer `support.source`** when the entry has one — it is usually a
+   `git://github.com/OWNER/REPO.git` or `https://github.com/OWNER/REPO.git` URL;
+   strip the scheme/`.git` suffix to get a browsable
+   `https://github.com/OWNER/REPO`. Most entries in the index have **no**
+   `support` field at all (an empty `{}` or the key absent), so expect to fall
+   through to step 2 often.
+2. **Fall back to the `dist` string's `auth<...>` field.** `auth<github:OWNER>`
+   almost always means the source lives at `https://github.com/OWNER/<repo>`,
+   but the repo name does not always match the dist name verbatim — `::`
+   commonly becomes `-`, and some repos carry a `p6-`/`perl6-`/`Raku-` prefix
+   (e.g. `CompUnit::Repository::Tar` → `ugexe/Raku-CompUnit--Repository--Tar`).
+   Confirm the guess resolves (`gh repo view OWNER/REPO`) before citing it.
+   `auth<zef:ORG>` and `auth<cpan:AUTHOR>` do **not** reliably map to a GitHub
+   owner this way — these need a search (`gh search repos <name>`, or the
+   dist's own README) instead of a guessed URL.
+
+### Stars and last commit via `gh`
+
+Once you have `OWNER/REPO`, `gh` (already authenticated in this environment —
+see `CLAUDE.md`'s GitHub-operations note) returns both signals in one call:
+
+```
+gh repo view OWNER/REPO --json url,stargazerCount,pushedAt,isArchived \
+  -q '"\(.url)\t★\(.stargazerCount)\tlast push: \(.pushedAt)\tarchived: \(.isArchived)"'
+```
+
+- **`stargazerCount`** — a secondary popularity signal. Weight it well below the
+  dependents count (§2 below): stars measure visibility, dependents measure
+  what actually breaks if the module disappears.
+- **`pushedAt`** — the last commit push, a maintenance signal that is often more
+  current than `rea.json`'s `release-date` (a repo can carry unreleased
+  bugfix commits with no new tagged version).
+- **`isArchived: true`** is close to a hard disqualifier — an archived repo
+  will not receive security fixes.
+
+Record all four (URL, stars, last push, archived-or-not) in the candidate's
+metrics table row, per the new columns in §2 below.
+
 ## 2. Compute the metrics
 
 For each candidate collect, in this order:
@@ -53,6 +97,7 @@ For each candidate collect, in this order:
 | **Version + release date** | `rea.json` `version` / `release-date` | is it maintained, or abandoned years ago? **Always state this explicitly in the record's final decision, not just the metrics table** — a stale release is a leading indicator of deeper problems, not just neglect: the TOML survey (`docs/batteries/toml.md`) found the one candidate last released in 2021 (5 years old) was also the one written directly against raw `nqp::` ops, a coding style essentially unseen in current-era modules and a near-guaranteed mutsu parser/interpreter gap. Check the age *before* spending time on the mutsu run, since it predicts where the mutsu run is likely to fail. |
 | **Maintainer org** | the `auth<...>` field of `dist` / the dist name in `rea.json` | per BATTERIES.md §2, `auth<zef:raku-community-modules>` is a preference tiebreaker among otherwise-comparable candidates — that org is a curated, actively-maintained home, distinct from a single-author dist that may be unmaintained. Note it in the record even when it doesn't change the winner. |
 | **Dependents** | count dists in the index whose `depends` names it | ecosystem standing — far better evidence than stars or opinion |
+| **GitHub URL / stars / last push** | `gh repo view OWNER/REPO --json url,stargazerCount,pushedAt,isArchived` (see "Resolving the GitHub URL" / "Stars and last commit via `gh`" above) | stars are a weak popularity signal (below dependents); last-push date is often a more current maintenance signal than `rea.json`'s `release-date`; an archived repo is close to a hard disqualifier |
 | raku result | run its own suite under `raku` | the baseline |
 | **mutsu result** | run its own suite under mutsu | the actual decision input |
 

--- a/todo/tickets/archive-simplezip-samewith-placeholder-slurpy-parse.md
+++ b/todo/tickets/archive-simplezip-samewith-placeholder-slurpy-parse.md
@@ -1,0 +1,58 @@
+# Parser fails on `samewith(...) ; ++ $count` combined with `|c` and `$^a` inside a `.map:` block
+
+## Repro
+
+`Archive::SimpleZip`'s `lib/Archive/SimpleZip.rakumod` (REA `Archive::SimpleZip`
+v0.8.0) has:
+
+```raku
+multi method add(Iterable:D $s, |c --> Int:D)
+{
+    my $count = 0;
+    $s.map: { samewith($^a, |c) ; ++ $count} ;
+    return $count;
+}
+```
+
+Under `raku` this compiles and the dist's own suite passes (3/3 files, 38
+assertions, excluding the author-only `meta.t` which needs `Test::META`).
+Under mutsu, `use Archive::SimpleZip;` fails to parse:
+
+```
+Failed to parse module 'Archive::SimpleZip': Confused. parse error at line 20,
+column 1: ... near: "++ $count} ;\n\n        return $count;\n    }\n\n
+multi method mkdir(Str:D() $name" ...
+```
+
+The error trail (nested "expected statement" frames) points at the
+`{ samewith($^a, |c) ; ++ $count}` block — a `.map:` block that uses a
+`$^a` placeholder parameter, calls `samewith` (multi-dispatch redispatch) with
+that placeholder plus a forwarded slurpy capture `|c`, followed by a
+`;`-separated `++ $count` statement, all on one line.
+
+## Where found
+
+`docs/batteries/compression.md` survey (2026-08-22), measuring
+`Archive::SimpleZip` (a zip-write battery candidate) — blocks `use
+Archive::SimpleZip` entirely, so its whole suite is 0/N under mutsu vs 3/3
+under raku.
+
+## Not yet isolated further
+
+A hand-written minimal repro (class with a `|c` slurpy method, a `.map:`
+block using `$^a` + `samewith` + a trailing `; ++ $var`) did not reproduce the
+parse failure in isolated testing — the trigger needs more of the surrounding
+file (possibly interacting with an earlier construct in the same file, or a
+`unit module`/dynamic-`EXPORT`-imported symbol also being referenced nearby,
+similar in flavor to
+[compress-bzip2-ternary-parse-after-dynamic-export.md](compress-bzip2-ternary-parse-after-dynamic-export.md)).
+Whoever picks this up should start from the real file
+(`Archive::SimpleZip.rakumod`, fetchable from
+`https://raw.githubusercontent.com/raku/REA/main/archive/A/Archive%3A%3ASimpleZip/`)
+and bisect it (e.g. binary-search which earlier declarations are load-bearing
+for the failure to reproduce) rather than re-guessing a repro from scratch.
+
+## Affected files
+
+`src/parser/` — likely the block-signature / placeholder-parameter or
+`samewith`+slurpy-capture parsing path.

--- a/todo/tickets/compress-bzip2-ternary-parse-after-dynamic-export.md
+++ b/todo/tickets/compress-bzip2-ternary-parse-after-dynamic-export.md
@@ -1,0 +1,77 @@
+# Parser misparses a `?? BAREWORD !! BAREWORD` ternary as a call to `use`d dynamic-EXPORT constants
+
+## Repro
+
+`Compress::Bzip2.pm6` (REA `Compress::Bzip2` v0.4.1) does `use
+Compress::Bzip2::Raw;`, and `Compress::Bzip2::Raw.pm6` re-exports its
+constants (`BZ_RUN`, `BZ_FLUSH`, ...) via a **dynamic `sub EXPORT`** that
+introspects its own package with `MY::`:
+
+```raku
+# in Compress::Bzip2::Raw.pm6
+my constant BZ_RUN = 0;
+my constant BZ_FLUSH = 1;
+...
+my %all-symbols = MY::.grep({ .key ~~ /:i 'bz'|'name'/ || .key eq '&fopen'|'&fclose' });
+sub EXPORT { ... }   # builds the export map from %all-symbols dynamically
+```
+
+`Compress::Bzip2.pm6` then uses one of those constants in a ternary passed as
+a NativeCall argument:
+
+```raku
+$!bzret = BZ2_bzCompress($!stream, ($!stream.avail-in) ?? BZ_RUN !! BZ_FLUSH);
+```
+
+Under `raku`, `use Compress::Bzip2;` compiles fine (and the dist's own suite
+is 10/10 under raku). Under mutsu:
+
+```
+$ mutsu -I lib -e 'use Compress::Bzip2; say "ok"'
+===SORRY!=== Error while compiling -e
+Failed to parse module 'Compress::Bzip2': Your !! was gobbled by the
+expression in the middle; please parenthesize
+at -e:168
+```
+
+(line 168 is the `?? BZ_RUN !! BZ_FLUSH` line quoted above, reached through
+the transitive `use`, not a literal line 168 of the `-e` string).
+
+## Working hypothesis
+
+The `Your !! was gobbled` message is the standard Raku parser error for "an
+unrecognized bareword before `!!` was greedily parsed as a listop/function
+call, consuming the `!!` and everything after it as arguments" — i.e. it
+looks exactly like what happens when `BZ_RUN` is **not yet known to the
+parser as a declared constant** at that point, so the parser falls back to
+treating it as a call. That would point at the same underlying gap as
+[nativecall-sizeof-cstruct-repr-unsupported.md](nativecall-sizeof-cstruct-repr-unsupported.md)'s
+sibling area — dynamic `sub EXPORT` built from `MY::` package-symbol-table
+introspection (rather than a static list of `is export`-tagged declarations)
+not registering its exported names as parse-time terms in the importing
+file.
+
+This hypothesis is **not confirmed**: a standalone check that
+`use Compress::Bzip2::Raw; say BZ_RUN;` works fine under mutsu (prints `0`),
+so the dynamic `EXPORT` mechanism does succeed in a simple case. The failure
+only reproduces inside the full `Compress::Bzip2.pm6` file; several
+hand-reduced repros (ternary in a NativeCall arg, inside a `class` method,
+inside a `repeat {...} while (...)` loop, with a typed `int32` attribute) did
+**not** reproduce it. Whoever picks this up should bisect the real file
+(fetchable via
+`https://raw.githubusercontent.com/raku/REA/main/archive/C/Compress%3A%3ABzip2/`)
+rather than re-guessing — something earlier in the file (the `X::Bzip2 is
+Exception` class with a `given/when` over the same dynamically-imported
+constants, lines ~7-30) is a candidate for what makes the difference.
+
+## Where found
+
+`docs/batteries/compression.md` survey (2026-08-22), measuring
+`Compress::Bzip2` (bzip2 compression battery candidate) — blocks `use
+Compress::Bzip2` entirely. raku: 1/1 file (10 assertions). mutsu: 0/1 (fails
+to parse).
+
+## Affected files
+
+`src/parser/` (ternary / bareword-before-`!!` disambiguation) and possibly
+the same dynamic-`EXPORT`-via-`MY::` machinery as the sizeof-CStruct ticket.

--- a/todo/tickets/libzip-nativecall-callback-signature-type-parse.md
+++ b/todo/tickets/libzip-nativecall-callback-signature-type-parse.md
@@ -1,0 +1,51 @@
+# Parser fails on a native-callback `&(...)` signature type used as a NativeCall parameter type
+
+## Repro
+
+`LibZip`'s `lib/LibZip/NativeCall.pm6` (REA `LibZip` dist) declares a native
+sub that takes a C function pointer (callback) as a parameter, typed with an
+anonymous `Callable` signature and a trailing comment on the next line:
+
+```raku
+sub zip_source_function(zip                   # zip*
+                       ,& (Pointer, Pointer, int64, int32 --> int64) # Typedef<zip_source_callback>->...
+                       ,Pointer                        # void*
+                       ...
+                       ) is native(LIB) is export { * }
+```
+
+Under `raku`, `use LibZip;` compiles cleanly. Under mutsu:
+
+```
+$ mutsu -I lib -e 'use LibZip; say "ok"'
+===SORRY!=== Error while compiling -e
+expected statement: expected ')'
+at -e:498
+```
+
+(line 498 is inside `LibZip::NativeCall`, reached transitively through `use
+LibZip`; the reported line number belongs to the imported module, not the
+`-e` snippet — worth checking mutsu's error-location reporting separately if
+it turns out to consistently misattribute lines across `use` boundaries).
+
+## Where found
+
+`docs/batteries/compression.md` survey (2026-08-22), measuring `LibZip` (a
+zip-file NativeCall binding candidate). Blocks `use LibZip` entirely — the
+dist's own (very thin, 2-assertion) test suite is 1/1 under raku and 0/1
+under mutsu (fails to parse before running).
+
+## Affected files
+
+Parser handling of NativeCall parameter-type syntax — search
+`src/parser/` for how `&(...)` / anonymous-Callable-signature parameter types
+are parsed (this is distinct from a `Callable` *variable* type; here it's
+used inline as a parameter type in a native sub signature).
+
+## Priority note
+
+`LibZip` has 0 known dependents and the thinnest test suite (2 trivial
+assertions) of any candidate in the compression/archive survey, so this is
+lower priority than the `Archive::Libarchive::Raw` CPointer-return-type bug
+or the `Compress::Zlib` shadowing bug — recorded for completeness, not as a
+next pick.

--- a/todo/tickets/nativecall-cpointer-repr-typed-param-returns-whatever.md
+++ b/todo/tickets/nativecall-cpointer-repr-typed-param-returns-whatever.md
@@ -1,0 +1,65 @@
+# A `repr('CPointer')`-typed native parameter makes the call return `Whatever` instead of the declared type
+
+## Repro
+
+`Archive::Libarchive::Raw.rakumod` (REA `Archive::Libarchive::Raw` v0.1.5)
+declares a `CPointer`-repr opaque handle class and native subs that take it:
+
+```raku
+class archive is repr('CPointer') is export { * }
+sub archive_read_new(--> archive) is native(LIB) is export { * }
+sub archive_read_support_filter_all(archive $archive --> int32) is native(LIB) is export { * }
+```
+
+Test usage:
+
+```raku
+my archive $a = archive_read_new();
+ok {defined $a}, 'initialization';       # passes
+is archive_read_support_filter_all($a), ARCHIVE_OK, ...;   # fails
+```
+
+Under `raku` this all passes. Under mutsu:
+
+```
+$ mutsu -I lib t/02-list.rakutest
+ok 1 - initialization
+Type check failed for return value; expected int32 but got Whatever (*)
+  in block <unit> at t/02-list.rakutest line 11
+```
+
+`archive_read_new()` itself apparently succeeds (the `archive` CPointer handle
+comes back defined — test 1 passes), but the *next* native call that takes
+that CPointer-repr value as a parameter fails its own return-type check,
+producing `Whatever` instead of running the native function and returning
+`int32`. This reads as: passing a `repr('CPointer')`-typed value as an
+argument to a second native call breaks that call's dispatch, and mutsu
+substitutes `Whatever` rather than actually invoking the native function or
+raising a clear argument-type error.
+
+## Where found
+
+`docs/batteries/compression.md` survey (2026-08-22), measuring
+`Archive::Libarchive::Raw` (archive/zip/tar-via-libarchive battery
+candidate) — every test file past `00-use`/`01-version` fails this way
+(`02-list.rakutest`, `03-extract.rakutest`, `04-archive.rakutest`,
+`05-archive-read-disk.rakutest`; the higher-level `Archive::Libarchive`
+wrapper inherits the same failure). raku: 6/6 files (119 assertions). mutsu:
+1/6 (2 assertions, `00-use`/`01-version` only — everything that actually
+calls a native `archive`-taking function fails).
+
+## Affected files
+
+NativeCall argument-passing / dispatch, likely `src/runtime/` NativeCall
+support and wherever native-call argument marshalling by repr happens (search
+for `CPointer` handling alongside the call-dispatch code, and whatever emits
+"Type check failed for return value").
+
+## Priority note
+
+This single bug blocks the entire `Archive::Libarchive` / `Archive::Libarchive::Raw`
+candidate, which is otherwise the strongest archive-format candidate found in
+the survey (Artistic-2.0, actively maintained — last push 2025-04-29 — and
+covers zip/tar/gzip/bzip2/xz uniformly via libarchive). Fixing this one gap
+is likely the highest-leverage single fix for the compression/archive battery
+slot.

--- a/todo/tickets/nativecall-local-sub-shadows-imported-same-name.md
+++ b/todo/tickets/nativecall-local-sub-shadows-imported-same-name.md
@@ -1,0 +1,54 @@
+# A locally-declared `sub` does not shadow a same-named imported NativeCall sub
+
+## Repro
+
+`Compress::Zlib.pm6` (from the `Compress::Zlib` REA dist, v1.1.0) does:
+
+```raku
+use Compress::Zlib::Raw;   # exports `sub compress(Blob, CArray[long], Blob, ulong) returns int32 is native(...)`
+
+our sub compress(Blob $data, Int $level = 6 --> Buf) is export {
+    if $level < -1 || $level > 9 {
+        die "compression level must be between -1 and 9";
+    }
+    _internal-compression($data, True, $level);
+}
+```
+
+Under `raku`, a call to `compress($data)` inside this file resolves to the
+**locally declared** `sub compress` (the 1-2-arg high-level wrapper), because a
+lexically-scoped declaration in the same file shadows a same-named imported
+symbol. Under mutsu it resolves to the **imported 4-arg NativeCall `compress`**
+from `Compress::Zlib::Raw` instead:
+
+```
+$ mutsu -I lib -I ../Compress-Zlib-Raw/lib t/01-basic.t
+1..5
+ok 1 - Compiled
+NativeCall: 'compress' expects 4 argument(s), got 1
+  in block <unit> at t/01-basic.t line 10
+```
+
+Minimal shape (not yet reduced to a standalone repro without NativeCall —
+reproducing needs two files: one that `is native(...) is export`s a sub named
+`foo`, and a second that `use`s it and then declares `our sub foo(...) is
+export { ... }` of its own, calling `foo(...)` from within its own body).
+
+## Root cause (hypothesis, not fully confirmed)
+
+mutsu's symbol resolution for a call inside a module body appears to prefer an
+imported symbol over a same-named local declaration in the same lexical
+scope, the reverse of Raku's own rule (own-file declarations shadow imports).
+This is a general dispatch-resolution bug, not specific to NativeCall — the
+NativeCall angle just makes the wrong-symbol case detectable (wrong arity).
+
+## Where found
+
+`docs/batteries/compression.md` survey (2026-08-22), measuring `Compress::Zlib`
+(zlib/gzip compression battery candidate) — `t/01-basic.t`, `t/02-stream.t`,
+`t/03-wrap.t` all fail this way; 0/3 files pass under mutsu vs 3/3 under raku.
+
+## Affected files
+
+- `src/compiler/` / `src/vm/vm_call_ops.rs` (function-call dispatch) — exact
+  site not yet located.

--- a/todo/tickets/nativecall-sizeof-cstruct-repr-unsupported.md
+++ b/todo/tickets/nativecall-sizeof-cstruct-repr-unsupported.md
@@ -1,0 +1,51 @@
+# NativeCall `nativesizeof` does not support `repr('CStruct')` classes
+
+## Repro
+
+`Compress::Zlib::Raw.pm6` (REA `Compress::Zlib::Raw` v1.0.1) declares a
+CStruct-repr class for zlib's `z_stream`:
+
+```raku
+class z_stream is repr('CStruct') is export {
+    has ...;
+}
+```
+
+and elsewhere computes its size for a native call:
+
+```raku
+sub z_stream_sizeof(...) { nativesizeof(z_stream) }
+```
+
+Under `raku` this works. Under mutsu:
+
+```
+$ mutsu -I lib t/02-stream.t
+NativeCall op sizeof expected type with CPointer, CStruct, CArray, P6int or
+P6num representation, but got a P6opaque (Compress::Zlib::Raw::z_stream)
+  in sub nativesizeof at lib/Compress/Zlib/Raw.pm6 line 2
+  in sub z_stream_sizeof at lib/Compress/Zlib/Raw.pm6 line 56
+```
+
+The error message names `repr('CStruct')` as one of the types it expects, but
+then reports the actual class as `P6opaque` — i.e. mutsu is not recognizing
+the class's own `is repr('CStruct')` trait when `nativesizeof` looks up its
+representation.
+
+## Where found
+
+`docs/batteries/compression.md` survey (2026-08-22), `Compress::Zlib`'s own
+streaming API (`t/02-stream.t`, `t/03-wrap.t`) — both fail this way.
+
+## Affected files
+
+NativeCall / repr handling, likely `src/runtime/` NativeCall support code and
+wherever `repr('CStruct')` traits are recorded on a class (search for
+`CStruct` and `nativesizeof`).
+
+## Notes
+
+This is a second, independent blocker for `Compress::Zlib` beyond
+[nativecall-local-sub-shadows-imported-same-name.md](nativecall-local-sub-shadows-imported-same-name.md) —
+fixing the shadowing bug alone will not get `t/02-stream.t`/`t/03-wrap.t`
+passing; this CStruct-sizeof gap also needs to be closed.


### PR DESCRIPTION
## Summary
- Surveys the zlib/gzip/bzip2/zip/tar battery slot (gap #4 in `docs/batteries/python-stdlib-comparison.md`) per `docs/batteries/selection-method.md`'s procedure. No candidate is bundle-ready today — every ergonomic candidate (`Compress::Zlib`, `Compress::Bzip2`, `Archive::Libarchive`, `Archive::SimpleZip`, `LibZip`) is healthy under raku but blocked by a specific mutsu bug, each filed as its own `todo/tickets/` entry. The low-level `::Raw` C bindings already pass fully under mutsu. `Archive::Libarchive` is flagged as the strongest archive candidate once its sole blocker (a NativeCall CPointer-typed-argument bug) is fixed.
- Extends `selection-method.md` with the GitHub URL / star count / last-commit procedure (resolve the URL from `rea.json`'s `support.source` or the `auth<github:...>` field, then `gh repo view`) — that data was missing from the existing survey method and is now recorded per candidate in `compression.md`.

## Test plan
- [x] Docs-only change; no code touched. CI's `changes` classifier should skip the heavy jobs.