### PR TITLE
docs: link doc-diff-backlog findings to filed tickets, file 9 new ones

### DIFF
--- a/docs/doc-diff-backlog.md
+++ b/docs/doc-diff-backlog.md
@@ -21,6 +21,14 @@ minimal-repro reports), `progress.txt` (one stats line per file), `summary.txt`
 `summary.txt`, and the counts drop as fixes land — that is the visible progress
 signal.
 
+**When a finding is confirmed real (not raku-drift, not a harness false positive —
+see "Known harness false positive" below), file it as a ticket immediately** under
+`todo/tickets/<slug>.md` (or `todo/deep/` for high-blast-radius ones) per the root
+`CLAUDE.md` conventions, and add a row to [Ticketed](#ticketed-open--linked-to-todo)
+below linking the doc location to the ticket file. This is what keeps this backlog
+and the `todo/` queue in sync — a finding sitting only in a sweep report or only in a
+ticket file with no cross-link is easy to lose track of.
+
 The **raw output of the latest committed sweep** is checked in under
 [doc-diff-sweep/](doc-diff-sweep/) — read a per-file report there to get the minimal
 repros without re-running the sweep. Re-copy it (see that dir's `README.md`) whenever
@@ -52,6 +60,14 @@ doc) are version skew, not mutsu bugs — lowest priority.
 > (e.g. `syntax.rakudoc` reported 19 mismatches, only 3 real). Any pre-#4982 scan
 > numbers — and memory/notes calling a file "block-misalignment garbage" — are
 > unreliable; re-sweep instead.
+
+> **2026-08-22 partial re-check:** the 8 core `Type/` files (`Str`/`Array`/`List`/
+> `Hash`/`Num`/`Rat`/`Range`/`Map`) were re-run individually (not a full corpus sweep —
+> the survey table below is still the 2026-07-22 full-sweep snapshot and is stale for
+> these 8 rows specifically). High-signal divergences on this subset dropped from 50
+> (2026-07-18) to 12; see [Ticketed](#ticketed-open--linked-to-todo) for the 9 confirmed
+> findings now tracked as tickets. A full re-sweep to refresh the whole survey table is
+> still pending.
 
 ## Triaged
 
@@ -169,6 +185,38 @@ doc) are version skew, not mutsu bugs — lowest priority.
   `(a=>0.1).Mix (+) (a=>0.02).Mix` remains `0.12000000000000001` — that needs the
   full exact-weight storage rework (the "FatRat-vs-Rat repr tag" class below), not
   a construction fix.
+
+### Ticketed (open — linked to todo/)
+Confirmed-real findings that have a filed ticket but are not yet fixed. Each row is the
+doc location the harness flagged plus the ticket that tracks it; when the ticket is
+resolved, move its content to `news/` (per `todo/README.md`) and delete the row here.
+
+Found in the 2026-08-22 re-run of the 8 core `Type/` files (`Str`/`Array`/`List`/`Hash`/
+`Num`/`Rat`/`Range`/`Map` — same set as the 2026-07-18 first run, which found 50
+high-signal divergences on this set; this re-run found 12, most of the difference being
+fixes that landed in between):
+
+| file:line | one-line summary | ticket |
+|---|---|---|
+| `Type/Hash.rakudoc:65` | `WHAT {...}` (bare hash-literal block, no parens/var) misparses as two statements | [what-prefix-bare-hash-literal-block-arg.md](../todo/tickets/what-prefix-bare-hash-literal-block-arg.md) |
+| `Type/Hash.rakudoc:336` | `my %h .= push(pair)` should leave `%h` empty, mutsu keeps the pair | [hash-dot-assign-push-result.md](../todo/tickets/hash-dot-assign-push-result.md) |
+| `Type/List.rakudoc:219` | `(gather {...}).list.raku` keeps a spurious `.Seq` suffix when chained directly (no intermediate var) | [gather-chained-list-raku-seq-suffix.md](../todo/tickets/gather-chained-list-raku-seq-suffix.md) |
+| `Type/List.rakudoc:1207` | global `rotor()` routine (`v6.e.PREVIEW`) not implemented; the `.rotor` method already works | [rotor-global-routine-missing.md](../todo/tickets/rotor-global-routine-missing.md) |
+| `Type/Map.rakudoc:62` | `Map.new(a, 1, :b(2))` — bare colon-pair should bind as a named arg to `.new`, not a positional Pair | [map-new-bare-colonpair-named-arg.md](../todo/tickets/map-new-bare-colonpair-named-arg.md) |
+| `Type/Range.rakudoc:80` | `@arr[$range-var]` doesn't flatten into `for` iteration (literal `@arr[0..2]` does) | [array-subscript-range-var-list-context-slip.md](../todo/tickets/array-subscript-range-var-list-context-slip.md) |
+| `Type/Range.rakudoc:266` | `Range.int-bounds` method not implemented | [range-int-bounds-method-missing.md](../todo/tickets/range-int-bounds-method-missing.md) |
+| `Type/Range.rakudoc:284` | `Range.minmax` on excluded-end Range should throw `X::AdHoc`, mutsu returns bounds silently | [range-minmax-excluded-ends-should-throw.md](../todo/tickets/range-minmax-excluded-ends-should-throw.md) |
+| `Type/Str.rakudoc:647` | `.comb(:match)` (named-arg-only call) fails to dispatch at all; plain `.comb` and other arities work | [str-comb-named-arg-only-dispatch-missing.md](../todo/tickets/str-comb-named-arg-only-dispatch-missing.md) |
+
+**Known harness false positive (not ticketed):** `Hash.rakudoc:21`, `Map.rakudoc:18`,
+`Map.rakudoc:122` all flagged as `output-mismatch` on `.keys`/`.kv` iteration order.
+Verified 2026-08-22 that raku's own hash/Map key order is randomized per-process (8
+repeated single-line `raku -e` runs of the same `Map.rakudoc:122` example gave `(a b)`
+6/8 times and `(b a)` 2/8) — the harness's single-run oracle comparison can't
+distinguish this from a real ordering bug. The existing nondet heuristic (skips
+`rand`/`.pick`/`.roll`/`now`/`Supply`) doesn't cover bare `.keys`/`.kv`/hash-iteration
+output; improving that heuristic is a possible future harness enhancement, not tracked
+as a ticket here.
 
 ### Deferred / deep (tracked elsewhere — do not re-open as a shallow slice)
 These root causes account for a large share of the survey's `mism`/`crash` and are

--- a/todo/tickets/array-subscript-range-var-list-context-slip.md
+++ b/todo/tickets/array-subscript-range-var-list-context-slip.md
@@ -1,0 +1,44 @@
+# `@arr[$range-or-array-var]` doesn't flatten into `for` iteration when the subscript is a variable
+
+Found by the doc-diff harness re-run (`docs/doc-diff-backlog.md`, `Type/Range.rakudoc:80`).
+
+## Root cause
+
+`@arr[0..2]` (a **literal** Range subscript) correctly slips its elements one-per-iteration
+into a `for` loop. But when the same Range (or an Array holding the same indices) is first
+bound/assigned to a variable and *that variable* is used as the subscript, the result is
+treated as a single list item instead of flattening:
+
+```raku
+my @numbers = <4 8 15 16 23 42>;
+.say for @numbers[0..2];        # raku AND mutsu: 4 / 8 / 15 (3 lines)      -- matches
+
+my $range := 0..2;
+.say for @numbers[$range];      # raku: 4 / 8 / 15 (3 lines)
+                                 # mutsu: "(4 8 15)" (1 line)               -- BROKEN
+
+my @range = 0..2;
+.say for @numbers[@range];      # raku: 4 / 8 / 15 (3 lines)
+                                 # mutsu: "(4 8 15)" (1 line)               -- BROKEN
+```
+
+## Minimal repro
+
+```raku
+my @numbers = <4 8 15 16 23 42>;
+my $range := 0..2;
+.say for @numbers[$range];
+```
+
+- `raku`: `4`, `8`, `15` (three separate lines)
+- `mutsu` (`target/debug/mutsu`): `(4 8 15)` (one line — the slice stayed a single list item)
+
+## Affected files (starting point)
+
+Array/List postcircumfix `[...]` subscript compilation — likely
+`vm/vm_var_ops.rs` or the index/subscript compiler helpers. The literal-Range-subscript
+path apparently marks the multi-element result for flattening (e.g. wraps it in a Slip),
+but the variable-subscript path does not carry that same "subscript was a
+multi-value/Range/Array selector" flag through to the `for` loop's iteration source. Needs
+the two paths to converge on the same flattening behavior regardless of whether the
+subscript expression is a literal or a variable.

--- a/todo/tickets/gather-chained-list-raku-seq-suffix.md
+++ b/todo/tickets/gather-chained-list-raku-seq-suffix.md
@@ -1,0 +1,39 @@
+# `(gather {...}).list.raku` keeps a spurious `.Seq` suffix when chained directly
+
+Found by the doc-diff harness re-run (`docs/doc-diff-backlog.md`, `Type/List.rakudoc:219`,
+minimized further during triage).
+
+## Root cause
+
+`.list` on a `Seq` produced by a `gather` block does not fully coerce to a `List` when
+called **directly on the gather expression** (no intermediate variable). When the gather
+result is first bound/assigned to a variable and `.list` is called on that variable, the
+coercion works correctly. `.raku` on the result reveals the difference — the
+direct-chain form still reports itself as a `Seq`:
+
+```raku
+put (gather { }).list.raku;                 # raku: ()        mutsu: ().Seq
+my $s := gather { }; put $s.list.raku;       # raku: ()        mutsu: ()      (matches)
+my $s = gather { }; put $s.list.raku;        # raku: ()        mutsu: ()      (matches)
+
+put (gather { take 1; take 2 }).list.raku;   # raku: (1, 2)    mutsu: (1, 2).Seq
+```
+
+## Minimal repro
+
+```raku
+put (gather { take 1; take 2 }).list.raku;
+```
+
+- `raku`: `(1, 2)`
+- `mutsu` (`target/debug/mutsu`): `(1, 2).Seq`
+
+## Affected files (starting point)
+
+The `.list` method dispatch on a `Seq`/gather-produced value — likely a compiler-level
+difference in how a method call chained directly onto a `gather {...}` expression result
+is compiled vs. a method call on a variable holding the same value (the receiver's
+runtime representation/type tag isn't being updated to `List` in the direct-chain case).
+Look at how `.list` coercion is implemented for Seq (`builtins/methods_0arg` or the
+Seq→List coercion helper) and how the gather-expression compile path hands its result to
+a chained postfix method call vs. a `my $x = ...` assignment.

--- a/todo/tickets/hash-dot-assign-push-result.md
+++ b/todo/tickets/hash-dot-assign-push-result.md
@@ -1,0 +1,38 @@
+# `my %h .= push(pair)` on a freshly-declared Hash should leave `%h` empty
+
+Found by the doc-diff harness re-run (`docs/doc-diff-backlog.md`, `Type/Hash.rakudoc:336`).
+
+## Root cause (not fully diagnosed)
+
+```raku
+my %h .= push(e => 6);
+say %h.raku; # OUTPUT: «{}␤»
+```
+
+`Hash` has no `.push` method of its own; the call resolves through some fallback (likely
+`Any`/`Cool`/`List`-ish coercion), and whatever `.push` returns gets `.=`-reassigned back
+into `%h`. Per raku, the net result is that `%h` ends up as an *empty* Hash (`{}`), not a
+Hash containing the pushed pair.
+
+mutsu instead resolves `.push` on `%h` as if it mutates the hash in place and keeps the
+pair, giving `{:e(6)}`.
+
+## Minimal repro
+
+```raku
+my %h .= push(e => 6);
+say %h.raku;
+```
+
+- `raku`: `{}`
+- `mutsu` (`target/debug/mutsu`): `{:e(6)}`
+
+## Affected files (starting point)
+
+Whatever handles `.push` dispatch on a `Hash` invocant when there is no native
+`Hash.push` — likely falls through to a generic/slow-path push handler in
+`runtime/methods.rs` or `builtins/methods_narg.rs`. Needs investigation into what raku's
+`.push` resolution on `Hash` actually returns (probably it resolves against `Any.push`,
+which does something unrelated to hash mutation, and the `.=` reassignment then replaces
+`%h` with that unrelated return value coerced back through the Hash container type,
+landing on an empty hash). Not root-caused further within this session's time budget.

--- a/todo/tickets/map-new-bare-colonpair-named-arg.md
+++ b/todo/tickets/map-new-bare-colonpair-named-arg.md
@@ -1,0 +1,44 @@
+# `Map.new(a, 1, :b(2))` — bare colon-pair should bind as a named arg to `.new`, not a positional Pair
+
+Found by the doc-diff harness re-run (`docs/doc-diff-backlog.md`, `Type/Map.rakudoc:62`).
+This is the exact "WRONG" footgun example the doc itself uses to teach the distinction.
+
+## Root cause
+
+A bare `:b(2)` colon-pair passed directly in a call's argument list (no extra
+parenthesization) is a **named argument**, not a positional `Pair` — this is general
+Raku call-argument parsing and already works correctly for a plain user sub:
+
+```raku
+sub f(*@pos, *%named) { say @pos; say %named };
+f("a", 1, :b(2));     # raku AND mutsu: @pos=[a 1]  %named={b => 2}   -- matches
+```
+
+But `Map.new(...)`'s constructor dispatch treats the same `:b(2)` as a positional `Pair`
+argument instead of consuming it as a named arg:
+
+```raku
+say Map.new("a", 1, :b(2)).keys;  # raku: (a)     mutsu: (a b)
+```
+
+Since the general named-arg mechanism works for ordinary subs, this looks specific to how
+`Map.new`'s native/builtin constructor collects its arguments (probably it slurps
+everything — positional and named alike — into the pair list instead of only the
+positional args).
+
+## Minimal repro
+
+```raku
+say Map.new("a", 1, :b(2)).keys;
+```
+
+- `raku`: `(a)`
+- `mutsu` (`target/debug/mutsu`): `(a b)`
+
+## Affected files (starting point)
+
+`Map.new` construction — likely `dispatch_new_from_pairs` or wherever `Map`/`Hash`
+`.new(...)` collects its constructor arguments (search for `Map.new` handling in
+`runtime/` or `builtins/`). Needs to only consume positional args into the pair list and
+let named args pass through/be dropped the way a real slurpy `(*@pos, *%_)` signature
+would.

--- a/todo/tickets/range-int-bounds-method-missing.md
+++ b/todo/tickets/range-int-bounds-method-missing.md
@@ -1,0 +1,33 @@
+# `Range.int-bounds` method is not implemented
+
+Found by the doc-diff harness re-run (`docs/doc-diff-backlog.md`, `Type/Range.rakudoc:266`).
+
+## Root cause
+
+`Range` has an `int-bounds(\min, \max)` method: it binds integer bounds into the two
+`rw` arguments and returns a `Bool` indicating whether the Range has determinable integer
+bounds (used as an `if` condition). mutsu does not implement this method at all.
+
+```raku
+if (3..5).int-bounds( my $min, my $max) {
+    say "$min, $max"; # OUTPUT: «3, 5␤»
+}
+```
+
+- `raku`: `3, 5`
+- `mutsu` (`target/debug/mutsu`): `No such method 'int-bounds' for invocant of type 'Range'`
+
+## Minimal repro
+
+```raku
+if (3..5).int-bounds( my $min, my $max) {
+    say "$min, $max";
+}
+```
+
+## Affected files (starting point)
+
+Range methods — likely `builtins/methods_narg.rs` (needs an rw-arg-writing method, similar
+in shape to other Range methods that already exist). Needs to compute the Range's integer
+min/max (respecting `excludes-min`/`excludes-max`), write them into the two caller-supplied
+containers, and return a `Bool` for whether bounds could be determined.

--- a/todo/tickets/range-minmax-excluded-ends-should-throw.md
+++ b/todo/tickets/range-minmax-excluded-ends-should-throw.md
@@ -1,0 +1,32 @@
+# `Range.minmax` on a Range with excluded ends should throw `X::AdHoc`, not silently return bounds
+
+Found by the doc-diff harness re-run (`docs/doc-diff-backlog.md`, `Type/Range.rakudoc:284`).
+
+## Root cause
+
+Per raku, calling `.minmax` on a `Range` whose upper (or lower) bound is excluded
+(`..^`, `^..`, `^..^`) is an error — `minmax` can't represent an excluded bound as a
+concrete value, so it throws `X::AdHoc: Cannot return minmax on Range with excluded ends`.
+mutsu instead just returns the plain `(min max)` pair, ignoring exclusivity.
+
+```raku
+my $r4 = (1.1..^5.2);
+say $r4.minmax;
+CATCH { default { put .^name, ': ', .Str } };
+```
+
+- `raku`: `X::AdHoc: Cannot return minmax on Range with excluded ends`
+- `mutsu` (`target/debug/mutsu`): `(1.1 5.2)` (no error)
+
+## Minimal repro
+
+```raku
+say (1.1..^5.2).minmax;
+```
+
+## Affected files (starting point)
+
+`Range.minmax` implementation — likely in `builtins/methods_0arg/` (Range methods).
+Needs to check the Range's `excludes-min`/`excludes-max` flags and throw
+`X::AdHoc` (via the standard exception-raising helper) when either is set, matching the
+existing message text.

--- a/todo/tickets/rotor-global-routine-missing.md
+++ b/todo/tickets/rotor-global-routine-missing.md
@@ -1,0 +1,36 @@
+# Global `rotor()` routine (v6.e.PREVIEW) is not implemented
+
+Found by the doc-diff harness re-run (`docs/doc-diff-backlog.md`, `Type/List.rakudoc:1207`).
+
+## Root cause
+
+`List.rotor(...)` (the **method**) already works correctly in mutsu. The doc example uses
+`rotor(...)` as a **global routine** (gated behind `use v6.e.PREVIEW;`), which raku
+provides but mutsu does not — even with the pragma present, mutsu has no top-level
+`rotor` sub registered:
+
+```raku
+use v6.e.PREVIEW;
+say rotor(3, 'a'..'h').join('|');  # raku: a b c|d e f
+                                    # mutsu: Unknown function: rotor
+```
+
+Without the pragma, raku itself also fails ("Undeclared routine: rotor"), confirming this
+is specifically a `v6.e.PREVIEW`-gated global, not a base-language gap. Lower priority
+than the other doc-diff findings from this sweep since it depends on preview-language-
+version support mutsu may not otherwise track.
+
+## Minimal repro
+
+```raku
+use v6.e.PREVIEW;
+say rotor(3, 'a'..'h').join('|');
+```
+
+## Affected files (starting point)
+
+Wherever global routines are registered (`runtime/builtins_*.rs`) and wherever
+`v6.e.PREVIEW`/language-version pragmas gate feature availability — needs a global
+`rotor(...)` sub that simply delegates to the existing `List.rotor` method
+implementation, registered only when the preview pragma is active (or unconditionally, if
+mutsu doesn't otherwise gate preview features).

--- a/todo/tickets/str-comb-named-arg-only-dispatch-missing.md
+++ b/todo/tickets/str-comb-named-arg-only-dispatch-missing.md
@@ -1,0 +1,37 @@
+# `Str.comb(:match)` (named-arg-only call, no positional matcher) fails to dispatch at all
+
+Found by the doc-diff harness re-run (`docs/doc-diff-backlog.md`, `Type/Str.rakudoc:647`).
+
+## Root cause
+
+Plain `.comb` (no args) works. But `.comb(:match)` — called with only a named argument and
+no positional matcher/limit — fails to dispatch entirely, as if no `comb` method exists on
+`Str` at all:
+
+```raku
+say "abc".comb.raku;          # raku AND mutsu: ("a", "b", "c").Seq   -- matches
+say "abc".comb(:match).raku;  # raku: (｢a｣ ｢b｣ ｢c｣)
+                               # mutsu: No such method 'comb' for invocant of type 'Str'
+```
+
+This looks like the native-method arity dispatch (`native_method_*arg`, see
+`builtins/methods_0arg/` vs `methods_narg.rs`) has no registered arm for "0 positional
+args + 1 named arg", so it falls through past `comb`'s normal implementations to nothing
+at all (not even a slow-path fallback) rather than being caught by the argument-count
+matching that presumably handles the other forms (`.comb(3)`, `.comb(3, 2)`,
+`comb(/\w/, ...)` etc., which the same doc block confirms already work correctly).
+
+## Minimal repro
+
+```raku
+say "abc".comb(:match).raku;
+```
+
+- `raku`: `(｢a｣ ｢b｣ ｢c｣)`
+- `mutsu` (`target/debug/mutsu`): `No such method 'comb' for invocant of type 'Str'`
+
+## Affected files (starting point)
+
+`Str.comb` method dispatch — wherever `comb` arity variants are registered (likely
+`builtins/methods_narg.rs` / `methods_0arg/`). Needs a 0-positional+named-`:match` arm
+that returns `Match` objects instead of plain `Str`s for each matched grapheme/substring.

--- a/todo/tickets/what-prefix-bare-hash-literal-block-arg.md
+++ b/todo/tickets/what-prefix-bare-hash-literal-block-arg.md
@@ -1,0 +1,38 @@
+# `WHAT {...}` (bare hash-literal block, no parens/var) misparses as two statements
+
+Found by the doc-diff harness re-run (`docs/doc-diff-backlog.md`, `Type/Hash.rakudoc:65`).
+
+## Root cause
+
+`WHAT`/`HOW`/`WHO` etc. are prefix pseudo-routines that take a term. When that term is a
+bare `{...}` immediately following the prefix — with no enclosing parens and no
+intermediate variable — mutsu does not recognize `{...}` as the argument term. Instead it
+parses `WHAT` as a bare identifier (which stringifies to the literal string `"WHAT"`) and
+`{...}` as a separate block statement run in sink context (hence the accompanying
+"Useless use of ... in sink context" warning).
+
+Every other shape works correctly:
+
+```
+say WHAT(3);              # (Int)  -- parens: OK
+say WHAT 3;                # (Int)  -- bare non-block term: OK
+my $h = {3=>4}; say WHAT $h;  # (Hash) -- via variable: OK
+say WHAT {3 => 4};          # should be (Hash), mutsu prints "WHAT"  -- BROKEN
+```
+
+## Minimal repro
+
+```raku
+say WHAT {3 => 4};
+```
+
+- `raku`: `(Hash)`
+- `mutsu` (`target/debug/mutsu`): prints `WHAT` to stdout, plus a stderr warning
+  `Useless use of "=>" in expression "3 => 4" in sink context`.
+
+## Affected files (starting point)
+
+Likely the parser's `WHAT`/`HOW`/`WHO`/`WHY` prefix-routine handling (identifier_call /
+primary parsing) — needs to special-case a following `{` as starting a hash-literal/block
+term argument, the same disambiguation `say {...}` already needs for direct hash-literal
+args to other listops.


### PR DESCRIPTION
## Summary
- Re-ran the doc-diff harness on the same 8 core `Type/` files as the 2026-07-18 first run (Str/Array/List/Hash/Num/Rat/Range/Map): high-signal divergences dropped from 50 (18.5%) to 12 (4.4%).
- Of the 12, 3 turned out to be a harness false positive (raku's own hash/Map `.keys`/`.kv` order is randomized per-process — verified via 8 repeated `raku -e` runs of the same example giving different orders). The other 9 are real bugs, each filed as a `todo/tickets/` entry.
- Added a new "Ticketed" section to `docs/doc-diff-backlog.md` linking each doc location to its ticket file, and updated the refresh workflow to file+link on every future confirmed finding. The backlog previously had no way to tell which findings already had a tracking ticket.

## Test plan
- [x] Docs-only change (`docs/`, `todo/tickets/`) — CI's `changes` classifier should skip the heavy jobs.
- [x] Verified all 9 findings against `raku` before filing (minimal repros included in each ticket).
- [x] Verified the 3 excluded findings are non-deterministic in raku itself (not mutsu bugs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)