### PR TITLE
docs: doc-diff batch5-B findings (SetHash/Mixins/BagHash/pod/containers/hashmap/Setty/Block/io-guide/Proxy/CompUnit)

### DIFF
--- a/docs/doc-diff-backlog.md
+++ b/docs/doc-diff-backlog.md
@@ -586,6 +586,48 @@ Found in the 2026-08-22 batch-4 re-run of `operators`/`MixHash`/`Phaser::PrePost
   args, i.e. internal plumbing, not user-visible language behavior) added to the current Rakudo
   build after this doc was written — treated as raku-implementation-drift, not a mutsu bug.
 
+Found in the 2026-08-22 batch-5 re-run of `SetHash`/`Metamodel::Mixins`/`BagHash`/`pod`/
+`containers`/`hashmap`/`Setty`/`Block`/`io-guide`/`Proxy`/`CompUnit::Repository::FileSystem`:
+
+| file:line | one-line summary | ticket |
+|---|---|---|
+| `Type/Metamodel/Mixins.rakudoc:18,63` | `my Type:D $var .= new: ...;` fails — the `.=` implicit invocant keeps the `:D` definedness smiley baked into the type-name bareword | [dot-assign-target-keeps-definedness-smiley.md](../todo/tickets/dot-assign-target-keeps-definedness-smiley.md) |
+| `Type/Metamodel/Mixins.rakudoc:112` | `but`-mixing a role onto a class instance: `.^name` correctly shows `Foo+{Bar}`, but the default `.gist`/`say` output still shows plain `Foo.new` | [but-mixin-object-gist-missing-plus-suffix.md](../todo/tickets/but-mixin-object-gist-missing-plus-suffix.md) |
+| `Type/BagHash.rakudoc:112` | `.add`/`.remove` methods are unimplemented on `BagHash` (subscript-based mutation already works) | [baghash-add-remove-methods-missing.md](../todo/tickets/baghash-add-remove-methods-missing.md) |
+| `Language/pod.rakudoc:908` | `$=pod` items are plain `List`s wrapping a generic `Pod::Block::Named`, not the flattened `Pod::Heading`/`Pod::Block::Para` objects raku produces; `.contents` fails | [dollar-equals-pod-item-not-iterable-block-object.md](../todo/tickets/dollar-equals-pod-item-not-iterable-block-object.md) |
+| `Language/containers.rakudoc:137`, `Language/hashmap.rakudoc:504` | assigning to a readonly *binding* (a `:=`-bound literal, a `for`-loop var over readonly hash values) throws `X::Assignment::RO` where raku throws the generic `X::AdHoc` | [readonly-variable-assign-uses-ro-instead-of-adhoc.md](../todo/tickets/readonly-variable-assign-uses-ro-instead-of-adhoc.md) |
+| `Type/Block.rakudoc:17` | `.signature` of a bare `{;}` block (implicit `$_` parameter) gists as the garbled `($$_?)` instead of `(;; $_? is raw = OUTER::<$_>)` | [implicit-topic-block-signature-gist-wrong.md](../todo/tickets/implicit-topic-block-signature-gist-wrong.md) |
+| `Type/Proxy.rakudoc:17` | `my $x := sub-call-returning-Proxy();` loses the Proxy's writability (binding directly to a `Proxy.new(...)` literal, or plain assignment, both work) | [bind-proxy-from-sub-return-value-loses-writability.md](../todo/tickets/bind-proxy-from-sub-return-value-loses-writability.md) |
+| `Type/CompUnit/Repository/FileSystem.rakudoc:45` | `.files(name, :ver)` introspection method is unimplemented | [compunit-repository-filesystem-files-method-missing.md](../todo/tickets/compunit-repository-filesystem-files-method-missing.md) |
+
+**Excluded from this batch-5 sub-run (already deferred/resolved/drift/false-positive/duplicate):**
+- `Type/SetHash.rakudoc` [1], [2] (lines 88, 99, `.keys`/`.values` order after `.new`/`.SetHash`
+  coercion) — hash/SetHash iteration-order nondeterminism, the "Known harness false positive"
+  documented above the Ticketed section.
+- `Type/BagHash.rakudoc` [1], [2] (as bucketed: line 66 `output-mismatch`, lines 58/78/129
+  `raku-drift`) — the same hash/BagHash iteration-order nondeterminism; verified directly that 3
+  repeated `raku` runs of the identical `new-from-pairs` example gave `("b","c")` twice and
+  `("c","b")` once.
+- `Language/pod.rakudoc` [1] (line 170, `Magician.WHY`/`&duel.WHY.leading`/`.trailing`) —
+  duplicates the already-filed
+  [pod-why-declarator-object-not-stringified.md](../todo/tickets/pod-why-declarator-object-not-stringified.md)
+  (same root cause: `Pod::Block::Declarator`'s `.Str`/`.gist` isn't implemented, so both the
+  bare-stringify and the `.leading`/`.trailing` accessor symptoms trace to the same gap).
+- `Language/containers.rakudoc` [1], [3], [4], [5] — `raku-drift` (exception-message wording
+  drift, object-address/generated-variable-name text, and big-Int-seed-dependent `.raku` gist,
+  all version/environment-specific).
+- `Language/hashmap.rakudoc` [1] (line 444, `.kv` iteration order) — hash iteration-order
+  nondeterminism, the same known false positive.
+- `Type/Setty.rakudoc` [1] (line 112, `Set.new(1,2,3).keys`) — Set iteration-order
+  nondeterminism, the same known false positive.
+- `Language/io-guide.rakudoc` [1] (line 281, `temp $*OUT = open :w, $*SPEC.devnull;` not
+  redirecting `say`) — re-verified directly: `open :w, PATH` (named adverb before the
+  positional path) itself fails and returns a `Failure` in mutsu, which then gets assigned to
+  `$*OUT`, so `say` silently keeps writing to the original stdout — this is a downstream
+  consequence of the already-filed
+  [open-named-adverb-before-positional-path.md](../todo/tickets/open-named-adverb-before-positional-path.md),
+  not a separate bug; not re-filed.
+
 ### Deferred / deep (tracked elsewhere — do not re-open as a shallow slice)
 These root causes account for a large share of the survey's `mism`/`crash` and are
 intentionally deferred; see PLAN.md §8.5 and the ADRs:

--- a/todo/tickets/baghash-add-remove-methods-missing.md
+++ b/todo/tickets/baghash-add-remove-methods-missing.md
@@ -1,0 +1,39 @@
+# `BagHash.add` / `.remove` methods are unimplemented
+
+Found by the doc-diff harness re-run (`docs/doc-diff-backlog.md`, `Type/BagHash.rakudoc:112`).
+
+## Minimal repro
+
+```raku
+my $n = BagHash.new: "a", "b", "c", "c";
+$n.add('c');
+say $n.raku;
+
+$n.remove('a');
+say $n.raku;
+```
+
+- `raku`: `.add` increments the given key's count by one (or inserts it at count 1 if
+  absent); `.remove` decrements it by one (removing the key entirely once its count hits 0).
+- `mutsu` (`target/debug/mutsu`): both throw
+  `No such method 'add'/'remove' for invocant of type 'BagHash'`.
+
+BagHash already supports the equivalent mutating operations via subscript assignment
+(`$n<c>++`, `$n<b> -= 1`, `$n{'a'} = 0` all work correctly per the same doc's next example),
+so the underlying mutable-count storage exists — only the named `.add`/`.remove` method
+wrappers are missing.
+
+## Root cause hypothesis
+
+`BagHash`'s method dispatch (native `methods_0arg`/`methods_narg`, or the QuantHash-specific
+handlers) has no `add`/`remove` arm at all — every other BagHash mutator (subscript
+increment/assign, `.roll`, etc.) is implemented, but these two named methods were never
+added. Per `raku-doc/doc/Type/Baggy.rakudoc`, `add`/`remove` are documented `Baggy` role
+methods, so `Bag`/`Mix` immutable variants correctly don't have them (or throw
+immutable-container errors), but `BagHash`/`MixHash` should.
+
+## Affected files (starting point)
+
+- `src/builtins/methods_narg.rs` / `src/runtime/methods.rs` — wherever other BagHash
+  mutators (the `$n{'a'} = 0` subscript-store path, `.roll`) are dispatched; `add`/`remove`
+  should route through the same per-key count adjustment.

--- a/todo/tickets/bind-proxy-from-sub-return-value-loses-writability.md
+++ b/todo/tickets/bind-proxy-from-sub-return-value-loses-writability.md
@@ -1,0 +1,48 @@
+# `my $x := sub-call-returning-Proxy();` loses the Proxy's writability
+
+Found by the doc-diff harness re-run (`docs/doc-diff-backlog.md`, `Type/Proxy.rakudoc:17`).
+
+## Minimal repro
+
+```raku
+sub double() {
+    my $storage = 0;
+    Proxy.new(
+        FETCH => method ()     { $storage * 2    },
+        STORE => method ($new) { $storage = $new },
+    )
+}
+my $doubled := double();
+$doubled = 4;
+say $doubled;
+```
+
+- `raku`: `8`
+- `mutsu` (`target/debug/mutsu`): dies with
+  `Cannot assign to a readonly variable (doubled) or a value`.
+
+Both these narrower variants work correctly, isolating the bug to the specific combination
+of `:=` binding + a sub-call RHS whose returned value is a `Proxy`:
+
+- `my $p = Proxy.new(...); $p = 4; say $p;` → `8` (direct assignment, no sub call: OK)
+- `my $doubled := Proxy.new(...); $doubled = 4; say $doubled;` → `8` (`:=` binding directly
+  to a `Proxy.new(...)` literal, no sub call: OK)
+- Removing `is rw` from `sub double()` makes no difference — the failure reproduces either
+  way, so this is not specifically about `is rw` return semantics.
+
+## Root cause hypothesis
+
+Binding (`:=`) to the result of a sub *call* appears to go through a different code path
+than binding directly to an expression — likely one that resolves/copies the sub's return
+value into a plain (readonly) binding slot rather than preserving the returned `Proxy`
+object's own FETCH/STORE dispatch. The Proxy's `STORE` method should still be reachable
+through the bound name after the call returns; instead mutsu's readonly-binding error fires,
+meaning the bind ends up wrapping something it treats as an immutable value rather than the
+live Proxy container.
+
+## Affected files (starting point)
+
+- Wherever `:=` binding to a function-call expression is compiled/executed (look at how the
+  VM's bind-op handles a `Call`/`MethodCall` RHS vs. a plain expression RHS) — needs to check
+  whether a returned `Proxy` value is unwrapped/copied before the bind instead of being bound
+  through directly.

--- a/todo/tickets/but-mixin-object-gist-missing-plus-suffix.md
+++ b/todo/tickets/but-mixin-object-gist-missing-plus-suffix.md
@@ -1,0 +1,41 @@
+# `but`-mixing a role onto a class instance: default gist drops the `+{Role}` suffix
+
+Found by the doc-diff harness re-run (`docs/doc-diff-backlog.md`,
+`Type/Metamodel/Mixins.rakudoc:112`).
+
+## Minimal repro
+
+```raku
+class Foo { }
+role Bar { }
+
+say Foo.new but Bar;     # OUTPUT: «Foo+{Bar}.new»
+say Foo.new.^mixin(Bar); # OUTPUT: «Foo+{Bar}.new»
+```
+
+- `raku`: both lines print `Foo+{Bar}.new`.
+- `mutsu` (`target/debug/mutsu`): both lines print `Foo.new` — the `+{Bar}` mixin
+  annotation is missing.
+
+## Root cause hypothesis
+
+`.^name` on the same mixed value is already correct:
+
+```raku
+my $x = Foo.new but Bar;
+say $x.^name;   # mutsu: Foo+{Bar}  -- matches raku
+say $x.gist;     # mutsu: Foo.new    -- raku: Foo+{Bar}.new
+```
+
+So the metaclass-name path (`dispatch_caret_name` or similar) already looks at the
+instance's role/mixin markers, but the default object gist/stringification path (the one
+producing `TypeName.new(...)`-shaped output for a plain class instance) does not — it must
+be reading the *base* type's name rather than going through the same mixin-aware name
+lookup that `.^name` uses.
+
+## Affected files (starting point)
+
+- Wherever the default `Any`/class-instance `.gist`/`.new`-shaped stringification builds
+  its type-name prefix (likely `src/runtime/methods_introspect.rs` or a gist-formatting
+  helper) — needs to route through the same mixin-name resolution `.^name` already uses
+  instead of the plain base-class name.

--- a/todo/tickets/compunit-repository-filesystem-files-method-missing.md
+++ b/todo/tickets/compunit-repository-filesystem-files-method-missing.md
@@ -1,0 +1,35 @@
+# `CompUnit::Repository::FileSystem.files` method is unimplemented
+
+Found by the doc-diff harness re-run (`docs/doc-diff-backlog.md`,
+`Type/CompUnit/Repository/FileSystem.rakudoc:45`).
+
+## Minimal repro
+
+```raku
+my $repo = CompUnit::Repository::FileSystem.new(prefix => $*CWD);
+say $repo.files('bin/zef', :ver<419.0+>).head.<name> // "Nada";
+```
+
+- `raku`: prints `Nada` (no distribution at that prefix advertises a file matching that
+  path/version, so `.files` returns an empty list and `.head` is `Nil`, coalescing to
+  `"Nada"`).
+- `mutsu` (`target/debug/mutsu`): dies with
+  `No such method 'files' for invocant of type 'CompUnit::Repository::FileSystem'`.
+
+## Root cause hypothesis
+
+`CompUnit::Repository::FileSystem` (mutsu's module-search-path repository type, used by
+`use lib`/`-I`/`MUTSULIB` resolution per the root `CLAUDE.md`) never implements the `.files`
+introspection method — it should look up distribution(s) at the repository's prefix matching
+the given short-name/version query and return the list of provided files (each with a `name`
+key, among others) declared in the matching `META6.json`. Since mutsu's repository is
+otherwise functional (module loading itself works), this is purely a missing introspection
+method, not a deeper repository-model gap.
+
+## Affected files (starting point)
+
+- Wherever `CompUnit::Repository::FileSystem`'s other methods (`resolve`, `need`, or
+  whatever backs `use`/`-I` module resolution) are implemented — likely under
+  `src/runtime/` module-loading code — needs a `.files(name, :ver, :auth, :api)` method that
+  scans the repository's known distributions' declared `provides`/file list and returns
+  matching entries.

--- a/todo/tickets/dollar-equals-pod-item-not-iterable-block-object.md
+++ b/todo/tickets/dollar-equals-pod-item-not-iterable-block-object.md
@@ -1,0 +1,59 @@
+# `$=pod` items aren't proper `Pod::*` block objects — `.contents` fails, wrong type
+
+Found by the doc-diff harness re-run (`docs/doc-diff-backlog.md`, `Language/pod.rakudoc:908`).
+
+## Minimal repro
+
+```raku
+=begin pod
+
+=head1 This is a head1 title
+
+This is a paragraph.
+
+=end pod
+
+for $=pod -> $pod-item {
+    for $pod-item.contents -> $pod-block {
+      $pod-block.raku.say;
+    }
+}
+```
+
+- `raku`:
+  ```
+  Pod::Heading.new(level => 1, config => {}, contents => [Pod::Block::Para.new(config => {}, contents => ["This is a head1 title"])])
+  Pod::Block::Para.new(config => {}, contents => ["This is a paragraph."])
+  ```
+- `mutsu` (`target/debug/mutsu`): dies with
+  `No such method 'contents' for invocant of type 'List'`.
+
+## Root cause hypothesis
+
+Iterating `$=pod` in mutsu yields elements that are plain `List`s (each wrapping a single
+`Pod::Block::Named` instance), not the flattened top-level sequence of `Pod::*` block
+objects real Raku produces. A follow-up probe:
+
+```raku
+for $=pod -> $pod-item {
+    say $pod-item.WHAT;   # mutsu: (List)  -- should be a Pod::* type, e.g. (Pod::Heading)
+    say $pod-item.raku;    # mutsu: $(Pod::Block::Named.new,)
+}
+```
+
+confirms two separate problems in mutsu's `$=pod` construction:
+
+1. Each top-level pod document element is wrapped an extra level deep in a 1-element `List`
+   instead of being the block object itself.
+2. `=head1 ...` (and presumably other `=headN` directives) produces a generic
+   `Pod::Block::Named` instead of the specific `Pod::Heading` type (with its `level`
+   attribute) that real Raku's Pod parser emits, and that block object has no `.contents`
+   method at all (since it's really a plain `List`, not a Pod block instance).
+
+## Affected files (starting point)
+
+- Wherever `$=pod` / the compile-time Pod-tree construction happens (grep for `Pod::Block`,
+  `"=pod"`, or the Pod-parsing pass in the parser/compiler) — needs to (a) not double-wrap
+  each top-level element in a `List`, and (b) special-case `=headN` blocks into a proper
+  `Pod::Heading` object carrying `level`/`config`/`contents`, matching the other already-
+  working `Pod::Block::*` types.

--- a/todo/tickets/dot-assign-target-keeps-definedness-smiley.md
+++ b/todo/tickets/dot-assign-target-keeps-definedness-smiley.md
@@ -1,0 +1,48 @@
+# `my Type:D $var .= new: ...` fails — dot-assign target keeps the `:D`/`:U` smiley in the type name
+
+Found by the doc-diff harness re-run (`docs/doc-diff-backlog.md`,
+`Type/Metamodel/Mixins.rakudoc:18,63`).
+
+## Minimal repro
+
+```raku
+class Billboard {
+    has Str $.advertisement;
+}
+my Billboard:D $billboard .= new: :advertisement("hi");
+say $billboard.advertisement;
+```
+
+- `raku`: prints `hi`.
+- `mutsu` (`target/debug/mutsu`): dies with
+  `X::Method::NotFound: Unknown method value dispatch (fallback disabled): new on Billboard:D`.
+
+Dropping the `:D` (`my Billboard $billboard .= new: ...;`) works fine, isolating the bug to
+the definedness smiley specifically combined with `.=`.
+
+## Root cause
+
+`--dump-ast` shows the declaration's `type_constraint` is stored as the whole string
+`"Billboard:D"` (smiley baked in), and `parse_my_decl_assign`'s `.=`-desugaring builds the
+implicit invocant straight from that string:
+
+```rust
+// src/parser/stmt/decl/my_decl_assign.rs, around line 654
+Some(c) => Expr::BareWord(c.clone()),
+```
+
+So `.= new: ...` desugars to `Billboard:D.new(...)` — a bareword lookup for a package
+literally named `"Billboard:D"`, which does not exist, instead of `Billboard.new(...)`.
+The array/hash-sigil arms just above it (lines 646-653) already build a *different* bareword
+string (`Array[c]`/`Hash[c]`) from the same `c`, so they'd have the identical bug for a typed
+`@`/`%` declaration too (e.g. `my Billboard:D @x .= new` would try `Array[Billboard:D]`) —
+worth checking/fixing alongside the scalar case.
+
+The type-constraint string needs its trailing `:D`/`:U`/`:_` smiley stripped before being
+used as a bareword type-name lookup here (the smiley is a definedness constraint on the
+*variable*, not part of the package name `.new` should resolve).
+
+## Affected files
+
+- `src/parser/stmt/decl/my_decl_assign.rs` — the `target_expr` match building the `.=`
+  implicit invocant from `s.type_constraint` (lines ~645-665).

--- a/todo/tickets/implicit-topic-block-signature-gist-wrong.md
+++ b/todo/tickets/implicit-topic-block-signature-gist-wrong.md
@@ -1,0 +1,33 @@
+# `.signature` of a bare `{;}` block (implicit `$_` parameter) gists wrong
+
+Found by the doc-diff harness re-run (`docs/doc-diff-backlog.md`, `Type/Block.rakudoc:17`).
+
+## Minimal repro
+
+```raku
+say {;}.signature;
+```
+
+- `raku`: `(;; $_? is raw = OUTER::<$_>)`
+- `mutsu` (`target/debug/mutsu`): `($$_?)`
+
+## Root cause hypothesis
+
+A block with no explicit parameter list (`{;}` — the `;` forces it to parse as a Block, not
+a Hash) gets an implicit `$_` parameter with these traits: optional (`?`), `is raw`, and
+defaulting to the outer `$_` (`= OUTER::<$_>`), placed in the *invocant* part of the
+signature (before the top-level `;;` separator, since it's an implicit self-like binding
+slot) — the doc's own gist format is `(;; $_? is raw = OUTER::<$_>)`.
+
+mutsu's `.signature` gist for this implicit-topic parameter renders as `($$_?)` — this looks
+like a garbled/malformed rendering (a stray extra `$`, missing the `is raw`/`OUTER::<$_>`
+default annotation, and not placed after the `;;` invocant-separator) rather than a
+deliberately different but equivalent representation. Likely the signature-gisting code has
+a generic path for named/positional parameters that doesn't special-case the synthetic
+implicit-`$_` parameter Raku attaches to a bare block.
+
+## Affected files (starting point)
+
+- Wherever a block's implicit `$_` parameter is synthesized (parser/compiler for bare
+  `{...}` blocks) and wherever `.signature`'s `.gist`/`.raku`/`.Str` renders a `Signature`
+  object (grep for `signature` gisting in `src/runtime/` or `src/builtins/`).

--- a/todo/tickets/readonly-variable-assign-uses-ro-instead-of-adhoc.md
+++ b/todo/tickets/readonly-variable-assign-uses-ro-instead-of-adhoc.md
@@ -1,0 +1,67 @@
+# Assigning to a readonly *variable*/binding throws `X::Assignment::RO` where raku throws `X::AdHoc`
+
+Found by the doc-diff harness re-run (`docs/doc-diff-backlog.md`, `Language/containers.rakudoc:137`
+and `Language/hashmap.rakudoc:504`).
+
+## Minimal repros
+
+```raku
+my $x := 42;
+$x = 23;
+CATCH { default { say .^name, ': ', .Str } };
+```
+- `raku`: `X::AdHoc: Cannot assign to an immutable value`
+- `mutsu`: `X::Assignment::RO: Cannot assign to a readonly variable (x) or a value`
+
+```raku
+my %answers = illuminatus => 23, hitchhikers => 42;
+for %answers.values -> $v { $v += 10 };
+CATCH { default { put .^name, ': ', .Str } };
+```
+- `raku`: `X::AdHoc: Cannot assign to a readonly variable or a value`
+- `mutsu`: `X::Assignment::RO: Cannot assign to a readonly variable (v) or a value`
+
+```raku
+# for comparison: a case where raku DOES use X::Assignment::RO
+my $a = 5;
+sub f($x) { $x = 10 }
+f($a);
+CATCH { default { say .^name, ": ", .Str } }
+```
+- `raku`: `X::AdHoc: Cannot assign to a readonly variable or a value` (also `X::AdHoc`!)
+
+```raku
+my constant PI = 3.14; PI = 5;
+CATCH { default { say .^name, ": ", .Str } }
+```
+- `raku`: `X::Assignment::RO: Cannot modify an immutable Rat (3.14)` (this one IS `X::Assignment::RO`)
+
+## Root cause hypothesis
+
+Real Raku distinguishes two different failure categories that mutsu currently conflates
+into one `X::Assignment::RO` error:
+
+- **Assigning through a readonly *binding*/alias with no writable container of its own**
+  (`:=`-bound literal, a non-`is rw` sub parameter, a `for`-loop variable iterating readonly
+  hash values) → real Raku throws the generic **`X::AdHoc`** with message "Cannot assign to
+  a readonly variable or a value" (or the containers.rakudoc-specific wording "Cannot assign
+  to an immutable value").
+- **Modifying an actually-immutable *value*** (a `constant`, a literal List/Array element)
+  → real Raku throws the specific **`X::Assignment::RO`** with a "Cannot modify an immutable
+  `TYPE` (`VALUE`)" message.
+
+mutsu appears to route every "can't assign to this" case through the same
+`X::Assignment::RO` handler regardless of which category applies, so a caller doing
+`CATCH { when X::AdHoc { ... } }` around, e.g., a `for %h.values -> $v { $v = ... }` typo
+would not catch mutsu's exception the way it catches real Raku's.
+
+## Affected files (starting point)
+
+- Wherever assignment to a non-writable lvalue throws `X::Assignment::RO` (grep
+  `X::Assignment::RO` in `src/vm/` and `src/runtime/`) — needs to distinguish "no backing
+  container at all" (readonly binding/alias/non-rw parameter/loop variable) from "backing
+  container refuses writes because the value itself is immutable" (constant, literal
+  list/array element), and throw `X::AdHoc` for the former.
+- Related, narrower finding already filed: [bind-scalar-literal-var-name-not-int.md](bind-scalar-literal-var-name-not-int.md)
+  (the `$b := 1; $b.VAR.^name` should be `Int` gap) — likely the same underlying "bind-to-
+  literal is not modeled as containerless" representation gap.


### PR DESCRIPTION
## Summary
- Batch5-B of the doc-diff campaign: re-ran the harness against `Type/SetHash`, `Type/Metamodel/Mixins`, `Type/BagHash`, `Language/pod`, `Language/containers`, `Language/hashmap`, `Type/Setty`, `Type/Block`, `Language/io-guide`, `Type/Proxy`, `Type/CompUnit/Repository/FileSystem`.
- Filed 8 new real bugs under `todo/tickets/` (dot-assign target keeping the `:D` smiley, `but`-mixin gist missing `+{Role}`, `BagHash.add`/`.remove` missing, `$=pod` items not proper `Pod::*` objects, `X::Assignment::RO` vs `X::AdHoc` for readonly bindings, bare-block `.signature` gist garbled, `:=`-bound Proxy from a sub call losing writability, `CompUnit::Repository::FileSystem.files` missing).
- Excluded hash/Set/BagHash iteration-order findings (verified nondeterministic against live raku), a `pod.rakudoc` duplicate of an already-filed `.WHY` stringification ticket, and an `io-guide.rakudoc` finding that's a downstream consequence of the already-filed `open :w, PATH` argument-parsing bug.
- Updated `docs/doc-diff-backlog.md` with the new "batch-5" ledger subsection.

## Test plan
- [x] Every finding re-verified directly against `raku -e`/a `tmp/*.raku` script and `target/debug/mutsu` before filing or excluding.
- [x] Docs-only change — CI's docs-only fast path should skip the heavy jobs.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>