### PR TITLE
docs(adr-0058): the residual try-cell divergences are eager `.map`, not a mis-placed LazyList force

### DIFF
--- a/docs/adr/0034-seq-reification-is-in-place-and-distinct-from-consumption.md
+++ b/docs/adr/0034-seq-reification-is-in-place-and-distinct-from-consumption.md
@@ -448,6 +448,14 @@ where raku keeps it lazy until something consumes it, so a `die` inside the map 
 `LazyList`, not about **what** forcing does to a `Seq`. It is not fixed by this ADR and should not
 be bundled into it.
 
+**Follow-up (2026-08-22):** that scoped-out work is now
+[ADR-0058](0058-map-grep-produce-a-deferred-seq.md), which also corrects the
+mechanism named above: the cells do *not* go through `LazyList` at all — a
+finite `(1..3).map(...)` is evaluated **eagerly at the `.map` call**, so there is
+no deferred value whose force could be moved. ADR-0058's decision is to give
+`SeqSource` a `MapGrep` variant and let this ADR's own reify/consume split do the
+deferring.
+
 The relationship is worth recording, though: those cells are hard to fix today partly because
 deferring the force means the value gets touched later and *by more consumers*, and every extra
 touch is currently a chance to hit the destroy-on-materialize bug. Landing this ADR removes that

--- a/docs/adr/0058-map-grep-produce-a-deferred-seq.md
+++ b/docs/adr/0058-map-grep-produce-a-deferred-seq.md
@@ -1,0 +1,355 @@
+# ADR-0058: `.map`/`.grep` produce a deferred `Seq` — the callback runs at first consumption, not at the call
+
+- **Status**: Proposed
+- **Date**: 2026-08-22
+- **Deciders**: tokuhirom, Claude
+- **Related**: [ADR-0034](0034-seq-reification-is-in-place-and-distinct-from-consumption.md)
+  (the `SeqBody`/`SeqSource` machinery this ADR extends, and whose §6 scoped this
+  defect out of itself), [ADR-0038](0038-seq-cache-returns-a-list-and-the-seq-list-view-is-a-property-of-the-value.md)
+  (the other open `SeqBody` decision)
+- **Ticket**: [todo/deep/residual-try-cell-eager-seq-reification-divergences.md](../../todo/deep/residual-try-cell-eager-seq-reification-divergences.md)
+
+---
+
+## 1. Context
+
+### 1.1 The symptom family
+
+A `map` callback that dies inside a `try` is caught by that `try` in mutsu and
+escapes it in rakudo:
+
+```raku
+try { (1..3).map({die "boom"}) }; say "alive ", $!.defined
+# raku:  dies, uncaught ("boom")
+# mutsu: alive True
+```
+
+The whole "residual try-cell" family in the ticket — P4, P5, P12, P13, P18, Q9,
+Q11, Q14 — is this one snippet in eight shapes (through a sub, through `EVAL`,
+with `fail` instead of `die`, with the value used instead of sunk, with an
+enclosing `CATCH`). mutsu is *more forgiving* than raku in every one: it never
+aborts a file raku would pass, only passes constructs raku would abort.
+
+All twelve cells the ticket lists were **re-measured on 2026-08-22 against a
+current `main` build**, and all twelve still reproduce exactly as recorded —
+none had been fixed by an intervening change:
+
+| Cell | raku | mutsu |
+| --- | --- | --- |
+| P4 `try { (1..3).map({die "boom"}) }; say "alive ", $!.defined` | throws | `alive True` |
+| P5 same via `sub f` | throws | `alive True` |
+| P12 / P13 `sub ee { try { f() }; $! }` | throws | `X::AdHoc` + alive |
+| P18 `sub ee { try { f() } }` (value used) | `Seq` + alive | `Nil` + alive |
+| Q5 / Q6 yada-stub map under a sub-scope `try` | throws | `Failure` + alive |
+| Q9 `try { … }; CATCH { default { … } }` | `unit-caught` | alive, nothing caught |
+| Q11 `try { EVAL $c }` in a sub | throws | `X::AdHoc` + alive |
+| Q14 `fail` instead of `die` | throws | `alive True` |
+| R6 / R7 Q5 / Q6 with a tail marker | throws | `Failure` + alive |
+
+### 1.2 The ticket's stated root cause is not the one these cells exercise
+
+The ticket (and ADR-0034 §6, quoting it) says mutsu "forces a `map`-produced
+`LazyList` at the assignment/call boundary, where raku keeps it lazy until
+something actually consumes it", and points at `force_lazy_list_vm`'s callers.
+
+That description does not fit the cells. `(1..3)` is a **finite** range, so
+`Interpreter::is_lazy_pipe_source` (`src/runtime/methods_collection.rs`) is
+`false` and no `LazyList` is ever built: `dispatch_map_method`
+(`src/runtime/methods_dispatch_match2.rs`) materializes the source and calls
+`eval_map_over_items` **immediately**, inside the `try`. There is no deferred
+value whose force could be moved — the callback has already run by the time the
+`try` block's tail value exists.
+
+mutsu's `try`/sink *placement* is not at fault either, and must not be touched:
+`compile_try_region` (`src/compiler/helpers_control_flow.rs`) deliberately
+leaves the tail value on the stack and lets the **enclosing** statement's
+`SinkPop` force it, outside the trap — which is exactly rakudo's rule, verified
+in `news/2026-08/try-statement-sink-semantics-pinned.md` and pinned by
+`t/try-sink-semantics.t`.
+
+**The real root cause is that `.map`/`.grep` are eager in mutsu and lazy in
+rakudo.** Everything else in the family follows from that.
+
+### 1.3 mutsu has three regimes for one Raku operation
+
+| Source / callback | Result | Callback runs |
+| --- | --- | --- |
+| infinite/lazy source, arity-1 callback (`is_lazy_pipe_source` + `make_lazy_pipe`) | `LazyList` with a `lazy_pipe` | on pull |
+| any source, callback body contains `return` **or** is a `...` stub (`create_lazy_map_list`) | `LazyList` with `__mutsu_lazy_map_items`/`_func` | on force |
+| **everything else — the overwhelming majority** | `Seq`, already reified | **at the `.map` call** |
+
+The second regime is the tell: mutsu already *knows* the callback has to be
+deferred whenever running it early is observable, and enumerates the two shapes
+where that had bitten hard enough to fix (`return` needs
+out-of-dynamic-scope detection; a `...` stub must not fire while the Seq is
+never iterated). `die`/`fail` inside the callback is a third shape of the same
+thing, and "the body contains a `die`" is not a predicate worth writing — the
+`die` can be indirect, behind a call, behind an operator that fails. The
+enumeration is a band-aid whose list can never be complete.
+
+Non-`try` shapes make the divergence visible without any exception at all:
+
+```raku
+my $s = (1..3).map({ say "side $_"; $_ });
+say "before";
+say $s.List;
+# raku:  before / side 1 / side 2 / side 3 / (1 2 3)
+# mutsu: side 1 / side 2 / side 3 / before / (1 2 3)
+```
+
+`grep` behaves identically in rakudo (lazy) and identically in mutsu (eager over
+a finite source), and does not even have the `return`/stub deferral that `map`
+has.
+
+### 1.4 Four of the twelve cells are a *different*, narrower bug
+
+Q5, Q6, R6 and R7 use a `...` **stub** callback, which mutsu already defers
+(regime 2 in §1.3), so eagerness is not their problem. Measured on the same
+build, mutsu matches raku exactly for the stub map as soon as the enclosing
+`try` is removed:
+
+```raku
+sub ee { map -> $x, $y { ... }, 1..6; say "reached-tail"; "done" }
+say ee(); say "alive";       # both: "Stub code executed", exit 1
+say ee().^name; say "alive"; # both: Failure / alive, exit 0
+```
+
+Add the `try` back (`sub ee { try { map … }; say "reached-tail"; $! }`) and raku
+throws while mutsu answers `Failure` and runs on. So for these four the force
+already lands in the right place, at the enclosing statement's `SinkPop` outside
+the trap; what differs is **how a `fail` raised during that force resolves when
+a `try` is lexically between it and the routine** — mutsu lets it return from
+the routine as a `Failure`, rakudo throws it. That is out of scope for this ADR
+and is pinned as two `todo` rows in
+`t/map-callback-runs-at-consumption.t`; the other ten rows of that file are
+already-correct behaviour this ADR must not regress.
+
+### 1.5 Why this only became tractable now
+
+ADR-0034 gave `Seq` a real body with a *deferred source* (`SeqSource`) and a
+reify/consume split, and taught the dispatch chokepoints, `for`, sink and
+`@`/`%` assignment to touch a not-yet-pulled body. Before that, deferring a map
+meant every extra touch of the deferred value was a chance to hit the
+destroy-on-materialize bug. That coupling is gone: `SeqSource` is now the
+natural place for "these elements come from running a callback over a list", the
+same way `SeqSource::IoLines` is the place for "these elements come from a
+filehandle".
+
+What is *not* gone is the read-path exposure, and that is what makes this an ADR
+rather than a patch — see §5.
+
+---
+
+## 2. Decision
+
+**`.map` and `.grep` return a `Seq` whose body is not yet reified. The callback
+runs when something consumes the Seq, through ADR-0034's existing
+`reify`/`take` split — not at the `.map` call. The `return`/stub deferral
+predicate and its `LazyList` detour are retired.**
+
+Concretely: `SeqSource` gains a `MapGrep { items, func, is_grep }` variant
+(§3.4), `Interpreter::pull_seq_source` gains the arm that runs the callback, and
+`dispatch_map_method` hands back `Value::seq_deferred(..)` instead of
+`Value::seq(items)`. No new `Value` variant and no new forcing rules: every site
+ADR-0034 already taught to reify-or-consume a `ValueView::Seq` that
+`needs_touch()` covers this for free.
+
+Two consequences are accepted up front, because they are the point:
+
+- **mutsu becomes stricter.** A `die`/`fail` in a `map` callback under a `try`
+  now escapes that `try`, matching rakudo (§1.1). Every whitelisted roast file
+  that relies on mutsu's permissiveness must be fixed, not exempted.
+- **Side-effect ordering changes.** A `map` callback's side effects happen at
+  first consumption, not at the call. That is rakudo's observable behaviour
+  (§1.3) and any local assertion that depends on the old order was pinning a
+  mutsu artefact.
+
+What is *not* decided here: whether the deferred body pulls one element at a
+time or reifies the whole source on first touch. This ADR reifies whole (the
+cheapest thing that is correct); §3.3 records the pull-granular refinement as a
+follow-up.
+
+---
+
+## 3. Options considered
+
+| Option | Matches rakudo? | Mechanism | Blast radius | Verdict |
+| --- | --- | --- | --- | --- |
+| **0.** Extend the deferral predicate with "body contains `die`/`fail`" | ✗ (indirect throws) | one predicate | tiny | Rejected — §3.1 |
+| **1.** Route every `.map` through `create_lazy_map_list` (`LazyList`) | ~ | existing | wide, plus a per-map `Env` clone | Rejected — §3.2 |
+| **2.** Make `is_lazy_pipe_source` true for finite sources too (`lazy_pipe`) | ~ | existing | wide; single-element pull only | Rejected — §3.3 |
+| **3.** A new `SeqSource::MapGrep`, reified by ADR-0034's `reify`/`take` | ✓ | ADR-0034's | wide, but on the *already-supported* deferred-Seq shape | **Recommended** |
+
+### 3.1 Why not widen the deferral predicate
+
+`dispatch_map_method` already defers when
+`body_contains_return(..) || is_stub_routine_body(..)`. Adding a third
+syntactic probe for `die`/`fail` fixes the literal snippets in the ticket and
+nothing else: `(1..3).map({ f() })` where `f` dies, `(1..3).map({ 1/0 })`,
+`(1..3).map({ @a[10].method })` all still diverge. A predicate that has to
+enumerate "ways a callback can throw" is unfinishable by construction — the same
+shape ADR-0034 §1.4 rejected for consumption method lists. It is also exactly
+the band-aid CLAUDE.md's gain/risk definition calls a *risk* (an ad-hoc
+mechanism whose failure mode is silent divergence).
+
+### 3.2 Why not route every map through the existing `LazyList` deferral
+
+`create_lazy_map_list` (`src/runtime/methods_dispatch_match2.rs`) already does
+the right thing semantically — it stores the source items plus the callback and
+runs `eval_map_over_items` at force time, and `resolution_lazy.rs` documents
+that this keeps "full fidelity with eager map: block arity > 1, Slip flattening,
+LAST/NEXT phasers, and composed callbacks". Flipping both call sites
+(`dispatch_map_method` and `builtin_map`) to always take it is a two-line change.
+
+It is still the wrong mechanism:
+
+- **It clones the whole `Env` per `map` call.** `create_lazy_map_list` does
+  `let mut env = self.env.clone()` and stuffs the items and the callback into
+  it, because `force_lazy_list` installs `list.env` as the interpreter env. On
+  the hottest list operation in the language that is a per-call allocation of
+  the entire lexical scope, paid whether or not the Seq is ever forced.
+- **It picks the wrong Raku type by accident.** The value is a `LazyList`, and
+  `value_type_name` only answers `Seq` for it because `create_lazy_map_list`
+  sets the `__mutsu_lazylist_from_gather` marker — a `gather` flag standing in
+  for "this is a Seq". mutsu would then have `map` produce a *fourth*
+  representation of a lazy sequence at exactly the moment ADR-0034 finished
+  collapsing three into two.
+- **It moves work away from the machinery that was just built for it.** ADR-0034
+  taught every dispatch chokepoint, `for`, `SinkPop`, `ExecCall`'s sink and
+  `@`/`%` assignment to reify/consume a `ValueView::Seq` whose body
+  `needs_touch()`. A `LazyList` needs a parallel set of forcing rules, which is
+  what the 37 `force_lazy_list_vm` call sites already are.
+
+Its one virtue is that it is *cheap to try*, which makes it the right vehicle
+for **measuring** the read-path exposure (§5) before committing to option 3 —
+see §4 step 0.
+
+### 3.3 Why not make the existing `lazy_pipe` cover finite sources
+
+`is_lazy_pipe_source` returning `true` for any source would reuse
+`force_lazy_pipe`'s genuine one-at-a-time pull, which is strictly closer to
+rakudo than a whole-list reify. But `make_lazy_pipe` bails out for any callback
+with arity > 1 or a slurpy parameter (single-element pull cannot reproduce
+chunked binding), so `map -> $x, $y { }, 1..6` — half the ticket's cells — would
+stay eager, and the two regimes would have to coexist anyway. It also inherits
+`LazyList`'s type-name problem from §3.2. Worth revisiting *after* option 3 as a
+pull-granularity refinement, not as the fix.
+
+### 3.4 The recommendation
+
+Give `SeqSource` a variant for "these elements come from running a callback over
+a list", exactly parallel to `SeqSource::IoLines`:
+
+```rust
+pub(crate) enum SeqSource {
+    Reified,
+    Iterator(Value),
+    IoLines { handle: Value, words: bool, kv: bool },
+    /// `.map`/`.grep` over an already-materialized source: run `func` over
+    /// `items` on first touch. rakudo's `Seq` from `map`/`grep`.
+    MapGrep { items: Arc<Vec<Value>>, func: Value, is_grep: bool },
+    Taken,
+}
+```
+
+`Interpreter::pull_seq_source` (`src/vm/vm_helpers_lazy.rs`) gains one arm that
+calls the existing `eval_map_over_items` / grep loop, and `dispatch_map_method`
+returns `Value::seq_deferred(SeqSource::MapGrep { .. })` instead of
+`Value::seq(items)`. Everything else — reify-in-place, idempotence, `.cache`,
+`X::Seq::Consumed`, `Trace`, the consumption matrix — is ADR-0034's, unchanged.
+No new `Value` variant, no new type-name special case, no `Env` clone: the
+callback `Value` already carries its own closure environment.
+
+---
+
+## 4. Migration plan
+
+| # | Step | Notes |
+| --- | --- | --- |
+| **0** | **Measure the read-path exposure** by flipping `dispatch_map_method`/`builtin_map` to always call `create_lazy_map_list` behind a temporary env gate, and running `t/` and the roast whitelist with it on. This is option 3's exposure without option 3's cost, and it produces the list of consumers that read a deferred sequence without forcing it. | Discard the gate afterwards; it is a measurement, not a slice. |
+| **1** | **Done (2026-08-22).** `t/map-callback-runs-at-consumption.t` — 23 rows, raku-verified 23/23, mutsu 12 passing and 11 `todo`. Un-`todo`ing the nine ADR-0058 rows is this ADR's completion signal; the other two `todo`s belong to §1.4's separate bug. | Same shape as ADR-0034 phase 1. |
+| **2** | Add `SeqSource::MapGrep` + the `pull_seq_source` arm + `Value::seq_deferred` construction in `dispatch_map_method` only (not `builtin_map`, not `grep`). Fix the consumers step 0 found. | `map` method form alone is enough to un-`todo` most of phase 1. |
+| **3** | Extend to `builtin_map` (the `map &f, @xs` function form) and to both `grep` entry points. `grep`'s `:k`/`:kv`/`:p` adverbs need positional indices over the whole result and can stay eager, exactly as they already opt out of `make_lazy_pipe`. | |
+| **4** | Retire the `body_contains_return` / `is_stub_routine_body` deferral predicate and `create_lazy_map_list` — both become dead once every map defers. | The maintainability payout. |
+
+### Verification
+
+```sh
+prove -e target/debug/mutsu t/map-callback-runs-at-consumption.t   # the oracle
+prove -e target/debug/mutsu t/try-sink-semantics.t t/seq-*.t t/lazy-*.t
+raku t/map-callback-runs-at-consumption.t                          # 23/23, the reference
+make roast      # mandatory: this makes mutsu STRICTER in every ticket cell
+```
+
+---
+
+## 5. Risks
+
+- **This makes mutsu stricter, deliberately, in every cell of the ticket.**
+  Constructs that pass today start aborting, matching raku. A full `make roast`
+  is mandatory, not `make test` alone, and the PR should expect a fix-forward
+  round. (CLAUDE.md: a temporary CI failure is the safety net working, not a
+  cost.)
+- **The read path is the real exposure.** There are 356 `ValueView::Seq(` match
+  sites, 292 `value_to_list(` calls and 16 `flat_val(` calls in `src/`. All of
+  them read a `SeqBody` through `Deref`, which by design returns the *empty
+  seed* for a body nobody has reified — ADR-0034 §2.1 chose that deliberately so
+  a read can never re-enter the VM. Today only `IO::Handle.lines` and
+  `Seq.new($iterator)` produce such bodies, so the exposure is rare; making
+  every `.map` deferred exposes all of them at once. ADR-0034's own outcome
+  (§7.1) already found two such consumers (`Value::eqv`'s `(Seq, Seq)` arm and
+  the `...` sequence generator) that its §1.5 site inventory had missed. Step 0
+  exists to turn this from a guess into a list.
+- **Side-effect *ordering* changes program output, not just exception timing.**
+  Any `t/` or roast assertion that depends on a `map` callback's `say`/push
+  happening before a later statement will flip. Most such assertions are testing
+  the wrong thing (mutsu's eagerness), but each one has to be re-checked against
+  `raku` rather than "fixed".
+- **Perf: neutral in principle, unmeasured in practice.** A deferred map trades
+  the callback loop for one `Arc<SeqBody>` allocation at the call and the same
+  loop at first touch; a map whose result is *never* consumed becomes free. But
+  every consumer now pays a `needs_touch()` state check plus, on first touch, a
+  `Mutex` acquisition. Do not sell this as an optimization without a bench row;
+  do watch for a regression on the map-heavy benches.
+- **`grep`'s adverbed forms and the rw path stay eager**
+  (`eval_map_over_items_rw` writes back into the source array, which is
+  meaningless to defer). Two regimes remain after step 4, but they are split on
+  a real semantic line (does the operation write back?) rather than on a
+  syntactic probe of the callback body.
+
+---
+
+## 6. Scope: what this ADR does not decide
+
+- **The `LazyList` pipe (`lazy_pipe`) over genuinely infinite sources stays as
+  it is.** Making it and `SeqSource::MapGrep` one mechanism (a pull-granular
+  deferred Seq) is the natural follow-up, and §3.3 records why it is not the
+  first step.
+- **`try`/sink placement is settled and out of scope** — see §1.2 and
+  `news/2026-08/try-statement-sink-semantics-pinned.md`.
+- **ADR-0038's `Seq`/`List` view question** is orthogonal; a `MapGrep` body
+  presents as `Seq` like every other `SeqSource`.
+
+---
+
+## 7. Consequences
+
+- **`map`/`grep` get rakudo's timing.** The whole try-cell family in the ticket
+  aligns, and so does the plain, exception-free side-effect ordering divergence
+  of §1.3 that nobody had written down before.
+- **A third representation of a lazy sequence is avoided.** ADR-0034 collapsed
+  three into two; routing map through `LazyList` (§3.2) would have made it three
+  again. Routing it through `SeqSource` keeps the count at two and gives the new
+  variant the reify/consume semantics for free.
+- **Two syntactic band-aids die** — `body_contains_return` and
+  `is_stub_routine_body` as *map-deferral* predicates, plus
+  `create_lazy_map_list` and the `__mutsu_lazy_map_items`/`_func` env keys.
+- **The read path becomes the load-bearing invariant.** After this, "a
+  `ValueView::Seq` may be a body nobody has pulled yet" stops being a rare
+  `IO::Handle.lines` corner and becomes the common case. That is a real,
+  permanent maintenance obligation on every new `ValueView::Seq(items)` reader,
+  and step 0 of §4 exists so it is entered with a list rather than a hope.
+- **If rejected**: the ticket's cells stay divergent, the deferral predicate
+  keeps growing one observable-eagerness bug at a time, and `map` keeps being
+  the one core operation whose laziness mutsu decides by grepping the callback's
+  AST.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -83,3 +83,4 @@ The role of an ADR is to preserve the *context of the judgment* — something th
 | [0055](0055-closure-free-vars-resolve-to-their-own-binding.md) | A closure's free variable resolves to its own captured binding — retiring `merge_all` and the two closure-state stores | Proposed (design complete; implementation not started) |
 | [0056](0056-nativecall-types-display-only-qualification.md) | NativeCall's `Pointer`/`CArray`/`long`/... display under `NativeCall::Types::*` — display-only, registry key stays bare | Accepted (implemented) |
 | [0057](0057-var-reflection-identity-cell-address.md) | `.VAR` reflection identity is the shared cell's address, not a per-frame cache — reusing ADR-0032's container-capture edge as the boxing trigger | Accepted (implemented) |
+| [0058](0058-map-grep-produce-a-deferred-seq.md) | `.map`/`.grep` produce a deferred `Seq` — the callback runs at first consumption, not at the call | Proposed (design complete; implementation not started) |

--- a/news/2026-08/map-eagerness-is-the-real-try-cell-root-cause.md
+++ b/news/2026-08/map-eagerness-is-the-real-try-cell-root-cause.md
@@ -1,0 +1,53 @@
+# The residual try-cell divergences are eager `.map`, not a mis-placed `LazyList` force
+
+`todo/deep/residual-try-cell-eager-seq-reification-divergences.md` carried a
+twelve-cell matrix where mutsu is more forgiving than raku: a `die` or `fail`
+inside a `map` callback under a statement-position `try` is caught by that
+`try` in mutsu and escapes it in rakudo. The ticket — and
+[ADR-0034](../../docs/adr/0034-seq-reification-is-in-place-and-distinct-from-consumption.md)
+§6 quoting it — attributed this to mutsu forcing a `map`-produced `LazyList` at
+the assignment/call boundary, and pointed at `force_lazy_list_vm`'s callers.
+
+Re-measuring all twelve cells against a current `main` build (none had been
+fixed by an intervening change) showed that diagnosis is wrong. `(1..3)` is a
+**finite** range, so `is_lazy_pipe_source` is false and no `LazyList` is ever
+built: `dispatch_map_method` materializes the source and runs the callback
+**immediately**, inside the `try`. There is no deferred value whose force could
+be moved. mutsu's `try`/sink placement is not at fault either — it was already
+verified rakudo-conformant in
+`news/2026-08/try-statement-sink-semantics-pinned.md`.
+
+The actual root cause is that `.map` and `.grep` are eager over a finite source
+in mutsu and lazy in rakudo, which is observable with no `try` and no exception
+at all:
+
+```raku
+my $s = (1..3).map({ say "side $_"; $_ }); say "before"; say $s.List;
+# raku:  before / side 1 / side 2 / side 3 / (1 2 3)
+# mutsu: side 1 / side 2 / side 3 / before / (1 2 3)
+```
+
+mutsu already *knows* some callbacks must be deferred — `dispatch_map_method`
+routes a callback whose body contains `return`, or is a `...` stub, through
+`create_lazy_map_list` — but "the body contains a `die`" is not a predicate
+worth writing, since the throw can be indirect. That enumeration is the band-aid
+the divergence grows out of.
+
+The design is recorded as
+[ADR-0058](../../docs/adr/0058-map-grep-produce-a-deferred-seq.md) (`Proposed`):
+give ADR-0034's `SeqSource` a `MapGrep` variant so a `.map` result is a `Seq`
+whose body is not yet reified, and let the reify/consume split that ADR already
+built do the deferring — rather than routing map through `LazyList` (a per-call
+`Env` clone and a fourth representation of a lazy sequence) or widening the
+syntactic predicate.
+
+Four of the twelve cells turned out to be a **different, narrower** bug, split
+out in ADR-0058 §1.4: the `...`-stub cells already defer, and already match raku
+exactly once the enclosing `try` is removed. What diverges there is how a `fail`
+raised *during the force* resolves when a `try` sits lexically between it and
+the routine — mutsu returns it from the routine as a `Failure`, rakudo throws.
+
+Everything is now pinned by `t/map-callback-runs-at-consumption.t`: 23 rows,
+verified 23/23 under real `raku`, of which mutsu passes 12 outright (real
+already-correct behaviour that the fix must not regress) and carries 11 as
+`todo`. Un-`todo`ing the nine ADR-0058 rows is that ADR's completion signal.

--- a/t/map-callback-runs-at-consumption.t
+++ b/t/map-callback-runs-at-consumption.t
@@ -1,0 +1,117 @@
+use Test;
+
+# rakudo's `.map`/`.grep` return a lazy `Seq`: the callback runs when something
+# consumes the sequence, not at the `.map` call. Every assertion in this file
+# was verified by running this exact file under real `raku`, which passes it
+# 23/23 (the `todo` rows pass there --- they are what mutsu is aiming at).
+#
+# The escaping rows are checked in a subprocess because they kill the program:
+# a statement-position `try { ... }` leaves its tail value un-sunk (rakudo's
+# `try` handler wrapper stops sink propagation), so the *enclosing* statement
+# sinks it OUTSIDE the try's protection, and a callback that throws while that
+# sink forces the Seq is uncaught. `t/try-sink-semantics.t` pins the
+# sink-placement half of this; the laziness half is docs/adr/0058.
+#
+# Part 2's rows are `todo` because mutsu evaluates a `.map` over a finite
+# source eagerly, at the `.map` call, so the callback has already thrown by the
+# time the `try` block's tail value exists. Un-`todo` them when ADR-0058 lands
+# --- they are that ADR's completion oracle.
+
+plan 23;
+
+sub run-snippet($code) {
+    my $p = run($*EXECUTABLE, '-e', $code, :out, :err);
+    my $out = $p.out.slurp(:close);
+    $p.err.slurp(:close);
+    ($p.exitcode, $out)
+}
+
+# ---------------------------------------------------------------------------
+# Part 1 --- a `...` stub callback, which mutsu already defers
+# (`create_lazy_map_list`, gated on `is_stub_routine_body`).
+# ---------------------------------------------------------------------------
+
+{
+    my ($rc, $out) = run-snippet(
+        'sub ee { try { map -> $x, $y { ... }, 1..6 }; say "reached-tail"; $! }; say ee().^name; say "alive"');
+    todo 'a force-time `fail` under an enclosing `try` returns a Failure instead of throwing';
+    isnt $rc, 0, 'Q5/R6: stub-map under a sub-scope try escapes the try';
+    unlike $out, /'reached-tail'/, 'Q5/R6: ... and the statement after the try never runs';
+}
+{
+    my ($rc, $out) = run-snippet(
+        'sub f { map -> $x, $y { ... }, 1..6 }; sub ee { try { f() }; say "reached-tail"; $! }; say ee().^name; say "alive"');
+    todo 'a force-time `fail` under an enclosing `try` returns a Failure instead of throwing';
+    isnt $rc, 0, 'Q6/R7: call-returned stub-map under a sub-scope try escapes too';
+    unlike $out, /'reached-tail'/, 'Q6/R7: ... and the statement after the try never runs';
+}
+{
+    my ($rc, $out) = run-snippet(
+        'sub f { map -> $x, $y { ... }, 1..6 }; sub ee { try { f() } }; say ee().^name; say "alive"');
+    is $rc, 0, 'a stub-map Seq returned as the try value is never forced';
+    like $out, /'alive'/, '... and the program runs on';
+}
+{
+    my ($rc, $out) = run-snippet(
+        'sub ee { my $r = try { map -> $x, $y { ... }, 1..6 }; say "r=", $r.^name; $! }; say ee().^name; say "alive"');
+    is $rc, 0, 'assigning a stub-map Seq to a scalar is not sink context';
+    like $out, /'r=Seq'/, '... and it is still a Seq';
+}
+{
+    my ($rc, $out) = run-snippet(
+        'my $r = (map -> $x, $y { ... }, 1..6); say "made-it"; say $r.List');
+    isnt $rc, 0, 'consuming a stub-map Seq runs the stub and throws';
+    like $out, /'made-it'/, '... only after the statements before the consumption';
+}
+{
+    # `for $r` would NOT force it: a `$`-contained Seq iterates as one item in
+    # rakudo, so the loop is written over the map expression itself.
+    my ($rc, $out) = run-snippet(
+        'say "made-it"; for (map -> $x, $y { ... }, 1..6) { }; say "unreached"');
+    isnt $rc, 0, 'a for loop over a stub-map Seq forces it';
+    unlike $out, /'unreached'/, '... and never reaches the statement after the loop';
+}
+
+# ---------------------------------------------------------------------------
+# Part 2 --- ADR-0058's target rows: an ordinary callback, which mutsu runs
+# eagerly at the `.map` call.
+# ---------------------------------------------------------------------------
+
+{
+    my ($rc, $out) = run-snippet('try { (1..3).map({die "boom"}) }; say "alive ", $!.defined');
+    todo 'ADR-0058: a finite-source .map runs its callback eagerly', 2;
+    isnt $rc, 0, 'P4: a dying map callback escapes a statement-position try';
+    unlike $out, /'alive'/, 'P4: ... and the next statement never runs';
+}
+{
+    my ($rc, $out) = run-snippet('sub f { (1..3).map({die "boom"}) }; try { f() }; say "alive"');
+    todo 'ADR-0058: a finite-source .map runs its callback eagerly', 2;
+    isnt $rc, 0, 'P5: same, through one level of call indirection';
+    unlike $out, /'alive'/, 'P5: ... and the next statement never runs';
+}
+{
+    my ($rc, $out) = run-snippet(
+        'sub f { (1..3).map({die "boom"}) }; sub ee { try { f() } }; say ee().^name; say "alive"');
+    is $rc, 0, 'P18: the program survives a dying map Seq used as the try value';
+    todo 'ADR-0058: a finite-source .map runs its callback eagerly';
+    like $out, /^^ 'Seq'/, 'P18: ... and the unforced Seq is still a Seq';
+}
+{
+    my ($rc, $out) = run-snippet(
+        'try { (1..3).map({die "boom"}) }; CATCH { default { say "unit-caught" } }; say "alive"');
+    is $rc, 0, 'Q9: the program survives an escape caught by the enclosing CATCH';
+    todo 'ADR-0058: a finite-source .map runs its callback eagerly';
+    like $out, /'unit-caught'/, 'Q9: ... and the enclosing block CATCH reports it';
+}
+{
+    my ($rc, $out) = run-snippet('sub f { (1..3).map({ fail "x" }) }; try { f() }; say "alive"');
+    todo 'ADR-0058: a finite-source .map runs its callback eagerly', 2;
+    isnt $rc, 0, 'Q14: a failing map callback escapes the try too';
+    unlike $out, /'alive'/, 'Q14: ... and the next statement never runs';
+}
+{
+    my ($rc, $out) = run-snippet(
+        'my $s = (1..3).map({ say "side $_"; $_ }); say "before"; say $s.List');
+    todo 'ADR-0058: a finite-source .map runs its callback eagerly';
+    like $out, /^ 'before'/, 'the map callback runs after the statement following the .map';
+}

--- a/todo/deep/residual-try-cell-eager-seq-reification-divergences.md
+++ b/todo/deep/residual-try-cell-eager-seq-reification-divergences.md
@@ -1,61 +1,55 @@
-# Residual try-cell divergences from eager sub-returned/assigned Seq reification
+# Residual try-cell divergences: `.map` runs its callback eagerly
 
-Split out of `todo/deep/deferred-seq-materialization-destroys-the-original.md`, which is now
-retired (its headline symptom — a second method call on a deferred `Seq` destroying the value —
-was fixed by [ADR-0034](../../docs/adr/0034-seq-reification-is-in-place-and-distinct-from-consumption.md),
-see `news/2026-08/seq-reification-distinct-from-consumption.md`). ADR-0034 §6 explicitly scopes
-this part out as a **different** defect: mutsu forces a `map`-produced `LazyList` at the
-assignment/call boundary, where raku keeps it lazy until something actually consumes it — that is
-about **where** forcing happens (in `LazyList`), not about **what** forcing does to a `Seq` (which
-ADR-0034 fixed). Landing ADR-0034 removed the coupling that made these cells hard to fix (every
-extra touch used to be a chance to hit the destroy-on-materialize bug), so this work is now
-tractable on its own terms, but it has not been attempted yet.
+**Re-diagnosed 2026-08-22.** All twelve cells below were re-measured against a
+current `main` build and all twelve still reproduce — none was fixed by an
+intervening change. The design for the main root cause now lives in
+[ADR-0058](../../docs/adr/0058-map-grep-produce-a-deferred-seq.md) (`Proposed`),
+and the whole cell matrix is pinned as a rakudo-verified oracle in
+`t/map-callback-runs-at-consumption.t` (23 rows; raku passes 23/23, mutsu 12,
+with the 11 divergent rows marked `todo`). This file stays open only to track
+that the work is not done.
 
-Originally found while investigating `todo/tickets/sinking-a-try-blocks-discarded-value-escapes-the-try.md`
-(now closed — its own motivating symptom was fixed by #6115, and its `try`-statement sink
-placement was verified rakudo-conformant; see `news/2026-08/try-statement-sink-semantics-pinned.md`).
-That investigation's probe matrix found a family of cells where mutsu is *more forgiving* than
-raku — it never aborts a file raku would pass, only passes constructs raku would abort. Each
-snippet is `raku` / `mutsu`:
+## The root cause is NOT what this ticket originally said
 
-- P4: `try { (1..3).map({die "boom"}) }; say "alive ", $!.defined` (unit scope)
-  — raku: **throws**; mutsu: `alive True` (caught inside the try, since the
-  force happens before the try's own boundary closes).
-- P5: `sub f { (1..3).map({die "boom"}) }; try { f() }; say ...` — same shape,
-  one level of call indirection; same divergence.
-- P12/P13: `sub f { (1..3).map({die "boom"}) }; sub ee { try { f() }; $! };
-  say ee().^name` (literal-`.map`-tail variant too) — raku: **throws**; mutsu:
-  `X::AdHoc` + alive (caught).
-- P18: `sub ee { try { f() } }; say ee().^name` (die-Seq, try final, value
-  used) — raku: `Seq` + alive, never forced; mutsu: `Nil` + alive, forced and
-  caught.
-- Q5/Q6: yada-stub `map -> $x,$y { ... }, 1..6` reached via `try { map ... }`
-  or `try { f() }` inside a sub — raku: **throws** (`in sub ee`); mutsu:
-  `Failure` + alive.
-- Q9: `try { (1..3).map({die "boom"}) }; CATCH { default { say
-  "unit-caught" } };` at unit scope — raku: **unit-caught** (the escape is
-  caught by the *enclosing* block's CATCH, since raku's try has already let it
-  through); mutsu: alive, no unit-caught (mutsu's inner try already caught it
-  before it could escape).
-- Q11: `try { EVAL $c }` in a sub, `$c` = die-Seq code — raku: **throws**;
-  mutsu: `X::AdHoc` + alive.
-- Q14: `sub f { (1..3).map({ fail "x" }) }; try { f() }; say ...` (unit) —
-  raku: **throws**; mutsu: `alive True`.
-- R6/R7: Q5/Q6 with a `reached-tail` marker after the `try` — raku: throws
-  before the marker prints (R6) or throws after invoking the block (R7);
-  mutsu: `reached-tail` prints, `r=Failure`/`r=X::StubCode`, alive — the
-  marker printing at all is the tell that mutsu's force happened too early.
+The original text (and [ADR-0034](../../docs/adr/0034-seq-reification-is-in-place-and-distinct-from-consumption.md)
+§6 quoting it) blamed "mutsu forces a `map`-produced `LazyList` at the
+assignment/call boundary" and pointed at `force_lazy_list_vm`'s callers. That
+does not fit the cells: `(1..3)` is **finite**, so `is_lazy_pipe_source`
+(`src/runtime/methods_collection.rs`) is false and **no `LazyList` is ever
+built**. `dispatch_map_method` (`src/runtime/methods_dispatch_match2.rs`)
+materializes the source and calls `eval_map_over_items` immediately, inside the
+`try`. There is no deferred value whose force could be moved — the callback has
+already run by the time the `try` block's tail value exists.
 
-These will align toward raku automatically once sub-returned/assigned Seqs stay lazy — **landing
-that laziness fix makes mutsu STRICTER in every one of these cells** (constructs that pass today
-will start aborting, matching raku), so a full roast-whitelist sweep is mandatory when it lands,
-not just `make test`. `t/try-sink-semantics.t` pins the cells that already match and must keep
-matching; re-run it after any laziness change here.
+mutsu's `try`/sink *placement* is also not at fault and must not be touched:
+`compile_try_region` leaves the tail value on the stack and lets the enclosing
+statement's `SinkPop` force it outside the trap, which is rakudo's own rule
+(`news/2026-08/try-statement-sink-semantics-pinned.md`).
 
-## Where to start
+**The real cause is that `.map`/`.grep` are eager over a finite source in mutsu
+and lazy in rakudo.** This is observable with no `try` and no exception at all:
 
-The root cause is `LazyList` forcing at the sub-return/assignment boundary rather than at first
-consumption — a different mechanism from `Seq`'s `SeqBody` (ADR-0034 §6 confirms `LazyList` is
-explicitly out of scope there). Look at `force_lazy_list_vm`/`force_lazy_list_vm_n`'s callers in
-`src/vm/vm_helpers_lazy.rs` and wherever a sub return value or `=`-assignment RHS gets eagerly
-forced before it reaches its actual first consumer.
+```raku
+my $s = (1..3).map({ say "side $_"; $_ }); say "before"; say $s.List;
+# raku:  before / side 1 / side 2 / side 3 / (1 2 3)
+# mutsu: side 1 / side 2 / side 3 / before / (1 2 3)
+```
+
+`.grep` behaves the same way and does not even have the `return`/stub deferral
+`.map` has.
+
+## What is left to do
+
+- **Nine of the eleven divergent rows** (P4, P5, P12, P13, P18, Q9, Q11, Q14 and
+  the side-effect-ordering row) are ADR-0058's target. Implementing that ADR
+  un-`todo`s them; it also makes mutsu **stricter**, so a full `make roast` is
+  mandatory, not `make test` alone.
+- **The other two rows** (Q5/Q6/R6/R7's exit status) are a **separate, narrower
+  bug**, recorded in ADR-0058 §1.4: the stub-map path already defers correctly
+  and already matches raku once the enclosing `try` is removed. What diverges is
+  how a `fail` raised *during the force* resolves when a `try` sits lexically
+  between it and the routine — mutsu returns it from the routine as a `Failure`,
+  rakudo throws it. Nobody has looked into that yet.
+
+`t/try-sink-semantics.t` pins the sink-placement half and must keep passing
+through both fixes.


### PR DESCRIPTION
Works `todo/deep/residual-try-cell-eager-seq-reification-divergences.md`.

## What was measured

All twelve divergence cells the ticket lists were re-run against a current
`main` build. **All twelve still reproduce** — nothing had gone stale. The raku
side of every cell was established with the installed `raku` first.

## The ticket's root cause was wrong

The ticket (and the sentence ADR-0034 §6 inherited from it) blamed "mutsu forces
a `map`-produced `LazyList` at the assignment/call boundary" and pointed at
`force_lazy_list_vm`'s callers. That does not fit the cells: `(1..3)` is a
**finite** range, so `is_lazy_pipe_source` is false and **no `LazyList` is ever
built**. `dispatch_map_method` materializes the source and calls
`eval_map_over_items` immediately, inside the `try` — there is no deferred value
whose force could be moved.

mutsu's `try`/sink placement is not at fault either; it was already verified
rakudo-conformant (`news/2026-08/try-statement-sink-semantics-pinned.md`) and
this PR does not touch it.

**The real root cause is that `.map`/`.grep` are eager over a finite source in
mutsu and lazy in rakudo**, which is observable with no `try` and no exception:

```raku
my $s = (1..3).map({ say "side $_"; $_ }); say "before"; say $s.List;
# raku:  before / side 1 / side 2 / side 3 / (1 2 3)
# mutsu: side 1 / side 2 / side 3 / before / (1 2 3)
```

## What this PR contains

- **`docs/adr/0058-map-grep-produce-a-deferred-seq.md` (`Proposed`)** — the
  design: give ADR-0034's `SeqSource` a `MapGrep` variant so a `.map` result is
  a `Seq` whose body is not yet reified, and let that ADR's reify/consume split
  do the deferring. Rejects routing map through `LazyList` (a per-call `Env`
  clone plus a fourth representation of a lazy sequence) and rejects widening
  the `body_contains_return`/`is_stub_routine_body` syntactic predicate (it
  cannot enumerate the ways a callback can throw). Includes the read-path
  exposure risk (356 `ValueView::Seq(` sites, 292 `value_to_list(` calls) and a
  measurement step to turn that from a guess into a list.
- **`t/map-callback-runs-at-consumption.t`** — 23 rows, **verified 23/23 under
  real `raku`**. mutsu passes 12 outright (already-correct behaviour the fix
  must not regress) and carries 11 as `todo`. Un-`todo`ing the nine ADR-0058
  rows is that ADR's completion signal.
- A **split-out finding**: four of the twelve cells (the `...`-stub ones) are a
  *different*, narrower bug. They already defer and already match raku once the
  enclosing `try` is removed; what diverges is how a `fail` raised during the
  force resolves when a `try` sits lexically between it and the routine. ADR-0058
  §1.4 and the ticket record it; the two corresponding `todo` rows carry their
  own reason string.
- Ticket rewritten with the corrected diagnosis; ADR-0034 §6 gets a forward
  pointer that also corrects its inherited mechanism claim.

**No interpreter behaviour changes.** The `t/` addition means CI runs the full
suite rather than the docs-only skip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
