### PR TITLE
fix: preserve submethod routine type

### DIFF
--- a/src/runtime/accessors_resolve.rs
+++ b/src/runtime/accessors_resolve.rs
@@ -350,6 +350,26 @@ impl Interpreter {
                     }
                     return Value::NIL;
                 }
+                if frame.is_submethod {
+                    let mut env = crate::env::Env::new();
+                    env.insert(
+                        "__mutsu_callable_type".to_string(),
+                        Value::str_from("Submethod"),
+                    );
+                    env.insert(
+                        "__mutsu_routine_name".to_string(),
+                        Value::str(format!("{}::{}", frame.package, frame.name)),
+                    );
+                    return Value::make_sub(
+                        frame.package,
+                        frame.name,
+                        Vec::new(),
+                        Vec::new(),
+                        Vec::new(),
+                        false,
+                        env,
+                    );
+                }
                 return Value::routine_parts(frame.package, frame.name, false);
             }
             return Value::NIL;

--- a/src/runtime/accessors_stack.rs
+++ b/src/runtime/accessors_stack.rs
@@ -52,6 +52,7 @@ impl Interpreter {
             line,
             file,
             is_method: false,
+            is_submethod: false,
             is_block: false,
             def_file,
             invocation_id: crate::runtime::next_invocation_id(),
@@ -65,6 +66,7 @@ impl Interpreter {
     /// this, `executing_source_file()`'s frame walk always fell through past a
     /// method frame to the dynamically-scoped `?FILE`, which had already
     /// reverted to the main script by the time the method ran.
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn push_method_routine_with_location(
         &mut self,
         package: Symbol,
@@ -73,6 +75,7 @@ impl Interpreter {
         line: Option<u32>,
         file: Option<Symbol>,
         def_file: Option<Symbol>,
+        is_submethod: bool,
     ) {
         self.routine_stack.push(super::RoutineFrame {
             package,
@@ -81,6 +84,7 @@ impl Interpreter {
             line,
             file,
             is_method: true,
+            is_submethod,
             is_block: false,
             def_file,
             invocation_id: crate::runtime::next_invocation_id(),
@@ -106,6 +110,7 @@ impl Interpreter {
             line,
             file,
             is_method: false,
+            is_submethod: false,
             is_block: true,
             def_file,
             invocation_id: crate::runtime::next_invocation_id(),

--- a/src/runtime/builtins_operators_fallback.rs
+++ b/src/runtime/builtins_operators_fallback.rs
@@ -617,6 +617,7 @@ impl Interpreter {
                 line: None,
                 file: None,
                 is_method: false,
+                is_submethod: false,
                 is_block: false,
                 def_file: None,
                 invocation_id: crate::runtime::next_invocation_id(),

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -242,6 +242,7 @@ impl Interpreter {
             line: None,
             file: None,
             is_method: false,
+            is_submethod: false,
             is_block: false,
             def_file: None,
             invocation_id: crate::runtime::next_invocation_id(),

--- a/src/runtime/dispatch_proto.rs
+++ b/src/runtime/dispatch_proto.rs
@@ -201,6 +201,7 @@ impl Interpreter {
             line: None,
             file: None,
             is_method: false,
+            is_submethod: false,
             is_block: false,
             def_file: None,
             invocation_id: crate::runtime::next_invocation_id(),

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1100,6 +1100,8 @@ pub(crate) struct RoutineFrame {
     pub line: Option<u32>,
     pub file: Option<Symbol>,
     pub is_method: bool,
+    /// Whether this method frame belongs to a `submethod` declaration.
+    pub is_submethod: bool,
     /// Whether this frame is a block/closure (not a named routine).
     pub is_block: bool,
     /// The file this routine's BODY lives in (None = same as the caller /

--- a/src/runtime/regex/regex_token_resolve.rs
+++ b/src/runtime/regex/regex_token_resolve.rs
@@ -383,6 +383,7 @@ impl Interpreter {
                     line: None,
                     file: None,
                     is_method: false,
+                    is_submethod: false,
                     is_block: false,
                     def_file: None,
                     invocation_id: crate::runtime::next_invocation_id(),

--- a/src/runtime/resolution_call_sub.rs
+++ b/src/runtime/resolution_call_sub.rs
@@ -650,6 +650,7 @@ impl Interpreter {
                 line: None,
                 file: None,
                 is_method: false,
+                is_submethod: false,
                 is_block: true,
                 def_file: None,
                 invocation_id: crate::runtime::next_invocation_id(),

--- a/src/runtime/seq_helpers/smart_match.rs
+++ b/src/runtime/seq_helpers/smart_match.rs
@@ -433,6 +433,7 @@ impl Interpreter {
                         line: None,
                         file: None,
                         is_method: false,
+                        is_submethod: false,
                         is_block: false,
                         def_file: None,
                         invocation_id: crate::runtime::next_invocation_id(),

--- a/src/vm/vm_method_dispatch.rs
+++ b/src/vm/vm_method_dispatch.rs
@@ -691,6 +691,7 @@ impl Interpreter {
             self.current_source_line(),
             self.current_source_file_sym(),
             method_def.source_file.as_deref().map(Symbol::intern),
+            method_def.is_submethod,
         );
 
         // Execute bytecode
@@ -1687,6 +1688,7 @@ impl Interpreter {
             self.current_source_line(),
             self.current_source_file_sym(),
             method_def.source_file.as_deref().map(Symbol::intern),
+            method_def.is_submethod,
         );
 
         // Execute bytecode (same as slow path)

--- a/t/routine-submethod-routine-name-wrong.t
+++ b/t/routine-submethod-routine-name-wrong.t
@@ -1,0 +1,11 @@
+use Test;
+
+plan 2;
+
+class Foo {
+    submethod bar { &?ROUTINE.^name }
+    method baz { &?ROUTINE.^name }
+}
+
+is Foo.bar, 'Submethod', '&?ROUTINE.^name identifies a submethod';
+is Foo.baz, 'Method', '&?ROUTINE.^name still identifies a regular method';


### PR DESCRIPTION
Preserve submethod identity in the active routine frame so &?ROUTINE.^name reports Submethod instead of Method. Regular methods retain their existing Method identity. Add a focused regression test.\n\nTests: cargo build; cargo clippy -- -D warnings; prove -v -e target/debug/mutsu t/routine-submethod-routine-name-wrong.t t/declarator-trailing-wherefore.t t/classhow-lookup-method-instance-callable.t t/can-does.t