### PR TITLE
fix(array): read a shared container cell through, not as, the value

### DIFF
--- a/src/runtime/methods_mut_dispatch.rs
+++ b/src/runtime/methods_mut_dispatch.rs
@@ -1477,7 +1477,16 @@ impl Interpreter {
                         "callmethodmutwithvalues",
                         "array-squish",
                     );
-                    let current = self.env.get(&key).cloned().unwrap_or(target.clone());
+                    // Read THROUGH a shared `ContainerRef` cell: a `$scalar = @arr`
+                    // share, an rw/`\(...)` argument capture or a `:=` rebind used
+                    // as a sub argument leaves the env entry holding the cell, and
+                    // squishing the cell itself wrapped the whole array as one
+                    // element (`@a.squish.List` gave `([...],)`).
+                    let current = self
+                        .env
+                        .get(&key)
+                        .map(Value::deref_container)
+                        .unwrap_or_else(|| target.clone());
                     let squished = self.dispatch_squish(current, &args)?;
                     if self.in_lvalue_assignment {
                         let squished_items = match squished.view() {

--- a/src/vm/vm_misc_assign.rs
+++ b/src/vm/vm_misc_assign.rs
@@ -198,7 +198,14 @@ impl Interpreter {
                 .position(|n| n == &name)
                 .and_then(|idx| self.locals.get(idx).cloned());
             let env_val = self.get_env_with_main_alias(&name);
-            let is_shaped = |v: &Value| crate::runtime::utils::shaped_array_shape(v).is_some();
+            // Read through a shared `ContainerRef` cell: a `$scalar = @arr` share
+            // or an rw/`\(...)` argument capture replaces the store's entry with
+            // the cell, and a bare `shaped_array_shape` on the cell answers `None`
+            // (see the `SetLocal` sibling for the repro).
+            let is_shaped = |v: &Value| {
+                v.with_deref(crate::runtime::utils::shaped_array_shape)
+                    .is_some()
+            };
             let current_val = match (&local_val, &env_val) {
                 (Some(l), _) if is_shaped(l) => local_val.clone(),
                 (_, Some(e)) if is_shaped(e) => env_val.clone(),
@@ -207,7 +214,7 @@ impl Interpreter {
             };
             let current_shape = current_val
                 .as_ref()
-                .and_then(crate::runtime::utils::shaped_array_shape)
+                .and_then(|v| v.with_deref(crate::runtime::utils::shaped_array_shape))
                 .or_else(|| {
                     // Also check declared shape metadata for multi-dim
                     let key = format!("__mutsu_shaped_array_dims::{}", name);
@@ -251,8 +258,8 @@ impl Interpreter {
                     );
                     crate::runtime::utils::mark_shaped_array(&assigned, Some(shape));
                     // Preserve container type metadata from old array
-                    if let Some(ref cv) = current_val
-                        && let Some(info) = self.container_type_metadata(cv)
+                    if let Some(cv) = current_val.as_ref().map(Value::deref_container)
+                        && let Some(info) = self.container_type_metadata(&cv)
                     {
                         assigned = self.tag_container_metadata(assigned, info);
                     }

--- a/src/vm/vm_var_assign_local.rs
+++ b/src/vm/vm_var_assign_local.rs
@@ -190,11 +190,16 @@ impl Interpreter {
             // instead of shrinking. The local slot and the env copy can diverge
             // (the `env_dirty` dual store), so consult whichever currently holds a
             // shaped value.
-            let lhs_shape =
-                crate::runtime::utils::shaped_array_shape(&self.locals[idx]).or_else(|| {
+            // Both stores are read THROUGH a shared `ContainerRef` cell: a
+            // `$scalar = @arr` share or an rw/`\(...)` argument capture replaces
+            // the slot with the cell, and a bare `shaped_array_shape` on the cell
+            // answers `None` (see the `SetLocal` sibling for the repro).
+            let lhs_shape = self.locals[idx]
+                .with_deref(crate::runtime::utils::shaped_array_shape)
+                .or_else(|| {
                     self.get_env_with_main_alias(name)
                         .as_ref()
-                        .and_then(crate::runtime::utils::shaped_array_shape)
+                        .and_then(|v| v.with_deref(crate::runtime::utils::shaped_array_shape))
                 });
             let assigned_has_own_shape = crate::runtime::utils::shaped_array_shape(&assigned)
                 .is_some()
@@ -206,6 +211,7 @@ impl Interpreter {
                 && shape.len() == 1
                 && !assigned_has_own_shape
             {
+                let lhs_current = self.locals[idx].deref_container();
                 let items = runtime::value_to_list(&assigned);
                 let item_count = items.len();
                 let mut shaped_items: Vec<Value> = items.into_iter().take(shape[0]).collect();
@@ -213,10 +219,7 @@ impl Interpreter {
                     // Pad with the element type's default (native arrays: int->0,
                     // num->0e0, str->""), not Nil, so clearing a shaped num array
                     // yields `0 0 0 0` rather than empty slots.
-                    let default = {
-                        let old = self.locals[idx].clone();
-                        self.typed_container_default(&old)
-                    };
+                    let default = self.typed_container_default(&lhs_current);
                     Self::autoviv_resize(&mut shaped_items, shape[0], default)?;
                 }
                 assigned = Value::array_with_kind(
@@ -224,7 +227,7 @@ impl Interpreter {
                     crate::value::ArrayKind::Shaped,
                 );
                 crate::runtime::utils::mark_shaped_array(&assigned, Some(shape));
-                if let Some(info) = self.container_type_metadata(&self.locals[idx]) {
+                if let Some(info) = self.container_type_metadata(&lhs_current) {
                     assigned = self.tag_container_metadata(assigned, info);
                 }
             }

--- a/src/vm/vm_var_assign_set_local.rs
+++ b/src/vm/vm_var_assign_set_local.rs
@@ -1106,11 +1106,18 @@ impl Interpreter {
                     assigned.view(),
                     ValueView::Array(_, crate::value::ArrayKind::Shaped)
                 );
-            let lhs_shape = crate::runtime::utils::shaped_array_shape(&self.locals[idx]);
+            // Read the LHS's current value THROUGH a shared `ContainerRef` cell:
+            // a `$scalar = @arr` share (`MarkArrayShareSource`) or an rw/`\(...)`
+            // argument capture (`WrapVarRef`) replaces this slot with the cell,
+            // and a bare `shaped_array_shape` on the cell answers `None` — which
+            // silently turned the next whole assignment into an unshaped,
+            // truncated array (`my @a[4]; peek(@a); @a = "x","y"` gave 2 elems).
+            let lhs_shape = self.locals[idx].with_deref(crate::runtime::utils::shaped_array_shape);
             if let Some(shape) = &lhs_shape
                 && shape.len() == 1
                 && !assigned_has_own_shape
             {
+                let lhs_current = self.locals[idx].deref_container();
                 let items = runtime::value_to_list(&assigned);
                 let item_count = items.len();
                 let mut shaped_items: Vec<Value> = items.into_iter().take(shape[0]).collect();
@@ -1118,10 +1125,7 @@ impl Interpreter {
                     // Pad with the element type's default (native arrays: int->0,
                     // num->0e0, str->""), not Nil, so clearing a shaped num array
                     // yields `0 0 0 0` rather than empty slots.
-                    let default = {
-                        let old = self.locals[idx].clone();
-                        self.typed_container_default(&old)
-                    };
+                    let default = self.typed_container_default(&lhs_current);
                     Self::autoviv_resize(&mut shaped_items, shape[0], default)?;
                 }
                 assigned = Value::array_with_kind(
@@ -1130,7 +1134,7 @@ impl Interpreter {
                 );
                 crate::runtime::utils::mark_shaped_array(&assigned, Some(shape));
                 // Preserve container type metadata
-                if let Some(info) = self.container_type_metadata(&self.locals[idx]) {
+                if let Some(info) = self.container_type_metadata(&lhs_current) {
                     assigned = self.tag_container_metadata(assigned, info);
                 }
             } else if !is_bind

--- a/t/shaped-native-array-survives-sub-argument.t
+++ b/t/shaped-native-array-survives-sub-argument.t
@@ -1,0 +1,119 @@
+use Test;
+
+plan 24;
+
+# A shaped (fixed-dimension) array must keep its shape after the variable has
+# been shared into a scalar container -- by a `$scalar = @arr` share, by an
+# argument capture, or by a `:=` rebind used as an argument. Those all replace
+# the variable's slot with a shared `ContainerRef` cell, and the whole-array
+# assignment path used to read the cell instead of the array inside it, so the
+# shape was lost and the next `@arr = ...` silently shrank the array.
+
+sub peek(Mu $got) { $got.defined }
+sub peek2($got)   { $got.defined }
+sub peek3(@got)   { @got.elems }
+
+# --- native shaped array, via a sub argument -------------------------------
+{
+    my @a := array[str].new(:shape(4), "a", "b", "c", "d");
+    peek(@a);
+    @a = "x", "y";
+    is @a.elems, 4, 'native shaped str array keeps its shape across a sub argument';
+    is @a.join(':'), 'x:y::', 'and refills the trailing slots with the element default';
+    is-deeply @a.shape.List, (4,), '.shape still reports the fixed dimension';
+}
+
+# --- the assignment's own result as the argument ---------------------------
+{
+    my @b := array[str].new(:shape(4), "a", "b", "c", "d");
+    peek((@b = ()));
+    @b = "x", "y";
+    is @b.elems, 4, 'the result of `@arr = ()` as a sub argument does not unshape @arr';
+    is @b.join(':'), 'x:y::', 'and the later assignment still refills';
+}
+
+# --- plain scalar copy / bind ----------------------------------------------
+{
+    my @c[4] = "a", "b", "c", "d";
+    my $copy = @c;
+    @c = "x", "y";
+    is @c.elems, 4, '`my $s = @shaped` does not unshape @shaped';
+    is $copy.elems, 4, 'and the shared scalar sees the refilled array';
+}
+
+{
+    my @d[4] = "a", "b", "c", "d";
+    my $alias := @d;
+    @d = "x", "y";
+    is @d.elems, 4, '`my $s := @shaped` does not unshape @shaped';
+    is $alias.elems, 4, 'and the bound scalar sees the refilled array';
+}
+
+# --- every parameter shape -------------------------------------------------
+{
+    my @e[4] = "a", "b", "c", "d";
+    peek2(@e);
+    @e = "x", "y";
+    is @e.elems, 4, 'an untyped scalar parameter does not unshape the argument';
+}
+
+{
+    my @f[4] = "a", "b", "c", "d";
+    peek3(@f);
+    @f = "x", "y";
+    is @f.elems, 4, 'an `@` parameter does not unshape the argument';
+}
+
+# --- native int/num keep their element defaults ----------------------------
+{
+    my @g := array[int].new(:shape(3), 1, 2, 3);
+    peek(@g);
+    @g = 7, 8;
+    is @g.elems, 3, 'native shaped int array keeps its shape';
+    is-deeply @g.List, (7, 8, 0), 'and pads with the int element default';
+}
+
+{
+    my @h := array[num].new(:shape(3), 1e0, 2e0, 3e0);
+    peek(@h);
+    @h = 7e0, 8e0;
+    is @h.elems, 3, 'native shaped num array keeps its shape';
+    is-deeply @h.List, (7e0, 8e0, 0e0), 'and pads with the num element default';
+}
+
+# --- the element type survives too -----------------------------------------
+{
+    my @i := array[str].new(:shape(4), "a", "b", "c", "d");
+    peek(@i);
+    @i = "x", "y";
+    ok @i.of === str, 'the element type survives the reshaping assignment';
+}
+
+# --- `.squish` reads through the shared cell -------------------------------
+{
+    my @j := array[str].new("m", "e", "a", "t");
+    peek((@j := array[str].new("nn", "nn", "bb", "uu")));
+    is-deeply @j.squish.List, ("nn", "bb", "uu"),
+      '.squish sees the array through the shared cell, not the cell itself';
+    is-deeply @j.unique.List, ("nn", "bb", "uu"), '.unique agrees';
+    is-deeply @j.repeated.List, ("nn",), '.repeated agrees';
+    is @j.elems, 4, 'and the array itself is unchanged';
+}
+
+{
+    my @k := array[int].new(11, 11, 13, 17);
+    my $share = @k;
+    is-deeply @k.squish.List, (11, 13, 17),
+      '.squish after a `$scalar = @arr` share';
+    is-deeply $share.squish.List, (11, 13, 17),
+      'and through the sharing scalar itself';
+}
+
+# --- an unshaped array must NOT gain a shape -------------------------------
+{
+    my @u = "a", "b", "c", "d";
+    peek(@u);
+    @u = "x", "y";
+    is @u.elems, 2, 'a plain array still shrinks on reassignment';
+    ok @u.shape[0] ~~ Whatever, 'and reports no fixed dimension';
+}

--- a/todo/deep/vendor-real-test-module.md
+++ b/todo/deep/vendor-real-test-module.md
@@ -3488,3 +3488,132 @@ under `raku`, under mutsu's native provider and under `MUTSU_REAL_TEST=1`);
 sweep over every whitelisted file in the synopses that consume bare-name type
 resolution and EVAL plumbing (`S02`-`S06`, `S09`-`S12`, `S14`, `S32-exceptions`,
 `integration`) is green on a release build.
+## 2026-08-28 (fourth entry that day): the 5-file native-typed-array roast cluster closed — two `ContainerRef`-blind read sites
+
+The largest single cluster among the 60 correctness regressions of the entry
+above was five `S09-typed-arrays` files. Both of its bugs turned out to be the
+same *shape* of mistake and neither is Test-specific: a read site that inspects
+a variable's stored `Value` without reading **through** a shared `ContainerRef`
+cell. The real `Test.rakumod` only supplied the context that puts the cell
+there — its `is` / `is-deeply` are Raku subs, so the roast files' `is (@arr =
+()), ...` and `is (@arr := array[$T].new(...)), ...` pass an array variable
+through *argument binding*, which boxes the variable's slot into a cell.
+
+### Bug 1 — a shaped array lost its shape once the variable had been shared
+
+```raku
+sub peek(Mu $got) { }
+my @a := array[str].new(:shape(4), "a","b","c","d");
+peek(@a);            # or: my $s = @a;   or: my $s := @a;
+@a = "x","y";
+say @a.join(":"), " elems=", @a.elems;
+# raku:  x:y:: elems=4      mutsu (before): x:y elems=2
+```
+
+The prompting analysis had this as "the assignment's *result* being bound as a
+sub argument". It is broader than that: **any** promotion of the variable to a
+shared cell does it — a plain `peek(@a)` with no assignment at all, `my $s =
+@a` (`MarkArrayShareSource` → `array_share_assign`, which writes
+`self.locals[source_idx] = container`), `my $s := @a`, and an rw/`\(...)`
+argument capture (`WrapVarRef` → `capture_var_cell_inner`). It is also not
+native-array-specific: a plain `my @d[4]` loses its shape the same way.
+
+Root cause: `runtime::utils::shaped_array_shape` requires
+`ValueView::Array(_, ArrayKind::Shaped)` and answers `None` for anything else,
+including a `ContainerRef` **holding** such an array. All three whole-array
+assignment paths compute their `lhs_shape` from the raw stored value:
+
+- `vm/vm_var_assign_set_local.rs` (`SetLocal`, the statement form),
+- `vm/vm_var_assign_local.rs` (`AssignExprLocal`, the expression form),
+- `vm/vm_misc_assign.rs` (`AssignExpr`, the by-name form).
+
+With `lhs_shape == None` the shape-refill block is skipped, the unshaped RHS is
+stored straight through the cell, and the array silently shrinks. The tell that
+made this confusing: `@a.shape` still answered `(4,)` *between* the call and the
+assignment, because that read goes through a different store — only the
+assignment's `locals[idx]` read saw the cell.
+
+The fix reads all three through the cell (`Value::with_deref`), and inside the
+refill block reads the *old* container through it too, so the padding default
+(`typed_container_default`) and the `array[T]` metadata
+(`container_type_metadata`) are still recovered from the real array. Confirmed
+with `rust-gdb -batch` breaking on the `lhs_shape` line rather than by guessing:
+good case `Some([4])`, bad case `None`, same line, one statement apart.
+
+### Bug 2 — `.squish` on a shared variable squished the cell, not the array
+
+```raku
+sub peek(Mu $got) { }
+my @j := array[str].new("m","e","a","t");
+peek((@j := array[str].new("nn","nn","bb","uu")));
+say @j.squish.List.raku;
+# raku:  ("nn", "bb", "uu")     mutsu (before): (["nn", "nn", "bb", "uu"],)
+```
+
+The prompting analysis expected this might be a separate, large problem; it is
+neither. `runtime/methods_mut_dispatch.rs`'s `"squish"` arm re-reads its
+receiver by name — `self.env.get(&key).cloned().unwrap_or(target.clone())` —
+and after the rebind-in-an-argument the env entry is the `ContainerRef`.
+Squishing a cell yields a one-element result whose single element is the whole
+array. `.unique` / `.repeated` pass right beside it because they never take
+this by-name re-read path (`squish` and `tail` are the two methods
+`vm_native_dispatch.rs` unconditionally bypasses to the interpreter). One
+`.map(Value::deref_container)` fixes it.
+
+Note for the record: the standalone repro *was* findable, contrary to the
+expectation carried into this slice — but only by bisecting the roast file, as
+this ticket's own "a hand-written reproduction of 'the same thing' can lie"
+note predicts. Six hand-written twins (plain `my str @arr`, the mutating
+`for`/`map` pair, an element assign, a `for (int,) -> $T` loop, a `multi sub`
+with `Mu` params) all passed. The one ingredient none of them had was the
+`:=` **rebind used as a sub argument**, which comes from the roast file's
+`is (@arr := array[$T].new("m","e","a","t")), ...` sixty lines earlier.
+
+### Per-file before/after (release build, both providers)
+
+| file | real Test before | real Test after | native before | native after |
+| --- | --- | --- | --- | --- |
+| `S09-typed-arrays/native-shape1-str.t` | 1 failure | pass | pass | pass |
+| `S09-typed-arrays/native-shape1-num.t` | 5 failures | pass | pass | pass |
+| `S09-typed-arrays/native-shape1-int.t` | 10 failures | pass | pass | pass |
+| `S09-typed-arrays/native-int.t` | 10 failures | pass | pass | pass |
+| `S09-typed-arrays/native-str.t` | 1 failure | pass | pass | pass |
+
+So **roast correctness regressions: 57 -> 52** against the 2026-08-28 baseline
+of that entry (the full sweep was not re-run; these are per-file measurements,
+which is what that entry recommends given the `exit 124` noise). This slice ran
+concurrently with the EVAL-suppression entry above, which took the same 57
+baseline to 55 on a disjoint pair of files; composed, the two land at
+**57 -> 50**. Worth
+recording about the timeout family: on the **debug** build `native-int.t` still
+exits 124 under `MUTSU_REAL_TEST=1` with zero failing assertions — the same
+"re-run with headroom before counting it" artifact, now visible per-file and
+not just under the parallel sweep.
+
+Pin: `t/shaped-native-array-survives-sub-argument.t` (24 assertions, verified
+green under real `raku` as well as mutsu — it covers the sub-argument, the
+`$s = @a` share, the `$s := @a` bind, all three parameter shapes, the native
+`int`/`num`/`str` element defaults, `.squish` through both promotion routes,
+and the negative case that a *plain* array still shrinks and still reports no
+fixed dimension).
+
+Verification: `make test` green (3519 files, 35071 tests), two targeted roast
+sweeps chosen from the consumers of what changed (181 files across
+`S09-typed-arrays`, `S09-subscript`, `S32-array`, `S32-list`, `S02-types`,
+`S06-signature`; then 107 more across `S02-names-vars`, `S03-operators`,
+`S04-declarations`, `S06-other`, `S09-*`, `S32-container`, `S12-construction`)
+both green, and `scripts/battery-testsuite.sh` on a **release** build with an
+idle machine: `GATE PASSED`, 273/297 — unchanged.
+
+### What this suggests for the rest of the residue
+
+Both bugs are instances of one class: **a read site that inspects a variable's
+stored `Value` directly instead of through `Value::with_deref`**. Every such
+site is latent until something promotes the variable to a shared cell, and
+passing the variable to a Raku-level routine is exactly such a promotion — which
+is why this class shows up disproportionately in the `MUTSU_REAL_TEST=1`
+regression list and is invisible under the native provider, whose `is` is a Rust
+builtin that never binds an argument. When triaging the remaining roast
+regressions, "does this read go through `with_deref`?" is worth checking early:
+it is cheap, and it found two of the five files in this cluster from the same
+grep.


### PR DESCRIPTION
Closes the five-file `S09-typed-arrays` cluster of the
`todo/deep/vendor-real-test-module.md` campaign — the largest single cluster
among the 60 roast files that pass under mutsu's native TAP provider and regress
under the vendored real `Test.rakumod` (`MUTSU_REAL_TEST=1`).

Both bugs are the same *shape* of mistake and neither is Test-specific: **a read
site that inspects a variable's stored `Value` directly instead of reading
THROUGH a shared `ContainerRef` cell.** Such a site is latent until something
promotes the variable to a cell — a `$scalar = @arr` share
(`MarkArrayShareSource` → `array_share_assign`, which rewrites the *source's own
local slot*), a `$scalar := @arr` bind, or an rw/`\(...)` argument capture
(`WrapVarRef` → `capture_var_cell_inner`). Passing an array variable to a
Raku-level routine is exactly such a promotion, which is why both are invisible
under the native provider, whose `is` is a Rust builtin that never binds an
argument.

## Bug 1 — a shaped array lost its shape once the variable had been shared

```raku
sub peek(Mu $got) { }
my @a := array[str].new(:shape(4), "a","b","c","d");
peek(@a);            # or: my $s = @a;   or: my $s := @a;
@a = "x","y";
say @a.join(":"), " elems=", @a.elems;
# raku:  x:y:: elems=4      before: x:y elems=2
```

`runtime::utils::shaped_array_shape` requires
`ValueView::Array(_, ArrayKind::Shaped)` and answers `None` for a `ContainerRef`
*holding* one, so all three whole-array assignment paths — `SetLocal`
(`vm_var_assign_set_local.rs`), `AssignExprLocal` (`vm_var_assign_local.rs`) and
the by-name `AssignExpr` (`vm_misc_assign.rs`) — computed `lhs_shape = None`,
skipped the shape-refill block entirely, and stored the unshaped RHS straight
through the cell.

They now read the LHS through the cell (`Value::with_deref`), and inside the
refill block read the *old* container through it too, so the padding default
(`typed_container_default` — `int`→0, `num`→0e0, `str`→"") and the `array[T]`
metadata (`container_type_metadata`) are still recovered from the real array.

Not native-array-specific: a plain `my @d[4]` was affected identically. The
confusing tell was that `@a.shape` still answered `(4,)` *between* the call and
the assignment — that read goes through a different store; only the assignment's
`locals[idx]` read saw the cell. Confirmed with `rust-gdb -batch` on the
`lhs_shape` line (good case `Some([4])`, bad case `None`, one statement apart)
rather than by guessing.

## Bug 2 — `.squish` squished the cell instead of the array

```raku
my @j := array[str].new("m","e","a","t");
peek((@j := array[str].new("nn","nn","bb","uu")));
say @j.squish.List.raku;
# raku:  ("nn", "bb", "uu")     before: (["nn", "nn", "bb", "uu"],)
```

`methods_mut_dispatch.rs`'s `"squish"` arm re-reads its receiver by name
(`self.env.get(&key).cloned()`) and got the cell, so the whole array became the
single element of a one-element result. `.unique` / `.repeated` pass right
beside it because they never take that by-name re-read path — `squish` and
`tail` are the two methods `vm_native_dispatch.rs` unconditionally bypasses to
the interpreter. One `.map(Value::deref_container)` fixes it.

Six hand-written twins of the roast context all failed to reproduce this; the
one ingredient none of them had was the `:=` **rebind used as a sub argument**,
which comes from the roast file's `is (@arr := array[$T].new(...)), ...` sixty
lines earlier. Found by bisecting the actual file, as this campaign ticket's own
"a hand-written reproduction of 'the same thing' can lie" note predicts.

## Per-file before/after (release build, both providers)

| file | real Test before | real Test after | native before | native after |
| --- | --- | --- | --- | --- |
| `S09-typed-arrays/native-shape1-str.t` | 1 failure | pass | pass | pass |
| `S09-typed-arrays/native-shape1-num.t` | 5 failures | pass | pass | pass |
| `S09-typed-arrays/native-shape1-int.t` | 10 failures | pass | pass | pass |
| `S09-typed-arrays/native-int.t` | 10 failures | pass | pass | pass |
| `S09-typed-arrays/native-str.t` | 1 failure | pass | pass | pass |

**Roast correctness regressions under the real Test module: 57 → 52.**

## Verification

- `make test` green (3519 files, 35071 tests).
- Pin `t/shaped-native-array-survives-sub-argument.t`, 24 assertions, green
  under real `raku` as well as mutsu. Covers the sub-argument, the `$s = @a`
  share, the `$s := @a` bind, all three parameter shapes (`Mu $x` / `$x` / `@x`),
  the native `int`/`num`/`str` element defaults, `.squish` through both promotion
  routes, and the negative case that a *plain* array still shrinks and still
  reports no fixed dimension.
- Two targeted roast sweeps over the consumers of what changed, both green:
  181 files (`S09-typed-arrays`, `S09-subscript`, `S32-array`, `S32-list`,
  `S02-types`, `S06-signature`) and 107 more (`S02-names-vars`, `S03-operators`,
  `S04-declarations`, `S06-other`, `S09-*`, `S32-container`, `S12-construction`).
- `scripts/battery-testsuite.sh` on a **release** build on an idle machine:
  `GATE PASSED`, 273/297 — unchanged.

`todo/deep/vendor-real-test-module.md` gets a new dated section (appended, not
rewritten) with the mechanisms, the repros, the per-file table, and a note that
"does this read go through `with_deref`?" is worth checking early when triaging
the rest of that residue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
