### PR TITLE
fix: bundle piped take arguments

### DIFF
--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -3396,6 +3396,29 @@ impl Compiler {
 
             // --- Take (gather/take) ---
             Stmt::Take(expr, is_rw) => {
+                // `take |EXPR` is a call with a flattened argument list, not
+                // `take` of a runtime Slip. Route this spelling through the
+                // ordinary call path so multiple positional arguments are
+                // bundled by the `take` builtin into one List item. The direct
+                // Take opcode must remain for `take EXPR`, where a Slip is
+                // intentionally flattened into the gather.
+                if !*is_rw
+                    && matches!(
+                        expr,
+                        Expr::Unary {
+                            op: crate::token_kind::TokenKind::Pipe,
+                            ..
+                        }
+                    )
+                {
+                    let call = Expr::Call {
+                        name: Symbol::intern("take"),
+                        args: vec![expr.clone()],
+                    };
+                    self.compile_expr(&call);
+                    self.code.emit(OpCode::Pop);
+                    return;
+                }
                 if *is_rw {
                     // `take-rw <lvalue>`: capture the source container (a shared
                     // `ContainerRef` cell), not a snapshot, so the gathered value

--- a/t/take-pipe-slip-over-flattens.t
+++ b/t/take-pipe-slip-over-flattens.t
@@ -1,0 +1,17 @@
+use Test;
+
+plan 8;
+
+my $pipe = gather { take |(1, 2) };
+is $pipe.elems, 1, 'take with a pipe produces one gathered item';
+is $pipe[0].raku, '(1, 2)', 'the pipe arguments are bundled into one List';
+is-deeply $pipe[0].list, (1, 2), 'the bundled List keeps both positional values';
+
+my $slip = gather { take (1, 2).Slip };
+is $slip.elems, 2, 'take of an explicit Slip still flattens';
+is-deeply $slip.list, (1, 2), 'the explicit Slip produces separate gathered items';
+
+my $looped = gather for 1 .. 10 -> $a, $b { take |($a, $b) };
+is $looped.elems, 5, 'each piped take contributes one item';
+is $looped[0].raku, '(1, 2)', 'the first looped piped take is bundled';
+is $looped[4].raku, '(9, 10)', 'the last looped piped take is bundled';


### PR DESCRIPTION
## Summary

- preserve the distinction between  and 
- route piped take arguments through normal call expansion so multiple positional values become one List item
- add regression coverage for direct, slipped, and looped gathers

## Tests

- cargo clippy -- -D warnings
- prove -e 'target/debug/mutsu' t/take-pipe-slip-over-flattens.t