### PR TITLE
fix: parse arbitrary numeric angle-word fractions

### DIFF
--- a/src/parser/primary/container/allomorph.rs
+++ b/src/parser/primary/container/allomorph.rs
@@ -206,6 +206,17 @@ fn parse_angle_rat_word(word: &str) -> Option<Value> {
     if lhs.is_empty() || rhs.is_empty() {
         return None;
     }
+
+    // Preserve exact Rat values when both parts are integers.  Going through
+    // generic division would promote large integer operands to Num, losing the
+    // numerator/denominator needed by `.raku` and by Rat stringification.
+    if let (Some(n), Some(d)) = (parse_angle_int(lhs), parse_angle_int(rhs)) {
+        return Some(crate::value::make_rat(n, d));
+    }
+    if let (Some(n), Some(d)) = (parse_angle_bigint(lhs), parse_angle_bigint(rhs)) {
+        return Some(crate::value::make_big_rat(n, d));
+    }
+
     let numer = parse_angle_numeric(lhs)?;
     let denom = parse_angle_numeric(rhs)?;
     let value = crate::builtins::arith_div(numer, denom).ok()?;

--- a/src/parser/primary/container/allomorph.rs
+++ b/src/parser/primary/container/allomorph.rs
@@ -206,18 +206,44 @@ fn parse_angle_rat_word(word: &str) -> Option<Value> {
     if lhs.is_empty() || rhs.is_empty() {
         return None;
     }
-    // Don't parse negative denominators as Rat (Raku spec: <1/-3> is Str)
-    if rhs.starts_with('-') {
+    let numer = parse_angle_numeric(lhs)?;
+    let denom = parse_angle_numeric(rhs)?;
+    let value = crate::builtins::arith_div(numer, denom).ok()?;
+    value.is_numeric().then_some(value)
+}
+
+/// Parse one of the arbitrary numeric parts accepted by a quote-word fraction.
+/// Unlike a numeric literal term, the sign belongs to the word and must be
+/// handled here rather than by the expression parser.
+fn parse_angle_numeric(word: &str) -> Option<Value> {
+    let (negative, unsigned) = match word.strip_prefix('-') {
+        Some(rest) if !rest.is_empty() => (true, rest),
+        _ => (false, word.strip_prefix('+').unwrap_or(word)),
+    };
+    if unsigned.is_empty() {
         return None;
     }
-    // Try i64 first, fall back to BigInt for large numbers
-    if let (Some(n), Some(d)) = (parse_angle_int(lhs), parse_angle_int(rhs)) {
-        return Some(crate::value::make_rat(n, d));
+
+    let value = parse_angle_inf_nan(word).or_else(|| {
+        for parse in [
+            crate::parser::primary::number::integer_no_warn,
+            crate::parser::primary::number::decimal,
+            crate::parser::primary::number::dot_decimal,
+        ] {
+            if let Ok((rest, crate::ast::Expr::Literal(value))) = parse(unsigned)
+                && rest.is_empty()
+            {
+                return Some(value);
+            }
+        }
+        parse_angle_num(unsigned)
+    })?;
+
+    if negative {
+        Some(negate_angle_numeric(value))
+    } else {
+        Some(value)
     }
-    // BigInt fallback
-    let numer = parse_angle_bigint(lhs)?;
-    let denom = parse_angle_bigint(rhs)?;
-    Some(crate::value::make_big_rat(numer, denom))
 }
 
 fn parse_angle_bigint(s: &str) -> Option<num_bigint::BigInt> {

--- a/t/allomorph-angle-bracket-whitespace.t
+++ b/t/allomorph-angle-bracket-whitespace.t
@@ -14,7 +14,7 @@ use Test;
 # mutsu used to shortcut a single space-padded fraction straight to a plain
 # `Rat`, losing the allomorph.
 
-plan 84;
+plan 86;
 
 # --- Int: allomorphic whether tight or padded --------------------------------
 
@@ -45,6 +45,11 @@ is <2/3>.^name,      'Rat',    '<2/3> is a plain Rat';
 is < 2/3 >.^name,    'RatStr', '< 2/3 > is a RatStr';
 is <1/0>.^name,      'Rat',    '<1/0> is a plain Rat';
 is < 1/0 >.^name,    'RatStr', '< 1/0 > is a RatStr';
+is <1/99999999999999999999>.gist, '0.00000000000000000001',
+    'large integer fractions retain exact Rat stringification';
+is <1/99999999999999999999>.raku,
+    '<1/99999999999999999999>',
+    'large integer fractions retain exact Rat repr';
 is +< 42/10 >, 4.2,  '< 42/10 > numeric half is the divided value';
 is ~< 42/10 >, '42/10', '< 42/10 > string half keeps the fraction spelling';
 is < 42/10 >.numerator,   21, '< 42/10 > numerator (reduced)';

--- a/t/allomorph-angle-bracket-whitespace.t
+++ b/t/allomorph-angle-bracket-whitespace.t
@@ -14,7 +14,7 @@ use Test;
 # mutsu used to shortcut a single space-padded fraction straight to a plain
 # `Rat`, losing the allomorph.
 
-plan 71;
+plan 84;
 
 # --- Int: allomorphic whether tight or padded --------------------------------
 
@@ -58,6 +58,22 @@ is <+1/2>.^name,  'Rat',    '<+1/2> is a plain Rat (signed numerator allowed)';
 is <-1/2>.^name,  'Rat',    '<-1/2> is a plain Rat';
 is <1/+3>.^name,  'RatStr', '<1/+3> is a RatStr (signed denominator is not a literal)';
 is <+1/+3>.^name, 'RatStr', '<+1/+3> is a RatStr';
+
+# Quote-word fractions divide arbitrary numeric parts. They are not literal
+# terms, so even a tightly written decimal/exponent fraction is an allomorph.
+is <1.5/2>.^name,   'RatStr', '<1.5/2> is a RatStr';
+is +<1.5/2>,        0.75,    '<1.5/2> divides a decimal numerator';
+is <1/2.5>.^name,   'RatStr', '<1/2.5> is a RatStr';
+is +<1/2.5>,        0.4,     '<1/2.5> divides a decimal denominator';
+is +<.5/2>,         0.25,    '<.5/2> accepts a leading-dot numerator';
+is +<1/.5>,         2,       '<1/.5> accepts a leading-dot denominator';
+is +<1/-3>,         -1/3,    '<1/-3> accepts a signed denominator';
+is +<-1/-3>,        1/3,     '<-1/-3> accepts signed parts';
+is <1e2/2>.^name,   'NumStr', '<1e2/2> promotes the result to NumStr';
+is +<1e2/2>,        50e0,    '<1e2/2> performs Num division';
+is <Inf/2>.^name,   'NumStr', '<Inf/2> is a NumStr';
+is +<Inf/2>,        Inf,     '<Inf/2> divides Inf';
+ok (+<NaN/2>).isNaN,          '<NaN/2> divides NaN';
 
 # --- Num: allomorphic whether tight or padded --------------------------------
 


### PR DESCRIPTION
## Summary
- parse arbitrary numeric numerator and denominator parts in angle-bracket quote-word fractions
- preserve Rat/Num promotion and signed denominators through native division
- add regression coverage for decimals, exponents, infinities, NaN, and signed parts

## Tests
- cargo clippy -- -D warnings
- make test