### PR TITLE
Fix self-referential gather junction stack overflow

### DIFF
--- a/src/value/value_lazy.rs
+++ b/src/value/value_lazy.rs
@@ -182,6 +182,7 @@ impl LazyList {
                     ll.coroutine.is_some() || ll.is_from_gather() || !ll.body.is_empty()
                 }
             }
+            ValueView::Junction { values, .. } => values.iter().all(Self::value_source_is_finite),
             _ => false,
         }
     }

--- a/src/vm/vm_native_dispatch.rs
+++ b/src/vm/vm_native_dispatch.rs
@@ -654,6 +654,32 @@ impl Interpreter {
             .any(|a| matches!(a.view(), ValueView::LazyList(_)))
         {
             let name = name_sym.resolve();
+            if matches!(name.as_str(), "any" | "all" | "one" | "none") {
+                // Junction constructors need concrete eigenstates. In
+                // particular, a finite gather/map/grep pipeline must be
+                // reified while the RHS is still being evaluated: otherwise
+                // an assignment such as `$j = any (gather $j».take).grep(...)`
+                // stores the pipeline itself as an eigenstate, and forcing it
+                // later observes the newly assigned (self-referential)
+                // junction and recurses forever. Leave genuinely infinite
+                // lazy sources untouched rather than attempting to exhaust
+                // them here.
+                let mut forced_args = Vec::with_capacity(args.len());
+                for arg in args {
+                    if let ValueView::LazyList(ll) = arg.view()
+                        && ll.is_from_gather()
+                        && !ll.is_lazy_infinite()
+                    {
+                        match self.force_lazy_list_vm(&ll) {
+                            Ok(items) => forced_args.push(Value::seq(items)),
+                            Err(e) => return Some(Err(e)),
+                        }
+                    } else {
+                        forced_args.push(arg.clone());
+                    }
+                }
+                return crate::builtins::native_function(name_sym, &forced_args);
+            }
             if matches!(name.as_str(), "flat" | "eager") {
                 // For `flat`, a single lazy argument stays lazy (`flat 42 xx *`
                 // / `flat 10,11 ... *` propagate `.is-lazy`). The one exception

--- a/t/junction-self-referential-gather.t
+++ b/t/junction-self-referential-gather.t
@@ -1,0 +1,9 @@
+use Test;
+
+plan 1;
+
+sub calc ($_) { 99 when 13 }
+my $j = any 1..5;
+$j = any (gather $j».take).grep: { Nil !=== calc $_ };
+lives-ok { $j == 3 },
+    'forcing a junction built from a self-referential gather does not recurse';


### PR DESCRIPTION
## Summary
- reify finite gather-derived inputs before native junction construction
- keep genuinely infinite lazy sources lazy
- add regression coverage for self-referential gather junction comparison

## Test evidence
- `target/debug/mutsu t/junction-self-referential-gather.t`
- `target/debug/mutsu t/junction-gist-in-list.t`
- `cargo clippy -- -D warnings`
- `cargo fmt --all`

The expected value difference involving `when` returning Nil is tracked separately; this regression verifies that forcing the junction no longer overflows the stack.