### PR TITLE
docs: file 17 tickets from doc-diff batch-3 (IO::Handle/structures/mop/independent-routines)

### DIFF
--- a/docs/doc-diff-backlog.md
+++ b/docs/doc-diff-backlog.md
@@ -347,6 +347,49 @@ Found in the same 2026-08-22 batch-2 re-run, `Language/regexes.rakudoc` /
   instead of raku's MoarVM-specific `moarvm`/`mbc`; this looks like an intentional identity
   difference (mutsu isn't MoarVM), not a bug — not ticketed.
 
+Found in the 2026-08-22 batch-3 re-run of `IO::Handle`/`structures`/`mop`/`independent-routines`:
+
+| file:line | one-line summary | ticket |
+|---|---|---|
+| `Type/IO/Handle.rakudoc:385` | global `lines(IO_object)` sub form doesn't open/read the file, just wraps the path arg | [lines-sub-form-io-object-not-read.md](../todo/tickets/lines-sub-form-io-object-not-read.md) |
+| `Type/IO/Handle.rakudoc:761` | `.open` stores the CWD-absolutized path instead of the path as given (`.Str`/`.path`) | [io-handle-open-stores-absolute-not-given-path.md](../todo/tickets/io-handle-open-stores-absolute-not-given-path.md) |
+| `Type/IO/Handle.rakudoc:959,1013` | custom `IO::Handle` subclasses overriding `WRITE`/`READ`/`EOF` are never dispatched to by native print/say/read | [custom-io-handle-write-read-not-dispatched.md](../todo/deep/custom-io-handle-write-read-not-dispatched.md) |
+| `Language/structures.rakudoc:233` | calling an undefined `Any`-typed value as a function throws instead of returning the args | [undefined-any-called-as-sub-throws.md](../todo/tickets/undefined-any-called-as-sub-throws.md) |
+| `Language/structures.rakudoc:258` | `but Associative[Int, Int]` (built-in parametric role) fails as "non-composable" | [builtin-parametric-role-mixin-not-composable.md](../todo/tickets/builtin-parametric-role-mixin-not-composable.md) |
+| `Language/structures.rakudoc:281` | `.sort` on a role-mixed (`but`) Hash returns the whole hash unsorted in a 1-element list | [role-mixed-hash-sort-method-dispatch-broken.md](../todo/tickets/role-mixed-hash-sort-method-dispatch-broken.md) |
+| `Language/structures.rakudoc:26`, `Language/mop.rakudoc:120` | `$(LIST).VAR.^name` reports `List` instead of `Scalar` (item contextualizer doesn't itemize) | [item-contextualized-list-var-name-not-scalar.md](../todo/tickets/item-contextualized-list-var-name-not-scalar.md) |
+| `Language/structures.rakudoc:458` | `$metadata.can($metadata, "uc")` returns `()` instead of `(uc uc)` when the invocant-arg is a `.HOW` | [metaclass-can-with-metaclass-as-invocant-arg-empty.md](../todo/tickets/metaclass-can-with-metaclass-as-invocant-arg-empty.md) |
+| `Language/mop.rakudoc:329` | a grammar's `method ^parameterize` + parametric role application stack-overflows | [grammar-metaclass-parameterize-stack-overflow.md](../todo/deep/grammar-metaclass-parameterize-stack-overflow.md) |
+| `Language/mop.rakudoc:34` | `constant NAME := Metamodel::ClassHOW.new_type(name => 'NAME')` immediately errors as "immutable" | [direct-metamodel-classhow-new-type-immutable-error.md](../todo/deep/direct-metamodel-classhow-new-type-immutable-error.md) |
+| `Language/mop.rakudoc:93` | `.HOW.^name` on a hash literal is missing the `+{<anon>}` mixin suffix | [how-gist-missing-anon-mixin-suffix.md](../todo/tickets/how-gist-missing-anon-mixin-suffix.md) |
+| `Type/independent-routines.rakudoc:110` | `EVAL` doesn't synthesize an `EVAL_N` filename for `$?FILE`, and ignores the `:filename` arg | [eval-dollar-question-file-not-synthesized.md](../todo/tickets/eval-dollar-question-file-not-synthesized.md) |
+| `Type/independent-routines.rakudoc:148` | `repl()` global routine is unimplemented (mutsu already has REPL machinery to reuse) | [repl-routine-unimplemented.md](../todo/tickets/repl-routine-unimplemented.md) |
+| `Type/independent-routines.rakudoc:473` | `open(:w, PATH)` — a named adverb before the positional path breaks argument parsing | [open-named-adverb-before-positional-path.md](../todo/tickets/open-named-adverb-before-positional-path.md) |
+| `Type/independent-routines.rakudoc:687,692` | `.printf` method form is unimplemented on Str, and format directives don't autothread over a Junction | [printf-method-form-and-junction-autothread-missing.md](../todo/tickets/printf-method-form-and-junction-autothread-missing.md) |
+| `Type/independent-routines.rakudoc:1497` | `done VALUE` inside a `supply {}` block drops the value instead of emitting it first | [supply-done-value-drops-emit.md](../todo/tickets/supply-done-value-drops-emit.md) |
+| `Type/independent-routines.rakudoc:312` | hyper method call (`».method`) / `.map` on a `gather {...}` Seq returns empty instead of forcing it | [gather-hyper-method-call-empty-result.md](../todo/tickets/gather-hyper-method-call-empty-result.md) |
+
+**Excluded from this batch-3 sub-run (already deferred/resolved/drift/false-positive):**
+- `Type/IO/Handle.rakudoc` [385] itself was bucketed `raku-drift` by the harness (raku's own
+  `/proc/$*PID/statm` numbers are PID-dependent and don't match the doc's stated numbers), but the
+  *shape* of mutsu's output underneath that drift (wrapping the literal path instead of reading the
+  file at all) is a real, separate bug — filed above as
+  [lines-sub-form-io-object-not-read.md](../todo/tickets/lines-sub-form-io-object-not-read.md).
+- `Language/structures.rakudoc` [36], [45] (`.WHICH` addresses) — `raku-drift`, pointer values are
+  inherently non-reproducible.
+- `Language/structures.rakudoc` [95], [108] (`%hash.list[0]`, `<a b c d>.Hash.kv` ordering) — the
+  "Known harness false positive" hash/Set iteration-order nondeterminism documented above the
+  Ticketed section; both sides are randomized per-process in real raku too.
+- `Language/structures.rakudoc` [123] (`class SortedArray is Array { method iterator {...} }`) —
+  matches the already-**Deferred** Lazy-list cluster's explicitly-named residue: "the custom `does
+  Iterator` residue where an `is Array` subclass skips its user iterator (`__mutsu_array_storage`
+  guard in `vm_for_loop_dispatch.rs`)".
+- `Type/independent-routines.rakudoc` [1429] (`append %h, i => (1, 42)`) — bucketed `raku-drift`
+  because the doc's stated error text doesn't match raku's actual error text; mutsu also throws (a
+  different, generic "Unknown call: append" instead of a specific signature-mismatch error) — same
+  "exception type/meaning matches, message text differs" shape already excluded elsewhere in this
+  ledger (e.g. `Language/control.rakudoc` [10] above), not ticketed.
+
 ### Deferred / deep (tracked elsewhere — do not re-open as a shallow slice)
 These root causes account for a large share of the survey's `mism`/`crash` and are
 intentionally deferred; see PLAN.md §8.5 and the ADRs:

--- a/todo/deep/custom-io-handle-write-read-not-dispatched.md
+++ b/todo/deep/custom-io-handle-write-read-not-dispatched.md
@@ -1,0 +1,104 @@
+# Custom `IO::Handle` subclasses overriding WRITE/READ/EOF are not honored by print/say/read
+
+Found by the doc-diff harness (`docs/doc-diff-backlog.md`, `Type/IO/Handle.rakudoc:959`
+and `:1013` — the "Creating Custom Handles" section's own worked examples).
+
+## What's broken
+
+`IO::Handle.rakudoc` documents a whole feature (6.d language, "Creating Custom
+Handles"): a user class `is IO::Handle` that implements `.WRITE`/`.READ`/`.EOF` gets
+all the textual read/write methods (`.print`, `.say`, `.get`, `.lines`, `.read`, ...)
+"for free" via the base `IO::Handle` class dispatching to those overridable primitives.
+This is completely unimplemented in mutsu: native `.print`/`.say`/`.read` write/read
+directly against a real OS file descriptor (or real stdout) and never consult a
+subclass's `.WRITE`/`.READ`/`.EOF` overrides.
+
+## Minimal repros (both straight from the doc)
+
+### 1. Redirecting `$*OUT` (or `$PROCESS::OUT`) to a custom WRITE-overriding handle
+
+```raku
+class IO::Store is IO::Handle {
+    has @.lines = [];
+    submethod TWEAK { self.encoding: 'utf8'; }
+    method WRITE(IO::Handle:D: Blob:D \data --> Bool:D) {
+        @!lines.push: data.decode();
+        True;
+    }
+    method gist() { return @!lines.join("\n"); }
+}
+my $store = IO::Store.new();
+my $output = $*OUT;
+$*OUT = $store;
+.say for <one two three>;
+$*OUT = $output;
+say $store.lines();
+```
+
+- `raku`: `[one\n two\n three\n]` — every `say` was routed through `.WRITE` and
+  captured into `@lines`; nothing printed to the real stdout during the redirect.
+- `mutsu`: prints `one`/`two`/`three` straight to the real stdout (the redirect is
+  ignored), then `$store.lines()` is `[]` (empty — `.WRITE` was never called).
+
+Confirmed this reproduces identically for both `$PROCESS::OUT = $store` (the doc's own
+form) and the more common `$*OUT = $store` (tested directly). Root-cause hint: `say`
+compiles to `write_to_named_handle("$*OUT", ...)`
+(`src/vm/vm_data_io_ops.rs::exec_say_op` → `src/runtime/io_env.rs::write_to_named_handle`),
+which *does* attempt `self.call_method_with_values(handle, "print", ...)` for a handle
+without a native `handle_id` before falling back to real stdout — so the intent is
+there, but that `.print` dispatch onto the `IO::Store` instance is evidently failing
+(or `IO::Handle`'s inherited native `.print` doesn't itself call back into the
+subclass's `.WRITE`), silently falling through to `emit_output` (real stdout).
+
+### 2. A custom READ/EOF handle used for output *and* input (`.print` + `.read`)
+
+```raku
+class IO::Store is IO::Handle {
+    has @.lines = [];
+    submethod TWEAK { self.encoding: 'utf8'; }
+    method WRITE(IO::Handle:D: Blob:D \data --> Bool:D) { @!lines.push: data; True; }
+    method whole() {
+        my Buf $everything = Buf.new();
+        for @!lines -> $b { $everything ~= $b; }
+        return $everything;
+    }
+    method READ(IO::Handle:D: Int:D \bytes --> Buf:D) {
+        my Buf $everything := self.whole();
+        return $everything;
+    }
+    method EOF { my $everything = self.whole(); !$everything; }
+}
+my $store := IO::Store.new();
+$store.print( $_ ) for <one two three>;
+say $store.read(3).decode;   # OUTPUT: «one␤»
+say $store.read(3).decode;   # OUTPUT: «two␤»
+```
+
+- `raku`: `one` then `two`.
+- `mutsu`: dies immediately with `Expected IO::Handle` (a type-check inside the native
+  `.print`/`.read` dispatch that rejects a non-native-backed `IO::Handle` subclass
+  instance outright).
+
+## Why this is a deep ticket
+
+Fixing this properly means every native IO::Handle read/write entry point
+(`.print`/`.put`/`.say`/`.printf`/`.write`, and `.read`/`.readchars`/`.get`/`.getc`/
+`.lines`/`.words`/`.slurp`) needs a "does this handle have a real native `handle_id`,
+or is it a user subclass with `.WRITE`/`.READ`/`.EOF` overrides?" branch, and the
+override branch needs to actually call back into the interpreter's method dispatch
+(recursively, since `.WRITE`/`.READ` are themselves regular user methods that can do
+anything). That is a systemic change across `src/runtime/native_io/io_handle.rs`,
+`src/runtime/handle_open.rs`, and the say/print/note VM ops
+(`src/vm/vm_data_io_ops.rs`), not a single-site fix — hence `todo/deep/` rather than
+`todo/tickets/`.
+
+## Affected files (starting point)
+
+- `src/runtime/io_env.rs::write_to_named_handle` — the `$*OUT`/`$*ERR` redirect path;
+  already has *some* handle-without-`handle_id` fallback logic that should be the
+  right shape once `.print` dispatch onto a user `IO::Handle` subclass actually works.
+- `src/runtime/native_io/io_handle.rs` — native `.print`/`.read`/etc. dispatch; needs a
+  branch that checks for user-defined `.WRITE`/`.READ`/`.EOF` before assuming a native
+  backing handle.
+- `src/runtime/handle_open.rs` — `IoHandleState`/`IoHandleTarget` may need a new target
+  variant for "backed by user WRITE/READ methods, not a real fd".

--- a/todo/deep/direct-metamodel-classhow-new-type-immutable-error.md
+++ b/todo/deep/direct-metamodel-classhow-new-type-immutable-error.md
@@ -1,0 +1,71 @@
+# `constant NAME := Metamodel::ClassHOW.new_type(name => 'NAME')` immediately errors as "immutable"
+
+Found by the doc-diff harness (`docs/doc-diff-backlog.md`, `Language/mop.rakudoc:34` —
+the doc's own worked example showing what a `class A { ... }` declaration desugars to
+at the metaobject-protocol level).
+
+## Repro
+
+```raku
+constant A := Metamodel::ClassHOW.new_type( name => 'A' );  # class A {
+A.^add_method('x', my method x(A:) { say 42 });             #   method x()
+A.^compose;                                                 # }
+
+A.x();
+```
+
+- `raku`: `42`
+- `mutsu` (`target/debug/mutsu`): dies immediately on the `constant A := ...` line
+  with `Cannot modify an immutable 'A' type object`.
+
+## Minimal isolation
+
+The error fires on the `constant` binding alone, before any `.^add_method`/`.^compose`
+call:
+
+```raku
+constant Zorp := Metamodel::ClassHOW.new_type( name => "Zorp" );
+say Zorp.^name;
+```
+
+- `raku`: `Zorp`
+- `mutsu`: same `Cannot modify an immutable 'Zorp' type object` error.
+
+## Root cause hypothesis
+
+The guard that produces this error lives in `src/vm/vm_exec_dispatch.rs` (~line
+1125-1140): when binding/assigning to a bareword name, it rejects the write if the
+name is already registered as a class (`self.has_class(&name)`) and the env already
+holds a `Package` value under that name. This guard is meant to catch real
+reassignment attempts like `Foo .= new` on a frozen type object.
+
+The false positive here is almost certainly that `Metamodel::ClassHOW.new_type(name =>
+"Zorp")` — mutsu's implementation of `new_type` — has a **side effect of eagerly
+registering a class named "Zorp"** in the class registry (and/or binding a `Package`
+value under that bareword in env) *before* the `constant Zorp := ...` binding itself
+executes. Then when the `constant` binding tries to actually establish `Zorp` as a
+name, the guard sees "there's already a registered class + Package value called Zorp"
+and treats it as an illegal reassignment — even though this is the *first and only*
+write, not a mutation of an already-composed type.
+
+In real Rakudo, `Metamodel::ClassHOW.new_type(...)` returns a fresh, still-mutable
+type object; it does not itself bind any global/package name. The name only comes into
+existence when the surrounding `constant`/`my`/`our` binding assigns it.
+
+## Why this is deep
+
+Fixing this requires understanding (and probably reworking) how mutsu's
+`Metamodel::ClassHOW.new_type` interacts with the class registry and with the
+generic "protect already-composed type objects from mutation" guard — a change that
+touches class registration bootstrapping, not just the guard's condition. There's also
+a design question of whether mutsu should support the *general* pattern of scripting
+type creation directly through `Metamodel::*` calls (as opposed to only via `class`/
+`role`/`enum` declarations), which has broader implications for the MOP.
+
+## Affected files (starting point)
+
+- `src/vm/vm_exec_dispatch.rs` (~line 1125-1140) — the immutable-type-object guard.
+- Wherever `Metamodel::ClassHOW.new_type` is implemented (grep for `"new_type"`) —
+  check whether it eagerly registers the class/binds the name as a side effect, and
+  whether that should instead be deferred until an explicit `.^compose` (matching
+  Rakudo's model of "mutable until composed").

--- a/todo/deep/grammar-metaclass-parameterize-stack-overflow.md
+++ b/todo/deep/grammar-metaclass-parameterize-stack-overflow.md
@@ -1,0 +1,64 @@
+# A grammar with `method ^parameterize` + parametric role application stack-overflows
+
+Found by the doc-diff harness (`docs/doc-diff-backlog.md`, `Language/mop.rakudoc:329`
+— the doc's own worked example for the "parametric" archetype / grammar
+parameterization).
+
+## Repro
+
+```raku
+grammar Bot::Grammar {
+    token TOP { <topic> || .+ }
+
+    proto token topic {*}
+    multi token topic:sym<command> { <command> <.ws> <command-args> }
+
+    token command      { '$' <!ws>+ }
+    token command-args { <!ws>+ % <.ws> }
+
+    method ^parameterize(::?CLASS:U $this is raw, +roles) {
+        my Str:D $name   = self.name: $this;
+        my Mu    $mixin := $this.^mixin: |roles;
+        $mixin.^set_name: [~] $name, '[', roles.map(*.^name).join(','), ']';
+        $mixin
+    }
+}
+
+role Greetings[Str:D $name] {
+    multi token topic:sym<greeting> { ^ [ 'hi' | 'hello' | 'hey' | 'sup' ] <.ws> $name }
+}
+
+my constant GreetBot = Bot::Grammar[Greetings['GreetBot']];
+GreetBot.parse: 'sup GreetBot';
+say ~$/;
+```
+
+- `raku`: `sup GreetBot`
+- `mutsu` (`target/debug/mutsu`): **crashes with a stack overflow**
+  (`thread 'mutsu-main' has overflowed its stack; fatal runtime error: stack overflow,
+  aborting`, exit 134). Confirmed with a 15s timeout — it's a genuine unbounded
+  recursion, not merely a slow computation.
+
+## Why this is deep
+
+The repro exercises several advanced MOP features together: a user-defined metaclass
+method (`method ^parameterize`), `.^mixin`/`.^set_name` metamethod calls, and applying
+a parametric role (`Greetings['GreetBot']`) as a type parameter to a grammar
+(`Bot::Grammar[...]`). The stack overflow strongly suggests one of these metamethod
+calls (most likely `.^mixin` or the `Bot::Grammar[Greetings['GreetBot']]`
+parameterization itself) recurses into itself — e.g. resolving the parameterization
+calls back into `method ^parameterize` again without terminating, or a mixin/role
+composition step loops through the same registration path repeatedly.
+
+Debugging this needs `rust-gdb -batch` breakpoints on the metaclass-method-dispatch
+and parametric-role-application call sites per the project's debugging guidelines (an
+`eprintln!`-based bisection would be slow given the crash is a stack overflow, not a
+clean error) to find which call is unbounded before attempting a fix.
+
+## Affected files (starting point)
+
+- Wherever `method ^name(...)` (user-defined metaclass methods, the `^` sigil on a
+  method declaration) is dispatched — grep for "parameterize" and "^set_name"/
+  "^mixin" metamethod handling.
+- Parametric role/grammar application (`Type[Args]` syntax) — likely in
+  `src/runtime/class.rs` or a dedicated parametric-role module.

--- a/todo/tickets/builtin-parametric-role-mixin-not-composable.md
+++ b/todo/tickets/builtin-parametric-role-mixin-not-composable.md
@@ -1,0 +1,43 @@
+# `but Associative[Int, Int]` (a built-in parametric role) fails as "non-composable"
+
+Found by the doc-diff harness (`docs/doc-diff-backlog.md`, `Language/structures.rakudoc:258`).
+
+## Root cause
+
+`exec_but_mixin_op` (`src/vm/vm_mixin_does_ops.rs`) decides whether the RHS of `but` is
+a role (and should go through `eval_does_values`) using `self.has_role(name)`
+(`src/runtime/types/type_registry.rs::has_role`), which only checks the
+user-role registry (`registry().roles`). Built-in roles that aren't registered there
+(`Positional`, `Associative`, `Callable`, `Iterable`, `Numeric`, `Real`, `Stringy`,
+`Mixy`, `Setty`, `Baggy`, `Blob`, `Buf`) are known elsewhere — `is_role_type_name`
+(same file, ~line 222) has its own separate `BUILTIN_ROLES` list — but that second list
+is only consulted for the *type-object* invocant error path
+(`but_on_type_object_error`), not for the main `role_composed` match at the top of
+`exec_but_mixin_op`.
+
+So `%hash but Associative[Int, Int]` never enters the `ParametricRole { base_name, .. }
+if self.has_role(&base_name.resolve())` arm (since `has_role("Associative")` is
+`false`), falls through to the generic "not a role" path, and hits
+`mixin_not_composable_error`.
+
+## Minimal repro
+
+```raku
+my %not-scalar := %(2 => 3) but Associative[Int, Int];
+say %not-scalar.^name;
+```
+
+- `raku`: `Hash+{Associative[Int,Int]}`
+- `mutsu` (`target/debug/mutsu`): dies with
+  `Cannot mix in non-composable type Associative[Int,Int] into object of type Hash`.
+
+## Affected files (starting point)
+
+- `src/vm/vm_mixin_does_ops.rs::exec_but_mixin_op` — the `role_composed` match's role
+  checks (`has_role`) should also recognize the built-in roles that
+  `is_role_type_name`'s `BUILTIN_ROLES` list already knows about. Consider unifying
+  the two role-name checks (`has_role` vs. `is_role_type_name`) so there's a single
+  source of truth for "is this name a role (user or built-in)".
+- `src/runtime/types/type_registry.rs::has_role` — may need to consult a shared
+  built-in-roles list, or `is_role_type_name` needs to be reachable/reused from
+  `vm_mixin_does_ops.rs`'s `role_composed` match arms.

--- a/todo/tickets/eval-dollar-question-file-not-synthesized.md
+++ b/todo/tickets/eval-dollar-question-file-not-synthesized.md
@@ -1,0 +1,41 @@
+# `EVAL` doesn't synthesize an `EVAL_N` filename for `$?FILE`, and ignores the `:filename` arg
+
+Found by the doc-diff harness (`docs/doc-diff-backlog.md`,
+`Type/independent-routines.rakudoc:110`).
+
+## Repro
+
+```raku
+use MONKEY-SEE-NO-EVAL;
+EVAL 'say $?FILE';                              # raku: a synthetic .../EVAL_0 path
+EVAL 'say $?FILE', filename => '/my-eval-code'; # raku: /my-eval-code
+```
+
+- `raku`: prints a synthetic `EVAL_0`-suffixed path for the first call (the doc says
+  `/tmp/EVAL_0`; current raku actually uses the CWD instead of `/tmp` — that specific
+  detail is `raku-drift`, not a mutsu bug), then `/my-eval-code` for the second call
+  (honoring the explicit `:filename` argument).
+- `mutsu` (`target/debug/mutsu`): both calls print the **outer script's own** file
+  path (e.g. `tmp/ddh/prog-....raku` under the harness, or `-e` for `-e` scripts) —
+  `$?FILE` inside `EVAL`-compiled code is never given a synthetic name, and the
+  `:filename` named argument is silently ignored entirely (both calls print the exact
+  same thing).
+
+## Minimal isolation
+
+```raku
+use MONKEY-SEE-NO-EVAL;
+EVAL q[say $?FILE];
+EVAL q[say $?FILE], filename => "/my-eval-code";
+```
+
+- `raku`: two different lines — a synthetic `EVAL_0` path, then `/my-eval-code`.
+- `mutsu`: `-e` printed twice (the outer script's own file, `:filename` ignored).
+
+## Affected files (starting point)
+
+- Wherever `EVAL`/`EVALFILE` is implemented and compiles/executes a sub-source string
+  (grep for `"EVAL"` in `src/runtime/`) — needs to (1) synthesize a per-call
+  `EVAL_<N>` filename (an incrementing counter) for the re-entrant compilation's
+  `$?FILE`/`$*PROGRAM-NAME`-equivalent context when no `:filename` is given, and (2)
+  honor an explicit `filename =>` named argument when present.

--- a/todo/tickets/gather-hyper-method-call-empty-result.md
+++ b/todo/tickets/gather-hyper-method-call-empty-result.md
@@ -1,0 +1,49 @@
+# Hyper method call (`».method`) / `.map` on a `gather {...}` Seq returns empty instead of forcing it
+
+Found by the doc-diff harness (`docs/doc-diff-backlog.md`,
+`Type/independent-routines.rakudoc:312` — the `indir` routine's own doc example).
+
+## Repro
+
+```raku
+say indir("/tmp", {
+    gather { take ".".IO }
+})».CWD;
+```
+
+- `raku`: `(/home/.../cwd-before-indir)` — one element, the CWD of the process before
+  `indir` temporarily changed it.
+- `mutsu` (`target/debug/mutsu`): `()` — empty.
+
+## Minimal isolation (no `indir` needed)
+
+```raku
+my $g = gather { take ".".IO };
+say $g».CWD;   # raku: (cwd); mutsu: ()
+say $g.map(*.CWD);  # raku: (cwd); mutsu: (...) -- literally the 3-dot placeholder string
+```
+
+So this isn't specific to `indir` at all — a `gather`-produced lazy `Seq`, when
+`.map`'d or hyper-method-called directly (without first being reified some other way,
+e.g. by assigning to an `@`-sigiled variable or calling `.elems`), silently produces no
+elements. `.map` is even worse: it doesn't error, it returns the literal 3-dot
+placeholder gist string wrapped as if it were a value, rather than either the mapped
+result or a genuine still-lazy Seq.
+
+## Root cause hypothesis (needs verification, not fixed here)
+
+Likely related to — but not explicitly listed as a residue of — the already-Deferred
+"Lazy-list cluster" in `docs/doc-diff-backlog.md` (gather/take reification,
+`vm_for_loop_dispatch.rs`'s `__mutsu_array_storage` guard, etc.). This ticket is filed
+separately because the specific symptom (a *directly* mapped/hyper-called gather Seq,
+with no intervening variable) isn't among that cluster's explicitly enumerated
+remaining items — worth checking whether a future fix for one also fixes the other,
+or whether this is a distinct gap in how `.map`/`».` dispatch onto a not-yet-reified
+`LazyList` value.
+
+## Affected files (starting point)
+
+- `src/vm/vm_call_ops.rs` (hyper method call `».` dispatch) and wherever `.map` is
+  implemented for a `ValueView::LazyList` receiver — needs to force/iterate the
+  gather's lazy Seq rather than treating it as already-empty or rendering its
+  placeholder gist as if it were the mapped value.

--- a/todo/tickets/how-gist-missing-anon-mixin-suffix.md
+++ b/todo/tickets/how-gist-missing-anon-mixin-suffix.md
@@ -1,0 +1,29 @@
+# `.HOW.^name` on a hash literal is missing the `+{<anon>}` mixin suffix
+
+Found by the doc-diff harness (`docs/doc-diff-backlog.md`, `Language/mop.rakudoc:93`).
+
+## Repro
+
+```raku
+say (%).HOW.^name
+```
+
+- `raku`: `Perl6::Metamodel::ClassHOW+{<anon>}`
+- `mutsu` (`target/debug/mutsu`): `Perl6::Metamodel::ClassHOW` (missing the
+  `+{<anon>}` suffix)
+
+## Root cause hypothesis
+
+Rakudo's `ClassHOW` metaclass instance for a value like a bare hash literal apparently
+has an anonymous role mixed into it (hence `+{<anon>}` in its own `.^name`), which
+mutsu's `.HOW` implementation doesn't replicate — mutsu's `HOW` metaclass object
+gists as the bare class name with no mixin annotation. This is a small, cosmetic-ish
+gap in how deep mutsu's `.HOW`/metaclass modeling goes, not a functional dispatch bug
+(the earlier line in the same doc, `$metadata.^mro` = `((ClassHOW) (Any) (Mu))`,
+already matches raku).
+
+## Affected files (starting point)
+
+- Wherever `.HOW` produces its metaclass instance/gist (grep for `ClassHOW` in
+  `src/runtime/`) — likely `src/runtime/class_introspection.rs` or
+  `src/runtime/methods_classhow_lookup.rs`.

--- a/todo/tickets/io-handle-open-stores-absolute-not-given-path.md
+++ b/todo/tickets/io-handle-open-stores-absolute-not-given-path.md
@@ -1,0 +1,42 @@
+# `.IO.open` stores the CWD-absolutized path instead of the path as given
+
+Found by the doc-diff harness (`docs/doc-diff-backlog.md`, `Type/IO/Handle.rakudoc:761`).
+
+## Root cause
+
+`IO::Handle::open` (`src/runtime/native_io/io_handle.rs`, the `"open"` match arm)
+resolves the requested path to an absolute path via `self.resolve_path(&path_str)`
+(`src/runtime/io_env.rs::resolve_path`, which always joins a relative path onto
+`$*CWD`) **before** opening the file, and then passes that already-absolutized
+`PathBuf` straight into `open_file_handle` (`src/runtime/handle_open.rs`). There,
+`open_file_handle` stores `Self::stringify_path(path)` — the absolutized path — as the
+handle's `path` attribute (`src/runtime/handle_open.rs:534`). Rakudo instead opens the
+file using the resolved/absolute path internally but keeps the *original* path string
+(relative or absolute, whatever the caller passed) as the handle's `.path`/`.Str`
+representation.
+
+## Minimal repro
+
+```raku
+say "foo".IO.open.Str;
+```
+
+- `raku`: `foo`
+- `mutsu` (`target/debug/mutsu`): the full absolutized path, e.g.
+  `/home/.../foo`
+
+Also affects `.path` (which raku gists as `"foo".IO`, mutsu gists as
+`"/home/.../foo".IO`). Confirmed the plain `.IO` (no `.open`) already keeps the
+relative path correctly (`"foo".IO.Str` prints `foo` in both); the absolutization only
+happens through the `.open` path.
+
+## Affected files (starting point)
+
+- `src/runtime/native_io/io_handle.rs` (`"open"` arm, ~line 195-263) — should keep the
+  original (as-given) path string for the handle's `path` attribute, using the
+  resolved/absolute `PathBuf` only for the actual `OpenOptions::open()` filesystem
+  call.
+- `src/runtime/handle_open.rs::open_file_handle` (~line 471-540) — currently stores
+  whatever `Path` it's given; may need an extra parameter (or the caller passing an
+  already-corrected display path) to decouple "path used to open" from "path stored
+  for display".

--- a/todo/tickets/item-contextualized-list-var-name-not-scalar.md
+++ b/todo/tickets/item-contextualized-list-var-name-not-scalar.md
@@ -1,0 +1,38 @@
+# `$(LIST).VAR.^name` reports `List` instead of `Scalar`
+
+Found by the doc-diff harness (`docs/doc-diff-backlog.md`,
+`Language/structures.rakudoc:26` and `Language/mop.rakudoc:120`).
+
+## Root cause hypothesis
+
+The item contextualizer `$(...)` is supposed to wrap its operand in a `Scalar`
+container (this is exactly what `mop.rakudoc`'s "VAR" section documents: "The
+presence of a `Scalar` object indicates that the object is itemized"). mutsu's
+`$(...)` appears to produce a value whose `.VAR` reports the *inner* type (`List`)
+rather than `Scalar`, i.e. the itemization isn't actually creating/tagging a Scalar
+container the way `.VAR` introspection expects.
+
+## Minimal repro
+
+```raku
+say $(4, 5).VAR.^name;      # raku: Scalar; mutsu: List
+say $(1, 2, 3).VAR ~~ Scalar;  # raku: True;   mutsu: False
+```
+
+Both are the same underlying bug (from two different doc files, `structures.rakudoc`
+and `mop.rakudoc`).
+
+For contrast, a plain (non-itemized) list already reports correctly:
+
+```raku
+say (1, 2, 3).VAR ~~ Scalar;  # raku AND mutsu: False
+```
+
+## Affected files (starting point)
+
+- Wherever `$(...)` (the item contextualizer, distinct from a `$var` sigil) is
+  compiled/evaluated — likely `src/compiler/expr.rs` and the corresponding VM op that
+  builds the itemized value. Also `.VAR`'s implementation (probably in
+  `src/runtime/methods_object_*` or a dedicated introspection module) — needs to
+  recognize the itemized-List representation as "wrapped in a Scalar" the same way it
+  presumably already does for `my $x = (1,2,3)`.

--- a/todo/tickets/lines-sub-form-io-object-not-read.md
+++ b/todo/tickets/lines-sub-form-io-object-not-read.md
@@ -1,0 +1,39 @@
+# `lines(IO_object)` sub form doesn't open/read the file — it wraps the arg unchanged
+
+Found by the doc-diff harness (`docs/doc-diff-backlog.md`, `Type/IO/Handle.rakudoc:385`
+and `Type/independent-routines.rakudoc`'s `lines` section).
+
+## Root cause hypothesis
+
+The global `lines()` routine (sub form, as opposed to the `.lines` method) does not
+dispatch to the same file-reading logic as the method form. When called with an
+`IO::Path` positional argument, it appears to just wrap the argument itself into a
+one-element list instead of opening the path and reading its lines.
+
+The **method** form (`"path".IO.lines`) works correctly — only the **sub** form
+(`lines($io-path)`) is broken.
+
+## Minimal repro
+
+```raku
+my $io = "tmp/lines-test.txt".IO;  # file contains "a\nb\nc\n"
+say lines($io);          # sub form
+say $io.lines;           # method form
+```
+
+- `raku`: `(a b c)` for both.
+- `mutsu` (`target/debug/mutsu`): sub form prints `(tmp/lines-test.txt)` (the
+  `IO::Path`'s stringified path wrapped in a list) instead of reading the file; the
+  method form correctly prints `(a b c)`.
+
+Also reproduces with `/proc/$*PID/statm` (the doc's own example) — mutsu prints
+`(/proc/<pid>/statm)` instead of the file's numeric fields (raku's own numbers are of
+course PID/environment-dependent, but the *shape* of mutsu's wrong output — a
+1-element list containing the literal path string — is not).
+
+## Affected files (starting point)
+
+- Wherever the global `lines` sub is dispatched (likely `src/runtime/builtins*.rs` or
+  `src/runtime/builtins_io.rs`) — needs to detect an `IO::Path`/`IO::Handle` positional
+  argument and delegate to the same open+read-lines logic the `.lines` method uses,
+  rather than treating the argument as an opaque value to wrap.

--- a/todo/tickets/metaclass-can-with-metaclass-as-invocant-arg-empty.md
+++ b/todo/tickets/metaclass-can-with-metaclass-as-invocant-arg-empty.md
@@ -1,0 +1,46 @@
+# `$metadata.can($metadata, "uc")` returns `()` instead of `(uc uc)` when `$metadata` is a `.HOW`
+
+Found by the doc-diff harness (`docs/doc-diff-backlog.md`,
+`Language/structures.rakudoc:458` — the "Introspection" section's own worked example).
+
+## Repro
+
+```raku
+my $any-object = "random object";
+my $metadata = $any-object.HOW;
+say $metadata.^mro;                   # OUTPUT: «((ClassHOW) (Any) (Mu))␤» -- matches raku
+say $metadata.can( $metadata, "uc" ); # OUTPUT: «(uc uc)␤»
+```
+
+- `raku`: `(uc uc)`
+- `mutsu` (`target/debug/mutsu`): `()`
+
+## Minimal isolation
+
+```raku
+my $s = "x";
+my $m = $s.HOW;
+say $m.can($m, "uc");   # raku: (uc uc); mutsu: ()
+```
+
+For contrast, passing the *original* instance (not the HOW itself) as the
+`can`-argument already works correctly in mutsu:
+
+```raku
+my $s = "x";
+say $s.HOW.can($s, "uc"); # raku AND mutsu: (uc)
+```
+
+So the bug is specific to passing the metaclass object itself (`$metadata`/`$m`) as
+the first argument to its own `.can` — Rakudo's `ClassHOW.can(invocant, name)`
+apparently resolves against the type `invocant` *represents* rather than literally
+introspecting `invocant`'s own type when `invocant` happens to be a HOW object, and
+returns two matches (`uc uc`) where the direct-instance call above returns only one
+(`uc`) — suggesting Rakudo's dispatch here is doing something more elaborate (walking
+both the represented type's MRO and possibly a self-referential HOW hierarchy) that
+mutsu's `can` implementation doesn't replicate.
+
+## Affected files (starting point)
+
+- Wherever `Metamodel::ClassHOW.can` / `.^can` is implemented — grep for `"can"` in
+  `src/runtime/class_introspection.rs` or `src/runtime/methods_classhow_lookup.rs`.

--- a/todo/tickets/open-named-adverb-before-positional-path.md
+++ b/todo/tickets/open-named-adverb-before-positional-path.md
@@ -1,0 +1,50 @@
+# `open(:w, PATH)` — a named adverb before the positional path argument breaks argument parsing
+
+Found by the doc-diff harness (`docs/doc-diff-backlog.md`,
+`Type/independent-routines.rakudoc:473`).
+
+## Root cause
+
+`builtin_open` (`src/runtime/builtins_io.rs::builtin_open`, ~line 376) unconditionally
+treats `args.first()` (the literal first element of the args slice) as the path, and
+`args[1..]` as the mode flags:
+
+```rust
+let path = match args.first() {
+    Some(v) => match v.view() { ... _ => v.to_string_value() },
+    None => return Err(...),
+};
+...
+let (read, write, ...) = self.parse_io_flags_values(&args[1..]);
+```
+
+This assumes the path is always the syntactically-first argument. But raku call
+syntax allows a named argument to appear *before* a positional one at the call site
+(`open :w, '/path'` is equivalent to `open '/path', :w`) — when that happens, `args[0]`
+is actually the `:w` Pair (`"w" => True`), not the path, and mutsu ends up trying to
+open a file literally named after the stringified Pair.
+
+## Minimal repro
+
+```raku
+my $fh = open :w, "/tmp/mutsu-open-test.txt";
+$fh.say: "hi";
+$fh.close;
+```
+
+- `raku`: works, creates/writes the file.
+- `mutsu` (`target/debug/mutsu`): dies with
+  `Failed to open '.../w\tTrue': No such file or directory (os error 2)` — the `:w`
+  Pair got stringified (`"w\tTrue"`, tab-separated) and treated as the filename.
+
+Also affects the doc's own example (`open :w, '/tmp/some-file.txt'`).
+
+## Affected files (starting point)
+
+- `src/runtime/builtins_io.rs::builtin_open` (~line 376-395) — should scan `args` for
+  the first *non-Pair* (or otherwise-not-a-named-adverb) positional value to use as
+  the path, and treat every `Pair` argument (regardless of position) as a flag, the
+  way `parse_io_flags_values` presumably already does for the flags themselves.
+- `src/runtime/native_io/io_handle.rs`'s `"open"` method arm may have a similar
+  positional-vs-named ordering assumption worth checking (`IO::Handle.new(...).open(:w
+  ...)`  uses only named args so is less likely affected, but worth a quick check).

--- a/todo/tickets/printf-method-form-and-junction-autothread-missing.md
+++ b/todo/tickets/printf-method-form-and-junction-autothread-missing.md
@@ -1,0 +1,43 @@
+# `.printf` method form is unimplemented on Str, and format directives don't autothread over a Junction
+
+Found by the doc-diff harness (`docs/doc-diff-backlog.md`,
+`Type/independent-routines.rakudoc:687` and `:692`).
+
+## Bug 1: `.printf` method form missing
+
+The doc (`independent-routines.rakudoc:677-688`) documents `printf` as callable both
+as a sub (`printf($format, *@args)`) and as a method
+(`$format.printf(*@args)`) — the same convention as `sprintf`, which mutsu already
+supports as a method.
+
+```raku
+"%s is %s".printf("thor", "mighty");    # method form
+printf( "%s is %s", "thor", "mighty");  # sub form
+```
+
+- `raku`: both print `thor is mighty`.
+- `mutsu` (`target/debug/mutsu`): the sub form works; the method form dies with
+  `No such method 'printf' for invocant of type 'Str'` (mutsu even suggests `Did you
+  mean 'print'?`, confirming `printf` isn't registered as a Str method at all).
+
+## Bug 2: format directives don't autothread over a Junction
+
+```raku
+printf( "%.2f ", 1/3 | 1/4 | 3/4 );
+```
+
+- `raku`: `0.33 0.25 0.75 ` — the doc notes "On Junctions, it will also autothread,
+  without a guaranteed order."
+- `mutsu`: dies with `Directive %f not applicable for type Junction` — `printf`/
+  `sprintf`'s format-directive matching doesn't special-case a Junction argument by
+  autothreading over its members the way most numeric operators already do.
+
+## Affected files (starting point)
+
+- Wherever `sprintf` is registered as a Str method (grep for `"sprintf"` in
+  `src/builtins/methods_narg.rs` or similar) — add `printf` as a method following the
+  same pattern (format the string via the existing sprintf logic, then write it via
+  `print`).
+- The format-directive type-matching logic (grep for `"not applicable for type"`) —
+  needs a Junction-autothreading branch, likely reusing the same autothreading
+  machinery other builtins already use for Junction arguments.

--- a/todo/tickets/repl-routine-unimplemented.md
+++ b/todo/tickets/repl-routine-unimplemented.md
@@ -1,0 +1,40 @@
+# `repl()` global routine is unimplemented (mutsu already has the REPL machinery to reuse)
+
+Found by the doc-diff harness (`docs/doc-diff-backlog.md`,
+`Type/independent-routines.rakudoc:148`).
+
+## Repro
+
+```raku
+my $name = "Alice";
+say "Hello, $name";
+repl();
+say "Goodbye, $name"
+```
+
+- `raku`: runs, drops into an interactive REPL at `repl()`, then continues after the
+  user exits it.
+- `mutsu` (`target/debug/mutsu`): fails to compile —
+  `===SORRY!=== Error while compiling ...\nUndeclared routine:\n    repl used`.
+
+## Root cause
+
+`repl` is documented as an independent routine
+(`raku-doc/doc/Type/independent-routines.rakudoc:134`, `sub repl()`) but is not
+registered as a builtin sub in mutsu at all.
+
+mutsu already has a REPL implementation used when the interpreter is invoked with no
+arguments (`mutsu::repl::run_repl()`, wired up in `src/main.rs:326`). Implementing the
+`repl()` builtin should mostly be a matter of exposing that existing function as a
+callable global sub from within running code, rather than building REPL support from
+scratch.
+
+## Affected files (starting point)
+
+- `src/repl.rs` (or wherever `run_repl()` lives) — the existing REPL entry point to
+  reuse.
+- Wherever builtin sub names are registered/dispatched (grep for how other
+  environment-interaction builtins like `sleep`/`exit` are wired) — add `repl` as a
+  builtin that calls into the same REPL loop, with access to the calling scope's
+  lexicals if mutsu's REPL supports that (raku's `repl()` gives you an interactive
+  prompt with the caller's lexical scope visible).

--- a/todo/tickets/role-mixed-hash-sort-method-dispatch-broken.md
+++ b/todo/tickets/role-mixed-hash-sort-method-dispatch-broken.md
@@ -1,0 +1,54 @@
+# `.sort` on a role-mixed (`but`) Hash returns the whole hash unsorted, wrapped in a 1-element list
+
+Found by the doc-diff harness (`docs/doc-diff-backlog.md`, `Language/structures.rakudoc:281`).
+
+## Repro
+
+```raku
+role Lastable {
+  method last() { self.sort.reverse[0] }
+}
+my %hash-plus := %( 3 => 33, 4 => 44) but Lastable;
+say %hash-plus.sort[0]; # OUTPUT: «3 => 33␤»
+say %hash-plus.last;    # OUTPUT: «4 => 44␤»
+```
+
+- `raku`: `3 => 33` then `4 => 44`.
+- `mutsu` (`target/debug/mutsu`): both lines print `{3 => 33, 4 => 44}` (the whole hash,
+  gisted, not sorted, not subscripted).
+
+## Isolated minimal repro
+
+`.sort` itself is what's broken specifically (not `.keys`/`.elems`, which both work
+fine on the same mixed value):
+
+```raku
+role Lastable { }
+my %hp := %(3=>33, 4=>44) but Lastable;
+say %hp.sort;        # raku: (3 => 33 4 => 44); mutsu: ({3 => 33, 4 => 44})
+say %hp.keys.sort;    # works correctly in mutsu: (3 4)
+```
+
+`%hp.sort` in mutsu returns a *1-element list containing the whole hash unsorted*
+(`({3 => 33, 4 => 44})`) rather than a sorted list of `Pair`s — i.e. `.sort`'s method
+dispatch on a `Mixin`-wrapped Hash isn't unwrapping/iterating the underlying hash the
+way the plain-Hash `.sort` handler does; a plain `%h.sort` (no mixin) works correctly.
+
+## Root cause hypothesis
+
+This looks like the same "a `but`/`does`-mixed value's role metadata (or, here,
+generic dispatch through the `Mixin` wrapper) not surviving a specific method-dispatch
+path" shape already tracked by three open tickets:
+[list-but-role-loses-positional-binding.md](list-but-role-loses-positional-binding.md),
+[hash-default-role-mixin-dropped.md](hash-default-role-mixin-dropped.md),
+[role-mixed-value-gist-skipped-in-array.md](role-mixed-value-gist-skipped-in-array.md).
+Those tickets note "investigate together and merge into one PR if a single fix site is
+found" — this is a fourth concrete symptom of the same family, this time specifically
+the `sort` method's slow-path handler apparently not unwrapping a `ValueView::Mixin`
+around a Hash before doing its per-element/pair iteration.
+
+## Affected files (starting point)
+
+- The `sort` method handler in `src/runtime/methods.rs` (or wherever `.sort` on a Hash
+  is implemented) — needs to unwrap a `Mixin`-wrapped Hash to its underlying Hash
+  value before sorting, the same way `.keys`/`.elems` apparently already do.

--- a/todo/tickets/supply-done-value-drops-emit.md
+++ b/todo/tickets/supply-done-value-drops-emit.md
@@ -1,0 +1,41 @@
+# `done VALUE` inside a `supply {}` block drops the value instead of emitting it
+
+Found by the doc-diff harness (`docs/doc-diff-backlog.md`,
+`Type/independent-routines.rakudoc:1497`).
+
+## Repro
+
+```raku
+my $supply = supply {
+    for 1 .. 3 {
+        emit($_);
+    }
+    done 42;  # same as: emit 42; done
+}
+$supply.tap: -> $v { say "Val: $v" }, done => { say "No more" }
+```
+
+- `raku`: `Val: 1` / `Val: 2` / `Val: 3` / `Val: 42` / `No more` — `done 42` emits `42`
+  before signaling completion, per the doc's own comment ("same as: emit 42; done").
+- `mutsu` (`target/debug/mutsu`): `Val: 1` / `Val: 2` / `Val: 3` / `No more` — the `42`
+  is silently dropped; only the bare `done` signal fires.
+
+## Root cause
+
+`src/parser/stmt/simple/control_stmts.rs` (~line 557-571) parses a bare `done`
+identifier directly into `Stmt::ReactDone`, with a comment stating `"done() is the
+explicit call form (it takes no payload)"`. That's only true for the parenthesized
+call form (`done()`); a bareword `done` followed by a value expression
+(`done 42;`, no parens) is valid raku syntax and is sugar for `emit 42; done` (per the
+doc). The current parsing doesn't consume a following non-empty, non-modifier
+expression as an emit-value before treating the statement as `Stmt::ReactDone` — it
+either needs a new AST shape (`Stmt::ReactDone` with an optional value) or should
+desugar to two statements (`emit VALUE` then bare `done`) at parse time.
+
+## Affected files (starting point)
+
+- `src/parser/stmt/simple/control_stmts.rs` (~line 551-571) — the `done` keyword
+  parsing.
+- `src/compiler/expr.rs` (~line 181, `Expr::BareWord(name) if name == "done"`) and
+  wherever `Stmt::ReactDone` is compiled — needs to thread an optional value through
+  to an `emit` before the completion signal.

--- a/todo/tickets/undefined-any-called-as-sub-throws.md
+++ b/todo/tickets/undefined-any-called-as-sub-throws.md
@@ -1,0 +1,35 @@
+# Calling an undefined `Any`-typed package variable as a function throws instead of returning the args
+
+Found by the doc-diff harness (`docs/doc-diff-backlog.md`, `Language/structures.rakudoc:233`).
+
+## Root cause hypothesis
+
+In raku, calling an undefined value (an `Any` type object, e.g. an undeclared package
+variable) with `(...)` call syntax does not throw — it silently returns the argument(s)
+unchanged. mutsu throws `No such method 'CALL-ME' for invocant of type 'Nil'` instead.
+
+This is presumably a special-cased fallback on `Any`/`Mu` (or in the call-dispatch
+logic for an undefined invocant) that mutsu's `CALL-ME` dispatch doesn't implement.
+
+## Minimal repro
+
+```raku
+my $x;
+say $x("hi");         # single arg
+say $x(1, 2, 3);       # multiple args
+```
+
+- `raku`: `hi` then `(1 2 3)`.
+- `mutsu` (`target/debug/mutsu`): `No such method 'CALL-ME' for invocant of type 'Nil'`.
+
+Note `Any.can("CALL-ME")` returns `()` in raku too — this isn't a normal method lookup
+succeeding, it's a special fallback the compiler/runtime applies when a call's
+invocant is undefined.
+
+## Affected files (starting point)
+
+- Wherever a `(...)` postfix call on a non-Callable value is dispatched — likely
+  `src/runtime/methods_call_dispatch.rs` or `src/runtime/calls.rs` (grep for
+  `CALL-ME`). Needs a check: if the invocant is undefined (`Nil`/`Any` type object,
+  no `CALL-ME` candidate), return the argument(s) as-is (a single arg unwrapped, or a
+  list) instead of throwing `X::Method::NotFound`.


### PR DESCRIPTION
## Summary
- Regenerated and re-verified doc-diff harness findings for `Type/IO/Handle.rakudoc`, `Language/structures.rakudoc`, `Language/mop.rakudoc`, and `Type/independent-routines.rakudoc` directly against `raku` and `target/debug/mutsu`.
- Filed 14 `todo/tickets/` entries and 3 `todo/deep/` entries for confirmed real bugs (custom `IO::Handle` WRITE/READ dispatch, `.open` path absolutization, `lines()` sub-form not reading a file, built-in parametric role mixin failing to compose, a role-mixed Hash's `.sort` breaking, a grammar metaclass-parameterize stack overflow, direct `Metamodel::ClassHOW.new_type` binding falsely rejected as immutable, `EVAL`'s `$?FILE`/`:filename` handling, `open()` named-adverb-before-positional-path ordering, `.printf` method form + Junction autothreading, `supply`'s `done VALUE` dropping the emit, and a hyper-method-call-on-gather empty result).
- Cross-linked all 17 in a new subsection of `docs/doc-diff-backlog.md`, plus an "Excluded" bullet list for hash/pointer-address `raku-drift`, one hit on the already-Deferred lazy-list cluster, and one message-text-only exception drift.

## Test plan
- [x] Docs-only change (`docs/doc-diff-backlog.md` + `todo/tickets/*.md` + `todo/deep/*.md`) — no code touched.
- [x] Every finding re-verified directly with `raku -e`/`raku <file>` vs `timeout 30 target/debug/mutsu -e`/`... <file>` before filing (not just trusting the harness report).
- [x] `cargo fmt`/`cargo clippy -- -D warnings` ran clean via the pre-commit hook (docs-only diff, no Rust files touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)