### PR TITLE
docs: file doc-diff batch-6-C findings (final sub-batch)

### DIFF
--- a/docs/doc-diff-backlog.md
+++ b/docs/doc-diff-backlog.md
@@ -765,6 +765,49 @@ Found in the 2026-08-22 batch-6 re-run of `Label`/`IO::Spec::Win32`/`Pair`/`Attr
   type 'Match'`, upgraded from the ticket's originally-recorded "silently wrong match" symptom) —
   ticket updated with this finding rather than re-filed.
 
+Found in the 2026-08-22 batch-6 re-run of `js-nutshell`/`IO::Spec::Unix`/`py-nutshell`/
+`X::AdHoc`/`Metamodel::Trusting`/`X::Proc::Async::CharsOrBytes`/`Iterable`/
+`statement-prefixes`/`exceptions`/`Metamodel::Stashing`/`optut`:
+
+| file:line | one-line summary | ticket |
+|---|---|---|
+| `Language/js-nutshell.rakudoc:384` | a user `multi prefix:<++>($a) is default {...}` wins the dispatch tie against the builtin `++`, where raku keeps the builtin | [multi-is-default-loses-to-user-candidate-over-builtin.md](../todo/tickets/multi-is-default-loses-to-user-candidate-over-builtin.md) |
+| `Language/js-nutshell.rakudoc:613` | `next`/`last LABEL` inside a labeled `repeat {} while` loop throws `X::ControlFlow` instead of being caught | [labeled-next-last-in-repeat-while-loop-throws.md](../todo/tickets/labeled-next-last-in-repeat-while-loop-throws.md) |
+| `Type/IO/Spec/Unix.rakudoc:230,291` | `IO::Spec::Unix.split`/`.splitpath` mishandle all-slash, empty, and bare-`.` path inputs | [iospec-unix-split-splitpath-edge-cases-wrong.md](../todo/tickets/iospec-unix-split-splitpath-edge-cases-wrong.md) |
+| `Language/py-nutshell.rakudoc:541` | `{ BLOCK } for LIST` (bare block as a `for` statement-modifier operand) parses as an uncalled closure term instead of being invoked per iteration with `$_` | [bare-block-for-statement-modifier-not-invoked-as-loop-body.md](../todo/tickets/bare-block-for-statement-modifier-not-invoked-as-loop-body.md) |
+| `Type/X/AdHoc.rakudoc:56` | `X::AdHoc.from-slurpy(...)` class method is entirely unimplemented | [xadhoc-from-slurpy-method-missing.md](../todo/tickets/xadhoc-from-slurpy-method-missing.md) |
+| `Type/X/AdHoc.rakudoc:20` | `$!.backtrace` after a `try` block reports the `try` statement's own line, not the `die`'s actual line | [backtrace-reports-try-line-not-throw-site-line.md](../todo/tickets/backtrace-reports-try-line-not-throw-site-line.md) |
+| `Type/Metamodel/Trusting.rakudoc:18,54` | the `trusts` trait is not honored by private-method dispatch, and `.^trusts` reflection is unimplemented | [metamodel-trusting-trait-and-reflection-unimplemented.md](../todo/tickets/metamodel-trusting-trait-and-reflection-unimplemented.md) |
+| `Type/X/Proc/Async/CharsOrBytes.rakudoc:14` | `X::Proc::Async::CharsOrBytes.Str` returns the bare type name instead of the descriptive message | [procasync-charsorbytes-exception-str-shows-typename.md](../todo/tickets/procasync-charsorbytes-exception-str-shows-typename.md) |
+| `Language/statement-prefixes.rakudoc:32` | `my @array = lazy { LIST-EXPR }` stores an unforceable `lazy(...)` placeholder element; `.eager` never forces/flattens it | [lazy-block-prefix-array-assign-never-forces.md](../todo/tickets/lazy-block-prefix-array-assign-never-forces.md) |
+| `Language/exceptions.rakudoc:428` | `.resume` on a `die`-based exception raised inside a nested sub does not resume execution at the `die`'s call site | [resume-does-not-return-to-die-call-site-in-nested-sub.md](../todo/deep/resume-does-not-return-to-die-call-site-in-nested-sub.md) |
+| `Language/optut.rakudoc:12` | a user-defined `circumfix:<...>` operator with a Unicode-letter delimiter (e.g. `α ... ω`) fails to parse at the call site | [custom-circumfix-unicode-delimiter-call-parse-fail.md](../todo/tickets/custom-circumfix-unicode-delimiter-call-parse-fail.md) |
+
+**Related finding (not a new ticket):** `Type/Metamodel/Stashing.rakudoc:45` — a custom
+metaclass composing `does Metamodel::Naming does Metamodel::Stashing` fails with
+`X::InvalidType: Invalid typename 'Metamodel::Naming'` before its class body is even
+considered. Added as a "Related finding" section to the existing
+[direct-metamodel-classhow-new-type-immutable-error.md](../todo/deep/direct-metamodel-classhow-new-type-immutable-error.md)
+deep ticket, since it's the same "script type creation directly through
+`Metamodel::*`" territory as that ticket's own finding.
+
+**Excluded from this batch-6 sub-run:**
+- `Language/js-nutshell.rakudoc` [2] (line 562, `my Str %letters{Str}` iteration order)
+  — the documented known harness false positive (hash/typed-hash iteration order is
+  nondeterministic per-process in real raku too).
+- `Type/IO/Spec/Unix.rakudoc` [1] (line 99, `$*SPEC.curupdir` block gist/pointer) and
+  [2] (line 201, `$*CWD`-relative `.rel2abs` outputs) — both `raku-drift-from-doc`:
+  the harness's checkout path (`$*CWD`) and the block's own gist address are
+  inherently environment-dependent, not stable doc `# OUTPUT` values.
+- `Language/py-nutshell.rakudoc` [1] (line 387, `%elem-for-symbol.kv` iteration order)
+  — the documented known harness false positive (hash iteration order).
+- `Type/Iterable.rakudoc` [1] (line 52, `(1..10).iterator.say`) — raku's internal
+  `Iterator` implementation class names (e.g. `Rakudo::Iterator::IntRange`) are a
+  Rakudo-internal implementation detail with no cross-implementation stability
+  guarantee (mutsu has a single generic `Iterator` value type rather than a zoo of
+  per-shape internal subclasses); treated the same as the documented hex-address
+  exclusion — non-actionable, not ticketed.
+
 ### Deferred / deep (tracked elsewhere — do not re-open as a shallow slice)
 These root causes account for a large share of the survey's `mism`/`crash` and are
 intentionally deferred; see PLAN.md §8.5 and the ADRs:

--- a/todo/deep/direct-metamodel-classhow-new-type-immutable-error.md
+++ b/todo/deep/direct-metamodel-classhow-new-type-immutable-error.md
@@ -87,3 +87,39 @@ handler as the already-filed
 which has the minimal repro; fixing `new_type` to actually respect (and record) which
 `Metamodel::*HOW` it was called on is likely a prerequisite for all three findings
 tracked across these two files, not just a message-text difference.
+
+## Related finding: `Metamodel::Naming`/`Metamodel::Stashing` are not valid `does` types (2026-08-22, doc-diff batch-6)
+
+`Type/Metamodel/Stashing.rakudoc:45`'s worked example defines a *custom* metaclass
+(`class WithStashHOW does Metamodel::Naming does Metamodel::Stashing { ... }`) that
+implements `.new_type`/`.set_name`/`.add_stash` itself, calling
+`Metamodel::Primitives.create_type` directly rather than going through
+`Metamodel::ClassHOW`. This fails even earlier than the `new_type` issues above:
+
+```raku
+class WithStashHOW
+    does Metamodel::Naming
+    does Metamodel::Stashing
+{
+    method new_type(WithStashHOW:_: Str:D :$name! --> Mu) {
+        my WithStashHOW:D $meta := self.new;
+        my Mu             $type := Metamodel::Primitives.create_type: $meta, 'Uninstantiable';
+        $meta.set_name: $type, $name;
+        self.add_stash: $type
+    }
+}
+my Mu constant WithStash = WithStashHOW.new_type: :name<WithStash>;
+say WithStash.WHO; # OUTPUT: «WithStash␤»
+```
+
+- `raku`: `WithStash`
+- `mutsu`: `X::InvalidType: Invalid typename 'Metamodel::Naming'` — `Metamodel::Naming`
+  is not registered as a composable role/type at all, so the `does Metamodel::Naming`
+  clause fails before the class body is even considered.
+
+This is a distinct (and more fundamental) blocker than the `new_type`-bootstrapping
+issue above: `Metamodel::Naming`, `Metamodel::Stashing`, and `Metamodel::Primitives`
+would all need to exist as genuine composable roles/types users can `does` and call
+directly, which is a much larger slice of the MOP than just fixing `new_type`'s
+bootstrapping. Filed here (rather than as a separate ticket) since it's part of the
+same "script type creation directly through `Metamodel::*`" question raised above.

--- a/todo/deep/resume-does-not-return-to-die-call-site-in-nested-sub.md
+++ b/todo/deep/resume-does-not-return-to-die-call-site-in-nested-sub.md
@@ -1,0 +1,80 @@
+# `.resume` on a caught exception does not resume execution at the `die`'s call site inside a nested sub
+
+Found by the doc-diff harness re-run (`docs/doc-diff-backlog.md`, `Language/exceptions.rakudoc:428`).
+
+## Repro
+
+```raku
+sub bad-sub {
+    die "Something bad happened";
+    return "not returning";
+}
+
+{
+    my $return = bad-sub;
+    say "Returned $return";
+    CATCH {
+        default {
+            say "Error ", .^name, ': ', .Str;
+            $return = '0';
+            .resume;
+        }
+    }
+}
+```
+
+- `raku`:
+  ```
+  Error X::AdHoc: Something bad happened
+  Returned not returning
+  ```
+- `mutsu` (`target/debug/mutsu`):
+  ```
+  Error X::AdHoc: Something bad happened
+  ```
+  (execution stops after the `CATCH` block runs — `bad-sub` never resumes past its
+  `die`, `return "not returning"` never executes, `bad-sub`'s call never completes, and
+  the enclosing block's `say "Returned $return"` is never reached.)
+
+## Root cause hypothesis
+
+Real Raku's `.resume` on an exception is a genuine continuation: calling it inside a
+`CATCH`/`default` handler causes execution to jump back to the exact statement *after*
+the `die` call, inside `bad-sub`'s own call frame, and `bad-sub` then completes normally
+(reaching its `return "not returning"`), unwinding back to the original call site
+(`my $return = bad-sub`) as if the `die` had simply been a no-op statement.
+
+This requires the VM to preserve enough state at the `die`/throw site — the exact
+program-counter position and live locals of every frame between the `die` and the
+handler — to be able to re-enter execution there after the handler decides to resume,
+rather than just discarding the unwound frames the way a normal exception propagation
+does. mutsu's existing `.resume` support (see `try_resume_safe_control_inline` and the
+`CONTROL`/`warn` resume work referenced in `todo/deep/vendor-real-test-module.md`)
+appears to be built for **CONTROL-flow exceptions** (`warn`, which is implicitly
+resumable and whose resume point is typically shallow/simple), not for an arbitrary
+`die`-based exception resumed from several frames up. Whether the same mechanism can be
+generalized, or whether `die`+`.resume` needs its own frame-preserving throw path, is
+an open design question.
+
+## Why this is deep
+
+Implementing this correctly means the VM's exception-unwinding machinery must be able
+to *not* unwind (or must be able to reconstruct enough continuation state to resume) an
+arbitrary call-frame chain between an arbitrary `die` site and its handler — this is
+architecturally a form of resumable/continuation-based exception handling, not a
+narrow bug fix. It likely interacts with:
+
+- How mutsu currently unwinds Rust call frames on a `die` (native `Result`/panic-style
+  propagation vs. preserved VM-level frames).
+- The existing `CONTROL`/`warn` resume machinery (`try_resume_safe_control_inline`,
+  `src/vm/` resume-safe control handling) — worth investigating whether that mechanism
+  already preserves what's needed and just isn't wired up for regular `X::*`
+  exceptions, or whether it fundamentally can't reach nested-sub call depth.
+
+## Affected files (starting point)
+
+- `src/vm/vm_control_ops.rs` (try/CATCH/`.resume` handling).
+- Exception-throw / call-frame-unwind machinery generally — grep for where `die`
+  triggers Rust-level unwinding vs. VM-level frame teardown.
+- `todo/deep/vendor-real-test-module.md`'s `warn-resumes-at-the-raise-site.t` sections
+  for prior art on the existing (CONTROL-exception-only) resume mechanism.

--- a/todo/tickets/backtrace-reports-try-line-not-throw-site-line.md
+++ b/todo/tickets/backtrace-reports-try-line-not-throw-site-line.md
@@ -1,0 +1,37 @@
+# `$!.backtrace` after a `try` block reports the `try` statement's own line, not the actual `die`'s line
+
+Found by the doc-diff harness re-run (`docs/doc-diff-backlog.md`, `Type/X/AdHoc.rakudoc:20`).
+
+## Root cause hypothesis
+
+When an exception is caught by `try` (or a `CATCH` block) and its `.backtrace` is read
+afterward, mutsu's backtrace records the source line of the `try {` statement itself
+rather than the line the `die`/throwing expression actually executed on. Real Rakudo's
+backtrace always points at the throw site, regardless of how many lines the `try`
+block's body spans before the `die`.
+
+## Minimal repro
+
+```raku
+try {
+    die "boom";
+}
+say $!.backtrace.Str;
+```
+
+(the `die` is on line 3, inside a `try` starting on line 2)
+
+- `raku`: `  in block <unit> at -e line 3`  (correctly points at the `die`)
+- `mutsu` (`target/debug/mutsu`): `  in block <unit> at -e line 2`  (points at the
+  `try` line instead)
+
+A `die` **not** inside a `try` (bare top-level) already reports the correct line —
+this only reproduces for the backtrace attached to an exception object recovered via
+`$!` after a `try`/`CATCH`.
+
+## Affected files (starting point)
+
+Wherever the `try`/`CATCH` VM op constructs or attaches the exception's backtrace
+(`vm/vm_control_ops.rs` try/catch handling) — likely capturing the current line number
+at the wrong point (the `try` statement's compiled position) instead of propagating the
+line recorded at the actual `die`/throw call site.

--- a/todo/tickets/bare-block-for-statement-modifier-not-invoked-as-loop-body.md
+++ b/todo/tickets/bare-block-for-statement-modifier-not-invoked-as-loop-body.md
@@ -1,0 +1,39 @@
+# `{ BLOCK } for LIST` (bare block as a `for` statement-modifier operand) is parsed as an uncalled closure term
+
+Found by the doc-diff harness re-run (`docs/doc-diff-backlog.md`, `Language/py-nutshell.rakudoc:541`).
+
+## Root cause hypothesis
+
+`EXPR for LIST` (the `for` statement-modifier) evaluates `EXPR` once per element of
+`LIST`, with `$_` bound to the current element. When `EXPR` is a bare `{ ... }` block,
+real Raku treats the block the same way it would treat the body of `for LIST { ... }`
+written the other way around: the block is invoked per iteration with `$_` set, and its
+return value is collected.
+
+mutsu's `--dump-ast` shows that `{ $_[0] + $_[1] } for LIST` compiles the block as an
+`Expr::AnonSub` term inside the `for`'s body — i.e. each iteration evaluates the
+`{...}` as a *closure literal* (producing a `Sub` value) rather than *calling* it with
+`$_` bound. The loop therefore collects a list of never-invoked closures instead of
+their results, and `say`ing that list produces empty output.
+
+## Minimal repro
+
+```raku
+say ( { $_ + 1 } for 1,2,3 );
+```
+
+- `raku`: `(2 3 4)`
+- `mutsu` (`target/debug/mutsu`): `(  )` (three empty/blank items — the uncalled closures)
+
+Confirmed unrelated to the doc's `X`-cross or sigilless-parameter forms: the same
+bare-block shape fails standalone, while the equivalent bare-expression form (no
+braces, e.g. `$_ + 1 for 1,2,3`) and the pointy-block forms (`-> $i, $j { ... } for ...`)
+both already work correctly.
+
+## Affected files (starting point)
+
+The `for` statement-modifier's parsing of its `EXPR` operand — needs to special-case a
+literal `{ ... }` immediately followed by `for` (or more generally, recognize this
+shape as a block-body-for-loop rather than a bare closure term), similar to the
+existing `say {...}` hash-vs-block disambiguation elsewhere in the parser. Likely in
+`src/parser/` around statement-modifier / `for` postfix parsing.

--- a/todo/tickets/custom-circumfix-unicode-delimiter-call-parse-fail.md
+++ b/todo/tickets/custom-circumfix-unicode-delimiter-call-parse-fail.md
@@ -1,0 +1,44 @@
+# User-defined `circumfix:<...>` with a non-ASCII (Unicode-letter) delimiter fails to parse at the call site
+
+Found by the doc-diff harness re-run (`docs/doc-diff-backlog.md`, `Language/optut.rakudoc:12`).
+
+## Root cause hypothesis
+
+Defining `sub circumfix:<α ω>( $a ) { ... }` itself parses fine. Calling it
+(`α 5 ω;`) fails to parse: mutsu's tokenizer/parser does not recognize a bare
+Unicode-letter identifier token (`α`) as a valid opening delimiter for a
+previously-declared custom circumfix operator invocation. The equivalent ASCII forms —
+single-token (`sub circumfix:<[[ ]]>`) and space-separated multi-word ASCII identifiers
+(`sub circumfix:<FOO BAR>`, called as `FOO 5 BAR`) — both already work correctly, so
+the gap is specifically in recognizing non-ASCII/Unicode-letter tokens as custom
+circumfix-operator delimiters at the call site, not in circumfix-operator support in
+general.
+
+## Minimal repro
+
+```raku
+sub circumfix:<α ω>( $a ) {
+    say $a * 2;
+}
+α 5 ω;
+```
+
+- `raku`: `10`
+- `mutsu` (`target/debug/mutsu`):
+  ```
+  ===SORRY!=== Error while compiling ...
+  Confused. expected statement: expected expression statement or expression after infix operator or '.' or digits or generic radix literal or ...
+  ------>α 5 ω;
+         ^
+  ```
+
+Confirmed the delimiter's Unicode-ness (not multi-char-ness) is the trigger:
+`sub circumfix:<αX Xω>(...)` called as `αX 5 Xω;` fails the same way, while
+`sub circumfix:<FOO BAR>(...)` called as `FOO 5 BAR;` works.
+
+## Affected files (starting point)
+
+The parser's custom-operator lookup for circumfix invocations (grep for where declared
+`circumfix:<...>` operators are matched against upcoming tokens) — likely in
+`src/parser/`, needs to accept a leading Unicode-letter/identifier token the same way
+it already accepts an ASCII bareword token as a registered circumfix opener.

--- a/todo/tickets/iospec-unix-split-splitpath-edge-cases-wrong.md
+++ b/todo/tickets/iospec-unix-split-splitpath-edge-cases-wrong.md
@@ -1,0 +1,45 @@
+# `IO::Spec::Unix.split`/`.splitpath` mishandle all-slash, empty, and single-dot paths
+
+Found by the doc-diff harness re-run (`docs/doc-diff-backlog.md`, `Type/IO/Spec/Unix.rakudoc:230`
+and `:291`).
+
+## Root cause hypothesis
+
+`IO::Spec::Unix.split(...)` and `.splitpath(...)` compute the directory/basename split
+correctly for normal paths, but mishandle a few edge-case inputs: an all-slashes path
+(`'///'`), the empty string, and a bare `'.'`. In each case mutsu appears to fall back
+to treating the whole (or a truncated) input as the "dirname" component and leaves the
+basename empty, where raku treats a bare `.`/all-slash input specially (keeping `.`/`/`
+as the basename too, or as the sole path component depending on the method).
+
+## Minimal repro
+
+```raku
+IO::Spec::Unix.split('///').raku.say;
+IO::Spec::Unix.split('').raku.say;
+IO::Spec::Unix.splitpath('.').raku.say;
+```
+
+- `raku`:
+  ```
+  IO::Path::Parts.new("","/","/")
+  IO::Path::Parts.new("","","")
+  ("", "", ".")
+  ```
+- `mutsu` (`target/debug/mutsu`):
+  ```
+  IO::Path::Parts.new("",".","")
+  IO::Path::Parts.new("",".","")
+  ("", ".", "")
+  ```
+
+Every other case in the doc's `.split`/`.splitpath` example tables (normal paths,
+trailing slash, `'./'`, Windows-style `C:/foo/bar.txt`) already matches raku exactly —
+only these three edge-case inputs diverge.
+
+## Affected files (starting point)
+
+`src/runtime/methods_call_dispatch.rs:1517` (`"splitpath"` dispatch arm) and wherever
+the sibling `.split` method for `IO::Spec::Unix` is implemented (grep for
+`"IO::Path::Parts"` / `Path::Parts` construction) — likely the same underlying
+dirname/basename decomposition helper feeds both methods.

--- a/todo/tickets/labeled-next-last-in-repeat-while-loop-throws.md
+++ b/todo/tickets/labeled-next-last-in-repeat-while-loop-throws.md
@@ -1,0 +1,38 @@
+# `next LABEL` / `last LABEL` inside a labeled `repeat {} while` loop throws X::ControlFlow
+
+Found by the doc-diff harness re-run (`docs/doc-diff-backlog.md`, `Language/js-nutshell.rakudoc:613`).
+
+## Root cause hypothesis
+
+A `repeat {...} while COND` (or `repeat while COND {...}`) loop's own control-flow
+handling recognizes unlabeled `next`/`last`, but does not recognize a `next`/`last`
+that targets the loop's own label. The labeled control-flow exception propagates past
+the `repeat` loop's catch site (which apparently only matches unlabeled `next`/`last`,
+or matches on some internal loop-id that isn't wired up for `repeat`), so it escapes as
+an uncaught `X::ControlFlow` runtime error instead of being caught and handled by the
+labeled loop.
+
+Every other labeled loop form (`for`, `while`, `loop`) handles a labeled `next`/`last`
+targeting itself correctly; only `repeat` reproduces this.
+
+## Minimal repro
+
+```raku
+OUTSIDE: repeat { next OUTSIDE; } while False;
+say "done";
+```
+
+- `raku`: prints `done`
+- `mutsu` (`target/debug/mutsu`): `Runtime error: X::ControlFlow`
+
+Also fails with `last OUTSIDE;` in place of `next OUTSIDE;`. An unlabeled `next;` (no
+label) inside the same `repeat` loop works fine — only the labeled form is broken.
+
+The original doc example nests this inside a `for %primes.keys` statement-modifier,
+but the label/repeat interaction alone reproduces it without any `for`.
+
+## Affected files (starting point)
+
+Loop control-flow handling in `vm/vm_control_ops.rs` (the `repeat`/`while`/`until`
+loop execution path) — compare how `next`/`last` label matching is wired for `for`
+loops vs. `repeat` loops.

--- a/todo/tickets/lazy-block-prefix-array-assign-never-forces.md
+++ b/todo/tickets/lazy-block-prefix-array-assign-never-forces.md
@@ -1,0 +1,56 @@
+# `my @array = lazy { LIST-EXPR }` stores an unforceable `lazy(...)` thunk element instead of a lazy list
+
+Found by the doc-diff harness re-run (`docs/doc-diff-backlog.md`, `Language/statement-prefixes.rakudoc:32`).
+
+## Root cause hypothesis
+
+The `lazy` statement-prefix applied to a block (`lazy { (^3).map( *² ) }`) should
+produce a lazy `Seq`/list whose *elements* are individually lazy-realized, so that
+assigning it to `my @array` stores an array whose elements get filled in on demand.
+`say @array` before forcing should show `[...]` (unrealized), and `@array.eager` should
+force and flatten it to `[0 1 4]`.
+
+mutsu instead appears to wrap the *entire block result* as a single `LazyThunk` value
+and stores that as one element of `@array` (see `src/value/display.rs` around line
+1084-1093, `ValueView::LazyThunk` displaying as the placeholder string `"lazy(...)"`
+when unforced). Both plain `say @array` and `@array.eager` show `[lazy(...)]` — the
+`.eager` call is not forcing-and-flattening the thunk into the array's actual element
+sequence; it just leaves the single opaque thunk element in place (and even the
+un-eager print renders `lazy(...)` as if it were a value, not raku's generic `...`
+not-yet-computed marker).
+
+## Minimal repro
+
+```raku
+my @array = lazy { (^3).map( *² )  };
+say @array;
+say @array.eager;
+```
+
+- `raku`:
+  ```
+  [...]
+  [0 1 4]
+  ```
+- `mutsu` (`target/debug/mutsu`):
+  ```
+  [lazy(...)]
+  [lazy(...)]
+  ```
+
+## Relationship to the existing Lazy-list cluster
+
+This is related to (but not identical to) the already-**Deferred** lazy-list cluster's
+"closure_seq / scan_spec arrays stay force-capped on `@`-assign" residue noted in
+`docs/doc-diff-backlog.md`'s Deferred section — both are about a lazily-computed value
+not surviving `@`-array assignment intact. This finding is specifically about the
+`lazy { BLOCK }` statement-prefix form (as opposed to a `...` sequence operator), and
+about `.eager` failing to force a `LazyThunk` at all (not just failing to share the
+reifier across a `.clone`), so it is filed separately in case the fix site differs.
+
+## Affected files (starting point)
+
+- `src/value/display.rs` (~line 1084) — `ValueView::LazyThunk` display.
+- Wherever `lazy { BLOCK }` statement-prefix is compiled/executed, and wherever
+  `.eager` is implemented for arrays containing a `LazyThunk` element (grep for
+  `LazyThunk` and `is_value_lazy` across `src/runtime/` and `src/vm/`).

--- a/todo/tickets/metamodel-trusting-trait-and-reflection-unimplemented.md
+++ b/todo/tickets/metamodel-trusting-trait-and-reflection-unimplemented.md
@@ -1,0 +1,57 @@
+# `trusts` trait is not honored, and `.^trusts` reflection method is unimplemented
+
+Found by the doc-diff harness re-run (`docs/doc-diff-backlog.md`,
+`Type/Metamodel/Trusting.rakudoc:18` and `:54`).
+
+## Root cause
+
+Two related gaps in `Metamodel::Trusting` support:
+
+1. **The `trusts TYPE;` trait declaration inside a class body has no effect on private
+   method dispatch.** A class that declares `trusts A;` should allow `A` to call its
+   private methods (via `$obj!ClassName::method()`) even from outside the trusting
+   class's own methods. mutsu still throws "does not trust" as if the trait were never
+   registered.
+2. **`SomeClass.^trusts` (the `Metamodel::Trusting` reflection method that lists the
+   trusted types) is entirely unimplemented** — calling it throws `X::Method::NotFound`
+   ("No such method 'trusts' for invocant of type 'Perl6::Metamodel::ClassHOW'").
+
+## Minimal repros
+
+```raku
+class A {
+    my class B {
+        trusts A;
+        method !private_method() {
+            say "Private method in B";
+        }
+    }
+    method build-and-poke {
+        B.new()!B::private_method();
+    }
+};
+A.build-and-poke;
+```
+
+- `raku`: `Private method in B`
+- `mutsu` (`target/debug/mutsu`): `Cannot call private method 'private_method' on
+  package B because it does not trust A`
+
+```raku
+class A { trusts Int; };
+say .^name for A.^trusts;
+```
+
+- `raku`: `Int`
+- `mutsu`: `No such method 'trusts' for invocant of type 'Perl6::Metamodel::ClassHOW'`
+
+## Affected files (starting point)
+
+- Wherever the `trusts` trait is parsed/registered on a class declaration (grep for
+  `"trusts"` in `compiler/`/`runtime/class.rs`) — check whether the trait is recorded
+  at all, or recorded but never consulted by the private-method-call permission check.
+- The private-method-call guard that currently always rejects cross-class private
+  calls (grep for "does not trust" / "Cannot call private method").
+- `Perl6::Metamodel::ClassHOW`'s reflection-method dispatch (`.^trusts`) — needs a new
+  0-arg reflection method returning the registered trusted-type list, alongside the
+  existing `.^methods`/`.^attributes`/etc.

--- a/todo/tickets/multi-is-default-loses-to-user-candidate-over-builtin.md
+++ b/todo/tickets/multi-is-default-loses-to-user-candidate-over-builtin.md
@@ -1,0 +1,35 @@
+# A user `multi` candidate marked `is default` wins a tie against the builtin instead of losing to it
+
+Found by the doc-diff harness re-run (`docs/doc-diff-backlog.md`, `Language/js-nutshell.rakudoc:384`).
+
+## Root cause hypothesis
+
+Declaring `multi prefix:<++>($a) is default { $a - 1 }` adds a user-defined multi
+candidate for the built-in `prefix:<++>` operator. In real Rakudo, `++$foo` on a plain
+`Int` still dispatches to the built-in numeric increment (`$foo` becomes `2`), even
+though the user's candidate is also applicable and marked `is default`. mutsu instead
+dispatches to the user's candidate (`$foo` becomes `0`, i.e. `$a - 1` with `$a == 1`).
+
+`is default` in Raku only breaks ties among otherwise-ambiguous candidates that are
+equally narrow; it does not make a user candidate preferred over a builtin whose own
+signature is already the (or a) best match. mutsu's multi-dispatch resolution appears
+to treat a user `is default` candidate as unconditionally preferred, or fails to give
+the builtin operator's own (typically `Int:D`-narrowed) candidate priority over a
+generic user `($a)` signature.
+
+## Minimal repro
+
+```raku
+multi prefix:<++>($a) is default { $a - 1 }
+my $foo = 1;
+say ++$foo;
+```
+
+- `raku`: `2`
+- `mutsu` (`target/debug/mutsu`): `0`
+
+## Affected files (starting point)
+
+Multi-dispatch candidate resolution / `is default` trait handling — likely in
+`runtime/dispatch.rs` or wherever multi candidates are ranked (grep for `"is default"`
+/ `is_default` and the prefix `++`/`--` builtin operator registration).

--- a/todo/tickets/procasync-charsorbytes-exception-str-shows-typename.md
+++ b/todo/tickets/procasync-charsorbytes-exception-str-shows-typename.md
@@ -1,0 +1,35 @@
+# `X::Proc::Async::CharsOrBytes.Str` returns the type name instead of the exception message
+
+Found by the doc-diff harness re-run (`docs/doc-diff-backlog.md`,
+`Type/X/Proc/Async/CharsOrBytes.rakudoc:14`).
+
+## Root cause hypothesis
+
+When tapping both `.stdout` and `.stdout(:bin)` on the same `Proc::Async`, mutsu
+correctly throws an `X::Proc::Async::CharsOrBytes` exception (the `.^name` in the
+harness output matches raku exactly), but the exception's `.Str` (and presumably
+`.message`) returns the literal type name `X::Proc::Async::CharsOrBytes` instead of the
+descriptive message ("Can only tap one of chars or bytes supply for stdout"). This
+looks like `X::Proc::Async::CharsOrBytes` is missing its `.message` method override (or
+the constructor doesn't populate whatever field `.message`/`.Str` reads), so it falls
+back to the generic default that just stringifies the type.
+
+## Minimal repro
+
+```raku
+my $proc = Proc::Async.new('echo');
+$proc.stdout.tap(&print);
+$proc.stdout(:bin).tap(&print);
+CATCH { default { put .^name, ': ', .Str } };
+```
+
+- `raku`: `X::Proc::Async::CharsOrBytes: Can only tap one of chars or bytes supply for stdout`
+- `mutsu` (`target/debug/mutsu`): `X::Proc::Async::CharsOrBytes: X::Proc::Async::CharsOrBytes`
+
+## Affected files (starting point)
+
+Wherever `X::Proc::Async::CharsOrBytes` is thrown/constructed (grep for
+`"CharsOrBytes"` in `runtime/`) — needs a `.message` method that builds the descriptive
+string (it should mention which of stdout/stderr and note "chars or bytes"), matching
+the pattern used by other `X::*` exception types that already have a working
+`.message`.

--- a/todo/tickets/xadhoc-from-slurpy-method-missing.md
+++ b/todo/tickets/xadhoc-from-slurpy-method-missing.md
@@ -1,0 +1,38 @@
+# `X::AdHoc.from-slurpy(...)` class method is entirely unimplemented
+
+Found by the doc-diff harness re-run (`docs/doc-diff-backlog.md`, `Type/X/AdHoc.rakudoc:56`).
+
+## Root cause
+
+`X::AdHoc.from-slurpy(...)` is a documented class method that builds an `X::AdHoc`
+whose `.payload` is a `Capture+{X::AdHoc::SlurpySentry}` built from the positional
+slurpy arguments, and whose `.message` is the concatenation of their stringifications.
+mutsu has no such method at all — calling it throws `X::Method::NotFound`.
+
+## Minimal repro
+
+```raku
+my $e = X::AdHoc.from-slurpy(3, False, "x");
+```
+
+- `raku`: succeeds, `$e.payload.^name` is `Capture+{X::AdHoc::SlurpySentry}`,
+  `$e.message` is `3FalseNot here`-shaped concatenation.
+- `mutsu` (`target/debug/mutsu`): `No such method 'from-slurpy' for invocant of type
+  'X::AdHoc'`.
+
+Doc's fuller example:
+
+```raku
+try {
+    X::AdHoc.from-slurpy( 3, False, "Not here" ).throw
+};
+print $!.payload.^name; # Capture+{X::AdHoc::SlurpySentry}
+print $!.message;       # 3FalseNot here
+```
+
+## Affected files (starting point)
+
+`X::AdHoc` class-method registration — grep for where `X::AdHoc`'s other methods
+(`.new`, `.message`, `.payload`) are implemented (likely `runtime/class.rs` /
+`runtime/methods.rs` exception-type bootstrapping) and add a `from-slurpy` class
+method alongside them.


### PR DESCRIPTION
## Summary
- Re-ran the doc-diff harness against the 11 files assigned to batch6-C: `js-nutshell`, `IO::Spec::Unix`, `py-nutshell`, `X::AdHoc`, `Metamodel::Trusting`, `X::Proc::Async::CharsOrBytes`, `Iterable`, `statement-prefixes`, `exceptions`, `Metamodel::Stashing`, `optut`.
- Filed 11 new tickets (10 `todo/tickets/`, 1 `todo/deep/`) for confirmed-real divergences, each individually re-verified against `raku`/`target/debug/mutsu`.
- Added a "Related finding" note to the existing `direct-metamodel-classhow-new-type-immutable-error.md` deep ticket (Metamodel::Naming/Stashing not being valid `does` types).
- Added a new dated subsection to `docs/doc-diff-backlog.md`'s Ticketed section with the table + Excluded bullets.
- This is the last of the 9 planned batch4/5/6 sub-batches in the raku-doc re-sweep.

## Test plan
- [x] `cargo build` succeeded.
- [x] Each finding re-verified directly via `raku -e`/`raku <file>` vs `timeout 30 target/debug/mutsu -e`/`<file>` (not just the harness report).
- [x] Docs-only change — no source/test files touched, so CI's docs-only fast path should skip the heavy jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)