### PR TITLE
perf: reuse compiled xx repeat closures

### DIFF
--- a/news/2026-08/closure-sequence-evolution-performance.md
+++ b/news/2026-08/closure-sequence-evolution-performance.md
@@ -1,0 +1,11 @@
+# Reused compiled repeat closures in evolutionary sequences
+
+Small fixed-count `xx` expressions now inline a scalar constant count in the
+enclosing bytecode, avoiding a synthetic closure call for every repeated
+element. Dynamic counts retain their closure semantics, but reuse the closure's
+already compiled bytecode through the normal call ABI instead of compiling its
+AST at every repeat expression evaluation.
+
+This removes repeated compiler work from the closure-generated candidate lists
+used by evolutionary-search style loops while preserving per-element evaluation
+and rw-argument behavior.

--- a/src/compiler/expr_binary.rs
+++ b/src/compiler/expr_binary.rs
@@ -263,9 +263,19 @@ impl Compiler {
             // (HTTP::HPACK's `decode-str($packed, $idx) xx 2` advances `$idx`
             // by reference twice) — see todo/tickets/closure-rw-arg-writeback.md.
             const XX_UNROLL_MAX: i64 = 32;
+            // A scalar `constant` is folded at this point just like a literal
+            // count. This is especially valuable for a small fixed repeat in a
+            // hot loop: compiling a synthetic thunk and dispatching it once per
+            // element adds a closure boundary that the direct, in-frame unroll
+            // does not need. Only `constant_value` participates, so an ordinary
+            // sigilless variable remains dynamically evaluated.
+            let known_repeat_count = match right {
+                Expr::Literal(value) => value.as_int(),
+                Expr::BareWord(name) => self.constant_value(name).and_then(Value::as_int),
+                _ => None,
+            };
             if Self::xx_lhs_needs_reeval(left)
-                && let Expr::Literal(n_lit) = right
-                && let ValueView::Int(n) = n_lit.view()
+                && let Some(n) = known_repeat_count
                 && (0..=XX_UNROLL_MAX).contains(&n)
             {
                 for _ in 0..n {

--- a/src/vm/vm_arith_int_ops.rs
+++ b/src/vm/vm_arith_int_ops.rs
@@ -124,9 +124,31 @@ impl Interpreter {
     /// avoiding the interpreter roundtrip through `eval_xx_repeat_thunk`.
     fn vm_xx_repeat_thunk(
         &mut self,
-        data: &crate::value::SubData,
+        data: &crate::gc::Gc<crate::value::SubData>,
         n: usize,
     ) -> Result<Vec<Value>, RuntimeError> {
+        // The compiler bakes every compiler-generated `xx` thunk into the
+        // enclosing code object's closure pool. Invoke that bytecode through
+        // the normal closure-call ABI: it installs the closure's own captured
+        // environment and upvalues, then restores the caller state. Running
+        // it as a bare reusable block would instead inherit the caller's frame
+        // layout, which is not a closure invocation and can bind a capture to
+        // the wrong local slot.
+        if let Some(code) = &data.compiled_code {
+            let empty_fns = crate::opcode::CompiledFns::default();
+            let fns = data.compiled_fns.as_deref().unwrap_or(&empty_fns);
+            let mut out = Vec::with_capacity(n);
+            for _ in 0..n {
+                let value = self.call_compiled_closure(data, code, Vec::new(), fns)?;
+                if let ValueView::Slip(items) = value.view() {
+                    out.extend(items.iter().cloned());
+                } else {
+                    out.push(value);
+                }
+            }
+            return Ok(out);
+        }
+
         // RAII (`MarkContextGuard`,
         // `todo/deep/mark-context-flags-leak-across-live-call-boundary.md`):
         // this drives the thunk body directly via `run_reuse` rather than
@@ -154,7 +176,9 @@ impl Interpreter {
             self.env_mut().insert_sym(*k, v.clone());
         }
 
-        // Compile the thunk body
+        // Runtime-created Sub values do not carry bytecode. Keep their legacy
+        // AST compilation fallback, but only for that genuinely uncompiled
+        // shape.
         let compiler = crate::compiler::Compiler::new();
         let (code, compiled_fns) = compiler.compile(&data.body);
         let code = Arc::new(code);
@@ -486,7 +510,7 @@ impl Interpreter {
                 self.stack.push(Value::seq(items));
                 return Ok(());
             }
-            let items = self.vm_xx_repeat_thunk(data.as_ref(), n)?;
+            let items = self.vm_xx_repeat_thunk(&data, n)?;
             self.stack.push(Value::seq(items));
             return Ok(());
         }

--- a/t/xx-constant-repeat.t
+++ b/t/xx-constant-repeat.t
@@ -1,0 +1,12 @@
+use Test;
+
+plan 2;
+
+# A small scalar constant count is known while compiling `xx`, so it can run
+# its re-evaluated left side directly in the enclosing frame.
+constant REPEATS = 10;
+my $calls = 0;
+my @values = $calls++ xx REPEATS;
+
+is @values.elems, REPEATS, 'constant-count xx produces every repetition';
+is $calls, REPEATS, 'constant-count xx re-evaluates its left side';


### PR DESCRIPTION
## Summary

Avoid runtime compilation for compiler-generated `xx` repeat closures, and inline small scalar constant repeat counts in the enclosing bytecode.

## Validation

- `cargo fmt --all`
- `cargo clippy -- -D warnings`
- `prove -e target/debug/mutsu t/xx-constant-repeat.t t/list-repeat-rand-and-pick.t t/xx-thunk-reeval.t t/xx-reevaluates-lhs.t`
- `make test` was started; the local command runner ended it during the Rust-test phase, so CI will provide the complete suite result.