### PR TITLE
fix: preserve topic in xx thunks

### DIFF
--- a/news/2026-08/xx-thunk-inherits-topic.md
+++ b/news/2026-08/xx-thunk-inherits-topic.md
@@ -1,0 +1,7 @@
+# `xx` thunks inherit the current topic
+
+The re-evaluation thunk used by list repetition now has bare-block semantics,
+so it closes over the current `$_` instead of resetting the topic like a
+routine call. This fixes repeated topic-dependent calls inside deferred
+closure sequences and lets the Rosetta Code evolutionary algorithm run to its
+target string.

--- a/src/compiler/expr_binary.rs
+++ b/src/compiler/expr_binary.rs
@@ -316,13 +316,15 @@ impl Compiler {
                 } else {
                     left.clone()
                 };
-                let thunk = Expr::AnonSubParams {
-                    params: Vec::new(),
-                    param_defs: Vec::new(),
-                    return_type: None,
+                // `xx` thunks its lhs as a bare block, not as a routine.  A
+                // routine gets a fresh undefined `$_`, while a bare block
+                // closes over the current topic.  The distinction matters
+                // when the repeated expression reads `$_` inside another
+                // deferred block, such as a closure-generated sequence.
+                let thunk = Expr::AnonSub {
                     body: vec![Stmt::Expr(reevaluated_lhs)],
                     is_rw: false,
-                    is_whatever_code: false,
+                    is_block: true,
                 };
                 self.compile_expr(&thunk);
             } else {

--- a/t/xx-constant-repeat.t
+++ b/t/xx-constant-repeat.t
@@ -1,6 +1,6 @@
 use Test;
 
-plan 2;
+plan 3;
 
 # A small scalar constant count is known while compiling `xx`, so it can run
 # its re-evaluated left side directly in the enclosing frame.
@@ -10,3 +10,15 @@ my @values = $calls++ xx REPEATS;
 
 is @values.elems, REPEATS, 'constant-count xx produces every repetition';
 is $calls, REPEATS, 'constant-count xx re-evaluates its left side';
+
+# A sequence generator is compiled independently from its surrounding unit, so
+# its compiler cannot fold the unit's constant repeat count.  The resulting xx
+# thunk must remain a bare block and inherit the generator's current topic.
+constant COPIES = 2;
+sub keep-topic(Str $value) { $value }
+my @generated;
+@generated.push($_) for "AA", {
+    (keep-topic($_) xx COPIES)[0] eq "AA" ?? "AB" !! "AB"
+} ... "AB";
+is-deeply @generated, ["AA", "AB"],
+    'xx thunk inside a deferred sequence inherits the current topic';


### PR DESCRIPTION
## Summary

Fixes #6932.

- Compile re-evaluated `xx` expressions as bare-block thunks so they inherit the current topic.
- Add a regression for a constant-count `xx` nested in a deferred closure sequence.
- Record the compatibility fix in the August news.

The Rosetta Code Evolutionary algorithm now reaches `METHINKS IT IS LIKE A WEASEL` and exits successfully.

## Tests

- `cargo fmt --all`
- `cargo clippy -- -D warnings`
- `prove -e target/debug/mutsu t/xx-constant-repeat.t t/statement-modifier-sequence.t t/sequence-closure-endpoint-over-256.t`
- Rosetta Code Evolutionary algorithm, current published Raku source: PASS, target reached at generation 9057 in the verification run
- `make roast`: PASS (1436 files, 218836 tests)
- `make test`: one environment-specific failure in `t/io-path-smartmatch-permissions.t`; this workspace has `/` owned by and writable to uid 1000, while the test expects `/` not to be writable. All other 3400 files and 32004 tests passed.