### PR TITLE
docs(todo): re-measure two Tier S findings; both were filed under the wrong root cause

### DIFF
--- a/todo/deep/bare-name-type-constraint-store-is-scope-blind.md
+++ b/todo/deep/bare-name-type-constraint-store-is-scope-blind.md
@@ -3,6 +3,37 @@
 `Interpreter::var_type_constraints` is a single global `HashMap<String,
 String>` keyed by BARE variable name, and it is never frame-scoped.
 
+## Spot-check 2026-08-27 (`main` @ `10ac4d450`): re-measure before dispatching slice 2
+
+Five rows this ticket and ADR-0042 §3 use as motivation now **agree with
+`raku`**, including the one ADR-0042 §5.2 names as the reason slice 2 is "the
+architectural half":
+
+| row | program | mutsu | raku |
+| --- | --- | --- | --- |
+| A | `my Str $s; my $t := $s; $t = 42` — **ADR-0042 §3's headline** | dies, correct message | dies |
+| B | `my $y; if True { my Str $y = "a" }; $y = 42` (residual 2, `if` branch) | `42` | `42` |
+| C | `my $x; my $i = 0; while $i++ < 2 { my Str $x = "a" }; $x = 42` (residual 2, `while` body) | `42` | `42` |
+| E | `my Str $s = "a"; my \x := $s; x = 42` | dies | dies |
+| F | `my Str $e = "a"; sub f { my $e = 1 }; f(); $e = 42` (residual 3) | dies | dies |
+
+Row A dying correctly means the *correctness* argument for giving the scalar
+cell an `of` field has, at least for this shape, already been satisfied by some
+other change. Rows B and C are residual 2's two literal repros, quoted verbatim
+from this file's own "What is still scope-blind" section; both now agree.
+
+**This is a spot-check, not a closure.** Only five rows were run — ADR-0042's
+§2.1 and §2.2 matrices are larger, and CLAUDE.md's standing lesson is that a
+*partial* fix is more common than full staleness, so a headline repro passing
+is exactly when to re-run the whole table rather than assume. Slice 2 also has
+a second, independent motivation this measurement says nothing about: deleting
+the `box_decl_local_cell` constraint bails and unblocking slice 3's removal of
+the global map and its six workarounds.
+
+**Before dispatching ADR-0042 slice 2, re-run §2.1 and §2.2 in full and rewrite
+its §3 with what actually still diverges.** Dispatching it on the ADR's stated
+motivation as written would be work against a repro that no longer fails.
+
 ## Status 2026-08-23: ADR-0042 Slice 1 is SHIPPED — residual 1 is closed
 
 Slice 1 landed 2026-08-20 as PR #6743 (`dc39cb3e3`), and the follow-on

--- a/todo/deep/sigilless-alias-closure-capture-skips-typecheck.md
+++ b/todo/deep/sigilless-alias-closure-capture-skips-typecheck.md
@@ -1,5 +1,45 @@
 # Writing through a sigilless bind alias captured into a closure still skips the type check
 
+## Measured 2026-08-27 (`main` @ `10ac4d450`): the title is wrong — this is a write-through bug, and it is not sigilless-specific
+
+The "Root cause (not yet investigated)" section below guessed correctly that
+this might be "a write-through bug first, type-check bug second". It is, and
+the type constraint is not involved at all. It is also **not specific to a
+sigilless alias** — an ordinary `$`-sigil `:=` alias fails identically, which
+the original repro did not reveal because it used a typed variable:
+
+| # | program | mutsu | raku |
+| --- | --- | --- | --- |
+| D2 | `my $s = "a"; my $t := $s; my $f = { $t = 42 }; $f(); say $s` | `a` | `42` |
+| D4 | `my $s = "a"; my \x := $s; { x = 42 }(); say $s` | `42` | `42` |
+| D5 | `my $s = "a"; my \x := $s; sub f { x = 42 }; f(); say $s` | `a` | `42` |
+
+D2 is untyped and uses `$t`, not `\x`, and still loses the write. D4 (the
+immediately-invoked block) agrees, so the discriminator is **stored/deferred
+closure vs. immediate invocation**, not the sigil and not the type. The
+type-check divergence in the original repro is downstream: the write never
+reaches `$s`, so there is nothing left to type-check.
+
+**Retitle when fixing.** The accurate statement is: *a `:=`-bound alias stops
+aliasing when the write happens inside a closure that is stored and called
+later.*
+
+### Likely one family with two neighbouring findings
+
+All three are about how a `:=` bind reaches a frame other than the one it was
+declared in, which today is `Interpreter::propagate_bind_to_ancestor_frames`
+(`src/vm/vm_var_assign_ops.rs`) — a **name-based** ancestor-frame splice:
+
+- [bind-propagate-ancestor-frames-clobbers-unrelated-recursive-locals](bind-propagate-ancestor-frames-clobbers-unrelated-recursive-locals.md)
+  — the bind reaches frames it must **not** (unrelated recursive invocations).
+- `todo/tickets/routine-local-bind-writes-through-to-same-named-outer-lexical.md`
+  — the bind leaks **out** to a same-named caller lexical.
+- This finding — the bind fails to reach a frame it **must**.
+
+"Reaches a frame it must not" and "fails to reach a frame it must" are
+plausibly the same missing identity token. Check the other two before scoping
+this one separately.
+
 ## Symptom
 
 `news/2026-08/sigilless-alias-write-now-type-checked.md` fixed the type check


### PR DESCRIPTION
Triaging the `todo/deep/` backlog by ADR cluster (per `todo/TRIAGE.md`'s "work `deep/` by ADR cluster" rule) surfaced that two Tier S findings no longer describe what actually diverges. Measured on `main` @ `10ac4d450`, oracled against `raku`.

## `sigilless-alias-closure-capture-skips-typecheck`

The type constraint is not involved, and the bug is not specific to a sigilless alias:

| # | program | mutsu | raku |
|---|---|---|---|
| D2 | `my $s = "a"; my $t := $s; my $f = { $t = 42 }; $f(); say $s` | `a` | `42` |
| D4 | `my $s = "a"; my \x := $s; { x = 42 }(); say $s` | `42` | `42` |
| D5 | `my $s = "a"; my \x := $s; sub f { x = 42 }; f(); say $s` | `a` | `42` |

D2 is untyped and uses `$t`, not `\x`, and still loses the write. D4 agrees, so the discriminator is **stored/deferred closure vs. immediate invocation** — not the sigil, not the type. The reported type-check divergence is downstream: the write never reaches `$s`, so there is nothing left to type-check.

The file's own "Root cause (not yet investigated)" section had guessed a write-through bug was possible; that is now measured, and the sigil-independence is new. Flagged as likely one family with `bind-propagate-ancestor-frames-clobbers-unrelated-recursive-locals` and `todo/tickets/routine-local-bind-writes-through-to-same-named-outer-lexical` — all three concern how a `:=` bind reaches a frame other than its declaring one, which today is a name-based ancestor-frame splice. "Reaches a frame it must not" and "fails to reach a frame it must" are plausibly the same missing identity token.

## `bare-name-type-constraint-store-is-scope-blind`

Five rows this file and ADR-0042 use as motivation now agree with `raku`, including ADR-0042 §3's headline `my Str $s; my $t := $s; $t = 42` (dies correctly) and **both** of residual 2's literal repros (`if` branch, `while` body).

Recorded as a **spot-check, not a closure**: only five rows were run, ADR-0042's §2.1/§2.2 matrices are larger, and CLAUDE.md's standing lesson is that a partial fix is more common than full staleness. Slice 2 also has a second motivation the measurement says nothing about (unblocking slice 3's removal of the global map and its six workarounds).

The actionable point: **ADR-0042 slice 2 must not be dispatched on its stated motivation** without re-running §2.1 and §2.2 in full and rewriting §3 with what actually still diverges.

## Why this is worth a PR

Both files are queue heads that an agent would otherwise have been dispatched against. Docs-only, so the four heavy CI jobs skip by design (`scripts/ci-docs-only.sh`).