### PR TITLE
fix: say/print/put/note must not read an adjacent colonpair as an invocant colon

### DIFF
--- a/news/2026-08/adjacent-colonpair-truncated-the-listop-argument-list.md
+++ b/news/2026-08/adjacent-colonpair-truncated-the-listop-argument-list.md
@@ -26,11 +26,12 @@ only one of them knew this:
 | --- | --- | --- |
 | `make_call_expr_from_listop_args` (`primary/ident/listop.rs`) | declared/imported/hyphenated subs | yes |
 | `parse_remaining_call_args` (`stmt/args.rs`) | statement-level calls | yes |
-| `parse_expr_listop_args` (`primary/ident/listop.rs`) | expression listops (`ok`, `is`, `diag`, ...) | **no** |
+| `parse_expr_listop_args` (`primary/ident/listop.rs`) | expression listops (`indir`, `flat`, `first`, ...) | **no** |
 | the builtin-listop loop (`primary/ident/identifier_call.rs`) | `sort`, `sprintf`, `chdir`, ... | **no** |
 | the generic bareword fallback (same file) | not-yet-declared / forward-referenced names | **no** |
+| `parse_expr_list` (`stmt/simple/io_stmts.rs`) | `say`, `print`, `put`, `note` | **no** |
 
-In the three loops without the rule, only the *first* colonpair became an
+In the four loops without the rule, only the *first* colonpair became an
 argument. The loop then saw a `:` where it wanted a `,`, decided the argument
 list was over, and returned the call with `:b, "x", "y"` still unconsumed.
 
@@ -46,26 +47,54 @@ three-element list. With a single colonpair there is nothing left over, the
 listop's own loop reaches the comma itself, and the call parses correctly —
 which is why chain length appeared to be the discriminator.
 
+The io listops fail one step earlier, and more loudly. `say`/`print`/`put`/
+`note` are parsed by their own statement handler
+(`src/parser/stmt/simple/io_stmts.rs`), which tries the *invocant colon* form
+(`say $*OUT: "hi"`) before the ordinary argument list. With no guard against a
+colonpair, `say :!d:r, "x"` parsed the leading `:!d` as the invocant and the
+second colon as the invocant marker, yielding `(:!d).say(r, "x")` — which dies
+with `No such method 'say' for invocant of type 'Pair'`.
+
 ## Fix
 
 `try_adjacent_colonpair_arg` in `src/parser/primary/ident/listop.rs` is now the
 one place that expresses the rule, and every no-paren argument-list loop
 consults it before concluding that a missing comma ends the list.
-`make_call_expr_from_listop_args` was rewritten to use it, and the three loops
-that lacked it (`parse_expr_listop_args` and both loops in
-`primary/ident/identifier_call.rs`) now call it too. The leftover colonpair
-never reaches the postfix call-adverb rule for these shapes, so the argument
-list continues normally through the following comma.
+`make_call_expr_from_listop_args` was rewritten to use it, and the four loops
+that lacked it (`parse_expr_listop_args`, both loops in
+`primary/ident/identifier_call.rs`, and `parse_expr_list` in `io_stmts.rs`) now
+call it too. The leftover colonpair never reaches the postfix call-adverb rule
+for these shapes, so the argument list continues normally through the following
+comma.
 
-All three previously-broken flavours now agree with rakudo:
-`foo :a:b, "x"` for a forward-referenced sub, `chdir :!d:r, $path` for a builtin
-listop, and `ok :a:b, 'desc'` for an expression listop.
+The invocant-colon guards were factored out alongside it as
+`colon_starts_colonpair` (a colon that binds a name or sigil with no space opens
+a colonpair, not an invocant marker) and `expr_is_colonpair` (a colon that
+*follows* a colonpair likewise opens another one). `try_parse_no_paren_invocant_colon_call`
+had both inline; `parse_io_colon_invocant_stmt` had neither, and now shares
+them. `say $*OUT: "hi"` is unaffected — its colon is followed by whitespace.
+
+All the previously-broken flavours now parse as rakudo does:
+`foo :a:b, "x"` (forward-referenced sub), `chdir :!d:r, $path` (builtin listop),
+`indir :!d:r, $path, { … }` (expression listop), and `say :!d:r, "x"`
+(io listop).
+
+One divergence deliberately remains out of scope and is filed as
+`todo/tickets/io-listops-bind-colonpair-args-as-positional.md`: the io listops
+bind a colonpair as a *positional* argument and print it, where raku binds it as
+a named argument that never reaches the output. That is argument-binding
+semantics (ADR-0021 pair-namedness territory), not parsing, and it predates this
+fix — it is equally visible in the single-adverb `say :d, "x"`.
 
 ## Tests
 
 `t/listop-adjacent-colonpair-args.t` pins the shape across all of them: a single
 adverb, comma-separated adverbs, two and three chained adverbs, space-separated
 adjacent adverbs, negated (`:!d`) and valued (`:a<1>`, `:a(1)`, `:a:$v`) adverbs,
-adverbs after and between positionals, and — for the builtin-listop path — an
-element-count assertion that fails outright if the call degenerates into a list
-again. The whole file also passes under `raku`.
+and adverbs after and between positionals. Because each call flavour has its own
+argument-list loop, the file also exercises each one separately: a
+forward-referenced (non-hyphenated) bareword for the generic fallback, `chdir`
+for the builtin listop — with an element-count assertion that fails outright if
+the call degenerates into a list again — `indir` for the expression listop, and
+`note` (which writes to stderr, so it does not disturb the file's own TAP
+stream) for the io listops. The whole file also passes under `raku`.

--- a/src/parser/primary/ident.rs
+++ b/src/parser/primary/ident.rs
@@ -9,6 +9,8 @@ mod term_literals;
 
 pub(super) use circumfix::declared_circumfix_op;
 pub(super) use identifier_call::identifier_or_call;
-pub(in crate::parser) use listop::parse_expr_listop_args;
+pub(in crate::parser) use listop::{
+    colon_starts_colonpair, expr_is_colonpair, parse_expr_listop_args, try_adjacent_colonpair_arg,
+};
 pub(in crate::parser) use predicates::is_keyword;
 pub(super) use term_literals::{class_literal, declared_term_symbol, keyword_literal, whatever};

--- a/src/parser/primary/ident/listop.rs
+++ b/src/parser/primary/ident/listop.rs
@@ -230,32 +230,12 @@ pub(crate) fn try_parse_no_paren_invocant_colon_call<'a>(
         return Ok((rest_after_first_arg, None));
     }
     // If the first arg is a colonpair (FatArrow Pair like :r, :!d, :name(val)),
-    // a following ':' is another colonpair, not an invocant colon.
-    if matches!(
-        &first_arg,
-        Expr::Binary {
-            op: crate::token_kind::TokenKind::FatArrow,
-            ..
-        }
-    ) {
+    // a following ':' is another colonpair, not an invocant colon. Likewise if
+    // the colon itself opens a colonpair (`:r`, `:!d`, `:$var`).
+    if expr_is_colonpair(&first_arg) || colon_starts_colonpair(r_ws) {
         return Ok((rest_after_first_arg, None));
     }
-
     let after_colon = &r_ws[1..];
-
-    // If the colon is immediately followed by an identifier char, `!`, or a sigil,
-    // it's a colonpair (e.g. `:r`, `:!d`, `:$var`), not an invocant colon.
-    if let Some(c) = after_colon.chars().next()
-        && (c.is_alphabetic()
-            || c == '_'
-            || c == '!'
-            || c == '$'
-            || c == '@'
-            || c == '%'
-            || c == '&')
-    {
-        return Ok((rest_after_first_arg, None));
-    }
     let (mut r, _) = ws(after_colon)?;
 
     if let Some(after_comma) = r.strip_prefix(',') {
@@ -347,6 +327,40 @@ pub(crate) fn try_adjacent_colonpair_arg(input: &str) -> Option<(&str, Expr)> {
         return None;
     }
     parse_listop_arg(input).ok()
+}
+
+/// Does the `:` at the head of `at_colon` open a colonpair (`:r`, `:!d`,
+/// `:$var`) rather than an *invocant* colon (`f $obj: @args`,
+/// `say $*OUT: "hi"`)?
+///
+/// The two are told apart by what directly follows the colon: a colonpair binds
+/// its name or sigil tightly with no space, while an invocant colon is followed
+/// by whitespace, the end of the argument list, or a non-name term. Every place
+/// that reads a `:` after a completed argument as an invocant colon must ask
+/// this first, or `f :a:b, $x` is misread as `(:a).f(b, $x)`.
+pub(crate) fn colon_starts_colonpair(at_colon: &str) -> bool {
+    let Some(after_colon) = at_colon.strip_prefix(':') else {
+        return false;
+    };
+    if after_colon.starts_with(':') {
+        return false;
+    }
+    after_colon.chars().next().is_some_and(|c| {
+        c.is_alphabetic() || c == '_' || c == '!' || c == '$' || c == '@' || c == '%' || c == '&'
+    })
+}
+
+/// Is this expression a colonpair (`:a`, `:!d`, `:name(val)`), which the parser
+/// represents as a fatarrow `Binary`? A `:` that follows one is necessarily the
+/// start of another colonpair, never an invocant colon.
+pub(crate) fn expr_is_colonpair(expr: &Expr) -> bool {
+    matches!(
+        expr,
+        Expr::Binary {
+            op: crate::token_kind::TokenKind::FatArrow,
+            ..
+        }
+    )
 }
 
 pub(crate) fn make_call_expr_from_listop_args<'a>(

--- a/src/parser/stmt/simple/io_stmts.rs
+++ b/src/parser/stmt/simple/io_stmts.rs
@@ -167,6 +167,13 @@ pub(crate) fn parse_expr_list(input: &str) -> PResult<'_, Vec<Expr>> {
     let mut rest = input;
     loop {
         let (r, _) = ws(rest)?;
+        // Adjacent colonpairs without commas: `say :a :b, $x` / `say :a:b, $x`
+        // are `say(:a, :b, $x)` — the argument list continues past them.
+        if let Some((r2, arg)) = crate::parser::primary::ident::try_adjacent_colonpair_arg(r) {
+            items.push(arg);
+            rest = r2;
+            continue;
+        }
         if !r.starts_with(',') {
             let gap = &rest[..rest.len() - r.len()];
             let is_legitimate_continuation = gap.contains('\n')
@@ -259,6 +266,16 @@ fn parse_io_colon_invocant_stmt<'a>(input: &'a str, method_name: &str) -> PResul
     let (rest_after_target, target) = expression(input)?;
     let (rest_after_target, _) = ws(rest_after_target)?;
     if !rest_after_target.starts_with(':') || rest_after_target.starts_with("::") {
+        return Err(PError::expected("io colon invocant call"));
+    }
+    // `say :!d:r, "x"` is `say(:!d, :r, "x")`, not `(:!d).say(r, "x")`: a colon
+    // that opens a colonpair, or that follows one, is never the invocant colon.
+    // These are the same two guards `try_parse_no_paren_invocant_colon_call`
+    // applies for the general listop form. `say $*OUT: "hi"` is unaffected — its
+    // colon is followed by whitespace, not by a name or a sigil.
+    if crate::parser::primary::ident::colon_starts_colonpair(rest_after_target)
+        || crate::parser::primary::ident::expr_is_colonpair(&target)
+    {
         return Err(PError::expected("io colon invocant call"));
     }
     let mut rest = &rest_after_target[1..];

--- a/t/listop-adjacent-colonpair-args.t
+++ b/t/listop-adjacent-colonpair-args.t
@@ -9,7 +9,7 @@ use Test;
 # the following comma was read by the enclosing list-expression parser and
 # `f :a:b, "x", "y"` silently parsed as the list `(f(:a, :b), "x", "y")`.
 
-plan 19;
+plan 22;
 
 sub collect(*@p, *%n) {
     @p.join('|') ~ ' / ' ~ %n.sort(*.key).map({ .key ~ '=' ~ .value }).join(',')
@@ -54,19 +54,42 @@ is $one, 'x|y / a=True,b=True', 'the call is a single expression, not a list';
 is (collect :a:b, 'x' xx 2), 'x|x / a=True,b=True',
     'chained adverbs then a repeated positional';
 
-# --- the three no-paren call flavours each have their own arg-list loop -----
+# --- each no-paren call flavour has its OWN argument-list loop --------------
+# The tests above all go through the declared-sub loop. The remaining flavours
+# each parse their argument list somewhere else, and every one of them had the
+# same defect, so they need their own coverage.
 
-# A bareword that is not yet a declared routine at the call site (forward
-# reference) takes the generic listop fallback.
-my $fwd = forward-ref :a:b, 'x', 'y';
+# (a) A bareword that is not a declared routine at the call site (forward
+#     reference) takes the generic listop fallback in `identifier_call.rs`.
+#     The name must NOT be hyphenated: a hyphenated bareword is routed to the
+#     declared-sub loop instead, which never had the bug.
+my $fwd = forwardref :a:b, 'x', 'y';
 is $fwd, 'x|y / a=True,b=True', 'forward-referenced sub: chained adverbs then positionals';
-sub forward-ref(*@p, *%n) { collect(|@p, |%n) }
+sub forwardref(*@p, *%n) { collect(|@p, |%n) }
 
-# A builtin listop (`chdir`) has its own argument-list loop. A misparse turns
-# the call into a two-element list, so pin the element count as well.
+# (b) A builtin listop (`chdir`) has its own loop in `identifier_call.rs`.
+#     A misparse turns the call into a two-element list, so pin the count too.
 my $cwd = $*CWD.Str;
 my @chdir-result = (chdir :!d:r, $cwd);
 is @chdir-result.elems, 1, 'builtin listop with chained adverbs is ONE call, not a list';
 is $*CWD.Str, $cwd, 'builtin listop with chained adverbs got the positional path argument';
+
+# (c) An expression listop in expression position uses `parse_expr_listop_args`.
+#     `indir` is one, and takes exactly the `:d`/`:r` adverbs this ticket came
+#     from. A misparse would call `indir(:!d, :r)` with no path and no block.
+my $indir-result = (indir :!d:r, $cwd, { $*CWD.Str });
+is $indir-result, $cwd, 'expression listop: chained adverbs then positionals';
+
+# (d) `say`/`print`/`put`/`note` are parsed by their own statement handler
+#     (`stmt/simple/io_stmts.rs`), which read the second colon as an *invocant*
+#     colon: `note :a:b, "x"` became `(:a).note(b, "x")` and died with
+#     "No such method 'note' for invocant of type 'Pair'". `note` writes to
+#     stderr, so exercising it here does not disturb this file's TAP stream.
+#     (What these print is still wrong — see
+#     todo/tickets/io-listops-bind-colonpair-args-as-positional.md — but that
+#     is an argument-binding bug, not this parse bug.)
+lives-ok { note :a:b, 'x' }, 'io listop with chained adverbs is a call, not a Pair method call';
+lives-ok { note :a :b, 'x' },
+    'io listop with space-separated adjacent adverbs is a call, not a Pair method call';
 
 done-testing;

--- a/todo/tickets/io-listops-bind-colonpair-args-as-positional.md
+++ b/todo/tickets/io-listops-bind-colonpair-args-as-positional.md
@@ -1,0 +1,67 @@
+# say/print/put/note bind a colonpair argument as positional, so they print it
+
+For the io listops `say`, `print`, `put` and `note`, a colonpair written in the
+argument list is bound as a **positional** argument and therefore printed. In
+Raku a colonpair is a **named** argument: `say`'s signature slurps it into `%_`
+and it never reaches the output.
+
+Every other call shape mutsu already gets right — a user sub binds the same
+colonpair as named, and a parenthesised `(a => 1)` is positional in both
+implementations — so this is specific to the io listops, not to colonpair
+binding in general.
+
+## Measured divergence
+
+| source | mutsu | raku |
+| --- | --- | --- |
+| `say :a;` | `a => True` | *(empty line)* |
+| `say :d, "x";` | `d => Truex` | `x` |
+| `say :!d:r, "x";` | `d => Falser => Truex` | `x` |
+| `say "x", :a;` | `xa => True` | `x` |
+| `say :a, :b;` | `a => Trueb => True` | *(empty line)* |
+| `put :a, "x";` | `a\tTruex` | `x` |
+| `note :a, "x";` | `a => Truex` | `x` |
+
+Not divergent — these already agree, and bound the scope of the bug:
+
+| source | mutsu | raku |
+| --- | --- | --- |
+| `say (a => 1), "x";` | `a => 1x` | `a => 1x` |
+| `sub f(*@p, *%n) { say @p.elems ~ "/" ~ %n.elems }; f :a, "x";` | `1/1` | `1/1` |
+
+## Root cause
+
+`src/parser/stmt/simple/io_stmts.rs` parses these four listops into
+`Stmt::Say(Vec<Expr>)` / `Stmt::Print` / `Stmt::Put` / `Stmt::Note`. That
+argument vector is flat: it carries no named/positional distinction, unlike the
+general call path, whose `CallArg` enum has a `Named` variant
+(`src/parser/stmt/args.rs`). A colonpair therefore arrives at the VM's print
+opcodes as an ordinary `Binary { FatArrow }` element and is stringified into the
+output like any other Pair.
+
+Note that `(a => 1)` must stay positional, so the fix cannot be "drop every Pair
+from the output" — it has to preserve *how the pair was written*, which is the
+pair-namedness distinction ADR-0021 introduced. The likely shape of the fix is
+to route these statements through the same named/positional argument
+representation the general call path uses (or to give the `Stmt::Say` family a
+named-argument slot), then have the print opcodes ignore the named ones.
+
+## Why this is filed separately
+
+Found while fixing the parse-level defect in
+`news/2026-08/adjacent-colonpair-truncated-the-listop-argument-list.md`. That
+fix made `say :!d:r, "x"` *parse* correctly (previously it misparsed as
+`(:!d).say(r, "x")` and died with "No such method 'say' for invocant of type
+'Pair'"); the remaining wrong output is this separate binding defect, which
+predates it and is equally visible in the single-adverb form `say :d, "x"`.
+It is argument-binding semantics, not parsing, and touches ADR-0021 territory,
+so it was deliberately not folded into that PR.
+
+## Repro
+
+```
+$ target/debug/mutsu -e 'say :d, "x"'
+d => Truex
+$ raku -e 'say :d, "x"'
+x
+```


### PR DESCRIPTION
Follow-up to #7047. That PR fixed "an adjacent colonpair ends the no-paren argument list" in the general call paths; the io listops (`say`/`print`/`put`/`note`) have their own statement handler and were still broken — more loudly than the others.

## Symptom

```
$ mutsu -e 'say :!d:r, "x"'
No such method 'say' for invocant of type 'Pair'
$ raku -e 'say :!d:r, "x"'
x
```
Same for `print`, `put`, `note`, and for `say :a:b`.

## Root cause

`parse_io_colon_invocant_stmt` (`src/parser/stmt/simple/io_stmts.rs`) tries the **invocant-colon** form (`say $*OUT: "hi"`) *before* the ordinary argument list, and had no guard against a colonpair. So `say :!d:r, "x"` parsed the leading `:!d` as the invocant and the second colon as the invocant marker → `(:!d).say(r, "x")`.

`try_parse_no_paren_invocant_colon_call` — the general listop equivalent in `primary/ident/listop.rs` — has had two guards against exactly this for a long time:

1. a colon that binds a name or a sigil with **no space** opens a colonpair, not an invocant marker;
2. a colon that *follows* a colonpair likewise opens another colonpair.

Both were inline and unshared, so the io handler never got them. They are now factored out as `colon_starts_colonpair` and `expr_is_colonpair`, and `parse_io_colon_invocant_stmt` applies them. `say $*OUT: "hi"` and `say $*OUT: "a", "b"` are unaffected — their colon is followed by whitespace, not a name or sigil (verified against `raku`).

Past that guard the io argument list also needed #7047's rule, so `parse_expr_list` now consults `try_adjacent_colonpair_arg` too; otherwise `say :a:b, $x` stopped after `:a` and left `:b, $x` unconsumed.

`say :!d:r, "x"` now parses as `say(:!d, :r, "x")` — `Stmt::Say([:!d, :r, "x"])` — matching rakudo's shape.

## Known residual, filed separately (NOT fixed here)

The io listops bind a colonpair as a **positional** argument and print it, where raku binds it as a **named** argument that never reaches the output. Measured:

| source | mutsu | raku |
| --- | --- | --- |
| `say :a;` | `a => True` | *(empty line)* |
| `say :d, "x";` | `d => Truex` | `x` |
| `say :!d:r, "x";` | `d => Falser => Truex` | `x` |
| `say "x", :a;` | `xa => True` | `x` |
| `put :a, "x";` | `a\tTruex` | `x` |

Bounding the scope — these already agree, so it is specific to the io listops, not to colonpair binding in general:

| source | mutsu | raku |
| --- | --- | --- |
| `say (a => 1), "x";` | `a => 1x` | `a => 1x` |
| `sub f(*@p, *%n) { say @p.elems ~ "/" ~ %n.elems }; f :a, "x";` | `1/1` | `1/1` |

`Stmt::Say(Vec<Expr>)` is a flat vector with no named/positional distinction, unlike the general call path's `CallArg::Named`. Since `(a => 1)` must stay positional, the fix has to preserve *how the pair was written* — ADR-0021 pair-namedness territory, i.e. argument-binding semantics rather than parsing. It predates this PR and is equally visible in the single-adverb `say :d, "x"`. Recorded with these rows in `todo/tickets/io-listops-bind-colonpair-args-as-positional.md`.

So this PR turns a hard error into a correct parse; the remaining output divergence is that separate, pre-existing ticket.

## Test corrections

While extending `t/listop-adjacent-colonpair-args.t` I found that two of the cases #7047 added did not exercise the paths they claimed, and fixed them:

- the forward-reference case used a **hyphenated** name, which `identifier_call.rs` routes to the already-correct declared-sub loop. It now uses a non-hyphenated name, which really does hit the generic fallback (confirmed: it returns a 3-element list on `main`).
- the expression-listop case used `sort`, which is a *builtin* listop, and its element-count assertion was ambiguous besides. It now uses `indir` (a genuine `is_expr_listop`, and the very routine whose `:d`/`:r` adverbs this ticket came from).

New io coverage uses `note`, which writes to stderr and so does not disturb the file's own TAP stream. The whole file (22 assertions) also passes under `raku`.

## Verification

`make test` green (3491 files / 34390 tests). `cargo clippy -D warnings` and `cargo fmt` clean. A full `roast-whitelist.txt` sweep is running locally; CI runs the authoritative one.
