### PR TITLE
fix: resolve a package's `our @a`/`our %h` by its qualified mirror, not the bare env key

### DIFF
--- a/docs/adr/0039-container-lexicals-resolve-lexically.md
+++ b/docs/adr/0039-container-lexicals-resolve-lexically.md
@@ -3,9 +3,14 @@
 - Status: Slice 1 (§4.1) landed 2026-08-20. §8.2's recorded cross-thread
   collisions closed 2026-08-22 by giving a container's bare-name lane entry a
   *lifetime* — see §8.6, which also records two cheaper routes measured and
-  rejected. Slice 2 (§4.2 — containers resolve by slot/upvalue, not by name,
-  retiring the by-name path at the compiler) is still next and still the end
-  state; it now carries no known open correctness bug of its own.
+  rejected. §4.1's excluded `our` container case (§1.2's third instance) was
+  fixed separately on 2026-08-23 by a resolution-only change, as §4.1
+  predicted it could be — see
+  `news/2026-08/our-container-bare-name-prefers-package-mirror.md` and
+  `src/vm/vm_our_package_vars.rs`. Slice 2 (§4.2 — containers resolve by
+  slot/upvalue, not by name, retiring the by-name path at the compiler) is
+  still next and still the end state; it now carries no known open
+  correctness bug of its own.
 - Date: 2026-08-20
 - Related: ADR-0013 (container interior mutability — `gc_contents_mut`),
   ADR-0024 (mainline lexicals for named subs — the scalar half of this bug),

--- a/news/2026-08/our-container-bare-name-prefers-package-mirror.md
+++ b/news/2026-08/our-container-bare-name-prefers-package-mirror.md
@@ -1,0 +1,110 @@
+# A module's `our @arr` / `our %h` is no longer the caller's container
+
+`todo/deep/module-file-scope-array-and-hash-still-share-the-caller.md` item 1 —
+the `our` instance of ADR-0039 §1.2, deliberately left unfixed by slice 1 — is
+closed. A module that declares a package-scoped container and mutates it from
+its own routines now mutates *its own* container, even when the loading script
+happens to declare a same-named `my`:
+
+```raku
+# UnitOurContainer.rakumod
+unit module UnitOurContainer;
+our @arr = <a b>;
+sub arr-push($v) is export { @arr.push($v) }
+sub arr-read()   is export { @arr.join(",") }
+```
+```raku
+use UnitOurContainer;
+my @arr = <x y z>;
+arr-push("c");
+say arr-read();       # raku: a,b,c    was: x,y,z,c    now: a,b,c
+say @arr.join(",");   # raku: x,y,z    was: x,y,z,c    now: x,y,z
+```
+
+## Root cause
+
+`our @arr` inside `unit module UFL3` publishes its container under the
+package-qualified mirror `@UFL3::arr`: the declaration compiles to
+`Dup; SetLocalDecl(slot); SetGlobal("@UFL3::arr")`, and the `SetGlobal` arm
+mirrors every package-qualified write into `our_vars`. That store was always
+correct — `@UFL3::arr` read back the right value throughout the bug's lifetime.
+
+The module's own routines, however, reference the container by its **bare**
+name. A sub body compiles in a fresh `Compiler` whose `current_package` has
+been overwritten with the mangled state-scope name `UFL3::&arr-push/1`
+(`compiler/helpers_sub_body.rs`), and `qualify_variable_name`
+(`compiler/mod.rs`) returns any name verbatim when the package contains `::&`
+— a guard that exists so `state`-variable scope names never leak into variable
+qualification. So `Expr::ArrayVar` emitted a bare `GetArrayVar("@arr")`, which
+resolved against `env`, whose `@arr` key belongs to whatever scope loaded the
+module. Every read and every mutation the module made went to the consumer's
+array while the correct container sat in the mirror, unconsulted.
+
+This was a **resolution** bug against an already-correct store, which is why
+ADR-0039 §4.1 excluded `our` from slice 1's `unit_lexicals` work: `our`
+variables are externally visible (`@UFL3::arr` must stay readable and writable
+from outside the module), so the qualified mirror — not a private per-compunit
+cell — is their canonical store.
+
+## The fix
+
+New `src/vm/vm_our_package_vars.rs` reconstructs the qualified key from the
+package the running routine belongs to and prefers the mirror.
+`our_package_container_key` mirrors `unit_lexical_slot`'s candidate order
+exactly (the frame's `lexical_package`, the method class, the frame package,
+then `current_package`), each walked up its `::` chain, and reuses
+`package_qualified_candidate` so it applies precisely the twigil /
+positional-capture exclusions the compiler's `qualify_variable_name` does —
+reads and writes therefore reconstruct exactly the key the declaration stored.
+
+It is wired into three chokepoints:
+
+- `get_env_with_main_alias` (`vm_env_helpers.rs`), the by-name **read**
+  chokepoint, immediately after `unit_scope_lexical` — so a compunit's
+  file-scope `my` still wins over a same-named package variable.
+- `env_root_descended_mut` (`vm_var_assign_index_named.rs`), the container
+  **mutation** chokepoint every element-assign / `push` / `pop` / key-set
+  funnels through, immediately after `unit_lexical_slot_mut`.
+- `exec_delete_index_named_op` (`vm_var_delete_ops.rs`), which resolves its
+  container out of `env` by name rather than through `env_root_descended_mut`
+  and so needed its own seed / run / write-back / restore dance — the same one
+  ADR-0039 §6.1 records for the unit-lexical case, and for the same reason.
+  Its write-back goes through a new `our_mirror_store_preserving_identity`,
+  which copies the mutated contents **into** the mirror's existing `Gc` node
+  rather than swapping it, so the module mainline's own slot and the
+  `env["%Pkg::h"]` entry are not orphaned on the first `:delete`.
+
+Nothing else was needed on the write side: container mutation in mutsu is
+write-through-the-shared-node (ADR-0013 / ADR-0039 §2), so once a chokepoint
+resolves to the mirror's node the mutation lands there by itself.
+
+A container the **running frame declares itself** shadows the package variable,
+so a name present in the frame's own `CompiledCode::locals` is never
+redirected. That keeps the change a resolution *preference* rather than a
+hijack in the opposite direction: `sub f { my @arr = <p q>; @arr.push('r') }`
+inside the very module that declares `our @arr` still uses its own lexical, and
+leaves the package container untouched.
+
+## Verification
+
+New pin `t/our-container-bare-name-resolution.t` (28 assertions, all verified
+against real `raku` first) with fixture `t/lib/UnitOurContainer.rakumod`: read /
+`push` / element-read / element-assign / `pop` / nested-block push for `@`, and
+read / key-set / element-read / `:delete` for `%`, each paired with an assertion
+that the script's same-named container is untouched and one that the
+package-qualified mirror agrees — plus the two lexical-shadowing rows above.
+
+Slice 1's pins (`t/module-file-scope-lexical.t`,
+`t/named-sub-lexical-scope-container.t`) and
+`t/anon-container-cell-inplace-reassign.t` stay green, as does the full local
+suite (3362 files, 31590 assertions).
+
+## Still open
+
+ADR-0039 slice 2 (containers resolve by slot/upvalue at the compiler, retiring
+by-name container resolution outright) remains the architectural end state and
+keeps the deep ticket open. The **scalar** twin of this bug — a module's
+`our $x` write landing on the caller's `my $x` — is a genuinely different
+mechanism (a scalar has no shared node, so it needs the bare env store
+*suppressed*, not just resolution redirected) and is recorded separately as
+`todo/tickets/our-scalar-write-leaks-to-the-callers-lexical.md`.

--- a/src/runtime/accessors_state.rs
+++ b/src/runtime/accessors_state.rs
@@ -270,6 +270,13 @@ impl Interpreter {
         self.our_vars.get(key)
     }
 
+    /// Mutable counterpart of [`Self::get_our_var`], for the container
+    /// write chokepoint (`env_root_descended_mut`): a package's `our @a`/`our
+    /// %h` is mutated in place through its stored `Gc`, not replaced.
+    pub(crate) fn get_our_var_mut(&mut self, key: &str) -> Option<&mut Value> {
+        self.our_vars.get_mut(key)
+    }
+
     pub(crate) fn our_vars_iter(&self) -> impl Iterator<Item = (&String, &Value)> {
         self.our_vars.iter()
     }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -216,6 +216,7 @@ mod vm_native_map;
 mod vm_native_sort;
 mod vm_native_subst;
 mod vm_native_test;
+mod vm_our_package_vars;
 mod vm_react_loop;
 mod vm_react_subscriptions;
 mod vm_react_supply_helpers;

--- a/src/vm/vm_env_helpers.rs
+++ b/src/vm/vm_env_helpers.rs
@@ -211,7 +211,7 @@ impl Interpreter {
     /// already qualified, sigil-stripped twigils, or positional captures —
     /// mirroring the `GetGlobal` bare-name read fallback so reads and writes
     /// resolve to the same canonical store.
-    fn package_qualified_candidate(name: &str, cur: &str) -> Option<String> {
+    pub(super) fn package_qualified_candidate(name: &str, cur: &str) -> Option<String> {
         if name.contains("::") || cur.is_empty() || cur == "GLOBAL" || cur.contains("::&") {
             return None;
         }
@@ -974,6 +974,17 @@ impl Interpreter {
         // what this returns is a mutation of the module's own container.
         if let Some(v) = self.unit_scope_lexical(name) {
             return Some(v.into_deref());
+        }
+        // An `our @a` / `our %h` of the package the running routine belongs to
+        // is likewise NOT reachable under its bare env key — the module's own
+        // routines compile the bare name (the sub-body state-scope package
+        // disables qualification), while the container itself lives under the
+        // package-qualified mirror `@Pkg::a`. Prefer that mirror over the env
+        // key, which belongs to whatever scope loaded the module. Checked
+        // AFTER `unit_scope_lexical` so a compunit's file-scope `my` still
+        // wins over a same-named package variable. See `vm_our_package_vars`.
+        if let Some(v) = self.our_package_container(name) {
+            return Some(v);
         }
         // Raku allows underscore variants of kebab-case identifiers
         // (e.g. $*EXECUTABLE_NAME is equivalent to $*EXECUTABLE-NAME).

--- a/src/vm/vm_our_package_vars.rs
+++ b/src/vm/vm_our_package_vars.rs
@@ -1,0 +1,174 @@
+//! Bare-name resolution for a package's `our`-declared `@`/`%` containers.
+//!
+//! `our @arr` inside `unit module UFL3` is a PACKAGE variable. Its canonical
+//! storage is the package-qualified mirror `@UFL3::arr`: the declaration
+//! compiles to `Dup; SetLocalDecl(slot); SetGlobal("@UFL3::arr")`, and the
+//! `SetGlobal` arm mirrors every package-qualified write into `our_vars`
+//! (`vm_exec_dispatch.rs`).
+//!
+//! The module's OWN routines, however, reference it by the BARE name. A sub
+//! body compiles in a fresh `Compiler` whose `current_package` was overwritten
+//! with the mangled state-scope name `UFL3::&arr-push/1`
+//! (`compiler/helpers_sub_body.rs`), and `qualify_variable_name`
+//! (`compiler/mod.rs`) returns the name verbatim for any package containing
+//! `::&`. So `Expr::ArrayVar` emits a bare `GetArrayVar("@arr")`.
+//!
+//! Resolved against `env` alone, that bare key belongs to whatever scope
+//! loaded the module — so a consumer's own `my @arr` hijacked every read and
+//! every mutation the module made, while `@UFL3::arr` sat holding the correct
+//! value nobody consulted. This module supplies the missing step: reconstruct
+//! the qualified key from the package the running routine belongs to and
+//! prefer the mirror.
+//!
+//! This is the RESOLUTION fix ADR-0039 §4.1 deliberately excluded from slice
+//! 1's `unit_lexicals` store. `our` variables are externally visible
+//! (`@UFL3::arr` must stay readable and writable from outside the module), so
+//! the qualified mirror — not a private per-compunit cell — is their canonical
+//! store; the bug was never a missing store, only a resolution that never
+//! looked at it.
+//!
+//! Containers need nothing beyond this. Their mutation is
+//! write-through-the-shared-node (ADR-0013 / ADR-0039 §2), so once a read or a
+//! write chokepoint resolves to the mirror's `Gc`, `push` / element-assign /
+//! `:delete` land on the module's own container with no separate write-back.
+
+use super::*;
+
+impl Interpreter {
+    /// The package-qualified `our_vars` key for a bare `@`/`%` container name,
+    /// as seen from the routine that is running, or `None` when the name does
+    /// not name an `our` container of a package in scope.
+    ///
+    /// Candidate packages mirror [`Interpreter::unit_lexical_slot`]'s order
+    /// exactly — the running frame's `lexical_package` (the only one that
+    /// survives a mixin), the method class, the frame package, then
+    /// `current_package` — each walked up its `::` chain so a class declared
+    /// inside a module resolves through its owner.
+    ///
+    /// A container the RUNNING FRAME declares itself shadows the package
+    /// variable (`sub f { my @arr = ...; @arr.push(1) }` inside the very
+    /// module that declares `our @arr`), so a name present in the frame's own
+    /// `locals` is never redirected. That check is what keeps this a
+    /// resolution *preference* rather than a hijack in the other direction.
+    pub(crate) fn our_package_container_key(&self, name: &str) -> Option<String> {
+        // Cheap gates first: this runs on every container read.
+        if self.our_vars_is_empty() {
+            return None;
+        }
+        if !(name.starts_with('@') || name.starts_with('%')) {
+            return None;
+        }
+        // An explicitly-written `@Other::x` is already the package variable it
+        // names; anonymous containers are never package variables.
+        if name.contains("::") || name.contains("__ANON") {
+            return None;
+        }
+        if self.running_frame_declares_local(name) {
+            return None;
+        }
+        let cur = self.current_package();
+        let frame = self.routine_stack().last();
+        let candidates = [
+            frame.and_then(|f| f.lexical_package).map(|s| s.as_str()),
+            self.method_class_stack_top_str(),
+            frame
+                .map(|f| f.package.as_str())
+                .filter(|pkg| !pkg.is_empty() && *pkg != "GLOBAL"),
+            Some(cur.as_str()),
+        ];
+        for candidate in candidates.into_iter().flatten() {
+            let mut pkg = candidate;
+            loop {
+                if pkg.is_empty() || pkg == "GLOBAL" || pkg.contains("::&") {
+                    break;
+                }
+                // `package_qualified_candidate` applies the same twigil /
+                // positional-capture exclusions the compiler's
+                // `qualify_variable_name` does, so reads and writes reconstruct
+                // exactly the key the declaration stored.
+                if let Some(key) = Self::package_qualified_candidate(name, pkg)
+                    && self.get_our_var(&key).is_some()
+                {
+                    return Some(key);
+                }
+                match pkg.rsplit_once("::") {
+                    Some((parent, _)) => pkg = parent,
+                    None => break,
+                }
+            }
+        }
+        None
+    }
+
+    /// Read companion of [`Self::our_package_container_key`]: the mirror's
+    /// current value, dereferenced. A container's `Gc` is shared with the
+    /// stored mirror, so mutating what this returns in place mutates the
+    /// package's own container.
+    pub(crate) fn our_package_container(&self, name: &str) -> Option<Value> {
+        let key = self.our_package_container_key(name)?;
+        self.get_our_var(&key).cloned().map(Value::into_deref)
+    }
+
+    /// Write companion of [`Self::our_package_container_key`], for the
+    /// container-mutation chokepoint [`Interpreter::env_root_descended_mut`].
+    pub(crate) fn our_package_container_mut(&mut self, name: &str) -> Option<&mut Value> {
+        let key = self.our_package_container_key(name)?;
+        self.get_our_var_mut(&key)
+    }
+
+    /// Store `val` into the `our` mirror at `key`, writing THROUGH the
+    /// container node the mirror already holds rather than swapping it for a
+    /// fresh one.
+    ///
+    /// `our @a` publishes one container under three names at declaration time
+    /// (`Dup; SetLocalDecl(slot); SetGlobal("@Pkg::a")`), all sharing one `Gc`.
+    /// A plain replace here would orphan the module mainline's own slot and the
+    /// `env["@Pkg::a"]` entry on the first `:delete`. Same reasoning as
+    /// [`Interpreter::cell_store_preserving_container_identity`], one
+    /// indirection shallower — the mirror is a plain `Value`, not a cell.
+    pub(crate) fn our_mirror_store_preserving_identity(&mut self, key: &str, val: &Value) {
+        let Some(slot) = self.get_our_var_mut(key) else {
+            return;
+        };
+        let replacement = match (slot.view(), val.view()) {
+            (ValueView::Hash(old_gc), ValueView::Hash(new_gc))
+                if !crate::gc::Gc::ptr_eq(&old_gc, &new_gc) =>
+            {
+                Some(Self::hash_inplace_reassign(&old_gc, &new_gc))
+            }
+            (ValueView::Array(old_gc, _), ValueView::Array(new_gc, kind))
+                if !crate::gc::Gc::ptr_eq(&old_gc, &new_gc) =>
+            {
+                Some(Self::array_inplace_reassign(&old_gc, &new_gc, kind))
+            }
+            _ => None,
+        };
+        // `hash_inplace_reassign` / `array_inplace_reassign` copy the new
+        // contents INTO the old node and return a `Value` pointing at it, so
+        // re-seating the slot on that result keeps the original `Gc`.
+        let new_slot = replacement.unwrap_or_else(|| val.clone());
+        if let Some(slot) = self.get_our_var_mut(key) {
+            *slot = new_slot;
+        }
+    }
+
+    /// Whether the bytecode frame currently executing declares `name` as one
+    /// of its own locals — i.e. the bare name is a genuine lexical of this
+    /// routine and must not be redirected to a package variable.
+    ///
+    /// Container locals keep their sigil in `CompiledCode::locals`
+    /// (`locals: ["@arr", "%h", "s"]` for a `unit module` mainline), so the
+    /// sigiled name is compared directly.
+    fn running_frame_declares_local(&self, name: &str) -> bool {
+        if self.current_code == 0 {
+            return false;
+        }
+        // SAFETY: `current_code` is the address of the `CompiledCode` of the
+        // bytecode frame currently executing in `exec_one` (set at the top of
+        // every dispatch). It is an ancestor stack frame of this synchronous
+        // call, and therefore alive. Same pattern as `builtins_atomic_shared`
+        // and `builtins_dispatch_next`.
+        let code = unsafe { &*(self.current_code as *const crate::opcode::CompiledCode) };
+        code.locals.iter().any(|n| n == name)
+    }
+}

--- a/src/vm/vm_var_assign_index_named.rs
+++ b/src/vm/vm_var_assign_index_named.rs
@@ -3291,6 +3291,17 @@ impl Interpreter {
             let descended = unsafe { Self::descend_container_ref(root) };
             return Some(unsafe { &mut *descended });
         }
+        // An `our @a`/`our %h` of the running routine's own package lives under
+        // the package-qualified mirror, not under the bare env key (which
+        // belongs to the loading scope). Mirrors the read-side precedence in
+        // `get_env_with_main_alias`, so every element-assign / `push` / `pop` /
+        // key-set / `:delete` that funnels through here mutates the package's
+        // own container. See `vm_our_package_vars`.
+        if let Some(root) = self.our_package_container_mut(var_name) {
+            let root = root as *mut Value;
+            let descended = unsafe { Self::descend_container_ref(root) };
+            return Some(unsafe { &mut *descended });
+        }
         let root = self.env_mut().get_mut(var_name)? as *mut Value;
         let descended = unsafe { Self::descend_container_ref(root) };
         Some(unsafe { &mut *descended })

--- a/src/vm/vm_var_delete_ops.rs
+++ b/src/vm/vm_var_delete_ops.rs
@@ -242,6 +242,26 @@ impl Interpreter {
             self.env_mut().insert(var_name.clone(), inner);
             saved
         });
+        // The `our`-package twin of the unit-lexical case just above: an
+        // `our %h`/`our @a` of the running routine's own package is stored
+        // under the package-qualified mirror in `our_vars`, while `env[%h]`
+        // holds the loading scope's own same-named binding. Same
+        // seed / run / write-back / restore dance, because this op resolves
+        // its container out of env by name rather than through
+        // `env_root_descended_mut` (which already prefers the mirror).
+        // Mutually exclusive with `unit_cell`: a compunit's file-scope `my`
+        // wins over a same-named package variable, matching the read-side
+        // precedence in `get_env_with_main_alias`.
+        let our_key = match unit_cell {
+            Some(_) => None,
+            None => self.our_package_container_key(&var_name),
+        };
+        let saved_our_env_entry = our_key.as_ref().map(|key| {
+            let saved = self.env().get(&var_name).cloned();
+            let inner = self.get_our_var(key).cloned().unwrap_or(Value::NIL);
+            self.env_mut().insert(var_name.clone(), inner);
+            saved
+        });
         let bound_cell = match self.env().get(&var_name).map(Value::view) {
             Some(ValueView::ContainerRef(cell)) => Some(cell.clone()),
             _ => None,
@@ -318,6 +338,22 @@ impl Interpreter {
             let cell_val = Value::container_ref(cell);
             self.env_mut().insert(var_name.clone(), cell_val.clone());
             self.write_local_slot_or_name(code, slot, &var_name, cell_val);
+        }
+        if let Some(key) = our_key {
+            if let Some(mutated) = self.env().get(&var_name).cloned() {
+                self.our_mirror_store_preserving_identity(&key, &mutated);
+            }
+            // Restore whatever the bare env key held before the seed — see
+            // the `unit_cell` restore below for why leaving the package
+            // container installed there would undo the isolation.
+            match saved_our_env_entry.flatten() {
+                Some(v) => {
+                    self.env_mut().insert(var_name.clone(), v);
+                }
+                None => {
+                    self.env_mut().remove(&var_name);
+                }
+            }
         }
         if let Some(cell) = unit_cell {
             if let Some(mutated) = self.env().get(&var_name).cloned() {

--- a/t/lib/UnitOurContainer.rakumod
+++ b/t/lib/UnitOurContainer.rakumod
@@ -1,0 +1,44 @@
+unit module UnitOurContainer;
+
+# Package-scoped (`our`) containers. Their canonical storage is the
+# package-qualified mirror (`@UnitOurContainer::arr`), but this module's own
+# routines reference them by the BARE name -- which is exactly the resolution
+# the loading script's same-named `my @arr` used to hijack.
+# See todo/deep/module-file-scope-array-and-hash-still-share-the-caller.md
+# item 1 and ADR-0039 sec 4.1.
+
+our @arr = <a b>;
+our %h = (k => 'v');
+
+sub arr-read() is export { @arr.join(",") }
+sub arr-push($v) is export { @arr.push($v) }
+sub arr-elem($i) is export { @arr[$i] // 'MISSING' }
+sub arr-set($i, $v) is export { @arr[$i] = $v }
+sub arr-pop() is export { @arr.pop }
+sub arr-elems() is export { @arr.elems }
+
+sub hash-read() is export { %h.keys.sort.map({ "$_=" ~ %h{$_} }).join(",") }
+sub hash-set($k, $v) is export { %h{$k} = $v }
+sub hash-elem($k) is export { %h{$k} // 'MISSING' }
+sub hash-delete($k) is export { %h{$k}:delete }
+
+# A block nested inside a module routine still sees the package container.
+sub arr-push-in-block($v) is export {
+    for 1 .. 1 { @arr.push($v) }
+    @arr.join(",")
+}
+
+# A routine-local `my @arr` SHADOWS the package variable: the lexical
+# declaration wins inside this routine, and the package container must be
+# left completely untouched.
+sub shadowed-local() is export {
+    my @arr = <p q>;
+    @arr.push('r');
+    @arr.join(",")
+}
+
+sub shadowed-local-hash() is export {
+    my %h = (own => 1);
+    %h<extra> = 2;
+    %h.keys.sort.join(",")
+}

--- a/t/our-container-bare-name-resolution.t
+++ b/t/our-container-bare-name-resolution.t
@@ -1,0 +1,71 @@
+use Test;
+use lib 't/lib';
+use UnitOurContainer;
+
+# A module's `our @arr` / `our %h` is a PACKAGE variable of that module. Its
+# own routines reference it by the bare name `@arr`, because a sub body
+# compiles under a mangled `Pkg::&sub/arity` state-scope package that disables
+# package-qualification. Resolved against `env` alone, that bare name found
+# whatever `@arr` the LOADING script had declared, so every module routine
+# mutated the script's array instead of its own -- while the package-qualified
+# mirror `@UnitOurContainer::arr` sat there holding the correct value nobody
+# consulted.
+#
+# See todo/deep/module-file-scope-array-and-hash-still-share-the-caller.md
+# item 1 and ADR-0039 sec 4.1 (which excluded `our` from slice 1 precisely
+# because it needs a resolution fix, not a store).
+
+plan 28;
+
+# The script declares its own same-named containers -- the collision setup.
+my @arr = <x y z>;
+my %h   = (own => 1);
+
+# --- @: read ---------------------------------------------------------------
+is arr-read(), "a,b", "module sees its own our @arr, not the script's";
+is @arr.join(","), "x,y,z", "script's my @arr is untouched by the module's read";
+is @UnitOurContainer::arr.join(","), "a,b", "package-qualified mirror agrees";
+is arr-elems(), 2, "module's our @arr has its own element count";
+
+# --- @: push ---------------------------------------------------------------
+arr-push("c");
+is arr-read(), "a,b,c", "the module's push lands on its own our @arr";
+is @arr.join(","), "x,y,z", "the module's push does not reach the script's my @arr";
+is @UnitOurContainer::arr.join(","), "a,b,c", "the mirror observes the push";
+
+# --- @: element read / element assign --------------------------------------
+is arr-elem(1), "b", "module indexes its own our @arr";
+arr-set(0, "Z");
+is arr-read(), "Z,b,c", "the module's element-assign lands on its own our @arr";
+is @arr.join(","), "x,y,z", "the module's element-assign does not reach the script";
+
+# --- @: pop ----------------------------------------------------------------
+is arr-pop(), "c", "the module pops from its own our @arr";
+is arr-read(), "Z,b", "the module's our @arr shrank";
+is @arr.join(","), "x,y,z", "the script's my @arr still has all three elements";
+
+# --- @: a block nested inside a module routine -----------------------------
+is arr-push-in-block("n"), "Z,b,n", "a block inside a module routine sees the package container";
+is @arr.join(","), "x,y,z", "the nested-block push does not reach the script";
+
+# --- %: read / key-set / delete --------------------------------------------
+is hash-read(), "k=v", "module sees its own our %h, not the script's";
+is %h.keys.sort.join(","), "own", "script's my %h is untouched";
+is %UnitOurContainer::h.keys.sort.join(","), "k", "package-qualified hash mirror agrees";
+
+hash-set("k2", "v2");
+is hash-read(), "k=v,k2=v2", "the module's key-set lands on its own our %h";
+is %h.keys.sort.join(","), "own", "the module's key-set does not reach the script's my %h";
+is hash-elem("k2"), "v2", "module reads back the key it just set";
+
+is hash-delete("k"), "v", ":delete returns the removed value from the module's own our %h";
+is hash-read(), "k2=v2", "the module's our %h lost the deleted key";
+is %h.keys.sort.join(","), "own", "the script's my %h is unaffected by the module's :delete";
+
+# --- lexical shadowing inside the module still wins ------------------------
+# A routine-local `my @arr` is a different variable from the package `our @arr`.
+# Preferring the package mirror must NOT override a genuine lexical declaration.
+is shadowed-local(), "p,q,r", "a routine-local my @arr shadows the package our @arr";
+is arr-read(), "Z,b,n", "the package our @arr is untouched by the shadowing routine";
+is shadowed-local-hash(), "extra,own", "a routine-local my %h shadows the package our %h";
+is hash-read(), "k2=v2", "the package our %h is untouched by the shadowing routine";

--- a/todo/deep/module-file-scope-array-and-hash-still-share-the-caller.md
+++ b/todo/deep/module-file-scope-array-and-hash-still-share-the-caller.md
@@ -11,9 +11,9 @@ ADR's stated architectural end state, not merely a follow-up; the exclusion
 list slice 1 carries (`our`, `state`, `is export`, `$*dynamic`, `::`-qualified,
 type-constrained, anonymous-container names) is explicitly "the list of things
 slice 2 must subsume" (ADR-0039 §4.3). `our @arr` colliding (§1.2's third
-instance) is ALSO still broken — slice 1 deliberately does not touch it (a
-separate resolution-bug ticket, not a store gap). Move this file to
-`news/2026-08/` only once slice 2 lands and closes the remaining by-name
+instance) was ALSO still broken after slice 1; it is **FIXED as of 2026-08-23**
+by a resolution-only change (see "Remaining open scope" item 1). Move this file
+to `news/2026-08/` only once slice 2 lands and closes the remaining by-name
 container resolution path.
 
 `news/2026-08/module-file-scope-lexical-is-not-the-callers.md` fixed this for
@@ -113,18 +113,30 @@ module — now pinned as `t/module-file-scope-lexical.t`'s container half),
 `namedsub-mainline.raku` (the module-free mainline shadow shape — now pinned
 as `t/named-sub-lexical-scope-container.t`), `repro-sub.raku` (consumer
 declares the shadow inside a sub — now fixed too), `ourtest.raku` (`our @a` —
-STILL diverges from `raku`, deliberately unfixed by slice 1), `alias.raku`
-(the write-through control, unaffected by this ADR either way).
+fixed 2026-08-23, now pinned as `t/our-container-bare-name-resolution.t`; only
+its trailing `our $s` scalar line still diverges, tracked separately),
+`alias.raku` (the write-through control, unaffected by this ADR either way).
 
 ## Remaining open scope (why this file is not fully closed)
 
-1. **`our @arr` colliding** (§1.2's third instance, `ourtest.raku`) — still
-   reproduces after slice 1. mutsu maintains the package-qualified mirror
-   (`@UFL3::arr` reads correctly), but the module's own routines never
-   consult it by the bare name, so `a-push` still lands on the consumer's
-   array. This needs a RESOLUTION fix (prefer the package-qualified mirror
-   for an `our`-declared name when running inside that package), not a store
-   change — deliberately out of slice 1's scope per ADR-0039 §4.1.
+1. ~~**`our @arr` colliding**~~ — **FIXED 2026-08-23**, see
+   `news/2026-08/our-container-bare-name-prefers-package-mirror.md`. The
+   resolution fix landed as `src/vm/vm_our_package_vars.rs`: a bare `@`/`%`
+   name is resolved to the package-qualified `our` mirror of the package the
+   running routine belongs to, wired into the read chokepoint
+   (`get_env_with_main_alias`), the container-mutation chokepoint
+   (`env_root_descended_mut`), and `:delete`'s own by-name dance
+   (`exec_delete_index_named_op`). A name the running frame declares as its
+   own local is never redirected, so lexical shadowing inside the module
+   still wins. Pinned by `t/our-container-bare-name-resolution.t` (28
+   assertions) with fixture `t/lib/UnitOurContainer.rakumod`. No store change
+   was needed, exactly as ADR-0039 §4.1 predicted.
+
+   The **scalar** twin (`our $x` written from a module routine landing on the
+   caller's `my $x`) is a different mechanism — a scalar has no shared node,
+   so it needs `SetGlobal`'s bare env store suppressed rather than resolution
+   redirected — and is tracked separately in
+   `todo/tickets/our-scalar-write-leaks-to-the-callers-lexical.md`.
 2. **Slice 2** (ADR-0039 §4.2): container free variables in ordinary inner
    blocks, closures, and any non-compunit-file-scope declaration still
    resolve by name at the compiler (`Expr::ArrayVar`/`Expr::HashVar` emit

--- a/todo/tickets/our-scalar-write-leaks-to-the-callers-lexical.md
+++ b/todo/tickets/our-scalar-write-leaks-to-the-callers-lexical.md
@@ -1,0 +1,87 @@
+# A module's `our $x` write lands on the caller's same-named `my $x`
+
+Found while fixing the `our @arr` / `our %h` half of
+`todo/deep/module-file-scope-array-and-hash-still-share-the-caller.md`
+(item 1). The container half is fixed; the **scalar** twin is not, and it is a
+different enough mechanism to deserve its own ticket rather than being folded
+into the container fix.
+
+## Repro
+
+```raku
+# t-lib/UFL4.rakumod
+unit module UFL4;
+our $s = 'S';
+sub s-set($v) is export { $s = $v }
+sub s-peek() is export { $s }
+```
+```raku
+use UFL4;
+my $s = 'mine';
+s-set('changed');
+say s-peek();     # raku: changed   mutsu: changed
+say $s;           # raku: mine      mutsu: changed   <-- WRONG
+say $UFL4::s;     # raku: changed   mutsu: changed
+```
+
+The pure-read direction is wrong too, and differently — it yields `Nil` rather
+than either the module's or the caller's value:
+
+```raku
+use UFL4;
+my $s = 'mine';
+say s-peek();     # raku: S         mutsu: Nil ("Use of Nil in string context")
+say $UFL4::s;     # raku: S         mutsu: S
+say $s;           # raku: mine      mutsu: mine
+```
+
+## Why the container fix does not cover it
+
+`our @arr` and `our $s` compile to different shapes:
+
+- `our @arr = <a b>` emits `Dup; SetLocalDecl(slot); SetGlobal("@UFL3::arr")`.
+  The container is one `Gc` node published under several names, and container
+  mutation is write-through-the-shared-node (ADR-0013 / ADR-0039 §2). So
+  redirecting *resolution* to the package-qualified mirror is sufficient: once
+  a read or write chokepoint resolves to the mirror's node, `push` /
+  element-assign / `:delete` land on the right container with no store change.
+  That is what `src/vm/vm_our_package_vars.rs` now does.
+- `our $s = 'S'` emits `DeclareOurScalar { slot, qualified_idx }`
+  (`src/compiler/stmt.rs`, gate `use_our_cell`), and a write inside a module
+  routine is a bare `SetGlobal("s")`. A scalar has no shared node: the write
+  must *replace* a value. `SetGlobal` already calls
+  `writeback_package_scope_var` (`src/vm/vm_env_helpers.rs`), which does update
+  `our_vars["UFL4::s"]` correctly — but it *also* writes the bare `env["s"]`
+  key unconditionally, and that key is the caller's `my $s`. So fixing the
+  scalar means **suppressing the bare env store** when the name resolves to an
+  `our` of the running routine's package, the way `unit_lexical_write`
+  suppresses it for ADR-0039 slice 1's compunit lexicals — a store/write-gating
+  change, not just a resolution preference.
+
+The read side needs matching work: `GetGlobal`'s cascade consults `our_vars`
+only when `name.contains("::")` (an explicit comment at
+`src/vm/vm_exec_dispatch.rs` says "Bare variable names should NOT fall back to
+our_vars"), so the bare `$s` read inside the module never reaches
+`our_vars["UFL4::s"]`. Whatever relaxes that has to keep the reason the
+restriction was added in the first place.
+
+## Affected files
+
+- `src/vm/vm_exec_dispatch.rs` — `GetGlobal` cascade (bare-name `our_vars`
+  exclusion) and the `SetGlobal` arm (unconditional bare env store).
+- `src/vm/vm_env_helpers.rs` — `writeback_package_scope_var`,
+  `package_qualified_candidate`.
+- `src/vm/vm_our_package_vars.rs` — the container-side resolution helper; its
+  `our_package_container_key` already builds the right key for a scalar too
+  (it is only gated to `@`/`%` because the scalar needs the write-gating above
+  before a redirect would be correct).
+
+## Why this is not trivial
+
+`SetGlobal` is the single hottest by-name write chokepoint in the VM and its
+bare env store is load-bearing for a great deal besides `our` (dynamic vars,
+plain globals, `$_`, package-qualified writes, the `:=`-rebind path). Gating it
+needs the same care ADR-0039 slice 1's `unit_lexical_write` gate needed, plus a
+matching relaxation of the deliberate bare-name `our_vars` read exclusion. Pin
+against `t/our-container-bare-name-resolution.t`'s shape (a `@`/`%` matrix that
+already passes) extended with the scalar rows.


### PR DESCRIPTION
A module that declares `our @arr` and mutates it from its own routines was mutating the **loading script's** same-named `my @arr` instead.

```raku
# UnitOurContainer.rakumod
unit module UnitOurContainer;
our @arr = <a b>;
sub arr-push($v) is export { @arr.push($v) }
sub arr-read()   is export { @arr.join(",") }
```
```raku
use UnitOurContainer;
my @arr = <x y z>;
arr-push("c");
say arr-read();       # raku: a,b,c    was: x,y,z,c    now: a,b,c
say @arr.join(",");   # raku: x,y,z    was: x,y,z,c    now: x,y,z
```

## Root cause

`our @arr` inside `unit module UFL3` publishes its container under the package-qualified mirror `@UFL3::arr` — the declaration compiles to `Dup; SetLocalDecl(slot); SetGlobal("@UFL3::arr")`, and the `SetGlobal` arm mirrors package-qualified writes into `our_vars`. **That store was always correct**; `@UFL3::arr` read back the right value throughout the bug's lifetime.

The module's own routines, though, reference the container by its **bare** name. A sub body compiles in a fresh `Compiler` whose `current_package` has been overwritten with the mangled state-scope name `UFL3::&arr-push/1` (`compiler/helpers_sub_body.rs`), and `qualify_variable_name` returns any name verbatim when the package contains `::&` — a guard that exists so `state`-variable scope names never leak into variable qualification. So `Expr::ArrayVar` emitted a bare `GetArrayVar("@arr")`, resolved against `env`, whose `@arr` key belongs to whatever scope loaded the module.

This is a **resolution** bug against an already-correct store, which is why ADR-0039 §4.1 excluded `our` from slice 1's `unit_lexicals` work: `our` variables are externally visible (`@UFL3::arr` must stay readable and writable from outside), so the qualified mirror — not a private per-compunit cell — is their canonical store.

## The fix

New `src/vm/vm_our_package_vars.rs` reconstructs the qualified key from the package the running routine belongs to and prefers the mirror. `our_package_container_key` mirrors `unit_lexical_slot`'s candidate order exactly (frame `lexical_package`, method class, frame package, `current_package`), each walked up its `::` chain, and reuses `package_qualified_candidate` so it applies precisely the twigil / positional-capture exclusions the compiler's `qualify_variable_name` does — reads and writes therefore reconstruct exactly the key the declaration stored.

Wired into three chokepoints:

- **`get_env_with_main_alias`** (`vm_env_helpers.rs`), the by-name read chokepoint, immediately after `unit_scope_lexical` — so a compunit's file-scope `my` still wins over a same-named package variable.
- **`env_root_descended_mut`** (`vm_var_assign_index_named.rs`), the container mutation chokepoint every element-assign / `push` / `pop` / key-set funnels through, immediately after `unit_lexical_slot_mut`.
- **`exec_delete_index_named_op`** (`vm_var_delete_ops.rs`), which resolves its container out of `env` by name rather than through `env_root_descended_mut` and so needed its own seed / run / write-back / restore dance — the same one ADR-0039 §6.1 records for the unit-lexical case. Its write-back goes through a new `our_mirror_store_preserving_identity`, which copies the mutated contents **into** the mirror's existing `Gc` node rather than swapping it, so the module mainline's own slot and the `env["%Pkg::h"]` entry are not orphaned on the first `:delete`.

Nothing else was needed on the write side: container mutation is write-through-the-shared-node (ADR-0013 / ADR-0039 §2), so once a chokepoint resolves to the mirror's node the mutation lands there by itself.

A container the **running frame declares itself** shadows the package variable, so a name present in the frame's own `CompiledCode::locals` is never redirected. That keeps this a resolution *preference* rather than a hijack in the opposite direction: `sub f { my @arr = <p q>; @arr.push("r") }` inside the very module that declares `our @arr` still uses its own lexical and leaves the package container untouched.

## Verification

New pin `t/our-container-bare-name-resolution.t` (28 assertions, **all verified against real `raku` first**) with fixture `t/lib/UnitOurContainer.rakumod`: read / `push` / element-read / element-assign / `pop` / nested-block push for `@`, and read / key-set / element-read / `:delete` for `%`, each paired with an assertion that the script's same-named container is untouched and one that the package-qualified mirror agrees — plus two lexical-shadowing rows.

Slice 1's pins (`t/module-file-scope-lexical.t`, `t/named-sub-lexical-scope-container.t`) and `t/anon-container-cell-inplace-reassign.t` stay green, as does the full local suite (3362 files, 31590 assertions) and a targeted 211-file `our`/`module`/`lexical`/`package`/`unit`/`closure-capture` subset.

## Scope

Closes **item 1** of `todo/deep/module-file-scope-array-and-hash-still-share-the-caller.md`; that file stays open for **slice 2** (ADR-0039 §4.2 — containers resolve by slot/upvalue at the compiler), which is untouched here.

The **scalar** twin found while investigating — a module's `our $x` write landing on the caller's `my $x` — is a genuinely different mechanism (a scalar has no shared node, so it needs `SetGlobal`'s bare env store *suppressed*, not just resolution redirected) and is recorded as `todo/tickets/our-scalar-write-leaks-to-the-callers-lexical.md` rather than folded in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)