### PR TITLE
docs: file 11 doc-diff batch-4 tickets (Code/DateTime/perl-func/Metamodel/Formatter/X::Cannot::Empty/Exception/nativetypes/Compiler/ArgFiles)

### DIFF
--- a/docs/doc-diff-backlog.md
+++ b/docs/doc-diff-backlog.md
@@ -501,6 +501,36 @@ Found in the 2026-08-22 batch-4 re-run of `Backtrace`/`Scalar`/`perl-var`/
   examples use live filesystem-watching (`IO::Notification.watch-path`), which is inherently
   timing/environment-dependent and not a clean minimal repro; not ticketed.
 
+Found in the 2026-08-22 batch-4 re-run of `Code`/`DateTime`/`perl-func`/
+`Metamodel::ParametricRoleGroupHOW`/`Formatter`/`X::Cannot::Empty`/`Exception`/
+`nativetypes`/`Compiler`/`IO::ArgFiles`:
+
+| file:line | one-line summary | ticket |
+|---|---|---|
+| `Type/Code.rakudoc:166,175,195` | `.line`/`.file` reflection methods missing on `Sub`/`Method` | [code-line-file-reflection-missing-on-sub-method.md](../todo/tickets/code-line-file-reflection-missing-on-sub-method.md) |
+| `Type/Code.rakudoc:81` | `$:name` named-placeholder variable fails to interpolate inside a double-quoted string (bare form already works) | [named-placeholder-var-interpolation-in-string-fails.md](../todo/tickets/named-placeholder-var-interpolation-in-string-fails.md) |
+| `Type/DateTime.rakudoc:137` | a `DateTime` day-range-check throws the generic `X::OutOfRange` instead of the already-registered, more specific `X::Temporal::OutOfRange` | [datetime-day-out-of-range-uses-generic-outofrange.md](../todo/tickets/datetime-day-out-of-range-uses-generic-outofrange.md) |
+| `Type/DateTime.rakudoc:281,302` | `.julian-date`/`.modified-julian-date` return `Num` (float noise) instead of an exact `Rat` | [datetime-julian-date-returns-num-not-rat.md](../todo/tickets/datetime-julian-date-returns-num-not-rat.md) |
+| `Language/perl-func.rakudoc:2281` | `but`-mixing a role onto an `Array` silently drops the mixin entirely (`.^name` shows plain `Array`, no role methods attached) | [array-but-role-mixin-dropped-join-flatten.md](../todo/tickets/array-but-role-mixin-dropped-join-flatten.md) |
+| `Language/perl-func.rakudoc:2310` | a role-mixed `.sink` method is never invoked when the value is used in sink context | [role-mixed-sink-method-not-invoked-in-sink-context.md](../todo/tickets/role-mixed-sink-method-not-invoked-in-sink-context.md) |
+| `Type/Metamodel/ParametricRoleGroupHOW.rakudoc:21` | an anonymous *parametric* `role Name[...] {...}` literal is misparsed as an expression term — refines [anon-role-expression-term-parse-fail.md](../todo/tickets/anon-role-expression-term-parse-fail.md) above: re-verified that the parameterless `(role NAME {...})` form it also lists already parses fine on its own, it's specifically the `[...]` parametric signature that breaks | [parametric-role-literal-as-expression-term-misparsed.md](../todo/tickets/parametric-role-literal-as-expression-term-misparsed.md) |
+| `Type/Metamodel/ParametricRoleGroupHOW.rakudoc:27` | `Metamodel::ParametricRoleHOW.new_type(...)` reports `.HOW` as `ClassHOW` instead of the specific metaclass it was called on — same finding as [metamodel-parametricrolehow-new-type-wrong-how.md](../todo/tickets/metamodel-parametricrolehow-new-type-wrong-how.md) above | (duplicate of the row above; cross-referenced from [direct-metamodel-classhow-new-type-immutable-error.md](../todo/deep/direct-metamodel-classhow-new-type-immutable-error.md), not re-filed) |
+| `Type/Formatter.rakudoc:16,32` | `Formatter.new(FORMAT_STRING)` is unimplemented | [formatter-new-unimplemented.md](../todo/tickets/formatter-new-unimplemented.md) |
+| `Type/X/Cannot/Empty.rakudoc:15` | `X::Cannot::Empty.new(:action, :what).message` returns an empty string instead of formatting "Cannot ACTION from an empty WHAT" | [x-cannot-empty-message-not-formatted.md](../todo/tickets/x-cannot-empty-message-not-formatted.md) |
+| `Type/Exception.rakudoc:78` | `.backtrace.full` joins its frame lines without newlines (all frames run together on one line) | [backtrace-full-frames-not-newline-separated.md](../todo/tickets/backtrace-full-frames-not-newline-separated.md) |
+| `Language/nativetypes.rakudoc:172` | `Pointer[T].raku` uses a bare type-parameter name and a named-arg constructor call instead of raku's fully-qualified positional form | [nativecall-pointer-raku-format-mismatch.md](../todo/tickets/nativecall-pointer-raku-format-mismatch.md) |
+| `Type/Compiler.rakudoc:58` | `$*RAKU.compiler.verbose-config` is unimplemented (low priority — the real output is exhaustively MoarVM-build-specific) | [compiler-verbose-config-unimplemented.md](../todo/tickets/compiler-verbose-config-unimplemented.md) |
+| `Type/IO/ArgFiles.rakudoc:34` | `$*ARGFILES.eof`/`.get` loops forever instead of terminating once stdin is exhausted (no file args given) | [argfiles-eof-infinite-loop-on-empty-stdin.md](../todo/tickets/argfiles-eof-infinite-loop-on-empty-stdin.md) |
+
+**Excluded from this batch-4 sub-run:**
+- `Type/Code.rakudoc` [3], [4] (lines 140, 153) — `raku-drift` (object hex-address
+  text in `#`(Block|...)`/`#`(Sub|...)` gist output, inherently non-reproducible).
+- `Type/Compiler.rakudoc` [1] (line 13, `$*RAKU.compiler`) — `raku-drift` and
+  environment-dependent (compiler name/version string), same shape as the already-
+  excluded `$*RAKU.compiler.version`/`$*VM.config` findings above; mutsu correctly
+  reports its own identity (`mutsu (0.1.0)`) rather than impersonating rakudo, which
+  is intentional, not a bug.
+
 ### Deferred / deep (tracked elsewhere — do not re-open as a shallow slice)
 These root causes account for a large share of the survey's `mism`/`crash` and are
 intentionally deferred; see PLAN.md §8.5 and the ADRs:

--- a/todo/deep/direct-metamodel-classhow-new-type-immutable-error.md
+++ b/todo/deep/direct-metamodel-classhow-new-type-immutable-error.md
@@ -69,3 +69,21 @@ type creation directly through `Metamodel::*` calls (as opposed to only via `cla
   check whether it eagerly registers the class/binds the name as a side effect, and
   whether that should instead be deferred until an explicit `.^compose` (matching
   Rakudo's model of "mutable until composed").
+
+## Related finding: `new_type` ignores which `Metamodel::*HOW` was called (2026-08-22, doc-diff batch-4)
+
+`src/runtime/methods_instance_ops.rs` (~line 2138) dispatches `.new_type` generically
+for *any* `Metamodel::*` package name
+(`matches!(target.view(), ValueView::Package(n) if n.resolve().starts_with("Metamodel::"))`)
+— it always registers a plain empty class and returns a bare `Package` value,
+regardless of which specific metaclass (`ClassHOW`, `ParametricRoleHOW`,
+`ParametricRoleGroupHOW`, ...) was actually invoked. This means the resulting type
+object's `.HOW` always introspects as `ClassHOW`-shaped, even when the caller asked
+for a different metaclass. Confirmed independently via
+`Type/Metamodel/ParametricRoleGroupHOW.rakudoc:27` (`Metamodel::ParametricRoleHOW.new_type(...)`
+also reports `.HOW` as `ClassHOW`) — same root cause and same generic `new_type`
+handler as the already-filed
+[metamodel-parametricrolehow-new-type-wrong-how.md](../tickets/metamodel-parametricrolehow-new-type-wrong-how.md),
+which has the minimal repro; fixing `new_type` to actually respect (and record) which
+`Metamodel::*HOW` it was called on is likely a prerequisite for all three findings
+tracked across these two files, not just a message-text difference.

--- a/todo/tickets/argfiles-eof-infinite-loop-on-empty-stdin.md
+++ b/todo/tickets/argfiles-eof-infinite-loop-on-empty-stdin.md
@@ -1,0 +1,37 @@
+# `$*ARGFILES.eof`/`.get` loops forever instead of terminating when input is exhausted
+
+Found by the doc-diff harness batch-4 re-run (`docs/doc-diff-backlog.md`,
+`Type/IO/ArgFiles.rakudoc:34`).
+
+## Root cause hypothesis
+
+`$*ARGFILES` (the magic "all `@*ARGS` files, or stdin if none given" handle) should
+report `.eof` as `True` once its underlying source is exhausted, so a
+`while ! $*ARGFILES.eof { say $*ARGFILES.get }` loop terminates. mutsu's `.eof` never
+flips to `True` after the source is exhausted (or `.get` doesn't advance/signal
+exhaustion the way `.eof` checks for), so the loop spins forever, printing `Nil` on
+every iteration (`.get` on an exhausted stream correctly returns `Nil`, but the loop
+condition never sees that as "done").
+
+## Minimal repro
+
+```raku
+while ! $*ARGFILES.eof {
+    say $*ARGFILES.get;
+}
+```
+
+Run with no file arguments and closed/empty stdin (`< /dev/null`):
+
+- `raku`: terminates immediately (prints at most one `Nil` depending on how the
+  zero-file/`<>`-over-stdin case is modeled, then exits 0).
+- `mutsu` (`target/debug/mutsu`): never terminates — an infinite loop printing `Nil`
+  forever (times out under `timeout N`, exit 124).
+
+## Affected files (starting point)
+
+- Wherever `$*ARGFILES`/`IO::ArgFiles` is implemented (grep for `ARGFILES` in
+  `src/runtime/`) — check the `.eof` implementation's interaction with the
+  zero-files/stdin-fallback case specifically; it likely works correctly for the
+  "at least one real file argument" case (since that path isn't flagged here) but
+  mishandles the "no file args, read from stdin" fallback.

--- a/todo/tickets/array-but-role-mixin-dropped-join-flatten.md
+++ b/todo/tickets/array-but-role-mixin-dropped-join-flatten.md
@@ -1,0 +1,48 @@
+# `but`-mixing a role onto an `Array` silently drops the mixin entirely
+
+Found by the doc-diff harness batch-4 re-run (`docs/doc-diff-backlog.md`,
+`Language/perl-func.rakudoc:2281`).
+
+## Repro
+
+```raku
+my @origlist = (3, 2, 1);
+my $r = @origlist but role { method Str { self.join("<") } };
+say $r.^name;
+print join(">", $r);
+```
+
+- `raku`: `Array+{<anon|1>}`, then `3<2<1` (`join(">", $r)` treats the mixed value's
+  single-argument list as a plain three-item list, joining with `>`: `3>2>1` — the
+  `Str` override on the mixin isn't what produces the `>`-separated output, plain
+  positional-list `join` semantics already do; the doc's own example is really about
+  `.Str` mattering when the value is stringified directly, e.g. by `print`).
+- `mutsu` (`target/debug/mutsu`): `Array` (the mixin is invisible on `.^name` — the
+  role composition did not take effect at all), then `3 2 1` (space-joined, i.e. `join`
+  received the mixed value as a single flattened-as-list argument using the *default*
+  list stringification, confirming the mixin's `Str` override was never attached to the
+  value either).
+
+## Root cause hypothesis
+
+mutsu's `but`-mixin path for an `Array`/`List` value appears to no-op silently instead
+of producing a role-composed value — `.^name` shows the plain `Array` type with no
+`+{...}` suffix, and neither the new `Str` method nor (going by `join`'s output) any
+role metadata survived. This is almost certainly the same family of bugs already
+tracked by
+[list-but-role-loses-positional-binding.md](list-but-role-loses-positional-binding.md),
+[hash-default-role-mixin-dropped.md](hash-default-role-mixin-dropped.md), and
+[role-mixed-value-gist-skipped-in-array.md](role-mixed-value-gist-skipped-in-array.md)
+— all involve a `but`/`does`-mixed value's role metadata not surviving a generic
+storage/dispatch path. This finding's minimal repro is the *plainest* case so far (no
+binding, no Hash default, no array nesting — a bare `Array but role {...}` loses the
+mixin outright), so it may be the best starting point for isolating the actual fix
+site.
+
+## Affected files (starting point)
+
+- `src/runtime/mixin.rs` (or wherever `but`/`does` role-mixing on an `Array`/`List`
+  value is implemented) — check what `@origlist but role {...}` actually produces
+  (`--dump-ast` plus a direct `.^name` check) to see whether the mixin call itself is a
+  no-op for Array-typed operands, or whether the composed value is created correctly
+  but lost/unwrapped somewhere between the `but` expression and the variable binding.

--- a/todo/tickets/backtrace-full-frames-not-newline-separated.md
+++ b/todo/tickets/backtrace-full-frames-not-newline-separated.md
@@ -1,0 +1,44 @@
+# `.backtrace.full` joins its frame lines without newlines
+
+Found by the doc-diff harness batch-4 re-run (`docs/doc-diff-backlog.md`,
+`Type/Exception.rakudoc:78`).
+
+## Root cause hypothesis
+
+`Backtrace.full` should render one `  in ... at FILE line N` line per frame, joined by
+newlines. mutsu's implementation appears to build the frame strings correctly (each
+individual frame's text matches raku's, modulo the missing `SETTING::`-internal
+`die`/`throw` frames mutsu doesn't model) but concatenates them without inserting a
+`\n` between frames, so the whole backtrace prints as one long line.
+
+## Minimal repro
+
+```raku
+sub f() { die 'Bad' };
+sub g() { f; CATCH { default { .rethrow } } };
+g;
+CATCH { default { say .backtrace.full } };
+```
+
+- `raku` (5 lines, one frame per line):
+  ```
+    in method throw at SETTING::src/core.c/Exception.rakumod line 65
+    in sub die at SETTING::src/core.c/control.rakumod line 253
+    in sub f at FILE line 1
+    in sub g at FILE line 2
+    in block <unit> at FILE line 3
+  ```
+- `mutsu` (`target/debug/mutsu`): a single line —
+  ```
+    in sub f at FILE line 2  in sub g at FILE line 3  in block <unit> at FILE line 4
+  ```
+  (also missing the two `SETTING::`-internal frames for `die`/`.throw`, which mutsu
+  doesn't model as call frames at all — that part is likely out of scope / a separate,
+  lower-priority gap, since mutsu's `die`/exception-throw path isn't itself
+  implemented as Raku-level setting subs the way Rakudo's is).
+
+## Affected files (starting point)
+
+- Wherever `Backtrace.full`/`.gist` (or the underlying frame-list-to-string join) is
+  implemented — grep for where backtrace frame strings (`"  in ... at ... line ..."`)
+  are assembled and joined; the join should use `"\n"` between frames, matching raku.

--- a/todo/tickets/code-line-file-reflection-missing-on-sub-method.md
+++ b/todo/tickets/code-line-file-reflection-missing-on-sub-method.md
@@ -1,0 +1,48 @@
+# `.line`/`.file` reflection methods missing on `Sub`/`Method`
+
+Found by the doc-diff harness batch-4 re-run (`docs/doc-diff-backlog.md`,
+`Type/Code.rakudoc:166,175,195`).
+
+## Root cause
+
+`Code` (and its subtypes `Sub`, `Method`) support `.file` and `.line` reflection
+methods that report the source location where the routine was declared. mutsu never
+registered these methods for `Sub`/`Method` invocants at all, so any call throws
+`X::Method::NotFound`.
+
+## Minimal repro
+
+```raku
+class Food { has $.ingredients; method eat {} }
+say Food.^lookup('eat').line;
+say &infix:<+>.file;
+say &infix:<+>.line;
+```
+
+- `raku`: prints a line number for `.line` (the exact value differs by
+  Rakudo version — the doc's own stated `# OUTPUT` of `4`/`1`/`208` is stale/doc-drift
+  against current raku's `2`/`2`/`209`, but raku always succeeds and returns an `Int`),
+  and `.file` on a core-setting sub prints `SETTING::src/core.c/Numeric.rakumod`.
+- `mutsu` (`target/debug/mutsu`): both throw
+  `No such method 'line'/'file' for invocant of type 'Method'/'Sub'`.
+
+```
+$ target/debug/mutsu -e 'class Food { has $.ingredients; method eat {} }; say Food.^lookup("eat").line;'
+No such method 'line' for invocant of type 'Method'
+Did you mean 'clone'?
+  in block <unit> at -e line 1
+```
+
+Note: the *value* raku reports for user-defined subs is drift-prone (it depends on
+exactly where in the source the routine's body starts, which shifts between Rakudo
+versions), so a fix does not need to match the doc's literal numbers — it needs to
+return a real line number (and for `.file`, the declaring file path or a
+`SETTING::...` marker for core-setting routines) instead of erroring.
+
+## Affected files (starting point)
+
+- Wherever `Code`/`Sub`/`Method` 0-arg reflection methods are dispatched — likely
+  `src/builtins/methods_0arg/` (grep for existing `Code` reflection methods like
+  `.name`, `.arity`, `.candidates`) plus wherever a `Sub`/`Method` value's declaration
+  site (source file + line) is tracked in the AST/compiler, since that's the data
+  `.file`/`.line` need to surface.

--- a/todo/tickets/compiler-verbose-config-unimplemented.md
+++ b/todo/tickets/compiler-verbose-config-unimplemented.md
@@ -1,0 +1,36 @@
+# `$*RAKU.compiler.verbose-config` is unimplemented
+
+Found by the doc-diff harness batch-4 re-run (`docs/doc-diff-backlog.md`,
+`Type/Compiler.rakudoc:58`).
+
+## Repro
+
+```raku
+say $*RAKU.compiler.verbose-config;
+```
+
+- `raku`: prints ~200 lines of MoarVM/Rakudo build configuration key=value pairs
+  (compiler flags, third-party library paths, kernel/distro info, etc.) — entirely
+  build-environment-specific, not reproducible across machines/versions.
+- `mutsu` (`target/debug/mutsu`):
+  ```
+  No such method 'verbose-config' for invocant of type 'Compiler'
+  ```
+
+## Priority note
+
+This is a low-priority gap: real raku's `.verbose-config` output is exhaustively tied
+to the exact MoarVM build (compiler flags, `3rdparty/` library paths, the build
+machine's `uname`/distro info, etc.) that produced the running `raku` binary — mutsu
+has no equivalent build-time data to report truthfully, so any implementation would
+either need to fabricate MoarVM-shaped keys (misleading) or return a
+mutsu-appropriate but structurally different config map (which would never match the
+doc's `# OUTPUT`). Worth a stub that returns *something* (e.g. mutsu's own
+build/version info under a smaller key set) so the method at least doesn't throw, but
+matching raku's exact output is not a realistic goal.
+
+## Affected files (starting point)
+
+- Wherever `Compiler`'s other reflection methods (`.version`, `.name`, `.build-date`,
+  etc.) are implemented — grep for `"Compiler"` method dispatch in `src/runtime/` or
+  `src/builtins/methods_0arg/`.

--- a/todo/tickets/datetime-day-out-of-range-uses-generic-outofrange.md
+++ b/todo/tickets/datetime-day-out-of-range-uses-generic-outofrange.md
@@ -1,0 +1,36 @@
+# `DateTime` range-check errors throw generic `X::OutOfRange` instead of `X::Temporal::OutOfRange`
+
+Found by the doc-diff harness batch-4 re-run (`docs/doc-diff-backlog.md`,
+`Type/DateTime.rakudoc:137`).
+
+## Root cause
+
+mutsu already registers `X::Temporal::OutOfRange` as a proper exception subclass of
+`X::OutOfRange` (`src/runtime/runtime_init.rs:2414`,
+`register_x("X::Temporal::OutOfRange", "X::OutOfRange", &["X::Temporal"]);`), but the
+actual `DateTime`/`Date` range-check helpers in
+`src/builtins/methods_0arg/temporal.rs` (the `day`/`second` out-of-range builders
+around lines 70-113) construct the error with
+`RuntimeError::typed("X::OutOfRange", attrs)` — the generic parent type — instead of
+`"X::Temporal::OutOfRange"`. So the specific type is registered and introspectable but
+never actually used at the real throw site.
+
+## Minimal repro
+
+```raku
+say DateTime.new("2012-02-29T12:34:56Z").clone(year => 2015);
+CATCH { default { put .^name, ': ', .Str } };
+```
+
+- `raku`: `X::Temporal::OutOfRange: Day out of range. Is: 29, should be in 1..28`
+- `mutsu` (`target/debug/mutsu`): `X::OutOfRange: Day out of range. Is: 29, should be
+  in 1..28` (same message text, wrong/too-generic exception type — a
+  `try { ... }; CATCH { when X::Temporal::OutOfRange { ... } }` written against the
+  documented type would not catch it in mutsu).
+
+## Affected files (starting point)
+
+- `src/builtins/methods_0arg/temporal.rs` — the `day`/`second` out-of-range error
+  builders (~lines 70-113) that call `RuntimeError::typed("X::OutOfRange", attrs)`;
+  switch them to `"X::Temporal::OutOfRange"` (the type is already registered and
+  `does` `X::Temporal`, so no registration changes should be needed).

--- a/todo/tickets/datetime-julian-date-returns-num-not-rat.md
+++ b/todo/tickets/datetime-julian-date-returns-num-not-rat.md
@@ -1,0 +1,33 @@
+# `DateTime.julian-date`/`.modified-julian-date` return `Num` instead of `Rat`
+
+Found by the doc-diff harness batch-4 re-run (`docs/doc-diff-backlog.md`,
+`Type/DateTime.rakudoc:281,302`).
+
+## Root cause hypothesis
+
+Real raku computes the Julian date as an exact `Rat`, so `.julian-date` and
+`.modified-julian-date` print with a short, exact decimal expansion. mutsu computes
+the same value using floating-point (`Num`) arithmetic somewhere in the julian-date
+calculation, so the result carries binary-float rounding noise and prints with many
+more digits.
+
+## Minimal repro
+
+```raku
+my $jd = DateTime.new('2021-12-24T12:23:00.43Z').julian-date;
+say $jd;
+say $jd.WHAT;
+```
+
+- `raku`: `2459573.0159772`, `(Rat)`
+- `mutsu` (`target/debug/mutsu`): `2459573.015977199`, `(Num)`
+
+Same shape for `.modified-julian-date`: raku's `59572.5159772` (`Rat`) vs. mutsu's
+`59572.51597719907` (`Num`).
+
+## Affected files (starting point)
+
+- `src/builtins/methods_0arg/temporal.rs` (or wherever `.julian-date`/
+  `.modified-julian-date` are computed) — the arithmetic should stay in `Rat`
+  end-to-end (day-fraction + epoch-offset math) instead of converting through `f64`
+  at any point.

--- a/todo/tickets/formatter-new-unimplemented.md
+++ b/todo/tickets/formatter-new-unimplemented.md
@@ -1,0 +1,37 @@
+# `Formatter.new(FORMAT_STRING)` is unimplemented
+
+Found by the doc-diff harness batch-4 re-run (`docs/doc-diff-backlog.md`,
+`Type/Formatter.rakudoc:16,32`).
+
+## Root cause
+
+`Formatter` (a `v6.e.PREVIEW` type) compiles an `sprintf`-style format string into a
+reusable `Callable` — `Formatter.new("'%5s'")` returns a `&handle` sub that formats its
+argument the same way `sprintf("'%5s'", $arg)` would. mutsu already has a `Formatter`
+type object stub (`say Formatter.^name` prints `Formatter`), but no `.new` method is
+registered for it, so any construction attempt throws.
+
+## Minimal repro
+
+```raku
+use v6.e.PREVIEW;
+my &handle = Formatter.new("'%5s'");
+say handle("foo");
+```
+
+- `raku`: `'  foo'`
+- `mutsu` (`target/debug/mutsu`):
+  ```
+  X::Method::NotFound: Unknown method value dispatch (fallback disabled): new on Formatter
+  ```
+
+A second example from the same doc (`Formatter.new("%05d")` used as `zero5(42)` →
+`00042`) fails the same way.
+
+## Affected files (starting point)
+
+- Wherever the `Formatter` type object is registered (grep for `"Formatter"` in
+  `src/runtime/runtime_init.rs` or similar) — needs a `.new` implementation that
+  parses the format string once (reusing mutsu's existing `sprintf`/`printf`
+  directive-parsing logic, since the format-string grammar is identical) and returns a
+  `Sub`/`Callable` closing over the parsed format spec.

--- a/todo/tickets/named-placeholder-var-interpolation-in-string-fails.md
+++ b/todo/tickets/named-placeholder-var-interpolation-in-string-fails.md
@@ -1,0 +1,42 @@
+# `$:name` named-placeholder variable fails to interpolate inside a double-quoted string
+
+Found by the doc-diff harness batch-4 re-run (`docs/doc-diff-backlog.md`,
+`Type/Code.rakudoc:81`).
+
+## Root cause hypothesis
+
+`$:name` is the named-placeholder-parameter form (like `$^a`/`$^b` for positional
+placeholders, used inside a sub body to implicitly declare a named parameter). It
+works fine as a bare statement/expression, but when interpolated inside a
+double-quoted string, mutsu's string-interpolation scanner does not recognize
+`$:name` as a variable at all — it apparently treats the bare `$` (immediately
+followed by `:`) as a literal, unescaped `$` sigil, which the general "a `$` must
+either start a variable or be backslashed" check then rejects.
+
+## Minimal repro
+
+```raku
+sub foo { say $:foo }
+&foo.assuming(foo => 42)();          # OK on mutsu: prints 42
+
+sub bar { say "$:foo" }
+&bar.assuming(foo => 42)();          # mutsu errors; should print 42
+```
+
+- `raku`: both print `42`.
+- `mutsu` (`target/debug/mutsu`): the bare-variable form works (`42`), but the
+  interpolated form throws:
+  ```
+  Runtime error: Non-variable $ must be backslashed
+  ```
+
+The doc's own combined example (`"$^a $^b $:foo $:bar"`) fails the same way for the
+same reason — `$^a`/`$^b` positional-placeholder interpolation already works, only the
+`$:name` named form is affected.
+
+## Affected files (starting point)
+
+- The double-quoted-string interpolation scanner (parser/quoting code that decides
+  what follows a `$` inside `"..."` — grep for where `$^` positional-placeholder
+  interpolation is already handled, since that sibling form works; the `$:name` case
+  needs the analogous branch).

--- a/todo/tickets/nativecall-pointer-raku-format-mismatch.md
+++ b/todo/tickets/nativecall-pointer-raku-format-mismatch.md
@@ -1,0 +1,33 @@
+# `Pointer[T].raku` uses a bare type name and named-arg form instead of raku's fully-qualified positional form
+
+Found by the doc-diff harness batch-4 re-run (`docs/doc-diff-backlog.md`,
+`Language/nativetypes.rakudoc:172`).
+
+## Repro
+
+```raku
+use NativeCall;
+sub malloc( int32 $size --> Pointer[void] ) is native { * };
+my Pointer[void] $for-malloc = malloc( 32 );
+say $for-malloc.raku;
+```
+
+- `raku`: `NativeCall::Types::Pointer[NativeCall::Types::void].new(297902560)` (the
+  trailing number is the pointer address, inherently non-reproducible/allocator-
+  dependent — not itself a bug to match).
+- `mutsu` (`target/debug/mutsu`): `NativeCall::Types::Pointer[void].new(address =>
+  128219605755824)`.
+
+Two deterministic (non-address) format differences, independent of the actual pointer
+value:
+1. The type parameter renders as the bare `void` instead of the fully-qualified
+   `NativeCall::Types::void`.
+2. The constructor call renders as a named argument (`.new(address => N)`) instead of
+   raku's positional form (`.new(N)`).
+
+## Affected files (starting point)
+
+- Wherever `Pointer[T]`'s `.raku` method is implemented (grep for `Pointer` in
+  `src/runtime/` NativeCall support) — needs to (a) fully-qualify the type-parameter
+  name the same way the outer `Pointer` type itself already is, and (b) emit the
+  constructor call positionally rather than as a named `address` pair.

--- a/todo/tickets/parametric-role-literal-as-expression-term-misparsed.md
+++ b/todo/tickets/parametric-role-literal-as-expression-term-misparsed.md
@@ -1,0 +1,75 @@
+# An anonymous *parametric* `role Name[...] {...}` literal is misparsed as an expression term
+
+Found by the doc-diff harness batch-4 re-run (`docs/doc-diff-backlog.md`,
+`Type/Metamodel/ParametricRoleGroupHOW.rakudoc:21`).
+
+**Refines** [anon-role-expression-term-parse-fail.md](anon-role-expression-term-parse-fail.md)
+(filed from a sibling batch-4 run against `Type/Metamodel/ParametricRoleHOW.rakudoc`),
+which described *both* the parameterless `(role NAME {...})` and parametric
+`(role NAME[...] {...})` forms as hard parse errors. Re-verified directly on current
+`main`: the parameterless form already parses and runs fine on its own (`(role Zape2
+{}).HOW.say;` succeeds); the doc's combined two-statement example only *looked* like
+both forms failed because mutsu parses a whole file before running any of it, so the
+first statement's real parse failure (the parametric form, below) aborts the entire
+file before the second, parameterless-form statement ever gets a chance to run. This
+ticket narrows the root cause to the parametric `[...]` signature specifically.
+
+## Root cause
+
+mutsu's expression-position parser recognizes `role Name {...}` (no parameter list) as
+a term — e.g. `my $x = role Zape {}; say $x;` works and prints `(Zape)`. But as soon as
+the role declaration carries a parameter list (`role Name[...] {...}`), the same
+construct in expression position is *not* recognized as a role-literal term at all.
+Instead the parser backtracks to treating the bare `role` keyword as an ordinary
+bareword term (satisfying `my $x = <term>`), and then tries to parse the remaining
+`Name[...]` as a *separate* expression — which misfires because `Name` starting with
+`Z` (or any identifier) followed by `[` is grammatically ambiguous with Raku's
+`Z<infix>` list metaop syntax (zip-with-operator, e.g. `Z+`), so `Zape[...]` gets
+parsed as the metaop `Z` with a custom infix operator named `ape`, applied to
+`[...]` as its right operand.
+
+`--dump-ast` on the minimal repro confirms this:
+
+```
+$ target/debug/mutsu --dump-ast -e 'my $x = role Zape[Int $n] {};'
+...
+Expr(
+    MetaOp {
+        meta: "Z",
+        op: "ape",
+        left: DoStmt(VarDecl { name: "x", expr: BareWord("role"), ... }),
+        right: BracketArray(...),
+```
+
+Note this reproduces with any parameter list, not just a type-capture (`::T`) one —
+`role Zape[Int $n] {}` fails the same way.
+
+## Minimal repro
+
+```raku
+(role Zape[::T] {}).HOW.say;
+```
+
+or, isolated further:
+
+```raku
+my $x = role Zape[Int $n] {};
+say $x;
+```
+
+- `raku`: `Perl6::Metamodel::ParametricRoleHOW.new` / prints the role type object.
+- `mutsu` (`target/debug/mutsu`): `===SORRY!=== ... Confused. expected statement:
+  expected use statement or import statement or no statement or need statement or unit
+  statement or ...` for the first form, and `Unsupported reduction operator: ape` for
+  the second.
+
+Note that the *statement-level* declaration form already works fine —
+`role Zape[::T] {}; say Zape;` parses and runs correctly. Only the anonymous
+expression-term form (RHS of `=`, argument position, etc.) is affected.
+
+## Affected files (starting point)
+
+- The parser's term-position handling of the `role`/`class` keyword (grep for where
+  the parameterless `role NAME {...}` expression-term case is already handled — the
+  parametric `[...]` signature needs to be recognized there too, the same way it
+  already is for the statement-level `role` declaration parser).

--- a/todo/tickets/role-mixed-sink-method-not-invoked-in-sink-context.md
+++ b/todo/tickets/role-mixed-sink-method-not-invoked-in-sink-context.md
@@ -1,0 +1,48 @@
+# A role-mixed `.sink` method is never invoked when the value is used in sink context
+
+Found by the doc-diff harness batch-4 re-run (`docs/doc-diff-backlog.md`,
+`Language/perl-func.rakudoc:2310`).
+
+## Root cause
+
+Raku calls a value's `.sink` method (if the value's type/role defines one) when the
+value is the result of a statement whose value is discarded ("sink context" — e.g. a
+bare expression-statement, or a sub call used as a full statement). mutsu never
+invokes `.sink` at all in this situation — a role-mixed `.sink` method is simply never
+called.
+
+## Minimal repro
+
+```raku
+role R { method sink { say "sunk!" } };
+(1) does R;
+say "after";
+```
+
+- `raku`: prints `sunk!` then `after`.
+- `mutsu` (`target/debug/mutsu`): prints only `after` — the mixed-in `.sink` method is
+  never dispatched.
+
+The doc's own (more elaborate) example relies on exactly this mechanism to implement
+an "increment on sink, copy on assignment" idiom:
+
+```raku
+multi increment($b is rw) {
+    ($b + 1) does role { method sink { $b++ } }
+}
+multi increment($b) { $b + 1 }
+my $a = 1;
+increment($a);
+say $a;                 # raku: 2, mutsu: 1 (the mixed sink method never fires)
+```
+
+## Affected files (starting point)
+
+- Wherever mutsu compiles/executes a statement in sink context (statement-expression
+  evaluation that discards its value — grep for "sink context" / where the "Useless
+  use of ..." warning is emitted, since that's the same context-detection machinery)
+  — after evaluating a statement's expression in sink position, if the resulting
+  value carries a role/class that defines a `sink` method, that method should be
+  invoked (with no arguments) before the value is discarded.
+- The mixin/role-dispatch machinery (`src/runtime/mixin.rs` or similar) for how a
+  `does`-mixed method is looked up on a value, to reuse for the sink-method lookup.

--- a/todo/tickets/x-cannot-empty-message-not-formatted.md
+++ b/todo/tickets/x-cannot-empty-message-not-formatted.md
@@ -1,0 +1,50 @@
+# `X::Cannot::Empty.new(:action, :what).message` returns an empty string
+
+Found by the doc-diff harness batch-4 re-run (`docs/doc-diff-backlog.md`,
+`Type/X/Cannot/Empty.rakudoc:15`).
+
+## Root cause
+
+Real raku's `X::Cannot::Empty` has a `method message { "Cannot $.action from an empty
+$.what" }` that formats its message from the `:action`/`:what` attributes at read
+time. mutsu registers `X::Cannot::Empty` as a plain exception subclass
+(`register_x("X::Cannot::Empty", "Exception", &[])` in
+`src/runtime/runtime_init.rs:1787`) with no such `message` formatter — the internal
+call sites that throw it (`src/runtime/sequence.rs`,
+`src/runtime/methods_mut_substr_buf.rs`, `src/runtime/methods_call_dispatch.rs`) each
+pass a pre-built literal message string, so they work by coincidence, but when *user
+code* constructs `X::Cannot::Empty.new(:action(...), :what(...))` directly (the
+documented, supported way to raise this exception from a custom class), `.message`
+has nothing to fall back to and returns an empty string.
+
+## Minimal repro
+
+```raku
+class Stack {
+    my class Node { has $.value; has Node $.next }
+    has Node $!next;
+    method push($value) { $!next .= new(:$value, :$!next); self }
+    method pop() {
+        fail X::Cannot::Empty.new(:action<pop>, :what(self.^name)) unless $!next;
+        my $value = $!next.value;
+        $!next .= next;
+        $value;
+    }
+}
+my $stack = Stack.new.push(42);
+say $stack.pop;
+try $stack.pop;
+say $!.message;
+```
+
+- `raku`: `42` then `Cannot pop from an empty Stack`.
+- `mutsu` (`target/debug/mutsu`): `42` then an empty line (`$!.message` is `""`, exit
+  code 0 — no crash, just a silently wrong/empty message).
+
+## Affected files (starting point)
+
+- `src/builtins/exception_message.rs` (the general per-exception-type `.message`
+  formatter dispatch, judging by its handling of similar "Is: N, should be in RANGE"
+  formatted messages for `X::OutOfRange` and friends) — needs an `X::Cannot::Empty`
+  case that reads the instance's `action`/`what` attributes and formats "Cannot
+  {action} from an empty {what}".


### PR DESCRIPTION
## Summary
- Re-ran the doc-diff harness against 10 files (batch4-C):
  `Type/Code.rakudoc`, `Type/DateTime.rakudoc`, `Language/perl-func.rakudoc`,
  `Type/Metamodel/ParametricRoleGroupHOW.rakudoc`, `Type/Formatter.rakudoc`,
  `Type/X/Cannot/Empty.rakudoc`, `Type/Exception.rakudoc`,
  `Language/nativetypes.rakudoc`, `Type/Compiler.rakudoc`,
  `Type/IO/ArgFiles.rakudoc`.
- Every finding was re-verified directly against `raku` before filing.
- Filed 11 new tickets under `todo/tickets/`, and folded one finding into the
  existing `todo/deep/direct-metamodel-classhow-new-type-immutable-error.md`
  ticket (same generic `new_type` handler root cause).
- Updated `docs/doc-diff-backlog.md` with the new batch-4 subsection + an
  Excluded (raku-drift) bullet list.

## Test plan
- [x] Docs-only change (`docs/doc-diff-backlog.md`, `todo/tickets/*.md`,
  `todo/deep/*.md`) — no code changes, no tests to run.
- [x] `cargo clippy -- -D warnings` and `cargo fmt` ran clean via the
  pre-commit hook.
- [x] Every repro in the new ticket files was manually re-verified against
  both `raku` and `target/debug/mutsu` before filing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>