### PR TITLE
docs: doc-diff batch-6 re-run findings (Label/Win32/Pair/Attribute/Unicode/MustBeStarted/Proc/traits/glossary/Metamodel::Versioning/regexes-best-practices)

### DIFF
--- a/docs/doc-diff-backlog.md
+++ b/docs/doc-diff-backlog.md
@@ -719,6 +719,52 @@ Found in the 2026-08-22 batch-5 re-run of `Test`/`Metamodel::EnumHOW`/`Sub`/`ipc
 - `Type/Bag.rakudoc` [1] (line 53, `.keys.raku`/`.values.raku` element order) — Bag/hash
   iteration-order `raku-drift`/nondeterminism, the documented known harness false positive.
 
+Found in the 2026-08-22 batch-6 re-run of `Label`/`IO::Spec::Win32`/`Pair`/`Attribute`/`Unicode`/
+`X::Proc::Async::MustBeStarted`/`Proc`/`traits`/`glossary`/`Metamodel::Versioning`/
+`regexes-best-practices`:
+
+| file:line | one-line summary | ticket |
+|---|---|---|
+| `Type/Label.rakudoc:87,101,120` | a hyphenated loop label (`MY-LABEL:`) is never recognized by `next`/`last`/`redo`, silently downgrading them to their unconditional/unlabeled form (and hanging forever for a mis-parsed `redo`) | [loop-label-name-rejects-hyphens.md](../todo/tickets/loop-label-name-rejects-hyphens.md) |
+| `Type/Pair.rakudoc:61` | `.raku` on a `Hash` populated via slurpy `*%h` named-arg binding doesn't abbreviate `Bool::True`-valued pairs to `:key` the way real raku does | [slurpy-hash-named-arg-raku-boolean-shorthand-missing.md](../todo/tickets/slurpy-hash-named-arg-raku-boolean-shorthand-missing.md) |
+| `Type/Attribute.rakudoc:58` | `has @.attr is default(V) is rw` — assigning `Nil` resets the array to `[Any]` instead of `[V]` | [array-attribute-default-not-applied-on-nil-assign.md](../todo/tickets/array-attribute-default-not-applied-on-nil-assign.md) |
+| `Type/Unicode.rakudoc:27,37` | the built-in `Unicode` type object doesn't exist at all; the bareword resolves to a plain `Str` | [unicode-type-object-missing.md](../todo/tickets/unicode-type-object-missing.md) |
+| `Type/X/Proc/Async/MustBeStarted.rakudoc:14` | `X::Proc::Async::MustBeStarted.Str` returns the bare class name instead of the "Process must be started first..." message | [x-proc-async-mustbestarted-str-not-message.md](../todo/tickets/x-proc-async-mustbestarted-str-not-message.md) |
+| `Language/traits.rakudoc:42` | a class-scoped `my $.counter` (dot-twigil'd `my` variable, not a `has` attribute) doesn't persist mutations across method calls | [class-scoped-my-dot-attribute-doesnt-persist.md](../todo/tickets/class-scoped-my-dot-attribute-doesnt-persist.md) |
+| `Language/glossary.rakudoc:1024` | `Pod::FormattingCode.raku` prints only the bare class name, omitting `type`/`meta`/`config`/`contents` | [pod-formattingcode-raku-missing-attributes.md](../todo/tickets/pod-formattingcode-raku-missing-attributes.md) |
+| `Type/Metamodel/Versioning.rakudoc:27` | `.^set_ver`/`.^set_auth`/`.^set_api` are unimplemented on `Perl6::Metamodel::ClassHOW` | [metamodel-classhow-set-ver-auth-api-missing.md](../todo/tickets/metamodel-classhow-set-ver-auth-api-missing.md) |
+
+**Excluded from this batch-6 sub-run (already deferred/resolved/drift/false-positive/duplicate):**
+- `Type/IO/Spec/Win32.rakudoc` [1] (line 162, `.rel2abs`) and [4] (line 126, `.join`) —
+  `raku-drift-from-doc` (both compare against the doc's stated Windows-style `# OUTPUT`, but the
+  running environment's actual `$*CWD` is this Linux checkout's path).
+- `Type/IO/Spec/Win32.rakudoc` [2] (line 190, `.split`) and [3] (line 251, `.splitpath`) — mutsu
+  mis-assigns/mis-normalizes path components (e.g. `.split('/foo/')` gives `"\\"` as the directory
+  component where raku gives `"/"`; `.splitpath('.')` swaps the dirname/filename slots) — same
+  Win32-path-component-computation root cause as the already-open
+  [iopath-win32-separator-normalization.md](../todo/tickets/iopath-win32-separator-normalization.md)
+  (itself filed from this same `Type/IO/Spec/Win32.rakudoc` file per its own text), not re-filed as
+  a separate ticket.
+- `Type/Attribute.rakudoc` [2] (line 186, `is built(:bind)` + `my Foo:D $foo .= new: ...`) — the
+  crash is the already-filed
+  [lexical-typed-var-dot-equals-init-fails.md](../todo/tickets/lexical-typed-var-dot-equals-init-fails.md)
+  (`my Type:D $var .= new;` fails to strip the `:D` smiley before building the `.=` call target);
+  confirmed with the minimal two-line repro (`class Foo {}; my Foo:D $foo .= new;`) — not re-filed.
+- `Type/Attribute.rakudoc` [3] (line 418, `.?DEPRECATED`) — `raku-drift-from-doc` (mutsu prints
+  nothing for either `with` block; not investigated further since it's bucketed as drift by the
+  harness).
+- `Type/Proc.rakudoc:140` (`shell(...)` inside a `temp $*OUT` block) — narrowed to the simpler,
+  already-filed
+  [run-shell-discard-stdout-stderr-by-default.md](../todo/deep/run-shell-discard-stdout-stderr-by-default.md)
+  (`shell()`'s spawned child process's stdout is lost even with **no** `$*OUT` redirection at all
+  — confirmed with `shell("raku some-file-that-says-42.raku")` alone); not re-filed.
+- `Language/regexes-best-practices.rakudoc:163` (`token ws { <!ww> \h* }` inside a grammar) —
+  matches the already-open
+  [grammar-ws-boundary-and-vertical-whitespace.md](../todo/tickets/grammar-ws-boundary-and-vertical-whitespace.md),
+  whose repro now also crashes identically on current `main` (`No such method 'ww' for invocant of
+  type 'Match'`, upgraded from the ticket's originally-recorded "silently wrong match" symptom) —
+  ticket updated with this finding rather than re-filed.
+
 ### Deferred / deep (tracked elsewhere — do not re-open as a shallow slice)
 These root causes account for a large share of the survey's `mism`/`crash` and are
 intentionally deferred; see PLAN.md §8.5 and the ADRs:

--- a/todo/tickets/array-attribute-default-not-applied-on-nil-assign.md
+++ b/todo/tickets/array-attribute-default-not-applied-on-nil-assign.md
@@ -1,0 +1,46 @@
+# `has @.attr is default(V) is rw` — assigning `Nil` doesn't reset the array to `[V]`
+
+Found by the doc-diff harness re-run (`docs/doc-diff-backlog.md`, `Type/Attribute.rakudoc:58`).
+
+## Root cause hypothesis
+
+For a **scalar** `rw` attribute with `is default(V)`, assigning `Nil` correctly resets it to `V`
+(this already works in mutsu — see the `C` class in the repro below). For an **array-sigiled**
+`rw` attribute with `is default(V)`, assigning `Nil` should likewise reset the array to a
+single-element array containing the default (`[V]`) — but mutsu leaves the array holding `[Any]`
+(i.e. it does apply *some* per-element default behavior, since the array isn't left as the plain
+assigned `Nil`, but the per-element default value it picks is the type-object `Any` rather than the
+attribute's declared `is default(42)` value). This suggests the `@`-sigil assignment/reset path
+consults a *generic* per-element default (whatever an untyped `Array` slot defaults to) instead of
+threading through the attribute's own `is default(...)` trait value the way the scalar path does.
+
+## Minimal repro
+
+```raku
+class Foo {
+    has @.bar is default(42) is rw
+};
+my $foo = Foo.new( bar => <a b c> );
+$foo.bar = Nil;
+say $foo;
+```
+- `raku`: `Foo.new(bar => [42])`
+- `mutsu`: `Foo.new(bar => [Any])`
+
+Compare with the scalar case, which mutsu already gets right:
+```raku
+class C {
+    has $.a is default(42) is rw = 666
+}
+my $c = C.new;
+$c.a = Nil;
+say $c;
+```
+- `raku` and `mutsu` agree: `C.new(a => 42)`
+
+## Affected files (starting point)
+
+- Wherever array-attribute assignment/reset applies the `is default(...)` trait — likely near the
+  scalar-attribute `is default` handling that already works, but on the `@`-sigil container path.
+  Search for `is default` / attribute default-value application in `src/runtime/class.rs` and the
+  compiler's attribute-assignment compilation.

--- a/todo/tickets/class-scoped-my-dot-attribute-doesnt-persist.md
+++ b/todo/tickets/class-scoped-my-dot-attribute-doesnt-persist.md
@@ -1,0 +1,39 @@
+# `my $.counter` (class-scoped shared "attribute") doesn't persist mutations across method calls
+
+Found by the doc-diff harness re-run (`docs/doc-diff-backlog.md`, `Language/traits.rakudoc:42`).
+
+## Root cause hypothesis
+
+`my $.counter;` inside a class body declares a lexical scalar with the `.` twigil — a class-level
+(shared-across-all-instances, and across calls on the type object itself) counter accessible as
+`$.counter` from methods, distinct from a `has $.counter` per-instance attribute. mutsu appears to
+either re-initialize this variable on every method call, or not write back the post-increment's
+mutation to the shared slot at all — each call sees the same starting value.
+
+## Minimal repro
+
+```raku
+class Foo {
+    my $.counter;
+    method imm() {
+        return $.counter++;
+    }
+}
+say Foo.imm for ^5;
+```
+- `raku`: `0 1 2 3 4` (five lines)
+- `mutsu`: `0 0 0 0 0` (five lines) — the counter never advances
+
+The original doc example additionally applies `is repr('Uninstantiable')` and indexes into a
+constant array with the counter (`@IMM[ $.counter++ mod @IMM.elems ]`), producing the same
+"always the first element" symptom (`Innie` repeated 10 times instead of cycling through
+`Innie Minnie Moe`), but neither of those extra pieces is needed to reproduce the bug — the bare
+`my $.counter; method imm() { return $.counter++ }` case above already shows it.
+
+## Affected files (starting point)
+
+- Class-body `my $.name` declaration handling (as opposed to `has $.name`) — search for how a
+  `my`-declared, dot-twigil'd class variable is registered and how `$.counter` reads/writes route
+  to it from inside a method body. Likely in `src/runtime/class.rs` or the compiler's
+  attribute/class-var resolution (`compiler/expr.rs` — dot-twigil variable compilation) and
+  wherever class-level (vs. instance-level) storage for such variables lives.

--- a/todo/tickets/grammar-ws-boundary-and-vertical-whitespace.md
+++ b/todo/tickets/grammar-ws-boundary-and-vertical-whitespace.md
@@ -37,6 +37,18 @@ assertion inside the custom `ws` itself is misbehaving, causing the whole `ws` t
   user-defined `ws` token is looked up and invoked between atoms in a `rule`
 - `<!ww>` word-boundary assertion implementation
 
+## Update (2026-08-22, batch-6 re-run)
+
+Re-verified on current `main`: the repro above no longer just returns `False` for every case — it
+now **crashes** on the very first `.parse` call with `No such method 'ww' for invocant of type
+'Match'` (i.e. `<!ww>` inside the custom `ws` token dispatches `.ww` as a method call rather than
+recognizing it as the builtin word-boundary assertion). Same root cause area, but the failure mode
+regressed from "silently wrong match" to "hard crash, aborts the whole program" — re-found
+independently via `raku-doc/doc/Language/regexes-best-practices.rakudoc:163`'s `IniFormat`
+grammar example (`token ws { <!ww> \h* }`), which crashes identically. This confirms the bug isn't
+specific to the original repro's particular grammar/pattern — any custom `ws` token override using
+`<!ww>` hits it.
+
 ## Suggested next step
 
 Isolate further: does a *plain* custom `ws { \h* }` (no `<!ww>`) already work for the `rule TOP {

--- a/todo/tickets/loop-label-name-rejects-hyphens.md
+++ b/todo/tickets/loop-label-name-rejects-hyphens.md
@@ -1,0 +1,112 @@
+# Loop labels containing a hyphen (`MY-LABEL:`) are silently ignored by `next`/`last`/`redo`
+
+Found by the doc-diff harness re-run (`docs/doc-diff-backlog.md`, `Type/Label.rakudoc:87,101,120`).
+
+## Root cause
+
+`src/parser/helpers.rs::is_loop_label_name` (around line 558) is used to decide whether an
+identifier following `next`/`last`/`redo` (in `src/parser/stmt/simple/control_stmts.rs`) is a
+loop label argument or not:
+
+```rust
+pub(super) fn is_loop_label_name(name: &str) -> bool {
+    let mut chars = name.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    if !first.is_ascii_uppercase() && first != '_' {
+        return false;
+    }
+    chars.all(|c| c.is_ascii_uppercase() || c.is_ascii_digit() || c == '_')
+}
+```
+
+This rejects any label containing a hyphen. But Raku's kebab-case identifier syntax allows
+hyphens in ordinary identifiers, and that includes loop labels — `raku-doc/doc/Type/Label.rakudoc`
+uses exactly this style (`MY-LABEL:`) in its own canonical example. Because `is_loop_label_name`
+returns `false` for `"MY-LABEL"`, `next_stmt`/`last_stmt`/`redo_stmt` in
+`src/parser/stmt/simple/control_stmts.rs` fall through to the unconditional, unlabeled form
+(`Stmt::Next(None)` / `Stmt::Last(None)` / `Stmt::Redo(None)`), and the label token itself (plus
+any trailing `if`/`unless` statement modifier) is left to be parsed as an unrelated *following*
+statement — a bare identifier expression statement, optionally with an `if`/`unless` modifier.
+
+This means:
+- `next MY-LABEL if COND;` compiles to `next; MY-LABEL if COND;` (an unconditional `next`, plus a
+  dead/harmless expression statement) — the loop body's `next` fires on every iteration regardless
+  of `COND`, so nothing after the `next` in the loop body ever runs.
+- `last MY-LABEL if COND;` likewise becomes an unconditional `last` — the loop exits on its first
+  iteration instead of exiting once `COND` becomes true.
+- `redo MY-LABEL unless COND;` becomes an unconditional `redo` — the loop body redoes forever
+  regardless of `COND`, hanging (this is what produced the `exit 124` timeout for finding [2] in
+  the harness report).
+
+Confirmed with `--dump-ast`: `next MY-LABEL if $_ < 5;` compiles to two separate statements,
+`Next(None)` followed by an `If` whose `then_branch` is `Expr(BareWord("MY-LABEL"))`.
+
+Loop *label declarations* (`LABEL: for ... { }`, handled by
+`src/parser/stmt/control/labeled_loop.rs::labeled_loop_stmt`) do **not** have this restriction —
+they accept any identifier via the ordinary `ident()` parser, hyphens included. So `MY-LABEL:` at
+the loop-declaration site parses fine; only the `next`/`last`/`redo` *reference* site (and the
+expression-context label check at `src/parser/primary/ident/identifier_call.rs:1139`, which reuses
+the same `is_loop_label_name` predicate) reject the hyphenated form.
+
+## Minimal repro
+
+```raku
+MY-LABEL:
+for 1..10 {
+    next MY-LABEL if $_ < 5;
+    print "$_ ";
+}
+```
+
+- `raku`: `5 6 7 8 9 10 `
+- `mutsu` (`target/debug/mutsu`): prints nothing (the `next` fires unconditionally every
+  iteration).
+
+```raku
+MY-LABEL:
+for 1..10 {
+    last MY-LABEL if $_ > 5;
+    print "$_ ";
+}
+```
+- `raku`: `1 2 3 4 5 `
+- `mutsu`: prints nothing (the `last` fires unconditionally on the first iteration).
+
+```raku
+my $has-repeated = False;
+MY-LABEL:
+for 1..10 {
+    print "$_ ";
+    if $_ == 5 {
+        LEAVE $has-repeated = True;
+        redo MY-LABEL unless $has-repeated;
+    }
+}
+```
+- `raku`: `1 2 3 4 5 5 6 7 8 9 10 `
+- `mutsu`: hangs (unconditional `redo` loops forever on `$_ == 5`).
+
+## Affected files
+
+- `src/parser/helpers.rs` — `is_loop_label_name` (the character-class predicate itself)
+- `src/parser/stmt/simple/control_stmts.rs` — `last_stmt`/`next_stmt`/`redo_stmt`, which gate the
+  label-vs-bare-form branch on this predicate
+- `src/parser/primary/ident/identifier_call.rs:1139` — the expression-context labeled-loop check,
+  which reuses the same predicate
+
+## Suggested next step
+
+Widen `is_loop_label_name` to accept the same hyphen-continuation rule ordinary Raku identifiers
+use (mirroring whatever character class `ident()` itself accepts for continuation). Verified with
+`raku` that labels are **not** restricted to all-caps either — a lowercase label
+(`my-label: for 1..3 { next my-label if $_ < 2; print "$_ "; }`) is legal and works
+(`raku` prints `2 3`). So the real fix is likely broader than "allow hyphens": a loop label is just
+an ordinary Raku identifier, and the ALL-CAPS-only restriction in `is_loop_label_name` exists only
+to disambiguate `next`/`last`/`redo` (which take an *optional* label with no other trailing term)
+from other constructs, not because labels are semantically restricted to uppercase. Whatever
+replaces this predicate must still avoid misparsing `next SOMETHING-THAT-IS-NOT-A-LABEL` (loop
+control statements don't take arbitrary expression arguments, so the disambiguation only needs to
+avoid swallowing a following statement/expression that happens to start with an identifier — e.g.
+a same-line `next if COND` where `if` is a keyword, not a label).

--- a/todo/tickets/metamodel-classhow-set-ver-auth-api-missing.md
+++ b/todo/tickets/metamodel-classhow-set-ver-auth-api-missing.md
@@ -1,0 +1,35 @@
+# `.^set_ver` / `.^set_auth` / `.^set_api` (Metamodel::Versioning) are unimplemented
+
+Found by the doc-diff harness re-run (`docs/doc-diff-backlog.md`,
+`Type/Metamodel/Versioning.rakudoc:27`).
+
+## Root cause
+
+`Metamodel::Versioning` is a metaclass role providing `.^ver`/`.^auth`/`.^api` (read) and
+`.^set_ver`/`.^set_auth`/`.^set_api` (write, typically used once at class-definition time, e.g. in
+a `BEGIN` block, to programmatically tag a class with a version/author/API-level). mutsu's
+`Perl6::Metamodel::ClassHOW` has no `set_ver`/`set_auth`/`set_api` methods at all — calling any of
+them throws `X::Method::NotFound`. (The read-side `.^ver`/`.^auth`/`.^api` were not exercised by
+this repro since the write call fails first, but they are presumably equally unimplemented or, at
+best, partially implemented via the `is Class(:ver<...>)`-style trait path rather than the runtime
+`.^set_*` API — worth checking both directions.)
+
+## Minimal repro
+
+```raku
+class Versioned { }
+Versioned.^set_ver: v0.0.1;
+say Versioned.^ver;
+```
+- `raku`: `v0.0.1`
+- `mutsu`: `No such method 'set_ver' for invocant of type 'Perl6::Metamodel::ClassHOW'`
+
+The doc's original example additionally calls `.^set_auth`/`.^set_api` inside a `BEGIN` block and
+reads all three back — same root cause, just exercising the sibling methods too.
+
+## Affected files (starting point)
+
+- `Perl6::Metamodel::ClassHOW` implementation — search for `ClassHOW` and existing `ver`/`auth`/
+  `api` metaclass method plumbing (likely already exists in read-only form for `is Class(:ver<>,
+  :auth<>, :api<>)`-declared classes) in `src/runtime/class.rs` / metamodel-related modules, and
+  add the mutating `set_ver`/`set_auth`/`set_api` counterparts.

--- a/todo/tickets/pod-formattingcode-raku-missing-attributes.md
+++ b/todo/tickets/pod-formattingcode-raku-missing-attributes.md
@@ -1,0 +1,35 @@
+# `Pod::FormattingCode.raku` prints only the bare class name, omitting all attributes
+
+Found by the doc-diff harness re-run (`docs/doc-diff-backlog.md`, `Language/glossary.rakudoc:1024`).
+
+## Root cause
+
+`Pod::FormattingCode`'s `.raku` representation should round-trip its constructor call, showing
+`type`, `meta`, `config`, and `contents` (mirroring how other Pod:: block objects' `.raku` already
+work). mutsu's `.raku` for `Pod::FormattingCode` prints only `Pod::FormattingCode.new` with no
+attribute list at all — the generic default-`.raku`-for-an-instance fallback is presumably being
+used instead of a type-specific (or attribute-introspecting) `.raku` for this Pod class.
+
+## Minimal repro
+
+```raku
+=begin pod
+C<foo>
+=end pod
+say $=pod[0].contents[0].contents.raku;
+```
+- `raku`: `[Pod::FormattingCode.new(type => "C", meta => [], config => {}, contents => ["foo"])]`
+- `mutsu`: `(Pod::FormattingCode.new,)`
+
+(Note the outer container also differs — `[...]` vs `(...)` — but the primary bug is the missing
+attribute list; investigate the outer-container mismatch too if it turns out not to be a separate
+existing issue.)
+
+## Affected files (starting point)
+
+- Wherever `Pod::FormattingCode` (and sibling `Pod::*` block classes) are defined/registered —
+  search for `Pod::FormattingCode` in `src/runtime/` (pod parsing/AST-to-Pod-object construction)
+  to find where its attributes (`type`/`meta`/`config`/`contents`) are stored, then check whether
+  the generic instance `.raku` builtin (`src/builtins/methods_0arg/raku_repr.rs`) fails to
+  enumerate them because they're stored in some non-standard internal representation rather than
+  ordinary public attributes.

--- a/todo/tickets/slurpy-hash-named-arg-raku-boolean-shorthand-missing.md
+++ b/todo/tickets/slurpy-hash-named-arg-raku-boolean-shorthand-missing.md
@@ -1,0 +1,52 @@
+# `.raku` on a `Hash` populated from slurpy `*%h` named-arg binding doesn't abbreviate Bool::True pairs
+
+Found by the doc-diff harness re-run (`docs/doc-diff-backlog.md`, `Type/Pair.rakudoc:61`).
+
+## Root cause hypothesis
+
+When a caller passes boolean-valued named arguments (`s :a1:b2;` or `s a => True;`) that get
+collected into a callee's slurpy `*%h` parameter, real `raku`'s `Hash.raku` renders `Bool::True`
+values in the Pair shorthand form (`:a1`, `:a`) rather than the fully-spelled-out
+`:a1(Bool::True)` form — even when the argument was written with explicit `=>` syntax rather than
+colon-pair syntax. mutsu always renders the fully-spelled-out form for a slurpy-hash-collected
+`Bool::True` pair.
+
+Curiously, this abbreviation does **not** happen for a `Hash` built by direct literal/list
+assignment with the same `Bool::True` values — both `raku` and mutsu print the full
+`:a(Bool::True)` form there, and both already agree on `.raku` for a **standalone** `Pair` (not
+inside a `Hash`) with a `Bool::True` value (`:a1`, in both). So the divergence is specific to
+`Hash.raku`'s handling of pairs that arrived via slurpy-hash **argument binding** — something in
+mutsu's named-argument-to-slurpy-hash collection path does not preserve whatever marker Rakudo
+uses (possibly related to how `Capture`/signature-binding materializes named args as Pairs, vs.
+how a hash literal materializes `=>` pairs) to make `Hash.raku` choose the shorthand form.
+
+## Minimal repro
+
+```raku
+sub s(*%h){ say %h.raku };
+s :a1:b2;
+```
+- `raku`: `{:a1, :b2}`
+- `mutsu`: `{:a1(Bool::True), :b2(Bool::True)}`
+
+Also reproduces with explicit `=>` syntax at the call site (ruling out a colon-pair-specific
+marker):
+```raku
+sub s(*%h){ say %h.raku }; s a => True;
+```
+- `raku`: `{:a}`
+- `mutsu`: `{:a(Bool::True)}`
+
+Does **not** reproduce for a plain hash literal/list assignment (both sides agree, full form):
+```raku
+my %h = a => True, b => False, c => 1; say %h.raku;
+# both raku and mutsu: {:a(Bool::True), :b(Bool::False), :c(1)}
+```
+
+## Affected files (starting point)
+
+- `src/builtins/methods_0arg/raku_repr.rs` / `src/runtime/methods_raku_dispatch.rs` — `.raku`
+  rendering for `Hash`/`Pair`
+- Named-argument-to-slurpy-hash binding (wherever `*%h` collects the caller's named args into
+  Pairs) — look for whatever distinguishes a signature-bound named-arg Pair from a hash-literal
+  Pair, since that's the signal `Hash.raku` needs to consult to decide the abbreviated form.

--- a/todo/tickets/unicode-type-object-missing.md
+++ b/todo/tickets/unicode-type-object-missing.md
@@ -1,0 +1,42 @@
+# The `Unicode` type object doesn't exist — bareword `Unicode` resolves to a plain `Str`
+
+Found by the doc-diff harness re-run (`docs/doc-diff-backlog.md`, `Type/Unicode.rakudoc:27,37`).
+
+## Root cause
+
+Raku has a built-in `Unicode` class (a singleton-style type used to query the Unicode database
+version and normalization-form settings the running VM uses, via class methods like `.version`,
+`.NFG`, `.NFC`, `.NFD`, `.NFKC`, `.NFKD`). mutsu does not implement this type at all: the bareword
+`Unicode` falls back to being interpreted as a plain string.
+
+```raku
+say Unicode.^name;
+```
+- `raku`: `Unicode`
+- `mutsu`: `Str`
+
+Calling any class method on it then fails, since mutsu is really calling a `Str` method:
+```raku
+say Unicode.version; # raku: v17.0 (doc says v15.0, drifted since); mutsu: No such method 'version' for invocant of type 'Str'
+say Unicode.NFG;      # raku: True; mutsu: No such method 'NFG' for invocant of type 'Str', "Did you mean 'NFC'?"
+```
+
+(Note: `Unicode.version` itself is `raku-drift` relative to the doc's stated `v15.0` — current
+`raku` reports `v17.0` — but the underlying bug, that mutsu has no `Unicode` type at all, is real
+and independent of which Unicode DB version is the "right" answer.)
+
+## Minimal repro
+
+```raku
+say Unicode.^name;
+```
+- `raku`: `Unicode`
+- `mutsu`: `Str`
+
+## Affected files (starting point)
+
+- Wherever mutsu's other built-in singleton-style types are registered (e.g. how `NFC`/`NFD`
+  normalization-form values or similar core type objects are set up) — search for existing
+  `Unicode`-related builtins (unicode.rs / `builtins/unicode.rs`) to see whether the underlying
+  version/NFG-query data already exists and just needs a `Unicode` type object + class methods
+  wired to it, versus needing new plumbing entirely.

--- a/todo/tickets/x-proc-async-mustbestarted-str-not-message.md
+++ b/todo/tickets/x-proc-async-mustbestarted-str-not-message.md
@@ -1,0 +1,30 @@
+# `X::Proc::Async::MustBeStarted.Str` returns the class name instead of its message
+
+Found by the doc-diff harness re-run (`docs/doc-diff-backlog.md`,
+`Type/X/Proc/Async/MustBeStarted.rakudoc:14`).
+
+## Root cause hypothesis
+
+`X::Proc::Async::MustBeStarted` is thrown when a method requiring a started `Proc::Async` (e.g.
+`.say`, `.print`, `.write`) is called before `.start`. Its `.Str`/message rendering should produce
+`"Process must be started first before calling '<method>'"` (interpolating the offending method
+name), but mutsu's `.Str` for this exception just returns the bare type name
+`"X::Proc::Async::MustBeStarted"` instead — i.e. the exception's `message`/`Str` method either
+isn't overridden for this type, or is falling back to a generic default that stringifies to the
+class name.
+
+## Minimal repro
+
+```raku
+Proc::Async.new('echo', :w).say(42);
+CATCH { default { put .^name, ': ', .Str } };
+```
+- `raku`: `X::Proc::Async::MustBeStarted: Process must be started first before calling 'say'`
+- `mutsu`: `X::Proc::Async::MustBeStarted: X::Proc::Async::MustBeStarted`
+
+## Affected files (starting point)
+
+- Wherever `X::Proc::Async::MustBeStarted` is defined/thrown (search for `MustBeStarted` in
+  `src/runtime/`) — needs a `.message`/`.Str` (or the general exception-message-formatting hook
+  other `X::` types use) that interpolates the method name that triggered it, not just the bare
+  class name.


### PR DESCRIPTION
## Summary
- Final sub-batch (batch6-B) of the doc-diff full-corpus re-sweep, triaging 11 files.
- Files 8 new tickets under `todo/tickets/` for confirmed-real divergences (loop labels with hyphens, slurpy-hash Bool shorthand in `.raku`, array-attribute `is default` reset, missing `Unicode` type object, `X::Proc::Async::MustBeStarted.Str`, class-scoped `my $.counter` not persisting, `Pod::FormattingCode.raku` missing attributes, missing `.^set_ver`/`.^set_auth`/`.^set_api`).
- Two findings turned out to be exact duplicates of already-filed tickets (`lexical-typed-var-dot-equals-init-fails.md`, `run-shell-discard-stdout-stderr-by-default.md`) and one duplicates `iopath-win32-separator-normalization.md` — cross-linked instead of re-filed.
- Updated `grammar-ws-boundary-and-vertical-whitespace.md` with a new finding: its repro now hard-crashes (`No such method 'ww'`) instead of just mismatching.
- Updated `docs/doc-diff-backlog.md` with the new batch-6 subsection.

## Test plan
- [x] Re-verified every finding directly with `raku -e`/`target/debug/mutsu` (or a `tmp/*.raku` file) before filing.
- [x] Docs/todo-only change — no source code touched, so this should hit the CI docs-only fast path.