### PR TITLE
fix(seq): the .cache List view is a List everywhere, and &infix:<eqv> is the eqv operator

### DIFF
--- a/news/2026-08/seq-list-view-is-a-list-everywhere-and-the-eqv-routine-is-the-eqv-operator.md
+++ b/news/2026-08/seq-list-view-is-a-list-everywhere-and-the-eqv-routine-is-the-eqv-operator.md
@@ -1,0 +1,142 @@
+# The `.cache` List view is a `List` everywhere, and `&infix:<eqv>` is the `eqv` operator
+
+Three of the whitelisted files still regressing under `MUTSU_REAL_TEST=1`
+(`todo/deep/vendor-real-test-module.md`) formed the campaign's "Seq/List"
+cluster: `roast/S32-list/tail.t` (test 57), `roast/S32-list/seq.t` (test 34's
+"methods still throw when Seq is NOT cached" subtest) and `roast/S16-io/words.t`
+(tests 1, 2, 5, 6). They are **two** root causes, not one, but both live in
+`infix:<eqv>` — which is exactly why only the real `Test.rakumod` sees them: its
+`is-deeply` narrows `Seq` arguments with `.cache` and then compares with `eqv`,
+and its `cmp-ok` reaches an operator only through the *routine* form
+`&CALLER::LEXICAL::("infix:<$op>")`. The native Rust `is-deeply`/`cmp-ok` do
+neither.
+
+## Root cause 1: the `SeqView::List` handle was only a `List` by name
+
+[ADR-0038](../../docs/adr/0038-seq-cache-returns-a-list-and-the-seq-list-view-is-a-property-of-the-value.md)
+gave `.cache` on a not-yet-reified `Seq` a second handle over the same body,
+tagged `SeqView::List`, and taught `value_type_name` to read that tag. That fixed
+the stack overflow the ADR was written for — `is-deeply`'s narrowing terminates
+because the narrowed argument no longer binds `Seq:D`. But the tag was read by
+`value_type_name` **and nothing else**, so the value's own representation stayed
+`ValueView::Seq`, and the two sites that ask a *structural* question about a
+value's Raku type never saw it:
+
+```raku
+my $d = Seq.new(class :: does Iterator {
+    has @!stuff = <a b c>;
+    method pull-one { @!stuff and return @!stuff.shift; IterationEnd }
+}.new);
+my $c = $d.cache;
+say $c.^name;                 # List          (right, since ADR-0038)
+say $c.raku;                  # ("a","b","c").Seq   <- raku: ("a","b","c")
+say $c eqv ('a','b','c');     # False               <- raku: True
+say $c eqv <a b c>.Seq;       # True                <- raku: False
+```
+
+`eqv` is type-strict by definition, so a value that Raku calls a `List` must
+compare as one; `.raku` renders the type, so it must render one. Both now
+normalise through a single new helper, `Value::seq_list_view_as_list` — the same
+"one oracle" shape ADR-0038 §2 applied to the type *name*, applied to the value's
+*representation*. `reify_or_consume_eqv_operand` learned it too: when it has to
+take a body it now rebuilds a `List`-view handle as a `List`, not as a plain
+`Seq`.
+
+That is `tail.t` 57 and all four `words.t` failures: both are
+`is-deeply <deferred Seq>, <something>`, whose first narrowing step produced a
+`Seq`-shaped value that then compared unequal to the `List` on the other side.
+
+## Root cause 2: the routine form of `eqv` was a different operator
+
+`a eqv b` compiles to `OpCode::Eqv`, whose handler carries the whole contract:
+the `X::Cannot::Lazy` rules for two lazy iterables, `Proxy` element FETCH, the
+same-`Seq` identity fast path, and the Seq reify/consume protocol that raises
+`X::Seq::Consumed`. `&infix:<eqv>($a, $b)` went somewhere else entirely — it fell
+through `call_infix_routine` to the pure `apply_reduction_op` fold, which is just
+`Value::eqv`. So:
+
+```raku
+(my $s1 = (1,2,3).Seq.slice(0,1,2)).sink;   # consume it
+(my $s2 = (3,4,5).Seq.slice(0,1,2)).sink;
+$s1 eqv $s2;                # throws X::Seq::Consumed  (correct)
+&infix:<eqv>($s1, $s2);     # answered False           (wrong)
+```
+
+`seq.t`'s `throws-like { cmp-ok $s1, 'eqv', $s2 }, X::Seq::Consumed` therefore
+saw no exception at all, and the un-thrown `cmp-ok` emitted its own TAP line
+inside the `throws-like` subtest ("You planned 2 tests, but ran 3").
+
+The operator's body is now `Interpreter::eqv_values`, and `call_infix_routine`
+routes `eqv` through it — the same way it already routes `~~`/`!~~` for needing
+the full interpreter. The native provider's `cmp-ok` kept a hand-rolled
+consumed-`Seq` check for precisely this gap; that check is now describing
+behaviour the operator itself has.
+
+There turned out to be a *third* route to `eqv` with the same defect:
+`eval_reduction_operator_values`, which serves `[eqv]` and every metaop
+(`Zeqv`, `Xeqv`, `>>eqv<<`). It too answered from the static
+`apply_reduction_op` table, so `[eqv] $consumed1, $consumed2` said `False`
+where raku throws. It gets the same one-line redirect, alongside the `=~=` and
+range-operator arms already there for exactly this reason ("the static table
+cannot host an operator that needs the interpreter").
+
+## The consequence that had to be chased: `unique`/`repeated` must cache their `:as` needles
+
+Making the routine form consume `Seq` operands (as raku does) exposed a
+pre-existing bug that the non-consuming routine had been hiding.
+`roast/S32-list/unique.t`'s last test is literally named *"Seq as the result of
+an `:as` caches the Seq"*:
+
+```raku
+[[1], ['1'], [4]].unique(:as(*.map(&[~])), :with(&[eqv]))
+```
+
+Each `:as` result is a `Seq`, and `unique` compares every needle against every
+needle seen so far — so with a genuinely consuming `&[eqv]` the second use of a
+needle dies. Rakudo caches the needle; mutsu did not, and only got away with it
+because its `&[eqv]` was inert. `unique` and `repeated` now `.cache` a
+`Seq`-valued `:as` needle (`.cache` does not force a deferred body, so an
+infinite `:as` result stays lazy).
+
+`squish` deliberately does **not** get the same treatment, and that asymmetry is
+measured rather than guessed: with a `Seq`-valued `:as` and `:with(&[eqv])`,
+`raku`'s `unique` and `repeated` both answer while its `squish` throws
+`X::Seq::Consumed` — `squish` keeps only the previous needle, which is used once
+as the right operand and again as the left one, and rakudo never cached it there.
+mutsu now reproduces all three exactly.
+
+## Measured, file by file (release build, `scripts/run-roast-test.sh`)
+
+| file | real Test before | real Test after | native before | native after |
+| --- | --- | --- | --- | --- |
+| `roast/S32-list/tail.t` | 1 failure (#57) | **PASS** | PASS | PASS |
+| `roast/S32-list/seq.t` | 1 failure (#34) | **PASS** | PASS | PASS |
+| `roast/S16-io/words.t` | 4 failures (#1, #2, #5, #6) | **PASS** | PASS | PASS |
+
+Three named files off the campaign's 2026-08-29 re-measured 40-file list, on a
+file set disjoint from the sibling slices landing the same day.
+
+Pin: `t/seq-cache-list-view-and-eqv-routine.t` — 38 assertions, green under real
+`raku` as well as under mutsu, covering the `.cache` List view in all five facets
+(`.^name`, smartmatch, `eqv` against List/Seq/Array, `.raku`, `.elems`), the
+original handle keeping its own `Seq` type, plain type-strict `eqv`, the routine
+form of `eqv` (agreement, type strictness, the List view, and `X::Seq::Consumed`
+from operator, routine, `cmp-ok`, `[eqv]` and `Zeqv` alike), and `is-deeply`'s
+narrowing end to end.
+
+Verification: `make test` green; the three files green under **both** providers;
+a 444-file native roast sweep across `S32-list`, `S32-array`, `S16-io`, `S32-io`,
+`S02-types`, `S04-statements`, `S07-*`, `S03-operators` and `integration` green
+(it is what caught the `unique.t` consequence above); and
+`scripts/battery-testsuite.sh` on a release build unchanged.
+
+## Note for the rest of the residue
+
+ADR-0038's "one oracle" rule was written about the type *name*. The lesson here
+is that a value carrying a type tag needs the same discipline everywhere its type
+is *observable* — `eqv` and `.raku` are as much type oracles as `.^name` is. And
+the second bug is the operator-vs-routine version of the trap the campaign has
+already recorded twice for fast paths: when two code paths implement one
+operation, the intercepted one is reliably the poorer of the two, and the real
+`Test.rakumod` is very good at finding whichever one mutsu did not think of as
+"the" implementation.

--- a/src/builtins/methods_0arg/raku_repr.rs
+++ b/src/builtins/methods_0arg/raku_repr.rs
@@ -638,6 +638,12 @@ pub fn raku_value(v: &Value) -> String {
             }
         }
         ValueView::Seq(items) => {
+            // ADR-0038 S2: a `SeqView::List` handle (what `.cache` on a
+            // not-yet-reified Seq returns) is a `List` to Raku, so it renders as
+            // one — `(1, 2, 3)`, never `(1, 2, 3).Seq`.
+            if let Some(as_list) = Value::seq_list_view_as_list(v) {
+                return raku_value(&as_list);
+            }
             // A consumed Seq is represented as Seq.new() so that EVALing it
             // produces a pre-consumed Seq (matching Raku's behavior). Verified
             // against raku: `.raku` on an already-taken Seq shows this

--- a/src/runtime/builtins_operators_infix.rs
+++ b/src/runtime/builtins_operators_infix.rs
@@ -429,6 +429,17 @@ impl Interpreter {
                 acc = Value::truth(!self.smart_match(&acc, rhs));
                 continue;
             }
+            // `eqv` likewise needs the full interpreter, not the pure
+            // `apply_reduction_op` fold: the lazy-iterable rules, `Proxy`
+            // element FETCH, and the Seq reify/consume protocol (the source of
+            // `X::Seq::Consumed`) all live in `eqv_values`, and the routine form
+            // `&infix:<eqv>($a, $b)` must behave exactly like the `a eqv b`
+            // operator. The real `Test.rakumod`'s `cmp-ok` reaches `eqv` only
+            // through this routine form.
+            if op == "eqv" {
+                acc = self.eqv_values(acc, rhs.clone())?;
+                continue;
+            }
             let mut lhs = acc.clone();
             let mut rhs = rhs.clone();
             if self.infix_uses_numeric_bridge(op) {

--- a/src/runtime/methods_collection_ops/unique_squish.rs
+++ b/src/runtime/methods_collection_ops/unique_squish.rs
@@ -16,6 +16,31 @@ fn adverb_pair(arg: &Value) -> Option<(String, &Value)> {
     }
 }
 
+/// `.cache` an `:as`-produced needle when it is a `Seq`.
+///
+/// A `:as` mapper may hand back a `Seq` (`:as(*.map(&[~]))`), and `unique` /
+/// `repeated` compare each needle against EVERY needle seen so far. `:with`
+/// comparators such as `&[eqv]` CONSUME a `Seq` operand (measured against
+/// `raku`: `my $a = (1,2).Seq; &[eqv]($a, $b); $a.List` throws
+/// `X::Seq::Consumed`), so an un-cached needle dies on its second use. Rakudo
+/// caches it — that is exactly what `roast/S32-list/unique.t`'s "Seq as the
+/// result of an :as caches the Seq" pins. `.cache` does not force a deferred
+/// body, so an infinite `:as` result stays lazy.
+///
+/// `squish` deliberately does NOT get this: it keeps only the PREVIOUS
+/// needle, and rakudo never cached it there. Measured — with a `Seq`-valued
+/// `:as` and `:with(&[eqv])`, `raku`'s `unique` and `repeated` both answer
+/// while its `squish` throws `X::Seq::Consumed`, because the middle needle is
+/// used once as the right operand and again as the left one.
+fn cache_seq_needle(key: Value) -> Value {
+    if matches!(key.view(), ValueView::Seq(_))
+        && let Some(Ok(cached)) = crate::builtins::native_method_0arg(&key, Symbol::intern("cache"))
+    {
+        return cached;
+    }
+    key
+}
+
 impl Interpreter {
     pub(in crate::runtime) fn dispatch_unique(
         &mut self,
@@ -57,7 +82,7 @@ impl Interpreter {
         let mut unique_items: Vec<Value> = Vec::new();
         for item in items {
             let key = if let Some(func) = as_func.clone() {
-                self.call_sub_value(func, vec![item.clone()], true)?
+                cache_seq_needle(self.call_sub_value(func, vec![item.clone()], true)?)
             } else {
                 item.clone()
             };
@@ -150,7 +175,7 @@ impl Interpreter {
         let mut repeated_items: Vec<Value> = Vec::new();
         for item in items {
             let key = if let Some(func) = as_func.clone() {
-                self.call_sub_value(func, vec![item.clone()], true)?
+                cache_seq_needle(self.call_sub_value(func, vec![item.clone()], true)?)
             } else {
                 item.clone()
             };

--- a/src/value/types_eqv.rs
+++ b/src/value/types_eqv.rs
@@ -27,6 +27,20 @@ impl Value {
         if matches!(other.view(), ValueView::ContainerRef(_)) {
             return self.eqv(&other.deref_container());
         }
+        // ADR-0038 S2: `.cache` on a not-yet-reified `Seq` hands back a SECOND
+        // handle over the same body tagged `SeqView::List`. That handle
+        // IS a `List` as far as Raku is concerned (`value_type_name` says so),
+        // and `eqv` is type-strict, so it must compare as one — otherwise
+        // `Seq.new($iter).cache eqv (1, 2, 3)` answers False (and, worse,
+        // `... eqv (1, 2, 3).Seq` answers True). Normalising here rather than
+        // adding four cross-arms keeps every pairing (List-view vs List,
+        // vs Array, vs real Seq, vs List-view) consistent in one place.
+        if let Some(as_list) = Self::seq_list_view_as_list(self) {
+            return as_list.eqv(other);
+        }
+        if let Some(as_list) = Self::seq_list_view_as_list(other) {
+            return self.eqv(&as_list);
+        }
         // Junction threading: if either side is a junction, thread eqv
         // through it and return the boolean result of the junction.
         if let ValueView::Junction { kind, values } = other.view() {

--- a/src/value/view.rs
+++ b/src/value/view.rs
@@ -391,6 +391,28 @@ impl Value {
         Value::Seq(body.as_list_view())
     }
 
+    /// `Some(list)` when `value` is a `SeqView::List` handle (what
+    /// [`Value::seq_list_view`] produced) — i.e. a value that Raku calls a
+    /// `List` even though mutsu still represents it with a `Seq` body.
+    ///
+    /// Sites that ask a *structural* question about a value's Raku type —
+    /// `eqv` (type-strict) and `.raku` (renders the type) — must see the
+    /// `List`, not the `Seq`. Both call this to normalise first, so neither
+    /// grows its own copy of the view rule (ADR-0038 S2's "one oracle" applied
+    /// to representation as well as to the type name).
+    ///
+    /// Reads the body's live generation, so it answers the *current*
+    /// reification state: a still-deferred body normalises to an empty list,
+    /// exactly as a direct element read of the `Seq` handle would.
+    pub(crate) fn seq_list_view_as_list(value: &Self) -> Option<Self> {
+        match value.view() {
+            ValueView::Seq(body) if body.view() == crate::value::SeqView::List => {
+                Some(Value::array(body.to_vec()))
+            }
+            _ => None,
+        }
+    }
+
     /// Construct a `HyperSeq` from an existing `SeqBody`.
     #[inline]
     pub(crate) fn hyper_seq_body(body: Arc<SeqBody>) -> Self {

--- a/src/vm/vm_comparison_order_ops.rs
+++ b/src/vm/vm_comparison_order_ops.rs
@@ -631,7 +631,15 @@ impl Interpreter {
         let body = Arc::clone(&body);
         let (items, outcome) = self.take_seq_body(&body)?;
         Ok(if matches!(outcome, SeqTaken::Taken) {
-            Value::seq(items)
+            // Keep the handle's Raku type: a `SeqView::List` handle (from
+            // `.cache` on a not-yet-reified Seq, ADR-0038 S2) is a
+            // `List`, and `eqv` is type-strict — rebuilding it as a plain
+            // `Seq` here would make `$seq.cache eqv (1, 2, 3)` answer False.
+            if body.view() == crate::value::SeqView::List {
+                Value::array(items)
+            } else {
+                Value::seq(items)
+            }
         } else {
             value
         })
@@ -640,6 +648,23 @@ impl Interpreter {
     pub(super) fn exec_eqv_op(&mut self) -> Result<(), RuntimeError> {
         let right = self.stack.pop().unwrap();
         let left = self.stack.pop().unwrap();
+        let result = self.eqv_values(left, right)?;
+        self.stack.push(result);
+        Ok(())
+    }
+
+    /// The full `infix:<eqv>` semantics: the lazy-iterable rules, `Proxy`
+    /// element resolution, the same-Seq identity fast path, and the Seq
+    /// reify/consume protocol (which is what raises `X::Seq::Consumed`), on top
+    /// of the pure [`Value::eqv`] comparison.
+    ///
+    /// Shared so that calling the operator as a routine — `&infix:<eqv>($a,
+    /// $b)`, which is exactly what the real `Test.rakumod`'s `cmp-ok` does via
+    /// `&CALLER::LEXICAL::("infix:<eqv>")` — behaves identically to the `a eqv
+    /// b` operator form. The routine path used to land on the pure
+    /// `apply_reduction_op` fold instead, so `cmp-ok $consumed1, 'eqv',
+    /// $consumed2` silently answered `False` where the operator throws.
+    pub(crate) fn eqv_values(&mut self, left: Value, right: Value) -> Result<Value, RuntimeError> {
         // `eqv` on two lazy iterables of the SAME type cannot be answered without
         // iterating them, so it throws X::Cannot::Lazy (action `eqv`). Two lazy
         // iterables of DIFFERENT type are trivially not-eqv (no iteration needed),
@@ -647,10 +672,7 @@ impl Interpreter {
         // which short-circuits on the length/laziness mismatch.
         match (Self::lazy_eqv_type(&left), Self::lazy_eqv_type(&right)) {
             (Some(a), Some(b)) if a == b => return Err(RuntimeError::cannot_lazy("eqv")),
-            (Some(_), Some(_)) => {
-                self.stack.push(Value::FALSE);
-                return Ok(());
-            }
+            (Some(_), Some(_)) => return Ok(Value::FALSE),
             _ => {}
         }
         // `Value::eqv` is a pure, interpreter-free comparison, so it cannot call
@@ -671,14 +693,10 @@ impl Interpreter {
         if let (ValueView::Seq(lb), ValueView::Seq(rb)) = (left.view(), right.view())
             && Arc::ptr_eq(&lb, &rb)
         {
-            self.stack.push(Value::TRUE);
-            return Ok(());
+            return Ok(Value::TRUE);
         }
         let left = self.reify_or_consume_eqv_operand(left)?;
         let right = self.reify_or_consume_eqv_operand(right)?;
-        let result =
-            self.eval_binary_with_junctions(left, right, |_, l, r| Ok(Value::truth(l.eqv(&r))))?;
-        self.stack.push(result);
-        Ok(())
+        self.eval_binary_with_junctions(left, right, |_, l, r| Ok(Value::truth(l.eqv(&r))))
     }
 }

--- a/src/vm/vm_dispatch_helpers.rs
+++ b/src/vm/vm_dispatch_helpers.rs
@@ -155,6 +155,14 @@ impl Interpreter {
         if normalized_op == "=~=" || normalized_op == "\u{2245}" {
             return self.approx_eq_values(left.clone(), right.clone());
         }
+        // `eqv` is the same story: the static table can only offer the pure
+        // `Value::eqv`, while the operator also owns the lazy-iterable rules,
+        // `Proxy` element FETCH and the Seq reify/consume protocol (the source
+        // of `X::Seq::Consumed`). `[eqv] $consumed1, $consumed2` and
+        // `@a Zeqv @b` must behave exactly like `$a eqv $b`.
+        if normalized_op == "eqv" {
+            return self.eqv_values(left.clone(), right.clone());
+        }
         // Range operators are legal metaop bases (`(1,2) Z.. (5,6)`,
         // `(1,2) X..^ (5,6)`) but are not reductions — they build a Range
         // value rather than fold two operands, so they cannot live in the

--- a/t/seq-cache-list-view-and-eqv-routine.t
+++ b/t/seq-cache-list-view-and-eqv-routine.t
@@ -1,0 +1,141 @@
+use Test;
+
+# Two rules this file pins, both surfaced by the vendored upstream
+# `Test.rakumod` (its `is-deeply` narrows `Seq` arguments with `.cache` and
+# compares with `eqv`; its `cmp-ok` reaches an operator only through
+# `&CALLER::LEXICAL::("infix:<...>")`, i.e. the ROUTINE form):
+#
+#   1. `.cache` on a not-yet-reified `Seq` returns a value that IS a `List`
+#      everywhere it is asked -- `.^name`/`.WHAT`, type matching, `eqv`, and
+#      `.raku` -- not only in its type name (ADR-0038 S2).
+#   2. `&infix:<eqv>($a, $b)` behaves exactly like `$a eqv $b`, including the
+#      Seq reify/consume protocol that raises `X::Seq::Consumed`.
+
+plan 38;
+
+sub make-deferred() {
+    Seq.new(class :: does Iterator {
+        has @!stuff = <a b c>;
+        method pull-one { @!stuff and return @!stuff.shift; IterationEnd }
+    }.new)
+}
+
+# --- 1. `.cache` on a deferred Seq is a List in every facet ----------------
+
+{
+    my $cached = make-deferred().cache;
+    is $cached.^name, 'List', '.cache on a deferred Seq is named List';
+    ok $cached ~~ List, '.cache result smartmatches List';
+    nok $cached ~~ Seq, '.cache result does not smartmatch Seq';
+    ok $cached eqv ('a', 'b', 'c'), '.cache result is eqv to a List';
+    nok $cached eqv <a b c>.Seq, '.cache result is NOT eqv to a Seq';
+    nok $cached eqv ['a', 'b', 'c'], '.cache result is NOT eqv to an Array';
+    is $cached.elems, 3, '.cache result has the right elements';
+}
+
+{
+    # Rendered without a Scalar container so the assertion is about the
+    # value's TYPE, not about itemization: a List renders `(...)`, a Seq
+    # renders `(...).Seq`.
+    is make-deferred().cache.raku, '("a", "b", "c")',
+        '.cache on a deferred Seq renders as a List';
+    is <a b c>.Seq.cache.raku, '("a", "b", "c")',
+        '.cache on an eager Seq renders as a List';
+    is <a b c>.Seq.raku, '("a", "b", "c").Seq', 'an uncached Seq renders as a Seq';
+}
+
+# The same, for an eagerly-built Seq (the arm that already worked -- pinned so
+# the two representations cannot drift apart again).
+{
+    my $cached = <a b c>.Seq.cache;
+    is $cached.^name, 'List', '.cache on an eager Seq is named List';
+    ok $cached eqv ('a', 'b', 'c'), 'eager .cache result is eqv to a List';
+    nok $cached eqv <a b c>.Seq, 'eager .cache result is NOT eqv to a Seq';
+}
+
+# The original Seq keeps its own type: the List view is a property of the
+# HANDLE, not of the shared body.
+{
+    my $s = make-deferred();
+    my $c = $s.cache;
+    is $s.^name, 'Seq', 'the original handle is still a Seq';
+    is $c.^name, 'List', 'the .cache handle is a List';
+    ok $s eqv <a b c>.Seq, 'the original handle is still eqv to a Seq';
+}
+
+# A plain (non-deferred) Seq compares type-strictly, as always.
+{
+    ok <a b c>.Seq eqv <a b c>.Seq, 'Seq eqv Seq';
+    nok <a b c>.Seq eqv ('a', 'b', 'c'), 'Seq is not eqv to a List';
+    nok ('a', 'b', 'c') eqv ['a', 'b', 'c'], 'List is not eqv to an Array';
+    ok ('a', 'b', 'c') eqv ('a', 'b', 'c'), 'List eqv List';
+}
+
+# --- 2. the routine form of an operator is the operator -------------------
+
+{
+    my $eqv = &infix:<eqv>;
+    ok $eqv((1, 2, 3), (1, 2, 3)), '&infix:<eqv> agrees on two Lists';
+    nok $eqv((1, 2, 3), [1, 2, 3]), '&infix:<eqv> is type-strict';
+    ok $eqv(make-deferred().cache, ('a', 'b', 'c')),
+        '&infix:<eqv> sees the .cache List view too';
+    nok $eqv(make-deferred().cache, <a b c>.Seq),
+        '&infix:<eqv> rejects List view vs Seq';
+}
+
+# A consumed Seq throws `X::Seq::Consumed` from BOTH the operator and the
+# routine form. This is what `cmp-ok $s1, 'eqv', $s2` needs.
+{
+    (my $s1 = (1, 2, 3).Seq.slice(0, 1, 2)).sink;
+    (my $s2 = (3, 4, 5).Seq.slice(0, 1, 2)).sink;
+    my $r = try { $s1 eqv $s2 };
+    nok $r.defined, 'operator eqv on a consumed Seq does not answer';
+    isa-ok $!, X::Seq::Consumed, 'operator eqv throws X::Seq::Consumed';
+}
+
+{
+    (my $s1 = (1, 2, 3).Seq.slice(0, 1, 2)).sink;
+    (my $s2 = (3, 4, 5).Seq.slice(0, 1, 2)).sink;
+    my $eqv = &infix:<eqv>;
+    my $r = try { $eqv($s1, $s2) };
+    nok $r.defined, 'routine eqv on a consumed Seq does not answer';
+    isa-ok $!, X::Seq::Consumed, 'routine eqv throws X::Seq::Consumed';
+}
+
+{
+    (my $s1 = (1, 2, 3).Seq.slice(0, 1, 2)).sink;
+    (my $s2 = (3, 4, 5).Seq.slice(0, 1, 2)).sink;
+    throws-like { cmp-ok $s1, 'eqv', $s2 }, X::Seq::Consumed,
+        'cmp-ok with the "eqv" operator name throws on a consumed Seq';
+}
+
+# ... and the reduction / metaop forms, which reach the operator by a third
+# route again (`eval_reduction_operator_values`).
+{
+    (my $s1 = (1, 2, 3).Seq.slice(0, 1, 2)).sink;
+    (my $s2 = (3, 4, 5).Seq.slice(0, 1, 2)).sink;
+    my $r = try { [eqv] $s1, $s2 };
+    nok $r.defined, '[eqv] on a consumed Seq does not answer';
+    isa-ok $!, X::Seq::Consumed, '[eqv] throws X::Seq::Consumed';
+}
+
+{
+    ok ([eqv] (1, 2, 3), (1, 2, 3)), '[eqv] agrees on two Lists';
+    is-deeply ((1, 2) Zeqv (1, '2')).List, (True, False),
+        'Zeqv compares element-wise and stays type-strict';
+}
+
+# --- 3. is-deeply's own narrowing, end to end ------------------------------
+
+is-deeply make-deferred(), <a b c>.Seq, 'is-deeply: deferred Seq vs eager Seq';
+is-deeply <a b c>.Seq, <a b c>.Seq, 'is-deeply: eager Seq vs eager Seq';
+is-deeply <a b c>.Seq, ('a', 'b', 'c'), 'is-deeply: Seq vs List';
+is-deeply make-deferred(), ('a', 'b', 'c'), 'is-deeply: deferred Seq vs List';
+
+{
+    my @res = <a b c>;
+    is-deeply @res.Seq, ('a', 'b', 'c').cache,
+        'is-deeply: Seq vs a cached List (the S16-io/words.t shape)';
+}
+
+# vim: expandtab shiftwidth=4

--- a/todo/deep/vendor-real-test-module.md
+++ b/todo/deep/vendor-real-test-module.md
@@ -4184,3 +4184,80 @@ Per the counting note above: this closes **one** named file. It composes with
 #7084 (2 files), #7085 (2) and #7086 (1) against the same re-measured 40
 baseline, so a fresh sweep should read 35 — measure it rather than trusting that
 arithmetic.
+
+## 2026-08-29: the Seq/List cluster — `tail.t`, `seq.t`, `words.t` (closes 3)
+
+The three files the end-of-day sweep grouped as `S32-list/{seq,tail}.t` plus
+`S16-io/words.t` are **two** root causes, not one, and both sit in
+`infix:<eqv>` — which is exactly why the native provider never saw them: the
+real `is-deeply` narrows `Seq` arguments with `.cache` and then compares with
+`eqv`, and the real `cmp-ok` reaches an operator only through the ROUTINE form
+`&CALLER::LEXICAL::("infix:<$op>")`.
+
+1. **The `SeqView::List` handle was a `List` only by name.** ADR-0038 gave
+   `.cache` on a not-yet-reified `Seq` a second handle tagged `SeqView::List`
+   and taught `value_type_name` to read the tag — enough for `is-deeply`'s
+   narrowing to terminate (the ADR's stack overflow), but the value stayed a
+   `ValueView::Seq`, so `eqv` (type-strict) and `.raku` (renders the type) both
+   still saw a `Seq`. `$d.cache eqv ('a','b','c')` answered False and
+   `$d.cache eqv <a b c>.Seq` answered True — both backwards. Fixed by
+   normalising through one new helper, `Value::seq_list_view_as_list`, read by
+   `Value::eqv`, the `.raku` renderer, and `reify_or_consume_eqv_operand` (which
+   used to rebuild a taken List-view handle as a plain `Seq`). That is
+   `tail.t` 57 and all four `words.t` failures.
+2. **`&infix:<eqv>` was not the `eqv` operator.** `a eqv b` runs `OpCode::Eqv`,
+   whose handler owns the lazy-iterable rules, `Proxy` element FETCH, the
+   same-Seq identity fast path and the Seq reify/consume protocol that raises
+   `X::Seq::Consumed`. The routine form fell through `call_infix_routine` to the
+   pure `apply_reduction_op` fold (just `Value::eqv`), so
+   `cmp-ok $consumed1, 'eqv', $consumed2` silently answered False and emitted
+   its own TAP line inside the `throws-like` subtest. The operator body is now
+   `Interpreter::eqv_values` and `call_infix_routine` routes `eqv` through it,
+   the same way it already routes `~~`. That is `seq.t` 34.
+
+A THIRD route to `eqv` had the same defect and was fixed in the same move:
+`eval_reduction_operator_values` (which serves `[eqv]` and every metaop —
+`Zeqv`, `Xeqv`, `>>eqv<<`) also answered from the static `apply_reduction_op`
+table, so `[eqv] $consumed1, $consumed2` said `False` where raku throws.
+
+The targeted sweep then caught the consequence of (2): making the routine form
+consume — as raku does — exposed that mutsu's `unique`/`repeated` never cached a
+`Seq`-valued `:as` needle, which is what `roast/S32-list/unique.t`'s last test
+("Seq as the result of an :as caches the Seq") pins. `unique` and `repeated` now
+`.cache` it; `squish` deliberately does not, because raku's `squish` genuinely
+throws `X::Seq::Consumed` on the same input (measured all three side by side).
+
+### Per-file before/after (release build, `scripts/run-roast-test.sh`)
+
+| file | real Test before | real Test after | native before | native after |
+| --- | --- | --- | --- | --- |
+| `roast/S32-list/tail.t` | 1 failure (#57) | **PASS** | PASS | PASS |
+| `roast/S32-list/seq.t` | 1 failure (#34) | **PASS** | PASS | PASS |
+| `roast/S16-io/words.t` | 4 failures (#1, #2, #5, #6) | **PASS** | PASS | PASS |
+
+Per the counting note above: this closes **three** named files against the
+2026-08-29 re-measured 40 baseline. It composes with #7084 (2 files), #7085
+(2), #7086 (1) and #7087 (1) on a disjoint file set — measure the next sweep
+rather than trusting the arithmetic.
+
+Pin: `t/seq-cache-list-view-and-eqv-routine.t` (38 assertions, green under real
+`raku` as well as mutsu). Verification: `make test` green; the three files green
+under BOTH providers; a 444-file native sweep across `S32-list`, `S32-array`,
+`S16-io`, `S32-io`, `S02-types`, `S04-statements`, `S07-*`, `S03-operators` and
+`integration` green; `scripts/battery-testsuite.sh` on a release build unchanged.
+Full write-up:
+`news/2026-08/seq-list-view-is-a-list-everywhere-and-the-eqv-routine-is-the-eqv-operator.md`.
+One residual was split off rather than forced through:
+`todo/tickets/seq-list-view-handle-is-not-itemized-by-scalar-assignment.md` (a
+`.raku`-only itemization gap on the deferred List-view handle).
+
+### Note for the rest of the residue
+
+ADR-0038's "one oracle" rule was written about the type *name*. Both bugs here
+say the same thing one level down: a value carrying a type tag needs that
+discipline everywhere its type is *observable* (`eqv` and `.raku` are type
+oracles too), and where an operation has an operator form and a routine form,
+the real `Test.rakumod` will find whichever of the two mutsu did not think of as
+"the" implementation. `cmp-ok` reaches EVERY operator by name through
+`&CALLER::LEXICAL::`, so any remaining operator whose routine form diverges from
+its opcode is a live candidate for the rest of the list.

--- a/todo/tickets/seq-list-view-handle-is-not-itemized-by-scalar-assignment.md
+++ b/todo/tickets/seq-list-view-handle-is-not-itemized-by-scalar-assignment.md
@@ -1,0 +1,82 @@
+# A `.cache` List-view handle is not itemized when assigned to a `$` variable
+
+`.raku` on a `List` held in a `Scalar` container renders with the itemization
+sigil — rakudo's `List.raku` takes its invocant raw and asks `nqp::iscont`, so
+`my $c = (1,2,3); $c.raku` is `$(1, 2, 3)`, not `(1, 2, 3)`. mutsu models the
+same thing on the value side: assigning a `List` to a `$`-sigiled variable
+converts its `ArrayKind::List` to `ArrayKind::ItemList`, which the `.raku`
+renderer prints with the `$` prefix.
+
+The `SeqView::List` handle that `.cache` returns for a **not-yet-reified** `Seq`
+(ADR-0038 §2) is not an `Array` at all — it is still a `ValueView::Seq` with a
+`List` view tag — so scalar assignment has nothing to re-tag, and the
+itemization is silently lost:
+
+```raku
+my $d = Seq.new(class :: does Iterator {
+    has @!stuff = <a b c>;
+    method pull-one { @!stuff and return @!stuff.shift; IterationEnd }
+}.new);
+my $c = $d.cache;
+say $c.raku;
+# raku:  $("a", "b", "c")
+# mutsu:  ("a", "b", "c")
+```
+
+Only the *deferred* arm diverges. `.cache` on an already-reified `Seq` returns a
+real `Value::array`, and that one itemizes correctly (`my $c = <a b c>.Seq.cache;
+$c.raku` is `$("a", "b", "c")` in both). Without a `Scalar` container the two
+agree as well (`<a b c>.Seq.cache.raku` is `("a", "b", "c")` in both) — the
+divergence is exactly "value in a scalar container".
+
+## Why it is not just a renderer tweak
+
+The renderer is not where the information is missing: by the time `.raku` runs,
+nothing distinguishes "this List-view handle was assigned to a `$`" from "this
+one was not". Fixing it means either
+
+* giving `SeqBody`'s handle an itemization bit alongside `SeqView` (so
+  `SeqView` becomes `Seq | List | ItemList`, and every site that builds a handle
+  has to decide), or
+* having scalar assignment *materialise* a still-deferred List-view handle into
+  a real itemized `Value::array` — which would force the body and defeat the
+  whole point of ADR-0038 §1.6 (an infinite `:as`/`lines` source must survive
+  `.cache`), or
+* deferring the decision: keep the handle, but let the scalar-assignment path
+  record itemization on the handle and have the renderer consult it.
+
+The third is probably right, but it is an ADR-0038 amendment, not a one-liner.
+
+## Blast radius / priority
+
+Cosmetic today: it is visible only through `.raku`, and `.raku` of a `.cache`d
+deferred `Seq` held in a scalar is not something any whitelisted roast file or
+`t/` test asserts. It surfaced while writing
+`t/seq-cache-list-view-and-eqv-routine.t` (which sidesteps it by rendering
+without a container, and says so in a comment). It would start to matter if a
+test ever round-trips such a value through `.raku.EVAL`, since the itemization
+is part of the round-trip.
+
+## Minimal repro
+
+```
+SNIPPET='my $d = Seq.new(class :: does Iterator {
+    has @!stuff = <a b c>;
+    method pull-one { @!stuff and return @!stuff.shift; IterationEnd }
+}.new); my $c = $d.cache; say $c.raku'
+
+raku  -e "$SNIPPET"    # $("a", "b", "c")
+mutsu -e "$SNIPPET"    #  ("a", "b", "c")
+```
+
+The `does Iterator` class is required: `Seq.new(<mutsu's own built-in
+iterator>)` takes the eager shortcut in `try_native_seq_construct`, so its
+`.cache` returns a real `Value::array` and both agree (`$(1, 2, 3)`). Only the
+deferred body reaches the List-view handle.
+
+## Affected files
+
+* `src/value/seq_body.rs` — `SeqView`, `SeqBody::as_list_view`
+* `src/value/view.rs` — `Value::seq_list_view`, `Value::seq_list_view_as_list`
+* `src/builtins/methods_0arg/raku_repr.rs` — the `ValueView::Seq` arm
+* wherever scalar assignment re-tags `ArrayKind::List` as `ArrayKind::ItemList`


### PR DESCRIPTION
Closes the real-`Test` campaign's Seq/List cluster (`todo/deep/vendor-real-test-module.md`): `roast/S32-list/tail.t` (test 57), `roast/S32-list/seq.t` (test 34) and `roast/S16-io/words.t` (tests 1, 2, 5, 6). **Two** root causes, not one, but both sit in `infix:<eqv>` — which is why only the vendored upstream `Test.rakumod` sees them: its `is-deeply` narrows `Seq` arguments with `.cache` and then compares with `eqv`, and its `cmp-ok` reaches an operator only through the *routine* form `&CALLER::LEXICAL::("infix:<$op>")`.

## 1. The `SeqView::List` handle was a `List` only by name

ADR-0038 gave `.cache` on a not-yet-reified `Seq` a second handle over the same body tagged `SeqView::List`, and taught `value_type_name` to read the tag — enough for `is-deeply`'s narrowing to terminate (the stack overflow that ADR was written for). But the value itself stayed a `ValueView::Seq`, so the two sites that ask a *structural* question about a value's Raku type never saw it:

```raku
my $c = Seq.new(<a user Iterator>).cache;
say $c.^name;              # List                (right, since ADR-0038)
say $c.raku;               # ("a","b","c").Seq   <- raku: ("a","b","c")
say $c eqv ('a','b','c');  # False               <- raku: True
say $c eqv <a b c>.Seq;    # True                <- raku: False
```

`Value::eqv`, the `.raku` renderer and `reify_or_consume_eqv_operand` (which rebuilt a *taken* List-view handle as a plain `Seq`) now all normalise through one new helper, `Value::seq_list_view_as_list` — ADR-0038 §2's "one oracle" rule applied to the value's representation, not only to its type name. This is `tail.t` 57 and all four `words.t` failures.

## 2. `&infix:<eqv>` was not the `eqv` operator

`a eqv b` runs `OpCode::Eqv`, whose handler owns the `X::Cannot::Lazy` rules for two lazy iterables, `Proxy` element FETCH, the same-`Seq` identity fast path and the Seq reify/consume protocol that raises `X::Seq::Consumed`. The routine form fell through `call_infix_routine` to the pure `apply_reduction_op` fold (just `Value::eqv`):

```raku
(my $s1 = (1,2,3).Seq.slice(0,1,2)).sink;
(my $s2 = (3,4,5).Seq.slice(0,1,2)).sink;
$s1 eqv $s2;             # throws X::Seq::Consumed  (correct)
&infix:<eqv>($s1, $s2);  # answered False           (wrong)
```

so `cmp-ok $s1, 'eqv', $s2` silently answered `False` and the un-thrown `cmp-ok` emitted its own TAP line inside the `throws-like` subtest ("You planned 2 tests, but ran 3"). The operator body is now `Interpreter::eqv_values`, and `call_infix_routine` routes `eqv` through it the same way it already routes `~~`/`!~~` for needing the full interpreter. This is `seq.t` 34.

A **third** route had the same defect and gets the same redirect: `eval_reduction_operator_values`, which serves `[eqv]` and every metaop (`Zeqv`, `Xeqv`, `>>eqv<<`), also answered from the static table.

## The consequence the sweep caught: `unique`/`repeated` must cache their `:as` needles

Making the routine form consume `Seq` operands (as raku does) exposed a pre-existing bug it had been hiding. `roast/S32-list/unique.t`'s last test is literally named *"Seq as the result of an `:as` caches the Seq"*: `[[1], ['1'], [4]].unique(:as(*.map(&[~])), :with(&[eqv]))` compares every needle against every needle seen so far, so an un-cached `Seq` needle dies on its second use. `unique` and `repeated` now `.cache` it (`.cache` does not force a deferred body, so an infinite `:as` result stays lazy).

`squish` deliberately does **not** get the same treatment, and the asymmetry is measured rather than guessed: with a `Seq`-valued `:as` and `:with(&[eqv])`, raku's `unique` and `repeated` both answer while its `squish` throws `X::Seq::Consumed` (squish keeps only the previous needle, used once as the right operand and again as the left). mutsu now reproduces all three exactly.

## Measured, file by file (release build, `scripts/run-roast-test.sh`)

| file | real Test before | real Test after | native before | native after |
| --- | --- | --- | --- | --- |
| `roast/S32-list/tail.t` | 1 failure (#57) | **PASS** | PASS | PASS |
| `roast/S32-list/seq.t` | 1 failure (#34) | **PASS** | PASS | PASS |
| `roast/S16-io/words.t` | 4 failures (#1, #2, #5, #6) | **PASS** | PASS | PASS |

So **roast correctness regressions under the real `Test`: 40 -> 37** against the 2026-08-28 end-of-day baseline.

## Verification

- `make test` green (3523 files, 35176 tests).
- The three files green under **both** providers.
- A 444-file native roast sweep across `S32-list`, `S32-array`, `S16-io`, `S32-io`, `S02-types`, `S04-statements`, `S07-*`, `S03-operators` and `integration` — green (it is what caught the `unique.t` consequence above).
- A 191-file real-`Test` sweep leaves only the four files already on the end-of-day baseline (`S32-io/{slurp,spurt,io-cathandle}.t`, `S32-list/skip.t`).
- `scripts/battery-testsuite.sh` on a release build: `GATE PASSED`, 273/297 — unchanged.
- `cargo fmt` + `cargo clippy -- -D warnings` clean.

Pin: `t/seq-cache-list-view-and-eqv-routine.t` — 38 assertions, **green under real `raku` as well as under mutsu**.

One residual was split off rather than forced through: `todo/tickets/seq-list-view-handle-is-not-itemized-by-scalar-assignment.md` (a `.raku`-only itemization gap on the deferred List-view handle — `$(...)` vs `(...)` when it is held in a scalar).
