### PR TITLE
docs: file 11 tickets from doc-diff batch-5 re-run (Routine/signatures/Cool/etc.)

### DIFF
--- a/docs/doc-diff-backlog.md
+++ b/docs/doc-diff-backlog.md
@@ -628,6 +628,54 @@ Found in the 2026-08-22 batch-5 re-run of `SetHash`/`Metamodel::Mixins`/`BagHash
   [open-named-adverb-before-positional-path.md](../todo/tickets/open-named-adverb-before-positional-path.md),
   not a separate bug; not re-filed.
 
+Found in the 2026-08-22 batch-5 re-run of `Routine`/`signatures`/`Cool`/`Metamodel::Documenting`/
+`Baggy`/`CallFrame`/`Slip`/`Buf`/`math`/`X::TypeCheck::Splice`/`HyperWhatever`:
+
+| file:line | one-line summary | ticket |
+|---|---|---|
+| `Type/Routine.rakudoc:29` | `&?ROUTINE.^name` inside a `submethod` reports `Method` instead of `Submethod` | [routine-submethod-routine-name-wrong.md](../todo/tickets/routine-submethod-routine-name-wrong.md) |
+| `Type/Routine.rakudoc:144` | `is cached` (`use experimental :cached`) doesn't memoize — every call re-executes the body | [is-cached-trait-not-caching.md](../todo/tickets/is-cached-trait-not-caching.md) |
+| `Type/Routine.rakudoc:231` | `sub ... is rw` returning an array/hash element as the implicit last statement doesn't produce a mutable container back to the caller (broad blast radius — narrowed to a 3-line minimal repro) | [is-rw-sub-implicit-return-element-not-mutable.md](../todo/deep/is-rw-sub-implicit-return-element-not-mutable.md) |
+| `Language/signatures.rakudoc:849` | single-argument-rule slurpy parameter (`+name`) always yields a plain `Array` instead of `List`/passing a `Seq` through unchanged | [single-arg-rule-slurpy-type-wrong.md](../todo/tickets/single-arg-rule-slurpy-type-wrong.md) |
+| `Language/signatures.rakudoc:1151,1159` | a sigilless parameter with an attached sub-signature (`\p(Int, Str)`) fails to parse; the sigiled equivalent (`@p (Int, Str)`) already works | [sigilless-param-sub-signature-parse-fails.md](../todo/tickets/sigilless-param-sub-signature-parse-fails.md) |
+| `Type/Cool.rakudoc:932` | `(0..0x1FFFF).sort(*.uniname.chars)` is ~18x slower than raku and times out under the harness's 10s budget (correct result, just too slow) | [uniname-sort-performance-gap.md](../todo/tickets/uniname-sort-performance-gap.md) |
+| `Type/Cool.rakudoc:1416` | `"foo".Rat` should return a `Failure` (matching `"foo".Num`'s error behavior); mutsu silently returns `Rat` `0` | [str-rat-coercion-should-fail.md](../todo/tickets/str-rat-coercion-should-fail.md) |
+| `Type/Metamodel/Documenting.rakudoc:30` | manual `Metamodel::ClassHOW.new_type`/`.compose` construction: `.HOW.set_why` after `.HOW.compose` fails with "Cannot modify an immutable ... type object" | [metamodel-how-set-why-after-compose-immutable.md](../todo/tickets/metamodel-how-set-why-after-compose-immutable.md) |
+| `Type/Baggy.rakudoc:197` | `classify-list` with an array mapper renders an out-of-range key as `Nil` instead of `(Any)` (plain `.classify` with a block mapper already gets this right) | [classify-list-array-mapper-out-of-range-shows-nil.md](../todo/tickets/classify-list-array-mapper-out-of-range-shows-nil.md) |
+| `Type/Slip.rakudoc:57` | `take \|($a, $b)` over-flattens like `.Slip`, instead of bundling the unpacked args into one `take`d `List` item | [take-pipe-slip-over-flattens.md](../todo/tickets/take-pipe-slip-over-flattens.md) |
+| `Type/Buf.rakudoc:84` | `subbuf-rw($buf, from, len) = value` (bare function-call form) silently doesn't mutate; the method-call form (`$buf.subbuf-rw(from, len) = value`) already works | [subbuf-rw-function-form-lvalue-not-mutating.md](../todo/tickets/subbuf-rw-function-form-lvalue-not-mutating.md) |
+| `Type/HyperWhatever.rakudoc:41` | `(**²)` — HyperWhatever (`**`) immediately followed by a postfix power operator — fails to parse; the single-`Whatever` equivalent (`*²`) already works | [hyperwhatever-postfix-power-parse-fails.md](../todo/tickets/hyperwhatever-postfix-power-parse-fails.md) |
+
+**Excluded from this batch-5 sub-run:**
+- `Type/Metamodel/Documenting.rakudoc` [1] (line 16, `#\|[...]`/`#=[...]` class-level declarator
+  comments, `say Documented.WHY`) — duplicate of the already-filed
+  `todo/tickets/pod-why-declarator-object-not-stringified.md` (same root cause: `Pod::Block::
+  Declarator`'s `.Str`/`.gist` isn't implemented; that ticket's repro uses a `sub`, this one a
+  `class`, but both hit the identical `Pod::Block::Declarator.new` gist fallback).
+- `Type/Baggy.rakudoc` [1], [4] (lines 43/355, `.grab`/`.hash` type-parameterization) —
+  `raku-drift-from-doc`: raku's own current output no longer matches the doc's `# OUTPUT` text
+  (floating precision / `Hash[UInt,Mu,Any]` vs the doc's stale `Hash[Any,Any]`), lower priority.
+- `Type/Baggy.rakudoc` [3] (line 293, `bag <eggs spam spam spam>; .kv`) — known Bag/Baggy
+  iteration-order false positive: verified non-determinism directly (3 fresh `raku` runs of the
+  identical program in this session all returned `(eggs 1 spam 3)`, which itself already
+  disagrees with the doc-diff harness's earlier-captured `(spam 3 eggs 1)` for the same command
+  in the same session — confirming per-process hash-seed nondeterminism, not a mutsu bug).
+- `Type/CallFrame.rakudoc` [1] (line 76, statement-form `FIRST $frame = callframe; ...; say
+  $frame.code()`) — matches the file's own already-documented Deferred residue exactly (`Code.new`
+  vs mutsu's `(Block)`; see the "CallFrame frame modeling" entry above).
+- `Type/CallFrame.rakudoc` [2] (line 122, `$frame.my<$the-answer>`) — `raku-drift-from-doc`: raku's
+  actual output is `(LoweredAwayLexical)`, not the doc's stale `42`.
+- `Language/math.rakudoc` [1] (line 185, golden-ratio continued-fraction `1 + 1 / * ... *` indexed
+  at `@phis[200]`) — narrowed the failure to `@phis[N]` returning `(Any)` for `N` somewhere in
+  `30..35` (works through at least `N=30`, fails by `N=35`), which is exactly where the
+  self-referential Rat/FatRat continued-fraction's numerator/denominator would first need
+  bigint magnitude beyond `i64` — matches the already-**Deferred** Lazy-list cluster's "big-Int→
+  Float degradation in geometric sequence generation past i64" residue.
+- `Type/X/TypeCheck/Splice.rakudoc` [1] (line 30, `use experimental :macros; macro an-ast {
+  quasi { 'yes AST' } }`) — matches the already-tracked deep `macro`/`quasi`/unquote design work
+  in `todo/deep/rakuast-remaining.md`'s "Macros" section (same cluster already excluded for
+  `Language/experimental.rakudoc` in the batch-3 sub-run above); not re-ticketed.
+
 ### Deferred / deep (tracked elsewhere — do not re-open as a shallow slice)
 These root causes account for a large share of the survey's `mism`/`crash` and are
 intentionally deferred; see PLAN.md §8.5 and the ADRs:

--- a/todo/deep/is-rw-sub-implicit-return-element-not-mutable.md
+++ b/todo/deep/is-rw-sub-implicit-return-element-not-mutable.md
@@ -1,0 +1,97 @@
+# `sub ... is rw` returning an array/hash element (implicit return) doesn't produce a mutable container
+
+Found by the doc-diff harness re-run (`docs/doc-diff-backlog.md`, `Type/Routine.rakudoc:231`).
+
+## Original repro (from the doc)
+
+```raku
+sub walk(\thing, *@keys) is rw {
+    my $current := thing;
+    for @keys -> $k {
+        if $k ~~ Int {
+            $current := $current[$k];
+        }
+        else {
+            $current := $current{$k};
+        }
+    }
+    $current;
+}
+
+my %hash;
+walk(%hash, 'some', 'key', 1, 2) = 'autovivified';
+say %hash<some><key>[1][2];
+```
+
+- raku: `autovivified`
+- mutsu: `(Any)` — the assignment through the `is rw` sub's return value is silently lost.
+
+## Minimal repro (much narrower than it first looks)
+
+The bug is **not** about `for`-loop rebinding, sigilless `\thing` binding, or autovivification
+specifically. It reproduces with a plain sigiled parameter and a single hash-element read as the
+sub's last (implicit-return) statement:
+
+```raku
+sub walk(%h) is rw {
+    %h<some>;
+}
+my %hash = some => 1;
+walk(%hash) = "val";
+say %hash<some>;   # raku: val   mutsu: 1 (unchanged)
+```
+
+And the same for an array element:
+
+```raku
+sub walk(@a) is rw {
+    @a[0];
+}
+my @arr = 1,2,3;
+walk(@arr) = 99;
+say @arr;          # raku: [99 2 3]   mutsu: [1 2 3] (unchanged)
+```
+
+Both cases: assigning to the call result of an `is rw` sub whose implicit return value is a
+hash/array element (whether or not the key/index previously existed) does not write back to the
+original container. mutsu accepts the assignment silently (exit 0, no error) and just discards
+it — this is a correctness bug, not a missing-feature error.
+
+Contrast: an `is rw` sub that returns a *sigilless-bound alias to the parameter itself*
+(`sub walk(\thing) is rw { thing }`) DOES work correctly — the container link survives when the
+returned expression is the bound term with no indexing on the way out. It's specifically the
+"index into the container as the returned expression" shape that loses mutability, whether that
+indexing happens directly (`%h<some>` as the last statement) or through an intermediate `:=`
+rebind (`my $b := %h<some>; $b`).
+
+## Why this is `todo/deep` and not a ticket
+
+This appears to be a general gap in how `is rw`'s "return a mutable container" contract is
+plumbed through the compiler/VM for the *implicit last-expression return* path when that
+expression is an array/hash element access — as opposed to `return-rw` (tracked separately,
+see `todo/tickets/control-return-rw-not-mutable.md`, which covers the explicit `return-rw`
+statement and appears to be a different code path/bug). Because `is rw` + implicit return of an
+indexed element is an extremely common idiom (accessor-style routines, `walk`-style container
+descent, `Buf`'s own `subbuf-rw` per-element helpers), this plausibly has a wide, currently
+unmeasured blast radius across roast and real-world code — it needs a proper investigation of
+how rw-ness is tracked from "last expression in an `is rw` sub body" through the call-return
+path to the caller's assignment target, not a narrow patch for one shape.
+
+## Related but distinct findings (do not conflate when fixing)
+
+- `todo/tickets/control-return-rw-not-mutable.md` — explicit `return-rw $a` on a plain scalar
+  lexical doesn't propagate mutability either; likely the same underlying rw-container-return
+  plumbing gap, but confirm before assuming a single fix covers both.
+- `Type/Buf.rakudoc:84` (`subbuf-rw($buf, from, len) = value` as a **function-call form**, not
+  a method call) also fails to mutate — but that one is root-caused separately (an env
+  identity-search lookup for the target variable, see
+  `todo/tickets/subbuf-rw-function-form-lvalue-not-mutating.md`) and should NOT be assumed to
+  share a fix with this ticket without checking.
+
+## Affected files (starting point)
+
+- `src/runtime/calls.rs` / `src/vm/vm_call_ops.rs` — return-value handling and `rw`/mutable-flag
+  propagation for the implicit (fall-through) last-statement return path.
+- Whatever marks a returned `Value` as "safe to assign through" (a `ContainerRef`/Proxy-like
+  wrapper) for `is rw` subs — compare how it's produced for a bare returned variable (works, per
+  `sub walk(\thing) is rw { thing }`) vs. an indexed element read (broken).

--- a/todo/tickets/classify-list-array-mapper-out-of-range-shows-nil.md
+++ b/todo/tickets/classify-list-array-mapper-out-of-range-shows-nil.md
@@ -1,0 +1,47 @@
+# `classify-list` with an array mapper renders an out-of-range key as `Nil` instead of `(Any)`
+
+Found by the doc-diff harness re-run (`docs/doc-diff-backlog.md`, `Type/Baggy.rakudoc:197`).
+
+## Repro
+
+```raku
+my @mapper = <zero one two three four five>;
+say MixHash.new.classify-list: @mapper, 1, 2, 3, 4, 4, 6;
+```
+
+- raku: `MixHash((Any) four(2) one three two)` — index `6` is out of range for `@mapper`
+  (valid indices `0..5`), so its classifier key is the `Any` type object, gisted as `(Any)`.
+- mutsu: `MixHash(Nil four(2) one three two)` — same element ordering and counts, but the
+  out-of-range key renders as `Nil` instead of `(Any)`.
+
+## Isolating the root cause
+
+A direct out-of-bound array read is correct on its own:
+
+```raku
+my @mapper = <zero one two three four five>;
+say @mapper[6];            # mutsu: (Any)  -- correct
+say @mapper[6].^name;      # mutsu: Any    -- correct
+```
+
+And `.classify` with an explicit block mapper is also correct:
+
+```raku
+say (1, 2, 3, 4, 4, 6).classify: { @mapper[$_] };
+# mutsu: {(Any) => [6], four => [4 4], one => [1], three => [3], two => [2]}   -- correct
+```
+
+So the bug is specific to `classify-list`'s **array-as-mapper** form (`classify-list: @mapper,
+LIST`, as opposed to `classify: BLOCK, LIST` or `classify-list: BLOCK, LIST`). This suggests
+`classify-list`'s array-mapper implementation substitutes a literal `Nil` for an out-of-range
+index result instead of using the array element read it actually got (which would already be
+the correct `Any` type object, per the two working cases above) — likely a `@mapper[$_] //
+Nil`-shaped defensive fallback where none should exist, or a distinct code path that doesn't
+reuse the plain indexed-read logic at all.
+
+## Affected files (starting point)
+
+- `classify-list` implementation (likely `runtime/methods.rs` or a dedicated
+  classify/categorize helper) — find the array-mapper branch specifically (as opposed to the
+  block-mapper branch, which is correct) and look for a `Nil`-substituting fallback on missing
+  array indices.

--- a/todo/tickets/hyperwhatever-postfix-power-parse-fails.md
+++ b/todo/tickets/hyperwhatever-postfix-power-parse-fails.md
@@ -1,0 +1,56 @@
+# `(**²)` — HyperWhatever followed directly by a postfix power operator — fails to parse
+
+Found by the doc-diff harness re-run (`docs/doc-diff-backlog.md`, `Type/HyperWhatever.rakudoc:41`).
+
+## Repro
+
+```raku
+say (**²)(1, 2, 3, 4, 5);   # OUTPUT: «(1 4 9 16 25)␤»
+```
+
+- raku: `(1 4 9 16 25)`
+- mutsu: parse error —
+  ```
+  ===SORRY!=== Error while compiling
+  Confused. expected statement: expected '.' or digits or generic radix literal or unicode
+  numeric literal or declared term symbol or ...
+  at ...:1
+  ------>say (**²)(1, 2, 3, 4, 5);
+  ```
+
+## Isolating the root cause
+
+The single-`Whatever` equivalent already works:
+
+```raku
+say (*²)(3);   # mutsu: 9 -- correct
+```
+
+And `**` (HyperWhatever) parses fine as a bare term in most positions:
+
+```raku
+my $h = **;      say $h.^name;   # mutsu: HyperWhatever -- OK
+my $h = (**);    say $h.^name;   # mutsu: HyperWhatever -- OK
+say (**).^name;                  # mutsu: HyperWhatever -- OK
+```
+
+But `**` immediately followed by the postfix superscript-power operator fails even without the
+outer call-parens:
+
+```raku
+my $h = **²; say $h.^name;
+# mutsu: Runtime error: X::Syntax::Malformed: Malformed initializer
+```
+
+So the bug is narrowly: the term parser recognizes a postfix `²`/`³`/etc. superscript operator
+immediately following `*` (single Whatever), but not immediately following `**`
+(HyperWhatever) — likely because `**` is tokenized/consumed by the exponentiation-operator
+lexing path in that position (expecting a right-hand operand) rather than being recognized as
+the two-character HyperWhatever term first, the same way single `*` is checked for a trailing
+postfix power glyph before being treated as an infix/prefix operator elsewhere.
+
+## Affected files (starting point)
+
+- Term/prefix parsing for `*` (Whatever) and `**` (HyperWhatever) — locate where a trailing
+  Unicode superscript digit (`²`, `³`, `⁴`, ...) is recognized as a postfix power operator after
+  `*`, and extend the same check to run after consuming `**` as a HyperWhatever term.

--- a/todo/tickets/is-cached-trait-not-caching.md
+++ b/todo/tickets/is-cached-trait-not-caching.md
@@ -1,0 +1,39 @@
+# `is cached` trait does not memoize — every call re-executes the body
+
+Found by the doc-diff harness re-run (`docs/doc-diff-backlog.md`, `Type/Routine.rakudoc:144`).
+
+## Repro
+
+```raku
+use experimental :cached;
+
+sub nth-prime(Int:D $x where * > 0) is cached {
+    say "Calculating {$x}th prime";
+    return (2..*).grep(*.is-prime)[$x - 1];
+}
+
+say nth-prime(43);
+say nth-prime(43);
+say nth-prime(43);
+```
+
+- raku: prints `Calculating 43th prime` once, then `191` three times (the second and third
+  calls hit the cache and skip the body, including the `say`).
+- mutsu: prints `Calculating 43th prime` / `191` three times — every call re-executes the full
+  body, i.e. the `is cached` trait has no effect.
+
+## Root cause hypothesis
+
+`is cached` (gated behind `use experimental :cached`) should wrap the routine so subsequent
+calls with identical arguments look up a per-signature cache keyed by the argument values and
+return the memoized result without re-invoking the body. mutsu likely does not implement this
+trait at all — it is probably accepted as a no-op unknown trait (parses fine, has zero runtime
+effect) rather than wiring an actual memoization wrapper around the compiled sub.
+
+## Affected files (starting point)
+
+- Trait registration/dispatch for routine traits (`is rw`, `is pure`, etc.) — grep for how
+  `is rw`/`is pure` are recognized on a `sub`/`method` declaration to find where a new `is
+  cached` case would plug in.
+- Needs a real memoization cache (keyed by argument values, presumably per-declaration-site),
+  not a stub — this is a genuine caching feature, not cosmetic.

--- a/todo/tickets/metamodel-how-set-why-after-compose-immutable.md
+++ b/todo/tickets/metamodel-how-set-why-after-compose-immutable.md
@@ -1,0 +1,58 @@
+# Manual `Metamodel::ClassHOW` construction: `.HOW.set_why` after `.HOW.compose` fails as "immutable"
+
+Found by the doc-diff harness re-run (`docs/doc-diff-backlog.md`, `Type/Metamodel/Documenting.rakudoc:30`).
+
+## Repro
+
+```raku
+BEGIN {
+    our Mu constant Documented = Metamodel::ClassHOW.new_type: :name<Documented>;
+    Documented.HOW.compose: Documented;
+    Documented.HOW.set_why: do {
+        my Pod::Block::Declarator:D $pod .= new;
+        $pod._add_leading:  "Documented is an example class for Metamodel::Documenting's documentation.";
+        $pod._add_trailing: "Take a look at my WHY!";
+        $pod
+    };
+}
+
+say Documented.HOW.WHY;
+```
+
+- raku:
+  ```
+  Documented is an example class for Metamodel::Documenting's documentation.
+  Take a look at my WHY!
+  ```
+- mutsu:
+  ```
+  Runtime error: An exception occurred while evaluating a CHECK
+  Exception details:
+    Cannot modify an immutable 'Documented' type object
+  ```
+
+## Root cause hypothesis
+
+This is manual, low-level MOP construction: `Metamodel::ClassHOW.new_type` builds a raw type
+object, `.HOW.compose` finalizes/locks it in, and `.HOW.set_why` attaches documentation
+metadata to the **HOW (metaclass)** object, not to the type object's own attribute storage —
+`set_why` is expected to remain callable after `compose` because it mutates the meta-level
+`HOW`, which is a separate, still-mutable object from the composed type. mutsu's `compose`
+implementation (or its generic "can I write to this?" immutability check) appears to treat
+*any* subsequent `.HOW.*` mutator call on a composed type as forbidden, rather than
+distinguishing "mutating the type object's own instance data" (correctly blocked post-compose)
+from "mutating metadata held by the HOW object" (should remain allowed for things like
+`set_why`).
+
+Note: this is a distinct bug from the more common `.WHY` stringification gap already tracked in
+`todo/tickets/pod-why-declarator-object-not-stringified.md` (that ticket covers `Pod::Block::
+Declarator.Str`/`.gist` for the normal `#|`/`#=` declarator-comment path; this one is about the
+manual `Metamodel::ClassHOW` construction path rejecting `set_why` outright before
+stringification is even reached).
+
+## Affected files (starting point)
+
+- Wherever `.HOW.compose`/type-object immutability is enforced (`runtime/class.rs` or the MOP
+  implementation) — find the "is this composed/immutable" check that `set_why` (and possibly
+  other post-compose `HOW` mutators) trips over, and confirm whether raku's actual semantics
+  intentionally exempt metadata-only mutators like `set_why` from the post-compose lock.

--- a/todo/tickets/routine-submethod-routine-name-wrong.md
+++ b/todo/tickets/routine-submethod-routine-name-wrong.md
@@ -1,0 +1,32 @@
+# `&?ROUTINE.^name` inside a `submethod` reports `Method` instead of `Submethod`
+
+Found by the doc-diff harness re-run (`docs/doc-diff-backlog.md`, `Type/Routine.rakudoc:29`).
+
+## Repro
+
+```raku
+class Foo {
+    submethod bar { &?ROUTINE.^name }
+};
+say Foo.bar;
+```
+
+- raku: `Submethod`
+- mutsu: `Method`
+
+## Root cause hypothesis
+
+`&?ROUTINE` resolves to the currently-executing routine's `Code`-family object, and `.^name`
+reports its dynamic type. mutsu's `submethod` declarations appear to construct (or tag)
+`&?ROUTINE`'s underlying value as a plain `Method` rather than as a `Submethod`, so the
+metaclass name comes back wrong even though a `submethod` otherwise dispatches and behaves
+correctly (it's the introspected type identity that's off, not the call itself).
+
+## Affected files (starting point)
+
+- Wherever `&?ROUTINE` is bound in the routine's compiled prologue (search for `ROUTINE` in
+  `compiler/`/`vm/vm_register_ops.rs`) — check whether it always tags the closure/routine value
+  as `Method`, or whether `submethod` registration itself doesn't record a distinct
+  `Submethod`-typed routine object for `.^name` to report.
+- `runtime/class.rs` — submethod registration, to compare against how `Method` is tagged for a
+  regular `method`.

--- a/todo/tickets/sigilless-param-sub-signature-parse-fails.md
+++ b/todo/tickets/sigilless-param-sub-signature-parse-fails.md
@@ -1,0 +1,56 @@
+# Sigilless parameter with an attached sub-signature (`\p(Int, Str)`) fails to parse
+
+Found by the doc-diff harness re-run (`docs/doc-diff-backlog.md`, `Language/signatures.rakudoc:1151` and `:1159`).
+
+## Repro 1
+
+```raku
+sub foo(\p(Int, Str)){
+   put "called with {p.raku}"
+};
+foo((42, "answer"));
+```
+
+- raku: `called with (42, "answer")`
+- mutsu: parse error —
+  ```
+  ===SORRY!=== Error while compiling
+  Confused. expected statement: expected ')'
+  at ...:1
+  ------>sub foo(\p(Int, Str)){
+         ^
+  ```
+
+## Repro 2
+
+```raku
+sub bar(\p(Int $y where * > 5, Str $s?, *%h)) { put p.raku; put $s // "undefined"; }
+bar((42, life => 40, universe => 41));
+```
+
+- raku: `(42, :life(40), :universe(41))` then `undefined`
+- mutsu: same parse error shape as above.
+
+## Root cause hypothesis
+
+A parameter's attached sub-signature (destructuring the argument, e.g. `@p (Int, Str)` for a
+sigiled positional) already parses correctly for sigiled parameters — confirmed working:
+
+```raku
+sub foo(@p (Int, Str)){ put "called with {@p.raku}" };
+foo((42, "answer"));   # mutsu: called with (42, "answer")  -- OK
+```
+
+So sub-signature parsing itself exists (`ParamDef.sub_signature` per
+`todo/tickets/parameter-sub-signature-and-modifier-attrs-missing.md`, which covers a *different*
+gap — the `.sub_signature`/`.modifier` reflection accessors on `Parameter`, not this parse
+failure). The bug here is narrower: the parser doesn't recognize a sub-signature immediately
+following a **sigilless** (`\name`) parameter — `\p(Int, Str)` — even though the sigiled form
+`@p (...)` works. Likely the sigilless-parameter parsing path doesn't call into the same
+"check for a following `(` sub-signature" logic that the sigiled-parameter path uses.
+
+## Affected files (starting point)
+
+- Parameter/signature parsing in `src/parser/` — locate where a sigiled parameter's optional
+  sub-signature `(...)` is recognized after the parameter name, and where sigilless (`\name`)
+  parameters are parsed, to see why the latter doesn't check for the same trailing `(`.

--- a/todo/tickets/single-arg-rule-slurpy-type-wrong.md
+++ b/todo/tickets/single-arg-rule-slurpy-type-wrong.md
@@ -1,0 +1,33 @@
+# Single-argument-rule slurpy parameter (`+name`) yields `Array`, not `List`/`Seq`
+
+Found by the doc-diff harness re-run (`docs/doc-diff-backlog.md`, `Language/signatures.rakudoc:849`).
+
+## Repro
+
+```raku
+sub zipi( +zape ) {
+    zape.^name => zape
+};
+say zipi( "Hey " );  # raku: List => (Hey )     mutsu: Array => [Hey ]
+say zipi( 1...* );   # raku: Seq => (...)        mutsu: Array => [(...)]
+```
+
+- raku: the single-argument rule (`+name`) binds a single non-list argument as a 1-element
+  `List`, and passes an already-list-like argument (e.g. a `Seq`) through unchanged (its
+  original type, here `Seq`).
+- mutsu: always produces a plain `Array` regardless of the argument's actual/original type.
+
+## Root cause hypothesis
+
+mutsu's `+name` slurpy parameter handling likely reuses the same "collect into an `Array`"
+logic as the ordinary `*@name` slurpy, without implementing the single-argument-rule's actual
+semantics: wrap a lone non-list scalar argument in a `List` (not `Array`), and pass an
+already-List/Seq-shaped single argument through by reference/identity (preserving its dynamic
+type) rather than re-collecting it into a fresh container.
+
+## Affected files (starting point)
+
+- Signature-binding code that recognizes `+name` slurpy parameters (grep for `"+"` sigil
+  handling alongside `*@`/`*%` slurpy binding in `src/compiler/` or `src/runtime/` signature
+  binding) — needs to special-case single-argument-rule collection instead of routing through
+  the generic array-slurpy path.

--- a/todo/tickets/str-rat-coercion-should-fail.md
+++ b/todo/tickets/str-rat-coercion-should-fail.md
@@ -1,0 +1,33 @@
+# `"non-numeric-string".Rat` should return a `Failure`, mutsu returns `Rat` `0`
+
+Found by the doc-diff harness re-run (`docs/doc-diff-backlog.md`, `Type/Cool.rakudoc:1416`).
+
+## Repro
+
+```raku
+say "foo".Rat.^name;   # raku: Failure   mutsu: Rat
+say "foo".Rat;         # raku: dies when sunk (Failure); mutsu: prints 0
+```
+
+Contrast with `.Num`, which already fails correctly on both:
+
+```raku
+say "foo".Num;
+# raku:  Cannot convert string to number: base-10 number must begin with valid digits or '.' ...
+# mutsu: Cannot convert string to number: base-10 number must begin with valid digits or '.' ...  -- matches
+```
+
+## Root cause hypothesis
+
+`Str.Rat` coercion on a non-numeric string should produce a `Failure` (a lazily-thrown
+exception carrier), matching `Str.Num`'s behavior of raising a conversion error. mutsu's `.Rat`
+coercion path for `Str` likely falls back silently to `0/1` (or similar) on a parse failure
+instead of routing through the same failure/error path `.Num` already uses correctly — i.e. the
+`.Rat` string-parsing code has its own separate, more lenient numeric-parse fallback that
+swallows the error instead of reusing (or delegating to) `.Num`'s strict parser.
+
+## Affected files (starting point)
+
+- `Str`/`Cool` `.Rat` coercion method — likely in `builtins/methods_0arg/` or
+  `runtime/builtins_*` numeric-coercion code; compare against the `.Num` implementation's
+  error path to find where `.Rat` diverges into a silent zero-fallback.

--- a/todo/tickets/subbuf-rw-function-form-lvalue-not-mutating.md
+++ b/todo/tickets/subbuf-rw-function-form-lvalue-not-mutating.md
@@ -1,0 +1,45 @@
+# `subbuf-rw($buf, from, len) = value` (function-call form) silently doesn't mutate
+
+Found by the doc-diff harness re-run (`docs/doc-diff-backlog.md`, `Type/Buf.rakudoc:84`).
+
+## Repro
+
+```raku
+my Buf $b .= new(1,2,3);
+subbuf-rw($b,2,1) = Buf.new(42);
+say $b.raku;
+```
+
+- raku: `Buf.new(1,2,42)`
+- mutsu: `Buf.new(1,2,3)` (exit 0, no error — the assignment is silently a no-op)
+
+## Isolating the root cause
+
+The **method-call form** already works correctly:
+
+```raku
+my Buf $b .= new(1,2,3);
+$b.subbuf-rw(2,1) = Buf.new(42);
+say $b.raku;   # mutsu: Buf.new(1,2,42)  -- correct
+```
+
+So only the bare **function-call form** (`subbuf-rw($buf, from, len) = value`, no leading `.`)
+is broken, even though mutsu does have dedicated handling for it: `src/runtime/
+builtins_lvalue.rs` (~line 451-480) special-cases `name == "subbuf-rw"` in an lvalue-assignment
+context, and tries to resolve the target variable by scanning `self.env` for an entry whose
+value is `values_identical` to `call_args[0]`, then delegates to
+`assign_method_lvalue_with_values(target_var, target, "subbuf-rw", ...)`. That delegation
+appears to silently no-op when it can't establish where to write back — worth checking whether
+the identity search actually finds `$b` (it should, since `$b` is a plain top-level lexical)
+or whether the write-back happens but doesn't reach the actual `env` slot/local slot mutsu's
+dual `locals`/`env` store needs updated. Compare against the working `substr-rw` function-form
+sibling case (same file, lines ~420-449) to see whether it has the identical bug or genuinely
+differs.
+
+## Affected files
+
+- `src/runtime/builtins_lvalue.rs` (~line 451-480) — the `subbuf-rw`-as-function lvalue special
+  case.
+- `src/runtime/methods_mut_substr_buf.rs` — `assign_subbuf_rw`, the actual mutation logic
+  reused by both the method-form (working) and function-form (broken) call sites; confirm it's
+  being invoked at all for the function form, and with the right target reference.

--- a/todo/tickets/take-pipe-slip-over-flattens.md
+++ b/todo/tickets/take-pipe-slip-over-flattens.md
@@ -1,0 +1,46 @@
+# `take |($a, $b)` over-flattens like `.Slip`, instead of bundling into one `take`d item
+
+Found by the doc-diff harness re-run (`docs/doc-diff-backlog.md`, `Type/Slip.rakudoc:57`).
+
+## Repro
+
+```raku
+my \l = gather for 1..10 -> $a, $b { take |($a, $b) }; say l.raku;
+# raku:  ((1, 2), (3, 4), (5, 6), (7, 8), (9, 10)).Seq
+# mutsu: (1, 2, 3, 4, 5, 6, 7, 8, 9, 10).Seq
+
+my \m = gather for 1..10 -> $a, $b { take ($a, $b).Slip }; say m.raku;
+# raku:  (1, 2, 3, 4, 5, 6, 7, 8, 9, 10).Seq
+# mutsu: (1, 2, 3, 4, 5, 6, 7, 8, 9, 10).Seq   -- this one already matches
+```
+
+Minimal isolation:
+
+```raku
+my \l = gather { take |(1,2) }; say l.raku;
+# raku:  ((1, 2),).Seq   -- take() got 2 positional args, bundled into one List item
+# mutsu: (1, 2).Seq      -- treated as if take() got 2 separate items (Slip-like over-flatten)
+```
+
+## Root cause hypothesis
+
+`|(...)` (the flattening prefix) in an argument-list position unpacks the list into multiple
+*positional arguments to the call* — so `take |($a, $b)` is equivalent to `take($a, $b)`, i.e.
+one call to `take` with 2 positional arguments. `take` with multiple positional arguments
+bundles them into a single taken `List` item (matching how `take` treats its argument list in
+general), which is a different operation from `.Slip`, which flattens *values already produced*
+directly into the enclosing sequence as separate items. mutsu appears to treat both forms
+identically — likely by resolving `|(...)` all the way down to a runtime Slip value that then
+gets flattened by `take`/`gather`'s take-collection logic, rather than expanding `|(...)` at
+the call-argument level before `take` ever sees a single combined value.
+
+## Affected files (starting point)
+
+- The `|` (flattening) prefix-operator's argument-expansion logic at call sites — confirm
+  whether it currently produces a runtime `Slip` value passed as `take`'s single argument
+  (wrong for this case) instead of expanding into N separate positional arguments to `take` at
+  compile/call time (which `take`'s own multi-arg-bundling logic would then combine correctly).
+- `take`'s multi-argument handling (`runtime/` gather/take implementation) — confirm it already
+  bundles multiple explicit positional args into one List item (as the working `.Slip` case's
+  contrast suggests it does for the direct-args case), so the fix is likely isolated to the `|`
+  expansion, not `take` itself.

--- a/todo/tickets/uniname-sort-performance-gap.md
+++ b/todo/tickets/uniname-sort-performance-gap.md
@@ -1,0 +1,42 @@
+# `.sort(*.uniname.chars)` over the full Unicode range is ~18x slower than raku (times out)
+
+Found by the doc-diff harness re-run (`docs/doc-diff-backlog.md`, `Type/Cool.rakudoc:932`).
+
+## Repro
+
+```raku
+say (0..0x1FFFF).sort(*.uniname.chars)[*-1].chr.uniname;
+# OUTPUT: «BOX DRAWINGS LIGHT DIAGONAL UPPER CENTRE TO MIDDLE RIGHT AND MIDDLE LEFT TO LOWER CENTRE␤»
+```
+
+Both produce the correct output — this is a pure performance finding, not a correctness bug.
+The doc-diff harness's default 10s timeout classifies it as a crash (`exit 124`), but it's
+really "too slow", not "wrong" or "hangs forever":
+
+- `raku`: completes in **~0.7s** wall clock.
+- `mutsu` (`target/debug/mutsu`, debug build): completes in **~12.5s** wall clock — correct
+  result, just far too slow. (No release-build measurement was taken; a release build would
+  likely still be several seconds, i.e. a real multi-x gap even after accounting for
+  debug-vs-release overhead, not just a debug-build artifact.)
+
+## Root cause hypothesis
+
+`.sort(*.uniname.chars)` sorts 131072 (`0x20000`) elements with a block comparator that calls
+`.uniname` (a Unicode character-name lookup) and `.chars` on each comparison. If mutsu
+re-evaluates the comparator block (and therefore re-computes `.uniname`) on every pairwise
+comparison during the sort, rather than computing each element's sort key once up front
+(Schwartzian-transform-style decorate/sort/undecorate, which is how `.sort(&block)` should be
+implemented for a single-argument block — the argument is a *key extractor*, not a
+comparator), that would explain an O(n log n) *comparator calls* × (redundant `.uniname` cost)
+blowup relative to raku's presumably-cached-or-key-extracted approach. Worth checking:
+1. Whether `.sort(&block)` with a 1-arity block computes the sort key once per element
+   (cache) or recomputes it on every comparison.
+2. Whether `.uniname` itself has an avoidable per-call cost (e.g., scanning a table linearly
+   instead of an indexed/hashed lookup) that would compound either way.
+
+## Affected files (starting point)
+
+- `.sort` implementation for a single-arg (key-extractor) block — likely in
+  `runtime/methods.rs` or a dedicated sort helper; check whether it does one key-computation
+  pass or repeatedly invokes the block during comparisons.
+- `.uniname` implementation in `builtins/unicode.rs` (or similar) — check lookup complexity.


### PR DESCRIPTION
## Summary
- Re-ran the doc-diff harness against `Type/Routine`, `Language/signatures`, `Type/Cool`, `Type/Metamodel/Documenting`, `Type/Baggy`, `Type/CallFrame`, `Type/Slip`, `Type/Buf`, `Language/math`, `Type/X/TypeCheck/Splice`, and `Type/HyperWhatever`, and triaged every reported mismatch/crash directly against `raku`.
- Filed 11 new findings under `todo/tickets/` (10) and `todo/deep/` (1, the `is rw` implicit-return-of-element bug given its likely blast radius).
- Excluded a duplicate of an existing ticket, raku-drift, a known Bag/Baggy iteration-order false positive, an already-documented CallFrame residue, the already-Deferred lazy-list big-Int-past-i64 cluster, and the already-tracked macro/quasi design work.
- Updated `docs/doc-diff-backlog.md` with the new batch-5 sub-run subsection (table + exclusions).

## Test plan
- [x] Docs-only change; no code touched — CI's docs-only fast path should skip the heavy jobs.