### PR TITLE
fix: test-module-sweep.sh passes() now recognizes TAP # TODO failures

### DIFF
--- a/news/2026-08/test-module-sweep-tap-todo-predicate.md
+++ b/news/2026-08/test-module-sweep-tap-todo-predicate.md
@@ -1,0 +1,34 @@
+# `test-module-sweep.sh` now recognizes TAP `# TODO` failures as expected
+
+`scripts/test-module-sweep.sh` (the harness that runs every `t/*.t` file
+under both mutsu's native `Test` provider and the vendored upstream
+`Test.rakumod`, per `todo/deep/vendor-real-test-module.md`) had a
+classification bug in its `passes()` predicate: it grepped raw output for
+`^not ok` without checking for a TAP `# TODO` suffix, so a legitimate,
+expected `not ok N ... # TODO ...` line -- the same thing `prove` and
+mutsu's own TAP consumer (`runtime/test_functions.rs`) both tolerate -- was
+scored as a genuine failure.
+
+This mattered for files whose *native*-provider baseline legitimately
+contains a TODO-annotated `not ok`, such as `t/exits-ok.t` (two negative-case
+subtests marked `todo`) and `t/failure-sink-handled.t` (one). Both were
+scored as "not passing" even on the native side, so a real difference on the
+real-Test side (a truncated plan / `Unknown call: is-approx`) fell into the
+sweep's "fail under both" bucket instead of "regressed" -- invisible to the
+tool meant to surface exactly that.
+
+The fix: `passes()` now only counts a `not ok` line as a failure when it
+lacks a case-insensitive `# TODO` marker:
+
+```sh
+grep -E '^not ok' "$out" | grep -qvi '#[[:space:]]*todo' && return 1
+```
+
+Verified by hand against both named files: under the fix, `t/exits-ok.t` and
+`t/failure-sink-handled.t` now score as passing under the native provider (as
+they should) and failing under `MUTSU_REAL_TEST=1` (their real, non-TODO
+difference), so they now correctly land in the sweep's "regressed" bucket.
+
+This is a `scripts/`-only test-harness fix; no interpreter code changed. See
+`todo/deep/vendor-real-test-module.md`'s 2026-08-23 entry for the full
+before/after detail.

--- a/scripts/test-module-sweep.sh
+++ b/scripts/test-module-sweep.sh
@@ -54,11 +54,23 @@ ls t/*.t | xargs -P "$JOBS" -I{} bash -c 'run_one "$@"' _ {}
 # module's END-phaser plan check prints *only*
 # "# You planned N tests, but ran M" and exits 255 -- no "not ok", no
 # "Runtime error" -- so the text-only grep used to score that as a pass.
+#
+# A "not ok N ... # TODO ..." line is standard TAP for an *expected* failure
+# (see mutsu's own `todo()` in Test.rakumod / raku-doc/doc/Type/Test.rakudoc)
+# and must not be scored as a genuine regression -- prove and mutsu's own TAP
+# consumer (runtime/test_functions.rs) both tolerate it. Without this, a file
+# whose native-provider baseline legitimately contains a TODO `not ok` (e.g.
+# t/exits-ok.t, t/failure-sink-handled.t) is scored as "not passing" on the
+# native side too, so a real regression on the real-Test side gets hidden in
+# the "fail under both" bucket instead of surfacing in "regressed". See
+# todo/deep/vendor-real-test-module.md's 2026-08-22 follow-up.
 passes() {
     local out="$1" st="$2"
     [ "$(cat "$st" 2>/dev/null)" = "0" ] || return 1
-    ! grep -qE '^(not ok|Runtime error|Parse error|===SORRY)' "$out" \
-        && ! grep -q '^# You planned' "$out"
+    grep -qE '^(Runtime error|Parse error|===SORRY)' "$out" && return 1
+    grep -q '^# You planned' "$out" && return 1
+    grep -E '^not ok' "$out" | grep -qvi '#[[:space:]]*todo' && return 1
+    return 0
 }
 
 both=0 regressed=0 real_only=0 neither=0

--- a/todo/deep/vendor-real-test-module.md
+++ b/todo/deep/vendor-real-test-module.md
@@ -2753,6 +2753,7 @@ hand, not guessed:
   the next person does not re-discover it from scratch. A real fix would need
   the predicate to parse the TAP `# TODO` suffix rather than grep raw `not
   ok`, which is more than "capture exit status" and is follow-up work.
+  **Fixed 2026-08-23 — see the dated entry at the end of this file.**
 
 So the honest current count is **20 confirmed regressions when checked by
 hand** (the 18 the script now surfaces, plus the 2 masked by the TODO-line
@@ -2833,3 +2834,41 @@ module" above) before this session began; re-confirmed passing 5/5 under
 
 roast side not re-swept this session (unrelated to the fix; the priority list
 item 3 above still applies).
+
+## 2026-08-23: `test-module-sweep.sh`'s `passes()` predicate now understands TAP `# TODO`
+
+Fixed the narrow follow-up recorded above: `passes()` in
+`scripts/test-module-sweep.sh` scored a `not ok N ... # TODO ...` line the
+same as a genuine `not ok`, so a file whose *native*-provider baseline
+legitimately carries a `# TODO`-annotated failure (an expected failure, per
+standard TAP and mutsu's own `todo()` — see `raku-doc/doc/Type/Test.rakudoc`)
+was scored as "not passing" on the native side too. That masked a real
+regression on the real-Test side by dropping the file into "fail under both"
+instead of "regressed".
+
+`passes()` now treats `^not ok` lines as a genuine failure only when they lack
+a case-insensitive `# TODO` suffix:
+
+```sh
+grep -E '^not ok' "$out" | grep -qvi '#[[:space:]]*todo' && return 1
+```
+
+Verified against the two files this ticket named by hand (debug build, repo
+root):
+
+- `t/exits-ok.t`: native exits 0 with two legitimate TODO `not ok` lines (its
+  own negative-case tests 10 and 12) -> now scores as **passing**. Real
+  (`MUTSU_REAL_TEST=1`) exits 4 with `# You planned 13 tests, but ran 0` -> still
+  scores as **failing**. The file now correctly lands in "regressed", not
+  "fail under both".
+- `t/failure-sink-handled.t`: native exits 0 with one legitimate TODO `not ok`
+  (test 4) -> now scores as **passing**. Real exits 255 with `# You planned 4
+  tests, but ran 3` then `Unknown call: is-approx` -> still scores as
+  **failing**. Same reclassification.
+
+This is a `scripts/`-only test-harness fix; no interpreter code was touched.
+The 22-regression sweep count from the 2026-08-21 entry above should now read
+24 once someone re-runs the full sweep (the two previously-masked files
+surfacing), consistent with the "20 confirmed by hand" / "24 raw" figures
+already recorded there -- not re-run here to keep this change scoped to the
+predicate fix itself.


### PR DESCRIPTION
## Summary
- `scripts/test-module-sweep.sh`'s `passes()` predicate scored a `not ok N ... # TODO ...` line the same as a genuine `not ok`. A TODO-marked failure is standard TAP for an *expected* failure (mutsu's own `todo()` emits exactly this; `prove` and `runtime/test_functions.rs` already tolerate it).
- This masked real regressions: `t/exits-ok.t` and `t/failure-sink-handled.t` both have legitimate TODO `not ok` lines in their native-provider baseline, so the sweep scored their native run as "not passing" too and dropped them into the "fail under both" bucket instead of "regressed" -- hiding a real difference under `MUTSU_REAL_TEST=1`.
- `passes()` now only treats a `not ok` line as a failure when it lacks a case-insensitive `# TODO` suffix.
- Updates `todo/deep/vendor-real-test-module.md`'s 2026-08-22 follow-up note (marked fixed, pointer added) and adds `news/2026-08/test-module-sweep-tap-todo-predicate.md`.

This is a `scripts/`-only test-harness fix; no interpreter code changed.

## Test plan
- [x] `bash -n scripts/test-module-sweep.sh` (syntax check)
- [x] Manually ran `t/exits-ok.t` and `t/failure-sink-handled.t` under both the native provider and `MUTSU_REAL_TEST=1`, extracted the fixed `passes()` from the script, and confirmed: native now scores as passing (TODO lines tolerated), real still scores as failing (genuine plan-truncation / `Unknown call: is-approx` difference) -- i.e. both files now correctly land in "regressed" instead of "fail under both".
- [x] CI (`make test` + `make roast`) will run on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)