### PR TITLE
fix: support Perlin noise language constructs

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -2895,14 +2895,8 @@ pub(crate) fn make_anon_sub(stmts: Vec<Stmt>) -> Expr {
         // empty `-> {}` signature, which still rejects positional arguments.
         let body_debug = format!("{stmts:?}");
         let uses_at_underscore = body_debug.contains("ArrayVar(\"_\")");
-        let uses_percent_underscore = body_debug.contains("HashVar(\"_\")");
-        if uses_at_underscore || uses_percent_underscore {
-            let legacy_params = [(uses_at_underscore, "@_"), (uses_percent_underscore, "%_")];
-            let legacy_params: Vec<_> = legacy_params
-                .into_iter()
-                .filter(|(used, _)| *used)
-                .map(|(_, name)| name.to_string())
-                .collect();
+        if uses_at_underscore {
+            let legacy_params = vec!["@_".to_string()];
             let param_defs = legacy_params
                 .iter()
                 .map(|name| ParamDef {

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -2890,6 +2890,53 @@ pub(crate) fn has_var_decl(stmts: &[Stmt], name: &str) -> bool {
 pub(crate) fn make_anon_sub(stmts: Vec<Stmt>) -> Expr {
     let placeholders = collect_placeholders_shallow(&stmts);
     if placeholders.is_empty() {
+        // A signature-less block has an implicit `*@_` when it reads the
+        // legacy argument array. Keep that distinction from an explicitly
+        // empty `-> {}` signature, which still rejects positional arguments.
+        let body_debug = format!("{stmts:?}");
+        let uses_at_underscore = body_debug.contains("ArrayVar(\"_\")");
+        let uses_percent_underscore = body_debug.contains("HashVar(\"_\")");
+        if uses_at_underscore || uses_percent_underscore {
+            let legacy_params = [(uses_at_underscore, "@_"), (uses_percent_underscore, "%_")];
+            let legacy_params: Vec<_> = legacy_params
+                .into_iter()
+                .filter(|(used, _)| *used)
+                .map(|(_, name)| name.to_string())
+                .collect();
+            let param_defs = legacy_params
+                .iter()
+                .map(|name| ParamDef {
+                    name: name.clone(),
+                    default: None,
+                    multi_invocant: true,
+                    required: false,
+                    named: false,
+                    slurpy: true,
+                    double_slurpy: false,
+                    onearg: false,
+                    sigilless: false,
+                    type_constraint: None,
+                    literal_value: None,
+                    sub_signature: None,
+                    where_constraint: None,
+                    traits: Vec::new(),
+                    optional_marker: false,
+                    outer_sub_signature: None,
+                    code_signature: None,
+                    is_invocant: false,
+                    shape_constraints: None,
+                    block_param: true,
+                })
+                .collect();
+            return Expr::AnonSubParams {
+                params: legacy_params,
+                param_defs,
+                return_type: None,
+                body: stmts,
+                is_rw: false,
+                is_whatever_code: false,
+            };
+        }
         Expr::AnonSub {
             body: stmts,
             is_rw: false,

--- a/src/compiler/expr_call.rs
+++ b/src/compiler/expr_call.rs
@@ -402,6 +402,10 @@ impl Compiler {
             let tmp_idx = self.code.add_constant(Value::str(tmp_name.clone()));
             self.code.emit(OpCode::Dup);
             self.code.emit(OpCode::SetGlobal(tmp_idx));
+            // SetGlobal preserves the value for expression context. The
+            // assignment loop reads the snapshot through tmp_name, so the
+            // duplicate must not remain below the later call arguments.
+            self.code.emit(OpCode::Pop);
             // List assignment copies RHS *values* into the LHS containers, and
             // the whole RHS is decontainerized into a value buffer BEFORE any LHS
             // is written (`($p, $q) = ($q, $p)` swaps, `($a, $b) = ($x, ++$x)`
@@ -480,6 +484,7 @@ impl Compiler {
                             });
                         }
                         self.emit_assign_local_or_name(var_name);
+                        self.code.emit(OpCode::Pop);
                         offset += 1;
                     }
                     Expr::ArrayVar(var_name) => {
@@ -498,6 +503,7 @@ impl Compiler {
                         };
                         self.compile_expr(&rhs_expr);
                         self.emit_assign_local_or_name(&format!("@{}", var_name));
+                        self.code.emit(OpCode::Pop);
                         seen_slurpy = true;
                     }
                     Expr::HashVar(var_name) => {
@@ -517,6 +523,7 @@ impl Compiler {
                         };
                         self.compile_expr(&rhs_expr);
                         self.emit_assign_local_or_name(&format!("%{}", var_name));
+                        self.code.emit(OpCode::Pop);
                         seen_slurpy = true;
                     }
                     Expr::Index {

--- a/src/parser/stmt/decl/destructure.rs
+++ b/src/parser/stmt/decl/destructure.rs
@@ -452,6 +452,9 @@ fn parse_destructuring_with_rhs(
     // optional trailing `;` when there is no such block.
     let (rest_ws, _) = ws(rest)?;
     let has_following_block = rest_ws.starts_with('{');
+    let rhs_ends_with_block = matches!(raw_rhs, Expr::DoBlock { .. } | Expr::DoStmt(_));
+    let block_rhs_ends_at_newline =
+        rhs_ends_with_block && rest[..rest.len() - rest_ws.len()].contains('\n');
     let rest = if has_following_block { rest } else { rest_ws };
 
     let has_named = vars.iter().any(|v| v.is_named);
@@ -618,7 +621,7 @@ fn parse_destructuring_with_rhs(
     // constrained decl block-final and skip its check. (subtypes.t 90)
     stmts.push(Stmt::Expr(Expr::ArrayVar(array_bare)));
     let block = Stmt::SyntheticBlock(stmts);
-    if has_following_block {
+    if has_following_block || block_rhs_ends_at_newline {
         // In `if my ($a, $b) = f() { ... }`, the braced block belongs to the
         // surrounding conditional, not to this declaration's modifier parser.
         Ok((rest, block))

--- a/src/parser/stmt/decl/destructure.rs
+++ b/src/parser/stmt/decl/destructure.rs
@@ -1,6 +1,7 @@
 use super::super::super::expr::expression;
 use super::super::super::helpers::{ws, ws1};
 use super::super::super::parse_result::{PError, PResult, opt_char, parse_char};
+use super::super::parse_statement_modifier;
 use super::super::{ident, keyword, var_name};
 use super::helpers::register_term_symbol_from_decl_name;
 use super::parse_decl_type_constraint;
@@ -450,11 +451,8 @@ fn parse_destructuring_with_rhs(
     // matching the scalar `if my $x = f() { ... }` path. Only consume the
     // optional trailing `;` when there is no such block.
     let (rest_ws, _) = ws(rest)?;
-    let rest = if rest_ws.starts_with('{') {
-        rest
-    } else {
-        opt_char(rest_ws, ';').0
-    };
+    let has_following_block = rest_ws.starts_with('{');
+    let rest = if has_following_block { rest } else { rest_ws };
 
     let has_named = vars.iter().any(|v| v.is_named);
 
@@ -619,7 +617,14 @@ fn parse_destructuring_with_rhs(
     // ...` whose trailing `MarkSigillessReadonly` would otherwise leave a
     // constrained decl block-final and skip its check. (subtypes.t 90)
     stmts.push(Stmt::Expr(Expr::ArrayVar(array_bare)));
-    Ok((rest, Stmt::SyntheticBlock(stmts)))
+    let block = Stmt::SyntheticBlock(stmts);
+    if has_following_block {
+        // In `if my ($a, $b) = f() { ... }`, the braced block belongs to the
+        // surrounding conditional, not to this declaration's modifier parser.
+        Ok((rest, block))
+    } else {
+        parse_statement_modifier(rest, block)
+    }
 }
 
 /// Return the default expression for a native type, or Nil for non-native types.

--- a/t/list-assignment-composition.t
+++ b/t/list-assignment-composition.t
@@ -1,6 +1,6 @@
 use Test;
 
-plan 8;
+plan 9;
 
 # Assignment expressions must leave exactly their value on the VM stack.
 {
@@ -30,6 +30,12 @@ plan 8;
     my $value = 0;
     my ($a, $b) = $_, $_ + 1 given 10;
     is "$a/$b", '10/11', 'given applies to a destructuring declaration';
+    my ($e, $f) = do given True {
+        when True { 30, 40 }
+        default { 0, 0 }
+    }
+    my $after-do-given = $e == 30 && $f == 40;
+    ok $after-do-given, 'a statement after do-given does not capture the declaration';
     my ($c, $d) = 20, 21;
     is "$c/$d", '20/21', 'plain destructuring remains unchanged';
 }

--- a/t/list-assignment-composition.t
+++ b/t/list-assignment-composition.t
@@ -1,0 +1,35 @@
+use Test;
+
+plan 8;
+
+# Assignment expressions must leave exactly their value on the VM stack.
+{
+    sub show($a, $b) { "$a/$b" }
+    my ($x, $y);
+    is show(42, (($x, $y) = 3, 4)), '42/3 4',
+        'nested list assignment does not steal a preceding argument';
+    is (($x, $y) = (5, 6)).join(','), '5,6',
+        'list assignment still returns its assigned list';
+}
+
+# A signature-less block has an implicit flattening *@_ when it uses @_.
+{
+    is { @_.elems }((1, 2, 3)), 3,
+        'signature-less block flattens a List into @_';
+    my @items = 4, 5, 6;
+    is { @_.elems }(@items), 3,
+        'signature-less block flattens an Array into @_';
+    is { @_.elems }('abc'.comb), 3,
+        'signature-less block flattens a Seq into @_';
+    is { @_[0] }(9, 8), 9,
+        'signature-less block keeps ordinary positional arguments';
+}
+
+# Destructuring declarations accept statement modifiers like scalar declarations.
+{
+    my $value = 0;
+    my ($a, $b) = $_, $_ + 1 given 10;
+    is "$a/$b", '10/11', 'given applies to a destructuring declaration';
+    my ($c, $d) = 20, 21;
+    is "$c/$d", '20/21', 'plain destructuring remains unchanged';
+}


### PR DESCRIPTION
## Summary
- fix list-assignment stack leaks in composed call expressions
- flatten iterable arguments into the implicit at-underscore of signature-less blocks
- parse given and other statement modifiers after destructuring declarations
- add focused regression coverage without copying the Rosetta Code source

Fixes #6847.

## Tests
- cargo test
- cargo clippy -- -D warnings
- make test (3,397 files; two unrelated existing failures: io-path-smartmatch-permissions.t and prelude-helper-not-block-lexical.t; the new and affected destructuring tests pass)