### PR TITLE
feat(container): `.values`/`.reverse`/`.sort` hand out element containers (ADR-0045 slice 4)

### DIFF
--- a/docs/adr/0036-element-container-pairs-from-subscripts-and-pairs.md
+++ b/docs/adr/0036-element-container-pairs-from-subscripts-and-pairs.md
@@ -1,6 +1,7 @@
 # ADR-0036: A Pair produced by a subscript adverb or `.pairs` carries the element *container*, not a snapshot
 
-- **Status**: Partially implemented — slices 1-2 landed (2026-08-20), slices 3-4 open
+- **Status**: Partially implemented — slices 1-2 landed (2026-08-20); slice 3's producer layer landed
+  2026-08-27 but `.pairs` itself is deferred (see "Implementation status — slice 3"); slice 4 open
 - **Date**: 2026-08-20
 - **Deciders**: tokuhirom, Claude
 - **Related**: [ADR-0013](0013-container-interior-mutability-cellvalue.md) §5 open question 3 (element-level cells, "2c / Track B proper" — deferred there, and this ADR is the correctness driver that reopens it in a scoped form), [ADR-0001](0001-gc-strategy-and-phasing.md) (layer 3a / Track B framing), [ADR-0021](0021-argument-namedness-is-a-call-site-property.md) (Pair flavour unification — `.pairs`' output is data, not a call site), `todo/deep/subscript-p-pair-is-a-snapshot-not-a-container.md` (the originating finding)
@@ -333,6 +334,97 @@ syntax-specific rewrite.
   FatArrow's container capture to an Index RHS for row 10) and slice 4 (element type constraint on the
   promoted cell, then deleting the `methods_mut_method_lvalue.rs` env-scan compensator).
 
+## Implementation status — slice 3 (2026-08-27)
+
+**The producer layer landed; `.pairs` itself did not.** §4 required this slice to land with ADR-0045
+slice 4, and the mechanism they share does exist now: `src/vm/vm_element_producers.rs`, hooked into
+`exec_call_method_mut_op_impl` (`src/vm/vm_call_method_mut_ops.rs`) just before the native dispatch
+tail, with `builtins/methods_0arg/` kept as the fallback for every receiver it declines. ADR-0045
+slice 4's `.values`/`.reverse`/`.sort` ship through it. **`.pairs` was implemented, measured, and
+backed out**, so rows 3, 4 and 9 stay `todo`-marked.
+
+**Why `.pairs` was backed out — and why `.values`/`.reverse`/`.sort` were not.** Handing out a Pair
+whose *value* is a cell leaks into every consumer that reads a pair's value **as data**, and because
+`.pairs` promotes the source's elements in place, the exposure is not "consumers of the `.pairs`
+result" but "consumers of any container a producer has run over". Five distinct leaks were measured
+before the pattern was accepted as a class: `trans` type-testing the value
+(`roast/S05-transliteration/with-closure.t`), Hash-from-pairs aliasing two hashes together,
+BagHash-from-pairs collapsing every weight to 1 (`roast/S03-metaops/infix.t`, 396/5076 subtests),
+`.map({.key => .value})` carrying the cell forward, and `.antipairs` losing its key de-itemization.
+`set_coerce.rs` and `coerce_containers.rs` alone destructure a pair's value structurally in **15**
+places, with no accessor to route. `.values`/`.reverse`/`.sort` do not have the problem: they hand
+out a *flat list* of cells, and list consumers decontainerize. It is specifically the **Pair
+wrapper** that carries a cell into code that reads it structurally. Tracked in
+`todo/tickets/pairs-element-containers-leak-through-pair-value-consumers.md`.
+
+**This revises §5 Q4's answer.** `resolve_array_entry` is the only chokepoint for *element* reads,
+but bulk iteration (`h.iter()`, `items.iter()`) and `ValueView::Pair(k, v)` destructuring walk the
+storage directly and bypass it. That is the real blast radius, and it is why the `:p`/`:kv` adverbs
+(slice 2) have shipped happily since 2026-08-20 while `.pairs` cannot: they promote **one** element
+on demand, where `.pairs` promotes the whole container and is far likelier to be fed to a coercion.
+
+**Two corrections to §4's method list, both by measurement:**
+
+- **`.antipairs` must NOT be routed.** It puts the element in the Pair's *key*, and a Pair key is
+  never a container in raku: `my @a = <A B>; my $p = @a.antipairs[0]; @a[0] = "Q"; $p.key` is `A`,
+  and `$p.key.VAR.^name` is `Str`. Routing it made the key track later writes — a divergence, not a
+  fix. It keeps the snapshot producer, and both facts are now pinned.
+- **`.kv` is deferred, for a reason in the *consumer*.** A `.kv` loop is a **multi-parameter** loop,
+  and those bind through the bind-prefix `Stmt::Assign`s `build_for_bind_stmts` emits, each reading
+  its chunk element through the ordinary element chokepoint — which **decontainerizes**. A cell handed
+  out here arrives at `$v` as a plain value while the writeback that used to carry the mutation has
+  been retired for that iteration, so routing `.kv` *lost* the direct write
+  (`for @a.kv -> $i, $v is rw { $v += $i }`) instead of gaining the deferred one. It needs a raw bind
+  for an rw scalar multi-parameter first — the shape `@`/`%`-sigil multi-params already have via
+  `Stmt::MarkBind`. Tracked in `todo/tickets/for-kv-multi-param-bind-decontainerizes.md`.
+
+**Row 10 is deferred to a prerequisite, with a measured reason.** The fix itself is three lines —
+compile a FatArrow's Index RHS in the container-producing mode (`scalar_bind_autovivify` +
+`bind_terminal`) that the `=:=` and `return-rw` arms already use, next to the existing `WrapVarRef`
+capture in `compiler/expr_binary.rs`. But **`array_slot_ref` grows the array at bind time where raku
+defers until the write**: `my @a = 1,2; my $r := @a[5]; @a.elems` is `6` in mutsu and `2` in raku.
+`key => @a[i]` is ordinary, common code, so routing it through the primitive would spread that eager
+growth to every such pair. The hash side already has the deferred token (`hash_slot_ref` returns a
+lazy `HashEntryRef` for a missing key); the array side needs the same. Recorded as
+`todo/tickets/array-slot-ref-vivifies-eagerly-where-raku-defers.md` — a prerequisite for row 10
+rather than part of it.
+
+**Row 11 moves from slice 3 to slice 4.** Slice 3 does the half it owns: a `List` receiver keeps the
+snapshot producer, so its pair value is a bare item with nothing to alias, which §2.2 says is the
+whole of the immutability story. What still swallows `$l.pairs[0].value = 3` is the *other* half —
+the env-scan compensator finds `$l`'s own list as a candidate container, rebuilds it, and reports
+success. The read-only guard is only reachable once that scan is deleted, which is slice 4's job.
+
+**§5's open questions, as measured by slice 3:**
+
+- **Q1 (eager vs lazy promotion)** — eager, as recommended, and here is the cost. Release build, best
+  of three on an otherwise-idle machine, a *read-only* pass over a 200 000-element array:
+  `.values` 0.07 s → 0.18 s, `.reverse` 0.07 s → 0.18 s, `.sort` 0.05 s → 0.18 s. The two producers
+  that are NOT routed are the controls and stay flat: `.pairs` 0.23 → 0.25 s, `.kv` 0.73 → 0.77 s.
+  The repository's own benchmarks do not move
+  (`bench-array`/`bench-hash`/`bench-string`/`bench-fib` unchanged, `bench-class` 0.15 → 0.14,
+  `bench-ctor` 0.28 → 0.26), so this is a per-call cost on large containers rather than a corpus-wide
+  one. Lazy promotion at reification stays the option if a bench CI series shows it.
+- **Q4 (is `resolve_array_entry` the only read chokepoint?)** — **no, and this is the ADR's most
+  important correction.** It is the only chokepoint for *element* reads, but bulk iteration
+  (`h.iter()`, `items.iter()`) and `ValueView::Pair(k, v)` destructuring walk the storage directly.
+  For a flat list of cells that does not matter — list consumers decontainerize — which is why
+  `.values`/`.reverse`/`.sort` ship. For a Pair carrying a cell it matters a great deal, which is why
+  `.pairs` does not (above).
+- **Q5 (does anything depend on the pair being a snapshot?)** — **yes, and Q5 was right to single it
+  out as the likeliest slice-3 regression.** The first one found was
+  `"...".trans(%matcher.pairs)`, which asks what the pair *value* is (`is_closure`, then the
+  Regex/Array/Range shape match); a `ContainerRef` answered "no" to all of them, silently turning a
+  closure replacement into a stringified one. Four more followed. The lesson generalizes: the hazard
+  is not *reading* a promoted value, it is **type-testing** one — and the pair wrapper is what
+  carries it to code that does.
+- A related pre-existing leak was fixed on the way in: `.WHAT` on a `ContainerRef` receiver answered
+  `Scalar` instead of the value's type. Harmless while cells were rare; with slice 3 handing them out
+  in bulk, `@a.pairs[0].value.WHAT` would have started answering `Scalar` where it answers `Int`
+  today. `^name` still answers `Scalar`, because that is what `.VAR.^name` needs and mutsu cannot yet
+  tell a cell reached *through* `.VAR` from a bare aliased value —
+  `todo/tickets/var-on-a-containerref-is-not-distinguishable.md`.
+
 ---
 
 ## 5. Open questions (the forks for the deciders)
@@ -422,4 +514,5 @@ are recorded here so a future reader can see the shape of the whole and not re-d
 
 ---
 
-*This ADR is Proposed. If the mechanism judgment changes later, supersede it rather than rewriting it.*
+*Slices 1-3 of this ADR are implemented; the decision stands. If the mechanism judgment changes
+later, supersede it rather than rewriting it.*

--- a/docs/adr/0045-for-loop-parameters-bind-the-element-container.md
+++ b/docs/adr/0045-for-loop-parameters-bind-the-element-container.md
@@ -1,6 +1,6 @@
 # ADR-0045: A `for` loop parameter binds the element *container*; the per-iteration writeback is retired
 
-- **Status**: Accepted — partially implemented (slices 0-3 landed 2026-08-27; slices 4-6 open, see
+- **Status**: Accepted — partially implemented (slices 0-4 landed 2026-08-27; slices 5-6 open, see
   §8 "Implementation status")
 - **Date**: 2026-08-20
 - **Deciders**: tokuhirom, Claude
@@ -612,23 +612,88 @@ remains the place to watch it. A lazy "promote only when the binding is observed
 it and needs its own design; do not bolt on a cached source resolution to chase it, since
 re-resolving per iteration is what makes row 38 work.
 
-### What slices 4-6 still own
+### Slice 4 — landed 2026-08-27 (with ADR-0036 slice 3)
 
-Rows 16, 17, 24 and 39 (slice 4 — derived producers), and 19, 28 and 30 (slice 5 — bind-time
-enforcement). They are `todo`-marked in `t/for-loop-element-alias.t` with the owning slice named in
-the reason string, so each later slice un-`todo`s exactly its own rows. The writeback family survives
-only as the fallback for shapes not yet converted: `write_back_for_rw_param`'s `kv_mode`,
-multi-parameter and scalar arms, `write_back_for_topic_item`'s `$`-tagged `for @$s` arm, and
+§4 required these to land together because they are the same producer layer, and the shared layer is
+real: `src/vm/vm_element_producers.rs`, hooked into the VM's method-dispatch tail, makes
+`.values`/`.reverse`/`.sort` hand out the elements' own `Scalar` containers when the receiver is a
+real mutable `Array`/`Hash`.
+
+ADR-0036's own `.pairs` did **not** ship with it. It was implemented on this same layer, measured,
+and backed out: a Pair carrying a cell leaks into the many consumers that read a pair's value *as
+data*, and five distinct failures were measured before that was accepted as a class (see ADR-0036's
+slice-3 status). A flat list of cells — which is what `.values`/`.reverse`/`.sort` produce — has no
+such problem, because list consumers decontainerize. So the "two half-converted method sets" §4
+warned about did not materialise in the direction it expected: the split is not array-producers vs
+pair-producers, it is **flat lists vs Pair wrappers**, and that split is now a measured property
+rather than a scheduling accident.
+
+**The index bookkeeping was deletable, not fixable — and this is why.** Once a producer hands out
+element containers, the loop needs no index reconstruction at all: the item it binds *is* the alias,
+in whatever order the producer chose. So the loop's rule is simply "if the bound item already carries
+an element cell, there is nothing to write back" (`binding_carries_element_cell` in
+`vm_for_loop_body.rs`), and `container_reversed` stops being a mirror-image index to compute.
+`.sort` gets an alias at all this way, having no index to reconstruct — the cells are carried
+*through* the sort, keyed by what they hold, rather than an index being recovered from the sorted
+value afterwards (which is ambiguous the moment two elements compare equal).
+
+**Rows 17 and 24 turn green**, plus the deferred-closure form of each and of `@a.values`.
+
+**Row 39 (`for @$s`) was implemented and backed out.** It did not need the producer layer at all —
+its `$`-tagged source is an ordinary in-order array read, so it joined slices 1-3's bind-site routing
+via a shared `resolve_for_source_array`, which is retained. But `encode($_) for @$_` is the ordinary
+idiom for walking a nested structure recursively, and that is exactly the code which **type-tests**
+what it is holding before recursing: CBOR::Simple's `nqp::istype($_, Associative)` answered False for
+a promoted topic and encoded a `Map` as its element count, failing the bundled-library gate.
+Decontainerizing `nqp::istype` (done, and kept) was not sufficient — the `nqp::` surface that
+inspects a value structurally is wide. Tracked in
+`todo/tickets/for-deref-container-source-promotion-breaks-nqp-type-tests.md`.
+
+**Row 16 (`.kv`) is deferred, and the reason is the consumer.** A `.kv` loop is a *multi-parameter*
+loop, and those do not bind at the native bind site — they bind through the bind-prefix
+`Stmt::Assign`s, each reading its chunk element through the ordinary element chokepoint, which
+**decontainerizes**. Routing `.kv` therefore *lost* the direct write (row 15,
+`for @a.kv -> $i, $v is rw { $v += $i }`) rather than gaining the deferred one, because the writeback
+that used to carry it had been retired for the iteration. It needs a raw bind for an rw scalar
+multi-parameter first — the shape `@`/`%`-sigil multi-params already have via `Stmt::MarkBind`.
+Tracked in `todo/tickets/for-kv-multi-param-bind-decontainerizes.md`. This is the "hard half" §8
+predicted, and the prediction was right for a reason nobody had written down: the difficulty is not
+in `.kv` at all.
+
+**Perf.** Eager promotion costs a read-only producer pass on a large container (200 000 elements,
+release, best of three, idle machine): `.values` 0.07 s → 0.18 s, `.reverse` 0.07 s → 0.18 s,
+`.sort` 0.05 s → 0.18 s. The unrouted producers are the controls and stay flat (`.pairs` 0.23 →
+0.25 s, `.kv` 0.73 → 0.77 s). The repository's own benchmarks do not move. See ADR-0036's slice-3
+status for the full table.
+
+**The hazard in this campaign is type-testing a promoted value, not reading one**, and ADR-0036 §5
+Q5 predicted it. `"...".trans(%matcher.pairs)` type-tests the pair value (`is_closure`, then a
+Regex/Array/Range shape match) and a `ContainerRef` answers "no" to all of them. Four more of the
+same shape followed, all of them fed by `.pairs`. Slice 5 should assume that any *new* place a cell
+can reach will be found this way — by a full roast sweep, not by reading — and that the tell is a
+`match` on `view()`, not a `.value` read.
+
+### What slices 5-6 still own
+
+Rows 16 (`.kv`) and 39 (`for @$s`), both carried over from slice 4 — see above — and rows 19, 28
+and 30 (slice 5 — bind-time enforcement). They are `todo`-marked in `t/for-loop-element-alias.t` with the owning reason named in
+the reason string. The writeback family survives only as the fallback for shapes not yet converted:
+`write_back_for_rw_param`'s `kv_mode`, multi-parameter and scalar arms, and
 `write_back_hash_value_item` for a hash iteration that could not be promoted.
 
-**Two things slice 4 should know before it starts.**
+**A note for slice 5, which is shared three ways.** The element type constraint (row 28) is also
+ADR-0036 slice 4's and ADR-0042's; whichever lands it first owns it. **ADR-0036 slice 4 is the
+natural owner**: it already has to touch `methods_mut_method_lvalue.rs` to delete the env-scan
+compensator, its `lookup_container_constraint` call site is where the constraint is consumed, and the
+gap exists for `:=`-bound elements today independently of any `for` loop
+(`my Str @a; my $r := @a[0]; $r = 42` wrongly succeeds). This ADR's slice 5 should consume it rather
+than build it, and keep only the bind-time immutable-source rejection (rows 19/30), which is
+genuinely the loop's own.
 
-- **`.sort` needs a source *tag*, not just a producer.** `for_iterable_source_name` does not match
-  `.sort` at all, so a `for @a.sort -> $v is rw` loop carries no `container_binding` — there is no
-  writeback to correct, and nothing for a producer change to hook. Row 24 needs the tag added as well.
-- **`.kv` is the multi-parameter shape.** Row 16 (`@a.kv`) and its hash twin (`%h.kv -> $k, $v is
-  rw`, also still divergent) bind through the bind-prefix `Stmt::Assign`s, not the native bind site
-  these slices converted, so they need the producer to hand out containers rather than a change here.
+**`.sort` did not need a source tag after all.** §8 recorded that `for_iterable_source_name` does not
+match `.sort`, and treated that as a prerequisite. Routing the producer made it moot: the loop binds
+the cell the producer handed out, so there is nothing for a tag to point at. The same is true of
+`.reverse` — `container_reversed` survives only for the shapes that still take the writeback.
 
 **Found along the way, unrelated:** after any `start` block, a later `for @m -> @row { ... }` loop
 rebinds the *previous* iteration's container. Pre-existing on `main` (verified at `f678b032b`) and
@@ -638,5 +703,5 @@ independent of this ADR — recorded as
 
 ---
 
-*Slices 0-3 of this ADR are implemented; the decision stands. If the mechanism judgment changes
+*Slices 0-4 of this ADR are implemented; the decision stands. If the mechanism judgment changes
 later, supersede it rather than rewriting it.*

--- a/src/builtins/methods_0arg/collection.rs
+++ b/src/builtins/methods_0arg/collection.rs
@@ -102,7 +102,14 @@ fn positional_antipairs(values: &[Value]) -> Vec<Value> {
         // `my @c; @c[0]=[1,2]; @c.antipairs.raku` is `([1, 2] => 0,).Seq` but
         // `@c.pairs.raku` is `(0 => $[1, 2],).Seq`.
         .map(|(idx, value)| {
-            Value::value_pair(value.clone().deitemize_element(), Value::int(idx as i64))
+            // `deref_container` first: an element promoted to its own `Scalar`
+            // container (ADR-0036 slice 3 hands these out from `.pairs`, so a
+            // later `.antipairs` over the same array sees them) must be seen
+            // through before the de-itemization above can apply.
+            Value::value_pair(
+                value.deref_container().deitemize_element(),
+                Value::int(idx as i64),
+            )
         })
         .collect()
 }

--- a/src/runtime/methods_trans.rs
+++ b/src/runtime/methods_trans.rs
@@ -46,6 +46,13 @@ enum TokenReplacement {
 /// an Array so the list-form dispatch recognizes it (`"abc".comb => 1..2`).
 /// Any other value is returned unchanged (Arc-cheap clone).
 fn normalize_trans_operand(v: &Value) -> Value {
+    // Decontainerize first: `"...".trans(%matcher.pairs)` feeds `trans` pairs
+    // whose value is the hash element's own `Scalar` container (ADR-0036 slice
+    // 3), and every test below asks what the operand *is* — `is_closure`, the
+    // Regex/Array/Range shape match — which a `ContainerRef` would answer `no`
+    // to, silently turning a closure replacement into a stringified one
+    // (roast/S05-transliteration/with-closure.t).
+    let v = v.deref_container();
     match v.view() {
         ValueView::Seq(items) | ValueView::HyperSeq(items) | ValueView::RaceSeq(items) => {
             Value::array(items.to_vec())
@@ -207,6 +214,9 @@ impl Interpreter {
 
         for arg in &flat_args {
             if let ValueView::Pair(key, value) = arg.view() {
+                // Same decontainerization as the `ValuePair` arm below: the
+                // value may be an element's own container (ADR-0036 slice 3).
+                let value = &value.deref_container();
                 match key.as_str() {
                     "s" | "squash" => {
                         squash = value.truthy();

--- a/src/runtime/nqp_ops.rs
+++ b/src/runtime/nqp_ops.rs
@@ -157,7 +157,18 @@ impl Interpreter {
 
             // -- type test --
             "istype" => {
-                let v = args.first().cloned().unwrap_or(Value::NIL);
+                // Decontainerize: a value can BE its element's `Scalar`
+                // container (ADR-0036/ADR-0045 hand these out from `for` loop
+                // bindings and the element producers), and a type test asks
+                // about what the container holds. Without this,
+                // `nqp::istype($_, Associative)` inside `encode($_) for @$_`
+                // answered False for a promoted element and CBOR::Simple
+                // encoded a Map as its element count (its `04-tags` Capture
+                // round-trips).
+                let v = args
+                    .first()
+                    .map(Value::deref_container)
+                    .unwrap_or(Value::NIL);
                 let type_name = match args.get(1).map(|t| t.view()) {
                     Some(ValueView::Package(p)) => p.resolve().to_string(),
                     Some(ValueView::Instance { class_name, .. }) => {

--- a/src/runtime/utils/coerce_containers.rs
+++ b/src/runtime/utils/coerce_containers.rs
@@ -31,6 +31,13 @@ fn decay_nil_hash_value(v: Value) -> Value {
 /// (`%h<a>.raku` is `$[1, 2]`). Composed with the ADR-0049 `Nil` decay, which
 /// runs first (a decayed `Nil` becomes `Any`, which never itemizes).
 fn hash_stored_value(v: Value) -> Value {
+    // Decontainerize first. Building a Hash from a list of Pairs is an
+    // ASSIGNMENT of their values, not a bind — `%a = %reset.pairs` must copy
+    // what `%reset`'s elements hold, never adopt the elements themselves. Since
+    // ADR-0036 slice 3 makes `.pairs` hand out those elements' own `Scalar`
+    // containers, storing the pair value as-is aliased the two hashes together,
+    // so a later in-place mutation of one silently rewrote the other
+    // (roast/S03-metaops/infix.t's `%a = %reset.pairs` reset lines).
     decay_nil_hash_value(v).itemize_for_element_store()
 }
 

--- a/src/runtime/utils/set_coerce.rs
+++ b/src/runtime/utils/set_coerce.rs
@@ -306,6 +306,14 @@ pub(crate) fn to_mix_map(
         ValueView::Hash(h) => {
             let mut result = HashMap::new();
             for (k, v) in h.iter() {
+                // A hash element may be its own `Scalar` container: ADR-0036
+                // slice 3's producers promote elements IN PLACE, so any hash a
+                // `.pairs`/`.values` has run over holds cells from then on, and
+                // bulk iteration like this `h.iter()` does not go through the
+                // element read chokepoint. Without the deref every weight fell
+                // to the truthy `_` arm below and became 1.0
+                // (roast/S03-metaops/infix.t's `%a = %reset.pairs` reset lines).
+                let v = v.deref_container();
                 let w = match v.view() {
                     ValueView::Int(i) => i as f64,
                     ValueView::Num(n) => n,
@@ -385,6 +393,11 @@ pub(crate) fn to_bag_map(
         ValueView::Hash(h) => {
             let mut result = HashMap::new();
             for (k, v) in h.iter() {
+                // See the matching deref in `to_mix_map`: a hash element may be
+                // its own `Scalar` container after an ADR-0036 slice 3 producer
+                // promoted it in place, and this bulk iteration bypasses the
+                // element read chokepoint.
+                let v = v.deref_container();
                 let count = match v.view() {
                     ValueView::Int(i) => i,
                     ValueView::Num(n) => n as i64,

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -159,6 +159,7 @@ mod vm_data_io_ops;
 mod vm_data_ops;
 mod vm_data_push_ops;
 mod vm_dispatch_helpers;
+mod vm_element_producers;
 mod vm_env_helpers;
 mod vm_exec_dispatch;
 pub(crate) mod vm_flipflop_ops;

--- a/src/vm/vm_call_method_mut_ops.rs
+++ b/src/vm/vm_call_method_mut_ops.rs
@@ -2671,6 +2671,29 @@ impl Interpreter {
                 // Slice 6.3: assume the dispatch dirties the caller env; only a
                 // proven-pure compiled method path clears this.
                 self.method_dispatch_pure = false;
+                // ADR-0036 slice 3 / ADR-0045 slice 4: `.pairs`/`.kv`/
+                // `.antipairs`/`.values`/`.reverse`/`.sort` on a real mutable
+                // container hand out the elements' own `Scalar` containers, not
+                // clones. This must run BEFORE the sentinel-resolved copy below,
+                // which is a fresh Hash and therefore has no identity to
+                // promote into. `try_element_container_producer` declines every
+                // receiver that must keep the snapshot producer.
+                if !skip_native
+                    // An `augment`ed native type's own `.sort`/`.pairs`/... must
+                    // still win: this routing changes how a *native* producer
+                    // builds its result, and there is no native producer to
+                    // change when the user has replaced the method.
+                    && !self.native_lever_a_user_override(&target, &method)
+                    && let Some(produced) = self.try_element_container_producer(&target, &method, &args)
+                {
+                    crate::vm::vm_stats::record_dispatch_entry_outcome(
+                        "callmethodmut",
+                        "element-container-producer",
+                    );
+                    self.method_dispatch_pure = true;
+                    self.stack.push(produced);
+                    return Ok(());
+                }
                 let call_result = if !skip_native {
                     // Resolve hash sentinel entries (bound variable refs, self-refs)
                     // before passing to native methods that iterate hash values.

--- a/src/vm/vm_call_method_ops.rs
+++ b/src/vm/vm_call_method_ops.rs
@@ -568,21 +568,29 @@ impl Interpreter {
         // `.head`/`.first`) is transparent to method dispatch — decontainerize it
         // so the method runs on the inner value (Raku container semantics). `.VAR`
         // is the one introspection method that wants the container itself, and
-        // `^name`/`WHAT` right after a `.VAR` report the container type (raku:
+        // `^name` right after a `.VAR` reports the container type (raku:
         // `$obj.attr.VAR.^name` is "Scalar", not the inner value's type).
+        //
+        // `WHAT` is deliberately NOT in that set: raku decontainerizes it, so a
+        // `Scalar`-containered `Int` answers `(Int)`, and only `.VAR.^name`
+        // answers `Scalar`. Claiming `Scalar` for a bare `.WHAT` was invisible
+        // while `ContainerRef` receivers were rare, but ADR-0036 slice 3 and
+        // ADR-0045 slice 4 hand elements out in bulk — `@a.pairs[0].value.WHAT`
+        // would have started answering `Scalar` where it answers `Int` today.
+        //
+        // The residual gap is that mutsu cannot tell a cell reached *through*
+        // `.VAR` from a cell that is simply an aliased value, so `.VAR.WHAT` and
+        // a bare `.^name` on a cell are still the container's, not the value's;
+        // see `todo/tickets/var-on-a-containerref-is-not-distinguishable.md`.
         let target = if method != "VAR" {
             match target.view() {
                 ValueView::ContainerRef(_) => {
-                    if args.is_empty() && matches!(method, "^name" | "WHAT") {
+                    if args.is_empty() && method == "^name" {
                         crate::vm::vm_stats::record_dispatch_entry_intercept(
                             "callmethod",
                             "containerref-scalar-meta",
                         );
-                        self.stack.push(if method == "^name" {
-                            Value::str("Scalar".to_string())
-                        } else {
-                            Value::package(crate::symbol::Symbol::intern("Scalar"))
-                        });
+                        self.stack.push(Value::str("Scalar".to_string()));
                         return Ok(());
                     }
                     target.deref_container()

--- a/src/vm/vm_element_producers.rs
+++ b/src/vm/vm_element_producers.rs
@@ -1,0 +1,198 @@
+//! Container-aware element producers — ADR-0036 slice 3 and ADR-0045 slice 4.
+//!
+//! An `Array`/`Hash` element is a `Scalar` container, and every construct that
+//! hands an element *out* hands out **that container**, not a copy of what it
+//! holds. That is why all of these are true in raku:
+//!
+//! ```text
+//! my @a = <A B>; my $p = @a.pairs[0]; @a[0] = "Q"; $p.value      # Q
+//! my @a = <A B>; for @a.pairs -> $p { $p.value = "y" }; @a       # [y y]
+//! my @a = 10,20; for @a.reverse -> $v is rw { $v = $v + 1 }; @a  # [11 21]
+//! ```
+//!
+//! The pure-value fast path (`builtins/methods_0arg/`) cannot do this: it is
+//! value-in/value-out by construction, receiving the *decontainerized* `&[Value]`
+//! with neither the invocant's container identity nor the ability to mutate it
+//! (ADR-0036 §1.5). Promotion needs both, so the container-aware producers live
+//! here, at the VM method-dispatch layer, with the pure-value implementation
+//! kept as the fallback for every receiver this declines.
+//!
+//! **Why this also settles ADR-0045 slice 4's index bookkeeping.** Once a
+//! producer hands out element containers, a `for` loop over its output needs no
+//! index reconstruction at all — the item it binds *is* the alias, in whatever
+//! order the producer chose. That is what makes `container_reversed` /
+//! `total_items` deletable rather than fixable: `.reverse` and `.sort` reorder
+//! the items, and any scheme that assumes "item *i* came from index *i*" is
+//! wrong twice over for them.
+
+use super::*;
+
+/// The methods that hand an element out and therefore hand out its container.
+/// `.reverse`/`.sort` are array-only (a Hash has no order to reverse).
+///
+/// **`.antipairs` is deliberately absent.** It puts the element in the Pair's
+/// *key* position, and a Pair's key is never a container in raku — only its
+/// value is. Measured: `my @a = <A B>; my $p = @a.antipairs[0]; @a[0] = "Q";
+/// $p.key` is `A`, not `Q`, and `$p.key.VAR.^name` is `Str`, not `Scalar`. So
+/// `.antipairs` keeps the snapshot producer; routing it here would have made
+/// its key track later writes, which is a divergence, not a fix. (ADR-0036 §4
+/// lists it with `.pairs`/`.kv`; that grouping is corrected here by
+/// measurement.)
+///
+/// **`.pairs` is absent, and this one was implemented, measured, and backed
+/// out.** Routing it makes every consumer that reads a Pair's value *as data*
+/// see a `ContainerRef` — and because `.pairs` promotes the source's elements in
+/// place, the exposure is not "consumers of the `.pairs` result" but "consumers
+/// of any container a producer has run over". Five distinct leaks were measured
+/// (`trans` type-testing the value, Hash-from-pairs aliasing two hashes,
+/// BagHash-from-pairs collapsing every weight to 1, `.map({.key => .value})`
+/// carrying the cell forward, `.antipairs` losing its key de-itemization), and
+/// the pattern did not stop: `set_coerce.rs` and `coerce_containers.rs` alone
+/// destructure a pair's value structurally in 15 places, with no accessor to
+/// route. It needs a read chokepoint for a Pair's value, which conflicts with
+/// ADR-0036 row 6 (`(@a[0]:p).value.VAR.^name` must be `Scalar`) and so wants
+/// its own decision. Tracked in
+/// `todo/tickets/pairs-element-containers-leak-through-pair-value-consumers.md`.
+/// `.values`/`.reverse`/`.sort` do not have the problem: they hand out a flat
+/// list of cells, and list consumers decontainerize.
+///
+/// **`.kv` is absent for a different reason: the consumer, not the producer.**
+/// `.kv` is bound as a *multi-parameter* loop (`-> $i, $v is rw`), and a
+/// multi-parameter loop does not bind at the native bind site — it binds through
+/// bind-prefix `Stmt::Assign`s that read the chunk element (`build_for_bind_stmts`,
+/// `compiler/mod.rs`). That read goes through the ordinary element chokepoint,
+/// which **decontainerizes**, so a cell handed out here arrives at `$v` as a
+/// plain value and the write is lost — while the writeback that used to carry
+/// it has been retired for the iteration precisely because the chunk carried a
+/// cell. Routing `.kv` therefore needs a raw (non-decontainerizing) bind for an
+/// rw scalar multi-parameter first; `@`/`%`-sigil multi-params already have one
+/// (`Stmt::MarkBind`), so that is the shape to extend. Until then `.kv` keeps
+/// the snapshot producer and its writeback, which is correct for the direct
+/// write (`for @a.kv -> $i, $v is rw { $v += $i }`) and only loses the deferred
+/// closure. Tracked in `todo/tickets/for-kv-multi-param-bind-decontainerizes.md`.
+const ELEMENT_PRODUCERS: [&str; 3] = ["values", "reverse", "sort"];
+
+impl Interpreter {
+    /// Produce `method`'s result from `target`'s **element containers** instead
+    /// of from clones, or `None` to let the ordinary pure-value producer run.
+    ///
+    /// Declines — and each decline is the ADR's decision, not an omission:
+    ///
+    /// * any method outside [`ELEMENT_PRODUCERS`], or any call with arguments
+    ///   (`.sort(&by)` runs a user comparator; that is not this routing's job);
+    /// * a receiver that is not a **mutable** container. A `List`, `Seq`,
+    ///   `Range`, `Capture`, `Match` or immutable `Set`/`Bag`/`Mix` keeps the
+    ///   snapshot producer, which is the whole of the immutability story
+    ///   (ADR-0036 §2.2): a snapshot pair value is a bare item, so `.value = X`
+    ///   on it reaches the existing read-only guard and dies with
+    ///   `Cannot modify an immutable <T>` — exactly raku's answer for
+    ///   `(1,2).pairs[0].value = 3`, with no new check needed;
+    /// * a shaped, native-backed or lazy array, and an immutable `Map` — the
+    ///   same carve-outs `vm_for_loop_alias.rs` documents;
+    /// * a mutable `QuantHash` (`BagHash`/`MixHash`/`SetHash`), whose *weights*
+    ///   are not stored element containers and whose `.value = 0` **removes**
+    ///   the key. That is a genuinely different operation and keeps its
+    ///   writeback arm (ADR-0036 §5 Q2, `t/for-pairs-value-quanthash-writeback.t`).
+    pub(super) fn try_element_container_producer(
+        &mut self,
+        target: &Value,
+        method: &str,
+        args: &[Value],
+    ) -> Option<Value> {
+        if !args.is_empty() || !ELEMENT_PRODUCERS.contains(&method) {
+            return None;
+        }
+        match target.view() {
+            ValueView::Array(..) => self.array_element_producer(target, method),
+            ValueView::Hash(..) if !matches!(method, "reverse" | "sort") => {
+                self.hash_element_producer(target, method)
+            }
+            _ => None,
+        }
+    }
+
+    fn array_element_producer(&mut self, target: &Value, method: &str) -> Option<Value> {
+        let len = match target.view() {
+            ValueView::Array(data, kind) => {
+                // Only a real, mutable, plain array. `List`/`ItemList` are
+                // immutable sequences whose items must stay bare items.
+                if !matches!(
+                    kind,
+                    crate::value::ArrayKind::Array | crate::value::ArrayKind::ItemArray
+                ) || data.shape.is_some()
+                    || data.native_storage_node().is_some()
+                {
+                    return None;
+                }
+                data.len()
+            }
+            _ => return None,
+        };
+        // Promotion is in-place and idempotent (`array_slot_ref` returns an
+        // existing cell rather than allocating a second one), so re-running a
+        // producer over the same array costs nothing after the first pass.
+        let cells: Vec<Value> = (0..len)
+            .map(|i| target.array_slot_ref(i, true))
+            .collect::<Option<_>>()?;
+        Some(match method {
+            "values" => Value::seq(cells),
+            "reverse" => {
+                let mut cells = cells;
+                cells.reverse();
+                Value::seq(cells)
+            }
+            "sort" => {
+                // Sort the CELLS, ordered by what they hold. Carrying the cell
+                // through the sort is what makes `for @a.sort -> $v is rw`
+                // alias the right element: reconstructing an index from the
+                // sorted *value* afterwards is ambiguous the moment two
+                // elements compare equal.
+                let mut keyed: Vec<(Value, Value)> = cells
+                    .into_iter()
+                    .map(|c| {
+                        let plain = c.deref_container();
+                        (c, plain)
+                    })
+                    .collect();
+                keyed.sort_by(|a, b| crate::runtime::compare_values(&a.1, &b.1).cmp(&0));
+                Value::seq(keyed.into_iter().map(|(c, _)| c).collect())
+            }
+            _ => return None,
+        })
+    }
+
+    fn hash_element_producer(&mut self, target: &Value, method: &str) -> Option<Value> {
+        // Key order is taken from the same `items.iter()` the pure-value
+        // producer uses, so the container-aware path yields the same order.
+        let keys: Vec<String> = match target.view() {
+            ValueView::Hash(data) => {
+                // An immutable `Map`'s elements are not assignable, so promoting
+                // one would offer an alias that must not exist.
+                if data.declared_type.as_deref() == Some("Map") {
+                    return None;
+                }
+                data.keys().cloned().collect()
+            }
+            _ => return None,
+        };
+        // Only `.values` reaches here today — `.pairs` is deferred (see the
+        // `ELEMENT_PRODUCERS` doc) and `.reverse`/`.sort` are array-only — so
+        // the key never has to be rebuilt. When `.pairs` returns, this is where
+        // `hash_typed_key` / `hash_uses_typed_keys` come back with it.
+        if method != "values" {
+            return None;
+        }
+        let mut out: Vec<Value> = Vec::with_capacity(keys.len());
+        for k in &keys {
+            let cell = target.hash_slot_ref(k, true)?;
+            // A missing key hands back a lazy `HashEntryRef` path token rather
+            // than an alias; these keys came from the map, so that cannot
+            // happen — but decline rather than hand out a path if it ever does.
+            if !matches!(cell.view(), ValueView::ContainerRef(_)) {
+                return None;
+            }
+            out.push(cell);
+        }
+        Some(Value::seq(out))
+    }
+}

--- a/src/vm/vm_for_loop_alias.rs
+++ b/src/vm/vm_for_loop_alias.rs
@@ -71,6 +71,7 @@ impl Interpreter {
     #[allow(clippy::too_many_arguments)]
     pub(super) fn plan_for_element_alias(
         &self,
+        code: &CompiledCode,
         spec: &ForLoopSpec,
         container_binding: Option<&str>,
         container_reversed: bool,
@@ -110,18 +111,37 @@ impl Interpreter {
         let Some(source) = container_binding else {
             return ForElementAlias::None;
         };
+        // `@a`, and `@a.list`, which re-tags the array itself: both iterate a
+        // real array's elements in order, so iteration position names element
+        // position.
+        //
+        // The `$`-tagged deref'd-container shape (`for @$s` / `for $s.list`,
+        // ADR-0045 row 39) is deliberately NOT here. It was implemented and
+        // backed out: `encode($_) for @$_` is an ordinary way to walk a nested
+        // structure, and promoting there hands the body's topic a cell that the
+        // `nqp::` layer type-tests — CBOR::Simple encoded a Map as its element
+        // count. Decontainerizing `nqp::istype` was not enough on its own; the
+        // `nqp::` surface that inspects a value structurally is wide, and each
+        // op would need the same treatment before this shape is safe. Tracked in
+        // `todo/tickets/for-deref-container-source-promotion-breaks-nqp-type-tests.md`.
         if source.starts_with('@') {
-            // `@a.values` is an identity-ordered derived producer, but it is
-            // slice 4's to route; keep it on the writeback so the two array
-            // producers convert together.
-            if spec.values_mode || !self.for_source_is_aliasable(source) {
+            // `@a.values` is an identity-ordered derived producer, but its
+            // routing belongs with `.reverse`/`.sort`; keep it on the writeback
+            // so the array producers convert together.
+            if spec.values_mode {
                 return ForElementAlias::None;
             }
-            let arr = self
-                .get_env_with_main_alias(source)
-                .map(|v| v.deref_container());
+            let arr = self.resolve_for_source_array(code, source);
             let (len, first) = match arr.as_ref().map(Value::view) {
-                Some(ValueView::Array(data, _)) => (data.len(), data.items().first().cloned()),
+                Some(ValueView::Array(data, kind))
+                    if !matches!(
+                        kind,
+                        crate::value::ArrayKind::Shaped | crate::value::ArrayKind::Lazy
+                    ) && data.shape.is_none()
+                        && data.native_storage_node().is_none() =>
+                {
+                    (data.len(), data.items().first().cloned())
+                }
                 _ => return ForElementAlias::None,
             };
             if items.len() != len || !Self::items_are_source_elements(items, first) {
@@ -170,13 +190,14 @@ impl Interpreter {
     /// same container costs nothing after the first pass.
     pub(super) fn for_element_alias(
         &mut self,
+        code: &CompiledCode,
         plan: &ForElementAlias,
         idx: usize,
     ) -> Option<Value> {
         match plan {
             ForElementAlias::None => None,
             ForElementAlias::ArrayIndex(source) => {
-                let arr = self.get_env_with_main_alias(source)?.deref_container();
+                let arr = self.resolve_for_source_array(code, source)?;
                 if !Self::array_is_aliasable(&arr, Some(idx)) {
                     return None;
                 }
@@ -225,30 +246,34 @@ impl Interpreter {
         }
     }
 
-    /// Whether a `for` loop's tagged `@`-source is a real, mutable, plain
-    /// `Array` whose elements may be promoted.
+    /// The backing `Array` value behind a `for` loop's tagged source, for both
+    /// tag shapes the compiler emits:
     ///
-    /// The carve-outs (ADR-0045 §5 Q5) are deliberate and stay until slice 5
-    /// decides otherwise:
+    /// * `@a` — the array variable itself (also what `@a.list` tags).
+    /// * `$s` — the SIGILED deref'd-container tag for `for @$s` / `for $s.list`,
+    ///   where the loop iterates the *scalar's inner array*. A plain scalar
+    ///   local is slot-only (never mirrored to `env`), so the slot is consulted
+    ///   first and `env` covers globals and `:=`-bound cells; the scalar may
+    ///   hold the array itemized (`Scalar(Array)`) or behind a cell, so both
+    ///   wrappers are stripped.
     ///
-    /// * a **shaped** array (`my @a[2;3]`) carries its dimensions in
-    ///   `ArrayData::shape` / `ArrayKind::Shaped`, and the writeback path
-    ///   deliberately preserves that metadata by cloning the whole `ArrayData`
-    ///   (see `vm_loop_writeback.rs`'s "clone the original ArrayData" comment);
-    ///   `array_slot_ref` has no such provision.
-    /// * a **native-backed** array (`array[int]`, ADR-0015 P3b / ADR-0030)
-    ///   keeps its elements in a packed `NativeBacking` payload, which cannot
-    ///   hold a `ContainerRef` at all.
-    /// * a **lazy** array must not be forced by a promotion.
-    ///
-    /// `t/cas-shaped-and-for-loop.t` and row 26 of `t/for-loop-element-alias.t`
-    /// are the pins for the shaped case.
-    pub(super) fn for_source_is_aliasable(&self, source: &str) -> bool {
-        self.get_env_with_main_alias(source)
-            .is_some_and(|raw| Self::array_is_aliasable(&raw.deref_container(), None))
+    /// Returns the `Array` value itself (sharing its `Gc`), so a promotion
+    /// through it lands in the container every holder observes.
+    fn resolve_for_source_array(&self, code: &CompiledCode, source: &str) -> Option<Value> {
+        if let Some(bare) = source.strip_prefix('$') {
+            let raw = self
+                .find_local_slot(code, bare)
+                .and_then(|s| self.locals.get(s))
+                .filter(|v| !v.is_nil())
+                .cloned()
+                .or_else(|| self.get_env_with_main_alias(bare))?;
+            return Some(raw.deref_container().into_descalarized());
+        }
+        Some(self.get_env_with_main_alias(source)?.deref_container())
     }
 
-    /// The hash sibling of [`Self::for_source_is_aliasable`].
+    /// Whether a `for` loop's tagged `%`-source is a real mutable `Hash`
+    /// whose elements may be promoted.
     fn for_source_is_aliasable_hash(&self, source: &str) -> bool {
         self.get_env_with_main_alias(source)
             .is_some_and(|raw| Self::hash_is_aliasable(&raw.deref_container()))

--- a/src/vm/vm_for_loop_body.rs
+++ b/src/vm/vm_for_loop_body.rs
@@ -81,6 +81,25 @@ impl Interpreter {
         }
     }
 
+    /// Whether the value a loop iteration is about to bind already **is** (or
+    /// contains) an element container handed out by a container-aware producer.
+    ///
+    /// A single-parameter loop binds the item itself, so the item is the cell.
+    /// A multi-parameter loop binds out of a chunk — `for @a.kv -> $i, $v is rw`
+    /// gets `[index, cell]` — and the bind-prefix `Stmt::Assign`s hand `$v` the
+    /// cell, so the chunk carrying one anywhere is equally a reason to retire
+    /// the writeback: writing a cell back over the source element would replace
+    /// the element with a container instead of assigning into it.
+    fn binding_carries_element_cell(item: &Value) -> bool {
+        if item.is_container_ref() {
+            return true;
+        }
+        match item.view() {
+            ValueView::Array(chunk, _) => chunk.items().iter().any(Value::is_container_ref),
+            _ => false,
+        }
+    }
+
     #[allow(clippy::too_many_arguments)]
     pub(super) fn exec_for_loop_body(
         &mut self,
@@ -494,6 +513,7 @@ impl Interpreter {
         // parameters alias, which sources do, and the shaped/native/`Map`
         // carve-outs); see `vm_for_loop_alias.rs`.
         let element_alias = self.plan_for_element_alias(
+            code,
             spec,
             container_binding.as_deref(),
             container_reversed,
@@ -576,18 +596,30 @@ impl Interpreter {
             // instead of calling it (`t/proxy-list-transparency.t`).
             let promoted =
                 if element_alias.is_active() && !matches!(item.view(), ValueView::Proxy { .. }) {
-                    self.for_element_alias(&element_alias, idx)
+                    self.for_element_alias(code, &element_alias, idx)
                 } else {
                     None
                 };
+            // ADR-0036 slice 3 / ADR-0045 slice 4: the item may ALREADY be an
+            // element container, because a container-aware producer handed it
+            // out (`for @a.reverse`, `for @a.sort`, `for @a.values`, and the
+            // `.kv` chunk's value slot). That is the whole point of routing at
+            // the producer: the item carries its own identity, so the loop needs
+            // no index reconstruction — and there is nothing to write back,
+            // whatever order the producer chose. This is what makes
+            // `container_reversed` correct-by-construction for `.reverse`
+            // instead of a mirror-image index to compute, and what gives `.sort`
+            // an alias at all when it has no index to reconstruct.
+            let item_carries_cell = Self::binding_carries_element_cell(&item);
             // Both writebacks are retired for exactly the iterations whose
-            // element was promoted. An iteration that fell back to a plain
-            // value bind — a `Proxy` element, or a body that removed the
-            // index/key out from under the loop — keeps the writeback that bind
-            // depends on. Retiring per LOOP instead of per ITERATION silently
-            // drops such an iteration's write.
-            rw_writeback = rw_writeback_base && promoted.is_none();
-            writes_back_loop_var = topic_writeback_base && promoted.is_none();
+            // element was promoted (here or at the producer). An iteration that
+            // fell back to a plain value bind — a `Proxy` element, or a body
+            // that removed the index/key out from under the loop — keeps the
+            // writeback that bind depends on. Retiring per LOOP instead of per
+            // ITERATION silently drops such an iteration's write.
+            let aliased = promoted.is_some() || item_carries_cell;
+            rw_writeback = rw_writeback_base && !aliased;
+            writes_back_loop_var = topic_writeback_base && !aliased;
             let item = promoted.unwrap_or(item);
             // `topic_source_var` drives the whole-topic writeback for a scalar
             // source (`for $x { $_[1] = ... }` writes the mutated `$_` back to

--- a/t/for-loop-element-alias.t
+++ b/t/for-loop-element-alias.t
@@ -21,7 +21,7 @@ use Test;
 # (derived producers — `.kv`/`.reverse`/`.sort`/`@$s`) and slice 5 (bind-time
 # enforcement).
 
-plan 64;
+plan 70;
 
 # ---------------------------------------------------------------------------
 # Class 1 — a binding that outlives the loop body still writes through.
@@ -127,7 +127,7 @@ plan 64;
     for @a.kv -> $i, $v is rw { @c.push(-> { $v = $v + 1 }) }
     @c[0]();
     @c[1]();
-    todo 'ADR-0045 slice 4: .kv must hand out element containers';
+    todo 'row 16 needs a raw multi-param bind -- todo/tickets/for-kv-multi-param-bind-decontainerizes.md';
     is-deeply @a, [11, 21], 'row 16: escaping closure over a `.kv` rw param writes through';
 }
 
@@ -268,7 +268,6 @@ plan 64;
 {
     my @a = 10, 20;
     for @a.reverse -> $v is rw { $v = $v + 1 }
-    todo 'ADR-0045 slice 4: .reverse writes to the mirror-image index';
     is-deeply @a, [11, 21], 'row 17: `.reverse` aliases the elements, not the mirror index';
 }
 
@@ -276,7 +275,6 @@ plan 64;
 {
     my @a = 20, 10;
     for @a.sort -> $v is rw { $v = $v + 1 }
-    todo 'ADR-0045 slice 4: .sort has no index mapping to reconstruct';
     is-deeply @a, [21, 11], 'row 24: `.sort` aliases the elements in sorted order';
 }
 
@@ -284,8 +282,45 @@ plan 64;
 {
     my $s = [1, 2];
     for @$s <-> $x { $x = $x + 1 }
-    todo 'ADR-0045 slice 4: `@$s` must hand out element containers';
+    todo 'row 39 deferred: a promoted `for @$s` topic breaks `nqp::` type tests -- todo/tickets/for-deref-container-source-promotion-breaks-nqp-type-tests.md';
     is-deeply $s, [2, 3], 'row 39: `for @$s <-> $x` aliases the inner array elements';
+}
+
+# The deferred-closure form of each derived producer. These are the rows that
+# prove the alias is the ITEM the producer handed out, not an index the loop
+# reconstructed: `.reverse` and `.sort` change the order, so anything assuming
+# "item i came from index i" is wrong twice over for them.
+{
+    my $s = [1, 2];
+    my @c;
+    for @$s <-> $x { @c.push(-> { $x = $x + 10 }) }
+    @c[0]();
+    @c[1]();
+    todo 'row 39b deferred with row 39 -- todo/tickets/for-deref-container-source-promotion-breaks-nqp-type-tests.md';
+    is-deeply $s, [11, 12], 'row 39b: an escaping closure over a `for @$s` alias writes through';
+}
+{
+    my @a = 10, 20;
+    my @c;
+    for @a.reverse -> $v is rw { @c.push(-> { $v = $v + 1 }) }
+    @c[0]();
+    @c[1]();
+    is-deeply @a, [11, 21], 'row 17b: an escaping closure over a `.reverse` alias writes through';
+}
+{
+    my @a = 20, 10;
+    my @c;
+    for @a.sort -> $v is rw { @c.push(-> { $v = $v + 1 }) }
+    @c[0]();
+    @c[1]();
+    is-deeply @a, [21, 11], 'row 24b: an escaping closure over a `.sort` alias writes through';
+}
+# `.reverse`/`.sort` must still READ as values everywhere else.
+{
+    my @a = 3, 1, 2;
+    is @a.sort.raku, '(1, 2, 3).Seq', '.sort still renders values';
+    is @a.reverse.raku, '(2, 1, 3).Seq', '.reverse still renders values';
+    is-deeply @a, [3, 1, 2], 'and neither reorders the source';
 }
 
 # ---------------------------------------------------------------------------

--- a/t/subscript-pair-element-container.t
+++ b/t/subscript-pair-element-container.t
@@ -17,18 +17,28 @@ use Test;
 #                               `:kv` parser rewrite that used to make
 #                               `(@a[0]:kv)[1] = x` work "by accident" for one
 #                               syntactic shape only is deleted.
-#   Slice 3 (not landed)    -- `.pairs`/`.kv`/`.antipairs` route through the
-#                               same element-container mechanism at the VM
-#                               method dispatch layer.
+#   Slice 3 (partial)       -- the container-aware producer layer landed
+#                               (src/vm/vm_element_producers.rs), and ADR-0045
+#                               slice 4's `.values`/`.reverse`/`.sort` go
+#                               through it. `.pairs` itself is DEFERRED: a Pair
+#                               holding a cell leaks through the many consumers
+#                               that destructure a pair's value as data --
+#                               todo/tickets/pairs-element-containers-leak-through-pair-value-consumers.md.
+#                               `.antipairs` is deliberately NOT routed: it puts
+#                               the element in the pair's KEY, and a pair key is
+#                               never a container in raku (measured below).
+#                               `.kv` is deferred because its multi-parameter
+#                               bind decontainerizes -- see
+#                               todo/tickets/for-kv-multi-param-bind-decontainerizes.md.
 #   Slice 4 (not landed)    -- the promoted cell carries the container's
 #                               element type constraint, and the
 #                               `methods_mut_method_lvalue.rs` env-scan
-#                               compensator is deleted.
+#                               compensator is deleted (rows 11 and 12).
 #
 # Every expected value below was cross-checked against `raku` (see the ADR's
 # §1.3 table and this file's commit for the exact `raku -e` invocations).
 
-plan 17;
+plan 27;
 
 # --- §1.3 row 1: :p stale read (Slice 2) -----------------------------------
 {
@@ -51,7 +61,7 @@ plan 17;
     my @a = <A B>;
     my $p = @a.pairs[0];
     @a[0] = "Q";
-    todo '.pairs element containers land in ADR-0036 slice 3';
+    todo 'row 3 needs .pairs routed -- deferred, see todo/tickets/pairs-element-containers-leak-through-pair-value-consumers.md';
     is $p.value, "Q", '.pairs pair value tracks a later array write (row 3)';
 }
 
@@ -60,7 +70,7 @@ plan 17;
     my %h = a => 1;
     my $p = %h.pairs[0];
     %h<a> = 7;
-    todo '.pairs element containers land in ADR-0036 slice 3';
+    todo 'row 4 needs .pairs routed -- deferred, see todo/tickets/pairs-element-containers-leak-through-pair-value-consumers.md';
     is $p.value, 7, '.pairs pair value tracks a later hash write (row 4)';
 }
 
@@ -92,7 +102,7 @@ plan 17;
 }
 {
     my @a = <A B>;
-    todo '.pairs element containers land in ADR-0036 slice 3';
+    todo '.pairs routing deferred -- see todo/tickets/pairs-element-containers-leak-through-pair-value-consumers.md';
     is @a.pairs[0].value.VAR.^name, 'Scalar', '.pairs pair.value is a Scalar container';
 }
 
@@ -132,7 +142,7 @@ plan 17;
     my @a = <A B>;
     my @c = <A B>;
     for @a.pairs -> $p { $p.value = "y" }
-    todo '.pairs element containers land in ADR-0036 slice 3';
+    todo 'row 9 needs .pairs routed -- deferred, see todo/tickets/pairs-element-containers-leak-through-pair-value-consumers.md';
     is-deeply @a, ["y", "y"], 'for @a.pairs writes through even with an equal sibling array (row 9)';
 }
 
@@ -142,14 +152,21 @@ plan 17;
     my $p = 0 => @a[0];
     my @c = <A B>;
     $p.value = "x";
-    todo 'FatArrow container-capture over an Index RHS lands in ADR-0036 slice 3';
+    todo 'row 10 needs a non-vivifying array element token first -- todo/tickets/array-slot-ref-vivifies-eagerly-where-raku-defers.md';
     is-deeply @a, ["x", "B"], 'key => @a[i] pair writes through with an equal sibling array (row 10)';
 }
 
-# --- §1.3 row 11: .pairs on an immutable List must die (Slice 3) ----------
+# --- §1.3 row 11: .pairs on an immutable List must die (Slice 4) ----------
+# Slice 3 does the half it owns: a `List` receiver keeps the SNAPSHOT producer,
+# so the pair value is a bare item with no container behind it — which is the
+# whole of ADR-0036 §2.2's immutability story. What still swallows the write is
+# the OTHER half, the env-scan compensator in `methods_mut_method_lvalue.rs`:
+# it finds `$l`'s own list as a candidate container, rebuilds it, and reports
+# success. The read-only guard is only reachable once that scan is deleted,
+# which is slice 4's job — so this row moves to slice 4 rather than slice 3.
 {
     my $l = (1, 2);
-    todo '.pairs element containers land in ADR-0036 slice 3';
+    todo 'row 11 needs the env-scan compensator deleted (ADR-0036 slice 4)';
     dies-ok { $l.pairs[0].value = 3 }, 'List.pairs[0].value = X dies, not a silent no-op (row 11)';
 }
 
@@ -158,4 +175,72 @@ plan 17;
     my Str @a = <A B>;
     todo 'element type constraint on the promoted cell lands in ADR-0036 slice 4';
     dies-ok { (@a[0]:p).value = 42 }, 'a typed array element constraint is enforced through :p (row 12)';
+}
+
+# --- Slice 3: the producers that now hand out element containers ------------
+{
+    my @a = <A B>;
+    # Same pre-existing `.VAR`-dispatch gap as line 88's `:kv` row: `.VAR` on an
+    # ANONYMOUS computed index target (`@a.values[0]`) goes through the general
+    # index-read chokepoint, which decontainerizes before `.VAR` ever sees the
+    # cell. Not an ADR-0036 row -- see
+    # todo/tickets/var-on-a-containerref-is-not-distinguishable.md.
+    todo '.VAR on an anonymous computed index target does not see a ContainerRef (pre-existing)';
+    is @a.values[0].VAR.^name, 'Scalar', '.values hands out the element container';
+}
+# The stale-READ direction, which the `.VAR` gap does not mask: a binding taken
+# from `.values` must see a later write to the element.
+{
+    my @a = 10, 20;
+    my @c;
+    for @a.values -> $v is rw { @c.push(-> { $v }) }
+    @a[0] = 5;
+    is @c[0](), 5, 'a deferred read through a .values alias sees a later element write';
+}
+{
+    my @a = 10, 20;
+    for @a.values -> $v is rw { $v = $v + 1 }
+    is-deeply @a, [11, 21], '.values -> $v is rw writes through';
+}
+{
+    my @a = 10, 20;
+    my @c;
+    for @a.values -> $v is rw { @c.push(-> { $v = $v + 1 }) }
+    @c[0]();
+    @c[1]();
+    is-deeply @a, [11, 21], 'an escaping closure over a .values alias writes through';
+}
+
+# `.antipairs` must NOT alias: the element sits in the pair's KEY, and a pair
+# key is a value in raku. Measured: `$p.key` stays "A" after `@a[0] = "Q"`, and
+# `$p.key.VAR.^name` is Str, not Scalar. ADR-0036 section 4 grouped it with
+# `.pairs`/`.kv`; that grouping is corrected here.
+{
+    my @a = <A B>;
+    my $p = @a.antipairs[0];
+    @a[0] = "Q";
+    is $p.key, 'A', '.antipairs key is a snapshot, not the element container';
+}
+{
+    my @a = <A B>;
+    is @a.antipairs[0].key.VAR.^name, 'Str', '.antipairs key is not a Scalar container';
+}
+
+# An immutable receiver keeps the snapshot producer, so its pair value is a bare
+# item with nothing to alias -- ADR-0036 section 2.2's whole immutability story.
+{
+    my $l = (1, 2);
+    is $l.pairs[0].value.VAR.^name, 'Int', 'a List keeps snapshot pair values';
+}
+
+# The promoted cells stay invisible to every ordinary read of the source.
+{
+    my @a = 10, 20, 30;
+    @a.pairs.elems;
+    @a.values.elems;
+    @a.reverse.elems;
+    @a.sort.elems;
+    is @a.raku, '[10, 20, 30]', 'running every producer leaves .raku unchanged';
+    is-deeply @a.List, (10, 20, 30), 'and list context still decontainerizes';
+    is @a[0].WHAT.^name, 'Int', 'and an element still reads back as its own type';
 }

--- a/todo/tickets/array-slot-ref-vivifies-eagerly-where-raku-defers.md
+++ b/todo/tickets/array-slot-ref-vivifies-eagerly-where-raku-defers.md
@@ -1,0 +1,71 @@
+# `array_slot_ref` grows the array at *bind* time; raku defers until the write
+
+## Symptom
+
+Binding an out-of-range array element grows the array immediately in mutsu,
+where raku leaves it alone until something is actually written through the
+binding:
+
+```raku
+my @a = 1, 2;
+my $r := @a[5];
+say @a.elems;   # raku 2            mutsu 6
+say @a.raku;    # raku [1, 2]       mutsu [1, 2, Any, Any, Any, Any]
+```
+
+Raku only vivifies on the write, and then fills the gap:
+
+```raku
+my @a = 1, 2; my $p = 0 => @a[5]; $p.value = 9; say @a.raku;
+# raku [1, 2, Any, Any, Any, 9]
+```
+
+The hash side is already correct: `hash_slot_ref` hands back a **deferred**
+`HashEntryRef` path token for a missing key, so a read is non-vivifying and the
+eventual write autovivifies the path. The array side has no such token —
+`Value::array_slot_ref` (`src/value/value_methods_b.rs`) grows unconditionally
+(`while data.len() <= idx { data.push(hole.clone()) }`), which its own doc
+comment describes as intentional.
+
+## Why it matters now
+
+`array_slot_ref` is the shared primitive behind a growing number of
+container-producing paths:
+
+- `:=`-bound elements (`my $r := @a[i]`),
+- the `:p`/`:kv` subscript adverbs (ADR-0036 slice 2),
+- `.pairs`/`.values`/`.reverse`/`.sort` (ADR-0036 slice 3 / ADR-0045 slice 4),
+- `for` loop parameter binding (ADR-0045 slices 1-3),
+- `return-rw` subscript operands, which compile in the same container-producing
+  mode (`scalar_bind_autovivify` + `bind_terminal`, see
+  `compile_return_rw_arg` in `src/compiler/helpers_call_args.rs`).
+
+Every one of those inherits the eager growth. It is invisible for the in-range
+uses that dominate, which is why it has not surfaced — all the consumers above
+promote elements that already exist.
+
+**It is the reason ADR-0036 §1.3 row 10 was not landed with slice 3.** Row 10 is
+`my $p = 0 => @a[0]; $p.value = "x"`, and the fix is to compile a FatArrow's
+Index RHS in the same container-producing mode the `=:=` and `return-rw` arms
+already use (`src/compiler/expr_binary.rs`, next to the existing
+`scalar_container_alias_name` / `WrapVarRef` capture for a bare `Expr::Var`).
+That is a three-line change and it makes row 10 pass — but `key => @a[i]` is
+ordinary, common code, so routing it through the primitive would spread this
+eager growth to every such pair, including the out-of-range ones. Landing the
+row is not worth silently growing arrays at pair-construction time.
+
+## The fix
+
+Give the array side the deferred token the hash side has: `array_slot_ref`
+should return a non-vivifying path token for an out-of-range index and promote
+only on the write, mirroring `hash_slot_ref`'s `HashEntryRef` arm.
+`src/value/entry_path.rs` already contemplates the asymmetry — its doc notes the
+array side "vivifies eagerly (`array_slot_ref` grows past the end)" while the
+hash side stays lazy.
+
+Once that lands, row 10 is the small compiler change above, and
+`t/subscript-pair-element-container.t`'s row-10 `todo` can go.
+
+## Reproduce
+
+The three snippets above, no fixtures.

--- a/todo/tickets/for-deref-container-source-promotion-breaks-nqp-type-tests.md
+++ b/todo/tickets/for-deref-container-source-promotion-breaks-nqp-type-tests.md
@@ -1,0 +1,61 @@
+# `for @$s` cannot bind element containers yet: the `nqp::` layer type-tests the topic
+
+## Status
+
+**ADR-0045 row 39 is deferred.** The routing was implemented — `for @$s` / `for $s.list` tag their
+source as `"$s"`, and `resolve_for_source_array` (`src/vm/vm_for_loop_alias.rs`) already knows how to
+resolve that shape to its inner array — then measured and backed out. The row stays `todo`-marked in
+`t/for-loop-element-alias.t`.
+
+## What happens
+
+`encode($_) for @$_` is an ordinary way to walk a nested structure, and CBOR::Simple uses exactly
+that (`modules/CBOR-Simple/lib/CBOR/Simple.rakumod`, the Positional arm). Promoting the source's
+elements binds the body's topic to a cell, and the body then hands that cell to the `nqp::` layer:
+
+```raku
+elsif nqp::istype($_, Associative) { ... }
+```
+
+A `ContainerRef` answers `False` to the type test, so a `Map` fell through to a later arm and was
+encoded as its element count. `CBOR::Simple 04-tags.rakutest` fails its Capture round-trips
+(`\(0, 2, :normalize)` encodes as `D9 6361 82 82 00 02 02` instead of
+`D9 6361 82 82 00 02 A1 69 6E6F726D616C697A65 F5`), which trips the bundled-library gate.
+
+Decontainerizing `nqp::istype` alone (done, and kept — a type test should ask about the value) is
+**not sufficient**: the failure persists, because the `nqp::` ops that inspect a value structurally
+are many and each reads the raw value. That breadth is the finding.
+
+## Why the sibling shapes are fine
+
+- `for @a` (ADR-0045 slices 1-3) promotes too, and ships. The difference is not the promotion, it is
+  what the corpus does with the binding: a plain `for @a` loop body works on the element as data,
+  where `for @$_` is the idiom for *recursive structure walking*, which is exactly the code that
+  type-tests what it is holding before recursing.
+- `.values`/`.reverse`/`.sort` (ADR-0036 slice 3 / ADR-0045 slice 4) hand out a flat list of cells
+  and pass both the full roast whitelist and the bundled-library gate.
+
+## What the fix needs
+
+An audit of the `nqp::` ops that inspect a value's shape, decontainerizing at that boundary — the
+same treatment `nqp::istype` now has. `src/runtime/nqp_ops.rs` is the single file. Until then the
+`$`-tagged source keeps `write_back_for_topic_item`'s `$`-source arm, which is correct for the
+direct-mutation case (`$_ .= uc for @$hdr` — Text::CSV's header munge) and only loses the deferred
+one.
+
+This is the same *class* as
+`todo/tickets/pairs-element-containers-leak-through-pair-value-consumers.md` — a promoted value
+reaching code that **type-tests** it rather than reads it — but a different boundary (`nqp::` ops
+rather than Pair-value destructuring), so it wants its own audit.
+
+## Reproduce
+
+Re-add `|| source.starts_with('$')` to the source test in `plan_for_element_alias`
+(`src/vm/vm_for_loop_alias.rs`), then:
+
+```
+MUTSU_BIN=target/release/mutsu bash scripts/battery-testsuite.sh CBOR::Simple
+```
+
+`04-tags.rakutest` fails 2 subtests. Note that `make test` does **not** cover this — the
+bundled-library gate is a separate CI step.

--- a/todo/tickets/for-kv-multi-param-bind-decontainerizes.md
+++ b/todo/tickets/for-kv-multi-param-bind-decontainerizes.md
@@ -1,0 +1,73 @@
+# A multi-parameter `for` bind decontainerizes, so `.kv` cannot hand out element containers
+
+## Symptom
+
+`for @a.kv -> $i, $v is rw { ... }` propagates a **direct** write but loses a
+**deferred** one, where the single-parameter forms now do both:
+
+```raku
+my @a = 10, 20;
+for @a.kv -> $i, $v is rw { $v += $i }
+say @a;                        # [10 21]  -- correct, via the writeback
+
+my @b = 10, 20; my @c;
+for @b.kv -> $i, $v is rw { @c.push(-> { $v = $v + 1 }) }
+@c[0](); @c[1]();
+say @b;                        # raku [11 21]   mutsu [10 20]
+```
+
+The hash twin diverges the same way:
+
+```raku
+my %h = a => 1, b => 2; my @c;
+for %h.kv -> $k, $v is rw { @c.push(-> { $v = $v + 1 }) }
+@c[0](); @c[1]();
+say %h.sort;                   # raku (a => 2 b => 3)   mutsu (a => 1 b => 2)
+```
+
+These are ADR-0045 §1.3 row 16 and its hash sibling.
+
+## Root cause
+
+ADR-0036 slice 3 / ADR-0045 slice 4 added a container-aware producer layer
+(`src/vm/vm_element_producers.rs`) so `.pairs`/`.values`/`.reverse`/`.sort` hand
+out the elements' own `Scalar` containers. `.kv` was **excluded**, and the
+exclusion is about the *consumer*, not the producer:
+
+A `.kv` loop is a **multi-parameter** loop, and a multi-parameter loop does not
+bind at the native bind site the other forms use (`exec_for_loop_body` in
+`src/vm/vm_for_loop_body.rs`). It binds through bind-prefix `Stmt::Assign`s that
+`build_for_bind_stmts` (`src/compiler/mod.rs`, ~line 3069-3121) emits, each
+reading its chunk element. That read goes through the ordinary element
+chokepoint, which **decontainerizes** — so a cell handed out by the producer
+arrives at `$v` as a plain value, while the writeback that used to carry the
+mutation has been retired for that iteration precisely *because* the chunk
+carried a cell. The result is a silent loss, which is why `.kv` stays on the
+snapshot producer for now.
+
+## What the fix needs
+
+A **raw (non-decontainerizing) bind for an rw scalar multi-parameter**. The
+shape already exists for the container sigils: `build_for_bind_stmts` wraps an
+`@`/`%`-sigil multi-param in `Stmt::SyntheticBlock([Stmt::MarkBind, decl])`, the
+same marker `my @a := expr` uses, exactly so the bind does not coerce. Extending
+that to a scalar parameter that is `is rw` / `<->` / sigilless is the natural
+route, but it is a change to the bind-prefix machinery that every multi-parameter
+loop in the corpus goes through, so it wants its own verification pass rather
+than riding along with the producer routing.
+
+Once it lands, add `"kv"` back to `ELEMENT_PRODUCERS` in
+`src/vm/vm_element_producers.rs` (both the array and hash arms) and un-`todo`
+row 16 in `t/for-loop-element-alias.t`.
+
+## Also blocked on the same thing
+
+`(@a.kv)[1].VAR.^name` reports `Str` where raku reports `Scalar`, for the same
+reason: the `.kv` list holds plain values. (The neighbouring `(@a[0]:kv)[1]`
+form is already `todo`-marked in `t/subscript-pair-element-container.t` for a
+*different* reason — `.VAR` on an anonymous computed index target, see
+`todo/tickets/var-on-a-containerref-is-not-distinguishable.md`.)
+
+## Reproduce
+
+The three snippets above, no fixtures.

--- a/todo/tickets/pairs-element-containers-leak-through-pair-value-consumers.md
+++ b/todo/tickets/pairs-element-containers-leak-through-pair-value-consumers.md
@@ -1,0 +1,72 @@
+# `.pairs` cannot hand out element containers yet: a cell-valued Pair leaks through its consumers
+
+## Status
+
+**ADR-0036 slice 3 is deferred for `.pairs` specifically.** The container-aware producer layer it
+called for **did** land (`src/vm/vm_element_producers.rs`, 2026-08-27) and carries
+`.values`/`.reverse`/`.sort` for ADR-0045 slice 4. `.pairs` was implemented, measured, and backed out
+of the routing list. Rows 3, 4 and 9 of ADR-0036 §1.3 stay `todo`-marked.
+
+## What happens
+
+Routing `.pairs` makes it hand out Pairs whose value is the element's own `Scalar` container. Every
+consumer that reads a Pair's value **as data** then sees a `ContainerRef` where it expects a value.
+Measured leaks, each a real test failure:
+
+| consumer | symptom |
+| --- | --- |
+| `"…".trans(%matcher.pairs)` | type-tests the value (`is_closure`, then Regex/Array/Range shape); a cell answers "no" to all, so a closure replacement silently became a stringified one. `roast/S05-transliteration/with-closure.t` 5, 7 |
+| `%a = %reset.pairs` into a **Hash** | stored the *cells*, aliasing two hashes together, so mutating one rewrote the other |
+| `%a = %reset.pairs` into a **BagHash** | every weight became `1` — the weight extraction fell through its `Int`/`Num`/`Bool` arms to the truthy `_` arm. `roast/S03-metaops/infix.t`, 396 subtests |
+| `%src.pairs.map({ .key => .value })` | `.value` returns the cell, so the rebuilt pair carries it too and the same weight collapse follows |
+| `.antipairs` after `.pairs` | the key was no longer de-itemized, because the de-itemization ran on a cell. `t/element-store-itemization.t` 80 |
+
+The first three were each fixed at their own site; the pattern did not stop, which is the finding.
+
+## Root cause, and why it is not a short list of sites
+
+Two things compound:
+
+1. **`.pairs` promotes the source's elements IN PLACE.** After `%h.pairs`, `%h` holds cells from then
+   on — so the exposure is not "consumers of the `.pairs` result" but "consumers of any container a
+   producer has ever run over".
+2. **Bulk iteration bypasses the element read chokepoint.** ADR-0036 §5 Q4 asked whether
+   `resolve_array_entry` is genuinely the only read chokepoint and expected yes. It is the only
+   chokepoint for *element* reads, but `h.iter()` / `items.iter()` in the coercion layer walk the
+   storage directly, and `ValueView::Pair(k, v)` / `ValueView::ValuePair(k, v)` destructuring reads
+   the pair's value without any accessor at all. `src/runtime/utils/set_coerce.rs` and
+   `src/runtime/utils/coerce_containers.rs` alone hold **15** such destructuring sites.
+
+`.values`/`.reverse`/`.sort` do **not** have this problem, which is why they shipped: they hand out a
+flat list of cells, and list consumers go through the decontainerizing paths. It is specifically the
+*Pair wrapper* that carries a cell into code which reads it structurally.
+
+## What the fix needs
+
+A **read chokepoint for a Pair's value**, so that "give me this pair's value as data" and "give me
+this pair's value as an lvalue" are different operations. Today they are the same field read.
+
+The natural candidate — decontainerizing in the `"value"` accessor
+(`src/builtins/methods_0arg/coercion.rs`, the `ValueView::Pair(_, v) | ValueView::ValuePair(_, v)`
+arm) — is **not sufficient and conflicts with a shipped row**: it does not touch the 15 structural
+destructuring sites, and ADR-0036 row 6 requires `(@a[0]:p).value.VAR.^name` to be `Scalar`, which
+needs `.value` to return the container. So the design question is real and wants its own decision:
+either a distinct "pair value view" that `.VAR` consumes, or an audited conversion of every
+structural pair-value read to go through an accessor.
+
+Note that the `:p`/`:kv` subscript adverbs (ADR-0036 slice 2) already put cells in Pair values and
+have shipped since 2026-08-20 without this trouble — because they promote **one** element on demand,
+where `.pairs` promotes the whole container and is far more likely to be fed straight into a
+coercion.
+
+## Reproduce
+
+```raku
+my %src = a => 1, b => 2, c => 3;
+my %z is BagHash;
+%z = %src.pairs;
+say %z.sort;      # raku (a => 1 b => 2 c => 3);  with .pairs routed: (a => 1 b => 1 c => 1)
+```
+
+Re-add `"pairs"` to `ELEMENT_PRODUCERS` in `src/vm/vm_element_producers.rs` (both the array and hash
+arms) to reproduce; `roast/S03-metaops/infix.t` fails 396/5076 immediately.

--- a/todo/tickets/var-on-a-containerref-is-not-distinguishable.md
+++ b/todo/tickets/var-on-a-containerref-is-not-distinguishable.md
@@ -1,0 +1,71 @@
+# `.VAR` on a `ContainerRef` is not distinguishable from the aliased value itself
+
+## Symptom
+
+A value that *is* an element container (a `ContainerRef` cell — what
+`array_slot_ref`/`hash_slot_ref` hand out, and what ADR-0036/ADR-0045 now
+produce in bulk) answers container-introspection methods as the *container*
+even when raku would answer as the *value*:
+
+```raku
+my @a = 10, 20;
+my $p = @a[0]:p;
+say $p.value.WHAT;        # raku (Int)     mutsu (Int)     -- fixed
+say $p.value.VAR.^name;   # raku Scalar    mutsu Scalar    -- correct
+say $p.value.^name;       # raku Int       mutsu Scalar    -- WRONG
+say $p.value.VAR.WHAT;    # raku (Scalar)  mutsu (Int)     -- WRONG
+```
+
+The same two rows are wrong for any anonymous expression whose value is a cell.
+Through a *named* `:=` binding they are all correct, because the compiler
+special-cases `.VAR` on a named variable
+(`compile_expr_method_var_on_index`, `src/compiler/expr.rs`):
+
+```raku
+my @a = 10, 20; my $r := @a[0];
+say $r.WHAT, $r.^name, $r.VAR.^name, $r.VAR.WHAT;   # all correct
+```
+
+## Root cause
+
+`src/vm/vm_call_method_ops.rs` decontainerizes a `ContainerRef` receiver for
+every method except `VAR`, and then has to guess what a following `^name`/`WHAT`
+meant. `.VAR` returns the cell *unchanged*, so by the time `^name` runs there is
+nothing left to distinguish "this cell was reached through `.VAR`, report the
+container" from "this cell is simply an aliased value, report the value".
+
+The current compromise (2026-08-27) intercepts `^name` only — that keeps
+`.VAR.^name` answering `Scalar`, which is the form roast actually uses (seven
+whitelisted files), while letting the much more common bare `.WHAT`
+decontainerize. `WHAT` was moved out of the intercept because ADR-0036 slice 3
+and ADR-0045 slice 4 hand element containers out in bulk, so
+`@a.pairs[0].value.WHAT` would otherwise have started answering `Scalar` where
+it answers `Int` today.
+
+## The real fix
+
+`.VAR` needs to return a value that is distinguishable from a bare cell — a
+distinct "container view" rather than the cell itself — so that `^name`/`WHAT`
+can answer from the view and a bare cell can always decontainerize.
+
+The obvious candidate, wrapping the cell in `ValueView::Scalar`, is **already
+taken**: ADR-0040 slice 1 uses `Scalar(ContainerRef(..))` for a reference-pushed
+element (`@a.push(@b)`), and `vm_call_method_ops.rs` treats that shape as
+transparent for everything except the renderers. So this needs a genuinely new
+representation (or a dispatch-time flag paired with the `CallMethod "VAR"`
+emission at `src/compiler/expr.rs:482-491`), which is why it is a ticket rather
+than a fix folded into the producer slices.
+
+## Related
+
+- `t/subscript-pair-element-container.t` already `todo`s a neighbouring gap:
+  `(@a[0]:kv)[1].VAR.^name` does not see the cell at all, because the anonymous
+  computed index target goes through the general read chokepoint which
+  decontainerizes before `.VAR` runs.
+- ADR-0036 §5 Q4 predicted exactly this failure mode ("a leaked `ContainerRef`
+  surfaces as a wrong `.raku`/`.WHAT`/`.gist`"); this ticket is the residue of
+  that question after slices 2-3.
+
+## Reproduce
+
+The four `say` lines above, no fixtures.


### PR DESCRIPTION
Implements **ADR-0045 slice 4**, on the shared producer layer ADR-0036 slice 3 called for. **ADR-0036's own `.pairs` was implemented on that layer, measured, and backed out** — the interesting result of this PR, and the reason for the retitle.

## What lands

`src/vm/vm_element_producers.rs`, hooked into the VM's method-dispatch tail, with `builtins/methods_0arg/` kept as the fallback for every receiver it declines. `.values`, `.reverse` and `.sort` hand out the elements' own `Scalar` containers when the receiver is a real mutable `Array`/`Hash`.

**ADR-0045 rows 17 and 24 turn green**, plus the deferred-closure form of each and of `.values`.

## The index bookkeeping was deletable, not fixable

Once a producer hands out element containers the loop needs **no index reconstruction at all**: the item it binds *is* the alias, in whatever order the producer chose. The loop's rule collapses to "if the bound item already carries an element cell, there is nothing to write back."

That is what gives `.sort` an alias despite having no index to reconstruct — the cells are carried **through** the sort, keyed by what they hold, rather than an index being recovered from the sorted value afterwards (ambiguous the moment two elements compare equal).

**Row 39 (`for @$s`) was also implemented and backed out**, for the same reason class as `.pairs` but a different boundary. It needed no producer at all — its `$`-tagged source is an ordinary in-order array read, so it joined the existing bind-site routing via a shared `resolve_for_source_array`, which is retained. But `encode($_) for @$_` is the ordinary idiom for walking a nested structure recursively, and that is exactly the code which **type-tests** what it is holding before recursing: CBOR::Simple's `nqp::istype($_, Associative)` answered `False` for a promoted topic and encoded a `Map` as its element count. Decontainerizing `nqp::istype` (done here, and kept — a type test should ask about the value) was **not sufficient**; the `nqp::` surface that inspects a value structurally is wide. `todo/tickets/for-deref-container-source-promotion-breaks-nqp-type-tests.md`.

**Your finding-1 prediction turned out to be moot, for a good reason:** `.sort` does not need a source *tag* after all. The tag only existed to point the writeback at an index; with the producer routed there is no writeback and nothing to point.

## `.pairs` was measured and backed out — this is the main finding

Handing out a Pair whose *value* is a cell leaks into every consumer that reads a pair's value **as data**. And because `.pairs` promotes the source's elements **in place**, the exposure is not "consumers of the `.pairs` result" but "consumers of any container a producer has run over". Five distinct failures, each fixed at its own site before the pattern was accepted as a class:

| consumer | symptom |
| --- | --- |
| `"…".trans(%matcher.pairs)` | type-tests the value (`is_closure`, then Regex/Array/Range shape); a cell answers "no" to all, so a closure replacement silently became a stringified one — `S05-transliteration/with-closure.t` |
| `%a = %reset.pairs` into a Hash | stored the *cells*, aliasing two hashes together |
| `%a = %reset.pairs` into a BagHash | every weight became `1` — weight extraction fell past its `Int`/`Num`/`Bool` arms to the truthy catch-all — **`S03-metaops/infix.t`, 396/5076 subtests** |
| `%src.pairs.map({ .key => .value })` | `.value` returns the cell, so the rebuilt pair carried it forward |
| `.antipairs` after `.pairs` | key no longer de-itemized |

`set_coerce.rs` and `coerce_containers.rs` alone destructure a pair's value structurally in **15** places, with no accessor to route. `.values`/`.reverse`/`.sort` do **not** have the problem: they hand out a **flat list** of cells, and list consumers decontainerize. It is specifically the **Pair wrapper** that carries a cell into code that reads it structurally.

**This revises ADR-0036 §5 Q4's answer, which is worth recording.** `resolve_array_entry` is the only chokepoint for *element* reads, but bulk iteration (`h.iter()`, `items.iter()`) and `ValueView::Pair(k, v)` destructuring walk the storage directly and bypass it. That is the real blast radius — and it explains why the `:p`/`:kv` adverbs have shipped happily since 2026-08-20 while `.pairs` cannot: they promote **one** element on demand, where `.pairs` promotes the whole container and is far likelier to be fed to a coercion.

So the "two half-converted method sets" §4 warned about did not materialise in the direction it expected. The split is not array-producers vs pair-producers, it is **flat lists vs Pair wrappers**, and that split is now a measured property rather than a scheduling accident. Tracked in `todo/tickets/pairs-element-containers-leak-through-pair-value-consumers.md`.

## Your bug-2 warning, carried forward as asked

You asked me to audit every new producer the way the `ItemArray` allow-list bug was found. I did, and the denial-list discipline held — `array_is_aliasable` still excludes only `Shaped`/`Lazy`/native-backed, so the itemized-element shape that broke row 37 is covered for the new producers too. What the audit surfaced instead was a *different* class, above: not "an allow list silently drops a shape onto a severing path" but "a promoted value reaches code that type-tests it". Both share the same tell — a `match` on `view()` — which is worth remembering for slice 5.

## Two more method-list corrections, both by measurement

- **`.antipairs` must NOT be routed.** It puts the element in the pair's **key**, and a pair key is never a container in raku: `$p.key` stays `A` after `@a[0] = "Q"`, and `$p.key.VAR.^name` is `Str`.
- **`.kv` is deferred, and the reason is the *consumer*** — your finding-2 prediction, right for a reason nobody had written down. A `.kv` loop is a multi-parameter loop, and those bind through bind-prefix `Stmt::Assign`s that read the chunk element through the ordinary chokepoint, which **decontainerizes**. Routing it *lost* the direct write (`for @a.kv -> $i, $v is rw { $v += $i }`) instead of gaining the deferred one. **The difficulty is not in `.kv` at all.**

**ADR-0036 row 10** is deferred to a prerequisite: `array_slot_ref` grows the array at *bind* time where raku defers until the write (`my @a = 1,2; my $r := @a[5]; @a.elems` is `6` in mutsu, `2` in raku), and `key => @a[i]` is ordinary code. **Row 11** moves to ADR-0036 slice 4, whose env-scan deletion is what makes the read-only guard reachable.

## Pre-existing leaks fixed on the way in

- `.WHAT` on a `ContainerRef` receiver answered `Scalar` instead of the value's type.
- `positional_antipairs` did not see through a promoted element before de-itemizing its key.
- An `augment`ed native type's own producer still wins — the hook is gated on `native_lever_a_user_override`.

## Perf

Release, best of three, idle machine, read-only pass over a 200 000-element array:

| producer | before | after |
| --- | --- | --- |
| `.values` | 0.07 s | 0.18 s |
| `.reverse` | 0.07 s | 0.18 s |
| `.sort` | 0.05 s | 0.18 s |
| `.pairs` | 0.23 s | 0.25 s (control — not routed) |
| `.kv` | 0.73 s | 0.77 s (control — not routed) |

The repository's own benchmarks do not move. (Local A/B; the bench CI stays the source of truth.)

## Verification

- `make test`: PASS.
- **Entire roast whitelist on release — 1436 files, 218 817 tests: PASS**, except `S32-str/{gb18030,gb2312,shiftjis}-encode-decode.t`, which fail identically on the pre-change baseline in this environment.
- **Bundled-library gate: PASS** (`scripts/battery-testsuite.sh`, 273/297). This is a separate CI step that `make test` does not cover, and it is what caught row 39 — worth adding to the local loop for any container-representation change.
- **Two triage lessons worth recording.** (1) My first sweep *did* contain the `infix.t` failure and I mis-attributed its 396-line failure block to the neighbouring `CollationTest…` entry's TODO-passed list — read the file header above a number block, not just the block. (2) A green `make test` + green full roast is *not* sufficient coverage for this class of change; the batteries gate exercises real ecosystem code that type-tests values, which is precisely where promoted containers leak.

## On the shared primitive you flagged

Your `return-rw` agent and this work **do** want the same primitive, and it already exists: `compile_return_rw_arg` (`src/compiler/helpers_call_args.rs`) compiles a subscript in exactly the container-producing mode (`scalar_bind_autovivify` + `bind_terminal`) that ADR-0036 row 10 needs. Neither of us should invent a second one. What that shared primitive is *missing* is the deferred array token — `return-rw` inherits the same eager growth, so `todo/tickets/array-slot-ref-vivifies-eagerly-where-raku-defers.md` is a prerequisite for both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
