### PR TITLE
fix(signature): scope a `where` constraint to its declaration, not its caller

### DIFF
--- a/news/2026-08/where-constraint-declaration-scope-capture.md
+++ b/news/2026-08/where-constraint-declaration-scope-capture.md
@@ -1,0 +1,118 @@
+# A `where` constraint now closes over its declaration scope, not its caller's
+
+A parameter's `where` constraint and its default value are the only two
+expressions in a Raku signature that are *evaluated at call time* but *scoped at
+declaration time*. mutsu got the first half right and the second half wrong: both
+were evaluated against whatever frame happened to be calling the routine, so a
+routine that escaped its declaring scope checked its arguments against a
+completely unrelated binding.
+
+## What rakudo actually does
+
+```raku
+my $a = 1;
+{
+    my $a = 3;
+    sub producer {
+        my $a = 2;
+        sub bar($x where $a) { $x }
+    }
+    my &bar := producer();
+    bar(2);   # lives  -- $a is producer's 2
+    bar(1);   # dies
+    bar(3);   # dies   -- the enclosing block's 3 is NOT in scope
+}
+```
+
+mutsu produced the exact mirror image — `bar(2)` died and `bar(3)` lived —
+because `where $a` resolved to the *enclosing block's* `$a = 3`, the binding
+visible at the call site. The failing value being precisely `3` is what made the
+diagnosis unambiguous: this was not a missing lookup, it was a lookup in the
+wrong frame.
+
+Narrowing it with a set of probe shapes showed the damage was wider than the one
+roast assertion. With the constraint moved into an anonymous sub returned from a
+factory (`sub f { my $f = 2; return sub ($x where $f) { $x } }`), *no* value
+passed at all: `$f` was not merely shadowed, it was invisible. The same held for
+a parameter **default** (`sub ($x = $f)`), and for a `where` closing over the
+factory's own parameter.
+
+## Two independent root causes
+
+**1. The compiler never recorded the signature's declaration-time reads as
+captures.** `CompiledCode::compute_free_vars` is a pure scan of a body's
+*opcodes*. A `where` clause and a default value are not compiled into the body at
+all — they are kept on the `ParamDef` AST and interpreted by
+`bind_function_args_values` at call time — so neither ever appeared in
+`free_var_syms`. `capture_closure_env` keeps exactly the free variables plus the
+system names and drops every other plain user lexical, so the name was pruned out
+of the closure's captured env and the call-time evaluation fell through to the
+caller's env. Lexical scoping silently degrading into dynamic scoping.
+
+The machinery to harvest those names already existed —
+`decl_time_param_free_var_syms` compiles each declaration-time expression as a
+throwaway analysis chunk — but it was wired only into the *method* path, and only
+to bubble the names *up* into the enclosing frame's capture set, never into the
+routine's own. The fix adds `Compiler::fold_decl_time_param_captures`, which
+folds those names into the compiled body's own `free_var_syms` right after
+`compute_needs_env_sync` (which is what runs `compute_free_vars`) and before
+`compute_upvalues` and the parent-slot bake consume the set. It is called from
+both `compile_closure_body_with_routine_flag` (which also serves every method
+body) and `compile_sub_body_with_deprecation`. A name the routine declares itself
+— a later parameter constraining on an earlier one, `sub f($a, $b where $a)` — is
+excluded, since the binder has already bound it into the callee env by then.
+
+**2. A named sub escaping as its declaring routine's return value captured a
+flattened env that could not see the routine's own locals.** Raku returns the
+`Sub` when a `sub` declaration is a routine's last statement, and
+`call_compiled_function_named_inner` builds that code object with
+`self.clone_env()`. But a `my $a` inside a routine body lives in the frame's
+local *slot* — mutsu's dual store does not necessarily mirror it into `env` — so
+the flattened snapshot either lacked the name entirely or, under shadowing, still
+carried an enclosing scope's value for it. This was not specific to `where` at
+all: `sub p { my $k = 2; sub b() { $k } }` returned a sub that read `3` from the
+caller instead of its own `2`.
+
+The fix mirrors what `capture_closure_env` already does for an anonymous closure.
+A new `Interpreter::inject_frame_locals_for_free_vars` overwrites each of the
+escaping routine's free variables with the live value of the declaring frame's
+local slot (resolved through the same `resolve_capture_slot` the closure paths
+use, so shadow slots are handled identically), skipping anything that is not a
+plain user lexical — dynamics, the topic and `__mutsu_*` metadata are resolved
+against the live frame by design and must never be frozen. Because the declaring
+frame is *gone* by the time such a sub can be called, its snapshot can never go
+stale, so the injected names are also recorded as
+`SubData::authoritative_captures` (via a new `make_sub_for_routine_owning`): the
+call-time env merge is don't-overwrite by default, and without the vouch a
+same-named lexical in the calling frame would still win.
+
+## Results
+
+The two roast files this frees, both previously green under the native `Test`
+provider and red under `MUTSU_REAL_TEST=1`, now pass under **both**:
+
+| file | test | before (real Test) | after |
+| --- | --- | --- | --- |
+| `roast/S02-types/subset-6e.t` | 39, `where-constraint picks up the right lexical (+)` | FAIL | PASS |
+| `roast/6.c/S02-types/subset-6c.t` | 38, same assertion | FAIL | PASS |
+
+Pinned by `t/where-constraint-lexical-scope.t` (23 assertions, green under real
+`raku` as well as under mutsu): the escaping named sub, its body-free-variable
+twin, the parameter-default twin, escaping anonymous subs and pointy blocks, two
+sibling closures from one factory each keeping their own captured value,
+two-deep shadowing, a `subset`'s `where`, a method parameter's `where`, and a
+later parameter constraining on an earlier one.
+
+Verified with `make test` green, the full 1436-file whitelisted roast suite green
+on a release build, and `scripts/battery-testsuite.sh` green (273/297, the
+whitelisted gate) — the last of those because the change touches closure-capture
+representation, which `make test` and roast between them have historically
+missed.
+
+## Still open
+
+A `class` declared *inside a routine* does not capture that routine's locals at
+all — `sub p { my $m = 2; class C { method go() { $m } }; C.new }` reads `Nil`
+where rakudo reads `2`, with or without a `where` in the signature. That is a
+separate capture channel (class registration, not sub registration) and is
+recorded in `todo/tickets/class-in-routine-does-not-capture-routine-lexicals.md`.

--- a/src/compiler/helpers_method_body.rs
+++ b/src/compiler/helpers_method_body.rs
@@ -273,6 +273,44 @@ impl Compiler {
         out
     }
 
+    /// Fold the outer lexicals a signature's *declaration-time* expressions
+    /// (parameter defaults and `where` constraints) reference into `code`'s OWN
+    /// capture set.
+    ///
+    /// Those expressions are evaluated from the `ParamDef` AST at **call** time
+    /// (`bind_function_args_values`) and never compile into `code.ops`, so
+    /// [`crate::opcode::CompiledCode::compute_free_vars`] — a pure op scan —
+    /// cannot see them. Without this fold the name is absent from
+    /// `free_var_syms`, `capture_closure_env` drops it as a non-free plain user
+    /// lexical, and the constraint/default silently resolves against whatever
+    /// the **calling** frame happens to hold under that name: lexical scoping
+    /// degrading into dynamic scoping (`sub outer { my $a = 2; sub inner($x
+    /// where $a) {...} }` checked `$x` against the caller's `$a`).
+    ///
+    /// A name the routine declares itself — a parameter referenced by a later
+    /// parameter's constraint (`sub f($a, $b where $a)`) — is bound into the
+    /// callee env by the binder before the constraint runs, so it is excluded.
+    pub(crate) fn fold_decl_time_param_captures(
+        &self,
+        code: &mut crate::opcode::CompiledCode,
+        param_defs: &[crate::ast::ParamDef],
+    ) {
+        if param_defs
+            .iter()
+            .all(|pd| pd.default.is_none() && pd.where_constraint.is_none())
+        {
+            return;
+        }
+        for sym in self.decl_time_param_free_var_syms(param_defs) {
+            if sym.with_str(|s| code.locals.iter().any(|l| l == s)) {
+                continue;
+            }
+            if !code.free_var_syms.contains(&sym) {
+                code.free_var_syms.push(sym);
+            }
+        }
+    }
+
     /// [`Self::decl_time_param_free_var_syms`] for one expression.
     pub(crate) fn decl_time_expr_free_var_syms(&self, expr: &Expr) -> Vec<Symbol> {
         let mut chunk_compiler = Compiler::new();

--- a/src/compiler/helpers_sub_body.rs
+++ b/src/compiler/helpers_sub_body.rs
@@ -538,6 +538,12 @@ impl Compiler {
         // channel (the closure paths already read `CompiledCode::source_line`).
         sub_compiler.code.source_line = self.last_source_line;
         sub_compiler.code.compute_needs_env_sync();
+        // See the twin call in `compile_closure_body_with_routine_flag`: a
+        // parameter default / `where` constraint reads its outer lexicals from
+        // the `ParamDef` AST at call time, invisibly to the op scan. A named
+        // sub has no runtime closure-creation op, so this set is what
+        // `RegisterSub` snapshots into the sub's captured env.
+        self.fold_decl_time_param_captures(&mut sub_compiler.code, param_defs);
         let own_compiled_fns = self.import_compiled_functions(
             &mut sub_compiler.code,
             std::mem::take(&mut sub_compiler.compiled_functions),
@@ -1456,6 +1462,13 @@ impl Compiler {
         // last_source_line.
         sub_compiler.code.source_line = sub_compiler.last_source_line.or(self.last_source_line);
         sub_compiler.code.compute_needs_env_sync();
+        // A parameter DEFAULT or `where` constraint is evaluated from the
+        // `ParamDef` AST at call time and never compiles into these ops, so
+        // `compute_free_vars` (which just ran, inside `compute_needs_env_sync`)
+        // cannot see the outer lexicals it reads. Fold them in before the
+        // capture set is consumed by `compute_upvalues` below and by
+        // `add_closure_code_baked`'s parent-slot bake.
+        self.fold_decl_time_param_captures(&mut sub_compiler.code, param_defs);
         // Promote read-only plain-lexical free variables to index-based upvalues.
         // Closure-only (this path compiles anonymous closures/blocks); named subs
         // and the top-level program never get an upvalue array at runtime.

--- a/src/value/value_methods_b.rs
+++ b/src/value/value_methods_b.rs
@@ -533,7 +533,39 @@ impl Value {
         env: Env,
         compiled_routine: Option<Arc<crate::opcode::CompiledFunction>>,
     ) -> Self {
+        Self::make_sub_for_routine_owning(
+            package,
+            name,
+            params,
+            param_defs,
+            body,
+            is_rw,
+            env,
+            compiled_routine,
+            Vec::new(),
+        )
+    }
+
+    /// [`Self::make_sub_for_routine`] plus [`Self::make_sub_owning`]'s vouch:
+    /// the named lexicals are installed from the captured env with OVERWRITE at
+    /// call time instead of losing to a same-named lexical in the calling
+    /// frame. Used when a named `sub` escapes its declaring routine as that
+    /// routine's return value — the declaring frame is gone, so its captured
+    /// bindings are lexically authoritative and can never go stale.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn make_sub_for_routine_owning(
+        package: Symbol,
+        name: Symbol,
+        params: Vec<String>,
+        param_defs: Vec<ParamDef>,
+        body: Vec<Stmt>,
+        is_rw: bool,
+        env: Env,
+        compiled_routine: Option<Arc<crate::opcode::CompiledFunction>>,
+        authoritative_captures: Vec<Symbol>,
+    ) -> Self {
         let mut data = Self::new_code_object(package, name, params, param_defs, body, is_rw, env);
+        data.authoritative_captures = authoritative_captures;
         // Declaration source location for `Code.line`/`Code.file`. Both already
         // ride on the routine's own `CompiledFunction` — the line stamped by
         // `Compiler::compile_sub_body`, the file by

--- a/src/vm/vm_call_named_inner.rs
+++ b/src/vm/vm_call_named_inner.rs
@@ -435,16 +435,33 @@ impl Interpreter {
                 .get(&Symbol::intern(&single_key))
                 .cloned();
             ret_val = if let Some(def) = registered {
-                Value::make_sub_for_routine(
+                // Flatten: a Sub returned as a value is dispatched cross-scope.
+                let mut captured = self.clone_env();
+                let mut owned: Vec<Symbol> = Vec::new();
+                // ...but the flattened env only has what `env` holds. A `my` in
+                // THIS routine's body lives in a local slot, so the returned Sub
+                // would resolve the name against its caller (or, under
+                // shadowing, against an enclosing scope's same-named binding)
+                // instead of its declaration scope. Overwrite with the live slot
+                // value, exactly as `capture_closure_env` does for an anonymous
+                // closure.
+                if let Some(callee) = def.compiled.as_ref() {
+                    owned = self.inject_frame_locals_for_free_vars(
+                        &cf.code,
+                        &callee.code,
+                        &mut captured,
+                    );
+                }
+                Value::make_sub_for_routine_owning(
                     def.package,
                     def.name,
                     def.params.clone(),
                     def.param_defs.clone(),
                     def.body.clone(),
                     def.is_rw,
-                    // Flatten: a Sub returned as a value is dispatched cross-scope.
-                    self.clone_env(),
+                    captured,
                     def.compiled.clone(),
+                    owned,
                 )
             } else {
                 // The plan's own compiled routine (same key this call's

--- a/src/vm/vm_register_ops.rs
+++ b/src/vm/vm_register_ops.rs
@@ -221,6 +221,51 @@ impl Interpreter {
         sym.with_str(|s| code.locals.iter().rposition(|n| n == s))
     }
 
+    /// Overwrite `env`'s entry for each free variable of `callee` that the
+    /// CURRENTLY RUNNING frame (`code`) owns as a local slot, with the live
+    /// slot value.
+    ///
+    /// This is the by-name half of [`Self::capture_closure_env`]'s "upvalue
+    /// read" step, factored out for the one env-capture site that cannot use
+    /// that function: a *named* sub returned as the trailing value of its
+    /// declaring routine (`sub outer { my $a = 2; sub inner {...} }`). That path
+    /// flattens the frame's env with `clone_env()`, but a `my` in a routine body
+    /// lives in the frame's local SLOT and is not necessarily mirrored into
+    /// `env` — so the flattened snapshot either lacks the name entirely or, when
+    /// an enclosing scope declared the same name, still holds the OUTER
+    /// binding's value. Either way the escaping Sub then resolved the name
+    /// against its caller instead of its declaration scope: lexical scoping
+    /// degrading into dynamic scoping.
+    /// Returns the names it installed, so the caller can vouch for them as
+    /// `SubData::authoritative_captures`: the declaring frame is gone by the
+    /// time such a Sub is called, so its snapshot can never be stale, and the
+    /// call-time merge must install it with OVERWRITE rather than losing to a
+    /// same-named lexical in whatever frame invokes it.
+    pub(crate) fn inject_frame_locals_for_free_vars(
+        &self,
+        code: &CompiledCode,
+        callee: &CompiledCode,
+        env: &mut Env,
+    ) -> Vec<crate::symbol::Symbol> {
+        let mut installed = Vec::new();
+        for (i, sym) in callee.free_var_syms.iter().enumerate() {
+            // Dynamics (`$*x`), the topic, attribute twigils and `__mutsu_*`
+            // metadata resolve through their own stores against the LIVE frame
+            // by design — never freeze one into a lexical snapshot.
+            if !sym.with_str(crate::env::is_plain_user_lexical) {
+                continue;
+            }
+            if let Some(slot) =
+                Self::resolve_capture_slot(code, &callee.free_var_parent_slots, i, *sym)
+                && let Some(val) = self.locals.get(slot)
+            {
+                env.insert_sym(*sym, val.clone());
+                installed.push(*sym);
+            }
+        }
+        installed
+    }
+
     pub(super) fn exec_make_anon_sub_op(
         &mut self,
         code: &CompiledCode,

--- a/t/where-constraint-lexical-scope.t
+++ b/t/where-constraint-lexical-scope.t
@@ -1,0 +1,139 @@
+use v6;
+use Test;
+
+plan 23;
+
+# A `where` constraint (and a parameter default) is a closure over the scope
+# the SIGNATURE is written in, not over whatever scope happens to be calling.
+# mutsu used to evaluate both against the caller's frame, so a routine that
+# escaped its declaring scope checked its arguments against the wrong `$a`.
+
+# --- 1. named sub inside a named sub, escaping as the return value ----------
+# (roast/S02-types/subset-6e.t #39, roast/6.c/S02-types/subset-6c.t #38)
+{
+    my $a = 1;                              #OK not used
+    {
+        my $a = 3;                          #OK not used
+        sub producer {
+            my $a = 2;
+            sub bar($x where $a) { $x }     #OK not used
+        }
+        my &bar := producer();
+        lives-ok { bar(2) }, 'named nested sub: where sees the declaring routine lexical';
+        dies-ok  { bar(1) }, 'named nested sub: where rejects a non-matching value';
+        dies-ok  { bar(3) }, 'named nested sub: where does not see the enclosing block lexical';
+    }
+}
+
+# The same escape, but the routine's own body reads the lexical: an escaping
+# named sub is lexically scoped, not dynamically scoped.
+{
+    my $k = 1;                              #OK not used
+    {
+        my $k = 3;                          #OK not used
+        sub kproducer {
+            my $k = 2;
+            sub kbar() { $k }               #OK not used
+        }
+        my &kbar := kproducer();
+        is kbar(), 2, 'escaping named sub reads its declaring routine lexical';
+    }
+}
+
+# ...and a parameter DEFAULT, the other declaration-time signature expression.
+{
+    my $d = 3;                              #OK not used
+    sub dproducer {
+        my $d = 2;
+        sub dbar($x = $d) { $x }            #OK not used
+    }
+    my &dbar := dproducer();
+    is dbar(), 2, 'escaping named sub: parameter default sees the declaring lexical';
+}
+
+# --- 2. anonymous sub returned from a routine ------------------------------
+{
+    my $e = 3;                              #OK not used
+    my &ee;
+    {
+        my $e = 2;
+        &ee = sub ($x where $e) { $x };
+    }
+    lives-ok { ee(2) }, 'escaping anon sub: where sees the declaring block lexical';
+    dies-ok  { ee(3) }, 'escaping anon sub: where does not see the outer lexical';
+}
+
+{
+    sub fproducer {
+        my $f = 2;
+        return sub ($x where $f) { $x };
+    }
+    my &ff := fproducer();
+    lives-ok { ff(2) }, 'escaping anon sub: where resolves an otherwise-invisible lexical';
+    dies-ok  { ff(9) }, 'escaping anon sub: where still rejects';
+}
+
+# A `where` closing over the PRODUCING routine's own parameter.
+{
+    sub gproducer($g) {
+        return sub ($x where $g) { $x };
+    }
+    my &g7 := gproducer(7);
+    my &g8 := gproducer(8);
+    lives-ok { g7(7) }, 'where over the factory parameter (first instance)';
+    dies-ok  { g7(8) }, 'where over the factory parameter rejects the sibling value';
+    lives-ok { g8(8) }, 'where over the factory parameter (second instance)';
+    dies-ok  { g8(7) }, 'each factory instance keeps its own captured value';
+}
+
+# --- 3. pointy block --------------------------------------------------------
+{
+    my $p = 3;                              #OK not used
+    sub pproducer {
+        my $p = 2;
+        return -> $x where $p { $x };
+    }
+    my &pp := pproducer();
+    lives-ok { pp(2) }, 'escaping pointy block: where sees the declaring lexical';
+    dies-ok  { pp(3) }, 'escaping pointy block: where does not see the outer lexical';
+}
+
+# --- 4. shadowing at two depths, called in place ----------------------------
+{
+    my $s = 1;                              #OK not used
+    {
+        my $s = 3;                          #OK not used
+        {
+            my $s = 2;
+            my &in := sub ($x where $s) { $x };
+            lives-ok { in(2) }, 'two-deep shadowing: innermost binding wins';
+            dies-ok  { in(3) }, 'two-deep shadowing: middle binding is not used';
+        }
+    }
+}
+
+# --- 5. a `where` on a subset, used from another scope ----------------------
+{
+    my $limit = 5;
+    subset Small of Int where { $_ <= $limit };
+    sub takes-small(Small $n) { $n }
+    lives-ok { takes-small(3) }, 'subset where closes over its declaring lexical';
+    dies-ok  { takes-small(9) }, 'subset where rejects out-of-range values';
+}
+
+# --- 6. a `where` on a method parameter ------------------------------------
+{
+    my $m = 2;
+    class WhereMeth {
+        method go($x where $m) { $x }
+    }
+    lives-ok { WhereMeth.new.go(2) }, 'method parameter where sees the enclosing lexical';
+    dies-ok  { WhereMeth.new.go(9) }, 'method parameter where rejects';
+}
+
+# --- 7. a later parameter constraining on an earlier one -------------------
+{
+    sub pair-eq($a, $b where $a) { "$a$b" }
+    is pair-eq(4, 4), '44', 'where may reference an earlier parameter of the same signature';
+    dies-ok { pair-eq(4, 5) }, 'where on an earlier parameter still rejects';
+}

--- a/todo/deep/vendor-real-test-module.md
+++ b/todo/deep/vendor-real-test-module.md
@@ -4003,3 +4003,55 @@ gist-comparing sites they would have to move with in
 `todo/tickets/blob-comparison-should-die-instead-of-answering.md`.
 
 Remaining in this cluster: `S16-io/words.t` and `S32-io/io-cathandle.t`.
+
+## 2026-08-29: the `where`-constraint scope pair (`subset-6c.t` / `subset-6e.t`)
+
+Two more files off the residue — **the two this slice closes; see the note on
+counting below before adding them to any running total** — and, as the
+classification entry two sections up predicted for this residue in general, the
+bug had nothing whatsoever to do with `Test`. It reproduced identically under
+the native provider; it only *surfaced* under the real module because
+`lives-ok`'s Raku-level implementation actually observes the exception the
+native builtin swallowed.
+
+| file | test | before (real Test) | after (real Test) | native provider |
+| --- | --- | --- | --- | --- |
+| `roast/S02-types/subset-6e.t` | 39, `where-constraint picks up the right lexical (+)` | FAIL (1/60) | PASS (60/60) | PASS before and after |
+| `roast/6.c/S02-types/subset-6c.t` | 38, same assertion | FAIL (1/51) | PASS (51/51) | PASS before and after |
+
+The bug: a parameter's `where` constraint (and its default value) was evaluated
+against the *calling* frame instead of the scope the signature was written in.
+The roast assertion's shape makes that unmissable — `bar(2)` died and `bar(3)`
+lived, `3` being exactly the enclosing block's shadowed binding. Two independent
+root causes, both general and both now fixed: the compiler never recorded a
+signature's declaration-time reads as captures (they live on the `ParamDef` AST
+and never reach the opcode scan `compute_free_vars` performs), and a named `sub`
+escaping as its declaring routine's return value captured a flattened env that
+could not see that routine's local *slots*. Full write-up:
+`news/2026-08/where-constraint-declaration-scope-capture.md`; pin:
+`t/where-constraint-lexical-scope.t` (23 assertions, also green under real
+`raku`).
+
+Verification: both files green under BOTH providers; `make test` green; the full
+1436-file whitelisted roast suite green on a release build; and
+`scripts/battery-testsuite.sh` green (the change touches closure-capture
+representation, which the note in CLAUDE.md warns roast alone will not catch).
+
+**Method for whoever continues here.** The previous entry's advice — classify by
+"what shape of mutsu bug can only be seen through a Raku-level assertion", not by
+synopsis — held up again, with one refinement worth writing down: for a file
+whose regression is a *single* assertion, read that assertion's expected/actual
+values before reading any code. Here, "the value that wrongly passed is precisely
+the shadowed outer binding" identified the failure as a wrong-frame lookup (not a
+missing one) in one step, and a handful of probe shapes then separated the two
+root causes without a single instrumented build.
+
+**A note on counting, since several slices are in flight at once.** This entry
+deliberately quotes only its own per-file before/after. A fresh session-opening
+sweep on `139aa395f` measured 42 raw regressions minus 2 `exit 124` timeouts =
+**40 correctness regressions**; the `infix:<eq>` entry above took that to 38;
+this slice closes 2 more; and PR #7086 closes `S24-testing/14-like-unlike.t`
+independently. Because those landed concurrently, no single running total in
+this file is trustworthy as arithmetic — subtract "the N files each entry names"
+from a *re-measured* baseline instead, and re-run
+`scripts/roast-test-module-sweep.sh` when you need an authoritative number.

--- a/todo/tickets/class-in-routine-does-not-capture-routine-lexicals.md
+++ b/todo/tickets/class-in-routine-does-not-capture-routine-lexicals.md
@@ -1,0 +1,67 @@
+# A class declared inside a routine does not capture that routine's lexicals
+
+A `class` (and by extension its methods) declared in the body of a `sub`/`method`
+sees `Nil` where it should see the routine's `my` variables. The same declaration
+inside a bare block, or at mainline scope, works.
+
+## Minimal repro
+
+```raku
+sub p { my $m = 2; class C { method go() { $m } }; C.new }
+my $c = p();
+say $c.go;
+```
+
+* `raku`: `2`
+* `mutsu`: `Nil`
+
+The signature side fails the same way, which is how this was found — a `where`
+constraint on a method parameter of such a class rejects every value:
+
+```raku
+sub p { my $m = 2; class C { method go($x where $m) { $x } }; C.new }
+p().go(2);   # raku: lives.  mutsu: X::TypeCheck::Binding::Parameter
+```
+
+## What is (and is not) already fixed
+
+`news/2026-08/where-constraint-declaration-scope-capture.md` fixed the two
+*sub-side* channels this shape resembles:
+
+* the compiler now folds a signature's declaration-time reads (parameter
+  defaults, `where` constraints) into the compiled body's own `free_var_syms`
+  (`Compiler::fold_decl_time_param_captures`), which covers method bodies too
+  since they go through `compile_closure_body_with_routine_flag`; and
+* a *named sub* escaping as its declaring routine's return value now has that
+  routine's live local slots injected into its captured env
+  (`Interpreter::inject_frame_locals_for_free_vars`, called from
+  `call_compiled_function_named_inner`).
+
+So the compile-time capture *set* is already correct for the method above — what
+is missing is the runtime injection on the class-registration path. A method's
+env is snapshotted when the class is registered (`exec_register_class_op` /
+`vm_register_ops.rs`'s method-capture path), and that snapshot has the same
+dual-store blind spot the sub path had: a `my` in the enclosing *routine* body
+lives in a local slot, not in `env`, so the flattened capture misses it (or, under
+shadowing, captures an outer scope's same-named value instead).
+
+## Where to look
+
+* `src/vm/vm_register_ops.rs` — the method-capture loop around
+  `analysis.free_var_syms` / `free_var_parent_slots`, and
+  `Interpreter::inject_frame_locals_for_free_vars`, which is the ready-made
+  primitive for exactly this injection (it returns the names it installed so they
+  can be vouched for as authoritative captures).
+* `src/vm/vm_typedecl_ops.rs` — `exec_register_class_op`.
+* `src/compiler/helpers_method_body.rs` — `bubble_decl_time_free_reads` /
+  `decl_time_param_free_var_syms`, the compile-time half, already in place.
+
+## Why it is a ticket and not a deep item
+
+The compile-time analysis is done and the runtime primitive exists; what is
+needed is finding the class/role registration site's env capture and giving it
+the same slot injection the sub path got, then deciding whether those names are
+authoritative (they are, once the declaring routine's frame has exited — but a
+class registered in a routine that is still running is a live frame, so the vouch
+needs more care here than it did for a returned sub). Pin any fix with the two
+repros above plus a shadowing variant.


### PR DESCRIPTION
A parameter's `where` constraint and its default value are the only two
expressions in a Raku signature that are **evaluated at call time but scoped at
declaration time**. mutsu got the first half right and the second half wrong, so
a routine that escaped its declaring scope checked its arguments against a
completely unrelated binding:

```raku
my $a = 1;
{
    my $a = 3;
    sub producer {
        my $a = 2;
        sub bar($x where $a) { $x }
    }
    my &bar := producer();
    bar(2);   # raku: lives.  mutsu: died
    bar(1);   # raku: dies.   mutsu: died
    bar(3);   # raku: dies.   mutsu: lived  <- the enclosing block's 3
}
```

The value that wrongly passed being *precisely* the shadowed outer binding is
what made this a wrong-frame lookup rather than a missing one.

## Two independent root causes

**1. The compiler never recorded a signature's declaration-time reads as
captures.** `CompiledCode::compute_free_vars` is a scan of a body's *opcodes*,
but a `where` clause and a parameter default are never compiled into the body —
they stay on the `ParamDef` AST and are interpreted by
`bind_function_args_values` at call time. So neither reached `free_var_syms`, and
`capture_closure_env` (which keeps free vars plus system names and prunes every
other plain user lexical) dropped the name from the captured env, leaving the
call-time evaluation to fall through to the caller. With a factory-returned
closure the name became *invisible*, not merely shadowed:
`sub f { my $f = 2; return sub ($x where $f) { $x } }` rejected every value. The
same held for a parameter default.

`Compiler::fold_decl_time_param_captures` now folds those names into the compiled
body's own `free_var_syms`, after `compute_needs_env_sync` runs
`compute_free_vars` and before `compute_upvalues` and the parent-slot bake consume
the set. The harvesting helper (`decl_time_param_free_var_syms`) already existed
but was wired only into the method path, and only to bubble names *upward* into
the enclosing frame. A name the routine declares itself (`sub f($a, $b where $a)`)
is excluded — the binder has already bound it by then.

**2. A named sub escaping as its declaring routine's return value captured a
flattened env that could not see the routine's own locals.** Raku returns the
`Sub` when a `sub` declaration is a routine's last statement, and
`call_compiled_function_named_inner` built that code object from
`self.clone_env()`. But a `my` in a routine body lives in the frame's local
*slot*, which the dual store does not necessarily mirror into `env`. This was not
specific to `where`: `sub p { my $k = 2; sub b() { $k } }` returned a sub that read
the caller's `$k`.

`Interpreter::inject_frame_locals_for_free_vars` now overwrites each of the
escaping routine's free variables with the declaring frame's live slot value,
through the same `resolve_capture_slot` the closure paths use, skipping anything
that is not a plain user lexical (dynamics, the topic and `__mutsu_*` metadata are
resolved against the live frame by design). The declaring frame is gone by the
time such a sub can be called, so the snapshot can never go stale and the injected
names are recorded as `SubData::authoritative_captures` — without that vouch the
don't-overwrite call-time merge would still let a same-named caller lexical win.

## Roast

Both files were green under the native `Test` provider and red under
`MUTSU_REAL_TEST=1`; both now pass under **both**. (The bug reproduced identically
under the native provider — it only *surfaced* under the real module because
`lives-ok`'s Raku-level implementation observes the exception the native builtin
swallowed.)

| file | test | before (real Test) | after |
| --- | --- | --- | --- |
| `roast/S02-types/subset-6e.t` | 39, `where-constraint picks up the right lexical (+)` | FAIL (1/60) | PASS (60/60) |
| `roast/6.c/S02-types/subset-6c.t` | 38, same assertion | FAIL (1/51) | PASS (51/51) |

## Verification

- `t/where-constraint-lexical-scope.t` — 23 assertions, **green under real `raku`
  as well as under mutsu**: the escaping named sub, its body-free-variable twin,
  the parameter-default twin, escaping anonymous subs and pointy blocks, two
  sibling closures from one factory each keeping their own captured value,
  two-deep shadowing, a `subset`'s `where`, a method parameter's `where`, and a
  later parameter constraining on an earlier one.
- `make test` green.
- The **full 1436-file whitelisted roast suite** green on a release build (not
  just a targeted sweep — the compiler change touches every routine with a
  default or a constraint).
- `scripts/battery-testsuite.sh` green (273/297, the whitelisted gate) — required
  because the change touches closure-capture representation, which CLAUDE.md
  records `make test` and roast between them have historically missed.

## Still open

A `class` declared *inside a routine* does not capture that routine's locals at
all (a separate registration channel), with or without a `where`. Recorded as
`todo/tickets/class-in-routine-does-not-capture-routine-lexicals.md`, including
the ready-made primitive that fix should reuse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
