### PR TITLE
fix: write back grouped meta-assignment lists

### DIFF
--- a/news/2026-08/grouped-meta-assignment.md
+++ b/news/2026-08/grouped-meta-assignment.md
@@ -1,0 +1,3 @@
+# Fix grouped list meta-assignment
+
+Grouped scalar declarations now produce a List value while keeping their variables in the surrounding lexical scope. Cross and zip assignment meta-operators also write updated values back through literal lists of scalar containers, fixing the register add-back used by the Rosetta Code MD4 implementation.

--- a/src/compiler/expr_block.rs
+++ b/src/compiler/expr_block.rs
@@ -790,6 +790,32 @@ impl Compiler {
             {
                 self.compile_synthetic_block_inline(inner);
             }
+            // An uninitialized grouped declaration (`my ($a, $b)`) is a List
+            // expression whose elements are the newly declared scalar values.
+            // Its SyntheticBlock is scopeless: the declarations remain visible
+            // in the surrounding lexical scope.
+            Stmt::SyntheticBlock(inner)
+                if !inner.is_empty()
+                    && inner
+                        .iter()
+                        .all(|stmt| matches!(stmt, Stmt::VarDecl { .. })) =>
+            {
+                let mut values = Vec::with_capacity(inner.len());
+                for stmt in inner {
+                    let Stmt::VarDecl { name, .. } = stmt else {
+                        unreachable!();
+                    };
+                    self.compile_stmt(stmt);
+                    values.push(if let Some(name) = name.strip_prefix('@') {
+                        Expr::ArrayVar(name.to_string())
+                    } else if let Some(name) = name.strip_prefix('%') {
+                        Expr::HashVar(name.to_string())
+                    } else {
+                        Expr::Var(name.clone())
+                    });
+                }
+                self.compile_expr(&Expr::ArrayLiteral(values));
+            }
             Stmt::SyntheticBlock(inner) => {
                 self.compile_do_block_expr_scoped(inner, &None);
             }

--- a/src/compiler/expr_ops.rs
+++ b/src/compiler/expr_ops.rs
@@ -384,6 +384,36 @@ impl Compiler {
 
     /// Compile MetaOp (Rop, Xop, Zop).
     pub(super) fn compile_expr_meta_op(&mut self, meta: &str, op: &str, left: &Expr, right: &Expr) {
+        // A grouped declaration used as an X/Z operand (`my ($a, $b) Z ...`)
+        // declares its scalars in the surrounding scope and contributes a List
+        // of those scalar values. The parser represents the declaration as a
+        // scopeless SyntheticBlock, so run the declarations first and continue
+        // with the corresponding literal list operand.
+        if matches!(meta, "X" | "Z")
+            && let Expr::DoStmt(stmt) = left
+            && let Stmt::SyntheticBlock(stmts) = stmt.as_ref()
+            && !stmts.is_empty()
+            && stmts
+                .iter()
+                .all(|stmt| matches!(stmt, Stmt::VarDecl { .. }))
+        {
+            let mut targets = Vec::with_capacity(stmts.len());
+            for stmt in stmts {
+                let Stmt::VarDecl { name, .. } = stmt else {
+                    unreachable!();
+                };
+                self.compile_stmt(stmt);
+                targets.push(if let Some(name) = name.strip_prefix('@') {
+                    Expr::ArrayVar(name.to_string())
+                } else if let Some(name) = name.strip_prefix('%') {
+                    Expr::HashVar(name.to_string())
+                } else {
+                    Expr::Var(name.clone())
+                });
+            }
+            self.compile_expr_meta_op(meta, op, &Expr::ArrayLiteral(targets), right);
+            return;
+        }
         if meta == "X" && matches!(op, "and" | "&&" | "or" | "||" | "andthen" | "orelse") {
             let thunked = Expr::AnonSub {
                 body: vec![Stmt::Expr(right.clone())],
@@ -527,9 +557,7 @@ impl Compiler {
         // in-place assignment operator, so each cross/zip pair mutates the
         // corresponding left cell and the mutated left container is written back
         // to the lvalue. The expression value is the Seq of per-op assignment
-        // results (which, for `X`, differs from the mutated container). Only a
-        // simple lvalue (`@a`, `$a`) is written back; any other left operand
-        // falls through to the general path.
+        // results (which, for `X`, differs from the mutated container).
         if (meta == "X" || meta == "Z")
             && let Some(target) = Self::meta_assign_writeback_target(op, left)
         {
@@ -541,6 +569,39 @@ impl Compiler {
             // The MetaOpAssign pushes [result_seq, mutated_left]; store the
             // mutated container (top) back into the lvalue, leaving the Seq.
             self.emit_set_named_var(&target);
+            return;
+        }
+        // A literal list of scalar lvalues (`($a, $b) Z[+=] ...`) needs the same
+        // MetaOpAssign result, but its mutated-left value must be distributed
+        // back across the individual containers. Stash that value temporarily,
+        // reuse the regular list-lvalue assignment compiler, and discard the
+        // assignment helper's value so the original per-op Seq remains.
+        if (meta == "X" || meta == "Z")
+            && Self::is_meta_assign_op(op)
+            && let Expr::ArrayLiteral(targets) = left
+        {
+            self.compile_expr(left);
+            self.compile_expr(right);
+            let meta_idx = self.code.add_constant(Value::str(meta.to_string()));
+            let op_idx = self.code.add_constant(Value::str(op.to_string()));
+            self.code.emit(OpCode::MetaOpAssign { meta_idx, op_idx });
+            let tmp_name = format!("__mutsu_meta_assign_tmp_{}", self.code.constants.len());
+            let tmp_idx = self.code.add_constant(Value::str(tmp_name.clone()));
+            self.code.emit(OpCode::SetGlobal(tmp_idx));
+            let result_name = format!("__mutsu_meta_assign_result_{}", self.code.constants.len());
+            let result_idx = self.code.add_constant(Value::str(result_name.clone()));
+            self.code.emit(OpCode::SetGlobal(result_idx));
+            let assign_call = Expr::Call {
+                name: Symbol::intern("__mutsu_assign_callable_lvalue"),
+                args: vec![
+                    Expr::ArrayLiteral(targets.clone()),
+                    Expr::ArrayLiteral(Vec::new()),
+                    Expr::Var(tmp_name),
+                ],
+            };
+            self.compile_expr(&assign_call);
+            self.code.emit(OpCode::Pop);
+            self.code.emit(OpCode::GetGlobal(result_idx));
             return;
         }
         // List-associative chaining for X/Z: `a X b X c` is a single n-ary
@@ -623,14 +684,17 @@ impl Compiler {
     /// end in `=` (`==`, `<=`, `=~=`, …) are not assignments. Returns `None`
     /// when the op is not an assignment or the left operand is not a plain
     /// variable lvalue.
-    fn meta_assign_writeback_target(op: &str, left: &Expr) -> Option<String> {
-        let is_assign_op = op.ends_with('=')
+    fn is_meta_assign_op(op: &str) -> bool {
+        op.ends_with('=')
             && op.len() > 1
             && !matches!(
                 op,
-                "==" | "!=" | "<=" | ">=" | "===" | "!==" | "<=>" | "=~=" | "=:="
-            );
-        if !is_assign_op {
+                "==" | "!=" | "<=" | ">=" | "===" | "!==" | "<=>" | "=~=" | "=:=" | "!=:="
+            )
+    }
+
+    fn meta_assign_writeback_target(op: &str, left: &Expr) -> Option<String> {
+        if !Self::is_meta_assign_op(op) {
             return None;
         }
         match left {

--- a/t/grouped-declaration-expression.t
+++ b/t/grouped-declaration-expression.t
@@ -1,0 +1,10 @@
+use Test;
+
+plan 5;
+
+is (my ($a, $b)).raku, '(Any, Any)', 'grouped declaration yields every scalar';
+is (my ($c, $d)).elems, 2, 'grouped declaration has the expected arity';
+is (my ($e, $f)).WHAT, List, 'grouped declaration yields a List';
+is (my ($g, $h) Z 1, 2).raku, '((Any, 1), (Any, 2)).Seq',
+    'grouped declaration supplies every operand to zip';
+ok !$a.defined && !$b.defined, 'grouped declarations remain visible in the surrounding scope';

--- a/t/meta-cross-zip-assign.t
+++ b/t/meta-cross-zip-assign.t
@@ -5,7 +5,7 @@ use Test;
 # (Z) pair mutates the corresponding left cell. The left container is written
 # back, and the expression value is the Seq of the per-op assignment results.
 
-plan 16;
+plan 22;
 
 # --- Cross meta-assignment: @a[i] accumulates every @b element. ---
 {
@@ -97,6 +97,26 @@ plan 16;
     my @b = 1, 2, 3;
     $a X[+=] @b;
     is $a, 11, 'scalar X[+=] folds every right element into the scalar';
+}
+
+# --- Literal lists write back to each scalar container. ---
+{
+    my ($a, $b);
+    my @r = ($a, $b) Z[+=] 1, 2;
+    is @r.raku, '[1, 2]', 'literal-list Z[+=] returns the assigned values';
+    is "$a,$b", '1,2', 'literal-list Z[+=] mutates both scalar containers';
+}
+{
+    my $a = 1;
+    my $b = 10;
+    my @r = ($a, $b) X[+=] 2, 3;
+    is @r.raku, '[3, 6, 12, 15]', 'literal-list X[+=] returns every intermediate value';
+    is "$a,$b", '6,15', 'literal-list X[+=] writes back the accumulated values';
+}
+{
+    is (my ($a, $b) Z[+=] 1, 2).raku, '(1, 2).Seq',
+        'grouped declaration works as a meta-assignment operand';
+    is "$a,$b", '1,2', 'grouped declaration remains visible after meta-assignment';
 }
 
 # --- Plain (non-assign) X still produces the flat cross list. ---


### PR DESCRIPTION
## Problem

Grouped declarations such as `my ($a, $b)` produced only their final declaration value in expression position. In addition, `X[op=]` and `Z[op=]` only wrote back through a single scalar or array variable, so a literal list of scalar containers was left unchanged. This broke the register add-back in the Rosetta Code MD4 implementation.

Closes #6935.

## Approach

- Compile an uninitialized grouped declaration as a scopeless declaration sequence followed by a List of the declared values.
- Normalize grouped declaration operands before compiling X/Z meta-operations.
- Reuse `MetaOpAssign` and the existing list-lvalue assignment compiler to distribute the mutated left values back through literal scalar lists while preserving the meta-operation result Seq.
- Keep identity operator `!=:=` out of assignment classification.

## Test evidence

- `cargo clippy -- -D warnings`
- `prove -e target/debug/mutsu t/list-infix-comma-precedence.t t/grouped-declaration-expression.t t/meta-cross-zip-assign.t` (52 tests pass)
- Rosetta Code MD4 returns `A5 2B CF C6 A0 D0 D3 00 CD C5 DD BF BE FE 47 8B`
- `make test`: Rust suite passed; TAP suite had one environment-dependent `/` write-permission failure under root. The initially exposed `!=:=` regression was fixed and its targeted test passes.
- `make roast`: completed once; precompilation cache was read-only in the sandbox, causing the precomp/module-related failures recorded in `tmp/make-roast.log`. Per repository policy, the full command was not rerun.