### PR TITLE
feat(for): bind the element container in an `is rw` loop (ADR-0045 slices 0-1)

### DIFF
--- a/docs/adr/0045-for-loop-parameters-bind-the-element-container.md
+++ b/docs/adr/0045-for-loop-parameters-bind-the-element-container.md
@@ -1,6 +1,7 @@
 # ADR-0045: A `for` loop parameter binds the element *container*; the per-iteration writeback is retired
 
-- **Status**: Proposed (design complete; implementation not started)
+- **Status**: Accepted — partially implemented (slices 0 and 1 landed 2026-08-27; slices 2-6 open, see
+  §8 "Implementation status")
 - **Date**: 2026-08-20
 - **Deciders**: tokuhirom, Claude
 - **Related**: [ADR-0036](0036-element-container-pairs-from-subscripts-and-pairs.md) §7 (which names
@@ -477,5 +478,81 @@ the container (ADR-0042), which all three consume in their enforcement slice.
 
 ---
 
-*This ADR is Proposed. If the mechanism judgment changes later, supersede it rather than rewriting
-it.*
+## 8. Implementation status
+
+### Slices 0 and 1 — landed 2026-08-27
+
+**Slice 0.** `t/for-loop-element-alias.t` pins the whole surface of §1.3: every divergence row and
+every invariant row, plus §5 Q6's `Proxy`-element probe, §5 Q1's already-a-cell capture probe, and
+§1.5's bench probe as an O(n) assertion. The whole §1.3 table was re-measured against `raku` before
+any code was written and reproduced exactly as recorded, so §1.3 stands as measured.
+
+**Slice 1.** `exec_for_loop_body` (`src/vm/vm_for_loop_body.rs`) now binds `array_slot_ref(idx, true)`
+at the bind site when the parameter is a writable aliasing one (`is rw` / `<->` / `\v`), the loop has
+a single parameter bound natively, and the tagged source is a direct, real, mutable, plain `Array`
+(`@`-sigil, `!kv_mode`, `!values_mode`, `!loop_var_wraps_element`, `!container_reversed`). The
+per-iteration `write_back_for_rw_param` is retired for exactly those iterations. Two helpers carry
+the discriminator, `for_source_is_aliasable` and `for_element_alias`.
+
+**Rows that turned green:** 01, 02, 03, 04, 07, 11, 12, 13, 14, 20, 27, 36 and 41 as planned, plus
+**38** (the body rebinding the source array wholesale — the sharpest class-3 clobber) and **43** (the
+sigilless `\v` read-alias, which §4 had filed under the topic slice but which binds through this same
+native single-parameter site). Every invariant row still agrees.
+
+**Perf (§1.5).** Release build, same machine, best of three, `for @a <-> $x { $x = $x + 1 }`:
+
+| n | before | after |
+| --- | --- | --- |
+| 5 000 | 0.04 s | 0.01 s |
+| 10 000 | 0.15 s | 0.01 s |
+| 20 000 | 0.56 s | 0.02 s |
+| 40 000 | 2.17 s | 0.03 s |
+| 80 000 | 9.01 s | 0.05 s |
+| 160 000 | 39.44 s | 0.11 s |
+
+Before, each doubling multiplied the time by 3.7-4.4× — the quadratic §1.5 measured. After, it
+roughly doubles. The quadratic is gone, not merely reduced. These are local A/B numbers recorded for
+this ADR's own acceptance criterion; the bench CI series remains the source of truth for any headline
+figure.
+
+### Answers to the open questions, as measured by slice 1
+
+- **§5 Q1 (ADR-0027 composition)** — no conflict, for a reason worth writing down: an `is rw` loop's
+  parameter never enters `loop_local_vars` in the first place (`exec_for_loop_body` gates that set on
+  `!spec.is_rw`), so `compute_owned_captures`'s unguarded primary branch is not reached by a promoted
+  cell and `freeze_readonly_owned_captures` cannot value-freeze one. Rows 34/35 (per-iteration
+  identity) and rows 12/36 (sharing *within* an iteration) both hold, and `box_captured_lexicals`
+  already refuses to double-box (`if self.locals[idx].is_container_ref() { continue }`).
+- **§5 Q3 (ADR-0040 itemization)** — unchanged, deliberately: slice 1 flips a *local* writeback flag
+  and never touches `spec.do_writeback`, which is what the bind-side itemization carve-out keys off.
+  `t/param-bind-itemization.t` and `t/for-bind-typed-array-deitemize.t` pass unmodified.
+- **§5 Q4 (leaked cells)** — none observed. Row 40 is extended in the pin to `.raku`, `.elems`,
+  `.WHAT`, an element's own `.WHAT`, list context and interpolation; all decontainerize.
+- **§5 Q5 (shaped / native-backed)** — kept as an explicit, commented carve-out in
+  `for_source_is_aliasable`: `ArrayKind::Shaped`, an embedded `shape`, a `NativeBacking` payload and
+  `ArrayKind::Lazy` all stay on the metadata-preserving writeback. `t/cas-shaped-and-for-loop.t` and
+  row 26 pin it.
+- **§5 Q6 (`Proxy` elements)** — the hazard does not evaporate by itself, and the fix is per
+  *iteration*, not per loop. A `Proxy` element is skipped by the promotion, and because the writeback
+  is retired per iteration rather than for the whole loop, that iteration keeps its writeback.
+  Retiring it loop-wide silently dropped the `Proxy` element's write; the pin is the second Q6
+  assertion in `t/for-loop-element-alias.t`.
+
+### What slices 2-6 still own
+
+Rows 08 (slice 2); 21, 22, 42, 44 (slice 3); 16, 17, 24, 39 (slice 4); 19, 28, 30 (slice 5). They are
+`todo`-marked in `t/for-loop-element-alias.t` with the owning slice named in the reason string, so
+each later slice un-`todo`s exactly its own rows. `write_back_for_rw_param` still carries the hash,
+`kv_mode`, multi-param and scalar arms; only its direct-array single-parameter path is now dead code
+for the promoted shape.
+
+**Found along the way, unrelated:** after any `start` block, a later `for @m -> @row { ... }` loop
+rebinds the *previous* iteration's container. Pre-existing on `main` (verified at `f678b032b`) and
+independent of this ADR — recorded as
+`todo/tickets/at-sigil-for-param-rebinds-stale-container-after-start-block.md`. It is why
+`t/for-loop-element-alias.t` keeps its `start`-block row last.
+
+---
+
+*Slices 0 and 1 of this ADR are implemented; the decision stands. If the mechanism judgment changes
+later, supersede it rather than rewriting it.*

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -162,6 +162,7 @@ mod vm_dispatch_helpers;
 mod vm_env_helpers;
 mod vm_exec_dispatch;
 pub(crate) mod vm_flipflop_ops;
+mod vm_for_loop_alias;
 mod vm_for_loop_body;
 mod vm_for_loop_dispatch;
 mod vm_for_loop_intrange;

--- a/src/vm/vm_for_loop_alias.rs
+++ b/src/vm/vm_for_loop_alias.rs
@@ -1,0 +1,86 @@
+//! ADR-0045: a `for` loop parameter binds the element *container*.
+//!
+//! Raku binds a `for` parameter to the item the iterator yields, and when the
+//! source is a real mutable `Array` that item **is** the element's `Scalar`
+//! container. The binding is therefore an alias with the lifetime of the
+//! binding, not of the loop body: a closure or `start` block that outlives the
+//! iteration still writes through, a read through the alias sees a write made
+//! to the element by anyone else, and a direct `@a[i] = v` in the body is not
+//! reverted afterwards.
+//!
+//! mutsu used to bind a plain value clone and copy it back once per iteration
+//! (`write_back_for_rw_param`), rebuilding the entire backing `ArrayData` to
+//! change one element — which is both the cause of five divergence classes
+//! (ADR-0045 §1.3) and the reason a mutating `<->` loop was O(n²) (§1.5).
+//!
+//! This module holds the discriminator for **slice 1**: which `for` loop
+//! sources may have their elements promoted to first-class containers via
+//! [`Value::array_slot_ref`], the primitive ADR-0036 shipped and that
+//! `:=`-bound elements already exercise daily. The bind site itself lives in
+//! `vm_for_loop_body.rs`.
+
+use super::*;
+
+impl Interpreter {
+    /// Whether a `for` loop's tagged `@`-source is a real, mutable, plain
+    /// `Array` whose elements ADR-0045 slice 1 may promote to their own
+    /// containers.
+    ///
+    /// The carve-outs (ADR-0045 §5 Q5) are deliberate and stay until slice 5
+    /// decides otherwise:
+    ///
+    /// * a **shaped** array (`my @a[2;3]`) carries its dimensions in
+    ///   `ArrayData::shape` / `ArrayKind::Shaped`, and the writeback path
+    ///   deliberately preserves that metadata by cloning the whole `ArrayData`
+    ///   (see `vm_loop_writeback.rs`'s "clone the original ArrayData" comment);
+    ///   `array_slot_ref` has no such provision.
+    /// * a **native-backed** array (`array[int]`, ADR-0015 P3b / ADR-0030)
+    ///   keeps its elements in a packed `NativeBacking` payload, which cannot
+    ///   hold a `ContainerRef` at all.
+    /// * a **lazy** array must not be forced by a promotion.
+    ///
+    /// `t/cas-shaped-and-for-loop.t` and row 26 of `t/for-loop-element-alias.t`
+    /// are the pins for the shaped case.
+    pub(super) fn for_source_is_aliasable(&self, source: &str) -> bool {
+        self.get_env_with_main_alias(source)
+            .is_some_and(|raw| Self::array_is_aliasable(&raw.deref_container(), None))
+    }
+
+    /// The element container for index `idx` of a `for` loop's `@`-source
+    /// (ADR-0045 slice 1). Promotion is idempotent — `array_slot_ref` returns
+    /// an existing cell rather than allocating a second one — so re-looping the
+    /// same array costs nothing after the first pass.
+    ///
+    /// `None` when the source is no longer an aliasable array, or the index is
+    /// out of range: a body that shrank the source out from under the loop has
+    /// no element left to alias, so the caller keeps the plain value bind (and
+    /// its writeback) rather than letting `array_slot_ref` autovivify a fresh
+    /// hole past the end.
+    ///
+    /// The source is resolved fresh on every call, on purpose: a body that
+    /// reassigns it wholesale (`@a = 7, 8`) must have the remaining iterations
+    /// alias the array it left behind, not the one the loop started with.
+    pub(super) fn for_element_alias(&mut self, source: &str, idx: usize) -> Option<Value> {
+        let arr = self.get_env_with_main_alias(source)?.deref_container();
+        if !Self::array_is_aliasable(&arr, Some(idx)) {
+            return None;
+        }
+        arr.array_slot_ref(idx, true)
+    }
+
+    /// Shared shape test for the two entry points above. `idx` additionally
+    /// requires that index to exist today.
+    fn array_is_aliasable(v: &Value, idx: Option<usize>) -> bool {
+        match v.view() {
+            ValueView::Array(data, kind) => {
+                matches!(
+                    kind,
+                    crate::value::ArrayKind::Array | crate::value::ArrayKind::List
+                ) && data.shape.is_none()
+                    && data.native_storage_node().is_none()
+                    && idx.is_none_or(|i| i < data.len())
+            }
+            _ => false,
+        }
+    }
+}

--- a/src/vm/vm_for_loop_body.rs
+++ b/src/vm/vm_for_loop_body.rs
@@ -469,6 +469,46 @@ impl Interpreter {
         // shared backing node (container identity §3), so binding the element
         // value as-is would let `@row[0] = v` reach the source element.
         let param_is_copy = spec.is_rw && !spec.do_writeback;
+        // ADR-0045 slice 1: a writable aliasing parameter (`is rw`, `<->`,
+        // sigilless `\v`) over a DIRECT, real, mutable `Array` source binds the
+        // element's own `ContainerRef` instead of a value clone, and the
+        // per-iteration writeback for that shape is retired. The alias then has
+        // the lifetime of the binding, not of the body — a closure or `start`
+        // block that outlives the iteration still writes through, a read
+        // through the alias sees a later write to the element, and a direct
+        // `@a[i] = v` in the body is no longer reverted by an end-of-iteration
+        // whole-container rebuild. It also removes that rebuild's O(n^2)
+        // (§1.5): promotion is O(1) and idempotent (`array_slot_ref` reuses an
+        // existing cell), where the writeback cloned the whole `ArrayData` per
+        // iteration.
+        //
+        // Deliberately narrow — the rest is later slices of the same ADR:
+        //   * hash sources stay on `write_back_hash_value_item` (slice 2);
+        //   * the implicit topic and the plain named param stay on
+        //     `write_back_for_topic_item` (slice 3);
+        //   * derived producers (`.values`/`.kv`/`.pairs`/`.reverse`, and the
+        //     `$`-tagged `for @$s` shape) keep the index-reconstruction
+        //     writeback until their producers hand out element containers
+        //     (slice 4), so they are excluded here by the `*_mode` flags, by
+        //     `container_reversed`, and by the `@`-sigil requirement;
+        //   * a multi-parameter loop binds through the bind-prefix
+        //     `Stmt::Assign`s, not this native bind site, so it is excluded.
+        let alias_array_elements = spec.do_writeback
+            && arity == 1
+            && param_name.is_some()
+            && spec.multi_param_names.is_empty()
+            && !spec.kv_mode
+            && !spec.values_mode
+            && !spec.loop_var_wraps_element
+            && !container_reversed
+            && container_binding
+                .as_deref()
+                .is_some_and(|name| name.starts_with('@') && self.for_source_is_aliasable(name));
+        // The base decision; each iteration retires it for itself only when the
+        // element really was promoted (see the bind site below). `spec.do_writeback`
+        // itself is left alone: ADR-0040's bind-side itemization carve-out keys
+        // off it, and ADR-0045 §5 Q3 keeps that carve-out unchanged here.
+        let rw_writeback_base = rw_writeback;
         'for_loop: for (idx, item) in chunked_items.into_iter().enumerate().skip(resume_index) {
             let item = if param_is_copy {
                 item.detach_shared_container()
@@ -522,6 +562,30 @@ impl Interpreter {
                     }
                 }
             }
+            // ADR-0045 slice 1: promote this element to its own container and
+            // bind THAT, so the parameter is a real alias for the lifetime of
+            // the binding. The source is re-resolved every iteration on purpose
+            // — a body that reassigns the source wholesale (`@a = 7, 8`) must
+            // have the remaining iterations alias the array it left behind, not
+            // the one the loop started with.
+            //
+            // A `Proxy` element is left alone (ADR-0045 §5 Q6): it mediates its
+            // own STORE, and a cell bound *around* one would take a plain write
+            // instead of calling it (`t/proxy-list-transparency.t`).
+            let promoted =
+                if alias_array_elements && !matches!(item.view(), ValueView::Proxy { .. }) {
+                    container_binding
+                        .as_deref()
+                        .and_then(|source| self.for_element_alias(source, idx))
+                } else {
+                    None
+                };
+            // The writeback is retired for exactly the iterations whose element
+            // was promoted. An iteration that fell back to a plain value bind —
+            // a `Proxy` element, or a body that shrank the source out from under
+            // the index — keeps the writeback that bind depends on.
+            rw_writeback = rw_writeback_base && promoted.is_none();
+            let item = promoted.unwrap_or(item);
             // `topic_source_var` drives the whole-topic writeback for a scalar
             // source (`for $x { $_[1] = ... }` writes the mutated `$_` back to
             // `$x`). For a `.values` loop over a mutable QuantHash the topic is a

--- a/t/for-loop-element-alias.t
+++ b/t/for-loop-element-alias.t
@@ -1,0 +1,471 @@
+use v6;
+use Test;
+
+# ADR-0045: a `for` loop parameter binds the element *container*.
+#
+# This file pins the whole semantic surface of that ADR — both halves, on
+# purpose:
+#
+#   * the DIVERGENCE table (ADR-0045 §1.3), so each slice can un-`todo` exactly
+#     the rows it claims; and
+#   * the INVARIANT table (same section), the rows that already agree with raku
+#     today. The invariant half is what stops a later slice from "fixing" a
+#     divergence by over-promoting — e.g. by making the plain named parameter
+#     `-> $v` alias (rows 45/46 say it must not), or by cascading a promoted
+#     cell across iterations (rows 34/35, ADR-0027's per-iteration freeze).
+#
+# Slice 1 (the direct array source with a writable aliasing parameter) has
+# landed, so rows 01, 02, 03, 04, 07, 11, 12, 13, 14, 20, 27, 36 and 41 are
+# ordinary passing tests here. The rows still `todo`-marked name the slice that
+# owns them: slice 2 (hash sources), slice 3 (the implicit topic and the plain
+# named param), slice 4 (derived producers) and slice 5 (bind-time enforcement).
+
+plan 57;
+
+# ---------------------------------------------------------------------------
+# Class 1 — a binding that outlives the loop body still writes through.
+# ---------------------------------------------------------------------------
+
+# row 01
+{
+    my @a = 10, 20;
+    my @c;
+    for @a -> $v is rw { @c.push(-> { $v = $v + 1 }) }
+    @c[0]();
+    @c[1]();
+    is-deeply @a, [11, 21], 'row 01: escaping closure over an `is rw` param writes through';
+}
+
+# row 02
+{
+    my @a = 10, 20;
+    my @c;
+    for @a <-> $v { @c.push(-> { $v = $v + 1 }) }
+    @c[0]();
+    @c[1]();
+    is-deeply @a, [11, 21], 'row 02: escaping closure over a `<->` param writes through';
+}
+
+# row 03
+{
+    my @a = 10, 20;
+    my @c;
+    for @a -> \v { @c.push(-> { v = v + 1 }) }
+    @c[0]();
+    @c[1]();
+    is-deeply @a, [11, 21], 'row 03: escaping closure over a sigilless param writes through';
+}
+
+# row 12 — two closures pushed in the SAME iteration share one cell.
+{
+    my @a = 10;
+    my @c;
+    for @a -> $v is rw {
+        @c.push(-> { $v = $v + 1 });
+        @c.push(-> { $v = $v + 1 });
+    }
+    @c[0]();
+    @c[1]();
+    is-deeply @a, [12], 'row 12: sibling closures in one iteration share the element cell';
+}
+
+# row 13 — called inside the loop AND after it.
+{
+    my @a = 10, 20;
+    my @c;
+    for @a -> $v is rw {
+        my $f = -> { $v = $v + 1 };
+        @c.push($f);
+        $f();
+    }
+    @c[0]();
+    @c[1]();
+    is-deeply @a, [12, 22], 'row 13: in-loop and post-loop calls both write through';
+}
+
+# row 14 — a whole-value rebind through the escaping closure.
+{
+    my @a = [1, 2], [3, 4];
+    my @c;
+    for @a -> $v is rw { @c.push(-> { $v = [9] }) }
+    @c[0]();
+    is-deeply @a[0], [9], 'row 14: rebinding the alias to a fresh container writes through';
+}
+
+# row 27 lives at the very END of this file, not here: a `start` block anywhere
+# in a program corrupts every LATER `for @m -> @row { ... }` loop, which would
+# otherwise sink the `-> @row` invariant rows 32 and 37 below. That is a
+# pre-existing, unrelated bug — see
+# `todo/tickets/at-sigil-for-param-rebinds-stale-container-after-start-block.md`.
+
+# row 36 — one closure writes, a sibling closure reads the new value.
+{
+    my @a = 1;
+    my @c;
+    for @a -> $v is rw {
+        @c.push(-> { $v = 9 });
+        @c.push(-> { $v });
+    }
+    @c[0]();
+    is @c[1](), 9, 'row 36: a sibling closure reads what its sibling wrote';
+}
+
+# row 08 — the hash source (slice 2).
+{
+    my %h = a => 1;
+    my @c;
+    for %h.values -> $v is rw { @c.push(-> { $v = $v + 1 }) }
+    @c[0]();
+    todo 'ADR-0045 slice 2: hash sources still use write_back_hash_value_item';
+    is %h<a>, 2, 'row 08: escaping closure over a `%h.values` rw param writes through';
+}
+
+# row 16 — `.kv` is a derived producer (slice 4).
+{
+    my @a = 10, 20;
+    my @c;
+    for @a.kv -> $i, $v is rw { @c.push(-> { $v = $v + 1 }) }
+    @c[0]();
+    @c[1]();
+    todo 'ADR-0045 slice 4: .kv must hand out element containers';
+    is-deeply @a, [11, 21], 'row 16: escaping closure over a `.kv` rw param writes through';
+}
+
+# row 44 — the implicit topic (slice 3).
+{
+    my @a = 1, 2;
+    my @c;
+    for @a { @c.push(-> { $_ = 99 }) }
+    @c[0]();
+    todo 'ADR-0045 slice 3: the implicit topic must bind the element container';
+    is-deeply @a, [99, 2], 'row 44: escaping closure over the implicit topic writes through';
+}
+
+# ---------------------------------------------------------------------------
+# Class 2 — an aliasing binding READS later writes to the element.
+# ---------------------------------------------------------------------------
+
+# row 11
+{
+    my @a = 10, 20;
+    my @c;
+    for @a -> $v is rw { @c.push(-> { $v }) }
+    @a[0] = 5;
+    is @c[0](), 5, 'row 11: a deferred read through an `is rw` alias sees a later element write';
+}
+
+# row 20
+{
+    my @a = 10, 20;
+    my @c;
+    for @a -> $v is rw { @c.push(-> { $v }) }
+    @a[0] = 5;
+    @a[1] = 6;
+    is-deeply (@c[0](), @c[1]()).List, (5, 6), 'row 20: every deferred read sees its later element write';
+}
+
+# row 41 — an in-body read after an in-body direct element write.
+{
+    my @a = 1, 2;
+    my $seen;
+    for @a -> $v is rw { @a[0] = 9; $seen = $v; last }
+    is $seen, 9, 'row 41: reading the `is rw` alias sees the body own direct element write';
+}
+
+# row 42 — the implicit topic (slice 3).
+{
+    my @a = 1, 2;
+    my $seen;
+    for @a { @a[0] = 9; $seen = $_; last }
+    todo 'ADR-0045 slice 3: the implicit topic must bind the element container';
+    is $seen, 9, 'row 42: reading the implicit topic sees the body own direct element write';
+}
+
+# row 43 — a sigilless param over the topic-ish path (slice 3/4 wiring).
+{
+    my @a = 1, 2;
+    my $seen;
+    for @a -> \v { @a[0] = 9; $seen = v; last }
+    is $seen, 9, 'row 43: reading a sigilless alias sees the body own direct element write';
+}
+
+# ---------------------------------------------------------------------------
+# Class 3 — the end-of-iteration snapshot must not clobber the body's own
+# direct writes to the source.
+# ---------------------------------------------------------------------------
+
+# row 04
+{
+    my @a = 10, 20;
+    for @a -> $v is rw { $v = $v + 1; @a[1] = 99 }
+    is-deeply @a, [11, 99], 'row 04: a direct `@a[1] = 99` in an `is rw` body survives';
+}
+
+# row 21 — implicit topic (slice 3).
+{
+    my @a = 10, 20;
+    for @a { $_ = $_ + 1; @a[1] = 99 }
+    todo 'ADR-0045 slice 3: the topic writeback still clobbers direct element writes';
+    is-deeply @a, [11, 99], 'row 21: a direct `@a[1] = 99` in a topic body survives';
+}
+
+# row 22 — no `rw`, no closure: ordinary code losing an ordinary write.
+{
+    my @a = 10, 20;
+    for @a -> $v { @a[1] = 99 }
+    todo 'ADR-0045 slice 3: the named-param writeback is a pure deletion';
+    is-deeply @a, [10, 99], 'row 22: a plain `-> $v` body direct element write survives';
+}
+
+# row 38 — the body rebinds the source wholesale.
+{
+    my @a = 1, 2;
+    for @a -> $v is rw { $v = 9; @a = 7, 8 }
+    is-deeply @a, [7, 8], 'row 38: rebinding the source array wholesale is not overwritten';
+}
+
+# row 07 — the iteration ends by dying, but the write already landed.
+{
+    my @a = 10, 20;
+    try { for @a -> $v is rw { $v = 77; die "stop" } }
+    is-deeply @a, [77, 20], 'row 07: a write through the alias survives an exception';
+}
+
+# ---------------------------------------------------------------------------
+# Class 4 — derived producers must alias in the derived order (slice 4).
+# ---------------------------------------------------------------------------
+
+# row 17
+{
+    my @a = 10, 20;
+    for @a.reverse -> $v is rw { $v = $v + 1 }
+    todo 'ADR-0045 slice 4: .reverse writes to the mirror-image index';
+    is-deeply @a, [11, 21], 'row 17: `.reverse` aliases the elements, not the mirror index';
+}
+
+# row 24
+{
+    my @a = 20, 10;
+    for @a.sort -> $v is rw { $v = $v + 1 }
+    todo 'ADR-0045 slice 4: .sort has no index mapping to reconstruct';
+    is-deeply @a, [21, 11], 'row 24: `.sort` aliases the elements in sorted order';
+}
+
+# row 39
+{
+    my $s = [1, 2];
+    for @$s <-> $x { $x = $x + 1 }
+    todo 'ADR-0045 slice 4: `@$s` must hand out element containers';
+    is-deeply $s, [2, 3], 'row 39: `for @$s <-> $x` aliases the inner array elements';
+}
+
+# ---------------------------------------------------------------------------
+# Class 5 — bind-time enforcement (slice 5).
+# ---------------------------------------------------------------------------
+
+# row 19
+{
+    todo 'ADR-0045 slice 5: an immutable source must reject an `is rw` bind';
+    dies-ok { for (1, 2) -> $v is rw { $v = 5 } }, 'row 19: `is rw` over a List dies at bind time';
+}
+
+# row 30
+{
+    todo 'ADR-0045 slice 5: an immutable source must reject an `is rw` bind';
+    dies-ok { for 1 .. 2 -> $v is rw { $v = 5 } }, 'row 30: `is rw` over a Range dies at bind time';
+}
+
+# row 28
+{
+    todo 'ADR-0045 slice 5 / ADR-0042: the promoted cell must carry the element constraint';
+    dies-ok { my Int @a = 1, 2; for @a -> $v is rw { $v = "s" } },
+        'row 28: a typed array rejects a bad element through the alias';
+}
+
+# ---------------------------------------------------------------------------
+# INVARIANTS — these agree with raku today and must keep agreeing. A later
+# slice that "fixes" a divergence by over-promoting breaks one of these.
+# ---------------------------------------------------------------------------
+
+# rows 05 / 06 — loop control after mutating the alias.
+{
+    my @a = 10, 20;
+    for @a -> $v is rw { $v = 77; last }
+    is-deeply @a, [77, 20], 'row 05: `last` after mutating the alias keeps the write';
+}
+{
+    my @a = 10, 20;
+    for @a -> $v is rw { $v = 77; next }
+    is-deeply @a, [77, 77], 'row 06: `next` after mutating the alias keeps every write';
+}
+
+# row 09 — direct `%h.values` mutation (the writeback path slice 2 replaces).
+{
+    my %h = a => 1, b => 2;
+    for %h.values -> $v is rw { $v *= 10 }
+    is-deeply %h, {a => 10, b => 20}, 'row 09: `%h.values -> $v is rw` mutates in place';
+}
+
+# rows 10 / 32 / 33 — a plain named param still mutates the container it binds.
+{
+    my @m = [1, 2], [3, 4];
+    for @m -> $row { $row.push(9) }
+    is-deeply @m, [[1, 2, 9], [3, 4, 9]], 'row 10: `-> $row` in-place container mutation propagates';
+}
+{
+    my @m = [1, 2], [3, 4];
+    for @m -> @row { @row.push(9) }
+    is-deeply @m, [[1, 2, 9], [3, 4, 9]], 'row 32: `-> @row` in-place container mutation propagates';
+}
+{
+    my %h = a => [1, 2];
+    for %h.values -> $v { $v.push(9) }
+    is-deeply %h<a>, [1, 2, 9], 'row 33: `%h.values -> $v` in-place container mutation propagates';
+}
+
+# row 15 — `.kv` with a direct rw write.
+{
+    my @a = 10, 20;
+    for @a.kv -> $i, $v is rw { $v += $i }
+    is-deeply @a, [10, 21], 'row 15: `.kv -> $i, $v is rw` writes each element';
+}
+
+# rows 23 / 26 — `.values` and a shaped array, direct.
+{
+    my @a = 10, 20;
+    for @a.values -> $v is rw { $v = $v + 1 }
+    is-deeply @a, [11, 21], 'row 23: `.values -> $v is rw` mutates the source';
+}
+{
+    my @a[2];
+    @a[0] = 10;
+    @a[1] = 20;
+    for @a -> $v is rw { $v = $v + 1 }
+    is @a[0] ~ "," ~ @a[1], '11,21', 'row 26: a shaped array `is rw` loop mutates the source';
+}
+
+# row 25 — mutate, then `last` partway.
+{
+    my @a = 10, 20;
+    for @a -> $v is rw { $v = $v + 1; last if $v > 20 }
+    is-deeply @a, [11, 21], 'row 25: mutations before a partway `last` all land';
+}
+
+# row 29 — a Seq source accepts an `is rw` param (no bind-time die).
+{
+    my @a = 1, 2;
+    lives-ok { for @a.map({ $_ }) -> $v is rw { $v = 5 } },
+        'row 29: an `is rw` param over a Seq source does not die';
+}
+
+# row 31 — the plain named param cannot be assigned at all.
+{
+    my @a = 1, 2;
+    dies-ok { for @a -> $v { $v = 5 } }, 'row 31: `-> $v` is read-only';
+}
+
+# rows 34 / 35 — ADR-0027 per-iteration capture identity. Each closure must
+# keep ITS OWN iteration's binding; a promoted cell must not cascade across
+# iterations. This pulls in the opposite direction from rows 12/36 above (which
+# require sharing WITHIN one iteration) — together they pin the behaviour.
+{
+    my @c;
+    for 1, 2, 3 -> $x { @c.push(-> { $x }) }
+    is-deeply @c.map({ .() }).List, (1, 2, 3), 'row 34: pointy closures keep per-iteration identity';
+}
+{
+    my @c;
+    for 1, 2, 3 -> $x { @c.push(sub { $x }) }
+    is-deeply @c.map({ .() }).List, (1, 2, 3), 'row 35: named-sub closures keep per-iteration identity';
+}
+# The same, over a real mutable Array source (the shape slice 1 promotes).
+{
+    my @a = 1, 2, 3;
+    my @c;
+    for @a -> $x is rw { @c.push(-> { $x }) }
+    is-deeply @c.map({ .() }).List, (1, 2, 3),
+        'row 34b: an `is rw` alias over an Array keeps per-iteration identity';
+}
+
+# row 37 — nesting.
+{
+    my @m = [1, 2], [3, 4];
+    for @m -> @row { for @row <-> $x { $x = $x * 10 } }
+    is-deeply @m, [[10, 20], [30, 40]], 'row 37: a nested `<->` loop mutates the inner rows';
+}
+
+# row 40 — the promoted cell stays invisible to reflection.
+{
+    my @a = 1, 2;
+    for @a -> $v is rw { $v = $v + 1 }
+    is @a.raku, '[2, 3]', 'row 40: `.raku` does not reveal the promoted element cell';
+    is @a.elems, 2, 'row 40: `.elems` is unaffected by element promotion';
+    is @a.WHAT.^name, 'Array', 'row 40: the source stays an Array';
+    is @a[0].WHAT.^name, 'Int', 'row 40: an element reads back decontainerized';
+    is-deeply @a.List, (2, 3), 'row 40: list context decontainerizes every element';
+    is "@a[]", '2 3', 'row 40: interpolation decontainerizes every element';
+}
+
+# rows 45 / 46 — the plain named param must NOT alias, in either direction.
+{
+    my @a = 1, 2;
+    my $seen;
+    for @a -> $v { @a[0] = 9; $seen = $v; last }
+    is $seen, 1, 'row 45: `-> $v` does not read-alias the element';
+}
+{
+    my @a = 1, 2;
+    my @c;
+    for @a -> $v { @c.push(-> { $v }) }
+    @a[0] = 9;
+    is @c[0]() ~ " " ~ @c[1](), '1 2', 'row 46: a deferred read of `-> $v` does not alias';
+}
+
+# ADR-0045 §5 Q6 — a `Proxy` element under an aliasing loop. Assigning a Proxy
+# into an Array FETCHes it, so the element is a plain value and the loop must
+# write the ARRAY, never the Proxy's STORE target.
+{
+    my $n = 5;
+    my @a = Proxy.new(FETCH => -> $ { $n }, STORE => -> $, $v { $n = $v });
+    for @a -> $x is rw { $x = 42 }
+    is $n, 5, 'Q6: an `is rw` loop over a FETCHed Proxy element leaves the Proxy target alone';
+    is @a[0], 42, 'Q6: ... and writes the array element';
+}
+
+# ADR-0045 §5 Q1 — `box_captured_lexicals` must not double-box an already-cell
+# param: the closure's read must decontainerize exactly once.
+{
+    my @a = 7;
+    my @c;
+    for @a -> $v is rw { @c.push(-> { $v + 1 }) }
+    is @c[0](), 8, 'Q1: a closure over a promoted element param reads a plain value';
+    is @a[0].WHAT.^name, 'Int', 'Q1: the source element still reads back as an Int';
+}
+
+# ---------------------------------------------------------------------------
+# ADR-0045 §1.5 — the mutating `<->` loop must be O(n), not O(n^2). Before
+# slice 1 every iteration rebuilt the whole backing ArrayData to replace one
+# element, so 20 000 elements took ~1.1 s release / far longer debug. The bound
+# is generous (this file runs on the DEBUG binary in CI) but still fails
+# decisively on a quadratic regression.
+# ---------------------------------------------------------------------------
+{
+    my @big = ^20000;
+    my $t0 = now;
+    for @big <-> $x { $x = $x + 1 }
+    my $elapsed = now - $t0;
+    ok $elapsed < 20, "mutating `<->` over 20k elements is O(n) ({$elapsed.round(0.01)}s)";
+    is @big[19999], 20000, 'the mutating `<->` loop actually wrote every element';
+}
+
+# row 27 — the binding also outlives the THREAD that captured it. Deliberately
+# last: see the note where this row would otherwise sit.
+{
+    my @a = 10, 20;
+    my @p;
+    for @a -> $v is rw { @p.push(start { $v = $v + 1 }) }
+    await @p;
+    is-deeply @a, [11, 21], 'row 27: a `start` block over an `is rw` param writes through';
+}
+
+done-testing;

--- a/todo/deep/for-loop-rw-element-alias-lost-through-deferred-closure.md
+++ b/todo/deep/for-loop-rw-element-alias-lost-through-deferred-closure.md
@@ -2,8 +2,24 @@
 
 ## Status
 
-**Designed. The mechanism decision now lives in
-[ADR-0045](../../docs/adr/0045-for-loop-parameters-bind-the-element-container.md)** (2026-08-20):
+**Partially fixed (2026-08-27) — ADR-0045 slices 0 and 1 landed.** The headline symptom below is
+gone: `for @list -> $v is rw { @callbacks.push(-> { $v = $v + 1 }) }` now binds `$v` to the element's
+own `ContainerRef` (`array_slot_ref`) at the bind site, so a closure called after the loop writes
+through and the repro prints raku's `[11 21]`.
+
+Slice 1 turned these ADR-0045 §1.3 rows green: **01, 02, 03, 04, 07, 11, 12, 13, 14, 20, 27, 36, 38,
+41, 43** — the whole deferred-closure class for a direct array source, the stale-read class for it,
+and the class-3 clobber (including row 38, the body rebinding `@a` wholesale). §1.5's O(n²) mutating
+`<->` loop is linear now (40 000 elements: 2.13 s → 0.09 s).
+
+**Still open**, and why this file stays here: row 08 (hash sources, slice 2); rows 21, 22, 42, 44 (the
+implicit topic and the plain named param, slice 3); rows 16, 17, 24, 39 (derived producers —
+`.kv`/`.reverse`/`.sort`/`@$s`, slice 4); rows 19, 28, 30 (bind-time enforcement, slice 5). Each is
+`todo`-marked in `t/for-loop-element-alias.t` with its owning slice named. Retire this file to
+`news/2026-08/` when ADR-0045's slice 6 lands, per the note below.
+
+The mechanism decision lives in
+[ADR-0045](../../docs/adr/0045-for-loop-parameters-bind-the-element-container.md) (2026-08-20):
 bind the loop parameter to the element's `ContainerRef` (`array_slot_ref` / `hash_slot_ref`) at the
 bind site and retire the per-iteration writeback family. Read ADR-0045 before starting — it carries a
 27-row divergence matrix re-measured on `main` (33f75a62f), the invariant table that bounds it, the

--- a/todo/tickets/at-sigil-for-param-rebinds-stale-container-after-start-block.md
+++ b/todo/tickets/at-sigil-for-param-rebinds-stale-container-after-start-block.md
@@ -1,0 +1,75 @@
+# After any `start` block, a `for @m -> @row` loop rebinds the PREVIOUS iteration's container
+
+## Symptom
+
+Once a program has run a `start` block (anywhere, on any data), every later
+`for @container -> @param { ... }` loop stops rebinding `@param` per iteration:
+from the second iteration on it still holds the *first* iteration's element, so
+in-place mutations pile up on one row and the rest of the source is never
+touched.
+
+```raku
+my $p = start { 1 };
+await $p;
+my @m = [1, 2], [3, 4];
+for @m -> @row { @row.push(9) }
+say "A: ", @m;
+```
+
+- raku:  `A: [[1 2 9] [3 4 9]]`
+- mutsu: `A: [[1 2 9] [1 2 9 9]]`
+
+Drop the first two lines and mutsu agrees with raku, so the `start`/`await` is
+the whole trigger. The `start` block does not have to touch `@m`, `@row`, or
+anything else in the loop — a `start { 1 }` is enough.
+
+## Status / provenance
+
+**Pre-existing and unrelated to ADR-0045.** Confirmed on a release build of
+`main` at `f678b032b` (before ADR-0045 slice 1) with the exact repro above. It
+was found while writing `t/for-loop-element-alias.t`: the ADR's invariant rows
+32 (`for @m -> @row { @row.push(9) }`) and 37 (the nested `<->` loop) both sit
+after that file's row 27, which uses a `start` block, and were being sunk by
+this leak rather than by anything the ADR touches. The workaround in that file
+is to keep the `start`-block row last; the note there points here.
+
+## Where to look
+
+The trigger is thread-related, so the suspects are the cross-thread bare-name
+lane and the env↔locals sync that runs once a thread has existed:
+
+- `Interpreter::thread_redeclared_vars` and `sync_shared_vars_to_env` /
+  `set_shared_var_sym` — `@row` is an `@`-sigil name, and
+  `exec_for_loop_body`'s `masked_multi_params` mask is only installed for
+  *multi*-param loops (`spec.multi_param_names`), never for the single named
+  param this loop uses.
+- `src/vm/vm_for_loop_body.rs`'s single-param bind: `saved_param` deliberately
+  **skips `@`/`%`-sigil params** ("they bind a shared mutable container the body
+  may legitimately reassign"), so an `@`-sigil loop param has no
+  save/restore — and, more to the point, nothing that would keep a stale
+  shared-lane copy from being re-injected over the per-iteration bind.
+
+The failing value is the *previous* iteration's container, which is the shape a
+stale `shared_vars` snapshot re-injected after the fresh bind would produce.
+
+## Why this is a ticket and not a one-liner
+
+The fix has to decide whether an `@`-sigil `for` parameter belongs on the
+cross-thread bare-name lane at all. It is a fresh per-iteration binding, like
+the multi-param names that `masked_multi_params` already keeps off the lane, so
+the likely fix is to extend that mask to the single named parameter — but that
+mask was written for multi-params on purpose and widening it touches every
+`for ... -> $x` loop in the corpus. Measure before widening.
+
+## Reproduce
+
+`tmp/rwalias/start-leak3.p6` above, no fixtures. A slightly wider form (two
+independent later loops, both corrupted) is in the same repro family:
+
+```raku
+{ my @p; for 1, 2 -> $v { @p.push(start { $v }) }; await @p; }
+{ my @m  = [1, 2], [3, 4]; for @m  -> @row { @row.push(9) }; say "A: ", @m;  }
+{ my @m2 = [1, 2], [3, 4]; for @m2 -> @r2  { @r2.push(9)  }; say "B: ", @m2; }
+```
+
+raku prints `[[1 2 9] [3 4 9]]` twice; mutsu prints `[[1 2 9] [1 2 9 9]]` twice.


### PR DESCRIPTION
Implements **slices 0 and 1** of [ADR-0045](../blob/main/docs/adr/0045-for-loop-parameters-bind-the-element-container.md).

## The problem

Raku binds a `for` parameter to the item the iterator yields, and when the source is a real mutable `Array` that item **is** the element's `Scalar` container. The binding is an alias with the lifetime of the *binding*, not of the loop body.

mutsu bound a plain value clone and copied it back once per iteration (`write_back_for_rw_param`), rebuilding the whole backing `ArrayData` to change one element. That snapshot-and-rebuild model is one root cause of four divergence classes (ADR-0045 §1.3) — lost writes through a binding that outlives the body, stale reads, the snapshot clobbering the body's own direct writes to the source, and index mis-mapping — and it is also why a mutating `<->` loop was O(n²).

The whole §1.3 table was **re-measured against `raku` before any code was written** and reproduced exactly as the ADR recorded it.

## The change

When the parameter is a writable aliasing one (`is rw` / `<->` / sigilless `\v`), the loop binds a single parameter natively, and the tagged source is a direct, real, mutable, plain `Array` (`@`-sigil, not `.kv`/`.values`/`.pairs`/`.reverse`), the bind site installs `array_slot_ref(idx, true)` and the per-iteration writeback is retired for exactly those iterations.

This is routing, not invention: the primitive shipped with ADR-0036, is exercised daily by `:=`-bound elements, and the hand-written equivalent (`my $r := @a[$i]`) already produced raku's answer on every probe.

## Rows that turn green

01, 02, 03, 04, 07, 11, 12, 13, 14, 20, 27, 36 and 41 as ADR-0045 §4 planned, **plus 38** (the body rebinding the source array wholesale — the sharpest class-3 clobber) and **43** (the sigilless read-alias, which §4 had filed under the topic slice but which binds through this same native site).

Every invariant row of §1.3 still agrees with raku.

## Perf (§1.5's acceptance number)

Release build, same machine, best of three, `for @a <-> $x { $x = $x + 1 }`:

| n | before | after |
| --- | --- | --- |
| 5 000 | 0.04 s | 0.01 s |
| 10 000 | 0.15 s | 0.01 s |
| 20 000 | 0.56 s | 0.02 s |
| 40 000 | 2.17 s | 0.03 s |
| 80 000 | 9.01 s | 0.05 s |
| 160 000 | 39.44 s | 0.11 s |

Each doubling used to multiply the time by 3.7-4.4×; it now roughly doubles. The quadratic is gone, not merely reduced. (Local A/B numbers, for this ADR's acceptance criterion only — no repository document cites them; the bench CI stays the source of truth.)

## Carve-outs kept, deliberately

- **Shaped, native-backed (`array[int]`) and lazy arrays** stay on the metadata-preserving writeback (§5 Q5): `array_slot_ref` has no provision for a shape, and a packed `NativeBacking` payload cannot hold a `ContainerRef`. Pinned by `t/cas-shaped-and-for-loop.t` and row 26.
- **`write_back_quanthash_rw` / `write_back_quanthash_value_item` stay**: a `BagHash`/`MixHash` weight is not a stored element container and `.value = 0` *removes* the key. Pinned by `t/for-pairs-value-quanthash-writeback.t`.
- **A `Proxy` element is not promoted** (§5 Q6) — and because the writeback is retired **per iteration** rather than for the whole loop, that iteration keeps it. Retiring it loop-wide silently dropped the Proxy element's write; the second Q6 assertion in the new test is the pin.
- **ADR-0040's bind-side itemization carve-out is untouched** (§5 Q3): this flips a *local* writeback flag and never touches `spec.do_writeback`, which is what that carve-out keys off. `t/param-bind-itemization.t` and `t/for-bind-typed-array-deitemize.t` pass unmodified.
- **ADR-0027's per-iteration capture freeze is not disturbed** (§5 Q1): an `is rw` loop's parameter never enters `loop_local_vars` in the first place, so a promoted cell cannot reach `compute_owned_captures`' unguarded primary branch or `freeze_readonly_owned_captures`, and `box_captured_lexicals` already refuses to double-box an already-cell local. Rows 34/35 (per-iteration identity) and 12/36 (sharing within an iteration) pull in opposite directions and both hold.

## Slice 0

`t/for-loop-element-alias.t` (57 assertions) pins the whole ADR-0045 surface: every divergence row — the ones later slices own are `todo`-marked with the owning slice named in the reason string, so each later slice un-`todo`s exactly its own — and every invariant row, plus the §5 Q6 `Proxy` probe, a §5 Q1 capture probe, an extended row 40 (`.raku`/`.elems`/`.WHAT`/list context/interpolation all decontainerize) and §1.5's bench as an O(n) assertion.

## Verification

- `make test`: PASS.
- All 16 ADR-named regression pins: PASS.
- Targeted roast: `S32-array/`, `S03-operators/`, `S29-context/`, `S09-typed-arrays/`, `S02-types/` (172 whitelisted files, 27 344 tests) — PASS. `S04-`, `S06-`, `S03-`, `S12-`, `S17-`, `integration/` (626 files, 36 163 tests) — PASS on release. (`integration/deep-recursion-initing-native-array.t` overflows the stack on a **debug** build both before and after this change; it passes on release, which is what `make roast` uses.)
- Full `make roast` delegated to CI.

## Unrelated finding

After any `start` block, a later `for @m -> @row { ... }` loop rebinds the *previous* iteration's container. Pre-existing on `main` (verified at `f678b032b`), independent of this ADR, and recorded as `todo/tickets/at-sigil-for-param-rebinds-stale-container-after-start-block.md`. It is why the new test keeps its `start`-block row last.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
