### PR TITLE
fix: render Backtrace::Frame .gist/.raku with Rakudo's attribute shape

### DIFF
--- a/news/2026-08/backtrace-frame-gist-raku-attribute-shape.md
+++ b/news/2026-08/backtrace-frame-gist-raku-attribute-shape.md
@@ -1,0 +1,49 @@
+# Backtrace::Frame's .gist and .raku now render Rakudo's attribute shape
+
+`Backtrace::Frame.gist` and `.raku` used to diverge sharply from Rakudo:
+`.gist` reused the frame's `.Str` text (`  in block <unit> at f.raku line 3`),
+and `.raku` fell through to the generic no-declared-attributes instance
+renderer, producing a bare `Backtrace::Frame.new` with nothing inside the
+parens.
+
+Rakudo's `Backtrace::Frame` has no custom `.gist` method, so it inherits the
+default `Mu` rendering, which is identical to `.raku`:
+
+```
+Backtrace::Frame.new(file => "...", line => 3, code => -> { ... }, subname => "<unit>")
+```
+
+mutsu now renders the same shape for both methods. `.Str` is unchanged (it
+stays the concise `  in block/sub ... at ... line N` text, which is what
+`Backtrace.full`/`.concise`/`.summary` are built from).
+
+## Why this needed `&mut self`
+
+A `Backtrace::Frame` instance only carries `subname`/`file`/`line` attributes;
+`.code` is synthesized on demand as a `Routine` stub (mutsu retains no real
+callframe object to point `.code` at). Rendering `code => ...` therefore means
+recursively invoking that synthesized value's own `.raku`, which needs the
+interpreter (`&mut self`) — something the pure, `&self`-free fast-path cascade
+in `builtins/methods_0arg/mod.rs` cannot do. The new rendering lives in
+`default_instance_repr` (`runtime/methods_instance_ops.rs`), the same place
+that already special-cases `IO::Path::Parts`, `Stash`, and a handful of other
+native pseudo-classes whose `.raku`/`.gist` need to recurse into a field's own
+rendering.
+
+`.gist` for `Backtrace::Frame` moved off the fast path entirely (it now falls
+through to the same `default_instance_repr` default that `.raku` already used
+to reach), so its `native_method_row_table.rs` arity row was removed — it was
+never rowed for `.raku` either, since that method was never in the fast-path
+cascade to begin with.
+
+A byte-identical `.raku` is not achievable: Rakudo's `code => ...` embeds a
+`Block`/`Method`'s per-run memory address, which mutsu's synthesized `Routine`
+stub does not model in the same way. The regression test
+(`t/backtrace-frame-gist-raku.t`) therefore asserts on the attribute shape
+(via a regex), not on an exact string, and passes unmodified under both
+`raku` and `mutsu`.
+
+Frame **count** and frame-model differences (mutsu has no Raku-written CORE
+setting, so it never has Rakudo's extra `SETTING::` frames) are unrelated and
+remain deliberately deferred — see
+`todo/tickets/backtrace-has-fewer-frames-than-rakudo.md`.

--- a/src/builtins/backtrace_methods.rs
+++ b/src/builtins/backtrace_methods.rs
@@ -20,6 +20,7 @@
 //! Rakudo's absolute frame count is deliberately not attempted.
 
 use crate::gc::Gc;
+use crate::symbol::Symbol;
 use crate::value::{InstanceAttrs, RuntimeError, Value, ValueView};
 
 /// Render a `Backtrace::Frame` instance as its `.Str`/`.gist` text.
@@ -56,6 +57,20 @@ fn frame_entry(subname: &str, file: &str, line: &str) -> String {
     } else {
         format!("  in sub {} at {} line {}", subname, file, line)
     }
+}
+
+/// The `Backtrace::Frame.code` value: mutsu does not retain the actual
+/// routine a frame points into, so this synthesizes a `Routine` carrying just
+/// the frame's `subname` (`.code.name` is the documented use). Shared by the
+/// `code` accessor and the `.raku`/`.gist` renderer so both describe the same
+/// object.
+pub(crate) fn frame_code_value(attributes: &Gc<InstanceAttrs>) -> Value {
+    let subname = attributes
+        .as_map()
+        .get("subname")
+        .map(|v| v.to_string_value())
+        .unwrap_or_default();
+    Value::routine_parts(Symbol::intern("GLOBAL"), Symbol::intern(&subname), false)
 }
 
 /// A `Backtrace::Frame` is a "routine" frame when it has a real subname

--- a/src/builtins/methods_0arg/mod.rs
+++ b/src/builtins/methods_0arg/mod.rs
@@ -1661,22 +1661,23 @@ fn dispatch_core(target: &Value, method: &str) -> Option<Result<Value, RuntimeEr
                         .cloned()
                         .unwrap_or(Value::int(0))));
                 }
-                "Str" | "gist" => {
+                // `.raku`/`.gist` are NOT handled here: Rakudo's
+                // `Backtrace::Frame` renders both as
+                // `Backtrace::Frame.new(file => ..., line => ..., code => ...,
+                // subname => ...)` (it has no custom `.gist`, so it falls back
+                // to the default `.raku`-shaped one), which needs `&mut self`
+                // to recursively render the synthesized `code` object -- see
+                // `default_instance_repr`'s `"Backtrace::Frame"` arm
+                // (`runtime/methods_instance_ops.rs`).
+                "Str" => {
                     return Some(Ok(Value::str(backtrace_frame_str(&attributes))));
                 }
                 "code" => {
                     // The Code object for this frame. mutsu does not retain the
                     // actual routine, so synthesize a Routine carrying the name
                     // (`.code.name` is the documented use).
-                    let subname = attributes
-                        .as_map()
-                        .get("subname")
-                        .map(|v| v.to_string_value())
-                        .unwrap_or_default();
-                    return Some(Ok(Value::routine_parts(
-                        Symbol::intern("GLOBAL"),
-                        Symbol::intern(&subname),
-                        false,
+                    return Some(Ok(crate::builtins::backtrace_methods::frame_code_value(
+                        &attributes,
                     )));
                 }
                 "name" => {

--- a/src/builtins/native_method_row_table.rs
+++ b/src/builtins/native_method_row_table.rs
@@ -969,7 +969,12 @@ pub(super) const RAW_ROWS: &[(&str, &str, u8, u8)] = &[
     ("Backtrace::Frame", "is-hidden", 1, 0),
     ("Backtrace::Frame", "file", 1, 0),
     ("Backtrace::Frame", "line", 1, 0),
-    ("Backtrace::Frame", "gist", 1, 0),
+    // `.gist` moved off the fast path: `Backtrace::Frame` has no custom
+    // `.gist` in Rakudo, so it falls back to the same attribute-listing
+    // default `default_instance_repr` gives `.raku` (which needs `&mut
+    // self` to recursively render the synthesized `code` object, so it
+    // cannot live in this pure fast-path cascade). No row here, matching
+    // `.raku`, which was never rowed for this owner either.
     ("Range", "hyper", 1, 8),
     ("Range", "lazy", 1, 8),
     ("Range", "int-bounds", 1, 8),

--- a/src/runtime/methods_instance_ops.rs
+++ b/src/runtime/methods_instance_ops.rs
@@ -38,9 +38,9 @@ impl Interpreter {
     /// Mu's default `.gist`/`.raku`/`.perl` rendering for a plain user
     /// instance (`ClassName.new(...)`, with special cases for `is Array`
     /// subclasses, `ObjAt`/`ValueObjAt`, `X::AdHoc`, schedulers,
-    /// `IO::Path::Parts`, `Stash`). Returns `None` when `method`/`args`
-    /// don't qualify (e.g. `.Str`, or a non-empty arg list) or `target`
-    /// isn't an Instance.
+    /// `IO::Path::Parts`, `Stash`, `Backtrace::Frame`). Returns `None` when
+    /// `method`/`args` don't qualify (e.g. `.Str`, or a non-empty arg list)
+    /// or `target` isn't an Instance.
     ///
     /// Factored out of `dispatch_instance_and_fallback`'s no-user-override
     /// fast path below so `native_any_base_next_candidate`
@@ -174,6 +174,41 @@ impl Interpreter {
                 return Some(Ok(Value::str(
                     crate::builtins::methods_0arg::raku_repr::raku_value(&symbols),
                 )));
+            }
+            // Rakudo's `Backtrace::Frame` has no custom `.gist`, so it falls
+            // back to the default `Backtrace::Frame.new(file => ..., line =>
+            // ..., code => ..., subname => ...)` rendering for BOTH `.gist`
+            // and `.raku` -- unlike the plain `.Str` text (`  in block ... at
+            // ... line N`), which `Str`/`gist`'s native fast path already
+            // handles and this arm never sees. `code` has no attribute of its
+            // own (it is synthesized on demand by the frame's `code`
+            // accessor), so it is rebuilt here the same way and rendered
+            // through the ordinary Code `.raku` dispatch.
+            "Backtrace::Frame" => {
+                let attr_map = attributes.as_map();
+                let file_value = attr_map
+                    .get("file")
+                    .cloned()
+                    .unwrap_or_else(|| Value::str(String::new()));
+                let line_value = attr_map.get("line").cloned().unwrap_or(Value::int(0));
+                let subname_value = attr_map
+                    .get("subname")
+                    .cloned()
+                    .unwrap_or_else(|| Value::str(String::new()));
+                let code_value = crate::builtins::backtrace_methods::frame_code_value(&attributes);
+                let raku_of = |interp: &mut Interpreter, v: Value| -> String {
+                    interp
+                        .call_method_with_values(v.clone(), "raku", vec![])
+                        .map(|r| r.to_string_value())
+                        .unwrap_or_else(|_| v.to_string_value())
+                };
+                let file = raku_of(self, file_value);
+                let line = raku_of(self, line_value);
+                let code = raku_of(self, code_value);
+                let subname = raku_of(self, subname_value);
+                return Some(Ok(Value::str(format!(
+                    "Backtrace::Frame.new(file => {file}, line => {line}, code => {code}, subname => {subname})"
+                ))));
             }
             _ => {}
         }

--- a/t/backtrace-frame-gist-raku.t
+++ b/t/backtrace-frame-gist-raku.t
@@ -1,0 +1,63 @@
+use v6;
+use Test;
+
+plan 15;
+
+# Backtrace::Frame has no custom `.gist` in Rakudo, so both `.gist` and
+# `.raku` fall back to the default instance rendering:
+#   Backtrace::Frame.new(file => "...", line => N, code => ..., subname => "...")
+# `.Str` is a different, deliberately concise rendering
+# ("  in block/sub ... at ... line N") and must stay untouched by this.
+# Frame *count* and *ordering* legitimately differ between mutsu and rakudo
+# (mutsu has no Raku-written CORE setting, so it has no setting frames --
+# see todo/tickets/backtrace-has-fewer-frames-than-rakudo.md), so this test
+# only asserts on the *shape* of a frame's rendering, never on which frame
+# ends up at a given index or on the `code =>` object's memory address.
+
+sub zipi { { { die "Something bad happened" }() }() };
+try {
+    zipi;
+}
+
+my $bt = $!.backtrace;
+ok $bt.defined, 'a caught exception carries a Backtrace';
+ok $bt.elems > 0, 'the Backtrace has at least one frame';
+
+my $f = $bt[0];
+isa-ok $f, Backtrace::Frame, '$bt[0] is a Backtrace::Frame';
+
+# .Str stays the concise "  in ... at ... line N" text, unaffected by the
+# .gist/.raku fix. (The exact leading word -- "block"/"sub"/"method" -- is
+# gap-2 frame-model territory, so this only checks the surrounding shape.)
+ok $f.Str.starts-with('  in ') && $f.Str.contains(' at ') && $f.Str.contains(' line '),
+        '.Str keeps its concise "in ... at ... line N" shape';
+
+my $frame_shape = rx/
+    ^ 'Backtrace::Frame.new(file => "' <-[ " ]>* '", '
+    'line => ' \d+ ', '
+    'code => ' .+ ', '
+    'subname => "' <-[ " ]>* '")' $
+/;
+
+like $f.raku, $frame_shape, '.raku renders the Backtrace::Frame.new(...) attribute shape';
+like $f.gist, $frame_shape, '.gist renders the same attribute shape as .raku';
+is $f.gist, $f.raku, '.gist and .raku produce the same string';
+
+# .Str must not have regressed into the same shape as .gist/.raku.
+isnt $f.Str, $f.gist, '.Str is still the concise text, not the .new(...) form';
+
+# The individual accessors that feed the rendering above must work too.
+isa-ok $f.file, Str, '.file returns a Str';
+ok $f.file.chars > 0, '.file is non-empty';
+isa-ok $f.line, Int, '.line returns an Int';
+ok $f.line > 0, '.line is positive';
+isa-ok $f.subname, Str, '.subname returns a Str';
+
+my $bool_predicates = so $f.is-hidden ~~ Bool
+        and $f.is-routine ~~ Bool
+        and $f.is-setting ~~ Bool;
+ok $bool_predicates, '.is-hidden / .is-routine / .is-setting all answer Bool';
+
+# .code is documented as "the code object .file/.line point into" -- it
+# should at least be defined and stringify without dying.
+ok $f.code.defined, '.code is defined';

--- a/todo/tickets/backtrace-has-fewer-frames-than-rakudo.md
+++ b/todo/tickets/backtrace-has-fewer-frames-than-rakudo.md
@@ -4,23 +4,16 @@ Found by the doc-diff harness re-run (`docs/doc-diff-backlog.md`, `Type/Backtrac
 
 ## Status
 
-This ticket originally covered two gaps. **Gap 1 (positional indexing) is
-fixed** — see `news/2026-08/backtrace-positional-indexing.md`. Only gap 2, the
-frame-count difference, remains open, and it is deliberately deferred (see
-"Why this is deferred" below).
+This ticket originally covered three gaps:
 
-- [x] **Gap 1 — `$bt[N]` returned `Nil`.** Positional indexing into a
-  `Backtrace` always answered `Nil`/`Any` regardless of the index, because no
-  arm of the subscript dispatch knew about the `frames` attribute. The
-  subscript now delegates to the stored `frames` List, so every index shape
-  (single index, `[*-1]`, `[0,1]` slices, `[^2]`/`[0 .. *-1]` ranges, `[*]`,
-  and out-of-range reading back as `Nil`) behaves exactly as it does on a
-  List. `$bt.AT-POS($i)` was implemented alongside it. Pinned by
-  `t/backtrace-positional-index.t`, which passes unmodified under both `raku`
-  and `mutsu`.
-- [ ] **Gap 2 — fewer frames than Rakudo.** Still open, lower priority.
+- **Gap 1 — `$bt[N]` returned `Nil`.** Fixed — see
+  `news/2026-08/backtrace-positional-indexing.md`.
+- **`Backtrace::Frame.gist`/`.raku` divergence.** Fixed — see
+  `news/2026-08/backtrace-frame-gist-raku-attribute-shape.md`.
+- **Gap 2 — fewer frames than Rakudo.** Still open (this file), deliberately
+  deferred — see "Why this is deferred" below.
 
-## Repro (gap 2)
+## Repro
 
 ```raku
 sub zipi { { { die "Something bad happened" }() }() };
@@ -59,20 +52,6 @@ make `.gist`/`.full` output *less* useful for mutsu users rather than more.
 The practical consequence is that a given index `N` refers to a different frame
 in mutsu than in Rakudo. Code that indexes from the end (`[*-1]`) is unaffected;
 code that hardcodes a small index expecting a setting frame will differ.
-
-## Related smaller divergence noticed while fixing gap 1
-
-`Backtrace::Frame.gist` / `.raku` do not match Rakudo's rendering:
-
-- `raku`: `Backtrace::Frame.new(file => "...", line => 3, code => -> { ... }, subname => "<unit>")`
-- `mutsu` `.gist`: the frame's `.Str` text (`  in block <unit> at f.raku line 3`)
-- `mutsu` `.raku`: a bare `Backtrace::Frame.new` with no attributes
-
-`.Str` itself matches Rakudo — including its trailing newline, since
-`news/2026-08/backtrace-full-frames-not-newline-separated.md`. Faithfully
-reproducing the gist is partly impossible (Rakudo's `code =>` renders a `Block`
-with its memory address) and partly the same frame-model question, so it is
-recorded here rather than fixed.
 
 ## What the introspection work relies on this ticket for
 


### PR DESCRIPTION
## Problem

`Backtrace::Frame.gist` reused the frame's `.Str` text and `.raku` produced a
bare `Backtrace::Frame.new` with no attributes:

```
raku  .raku / .gist : Backtrace::Frame.new(file => "...", line => 3, code => -> { ... }, subname => "<unit>")
mutsu .gist          : "  in block <unit> at f.raku line 3"
mutsu .raku          : "Backtrace::Frame.new"
```

## Root cause

`Backtrace::Frame` is a native pseudo-class whose instances carry only
`subname`/`file`/`line` attributes, with `.code` synthesized on demand rather
than stored. The generic `.raku` renderer lists *declared public attributes*,
of which this class has none registered — hence the empty parameter list.
`.gist` never reached that renderer at all: the pure fast-path cascade in
`builtins/methods_0arg/mod.rs` claimed it alongside `.Str`.

Rakudo's `Backtrace::Frame` defines no custom `.gist`, so it inherits the
default `Mu` rendering, which is identical to `.raku`.

## Fix

Rendering `code => ...` means recursively invoking the synthesized Code
object's own `.raku`, which needs `&mut self` and so cannot live in the
`&self`-only fast-path cascade. The rendering therefore goes in
`default_instance_repr` (`runtime/methods_instance_ops.rs`), alongside the
existing `IO::Path::Parts` / `Stash` arms that recurse the same way, and
`.gist` is removed from the `Backtrace::Frame` fast path so both methods reach
it. The `Backtrace::Frame`×`gist` row in `native_method_row_table.rs` is
dropped accordingly (`.raku` was never rowed for this owner either, for the
same reason — pinned by the existing `*_rows_are_backed_by_the_cascade` unit
tests, which caught this). The `code` synthesis is factored into
`backtrace_methods::frame_code_value` so the accessor and the renderer
describe the same object.

`.Str` is deliberately unchanged — it stays the concise
`  in block/sub ... at ... line N` text that `Backtrace.full` / `.concise` /
`.summary` are built from.

## Accessors

Checked all of `.file` / `.line` / `.code` / `.subname` / `.is-hidden` /
`.is-routine` / `.is-setting` against `raku`; all already behaved correctly, so
no accessor changes were needed. They are now pinned by the new test.

## Test

A byte-identical `.raku` is impossible (Rakudo's `code =>` embeds a per-run
memory address), so `t/backtrace-frame-gist-raku.t` asserts on the attribute
*shape* via a regex, plus each accessor individually. **It passes unmodified
under both `raku` and `mutsu` (15/15).**

## Verification

- `make test`: **PASS** — 3474 files, 33997 tests.
- Whitelisted roast files touching Backtrace (`S32-exceptions/misc.t`,
  `S32-exceptions/misc2.t`, `integration/error-reporting.t`): PASS, 481 tests.
- All 10 existing `t/*backtrace*` files: PASS.
- `cargo fmt --check` and `cargo clippy -- -D warnings`: clean.

## Ticket

Frame *count* / frame-model differences (mutsu has no Raku-written CORE
setting, so no `SETTING::` frames) are unrelated and stay deliberately
deferred. The ticket is trimmed to only that remaining gap and renamed to
`todo/tickets/backtrace-has-fewer-frames-than-rakudo.md`; the fix is recorded
in `news/2026-08/backtrace-frame-gist-raku-attribute-shape.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
