### PR TITLE
feat(for): the topic and hash sources bind the element container (ADR-0045 slices 2-3)

### DIFF
--- a/docs/adr/0045-for-loop-parameters-bind-the-element-container.md
+++ b/docs/adr/0045-for-loop-parameters-bind-the-element-container.md
@@ -1,6 +1,6 @@
 # ADR-0045: A `for` loop parameter binds the element *container*; the per-iteration writeback is retired
 
-- **Status**: Accepted — partially implemented (slices 0 and 1 landed 2026-08-27; slices 2-6 open, see
+- **Status**: Accepted — partially implemented (slices 0-3 landed 2026-08-27; slices 4-6 open, see
   §8 "Implementation status")
 - **Date**: 2026-08-20
 - **Deciders**: tokuhirom, Claude
@@ -515,14 +515,18 @@ roughly doubles. The quadratic is gone, not merely reduced. These are local A/B 
 this ADR's own acceptance criterion; the bench CI series remains the source of truth for any headline
 figure.
 
-### Answers to the open questions, as measured by slice 1
+### Answers to the open questions, as measured by slices 1-3
 
-- **§5 Q1 (ADR-0027 composition)** — no conflict, for a reason worth writing down: an `is rw` loop's
-  parameter never enters `loop_local_vars` in the first place (`exec_for_loop_body` gates that set on
-  `!spec.is_rw`), so `compute_owned_captures`'s unguarded primary branch is not reached by a promoted
-  cell and `freeze_readonly_owned_captures` cannot value-freeze one. Rows 34/35 (per-iteration
-  identity) and rows 12/36 (sharing *within* an iteration) both hold, and `box_captured_lexicals`
-  already refuses to double-box (`if self.locals[idx].is_container_ref() { continue }`).
+- **§5 Q1 (ADR-0027 composition)** — no conflict, and slice 3 confirmed why rather than by luck. An
+  `is rw` loop's parameter never enters `loop_local_vars` (`exec_for_loop_body` gates that set on
+  `!spec.is_rw`), so slice 1's promoted cell could not reach `compute_owned_captures`'s unguarded
+  primary branch. The **topic is not gated that way** — but it is excluded from `loop_param_names` by
+  an explicit `name != "_"` filter, so it never enters that set either, and no guard was needed after
+  all. Measured, not assumed: the topic form of rows 11/20 (a read-only closure over `$_` seeing a
+  later element write) passes, and it is pinned in `t/for-loop-element-alias.t` precisely because it
+  is what would break first if that filter ever changed. Rows 34/35 (per-iteration identity) and rows
+  12/36 (sharing *within* an iteration) both hold, and `box_captured_lexicals` already refuses to
+  double-box (`if self.locals[idx].is_container_ref() { continue }`).
 - **§5 Q3 (ADR-0040 itemization)** — unchanged, deliberately: slice 1 flips a *local* writeback flag
   and never touches `spec.do_writeback`, which is what the bind-side itemization carve-out keys off.
   `t/param-bind-itemization.t` and `t/for-bind-typed-array-deitemize.t` pass unmodified.
@@ -538,13 +542,93 @@ figure.
   Retiring it loop-wide silently dropped the `Proxy` element's write; the pin is the second Q6
   assertion in `t/for-loop-element-alias.t`.
 
-### What slices 2-6 still own
+### Slices 2 and 3 — landed 2026-08-27
 
-Rows 08 (slice 2); 21, 22, 42, 44 (slice 3); 16, 17, 24, 39 (slice 4); 19, 28, 30 (slice 5). They are
-`todo`-marked in `t/for-loop-element-alias.t` with the owning slice named in the reason string, so
-each later slice un-`todo`s exactly its own rows. `write_back_for_rw_param` still carries the hash,
-`kv_mode`, multi-param and scalar arms; only its direct-array single-parameter path is now dead code
-for the promoted shape.
+**Slice 2 (hash sources).** `for %h.values -> $v is rw` (and its topic form) binds
+`hash_slot_ref(key, true)`, keyed by the key order captured before the loop — the same order the
+materialized `.values` list was built from. The key capture moves from *writeback* time to *bind*
+time, which is strictly earlier and therefore strictly less exposed to a body that mutates the map.
+`write_back_hash_value_item` survives only as the fallback for iterations that could not be promoted.
+**Row 08 turns green**, along with the topic form and the hash sibling of rows 11/20 (a read through
+the alias seeing a later `%h<a> = 5`).
+
+**Slice 3 (the implicit topic, and the plain named parameter).** Two different jobs, as §4 predicted:
+
+- **The topic promotes.** `for @a { … }` binds `$_` to the element container. **Rows 21, 42 and 44
+  turn green**, and so does the topic form of rows 11/20.
+- **The plain named parameter is a pure deletion.** `writes_back_named_param` is gone with nothing put
+  in its place. **Row 22 turns green** — `for @a -> $v { @a[1] = 99 }`, silent corruption in code
+  using no advanced feature at all, which was this pair of slices' acceptance criterion.
+
+The discriminator moved into a single `plan_for_element_alias` (`src/vm/vm_for_loop_alias.rs`),
+decided once per loop and carrying the resolved source.
+
+**Three things the deletion exposed** — each a latent bug the writeback had been masking, and each a
+pin in `t/for-loop-element-alias.t`:
+
+1. **An `@`/`%`-sigil parameter did not bind *through* a `ContainerRef` element.** `for @c -> @row
+   { @row.push(8) }` over an array whose elements are already cells (the rw-alias cells `.grep`
+   leaves behind) pushed onto the *cell* rather than the row. The writeback re-stored the mutated
+   binding over the element, hiding that the binding was never the container. Fixed at the bind site:
+   a container-sigil parameter derefs a cell element. `t/for-loop-cell-elements.t` is the other pin.
+2. **The kind test for "aliasable array" has to be a denial list.** ADR-0040 stores an `Array`
+   element *itemized*, so the very common `for @m -> @row { for @row <-> $x { … } }` binds `@row` to
+   an `ItemArray`. An allow list of `Array | List` dropped it back onto the writeback — which rebuilds
+   a fresh `ArrayData` and **severs** `@row` from the `@m` element it shared. Invisible while the
+   named parameter's writeback copied the severed array back; a lost mutation the moment that
+   writeback went (row 37, plus a new row 37b that pins the sharing directly).
+3. **A source tag does not prove the loop iterates that source's elements one-for-one.** `for @a,`
+   builds a *one*-element list whose single item is the whole `@a`, yet still tags `@a`. Guarded by a
+   **loop-entry** check (item count against element count, plus first-item identity). Deliberately
+   *not* per iteration: the item vector is a loop-entry snapshot, so once the body has mutated an
+   element it no longer matches — and that is precisely the case an alias must keep serving. A
+   per-iteration version of this test silently re-broke rows 04, 21 and 38.
+
+**Two topic-write paths had to learn to write *through* the binding**, since an aliasing topic is no
+longer a plain value: the destructive `s///` writeback (`vm_subst_exec.rs`) and the `$_ ~~ s///`
+smartmatch writeback (`vm_smartmatch_ops.rs`), which additionally must not install the
+decontainerized LHS over the cell for the duration of its RHS. Pins: `t/subst-readonly-topic.t`,
+`t/smartmatch-subst-topic.t`, `t/statement-modifier-for-regression.t`.
+
+**Perf.** Release build, best of three. The topic loop carried the same quadratic the `<->` loop did,
+and `%h.values` carried a worse one:
+
+| probe (n) | before slices 1-3 | after |
+| --- | --- | --- |
+| `for @a { $_ = $_ + 1 }` (20 000) | 0.71 s | 0.02 s |
+| `for @a { $_ = $_ + 1 }` (160 000) | 43.14 s | 0.16 s |
+| `for @a <-> $x { $x = $x + 1 }` (160 000) | 39.83 s | 0.16 s |
+| `for %h.values -> $v is rw { … }` (20 000) | 17.32 s | 0.04 s |
+
+**§5 Q2's predicted cost is real, and here it is.** A *read-only* topic loop pays for a promotion
+nothing observes: 160 000 elements go from 0.07 s to 0.24 s on the first pass. Splitting the two
+costs (four passes over the same array, where `array_slot_ref` is idempotent) puts ~0.12 s of that in
+the first pass's per-element cell allocation and ~0.12 s in the steady-state per-iteration source
+resolution plus cell deref — against 0.05 s for the equivalent named-parameter loop. The repository's
+own benchmarks do not move (`bench-array` 0.03→0.02, `bench-hash` 0.03→0.02, `bench-class`
+0.15→0.17, `bench-string`/`bench-ctor`/`bench-mandelbrot` unchanged), so this is a synthetic-shape
+cost rather than a corpus-wide one — but it is the honest answer to Q2, and the bench CI series
+remains the place to watch it. A lazy "promote only when the binding is observed" scheme would remove
+it and needs its own design; do not bolt on a cached source resolution to chase it, since
+re-resolving per iteration is what makes row 38 work.
+
+### What slices 4-6 still own
+
+Rows 16, 17, 24 and 39 (slice 4 — derived producers), and 19, 28 and 30 (slice 5 — bind-time
+enforcement). They are `todo`-marked in `t/for-loop-element-alias.t` with the owning slice named in
+the reason string, so each later slice un-`todo`s exactly its own rows. The writeback family survives
+only as the fallback for shapes not yet converted: `write_back_for_rw_param`'s `kv_mode`,
+multi-parameter and scalar arms, `write_back_for_topic_item`'s `$`-tagged `for @$s` arm, and
+`write_back_hash_value_item` for a hash iteration that could not be promoted.
+
+**Two things slice 4 should know before it starts.**
+
+- **`.sort` needs a source *tag*, not just a producer.** `for_iterable_source_name` does not match
+  `.sort` at all, so a `for @a.sort -> $v is rw` loop carries no `container_binding` — there is no
+  writeback to correct, and nothing for a producer change to hook. Row 24 needs the tag added as well.
+- **`.kv` is the multi-parameter shape.** Row 16 (`@a.kv`) and its hash twin (`%h.kv -> $k, $v is
+  rw`, also still divergent) bind through the bind-prefix `Stmt::Assign`s, not the native bind site
+  these slices converted, so they need the producer to hand out containers rather than a change here.
 
 **Found along the way, unrelated:** after any `start` block, a later `for @m -> @row { ... }` loop
 rebinds the *previous* iteration's container. Pre-existing on `main` (verified at `f678b032b`) and
@@ -554,5 +638,5 @@ independent of this ADR — recorded as
 
 ---
 
-*Slices 0 and 1 of this ADR are implemented; the decision stands. If the mechanism judgment changes
+*Slices 0-3 of this ADR are implemented; the decision stands. If the mechanism judgment changes
 later, supersede it rather than rewriting it.*

--- a/src/vm/vm_for_loop_alias.rs
+++ b/src/vm/vm_for_loop_alias.rs
@@ -1,30 +1,232 @@
 //! ADR-0045: a `for` loop parameter binds the element *container*.
 //!
 //! Raku binds a `for` parameter to the item the iterator yields, and when the
-//! source is a real mutable `Array` that item **is** the element's `Scalar`
-//! container. The binding is therefore an alias with the lifetime of the
-//! binding, not of the loop body: a closure or `start` block that outlives the
-//! iteration still writes through, a read through the alias sees a write made
-//! to the element by anyone else, and a direct `@a[i] = v` in the body is not
-//! reverted afterwards.
+//! source is a real mutable `Array`/`Hash` that item **is** the element's
+//! `Scalar` container. The binding is therefore an alias with the lifetime of
+//! the binding, not of the loop body: a closure or `start` block that outlives
+//! the iteration still writes through, a read through the alias sees a write
+//! made to the element by anyone else, and a direct `@a[i] = v` in the body is
+//! not reverted afterwards.
 //!
 //! mutsu used to bind a plain value clone and copy it back once per iteration
-//! (`write_back_for_rw_param`), rebuilding the entire backing `ArrayData` to
-//! change one element — which is both the cause of five divergence classes
-//! (ADR-0045 §1.3) and the reason a mutating `<->` loop was O(n²) (§1.5).
+//! (`write_back_for_rw_param` / `write_back_for_topic_item` /
+//! `write_back_hash_value_item`), rebuilding the entire backing container to
+//! change one element — which is both the cause of the divergence classes in
+//! ADR-0045 §1.3 and the reason a mutating loop was O(n²) (§1.5).
 //!
-//! This module holds the discriminator for **slice 1**: which `for` loop
-//! sources may have their elements promoted to first-class containers via
-//! [`Value::array_slot_ref`], the primitive ADR-0036 shipped and that
-//! `:=`-bound elements already exercise daily. The bind site itself lives in
-//! `vm_for_loop_body.rs`.
+//! This module holds the **discriminator**: which loop/source/parameter
+//! combinations may have their elements promoted to first-class containers via
+//! [`Value::array_slot_ref`] / [`Value::hash_slot_ref`], the primitives
+//! ADR-0036 shipped and that `:=`-bound elements already exercise daily. The
+//! bind site itself lives in `vm_for_loop_body.rs`.
+//!
+//! Slices landed here: 1 (direct array source, writable aliasing parameter),
+//! 2 (`%h.values`), 3 (the implicit topic; the plain named parameter is a pure
+//! deletion with no promotion at all — rows 45/46 pin that `-> $v` binds the
+//! *value*).
 
+use super::vm_control_ops::ForLoopSpec;
 use super::*;
 
+/// How a `for` loop's binding aliases its source's elements, decided once per
+/// loop. Carrying the resolved source name (and, for a hash, the key order the
+/// producer yielded) makes the per-iteration promotion a lookup rather than a
+/// re-derivation.
+pub(super) enum ForElementAlias {
+    /// No promotion: the loop keeps the plain value bind and whatever
+    /// writeback it had.
+    None,
+    /// A direct `@`-array source, keyed by iteration index.
+    ArrayIndex(String),
+    /// A `%h.values` source, keyed by the key order captured before the loop —
+    /// the same order the materialized `.values` list was built from, so
+    /// position `idx` names the key whose value the loop is binding.
+    HashValue(String, Vec<String>),
+}
+
+impl ForElementAlias {
+    pub(super) fn is_active(&self) -> bool {
+        !matches!(self, Self::None)
+    }
+}
+
 impl Interpreter {
+    /// Decide once per loop whether this `for` may bind element containers, and
+    /// against which source.
+    ///
+    /// **Which parameters alias** (ADR-0045 §1.1, measured against raku, not
+    /// assumed): `is rw`, `<->`, sigilless `\v` — all of which set
+    /// `spec.do_writeback` — and the **implicit topic**. The plain named
+    /// parameter `-> $v` is a read-only binding of the *value* and is absent
+    /// here on purpose: `for @a -> $v { @a[0] = 9; say $v }` prints `1` in
+    /// raku, and the deferred-read form prints `1 2` (rows 45/46).
+    ///
+    /// **Which sources alias**: a direct, real, mutable, plain `Array`, or a
+    /// `%h.values` over a real mutable `Hash`. Derived producers
+    /// (`.kv`/`.pairs`/`.reverse`/`.sort`, and the `$`-tagged `for @$s` shape)
+    /// are excluded until slice 4 makes those producers hand out element
+    /// containers themselves; a multi-parameter loop binds through the
+    /// bind-prefix `Stmt::Assign`s rather than this native bind site, so it is
+    /// excluded too.
+    #[allow(clippy::too_many_arguments)]
+    pub(super) fn plan_for_element_alias(
+        &self,
+        spec: &ForLoopSpec,
+        container_binding: Option<&str>,
+        container_reversed: bool,
+        arity: usize,
+        param_name: Option<&str>,
+        writes_back_topic: bool,
+        topic_readonly: bool,
+        hash_keys: Option<&[String]>,
+        items: &[Value],
+    ) -> ForElementAlias {
+        // A `@`/`%`/`&`-sigil parameter binds the element's *container*, not a
+        // scalar slot: `for @m -> @row { @row.push(9) }` mutates `@m` through
+        // the shared `Gc` with no cell involved (rows 32/33). Promoting such an
+        // element would hand the parameter a `ContainerRef` where a
+        // Positional/Associative is expected, so element promotion is for
+        // scalar bindings only — `$v`, `\v`, and the topic.
+        let scalar_binding = !param_name.is_some_and(|n| n.starts_with(['@', '%', '&']));
+        let aliasing_param = scalar_binding
+            && if spec.do_writeback {
+                // `is rw` / `<->` / `\v`, bound natively as a single parameter
+                // (or as the topic, for a `<->` block with no signature).
+                arity == 1
+                    && spec.multi_param_names.is_empty()
+                    && (param_name.is_some() || writes_back_topic)
+            } else {
+                // The implicit topic. An immutable Mix/Set/Bag source, or a
+                // source whose items are provably bare values, marks the topic
+                // read-only — there is no container behind those items to alias.
+                writes_back_topic && !topic_readonly
+            };
+        // `.pairs`/`.antipairs` yield a `Pair` *wrapping* the element, so the
+        // binding is not the element; `.kv` and `.reverse` are derived orders
+        // whose producers do not hand out containers yet (slice 4).
+        if !aliasing_param || spec.loop_var_wraps_element || spec.kv_mode || container_reversed {
+            return ForElementAlias::None;
+        }
+        let Some(source) = container_binding else {
+            return ForElementAlias::None;
+        };
+        if source.starts_with('@') {
+            // `@a.values` is an identity-ordered derived producer, but it is
+            // slice 4's to route; keep it on the writeback so the two array
+            // producers convert together.
+            if spec.values_mode || !self.for_source_is_aliasable(source) {
+                return ForElementAlias::None;
+            }
+            let arr = self
+                .get_env_with_main_alias(source)
+                .map(|v| v.deref_container());
+            let (len, first) = match arr.as_ref().map(Value::view) {
+                Some(ValueView::Array(data, _)) => (data.len(), data.items().first().cloned()),
+                _ => return ForElementAlias::None,
+            };
+            if items.len() != len || !Self::items_are_source_elements(items, first) {
+                return ForElementAlias::None;
+            }
+            return ForElementAlias::ArrayIndex(source.to_string());
+        }
+        // A mutable QuantHash (`for $b.values`) binds to a scalar, so it never
+        // reaches here: its `container_binding` carries no `%` sigil. That is
+        // the ADR-0045 §2.4 carve-out — a BagHash/MixHash *weight* is not a
+        // stored element container, and `.value = 0` REMOVES the key, so it is
+        // a different operation and keeps `write_back_quanthash_*`.
+        if source.starts_with('%') && spec.values_mode {
+            let Some(keys) = hash_keys.filter(|k| !k.is_empty()) else {
+                return ForElementAlias::None;
+            };
+            if !self.for_source_is_aliasable_hash(source) {
+                return ForElementAlias::None;
+            }
+            let first = self
+                .get_env_with_main_alias(source)
+                .map(|v| v.deref_container())
+                .and_then(|h| keys.first().and_then(|k| h.hash_get_str(k)));
+            if items.len() != keys.len() || !Self::items_are_source_elements(items, first) {
+                return ForElementAlias::None;
+            }
+            return ForElementAlias::HashValue(source.to_string(), keys.to_vec());
+        }
+        ForElementAlias::None
+    }
+
+    /// The element container this iteration's binding should alias, or `None`
+    /// when nothing can be promoted — the source stopped being an aliasable
+    /// container, the index/key is gone (a body that shrank the source out from
+    /// under the loop), or the key was never there. The caller then keeps the
+    /// plain value bind *and* the writeback that bind depends on: retiring the
+    /// writeback per **loop** rather than per **iteration** silently drops such
+    /// an iteration's write.
+    ///
+    /// The source is resolved fresh on every call, on purpose: a body that
+    /// reassigns it wholesale (`@a = 7, 8`) must have the remaining iterations
+    /// alias the container it left behind, not the one the loop started with.
+    ///
+    /// Promotion is idempotent — `array_slot_ref`/`hash_slot_ref` return an
+    /// existing cell rather than allocating a second one — so re-looping the
+    /// same container costs nothing after the first pass.
+    pub(super) fn for_element_alias(
+        &mut self,
+        plan: &ForElementAlias,
+        idx: usize,
+    ) -> Option<Value> {
+        match plan {
+            ForElementAlias::None => None,
+            ForElementAlias::ArrayIndex(source) => {
+                let arr = self.get_env_with_main_alias(source)?.deref_container();
+                if !Self::array_is_aliasable(&arr, Some(idx)) {
+                    return None;
+                }
+                arr.array_slot_ref(idx, true)
+            }
+            ForElementAlias::HashValue(source, keys) => {
+                let key = keys.get(idx)?;
+                let hash = self.get_env_with_main_alias(source)?.deref_container();
+                if !Self::hash_is_aliasable(&hash) {
+                    return None;
+                }
+                // Only an EXISTING key is an element container. `hash_slot_ref`
+                // hands back a lazy `HashEntryRef` token for a missing one,
+                // which is a path, not an alias — and this loop's key came from
+                // the map, so a miss means the body deleted it.
+                hash.hash_get_str(key)?;
+                hash.hash_slot_ref(key, true)
+            }
+        }
+    }
+
+    /// Loop-entry guard: does this loop iterate the tagged source's elements
+    /// **one-for-one**, so that iteration position `idx` names element `idx`?
+    ///
+    /// The source tag names a container, but it does not by itself prove that.
+    /// `for @a,` is the counter-example: a trailing comma builds a **one**-
+    /// element list whose single item is the whole `@a`, yet the tag still says
+    /// `@a`, so indexing by iteration position would alias `@a[0]` to a binding
+    /// that holds all of `@a` (`t/for-modifier-trailing-comma.t`). The old
+    /// writeback survived this only because its unchanged-value guard happened
+    /// to make it a no-op.
+    ///
+    /// This is checked **once, before the body has run**, and deliberately not
+    /// per iteration: the item vector is a snapshot taken at loop entry, so once
+    /// the body has mutated an element the snapshot no longer matches it — and
+    /// that is exactly the case an alias must keep serving, not decline (rows
+    /// 04/21/38, where the body writes the source directly). A per-iteration
+    /// version of this test silently re-broke all three.
+    fn items_are_source_elements(items: &[Value], first_element: Option<Value>) -> bool {
+        match (items.first(), first_element) {
+            // An empty loop never binds anything, so the plan is moot; say yes
+            // rather than special-casing the caller.
+            (None, _) => true,
+            (Some(first_item), Some(elem)) => Self::loop_var_unchanged(first_item, &elem),
+            (Some(_), None) => false,
+        }
+    }
+
     /// Whether a `for` loop's tagged `@`-source is a real, mutable, plain
-    /// `Array` whose elements ADR-0045 slice 1 may promote to their own
-    /// containers.
+    /// `Array` whose elements may be promoted.
     ///
     /// The carve-outs (ADR-0045 §5 Q5) are deliberate and stay until slice 5
     /// decides otherwise:
@@ -46,40 +248,44 @@ impl Interpreter {
             .is_some_and(|raw| Self::array_is_aliasable(&raw.deref_container(), None))
     }
 
-    /// The element container for index `idx` of a `for` loop's `@`-source
-    /// (ADR-0045 slice 1). Promotion is idempotent — `array_slot_ref` returns
-    /// an existing cell rather than allocating a second one — so re-looping the
-    /// same array costs nothing after the first pass.
-    ///
-    /// `None` when the source is no longer an aliasable array, or the index is
-    /// out of range: a body that shrank the source out from under the loop has
-    /// no element left to alias, so the caller keeps the plain value bind (and
-    /// its writeback) rather than letting `array_slot_ref` autovivify a fresh
-    /// hole past the end.
-    ///
-    /// The source is resolved fresh on every call, on purpose: a body that
-    /// reassigns it wholesale (`@a = 7, 8`) must have the remaining iterations
-    /// alias the array it left behind, not the one the loop started with.
-    pub(super) fn for_element_alias(&mut self, source: &str, idx: usize) -> Option<Value> {
-        let arr = self.get_env_with_main_alias(source)?.deref_container();
-        if !Self::array_is_aliasable(&arr, Some(idx)) {
-            return None;
-        }
-        arr.array_slot_ref(idx, true)
+    /// The hash sibling of [`Self::for_source_is_aliasable`].
+    fn for_source_is_aliasable_hash(&self, source: &str) -> bool {
+        self.get_env_with_main_alias(source)
+            .is_some_and(|raw| Self::hash_is_aliasable(&raw.deref_container()))
     }
 
-    /// Shared shape test for the two entry points above. `idx` additionally
+    /// Shared shape test for the array entry points. `idx` additionally
     /// requires that index to exist today.
+    ///
+    /// The kind test is a **denial list**, not an allow list. Only `Shaped` and
+    /// `Lazy` are genuinely unable to hand out an element container; every other
+    /// kind is an ordinary `ArrayData` whose elements promote normally. An allow
+    /// list of `Array | List` looked equivalent and was not: ADR-0040 stores an
+    /// `Array` element *itemized*, so the very common
+    /// `for @m -> @row { for @row <-> $x { … } }` binds `@row` to an
+    /// `ItemArray`, which an allow list silently dropped back onto the
+    /// writeback — and that writeback rebuilds a fresh `ArrayData`, severing
+    /// `@row` from the `@m` element it was sharing (row 37).
     fn array_is_aliasable(v: &Value, idx: Option<usize>) -> bool {
         match v.view() {
             ValueView::Array(data, kind) => {
-                matches!(
+                !matches!(
                     kind,
-                    crate::value::ArrayKind::Array | crate::value::ArrayKind::List
+                    crate::value::ArrayKind::Shaped | crate::value::ArrayKind::Lazy
                 ) && data.shape.is_none()
                     && data.native_storage_node().is_none()
                     && idx.is_none_or(|i| i < data.len())
             }
+            _ => false,
+        }
+    }
+
+    /// A real mutable `Hash`. An immutable `Map` is excluded: its elements are
+    /// not assignable, so promoting one would offer an alias that must not
+    /// exist (slice 5 owns turning that into a bind-time error).
+    fn hash_is_aliasable(v: &Value) -> bool {
+        match v.view() {
+            ValueView::Hash(data) => data.declared_type.as_deref() != Some("Map"),
             _ => false,
         }
     }

--- a/src/vm/vm_for_loop_body.rs
+++ b/src/vm/vm_for_loop_body.rs
@@ -133,22 +133,32 @@ impl Interpreter {
             && spec.arity <= 1
             && spec.multi_param_names.is_empty();
         let mut rw_writeback = spec.do_writeback;
-        // A plain (non-rw, non-copy) named loop variable aliases the source
-        // element in Raku: `for @m -> @row { @row.push(9) }` and
-        // `for @m -> $row { $row.push(9) }` both mutate `@m` (a scalar binding a
-        // container can still mutate the container, though not rebind it).
-        // Mirror the topic writeback for it. `is copy` sets `is_rw` (suppressing
-        // this), and `<->` rw uses `rw_writeback` instead. The unchanged-value
-        // guard in `write_back_for_topic_item` keeps read-only loops O(n).
-        let writes_back_named_param =
-            !spec.is_rw && !rw_writeback && spec.arity <= 1 && param_name.is_some();
+        // ADR-0045 slice 3: a plain (non-rw, non-copy) named loop variable used
+        // to get a writeback of its own, on the theory that `for @m -> @row
+        // { @row.push(9) }` and `for @m -> $row { $row.push(9) }` need one to
+        // mutate `@m`. **They do not, and the writeback was actively harmful.**
+        //
+        // A `-> $v` parameter binds the element's *value*, not its container
+        // (§1.1, measured: `for @a -> $v { @a[0] = 9; say $v }` prints `1` in
+        // raku, and the deferred-read form prints `1 2` — rows 45/46), so there
+        // is nothing for it to write back. In-place *container* mutation
+        // through such a parameter already propagates on its own, because the
+        // bound value shares the source element's `Gc` (rows 10/32/33), and the
+        // parameter cannot be assigned at all (row 31). Meanwhile the writeback
+        // was a whole-container rebuild from a snapshot taken before the body
+        // ran, so an ordinary `for @a -> $v { @a[1] = 99 }` — no `rw`, no
+        // closure, no advanced feature — silently lost the write (row 22).
+        //
+        // So the named-parameter half is a **pure deletion**: nothing replaces
+        // it. Only the implicit topic keeps a writeback here, and only until it
+        // is promoted below.
+        //
         // `.pairs`/`.antipairs` loop variables are `Pair`s wrapping the element,
         // not the element itself — writing one back would overwrite the source
         // element with the Pair (S32-array/pairs.t 14). The Pair's rw `.value`
         // alias handles propagation (and immutability for Mix), so suppress the
         // plain writeback here while keeping the source tag.
-        let writes_back_loop_var =
-            (writes_back_topic || writes_back_named_param) && !spec.loop_var_wraps_element;
+        let writes_back_loop_var = writes_back_topic && !spec.loop_var_wraps_element;
         let chunked_items: Vec<Value> = if spec.chunks_items() {
             items
                 .chunks(arity)
@@ -469,46 +479,41 @@ impl Interpreter {
         // shared backing node (container identity §3), so binding the element
         // value as-is would let `@row[0] = v` reach the source element.
         let param_is_copy = spec.is_rw && !spec.do_writeback;
-        // ADR-0045 slice 1: a writable aliasing parameter (`is rw`, `<->`,
-        // sigilless `\v`) over a DIRECT, real, mutable `Array` source binds the
-        // element's own `ContainerRef` instead of a value clone, and the
-        // per-iteration writeback for that shape is retired. The alias then has
-        // the lifetime of the binding, not of the body — a closure or `start`
-        // block that outlives the iteration still writes through, a read
-        // through the alias sees a later write to the element, and a direct
-        // `@a[i] = v` in the body is no longer reverted by an end-of-iteration
-        // whole-container rebuild. It also removes that rebuild's O(n^2)
-        // (§1.5): promotion is O(1) and idempotent (`array_slot_ref` reuses an
-        // existing cell), where the writeback cloned the whole `ArrayData` per
-        // iteration.
+        // ADR-0045 slices 1-3: an aliasing binding — `is rw` / `<->` /
+        // sigilless `\v`, or the implicit topic — over a real mutable
+        // `Array`/`Hash` source binds the element's own `ContainerRef` instead
+        // of a value clone, and the per-iteration writeback for that shape is
+        // retired. The alias then has the lifetime of the binding, not of the
+        // body: a closure or `start` block that outlives the iteration still
+        // writes through, a read through the alias sees a later write to the
+        // element, and a direct `@a[i] = v` in the body is no longer reverted
+        // by an end-of-iteration whole-container rebuild. It also removes that
+        // rebuild's O(n^2) (§1.5) — promotion is O(1) and idempotent.
         //
-        // Deliberately narrow — the rest is later slices of the same ADR:
-        //   * hash sources stay on `write_back_hash_value_item` (slice 2);
-        //   * the implicit topic and the plain named param stay on
-        //     `write_back_for_topic_item` (slice 3);
-        //   * derived producers (`.values`/`.kv`/`.pairs`/`.reverse`, and the
-        //     `$`-tagged `for @$s` shape) keep the index-reconstruction
-        //     writeback until their producers hand out element containers
-        //     (slice 4), so they are excluded here by the `*_mode` flags, by
-        //     `container_reversed`, and by the `@`-sigil requirement;
-        //   * a multi-parameter loop binds through the bind-prefix
-        //     `Stmt::Assign`s, not this native bind site, so it is excluded.
-        let alias_array_elements = spec.do_writeback
-            && arity == 1
-            && param_name.is_some()
-            && spec.multi_param_names.is_empty()
-            && !spec.kv_mode
-            && !spec.values_mode
-            && !spec.loop_var_wraps_element
-            && !container_reversed
-            && container_binding
-                .as_deref()
-                .is_some_and(|name| name.starts_with('@') && self.for_source_is_aliasable(name));
-        // The base decision; each iteration retires it for itself only when the
-        // element really was promoted (see the bind site below). `spec.do_writeback`
-        // itself is left alone: ADR-0040's bind-side itemization carve-out keys
-        // off it, and ADR-0045 §5 Q3 keeps that carve-out unchanged here.
+        // `plan_for_element_alias` owns the whole discriminator (which
+        // parameters alias, which sources do, and the shaped/native/`Map`
+        // carve-outs); see `vm_for_loop_alias.rs`.
+        let element_alias = self.plan_for_element_alias(
+            spec,
+            container_binding.as_deref(),
+            container_reversed,
+            arity,
+            param_name.as_deref(),
+            writes_back_topic,
+            topic_readonly,
+            hash_keys_for_writeback.as_deref(),
+            &chunked_items,
+        );
+        // The base decisions; each iteration retires them for itself only when
+        // the element really was promoted (see the bind site below).
+        // `spec.do_writeback` itself is left alone: ADR-0040's bind-side
+        // itemization carve-out keys off it, and ADR-0045 §5 Q3 keeps that
+        // carve-out unchanged here.
         let rw_writeback_base = rw_writeback;
+        let topic_writeback_base = writes_back_loop_var;
+        // Set per iteration at the bind site below; the initial value is never
+        // read.
+        let mut writes_back_loop_var;
         'for_loop: for (idx, item) in chunked_items.into_iter().enumerate().skip(resume_index) {
             let item = if param_is_copy {
                 item.detach_shared_container()
@@ -562,29 +567,27 @@ impl Interpreter {
                     }
                 }
             }
-            // ADR-0045 slice 1: promote this element to its own container and
-            // bind THAT, so the parameter is a real alias for the lifetime of
-            // the binding. The source is re-resolved every iteration on purpose
-            // — a body that reassigns the source wholesale (`@a = 7, 8`) must
-            // have the remaining iterations alias the array it left behind, not
-            // the one the loop started with.
+            // ADR-0045 slices 1-3: promote this element to its own container
+            // and bind THAT, so the binding is a real alias for the lifetime of
+            // the binding.
             //
             // A `Proxy` element is left alone (ADR-0045 §5 Q6): it mediates its
             // own STORE, and a cell bound *around* one would take a plain write
             // instead of calling it (`t/proxy-list-transparency.t`).
             let promoted =
-                if alias_array_elements && !matches!(item.view(), ValueView::Proxy { .. }) {
-                    container_binding
-                        .as_deref()
-                        .and_then(|source| self.for_element_alias(source, idx))
+                if element_alias.is_active() && !matches!(item.view(), ValueView::Proxy { .. }) {
+                    self.for_element_alias(&element_alias, idx)
                 } else {
                     None
                 };
-            // The writeback is retired for exactly the iterations whose element
-            // was promoted. An iteration that fell back to a plain value bind —
-            // a `Proxy` element, or a body that shrank the source out from under
-            // the index — keeps the writeback that bind depends on.
+            // Both writebacks are retired for exactly the iterations whose
+            // element was promoted. An iteration that fell back to a plain
+            // value bind — a `Proxy` element, or a body that removed the
+            // index/key out from under the loop — keeps the writeback that bind
+            // depends on. Retiring per LOOP instead of per ITERATION silently
+            // drops such an iteration's write.
             rw_writeback = rw_writeback_base && promoted.is_none();
+            writes_back_loop_var = topic_writeback_base && promoted.is_none();
             let item = promoted.unwrap_or(item);
             // `topic_source_var` drives the whole-topic writeback for a scalar
             // source (`for $x { $_[1] = ... }` writes the mutated `$_` back to
@@ -617,6 +620,20 @@ impl Interpreter {
                 Some(name) if !name.starts_with(['@', '%', '&', '\\']) && !spec.do_writeback => {
                     Self::itemize_scalar_store(name, item)
                 }
+                // An `@`/`%`-sigil parameter binds a Positional/Associative, so
+                // when the element it binds is a shared `ContainerRef` cell —
+                // the rw-alias cell `.grep` leaves in its source array, or a
+                // `:=`-bound element — it must bind the container INSIDE the
+                // cell, not the cell itself. Otherwise `@row.push(8)` pushes
+                // onto a cell rather than the row (`t/for-loop-cell-elements.t`).
+                // A shared `Gc` is what makes the mutation propagate, and the
+                // deref keeps it: the cell holds the very same `Gc`.
+                //
+                // This used to be masked by the plain named parameter's
+                // writeback, which ADR-0045 slice 3 deletes — the writeback
+                // re-stored the mutated binding over the element, hiding the
+                // fact that the binding was never the container to begin with.
+                Some(name) if name.starts_with(['@', '%']) => item.deref_container(),
                 _ => item,
             };
             if let Some(ref name) = param_name {

--- a/src/vm/vm_smartmatch_ops.rs
+++ b/src/vm/vm_smartmatch_ops.rs
@@ -39,7 +39,22 @@ impl Interpreter {
         // (the engine records them there but nothing consumes the log otherwise).
         self.pending_local_updates.clear();
         let saved_topic = self.env().get("_").cloned();
-        self.env_mut().insert("_".to_string(), left.clone());
+        // ADR-0045: `$_ ~~ s///` where the topic is an *aliasing* binding — a
+        // `for` loop parameter bound to its source's element container — must
+        // keep that binding for the duration of the RHS and write through it.
+        // `left` has already been decontainerized, so installing it here would
+        // orphan the cell and the substitution would never reach the source
+        // element (`t/smartmatch-subst-topic.t`). The topic already holds
+        // exactly `left`'s container, so there is nothing to install.
+        let topic_cell = match self.env().get("_").map(Value::view) {
+            Some(ValueView::ContainerRef(arc)) if matches!(lhs, Some(SmartMatchLhs::Var { name, .. }) if name == "_") => {
+                Some(arc.clone())
+            }
+            _ => None,
+        };
+        if topic_cell.is_none() {
+            self.env_mut().insert("_".to_string(), left.clone());
+        }
         // While the RHS runs, `$_` is *aliased* to the LHS variable (`$x ~~ s///`
         // topicalizes `$x`). A destructive `s///`/`tr///` checks `$_`'s readonly
         // status, but the enclosing scope may have marked `_` readonly for an
@@ -115,26 +130,43 @@ impl Interpreter {
         // caller, clobbering a same-named caller lexical of a different sigil
         // (JSON::Unmarshal: the callee's `$json` Int overwrote the caller's
         // `%json` hash after `if $json ~~ Int`).
-        let topic_after = self.env().get("_").cloned().unwrap_or(Value::NIL);
+        // Decontainerized on purpose: when the topic is an aliasing cell the RHS
+        // wrote THROUGH it, so the modified value is the cell's content — and
+        // comparing the cell itself against the plain `left` would report every
+        // pure predicate match as "modified".
+        let topic_after = self
+            .env()
+            .get("_")
+            .cloned()
+            .unwrap_or(Value::NIL)
+            .deref_container();
         let topic_modified = was_substitution
             || was_transliterate
             || !crate::runtime::utils::values_identical(&topic_after, &left);
         if let Some(var_name) = lhs_var.filter(|_| topic_modified) {
             let modified_topic = topic_after.clone();
-            self.env_mut()
-                .insert(var_name.clone(), modified_topic.clone());
-            // Reverse write-through: if the lhs alias names a compiled local slot,
-            // mirror the (possibly substitution-modified) topic into it so the
-            // caller sees it without an O(locals) sync_locals_from_env pull.
-            // §1.5: prefer the compile-time-baked `lhs_slot` (scope-correct even
-            // once a name occupies several slots) over the by-name resolution; the
-            // by-name fallback stays for a `None` slot (global LHS, or an EVAL /
-            // carrier where the var is an outer lexical with no current-frame slot).
-            match lhs_slot {
-                Some(slot) if (slot as usize) < self.locals.len() => {
-                    self.locals[slot as usize] = modified_topic.clone();
+            // An aliasing topic keeps its binding: write the modified value into
+            // the cell rather than replacing the binding with a plain value, and
+            // leave the local slot alone (it holds that same cell).
+            if let Some(arc) = topic_cell.clone() {
+                Self::cell_store_preserving_container_identity(var_name, &arc, &modified_topic);
+            } else {
+                self.env_mut()
+                    .insert(var_name.clone(), modified_topic.clone());
+                // Reverse write-through: if the lhs alias names a compiled local
+                // slot, mirror the (possibly substitution-modified) topic into it
+                // so the caller sees it without an O(locals)
+                // sync_locals_from_env pull. §1.5: prefer the compile-time-baked
+                // `lhs_slot` (scope-correct even once a name occupies several
+                // slots) over the by-name resolution; the by-name fallback stays
+                // for a `None` slot (global LHS, or an EVAL / carrier where the
+                // var is an outer lexical with no current-frame slot).
+                match lhs_slot {
+                    Some(slot) if (slot as usize) < self.locals.len() => {
+                        self.locals[slot as usize] = modified_topic.clone();
+                    }
+                    _ => self.update_local_if_exists(code, var_name, &modified_topic),
                 }
-                _ => self.update_local_if_exists(code, var_name, &modified_topic),
             }
             // The env insert above bypasses `set_env_with_main_alias`, and
             // `update_local_if_exists` only touches the *current* frame's slot —

--- a/src/vm/vm_subst_exec.rs
+++ b/src/vm/vm_subst_exec.rs
@@ -303,7 +303,25 @@ impl Interpreter {
             attrs.insert("value".to_string(), result);
             return Err(RuntimeError::typed("X::Assignment::RO", attrs));
         }
-        self.env_mut().insert("_".to_string(), result.clone());
+        // ADR-0045: when the topic is an aliasing binding — a `for` loop
+        // parameter bound to its source's element container — `s///` assigns
+        // INTO that container. Replacing the env entry with a plain value would
+        // orphan the cell, so the substitution would be invisible to the source
+        // (`for @a { s:g/c/X/ }`, `t/subst-readonly-topic.t`). Writing through
+        // is also what leaves the alias intact for the rest of the iteration.
+        // The local slot holds the same cell, so it must not be overwritten
+        // either — see the `update_local_if_exists` call below.
+        let topic_cell = match self.env().get("_").map(Value::view) {
+            Some(ValueView::ContainerRef(arc)) => Some(arc.clone()),
+            _ => None,
+        };
+        let topic_is_cell = topic_cell.is_some();
+        match topic_cell {
+            Some(arc) => Self::cell_store_preserving_container_identity("_", &arc, &result),
+            None => {
+                self.env_mut().insert("_".to_string(), result.clone());
+            }
+        }
         self.env_mut().insert("$_".to_string(), result.clone());
         self.env_mut()
             .insert("__mutsu_rw_map_topic__".to_string(), result.clone());
@@ -315,7 +333,13 @@ impl Interpreter {
         // matching the `$x ~~ s///` smartmatch writeback path. Both `_` and the
         // source name are flagged for the carrier (env_dirty) so an enclosing
         // EVAL/carrier dropping its blanket net still reconciles the slot.
-        self.update_local_if_exists(code, "_", &result);
+        // Skipped when the topic is an aliasing cell: the slot holds that very
+        // cell, and storing the plain result over it would sever the alias for
+        // the rest of the iteration (the cell write above already reached
+        // every holder, the slot included).
+        if !topic_is_cell {
+            self.update_local_if_exists(code, "_", &result);
+        }
         self.note_caller_env_write("_");
         // Inside a smartmatch RHS (`$frag ~~ s///`) the topic is temporarily the
         // smartmatch LHS, not the enclosing `given`/`for` source — mirroring

--- a/t/for-loop-element-alias.t
+++ b/t/for-loop-element-alias.t
@@ -14,13 +14,14 @@ use Test;
 #     `-> $v` alias (rows 45/46 say it must not), or by cascading a promoted
 #     cell across iterations (rows 34/35, ADR-0027's per-iteration freeze).
 #
-# Slice 1 (the direct array source with a writable aliasing parameter) has
-# landed, so rows 01, 02, 03, 04, 07, 11, 12, 13, 14, 20, 27, 36 and 41 are
-# ordinary passing tests here. The rows still `todo`-marked name the slice that
-# owns them: slice 2 (hash sources), slice 3 (the implicit topic and the plain
-# named param), slice 4 (derived producers) and slice 5 (bind-time enforcement).
+# Slices 1 (the direct array source with a writable aliasing parameter),
+# 2 (`%h.values`) and 3 (the implicit topic, plus the plain named parameter's
+# pure deletion) have landed, so every row they own is an ordinary passing test
+# here. The rows still `todo`-marked name the slice that owns them: slice 4
+# (derived producers — `.kv`/`.reverse`/`.sort`/`@$s`) and slice 5 (bind-time
+# enforcement).
 
-plan 57;
+plan 64;
 
 # ---------------------------------------------------------------------------
 # Class 1 — a binding that outlives the loop body still writes through.
@@ -116,7 +117,6 @@ plan 57;
     my @c;
     for %h.values -> $v is rw { @c.push(-> { $v = $v + 1 }) }
     @c[0]();
-    todo 'ADR-0045 slice 2: hash sources still use write_back_hash_value_item';
     is %h<a>, 2, 'row 08: escaping closure over a `%h.values` rw param writes through';
 }
 
@@ -137,8 +137,17 @@ plan 57;
     my @c;
     for @a { @c.push(-> { $_ = 99 }) }
     @c[0]();
-    todo 'ADR-0045 slice 3: the implicit topic must bind the element container';
     is-deeply @a, [99, 2], 'row 44: escaping closure over the implicit topic writes through';
+}
+
+# The topic sibling of row 08: an escaping closure over the topic of a
+# `%h.values` loop (slice 2 x slice 3).
+{
+    my %h = a => 1;
+    my @c;
+    for %h.values { @c.push(-> { $_ = 99 }) }
+    @c[0]();
+    is %h<a>, 99, 'slice 2/3: escaping closure over a `%h.values` topic writes through';
 }
 
 # ---------------------------------------------------------------------------
@@ -177,7 +186,6 @@ plan 57;
     my @a = 1, 2;
     my $seen;
     for @a { @a[0] = 9; $seen = $_; last }
-    todo 'ADR-0045 slice 3: the implicit topic must bind the element container';
     is $seen, 9, 'row 42: reading the implicit topic sees the body own direct element write';
 }
 
@@ -187,6 +195,29 @@ plan 57;
     my $seen;
     for @a -> \v { @a[0] = 9; $seen = v; last }
     is $seen, 9, 'row 43: reading a sigilless alias sees the body own direct element write';
+}
+
+# The topic sibling of rows 11/20 — ADR-0045 §5 Q1's pin. Slice 1 was protected
+# from ADR-0027's capture freeze by accident: an `is rw` parameter never enters
+# `loop_local_vars` (that set is gated on `!spec.is_rw`), so a promoted cell
+# could not reach `compute_owned_captures`' unguarded primary branch or
+# `freeze_readonly_owned_captures`. The topic is NOT gated that way, so this row
+# is the one that would break first if the freeze ever value-froze a promoted
+# cell: a READ-ONLY closure over the topic must still see later element writes.
+{
+    my @a = 1, 2;
+    my @c;
+    for @a { @c.push(-> { $_ }) }
+    @a[0] = 9;
+    is @c[0]() ~ " " ~ @c[1](), '9 2', 'Q1: a deferred read of the promoted topic sees a later write';
+}
+
+# The same, through a hash value.
+{
+    my %h = a => 1;
+    my $seen;
+    for %h.values -> $v is rw { %h<a> = 5; $seen = $v; last }
+    is $seen, 5, 'slice 2: reading a `%h.values` rw alias sees a later element write';
 }
 
 # ---------------------------------------------------------------------------
@@ -205,7 +236,6 @@ plan 57;
 {
     my @a = 10, 20;
     for @a { $_ = $_ + 1; @a[1] = 99 }
-    todo 'ADR-0045 slice 3: the topic writeback still clobbers direct element writes';
     is-deeply @a, [11, 99], 'row 21: a direct `@a[1] = 99` in a topic body survives';
 }
 
@@ -213,7 +243,6 @@ plan 57;
 {
     my @a = 10, 20;
     for @a -> $v { @a[1] = 99 }
-    todo 'ADR-0045 slice 3: the named-param writeback is a pure deletion';
     is-deeply @a, [10, 99], 'row 22: a plain `-> $v` body direct element write survives';
 }
 
@@ -322,6 +351,33 @@ plan 57;
     for %h.values -> $v { $v.push(9) }
     is-deeply %h<a>, [1, 2, 9], 'row 33: `%h.values -> $v` in-place container mutation propagates';
 }
+# A container-sigil parameter binds the element's CONTAINER, and must keep
+# doing so when the element is already a shared `ContainerRef` cell (the rw-alias
+# cell `.grep` leaves behind, or a `:=`-bound element): it has to bind the
+# container INSIDE the cell, not the cell. This was masked by the named
+# parameter's writeback until slice 3 deleted it — the writeback re-stored the
+# mutated binding over the element, hiding that the binding was never the
+# container. `t/for-loop-cell-elements.t` is the other pin.
+{
+    my @c = [1, 2], [3, 4];
+    @c.grep(*.so).elems;
+    for @c -> @row { @row.push(8) }
+    is-deeply @c, [[1, 2, 8], [3, 4, 8]],
+        'slice 3: an `@`-sigil param binds through a ContainerRef element';
+}
+{
+    my @c = [1, 2], [3, 4];
+    @c.grep(*.so).elems;
+    for @c -> $row { $row.push(8) }
+    is-deeply @c, [[1, 2, 8], [3, 4, 8]],
+        'slice 3: a `$`-sigil param binds through a ContainerRef element';
+}
+# The statement-modifier topic form of row 09.
+{
+    my %h = a => 1, b => 2;
+    $_ = $_ * 10 for %h.values;
+    is-deeply %h, {a => 10, b => 20}, 'slice 2: `$_ = X for %h.values` mutates in place';
+}
 
 # row 15 — `.kv` with a direct rw write.
 {
@@ -387,11 +443,28 @@ plan 57;
         'row 34b: an `is rw` alias over an Array keeps per-iteration identity';
 }
 
-# row 37 — nesting.
+# row 37 — nesting. Also the pin for the kind test in `array_is_aliasable`:
+# ADR-0040 stores an `Array` element ITEMIZED, so `@row` here binds an
+# `ItemArray`. An allow list of `Array | List` silently dropped that back onto
+# the writeback, which rebuilds a fresh `ArrayData` and severs `@row` from the
+# `@m` element it was sharing — invisible while the named parameter's writeback
+# copied the severed array back, and a lost mutation the moment slice 3 deleted
+# that writeback.
 {
     my @m = [1, 2], [3, 4];
     for @m -> @row { for @row <-> $x { $x = $x * 10 } }
     is-deeply @m, [[10, 20], [30, 40]], 'row 37: a nested `<->` loop mutates the inner rows';
+}
+# The same severance, one level flatter: whatever the inner loop does to the
+# bound row must leave the row still shared with its source element.
+{
+    my @m = [1, 2], [3, 4];
+    for @m -> @row {
+        for @row <-> $x { $x = $x * 10 }
+        @row.push(9);
+    }
+    is-deeply @m, [[10, 20, 9], [30, 40, 9]],
+        'row 37b: a bound row stays shared with its source element across an inner loop';
 }
 
 # row 40 — the promoted cell stays invisible to reflection.

--- a/todo/deep/for-loop-rw-element-alias-lost-through-deferred-closure.md
+++ b/todo/deep/for-loop-rw-element-alias-lost-through-deferred-closure.md
@@ -2,20 +2,25 @@
 
 ## Status
 
-**Partially fixed (2026-08-27) — ADR-0045 slices 0 and 1 landed.** The headline symptom below is
-gone: `for @list -> $v is rw { @callbacks.push(-> { $v = $v + 1 }) }` now binds `$v` to the element's
-own `ContainerRef` (`array_slot_ref`) at the bind site, so a closure called after the loop writes
-through and the repro prints raku's `[11 21]`.
+**Partially fixed (2026-08-27) — ADR-0045 slices 0-3 landed.** The headline symptom below is gone:
+`for @list -> $v is rw { @callbacks.push(-> { $v = $v + 1 }) }` now binds `$v` to the element's own
+`ContainerRef` (`array_slot_ref`) at the bind site, so a closure called after the loop writes through
+and the repro prints raku's `[11 21]`.
 
 Slice 1 turned these ADR-0045 §1.3 rows green: **01, 02, 03, 04, 07, 11, 12, 13, 14, 20, 27, 36, 38,
 41, 43** — the whole deferred-closure class for a direct array source, the stale-read class for it,
-and the class-3 clobber (including row 38, the body rebinding `@a` wholesale). §1.5's O(n²) mutating
-`<->` loop is linear now (40 000 elements: 2.13 s → 0.09 s).
+and the class-3 clobber (including row 38, the body rebinding `@a` wholesale). Slices 2 and 3 added
+**08** (hash sources, via `hash_slot_ref`), **21, 42, 44** (the implicit topic, which promotes) and
+**22** (the plain named parameter, which turned out to be a pure deletion — `for @a -> $v { @a[1] =
+99 }`, silent corruption in code using no advanced feature at all).
 
-**Still open**, and why this file stays here: row 08 (hash sources, slice 2); rows 21, 22, 42, 44 (the
-implicit topic and the plain named param, slice 3); rows 16, 17, 24, 39 (derived producers —
-`.kv`/`.reverse`/`.sort`/`@$s`, slice 4); rows 19, 28, 30 (bind-time enforcement, slice 5). Each is
-`todo`-marked in `t/for-loop-element-alias.t` with its owning slice named. Retire this file to
+Three measured quadratics went with them: the mutating `<->` loop (160 000 elements: 39.8 s →
+0.16 s), the mutating *topic* loop (43.1 s → 0.16 s) and `for %h.values -> $v is rw` (20 000
+elements: 17.3 s → 0.04 s).
+
+**Still open**, and why this file stays here: rows 16, 17, 24, 39 (derived producers —
+`.kv`/`.reverse`/`.sort`/`@$s`, slice 4) and rows 19, 28, 30 (bind-time enforcement, slice 5). Each
+is `todo`-marked in `t/for-loop-element-alias.t` with its owning slice named. Retire this file to
 `news/2026-08/` when ADR-0045's slice 6 lands, per the note below.
 
 The mechanism decision lives in


### PR DESCRIPTION
Implements **slices 2 and 3** of [ADR-0045](../blob/main/docs/adr/0045-for-loop-parameters-bind-the-element-container.md), following slice 1 in #7065.

## What lands

**Slice 2 — hash sources.** `for %h.values -> $v is rw` (and its topic form) binds `hash_slot_ref(key, true)`, keyed by the key order captured before the loop — the same order the materialized `.values` list was built from. The key capture moves from *writeback* time to *bind* time, which is strictly earlier and so strictly less exposed to a body that mutates the map. **Row 08** turns green, along with the topic form and the hash sibling of rows 11/20.

**Slice 3 — the implicit topic, and the plain named parameter.** Two different jobs, exactly as ADR-0045 §4 predicted:

- **The topic promotes.** `for @a { … }` binds `$_` to the element container. **Rows 21, 42, 44** turn green, and so does the topic form of rows 11/20.
- **The plain named parameter is a pure deletion.** `-> $v` binds the element's *value*, not its container (measured: raku prints `1` for `for @a -> $v { @a[0] = 9; say $v }`), so it had nothing to write back — while the writeback itself was a whole-container rebuild from a snapshot taken before the body ran. Deleting it turns **row 22** green: `for @a -> $v { @a[1] = 99 }`, silent data loss in code that uses no `rw`, no closure, and no advanced feature at all. That row was this PR's acceptance criterion.

The discriminator now lives in one `plan_for_element_alias`, decided once per loop. Writebacks are retired **per iteration**, only for iterations that actually promoted.

## Three latent bugs the deletion exposed

Each had been masked by the named parameter's writeback; each is now pinned.

1. **An `@`/`%`-sigil parameter did not bind *through* a `ContainerRef` element.** `for @c -> @row { @row.push(8) }` over an array whose elements are already cells (the rw-alias cells `.grep` leaves behind) pushed onto the *cell*, not the row. The writeback re-stored the mutated binding over the element, hiding that the binding was never the container. Fixed at the bind site; `t/for-loop-cell-elements.t` is the other pin.
2. **The "aliasable array" kind test has to be a denial list, not an allow list.** ADR-0040 stores an `Array` element *itemized*, so the very common `for @m -> @row { for @row <-> $x { … } }` binds `@row` to an `ItemArray`. An `Array | List` allow list dropped it back onto the writeback — which rebuilds a fresh `ArrayData` and **severs** `@row` from the `@m` element it shared (row 37, plus a new row 37b pinning the sharing directly).
3. **A source tag does not prove the loop iterates that source's elements one-for-one.** `for @a,` builds a *one*-element list holding the whole `@a`, yet still tags `@a`. Guarded at **loop entry** (item count vs element count, plus first-item identity), deliberately *not* per iteration: the item vector is a loop-entry snapshot, so once the body mutates an element it stops matching — and that is exactly the case an alias must keep serving. A per-iteration version of this test silently re-broke rows 04, 21 and 38, which is how I found out.

**Two topic-write paths had to learn to write *through* the binding**, since an aliasing topic is no longer a plain value: the destructive `s///` writeback (`vm_subst_exec.rs`) and the `$_ ~~ s///` smartmatch writeback (`vm_smartmatch_ops.rs`), which additionally must not install the decontainerized LHS over the cell for the duration of its RHS.

## Perf

Release build, best of three. The topic loop carried the same quadratic the `<->` loop did, and `%h.values` carried a worse one:

| probe (n) | before slices 1-3 | after |
| --- | --- | --- |
| `for @a { $_ = $_ + 1 }` (20 000) | 0.71 s | 0.02 s |
| `for @a { $_ = $_ + 1 }` (160 000) | 43.14 s | 0.16 s |
| `for @a <-> $x { $x = $x + 1 }` (160 000) | 39.83 s | 0.16 s |
| `for %h.values -> $v is rw { … }` (20 000) | 17.32 s | 0.04 s |

**§5 Q2's predicted cost is real, and I am reporting it rather than burying it.** A *read-only* topic loop now pays for a promotion nothing observes: 160 000 elements go 0.07 s → 0.24 s on the first pass. Splitting the two costs (four passes over the same array, where `array_slot_ref` is idempotent) puts ~0.12 s in the first pass's per-element cell allocation and ~0.12 s in steady-state per-iteration source resolution plus cell deref — against 0.05 s for the equivalent named-parameter loop.

The repository's own benchmarks do not move: `bench-array` 0.03→0.02, `bench-hash` 0.03→0.02, `bench-class` 0.15→0.17, `bench-string`/`bench-ctor`/`bench-mandelbrot` unchanged. So it is a synthetic-shape cost, not a corpus-wide one. A lazy "promote only when the binding is observed" scheme would remove it and needs its own design; note that a cached source resolution is *not* the fix, since re-resolving per iteration is what makes row 38 work.

(Local A/B numbers, for the ADR's own acceptance criterion — no repository document cites them; the bench CI stays the source of truth.)

## §5 Q1, answered by measurement rather than by the guard it anticipated

Slice 1 was protected from ADR-0027's capture freeze because an `is rw` parameter never enters `loop_local_vars`. The topic is not gated that way — but it is excluded from `loop_param_names` by an explicit `name != "_"` filter, so a promoted cell never reaches `compute_owned_captures`' unguarded primary branch or `freeze_readonly_owned_captures` either, and **no guard turned out to be needed**. Rather than add an unexercised one, I pinned the shape that would break first if that filter ever changed: the topic form of rows 11/20 (a read-only closure over `$_` seeing a later element write).

## Verification

- `make test`: PASS (after rebasing onto `main` with #7064's `$self` env-key change and #7067).
- The **entire roast whitelist** on release — 1436 files, 218 817 tests — PASS, except `S32-str/{gb18030,gb2312,shiftjis}-encode-decode.t`, which fail identically on the pre-change baseline binary in this environment. Widened from slice 1's targeted sweep because the topic path reaches far more than the `is rw` path did. Full `make roast` still delegated to CI.
- All 16 ADR-named pins plus the four files the exposed bugs touched: PASS.
- ADR-0045 §1.3 re-measured against `raku`: the only remaining divergences are slice 4's (16, 17, 24, 39) and slice 5's (19, 28, 30).

## Notes for slice 4

Recorded in ADR-0045 §8 so they don't get lost:

- **`.sort` needs a source *tag*, not just a producer** — `for_iterable_source_name` doesn't match `.sort` at all, so row 24 has no `container_binding` for a producer change to hook.
- **`.kv` is the multi-parameter shape** (row 16, and the still-divergent `%h.kv -> $k, $v is rw`): it binds through the bind-prefix `Stmt::Assign`s, not the native bind site these slices converted, so it needs the producer to hand out containers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
