### PR TITLE
fix(regex): token-body interpolation provenance + litlen for proto entry (ADR-0046 Slices 2-3)

### DIFF
--- a/docs/adr/0046-proto-token-ltm-shares-one-ranking-mechanism.md
+++ b/docs/adr/0046-proto-token-ltm-shares-one-ranking-mechanism.md
@@ -12,9 +12,20 @@
   interpolation, and a pre-existing, unrelated named-subrule-call LTM
   over-crediting gap) was fixed/documented in the same slice — see
   `todo/deep/named-subrule-unbounded-quantifier-wrongly-gets-greedy-ltm-credit.md`
-  for the latter, left for Slices 3/4. **Slices 2-5 (bound/token-body scalar
-  provenance, mechanism unification, ledger) are next**, in the order §4
-  specifies.
+  for the latter, left for Slices 3/4.
+  **Slices 2 and 3 landed 2026-08-22**: `interpolate_bound_regex_scalars` now
+  marks its substitutions (`scalar` row of §2.2 green on mechanism 1), and
+  mechanism 1 (`eval_token_call_values_at`) ranks via the shared
+  `ltm_branch_rank_key` primitive, gaining the litlen tie-break (`litlen` row
+  green). Slice 3 also had to make `RegexAtom::VarDecl` a new
+  `LtmAtomMode::SkipZeroWidth` — zero-width, non-terminating, and *not
+  executed* — because the parsed-pattern measurement path no longer goes
+  through `regex_match_with_captures`'s string-level declarator strip; that
+  closed a real ADR-0009 leak where measuring `token TOP { :my $x = …; <inner> }`
+  wrote `$x` into the live env and changed what `inner` interpolated (stale
+  `todo` in `t/regex-inline-code-block.t` removed). Pins:
+  `t/regex-ltm-proto-dispatch.t`, `t/regex-ltm-interpolation-provenance.t`
+  probes T/U. **Slices 4-5 (mechanism 3 rank-then-match, ledger) are next.**
 - **Context**: `todo/deep/proto-token-ltm-and-interpolation-provenance.md` (renamed from
   `ltm-inline-unbounded-quantifier-vs-array-tie.md`, whose recorded root cause this ADR
   corrects). Builds directly on [ADR-0009](0009-regex-code-assertion-execution-model.md)
@@ -269,14 +280,31 @@ to unify onto.
      full/greedy ranking credit — see
      `todo/deep/named-subrule-unbounded-quantifier-wrongly-gets-greedy-ltm-credit.md`;
      `t/grammar-body-my-lexical-scope.t` test 5 was reshaped to stop depending on it.
-2. **Slice 2 — bound/token-body scalar provenance** (Decision 2 item 2). Pin: the `scalar`
-   row of §2.2 as a grammar test. Watch: `roast/S05-grammar/*`, `roast/S05-modifier/my.t`
+2. **Slice 2 — bound/token-body scalar provenance (landed 2026-08-22)** (Decision 2 item 2).
+   Pin: the `scalar` row of §2.2 as a grammar test (`t/regex-ltm-interpolation-provenance.t`
+   probes T and U, the second a `constant` negative control). Watch: `roast/S05-grammar/*`,
+   `roast/S05-modifier/my.t`
    (ADR-0022 Slice 5 already had to fix a `:our` fallback that depended on the measurement
    pass leaking a real `env` write — the same class of hidden dependency may exist for
-   token bodies).
-3. **Slice 3 — mechanism 1 onto `ltm_branch_rank_key`** (Decision 1, the easy half; adds
-   litlen). Pin: the `litlen` row of §2.2. Acceptance: `roast/S05-grammar/protoregex.t`
+   token bodies) — all stayed green.
+3. **Slice 3 — mechanism 1 onto `ltm_branch_rank_key` (landed 2026-08-22)** (Decision 1, the
+   easy half; adds litlen). Pin: the `litlen` row of §2.2, in
+   `t/regex-ltm-proto-dispatch.t`. Acceptance: `roast/S05-grammar/protoregex.t`
    (whitelisted) stays green — it is the existing regression net for this mechanism.
+   - **Implementation note beyond the plan:** `ltm_rank_token_candidate_source`
+     parses the candidate and measures it with `ltm_prefix_len_at` /
+     `ltm_litlen_at` directly, so it no longer passes through
+     `regex_match_with_captures` — and therefore no longer benefits from that
+     function's string-level "skip the leading `:my`/`:our`/`:constant`
+     declarators while measuring" guard (`regex_match_public.rs`). Measuring a
+     `RegexAtom::VarDecl` for real *executes* its initializer, which is exactly
+     the ADR-0009 violation that guard existed to prevent. The fix is at the
+     atom level instead: a new `LtmAtomMode::SkipZeroWidth` (zero-width, does
+     not terminate the prefix, never runs), which is strictly more general — it
+     also covers a declarator that is not at the very start of the source text.
+     Validated against `raku`: reversing two proto candidates whose only
+     difference is a leading `:my` flips the winner, i.e. their prefixes tie, so
+     a declarator neither consumes nor terminates.
 4. **Slice 4 — mechanism 3 restructured to rank-then-match** (Decision 1, the semantic
    change). Pin: the `code` / `ws` / `litlen` rows of §2.2 in their nested-`<val>` form,
    plus §2.3's side-effect assertion. This is the high-blast-radius slice: every grammar

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -156,38 +156,40 @@ impl Interpreter {
                 s.chars().skip(start_pos).collect::<String>()
             }
         });
-        // Collect all matching candidates with their declarative prefix match
-        // lengths. `declarative_prefix_match_len` is the ONLY trial match here:
-        // it stops at the candidate's first code block/assertion and never
-        // executes one, so measuring a candidate cannot duplicate its side
-        // effects (ADR-0009). For a candidate with no code atom it is a full
-        // match — which executes nothing — so the "does this candidate match at
-        // all?" filter is unchanged for those.
-        // (prefix_match_len, pattern, sym adverb of the candidate's def)
-        let mut candidates: Vec<(usize, String, Option<String>)> = Vec::new();
+        // Collect all matching candidates with their LTM rank key.
+        // `ltm_rank_token_candidate_source` (ADR-0046 Decision 1) is the ONLY
+        // trial match here: it measures under `LTM_DECLARATIVE_MODE`, stopping
+        // at the candidate's first code block/assertion and never executing
+        // one, so measuring a candidate cannot duplicate its side effects
+        // (ADR-0009). For a candidate with no code atom it is a full match —
+        // which executes nothing — so the "does this candidate match at all?"
+        // filter is unchanged for those. It is the same primitive
+        // `|`-alternation ranking uses (`ltm_branch_rank_key`), so this site
+        // now also gets ADR-0022's `litlen` tie-break.
+        // ((prefix_match_len, litlen), pattern, sym adverb of the candidate's def)
+        let mut candidates: Vec<((usize, usize), String, Option<String>)> = Vec::new();
         let mut rejected: Vec<String> = Vec::new();
         for def in defs {
             let sym = Self::extract_sym_adverb(&def.name.resolve());
             if let Some(pattern) = self.eval_token_def(&def, arg_values)? {
                 if let Some(ref text) = subject {
-                    match self.declarative_prefix_match_len(&pattern, text) {
-                        (Some(prefix_match_len), _) => {
-                            candidates.push((prefix_match_len, pattern, sym))
-                        }
+                    match self.ltm_rank_token_candidate_source(&pattern, text) {
+                        (Some(rank), _) => candidates.push((rank, pattern, sym)),
                         // Measurement stopped at a code atom, so it proves nothing
                         // about whether the candidate matches — keep it (ranked
                         // last) and let the real match decide.
-                        (None, true) => candidates.push((0, pattern, sym)),
+                        (None, true) => candidates.push(((0, 0), pattern, sym)),
                         // A fully declarative candidate that does not match at all.
                         (None, false) => rejected.push(pattern),
                     }
                 } else {
-                    candidates.push((0, pattern, sym));
+                    candidates.push(((0, 0), pattern, sym));
                 }
             }
         }
-        // Sort by declarative prefix match length (longest first). The sort is
-        // stable, so an LTM tie falls back to declaration order (as in Rakudo).
+        // Sort by (declarative prefix length, litlen), longest first. The sort
+        // is stable, so an LTM tie falls back to declaration order (as in
+        // Rakudo) — ADR-0022 §4.4's third and final tie-break.
         candidates.sort_by_key(|c| std::cmp::Reverse(c.0));
         if let Some((_, pattern, sym)) = candidates.into_iter().next() {
             return Ok(Some((pattern, sym)));

--- a/src/runtime/regex/regex_interpolate.rs
+++ b/src/runtime/regex/regex_interpolate.rs
@@ -387,11 +387,32 @@ impl Interpreter {
                         .cloned()
                         .or_else(|| self.env.get(&format!("${name}")).cloned())
                     {
+                        // ADR-0046 Decision 2 item 2: a substitution made here is
+                        // a *runtime* interpolation, exactly like the general-case
+                        // `interpolate_regex_scalars` ones, so it must terminate
+                        // the candidate's declarative LTM prefix. Wrap the spliced
+                        // span in `NON_DECLARATIVE_INTERP_MARK` so the tokenizer
+                        // sets `RegexToken::from_runtime_interpolation` on every
+                        // atom it builds from it. Genuine `constant`s are exempt
+                        // (Rakudo inlines them at compile time — ADR-0022 §2), and
+                        // so is a `"..."` regex literal, whose own tokenizer arm
+                        // does not strip the mark (see the identical
+                        // `// TODO:` at `regex_parse_modifier.rs`).
+                        let is_const =
+                            crate::runtime::regex_parse::is_inside_double_quoted_regex_literal(
+                                &chars, start,
+                            ) || self.is_compile_time_constant_scalar(&name);
+                        if !is_const {
+                            out.push(Interpreter::NON_DECLARATIVE_INTERP_MARK);
+                        }
                         match value.view() {
                             ValueView::Regex(pat) => out.push_str(&pat),
                             _ => {
                                 out.push_str(&Self::regex_escape_literal(&value.to_string_value()))
                             }
+                        }
+                        if !is_const {
+                            out.push(Interpreter::NON_DECLARATIVE_INTERP_MARK);
                         }
                     } else {
                         out.extend(chars[start..end].iter());

--- a/src/runtime/regex/regex_ltm_rank.rs
+++ b/src/runtime/regex/regex_ltm_rank.rs
@@ -38,6 +38,11 @@ pub(super) enum LtmAtomMode<'a> {
     /// consuming (positive lookahead: `<?before X>` inlines `X` then stops),
     /// then terminate.
     TerminateAfter(&'a RegexPattern),
+    /// Zero-width success that must NOT run and must NOT stop the walk: the
+    /// atom consumes nothing and contributes nothing, and measurement keeps
+    /// going past it at full strength. Distinct from `Terminate`, which also
+    /// returns `pos` but declares everything after it non-declarative.
+    SkipZeroWidth,
 }
 
 /// Classify `atom` for LTM declarative-prefix measurement. Only meaningful
@@ -58,6 +63,17 @@ pub(super) fn ltm_atom_mode(atom: &RegexAtom) -> LtmAtomMode<'_> {
         // literal; terminate (constants are inlined as literals before this
         // atom kind is ever produced, so they never reach here — see §2).
         RegexAtom::VarInterp(_) => LtmAtomMode::Terminate,
+        // `:my $x = …;` / `:our` / `:constant` — a zero-width *declaration*.
+        // Rakudo's NFA walks straight past it (validated: reordering two proto
+        // candidates whose only difference is a leading `:my` flips the winner
+        // purely by declaration order, i.e. their prefixes tie — ADR-0046
+        // Slice 3), so it neither consumes nor terminates. It must be skipped
+        // rather than measured normally, because the real `VarDecl` arm
+        // *evaluates* the initializer, and measuring must never execute
+        // (ADR-0009). This replaces the string-level declarator strip in
+        // `regex_match_with_captures`, which only saw a declarator sitting at
+        // the very start of a pattern's source text.
+        RegexAtom::VarDecl { .. } => LtmAtomMode::SkipZeroWidth,
         // `<{ code }>` — the interpolated pattern is not known without running
         // code, so it cannot participate in a declarative prefix.
         RegexAtom::ClosureInterpolation { .. } => LtmAtomMode::Terminate,
@@ -332,6 +348,42 @@ impl Interpreter {
         let mut seen = HashSet::new();
         let litlen = self.ltm_litlen_at(alt, chars, pos, pkg, &mut seen, 0);
         (plen.unwrap_or(0), litlen)
+    }
+
+    /// ADR-0046 Decision 1, mechanism 1: rank one proto-token candidate that is
+    /// still in *pattern-source* form, as `eval_token_call_values_at` (the
+    /// `:rule<...>` / outermost proto entry point) holds it.
+    ///
+    /// Parses the candidate once and delegates to the shared
+    /// [`Self::ltm_branch_rank_key`] primitive, so this call site gets ADR-0022's
+    /// `litlen` tie-break instead of ranking on `prefix_len` alone. Returns the
+    /// same `(rank, stopped)` contract as [`Self::ltm_prefix_len_at`]: a `None`
+    /// rank with `stopped == false` is a sound "cannot match here" verdict the
+    /// caller may filter on, while `stopped == true` means the measurement was
+    /// cut short and proves nothing.
+    ///
+    /// Falls back to the string-based `declarative_prefix_match_len` (with a
+    /// zero litlen) when the source does not parse — that path also covers the
+    /// `parse_anchored_single_subrule` shortcut, which only `regex_match_with_captures`
+    /// implements.
+    pub(in crate::runtime) fn ltm_rank_token_candidate_source(
+        &mut self,
+        pattern: &str,
+        text: &str,
+    ) -> (Option<(usize, usize)>, bool) {
+        let Some(parsed) = self.parse_regex(pattern) else {
+            let (plen, stopped) = self.declarative_prefix_match_len(pattern, text);
+            return (plen.map(|p| (p, 0)), stopped);
+        };
+        let chars: Vec<char> = text.chars().collect();
+        let pkg = self.current_package();
+        let (plen, stopped) = self.ltm_prefix_len_at(&parsed, &chars, 0, &pkg);
+        let Some(plen) = plen else {
+            return (None, stopped);
+        };
+        let mut seen = HashSet::new();
+        let litlen = self.ltm_litlen_at(&parsed, &chars, 0, &pkg, &mut seen, 0);
+        (Some((plen, litlen)), stopped)
     }
 
     /// [`Self::ltm_seqalt_candidates`] collapsed to the single longest

--- a/src/runtime/regex/regex_match_atom.rs
+++ b/src/runtime/regex/regex_match_atom.rs
@@ -163,6 +163,9 @@ impl Interpreter {
                     LTM_PREFIX_TERMINATED.with(|f| f.set(true));
                     return vec![(best_end, RegexCaptures::default())];
                 }
+                LtmAtomMode::SkipZeroWidth => {
+                    return vec![(pos, RegexCaptures::default())];
+                }
                 LtmAtomMode::Normal => {}
             }
         }

--- a/src/runtime/regex/regex_match_atom_simple.rs
+++ b/src/runtime/regex/regex_match_atom_simple.rs
@@ -196,6 +196,7 @@ impl Interpreter {
                     LTM_PREFIX_TERMINATED.with(|f| f.set(true));
                     return Some(best_end);
                 }
+                LtmAtomMode::SkipZeroWidth => return Some(pos),
                 LtmAtomMode::Normal => {}
             }
         }

--- a/src/runtime/regex/regex_match_capture.rs
+++ b/src/runtime/regex/regex_match_capture.rs
@@ -77,6 +77,9 @@ impl Interpreter {
                     LTM_PREFIX_TERMINATED.with(|f| f.set(true));
                     return Some((best_end, RegexCaptures::default()));
                 }
+                LtmAtomMode::SkipZeroWidth => {
+                    return Some((pos, RegexCaptures::default()));
+                }
                 LtmAtomMode::Normal => {}
             }
         }

--- a/src/runtime/regex_parse_modifier.rs
+++ b/src/runtime/regex_parse_modifier.rs
@@ -145,7 +145,7 @@ impl Interpreter {
     /// `exec_set_local_op_inner`)? An ordinary `my`/`state`/param scalar
     /// answers `false` here even if it happens to never be reassigned:
     /// only a genuine `constant` is a Rakudo compile-time value.
-    fn is_compile_time_constant_scalar(&self, name: &str) -> bool {
+    pub(in crate::runtime) fn is_compile_time_constant_scalar(&self, name: &str) -> bool {
         self.env
             .get(&format!("__mutsu_constant_var::{name}"))
             .is_some()

--- a/t/regex-inline-code-block.t
+++ b/t/regex-inline-code-block.t
@@ -57,11 +57,11 @@ ok ArgFromMy.parse("  a\n  a").defined, ':my lexical passed as a subrule argumen
         token TOP { :my $shared = 'zz'; <inner> }
         token inner { $shared }
     }
-    # Pre-existing gap (also fails before this change): the caller's `:my` keeps
-    # the subrule's own pre-substitution from resolving the outer lexical, so the
-    # subrule interpolates nothing at all. The important half — that the caller's
-    # VALUE does not leak in — holds either way.
-    todo 'caller :my suppresses the subrule\'s own outer-lexical substitution';
+    # Was a known gap until ADR-0046 Slice 3: LTM measurement of `TOP` ran the
+    # `:my` declarator for real, so `$shared = 'zz'` leaked into the env that
+    # `inner`'s own pre-substitution then read. `RegexAtom::VarDecl` is now
+    # skipped zero-width under `LTM_DECLARATIVE_MODE` (measuring must never
+    # execute — ADR-0009), so `inner` resolves the outer lexical again.
     ok NoLeakIntoSubrule.parse('q').defined,     'a subrule sees the outer lexical, not the caller regex\'s :my';
     nok NoLeakIntoSubrule.parse('zz').defined,   'the caller regex\'s :my value does not leak into the subrule';
 }

--- a/t/regex-ltm-interpolation-provenance.t
+++ b/t/regex-ltm-interpolation-provenance.t
@@ -1,7 +1,7 @@
 use v6;
 use Test;
 
-plan 16;
+plan 20;
 
 # ADR-0046 Slice 1: array- and regex-object-valued regex interpolation forms
 # (`@name`, `<@name>`, `@(...)`, `@$ref`, `<$var>` holding a Regex) terminate
@@ -75,4 +75,49 @@ plan 16;
     my $rx = rx/Strict/;
     ok "StrictX" ~~ / <$rx> 'X' | 'St' /, 'probe S: matches';
     is ~$/, 'St', 'probe S: <$rx> regex-value form terminates too';
+}
+
+# ---------------------------------------------------------------------------
+# ADR-0046 Slice 2: the *bound* interpolator (`interpolate_bound_regex_scalars`),
+# which renders grammar/token bodies, must mark its substitutions the same way.
+# Before this slice only the general-case `interpolate_regex_scalars` did, so a
+# `$var` inside a token body stayed indistinguishable from a hand-written
+# literal and wrongly extended the candidate's declarative LTM prefix.
+# Expectations verified against `raku`; see ADR-0046 §2.2's `scalar` row.
+
+class LTMActions {
+    method val:sym<known>($/) { make 'KNOWN' }
+    method val:sym<other>($/) { make 'OTHER' }
+}
+
+# Probe T: a `my` scalar interpolated into a token body terminates the prefix,
+# so `known`'s prefix stops at 4 ('Foo=') and `other`'s 10 wins outright.
+{
+    grammar BodyScalar {
+        my $opt = 'Strict';
+        proto token val {*}
+        token val:sym<known> { 'Foo=' $opt }
+        token val:sym<other> { <-[;]>+ }
+    }
+    my $m = BodyScalar.parse('Foo=Strict', :rule<val>, :actions(LTMActions.new));
+    ok $m, 'probe T: matches';
+    is $m.made, 'OTHER',
+        'probe T: a token body $var interpolation terminates the declarative prefix';
+}
+
+# Probe U: negative control -- a genuine `constant` IS inlined at compile time
+# by Rakudo, so it keeps participating and `known` (prefix 10, declared first)
+# wins the tie. This is the `$`-scalar exemption ADR-0022 Slice 5 established,
+# which has no `@`-array analogue (probe J above).
+{
+    grammar BodyConstant {
+        my constant $copt = 'Strict';
+        proto token val {*}
+        token val:sym<known> { 'Foo=' $copt }
+        token val:sym<other> { <-[;]>+ }
+    }
+    my $m = BodyConstant.parse('Foo=Strict', :rule<val>, :actions(LTMActions.new));
+    ok $m, 'probe U: matches';
+    is $m.made, 'KNOWN',
+        'probe U: a token body `constant` $var still participates (negative control)';
 }

--- a/t/regex-ltm-proto-dispatch.t
+++ b/t/regex-ltm-proto-dispatch.t
@@ -1,0 +1,85 @@
+use v6;
+use Test;
+
+plan 8;
+
+# ADR-0046 Decision 1: proto-token candidates are ranked by the ONE LTM ranking
+# primitive (`ltm_branch_rank_key`) at every call site, i.e. by
+# `(declarative prefix length desc, litlen desc, declaration order asc)`.
+#
+# This file covers ADR-0046 §2.2 for *mechanism 1* -- the `parse(:rule<...>)` /
+# outermost-proto entry point (`eval_token_call_values_at`). Before Slice 3 that
+# site ranked on declarative prefix length alone, with no `litlen` tie-break.
+# All expectations were verified against `raku` first.
+
+class LTMActions {
+    method val:sym<known>($/) { make 'KNOWN' }
+    method val:sym<other>($/) { make 'OTHER' }
+}
+
+# Row `code`: a plain `{ }` block is the oldest LTM prefix stopper mutsu
+# implements (ADR-0009), so `known`'s prefix stops at 4 and `other`'s 10 wins.
+{
+    grammar GCode {
+        proto token val {*}
+        token val:sym<known> { 'Foo=' {} 'Strict' }
+        token val:sym<other> { <-[;]>+ }
+    }
+    my $m = GCode.parse('Foo=Strict', :rule<val>, :actions(LTMActions.new));
+    ok $m, 'code row: matches';
+    is $m.made, 'OTHER', 'code row: a plain {} block terminates the declarative prefix';
+}
+
+# Row `ws`: `<.ws>` is a fate/terminate atom in Rakudo's NFA, same outcome.
+{
+    grammar GWs {
+        proto token val {*}
+        token val:sym<known> { 'Foo=' <.ws> 'Strict' }
+        token val:sym<other> { <-[;]>+ }
+    }
+    my $m = GWs.parse('Foo=Strict', :rule<val>, :actions(LTMActions.new));
+    ok $m, 'ws row: matches';
+    is $m.made, 'OTHER', 'ws row: <.ws> terminates the declarative prefix';
+}
+
+# Row `litlen`: both candidates measure a declarative prefix of 3 on "abc", so
+# the winner is decided by the ADR-0022 §4.3 `litlen` tie-break -- the literal
+# 'abc' has litlen 3, the char-class walk `\w\w\w` has litlen 0. Declaration
+# order deliberately favours the LOSER here, so a missing tie-break shows up.
+{
+    grammar GLit {
+        proto token v {*}
+        token v:sym<cc>  { \w\w\w }
+        token v:sym<lit> { 'abc' }
+    }
+    class LitActions {
+        method v:sym<lit>($/) { make 'LIT' }
+        method v:sym<cc>($/)  { make 'CC' }
+    }
+    my $m = GLit.parse('abc', :rule<v>, :actions(LitActions.new));
+    ok $m, 'litlen row: matches';
+    is $m.made, 'LIT',
+        'litlen row: equal prefixes are broken by litlen, not declaration order';
+}
+
+# A `:my` declarator is zero-width and transparent to LTM measurement: it must
+# neither consume, nor terminate the prefix, nor be *executed* while measuring
+# (ADR-0009). Both candidates therefore tie at prefix 10 and declaration order
+# decides -- which means reversing the declarations flips the winner.
+{
+    grammar GMyFirst {
+        proto token val {*}
+        token val:sym<known> { :my $z = 1; 'Foo=Strict' }
+        token val:sym<other> { <-[;]>+ }
+    }
+    my $m = GMyFirst.parse('Foo=Strict', :rule<val>, :actions(LTMActions.new));
+    is $m.made, 'KNOWN', ':my is transparent: declared first, wins the prefix tie';
+
+    grammar GMyLast {
+        proto token val {*}
+        token val:sym<other> { <-[;]>+ }
+        token val:sym<known> { :my $z = 1; 'Foo=Strict' }
+    }
+    my $m2 = GMyLast.parse('Foo=Strict', :rule<val>, :actions(LTMActions.new));
+    is $m2.made, 'OTHER', ':my is transparent: declared last, loses the prefix tie';
+}


### PR DESCRIPTION
Implements ADR-0046 Slices 2 and 3. Both concern the `:rule<...>` / outermost-proto LTM entry point (`eval_token_call_values_at`, the ADR's "mechanism 1").

## Slice 2 — token-body interpolation provenance

ADR-0022 Slice 5 added `NON_DECLARATIVE_INTERP_MARK`, the sentinel that makes the tokenizer set `RegexToken::from_runtime_interpolation` so `walk_tokens` terminates the declarative LTM prefix at a runtime interpolation. It was wired into the general-case interpolator only. `interpolate_bound_regex_scalars` — the pass that renders grammar/token bodies — substituted `$var` with no marking, so a `$var` inside a token body looked exactly like a hand-written literal:

```raku
token val:sym<known> { 'Foo=' $opt }   # my $opt = 'Strict'
token val:sym<other> { <-[;]>+ }
```

raku answers `other` (prefix 10 beats `known`'s 4, which stops at the interpolation); mutsu answered `known`. Now marked, keeping the `constant` exemption (a genuine `constant` *is* inlined by Rakudo and still participates — pinned as a negative control) and the `"..."`-literal carve-out.

## Slice 3 — mechanism 1 onto the one shared ranking primitive

It ranked by declarative prefix length alone (string-based `declarative_prefix_match_len`), with no `litlen` tie-break, so on `"abc"` `token v:sym<cc> { \w\w\w }` beat `token v:sym<lit> { 'abc' }` purely by declaration order. It now parses the candidate and delegates to `ltm_branch_rank_key` — the same `(prefix_len, litlen)` primitive `|`-alternation ranking uses. Declaration order remains the third tie-break, free from the stable sort.

### Knock-on ADR-0009 fix: `LtmAtomMode::SkipZeroWidth`

Measuring a *parsed* pattern no longer passes through `regex_match_with_captures`, whose LTM guard stripped a leading `:my`/`:our`/`:constant` declarator from the pattern *source* before measuring. Without that strip, the measurement reaches the real `RegexAtom::VarDecl` arm — which **executes** the initializer. That is precisely the ADR-0009 violation ("measuring a candidate must never execute it").

Fixed at the atom level instead, with a new `LtmAtomMode::SkipZeroWidth` (zero-width, non-terminating, never run). This is strictly more general than the string-level strip — it also covers a declarator that is not at the very start of the text — and it closes a real leak the old guard missed: measuring `token TOP { :my $shared = 'zz'; <inner> }` wrote `$shared` into the live env, which `inner`'s own pre-substitution then read, so `inner` matched `'zz'` instead of the outer lexical's `'q'`. That was the stale `todo` in `t/regex-inline-code-block.t`, now removed (mutsu matches raku on both halves).

Rakudo semantics validated first: reversing two proto candidates whose only difference is a leading `:my` flips the winner, i.e. their prefixes tie — a declarator neither consumes nor terminates.

## Probe matrix (ADR-0046 §2.2), mechanism 1 column

| row | raku | before | after |
|---|---|---|---|
| code | OTHER | OTHER | OTHER |
| ws | OTHER | OTHER | OTHER |
| scalar | OTHER | **KNOWN** | OTHER ✅ |
| array | OTHER | OTHER | OTHER |
| litlen | LIT | **CC** | LIT ✅ |

Mechanism 3 (nested `<name>` dispatch) is untouched and still red on every row — that is Slice 4, landing next off `main`.

## Verification

- `t/regex-ltm-proto-dispatch.t` (new, 8 assertions) and probes T/U in `t/regex-ltm-interpolation-provenance.t`, each verified against the system `raku` first (both oracles produce identical TAP).
- Full `t/` suite: 3346 files, 31153 tests, PASS.
- `cargo test -- --test-threads=1`: all green.
- `make roast` on a release build: 1436 files, 218836 tests, PASS.
- Bundled-battery gate (`scripts/battery-testsuite.sh`, the last step of CI's `test` job): 257/272, GATE PASSED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
