### PR TITLE
fix(eval): stop two context-dependent suppressions of EVAL failures

### DIFF
--- a/src/env.rs
+++ b/src/env.rs
@@ -133,6 +133,36 @@ pub(crate) fn is_plain_user_lexical(name: &str) -> bool {
     matches!(decider, Some(c) if c.is_ascii_lowercase())
 }
 
+/// True when `name` is a sigil-less env key that holds a *magic variable* rather
+/// than a name binding, and must therefore never be read as a lexical
+/// type/package alias.
+///
+/// A lexically scoped `my class Foo` binds `env["Foo"]` to a `Package` naming its
+/// mangled storage symbol, and several bare-name type lookups resolve a short
+/// name through exactly that binding (see
+/// [`crate::runtime::Interpreter::resolve_bare_type_name`]). The topic `$_` is
+/// stored sigil-less as `"_"`, which collides with the identifier `_` in that
+/// namespace: entering a routine seeds the implicit topic with the `Any` type
+/// object, so `env.get("_")` answers `Package(Any)` and those lookups read the
+/// topic as if it were a `my class _` aliasing `Any`. Inside a routine that
+/// turned an unresolvable `_(1, 2)` into a coercion to `Any` returning `(1, 2)`
+/// instead of "Unknown function: _" — which is how `EVAL '10_.0'` (parsed as a
+/// speculative `infix:<_>`) stopped throwing whenever the `EVAL` ran inside a
+/// routine.
+///
+/// `_` is the only sigil-less magic key that is also a legal bare identifier
+/// (`/`, `!`, `?FILE`, `0`, `<n>`, `*x`, `__mutsu_*` are all unreachable as type
+/// names), so this is deliberately exactly one name.
+///
+// TODO: the real fix is to stop storing the topic under a key that lives in the
+// identifier namespace (`"$_"`, or a reserved prefix like `LEX_SELF`), which
+// would also make a genuine `class _ { }` reachable — it is unreachable through
+// these lookups for as long as the collision stands.
+#[inline]
+pub(crate) fn is_magic_sigilless_key(name: &str) -> bool {
+    name == "_"
+}
+
 /// True for a dynamic variable's env key (the `*` twigil): `$*x` → `"*x"` (scalars
 /// are stored sigil-less), `@*x` → `"@*x"`, `%*VAR` → `"%*VAR"`, `&*f` → `"&*f"`.
 ///

--- a/src/runtime/builtins_eval_misc.rs
+++ b/src/runtime/builtins_eval_misc.rs
@@ -350,9 +350,6 @@ impl Interpreter {
                 return Err(err);
             }
         }
-        if code.contains("&?ROUTINE") && self.routine_stack.is_empty() {
-            return Err(RuntimeError::undeclared_symbols("Undeclared name"));
-        }
         // `EVAL $code, context => $ctx` compiles the string as if it stood at
         // `$ctx`'s frame, so a package the snippet declares is named after the
         // caller and not after whichever module called EVAL. Without this a

--- a/src/runtime/eval_routine_magicals.rs
+++ b/src/runtime/eval_routine_magicals.rs
@@ -1,0 +1,245 @@
+//! Post-parse check for `&?ROUTINE` used outside the lexical scope of a routine
+//! in an `EVAL`'d compilation unit.
+//!
+//! `&?ROUTINE` is resolved *lexically at compile time* to the innermost
+//! enclosing `sub`/`method`/`token`/`rule`/`regex`. An `EVAL`'d string is its own
+//! compilation unit, so its mainline has no enclosing routine no matter what the
+//! caller's runtime routine stack looks like — rakudo answers
+//! `X::Undeclared::Symbols` for `EVAL '&?ROUTINE'` even when the `EVAL` itself
+//! sits inside a `sub`, and conversely accepts
+//! `EVAL 'sub g { &?ROUTINE.name }; g()'` from the mainline.
+//!
+//! mutsu used to approximate this with a textual `code.contains("&?ROUTINE")`
+//! test gated on `self.routine_stack.is_empty()`, which was wrong in *both*
+//! directions: it accepted a mainline `&?ROUTINE` inside the snippet whenever the
+//! caller happened to be in a routine (this is what let
+//! `throws-like { EVAL 'my $baz = try { &?ROUTINE.name };' }` report "code did
+//! not die" under the real `Test` module, whose `throws-like` calls the Callable
+//! from Raku-level code), and rejected a snippet that declared its own routine
+//! around the use.
+//!
+//! This walker mirrors the lexical rule structurally instead. It carries one
+//! boolean, `in_routine`:
+//!
+//! * `sub`/`method`/`token`/`rule`/`regex`/`proto` declarations and anonymous
+//!   `sub { }` expressions set it true for their body — they *are* `Routine`s.
+//! * A bare block, a pointy `-> { }` (`Block`, not `Routine`), a `class`/`role`
+//!   body and every control-flow construct preserve it, so `&?ROUTINE` inside a
+//!   block nested in a routine is fine, and inside a pointy at unit mainline is
+//!   not (measured against `raku`).
+//!
+//! Like `parser::whenever_scope`, the walker is deliberately conservative: an
+//! unhandled container is simply not recursed into, which can only *miss* an
+//! offending use (leaving today's behaviour), never invent one.
+
+use crate::ast::{Expr, Stmt};
+use crate::runtime::Interpreter;
+use crate::value::RuntimeError;
+
+impl Interpreter {
+    /// Reject `&?ROUTINE` used outside a routine in an `EVAL`'d unit, the way
+    /// rakudo's compile-time lexical lookup does. Run alongside the other
+    /// `check_eval_*` passes, on the snippet's own parsed statements — the
+    /// caller's runtime routine stack is irrelevant (see the module docs).
+    pub(crate) fn check_eval_routine_magicals(stmts: &[Stmt]) -> Result<(), RuntimeError> {
+        match find_routine_magical_outside_routine(stmts) {
+            Some(name) => Err(RuntimeError::undeclared_symbols(format!(
+                "Undeclared name:\n    {name} used at line 1"
+            ))),
+            None => Ok(()),
+        }
+    }
+}
+
+/// The name of the first routine-scoped magical used outside a routine, or
+/// `None` when every use is properly enclosed.
+pub(crate) fn find_routine_magical_outside_routine(stmts: &[Stmt]) -> Option<String> {
+    let mut found: Option<String> = None;
+    walk_stmts(stmts, false, &mut found);
+    found
+}
+
+fn walk_stmts(stmts: &[Stmt], in_routine: bool, found: &mut Option<String>) {
+    for s in stmts {
+        walk_stmt(s, in_routine, found);
+    }
+}
+
+fn walk_stmt(stmt: &Stmt, in_routine: bool, found: &mut Option<String>) {
+    if found.is_some() {
+        return;
+    }
+    match stmt {
+        // Routine boundaries: everything below them has an enclosing routine.
+        Stmt::SubDecl { body, .. }
+        | Stmt::MethodDecl { body, .. }
+        | Stmt::TokenDecl { body, .. }
+        | Stmt::RuleDecl { body, .. }
+        | Stmt::ProtoDecl { body, .. } => walk_stmts(body, true, found),
+
+        // Package-like bodies are not routines: `class C { &?ROUTINE }` is as
+        // undeclared as a mainline use, while `class C { method m { … } }` is
+        // covered by the MethodDecl arm above.
+        Stmt::ClassDecl { body, .. }
+        | Stmt::RoleDecl { body, .. }
+        | Stmt::Package { body, .. }
+        | Stmt::Block(body)
+        | Stmt::SyntheticBlock(body)
+        | Stmt::Default(body)
+        | Stmt::Catch(body)
+        | Stmt::Control(body)
+        | Stmt::Given { body, .. }
+        | Stmt::When { body, .. }
+        | Stmt::While { body, .. }
+        | Stmt::Subtest { body, .. }
+        | Stmt::React { body, .. } => walk_stmts(body, in_routine, found),
+        Stmt::Whenever { supply, body, .. } => {
+            walk_expr(supply, in_routine, found);
+            walk_stmts(body, in_routine, found);
+        }
+        Stmt::Phaser { body, .. } => walk_stmts(body, in_routine, found),
+        Stmt::For { body, iterable, .. } => {
+            walk_expr(iterable, in_routine, found);
+            walk_stmts(body, in_routine, found);
+        }
+        Stmt::Loop { body, init, .. } => {
+            if let Some(init) = init {
+                walk_stmt(init, in_routine, found);
+            }
+            walk_stmts(body, in_routine, found);
+        }
+        Stmt::If {
+            cond,
+            then_branch,
+            else_branch,
+            ..
+        } => {
+            walk_expr(cond, in_routine, found);
+            walk_stmts(then_branch, in_routine, found);
+            walk_stmts(else_branch, in_routine, found);
+        }
+        Stmt::Label { stmt, .. } => walk_stmt(stmt, in_routine, found),
+
+        Stmt::Expr(e)
+        | Stmt::VarDecl { expr: e, .. }
+        | Stmt::Assign { expr: e, .. }
+        | Stmt::Return(e)
+        | Stmt::Die(e)
+        | Stmt::Fail(e)
+        | Stmt::Take(e, _) => walk_expr(e, in_routine, found),
+        Stmt::Say(es) | Stmt::Put(es) | Stmt::Print(es) | Stmt::Note(es) => {
+            for e in es {
+                walk_expr(e, in_routine, found);
+            }
+        }
+
+        _ => {}
+    }
+}
+
+fn walk_expr(expr: &Expr, in_routine: bool, found: &mut Option<String>) {
+    if found.is_some() {
+        return;
+    }
+    match expr {
+        // The use itself. `&?BLOCK` is deliberately NOT checked: every block —
+        // the unit mainline included — is a `Block`, so it is always declared.
+        Expr::CodeVar(name) if name == "?ROUTINE" => {
+            if !in_routine {
+                *found = Some(name.clone());
+            }
+        }
+
+        // `AnonSub` carries `is_block`, which separates a bare block `{ }` (a
+        // `Block`: NOT a routine boundary) from an anonymous `sub { }` (a
+        // `Routine`: it does supply `&?ROUTINE`).
+        Expr::AnonSub {
+            body,
+            is_block: true,
+            ..
+        } => walk_stmts(body, in_routine, found),
+        Expr::AnonSub { body, .. } => walk_stmts(body, true, found),
+
+        // `AnonSubParams` and `Lambda` are ambiguous in the AST: a pointy block
+        // `-> { }` / `-> $x { }` (a `Block`, which does NOT supply `&?ROUTINE` —
+        // measured: `EVAL 'my $z = -> { &?ROUTINE }; $z()'` is
+        // X::Undeclared::Symbols in raku) and a parameterised anonymous
+        // `sub ($x) { }` (which does) both lower to them, with nothing left to
+        // tell them apart. Treat them as routine boundaries: per this module's
+        // conservatism rule that can only *miss* an offending pointy-block use,
+        // where the alternative would wrongly reject a legal `sub ($x) { … }`.
+        Expr::AnonSubParams { body, .. } | Expr::Lambda { body, .. } => {
+            walk_stmts(body, true, found)
+        }
+        Expr::Block(body) | Expr::Gather(body) => walk_stmts(body, in_routine, found),
+        Expr::DoBlock { body, .. } => walk_stmts(body, in_routine, found),
+        Expr::DoStmt(s) => walk_stmt(s, in_routine, found),
+        Expr::Try { body, catch } => {
+            walk_stmts(body, in_routine, found);
+            if let Some(catch) = catch {
+                walk_stmts(catch, in_routine, found);
+            }
+        }
+
+        Expr::Grouped(inner)
+        | Expr::WhateverCurry(inner)
+        | Expr::Itemize(inner)
+        | Expr::Eager(inner)
+        | Expr::ZenSlice(inner)
+        | Expr::PositionalPair(inner)
+        | Expr::DeitemizeForBind(inner) => walk_expr(inner, in_routine, found),
+        Expr::Unary { expr, .. } | Expr::PostfixOp { expr, .. } => {
+            walk_expr(expr, in_routine, found)
+        }
+        Expr::Binary { left, right, .. } => {
+            walk_expr(left, in_routine, found);
+            walk_expr(right, in_routine, found);
+        }
+        Expr::AssignExpr { expr, .. } => walk_expr(expr, in_routine, found),
+        Expr::Ternary {
+            cond,
+            then_expr,
+            else_expr,
+        } => {
+            walk_expr(cond, in_routine, found);
+            walk_expr(then_expr, in_routine, found);
+            walk_expr(else_expr, in_routine, found);
+        }
+        Expr::ChainedCompare { operands, .. } => {
+            for o in operands {
+                walk_expr(o, in_routine, found);
+            }
+        }
+        Expr::InfixFunc { left, right, .. } => {
+            walk_expr(left, in_routine, found);
+            for r in right {
+                walk_expr(r, in_routine, found);
+            }
+        }
+        Expr::ArrayLiteral(items)
+        | Expr::BracketArray(items, _)
+        | Expr::CaptureLiteral(items)
+        | Expr::StringInterpolation(items) => {
+            for i in items {
+                walk_expr(i, in_routine, found);
+            }
+        }
+        Expr::Call { args, .. } | Expr::UserRoutineCall { args, .. } => {
+            for a in args {
+                walk_expr(a, in_routine, found);
+            }
+        }
+        Expr::MethodCall { target, args, .. } | Expr::HyperMethodCall { target, args, .. } => {
+            walk_expr(target, in_routine, found);
+            for a in args {
+                walk_expr(a, in_routine, found);
+            }
+        }
+        Expr::Index { target, index, .. } => {
+            walk_expr(target, in_routine, found);
+            walk_expr(index, in_routine, found);
+        }
+
+        _ => {}
+    }
+}

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -432,6 +432,7 @@ mod dispatch_proto_call;
 mod dispatch_proto_rewrite;
 mod dispatch_resolve;
 mod eval_check;
+mod eval_routine_magicals;
 mod exception_message;
 mod gc_roots;
 mod handle;

--- a/src/runtime/runtime_class_query.rs
+++ b/src/runtime/runtime_class_query.rs
@@ -36,7 +36,14 @@ impl Interpreter {
         // Checked before the "::"-gated package-chain walk below, and before
         // it too — `env` reflects the innermost lexical scope directly, which
         // is at least as precise as walking `current_package`'s chain.
-        if let Some(ValueView::Package(target)) = self.env().get(name).map(Value::view) {
+        //
+        // `is_magic_sigilless_key` excludes the topic: `$_` is stored under the
+        // bare key `_`, seeded with the `Any` type object on routine entry, so
+        // without the guard `_` resolves to `Any` here and every bare `_` in
+        // call/type position silently becomes an `Any` coercion inside a routine.
+        if !crate::env::is_magic_sigilless_key(name)
+            && let Some(ValueView::Package(target)) = self.env().get(name).map(Value::view)
+        {
             let resolved = target.resolve();
             if resolved != name && (self.has_class(&resolved) || self.has_role(&resolved)) {
                 return Some(resolved);
@@ -70,10 +77,11 @@ impl Interpreter {
             return false;
         }
         self.chain_declared_packages.contains(name)
-            || matches!(
-                self.env.get(name).map(Value::view),
-                Some(ValueView::Package(_))
-            )
+            || (!crate::env::is_magic_sigilless_key(name)
+                && matches!(
+                    self.env.get(name).map(Value::view),
+                    Some(ValueView::Package(_))
+                ))
     }
 
     /// Check if a class name refers to a user-defined class that inherits from

--- a/src/runtime/system.rs
+++ b/src/runtime/system.rs
@@ -102,6 +102,7 @@ impl Interpreter {
                 self.check_eval_undeclared_vars(&stmts)?;
                 self.check_eval_undeclared_names(&stmts)?;
                 self.check_eval_undeclared_routines(&stmts)?;
+                Self::check_eval_routine_magicals(&stmts)?;
                 self.check_eval_post_declared_types(&stmts)?;
                 self.check_eval_begin_forward_calls(&stmts)?;
                 self.check_eval_param_type_constraints(&stmts)?;

--- a/src/runtime/types/type_matching.rs
+++ b/src/runtime/types/type_matching.rs
@@ -353,7 +353,11 @@ impl Interpreter {
         if self.registry().roles.contains_key(name) {
             return Some(name.to_string());
         }
-        if let Some(ValueView::Package(pkg)) = self.env.get(name).map(Value::view) {
+        // Same topic exclusion as the class-side lookups: see
+        // `crate::env::is_magic_sigilless_key`.
+        if !crate::env::is_magic_sigilless_key(name)
+            && let Some(ValueView::Package(pkg)) = self.env.get(name).map(Value::view)
+        {
             let resolved = pkg.resolve();
             if self.registry().roles.contains_key(&resolved) {
                 return Some(resolved);

--- a/src/runtime/types/type_registry.rs
+++ b/src/runtime/types/type_registry.rs
@@ -353,7 +353,12 @@ impl Interpreter {
         // importing module's scope. Humming-Bird's `Route.CALL-ME` does
         // `my Response:D $res = ...` with `Response` imported from
         // `Humming-Bird::Glue`.
-        if let Some(ValueView::Package(target)) = self.env.get(name).map(Value::view) {
+        // The topic is excluded for the reason `is_magic_sigilless_key` records:
+        // `$_` lives under the bare key `_` and holds `Any` inside a routine, so
+        // without the guard `my _ $x` would accept `_` as a type name.
+        if !crate::env::is_magic_sigilless_key(name)
+            && let Some(ValueView::Package(target)) = self.env.get(name).map(Value::view)
+        {
             let resolved = target.resolve();
             if resolved != name && self.has_type_direct(&resolved) {
                 return true;

--- a/t/eval-parse-failure-propagates-through-block-call.t
+++ b/t/eval-parse-failure-propagates-through-block-call.t
@@ -1,0 +1,71 @@
+use Test;
+use MONKEY-SEE-NO-EVAL;
+
+# An EVAL that fails must throw the same way no matter where the EVAL sits.
+# Two independent mechanisms used to suppress the throw whenever the EVAL ran
+# inside a routine (which is exactly the shape the real `Test.rakumod`'s
+# Raku-level `throws-like` puts it in):
+#
+#  1. `$_` is stored under the sigil-less env key `_`, seeded with the `Any`
+#     type object on routine entry, so every "resolve a bare type name through
+#     its env alias" lookup read the topic as a `my class _` aliasing `Any`.
+#     `10_.0` parses as a speculative `infix:<_>`; inside a routine its
+#     unresolvable fallback then became a coercion to `Any` returning
+#     `(10, 0.0)` instead of throwing X::Syntax::Confused.
+#  2. EVAL's `&?ROUTINE` check was gated on the *caller's* routine stack rather
+#     than the snippet's own lexical structure, so `EVAL '&?ROUTINE'` was
+#     accepted whenever the EVAL happened to be called from inside a sub.
+
+plan 14;
+
+sub runit(&c) {
+    my $ex;
+    {
+        &c();
+        CATCH { default { $ex = $_ } }
+    }
+    $ex;
+}
+
+# A/B: both spellings are X::Syntax::Confused in rakudo; B is the one that used
+# to vanish. Run through `runit` so the EVAL is invoked from inside a routine.
+isa-ok runit({ EVAL '10_' }), X::Syntax::Confused,
+    'EVAL q|10_| throws through a routine-invoked block';
+isa-ok runit({ EVAL '10_.0' }), X::Syntax::Confused,
+    'EVAL q|10_.0| throws through a routine-invoked block';
+# C: &?ROUTINE has no enclosing routine in the EVAL'd compilation unit.
+isa-ok runit({ EVAL 'my $baz = try { &?ROUTINE.name };' }), X::Undeclared::Symbols,
+    'EVAL q|&?ROUTINE| throws through a routine-invoked block';
+# D: the control -- a plain die always propagated.
+isa-ok runit({ die 'plain' }), X::AdHoc,
+    'a plain die still throws through a routine-invoked block';
+
+# The same failure at mainline, where it always worked.
+my $mainline; try { EVAL '10_.0'; CATCH { default { $mainline = $_ } } };
+isa-ok $mainline, X::Syntax::Confused, 'B also throws at mainline';
+
+# The `throws-like` shape the real Test module uses.
+throws-like { EVAL '10_.0' }, X::Syntax::Confused,
+    'throws-like sees the EVAL failure';
+
+# The underlying mechanism, without EVAL: an undeclared word infix / an unknown
+# routine named `_` must not resolve to the topic's `Any` inside a routine.
+dies-ok { EVAL 'sub uid { 1 _ 2 }; uid()' },
+    'an undeclared `_` word infix dies inside a routine';
+dies-ok { EVAL 'sub g() { _(1, 2) }; g()' },
+    'calling an undeclared routine `_` dies inside a routine';
+dies-ok { EVAL 'sub h { my _ $x = 3; $x }; h()' },
+    '`_` is not accepted as a type name inside a routine';
+
+# `&?ROUTINE` resolution is lexical in the EVAL'd unit, not caller-dependent.
+sub eval-from-a-routine { EVAL 'sub g { &?ROUTINE.name }; g()' }
+is eval-from-a-routine(), 'g',
+    'a routine the EVAL declares does supply &?ROUTINE (called from a routine)';
+is EVAL('sub g2 { &?ROUTINE.name }; g2()'), 'g2',
+    'a routine the EVAL declares does supply &?ROUTINE (called from mainline)';
+is EVAL('sub g3 { my $b = { &?ROUTINE.name }; $b() }; g3()'), 'g3',
+    'a bare block inside the EVAL-declared routine still sees &?ROUTINE';
+is EVAL('class C { method m { &?ROUTINE.name } }; C.m'), 'm',
+    'a method the EVAL declares supplies &?ROUTINE';
+throws-like { EVAL 'sub g4 { }; &?ROUTINE' }, X::Undeclared::Symbols,
+    'a mainline &?ROUTINE is undeclared even when the snippet declares a routine';

--- a/todo/deep/vendor-real-test-module.md
+++ b/todo/deep/vendor-real-test-module.md
@@ -3346,3 +3346,145 @@ One caveat to carry forward: this sweep takes ~25 minutes on a release build
 and is still not in CI, so it remains a manual ritual. Gating it means a second
 full roast pass; with 60 correctness regressions left that is still not worth
 2x the roast CI cost, but the gap is narrowing.
+
+## 2026-08-28 (third entry that day): the "swallowed EVAL failure" was two context-dependent error suppressions, both fixed; the rest of that candidate list is a wrong-exception-class long tail
+
+The starting hypothesis was a single shared mechanism: "`EVAL` of a snippet that
+fails to parse silently does not throw when the `EVAL` is inside a block that
+another routine invokes", with eleven roast files from the 60-file regression
+list nominated as likely consumers. Investigated with `rust-gdb` rather than
+`eprintln!`, the hypothesis turned out to be **two unrelated suppressions with
+the same shape** — and to explain **only two of the eleven files**. Both
+suppressions are now fixed; the other nine are a different family and are filed
+as their own tickets.
+
+### The discriminating pair in the repro was the whole diagnostic
+
+`EVAL '10_'` threw and `EVAL '10_.0'` did not, from the same call site, with the
+same exception class. That rules out both "it is about the exception type" and
+"it is about `EVAL`-in-a-block". Breaking on the parse showed why: **neither
+snippet is a parse error in mutsu.** `parse_program` returns `Ok` for `10_.0` in
+*both* contexts, with a byte-identical tree —
+`Expr::InfixFunc { name: "_", left: 10, right: [0.0] }`. mutsu's parser accepts
+any non-reserved word as a *speculative* `infix:<word>` at the loosest
+precedence level (`parse_custom_infix_word`, deliberately permissive because an
+infix can be installed at runtime), so `10_ .0` reads as `10 infix:<_> .0`. The
+"parse error" is raised much later, by the runtime's unresolvable-infix fallback
+(`call_infix_fallback` -> `X::Syntax::Confused: "Two terms in a row"`).
+
+### Mechanism 1: the topic occupies the identifier `_`, so bare-name type lookups resolved `_` to `Any`
+
+`$_` is stored in `env` under the **sigil-less key `_`** (CLAUDE.md's
+debugging section already warns about this key). Entering a compiled routine
+seeds the implicit topic with the `Any` **type object**, i.e. `Value::Package`.
+`resolve_bare_type_name` resolves a short type name through exactly such an
+`env` binding, because that is how a lexical `my class Foo` is reachable (it
+registers under a mangled storage name and `env["Foo"]` points at it). So inside
+any routine, `env.get("_")` answered `Package(Any)` and `_` resolved to the type
+`Any` — after which `call_function_fallback`'s coercion arm turned the
+unresolvable `_(10, 0.0)` into `Any(10, 0.0)`, which type-matches and **returns
+its argument list**. `EVAL '10_.0'` therefore evaluated to `(10, 0.0)` and threw
+nothing. At mainline there is no such env entry, the fallback ran out of options,
+and the error appeared — which is the entire top-level-vs-routine divergence.
+
+The bug is general, not EVAL-specific (all measured against `raku`):
+
+```
+sub f() { say _(1,2) }; f()          # was: (1 2)     raku: Undeclared name: _
+sub f() { say 1 _ 2 }; f()           # was: (1 2)     raku: Two terms in a row
+sub f() { my _ $x = 3; say $x }; f() # was: 3         raku: Type '_' is not declared
+```
+
+Fixed by `crate::env::is_magic_sigilless_key` — a documented, one-name guard
+applied at the four bare-name type/role alias lookups (`resolve_bare_type_name`,
+`is_declared_package`, `type_registry`'s short-import-alias arm,
+`resolve_role_key`). `_` is the only sigil-less magic env key that is also a
+legal bare identifier (`/`, `!`, `?FILE`, `0`, `<n>`, `*x` are not), so the guard
+is exactly one name. The real fix — not storing the topic in the identifier
+namespace — is recorded as a `TODO:` at the helper; until then a genuine
+`class _ { }` stays unreachable through these lookups, which it already was.
+
+### Mechanism 2: EVAL's `&?ROUTINE` check consulted the CALLER's routine stack
+
+```rust
+if code.contains("&?ROUTINE") && self.routine_stack.is_empty() { ...Undeclared... }
+```
+
+`&?ROUTINE` is resolved **lexically at compile time**, and an `EVAL`'d string is
+its own compilation unit, so the caller's runtime stack is irrelevant. The gate
+was wrong in both directions (both measured against `raku`): it accepted a
+mainline `&?ROUTINE` in the snippet whenever the `EVAL` happened to sit inside a
+`sub` (the reported symptom), and it **rejected** `EVAL 'sub g { &?ROUTINE.name }; g()'`
+called from mainline, which raku accepts.
+
+Replaced with a structural post-parse walk over the snippet's own statements
+(`src/runtime/eval_routine_magicals.rs`, modelled on `parser::whenever_scope`),
+run alongside the other `check_eval_*` passes. `sub`/`method`/`token`/`rule`/
+`proto` and an anonymous `sub { }` open a routine scope; a bare block, a
+`class`/`role` body and control flow preserve it. One documented limitation: a
+pointy `-> { }` and a parameterised `sub ($x) { }` both lower to
+`Expr::AnonSubParams`/`Expr::Lambda` with nothing left to tell them apart, so
+both are treated as routine boundaries — per the walker's conservatism rule that
+can only *miss* an offending pointy-block use, never invent one. (`raku` rejects
+`EVAL 'my $z = -> { &?ROUTINE }; $z()'`; mutsu now does not. Every other measured
+shape matches.)
+
+### Measured, file by file (debug build, `scripts/run-roast-test.sh`, both providers)
+
+| file | before (real) | after (real) | native |
+| --- | --- | --- | --- |
+| `S02-literals/underscores.t` | 1 failure ("Underscore before . fails") | **PASS** | still PASS |
+| `S02-magicals/subname.t` | 1 failure ("&?ROUTINE not available outside of a routine") | **PASS** | still PASS |
+| `S02-lexical-conventions/minimal-whitespace.t` | 3 | 3 (unchanged) | PASS |
+| `S02-lexical-conventions/comments.t` | 1 | 1 (unchanged) | PASS |
+| `S02-literals/quoting-unicode.t` | 1 | 1 (unchanged) | PASS |
+| `S03-operators/context.t` | 2 | 2 (unchanged) | PASS |
+| `S06-signature/optional.t` | 1 | 1 (unchanged) | PASS |
+| `S06-signature/positional-placeholders.t` | 1 | 1 (unchanged) | PASS |
+| `S02-types/whatever.t` | 1 (+2 TODO) | 1 (unchanged) | PASS |
+| `S12-enums/misc.t` | 1 | 1 (unchanged) | PASS |
+| `S32-exceptions/misc2.t` | 3 | 3 (unchanged) | PASS |
+
+**So: roast correctness regressions 57 -> 55.** The full sweep was not re-run
+(it is ~25 minutes and its raw count is noisy by about +-6 because of the
+timeout family); the per-file before/after above is the measurement.
+
+### The other nine are NOT this mechanism — they are wrong exception classes
+
+Each of the nine remaining assertions *does* throw in both contexts; it throws
+the **wrong class**, and mutsu's native `throws-like` hides that on purpose:
+`src/runtime/test_functions/throws_like.rs` accepts any error whose message
+contains `"Confused"`/`"parse error"` whenever the expected class starts with
+`X::Syntax`, plus a similar `X::Comp`/`X::Comp::Group` widening. The real
+module's `$_ ~~ $expected` does not. Filed with the full measured table as
+`todo/tickets/parse-errors-collapse-to-x-syntax-confused.md` (nine rows,
+independent of each other, so it parallelises well). Two rows are *not* in that
+family and are called out there: `S12-enums/misc.t` (right class, empty `.enum`
+attribute) and `S32-exceptions/misc2.t` (`X::Placeholder::Mainline`, already a
+known separate gap).
+
+One more general bug fell out of that triage and is filed separately:
+`todo/tickets/eval-write-to-outer-lexical-lost-inside-a-closure-or-routine.md`
+— `EVAL '$a = 32'` writes through at mainline and inside a bare block, but the
+write is **silently lost** once the `EVAL` runs inside an invoked closure or a
+`sub` (raku: 32, mutsu: `Any`). That is `comments.t` #41, and it is a dual-store /
+closure-writeback problem rather than an exception one.
+
+### A correction to carry forward
+
+The 2026-08-28 roast entry's classification ("39 files lose exactly one
+assertion … no large shared mechanism left") is right about the *shape* but the
+reason matters: a large part of that long tail is not missing behaviour, it is
+**mutsu raising a generic parse exception where rakudo raises a specific one**,
+masked by the native provider's deliberate leniency. Counting those as
+"one fix per file" overstates the work — several of them will fall to one
+parser change each, and the `X::Obsolete`-in-interpolation pair is one change
+for two assertions.
+
+Verification for this entry: the four-line repro now matches `raku` exactly;
+`t/eval-parse-failure-propagates-through-block-call.t` (14 assertions, green
+under `raku`, under mutsu's native provider and under `MUTSU_REAL_TEST=1`);
+`make test` green (3518 files, 35036 tests); and an 823-file targeted roast
+sweep over every whitelisted file in the synopses that consume bare-name type
+resolution and EVAL plumbing (`S02`-`S06`, `S09`-`S12`, `S14`, `S32-exceptions`,
+`integration`) is green on a release build.

--- a/todo/tickets/eval-write-to-outer-lexical-lost-inside-a-closure-or-routine.md
+++ b/todo/tickets/eval-write-to-outer-lexical-lost-inside-a-closure-or-routine.md
@@ -1,0 +1,59 @@
+# An `EVAL` that assigns to an outer lexical loses the write when the EVAL runs inside a closure or a routine
+
+`EVAL '$a = 32'` writes through to the caller's `$a` at mainline and inside a
+bare block, but the write is silently lost as soon as the `EVAL` runs inside a
+closure that is *invoked* (`$c()`) or inside a named `sub`. No error is raised —
+`$a` simply stays `Any`.
+
+## Repro (measured 2026-08-28, release build, against `raku` as the oracle)
+
+```
+$ mutsu -e 'use MONKEY-SEE-NO-EVAL; my $a; EVAL q|$a = 32|; say $a.raku'
+32                                    # raku: 32   OK
+$ mutsu -e 'use MONKEY-SEE-NO-EVAL; my $a; { EVAL q|$a = 32| }; say $a.raku'
+32                                    # raku: 32   OK
+$ mutsu -e 'use MONKEY-SEE-NO-EVAL; my $a; my $c = { EVAL q|$a = 32| }; $c(); say $a.raku'
+Any                                   # raku: 32   WRONG
+$ mutsu -e 'use MONKEY-SEE-NO-EVAL; my $a; sub w(&c) { &c() }; w({ EVAL q|$a = 32| }); say $a.raku'
+Any                                   # raku: 32   WRONG
+$ mutsu -e 'use MONKEY-SEE-NO-EVAL; my $a; sub w() { EVAL q|$a = 32| }; w(); say $a.raku'
+Any                                   # raku: 32   WRONG
+```
+
+The construct is Test-free; the `Test` module is only the shape that surfaced it.
+
+## Where it bites
+
+`roast/S02-lexical-conventions/comments.t` test 41 under `MUTSU_REAL_TEST=1`:
+
+```raku
+my $a;
+lives-ok { EVAL '$a = q{ 32 }' }, 'sanity check';
+is $a, ' 32 ', 'sanity check';        # <- fails: got (Any)
+```
+
+The real `Test.rakumod`'s `lives-ok` is Raku-level and calls the Callable, so the
+`EVAL` runs one closure-invocation deep and the write is lost. mutsu's native
+`lives-ok` does not take that path, which is why the file passes natively and
+regresses under the real module (`todo/deep/vendor-real-test-module.md`).
+
+## Likely root cause (not verified)
+
+`eval_eval_string` snapshots and restores env around the snippet
+(`env_snapshot`, `eval_pre_lexicals`, `eval_shadowed` in
+`src/runtime/system.rs` / `src/runtime/system_eval_string.rs`). It deliberately
+keeps *assignments* to pre-existing keys while dropping the snippet's own `my`
+declarations. That works while the caller's `$a` is a plain env key. Inside an
+invoked closure / a compiled routine the caller's `$a` is reached through the
+capture/locals machinery instead, so the write lands in the EVAL's borrowed env
+and is discarded on the way out. Confirm with `rust-gdb` on the writeback path
+rather than assuming.
+
+## Why it is not a one-liner
+
+It sits on the `locals`↔`env` dual store and the closure-capture writeback
+(`capture_closure_env`, `apply_pending_rw_writeback`), which is the area
+`PLAN.md` §6 / the Slice F campaign owns. A naive "always write env through"
+would resurrect the leaks the snapshot/restore exists to prevent (a `my` inside
+the EVAL must stay EVAL-scoped, `EVAL 'my $a = 999'` must not clobber the
+caller's `$a`) — both are pinned by existing tests.

--- a/todo/tickets/parse-errors-collapse-to-x-syntax-confused.md
+++ b/todo/tickets/parse-errors-collapse-to-x-syntax-confused.md
@@ -1,0 +1,52 @@
+# mutsu collapses most parse errors to `X::Syntax::Confused`, and only the native `throws-like` hides it
+
+Eight roast assertions across seven whitelisted files ask `throws-like` for a
+*specific* compile-time exception class. mutsu raises a generic
+`X::Syntax::Confused` (or `X::AdHoc`) for all of them. They pass today only
+because mutsu's **native** `throws-like` deliberately broadens the type check:
+`src/runtime/test_functions/throws_like.rs` accepts any error whose message
+contains `"Confused"` / `"parse error"` whenever the *expected* class starts with
+`X::Syntax`, and has a similar widening for `X::Comp` / `X::Comp::Group`. The
+real `Test.rakumod` compares `$_ ~~ $expected` and reports "right exception type
+… FAILED", so every one of these regresses under `MUTSU_REAL_TEST=1`
+(`todo/deep/vendor-real-test-module.md`).
+
+**This is a mutsu bug, not a `Test` bug.** The fix is to raise the right class,
+not to keep the native provider's leniency — and each of these is independent of
+the others, so this is a volume ticket that parallelises.
+
+## Measured 2026-08-28 (release build; `raku` column is the oracle)
+
+| snippet (inside `EVAL`) | mutsu | raku | roast file / assertion |
+| --- | --- | --- | --- |
+| `@arr [0]` | `X::Syntax::Confused` | `X::Syntax::Missing` | `S02-lexical-conventions/minimal-whitespace.t` #1 |
+| `42.:all` | `X::Syntax::Confused` | `X::Syntax::Number::IllegalDecimal` | `S02-lexical-conventions/minimal-whitespace.t` #17 |
+| `say 42.:all` | `X::Syntax::Confused` | `X::Syntax::Number::IllegalDecimal` | `S02-lexical-conventions/minimal-whitespace.t` #18 |
+| `"${$scalar}"` | `X::AdHoc` | `X::Obsolete` | `S03-operators/context.t` #27 |
+| `"@{$array}"` | `X::AdHoc` | `X::Obsolete` | `S03-operators/context.t` #29 |
+| `rt54804( 1, , 3, )` | `X::Syntax::Confused` | `X::Syntax::InfixInTermPosition` | `S06-signature/optional.t` #15 |
+| `{my $foo; $^foo;}(1)` | `X::AdHoc` | `X::Redeclaration` | `S06-signature/positional-placeholders.t` #7 |
+| `{*.{}}()` | `X::Syntax::Confused` | `X::Syntax::Malformed` | `S02-types/whatever.t` #67 |
+| `'RT' ~~ m\c[SNOWMAN].\c[COMET]` | `X::Syntax::Confused` | `X::Comp::Group` | `S02-literals/quoting-unicode.t` #72 |
+
+Note the two `X::Obsolete` rows: the *unquoted* forms (`${$scalar}`, `@{$array}`)
+already raise `X::Obsolete` correctly — only the interpolated string forms fall
+back to `X::AdHoc`, so the deprecated-P5-dereference detector exists and simply
+does not run inside `qq` interpolation. That pair is probably the cheapest of
+the nine.
+
+## Not in this family (separately filed / already known)
+
+- `S12-enums/misc.t` #26 — `X::Enum::NoValue` is raised with the right class but
+  an empty `.enum` attribute (`Expected: Direction, Got: `).
+- `S32-exceptions/misc2.t` #13-15 — `X::Placeholder::Mainline` is not raised at
+  all; recorded as a separate gap in `todo/deep/vendor-real-test-module.md`
+  (2026-08-28).
+- `S02-lexical-conventions/comments.t` #41 — not an exception-class issue at all;
+  see `todo/tickets/eval-write-to-outer-lexical-lost-inside-a-closure-or-routine.md`.
+
+## Method note
+
+Do not "fix" any of these by widening `throws_like.rs` further. The point of the
+campaign is to retire the native provider, and every widening there is a
+divergence that has to be paid back later.


### PR DESCRIPTION
An `EVAL` whose snippet fails silently returned a value instead of throwing whenever the `EVAL` ran inside a routine — the exact shape the real `Test.rakumod`'s Raku-level `throws-like` puts it in, so it reported "code dies FAILED" while mutsu's native provider passed.

```
mutsu (before)                          raku
A 10_:     died=True  X::Syntax::Confused    died=True  X::Syntax::Confused
B 10_.0:   died=False -                      died=True  X::Syntax::Confused
C routine: died=False -                      died=True  X::Undeclared::Symbols
D plain:   died=True  X::AdHoc               died=True  X::AdHoc
```

Investigated with `rust-gdb` (no rebuild-per-guess): **two unrelated mechanisms** with the same shape, not one.

## 1. The topic occupies the identifier `_`

Neither `10_` nor `10_.0` is a parse error in mutsu — `parse_program` returns the *same* tree in both contexts, `Expr::InfixFunc { name: "_", .. }`, because the parser accepts any non-reserved word as a speculative runtime-installable `infix:<word>`. The error is raised much later by the runtime's unresolvable-infix fallback.

`$_` is stored in `env` under the **sigil-less key `_`**, and entering a compiled routine seeds the implicit topic with the `Any` *type object*. `resolve_bare_type_name` — and three sibling bare-name type/role lookups — resolve a short type name through exactly such an `env` `Package` binding, because that is how a lexical `my class Foo` is reachable. So inside any routine `_` resolved to `Any`, and `call_function_fallback`'s coercion arm turned the unresolvable `_(10, 0.0)` into `Any(10, 0.0)`, which type-matches and **returns its argument list**.

General, not EVAL-specific (all measured against `raku`):

```
sub f() { say _(1,2) }; f()          # was: (1 2)   raku: Undeclared name: _
sub f() { say 1 _ 2 }; f()           # was: (1 2)   raku: Two terms in a row
sub f() { my _ $x = 3; say $x }; f() # was: 3       raku: Type '_' is not declared
```

Fixed with `env::is_magic_sigilless_key`, a documented one-name guard at those four lookups. `_` is the only sigil-less magic env key that is also a legal bare identifier.

## 2. EVAL's `&?ROUTINE` check consulted the *caller's* routine stack

`if code.contains("&?ROUTINE") && self.routine_stack.is_empty()` — but `&?ROUTINE` is resolved lexically at compile time and an `EVAL`'d string is its own compilation unit, so that gate was wrong in **both** directions: it accepted a mainline `&?ROUTINE` in the snippet whenever the EVAL sat inside a `sub`, and rejected `EVAL 'sub g { &?ROUTINE.name }; g()'` from mainline, which raku accepts.

Replaced with a structural post-parse walk over the snippet's own statements (`runtime/eval_routine_magicals.rs`, modelled on `parser::whenever_scope`), run with the other `check_eval_*` passes. One documented limitation: `-> { }` and `sub ($x) { }` both lower to `AnonSubParams`/`Lambda` with nothing to tell them apart, so both count as routine boundaries — per the walker's conservatism rule that can only *miss* an offending use, never invent one.

## Measured, file by file (both providers)

`roast/S02-literals/underscores.t` and `roast/S02-magicals/subname.t` now **PASS** under `MUTSU_REAL_TEST=1` and still pass natively. **Roast correctness regressions 57 -> 55.**

The other nine files nominated for this mechanism are a **different family**: they *do* throw in both contexts, with the wrong class (`X::Syntax::Confused`/`X::AdHoc` where rakudo raises `X::Syntax::Missing`, `X::Syntax::Number::IllegalDecimal`, `X::Obsolete`, `X::Redeclaration`, …), masked by the native `throws-like`'s deliberate leniency. Filed with the measured table as `todo/tickets/parse-errors-collapse-to-x-syntax-confused.md`, plus `todo/tickets/eval-write-to-outer-lexical-lost-inside-a-closure-or-routine.md` for a separate bug the triage turned up (`EVAL '$a = 32'` loses the write inside an invoked closure/routine).

## Verification

- The four-line repro now matches `raku` exactly.
- Pin: `t/eval-parse-failure-propagates-through-block-call.t` — 14 assertions, green under `raku`, under the native provider, and under `MUTSU_REAL_TEST=1`.
- `make test` green (3518 files, 35036 tests).
- 823-file targeted roast sweep (release) over every whitelisted file in the synopses that consume bare-name type resolution and EVAL plumbing (`S02`–`S06`, `S09`–`S12`, `S14`, `S32-exceptions`, `integration`): all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
