### PR TITLE
perf(vm): compiled-method fast path binds simple named/attributive params

### DIFF
--- a/src/runtime/types/binding_helpers.rs
+++ b/src/runtime/types/binding_helpers.rs
@@ -99,14 +99,36 @@ impl Interpreter {
                 if key.is_empty() {
                     continue;
                 }
-                let consumed = param_defs.iter().any(|pd| {
-                    (pd.named && pd.name == *key)
-                        || pd.name == format!(":{}", key)
-                        || (pd.named
-                            && (pd.name == format!("@{}", key)
-                                || pd.name == format!("%{}", key)
-                                || pd.name == format!("&{}", key)))
-                });
+                // Mirror the slow binder's `explicit_named_keys` (and rakudo):
+                // strip the container sigil, then the attribute twigil, so an
+                // attributive named param (`:$!x` -> name "!x") consumes the
+                // caller key "x" and keeps it out of `%_`.
+                let consumed = param_defs
+                    .iter()
+                    .filter(|pd| (pd.named || pd.name.starts_with(':')) && !pd.slurpy)
+                    .any(|pd| {
+                        let bare = if let Some(rest) = pd.name.strip_prefix(':') {
+                            rest
+                        } else if let Some(rest) = pd
+                            .name
+                            .strip_prefix("@:")
+                            .or_else(|| pd.name.strip_prefix("%:"))
+                        {
+                            rest
+                        } else {
+                            let after_sigil = pd
+                                .name
+                                .strip_prefix('@')
+                                .or_else(|| pd.name.strip_prefix('%'))
+                                .or_else(|| pd.name.strip_prefix('&'))
+                                .unwrap_or(&pd.name);
+                            after_sigil
+                                .strip_prefix('!')
+                                .or_else(|| after_sigil.strip_prefix('.'))
+                                .unwrap_or(after_sigil)
+                        };
+                        bare == *key
+                    });
                 if !consumed {
                     implicit_named.insert(key.to_string(), val.clone());
                 }

--- a/src/runtime/types/mod.rs
+++ b/src/runtime/types/mod.rs
@@ -470,7 +470,7 @@ impl Interpreter {
     /// not a single element holding the list. Every other value is passed through
     /// untouched, so an ordinary Array keeps sharing the caller's container and a
     /// non-Positional is left for the binder's type check to reject.
-    fn normalize_positional_param_value(value: Value) -> Value {
+    pub(crate) fn normalize_positional_param_value(value: Value) -> Value {
         match value.view() {
             // De-itemize in place: `$[…]` becomes an `Array` and `$(…)` a `List`,
             // so `.raku` still renders the shape the argument had.

--- a/src/vm/vm_call_eligibility.rs
+++ b/src/vm/vm_call_eligibility.rs
@@ -275,6 +275,16 @@ impl Interpreter {
             if pd.is_invocant || pd.traits.iter().any(|t| t == "invocant") || pd.named {
                 continue;
             }
+            // Skip named (string-keyed Pair) arguments when aligning positional
+            // params to args — the binder does not consume them positionally.
+            // (Reached with Pair args now that the fast path accepts simple
+            // named-param methods, S6.)
+            while args
+                .get(arg_idx)
+                .is_some_and(|a| a.unwrap_varref().is_string_pair_value())
+            {
+                arg_idx += 1;
+            }
             let Some(arg) = args.get(arg_idx) else {
                 break;
             };
@@ -383,6 +393,133 @@ impl Interpreter {
                 .as_bytes()
                 .first()
                 .is_some_and(|b| b.is_ascii_alphabetic() || *b == b'_')
+    }
+
+    /// Method analogue of [`Self::call_shares_container_into_named_scalar_param`]:
+    /// true when an `@`/`%` *variable* is passed by name into a plain readonly
+    /// scalar `$` named param of a method (`method m(:$n) { $n.push }` called as
+    /// `$o.m(n => @a)`). Raku binds the same mutable container; the slot-only
+    /// fast path binds a copy whose `.push` COW-detaches, so such a call must
+    /// take the slow `bind_function_args_values` path (which promotes the bound
+    /// value to a shared cell and registers the rw writeback). The source
+    /// variable name arrives as the "key=source" encoding in `arg_sources`,
+    /// exactly like the sub side.
+    pub(super) fn method_shares_container_into_named_scalar_param(
+        &self,
+        method_def: &crate::runtime::MethodDef,
+        args: &[Value],
+    ) -> bool {
+        let Some(sources) = self.pending_call_arg_sources() else {
+            return false;
+        };
+        args.iter().enumerate().any(|(i, arg)| {
+            let unwrapped = unwrap_varref_value(arg.clone());
+            let ValueView::Pair(key, val) = unwrapped.view() else {
+                return false;
+            };
+            if !matches!(val.view(), ValueView::Array(..) | ValueView::Hash(..)) {
+                return false;
+            }
+            let has_container_source = sources
+                .get(i)
+                .and_then(|s| s.as_ref())
+                .and_then(|enc| enc.split_once('='))
+                .is_some_and(|(_, src)| src.starts_with('@') || src.starts_with('%'));
+            if !has_container_source {
+                return false;
+            }
+            method_def.param_defs.iter().any(|pd| {
+                pd.named
+                    && Self::named_param_share_match_key(pd) == key.as_str()
+                    && Self::is_eligible_named_scalar_share_param(pd)
+            })
+        })
+    }
+
+    /// The caller-side Pair key a NAMED parameter matches on the compiled-method
+    /// fast path — mirroring the slow binder's named arm (binding_signature.rs):
+    /// strip an optional container sigil (`@`/`%`), then an attribute twigil
+    /// (`!`/`.`). Returns `None` for named shapes the fast path does not model:
+    /// `:name`-literal / `@:`/`%:` placeholder forms, `&`-sigiled callables,
+    /// plain (non-attributive) `@`/`%` container named params (container-alias
+    /// semantics live only on the full path), the topic `_`, and `self`.
+    pub(super) fn named_param_fast_match_key(pd: &crate::ast::ParamDef) -> Option<&str> {
+        let name = pd.name.as_str();
+        let bare = if let Some(rest) = name
+            .strip_prefix("@!")
+            .or_else(|| name.strip_prefix("@."))
+            .or_else(|| name.strip_prefix("%!"))
+            .or_else(|| name.strip_prefix("%."))
+        {
+            // Attributive container form (`:@!a` / `:%.h`).
+            rest
+        } else if let Some(rest) = name.strip_prefix('!').or_else(|| name.strip_prefix('.')) {
+            // Attributive scalar form (`:$!x` / `:$.x`).
+            rest
+        } else if name
+            .as_bytes()
+            .first()
+            .is_some_and(|b| b.is_ascii_alphabetic() || *b == b'_')
+        {
+            // Plain scalar named param (`:$x` — stored sigil-less).
+            name
+        } else {
+            return None;
+        };
+        if bare == "_" || bare == "self" {
+            return None;
+        }
+        bare.as_bytes()
+            .first()
+            .is_some_and(|b| b.is_ascii_alphabetic() || *b == b'_')
+            .then_some(bare)
+    }
+
+    /// S6 (bench-ctor): whether a NAMED parameter is simple enough for the
+    /// compiled-method fast path to bind directly. Conservative allow-list:
+    /// a plain readonly scalar named param (`:$x`) or an attributive named
+    /// param (`:$!x` / `:@!a` / `:%!h` — bound through the invocant's live
+    /// attribute cell), with no traits, no type constraint, no
+    /// where/sub-signature/coercion, and no default needing evaluation. A
+    /// defaulted or required named param is eligible only when the call
+    /// actually supplies its key — otherwise the full path evaluates the
+    /// default expression / raises the proper "required named parameter not
+    /// passed" error.
+    pub(super) fn named_param_fast_eligible(
+        pd: &crate::ast::ParamDef,
+        args: &[Value],
+        base_is_instance: bool,
+    ) -> bool {
+        if !pd.traits.is_empty()
+            || pd.slurpy
+            || pd.double_slurpy
+            || pd.onearg
+            || pd.sigilless
+            || pd.where_constraint.is_some()
+            || pd.sub_signature.is_some()
+            || pd.outer_sub_signature.is_some()
+            || pd.code_signature.is_some()
+            || pd.type_constraint.is_some()
+            || pd.literal_value.is_some()
+            || pd.shape_constraints.is_some()
+        {
+            return false;
+        }
+        let Some(key) = Self::named_param_fast_match_key(pd) else {
+            return false;
+        };
+        if crate::value::attr_twigil_base(&pd.name).is_some() && !base_is_instance {
+            return false;
+        }
+        if pd.default.is_some() || pd.required {
+            let supplied = args.iter().any(
+                |a| matches!(a.unwrap_varref().view(), ValueView::Pair(k, _) if k.as_str() == key),
+            );
+            if !supplied {
+                return false;
+            }
+        }
+        true
     }
 
     /// Ultra-fast call for simple positional-only functions (e.g. `sub fib($n)`).

--- a/src/vm/vm_method_dispatch.rs
+++ b/src/vm/vm_method_dispatch.rs
@@ -174,6 +174,25 @@ impl Interpreter {
             // (mirrors the sub side's named-share gate).
             let named_container_share = has_named_args
                 && self.method_shares_container_into_named_scalar_param(method_def, &args);
+            // Every named argument must have somewhere to land: a named slurpy
+            // (`*%_` — implicit, or explicit) absorbing leftovers, or an
+            // eligible named param consuming its key. An `is hidden` class's
+            // methods get NO implicit `*%_` (`effective_method_param_defs`),
+            // and the slow binder rejects an unexpected named argument for
+            // them (roast S12-class/interface-consistency.t test 5:
+            // `Bar.new.m1(1, :x)` must die) — the fast path must not silently
+            // drop it, so such calls keep the full path.
+            let named_args_all_land = !has_named_args
+                || method_def
+                    .param_defs
+                    .iter()
+                    .any(|pd| pd.slurpy && pd.name.starts_with('%'))
+                || args.iter().all(|a| match a.unwrap_varref().view() {
+                    ValueView::Pair(k, _) => method_def.param_defs.iter().any(|pd| {
+                        pd.named && Self::named_param_fast_match_key(pd) == Some(k.as_str())
+                    }),
+                    _ => true,
+                });
             let has_complex_params = method_def.param_defs.iter().any(|pd| {
                 if pd.is_invocant || pd.traits.iter().any(|t| t == "invocant") {
                     return false;
@@ -261,6 +280,7 @@ impl Interpreter {
 
             if !has_unmodeled_pair_arg
                 && named_params_fast_ok
+                && named_args_all_land
                 && !named_container_share
                 && !has_missing_required
                 && !has_invocant_constraint

--- a/src/vm/vm_method_dispatch.rs
+++ b/src/vm/vm_method_dispatch.rs
@@ -132,6 +132,48 @@ impl Interpreter {
                 || self
                     .class_role_param_bindings(receiver_class_name)
                     .is_some();
+            // Classify arguments the way the slow binder does
+            // (`bind_function_args_values`): a string-keyed `Pair` (after VarRef
+            // unwrap) is a named argument; everything else is positional. Two
+            // shapes always keep the full path: a non-string-keyed `ValuePair`
+            // (the main binder treats it as positional but the legacy
+            // placeholder path as named — ambiguous), and an internal
+            // `__mutsu_*` Pair (the slow path filters it before binding).
+            let mut positional_arg_count = 0usize;
+            let mut has_named_args = false;
+            let mut has_unmodeled_pair_arg = false;
+            for a in &args {
+                let u = a.unwrap_varref();
+                if u.is_string_pair_value() {
+                    has_named_args = true;
+                    if let ValueView::Pair(key, _) = u.view()
+                        && key.starts_with("__mutsu_")
+                    {
+                        has_unmodeled_pair_arg = true;
+                    }
+                } else if u.is_any_pair_value() || a.is_any_pair_value() {
+                    has_unmodeled_pair_arg = true;
+                } else {
+                    positional_arg_count += 1;
+                }
+            }
+            // S6 (bench-ctor): simple named/attributive params now bind on the
+            // fast path (`named_param_fast_eligible` — plain readonly scalar
+            // `:$x`, attributive `:$!x`/`:@!a`/`:%!h` via the live attribute
+            // cell). Everything else named-shaped bails via this predicate.
+            let base_is_instance = matches!(base.view(), ValueView::Instance { .. });
+            let named_params_fast_ok = method_def.param_defs.iter().all(|pd| {
+                if pd.is_invocant || pd.traits.iter().any(|t| t == "invocant") || !pd.named {
+                    return true;
+                }
+                Self::named_param_fast_eligible(pd, &args, base_is_instance)
+            });
+            // A named `@`/`%`-container argument bound to a plain named scalar
+            // param shares the caller's container (slow-path ContainerRef
+            // promotion + exit writeback) — keep such calls on the full path
+            // (mirrors the sub side's named-share gate).
+            let named_container_share = has_named_args
+                && self.method_shares_container_into_named_scalar_param(method_def, &args);
             let has_complex_params = method_def.param_defs.iter().any(|pd| {
                 if pd.is_invocant || pd.traits.iter().any(|t| t == "invocant") {
                     return false;
@@ -140,16 +182,21 @@ impl Interpreter {
                 if pd.slurpy && pd.name == "%_" {
                     return false;
                 }
-                // An attributive parameter (`$!x`/`@!a`) binds straight to an
-                // attribute, i.e. it mutates `self` — so it is not read-only and
-                // must take the full path (which mirrors it into the shared cell
-                // and writes it back). The read-only fast path drops the write.
+                // Named params are vetted by `named_params_fast_ok` above.
+                if pd.named {
+                    return false;
+                }
+                // A POSITIONAL attributive parameter (`$!x`/`@!a`) binds straight
+                // to an attribute, i.e. it mutates `self` — so it is not
+                // read-only and must take the full path (which mirrors it into
+                // the shared cell and writes it back). The read-only fast path
+                // drops the write. (NAMED attributive params write the live cell
+                // on the fast path now — see `named_param_fast_eligible`.)
                 if Self::attr_twigil_base(&pd.name).is_some() {
                     return true;
                 }
                 pd.slurpy
                     || pd.double_slurpy
-                    || pd.named
                     || pd.where_constraint.is_some()
                     || pd.sub_signature.is_some()
                     || pd.outer_sub_signature.is_some()
@@ -160,13 +207,20 @@ impl Interpreter {
                         .is_some_and(|tc| tc.contains('('))
             });
             // If a default expr needs evaluation and args are missing, fall back
+            // (named-param defaults are handled by `named_param_fast_eligible`;
+            // only positional params consume positional args here).
             let needs_default_eval = {
                 let mut pos = 0;
                 method_def.param_defs.iter().any(|pd| {
-                    if pd.is_invocant || pd.traits.iter().any(|t| t == "invocant") {
+                    if pd.is_invocant
+                        || pd.traits.iter().any(|t| t == "invocant")
+                        || pd.named
+                        || pd.slurpy
+                        || pd.double_slurpy
+                    {
                         return false;
                     }
-                    let result = pos >= args.len() && pd.default.is_some();
+                    let result = pos >= positional_arg_count && pd.default.is_some();
                     pos += 1;
                     result
                 })
@@ -185,7 +239,8 @@ impl Interpreter {
                     {
                         return false;
                     }
-                    let missing = pos >= args.len() && pd.default.is_none() && !pd.optional_marker;
+                    let missing =
+                        pos >= positional_arg_count && pd.default.is_none() && !pd.optional_marker;
                     pos += 1;
                     missing
                 })
@@ -202,17 +257,11 @@ impl Interpreter {
                         && !pd.named
                 })
                 .count();
-            let has_arg_mismatch = args.len() > positional_count;
-            // A named argument (`$obj.m(:a)` → `Pair("a", …)`) must not be bound to a
-            // positional param by the fast path's index loop — it belongs in the
-            // implicit `*%_`, and a required positional left unfilled by it must die
-            // (`method m($x){}; X(:a)` → too-few-positionals). Routing any call that
-            // carries a Pair/ValuePair to the full path (which separates named from
-            // positional and validates arity via `bind_function_args_values`) keeps
-            // that check; the fast path stays for the common all-positional call.
-            let has_named_arg = args.iter().any(|a| a.is_any_pair_value());
+            let has_arg_mismatch = positional_arg_count > positional_count;
 
-            if !has_named_arg
+            if !has_unmodeled_pair_arg
+                && named_params_fast_ok
+                && !named_container_share
                 && !has_missing_required
                 && !has_invocant_constraint
                 && !has_attr_aliases
@@ -1419,7 +1468,11 @@ impl Interpreter {
                 .cloned()
         };
 
-        // Build param name → arg value mapping (skip invocant)
+        // Build param name → arg value mapping (skip invocant). Positional
+        // args are consumed in order, skipping named (string-keyed Pair)
+        // arguments the way the slow binder does; named params match Pair args
+        // by key (rightmost wins), and attributive named params write through
+        // the invocant's live attribute cell exactly like `bind_param_value`.
         let mut param_values: Vec<(&str, Value)> = Vec::new();
         let mut arg_idx = 0;
         for (idx, param_name) in method_def.params.iter().enumerate() {
@@ -1430,6 +1483,57 @@ impl Interpreter {
             if is_invocant {
                 param_values.push((param_name, base.clone()));
                 continue;
+            }
+            if let Some(pd) = pd.filter(|pd| pd.named) {
+                // Simple named/attributive param (gate: `named_param_fast_eligible`).
+                let bound = Self::named_param_fast_match_key(pd).and_then(|key| {
+                    args.iter()
+                        .rev()
+                        .find_map(|a| match a.unwrap_varref().view() {
+                            ValueView::Pair(k, v) if k.as_str() == key => Some(v.clone()),
+                            _ => None,
+                        })
+                });
+                let val = match bound {
+                    // `@`-sigiled (attributive) named param: re-home a List
+                    // into an Array (mirrors `bind_param_value`); scalar named
+                    // params are item bindings (mirrors the slow binder's
+                    // named arm).
+                    Some(v) if pd.name.starts_with('@') => {
+                        Self::normalize_positional_param_value(v)
+                    }
+                    Some(v) if pd.name.starts_with('%') => v,
+                    Some(v) => Self::itemize_plain_scalar_param(pd, v),
+                    // An unsupplied optional named param binds its type-object
+                    // default. For an attributive param this overwrites the
+                    // attribute — the slow path and rakudo both do (pinned by
+                    // t/tweak-named-fast-path.t).
+                    None => Self::missing_optional_param_value(pd),
+                };
+                // Attributive param: write the one attribute through `self`'s
+                // shared cell (the single-key cell write `bind_param_value`
+                // performs) BEFORE the locals-init loop below reads attribute
+                // slots off the cell.
+                if let Some((attr_name, _)) = crate::value::attr_twigil_base(&pd.name)
+                    && let Some(cell) = &attrs_cell
+                {
+                    // Inside a BUILD phase this bind counts as "BUILD set it",
+                    // even unpassed (the type-object bind must suppress the
+                    // `has $.a = 5` initializer; the seed comparison alone
+                    // cannot tell — an untyped attribute's seed IS the same
+                    // type object). The slow path records this via its exit
+                    // attr-local sync through `write_attr_cell_by_key`; the
+                    // fast path records it here. No-op outside BUILD.
+                    self.record_build_attr_write(cell, crate::symbol::Symbol::intern(attr_name));
+                    cell.insert(attr_name.to_string(), val.clone());
+                }
+                param_values.push((param_name, val));
+                continue;
+            }
+            // Positional param: skip named (string-Pair) args, as the slow
+            // binder does when consuming positionals.
+            while arg_idx < args.len() && args[arg_idx].unwrap_varref().is_string_pair_value() {
+                arg_idx += 1;
             }
             if arg_idx < args.len() {
                 let mut val = args[arg_idx].clone();

--- a/t/tweak-named-fast-path.t
+++ b/t/tweak-named-fast-path.t
@@ -1,0 +1,147 @@
+use v6;
+use Test;
+
+# Pins the compiled-method fast path's named/attributive parameter binding
+# (bench-ctor S6, todo/tickets/bench-ctor-construction-parity.md): simple
+# named scalar params and attributive named params (`:$!x`, `:@!a`, `:%!h`)
+# now bind on the fast path. Every behavior here was verified against rakudo
+# (v2026.06) before the fast path was extended, and must stay identical
+# whichever dispatch path a call takes.
+
+plan 33;
+
+# --- attributive scalar named param on TWEAK ---
+class TScalar {
+    has $.x = 10;
+    submethod TWEAK(:$!x) { }
+}
+# rakudo: an UNSUPPLIED attributive named param still binds — it overwrites
+# the attribute default with the type object.
+ok TScalar.new.x === Any, 'unsupplied :$!x overwrites the default with Any (rakudo semantics)';
+is TScalar.new(x => 5).x, 5, 'supplied :$!x binds the named arg into the attribute';
+
+# --- attributive array/hash named params on TWEAK ---
+class TContainers {
+    has @.r = (1, 2);
+    has %.m = (a => 1);
+    submethod TWEAK(:@!r, :%!m) { }
+}
+is-deeply TContainers.new.r, [], 'unsupplied :@!r binds a fresh empty Array';
+is-deeply TContainers.new.m, {}, 'unsupplied :%!m binds a fresh empty Hash';
+my $tc = TContainers.new(r => [3, 4], m => { b => 2 });
+is-deeply $tc.r, [3, 4], 'supplied :@!r binds through the attribute cell';
+is-deeply $tc.m, { b => 2 }, 'supplied :%!m binds through the attribute cell';
+# List re-homing: a List handed to :@!r becomes the array's elements.
+my $tl = TContainers.new(r => (7, 8));
+is $tl.r.elems, 2, ':@!r re-homes a List into the array';
+is $tl.r[1], 8, ':@!r element access after re-homing';
+
+# --- plain named scalar param on TWEAK, and %_ ---
+class TPlain {
+    has $.y;
+    has %.rest;
+    submethod TWEAK(:$z) { $!y = $z // 'none'; %!rest = %_; }
+}
+is TPlain.new.y, 'none', 'unsupplied :$z binds Any (// picks the default)';
+is TPlain.new(z => 7).y, 7, 'supplied :$z binds the named arg';
+is-deeply TPlain.new(z => 1, extra => 2).rest, { extra => 2 },
+    '%_ holds only named args not consumed by an explicit named param';
+
+# --- %_ excludes keys consumed by ATTRIBUTIVE params (rakudo behavior) ---
+class TSlurpySeen {
+    has $.x;
+    has %.seen;
+    submethod TWEAK(:$!x) { %!seen = %_; }
+}
+is-deeply TSlurpySeen.new(x => 5, q => 9).seen, { q => 9 },
+    '%_ excludes a key consumed by an attributive named param';
+
+# --- multi-level MRO TWEAK chain (the bench-ctor shape) ---
+class Base1 {
+    has $.spec;
+    submethod TWEAK(:$!spec) { }
+}
+class Child1 is Base1 {
+    has %!meta;
+    has @.resources;
+    has $.name;
+    method new(*%_) { self.bless(|%_, :meta(%_)) }
+    method meta { %!meta }
+    submethod TWEAK(:%!meta, :@!resources --> Nil) {
+        @!resources = @!resources.map(*.flat);
+    }
+}
+my $c = Child1.new(name => 'N', spec => 'S', resources => [(1, 2), (3,)]);
+is $c.name, 'N', 'MRO chain: ordinary attribute set by bless';
+is $c.spec, 'S', 'MRO chain: parent TWEAK attributive param bound';
+is $c.meta<name>, 'N', 'MRO chain: child TWEAK :%!meta bound from :meta(%_)';
+is $c.resources.elems, 2, 'MRO chain: child TWEAK body ran over @!resources';
+
+# --- defaults still evaluate (falls back to the full path when unsupplied) ---
+class TDefault {
+    has $.v;
+    submethod TWEAK(:$w = 40 + 2) { $!v = $w; }
+}
+is TDefault.new.v, 42, 'unsupplied defaulted named param evaluates its default expr';
+is TDefault.new(w => 1).v, 1, 'supplied defaulted named param binds the arg';
+
+# --- required named param still dies when missing ---
+class TRequired {
+    has $.v;
+    submethod TWEAK(:$r!) { $!v = $r; }
+}
+is TRequired.new(r => 3).v, 3, 'supplied required named param binds';
+dies-ok { TRequired.new }, 'missing required named param still dies';
+
+# --- type constraints keep the full path (still enforced) ---
+class TTyped {
+    has $.v;
+    submethod TWEAK(Int :$t) { $!v = $t; }
+}
+is TTyped.new(t => 3).v, 3, 'typed named param binds a conforming arg';
+dies-ok { TTyped.new(t => 'nope') }, 'typed named param still rejects a mismatch';
+
+# --- named params are readonly on every path ---
+class TReadonly {
+    method m(:$x) { $x = 5 }
+}
+dies-ok { TReadonly.new.m(x => 1) }, 'assigning to a named param still dies (readonly)';
+
+# --- ordinary methods (not just TWEAK) with named params ---
+class TMethod {
+    has $.acc = '';
+    method greet(:$name, :$punct) { "hi { $name // '?' }{ $punct // '' }" }
+    method both($pos, :$named) { "$pos/{ $named // 'n' }" }
+}
+is TMethod.new.greet(name => 'bob', punct => '!'), 'hi bob!', 'method named params bind';
+is TMethod.new.greet(punct => '?'), 'hi ??', 'method unsupplied named param is Any';
+is TMethod.new.both('p', named => 'x'), 'p/x', 'mixed positional + named binding';
+is TMethod.new.both('p'), 'p/n', 'mixed shape with named unsupplied';
+# rightmost duplicate named arg wins (slow-binder rule)
+is TMethod.new.greet(name => 'a', name => 'b'), 'hi b', 'rightmost duplicate named arg wins';
+
+# --- named container arg into a scalar named param still aliases the caller ---
+class TShare {
+    method push-it(:$n) { $n.push: 99 }
+}
+my @shared = 1, 2;
+TShare.new.push-it(n => @shared);
+is @shared.elems, 3, 'named @-variable arg into :$n still mutates the caller array';
+
+# --- BUILD attributive bind counts as "BUILD set it" (initializer suppressed) ---
+class TBuildBind {
+    has $.a = 5;
+    submethod BUILD(:$!a) { }
+}
+ok TBuildBind.new.a === Any, 'unpassed :$!a in BUILD suppresses the has-initializer';
+is TBuildBind.new(a => 9).a, 9, 'supplied :$!a in BUILD binds the named arg';
+
+# --- rename/alias params keep working (full path) ---
+class TAlias {
+    has $.v;
+    submethod TWEAK(:long(:$short)) { $!v = $short // 'none'; }
+}
+is TAlias.new(long => 'L').v, 'L', 'alias named param binds via outer key';
+is TAlias.new(short => 'S').v, 'S', 'alias named param binds via inner key';
+
+done-testing;

--- a/t/tweak-named-fast-path.t
+++ b/t/tweak-named-fast-path.t
@@ -8,7 +8,7 @@ use Test;
 # (v2026.06) before the fast path was extended, and must stay identical
 # whichever dispatch path a call takes.
 
-plan 33;
+plan 35;
 
 # --- attributive scalar named param on TWEAK ---
 class TScalar {
@@ -127,6 +127,19 @@ class TShare {
 my @shared = 1, 2;
 TShare.new.push-it(n => @shared);
 is @shared.elems, 3, 'named @-variable arg into :$n still mutates the caller array';
+
+# --- is hidden: no implicit *%_, so an unexpected named arg must die ---
+# (roast S12-class/interface-consistency.t test 5 — the fast path must not
+# silently drop a named arg the method has no %_ slurpy to absorb.)
+class THiddenBase {
+    method m1($a) { 1 }
+}
+class THidden is THiddenBase is hidden {
+    method m1($a) { 2 }
+}
+dies-ok { THidden.new.m1(1, :x<1>, :y<2>) },
+    'is hidden method (no implicit *%_) still dies on unexpected named args';
+is THidden.new.m1(1), 2, 'is hidden method still callable without named args';
 
 # --- BUILD attributive bind counts as "BUILD set it" (initializer suppressed) ---
 class TBuildBind {

--- a/todo/tickets/bench-ctor-construction-parity.md
+++ b/todo/tickets/bench-ctor-construction-parity.md
@@ -91,8 +91,11 @@ specializes the whole new -> bless -> BUILDALL chain.
   compiled BUILDALL that skips per-phase full-path dispatch + capture-style
   named args). Blast radius measured: 88 files / ~800 `to_map()`/`as_map()`
   sites.**
-- [ ] **S6 (NEW, 2026-08-25 — the actionable residual): extend the
+- [x] **S6 (NEW, 2026-08-25 — the actionable residual): extend the
   compiled-method fast path to simple named/attributive parameter shapes.**
+  **Implemented 2026-08-25 (round 4, see below): −15.9% instructions /
+  −21% wall clock on this bench; the `fast_method_cache` tier and the
+  TWEAK(Dist) closure-body residual remain follow-ups.**
   Instruction-count decomposition (see round 3 below) shows the two
   near-empty TWEAK submethods cost ~240k instructions/construction — 51% of
   the bench — and virtually all of it is full-path dispatch overhead, not
@@ -312,6 +315,72 @@ session with the binding roast set as gate) first; the S4-class
 construction-pipeline campaign (ADR) only after S6 lands and is measured, as
 S6 may take the CI ratio to parity by itself. S2's env_deep_copies remainder
 stays gated on `docs/vm-single-store.md` §3; S3 stays closed.**
+
+## Update (2026-08-25, round 4 — S6 implemented)
+
+S6 landed: the compiled-method fast path (`call_compiled_method` gate +
+`call_compiled_method_fast` binding, src/vm/vm_method_dispatch.rs) now accepts
+**simple named and attributive parameter shapes**, and calls carrying named
+(string-keyed Pair) arguments. What the fast path binds directly:
+
+- plain readonly scalar named params (`:$x`) — Pair args matched by key,
+  rightmost wins, itemized via `itemize_plain_scalar_param` like the binder;
+- attributive named params (`:$!x` / `:$.x` / `:@!a` / `:%!h`) — bound via the
+  same single-key live-cell write `bind_param_value` performs (`@`-sigiled
+  values re-homed through `normalize_positional_param_value`); an unsupplied
+  one binds its type-object default into the attribute (rakudo semantics,
+  verified against v2026.06 and pinned by `t/tweak-named-fast-path.t`);
+- the implicit/explicit `*%_` slurpy — leftover named args, with
+  `implicit_method_named_slurpy` fixed to strip sigil+twigil when computing
+  consumed keys (an attributive `:$!x` now keeps caller key "x" out of `%_`,
+  matching the slow path's `explicit_named_keys` and rakudo);
+- `method new(*%_)`-shaped methods called with all-named args (the custom-new
+  half of the bench) — no eligible-param change needed, only the arg-side gate.
+
+Conservative bails to the full path (all pinned by the new test): named params
+with traits / type constraints / where / sub-signature aliases (`:a(:$b)`) /
+defaults-when-unsupplied / required-when-missing; non-attributive `@`/`%`/`&`
+named params (container-alias semantics); non-string-keyed `ValuePair` args;
+internal `__mutsu_*` pairs; a named container-variable arg feeding a plain
+named scalar param (new `method_shares_container_into_named_scalar_param`,
+mirroring the sub side — `$n.push` writeback stays correct).
+`method_shares_container_into_scalar_param`'s positional alignment was also
+made Pair-aware (it could misalign once Pair args reach the gate). The
+`fast_method_cache` gate (vm_call_method_compiled_cache.rs) is deliberately
+unchanged — extending the *cached* tier to named shapes is a follow-up.
+
+One subtlety the full `make test` run caught: an attributive bind during the
+BUILD phase must be recorded via `record_build_attr_write`, or the post-BUILD
+initializer pass re-applies `has $.a = 5` over an *unpassed* `:$!a` bind — the
+seed comparison alone cannot tell, because an untyped attribute's seed IS the
+same `Any` type object the bind writes (t/build-attr-default-order.t test 8).
+The slow path records this through its exit attr-local sync
+(`write_attr_cell_by_key`); the fast path now records it at bind time.
+
+**Measured (release, core-pinned `perf stat -e instructions`, 5000 ctors,
+local box):**
+
+| slice                     | before (insns/ctor) | after | delta |
+|---------------------------|--------------------:|------:|------:|
+| full bench                | 474.4k | 399.2k | −75.2k (−15.9%) |
+| custom-new→bless plumbing | 233.8k (no-TWEAK variant) | 211.1k | −22.7k |
+| TWEAK(Spec) (empty body)  | 59.5k | 34.1k | −43% |
+| TWEAK(Dist) (`.map` body) | 181.1k | 154.0k | −15% |
+
+Wall clock (min of 5, `taskset -c 3`): 0.28s → 0.22s whole run, ≈52µs →
+≈40µs/ctor startup-subtracted (−21%). Confirm on bench CI after merge, per the
+measurement notes below.
+
+**Remaining headroom after S6:** TWEAK(Dist) still costs ~154k insns/ctor —
+dominated not by param binding but by its body's closure creation (`*.flat`
+MakeLambda per call), the non-scoped env path (its nested closure disables the
+overlay → the one real O(env) deep copy per ctor survives, still 15002
+env_deep_copies for the run), `flatten_scoped_env` on the nested `.map`
+dispatch, and the exit merge/reconcile. That is the `docs/vm-single-store.md`
+§3 territory round 3 already gated S2 on, plus the S4-class construction
+pipeline. Next actionable, if wanted: extend the `fast_method_cache` tier to
+the same named shapes, and look at per-call closure-literal reuse for
+immediately-invoked WhateverCode.
 
 ## Measurement notes
 

--- a/todo/tickets/bench-ctor-construction-parity.md
+++ b/todo/tickets/bench-ctor-construction-parity.md
@@ -357,6 +357,17 @@ same `Any` type object the bind writes (t/build-attr-default-order.t test 8).
 The slow path records this through its exit attr-local sync
 (`write_attr_cell_by_key`); the fast path now records it at bind time.
 
+A second subtlety the first CI run caught (all three roast jobs failed
+identically on S12-class/interface-consistency.t test 5): an `is hidden`
+class's methods get NO implicit `*%_` (`effective_method_param_defs`), so an
+unexpected named argument must die — but the fast path silently dropped
+leftover named args regardless of whether a `%_` slurpy existed to absorb
+them. Fixed with the `named_args_all_land` gate: named-arg calls take the
+fast path only when a `%`-named slurpy exists or every named key is consumed
+by an eligible named param; otherwise the full path raises the proper error.
+Pinned in t/tweak-named-fast-path.t. (No bench cost: normal methods have the
+implicit `*%_`, so the check short-circuits on the slurpy probe.)
+
 **Measured (release, core-pinned `perf stat -e instructions`, 5000 ctors,
 local box):**
 


### PR DESCRIPTION
## Summary

Implements **S6** of `todo/tickets/bench-ctor-construction-parity.md`: the round-3 instruction-count decomposition showed the two near-empty TWEAK submethods cost **~240k instructions per construction — 51% of bench-ctor** — purely in full-path dispatch overhead, because the `call_compiled_method` fast-path gate rejected ANY named (`pd.named`) or attributive (`:$!x`) parameter (`has_complex_params`) and any call carrying a Pair argument (`has_named_arg`).

The compiled-method fast path now binds, behind conservative allow-list gates (`named_param_fast_eligible`):

- **plain readonly scalar named params** (`:$x`) — Pair args matched by key, rightmost wins, itemized like the slow binder;
- **attributive named params** (`:$!x` / `:$.x` / `:@!a` / `:%!h`) — bound through the invocant's live attribute cell (the same single-key write `bind_param_value` performs); an unsupplied one binds its type-object default into the attribute (rakudo semantics, verified against v2026.06). During a BUILD phase the bind is recorded via `record_build_attr_write` so the post-BUILD initializer pass doesn't re-apply `has $.a = 5` over an unpassed `:$!a` (the untyped seed IS the same `Any` type object, so the seed comparison alone cannot tell — caught by `t/build-attr-default-order.t` in the full suite run);
- **named-arg calls to `*%_`-shaped methods** (`method new(*%_)`) — leftover named args flow into `%_` as before.

Everything else keeps the full path: named params with traits / type constraints / `where` / alias sub-signatures (`:a(:$b)`) / defaults-when-unsupplied / required-when-missing; non-attributive `@`/`%`/`&` named params (container-alias semantics); non-string-keyed `ValuePair` args; internal `__mutsu_*` pairs; and named container-variable args feeding a plain named scalar param (new `method_shares_container_into_named_scalar_param` mirrors the sub side, keeping `method m(:$n) { $n.push }` caller-mutation correct).

Supporting fixes:
- `implicit_method_named_slurpy` strips sigil+twigil when computing consumed keys, so `:$!x` keeps caller key `x` out of `%_` (matches the slow path's `explicit_named_keys` and rakudo; previously unreachable divergence).
- `method_shares_container_into_scalar_param` skips string-Pair args when aligning positional params (could misalign once Pairs reach the gate).

The `fast_method_cache` tier is deliberately unchanged (follow-up).

## Measurements (release, core-pinned `perf stat -e instructions`, 5000 ctors, local)

| slice | before (insns/ctor) | after | delta |
|---|---:|---:|---:|
| bench-ctor full | 474.4k | 399.2k | **−15.9%** |
| custom-new→bless (no-TWEAK variant) | 233.8k | 211.1k | −22.7k |
| TWEAK(Spec) (empty body) | 59.5k | 34.1k | −43% |
| TWEAK(Dist) (`.map` body) | 181.1k | 154.0k | −15% |

Wall clock (min of 5, `taskset`): 0.28s → 0.22s (≈52µs → ≈40µs/ctor startup-subtracted, **−21%**). Bench CI remains the source of truth; the remaining TWEAK(Dist) residual is closure/env work gated on `docs/vm-single-store.md` §3 (documented in the ticket's round-4 entry).

## Testing

- New `t/tweak-named-fast-path.t` (33 assertions; every behavior verified against rakudo v2026.06, file passes under both raku and mutsu).
- Full `make test`: 3415 files / 32114 tests, PASS.
- Roast binding gate: `S06-signature/named-*`, `S12-construction/*` (all 8 files), all of `S12-methods/`, `S06-multi/positional-vs-named.t`, `redispatch.t` — all green.
- gdb-verified all three bench dispatches (`new`, `TWEAK(Spec)`, `TWEAK(Dist)`) now take `call_compiled_method_fast`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
