### PR TITLE
docs: file the reduce-metaop zero-arg-meaning divergence as a ticket

### DIFF
--- a/todo/tickets/reduce-metaop-zero-arg-meaning-returns-nil-not-failure.md
+++ b/todo/tickets/reduce-metaop-zero-arg-meaning-returns-nil-not-failure.md
@@ -1,0 +1,46 @@
+# A reduce metaop over an empty list returns `Nil` instead of an `X::NoZeroArgMeaning` `Failure` for operators that have no identity
+
+Found while verifying `news/2026-08/reduce-x-xx-left-associative.md` (the `[x]`/`[xx]`
+associativity fix). It is unrelated to associativity — it reproduces on `main` before that
+fix — so it was not folded into that PR.
+
+## Repro
+
+```raku
+say ([x] ()).raku;
+```
+
+- `raku`: `Failure.new(exception => X::NoZeroArgMeaning.new(name => "infix:<x>"), ...)`
+- `mutsu`: `Nil`
+
+Operators that *do* have a well-defined identity element already agree, which is the useful
+contrast:
+
+```raku
+say ([~] ()).raku;   # both: ""
+say ([+] ()).raku;   # both: 0
+```
+
+## What Raku specifies
+
+Reducing an empty list yields the operator's identity element. An operator with no meaningful
+identity (`infix:<x>` among them — there is no value `v` such that `v x n` is a no-op for all
+`n`) instead returns a `Failure` wrapping `X::NoZeroArgMeaning`, so the divergence only shows
+up once the empty-list case is actually reached. mutsu returns a bare `Nil` for the whole
+no-identity class rather than the typed `Failure`.
+
+Because it is a `Failure` and not a thrown exception, the divergence is silent until the value
+is used: `[x] ()` sinks harmlessly in mutsu where raku would explode on the unhandled `Failure`.
+
+## Scope to establish before implementing
+
+The fix is not just `infix:<x>`. Enumerate which core infixes raku gives a zero-arg meaning to
+and which it does not (`raku -e 'say ([OP] ()).raku'` across the infix table), and drive mutsu's
+reduce from that same classification rather than special-casing `x`. Check the triangle form
+(`[\x] ()`) and the `&infix:<...>` spelling too. `X::NoZeroArgMeaning` also needs to exist as a
+real exception type in mutsu's taxonomy with the `name` attribute raku populates.
+
+## Affected files (starting point)
+
+- `src/runtime/builtins_reduce.rs` — the reduce fold and its empty-input arm.
+- `src/vm/vm_misc_ops.rs` — the VM-side reduce path with its parallel classification table.


### PR DESCRIPTION
## What

Records a new `todo/tickets/` finding: a reduce metaop over an empty list returns `Nil` in mutsu where raku returns a `Failure` wrapping `X::NoZeroArgMeaning`, for the class of infixes that have no identity element.

```raku
say ([x] ()).raku;
# raku:  Failure.new(exception => X::NoZeroArgMeaning.new(name => "infix:<x>"), ...)
# mutsu: Nil
```

Operators that *do* have an identity already agree (`[~] ()` -> `""`, `[+] ()` -> `0`), which localises the gap.

## Why a separate ticket

Found while verifying #7045 (the `[x]`/`[xx]` associativity fix), but confirmed to reproduce on `main` before it — unrelated root cause, so it does not belong in that PR.

The ticket deliberately scopes the fix wider than `infix:<x>`: mutsu's reduce should be driven by raku's own zero-arg-meaning classification across the infix table, and `X::NoZeroArgMeaning` needs to exist as a real exception type with its `name` attribute before any of it can be correct.

Docs-only, so the four heavy CI jobs are skipped by design (`scripts/ci-docs-only.sh`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)