### PR TITLE
docs: note libxml2's 2025 maintainer sustainability crisis in xml.md

### DIFF
--- a/docs/batteries/xml.md
+++ b/docs/batteries/xml.md
@@ -26,6 +26,36 @@ candidate's build step was actually exercised, not just assumed. That said, a he
 pure-Raku candidate is preferred when one exists, since it avoids the system-library
 runtime dependency entirely — and this slot turned out to have exactly that.
 
+### `libxml2` upstream has a real sustainability history worth weighing (added 2026-08-22)
+
+BATTERIES.md §6's "native system libraries ride the OS" reasoning assumes a healthy
+upstream is there to produce the fixes that distro security teams then backport — that
+assumption briefly did not hold for `libxml2` itself, independent of anything in the
+`LibXML` Raku binding:
+
+- As of mid-2025, `libxml2` (despite being embedded in browsers, most Linux
+  distributions, and a huge share of XML-processing infrastructure worldwide) was
+  maintained by essentially one unpaid volunteer, Nick Wellnhofer, and had received only
+  ~$17,000 in total project donations (~$10,000 of it from Google) — see
+  [the LWN coverage](https://lwn.net/Articles/1025971/) and
+  [Socket's summary](https://socket.dev/blog/libxml2-maintainer-ends-embargoed-vulnerability-reports).
+- On 2025-09-15, Wellnhofer announced he was stepping down as maintainer, citing
+  security-report triage alone costing "several hours each week" — unsustainable
+  unpaid volunteer work ([source](https://androidexperto.com/libxml2-becomes-officially-unmaintained-after-maintainer-steps-down/)).
+- The project did not stay unmaintained: on 2025-12-09 two new maintainers (Daniel
+  Garcia Moreno, Iván Chavero) took over, and releases have continued into 2026
+  (2.15.2 on 2026-03-03, 2.15.3 on 2026-04-16) — so this is a recovered, not an
+  ongoing, crisis. But it demonstrates the risk was real, not hypothetical: a
+  library this widely relied upon ran for years as a single-person bus-factor
+  operation before anyone else stepped in.
+
+This does not disqualify `LibXML` outright — the OS-patches-the-native-library
+mechanism (§6) still applies once upstream ships a fix, and a new maintainer team is now
+in place. But it is a genuine point in `XML`'s favor in the head-to-head: `XML` is pure
+Raku with **zero** runtime dependencies, so it carries none of this transitive
+system-library sustainability risk at all. Weigh this alongside the dependents-count
+signal (45 vs. 7) when deciding which candidate to prioritize fixing/bundling first.
+
 ## The field
 
 Enumerated from `~/.zef/store/{rea,fez}/*.json` by filtering name/description/tags on
@@ -266,23 +296,30 @@ its own general, now-filed interpreter bugs:
    independently worth doing for its own sake (silently losing a method is a worse
    failure mode than erroring loudly).
 2. **`LibXML` is the stronger candidate on feature completeness and native-library
-   soundness** — it is the most actively maintained repository found in this entire
-   survey (last push 2026-06-10, the same day as this survey's `rea.json` version), has
-   the deepest test suite by far (723 assertions vs `XML`'s 149), and its native shim
-   built and ran cleanly against the system `libxml2` with zero native-side problems.
-   It is blocked purely by a role/parser interaction bug (a nested colonpair-alias
-   parameter paired with the role's own `::?ROLE:D` meta-invocant type) that prevents
-   `use LibXML;` from completing at all — fixing it is a single, well-isolated parser
-   fix, not an architectural gap.
+   soundness, with one caveat** — it is the most actively maintained *Raku binding*
+   repository found in this entire survey (last push 2026-06-10, the same day as this
+   survey's `rea.json` version), has the deepest test suite by far (723 assertions vs
+   `XML`'s 149), and its native shim built and ran cleanly against the system `libxml2`
+   with zero native-side problems. It is blocked purely by a role/parser interaction bug
+   that prevents `use LibXML;` from completing at all — fixing it is a single,
+   well-isolated parser fix, not an architectural gap. **The caveat**: `libxml2` itself
+   (the underlying C library, not the Raku binding) had a real sustainability crisis as
+   recently as 2025 — see "`libxml2` upstream has a real sustainability history worth
+   weighing" above. It has since gained new maintainers and resumed releases, so this is
+   a recovered risk, not a live blocker, but it is a genuine mark against `LibXML` in the
+   comparison that `XML`'s zero-dependency, pure-Raku design simply does not carry.
 3. **No candidate is bundle-ready today**, and this survey's real output is the four
    filed bugs above rather than a winner — the same "expect the answer to be 'fix mutsu
    first'" outcome selection-method.md documents as normal for this project's current
    stage (see the template and compression surveys for precedent). Given `XML`'s much
-   larger ecosystem footprint (45 vs 7 dependents) and its zero-dependency, pure-Raku
-   nature (no system-library runtime dependency to carry forward), it is the more
-   valuable of the two to prioritize fixing first if only one gets attention — but
-   `LibXML`'s blocker looks like the cheaper fix of the two, so a future session might
-   reasonably pick it up first purely on lever size.
+   larger ecosystem footprint (45 vs 7 dependents), its zero-dependency, pure-Raku
+   nature (no system-library runtime dependency to carry forward, and none of
+   `libxml2`'s sustainability history), it is both the more valuable of the two to
+   prioritize fixing first *and* the safer long-term bet if only one gets bundled.
+   `LibXML`'s blocker looks like the cheaper fix of the two in isolation, so a future
+   session might still reasonably pick it up first purely on lever size — but that
+   should be a conscious tradeoff against the maintenance-risk point above, not a
+   default.
 4. `XML::Writer` (generate-only, 2/2 on mutsu) is a possible generate-only stopgap in
    the same shape `CSV::Parser` was for CSV — **not recommended** for the same reason:
    this slot's own criterion requires both directions, and bundling a half-solution now


### PR DESCRIPTION
## Summary
- Follow-up to #6842 (docs-only XML battery survey), per user request.
- `libxml2` (the C library `LibXML`'s NativeCall binding depends on, not the Raku binding itself) went through a real maintainer sustainability crisis in 2025: essentially one unpaid volunteer maintainer, total project funding ~$17k, and the maintainer stepped down in September 2025 citing unsustainable security-triage workload. New maintainers took over in December 2025 and releases have continued into 2026, so this is a recovered risk rather than a live blocker — but it's a real signal worth recording and weighing.
- Adds a dated note to `docs/batteries/xml.md` and folds it into the Recommendation section's `LibXML` point, strengthening the existing lean toward prioritizing `XML` (pure Raku, zero runtime deps, none of this transitive risk) over `LibXML` when only one gets attention.

## Test plan
- [x] Docs-only change; no code touched. CI's `changes` classifier should skip the heavy jobs.