### PR TITLE
fix: honor metaclass methods all flag

### DIFF
--- a/src/runtime/methods_classhow_builtin_methods.rs
+++ b/src/runtime/methods_classhow_builtin_methods.rs
@@ -107,8 +107,13 @@ impl Interpreter {
                 self.collect_class_methods(cn, private, &mut result);
             }
 
-            // For built-in types that don't have class defs, add known methods
-            if result.is_empty() || !self.registry().classes.contains_key(&class_name) {
+            // For built-in types that don't have class defs, add known methods.
+            // `:all` also exposes the universal Any/Mu methods for user-defined
+            // classes. The MRO walk above visits those names, but they are
+            // native catalog entries rather than registry ClassDefs, so the
+            // normal user-class result is non-empty and the old condition
+            // skipped them entirely.
+            if all || result.is_empty() || !self.registry().classes.contains_key(&class_name) {
                 self.collect_builtin_type_methods(&class_name, &mut result);
                 if all {
                     self.collect_builtin_type_methods("Any", &mut result);

--- a/t/metaclass-methods-all.t
+++ b/t/metaclass-methods-all.t
@@ -1,0 +1,20 @@
+use Test;
+
+plan 4;
+
+class ParentForMethodsAll {
+    method inherited { 'inherited' }
+}
+class ChildForMethodsAll is ParentForMethodsAll {
+    method own { 'own' }
+}
+
+my @ordinary = ChildForMethodsAll.^methods.map(*.name);
+my @all = ChildForMethodsAll.^methods(:all).map(*.name);
+
+ok 'own' (elem) @ordinary, 'ordinary .^methods includes the class method';
+ok 'inherited' (elem) @ordinary, 'ordinary .^methods includes user-defined ancestors';
+ok 'serial' (elem) @all, '.^methods(:all) includes universal Any methods';
+ok !('serial' (elem) @ordinary), 'ordinary .^methods does not include universal Any methods';
+
+done-testing;


### PR DESCRIPTION
## Summary

- include universal Any/Mu methods in `.^methods(:all)` for user-defined classes
- add a regression test covering inherited and universal methods

## Tests

- `/tmp/mutsu-codex-check/debug/mutsu t/metaclass-methods-all.t`
- `cargo clippy --target-dir /tmp/mutsu-codex-check -- -D warnings`
- pre-commit hooks: clippy and fmt