### PR TITLE
fix(parser): compound-assign RHS continues past a parenthesized inner assignment

### DIFF
--- a/news/2026-08/compound-assign-paren-rhs-infix-continuation.md
+++ b/news/2026-08/compound-assign-paren-rhs-infix-continuation.md
@@ -1,0 +1,73 @@
+# Compound-assignment RHS now continues past a parenthesized inner assignment
+
+`$term += ($sign = -$sign) / $_` — the inner loop of a Rosetta Code
+Euler-Mascheroni (Vacca series) program — failed to parse in mutsu with
+`Runtime error: Regex not terminated.` (issue #6953), even though `raku` runs
+it fine. The minimal repro was even smaller:
+
+```raku
+my $a; my $b = 1;
+$a += ($b = 2) / 2;   # mutsu: "Regex not terminated."; raku: $a becomes 1
+```
+
+## Root cause
+
+Statement-level `$var += RHS` parses its RHS through
+`parse_assign_expr_or_comma_no_word_logical` (`src/parser/stmt/assign/sink.rs`),
+which tries `try_parse_assign_expr` first so a chained assignment like
+`$a += $b = 3` still works. When the RHS text starts with `(` and looks like
+a parenthesized assignment, `try_parse_assign_expr` delegates to
+`parenthesized_assign_expr` (`src/parser/stmt/assign/paren.rs`), which parses
+`($b = 2)` and returns *immediately* after the closing `)` — without checking
+whether a tighter infix operator (`/`, `+`, `-`, `*`, ...) follows.
+
+`+=` is item assignment in Raku, which is *looser* than the following `/`, so
+`$a += ($b = 2) / 2` must parse as `$a += (($b = 2) / 2)`. Because the
+compound-assign RHS parsers treated the paren-assignment shortcut's `Ok`
+result as the complete answer, the leftover `/ 2` became a separate
+statement. In term position a leading `/` starts a regex literal, which never
+terminates — hence the confusing "Regex not terminated" error. For `+`, `-`,
+and `*` the leftover text didn't error; it silently parsed as a second,
+sink-context statement, producing a *silently wrong* answer instead
+(`$a += ($b = 2) + 3` gave `$a == 2` instead of `5`).
+
+The plain (non-compound) `$var = RHS` path never hit this bug: it parses its
+RHS with `expression_no_word_logical` directly (not `try_parse_assign_expr`),
+so `paren_expr` (the general parenthesized-primary parser) recognizes the
+inner assignment, wraps it in `Expr::Grouped`, and the ambient
+precedence-climbing call stack (`additive_expr` → `multiplicative_expr` → ...
+→ `primary` → `paren_expr`) naturally continues parsing `/ 2` on top of it —
+exactly the continuation the compound-assign RHS path was missing.
+
+## Fix
+
+Added `paren_assign_rhs_is_complete` (`src/parser/stmt/assign/try_assign.rs`):
+given the input immediately after a parenthesized-assignment's closing `)`,
+it reports whether that's a genuine terminator (end of input, `;`, `)`, `}`,
+`]`, a comma, `=>`, or a loose word-logical / statement-modifier keyword that
+an enclosing layer is responsible for) as opposed to a tighter infix/postfix
+operator that still needs to bind to the group.
+
+The compound-assign RHS call sites — `parse_assign_expr_or_comma` and
+`parse_assign_expr_or_comma_no_word_logical` (`sink.rs`), and the
+`parse_compound_assign_op` arm of `try_parse_assign_expr` itself
+(`try_assign.rs`, per the reporter's note that the expression-form compound-
+assign path needed the identical fix) — now only accept the parenthesized-
+assignment shortcut when `paren_assign_rhs_is_complete` holds. Otherwise they
+discard the shortcut result and fall back to the general expression grammar
+(`parse_comma_or_expr`/`_no_word_logical`, `expression_no_sequence`), which
+reaches the same recognition through `paren_expr` and then correctly
+continues the infix/postfix precedence chain — the same mechanism that
+already made the plain `=` case work.
+
+## Tests
+
+`t/compound-assign-paren-rhs-infix.t` (22 assertions, cross-checked against
+`raku`) covers: the issue's minimal repros (`/`, and the Vacca-series
+`($sign = -$sign) / $_` shape), the silently-wrong-answer `+`/`-`/`*`
+variants, the negative cases from the issue that must keep working (plain
+`=`, no inner paren-assignment, extra grouping parens, parenthesized `(my
+$)`/`(my $x)`/`($x)` lvalue targets, and a `my` declaration inside parens),
+the Vacca-series inner loop with a small range, and the full motivating
+Rosetta Code `gamma` function for `N=10` (`0.574285301882304`, matching
+`raku` exactly).

--- a/src/parser/stmt/assign.rs
+++ b/src/parser/stmt/assign.rs
@@ -80,7 +80,7 @@ pub(in crate::parser) use comma::{
     normalize_comma_list_items, parse_comma_or_expr, parse_comma_or_expr_item_no_word_logical,
     parse_comma_or_expr_no_word_logical,
 };
-pub(in crate::parser) use try_assign::try_parse_assign_expr;
+pub(in crate::parser) use try_assign::{paren_assign_rhs_is_complete, try_parse_assign_expr};
 
 pub(crate) use bracket::parse_bracket_meta_assign_op;
 pub(crate) use compound_expr::{

--- a/src/parser/stmt/assign/sink.rs
+++ b/src/parser/stmt/assign/sink.rs
@@ -2,7 +2,18 @@ use super::*;
 
 pub(crate) fn parse_assign_expr_or_comma(input: &str) -> PResult<'_, Expr> {
     // Try to parse a chained assignment: $var op= ...
-    if let Ok((rest, assign_expr)) = try_parse_assign_expr(input) {
+    //
+    // `try_parse_assign_expr` short-circuits a leading parenthesized
+    // assignment (`($b = 2)`), stopping right after the `)`. When something
+    // other than a clean terminator follows -- e.g. `($b = 2) / 2`, where `/`
+    // still needs to bind to the whole group -- fall through to
+    // `parse_comma_or_expr` below instead, which reaches the same
+    // recognition through `paren_expr` (wrapping it in `Expr::Grouped`) and
+    // then correctly continues the infix/postfix precedence chain, exactly
+    // like the plain `=` statement path already does. See #6953.
+    if let Ok((rest, assign_expr)) = try_parse_assign_expr(input)
+        && (!input.starts_with('(') || paren_assign_rhs_is_complete(rest))
+    {
         // After a chained assign, check for comma list at this level
         let (r, _) = ws(rest)?;
         // A chained *list* assignment to an `@`/`%` container absorbs the comma
@@ -94,7 +105,12 @@ pub(crate) fn parse_assign_expr_or_comma(input: &str) -> PResult<'_, Expr> {
 /// `(@a = 1, 2) and 3` while `$x ||= 42, 43` keeps its item-assignment
 /// (comma-tight) `||=`.
 pub(crate) fn parse_assign_expr_or_comma_no_word_logical(input: &str) -> PResult<'_, Expr> {
-    if let Ok((rest, assign_expr)) = try_parse_assign_expr(input) {
+    // See the matching comment in `parse_assign_expr_or_comma` above (#6953):
+    // only take the parenthesized-assignment shortcut when nothing but a
+    // clean terminator follows the `)`.
+    if let Ok((rest, assign_expr)) = try_parse_assign_expr(input)
+        && (!input.starts_with('(') || paren_assign_rhs_is_complete(rest))
+    {
         let (r, _) = ws(rest)?;
         // Chained *list* assignment to an `@`/`%` container absorbs the comma list
         // on its right (see [`parse_assign_expr_or_comma`]).

--- a/src/parser/stmt/assign/try_assign.rs
+++ b/src/parser/stmt/assign/try_assign.rs
@@ -1,5 +1,72 @@
 use super::*;
 
+/// Does `rest` -- the input immediately after a parenthesized-assignment's
+/// closing `)` -- start with something an ENCLOSING layer is responsible for
+/// consuming (a comma list, a trailing word-logical/statement-modifier
+/// re-attached above this precedence level, an enclosing bracket, etc.), as
+/// opposed to a tighter infix/postfix operator that must still bind to the
+/// group itself?
+///
+/// Used by [`try_parse_assign_expr`]'s callers to decide whether a
+/// successful parenthesized-assignment shortcut (`($b = 2)` recognized as a
+/// complete `Expr::AssignExpr`, stopping right after the `)`) is really the
+/// whole answer. When it is NOT -- e.g. `($b = 2) / 2`, where `/` still needs
+/// to apply to the whole group -- the caller must discard the shortcut and
+/// re-parse via the general expression grammar instead, which recognizes the
+/// same inner assignment through `paren_expr` (wrapping it in
+/// `Expr::Grouped`) and then correctly continues through the normal
+/// infix/postfix precedence chain (see `fixes #6953`).
+pub(in crate::parser) fn paren_assign_rhs_is_complete(rest: &str) -> bool {
+    let Ok((rest, _)) = ws(rest) else {
+        return true;
+    };
+    if rest.is_empty() {
+        return true;
+    }
+    if rest.starts_with(';')
+        || rest.starts_with(')')
+        || rest.starts_with('}')
+        || rest.starts_with(']')
+    {
+        return true;
+    }
+    if rest.starts_with(",,") {
+        return false;
+    }
+    if rest.starts_with(',') || rest.starts_with("=>") {
+        return true;
+    }
+    // Loose word-logicals and statement modifiers are looser than assignment
+    // and are re-attached by an enclosing layer (`word_logical_split`,
+    // `parse_statement_modifier`) -- they must not be treated as "more RHS".
+    const WORD_TERMINATORS: [&str; 11] = [
+        "andthen",
+        "notandthen",
+        "orelse",
+        "and",
+        "or",
+        "xor",
+        "if",
+        "unless",
+        "while",
+        "until",
+        "for",
+    ];
+    for kw in WORD_TERMINATORS {
+        if let Some(after) = rest.strip_prefix(kw) {
+            let is_boundary = after
+                .chars()
+                .next()
+                .map(|c| !c.is_alphanumeric() && c != '_')
+                .unwrap_or(true);
+            if is_boundary {
+                return true;
+            }
+        }
+    }
+    false
+}
+
 /// Parse a single argument in colon method-call syntax (.method: arg1, arg2).
 /// Tries colonpair first (:name, :$var, :!flag, :0port), then expression.
 pub(crate) fn parse_colon_method_arg(input: &str) -> PResult<'_, Expr> {
@@ -375,9 +442,20 @@ pub(in crate::parser) fn try_parse_assign_expr(input: &str) -> PResult<'_, Expr>
         let (rest, rhs) = if op.is_list_precedence() {
             parse_comma_or_expr(rest)?
         } else {
+            // `try_parse_assign_expr` short-circuits a leading parenthesized
+            // assignment (`($b = 2)`), stopping right after the `)`. But
+            // `+=` (and friends) is item assignment -- looser than a
+            // following tighter infix like `/` -- so `$a += ($b = 2) / 2`
+            // must parse as `$a += (($b = 2) / 2)`. Only accept the shortcut
+            // when nothing but a clean terminator follows the `)`;
+            // otherwise fall back to the general expression grammar, which
+            // reaches the same recognition through `paren_expr` and then
+            // correctly continues the infix/postfix chain. See #6953.
             match try_parse_assign_expr(rest) {
-                Ok(r) => r,
-                Err(_) => expression_no_sequence(rest)?,
+                Ok((r, expr)) if !rest.starts_with('(') || paren_assign_rhs_is_complete(r) => {
+                    (r, expr)
+                }
+                _ => expression_no_sequence(rest)?,
             }
         };
         let name = format!("{}{}", prefix, var);

--- a/t/compound-assign-paren-rhs-infix.t
+++ b/t/compound-assign-paren-rhs-infix.t
@@ -1,0 +1,112 @@
+use Test;
+
+plan 22;
+
+# GitHub issue #6953: `$a += ($b = 2) / 2` failed to parse ("Regex not
+# terminated") because the parenthesized-assignment shortcut inside
+# `try_parse_assign_expr` recognized `($b = 2)` and stopped right after the
+# closing `)`, leaving `/ 2` as a dangling leftover statement. In term
+# position a leading `/` starts a regex literal, which never terminates.
+# `+`/`-`/`*` didn't error, but silently produced the WRONG answer: the RHS
+# collapsed to just `($b = 2)` and the trailing operator became a separate
+# (sink-context) statement.
+#
+# `+=` is item assignment in Raku, which is LOOSER than the following tighter
+# infix, so `$a += ($b = 2) / 2` must parse as `$a += (($b = 2) / 2)`.
+
+# --- the exact minimal repros from the issue ---
+{
+    my $a; my $b = 1;
+    $a += ($b = 2) / 2;
+    is $a, 1, '$a += ($b = 2) / 2 -- division continues past the paren-assign';
+    is $b, 2, '... and $b was still assigned by the inner paren-assignment';
+}
+
+{
+    my $term = 0; my $sign = 1;
+    $term += ($sign = -$sign) / 2;
+    is $term, -0.5, '$term += ($sign = -$sign) / 2 -- Vacca-series minimal shape';
+    is $sign, -1, '... and $sign was flipped by the inner paren-assignment';
+}
+
+# --- the silently-wrong-answer variants (+, -, *) ---
+{
+    my $a; my $b = 1;
+    $a += ($b = 2) + 3;
+    is $a, 5, '$a += ($b = 2) + 3 -- addition continues past the paren-assign';
+    is $b, 2, '... and $b was still assigned';
+}
+
+{
+    my $a; my $b = 1;
+    $a += ($b = 2) * 3;
+    is $a, 6, '$a += ($b = 2) * 3 -- multiplication continues past the paren-assign';
+}
+
+{
+    my $a; my $b = 1;
+    $a -= ($b = 2) - 3;
+    is $a, 1, '$a -= ($b = 2) - 3 -- subtraction continues past the paren-assign';
+    is $b, 2, '... and $b was still assigned';
+}
+
+# --- cases that must keep working (negative/regression coverage) ---
+{
+    my $a = 10; my $b = 1;
+    $a = ($b = 2) / 2;
+    is $a, 1, 'plain `=` (not compound) already worked and must keep working';
+    is $b, 2, '... $b assigned';
+}
+
+{
+    my $a; my $b = 1;
+    $a += $b / 2;
+    is $a, 0.5, 'no inner paren-assignment: += RHS is a plain division';
+}
+
+{
+    my $a; my $b = 1;
+    $a += (($b = 2) / 2);
+    is $a, 1, 'extra parens make the division part of the grouped primary';
+    is $b, 2, '... $b assigned';
+}
+
+{
+    (my $) += ($ = 1) / 1;
+    pass 'parenthesized anonymous-state lvalue does not blow up';
+}
+
+{
+    (my $x) += ($ = 1) / 1;
+    is $x, 1, 'parenthesized `my` lvalue target with paren-assign RHS';
+}
+
+{
+    my $x; ($x) += ($ = 1) / 1;
+    is $x, 1, 'parenthesized plain-var lvalue target with paren-assign RHS';
+}
+
+{
+    my $a; my $b = 1;
+    $a += (my $x = 1) / 2;
+    is $a, 0.5, 'a `my` decl inside parens is not try_parse_assign_expr, falls through correctly';
+    is $x, 1, '... and the `my` declaration itself still ran';
+}
+
+# --- the actual Vacca-series minimal shape (small loop) ---
+{
+    my ($power, $sign, $term) = 4, -1, 0;
+    for $power..^2*$power { $term += ($sign = -$sign) / $_ }
+    is $term, 0.07381, 'Vacca-series inner loop shape matches raku';
+    is $sign, -1, '... sign ends flipped an odd number of times';
+}
+
+# --- the original motivating Rosetta Code program (small N, no .race for determinism) ---
+sub vacca-gamma (\N where N > 1) {
+    return (1/2 - 1/3) + [+] (2..N).map: -> \n {
+        my ($power, $sign, $term) = 2**n, -1;
+        for $power..^2*$power { $term += ($sign = -$sign) / $_ }
+        n * $term
+    }
+}
+is vacca-gamma(10), 0.574285301882304, 'Vacca series Euler-Mascheroni approximation (N=10)';


### PR DESCRIPTION
## Summary

`$term += ($sign = -$sign) / $_` (the inner loop of a Rosetta Code Euler-Mascheroni / Vacca series program) failed to parse in mutsu with `Runtime error: Regex not terminated.`, even though `raku` runs it fine.

**Root cause:** statement-level `$var += RHS` parses its RHS through `try_parse_assign_expr`, which tries a parenthesized-assignment shortcut first (to support chained assignment like `$a += $b = 3`). When the RHS starts with `(...)` and looks like an assignment, `parenthesized_assign_expr` parses `($b = 2)` and returns immediately after the closing `)`, without checking whether a tighter infix operator (`/`, `+`, `-`, `*`, ...) follows. `+=` is item assignment in Raku, looser than `/`, so `$a += ($b = 2) / 2` must parse as `$a += (($b = 2) / 2)`. The leftover `/ 2` became a separate statement; in term position a leading `/` starts a regex literal that never terminates. For `+`/`-`/`*` the leftover didn't error — it silently parsed as a second, sink-context statement, giving a silently WRONG answer instead (`$a += ($b = 2) + 3` gave `$a == 2`, not `5`).

The plain `=` path never hit this: it parses its RHS with `expression_no_word_logical` directly, so `paren_expr` wraps the inner assignment in `Expr::Grouped` and the ambient precedence-climbing call stack (`additive_expr` -> `multiplicative_expr` -> ... -> `primary` -> `paren_expr`) naturally continues parsing `/ 2` on top of it.

**Fix:** add `paren_assign_rhs_is_complete` (`src/parser/stmt/assign/try_assign.rs`), which checks whether the input right after a parenthesized-assignment's closing `)` is a genuine terminator (end of input, `;`, `)`, `}`, `]`, comma, `=>`, or a loose word-logical/statement-modifier an enclosing layer handles) versus a tighter infix/postfix operator that still needs to bind to the group. The compound-assign RHS call sites — `parse_assign_expr_or_comma` and `parse_assign_expr_or_comma_no_word_logical` (`sink.rs`), and the compound-assign-op arm of `try_parse_assign_expr` itself (`try_assign.rs`, the expression-form compound-assign path) — now only accept the shortcut when that check holds; otherwise they fall back to the general expression grammar, which reaches the same recognition through `paren_expr` and correctly continues the infix/postfix chain.

Fixes #6953

## Test plan

- [x] `t/compound-assign-paren-rhs-infix.t` (22 assertions, cross-checked against `raku`): the issue's minimal repros, the `+`/`-`/`*` silently-wrong-answer variants, all of the issue's negative/regression cases (plain `=`, no inner paren-assignment, extra grouping parens, `(my $)`/`(my $x)`/`($x)` parenthesized lvalue targets, a `my` declaration inside parens), the Vacca-series inner loop, and the full motivating Rosetta Code `gamma()` function for N=10 (matches `raku` exactly: `0.574285301882304`).
- [x] `cargo build`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo fmt`
- [x] `make test` (local, full suite): `All tests successful. Files=3415, Tests=32103 ... Result: PASS`
- [ ] CI (`make test` + `make roast`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)