### PR TITLE
feat: ADR-0048 Phase 3 -- one shared placeholder-bind emitter with raku's arity error

### DIFF
--- a/docs/adr/0048-placeholder-scope-is-a-block-invocation-contract.md
+++ b/docs/adr/0048-placeholder-scope-is-a-block-invocation-contract.md
@@ -1,6 +1,6 @@
 # ADR-0048: Placeholder scope is a per-construct block-invocation contract, not a per-AST-arm boundary flag
 
-- Status: Accepted (P1, P2 landed; P3-P5 not started)
+- Status: Accepted (P1, P2, P3 landed; P4-P5 not started)
 - Date: 2026-08-20
 - Supersedes the framing of: `todo/deep/placeholder-scope-loop-while-block-boundaries.md`
   (and, transitively, the retired `todo/tickets/placeholder-scope-while-loop-not-a-boundary.md`)
@@ -446,11 +446,102 @@ both backwards for `role` (over-rejects) and `module` (accepts). Classify
      construct/kind) and a clean run of the full local `t/` suite (30788
      tests; the only failure was the pre-existing, environment-specific
      `t/compunit-can-install.t` test 4 already noted under Phase 1).
-3. **Shared bind emitter + arity error (D3).** Fixes multi-placeholder
-   `if`/`given`, and `when` / bare `{}` via `ArgSupply::None`; retires the two
-   ad-hoc bare-block strings.
+3. **Shared bind emitter + arity error (D3). LANDED (PR #6897, 2026-08-23).**
+   Added `Compiler::emit_inlined_body_placeholder_binds` (plus
+   `inlined_body_caret_placeholders`/`inlined_body_binds_supplied_value`) in
+   the new `src/compiler/helpers_placeholder_binds.rs`, and routed all five
+   copy-pasted single-placeholder-bind sites through it: `Stmt::If`
+   (`compiler/stmt.rs`), `compile_if_value`
+   (`compiler/helpers_control_flow.rs`), `compile_do_if_expr_bound`
+   (`compiler/helpers_do_expr.rs`), `Stmt::Given` (`compiler/stmt.rs`) and the
+   value-position `do given` (`compiler/expr_block.rs`). The emitter collects
+   *every* caret placeholder of the body (`$^a`, and the `@^a`/`%^a`/`&^a`
+   forms the old `.find(|n| n.starts_with('^'))` filter silently skipped —
+   raku counts those as positionals too), binds as many as `supplied`
+   provides, and emits raku's verbatim
+   `Too few positionals passed; expected N argument(s) but got M` (singular
+   at N == 1) for the rest. The die is emitted *inside* the body's own
+   control-flow region, because the arity failure is raised on invocation:
+   `if 0 { "$^a $^b" }` and a non-matching `when` must not raise at all.
+   - **`when` and the bare `{}` statement are now
+     `Signature(ArgSupply::None)`** (D6), so the shallow walks stop at them
+     and `emit_inlined_body_placeholder_binds` raises the zero-supply arity
+     error at `Stmt::When`, `Stmt::Block`, and the three tail-block sites
+     (`compiler/mod.rs`, two in `compiler/helpers_sub_body.rs`). That retires
+     both copies of the ad-hoc `"Implicit placeholder parameters are not
+     available in bare nested blocks"` string, *and* fixes the non-tail bare
+     block, which previously leaked its placeholder onto the enclosing
+     routine's signature entirely unchecked (`sub f { { $^c }; 99 }` gave `f`
+     arity 1; raku gives it `()`).
+   - **`Stmt::SyntheticBlock` deliberately stays `Transparent`** and is
+     excluded from the bare-block check. It is a parser desugar wrapper
+     (destructuring declarations, `has` lowering, package meta-statements)
+     with no `{ ... }` in the source at all, so a placeholder inside one still
+     belongs to the enclosing block. The two ad-hoc-string sites applied their
+     check to `SyntheticBlock` as well; that was over-rejection, not a
+     behaviour worth preserving.
+   - **The `Stmt::If` statement-position site was missing the
+     `!is_statement_modifier` guard its two value-position siblings already
+     had**, so a NON-tail `if` statement modifier bound the enclosing
+     routine's placeholder to the modifier's condition:
+     `sub f { say "$^a" if 1; 0 }; f(7)` printed `1` instead of `7` (the tail
+     form went through `compile_if_value` and was already correct). Unifying
+     the five sites on one emitter made the asymmetry visible; the guard is
+     now identical at all of them.
+   - **A statement modifier's *modified statement* can itself be a bare
+     block, and then that block IS the construct's own** — the first CI-visible
+     casualty of D6, caught locally by `t/statement-modifiers.t` and
+     `roast/S04-statement-modifiers/{if,unless}.t`. `{ $a = $^x } unless 0`
+     parses to an `If` whose `then_branch` is exactly `[Stmt::Block(inner)]`,
+     and raku supplies the modifier's value to that block (it prints `0`, and
+     `{ $a = $^x } given 69` prints `69`; the parser already lowers those two
+     into a `VarDecl` of `^x` at the head of the block —
+     `rewrite_placeholder_block_modifier_stmt`). Only a block *genuinely
+     nested* inside a construct's braces (`if 1 { { $^a } }`) is a second,
+     separately-invoked zero-argument Block, and the two are indistinguishable
+     from inside the `Stmt::Block` arm. `Compiler::note_construct_body_block`
+     therefore records the body block's *address* (the AST outlives the whole
+     compile) for a statement-modifier `If`/`Given`/`For` and for any
+     sole-block `While` body, and `is_construct_body_block` makes that one
+     node skip the zero-supply check. The loop arms re-note it after
+     `expand_loop_phasers`, which rebuilds the body list and so invalidates
+     the original address. `Stmt::While` carries no `is_statement_modifier`
+     flag, so the far rarer `while C { { $^a } }` gets the same pass — a
+     deliberate false negative whose real fix is D4.
+   - **Phase 3 required promoting `repeat {} while/until` to its real
+     `Signature(ArgSupply::ConditionAfterFirstPass)` classification** — the
+     *classification* half of D4 only, no new codegen. Once a bare `{ ... }`
+     statement became a zero-argument boundary, a `repeat` nested inside one
+     leaked its `$^a` out to that block, which then correctly-but-wrongly
+     reported it as a parameter nothing supplies. That is exactly the shape of
+     `roast/S04-statements/repeat.t`'s "placeholders and 'repeat while' mix"
+     subtest (whitelisted) and of the accepting pin Phase 2 added to
+     `t/placeholder-scope-rejecting.t`, so Phase 3 could not land without it.
+     Phase 2's note that `repeat` "belongs with D4, not this rejecting set"
+     stands — it is still not *rejected*; it is now a boundary whose parameter
+     nothing binds yet, which is what D4/Phase 4 finishes.
+   - Verified by a new `t/placeholder-scope-signature-capable.t` (36 cases,
+     one per row of the signature-capable evidence table plus the
+     modifier-over-a-bare-block group) that passes **unmodified under real
+     `raku`** as well as under mutsu — including the exact failure text,
+     asserted via an `EVAL`/`CATCH` helper rather than `throws-like`'s
+     `message` matcher (which mutsu currently accepts and ignores).
+   - **Residual divergences Phase 3 deliberately did not chase** (all
+     pre-existing, all D4/Phase 4 shaped, none regressed by this phase):
+     `{ $a = "$^x $^y" } unless 0` under-supplies without raising, because the
+     parser's modifier desugar binds the first placeholder to the condition
+     and the rest to `Nil` rather than deferring to D3's emitter;
+     `{ @a.push($^x) } for 1, 2` yields `True` per element instead of the
+     element (verified pre-existing by temporarily reverting the `Stmt::Block`
+     classification); `while` still leaks a placeholder in its body to the
+     enclosing routine and mutsu *calls* a `{ ... } while COND` block that
+     raku never calls; and a genuinely nested `if 1 { { $^a } }` / `given 5 { {
+     $^a } }` prints `True` where raku raises the zero-supply failure.
 4. **`while`/`until`/`repeat` raw-condition supply (D4) and the signature
-   clash (D5).**
+   clash (D5).** (`repeat`'s oracle *classification* already landed in Phase 3
+   above; what remains is the per-iteration bind for all three, and `while`'s
+   own classification — a placeholder in a `while` body still leaks to the
+   enclosing routine.)
 5. **Role classification (D7).** (`module`/`package`/`grammar` — the other
    half of D7 — already landed in Phase 2 above.)
 

--- a/news/2026-08/adr-0048-phase-3-shared-placeholder-bind-emitter.md
+++ b/news/2026-08/adr-0048-phase-3-shared-placeholder-bind-emitter.md
@@ -1,0 +1,91 @@
+# ADR-0048 Phase 3: one shared placeholder-bind emitter, and raku's arity error
+
+`if 42 { "$^a $^b" }` printed `42 True` in mutsu. In raku it dies with
+`Too few positionals passed; expected 2 arguments but got 1`, because the
+branch is a Block declaring two positional parameters and `if` invokes it with
+exactly one argument — the raw condition value.
+
+The cause was structural, and is what ADR-0048 D3 was written to fix: the
+value-binding half of the block-invocation contract was copy-pasted at five
+codegen sites, each of which located only the *first* placeholder
+(`collect_placeholders_shallow(..).find(|n| n.starts_with('^'))`) and let any
+further placeholder fall through to the *enclosing* block's signature. A
+boolean "descend or stop" per AST arm has nowhere to record how many arguments
+a construct actually supplies, so there was nothing to compare a body's arity
+against.
+
+## What landed
+
+A single compiler helper,
+`Compiler::emit_inlined_body_placeholder_binds(body, supplied)`
+(`src/compiler/helpers_placeholder_binds.rs`), now owns that half of the
+contract. It collects **all** of a body's caret placeholders in
+`collect_placeholders_shallow` order, binds as many as the construct's
+`ArgSupply` provides, and emits raku's verbatim failure — including the
+singular `expected 1 argument` — for the rest. All five sites call it:
+`Stmt::If`, `compile_if_value`, `compile_do_if_expr_bound`, `Stmt::Given`, and
+the value-position `do given`.
+
+Three things fell out of unifying them:
+
+- **`@^a`/`%^a` count.** The old `starts_with('^')` filter silently skipped the
+  non-scalar placeholder forms, so `if 42 { $^a; @^b }` bound `$^a` and
+  dropped `@^b`. raku reports both as positionals (`expected 2 arguments but
+  got 1`), and now so does mutsu.
+- **`when` and the bare `{ ... }` statement are zero-argument bodies** (D6).
+  Classifying them `Signature(ArgSupply::None)` makes them boundaries the
+  shallow walks stop at, and the same emitter produces
+  `expected 1 argument but got 0` for `{ $^c }` and
+  `given 5 { when 5 { $^c } }`. That retires both copies of the ad-hoc
+  `"Implicit placeholder parameters are not available in bare nested blocks"`
+  string — and fixes the *non-tail* bare block, which had no check at all and
+  leaked its placeholder straight onto the enclosing routine's signature
+  (`sub f { { $^c }; 99 }` gave `f` arity 1 where raku gives it `()`).
+  `Stmt::SyntheticBlock` — the parser's desugar wrapper, with no `{ ... }` in
+  the source — is deliberately excluded and stays transparent.
+- **A missing guard surfaced.** The statement-position `Stmt::If` site never
+  had the `!is_statement_modifier` guard its two value-position siblings
+  carried, so a non-tail `if` *statement modifier* bound the enclosing
+  routine's placeholder to the modifier's condition:
+  `sub f { say "$^a" if 1; 0 }; f(7)` printed `1` instead of `7`. The tail form
+  went through `compile_if_value` and was already right, which is why the bug
+  had stayed invisible. One emitter, one guard, at all five sites.
+
+D6 also turned up a shape the model had to grow a name for: a statement
+modifier's *modified statement* can itself be a bare block, and then that block
+is the construct's own. `{ $a = $^x } unless 0` parses to an `If` whose branch
+is exactly `[Stmt::Block(inner)]` — the very same shape as the genuinely nested
+`if 1 { { $^a } }` — but raku supplies the modifier's value to it (it prints
+`0`; `{ $a = $^x } given 69` prints `69`) rather than invoking it with nothing.
+`note_construct_body_block` records that one body block's address so
+`is_construct_body_block` can let it through the zero-argument check, re-noted
+by the loop arms after `expand_loop_phasers` rebuilds their body list.
+`t/statement-modifiers.t` and `roast/S04-statement-modifiers/{if,unless}.t`
+caught this immediately, which is the safety net working as intended.
+
+Phase 3 also had to promote `repeat {} while/until` to its real
+`Signature(ArgSupply::ConditionAfterFirstPass)` classification — the
+classification half of D4, no new codegen. Once a bare `{ ... }` statement
+became a zero-argument boundary, a `repeat` nested inside one leaked its `$^a`
+out to that block, which then reported it as a parameter nothing supplies.
+That is precisely the shape of `roast/S04-statements/repeat.t`'s
+"placeholders and 'repeat while' mix" subtest, so the promotion was a
+prerequisite rather than scope creep. A placeholder in a `while` body still
+leaks; supplying the raw condition per iteration for all three remains D4.
+
+## Verification
+
+`t/placeholder-scope-signature-capable.t` adds 36 cases — one per row of
+ADR-0048's signature-capable evidence table, plus the
+modifier-over-a-bare-block group — and **passes unmodified under real `raku`**
+as well as under mutsu, so every expectation is the rakudo observable rather
+than mutsu's own output. The exact failure text is asserted through an
+`EVAL`/`CATCH` helper rather than `throws-like`'s `message` matcher, which
+mutsu currently accepts and ignores.
+
+Several neighbouring divergences were measured and deliberately left to D4:
+`{ @a.push($^x) } for 1, 2` yields `True` per element instead of the element
+(confirmed pre-existing by temporarily reverting the classification), `while`
+still leaks a placeholder in its body to the enclosing routine, and a
+genuinely nested `if 1 { { $^a } }` prints `True` where raku raises. They are
+recorded in the ADR so Phase 4 inherits a list rather than a surprise.

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -2239,12 +2239,12 @@ fn collect_ph_expr(expr: &Expr, out: &mut Vec<String>) {
 ///
 /// `ArgSupply` is only meaningful when the construct is `Signature`-capable
 /// (see [`PlaceholderBodyKind`]); it names *what value* the construct hands
-/// its body when it invokes it. Not every variant is exercised yet — ADR-0048
-/// Phase 1 only *classifies* existing constructs (`Condition`, `Elements`,
-/// `Topic`, `CallerArgs`); `ConditionAfterFirstPass` (repeat's first pass) and
-/// `None` (zero-arg bodies like `when`/bare `{}`) are reserved for the later
-/// phases that actually bind them (D3/D4).
-#[allow(dead_code)] // ConditionAfterFirstPass/None: reserved for Phase 2+ (D3/D4)
+/// its body when it invokes it. Not every variant is exercised yet — Phase 1
+/// classified `Condition`, `Elements`, `Topic` and `CallerArgs`; Phase 3
+/// (D3/D6) put `None` to work for the zero-argument bodies (`when`, the bare
+/// `{}` statement). `ConditionAfterFirstPass` (`repeat {} while/until`'s `Mu`
+/// first pass) is still reserved for D4/Phase 4.
+#[allow(dead_code)] // ConditionAfterFirstPass: reserved for Phase 4 (D4)
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum ArgSupply {
     /// The enclosing block's own arguments (routine bodies, closure values).
@@ -2275,16 +2275,18 @@ pub(crate) enum PlaceholderBodyKind {
     /// No block of its own: descend, placeholders belong to the enclosing
     /// scope. Covers statement MODIFIERS (`if`/`for`/`given` with
     /// `is_statement_modifier: true`, which have no block at all — mirroring
-    /// the `For`/`Given` modifier rule below), and also `while`/bare
-    /// `{}`-family statements/`when`/`RoleDecl`/WhateverCode closures, which
-    /// mutsu currently (WRONGLY, per ADR-0048's raku audit) treats the same
-    /// way: they leak their placeholders to the enclosing scope (or, for
+    /// the `For`/`Given` modifier rule below), the parser's synthetic
+    /// `SyntheticBlock` desugar wrapper (no `{ ... }` in the source at all),
+    /// and also `while`/`RoleDecl`/WhateverCode closures, which mutsu
+    /// currently (WRONGLY, per ADR-0048's raku audit) treats the same way:
+    /// they leak their placeholders to the enclosing scope (or, for
     /// `RoleDecl`, over-reject) instead of matching raku's rule. Phase 1 was
     /// a pure refactor of the existing (partly wrong) behaviour into one
     /// table; Phase 2 corrected `loop`/`react`/`default`/`Catch`/`Control`/
-    /// `Phaser` (moved to `NoSignature`, see below); the remaining wrong
-    /// entries are corrected by ADR-0048's later phases (D3 for `when`/bare
-    /// `{}`'s *arity*, D7 for `RoleDecl`), not here.
+    /// `Phaser` (moved to `NoSignature`, see below); Phase 3 corrected `when`
+    /// and the bare `{}` statement (moved to `Signature(ArgSupply::None)`);
+    /// the remaining wrong entries are corrected by ADR-0048's later phases
+    /// (D4 for `while`/`repeat`, D7 for `RoleDecl`), not here.
     Transparent,
     /// A boundary that takes a signature; the construct supplies `ArgSupply`
     /// when it invokes its body. `if`/`elsif`/`unless`/`with`/`without`
@@ -2293,11 +2295,12 @@ pub(crate) enum PlaceholderBodyKind {
     /// (`ArgSupply::Elements`); `given`/`with` (non-modifier) and `whenever`
     /// supply the topic/emitted value (`ArgSupply::Topic`); real closures
     /// (`sub {}`/`-> {}`/named subs) supply the caller's own arguments
-    /// (`ArgSupply::CallerArgs`). Only the *first* placeholder is currently
-    /// bound at each of these sites (a second placeholder falls through to
-    /// the enclosing scope instead of raising raku's arity error) — ADR-0048
-    /// D3 fixes that binding in a later phase; Phase 1 only records the
-    /// classification.
+    /// (`ArgSupply::CallerArgs`); `when` bodies and the bare `{}` statement
+    /// are invoked with nothing (`ArgSupply::None`, ADR-0048 Phase 3/D6).
+    /// The *value* half of the contract lives in the compiler's shared
+    /// `Compiler::emit_inlined_body_placeholder_binds` (ADR-0048 D3), which
+    /// binds as many of the body's placeholders as the construct supplies and
+    /// raises raku's `Too few positionals passed` for the rest.
     Signature(ArgSupply),
     /// A boundary that may not take a signature at all: a placeholder used
     /// directly inside it is `X::Placeholder::Block`. `class`/`RoleDecl`
@@ -2368,7 +2371,22 @@ pub(crate) fn placeholder_body_kind(stmt: &Stmt) -> PlaceholderBodyKind {
         // `repeat while $b < 10 { $tracker = $^a; $b++ }` does NOT reject
         // `$^a` (pins `roast/S04-statements/repeat.t`'s "placeholders and
         // 'repeat while' mix" subtest, which would otherwise regress).
-        Stmt::Loop { repeat: true, .. } => PlaceholderBodyKind::Transparent,
+        //
+        // ADR-0048 Phase 3 had to promote it from that placeholder
+        // `Transparent` to its real `Signature` classification: once the bare
+        // `{ ... }` STATEMENT became a zero-argument boundary (D6, below), a
+        // `repeat` nested in one — exactly the shape of
+        // `roast/S04-statements/repeat.t`'s subtest and of
+        // `t/placeholder-scope-rejecting.t`'s accepting pin — leaked its
+        // `$^a` out to the enclosing bare block, which then reported it as a
+        // parameter nothing supplies. This is the *classification* half of
+        // D4 only: the `ArgSupply::ConditionAfterFirstPass` bind itself (`Mu`
+        // on the first pass, the raw condition afterwards) is still Phase 4's
+        // work, so a placeholder in a `repeat` body is a parameter of that
+        // body that nothing binds yet, rather than the enclosing block's.
+        Stmt::Loop { repeat: true, .. } => {
+            PlaceholderBodyKind::Signature(ArgSupply::ConditionAfterFirstPass)
+        }
         // `loop {}` (`repeat: false`, both headerless and C-style) and
         // `react {}` fall through to the `NoSignature` catch-all below.
         // The `whenever` body is its own block scope, supplied the emitted
@@ -2379,14 +2397,27 @@ pub(crate) fn placeholder_body_kind(stmt: &Stmt) -> PlaceholderBodyKind {
         Stmt::Whenever { .. } => PlaceholderBodyKind::Signature(ArgSupply::Topic),
         // `Default`/`Catch`/`Control`/`Phaser` do not take a signature in
         // raku either — ADR-0048 Phase 2 flips them to `NoSignature` via the
-        // catch-all below. `Block`/`SyntheticBlock` (the bare `{}` statement,
-        // D6) and `When` (D3) stay `Transparent`/pending later phases;
+        // catch-all below.
+        //
+        // ADR-0048 Phase 3 (D3/D6): a bare `{ ... }` STATEMENT and a `when`
+        // body are real Blocks that raku invokes with ZERO arguments, so a
+        // placeholder in one is that block's own unsatisfied parameter, not
+        // the enclosing block's — `{ $^c }` and `given 5 { when 5 { $^c } }`
+        // both die with "Too few positionals passed; expected 1 argument but
+        // got 0", and `{ when 5 { $^c } }.arity` is 0. Hence
+        // `Signature(ArgSupply::None)`: a boundary the shallow walks stop at,
+        // whose arity failure `emit_inlined_body_placeholder_binds` raises at
+        // the body's own compile site.
+        //
+        // `SyntheticBlock` is NOT included: it is a parser desugar wrapper
+        // (destructuring declarations, `has` attribute lowering, package
+        // meta-statements, ...) with no `{ ... }` in the source at all, so a
+        // placeholder inside one still belongs to the enclosing block.
         // `RoleDecl` stays `Transparent` too (a deliberate Phase-1
         // over-reject via its own `emit_block_placeholder_die` call site —
         // correcting it is Phase 5/D7, not here).
-        Stmt::Block(_) | Stmt::SyntheticBlock(_) | Stmt::RoleDecl { .. } | Stmt::When { .. } => {
-            PlaceholderBodyKind::Transparent
-        }
+        Stmt::Block(_) | Stmt::When { .. } => PlaceholderBodyKind::Signature(ArgSupply::None),
+        Stmt::SyntheticBlock(_) | Stmt::RoleDecl { .. } => PlaceholderBodyKind::Transparent,
         Stmt::Given {
             is_statement_modifier: true,
             ..
@@ -2421,7 +2452,11 @@ pub(crate) fn placeholder_body_kind_expr(expr: &Expr) -> PlaceholderBodyKind {
         Expr::AnonSub { .. } | Expr::AnonSubParams { .. } | Expr::Lambda { .. } => {
             PlaceholderBodyKind::Signature(ArgSupply::CallerArgs)
         }
-        // The bare `{}` term (D6, Phase 3) stays `Transparent`. `Gather`
+        // The bare `{}` TERM (an `Expr::Block` in value position) stays
+        // `Transparent`: `compile_expr_block` turns a placeholder-bearing one
+        // into a real closure with those placeholders as its signature
+        // (`{ $^c }.arity` is 1), so it is not the zero-argument statement
+        // Block that ADR-0048 Phase 3/D6 reclassified. `Gather`
         // (`gather {}`) does NOT — ADR-0048 Phase 2 flips it to `NoSignature`
         // via the catch-all below (raku: a placeholder inside `gather {}` is
         // `X::Placeholder::Block`, not the enclosing block's own param).

--- a/src/compiler/expr_block.rs
+++ b/src/compiler/expr_block.rs
@@ -116,13 +116,15 @@ impl Compiler {
                 // statement-position Given arm in `stmt.rs`. Rebinding it to
                 // the topic here made `sub w1 { "a=$^a" with $^n }` read the
                 // topic for `$^a` instead of the sub's own first argument.
-                if !is_statement_modifier
-                    && let Some(ph) = crate::ast::collect_placeholders_shallow(body)
-                        .into_iter()
-                        .find(|n| n.starts_with('^'))
-                {
-                    self.code.emit(OpCode::Dup);
-                    self.emit_set_named_var(&ph);
+                if !is_statement_modifier {
+                    // ADR-0048 D3's shared bind (mirrors the statement-position
+                    // `Given` arm). `Dup` only when a scalar placeholder will
+                    // consume the copy -- the topic must stay on the stack for
+                    // `OpCode::DoGivenExpr`.
+                    if Self::inlined_body_binds_supplied_value(body) {
+                        self.code.emit(OpCode::Dup);
+                    }
+                    self.emit_inlined_body_placeholder_binds(body, ArgSupply::Topic);
                 }
                 let given_idx = self.code.emit(OpCode::DoGivenExpr { body_end: 0 });
                 self.compile_block_inline(body);

--- a/src/compiler/helpers_control_flow.rs
+++ b/src/compiler/helpers_control_flow.rs
@@ -258,22 +258,19 @@ impl Compiler {
         let needs_at_underscore = Self::body_uses_legacy_args(then_branch);
         // A bare `if EXPR { ... $^a ... }` whose block has a scalar placeholder
         // receives the condition value as that placeholder (like `-> $a`), so
-        // `if 42 { $^a.say }` prints 42. Bind the first scalar placeholder
-        // (`$^a` → env key `^a`); a valid block takes only the one condition value.
+        // `if 42 { $^a.say }` prints 42. The bind (and the arity failure when the
+        // branch declares more placeholders than the single condition value
+        // satisfies) is ADR-0048 D3's shared emitter.
         //
         // An `if`/`unless`/`with`/`without` STATEMENT MODIFIER (including the
         // synthetic `If` `with`/`without` desugar to) has no block of its own,
         // so this binding does not apply: `sub f { $^a if $^n }` must bind
         // `$^a` to the sub's own placeholder argument, not to the modifier's
         // boolean condition result (`$^n.defined`/truthiness).
-        let cond_placeholder: Option<String> = if binding_var.is_none() && !is_statement_modifier {
-            crate::ast::collect_placeholders_shallow(then_branch)
-                .into_iter()
-                .find(|n| n.starts_with('^'))
-        } else {
-            None
-        };
-        let needs_cond_value = needs_at_underscore || cond_placeholder.is_some();
+        let bind_cond_placeholders = binding_var.is_none() && !is_statement_modifier;
+        let binds_cond_placeholder =
+            bind_cond_placeholders && Self::inlined_body_binds_supplied_value(then_branch);
+        let needs_cond_value = needs_at_underscore || binds_cond_placeholder;
         // A topic-binding `if EXPR -> $v { ... }` (or a pointy `elsif`): bind the
         // condition value to `$v` and test the bound variable, mirroring the
         // statement-form desugar (`{ my $v = EXPR; if $v { ... } }`) that
@@ -310,9 +307,10 @@ impl Compiler {
             // Flatten the duplicated condition into @_.
             self.code.emit(OpCode::FlattenSlurpy);
             self.emit_set_named_var("@_");
-        } else if let Some(ph) = &cond_placeholder {
-            // Bind the scalar placeholder to the (unflattened) condition value.
-            self.emit_set_named_var(ph);
+        } else if bind_cond_placeholders {
+            // Bind the branch's placeholders to the (unflattened) condition value
+            // -- ADR-0048 D3.
+            self.emit_inlined_body_placeholder_binds(then_branch, ArgSupply::Condition);
         }
         // A branch with ENTER/LEAVE/KEEP/UNDO phasers is a real block scope:
         // its LEAVE must fire when the branch exits, with the branch value

--- a/src/compiler/helpers_do_expr.rs
+++ b/src/compiler/helpers_do_expr.rs
@@ -174,14 +174,10 @@ impl Compiler {
         // so this binding does not apply — mirrors the same guard in
         // `compile_if_value`.
         let needs_at_underscore = binding_var.is_none() && Self::body_uses_legacy_args(then_branch);
-        let cond_placeholder: Option<String> = if binding_var.is_none() && !is_statement_modifier {
-            crate::ast::collect_placeholders_shallow(then_branch)
-                .into_iter()
-                .find(|n| n.starts_with('^'))
-        } else {
-            None
-        };
-        let needs_cond_value = needs_at_underscore || cond_placeholder.is_some();
+        let bind_cond_placeholders = binding_var.is_none() && !is_statement_modifier;
+        let binds_cond_placeholder =
+            bind_cond_placeholders && Self::inlined_body_binds_supplied_value(then_branch);
+        let needs_cond_value = needs_at_underscore || binds_cond_placeholder;
         let mut deferred_container_decl = None;
         if let Some(var_name) = binding_var {
             let (read_expr, deferred) = self.compile_if_binding_decl(var_name, cond);
@@ -198,8 +194,11 @@ impl Compiler {
         if needs_at_underscore {
             self.code.emit(OpCode::FlattenSlurpy);
             self.emit_set_named_var("@_");
-        } else if let Some(ph) = &cond_placeholder {
-            self.emit_set_named_var(ph);
+        } else if bind_cond_placeholders {
+            // ADR-0048 D3's shared bind: binds every placeholder the branch
+            // declares that the single condition value can satisfy, and raises
+            // raku's "Too few positionals passed" for the rest.
+            self.emit_inlined_body_placeholder_binds(then_branch, ArgSupply::Condition);
         }
         // The branch is a block literal re-cloned per execution of the enclosing
         // block, so its own `state` restarts — see `OpCode::ResetStateLocals`.

--- a/src/compiler/helpers_placeholder_binds.rs
+++ b/src/compiler/helpers_placeholder_binds.rs
@@ -1,0 +1,180 @@
+//! ADR-0048 D3: the single shared emitter for binding an *inlined* construct
+//! body's placeholder parameters.
+//!
+//! Every `{ ... }` body is a Block in raku, and a construct invokes it with
+//! some number of arguments (ADR-0048's block-invocation contract). mutsu
+//! compiles `if`/`given`/`when`/bare-`{}` bodies inline into the enclosing
+//! frame (D1), so the bind has to be reconstructed here from the AST oracle's
+//! [`ArgSupply`] classification instead of falling out of a real call.
+//!
+//! Before this module the bind was copy-pasted at five sites, each of which
+//! found only the *first* placeholder
+//! (`collect_placeholders_shallow(..).find(|n| n.starts_with('^'))`) and
+//! silently let any further placeholder fall through to the *enclosing*
+//! block's signature — so `if 42 { "$^a $^b" }` printed `42 True` where raku
+//! raises `Too few positionals passed; expected 2 arguments but got 1`.
+
+use super::*;
+
+impl Compiler {
+    /// The caret (positional) placeholders `body` declares, in
+    /// `collect_placeholders_shallow` order.
+    ///
+    /// Names come back sigil-prefixed for the non-scalar forms (`^a`, `@^b`,
+    /// `%^c`, `&^d`), and *all* of them are positional parameters of the body:
+    /// raku reports `if 42 { $^a; @^b }` as `expected 2 arguments but got 1`.
+    /// Named placeholders (`$:name`) are deliberately excluded — they are
+    /// named parameters, and under-supplying one is raku's separate
+    /// "Required named parameter 'a' not passed", not an arity failure.
+    pub(super) fn inlined_body_caret_placeholders(body: &[Stmt]) -> Vec<String> {
+        crate::ast::collect_placeholders_shallow(body)
+            .into_iter()
+            .filter(|n| n.trim_start_matches(['@', '%', '&']).starts_with('^'))
+            .collect()
+    }
+
+    /// Does this inlined body need the construct's supplied value kept on the
+    /// stack so [`Compiler::emit_inlined_body_placeholder_binds`] can bind it?
+    ///
+    /// Only a *scalar* `$^name` can receive a single supplied value, so a body
+    /// whose first positional placeholder is `@^a`/`%^a` consumes nothing
+    /// (raku type-checks that bind and fails; mutsu leaves the placeholder
+    /// unbound rather than assigning a scalar into an array parameter). The
+    /// stack contract of the emitter is exactly this predicate: it pops one
+    /// value iff this returns true and the construct supplies at least one.
+    pub(super) fn inlined_body_binds_supplied_value(body: &[Stmt]) -> bool {
+        Self::inlined_body_caret_placeholders(body)
+            .first()
+            .is_some_and(|n| n.starts_with('^'))
+    }
+
+    /// ADR-0048 D3/D6 — remember that this construct's body IS a source
+    /// `{ ... }` block, so that block is not *additionally* a zero-argument
+    /// nested one.
+    ///
+    /// A statement MODIFIER modifies a statement, and that statement can be a
+    /// bare block: `{ $a = $^x } unless 0` and `{ $a = $^x } given 69` both
+    /// parse to a construct whose body is exactly `[Stmt::Block(inner)]`, and
+    /// raku supplies the modifier's value to that block (it prints `0` and
+    /// `69` respectively, not an arity failure — the parser already lowers
+    /// those two into a `VarDecl` of `^x` at the head of the block). The same
+    /// holds for `{ @a.push($^x) } for 1, 2` and for a `while` modifier. Only
+    /// a block that is *genuinely nested* inside a construct's braces
+    /// (`if 1 { { $^a } }`) is a second, separately-invoked Block.
+    ///
+    /// The two shapes are indistinguishable from inside the `Stmt::Block` arm,
+    /// so record the body block's address here (the AST outlives the whole
+    /// compile, so the address is a stable identity) and let that arm skip its
+    /// zero-supply check for exactly that node. `Stmt::While` has no
+    /// `is_statement_modifier` flag, so a sole-block `while` body is treated
+    /// as the modifier form either way — a deliberate false negative for the
+    /// rare `while C { { $^a } }`, whose real fix is D4/Phase 4 anyway.
+    pub(super) fn note_construct_body_block(&mut self, stmt: &Stmt) {
+        let body = match stmt {
+            Stmt::If {
+                then_branch,
+                is_statement_modifier: true,
+                ..
+            } => then_branch,
+            Stmt::Given {
+                body,
+                is_statement_modifier: true,
+                ..
+            }
+            | Stmt::For {
+                body,
+                is_statement_modifier: true,
+                ..
+            }
+            | Stmt::While { body, .. } => body,
+            _ => return,
+        };
+        self.note_construct_body_block_stmts(body);
+    }
+
+    /// Re-note a construct's body block after the body list was REBUILT.
+    /// `expand_loop_phasers` returns a fresh `Vec<Stmt>`, so the address
+    /// [`Compiler::note_construct_body_block`] recorded for a `for`/`while`
+    /// modifier's body no longer identifies the block that actually gets
+    /// compiled; the loop arms call this with the expanded list.
+    pub(super) fn note_construct_body_block_stmts(&mut self, body: &[Stmt]) {
+        if let [Stmt::Block(inner)] = body {
+            self.construct_body_block = Some(inner.as_ptr() as usize);
+        }
+    }
+
+    /// Is `stmts` the body block a statement modifier (or a `while`) supplies
+    /// its own value to, rather than a separately-invoked nested block?
+    /// See [`Compiler::note_construct_body_block`].
+    pub(super) fn is_construct_body_block(&self, stmts: &[Stmt]) -> bool {
+        !stmts.is_empty() && self.construct_body_block == Some(stmts.as_ptr() as usize)
+    }
+
+    /// ADR-0048 D3 — bind an inlined body's placeholder parameters from what
+    /// its construct supplies, and raise raku's arity error when the body
+    /// declares more positionals than the construct provides.
+    ///
+    /// `supplied` comes from the AST oracle (`placeholder_body_kind`): an
+    /// `if`/`elsif`/`unless`/`with`/`without` branch is handed the raw
+    /// condition ([`ArgSupply::Condition`]), a `given`/`with` body the topic
+    /// ([`ArgSupply::Topic`]), and a `when` body or a bare `{ ... }` statement
+    /// nothing at all ([`ArgSupply::None`]) — which is why
+    /// `given 5 { when 5 { $^c } }` and `{ $^c }` both die with
+    /// `Too few positionals passed; expected 1 argument but got 0` in raku.
+    ///
+    /// Stack contract: when the construct supplies a value it must be on top
+    /// of the stack, and is consumed exactly when
+    /// [`Compiler::inlined_body_binds_supplied_value`] is true. Emit this
+    /// *inside* the body's own control-flow region — the arity failure is a
+    /// runtime error raised when the block is invoked, so a never-taken
+    /// branch (`if 0 { "$^a $^b" }`) and a non-matching `when` must not raise
+    /// it at all.
+    ///
+    /// Returns true when a fatal arity die was emitted, so callers that can
+    /// bail out of compiling the body (the bare-`{}` statement) may do so.
+    pub(super) fn emit_inlined_body_placeholder_binds(
+        &mut self,
+        body: &[Stmt],
+        supplied: ArgSupply,
+    ) -> bool {
+        let phs = Self::inlined_body_caret_placeholders(body);
+        if phs.is_empty() {
+            return false;
+        }
+        let supplied_n = match supplied {
+            ArgSupply::None => 0,
+            // Every inlined construct that supplies anything supplies exactly
+            // one value: the raw condition, the topic, or (`repeat`, D4/Phase
+            // 4) `Mu` on the first pass and the condition afterwards.
+            ArgSupply::Condition | ArgSupply::ConditionAfterFirstPass | ArgSupply::Topic => 1,
+            // A real invocation binds the body's own declared arity, so it can
+            // never under-supply here; these never reach an inlined body.
+            ArgSupply::CallerArgs | ArgSupply::Elements => phs.len(),
+        };
+        if supplied_n >= 1 && phs[0].starts_with('^') {
+            self.emit_set_named_var(&phs[0]);
+        }
+        if phs.len() > supplied_n {
+            self.emit_too_few_positionals_die(phs.len(), supplied_n);
+            return true;
+        }
+        false
+    }
+
+    /// Emit raku's runtime arity failure for an under-supplied inlined body.
+    ///
+    /// The wording is raku's verbatim (`Too few positionals passed; expected 2
+    /// arguments but got 1`), including the singular "argument" at
+    /// `expected == 1`, so `{ $^c }` reports exactly what rakudo reports.
+    fn emit_too_few_positionals_die(&mut self, expected: usize, got: usize) {
+        let msg = format!(
+            "Too few positionals passed; expected {} argument{} but got {}",
+            expected,
+            if expected == 1 { "" } else { "s" },
+            got
+        );
+        let idx = self.code.add_constant(Value::str(msg));
+        self.code.emit(OpCode::LoadConst(idx));
+        self.code.emit(OpCode::Die);
+    }
+}

--- a/src/compiler/helpers_sub_body.rs
+++ b/src/compiler/helpers_sub_body.rs
@@ -687,7 +687,13 @@ impl Compiler {
                     }
                     Stmt::Block(stmts) => {
                         // Bare blocks in final statement position auto-execute and
-                        // produce their final value.
+                        // produce their final value -- but raku still invokes them
+                        // with zero arguments, so a placeholder inside one is an
+                        // unsatisfied parameter (ADR-0048 D3/D6).
+                        if sub_compiler.emit_inlined_body_placeholder_binds(stmts, ArgSupply::None)
+                        {
+                            continue;
+                        }
                         sub_compiler.compile_block_inline(stmts);
                         continue;
                     }
@@ -1310,11 +1316,16 @@ impl Compiler {
                             continue;
                         }
                         Stmt::Block(stmts) | Stmt::SyntheticBlock(stmts) => {
-                            if Self::has_block_placeholders(stmts) {
-                                sub_compiler.compile_stmt(&Stmt::Die(Expr::Literal(Value::str(
-                                    "Implicit placeholder parameters are not available in bare nested blocks"
-                                        .to_string(),
-                                ))));
+                            // ADR-0048 D3/D6: see the matching tail-block site in
+                            // `compiler/mod.rs` -- a tail bare `{ ... }` statement
+                            // is a Block invoked with zero arguments, so it gets
+                            // raku's "Too few positionals passed" instead of the
+                            // retired ad-hoc bare-nested-block string.
+                            if matches!(stmt, Stmt::Block(_))
+                                && sub_compiler
+                                    .emit_inlined_body_placeholder_binds(stmts, ArgSupply::None)
+                            {
+                                // fatal: the block never runs
                             } else if matches!(stmt, Stmt::SyntheticBlock(_)) {
                                 // A parser wrapper, not a real scope -- see
                                 // `compile_synthetic_block_inline`.

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -1,7 +1,7 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-use crate::ast::{AssignOp, CallArg, Expr, PhaserKind, Stmt, make_anon_sub};
+use crate::ast::{ArgSupply, AssignOp, CallArg, Expr, PhaserKind, Stmt, make_anon_sub};
 use crate::opcode::{CompiledCode, CompiledFns, CompiledFunction, OpCode};
 use crate::symbol::Symbol;
 use crate::token_kind::TokenKind;
@@ -1125,6 +1125,7 @@ mod helpers_dynamic;
 mod helpers_method_body;
 pub(crate) mod helpers_ops;
 mod helpers_phasers;
+mod helpers_placeholder_binds;
 mod helpers_stmt_analysis;
 mod helpers_sub_body;
 pub(crate) mod lex_scope;
@@ -1422,6 +1423,12 @@ pub(crate) struct Compiler {
     /// not a genuine source `{ ... }`). The `Stmt::Block` arm consumes it to
     /// decide whether the resulting scope is a backtrace-visible callframe.
     synthetic_block_body: bool,
+    /// Address of the `Stmt::Block` body a statement modifier (or a `while`)
+    /// supplies its own value to — ADR-0048 D3/D6. See
+    /// `Compiler::note_construct_body_block`, which records it, and
+    /// `is_construct_body_block`, which the `Stmt::Block` arm consults to skip
+    /// its zero-argument arity check for exactly that node.
+    construct_body_block: Option<usize>,
     /// Set true immediately before the ONE NEXT `push_dynamic_scope_lexical`
     /// call recursively invoked to inline a `Stmt::SyntheticBlock`'s body (the
     /// parser's wrapper for a `:=`-bind declaration, e.g. `my $x := expr` ->
@@ -1620,6 +1627,7 @@ impl Compiler {
             suppress_list_var_alias: false,
             sunk_list_assign_result: false,
             synthetic_block_body: false,
+            construct_body_block: None,
             next_dynamic_scope_inline_transparent: false,
             suppress_loop_block_state_reset: false,
             next_try_is_bare_block: false,
@@ -3208,11 +3216,17 @@ impl Compiler {
                             continue;
                         }
                         Stmt::Block(body) | Stmt::SyntheticBlock(body) => {
-                            if Self::has_block_placeholders(body) {
-                                self.compile_stmt(&Stmt::Die(Expr::Literal(Value::str(
-                                    "Implicit placeholder parameters are not available in bare nested blocks"
-                                        .to_string(),
-                                ))));
+                            // ADR-0048 D3/D6: a tail bare `{ ... }` statement is
+                            // still a Block invoked with zero arguments, so it
+                            // gets raku's arity failure -- retiring the ad-hoc
+                            // "Implicit placeholder parameters are not available
+                            // in bare nested blocks" string that used to live
+                            // here. `SyntheticBlock` is a parser desugar wrapper,
+                            // not a source block, so it is excluded: its
+                            // placeholders belong to the enclosing routine.
+                            if matches!(stmt, Stmt::Block(_))
+                                && self.emit_inlined_body_placeholder_binds(body, ArgSupply::None)
+                            {
                                 continue;
                             }
                             // A tail block carrying ENTER/LEAVE/KEEP/UNDO/PRE/POST

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -769,6 +769,7 @@ impl Compiler {
     }
 
     pub(super) fn compile_stmt(&mut self, stmt: &Stmt) {
+        self.note_construct_body_block(stmt);
         match stmt {
             Stmt::Expr(expr) => {
                 // See `Compiler::sunk_list_assign_result` — the statement's
@@ -836,6 +837,30 @@ impl Compiler {
                     let idx = self.code.add_constant(err_val);
                     self.code.emit(OpCode::LoadConst(idx));
                     self.code.emit(OpCode::Die);
+                    return;
+                }
+                // ADR-0048 D3/D6: a bare `{ ... }` STATEMENT is a Block raku
+                // invokes with ZERO arguments, so a placeholder it declares is
+                // that block's own unsatisfied parameter -- `{ $^c }` dies with
+                // "Too few positionals passed; expected 1 argument but got 0".
+                // (This replaces the ad-hoc "Implicit placeholder parameters are
+                // not available in bare nested blocks" string the two tail-block
+                // sites used to emit, and additionally covers the NON-tail form,
+                // which previously leaked the placeholder onto the enclosing
+                // routine's signature.)
+                //
+                // Two shapes are NOT such a block. A SYNTHESIZED body -- an
+                // `if`/`while`/`loop` branch the compile sites re-wrap in
+                // `Stmt::Block` -- is not a block of its own; `synthetic_block_body`
+                // marks those, so peek it here rather than consuming it (it is
+                // taken further down as `is_bare`). And a statement MODIFIER's
+                // modified statement (`{ $a = $^x } unless 0`) IS this construct's
+                // own block, supplied the modifier's value -- see
+                // `is_construct_body_block`.
+                if !self.synthetic_block_body
+                    && !self.is_construct_body_block(stmts)
+                    && self.emit_inlined_body_placeholder_binds(stmts, ArgSupply::None)
+                {
                     return;
                 }
                 // A block with a top-level `when`/`default` is where that
@@ -2066,16 +2091,21 @@ impl Compiler {
                 // A bare `if EXPR { ... $^a ... }` whose block has a scalar
                 // placeholder receives the condition value as that placeholder
                 // (like `if EXPR -> $a { ... }`), so `if 42 { $^a.say }` prints 42.
-                // Bind the first scalar placeholder (`$^a` → env key `^a`); a valid
-                // block can take only the one condition value.
-                let cond_placeholder: Option<String> = if binding_var.is_none() {
-                    crate::ast::collect_placeholders_shallow(then_branch)
-                        .into_iter()
-                        .find(|n| n.starts_with('^'))
-                } else {
-                    None
-                };
-                let needs_cond_value = needs_at_underscore || cond_placeholder.is_some();
+                // The bind itself (and the arity failure when the branch declares
+                // more placeholders than the single condition value satisfies) is
+                // ADR-0048 D3's shared `emit_inlined_body_placeholder_binds`.
+                //
+                // An `if`/`unless`/`with`/`without` STATEMENT MODIFIER introduces
+                // no block of its own (the oracle classifies it `Transparent`), so
+                // its "body" placeholders are the enclosing routine's own
+                // parameters: `sub f { say "$^a" if 1; 0 }; f(7)` must print 7, not
+                // the condition. The two value-position `if` sites already carried
+                // this guard; this one did not, which is why only the *non-tail*
+                // statement-modifier form diverged.
+                let bind_cond_placeholders = binding_var.is_none() && !*is_statement_modifier;
+                let binds_cond_placeholder =
+                    bind_cond_placeholders && Self::inlined_body_binds_supplied_value(then_branch);
+                let needs_cond_value = needs_at_underscore || binds_cond_placeholder;
                 // A condition that is a compile-time constant resolves the branch
                 // here (ADR-0006 §2.2): `constant DEBUG = False; if DEBUG { note
                 // ... }` emits nothing at all. The unreachable branch is only
@@ -2129,9 +2159,11 @@ impl Compiler {
                     // Flatten the duplicated condition into @_ (like *@ slurpy).
                     self.code.emit(OpCode::FlattenSlurpy);
                     self.emit_set_named_var("@_");
-                } else if let Some(ph) = &cond_placeholder {
-                    // Bind the scalar placeholder to the (unflattened) condition value.
-                    self.emit_set_named_var(ph);
+                } else if bind_cond_placeholders {
+                    // Bind the branch's placeholders to the (unflattened) condition
+                    // value -- ADR-0048 D3. Emitted inside the taken branch so a
+                    // never-taken `if 0 { "$^a $^b" }` raises nothing, matching raku.
+                    self.emit_inlined_body_placeholder_binds(then_branch, ArgSupply::Condition);
                 }
                 // The branch is a block literal the enclosing block re-clones on
                 // every execution, so its own `state` restarts each time — see
@@ -2218,6 +2250,16 @@ impl Compiler {
                     // never calls the block in raku at all, so there is no
                     // persisting-modifier case to preserve (unlike `for`,
                     // which gates on `is_statement_modifier`).
+                    //
+                    // For ADR-0048 D3/D6 that sole block is still treated as
+                    // this loop's own body rather than a nested zero-argument
+                    // one: `Stmt::While` carries no `is_statement_modifier`
+                    // flag, so `{ $a = $^x } while COND` and the far rarer
+                    // `while COND { { $^a } }` are indistinguishable here, and
+                    // the conservative choice is to not raise. Supplying the
+                    // raw condition to either is D4/Phase 4's job. Re-noted
+                    // because `expand_loop_phasers` rebuilt the body list.
+                    self.note_construct_body_block_stmts(&loop_body);
                     self.compile_scope_restored_loop_body(&loop_body);
                 }
                 self.code.patch_loop_end(loop_idx);
@@ -2578,6 +2620,13 @@ impl Compiler {
                 // there — t/state-var-per-block-clone.t test 5).
                 self.suppress_loop_block_state_reset =
                     *is_statement_modifier && Self::loop_body_is_sole_block(&loop_body);
+                // ...and by the same token that sole block is the loop's own
+                // block, supplied one element per iteration -- not a nested
+                // zero-argument one (ADR-0048 D3/D6). Re-noted here because
+                // `expand_loop_phasers` rebuilt the body list.
+                if *is_statement_modifier {
+                    self.note_construct_body_block_stmts(&loop_body);
+                }
                 self.compile_scope_restored_loop_body(&loop_body);
                 self.callframe_block_depth -= 1;
                 for n in &newly_registered {
@@ -3082,13 +3131,14 @@ impl Compiler {
                 // Rebinding it to the topic here made
                 // `sub ROL64 { ($^a … $_ …) given $^n%64 }` read the topic for
                 // `$^a` instead of the first argument.
-                if !*is_statement_modifier
-                    && let Some(ph) = crate::ast::collect_placeholders_shallow(body)
-                        .into_iter()
-                        .find(|n| n.starts_with('^'))
-                {
-                    self.code.emit(OpCode::Dup);
-                    self.emit_set_named_var(&ph);
+                if !*is_statement_modifier {
+                    // ADR-0048 D3's shared bind. `Dup` only when a scalar
+                    // placeholder will actually consume the copy -- the topic
+                    // itself must stay on the stack for `OpCode::Given`.
+                    if Self::inlined_body_binds_supplied_value(body) {
+                        self.code.emit(OpCode::Dup);
+                    }
+                    self.emit_inlined_body_placeholder_binds(body, ArgSupply::Topic);
                 }
                 let pointy_param_idx =
                     pointy_param_name.map(|name| self.code.add_constant(Value::str(name)));
@@ -3174,6 +3224,13 @@ impl Compiler {
                     })
                 });
                 let saved_scope = self.push_dynamic_scope_lexical();
+                // ADR-0048 D3: a `when` body is a Block raku invokes with ZERO
+                // arguments (`{ when 5 { $^c } }.arity` is 0), so any placeholder
+                // it declares is an unsatisfied parameter. Emitted INSIDE the
+                // `When` region: a non-matching `when` never invokes its body and
+                // must not raise (`given 5 { when 6 { $^c }; say "no match" }`
+                // prints "no match" in raku).
+                self.emit_inlined_body_placeholder_binds(body, ArgSupply::None);
                 for (i, s) in body.iter().enumerate() {
                     let is_last = i == body.len() - 1;
                     if is_last {

--- a/t/placeholder-scope-signature-capable.t
+++ b/t/placeholder-scope-signature-capable.t
@@ -1,0 +1,197 @@
+use Test;
+
+plan 36;
+
+# ADR-0048 Phase 3 (D3/D6): constructs whose body DOES take a signature, and
+# what each of them supplies when it invokes that body. Every expectation here
+# was verified against real `raku` (the "Constructs whose body may take a
+# signature" table in
+# docs/adr/0048-placeholder-scope-is-a-block-invocation-contract.md), not
+# against mutsu's previous output -- including the exact failure text, which
+# rakudo reports as a plain X::AdHoc.
+#
+# The shared rule: a `{ ... }` body's placeholders are its own positional
+# parameters, so supplying fewer arguments than it declares is the ordinary
+# runtime arity failure -- `Too few positionals passed; expected N argument(s)
+# but got M` -- raised when (and only when) the body is actually invoked.
+
+# Assert the *exact* message, not just that it dies: the whole point of D3 is
+# replacing two ad-hoc strings with raku's own wording.
+sub arity-fails($code, $expected, $desc) {
+    my $msg = 'did not die';
+    try {
+        EVAL $code;
+        CATCH { default { $msg = .message } }
+    }
+    is $msg, $expected, $desc;
+}
+
+my $expect1 = 'Too few positionals passed; expected 1 argument but got 0';
+my $expect-two-of-one = 'Too few positionals passed; expected 2 arguments but got 1';
+my $expect-two-of-zero = 'Too few positionals passed; expected 2 arguments but got 0';
+
+# --- if / unless / with / without supply ONE argument: the raw condition ---
+
+is (if 42 { "$^a" }), '42', 'if supplies the raw condition to one placeholder';
+
+arity-fails 'if 42 { "$^a $^b" }', $expect-two-of-one,
+    'if with two placeholders is an arity failure (only the condition is supplied)';
+
+arity-fails 'unless 0 { "$^a $^b" }', $expect-two-of-one,
+    'unless with two placeholders is an arity failure';
+
+arity-fails 'with 7 { "$^a $^b" }', $expect-two-of-one,
+    'with, two placeholders: an arity failure';
+
+arity-fails 'without Nil { "$^a $^b" }', $expect-two-of-one,
+    'without with two placeholders is an arity failure';
+
+arity-fails 'if 42 { "$^a"; my @x = @^b; }', $expect-two-of-one,
+    'an @^b counts as a positional parameter too, not only $^a';
+
+# The failure is a RUNTIME failure of the body's invocation, so a branch that
+# never runs never raises it.
+{
+    my $ran = 0;
+    if 0 { $ran = "$^a $^b" }
+    is $ran, 0, 'a never-taken if branch does not raise its arity failure';
+}
+
+{
+    my $ran = 0;
+    if 1 { $ran = 1 } else { $ran = "$^a $^b" }
+    is $ran, 1, 'a never-taken else branch does not raise either';
+}
+
+# Value position (`do if ...`, and an `if` as a routine's tail statement) goes
+# through the same shared emitter.
+is (do if 42 { "$^a" }), '42', 'value-position if supplies the raw condition';
+
+arity-fails 'my $r = do if 42 { "$^a $^b" }', $expect-two-of-one,
+    'value-position if with two placeholders is an arity failure';
+
+sub tail-if { if 9 { "$^a" } }
+is tail-if(), '9', 'tail-position if supplies the raw condition';
+
+arity-fails 'sub f { if 42 { "$^a $^b" } }; f()', $expect-two-of-one,
+    'tail-position if with two placeholders is an arity failure';
+
+# --- given / with supply ONE argument: the topic ---
+
+is (do given 5 { "$^a" }), '5', 'given supplies the topic to one placeholder';
+
+arity-fails 'given 5 { "$^a $^b" }', $expect-two-of-one,
+    'given with two placeholders is an arity failure (only the topic is supplied)';
+
+arity-fails 'my $r = do given 5 { "$^a $^b" }', $expect-two-of-one,
+    'value-position given with two placeholders is an arity failure';
+
+# --- when supplies ZERO arguments ---
+
+arity-fails 'given 5 { when 5 { $^c } }', $expect1,
+    'a when body is invoked with no arguments, so one placeholder under-supplies it';
+
+arity-fails 'given 5 { when 5 { "$^a $^b" } }', $expect-two-of-zero,
+    'two placeholders in a when body report expected 2 but got 0';
+
+{
+    my $ran = 'no match';
+    given 5 { when 6 { $ran = $^c }; }
+    is $ran, 'no match', 'a non-matching when never invokes its body, so it never raises';
+}
+
+is { when 5 { $^c } }.arity, 0,
+    'a when body is a boundary: its placeholder is not the enclosing block parameter';
+
+# --- a bare `{ ... }` STATEMENT supplies ZERO arguments ---
+
+arity-fails '{ $^c }', $expect1,
+    'a bare block statement is invoked with no arguments';
+
+arity-fails '{ "$^a $^b" }', $expect-two-of-zero,
+    'two placeholders in a bare block report expected 2 but got 0';
+
+arity-fails '{ $^c }; my $after = 1', $expect1,
+    'a NON-tail bare block statement raises too (it used to leak its placeholder)';
+
+arity-fails 'sub f { { $^c }; 99 }; f()', $expect1,
+    'a bare block nested in a sub does not contribute to that sub signature';
+
+arity-fails 'sub f { { $^c } }; f()', $expect1,
+    'the same holds when the bare block is the sub tail statement';
+
+# The `{ ... }` TERM in value position is a different construct: it is a real
+# closure whose placeholders ARE its signature.
+is { $^c }.arity, 1, 'a block TERM keeps its placeholder as its own parameter';
+is { $^c }(7), 7, 'and binds it when invoked with an argument';
+
+# --- statement modifiers introduce no block, so they bind nothing ---
+
+sub modifier-nontail { my $seen; $seen = "$^a" if 1; $seen }
+is modifier-nontail(7), '7',
+    'a NON-tail if statement modifier leaves its placeholder to the enclosing routine';
+
+sub modifier-tail { "$^a" if 1 }
+is modifier-tail(7), '7', 'and so does a tail-position one';
+
+sub modifier-two { "$^a $^b" if 1 }
+is modifier-two(1, 2), '1 2',
+    'a modifier never raises the arity failure of a block it does not have';
+
+# --- constructs the enclosing body must still see through ---
+
+# `for` supplies N elements per iteration, so N placeholders are all bound.
+{
+    my @out;
+    for 1, 2 { @out.push("$^a $^b") }
+    is @out.join('|'), '1 2', 'for supplies one element per placeholder';
+}
+
+# `repeat {} while/until` is signature-capable (ADR-0048 D4), so a placeholder
+# inside one belongs to the repeat body -- NOT to an enclosing bare block, which
+# would otherwise report it as an unsupplied parameter of that block. This is
+# the shape roast/S04-statements/repeat.t pins.
+{
+    my $b = 1;
+    my $tracker;
+    repeat while $b < 10 {
+        $tracker = $^a;
+        $b++;
+    }
+    ok $tracker.defined, 'a placeholder in a repeat body does not leak to an enclosing bare block';
+}
+
+# --- a statement MODIFIER whose statement is a bare block ---
+#
+# The modifier introduces no block, but the statement it modifies can BE one,
+# and then that block is the construct's own: raku supplies the modifier's
+# value to it. `{ $a = $^x } unless 0` prints 0, not an arity failure -- so the
+# zero-argument rule above must NOT fire for these.
+
+{
+    my $a; { $a = $^x } unless 0;
+    is $a, 0, 'an unless modifier supplies its raw condition to a bare block statement';
+}
+
+{
+    my $a; { $a = $^x } if 5;
+    is $a, 5, 'an if modifier does the same';
+}
+
+{
+    my $a; { $a = $^x } with 7;
+    is $a, 7, 'a with modifier supplies its topic';
+}
+
+{
+    my $a; { $a = $^x } given 69;
+    is $a, 69, 'a given modifier supplies its topic';
+}
+
+sub tail-modifier-block { { $^x } unless 0 }
+is tail-modifier-block(), 0, 'the same in a routine tail position';
+
+# (A `while` modifier over a bare block is deliberately NOT pinned here: raku
+# never calls the block at all, so `{ $n++ } while $n < 2` loops forever there
+# while mutsu runs it. That divergence is D4/Phase 4's, not D3's -- Phase 3 only
+# has to make sure the zero-argument arity check does not fire on such a block.)


### PR DESCRIPTION
Implements **Phase 3 (D3 + D6) of [ADR-0048](docs/adr/0048-placeholder-scope-is-a-block-invocation-contract.md)**.

## The bug

```raku
if 42 { say "$^a $^b" }
# raku:  Too few positionals passed; expected 2 arguments but got 1
# mutsu: 42 True
```

The branch is a Block declaring two positional parameters, and `if` invokes it with one argument — the raw condition. mutsu printed `42 True` because the value-binding half of the block-invocation contract was copy-pasted at **five** codegen sites, each finding only the *first* placeholder via `collect_placeholders_shallow(..).find(|n| n.starts_with('^'))` and letting any further placeholder fall through to the *enclosing* block's signature. A per-AST-arm boolean has nowhere to record how many arguments a construct supplies, so there was nothing to compare a body's arity against.

## What this does

One shared emitter, `Compiler::emit_inlined_body_placeholder_binds(body, supplied)`, in the new `src/compiler/helpers_placeholder_binds.rs`. All five sites call it: `Stmt::If`, `compile_if_value`, `compile_do_if_expr_bound`, `Stmt::Given`, and the value-position `do given`. It collects **every** caret placeholder of the body, binds as many as `supplied` provides, and emits raku's verbatim `Too few positionals passed; expected N argument(s) but got M` (singular at N == 1) for the rest. The die goes *inside* the body's own control-flow region, because the failure is raised on invocation — a never-taken `if 0 { "$^a $^b" }` and a non-matching `when` must not raise at all.

Three consequences fall out:

- **`@^a`/`%^a` count.** The old `starts_with('^')` filter skipped the non-scalar forms, so `if 42 { $^a; @^b }` bound `$^a` and dropped `@^b`. raku reports both as positionals.
- **`when` and the bare `{ ... }` statement are zero-argument bodies** (D6). Classifying them `Signature(ArgSupply::None)` makes them boundaries the shallow walks stop at, and the same emitter produces `expected 1 argument but got 0` for `{ $^c }` and `given 5 { when 5 { $^c } }`. This **retires both copies of the ad-hoc `"Implicit placeholder parameters are not available in bare nested blocks"` string** and fixes the *non-tail* bare block, which had no check at all and leaked its placeholder onto the enclosing routine's signature (`sub f { { $^c }; 99 }` gave `f` arity 1; raku gives it `()`). `Stmt::SyntheticBlock` — the parser's desugar wrapper, with no `{ ... }` in the source — is deliberately excluded and stays transparent.
- **A missing guard surfaced.** The statement-position `Stmt::If` site never had the `!is_statement_modifier` guard its two value-position siblings carried, so a non-tail `if` *statement modifier* bound the enclosing routine's placeholder to the modifier's condition: `sub f { say "$^a" if 1; 0 }; f(7)` printed `1` instead of `7`. The tail form went through `compile_if_value` and was already right, which is why it had stayed invisible.

## Two prerequisites Phase 3 had to pick up

**A statement modifier's modified statement can itself be a bare block, and then that block is the construct's own.** `{ $a = $^x } unless 0` parses to an `If` whose branch is exactly `[Stmt::Block(inner)]` — the same shape as the genuinely nested `if 1 { { $^a } }` — but raku supplies the modifier's value to it (prints `0`; `{ $a = $^x } given 69` prints `69`). `note_construct_body_block` records that one body block's address so `is_construct_body_block` can let it through the zero-argument check; the loop arms re-note it after `expand_loop_phasers` rebuilds their body list. `t/statement-modifiers.t` and `roast/S04-statement-modifiers/{if,unless}.t` caught this immediately.

**`repeat {} while/until` needed its real `Signature(ArgSupply::ConditionAfterFirstPass)` classification** — the classification half of D4 only, no new codegen. Once a bare block became a zero-argument boundary, a `repeat` nested in one leaked its `$^a` out to that block, which then reported it as a parameter nothing supplies: exactly the shape of `roast/S04-statements/repeat.t`'s whitelisted "placeholders and 'repeat while' mix" subtest.

## Verification

`t/placeholder-scope-signature-capable.t` adds **36 cases** — one per row of ADR-0048's signature-capable evidence table, plus the modifier-over-a-bare-block group — and **passes unmodified under real `raku`** as well as under mutsu, so every expectation is the rakudo observable rather than mutsu's own output. The exact failure text is asserted through an `EVAL`/`CATCH` helper rather than `throws-like`'s `message` matcher, which mutsu currently accepts and ignores.

- `make test`: **3362 files / 31598 tests, all pass**
- The 119 whitelisted roast files that use placeholders: **7004 tests, all pass**

Neighbouring divergences were measured and are recorded in the ADR as D4's inheritance rather than left as surprises: `{ @a.push($^x) } for 1, 2` yields `True` per element (confirmed pre-existing by temporarily reverting the classification), `while` still leaks a placeholder in its body, and a genuinely nested `if 1 { { $^a } }` prints `True` where raku raises.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
