### PR TITLE
fix(coercion): a type object's own `.Str` is what a regex match and a coercion parameter see

### DIFF
--- a/news/2026-08/type-object-string-coercion-dispatches-its-own-str.md
+++ b/news/2026-08/type-object-string-coercion-dispatches-its-own-str.md
@@ -1,0 +1,89 @@
+# A type object's own `.Str` is what a regex match and a coercion parameter see
+
+Two independent sites treated a *type object* as a name rather than as a value
+to coerce, and both are fixed. They were found together while working the
+`MUTSU_REAL_TEST=1` residue of `todo/deep/vendor-real-test-module.md`, because
+the real `Test.rakumod` reaches both of them where the native provider reaches
+neither.
+
+## A regex smartmatch matched the type NAME
+
+`regex_match_text` (`src/runtime/seq_helpers/smart_match.rs`) is the single
+chokepoint every regex-matching arm of `smart_match` stringifies its subject
+through. It dispatched a user `.Str` for an `Instance` and otherwise fell back
+to `to_string_value()` — which, for a type object, is the type's own name. So
+mutsu answered:
+
+| | mutsu (before) | rakudo |
+| --- | --- | --- |
+| `Int ~~ /Int/` | True | **False** |
+| `Any ~~ /Any/` | True | **False** |
+| `class C { method Str { 'foo' } }` then `C ~~ /foo/` | False | **True** |
+| `C ~~ /C/` | True | **False** |
+
+Rakudo has no "match the type name" rule: a regex match is ordinary string
+context, so a type object dispatches its class's `.Str` and otherwise coerces to
+`""` with the familiar "Use of uninitialized value of type X in string context"
+warning. mutsu already had `warn_type_object_string_context` for exactly that
+coercion; `regex_match_text` simply never consulted it. It does now, and the
+warnings, their wording and their ordering are byte-identical to rakudo's.
+
+Two details are deliberate and were measured rather than assumed.
+
+**`.Str` only, not `.Stringy`.** Prefix `~` is `.Stringy`, and the two differ —
+with `class B { method Stringy { 'bar' }; method Str { 'baz' } }`, rakudo gives
+`~B` eq `'bar'` but `B ~~ /baz/` True and `B ~~ /bar/` False. Reusing
+`render_str_value` (which is `.Stringy`-first) would have got the headline case
+right and this one wrong.
+
+**A bare `/regex/` coerces its subject QUIETLY.** `Any ~~ /a/` and
+`Any.match(/a/)` warn, but `/a/`, `if /a/` and `so /a/` against an undefined
+topic do not — `roast/S05-metasyntax/regex.t` pins exactly that (`/a/; print
+"pass"` must leave STDERR empty), and the first draft of this fix regressed it.
+The distinction is a *compile-time* fact — the compiler synthesizes `$_` as the
+LHS of a bare regex in `compile_match_regex` — so it is carried on the opcode
+rather than guessed at run time: `SmartMatchLhs::Var` gained an
+`implicit_topic` flag, which `exec_smart_match_expr_op` reads to route the
+subject through `quiet_topic_for_regex_match` before the match. `SmartMatchLhs`
+is boxed, so the extra field costs nothing in `size_of::<OpCode>()` (the
+`opcode_size_guard` test still passes), and the existing `Var { name, .. }`
+patterns needed no change.
+
+Pin: `t/regex-smartmatch-type-object.t`, 23 assertions, green under real `raku`
+unchanged — including both halves of the implicit/explicit warning split.
+
+## A coercion-type parameter skipped a type object's coercion method
+
+`try_coerce_value_with_method` (`src/runtime/types/coercion.rs`) dispatches the
+target-named method when the argument is an `Instance` whose class defines it,
+and had no matching branch for a type object. So `sub f(Str() $g)` given a
+`class C { method Str { 'foo' } }` bound `""` where rakudo binds `"foo"`.
+
+A coercion type calls the named method on its argument, and a method call on a
+type object dispatches like any other, so the fix is the same branch for
+`ValueView::Package`. It is guarded on the class actually defining the method,
+which is what keeps `Str(Int)` and `Str(Any)` at `""` — measured against rakudo
+across the whole matrix, the type-object-with-a-user-method case was the only
+divergence. The branch is not `Str`-specific: `Int()` / `Num()` on a type object
+defining `.Int` / `.Num` now dispatch too.
+
+Pin: `t/coercion-param-type-object-user-method.t`, 14 assertions, green under
+real `raku` unchanged.
+
+## What it freed
+
+`roast/S24-testing/14-like-unlike.t` passes under both providers. It is the real
+module's own spec for `like`/`unlike` accepting non-`Str` objects, and it failed
+under `MUTSU_REAL_TEST=1` because rakudo's `like` declares `Str() $got` and the
+test hands it `class { method Str { 'foo' } }` — so the whole assertion turned
+on the coercion-parameter half. The regex half was found on the way in (the
+first reading of the failure blamed the smartmatch, and the diagnostic
+`got: ""` is what corrected it) and is a real divergence in its own right, so it
+is fixed here as well rather than left behind.
+
+A third divergence surfaced by the same probe is *not* fixed here and is
+recorded in `todo/tickets/print-and-put-stringify-through-stringy-not-str.md`:
+`print`/`put` go through `render_str_value`, which tries `.Stringy` before
+`.Str`, so `print WithStringy` renders `bar` where rakudo renders `""`. That one
+changes output for every `print`/`put` of a type object and deserves its own
+measurement.

--- a/src/compiler/expr_binary.rs
+++ b/src/compiler/expr_binary.rs
@@ -529,6 +529,7 @@ impl Compiler {
                     Expr::Var(name) => Some(Box::new(crate::opcode::SmartMatchLhs::Var {
                         name: name.clone(),
                         slot: self.local_map.get(name.as_str()).copied(),
+                        implicit_topic: false,
                     })),
                     // `$obj.meth ~~ s///`: an rw-accessor LHS whose returned
                     // container Raku's substitution writes through. Only a
@@ -896,6 +897,7 @@ impl Compiler {
             lhs: Some(Box::new(crate::opcode::SmartMatchLhs::Var {
                 name: val_name.clone(),
                 slot: Some(val_slot),
+                implicit_topic: false,
             })),
             rhs_is_match_regex: false,
             lhs_is_literal: false,

--- a/src/compiler/expr_helpers.rs
+++ b/src/compiler/expr_helpers.rs
@@ -766,6 +766,8 @@ impl Compiler {
             lhs: Some(Box::new(crate::opcode::SmartMatchLhs::Var {
                 name: "_".to_string(),
                 slot: self.local_map.get("_").copied(),
+                // Synthesized topic: this is a bare `/regex/`, not `$_ ~~ /regex/`.
+                implicit_topic: true,
             })),
             // Standalone m// (not in ~~ context) returns Nil on failure, not False.
             // Setting this to false makes smart_match_op return $/ (Nil) on failure.

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -170,7 +170,15 @@ pub(crate) enum SmartMatchLhs {
     /// current-scope local (§1.5: bakes the scope-correct slot so the
     /// writeback does not re-resolve the name at run time — see
     /// docs/lexical-scope-slot-campaign.md); `None` keeps the env-by-name path.
-    Var { name: String, slot: Option<u32> },
+    /// `implicit_topic` marks the LHS the compiler SYNTHESIZED for a bare
+    /// regex (`/a/`, `if /a/`, `so /a/`) rather than one the source wrote.
+    /// Rakudo coerces that subject quietly, while an explicit `$_ ~~ /a/`
+    /// warns -- see `Interpreter::quiet_topic_for_regex_match`.
+    Var {
+        name: String,
+        slot: Option<u32>,
+        implicit_topic: bool,
+    },
     /// `$obj.meth ~~ s///` — the LHS is a zero-arg method call on a variable
     /// (an `is rw` accessor in Raku, whose returned container the substitution
     /// writes through). mutsu's method calls return plain values, so the VM

--- a/src/runtime/seq_helpers/smart_match.rs
+++ b/src/runtime/seq_helpers/smart_match.rs
@@ -50,7 +50,58 @@ impl Interpreter {
     /// defines a user `Str` method must match against that string (e.g. a
     /// `URI::Path` object with `multi method Str` smartmatched against a path
     /// regex); everything else keeps the plain value stringification.
+    ///
+    /// A *type object* is ordinary string context, not its own name: rakudo
+    /// dispatches a user `.Str` (so `class C { method Str { 'foo' } }` makes
+    /// `C ~~ /foo/` True) and otherwise coerces to `""` with the
+    /// "uninitialized value of type X in string context" warning — which makes
+    /// `Int ~~ /Int/` and `Any ~~ /Any/` False, where matching the type NAME
+    /// answered True.
+    ///
+    /// Only `.Str`, deliberately: unlike prefix `~` (which is `.Stringy`), the
+    /// match target is the `.Str` coercion, so a class defining `.Stringy`
+    /// alone stringifies to `""` here and one defining both matches its `.Str`.
+    /// Measured against rakudo — `class B { method Stringy {'bar'}; method Str
+    /// {'baz'} }` gives `B ~~ /baz/` True and `B ~~ /bar/` False.
+    /// Pre-coerce the IMPLICIT TOPIC of a bare regex match (`/a/`, `if /a/`,
+    /// `so /a/`) so that [`Self::regex_match_text`] never has to warn about it.
+    ///
+    /// Rakudo distinguishes the two forms: `Any ~~ /a/` and `Any.match(/a/)`
+    /// warn "Use of uninitialized value of type Any in string context", but a
+    /// bare `/a/` against an undefined topic is silent — `/a/; print "pass"`
+    /// prints `pass` with an empty STDERR, which `roast/S05-metasyntax/regex.t`
+    /// pins. Doing the coercion at the implicit-topic call sites keeps that
+    /// distinction where the information actually is; `regex_match_text` cannot
+    /// see which form it was reached from.
+    ///
+    /// Only a type object needs the treatment, and a class defining `.Str`
+    /// still dispatches it — quieting the warning must not also lose the value.
+    pub(crate) fn quiet_topic_for_regex_match(&mut self, topic: Value) -> Value {
+        let ValueView::Package(name) = topic.view() else {
+            return topic;
+        };
+        let cn = name.resolve().to_string();
+        if self.has_user_method(&cn, "Str")
+            && let Ok(v) = self.call_method_with_values(topic.clone(), "Str", vec![])
+        {
+            return Value::str(v.to_string_value());
+        }
+        Value::str(String::new())
+    }
+
     fn regex_match_text(&mut self, left: &Value) -> String {
+        if let ValueView::Package(name) = left.view() {
+            let cn = name.resolve().to_string();
+            if self.has_user_method(&cn, "Str")
+                && let Ok(v) = self.call_method_with_values(left.clone(), "Str", vec![])
+            {
+                return v.to_string_value();
+            }
+            return self
+                .warn_type_object_string_context(&cn, false)
+                .map(|v| v.to_string_value())
+                .unwrap_or_default();
+        }
         if let ValueView::Instance { class_name, .. } = left.view()
             && self.has_user_method(&class_name.resolve(), "Str")
             && let Ok(v) = self.call_method_with_values(left.clone(), "Str", vec![])

--- a/src/runtime/types/coercion.rs
+++ b/src/runtime/types/coercion.rs
@@ -194,6 +194,22 @@ impl Interpreter {
             }
             return Err(coerce_impossible_error(target, &value));
         }
+        // The same rule for a TYPE OBJECT. A coercion type calls the named
+        // method on its argument, and a method call on a type object dispatches
+        // like any other, so `sub f(Str() $g)` given `class C { method Str
+        // {'foo'} }` binds "foo" — not the "" a bare type object stringifies to.
+        // Only a class that actually defines the method takes this path; a plain
+        // type object falls through to the ordinary coercion below (`Str(Int)`
+        // stays ""), which is what rakudo does.
+        if let ValueView::Package(class_name) = value.view()
+            && self.class_has_user_method(&class_name.resolve(), base_target)
+        {
+            let coerced = self.call_method_with_values(value.clone(), base_target, vec![])?;
+            if self.type_matches_value(base_target, &coerced) {
+                return Ok(coerced);
+            }
+            return Err(coerce_impossible_error(target, &value));
+        }
         if let ValueView::Instance {
             class_name,
             attributes,

--- a/src/vm/vm_coerce_concat_ops.rs
+++ b/src/vm/vm_coerce_concat_ops.rs
@@ -172,6 +172,9 @@ impl Interpreter {
             | ValueView::RegexWithAdverbs { .. }
             | ValueView::Routine { is_regex: true, .. } => {
                 let topic = self.env().get("_").cloned().unwrap_or(Value::NIL);
+                // The IMPLICIT topic of a bare regex coerces quietly -- see
+                // `quiet_topic_for_regex_match`.
+                let topic = self.quiet_topic_for_regex_match(topic);
                 Value::truth(self.vm_smart_match(&topic, &val))
             }
             _ => {

--- a/src/vm/vm_dispatch_helpers.rs
+++ b/src/vm/vm_dispatch_helpers.rs
@@ -479,6 +479,9 @@ impl Interpreter {
             | ValueView::RegexWithAdverbs { .. }
             | ValueView::Routine { is_regex: true, .. } => {
                 let topic = self.env().get("_").cloned().unwrap_or(Value::NIL);
+                // The IMPLICIT topic of a bare regex coerces quietly -- see
+                // `quiet_topic_for_regex_match`.
+                let topic = self.quiet_topic_for_regex_match(topic);
                 self.vm_smart_match(&topic, val)
             }
             _ => val.truthy(),

--- a/src/vm/vm_smartmatch_ops.rs
+++ b/src/vm/vm_smartmatch_ops.rs
@@ -24,6 +24,15 @@ impl Interpreter {
             Some(SmartMatchLhs::Var { slot, .. }) => *slot,
             _ => None,
         };
+        // A bare `/regex/` (the compiler synthesizes `$_` as its LHS) coerces
+        // its subject QUIETLY, unlike an explicit `$_ ~~ /regex/`.
+        let lhs_is_implicit_topic = matches!(
+            lhs,
+            Some(SmartMatchLhs::Var {
+                implicit_topic: true,
+                ..
+            })
+        );
         // Smartmatching *reads* the left operand, and reading a `Proxy` means
         // FETCH: `cglobal(...) ~~ Pointer` asks about the value in the C global,
         // not about the Proxy standing in for it (`NativeLibs::Searcher` probes
@@ -279,6 +288,18 @@ impl Interpreter {
             {
                 self.set_pending_call_arg_sources(Some(vec![Some(v.clone())]));
             }
+            // The subject of a bare `/regex/` is coerced quietly -- see
+            // `quiet_topic_for_regex_match`. Only for a regex RHS: a value
+            // smartmatch against a type object is a type test, not a string one.
+            let left = if lhs_is_implicit_topic
+                && matches!(
+                    right.view(),
+                    ValueView::Regex(_) | ValueView::RegexWithAdverbs(_)
+                ) {
+                self.quiet_topic_for_regex_match(left)
+            } else {
+                left
+            };
             self.eval_smartmatch_with_junctions_ex(left, right, negate, rhs_is_match_regex)?
         };
         self.stack.push(out);

--- a/t/coercion-param-type-object-user-method.t
+++ b/t/coercion-param-type-object-user-method.t
@@ -1,0 +1,62 @@
+use Test;
+
+# A coercion-type parameter (`Str() $x`) calls the named method on its
+# argument, and a method call on a TYPE OBJECT dispatches like any other. So a
+# class that defines `method Str` coerces through it even when the argument is
+# the bare type object -- it does not fall back to the "" a plain type object
+# stringifies to.
+#
+# This is what the real `Test.rakumod`'s `like`/`unlike` rely on: they declare
+# `Str() $got`, and roast/S24-testing/14-like-unlike.t passes them an anonymous
+# class with a `Str` method.
+#
+# Verified assertion-for-assertion against rakudo.
+
+plan 14;
+
+class WithStr    { method Str { 'foo' } }
+class WithInt    { method Int { 99 } }
+class WithNum    { method Num { 2.5e0 } }
+class Plain      { }
+
+sub takes-str(Str() $g) { $g }
+sub takes-int(Int() $g) { $g }
+sub takes-num(Num() $g) { $g }
+
+# --- the type object dispatches its class's coercion method ---------------
+is takes-str(WithStr), 'foo',
+   'Str() parameter coerces a type object through its own .Str';
+is takes-str(WithStr.new), 'foo',
+   'Str() parameter still coerces an instance through its .Str';
+
+is takes-int(WithInt), 99,
+   'Int() parameter coerces a type object through its own .Int';
+is takes-int(WithInt.new), 99,
+   'Int() parameter still coerces an instance through its .Int';
+
+is takes-num(WithNum), 2.5e0,
+   'Num() parameter coerces a type object through its own .Num';
+
+# An anonymous class is the shape roast/S24-testing/14-like-unlike.t uses.
+is takes-str(class { method Str { 'zap' } }), 'zap',
+   'Str() parameter coerces an anonymous type object through its .Str';
+
+# The coerced value really is of the target type, not the original.
+isa-ok takes-str(WithStr), Str,
+   'the bound value is a Str, not the type object';
+
+# --- a class without the method is unaffected -----------------------------
+# A bare type object stringifies to "" (with a warning); that must not change.
+quietly {
+    is takes-str(Plain), '', 'a type object with no .Str still coerces to ""';
+    is takes-str(Int),   '', 'Int still coerces to ""';
+    is takes-str(Any),   '', 'Any still coerces to ""';
+}
+
+# --- ordinary values are unaffected ---------------------------------------
+is takes-str(42),    '42', 'an Int value still coerces to its text';
+is takes-str('s'),   's',  'a Str value passes through';
+is takes-int('7'),   7,    'a numeric string still coerces to Int';
+is takes-int(3.9),   3,    'a Rat still truncates to Int';
+
+# vim: expandtab shiftwidth=4

--- a/t/regex-smartmatch-type-object.t
+++ b/t/regex-smartmatch-type-object.t
@@ -1,0 +1,97 @@
+use Test;
+
+# A regex smartmatch stringifies its subject in ordinary STRING CONTEXT.
+# For a type object that means: a user `.Stringy`/`.Str` dispatches, and a bare
+# type object coerces to "" (with rakudo's uninitialized-value warning), so the
+# type NAME is never what the regex is matched against.
+#
+# Verified assertion-for-assertion against rakudo.
+
+plan 23;
+
+class WithStr    { method Str     { 'foo' } }
+class WithStringy { method Stringy { 'bar' } }
+class BothCoercions { method Stringy { 'bar' }; method Str { 'baz' } }
+class Plain      { }
+
+# --- a type object with a user Str ---------------------------------------
+ok  (WithStr ~~ /foo/),  'type object with .Str matches its .Str result';
+nok (WithStr ~~ /WithStr/),
+    'type object with .Str does NOT match its own type name';
+ok  (WithStr.new ~~ /foo/), 'instance with .Str still matches its .Str result';
+
+# An anonymous class has no usable name at all, so this is the shape
+# roast/S24-testing/14-like-unlike.t exercises through `like`.
+my $anon = class { method Str { 'zap' } };
+ok  ($anon ~~ /zap/), 'anonymous type object with .Str matches its .Str result';
+
+# --- .Str, NOT .Stringy, is the coercion a regex match uses ---------------
+# Unlike prefix `~` (which is .Stringy), the match target is the .Str
+# coercion, so a class defining only .Stringy stringifies to "" here.
+quietly {
+    nok (WithStringy ~~ /bar/),
+        'a type object with only .Stringy does NOT match its .Stringy result';
+    nok (WithStringy ~~ /WithStringy/),
+        'a type object with only .Stringy does NOT match its own type name';
+}
+ok  (BothCoercions ~~ /baz/),
+    'a type object defining both matches its .Str result';
+nok (BothCoercions ~~ /bar/),
+    'a type object defining both does NOT match its .Stringy result';
+
+# --- a bare type object coerces to "" -------------------------------------
+# The coercion warns, so run these quietly: what is under test is the ANSWER.
+quietly {
+    nok (Plain ~~ /Plain/), 'bare type object does not match its own type name';
+    nok (Int   ~~ /Int/),   'Int does not match /Int/';
+    nok (Any   ~~ /Any/),   'Any does not match /Any/';
+    nok (Str   ~~ /Str/),   'Str does not match /Str/';
+
+    my $undeclared-value;
+    nok ($undeclared-value ~~ /Any/),
+        'an uninitialized scalar does not match its type name either';
+
+    # "" is what it coerces to, so an anchored-empty pattern still matches.
+    ok (Plain ~~ /^$/), 'bare type object coerces to the empty string';
+}
+
+# The coercion is a warning, not a failure, and it names the type.
+{
+    my $warning;
+    {
+        CONTROL { default { $warning = .message; .resume } }
+        my $ignored = Int ~~ /Int/;
+    }
+    ok $warning.defined, 'coercing a bare type object for a regex warns';
+    ok $warning.contains('Int'), 'the warning names the type';
+    ok $warning.contains('string context'), 'the warning is the string-context one';
+}
+
+# --- an IMPLICIT-topic match coerces quietly ------------------------------
+# `Any ~~ /a/` warns, but a bare `/a/` against an undefined topic does not --
+# rakudo distinguishes the synthesized topic from a written-out one. Both
+# answer the same; only the warning differs.
+{
+    my @warnings;
+    {
+        CONTROL { default { @warnings.push: .message; .resume } }
+        my $bare = ?/a/;            # implicit topic, undefined
+        is $bare, False, 'a bare regex against an undefined topic is False';
+    }
+    is @warnings.elems, 0, 'a bare regex against an undefined topic does not warn';
+}
+{
+    my @warnings;
+    {
+        CONTROL { default { @warnings.push: .message; .resume } }
+        my $explicit = ?($_ ~~ /a/);
+        is $explicit, False, 'an explicit match on an undefined topic is False too';
+    }
+    is @warnings.elems, 1, 'but the explicit form does warn';
+}
+
+# --- values that are not type objects are untouched -----------------------
+ok  (42  ~~ /42/), 'an Int value still matches its own text';
+ok  (1.5 ~~ /\.5/), 'a Rat value still matches its own text';
+
+# vim: expandtab shiftwidth=4

--- a/todo/deep/vendor-real-test-module.md
+++ b/todo/deep/vendor-real-test-module.md
@@ -3956,6 +3956,103 @@ The remaining named clusters are `S24-testing/{10-is-approx,14-like-unlike,3-out
 pair, which needs the `#?rakudo eval` fudge directive or an un-whitelisting
 rather than an interpreter fix.
 
+## 2026-08-29: the session-opening sweep reproduces 40, and `S24-testing/14-like-unlike.t` closes
+
+Per this file's own process note, the day opened with a fresh
+`scripts/roast-test-module-sweep.sh` on `main` @ `139aa395f` (release, `-j6`):
+
+```
+pass under both:                   1394
+regressed under the real Test:      42
+passes only under the real Test:     0
+fail under both (pre-existing):      0
+```
+
+Two of the 42 are the familiar `exit 124` performance artifact
+(`S03-buf/read-write-bits.t`, `S03-buf/write-int.t`), so **40 correctness
+regressions** — and the regressed *file set* is byte-identical to the previous
+evening's, so the count is reproducible rather than noisy. Report preserved at
+`tmp/real-test-regressions-2026-08-28-round151-start.txt`.
+
+### `S24-testing/14-like-unlike.t`, and the value of reading the diagnostic
+
+The failing assertion is
+`like class { method Str { 'foo' } }, /foo/, '...'`, and the obvious first
+reading — "mutsu's regex smartmatch does not stringify a non-`Str` object" — was
+**wrong**, even though probing it *did* turn up a real divergence. The
+diagnostic is what corrects it:
+
+```
+# expected a match with: /foo/
+#                   got: ""
+```
+
+`got: ""` means the argument was already `""` before any matching happened, and
+rakudo's `like` declares **`Str() $got`** — a coercion-type parameter. mutsu's
+`try_coerce_value_with_method` dispatched the target-named method for an
+`Instance` but had no branch for a *type object*, so a class defining
+`method Str` coerced to `""`. That, not the smartmatch, is what failed the file.
+
+The smartmatch divergence found on the way in is real too and is fixed in the
+same PR: `regex_match_text` matched a type object against its own type NAME, so
+`Int ~~ /Int/` was True (rakudo: False, with the uninitialized-value warning)
+and `C ~~ /foo/` was False for a `C` defining `method Str` (rakudo: True). Both
+are in `news/2026-08/type-object-string-coercion-dispatches-its-own-str.md`,
+pinned by `t/regex-smartmatch-type-object.t` (23 assertions) and
+`t/coercion-param-type-object-user-method.t` (14), both green under real `raku`.
+
+The smartmatch half also cost a lesson worth recording: making the coercion
+*warn*, as rakudo does for `Any ~~ /a/`, regressed `roast/S05-metasyntax/regex.t`
+test 51 in the targeted sweep, because a **bare** `/a/` is silent in rakudo where
+the written-out `$_ ~~ /a/` warns. That is a compile-time distinction — the
+compiler synthesizes the `$_` LHS in `compile_match_regex` — so it is now carried
+on `SmartMatchLhs::Var` as an `implicit_topic` flag. **Run the targeted sweep
+before believing a spec-fidelity addition is free**: this one looked like a pure
+improvement and broke a whitelisted file.
+
+| file | real Test before | real Test after | native before | native after |
+| --- | --- | --- | --- | --- |
+| `S24-testing/14-like-unlike.t` | 1 failure (#2) | **PASS** | PASS | PASS |
+
+**So: 40 -> 39 correctness regressions** from this slice alone. Two other slices
+ran concurrently on disjoint files (`S32-io/{slurp,spurt}.t`;
+`S02-types/subset-6e.t` + `6.c/S02-types/subset-6c.t`) and are measured in their
+own entries.
+
+### Two clusters classified for whoever goes next
+
+Probing the residue turned up one cluster that is worth taking as a unit,
+because three files reduce to a single root cause:
+
+**A runtime, name-resolved write to an outer lexical is lost as soon as it
+happens inside an *invoked* closure or a routine.** Both `EVAL` and symbolic
+dereference show the identical shape, and neither involves `Test`:
+
+```raku
+my $z = 1; $::('z') = 11;                              # 11   OK
+my $z = 1; { $::('z') = 22 };                          # 22   OK  (bare block)
+my $z = 1; my $c = { $::('z') = 33 }; $c();            #  1   WRONG (raku: 33)
+my $z = 1; sub w(&f) { f() }; w({ $::('z') = 44 });    #  1   WRONG (raku: 44)
+my $z = 1; sub w2() { $::('z') = 55 }; w2();           #  1   WRONG (raku: 55)
+```
+
+`todo/tickets/eval-write-to-outer-lexical-lost-inside-a-closure-or-routine.md`
+already records the `EVAL` half and names
+`roast/S02-lexical-conventions/comments.t` (test 41). The sweep says it is worth
+more than that one file: `roast/S06-signature/sigilless.t` (test 5,
+`lives-ok { EVAL 'swap($a, $b)' }` with sigilless rw parameters) is the same
+`EVAL` half, and `roast/S02-names/symbolic-deref.t` (tests 3 and 14) is the
+`$::(…)` half — **three files, one root cause**. It only surfaces under the real
+module because both are written inside a `lives-ok { … }`, and the real
+`lives-ok` is a Raku sub that *calls* the block where the native one does not.
+
+The second, smaller observation: `S24-testing/{2-force_todo,6-done_testing}.t`
+remain the native-provider-only pair described above, and
+`S24-testing/3-output.t` is not a `Test` gap either — it compares `diag` output
+and mutsu's parse-error text is both more verbose and internally duplicated
+("expected expected statement …", "— near: X — near: X"), which is a message
+-quality bug rather than a behavioural one.
+
 ## 2026-08-29: the Buf/handle-I/O cluster, part 1 — `infix:<eq>` across Blob types (40 -> 38)
 
 Taking the `S32-io/{slurp,spurt}.t` pair named in the residue above. Both

--- a/todo/tickets/print-and-put-stringify-through-stringy-not-str.md
+++ b/todo/tickets/print-and-put-stringify-through-stringy-not-str.md
@@ -1,0 +1,47 @@
+# `print`/`put` stringify a type object through `.Stringy`, but rakudo uses `.Str`
+
+`render_str_value` (`src/runtime/io_env.rs`, the coercion `print`/`put` use)
+tries a user `.Stringy` before a user `.Str` when its argument is a type object.
+Rakudo's `print`/`put` are `.Str`, and the two are genuinely different methods —
+prefix `~` is the `.Stringy` one.
+
+## Repro (measured 2026-08-28 against `raku` as the oracle)
+
+```raku
+class WithStringy { method Stringy { 'bar' } }
+print WithStringy;         # raku: ""     mutsu: "bar"
+say ~WithStringy;          # raku: "bar"  mutsu: "bar"   (agree)
+say WithStringy.Str;       # raku: ""     mutsu: ""      (agree)
+```
+
+So only the `print`/`put` path diverges, and only for a class that defines
+`.Stringy` *without* a `.Str`. A class defining both is worth checking too — the
+same `Stringy`-first ordering would prefer the wrong one there as well.
+
+`raku` emits its "Use of uninitialized value of type WithStringy in string
+context" warning in the `print` case, which mutsu currently does not, because it
+answered through `.Stringy` instead of reaching the warning.
+
+## How it was found
+
+While fixing `regex_match_text` to coerce a type object properly
+(`news/2026-08/type-object-string-coercion-dispatches-its-own-str.md`). The
+first draft of that fix delegated to `render_str_value` and got the
+`.Stringy`-only case wrong, which is what exposed this. The regex path now has
+its own `.Str`-only coercion and does not go through `render_str_value`, so the
+two are independent.
+
+## Why it is not in that PR
+
+Changing `render_str_value` changes the rendered output of every `print`/`put`
+of a type object, including inside diagnostics and inside `Test`'s own output
+paths, and it adds a warning where there was none. That is a wider blast radius
+than the fix it was found under, and it deserves its own before/after
+measurement over the whitelist rather than being folded in.
+
+## Where to start
+
+`src/runtime/io_env.rs`, `render_str_value` — the `ValueView::Package` branch
+tries `Stringy` then `Str` then warns. Check what the non-`Package` tail
+(`call_method_with_values(value, "Str", ...)`) does for an *instance* defining
+only `.Stringy` before changing the ordering; the two halves should agree.


### PR DESCRIPTION
Two independent sites treated a *type object* as a name rather than as a value to coerce. Both were found working the `MUTSU_REAL_TEST=1` residue of `todo/deep/vendor-real-test-module.md`, because the real `Test.rakumod` reaches both where the native provider reaches neither.

## 1. A regex smartmatch matched the type NAME

`regex_match_text` — the chokepoint every regex-matching arm of `smart_match` stringifies its subject through — dispatched a user `.Str` for an `Instance` and otherwise fell back to `to_string_value()`, which for a type object is the type's own name.

| | mutsu (before) | rakudo |
| --- | --- | --- |
| `Int ~~ /Int/` | True | **False** |
| `Any ~~ /Any/` | True | **False** |
| `class C { method Str { 'foo' } }` then `C ~~ /foo/` | False | **True** |
| `C ~~ /C/` | True | **False** |

A regex match is ordinary string context: the class's `.Str` dispatches, and a bare type object coerces to `""` with the existing `warn_type_object_string_context` warning.

Two details were measured rather than assumed:

* **`.Str` only, not `.Stringy`.** Prefix `~` is the `.Stringy` one, and with `class B { method Stringy {'bar'}; method Str {'baz'} }` rakudo gives `~B` eq `'bar'` but `B ~~ /baz/` True and `B ~~ /bar/` False. Reusing `render_str_value` (`.Stringy`-first) got the headline case right and this one wrong.
* **A bare `/regex/` coerces its subject QUIETLY.** `Any ~~ /a/` warns, but `/a/`, `if /a/` and `so /a/` do not — `roast/S05-metasyntax/regex.t` test 51 pins that (`/a/; print "pass"` must leave STDERR empty), and the first draft of this fix regressed it, caught by the targeted sweep. The distinction is a **compile-time** fact (the compiler synthesizes the `$_` LHS in `compile_match_regex`), so it is carried on the opcode: `SmartMatchLhs::Var` gained an `implicit_topic` flag that `exec_smart_match_expr_op` reads. `SmartMatchLhs` is boxed, so `size_of::<OpCode>()` is unchanged and `opcode_size_guard` still passes.

## 2. A coercion-type parameter skipped a type object's coercion method

`try_coerce_value_with_method` dispatched the target-named method for an `Instance` but had no branch for a type object, so `sub f(Str() $g)` given that same `C` bound `""` where rakudo binds `"foo"`. A coercion type calls the named method on its argument and a method call on a type object dispatches like any other, so the same branch now covers `ValueView::Package`, guarded on the class actually defining the method — which keeps `Str(Int)` and `Str(Any)` at `""`. Not `Str`-specific: `Int()` / `Num()` on a type object defining `.Int` / `.Num` dispatch too.

## What it frees

`roast/S24-testing/14-like-unlike.t` under the real `Test`, whose `like` declares `Str() $got`. The first reading of that failure blamed the smartmatch; the diagnostic `got: ""` is what corrected it to the coercion parameter. The smartmatch divergence found on the way in is real in its own right and is fixed here rather than left behind.

| file | real Test before | after | native before | after |
| --- | --- | --- | --- | --- |
| `S24-testing/14-like-unlike.t` | 1 failure (#2) | **PASS** | PASS | PASS |
| `S05-metasyntax/regex.t` | PASS | PASS | PASS | PASS |

So **40 -> 39** correctness regressions against this morning's re-measured sweep baseline (42 raw minus 2 `exit 124` timeouts), which reproduced the previous evening's file set exactly.

## Verification

* `make test` green — 3524 files, 35176 tests.
* Targeted roast sweep over the consumers of both changes (`S05-*`, `S03-smartmatch`, `S32-str`, `S24-testing`, `S06-signature`, `S12-coercion`, `S02-types`, `S06-multi`, `S32-num`, `S02-literals`, `S04-statements`, `S03-operators`) — **480 files, 83646 tests, PASS**.
* `scripts/battery-testsuite.sh` on a release build — **GATE PASSED, 273/297**, unchanged.
* `opcode_size_guard` passes.
* Pins `t/regex-smartmatch-type-object.t` (23 assertions) and `t/coercion-param-type-object-user-method.t` (14) — **both green under real `raku`** as well as mutsu.

Also filed, not fixed here: `todo/tickets/print-and-put-stringify-through-stringy-not-str.md` — `print`/`put` go through `render_str_value`, which is `.Stringy`-first, so `print WithStringy` renders `bar` where rakudo renders `""`. That changes output for every `print` of a type object and deserves its own measurement.