### PR TITLE
fix(hash): mutate a hash through its shared container cell, not around it

### DIFF
--- a/src/runtime/builtins_multidim_subscript.rs
+++ b/src/runtime/builtins_multidim_subscript.rs
@@ -488,9 +488,14 @@ impl Interpreter {
                     .unwrap_or_else(|| "Any".to_string());
                 let mut leaves: Vec<i64> = Vec::new();
                 Self::collect_slice_leaf_indices(&indices, &mut leaves);
+                // Descend a shared `ContainerRef` cell, exactly as the
+                // associative `:delete` companion below does: `@a` boxed into a
+                // cell (a `:=` rebind, an rw capture, or having been passed to
+                // a Raku-level routine) does not match `with_array_mut`, so
+                // `@a[0, 1]:delete:p` reported the right pairs but deleted
+                // nothing.
                 let was_array = self
-                    .env
-                    .get_mut(var_name)
+                    .env_root_descended_mut(var_name)
                     .and_then(|entry| {
                         entry.with_array_mut(|live, _| {
                             let hole_value =
@@ -660,7 +665,14 @@ impl Interpreter {
             }
         } else if delete_after
             && let Some(var_name) = var_name.as_ref()
-            && let Some(entry) = self.env.get_mut(var_name)
+            // Read/write THROUGH a shared `ContainerRef` cell: `%h` is boxed
+            // into one by a `:=` rebind, an rw / `\(...)` capture, or simply by
+            // being passed to a Raku-level routine. A raw `env.get_mut` then
+            // hands `with_hash_mut` the CELL, which does not match
+            // `ValueView::Hash`, so the whole `:delete` half of an adverb pair
+            // (`%h<a c>:delete:p`, `:delete:k`, ...) was silently dropped while
+            // the `:p`/`:k` half still answered correctly.
+            && let Some(entry) = self.env_root_descended_mut(var_name)
         {
             entry.with_hash_mut(|map| {
                 let h = crate::value::gc_data_mut(map);

--- a/src/runtime/methods_call_dispatch.rs
+++ b/src/runtime/methods_call_dispatch.rs
@@ -1500,10 +1500,26 @@ impl Interpreter {
                     }
                 }
             }
-            // Build the updated hash by merging pairs
+            // Build the updated hash by merging pairs.
+            //
+            // This is the by-value twin of the `%`-sigiled lvalue arm in
+            // `methods_mut_dispatch.rs`, and it must implement the SAME
+            // semantics: it used to hand-roll a version that only understood a
+            // bare `ValuePair` argument and applied push semantics to `append`
+            // as well. Everything else silently vanished -- an alternating
+            // `'k', $v` list, a parenthesised list / `Seq` / `Slip` / `Hash`
+            // argument, `append`'s array flattening, and the element
+            // itemization at the store. That was invisible until
+            // `try_native_hash_mut_bound` started routing `%h.push` on a
+            // variable boxed into a shared `ContainerRef` cell (which passing
+            // it to any Raku-level routine does) through here. Delegate to the
+            // shared `hash_push_collect_pairs` / `hash_push_insert` helpers so
+            // the two implementations cannot drift apart again.
             let ValueView::Hash(arc) = target.view() else {
                 unreachable!()
             };
+            let is_push = method == "push";
+            let pairs = Self::hash_push_collect_pairs(args);
             // Check if we can mutate in-place (shared reference)
             if crate::gc::Gc::strong_count_of(&arc) > 1 {
                 // SAFETY: aliased in-place mutation of a shared hash (guarded by
@@ -1511,48 +1527,17 @@ impl Interpreter {
                 // see `gc_contents_mut`. No borrow into the map is live across
                 // each insert.
                 let data = unsafe { crate::value::gc_contents_mut(&arc) };
-                for arg in args {
-                    if let ValueView::ValuePair(k, v) = arg.view() {
-                        let key = k.to_string_value();
-                        let v = v.clone();
-                        let map = &mut data.map;
-                        if let Some(existing) = map.get(&key) {
-                            let arr = Value::array_with_kind(
-                                crate::gc::Gc::new(crate::value::ArrayData::new(vec![
-                                    existing.clone(),
-                                    v,
-                                ])),
-                                crate::value::ArrayKind::ItemArray,
-                            );
-                            map.insert(key, arr);
-                        } else {
-                            map.insert(key, v);
-                        }
-                    }
+                for (k, v) in pairs {
+                    Self::hash_push_insert(&mut data.map, k, v, is_push);
                 }
                 return Ok(target);
             }
-            // Not shared: build new hash
-            let mut new_map = (**arc).clone();
-            for arg in args {
-                if let ValueView::ValuePair(k, v) = arg.view() {
-                    let key = k.to_string_value();
-                    let v = v.clone();
-                    if let Some(existing) = new_map.get(&key) {
-                        let arr = Value::array_with_kind(
-                            crate::gc::Gc::new(crate::value::ArrayData::new(vec![
-                                existing.clone(),
-                                v,
-                            ])),
-                            crate::value::ArrayKind::ItemArray,
-                        );
-                        new_map.insert(key, arr);
-                    } else {
-                        new_map.insert(key, v);
-                    }
-                }
+            // Not shared: build a new hash
+            let mut new_data: crate::value::HashData = (**arc).clone();
+            for (k, v) in pairs {
+                Self::hash_push_insert(&mut new_data.map, k, v, is_push);
             }
-            return Ok(Value::hash_with_data(Value::hash_arc(new_map)));
+            return Ok(Value::hash_with_data(Value::hash_arc(new_data)));
         }
         // IO::Special.new("<STDOUT>")
         if let ValueView::Package(name) = target.view()

--- a/src/runtime/methods_mut_dispatch.rs
+++ b/src/runtime/methods_mut_dispatch.rs
@@ -1520,8 +1520,25 @@ impl Interpreter {
                     // constraints off the hash's own metadata (authoritative,
                     // travels with COW) falling back to the variable's declared
                     // constraints.
+                    //
+                    // ADR-0039 slice 1, `%`-sigil twin of the `@`-append fix
+                    // below: `%h` may hold a shared `ContainerRef` cell rather
+                    // than the hash itself -- a `%r := %h` rebind, an rw /
+                    // `\(...)` capture, or simply having been passed to a
+                    // Raku-level routine, all of which box the slot. A raw
+                    // `self.env.get(&key)` then sees the CELL, never matches
+                    // `ValueView::Hash`, and the whole arm falls through to the
+                    // "create from target value" fallback at the end, which
+                    // rebuilds a DETACHED hash and overwrites `env[key]` with
+                    // it -- severing the cell, so every alias of the hash goes
+                    // stale. So every read AND write below goes through
+                    // `env_root_descended_mut`, the same cell-descending
+                    // chokepoint the array mutators use. Reading and writing
+                    // through the identical resolution is also what makes the
+                    // `.unwrap()`s below sound.
+                    let stored = self.env_root_descended_mut(&key).map(|v| v.clone());
                     let (key_constraint, value_constraint, is_object_hash) =
-                        match self.env.get(&key).map(Value::view) {
+                        match stored.as_ref().map(Value::view) {
                             Some(ValueView::Hash(h)) => (
                                 h.key_type
                                     .clone()
@@ -1548,7 +1565,8 @@ impl Interpreter {
                         // the duplicate-key array-conflict check can run before the
                         // mutable borrow (type_matches_value needs `&mut self`).
                         let existing: Vec<Option<Value>> = {
-                            let h = match self.env.get(&key).map(Value::view) {
+                            let stored = self.env_root_descended_mut(&key).map(|v| v.clone());
+                            let h = match stored.as_ref().map(Value::view) {
                                 Some(ValueView::Hash(h)) => Some(h),
                                 _ => None,
                             };
@@ -1607,14 +1625,12 @@ impl Interpreter {
                                 }
                             }
                         }
-                        let hash_present = matches!(
-                            self.env.get(&key).map(Value::view),
-                            Some(ValueView::Hash(_))
-                        );
+                        let hash_present = self
+                            .env_root_descended_mut(&key)
+                            .is_some_and(|slot| matches!(slot.view(), ValueView::Hash(_)));
                         if hash_present {
                             return Ok(self
-                                .env
-                                .get_mut(&key)
+                                .env_root_descended_mut(&key)
                                 .unwrap()
                                 .with_hash_mut(|arc_hash| {
                                     // Container identity (§3): push through a shared node.
@@ -1663,15 +1679,13 @@ impl Interpreter {
                     }
 
                     // Fast path: COW via Arc::make_mut (O(1) when refcount=1)
-                    let hash_present = matches!(
-                        self.env.get(&key).map(Value::view),
-                        Some(ValueView::Hash(_))
-                    );
+                    let hash_present = self
+                        .env_root_descended_mut(&key)
+                        .is_some_and(|slot| matches!(slot.view(), ValueView::Hash(_)));
                     if hash_present {
                         let pairs = Self::hash_push_collect_pairs(args);
                         return Ok(self
-                            .env
-                            .get_mut(&key)
+                            .env_root_descended_mut(&key)
                             .unwrap()
                             .with_hash_mut(|arc_hash| {
                                 // Container identity (§3): push through a shared node.

--- a/src/vm/vm_call_method_mut_ops.rs
+++ b/src/vm/vm_call_method_mut_ops.rs
@@ -1837,9 +1837,14 @@ impl Interpreter {
                         // hash (the fallback below) severs the alias, so a
                         // `postcircumfix:<{ }>(\SELF, \k, :$eject){ SELF.DELETE-KEY(k) }`
                         // would not reach the caller's `%h`.
+                        // `env_root_descended_mut` rather than a raw
+                        // `env.get_mut`: the name may hold a shared
+                        // `ContainerRef` cell (a `:=` rebind, an rw capture, or
+                        // simply having been passed to a Raku-level routine),
+                        // which `with_hash_mut` does not match, dropping us into
+                        // the alias-severing rebuild below.
                         let removed_in_place = self
-                            .env_mut()
-                            .get_mut(target_name.as_ref())
+                            .env_root_descended_mut(target_name.as_ref())
                             .and_then(|v| {
                                 v.with_hash_mut(|gc| {
                                     crate::value::gc_data_mut(gc).remove(&key);

--- a/t/hash-mutation-visible-after-sub-argument.t
+++ b/t/hash-mutation-visible-after-sub-argument.t
@@ -1,0 +1,196 @@
+use v6;
+use Test;
+
+# Passing a container to a Raku-level routine boxes its slot into a shared
+# container cell. Every later mutation of that variable must still be visible
+# through the variable itself AND through any alias of it. These all silently
+# no-op'd (or detached the alias) before the `with_deref`-blind read/write sites
+# behind `Hash.push`/`Hash.append` and the `:delete`-with-adverb companion were
+# routed through the cell-descending chokepoint.
+
+plan 28;
+
+sub peek(Mu $got) { }
+
+# --- Hash.push / Hash.append after the hash has been passed as an argument ---
+
+{
+    my %h;
+    %h.push: 'b', 2, 'a', 1, 'c', 3;
+    is-deeply %h, {a => 1, b => 2, c => 3}, 'push before any argument binding';
+    peek(%h);
+    %h.push: (:a(4), :a(5));
+    is-deeply %h, {a => [1, 4, 5], b => 2, c => 3},
+        'stacking push of a pair list survives argument binding';
+}
+
+{
+    my %h;
+    %h.push: 'b', 2;
+    peek(%h);
+    %h.push: 'c', 3;
+    is-deeply %h, {b => 2, c => 3}, 'alternating key/value push survives argument binding';
+}
+
+{
+    my %h = x => 1;
+    peek(%h);
+    %h.push: (:y(2), :z(3));
+    is-deeply %h, {x => 1, y => 2, z => 3}, 'pair-list push survives argument binding';
+}
+
+{
+    my %h = x => 1;
+    peek(%h);
+    %h.push: {y => 2};
+    is-deeply %h, {x => 1, y => 2}, 'hash-argument push survives argument binding';
+}
+
+{
+    my %h = k => [1, 2];
+    peek(%h);
+    %h.append: 'k', [3, 4];
+    is-deeply %h, {k => [1, 2, 3, 4]}, 'append flattens after argument binding';
+}
+
+{
+    my %h = k => 1;
+    peek(%h);
+    %h.push: (k => 2);
+    is-deeply %h, {k => [1, 2]}, 'duplicate-key push stacks after argument binding';
+}
+
+{
+    my %h = x => 1;
+    peek(%h);
+    %h.push('y', 2);
+    is-deeply %h, {x => 1, y => 2}, 'parenthesised push call survives argument binding';
+}
+
+{
+    my %h = x => 1;
+    peek(%h);
+    %h.append('y', 2);
+    is-deeply %h, {x => 1, y => 2}, 'parenthesised append call survives argument binding';
+}
+
+{
+    my %h = x => 1;
+    peek(%h);
+    push %h, 'y', 2;
+    is-deeply %h, {x => 1, y => 2}, 'push listop survives argument binding';
+}
+
+{
+    my %h = x => 1;
+    peek(%h);
+    my $name = 'push';
+    %h."$name"('y', 2);
+    is-deeply %h, {x => 1, y => 2}, 'indirect push call survives argument binding';
+}
+
+# --- the same, observed through an alias ---
+
+{
+    my %h = x => 1;
+    my %alias := %h;
+    peek(%h);
+    %h.push('y', 2);
+    is-deeply %alias, {x => 1, y => 2}, 'alias sees a push made after argument binding';
+    is-deeply %h, %alias, 'the hash and its alias stay the same value';
+}
+
+{
+    my %h = x => 1;
+    my %alias := %h;
+    peek(%h);
+    push %h, 'y', 2;
+    is-deeply %alias, {x => 1, y => 2}, 'alias sees a listop push made after argument binding';
+}
+
+{
+    my %h = a => 1;
+    my $bound := %h;
+    peek($bound);
+    $bound.push('b', 2);
+    is-deeply %h, {a => 1, b => 2}, 'scalar-bound hash push reaches the bind source';
+}
+
+# --- `:delete` combined with a `:k`/`:v`/`:p`/`:kv` adverb ---
+
+{
+    my %h = a => 1, b => 2;
+    peek(%h);
+    my $got = %h<a>:delete;
+    is-deeply $got, 1, 'plain :delete still answers the removed value';
+    is-deeply %h, {b => 2}, 'plain :delete removes after argument binding';
+}
+
+{
+    my %h = a => 1, b => 2;
+    peek(%h);
+    my $got = %h<a>:delete:p;
+    is-deeply $got, (a => 1), ':delete:p answers the removed pair';
+    is-deeply %h, {b => 2}, ':delete:p actually removes after argument binding';
+}
+
+{
+    my %h = a => 1, b => 2;
+    peek(%h);
+    my @got = (%h<a c>:delete:p).list;
+    is-deeply @got, [a => 1], ':delete:p slice answers the present pairs';
+    is-deeply %h, {b => 2}, ':delete:p slice removes after argument binding';
+}
+
+{
+    my %h = a => 1, b => 2;
+    peek(%h);
+    %h<a b>:delete:k;
+    is-deeply %h, {}, ':delete:k slice removes after argument binding';
+}
+
+{
+    my %h = a => 1, b => 2;
+    my %alias := %h;
+    peek(%h);
+    %h<a>:delete:p;
+    is-deeply %alias, {b => 2}, 'alias sees a :delete:p made after argument binding';
+}
+
+# --- the positional twin ---
+
+{
+    my @a = 1, 2, 3;
+    peek(@a);
+    @a[0, 1]:delete:p;
+    is-deeply @a, [Any, Any, 3], ':delete:p on a positional slice removes after argument binding';
+}
+
+{
+    my @a = 1, 2, 3;
+    my @alias := @a;
+    peek(@a);
+    @a[0]:delete;
+    is-deeply @alias, [Any, 2, 3], 'alias sees an array :delete made after argument binding';
+}
+
+# --- the by-value hash push implementation agrees with the lvalue one ---
+
+{
+    my %h = a => 1;
+    my $copy = %h.push('b', 2);
+    is-deeply $copy, {a => 1, b => 2}, 'Hash.push returns the merged hash';
+}
+
+{
+    my %h = k => [1, 2];
+    my $copy = %h.append('k', [3, 4]);
+    is-deeply $copy, {k => [1, 2, 3, 4]}, 'Hash.append flattens in the returned hash';
+}
+
+{
+    my %h;
+    peek(%h);
+    %h.push: 'a', 1, 'a', 2;
+    is-deeply %h, {a => [1, 2]}, 'repeated key in one push stacks after argument binding';
+}

--- a/todo/deep/vendor-real-test-module.md
+++ b/todo/deep/vendor-real-test-module.md
@@ -3617,3 +3617,165 @@ builtin that never binds an argument. When triaging the remaining roast
 regressions, "does this read go through `with_deref`?" is worth checking early:
 it is cheap, and it found two of the five files in this cluster from the same
 grep.
+
+## 2026-08-28 (fifth entry that day): the `%`-sigil half of the same `ContainerRef`-blind class — hash `push`/`append` and `:delete`-with-adverb
+
+The entry above closed the `@`-sigil instances of "a read site that inspects a
+variable's stored `Value` instead of going through `with_deref`" and explicitly
+left the `%`-sigil siblings for a follow-up. This slice took that follow-up.
+The prompting analysis pointed at `runtime/methods_mut_dispatch.rs`'s
+`self.env.get(&key).cloned()` shape; that site is indeed blind and is fixed
+here, but it is **not** what the headline repro was hitting. `rust-gdb -batch`
+settled it in three breakpoints and zero rebuilds:
+
+### The headline bug was a fast-path delegating to a weaker implementation
+
+```raku
+sub peek(Mu $got) { }
+my %h;
+%h.push: 'b', 2, 'a', 1, 'c', 3;
+peek(%h);                       # boxes %h's slot into a shared ContainerRef cell
+%h.push: (:a(4), :a(5));
+say %h.raku;
+# raku:  {:a($[1, 4, 5]), :b(2), :c(3)}     mutsu (before): {:a(1), :b(2), :c(3)}
+```
+
+The second `.push` was lost outright — not merely invisible to the read, as the
+prompting analysis had it: a plain `say %h.raku` right after it was stale too.
+
+`vm/vm_call_method_mut_ops.rs`'s `try_native_hash_mut_bound` intercepts
+`%h.push` / `%h.append` whenever the name's env entry is a `ContainerRef`,
+unwraps the cell, and delegates to `call_method_with_values` on the inner hash
+so the write lands through the cell. That routing is right. The problem is
+where it lands: `runtime/methods_call_dispatch.rs`'s by-value `Hash.push` arm was
+an inline hand-rolled duplicate of the `%`-sigiled lvalue arm, and it only
+understood a bare `ValuePair` argument. Everything else silently vanished:
+
+- an alternating `'k', $v, 'k2', $v2` list,
+- a parenthesised list / `Seq` / `Slip` / `Hash` argument,
+- `append`'s array-flattening semantics (it applied `push` semantics to both),
+- the element itemization at the store.
+
+Nothing noticed because the by-value arm was only reachable from routes that
+happened to pass plain pairs — until `try_native_hash_mut_bound` started
+funnelling every cell-boxed `%h.push` through it, and passing a hash to *any*
+Raku-level routine boxes it. Under the native provider `is`/`is-deeply` are Rust
+builtins that never bind an argument, so the whole family was invisible there;
+under the real `Test.rakumod` they are Raku subs, and the first `is %h, ...` in a
+file arms the bug for every later `.push` in that file.
+
+The fix deletes the duplicate: the by-value arm now calls the same
+`hash_push_collect_pairs` / `hash_push_insert` helpers the lvalue arm uses, so
+the two implementations of `Hash.push`/`Hash.append` cannot drift apart again.
+
+### Bug 2 — the `%`-sigil lvalue arm really is `with_deref`-blind
+
+Separately observable, and exactly the shape the entry above predicted:
+
+```raku
+sub peek(Mu $got) { }
+my %a; %a<x> = 1;
+my %r := %a;
+peek(%a);
+push %a, 'y', 2;
+say %a.raku, " ", %r.raku;
+# raku:  {:x(1), :y(2)} {:x(1), :y(2)}      mutsu (before): {:x(1), :y(2)} {:x(1)}
+```
+
+The listop and `%h."$name"()` routes reach `call_method_mut_with_values` without
+passing `try_native_hash_mut_bound`, so they land in the `%`-sigil arm, whose
+`hash_present` predicate and both write sites used a raw `self.env.get(&key)` /
+`self.env.get_mut(&key)`. Against a `ContainerRef` those never match
+`ValueView::Hash`, so the arm fell through to its "create from target value"
+fallback, which rebuilds a **detached** hash and overwrites `env[key]` with it —
+severing the cell, so `%r` never sees the push again. The mutation still looked
+right through `%a` itself, which is why it survived so long. Every read and both
+writes now go through `env_root_descended_mut`, the same cell-descending
+chokepoint the array mutators use; reading and writing through the identical
+resolution is also what keeps the `.unwrap()`s sound.
+
+### Bug 3 — `:delete` combined with a `:k`/`:v`/`:p`/`:kv` adverb
+
+Found by auditing the class rather than the one call site — a 27-case
+mutsu-vs-`raku` diff of every hash/array mutator run after a `peek()`:
+
+```raku
+sub peek(Mu $got) { }
+my %h = a=>1, b=>2; peek(%h); %h<a c>:delete:p; say %h.raku;
+# raku:  {:b(2)}      mutsu (before): {:a(1), :b(2)}
+my @a = 1,2,3;      peek(@a); @a[0,1]:delete:p; say @a.raku;
+# raku:  [Any, Any, 3]  mutsu (before): [1, 2, 3]
+```
+
+A bare `:delete` lowers to the `DeleteIndexNamed` opcode, which already descends
+cells. Combined with a `:k`/`:v`/`:p`/`:kv` adverb the compiler instead routes it
+to `__mutsu_subscript_adverb` with a `delete => True` flag, and **both** of that
+builtin's delete companions in `runtime/builtins_multidim_subscript.rs` (the
+associative one and the positional one) used a raw `self.env.get_mut(var_name)`.
+Against a cell, `with_hash_mut` / `with_array_mut` return `None`, and neither
+site has a fallback — so the `:p`/`:k` half answered correctly while the
+`:delete` half was silently dropped. This is what actually failed
+`advent2013-day12.t` test 24; the prompting analysis's guess that the two
+`integration/` files were the same `push` mechanism was right for
+`advent2010-day08.t` and wrong for `advent2013-day12.t`.
+
+`vm/vm_call_method_mut_ops.rs`'s `DELETE-KEY` in-place removal had the same raw
+`env_mut().get_mut(target_name)`; it does have a fallback, but the fallback is
+the alias-severing rebuild, so it was fixed for the same reason.
+
+### Sites audited
+
+| site | verdict |
+| --- | --- |
+| `runtime/methods_call_dispatch.rs` by-value `Hash.push`/`append` | duplicate implementation, replaced by the shared helpers |
+| `runtime/methods_mut_dispatch.rs` `%`-arm: `key_constraint` read | blind, now `env_root_descended_mut` |
+| `runtime/methods_mut_dispatch.rs` `%`-arm: `existing` snapshot | blind, now `env_root_descended_mut` |
+| `runtime/methods_mut_dispatch.rs` `%`-arm: typed `hash_present` + write | blind, now `env_root_descended_mut` |
+| `runtime/methods_mut_dispatch.rs` `%`-arm: untyped `hash_present` + write | blind, now `env_root_descended_mut` |
+| `runtime/builtins_multidim_subscript.rs` associative `:delete` companion | blind, now `env_root_descended_mut` |
+| `runtime/builtins_multidim_subscript.rs` positional `:delete` companion | blind, now `env_root_descended_mut` |
+| `vm/vm_call_method_mut_ops.rs` `DELETE-KEY` in-place removal | blind, now `env_root_descended_mut` |
+| `runtime/methods_mut_dispatch.rs` sigilless-array `unshift`/`prepend` (`env.get_mut`) | reachable only behind `try_native_array_mut`, which already descends; measured green in the 16-case sigilless/bound audit, left alone |
+| `vm/vm_var_index_tracking.rs`, `vm_var_assign_element.rs`, `vm_var_assign_index_named.rs`, `vm_var_assign_post_incdec.rs` `env_mut().get_mut` sites | measured green for every element-assign / incr / slice-assign / nested-assign case in the audit, left alone |
+
+### Per-file before/after (release build, both providers)
+
+| file | real Test before | real Test after | native before | native after |
+| --- | --- | --- | --- | --- |
+| `S32-hash/push.t` | 2 failures (#3, #5) | pass | pass | pass |
+| `integration/advent2010-day08.t` | 1 failure (#7) | pass | pass | pass |
+| `integration/advent2013-day12.t` | 1 failure (#24) | pass | pass | pass |
+
+So **roast correctness regressions: 50 -> 47** against the 2026-08-28 baseline
+(the 57 of the sweep entry above, minus PRs #7078/#7079). Per-file
+measurements, as that entry recommends given the `exit 124` noise. A real-Test
+re-run of all 285 whitelisted files under `S32-hash` / `S09-hash` / `S32-list` /
+`S02-types` / `S06-signature` / `integration` reports exactly the baseline's
+failure set for those directories minus these three files — no new real-Test
+regression.
+
+Pin: `t/hash-mutation-visible-after-sub-argument.t` (28 assertions, verified
+green under real `raku` as well as mutsu — it covers the argument-binding
+promotion, the `:=` rebind, both `%`- and `$`-named bind targets, all five call
+forms of `push`/`append` (colon-listop, parenthesised, listop, `."$name"`,
+`append`), alternating / pair-list / hash / duplicate-key arguments, alias
+visibility, and `:delete` with `:p`/`:k` on both an associative and a positional
+slice).
+
+Verification: `make test` green (3521 files, 35113 tests), two targeted roast
+sweeps chosen from the consumers of what changed (285 files across `S32-hash`,
+`S09-hash`, `S32-list`, `S02-types`, `S06-signature`, `integration`; then 139
+more across `S09-subscript`, `S32-array`, `S32-container`, `S02-names-vars`,
+`S03-operators`, `S12-construction`, `S09-typed-arrays`, `S06-other`,
+`S04-declarations`) both green, and `scripts/battery-testsuite.sh` on a
+**release** build with an idle machine: `GATE PASSED`, 273/297 — unchanged.
+
+### Note for the rest of the residue
+
+The `with_deref` heuristic held up, but with a twist worth carrying forward: two
+of the three bugs here were *write* sites, not read sites, and the headline one
+was a **fast path delegating to a second, weaker implementation of the same
+operation**. When a cell-boxed receiver misbehaves, check not only "does this
+read go through `with_deref`?" but also "does this interception land in the same
+implementation the non-intercepted path uses?" — a duplicated implementation is
+latent divergence that only the cell case exercises.


### PR DESCRIPTION
Part of the `todo/deep/vendor-real-test-module.md` campaign (retiring mutsu's
native TAP provider in favour of the vendored rakudo `Test.rakumod`). This is
the `%`-sigil follow-up that #7079 explicitly left out of scope.

## Root cause

Passing a container to a Raku-level routine boxes its slot into a shared
`ContainerRef` cell. Three write paths did not read *through* that cell, so
every mutation made after such a call was silently lost, or detached from the
variable's aliases. The whole class is invisible under mutsu's native TAP
provider — its `is`/`is-deeply` are Rust builtins that never bind an argument —
and surfaces under the real `Test.rakumod`, whose `is`/`is-deeply` are Raku subs.

Headline repro (no Test module involved):

```raku
sub peek(Mu $got) { }
my %h;
%h.push: 'b', 2, 'a', 1, 'c', 3;
peek(%h);                       # boxes %h's slot into a shared cell
%h.push: (:a(4), :a(5));
say %h.raku;
# raku:  {:a($[1, 4, 5]), :b(2), :c(3)}   mutsu (before): {:a(1), :b(2), :c(3)}
```

### 1. A fast path delegating to a weaker duplicate implementation

`try_native_hash_mut_bound` correctly intercepts `%h.push`/`.append` on a
cell-boxed name and delegates to `call_method_with_values` on the inner hash.
But `runtime/methods_call_dispatch.rs`'s by-value `Hash.push` arm was an inline
hand-rolled duplicate of the `%`-sigiled lvalue arm that only understood a bare
`ValuePair` argument. An alternating `'k', $v` list, a parenthesised list /
`Seq` / `Slip` / `Hash` argument, `append`'s array flattening, and the element
itemization at the store all silently vanished. Now delegates to the same
`hash_push_collect_pairs` / `hash_push_insert` helpers the lvalue arm uses.

### 2. The `%`-sigil lvalue arm really is `with_deref`-blind

The listop and `%h."$name"()` routes bypass the fast path and land in
`methods_mut_dispatch.rs`'s `%` arm, whose `hash_present` predicate and both
write sites used a raw `env.get(&key)` / `env.get_mut(&key)`. Against a cell
those never match `ValueView::Hash`, so the arm fell through to its
"create from target value" fallback, which rebuilds a **detached** hash and
overwrites `env[key]` — severing the cell:

```raku
my %a; %a<x> = 1; my %r := %a; peek(%a); push %a, 'y', 2;
say %a.raku, " ", %r.raku;
# raku:  {:x(1), :y(2)} {:x(1), :y(2)}   mutsu (before): {:x(1), :y(2)} {:x(1)}
```

Now routed through `env_root_descended_mut`, the same cell-descending chokepoint
the array mutators use.

### 3. `:delete` combined with a `:k`/`:v`/`:p`/`:kv` adverb

A bare `:delete` lowers to `DeleteIndexNamed`, which already descends cells.
Combined with an adverb the compiler routes it to `__mutsu_subscript_adverb`
with `delete => True` instead, and **both** of that builtin's delete companions
(associative and positional) used a raw `env.get_mut` with no fallback — so the
`:p`/`:k` half answered correctly while the `:delete` half was dropped:

```raku
my %h = a=>1, b=>2; peek(%h); %h<a c>:delete:p;  # raku: {:b(2)}  mutsu: unchanged
my @a = 1,2,3;      peek(@a); @a[0,1]:delete:p;  # raku: [Any, Any, 3]  mutsu: unchanged
```

`vm_call_method_mut_ops.rs`'s `DELETE-KEY` in-place removal had the same blind
read (its fallback is the alias-severing rebuild), fixed for the same reason.

Diagnosed with `rust-gdb -batch` breakpoints (zero rebuilds), then the class was
audited by diffing 43 hash/array mutation cases against real `raku`.

## Results

Per-file, release build, both providers:

| file | real Test before | real Test after | native before | native after |
| --- | --- | --- | --- | --- |
| `roast/S32-hash/push.t` | 2 failures (#3, #5) | pass | pass | pass |
| `roast/integration/advent2010-day08.t` | 1 failure (#7) | pass | pass | pass |
| `roast/integration/advent2013-day12.t` | 1 failure (#24) | pass | pass | pass |

Roast correctness regressions under `MUTSU_REAL_TEST=1`: **50 -> 47**.

## Verification

- `make test` green (3521 files, 35113 tests).
- Pin `t/hash-mutation-visible-after-sub-argument.t` (28 assertions) — green
  under real `raku` as well as mutsu.
- Targeted roast sweeps, release build: 285 files across `S32-hash`, `S09-hash`,
  `S32-list`, `S02-types`, `S06-signature`, `integration`; then 139 more across
  `S09-subscript`, `S32-array`, `S32-container`, `S02-names-vars`,
  `S03-operators`, `S12-construction`, `S09-typed-arrays`, `S06-other`,
  `S04-declarations`. Both green.
- A real-Test re-run of those 285 files reports exactly the 2026-08-28
  baseline's failure set for those directories minus the three files fixed here
  — no new real-Test regression.
- `scripts/battery-testsuite.sh` on a release build, idle machine:
  `GATE PASSED`, 273/297 — unchanged.
