### PR TITLE
fix: Whatever-priming stops at thunk barriers (ADR-0033 Phase 4)

### DIFF
--- a/docs/adr/0033-whatever-priming-leaf-and-derived-scope.md
+++ b/docs/adr/0033-whatever-priming-leaf-and-derived-scope.md
@@ -1,7 +1,10 @@
 # ADR-0033: Whatever-priming is a leaf property plus a derived scope — defer `WhateverCode` construction out of the parser
 
 - **Status**: Phase 1 shipped (2026-08-19). Phase 2 shipped (2026-08-20, see "Phase 2
-  outcome" below). Phases 3-4 not started.
+  outcome" below). **Phase 4 shipped (2026-08-23, see "Phase 4 outcome" below)** — the
+  thunk-barrier priming correctness fix, plus its chained-comparison prerequisite. Phase 3
+  (RakuAST write / `EVAL`) not started; it has no roast or correctness payoff of its own
+  and was deliberately left until after Phase 4.
 - **Scope**: Owns the `WhateverCode` item of
   [`todo/deep/rakuast-remaining.md`](../../todo/deep/rakuast-remaining.md) — both its
   read-direction half ("`* + 1` has no `.AST`") and its lowering half ("`EVAL` of a
@@ -531,6 +534,110 @@ plan except `[*]` (excluded with an inline comment: mutsu currently parses a sta
 `[*]` as the `[*]`-reduction metaoperator over an empty list — a pre-existing,
 Whatever-unrelated parse ambiguity with no `*` node in the tree to classify either way —
 while raku renders `Term::Whatever`; out of scope for this ADR).
+
+## Phase 4 outcome (2026-08-23)
+
+Shipped. Every row of the Problem-2 table at the top of this ADR now matches the system
+`raku`, re-measured on the day rather than trusted from the table, and pinned by a new
+**dual-oracle** `t/whatever-thunky-operators.t` (34 assertions, passing verbatim under
+both `target/debug/mutsu` and `raku`).
+
+### What actually changed — much less than section 4 anticipated
+
+The design in section 4 assumed Phase 4 had to "replace the ~50 parser sites with a single
+`plant` call". Measuring first showed that is not what the correctness fix requires, and
+that doing it would have been a large *behaviour-neutral* refactor bolted onto a
+behaviour-changing one. The rule decomposes into two halves, and the parser's existing
+sites fall into line on their own once the first half is in place:
+
+1. **A thunk barrier is opaque to the enclosing priming scope.** `contains_whatever`
+   (`src/parser/expr/whatever.rs`), `count_whatever` (`whatever_curry/build.rs`) and both
+   `replace_whatever_*` walkers (`whatever_curry/replace.rs`) stop dead at a barrier. This
+   is Rakudo's own model: a thunky op is never "whatever-ish", so it neither creates nor
+   enlarges a scope above it. Because every one of the ~50 parser planting sites is gated
+   on `should_wrap_whatevercode` → `contains_whatever`, **no site can any longer propose a
+   scope that spans a barrier** — the fifty-site rewrite turned out to be unnecessary for
+   the correctness goal, not merely deferrable.
+2. **Each barrier operand is a scope of its own.** The new `src/whatever_curry/plant.rs`
+   owns this — `is_thunk_barrier()` (the barrier set) and `plant_here()` (materialise an
+   `Expr::WhateverCurry` around each operand that primes, gated by the same
+   `should_wrap_whatevercode`). It is invoked from the head of `mark_expr`
+   (`whatever_curry/mark/expr.rs`), which section 2.3 already designated "deliberately the
+   seed of the `plant.rs` this ADR's section 4 calls for — same traversal, same
+   parent-context switch, one phase later it also decides where scopes begin". That
+   prediction held exactly: no second walk was needed.
+
+Half 1 is what makes the *residue* case fall out for free. `((* > 3 && * < 8) + *)` is a
+single arity-1 `WhateverCode` in rakudo (measured); with the barrier opaque, the enclosing
+`+` sees exactly one placeholder and the existing machinery curries it correctly, with no
+special case. Half 2 is a strict gain for the ternary, which mutsu previously primed *not
+at all*: all three parts are now scopes, so `(* + 1 ?? * + 2 !! * + 3)` is a
+`WhateverCode` instead of dying while coercing `Whatever` to `Numeric`.
+
+Because a barrier's operands are materialised *before* the enclosing closure body is
+built, `replace_whatever_*` must clone a barrier subtree through untouched rather than
+substituting `$_` / `__wc_N` into it — the inner markers are separate closures that the
+compiler expands on its own when it compiles the outer lambda's body.
+
+### The prerequisite: `TokenKind::ChainAnd`, not `Expr::ChainedCompare`
+
+The "Phase-4 prerequisite" section below is confirmed real, and the measurement that
+proves it also corrects section 2.6. That section states `(1 < * < 10).arity` "is 1 in
+both implementations"; it is not — rakudo prints `WhateverCode.new`, because `.arity` is
+itself inside the priming scope. The load-bearing measurement is instead the pair
+
+```text
+(1 < * < 10)(0)        False   # one arity-1 curry over the whole chain
+(1 < * && * < 10)(0)   True    # a real `&&` yields only its right-hand thunk
+```
+
+which shows a synthesized chain conjunction and a user-written `&&` must land on opposite
+sides of the barrier rule. The prerequisite section offers two resolutions; this PR takes
+a third, lighter one that satisfies the same requirement ("make the expansion
+distinguishable"): a dedicated `TokenKind::ChainAnd`, emitted by `chain_cmp.rs` and
+`comparison.rs` where they synthesize the conjunction, absent from `is_thunk_barrier`, and
+compiled exactly like `AndAnd`.
+
+`Expr::ChainedCompare { operands, ops }` was costed and rejected *for this PR*. A new
+`Expr` variant needs an arm in every walker that must see through it — Phase 1's own
+Outcome records 41 files needing a `WhateverCurry` arm — and the failure mode is silent:
+a walker with a `_ => {}` catch-all (placeholder collection, sink warnings, closure
+free-variable analysis) would simply stop seeing the chain's operands. `ChainAnd` keeps
+the `Expr::Binary` shape every existing walker already handles, so its audit is the
+bounded set of 20 `TokenKind::AndAnd` sites, all inspected. The node form remains worth
+doing for its *other* benefit — rendering `1 < * < 10` faithfully in RakuAST instead of as
+the expanded `&&` — and is tracked as
+[`todo/tickets/chained-compare-ast-node.md`](../../todo/tickets/chained-compare-ast-node.md).
+
+A bonus correctness fix came with it: the `count_whatever` / `replace_whatever_numbered`
+de-duplication special case, which used to fire on *any* `AndAnd` whose two operands
+shared a structurally-equal middle, now fires only on `ChainAnd`. That heuristic was
+mis-firing on a user-written `1 < * && * < 10`, which mutsu curried into one arity-1
+closure (`(0)` → `False`); it now correctly yields the right-hand thunk (`(0)` → `True`,
+matching rakudo).
+
+### `xor` and `^^` re-measured, as the Risks section demanded
+
+Both are non-short-circuit and rakudo primes neither: `(* + 1 xor * + 2).WHAT` and
+`(* + 1 ^^ * + 2).WHAT` are each `Nil` plus a `Useless use of "+" in expression "* + 2" in
+sink context` warning. No barrier treatment reproduces that (splitting would yield a
+`Bool`, not `Nil`), so both stay off the barrier list and mutsu keeps returning
+`(WhateverCode)` — a documented divergence rather than a guess. This resolves the "`xor`
+is unresolved" risk: excluded, deliberately, with `^^` alongside it.
+
+### Divergences left standing (all pre-existing, none touched by this phase)
+
+`(1 xx *).WHAT` is `Array` vs rakudo's `Seq`; `((* - 1) o (* * 2)).WHAT` is `Sub` vs
+`Block+{...}`; `(*(1))` curries in mutsu where rakudo dies with "No such method 'CALL-ME'
+for invocant of type 'Whatever'". None involve a thunk barrier.
+
+### Validation
+
+`prove t/` in full (3361 files, 31562 assertions) green; `cargo test --workspace` (868
+unit tests plus every integration binary) green; `cargo clippy -- -D warnings` clean; the
+whitelisted `roast/S02-*`, `roast/S03-*` and `roast/S04-*` sweep (345 files) green, with
+`roast/S02-types/{whatever,hyperwhatever}.t`, `roast/S03-operators/composition.t`,
+`short-circuit.t` and `ternary.t` checked individually first.
 
 ## Phase 2 detailed design (added 2026-08-20)
 

--- a/news/2026-08/whatever-priming-stops-at-thunk-barriers.md
+++ b/news/2026-08/whatever-priming-stops-at-thunk-barriers.md
@@ -1,0 +1,74 @@
+# Whatever-priming now stops at thunk barriers (ADR-0033 Phase 4)
+
+`(1..10).grep(* > 3 && * < 8)` returned `5 6`. Rakudo returns `1 2 3 4 5 6 7`. No error,
+no warning — just a quietly wrong list, in one of the most idiomatic shapes in Raku.
+
+The cause was mutsu priming `*` straight *through* the thunky operators. Raku compiles
+the operands of `&&`, `||`, `//`, `and`, `or`, `andthen`, `orelse`, `notandthen` and each
+of the ternary's three parts as **thunks**, and Whatever-priming happens per thunk. So
+`* > 3 && * < 8` is two independent arity-1 `WhateverCode`s; the `&&` then runs at its own
+evaluation time, sees a truthy `Code` object on the left, and yields the right-hand
+`WhateverCode`. mutsu instead built one arity-2 closure, so `grep` fed it pairs. The
+ternary was the same bug from the other side: `Expr::Ternary` appeared in none of the
+priming predicates, so mutsu primed *nothing* there and a bare `Whatever` survived to the
+runtime, dying while coercing to `Numeric`.
+
+Every row of the divergence table in
+[ADR-0033](../../docs/adr/0033-whatever-priming-leaf-and-derived-scope.md) now matches the
+system `raku`, and the new `t/whatever-thunky-operators.t` is dual-oracle: its 34
+assertions pass verbatim under both mutsu and `raku`.
+
+## The rule has two halves, and the second one is small
+
+Section 4 of the ADR assumed this phase had to replace the parser's ~50 priming-scope
+sites with one call. Measuring first showed otherwise. The fix decomposes as:
+
+1. **A thunk barrier is opaque to the enclosing scope.** `contains_whatever`,
+   `count_whatever` and both `replace_whatever_*` walkers stop dead at one — Rakudo's own
+   model, in which a thunky op is never "whatever-ish". Every parser planting site is
+   gated on `contains_whatever`, so *no site can any longer propose a scope that spans a
+   barrier*. The fifty-site rewrite turned out to be unnecessary for the correctness goal
+   rather than merely deferrable.
+2. **Each barrier operand is a scope of its own.** The new `src/whatever_curry/plant.rs`
+   owns exactly this, and it hooks into the walk `mark.rs` already performs — which the
+   ADR's section 2.3 had predicted would happen ("deliberately the seed of the `plant.rs`
+   section 4 calls for — same traversal, same parent-context switch").
+
+Half 1 is why the awkward residue case needed no special case at all:
+`((* > 3 && * < 8) + *)` is a single arity-1 `WhateverCode` in rakudo, and with the
+barrier opaque the enclosing `+` simply sees one placeholder.
+
+## The prerequisite, and a bug it flushed out
+
+Making `&&` a barrier first required separating it from the `&&` the parser *synthesizes*
+when it expands a chained comparison (`a < m < b` → `(a < m) && (m < b)`, middle
+duplicated). The two must land on opposite sides of the rule:
+
+```
+(1 < * < 10)(0)        False   # one arity-1 curry over the whole chain
+(1 < * && * < 10)(0)   True    # a real && yields only its right-hand thunk
+```
+
+A dedicated `TokenKind::ChainAnd` does that, keeping the `Expr::Binary` shape so no
+expression walker needed changing (the ADR's alternative, a full `Expr::ChainedCompare`
+node, needs an arm in every walker and fails *silently* where one has a catch-all; it is
+worth doing for RakuAST rendering fidelity and is now filed as
+`todo/tickets/chained-compare-ast-node.md`).
+
+Separating them also fixed a real bug. The middle-duplication de-duplication in
+`count_whatever` had to guess, by structural comparison, whether an `&&` came from a chain
+— and it guessed wrong on a user-written `1 < * && * < 10`, collapsing it into one
+arity-1 closure. With the synthesized conjunction now labelled, the heuristic fires only
+where it belongs and that expression yields its right-hand thunk, as rakudo does.
+
+## `xor` and `^^`
+
+The ADR flagged `xor` as unresolved and asked for a measurement rather than a guess.
+Rakudo primes neither `xor` nor `^^`: both `(* + 1 xor * + 2).WHAT` and
+`(* + 1 ^^ * + 2).WHAT` are `Nil` with a "Useless use of `+` in sink context" warning.
+Since neither barrier nor non-barrier treatment reproduces that, both stay off the barrier
+list and mutsu keeps returning `(WhateverCode)` — recorded as a known divergence instead
+of being guessed at.
+
+Validated with the full `t/` suite (3361 files, 31562 assertions), `cargo test
+--workspace`, and the whitelisted `roast/S02-*`/`S03-*`/`S04-*` sweep, all green.

--- a/src/compiler/expr_binary.rs
+++ b/src/compiler/expr_binary.rs
@@ -356,7 +356,7 @@ impl Compiler {
         }
         // Short-circuit operators
         match op {
-            TokenKind::AndAnd | TokenKind::AndWord => {
+            TokenKind::AndAnd | TokenKind::AndWord | TokenKind::ChainAnd => {
                 self.compile_expr(left);
                 self.code.emit(OpCode::Dup);
                 let jump_end = self.code.emit(OpCode::JumpIfFalse(0));

--- a/src/compiler/helpers_ops.rs
+++ b/src/compiler/helpers_ops.rs
@@ -23,7 +23,7 @@ pub(crate) fn token_kind_to_op_name(op: &TokenKind) -> String {
         TokenKind::Lte => "<=".to_string(),
         TokenKind::Gt => ">".to_string(),
         TokenKind::Gte => ">=".to_string(),
-        TokenKind::AndAnd => "&&".to_string(),
+        TokenKind::AndAnd | TokenKind::ChainAnd => "&&".to_string(),
         TokenKind::OrOr => "||".to_string(),
         TokenKind::XorXor => "^^".to_string(),
         TokenKind::SmartMatch => "~~".to_string(),

--- a/src/parser/expr/precedence/chain_cmp.rs
+++ b/src/parser/expr/precedence/chain_cmp.rs
@@ -48,7 +48,7 @@ pub(crate) fn build_chain_cmp_expr(
             },
             Stmt::Expr(Expr::Binary {
                 left: Box::new(cmp),
-                op: TokenKind::AndAnd,
+                op: TokenKind::ChainAnd,
                 right: Box::new(rest),
             }),
         ],
@@ -72,7 +72,7 @@ pub(crate) fn build_chain_cmp_expr_with_repeated_middle(
         let next_cmp = make_chain_cmp(prev_right, op.clone(), next_right.clone(), *negated);
         result = Expr::Binary {
             left: Box::new(result),
-            op: TokenKind::AndAnd,
+            op: TokenKind::ChainAnd,
             right: Box::new(next_cmp),
         };
         prev_right = next_right;

--- a/src/parser/expr/precedence/comparison.rs
+++ b/src/parser/expr/precedence/comparison.rs
@@ -201,7 +201,7 @@ pub(crate) fn comparison_expr_mode(input: &str, mode: ExprMode) -> PResult<'_, E
                 };
                 result = Expr::Binary {
                     left: Box::new(result),
-                    op: TokenKind::AndAnd,
+                    op: TokenKind::ChainAnd,
                     right: Box::new(next_cmp),
                 };
                 prev_right = next_right;
@@ -228,7 +228,7 @@ pub(crate) fn comparison_expr_mode(input: &str, mode: ExprMode) -> PResult<'_, E
                 };
                 result = Expr::Binary {
                     left: Box::new(result),
-                    op: TokenKind::AndAnd,
+                    op: TokenKind::ChainAnd,
                     right: Box::new(next_cmp),
                 };
                 prev_right = next_right;

--- a/src/parser/expr/whatever.rs
+++ b/src/parser/expr/whatever.rs
@@ -160,6 +160,15 @@ fn is_wrapped_whatevercode(expr: &Expr) -> bool {
 pub(crate) fn contains_whatever(expr: &Expr) -> bool {
     match expr {
         e if is_whatever(e) => true,
+        // Thunk barriers (`&&`, `||`, `//`, `and`, `or`, `andthen`, `orelse`,
+        // `notandthen`, and the ternary) are **opaque** to the enclosing
+        // priming scope: each operand is a thunk, hence a priming scope of its
+        // own, planted by `crate::whatever_curry::plant`. A `*` below a barrier
+        // therefore neither creates nor enlarges any scope above it — which is
+        // exactly why `(* > 3 && * < 8)` is two arity-1 `WhateverCode`s (rakudo:
+        // `.arity` 1, `(5)` True) rather than one arity-2 closure, and why
+        // `((* > 3 && * < 8) + *)` is a single arity-1 closure. ADR-0033 Phase 4.
+        e if crate::whatever_curry::is_thunk_barrier(e) => false,
         // Don't treat bare * inside range/sequence operators as WhateverCode.
         // `1..*` is a Range, but `1..*-1` is a WhateverCode.
         // If an endpoint contains a non-bare Whatever (e.g. `*-1`), the whole

--- a/src/token_kind.rs
+++ b/src/token_kind.rs
@@ -128,6 +128,16 @@ pub(crate) enum TokenKind {
     Gt,
     Gte,
     AndAnd,
+    /// The conjunction the parser *synthesizes* when it expands a chained
+    /// comparison (`a < m < b` => `(a < m) && (m < b)`). Runtime semantics are
+    /// identical to `AndAnd`, but it must stay distinguishable from a
+    /// user-written `&&`: ADR-0033 Phase 4 makes `&&` a Whatever-priming thunk
+    /// barrier, and a synthesized chain conjunction is *not* one — the whole
+    /// chain is a single priming scope (`(1 < * < 10)(0)` is `False`, one
+    /// arity-1 `WhateverCode`, where the user-written `(1 < * && * < 10)(0)` is
+    /// `True` because `&&` returns its right-hand `WhateverCode`). Both
+    /// measured against rakudo.
+    ChainAnd,
     OrOr,
     XorXor, // ^^
     OrWord,

--- a/src/whatever_curry/build.rs
+++ b/src/whatever_curry/build.rs
@@ -112,9 +112,17 @@ pub(crate) fn count_whatever(expr: &Expr) -> usize {
         // dedup below, so recursing here yields exactly the arity
         // `build_closure` would give it if built standalone.
         Expr::WhateverCurry(inner) => count_whatever(inner),
+        // A thunk barrier is opaque to the enclosing priming scope: its operands
+        // are scopes of their own (already materialised as `WhateverCurry`
+        // markers by `super::plant`), so they contribute no placeholder to the
+        // arity of whatever encloses them. ADR-0033 Phase 4.
+        e if super::plant::is_thunk_barrier(e) => 0,
+        // `ChainAnd` is the parser's *synthesized* chained-comparison
+        // conjunction, not a user-written `&&` — it is deliberately not a thunk
+        // barrier, and its middle operand is duplicated by the expansion.
         Expr::Binary {
             left,
-            op: TokenKind::AndAnd,
+            op: TokenKind::ChainAnd,
             right,
         } => {
             if let (

--- a/src/whatever_curry/mark/expr.rs
+++ b/src/whatever_curry/mark/expr.rs
@@ -24,6 +24,12 @@ fn is_noncurrying_pseudo_method(name: &str) -> bool {
 }
 
 pub(super) fn mark_expr(expr: &mut Expr) {
+    // ADR-0033 Phase 4: this same top-down walk is also the priming-*scope*
+    // authority. At a thunk barrier (or a ternary) each operand is its own
+    // scope, so plant a `WhateverCurry` marker around it *before* recursing —
+    // the recursion below then classifies the leaves inside the new marker
+    // exactly as it would have classified them in place.
+    crate::whatever_curry::plant_here(expr);
     match expr {
         Expr::Whatever => *expr = Expr::WhateverArg,
         // Already classified (re-running mark_expr should never happen in

--- a/src/whatever_curry/mod.rs
+++ b/src/whatever_curry/mod.rs
@@ -26,6 +26,8 @@
 
 mod build;
 pub(crate) mod mark;
+mod plant;
 mod replace;
 
 pub(crate) use build::{build_closure, make_wc_param};
+pub(crate) use plant::{is_thunk_barrier, plant_here};

--- a/src/whatever_curry/plant.rs
+++ b/src/whatever_curry/plant.rs
@@ -1,0 +1,135 @@
+//! The Whatever-priming **scope authority** (ADR-0033 section 4, Phase 4).
+//!
+//! Raku's priming scope does not run through a *thunky* operator. `&&`, `||`,
+//! `//`, `and`, `or`, `andthen`, `orelse`, `notandthen` and the ternary's three
+//! parts compile their operands as thunks, and Whatever-priming happens **per
+//! thunk**: `* > 3 && * < 8` is *two* independent arity-1 `WhateverCode`s, and
+//! the `&&` then runs at its own evaluation time, sees a truthy `Code` object on
+//! the left and yields the right-hand `WhateverCode`. Measured against rakudo:
+//!
+//! ```text
+//! (* > 3 && * < 8).arity          1
+//! (* > 3 && * < 8)(5)             True
+//! (1..10).grep(* > 3 && * < 8)    (1 2 3 4 5 6 7)
+//! (* + 1 && 5).WHAT               (Int)
+//! (* // 5)(Nil)                   No such method 'CALL-ME' for ... 'Whatever'
+//! (* + 1 ?? * + 2 !! * + 3).WHAT  (WhateverCode)
+//! ```
+//!
+//! mutsu used to prime straight *through* those operators, producing a single
+//! arity-2 closure (`(1..10).grep(* > 3 && * < 8)` silently returned `5 6`), and
+//! primed *nothing at all* inside a ternary (a bare `Expr::Whatever` survived to
+//! the runtime and died coercing to `Numeric`). One rule fixes both directions.
+//!
+//! # The rule, in two halves
+//!
+//! 1. **A thunk barrier is opaque to the enclosing scope.** `contains_whatever`
+//!    (`crate::parser::expr::whatever`), [`super::build::count_whatever`] and
+//!    [`super::replace`] all stop at a barrier, so a `*` inside one contributes
+//!    nothing to the arity — or even the existence — of any scope above it.
+//!    That is what makes `((* > 3 && * < 8) + *)` a *single* arity-1
+//!    `WhateverCode` (measured) rather than an arity-3 one, and what stops the
+//!    parser's existing planting sites from ever proposing a scope that spans a
+//!    barrier.
+//! 2. **Each barrier operand is a scope of its own.** [`plant_here`] runs on
+//!    every expression node of a freshly-parsed program and, at a barrier or a
+//!    ternary, materialises an `Expr::WhateverCurry` marker around each operand
+//!    that primes. For the ternary this is a strict *gain*: mutsu planted no
+//!    scope there at all before.
+//!
+//! # Why the synthesized chain conjunction is excluded
+//!
+//! `src/parser/expr/precedence/chain_cmp.rs` expands `a < m < b` into
+//! `(a < m) && (m < b)` with the middle operand duplicated. That `&&` is a
+//! compiler artefact, not a user-written thunk barrier, and treating it as one
+//! would break chained comparison outright: rakudo makes the whole chain a
+//! single priming scope (`(1 < * < 10)(0)` is `False`) while a genuine
+//! user-written `&&` yields its right operand (`(1 < * && * < 10)(0)` is
+//! `True`). ADR-0033's "Phase-4 prerequisite" section calls for making the
+//! expansion distinguishable; mutsu does that with a dedicated
+//! [`TokenKind::ChainAnd`], which is deliberately absent from
+//! [`is_thunk_barrier`]. (Giving the expansion a whole `Expr::ChainedCompare`
+//! node — the ADR's other suggestion, which would additionally let RakuAST
+//! render `1 < * < 10` faithfully — is tracked separately; it needs an arm in
+//! every `Expr` walker, whereas the token keeps the `Expr::Binary` shape every
+//! existing walker already handles.)
+//!
+//! # Not barriers
+//!
+//! `xor` and `^^` are **not** short-circuit, and rakudo primes neither: both
+//! `(* + 1 xor * + 2).WHAT` and `(* + 1 ^^ * + 2).WHAT` are `Nil` with a
+//! "Useless use of ... in sink context" warning — neither a `WhateverCode` nor
+//! a plain `Bool`, so no barrier treatment reproduces them. ADR-0033
+//! deliberately excludes `xor`; the same measurement puts `^^` alongside it.
+//! mutsu keeps currying through both (`(WhateverCode)`), a documented
+//! divergence rather than a guess.
+
+use crate::ast::Expr;
+use crate::parser::should_wrap_whatevercode;
+use crate::token_kind::TokenKind;
+
+/// True for an expression whose operands are *thunks*, and therefore each a
+/// Whatever-priming scope of their own rather than part of the enclosing one.
+///
+/// Note `TokenKind::ChainAnd` is absent on purpose — see the module docs.
+pub(crate) fn is_thunk_barrier(expr: &Expr) -> bool {
+    match expr {
+        Expr::Ternary { .. } => true,
+        Expr::Binary { op, .. } => matches!(
+            op,
+            TokenKind::AndAnd
+                | TokenKind::OrOr
+                | TokenKind::SlashSlash
+                | TokenKind::AndWord
+                | TokenKind::OrWord
+                | TokenKind::AndThen
+                | TokenKind::OrElse
+                | TokenKind::NotAndThen
+        ),
+        _ => false,
+    }
+}
+
+/// Materialise `slot` as its own priming scope if it primes.
+///
+/// A bare `*` deliberately does not wrap (`should_wrap_whatevercode` excludes
+/// it), which is what makes `(* // 5)` yield the `Whatever` *value* — rakudo
+/// then dies with "No such method 'CALL-ME'" when it is invoked, exactly as
+/// mutsu now does. An operand the parser already planted is likewise left
+/// alone: `contains_whatever` does not see through a `WhateverCurry` marker, so
+/// `((* > 3) && (* < 8))` is not double-wrapped.
+fn materialise_scope(slot: &mut Expr) {
+    if should_wrap_whatevercode(slot) {
+        let body = std::mem::replace(slot, Expr::Whatever);
+        *slot = Expr::WhateverCurry(Box::new(body));
+    }
+}
+
+/// The scope authority, applied to one expression node.
+///
+/// Invoked from [`super::mark`]'s post-parse walk (which already visits every
+/// `Expr` in the program exactly once, top-down) *before* that walk recurses
+/// into the node's children, so the recursion sees — and classifies the leaves
+/// of — whatever markers this planted.
+pub(crate) fn plant_here(expr: &mut Expr) {
+    if !is_thunk_barrier(expr) {
+        return;
+    }
+    match expr {
+        Expr::Ternary {
+            cond,
+            then_expr,
+            else_expr,
+        } => {
+            materialise_scope(cond);
+            materialise_scope(then_expr);
+            materialise_scope(else_expr);
+        }
+        Expr::Binary { left, right, .. } => {
+            materialise_scope(left);
+            materialise_scope(right);
+        }
+        // `is_thunk_barrier` matches only the two shapes above.
+        _ => {}
+    }
+}

--- a/src/whatever_curry/replace.rs
+++ b/src/whatever_curry/replace.rs
@@ -24,9 +24,17 @@ pub(crate) fn replace_whatever_numbered(expr: &Expr, counter: &mut usize) -> Exp
             Expr::Var(var_name)
         }
         Expr::WhateverCurry(inner) => replace_whatever_numbered(inner, counter),
+        // A thunk barrier is opaque: each of its operands is its own priming
+        // scope (already wrapped in a `WhateverCurry` by `super::plant`, which
+        // the compiler expands into its own closure), so no placeholder inside
+        // it belongs to the enclosing closure's parameter list. Clone it
+        // through untouched. ADR-0033 Phase 4.
+        e if super::plant::is_thunk_barrier(e) => e.clone(),
+        // `ChainAnd`: the parser's synthesized chained-comparison conjunction,
+        // whose middle operand is duplicated by the expansion.
         Expr::Binary {
             left,
-            op: TokenKind::AndAnd,
+            op: TokenKind::ChainAnd,
             right,
         } => {
             if let (
@@ -57,7 +65,7 @@ pub(crate) fn replace_whatever_numbered(expr: &Expr, counter: &mut usize) -> Exp
                         op: lop.clone(),
                         right: Box::new(new_mid.clone()),
                     }),
-                    op: TokenKind::AndAnd,
+                    op: TokenKind::ChainAnd,
                     right: Box::new(Expr::Binary {
                         left: Box::new(new_mid),
                         op: rop.clone(),
@@ -67,7 +75,7 @@ pub(crate) fn replace_whatever_numbered(expr: &Expr, counter: &mut usize) -> Exp
             }
             Expr::Binary {
                 left: Box::new(replace_whatever_numbered(left, counter)),
-                op: TokenKind::AndAnd,
+                op: TokenKind::ChainAnd,
                 right: Box::new(replace_whatever_numbered(right, counter)),
             }
         }
@@ -203,6 +211,10 @@ pub(crate) fn replace_whatever_single(expr: &Expr) -> Expr {
     match expr {
         e if is_whatever(e) => Expr::Var("_".to_string()),
         Expr::WhateverCurry(inner) => replace_whatever_single(inner),
+        // See the matching arm in `replace_whatever_numbered`: a thunk barrier's
+        // operands are separate priming scopes and must not be substituted into
+        // the enclosing closure's body. ADR-0033 Phase 4.
+        e if super::plant::is_thunk_barrier(e) => e.clone(),
         // SmartMatch/BangTilde: see the matching arm in
         // `replace_whatever_numbered` above.
         Expr::Binary {

--- a/t/whatever-thunky-operators.t
+++ b/t/whatever-thunky-operators.t
@@ -1,0 +1,92 @@
+use Test;
+
+# ADR-0033 Phase 4: Whatever-priming does not run through a *thunky* operator.
+#
+# `&&`, `||`, `//`, `and`, `or`, `andthen`, `orelse`, `notandthen` and the
+# ternary's three parts compile their operands as thunks, and priming happens
+# per thunk. So `* > 3 && * < 8` is TWO independent arity-1 WhateverCodes; the
+# `&&` runs at its own evaluation time, sees a truthy Code object on the left,
+# and yields the right-hand WhateverCode.
+#
+# Every expectation below was measured against rakudo before being written
+# here. mutsu used to prime straight through these operators (producing one
+# arity-2 closure) and to prime nothing at all inside a ternary.
+
+plan 34;
+
+# --- the headline correctness bug -------------------------------------------
+
+is (* > 3 && * < 8).arity, 1, '&& does not merge two curries into arity 2';
+is (* > 3 && * < 8)(5), True, 'the yielded right-hand curry takes one argument';
+is (* > 3 && * < 8)(9), False, '... and evaluates only that thunk';
+is (1..10).grep(* > 3 && * < 8).join(' '), '1 2 3 4 5 6 7',
+        'grep(* > 3 && * < 8) greps on the right-hand thunk alone';
+is (* > 3 && * < 8).WHAT.^name, 'WhateverCode', '&& of two curries is still a WhateverCode';
+
+# Parenthesised operands are already materialised scopes; do not double-wrap.
+is ((* > 3) && (* < 8)).arity, 1, 'explicitly parenthesised operands behave the same';
+
+# Left-nested chain of barriers.
+is (* > 3 && * < 8 && * != 5)(5), False, 'a chain of && yields the last thunk (false case)';
+is (* > 3 && * < 8 && * != 5)(6), True, 'a chain of && yields the last thunk (true case)';
+
+is (*.defined && *.Str)(7), '7', 'method-call curries either side of && are independent';
+
+# --- the barrier is opaque to the enclosing scope ---------------------------
+
+# `&&` contributes nothing to any scope above it, so the `+` below sees exactly
+# one placeholder and curries to arity 1 (rakudo: `(WhateverCode)`).
+is ((* > 3 && * < 8) + *).WHAT.^name, 'WhateverCode',
+        'a barrier contributes no placeholder to the enclosing curry';
+# (No `.arity` probe here: `.arity` is itself *inside* the priming scope, so
+# `((...) + *).arity` is a larger WhateverCode in both implementations rather
+# than a number -- see ADR-0033's Risks section on `.arity` composition. The
+# barrier ends the scope in `(* > 3 && * < 8).arity` above, which is why that
+# one does read back as 1.)
+
+# --- the other short-circuit operators --------------------------------------
+
+is (* + 1 && 5).WHAT.^name, 'Int', '&& with a plain right operand yields that operand';
+is (* + 1 and * + 2).arity, 1, '`and` is a barrier too';
+is (* + 1 orelse * + 2).arity, 1, '`orelse` is a barrier';
+is (* > 3 orelse * < 8).arity, 1, '`orelse` yields the defined left curry';
+is (* > 3 // * < 8).arity, 1, '`//` is a barrier';
+is (1 < 2 && * > 3).arity, 1, 'a non-Whatever left operand still yields the right curry';
+is (1..10).grep(* %% 2 || * > 7).join(' '), '2 4 6 8 10',
+        '|| yields its truthy left curry';
+is (1..10).grep(* > 3 || * > 8).join(' '), '4 5 6 7 8 9 10',
+        '... measured on a second || shape';
+is (* eq "a" or * eq "b")("b"), False, '`or` yields its truthy LEFT operand';
+
+# A *bare* `*` is a Whatever value, not a curry, so a barrier just returns it.
+is (* || 5).WHAT.^name, 'Whatever', 'a bare * operand of || stays a Whatever value';
+is (* andthen 5).WHAT.^name, 'Int', 'a bare * is defined, so `andthen` yields the right side';
+dies-ok { (* // 5)(Nil) }, 'invoking the Whatever that `//` yielded dies (no CALL-ME)';
+
+# --- the ternary: mutsu used to prime nothing at all here -------------------
+
+is (* + 1 ?? * + 2 !! * + 3).WHAT.^name, 'WhateverCode',
+        'each ternary part is its own priming scope';
+is (* + 1 ?? * + 2 !! * + 3)(10), 12, '... and the chosen branch is an arity-1 curry';
+is (* + 1 ?? 2 !! 3).WHAT.^name, 'Int', 'a curried condition is truthy, yielding the then-branch';
+is (1 ?? * + 2 !! * + 3).WHAT.^name, 'WhateverCode', 'a plain condition selects a curried branch';
+is (1 ?? * + 2 !! * + 3)(5), 7, '... which is callable';
+is (0 ?? * + 2 !! * + 3)(5), 8, '... and the else-branch likewise';
+is (* ?? 1 !! 2).WHAT.^name, 'Int', 'a bare * condition is a truthy Whatever value';
+
+# --- chained comparison must NOT be split (the Phase-4 prerequisite) --------
+#
+# `a < m < b` is expanded by the parser into `(a < m) && (m < b)` with the
+# middle duplicated. That synthesized conjunction is a distinct operator
+# (`TokenKind::ChainAnd`), NOT a thunk barrier: rakudo keeps the whole chain as
+# a single priming scope. Contrast the user-written `&&` immediately below --
+# the two must not collapse into each other.
+
+is (0 <= * <= 5)(3), True, 'a chained comparison is ONE arity-1 curry (inside)';
+is (0 <= * <= 5)(9), False, '... and both ends are checked (outside)';
+is (1 < * < 10)(0), False, 'a chained comparison checks its left end too';
+is (1 < * && * < 10)(0), True,
+        'a user-written && with the same operands yields only its right thunk';
+
+# Placeholder parameters must keep working through the same expansion.
+is { $^a < $^b < $^c }(1, 2, 3), True, 'a chained comparison over placeholders still works';

--- a/todo/deep/rakuast-remaining.md
+++ b/todo/deep/rakuast-remaining.md
@@ -107,10 +107,9 @@ an explicit design:
 - `constant`
 - associative subscripts
 - `CATCH` blocks
-- WhateverCode such as `* + 1` — **Phase 1 (deferral) and Phase 2 (RakuAST read / the
-  leaf split) shipped: `Q[* + 1].AST` works now. Phase 4 (the thunk-barrier priming
-  correctness fix — the highest-payoff remaining slice, see below) is next; Phase 3
-  (RakuAST write / `EVAL`) not started — see
+- WhateverCode such as `* + 1` — **Phases 1, 2 and 4 shipped: `Q[* + 1].AST` works, and
+  priming now stops at thunk barriers. Only Phase 3 (RakuAST write / `EVAL`) is left, and
+  it has no roast or correctness payoff of its own — see
   [ADR-0033](../../docs/adr/0033-whatever-priming-leaf-and-derived-scope.md)**
 - code-block interpolation
 - regexes
@@ -119,7 +118,7 @@ Pick these deliberately by user impact rather than treating them as another
 cadence of mechanical slices. Lower through the existing internal AST and
 compiler; do not add a second execution engine.
 
-### Phases 1-2 shipped, Phase 4 is the next highest-payoff slice: WhateverCode (ADR-0033)
+### Phases 1, 2 and 4 shipped; only Phase 3 remains: WhateverCode (ADR-0033)
 
 `* + 1` was picked first because it is the highest-frequency construct on the list
 (`.map(* + 1)`, `.grep(* > 3)`, `@a[* - 1]`) and because investigating it surfaced a
@@ -154,18 +153,25 @@ including two adjacent RakuAST operator-name rendering bugs (`!~~`, `=>`) it fix
 the way and one latent runtime bug it fixed as a side effect (`$_ ~~ *` previously
 shadowed the caller's topic instead of reading it dynamically).
 
-**Phase 4 (the thunk-barrier priming correctness fix) is now the highest-payoff remaining
-slice** — it is a genuine, user-visible correctness bug independent of RakuAST
-(`(1..10).grep(* > 3 && * < 8)` silently returns the wrong list, `5 6` instead of raku's
-`1 2 3 4 5 6 7`), not merely a `.AST` gap, and Phase 2's leaf split is its prerequisite
-(the ADR's `plant()` scope authority needs to read the classified leaves). See the ADR's
-"Phasing" section for the exact scope (thunk barriers: `&&`/`||`/`//`/`and`/`or`/
-`andthen`/`orelse`/`notandthen`/ternary) and its "Phase-4 prerequisite" section (the
-chained-comparison `&&`-duplication trap that must be resolved first, e.g. via a new
-`Expr::ChainedCompare` node). Phase 3 (RakuAST write / `EVAL` of a hand-constructed
-`WhateverCode::Argument` tree) remains designed only at the ADR's outline level and has
-no roast/correctness payoff of its own (RakuAST has zero roast dependents, ADR-0011
-ANALYSIS §7-9) — pick it up after Phase 4, not before.
+Phase 4 — the thunk-barrier priming correctness fix — shipped 2026-08-23. It was a
+genuine, user-visible correctness bug independent of RakuAST: `(1..10).grep(* > 3 && * < 8)`
+silently returned `5 6` instead of raku's `1 2 3 4 5 6 7`, because mutsu primed straight
+through the thunky operators and built one arity-2 closure where raku builds two
+independent arity-1 ones; a ternary primed nothing at all. `src/whatever_curry/plant.rs`
+now owns the barrier rule (`&&`/`||`/`//`/`and`/`or`/`andthen`/`orelse`/`notandthen`/
+ternary), and the barrier is *opaque* to the enclosing scope, which is what let the ~50
+parser planting sites fall into line without being rewritten. The ADR's "Phase-4
+prerequisite" (the chained-comparison `&&`-duplication trap) was resolved with a dedicated
+`TokenKind::ChainAnd` rather than the heavier `Expr::ChainedCompare` node — that node is
+still worth having for RakuAST rendering fidelity and is filed as
+[`todo/tickets/chained-compare-ast-node.md`](../tickets/chained-compare-ast-node.md). See
+the ADR's "Phase 4 outcome" section for the full account, including the `xor` / `^^`
+re-measurement and a latent de-duplication bug the prerequisite flushed out.
+
+**Phase 3 (RakuAST write / `EVAL` of a hand-constructed `WhateverCode::Argument` tree) is
+the only part of ADR-0033 still open.** It remains designed only at the ADR's outline
+level and has no roast/correctness payoff of its own (RakuAST has zero roast dependents,
+ADR-0011 ANALYSIS §7-9), so it is a low-priority pick relative to the rest of this file.
 
 The remaining items on both lists above are still undesigned.
 

--- a/todo/tickets/chained-compare-ast-node.md
+++ b/todo/tickets/chained-compare-ast-node.md
@@ -1,0 +1,64 @@
+# Chained comparison has no AST node, so RakuAST renders the expanded `&&` / `DoBlock`
+
+mutsu's parser expands a chained comparison at parse time instead of representing it.
+`src/parser/expr/precedence/chain_cmp.rs` has two expansions:
+
+- **pure middle** — `build_chain_cmp_expr_with_repeated_middle` rewrites `a < m < b` into
+  `(a < m) && (m < b)`, *duplicating* `m`;
+- **effectful middle** — `build_chain_cmp_expr` emits an `Expr::DoBlock` that binds a
+  `__mutsu_chain_cmp_N` temporary and then conjoins.
+
+`src/parser/expr/precedence/comparison.rs` synthesizes the same conjunction for the mixed
+and negated chaining paths.
+
+Runtime semantics are correct in both shapes (the middle is evaluated exactly once), so
+this is purely a *representation* gap. Its visible cost is RakuAST fidelity:
+
+```
+$ raku  -e 'say Q[1 < 2 < 3].AST'   # ApplyInfix(ApplyInfix(1,"<",2), "<", 3)
+$ mutsu -e 'say Q[1 < 2 < 3].AST'   # RakuAST::StatementPrefix::Do  (the DoBlock shape)
+```
+
+Rakudo has no AST-level `&&` here at all — the chaining semantics come from the
+operator's *chaining precedence* at code-gen. ADR-0033's "Phase-4 prerequisite" section
+proposed `Expr::ChainedCompare { operands, ops }` to close this, noting it would let
+Phase 2 render `1 < * < 10` faithfully rather than as the expanded form.
+
+## Why this is a separate ticket rather than part of ADR-0033 Phase 4
+
+Phase 4 needed only that the synthesized conjunction be *distinguishable* from a
+user-written `&&` (so that `&&` could become a Whatever-priming thunk barrier while
+`1 < * < 10` stayed a single priming scope). It got that from a dedicated
+`TokenKind::ChainAnd`, which keeps the `Expr::Binary` shape and therefore needed no
+changes in any expression walker — a bounded 20-site audit. See ADR-0033's "Phase 4
+outcome" section.
+
+A new `Expr` variant is the expensive half and buys only the rendering fidelity. Phase 1
+of the same ADR needed `Expr::WhateverCurry` arms in **41 files**, and the failure mode is
+silent rather than a compile error: any walker with a `_ => {}` catch-all — placeholder
+collection (`collect_ph_expr_shallow`, which must see `{ $^a < $^b < $^c }`), sink
+warnings, closure free-variable analysis, `outer_redecl`, `whenever_scope` — would simply
+stop seeing the chain's operands, with no diagnostic.
+
+## Shape of the work
+
+1. Add `Expr::ChainedCompare { operands: Vec<Expr>, ops: Vec<(TokenKind, bool)> }`,
+   produced by `chain_cmp.rs` / `comparison.rs` instead of the expanded form.
+2. Defer the expansion to the compiler, exactly as ADR-0033 Phase 1 did for
+   `Expr::WhateverCurry`: a `compile_expr` arm that calls the existing
+   `build_chain_cmp_expr*` helpers and compiles the result, so emitted bytecode is
+   unchanged. Note `build_chain_cmp_expr` synthesizes `Stmt::VarDecl` and uses the global
+   `CHAIN_CMP_TMP_COUNTER`, which moves with it.
+3. Audit every `Expr` walker for a missing arm. Grep for the files that took a
+   `WhateverCurry` arm in ADR-0033 Phase 1 — that list is a good proxy.
+4. `src/rakuast/convert.rs`: render it as rakudo's left-nested `ApplyInfix` chain.
+5. Once the node exists, `TokenKind::ChainAnd` can be retired along with the
+   `exprs_structurally_eq` middle-duplication detector in
+   `src/whatever_curry/{build,replace}.rs` — with a real node there is no duplication to
+   undo. That cleanup is the main non-cosmetic gain.
+
+## Pins that must keep passing
+
+`t/whatever-chained-comparison.t`, `t/whatever-thunky-operators.t` (its last four
+assertions are exactly the chain-vs-`&&` distinction, dual-oracle against raku), and
+`t/rakuast-whatever-code.t`.


### PR DESCRIPTION
## The bug

```raku
say (1..10).grep(* > 3 && * < 8);   # raku: 1 2 3 4 5 6 7    mutsu (before): 5 6
```

No error, no warning -- a quietly wrong list, in one of the most idiomatic shapes in Raku. This is a genuine user-visible correctness bug, independent of RakuAST.

Raku compiles the operands of `&&`, `||`, `//`, `and`, `or`, `andthen`, `orelse`, `notandthen` and each of the ternary's three parts as **thunks**, and Whatever-priming happens per thunk. So `* > 3 && * < 8` is *two* independent arity-1 `WhateverCode`s; the `&&` then runs at its own evaluation time, sees a truthy `Code` object on the left, and yields the right-hand `WhateverCode`. mutsu primed straight through and built one arity-2 closure, so `grep` fed it pairs. The ternary was the same bug from the other side: `Expr::Ternary` appeared in none of the priming predicates, so mutsu primed *nothing* there and a bare `Whatever` reached the runtime and died coercing to `Numeric`.

Every row of [ADR-0033](docs/adr/0033-whatever-priming-leaf-and-derived-scope.md)'s Problem-2 table now matches the system `raku` -- each one re-measured today rather than trusted from the table:

| expression | raku | mutsu before | mutsu now |
|---|---|---|---|
| `(* > 3 && * < 8).arity` | `1` | `WhateverCode.new` | `1` |
| `(* > 3 && * < 8)(5)` | `True` | *Too few positionals* | `True` |
| `(1..10).grep(* > 3 && * < 8)` | `1 2 3 4 5 6 7` | `5 6` | `1 2 3 4 5 6 7` |
| `(*.defined && *.Str)(7)` | `7` | *Too few positionals* | `7` |
| `(* + 1 && 5).WHAT` | `(Int)` | `(WhateverCode)` | `(Int)` |
| `(* + 1 and * + 2).arity` | `1` | `WhateverCode.new` | `1` |
| `(* + 1 orelse * + 2).arity` | `1` | `WhateverCode.new` | `1` |
| `(* // 5)(Nil)` | *no CALL-ME for Whatever* | `5` | *no CALL-ME for Whatever* |
| `(* + 1 ?? * + 2 !! * + 3).WHAT` | `(WhateverCode)` | *dies coercing Whatever* | `(WhateverCode)` |

## The rule has two halves, and the second is small

ADR-0033 section 4 assumed this phase had to "replace the ~50 parser sites with a single `plant` call". Measuring first showed that is not what the correctness fix requires:

1. **A thunk barrier is opaque to the enclosing scope.** `contains_whatever`, `count_whatever` and both `replace_whatever_*` walkers stop dead at one -- rakudo's own model, in which a thunky op is never "whatever-ish". Every one of the ~50 parser planting sites is gated on `contains_whatever`, so **no site can any longer propose a scope that spans a barrier**. The fifty-site rewrite turned out to be unnecessary for the correctness goal, not merely deferrable.
2. **Each barrier operand is a scope of its own.** The new `src/whatever_curry/plant.rs` owns exactly this, hooked into the walk `mark.rs` already performs -- which ADR-0033 section 2.3 had predicted ("deliberately the seed of the `plant.rs` section 4 calls for -- same traversal, same parent-context switch").

Half 1 is why the awkward residue case needed no special case at all: `((* > 3 && * < 8) + *)` is a single arity-1 `WhateverCode` in rakudo, and with the barrier opaque the enclosing `+` simply sees one placeholder.

## The prerequisite, and a bug it flushed out

Making `&&` a barrier first required separating it from the `&&` the parser *synthesizes* when it expands a chained comparison (`a < m < b` -> `(a < m) && (m < b)`, middle duplicated). The two must land on opposite sides of the rule:

```
(1 < * < 10)(0)        False   # one arity-1 curry over the whole chain
(1 < * && * < 10)(0)   True    # a real && yields only its right-hand thunk
```

A dedicated `TokenKind::ChainAnd` does that, keeping the `Expr::Binary` shape so no expression walker needed changing. The ADR's alternative -- a full `Expr::ChainedCompare` node -- was costed and deferred: a new `Expr` variant needs an arm in every walker (Phase 1 needed 41 files for `WhateverCurry`) and fails **silently** where one has a `_ => {}` catch-all, which includes placeholder collection, sink warnings and closure free-variable analysis. It remains worth doing for its other benefit (rendering `1 < * < 10` faithfully in RakuAST) and is filed as `todo/tickets/chained-compare-ast-node.md`.

Separating them also **fixed a real bug**. The middle-duplication de-duplication in `count_whatever` had to guess, by structural comparison, whether an `&&` came from a chain -- and it guessed wrong on a user-written `1 < * && * < 10`, collapsing it into one arity-1 closure (`(0)` -> `False`). It now fires only on `ChainAnd`, and that expression yields its right-hand thunk (`(0)` -> `True`), matching rakudo.

## `xor` and `^^`

ADR-0033 flagged `xor` as unresolved and asked for a measurement rather than a guess. Rakudo primes neither `xor` nor `^^`: both `(* + 1 xor * + 2).WHAT` and `(* + 1 ^^ * + 2).WHAT` are `Nil` with a `Useless use of "+" in expression "* + 2" in sink context` warning. Since neither barrier nor non-barrier treatment reproduces that, both stay off the barrier list and mutsu keeps returning `(WhateverCode)` -- recorded in the ADR as a known divergence.

## Scope

Phase 4 plus its named prerequisite only. **Phase 3 (RakuAST write / `EVAL`) is deliberately not touched** -- the ADR states it has no roast or correctness payoff and should be picked up strictly after Phase 4.

## Testing

- New dual-oracle `t/whatever-thunky-operators.t` -- **34 assertions passing verbatim under both `target/debug/mutsu` and the system `raku`**, covering every row of the Problem-2 table, the barrier-opacity residue case, all eight barrier operators, the ternary, and the chain-vs-`&&` distinction.
- Full `prove t/`: 3361 files, 31562 assertions, green.
- `cargo test --workspace`: green (868 unit tests plus every integration binary).
- Whitelisted roast `S02-*`/`S03-*`/`S04-*` sweep: 345 files, 38504 assertions, green. `roast/S02-types/{whatever,hyperwhatever}.t`, `roast/S03-operators/composition.t`, `short-circuit.t` and `ternary.t` checked individually first.
- `cargo clippy -- -D warnings` clean, `cargo fmt` applied.

## Docs

ADR-0033 status line updated and a "Phase 4 outcome" section added (including the correction to section 2.6's claim that `(1 < * < 10).arity` is `1` in both implementations -- rakudo prints `WhateverCode.new`, because `.arity` is itself inside the priming scope). `todo/deep/rakuast-remaining.md` updated so Phase 3 is the only open item. News entry at `news/2026-08/whatever-priming-stops-at-thunk-barriers.md`.
