### PR TITLE
Fix labeled next/last in repeat while loops

### DIFF
--- a/src/parser/stmt/control/labeled_loop.rs
+++ b/src/parser/stmt/control/labeled_loop.rs
@@ -19,6 +19,7 @@ pub(crate) fn labeled_loop_stmt(input: &str) -> PResult<'_, Stmt> {
         && !rest.starts_with("while")
         && !rest.starts_with("until")
         && !rest.starts_with("loop")
+        && !rest.starts_with("repeat")
         && !rest.starts_with("do")
     {
         return Err(PError::expected("labeled loop"));
@@ -91,6 +92,34 @@ pub(crate) fn labeled_loop_stmt(input: &str) -> PResult<'_, Stmt> {
         // { ... }` header and the infinite `loop { ... }` form are handled, then
         // stamp the label onto the returned loop node.
         let (r, stmt) = loop_stmt(rest)?;
+        if let Stmt::Loop {
+            init,
+            cond,
+            step,
+            body,
+            repeat,
+            ..
+        } = stmt
+        {
+            return Ok((
+                r,
+                Stmt::Loop {
+                    init,
+                    cond,
+                    step,
+                    body,
+                    repeat,
+                    label: Some(label),
+                },
+            ));
+        }
+        return Ok((r, stmt));
+    }
+    if keyword("repeat", rest).is_some() {
+        // Delegate to `repeat_stmt` so both `repeat while/until` and
+        // `repeat { ... } while/until` forms are handled, then stamp the
+        // label onto the returned loop node.
+        let (r, stmt) = repeat_stmt(rest)?;
         if let Stmt::Loop {
             init,
             cond,

--- a/t/labeled-repeat-loop-control.t
+++ b/t/labeled-repeat-loop-control.t
@@ -1,0 +1,17 @@
+use Test;
+
+plan 2;
+
+{
+    my $completed = False;
+    OUTSIDE-NEXT: repeat { next OUTSIDE-NEXT } while False;
+    $completed = True;
+    ok $completed, 'next LABEL exits a labeled repeat/while loop';
+}
+
+{
+    my $completed = False;
+    OUTSIDE-LAST: repeat { last OUTSIDE-LAST } while False;
+    $completed = True;
+    ok $completed, 'last LABEL exits a labeled repeat/while loop';
+}


### PR DESCRIPTION
## Summary
- preserve labels when parsing repeat loops
- add regression coverage for labeled next and last

## Test evidence
- `/tmp/mutsu-codex-check/debug/mutsu t/labeled-repeat-loop-control.t`
- `/tmp/mutsu-codex-check/debug/mutsu t/loop-control-without-loop.t`
- `cargo clippy -- -D warnings`
- `cargo fmt --all`