### PR TITLE
docs: record ADR-0042 slice 1 as shipped and retract its stale "ready to implement" flag

### DIFF
--- a/docs/adr/0042-type-constraints-belong-to-the-container-not-to-a-name.md
+++ b/docs/adr/0042-type-constraints-belong-to-the-container-not-to-a-name.md
@@ -1,8 +1,10 @@
 # ADR-0042: A type constraint belongs to the container, not to a name — retiring the `var_type_constraints` side table
 
-- Status: Partially Implemented — Slice 1 landed 2026-08-20 (see §10); its
-  follow-on "outer-first shadow" finding fixed 2026-08-22 (see §11, which
-  supersedes part of §5.2/§6). Slices 2 and 3 not started.
+- Status: Partially Implemented — Slice 1 landed 2026-08-20 as PR #6743
+  (`dc39cb3e3`; see §10); its follow-on "outer-first shadow" finding fixed
+  2026-08-22 as `b388b1b9f` (see §11, which supersedes part of §5.2/§6).
+  Slice 1 re-verified `raku`-oracled on `c10d305d4` (2026-08-23): §2.2 matrix
+  7/7, §3 alias probe 8/8, §3.1 `state` gap closed. Slices 2 and 3 not started.
 - Date: 2026-08-20
 - Related: ADR-0013 (container interior mutability), ADR-0024 (mainline lexicals —
   the same by-name/lexical split for scalar *values*),
@@ -337,7 +339,7 @@ save/restore is a workaround for the unscoped map, carrying the latent
 promotion defect noted in §5.3. It is recorded here as part of slice 3's
 deletion list, not as a failing shape to fix.
 
-## 10. Slice 1 status (landed 2026-08-20)
+## 10. Slice 1 status (landed 2026-08-20 as PR #6743, `dc39cb3e3`)
 
 All four §5.1 steps landed as specified, with two adjustments discovered
 during implementation:

--- a/news/2026-08/adr0042-slice1-container-constraints-read-from-the-container.md
+++ b/news/2026-08/adr0042-slice1-container-constraints-read-from-the-container.md
@@ -1,0 +1,63 @@
+# ADR-0042 slice 1: a container's type constraint is read from the container
+
+`Interpreter::var_type_constraints` is a `HashMap<String, String>` keyed by BARE
+variable name and never frame-scoped. A `my Int @a` anywhere in the process
+registered `"@a" -> "Int"` globally, and any later `@a` — a different variable,
+in a different frame, in a different file — was type-checked against it. Two
+earlier fixes (2026-08-13) had scoped typed *scalars* in routine bodies and in
+genuine `{ ... }` blocks, but containers were explicitly excluded from both:
+`Compiler::emit_set_var_type` skipped the scoped opcode by sigil for `@` and `%`
+precisely because the push/subscript fast paths read element metadata through
+the global map.
+
+The deep ticket sized the container half as the architectural one. That was
+backwards, and ADR-0042 corrected it. `ArrayData` and `HashData` already carry
+`value_type` / `key_type` / `declared_type`, and the decisive measurement is an
+alias probe: binding a *differently-named* alias (`my @x := @a`) and pushing a
+bad element through it still enforced in 8 of 8 container shapes. Enforcement
+reached through a different name cannot be coming from a name-keyed map — it was
+already coming from the container. So for containers the map was not the
+mechanism at all; it was a redundant second source of truth contributing only
+false positives. The container-first accessor `element_constraint_for` even
+existed already, with a doc comment stating the thesis. The thirteen
+`var_type_constraint_fast` call sites simply did not use it.
+
+Slice 1 broke the circular dependency at the *read* sites rather than the
+declaration sites. The ten container mutation chokepoints (push, the shared- and
+fast-hash/array element-assign bailouts, `:delete`, the whole-`%h` Mix-trait RO
+check, QuantHash coercion on hash store, the `__ANON_STATE__` guard) now consult
+`element_constraint_for` / `container_type_metadata` instead of the name map.
+`state` containers are tagged with their `ContainerTypeInfo` at declaration,
+closing the one measured shape whose constraint lived only in the name map.
+`@`/`%` were dropped from the sigil exclusion so a typed container declared in a
+routine or block registers env-scoped like a scalar does (`&` stays excluded),
+and `BlockLocalScope`'s exit cleanup now strips the `__mutsu_type::` /
+`__mutsu_hash_key_type::` metadata keys, mirroring what `BlockScope` already did.
+
+Two regressions surfaced during the work and were fixed in the same change.
+`set_var_type_constraint_routine_scoped` had only ever registered the value-type
+env entry, never the key-type twin — harmless until step 3 routed a key-only
+object hash (`my %h{Int}`, empty `value_type`) through that scoped path for the
+first time, which silently dropped key-type enforcement for exactly that shape.
+Relatedly, three hash-element bailout checks had to route through
+`container_type_metadata` rather than `element_constraint_for`, because the
+latter filters out an empty `value_type` — which is precisely what a key-only
+object hash has, so it alone would have reintroduced the same gap at the read
+side. `var_hash_key_constraint_fast` lost its last caller and was removed.
+
+The result is `raku`-oracled green: the ADR's container matrix matches `raku` in
+all 7 shapes (routine / block / `if` / `while` / `for` bodies, plus `my Int %h`
+and `my %h{Int}`), the `if`/`unless`/`else` scalar rows go green as a side
+effect of the `BlockLocalScope` cleanup, the alias probe matches 8/8 including
+`state`, and there were zero regressions across the 62 pre-existing `t/*typed*`
+files and the `S02-types` / `S09-typed-arrays` roast whitelist.
+
+Pinned by `t/typed-constraint-scope-matrix.t` and
+`t/state-typed-container-alias.t`. A separate pre-existing "outer-first shadow"
+bug surfaced by this work — a typed declaration that *shadows* an existing outer
+binding leaking its constraint onto that binding — was fixed two days later and
+is written up in `news/2026-08/typed-declaration-shadow-scope-leak.md`.
+
+ADR-0042 slices 2 (a scalar cell carries its `of`) and 3 (delete the map and its
+workarounds) remain open; `todo/deep/bare-name-type-constraint-store-is-scope-blind.md`
+stays open for them.

--- a/todo/deep/bare-name-type-constraint-store-is-scope-blind.md
+++ b/todo/deep/bare-name-type-constraint-store-is-scope-blind.md
@@ -3,6 +3,29 @@
 `Interpreter::var_type_constraints` is a single global `HashMap<String,
 String>` keyed by BARE variable name, and it is never frame-scoped.
 
+## Status 2026-08-23: ADR-0042 Slice 1 is SHIPPED — residual 1 is closed
+
+Slice 1 landed 2026-08-20 as PR #6743 (`dc39cb3e3`), and the follow-on
+"outer-first shadow" finding landed 2026-08-22 as `b388b1b9f`
+(`news/2026-08/typed-declaration-shadow-scope-leak.md`). Re-verified on
+`c10d305d4`, `raku`-oracled: the ADR's §2.2 container matrix matches `raku`
+7/7, the §3 alias probe (enforcement reached through a differently-named bound
+alias, which only the container can supply) matches 8/8, and the §3.1 `state`
+container gap is closed. Pins green: `t/typed-constraint-scope-matrix.t`,
+`t/state-typed-container-alias.t`, `t/typed-constraint-shadow-scope.t`,
+`t/typed-lexical-constraint-frame-scoped.t`,
+`t/typed-lexical-constraint-block-scoped.t`.
+
+**Residual 1 below (`@`/`%` containers) is therefore CLOSED** — a container's
+element/key constraint is now read from the value's own embedded
+`ArrayData`/`HashData` metadata at the ten mutation chokepoints, not from the
+bare-name map. Residual 4 was already found not to reproduce (ADR-0042 §9).
+
+This ticket stays open for **ADR-0042 Slices 2 and 3**, which are NOT started:
+slice 2 (a scalar cell carries its `of`, the architectural half — residuals 2
+and 3 below) and slice 3 (delete the map and its workarounds). Do not re-dispatch
+slice 1.
+
 ## Status 2026-08-20: superseded by ADR-0042 — read that first
 
 The remaining work is now designed in
@@ -24,8 +47,9 @@ is **stale in two ways** and the ADR carries the corrected, measured version:
   `my Str $s; my $t := $s; $t = 42` wrongly succeeds.
 
 Residual 4 (`for`-loop typed params) does not reproduce as a divergence; see
-ADR-0042 §9. Slice 1 of ADR-0042 is **ready for direct implementation** — it is
-mechanical and needs no further design.
+ADR-0042 §9. Slice 1 of ADR-0042 was ready for direct implementation — it was
+mechanical and needed no further design. **It has since shipped; see the
+2026-08-23 status above.**
 
 ## Status 2026-08-13: routine-scoped SCALARS are fixed
 
@@ -72,7 +96,8 @@ Pinned by `t/typed-lexical-constraint-block-scoped.t` (verified against
 
 ## What is still scope-blind (as recorded 2026-08-13 — see the stale-scope note above)
 
-1. **`@`/`%` containers**: `my Int @a` inside a routine still registers the
+1. **[CLOSED 2026-08-23 by ADR-0042 slice 1, PR #6743.]** **`@`/`%` containers**:
+   `my Int @a` inside a routine still registers the
    bare name in the global map (their element/key-type metadata is consulted
    through `var_type_constraint_fast` by the push/subscript/element-assign
    fast paths, which never probe env). A module method's `my Int @r` can


### PR DESCRIPTION
## Summary

I was dispatched to implement **ADR-0042 slice 1**. It was already shipped — it landed on 2026-08-20 as **PR #6743** (`dc39cb3e3`), three days before the dispatch, and its follow-on "outer-first shadow" finding landed 2026-08-22 as `b388b1b9f`.

Rather than re-implement it, this PR verifies the shipped state and closes out the documentation, because the stale docs are what caused the misdispatch and would cause it again.

## Why this is not merely cosmetic

`todo/deep/bare-name-type-constraint-store-is-scope-blind.md` still ended its status section with:

> Slice 1 of ADR-0042 is **ready for direct implementation** — it is mechanical and needs no further design.

That sentence is a live dispatch signal for the `todo/deep` + `todo/tickets` pipeline, which selects work by skimming these files. It survived three days past the slice landing and produced one duplicate work assignment. Retracting it is the actual fix.

Separately, slice 1 never got a `news/` entry when it landed, so the accomplishment was recorded only inside the ADR.

## Verification performed (not taken on trust)

Per CLAUDE.md's `trap-todo-and-adr-root-cause-often-wrong` lesson, I re-measured against `raku` on `c10d305d4` instead of trusting the ADR's own write-up:

- **ADR §2.2 container matrix — mutsu matches `raku` 7/7.** A typed container declared in a routine / bare block / `if` branch / `while` body / `for` body, plus `my Int %h` and `my %h{Int}`, each followed by use of a same-named *untyped* outer container that must not be poisoned.
- **ADR §3 alias probe — 8/8 die in both**, including the §3.1 `state` container. This is the load-bearing check: enforcement reached through a *differently-named* bound alias (`my @x := @a`) cannot come from a bare-name map, so it demonstrates the constraint really is being read off the container.
- **All four specified slice-1 steps confirmed present** in the tree: the ten rerouted container chokepoints (`element_constraint_for` / `container_type_metadata` in place of `var_type_constraint_fast`), `state` container tagging, the `@`/`%` sigil-exclusion drop in `emit_set_var_type` with `&` correctly retained, and `BlockLocalScope`'s `__mutsu_type::` / `__mutsu_hash_key_type::` exit cleanup. The only surviving `var_type_constraint_fast` readers are the scalar ones the ADR explicitly puts out of slice 1's scope.

Regression sweep (all pass):

- 5 slice-1 pins — `t/typed-constraint-scope-matrix.t`, `t/state-typed-container-alias.t`, `t/typed-constraint-shadow-scope.t`, `t/typed-lexical-constraint-frame-scoped.t`, `t/typed-lexical-constraint-block-scoped.t` (73 tests)
- 57 `t/*typed*.t` files (611 tests)
- 10 `roast/S09-typed-arrays/*.t` files (4261 tests)

## Changes (documentation only)

- **`todo/deep/bare-name-type-constraint-store-is-scope-blind.md`** — new status section recording slice 1 as shipped and re-verified; residual 1 (`@`/`%` containers) marked `CLOSED` inline; the "ready for direct implementation" sentence retracted; explicit "do not re-dispatch slice 1" note added.
- **`docs/adr/0042-*.md`** — PR/commit pointers on the Status line and the §10 heading, plus the 2026-08-23 re-verification result.
- **`news/2026-08/adr0042-slice1-container-constraints-read-from-the-container.md`** — the missing slice-1 accomplishment entry.

## Scope

**The ticket stays open.** ADR-0042 slices 2 (a scalar cell carries its `of` — the architectural half) and 3 (delete the map and its workarounds) are not started, and the ticket's residuals 2 and 3 belong to slice 2. No later slice was attempted, and there are no interpreter code changes.

This is a docs-only diff (`docs/`, `todo/`, `news/`), so per `scripts/ci-docs-only.sh` the four heavy CI jobs report `skipped` by design — that is correct here, not a stuck CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
