### PR TITLE
fix(parser): `return()` is a zero-argument call, so it returns Nil

### DIFF
--- a/news/2026-08/bare-return-with-parens-is-nil.md
+++ b/news/2026-08/bare-return-with-parens-is-nil.md
@@ -1,0 +1,43 @@
+# `return()` is a zero-argument call, so it returns `Nil`
+
+`return()` returned an empty list where rakudo returns `Nil`. The distinction is
+one of Raku's oldest whitespace rules and mutsu's parser dropped it on the floor:
+
+```raku
+sub a { return   };  say a().raku;   # Nil   -- both agree
+sub b { return() };  say b().raku;   # mutsu: ()    rakudo: Nil
+sub c { return ()  };  say c().raku;   # ()    -- both agree
+```
+
+An argument list attached to a name with **no** intervening space is that
+routine's argument list, so `return()` passes *zero* arguments and is exactly a
+bare `return`. Put a space in and the `()` stops being an argument list and
+becomes a *term* — the empty list — passed as the one argument, so `return ()`
+really does return `()`. `return(5)`, `return(1, 2)` and `return (5)` were all
+already right; only the empty case was wrong.
+
+`return_stmt` (`src/parser/stmt/simple/control_stmts.rs`) called `ws` immediately
+after the keyword and only then parsed a value expression, which erased the
+distinction before anything could act on it — `return()` and `return ()` produced
+a byte-identical `Return(ArrayLiteral([]))` AST. The empty-attached-parens case
+is now recognised before that `ws`, and takes the same `Expr::Literal(Value::NIL)`
+path a bare `return` takes, including through a statement modifier
+(`return() if 1`).
+
+## What it freed
+
+`roast/S04-statements/return.t` passes under both providers. It regressed under
+`MUTSU_REAL_TEST=1` on tests 2 and 5 — `is(bar2(), Nil, ...)` for `sub bar2 {
+return() }` and `sub foobar2 { return() if 1 }`. Measured on a rebuilt pre-fix
+binary, mutsu's native `is` accepted the wrong value (`ok 1`) where the real
+module's rejected it; rakudo's `is` dispatches a `Mu:U $expected` candidate that
+compares with `===`, which `()` does not satisfy.
+
+That is the general shape of this whole campaign's residue: the answer was
+already wrong under the native provider too, and only a `Test` implementation
+strict enough to ask the right question made it visible.
+
+Pin: `t/bare-return-with-parens.t`, 17 assertions covering the bare form, the
+attached-parens form (plain, with inner whitespace, before a newline, and under a
+statement modifier), the spaced form, every non-empty argument shape, and the
+same in a method and an anonymous sub — green under real `raku` unchanged.

--- a/src/parser/stmt/simple/control_stmts.rs
+++ b/src/parser/stmt/simple/control_stmts.rs
@@ -12,6 +12,25 @@ pub(crate) fn return_stmt(input: &str) -> PResult<'_, Stmt> {
         return Err(PError::expected("return statement"));
     }
     let rest = keyword("return", input).ok_or_else(|| PError::expected("return statement"))?;
+    // `return()` -- an argument list attached with NO space -- is a zero-argument
+    // call, so it returns `Nil` exactly like a bare `return`. `return ()` (with a
+    // space) is different: the `()` is a term, an empty list, passed as the
+    // argument, and the routine returns `()`. Rakudo splits the two on the
+    // whitespace, so this test has to run before `ws` eats it.
+    if let Some(after_open) = rest.strip_prefix('(') {
+        let (inner, _) = ws(after_open)?;
+        if let Some(after_close) = inner.strip_prefix(')') {
+            let (after_close, _) = ws(after_close)?;
+            if is_stmt_modifier_keyword(after_close) {
+                return parse_statement_modifier(
+                    after_close,
+                    Stmt::Return(Expr::Literal(Value::NIL)),
+                );
+            }
+            let (after_close, _) = opt_char(after_close, ';');
+            return Ok((after_close, Stmt::Return(Expr::Literal(Value::NIL))));
+        }
+    }
     let (rest, _) = ws(rest)?;
     if is_stmt_modifier_keyword(rest) {
         return parse_statement_modifier(rest, Stmt::Return(Expr::Literal(Value::NIL)));

--- a/t/bare-return-with-parens.t
+++ b/t/bare-return-with-parens.t
@@ -1,0 +1,60 @@
+use Test;
+
+# `return()` -- an argument list attached with NO space -- is a zero-argument
+# call and returns Nil, exactly like a bare `return`. `return ()` (with a space)
+# is a different thing: the `()` is a term, an empty list, passed as the
+# argument, so the routine returns `()`.
+#
+# Verified assertion-for-assertion against rakudo.
+
+plan 17;
+
+# --- the zero-argument call -----------------------------------------------
+sub bare        { return }
+sub parens      { return() }
+sub parens-ws   { return( ) }
+sub bare-mod    { return if 1; 42 }
+sub parens-mod  { return() if 1; 42 }
+sub parens-nl   {
+    return()
+}
+sub bare-dead   { return; 1 }
+
+is-deeply bare(),       Nil, 'a bare `return` returns Nil';
+is-deeply parens(),     Nil, '`return()` returns Nil';
+is-deeply parens-ws(),  Nil, '`return( )` returns Nil';
+is-deeply bare-mod(),   Nil, '`return if 1` returns Nil';
+is-deeply parens-mod(), Nil, '`return() if 1` returns Nil';
+is-deeply parens-nl(),  Nil, '`return()` before a newline returns Nil';
+is-deeply bare-dead(),  Nil, '`return; 1` returns Nil, not 1';
+
+# --- a space makes the `()` an argument -----------------------------------
+sub spaced    { return () }
+sub spaced-ws { return ( ) }
+
+is-deeply spaced(),    (),   '`return ()` returns the empty list';
+is-deeply spaced-ws(), (),   '`return ( )` returns the empty list';
+
+# --- a non-empty argument list is unaffected ------------------------------
+sub one       { return(5) }
+sub two       { return(1, 2) }
+sub one-sp    { return 5 }
+sub paren-term { return (5) }
+sub listy     { return 1, 2 }
+sub empty-seq { return Empty }
+
+is-deeply one(),        5,      '`return(5)` returns 5';
+is-deeply two(),        (1, 2), '`return(1, 2)` returns the list';
+is-deeply one-sp(),     5,      '`return 5` returns 5';
+is-deeply paren-term(), 5,      '`return (5)` returns 5';
+is-deeply listy(),      (1, 2), '`return 1, 2` returns the list';
+is-deeply empty-seq(),  Empty,  '`return Empty` returns Empty';
+
+# --- the same in a method and in an anonymous sub -------------------------
+class WithMethod { method m { return() } }
+is-deeply WithMethod.m, Nil, '`return()` in a method returns Nil';
+
+my $anon = sub { return(); 1 };
+is-deeply $anon(), Nil, '`return()` in an anonymous sub returns Nil';
+
+# vim: expandtab shiftwidth=4

--- a/todo/deep/vendor-real-test-module.md
+++ b/todo/deep/vendor-real-test-module.md
@@ -4152,3 +4152,35 @@ independently. Because those landed concurrently, no single running total in
 this file is trustworthy as arithmetic — subtract "the N files each entry names"
 from a *re-measured* baseline instead, and re-run
 `scripts/roast-test-module-sweep.sh` when you need an authoritative number.
+
+## 2026-08-29: `return()` is a zero-argument call (`S04-statements/return.t`)
+
+`roast/S04-statements/return.t` regressed on tests 2 and 5 —
+`is(bar2(), Nil, ...)` for `sub bar2 { return() }` and
+`sub foobar2 { return() if 1 }`. mutsu returned an empty list where rakudo
+returns `Nil`, and the cause is one of Raku's oldest whitespace rules that the
+parser dropped: an argument list attached with **no** space is the routine's
+argument list, so `return()` passes zero arguments and is exactly a bare
+`return`, while `return ()` passes the empty list as a term and really does
+return `()`. `return_stmt` called `ws` immediately after the keyword, so both
+spellings produced a byte-identical `Return(ArrayLiteral([]))`.
+
+Measured on a rebuilt pre-fix binary: the **native** `is` accepted the wrong
+value (`ok 1`), the real module's rejected it. Another instance of this file's
+recurring shape — the answer was already wrong under the native provider, and
+only the strict module asks a question sharp enough to see it.
+
+| file | real Test before | after | native before | after |
+| --- | --- | --- | --- | --- |
+| `S04-statements/return.t` | 2 failures (#2, #5) | **PASS** | PASS | PASS |
+
+Fix and pin: `news/2026-08/bare-return-with-parens-is-nil.md`,
+`t/bare-return-with-parens.t` (17 assertions, green under real `raku`).
+Verification: `make test` green (3526 files, 35226 tests); a 523-file targeted
+roast sweep across `S04-statements`, `S04-blocks*`, `S06-*`, `S02-names`,
+`S32-list`, `S05-*`, `S12-*` and `integration` green on the native provider.
+
+Per the counting note above: this closes **one** named file. It composes with
+#7084 (2 files), #7085 (2) and #7086 (1) against the same re-measured 40
+baseline, so a fresh sweep should read 35 — measure it rather than trusting that
+arithmetic.


### PR DESCRIPTION
`return()` returned an empty list where rakudo returns `Nil`.

```raku
sub a { return   };  say a().raku;   # Nil            -- both agree
sub b { return() };  say b().raku;   # mutsu: ()   rakudo: Nil
sub c { return () };  say c().raku;  # ()             -- both agree
```

An argument list attached to a name with **no** intervening space is that routine's argument list, so `return()` passes *zero* arguments and is exactly a bare `return`. Put a space in and the `()` stops being an argument list and becomes a *term* — the empty list — passed as the one argument, so `return ()` really does return `()`. `return(5)`, `return(1, 2)` and `return (5)` were all already right; only the empty case was wrong.

`return_stmt` (`src/parser/stmt/simple/control_stmts.rs`) called `ws` immediately after the keyword and only then parsed a value expression, which erased the distinction before anything could act on it — `return()` and `return ()` produced a byte-identical `Return(ArrayLiteral([]))` AST. The empty-attached-parens case is now recognised before that `ws` and takes the same `Expr::Literal(Value::NIL)` path a bare `return` takes, including through a statement modifier (`return() if 1`).

## What it frees

`roast/S04-statements/return.t`, which regressed under `MUTSU_REAL_TEST=1` (the campaign in `todo/deep/vendor-real-test-module.md`) on tests 2 and 5: `is(bar2(), Nil, ...)` for `sub bar2 { return() }` and `sub foobar2 { return() if 1 }`.

Measured on a rebuilt pre-fix binary, mutsu's **native** `is` accepted the wrong value (`ok 1`) where the real module's rejected it. That is this campaign's recurring shape: the answer was already wrong under the native provider, and only a `Test` implementation strict enough to ask the right question made it visible.

| file | real Test before | after | native before | after |
| --- | --- | --- | --- | --- |
| `S04-statements/return.t` | 2 failures (#2, #5) | **PASS** | PASS | PASS |

## Verification

* `make test` green — 3526 files, 35226 tests.
* Targeted roast sweep over the parser's consumers (`S04-statements`, `S04-blocks-and-statements`, `S06-*`, `S02-names`, `S32-list`, `S05-*`, `S12-*`, `integration`) — **523 files, 15246 tests, PASS**.
* The roast file green under **both** providers.
* Pin `t/bare-return-with-parens.t` — 17 assertions covering the bare form, the attached-parens form (plain, with inner whitespace, before a newline, and under a statement modifier), the spaced form, every non-empty argument shape, and the same in a method and an anonymous sub — **green under real `raku`** as well as mutsu.