### PR TITLE
fix: EVAL now reads the caller's current lexical value, not just writes it

### DIFF
--- a/news/2026-08/eval-read-side-caller-lexicals.md
+++ b/news/2026-08/eval-read-side-caller-lexicals.md
@@ -1,0 +1,100 @@
+# EVAL now sees the caller's current lexical values, not just writes
+
+`EVAL` already let an EVAL'd string *write* a caller's lexical (`EVAL '$x = 7'`
+after this returns, the caller's `$x` really is `7`), but *reading* an
+already-declared caller lexical silently came back as a stale placeholder in
+one specific, extremely common shape:
+
+```
+$ mutsu -e 'my $x = 5; EVAL q[say $x]; EVAL q[$x = 7]; say $x;'
+(Any)     # raku: 5
+7         # raku: 7
+```
+
+The first line printed `(Any)` where raku prints `5` — the read failed, while
+the write on the next line already worked.
+
+## Root cause
+
+`EVAL` compiles the string it is given into a fresh, separately-compiled unit
+and runs it via `eval_block_value`/`run_compiled_block` on the same
+`Interpreter`. That fresh unit has no compile-time knowledge of the caller's
+local variable *slots* — it resolves every caller lexical by NAME against
+`Interpreter::env` instead.
+
+A plain lexical's slot only mirrors its value into `env` on every write once
+the process-global, monotonic `REFLECTIVE_NAME_ACCESS_SEEN` flag has latched
+(`crate::opcode::reflective_name_access_possible`, consulted by
+`vm_var_assign_set_local.rs`'s `skip_env_write` gate). Without it latched, a
+"slot-only" plain lexical never reaches `env` at all — a perf optimization
+(`docs/vm-dual-store.md`) that assumes nothing needs to read that lexical by
+name.
+
+The flag latches during compile-time finalization
+(`CompiledCode::scan_reflective_name_access` in `opcode.rs`), which scans a
+chunk's compiled ops for `EVAL`/`EVALFILE` calls (among other reflective
+constructs like `CALLER::`/`OUTER::`). That scan recognized only the
+tail/expression call shapes `OpCode::CallFunc`/`CallFuncNamed` — but `EVAL
+'...';` written as a bare statement (its return value discarded, which is how
+almost every real-world `EVAL '...';` is written) compiles to
+`OpCode::ExecCall`, or `OpCode::ExecCallPairs` when it carries named arguments
+like `:lang`. Neither of those was in the scan's match arm. So a program whose
+only `EVAL` calls were bare statements never latched the flag at all: every
+plain lexical it might read stayed unmirrored in `env`, and `EVAL` read back
+the placeholder `Any` the declaration seeded rather than the live value.
+
+The write side worked regardless, because it goes through a separate,
+already-correct mechanism (`writeback_carrier_writes`, driven by
+`begin_carrier`/`end_carrier`) that reconciles whatever `EVAL` wrote into
+`env` back into the calling frame's own local slots after the call returns —
+independent of whether that frame's own writes were mirrored going in.
+
+## Fix
+
+`scan_reflective_name_access` now also recognizes `OpCode::ExecCall` and
+`OpCode::ExecCallPairs` (`src/opcode.rs`), so any `EVAL`/`EVALFILE` call —
+regardless of whether its result is used — latches the flag. This is a small
+extension of the existing, already-sound mechanism (no new dual-store
+machinery, no special-casing of the read path), so it composes with every
+other consumer of the flag automatically.
+
+## What was measured against raku
+
+Before implementing, the following axes of EVAL's caller-lexical read
+visibility were measured against `raku` directly (not assumed):
+
+- Reading a `my` lexical from the immediately enclosing scope, and from
+  several enclosing routine frames up: both now work.
+- A `my` declared *inside* the EVAL'd string does not leak into (or overwrite)
+  a same-named caller lexical — confirmed unaffected by this fix (was already
+  correct, and stays correct).
+- `our`/package vars, `state` vars, and the topic `$_`: all read correctly,
+  both before and after this fix in the cases they didn't already hit the
+  gap.
+- Sigilless reads work the same via `@`/`%`/`&` sigils (array/hash/code-var
+  lexicals), not just `$`.
+- A closure created *inside* the EVAL'd string that captures a caller
+  lexical, called after the EVAL returns and after a further external
+  mutation of that lexical, correctly tracks the live value (was returning a
+  stale `Any` before this fix; now matches raku).
+- `EVAL` with `:lang<Raku>` (a named-arg call site, `ExecCallPairs`) and a
+  nested `EVAL` inside an EVAL'd string both read the outer caller's lexical
+  correctly.
+
+One narrower, pre-existing, and unrelated gap was found and intentionally
+left out of scope: reading a `my` declared *textually after* the `EVAL` call
+in the same block raises `Variable ... is not declared` in mutsu, where raku
+resolves it to `(Any)` (its lexical pad slot exists but is not yet
+initialized). This is a compile-time lexical-hoisting difference, not a
+caller-lexical-*visibility* gap, and is unaffected by this change.
+
+## Regression test
+
+`t/eval-read-caller-lexicals.t` pins the fix with 16 subtests, deliberately
+written so every `EVAL` call in the file is a bare statement (never assigned,
+never a call argument, never a block's tail expression) — the exact shape
+that exposed the gap — and so every closure the file needs is anonymous
+(`my &f = sub (...) {...}`), never a named `sub f(...) {...}` declaration,
+since a named sub triggers a separate, unrelated "unknown free variables"
+conservative-sync rule that would otherwise mask this specific bug. The file
+passes under both `raku` and mutsu.

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -5176,7 +5176,26 @@ impl CompiledCode {
                 | OpCode::SymbolicDeref { .. }
                 | OpCode::SymbolicDerefStore(_)
                 | OpCode::IndirectCodeLookup(_) => true,
-                OpCode::CallFunc { name_idx, .. } | OpCode::CallFuncNamed { name_idx, .. } => {
+                // `EVAL`/`EVALFILE` are reflective regardless of which call
+                // shape the call site compiled to: a statement-position call
+                // (`EVAL q[...];`, whose value is discarded) reaches
+                // `ExecCall`/`ExecCallPairs`, not just the tail/expression
+                // forms `CallFunc`/`CallFuncNamed`. Missing the statement
+                // forms here left the READ side of EVAL's caller-lexical
+                // visibility working only when an EVAL happened to also
+                // appear in tail position somewhere in the same compiled
+                // chunk (see `todo/tickets/repl-routine-unimplemented.md` /
+                // `news/2026-08/eval-read-side-caller-lexicals.md`): with no
+                // tail-form EVAL anywhere, this flag never latched, so a
+                // plain lexical's `SetLocal` never mirrored into `env` and a
+                // later `EVAL 'say $x'` -- which resolves `$x` by name
+                // against `env`, having no compile-time knowledge of the
+                // caller's local slots -- read the stale placeholder instead
+                // of the live value.
+                OpCode::CallFunc { name_idx, .. }
+                | OpCode::CallFuncNamed { name_idx, .. }
+                | OpCode::ExecCall { name_idx, .. }
+                | OpCode::ExecCallPairs { name_idx, .. } => {
                     matches!(
                         self.constants.get(*name_idx as usize).map(Value::view),
                         Some(ValueView::Str(name)) if name.as_str() == "EVAL" || name.as_str() == "EVALFILE"

--- a/t/eval-read-caller-lexicals.t
+++ b/t/eval-read-caller-lexicals.t
@@ -1,0 +1,197 @@
+use MONKEY-SEE-NO-EVAL;
+use Test;
+
+# EVAL's caller-lexical visibility has two independent directions: WRITES from
+# an EVAL'd string into the caller's lexicals already worked (the carrier
+# writeback, see t/eval-carrier-precise-writeback.t and friends), but READS —
+# the EVAL'd string seeing the caller's *current* value of an already-declared
+# lexical — silently returned a stale placeholder in one specific, easy-to-hit
+# shape: an `EVAL '...'` used as a bare STATEMENT (its own return value
+# discarded), anywhere other than the tail/last position of its enclosing
+# chunk.
+#
+# Root cause: EVAL resolves the caller's lexicals by NAME against
+# `Interpreter::env` (it has no compile-time knowledge of the caller's local
+# slots — the EVAL'd string is a fresh, separately-compiled unit). A plain
+# lexical's *slot* only mirrors into `env` on every write when the
+# process-global, monotonic `REFLECTIVE_NAME_ACCESS_SEEN` flag has latched
+# (see `crate::opcode::reflective_name_access_possible`); otherwise a
+# perf-motivated gate (`vm_var_assign_set_local.rs`'s `skip_env_write`) keeps
+# a slot-only local out of `env` entirely. The flag latches during
+# `scan_reflective_name_access` (`opcode.rs`), which used to recognize only
+# the tail/expression call shapes `CallFunc`/`CallFuncNamed` -- but a bare
+# `EVAL '...';` statement (its value never used) compiles to `ExecCall` (or,
+# with named args like `:lang`, `ExecCallPairs`), which that scan never
+# matched. So a program whose only `EVAL` calls are bare statements never set
+# the flag at all: every plain lexical it might read stayed a stale
+# placeholder in `env`.
+#
+# EVERY EVAL call in this file is deliberately a bare statement (never
+# assigned, never a call argument, never a block's tail expression) so this
+# file pins exactly that gap -- an `is $result, ...` after an `EVAL
+# q[$result = ...];` on its own line, never `is EVAL(...), ...`.
+#
+# For the same reason, every "sub" this file needs is an ANONYMOUS sub bound
+# to a lexical (`my &f = sub (...) { ... }`), never a NAMED `sub f(...) {...}`
+# declaration: a *named* sub is compiled lazily and is invisible to its
+# enclosing frame's free-variable analysis, so `compute_needs_env_sync`
+# conservatively keeps EVERY local of any frame that declares one
+# permanently mirrored into `env` (see `defines_lazy_body` in `opcode.rs`) --
+# regardless of whether that frame's EVAL calls are reflective. A named sub
+# anywhere in this file would silently make every subtest pass whether or not
+# the EVAL-read fix is present, defeating the point of a regression test.
+#
+# Not covered here (a separate, narrower, pre-existing gap, unrelated to
+# caller-lexical *visibility*): reading a `my` declared textually AFTER the
+# EVAL call in the same block. Both raku and mutsu treat this differently
+# from a normal forward reference; see
+# todo/tickets/eval-forward-declared-lexical-read.md.
+
+plan 16;
+
+# --- 1. The ticket's own repro: read, then write, then read again, with a
+# trailing plain statement so the read EVAL is provably mid-chunk (ExecCall),
+# never tail. ---
+{
+    my $x = 5;
+    my $before;
+    EVAL q[$before = $x];
+    EVAL q[$x = 7];
+    is $before, 5, 'EVAL sees the current value of a caller lexical on first read';
+    is $x, 7, 'and a later EVAL write still lands (already worked pre-fix)';
+}
+
+# --- 2. Read-only, no subsequent write anywhere for this variable. ---
+{
+    my $y = 11;
+    my $seen;
+    EVAL q[$seen = $y];
+    my $unrelated = 1 + 1; # keeps the EVAL out of tail position, no-op otherwise
+    is $seen, 11, 'a read-only lexical is visible to a mid-chunk EVAL';
+}
+
+# --- 3. Several frames up: nested anonymous subs, EVAL as a bare statement
+# deep inside. The read result comes back through an ordinary `return` (a
+# well-tested, unrelated mechanism), not by writing into a distant ancestor
+# frame's own lexical from inside the EVAL -- propagating an EVAL's reflective
+# write back through more than one intervening call frame is a separate,
+# narrower gap this ticket does not cover (only the frame that directly calls
+# EVAL gets its own locals reconciled; see `writeback_carrier_writes`). ---
+{
+    my $z = 42;
+    my &outer-fn = sub {
+        my &inner-fn = sub {
+            my $local-result;
+            EVAL q[$local-result = $z];
+            return $local-result;
+        };
+        return inner-fn();
+    };
+    is outer-fn(), 42, 'EVAL reads a lexical from several enclosing routine frames up';
+}
+
+# --- 4. `our` / package vars: read then write, both as bare statements. ---
+{
+    our $pkg-var = 3;
+    my $read-back;
+    EVAL q[$read-back = $pkg-var];
+    is $read-back, 3, 'EVAL reads an `our` package var';
+    EVAL q[$pkg-var = 4];
+    is $pkg-var, 4, 'and can still write it';
+}
+
+# --- 5. `state` vars: each call's current value is visible. ---
+{
+    my @seen;
+    my &with-state = sub {
+        state $s = 0;
+        $s++;
+        EVAL q[@seen.push: $s];
+    };
+    with-state();
+    with-state();
+    is-deeply @seen, [1, 2], 'EVAL reads the current-call value of a state var';
+}
+
+# --- 6. Topic `$_` inside a `for` loop body. ---
+{
+    my @seen;
+    for 1, 2, 3 {
+        EVAL q[@seen.push: $_];
+    }
+    is-deeply @seen, [1, 2, 3], 'EVAL reads the topic $_ on each loop iteration';
+}
+
+# --- 7. Sub parameters. Read result comes back via `return`, for the same
+# reason as case 3 above (the write side, several frames up, is out of
+# scope here). ---
+{
+    my &with-param = sub ($a) {
+        my $seen;
+        EVAL q[$seen = $a];
+        return $seen;
+    };
+    is with-param(99), 99, 'EVAL reads a sub parameter';
+}
+
+# --- 8. Sigilless / @ / % / & sigils. ---
+{
+    my @arr = 1, 2, 3;
+    my $seen-arr;
+    EVAL q[$seen-arr = @arr.elems];
+    is $seen-arr, 3, 'EVAL reads an @ array lexical';
+
+    my %h = a => 1, b => 2;
+    my $seen-hash;
+    EVAL q[$seen-hash = %h.elems];
+    is $seen-hash, 2, 'EVAL reads a % hash lexical';
+
+    my &c = sub { 123 };
+    my $seen-code;
+    EVAL q[$seen-code = c()];
+    is $seen-code, 123, 'EVAL reads a lexical & code var';
+}
+
+# --- 9. A closure MADE inside the EVAL'd string, capturing a caller lexical,
+# called after the EVAL returns -- and after a further OUTSIDE mutation, to
+# confirm it shares the live variable rather than snapshotting a stale copy. ---
+{
+    my $w = 1;
+    my $cl;
+    EVAL q[$cl = { $w }];
+    $w = 77;
+    is $cl(), 77, 'a closure made inside EVAL tracks a later mutation of the caller lexical';
+}
+
+# --- 10. `EVAL :lang<Raku>` (a named-arg call site, ExecCallPairs) is just as
+# reflective as the plain form. ---
+{
+    my $v = 55;
+    my $seen;
+    EVAL(q[$seen = $v], :lang<Raku>);
+    is $seen, 55, 'EVAL with :lang reads the caller lexical too';
+}
+
+# --- 11. Nested EVAL: the inner EVAL'd string still reads the outermost
+# caller's lexical. ---
+{
+    my $n = 8;
+    my $seen;
+    EVAL q[EVAL q[$seen = $n]];
+    is $seen, 8, 'a nested EVAL still reads the outermost caller lexical';
+}
+
+# --- 12. Negative case: a `my` declared INSIDE the EVAL'd string must not
+# leak out and overwrite a same-named caller lexical -- it only shadows it
+# for the duration of the EVAL'd snippet. (A *new* name the EVAL declares
+# cannot be probed at all without a static "undeclared variable" compile
+# error, since raku resolves that check against the OUTER script's compile-time
+# scope, which never saw the EVAL's internal declaration -- so shadowing an
+# existing caller lexical is the only way to observe this that both raku and
+# mutsu can even parse.)
+{
+    my $leaked = 111;
+    EVAL q[my $leaked = 999];
+    is $leaked, 111,
+        'a my declared inside EVAL shadows, not overwrites, a same-named caller lexical';
+}

--- a/todo/tickets/repl-routine-unimplemented.md
+++ b/todo/tickets/repl-routine-unimplemented.md
@@ -24,7 +24,7 @@ resolves `repl` with no `use`, and it is documented as `sub repl()` in
 `raku-doc/doc/Type/independent-routines.rakudoc:134`. So it does belong in core
 eventually.
 
-## Why it is deferred rather than implemented (measured 2026-08-26)
+## Why it is deferred rather than implemented (updated 2026-08-26)
 
 The ticket originally read "mutsu already has the REPL machinery to reuse —
 `mutsu::repl::run_repl()`, wired up in `src/main.rs`". That machinery is not
@@ -39,30 +39,60 @@ whole point is the caller's lexical scope. `run_repl()` constructs a *fresh*
 access to a running frame's lexicals at all.
 
 The obvious alternative — evaluate each REPL line with `EVAL` in the caller's
-scope — is blocked on a live mutsu gap. `EVAL` sees caller lexicals for
-**writes** but not for **reads**:
+scope — was blocked on a live mutsu gap, now fixed: `EVAL` used to see caller
+lexicals for **writes** but not for **reads**:
 
 ```
 $ mutsu -e 'my $x = 5; EVAL q[say $x]; EVAL q[$x = 7]; say $x;'
-(Any)     # raku: 5
+(Any)     # raku: 5    -- was the bug; mutsu now also prints 5
 7         # raku: 7
 ```
 
-So a `repl()` built on `EVAL` would greet the user with `(Any)` for every
-variable they asked about — worse than not having the routine, because it looks
-like it works. A `repl()` built on `run_repl()` would silently be a scratch
-prompt with none of the calling context.
+**Status: that blocker is cleared.** Root cause and fix are recorded in
+`news/2026-08/eval-read-side-caller-lexicals.md` — in short, `EVAL` resolves
+caller lexicals by NAME against `Interpreter::env`, and a plain lexical's slot
+only mirrors into `env` once the process-global `REFLECTIVE_NAME_ACCESS_SEEN`
+flag has latched (`crate::opcode::reflective_name_access_possible`). The
+compile-time scan that latches it (`scan_reflective_name_access` in
+`opcode.rs`) used to recognize only the tail/expression call shapes
+(`CallFunc`/`CallFuncNamed`); a bare statement `EVAL '...';` (the overwhelmingly
+common shape — its value discarded) compiles to `ExecCall`/`ExecCallPairs`,
+which the scan never matched. Fixed by adding those two opcodes to the scan.
+Regression coverage: `t/eval-read-caller-lexicals.t` (16 subtests spanning
+`our`/`state`/topic/sigilless/`@`/`%`/`&`/nested-closure/`:lang`/nested-EVAL
+reads, plus the no-leak negative case), passing under both `raku` and mutsu.
 
-**Implement the EVAL read-side lexical visibility first**; `repl()` is a thin
-wrapper on top of it and is not worth attempting before then. Note also that
-mutsu's REPL is the `native` feature's rustyline loop, so `repl()` would need a
-sensible non-interactive answer (and a piped-stdin test) as well.
+**`repl()` itself is still unimplemented** — this ticket now covers only that.
+What's left to actually write it:
+
+1. Wire `repl` into the builtin/name tables (`src/runtime/builtins.rs`,
+   `src/runtime/system_eval_names.rs`, `src/parser/primary/ident/predicates.rs`),
+   dispatching to a routine that runs each line through the same `EVAL`
+   machinery `builtin_eval` in `src/runtime/builtins_eval_misc.rs` uses, so it
+   inherits the caller's lexical scope for both reads and writes (now that both
+   directions work).
+2. mutsu's existing interactive REPL (`src/repl.rs`/`src/repl_core.rs`) is
+   gated behind the `native` feature's rustyline loop. `repl()` must work in a
+   build without that feature too (or without a TTY at all — piped stdin),
+   since it is an ordinary Raku statement a script can call from any build.
+   Decide the non-interactive behavior (e.g. read lines from `$*IN` until EOF,
+   `EVAL`-ing each one in the caller's scope, printing results the way the
+   real REPL echoes non-`;`-terminated expressions) and add a piped-stdin test
+   for it — do not assume a TTY is present.
+3. `repl_core::process_line`'s existing parsing/echo logic is a useful
+   reference for the piped-stdin behavior, but it currently runs against a
+   fresh `Interpreter`; the `repl()` builtin must instead reuse `EVAL` against
+   `self` (the caller's own live interpreter) so declarations and mutations
+   the REPL session makes are visible to `say "Goodbye, $name"` after the
+   session ends, per the repro at the top of this file.
 
 ## Affected files (starting point)
 
-- `src/runtime/builtins_eval_misc.rs` — `builtin_eval`, the read-side scope gap
-  that is the actual blocker
-- `src/repl.rs` / `src/repl_core.rs` — the existing REPL loop, reusable only
-  once the above is solved
+- `src/runtime/builtins_eval_misc.rs` — `builtin_eval`; the routine `repl()`
+  should reuse (`eval_eval_string`/`eval_block_value`) rather than
+  reimplementing scope handling
+- `src/repl.rs` / `src/repl_core.rs` — the existing (native-feature-gated,
+  fresh-`Interpreter`) REPL loop; useful as a reference for echo/parse
+  behavior, not directly reusable as-is (see point 3 above)
 - `src/runtime/builtins.rs`, `src/runtime/system_eval_names.rs`,
   `src/parser/primary/ident/predicates.rs` — where the sub would be registered


### PR DESCRIPTION
## Summary
- `EVAL` used to see caller lexicals for **writes** but not for **reads**, in one specific, extremely common shape: `EVAL '...';` written as a bare statement (its value discarded). Root cause and the fix are detailed in `news/2026-08/eval-read-side-caller-lexicals.md`.
- One-line fix in `src/opcode.rs`: `CompiledCode::scan_reflective_name_access` now also recognizes `OpCode::ExecCall`/`ExecCallPairs` (not just the tail/expression forms `CallFunc`/`CallFuncNamed`), so the existing `REFLECTIVE_NAME_ACCESS_SEEN` latch fires for a bare-statement `EVAL` too.
- This was the blocker `todo/tickets/repl-routine-unimplemented.md` named for implementing `repl()`; that ticket is updated to reflect the blocker is cleared and lay out what `repl()` itself still needs (not implemented in this PR).
- New regression test `t/eval-read-caller-lexicals.t` (16 subtests), passing under both `raku` and mutsu, deliberately using only bare-statement EVAL calls and anonymous closures.

## Test plan
- [x] `cargo build`, `cargo fmt`, `cargo clippy -- -D warnings` clean
- [x] `t/eval-read-caller-lexicals.t` passes under both `raku` and `target/debug/mutsu`
- [x] Full `t/eval-*.t` + `t/rakuast-eval-*.t` sweep (70 files, 451 tests) passes
- [x] `cargo test -- --test-threads=1` clean (one transient unrelated flake in `tests/flaky_retry.rs` under concurrent-session load, reproduced clean on isolated re-run)
- [x] Full `t/` TAP suite (`MUTSU_BIN=target/debug/mutsu MUTSU_T_TIMEOUT=60 prove -e scripts/run-t-test.sh t/`): 3480 files, 34078 tests, all pass
- [x] Targeted roast sweep on consumers of the changed scan: `roast/S02-names-vars/`, `roast/S04-declarations/`, `roast/S11-modules/`, and every whitelisted file that uses `EVAL`/`EVALFILE` (293 files, 23095 tests) — all pass (two pre-existing, non-whitelisted failures unrelated to this change: `roast/S02-names-vars/names.t`, `roast/S11-modules/re-export.t`)
- [x] CI will run the full `make roast`

🤖 Generated with [Claude Code](https://claude.com/claude-code)