### PR TITLE
fix: match raku utf8-c8 invalid byte codepoints

### DIFF
--- a/src/builtins/functions/dispatch_1arg.rs
+++ b/src/builtins/functions/dispatch_1arg.rs
@@ -258,9 +258,9 @@ pub(crate) fn native_function_1arg(name: &str, arg: &Value) -> Option<Result<Val
                 .collect();
             Some(Ok(Value::seq(parts)))
         }
-        "chars" => Some(Ok(Value::int(
-            arg.to_string_value().graphemes(true).count() as i64,
-        ))),
+        "chars" => Some(Ok(Value::int(crate::builtins::string_pos::grapheme_len(
+            &arg.to_string_value(),
+        ) as i64))),
         "chr" => {
             let (code, display) = match arg.view() {
                 ValueView::Int(i) => (i, format!("{}", i)),

--- a/src/builtins/methods_0arg/dispatch_core_unicode.rs
+++ b/src/builtins/methods_0arg/dispatch_core_unicode.rs
@@ -2,7 +2,6 @@
 /// uninames, uniparse, uniprops, unival, univals, chr, chrs
 use crate::value::{RuntimeError, Value, ValueView};
 use unicode_normalization::UnicodeNormalization;
-use unicode_segmentation::UnicodeSegmentation;
 
 use super::make_no_match_error;
 
@@ -56,7 +55,7 @@ pub(super) fn dispatch(
                 return Some(Some(Err(err)));
             }
             Some(Some(Ok(Value::int(
-                target.to_string_value().graphemes(true).count() as i64,
+                crate::builtins::string_pos::grapheme_len(&target.to_string_value()) as i64,
             ))))
         }
         "ord" => {

--- a/src/builtins/string_pos.rs
+++ b/src/builtins/string_pos.rs
@@ -22,6 +22,14 @@
 
 use unicode_segmentation::UnicodeSegmentation;
 
+fn is_utf8_c8_payload(g: &str) -> bool {
+    g == "x"
+}
+
+fn is_hex_digit(g: &str) -> bool {
+    g.len() == 1 && g.as_bytes()[0].is_ascii_hexdigit()
+}
+
 /// True when `s` has one grapheme per byte, so byte offsets *are* grapheme
 /// offsets. ASCII guarantees one byte per codepoint; the only ASCII sequence
 /// that merges two codepoints into one grapheme is `\r\n`.
@@ -35,7 +43,26 @@ pub(crate) fn grapheme_units(s: &str) -> Vec<&str> {
     if is_flat_ascii(s) {
         return (0..s.len()).map(|i| &s[i..i + 1]).collect();
     }
-    s.graphemes(true).collect()
+    let raw: Vec<(usize, &str)> = s.grapheme_indices(true).collect();
+    let mut units = Vec::with_capacity(raw.len());
+    let mut i = 0;
+    while i < raw.len() {
+        let (start, grapheme) = raw[i];
+        if grapheme == crate::runtime::utf8_c8::SYNTHETIC_MARKER_STR
+            && i + 3 < raw.len()
+            && is_utf8_c8_payload(raw[i + 1].1)
+            && is_hex_digit(raw[i + 2].1)
+            && is_hex_digit(raw[i + 3].1)
+        {
+            let end = raw[i + 3].0 + raw[i + 3].1.len();
+            units.push(&s[start..end]);
+            i += 4;
+        } else {
+            units.push(grapheme);
+            i += 1;
+        }
+    }
+    units
 }
 
 /// Convert a **byte** offset (what `str::find` returns) into the grapheme
@@ -45,7 +72,7 @@ pub(crate) fn grapheme_offset(s: &str, byte_pos: usize) -> usize {
     if is_flat_ascii(s) {
         return byte_pos;
     }
-    s[..byte_pos].graphemes(true).count()
+    grapheme_units(&s[..byte_pos]).len()
 }
 
 /// The number of graphemes in `s` — the length `index`/`substr` positions are
@@ -54,7 +81,7 @@ pub(crate) fn grapheme_len(s: &str) -> usize {
     if is_flat_ascii(s) {
         return s.len();
     }
-    s.graphemes(true).count()
+    grapheme_units(s).len()
 }
 
 #[cfg(test)]

--- a/src/runtime/utf8_c8.rs
+++ b/src/runtime/utf8_c8.rs
@@ -2,22 +2,38 @@
 //!
 //! utf8-c8 is Raku's encoding that allows round-tripping arbitrary byte
 //! sequences through strings. Valid UTF-8 is decoded normally; invalid
-//! bytes are represented as synthetic codepoints in the Supplementary
-//! Private Use Area-A (U+F0000..U+F00FF), where the low 8 bits encode
-//! the original byte value.
+//! bytes are represented as the synthetic codepoint U+10FFFD followed by
+//! `xNN`, where `NN` is the original byte in uppercase hexadecimal. Raku's
+//! grapheme handling keeps that four-codepoint sequence as one character.
 //!
-//! When encoding back to utf8-c8, characters in U+F0000..U+F00FF are
-//! emitted as the corresponding single byte, and all other characters
-//! are emitted as standard UTF-8.
+//! When encoding back to utf8-c8, the synthetic marker plus its `xNN` payload
+//! is emitted as the corresponding single byte, and all other characters are
+//! emitted as standard UTF-8.
 
-/// Base codepoint for synthetic byte representations.
-const SYNTHETIC_BASE: u32 = 0xF0000;
+/// Marker codepoint for Raku's invalid-byte grapheme representation.
+pub(crate) const SYNTHETIC_MARKER: char = '\u{10FFFD}';
+pub(crate) const SYNTHETIC_MARKER_STR: &str = "\u{10FFFD}";
+
+fn append_invalid_byte(result: &mut String, byte: u8) {
+    result.push(SYNTHETIC_MARKER);
+    result.push('x');
+    result.push(
+        char::from_digit((byte >> 4) as u32, 16)
+            .unwrap()
+            .to_ascii_uppercase(),
+    );
+    result.push(
+        char::from_digit((byte & 0x0F) as u32, 16)
+            .unwrap()
+            .to_ascii_uppercase(),
+    );
+}
 
 /// Decode a byte slice using the utf8-c8 scheme.
 ///
 /// Valid UTF-8 sequences are decoded normally. Each byte that is part of
-/// an invalid sequence is individually mapped to the synthetic codepoint
-/// U+F0000 + byte_value.
+/// an invalid sequence is represented by the synthetic marker and its `xNN`
+/// byte payload.
 pub fn decode_utf8_c8(bytes: &[u8]) -> String {
     let mut result = String::new();
     let mut i = 0;
@@ -38,12 +54,10 @@ pub fn decode_utf8_c8(bytes: &[u8]) -> String {
                     result.push_str(valid);
                     i += valid_up_to;
                 }
-                // Now bytes[i] starts an invalid sequence. Emit one synthetic char
-                // for the single bad byte.
+                // Now bytes[i] starts an invalid sequence. Emit Raku's marker
+                // plus a visible hexadecimal payload for the single bad byte.
                 let bad_byte = bytes[i];
-                let synthetic = char::from_u32(SYNTHETIC_BASE + bad_byte as u32)
-                    .expect("synthetic codepoint must be valid");
-                result.push(synthetic);
+                append_invalid_byte(&mut result, bad_byte);
                 i += 1;
             }
         }
@@ -53,20 +67,26 @@ pub fn decode_utf8_c8(bytes: &[u8]) -> String {
 
 /// Encode a utf8-c8 string back to bytes.
 ///
-/// Characters in the synthetic range U+F0000..U+F00FF are emitted as
-/// the single byte (codepoint - U+F0000). All other characters are
-/// emitted as standard UTF-8.
+/// A synthetic marker followed by `xNN` is emitted as the single byte `NN`.
+/// All other characters are emitted as standard UTF-8.
 pub fn encode_utf8_c8(s: &str) -> Vec<u8> {
     let mut result = Vec::new();
-    for ch in s.chars() {
-        let cp = ch as u32;
-        if (SYNTHETIC_BASE..=SYNTHETIC_BASE + 0xFF).contains(&cp) {
-            result.push((cp - SYNTHETIC_BASE) as u8);
-        } else {
-            let mut buf = [0u8; 4];
-            let encoded = ch.encode_utf8(&mut buf);
-            result.extend_from_slice(encoded.as_bytes());
+    let mut chars = s.chars().peekable();
+    while let Some(ch) = chars.next() {
+        if ch == SYNTHETIC_MARKER {
+            let mut payload = chars.clone();
+            if payload.next() == Some('x')
+                && let (Some(hi), Some(lo)) = (payload.next(), payload.next())
+                && let (Some(hi), Some(lo)) = (hi.to_digit(16), lo.to_digit(16))
+            {
+                result.push(((hi << 4) | lo) as u8);
+                chars = payload;
+                continue;
+            }
         }
+
+        let mut buf = [0u8; 4];
+        result.extend_from_slice(ch.encode_utf8(&mut buf).as_bytes());
     }
     result
 }
@@ -79,7 +99,8 @@ mod tests {
     fn roundtrip_simple_invalid_byte() {
         let input = vec![b'A', 0xFE, b'Z'];
         let decoded = decode_utf8_c8(&input);
-        assert_eq!(decoded.chars().count(), 3);
+        assert_eq!(decoded, "A\u{10FFFD}xFEZ");
+        assert_eq!(decoded.chars().count(), 6);
         assert_eq!(decoded.chars().next().unwrap(), 'A');
         assert_eq!(decoded.chars().last().unwrap(), 'Z');
         let encoded = encode_utf8_c8(&decoded);
@@ -90,7 +111,7 @@ mod tests {
     fn roundtrip_multiple_invalid_bytes() {
         let input = vec![b'A', 0xFE, 0xFD, b'Z'];
         let decoded = decode_utf8_c8(&input);
-        assert_eq!(decoded.chars().count(), 4);
+        assert_eq!(decoded, "A\u{10FFFD}xFE\u{10FFFD}xFDZ");
         let encoded = encode_utf8_c8(&decoded);
         assert_eq!(encoded, input);
     }
@@ -99,7 +120,7 @@ mod tests {
     fn roundtrip_trailing_invalid() {
         let input = vec![b'A', b'B', 0xFC];
         let decoded = decode_utf8_c8(&input);
-        assert_eq!(decoded.chars().count(), 3);
+        assert_eq!(decoded, "AB\u{10FFFD}xFC");
         let encoded = encode_utf8_c8(&decoded);
         assert_eq!(encoded, input);
     }
@@ -117,7 +138,7 @@ mod tests {
     fn roundtrip_mixed_valid_invalid() {
         let input = vec![b'L', 0xE9, b'o', b'n'];
         let decoded = decode_utf8_c8(&input);
-        assert_eq!(decoded.chars().count(), 4);
+        assert_eq!(decoded, "L\u{10FFFD}xE9on");
         let encoded = encode_utf8_c8(&decoded);
         assert_eq!(encoded, input);
     }

--- a/t/utf8-c8-invalid-byte-codepoint.t
+++ b/t/utf8-c8-invalid-byte-codepoint.t
@@ -1,0 +1,21 @@
+use Test;
+
+plan 8;
+
+my $decoded = Buf.new(ord('A'), 0xFE, ord('Z')).decode('utf8-c8');
+
+is $decoded.chars, 3, 'an invalid byte remains one grapheme';
+is $decoded.ords[0], ord('A'), 'valid codepoint before the invalid byte is preserved';
+is $decoded.ords[1], 0x10FFFD, 'invalid byte uses Raku\'s synthetic marker codepoint';
+is-deeply $decoded.ords[2..4], (ord('x'), ord('F'), ord('E')),
+    'invalid byte payload is rendered as uppercase hexadecimal';
+is $decoded.ords[5], ord('Z'), 'valid codepoint after the invalid byte is preserved';
+is-deeply $decoded.encode('utf8-c8').list, (ord('A'), 0xFE, ord('Z')),
+    'the synthetic marker and payload round-trip to the original byte';
+
+my $multiple = Buf.new(ord('A'), 0xFA, ord('B'), 0xFB, 0xFC, ord('C'))
+    .decode('utf8-c8');
+is $multiple.chars, 6, 'each invalid byte is one grapheme';
+is-deeply $multiple.encode('utf8-c8').list,
+    (ord('A'), 0xFA, ord('B'), 0xFB, 0xFC, ord('C')),
+    'multiple invalid bytes round-trip independently';


### PR DESCRIPTION
## Summary

- represent invalid utf8-c8 bytes with Raku's U+10FFFD + xNN sequence
- preserve utf8-c8 round-tripping and Raku grapheme counts
- add regression coverage for codepoints, payloads, and multiple invalid bytes

## Tests

- cargo clippy -- -D warnings
- cargo test runtime::utf8_c8
- prove -e 'target/debug/mutsu' t/utf8-c8-invalid-byte-codepoint.t roast/S32-str/utf8-c8.t