### PR TITLE
fix: preserve anonymous sub gist names

### DIFF
--- a/src/parser/primary/misc/anon_decl.rs
+++ b/src/parser/primary/misc/anon_decl.rs
@@ -67,11 +67,12 @@ pub(crate) fn anon_class_expr(input: &str) -> PResult<'_, Expr> {
     } else if rest.starts_with('{') {
         let id = ANON_CLASS_COUNTER.fetch_add(1, Ordering::Relaxed);
         (rest, format!("__ANON_CLASS_{id}__"), Vec::new(), Vec::new())
-    } else if rest.starts_with(|c: char| c.is_ascii_uppercase() || c == '_') {
+    } else if rest.starts_with(crate::parser::helpers::is_raku_identifier_start) {
         // Named class in expression context: `class Foo { ... }`. The name may
         // be QUALIFIED — `class X::Foo is Exception {}.new.throw` is the shape
         // roast/S04-exceptions/exceptions-alternatives.t uses — so stopping at
-        // the first `::` would leave `::Foo is Exception` unparsed.
+        // the first `::` would leave `::Foo is Exception` unparsed. Raku class
+        // names may also begin with non-ASCII identifier characters.
         let (r, class_name) = parse_qualified_ident_with_hyphens(rest)?;
         let (r, _) = ws(r)?;
         // Parse optional `is Parent` / `does Role` clauses

--- a/src/vm/vm_data_io_ops.rs
+++ b/src/vm/vm_data_io_ops.rs
@@ -26,6 +26,11 @@ fn needs_method_dispatch(v: &Value) -> bool {
         // `gist_value`/`to_str_context` fast paths would print the bare type
         // name "LazyList" instead.
         ValueView::LazyList(..) => true,
+        // Sub/Routine gist is not the same as their stringification: a named
+        // routine gists as `&name` while `.Str` remains the bare name. Route
+        // these through the native `.gist` dispatch instead of the fast
+        // string-value fallback used by the output op.
+        ValueView::Sub(..) | ValueView::WeakSub(..) | ValueView::Routine { .. } => true,
         // A collection whose gist embeds an element's gist must be rendered via
         // method dispatch when any element needs it (e.g. an instance/type-object
         // with a custom `method gist`), so the per-element gist is honored.
@@ -52,7 +57,10 @@ fn element_needs_method_dispatch(v: &Value) -> bool {
         ValueView::Instance { .. }
         | ValueView::CustomType { .. }
         | ValueView::CustomTypeInstance(_)
-        | ValueView::Package(..) => true,
+        | ValueView::Package(..)
+        | ValueView::Sub(..)
+        | ValueView::WeakSub(..)
+        | ValueView::Routine { .. } => true,
         ValueView::Array(items, _) => items.iter().any(element_needs_method_dispatch),
         ValueView::Seq(items) | ValueView::HyperSeq(items) | ValueView::RaceSeq(items) => {
             items.iter().any(element_needs_method_dispatch)

--- a/t/anon-sub-name-gist.t
+++ b/t/anon-sub-name-gist.t
@@ -1,7 +1,9 @@
 use v6;
 use Test;
+use lib $?FILE.IO.parent(2).add("roast/packages/Test-Helpers/lib");
+use Test::Util;
 
-plan 14;
+plan 19;
 
 # PLAN §8.13 leftovers: `anon sub NAME {...}` keeps its .name without
 # installing `&NAME`, and Sub gist/Str/raku render the Rakudo forms.
@@ -23,6 +25,17 @@ sub outer { 'outer' }
 my $shadow = anon sub outer { 'anon' };
 is outer(), 'outer', 'anon sub does not clobber an existing same-named sub';
 is $shadow.(), 'anon', 'the anon value itself stays callable';
+
+# Anonymous declarations accept the same Unicode identifier starts as regular
+# declarations, and say uses the named Sub's gist form.
+my $unicode-sub = anon sub þ { 42 };
+is $unicode-sub.name, 'þ', 'anon sub keeps a non-ASCII name';
+is $unicode-sub.(), 42, 'anon sub with a non-ASCII name is callable';
+is (anon class þ {}).^name, 'þ', 'anon class accepts a non-ASCII name';
+is_run 'say anon sub Foo { 42 };', { :out("&Foo\n") },
+    'say uses the named anon sub gist';
+is_run 'say anon sub þ { 42 };', { :out("&þ\n") },
+    'say uses the non-ASCII anon sub gist';
 
 # Sub rendering forms (Rakudo-compatible).
 sub named-here { }


### PR DESCRIPTION
## Summary
- accept non-ASCII identifier names for expression-position anonymous classes
- route Sub/Routine output through gist dispatch so named routines render as ampersand-prefixed names
- add regressions for Unicode anonymous names and say anon sub

## Tests
- prove -e 'target/debug/mutsu' t/anon-sub-name-gist.t
- cargo clippy -- -D warnings