### PR TITLE
docs: doc-diff batch4-B triage (Backtrace/Scalar/perl-var/ParametricRoleHOW/Lock::Async/InvalidQualifier/IO::Path::Parts/phasers/TypePretense/Notification::Change)

### DIFF
--- a/docs/doc-diff-backlog.md
+++ b/docs/doc-diff-backlog.md
@@ -469,6 +469,38 @@ Found in the 2026-08-22 batch-3 re-run of `Parameter`/`Match`/`Mu`/`subscripts`/
   [promise-broken-exception-not-wrapped-in-x-promise-broken.md](../todo/tickets/promise-broken-exception-not-wrapped-in-x-promise-broken.md)
   above rather than being skipped.
 
+Found in the 2026-08-22 batch-4 re-run of `Backtrace`/`Scalar`/`perl-var`/
+`Metamodel::ParametricRoleHOW`/`Lock::Async`/`X::Method::InvalidQualifier`/
+`IO::Path::Parts`/`phasers`/`Metamodel::TypePretense`/`IO::Notification::Change`:
+
+| file:line | one-line summary | ticket |
+|---|---|---|
+| `Type/Backtrace.rakudoc:15` | `$!.backtrace[N]` positional indexing always returns `Nil` | [backtrace-frame-indexing-returns-nil.md](../todo/tickets/backtrace-frame-indexing-returns-nil.md) |
+| `Type/Backtrace.rakudoc:72,84,96` | `Backtrace` is missing `.next-interesting-index`, `.outer-caller-idx`, `.nice` | [backtrace-introspection-methods-missing.md](../todo/tickets/backtrace-introspection-methods-missing.md) |
+| `Type/Scalar.rakudoc:43` | `my $b := 1; $b.VAR.^name` should be `Int` (bind creates no container), mutsu gives `Scalar` | [bind-scalar-literal-var-name-not-int.md](../todo/tickets/bind-scalar-literal-var-name-not-int.md) |
+| `Language/perl-var.rakudoc:154` | `CompUnit::Repository::FileSystem`/`Installation` stringify as `TypeName.new` instead of `inst#<path>` | [compunit-repository-gist-missing-inst-prefix.md](../todo/tickets/compunit-repository-gist-missing-inst-prefix.md) |
+| `Type/Metamodel/ParametricRoleHOW.rakudoc:29` | a parenthesized anonymous `role {...}` term (parameterized or not) is a hard parse error; `(class {...})` already works | [anon-role-expression-term-parse-fail.md](../todo/tickets/anon-role-expression-term-parse-fail.md) |
+| `Type/Metamodel/ParametricRoleHOW.rakudoc:35` | `Metamodel::ParametricRoleHOW.new_type(...)` returns a type whose `.HOW` is `ClassHOW`, not `ParametricRoleHOW` | [metamodel-parametricrolehow-new-type-wrong-how.md](../todo/tickets/metamodel-parametricrolehow-new-type-wrong-how.md) |
+| `Type/Lock/Async.rakudoc:162,202` | `Lock::Async` is missing `.protect-or-queue-on-recursion` and `.with-lock-hidden-from-recursion-check` | [lock-async-recursion-methods-missing.md](../todo/tickets/lock-async-recursion-methods-missing.md) |
+| `Type/X/Method/InvalidQualifier.rakudoc:14` | `X::Method::InvalidQualifier` message says "a method" instead of naming the actual method | [invalid-qualifier-error-message-missing-method-name.md](../todo/tickets/invalid-qualifier-error-message-missing-method-name.md) |
+| `Type/IO/Path/Parts.rakudoc:71` | `$parts[]` (empty postcircumfix index) on `IO::Path::Parts` shows the whole-object gist instead of iterating its 3 positional elements | [io-path-parts-empty-subscript-not-positional.md](../todo/tickets/io-path-parts-empty-subscript-not-positional.md) |
+| `Language/phasers.rakudoc:401` | a `CONTROL { when CX::Take {...} }` handler is never invoked for `take` inside `gather` (unlike `CX::Warn`/`CX::Done`, which work) | [control-phaser-cx-take-not-intercepted.md](../todo/tickets/control-phaser-cx-take-not-intercepted.md) |
+| `Type/Metamodel/TypePretense.rakudoc:15,47` | `Role ~~ Cool` is `False` (should be `True`, same as `Mu`/`Any`), and `.HOW.pretending_to_be` is unimplemented | [role-type-pretense-cool-incomplete.md](../todo/tickets/role-type-pretense-cool-incomplete.md) |
+
+**Excluded from this batch-4 sub-run (already deferred/resolved/drift/false-positive/environment):**
+- `Type/Scalar.rakudoc` [2] (line 53, `[1, 2, 3][0].VAR.^name` should be `Scalar`, mutsu gives
+  `Int`) — the already-**Deferred**/deep "Array/Hash elements are stored bare — element reads lack
+  itemization" cluster (`todo/deep/element-itemization-lost-in-scalar-binding.md`, ADR-0040); the
+  `(1, 2, 3)[0]` (plain List, not Array) case in the same example already matches raku.
+- `Language/perl-var.rakudoc` [1] (line 198, `$*KERNEL`/`$*DISTRO`/`$*VM` release/name/auth fields) —
+  inherently environment/build-dependent (kernel version, OS distro, VM identity), same exclusion
+  category as `Language/variables.rakudoc` [6]/[7]/[9]/[10]/[8] noted above; not a bug.
+- `Type/IO/Notification/Change.rakudoc` — re-ran the harness; all 3 candidate blocks are bucketed
+  "no oracle" (raku itself does not exit cleanly on any of them in this environment) rather than
+  `mutsu-crash`, so there is no finding to compare against the survey table's stale `crash=1`. These
+  examples use live filesystem-watching (`IO::Notification.watch-path`), which is inherently
+  timing/environment-dependent and not a clean minimal repro; not ticketed.
+
 ### Deferred / deep (tracked elsewhere — do not re-open as a shallow slice)
 These root causes account for a large share of the survey's `mism`/`crash` and are
 intentionally deferred; see PLAN.md §8.5 and the ADRs:

--- a/todo/tickets/anon-role-expression-term-parse-fail.md
+++ b/todo/tickets/anon-role-expression-term-parse-fail.md
@@ -1,0 +1,44 @@
+# A parenthesized anonymous `role` declaration fails to parse as an expression term
+
+Found by the doc-diff harness re-run (`docs/doc-diff-backlog.md`,
+`Type/Metamodel/ParametricRoleHOW.rakudoc:29`).
+
+## Repro
+
+```raku
+(role Zape[::T] {}).HOW.say;
+(role Zape2 {}).HOW.say;
+```
+
+- `raku`: both succeed, printing `Perl6::Metamodel::ParametricRoleHOW.new`.
+- `mutsu` (`target/debug/mutsu`): both are a **hard parse error**:
+  ```
+  ===SORRY!=== Error while compiling ...
+  Confused. expected statement: expected use statement or import statement or no statement or need statement or unit statement or ...
+  ```
+
+Verified directly, and narrowed to a plain (non-parameterized) `role` declaration too:
+
+```
+$ target/debug/mutsu -e '(role Zape2 {}).HOW.say;'
+===SORRY!=== ... Confused. expected statement ...
+$ target/debug/mutsu -e '(class Foo {}).HOW.say;'
+Perl6::Metamodel::ClassHOW.new
+```
+
+So `(class NAME {...})` already parses fine as a parenthesized expression term, but the
+equivalent `(role NAME {...})` does not — this is `role`-declaration-specific, not a
+general "package declaration in expression position" gap.
+
+## Root cause hypothesis
+
+The parser's handling of `role` declarations (in whatever module recognizes
+`class`/`role`/`grammar`/`enum` as expression-position terms — likely near wherever
+`class {...}` as a term is special-cased) doesn't extend to `role`. Since `class {...}`
+already works as a term, the fix is probably adding `role` (and checking `grammar`)
+alongside it in the same dispatch point.
+
+## Affected files (starting point)
+
+- `src/parser/` — wherever an anonymous `class {...}` expression-term is recognized;
+  grep for how that dispatches and check why `role` isn't included.

--- a/todo/tickets/backtrace-frame-indexing-returns-nil.md
+++ b/todo/tickets/backtrace-frame-indexing-returns-nil.md
@@ -1,0 +1,43 @@
+# `$!.backtrace[N]` positional indexing returns `Nil`, and mutsu's backtrace has fewer frames
+
+Found by the doc-diff harness re-run (`docs/doc-diff-backlog.md`, `Type/Backtrace.rakudoc:15`).
+
+## Repro
+
+```raku
+sub zipi { { { die "Something bad happened" }() }() };
+try {
+    zipi;
+}
+if ($!) {
+    say $!.backtrace.elems;
+    say $!.backtrace[0];
+    say $!.backtrace[*-1];
+}
+```
+
+- `raku`: prints `7`, then two `Backtrace::Frame.new(...)` gists (one per index).
+- `mutsu` (`target/debug/mutsu`): prints `4`, then `Nil` twice — positional indexing into
+  the `Backtrace` object always returns `Nil`, regardless of index.
+
+## Root cause hypothesis
+
+Two separate but related gaps:
+
+1. `Backtrace` positional indexing (`$bt[N]`, including the `*-1` whatever-index form)
+   is not implemented/dispatched — it falls through to a default that returns `Nil`
+   instead of returning the `Backtrace::Frame` at that position.
+2. mutsu's captured backtrace has fewer frames than raku's (4 vs 7) — raku includes
+   internal setting frames (e.g. `Exception.throw`) that mutsu's frame capture skips.
+   This is a secondary, lower-priority difference (mutsu's frame model is inherently
+   different from Rakudo's), but is worth noting since it changes what index `N` even
+   refers to.
+
+The `.raku` call on the indexed frame in the doc's original example
+(`$!.backtrace[*-1].raku`) never even gets reached because the indexing itself already
+returns `Nil`.
+
+## Affected files (starting point)
+
+- Wherever `Backtrace` is implemented as a builtin type (grep for `"Backtrace"` in
+  `src/runtime/` and `src/builtins/`) — the positional/subscript dispatch for this type.

--- a/todo/tickets/backtrace-introspection-methods-missing.md
+++ b/todo/tickets/backtrace-introspection-methods-missing.md
@@ -1,0 +1,42 @@
+# `Backtrace` is missing several introspection methods (`next-interesting-index`, `outer-caller-idx`, `nice`)
+
+Found by the doc-diff harness re-run (`docs/doc-diff-backlog.md`, `Type/Backtrace.rakudoc:72,84,96`).
+
+## Repro
+
+```raku
+sub zipi { { { die "Something bad happened" }() }() };
+try zipi;
+say $!.backtrace.next-interesting-index;           # raku: 2
+say $!.backtrace.next-interesting-index( :named );  # raku: 4
+say $!.backtrace.outer-caller-idx( 4 );              # raku: [6]
+say $!.backtrace.nice( :oneline ) if $!;             # raku: "  in sub zipi at ... line 1"
+```
+
+- `raku`: all four calls succeed, returning the documented values.
+- `mutsu` (`target/debug/mutsu`): each dies with
+  `No such method '<name>' for invocant of type 'Backtrace'` — none of
+  `next-interesting-index`, `outer-caller-idx`, or `nice` are implemented on `Backtrace`.
+
+## Root cause
+
+`Backtrace` (wherever it is implemented as a builtin type, grep for `"Backtrace"` in
+`src/runtime/` and `src/builtins/`) does not define these three methods. Per
+`raku-doc/doc/Type/Backtrace.rakudoc`:
+
+- `.next-interesting-index([:$named])` — returns the index of the next "interesting"
+  frame (skipping setting/internal frames) after the given/first one.
+- `.outer-caller-idx($from-idx)` — returns the frame indices of the callers of a given
+  frame's containing routine.
+- `.nice(:$oneline)` — a human-readable rendering of the backtrace (the basis of the
+  default exception `.gist`).
+
+## Affected files (starting point)
+
+- Wherever `Backtrace`'s existing methods (`.full`, `.concise`, `.list`, etc.) are
+  implemented — add these three alongside them.
+
+Note: this is a separate finding from
+[backtrace-frame-indexing-returns-nil.md](backtrace-frame-indexing-returns-nil.md)
+(positional `[N]` indexing into `Backtrace` returning `Nil`), though both point at the
+same underlying gap — `Backtrace`'s introspection surface is thin compared to Rakudo's.

--- a/todo/tickets/bind-scalar-literal-var-name-not-int.md
+++ b/todo/tickets/bind-scalar-literal-var-name-not-int.md
@@ -1,0 +1,45 @@
+# `my $b := 1; $b.VAR.^name` should be `Int` (no container), mutsu gives `Scalar`
+
+Found by the doc-diff harness re-run (`docs/doc-diff-backlog.md`, `Type/Scalar.rakudoc:43`).
+
+## Repro
+
+```raku
+my $a = 1;
+say $a.VAR.^name; # Scalar (ordinary assignment: creates a container)
+my $b := 1;
+say $b.VAR.^name; # Int   (bind: no container created)
+```
+
+- `raku`: `Scalar` then `Int`.
+- `mutsu` (`target/debug/mutsu`): `Scalar` then `Scalar`.
+
+Verified directly with `raku -e` / `target/debug/mutsu -e`:
+
+```
+$ raku -e 'my $a = 1; say $a.VAR.^name; my $b := 1; say $b.VAR.^name;'
+Scalar
+Int
+$ target/debug/mutsu -e 'my $a = 1; say $a.VAR.^name; my $b := 1; say $b.VAR.^name;'
+Scalar
+Scalar
+```
+
+## Root cause hypothesis
+
+Per Raku semantics, ordinary assignment (`=`) to a `$`-sigiled `my` variable creates a
+fresh `Scalar` container that holds the value; `:=` (bind) instead makes the variable
+name directly refer to whatever is on the right-hand side, with no intervening
+container — so `.VAR` on a bound variable returns the bound value itself (here, the bare
+`Int` `1`), not a `Scalar` wrapper.
+
+mutsu's compiler/VM appears to treat every `$`-sigiled `my` declaration uniformly as
+getting a `Scalar` container, regardless of whether the initializer used `=` or `:=`.
+The `:=` bind path needs to skip container creation and store the RHS value directly,
+the same way it already does correctly for sigilless (`\x := ...`) bindings.
+
+## Affected files (starting point)
+
+- `src/compiler/` — wherever `:=` bind-declaration (`AssignExpr`/bind variant with a
+  `$`-sigiled LHS) is compiled; compare against the sigilless `\x := ...` bind path,
+  which already skips the container correctly.

--- a/todo/tickets/compunit-repository-gist-missing-inst-prefix.md
+++ b/todo/tickets/compunit-repository-gist-missing-inst-prefix.md
@@ -1,0 +1,47 @@
+# `CompUnit::Repository::FileSystem`/`Installation` stringify as `.new`, not `inst#<path>`
+
+Found by the doc-diff harness re-run (`docs/doc-diff-backlog.md`, `Language/perl-var.rakudoc:154`).
+
+## Repro
+
+```raku
+.say for $*REPO.repo-chain;
+```
+
+- `raku`: prints one line per repo in the chain, each formatted with its short kind
+  prefix and path, e.g. `inst#/home/user/.raku`, `ap#`, `nqp#`, `perl5#`.
+- `mutsu` (`target/debug/mutsu`): prints the generic default gist, e.g.
+  `CompUnit::Repository::FileSystem.new`, `CompUnit::Repository::Installation.new`.
+
+Verified directly:
+
+```
+$ raku -e '.say for $*REPO.repo-chain;'
+inst#/home/tokuhirom/.raku
+inst#/home/.../site
+inst#/home/.../vendor
+inst#/home/.../core
+ap#
+nqp#
+perl5#
+$ target/debug/mutsu -e '.say for $*REPO.repo-chain;'
+CompUnit::Repository::FileSystem.new
+CompUnit::Repository::Installation.new
+```
+
+(The number/kind of repos in the chain will legitimately differ across environments —
+that part is not a bug. The bug is the stringification format itself.)
+
+## Root cause hypothesis
+
+`CompUnit::Repository::FileSystem` and `CompUnit::Repository::Installation` (or
+whichever native type backs `$*REPO.repo-chain`'s elements) don't define a custom
+`.Str`/`.gist` that renders as `<short-name>#<path>` (per
+`raku-doc/doc/Type/CompUnit/Repository/FileSystem.rakudoc` and
+`raku-doc/doc/Type/CompUnit/Repository/Installation.rakudoc`'s documented `.Str`
+behavior), so `.say`/default gist falls back to the generic `TypeName.new` rendering.
+
+## Affected files (starting point)
+
+- Wherever `$*REPO` / `CompUnit::Repository::*` are implemented as builtin types (grep
+  for `"CompUnit::Repository"` in `src/runtime/`) — add a `.Str`/`.gist` method.

--- a/todo/tickets/control-phaser-cx-take-not-intercepted.md
+++ b/todo/tickets/control-phaser-cx-take-not-intercepted.md
@@ -1,0 +1,61 @@
+# A `CONTROL { when CX::Take {...} }` handler is never invoked for `take` inside `gather`
+
+Found by the doc-diff harness re-run (`docs/doc-diff-backlog.md`, `Language/phasers.rakudoc:401`).
+
+## Repro
+
+```raku
+say elems gather {
+    CONTROL {
+        when CX::Warn { say "WARNING!!! $_"; .resume }
+        when CX::Take { say "Don't take my stuff"; .resume }
+        when CX::Done { say "Done"; .resume }
+    }
+    warn 'people take stuff here';
+    take 'keys';
+    done;
+}
+```
+
+- `raku`:
+  ```
+  WARNING!!! people take stuff here
+  Don't take my stuff
+  Done
+  0
+  ```
+- `mutsu` (`target/debug/mutsu`):
+  ```
+  WARNING!!! people take stuff here
+  Done
+  1
+  ```
+
+Verified directly with `raku -e` / `target/debug/mutsu -e` on this exact snippet. The
+`CX::Warn` and `CX::Done` branches both fire correctly (mutsu prints "WARNING!!!" and
+"Done"), but the `CX::Take` branch never fires — `take 'keys'` proceeds as a normal,
+un-intercepted take (contributing 1 element to the gather), instead of being caught by
+the `CONTROL` block, printing "Don't take my stuff", and being resumed as a no-op
+(`.resume` on a caught `CX::Take` discards the taken value per the doc's semantics,
+hence raku's final count of `0`).
+
+`CX::Take` itself exists as a type in mutsu (`say CX::Take.^name` → `CX::Take`), so this
+isn't a missing-type gap — it's that `take`'s control-flow signal isn't routed through
+the same `CONTROL`-catchable control-exception machinery that `warn` and `done` already
+use.
+
+## Root cause hypothesis
+
+Wherever mutsu implements `warn`/`done` as catchable control exceptions dispatched to an
+enclosing `CONTROL` block (grep for `"CX::Warn"` / `"CX::Done"` handling in
+`src/runtime/` or `src/vm/`), `take` doesn't raise the equivalent `CX::Take` control
+exception through that same path — it's likely implemented as a direct
+gather/take-buffer push with no control-exception signal at all, so there is nothing for
+`CONTROL`'s `when CX::Take` to catch.
+
+## Affected files (starting point)
+
+- Wherever `warn`/`done` control-exception dispatch to `CONTROL` lives (grep for
+  `"CX::Warn"`, `"CONTROL"` in `src/runtime/`, `src/vm/`) — compare against wherever
+  `take` is implemented (grep for `"take"` handling in gather-related VM ops) to see why
+  it doesn't raise a matching `CX::Take` control exception.

--- a/todo/tickets/invalid-qualifier-error-message-missing-method-name.md
+++ b/todo/tickets/invalid-qualifier-error-message-missing-method-name.md
@@ -1,0 +1,37 @@
+# `X::Method::InvalidQualifier` message drops the method name (says "a method" instead of "method NAME")
+
+Found by the doc-diff harness re-run (`docs/doc-diff-backlog.md`,
+`Type/X/Method/InvalidQualifier.rakudoc:14`).
+
+## Repro
+
+```raku
+1.Str::split(/a/);
+CATCH { default { put .^name, ': ', .Str } };
+```
+
+- `raku`: `X::Method::InvalidQualifier: Cannot dispatch to method split on Str because it is not inherited or done by Int`
+- `mutsu` (`target/debug/mutsu`): `X::Method::InvalidQualifier: Cannot dispatch to a method on Str because it is not inherited or done by Int`
+
+Verified directly with `raku -e` / `target/debug/mutsu -e` on this exact snippet.
+
+The exception type matches (`X::Method::InvalidQualifier`, correctly thrown — this is
+the same qualified-method-dispatch machinery that `operators.rakudoc` [17] / #5124
+fixed for the *successful* dispatch case). The bug here is narrower: the thrown
+exception's message substitutes a generic "a method" for the actual method name
+("split") that was being dispatched. This is not mere wording drift (which would be
+excluded per this ledger's "message text differs, meaning matches" rule) — it's a
+missing piece of information that Rakudo's message includes and mutsu's doesn't,
+which could matter for scripts that pattern-match on the exception text.
+
+## Root cause hypothesis
+
+Wherever `X::Method::InvalidQualifier` is constructed/thrown (grep for
+`"InvalidQualifier"` in `src/runtime/`), the message-building code isn't passed (or
+isn't interpolating) the method name that was being looked up — likely a hardcoded "a
+method" string where the real method name should be substituted.
+
+## Affected files (starting point)
+
+- `src/runtime/` — grep for `"InvalidQualifier"` to find the exception construction
+  site and thread the method name through to the message.

--- a/todo/tickets/io-path-parts-empty-subscript-not-positional.md
+++ b/todo/tickets/io-path-parts-empty-subscript-not-positional.md
@@ -1,0 +1,53 @@
+# `$parts[]` (empty postcircumfix index) on `IO::Path::Parts` doesn't iterate its positional elements
+
+Found by the doc-diff harness re-run (`docs/doc-diff-backlog.md`, `Type/IO/Path/Parts.rakudoc:71`).
+
+## Repro
+
+```raku
+my $parts = IO::Path::Parts.new('C:', '/some/dir', 'foo.txt');
+.say for $parts[];
+```
+
+- `raku`:
+  ```
+  volume => C:
+  dirname => /some/dir
+  basename => foo.txt
+  ```
+- `mutsu` (`target/debug/mutsu`): a single line — the whole object's default gist:
+  ```
+  IO::Path::Parts.new("C:","/some/dir","foo.txt")
+  ```
+
+Verified directly. Also verified this is `IO::Path::Parts`-specific, not a general
+"empty subscript" gap — a plain `Array` already works correctly:
+
+```
+$ target/debug/mutsu -e 'my @a = 1,2,3; .say for @a[];'
+1
+2
+3
+$ target/debug/mutsu -e 'my $parts = IO::Path::Parts.new("C:", "/some/dir", "foo.txt"); .say for $parts[];'
+IO::Path::Parts.new("C:","/some/dir","foo.txt")
+```
+
+Earlier lines in the same doc example (`$parts<volume>`, `$parts[0]`,
+`$parts[0].^name`) all already match raku — only the bare `$parts[]` ("all positional
+elements") form fails.
+
+## Root cause hypothesis
+
+`IO::Path::Parts` is documented (`raku-doc/doc/Type/IO/Path/Parts.rakudoc`) as both
+`Associative` (keyed access via `<volume>` etc.) and `Positional` (indexed access via
+`[0]`, and here, "all elements" via `[]`) — it presumably wraps 3 key/value pairs. The
+single-index form `$parts[0]` works, so positional dispatch exists at some level, but
+the bare/empty-index form (which should mean "give me all positional elements as a
+list", the same as it does for `Array`) isn't recognized for this type and falls back
+to treating `$parts[]` as if it were just `$parts` (hence the whole-object gist).
+
+## Affected files (starting point)
+
+- Wherever `IO::Path::Parts` is implemented (grep for `"IO::Path::Parts"` in
+  `src/runtime/`, `src/builtins/`) — check its positional/subscript dispatch,
+  specifically the no-index-given case, versus how plain `Array`'s `@a[]` is handled.

--- a/todo/tickets/lock-async-recursion-methods-missing.md
+++ b/todo/tickets/lock-async-recursion-methods-missing.md
@@ -1,0 +1,45 @@
+# `Lock::Async` is missing `protect-or-queue-on-recursion` and `with-lock-hidden-from-recursion-check`
+
+Found by the doc-diff harness re-run (`docs/doc-diff-backlog.md`, `Type/Lock/Async.rakudoc:162,202`).
+
+## Repro
+
+```raku
+my Lock::Async $lock .= new;
+my Int         $count = 0;
+
+$lock.protect-or-queue-on-recursion({
+    $count++
+});
+say $count;
+```
+
+- `raku`: runs (result depends on the rest of the doc's example; the point is the
+  method exists and dispatches).
+- `mutsu` (`target/debug/mutsu`): dies immediately with
+  `No such method 'protect-or-queue-on-recursion' for invocant of type 'Lock::Async'`.
+
+The doc's second example (`Type/Lock/Async.rakudoc:202`) hits the same missing method,
+plus also calls `.with-lock-hidden-from-recursion-check`, which is equally
+unimplemented.
+
+## Root cause
+
+Per `raku-doc/doc/Type/Lock/Async.rakudoc`, `Lock::Async` documents two methods beyond
+the basic `.lock`/`.protect`:
+
+- `.protect-or-queue-on-recursion(&code)` — like `.protect`, but detects when the
+  calling thread is already inside a `.protect-or-queue-on-recursion` call on the same
+  lock (recursion) and, in that case, queues `&code` to run after the outer call
+  finishes (returning a `Promise`) rather than deadlocking.
+- `.with-lock-hidden-from-recursion-check(&code)` — runs `&code` under the lock without
+  it counting toward the above recursion detection.
+
+Neither is implemented on mutsu's `Lock::Async`.
+
+## Affected files (starting point)
+
+- Wherever `Lock::Async`'s existing methods (`.lock`, `.protect`) are implemented (grep
+  for `"Lock::Async"` in `src/runtime/`) — add these two alongside them. This is a
+  genuinely nontrivial concurrency feature (per-thread recursion tracking + queued
+  continuation), not a one-line stub.

--- a/todo/tickets/metamodel-parametricrolehow-new-type-wrong-how.md
+++ b/todo/tickets/metamodel-parametricrolehow-new-type-wrong-how.md
@@ -1,0 +1,37 @@
+# `Metamodel::ParametricRoleHOW.new_type(...)` returns a type whose `.HOW` is `ClassHOW`, not `ParametricRoleHOW`
+
+Found by the doc-diff harness re-run (`docs/doc-diff-backlog.md`,
+`Type/Metamodel/ParametricRoleHOW.rakudoc:35`).
+
+## Repro
+
+```raku
+my \zipi := Metamodel::ParametricRoleHOW.new_type( name => "zape", group => "Zape");
+say zipi.HOW;
+```
+
+- `raku`: `Perl6::Metamodel::ParametricRoleHOW.new`
+- `mutsu` (`target/debug/mutsu`): `Perl6::Metamodel::ClassHOW.new`
+
+Verified directly with `raku -e` / `target/debug/mutsu -e` on this exact snippet (using
+`my \zipi :=`, so this is independent of the separate `constant NAME := Metamodel::
+ClassHOW.new_type(...)` "immutable" bug tracked in
+`todo/deep/direct-metamodel-classhow-new-type-immutable-error.md` — that ticket is about
+a spurious readonly error on `constant` binding; this one is about which `.HOW`
+metaclass the returned type object reports, and reproduces cleanly with `:=`, no
+`constant` involved).
+
+## Root cause hypothesis
+
+mutsu's `Metamodel::ParametricRoleHOW.new_type` implementation (or its generic
+`Metamodel::*.new_type` dispatch) doesn't thread through which specific `*HOW` class
+was invoked — it appears to always construct a type object tagged with `ClassHOW`
+regardless of which `Metamodel::*HOW` the `.new_type` call was made on. Grep for
+`"new_type"` and `"ParametricRoleHOW"` in `src/runtime/` to find the dispatch and see
+whether it's hardcoded to `ClassHOW` or genuinely shared/generic code that lost the
+caller's metaclass identity.
+
+## Affected files (starting point)
+
+- Wherever `Metamodel::*.new_type` is implemented (grep for `"new_type"` in
+  `src/runtime/`).

--- a/todo/tickets/role-type-pretense-cool-incomplete.md
+++ b/todo/tickets/role-type-pretense-cool-incomplete.md
@@ -1,0 +1,53 @@
+# Role type-pretense doesn't include `Cool`, and `.HOW.pretending_to_be` is unimplemented
+
+Found by the doc-diff harness re-run (`docs/doc-diff-backlog.md`,
+`Type/Metamodel/TypePretense.rakudoc:15,47`).
+
+## Repro 1 — `Role ~~ Cool` should be `True`
+
+```raku
+class Class { }
+role  Role  { }
+
+say Role ~~ Mu;   # True
+say Role ~~ Any;  # True
+say Role ~~ Cool; # True
+```
+
+- `raku`: `True`, `True`, `True`.
+- `mutsu` (`target/debug/mutsu`): `True`, `True`, **`False`**.
+
+Verified directly with `raku -e` / `target/debug/mutsu -e` on this exact snippet. (The
+rest of the doc's original example — `Role.^pun.^parents(:all)` — is separately bucketed
+`raku-drift`: the doc's stated `# OUTPUT: «()»` no longer matches current raku's `(Any
+Mu)`, and mutsu's `(Any Mu)` there already matches current raku, so that part is not a
+bug.)
+
+## Repro 2 — `.HOW.pretending_to_be` missing
+
+```raku
+role Role { }
+say Role.HOW.pretending_to_be.map(*.^name); # raku: (Cool Any Mu)
+```
+
+- `raku`: `(Cool Any Mu)`
+- `mutsu`: dies with
+  `No such method 'pretending_to_be' for invocant of type 'Perl6::Metamodel::ParametricRoleGroupHOW'`
+
+## Root cause hypothesis
+
+Per `raku-doc/doc/Type/Metamodel/TypePretense.rakudoc`, an un-composed `role` "pretends"
+to be part of the `Cool`/`Any`/`Mu` chain (via `Metamodel::TypePretense`, mixed into
+`ParametricRoleGroupHOW`) so that smart-matching/type-checking against those ancestor
+types succeeds even before the role is composed into a class. mutsu's role type-object
+smart-match (`~~`) handling implements the `Mu`/`Any` pretense levels but not `Cool`,
+and doesn't implement the `.pretending_to_be` introspection method that lists the
+pretended-to types at all.
+
+## Affected files (starting point)
+
+- Wherever role type-objects' `~~ Mu`/`~~ Any` pretense is implemented (grep for
+  `"TypePretense"` or the `Mu`/`Any` role-smartmatch special-case in `src/runtime/`) —
+  extend to `Cool`, and add `.pretending_to_be` returning the pretended type chain
+  (`(Cool Any Mu)`) on `Perl6::Metamodel::ParametricRoleGroupHOW` (and presumably
+  `ParametricRoleHOW`).


### PR DESCRIPTION
## Summary
- doc-diff batch4-B round: re-ran the harness on 10 raku-doc files, re-verified each finding directly against `raku`, filed 10 new tickets under `todo/tickets/`, and added the corresponding subsection to `docs/doc-diff-backlog.md`.
- Excluded (not ticketed, noted in the ledger): `Type/Scalar.rakudoc` [2] (existing element-itemization/ADR-0040 deep cluster), `Language/perl-var.rakudoc` [1] (environment-dependent `$*KERNEL`/`$*DISTRO`/`$*VM` fields), `Type/IO/Notification/Change.rakudoc` (all candidates raku-unclean — live filesystem-watching, not a clean repro in this environment).

## Test plan
- [x] Re-verified every ticketed finding directly with `raku -e` / `target/debug/mutsu -e` (not just the harness report).
- [x] `cargo build` succeeded; pre-commit hooks (`clippy -D warnings`, `cargo fmt`) passed on commit.
- [x] Docs-only change — CI's docs-only fast path should skip the heavy test/roast jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)