### PR TITLE
fix: preserve condition wait predicate captures

### DIFF
--- a/src/runtime/native_methods/concurrency.rs
+++ b/src/runtime/native_methods/concurrency.rs
@@ -211,7 +211,7 @@ impl Interpreter {
                     }
                 }
                 if let Some(test) = maybe_test.clone()
-                    && self.call_sub_value(test, Vec::new(), false)?.truthy()
+                    && self.call_protect_block(&test)?.truthy()
                 {
                     return Ok(Value::NIL);
                 }
@@ -234,7 +234,8 @@ impl Interpreter {
                     drop(state);
 
                     let predicate_ok = if let Some(test) = maybe_test.clone() {
-                        self.call_sub_value(test, Vec::new(), false)?.truthy()
+                        let value = self.call_protect_block(&test)?;
+                        value.truthy()
                     } else {
                         true
                     };

--- a/t/loop-scoped-lock-condition.t
+++ b/t/loop-scoped-lock-condition.t
@@ -1,0 +1,40 @@
+use Test;
+
+plan 2;
+
+my @results;
+
+for 1..1 -> $iter {
+    my $lock = Lock.new;
+    my $condition = $lock.condition;
+    my $done = 0;
+    Thread.start({
+        sleep 0.1;
+        $lock.protect({
+            $done = 1;
+            $condition.signal;
+        });
+    });
+    $lock.protect({ $condition.wait({ $done == 1 }) });
+    @results.push($done);
+}
+
+while @results.elems < 2 {
+    my $lock = Lock.new;
+    my $condition = $lock.condition;
+    my $done = 0;
+    Thread.start({
+        sleep 0.1;
+        $lock.protect({
+            $done = 1;
+            $condition.signal;
+        });
+    });
+    $lock.protect({ $condition.wait({ $done == 1 }) });
+    @results.push($done);
+}
+
+is @results, [1, 1], 'loop-scoped Lock condition variables share captured state';
+ok True, 'for and while loop bodies complete after the signal';
+
+done-testing;


### PR DESCRIPTION
## Summary

- evaluate condition-variable wait predicates through the protect-block path so loop-scoped captured state remains live
- add for/while regression coverage for Lock, condition, and Thread.start rendezvous

## Tests

- `/tmp/mutsu-codex-check/debug/mutsu t/loop-scoped-lock-condition.t`
- `/tmp/mutsu-codex-check/debug/mutsu t/lock.t`
- `/tmp/mutsu-codex-check/debug/mutsu t/concurrency-threading.t`
- `cargo clippy --target-dir /tmp/mutsu-codex-check -- -D warnings`
- pre-commit hooks: clippy and fmt