### PR TITLE
fix: interpolate named placeholder variables

### DIFF
--- a/src/parser/primary/string/interp_var.rs
+++ b/src/parser/primary/string/interp_var.rs
@@ -358,6 +358,11 @@ pub(crate) fn try_interpolate_var<'a>(
             || next == '?'
             || next == '!'
             || next == '^'
+            || (next == ':'
+                && rest[2..]
+                    .chars()
+                    .next()
+                    .is_some_and(crate::parser::helpers::is_raku_identifier_start))
         {
             if !current.is_empty() {
                 parts.push(Expr::Literal(literal_str(std::mem::take(current))));

--- a/src/parser/primary/var/scalar.rs
+++ b/src/parser/primary/var/scalar.rs
@@ -77,11 +77,16 @@ pub(in crate::parser) fn parse_symbolic_deref_segments(
 
 /// Parse a variable name from raw string (used in interpolation).
 pub(crate) fn parse_var_name_from_str(input: &str) -> (&str, String) {
-    // Handle twigils: $*, $?, $!, $^
+    // Handle twigils: $*, $?, $!, $^, $:
     let (rest, twigil) = if input.starts_with('*')
         || input.starts_with('?')
         || input.starts_with('!')
         || input.starts_with('^')
+        || (input.starts_with(':')
+            && input[1..]
+                .chars()
+                .next()
+                .is_some_and(is_raku_identifier_start))
     {
         (&input[1..], &input[..1])
     } else {

--- a/t/named-placeholder-string-interpolation.t
+++ b/t/named-placeholder-string-interpolation.t
@@ -1,0 +1,12 @@
+use v6;
+use Test;
+
+plan 2;
+
+sub bare-named-placeholder { $:foo }
+sub string-named-placeholder { "$:foo" }
+
+is &bare-named-placeholder.assuming(foo => 42)(), 42,
+    'named placeholder works as a bare variable';
+is &string-named-placeholder.assuming(foo => 42)(), '42',
+    'named placeholder interpolates inside a double-quoted string';


### PR DESCRIPTION
## Summary

- recognize the `$:name` named-placeholder twigil in double-quoted interpolation
- keep interpolation variable parsing consistent with ordinary scalar parsing
- add a regression test covering bare and interpolated named placeholders

## Tests

- cargo check
- cargo clippy -- -D warnings
- targeted string/interpolation TAP tests (31 tests)