### PR TITLE
docs: file 11 doc-diff findings from batch5-C re-run

### DIFF
--- a/docs/doc-diff-backlog.md
+++ b/docs/doc-diff-backlog.md
@@ -676,6 +676,49 @@ Found in the 2026-08-22 batch-5 re-run of `Routine`/`signatures`/`Cool`/`Metamod
   in `todo/deep/rakuast-remaining.md`'s "Macros" section (same cluster already excluded for
   `Language/experimental.rakudoc` in the batch-3 sub-run above); not re-ticketed.
 
+Found in the 2026-08-22 batch-5 re-run of `Test`/`Metamodel::EnumHOW`/`Sub`/`ipc`/`numerics`/
+`contexts`/`Sequence`/`Bag`/`haskell-to-p6`/`PositionalBindFailover`/`using-modules::code`:
+
+| file:line | one-line summary | ticket |
+|---|---|---|
+| `Type/Test.rakudoc:323` | regex char class `<.-:letter-:digit>` (dot base + two chained `-` subtractions) matches everything instead of subtracting | [charclass-dot-base-chained-subtraction-broken.md](../todo/tickets/charclass-dot-base-chained-subtraction-broken.md) |
+| `Type/Test.rakudoc:400` | `.isa(Numeric)` (and other roles) wrongly returns `True` — `isa_check` conflates nominal class hierarchy with role composition | [isa-conflates-roles-with-nominal-supertypes.md](../todo/deep/isa-conflates-roles-with-nominal-supertypes.md) |
+| `Type/Test.rakudoc:586` | `throws-like`'s `message =>`/`gist =>` matchers are silently skipped when the thrown exception is `X::AdHoc` (e.g. from `fail`/`die` with a string) | [throws-like-message-matcher-skipped-for-adhoc-exception.md](../todo/tickets/throws-like-message-matcher-skipped-for-adhoc-exception.md) |
+| `Type/Metamodel/EnumHOW.rakudoc:139,148,157` | `EnumHOW` is missing `.^enum_values`/`.^enum_from_value` (No such method) and `.^elems` (deterministic stack overflow) | [enumhow-missing-enum-values-elems-enum-from-value.md](../todo/tickets/enumhow-missing-enum-values-elems-enum-from-value.md) |
+| `Type/Sub.rakudoc:19` | a user `sub Int(...)` wrongly shadows the built-in `Int(...)` type-coercion call syntax (only `&Int(...)` should reach it) | [user-sub-named-int-shadows-builtin-coercion-call.md](../todo/tickets/user-sub-named-int-shadows-builtin-coercion-call.md) |
+| `Type/Sub.rakudoc:78` | `is foo[1,2,3]` custom variable-trait bracket-argument sugar is misparsed as `is Set[Int]`-style type parameterization, folding the args into the (bogus) trait name | [variable-trait-bracket-argument-misparsed-as-type-param.md](../todo/tickets/variable-trait-bracket-argument-misparsed-as-type-param.md) |
+| `Language/ipc.rakudoc:14` | `run`/`shell` discard the child's stdout/stderr by default (`Stdio::null()`) instead of inheriting the parent's | [run-shell-discard-stdout-stderr-by-default.md](../todo/deep/run-shell-discard-stdout-stderr-by-default.md) |
+| `Language/numerics.rakudoc:353` | calling `.^name` on a `MAIN`-bound `IntStr` argument corrupts a later, unrelated `IntStr.new(...).^name` (reports `Str`) | [main-allomorph-arg-name-corrupts-later-intstr-new.md](../todo/tickets/main-allomorph-arg-name-corrupts-later-intstr-new.md) |
+| `Language/contexts.rakudoc:45` | a bare sub-CALL statement (`foo;`) returning a fresh custom-`.sink`-method instance never invokes `.sink` — the existing function-call-return gap noted in [role-mixed-sink-method-not-invoked-in-sink-context.md](../todo/tickets/role-mixed-sink-method-not-invoked-in-sink-context.md)'s target code | (not re-filed — see Excluded below) |
+| `Type/PositionalBindFailover.rakudoc:34` | `does PositionalBindFailover` fails with `X::InvalidType` — the role is missing from the `BUILTIN_PARENT_TYPES` allow-list | [positionalbindfailover-not-recognized-as-builtin-role.md](../todo/tickets/positionalbindfailover-not-recognized-as-builtin-role.md) |
+| `Language/using-modules/code.rakudoc:95` | a module's `EXPORT::DEFAULT` namespace isn't a real, symbolically-navigable package (`::("Test::EXPORT::DEFAULT::&ok")` fails) | [export-default-package-not-symbolically-navigable.md](../todo/deep/export-default-package-not-symbolically-navigable.md) |
+| `Language/haskell-to-p6.rakudoc:263` | `.signature` on a `proto` sub reports a generic `($arg0)` placeholder instead of the declared signature | [proto-sub-signature-reports-generic-placeholder.md](../todo/tickets/proto-sub-signature-reports-generic-placeholder.md) |
+
+**Excluded from this batch-5 sub-run:**
+- `Language/ipc.rakudoc` [1] (`run 'git', 'status';`) — the `git status` text itself is
+  environment-dependent (repo state), but the underlying reproducible defect (mutsu prints
+  no output at all, regardless of repo state) is the real finding, ticketed above as
+  `run-shell-discard-stdout-stderr-by-default.md`.
+- `Language/numerics.rakudoc` [2], [3], [4] (lines 595, 609, 751) — `raku-drift-from-doc`
+  (native-int wraparound, `uint8` array coercion, and atomic-increment counts in the doc's
+  `# OUTPUT` no longer match current `raku`'s own output).
+- `Language/contexts.rakudoc` [2] (line 130, `[~] [3, 5+6i, Set(<a b c>), ...]`) —
+  `raku-drift-from-doc` (the `Set`'s `.keys` iteration order in the reduced string differs
+  from the doc's `# OUTPUT`, and also varies run-to-run in real `raku` itself — the same
+  Set/Bag/hash iteration-order nondeterminism documented as a known harness false positive
+  above).
+- `Language/contexts.rakudoc` [1] (line 45, `return [<a b c>] does role { method sink {...} }`)
+  — see the ticket-column note above: this is the same `.sink`-in-sink-context gap already
+  filed as `role-mixed-sink-method-not-invoked-in-sink-context.md`, specifically its
+  documented "function-call return" residue (the `SinkPop` VM op's own code comment already
+  says a normal sub's fresh-instance return is conservatively not auto-sunk, pending
+  first-class container identity) — not re-filed as a separate ticket.
+- `Type/Sequence.rakudoc` [1] (line 69, `$s.eager` twice on a `lazy 1..5` — should throw
+  `X::Seq::Consumed` on the second call) — matches the already-**Deferred** Lazy-list
+  cluster's container-repr/reification-consumption residue.
+- `Type/Bag.rakudoc` [1] (line 53, `.keys.raku`/`.values.raku` element order) — Bag/hash
+  iteration-order `raku-drift`/nondeterminism, the documented known harness false positive.
+
 ### Deferred / deep (tracked elsewhere — do not re-open as a shallow slice)
 These root causes account for a large share of the survey's `mism`/`crash` and are
 intentionally deferred; see PLAN.md §8.5 and the ADRs:

--- a/todo/deep/export-default-package-not-symbolically-navigable.md
+++ b/todo/deep/export-default-package-not-symbolically-navigable.md
@@ -1,0 +1,63 @@
+# A module's `EXPORT::DEFAULT` namespace isn't a real, symbolically-navigable package
+
+Found by the doc-diff harness re-run (`docs/doc-diff-backlog.md`, `Language/using-modules/code.rakudoc:95`).
+
+## Root cause
+
+Raku models a used module's exported symbols as living in a real nested package,
+`ModuleName::EXPORT::DEFAULT`, reachable like any other package — including via symbolic
+package lookup (`::("...")`). mutsu's `use`/`require` machinery evidently copies exported
+symbols directly into the importing scope (confirmed: an unqualified `::("&ok")` lookup
+after `use Test` succeeds), but never materializes the `ModuleName::EXPORT::DEFAULT`
+package itself as a queryable stash — so a *fully-qualified* symbolic lookup through that
+path fails, and the module's own package stash (`.WHO`) doesn't even list `"EXPORT"` as a
+key.
+
+## Minimal repro
+
+```raku
+use Test;
+my &mmk = ::("Test::EXPORT::DEFAULT::&ok");
+say &mmk;
+```
+
+- `raku`: resolves to the `Test` module's exported `&ok` sub.
+- `mutsu` (`target/debug/mutsu`): `No such symbol 'Test::EXPORT::DEFAULT::&ok'`.
+
+Confirmed narrower pieces that DO work (isolating the gap to the qualified-package path
+specifically):
+
+```raku
+require ::("Test"); say "loaded";     # OK — dynamic module loading works
+use Test; my &mmk = ::("&ok"); say &mmk;   # OK — unqualified symbolic lookup works
+```
+
+And confirmed the module's own stash doesn't expose the `EXPORT` sub-package at all:
+
+```raku
+use Test; say Test.WHO.keys;
+```
+
+prints an unrelated set of keys (no `"EXPORT"` among them) rather than the module's real
+export namespace structure.
+
+## Why this is `todo/deep`, not a shallow slice
+
+- This is a module-system / package-stash architecture gap, not a missing individual
+  function: mutsu's `use Module` import path apparently does NOT model
+  `Module::EXPORT::DEFAULT` (and by extension `EXPORT::MANDATORY`/tag-named export groups)
+  as real nested packages with real stashes at all — it just copies symbols into scope
+  by name. Making `::("Module::EXPORT::DEFAULT::&name")` work requires either
+  constructing that nested package structure for every `use`d module (so `.WHO`/symbolic
+  lookup can walk it), or special-casing the `::(...)` resolver to recognize an
+  `EXPORT::DEFAULT`-shaped qualified name and redirect it into whatever internal export
+  table mutsu actually uses today.
+- Any fix here touches the module-loading/import path (`use`/`require` machinery, package
+  registration) broadly enough that it needs its own design decision about how deep to
+  model the export-tag namespace (`DEFAULT` only, or also user-declared export tags like
+  `is export(:MANDATORY)`), not a one-file patch.
+
+## Affected files (starting point)
+
+Module-loading/import registration (wherever `use`/`require` copies a module's exported
+symbols into the importing scope) and the `::(...)` symbolic package/symbol resolver.

--- a/todo/deep/isa-conflates-roles-with-nominal-supertypes.md
+++ b/todo/deep/isa-conflates-roles-with-nominal-supertypes.md
@@ -1,0 +1,62 @@
+# `.isa()` wrongly returns `True` for role names — conflates nominal class hierarchy with role composition
+
+Found by the doc-diff harness re-run (`docs/doc-diff-backlog.md`, `Type/Test.rakudoc:400`).
+
+## Root cause
+
+Raku's `.isa(Type)` checks only the **nominal class hierarchy** (`.^mro`) — it is `False`
+for a role the value merely *does*, even when that role is transitively composed by an
+ancestor class. `.does(Type)` / `~~ Type` are the role-aware checks. mutsu's single
+`Value::isa_check` (`src/value/types_isa.rs`) implements both `isa_check` (used directly
+by `.isa`) and `does_check` (which delegates to `isa_check` for non-mixin cases) through
+the *same* type-hierarchy `match` block (lines ~222-423). That match block lists several
+entries that are actually **roles**, not real nominal ancestors, so `.isa` on them wrongly
+returns `True`:
+
+- `"Numeric"`, `"Real"`, `"Rational"` — roles `Cool`/`Int`/`Rat`/etc. compose, not classes
+  they inherit from (confirmed via `raku -e 'say Int.^mro'` → `(Int Cool Any Mu)`, no
+  `Numeric`/`Real` in the MRO).
+- Likely also `"Stringy"`, `"Positional"`, `"Map"`/`"Associative"`, `"Iterable"`,
+  `"Block"`/`"Routine"`/`"Code"`/`"Callable"` — these read as role names in Raku's type
+  system too, though only `Numeric`/`Real`/`Rational` were directly verified against real
+  `raku` here.
+
+## Minimal repro
+
+```raku
+say 42.isa(Numeric);   # raku: False (role, not in Int's MRO)  mutsu: True
+say 42.isa(Real);      # raku: False                            mutsu: (untested but same shape)
+say 42.isa(Cool);      # raku: True (Cool IS in Int's MRO)      mutsu: True (correct)
+```
+
+- `raku`: `False`
+- `mutsu` (`target/debug/mutsu`): `True`
+
+The doc's own example (`Type/Test.rakudoc:400`) relies on this distinction directly:
+`say 42.isa(Numeric)` is documented as `False`, contrasted with `isa-ok 42, Numeric` (a
+`Test` assertion that uses the role-aware `~~`/`does` check and correctly says `ok`).
+
+## Why this is `todo/deep`, not a shallow slice
+
+- `isa_check` is the single shared implementation behind BOTH `.isa` (should be
+  nominal-only) and `.does`/`~~` (should be role-aware) — `does_check` explicitly falls
+  through to `isa_check` for the non-mixin case (`src/value/types_isa.rs:449`). Simply
+  removing the role entries from the match would break `.does(Numeric)`/`42 ~~ Numeric`,
+  which must stay `True`.
+- A correct fix needs to bifurcate the current single match block into two: a nominal-only
+  table (real class-hierarchy ancestors: `Any`, `Mu`, `Cool`, `Dateish`, the `Exception`
+  family, `ObjAt`, `Pod::Block`, ...) consulted by `.isa`, and a role-table (`Numeric`,
+  `Real`, `Rational`, `Positional`, `Associative`/`Map`, `Iterable`, `Stringy`, `Block`
+  family, ...) consulted only by `.does`/`~~`/smart-match. Several entries in the current
+  match (`SetHash`/`BagHash`/`MixHash`, `Seq`/`List`, `HyperSeq`/`RaceSeq`) may be
+  legitimately nominal (they're concrete classes, not roles) and should stay shared — this
+  needs a careful per-entry audit against real `raku -e 'say TYPE.^mro'` /
+  `say TYPE.^roles` output, not a blanket split.
+- Touches a very hot, widely-used primitive (`isa_check`/`does_check` back essentially
+  every `.isa`, `.does`, `~~`, and multi-dispatch type-constraint check in the
+  interpreter), so the blast radius of getting the split wrong is large — this needs
+  `make test` + a full roast run to validate, not a quick local check.
+
+## Affected files (starting point)
+
+- `src/value/types_isa.rs` (`isa_check`, `does_check`)

--- a/todo/deep/run-shell-discard-stdout-stderr-by-default.md
+++ b/todo/deep/run-shell-discard-stdout-stderr-by-default.md
@@ -1,0 +1,77 @@
+# `run`/`shell` silently discard the child's stdout/stderr instead of inheriting the parent's
+
+Found by the doc-diff harness re-run (`docs/doc-diff-backlog.md`, `Language/ipc.rakudoc:14`).
+
+## Root cause
+
+In real Raku, `run`/`shell` (unlike a fully-captured `run(..., :out)`) let the child
+process's stdout/stderr go straight to the same streams as the parent (OS-level
+inheritance) when the caller does not ask to capture them. mutsu instead explicitly
+redirects both to `/dev/null` whenever `:out`/`:err`/`:merge` are not requested:
+
+```rust
+// src/runtime/builtins_system_run.rs, builtin_run:
+} else if opts.capture_out {
+    cmd.stdout(std::process::Stdio::piped());
+} else {
+    cmd.stdout(std::process::Stdio::null());   // should inherit, not null
+}
+...
+} else if opts.capture_err {
+    cmd.stderr(std::process::Stdio::piped());
+} else {
+    cmd.stderr(std::process::Stdio::null());   // should inherit, not null
+}
+```
+
+`builtin_shell` (same file, ~line 415-424) has the identical pattern. So any script that
+calls `run`/`shell` without explicitly capturing output produces no visible output at all
+in mutsu, where real Raku shows the child's output live (this is the normal/default way
+scripts shell out and expect to see e.g. `git status`, `ls`, compiler/build tool output,
+etc.).
+
+## Minimal repro
+
+```raku
+run 'echo', 'hello';
+```
+
+- `raku`: prints `hello` (inherited stdout).
+- `mutsu` (`target/debug/mutsu`): prints nothing.
+
+Also affects `shell`:
+
+```raku
+shell 'echo hello';
+```
+
+- `raku`: prints `hello`.
+- `mutsu`: prints nothing.
+
+The doc's own example (`Language/ipc.rakudoc:14`, `run 'git', 'status';`) is exactly this
+shape — the specific `git status` text itself is environment-dependent (repo state
+varies), but mutsu producing **no output at all** regardless of repo state is the real,
+reproducible bug underneath that finding.
+
+## Why this is `todo/deep`, not a shallow one-line fix
+
+- This is not obviously an accident — `Command::spawn()`'s default behavior already
+  inherits stdio without any explicit `.stdout()`/`.stderr()` call, so someone had to
+  deliberately write the `Stdio::null()` branches. It is worth checking whether this was
+  done on purpose to keep child-process output from polluting TAP output during roast/test
+  runs (`run`/`shell` appear inside several roast tests), in which case naively switching
+  to inherited stdio could break existing whitelisted tests that currently rely on the
+  child's output being suppressed by default.
+- Fixing it requires auditing roast/`t/` coverage of `run`/`shell` for tests that
+  implicitly depend on the current suppress-by-default behavior (a test whose PASS
+  currently depends on a subprocess's stray output NOT reaching the TAP stream), not just
+  flipping `Stdio::null()` to inherited and hoping nothing regresses.
+- Affects two builtins (`run` and `shell`) with duplicated logic, and interacts with the
+  existing `:merge`/`:out(handle)` special-casing already in the same functions, so the
+  fix needs to preserve those paths' current (correct) behavior while changing only the
+  true default (no capture options given at all) case.
+
+## Affected files (starting point)
+
+- `src/runtime/builtins_system_run.rs` (`builtin_run` around line 130-133,
+  `builtin_shell` around line 415-424)

--- a/todo/tickets/charclass-dot-base-chained-subtraction-broken.md
+++ b/todo/tickets/charclass-dot-base-chained-subtraction-broken.md
@@ -1,0 +1,52 @@
+# Regex character class with a `.` (any-char) base and two chained `-` subtractions is mis-parsed
+
+Found by the doc-diff harness re-run (`docs/doc-diff-backlog.md`, `Type/Test.rakudoc:323`).
+
+## Root cause
+
+A Raku regex character class of the shape `<.-A-B>` — the any-char base `.` followed by
+**two** chained subtraction parts — is not composed correctly. A *single* subtraction
+after the dot base works fine (`<.-:letter>` correctly matches "any char that is not a
+letter"), but adding a second subtraction breaks differently depending on the item kind:
+
+- Two Unicode-property subtractions (`<.-:letter-:digit>`) silently **drops both
+  subtractions** and matches every character (equivalent to bare `.`).
+- Two bracket-class subtractions (`<.-[a]-[b]>`) does the opposite: it becomes
+  **over-restrictive** and matches nothing.
+
+Plain (non-dot-based) chained subtraction works correctly in both cases
+(`<-:letter-:digit>`, `<-[a]-[b]>`), so the bug is specifically in how the leading `.`
+combines with a *chain* of two or more subtraction parts. `parse_combined_class` in
+`src/runtime/regex_parse_charclass.rs` (the `+`/`-` prefixed-part loop starting around
+line 749) is the composition logic for chained parts; the dot-base case likely enters a
+different code path upstream (in `src/runtime/regex_parse_core.rs`, the `<...>` content
+dispatch) that does not fully delegate to the same chained-subtraction accumulator once a
+leading `.` is present.
+
+## Minimal repro
+
+```raku
+say "ab1 c".comb(/<.-:letter-:digit>/);   # any char, not letter, not digit
+say "ab1 c".comb(/<.-[a]-[b]>/);          # any char, not 'a', not 'b'
+```
+
+- `raku`: `( )` (a single space) for the first; `(1   c)` (digit, space, 'c') for the second.
+- `mutsu` (`target/debug/mutsu`): `(a b 1  c)` (everything — subtraction ignored) for the
+  first; `()` (nothing — over-restricted) for the second.
+
+Single-subtraction dot-base forms are unaffected and already correct:
+
+```raku
+say "ab1 ".comb(/<.-:letter>/);   # both raku and mutsu: (1  )
+```
+
+This is what the doc example (`Type/Test.rakudoc:323`) actually exercises via
+`.comb(/<.-:letter-:digit>/)` inside a `Bag.new-from-pairs` count, producing a wrong
+`other` count (21, the whole string length, instead of 4).
+
+## Affected files (starting point)
+
+- `src/runtime/regex_parse_charclass.rs` (`parse_combined_class`, the chained `+`/`-`
+  accumulator)
+- `src/runtime/regex_parse_core.rs` (the `<...>` dispatch that decides when to route into
+  `parse_combined_class` vs. some other any-char/dot-specific path)

--- a/todo/tickets/enumhow-missing-enum-values-elems-enum-from-value.md
+++ b/todo/tickets/enumhow-missing-enum-values-elems-enum-from-value.md
@@ -1,0 +1,58 @@
+# `EnumHOW` is missing `.^enum_values`, `.^elems`, `.^enum_from_value`
+
+Found by the doc-diff harness re-run (`docs/doc-diff-backlog.md`, `Type/Metamodel/EnumHOW.rakudoc:139,148,157`).
+
+## Root cause
+
+`Perl6::Metamodel::EnumHOW` already implements `enum_value_list` (returns the ordered list
+of enum-value objects, `src/runtime/methods_classhow_dispatch.rs:1280`) and is dispatched
+through `dispatch_classhow_method`/`is_classhow_method`
+(`src/runtime/methods_native_bypass.rs`). Three sibling introspection methods documented
+in `Type/Metamodel/EnumHOW.rakudoc` are simply not in the `is_classhow_method` allow-list
+(so they never reach `dispatch_classhow_method` at all — they fail generic method lookup
+with "No such method"):
+
+- `.^enum_values` — a `Map` from enum-key name to its ordinal value.
+- `.^elems` — the number of enum values.
+- `.^enum_from_value(ordinal)` — reverse lookup: the enum-key name for a given ordinal.
+
+All three can be implemented the same way `enum_value_list` already is: read
+`self.registry().enum_types.get(&type_name)`, which stores the `(key, value)` variant
+pairs in declaration order.
+
+## Minimal repro
+
+```raku
+enum Numbers <10 20>;
+say Numbers.^enum_values;        # {10 => 0, 20 => 1}
+say Numbers.^elems;              # 2
+say Numbers.^enum_from_value(0); # 10
+```
+
+- `raku`: as commented above.
+- `mutsu` (`target/debug/mutsu`): `.^enum_values` and `.^enum_from_value` both die with
+  `No such method 'enum_values'/'enum_from_value' for invocant of type
+  'Perl6::Metamodel::EnumHOW'`. `.^elems` is worse: it **deterministically crashes with a
+  stack overflow** (`thread 'mutsu-main' has overflowed its stack`, exit 134, reproduces
+  every run) — reduced to a two-line repro:
+
+  ```raku
+  enum Numbers <10 20>;
+  say Numbers.^elems;
+  ```
+
+  `"elems"` is presumably not in `is_classhow_method`'s allow-list either, so the call
+  falls through the generic method-dispatch chain instead of `dispatch_classhow_method`;
+  something in that fallback chain for an `EnumHOW` instance (a `Perl6::Metamodel::EnumHOW`
+  `Instance`) apparently recurses into itself. Whoever picks this up should confirm with
+  `rust-gdb -batch` (per the repo's debugging guidelines) which dispatch path loops, since
+  this is a crash (highest priority per the roast triage rules), not just a missing
+  method.
+
+## Affected files (starting point)
+
+- `src/runtime/methods_native_bypass.rs` (`is_classhow_method` — add `"enum_values"`,
+  `"elems"`, `"enum_from_value"`)
+- `src/runtime/methods_classhow_dispatch.rs` (`dispatch_classhow_method` — add match arms
+  next to the existing `"enum_value_list"` arm, reusing the same
+  `self.registry().enum_types.get(&type_name)` lookup)

--- a/todo/tickets/main-allomorph-arg-name-corrupts-later-intstr-new.md
+++ b/todo/tickets/main-allomorph-arg-name-corrupts-later-intstr-new.md
@@ -1,0 +1,71 @@
+# Calling `.^name` on a `MAIN`-bound allomorph argument corrupts a later `IntStr.new(...).^name`
+
+Found by the doc-diff harness re-run (`docs/doc-diff-backlog.md`, `Language/numerics.rakudoc:353`).
+
+## Root cause (unconfirmed — narrowed but not root-caused)
+
+Bisected from the doc's full example down to a minimal 3-line repro. This looks like
+order-dependent global/shared-state corruption triggered specifically by invoking
+`.^name` inside `sub MAIN($x)` on an argument auto-coerced from `@*ARGS` to `IntStr`.
+
+```raku
+@*ARGS = "42";
+sub MAIN($x) { say $x.^name; }
+say IntStr.new(42, "42").^name;
+```
+
+- `raku`: `IntStr` then `IntStr`.
+- `mutsu` (`target/debug/mutsu`): `IntStr` then `Str` — the *second* `IntStr.new(...)`
+  loses its allomorph tag after `MAIN` ran `say $x.^name` on its own `IntStr` argument.
+
+Bisection notes:
+
+- `IntStr.new(42, "42").^name` alone (no `MAIN` at all) correctly prints `IntStr` — the
+  constructor itself is fine in isolation.
+- `sub MAIN($x) { $x.^name }` (no `say`, i.e. computing but not printing/saying the name)
+  does **not** trigger the corruption — the next `IntStr.new(...).^name` still prints
+  `IntStr` correctly.
+- `sub MAIN($x) { say $x.^name; }` (with the explicit `say`) DOES trigger it.
+- A non-`MAIN` `say $x.^name` on a directly-constructed `IntStr` value (`my $x =
+  IntStr.new(...); say $x.^name; say IntStr.new(...).^name;`) does NOT reproduce it —
+  `MAIN`'s specific argument-binding/auto-coercion path appears necessary, not just
+  "any `say $foo.^name` on an IntStr value".
+
+So the trigger is specifically: `MAIN` auto-coerces an `@*ARGS` string into `IntStr` for
+its parameter, and `say`ing that parameter's `.^name` leaves some piece of shared/global
+state (perhaps a memoized HOW/mixin-overrides object keyed by type name, given `IntStr` is
+implemented as a `Mixin` allomorph) corrupted such that the *next*, unrelated
+`IntStr.new(...)` no longer tags its result as the `IntStr` allomorph — it degrades to a
+plain `Str`.
+
+## Minimal repro
+
+```raku
+@*ARGS = "42";
+sub MAIN($x) { say $x.^name; }
+say IntStr.new(42, "42").^name;
+```
+
+Run as a script (not `-e`, so `MAIN` auto-invokes): prints `IntStr` then `Str` in mutsu,
+`IntStr` then `IntStr` in raku.
+
+## Affected files (starting point)
+
+Likely somewhere in the allomorph/`Mixin` construction or `.^name` dispatch path for
+`IntStr`/`NumStr`/`RatStr`/`ComplexStr` — search for how `MAIN`'s argument auto-coercion
+constructs an allomorph value (probably shares code with `IntStr.new`) and whether any
+step mutates a shared/cached structure by reference rather than cloning. A `rust-gdb`
+watchpoint on the `IntStr` mixin-overrides map (per the repo's debugging guidelines) once
+the corruption window is narrowed further would likely find this quickly — this ticket is
+triage-only and does not pin down the exact write site.
+
+## Secondary, distinct finding from the same doc example (not investigated further)
+
+The same finding also showed `< 1/2>.^name` (a space-padded angle-bracket-quoted `Rat`
+word) reporting plain `Rat` in mutsu vs. `RatStr` in real `raku` — while the *unpadded*
+`<1/2>.^name` is `Rat` in BOTH raku and mutsu (verified directly). So leading whitespace
+inside `< ... >` changes whether raku classifies the literal as the `RatStr` allomorph.
+This is the same shape as the already-ticketed
+[`angle-bracket-quoted-word-space-padded-loses-allomorph.md`](angle-bracket-quoted-word-space-padded-loses-allomorph.md)
+(filed for the analogous `< 42/10 >` Complex-adjacent case in `quoting.rakudoc`) — not
+re-filed here, just noted as another instance of that same root cause.

--- a/todo/tickets/positionalbindfailover-not-recognized-as-builtin-role.md
+++ b/todo/tickets/positionalbindfailover-not-recognized-as-builtin-role.md
@@ -1,0 +1,53 @@
+# `does PositionalBindFailover` fails with `X::InvalidType` — the role isn't in `BUILTIN_PARENT_TYPES`
+
+Found by the doc-diff harness re-run (`docs/doc-diff-backlog.md`, `Type/PositionalBindFailover.rakudoc:34`).
+
+## Root cause
+
+`class Foo does PositionalBindFailover { ... }` fails to even compose — `class`
+registration rejects the role as an unknown type name. `validate_class_parents`
+(`src/runtime/registration_class_validate.rs`, ~line 228) accepts a `does`/`is` parent
+name only if it is a registered class, a registered role, a registered enum, or appears in
+the hardcoded `BUILTIN_PARENT_TYPES` list (`src/runtime/registration_class_decl.rs`,
+lines 26-105). `"PositionalBindFailover"` is missing from that list — even though sibling
+core roles like `"Positional"`, `"Associative"`, `"Stringy"` are present, and even though
+`PositionalBindFailover` IS recognized as a valid type name by the separate, more general
+type-constraint checker in `src/runtime/utils/type_constraints.rs` (line 193) — that
+checker is just not consulted here.
+
+Note: other core roles that a class might `does` (`Iterable`, `Iterator`,
+`PredictiveIterator`, `Dateish`, `Sequence`) are ALSO absent from `BUILTIN_PARENT_TYPES`,
+but those work anyway because they happen to already be pre-registered as real roles in
+`self.registry().roles` (verified: `class Foo does Iterator { method pull-one {1} }`
+composes and runs fine). `PositionalBindFailover` has no such registry entry, so it falls
+through every check and hits the `X::InvalidType` error path.
+
+## Minimal repro
+
+```raku
+class Foo does PositionalBindFailover { }
+```
+
+- `raku`: composes without error.
+- `mutsu` (`target/debug/mutsu`): `X::InvalidType: Invalid typename 'PositionalBindFailover'`.
+
+## Scope note — this ticket is about the immediate crash, not full failover semantics
+
+Adding `"PositionalBindFailover"` to `BUILTIN_PARENT_TYPES` (or registering it as a real
+empty/marker role, matching how `Iterator` etc. already work) unblocks class composition,
+but the doc's fuller example additionally requires the actual runtime behavior: an object
+that `does PositionalBindFailover` and defines `.iterator` should have that iterator
+consulted by positional-context binding/subscripting (e.g. `@a[^5]`, treating missing
+tail elements as `Nil`). That deeper behavior overlaps with the already-**Deferred**
+"Custom `does Iterable`/`does Iterator` protocol" cluster
+(`iterating.rakudoc`/`Iterator.rakudoc`) noted in `docs/doc-diff-backlog.md`'s Deferred
+section — this ticket only covers the shallow "recognize the type name so the class can
+compile at all" gap; the follow-on iterator-consultation behavior should be picked up
+alongside that existing deferred cluster, not duplicated here.
+
+## Affected files (starting point)
+
+- `src/runtime/registration_class_decl.rs` (`BUILTIN_PARENT_TYPES` — add
+  `"PositionalBindFailover"`, and consider auditing for `"Iterable"`, `"Iterator"`,
+  `"PredictiveIterator"`, `"Dateish"`, `"Sequence"` too, even though those currently work
+  via a different registry path)

--- a/todo/tickets/proto-sub-signature-reports-generic-placeholder.md
+++ b/todo/tickets/proto-sub-signature-reports-generic-placeholder.md
@@ -1,0 +1,52 @@
+# `.signature` on a `proto` sub reports a generic `($arg0)` placeholder instead of the declared signature
+
+Found by the doc-diff harness re-run (`docs/doc-diff-backlog.md`, `Language/haskell-to-p6.rakudoc:263`).
+
+## Root cause
+
+`Interpreter::callable_signature` (`src/runtime/accessors_state.rs`) computes a callable's
+displayed signature. For a `ValueView::Routine { name, .. }` (the `&name` form `.signature`
+is typically called on), it looks up the routine via `self.resolve_function(&name.resolve())`
+— but `resolve_function` (`src/runtime/resolution.rs`) only consults
+`self.registry().functions`, never `self.registry().proto_functions`. A `proto` sub with
+no other multi candidate registered under `functions` is therefore never found, and
+`callable_signature` falls through to the generic placeholder:
+
+```rust
+(vec!["arg0".to_string()], Vec::new())
+```
+
+A plain (non-`proto`) `sub` with the identical signature shape works correctly — the bug
+is specific to `proto` routines.
+
+## Minimal repro
+
+```raku
+proto greeting (Str \name --> Str) {*}
+say &greeting.signature;
+```
+
+- `raku`: `(Str \name --> Str)`.
+- `mutsu` (`target/debug/mutsu`): `($arg0)`.
+
+Confirmed the sigilless-parameter (`\name`) shape isn't the trigger — a plain named
+parameter reproduces identically:
+
+```raku
+proto greeting (Str $name --> Str) {*}
+say &greeting.signature;   # mutsu: ($arg0)  (raku: (Str $name --> Str))
+```
+
+And confirmed a non-`proto` sub with the same signature is unaffected:
+
+```raku
+sub greeting (Str \name --> Str) { name }
+say &greeting.signature;   # mutsu: (Str \name --> Str)  -- correct
+```
+
+## Affected files (starting point)
+
+- `src/runtime/accessors_state.rs` (`callable_signature`, the `ValueView::Routine` arm)
+- `src/runtime/resolution.rs` (`resolve_function` — needs a `proto_functions` fallback, or
+  `callable_signature` needs to consult `registry().proto_functions` directly when
+  `resolve_function` returns `None`)

--- a/todo/tickets/throws-like-message-matcher-skipped-for-adhoc-exception.md
+++ b/todo/tickets/throws-like-message-matcher-skipped-for-adhoc-exception.md
@@ -1,0 +1,61 @@
+# `throws-like`'s `message =>`/`gist =>` matchers are silently skipped for an `X::AdHoc` exception
+
+Found by the doc-diff harness re-run (`docs/doc-diff-backlog.md`, `Type/Test.rakudoc:586`).
+
+## Root cause
+
+`test_fn_throws_like` (`src/runtime/test_functions/throws_like.rs`) only runs named
+attribute matchers (`message => /.../`, `payload => ...`, etc.) when
+`has_structured_exception` is true:
+
+```rust
+let has_structured_exception = exception_val.as_ref().is_some_and(|ex| {
+    if let ValueView::Instance { class_name, .. } = ex.view() {
+        let cn = class_name.resolve();
+        cn.starts_with("X::") && cn != "X::AdHoc"
+    } else {
+        false
+    }
+});
+let named_checks: Vec<(String, Value)> = if has_structured_exception {
+    named_matchers
+} else {
+    Vec::new()
+};
+```
+
+`X::AdHoc` is excluded entirely because it "doesn't carry the attributes of the expected
+exception type" — true for arbitrary named attribute matchers (e.g. `status =>`,
+`payload =>`), which really do need real per-type attributes. But the `message`/`gist`
+matchers are a special case: the code already has a working fallback for them (further
+down, when `actual_val` is `None`) that reads `err_message` / calls a user `.message`
+method rather than an instance attribute — that fallback works fine for `X::AdHoc` too,
+it's just never reached because `has_structured_exception` filters the whole
+`named_checks` list out before the loop runs.
+
+`fail "some string"` (and a bare `die "some string"`) both produce an `X::AdHoc`
+exception (confirmed: `$!.^name` is `X::AdHoc` after `try { fail "..." }`), so any
+`throws-like { ... }, ExceptionType, message => /.../` against a `fail`/`die`-thrown
+string message is silently dropped — the subtest plan undercounts (2 instead of 3) and
+the message is never actually checked.
+
+## Minimal repro
+
+```raku
+use Test;
+sub frodo(Bool :$destroys-ring) {
+    fail "Oops. Frodo dies" unless $destroys-ring
+};
+throws-like { frodo }, Exception, message => /dies/;
+```
+
+- `raku`: subtest plans `1..3` and includes `ok 3 - .message matches /dies/`.
+- `mutsu` (`target/debug/mutsu`): subtest plans `1..2` — the `message` check never runs at
+  all.
+
+## Affected files (starting point)
+
+- `src/runtime/test_functions/throws_like.rs` — the `has_structured_exception` gate should
+  let `message`/`gist` matchers through regardless of exception class (they already fall
+  back to `err_message` when there's no real attribute), while still excluding other
+  named matchers for a non-structured (`X::AdHoc`) exception.

--- a/todo/tickets/user-sub-named-int-shadows-builtin-coercion-call.md
+++ b/todo/tickets/user-sub-named-int-shadows-builtin-coercion-call.md
@@ -1,0 +1,36 @@
+# A user `sub Int(...)` wrongly shadows the built-in `Int(...)` type-coercion call syntax
+
+Found by the doc-diff harness re-run (`docs/doc-diff-backlog.md`, `Type/Sub.rakudoc:19`).
+
+## Root cause
+
+In real Raku, declaring a sub with the same name as a core type coercer (e.g.
+`sub Int(Str $s) {...}`) does NOT shadow the bareword type-coercion call `Int(x)` — that
+call form keeps resolving to the built-in `Int` coercer. Only an explicit `&Int(x)` call
+(taking the routine by its `&`-sigiled name) reaches the user-defined sub. mutsu resolves
+*both* call forms to the user sub, losing access to the built-in coercion entirely once a
+same-named sub is declared.
+
+## Minimal repro
+
+```raku
+sub Int(Str $s){'what?'};
+say [Int, Int('42'), &Int('42')];
+```
+
+- `raku`: `[(Int) 42 what?]` — `Int` (bare term) is still the type object, `Int('42')`
+  still calls the built-in coercer (`42`), and only `&Int('42')` reaches the user sub
+  (`what?`).
+- `mutsu` (`target/debug/mutsu`): `[(Int) what? what?]` — `Int('42')` also resolves to the
+  user sub.
+
+## Affected files (starting point)
+
+- Wherever a bareword call `Name(...)` is resolved against user-declared subs vs. the
+  built-in type-coercer table — likely in the call-dispatch/resolution path (`runtime/
+  calls.rs`, `runtime/dispatch.rs`, or the compiler's call-site resolution in
+  `compiler/expr.rs`/`compiler/helpers_call_args.rs`). The fix needs the bareword-call
+  form for a name that collides with a core type name to prefer the built-in coercer
+  unless there is no user sub at all under that name reachable via `&Name`, matching
+  Raku's rule that user subs never occlude built-in type-coercion call syntax for a
+  colliding name — only the explicit `&`-sigiled call reaches the user definition.

--- a/todo/tickets/variable-trait-bracket-argument-misparsed-as-type-param.md
+++ b/todo/tickets/variable-trait-bracket-argument-misparsed-as-type-param.md
@@ -1,0 +1,52 @@
+# `is foo[...]` custom variable-trait argument sugar is misparsed as a parameterized-type trait
+
+Found by the doc-diff harness re-run (`docs/doc-diff-backlog.md`, `Type/Sub.rakudoc:78`).
+
+## Root cause
+
+`parse_variable_traits` (`src/parser/stmt/decl/my_decl.rs`) handles a trait name followed
+by `[...]` unconditionally as "parameterized type trait" sugar for `is Set[Int]`-style
+type traits (lines ~551-581): it folds the entire bracket content into the `trait_name`
+string itself (`trait_name = format!("{}[{}]", trait_name, param_text)`), regardless of
+whether the trait name is a real uppercase type (`Set`, `Foo`) or a lowercase
+custom-trait-call name.
+
+Real Raku also supports `is TraitName[...]` as sugar for calling a **lowercase**
+`trait_mod:<is>` candidate with a single Array-literal argument — analogous to the
+already-supported `is TraitName<a b>` sugar (an adjacent `<...>` word-list, handled a few
+lines below in the same function, line ~597) which desugars to `is TraitName(<a b>)`. When
+the trait name is a lowercase custom trait, `[1,2,3,...]` should be parsed as an
+array-literal expression argument (same as the explicit `is foo([1,2,3,...])` parenthesized
+form), not folded into the type name string.
+
+Because the current code always folds it into the name, the VM's trait dispatch later
+receives a bogus trait name like `"foo[1,2,3,:named<a>, :2b, :3c]"` (the entire bracket
+content, verbatim) and no argument at all, so it reports "Unknown variable trait" even
+when a matching `trait_mod:<is>` candidate for `foo` exists.
+
+## Minimal repro
+
+```raku
+multi trait_mod:<is>(Variable $a, :@foo) {
+    say "called with @foo[]"
+}
+my $x is foo[1,2,3] = 1;
+```
+
+- `raku`: runs the custom trait, printing `called with 1 2 3`.
+- `mutsu` (`target/debug/mutsu`): `X::Comp::Trait::Unknown: Unknown variable trait
+  'is foo[1,2,3]'`.
+
+The doc's fuller example (`Type/Sub.rakudoc:78`) additionally destructures the array
+literal's positional/named parts via a complex signature
+(`:@foo [$firstpos, *@restpos, :$named, *%restnameds]`), but the crash reproduces on the
+much simpler case above — the destructuring signature is a separate, secondary concern
+once the basic bracket-argument parse is fixed.
+
+## Affected files (starting point)
+
+- `src/parser/stmt/decl/my_decl.rs` (`parse_variable_traits`, the `r2.starts_with('[')`
+  branch around lines 551-581) — needs to distinguish an uppercase type-parameterization
+  trait (fold into the name, current behavior) from a lowercase custom-trait bracket
+  argument (parse as an Array-literal expression argument, mirroring the `(...)` and
+  `<...>` branches immediately below it).


### PR DESCRIPTION
## Summary
- Re-ran the doc-diff harness against `Test`/`Metamodel::EnumHOW`/`Sub`/`ipc`/`numerics`/`contexts`/`Sequence`/`Bag`/`haskell-to-p6`/`PositionalBindFailover`/`using-modules::code` and re-verified every reported finding directly against `raku` and `mutsu`.
- Filed 11 new tickets for confirmed real bugs (9 under `todo/tickets/`, 2 under `todo/deep/` — role-vs-nominal `.isa()`, and the `run`/`shell` stdout-suppression default).
- Linked all findings into `docs/doc-diff-backlog.md` under a new batch-5-C subsection, with an Excluded list for raku-drift / known nondeterminism / an existing duplicate ticket.

## Test plan
- [x] Re-verified every finding directly with `raku -e` / `timeout 30 target/debug/mutsu -e` (not just trusting the harness report)
- [x] Docs-only change — no code touched, so `make test`/`make roast` are not required; CI's docs-only fast path should skip the heavy jobs
- [x] `cargo fmt`/`cargo clippy` ran clean via the pre-commit hook

🤖 Generated with [Claude Code](https://claude.com/claude-code)