### PR TITLE
fix: mark several immutable lvalues mutsu still let you assign to

### DIFF
--- a/news/2026-08/closure-call-and-bareword-term-readonly-gaps.md
+++ b/news/2026-08/closure-call-and-bareword-term-readonly-gaps.md
@@ -96,6 +96,35 @@ coverage lost (a lowercase native-type bareword's very first, never-yet-
 referenced assignment) is a deliberate, safe trade-off, and `Int`/`Nil`/a
 user class (all TitleCase by convention) keep working.
 
+**A fourth trap: the same lowercase collision recurs through a THIRD current-value
+shape, `Package(Any)`.** The `None` fix above did not cover `roast/S02-types/set.t`
+and `sethash.t`, which went red in CI with an unrelated-looking symptom:
+`lives-ok`/`dies-ok` false negatives, e.g. `my $str; lives-ok { $str = 1 },
+"x"` reported "not ok" even though the assignment itself succeeded and nothing
+threw. Root cause: `SetVarDynamic`'s closure-capture-by-reference support
+pre-seeds ANY not-yet-assigned closure-captured variable's env slot with the
+placeholder `ValueView::Package(Symbol::intern("Any"))` — regardless of the
+variable's own name — before its real value is ever assigned (the exact
+mechanism `exec_get_bare_word_op`'s own read-side fallback already special-
+cases: "A `my $Buf = Buf.new` declaration pre-seeds env[\"Buf\"] with the
+placeholder `Package(Any)`"). The original fix's `Package(_)` branch was left
+completely unconditional (trusted unconditionally, no TitleCase gate at all),
+so a captured `$str` — whose free-variable write inside the `lives-ok` block
+reaches the exact same `SetGlobal` bareword check — hit this placeholder and
+was misidentified as assigning to the lowercase native type `str`.
+`lives-ok`/`dies-ok` correctly caught the resulting spurious
+`X::Assignment::RO`, which is why the symptom looked like a `Test` bug rather
+than an assignment bug. **Fix:** `Package(Any)` (for any name other than the
+literal bareword `Any` itself) is now gated by the same TitleCase requirement
+as `None`/a real `Nil`; only a genuine `Package(SomeRealType)` — set
+exclusively by actual class/type registration, e.g. `class Foo {}` setting
+`env["Foo"] = Package("Foo")` directly — is trusted unconditionally. This is
+the third distinct "looks like an unbound type slot" shape found for this one
+underlying ambiguity (`None`, `Nil`, `Package(Any)`); all three are now gated
+the same way, and `t/immutable-lvalue-assignment-gaps.t` pins each of them (a
+`for`-loop destructure leaf, a `lives-ok`-captured uninitialized variable, and
+the direct `Int`/`Nil`/`Foo` cases) as its own regression control.
+
 ## What's still open
 
 **`my $s = { $_ = 5 }; $s(7)` (a bare block's implicit topic) is deliberately

--- a/news/2026-08/closure-call-and-bareword-term-readonly-gaps.md
+++ b/news/2026-08/closure-call-and-bareword-term-readonly-gaps.md
@@ -1,0 +1,143 @@
+# Seven more immutable-lvalue assignment gaps closed
+
+`todo/tickets/immutable-lvalues-that-mutsu-still-lets-you-assign-to.md` (the
+survey the exception-taxonomy work spun off) listed cases where Raku rejects
+an assignment to an immutable lvalue but mutsu silently accepted it. Seven of
+those rows are now fixed, each verified against `raku` v2026.06 for both
+exception class and message:
+
+- **A `$`-sigiled pointy-block parameter is now readonly**: `my $b = -> $v {
+  $v = 1 }; $b(3)` now throws `X::AdHoc` "Cannot assign to a readonly variable
+  or a value", matching a non-`is rw` sub parameter and a multi-param pointy
+  block (both already correct). A single-param, trait-less pointy block
+  (`-> $v {...}`) compiles via `Expr::Lambda` with an empty `param_defs`
+  (`bind_function_args_values`'s "legacy" binding path), so it never reached
+  the general "mark parameters readonly unless `is rw`/`is copy`/`is raw`"
+  logic a real `ParamDef` goes through.
+- **Assigning to a bareword that names an immutable VALUE**: `Nil = 5`
+  (`X::Assignment::RO`, "Cannot modify an immutable Nil value"), `Int = 5`
+  (same class, "Cannot modify an immutable 'Int' type object"), and an enum
+  value (`enum Fo <A B>; A = 3`, "Cannot modify an immutable Fo (A)") all now
+  throw. These are one mechanism, not three special cases — the existing
+  `SetGlobal` guard against reassigning a type object was scoped to
+  `self.has_class` (user-declared classes only) and, for the class case it
+  did catch, threw an untyped `X::AdHoc` instead of `X::Assignment::RO`; both
+  bugs are fixed together.
+- **Sub-signature destructure leaves are now readonly**: neither a sigilless
+  leaf (`sub f($ (\a, \b)) { a = 1 }`) nor a `$`-sigiled leaf (`sub f($ ($x,
+  $y)) { $x = 1 }`) was ever marked — `bind_sub_signature_from_value` is a
+  distinct, purely-runtime binding path that neither the parser's
+  `MarkSigillessReadonly` prologue nor the ordinary flat-signature marking
+  branch reaches.
+- **`push`/`append`/`unshift`/`prepend`/`pop`/`shift` on an `@`-var bound to an
+  immutable List** (`my @a := (1,2,3); @a.push(4)`): the scalar twin
+  (`my $a := (1,2,3); $a.push(4)`) already correctly threw `X::Immutable`, but
+  the check (`methods_mut_dispatch.rs`) excluded any `@`-sigiled target, and a
+  SEPARATE fast-path opcode (`OpCode::ArrayPush`, `vm_data_push_ops.rs`)
+  accepted any `ValueView::Array` kind at all rather than checking
+  `kind.is_real_array()`, so it silently mutated the supposedly-immutable
+  List in place.
+- **`my \G = 5; G++`/`G--`/`++G` now throw `X::Multi::NoMatch`**: a sigilless
+  bind's readonly-ness lives in a separate `__mutsu_sigilless_readonly::NAME`
+  env-key mechanism from `readonly_vars`; plain assignment already consulted
+  it, in/decrement did not.
+
+## Two traps this fix ran into (both worth remembering)
+
+**A prologue statement injected into compiled bytecode runs on every path
+that executes that bytecode, not just "the call".** The first cut of the
+pointy-block-parameter fix injected a `Stmt::MarkReadonly` prologue into the
+block's compiled body (mirroring `Stmt::MarkSigillessReadonly`). That passed
+locally but broke `t/digest-battery.t` and `t/map-native-rw-param.t` in CI:
+`resolution_map_grep.rs`/`resolution_map_grep_rw.rs` bind a block's params by
+direct `env.insert` and run the body via `run_reuse` — a deliberate
+`push_call_frame`-bypassing perf shortcut for `.map`/`.grep`/`.first`. A mark
+made with no readonly frame open skips the undo journal
+(`mark_readonly_sym_with`'s `readonly_frames == 0` early return) and leaks
+PERMANENTLY into the next unrelated same-named lexical anywhere later in the
+program. The fix moved the mark to the CALL SITE
+(`call_compiled_closure_with_topic`, gated on a new
+`CompiledCode::pointy_alias_param` flag) instead of the compiled body, where
+`push_call_frame` already opened a properly-scoped frame — and, as a bonus,
+this means the mark is simply never applied on the native fast-loop paths,
+which is exactly the boundary the ticket's "leave `.map`/`.grep` topics alone"
+already drew. The two leaky loops were also hardened with a
+`ReadonlyFrameGuard` around each iteration regardless, so a future body side
+effect of the same shape can't reintroduce the leak.
+
+**A bareword's storage key carries no sigil, so a check on the CURRENT value
+alone can't tell "the term itself" from "a variable that happens to hold a
+copy of that value."** The Nil/type-object/enum fix first broke
+`t/topic-alias-does-not-cross-frames.t`: `$_ = $state` where `$state` held an
+enum value from an earlier loop iteration was rejected as if `$_` were the
+enum member itself. The fix excludes `name == "_"` specifically — the topic
+is the one variable that is both stored bare (no twigil, unlike `$*foo`/
+`$!attr`) and never slot-allocated (unlike an ordinary `my`/`our` variable,
+which reaches a different, unaffected code path or keeps its own twigil), and
+a bareword `_` alone is never a valid Raku term regardless.
+
+**A third trap, found after the first two: a bareword's sigil-stripped storage
+key can ALSO collide with a lowercase native-type synonym on a variable's
+first-ever write.** Extending the `unbound_type_slot` inference to treat
+"never referenced at all" (`env.get(name)` returns `None`) the same as a
+pre-seeded `Nil` slot was necessary for `Int = 5` to be caught at all (a
+builtin type's bareword is never actually written into env by anything), but
+it also broke `roast/S32-str/comb.t`: `for @tests -> ($str, $expected, |args)
+{...}` binds its sub-signature destructure leaves by a direct `SetGlobal`
+(not a local slot — for-loop destructure leaves aren't slot-allocated the way
+a simple `my $str` is), so `$str`'s very first write reached the exact same
+"never referenced" check and was misidentified as assigning to the lowercase
+native type `str`. The fix restricts the `None`-counts-as-unbound inference to
+TitleCase names only (`name.starts_with` an uppercase char): `str`/`int`/
+`num`/`array`/`bool`/... are realistic, common variable names whose
+sigil-stripped key collides with a type synonym, while `str = 5`/`int = 5` as
+a bare statement referencing the TYPE is not idiomatic Raku at all — so the
+coverage lost (a lowercase native-type bareword's very first, never-yet-
+referenced assignment) is a deliberate, safe trade-off, and `Int`/`Nil`/a
+user class (all TitleCase by convention) keep working.
+
+## What's still open
+
+**`my $s = { $_ = 5 }; $s(7)` (a bare block's implicit topic) is deliberately
+left unfixed, NOT missed.** It looks like the sibling of the pointy-block-
+parameter fix above — the ticket originally grouped both under "named routines
+mark their params, the closure-call path does not" — but they need genuinely
+different mechanisms:
+
+- A `$`-sigiled pointy-block PARAMETER is *always* readonly regardless of what
+  it is called with (a `for`-loop's named alias gets the same rule), so
+  marking it unconditionally at the call site is sound.
+- A bare block's implicit TOPIC is readonly only when the argument is not a
+  container — `$s(7)` passes a literal `7` (never a container, so it should
+  always be rejected), but the *exact same* VM code path
+  (`call_compiled_closure_with_topic`'s "implicit `$_` for bare blocks" branch)
+  is also what `@a.map({ $_ *= 10 })` uses when the native `.map` loop hands it
+  a *named array's real element* with `capture_rw_topic: true` — and that case
+  legitimately mutates the source array (verified: `my @a = 1,2,3; @a.map({
+  $_ *= 10 }); say @a;` prints `[10 20 30]` in both raku and mutsu — this is
+  load-bearing existing behavior, not a bug, and this test's own regression
+  suite pins it). Marking the implicit topic readonly at that shared call site
+  would break `.map`'s rw writeback outright. This is the exact same "does
+  mutsu know the source item is a container" gap the `for`-loop topic rows are
+  blocked on (ADR-0040), just reached from `.map`/a direct value call instead
+  of `for`. It is intentionally left in
+  `todo/tickets/immutable-lvalues-that-mutsu-still-lets-you-assign-to.md`,
+  with this reasoning spelled out there too.
+- The two `.map`/`.grep`-literal-topic rows (`(1,2).map({ $_ = 5 })`) are the
+  same blocker by the same mechanism.
+
+The ticket file lists the remaining rows and why each is blocked: the
+`for`-loop per-item topic rows and `.map`/`.grep`/block-argument block-topic
+mutation both need ADR-0040's store-side element itemization (mutsu can't yet
+tell, at the point a block's topic is bound, whether the source item was a
+container); `my $x := (1,2,3); $x = 5` is deliberately conservative pending
+the same container/no-container distinction becoming a property of the value
+rather than a view-kind whitelist; and element assignment (`(1,2,3)[0] = 9`,
+Range, Seq) needs the subscript store path to know its target is immutable.
+
+## Tests
+
+`t/immutable-lvalue-assignment-gaps.t` pins all seven fixes (class and
+message) plus negative controls (`is rw`/`is copy` pointy-block params, `for
+@a { $_ = ... }` over a real Array, `@a.map({ $_ *= 10 })`'s rw writeback, a
+real Array's `push`) — verified to pass verbatim under both `raku` and mutsu.

--- a/src/compiler/expr_closure.rs
+++ b/src/compiler/expr_closure.rs
@@ -351,6 +351,41 @@ impl Compiler {
         } else {
             body
         };
+        // A `$`-sigiled single pointy-block parameter (`-> $v { }`) reaches this
+        // function with an empty `param_defs` (see the module doc on
+        // `bind_function_args_values`'s legacy binding path), so it never passes
+        // through the general "mark parameters readonly unless `is rw`/`is copy`/
+        // `is raw`" logic that a multi-param pointy block (which DOES get a real
+        // `ParamDef`, even with no traits) or a named sub parameter goes through.
+        // That let `-> $v { $v = 1 }` silently accept an assignment Raku rejects
+        // (`X::AdHoc`, "Cannot assign to a readonly variable or a value") --
+        // `sub f($x) { $x = 1 }` and `-> $v, $w { $v = 1 }` were already correctly
+        // rejected.
+        //
+        // This is marked at the CALL SITE (`call_compiled_closure_with_topic`,
+        // gated on `cc.pointy_alias_param`), NOT by injecting a `MarkReadonly`
+        // prologue statement into the compiled BODY. A prologue statement runs
+        // unconditionally whenever this bytecode executes -- including several
+        // "fast native loop" paths (`.map`/`.grep`/`.first`, in
+        // `resolution_map_grep.rs`/`resolution_map_grep_rw.rs`) that bind a
+        // block's params by a direct `env.insert` and run its body via
+        // `run_reuse`, bypassing `push_call_frame`/`enter_readonly_frame`
+        // entirely for performance. A mark made with no readonly frame open
+        // skips the undo journal (see `mark_readonly_sym_with`) and leaks
+        // PERMANENTLY into any later, unrelated same-named lexical in the
+        // program -- this reached CI as a real regression (SHA3's `map -> $x
+        // {...}` leaking into a later `for ... -> ($x, $y)` reusing the same
+        // name) before being moved here. `call_compiled_closure_with_topic`
+        // always calls `push_call_frame` before binding parameters, so marking
+        // there is properly scoped and rolled back on return -- and it is
+        // never reached by those fast-loop paths for this closure shape, so
+        // marking there also does not (and must not) affect them: whether a
+        // `.map`/`.grep` block topic is writable depends on whether the
+        // SOURCE item is a container, which mutsu cannot yet decide on the
+        // eager path (ADR-0040) -- that is a separate, deliberately
+        // unaddressed gap, not something this fix may accidentally start
+        // rejecting via a shared mechanism.
+        let pointy_alias_param = !is_whatever_code && !param_sigilless && !param.is_empty();
         // A single-`*` WhateverCode whose body *mutates* the `_` placeholder
         // (`*++`, `*--`, `++*`, `* =:= $x`, `*.=foo`) binds `_` `is raw`, so the
         // mutation/identity reaches the caller's container (S02 "WhateverCode
@@ -416,6 +451,7 @@ impl Compiler {
         if !is_whatever_code {
             compiled.is_pointy_block = true;
         }
+        compiled.pointy_alias_param = pointy_alias_param;
         // `supply { … }` lowers to `Supply.on-demand(-> $__mutsu_supply_emitter_N
         // { … })`, so the generated emitter parameter identifies the supply body.
         // See `CompiledCode::is_supply_block_body`.

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -3789,6 +3789,19 @@ pub(crate) struct CompiledCode {
     /// Pointy blocks are NOT routine boundaries — `return` propagates through
     /// them to the enclosing routine, and `&?ROUTINE` sees the enclosing routine.
     pub(crate) is_pointy_block: bool,
+    /// Whether this is a single-`$`-sigiled-parameter pointy block (`-> $v {
+    /// }`, compiled via `Expr::Lambda`) whose one parameter must be marked
+    /// readonly (`ReadonlyKind::Alias`) at the call site. Set only for the
+    /// plain, trait-less, non-sigilless, non-WhateverCode shape — a traited
+    /// (`is rw`/`is copy`) or multi-param pointy block instead carries a real
+    /// `ParamDef` and is marked by the ordinary signature-binding path
+    /// (`binding_signature.rs`). Consumed by `call_compiled_closure_with_topic`,
+    /// NOT by an injected body prologue statement — see the comment on
+    /// `Compiler::compile_expr_lambda`'s `pointy_alias_param` for why a
+    /// prologue statement is unsafe here (it also runs inside several
+    /// `push_call_frame`-bypassing "fast native loop" paths, which would leak
+    /// the mark permanently).
+    pub(crate) pointy_alias_param: bool,
     /// Whether this code contains opcodes that write to env (SetGlobal,
     /// AssignExpr, PostIncrement, etc.). Used by call_compiled_method to
     /// skip the expensive env merge when the method body is read-only.
@@ -4509,6 +4522,7 @@ impl CompiledCode {
             uses_dispatcher: false,
             source_line: None,
             is_pointy_block: false,
+            pointy_alias_param: false,
             has_env_writes: false,
             may_capture_outer_vars: false,
             needs_env_sync: Vec::new(),

--- a/src/runtime/methods_mut_dispatch.rs
+++ b/src/runtime/methods_mut_dispatch.rs
@@ -67,7 +67,17 @@ impl Interpreter {
                 && !target_var.starts_with('%')
                 && !target_var.starts_with('&')
                 && !has_sigilless_meta);
-        if scalar_like_target
+        // `my @a := (1,2,3); @a.push(4)` must be rejected the same way
+        // `my $a := (1,2,3); $a.push(4)` already is: `:=`-binding an `@`-var to
+        // a List literal preserves the List's `ArrayKind` (see
+        // `bind_positional_value` in `vm_var_assign_set_local.rs` -- only an
+        // itemized/decontainerized Array is re-kinded, a plain List literal
+        // falls through unchanged), so `!kind.is_real_array()` is already the
+        // correct signal for an `@`-sigiled target too. `scalar_like_target`
+        // was scoped to `$`/sigilless names only, so a same-shaped `@`-bound
+        // List silently allowed mutation.
+        let mutable_container_check_target = scalar_like_target || target_var.starts_with('@');
+        if mutable_container_check_target
             && let ValueView::Array(_, kind) = target.view()
             && !kind.is_real_array()
             && matches!(

--- a/src/runtime/methods_signature_errors.rs
+++ b/src/runtime/methods_signature_errors.rs
@@ -97,7 +97,7 @@ pub(super) fn make_method_not_found_error(
 }
 
 /// Create a structured X::Immutable error.
-pub(super) fn make_x_immutable_error(method_name: &str, typename: &str) -> RuntimeError {
+pub(crate) fn make_x_immutable_error(method_name: &str, typename: &str) -> RuntimeError {
     let msg = format!(
         "Cannot call '{}' on an immutable '{}'",
         method_name, typename

--- a/src/runtime/resolution_map_grep.rs
+++ b/src/runtime/resolution_map_grep.rs
@@ -552,6 +552,21 @@ impl Interpreter {
                     }
                     let saved_when_matched = vm.when_matched();
                     vm.when_nonmatch_value = None;
+                    // This loop binds the block's params directly into `env`
+                    // (above) instead of going through the normal call
+                    // machinery (`bind_function_args_values`/`push_call_frame`),
+                    // so `readonly_frames` is never incremented here. A
+                    // compiled body that marks itself readonly at runtime --
+                    // e.g. a single-param pointy block's `Stmt::MarkReadonly`
+                    // prologue (`compiler/expr_closure.rs`) -- would otherwise
+                    // mark `readonly_vars` with `readonly_frames == 0`, which
+                    // skips the undo journal entirely (see
+                    // `mark_readonly_sym_with`) and leaks the mark PERMANENTLY
+                    // into every later, unrelated same-named lexical in the
+                    // program (see the sibling fix + comment in
+                    // `resolution_map_grep_rw.rs`).
+                    let _readonly_guard =
+                        crate::vm::vm_call_state_guard::ReadonlyFrameGuard::new(vm);
                     match vm.run_reuse(&code, &compiled_fns) {
                         Ok(()) => {
                             let val = vm
@@ -618,6 +633,7 @@ impl Interpreter {
                             return Err(e);
                         }
                     }
+                    drop(_readonly_guard);
                     i += arity;
                 }
 

--- a/src/runtime/resolution_map_grep_rw.rs
+++ b/src/runtime/resolution_map_grep_rw.rs
@@ -272,6 +272,22 @@ impl Interpreter {
                     };
                     let saved_when_matched = vm.when_matched();
                     vm.when_nonmatch_value = None;
+                    // This loop binds the block's param directly into `env`
+                    // (above) instead of going through the normal call machinery
+                    // (`bind_function_args_values`/`push_call_frame`), so
+                    // `readonly_frames` is never incremented here. A compiled
+                    // body that marks itself readonly at runtime -- e.g. a
+                    // single-param pointy block's `Stmt::MarkReadonly` prologue
+                    // (`compiler/expr_closure.rs`) -- would otherwise mark
+                    // `readonly_vars` with `readonly_frames == 0`, which skips
+                    // the undo journal entirely (see `mark_readonly_sym_with`)
+                    // and leaks the mark PERMANENTLY into every later,
+                    // unrelated same-named lexical in the program. Opening a
+                    // proper (panic-safe) readonly scope per iteration — the
+                    // same guard a real call frame uses — gives this body the
+                    // same isolation `call_compiled_closure_with_topic` does.
+                    let _readonly_guard =
+                        crate::vm::vm_call_state_guard::ReadonlyFrameGuard::new(vm);
                     match vm.run_reuse(&code, &compiled_fns) {
                         Ok(()) => {
                             let val = vm
@@ -317,6 +333,7 @@ impl Interpreter {
                             return Err(e);
                         }
                     }
+                    drop(_readonly_guard);
                     i += arity;
                 }
 

--- a/src/runtime/types/mod.rs
+++ b/src/runtime/types/mod.rs
@@ -361,7 +361,23 @@ impl Interpreter {
         name: &str,
         op: &str,
     ) -> Result<(), RuntimeError> {
-        if self.is_readonly(name) {
+        // A sigilless bind (`my \G = 5`) is marked via a SEPARATE mechanism
+        // from `readonly_vars`/`ReadonlyKind` -- the `__mutsu_sigilless_readonly::
+        // NAME` env key `Stmt::MarkSigillessReadonly` sets (see
+        // `CheckReadOnly`'s own probe of the same key in `vm_exec_dispatch.rs`).
+        // Plain assignment (`G = 10`) already consulted it; `G++`/`G--` did
+        // not, so `my \G = 5; G++` silently mutated the "value" in place
+        // where Raku's postfix:<++> dispatch rejects it (X::Multi::NoMatch,
+        // "requires mutable arguments") the same way it rejects a readonly
+        // sub parameter's `++$n`.
+        let sigilless_readonly = crate::env::closure_meta_keys_possible()
+            && matches!(
+                self.env()
+                    .get(&format!("__mutsu_sigilless_readonly::{}", name))
+                    .map(Value::view),
+                Some(ValueView::Bool(true))
+            );
+        if self.is_readonly(name) || sigilless_readonly {
             let msg = format!(
                 "Cannot resolve caller {op}({}); the parameter requires mutable arguments",
                 name

--- a/src/runtime/types/signature.rs
+++ b/src/runtime/types/signature.rs
@@ -971,6 +971,47 @@ pub(in crate::runtime) fn bind_sub_signature_from_value(
         let bind_alias_name = !(sub_pd.named && sub_pd.sub_signature.is_some());
         if !sub_pd.name.is_empty() && bind_alias_name {
             bind_sub_param_name(interpreter, &sub_pd.name, candidate.clone());
+            // Neither shape of a destructured leaf ever got marked readonly:
+            // a sigilless leaf (`sub f($ (\a, \b)) { a = 1 }`) is a TERM
+            // binding like a top-level `sub f(\a) { a = 1 }` param, and a
+            // `$`-sigiled leaf (`sub f($ ($x, $y)) { $x = 1 }`) is a readonly
+            // ALIAS like any other non-`is rw` parameter. Both are marked at
+            // the ordinary top-level binding site -- `MarkSigillessReadonly`
+            // (a parser/compiler prologue, `compiler/helpers_sub_body.rs`)
+            // for the former, `mark_readonly` (`binding_signature.rs`'s
+            // "correct" branch) for the latter -- but a destructure leaf is
+            // bound purely at RUNTIME, here, and neither mechanism reaches
+            // it, so an assignment silently succeeded where Raku throws.
+            if sub_pd.sigilless {
+                // Mirror the exact env-key marker `Stmt::MarkSigillessReadonly`
+                // compiles to, so `CheckReadOnly` treats this identically to a
+                // top-level sigilless param or a `my \x = 5` bind (X::Assignment::RO,
+                // "Cannot modify an immutable TYPE (VALUE)").
+                interpreter.env.insert(
+                    format!("__mutsu_sigilless_readonly::{}", sub_pd.name),
+                    Value::TRUE,
+                );
+            } else if !sub_pd.name.starts_with('@')
+                && !sub_pd.name.starts_with('%')
+                && !sub_pd.name.starts_with('!')
+                && !sub_pd.name.starts_with('.')
+            {
+                // `@`/`%` destructure leaves bind a writable container (same
+                // exemption as top-level `@`/`%` params); `!`/`.` are
+                // attribute-binding leaves, always writable. A plain `$`
+                // leaf is readonly (X::AdHoc, "Cannot assign to a readonly
+                // variable or a value") unless explicitly `is rw`/`is copy`/
+                // `is raw`.
+                let has_mutable_trait = sub_pd
+                    .traits
+                    .iter()
+                    .any(|t| t == "rw" || t == "copy" || t == "raw");
+                if has_mutable_trait {
+                    interpreter.unmark_readonly(&sub_pd.name);
+                } else {
+                    interpreter.mark_readonly(&sub_pd.name);
+                }
+            }
         }
         if let Some(nested) = &sub_pd.sub_signature {
             // A named sub-param's parens are either a RENAME/alias target

--- a/src/value/error_construct.rs
+++ b/src/value/error_construct.rs
@@ -439,6 +439,28 @@ impl RuntimeError {
         Self::typed("X::Assignment::RO", attrs)
     }
 
+    /// X::Assignment::RO - assigning to a type object (`Int = 5`, `class Foo
+    /// {}; Foo = 5`). Rakudo's own wording names the type, not a value repr
+    /// ("Cannot modify an immutable 'Int' type object", no `(...)`), so this
+    /// does not reuse `assignment_ro_typename`'s "TYPE (VALUE)" shape.
+    pub(crate) fn assignment_ro_type_object(name: &str) -> Self {
+        let msg = format!("Cannot modify an immutable '{}' type object", name);
+        let mut attrs = HashMap::new();
+        attrs.insert("typename".to_string(), Value::str(name.to_string()));
+        attrs.insert("message".to_string(), Value::str(msg));
+        Self::typed("X::Assignment::RO", attrs)
+    }
+
+    /// X::Assignment::RO - assigning to the bare `Nil` term (`Nil = 5`).
+    /// Rakudo's wording is its own special case ("Cannot modify an immutable
+    /// Nil value"), distinct from both the typed-value and type-object forms.
+    pub(crate) fn assignment_ro_nil() -> Self {
+        let msg = "Cannot modify an immutable Nil value".to_string();
+        let mut attrs = HashMap::new();
+        attrs.insert("message".to_string(), Value::str(msg));
+        Self::typed("X::Assignment::RO", attrs)
+    }
+
     /// X::Str::Numeric - Cannot convert string to number
     #[allow(dead_code)]
     pub(crate) fn str_numeric(source: &str, reason: &str) -> Self {

--- a/src/vm/vm_closure_dispatch.rs
+++ b/src/vm/vm_closure_dispatch.rs
@@ -589,6 +589,25 @@ impl Interpreter {
             }
         };
 
+        // A plain `$`-sigiled single pointy-block parameter (`-> $v { }`,
+        // `cc.pointy_alias_param`) reached `bind_function_args_values`'s
+        // legacy path above (empty `param_defs`), which carries no trait
+        // information and so cannot mark it readonly itself -- unlike a
+        // multi-param/traited pointy block (a real `ParamDef`, marked by
+        // `binding_signature.rs`'s "correct" branch). Marked HERE (the call
+        // site), not via a body-prologue statement: `push_call_frame` above
+        // already opened this call's readonly scope, so the mark is properly
+        // journaled and rolled back by `pop_call_frame` on every exit path
+        // (see `Compiler::compile_expr_lambda`'s `pointy_alias_param` comment
+        // for why a prologue statement is unsound here — it would also run
+        // inside several `push_call_frame`-bypassing "fast native loop" paths
+        // and leak permanently).
+        if cc.pointy_alias_param
+            && let Some(name) = data.params.first()
+        {
+            self.mark_readonly(name);
+        }
+
         // Handle implicit $_ for bare blocks (no explicit params, single arg)
         let uses_positional = data.params.iter().any(|p| p != "_" && !p.starts_with(':'));
         // A plain bare block (`data.params` empty, no placeholder/pointy

--- a/src/vm/vm_data_push_ops.rs
+++ b/src/vm/vm_data_push_ops.rs
@@ -71,6 +71,25 @@ impl Interpreter {
             let _ = self.stack.pop();
             return Err(RuntimeError::cannot_lazy_with_action("push to", "Array"));
         }
+        // `my @a := (1,2,3); @a.push(4)` must be rejected the same way a
+        // scalar bind is (`my $a := (1,2,3); $a.push(4)`, already caught by
+        // `call_method_mut_with_values`'s immutable-list check): `:=`-binding
+        // an `@`-var to a List literal preserves the source's `ArrayKind::List`
+        // (see `bind_positional_value` in `vm_var_assign_set_local.rs`), so
+        // `env[target_name]` is `ValueView::Array(_, ArrayKind::List)` here --
+        // but this fast path's `is_simple_array` check below (`matches!(...,
+        // ValueView::Array(..))`) accepts ANY array kind, so it mutated the
+        // supposedly-immutable List in place without ever reaching that check.
+        // Checked before the (also kind-blind) `shared_vars_active` branch so
+        // both single-threaded and threaded programs reject it alike.
+        if let Some(ValueView::Array(_, kind)) = self.env().get(target_name).map(Value::view)
+            && !kind.is_real_array()
+        {
+            let _ = self.stack.pop();
+            return Err(
+                crate::runtime::methods_signature_errors::make_x_immutable_error("push", "List"),
+            );
+        }
         // Shared (threaded) context: route an Array push through the atomic
         // shared store so concurrent `@a.push` from multiple threads serialize
         // under the shared_vars write lock instead of clobbering each other's

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -1126,29 +1126,91 @@ impl Interpreter {
                         )));
                     }
                 }
-                // Reject assignment to immutable type objects (e.g., `Foo .= new`).
+                // Reject assignment to immutable type objects (e.g., `Foo .= new`),
+                // the bare `Nil` term, and an enum value (`enum Fo <A B>; A = 3`).
                 // A `constant` DECLARATION (`raw_mode`) is exempt: it binds the
                 // name rather than modifying whatever the name currently means,
                 // so `constant Int = 5` shadows the builtin (raku prints 5) and
                 // `our Mu constant D = Metamodel::ClassHOW.new_type(:name<D>)`
                 // -- the documented manual-MOP idiom, whose RHS registers a
                 // class literally named `D` before the binding runs -- is legal.
+                //
+                // These three are one mechanism, not three special cases: each is
+                // a bareword whose name denotes an immutable VALUE rather than a
+                // container (X::Assignment::RO, per the readonly-assign-exception
+                // taxonomy's rule 3), and the check was previously scoped to
+                // user-declared classes only (`self.has_class`), silently
+                // no-opping on a builtin type (`Int = 5`), `Nil = 5`, and an enum
+                // value. It also used to throw an untyped `X::AdHoc` instead of
+                // `X::Assignment::RO` even for the user-class case it did catch.
+                // `_` is excluded even though it carries no sigil in its own
+                // storage key: it is the TOPIC's env key (`$_`, never
+                // slot-allocated -- it is dynamically resolved via env by
+                // design, unlike an ordinary `my`/`our` variable, which either
+                // gets a local slot or keeps its own twigil in its key), and a
+                // bare `_` is never a valid Raku term at all (rejected at
+                // `exec_get_bare_word_op`'s very first check). So whenever a
+                // regular variable's CURRENT value happens to be a copy of an
+                // enum member or type object (`$_ = $state` where `$state`
+                // holds an enum value from an earlier iteration), only `$_`'s
+                // reassignment can reach this bareword-shaped check at all --
+                // and it must never be treated as reassigning that term.
                 if !raw_mode
+                    && name != "_"
                     && !name.starts_with('$')
                     && !name.starts_with('@')
                     && !name.starts_with('%')
                     && !name.starts_with('&')
                     && !name.contains("::")
-                    && matches!(
-                        self.env().get(&name).map(Value::view),
-                        Some(ValueView::Package(_))
-                    )
-                    && self.has_class(&name)
                 {
-                    return Err(RuntimeError::new(format!(
-                        "Cannot modify an immutable '{}' type object",
-                        name
-                    )));
+                    // A bareword that has never been (re)bound to something
+                    // else still resolves to the type object it names (an
+                    // unreferenced builtin type is never actually stored in
+                    // env, and a pre-seeded slot holds `Nil` -- both mirror
+                    // the fallback `exec_get_bare_word_op` uses for reads).
+                    // Anything else (e.g. a sigilless `\Int := 5` shadow)
+                    // means the name was rebound to a real value and must NOT
+                    // be treated as the type object anymore.
+                    //
+                    // The "never referenced" (env has no entry at all) case is
+                    // trustworthy ONLY for a TitleCase name. A lowercase
+                    // bareword reaching `SetGlobal` with no prior env entry is
+                    // overwhelmingly more likely to be an ordinary variable's
+                    // first-ever write (e.g. a `for`-loop sub-signature
+                    // destructure leaf, which is bound directly by `SetGlobal`
+                    // rather than a local slot) than a genuine reference to a
+                    // lowercase native-type synonym (`int`, `str`, `num`,
+                    // `array`, `bool`, ...) -- `str = 5` as a bare statement is
+                    // not idiomatic Raku, while `$str`/`$int` are extremely
+                    // common variable names whose sigil-stripped storage key
+                    // is indistinguishable from the type name at this point.
+                    // `for @tests -> ($str, $expected, |args) {...}`
+                    // (roast S32-str/comb.t) hit exactly this: its `$str`
+                    // destructure leaf's very first (never-yet-referenced)
+                    // write was misidentified as assigning to the `str` type
+                    // object. A TitleCase name (`Int`, `Nil`, a user class) has
+                    // no such realistic collision — Raku convention never uses
+                    // a TitleCase bareword as an ordinary variable's storage
+                    // key.
+                    let current_view = self.env().get(&name).map(Value::view);
+                    let first_letter_uppercase = name.starts_with(|c: char| c.is_uppercase());
+                    let unbound_type_slot = matches!(
+                        current_view,
+                        Some(ValueView::Package(_)) | Some(ValueView::Nil)
+                    ) || (current_view.is_none() && first_letter_uppercase);
+                    if unbound_type_slot && name == "Nil" {
+                        return Err(RuntimeError::assignment_ro_nil());
+                    }
+                    if unbound_type_slot && (self.has_class(&name) || Self::is_builtin_type(&name))
+                    {
+                        return Err(RuntimeError::assignment_ro_type_object(&name));
+                    }
+                    if let Some(ValueView::Enum { enum_type, key, .. }) = current_view {
+                        return Err(RuntimeError::assignment_ro_typename(
+                            &enum_type.resolve(),
+                            &key.resolve(),
+                        ));
+                    }
                 }
                 let raw_val = self.stack.pop().unwrap_or(Value::NIL);
                 let (raw_val, bind_source) = match raw_val.as_varref() {

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -1172,32 +1172,62 @@ impl Interpreter {
                     // means the name was rebound to a real value and must NOT
                     // be treated as the type object anymore.
                     //
-                    // The "never referenced" (env has no entry at all) case is
-                    // trustworthy ONLY for a TitleCase name. A lowercase
-                    // bareword reaching `SetGlobal` with no prior env entry is
-                    // overwhelmingly more likely to be an ordinary variable's
-                    // first-ever write (e.g. a `for`-loop sub-signature
-                    // destructure leaf, which is bound directly by `SetGlobal`
-                    // rather than a local slot) than a genuine reference to a
-                    // lowercase native-type synonym (`int`, `str`, `num`,
-                    // `array`, `bool`, ...) -- `str = 5` as a bare statement is
-                    // not idiomatic Raku, while `$str`/`$int` are extremely
-                    // common variable names whose sigil-stripped storage key
-                    // is indistinguishable from the type name at this point.
-                    // `for @tests -> ($str, $expected, |args) {...}`
-                    // (roast S32-str/comb.t) hit exactly this: its `$str`
-                    // destructure leaf's very first (never-yet-referenced)
-                    // write was misidentified as assigning to the `str` type
-                    // object. A TitleCase name (`Int`, `Nil`, a user class) has
-                    // no such realistic collision — Raku convention never uses
-                    // a TitleCase bareword as an ordinary variable's storage
-                    // key.
+                    // The "never referenced" (env has no entry at all) AND the
+                    // "pre-seeded Nil slot" cases are trustworthy ONLY for a
+                    // TitleCase name. A lowercase bareword reaching `SetGlobal`
+                    // with `None`/`Nil` currently stored is overwhelmingly more
+                    // likely to be an ordinary variable's write than a genuine
+                    // reference to a lowercase native-type synonym (`int`,
+                    // `str`, `num`, `array`, `bool`, ...) -- `str = 5` as a bare
+                    // statement is not idiomatic Raku, while `$str`/`$int` are
+                    // extremely common variable names whose sigil-stripped
+                    // storage key is indistinguishable from the type name at
+                    // this point. TWO separate shapes hit this: a `for`-loop
+                    // sub-signature destructure leaf (`for @tests -> ($str,
+                    // $expected, |args) {...}`, roast S32-str/comb.t), which is
+                    // bound directly by `SetGlobal` rather than a local slot,
+                    // so its first-ever write sees `None`; and an uninitialized
+                    // outer `my $str;` (Nil) captured and assigned INSIDE a
+                    // closure (`my $str; lives-ok { $str = 1 }, "..."` --
+                    // `Test`'s `lives-ok` catches the resulting spurious
+                    // X::Assignment::RO and reports a false test failure,
+                    // caught by `t/immutable-lvalue-assignment-gaps.t`'s
+                    // regression control), whose free-variable write also
+                    // reaches `SetGlobal` and sees the captured `Some(Nil)`.
+                    // A TitleCase name (`Int`, `Nil`, a user class) has no such
+                    // realistic collision — Raku convention never uses a
+                    // TitleCase bareword as an ordinary variable's storage key
+                    // -- so the check requires it for those shapes; only a
+                    // REAL `Package(SomeType)` current value (set exclusively
+                    // by genuine class/type registration, e.g. `class Foo {}`
+                    // sets env["Foo"] = Package("Foo") directly) is trusted
+                    // unconditionally.
+                    //
+                    // `Package(Any)` is NOT that -- it is a generic "not yet
+                    // materialized" placeholder `SetVarDynamic` pre-seeds for
+                    // ANY closure-captured variable regardless of its name
+                    // (see the matching special case in
+                    // `exec_get_bare_word_op`, "A `my $Buf = Buf.new`
+                    // declaration pre-seeds env[\"Buf\"] with the placeholder
+                    // `Package(Any)`"), so it needs the SAME uppercase gate as
+                    // `None`/a genuine `Nil` slot: `my $str; lives-ok { $str =
+                    // 1 }, "..."` captures the outer, not-yet-assigned `$str`
+                    // this way, and without the gate its free-variable write
+                    // was misidentified as assigning to the lowercase native
+                    // type `str` (a spurious `X::Assignment::RO` that
+                    // `lives-ok` correctly caught and reported as a test
+                    // failure, even though nothing in the block actually
+                    // "died").
                     let current_view = self.env().get(&name).map(Value::view);
                     let first_letter_uppercase = name.starts_with(|c: char| c.is_uppercase());
-                    let unbound_type_slot = matches!(
-                        current_view,
-                        Some(ValueView::Package(_)) | Some(ValueView::Nil)
-                    ) || (current_view.is_none() && first_letter_uppercase);
+                    let unbound_type_slot = match current_view {
+                        Some(ValueView::Package(p)) if p == "Any" && name != "Any" => {
+                            first_letter_uppercase
+                        }
+                        Some(ValueView::Package(_)) => true,
+                        Some(ValueView::Nil) | None => first_letter_uppercase,
+                        _ => false,
+                    };
                     if unbound_type_slot && name == "Nil" {
                         return Err(RuntimeError::assignment_ro_nil());
                     }

--- a/t/immutable-lvalue-assignment-gaps.t
+++ b/t/immutable-lvalue-assignment-gaps.t
@@ -168,6 +168,61 @@ throws-like { my \G = 5; ++G }, X::Multi::NoMatch,
 }
 
 {
+    # An uninitialized outer `my $str;` captured by a closure and assigned
+    # INSIDE the closure (`lives-ok { $str = 1 }, "..."`) must stay writable.
+    # `SetVarDynamic`'s closure-capture-by-reference support pre-seeds a
+    # not-yet-assigned captured variable's env slot with the placeholder
+    # `Package(Any)` regardless of the variable's own name, so this hit the
+    # exact same lowercase-native-type collision as the for-loop destructure
+    # leaf above, but via a different current-value shape (`Package(Any)`
+    # instead of `None`). `lives-ok` catches the resulting spurious
+    # X::Assignment::RO and reports a false test failure -- the outer `plan`
+    # below asserts the assignment itself is silently accepted, i.e. that
+    # `lives-ok`'s own inner test reports "ok".
+    my $str;
+    my $inner_ok = lives-ok { $str = 1 }, "assigning to a captured, uninitialized \$str";
+    ok $inner_ok, 'lives-ok on a captured uninitialized $str reports success (roast S02-types/set.t, sethash.t)';
+    is $str, 1, 'and the assignment actually took effect';
+}
+
+{
+    # The reduced repro that first caught this in CI, pinned verbatim.
+    my $str;
+    my $inner_ok = lives-ok { $str = 1 }, "x";
+    ok $inner_ok, 'reduced repro: my $str; lives-ok { $str = 1 } reports success';
+}
+
+{
+    # Same class of bug, checked against dies-ok/throws-like/plain try too --
+    # a spurious X::Assignment::RO would show up in all of them, since they
+    # all inspect the block's thrown-or-not outcome the same way lives-ok does.
+    my $str;
+    todo "dies-ok correctly reports false: the assignment is legal and does not die";
+    my $inner_ok = dies-ok { $str = 1 }, "should NOT die (assignment is legal)";
+    nok $inner_ok, 'dies-ok on a captured uninitialized $str correctly reports "did not die"';
+    is $str, 1, 'and the assignment still took effect';
+}
+
+{
+    my $str;
+    throws-like { $str = 1; die "boom" }, X::AdHoc,
+        message => /'boom'/,
+        'throws-like still sees the REAL exception, not a spurious one from the assignment';
+    is $str, 1, 'and the assignment before the real die still took effect';
+}
+
+{
+    my $str;
+    my $threw = False;
+    try {
+        $str = 1;
+        CATCH { default { $threw = True } }
+    }
+    nok $threw, 'a plain try{} around the same assignment does not set $!/CATCH';
+    is $str, 1, 'and the assignment took effect';
+}
+
+{
     # A plain single-param pointy block reused across an outer `for ^N {}`
     # AND a later `for ... -> ($x, $y) {}` sharing a variable name (the
     # digest-battery.t / SHA3 shape) must not leak a readonly mark from the

--- a/t/immutable-lvalue-assignment-gaps.t
+++ b/t/immutable-lvalue-assignment-gaps.t
@@ -1,0 +1,220 @@
+use Test;
+
+# Regression test for the fixed rows of
+# todo/tickets/immutable-lvalues-that-mutsu-still-lets-you-assign-to.md: cases
+# where Raku rejects an assignment to an immutable lvalue but mutsu used to
+# silently succeed. Every shape below was verified against `raku` v2026.06
+# before this test was written.
+
+# ---------------------------------------------------------------------------
+# 1. A plain `$`-sigiled pointy-block parameter is a readonly ALIAS (like a
+#    non-`is rw` sub parameter), regardless of how it is invoked.
+# ---------------------------------------------------------------------------
+
+throws-like { my $b = -> $v { $v = 1 }; $b(3) }, X::AdHoc,
+    message => /'Cannot assign to a readonly variable or a value'/,
+    'assigning to a single-param pointy-block parameter';
+
+throws-like { my $b = -> $v { $v += 1 }; $b(3) }, X::AdHoc,
+    message => /'Cannot assign to a readonly variable or a value'/,
+    'compound-assigning to a single-param pointy-block parameter';
+
+throws-like { my $b = -> $v, $w { $v = 1 }; $b(3, 4) }, X::AdHoc,
+    message => /'Cannot assign to a readonly variable or a value'/,
+    'assigning to a multi-param pointy-block parameter (already worked; pinned here too)';
+
+# ---------------------------------------------------------------------------
+# 2. Assigning to a bareword that IS the immutable value (a builtin type
+#    object, the bare `Nil` term, or an enum value) -- X::Assignment::RO.
+# ---------------------------------------------------------------------------
+
+throws-like { Int = 5 }, X::Assignment::RO,
+    message => /'Cannot modify an immutable \'Int\' type object'/,
+    'assigning to the Int type object';
+
+throws-like { Nil = 5 }, X::Assignment::RO,
+    message => /'Cannot modify an immutable Nil value'/,
+    'assigning to the bare Nil term';
+
+throws-like { enum Fo <A B>; A = 3 }, X::Assignment::RO,
+    message => /'Cannot modify an immutable Fo (A)'/,
+    'assigning to an enum value';
+
+throws-like { class Foo {}; Foo = 5 }, X::Assignment::RO,
+    message => /'Cannot modify an immutable \'Foo\' type object'/,
+    'assigning to a user-declared class type object (also fixes its exception class)';
+
+# `constant` shadowing a builtin type name is a DECLARATION, not a
+# modification, and must stay legal.
+{
+    constant Int = 5;
+    is Int, 5, 'a constant may shadow a builtin type name';
+}
+
+# ---------------------------------------------------------------------------
+# 3. `my @a := (1,2,3); @a.push(...)` -- an Array-sigiled variable bound to an
+#    immutable List, the array twin of the already-working scalar bind
+#    (`my $a := (1,2,3); $a.push(...)`).
+# ---------------------------------------------------------------------------
+
+# `splice` is deliberately excluded: Raku does not define a `splice`
+# candidate on a plain `List` at all (X::Multi::NoMatch, "Routine does not
+# have any candidates"), so it never reaches the immutable-container check
+# these methods do -- that is a separate, pre-existing gap, not one of the
+# rows this test pins.
+for <push append unshift prepend pop shift> -> $method {
+    my $code = do given $method {
+        when 'push'     { -> @a { @a.push(4) } }
+        when 'append'   { -> @a { @a.append(4) } }
+        when 'unshift'  { -> @a { @a.unshift(0) } }
+        when 'prepend'  { -> @a { @a.prepend(0) } }
+        when 'pop'      { -> @a { @a.pop } }
+        when 'shift'    { -> @a { @a.shift } }
+    };
+    throws-like { my @a := (1, 2, 3); $code(@a) }, X::Immutable,
+        message => /'immutable' .* 'List'/,
+        ":= -bound Array rejects .$method";
+}
+
+# ---------------------------------------------------------------------------
+# 4. Sub-signature destructuring: neither a sigilless leaf (`\a`) nor a plain
+#    `$`-sigiled leaf inside a `(...)` sub-signature was ever marked readonly.
+# ---------------------------------------------------------------------------
+
+throws-like { sub f($ (\a, \b)) { a = 1 }; f((10, 20)) }, X::Assignment::RO,
+    message => /'Cannot modify an immutable Int (10)'/,
+    'assigning to a sigilless sub-signature destructure leaf';
+
+throws-like { sub f($ ($x, $y)) { $x = 1 }; f((10, 20)) }, X::AdHoc,
+    message => /'Cannot assign to a readonly variable or a value'/,
+    'assigning to a $-sigiled sub-signature destructure leaf';
+
+# ---------------------------------------------------------------------------
+# 5. `my \G = 5; G++` -- postfix/prefix `++`/`--` on a sigilless bind now
+#    dispatches the same way an in-place mutation of a readonly parameter does.
+# ---------------------------------------------------------------------------
+
+throws-like { my \G = 5; G++ }, X::Multi::NoMatch,
+    'postfix ++ on a sigilless bind';
+
+throws-like { my \G = 5; G-- }, X::Multi::NoMatch,
+    'postfix -- on a sigilless bind';
+
+throws-like { my \G = 5; ++G }, X::Multi::NoMatch,
+    'prefix ++ on a sigilless bind';
+
+# ---------------------------------------------------------------------------
+# Writable controls: none of the fixes above may broaden into these.
+# ---------------------------------------------------------------------------
+
+{
+    my $r = do { sub f($x is rw) { $x = 1 }; my $v = 5; f($v); $v };
+    is $r, 1, 'a sub "is rw" parameter still writes back';
+}
+
+{
+    my $r = do { my $b = -> $v is rw { $v = 1 }; my $v = 5; $b($v); $v };
+    is $r, 1, 'a pointy-block "is rw" parameter still writes back';
+}
+
+{
+    my $r = do { my $b = -> $v is copy { $v = 1; $v }; $b(3) };
+    is $r, 1, 'a pointy-block "is copy" parameter is still writable';
+}
+
+{
+    my @a = 1, 2, 3;
+    for @a { $_ = $_ * 10 }
+    is-deeply @a, [10, 20, 30], 'for @a { $_ = ... } still mutates a real Array\'s elements';
+}
+
+{
+    my @a = 1, 2, 3;
+    @a.push(4);
+    is-deeply @a, [1, 2, 3, 4], 'push on a real (non-bound) Array still works';
+}
+
+{
+    my @a := my @b = 1, 2, 3;
+    @a.push(4);
+    is-deeply @b, [1, 2, 3, 4], 'binding an @-var to a real Array keeps push writable';
+}
+
+{
+    my $r = do {
+        my $x = 0;
+        my @a = 1, 2, 3;
+        @a.map({ $_ *= 10 });
+        @a;
+    };
+    is-deeply $r, [10, 20, 30], '@a.map({ $_ = ... }) topic mutation over a real Array still writes back';
+}
+
+# --- regression controls for two bugs the fix above ran into in CI ---
+
+{
+    # A `for`-loop sub-signature destructure leaf (`-> ($str, $expected,
+    # |args)`, roast S32-str/comb.t) binds by a direct `SetGlobal`, not a
+    # local slot. Its first-ever write must not be misidentified as
+    # assigning to the lowercase native-type synonym of the same bare name
+    # (`str`, `int`, `num`, `array`, `bool`, ...).
+    my @tests = ("abc", <a b c>.Seq, ""), ("xyz", <x y z>.Seq, "", 4);
+    my @seen;
+    for @tests -> ($str, $expected, |args) {
+        @seen.push($str);
+    }
+    is-deeply @seen, ["abc", "xyz"],
+        'for-loop sub-signature destructure leaf named like a lowercase native type stays writable';
+}
+
+{
+    # A plain single-param pointy block reused across an outer `for ^N {}`
+    # AND a later `for ... -> ($x, $y) {}` sharing a variable name (the
+    # digest-battery.t / SHA3 shape) must not leak a readonly mark from the
+    # first pointy-block call into the later destructure.
+    my $r = do {
+        sub f() {
+            my @lanes = [1, 2, 3, 4, 5] xx 5;
+            my @c = map -> $x { [+^] @lanes[$x; ^5] }, ^5;
+            for ^2 X ^2 -> ($x, $y) { @lanes[$x; $y] +^= @c[$x] }
+            @lanes;
+        }
+        f();
+    };
+    ok $r.elems == 5, 'pointy-block param mark does not leak into a later for-loop destructure of the same name';
+}
+
+{
+    # The native `.map` rw-writeback path (`next`/`last` inside an `is rw`
+    # param block) must still work after moving the plain pointy-block
+    # readonly mark to the call site.
+    my @a = 1, 2, 3, 4, 5;
+    my @r = @a.map(-> $x is rw { next if $x %% 2; $x++; $x });
+    is-deeply @a, [2, 2, 4, 4, 6], 'next inside an rw-param native map block still skips its own mutation';
+    is-deeply @r, [2, 4, 6], 'and the return value still omits the skipped iterations';
+}
+
+{
+    # `$_ = $state` where `$state` holds an enum value from an earlier loop
+    # iteration must not be treated as reassigning that enum member itself
+    # (t/topic-alias-does-not-cross-frames.t).
+    my enum State <A B>;
+    sub advance() {
+        my $state = A;
+        loop {
+            $_ = $state;
+            when A { $state = B; next }
+            when B { last }
+        }
+        1;
+    }
+    class C { method tag() { 'C' } }
+    my $seen;
+    given C.new -> $c {
+        advance();
+        $seen = $c.tag;
+    }
+    is $seen, 'C', 'a when-loop driven off its topic does not corrupt an outer given-binding';
+}
+
+done-testing;

--- a/todo/tickets/immutable-lvalues-that-mutsu-still-lets-you-assign-to.md
+++ b/todo/tickets/immutable-lvalues-that-mutsu-still-lets-you-assign-to.md
@@ -6,7 +6,17 @@ exception a rejected assignment throws; this ticket collects the cases where
 mutsu does not reject the assignment at all, which the same survey surfaced.
 Every row was probed against `raku` v2026.06.
 
-## Cases (raku throws, mutsu silently succeeds)
+## Status update (2026-08-27)
+
+Seven more rows are now **fixed** (`news/2026-08/closure-call-and-bareword-term-readonly-gaps.md`):
+a `$`-sigiled single-param pointy block (`-> $v { $v = 1 }`); assigning to the
+bare `Nil` term, a builtin type object (`Int = 5`), or an enum value (`enum Fo
+<A B>; A = 3`); a sub-signature destructure leaf, both sigilless (`\a`) and
+`$`-sigiled (`$x`); `push`/`append`/`unshift`/`prepend`/`pop`/`shift` on an
+`@`-var bound to an immutable List (`my @a := (1,2,3); @a.push(4)`); and
+postfix/prefix `++`/`--` on a sigilless bind (`my \G = 5; G++`).
+
+The remaining probe harness (unchanged rows only):
 
 ```raku
 sub p($l, &c) { my $r = try { c() }; say $l, " => ", ($! ?? $!.^name ~ " | " ~ $!.Str !! "OK") }
@@ -14,34 +24,150 @@ sub p($l, &c) { my $r = try { c() }; say $l, " => ", ($! ?? $!.^name ~ " | " ~ $
 p "list elem",        { (1,2,3)[0] = 9 };            # raku: X::Assignment::RO, Cannot modify an immutable List ((1 2 3))
 p "range elem",       { (1..3)[0] = 9 };             # raku: X::Assignment::RO, Cannot modify an immutable Range (1..3)
 p "Seq elem",         { my $s = (1,2,3).Seq; $s[0] = 5 };   # raku: X::Assignment::RO, immutable Int (1)
-p "bound list elem",  { my @a := (1,2,3); @a[0] = 9 };      # raku: X::Assignment::RO, immutable List
-p "assign to Nil",    { Nil = 5 };                   # raku: X::Assignment::RO, Cannot modify an immutable Nil value
-p "assign to type",   { Int = 5 };                   # raku: X::Assignment::RO, Cannot modify an immutable 'Int' type object
-p "assign to enum",   { enum Fo <A B>; A = 3 };      # raku: X::Assignment::RO, Cannot modify an immutable Fo (A)
 p "map literal topic",{ (1,2).map({ $_ = 5 }).eager };          # raku: X::AdHoc
 p "grep topic",       { (1,2).grep({ $_ = 5 }).eager };         # raku: X::AdHoc
 p "block arg topic",  { my $s = { $_ = 5 }; $s(7) };            # raku: X::AdHoc
-p "pointy param",     { my $b = -> $v { $v = 1 }; $b(3) };      # raku: X::AdHoc, readonly variable
-p "sub-signature",    { sub f($ (\a, \b)) { a = 1 }; f((1,2)) };# raku: X::Assignment::RO
-p "sigilless incr",   { my \G = 5; G++ };            # raku: X::Multi::NoMatch
 p "bind list assign", { my $x := (1,2,3); $x = 5 };  # raku: X::AdHoc, Cannot assign to an immutable value
-p "bound array elem", { my @a := (1,2,3); @a.push(4) };  # raku: X::Immutable, Cannot call 'push' on an immutable 'List'
 ```
 
-## Status update (2026-08-26)
+(The four topic rows fixed 2026-08-26 -- `for 1,2`, `for (1,2)`, `for <a b>`,
+`for %h.keys` -- and the seven fixed 2026-08-27 above are no longer listed.)
 
-Four topic rows are now **fixed** and moved out of this list:
-`for 1,2`, `for (1,2)`, `for <a b>` and `for %h.keys` throw `X::AdHoc` "Cannot
-assign to an immutable value", matching raku
-(`news/2026-08/topic-var-name-still-scalar-for-literal-alias.md`). The mechanism
-is `ForLoopSpec::source_items_are_bare`, a *provable* compile-time property
-(`Compiler::for_iterable_yields_bare_items`).
+## Why `-> $v { $v = 1 }` was fixable but `{ $_ = 5 }` (block-argument topic) is not
 
-The remaining topic rows — `map`/`grep` block topics, a plain block invocation
-(`my $s = { $_ = 5 }; $s(7)`), a pointy block parameter (`-> $v { $v = 1 }`) and
-`for %h` (whose items are immutable `Pair`s) — could **not** be closed the same
-way, and the measurement explains why. Raku's rule is per item: the topic is
-writable exactly when the item is a container.
+Both looked like the same gap ("named routines mark their params, the
+closure-call path does not"), but they turned out to need genuinely different
+mechanisms, and only one is safe to ship:
+
+- **A `$`-sigiled pointy-block parameter is *always* readonly**, regardless of
+  what it is called with (row 1 of the readonly-assign-exception-taxonomy: a
+  readonly binding with a container, `X::AdHoc` "Cannot assign to a readonly
+  variable or a value") — the same rule a `for`-loop's named alias already
+  gets. This does not depend on whether the argument came from a container, so
+  it is safe to mark unconditionally.
+- **A bare `{ $_ = 5 }` block's IMPLICIT topic is writable exactly when the
+  argument is a container** (row 2 vs. row 3 of the same taxonomy). `$s(7)`
+  passes a literal `7` — never a container — so it should always be readonly.
+  But the exact same VM code path (`call_compiled_closure_with_topic`'s
+  "implicit `$_` for bare blocks" branch, `vm_closure_dispatch.rs`) is also
+  what `@a.map({ $_ *= 10 })` uses when the native `.map` loop's rw-writeback
+  detection (`vm_native_map.rs`'s `mutates_topic`/`writeback_name`) hands it a
+  *named array's real element* with `capture_rw_topic: true` — and THAT case
+  legitimately mutates the source array (verified: `my @a = 1,2,3;
+  @a.map({ $_ *= 10 }); say @a;` prints `[10 20 30]` in both raku and mutsu,
+  and this is load-bearing existing behaviour, not a bug). Marking the
+  implicit topic readonly at that shared call site would break
+  `@a.map({ $_ = ... })`'s rw writeback outright — it is the exact same
+  ADR-0040 "does mutsu know the source item is a container" gap the `for`-loop
+  topic rows are blocked on, just reached from `.map`/direct-call instead of
+  `for`. **Left unfixed; do not attempt without ADR-0040's store-side element
+  itemization**, and do not reuse `call_compiled_closure_with_topic`'s
+  implicit-topic branch for this without first separating the "direct value
+  call" and "native map rw-writeback" callers, which currently share it.
+- The two `.map`/`.grep`-literal-topic rows are the same blocker by the same
+  mechanism (both go through the identical "implicit topic from a positional
+  arg, `capture_rw_topic` may or may not be set" code, since `(1,2).map({ $_ =
+  5 })` over non-Pair literal elements takes the exact same `explicit_topic:
+  None` path as `@a.map({ $_ *= 10 })` over a real array — the two are
+  indistinguishable at that call site without per-item container information).
+
+## A live trap this ticket's fix ran into: bytecode-injected readonly marks leak through "fast native loop" call paths
+
+The first implementation of the `-> $v { $v = 1 }` fix injected a
+`Stmt::MarkReadonly` prologue statement into the pointy block's *compiled
+body*, mirroring how `Stmt::MarkSigillessReadonly` already does this for `my
+\x = 5`. That reached CI green locally but broke `t/digest-battery.t`,
+`t/map-native-rw-param.t`, and `t/topic-alias-does-not-cross-frames.t`:
+`resolution_map_grep.rs`/`resolution_map_grep_rw.rs` (the native `.map`/`.grep`
+loops, plus a `.first` matcher) bind a block's params by a direct `env.insert`
+and run its body via `run_reuse` *without* `push_call_frame`/
+`enter_readonly_frame` (a deliberate perf shortcut around the general call
+machinery). A prologue statement runs unconditionally wherever the bytecode
+executes, so it marked `readonly_vars` with `readonly_frames == 0` — which
+skips the undo journal entirely (`mark_readonly_sym_with`'s `if
+self.readonly_frames.get() == 0 { return; }`) and leaked the mark
+PERMANENTLY into the next unrelated same-named lexical anywhere later in the
+program (SHA3's `map -> $x {...}` leaking "x" into a later `for ... -> ($x,
+$y)` reusing the name; digest's rw-map "x" leaking across an outer `for`
+iteration).
+
+**Fix actually shipped:** mark the parameter at the CALL SITE
+(`call_compiled_closure_with_topic` in `vm_closure_dispatch.rs`, gated on a
+new `CompiledCode::pointy_alias_param` flag set only for this one shape) right
+after `bind_function_args_values` succeeds, not via a body prologue.
+`push_call_frame` already ran earlier in that same function, so the mark is
+correctly scoped and rolled back on every exit. This also means the mark is
+simply never applied when a native fast loop bypasses that function entirely
+— which is exactly the "leave the topic rows alone" boundary this ticket
+already draws, achieved as a side effect rather than a special case.
+
+The two leaky loops (`eval_map_over_items` and `eval_map_over_items_rw`) were
+also hardened directly with a `ReadonlyFrameGuard` around each iteration's
+`run_reuse` call, so a *future* body side effect of the same shape doesn't
+reintroduce this class of leak.
+
+## A second live trap: the bareword-term check can't just test the CURRENT value
+
+The `Nil`/type-object/enum fix (added to the `SetGlobal` opcode handler)
+rejects an assignment when the target's CURRENT env value looks like a type
+object, `Nil`, or an enum member. That is unsound on its own: a bareword
+carries no sigil in its *storage key* either way (`Nil = 5` and `$_ = 5` both
+compile to `Stmt::Assign { name: "_"|"Nil", ... }` — the sigil is stripped
+before this point, same information loss `constant $PI` vs. `constant PI` hit
+in the exception-taxonomy work), so a check keyed only on "does the current
+value look like an enum" cannot tell the true case (`enum Fo <A B>; A = 3`)
+apart from a plain variable that merely happens to currently hold a COPY of
+that same enum value — e.g. `$_ = $state` where `$state` holds `A` from an
+earlier loop iteration reached `t/topic-alias-does-not-cross-frames.t` and
+broke it (mutsu called `.=` on the container-less topic and reported "Cannot
+modify an immutable State (A)").
+
+The reason only `$_` triggers this SPECIFIC ambiguity in practice: a simple
+`my`/`our`-declared variable (`my $state = ...`) compiles to a local SLOT
+(`SetLocal`, never reaching this `SetGlobal`-only check at all), so it can't
+collide with a bareword this way. `$_` is dynamically resolved via env by
+design on every frame, never slot-allocated — and a bareword `_` alone is
+never a valid Raku term regardless (rejected at `exec_get_bare_word_op`'s very
+first check). So excluding `name == "_"` from this check is a principled fix
+for that specific case, not a narrow patch papering over the real gap —
+verified against `my $state`/`our $state` holding-then-reassigning an enum
+value, neither of which reaches this code path at all. (This claim held for
+the ENUM check; the type-object check needed a further refinement — see the
+third trap below, which found that NOT EVERY variable avoids `SetGlobal` the
+way a simple `my $x` does.)
+
+## A third live trap: a lowercase bareword's storage key ALSO collides with a variable, on its first-ever write
+
+The type-object check's `unbound_type_slot` test originally treated "never
+referenced at all" (`env.get(name)` is `None`) the same as a pre-seeded `Nil`
+slot — necessary for `Int = 5` to be caught, since a builtin type's bareword
+is never actually written into env by anything else. That broke
+`roast/S32-str/comb.t`: `for @tests -> ($str, $expected, |args) {...}` binds
+its sub-signature destructure leaves by a direct `SetGlobal`, NOT a local
+slot (destructure leaves aren't slot-allocated the way a simple `my $str` is —
+contradicting the "an ordinary variable always compiles to SetLocal" claim
+above, which is true for a simple declaration but not for every binding
+shape). `$str`'s very first write hit the exact same "never referenced" check
+and was misidentified as assigning to the lowercase native type `str`.
+
+**Fix:** restrict the `None`-counts-as-unbound inference to TitleCase names
+(`name.starts_with` an uppercase char). `str`/`int`/`num`/`array`/`bool`/...
+are realistic, common variable names whose sigil-stripped key collides with a
+type synonym; `str = 5` as a bare statement referencing the TYPE object is not
+idiomatic Raku at all. So the lost coverage (a lowercase native-type
+bareword's very first, never-yet-referenced assignment) is a deliberate,
+accepted trade-off — `Int`/`Nil`/a user class (TitleCase by convention) still
+work, and a genuinely ambiguous case would need the sigil-vs-bareword
+distinction preserved at compile time (the same class of fix the
+exception-taxonomy work made for `constant $PI` vs. `constant PI` via the
+parser-recorded `__constant_sigil` trait) to close soundly — not attempted
+here, since the current fix already covers every case this ticket's probe
+harness names.
+
+## Still blocked: the topic rows (`for`-loop per-item container-ness)
+
+`for %h`, `for @a[0..1]`, `for @a.map(…)` remain blocked on ADR-0040's
+store-side element itemization, unrelated to the mechanism above:
 
 ```
 for @a         Scalar      for 1,2        Int
@@ -60,27 +186,20 @@ correctly; applying the same test on the eager path would additionally mark
 have. **These rows are therefore blocked on ADR-0040's store-side element
 itemization, not on the topic-marking code.**
 
-The `map`/`grep`/block-argument rows are a *different* blocker: those topics are
-bound by the block invocation path, not the loop, and none of those paths marks
-the bound topic at all. `sub f($x) { $x = 1 }` is correctly rejected, but the
-pointy-block form `-> $v { $v = 1 }` is not — named routines mark their params
-(`vm_call_light.rs`), the closure-call path does not.
+## Still blocked: `my $x := (1,2,3); $x = 5`
 
-The original note, for reference: mutsu only marks `$_` readonly for *some*
-immutable sources — see the `topic_readonly` computation in
-`src/vm/vm_for_loop_body.rs` and the corresponding sites in
-`vm_for_loop_intrange.rs` / `vm_for_loop_lazy.rs` / `vm_given_when_ops.rs`.
+The deliberate conservatism in `src/vm/vm_var_assign_set_local.rs`: the
+`:=`-to-literal readonly marking fires only for scalar-shaped values
+(`Int`/`Str`/`Num`/`Rat`/`Bool`/`Complex`), because anything container-like or
+written-through (`ContainerRef`, `Proxy`, `HashEntryRef`, `is raw`) must stay
+writable and an overlooked kind becomes a hard error. Widening it needs the
+container/no-container distinction to be a property of the *value*, not a
+whitelist of view kinds.
 
-The `my $x := (1,2,3)` case is the deliberate conservatism in
-`src/vm/vm_var_assign_set_local.rs`: the `:=`-to-literal readonly marking fires
-only for scalar-shaped values (`Int`/`Str`/`Num`/`Rat`/`Bool`/`Complex`), because
-anything container-like or written-through (`ContainerRef`, `Proxy`,
-`HashEntryRef`, `is raw`) must stay writable and an overlooked kind becomes a
-hard error. Widening it needs the container/no-container distinction to be a
-property of the *value*, not a whitelist of view kinds.
+## Still blocked: element assignment (`(1,2,3)[0] = 9`, `Range`, `Seq`)
 
-The element cases (`(1,2,3)[0] = 9`, `Range`, `Seq`) need the subscript store
-path to know its target is an immutable container.
+Need the subscript store path to know its target is an immutable container —
+the same underlying container/no-container information ADR-0040 would supply.
 
 ## Messages that are close but not exact
 
@@ -97,3 +216,10 @@ These already throw the right class; only the rendered value differs:
 - `sub g() {...}; g() = 5` — raku "Cannot modify an immutable Int (42)", mutsu
   "sub 'g' is not rw"; `$obj.x = 5` on a non-`rw` attribute — raku
   "Cannot modify an immutable Int (1)", mutsu "method 'x' is not rw".
+- `my @a := (1,2,3); @a.splice(0,1)` — raku does not even define a `splice`
+  candidate on a plain `List` (`X::Multi::NoMatch`, "Routine does not have any
+  candidates"); mutsu reports `X::Immutable` "Cannot call 'splice' on an
+  immutable 'List'" (the same message the other five list mutators correctly
+  use, since `splice` shares their dispatch check). Pre-existing, not
+  introduced by the 2026-08-27 push/append/unshift/prepend/pop/shift fix above
+  (which only extended that same check from `$`-bound to `@`-bound targets).

--- a/todo/tickets/immutable-lvalues-that-mutsu-still-lets-you-assign-to.md
+++ b/todo/tickets/immutable-lvalues-that-mutsu-still-lets-you-assign-to.md
@@ -160,9 +160,30 @@ accepted trade-off — `Int`/`Nil`/a user class (TitleCase by convention) still
 work, and a genuinely ambiguous case would need the sigil-vs-bareword
 distinction preserved at compile time (the same class of fix the
 exception-taxonomy work made for `constant $PI` vs. `constant PI` via the
-parser-recorded `__constant_sigil` trait) to close soundly — not attempted
-here, since the current fix already covers every case this ticket's probe
-harness names.
+parser-recorded `__constant_sigil` trait) to close soundly.
+
+**This same ambiguity turned out to have a THIRD current-value shape, not just
+`None`/`Nil`: `Package(Any)`.** That one reached CI as `roast/S02-types/set.t`
+and `sethash.t` going red with an unrelated-looking symptom — `lives-ok`/
+`dies-ok` false negatives (`my $str; lives-ok { $str = 1 }, "x"` reported "not
+ok" even though the assignment succeeded and nothing threw). Root cause:
+`SetVarDynamic`'s closure-capture-by-reference support pre-seeds ANY not-yet-
+assigned closure-captured variable's env slot with the placeholder
+`Package(Any)`, regardless of the variable's own name (the same mechanism
+`exec_get_bare_word_op`'s read-side fallback already special-cases). The
+`Package(_)` branch of the original fix was left completely unconditional —
+no TitleCase gate at all — so a captured, not-yet-initialized `$str` hit this
+placeholder on its first (`lives-ok`-internal) write and was misidentified as
+assigning to the type `str`; `lives-ok` correctly caught the resulting
+spurious `X::Assignment::RO`, which is why the symptom looked like a `Test`
+bug rather than an assignment bug. Fixed the same way: `Package(Any)` (for any
+name other than the literal bareword `Any`) now requires the same TitleCase
+gate as `None`/a real `Nil`; only a genuine `Package(SomeRealType)` (set
+exclusively by actual class/type registration) is trusted unconditionally.
+`t/immutable-lvalue-assignment-gaps.t` pins all three shapes as separate
+regression controls (a `for`-loop destructure leaf, a `lives-ok`-captured
+uninitialized variable, and the direct `Int`/`Nil`/`Foo` cases) so a future
+change to this check has to keep all three honest at once.
 
 ## Still blocked: the topic rows (`for`-loop per-item container-ness)
 


### PR DESCRIPTION
## Summary

Closes seven rows from `todo/tickets/immutable-lvalues-that-mutsu-still-lets-you-assign-to.md` — cases where Raku rejects an assignment to an immutable lvalue but mutsu silently accepted it. Each was verified against `raku` v2026.06 for both exception class and message.

- A single-param, trait-less pointy-block parameter (`-> $v { $v = 1 }`) is now readonly (`X::AdHoc`), like a non-`is rw` sub parameter. Marked at the call site (`call_compiled_closure_with_topic`), not via an injected body-prologue statement — the latter leaks permanently through several `push_call_frame`-bypassing "fast native loop" paths (`resolution_map_grep.rs`/`resolution_map_grep_rw.rs`), which this branch hit and fixed along the way.
- Assigning to a bareword that names an immutable value — `Nil`, a builtin type object (`Int = 5`), or an enum value — now throws `X::Assignment::RO`. Restricted to TitleCase names and excludes the topic `$_`, both found necessary by two more regressions this branch caught and fixed (`roast/S32-str/comb.t`, `t/topic-alias-does-not-cross-frames.t`).
- Sub-signature destructure leaves (sigilless `\a` and `$`-sigiled `$x`) are now readonly.
- `push`/`append`/`unshift`/`prepend`/`pop`/`shift` on an `@`-var bound to an immutable List now throws `X::Immutable`, matching the already-correct scalar-bind case.
- `my \G = 5; G++`/`G--`/`++G` now throw `X::Multi::NoMatch`.

`my $s = { $_ = 5 }; $s(7)` (a bare block's implicit topic) is **deliberately left open** — it shares its VM code path with the native `.map` loop's rw-writeback over a real array's container elements (`@a.map({ $_ *= 10 })`), which must stay writable; distinguishing the two needs ADR-0040's store-side element itemization. See the ticket and news entry for the full reasoning and the traps this fix ran into.

## Test plan

- [x] `t/immutable-lvalue-assignment-gaps.t` (new): pins all seven fixes (class + message) plus negative controls (`is rw`/`is copy` pointy-block params, `for @a { $_ = ... }`, `@a.map({ $_ *= 10 })` rw writeback, real-Array `push`) — passes verbatim under both `raku` and mutsu.
- [x] `make test`: `All tests successful.` (34264 tests)
- [x] `cargo test jit_diff`: 5/5 pass (touched `src/opcode.rs`)
- [x] `cargo test --lib opcode_size_guard`: pass
- [x] Targeted roast sweep (434 whitelisted files across `S02-names-vars/`, `S04-blocks-and-statements/`, `S06-*`, `S32-*`, `S03-operators/` — the consumers of the closure-call and bareword-assignment paths touched here): only pre-existing, unrelated failures (`gb18030`/`gb2312`/`shiftjis`-encode-decode.t, a `t/spec/...` path resolution artifact of running files directly instead of via `make roast`'s runner — confirmed identical on `main`)
- [x] `cargo fmt` / `cargo clippy -- -D warnings`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)