### PR TITLE
docs: file batch-2 doc-diff findings across 10 core files

### DIFF
--- a/docs/doc-diff-backlog.md
+++ b/docs/doc-diff-backlog.md
@@ -218,6 +218,136 @@ distinguish this from a real ordering bug. The existing nondet heuristic (skips
 output; improving that heuristic is a possible future harness enhancement, not tracked
 as a ticket here.
 
+Found in the 2026-08-22 batch-2 re-run of `regexes`/`traps`/`variables`/`control`/`list`/
+`IO::Path`/`Any`/`objects`/`Iterator`/`typesystem`:
+
+| file:line | one-line summary | ticket |
+|---|---|---|
+| `Language/control.rakudoc:526,537` | `do when COND { BLOCK }` used as an expression crashes / gives the wrong value | [control-do-when-expression-value.md](../todo/tickets/control-do-when-expression-value.md) |
+| `Language/control.rakudoc:717` | `race for` doesn't collect the loop's per-iteration results | [control-race-for-drops-results.md](../todo/tickets/control-race-for-drops-results.md) |
+| `Language/control.rakudoc:388` | `if`/`unless`/`while` block body rejects a pointy-block parameter | [control-if-unless-pointy-block-param.md](../todo/tickets/control-if-unless-pointy-block-param.md) |
+| `Language/control.rakudoc:854` | `default { }` cannot be used as a term nested inside an expression | [control-default-term-expression-position.md](../todo/tickets/control-default-term-expression-position.md) |
+| `Language/control.rakudoc:973` | `proceed` inside a bare block with a trailing `when` modifier doesn't skip the enclosing `when` | [control-nested-when-proceed-skip.md](../todo/tickets/control-nested-when-proceed-skip.md) |
+| `Language/control.rakudoc:1375` | `return-rw` doesn't return a mutable container | [control-return-rw-not-mutable.md](../todo/tickets/control-return-rw-not-mutable.md) |
+| `Language/control.rakudoc:263` | statement-modifier `if` mid-comma-list inside parens is a hard parse failure | [control-if-modifier-mid-comma-list-parse-fail.md](../todo/tickets/control-if-modifier-mid-comma-list-parse-fail.md) |
+| `Language/list.rakudoc:54` | a parenthesized `;`-separated statement list drops its trailing empty-statement element | [paren-statement-list-trailing-empty-element.md](../todo/tickets/paren-statement-list-trailing-empty-element.md) |
+| `Type/IO/Path.rakudoc:128,290,423` | `IO::Path::Win32` inconsistently normalizes `/` vs `\` separators | [iopath-win32-separator-normalization.md](../todo/tickets/iopath-win32-separator-normalization.md) |
+| `Type/IO/Path.rakudoc:561` | `~~ :w`/`:r`/`:x` smart-match ignores effective per-user permission (raw mode bits instead of `access()`) | [iopath-filetest-smartmatch-wrong-permission-check.md](../todo/tickets/iopath-filetest-smartmatch-wrong-permission-check.md) |
+
+**Excluded from this batch-2 re-run (already deferred/resolved/drift/false-positive):**
+- `Language/control.rakudoc` [1] (`{ block } or die;` not executing the block) — the
+  already-**Deferred** "`and`/`or`/`not` word-logical precedence" cluster, explicitly named for
+  `control.rakudoc`.
+- `Language/control.rakudoc` [7] — hash-iteration-order `raku-drift`, both sides nondeterministic.
+- `Language/control.rakudoc` [10] — `X::Multi::NoMatch` message text is shorter in mutsu but the
+  exception type/meaning match; cosmetic, not ticketed.
+- `Language/list.rakudoc` [1] tail (line 338, geometric sequence past i64 degrading to Float) —
+  the named **Deferred** "big-Int→Float degradation in geometric sequence generation past i64"
+  item.
+- `Language/list.rakudoc` [2] (line 707, `@cards.shape` with enum-valued dimensions) — bucketed
+  `raku-drift` (doc says "Deuce Deuce", raku prints "2 2"); mutsu's own `(*)` looks wrong too but
+  wasn't ticketed per the skip-drift instruction — worth a second look later.
+- `Type/IO/Path.rakudoc` [4] (line 509, `MAIN` sub recursively walking `.`) — mutsu times out;
+  inherently dependent on this checkout's file count (walks `target/`/`vendor/`/`.git/`), not a
+  clean minimal repro — flagged for awareness, not ticketed.
+- `Type/IO/Path.rakudoc` [6] (line 609, `$*EXECUTABLE.IO.s`) — `raku-drift` and
+  build-environment-dependent (binary size), not a bug.
+
+Found in the same 2026-08-22 batch-2 re-run, `Type/Any.rakudoc` / `Language/objects.rakudoc` /
+`Type/Iterator.rakudoc` / `Language/typesystem.rakudoc`:
+
+| file:line | one-line summary | ticket |
+|---|---|---|
+| `Type/Any.rakudoc:961` | `.categorize`/`.classify` into an untyped Hash mis-renders a non-Str bucket key when the source array holds class instances | [categorize-into-hash-instance-bool-key-corruption.md](../todo/tickets/categorize-into-hash-instance-bool-key-corruption.md) |
+| `Type/Any.rakudoc:1525` | `.snip` with multiple positional predicates silently drops all but the first | [snip-multiple-positional-matchers-dropped.md](../todo/tickets/snip-multiple-positional-matchers-dropped.md) |
+| `Type/Any.rakudoc:1549,1559` | `.snitch` (v6.e.PREVIEW debugging method) is entirely unimplemented | [snitch-method-unimplemented.md](../todo/tickets/snitch-method-unimplemented.md) |
+| `Type/Any.rakudoc:1420` | `$*COLLATION.set(...)` does not persist / is not honored by `coll` | [collation-set-not-persisted.md](../todo/tickets/collation-set-not-persisted.md) |
+| `Language/objects.rakudoc:1067` | a user class `is Str` (or other native type) doesn't inherit native stringification | [str-subclass-loses-native-stringify.md](../todo/tickets/str-subclass-loses-native-stringify.md) |
+| `Language/objects.rakudoc:1132` | a role's 0-arg `multi method` loses its trailing string literal, only when the composing class has its own extra attribute | [role-multi-method-trailing-literal-dropped.md](../todo/tickets/role-multi-method-trailing-literal-dropped.md) |
+| `Language/objects.rakudoc:1185` | attribute order in a `.new`/gist under multiple inheritance is wrong (deterministic, not hash-order noise) | [multi-inheritance-attribute-gist-order.md](../todo/tickets/multi-inheritance-attribute-gist-order.md) |
+| `Language/objects.rakudoc:1457` | `but`-mixing a role onto a `List` breaks its `Positional` binding | [list-but-role-loses-positional-binding.md](../todo/tickets/list-but-role-loses-positional-binding.md) |
+| `Language/objects.rakudoc:1526` | `is default(0 but role :: {...})` on a typed Hash drops the role mixin on the default value | [hash-default-role-mixin-dropped.md](../todo/tickets/hash-default-role-mixin-dropped.md) |
+| `Language/objects.rakudoc:65` | colon-call syntax with zero arguments (`.method:` immediately followed by `;`) fails to parse | [colon-call-empty-args-parse-error.md](../todo/tickets/colon-call-empty-args-parse-error.md) |
+| `Language/objects.rakudoc:1397` | a parameterized role with a self-referential attribute type fails a spurious type-check, with a malformed error message | [parametric-role-self-referential-attribute-typecheck.md](../todo/tickets/parametric-role-self-referential-attribute-typecheck.md) |
+| `Language/typesystem.rakudoc:657` | a custom `.gist` on a role-mixed native value is skipped when gisted inside an array/list | [role-mixed-value-gist-skipped-in-array.md](../todo/tickets/role-mixed-value-gist-skipped-in-array.md) |
+| `Language/typesystem.rakudoc:846` | `enum ... does Role`'s overriding `ACCEPTS` is never dispatched by `~~`, plus a spurious `=>` warning | [enum-does-role-accepts-not-dispatched.md](../todo/tickets/enum-does-role-accepts-not-dispatched.md) |
+| `Language/typesystem.rakudoc:594` | a role's `.new` instance reports the wrong `.HOW` metaclass | [role-instance-how-wrong-metaclass.md](../todo/tickets/role-instance-how-wrong-metaclass.md) |
+| `Language/typesystem.rakudoc:611` | a forward-declared role stub used by another role is never upgraded to its real body | [forward-declared-role-stub-not-upgraded.md](../todo/tickets/forward-declared-role-stub-not-upgraded.md) |
+| `Language/typesystem.rakudoc:644` | a role parameter's `fail(...)` default expression is never evaluated/enforced | [role-parameter-fail-default-not-enforced.md](../todo/tickets/role-parameter-fail-default-not-enforced.md) |
+
+Three of these ([list-but-role-loses-positional-binding.md](../todo/tickets/list-but-role-loses-positional-binding.md),
+[hash-default-role-mixin-dropped.md](../todo/tickets/hash-default-role-mixin-dropped.md),
+[role-mixed-value-gist-skipped-in-array.md](../todo/tickets/role-mixed-value-gist-skipped-in-array.md))
+share a hypothesis — a `but`/`does`-mixed value's role metadata not surviving a generic
+storage/dispatch path — noted cross-links in each ticket; investigate together and merge into
+one PR if a single fix site is found.
+
+**Excluded from this sub-batch (already deferred/resolved/drift/false-positive):**
+- `Type/Any.rakudoc` [2], [6]-[11] — hash/Set/Bag iteration-order/address `raku-drift`.
+- `Language/objects.rakudoc` [1], [2] — `raku-drift` (stale doc error-message wording).
+- `Type/Iterator.rakudoc` [1] — the **Deferred** "Custom `does Iterable`/`does Iterator`
+  protocol" cluster, explicitly named for this file.
+- `Type/Iterator.rakudoc` [2], [3], [5] — the **Deferred** lazy-list cluster's "`=:= IterationEnd`
+  container identity" and "IterationEnd's repr (it is a Str internally...)" residues.
+- `Type/Iterator.rakudoc` [4] — `raku-drift` (doc's stated OUTPUT no longer matches current raku
+  for the custom-iterator example).
+- `Language/typesystem.rakudoc` [3] — `raku-drift` (object hex-address text, inherently
+  non-reproducible).
+- `Language/typesystem.rakudoc` [6] — the exception *type* text is drift (`X::AdHoc` vs. real
+  raku's `X::Role::Instantiation`), but mutsu not throwing at all is real — filed as
+  [role-parameter-fail-default-not-enforced.md](../todo/tickets/role-parameter-fail-default-not-enforced.md)
+  above.
+
+Found in the same 2026-08-22 batch-2 re-run, `Language/regexes.rakudoc` /
+`Language/traps.rakudoc` / `Language/variables.rakudoc`:
+
+| file:line | one-line summary | ticket |
+|---|---|---|
+| `Language/regexes.rakudoc:1331` | `<!:Script<Name>>` negated Unicode-property lookahead doesn't stop the preceding quantifier's backtrack | [regex-script-lookahead-negation-wrong.md](../todo/tickets/regex-script-lookahead-negation-wrong.md) |
+| `Language/regexes.rakudoc:1349` | `<same>` builtin regex subrule is unimplemented | [regex-same-subrule-missing.md](../todo/tickets/regex-same-subrule-missing.md) |
+| `Language/regexes.rakudoc:1595` | a regex-embedded `:my $c = $/;` (self-referencing the in-progress match) fails to parse | [regex-embedded-my-decl-self-referential-slash.md](../todo/tickets/regex-embedded-my-decl-self-referential-slash.md) |
+| `Language/regexes.rakudoc:1602` | a regex-embedded `:my $c = ~$0;` captures an empty value instead of the current match text | [regex-embedded-my-decl-value-not-captured.md](../todo/tickets/regex-embedded-my-decl-value-not-captured.md) |
+| `Language/regexes.rakudoc:1612` | a regex-embedded `:our $var = ...;` doesn't write back to the package variable | [regex-our-declarator-writeback-missing.md](../todo/tickets/regex-our-declarator-writeback-missing.md) |
+| `Language/regexes.rakudoc:1966` | a subrule call with a block-literal argument (`<name: { ... }>`) fails entirely | [regex-subrule-block-argument-parse-fail.md](../todo/tickets/regex-subrule-block-argument-parse-fail.md) |
+| `Language/regexes.rakudoc:1543` | capture-group numbering across an alternation branch is wrong | [regex-capture-numbering-across-alternation.md](../todo/tickets/regex-capture-numbering-across-alternation.md) |
+| `Language/regexes.rakudoc:1587` | an embedded code block inside a quantified group doesn't persist its side effect on an outer `:my` variable | [regex-embedded-code-block-quantifier-scope.md](../todo/tickets/regex-embedded-code-block-quantifier-scope.md) |
+| `Language/regexes.rakudoc:1816` | `s///` replacement string doesn't interpolate named captures (`$<name>`) | [subst-named-capture-interpolation-in-replacement.md](../todo/tickets/subst-named-capture-interpolation-in-replacement.md) |
+| `Language/regexes.rakudoc:1823` | `s///` replacement over-escapes a literal `\:` | [subst-replacement-code-block-not-evaluated.md](../todo/tickets/subst-replacement-code-block-not-evaluated.md) |
+| `Language/regexes.rakudoc:2290` | `S:g/@(EXPR)/.../ ` doesn't interpolate an array as a regex alternation | [subst-array-interpolation-as-alternation.md](../todo/tickets/subst-array-interpolation-as-alternation.md) |
+| `Language/regexes.rakudoc:2623` | a custom grammar `ws` token override with `<!ww>` doesn't match per raku's boundary rules | [grammar-ws-boundary-and-vertical-whitespace.md](../todo/tickets/grammar-ws-boundary-and-vertical-whitespace.md) |
+| `Language/regexes.rakudoc:2684` | `m:st(...)` regex adverb (starting positions) is unsupported | [regex-st-adverb-unsupported.md](../todo/tickets/regex-st-adverb-unsupported.md) |
+| `Language/regexes.rakudoc:2892` | a grammar's `FAILGOAL` method isn't invoked when a goal-matching conjunction (`~`) fails | [grammar-failgoal-not-invoked.md](../todo/tickets/grammar-failgoal-not-invoked.md) |
+| `Language/regexes.rakudoc:2935` | `<~~>` recursive self-match returns the wrong (inner, not outer) nesting level | [regex-recursive-self-match-wrong-nesting-level.md](../todo/tickets/regex-recursive-self-match-wrong-nesting-level.md) |
+| `Language/traps.rakudoc:91` | `$++` inside a string-interpolated block doesn't reset per call the way raku's does | [dollar-plusplus-state-scope-in-interpolated-block.md](../todo/tickets/dollar-plusplus-state-scope-in-interpolated-block.md) |
+| `Language/traps.rakudoc:212` | `$.attr *= 2` inside a method throws `X::Assignment::RO` where current raku silently no-ops | [dollar-dot-attr-compound-assign-spurious-ro-error.md](../todo/tickets/dollar-dot-attr-compound-assign-spurious-ro-error.md) |
+| `Language/traps.rakudoc:1948` | `\|«@array` (flatten + hyper prefix combined) fails to parse | [flatten-hyper-prefix-parse-error.md](../todo/tickets/flatten-hyper-prefix-parse-error.md) |
+| `Language/traps.rakudoc:1067` | `for EXPR ~~ /regex/ { BLOCK }` executes `BLOCK` where raku produces no output | [for-loop-over-smartmatch-result-executes-unexpectedly.md](../todo/tickets/for-loop-over-smartmatch-result-executes-unexpectedly.md) |
+| `Language/traps.rakudoc:406`, `Language/variables.rakudoc:853` | a scalar's container isn't aliased when pushed into a collection without `.clone` — mutsu snapshots by value where raku aliases | [container-aliasing-not-preserved-into-collection.md](../todo/tickets/container-aliasing-not-preserved-into-collection.md) |
+| `Language/variables.rakudoc:1551` | `».&?BLOCK` (hyper-call with a block self-reference) dispatches an empty method name | [hyper-call-block-self-reference-empty-method.md](../todo/tickets/hyper-call-block-self-reference-empty-method.md) |
+| `Language/variables.rakudoc:134` | `my ($g) = LIST;` gives `$g.VAR.^name` of `Int` instead of `Scalar` (harness mis-bucketed as drift) | [paren-single-var-decl-var-scalar-name.md](../todo/tickets/paren-single-var-decl-var-scalar-name.md) |
+| `Language/variables.rakudoc:768` | `anon class`/`anon sub` with a non-ASCII name fails to parse; `anon sub NAME` also gists without the `&` sigil | [anon-class-sub-non-ascii-name-and-sub-gist.md](../todo/tickets/anon-class-sub-non-ascii-name-and-sub-gist.md) |
+| `Language/variables.rakudoc:1765` | `$*RAKU` reports the wrong metaclass name (`Perl`) and inconsistent stringification | [dollar-raku-wrong-metaclass-and-stringify.md](../todo/tickets/dollar-raku-wrong-metaclass-and-stringify.md) |
+| `Language/variables.rakudoc:318` | `$?FILE` reports the relative invocation path instead of an absolute path | [dollar-question-file-relative-not-absolute.md](../todo/tickets/dollar-question-file-relative-not-absolute.md) |
+
+**Excluded from this sub-batch (already deferred/resolved/drift/false-positive/environment):**
+- `Language/regexes.rakudoc` [3], [8] — `raku-drift`.
+- `Language/traps.rakudoc` [1], [2] — instances of the already-**Deferred** Nil-vs-Any identity
+  knot (`%h is default(Nil)` and `:= Nil` both render `(Any)` instead of `Nil`).
+- `Language/traps.rakudoc` [6] — Set iteration-order `raku-drift`.
+- `Language/variables.rakudoc` [1] — mutsu errors partway through a recursive `.` directory walk
+  (same shape as `Type/IO/Path.rakudoc` [4] from the earlier sub-batch); the real bug underneath
+  it (`».&?BLOCK` dispatching an empty method name) was isolated to a small non-environment-
+  dependent repro and filed as
+  [hyper-call-block-self-reference-empty-method.md](../todo/tickets/hyper-call-block-self-reference-empty-method.md).
+- `Language/variables.rakudoc` [3] — `$?FILE` reports mutsu's relative invocation path where raku
+  resolves to an absolute path; confirmed real, low-priority/cosmetic, filed as
+  [dollar-question-file-relative-not-absolute.md](../todo/tickets/dollar-question-file-relative-not-absolute.md).
+- `Language/variables.rakudoc` [6], [7], [9], [10] — `raku-drift` (`$*DISTRO`, `$*VM.config`,
+  `$*RAKU.compiler.version` are inherently environment/version-specific).
+- `Language/variables.rakudoc` [8] — `$*VM.precomp-ext`/`.precomp-target` report `mutsu`/`mutsu`
+  instead of raku's MoarVM-specific `moarvm`/`mbc`; this looks like an intentional identity
+  difference (mutsu isn't MoarVM), not a bug — not ticketed.
+
 ### Deferred / deep (tracked elsewhere — do not re-open as a shallow slice)
 These root causes account for a large share of the survey's `mism`/`crash` and are
 intentionally deferred; see PLAN.md §8.5 and the ADRs:

--- a/todo/tickets/anon-class-sub-non-ascii-name-and-sub-gist.md
+++ b/todo/tickets/anon-class-sub-non-ascii-name-and-sub-gist.md
@@ -1,0 +1,42 @@
+# `anon class`/`anon sub` with a non-ASCII name fails to parse; `anon sub NAME` also gists without the `&` sigil
+
+Discovered via the doc-diff harness on `raku-doc/doc/Language/variables.rakudoc` (around line
+768).
+
+## Repro 1 — non-ASCII name parse failure
+
+```
+say anon class þ {};
+say anon sub þ  { 42 };
+```
+
+- raku: `(þ)` then `&þ`
+- mutsu: `Runtime error: comma or statement end after argument`
+
+With a plain ASCII name (`Foo` instead of `þ`), both declarations parse fine in mutsu — so the
+parse failure is specific to a non-ASCII identifier following `anon class`/`anon sub`.
+
+## Repro 2 — `anon sub NAME` gists without its `&` sigil (ASCII name, so parses; separate bug)
+
+```
+say anon sub Foo { 42 };
+```
+
+- raku: `&Foo`
+- mutsu: `Foo`
+
+A named anonymous sub's default stringification should include the leading `&` (matching how a
+regular named sub gists), but mutsu drops it.
+
+## Root cause guess
+
+1. The identifier-parsing path used right after `anon class`/`anon sub` likely only accepts an
+   ASCII identifier character class, unlike ordinary declaration-name parsing elsewhere (which
+   presumably already supports non-ASCII identifiers, since raku itself allows them freely).
+2. `anon sub NAME { }`'s default `.gist`/`.Str` is missing the `&`-sigil prefix that a normal
+   named `Sub`'s stringification includes.
+
+## Affected files (starting point)
+
+- `src/parser/` — `anon class`/`anon sub` name-token parsing (character class accepted)
+- `src/builtins/methods_0arg/` or wherever `Sub`/`Routine` default gist/stringify lives

--- a/todo/tickets/categorize-into-hash-instance-bool-key-corruption.md
+++ b/todo/tickets/categorize-into-hash-instance-bool-key-corruption.md
@@ -1,0 +1,47 @@
+# `.categorize`/`.classify` into an untyped `Hash` mis-renders a non-Str bucket key when the source array holds class instances
+
+Discovered via the doc-diff harness on `raku-doc/doc/Type/Any.rakudoc` (around line 961).
+
+## Repro
+
+```
+my %h;
+class Foo {}
+my @a = (Foo.new,);
+@a.categorize({True}, into => %h);
+say %h;
+```
+
+- raku: `{True => [Foo.new]}`
+- mutsu: `{Bool|1 => [Foo.new]}` — the `True` bucket key renders as its internal `WHICH`-style
+  representation instead of `True`
+
+The identical script with `@a = (1,)` (a plain Int element instead of a class instance) prints
+correctly: `{True => [1]}`.
+
+## Investigation so far
+
+`dd %h` shows the *underlying* hash structure looks identical in both cases (`%{Any} =
+Bool::True => ...`, `which_keyed=false`, `key_type=Some("Any")` via `rust-gdb` breakpoints in
+`classify_finish_hash`/`ensure_object_hash_which_keys` in
+`src/runtime/builtins_collection_classify.rs`) — so the corruption is not visible at
+construction time, only when the result is rendered via `say`/`.Str`/`.gist`, and only for the
+instance-array run.
+
+`typed_key()` in `src/value/value_collections.rs` has a fallback that stringifies the raw
+`.WHICH` key when a lookup misses — consistent with the observed `Bool|1` output — but it's
+unclear why the lookup misses only when the source array's elements are `ValueView::Instance`.
+
+## Affected files (starting point)
+
+- `src/runtime/builtins_collection_classify.rs` — `classify_finish_hash`,
+  `ensure_object_hash_which_keys`
+- `src/value/value_collections.rs` — `typed_key()` and its miss-fallback
+
+## Suggested next step
+
+A further `rust-gdb` session watching the `Gc<HashData>`'s `original_keys` field between the
+write-back call and the final `say`/gist render, to see whether something in instance
+GC-tracking touches that allocation in between (the divergence only appears with an
+`Instance`-holding source array, which hints at a GC-interaction bug rather than a classify
+logic bug).

--- a/todo/tickets/collation-set-not-persisted.md
+++ b/todo/tickets/collation-set-not-persisted.md
@@ -1,0 +1,36 @@
+# `$*COLLATION.set(...)` does not persist / is not honored by `coll`
+
+Discovered via the doc-diff harness on `raku-doc/doc/Type/Any.rakudoc` (around line 1420).
+
+## Repro
+
+```
+$*COLLATION.set(:quaternary(False), :tertiary(False));
+say $*COLLATION.tertiary;
+say 'a' coll 'A';
+```
+
+- raku: `0` then `Same`
+- mutsu: `Nil` then `Less` — the `.set(...)` call has no visible effect on subsequent reads
+
+## Root cause guess
+
+`src/runtime/methods_collection_ops/collation_temporal.rs`'s `"set"` arm calls
+`Value::write_back_sharing(&attributes, class_name, new_attrs, id)`, but subsequent reads of
+`$*COLLATION` — both the 0-arg `tertiary`/`quaternary` accessor and
+`vm/vm_value_helpers.rs::get_collation_settings` (used by the `coll` operator) — don't observe
+the update. The write-back likely lands on a different copy/binding than the one later reads
+resolve through (a dynamic-variable aliasing issue, similar in shape to other `$*`-dynamic
+write-back bugs already fixed elsewhere in the codebase).
+
+## Affected files (starting point)
+
+- `src/runtime/methods_collection_ops/collation_temporal.rs` — the `"set"` method arm
+- `src/vm/vm_value_helpers.rs` — `get_collation_settings`
+
+## Suggested next step
+
+Compare how `$*COLLATION`'s instance is stored/retrieved to how another already-working
+`$*`-dynamic mutable-attribute case (e.g. `$*TOLERANCE`, if seeded, or any other settable
+dynamic singleton) round-trips a `.set`/mutator call, to find where `$*COLLATION`'s path
+diverges.

--- a/todo/tickets/colon-call-empty-args-parse-error.md
+++ b/todo/tickets/colon-call-empty-args-parse-error.md
@@ -1,0 +1,32 @@
+# Colon-call syntax with zero arguments (`.method:` immediately followed by `;`) fails to parse
+
+Discovered via the doc-diff harness on `raku-doc/doc/Language/objects.rakudoc` (around line 65).
+
+## Repro
+
+```
+say 4.log:   ;
+```
+
+- raku: `1.386...` (parses `4.log:` with no following argument the same as plain `4.log`)
+- mutsu: `===SORRY!=== Error while compiling ... Confused. expected statement`
+
+`4.log: 2;` (colon-call with an actual argument) already parses fine in mutsu.
+
+## Root cause guess
+
+The colon-call argument parser (invoked after `.method:`) presumably assumes at least one
+argument token follows the colon and fails/errors when it immediately hits a statement
+terminator, instead of treating a colon-call with nothing after it as equivalent to a
+zero-argument call.
+
+## Affected files (starting point)
+
+- `src/parser/expr/postfix/call_method.rs` (or wherever colon-call argument parsing lives —
+  grep for the colon-call method-argument parsing function)
+
+## Suggested next step
+
+Find the exact parse function invoked right after consuming the `:` in a colon-call and check
+what it does when the next token is a statement terminator (`;`) or closing delimiter instead of
+an argument expression — it should back off to zero args rather than erroring.

--- a/todo/tickets/container-aliasing-not-preserved-into-collection.md
+++ b/todo/tickets/container-aliasing-not-preserved-into-collection.md
@@ -1,0 +1,72 @@
+# A scalar's container isn't aliased when pushed/assigned into a collection without `.item`/`.clone` — mutsu snapshots by value where raku aliases
+
+Discovered via the doc-diff harness on two files, both showing the same shape of divergence:
+`raku-doc/doc/Language/traps.rakudoc` (around line 406) and
+`raku-doc/doc/Language/variables.rakudoc` (around line 853). Filed as one ticket since both
+repros demonstrate the identical underlying behavior.
+
+## Repro 1 (traps.rakudoc:406)
+
+```
+my @arr;
+my ($a, $b) = (1,1);
+for ^5 {
+    ($a,$b) = ($b, $a+$b);
+    @arr.push: ($a.item, $b.item);
+    say @arr
+};
+```
+
+- raku: every previously-pushed entry's displayed value **changes** on each iteration
+  (`[(1 2)]` → `[(2 3) (2 3)]` → `[(3 5) (3 5) (3 5)]` → ...) — i.e. `.item`-ing `$a`/`$b` here
+  still leaves every pushed tuple aliased to the *same* `$a`/`$b` containers, so they all show
+  the latest value (this is presented by the doc as a "trap" / surprising gotcha)
+- mutsu: each entry keeps the value it had *at push time* (`[(1 2)]` → `[(1 2) (2 3)]` → `[(1 2)
+  (2 3) (3 5)]` → ...) — i.e. mutsu's push makes an independent snapshot, so it does NOT
+  reproduce the aliasing trap
+
+## Repro 2 (variables.rakudoc:853)
+
+```
+my @a;
+my @a-cloned;
+sub f() {
+    state $i;
+    $i++;
+    @a       .push: "k$i" => $i;
+    @a-cloned.push: "k$i" => $i.clone;
+};
+f for 1..3;
+say @a;         # raku: [k1 => 3 k2 => 3 k3 => 3]   mutsu: [k1 => 1 k2 => 2 k3 => 3]
+say @a-cloned;  # raku & mutsu agree: [k1 => 1 k2 => 2 k3 => 3]
+```
+
+Same shape: pushing a `Pair` whose value is the *un*-cloned `state $i` scalar should keep every
+pushed entry aliased to the single shared `$i` container (so they all end up showing the final
+value, `3`), while `.clone`-ing breaks the alias and gives the expected independent snapshots
+(both agree on the cloned case). mutsu behaves as if `.clone` were always implied — the uncloned
+case gives the same (non-aliased) result as the cloned case.
+
+## Root cause guess
+
+mutsu's array `.push`/collection-store path (and/or Pair-value construction) always copies a
+scalar's *value* into the new element slot rather than preserving a live reference to the
+original container when the source expression is a bare variable or `.item`-ized scalar without
+an explicit `.clone`. Per raku's actual (if gotcha-prone) semantics, `.item` on a container still
+shares the *same* underlying container — it only prevents auto-flattening in list context, it
+does not imply a copy. This may be the same store-side itemization/container question already
+being tracked architecturally (see `docs/adr/0040-array-hash-elements-are-itemized-at-the-store.md`
+and its follow-up tickets, e.g. `todo/tickets/splice-multi-arg-array-incorrectly-flattens.md`'s
+neighborhood) — worth checking against that ADR before implementing, since "does push alias or
+copy a container" is a core container-semantics question that ADR's itemization work may already
+touch.
+
+## Affected files (starting point)
+
+- `src/runtime/methods_mut_dispatch.rs` — `.push`/array-store implementation
+- `src/value/` — scalar container aliasing vs. value-copy semantics on collection insertion
+
+## Suggested next step
+
+Read `docs/adr/0040-array-hash-elements-are-itemized-at-the-store.md` first to see whether this
+aliasing gap is already in that ADR's scope or is a distinct, pre-existing bug it doesn't cover.

--- a/todo/tickets/control-default-term-expression-position.md
+++ b/todo/tickets/control-default-term-expression-position.md
@@ -1,0 +1,35 @@
+# `default { }` cannot be used as a term nested inside an expression
+
+Discovered via the doc-diff harness on `raku-doc/doc/Language/control.rakudoc` (around line
+854).
+
+## Repro
+
+```
+given 42 {
+    "a".say;
+    $_ == 42 and ( default { "b".say; 43 } );
+    "c".say;
+}
+```
+
+- raku: prints `a` then `b` (the `and`'s short-circuit means `"c".say` is never reached because
+  the `default` block, once entered, exits the enclosing `given`)
+- mutsu: `===SORRY!=== Error while compiling ... Unexpected block in infix position ...`
+
+## Root cause guess
+
+`default { }` is presumably only recognized by the parser/compiler in statement position
+directly inside a `given`/`when` chain, not as a term that can appear nested inside another
+expression (here, as the RHS operand of `and`, itself inside parens).
+
+## Affected files (starting point)
+
+- `src/parser/` — wherever `default`/`when` blocks are parsed as statements vs. terms
+- `src/compiler/stmt.rs` / `src/compiler/expr.rs` — given/when/default compilation
+
+## Suggested next step
+
+Check how `when { }` is parsed when the grammar allows statement-modifier and nested forms
+(e.g. `raku-doc/doc/Language/control.rakudoc`'s other `when`-as-expression examples) and see if
+`default` can share that same term-level parse path.

--- a/todo/tickets/control-do-when-expression-value.md
+++ b/todo/tickets/control-do-when-expression-value.md
@@ -1,0 +1,51 @@
+# `do when COND { BLOCK }` used as an expression gives the wrong value / crashes
+
+Discovered via the doc-diff harness on `raku-doc/doc/Language/control.rakudoc` (around line
+526/537).
+
+## Repro
+
+```
+$_ = True;
+my $a;
+{ $a = do when .so { "foo" } }
+say $a;
+```
+
+- raku: `foo`
+- mutsu: crashes with a bare `Runtime error:` (no useful message)
+
+With the topic not matching:
+
+```
+$_ = False;
+my $a;
+{ $a = do when .so { "foo" } }
+say $a;
+```
+
+- raku: `(Any)` (the `do when` expression evaluates to `Any` when the `when` does not match)
+- mutsu: currently gives an inconsistent result (does not crash but the value is wrong — see
+  investigation notes below); needs re-verification once the crash is fixed.
+
+## Root cause (unconfirmed, needs a debugger session)
+
+`do EXPR` normally just evaluates `EXPR` and returns its value. When `EXPR` is a bare `when`
+statement (`do when COND { BLOCK }`), Raku treats this as an expression form: if `COND` matches
+against `$_`, evaluate `BLOCK` and use its value; otherwise the whole `do when` evaluates to
+`Any`. mutsu's `when` is implemented as a control-flow statement (see `vm_control_ops.rs`) that
+presumably assumes it is always used in statement position inside a `given`/loop body, and
+doesn't have a value-producing path when wrapped in `do`.
+
+## Affected files (starting point)
+
+- `src/compiler/expr.rs` / `src/compiler/stmt.rs` — wherever `do BLOCK`/`do STATEMENT` is
+  compiled, to see how it handles a `when` operand
+- `src/vm/vm_control_ops.rs` — `when` execution
+
+## Suggested next step
+
+Reproduce under `rust-gdb` per the debugging guidelines to find exactly which opcode sequence
+`do when` compiles to and where the crash originates, then decide whether `do when` needs a
+dedicated compiler path that captures the block's value (or `Any` on no-match) instead of
+relying on the statement-position `when` control flow.

--- a/todo/tickets/control-if-modifier-mid-comma-list-parse-fail.md
+++ b/todo/tickets/control-if-modifier-mid-comma-list-parse-fail.md
@@ -1,0 +1,35 @@
+# Statement-modifier `if` in the middle of a parenthesized comma list fails to parse
+
+Discovered via the doc-diff harness on `raku-doc/doc/Language/control.rakudoc` (around line
+263). This is a hard parse failure, distinct from the already-deferred "`and`/`or`/`not`
+word-logical precedence" cluster (that cluster is about word-operator precedence, not
+statement-modifier `if`/`unless`/`for` placement).
+
+## Repro
+
+```
+say (1, 2 if True, 3);
+```
+
+- raku: `(1 2)` — the statement-modifier `if` applies to the whole preceding comma expression
+  (`1, 2`), and `, 3` starts a fresh element... actually per raku's own precedence rules the
+  modifier binds loosely enough that this parses and evaluates to `(1 2)`.
+- mutsu: `===SORRY!=== Confused. expected statement: expected '.' or digits ...` — a hard parse
+  error, not just a wrong value.
+
+## Root cause guess
+
+mutsu's parser for a statement-modifier `if`/`unless`/`for`/`while` inside a parenthesized
+term/comma-list doesn't expect another comma-separated element to follow the modifier's
+condition, and fails to parse rather than mis-evaluating. Likely in the parser's handling of
+`(...)` list parsing when a comma-list element carries a trailing statement modifier.
+
+## Affected files (starting point)
+
+- `src/parser/` — parenthesized list / comma-list parsing, statement-modifier attachment
+
+## Suggested next step
+
+Isolate whether the failure is specific to a modifier mid-list (`(1, 2 if True, 3)`) vs. a
+modifier at the very end (`(1, 2 if True)`, which likely already works) to scope the parser fix
+precisely.

--- a/todo/tickets/control-if-unless-pointy-block-param.md
+++ b/todo/tickets/control-if-unless-pointy-block-param.md
@@ -1,0 +1,33 @@
+# `if`/`unless`/`while` block body rejects a pointy-block parameter
+
+Discovered via the doc-diff harness on `raku-doc/doc/Language/control.rakudoc` (around line
+388).
+
+## Repro
+
+```
+$_ = 1;
+unless 0 -> $_ { $_.say };
+```
+
+- raku: `0` (the pointy-block parameter `$_` shadows the topic, binding to the condition's
+  value)
+- mutsu: `===SORRY!=== Error while compiling ... Missing block ... at -e:1`
+
+## Root cause guess
+
+The parser for `if`/`unless`/`while` (and likely `until`) block bodies only accepts a plain
+`{ ... }` block; it doesn't accept a `-> $param { ... }` signature form on the conditional
+block, even though Raku allows a pointy block there (the condition's value is passed as the
+block's argument, in addition to being available as `.so`/topicalized in some contexts).
+
+## Affected files (starting point)
+
+- `src/parser/` — wherever `if`/`unless`/`while` statement parsing consumes the block body
+  (search for the "Missing block" error message to find the exact call site)
+
+## Suggested next step
+
+Grep the parser for the `if`/`unless` block-parsing function and check whether it calls the
+same block-parsing helper used by `for`/`given` (which already accept pointy-block params), or
+a separate one that needs the same extension.

--- a/todo/tickets/control-nested-when-proceed-skip.md
+++ b/todo/tickets/control-nested-when-proceed-skip.md
@@ -1,0 +1,37 @@
+# `proceed` inside a bare block used with a trailing `when` statement modifier doesn't skip the enclosing `when`
+
+Discovered via the doc-diff harness on `raku-doc/doc/Language/control.rakudoc` (around line
+973).
+
+## Repro
+
+```
+given 42 {
+    when * > 41 {
+        { "A".say; proceed } when * > 41;
+        "B".say;
+    }
+}
+```
+
+- raku: prints `A` only — `proceed` unwinds out of the enclosing `when * > 41 { ... }` block
+  entirely, so `"B".say` is never reached
+- mutsu: prints `A` then `B` — the `proceed` only exits the inner bare block/statement-modifier
+  `when`, not the enclosing `when` block
+
+## Root cause guess
+
+`proceed`'s control-flow target is presumably resolved to "the nearest enclosing `when`/
+`given`", but when the nearest syntactic `when` is a *statement-modifier* form
+(`{ ... } when COND;`) wrapping a bare block, mutsu treats that inner form as the unwind target
+instead of continuing the search outward to the real enclosing `when` block.
+
+## Affected files (starting point)
+
+- `src/vm/vm_control_ops.rs` — given/when/`proceed`/`succeed` handling
+
+## Suggested next step
+
+Compare how mutsu tracks the "current when/given frame" stack for `proceed` to unwind through,
+and check whether a statement-modifier `when` pushes a frame that it shouldn't (or fails to
+delegate to the outer frame when its own block completes).

--- a/todo/tickets/control-race-for-drops-results.md
+++ b/todo/tickets/control-race-for-drops-results.md
@@ -1,0 +1,39 @@
+# `race for` doesn't collect the loop's per-iteration results
+
+Discovered via the doc-diff harness on `raku-doc/doc/Language/control.rakudoc` (around line
+717).
+
+## Repro
+
+```
+my $r = race for ^10 -> $n { $n if $n %% 2 };
+say $r.elems;
+```
+
+- raku: collects the truthy per-iteration values into a list (same count as plain `for`
+  without `race`)
+- mutsu: prints `Useless use of $number in sink context` and `$r.elems` is `1`
+
+Confirmed that plain `for` (no `race`/`hyper` prefix) already collects results correctly in
+mutsu — the bug is specific to the `race`/`hyper` statement-prefix combined with `for` used as
+an expression.
+
+## Root cause guess
+
+The `race`/`hyper` statement-prefix wrapping a `for` loop is not wired into the same
+list-collection / lazy-Seq path that a plain `for`-as-expression uses (see the "lazy-list
+cluster" work in `docs/doc-diff-backlog.md`'s Deferred section, which made bare `for`/`while`/
+`until` expressions lazy Seqs pulled on demand — `race for` looks like it bypasses that path
+entirely and falls back to treating the loop as a sunk statement).
+
+## Affected files (starting point)
+
+- `src/vm/vm_control_ops.rs` — for-loop execution and the race/hyper statement-prefix wiring
+- `src/compiler/stmt.rs` — wherever `race`/`hyper` prefixes are compiled onto a `for`
+
+## Suggested next step
+
+Compare `--dump-ast` for `my $r = for ^10 -> $n { $n if $n %% 2 };` (works) vs. the `race for`
+variant (broken) to see whether the AST/compiled form differs in how the loop's produced value
+is threaded to the assignment, then fix the `race`/`hyper` path to reuse the same collection
+mechanism.

--- a/todo/tickets/control-return-rw-not-mutable.md
+++ b/todo/tickets/control-return-rw-not-mutable.md
@@ -1,0 +1,34 @@
+# `return-rw` doesn't return a mutable container
+
+Discovered via the doc-diff harness on `raku-doc/doc/Language/control.rakudoc` (around line
+1375).
+
+## Repro
+
+```
+sub s() { my $a = 41; return-rw $a }
+say ++s();
+```
+
+- raku: `42` (`return-rw` returns the actual container `$a` is bound to, so `++` can mutate it
+  through the call result)
+- mutsu: `Cannot resolve caller prefix:<++>(...); the parameter requires mutable arguments`
+
+## Root cause guess
+
+`return-rw` is either unimplemented and silently falling back to plain `return`'s by-value
+semantics, or implemented but not preserving the rw/container-binding flag on the returned
+value all the way through the call-return path, so downstream mutation (`++`) sees a
+non-mutable value.
+
+## Affected files (starting point)
+
+- `src/runtime/calls.rs` / `src/vm/vm_call_ops.rs` — return-value handling, `rw` propagation
+- Grep for `"return-rw"` / `ReturnRw` in the parser/compiler/VM to find the current (likely
+  stubbed) implementation
+
+## Suggested next step
+
+Check whether `return-rw` exists at all as a distinct AST/opcode form vs. just being parsed as
+`return`; if it's missing, this needs the same rw-container plumbing that `is rw` return-type
+traits and `sub f() is rw { $a }` already use elsewhere in the codebase.

--- a/todo/tickets/dollar-dot-attr-compound-assign-spurious-ro-error.md
+++ b/todo/tickets/dollar-dot-attr-compound-assign-spurious-ro-error.md
@@ -1,0 +1,48 @@
+# `$.attr *= 2` inside a method throws `X::Assignment::RO` where current raku allows it
+
+Discovered via the doc-diff harness on `raku-doc/doc/Language/traps.rakudoc` (around line 212).
+Note the doc's own `# OUTPUT:` comment is stale here (it says the trap *should* throw
+"Cannot assign to an immutable value") — but re-verified directly, current `raku` does NOT
+throw; it silently returns the original unmodified value. So the real, current-raku-verified
+bug is that mutsu throws where raku doesn't (the doc's comment is drift, the underlying
+behavior mismatch is real).
+
+## Repro
+
+```
+class Point {
+    has $.x;
+    has $.y;
+    method double {
+        $.x *= 2;
+        $.y *= 2;
+        self;
+    }
+}
+say Point.new(x => 1, y => -2).double.x
+```
+
+- raku: `1` (no exception — `$.x *= 2` inside the method silently doesn't mutate the read-only
+  accessor-backed attribute, and execution continues past it)
+- mutsu: throws `X::Assignment::RO: method 'x' is not rw`, so the whole program aborts with exit
+  1
+
+## Root cause guess
+
+`$.x` inside a method is sugar for `self.x` (a method call through the public accessor), which
+is read-only by default (no `is rw` on the attribute). raku evidently treats a compound-assign
+(`*=`) through this read-only accessor as a silent no-op rather than a hard error, while mutsu's
+compound-assign path raises `X::Assignment::RO`. This may be intentional in mutsu (arguably
+"more correct"), but it diverges from raku's actual observed behavior.
+
+## Affected files (starting point)
+
+- `src/vm/vm_arith_ops.rs` / wherever compound-assignment operators (`*=`, `+=`, etc.) check
+  target mutability for a `$.attr`-sugar method-call target
+
+## Suggested next step
+
+Confirm this exact behavior (no throw, silent no-op) is stable across a few raku point releases
+before changing mutsu — if it's itself considered a raku bug/quirk that may get fixed upstream,
+weigh whether matching it is worth the compatibility churn versus just documenting the
+divergence.

--- a/todo/tickets/dollar-plusplus-state-scope-in-interpolated-block.md
+++ b/todo/tickets/dollar-plusplus-state-scope-in-interpolated-block.md
@@ -1,0 +1,42 @@
+# `$++` inside a string-interpolated `{...}` block doesn't reset per call the way raku's does
+
+Discovered via the doc-diff harness on `raku-doc/doc/Language/traps.rakudoc` (around line 91).
+This is one of the doc's actual "traps" — the surprising behavior IS the documented correct
+one.
+
+## Repro
+
+```
+sub count-it { say "Count is {$++}" }
+count-it;
+count-it;
+```
+
+- raku: `Count is 0` / `Count is 0` (the interpolated `{$++}` block is compiled once (it's the
+  same source location every call), so its implicit `state`-like counter is tied to that single
+  compiled closure/block object, not to the enclosing sub's call count — this is the documented
+  "trap": naively you'd expect it to increment, but it doesn't)
+- mutsu: `Count is 0` / `Count is 1` — mutsu's `$++` *does* increment across calls, meaning it
+  doesn't reproduce raku's actual (surprising) per-block-instance scoping
+
+## Root cause guess
+
+`$++` is sugar for an implicitly-`state`-scoped auto-incrementing counter tied to its specific
+source location. Inside a string-interpolated `{...}` block, raku apparently ties that state to
+the block's *one-time compilation* in a way that makes it stable/shared appropriately, while
+mutsu's implementation likely just uses a per-call-frame or globally-persistent state slot keyed
+differently than raku's actual semantics.
+
+## Affected files (starting point)
+
+- `src/compiler/` / `src/runtime/` — `$++`/`$--` implicit state-variable implementation, and how
+  it interacts with string-interpolated embedded blocks specifically (as opposed to `$++` used
+  directly in a sub body, which may already behave differently — worth checking as a control
+  case)
+
+## Suggested next step
+
+Check whether `sub count-it { state $c; say "Count is {$c++}" }` (an explicit outer `state`, not
+`$++`) already gives the "expected" incrementing behavior in mutsu — if so, the bug is
+specifically in how `$++`'s implicit state binds to an embedded interpolation block vs. a
+directly-written sub body.

--- a/todo/tickets/dollar-question-file-relative-not-absolute.md
+++ b/todo/tickets/dollar-question-file-relative-not-absolute.md
@@ -1,0 +1,35 @@
+# `$?FILE` reports the relative invocation path instead of an absolute path
+
+Discovered via the doc-diff harness on `raku-doc/doc/Language/variables.rakudoc` (around line
+318).
+
+## Repro
+
+```
+say "$?FILE: $?LINE";
+```
+
+Run as `raku tmp/t1.raku` vs. `target/debug/mutsu tmp/t1.raku` from the same working directory:
+
+- raku: `/absolute/path/to/tmp/t1.raku: 1`
+- mutsu: `tmp/t1.raku: 1`
+
+`$?FILE` is a compile-time constant naming the source file being compiled; raku resolves it to
+an absolute path regardless of how the file was invoked on the command line, while mutsu keeps
+whatever path string was passed on the command line verbatim.
+
+## Root cause guess
+
+Wherever `$?FILE` is populated at parse/compile time, mutsu likely stores the raw CLI argument
+path instead of canonicalizing it (e.g. via `std::fs::canonicalize` or similar) the way raku
+does.
+
+## Affected files (starting point)
+
+- `src/main.rs` / `src/parser/` — wherever the source file path is captured and bound to
+  `$?FILE`
+
+## Priority note
+
+Low-priority/cosmetic — this only affects diagnostic output, not program semantics — but simple
+enough to fix opportunistically.

--- a/todo/tickets/dollar-raku-wrong-metaclass-and-stringify.md
+++ b/todo/tickets/dollar-raku-wrong-metaclass-and-stringify.md
@@ -1,0 +1,35 @@
+# `$*RAKU` reports the wrong metaclass name (`Perl` instead of `Raku`) and inconsistent stringification
+
+Discovered via the doc-diff harness on `raku-doc/doc/Language/variables.rakudoc` (around line
+1765).
+
+## Repro
+
+```
+$*RAKU.put;
+say $*RAKU.^name;
+say $*RAKU;
+```
+
+- raku: `$*RAKU.put` prints `Raku`
+- mutsu: `$*RAKU.put` prints `Perl()`; `$*RAKU.^name` is `Perl` (should be `Raku`); plain
+  `say $*RAKU` gives `Raku (6.d)` — inconsistent with both of the above, which still reference
+  the legacy `Perl` name
+
+## Root cause guess
+
+`$*RAKU`'s underlying type is presumably still named/tagged internally as `Perl` (a pre-rename
+leftover — the compiler identity object was called `Perl` before the Perl-6-to-Raku rename), and
+only some of its stringification paths (`.gist` used by plain `say`) were updated to say "Raku"
+while `.^name` and `.put`/`.Str` still reference the old internal type name and produce an
+inconsistent `Perl()` render.
+
+## Affected files (starting point)
+
+- `src/runtime/` — wherever `$*RAKU`'s backing type/class is registered (grep for `"Perl"` as a
+  class/type name in the compiler-identity object's registration)
+
+## Suggested next step
+
+Grep the codebase for the literal type name `"Perl"` used for this compiler-identity object and
+rename it to `"Raku"` consistently, then verify `.^name`/`.put`/`.Str`/`say` all agree.

--- a/todo/tickets/enum-does-role-accepts-not-dispatched.md
+++ b/todo/tickets/enum-does-role-accepts-not-dispatched.md
@@ -1,0 +1,39 @@
+# `enum ... does SomeRole` — the role's overriding `ACCEPTS` is never dispatched by `~~`, plus a spurious warning
+
+Discovered via the doc-diff harness on `raku-doc/doc/Language/typesystem.rakudoc` (around line
+846).
+
+## Repro
+
+```
+role Weird { multi method ACCEPTS(Int:D $v) { True } }
+enum Flags does Weird (A => 1, B => 2);
+say 5 ~~ A;
+```
+
+- raku: `True`
+- mutsu: `False`, plus a spurious `Useless use of '=>' in expression...` warning that does not
+  appear for a plain `enum Flags (...)` without `does`.
+
+## Root cause guess
+
+Two related bugs:
+1. `enum ... does Role` composes the role's methods onto the enum type, but `~~` smart-match
+   dispatch on an enum value apparently always uses the built-in enum `ACCEPTS` semantics
+   instead of checking for (and preferring) a role-supplied `multi method ACCEPTS` override.
+2. The parser misinterprets the enum pair-list `(A => 1, B => 2)` differently when a `does
+   Role` clause precedes it, producing the spurious `Useless use of '=>'` warning — suggests the
+   `does Role (...)` form parses the parenthesized pair-list as a plain expression/argument list
+   rather than the enum's value list.
+
+## Affected files (starting point)
+
+- `src/parser/` — `enum ... does Role (...)` declaration parsing
+- `src/vm/vm_smart_match.rs` or wherever `~~` dispatch checks for a user-defined `ACCEPTS`
+  before falling back to type/enum built-in matching
+
+## Suggested next step
+
+First isolate the parse-warning bug alone (`enum Flags does Weird (A => 1, B => 2);` with a
+`Weird` that does *not* override `ACCEPTS` — does the warning still appear?) to determine if it's
+independent of the ACCEPTS-dispatch bug or caused by the same misparse.

--- a/todo/tickets/flatten-hyper-prefix-parse-error.md
+++ b/todo/tickets/flatten-hyper-prefix-parse-error.md
@@ -1,0 +1,32 @@
+# `|«@array` (flatten + hyper prefix combined) fails to parse
+
+Discovered via the doc-diff harness on `raku-doc/doc/Language/traps.rakudoc` (around line 1948).
+
+## Repro
+
+```
+my @chunks;
+say Blob.new: |«@chunks;
+```
+
+- raku: `Blob:0x<>` (parses fine; `|«` here means something like "flatten, hyper-applied" as an
+  argument-list prefix)
+- mutsu: `===SORRY!=== Error while compiling ... Confused. expected statement: expected '.' or
+  digits or generic radix literal or unicode numeric literal or declared term symbol or ...`
+
+## Root cause guess
+
+The parser's argument-list prefix operators presumably recognize `|` (flatten) and `«...»`
+(hyper) separately, but not the combined `|«` sequence as a single valid prefix token/operator
+in this position.
+
+## Affected files (starting point)
+
+- `src/parser/` — argument-list prefix parsing (`|`, slurpy-flatten operators)
+
+## Suggested next step
+
+Check `raku-doc/doc/Language/operators.rakudoc` for how `|«`/`|»` are documented (if at all) to
+confirm the exact intended semantics before implementing — this may be a rarely-used corner of
+the flatten-prefix family worth double-checking against `raku -e` with a few more variations
+(`|@chunks`, `«@chunks`, `|«@chunks`) to scope exactly what's missing.

--- a/todo/tickets/for-loop-over-smartmatch-result-executes-unexpectedly.md
+++ b/todo/tickets/for-loop-over-smartmatch-result-executes-unexpectedly.md
@@ -1,0 +1,35 @@
+# `for EXPR ~~ /regex/ { BLOCK }` executes `BLOCK` where raku produces no output
+
+Discovered via the doc-diff harness on `raku-doc/doc/Language/traps.rakudoc` (around line 1067).
+
+## Repro
+
+```
+if  'x' ~~ /./ { say 'yes' }
+for 'x' ~~ /./ { say 'yes' }
+```
+
+- raku: `yes` (from the `if` only — the `for` line produces no output at all)
+- mutsu: `yes` / `yes` (both the `if` and the `for` print)
+
+## Notes / possible explanation
+
+This is filed as a doc-diff finding without a confirmed root-cause mechanism — worth
+investigating from scratch. One hypothesis: `for` binds its trailing `{ BLOCK }` differently than
+`if` when the loop-source expression itself ends in a regex match (`~~ /./`) — e.g. if raku's
+grammar parses the block as part of the smart-match's RHS rather than as the `for`-loop's body in
+this specific construct, the `for` statement would have no body to execute, producing the
+observed "no output." Needs a `--target=ast`/AST-shape comparison between the `if` and `for`
+forms in real raku to confirm before assuming the same about mutsu's parser.
+
+## Affected files (starting point)
+
+- `src/parser/` — `for`-loop body/source-expression parsing when the source ends in a
+  regex-match expression
+- Compare against `raku --target=ast` for both the `if` and `for` variants
+
+## Suggested next step
+
+Get raku's AST for `for 'x' ~~ /./ { say 'yes' }` (`raku --target=ast -e '...'`) to see whether
+the block truly isn't attached as the for-loop's body, then compare with
+`timeout 30 target/debug/mutsu --dump-ast` for the same snippet.

--- a/todo/tickets/forward-declared-role-stub-not-upgraded.md
+++ b/todo/tickets/forward-declared-role-stub-not-upgraded.md
@@ -1,0 +1,48 @@
+# A forward-declared role stub (`role R {...}`) used by another role is never upgraded to its real body
+
+Discovered via the doc-diff harness on `raku-doc/doc/Language/typesystem.rakudoc` (around line
+611).
+
+## Repro
+
+```
+role R2 {...};
+role R1 does R2 {};
+role R2 {};
+class C does R1 {};
+say [C ~~ R1, C ~~ R2];
+```
+
+- raku: `[True True]`
+- mutsu: errors with "No matching candidate found for the parametric role"
+
+## Relationship to the existing deferred "Forward-declaration stub upgrade" cluster
+
+`docs/doc-diff-backlog.md`'s Deferred section already tracks a **"Forward-declaration stub
+upgrade"** cluster, but it is scoped explicitly to `sub` stubs (`sub a() {...}; say a; sub a()
+{42}`). This finding is the same forward-declare/stub-upgrade idea applied to `role` declarations
+instead of `sub` — a distinct code path (role registration vs. sub registration), so it's filed
+as its own ticket rather than folded into that sub-scoped cluster. The two probably share a
+common underlying design question (how mutsu's hoist pass handles a `{...}` yada-stub being
+superseded by a later real definition) and may be worth solving together once someone picks
+either one up.
+
+## Root cause guess
+
+`role R2 {...}` registers a stub role; `role R1 does R2 {}` composes against that stub; the later
+`role R2 {}` real definition presumably doesn't retroactively update `R1`'s already-composed
+role-list/MRO, so when `C does R1` is later checked against `R2`, it's checking against the
+stale stub rather than the real (empty but valid) `R2`.
+
+## Affected files (starting point)
+
+- `src/runtime/class.rs` / `src/runtime/registration_role.rs` (or equivalent) — role stub
+  registration and later upgrade
+- Whatever emits "No matching candidate found for the parametric role" — grep for that exact
+  message to find the composition-time role-resolution code
+
+## Suggested next step
+
+Check how `sub`'s stub-upgrade fix (once implemented, per the existing deferred cluster) handles
+the hoist-pass + inline-pass double-registration problem, and see whether the same design applies
+to `role`'s registration path.

--- a/todo/tickets/grammar-failgoal-not-invoked.md
+++ b/todo/tickets/grammar-failgoal-not-invoked.md
@@ -1,0 +1,39 @@
+# A grammar's `FAILGOAL` method isn't invoked when a goal-matching conjunction (`~`) fails
+
+Discovered via the doc-diff harness on `raku-doc/doc/Language/regexes.rakudoc` (around line
+2892).
+
+## Repro
+
+```
+grammar A {
+    token TOP { '[' ~ ']' \w+ };
+    method FAILGOAL($goal) {
+        die "Cannot find $goal near position {self.pos}"
+    }
+}
+say A.parse: '[good]';
+A.parse: '[bad';
+CATCH { default { put .^name, ': ', .Str } };
+```
+
+- raku: `｢[good]｣` then (on the failing parse) `X::AdHoc: Cannot find ']'  near position 4`
+- mutsu: `｢[good]｣` then nothing — the failing `A.parse: '[bad'` produces no output and no
+  exception is caught (the `CATCH` block presumably never fires because nothing was thrown)
+
+`'[' ~ ']' \w+` is the goal-matching conjunction form (`OPENER ~ CLOSER MIDDLE`): when the
+closer `]` can't be found, Raku is supposed to call the grammar's `FAILGOAL` method (if defined)
+instead of just failing silently, so the user can customize the failure (here, `die`-ing with a
+custom message).
+
+## Root cause guess
+
+The goal-matching conjunction operator (`~` inside a regex/token) likely already handles the
+successful-match case, but doesn't check for (or call) a user-defined `FAILGOAL` method on parse
+failure — it probably just returns/fails silently the way a normal non-conjunction match failure
+would.
+
+## Affected files (starting point)
+
+- `src/runtime/regex.rs` — goal-matching conjunction (`~`) implementation, grammar method
+  dispatch on match failure

--- a/todo/tickets/grammar-ws-boundary-and-vertical-whitespace.md
+++ b/todo/tickets/grammar-ws-boundary-and-vertical-whitespace.md
@@ -1,0 +1,44 @@
+# A custom grammar's `ws` token override doesn't match per raku's whitespace-boundary rules
+
+Discovered via the doc-diff harness on `raku-doc/doc/Language/regexes.rakudoc` (around line
+2623).
+
+## Repro
+
+```
+grammar Demo {
+    token ws {
+        <!ww>       # only match when not within a word
+        \h*         # only match horizontal whitespace
+    }
+    rule TOP {
+        a b '.'
+    }
+}
+say so Demo.parse("ab.");    # False (no ws required between a and b)
+say so Demo.parse("a b.");   # True
+say so Demo.parse("a\tb .");  # True
+say so Demo.parse("a\tb\n.");  # False (\n is vertical whitespace, ws requires only \h)
+```
+
+- raku: `False` / `True` / `True` / `False`
+- mutsu: `False` / `False` / `False` / `False` — every case requiring the custom `ws` token to
+  actually match whitespace between `a` and `b` fails
+
+## Root cause guess
+
+Either the custom `ws` token override isn't being consulted by the implicit whitespace-skipping
+that `rule` (as opposed to `token`) inserts between adjacent atoms, or the `<!ww>` word-boundary
+assertion inside the custom `ws` itself is misbehaving, causing the whole `ws` to never match.
+
+## Affected files (starting point)
+
+- `src/runtime/regex.rs` / grammar `rule`-vs-`token` implicit whitespace handling — check where a
+  user-defined `ws` token is looked up and invoked between atoms in a `rule`
+- `<!ww>` word-boundary assertion implementation
+
+## Suggested next step
+
+Isolate further: does a *plain* custom `ws { \h* }` (no `<!ww>`) already work for the `rule TOP {
+a b '.' }` case? That would narrow the bug to `<!ww>` specifically rather than custom-`ws`
+dispatch in general.

--- a/todo/tickets/hash-default-role-mixin-dropped.md
+++ b/todo/tickets/hash-default-role-mixin-dropped.md
@@ -1,0 +1,41 @@
+# `is default(0 but role :: {...})` on a typed Hash drops the role mixin on the default value
+
+Discovered via the doc-diff harness on `raku-doc/doc/Language/objects.rakudoc` (around line
+1526).
+
+## Repro
+
+```
+my %seen of Int is default(0 but role :: { method Str() {"NULL"} });
+say %seen<not-there>;
+```
+
+- raku: `NULL`
+- mutsu: `0` — the role mixin on the default value is not applied when the default is returned
+  for a missing key
+
+## Root cause guess
+
+The Hash's `is default(...)` value is presumably stored/cloned in a way that only keeps the
+"plain" `Int` payload and drops the mixed-in anonymous role, so every miss-lookup returns the
+un-mixed base value instead of the `but`-mixed one.
+
+**Possibly the same underlying root cause as**
+[list-but-role-loses-positional-binding.md](list-but-role-loses-positional-binding.md) and
+[role-mixed-value-gist-skipped-in-array.md](role-mixed-value-gist-skipped-in-array.md) — see
+that ticket's note on the shared hypothesis. Filed separately because each has a distinct
+minimal repro; investigate together and merge into one PR if a single fix site is found.
+
+## Affected files (starting point)
+
+- `src/runtime/class.rs` / wherever `is default(...)` trait values are stored on a typed Hash
+- Hash miss-lookup path (returns the default value) — check whether it clones the stored default
+  Value directly or reconstructs a fresh one from a type-erased representation
+
+## Suggested next step
+
+Check whether the default value, once stored on the Hash's type metadata, still carries its
+mixin flag/role-list when read back via `%h<missing-key>` — compare to a directly-read
+`$x = 0 but role :: {...}; say $x;` case (which works — see the `role-mixed-value-gist-skipped-in-array`
+ticket's repro) to see where the mixin info is lost specifically on the Hash-default storage
+path.

--- a/todo/tickets/hyper-call-block-self-reference-empty-method.md
+++ b/todo/tickets/hyper-call-block-self-reference-empty-method.md
@@ -1,0 +1,41 @@
+# `».&?BLOCK` (hyper-call with a block self-reference) dispatches an empty method name instead of calling the block
+
+Discovered via the doc-diff harness on `raku-doc/doc/Language/variables.rakudoc` (around line
+1551).
+
+## Repro
+
+```
+for 'tmp/ddhtest' {
+    .Str.say when !.IO.d;
+    .IO.dir()».&?BLOCK when .IO.d
+}
+```
+
+(with `tmp/ddhtest/` containing a subdirectory holding one file, so the block recurses once)
+
+- raku: prints the file's path (`tmp/ddhtest/sub1/file.txt`) — `&?BLOCK` refers to the
+  currently-executing block, and `».&?BLOCK` hyper-calls it recursively over each directory
+  entry
+- mutsu: `No such method '' for invocant of type 'IO::Path'` — the hyper-call `».&NAME` syntax
+  with `&?BLOCK` as the "method" seems to be parsed/dispatched as a method call with an **empty**
+  method name, rather than recognizing `&?BLOCK` as a callable to invoke on each hyper'd element.
+
+## Root cause guess
+
+`».&EXPR` (hyper meta-op combined with the `&`-sigil "call this Callable as a method" syntax) is
+presumably implemented for a named sub (`».&some-sub`) but the parser/compiler doesn't recognize
+`&?BLOCK` (the "current block" pseudo-variable) in that position, and instead falls through to
+a plain method-call path with an empty name extracted.
+
+## Affected files (starting point)
+
+- `src/parser/` / `src/compiler/expr.rs` — `».&EXPR` hyper meta-op parsing, specifically the
+  `&?BLOCK` pseudo-variable case
+- `src/vm/vm_call_ops.rs` — hyper method-call dispatch
+
+## Suggested next step
+
+Check whether a *named* sub already works in this position (`».&some-named-sub`) to confirm the
+bug is specific to `&?BLOCK` (or more broadly, any pseudo-variable / non-identifier expression)
+rather than the whole `».&EXPR` mechanism being broken.

--- a/todo/tickets/iopath-filetest-smartmatch-wrong-permission-check.md
+++ b/todo/tickets/iopath-filetest-smartmatch-wrong-permission-check.md
@@ -1,0 +1,38 @@
+# `IO::Path ~~ :w`/`:r`/`:x` smart-match ignores effective (per-user) permission
+
+Discovered via the doc-diff harness on `raku-doc/doc/Type/IO/Path.rakudoc` (around line 561).
+
+## Repro
+
+As a non-root user, where `/` is mode `755` and owned by `root`:
+
+```
+say '/'.IO ~~ :w;
+```
+
+- raku: `False` (the current user cannot actually write to `/`)
+- mutsu: `True`
+
+Confirmed the plain `.w` **method** is already correct: `'/'.IO.w` gives `False` in both raku
+and mutsu. The bug is specific to the `~~ :w` smart-match dispatch path.
+
+## Root cause (confirmed)
+
+`src/vm/vm_smart_match.rs`, `io_path_file_test_result()` — the `"w"`/`"r"`/`"x"` arms check the
+raw mode bits (e.g. `mode & 0o222 != 0`, true if **any** of owner/group/other has the write bit
+set) instead of performing an actual effective-access check for the current user. The correct
+logic already exists and is used by the `.w`/`.r`/`.x` *methods* via `libc::access()` in
+`src/runtime/native_io/helpers.rs:64` — the smart-match path duplicates the file-test logic
+independently instead of delegating to the same helper.
+
+## Suggested fix
+
+Have `io_path_file_test_result()` in `src/vm/vm_smart_match.rs` call the same `libc::access()`
+based helper that `src/runtime/native_io/helpers.rs:64` already uses for `.w`/`.r`/`.x`, instead
+of re-deriving the answer from raw mode bits.
+
+## Suggested test
+
+A regression test needs a file/dir with a mode that has the bit set for some class other than
+the current effective user (e.g. a `chmod`-created file the test creates and owns, checked
+against `:w` after `chmod 0o444`), verified against raku's actual `access()`-based semantics.

--- a/todo/tickets/iopath-win32-separator-normalization.md
+++ b/todo/tickets/iopath-win32-separator-normalization.md
@@ -1,0 +1,43 @@
+# `IO::Path::Win32` inconsistently normalizes `/` vs `\` separators
+
+Discovered via the doc-diff harness on `raku-doc/doc/Type/IO/Path.rakudoc` (around lines 128,
+290, 423).
+
+## Repros
+
+```
+IO::Path::Win32.new('//server/share').basename.say;
+```
+- raku: `\`
+- mutsu: `/`
+
+```
+IO::Path::Win32.new("C:\foo/bar\").say;
+```
+- raku: round-trips the trailing `\` — `"C:\foo/bar\".IO`
+- mutsu: normalizes it to `"C:\foo\bar".IO` (drops/changes the trailing separator)
+
+```
+IO::Path::Win32.new('C:/').parent.say;
+```
+- raku: `"C:/".IO` (preserves the `/` the caller used)
+- mutsu: `"C:\".IO` (normalizes to `\`)
+
+## Root cause guess
+
+`IO::Path::Win32`'s basename/parent/`.Str` computation doesn't consistently thread the Win32
+`SPEC`'s separator preference through every code path — some operations hardcode `/`, others
+normalize to `\`, and raku's actual behavior is to largely preserve whichever separator the
+caller originally used rather than aggressively normalizing.
+
+## Affected files (starting point)
+
+- `src/runtime/native_io/path_spec.rs` — `io_path_parts`, `io_path_sep`, basename/dirname/parent
+  computation for the Win32 spec
+
+## Suggested next step
+
+Read `raku-doc/doc/Type/IO/Spec/Win32.rakudoc` (also flagged with divergences in the backlog
+survey) for the documented separator/normalization rules, then audit every place
+`path_spec.rs` hardcodes `'/'` or `'\\'` instead of consulting the path's original separator or
+the spec's canonical one consistently.

--- a/todo/tickets/list-but-role-loses-positional-binding.md
+++ b/todo/tickets/list-but-role-loses-positional-binding.md
@@ -1,0 +1,44 @@
+# `but`-mixing a role onto a `List` breaks its `Positional` binding
+
+Discovered via the doc-diff harness on `raku-doc/doc/Language/objects.rakudoc` (around line
+1457).
+
+## Repro
+
+```
+role R { method Str() {'hidden!'} };
+my @positional := <a b> but R;
+say @positional.^name;
+```
+
+- raku: `List+{R}`
+- mutsu: `Type check failed in binding; expected Positional but got List`
+
+## Root cause guess
+
+`but`-mixing a role onto a `List` value should produce a value that both keeps its `Positional`
+role (so `@`-sigil binding still type-checks) and gains the mixed-in role's methods. mutsu's
+`but`-mixin path for a `List` likely wraps/replaces the value in a way that its `Positional`-ness
+is no longer visible to the binding type-check, even though the underlying data is still
+list-shaped.
+
+**Possibly the same underlying root cause as** [hash-default-role-mixin-dropped.md](hash-default-role-mixin-dropped.md)
+and [role-mixed-value-gist-skipped-in-array.md](role-mixed-value-gist-skipped-in-array.md) — all
+three involve a `but`/`does`-mixed value's role metadata not surviving a generic storage/dispatch
+path (binding type-check here, hash default-value storage there, array-element gisting there).
+Filed as separate tickets since each has a distinct minimal repro and it isn't yet confirmed they
+share one fix site, but worth investigating together — if a single root cause is found, merge
+these into one PR.
+
+## Affected files (starting point)
+
+- `src/vm/vm_var_ops.rs` / wherever `:=` binding does its `Positional` type-check
+- `src/runtime/mixin.rs` (or wherever `but`/`does` role-mixing on a `List`/Array value is
+  implemented)
+
+## Suggested next step
+
+Check what `<a b> but R` actually produces (`--dump-ast` plus a direct `.^name`/`.WHAT` check
+without going through the `:=` binding) to see whether the mixed value itself lost its
+`Positional` role, or whether it's specifically the binding type-check that fails to recognize
+it.

--- a/todo/tickets/multi-inheritance-attribute-gist-order.md
+++ b/todo/tickets/multi-inheritance-attribute-gist-order.md
@@ -1,0 +1,39 @@
+# Attribute order in a `.new`/gist under multiple inheritance is wrong (deterministic, not hash-order noise)
+
+Discovered via the doc-diff harness on `raku-doc/doc/Language/objects.rakudoc` (around line
+1185).
+
+## Repro
+
+```
+class Bull { has Bool $.castrated = False; }
+class Automobile { has $.direction; }
+class Taurus is Bull is Automobile { }
+say Taurus.new;
+```
+
+- raku: `Taurus.new(castrated => Bool::False, direction => Any)`
+- mutsu: `Taurus.new(direction => Any, castrated => Bool::False)`
+
+Confirmed deterministic across 3 repeated runs — this is not hash-iteration-order noise.
+Attribute order in a gist should follow MRO/declaration order (parents in linearization order,
+each parent's own attributes in declaration order), and mutsu has the two parents' attribute
+groups swapped.
+
+## Root cause guess
+
+Wherever mutsu assembles an instance's attribute list for `.gist`/default stringification under
+multiple inheritance (`is Bull is Automobile`), it's likely iterating parents in reverse MRO
+order, or building the attribute list by walking the class hierarchy in a different direction
+than the C3 linearization used elsewhere for method dispatch.
+
+## Affected files (starting point)
+
+- `src/runtime/class.rs` — attribute-list assembly for multi-inheritance classes, `class_mro`
+- Wherever `.gist`/default `Instance` stringification enumerates attributes
+
+## Suggested next step
+
+Check whether `class_mro(Taurus)` itself returns `[Taurus, Bull, Automobile, ...]` in the
+correct order, then check if the gist-attribute-collection code walks that MRO list forwards or
+backwards (or uses a separate, differently-ordered mechanism entirely).

--- a/todo/tickets/parametric-role-self-referential-attribute-typecheck.md
+++ b/todo/tickets/parametric-role-self-referential-attribute-typecheck.md
@@ -1,0 +1,49 @@
+# A parameterized role with a self-referential attribute type fails a spurious type-check, with a malformed error message
+
+Discovered via the doc-diff harness on `raku-doc/doc/Language/objects.rakudoc` (around line
+1397).
+
+## Repro
+
+```
+role Box[::Type] {
+    has Box[Type] $.child;
+    has Type $.val;
+}
+my $b = Box[Int].new(val => 1);
+say $b.^name;
+```
+
+- raku: `Box[Int]`
+- mutsu: `Type check failed in assignment to $!child; expected Box[Int]::Box[Int] but got
+  Box[Type] (Box[Type])`
+
+Note the malformed doubled type name in the error text itself (`Box[Int]::Box[Int]`) — a strong
+clue that the parametric-role instantiation is being applied twice (or concatenated instead of
+substituted) when computing the expected type for the self-referential `has Box[Type] $.child`
+attribute. Also note `$.child` is never assigned in the repro (it defaults to its type), so this
+type-check shouldn't even fire for an unset attribute.
+
+## Root cause guess
+
+Two candidate bugs, possibly both present:
+1. The default (unset) value of a typed attribute is being type-checked against the
+   *parameterized* attribute type at all — Raku shouldn't type-check an attribute against its
+   declared type when it's simply left at its default/undefined value.
+2. The parametric-role attribute type `Box[Type]` (self-referential, `Type` bound to the *same*
+   role's own parameter) resolves to a malformed/duplicated type name (`Box[Int]::Box[Int]`)
+   instead of `Box[Int]`, suggesting the role-parameter substitution runs twice or concatenates
+   the outer instantiation's name onto the inner one.
+
+## Affected files (starting point)
+
+- `src/runtime/class.rs` — parametric role instantiation / type substitution
+- Wherever attribute type-checking happens on `.new` (look for where the malformed
+  `ClassName::ClassName` string could be constructed — likely a role-parameterization
+  name-building helper called twice)
+
+## Suggested next step
+
+Grep for how a parametric role's type name is built during instantiation
+(`Box[Int]`-style formatting) and trace why the self-referential `has Box[Type] $.child`
+attribute's expected-type string ends up doubled.

--- a/todo/tickets/paren-single-var-decl-var-scalar-name.md
+++ b/todo/tickets/paren-single-var-decl-var-scalar-name.md
@@ -1,0 +1,36 @@
+# `my ($g) = LIST;` gives `$g.VAR.^name` of `Int` instead of `Scalar`
+
+Discovered via the doc-diff harness on `raku-doc/doc/Language/variables.rakudoc` (around line
+134). The harness auto-bucketed this as `raku-drift-from-doc`, but re-verified directly with
+`raku -e` — this is NOT drift, it's a real mismatch (the harness's drift heuristic misfired,
+likely due to the doc's multi-statement OUTPUT block formatting).
+
+## Repro
+
+```
+my ($g) = 7,8,9;
+say $g;
+say ( ($g) ).VAR.^name
+```
+
+- raku: `7` then `Scalar`
+- mutsu: `7` then `Int`
+
+`my ($g) = LIST;` is documented special syntax: parenthesizing a single variable in a `my`
+declaration makes it a "list assignment to a List with one element" (as opposed to plain
+`my $g = LIST;`, which would take just the first value in scalar context) — but the variable
+`$g` itself should still be an ordinary `Scalar` container afterward, holding the value `7`. In
+mutsu, `$g` ends up literally *being* the bare `Int` `7` (no `Scalar` container wrapper).
+
+## Root cause guess
+
+The parenthesized-single-variable declaration form (`my ($g) = ...`) likely takes a shortcut that
+directly stores the extracted list-assignment value without wrapping it in a proper `Scalar`
+container the way the ordinary `my $g = ...` declaration path does.
+
+## Affected files (starting point)
+
+- `src/compiler/` — `my (...)` destructuring-declaration compilation, specifically the
+  single-variable-in-parens special case
+- Compare to how `my $g = 7,8,9;` (no parens, which raku documents as scalar-context assignment
+  taking a different value) wraps its target in a `Scalar` container correctly

--- a/todo/tickets/paren-statement-list-trailing-empty-element.md
+++ b/todo/tickets/paren-statement-list-trailing-empty-element.md
@@ -1,0 +1,35 @@
+# A parenthesized `;`-separated statement list drops its trailing empty-statement element
+
+Discovered via the doc-diff harness on `raku-doc/doc/Language/list.rakudoc` (around line 54).
+
+## Repro
+
+```
+say('foo';);
+```
+
+- raku: `(foo)()` — the list has 2 elements: `"foo"` and the empty list `()` produced by the
+  trailing empty statement after the last `;`
+- mutsu: `(foo)` — only 1 element
+
+Confirmed via `--dump-ast`: mutsu compiles `('foo';)` to `ArrayLiteral([Literal(Str("foo"))])`,
+silently dropping the value of the trailing empty statement.
+
+## Root cause guess
+
+The parenthesized statement-list-to-list compiler/parser path (`(...)` containing `;`-separated
+statements, evaluated as a list of each statement's value) doesn't emit a value for a trailing
+empty statement — likely because an empty statement (nothing between the last `;` and the
+closing `)`) isn't represented as an AST node at all, so there's nothing to compile into a list
+element.
+
+## Affected files (starting point)
+
+- `src/parser/` — parenthesized statement-list parsing
+- `src/compiler/expr.rs` — compiling a statement-list term into a list value
+
+## Suggested next step
+
+Check whether the parser needs to synthesize an explicit "empty statement → empty list" node
+when it sees a trailing `;` with no following statement inside `(...)`, mirroring how a bare
+`;` mid-list already must produce *some* statement boundary.

--- a/todo/tickets/regex-capture-numbering-across-alternation.md
+++ b/todo/tickets/regex-capture-numbering-across-alternation.md
@@ -1,0 +1,32 @@
+# Capture group numbering across an alternation branch is wrong
+
+Discovered via the doc-diff harness on `raku-doc/doc/Language/regexes.rakudoc` (around line
+1543).
+
+## Repro
+
+```
+if 'abcd' ~~ / a [ b (.) || (x) (y) ] (.) / {
+    #                 $0     $0  $1    $2
+    say ~$2;
+}
+```
+
+- raku: `d` (the trailing `(.)` after the alternation group is capture number 2, since the first
+  alternation branch `b (.)` contributes one capture (`$0`) and the second branch `(x) (y)`
+  contributes two (`$0`, `$1`), so the numbering continues from the alternation's *maximum*
+  branch-capture-count)
+- mutsu: empty (`$2` doesn't hold `d`)
+
+## Root cause guess
+
+mutsu's capture-numbering pass likely numbers captures per-branch independently (or doesn't
+correctly account for an alternation where different branches declare different numbers of
+capture groups) instead of reserving numbers based on the alternation's capture-count so that
+captures *after* the alternation continue numbering correctly regardless of which branch
+actually matched.
+
+## Affected files (starting point)
+
+- `src/runtime/regex_parse.rs` — capture-group numbering/allocation for alternation (`||`, `|`)
+  constructs

--- a/todo/tickets/regex-embedded-code-block-quantifier-scope.md
+++ b/todo/tickets/regex-embedded-code-block-quantifier-scope.md
@@ -1,0 +1,37 @@
+# An embedded code block inside a quantified group doesn't persist its side effect on an outer `:my` variable
+
+Discovered via the doc-diff harness on `raku-doc/doc/Language/regexes.rakudoc` (around line
+1587).
+
+## Repro
+
+```
+my $paragraph = "line\nline2\nline3";
+$paragraph ~~ rx| :my $counter = 0; ( \V* { ++$counter } ) *%% \n |;
+say "Matched $counter lines";
+```
+
+- raku: `Matched 3 lines` (the embedded `{ ++$counter }` block runs once per quantifier
+  repetition, incrementing the `:my`-declared counter each time)
+- mutsu: `Matched  lines` (`$counter` is empty/undefined — the increments inside the quantified
+  group never reached the outer `:my $counter` binding)
+
+## Root cause guess
+
+Combines two already-suspect mechanisms (both also seen failing elsewhere in this batch): a
+regex-embedded `:my $var = ...;` declarator, and an embedded `{...}` code block executed once
+per quantifier iteration (`*%%`). The counter's mutation inside the code block presumably isn't
+writing back to the same binding the `:my` declarator created — possibly because each quantifier
+iteration re-evaluates the embedded block in a fresh scope instead of sharing the enclosing
+regex's `:my`-declared lexical.
+
+## Affected files (starting point)
+
+- `src/runtime/regex.rs` — embedded code-block execution inside a quantified group, `:my`
+  variable scoping across quantifier iterations
+
+## Suggested next step
+
+First isolate whether a *simpler* case works: `:my $counter = 0; ( a { ++$counter } )*` (no `%%`
+separator, plain `*` quantifier) — if that already fails, the bug is about embedded-code-in-
+quantifier scoping generally, not the `*%%` separator form specifically.

--- a/todo/tickets/regex-embedded-my-decl-self-referential-slash.md
+++ b/todo/tickets/regex-embedded-my-decl-self-referential-slash.md
@@ -1,0 +1,35 @@
+# A regex-embedded `:my $c = $/;` declaration referencing the in-progress match (`$/`) fails to parse
+
+Discovered via the doc-diff harness on `raku-doc/doc/Language/regexes.rakudoc` (around line
+1595).
+
+## Repro
+
+```
+"aba" ~~ / (a) b {} :my $c = $/; /;
+say $c;
+```
+
+- raku: `｢ab｣` with `0 => ｢a｣` (assigns the in-progress match object, as captured so far, to
+  `$c`)
+- mutsu: `Runtime error: Regex not terminated.`
+
+## Root cause guess
+
+An embedded `:my $var = EXPR;` declarator inside a regex is parsed specially (it needs to stay
+inside the regex's own mini-grammar rather than being treated as ordinary code), and the parser
+presumably doesn't expect `$/` (the match-so-far pseudo-variable) to appear as the RHS of such a
+declaration — possibly misinterpreting the `/` in `$/` as the regex's own closing delimiter,
+which would explain "Regex not terminated" as a delimiter-matching failure.
+
+## Affected files (starting point)
+
+- `src/parser/` — regex-embedded `:my` declarator parsing, delimiter scanning for `/ ... /`
+  regex literals
+
+## Suggested next step
+
+Check whether the parser's regex-delimiter scanner treats `$/` specially anywhere else inside a
+regex body (e.g. inside a `{...}` code block it presumably already must, since `{ $/ }` embedded
+code blocks work) — the `:my $c = $/;` declarator form may need the same delimiter-aware handling
+extended to it.

--- a/todo/tickets/regex-embedded-my-decl-value-not-captured.md
+++ b/todo/tickets/regex-embedded-my-decl-value-not-captured.md
@@ -1,0 +1,37 @@
+# A regex-embedded `:my $c = ~$0;` declaration captures an empty value instead of the current match text
+
+Discovered via the doc-diff harness on `raku-doc/doc/Language/regexes.rakudoc` (around line
+1602).
+
+## Repro
+
+```
+"aba" ~~ / (a) {say "Check so far ", ~$/} b :my $c = ~$0; /;
+say "Capture $c";
+```
+
+- raku: `Check so far a` then `Capture a`
+- mutsu: `Check so far a` then `Capture` (empty — `$c` never got `~$0`'s value)
+
+Notably, the plain embedded code block `{say "Check so far ", ~$/}` earlier in the same regex
+*does* correctly see the in-progress `$/`/`$0` — the bug is specific to the `:my $var = EXPR;`
+declarator form, not embedded-code access to captures in general.
+
+## Root cause guess
+
+Since a plain `{...}` code block can already read `$0`/`$/` correctly mid-regex, the bug is
+localized to how the `:my $var = EXPR;` declarator evaluates and stores its RHS — it likely
+either evaluates `EXPR` too early (before `$0` is bound) or fails to write the evaluated value
+into the declared variable's binding that survives past the regex.
+
+## Affected files (starting point)
+
+- `src/runtime/regex.rs` / `src/parser/` — regex-embedded `:my` declarator evaluation and
+  variable binding
+
+## Suggested next step
+
+Compare this to the working `{...}` code-block case: does `:my $c = EXPR` compile to a different
+opcode/AST shape that evaluates `EXPR` at a different point in the match (e.g. at declaration
+time before the capture group commits) rather than at the point the declarator statement is
+reached during matching?

--- a/todo/tickets/regex-our-declarator-writeback-missing.md
+++ b/todo/tickets/regex-our-declarator-writeback-missing.md
@@ -1,0 +1,42 @@
+# A regex-embedded `:our $var = ...;` declarator doesn't write back to the package variable
+
+Discovered via the doc-diff harness on `raku-doc/doc/Language/regexes.rakudoc` (around line
+1612).
+
+## Repro
+
+```
+grammar HasOur {
+    token TOP {
+        :our $our = 'thor';
+        $our \s+ is \s+ mighty
+    }
+}
+say HasOur.parse('thor is mighty');
+say $HasOur::our;
+```
+
+- raku: `｢thor is mighty｣` then `thor`
+- mutsu: `｢thor is mighty｣` then `Nil`
+
+The match itself succeeds (so the `:our $our = 'thor';` declaration is at least usable *within*
+the token — `$our` correctly matches the literal text), but the package variable
+`$HasOur::our` isn't updated afterward.
+
+## Root cause guess
+
+`:our $var = ...;` inside a regex/token presumably creates a lexical binding for use during
+matching (which works — that's why the match succeeds), but doesn't additionally write the value
+through to the package's `our`-scoped storage the way a plain (non-regex) `our $var = ...;`
+declaration would.
+
+## Affected files (starting point)
+
+- `src/runtime/regex.rs` / `src/parser/` — regex-embedded `:our` declarator handling
+- Compare to how a plain top-level `our $var = ...;` writes to package storage
+
+## Suggested next step
+
+Check whether the regex-embedded declarator path even attempts a package-scope write, or skips
+it entirely (treating `:our` the same as `:my` internally, which would explain the exact
+symptom observed).

--- a/todo/tickets/regex-recursive-self-match-wrong-nesting-level.md
+++ b/todo/tickets/regex-recursive-self-match-wrong-nesting-level.md
@@ -1,0 +1,39 @@
+# `<~~>` recursive self-match returns the wrong (inner, not outer) nesting level
+
+Discovered via the doc-diff harness on `raku-doc/doc/Language/regexes.rakudoc` (around line
+2935).
+
+## Repro
+
+```
+my $paren = rx/ '(' <-[()]>* ')' || '('[ <-[()]>* <~~> <-[()]>* ]* ')' /;
+say '(1 + (2 x 3)) = 7' ~~ $paren;
+say '((5 + 2) x 6) = 42 (the answer)' ~~ $paren;
+```
+
+- raku: `｢(1 + (2 x 3))｣` then `｢((5 + 2) x 6)｣` — the outermost balanced-parenthesis span
+- mutsu: `｢(2 x 3)｣` then `｢(5 + 2)｣` — an *inner* balanced-parenthesis span, one recursion level
+  too deep
+
+The simpler cases (no nesting, or a single level of nesting matched from the top) already work
+correctly (`(1 + 1)` case matches in both).
+
+## Root cause guess
+
+`<~~>` (recursive self-reference to the enclosing regex/rule, used here to match balanced nested
+parens) likely returns the *innermost* successful recursive match instead of letting the
+*outermost* invocation's match span win — i.e., the recursion's result propagation/backtracking
+returns control to the wrong stack frame, or the outer alternation branch re-matches from the
+inner recursive call's position instead of its own start.
+
+## Affected files (starting point)
+
+- `src/runtime/regex.rs` — `<~~>` recursive self-match implementation
+
+## Suggested next step
+
+Test with exactly one level of nesting deeper than the working case to see whether the "off by
+one recursion level" is exact (matching a specific inner span each time) or grows worse with
+deeper nesting — that will show whether the whole match-span stack is shifted by a constant
+offset or whether something more structural is wrong with how recursion results are threaded back
+to the outer match.

--- a/todo/tickets/regex-same-subrule-missing.md
+++ b/todo/tickets/regex-same-subrule-missing.md
@@ -1,0 +1,33 @@
+# `<same>` builtin regex subrule (repeat-previous-capture) is unimplemented
+
+Discovered via the doc-diff harness on `raku-doc/doc/Language/regexes.rakudoc` (around line
+1349). Already noted as an aside in `docs/doc-diff-backlog.md`'s Deferred section ("NB:
+`regexes.rakudoc` [3] `<same>` is a *separate* missing builtin subrule, not this root") but was
+never filed as its own ticket — filing it now.
+
+## Repro
+
+```
+say '123345' ~~ m/ <same>\d+ /;
+say 'aa11' ~~ m/ <alpha><same><digit> /;
+```
+
+- raku: `｢345｣` (with `same => ｢｣`) then `False`
+- mutsu: `No such method 'same' for invocant of type 'Match'`
+
+`<same>` is a builtin regex subrule that matches only if it repeats the immediately preceding
+capture's matched text (a backreference-like assertion).
+
+## Root cause
+
+Simply unimplemented as a builtin regex subrule — `src/runtime/regex.rs` /
+`src/runtime/regex_parse.rs`'s builtin-subrule table (alongside `<alpha>`, `<digit>`, etc.) has
+no `<same>` entry.
+
+## Suggested next step
+
+Add `<same>` to the builtin regex subrule dispatch, implementing "match text identical to the
+immediately preceding capture" (this needs access to the most recent capture's matched
+substring at the point `<same>` appears, similar to how a numbered backreference like `$0` would
+be resolved, but referring to whatever capture came immediately before rather than a specific
+index).

--- a/todo/tickets/regex-script-lookahead-negation-wrong.md
+++ b/todo/tickets/regex-script-lookahead-negation-wrong.md
@@ -1,0 +1,31 @@
+# `<!:Script<Name>>` Unicode-property negated lookahead doesn't stop the preceding quantifier
+
+Discovered via the doc-diff harness on `raku-doc/doc/Language/regexes.rakudoc` (around line
+1331).
+
+## Repro
+
+```
+say '333' ~~ m/^^ \d+ <!:Script<Tamil>> /;
+```
+
+- raku: `｢33｣` (the greedy `\d+` backtracks by one so the negated lookahead can succeed at that
+  position — a subtle interaction between quantifier backtracking and a Unicode-property
+  negated assertion)
+- mutsu: `｢333｣` — matches the full string, meaning the `<!:Script<Tamil>>` assertion isn't
+  actually constraining where `\d+` stops
+
+The other 3 examples on the same lines (`<?alnum>`, `<?:Nd>`, `<!:L>`) all already match raku
+correctly — only the `:Script<...>`-parameterized property negation misbehaves.
+
+## Root cause guess
+
+`<!:Script<Tamil>>` is a negated Unicode-property assertion parameterized with a specific script
+name. The plain `<!:L>` (general category negation) already works, so the bug is likely
+specific to the parameterized `:Script<Name>` form not being evaluated at all (always
+succeeding trivially, so the assertion never actually blocks backtracking).
+
+## Affected files (starting point)
+
+- `src/runtime/regex.rs` / `src/runtime/regex_parse.rs` — Unicode property assertion handling,
+  specifically the `:Script<...>` parameterized form vs. plain category assertions

--- a/todo/tickets/regex-st-adverb-unsupported.md
+++ b/todo/tickets/regex-st-adverb-unsupported.md
@@ -1,0 +1,29 @@
+# `m:st(...)` regex adverb (starting positions) is unsupported
+
+Discovered via the doc-diff harness on `raku-doc/doc/Language/regexes.rakudoc` (around line
+2684).
+
+## Repro
+
+```
+my $data = "f fo foo fooo foooo fooooo foooooo";
+say $data ~~ m:st(1|8)/fo+/;
+```
+
+- raku: `True`
+- mutsu: `Runtime error: Unsupported regex adverb :st`
+
+`:st(positions)` restricts matching to only start at one of the given position(s) (a junction or
+list of integer offsets).
+
+## Root cause
+
+Simply unimplemented — the regex-adverb table in `src/runtime/regex.rs` /
+`src/runtime/regex_parse.rs` doesn't have a `:st` entry (unlike `:pos`/`:continue`, which were
+already fixed per `docs/doc-diff-backlog.md`'s Resolved section — #4996).
+
+## Suggested next step
+
+Read the `:pos(N)`/`:continue(N)` implementation (already correct per #4996) as a model — `:st`
+is a related-but-distinct adverb that restricts the match's *starting* position(s) to a
+set/junction of offsets rather than resuming from a single position.

--- a/todo/tickets/regex-subrule-block-argument-parse-fail.md
+++ b/todo/tickets/regex-subrule-block-argument-parse-fail.md
@@ -1,0 +1,40 @@
+# A subrule call with a block-literal argument (`<name: { ... }>`) fails entirely
+
+Discovered via the doc-diff harness on `raku-doc/doc/Language/regexes.rakudoc` (around line
+1966).
+
+## Repro
+
+```
+my regex demo ($param) {
+    foo
+    { say $param }
+    bar
+}
+'foobar' ~~ / <demo: { key => <v a l> }> /
+```
+
+- raku: prints `{key => (v a l)}` (the subrule `demo` is called with a hash-literal-with-quote-
+  words argument, and its embedded `{ say $param }` prints the received parameter)
+- mutsu: `Nil` — the whole match fails, meaning either the subrule-with-argument call syntax
+  isn't parsed as intended, or the argument expression itself (a block containing a Pair whose
+  value is a `<...>` word-quote list) isn't evaluated/passed correctly.
+
+## Root cause guess
+
+Parametrized subrule calls (`<name: ARGS>`) with a simple argument (e.g. a variable or literal)
+likely already work elsewhere in the codebase; this specific combination — a *block-literal*
+argument containing a Pair whose value is itself a `<...>` word-quote — may be exposing either a
+parser ambiguity (is `{ ... }` here a hash literal, a code block, or a Match closure?) or simply
+an unimplemented argument-expression shape for subrule calls.
+
+## Affected files (starting point)
+
+- `src/parser/` — subrule-call argument parsing (`<name: ARGS>`)
+- `src/runtime/regex.rs` — subrule invocation with arguments
+
+## Suggested next step
+
+Narrow further: does `<demo: {"literal"}>` (a plain string, no Pair/word-quote) already work?
+Does `<demo: (key => "v")>` (parenthesized, not a bare block) work? Bisecting which piece of the
+argument syntax breaks will scope the actual parser/runtime fix.

--- a/todo/tickets/role-instance-how-wrong-metaclass.md
+++ b/todo/tickets/role-instance-how-wrong-metaclass.md
@@ -1,0 +1,33 @@
+# A role's `.new` instance reports the wrong `.HOW` metaclass
+
+Discovered via the doc-diff harness on `raku-doc/doc/Language/typesystem.rakudoc` (around line
+594).
+
+## Repro
+
+```
+role R { method m { say 1 } };
+say R.new.^mro[0].HOW.^name;
+```
+
+- raku: `Perl6::Metamodel::ClassHOW`
+- mutsu: `Perl6::Metamodel::ParametricRoleGroupHOW`
+
+## Root cause guess
+
+Calling `.new` directly on a bare role (`R.new`) implicitly creates an anonymous class that does
+the role (Raku allows this as sugar), and that anonymous class should have the ordinary
+`ClassHOW` metaclass like any other class. mutsu's `.new`-on-a-role path likely returns/reuses
+the role's own `ParametricRoleGroupHOW`-tagged type object directly instead of synthesizing (or
+tagging) a proper anonymous class wrapper.
+
+## Affected files (starting point)
+
+- `src/runtime/class.rs` — role `.new` handling, `ParametricRoleGroupHOW`/`ClassHOW` tagging
+
+## Suggested next step
+
+Check what mutsu's `R.new` actually constructs today (an `Instance` of `R` directly, vs. an
+anonymous class doing `R`) via `--dump-ast`/`.^name`/`.^mro`, and compare to how an explicit
+`class C does R {}; C.new` already produces the correct `ClassHOW` — the fix is likely to route
+bare-role `.new` through the same anonymous-class synthesis.

--- a/todo/tickets/role-mixed-value-gist-skipped-in-array.md
+++ b/todo/tickets/role-mixed-value-gist-skipped-in-array.md
@@ -1,0 +1,43 @@
+# A custom `.gist` method on a role-mixed (`does`/`but`) native value is skipped when the value is gisted inside an array/list
+
+Discovered via the doc-diff harness on `raku-doc/doc/Language/typesystem.rakudoc` (around line
+657, the SI-unit `Unitish` example: `say [75kg, N(75kg)]` prints raw numbers instead of
+`75kg`/`735.49875kN`).
+
+## Repro
+
+```
+role Tag { method gist { "TAGGED:" ~ self } }
+my $x = (5) does Tag;
+say $x;
+say [$x];
+```
+
+- raku: `TAGGED:5` then `[TAGGED:5]`
+- mutsu: `TAGGED:5` then `[5]` — the custom `.gist` from the mixed-in role is honored when the
+  value is gisted directly, but is bypassed when the value is an element being gisted as part of
+  an array/list.
+
+## Root cause guess
+
+Array/List gisting likely has its own per-element stringification path that dispatches based on
+the element's *base* type (numeric formatting fast path) rather than going through the normal
+method-dispatch `.gist` lookup that would find the role-mixed override.
+
+**Possibly the same underlying root cause as**
+[list-but-role-loses-positional-binding.md](list-but-role-loses-positional-binding.md) and
+[hash-default-role-mixin-dropped.md](hash-default-role-mixin-dropped.md) — see that ticket's
+note on the shared hypothesis ("a `but`/`does`-mixed value's role metadata doesn't survive a
+generic storage/dispatch path"). Filed separately because each has a distinct minimal repro;
+investigate together and merge into one PR if a single fix site is found.
+
+## Affected files (starting point)
+
+- `src/runtime/` — array/list `.gist` implementation (look for a fast-path numeric formatter
+  used when gisting collection elements)
+
+## Suggested next step
+
+Find where `[$x].gist`/`say [$x]` iterates elements and calls each one's stringification —
+check whether it calls the generic method-dispatch `.gist` (which would find the role mixin) or
+a native fast-path formatter that only looks at the element's underlying primitive type.

--- a/todo/tickets/role-multi-method-trailing-literal-dropped.md
+++ b/todo/tickets/role-multi-method-trailing-literal-dropped.md
@@ -1,0 +1,49 @@
+# A role's 0-arg `multi method` loses a trailing literal from an interpolated string, only when the composing class has its own extra attribute
+
+Discovered via the doc-diff harness on `raku-doc/doc/Language/objects.rakudoc` (around line
+1132, the `Notable`/`Journey` example).
+
+## Repro (isolated by binary search from the doc example)
+
+```
+constant t = " " xx 4;
+role Notable {
+    has Str $.notes is rw;
+    multi method notes() { "$!notes\n" };
+    multi method notes( Str $note ) { $!notes ~= "$note\n" ~ t };
+}
+class J does Notable { has $.zzz; }
+my $j = J.new;
+$j.notes("First steps");
+$j.notes("Almost there");
+say "[" ~ $j.notes ~ "]";
+```
+
+- raku: `[First steps\n    Almost there\n    \n]`
+- mutsu: `[First steps\n    Almost there\n    ]` — the final `notes()` call's own trailing `"\n"`
+  is dropped
+
+## Isolation notes
+
+- Removing the class's extra attribute (`has $.zzz`) makes the bug disappear.
+- Replacing the role's `multi method notes()` (the 0-arg variant) with a plain non-`multi`
+  method also makes the bug disappear, even with the extra attribute still present.
+
+So the bug requires **both** "0-arg `multi method` declared inside a role" and "the composing
+class declares its own attribute". Since the *content* returned is correct up to the very last
+character (only the method's own trailing string literal is missing), this looks like a
+compiled-string-template / constant-pool interaction tied to per-class multi-method
+compilation, not attribute-value corruption.
+
+## Affected files (starting point)
+
+- `src/compiler/` — multi-method compilation when composed into a class that has its own
+  attribute list (attribute-count-dependent constant/slot allocation is the suspicious
+  variable)
+- `src/runtime/class.rs` — role composition, multi-method registration
+
+## Suggested next step
+
+Compare `--dump-ast`/bytecode for the 0-arg `notes()` method compiled standalone vs. compiled
+after the class gains an attribute, to see whether a string-literal constant or template slot is
+being mis-indexed or truncated when the class's attribute count changes.

--- a/todo/tickets/role-parameter-fail-default-not-enforced.md
+++ b/todo/tickets/role-parameter-fail-default-not-enforced.md
@@ -1,0 +1,39 @@
+# A role parameter's `fail(...)` default expression is never evaluated/enforced
+
+Discovered via the doc-diff harness on `raku-doc/doc/Language/typesystem.rakudoc` (around line
+644).
+
+## Repro
+
+```
+role R[$p = fail("boom")] {};
+my $i = 1 does R;
+say $i.^name;
+```
+
+- raku: throws (a `CATCH` fires; the exception is `X::Role::Instantiation` wrapping the
+  `X::AdHoc` from `fail("boom")`) — composing `R` without supplying `$p` is an error
+- mutsu: succeeds silently; `$i.^name` is `Int+{R}`
+
+Note: the doc's `# OUTPUT:` for the exception's exact type has drifted (`X::AdHoc` vs. current
+raku's `X::Role::Instantiation`-wrapped form) — that specific text mismatch is drift, not part
+of this finding. The real bug is that mutsu doesn't throw *at all*.
+
+## Root cause guess
+
+Role parameters with a default expression are presumably only evaluated when actually
+referenced inside the role body, but a default that itself calls `fail(...)` needs to be forced
+(evaluated) at composition time when the parameter isn't explicitly supplied, precisely so it
+*can* raise. mutsu likely treats an omitted role parameter as simply unbound/lazy without ever
+forcing its default expression during `does`/parameterized composition.
+
+## Affected files (starting point)
+
+- `src/runtime/class.rs` — parametric role composition, default-parameter evaluation
+
+## Suggested next step
+
+Check whether role parameter defaults are evaluated eagerly at all during `does R` (without
+explicit parameterization) — a defaults that's a plain literal (e.g. `$p = 5`) is a good control
+case to confirm defaults are evaluated at all, then narrow down why a `fail(...)`-producing
+default specifically doesn't propagate its exception.

--- a/todo/tickets/snip-multiple-positional-matchers-dropped.md
+++ b/todo/tickets/snip-multiple-positional-matchers-dropped.md
@@ -1,0 +1,36 @@
+# `.snip` with multiple positional predicates silently drops all but the first
+
+Discovered via the doc-diff harness on `raku-doc/doc/Type/Any.rakudoc` (around line 1525).
+
+## Repro
+
+```
+use v6.e.PREVIEW;
+.say for (5, 13, 29).snip(* < 10, * < 20);
+```
+
+- raku: `(5)` / `(13)` / `(29)` (each matcher advances round-robin as its predicate stops
+  matching)
+- mutsu: `(5)` / `(13 29)` (only the first matcher `* < 10` is honored; the second is ignored)
+
+## Root cause (pinned)
+
+`src/runtime/methods_dispatch_match2.rs::dispatch_snip_method` (~line 799-802) does
+`let matcher = args[0].clone();` — it only ever looks at the *first* positional argument and
+passes it alone to `eval_snip`, discarding any further comma-separated matcher arguments.
+
+`eval_snip` itself (`src/runtime/builtins_collection_mapgrep.rs:276`) is already correct: it
+supports a *list* of matchers (array/Seq/Slip) with round-robin advance. The bug is purely that
+`dispatch_snip_method` never assembles the separate positional args into that list before
+calling `eval_snip`.
+
+## Suggested fix
+
+In `dispatch_snip_method`, collect all positional `args` into a single list/array Value (instead
+of taking only `args[0]`) before calling `eval_snip`, mirroring however `eval_snip` already
+expects a multi-matcher list to look when passed as one array literal.
+
+## Suggested test
+
+`t/snip-multiple-predicates.t` covering both the doc's 2-predicate example and a 3+ predicate
+case, comparing against raku's documented round-robin advance semantics.

--- a/todo/tickets/snitch-method-unimplemented.md
+++ b/todo/tickets/snitch-method-unimplemented.md
@@ -1,0 +1,42 @@
+# `.snitch` (v6.e.PREVIEW debugging method) is unimplemented
+
+Discovered via the doc-diff harness on `raku-doc/doc/Type/Any.rakudoc` (around lines 1549,
+1559).
+
+## Repro
+
+```
+use v6.e.PREVIEW;
+(1..5).snitch;
+```
+
+- raku: prints `1..5` (to `$*ERR` by default) and returns `self` unchanged
+- mutsu: `Unknown function: snitch`
+
+The writable-attribute form is also missing:
+
+```
+(my $a = 42).snitch = 666;
+```
+
+- raku: sets the "what to print" formatter/behavior (per the doc, `.snitch` exposes a settable
+  attribute controlling its output)
+- mutsu: `X::Assignment::RO: cannot assign through .snitch on non-instance`
+
+## Root cause
+
+Simply unimplemented — `.snitch` is a `v6.e.PREVIEW`-gated debugging method on `Any` (like
+`.say`/`.note` but mid-expression-transparent: it returns its invocant unchanged after printing
+it, so it can be spliced into a chain for debugging). Needs a native 0-arg method (and possibly
+a writable-attribute variant per the doc) added under whatever `v6.e.PREVIEW`-only method gating
+mutsu already uses for other 6.e.PREVIEW features (e.g. `.snip`, global `rotor()`).
+
+## Affected files (starting point)
+
+- `src/builtins/methods_0arg/` — where other `Any`/`Cool` 0-arg methods live
+- Grep for how other `v6.e.PREVIEW`-only builtins (e.g. `.snip`) are gated in the codebase
+
+## Suggested test
+
+`t/snitch.t`, verifying invocant pass-through and stderr output (per the doc's description) for
+at least one representative type (Int/Range/Str).

--- a/todo/tickets/str-subclass-loses-native-stringify.md
+++ b/todo/tickets/str-subclass-loses-native-stringify.md
@@ -1,0 +1,39 @@
+# A user class `is Str` (or other native type) doesn't inherit native stringification
+
+Discovered via the doc-diff harness on `raku-doc/doc/Language/objects.rakudoc` (around line
+1067).
+
+## Repro
+
+```
+class Foo is Str { }
+my $x = Foo.new(:value("hi"));
+say $x;
+say $x.Str;
+say "v=$x";
+```
+
+- raku: `hi` / `hi` / `v=hi`
+- mutsu: `Foo.new` / `Foo.new` / `v=Foo()`
+
+## Root cause guess
+
+Subclassing a native type (`is Str`, likely also `is Int`/`is Num`/etc.) is expected to give the
+subclass the parent's underlying native representation and its `.Str`/stringify behavior
+(reading the `$.value` the native type stores). mutsu's class system probably treats `is Str`
+like any other user-class inheritance (MRO/method lookup only) without giving the instance the
+native `Str` payload or wiring `.Str`/`.gist`/interpolation to fall through to it.
+
+## Affected files (starting point)
+
+- `src/runtime/class.rs` — class construction/inheritance from a native type
+- Wherever `.Str`/interpolation/`say` resolves an `Instance`'s default stringification (likely
+  falls back to `ClassName.new` formatting when there's no user `.Str`, and needs a native-type
+  fallback checked first)
+
+## Suggested next step
+
+Check how `.new(:value(...))` is handled for a class subclassing a native type — does it store
+the native payload anywhere retrievable, or does `Foo.new(:value("hi"))` just become a plain
+attribute-less instance? That determines whether the fix is at construction time or at
+stringify-dispatch time (or both).

--- a/todo/tickets/subst-array-interpolation-as-alternation.md
+++ b/todo/tickets/subst-array-interpolation-as-alternation.md
@@ -1,0 +1,45 @@
+# `S:g/@(EXPR)/.../ ` doesn't interpolate an array as a regex alternation
+
+Discovered via the doc-diff harness on `raku-doc/doc/Language/regexes.rakudoc` (around line
+2290).
+
+## Repro
+
+```
+my %h = a => 1, b => 2;
+my @a = %h.keys;
+say S:g/@(%h.keys)/%h{$/}/ given 'abc';
+say S:g/@a/%h{$/}/ given 'abc';
+```
+
+- raku: `12c` (both forms) — `@(...)`/`@array` interpolated directly into a regex pattern is
+  treated as an alternation over the array's elements (matching `a` or `b`), and each match is
+  replaced by looking it up in `%h`)
+- mutsu: `%ha%hbc` (both forms) — the interpolation is being stringified as literal text
+  (`%h{...}`-looking output) rather than either (a) building an alternation from the array, or
+  (b) evaluating the replacement's `%h{$/}` hash lookup
+
+Two possible independent bugs bundled in one symptom: array-as-regex-pattern interpolation, and
+`%h{$/}` (hash-lookup-on-the-match-object) in the replacement.
+
+## Root cause guess
+
+`@(...)`/bare `@array` interpolated inside a regex pattern presumably isn't recognized as
+"expand to an alternation of the array's stringified elements" at all — it's likely being
+inserted as a literal stringification of the array (hence `%h`-looking noise appearing in the
+output, which looks like the *replacement* side's `%h{$/}` wasn't evaluated either and got
+stringified/escaped literally).
+
+## Affected files (starting point)
+
+- `src/runtime/regex_parse.rs` — array interpolation into a regex pattern (`@(...)`, bare
+  `@array`)
+- `src/vm/vm_string_regex_ops.rs` — `S:g/.../` replacement-string evaluation, specifically a
+  hash-subscript expression (`%h{$/}`) as the replacement
+
+## Suggested next step
+
+Split into two smaller repros to isolate which side is actually broken: (a) `'abc' ~~ S:g/@a//`
+(empty replacement) to check if the array-as-alternation match itself works at all; (b) a
+simpler replacement like `S:g/a/%h<a>/` to check if a hash-lookup replacement expression
+evaluates correctly outside of array-pattern interpolation.

--- a/todo/tickets/subst-named-capture-interpolation-in-replacement.md
+++ b/todo/tickets/subst-named-capture-interpolation-in-replacement.md
@@ -1,0 +1,28 @@
+# `s///` replacement string doesn't interpolate named captures (`$<name>`)
+
+Discovered via the doc-diff harness on `raku-doc/doc/Language/regexes.rakudoc` (around line
+1816).
+
+## Repro
+
+```
+$_ = '2016-01-23 18:09:00';
+s/ $<y>=(\d+)\-$<m>=(\d+)\-$<d>=(\d+) /$<m>-$<d>-$<y>/;
+.say;
+```
+
+- raku: `01-23-2016 18:09:00` (the named captures `$<y>`/`$<m>`/`$<d>` set in the pattern are
+  interpolated into the replacement string)
+- mutsu: `$<m>-$<d>-$<y> 18:09:00` — the replacement string is inserted **literally**, with none
+  of the `$<name>` references interpolated
+
+## Root cause guess
+
+The `s///` replacement-string interpolation pass presumably handles plain scalar (`$var`) and
+positional-capture (`$0`/`$1`) interpolation, but doesn't recognize/interpolate the
+`$<name>`-postcircumfix-on-`$/`-implicit named-capture syntax when it appears directly in a
+replacement string.
+
+## Affected files (starting point)
+
+- `src/vm/vm_string_regex_ops.rs` — substitution (`s///`) replacement-string interpolation

--- a/todo/tickets/subst-replacement-code-block-not-evaluated.md
+++ b/todo/tickets/subst-replacement-code-block-not-evaluated.md
@@ -1,0 +1,38 @@
+# `s///` replacement string doesn't evaluate an embedded `{ ... }` code block, and over-escapes a literal `:`
+
+Discovered via the doc-diff harness on `raku-doc/doc/Language/regexes.rakudoc` (around line
+1823).
+
+## Repro
+
+```
+$_ = '18:38';
+s/(\d+)\:(\d+)/{$0 % 12}\:$1 {$0 < 12 ?? 'AM' !! 'PM'}/;
+.say;
+```
+
+- raku: `6:38 PM`
+- mutsu: `6\:38 PM`
+
+Two distinct bugs visible here:
+1. The two embedded `{ ... }` code blocks in the replacement string are supposed to be evaluated
+   and their results interpolated (`{$0 % 12}` → `6`, `{$0 < 12 ?? 'AM' !! 'PM'}` → `PM`) —
+   mutsu's `6` and `PM` DO appear correctly in the output, so code-block evaluation itself
+   partially works.
+2. The literal escaped colon `\:` in the replacement string is emitted **with the backslash
+   still attached** (`6\:38` instead of `6:38`) — the replacement-string parser isn't stripping
+   the backslash-escape for a literal `:` the way it should for an ordinary string/regex
+   replacement text.
+
+So the actual, narrower bug is #2 (`\:` renders literally); the `{ ... }` block evaluation
+already works correctly in this example (re-read the outputs: `6` and `PM` did make it through).
+
+## Root cause guess
+
+The `s///` replacement-string lexer/interpolator likely only recognizes a small fixed set of
+backslash escapes (`\n`, `\\`, `\/` maybe) and passes through `\:` unrecognized instead of
+treating it as an escaped literal colon.
+
+## Affected files (starting point)
+
+- `src/vm/vm_string_regex_ops.rs` — substitution (`s///`) replacement-string escape handling


### PR DESCRIPTION
## Summary

Re-ran the doc-diff harness (`scripts/doc-diff-harness.raku`) fresh on the next 10 highest-signal
files from `docs/doc-diff-backlog.md`'s survey table:

- `Language/regexes.rakudoc`
- `Language/traps.rakudoc`
- `Language/variables.rakudoc`
- `Language/control.rakudoc`
- `Language/list.rakudoc`
- `Type/IO/Path.rakudoc`
- `Type/Any.rakudoc`
- `Language/objects.rakudoc`
- `Type/Iterator.rakudoc`
- `Language/typesystem.rakudoc`

Every `output-mismatch`/`mutsu-error` finding was cross-checked against the backlog's
Resolved/Deferred sections, re-verified directly with `raku -e` / `target/debug/mutsu -e`, and
narrowed to a minimal repro before being filed.

**51 new tickets filed** under `todo/tickets/`, each with a root-cause guess, minimal repro, and
starting-point source files. All cross-linked into three new sub-batch tables in the "Ticketed"
section of `docs/doc-diff-backlog.md` (one per file group, matching the harness runs).

Notable findings:
- Three tickets ([list-but-role-loses-positional-binding.md](todo/tickets/list-but-role-loses-positional-binding.md),
  [hash-default-role-mixin-dropped.md](todo/tickets/hash-default-role-mixin-dropped.md),
  [role-mixed-value-gist-skipped-in-array.md](todo/tickets/role-mixed-value-gist-skipped-in-array.md))
  share a hypothesis (a `but`/`does`-mixed value's role metadata not surviving a generic
  storage/dispatch path) and are cross-linked for joint investigation.
- One ticket ([container-aliasing-not-preserved-into-collection.md](todo/tickets/container-aliasing-not-preserved-into-collection.md))
  merges two doc-diff findings (traps.rakudoc:406, variables.rakudoc:853) that turned out to be
  the same underlying container-aliasing gap.
- One finding ([paren-single-var-decl-var-scalar-name.md](todo/tickets/paren-single-var-decl-var-scalar-name.md))
  had been auto-bucketed by the harness as `raku-drift-from-doc`, but direct re-verification
  showed it was a real bug — ticketed instead of skipped.

**Excluded** (documented in the backlog, not ticketed): findings already covered by the
Nil-vs-Any identity knot, the lazy-list cluster, the `and`/`or`/`not` word-logical precedence
cluster, and the sub-stub-upgrade cluster (one new instance applied to `role` stubs instead was
ticketed separately); `raku-drift-from-doc` findings; a directory-walk timeout inherently
dependent on this checkout's file/tree size (two instances, one of which had a real, isolable bug
underneath that *was* ticketed); and an intentional mutsu-vs-MoarVM identity difference
(`$*VM.precomp-ext`/`.precomp-target`).

No interpreter code was changed — this is discovery/ticket-filing only, per the doc-diff harness's
discovery-vs-fix discipline.

## Test plan

- [x] Docs-only change (`docs/`, `todo/tickets/`) — CI's `changes` classifier should skip the
      heavy `test`/`roast`/`wasm-e2e`/`gc-stress`/`jit-stress` jobs (reported as `skipped`, which
      counts as success for branch protection).
- [x] Every filed finding was re-verified directly against both `raku` and `target/debug/mutsu`
      before ticketing (not just trusted from the harness's automated bucketing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>