### PR TITLE
docs: doc-diff batch-4 triage (operators/MixHash/PrePost/Cygwin/quoting/classtut/ConditionVariable/newline)

### DIFF
--- a/docs/doc-diff-backlog.md
+++ b/docs/doc-diff-backlog.md
@@ -531,6 +531,61 @@ Found in the 2026-08-22 batch-4 re-run of `Code`/`DateTime`/`perl-func`/
   reports its own identity (`mutsu (0.1.0)`) rather than impersonating rakudo, which
   is intentional, not a bug.
 
+Found in the 2026-08-22 batch-4 re-run of `operators`/`MixHash`/`Phaser::PrePost`/
+`IO::Spec::Cygwin`/`quoting`/`classtut`/`Lock::ConditionVariable`/`newline`:
+
+| file:line | one-line summary | ticket |
+|---|---|---|
+| `Language/operators.rakudoc:1991` | `42 but 'string'`'s `.^name` reports the `IntStr` allomorph type instead of raku's `Int+{<anon\|1>}` | [but-mixin-anon-name-uses-allomorph-instead-of-plus-anon.md](../todo/tickets/but-mixin-anon-name-uses-allomorph-instead-of-plus-anon.md) |
+| `Language/operators.rakudoc:3177` | `infix:<Z>(...)` function-call form dies at runtime ("Two terms in a row"), other `infix:<...>` ops work | [infix-z-function-call-form-parse-fails.md](../todo/tickets/infix-z-function-call-form-parse-fails.md) |
+| `Language/operators.rakudoc:482` | `«=»` hyper-assignment to a nested-tuple destructuring target silently no-ops | [hyper-assign-nested-destructuring-target-not-applied.md](../todo/tickets/hyper-assign-nested-destructuring-target-not-applied.md) |
+| `Language/operators.rakudoc:567` | a hyper-operator wrapping another hyper-operator (`»>>+<<»`) fails to parse | [nested-hyper-operator-parse-fail.md](../todo/tickets/nested-hyper-operator-parse-fail.md) |
+| `Language/operators.rakudoc:707` | `.raku` on a nested array-literal element drops the `$`-itemization prefix | [array-literal-nested-element-itemization-lost-in-raku.md](../todo/tickets/array-literal-nested-element-itemization-lost-in-raku.md) |
+| `Language/operators.rakudoc:1675` | `[∘]` (empty-operand function-composition reduce) doesn't produce an identity `Callable` | [compose-reduce-empty-list-not-identity-callable.md](../todo/tickets/compose-reduce-empty-list-not-identity-callable.md) |
+| `Language/operators.rakudoc:214` | `s///` replacement text with a literal word immediately followed by `{block}` is a hard parse error | [subst-replacement-bareword-adjacent-code-block-parse-fail.md](../todo/tickets/subst-replacement-bareword-adjacent-code-block-parse-fail.md) |
+| `Type/X/Phaser/PrePost.rakudoc:15` | `X::Phaser::PrePost`'s message drops the failed `PRE`/`POST` condition's source text | [phaser-pre-post-message-drops-condition-source-text.md](../todo/tickets/phaser-pre-post-message-drops-condition-source-text.md) |
+| `Type/IO/Spec/Cygwin.rakudoc:80` | `IO::Spec::Cygwin.is-absolute` doesn't recognize a Win32-style drive path (`C:\foo`) | [iospec-cygwin-is-absolute-missing-win32-drive-path.md](../todo/tickets/iospec-cygwin-is-absolute-missing-win32-drive-path.md) |
+| `Language/quoting.rakudoc:368` | `< 42/10 >` (space-padded angle-quote word) doesn't produce the `RatStr` allomorph like the Complex case does | [angle-bracket-quoted-word-space-padded-loses-allomorph.md](../todo/tickets/angle-bracket-quoted-word-space-padded-loses-allomorph.md) |
+| `Type/Lock/ConditionVariable.rakudoc:69` | `Lock`/`condition`/`Thread.start` signal-wait deadlocks when the lock/condition/counter locals are declared inside a loop body (works fine at top level / in a bare block) | [loop-scoped-lock-condition-thread-signal-hang.md](../todo/tickets/loop-scoped-lock-condition-thread-signal-hang.md) |
+| `Language/newline.rakudoc:40` | `open()` doesn't recognize an `IO::Special` object (`<STDOUT>`/etc.) as a special-handle target, tries to open it as a literal path | [open-io-special-stdout-target-not-recognized.md](../todo/tickets/open-io-special-stdout-target-not-recognized.md) |
+| `Type/MixHash.rakudoc:99` | `MixHash (^) MixHash` / `MixHash (+) MixHash` give garbage output (raw un-combined pairs) where the same ops on plain `Mix` work correctly | [mixhash-set-operators-give-wrong-uncoerced-output.md](../todo/tickets/mixhash-set-operators-give-wrong-uncoerced-output.md) |
+
+**Excluded from this batch-4 sub-run (already deferred/resolved/drift/false-positive):**
+- `Language/operators.rakudoc` [1] (line 1795, `<a b c> (+) (a => 2.5, b => 3.14).Mix`) — matches
+  the already-documented "Still deferred: Mix *arithmetic* operators" residue under the
+  `Mix.rakudoc`/`Baggy.rakudoc` entry in the Resolved section above (lossy f64 weight addition,
+  `4.140000000000001` vs `4.14`).
+- `Language/operators.rakudoc` [3]/[chained-Z parse crash] (line 3157, `say (1, 2 Z <a b c> Z <+
+  ->).raku;`, and the simpler `say 1, 2 Z 3, 4 Z 5, 6;`) — a residue of the already-**Deferred**
+  "List-infix (`Z`/`X`/meta/infix-func) comma precedence" cluster: the statement/argument listop
+  fix (#5268/#5271) lifts a *single* `Z` occurrence in a comma-list argument, but a *second*,
+  chained `Z` in the same argument still hard-fails to parse ("Two terms in a row") instead of
+  just giving a wrong precedence result. Confirmed the fully-parenthesized form (`(1,2) Z (3,4) Z
+  (5,6)`) parses and evaluates correctly, isolating the gap to the same listop-arg-list-lifting
+  mechanism, not a new root cause.
+- `Language/operators.rakudoc` [8] (line 602, `my @n = [\~] 1..*; say @n[^5];`) — matches the
+  already-**Deferred** Lazy-list cluster's named "closure_seq / scan_spec arrays stay
+  force-capped on `@`-assign" residue (confirmed: this exact `@`-assigned triangle-reduce over an
+  infinite Range hangs).
+- `Language/operators.rakudoc` [11] (line 2376, `Set(...) eqv Set(...)` with a custom `.WHICH`
+  method) — matches the already-**Deferred** "WHICH-keyed QuantHash storage" cluster.
+- `Language/operators.rakudoc` [12] (line 2507, bare `$*TOLERANCE` arithmetic) — matches the
+  already-documented "Still open" residue of the `≅`/`=~=` fix (operators.rakudoc [20]/[21]
+  above) and the "Block-scope restore of a dynamic var with a pre-existing outer value" deferred
+  cluster.
+- `Type/MixHash.rakudoc` [1], [3], [4] (lines 38/58/69, `.pairs`/`.keys.map(&WHAT)` element
+  order) — hash/QuantHash iteration-order `raku-drift`/nondeterminism, the "Known harness false
+  positive" documented above the Ticketed section; verified directly that repeated `raku` runs
+  of the identical program (`MixHash.new: "a","a","b"=>0,"c"=>3.14; .keys.map(&WHAT)`) give
+  different orders across runs (4 runs: `(Pair)(Str)(Pair)` ×3, `(Str)(Pair)(Pair)` ×1).
+- `Language/classtut.rakudoc` [1] (line 805, `$o.^methods(:local)».name.join(', ')` on stub
+  classes) — the real-`raku` output includes a synthesized `POPULATE` method that the doc's own
+  illustrative `# OUTPUT` block (for a related, fuller example a few lines up) does not mention
+  at all; this looks like an undocumented, Rakudo-build-specific internal method (confirmed: even
+  a bare `class Foo {}; say Foo.^methods(:local)».name` shows `(POPULATE)` taking 2 positional
+  args, i.e. internal plumbing, not user-visible language behavior) added to the current Rakudo
+  build after this doc was written — treated as raku-implementation-drift, not a mutsu bug.
+
 ### Deferred / deep (tracked elsewhere — do not re-open as a shallow slice)
 These root causes account for a large share of the survey's `mism`/`crash` and are
 intentionally deferred; see PLAN.md §8.5 and the ADRs:

--- a/todo/tickets/angle-bracket-quoted-word-space-padded-loses-allomorph.md
+++ b/todo/tickets/angle-bracket-quoted-word-space-padded-loses-allomorph.md
@@ -1,0 +1,40 @@
+# `< 42/10 >` (space-padded inside angle brackets) doesn't produce the `RatStr` allomorph like `<42/10>` does
+
+Found by the doc-diff harness re-run (`docs/doc-diff-backlog.md`, `Language/quoting.rakudoc:368`).
+
+## Root cause hypothesis
+
+An angle-bracket quote-words term (`< ... >`) containing a single number-like word produces an
+"allomorph" — a value that is simultaneously the numeric type and a `Str`-flavored variant
+(`RatStr`, `ComplexStr`, etc.) — because `<...>` is fundamentally a *string* quoting construct
+that also happens to auto-coerce number-shaped words:
+
+```raku
+say <42/10>.^name;   # Rat        (no surrounding whitespace)
+say <1+42i>.^name;   # Complex
+say < 42/10 >.^name; # RatStr     (surrounding whitespace still normal quote-words behavior)
+say < 1+42i >.^name; # ComplexStr
+```
+
+mutsu gets the tight (`<42/10>`) and the Complex-with-space (`< 1+42i >`) cases right, but for
+`< 42/10 >` (space-padded Rat) it reports plain `Rat` instead of `RatStr`. This suggests
+mutsu's quote-words tokenizer special-cases a *single* padded numeric word and, for the
+Rat-shaped case specifically, takes a shortcut straight to the plain `Rat` value instead of
+going through the same allomorph-construction path that the Complex case (and the
+no-whitespace `<42/10>` case) correctly uses.
+
+## Minimal repro
+
+```raku
+say < 42/10 >.^name;
+```
+
+- `raku`: `RatStr`
+- `mutsu` (`target/debug/mutsu`): `Rat`
+
+## Affected files (starting point)
+
+- Quote-words (`<...>`) tokenizing/allomorph construction — likely in `src/parser/` (angle
+  bracket quoting) where number-shaped single words are turned into allomorph values; the
+  `Complex`/`ComplexStr` path already works correctly and is a good reference for how the
+  `Rat`/`RatStr` path should behave.

--- a/todo/tickets/array-literal-nested-element-itemization-lost-in-raku.md
+++ b/todo/tickets/array-literal-nested-element-itemization-lost-in-raku.md
@@ -1,0 +1,49 @@
+# `.raku` on an array-literal element that is itself an array literal drops the `$`-itemization prefix
+
+Found by the doc-diff harness re-run (`docs/doc-diff-backlog.md`, `Language/operators.rakudoc:707`).
+
+## Root cause hypothesis
+
+Every element of an array literal (`[...]`) is documented to be `Scalar`-itemized (contained),
+including nested array-literal elements. `.raku` on such an itemized element therefore prefixes
+it with `$` to show it round-trips as a single scalar item, not a flattenable list:
+
+```raku
+say .raku for [3,2,[1,0]];
+# raku:  3 / 2 / $[1, 0]
+```
+
+mutsu prints the third element as plain `[1, 0]` (no `$` prefix), meaning the nested
+array-literal element is not being wrapped in an item container the way `raku`'s array-literal
+construction itemizes each of its elements. This is a distinct manifestation from the already-
+ticketed [item-contextualized-list-var-name-not-scalar.md](item-contextualized-list-var-name-not-scalar.md)
+(which is about the `$(LIST)` contextualizer operator specifically) — here there is no `$(...)`
+involved at all, the itemization is supposed to come purely from being a nested element of an
+outer `[...]` array-literal construction.
+
+## Minimal repro
+
+```raku
+say .raku for [3,2,[1,0]];
+```
+
+- `raku`:
+  ```
+  3
+  2
+  $[1, 0]
+  ```
+- `mutsu` (`target/debug/mutsu`):
+  ```
+  3
+  2
+  [1, 0]
+  ```
+
+## Affected files (starting point)
+
+- Array-literal (`[...]`) construction/compilation — likely `src/compiler/expr.rs` or
+  `src/vm/vm_data_ops.rs` (array-literal construction opcode), wherever each array-literal
+  element value is stored; nested-array-literal elements need to be item-contained the same way
+  a plain scalar element already presumably is (since `.raku` on a non-nested scalar element
+  works correctly, only nested-array elements lose the wrapper).

--- a/todo/tickets/but-mixin-anon-name-uses-allomorph-instead-of-plus-anon.md
+++ b/todo/tickets/but-mixin-anon-name-uses-allomorph-instead-of-plus-anon.md
@@ -1,0 +1,38 @@
+# `Int but Str` value's `.^name` reports the `IntStr` allomorph type instead of raku's `Int+{<anon|1>}`
+
+Found by the doc-diff harness re-run (`docs/doc-diff-backlog.md`, `Language/operators.rakudoc:1991`).
+
+## Root cause hypothesis
+
+`42 but 'forty two'` mixes a role-like string identity onto an `Int` value. Rakudo represents
+this as an anonymous mixin type built on the fly (`Int+{<anon|1>}` — `Int` composed with an
+anonymous role holding the `Str`-role behavior), which is what `.^name` reports.
+
+mutsu instead appears to special-case `Int but Str-literal` and route it to the pre-existing
+built-in `IntStr` allomorph representation (the same type used for e.g. `<42>` numeric
+literals that carry both numeric and string forms). That is a plausible representation for the
+*value* (stringifies/numifies correctly — `+33` and `.Str` both work fine in the repro), but it
+leaks through `.^name`, which should report the anonymous-mixin name, not the allomorph type
+name.
+
+## Minimal repro
+
+```raku
+my $forty-two = 42 but 'forty two';
+say $forty-two+33;    # 75 in both
+say $forty-two.^name; # raku: Int+{<anon|1>}   mutsu: IntStr
+say $forty-two.Str;   # forty two in both
+```
+
+- `raku`: `Int+{<anon|1>}`
+- `mutsu` (`target/debug/mutsu`): `IntStr`
+
+Only the `.^name` line diverges; the arithmetic and stringification results already match.
+
+## Affected files (starting point)
+
+Likely wherever `but` mixin construction chooses a representation for an `Int`/numeric LHS
+mixed with a `Str`/literal RHS — probably in the mixin (`but`) handling in
+`builtins/arith.rs`/`runtime/` mixin dispatch, where it likely takes a shortcut to the
+`IntStr` allomorph instead of building a proper anonymous-mixin type whose `.^name` reflects
+`Int+{<anon|N>}`.

--- a/todo/tickets/compose-reduce-empty-list-not-identity-callable.md
+++ b/todo/tickets/compose-reduce-empty-list-not-identity-callable.md
@@ -1,0 +1,50 @@
+# `[∘]` (function-composition reduce) with an empty operand list doesn't produce a working identity `Callable`
+
+Found by the doc-diff harness re-run (`docs/doc-diff-backlog.md`, `Language/operators.rakudoc:1675`).
+
+## Root cause hypothesis
+
+The reduce meta-operator `[OP]` applied to zero operands is documented to return `OP`'s
+identity value; for `∘` (function composition), the identity is the identity function, so
+`[∘]` alone should evaluate to a `Callable` that returns its argument unchanged:
+
+```raku
+my &composed = [∘];
+say composed("foo");  # raku: foo
+```
+
+mutsu instead produces something that is not a valid, resolvable named sub:
+
+```raku
+say composed("foo");
+# Unknown function: composed
+```
+
+and directly inspecting `[∘]`'s type confirms it isn't a `Callable` at all in mutsu:
+
+```
+my $x = [∘]; say $x.WHAT;   # mutsu: (Any)   -- should be some Callable/Block type
+```
+
+So `[∘]` on an empty operand list is evaluating to `Any`/`Nil` rather than synthesizing the
+identity-function closure, and binding that non-callable to `&composed` leaves the symbol
+effectively unusable (hence "Unknown function" when later called by bare name).
+
+## Minimal repro
+
+```raku
+my &composed = [∘];
+say composed("foo");
+```
+
+- `raku`: `foo`
+- `mutsu` (`target/debug/mutsu`): `Unknown function: composed` (runtime error)
+- Also: `my $x = [∘]; say $x.WHAT;` — `raku`: some Callable type; `mutsu`: `(Any)`
+
+## Affected files (starting point)
+
+- The reduce meta-operator (`[OP]`) implementation for a zero-operand list — likely
+  `src/runtime/methods.rs` / wherever `.reduce`/triangle-reduce dispatches per-operator
+  identity values (search for how other operators' identity elements are handled for empty
+  input, e.g. `[+]` on an empty list returning `0`) and add the `∘` (function composition)
+  case, which needs to return an identity *Callable* rather than a scalar identity value.

--- a/todo/tickets/hyper-assign-nested-destructuring-target-not-applied.md
+++ b/todo/tickets/hyper-assign-nested-destructuring-target-not-applied.md
@@ -1,0 +1,48 @@
+# `«=»` hyper-assignment to a nested-tuple destructuring target silently does nothing
+
+Found by the doc-diff harness re-run (`docs/doc-diff-backlog.md`, `Language/operators.rakudoc:482`).
+(The harness itself mis-bucketed this as `raku-drift` because the underlying multi-line block's
+first line already matched, but the second line is a genuine, reproducible divergence —
+re-verified directly against current `raku`.)
+
+## Root cause hypothesis
+
+`«=»` (hyper-assignment) with a nested-tuple LHS is documented to recursively assign
+element-wise into a matching nested-tuple RHS shape:
+
+```raku
+my ($a, $b, $c);
+(($a, $b), $c) «=» ((1, 2), 3);
+say "$a, $c";       # raku: 1, 3
+```
+
+mutsu does not perform the assignment at all: it emits "Useless use of $a/$b/$c/constant N in
+sink context" warnings (implying it evaluated `($a, $b), $c` and `((1, 2), 3)` as two
+independent sink-context list expressions, not as a hyper-assignment), and `$a`/`$c` remain
+undefined afterward — `say "$a, $c"` then throws "Use of uninitialized value" warnings and
+prints `, ` (both empty) instead of `1, 3`.
+
+This suggests the hyper-assignment compiler/parser path recognizes `«=»`/`»=»`/`<<=>>` for a
+flat LHS (a plain array/list of scalars — the `@a »+=» 1` case one line above in the same doc
+example works fine), but does not recognize a **parenthesized, nested-tuple** LHS as a valid
+hyper-assignment target, falling back to parsing the whole thing as an ordinary
+comma-expression statement instead.
+
+## Minimal repro
+
+```raku
+my ($a, $b, $c);
+(($a, $b), $c) «=» ((1, 2), 3);
+say "$a, $c";
+```
+
+- `raku`: `1, 3`
+- `mutsu` (`target/debug/mutsu`): several sink-context / uninitialized-value warnings, then
+  `, ` (both `$a` and `$c` stay undefined).
+
+## Affected files (starting point)
+
+- The hyper-operator (`»`/`«`) parsing/compiling path, likely in `src/parser/` (wherever
+  `«=»`/`»=»` hyper-assignment is recognized) and `src/compiler/expr.rs` (wherever a hyper
+  assignment LHS is walked to determine element targets) — needs to accept a parenthesized
+  nested-list LHS, not just a flat array/list.

--- a/todo/tickets/infix-z-function-call-form-parse-fails.md
+++ b/todo/tickets/infix-z-function-call-form-parse-fails.md
@@ -1,0 +1,51 @@
+# `infix:<Z>(...)` function-call form fails ("Two terms in a row"), while other `infix:<...>` operators work
+
+Found by the doc-diff harness re-run (`docs/doc-diff-backlog.md`, `Language/operators.rakudoc:3177`).
+
+## Root cause hypothesis
+
+Calling an operator by its fully-qualified function name (`infix:<OP>(lhs, rhs)`) is a general
+Raku mechanism and works for ordinary operators in mutsu:
+
+```raku
+say infix:<+>(1,2);          # 3            -- OK
+say infix:<X>(<a b>,<c d>);  # ((a c)...)   -- OK
+say infix:<Z>(<a b>,<c d>);  # BROKEN
+```
+
+Specifically `infix:<Z>` fails — not at parse time (`--dump-ast` succeeds and shows a normal
+`Call { name: Symbol("infix:<Z>"), args: [...] }` node), but at **runtime**, where it raises a
+`RuntimeError` whose message text is literally `"Two terms in a row"` (the same string the
+*parser* uses for a completely different situation — an unexpected second term). That reused
+error string, appearing from a runtime call-dispatch path rather than the parser, suggests
+`infix:<Z>` dispatch takes a code path that re-invokes some parsing/matching logic keyed on the
+literal name `"Z"` (colliding with the `Z`/zip meta-op or sequence-operator special-casing
+elsewhere in the interpreter) instead of just dispatching to the same native `Z` binary-op
+implementation that `<a b> Z <c d>` (infix syntax) already uses correctly.
+
+`&infix:<Z>` (as a bare term, no call) also fails when *called* via `&infix:<Z>(...)`, so the
+gap is not specific to the bareword-call form — it's in the callable itself / how it's looked
+up and invoked.
+
+## Minimal repro
+
+```raku
+say infix:<Z>(<a b>,<c d>);
+```
+
+- `raku`: `((a c) (b d))`
+- `mutsu` (`target/debug/mutsu`): dies at runtime:
+  ```
+  Two terms in a row
+    in block <unit> at -e line 1
+  ```
+- Compare: `say infix:<X>(<a b>,<c d>);` works correctly in mutsu (`((a c) (a d) (b c) (b d))`),
+  ruling out a generic "infix:<...>() call form" gap — this is `Z`-specific.
+
+## Affected files (starting point)
+
+- Wherever `Call { name: Symbol("infix:<Z>") }` gets dispatched at runtime (likely
+  `runtime/calls.rs` / `runtime/dispatch.rs`, or a builtin lookup table keyed by operator name)
+  — search for how the bare string `"Z"` is special-cased (`src/vm/vm_meta_ops.rs`,
+  `src/vm/vm_dispatch_helpers.rs`, `src/vm/vm_misc_reduction_exec.rs` all reference `"Z"`
+  specially and are good starting points).

--- a/todo/tickets/iospec-cygwin-is-absolute-missing-win32-drive-path.md
+++ b/todo/tickets/iospec-cygwin-is-absolute-missing-win32-drive-path.md
@@ -1,0 +1,37 @@
+# `IO::Spec::Cygwin.is-absolute` doesn't recognize a Win32-style drive path (`C:\foo`) as absolute
+
+Found by the doc-diff harness re-run (`docs/doc-diff-backlog.md`, `Type/IO/Spec/Cygwin.rakudoc:80`).
+
+## Root cause hypothesis
+
+`IO::Spec::Cygwin` inherits from `IO::Spec::Unix` but additionally treats Windows-style drive
+paths (`C:\foo`) as absolute, since Cygwin paths can be either POSIX-style (`/foo`) or
+Win32-style (`C:\foo`):
+
+```raku
+say IO::Spec::Cygwin.is-absolute: "/foo";        # True
+say IO::Spec::Cygwin.is-absolute: "/\x[308]foo"; # True
+say IO::Spec::Cygwin.is-absolute: ｢C:\foo｣;      # True
+say IO::Spec::Cygwin.is-absolute: "bar";         # False
+```
+
+mutsu gets the first, second, and fourth cases right, but returns `False` for the Win32-style
+drive path case — its `.is-absolute` implementation for `IO::Spec::Cygwin` likely just reuses
+the POSIX-only check (leading `/`) without also recognizing the `<letter>:\` / `<letter>:/`
+drive-prefix form that `IO::Spec::Win32` (and Cygwin, per this doc) already needs to detect.
+
+## Minimal repro
+
+```raku
+say IO::Spec::Cygwin.is-absolute: "C:\\foo";
+```
+
+- `raku`: `True`
+- `mutsu` (`target/debug/mutsu`): `False`
+
+## Affected files (starting point)
+
+- `IO::Spec::Cygwin`'s `.is-absolute` method implementation — likely near the
+  `IO::Spec::Win32`/`IO::Spec::Unix` implementations (grep for `is-absolute` and `Cygwin` in
+  `src/runtime/` or wherever `IO::Spec::*` classes are implemented) — needs to also match the
+  drive-prefix pattern that `IO::Spec::Win32.is-absolute` presumably already recognizes.

--- a/todo/tickets/loop-scoped-lock-condition-thread-signal-hang.md
+++ b/todo/tickets/loop-scoped-lock-condition-thread-signal-hang.md
@@ -1,0 +1,77 @@
+# `Lock`/`condition`/`Thread.start` signal-wait deadlocks when the lock/condition/topic variables are declared inside a loop body
+
+Found by the doc-diff harness re-run (`docs/doc-diff-backlog.md`, `Type/Lock/ConditionVariable.rakudoc:69`).
+
+## Root cause hypothesis
+
+A `Lock`, its `.condition`, and a shared counter variable, all declared with `my` and used from
+a spawned `Thread.start` closure plus a `.protect`/`.wait`/`.signal` rendezvous, works correctly
+at the **top level** / inside a bare block:
+
+```raku
+{
+    my $lock = Lock.new;
+    my $cond = $lock.condition;
+    my $done = 0;
+    Thread.start({ sleep 0.1; $lock.protect({ $done = 1; $cond.signal; }); });
+    $lock.protect({ $cond.wait({ $done == 1 }); });
+    say "done";
+}
+```
+
+This prints `done` and exits (verified with `target/debug/mutsu`). But wrapping the **exact
+same code** inside a `for`-loop body (even a single-iteration `for 1..1 -> $iter { ... }`) or a
+`while`-loop body hangs forever — `$cond.wait` never sees `$done` become `1`, even though the
+`Thread.start` closure still runs and calls `$cond.signal`:
+
+```raku
+for 1..1 -> $iter {
+    my $lock = Lock.new;
+    my $cond = $lock.condition;
+    my $done = 0;
+    Thread.start({ sleep 0.1; $lock.protect({ $done = 1; $cond.signal; }); });
+    $lock.protect({ $cond.wait({ $done == 1 }); });
+    say "done";
+}
+```
+
+- `raku`: prints `done` and exits normally.
+- `mutsu` (`target/debug/mutsu`): hangs indefinitely (verified `timeout 10` → exit 124, both for
+  `for` and `while` loop bodies).
+
+This strongly suggests a loop-body-scoped local variable (`$lock`/`$cond`/`$done`) captured by
+the `Thread.start` closure is not sharing the same underlying cell/state as the loop-body-local
+copy that `$cond.wait`'s predicate closure reads — i.e. the spawned thread's closure and the
+waiting thread's closure end up looking at two different `$done` cells (or the `$lock` used by
+`.protect` in the spawned closure isn't the same `Lock` object instance), so the signal never
+reaches / is never observed by the waiter. This matches the general class of dual-store
+(locals-vs-env) desync bugs this codebase has hit before with closures over loop-scoped
+variables (see `docs/doc-diff-backlog.md`'s "Sigilless-parameter scoping" deferred cluster for
+a related loop-scope leak, and the project memory note on "env-writeback campaign: the
+state-sync bug shape" for the general bug shape), but this is a fresh, undiagnosed instance —
+not yet confirmed to share the exact same root cause.
+
+## Minimal repro
+
+```raku
+for 1..1 -> $iter {
+    my $lock = Lock.new;
+    my $cond = $lock.condition;
+    my $done = 0;
+    Thread.start({ sleep 0.1; $lock.protect({ $done = 1; $cond.signal; }); });
+    $lock.protect({ $cond.wait({ $done == 1 }); });
+    say "done";
+}
+```
+
+- `raku`: prints `done`.
+- `mutsu` (`target/debug/mutsu`): hangs (deterministic, reproduces every run; also reproduces
+  with a `while` loop instead of `for`).
+
+## Affected files (starting point)
+
+- Loop-body compilation (for/while loop-scoped local allocation) and how loop-body closures
+  capture `my`-declared locals — `src/compiler/stmt.rs` (loop compilation),
+  `src/vm/vm_control_ops.rs` (loop execution), and the `Lock`/`condition`/`Thread` runtime
+  implementation (concurrency-related `runtime/` submodules) for how `.protect`/`.wait`/
+  `.signal` read/write their captured variables across threads.

--- a/todo/tickets/mixhash-set-operators-give-wrong-uncoerced-output.md
+++ b/todo/tickets/mixhash-set-operators-give-wrong-uncoerced-output.md
@@ -1,0 +1,58 @@
+# `MixHash (^) MixHash` / `MixHash (+) MixHash` (symmetric-difference / union) produce garbage output; the same ops work fine on plain `Mix`
+
+Found by the doc-diff harness re-run (`docs/doc-diff-backlog.md`, `Type/MixHash.rakudoc:99`).
+The harness bucketed this whole block as `raku-drift-from-doc` (the doc's stated element order
+for one line doesn't match current raku's output), but a genuine, separate bug hides underneath
+that drift: re-verified directly against current `raku`, isolating the divergence to the
+weighted set-operators on `MixHash` specifically.
+
+## Root cause hypothesis
+
+The Baggy/Mix set operators (`(^)` symmetric difference, `(+)`/`(<+>)` union addition, etc.)
+work correctly on immutable `Mix` operands:
+
+```raku
+my $a = (2 => 2, 4).Mix;
+my $b = (2 => 1.5, 3 => 2, 4).Mix;
+say $a (^) $b;   # Mix(2(0.5) 3(2))          -- matches raku exactly
+say $a (+) $b;   # Mix(2(3.5) 3(2) 4(2))     -- matches raku exactly
+```
+
+But the same operators on **mutable `MixHash`** operands produce clearly wrong results — not
+just a different element order, but the wrong *shape* entirely (raw `key => value` `Pair`
+gists instead of computed `key(weight)` results, and the union/symmetric-difference math is not
+actually performed — mutsu just seems to dump one or both operand's raw pairs):
+
+```raku
+my ($a, $b) = MixHash(2 => 2, 4), MixHash(2 => 1.5, 3 => 2, 4);
+say $a (^) $b;   # raku: MixHash(2(0.5) 3(2))
+                 # mutsu: MixHash(2 => 2 2 => 1.5 3 => 2)          -- wrong
+say $a (+) $b;   # raku: MixHash(2(3.5) 3(2) 4(2))
+                 # mutsu: MixHash(4(2) 2 => 2 2 => 1.5 3 => 2)     -- wrong
+```
+
+This strongly suggests `MixHash` operands take a different (and broken/unfinished) dispatch
+path for these weighted set operators than plain `Mix` does — likely falling through to a
+generic Hash-merge or pair-concatenation fallback instead of the same weighted symmetric-
+difference/union arithmetic that `Mix` correctly uses.
+
+## Minimal repro
+
+```raku
+my ($a, $b) = MixHash(2 => 2, 4), MixHash(2 => 1.5, 3 => 2, 4);
+say $a (^) $b;
+say $a (+) $b;
+```
+
+- `raku`: `MixHash(2(0.5) 3(2))` then `MixHash(2(3.5) 3(2) 4(2))` (element order may vary, but
+  the weights/keys are always these).
+- `mutsu` (`target/debug/mutsu`): `MixHash(2 => 2 2 => 1.5 3 => 2)` then
+  `MixHash(4(2) 2 => 2 2 => 1.5 3 => 2)` — wrong keys/weights, `=>` pair-gist syntax mixed in
+  with weight-gist syntax.
+
+## Affected files (starting point)
+
+- Set-operator (`(^)`/`(+)`/`(&)`/etc.) dispatch for `Mix`/`MixHash`/`Bag`/`BagHash` operands —
+  likely `src/vm/vm_set_ops.rs` — needs to route `MixHash` operands through the same weighted
+  computation `Mix` already uses correctly, rather than falling back to a generic/incomplete
+  path for the mutable variant.

--- a/todo/tickets/nested-hyper-operator-parse-fail.md
+++ b/todo/tickets/nested-hyper-operator-parse-fail.md
@@ -1,0 +1,43 @@
+# A hyper-operator wrapping another hyper-operator (`»>>+<<»`) fails to parse
+
+Found by the doc-diff harness re-run (`docs/doc-diff-backlog.md`, `Language/operators.rakudoc:567`).
+
+## Root cause hypothesis
+
+Raku allows an outer hyper-op (`»...«`) whose wrapped operator is itself already a hyper form
+(`>>+<<`, i.e. `«+»` written in the ASCII `<<...>>` style), used to broadcast a nested-tuple
+element-wise binary operation across two nested-tuple lists:
+
+```raku
+my $neighbors = ((-1, 0), (0, -1), (0, 1), (1, 0));
+my $p = (2, 3);
+say $neighbors »>>+<<» ($p, *);   # raku: ((1 3) (2 2) (2 4) (3 3))
+```
+
+mutsu fails to parse this at all — `===SORRY!=== ... Confused. expected expression after hyper
+operator or '.' or digits ...`. The hyper-operator grammar apparently only recognizes a single
+plain infix operator token between the `»`/`«` delimiters (e.g. `»+»`, `»>>+<<»` is presumably
+being tokenized in a way where the parser doesn't expect `>>+<<` — a full nested hyper spelling
+— as the "operator" term inside the outer hyper brackets.
+
+## Minimal repro
+
+```raku
+my $neighbors = ((-1, 0), (0, -1), (0, 1), (1, 0));
+my $p = (2, 3);
+say $neighbors »>>+<<» ($p, *);
+```
+
+- `raku`: `((1 3) (2 2) (2 4) (3 3))`
+- `mutsu` (`target/debug/mutsu`): compile-time parse error:
+  ```
+  ===SORRY!=== Error while compiling ...
+  Confused. expected expression after hyper operator or '.' or digits or generic radix literal or unicode numeric literal or ...
+  ```
+
+## Affected files (starting point)
+
+- The hyper-operator parsing code (look for where `»`/`«` / `<<`/`>>` hyper-op delimiters are
+  recognized and the wrapped-operator token is parsed) — likely under `src/parser/` in the
+  operator/hyper-op handling. Needs to accept a nested hyper-form operator spelling
+  (`>>+<<`/`«+»`) as the operator between the outer `»`/`«` pair.

--- a/todo/tickets/open-io-special-stdout-target-not-recognized.md
+++ b/todo/tickets/open-io-special-stdout-target-not-recognized.md
@@ -1,0 +1,47 @@
+# `open()` doesn't recognize an `IO::Special` object (`<STDOUT>`/`<STDERR>`/`<STDIN>`) as a special-handle target
+
+Found by the doc-diff harness re-run (`docs/doc-diff-backlog.md`, `Language/newline.rakudoc:40`).
+
+## Root cause hypothesis
+
+`IO::Special.new('<STDOUT>')` (and `<STDERR>`/`<STDIN>`) is a sentinel object that, when passed
+to `open()`, is supposed to return a handle wrapping the corresponding standard stream (so you
+can reopen it with different options, e.g. a custom `:nl-out`):
+
+```raku
+my $crlf-out = open(IO::Special.new('<STDOUT>'), :nl-out("\\\n\r"));
+$*OUT.say: 1;     # 1
+$crlf-out.say: 1; # 1\  (with a literal backslash + CRLF newline)
+```
+
+mutsu's `open()` instead treats the `IO::Special` argument like an ordinary path/filename and
+tries to `open()` it as a literal file, which of course fails:
+
+```
+Failed to open '.../IO::Special()': No such file or directory (os error 2)
+```
+
+(Note the error text itself — `'.../IO::Special()'` — shows the object's stringification/gist
+being concatenated onto the CWD as if it were a relative path, confirming `open()` never special-cased the `IO::Special` type at all.)
+
+## Minimal repro
+
+```raku
+my $crlf-out = open(IO::Special.new('<STDOUT>'), :nl-out("\\\n\r"));
+$*OUT.say: 1;
+$crlf-out.say: 1;
+```
+
+- `raku` stdout (raw bytes): `1\n1\\\n\r` (i.e. `1`, newline, `1\`, then a literal `\r`)
+- `mutsu` (`target/debug/mutsu`): prints `1` for the first `.say`, then dies:
+  ```
+  Failed to open '<cwd>/IO::Special()': No such file or directory (os error 2)
+  ```
+
+## Affected files (starting point)
+
+- `open()`'s implementation — likely `src/runtime/builtins_*.rs` (file/IO builtins) or wherever
+  `IO::Path`/`open` argument coercion happens — needs to check whether the first argument is an
+  `IO::Special` instance (holding one of `<STDOUT>`/`<STDERR>`/`<STDIN>`) and dispatch to
+  wrapping the corresponding already-open standard stream (applying any given `:nl-out`/other
+  adverbs) instead of falling through to the ordinary path-based `open()` logic.

--- a/todo/tickets/phaser-pre-post-message-drops-condition-source-text.md
+++ b/todo/tickets/phaser-pre-post-message-drops-condition-source-text.md
@@ -1,0 +1,40 @@
+# `X::Phaser::PrePost` failure message drops the source text of the failed `PRE`/`POST` condition
+
+Found by the doc-diff harness re-run (`docs/doc-diff-backlog.md`, `Type/X/Phaser/PrePost.rakudoc:15`).
+
+## Root cause hypothesis
+
+When a `PRE { ... }` (or `POST { ... }`) phaser's condition evaluates false, Raku raises
+`X::Phaser::PrePost` with a message that quotes the condition's own source text:
+
+```raku
+sub f($x) { PRE { $x ~~ Int } };
+f "foo";
+CATCH { default { put .^name, ': ', .Str } };
+```
+
+- `raku`: `X::Phaser::PrePost: Precondition '{ $x ~~ Int }' failed`
+- `mutsu`: `X::Phaser::PrePost: Precondition '' failed`
+
+mutsu constructs the same exception type and message shape, but the quoted condition text is
+always empty. The exception-construction site for `X::Phaser::PrePost` is presumably passing an
+empty/unfilled string for the condition-source field instead of the phaser body's original
+source text (or a `.raku`/gist-style reconstruction of it).
+
+## Minimal repro
+
+```raku
+sub f($x) { PRE { $x ~~ Int } };
+f "foo";
+CATCH { default { put .^name, ': ', .Str } };
+```
+
+- `raku`: `X::Phaser::PrePost: Precondition '{ $x ~~ Int }' failed`
+- `mutsu` (`target/debug/mutsu`): `X::Phaser::PrePost: Precondition '' failed`
+
+## Affected files (starting point)
+
+- Wherever `PRE`/`POST` phasers are compiled and their failure raises `X::Phaser::PrePost` —
+  likely in the phaser-handling compiler code (`src/compiler/`) and/or the exception
+  construction site in `src/runtime/` — the phaser's original source span needs to be captured
+  at compile time and threaded into the exception's condition-text field.

--- a/todo/tickets/subst-replacement-bareword-adjacent-code-block-parse-fail.md
+++ b/todo/tickets/subst-replacement-bareword-adjacent-code-block-parse-fail.md
@@ -1,0 +1,54 @@
+# `s///` replacement text with a literal word immediately followed by an embedded `{...}` code block is a hard parse error
+
+Found by the doc-diff harness re-run (`docs/doc-diff-backlog.md`, `Language/operators.rakudoc:214`).
+
+Related to, but distinct from, the already-filed
+[subst-replacement-code-block-not-evaluated.md](subst-replacement-code-block-not-evaluated.md)
+(that ticket's repro parses fine and mostly evaluates its embedded code blocks correctly — its
+bug is a stray backslash on `\:`). This finding is a **compile-time parse failure**, not a
+runtime interpolation bug.
+
+## Root cause hypothesis
+
+A substitution replacement string can mix literal text directly adjacent to an embedded `{...}`
+code block, with no separator between them — the literal text ends and the code block begins
+right where `{` appears:
+
+```raku
+$str ~~ s :g :i/<[ML]> (\S+)/d{lc $0}/;
+```
+
+Here the replacement text is the literal letter `d` followed immediately by the code block
+`{lc $0}` (no space, no explicit concatenation operator). mutsu fails to compile this at all:
+
+```
+Confused. expected statement: expected expression statement or expression after additive operator or '.' or digits or generic radix literal or ...
+------>$str ~~ s :g :i/<[ML]> (\S+)/d{lc $0}/;
+                              ^
+binary operators require a right-hand expression.
+```
+
+The error text ("binary operators require a right-hand expression") suggests the
+replacement-string parser is treating the bareword-like `d` as the start of an expression (and
+then choking when `{` follows it with no operator in between), rather than treating `d` as
+**literal replacement text** and `{lc $0}` as a separately-recognized embedded interpolation
+block — the same way a plain `"literal text{block}"` interpolated string already handles a
+bareword immediately followed by `{`.
+
+## Minimal repro
+
+```raku
+my $str = 'foo muCKed into the lEn';
+$str ~~ s:2nd/o/x/;
+$str ~~ s :g :i/<[ML]> (\S+)/d{lc $0}/;
+say $str;
+```
+
+- `raku`: `fox ducked into the den`
+- `mutsu` (`target/debug/mutsu`): fails to compile (`===SORRY!===` parse error, see above)
+
+## Affected files (starting point)
+
+- `s///` replacement-string parsing/lexing, likely near where interpolated strings and
+  embedded code blocks are lexed for substitution replacement text — `src/parser/` (quote/regex
+  slang replacement handling) and possibly `src/vm/vm_string_regex_ops.rs`.


### PR DESCRIPTION
## Summary
- Re-ran the doc-diff harness against 8 files (`operators`, `MixHash`, `X/Phaser/PrePost`, `IO/Spec/Cygwin`, `quoting`, `classtut`, `Lock/ConditionVariable`, `newline`) and re-verified every finding directly against `raku`.
- Filed 13 new tickets under `todo/tickets/` for confirmed real bugs, including two hard crashes (a parse failure and a deterministic hang in a loop-scoped `Lock`/`condition`/`Thread` deadlock).
- Excluded findings that match already-documented Deferred clusters (Mix arithmetic weight residue, list-infix `Z`/`X` comma-precedence residue, lazy-list `scan_spec` residue, WHICH-keyed QuantHash storage, `$*TOLERANCE` block-scope residue), plus hash-iteration-order nondeterminism and one undocumented Rakudo-internal `POPULATE` method.
- Updated `docs/doc-diff-backlog.md` with a new dated subsection under "Ticketed (open — linked to todo/)".

## Test plan
- [x] Re-verified every reported finding directly with `raku -e` / `target/debug/mutsu` before ticketing (no fixes in this PR — triage/filing only).
- [x] `cargo fmt` / `cargo clippy -- -D warnings` ran via the pre-commit hook.
- Docs-only change — CI's `test`/`wasm-e2e`/`gc-stress`/`jit-stress` jobs should report `skipped`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)