### PR TITLE
docs: file 16 tickets from doc-diff batch-3 (grammars/syntax/Proc::Async/nativecall/experimental/unicode)

### DIFF
--- a/docs/doc-diff-backlog.md
+++ b/docs/doc-diff-backlog.md
@@ -390,6 +390,41 @@ Found in the 2026-08-22 batch-3 re-run of `IO::Handle`/`structures`/`mop`/`indep
   "exception type/meaning matches, message text differs" shape already excluded elsewhere in this
   ledger (e.g. `Language/control.rakudoc` [10] above), not ticketed.
 
+Found in the 2026-08-22 batch-3 re-run of `grammars`/`syntax`/`Proc::Async`/`nativecall`/
+`experimental`/`unicode`:
+
+| file:line | one-line summary | ticket |
+|---|---|---|
+| `Language/grammars.rakudoc:112,132` | `[+]`/`[-]` reduce meta-op silently gives `0` for Match/user-Numeric objects (arith ops bypass the numeric-coercion bridge `.reduce()`/binary `+` use) | [reduce-metaop-numeric-coercion-bypassed.md](../todo/tickets/reduce-metaop-numeric-coercion-bypassed.md) |
+| `Language/grammars.rakudoc:260` | `<sym>` named-capture inside a `token X:sym<...>` proto/multi-dispatch body isn't recorded on the Match | [grammar-sym-capture-not-in-match-hash.md](../todo/tickets/grammar-sym-capture-not-in-match-hash.md) |
+| `Language/grammars.rakudoc:387` | a grammar-embedded custom assertion method (`<.method>`) sees `self` as an uninstantiated type object | [grammar-embedded-custom-assertion-method-self-type-object.md](../todo/tickets/grammar-embedded-custom-assertion-method-self-type-object.md) |
+| `Language/grammars.rakudoc:289` | `.tail ~= ...` on a private class-attribute array silently no-ops instead of mutating the last element | [tail-lvalue-compound-assign-attribute-array-noop.md](../todo/tickets/tail-lvalue-compound-assign-attribute-array-noop.md) |
+| `Language/grammars.rakudoc:509` | a grammar rule with dynamic-variable parameters (`rule TOP ($*word, $*extra)`) + `.parse(..., :args(...))` fails entirely (harness mis-bucketed as drift) | [grammar-dynamic-rule-parameters-args-fail.md](../todo/tickets/grammar-dynamic-rule-parameters-args-fail.md) |
+| `Language/syntax.rakudoc:354,384` | adverbial-pair variable name syntax (`$var:adverb<value>`) is incomplete — quoted-identifier form is a hard parse error, interpolated adverb values don't resolve | [adverbial-pair-variable-name-syntax-incomplete.md](../todo/tickets/adverbial-pair-variable-name-syntax-incomplete.md) |
+| `Language/syntax.rakudoc:429` | `OUR::` pseudo-package doesn't expose file-scope `our`-declared package symbols | [our-pseudopackage-missing-file-scope-symbols.md](../todo/tickets/our-pseudopackage-missing-file-scope-symbols.md) |
+| `Language/syntax.rakudoc:1091` | a colon-call's trailing `.method` (`.substr: 0, 3  .uc`) binds to the wrong operand | [colon-call-trailing-dot-method-binds-wrong-operand.md](../todo/tickets/colon-call-trailing-dot-method-binds-wrong-operand.md) |
+| `Type/Proc/Async.rakudoc:172,203` | `Proc::Async.new` shoves an unrecognized named arg (e.g. `:r`) into the spawned command's argv, corrupting it | [procasync-new-unknown-named-arg-leaks-into-argv.md](../todo/tickets/procasync-new-unknown-named-arg-leaks-into-argv.md) |
+| `Type/Proc/Async.rakudoc:102,110,233` | `Proc::Async` output is silently dropped instead of passed through when nobody `.tap`s the stdout/stderr Supply | [procasync-untapped-stdout-not-passthrough.md](../todo/tickets/procasync-untapped-stdout-not-passthrough.md) |
+| `Language/nativecall.rakudoc:1186` | `enum Name (a => 1; b => 2;)` — semicolon-separated variant list fails to parse as an enum at all (general parser bug, not NativeCall-specific) | [enum-semicolon-separated-variants-parse-fail.md](../todo/tickets/enum-semicolon-separated-variants-parse-fail.md) |
+| `Language/nativecall.rakudoc:598` | `Pointer[T].deref` method is missing (the FFI call itself succeeds) | [nativecall-pointer-deref-method-missing.md](../todo/tickets/nativecall-pointer-deref-method-missing.md) |
+| `Language/experimental.rakudoc:32` | `Buf`/`Blob.contents` method is missing | [buf-contents-method-missing.md](../todo/tickets/buf-contents-method-missing.md) |
+| `Language/experimental.rakudoc:144` | a user-defined custom infix's RHS operand fails to parse when followed by `??...!!` | [custom-infix-rhs-operand-rejects-ternary.md](../todo/tickets/custom-infix-rhs-operand-rejects-ternary.md) |
+| `Language/unicode.rakudoc:83,90` | `utf8-c8` decoding of an invalid byte uses a different synthetic private-use codepoint than raku | [utf8-c8-invalid-byte-codepoint-mismatch.md](../todo/tickets/utf8-c8-invalid-byte-codepoint-mismatch.md) |
+| `Language/unicode.rakudoc:190,212,224` | `\c[NAME]` fails to resolve Unicode NameAlias corrections and multi-codepoint named sequences | [c-bracket-character-name-lookup-gaps.md](../todo/tickets/c-bracket-character-name-lookup-gaps.md) |
+
+**Excluded from this batch-3 sub-run:**
+- `Language/syntax.rakudoc` [5] (line 763, `%(...)`hash-constructor `.keys.join`) — hash
+  iteration-order `raku-drift`, both sides nondeterministic (same known false positive as
+  the survey table's `Hash.rakudoc`/`Map.rakudoc` note above).
+- `Language/experimental.rakudoc` [2], [3], [4] (`use experimental :macros`, `macro`/`quasi`
+  examples) — the already-tracked deep `macro`/`quasi`/unquote design work in
+  `todo/deep/rakuast-remaining.md`'s "Macros" section; not re-ticketed here.
+- `Language/nativecall.rakudoc` [2] (the `getaddrinfo`/DNS CStruct example) — beyond the
+  parse-time `enum` bug ticketed above, this example also depends on a live DNS lookup
+  (`google.com`) and full `CStruct`/`nativecast` FFI plumbing; not a clean minimal repro on
+  its own and squarely within NativeCall's known, measured gaps
+  (`todo/deep/nativecall-cannot-be-vendored.md`) — not ticketed further.
+
 ### Deferred / deep (tracked elsewhere — do not re-open as a shallow slice)
 These root causes account for a large share of the survey's `mism`/`crash` and are
 intentionally deferred; see PLAN.md §8.5 and the ADRs:

--- a/todo/tickets/adverbial-pair-variable-name-syntax-incomplete.md
+++ b/todo/tickets/adverbial-pair-variable-name-syntax-incomplete.md
@@ -1,0 +1,61 @@
+# Adverbial-pair variable names (`$var:adverb<value>`) parsing is incomplete
+
+Found by the doc-diff harness batch-3 re-run (`docs/doc-diff-backlog.md`,
+`Language/syntax.rakudoc:354` and `:384`).
+
+## Root cause hypothesis
+
+Raku allows a variable's name to carry an "adverbial pair" component, written
+`$identifier:adverb<value>` (or with `«...»`/`[...]`/`(...)` instead of `<...>` for the
+value, or with the identifier itself replaced by `<...>` too, e.g.
+`$take-me:<home>`). The declaration and every subsequent read/write must use a matching
+name; reading it uses `$var:adverb<value>` again (with `<>`/`«»`/`[...]`/`(...)` all being
+valid ways to spell the same lookup, and `(...)` allowing an arbitrary expression).
+
+mutsu's parser only handles some spellings:
+- `my $foo:bar<baz> = 'quux'; say $foo:bar«baz»;` works (angle-bracket declaration + double
+  angle-bracket read both parse).
+- `my $take-me:<home> = ...;` — a declaration where the *identifier itself* is `<...>`
+  quoted — is a hard parse error (`Confused. expected statement...`).
+- Interpolating a value into the adverb's value part
+  (`say $a:foo«$c»;` where `$c` holds `42`) parses but evaluates to `Nil` instead of
+  reading back the value stored under `$a:foo<42>`.
+
+## Minimal repro
+
+```raku
+my $foo:bar<baz> = 'quux';
+say $foo:bar«baz»;                               # OUTPUT: «quux␤» -- OK on mutsu
+
+my $take-me:<home> = 'Where the glory has no end';
+say $take-me:['home'];                           # OUTPUT: «Where [...]␤»
+```
+
+- `raku`: `quux`, `Where the glory has no end`, then `5` for a third `$foo:bar(1+1)` case.
+- `mutsu`: hard parse error at `my $take-me:<home> = ...`:
+  ```
+  ===SORRY!=== Error while compiling ...
+  Confused. expected statement: expected use statement or import statement or no statement or need statement or unit statement or ...
+  ------>my $take-me:<home> = 'Where the glory has no end';
+                    ^
+  ```
+
+Second, narrower repro (interpolated adverb value):
+
+```raku
+constant $c = 42;
+my $a:foo<42> = "answer";
+say $a:foo«$c»;    # OUTPUT: «answer␤»
+```
+
+- `raku`: `answer`
+- `mutsu`: `Nil` (parses without error, but the lookup doesn't find the stored value —
+  likely because `«$c»` interpolation of the adverb value isn't resolved to `42` before the
+  variable-name match, or the two spellings resolve to differently-keyed storage).
+
+## Affected files (starting point)
+
+- Parser: wherever `$identifier:adverb<value>` variable-name syntax is recognized (grep for
+  "adverbial" / colon-pair variable name parsing in `src/parser/`). Needs to accept
+  `$<...>:adverb<...>` (identifier itself quoted) and to correctly interpolate/resolve the
+  adverb value consistently between declaration and read sites.

--- a/todo/tickets/buf-contents-method-missing.md
+++ b/todo/tickets/buf-contents-method-missing.md
@@ -1,0 +1,35 @@
+# `Buf`/`Blob.contents` method is missing
+
+Found by the doc-diff harness batch-3 re-run (`docs/doc-diff-backlog.md`,
+`Language/experimental.rakudoc:32`).
+
+## Root cause
+
+`Blob`/`Buf` has a `.contents` method that returns the list of byte values (equivalent to
+`.list`/iterating the buffer as integers). This is a general `Blob`/`Buf` method, not
+specific to the `use experimental :pack` feature the doc example happens to demonstrate it
+with. mutsu doesn't implement it.
+
+## Minimal repro
+
+```raku
+my $b = Buf.new(1,2,3);
+say $b.contents;       # (1 2 3)
+say $b.contents.WHAT;  # (List)
+```
+
+- `raku`: `(1 2 3)` then `(List)`
+- `mutsu`: `No such method 'contents' for invocant of type 'Buf'`
+
+Doc's original example (using `pack`, unrelated to the missing method):
+
+```raku
+use experimental :pack;
+say pack("H*", "414243").contents;  # OUTPUT: «(65 66 67)␤»
+```
+
+## Affected files (starting point)
+
+- `src/builtins/methods_0arg/` — wherever other `Buf`/`Blob` 0-arg methods (`.list`,
+  `.elems`, `.bytes`, etc.) are implemented; `.contents` should be a straightforward
+  addition alongside those, returning the byte values as a `List`.

--- a/todo/tickets/c-bracket-character-name-lookup-gaps.md
+++ b/todo/tickets/c-bracket-character-name-lookup-gaps.md
@@ -1,0 +1,69 @@
+# `\c[NAME]` fails to resolve Unicode NameAlias corrections and multi-codepoint named sequences
+
+Found by the doc-diff harness batch-3 re-run (`docs/doc-diff-backlog.md`,
+`Language/unicode.rakudoc:190`, `:212`, `:224`).
+
+## Root cause
+
+`lookup_unicode_char_by_name` (`src/token_kind.rs`) resolves `\c[NAME]` via the
+`unicode_names2` crate (single-codepoint standard `Name` property lookups) plus a small
+hardcoded fallback table for C0 control names, and a separate `lookup_emoji_sequence`
+(backed by the `emojis` crate) for CLDR emoji short names. This covers ordinary character
+names and basic single-emoji CLDR names, but misses three related data sources real Raku's
+`\c[...]` also consults:
+
+1. **Unicode `NameAlias` corrections.** Some characters have a "correction" alias distinct
+   from their immutable (never-changed) `Name` property — e.g. U+01A2's stable `Name` is
+   `LATIN CAPITAL LETTER OI` (what `.uniname` reports), but its corrected alias
+   `LATIN CAPITAL LETTER GHA` is also a valid `\c[...]` input. `unicode_names2` only
+   indexes the primary `Name` property, not `NameAlias` corrections, so `\c[LATIN CAPITAL
+   LETTER GHA]` (and other alias-only names) fail to resolve at all.
+2. **Named character sequences** (`NamedSequences.txt`) — some `\c[NAME]` inputs name a
+   *sequence* of codepoints (e.g. a base letter + combining diacritic), not a single
+   character. mutsu's lookup only ever returns a single `char`, so these fail entirely.
+3. **Compound/multi-emoji named sequences** beyond a single CLDR short name — e.g. a
+   "family: man woman girl boy" ZWJ sequence with a colon-prefixed category. `emojis`
+   crate's flat per-emoji name index apparently doesn't include these compound names (a
+   single simpler CLDR name like "woman gesturing OK" does resolve correctly).
+
+## Minimal repro
+
+```raku
+say "\c[LATIN CAPITAL LETTER GHA]";
+say "\c[LATIN CAPITAL LETTER E WITH VERTICAL LINE BELOW AND ACUTE]".ords;
+say "\c[PRESENTATION FORM FOR VERTICAL RIGHT WHITE LENTICULAR BRACKET]".ords;
+say "\c[woman gesturing OK]".ords;
+say "\c[family: man woman girl boy]".ords;
+```
+
+- `raku`:
+  ```
+  Ƣ
+  (201 809)
+  (65048)
+  (128582 8205 9792 65039)
+  (128104 8205 128105 8205 128103 8205 128102)
+  ```
+- `mutsu`:
+  ```
+  (empty line -- name not found, or renders as empty)
+  ()
+  ()
+  (128582 8205 9792 65039)
+  ()
+  ```
+  Only the plain single-emoji CLDR name ("woman gesturing OK") resolves correctly; the
+  NameAlias-only name, the accented-letter named sequence, the corrected-spelling alias,
+  and the compound family emoji sequence all fail.
+
+## Affected files (starting point)
+
+- `src/token_kind.rs` — `lookup_unicode_char_by_name` (single-char lookup, needs a
+  `NameAlias`-correction fallback table or a crate/data source that includes them) and
+  `lookup_emoji_sequence` (needs compound/colon-prefixed sequence names).
+- Wherever `\c[...]` is parsed/evaluated (grep for `lookup_unicode_char_by_name` callers)
+  — needs a new lookup path returning a `String`/multi-codepoint result for
+  `NamedSequences.txt`-style entries, since the current API assumes a single `char`.
+- Consider whether `unicode_names2`'s crate version/feature flags expose `NameAlias` data,
+  or whether a small supplementary static table (like the existing C0-control fallback) is
+  the pragmatic fix for the alias-correction cases.

--- a/todo/tickets/colon-call-trailing-dot-method-binds-wrong-operand.md
+++ b/todo/tickets/colon-call-trailing-dot-method-binds-wrong-operand.md
@@ -1,0 +1,39 @@
+# Colon-call's trailing `.method` binds to the last argument, not the whole call
+
+Found by the doc-diff harness batch-3 re-run (`docs/doc-diff-backlog.md`,
+`Language/syntax.rakudoc:1091`).
+
+## Root cause
+
+In Raku, a colon-call's argument list is a low-precedence listop, so a `.method` written
+right after the last argument (with whitespace, no dot-call chaining syntax) binds to
+*that last argument*, not to the overall method-call's result. Confirmed via
+`raku --target=ast`: `$band.substr: 0, 3  .uc` compiles to
+`callmethod substr($band, 0, callmethod uc(3))` — i.e. `.substr(0, 3.uc)`, where `3.uc`
+stringifies `3` to `"3"` (uc is a no-op on digits) so the effective call is just
+`$band.substr(0, "3")`, producing `"Foo"` (no uppercasing at all — this is Raku's own
+"trap"/gotcha the doc section is illustrating).
+
+mutsu instead returns the entire original string unmodified (`"Foo Fighters"`), meaning it
+neither performs the substr correctly nor applies `.uc` to the last argument the way raku's
+parser does — the whole call appears to be mis-parsed or mis-evaluated for this
+no-parens-colon-call-with-trailing-method shape.
+
+## Minimal repro
+
+```raku
+my $band = 'Foo Fighters';
+say $band.substr( 0, 3 ).uc; # OUTPUT: «FOO␤»   -- parenthesized: mutsu already OK
+say $band.substr: 0, 3  .uc; # OUTPUT: «Foo␤»   -- colon-call: mutsu gives "Foo Fighters"
+```
+
+- `raku`: `FOO` then `Foo`
+- `mutsu`: `FOO` (correct) then `Foo Fighters` (wrong — should be `Foo`)
+
+## Affected files (starting point)
+
+- Parser: colon-call argument-list parsing (`.method: arg1, arg2 ...`) — grep for the
+  colon-call listop precedence handling and confirm whether a trailing `.method` after the
+  last argument is currently attached to the whole call result instead of the last
+  argument expression. Compare `--dump-ast` output for this repro against raku's
+  `--target=ast` (shown above) to see where mutsu's parse tree diverges.

--- a/todo/tickets/custom-infix-rhs-operand-rejects-ternary.md
+++ b/todo/tickets/custom-infix-rhs-operand-rejects-ternary.md
@@ -1,0 +1,46 @@
+# A user-defined custom infix's RHS operand fails to parse when followed by `??...!!`
+
+Found by the doc-diff harness batch-3 re-run (`docs/doc-diff-backlog.md`,
+`Language/experimental.rakudoc:144`).
+
+## Root cause hypothesis
+
+When the right-hand operand of a user-defined custom infix operator
+(`sub infix:<name>(...) {...}`) is an expression that continues into a ternary
+(`??...!!...`), mutsu fails to parse it at all, even though the same shape parses fine
+when the LHS is a bare literal instead of going through a custom infix. This looks like the
+custom-infix operand parser uses a narrower/lower-precedence term-parsing routine than the
+general expression parser (one that doesn't include `??`/`!!` as a valid continuation),
+so it stops after consuming just the immediate term and then chokes on the leftover `??`.
+
+## Minimal repro
+
+```raku
+sub infix:<amic>( $m, $n ) { $m == $n }
+my @pair = (2, 2);
+say 2 amic @pair[1]??" yes"!!"no";
+```
+
+- `raku`: parses fine, `amic`'s default (loose, comma-like) precedence means the ternary
+  binds as `2 amic (@pair[1] ?? " yes" !! "no")`.
+- `mutsu`: `Runtime error: Expected a term, but found either infix ?? or redundant prefix
+  ?  (to suppress this message, please use a space like ? ?)`
+
+For comparison, ternary alone (no custom infix in the way) parses fine on both:
+
+```raku
+my $x = 5;
+say $x > 3??" yes"!!"no";   # both raku and mutsu: " yes"
+```
+
+This is how it surfaces in the doc's `:cached`/amicable-numbers example
+(`experimental.rakudoc`): `@pair[0] amic @pair[1]??" "!!"not ", "amicable"` — the `:cached`
+trait itself is unrelated; the crash is purely this custom-infix-operand parsing gap.
+
+## Affected files (starting point)
+
+- Parser: wherever a user-declared custom infix operator's right-hand operand is parsed
+  after the operator token is recognized — grep for custom infix / `infix:<...>` operand
+  parsing in `src/parser/expr/`. It likely needs to call the same term/expression parser
+  used for the RHS of built-in infix operators (which already accepts a following ternary)
+  instead of a narrower one.

--- a/todo/tickets/enum-semicolon-separated-variants-parse-fail.md
+++ b/todo/tickets/enum-semicolon-separated-variants-parse-fail.md
@@ -1,0 +1,64 @@
+# `enum Name (a => 1; b => 2;)` — semicolon-separated variant list fails to parse as an enum
+
+Found by the doc-diff harness batch-3 re-run (`docs/doc-diff-backlog.md`,
+`Language/nativecall.rakudoc:1186`). Despite being discovered via the `nativecall.rakudoc`
+example, this is a general parser bug unrelated to NativeCall — the failure happens at
+compile time, before any FFI call is attempted.
+
+## Root cause
+
+`enum Name ( pair, pair, ... )`'s body parser
+(`parse_enum_decl_body_with_type` in `src/parser/stmt/decl/enum_decl.rs`) tries
+`parse_static_enum_variants` (comma-separated pairs) first; if that fails it falls back to
+parsing the body as a single "dynamic" expression followed by an optional `,`-separated
+list (`expression(r)` then expects `,` or the closing `)`). Neither path accepts `;` as a
+variant separator, so `enum Foo (A => 0; B => 10)` fails to parse as an enum body at all —
+and because `enum_decl` returns an error, the statement-level parser backtracks and treats
+the bare word `enum` as an ordinary (undeclared) function-call statement instead, producing
+a confusing `Undeclared routine: enum used` error rather than a body-parse error.
+
+Real Raku accepts `;` as a statement/expression separator inside a parenthesized term in
+general (`(a; b; c)` builds a List from each statement's value — see the existing ticket
+`paren-statement-list-trailing-empty-element.md` for that general mechanism), and `enum`'s
+own body apparently reuses that general grammar rule rather than a comma-only list. mutsu's
+`enum` body parser has its own hand-rolled comma-only variant-list logic that never
+delegates to (or falls back to) the general semicolon-list parsing path.
+
+## Minimal repro
+
+```raku
+enum Foo (A_INET => 0; A_INET6 => 10);
+say A_INET;
+```
+
+- `raku`: `0`
+- `mutsu`:
+  ```
+  ===SORRY!=== Error while compiling ...
+  Undeclared routine:
+      enum used
+  ------>enum Foo (A_INET => 0; A_INET6 => 10);
+         ^
+  ```
+
+Multi-line form (as it appears in the doc) fails the same way:
+
+```raku
+enum AddrInfo-Family (
+    AF_UNSPEC => 0;
+    AF_INET   => 2;
+    AF_INET6  => 10;
+);
+```
+
+Comma-separated forms (with or without a trailing comma, with or without surrounding
+parens) already work correctly and are unaffected.
+
+## Affected files
+
+- `src/parser/stmt/decl/enum_decl.rs` — `parse_enum_decl_body_with_type`'s `(` branch:
+  `parse_static_enum_variants` needs to accept `;` as an alternate separator (in addition to
+  `,`), or the "dynamic" fallback's `,`-loop needs a `;`-loop counterpart (or should
+  delegate to the same statement-list-to-List parsing used for a plain parenthesized `(a;
+  b; c)` term, once `paren-statement-list-trailing-empty-element.md` establishes that
+  mechanism is sound).

--- a/todo/tickets/grammar-dynamic-rule-parameters-args-fail.md
+++ b/todo/tickets/grammar-dynamic-rule-parameters-args-fail.md
@@ -1,0 +1,55 @@
+# A grammar rule with dynamic-variable parameters + `.parse(..., :args(...))` fails entirely
+
+Found by the doc-diff harness batch-3 re-run (`docs/doc-diff-backlog.md`,
+`Language/grammars.rakudoc:509`). The harness bucketed this as `raku-drift-from-doc`
+because the doc's `# OUTPUT:` annotation lacks a leading space that real raku's actual
+gist output has (a documentation typo, unrelated to this bug) — re-verified directly
+against `raku` and this is a real, confirmed divergence, not drift.
+
+## Root cause
+
+Raku grammars can declare a rule/token with a parameter list that binds **dynamic**
+variables (`rule TOP ($*word, $*extra) { ... }`), which `.parse()` fills in via the
+`:args(...)` named argument. mutsu appears not to support this feature at all: the whole
+parse fails silently, returning `Nil` instead of a `Match`.
+
+## Minimal repro
+
+```raku
+grammar demonstrate-arguments-dynamic {
+   rule TOP ($*word, $*extra) {
+      <phrase-stem><added-words>
+   }
+   rule phrase-stem {
+      "I like"
+   }
+   rule added-words {
+      $*word $*extra
+   }
+}
+
+say demonstrate-arguments-dynamic.parse("I like everything else",
+  :args(("everything", "else")));
+```
+
+- `raku`:
+  ```
+  ｢I like everything else｣
+   phrase-stem => ｢I like ｣
+   added-words => ｢everything else｣
+  ```
+- `mutsu`: `Nil`
+
+## Affected files (starting point)
+
+- Parser: wherever a `token`/`rule`/`regex` declaration's parameter list is parsed —
+  needs to accept dynamic-variable (`$*name`) parameters, not just ordinary ones.
+- `src/runtime/methods_grammar.rs` / grammar `.parse()` dispatch — needs to accept the
+  `:args(...)` named argument and bind it into the rule's declared dynamic parameters
+  before running `TOP`.
+- Compare against `grammar-token-param-dynvar-not-visible-in-subrule.md` (an existing
+  ticket) — that one is about a *default-valued* `$*` token parameter not propagating to a
+  called subrule; this finding is about a `.parse(..., :args(...))`-supplied `$*` parameter
+  on the grammar's own `TOP` rule not working at all. They may share underlying
+  infrastructure (how token/rule parameter lists bind into dynamic scope) but are distinct
+  failure modes — investigate together if convenient.

--- a/todo/tickets/grammar-embedded-custom-assertion-method-self-type-object.md
+++ b/todo/tickets/grammar-embedded-custom-assertion-method-self-type-object.md
@@ -1,0 +1,67 @@
+# A grammar-embedded custom assertion method (`<.method>`) sees `self` as an uninstantiated type object
+
+Found by the doc-diff harness batch-3 re-run (`docs/doc-diff-backlog.md`,
+`Language/grammars.rakudoc:387`).
+
+## Root cause hypothesis
+
+A grammar can define its own methods (not via a separate `actions =>` class) and call them
+as custom regex assertions with `<.method-name>`. Inside such a method, `self` should be
+the in-progress grammar instance (so attribute reads/writes like `$!invalid = True` work,
+and returning `self` is the idiomatic way to signal "accept"/"error" while continuing the
+parse). On mutsu, invoking one of these embedded methods via `<.method>` treats `self` as
+the grammar's bare **type object** rather than an instance — attribute assignment fails
+with `Cannot look up attributes in a G type object. Did you forget a '.new'?`, and even
+when the method has no attributes at all (just `self;`), the overall `.parse()` result is
+`Nil` instead of a `Match`.
+
+This is a different code path from the ordinary subrule/token dispatch (`<name>` calling
+another `token`/`rule`) and from `actions=>`-class method dispatch (`<sym>`/`make`) — both
+of those already work correctly in mutsu's grammar engine.
+
+## Minimal repro
+
+```raku
+grammar G {
+    token TOP { <a> }
+    token a { \w+ <.mark> }
+    method mark() {
+        self;
+    }
+}
+say G.parse("hello").WHAT;
+```
+
+- `raku`: `(G)`
+- `mutsu`: `Nil`
+
+With an attribute involved (closer to the original doc example), it's a hard error instead
+of a silent `Nil`:
+
+```raku
+grammar G {
+    has Bool $.invalid;
+    token TOP { <a> }
+    token a { \w+ <.mark> }
+    method mark(--> ::?CLASS:D) {
+        $!invalid = True;
+        self;
+    }
+}
+my $m = G.parse("hello");
+say $m.WHAT;
+```
+
+- `raku`: `(G)`
+- `mutsu`: `Cannot look up attributes in a G type object. Did you forget a '.new'?`
+  (`in sub mark at ... line 1`)
+
+## Affected files (starting point)
+
+- `src/runtime/regex/` — the custom-assertion dispatch for `<.method-name>` (distinct from
+  ordinary subrule-token dispatch and from `actions=>` dispatch); look for wherever a
+  grammar method is called as a regex assertion and how `self` is bound for that call —
+  it needs to resolve to the same in-progress instance the enclosing `token`/`rule` body
+  sees (`$/`'s originating grammar object), not the class/type object.
+- `src/runtime/methods_grammar.rs` may be the right place to compare against the working
+  subrule/actions dispatch paths.

--- a/todo/tickets/grammar-sym-capture-not-in-match-hash.md
+++ b/todo/tickets/grammar-sym-capture-not-in-match-hash.md
@@ -1,0 +1,51 @@
+# `<sym>` named-capture inside a `token X:sym<...>` multi-token body isn't recorded on the Match
+
+Found by the doc-diff harness batch-3 re-run (`docs/doc-diff-backlog.md`,
+`Language/grammars.rakudoc:260`).
+
+## Root cause hypothesis
+
+When a `proto token`/multi-dispatch token body (`token letter:sym<R> { <sym> }`) matches
+via the special `<sym>` regex atom (which captures the literal `sym<...>` string used for
+that candidate), raku records that capture into the resulting `Match`'s named-capture hash
+(`$/.hash` includes `sym => Match.new(...)`), so `$match<sym>` is truthy for every match
+produced by a `sym<...>`-carrying candidate (and falsy/absent for a catch-all
+`token letter:sym<*> { . }` candidate that never mentions `<sym>`). mutsu's `<sym>` atom
+appears to match successfully (the token still matches the right characters — `.raku`
+shows the correct `:from`/`:pos` — and the doc's overall filter-by-`.grep(*.<sym>)`
+approach *should* separate matched-letters from the catch-all), but the resulting `Match`
+objects never get a `sym` entry in their hash at all, for any candidate, so
+`.grep(*.<sym>)` finds nothing and the actions method's join is empty.
+
+## Minimal repro
+
+```raku
+grammar Foo {
+    token TOP { <letter>+ }
+    proto token letter {*}
+          token letter:sym<R> { <sym> }
+          token letter:sym<a> { <sym> }
+          token letter:sym<k> { <sym> }
+          token letter:sym<u> { <sym> }
+          token letter:sym<*> {   .   }
+}.parse("I ♥ Raku", actions => class {
+    method TOP($/) { say $<letter>.raku; make $<letter>.grep(*.<sym>).join }
+}).made.say;
+```
+
+- `raku`: each matched-letter `Match` object's `.raku` shows a trailing
+  `:hash(Map.new((:sym(Match.new(...)))))` for the `R`/`a`/`k`/`u` candidates (and none for
+  the `sym<*>` catch-all); `.grep(*.<sym>)` correctly keeps only those, `.join` → `Raku`.
+- `mutsu`: none of the `Match` objects carry any `:hash(...)` in their `.raku` — the `<sym>`
+  capture is entirely missing — so `.grep(*.<sym>)` returns nothing and `.made` is `""`
+  (empty line printed, not `Raku`).
+
+## Affected files (starting point)
+
+- `src/runtime/regex/regex_eval*.rs`, `src/runtime/regex/regex_eval_repeat.rs` — wherever
+  the `<sym>` builtin regex atom is matched during proto/multi-token dispatch; needs to
+  register a `sym` entry into the resulting `CapNode`/Match hash the same way an explicit
+  `$<name>=...` named capture does.
+- Grep for how `sym<...>` candidate dispatch is compiled/executed (likely
+  `runtime/methods_grammar.rs` or the proto-dispatch machinery) to find where the matched
+  candidate's `sym` value is known but not threaded into the capture tree.

--- a/todo/tickets/nativecall-pointer-deref-method-missing.md
+++ b/todo/tickets/nativecall-pointer-deref-method-missing.md
@@ -1,0 +1,34 @@
+# `Pointer[T].deref` method is missing
+
+Found by the doc-diff harness batch-3 re-run (`docs/doc-diff-backlog.md`,
+`Language/nativecall.rakudoc:598`).
+
+## Context
+
+NativeCall is a measured, justified rung-3 native provider with known gaps (see
+`todo/deep/nativecall-cannot-be-vendored.md`). This finding is narrower than that
+document's scope: the actual FFI call in the repro below (`strdup`, a plain libc function)
+succeeds — the native call machinery, argument marshaling, and `Pointer[Str]` typed-pointer
+construction all work. Only the `.deref` accessor method on a typed `Pointer[T]` value is
+missing, which is a small, self-contained, worth-filing gap rather than part of the deep
+"cannot be vendored" cluster.
+
+## Minimal repro
+
+```raku
+use NativeCall;
+sub strdup(Str $s --> Pointer[Str]) is native { * }
+my Pointer[Str] $p = strdup("Success!");
+say $p.deref;
+```
+
+- `raku`: `Success!`
+- `mutsu`: `No such method 'deref' for invocant of type 'NativeCall::Types::Pointer[Str]'`
+
+## Affected files (starting point)
+
+- Wherever `NativeCall::Types::Pointer` methods are implemented — grep for
+  `"Pointer"` in `src/runtime/native_methods/` / NativeCall-related modules. `.deref`
+  should read the pointed-to value using the pointer's parameterized type (`Pointer[Str]`
+  reads a C string; `Pointer[int32]` reads an int32; etc.), mirroring however
+  `nativecast`/typed-pointer construction already resolves the parameterized type.

--- a/todo/tickets/our-pseudopackage-missing-file-scope-symbols.md
+++ b/todo/tickets/our-pseudopackage-missing-file-scope-symbols.md
@@ -1,0 +1,41 @@
+# `OUR::` pseudo-package doesn't expose file-scope package variables/routines
+
+Found by the doc-diff harness batch-3 re-run (`docs/doc-diff-backlog.md`,
+`Language/syntax.rakudoc:429`).
+
+## Root cause hypothesis
+
+`OUR::` is a pseudo-package giving reflective access to the current package's symbol
+table (`OUR::.keys` lists its symbol names; `OUR::name` / `OUR::foo.HOW` access a specific
+symbol). mutsu's `OUR::` appears to be backed by a fixed/global symbol list (built-ins,
+dynamic variables, core types) rather than the actual current package's stash — it doesn't
+include a package-scoped variable declared with `our` in the same file, and looking such a
+symbol up by name fails outright.
+
+## Minimal repro
+
+```raku
+my $foo::bar = 1;
+say OUR::.keys;           # OUTPUT: «(foo)␤»
+say OUR::foo.HOW          # OUTPUT: «Perl6::Metamodel::PackageHOW.new␤»
+```
+
+- `raku`: `(foo)` then `Perl6::Metamodel::PackageHOW.new`
+- `mutsu`: `OUR::.keys` returns a long, unrelated list of ~50 built-in/dynamic-variable
+  names (`$*PROGRAM-NAME`, `ThreadPoolScheduler`, `Promise`, ... `foo::bar` appears in
+  there as a literal entry, but not `foo` as a package alone), and the second line fails
+  outright:
+  ```
+  Could not find symbol '&foo' in 'OUR'
+  ```
+
+## Affected files (starting point)
+
+- Wherever `OUR::` (and likely the sibling pseudo-packages `MY::`, `PROCESS::`, `GLOBAL::`)
+  are implemented — probably `src/runtime/` reflection/pseudo-package handling. Needs to
+  read from the actual current-package symbol table (built from `our`/package declarations
+  in the compiled unit) rather than (or in addition to) a static builtin-name list, and
+  needs to resolve `OUR::name` as a package/symbol lookup, not a sub-call lookup (the error
+  message `Could not find symbol '&foo' in 'OUR'` suggests it's trying to resolve `foo` as
+  a callable `&foo`, when here `foo` is a sub-package created implicitly by
+  `my $foo::bar = 1`).

--- a/todo/tickets/procasync-new-unknown-named-arg-leaks-into-argv.md
+++ b/todo/tickets/procasync-new-unknown-named-arg-leaks-into-argv.md
@@ -1,0 +1,55 @@
+# `Proc::Async.new` shoves an unrecognized named argument into the spawned command's argv
+
+Found by the doc-diff harness batch-3 re-run (`docs/doc-diff-backlog.md`,
+`Type/Proc/Async.rakudoc:172` and `:203`).
+
+## Root cause
+
+`Proc::Async.new`'s constructor (`src/runtime/methods_object_native_ctors_io.rs`,
+`native_proc_async_new` or equivalent around line 230) only recognizes three named pairs
+specially — `:w`, `:out`, `:enc` — and falls through to `positional.push(arg.clone())` for
+**any other named pair**, including `:r`:
+
+```rust
+for arg in args {
+    match arg.view() {
+        ValueView::Pair(key, value) if key == "w" => { w_flag = value.truthy(); }
+        ValueView::Pair(key, _value) if key == "out" => {}
+        ValueView::Pair(key, value) if key == "enc" => { enc = Value::str(value.to_string_value()); }
+        _ => positional.push(arg.clone()),
+    }
+}
+```
+
+So `Proc::Async.new(:r, 'echo', 'Raku')` pushes the `:r` `Pair` value itself into
+`positional`, which becomes the `cmd` attribute array consumed by `.start()`
+(`src/runtime/native_proc_async.rs`). At spawn time the `Pair` stringifies to something
+like `"r\tTrue"` and is inserted as if it were a real argv element ahead of the actual
+`echo`/`Raku` program name, so `Command::new(&program)` tries to spawn a program literally
+named `r\tTrue`, failing with `No such file or directory`.
+
+Real Rakudo's `Proc::Async.new` signature has a slurpy `*%_` for named args it doesn't
+otherwise recognize, silently absorbing them without corrupting the positional command.
+
+## Minimal repro
+
+```raku
+my $proc = Proc::Async.new(:r, 'echo', 'Raku');
+$proc.stdout.tap( -> $str { say "got: $str"; });
+my $promise = $proc.start;
+await $promise;
+```
+
+- `raku`: `got: Raku` (`:r`/etc. named args Proc::Async doesn't specifically use are simply
+  ignored)
+- `mutsu`: `Failed to spawn 'r\tTrue': No such file or directory (os error 2)`
+
+## Affected files
+
+- `src/runtime/methods_object_native_ctors_io.rs` — the `for arg in args` loop building
+  `positional`/`attrs` for `Proc::Async.new` (around line 230-245). The catch-all `_ =>`
+  arm needs to distinguish "an unrecognized *named* `Pair`" (absorb and drop, or store for
+  future use) from "a genuine *positional* command/argv element" (push as today) — a
+  `Pair` reaching this constructor should never be pushed into `positional` unless Raku's
+  own `Proc::Async.new` signature treats bare positional pairs as literal argv strings
+  (it does not).

--- a/todo/tickets/procasync-untapped-stdout-not-passthrough.md
+++ b/todo/tickets/procasync-untapped-stdout-not-passthrough.md
@@ -1,0 +1,67 @@
+# `Proc::Async` output is silently dropped when nobody `.tap`s it, instead of passing through
+
+Found by the doc-diff harness batch-3 re-run (`docs/doc-diff-backlog.md`,
+`Type/Proc/Async.rakudoc:102`, `:110`, `:233`).
+
+## Root cause hypothesis
+
+When a `Proc::Async`'s `.stdout` (or `.stderr`) `Supply` is never `.tap`ped, real Rakudo
+lets the child process's stdout/stderr **inherit the parent's real stdout/stderr** (or, for
+`bind-stdin`-chained processes, feed straight into the bound consumer) — nothing captures
+it into an internal buffer that then goes nowhere. mutsu's `.start()`
+(`src/runtime/native_proc_async.rs`) unconditionally does
+`cmd.stdout(Stdio::piped()).stderr(Stdio::piped())` regardless of whether a tap exists, so
+when nothing ever reads that pipe, the child's output is captured into a channel that is
+simply never drained — the output is lost rather than shown.
+
+## Minimal repro
+
+```raku
+my $prog = Proc::Async.new(:w, 'hexdump', '-C');
+my $promise = $prog.start;
+await $prog.write(Buf.new(12, 42));
+$prog.close-stdin;
+await $promise;
+```
+
+- `raku`: prints the hexdump output directly to the terminal (child's stdout passes
+  through since nobody tapped it):
+  ```
+  00000000  0c 2a                                             |.*|
+  00000002
+  ```
+- `mutsu`: prints nothing.
+
+Same root cause via piping one `Proc::Async`'s stdout into another's stdin
+(`bind-stdin`) when neither process's output is tapped:
+
+```raku
+my $proc-echo = Proc::Async.new: 'echo', 'Hello, world';
+my $proc-cat = Proc::Async.new: 'cat', '-n';
+$proc-cat.bind-stdin: $proc-echo.stdout;
+await $proc-echo.start, $proc-cat.start;
+```
+
+- `raku`: `     1\tHello, world` (from `cat -n`, printed to the parent's real stdout since
+  nobody tapped `$proc-cat.stdout`)
+- `mutsu`: prints nothing.
+
+And via `bind-stdin` from a real file, again with nothing tapped:
+
+```raku
+my $p = Proc::Async.new("cat", :in);
+my $h = "/etc/profile".IO.open;
+$p.bind-stdin($h);
+$p.start;
+```
+
+- `raku`: prints the file's contents (via `cat`'s pass-through stdout).
+- `mutsu`: prints nothing.
+
+## Affected files (starting point)
+
+- `src/runtime/native_proc_async.rs` — `.start()`'s `Command::new(&program)` setup
+  (`cmd.stdout(Stdio::piped())`/`cmd.stderr(Stdio::piped())`) should only pipe when there is
+  an actual tap (or a `bind-stdin` consumer, or binary/text mode was explicitly requested)
+  registered on the corresponding `Supply`; otherwise it should use `Stdio::inherit()` so
+  the child's output reaches the parent's real stdout/stderr, matching Rakudo.

--- a/todo/tickets/reduce-metaop-numeric-coercion-bypassed.md
+++ b/todo/tickets/reduce-metaop-numeric-coercion-bypassed.md
@@ -1,0 +1,84 @@
+# `[+]`/`[-]`/etc. reduce meta-operator silently gives `0` for Match/user-Numeric objects
+
+Found by the doc-diff harness batch-3 re-run (`docs/doc-diff-backlog.md`,
+`Language/grammars.rakudoc:112` and `:132`).
+
+## Root cause
+
+The compiled `[+]` reduction meta-operator (`Expr::Reduction` → `OpCode::Reduction` →
+`exec_reduction_op` in `src/vm/vm_misc_reduction_exec.rs` → `eval_reduction_operator_values`
+in `src/vm/vm_dispatch_helpers.rs` → `Interpreter::apply_reduction_op` in
+`src/runtime/ops_reduction.rs`) implements `"+"` by calling
+`crate::builtins::arith_add(left.clone(), right.clone())` (`src/builtins/arith/add_sub.rs`)
+**directly on the raw operand `Value`s**, with no numeric-coercion bridge in front of it.
+`arith_add` is a pure/static function with no interpreter access, so it cannot dispatch a
+user-defined `method Numeric { ... }` (or a `Match` object's implicit numeric coercion) —
+it silently falls through its internal `to_num`/type-match arms to a `0.0` default for any
+`Instance`/`Match` operand it doesn't specifically recognize.
+
+By contrast:
+- The plain binary `+` operator (compiled `OpCode::Add` or similar) goes through
+  `coerce_numeric_bridge_pair`/`coerce_infix_operand_numeric` (in
+  `vm_dispatch_helpers.rs`) **before** calling `arith_add`, so `$a + $b` on two `Match` or
+  user-Numeric objects works correctly.
+- `.reduce(&infix:<+>)` and `.reduce({$^a + $^b})` (the *method*, in
+  `src/runtime/builtins_reduce.rs`, `reduce_items`/`reduce_call_step`) dispatch through
+  `vm_call_on_value`/`call_sub_value`, which reaches the same coercing binary-`+` path.
+
+Only the compiled `[+]`/`[-]`/`[*]`/... reduction **meta-operator** skips the bridge,
+because `apply_reduction_op` calls the raw arithmetic builtins instead of routing through
+`eval_truthy`/`coerce_numeric_bridge_pair`-style dispatch (or falling back to
+`try_user_infix`/a callable dispatch) for non-primitive operands.
+
+## Minimal repro
+
+```raku
+class Foo { has $.n; method Numeric { $!n } }
+my @c = Foo.new(n=>2), Foo.new(n=>3);
+say @c.reduce(&infix:<+>);   # 5 -- correct
+say @c.reduce({$^a + $^b});  # 5 -- correct
+say [+] @c;                  # 0 -- WRONG, raku: 5
+```
+
+Grammar-flavored repro (this is how it surfaces in `grammars.rakudoc`, since a Match
+capture array reduced with `[+]`/`[-]` hits the same path):
+
+```raku
+grammar Calculator {
+    token TOP { [ <add> | <sub> ] }
+    rule  add { <num> '+' <num> }
+    rule  sub { <num> '-' <num> }
+    token num { \d+ }
+}
+class Calculations {
+    method TOP ($/) { make $<add> ?? $<add>.made !! $<sub>.made; }
+    method add ($/) { make [+] $<num>; }
+    method sub ($/) { make [-] $<num>; }
+}
+say Calculator.parse('2 + 3', actions => Calculations).made;
+# raku: 5
+# mutsu: 0
+```
+
+Plain integers/Str/Rat are unaffected (`[+] (2,3)` correctly gives `5`) — only operands
+that need a `.Numeric`/`.Bridge` method dispatch (any `Instance`, including `Match`) hit
+the `0` default.
+
+## Affected files
+
+- `src/runtime/ops_reduction.rs` — `apply_reduction_op`'s `to_num`/`"+"`/`"-"`/`"*"`/`"/"`
+  arms call the raw `arith_*` builtins without coercion.
+- `src/vm/vm_dispatch_helpers.rs` — `eval_reduction_operator_values` (calls
+  `apply_reduction_op`) and `coerce_numeric_bridge_pair`/`coerce_infix_operand_numeric`,
+  which is the existing bridge the fix should route through.
+- `src/vm/vm_misc_reduction_exec.rs` — `exec_reduction_op`, the reduction fold driver that
+  calls `eval_reduction_operator_values` per step.
+
+## Suggested next step
+
+Before calling `apply_reduction_op`'s arithmetic arms, coerce `Instance`/`Match` operands
+through the same `coerce_numeric_bridge_pair` (or `try_user_infix`) path the binary
+operator and `.reduce()` method already use — likely by giving `eval_reduction_operator_values`
+(which already has `&mut self`) first refusal on Instance operands before falling into the
+static `apply_reduction_op` table, mirroring how it already special-cases Junction operands
+just above the `apply_reduction_op` call.

--- a/todo/tickets/tail-lvalue-compound-assign-attribute-array-noop.md
+++ b/todo/tickets/tail-lvalue-compound-assign-attribute-array-noop.md
@@ -1,0 +1,61 @@
+# `.tail` used as an lvalue for compound assignment on a private attribute array silently no-ops
+
+Found by the doc-diff harness batch-3 re-run (`docs/doc-diff-backlog.md`,
+`Language/grammars.rakudoc:289`).
+
+## Root cause hypothesis
+
+`@array.tail` returns a writable (rw) reference to the array's last element, so
+`@array.tail ~= 'x'` (or any compound-assignment op) should mutate that element in place.
+This works for a plain lexical `my @a` array. It does **not** work when the receiver is a
+private class-attribute array (`has @!numbers;`, accessed as `@!numbers.tail`): the
+compound assignment silently no-ops instead of mutating the last element, and the array
+appears unchanged afterward. When `.tail` is later called on what *should* be a non-empty
+array but the accumulated pushes never actually landed (each iteration's mutation was
+dropped), an empty array's `.tail` correctly returns `Nil`, which then throws
+`X::Assignment::RO: cannot assign through .tail on non-instance` on the next attempted
+`~=` — this is *downstream* of the real bug, not a separate one.
+
+## Minimal repro
+
+```raku
+class Foo {
+    has @!numbers;
+    method go() {
+        @!numbers.push: '';
+        say @!numbers.elems;      # 1 -- correct, push worked
+        say @!numbers.raku;       # [""] -- correct
+        @!numbers.tail ~= 'x';
+        say @!numbers.raku;       # should be ["x"]
+    }
+}
+Foo.new.go;
+```
+
+- `raku`: prints `1`, `[""]`, `["x"]`
+- `mutsu`: prints `1`, `[""]`, `[""]` — the `.tail ~= 'x'` assignment is a no-op
+
+For comparison, the same operation on a plain lexical array works correctly on both:
+
+```raku
+my @a = [1,2,3];
+@a.push: 0;
+@a.tail ~= 5;
+say @a;   # both raku and mutsu: [1 2 3 05]
+```
+
+This is how it surfaces in the doc's grammar-actions example
+(`Digifier`/`Devanagari` in `grammars.rakudoc`): `method digit ($/) { @!numbers.tail ~=
+<...>[$/] }` accumulates digits into the last pushed element of a private attribute array,
+and because the mutation never lands, the array stays effectively empty and a later
+`.tail` throws `X::Assignment::RO`.
+
+## Affected files (starting point)
+
+- Wherever `.tail` (and likely `.head`/other rw-container-returning accessor methods) is
+  implemented as an lvalue target for compound assignment — probably in
+  `src/builtins/methods_0arg/` or `src/vm/vm_var_assign_*.rs`. The write-back path likely
+  resolves the container cell correctly for a `my @a` local's array storage but not for an
+  `Instance` attribute's array storage (`@!name`), which may use a different storage/cell
+  representation (`vm_var_assign_computed_attr.rs` handles attribute writeback elsewhere in
+  the codebase and may be the right model to follow).

--- a/todo/tickets/utf8-c8-invalid-byte-codepoint-mismatch.md
+++ b/todo/tickets/utf8-c8-invalid-byte-codepoint-mismatch.md
@@ -1,0 +1,53 @@
+# `utf8-c8` decoding of an invalid byte uses a different private-use codepoint than raku
+
+Found by the doc-diff harness batch-3 re-run (`docs/doc-diff-backlog.md`,
+`Language/unicode.rakudoc:83` and `:90`).
+
+## Root cause hypothesis
+
+The `utf8-c8` encoding is a lossy-roundtrip variant of UTF-8: when decoding a byte sequence
+that isn't valid UTF-8, instead of using the standard U+FFFD replacement character (which
+loses the original byte value), Rakudo synthesizes a private-use-area codepoint that
+records the original invalid byte, so it can later re-encode back to the exact original
+bytes. mutsu also produces a private-use codepoint for an invalid byte (so its `utf8-c8`
+decoding is at least attempting the right feature) but picks a **different** synthetic
+codepoint than raku's scheme, so the visible output (and any downstream `.ords`) differs.
+
+## Minimal repro
+
+```raku
+say Buf.new(ord('A'), 0xFE, ord('Z')).decode('utf8-c8');
+```
+
+- `raku`: `A􏿽xFEZ` (the invalid byte `0xFE` becomes a specific synthetic PUA codepoint
+  that raku's terminal rendering shows as `􏿽xFE` — U+10FFFD followed by the literal hex
+  digits, i.e. Rakudo's synthetic-codepoint scheme stringifies to show the original byte's
+  hex value as plain text after a fixed marker character)
+- `mutsu`: `A󰃾Z` — a different-looking synthetic character, not matching raku's
+  hex-suffixed rendering.
+
+Same root cause, via `slurp(..., enc => 'utf8-c8')` after writing raw bytes to a file:
+
+```raku
+my $test-file = "/tmp/test";
+given open($test-file, :w, :bin) {
+  .write: Buf.new(ord('A'), 0xFA, ord('B'), 0xFB, 0xFC, ord('C'), 0xFD);
+  .close;
+}
+say slurp($test-file, enc => 'utf8-c8');
+```
+
+- `raku`: `A􏿽xFAB􏿽xFB􏿽xFCC􏿽xFD` (each invalid byte gets the same hex-suffixed rendering)
+- `mutsu`: `A󰃺B󰃻󰃼C󰃽` (different synthetic codepoints per byte)
+
+(The harness bucketed the second repro as `raku-drift-from-doc` due to a doc `# OUTPUT:`
+annotation quirk, but the underlying divergence from `raku`'s actual output is real and
+shares the exact same root cause as the first repro.)
+
+## Affected files (starting point)
+
+- Wherever `utf8-c8` decoding is implemented (grep `utf8-c8` in `src/builtins/` /
+  `src/runtime/`) — needs to match Rakudo's exact synthetic-codepoint scheme for invalid
+  bytes (a fixed high codepoint whose low bits or accompanying rendering encode the
+  original byte, matching the `〈marker〉xNN` stringification raku shows), not an
+  independently-chosen PUA codepoint.


### PR DESCRIPTION
## Summary
- Re-ran `scripts/doc-diff-harness.raku` against `grammars.rakudoc`, `syntax.rakudoc`, `Type/Proc/Async.rakudoc`, `nativecall.rakudoc`, `experimental.rakudoc`, and `unicode.rakudoc`, and re-verified each divergence directly against `raku`.
- Filed 16 confirmed-real bugs under `todo/tickets/`, cross-linked in a new `docs/doc-diff-backlog.md` subsection.
- Excluded macro/quasi findings (already tracked in `todo/deep/rakuast-remaining.md`) and the hash-iteration-order / live-DNS findings per the existing exclusion patterns documented in the same file.

## Test plan
- [x] Docs-only change — no `cargo build`/`make test`/`make roast` required.
- [x] Each finding re-verified independently against `raku -e` / `target/debug/mutsu` before filing.
- [x] `docs/doc-diff-backlog.md` table format matches existing batch-2 subsections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)