### PR TITLE
docs: file 13 new doc-diff findings, batch-6 (final) misc-a re-run

### DIFF
--- a/docs/doc-diff-backlog.md
+++ b/docs/doc-diff-backlog.md
@@ -808,6 +808,50 @@ deep ticket, since it's the same "script type creation directly through
   per-shape internal subclasses); treated the same as the documented hex-address
   exclusion — non-actionable, not ticketed.
 
+Found in the 2026-08-22 batch-6 re-run of `Metamodel::DefiniteHOW`/`Junction`/`functions`/
+`Metamodel::MethodContainer`/`faq`/`X::Str::Match::x`/`Real`/`Associative`/`grammar_tutorial`/
+`Method`/`unicode_entry`:
+
+| file:line | one-line summary | ticket |
+|---|---|---|
+| `Type/Metamodel/DefiniteHOW.rakudoc:18,27,80` | a bare `Type:D`/`Type:U` term loses its definiteness constraint entirely — `.^name`, `~~`, and `.^base_type` all treat it as the plain unconstrained type | [definiteness-constrained-type-object-identity-lost.md](../todo/deep/definiteness-constrained-type-object-identity-lost.md) |
+| `Type/Junction.rakudoc:266` | `Junction.new("one", 1..6)` doesn't flatten a `Range` values-argument into individual elements, so `.Bool` is wrong | [junction-new-range-argument-not-flattened.md](../todo/tickets/junction-new-range-argument-not-flattened.md) |
+| `Type/Junction.rakudoc:205` | a self-referential `$j = any (gather $j».take)...` combined with a value-producing `when` in a helper sub crashes with a stack overflow | [junction-self-referential-gather-stack-overflow.md](../todo/tickets/junction-self-referential-gather-stack-overflow.md) |
+| `Language/functions.rakudoc:1291` | `nextsame` from a user subclass `.new` into a built-in `Version.new` doesn't reach the built-in constructor | [nextsame-into-builtin-version-new-broken.md](../todo/tickets/nextsame-into-builtin-version-new-broken.md) |
+| `Type/Metamodel/MethodContainer.rakudoc:15`, `Type/Method.rakudoc:18` | `method` literal invocant-declaration syntax is broken: a named invocant (`method ($x:) {...}`) never binds `$x`, and a type-only unnamed invocant (`method (List:D:) {...}`) is a hard parse error | [method-literal-invocant-declaration-syntax-broken.md](../todo/tickets/method-literal-invocant-declaration-syntax-broken.md) |
+| `Type/Metamodel/MethodContainer.rakudoc:40` | `.^methods(:all)` ignores the `:all` adverb — returns own methods only, same as the plain call | [metaclass-methods-all-flag-ignored.md](../todo/tickets/metaclass-methods-all-flag-ignored.md) |
+| `Type/Metamodel/MethodContainer.rakudoc:73` | `.^lookup("nonexistent")` returns `Nil` instead of the `Mu` type object | [classhow-lookup-missing-method-returns-nil-not-mu.md](../todo/tickets/classhow-lookup-missing-method-returns-nil-not-mu.md) |
+| `Language/faq.rakudoc:359` | a custom `postcircumfix:<[...]>` operator's `+@slurpy` args are wrong when called via subscript syntax, though the identical logic works fine as a plain sub call | [custom-postcircumfix-slurpy-args-wrong-in-subscript-form.md](../todo/tickets/custom-postcircumfix-slurpy-args-wrong-in-subscript-form.md) |
+| `Language/faq.rakudoc:1108` | repeated big-Int addition (growing-magnitude Fibonacci-style loop) is ~14x slower than raku, timing out under the harness budget at 100k iterations | [bigint-repeated-addition-performance-gap.md](../todo/tickets/bigint-repeated-addition-performance-gap.md) |
+| `Type/X/Str/Match/x.rakudoc:15` | `.match(pattern, :x(BAD_TYPE))` doesn't validate the `:x` adverb's value type, so `X::Str::Match::x` is never thrown | [str-match-x-adverb-type-not-validated.md](../todo/tickets/str-match-x-adverb-type-not-validated.md) |
+| `Type/Real.rakudoc:31` | adding two custom `Real`-subclass instances (via `.Bridge`) produces an exact `Rat` where raku produces an approximate `Num` | [real-subclass-generic-plus-produces-exact-rat-not-num.md](../todo/tickets/real-subclass-generic-plus-produces-exact-rat-not-num.md) |
+| `Type/Associative.rakudoc:53` | `.of` on a class statically `does`-ing a parametric `Associative[Cool,DateTime]` reports `(Mu)` instead of the declared value type `(Cool)` | [associative-of-static-does-parametric-role-wrong-value-type.md](../todo/tickets/associative-of-static-does-parametric-role-wrong-value-type.md) |
+| `Language/grammar_tutorial.rakudoc:679` | a grammar `rule` with multiple embedded code blocks and subrule calls executes them out of the declared left-to-right order | [grammar-rule-embedded-actions-execute-out-of-order.md](../todo/tickets/grammar-rule-embedded-actions-execute-out-of-order.md) |
+| `Language/unicode_entry.rakudoc:532` | nested Unicode "curly" double quotes (`“...“...”...”`) fail to parse — the lexer doesn't track nesting depth for this quote pair | [nested-unicode-curly-double-quotes-parse-fail.md](../todo/tickets/nested-unicode-curly-double-quotes-parse-fail.md) |
+
+**Excluded from this batch-6 sub-run (already deferred/resolved/drift/false-positive/duplicate):**
+- `Language/functions.rakudoc` [1] (line 1127, `&how-many.cando(...)` gist) — bucketed
+  `raku-drift` overall (the doc's stated candidate-signature format is stale), but re-verified
+  directly that mutsu's own gist of the returned `Sub`s is also wrong independent of that drift:
+  `(how-many how-many)` instead of raku's `(&how-many &how-many)`. This is the same root cause
+  (a `Sub`'s default stringify/gist drops the leading `&` sigil) already filed as
+  [anon-class-sub-non-ascii-name-and-sub-gist.md](../todo/tickets/anon-class-sub-non-ascii-name-and-sub-gist.md)'s
+  second repro; not re-filed.
+- `Language/functions.rakudoc` [3] (line 720, `&infix:<XX>([1,(2,3)], [(4,5),6])`) — matches the
+  already-**Deferred**/deep "Array/Hash elements are stored bare — element reads lack
+  itemization" cluster (`todo/deep/element-itemization-lost-in-scalar-binding.md`, ADR-0040): the
+  nested `List` literal `(2,3)` inside the outer `Array` literal `[1,(2,3)]` loses its
+  itemization boundary, so the `X`-cross meta-op treats it as two separate elements instead of
+  one itemized `List` element.
+- `Type/Junction.rakudoc` [2], [3], [4] — `raku-drift-from-doc` (stale doc `# OUTPUT` text for
+  the string-concatenation-junction example, the `:exists` junction-key example, and the
+  `+any(...)` numeric-coercion-failure example's exception message format).
+- `Type/Method.rakudoc` [1] — the named-invocant repro (`method ($invocant: $param) {...}`) is
+  the same root cause as
+  [method-literal-invocant-declaration-syntax-broken.md](../todo/tickets/method-literal-invocant-declaration-syntax-broken.md)'s
+  Bug 1, and the type-only-invocant repro (`method (List:D:) {...}`) is that same ticket's Bug 2;
+  both folded into the one ticket above rather than being filed separately.
+
 ### Deferred / deep (tracked elsewhere — do not re-open as a shallow slice)
 These root causes account for a large share of the survey's `mism`/`crash` and are
 intentionally deferred; see PLAN.md §8.5 and the ADRs:

--- a/todo/deep/definiteness-constrained-type-object-identity-lost.md
+++ b/todo/deep/definiteness-constrained-type-object-identity-lost.md
@@ -1,0 +1,88 @@
+# A bare `Type:D`/`Type:U` term loses its definiteness constraint entirely
+
+Discovered via the doc-diff harness on `raku-doc/doc/Type/Metamodel/DefiniteHOW.rakudoc`
+(around lines 18, 27, 80).
+
+## Root cause
+
+Raku models a definiteness-constrained type (`Any:D`, `Any:U`) as a distinct type object
+produced by `Metamodel::DefiniteHOW` wrapping the base type's metaclass — it has its own
+`.^name` (`Any:D`), participates correctly in `~~` smart-matching against defined/undefined
+values, and `.^base_type` recovers the original unconstrained type.
+
+mutsu's type-smiley (`:D`/`:U`/`:_`) handling (`strip_type_smiley` and the many call sites
+using `strip_suffix(":D")`/`strip_suffix(":U")`) is entirely string-based and scoped to
+*signature/attribute type-constraint checking* (parameter binding, `where`, attribute
+declarations). When `Any:D` appears as a **bare term** (not inside a signature or attribute
+declaration), the smiley is dropped somewhere in parsing/evaluation and the expression just
+evaluates to the plain type object `Any` — indistinguishable from `Any:U`/`Any:_`. There is no
+`DefiniteHOW`-equivalent Value representation anywhere in the codebase (`grep -rn
+"DefiniteHOW" src/` finds nothing).
+
+## Minimal repro
+
+```raku
+say Any:D.^name; say Any:U.^name; say Any:_.^name;
+say Any ~~ Any:D;     say Any ~~ Any:U;
+say Any.new ~~ Any:D; say Any.new ~~ Any:U;
+say Any:D.^base_type.^name;
+```
+
+- `raku`:
+  ```
+  Any:D
+  Any:U
+  Any
+  False
+  True
+  True
+  False
+  Any
+  ```
+- `mutsu` (`target/debug/mutsu`):
+  ```
+  Any
+  Any
+  Any
+  True
+  True
+  True
+  True
+  ```
+  and `Any:D.^base_type.^name` throws:
+  `No such method 'base_type' for invocant of type 'Perl6::Metamodel::ClassHOW'`
+
+So every bare `Type:D`/`Type:U` term currently behaves exactly like the plain `Type`, both for
+`.^name` and for `~~` smart-matching (which always returns `True` regardless of whether the
+smiley is `:D` or `:U`, and regardless of whether the tested value is defined or not).
+
+## Why this is a deep/design item, not a shallow fix
+
+Fixing this correctly needs a Value-level representation of "a type object plus a definiteness
+constraint" (mirroring Rakudo's `DefiniteHOW`) that:
+- is produced when the parser/compiler sees a bare `Type:D`/`Type:U` term (today the smiley is
+  only threaded through the signature/attribute-declaration compiler paths, not general
+  expression parsing/compilation)
+- reports the right `.^name` (`Foo:D`) and `.HOW` (a `DefiniteHOW`-like metaclass, distinct from
+  the plain `ClassHOW` `Any:D.^base_type` currently fails on)
+- participates correctly in `~~` (`ACCEPTS`) against both defined and undefined values
+- exposes `.^base_type` to recover the unconstrained type
+
+This touches the parser (bare-term smiley parsing), the type-object representation, `~~`
+dispatch, and the ClassHOW/metamodel reflection surface — a genuine cross-cutting design
+decision (how mutsu represents constrained type objects generally), not a single-site patch.
+Given the codebase's existing string-suffix-based smiley handling is deeply embedded in the
+signature-checking paths, this likely needs its own small ADR to decide the representation
+(e.g. a new `Value` variant/wrapper vs. reusing the existing type-object representation with an
+extra definiteness tag) before implementation.
+
+## Affected files (starting point)
+
+- `src/runtime/types.rs` (`strip_type_smiley`) — the existing string-based smiley model
+- Parser: wherever a bare type-name term (`Any`, `Int`, etc.) is parsed as an expression — needs
+  to also recognize a trailing `:D`/`:U`/`:_` smiley outside of signature/attribute-declaration
+  context
+- `src/runtime/methods_classhow_dispatch.rs` — `.^name`/`.^base_type` and other ClassHOW
+  reflection methods, to add `DefiniteHOW`-equivalent behavior
+- Smartmatch (`~~`/`ACCEPTS`) dispatch — needs to check both the base type and the definiteness
+  flag when the RHS is a definiteness-constrained type object

--- a/todo/tickets/associative-of-static-does-parametric-role-wrong-value-type.md
+++ b/todo/tickets/associative-of-static-does-parametric-role-wrong-value-type.md
@@ -1,0 +1,47 @@
+# `.of` on a class statically `does`-ing a parametric `Associative[K,V]` reports the wrong value type
+
+Discovered via the doc-diff harness on `raku-doc/doc/Type/Associative.rakudoc` (around line 53).
+
+## Minimal repro
+
+```raku
+class DateHash is Hash does Associative[Cool,DateTime] {};
+my %date-hash := DateHash.new;
+say %date-hash.of;
+```
+
+- `raku`: `(Cool)`
+- `mutsu` (`target/debug/mutsu`): `(Mu)`
+
+The class composes without error (no crash), and `%date-hash.of` returns *a* type object, just
+the wrong one — `Mu` (the generic fallback / "no constraint") instead of the declared value-type
+parameter `Cool` from `Associative[Cool, DateTime]`.
+
+## Relationship to other tickets
+
+This is a *different* code path from the already-filed
+`builtin-parametric-role-mixin-not-composable.md`, which is about the runtime `but` mixin
+operator (`%hash but Associative[Int, Int]`) failing to compose at all because `but`'s built-in
+role lookup doesn't recognize `Associative` as a role name. Here, composition via a **static
+class declaration** (`class Foo is Hash does Associative[K,V] {}`) already works — the bug is
+that the composed parametric role's type parameters aren't threaded through to the `.of`
+reflection method.
+
+## Root cause hypothesis
+
+The `.of` method (typed-container introspection, already correctly used elsewhere for e.g.
+`Array[Int].of`) presumably reads a type-parameter slot that gets populated when a class is
+declared with the built-in `Array[T]`/`Hash[K,V]` *type-parameterization* syntax, but is not
+populated when the value type instead comes from a `does Associative[K,V]` role composition in
+the class body. These are two different mechanisms in Raku for expressing the same
+"parameterized container" concept, and mutsu's `.of` implementation likely only consults the
+former.
+
+## Affected files (starting point)
+
+- Wherever `.of` is implemented (native method, `src/builtins/methods_0arg/` or
+  `src/runtime/methods.rs`) — needs to also check a composed `Associative[K,V]`/`Positional[T]`
+  role's type arguments (recorded somewhere during class-body `does` role composition), not just
+  the built-in parametric-package type-argument slot.
+- `src/runtime/registration_class_body_*.rs` — class-body role composition, to see whether/where
+  a composed parametric role's type arguments are stored on the class metadata at all.

--- a/todo/tickets/bigint-repeated-addition-performance-gap.md
+++ b/todo/tickets/bigint-repeated-addition-performance-gap.md
@@ -1,0 +1,48 @@
+# Repeated big-Int addition (growing-magnitude Fibonacci-style loop) is roughly 14x slower than raku
+
+Discovered via the doc-diff harness on `raku-doc/doc/Language/faq.rakudoc` (around line 1108);
+the harness bucketed it as a `mutsu-error` because the 100,000-iteration example (with a
+multi-thousand-digit final result) exceeds the harness's per-example timeout, but this is a
+**performance gap, not a correctness bug** — smaller iteration counts produce the correct
+result, just slowly.
+
+## Repro
+
+```raku
+my ($prev, $current) = (1, 0);
+for (0..10_000) {
+    ($prev, $current) = ($current, $prev + $current);
+}
+print "done\n";
+```
+
+Timing (release... actually debug `target/debug/mutsu` build used for this measurement, see
+note below):
+- `raku`: ~0.31s
+- `mutsu` (`target/debug/mutsu`): ~4.4s (roughly 14x slower)
+
+The doc's full example runs the loop 100,000 times (final `$current` has ~20,000 decimal
+digits); at that size mutsu times out under the harness's budget while raku completes and prints
+the correct multi-thousand-digit number (verified the *correctness* of mutsu's output at smaller
+iteration counts — e.g. 1,000 iterations — matches raku's digit-for-digit).
+
+Note: this timing used the **debug** build per the correctness-check convention in this repo,
+but since the loop count scales roughly quadratically (digit count grows ~linearly with `n`, so
+per-addition cost also grows ~linearly, giving ~O(n^2) total), the gap is large enough that it is
+very likely still significant on a release build — worth re-measuring with
+`target/release/mutsu` before prioritizing, per the "release is for wall-clock only" convention.
+
+## Root cause hypothesis (unconfirmed)
+
+Likely inefficiency in the big-integer (`BigInt`) addition path in `src/builtins/arith.rs` (or
+wherever bignum `+` is implemented) — e.g. avoidable allocation/reparsing/string-roundtripping
+per addition, or not using the underlying bignum library's in-place/fast-path addition
+efficiently. This is the same general "measured perf gap" shape as the existing
+`uniname-sort-performance-gap.md` ticket (a specific slow builtin operation, not a correctness
+bug), not something to guess at without profiling (`perf`/flamegraph) first.
+
+## Affected files (starting point)
+
+- `src/builtins/arith.rs` — bignum `+` implementation
+- `src/value.rs` — `Value`'s bigint variant representation, to check for unnecessary
+  clone/realloc on each addition

--- a/todo/tickets/classhow-lookup-missing-method-returns-nil-not-mu.md
+++ b/todo/tickets/classhow-lookup-missing-method-returns-nil-not-mu.md
@@ -1,0 +1,30 @@
+# `.^lookup("nonexistent-method")` returns `Nil` instead of the `Mu` type object
+
+Discovered via the doc-diff harness on `raku-doc/doc/Type/Metamodel/MethodContainer.rakudoc`
+(around line 73 — bucketed `raku-drift` overall because the doc's other two example lines have
+since drifted from current raku's actual signature-gist format, but this specific line is a
+real, separate bug independent of that drift).
+
+## Minimal repro
+
+```raku
+say Int.^lookup("does-not-exist");
+```
+
+- `raku`: `(Mu)`
+- `mutsu` (`target/debug/mutsu`): `Nil`
+
+## Root cause hypothesis
+
+`.^lookup` (the `Metamodel::MethodContainer` reflection method that looks up a method by name
+and returns its `Method` object, or an "absent" marker when not found) presumably falls back to
+mutsu's internal `Nil` value on a failed lookup, where raku's `MethodContainer.lookup` returns
+the `Mu` type object (the universal "no value" type object) for a not-found name. This looks like
+a narrow, single-site fix — return `Value::mu_type_object()` (or however mutsu represents the
+bare `Mu` type object elsewhere) instead of `Value::NIL` from the not-found branch — rather than
+being related to the broader Nil-vs-Any identity knot tracked as Deferred (that cluster is about
+*scalar* Nil/Any rendering, not about a specific reflection method's "not found" sentinel).
+
+## Affected files (starting point)
+
+- `src/runtime/methods_classhow_dispatch.rs` — the `.^lookup` implementation's not-found path

--- a/todo/tickets/custom-postcircumfix-slurpy-args-wrong-in-subscript-form.md
+++ b/todo/tickets/custom-postcircumfix-slurpy-args-wrong-in-subscript-form.md
@@ -1,0 +1,55 @@
+# A custom `postcircumfix:<[...]>` operator's `+@slurpy` args are wrong when called via subscript syntax (but correct as a plain sub call)
+
+Discovered via the doc-diff harness on `raku-doc/doc/Language/faq.rakudoc` (around line 359).
+
+## Repro
+
+```raku
+multi postcircumfix:<[- ]> (Str:D $str is copy, +@indices) {
+    for @indices.reverse {
+        when Int   { $str.substr-rw($_,1) = '' }
+        when Range { $str.substr-rw($_  ) = '' }
+    }
+    return $str;
+}
+
+say '0123456789'[- 1..3, 8 ];
+```
+
+- `raku`: `045679`
+- `mutsu` (`target/debug/mutsu`): `(Index out of range. Is: 1, should be in 0..0 Index out of
+  range. Is: 8, should be in 0..0)` — a `Failure`/error object is printed instead of the mutated
+  string, meaning the `substr-rw` calls inside the loop failed against out-of-range indices.
+
+## Isolated: the identical logic works fine as a plain sub call
+
+```raku
+sub foo(Str:D $str is copy, +@indices) {
+    for @indices.reverse {
+        when Int   { $str.substr-rw($_,1) = '' }
+        when Range { $str.substr-rw($_  ) = '' }
+    }
+    return $str;
+}
+say foo('0123456789', 1..3, 8);   # 045679 -- matches raku, both with mutsu and raku
+```
+
+This is confirmed correct in mutsu when called as a normal sub `foo('0123456789', 1..3, 8)`. It
+is *only* wrong when the exact same signature/body is declared as `multi
+postcircumfix:<[- ]>` and invoked via the subscript syntax `'...'[- 1..3, 8]`. Also confirmed
+each individual step works when done manually in sequence at the top level (`$str.substr-rw(8,1)
+= ''` then `$str.substr-rw(1..3) = ''` on the same string both give the correct `045679`), which
+rules out a `substr-rw`/`when Int`/`when Range` dispatch bug in isolation.
+
+So the bug is specific to how mutsu passes/threads the postcircumfix-subscript's bracket
+arguments into the `+@indices` slurpy parameter when dispatched through custom
+`postcircumfix:<...>` operator syntax, as opposed to an ordinary named-sub call with the same
+arguments.
+
+## Affected files (starting point)
+
+- Wherever a custom `postcircumfix:<...>` operator's subscript-bracket contents are parsed and
+  turned into an argument list for the underlying multi-sub call (likely in `src/parser/` for
+  the postcircumfix-subscript grammar, and/or `src/compiler/` for how that argument list is
+  compiled/passed) — compare against the normal call-argument-list compilation path that the
+  plain-sub-call repro above goes through correctly.

--- a/todo/tickets/grammar-rule-embedded-actions-execute-out-of-order.md
+++ b/todo/tickets/grammar-rule-embedded-actions-execute-out-of-order.md
@@ -1,0 +1,64 @@
+# A grammar `rule` with multiple embedded code blocks and subrule calls executes them out of the declared order
+
+Discovered via the doc-diff harness on `raku-doc/doc/Language/grammar_tutorial.rakudoc` (around
+line 679).
+
+## Minimal repro
+
+```raku
+grammar G {
+  rule TOP { <function-define> }
+  rule function-define {
+    'sub' <identifier>
+    {
+      say "func " ~ $<identifier>.made;
+      make $<identifier>.made;
+    }
+    '(' <parameter> ')' '{' '}'
+    { say "end " ~ $/.made; }
+  }
+  token identifier { \w+ { make ~$/; } }
+  token parameter { \w+ { say "param " ~ $/; } }
+}
+
+G.parse('sub f ( a ) { }');
+```
+
+- `raku` (matches the doc's stated `# OUTPUT`):
+  ```
+  func f
+  param a
+  end f
+  ```
+- `mutsu` (`target/debug/mutsu`):
+  ```
+  param a
+  Use of Nil in string context
+  end 
+  func f
+  ```
+
+Every piece of output is present but in the **wrong order**, and the first embedded block's side
+effect (`make $<identifier>.made` before the second block runs) hasn't happened yet when the
+second block (`{ say "end " ~ $/.made; }`) runs — `$/.made` reads `Nil` there (triggering the
+"Use of Nil in string context" warning) instead of the value the first block should have already
+`make`'d onto `$/`. The `<parameter>` subrule's own embedded action (`say "param " ~ $/;`) runs
+*before* the first `function-define` embedded block at all, even though it's declared later in
+the pattern (`'sub' <identifier> {block1} '(' <parameter> ')' ... {block2}`).
+
+## Root cause hypothesis (unconfirmed — needs investigation)
+
+The regex/grammar engine appears to not execute a `rule`'s sequence of subrule-calls and
+embedded `{...}` action blocks strictly in left-to-right declared order during matching. This
+looks different from the already-tracked "embedded code block inside a *quantified* group
+doesn't persist its side effect" ticket
+(`regex-embedded-code-block-quantifier-scope.md`) — this repro has no quantifiers at all, just a
+plain linear sequence of literals/subrules/blocks, and the bug is about *execution order across
+the whole rule*, not about a `:my`-declared variable losing writes across repetitions.
+
+## Affected files (starting point)
+
+- `src/runtime/regex.rs` / `src/runtime/regex_parse.rs` — the concatenation-sequence matcher for
+  a `rule`/`token`, to check whether it evaluates embedded code blocks / subrule calls eagerly
+  out of sequence (e.g. some kind of pre-pass or deferred-block-execution queue) rather than
+  inline as each sequence element matches.

--- a/todo/tickets/junction-new-range-argument-not-flattened.md
+++ b/todo/tickets/junction-new-range-argument-not-flattened.md
@@ -1,0 +1,56 @@
+# `Junction.new(TYPE, values)` doesn't flatten a `Range` values argument
+
+Discovered via the doc-diff harness on `raku-doc/doc/Type/Junction.rakudoc` (around line 266).
+
+## Root cause
+
+`methods_object_dispatch_new.rs`'s `"Junction"` arm builds the junction's element list from the
+values argument with:
+
+```rust
+let elems: Vec<Value> = match values_arg {
+    Some(v) => match v.view() {
+        ValueView::Array(items, ..) => items.to_vec(),
+        ValueView::Seq(items) => items.to_vec(),
+        ValueView::Slip(items) => items.to_vec(),
+        _ => vec![v.clone()],
+    },
+    None => vec![],
+};
+```
+
+Only `Array`/`Seq`/`Slip` are flattened into individual elements; anything else — including a
+bare `Range` — falls into the `_ => vec![v.clone()]` arm and is wrapped as a **single** element.
+So `Junction.new("one", 1..6)` builds a `one()` junction with one element (the `Range` value
+`1..6`, itself truthy), instead of a `one()` junction over the six individual integers `1..6`.
+
+## Minimal repro
+
+```raku
+my $n = Junction.new( "one", 1..6 );
+say $n.Bool;
+```
+
+- `raku`: `False` (a `one()` junction over 6 truthy elements — more than one is true, so `one`
+  fails)
+- `mutsu` (`target/debug/mutsu`): `True` (treats `1..6` as a single truthy element, so `one`
+  trivially succeeds)
+
+Confirmed with `.raku`/gist too:
+
+```raku
+$ raku -e 'say Junction.new("one", 1..6).raku'
+one(1, 2, 3, 4, 5, 6)
+$ target/debug/mutsu -e 'say Junction.new("one", 1..6).raku'
+one(1 2 3 4 5 6)
+```
+
+(mutsu's gist format for the range case is also slightly off — no commas/space — but the real
+bug is the element count/identity, confirmed via `.Bool` above.)
+
+## Affected files (starting point)
+
+- `src/runtime/methods_object_dispatch_new.rs` — the `"Junction"` arm's `elems` match (around
+  line 1275-1283 as of this writing). Needs a `ValueView::Range(..)` arm (and likely any other
+  general iterable) that flattens like `Array`/`Seq`/`Slip` do, rather than falling through to
+  the single-element wrap.

--- a/todo/tickets/junction-self-referential-gather-stack-overflow.md
+++ b/todo/tickets/junction-self-referential-gather-stack-overflow.md
@@ -1,0 +1,68 @@
+# A self-referential `$j = any (gather $j».take)...` combined with a value-producing `when` crashes with a stack overflow
+
+Discovered via the doc-diff harness on `raku-doc/doc/Type/Junction.rakudoc` (around line 205).
+
+## Repro (from the doc)
+
+```raku
+sub calc ($_) { die when 13 }
+my $j = any 1..42;
+$j = any (gather $j».take).grep: {Nil !=== try calc $_};
+say so $j == 42;
+```
+
+- `raku`: `True`
+- `mutsu` (`target/debug/mutsu`): `thread 'mutsu-main' has overflowed its stack` (exit 134)
+
+## Narrowed repro
+
+The crash does not need `die`/`try`; a plain sub containing a value-producing `when` (which
+mutsu evaluates to `Nil` instead of raku's `Empty`/`()` on no-match — see the related
+`control-do-when-expression-value.md` ticket) is enough, as long as it is combined with a
+self-referential `$j` reassignment through `gather`/hyper-`.take`:
+
+```raku
+sub calc ($_) { 99 when 13 }
+my $j = any 1..5;
+$j = any (gather $j».take).grep: { Nil !=== calc $_ };
+say $j == 3;   # crashes
+```
+
+Removing any one piece stops the crash:
+- Replacing `calc` with a sub that has no `when` (e.g. `sub calc ($_) { 99 }` or `sub calc ($_)
+  { Nil }`) → no crash (wrong result, but that's the separately-tracked Nil-vs-Empty `when`-value
+  bug).
+- Replacing the self-referential `gather $j».take` with a non-self-referential source
+  (`$j.eigenstates`/a plain list) → no crash.
+- Dropping the trailing `$j == 3` (i.e. never forcing/comparing the newly-built Junction) → no
+  crash, `say "done"` prints fine.
+
+## Root cause hypothesis (unconfirmed — needs a debugger session)
+
+Raku evaluates the RHS of `$j = any (gather $j».take)...` **fully** (eagerly reifying the
+`gather`'s lazy Seq, since Junction construction requires concrete eigenstates) before the
+assignment to `$j` takes effect — so the `gather` block's `$j».take` still reads the *old* `$j`
+(the plain `any 1..5`), never the value being constructed.
+
+The crash pattern (only reproducing when a `when`-in-sub is in the pipeline, and only surfacing
+later at `$j == 3` rather than at the assignment itself) suggests mutsu's `gather` here is not
+being reified eagerly at Junction-construction time. If the lazy Seq underlying the new `$j` is
+only forced later — at the `$j == 3` comparison — then by that point `$j` has already been
+reassigned to the new (self-referential) Junction, so forcing the `gather` reads `$j».take`
+against the *new*, not-yet-fully-constructed `$j`, recursing into itself without a base case →
+stack overflow. It's unclear why the `when`-in-sub specifically is needed to trigger this
+(possibly the `Nil`-vs-`Empty` return value takes a different code path through `.grep`'s lazy
+machinery that skips whatever eager-reification the "no when" path performs), which needs a
+`rust-gdb` session on the crash to confirm.
+
+## Affected files (starting point)
+
+- `src/runtime/methods_object_dispatch_new.rs` — the `Junction.new`/`any()`/`all()`/etc.
+  eigenstate construction, to check whether it always eagerly reifies its Seq/gather argument
+  before returning
+- Regex/gather laziness: `runtime/iterator_protocol.rs`, the `gather`/`take` VM ops in
+  `vm_control_ops.rs` — whether `gather`'s reification order relative to an enclosing assignment
+  is correct
+- Related, already-filed: `control-do-when-expression-value.md` (the `when`-as-expression
+  Nil-vs-Empty gap that seems to be a necessary ingredient here, though not sufficient on its
+  own — this crash needs the self-referential-Junction-via-gather shape too)

--- a/todo/tickets/metaclass-methods-all-flag-ignored.md
+++ b/todo/tickets/metaclass-methods-all-flag-ignored.md
@@ -1,0 +1,44 @@
+# `.^methods(:all)` ignores the `:all` adverb — returns own methods only
+
+Discovered via the doc-diff harness on `raku-doc/doc/Type/Metamodel/MethodContainer.rakudoc`
+(around line 40).
+
+## Minimal repro
+
+```raku
+class A {
+    method x() { };
+}
+say A.^methods();      # own methods only
+say A.^methods(:all);  # should ALSO include inherited methods
+```
+
+- `raku`:
+  ```
+  (x POPULATE)
+  (x POPULATE EXISTS-KEY DELETE-KEY DELETE-POS cache list fmt flat eager serial List Slip Array
+  Seq hash Hash Map elems end keys kv values pairs antipairs invert splice pick roll match
+  classify categorize reverse combinations permutations join tree push append unshift prepend ...)
+  ```
+  (167 methods total for `.^methods(:all)` vs. 2 for the plain form)
+- `mutsu` (`target/debug/mutsu`):
+  ```
+  (x)
+  (x)
+  ```
+  Both calls return the same single-element list — `:all` has no effect at all.
+
+## Root cause hypothesis
+
+`.^methods` presumably only ever walks the class's *own* method table
+(`Perl6::Metamodel::ClassHOW`'s locally-declared methods) and doesn't check for/honor an `:all`
+named argument that should walk the full MRO chain and collect inherited methods too (mirroring
+how `.^method` reflection generally needs to distinguish "declared on this class" vs. "visible
+via inheritance").
+
+## Affected files (starting point)
+
+- `src/runtime/methods_classhow_dispatch.rs` — wherever `.^methods` is implemented; needs an
+  `:all` named-arg check that walks the class's full MRO (`class_mro` or similar helper already
+  used elsewhere for method resolution) and unions in each ancestor's own methods, rather than
+  just the invocant class's local table.

--- a/todo/tickets/method-literal-invocant-declaration-syntax-broken.md
+++ b/todo/tickets/method-literal-invocant-declaration-syntax-broken.md
@@ -1,0 +1,71 @@
+# `method` literal invocant-declaration syntax variants (named / type-only) are broken
+
+Discovered via the doc-diff harness on `raku-doc/doc/Type/Metamodel/MethodContainer.rakudoc`
+(around line 15) and `raku-doc/doc/Type/Method.rakudoc` (around line 18). Two related but
+distinct bugs in how a `method (...)` literal declares its invocant.
+
+## Bug 1 — a named invocant (`method ($x:) { ... }`) doesn't bind `$x` from the invocant
+
+```raku
+my $m = method ($invocant: $param) {
+    say "$invocant: '$param'";
+}
+"greeting".$m("hello");
+```
+
+- `raku`: `greeting: 'hello'`
+- `mutsu` (`target/debug/mutsu`): `Too few positionals passed; expected 3 arguments but got 2`
+
+A shorter repro without a trailing positional, showing the invocant name itself is simply not
+declared as a variable in the method body:
+
+```raku
+my $m = method ($x:) { say $x };
+5.&$m;
+```
+
+- `raku`: `5`
+- `mutsu`: `Too few positionals passed; expected 2 arguments but got 1`
+
+The same shape crashes differently when used via `.^add_method`:
+
+```raku
+Int.^add_method('double', method ($x:) { 2 * $x });
+say 21.double;
+```
+
+- `raku`: `42`
+- `mutsu`: `Variable '$x' is not declared` (a runtime error, not a compile error — the method
+  body compiles, but `$x` was never bound/allocated as a local)
+
+## Bug 2 — a type-only, unnamed invocant (`method (List:D:) { ... }`) is a hard parse error
+
+```raku
+<a b c>.&(my method (List:D:) { say self.raku; self }).say;
+```
+
+- `raku`: `("a", "b", "c")` then `(a b c)` (the block runs with `self` bound to the invocant,
+  type-checked against `List:D`)
+- `mutsu`: `===SORRY!=== ... Confused. expected statement: expected expression statement or ')'`
+  — the parser doesn't accept a bare type constraint (no parameter name) followed directly by
+  `:` inside a method-literal signature.
+
+## Root cause hypothesis
+
+Both bugs point at the same area: the method-literal signature parser/compiler's handling of the
+invocant declaration (the part before the first `:` in a `method (...)` parameter list) only
+supports the default, unwritten `self:` case. It does not:
+1. Allocate/bind a *named* invocant parameter (`$x:`) as a normal parameter local the body can
+   read (Bug 1) — the invocant is consumed as the call's receiver but never registered under its
+   given name, so the parameter-count bookkeeping for the *rest* of the signature is also thrown
+   off by one (hence "expected N but got N-1").
+2. Even *parse* a type-only invocant declaration with no name at all (`List:D:`) (Bug 2) — likely
+   because the invocant-parsing code expects a leading `$name` token and doesn't fall back to
+   accepting a bare type-constraint term before the `:`.
+
+## Affected files (starting point)
+
+- `src/parser/` — signature parsing for `method (...) { }` literals / `method` declarations,
+  specifically how the pre-`:` invocant token is recognized (name vs. type-only)
+- `src/compiler/` — signature-to-bytecode lowering for the invocant parameter, to bind a named
+  invocant into the method body's locals like any other parameter

--- a/todo/tickets/nested-unicode-curly-double-quotes-parse-fail.md
+++ b/todo/tickets/nested-unicode-curly-double-quotes-parse-fail.md
@@ -1,0 +1,38 @@
+# Nested Unicode "curly" double quotes (`“ ... “ ... ” ... ”`) fail to parse
+
+Discovered via the doc-diff harness on `raku-doc/doc/Language/unicode_entry.rakudoc` (around
+line 532).
+
+## Minimal repro
+
+```raku
+say "here: "no problem" at all!";
+```
+(using the actual Unicode curly-quote characters `“`/`”` throughout, i.e.
+`say ``“``here: ``“``no problem``”`` at all!``”``;`)
+
+- `raku`: `here: “no problem” at all!` (the doc's own explanatory comment: "You can nest them!")
+- `mutsu` (`target/debug/mutsu`):
+  ```
+  ===SORRY!=== Error while compiling ...
+  Unable to parse expression in curly double quotes; couldn't find final '”' (corresponding starter was)
+  ```
+
+The three other Unicode quote pairs tested in the same doc example (`｢...｣` corner brackets,
+`”...“`/`„...”`/`„...“` reversed-direction curly pairs) all already parse correctly in mutsu —
+this is specific to the `“...”` pair being **nested inside itself**.
+
+## Root cause hypothesis
+
+mutsu's quote-parsing for the Unicode curly-double-quote pair `“`/`”` presumably scans forward
+for the first matching closer without tracking nesting depth (i.e. treats every `“` after the
+first purely as literal text and stops at the very first `”`), unlike how mutsu already handles
+nesting for bracket-style quote delimiters (`(...)`, `[...]`, `{...}` used with `q(...)` etc.,
+which do need depth-tracking and evidently already have it, since those work). The curly-quote
+lexer path needs the same nesting-depth counter: increment on each literal `“` encountered while
+scanning, decrement on each `”`, and only stop at the `”` that brings the depth back to zero.
+
+## Affected files (starting point)
+
+- `src/parser/` — wherever Unicode quote-pair delimiters (`“”`, `‘’`, `｢｣`, `„"`, etc.) are
+  recognized and their contents are scanned for the matching closer.

--- a/todo/tickets/nextsame-into-builtin-version-new-broken.md
+++ b/todo/tickets/nextsame-into-builtin-version-new-broken.md
@@ -1,0 +1,54 @@
+# `nextsame` from a user subclass `.new` into a built-in `Version.new` doesn't reach the built-in constructor
+
+Discovered via the doc-diff harness on `raku-doc/doc/Language/functions.rakudoc` (around line
+1291).
+
+## Minimal repro
+
+```raku
+class LoggedVersion is Version {
+    method new(|c) {
+        note "New version object created with arguments " ~ c.raku;
+        nextsame;
+    }
+}
+say LoggedVersion.new('1.0.2');
+```
+
+- `raku`:
+  ```
+  New version object created with arguments \("1.0.2")
+  v1.0.2
+  ```
+- `mutsu` (`target/debug/mutsu`):
+  ```
+  New version object created with arguments \("1.0.2")
+  LoggedVersion.new
+  ```
+
+The `note` line (the user override actually running) matches. The final `say` differs: raku's
+`nextsame` correctly dispatches onward to the built-in `Version.new(Str)` constructor, producing
+a real `Version` object that stringifies as `v1.0.2`. mutsu's `nextsame` instead appears to fall
+through to some generic default `.new`/instance-gist fallback — the printed `LoggedVersion.new`
+looks like the default `ClassName.new` gist of a bare, un-parsed `Instance`, not a constructed
+`Version`.
+
+## Root cause hypothesis
+
+`nextsame`/`callsame` MRO dispatch presumably walks the user class's method-resolution chain
+looking for the next `new` candidate up the inheritance chain. For a class extending a
+*built-in* type (`Version`, `Str`, etc.) whose `.new` is implemented natively (not as a
+registered user-visible multi/method in the normal dispatch table), the "next method" lookup
+likely doesn't know how to reach the native constructor logic, so it silently produces some
+generic instance-creation fallback instead. This is the same general shape as other "subclassing
+a built-in type loses its native behavior" findings already tracked elsewhere in this backlog
+(e.g. `str-subclass-loses-native-stringify.md`), but specific to `.new`/`nextsame` dispatch
+rather than stringification.
+
+## Affected files (starting point)
+
+- `src/runtime/methods_object_dispatch_new.rs` — where `.new` dispatch/MRO walking happens for
+  a `nextsame`/`callsame` call originating from an overridden `new`
+- `src/runtime/dispatch.rs` / `src/runtime/calls.rs` — `nextsame` MRO-walk implementation, to see
+  whether it special-cases user methods but has no case for "next candidate is a native builtin
+  constructor"

--- a/todo/tickets/real-subclass-generic-plus-produces-exact-rat-not-num.md
+++ b/todo/tickets/real-subclass-generic-plus-produces-exact-rat-not-num.md
@@ -1,0 +1,60 @@
+# Adding two custom `Real`-subclass instances (via `.Bridge`) produces an exact `Rat` where raku produces an approximate `Num`
+
+Discovered via the doc-diff harness on `raku-doc/doc/Type/Real.rakudoc` (around line 31) — the
+"Temperature" tutorial example that defines a `class Temperature is Real` with a `method
+Bridge`.
+
+## Minimal repro
+
+```raku
+class Temperature is Real {
+    has Str:D  $.unit  is required where any <K F C>;
+    has Real:D $.value is required;
+    method new ($value, :$unit = 'K') { self.bless :$value :$unit }
+
+    method Bridge {
+        when $!unit eq 'F' { ($!value + 459.67) * 5/9 }
+        when $!unit eq 'C' {  $!value + 273.15 }
+        $!value
+    }
+    method gist { self.Str }
+    method Str  { "$!value degrees $!unit" }
+}
+
+sub postfix:<C> { Temperature.new: $^value, :unit<C> }
+sub postfix:<F> { Temperature.new: $^value, :unit<F> }
+sub postfix:<K> { Temperature.new: $^value, :unit<K> }
+
+my $human := 36.6C;
+my $book  := 451F;
+my $sun   := 5778K;
+my $sum = $human + $book + $sun;
+say $sum;       # raku: 6593.677777777778   mutsu: 6593.677778
+say $sum.WHAT;  # raku: (Num)               mutsu: (Rat)
+```
+
+- `raku`: `$sum` is a `Num` (`6593.677777777778e0`), printed at full float precision.
+- `mutsu` (`target/debug/mutsu`): `$sum` is an exact `Rat` (`593431/90`), which then goes
+  through the (correct, separately-fixed) Rat-to-Str digit-budget rounding, printing the
+  truncated `6593.677778`.
+
+## Root cause hypothesis
+
+mutsu's generic `Real` `+` operator (used when neither operand has its own `infix:<+>`
+overload — dispatch via each operand's `.Bridge`) apparently just adds the two `.Bridge` return
+values directly (`Rat + Rat + Int` here, since every `.Bridge` call in this example returns
+exact-Rat arithmetic), yielding an exact `Rat`. Rakudo's actual generic `Real`-role arithmetic
+does not preserve exactness this way for *heterogeneous, arbitrary user-defined* `Real`
+subclasses — it appears to coerce through `.Num` (approximate double) when combining values from
+different concrete `Real` subtypes, since a user-defined `Real.Bridge` gives no general guarantee
+of exactness/compatible denominators across subclasses. This needs checking against Rakudo's
+actual `Real` role source (or further `raku -e` probing of mixed-type `Real` arithmetic) to
+confirm the precise rule before implementing — it is not simply "always coerce Bridge results to
+Num" since same-type or plain-Rat/Int arithmetic elsewhere in the codebase correctly stays exact.
+
+## Affected files (starting point)
+
+- `src/runtime/builtins_operators_fallback.rs` or wherever the generic cross-type `Real`
+  arithmetic fallback (via `.Bridge`) is implemented — need to find the exact `+` dispatch path
+  taken when both operands are instances of user-defined classes that only implement `Real`
+  through `.Bridge` (not native `Int`/`Rat`/`Num` values).

--- a/todo/tickets/str-match-x-adverb-type-not-validated.md
+++ b/todo/tickets/str-match-x-adverb-type-not-validated.md
@@ -1,0 +1,32 @@
+# `Str.match(pattern, :x(BAD_TYPE))` doesn't validate the `:x` adverb's value type
+
+Discovered via the doc-diff harness on `raku-doc/doc/Type/X/Str/Match/x.rakudoc` (around line
+15) — the exception type `X::Str::Match::x` this doc page documents is never thrown at all.
+
+## Minimal repro
+
+```raku
+say "foobar".match("o", :x<hello>);
+CATCH { default { put .^name, ': ', .Str } };
+```
+
+- `raku`: `X::Str::Match::x: in Str.match, got invalid value of type Str for :x, must be Int or
+  Range`
+- `mutsu` (`target/debug/mutsu`): `｢o｣` — the `:x` adverb is silently ignored (the match runs as
+  if `:x` weren't passed at all) instead of validating its value type and throwing.
+
+## Root cause
+
+`.match`'s `:x` adverb (ordinal-shortcut match selection, already implemented per the Resolved
+entry "`Str.rakudoc` [match] — `.match(/../, :1st/:2nd/:Nth)` ignored the ordinal adverb
+shortcuts") accepts an `Int` or `Range` value. mutsu's implementation apparently doesn't
+type-check the `:x` value before using/ignoring it — it needs to check that the passed value is
+`Int` or `Range` and throw the registered `X::Str::Match::x` exception (already present in
+`runtime_init.rs`'s exception-type registry, per the doc's own class name existing in mutsu's `X`
+hierarchy — worth confirming) when it isn't.
+
+## Affected files (starting point)
+
+- `src/runtime/` — wherever `.match`'s `:x`/`:1st`/`:2nd`/`:Nth` adverb handling lives (see the
+  Resolved-section note above for the PR that added the ordinal-shortcut parsing — the same
+  function needs a type-check on the resolved `:x` value before use)


### PR DESCRIPTION
## Summary
- Re-triaged 11 files from the 2026-08-22 doc-diff survey (batch-6, the last of the planned sub-batches): `Metamodel::DefiniteHOW`, `Junction`, `functions`, `Metamodel::MethodContainer`, `faq`, `X::Str::Match::x`, `Real`, `Associative`, `grammar_tutorial`, `Method`, `unicode_entry`.
- Filed 13 new tickets for confirmed real bugs (12 in `todo/tickets/`, 1 deep DefiniteHOW/definiteness-constraint design item in `todo/deep/`), including a stack-overflow crash (self-referential Junction via `gather`), a parse failure (nested Unicode curly quotes), and a ~14x big-Int addition performance gap.
- Excluded 3 findings as duplicates of already-filed tickets or the already-Deferred element-itemization cluster.
- Updated `docs/doc-diff-backlog.md` with the batch-6 subsection under "Ticketed (open — linked to todo/)".

## Test plan
- [x] Docs-only change (`docs/`, `todo/`) — CI's docs-only fast path should skip the heavy jobs.
- [x] Verified every finding directly with `raku -e`/`target/debug/mutsu -e` before filing.