### PR TITLE
fix: pull lazy zip operands

### DIFF
--- a/src/vm/vm_meta_ops.rs
+++ b/src/vm/vm_meta_ops.rs
@@ -96,18 +96,17 @@ impl Interpreter {
                 };
                 let lazy_inputs = value_is_lazy(&left) || value_is_lazy(&right);
                 let lazy_limit = 256usize;
-                let left_list = if value_is_lazy(&left) {
-                    let iter = self.zip_iter_from_value(&left, lazy_limit)?;
-                    (0..iter.len()).map(|i| iter.nth(i)).collect()
-                } else {
-                    runtime::value_to_list(&left)
+                let materialize_side = |v: &Value| -> Vec<Value> {
+                    if value_is_lazy(v) {
+                        let iter = ZipIter::from_value(v);
+                        let len = iter.len().min(lazy_limit);
+                        (0..len).map(|i| iter.nth(i)).collect()
+                    } else {
+                        runtime::value_to_list(v)
+                    }
                 };
-                let right_list = if value_is_lazy(&right) {
-                    let iter = self.zip_iter_from_value(&right, lazy_limit)?;
-                    (0..iter.len()).map(|i| iter.nth(i)).collect()
-                } else {
-                    runtime::value_to_list(&right)
-                };
+                let left_list = materialize_side(&left);
+                let right_list = materialize_side(&right);
                 let mut results = Vec::new();
                 if op.is_empty() || op == "," {
                     for l in &left_list {

--- a/src/vm/vm_meta_ops.rs
+++ b/src/vm/vm_meta_ops.rs
@@ -1,6 +1,32 @@
 use super::*;
 
 impl Interpreter {
+    fn zip_iter_from_value(&mut self, val: &Value, needed: usize) -> Result<ZipIter, RuntimeError> {
+        if let ValueView::LazyList(list) = val.view() {
+            // A cache-only lazy value is already finite.  Pull-backed values
+            // (map/grep pipes and sequences) need VM execution to populate the
+            // prefix consumed by Z/X; reading value_to_list here would only
+            // observe their current cache.
+            let has_extendable_source = list.sequence_spec.is_some()
+                || list.closure_seq.is_some()
+                || list.scan_spec.is_some()
+                || list.lazy_pipe.is_some()
+                || list.coroutine.is_some()
+                || list.walk_pending.is_some()
+                || list.cat_pull.is_some()
+                || list.compiled_code.is_some();
+            let items = if has_extendable_source {
+                self.force_lazy_list_vm_n(&list, needed)?
+            } else {
+                list.cache.lock().unwrap().clone().unwrap_or_default()
+            };
+            return Ok(ZipIter::Lazy(
+                items.into_iter().take(MAX_ZIP_EXPAND).collect(),
+            ));
+        }
+        Ok(ZipIter::from_value(val))
+    }
+
     pub(super) fn canonical_infix_lookup_name(name: &str) -> std::borrow::Cow<'_, str> {
         if name == "(+)" {
             return std::borrow::Cow::Borrowed("+");
@@ -70,17 +96,18 @@ impl Interpreter {
                 };
                 let lazy_inputs = value_is_lazy(&left) || value_is_lazy(&right);
                 let lazy_limit = 256usize;
-                let materialize_side = |v: &Value| -> Vec<Value> {
-                    if value_is_lazy(v) {
-                        let iter = ZipIter::from_value(v);
-                        let len = iter.len().min(lazy_limit);
-                        (0..len).map(|i| iter.nth(i)).collect()
-                    } else {
-                        runtime::value_to_list(v)
-                    }
+                let left_list = if value_is_lazy(&left) {
+                    let iter = self.zip_iter_from_value(&left, lazy_limit)?;
+                    (0..iter.len()).map(|i| iter.nth(i)).collect()
+                } else {
+                    runtime::value_to_list(&left)
                 };
-                let left_list = materialize_side(&left);
-                let right_list = materialize_side(&right);
+                let right_list = if value_is_lazy(&right) {
+                    let iter = self.zip_iter_from_value(&right, lazy_limit)?;
+                    (0..iter.len()).map(|i| iter.nth(i)).collect()
+                } else {
+                    runtime::value_to_list(&right)
+                };
                 let mut results = Vec::new();
                 if op.is_empty() || op == "," {
                     for l in &left_list {
@@ -113,8 +140,22 @@ impl Interpreter {
             "Z" => {
                 // Use lazy index-based iteration for ranges to avoid
                 // materializing huge/infinite lists like 1..*.
-                let left_iter = ZipIter::from_value(&left);
-                let right_iter = ZipIter::from_value(&right);
+                let left_lazy = matches!(left.view(), ValueView::LazyList(_));
+                let right_lazy = matches!(right.view(), ValueView::LazyList(_));
+                let left_probe = ZipIter::from_value(&left);
+                let right_probe = ZipIter::from_value(&right);
+                let left_needed = if left_lazy && !right_lazy {
+                    right_probe.len()
+                } else {
+                    MAX_ZIP_EXPAND
+                };
+                let right_needed = if right_lazy && !left_lazy {
+                    left_probe.len()
+                } else {
+                    MAX_ZIP_EXPAND
+                };
+                let left_iter = self.zip_iter_from_value(&left, left_needed)?;
+                let right_iter = self.zip_iter_from_value(&right, right_needed)?;
                 let all_lazy = left_iter.is_lazy() && right_iter.is_lazy();
                 let len = left_iter.len().min(right_iter.len()).min(MAX_ZIP_EXPAND);
                 let mut results = Vec::new();
@@ -345,7 +386,25 @@ impl Interpreter {
                 }
             }
             "Z" => {
-                let iters: Vec<ZipIter> = operands.iter().map(ZipIter::from_value).collect();
+                let probes: Vec<ZipIter> = operands.iter().map(ZipIter::from_value).collect();
+                let has_eager_operand = operands
+                    .iter()
+                    .any(|v| !matches!(v.view(), ValueView::LazyList(_)));
+                let pull_limit = if has_eager_operand {
+                    probes
+                        .iter()
+                        .zip(&operands)
+                        .filter(|(_, v)| !matches!(v.view(), ValueView::LazyList(_)))
+                        .map(|(iter, _)| iter.len())
+                        .min()
+                        .unwrap_or(0)
+                } else {
+                    MAX_ZIP_EXPAND
+                };
+                let iters: Vec<ZipIter> = operands
+                    .iter()
+                    .map(|v| self.zip_iter_from_value(v, pull_limit))
+                    .collect::<Result<_, _>>()?;
                 let all_lazy = iters.iter().all(|it| it.is_lazy());
                 let len = iters
                     .iter()
@@ -434,7 +493,11 @@ impl ZipIter {
         match val.view() {
             ValueView::Range(a, b) => {
                 let count = if b >= a {
-                    ((b - a + 1) as usize).min(MAX_ZIP_EXPAND)
+                    b.saturating_sub(a)
+                        .saturating_add(1)
+                        .try_into()
+                        .unwrap_or(usize::MAX)
+                        .min(MAX_ZIP_EXPAND)
                 } else {
                     0
                 };
@@ -449,18 +512,25 @@ impl ZipIter {
                 ZipIter::IntRangeExcl { start: a, count }
             }
             ValueView::RangeExclStart(a, b) => {
-                let start = a + 1;
+                let start = a.saturating_add(1);
                 let count = if b >= start {
-                    ((b - start + 1) as usize).min(MAX_ZIP_EXPAND)
+                    b.saturating_sub(start)
+                        .saturating_add(1)
+                        .try_into()
+                        .unwrap_or(usize::MAX)
+                        .min(MAX_ZIP_EXPAND)
                 } else {
                     0
                 };
                 ZipIter::IntRange { start, count }
             }
             ValueView::RangeExclBoth(a, b) => {
-                let start = a + 1;
+                let start = a.saturating_add(1);
                 let count = if b > start {
-                    ((b - start) as usize).min(MAX_ZIP_EXPAND)
+                    b.saturating_sub(start)
+                        .try_into()
+                        .unwrap_or(usize::MAX)
+                        .min(MAX_ZIP_EXPAND)
                 } else {
                     0
                 };

--- a/t/zip-operator.t
+++ b/t/zip-operator.t
@@ -1,6 +1,6 @@
 use Test;
 
-plan 18;
+plan 23;
 
 # Basic Z operator
 is (<a b> Z <1 2>), <a 1 b 2>, 'non-meta zip produces expected result';
@@ -38,3 +38,21 @@ is (1,2 Zcmp 3,2,0), (Order::Less, Order::Same), 'zip-cmp works';
 
 # Z with =>
 is (<a b> Z=> (1, 2)), (a => 1, b => 2), 'zip with pair construction';
+
+# Pull lazy map/grep pipes and sequence specs when they are zip operands.
+is ((10, 20) Z* map { $_ }, (0, 1 ... *)), (0, 20),
+    'zip pulls a lazy map pipe';
+is ((10, 20) Z* (0, 1 ... *).map({ $_ + 1 })), (10, 40),
+    'zip pulls a lazy mapped sequence method';
+is ((1..40) Z+ (0, 1 ... *)).elems, 40,
+    'zip extends an arithmetic sequence beyond its eager prefix';
+is ((1..4) Z+ (0..*)).[^4], (1, 3, 5, 7),
+    'zip handles an inclusive infinite range without overflow';
+
+sub fft {
+    return @_ if @_ == 1;
+    my @evn = fft(@_[0, 2 ... *]);
+    my @odd = fft(@_[1, 3 ... *]) Z* map &cis, (0, -tau / @_ ... *);
+    flat @evn »+« @odd, @evn »-« @odd;
+}
+is fft(<1 1 1 1 0 0 0 0>).elems, 8, 'FFT zips a lazy map pipe';


### PR DESCRIPTION
## Problem
Z/Z* observed only the cache of lazy map/grep pipes, so an unforced infinite mapped sequence appeared empty and broke the Rosetta Code FFT. Integer range counting also overflowed for 0..*.

## Fix
- Pull lazy sequence and map/grep prefixes through the VM, bounded by the finite counterpart or MAX_ZIP_EXPAND.
- Preserve finite cache-only lazy values.
- Use saturating range arithmetic.
- Add zip and FFT regression coverage.

## Tests
- cargo clippy -- -D warnings
- prove -e target/debug/mutsu t/zip-operator.t (23 passed)
- make test: Rust tests passed; 31,977 TAP tests ran, with one unrelated environment-sensitive failure in t/io-path-smartmatch-permissions.t because the workspace reports write access where the test expects none.