### PR TITLE
fix: preserve closure sequence array reifiers

### DIFF
--- a/docs/lazy-arrays.md
+++ b/docs/lazy-arrays.md
@@ -91,10 +91,12 @@ needs_vm_lazy_dispatch}`. **The catch (handled):** `force_lazy_list_vm` and
 `reify_lazy_array_slot` now *extend* a sequence spec to the 100k cap rather than
 reading the O(1) seed cache, so a strict force / front mutation still gets a real
 prefix. t/lazy-array-reify.t gained 3 fresh-`1..*` map/grep cases; the reify test
-runs in 0.06 CPU (was 1.8) — confirming the O(1) read path. **Still deferred to
-step 6:** converting `(1...*)`/closure-seq arrays at `@`-assign (gated on
-S32-array/create.t partial-reify surviving). Original plan kept below for
-reference.
+runs in 0.06 CPU (was 1.8) — confirming the O(1) read path. **Step 6 completed
+(2026-08-24):** endpoint-less closure-seq arrays now remain reify-on-demand
+`LazyList` values across `@` assignment. The existing shared `Gc<LazyList>`
+reifier and L2c mutation restore path satisfy S32-array/create.t's
+partial-reify contract: clones see the same generated values while element
+mutations remain container-local. Original plan kept below for reference.
 
 ## L2c — bounded reify on element mutation (DONE 2026-08-22)
 

--- a/news/2026-08/closure-sequence-arrays-keep-reifier.md
+++ b/news/2026-08/closure-sequence-arrays-keep-reifier.md
@@ -1,0 +1,12 @@
+# Closure-sequence arrays keep their reifier
+
+Endpoint-less closure sequences assigned to an `@` array now retain their live
+generator instead of becoming a finite snapshot of the 32-step eager prefix.
+Indexing extends the array on demand, display keeps the lazy `[...]` placeholder,
+and bounded element mutation preserves both the live tail and the generator's
+pristine recurrence history.
+
+The change uses the existing shared `Gc<LazyList>` representation and the
+bounded lazy-array mutation restore path. The upstream partially-reified Array
+clone tests confirm that clones share generated values while subsequent element
+mutations remain independent.

--- a/src/value/value_lazy.rs
+++ b/src/value/value_lazy.rs
@@ -230,25 +230,30 @@ impl LazyList {
     /// Whether `my @a = <this list>` keeps the list as a reify-on-demand lazy
     /// array (L2b step 6, docs/lazy-arrays.md) instead of eagerly
     /// materializing. An explicit `lazy` marker always preserves; otherwise
-    /// only a *deterministic* unreifiable source does — an infinite
-    /// arithmetic/geometric sequence spec, or a map/grep pipe over an
-    /// infinite source. A pipe bottoming out in a finite source (a plain
-    /// gather) and a finite cat-pull materialize eagerly, matching raku.
+    /// only an unreifiable source does — an infinite arithmetic/geometric or
+    /// closure sequence, or a map/grep pipe over an infinite source. A pipe
+    /// bottoming out in a finite source (a plain gather) and a finite cat-pull
+    /// materialize eagerly, matching raku.
     ///
-    /// TODO: closure_seq (`1, {rand} ... *`) and scan_spec stay on the old
-    /// capped-Array path: S32-array/create.t "partially-reified" requires
-    /// `@a.clone` to SHARE the reifier (clone and original see the same
-    /// `{rand}` values), which needs a shared element-cell store —
-    /// container-repr territory (ADR-0001 layer 3a), not a per-site fix.
+    /// `closure_seq` is safe to preserve here: `LazyList` lives behind a shared
+    /// `Gc`, so ordinary Value clones share the reifier and its generated
+    /// cache. Array assignment's `with_array_context` clone snapshots that
+    /// shared state only when constructing a distinct Array container; later
+    /// element writes remain isolated by the existing restore-lazy-array path.
     pub(crate) fn preserve_lazy_on_array_assign(&self) -> bool {
         self.is_lazy_marked()
             || self.sequence_spec.is_some()
+            || self
+                .closure_seq
+                .as_ref()
+                .is_some_and(|state| state.lock().unwrap().endpoint.is_none())
             || (self.lazy_pipe.is_some() && !self.pipe_bottoms_out_finite())
     }
 
     /// Whether this list is genuinely *infinite / unreifiable* — an infinite
-    /// `...` sequence spec, or a lazy map/grep pipe over an infinite source —
-    /// as opposed to a merely `lazy`-marked but *finite* list (`lazy 1, 2`).
+    /// `...` sequence spec, an endpoint-less closure sequence, or a lazy
+    /// map/grep pipe over an infinite source — as opposed to a merely
+    /// `lazy`-marked but *finite* list (`lazy 1, 2`).
     /// This is `preserve_lazy_on_array_assign` MINUS the `is_lazy_marked` case.
     ///
     /// A `[...]` bracket-array keeps only these lazy (`.is-lazy` True, `.elems`
@@ -257,6 +262,10 @@ impl LazyList {
     /// the tiny seed cache keep working.
     pub(crate) fn is_lazy_infinite(&self) -> bool {
         self.sequence_spec.is_some()
+            || self
+                .closure_seq
+                .as_ref()
+                .is_some_and(|state| state.lock().unwrap().endpoint.is_none())
             || (self.lazy_pipe.is_some() && !self.pipe_bottoms_out_finite())
     }
 

--- a/t/lazy-array-assign-preserve.t
+++ b/t/lazy-array-assign-preserve.t
@@ -5,7 +5,7 @@ use Test;
 # `@` array survives as a reify-on-demand lazy array, matching raku.
 # Found by the doc-diff sweep (Language/list.rakudoc [7], [1]).
 
-plan 17;
+plan 23;
 
 # Infinite sequence assigned directly.
 {
@@ -23,6 +23,23 @@ plan 17;
     ok @lazy-array.is-lazy, 'sequence via bound scalar stays lazy';
     is-deeply @lazy-array[10..15], (1024, 2048, 4096, 8192, 16384, 32768),
         'doc example slice matches';
+}
+
+# An endpoint-less closure sequence keeps its live generator when assigned to
+# an Array. The eager construction prefix is deliberately small; indexing past
+# it must resume the generator instead of exposing a capped finite Array.
+{
+    my @fib = 1, 1, * + * ... *;
+    ok @fib.is-lazy, 'closure-sequence array stays lazy';
+    is @fib[34], 9227465, 'closure-sequence array reifies past the eager prefix';
+    is @fib.gist, '[...]', 'closure-sequence array gist stays a placeholder';
+    throws-like { @fib.elems }, X::Cannot::Lazy,
+        'closure-sequence array has no finite elems count';
+
+    @fib[2] = 99;
+    is @fib[2], 99, 'closure-sequence array element mutation is visible';
+    is @fib[35], 14930352,
+        'mutation does not corrupt the generator history or discard its tail';
 }
 
 # The `lazy` prefix takes the whole sequence as its operand (looser than


### PR DESCRIPTION
## Problem

Endpoint-less closure sequences assigned to an `@` array were eagerly collapsed to the 32-step construction cache. Values beyond index 33 therefore became `(Any)`, and array display incorrectly showed a finite prefix.

## Approach

- Preserve endpoint-less closure sequences as reify-on-demand `LazyList` arrays.
- Classify them as genuinely infinite for display and `.elems` behavior.
- Add regression coverage for indexing beyond the prefix, lazy display, `.elems`, and mutation without corrupting generator history.
- Document completion of the lazy-array closure-sequence step.

## Test evidence

- `cargo build`
- targeted TAP tests: 3 files, 55 tests, PASS
- `roast/S32-array/create.t`: 12 tests, PASS
- `cargo fmt --all`
- `cargo clippy -- -D warnings`
- `make roast`: 1,436 files, 218,836 tests, PASS
- `make test`: 3,400 of 3,401 files passed; the environment-sensitive `t/io-path-smartmatch-permissions.t` expected `/` to be non-writable, but this workspace runs as root and reports it writable. The sequence regression tests pass.