### PR TITLE
feat(rakuast): routine return types and hyper infix operators (ADR-0011)

### DIFF
--- a/docs/adr/0011-rakuast-model-layer-and-phasing.md
+++ b/docs/adr/0011-rakuast-model-layer-and-phasing.md
@@ -597,9 +597,30 @@ earlier ones.
   signature parameters carry an implicit `type => Type::Setting(Name.from-identifier("Any"))` that
   pointy-block parameters do not — the `signature`/`parameter`/`simple_parameter` helpers thread a
   `type_setting` flag to add it. Boundary (explicit `RuntimeError`): traits, `multi`, `is export`,
-  return types, operator subs (associativity/precedence), alternate signatures, and anonymous
+  operator subs (associativity/precedence), alternate signatures, and anonymous
   `sub { }` (deferred). Parameters reuse the slice-3 plain-positional boundary (typed/named/slurpy/
   `where`/… still error).
+- **Routine return types (2026-08-22, both directions).** raku models the two spellings with
+  different nodes and mutsu's internal AST keeps them apart, so the converter never guesses:
+  `sub f(--> Int)` → `signature => Signature(parameters => …, returns => Type::Simple(Name))`
+  (a parameter-less sub with a `-->` type therefore *does* emit a `signature`, whose empty
+  `parameters` renders as raku's itemized `$( )` — the renderer special-cases the empty list);
+  `sub f() returns Int` → `traits => (Trait::Returns(Type::Simple),)`; `sub f() of Int` →
+  `Trait::Of`. The `returns`/`of` distinction rides on the parser's `custom_traits` markers —
+  `returns` already set `__return_via_trait`, and `of` now sets its own `__return_via_of` (both
+  still mean "not a `-->` arrow" to `eval_check`'s undeclared-type classification). `EVAL` lowers
+  all three back to `SubDecl.return_type` plus the matching marker. Pointy blocks carry a `-->`
+  type the same way; this also fixed a **runtime** bug — a single-parameter pointy block parsed to
+  `Expr::Lambda`, which has no return-type field, so `-> $x --> Int { "s" }` silently returned a
+  `Str`. Such a block now takes the `AnonSubParams` path, which carries the constraint
+  (`t/pointy-block-return-type.t`). Enforcing it exposed a second, latent bug: the bare-block
+  closure arm (`MakeAnonSub`) kept a lexically captured `__mutsu_return_type`, so a `{ … }`
+  argument written inside a `--> T` routine enforced the *outer* type on its own value — the
+  `MakeLambda` / `MakeAnonSubParams` arms already dropped it, that one now does too
+  (`t/return-type-not-inherited-by-inner-block.t`). Still deferred: **methods** — `method_decl.rs` filters every
+  `__`-prefixed marker out of `MethodDecl.custom_traits`, so `-->` and `returns` are
+  indistinguishable there; and `returns X of Y` (mutsu folds it into one `X[Y]` type, raku keeps
+  one trait). Tests: `t/rakuast-return-type.t`.
 - **Anonymous parameter-less `sub { }` (Phase 2 slice 11).** `sub { ... }` with no signature
   (`Expr::AnonSub { is_block: false }`) → `RakuAST::Sub(body => Blockoid)` with no `name` field.
   Only the no-parameter form is handled: `sub ($x) { }` parses to `Expr::AnonSubParams`, which mutsu
@@ -633,8 +654,17 @@ earlier ones.
 - **Hyper method calls (Phase 2 slice 26).** `@a>>.abs` (`Expr::HyperMethodCall`) → `ApplyPostfix(
   operand, postfix => MetaPostfix::Hyper(Call::Method(...)))` — the inner `Call::Method` /
   `Call::QuotedMethod` is built by the same `method_call_postfix` helper as a plain method call, then
-  wrapped in a `MetaPostfix::Hyper`. Other hyper forms (`<<.m`, `>>.m<<`, hyper infix `>>+<<`) are
-  the boundary.
+  wrapped in a `MetaPostfix::Hyper`.
+- **Hyper infix operators (2026-08-22, both directions).** `@a >>+<< @b` (`Expr::HyperOp`) →
+  `ApplyInfix(left, infix => MetaInfix::Hyper([dwim-left => True,] infix => Infix(op),
+  [dwim-right => True]), right)`, and `EVAL` lowers it back. mutsu's `HyperOp` already stores the
+  operator text plus both dwim flags, so the mapping is 1:1; raku omits a dwim field whose value is
+  False, which the converter reproduces by simply not emitting it (and the lowerer reads a missing
+  field as False). Tests: `t/rakuast-hyper-infix.t`. Remaining hyper boundary: hyper *prefix*
+  (`-<<@a`, desugared to a `__mutsu_hyper_prefix` call), hyper *postcircumfix* (`@a>>[1]`,
+  desugared to a hyper `AT-POS` method call), hyper *function* infix (`>>[&f]<<`, raku's
+  `MetaInfix::Hyper(FunctionInfix)`; mutsu has `Expr::HyperFuncOp`), and `@a<<.abs` (which mutsu's
+  parser currently reads as a quote-words subscript).
 - **Reduction metaoperator (Phase 2 slice 25).** `[+] @a` (`Expr::Reduction`) → `Term::Reduce(
   triangle => False, infix => Infix("+"), args => ArgList(@a))`. The triangle form `[\+] @a`
   (mutsu stores its op as `"\+"`) sets `triangle => True` with the backslash stripped from the infix.

--- a/news/2026-08/rakuast-return-types-and-hyper-infix.md
+++ b/news/2026-08/rakuast-return-types-and-hyper-infix.md
@@ -1,0 +1,86 @@
+# RakuAST: routine return types and hyper infix operators (and a dropped pointy return type)
+
+Two of the read-direction representation gaps listed in
+`todo/deep/rakuast-remaining.md` are closed, in both directions (`.AST` read and
+`EVAL` lowering), and pinned by dual-oracle tests that pass verbatim under both
+mutsu and the system raku.
+
+## Signature return types
+
+raku models the two spellings of a routine return type with different nodes:
+
+- `sub f(--> Int)` puts it in the signature — `Signature.returns => Type::Simple`
+- `sub f() returns Int` makes it a routine trait — `Trait::Returns`
+- `sub f() of Int` makes it a *different* routine trait — `Trait::Of`
+
+mutsu's internal AST already distinguished the first two (the parser records a
+`__return_via_trait` marker in `custom_traits` for the trait spelling, because an
+undeclared `returns` type is `X::InvalidType` while an undeclared `-->` type is
+`X::Undeclared`). It collapsed `of` into the same marker, so the parser now sets a
+distinct `__return_via_of` for it — a small, honest internal-AST refinement rather
+than a guess in the converter. All three node choices now come straight out of the
+parse; `EVAL` lowers them back to `SubDecl.return_type` plus the matching marker,
+so a round-trip reproduces the source spelling.
+
+Rendering a parameter-less signature exposed a small renderer bug: raku prints an
+empty attribute list as the itemized `$( )`, while mutsu printed a bare multi-line
+`(\n)`. `RakuAST::Signature.new.gist` now matches Rakudo exactly.
+
+## A pointy block silently dropped its return type
+
+Extending the same work to pointy blocks surfaced a real, RakuAST-independent
+correctness bug. A *single*-parameter pointy block parses to the internal
+`Expr::Lambda` node, which has no field for a return type — so the parser parsed
+`--> Int` and threw it away:
+
+```raku
+my $f = -> $x --> Int { "s" };
+say $f(1);      # mutsu printed "s"; raku dies with a return type check failure
+```
+
+The multi-parameter form (`-> $a, $b --> Int`) was fine, because it uses
+`Expr::AnonSubParams`, which carries `return_type`. The fix routes a pointy block
+that declares a return type through that same node, so the constraint survives to
+the compiler. Pinned by `t/pointy-block-return-type.t`.
+
+## …which in turn exposed a second one: an inner block inherited the check
+
+Enforcing the pointy-block return type turned the battery gate red on
+`Text::CSV`'s `90_csv.t`, and the cause was a *separate*, pre-existing bug that
+the new enforcement merely made reachable. The closure-construction path for a
+**bare block** kept a lexically captured `__mutsu_return_type`, so a block written
+inside a routine that declares one enforced the outer routine's type on its own
+inner value:
+
+```raku
+-> $x --> Pair { (@k.map({ $x{$_} }).join: ":") => $x }
+# Type check failed for return value; expected Pair but got Str ("1")
+```
+
+The `{ $x{$_} }` argument to `.map` was being checked against `Pair`. The
+`MakeLambda` and `MakeAnonSubParams` arms already dropped the inherited marker;
+`MakeAnonSub` (the bare-block arm) did not. It does now. The bug was reproducible
+without any of this slice's other changes (a two-parameter pointy block hits it
+too), so it had been latent since the marker was introduced. Pinned by
+`t/return-type-not-inherited-by-inner-block.t`.
+
+## Hyper infix operators
+
+`@a >>+<< @b` now renders as
+`ApplyInfix(left, MetaInfix::Hyper([dwim-left,] infix, [dwim-right]), right)` and
+lowers back through `EVAL`. mutsu's `Expr::HyperOp` already kept the operator text
+and both dwim flags, so this needed no parser change at all — every `<<`/`>>`
+combination (`>>+<<`, `<<+>>`, `>>+>>`, `<<+<<`) matches Rakudo's gist byte for
+byte, including raku's habit of omitting a dwim field whose value is False.
+
+The remaining hyper boundary is narrower now: hyper prefix (`-<<@a`), hyper
+postcircumfix (`@a>>[1]`), hyper function infix (`>>[&f]<<`), and `@a<<.abs`
+(which mutsu's parser currently reads as a quote-words subscript).
+
+## Tests
+
+`t/rakuast-return-type.t` (21 assertions), `t/rakuast-hyper-infix.t` (15),
+`t/pointy-block-return-type.t` (8), and
+`t/return-type-not-inherited-by-inner-block.t` (6). See
+[ADR-0011](../../docs/adr/0011-rakuast-model-layer-and-phasing.md) for the updated
+divergence record and `todo/deep/rakuast-remaining.md` for what is still open.

--- a/src/parser/expr/tests_errors.rs
+++ b/src/parser/expr/tests_errors.rs
@@ -320,7 +320,17 @@ fn parse_method_colon_arg_pointy_with_return_type() {
         Expr::MethodCall { name, args, .. } => {
             assert_eq!(name, "map");
             assert_eq!(args.len(), 1);
-            assert!(matches!(args[0], Expr::Lambda { ref param, .. } if param.as_str() == "x"));
+            // A pointy block that declares a `--> T` return type keeps the
+            // constraint, so it parses to the param_defs-carrying closure node
+            // rather than the name-only `Expr::Lambda`.
+            assert!(matches!(
+                args[0],
+                Expr::AnonSubParams {
+                    ref params,
+                    ref return_type,
+                    ..
+                } if params == &["x".to_string()] && return_type.as_deref() == Some("Int")
+            ));
         }
         _ => panic!("expected method call expression"),
     }

--- a/src/parser/primary/misc/lambda.rs
+++ b/src/parser/primary/misc/lambda.rs
@@ -234,6 +234,11 @@ fn arrow_lambda_inner(input: &str) -> PResult<'_, Expr> {
             body.insert(0, crate::ast::Stmt::SetLine(arrow_line));
         }
         let simple_single = first.traits.is_empty()
+            // `Expr::Lambda` has nowhere to keep a `--> T` return type, so the
+            // constraint would be silently dropped (`-> $x --> Int { "s" }`
+            // returned a Str instead of failing the return type check). Route
+            // such a block through the `AnonSubParams` path, which carries it.
+            && return_type.is_none()
             && first.shape_constraints.is_none()
             // A literal parameter (`-> 'about' { … }`) carries its constraint in
             // `literal_value`, which the name-only `Lambda` form cannot hold —

--- a/src/parser/stmt/sub/traits.rs
+++ b/src/parser/stmt/sub/traits.rs
@@ -303,8 +303,11 @@ pub(crate) fn parse_sub_traits(mut input: &str) -> PResult<'_, SubTraits> {
                 Some(base) if !base.contains('[') => format!("{base}[{type_name}]"),
                 _ => type_name,
             });
-            if !custom_traits.iter().any(|(t, _)| t == "__return_via_trait") {
-                custom_traits.push(("__return_via_trait".to_string(), None));
+            // `of` is a distinct trait from `returns` in RakuAST
+            // (`Trait::Of` vs `Trait::Returns`), so it gets its own marker;
+            // both mean "the return type came from a trait, not `-->`".
+            if !custom_traits.iter().any(|(t, _)| t == "__return_via_of") {
+                custom_traits.push(("__return_via_of".to_string(), None));
             }
             input = r;
             continue;

--- a/src/rakuast/convert.rs
+++ b/src/rakuast/convert.rs
@@ -274,7 +274,7 @@ fn convert_stmt(stmt: &Stmt) -> Result<Option<RakuAstNode>, RuntimeError> {
             let body_node = if explicit_defs.is_empty() {
                 topic_block_node(body)?
             } else {
-                pointy_block(explicit_defs, body)?
+                pointy_block(explicit_defs, body, None)?
             };
             // Field order matches raku: labels, mode, source, body.
             let mut fields = label_fields(label);
@@ -349,10 +349,12 @@ fn convert_stmt(stmt: &Stmt) -> Result<Option<RakuAstNode>, RuntimeError> {
             ..
         } => {
             // Phase 2 slice 7 covers the plain named `sub NAME (params) { body }`
-            // form. Traits, multi, export, return type, operator subs, and
-            // alternate signatures carry extra RakuAST shape, deferred.
+            // form; return types are covered too (`-->` via `Signature.returns`,
+            // `returns`/`of` via `Trait::Returns`/`Trait::Of`). Other traits,
+            // multi, export, operator subs, and alternate signatures carry extra
+            // RakuAST shape, deferred.
+            let spelling = return_type_spelling(custom_traits)?;
             if name_expr.is_some()
-                || return_type.is_some()
                 || associativity.is_some()
                 || precedence_trait.is_some()
                 || !signature_alternates.is_empty()
@@ -363,17 +365,23 @@ fn convert_stmt(stmt: &Stmt) -> Result<Option<RakuAstNode>, RuntimeError> {
                 || !export_tags.is_empty()
                 || *is_test_assertion
                 || *supersede
-                || !custom_traits.is_empty()
+                || custom_traits
+                    .iter()
+                    .any(|(t, _)| !is_return_spelling_marker(t))
             {
-                return Err(unsupported(
-                    "sub with traits / multi / export / return type",
-                ));
+                return Err(unsupported("sub with traits / multi / export"));
+            }
+            if return_type.is_none() && spelling != ReturnSpelling::Arrow {
+                // A `__return_via_*` marker without a return type would be a
+                // parser inconsistency; refuse rather than render a wrong node.
+                return Err(unsupported("sub with a return trait but no return type"));
             }
             Ok(Some(statement_expression(routine_node(
                 RakuAstClass::Sub,
                 &name.resolve(),
                 param_defs,
                 body,
+                return_type.as_deref().map(|t| (t, spelling)),
             )?)))
         }
         Stmt::MethodDecl {
@@ -420,6 +428,7 @@ fn convert_stmt(stmt: &Stmt) -> Result<Option<RakuAstNode>, RuntimeError> {
                 &name.resolve(),
                 param_defs,
                 body,
+                None,
             )?)))
         }
         Stmt::ClassDecl {
@@ -953,6 +962,52 @@ fn convert_expr(expr: &Expr) -> Result<RakuAstNode, RuntimeError> {
                 node_field(Some("right"), convert_expr(right)?),
             ],
         }),
+        // A hyper infix `@a >>+<< @b` -> ApplyInfix(left, MetaInfix::Hyper(
+        // [dwim-left,] infix, [dwim-right]), right). mutsu keeps the operator
+        // text and both dwim flags on `Expr::HyperOp`, so this is a faithful
+        // 1:1 mapping; raku omits a dwim field whose value is False.
+        Expr::HyperOp {
+            op,
+            left,
+            right,
+            dwim_left,
+            dwim_right,
+        } => {
+            let mut hyper_fields = Vec::with_capacity(3);
+            if *dwim_left {
+                hyper_fields.push(RakuAstField {
+                    name: Some("dwim-left"),
+                    value: RakuAstFieldValue::Node(Value::truth(true)),
+                });
+            }
+            hyper_fields.push(node_field(
+                Some("infix"),
+                RakuAstNode {
+                    class: RakuAstClass::Infix,
+                    fields: vec![leaf_field(None, Value::str(op.clone()))],
+                },
+            ));
+            if *dwim_right {
+                hyper_fields.push(RakuAstField {
+                    name: Some("dwim-right"),
+                    value: RakuAstFieldValue::Node(Value::truth(true)),
+                });
+            }
+            Ok(RakuAstNode {
+                class: RakuAstClass::ApplyInfix,
+                fields: vec![
+                    node_field(Some("left"), convert_expr(left)?),
+                    node_field(
+                        Some("infix"),
+                        RakuAstNode {
+                            class: RakuAstClass::MetaInfixHyper,
+                            fields: hyper_fields,
+                        },
+                    ),
+                    node_field(Some("right"), convert_expr(right)?),
+                ],
+            })
+        }
         Expr::Unary { op, expr } => Ok(RakuAstNode {
             class: RakuAstClass::ApplyPrefix,
             fields: vec![
@@ -1138,10 +1193,10 @@ fn convert_expr(expr: &Expr) -> Result<RakuAstNode, RuntimeError> {
             if *is_whatever_code {
                 return Err(unsupported("Whatever-code closure (compound assignment)"));
             }
-            if *is_rw || return_type.is_some() {
-                return Err(unsupported("`is rw` / typed pointy block"));
+            if *is_rw {
+                return Err(unsupported("`is rw` pointy block"));
             }
-            pointy_block(param_defs, body)
+            pointy_block(param_defs, body, return_type.as_deref())
         }
         // An interpolated string `"a $x b"` -> QuotedString with a segment per
         // part (a literal run is a `StrLiteral`, an interpolated term keeps its
@@ -1307,11 +1362,19 @@ fn topic_block_node(body: &[Stmt]) -> Result<RakuAstNode, RuntimeError> {
 }
 
 /// A multi/zero-parameter pointy block (`-> $a, $b { }`, `-> { }`). An empty
-/// parameter list omits the `signature` field entirely (matching raku).
-fn pointy_block(param_defs: &[ParamDef], body: &[Stmt]) -> Result<RakuAstNode, RuntimeError> {
+/// parameter list with no `--> T` return type omits the `signature` field
+/// entirely (matching raku).
+fn pointy_block(
+    param_defs: &[ParamDef],
+    body: &[Stmt],
+    returns: Option<&str>,
+) -> Result<RakuAstNode, RuntimeError> {
     let mut fields = Vec::new();
-    if !param_defs.is_empty() {
-        fields.push(node_field(Some("signature"), signature(param_defs, false)?));
+    if !param_defs.is_empty() || returns.is_some() {
+        fields.push(node_field(
+            Some("signature"),
+            signature(param_defs, false, returns)?,
+        ));
     }
     fields.push(node_field(Some("body"), blockoid(body)?));
     Ok(RakuAstNode {
@@ -1343,37 +1406,107 @@ fn pointy_block_from_lambda(param: &str, body: &[Stmt]) -> Result<RakuAstNode, R
     })
 }
 
-/// A named routine — `Sub` or `Method` — with an optional signature and a
-/// body. A parameter-less routine omits the `signature` field; parameters
-/// carry the implicit `type => Type::Setting(Any)` (`type_setting = true`).
+/// The parser markers that record a `returns` / `of` return-type trait. They
+/// are internal (`__`-prefixed) bookkeeping, not user traits, so the converter
+/// reads them for the spelling instead of treating them as a coverage boundary.
+fn is_return_spelling_marker(trait_name: &str) -> bool {
+    matches!(trait_name, "__return_via_trait" | "__return_via_of")
+}
+
+/// Which spelling a routine's return type used, read off the parser markers.
+/// `returns X of Y` leaves both markers (mutsu folds them into one
+/// `X[Y]` return type); raku models that as a single trait, so defer.
+fn return_type_spelling(
+    custom_traits: &[(String, Option<Expr>)],
+) -> Result<ReturnSpelling, RuntimeError> {
+    let returns = custom_traits.iter().any(|(t, _)| t == "__return_via_trait");
+    let of = custom_traits.iter().any(|(t, _)| t == "__return_via_of");
+    match (returns, of) {
+        (false, false) => Ok(ReturnSpelling::Arrow),
+        (true, false) => Ok(ReturnSpelling::ReturnsTrait),
+        (false, true) => Ok(ReturnSpelling::OfTrait),
+        (true, true) => Err(unsupported("`returns X of Y` combined return trait")),
+    }
+}
+
+/// How a routine's return type was written in the source. raku models the two
+/// spellings with different nodes, and mutsu's internal AST keeps them apart
+/// (the `returns`/`of` forms leave a `__return_via_*` marker in `custom_traits`),
+/// so the converter never has to guess.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(super) enum ReturnSpelling {
+    /// `sub f(--> Int)` — part of the signature (`Signature.returns`).
+    Arrow,
+    /// `sub f() returns Int` — a routine trait (`Trait::Returns`).
+    ReturnsTrait,
+    /// `sub f() of Int` — a routine trait (`Trait::Of`).
+    OfTrait,
+}
+
+/// A named routine — `Sub` or `Method` — with an optional signature, optional
+/// return type, and a body. A parameter-less routine with no `-->` return type
+/// omits the `signature` field; parameters carry the implicit
+/// `type => Type::Setting(Any)` (`type_setting = true`).
 fn routine_node(
     class: RakuAstClass,
     name: &str,
     param_defs: &[ParamDef],
     body: &[Stmt],
+    return_type: Option<(&str, ReturnSpelling)>,
 ) -> Result<RakuAstNode, RuntimeError> {
     let mut fields = vec![node_field(Some("name"), name_from_identifier(name))];
-    if !param_defs.is_empty() {
-        fields.push(node_field(Some("signature"), signature(param_defs, true)?));
+    let arrow_returns = match return_type {
+        Some((t, ReturnSpelling::Arrow)) => Some(t),
+        _ => None,
+    };
+    if !param_defs.is_empty() || arrow_returns.is_some() {
+        fields.push(node_field(
+            Some("signature"),
+            signature(param_defs, true, arrow_returns)?,
+        ));
+    }
+    if let Some((t, spelling)) = return_type
+        && spelling != ReturnSpelling::Arrow
+    {
+        let trait_class = match spelling {
+            ReturnSpelling::OfTrait => RakuAstClass::TraitOf,
+            _ => RakuAstClass::TraitReturns,
+        };
+        let trait_node = RakuAstNode {
+            class: trait_class,
+            fields: vec![node_field(None, build_type_node(t)?)],
+        };
+        fields.push(RakuAstField {
+            name: Some("traits"),
+            value: RakuAstFieldValue::List(vec![Value::rakuast(Box::new(trait_node))]),
+        });
     }
     fields.push(node_field(Some("body"), blockoid(body)?));
     Ok(RakuAstNode { class, fields })
 }
 
-/// `Signature(parameters => (Parameter, ...))`. `type_setting` prepends the
-/// implicit `type => Type::Setting(Any)` on each parameter — present in
-/// sub/method signatures, absent in pointy-block signatures.
-fn signature(param_defs: &[ParamDef], type_setting: bool) -> Result<RakuAstNode, RuntimeError> {
+/// `Signature(parameters => (Parameter, ...)[, returns => Type])`. `type_setting`
+/// prepends the implicit `type => Type::Setting(Any)` on each parameter —
+/// present in sub/method signatures, absent in pointy-block signatures.
+fn signature(
+    param_defs: &[ParamDef],
+    type_setting: bool,
+    returns: Option<&str>,
+) -> Result<RakuAstNode, RuntimeError> {
     let mut params = Vec::with_capacity(param_defs.len());
     for pd in param_defs {
         params.push(Value::rakuast(Box::new(parameter(pd, type_setting)?)));
     }
+    let mut fields = vec![RakuAstField {
+        name: Some("parameters"),
+        value: RakuAstFieldValue::List(params),
+    }];
+    if let Some(t) = returns {
+        fields.push(node_field(Some("returns"), build_type_node(t)?));
+    }
     Ok(RakuAstNode {
         class: RakuAstClass::Signature,
-        fields: vec![RakuAstField {
-            name: Some("parameters"),
-            value: RakuAstFieldValue::List(params),
-        }],
+        fields,
     })
 }
 

--- a/src/rakuast/lower.rs
+++ b/src/rakuast/lower.rs
@@ -203,6 +203,7 @@ fn lower_for(node: &RakuAstNode) -> Result<Stmt, RuntimeError> {
 fn lower_sub(node: &RakuAstNode) -> Result<Stmt, RuntimeError> {
     let name = call_name_str(node)?;
     let (params, param_defs) = signature_positional_params(node)?;
+    let (return_type, custom_traits) = routine_return_type(node)?;
     // A Sub's `body` is the Blockoid directly (not a Block wrapping one).
     let body = lower(named_child_or_positional(named_child(node, "body")?)?)?;
     Ok(Stmt::SubDecl {
@@ -210,7 +211,7 @@ fn lower_sub(node: &RakuAstNode) -> Result<Stmt, RuntimeError> {
         name_expr: None,
         params,
         param_defs,
-        return_type: None,
+        return_type,
         associativity: None,
         precedence_trait: None,
         signature_alternates: Vec::new(),
@@ -222,8 +223,68 @@ fn lower_sub(node: &RakuAstNode) -> Result<Stmt, RuntimeError> {
         export_tags: Vec::new(),
         is_test_assertion: false,
         supersede: false,
-        custom_traits: Vec::new(),
+        custom_traits,
     })
+}
+
+/// A routine's return type, from either spelling: `signature.returns` (the
+/// `-->` arrow) or a `traits => (Trait::Returns|Trait::Of(Type),)` entry. The
+/// trait spelling round-trips through the same `__return_via_*` marker the
+/// parser sets, so `EVAL` reproduces the source form the converter read.
+/// Declaring both is refused rather than silently collapsed.
+#[allow(clippy::type_complexity)]
+fn routine_return_type(
+    node: &RakuAstNode,
+) -> Result<(Option<String>, Vec<(String, Option<Expr>)>), RuntimeError> {
+    let arrow = match named_child(node, "signature") {
+        Ok(sig) => match sig.fields.iter().find(|f| f.name == Some("returns")) {
+            Some(f) => Some(simple_type_name(node, child_node(&f.value)?)?),
+            None => None,
+        },
+        Err(_) => None,
+    };
+    let mut via_trait = None;
+    if let Some(f) = node.fields.iter().find(|f| f.name == Some("traits")) {
+        let RakuAstFieldValue::List(items) = &f.value else {
+            return Err(unsupported(node));
+        };
+        for item in items {
+            let ValueView::RakuAst(t) = item.view() else {
+                return Err(unsupported(node));
+            };
+            let marker = match t.class {
+                RakuAstClass::TraitReturns => "__return_via_trait",
+                RakuAstClass::TraitOf => "__return_via_of",
+                _ => return Err(unsupported(node)),
+            };
+            if via_trait.is_some() {
+                return Err(unsupported(node));
+            }
+            via_trait = Some((
+                simple_type_name(node, named_child_or_positional(t)?)?,
+                marker,
+            ));
+        }
+    }
+    match (arrow, via_trait) {
+        (Some(t), None) => Ok((Some(t), Vec::new())),
+        (None, Some((t, marker))) => Ok((Some(t), vec![(marker.to_string(), None)])),
+        (None, None) => Ok((None, Vec::new())),
+        (Some(_), Some(_)) => Err(unsupported(node)),
+    }
+}
+
+/// The plain type name of a `Type::Simple` node. Richer type node kinds
+/// (definite / coercion / parameterised) are the coverage boundary, matching
+/// the parameter `type` handling above.
+fn simple_type_name(node: &RakuAstNode, type_node: &RakuAstNode) -> Result<String, RuntimeError> {
+    if type_node.class != RakuAstClass::TypeSimple {
+        return Err(unsupported(node));
+    }
+    match positional_leaf(named_child_or_positional(type_node)?)?.view() {
+        ValueView::Str(s) => Ok(s.to_string()),
+        _ => Err(unsupported(node)),
+    }
 }
 
 /// The positional scalar parameter names of a routine's `signature`, each with
@@ -722,6 +783,24 @@ fn lower_expr(node: &RakuAstNode) -> Result<Expr, RuntimeError> {
                 is_bind: false,
             })
         }
+        // `@a >>+<< @b` -> the hyper operator, keeping both dwim flags.
+        RakuAstClass::ApplyInfix
+            if named_child(node, "infix")
+                .is_ok_and(|i| i.class == RakuAstClass::MetaInfixHyper) =>
+        {
+            let hyper = named_child(node, "infix")?;
+            let op_value = positional_leaf(named_child(hyper, "infix")?)?;
+            let ValueView::Str(op) = op_value.view() else {
+                return Err(unsupported(node));
+            };
+            Ok(Expr::HyperOp {
+                op: op.to_string(),
+                left: Box::new(lower_expr(named_child(node, "left")?)?),
+                right: Box::new(lower_expr(named_child(node, "right")?)?),
+                dwim_left: bool_field(hyper, "dwim-left")?,
+                dwim_right: bool_field(hyper, "dwim-right")?,
+            })
+        }
         RakuAstClass::ApplyInfix => {
             let left = lower_expr(named_child(node, "left")?)?;
             let right = lower_expr(named_child(node, "right")?)?;
@@ -815,6 +894,21 @@ fn infix_token(node: &RakuAstNode) -> Result<crate::token_kind::TokenKind, Runti
         return Err(unsupported(node));
     };
     crate::compiler::helpers_ops::op_name_to_token_kind(&s).ok_or_else(|| unsupported(node))
+}
+
+/// An optional boolean-valued named field (an omitted field is `False`, which
+/// is exactly how raku's gist elides a false `dwim-left` / `dwim-right`).
+fn bool_field(node: &RakuAstNode, name: &str) -> Result<bool, RuntimeError> {
+    match node.fields.iter().find(|f| f.name == Some(name)) {
+        None => Ok(false),
+        Some(f) => match &f.value {
+            RakuAstFieldValue::Node(v) => match v.view() {
+                ValueView::Bool(b) => Ok(b),
+                _ => Err(unsupported(node)),
+            },
+            _ => Err(unsupported(node)),
+        },
+    }
 }
 
 /// The value of a node's single positional (name-less) leaf field.

--- a/src/rakuast/mod.rs
+++ b/src/rakuast/mod.rs
@@ -76,6 +76,8 @@ pub enum RakuAstClass {
     CallQuotedMethod,
     // Phase 2 slice 26: hyper method calls.
     MetaPostfixHyper,
+    // Hyper infix operators (`@a >>+<< @b`).
+    MetaInfixHyper,
     // Phase 2 slice 3: blocks & pointy blocks.
     Block,
     Blockoid,
@@ -104,6 +106,9 @@ pub enum RakuAstClass {
     TypeDefinedness,
     // Phase 2 slice 27: attribute build-time defaults.
     TraitWillBuild,
+    // Routine return types written as a trait (`sub f() returns Int` / `of Int`).
+    TraitReturns,
+    TraitOf,
     // Phase 2 slice 21: parameterised types (`Array[Int]`).
     TypeParameterized,
     // Phase 2 slice 29: coercion types (`Int()`).
@@ -191,6 +196,7 @@ impl RakuAstClass {
             CallMethod => "RakuAST::Call::Method",
             CallQuotedMethod => "RakuAST::Call::QuotedMethod",
             MetaPostfixHyper => "RakuAST::MetaPostfix::Hyper",
+            MetaInfixHyper => "RakuAST::MetaInfix::Hyper",
             Block => "RakuAST::Block",
             Blockoid => "RakuAST::Blockoid",
             PointyBlock => "RakuAST::PointyBlock",
@@ -209,6 +215,8 @@ impl RakuAstClass {
             TypeSimple => "RakuAST::Type::Simple",
             TypeDefinedness => "RakuAST::Type::Definedness",
             TraitWillBuild => "RakuAST::Trait::WillBuild",
+            TraitReturns => "RakuAST::Trait::Returns",
+            TraitOf => "RakuAST::Trait::Of",
             TypeParameterized => "RakuAST::Type::Parameterized",
             TypeCoercion => "RakuAST::Type::Coercion",
             Class => "RakuAST::Class",
@@ -432,6 +440,7 @@ fn is_registered_type_object(class_name: &str) -> bool {
             | "RakuAST::StatementModifier"
             | "RakuAST::StatementPrefix"
             | "RakuAST::MetaPostfix"
+            | "RakuAST::MetaInfix"
     ) {
         return true;
     }
@@ -464,6 +473,7 @@ const RAKUAST_CLASSES: &[RakuAstClass] = &[
     RakuAstClass::CallMethod,
     RakuAstClass::CallQuotedMethod,
     RakuAstClass::MetaPostfixHyper,
+    RakuAstClass::MetaInfixHyper,
     RakuAstClass::Block,
     RakuAstClass::Blockoid,
     RakuAstClass::PointyBlock,
@@ -482,6 +492,8 @@ const RAKUAST_CLASSES: &[RakuAstClass] = &[
     RakuAstClass::TypeSimple,
     RakuAstClass::TypeDefinedness,
     RakuAstClass::TraitWillBuild,
+    RakuAstClass::TraitReturns,
+    RakuAstClass::TraitOf,
     RakuAstClass::TypeParameterized,
     RakuAstClass::TypeCoercion,
     RakuAstClass::Class,
@@ -934,6 +946,12 @@ pub fn node_accessor(node: &RakuAstNode, method: &str) -> Option<Value> {
             return Some(field_to_value(&f.value));
         }
     }
+    // A declared-but-omitted boolean field reads as `False`: raku's gist elides
+    // `dwim-left` / `dwim-right` when they are false, but the accessors still
+    // answer.
+    if node.class == RakuAstClass::MetaInfixHyper && matches!(method, "dwim-left" | "dwim-right") {
+        return Some(Value::truth(false));
+    }
     if method == "statements" && matches!(node.class, RakuAstClass::StatementList) {
         let items = node
             .fields
@@ -954,6 +972,7 @@ pub fn node_accessor(node: &RakuAstNode, method: &str) -> Option<Value> {
         RakuAstClass::Blockoid => Some("statement-list"),
         RakuAstClass::InitializerAssign => Some("expression"),
         RakuAstClass::TypeSimple | RakuAstClass::TypeSetting => Some("name"),
+        RakuAstClass::TraitReturns | RakuAstClass::TraitOf => Some("type"),
         _ => None,
     };
     if positional_name == Some(method)
@@ -1050,8 +1069,10 @@ fn accessor_names(class: RakuAstClass) -> &'static [&'static str] {
         Postfix => &["operator"],
         Block => &["body"],
         Blockoid => &["statement-list"],
-        Sub => &["name", "signature", "body"],
-        Signature => &["parameters"],
+        Sub => &["name", "signature", "traits", "body"],
+        Signature => &["parameters", "returns"],
+        MetaInfixHyper => &["dwim-left", "infix", "dwim-right"],
+        TraitReturns | TraitOf => &["type"],
         Parameter => &[
             "type", "names", "target", "optional", "default", "where", "slurpy",
         ],

--- a/src/rakuast/render.rs
+++ b/src/rakuast/render.rs
@@ -127,8 +127,13 @@ fn render_field_value(fv: &RakuAstFieldValue, indent: usize) -> String {
 }
 
 /// A parenthesised, trailing-comma list — every element gets a trailing comma
-/// (so a single element reads `( x, )`).
+/// (so a single element reads `( x, )`). An *empty* list is the itemized empty
+/// list `$( )`, exactly as raku's gist prints it (e.g. the `parameters` of a
+/// parameter-less `RakuAST::Signature`).
 fn render_paren_list(items: &[Value], indent: usize) -> String {
+    if items.is_empty() {
+        return "$( )".to_string();
+    }
     let child_indent = indent + 2;
     let pad = " ".repeat(child_indent);
     let mut s = String::from("(\n");

--- a/src/runtime/eval_check.rs
+++ b/src/runtime/eval_check.rs
@@ -244,7 +244,9 @@ fn walk_validate_sub_param_types(
                 ..
             } => {
                 interp.validate_param_type_constraints(param_defs, declared, packages, classes)?;
-                let via_trait = custom_traits.iter().any(|(t, _)| t == "__return_via_trait");
+                let via_trait = custom_traits
+                    .iter()
+                    .any(|(t, _)| t == "__return_via_trait" || t == "__return_via_of");
                 interp.validate_return_type_constraint(
                     return_type.as_deref(),
                     param_defs,

--- a/src/vm/vm_register_ops.rs
+++ b/src/vm/vm_register_ops.rs
@@ -247,6 +247,15 @@ impl Interpreter {
                 &mut captured_env,
                 &mut upvalues,
             );
+            // A bare block never declares a return type of its own, so a
+            // lexically-inherited `__mutsu_return_type` (from the routine or
+            // pointy block it is written inside) must not be enforced on the
+            // block's own result — the same guard the `MakeLambda` /
+            // `MakeAnonSubParams` arms already apply. Without it, a block
+            // argument written inside e.g. `-> $x --> Pair { (@k.map({ … })
+            // .join: $sep) => $x }` failed the *outer* `Pair` check on its own
+            // inner value.
+            captured_env.remove("__mutsu_return_type");
             let cc_source_line = compiled_code
                 .as_ref()
                 .and_then(|cc| cc.source_line)

--- a/t/pointy-block-return-type.t
+++ b/t/pointy-block-return-type.t
@@ -1,0 +1,37 @@
+use v6;
+use Test;
+
+# A pointy block may declare a return type (`-> $x --> Int { ... }`), and the
+# constraint is checked on the block's return value just like a sub's.
+#
+# Regression: a *single*-parameter pointy block parsed to the internal `Lambda`
+# node, which has nowhere to keep the return type, so the constraint was
+# silently dropped (`-> $x --> Int { "s" }` happily returned a Str). The
+# multi-parameter form already carried it.
+
+plan 8;
+
+my $one = -> $x --> Int { $x * 2 };
+is $one(4), 8, 'a single-parameter pointy block with a matching return type works';
+dies-ok { my $f = -> $x --> Int { "s" }; $f(1) },
+    'a single-parameter pointy block enforces its return type';
+
+my $two = -> $x, $y --> Int { $x + $y };
+is $two(3, 4), 7, 'a two-parameter pointy block with a matching return type works';
+dies-ok { my $f = -> $x, $y --> Int { "s" }; $f(1, 2) },
+    'a two-parameter pointy block enforces its return type';
+
+my $none = -> --> Int { 7 };
+is $none(), 7, 'a parameter-less pointy block with a return type works';
+
+# The declared return type is visible through the block's signature.
+is (-> $x --> Int { $x }).signature.returns.^name, 'Int',
+    'the return type is reachable through .signature.returns';
+
+# A typed parameter plus a return type compose.
+my $typed = -> Int $x --> Str { "v$x" };
+is $typed(3), 'v3', 'a typed parameter composes with a return type';
+
+# A pointy block without a return type is unconstrained, as before.
+my $plain = -> $x { "s" };
+is $plain(1), 's', 'a pointy block with no return type is unconstrained';

--- a/t/rakuast-hyper-infix.t
+++ b/t/rakuast-hyper-infix.t
@@ -1,0 +1,51 @@
+use v6;
+use MONKEY-SEE-NO-EVAL;
+use experimental :rakuast;
+use Test;
+
+# RakuAST hyper infix operators (ADR-0011), both directions.
+#
+# `@a >>+<< @b` is an `ApplyInfix` whose infix is a `MetaInfix::Hyper` wrapping
+# the base `Infix`. Each `<<` side sets the corresponding dwim flag, and raku's
+# gist omits a dwim field whose value is False. mutsu's internal `Expr::HyperOp`
+# already keeps the operator text and both flags, so the mapping is 1:1.
+#
+# Verified against Rakudo; passes under BOTH mutsu and raku.
+
+plan 15;
+
+# --- read side: the non-dwim form -------------------------------------------
+my $strict = Q[my @a; my @b; @a >>+<< @b].AST.gist;
+ok $strict.contains('RakuAST::MetaInfix::Hyper.new('),
+    'a hyper infix renders as a MetaInfix::Hyper';
+ok $strict.contains('infix      => RakuAST::Infix.new("+")')
+    || $strict.contains('infix => RakuAST::Infix.new("+")'),
+    'the base operator is kept as an Infix node';
+nok $strict.contains('dwim-left'), '>>+<< sets no dwim-left';
+nok $strict.contains('dwim-right'), '>>+<< sets no dwim-right';
+
+# --- read side: the dwim forms ----------------------------------------------
+my $both = Q[my @a; @a <<+>> 1].AST.gist;
+ok $both.contains('dwim-left') && $both.contains('=> True'), '<<+>> sets dwim-left';
+ok $both.contains('dwim-right => True'), '<<+>> sets dwim-right';
+
+my $right = Q[my @a; @a >>+>> 1].AST.gist;
+nok $right.contains('dwim-left'), '>>+>> sets no dwim-left';
+ok $right.contains('dwim-right => True'), '>>+>> sets dwim-right';
+
+my $left = Q[my @a; @a <<+<< 1].AST.gist;
+ok $left.contains('dwim-left => True'), '<<+<< sets dwim-left';
+nok $left.contains('dwim-right'), '<<+<< sets no dwim-right';
+
+# --- introspection ----------------------------------------------------------
+my $meta = Q[my @a; my @b; @a >>+<< @b].AST.statements[2].expression.infix;
+is $meta.^name, 'RakuAST::MetaInfix::Hyper', 'the infix child is a MetaInfix::Hyper';
+is $meta.infix.gist, 'RakuAST::Infix.new("+")', 'MetaInfix::Hyper.infix is the base operator';
+# An omitted dwim field still answers False through the accessor.
+is $meta.dwim-left, False, 'an elided dwim-left reads as False';
+
+# --- write side: EVAL round-trips the hyper operator ------------------------
+is EVAL(Q[my @a = 1, 2, 3; my @b = 10, 20, 30; (@a >>+<< @b).join(",")].AST),
+    '11,22,33', 'an element-wise hyper infix round-trips through EVAL';
+is EVAL(Q[my @a = 1, 2, 3; (@a >>+>> 1).join(",")].AST), '2,3,4',
+    'a dwim-right hyper infix round-trips through EVAL';

--- a/t/rakuast-return-type.t
+++ b/t/rakuast-return-type.t
@@ -1,0 +1,84 @@
+use v6;
+use MONKEY-SEE-NO-EVAL;
+use experimental :rakuast;
+use Test;
+
+# RakuAST routine return types (ADR-0011), both directions.
+#
+# raku models the two spellings with different nodes and mutsu's internal AST
+# keeps them apart, so the converter never guesses:
+#   * `sub f(--> Int)`        -> Signature.returns => Type::Simple
+#   * `sub f() returns Int`   -> traits => (Trait::Returns(Type::Simple),)
+#   * `sub f() of Int`        -> traits => (Trait::Of(Type::Simple),)
+# A parameter-less signature renders its empty parameter list as `$( )`.
+#
+# Verified against Rakudo; passes under BOTH mutsu and raku.
+
+plan 21;
+
+# --- read side: the `-->` arrow lands in the signature ----------------------
+my $arrow = Q[sub f(--> Int) { 1 }].AST.gist;
+ok $arrow.contains('returns    => RakuAST::Type::Simple.new('),
+    'a `-->` return type renders as Signature.returns';
+ok $arrow.contains('parameters => $( )'),
+    'a parameter-less signature renders its empty parameter list as $( )';
+nok $arrow.contains('RakuAST::Trait::'),
+    'a `-->` return type emits no trait';
+
+my $arrow_p = Q[sub f($x --> Int) { 1 }].AST.gist;
+ok $arrow_p.contains('RakuAST::ParameterTarget::Var.new(')
+    && $arrow_p.contains('returns    => RakuAST::Type::Simple.new('),
+    'a signature can carry both parameters and a `-->` return type';
+
+# --- read side: the `returns` / `of` traits ---------------------------------
+my $ret = Q[sub f() returns Int { 1 }].AST.gist;
+ok $ret.contains('RakuAST::Trait::Returns.new('),
+    '`returns Int` renders as a Trait::Returns';
+nok $ret.contains('returns    =>'),
+    '`returns Int` does not also fill Signature.returns';
+
+ok Q[sub f() of Int { 1 }].AST.gist.contains('RakuAST::Trait::Of.new('),
+    '`of Int` renders as a Trait::Of';
+
+ok Q[sub f($x) returns Int { 1 }].AST.gist.contains('RakuAST::Trait::Returns.new('),
+    'a parameterised sub can carry a `returns` trait';
+
+# --- a plain parameter-less sub still omits the signature -------------------
+nok Q[sub f() { 1 }].AST.gist.contains('signature'),
+    'a sub with neither parameters nor a return type omits the signature';
+
+# --- read side: an empty Signature built by hand ----------------------------
+is RakuAST::Signature.new.gist.lines[1].trim, 'parameters => $( )',
+    'a hand-built empty Signature renders parameters as $( )';
+
+# --- introspection ----------------------------------------------------------
+my $sig = Q[sub f(--> Int) { 1 }].AST.statements[0].expression.signature;
+ok $sig ~~ RakuAST::Signature, 'the sub exposes its Signature';
+is $sig.returns.name.gist, 'RakuAST::Name.from-identifier("Int")',
+    'Signature.returns is reachable through the accessors';
+
+my $trait = Q[sub f() returns Int { 1 }].AST.statements[0].expression.traits[0];
+is $trait.^name, 'RakuAST::Trait::Returns', 'the sub exposes its return trait';
+is $trait.type.name.gist, 'RakuAST::Name.from-identifier("Int")',
+    'Trait::Returns.type is reachable through the accessors';
+
+# --- write side: EVAL round-trips both spellings ----------------------------
+is EVAL(Q[sub f(Int $x --> Int) { $x * 2 }; f(5)].AST), 10,
+    'a `-->` return type round-trips through EVAL';
+is EVAL(Q[sub f($x) returns Int { $x + 1 }; f(4)].AST), 5,
+    'a `returns` trait round-trips through EVAL';
+is EVAL(Q[sub f($x) of Int { $x + 1 }; f(4)].AST), 5,
+    'an `of` trait round-trips through EVAL';
+
+# --- pointy blocks carry a `-->` return type too ----------------------------
+my $pointy = Q[my $f = -> $x --> Int { $x }].AST.gist;
+ok $pointy.contains('RakuAST::PointyBlock.new('),
+    'a single-parameter pointy block still renders as a PointyBlock';
+ok $pointy.contains('returns    => RakuAST::Type::Simple.new('),
+    'a pointy block renders its `-->` return type in the signature';
+is EVAL(Q[my $f = -> $x --> Int { $x * 3 }; $f(4)].AST), 12,
+    'a pointy block return type round-trips through EVAL';
+
+# --- write side: the lowered return type is still enforced ------------------
+throws-like { EVAL(Q[sub f(--> Int) { "nope" }; f()].AST) }, Exception,
+    'the lowered return type is checked at run time';

--- a/t/return-type-not-inherited-by-inner-block.t
+++ b/t/return-type-not-inherited-by-inner-block.t
@@ -1,0 +1,40 @@
+use v6;
+use Test;
+
+# A bare block never declares a return type, so it must not inherit — and
+# enforce — the `--> T` of the routine or pointy block it is written inside.
+#
+# Regression: the closure-construction path for a bare block `{ ... }` kept a
+# lexically captured `__mutsu_return_type`, so a block argument written inside a
+# `--> Pair` routine failed the *outer* Pair check on its own inner value:
+#
+#   -> $x --> Pair { (@k.map({ $x{$_} }).join: ":") => $x }
+#      # Type check failed for return value; expected Pair but got Str
+#
+# (found via Text::CSV's `csv(:key[...])`, which builds exactly this shape)
+
+plan 6;
+
+my %row = bar => "1", baz => "2";
+my @k = <bar baz>;
+
+my $pointy = -> $x --> Pair { (@k.map({ $x{$_} }).join: ":") => $x };
+is $pointy(%row).^name, 'Pair',
+    'a nested block inside a `--> Pair` pointy block does not inherit the check';
+is $pointy(%row).key, '1:2', 'and the pair is built from the nested block results';
+
+sub named($x --> Pair) { (@k.map({ $x{$_} }).join: ":") => $x }
+is named(%row).^name, 'Pair',
+    'a nested block inside a `--> Pair` sub does not inherit the check';
+
+my $two = -> $x, $y --> Pair { (@k.map({ $x{$_} }).join: $y) => $x };
+is $two(%row, '-').key, '1-2',
+    'the same holds for a multi-parameter pointy block';
+
+# The enclosing routine's own return type is still enforced.
+dies-ok { my $f = -> $x --> Pair { @k.map({ $x{$_} }).join(":") }; $f(%row) },
+    'the outer return type is still checked on the outer result';
+
+# A nested block that declares its own return type still enforces it.
+dies-ok { my $f = -> $x --> Pair { my $g = -> --> Int { "s" }; $g(); 'k' => $x }; $f(%row) },
+    'a nested block with its own return type still enforces that one';

--- a/todo/deep/rakuast-remaining.md
+++ b/todo/deep/rakuast-remaining.md
@@ -5,23 +5,72 @@ internal `Expr`/`Stmt` AST, not a frontend rewrite. The fixed design and phasing
 are in [ADR-0011](../../docs/adr/0011-rakuast-model-layer-and-phasing.md).
 Completed read, introspection, construction, and EVAL slices are recorded in
 [the July 2026 news](../../news/2026-07.md) and the individual
-`news/2026-07/rakuast-*.md` entries.
+`news/2026-07/rakuast-*.md` entries; the 2026-08 return-type / hyper-infix slice
+is [here](../../news/2026-08/rakuast-return-types-and-hyper-infix.md).
 
 ## Read-direction representation gaps
 
 Several source constructs are desugared or lose distinctions before the RakuAST
-conversion sees them:
+conversion sees them. Recovering these requires preserving the distinction in
+the parser/internal AST, not guessing during RakuAST conversion.
 
-- `.=` and compound assignment
-- hyper operators other than the supported hyper-method form
-- signature return types
-- anonymous subs with explicit signatures
-- `with` / `without`
-- grammar declarations
-- associative `%h{...}` versus `%h<...>` subscripts
+**Closed 2026-08-22** (both directions, pinned by `t/rakuast-return-type.t` and
+`t/rakuast-hyper-infix.t`):
 
-Recovering these requires preserving the distinction in the parser/internal AST,
-not guessing during RakuAST conversion.
+- *Signature return types on `sub` and pointy blocks.* `sub f(--> Int)` now
+  renders `Signature.returns`, `sub f() returns Int` renders
+  `traits => (Trait::Returns(...),)`, and `sub f() of Int` renders
+  `Trait::Of` — mutsu's internal AST already distinguished the two spellings
+  (a `__return_via_trait` marker in `custom_traits`), and the `of` form now
+  carries its own `__return_via_of` marker so the third node choice is not a
+  guess either. `EVAL` lowers all three back. A parameter-less signature
+  renders its empty parameter list as raku's `$( )` (mutsu printed a bare
+  multi-line `(\n)` before). Fixing the pointy-block case also fixed a real
+  runtime bug: a *single*-parameter pointy block parsed to `Expr::Lambda`,
+  which has nowhere to keep a return type, so `-> $x --> Int { "s" }`
+  silently returned a `Str` (pinned by `t/pointy-block-return-type.t`).
+- *Hyper infix operators.* `@a >>+<< @b` renders
+  `ApplyInfix(left, MetaInfix::Hyper([dwim-left,] infix, [dwim-right]), right)`
+  and lowers back. mutsu's `Expr::HyperOp` already kept the operator text and
+  both dwim flags, so this is a 1:1 mapping.
+
+Still open:
+
+- `.=` and compound assignment. `$x += 3` desugars to
+  `$x = MetaAssignIdentity(Zero)($x) + 3` (raku: `MetaInfix::Assign(Infix("+"))`)
+  and `$x .= Str` desugars to a plain `=` over a method call (raku:
+  `ApplyDottyInfix` + `DottyInfix::CallAssign`). Both need the parser to keep
+  the meta-operator instead of expanding it. ADR-0033 §2.5 already blocks the
+  `* += 1` Whatever autoprime path on the same missing `MetaInfix::Assign`.
+- Signature return types **on methods**. `method m(--> Int)` is still deferred:
+  `src/parser/stmt/sub_param/method_decl.rs` filters every `__`-prefixed marker
+  out of `MethodDecl.custom_traits`, so `-->` and `returns` are indistinguishable
+  there. Fixing it means either plumbing the spelling through a dedicated
+  `MethodDecl` field or keeping the marker and teaching the method trait-application
+  loop (`registration_class_body_method.rs`) to skip `__`-prefixed names.
+- The remaining hyper forms: hyper *prefix* (`-<<@a`, desugared to a
+  `__mutsu_hyper_prefix` call), hyper *postcircumfix* (`@a>>[1]`, desugared to a
+  hyper `AT-POS` method call), hyper *function* infix (`>>[&f]<<`, raku's
+  `MetaInfix::Hyper(FunctionInfix)` — mutsu has `Expr::HyperFuncOp` and could map
+  it), and `@a<<.abs` (which mutsu's parser currently reads as a quote-words
+  subscript).
+- Anonymous subs with explicit signatures. `sub ($x) { }` and `-> $a, $b { }` are
+  both `Expr::AnonSubParams`, so the former renders as a `PointyBlock`. Needs a
+  distinguishing flag on that node (~73 construction sites).
+- `with` / `without`. Desugared at parse time into a `__with_tmp_N` temp var plus
+  an `if` on `.defined`, so there is no statement to map to
+  `Statement::With` / `Statement::Without`.
+- Grammar declarations. `grammar G { }` is a `Stmt::ClassDecl` with
+  `parents = ["Grammar"]`, so it hits the class-inheritance boundary instead of
+  producing `RakuAST::Grammar` + `TokenDeclaration` + the regex node tree.
+- Associative `%h{...}` versus `%h<...>` subscripts. Both are
+  `Expr::Index { is_positional: false }` with a `Literal(Str)` index, so the read
+  side cannot choose raku's `Postcircumfix::LiteralHashIndex` (a word-quoted
+  `QuotedString`) over `Postcircumfix::HashIndex` (a `SemiList`). This is the
+  single highest-impact remaining read gap — associative subscripts also block
+  the corresponding `EVAL` item below — but it needs a third state on
+  `Expr::Index` (or a `SubscriptKind` enum replacing `is_positional`), and that
+  field is touched at ~225 sites across the parser, compiler, and VM.
 
 ## Type-object introspection
 
@@ -40,6 +89,12 @@ Advanced parameter construction remains:
 
 These must validate, render, expose through introspection, and lower through
 `EVAL` consistently with the already-supported parameter forms.
+
+`RakuAST::Signature.new` accepts no `returns` argument yet, and
+`RakuAST::Trait::Returns` / `Trait::Of` are read-and-lower-only (the converter
+builds them, `EVAL` lowers them, but there is no `.new` constructor). Both are
+straightforward extensions of the existing per-class schema now that the node
+kinds exist.
 
 ## Lowering and EVAL
 


### PR DESCRIPTION
Works `todo/deep/rakuast-remaining.md`. Every listed gap was re-verified against a current build first (all seven read-direction entries were still genuinely open — none had gone stale), then the two that mutsu's internal AST already had enough information for were closed end to end.

## Signature return types (read + `EVAL`)

raku models the two spellings with different nodes:

| source | raku node |
| --- | --- |
| `sub f(--> Int)` | `Signature.returns => Type::Simple` |
| `sub f() returns Int` | `traits => (Trait::Returns(...),)` |
| `sub f() of Int` | `traits => (Trait::Of(...),)` |

mutsu's parser already distinguished the first two (a `__return_via_trait` marker in `custom_traits`, because an undeclared `returns` type is `X::InvalidType` while an undeclared `-->` type is `X::Undeclared`) but collapsed `of` into the same marker. `of` now sets its own `__return_via_of`, so all three node choices come out of the parse rather than being guessed in the converter — which is exactly what the ticket asks for. `EVAL` lowers all three back to `SubDecl.return_type` plus the matching marker.

The renderer also learned raku's itemized empty-list form (`parameters => $( )`), so a parameter-less signature matches Rakudo exactly.

**Methods stay deferred** — `method_decl.rs` strips every `__`-prefixed marker from `MethodDecl.custom_traits`, so `-->` and `returns` are indistinguishable there. Recorded in the ADR and the narrowed ticket.

## Two runtime bugs found on the way

1. **A single-parameter pointy block silently dropped its return type.** It parses to `Expr::Lambda`, which has no field for one, so `-> $x --> Int { "s" }` returned a `Str` instead of failing the check (the multi-parameter form was fine). Such a block now takes the `AnonSubParams` path.
2. **A bare block inherited the enclosing routine's return type.** Enforcing (1) turned the battery gate red on `Text::CSV`'s `90_csv.t`: `MakeAnonSub` kept a lexically captured `__mutsu_return_type`, so the `{ ... }` argument inside `-> $x --> Pair { (@k.map({ $x{$_} }).join: ":") => $x }` was checked against `Pair` and failed with its own `Str`. The `MakeLambda` / `MakeAnonSubParams` arms already dropped the marker; this one now does too. It reproduces without any of the other changes (a two-parameter pointy block hits it), so it was latent.

## Hyper infix operators (read + `EVAL`)

`@a >>+<< @b` → `ApplyInfix(left, MetaInfix::Hyper([dwim-left,] infix, [dwim-right]), right)`. `Expr::HyperOp` already kept the operator text and both dwim flags, so this needed no parser change at all; every `<<`/`>>` combination matches Rakudo's gist byte for byte.

## Tests

All four new files are dual-oracle — they pass verbatim under both mutsu and the system raku:

- `t/rakuast-return-type.t` (21)
- `t/rakuast-hyper-infix.t` (15)
- `t/pointy-block-return-type.t` (8)
- `t/return-type-not-inherited-by-inner-block.t` (6)

One parser unit test was updated because a return-type-carrying pointy block deliberately no longer produces `Expr::Lambda`.

## Verification

- `cargo test` + `prove t/` — 3349 files, 31216 tests, **PASS**
- `make roast` (release) — 1436 files, 218836 tests, **PASS**
- `MUTSU_BIN=target/release/mutsu scripts/battery-testsuite.sh` — **GATE PASSED**, 257/272 (up from 256/272: `Text::CSV/90_csv.t` is fixed by the inner-block fix)

No roast file becomes newly passing — RakuAST has no roast dependents (ADR-0011 ANALYSIS §7-9), so `roast-whitelist.txt` is unchanged.

## Ticket status

`todo/deep/rakuast-remaining.md` is updated to match reality: the two closed entries are struck, and each remaining one now records *why* it is blocked and roughly how big the fix is — e.g. associative `%h{...}` vs `%h<...>` is called out as the highest-impact remainder but needs a third state on `Expr::Index`, a field touched at ~225 sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
