### PR TITLE
fix: emit value before supply done

### DIFF
--- a/src/parser/stmt/simple/control_stmts.rs
+++ b/src/parser/stmt/simple/control_stmts.rs
@@ -566,6 +566,29 @@ pub(crate) fn known_call_stmt(input: &str) -> PResult<'_, Stmt> {
         } else {
             rest
         };
+        // `done VALUE` is shorthand for `emit VALUE; done`. Keep the payload
+        // as a separate statement so supply's existing lowering can rewrite
+        // both operations to the current emitter. Parenthesised `done()` is
+        // deliberately still the no-payload control-flow form above.
+        if had_ws
+            && !rest.is_empty()
+            && !rest.starts_with(';')
+            && !rest.starts_with('}')
+            && !is_stmt_modifier_keyword(rest)
+        {
+            let (rest, value) =
+                crate::parser::stmt::assign::parse_comma_or_expr_no_word_logical(rest)?;
+            return parse_statement_modifier(
+                rest,
+                Stmt::SyntheticBlock(vec![
+                    Stmt::Call {
+                        name: Symbol::intern("emit"),
+                        args: vec![crate::ast::CallArg::Positional(value)],
+                    },
+                    Stmt::ReactDone,
+                ]),
+            );
+        }
         // Support statement modifiers like `done if $v >= 2`
         return parse_statement_modifier(rest, Stmt::ReactDone);
     }

--- a/t/supply-done-value-emits.t
+++ b/t/supply-done-value-emits.t
@@ -1,0 +1,14 @@
+use Test;
+
+plan 2;
+
+# `done VALUE` is shorthand for emitting VALUE and then completing the supply.
+my @got;
+my $done = False;
+supply { emit 1; done 20 + 22 }.tap(
+    -> $value { @got.push($value) },
+    done => { $done = True },
+);
+
+is @got, [1, 42], '`done VALUE` emits its value before completing';
+ok $done, '`done VALUE` still completes the supply';


### PR DESCRIPTION
Fix done VALUE in supply blocks by lowering it to emit VALUE followed by done. Add a regression test covering expression payloads, delivery, and completion.\n\nTests: cargo build; cargo clippy -- -D warnings; prove -v -e target/debug/mutsu t/supply-done-value-emits.t t/emit-done-controlflow.t t/supply-done-in-method-supply-block.t t/supply-done-detection-is-per-supplier.t