### PR TITLE
fix(blob): eq/ne between two Blobs compares bytes across Blob types

### DIFF
--- a/news/2026-08/blob-eq-compares-bytes-across-blob-types.md
+++ b/news/2026-08/blob-eq-compares-bytes-across-blob-types.md
@@ -1,0 +1,75 @@
+# `eq`/`ne` between two Blobs now compares bytes across Blob types
+
+`"hi".encode eq Buf[uint8].new(104, 105)` answered `False` in mutsu where rakudo
+answers `True`, and `ne` was wrong in the same way. The two operands hold the
+same two bytes; they differ only in their Blob type (`utf8` vs `Buf[uint8]`).
+
+## The rakudo rule, measured
+
+Rakudo's comparators carry a `(Blob:D $a, Blob:D $b)` candidate
+(`SETTING::src/core.c/Buf.rakumod:1776`). For `eq`/`ne` it compares the **bytes**
+whatever the two Blob types are — verified directly:
+
+```
+$ raku -e 'my $u = "hi".encode; my $b = Buf[uint8].new(104,105);
+           say $u eq $b, " ", $b eq $u, " ", $u ne $b, " ",
+               $u eq Blob[uint8].new(104,105)'
+True True False True
+```
+
+The `.Str` coercion only applies when the *other* side is not a Blob, and there
+`utf8` is the one Blob type with a working `.Str`: `"hi".encode eq "hi"` is
+`True`, while a plain `Buf[uint8]` in a string context dies with
+`X::Buf::AsStr`.
+
+Ordering is a separate rule and was deliberately left alone: rakudo's
+`lt`/`gt`/`le`/`ge`/`cmp` Blob candidates are effectively same-type only, so
+`"hi".encode lt Buf[uint8].new(104,105)` is a type-check failure in rakudo where
+mutsu answers `False`. That divergence, and the missing `X::Buf::AsStr` on
+`Buf eq Str`, are recorded in
+`todo/tickets/blob-comparison-should-die-instead-of-answering.md` together with
+the dozen other `to_str_context()`-based comparison sites they would have to
+move with.
+
+## Root cause
+
+Every string comparator in `src/vm/vm_comparison_order_ops.rs` already had the
+right byte branch — `exec_str_eq_op` and friends all test
+`is_buf_value(&l) && is_buf_value(&r)` and call `buf_cmp_bytes`. The branch was
+simply unreachable for a mixed pair.
+
+`coerce_str_compare_operands` applied `decode_utf8_compare_operand` to each
+operand **independently**, before the comparator body ran. That turned the
+`utf8` side into a decoded `Str`, so the pair stopped being a Blob pair and fell
+into the `to_str_context()` else-branch — where the surviving `Buf[uint8]`
+stringifies to its *gist*, `Buf[uint8]:0x<68 69>`. Comparing `"hi"` against that
+text is `False` for every input, which is exactly the symptom. The same
+mechanism made `"".encode eq Buf[uint8].new()` answer `False`.
+
+The utf8 decode is a property of the **pair**, not of either operand on its own.
+The fix decides it jointly: when both operands are Blob values the decode is
+skipped and the existing byte branch is reached; otherwise both operands are
+decoded exactly as before, preserving `"hi".encode eq "hi"`. Two `utf8`s now
+also route through the byte comparison rather than the decoded-text one, which
+is the same answer — `.encode` produces NFC bytes in both implementations, and
+UTF-8 byte order matches codepoint order.
+
+## Effect
+
+Pinned by `t/blob-comparison-across-types.t`, a 33-assertion matrix over
+utf8/Buf/Blob in both operand positions, differing bytes, differing lengths,
+empty buffers, multi-byte content and utf8-vs-`Str`. Every assertion is green
+under real `raku` as well as under mutsu, which is what proves the file encodes
+rakudo's semantics rather than mutsu's.
+
+This closes two of the regressions in the `MUTSU_REAL_TEST=1` campaign
+(`todo/deep/vendor-real-test-module.md`), where the strict Raku-level `Test`
+module exposes divergences the lenient native Rust `is` hides:
+
+- `roast/S32-io/slurp.t` — test 12, "binary slurp returns correct content"
+  (`is slurp($path, :bin), $test-contents.encode`: a `Buf` against a `utf8`).
+- `roast/S32-io/spurt.t` — tests 1, 4, 12 and 15, "spurting Buf ok" /
+  "spurting Buf with append" (the helper sub runs twice, once per path form).
+
+Both files pass under both providers now; they already passed under the native
+provider before, and continue to.

--- a/src/vm/vm_comparison_order_ops.rs
+++ b/src/vm/vm_comparison_order_ops.rs
@@ -20,8 +20,27 @@ impl Interpreter {
         right: Value,
     ) -> Result<(Value, Value), RuntimeError> {
         let caller_code = self.current_code;
-        let left = Self::decode_utf8_compare_operand(self.coerce_stringy_operand(left)?);
-        let right = Self::decode_utf8_compare_operand(self.coerce_stringy_operand(right)?);
+        let left = self.coerce_stringy_operand(left)?;
+        let right = self.coerce_stringy_operand(right)?;
+        // The utf8 decode is a property of the PAIR, not of either operand on
+        // its own. Rakudo's comparators have a `(Blob:D, Blob:D)` candidate that
+        // compares BYTES whatever the two Blob types are -- measured:
+        // `"hi".encode eq Buf[uint8].new(104, 105)` is True, as is the same
+        // comparison against a `Blob[uint8]` or with the operands swapped. Only
+        // when the other side is NOT a Blob does the `.Str` coercion apply, and
+        // there `utf8` is the one Blob type that decodes
+        // (`"hi".encode eq "hi"` is True). Decoding per-operand made a mixed
+        // pair stop being a Blob pair before the byte branch below was ever
+        // consulted, so it compared the decoded text against the other Blob's
+        // *gist* (`Blob[uint8]:0x<68 69>`) and always answered False.
+        let (left, right) = if Self::is_buf_value(&left) && Self::is_buf_value(&right) {
+            (left, right)
+        } else {
+            (
+                Self::decode_utf8_compare_operand(left),
+                Self::decode_utf8_compare_operand(right),
+            )
+        };
         self.reconcile_caller_after_internal_dispatch(caller_code);
         Ok((left, right))
     }

--- a/t/blob-comparison-across-types.t
+++ b/t/blob-comparison-across-types.t
@@ -1,0 +1,75 @@
+use v6;
+use Test;
+
+# Rakudo's `infix:<eq>`/`infix:<ne>` have a `(Blob:D, Blob:D)` candidate that
+# compares the BYTES, whatever the two Blob types are: `"hi".encode` (a `utf8`)
+# compares equal to a `Buf[uint8]`/`Blob[uint8]` holding the same bytes. Only
+# when one side is NOT a Blob does the `.Str` coercion apply, and there `utf8`
+# is the one Blob type that decodes (`"hi".encode eq "hi"` is True).
+#
+# This file is measured against real `raku` as well as mutsu: every assertion
+# below is green under both.
+
+plan 33;
+
+my $utf8    = "hi".encode;
+my $utf8b   = "hi".encode;
+my $buf     = Buf[uint8].new(104, 105);
+my $buf2    = Buf[uint8].new(104, 105);
+my $blob    = Blob[uint8].new(104, 105);
+
+# --- same type ------------------------------------------------------------
+ok  $utf8 eq $utf8b, 'utf8 eq utf8 (same bytes)';
+nok $utf8 ne $utf8b, 'utf8 ne utf8 (same bytes) is False';
+ok  $buf  eq $buf2,  'Buf[uint8] eq Buf[uint8] (same bytes)';
+nok $buf  ne $buf2,  'Buf[uint8] ne Buf[uint8] (same bytes) is False';
+
+# --- across Blob types ----------------------------------------------------
+ok  $utf8 eq $buf,   'utf8 eq Buf[uint8] (same bytes)';
+ok  $buf  eq $utf8,  'Buf[uint8] eq utf8 (same bytes)';
+nok $utf8 ne $buf,   'utf8 ne Buf[uint8] (same bytes) is False';
+nok $buf  ne $utf8,  'Buf[uint8] ne utf8 (same bytes) is False';
+ok  $utf8 eq $blob,  'utf8 eq Blob[uint8] (same bytes)';
+ok  $blob eq $utf8,  'Blob[uint8] eq utf8 (same bytes)';
+ok  $buf  eq $blob,  'Buf[uint8] eq Blob[uint8] (same bytes)';
+nok $buf  ne $blob,  'Buf[uint8] ne Blob[uint8] (same bytes) is False';
+
+# --- differing bytes ------------------------------------------------------
+my $other = Buf[uint8].new(104, 106);       # "hj"
+nok $utf8 eq $other, 'utf8 eq Buf[uint8] (different bytes) is False';
+ok  $utf8 ne $other, 'utf8 ne Buf[uint8] (different bytes)';
+nok $blob eq $other, 'Blob[uint8] eq Buf[uint8] (different bytes) is False';
+ok  $blob ne $other, 'Blob[uint8] ne Buf[uint8] (different bytes)';
+
+# --- differing lengths ----------------------------------------------------
+my $short = Buf[uint8].new(104);            # "h"
+nok $utf8 eq $short, 'utf8 eq shorter Buf[uint8] is False';
+ok  $utf8 ne $short, 'utf8 ne shorter Buf[uint8]';
+nok $short eq $utf8, 'shorter Buf[uint8] eq utf8 is False';
+ok  $short ne $utf8, 'shorter Buf[uint8] ne utf8';
+
+# --- empty buffers --------------------------------------------------------
+my $empty-utf8 = "".encode;
+my $empty-buf  = Buf[uint8].new();
+my $empty-blob = Blob[uint8].new();
+ok  $empty-utf8 eq $empty-buf,  'empty utf8 eq empty Buf[uint8]';
+ok  $empty-buf  eq $empty-blob, 'empty Buf[uint8] eq empty Blob[uint8]';
+nok $empty-utf8 ne $empty-buf,  'empty utf8 ne empty Buf[uint8] is False';
+nok $empty-utf8 eq $utf8,       'empty utf8 eq non-empty utf8 is False';
+ok  $empty-utf8 ne $buf,        'empty utf8 ne non-empty Buf[uint8]';
+
+# --- utf8 against a plain Str (the one Blob type with a working .Str) -----
+ok  $utf8 eq "hi",   'utf8 eq Str (decoded text)';
+ok  "hi"  eq $utf8,  'Str eq utf8 (decoded text)';
+nok $utf8 ne "hi",   'utf8 ne Str (decoded text) is False';
+nok $utf8 eq "hj",   'utf8 eq different Str is False';
+ok  $utf8 ne "hj",   'utf8 ne different Str';
+
+# --- multi-byte content ---------------------------------------------------
+my $uni      = "\c[SNOWMAN]".encode;
+my $uni-buf  = Buf[uint8].new($uni.list);
+ok  $uni eq $uni-buf, 'multi-byte utf8 eq Buf[uint8] with the same bytes';
+ok  $uni eq "\c[SNOWMAN]", 'multi-byte utf8 eq Str (decoded text)';
+nok $uni eq $buf,     'multi-byte utf8 eq unrelated Buf[uint8] is False';
+
+# vim: ft=raku

--- a/todo/deep/vendor-real-test-module.md
+++ b/todo/deep/vendor-real-test-module.md
@@ -3955,3 +3955,51 @@ The remaining named clusters are `S24-testing/{10-is-approx,14-like-unlike,3-out
 `S24-testing/{2-force_todo,6-done_testing}.t` remain the native-provider-only
 pair, which needs the `#?rakudo eval` fudge directive or an un-whitelisting
 rather than an interpreter fix.
+
+## 2026-08-29: the Buf/handle-I/O cluster, part 1 — `infix:<eq>` across Blob types (40 -> 38)
+
+Taking the `S32-io/{slurp,spurt}.t` pair named in the residue above. Both
+regressed for one reason, and it was a general interpreter bug rather than
+anything about I/O: **`eq`/`ne` between two Blob values of *different* Blob
+types answered the wrong result.**
+
+The two assertions are `is slurp($path, :bin), $test-contents.encode` and
+`is slurp($path, :bin), $buf` / `($buf ~ $buf)` — in each case a `Buf` coming
+back from `slurp :bin` compared against a `utf8` produced by `.encode`. Rakudo's
+`(Blob:D, Blob:D)` `eq` candidate compares the bytes whatever the two Blob types
+are (measured: `"hi".encode eq Buf[uint8].new(104,105)` is `True`, as are the
+swapped and `Blob[uint8]` forms), so the assertion holds there. mutsu answered
+`False` for every such pair. The native `is` never surfaced it because it
+byte-compares Bufs itself (`runtime/test_functions/basic.rs`), bypassing
+`infix:<eq>` entirely.
+
+Root cause: `coerce_str_compare_operands`
+(`src/vm/vm_comparison_order_ops.rs`) decoded a `utf8` operand to a `Str`
+**per operand**, before the comparator body ran. Every comparator already had
+the correct `is_buf_value(&l) && is_buf_value(&r)` byte branch — it was just
+unreachable for a mixed pair, because the decode had already dissolved the Blob
+pair. The surviving Buf then stringified to its gist (`Buf[uint8]:0x<68 69>`),
+which no decoded text ever equals. Fixed by deciding the decode for the *pair*:
+skip it when both operands are Blobs, keep it otherwise (so
+`"hi".encode eq "hi"` still holds).
+
+Per-file, release build, `MUTSU_BIN` set both ways:
+
+| file | native, before | real Test, before | native, after | real Test, after |
+| --- | --- | --- | --- | --- |
+| `roast/S32-io/slurp.t` | PASS 21/21 | FAIL, test 12 | PASS 21/21 | PASS 21/21 |
+| `roast/S32-io/spurt.t` | PASS 62/62 | FAIL, tests 1, 4, 12, 15 | PASS 62/62 | PASS 62/62 |
+
+(The spurt helper `all-basic` runs twice, once per path form, which is why the
+two failing assertions show up as four subtests.)
+
+**Count: 40 -> 38 correctness regressions.** Pinned by
+`t/blob-comparison-across-types.t` (33 assertions, green under real `raku` as
+well as under mutsu). Two adjacent divergences were deliberately left out of
+scope because they require mutsu to start *throwing* where it currently answers
+(`Buf[uint8] eq "hi"` should be `X::Buf::AsStr`; mixed-Blob-type `lt`/`cmp`
+should be a type-check failure); they are written up with the dozen other
+gist-comparing sites they would have to move with in
+`todo/tickets/blob-comparison-should-die-instead-of-answering.md`.
+
+Remaining in this cluster: `S16-io/words.t` and `S32-io/io-cathandle.t`.

--- a/todo/tickets/blob-comparison-should-die-instead-of-answering.md
+++ b/todo/tickets/blob-comparison-should-die-instead-of-answering.md
@@ -1,0 +1,102 @@
+# Blob comparisons that rakudo rejects with a type error, mutsu silently answers
+
+Two families of Blob comparison still diverge from rakudo after the
+`infix:<eq>`/`infix:<ne>` cross-Blob-type byte-comparison fix
+(`news/2026-08/blob-eq-compares-bytes-across-blob-types.md`). Both of them are
+cases where **rakudo throws and mutsu returns a value**, so they are strictly
+riskier to change than the `eq`/`ne` fix was: a new throw can abort a whole test
+file mid-run, and the wrong answers are currently "harmless" in the sense that
+nothing in the whitelisted roast suite depends on them.
+
+## 1. A non-`utf8` Blob in a string context must throw `X::Buf::AsStr`
+
+`Buf`/`Blob` (every parameterisation except `utf8`) has no usable `.Str`;
+rakudo dies rather than stringifying it.
+
+```
+$ raku -e 'say Buf[uint8].new(104,105) eq "hi"'
+Stringification of a Buf[uint8] is not done with 'Stringy'. The
+'decode' method should be used to convert a Buf[uint8] to a Str.
+
+$ ./target/debug/mutsu -e 'say Buf[uint8].new(104,105) eq "hi"'
+False
+```
+
+mutsu falls through to `to_str_context()`, which for a Buf renders the *gist*
+(`Buf[uint8]:0x<68 69>`, `src/value/display.rs:807-828`), so the comparison
+answers `False` for every Str. `.Str`/`.Stringy` on a Buf *already* throws
+`X::Buf::AsStr` in mutsu (`src/builtins/methods_0arg/mod.rs:1331-1355`) — the
+comparators simply never call it, because `coerce_stringy_operand` only
+dispatches a *user-defined* `Stringy`/`Str`, not a native one.
+
+The fix is to make the string comparators (and `leg`, `coll`, `unicmp`, the
+`[eq]`/`[lt]` reduction table, and the `to_str_context()`-based sort
+comparators) raise `X::Buf::AsStr` when a non-`utf8` Blob reaches a genuine
+string context. That is a wide, throw-introducing change touching every site
+listed under "the other decision points" below, which is why it is not folded
+into the `eq`/`ne` fix.
+
+## 2. Ordering ops across two *different* Blob types must throw
+
+Rakudo's `Blob` ordering candidates (`infix:<lt>`/`gt`/`le`/`ge`/`cmp`, from
+`SETTING::src/core.c/Buf.rakumod:1784`) are effectively same-type only: the
+declared signature is `(Blob:D $a, Blob:D $b)` but the body binds the second
+operand to a same-type parameter, so a mixed pair fails the type check.
+
+```
+$ raku -e 'my $u = "hi".encode; say $u lt Buf[uint8].new(104,105)'
+Type check failed in binding to parameter 'other'; expected utf8 but got Buf[uint8]
+
+$ raku -e 'my $u = "hi".encode; say $u cmp Buf[uint8].new(104,105)'
+Type check failed in binding to parameter 'other'; expected utf8 but got Buf[uint8]
+
+$ ./target/debug/mutsu -e 'my $u = "hi".encode; say $u lt Buf[uint8].new(104,105)'
+False
+$ ./target/debug/mutsu -e 'my $u = "hi".encode; say $u cmp Buf[uint8].new(104,105)'
+Same
+```
+
+Same-type ordering (`Buf[uint8] lt Buf[uint8]`, `utf8 lt utf8`) is byte-wise in
+both implementations and already agrees, so only the *mixed* pair diverges.
+`eq`/`ne` deliberately do **not** belong here: they have a genuine
+`(Blob:D, Blob:D)` candidate and compare bytes across types (measured; that is
+the behaviour the accompanying fix implements).
+
+Note that `leg` is a third case again: rakudo routes it through `Str`, so
+`utf8 leg utf8` works (both decode) but `Buf[uint8] leg Buf[uint8]` throws
+`X::Buf::AsStr`. mutsu's `exec_leg_op` has no Blob handling at all and compares
+the two gists.
+
+## The other decision points that would need to move together
+
+Mapped while fixing `eq`/`ne`; every one of these compares two Blobs by their
+hex-gist string today, so they are all wrong in the same way and should be
+settled by whatever shape this ticket lands:
+
+- `src/vm/vm_comparison_order_ops.rs` — `exec_leg_op`, `spaceship_ordering`
+  (reached by `before`/`after`), `exec_coll_op`, `exec_unicmp_op`.
+- `src/vm/vm_comparison_ops.rs` — `cmp_values` (list/range operands).
+- `src/runtime/ops_reduction.rs:548-574` — the `[eq]`/`[lt]`/`[leg]`/`[cmp]`/
+  `before`/`after` reduction and metaop table.
+- `src/runtime/test_functions/comparison.rs:77-79`, `:176-178` — `cmp-ok`'s
+  `"eq"`/`"lt"` handlers.
+- `src/runtime/methods_collection_ops/sort.rs:350, 368, 429, 445` — the
+  fast-path `.sort({ $^a leg $^b })` inline comparators.
+
+Two predicates also need reconciling first: `Interpreter::is_buf_value`
+(`src/vm/vm_coerce_concat_ops.rs:421`) misses `utf32` and the `bufN` spellings
+that the broader `crate::runtime::utils::is_buf_or_blob_class`
+(`src/runtime/utils.rs:237`) covers, and `src/vm/vm_smart_match.rs:335-365`
+carries a third, hand-inlined copy of the same eight-arm list. Any change here
+should collapse them to one predicate rather than adding a fourth copy.
+
+## Minimal repro
+
+```raku
+my $u = "hi".encode;
+my $b = Buf[uint8].new(104, 105);
+say $b eq "hi";   # raku: X::Buf::AsStr   mutsu: False
+say $u lt $b;     # raku: type check failure   mutsu: False
+say $u cmp $b;    # raku: type check failure   mutsu: Same
+say $b leg $b;    # raku: X::Buf::AsStr   mutsu: Same
+```


### PR DESCRIPTION
## The bug

`eq`/`ne` between two Blob values of **different** Blob types answered the wrong result:

```raku
my $u = "hi".encode;              # a utf8
my $b = Buf[uint8].new(104,105);  # a Buf[uint8], same bytes
say $u eq $b;   # raku: True     mutsu: False
say $b eq $u;   # raku: True     mutsu: False
say $u ne $b;   # raku: False    mutsu: True
say $u eq Blob[uint8].new(104,105);   # raku: True   mutsu: False
say "".encode eq Buf[uint8].new();    # raku: True   mutsu: False
```

## The rakudo rule (measured, not assumed)

Rakudo's comparators carry a `(Blob:D $a, Blob:D $b)` candidate (`SETTING::src/core.c/Buf.rakumod:1776`). For `eq`/`ne` it compares the **bytes** whatever the two Blob types are. The `.Str` coercion only applies when the *other* side is not a Blob, and there `utf8` is the one Blob type with a working `.Str`, so `"hi".encode eq "hi"` stays `True`.

## Root cause

Every string comparator in `src/vm/vm_comparison_order_ops.rs` already had the correct byte branch — `exec_str_eq_op` and friends all test `is_buf_value(&l) && is_buf_value(&r)` and call `buf_cmp_bytes`. The branch was simply **unreachable** for a mixed pair.

`coerce_str_compare_operands` applied `decode_utf8_compare_operand` to each operand **independently**, before the comparator body ran. That turned the `utf8` side into a decoded `Str`, so the pair stopped being a Blob pair and fell into the `to_str_context()` else-branch — where the surviving `Buf[uint8]` stringifies to its *gist*, `Buf[uint8]:0x<68 69>`. No decoded text ever equals that, hence `False` for every input.

The utf8 decode is a property of the **pair**, not of either operand on its own. The fix decides it jointly: skip the decode when both operands are Blobs (so the existing byte branch is reached), keep the per-operand decode otherwise. Two `utf8`s now route through the byte comparison too — the same answer, since `.encode` produces NFC bytes in both implementations and UTF-8 byte order matches codepoint order.

## Effect

Closes two of the `MUTSU_REAL_TEST=1` regressions from `todo/deep/vendor-real-test-module.md` (40 -> 38). Both files already passed under the native provider and still do:

| file | native, before | real Test, before | native, after | real Test, after |
| --- | --- | --- | --- | --- |
| `roast/S32-io/slurp.t` | PASS 21/21 | FAIL, test 12 | PASS 21/21 | PASS 21/21 |
| `roast/S32-io/spurt.t` | PASS 62/62 | FAIL, tests 1, 4, 12, 15 | PASS 62/62 | PASS 62/62 |

The native `is` never surfaced this because it byte-compares Bufs itself and bypasses `infix:<eq>` entirely.

## Tests

- New pin `t/blob-comparison-across-types.t`: 33 assertions over utf8/Buf/Blob in both operand positions, differing bytes, differing lengths, empty buffers, multi-byte content and utf8-vs-`Str`. **Green under real `raku` as well as under mutsu**, which is what proves it encodes rakudo's semantics rather than mutsu's.
- `make test` green (3523 files, 35171 tests).
- Targeted roast sweep on a release build under the **native** provider — every whitelisted file under `S32-io`, `S16-io`, `S03-buf`, `S32-str`, `S02-types`, `S03-operators`, `S32-list`: `Files=330, Tests=81347`, `Result: PASS`.

## Deliberately out of scope

Two adjacent divergences need mutsu to start **throwing** where it currently answers, which is a much wider and riskier change; they are written up with the dozen other gist-comparing comparison sites they would have to move with in `todo/tickets/blob-comparison-should-die-instead-of-answering.md`:

- `Buf[uint8] eq "hi"` — raku dies with `X::Buf::AsStr`, mutsu answers `False`.
- mixed-Blob-type ordering (`$u lt $b`, `$u cmp $b`) — raku fails the type check, mutsu answers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
