### PR TITLE
fix(hash): keep typed/object-hash push semantics on a cell-boxed `%h`

### DIFF
--- a/src/vm/vm_call_method_mut_ops.rs
+++ b/src/vm/vm_call_method_mut_ops.rs
@@ -2835,21 +2835,30 @@ impl Interpreter {
             && matches!(bytes.next(), Some(c) if c.is_ascii_alphabetic() || c == b'_')
     }
 
-    /// Bound-hash twin of `try_native_array_mut`: `%h.push((k => v))` /
-    /// `%h.append(...)` where `%h := %g` holds a shared `ContainerRef` cell.
+    /// Bound-hash twin of `try_native_array_mut`: `$r.push((k => v))` /
+    /// `$r.append(...)` where `my $r := %g` holds a shared `ContainerRef` cell.
     /// Only the bound case is intercepted — a plain hash has no cell to detach,
     /// so its existing interpreter writeback (into the receiver's slot) is
     /// already correct. Hash push/append semantics (existing-key value becomes a
     /// list) are non-trivial, so we delegate to the interpreter on the *inner*
     /// hash and write the result back through the cell, keeping every alias
     /// coherent.
+    ///
+    /// A `%`-SIGILED name is deliberately NOT intercepted: the interpreter's own
+    /// `%`-arm (`runtime/methods_mut_dispatch.rs`) descends the cell itself now,
+    /// and it is the only path carrying the richer semantics an intercept here
+    /// would skip — the object-hash `.WHICH` key encoding with its
+    /// `original_keys` record, the typed-hash key/value type checks, and the
+    /// duplicate-key array-conflict check. Routing `%h` through the by-value
+    /// implementation instead silently stringified an object hash's key and
+    /// dropped the type check.
     fn try_native_hash_mut_bound(
         &mut self,
         target_name: &str,
         method: &str,
         args: &[Value],
     ) -> Option<Result<Value, RuntimeError>> {
-        if !matches!(method, "push" | "append") {
+        if !matches!(method, "push" | "append") || target_name.starts_with('%') {
             return None;
         }
         let cell = match self.env().get(target_name).map(Value::view) {

--- a/t/hash-mutation-visible-after-sub-argument.t
+++ b/t/hash-mutation-visible-after-sub-argument.t
@@ -8,7 +8,7 @@ use Test;
 # behind `Hash.push`/`Hash.append` and the `:delete`-with-adverb companion were
 # routed through the cell-descending chokepoint.
 
-plan 28;
+plan 33;
 
 sub peek(Mu $got) { }
 
@@ -193,4 +193,29 @@ sub peek(Mu $got) { }
     peek(%h);
     %h.push: 'a', 1, 'a', 2;
     is-deeply %h, {a => [1, 2]}, 'repeated key in one push stacks after argument binding';
+}
+
+# --- the richer typed/object-hash semantics survive argument binding too ---
+
+{
+    my %h{Int};
+    peek(%h);
+    %h.push(1, 'x');
+    is-deeply %h.keys.list, (1,), 'object-hash push keeps the typed key after argument binding';
+    is-deeply %h{1}, 'x', 'object-hash push stores under the typed key';
+}
+
+{
+    my Int %h = a => 1;
+    peek(%h);
+    dies-ok { %h.push('b', 'not-an-int') },
+        'typed-hash push still type-checks after argument binding';
+}
+
+{
+    my %h is default(42) = a => 1;
+    peek(%h);
+    %h.push('b', 2);
+    is-deeply %h, {a => 1, b => 2}, 'is default(...) hash pushes after argument binding';
+    is-deeply %h<zz>, 42, 'is default(...) survives the push';
 }

--- a/todo/deep/vendor-real-test-module.md
+++ b/todo/deep/vendor-real-test-module.md
@@ -3779,3 +3779,35 @@ operation**. When a cell-boxed receiver misbehaves, check not only "does this
 read go through `with_deref`?" but also "does this interception land in the same
 implementation the non-intercepted path uses?" — a duplicated implementation is
 latent divergence that only the cell case exercises.
+
+### Follow-up the same day: `%`-sigiled names must NOT take the bound-hash fast path
+
+Landing the above exposed one more consequence of routing a cell-boxed `%h`
+through the by-value implementation: the by-value arm carries none of the
+*richer* hash-push semantics the `%`-sigiled lvalue arm does. Measured against
+`raku` right after the fix:
+
+```raku
+sub peek(Mu $got) { }
+my %h{Int};  peek(%h); %h.push(1, 'x'); say %h.raku;
+# raku: (my Any %{Int} = 1 => "x")    mutsu: (my Any %{Int} = "1" => "x")
+my Int %h = a=>1; peek(%h); %h.push('b', 'not-an-int');   # raku dies, mutsu did not
+```
+
+The object hash's `.WHICH` key encoding with its `original_keys` record, the
+typed-hash key/value type checks and the duplicate-key array-conflict check all
+live in the `%` arm. Before this campaign the fast path hid that because it
+dropped the push entirely; afterwards it performed the push, with the wrong key
+representation and no type check.
+
+Since the `%` arm now descends the cell on its own, the fast path is simply
+redundant for a `%`-sigiled name, so `try_native_hash_mut_bound` bails on one.
+It still owns the case the `%` arm cannot see — a *scalar*-named bind
+(`my $r := %g; $r.push(...)`), which is what it was written for. Pinned by five
+more assertions in `t/hash-mutation-visible-after-sub-argument.t` (33 total,
+green under real `raku`).
+
+The general lesson, sharper than the one above: when a fast path "delegates to
+the interpreter", check *which* interpreter arm it lands in. Two arms
+implementing one operation will differ, and the intercept silently picks the
+poorer one.


### PR DESCRIPTION
Follow-up to #7080, same `todo/deep/vendor-real-test-module.md` campaign.

## What #7080 left behind

#7080 fixed `try_native_hash_mut_bound`'s *delegation target* (the by-value
`Hash.push` arm was a weaker duplicate of the `%`-sigiled lvalue arm and is now
the same code). But the by-value arm still carries none of the *richer*
semantics the `%` arm does:

- the object-hash `.WHICH` key encoding with its `original_keys` record,
- the typed-hash key and value type checks,
- the duplicate-key array-conflict check.

Once a `%h` has been passed to a Raku-level routine — which boxes its slot into
a shared `ContainerRef` cell — the fast path intercepted it and those were
skipped:

```raku
sub peek(Mu $got) { }
my %h{Int}; peek(%h); %h.push(1, 'x'); say %h.raku;
# raku:  (my Any %{Int} = 1 => "x")     mutsu: (my Any %{Int} = "1" => "x")

my Int %h = a => 1; peek(%h); %h.push('b', 'not-an-int');
# raku dies; mutsu did not
```

Before #7080 this was masked, because the fast path dropped the push entirely.

## Fix

The `%` arm descends the cell itself now (that was #7080's second fix), so the
fast path is simply redundant for a `%`-sigiled name — `try_native_hash_mut_bound`
bails on one. It still owns the case the `%` arm cannot see: a *scalar*-named
bind (`my $r := %g; $r.push(...)`), which is what it was written for.

## Verification

- `make test` green (3521 files, 35118 tests).
- Pin `t/hash-mutation-visible-after-sub-argument.t` extended to 33 assertions
  (object-hash key, typed-hash `dies-ok`, `is default(...)`), green under real
  `raku` as well as mutsu.
- Targeted roast sweeps, release build: the same 285 + 139 files as #7080, both
  green; a real-Test re-run of the 285 still reports exactly the 2026-08-28
  baseline's failure set for those directories minus the three files #7080 fixed.
- `roast/S32-hash/push.t`, `roast/integration/advent2010-day08.t`,
  `roast/integration/advent2013-day12.t` still pass under **both** providers.
- `scripts/battery-testsuite.sh` on a release build, idle machine:
  `GATE PASSED`, 273/297 — unchanged.
