### PR TITLE
docs: file 18 tickets from doc-diff batch-3 (Parameter/Match/Mu/subscripts/concurrency)

### DIFF
--- a/docs/doc-diff-backlog.md
+++ b/docs/doc-diff-backlog.md
@@ -425,6 +425,50 @@ Found in the 2026-08-22 batch-3 re-run of `grammars`/`syntax`/`Proc::Async`/`nat
   its own and squarely within NativeCall's known, measured gaps
   (`todo/deep/nativecall-cannot-be-vendored.md`) — not ticketed further.
 
+Found in the 2026-08-22 batch-3 re-run of `Parameter`/`Match`/`Mu`/`subscripts`/`concurrency`:
+
+| file:line | one-line summary | ticket |
+|---|---|---|
+| `Type/Parameter.rakudoc:306` | a generic `::T` type parameter isn't resolved when reporting later type-check failures (shows literal `T`, and takes a completely different error-shape for a second case) | [generic-type-param-binding-error-message-unresolved.md](../todo/tickets/generic-type-param-binding-error-message-unresolved.md) |
+| `Type/Parameter.rakudoc:347,395` | `Parameter.sub_signature`/`.modifier` reflection methods are unimplemented | [parameter-sub-signature-and-modifier-attrs-missing.md](../todo/tickets/parameter-sub-signature-and-modifier-attrs-missing.md) |
+| `Type/Parameter.rakudoc:197` | `+@l` slurpy's "single argument rule" wrongly preserves element identity like `is raw` does | [plus-sigil-single-arg-rule-list-context-flattening.md](../todo/tickets/plus-sigil-single-arg-rule-list-context-flattening.md) |
+| `Type/Match.rakudoc:20` | `$¢` (cursor-position variable) inside a regex-embedded code block is unimplemented | [dollar-cent-cursor-variable-in-embedded-regex-block-missing.md](../todo/tickets/dollar-cent-cursor-variable-in-embedded-regex-block-missing.md) |
+| `Type/Match.rakudoc:40` | `$0` read inside a regex-embedded code block returns the raw string instead of a `Match` object | [dollar-numbered-capture-in-embedded-regex-block-returns-raw-value.md](../todo/tickets/dollar-numbered-capture-in-embedded-regex-block-returns-raw-value.md) |
+| `Type/Mu.rakudoc:238` | default `.clone()` doesn't share Array/Hash-typed attribute containers with the original (found while investigating a raku-drift-bucketed example — the drift bucketing itself is correct, but a real bug was hiding in the same example) | [clone-array-hash-attribute-containers-not-shared.md](../todo/tickets/clone-array-hash-attribute-containers-not-shared.md) |
+| `Type/Mu.rakudoc:267` | assigning a list through a `%`-sigil `rw` accessor doesn't coerce it to Hash pairs the way a direct `%var = list` does | [hash-attribute-rw-accessor-list-assignment-not-coerced-to-pairs.md](../todo/tickets/hash-attribute-rw-accessor-list-assignment-not-coerced-to-pairs.md) |
+| `Type/Mu.rakudoc:435` | `.WHY`'s `Pod::Block::Declarator` doesn't stringify to the leading/trailing doc-comment text | [pod-why-declarator-object-not-stringified.md](../todo/tickets/pod-why-declarator-object-not-stringified.md) |
+| `Type/Mu.rakudoc:119` | `.Capture` reads a raw stored attribute value instead of calling an overriding accessor method | [capture-coercion-uses-stored-attribute-not-accessor-method.md](../todo/tickets/capture-coercion-uses-stored-attribute-not-accessor-method.md) |
+| `Type/Mu.rakudoc:515` | `next` thrown mid-evaluation of a `FIRST`-phaser comma expression corrupts later `take slip(...)` calls in the same `gather` | [next-inside-comma-expression-corrupts-following-take-slip.md](../todo/tickets/next-inside-comma-expression-corrupts-following-take-slip.md) |
+| `Type/Mu.rakudoc:531` | `take-rw` doesn't preserve a mutable container alias through `gather` | [take-rw-loses-mutable-container-alias.md](../todo/tickets/take-rw-loses-mutable-container-alias.md) |
+| `Language/subscripts.rakudoc:418` | a chained hash-then-array autovivification (`$h{"k"}[0] = v`) leaves the root variable showing `Any` on `.raku` | [nested-autovivification-then-raku-shows-any.md](../todo/tickets/nested-autovivification-then-raku-shows-any.md) |
+| `Language/subscripts.rakudoc:462` | indexing a `:=`-bound infinite sequence through a hash slice (`%h{$key}[idx]`) divides by zero | [bound-infinite-sequence-hash-slice-divide-by-zero.md](../todo/tickets/bound-infinite-sequence-hash-slice-divide-by-zero.md) |
+| `Language/subscripts.rakudoc:964` | `my @var is CustomClass = ...` never dispatches the class's `STORE`/overridden `Str` methods (custom Proxy-like container binding) | [is-typename-custom-container-store-protocol-unimplemented.md](../todo/deep/is-typename-custom-container-store-protocol-unimplemented.md) |
+| `Language/concurrency.rakudoc:49,85` | a broken `Promise`'s exception isn't wrapped/mixed with `X::Promise::Broken` | [promise-broken-exception-not-wrapped-in-x-promise-broken.md](../todo/tickets/promise-broken-exception-not-wrapped-in-x-promise-broken.md) |
+| `Language/concurrency.rakudoc:124` | `Promise.cause`'s backtrace duplicates the `in block <unit>` frame | [promise-cause-duplicate-in-block-backtrace-frame.md](../todo/tickets/promise-cause-duplicate-in-block-backtrace-frame.md) |
+| `Language/concurrency.rakudoc:213` | `Promise.vow` doesn't protect against a second `.keep`/`.break` via the original Promise | [promise-vow-keep-protection-not-enforced.md](../todo/tickets/promise-vow-keep-protection-not-enforced.md) |
+| `Language/concurrency.rakudoc:703` | `Thread.new(code => {...}).run` — `.run` method is unimplemented | [thread-new-run-method-missing.md](../todo/tickets/thread-new-run-method-missing.md) |
+| `Language/concurrency.rakudoc:709` | `Thread.start({...})`'s block never runs — the main program exits before the spawned thread completes | [thread-start-block-not-awaited-before-process-exit.md](../todo/tickets/thread-start-block-not-awaited-before-process-exit.md) |
+
+**Excluded from this batch-3 sub-run (already deferred/resolved/drift/false-positive):**
+- `Type/Parameter.rakudoc` [3] (line 176) — `raku-drift` (the doc's stated `# OUTPUT` omits the
+  `(42)` value that raku's actual current output includes).
+- `Language/subscripts.rakudoc` [4] (line 51, a `.Mix` keyed by a `Date` object failing to match a
+  distinct-but-equal-value `Date` lookup key) — the **Deferred** "WHICH-keyed QuantHash storage"
+  cluster; confirmed the same root cause with a minimal repro (a plain `Hash` with the same Date
+  keys looks up correctly, only `.Mix`/QuantHash storage fails), not re-ticketed.
+- `Language/subscripts.rakudoc` [5], [6] (lines 225, 336) — hash/Bag iteration-order `raku-drift`,
+  both sides nondeterministic (the known harness false positive for `.keys`/`{*}` iteration order).
+- `Language/subscripts.rakudoc` [7] (line 348, `say @fib[]` on a `1,1, * + * … *` sequence fully
+  reifying instead of showing `[...]`) — the **Deferred** lazy-list cluster's "closure_seq /
+  scan_spec arrays stay force-capped on `@`-assign" residue; confirmed a bare `say @fib;` (no
+  subscript at all) already shows the same full-reification bug for this exact sequence shape.
+- `Language/concurrency.rakudoc` [2] (line 85) — bucketed `raku-drift` by the harness (correctly,
+  since raku's current output no longer matches the doc's stated `# OUTPUT`), but re-verified
+  directly: mutsu's own output diverges from raku's *actual* behavior for the same root cause as
+  the `:49` finding above (missing `X::Promise::Broken` wrapping), so it is folded into
+  [promise-broken-exception-not-wrapped-in-x-promise-broken.md](../todo/tickets/promise-broken-exception-not-wrapped-in-x-promise-broken.md)
+  above rather than being skipped.
+
 ### Deferred / deep (tracked elsewhere — do not re-open as a shallow slice)
 These root causes account for a large share of the survey's `mism`/`crash` and are
 intentionally deferred; see PLAN.md §8.5 and the ADRs:

--- a/todo/deep/is-typename-custom-container-store-protocol-unimplemented.md
+++ b/todo/deep/is-typename-custom-container-store-protocol-unimplemented.md
@@ -1,0 +1,105 @@
+# `my @var is CustomContainerClass = ...` never dispatches the class's `STORE`/overridden `Str` methods
+
+Found by the doc-diff harness re-run (`docs/doc-diff-backlog.md`, `Language/subscripts.rakudoc:964`).
+
+## Repro
+
+```raku
+role Logger { method log( Str $msg) {…}}
+
+class ConsoLogger does Logger { method log ( Str $msg ) { "L $msg".say }}
+
+class DNA {
+    has $.chain;
+    has Logger $!logger;
+
+    submethod BUILD( :$chain, :$logger = ConsoLogger.new() ) {}
+
+    method STORE (Str $chain where {
+            /^^ <[ACGT]>+ $$ / and
+            .chars %% 3
+        },
+        :$INITIALIZE --> DNA) {
+
+        if ($INITIALIZE) {
+            $!logger = ConsoLogger.new();
+            $!logger.log( "Initialized" );
+        }
+
+        $!chain  := $chain;
+        $!logger.log("Change value to $chain" );
+        self
+    }
+
+    method Str(::?CLASS:D:) { return $!chain.comb.rotor(3).map( *.join("")).join("|") }
+};
+
+my @string is DNA = 'GAATCC';    # OUTPUT: «L Initialized␤L Change value to GAATCC␤»
+say ~@string;                    # OUTPUT: «GAA|TCC␤»
+@string = 'ACGTCG';              # OUTPUT: «L Change value to ACGTCG␤»
+say  ~@string;                   # OUTPUT: «ACG|TCG␤»
+```
+
+- raku:
+  ```
+  L Initialized
+  L Change value to GAATCC
+  GAA|TCC
+  L Change value to ACGTCG
+  ACG|TCG
+  ```
+- mutsu (`target/debug/mutsu`):
+  ```
+  GAATCC
+  ACGTCG
+  ```
+  (No logger output at all, and `~@string` just stringifies the plain assigned value instead of
+  going through `DNA`'s custom `.Str` method.)
+
+## Analysis
+
+`my @string is DNA = 'GAATCC'` uses the `is` trait on a variable declaration to bind the variable's
+*container* to a user-defined class (`DNA`) that implements the `STORE` protocol (a Proxy-like
+custom container: assignment into the variable calls `DNA.STORE` with the RHS value, and reading
+the variable's stringification dispatches through `DNA`'s `Str` method). mutsu appears to treat
+`is DNA` as inert here — `@string` behaves like a plain container holding the raw assigned string,
+with none of `STORE`/`Str`/the `INITIALIZE`-flagged first assignment being dispatched at all.
+
+This is a non-trivial container/Metamodel feature: it requires the variable-declaration compiler
+to recognize a custom `is <ClassName>` container binding (distinct from the ordinary `is
+Array`/`is Hash`-style typed-storage traits, and distinct from role composition via `does`), route
+every assignment through the class's `STORE` method (passing along any named arguments, like the
+first-assignment `:INITIALIZE` seen implicitly here — worth checking how raku decides to pass
+`:INITIALIZE` on the very first store), and route stringification/other coercions through the
+class's own methods instead of the built-in container's.
+
+## Why this is `todo/deep`
+
+- Requires new variable-declaration-time dispatch (recognizing `is <UserClass>` as "bind this
+  variable to a custom Proxy-like container implementing STORE", not just "use this native storage
+  representation").
+- Requires wiring assignment (`=`) to call through to `STORE` for such variables, which touches
+  the core assignment-compilation path broadly (any `=` onto such a variable, from anywhere in the
+  program).
+- Interacts with the class/role/Metamodel system (the class implementing `STORE` may also
+  `does` a `Logger`-style role, use `submethod BUILD`, `where`-constrained method signatures,
+  `-->` return-type constraints, `::?CLASS:D:` invocant syntax — all need to already work
+  correctly along the STORE-dispatch path).
+- No existing ticket/ADR in the repo covers "custom `is ClassName` container binding on a
+  variable declaration" (checked `todo/deep/user-postcircumfix-index-not-dispatched-for-instances.md`
+  and `todo/deep/p5tie-stash-bind-key-protocol.md` — related container-protocol themes, but neither
+  covers this specific `is TypeName` variable-declaration binding).
+
+## Affected files (starting point)
+
+- `src/compiler/stmt.rs` — variable-declaration compilation, `is` trait handling
+- `src/vm/vm_var_assign_ops.rs` (or equivalent) — assignment-to-variable execution, to add a
+  STORE-dispatch branch for custom-container-bound variables
+- `src/runtime/class.rs` — class/method resolution, to look up a `STORE` method on the bound class
+
+## Suggested next step
+
+Start by confirming the scope: is `is <UserClass>` (custom container binding via `STORE`) used
+elsewhere in the doc corpus or in roast, or is this a rarely-exercised corner? A quick grep over
+`raku-doc/doc/` and `roast/` for `method STORE` would help scope whether this is worth the
+investment before committing to a design.

--- a/todo/tickets/bound-infinite-sequence-hash-slice-divide-by-zero.md
+++ b/todo/tickets/bound-infinite-sequence-hash-slice-divide-by-zero.md
@@ -1,0 +1,51 @@
+# Indexing a hash-bound infinite sequence via `%h{$key}[idx]` divides by zero
+
+Found by the doc-diff harness re-run (`docs/doc-diff-backlog.md`, `Language/subscripts.rakudoc:462`).
+
+## Repro
+
+```raku
+my @fib = 1,1, * + * … ∞;
+my @lucas = 1,3, * + * … ∞;
+my %sequences;
+%sequences<f> := @fib;
+%sequences<l> := @lucas;
+for %sequences.keys -> $s {
+    for ^10 -> $n {
+        say %sequences{$s}[100+$n*10]/%sequences{$s}[101+$n*10];
+    }
+}
+# OUTPUT: 0.6180339887498949 times 20.
+```
+
+- raku: prints `0.6180339887498949` 20 times (the golden-ratio convergence ratio, for both bound
+  sequences × 10 indices each).
+- mutsu (`target/debug/mutsu`): crashes on the very first division —
+  ```
+  Attempt to divide 0 by zero
+    in block <unit> at ... line 8
+  ```
+
+## Analysis
+
+`%sequences<f> := @fib` binds the hash value directly to the (lazy, infinite) `@fib` array via
+`:=` (no copy). Reading `%sequences{$s}[100+$n*10]` (an element deep into the infinite sequence,
+reached indirectly through a hash-bound alias) returns `0` in mutsu instead of forcing the
+sequence to reify up to that index — so the division sees `0/0`-like results and dies. Indexing
+the array directly (`@fib[100]`) likely already reifies correctly (per the lazy-list work noted
+in `docs/doc-diff-backlog.md`'s Deferred section); the gap here is specific to reaching the same
+lazy array *through* a `:=`-bound hash value subscript chain (`%h{key}[idx]`), which appears to
+not trigger the same on-demand reification path.
+
+## Affected files (starting point)
+
+- `src/vm/vm_var_ops.rs` — hash-then-array chained subscript read path, specifically when the
+  hash value is a `:=`-bound alias to a lazy/infinite array
+- Compare against `@fib[100]` (direct array indexing, expected to already work per the lazy-list
+  cluster fixes) to isolate what's different about the hash-indirection path
+
+## Suggested next step
+
+Minimize further: does `my @b := @fib; say @b[100];` (bind through a scalar-ish alias, no hash)
+reproduce the same zero? That would narrow it to the `:=`-bind-then-reify gap rather than
+something hash-subscript-specific.

--- a/todo/tickets/capture-coercion-uses-stored-attribute-not-accessor-method.md
+++ b/todo/tickets/capture-coercion-uses-stored-attribute-not-accessor-method.md
@@ -1,0 +1,32 @@
+# `.Capture` on an instance reads the raw attribute value, bypassing an overriding accessor method
+
+Found by the doc-diff harness re-run (`docs/doc-diff-backlog.md`, `Type/Mu.rakudoc:119`).
+
+## Repro
+
+```raku
+class Foo {
+    has $.foo = 42;
+    has $.bar = 70;
+    method bar { 'something else' }
+}.new.Capture.say; # OUTPUT: «\(:bar("something else"), :foo(42))␤»
+```
+
+- raku: `\(:bar("something else"), :foo(42))`
+- mutsu (`target/debug/mutsu`): `\(:bar(70), :foo(42))`
+
+## Analysis
+
+`Foo` declares an attribute `$.bar` (which would normally auto-generate a `bar` accessor
+returning the stored value `70`) but also explicitly declares `method bar { 'something else' }`,
+which overrides the auto-generated accessor. Calling `.bar` on an instance correctly dispatches to
+the explicit method (not the attribute default) per normal method-resolution rules. `.Capture`
+should build its pairs by calling each public accessor *method* (so it picks up the override and
+reports `"something else"`), but mutsu's `.Capture` conversion appears to read the raw stored
+attribute value directly, bypassing the method-dispatch/override step entirely.
+
+## Affected files (starting point)
+
+- The built-in `.Capture` coercion for class instances — find where it enumerates public
+  attributes to build the resulting `Capture`'s named pairs; it needs to invoke the (possibly
+  user-overridden) accessor method for each, not read the attribute store directly.

--- a/todo/tickets/clone-array-hash-attribute-containers-not-shared.md
+++ b/todo/tickets/clone-array-hash-attribute-containers-not-shared.md
@@ -1,0 +1,68 @@
+# Default `.clone()` doesn't share Array/Hash-typed attribute containers with the original
+
+Found via direct verification while investigating the doc-diff harness's `Type/Mu.rakudoc:238`
+finding (bucketed `raku-drift` by the harness because of an unrelated closure-gist text mismatch
+in the same example — the harness's raku-drift bucketing for that finding is correct as far as
+the closure text goes, but a second, real bug was hiding in the same example and is filed here
+separately).
+
+## Repro
+
+```raku
+class Foo {
+    has $.foo is rw = 42;
+    has @.bar       = <a b>;
+    has %.baz       = <a b c d>;
+}
+
+my $o1 = Foo.new;
+with my $o2 = $o1.clone {
+    .foo = 70;
+    .bar = <Z Y>;
+}
+
+say $o1;
+say $o2;
+```
+
+- raku:
+  ```
+  Foo.new(foo => 42, bar => ["Z", "Y"], baz => {:a("b"), :c("d")})
+  Foo.new(foo => 70, bar => ["Z", "Y"], baz => {:a("b"), :c("d")})
+  ```
+  (`$o1.bar` shows the *mutated* value `["Z", "Y"]` too — the default `.clone()` shares the
+  `@.bar` Array container between `$o1` and `$o2`, so mutating it through either instance's
+  accessor is visible on both, per the doc's own comment: "Hash and Array attribute modifications
+  in clone appear in original as well".)
+- mutsu (`target/debug/mutsu`):
+  ```
+  Foo.new(foo => 42, bar => ["a", "b"], baz => {:a("b"), :c("d")})
+  Foo.new(foo => 70, bar => ["Z", "Y"], baz => {:a("b"), :c("d")})
+  ```
+  (`$o1.bar` still shows the original `["a", "b"]` — mutsu's `.clone()` gave `$o2` an independent
+  copy of the `@.bar` array instead of sharing the container.)
+
+## Analysis
+
+Raku's default (Mu-inherited) `.clone()` does a *shallow* copy: scalar attributes get their own
+fresh container, but reference-type attributes (Array, Hash) keep pointing at the *same*
+underlying object as the original. Since `@.bar = <Z Y>` mutates the array container in place
+(rather than rebinding the attribute to a new container), that mutation is visible through both
+`$o1` and `$o2` when they share the container. mutsu's `.clone()` appears to deep-copy Array/Hash
+attributes instead, breaking that sharing.
+
+## Related
+
+This may share a root cause with the already-filed
+[container-aliasing-not-preserved-into-collection.md](container-aliasing-not-preserved-into-collection.md)
+ticket (mutsu snapshotting containers by value where raku aliases them) — that ticket covers the
+`.push`/collection-insertion case, this one covers the `.clone()` attribute-copy case. Worth
+checking together, but filed separately since `.clone()`'s copy semantics are a distinct code
+path from array `.push`.
+
+## Affected files (starting point)
+
+- The built-in `.clone()` implementation for instances with Array/Hash-typed attributes — find
+  where it iterates attributes and copies each one; it needs to preserve container identity
+  (share the same `Gc<Array>`/`Gc<Hash>` reference) for reference-type attributes instead of
+  deep-copying them.

--- a/todo/tickets/dollar-cent-cursor-variable-in-embedded-regex-block-missing.md
+++ b/todo/tickets/dollar-cent-cursor-variable-in-embedded-regex-block-missing.md
@@ -1,0 +1,36 @@
+# `$¢` (current cursor position variable) inside a regex-embedded code block is unimplemented
+
+Found by the doc-diff harness re-run (`docs/doc-diff-backlog.md`, `Type/Match.rakudoc:20`).
+
+## Repro
+
+```raku
+my $c;
+'abc' ~~ /.$${ $c = $¢ }/;
+say $c; # OUTPUT: «｢c｣␤»
+```
+
+- raku: `｢c｣` (a `Match` object for the single character at the current cursor position)
+- mutsu (`target/debug/mutsu`): `(Any)`
+
+## Analysis
+
+`$¢` is a special variable available inside a regex-embedded code block (`{ ... }` inside a
+regex/token/rule), representing a `Match` for the character at the cursor's *current* match
+position (distinct from `$/`, the whole match-so-far, and from `$0`/named captures). mutsu does
+not implement this variable at all — reading it returns the undefined default (`(Any)`) instead
+of resolving to a synthesized single-character `Match`.
+
+## Affected files (starting point)
+
+- `src/runtime/regex.rs` / `src/runtime/regex_parse.rs` — regex-embedded code-block variable
+  environment setup (where `$/`, `$0`, named captures etc. are bound for use inside `{ ... }`
+  blocks embedded in a regex). `$¢` needs to be added there, bound to a `Match` representing the
+  single character at the current scan position.
+- Compare with how `$/` is already threaded into an embedded code block's environment — `$¢`
+  needs the same mechanism, with a position-only Match value.
+
+## Suggested next step
+
+Grep for where `$/` gets bound in the embedded-block execution path and add a sibling binding for
+`$¢` using the cursor's current byte/char offset.

--- a/todo/tickets/dollar-numbered-capture-in-embedded-regex-block-returns-raw-value.md
+++ b/todo/tickets/dollar-numbered-capture-in-embedded-regex-block-returns-raw-value.md
@@ -1,0 +1,47 @@
+# `$0` read inside a regex-embedded code block returns the raw captured string, not a `Match` object
+
+Found by the doc-diff harness re-run (`docs/doc-diff-backlog.md`, `Type/Match.rakudoc:40`).
+
+## Repro
+
+```raku
+'123' ~~ / (\d) { say $0; say $/; } \d+ /; # OUTPUT: «｢1｣␤｢1｣␤ 0 => ｢1｣␤»
+```
+
+- raku:
+  ```
+  ｢1｣
+  ｢1｣
+   0 => ｢1｣
+  ```
+- mutsu (`target/debug/mutsu`):
+  ```
+  1
+  ｢1｣
+   0 => ｢1｣
+  ```
+
+Only the first line differs: `say $0` inside the embedded code block prints the bare string `1`
+in mutsu instead of the quoted Match gist `｢1｣` that `say $/` (line 2) and the positional-capture
+list (line 3) already correctly render.
+
+## Analysis
+
+Outside a regex-embedded block, `$0`/`$/[0]` already resolve to proper `Match` objects (as line 2
+and 3 confirm — `$/` itself gists the capture correctly). But when `$0` is read from *inside* the
+embedded `{ ... }` code block mid-match, mutsu appears to bind it to the raw captured substring
+(a `Str`) rather than the `Match` object that `$/`'s corresponding element holds. This looks like
+a separate binding path for numbered-capture variables inside an embedded block that skips
+wrapping the value as a `Match`.
+
+## Affected files (starting point)
+
+- `src/runtime/regex.rs` / `src/runtime/regex_parse.rs` — wherever `$0`/`$1`/... get bound into
+  the embedded code block's local environment during an in-progress match, likely a different
+  code path than the one that builds `$/`'s final capture list after the whole match completes.
+
+## Suggested next step
+
+Compare the embedded-block variable-binding code for `$0` against the post-match `$/`
+capture-list construction to find where the `Match`-wrapping step is skipped for the mid-match
+case.

--- a/todo/tickets/generic-type-param-binding-error-message-unresolved.md
+++ b/todo/tickets/generic-type-param-binding-error-message-unresolved.md
@@ -1,0 +1,61 @@
+# A generic `::T` type parameter is not resolved when reporting later type-check failures
+
+Found by the doc-diff harness re-run (`docs/doc-diff-backlog.md`, `Type/Parameter.rakudoc:306`).
+
+## Repro
+
+```raku
+sub c(::T $x, T $y, $z) { my T $zz = $z };
+c(4, 5, 6);          # OK
+
+try c(4, 5, "six");
+given $! { .message.say };
+
+try c("four", 5, "six");
+given $! { .message.say };
+```
+
+- raku:
+  ```
+  Type check failed in assignment to $zz; expected Int but got Str ("six")
+  Type check failed in binding to parameter '$y'; expected Str but got Int (5)
+  ```
+- mutsu (`target/debug/mutsu`):
+  ```
+  Type check failed in assignment to $zz; expected T but got Str ("six")
+  Calling c(Str, Int, Str) will never work with declared signature (::T $x, T $y, $z)
+    X::TypeCheck::Binding::Parameter: Type check failed for y: expected Str, got Int
+  ```
+
+## Analysis
+
+Two distinct symptoms, both stemming from the same root cause — mutsu never resolves the
+generic type-capture `::T` (bound from the first call argument's actual type) when later
+checking `T`-typed declarations against it:
+
+1. First `try`: `c(4, 5, "six")` binds `::T` to `Int` (from `$x = 4`). The `my T $zz = $z`
+   assignment then fails its type check (`$z = "six"` is a `Str`), and the error message
+   should report the *resolved* type (`expected Int`), but mutsu prints the literal type-capture
+   name `T` instead — `T` was never substituted with the value bound at the `::T $x` parameter.
+2. Second `try`: `c("four", 5, "six")` binds `::T` to `Str` (from `$x = "four"`), so `$y`
+   (typed `T`, i.e. now `Str`) should fail binding against the `Int` argument `5` with a plain
+   single-parameter binding error. Instead mutsu produces a completely different error shape —
+   a multi-line "Calling c(...) will never work with declared signature ..." message plus a
+   different exception class (`X::TypeCheck::Binding::Parameter` with a differently-worded
+   message) — suggesting the failed `T` comparison falls through to a generic
+   "no signature matches" style diagnostic (as if this were multi-dispatch resolution) instead
+   of the ordinary single-sub parameter-binding type-check path.
+
+## Affected files (starting point)
+
+- Wherever `::T`-style generic type captures are resolved and threaded through parameter/variable
+  type checks (look for `type_captures` handling — also referenced in the `Type/Parameter.rakudoc`
+  reflection code at `src/value/signature.rs`).
+- The binding-failure error-reporting path for a single (non-multi) sub call, to see why a `T`-typed
+  parameter mismatch takes a different code path than an ordinary type mismatch.
+
+## Suggested next step
+
+Compare `--dump-ast`/trace for a working `::T`-generic assignment type check against this failing
+one to find where the resolved concrete type gets dropped, and where the second `try`'s error
+path diverges into the multi-dispatch-shaped diagnostic.

--- a/todo/tickets/hash-attribute-rw-accessor-list-assignment-not-coerced-to-pairs.md
+++ b/todo/tickets/hash-attribute-rw-accessor-list-assignment-not-coerced-to-pairs.md
@@ -1,0 +1,70 @@
+# Assigning a plain list through a `%`-sigil `rw` accessor doesn't coerce it to Hash pairs
+
+Found by the doc-diff harness re-run (`docs/doc-diff-backlog.md`, `Type/Mu.rakudoc:267`, with the
+same root cause also visible in the `Type/Mu.rakudoc:238` raku-drift-bucketed example's `baz`
+field).
+
+## Repro
+
+```raku
+class Bar {
+    has $.quux;
+    has @.foo = <a b>;
+    has %.bar = <a b c d>;
+    method clone { nextwith :foo(@!foo.clone), :bar(%!bar.clone), |%_  }
+}
+
+my $o1 = Bar.new( :42quux );
+with my $o2 = $o1.clone {
+    .foo = <Z Y>;
+    .bar = <Z Y X W>;
+}
+
+say $o1;
+say $o2;
+```
+
+- raku:
+  ```
+  Bar.new(quux => 42, foo => ["a", "b"], bar => {:a("b"), :c("d")})
+  Bar.new(quux => 42, foo => ["Z", "Y"], bar => {:X("W"), :Z("Y")})
+  ```
+- mutsu (`target/debug/mutsu`):
+  ```
+  Bar.new(quux => 42, foo => ["a", "b"], bar => {:a("b"), :c("d")})
+  Bar.new(quux => 42, foo => ["Z", "Y"], bar => ("Z", "Y", "X", "W"))
+  ```
+
+`$o2.bar` should still be a `Hash` (the flat list `<Z Y X W>` coerced into key/value pairs, same
+as a direct `%h = <Z Y X W>` assignment already does correctly). mutsu instead stores the raw list.
+
+## Isolated minimal repro (no `clone`/no custom `.clone` method needed)
+
+```raku
+class Bar {
+    has %.bar is rw = <a b c d>;
+}
+my $o = Bar.new;
+say $o.bar;             # {a => b, c => d}     -- OK in mutsu too
+$o.bar = <Z Y X W>;
+say $o.bar;              # raku: {X => W, Z => Y}   mutsu: (Z Y X W)
+```
+
+A direct hash-variable assignment already coerces correctly:
+
+```raku
+my %h = <a b c d>;
+%h = <Z Y X W>;
+say %h;   # {X => W, Z => Y} -- correct in mutsu too
+```
+
+So the bug is specific to assignment routed through the auto-generated `rw` accessor *method*
+for a `%`-sigil attribute — it doesn't go through the same list-to-hash coercion that a direct
+`%var = list` assignment uses.
+
+## Affected files (starting point)
+
+- The auto-generated `is rw` accessor's assignment path for `%`-sigil attributes (likely near
+  where `.=`/accessor-assignment compiles to a method call, or wherever the accessor's underlying
+  container's assignment operator is invoked) — needs to route through the same hash-coercion
+  logic used for direct `%var = list` assignment.

--- a/todo/tickets/nested-autovivification-then-raku-shows-any.md
+++ b/todo/tickets/nested-autovivification-then-raku-shows-any.md
@@ -1,0 +1,38 @@
+# A chained hash-then-array autovivification leaves the root variable showing `Any` on `.raku`
+
+Found by the doc-diff harness re-run (`docs/doc-diff-backlog.md`, `Language/subscripts.rakudoc:418`).
+
+## Repro
+
+```raku
+my $beatles;
+
+$beatles{"White Album"}[0] = "Back in the U.S.S.R.";  # autovivification!
+
+say $beatles.raku;  # OUTPUT: «${"White Album" => $["Back in the U.S.S.R."]}␤»
+```
+
+- raku: `${"White Album" => $["Back in the U.S.S.R."]}`
+- mutsu (`target/debug/mutsu`): `Any`
+
+## Analysis
+
+`$beatles` starts undefined. Indexing it with `{"White Album"}` should autovivify it into a Hash
+container, and further indexing that with `[0]` should autovivify that hash value into an Array
+container, with the final assignment landing in `$beatles{"White Album"}[0]`. mutsu's `.raku` on
+`$beatles` afterward shows `Any` — meaning either the autovivification chain never actually wrote
+back into `$beatles`'s own container (the write only affected a disconnected temporary), or the
+two-level `{...}` → `[...]` autovivification chain isn't establishing the container nesting at
+all.
+
+## Affected files (starting point)
+
+- `src/vm/vm_var_ops.rs` — indexing/autovivification for chained hash/array subscripts
+- Compare with a single-level autovivification (`$h{"k"} = 1` alone, or `$a[0] = 1` alone) to see
+  whether those work and only the *chained* two-level case (hash-of-array) fails.
+
+## Suggested next step
+
+`--dump-ast` the assignment to see how the chained `{...}[...]` index-assign is compiled, and
+trace whether the intermediate autovivified Hash container is the same object that
+`$beatles`'s own scalar container ends up referencing.

--- a/todo/tickets/next-inside-comma-expression-corrupts-following-take-slip.md
+++ b/todo/tickets/next-inside-comma-expression-corrupts-following-take-slip.md
@@ -1,0 +1,65 @@
+# `next` thrown mid-evaluation of a comma-expression corrupts later `take slip(...)` calls in the same `gather`
+
+Found by the doc-diff harness re-run (`docs/doc-diff-backlog.md`, `Type/Mu.rakudoc:515`).
+
+## Repro
+
+```raku
+sub insert($sep, +@list) {
+    gather for @list {
+        FIRST .take, next;
+        take slip $sep, .item
+    }
+}
+
+say insert ':', <a b c>;
+# OUTPUT: «(a : b : c)␤»
+```
+
+- raku: `(a : b : c)`
+- mutsu (`target/debug/mutsu`): `(a b c)` — every separator is missing, as if every `take
+  slip(...)` call after the first iteration only ever took `.item`, dropping `$sep`.
+
+## Isolated minimal repro (no sub/slurpy needed)
+
+```raku
+my @list = <a b c>;
+my $sep = ':';
+say gather for @list {
+    FIRST .take, next;
+    take slip $sep, .item
+}
+```
+Same divergence: raku `(a : b : c)`, mutsu `(a b c)`.
+
+Removing the `FIRST` phaser (replacing it with an ordinary `if` that also `.take`s and `next`s
+on the first element) makes mutsu match raku exactly — so the bug is specific to the `FIRST
+.take, next;` phaser form, not to `slip`/`take` in general (a standalone
+`gather { take slip $sep, $item }` outside a `FIRST` phaser already works correctly in mutsu).
+Wrapping the `slip(...)` argument in explicit parens does not change the outcome either.
+
+## Root cause hypothesis
+
+`FIRST .take, next;` parses as a `Phaser { body: [ArrayLiteral([MethodCall(.take), ControlFlow
+(Next)])] }` (confirmed via `--dump-ast`) — i.e. the comma builds an array-literal expression
+containing the `.take` call and the `next` control-flow as its two elements, evaluated in a sink
+statement. `next` throws mid-construction of that array literal (after `.take()`'s side effect
+has already run). This suggests the VM's array-literal-building machinery pushes some internal
+state (e.g. an "elements collected so far" stack/buffer) that is not correctly unwound when a
+control-flow exception (`next`) is thrown out of the middle of building it — and that leftover
+state then corrupts the *next* listop call that uses the same machinery (`slip`'s argument
+collection) in later loop iterations.
+
+## Affected files (starting point)
+
+- `src/vm/vm_control_ops.rs` — `next`/control-flow exception handling
+- `src/vm/vm_data_ops.rs` — array-literal construction (the "building an array" state that a
+  thrown control-flow exception might leave dirty)
+- `src/vm/vm_string_regex_ops.rs` / wherever `slip`'s argument-flattening reuses the same
+  machinery
+
+## Suggested next step
+
+Use `rust-gdb` to break on the array-literal-construction opcode and step through the `FIRST
+.take, next;` case to find what state survives the `next` throw and is still present when the
+next `take slip(...)` call runs.

--- a/todo/tickets/parameter-sub-signature-and-modifier-attrs-missing.md
+++ b/todo/tickets/parameter-sub-signature-and-modifier-attrs-missing.md
@@ -1,0 +1,56 @@
+# `Parameter.sub_signature` and `Parameter.modifier` methods are unimplemented
+
+Found by the doc-diff harness re-run (`docs/doc-diff-backlog.md`, `Type/Parameter.rakudoc:347` and
+`:395`).
+
+## Repro 1 — `.sub_signature`
+
+```raku
+my Signature $sig = :(@array ($first, *@rest), @other);
+say $sig.params[0].sub_signature;     # OUTPUT: «($first, *@rest)␤»
+say $sig.params[1].sub_signature;     # OUTPUT: «(Signature)␤»
+```
+
+- raku: `($first, *@rest)` then `(Signature)`
+- mutsu: `No such method 'sub_signature' for invocant of type 'Parameter'`
+
+## Repro 2 — `.modifier`
+
+```raku
+my Signature $sig = :(Str:U $a, UInt:D $b, $c);
+say $sig.params[0].modifier; # OUTPUT: «:U␤»
+say $sig.params[1].modifier; # OUTPUT: «:D␤»
+say $sig.params[2].modifier; # OUTPUT: «␤»
+```
+
+- raku: `:U` then `:D` (then empty)
+- mutsu: `No such method 'modifier' for invocant of type 'Parameter'`
+
+## Root cause / extension point
+
+`Parameter` reflection objects are built by `build_parameter_attrs()` in
+`src/value/signature.rs` (function starts at line 497) — it fills a `HashMap<String, Value>` of
+attribute name to value from a `SigParam`, wrapped as a `Value::Instance` of class `Parameter` by
+`sig_param_to_parameter_instance[_with_owner]` (lines 433-450). Because `Parameter` is a built-in
+(not in `user_declared_classes`), method dispatch in `dispatch_instance_and_fallback()`
+(`src/runtime/methods_instance_ops.rs`, fn starts line 192, fallback-accessor block around
+lines 1345-1377) auto-generates a zero-arg accessor for any key present in that attrs map — so
+adding `sub_signature`/`modifier` support is purely a matter of populating those two keys in
+`build_parameter_attrs`, not adding new dispatch machinery.
+
+Currently populated keys (for reference): `name` (509), `type` + `type_captures` (544-545),
+`named` (553), `slurpy` (554), `sigil` (555), `multi-invocant` (556), `readonly`/`rw`/`raw`/`copy`
+(563-566), `optional` (569), `invocant` (572), `positional` (575-578), `capture` (581).
+
+- `sub_signature`: `ParamDef` already carries `sub_signature: Option<Vec<ParamDef>>` on the AST
+  side (`src/ast.rs` line 73) but it is never read into `build_parameter_attrs`. Needs conversion
+  to a `Signature` value (or `(Signature)` type object when absent, per repro 1's second line).
+- `modifier`: needs to derive the `:U`/`:D`/(empty) string from the parameter's type-smiley
+  definedness constraint (the same information that already drives type checking for `Str:U`/
+  `UInt:D`-style parameters).
+
+## Affected files
+
+- `src/value/signature.rs` — `build_parameter_attrs()`
+- `src/ast.rs` — `ParamDef` (confirm `sub_signature` and definedness-smiley fields already carry
+  the needed data)

--- a/todo/tickets/plus-sigil-single-arg-rule-list-context-flattening.md
+++ b/todo/tickets/plus-sigil-single-arg-rule-list-context-flattening.md
@@ -1,0 +1,43 @@
+# `+@l` slurpy parameter's single-argument rule doesn't preserve list-context flattening semantics
+
+Found by the doc-diff harness re-run (`docs/doc-diff-backlog.md`, `Type/Parameter.rakudoc:197`).
+
+## Repro
+
+```raku
+my @types is List = Mu, Any;
+say -> *@l { @l }(@types)[0] =:= @types[0];        # OUTPUT: «False␤»
+say -> +@l { @l }(@types)[0] =:= @types[0];        # OUTPUT: «False␤»
+say -> +l { l }(@types)[0] =:= @types[0];          # OUTPUT: «True␤»
+say -> *@l is raw { @l }(@types)[0] =:= @types[0]; # OUTPUT: «True␤»
+```
+
+- raku: `False`, `False`, `True`, `True`
+- mutsu (`target/debug/mutsu`): `False`, `True`, `True`, `True`
+
+Line 2 (`+@l`, the "single argument rule" slurpy sigil applied to an `@`-sigiled parameter)
+diverges: raku still gives `False` (the element is a fresh, non-identical copy — same as plain
+`*@l`), mutsu gives `True` (as if `+@l` behaved like the `is raw`/bare-`+l` forms that preserve
+element identity).
+
+## Analysis
+
+Per `raku-doc/doc/Language/functions.rakudoc` / `signatures.rakudoc`, the `+` sigil-modifier
+("single argument rule") only changes whether a single argument is treated as the whole list vs.
+one element — it should not, by itself, change whether an `@`-sigiled slurpy's elements are
+itemized copies or raw aliases. Only the sigilless (`+l`, no `@`) form and the explicit `is raw`
+trait skip itemization. mutsu's `+@l` case appears to be conflating the `+`-sigil's "raw" binding
+behavior with the sigilless-parameter's raw-alias behavior, treating `+@l` as if it implied `is
+raw`.
+
+## Affected files (starting point)
+
+- Compiler/runtime code that binds the `+`-sigil-modifier slurpy parameter (`src/compiler/` or
+  `src/runtime/` parameter-binding logic) — look for where `+`-sigil vs. `*`-sigil vs. bare
+  sigilless slurpy binding decides whether to itemize/copy vs. alias each element.
+
+## Suggested next step
+
+Compare `--dump-ast` for the `+@l` and `*@l` closures to see whether they compile to the same
+binding opcode/flag, then find where that flag incorrectly turns on raw/alias semantics for the
+`+@l` case.

--- a/todo/tickets/pod-why-declarator-object-not-stringified.md
+++ b/todo/tickets/pod-why-declarator-object-not-stringified.md
@@ -1,0 +1,41 @@
+# `.WHY` on a sub with leading/trailing Pod declarator comments doesn't stringify to the doc text
+
+Found by the doc-diff harness re-run (`docs/doc-diff-backlog.md`, `Type/Mu.rakudoc:435`).
+
+## Repro
+
+```raku
+class Spell {};sub do-raw-magic(Spell) {};
+#| Initiate a specified spell normally
+sub cast(Spell $s) {
+  do-raw-magic($s);
+}
+#= (do not use for class 7 spells)
+say &cast.WHY;
+# OUTPUT: «Initiate a specified spell normally␤(do not use for class 7 spells)␤»
+```
+
+- raku:
+  ```
+  Initiate a specified spell normally
+  (do not use for class 7 spells)
+  ```
+- mutsu (`target/debug/mutsu`):
+  ```
+  Pod::Block::Declarator.new
+  ```
+
+## Analysis
+
+`.WHY` on a routine returns a `Pod::Block::Declarator` object built from the `#|`/`#=` leading and
+trailing declarator comments. `say`-ing it should stringify to the concatenated doc text (both the
+leading `#|` block and the trailing `#=` block, newline-joined). mutsu returns a
+`Pod::Block::Declarator` instance whose `.Str`/`.gist` isn't implemented — it falls back to the
+generic `TypeName.new` gist instead of rendering the captured comment text.
+
+## Affected files (starting point)
+
+- Wherever `#|`/`#=` declarator comments are parsed and attached to a routine's `.WHY` (look for
+  `Pod::Block::Declarator` construction in the parser/compiler).
+- The `Pod::Block::Declarator` type's `.Str`/`.gist` method — needs to join the leading and
+  trailing comment text the way the doc example expects.

--- a/todo/tickets/promise-broken-exception-not-wrapped-in-x-promise-broken.md
+++ b/todo/tickets/promise-broken-exception-not-wrapped-in-x-promise-broken.md
@@ -1,0 +1,69 @@
+# A broken `Promise`'s exception isn't wrapped/mixed with `X::Promise::Broken`
+
+Found by the doc-diff harness re-run (`docs/doc-diff-backlog.md`, `Language/concurrency.rakudoc:49`
+and `:85`).
+
+## Repro 1 — `.break('str')` should mix `X::Promise::Broken` into the resulting exception
+
+```raku
+my $p2 = Promise.new;
+$p2.break('oh no');
+say $p2.status;         # OUTPUT: «Broken␤»
+say $p2.result;         # dies, because the promise has been broken
+CATCH { default { say .^name, ': ', .Str } };
+# OUTPUT: «X::AdHoc+{X::Promise::Broken}: oh no␤»
+```
+
+- raku: `X::AdHoc+{X::Promise::Broken}: oh no` (an anonymous mixin combining `X::AdHoc` with the
+  `X::Promise::Broken` role)
+- mutsu (`target/debug/mutsu`): `X::AdHoc: oh no` (plain `X::AdHoc`, no `X::Promise::Broken` mixin)
+
+## Repro 2 — a chained `.then` on a broken Promise should wrap the cause with "Tried to get the result of a broken Promise" / "Original exception:"
+
+```raku
+my $promise1 = Promise.new();
+my $promise2 = $promise1.then(-> $v { say "Handled but : "; say $v.result});
+$promise1.break("First Result");
+try $promise2.result;
+say $promise2.cause;
+```
+
+- raku:
+  ```
+  Handled but : 
+  Tried to get the result of a broken Promise
+    in block  at ... line 2
+  
+  Original exception:
+      First Result
+        in block  at ... line 2
+  ```
+- mutsu:
+  ```
+  Handled but : 
+  First Result
+    in block <unit>
+  ```
+
+(The doc-diff harness bucketed repro 2 as `raku-drift-from-doc` because raku's *current* output
+no longer matches the doc's stated `# OUTPUT` — that bucketing is correct for the doc-vs-raku
+comparison, but re-verified directly here: mutsu's own output diverges from *raku's actual current
+behavior* in a real, substantive way — the "Tried to get the result of a broken Promise" /
+"Original exception:" wrapper is missing entirely, not just cosmetically different — so it is
+filed here as a real bug rather than skipped.)
+
+## Analysis
+
+Both repros show the same root cause: when a `Promise` is broken (via `.break(...)` or by an
+upstream broken Promise propagating through `.then`), raku wraps/exposes the cause through an
+`X::Promise::Broken`-flavored exception (either directly mixed with `X::AdHoc` for a plain
+`.break('str')`, or — when the caller tries to read `.result` on an already-broken Promise —
+wrapped in a "Tried to get the result of a broken Promise" message chaining to the original cause
+via "Original exception:"). mutsu's Promise-break path never constructs this
+`X::Promise::Broken`-flavored wrapper; it surfaces the raw broken-with value/exception directly.
+
+## Affected files (starting point)
+
+- Wherever `Promise.break()`/`.then()`-on-broken-Promise resolution builds the resulting
+  exception/cause (likely `src/runtime/` concurrency/Promise implementation) — needs an
+  `X::Promise::Broken` role mixin path.

--- a/todo/tickets/promise-cause-duplicate-in-block-backtrace-frame.md
+++ b/todo/tickets/promise-cause-duplicate-in-block-backtrace-frame.md
@@ -1,0 +1,40 @@
+# `Promise.cause`'s backtrace duplicates the `in block <unit>` frame
+
+Found by the doc-diff harness re-run (`docs/doc-diff-backlog.md`, `Language/concurrency.rakudoc:124`).
+
+## Repro
+
+```raku
+my $promise = Promise.start({ die "Broken Promise" });
+try $promise.result;
+say $promise.cause;
+```
+
+- raku:
+  ```
+  Broken Promise
+    in block  at ... line 1
+  ```
+  (a single backtrace frame, and the anonymous block inside `Promise.start` shows an unnamed
+  `in block ` rather than `<unit>`)
+- mutsu (`target/debug/mutsu`):
+  ```
+  Broken Promise
+    in block <unit> at ... line 1
+    in block <unit> at ... line 1
+  ```
+  (the `in block <unit> at ... line 1` frame is duplicated, and both are labeled `<unit>` instead
+  of raku's unnamed anonymous-block frame)
+
+## Analysis
+
+Minor, cosmetic backtrace-formatting bug: `.cause`'s exception backtrace for a `Promise.start`
+block gets an extra duplicate frame (and mislabels the anonymous `Promise.start` block as `<unit>`
+— the top-level program unit — rather than an anonymous inner block). Likely the backtrace
+construction path for a Promise's stored exception walks/appends a frame twice, or reuses the
+outer `<unit>` frame's label for the inner anonymous-block frame instead of a distinct one.
+
+## Affected files (starting point)
+
+- Wherever `Promise.start`'s worker-thread exception capture builds/formats the backtrace for
+  later `.cause`/`.result` access (concurrency/Promise implementation, backtrace formatting code).

--- a/todo/tickets/promise-vow-keep-protection-not-enforced.md
+++ b/todo/tickets/promise-vow-keep-protection-not-enforced.md
@@ -1,0 +1,40 @@
+# `Promise.vow` doesn't protect against a second `.keep`/`.break` via the original Promise
+
+Found by the doc-diff harness re-run (`docs/doc-diff-backlog.md`, `Language/concurrency.rakudoc:213`).
+
+## Repro
+
+```raku
+sub get_promise {
+    my $promise = Promise.new;
+    my $vow = $promise.vow;
+    Promise.in(10).then({$vow.keep});
+    $promise;
+}
+
+my $promise = get_promise();
+
+# Will throw an exception
+# "Access denied to keep/break this Promise; already vowed"
+$promise.keep;
+CATCH { default { say .^name, ': ', .Str } };
+# OUTPUT: «X::Promise::Vowed: Access denied to keep/break this Promise; already vowed␤»
+```
+
+- raku: `X::Promise::Vowed: Access denied to keep/break this Promise; already vowed`
+- mutsu (`target/debug/mutsu`): no output at all — the `CATCH` block never fires, meaning
+  `$promise.keep` neither throws nor is reported.
+
+## Analysis
+
+Calling `.vow` on a `Promise` should mark it as "vowed" — from then on, only that specific `Vow`
+object (not the `Promise` itself) is allowed to `.keep`/`.break` it; attempting `.keep`/`.break`
+directly on an already-vowed `Promise` should throw `X::Promise::Vowed`. mutsu appears not to
+implement this protection at all: `$promise.keep` silently does nothing (or silently succeeds)
+instead of throwing.
+
+## Affected files (starting point)
+
+- `Promise.vow`/`Promise.keep`/`Promise.break` implementation (concurrency runtime module) — needs
+  a "vowed" flag set by `.vow` and checked by `.keep`/`.break` on the `Promise` object itself
+  (raising `X::Promise::Vowed` when set).

--- a/todo/tickets/take-rw-loses-mutable-container-alias.md
+++ b/todo/tickets/take-rw-loses-mutable-container-alias.md
@@ -1,0 +1,45 @@
+# `take-rw` doesn't preserve a mutable container alias through `gather`
+
+Found by the doc-diff harness re-run (`docs/doc-diff-backlog.md`, `Type/Mu.rakudoc:531`).
+
+## Repro
+
+```raku
+my @a = 1...3;
+sub f(@list){ gather for @list { take-rw $_ } };
+for f(@a) { $_++ };
+say @a;
+# OUTPUT: «[2 3 4]␤»
+```
+
+- raku: `[2 3 4]` — mutating `$_` while iterating over `f(@a)`'s gathered results writes back
+  through to the original `@a` elements.
+- mutsu (`target/debug/mutsu`): crashes —
+  ```
+  Cannot resolve caller postfix:<++>(_); the parameter requires mutable arguments
+    in block <unit> at ... line 2
+  ```
+
+## Analysis
+
+`take-rw` is documented to take its argument *by reference* (as opposed to plain `take`, which
+takes a value/copy) — the gathered sequence's elements should remain live aliases to the source
+container. mutsu's `take-rw` appears to behave like plain `take` (or otherwise fails to mark the
+resulting sequence element as a mutable container), so a later `$_++` over the gathered result has
+nothing mutable to write through, and mutsu throws instead of silently doing the wrong thing.
+
+Note this is a different, narrower gap than the general `for @arr -> $v is rw { ... }`
+element-aliasing architecture question tracked in
+`todo/deep/for-loop-rw-element-alias-lost-through-deferred-closure.md` /
+[ADR-0045](../../docs/adr/0045-for-loop-parameters-bind-the-element-container.md) — a plain
+`for @a { $_++ }` (no `gather`/`take-rw` involved) already correctly mutates `@a` in mutsu today,
+confirming the base for-loop `$_` aliasing works. This bug is specific to `take-rw` not
+propagating that live container reference into the value it pushes onto the `gather` sequence.
+If ADR-0045's element-`ContainerRef` work lands first, it may be worth re-checking whether it also
+fixes this case for free before implementing a `take-rw`-specific patch.
+
+## Affected files (starting point)
+
+- Wherever `take`/`take-rw` are implemented for `gather` (likely `src/vm/vm_control_ops.rs` or
+  `src/runtime/` gather/take handling) — `take-rw` needs to store a live container reference
+  (`ContainerRef`) for its argument instead of a plain value snapshot.

--- a/todo/tickets/thread-new-run-method-missing.md
+++ b/todo/tickets/thread-new-run-method-missing.md
@@ -1,0 +1,32 @@
+# `Thread.new(code => {...}).run` — `.run` method is unimplemented
+
+Found by the doc-diff harness re-run (`docs/doc-diff-backlog.md`, `Language/concurrency.rakudoc:703`).
+
+## Repro
+
+```raku
+my $thread = Thread.new(code => { for  1 .. 10  -> $v { say $v }});
+# ...
+$thread.run;
+```
+
+- raku: prints `1` through `10`
+- mutsu (`target/debug/mutsu`): crashes —
+  ```
+  No such method 'run' for invocant of type 'Thread'
+    in block <unit> at ... line 3
+  ```
+
+## Analysis
+
+`Thread.new(code => {...})` constructs a `Thread` object without starting it; `.run` is the method
+that actually starts execution of the thread's code block. mutsu's `Thread` type doesn't implement
+`.run` at all (compare with `Thread.start({...})`, the more common one-step constructor-and-start
+form, which does exist but has its own bug — see
+[thread-start-block-not-awaited-before-process-exit.md](thread-start-block-not-awaited-before-process-exit.md)).
+
+## Affected files (starting point)
+
+- Wherever the `Thread` type's methods are implemented (concurrency runtime module) — needs a
+  `.run` method that starts the underlying OS thread for a `Thread.new`-constructed (not-yet-
+  started) `Thread` object.

--- a/todo/tickets/thread-start-block-not-awaited-before-process-exit.md
+++ b/todo/tickets/thread-start-block-not-awaited-before-process-exit.md
@@ -1,0 +1,35 @@
+# `Thread.start({...})` never produces output — the main program exits before the thread runs
+
+Found by the doc-diff harness re-run (`docs/doc-diff-backlog.md`, `Language/concurrency.rakudoc:709`).
+
+## Repro
+
+```raku
+my $thread = Thread.start({ for  1 .. 10  -> $v { say $v }});
+```
+
+(no explicit `.join`/wait — the script ends immediately after starting the thread)
+
+- raku: reliably prints `1` through `10` before the process exits (verified 3/3 runs) — raku's
+  main thread waits for spawned non-daemon `Thread`s to finish before the process terminates.
+- mutsu (`target/debug/mutsu`): produces **no output at all** (verified 3/3 runs, deterministic —
+  not a race/flake) — the main program exits immediately, and the spawned thread's work is never
+  observed to run (or runs after the process has already begun tearing down and its output is
+  lost).
+
+Adding an explicit `.join` after `.start` makes mutsu produce correct output (`1`..`10`), so the
+underlying thread-spawn-and-run mechanism itself works — the bug is specifically that mutsu's
+process-exit path does not wait for outstanding non-daemon threads the way raku's does.
+
+## Analysis
+
+Per Raku's threading model, `Thread` objects spawned via `.start` are (by default) not daemon
+threads, so the runtime should keep the process alive until they complete, even if the main
+program's own statements have all finished. mutsu appears to exit the process as soon as the main
+thread's statements complete, without joining/waiting on any still-running `Thread`s it spawned.
+
+## Affected files (starting point)
+
+- Wherever `Thread.start` spawns the underlying OS thread (concurrency runtime module)
+- `src/main.rs` / process-exit path — needs to join outstanding non-daemon threads before the
+  process actually terminates


### PR DESCRIPTION
## Summary
- Triaged the 2026-08-22 batch-3 doc-diff re-sweep findings for `Type/Parameter.rakudoc`, `Type/Match.rakudoc`, `Type/Mu.rakudoc`, `Language/subscripts.rakudoc`, and `Language/concurrency.rakudoc`.
- Filed 18 tickets under `todo/tickets/` plus 1 deep ticket (`is ClassName` custom container/STORE protocol) under `todo/deep/`.
- Excluded findings matching already-Deferred clusters (WHICH-keyed QuantHash storage, lazy-list scan_spec force-capping) and hash/Bag iteration-order false positives, per `docs/doc-diff-backlog.md`'s triage rules.
- Added the batch-3 subsection + exclusion bullets to `docs/doc-diff-backlog.md`.

Every finding was re-verified directly (`raku -e`/`raku <file>` vs `target/debug/mutsu`) before filing, not just trusted from the harness report.

## Test plan
- [x] Docs-only change — no code touched.
- [x] `docs/doc-diff-backlog.md` edit is additive (new subsection only, no other section touched).
- [x] Each of the 18 tickets' repros were independently re-run against both `raku` and `target/debug/mutsu` to confirm they're real divergences, not harness artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)