### PR TITLE
fix: return the Backtrace::Frame from `$!.backtrace[N]` instead of Nil

### DIFF
--- a/news/2026-08/backtrace-positional-indexing.md
+++ b/news/2026-08/backtrace-positional-indexing.md
@@ -1,0 +1,58 @@
+# `$!.backtrace[N]` now returns the Backtrace::Frame instead of Nil
+
+Positional indexing into a `Backtrace` object always answered `Nil`/`Any`,
+regardless of the index:
+
+```raku
+sub zipi { { { die "Something bad happened" }() }() };
+try { zipi; }
+say $!.backtrace[0];      # was: Nil
+say $!.backtrace[*-1];    # was: Nil
+```
+
+`Backtrace` was already Positional everywhere *except* the subscript. List
+context unwrapped its `frames` attribute (`runtime/utils/list.rs`), and
+`.list`/`.elems`/`.map`/`.grep`/`.head`/`.tail` all worked off it, so
+`$bt.list[0]` answered the right frame while `$bt[0]` did not.
+
+## Root cause
+
+`Backtrace` is an `Instance` whose frames live in a `frames` attribute, and no
+arm of the subscript dispatch in `vm/vm_var_index_ops.rs` knew about it. An
+`Int` index therefore fell through to the generic `(Instance, Int)` arm, which
+tries the class's `AT-POS`/`AT-KEY` methods — `Backtrace` had neither — and
+returned `Nil`, which the typed-container default then turned into `Any`. The
+whatever-star form `[*-1]` was worse: its `(Instance, Sub)` arm derives the
+element count from a `Buf`'s bytes or a `Match`'s `list` attribute only, so a
+`Backtrace` measured as zero-length and `*-1` evaluated to `-1`, again `Nil`.
+
+## Fix
+
+Rather than re-deriving each index shape for `Backtrace`, the subscript is now
+delegated to the stored `frames` List, the way the `__baggy_data__` arm already
+delegates to its inner Bag/Set: push the frame list back onto the stack and
+re-enter the index op. Every index shape a List supports therefore works, and
+works identically to a List — single index, `[*-1]`, `[0,1]` slices, `[^2]` and
+`[0 .. *-1]` ranges, and `[*]`. Because Rakudo keeps a `Backtrace`'s frames in a
+`List` rather than an `Array`, an out-of-range index correctly reads back as
+`Nil` (not the `Any` an Array hands out) — mutsu's List subscript already
+matched raku here, so the delegation inherits it for free.
+
+The explicit `AT-POS` spelling (`$bt.AT-POS(0)`, previously an
+`X::Method::NotFound`) is implemented alongside it in
+`builtins/methods_narg/dispatch_1arg.rs`, with a matching row in the native
+method table so introspection reports it.
+
+Verified against real `raku`: the new `t/backtrace-positional-index.t` passes
+unmodified under both `raku` and `mutsu` (21 assertions covering every index
+shape above, out-of-range, `.AT-POS`, and the associative subscript staying
+undefined).
+
+## Deliberately not changed
+
+mutsu's captured backtrace has fewer frames than Rakudo's (4 vs 7 for the repro
+above) because Rakudo includes internal setting frames such as
+`SETTING::src/core.c/Exception.rakumod`'s `Exception.throw` that mutsu's frame
+capture has no equivalent for. That is a frame-model difference, not an
+indexing bug, and it is tracked separately in
+`todo/tickets/backtrace-frame-indexing-returns-nil.md`.

--- a/src/builtins/methods_narg/dispatch_1arg.rs
+++ b/src/builtins/methods_narg/dispatch_1arg.rs
@@ -507,6 +507,25 @@ pub(crate) fn native_method_1arg(
                         }
                         Some(Ok(Value::NIL))
                     }
+                    // `Backtrace` is Positional over its frames (Rakudo's
+                    // Backtrace is a List of Backtrace::Frame), so
+                    // `$!.backtrace.AT-POS($i)` reads the frame at that
+                    // position and an out-of-range index reads back as Nil.
+                    ValueView::Instance {
+                        class_name,
+                        attributes,
+                        ..
+                    } if class_name == "Backtrace" => {
+                        let frames = attributes
+                            .as_map()
+                            .get("frames")
+                            .cloned()
+                            .unwrap_or(Value::NIL);
+                        Some(Ok(crate::runtime::utils::value_to_list(&frames)
+                            .get(idx)
+                            .cloned()
+                            .unwrap_or(Value::NIL)))
+                    }
                     ValueView::Instance {
                         class_name,
                         attributes,

--- a/src/builtins/native_method_row_table.rs
+++ b/src/builtins/native_method_row_table.rs
@@ -956,6 +956,7 @@ pub(super) const RAW_ROWS: &[(&str, &str, u8, u8)] = &[
     ("Backtrace", "list", 1, 0),
     ("Backtrace", "Str", 3, 0),
     ("Backtrace", "gist", 1, 0),
+    ("Backtrace", "AT-POS", 2, 0),
     ("Backtrace::Frame", "is-routine", 1, 0),
     ("Backtrace::Frame", "subname", 1, 0),
     ("Backtrace::Frame", "is-hidden", 1, 0),

--- a/src/vm/vm_var_index_ops.rs
+++ b/src/vm/vm_var_index_ops.rs
@@ -1217,6 +1217,32 @@ impl Interpreter {
                     Value::NIL
                 }
             }
+            // `Backtrace` is Positional over its frames: `$!.backtrace[0]`,
+            // `[*-1]`, `[0..2]` and slices all index the frame list, exactly as
+            // list context already does (`runtime::utils::list` unwraps the same
+            // `frames` attribute). Rakudo keeps those frames in a List, so an
+            // out-of-range index reads back as `Nil` rather than the `Any` an
+            // Array would hand out — delegating the whole subscript to the
+            // stored `frames` List reproduces every index shape for free
+            // instead of re-deriving them per index kind here.
+            (
+                ValueView::Instance {
+                    class_name,
+                    attributes,
+                    ..
+                },
+                _,
+            ) if is_positional && class_name == "Backtrace" => {
+                let frames = attributes
+                    .as_map()
+                    .get("frames")
+                    .cloned()
+                    .unwrap_or_else(|| Value::array(vec![]));
+                let idx_clone = index.clone();
+                self.stack.push(frames);
+                self.stack.push(idx_clone);
+                return self.exec_index_op_with_positional(is_positional);
+            }
             // Instance with __baggy_data__: delegate subscript to the inner Bag/Set
             (ValueView::Instance { attributes, .. }, _)
                 if attributes.contains_key("__baggy_data__") =>

--- a/t/backtrace-positional-index.t
+++ b/t/backtrace-positional-index.t
@@ -1,0 +1,59 @@
+use v6;
+use Test;
+
+plan 21;
+
+# A Backtrace is Positional over its frames: `$bt[N]` reads the
+# Backtrace::Frame at that position, `[*-1]` the last one, and an
+# out-of-range index reads back as Nil (rakudo keeps the frames in a
+# List, not an Array). Regression pin for the bug where every positional
+# index into a Backtrace returned Nil/Any regardless of the index.
+
+sub zipi { { { die "Something bad happened" }() }() };
+try {
+    zipi;
+}
+
+my $bt = $!.backtrace;
+ok $bt.defined, 'a caught exception carries a Backtrace';
+ok $bt.elems > 0, 'the Backtrace has at least one frame';
+
+my $first = $bt[0];
+isa-ok $first, Backtrace::Frame, '$bt[0] is a Backtrace::Frame';
+ok $first.file.chars > 0, '$bt[0].file is set';
+ok $first.line > 0, '$bt[0].line is set';
+
+my $last = $bt[*-1];
+isa-ok $last, Backtrace::Frame, '$bt[*-1] is a Backtrace::Frame';
+ok $last.file.chars > 0, '$bt[*-1].file is set';
+
+is $bt[$bt.elems - 1].line, $last.line, '[*-1] is the same frame as [elems-1]';
+is $bt[*-1].subname, $bt.list[*-1].subname, '[*-1] agrees with .list[*-1]';
+is $bt[0].subname, $bt.list[0].subname, '[0] agrees with .list[0]';
+
+# Middle index, when there is one.
+if $bt.elems > 2 {
+    isa-ok $bt[1], Backtrace::Frame, '$bt[1] is a Backtrace::Frame';
+} else {
+    skip 'backtrace too short for a middle index', 1;
+}
+
+# Out of range reads back as Nil, exactly as it does off a List.
+nok $bt[$bt.elems].defined, 'an index one past the end is undefined';
+is $bt[1000].raku, Nil.raku, 'a far out-of-range index is Nil';
+
+# Every index shape a List supports works through the Backtrace too.
+is $bt[0, 1].elems, 2, 'a two-element slice yields two frames';
+is $bt[^2].elems, 2, 'a range slice yields two frames';
+is $bt[0 .. *-1].elems, $bt.elems, 'a [0 .. *-1] slice covers every frame';
+is $bt[*].elems, $bt.elems, 'a whatever slice covers every frame';
+is-deeply $bt[0, 1].map(*.line).List, $bt.list[0, 1].map(*.line).List,
+        'slice frames agree with .list';
+
+# The explicit AT-POS spelling matches the subscript.
+is $bt.AT-POS(0).line, $bt[0].line, '.AT-POS(0) matches $bt[0]';
+nok $bt.AT-POS($bt.elems).defined, '.AT-POS past the end is undefined';
+
+# An associative subscript is a different question and stays undefined.
+nok $bt<nosuchkey>.defined, 'an associative subscript on a Backtrace is undefined';
+

--- a/todo/tickets/backtrace-frame-indexing-returns-nil.md
+++ b/todo/tickets/backtrace-frame-indexing-returns-nil.md
@@ -1,8 +1,26 @@
-# `$!.backtrace[N]` positional indexing returns `Nil`, and mutsu's backtrace has fewer frames
+# mutsu's backtrace has fewer frames than Rakudo's
 
 Found by the doc-diff harness re-run (`docs/doc-diff-backlog.md`, `Type/Backtrace.rakudoc:15`).
 
-## Repro
+## Status
+
+This ticket originally covered two gaps. **Gap 1 (positional indexing) is
+fixed** — see `news/2026-08/backtrace-positional-indexing.md`. Only gap 2, the
+frame-count difference, remains open, and it is deliberately deferred (see
+"Why this is deferred" below).
+
+- [x] **Gap 1 — `$bt[N]` returned `Nil`.** Positional indexing into a
+  `Backtrace` always answered `Nil`/`Any` regardless of the index, because no
+  arm of the subscript dispatch knew about the `frames` attribute. The
+  subscript now delegates to the stored `frames` List, so every index shape
+  (single index, `[*-1]`, `[0,1]` slices, `[^2]`/`[0 .. *-1]` ranges, `[*]`,
+  and out-of-range reading back as `Nil`) behaves exactly as it does on a
+  List. `$bt.AT-POS($i)` was implemented alongside it. Pinned by
+  `t/backtrace-positional-index.t`, which passes unmodified under both `raku`
+  and `mutsu`.
+- [ ] **Gap 2 — fewer frames than Rakudo.** Still open, lower priority.
+
+## Repro (gap 2)
 
 ```raku
 sub zipi { { { die "Something bad happened" }() }() };
@@ -11,33 +29,50 @@ try {
 }
 if ($!) {
     say $!.backtrace.elems;
-    say $!.backtrace[0];
-    say $!.backtrace[*-1];
 }
 ```
 
-- `raku`: prints `7`, then two `Backtrace::Frame.new(...)` gists (one per index).
-- `mutsu` (`target/debug/mutsu`): prints `4`, then `Nil` twice — positional indexing into
-  the `Backtrace` object always returns `Nil`, regardless of index.
+- `raku`: prints `7`.
+- `mutsu`: prints `4`.
 
-## Root cause hypothesis
+Rakudo counts internal setting frames that mutsu never captures. In the repro
+above, `raku`'s frame 0 is
 
-Two separate but related gaps:
+```
+Backtrace::Frame.new(file => "SETTING::src/core.c/Exception.rakumod", line => 65,
+                     code => method throw (...), subname => "throw")
+```
 
-1. `Backtrace` positional indexing (`$bt[N]`, including the `*-1` whatever-index form)
-   is not implemented/dispatched — it falls through to a default that returns `Nil`
-   instead of returning the `Backtrace::Frame` at that position.
-2. mutsu's captured backtrace has fewer frames than raku's (4 vs 7) — raku includes
-   internal setting frames (e.g. `Exception.throw`) that mutsu's frame capture skips.
-   This is a secondary, lower-priority difference (mutsu's frame model is inherently
-   different from Rakudo's), but is worth noting since it changes what index `N` even
-   refers to.
+whereas mutsu's frame 0 is already the user-level `<unit>` block. The user-level
+frames themselves line up; Rakudo simply has more of them below and above.
 
-The `.raku` call on the indexed frame in the doc's original example
-(`$!.backtrace[*-1].raku`) never even gets reached because the indexing itself already
-returns `Nil`.
+## Why this is deferred
+
+mutsu's frame model is inherently different from Rakudo's: mutsu has no CORE
+setting written in Raku, so there is no `SETTING::src/core.c/*.rakumod` frame to
+report, and its native builtins are Rust functions rather than Raku routines
+with callframes. Matching Rakudo's count would mean synthesizing frames for
+interpreter internals that have no natural mutsu equivalent — a much larger and
+more architecturally invasive change than the indexing fix, and one that would
+make `.gist`/`.full` output *less* useful for mutsu users rather than more.
+
+The practical consequence is that a given index `N` refers to a different frame
+in mutsu than in Rakudo. Code that indexes from the end (`[*-1]`) is unaffected;
+code that hardcodes a small index expecting a setting frame will differ.
+
+## Related smaller divergence noticed while fixing gap 1
+
+`Backtrace::Frame.gist` / `.raku` do not match Rakudo's rendering:
+
+- `raku`: `Backtrace::Frame.new(file => "...", line => 3, code => -> { ... }, subname => "<unit>")`
+- `mutsu` `.gist`: the frame's `.Str` text (`  in block <unit> at f.raku line 3`)
+- `mutsu` `.raku`: a bare `Backtrace::Frame.new` with no attributes
+
+`.Str` itself matches Rakudo. Faithfully reproducing the gist is partly
+impossible (Rakudo's `code =>` renders a `Block` with its memory address) and
+partly the same frame-model question, so it is recorded here rather than fixed.
 
 ## Affected files (starting point)
 
-- Wherever `Backtrace` is implemented as a builtin type (grep for `"Backtrace"` in
-  `src/runtime/` and `src/builtins/`) — the positional/subscript dispatch for this type.
+- `src/vm/vm_helpers.rs` — `build_backtrace_value` / `backtrace_value_from_string`
+  build the frame list; this is where extra frames would have to originate.


### PR DESCRIPTION
Fixes gap 1 of `todo/tickets/backtrace-frame-indexing-returns-nil.md`.

## The bug

Positional indexing into a `Backtrace` always answered `Nil`/`Any`, regardless of the index:

```raku
sub zipi { { { die "Something bad happened" }() }() };
try { zipi; }
say $!.backtrace[0];      # was: Nil
say $!.backtrace[*-1];    # was: Nil
```

`Backtrace` was already Positional everywhere *except* the subscript. List context
unwraps its `frames` attribute (`runtime/utils/list.rs`), so `.list` / `.elems` /
`.map` / `.grep` / `.head` / `.tail` all worked -- `$bt.list[0]` answered the right
frame while `$bt[0]` did not.

## Root cause

`Backtrace` is an `Instance` holding its frames in a `frames` attribute, and no arm
of the subscript dispatch in `src/vm/vm_var_index_ops.rs` knew about it.

- An `Int` index fell through to the generic `(Instance, Int)` arm, which tries the
  class's `AT-POS`/`AT-KEY` methods. `Backtrace` had neither, so it returned `Nil`,
  which the typed-container default then turned into `Any`.
- `[*-1]` failed differently: its `(Instance, Sub)` arm derives the element count
  from a `Buf`'s bytes or a `Match`'s `list` attribute only, so a `Backtrace`
  measured as zero-length and `*-1` evaluated to `-1` -- again `Nil`.

## The fix

Rather than re-deriving every index shape for `Backtrace`, the subscript is
delegated to the stored `frames` List, the way the existing `__baggy_data__` arm
already delegates to its inner Bag/Set: push the frame list back onto the stack and
re-enter the index op.

Every index shape a List supports therefore works, and works *identically* to a
List: single index, `[*-1]`, `[0,1]` slices, `[^2]` and `[0 .. *-1]` ranges, `[*]`.
Because Rakudo keeps a Backtrace's frames in a `List` rather than an `Array`, an
out-of-range index correctly reads back as `Nil` (not the `Any` an Array hands out).
I verified up front that mutsu's List subscript already matches raku exactly on all
of these, so the delegation inherits the correct semantics rather than reimplementing
them.

The explicit `AT-POS` spelling (`$bt.AT-POS(0)`, previously an `X::Method::NotFound`)
is implemented alongside it in `builtins/methods_narg/dispatch_1arg.rs`, with a
matching row in the native method table so introspection reports it.

## Testing

- **New `t/backtrace-positional-index.t` (21 assertions) passes unmodified under both
  real `raku` and `mutsu`** -- it was run against `raku` first, so it encodes the spec
  rather than codifying mutsu's own output. Covers every index shape above,
  out-of-range, `.AT-POS`, and the associative subscript staying undefined.
- All 8 existing `t/*backtrace*.t` files pass.
- All 9 roast files mentioning `Backtrace` pass (2281 assertions): `S04-exceptions/fail.t`,
  `S32-exceptions/misc.t`, `S32-exceptions/misc2.t`, `S17-promise/start.t`,
  `S06-currying/misc.t`, `integration/error-reporting.t`, `S29-context/evalfile.t`,
  `S02-types/isDEPRECATED.t`, `S02-types/WHICH.t`.
- Full `make test`: 3368 files, 31751 tests, all pass.
- `cargo clippy -- -D warnings` and `cargo fmt` clean.

## Deliberately out of scope

Two divergences are recorded on the ticket rather than fixed here:

1. **Frame count** (gap 2, the ticket's sole remaining item). mutsu reports 4 frames
   where raku reports 7, because Rakudo includes internal setting frames such as
   `Exception.throw` from `SETTING::src/core.c/Exception.rakumod`. mutsu has no
   Raku-written CORE setting and its builtins are Rust functions without callframes,
   so there is no natural equivalent to synthesize. This is a frame-model difference,
   not an indexing bug, and matching it would be a much larger, more invasive change.
2. **`Backtrace::Frame.gist` / `.raku`** (noticed while verifying, not previously on
   the ticket). raku renders `Backtrace::Frame.new(file => ..., line => ...,
   code => ..., subname => ...)`; mutsu's `.gist` returns the frame's `.Str` text and
   `.raku` a bare `Backtrace::Frame.new`. `.Str` itself already matches raku.
   Reproducing the gist faithfully is partly impossible (raku's `code =>` embeds a
   `Block` memory address) and partly the same frame-model question.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
