### PR TITLE
docs: survey XML parsing/generation battery slot

### DIFF
--- a/docs/batteries/xml.md
+++ b/docs/batteries/xml.md
@@ -1,0 +1,293 @@
+# Battery survey: XML parsing and generation
+
+**Slot:** XML parse + generate (DOM-style tree building, serialization back to an XML
+string) · **Status:** **no candidate bundled — survey only** (2026-08-22) ·
+**Yardstick:** [BATTERIES.md §2](../../BATTERIES.md#2-selection-criteria) — license
+(hard gate) → dependency weight → proven behaviour on mutsu → API fit ·
+**Procedure:** [selection-method.md](selection-method.md)
+
+Flagged as gap #3 in
+[python-stdlib-comparison.md](python-stdlib-comparison.md)'s "Structured Markup
+Processing Tools" section: Python's `xml.etree.ElementTree`/`xml.dom`/`xml.sax` have no
+mutsu equivalent. This is the first pass at the slot. **Selection criterion (user
+decision, matching the CSV survey): the candidate must support both parsing and
+generating XML** (build a tree in memory, serialize it back to an XML string), not
+reading alone — the same rule that disqualified `CSV::Parser` in [csv.md](csv.md).
+
+## A note on the no-native-dependency rule
+
+Like the compression slot ([compression.md](compression.md)), a native/C dependency is
+**not** an automatic disqualifier here (same user decision, restated for this slot): a
+NativeCall binding to `libxml2` is architecturally the same shape as the already-bundled
+`OpenSSL`/`DBIish`. `libxml2` (both the runtime `.so` and the `/usr/include/libxml2` dev
+headers) is present on this survey machine (`ldconfig -p | grep -i libxml` shows
+`libxml2.so.2`/`libxml2.so`; `xml2-config --version` reports `2.9.14`), so a native
+candidate's build step was actually exercised, not just assumed. That said, a healthy
+pure-Raku candidate is preferred when one exists, since it avoids the system-library
+runtime dependency entirely — and this slot turned out to have exactly that.
+
+## The field
+
+Enumerated from `~/.zef/store/{rea,fez}/*.json` by filtering name/description/tags on
+`xml|xhtml|dom|sax|xpath|xslt` (192 raw hits in `rea.json`). Most hits were noise:
+general tools that merely touch XML as one input/output format among several
+(`Audio::Hydrogen`, `Cmark`, `Gnome::Gtk3::Glade`, `Map::Mapnik`, `PDF::Extract`,
+`PDF::Tags::Reader`, `JSON::Path`, `Data::DPath`, `Qwiratry::Format::XML`), CSS-tooling
+that uses `xml`/`xpath` only as dependency tags (`CSS`, `CSS::Selector::To::XPath`,
+`CSS::TagSet`), or HTML-focused converters (`HTML::Parser::XML`, `XML::Entity::HTML`).
+`fez.json` carried only stale versions of the real candidates below (its `LibXML` entry
+is 0.9.9 against `rea.json`'s current 0.11.3), so `rea.json` is the field of record here,
+same as the CSV and compression surveys.
+
+The real candidates, after excluding the noise above:
+
+| Candidate | Version | Released | License | Runtime deps | Read+generate? | Native/C dep? | Dependents¹ | GitHub | raku | **mutsu** |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| **`XML`** | 0.3.6 | 2025-02-21 | Artistic-2.0² | none | ✅ both — full DOM tree, `.Str`/`.emit` serialization | none (pure Raku) | **45** | [raku-community-modules/XML](https://github.com/raku-community-modules/XML) — ★31, last push 2025-02-26, not archived | **15/15** (149 tests) | **1/15** ❌ — see below |
+| **`LibXML`** | 0.11.3 | 2026-06-10 | Artistic-2.0² | `File::Temp`, `Method::Also`, `W3C::DOM`, `XML` (+build-time `LibraryMake`) | ✅ both — full DOM/SAX/XPath, `.Str` serialization | **libxml2 (native)** | **7** | [libxml-raku/LibXML-raku](https://github.com/libxml-raku/LibXML-raku) — ★13, **last push 2026-06-10** (most recent in this survey), not archived | **70/70** (723 tests) | **0/70** ❌ — see below |
+| `XML::Writer` | * (2017) | 2017-05-26 | Artistic-2.0² | none | ❌ generate-only — **disqualified** | none | 0 | [masak/xml-writer](https://github.com/masak/xml-writer) — ★8, last push 2017-05-26, not archived | **2/2** (11 tests) | **2/2** ✅ (11/11) |
+| `XML::Fast` | 0.0.3 | 2023-09-12 | Artistic-2.0 | `LibXML` | ❌ read-only (XML→Hash deserializer) — **disqualified** | libxml2 (via `LibXML`) | 0 | [jonathanstowe/XML-Fast](https://github.com/jonathanstowe/XML-Fast) — not checked³ | **3/3** (5 tests) | not measured⁴ |
+| `XML::XPath` | 0.9.3 | 2019-04-11 | Artistic-2.0 | `XML` | extension layer, not a distinct reader/writer | none | 0 | [ufobat/XML-XPath](https://github.com/ufobat/XML-XPath) — ★0, last push 2017-07-30, not archived | not measured⁵ | not measured⁵ |
+| `DOM::Tiny` | 0.5.2 | 2019-01-06 | Artistic-2.0 (README only)⁶ | none | ✅ both, but HTML-first/relaxed parser, not a strict XML DOM | none | 0 | [zostay/raku-DOM-Tiny](https://github.com/zostay/raku-DOM-Tiny) — ★13, last push 2026-07-08, **archived: true** | not measured⁷ | not measured⁷ |
+| `W3C::DOM` | 0.0.3 | 2022-06-29 | Artistic-2.0 | none | abstract interface roles only, not an implementation | none | 0 | not resolved | n/a | n/a |
+| `LibXML::Writer` | 0.0.5 | 2026-02-07 | Artistic-2.0 | `LibXML` | extension of `LibXML` (streaming writer) | libxml2 (via `LibXML`) | 0 | [libxml-raku/LibXML-Writer-raku](https://github.com/libxml-raku/LibXML-Writer-raku) — ★0, last push 2026-03-29, not archived | not measured⁸ | not measured⁸ |
+| `LibXSLT` | 0.1.8 | 2026-02-21 | Artistic-2.0 | `LibXML` | XSLT transform layer, not a parser/writer itself | libxml2+libxslt (via `LibXML`) | 0 | [libxml-raku/LibXSLT-raku](https://github.com/libxml-raku/LibXSLT-raku) — not checked³ | not measured⁸ | not measured⁸ |
+
+¹ Distributions in the local REA index whose `depends` names the candidate — same method
+as [csv.md](csv.md)/[compression.md](compression.md). `XML`'s 45 dependents (versus
+`LibXML`'s 7) is the largest dependents count seen across every battery survey run to
+date (CSV's leader had 0; compression's leader had 4) — a strong, independent signal
+that `XML` is the ecosystem's de facto standard XML library, matching the task's own
+expectation going in.
+² Cross-checked: a shipped `LICENSE` file (Artistic License 2.0, Perl Foundation
+copyright header) matches the `META6.json` `license` field for `XML`, `LibXML`, and
+`XML::Writer` — no license-gate concerns for any of the three measured candidates.
+³ Stars/last-push not resolved for this candidate — deprioritized once it was ruled out
+on the read+generate criterion (`XML::Fast`) or as a `LibXML` extension layer
+(`LibXSLT`), so a `gh repo view` call was not worth spending here.
+⁴ Not measured under mutsu: `XML::Fast` depends on `LibXML`, which is already 0/70 on
+mutsu (blocked at `use` — see below), so it would inherit that blocker with zero new
+information, and it is disqualified anyway (read-only). Its raku run alone took 113
+wallclock seconds for 3 tiny files (5 assertions) — the native `LibXML` startup cost is
+substantial even under raku.
+⁵ Not measured: `XML::XPath` only adds XPath querying on top of `XML`'s own tree (it is
+not a distinct reader/writer), and `XML`'s own parser is already the survey's headline
+finding (1/15 on mutsu) — measuring the dependent would add no new signal beyond
+confirming it inherits the same grammar blocker.
+⁶ No `LICENSE`/`LICENCE` file shipped; `README.md` states "licensed under: The Artistic
+License 2.0 (GPL Compatible)" in prose. Same weaker-evidence tier as `CSV::Parser` in
+[csv.md](csv.md) — not a hard gate, but real weakness on top of the archived-repo signal
+below.
+⁷ Not measured: ruled out on secondary signals before a mutsu run was worth doing — see
+"Ruled out" below.
+⁸ Not measured: both are thin extension layers over `LibXML` (a streaming writer, an
+XSLT transform binding respectively), not distinct parse+generate candidates in their
+own right; each would inherit `LibXML`'s `use`-time blocker regardless.
+
+## What blocks mutsu today
+
+Both real read+generate candidates are **fully healthy under raku** (`XML`: 15/15 files,
+149 assertions; `LibXML`: 70/70 files, 723 assertions — the largest, healthiest upstream
+suite of any battery survey run so far) and **essentially dead on mutsu**, each behind
+its own distinct, now-filed general interpreter bugs (two apiece):
+
+### `XML` — grammar dynamic-variable scoping bug blocks 14 of 15 test files
+
+`XML::Grammar`'s value-parsing token parameterizes itself with a **dynamic variable**
+that carries a default (`token value($*STOPPER = '"') { ... }`), then calls a separate
+subrule (`token char { ... }`) that reads that dynamic variable back via a code
+assertion (`<?{ $*STOPPER eq '"' }>`). This is a standard, documented Raku grammar idiom
+for parameterizing a shared subrule from its caller. On mutsu, `$*STOPPER` reads back as
+`Nil` inside the subrule — the value set by the caller token's own parameter binding
+does not propagate into the dynamic scope of a subrule it calls. Every real
+`XML::Grammar.parse` call fails with `could not parse XML` as a result; the only test
+file that doesn't touch parsing at all (`t/numeric-entities.rakutest`, pure
+string-function tests) passes.
+
+Minimal repro (full detail, including the closer XML-shaped repro, in the ticket):
+
+```raku
+grammar G {
+    token TOP { <value> }
+    token value($*STOPPER = '"') { <char> }
+    token char { { say "STOPPER is ", $*STOPPER.raku }; . }
+}
+G.parse('x');
+```
+
+`raku`: `STOPPER is "\""`. `mutsu`: `STOPPER is Nil`.
+
+Ticket: [`todo/tickets/grammar-token-param-dynvar-not-visible-in-subrule.md`](../../todo/tickets/grammar-token-param-dynvar-not-visible-in-subrule.md)
+
+A second, narrower bug blocks the remaining file pair (`t/emitter.rakutest`,
+`t/make.rakutest`, both needing `XML::Element.append` → `XML::Node.reparent`):
+`XML::Node::reparent`'s parameter uses Raku's indirect/dynamic type-lookup syntax
+(`method reparent(::(q<XML::Element>) $parent)`), which mutsu does not accept as a
+parameter type constraint. At the top level this is a hard parse failure for the whole
+file; inside a `role` body (as here) mutsu instead **silently drops just that one method
+declaration** and keeps compiling the rest of the file, which is how the `XML::Node`
+role composes into `XML::Element` successfully everywhere else and then fails with
+`No such method 'reparent'` only when actually called.
+
+Ticket: [`todo/tickets/indirect-type-param-parse-failure-silently-drops-role-method.md`](../../todo/tickets/indirect-type-param-parse-failure-silently-drops-role-method.md)
+
+### `LibXML` — role meta-invocant + nested-colonpair-alias parameter blocks `use LibXML` entirely
+
+`LibXML::_Configurable` (a role every major `LibXML` class does) declares:
+
+```raku
+multi method create(::?ROLE:D :from(:$for)! is raw, |c) {
+    self.WHAT.new: :config($for.config), |c
+}
+```
+
+`::?ROLE:D` is the role's own meta-invocant-type variable; `:from(:$for)!` is a nested
+colonpair parameter alias (callable as `:from(...)` or `:for(...)`, bound to `$for`).
+Each ingredient works fine alone on mutsu (`::?ROLE:D` with a plain named param; a
+nested-colonpair-alias param with a concrete class invocant); only the combination — the
+role's own meta-invocant type paired with a nested-colonpair-alias parameter — breaks,
+with `Invalid typename 'from' in parameter declaration.` fired at role-body evaluation
+time, before any composition or call happens. Since this role is composed early during
+`LibXML.rakumod`'s own compilation, `use LibXML;` fails before any user code runs —
+mutsu never gets past module load, so all 70 upstream test files fail identically.
+
+Minimal repro:
+
+```raku
+role Foo {
+    method create(::?ROLE:D :from(:$for)!) { say $for }
+}
+say "loaded ok";
+```
+
+`raku`: `loaded ok`. `mutsu`: `Invalid typename 'from' in parameter declaration.`
+
+Ticket: [`todo/tickets/role-meta-invocant-nested-colonpair-alias-param.md`](../../todo/tickets/role-meta-invocant-nested-colonpair-alias-param.md)
+
+None of these bugs (the two above, plus the two `LibXML` bugs below) are XML-specific —
+they are general grammar-dynamic-scoping, parser, and NativeCall gaps that happened to
+surface here, in the same spirit as the CSV survey's shared heredoc-in-sub-body bug and
+the compression survey's shared NativeCall bugs. The `XML::Grammar` bug in particular
+(dynamic variable set by a token's own parameter not visible to a subrule it calls) is a
+core regex/grammar-engine correctness gap likely to recur in any hand-rolled Raku grammar
+using the same idiom, not just this one.
+
+### `LibXML` — a second, independent blocker even for files that avoid the first
+
+`t/000sanity.t` does not `use LibXML;` (it exercises `LibXML::Raw::Defs` directly), so
+it sidesteps the role bug above and gets further — 7 assertions in — before hitting a
+second, unrelated NativeCall bug: `LibXML::Raw::Defs` deliberately leaves `$CLIB` as an
+**undefined `Str` type object** on Linux (the standard idiom for "resolve this symbol
+against the process-global namespace" — `malloc`/`memcpy`/`free` are already linked into
+every process). mutsu instead tries to literally `dlopen` a file named `lib(Str).so`:
+
+```
+Cannot locate native library 'lib(Str).so': lib(Str).so.2: dlopen failed
+```
+
+Minimal repro: `my $CLIB = Str; $CLIB.&cglobal("malloc", Pointer)` throws on mutsu,
+returns a valid pointer on raku. Ticket:
+[`todo/tickets/nativecall-cglobal-undefined-str-library-mistokenized.md`](../../todo/tickets/nativecall-cglobal-undefined-str-library-mistokenized.md).
+This means fixing the role bug alone would not make `LibXML` fully green — this second
+bug is an independent blocker for at least this one file, and possibly others using the
+same `$CLIB` pattern.
+
+### Building the `LibXML` native shim worked cleanly
+
+For completeness: the `LibXML` `Build.pm6` step (compiling its `xml6` native shim
+against system `libxml2`, via `LibraryMake`) was actually run for this survey (not just
+assumed) and succeeded with no errors — `gcc`, `make`, and `/usr/include/libxml2` are all
+present on this machine, and the resulting `resources/libraries/libxml6.so` loaded and
+ran correctly under `raku`. The `use LibXML;` failure above is a pure Raku-level parser
+bug in the dist's own `.rakumod` source, unrelated to the native build.
+
+## Ruled out before a full measurement
+
+- **`XML::Writer`** (masak, Artistic-2.0) — **generate-only**: no reader/parser half at
+  all, disqualified by this slot's read-and-generate criterion (same rule that dropped
+  `CSV::Parser` in [csv.md](csv.md)). Kept in the table for completeness since it is a
+  genuinely healthy, small, zero-dependency candidate — **2/2 files (11 assertions)
+  under both raku and mutsu**, no interpreter bugs found. Worth revisiting only if the
+  slot's criterion is ever relaxed to a generate-only stopgap, which is not recommended
+  for the same reason `CSV::Parser` was not recommended as a read-only stopgap in the
+  CSV survey: bundling it now would mean re-surveying and likely replacing it once a
+  real read+generate candidate clears.
+- **`XML::Fast`** (jonathanstowe, Artistic-2.0) — **read-only**: turns XML into a Hash
+  structure, no writer/composer API. Disqualified on the same read+generate criterion,
+  independent of its `LibXML` dependency chain (which is itself blocked on mutsu — see
+  above).
+- **`DOM::Tiny`** (HANENKAMP → now maintained by zostay, Artistic-2.0) — ruled out on
+  three independent secondary signals, any one of which would deprioritize it: (1) the
+  GitHub repository is **archived** (`isArchived: true`), the same near-hard-disqualifier
+  selection-method.md calls out; (2) license evidence is README-only, no shipped
+  `LICENSE` file (the weaker tier, same as `CSV::Parser`); (3) it is architecturally an
+  HTML-first, CSS-selector-driven "relaxed" DOM (a Raku port of Perl 5's `Mojo::DOM58`)
+  rather than a strict XML/DOM-standard library — its own test file names
+  (`t/023-dom-script-tag.t`, `t/028-dom-barely-html.t`, …) confirm the HTML-tolerance
+  focus. Not measured under either raku or mutsu given these three independent strikes
+  against it while two much stronger XML-first candidates were already found.
+- **`W3C::DOM`** (dwarring, Artistic-2.0) — abstract interface *roles* only ("Abstract
+  W3C DOM Level 2 interface roles"), not an implementation; it is `LibXML`'s own
+  dependency for DOM-interface conformance, not a standalone candidate.
+- **`XML::XPath`** (ufobat, Artistic-2.0) — an XPath query layer built on top of `XML`'s
+  own tree, not a distinct reader/writer; inherits `XML`'s blocker regardless. Also the
+  stalest repository touched in this survey (last push 2017-07-30).
+- **`LibXML::Writer`** and **`LibXSLT`** (both dwarring, Artistic-2.0) — both are thin
+  extension layers over `LibXML` (a streaming writer API, an XSLT transform binding),
+  not distinct parse+generate candidates; both would inherit `LibXML`'s `use`-time
+  blocker regardless of their own code.
+- General-purpose/HTML-adjacent tools that merely touch XML as one feature among several
+  were excluded from the field entirely per the task's own instruction: `CSS`/
+  `CSS::Selector::To::XPath`/`CSS::TagSet` (CSS tooling that tags `xml`/`xpath` as
+  related keywords, not XML libraries), `HTML::Parser::XML` (HTML→XML conversion, not a
+  general XML parser), `XML::Entity::HTML` (HTML entity encode/decode utility),
+  `Audio::Hydrogen`/`Cmark`/`Gnome::Gtk3::Glade`/`Map::Mapnik`/`PDF::Extract`/
+  `PDF::Tags::Reader`/`JSON::Path`/`Data::DPath`/`Qwiratry::Format::XML` (XML as one
+  input/output format among several in an otherwise unrelated tool).
+
+## Recommendation
+
+Under the stated criteria (read-and-generate, no license gate, native dependency
+tolerated per the compression-survey precedent), the field narrows to exactly two live
+candidates — `XML` (pure Raku) and `LibXML` (libxml2 binding) — both Artistic-2.0, both
+with a clean license cross-check, and both **completely healthy under `raku`** (15/15
+and 70/70 files respectively — no candidate in this survey needed to be excluded for
+being broken upstream). **Neither is close to usable on mutsu today**, each blocked by
+its own general, now-filed interpreter bugs:
+
+1. **`XML` is the stronger candidate on ecosystem standing** — 45 dependents (the
+   highest of any battery survey to date, well above `LibXML`'s 7), zero runtime
+   dependencies, and matches the task's own expectation that it is the ecosystem's de
+   facto standard. It is blocked by a genuine grammar/regex-engine correctness gap
+   (dynamic-variable token parameters not visible to a called subrule) that is likely to
+   recur elsewhere, making it a good general lever to pull — fixing it probably helps
+   more than just this one module. The second, narrower blocker (indirect type-name
+   parameter syntax silently dropping a role method) is comparatively easy to fix and
+   independently worth doing for its own sake (silently losing a method is a worse
+   failure mode than erroring loudly).
+2. **`LibXML` is the stronger candidate on feature completeness and native-library
+   soundness** — it is the most actively maintained repository found in this entire
+   survey (last push 2026-06-10, the same day as this survey's `rea.json` version), has
+   the deepest test suite by far (723 assertions vs `XML`'s 149), and its native shim
+   built and ran cleanly against the system `libxml2` with zero native-side problems.
+   It is blocked purely by a role/parser interaction bug (a nested colonpair-alias
+   parameter paired with the role's own `::?ROLE:D` meta-invocant type) that prevents
+   `use LibXML;` from completing at all — fixing it is a single, well-isolated parser
+   fix, not an architectural gap.
+3. **No candidate is bundle-ready today**, and this survey's real output is the four
+   filed bugs above rather than a winner — the same "expect the answer to be 'fix mutsu
+   first'" outcome selection-method.md documents as normal for this project's current
+   stage (see the template and compression surveys for precedent). Given `XML`'s much
+   larger ecosystem footprint (45 vs 7 dependents) and its zero-dependency, pure-Raku
+   nature (no system-library runtime dependency to carry forward), it is the more
+   valuable of the two to prioritize fixing first if only one gets attention — but
+   `LibXML`'s blocker looks like the cheaper fix of the two, so a future session might
+   reasonably pick it up first purely on lever size.
+4. `XML::Writer` (generate-only, 2/2 on mutsu) is a possible generate-only stopgap in
+   the same shape `CSV::Parser` was for CSV — **not recommended** for the same reason:
+   this slot's own criterion requires both directions, and bundling a half-solution now
+   would mean re-surveying and likely replacing it once `XML` or `LibXML` clears.
+
+Re-run this survey (or at least re-measure the four filed bugs) before acting on any of
+the above — per selection-method.md, a readiness claim nobody just re-measured is not
+evidence.

--- a/todo/tickets/grammar-token-param-dynvar-not-visible-in-subrule.md
+++ b/todo/tickets/grammar-token-param-dynvar-not-visible-in-subrule.md
@@ -1,0 +1,108 @@
+# Grammar token-parameter dynamic variable not visible inside a called subrule
+
+Found during the XML battery survey (`docs/batteries/xml.md`) while investigating why
+the pure-Raku `XML` module (`raku-community-modules/XML`) fails to parse even the
+simplest XML document on mutsu ("could not parse XML" from every test file that
+calls `from-xml`).
+
+## Root cause
+
+`XML::Grammar` (`lib/XML/Grammar.rakumod` in the `XML` dist) declares its quoted-value
+token with a **dynamic-variable parameter that carries a default value**:
+
+```raku
+token value($*STOPPER = '"') {
+    \"
+    [
+    | \"
+    | <char>+ \"
+    ]
+}
+token char {
+    <?{ $*STOPPER eq '"' }>
+    <!["]> .
+}
+```
+
+`value` sets `$*STOPPER` (a dynamic/contextual variable) as part of its own parameter
+list, then calls the separately-declared subrule `char`, which reads `$*STOPPER` back
+via a code assertion. This is a normal, documented Raku grammar idiom for
+parameterizing a shared subrule from its caller (`raku-doc/doc/Language/regexes.rakudoc`
+covers regex/token parameters; `variables.rakudoc` covers dynamic-scope `$*` lookup).
+
+On mutsu, `$*STOPPER` reads back as `Nil` inside `char`, i.e. the dynamic variable set
+by `value`'s own parameter binding does not propagate into the dynamic scope of a
+subrule token it calls.
+
+## Minimal repro
+
+```raku
+grammar G {
+    token TOP { <value> }
+    token value($*STOPPER = '"') {
+        <char>
+    }
+    token char {
+        { say "STOPPER is ", $*STOPPER.raku }
+        .
+    }
+}
+G.parse('x');
+```
+
+- `raku`: prints `STOPPER is "\""` (the default value is visible).
+- `mutsu` (`target/debug/mutsu`): prints `STOPPER is Nil`.
+
+A closer repro matching the actual failure shape (alternation + code assertion +
+quantified subrule call, as in `XML::Grammar`):
+
+```raku
+grammar G {
+    token TOP { <value> }
+    token value($*STOPPER = '"') {
+        \"
+        [
+        | \"
+        | <char>+ \"
+        ]
+    }
+    token char {
+        <?{ $*STOPPER eq '"' }>
+        <!["]> .
+    }
+}
+my $m = G.parse('"hello"');
+say $m ?? "matched: $m" !! "no match";
+```
+
+- `raku`: `matched: "hello"`.
+- `mutsu`: `Use of Nil in string context` warning, then `no match` (the code assertion
+  fails because `$*STOPPER` reads as `Nil`, so `Nil eq '"'` is false).
+
+Isolated to confirm the token-parameter-default itself is fine when read from *within
+the same token* (`token value($*STOPPER = '"') { ... }` reading `$*STOPPER` directly in
+its own body works); the bug is specifically about visibility **across a subrule call**
+made from that token's body.
+
+## Why this matters beyond XML
+
+This is a general grammar/regex-engine gap, not XML-specific: any grammar using the
+"parameterize a token with a dynamic variable, then delegate to a shared subrule that
+reads it back" idiom will hit the same silent-`Nil` failure. It fully blocks the `XML`
+dist's own parser (`XML::Grammar`), which is otherwise a healthy, 0-dependency,
+45-dependent, actively-referenced pure-Raku candidate — see `docs/batteries/xml.md` for
+the full survey. 14 of 16 upstream test files fail this way (`could not parse XML` /
+silently mis-parsed values); only `t/numeric-entities.rakutest` (pure string-function
+tests, no grammar involved) passes.
+
+## Affected files (starting point, not exhaustive)
+
+- `src/vm/` grammar/regex execution — wherever token-parameter default bindings are
+  installed into the dynamic scope (`$*`-lookup) versus the ordinary lexical scope.
+  Grep for how `Grammar`/regex subrule calls thread the caller's frame relative to
+  dynamic variables (`PSEUDO::DYNAMIC` / `$*` resolution in `runtime/regex.rs` /
+  `runtime/regex_parse.rs`).
+
+Not root-caused further within this survey's time budget — this ticket records the
+minimal repro so the next session can dive straight into the regex/grammar dynamic-scope
+code without re-deriving it.

--- a/todo/tickets/indirect-type-param-parse-failure-silently-drops-role-method.md
+++ b/todo/tickets/indirect-type-param-parse-failure-silently-drops-role-method.md
@@ -1,0 +1,121 @@
+# `::(EXPR)` indirect type constraint in a parameter fails to parse; silently drops the method inside a role body
+
+Found during the XML battery survey (`docs/batteries/xml.md`) while investigating the
+`XML` module's (`raku-community-modules/XML`) `t/emitter.rakutest` and `t/make.rakutest`
+failures: `No such method 'reparent' for invocant of type 'XML::Element'`.
+
+## Root cause
+
+`XML::Node` (`lib/XML/Node.rakumod` in the `XML` dist) is a role with:
+
+```raku
+role XML::Node {
+    method reparent(::(q<XML::Element>) $parent) {
+        self.remove if $.parent.defined;
+        $.parent = $parent;
+        self
+    }
+    ...
+}
+```
+
+`::(q<XML::Element>)` is Raku's **indirect/dynamic type-name lookup** syntax — resolve a
+type at compile time from a string expression, used here (instead of a plain
+`XML::Element $parent`) presumably to sidestep a forward-reference / circular-dependency
+ordering issue between `XML::Node` and `XML::Element`.
+
+On mutsu this syntax is not accepted as a parameter type constraint:
+
+```raku
+class Foo {
+    method bar(::(q<Foo>) $x) { say "bar called with $x" }
+}
+Foo.new.bar(Foo.new);
+```
+
+- `raku`: prints `bar called with Foo<...>`.
+- `mutsu`: **hard parse failure for the whole file**:
+  ```
+  ===SORRY!=== Error while compiling ...
+  Confused. expected statement: expected expected statement: expected expression
+  statement or expression after infix operator or '.' or digits or generic radix
+  literal or ...
+  ```
+
+But when the same construct appears **inside a `role` body** instead of a top-level
+`class`, mutsu does not hard-fail the file — it silently drops just that one method
+declaration and continues compiling/running the rest of the file:
+
+```raku
+role Bar {
+    method reparent(::(q<Foo>) $parent) {
+        say "reparent called";
+    }
+}
+class Foo does Bar {}
+Foo.new.reparent(Foo.new);
+```
+
+- `raku`: prints `reparent called`.
+- `mutsu`: `No such method 'reparent' for invocant of type 'Foo'` — i.e. `Foo` composed
+  `Bar` successfully, and every *other* method in `Bar` presumably still works, but
+  `reparent` itself is simply absent from the MRO. This is the exact symptom `XML`'s own
+  test suite hits (`XML::Element does XML::Node`, and `XML::Node::reparent` vanishes).
+
+This is really two related findings about the same underlying parser gap:
+
+1. `::(EXPR)` is not supported as a parameter type constraint at all (should resolve the
+   type at compile/run time from the string, same as it already presumably works as a
+   *value*-position type-object reference — `$.parent ~~ ::(q<XML::Element>)` inside the
+   same file's `previousSibling`/`nextSibling`/`remove` methods does work, since those
+   test files get as far as failing on `reparent` specifically, not aborting entirely).
+2. The failure mode is **inconsistent by container**: a hard `===SORRY!===` compile abort
+   at top level (class), but a swallowed/dropped declaration inside a role. The dropped
+   case is more dangerous — it produces a working-looking program that silently omits
+   functionality instead of failing loudly, which is a worse failure mode than the parse
+   error itself.
+
+## Minimal repros
+
+Top-level (hard parse failure, whole file dies):
+
+```raku
+class Foo {
+    method bar(::(q<Foo>) $x) {
+        say "bar called with $x";
+    }
+}
+Foo.new.bar(Foo.new);
+```
+
+Inside a role (silent method drop, file keeps running):
+
+```raku
+role Bar {
+    method reparent(::(q<Foo>) $parent) {
+        say "reparent called";
+    }
+}
+class Foo does Bar {}
+Foo.new.reparent(Foo.new);
+```
+
+## Why this matters beyond XML
+
+This is a general parser gap (indirect type-name resolution, `Language/typesystem.rakudoc`
+covers `::(...)`), not XML-specific — any module using `::(q<TypeName>)` to sidestep a
+circular/forward type reference in a method signature will hit this. It blocks 2 of the
+`XML` dist's 16 test files outright (`t/emitter.rakutest`, `t/make.rakutest` — both need
+`XML::Element.append`, which calls `.reparent`), on top of the separate, more severe
+grammar blocker (`todo/tickets/grammar-token-param-dynvar-not-visible-in-subrule.md`)
+that blocks the other 14. See `docs/batteries/xml.md` for the full survey.
+
+## Affected files (starting point, not exhaustive)
+
+- `src/parser/` — parameter-type-declaration grammar needs to accept `::(EXPR)` the same
+  way it presumably already accepts `::(EXPR)` in expression/value position.
+- Whatever swallows the parse error inside a role body instead of propagating it should
+  also be tightened regardless of the `::(EXPR)` fix — a role that fails to parse one of
+  its methods should not silently compose successfully with that method missing.
+
+Not root-caused further within this survey's time budget.

--- a/todo/tickets/nativecall-cglobal-undefined-str-library-mistokenized.md
+++ b/todo/tickets/nativecall-cglobal-undefined-str-library-mistokenized.md
@@ -1,0 +1,72 @@
+# `cglobal()`/`native()` with an undefined `Str` library name tries to load a literal file instead of the process-global namespace
+
+Found during the XML battery survey (`docs/batteries/xml.md`) while running `LibXML`'s
+(`zef:dwarring`, libxml2 NativeCall binding) own `t/000sanity.t` under mutsu — this test
+does not `use LibXML;` (so it does not hit the role/parser bug in
+`todo/tickets/role-meta-invocant-nested-colonpair-alias-param.md`), which let it get
+further and expose this separate, more general NativeCall bug.
+
+## Root cause
+
+`LibXML::Raw::Defs` (`lib/LibXML/Raw/Defs.rakumod` in the `LibXML` dist) sets:
+
+```raku
+our $CLIB is export(:CLIB) = Rakudo::Internals.IS-WIN ?? 'msvcrt' !! Str;
+```
+
+On Linux, `$CLIB` is deliberately left as the **undefined `Str` type object** — this is
+the standard NativeCall idiom for "resolve the symbol against the current process /
+global namespace" (glibc functions like `malloc`/`memcpy`/`free` are already linked into
+every process, so no specific library needs to be named). `t/000sanity.t` then does:
+
+```raku
+ok(try {$CLIB.&cglobal($_, Pointer)}, "clib $_ binding")
+```
+
+for `<malloc memcpy free>`.
+
+On mutsu this fails with:
+
+```
+Cannot locate native library 'lib(Str).so': lib(Str).so.2: dlopen failed
+```
+
+i.e. mutsu is literally trying to `dlopen` a file named `lib(Str).so` — it appears to
+have stringified the undefined `Str` type object's *type name* into the library-name
+template (`lib<NAME>.so`) instead of recognizing "library name is an undefined `Str`"
+as the documented "use the process-global/default namespace" case.
+
+## Minimal repro
+
+```raku
+use NativeCall;
+my $CLIB = Str;
+say try { $CLIB.&cglobal("malloc", Pointer) } // "FAILED: $!";
+```
+
+- `raku`: prints a `NativeCall::Types::Pointer<0x...>` (the symbol resolves against the
+  process-global namespace).
+- `mutsu` (`target/debug/mutsu`): `Cannot locate native library 'lib(Str).so': lib(Str).so.2: dlopen failed`
+
+## Why this matters beyond LibXML
+
+This is a general NativeCall gap (in the same family as the compression survey's
+NativeCall findings — `docs/batteries/compression.md`'s "What blocks mutsu today"
+section, e.g. `nativecall-cpointer-repr-typed-param-returns-whatever.md`), not specific
+to `LibXML`. Any NativeCall binding that binds against already-process-linked libc
+symbols by passing an undefined `Str`/`Any` as the library name (a common idiom to avoid
+hardcoding `libc.so.6` vs `msvcrt` vs `libSystem.dylib` per platform) will hit this. It
+is a secondary, independent blocker for `LibXML` beyond the role/parser bug already filed
+— even once that one is fixed, `t/000sanity.t` (and potentially other files using the
+same `$CLIB` pattern for `malloc`/`memcpy`/`free`) would still fail here.
+
+## Affected files (starting point, not exhaustive)
+
+- Wherever mutsu resolves the library-name argument of `is native(...)` / `cglobal()` —
+  likely in the NativeCall support code that builds the `dlopen` path from the trait
+  argument's value. It needs a branch for "argument is an undefined `Str`/type object"
+  that skips `dlopen` entirely and resolves the symbol against the current process
+  (`dlopen(NULL, ...)` / `RTLD_DEFAULT` equivalent) instead of stringifying the type
+  object into a filename template.
+
+Not root-caused further within this survey's time budget.

--- a/todo/tickets/role-meta-invocant-nested-colonpair-alias-param.md
+++ b/todo/tickets/role-meta-invocant-nested-colonpair-alias-param.md
@@ -1,0 +1,96 @@
+# `::?ROLE:D` invocant type + nested colonpair-alias named param breaks method registration
+
+Found during the XML battery survey (`docs/batteries/xml.md`) while investigating why
+`LibXML` (`zef:dwarring`, the libxml2 NativeCall binding) fails at `use LibXML;` itself
+on mutsu.
+
+## Root cause
+
+`LibXML::_Configurable` (`lib/LibXML/_Configurable.rakumod` in the `LibXML` dist) has:
+
+```raku
+unit role LibXML::_Configurable;
+...
+multi method create(::?ROLE:D :from(:$for)! is raw, |c) {
+    self.WHAT.new: :config($for.config), |c
+}
+```
+
+`::?ROLE:D` is the role's own meta-invocant-type variable (analogous to `::?CLASS:D`
+for classes); `:from(:$for)!` is a **nested colonpair parameter alias** — a required
+named parameter callable as either `:from(...)` or `:for(...)`, bound to `$for`
+internally (documented idiom, `raku-doc/doc/Language/signatures.rakudoc`).
+
+On mutsu, declaring a role method whose invocant type is `::?ROLE:D` and which also has
+a nested-colonpair-alias named parameter fails with:
+
+```
+Invalid typename 'from' in parameter declaration.
+```
+
+This happens at role-body evaluation time (i.e. merely declaring the role, no
+composition or call needed) and — critically — **the parse error is swallowed rather
+than propagated**: the file continues running with the method simply absent from the
+role (see the companion ticket
+`todo/tickets/indirect-type-param-parse-failure-silently-drops-role-method.md` for the
+general "silently dropped role method" shape, which is the same failure mode as this
+bug's symptom once composed into a class).
+
+## Minimal repro
+
+```raku
+role Foo {
+    method create(::?ROLE:D :from(:$for)!) {
+        say $for;
+    }
+}
+say "loaded ok";
+```
+
+- `raku`: prints `loaded ok` (parses and composes fine; `Foo` is a role so nothing
+  calls `create` here, but declaration succeeds).
+- `mutsu` (`target/debug/mutsu`): fails with
+  `Invalid typename 'from' in parameter declaration.` before reaching the `say`.
+
+### Isolating the two ingredients
+
+Each ingredient alone is fine on mutsu; only the combination breaks:
+
+```raku
+# OK on mutsu: ::?ROLE:D invocant + a PLAIN named param
+role Foo {
+    method create(::?ROLE:D :$for!) { say $for }
+}
+say "loaded ok";      # -> loaded ok
+
+# OK on mutsu: nested colonpair alias + a CONCRETE class invocant (not ::?ROLE)
+class Foo {
+    method create(Foo:D :from(:$for)! is raw) { say $for }
+}
+say "loaded ok";      # -> loaded ok (also OK with ::?CLASS:D in place of Foo:D)
+```
+
+So the bug is specifically the pairing of the role's own meta-invocant-type variable
+(`::?ROLE:D`) with a nested colonpair-alias named parameter in the same signature.
+
+## Why this matters beyond LibXML
+
+This blocks `use LibXML;` entirely — the module never loads on mutsu, so its full
+70-file / 723-test upstream suite (100% green under `raku`) cannot even start. See
+`docs/batteries/xml.md` for the full survey; `LibXML` is otherwise the strongest
+NativeCall-based candidate in the field (Artistic-2.0, actively maintained — last push
+2026-06-10 — 7 dependents, and the machine already has libxml2 + its dev headers
+installed so the native shim builds cleanly).
+
+## Affected files (starting point, not exhaustive)
+
+- Wherever role method signatures are parsed/registered — likely the same signature
+  parsing path exercised by `todo/tickets/grammar-token-param-dynvar-not-visible-in-subrule.md`'s
+  neighborhood is unrelated; this one is specifically about `::?ROLE` meta-type
+  resolution interacting with the nested-colonpair-alias parameter parse, probably in
+  `src/parser/` (signature/parameter grammar) or `src/compiler/` (role method
+  registration). Worth checking whether `::?CLASS` invocants share the same code path
+  as `::?ROLE` — the repro above shows `::?CLASS:D` does NOT trigger the bug, so the
+  role-specific meta-type resolution is the more likely culprit.
+
+Not root-caused further within this survey's time budget.


### PR DESCRIPTION
## Summary
- Surveys the XML slot (gap #3 in `docs/batteries/python-stdlib-comparison.md`'s "Structured Markup Processing Tools" section) per `docs/batteries/selection-method.md`'s procedure, with a read-and-generate criterion (same rule that disqualified read-only `CSV::Parser` in the CSV survey).
- Two live candidates, both healthy under raku and both blocked on mutsu:
  - **`XML`** (raku-community-modules, pure Raku, 45 dependents — the highest ecosystem-standing signal of any battery survey to date) — 15/15 files under raku, 1/15 under mutsu, blocked by a grammar dynamic-variable scoping bug plus a narrower indirect-type-param parse bug that silently drops a role method.
  - **`LibXML`** (libxml2 binding, most actively maintained repo found in this survey) — 70/70 files under raku (723 assertions, the deepest suite seen yet), 0/70 under mutsu, blocked by a role meta-invocant + nested-colonpair-alias parameter parse bug plus a second independent NativeCall `cglobal` bug.
- No candidate bundled; four mutsu bugs filed as individual `todo/tickets/` entries with minimal raku-vs-mutsu repros.

## Test plan
- [x] Docs-only change; no code touched. CI's `changes` classifier should skip the heavy jobs.