### PR TITLE
fix(eval): an EVAL'd unit does not inherit the caller's `fatal`

### DIFF
--- a/news/2026-08/eval-unit-does-not-inherit-fatal.md
+++ b/news/2026-08/eval-unit-does-not-inherit-fatal.md
@@ -1,0 +1,58 @@
+# An EVAL'd unit does not inherit the caller's `fatal`
+
+`fatal` is lexical to a compilation unit, and `EVAL` compiles a fresh one — so a
+caller's `use fatal`, or the implicit one a `try` block turns on, does not reach
+the snippet. mutsu let it through, which made every `try EVAL '…'` fatal:
+
+```raku
+try EVAL 'my $x = Failure.new; 1';                # rakudo: 1   mutsu: died
+try EVAL 'sub f { fail "z" }; my $r = f(); 1';    # rakudo: 1   mutsu: died
+```
+
+Under `fatal`, assigning an unhandled `Failure` to a variable throws
+(`exec_set_local_op_inner` gates exactly that on `self.fatal_mode`); without it
+the `Failure` simply sits in the variable. `eval_eval_string` saved and restored
+`fatal_mode` around the snippet — so a snippet's own `use fatal` correctly stopped
+at the EVAL boundary — but never *cleared* it on the way in, so the caller's
+setting stayed live inside.
+
+The measured rule, re-derived against rakudo across the whole matrix:
+
+| snippet | outer `use fatal`? | rakudo |
+| --- | --- | --- |
+| `my $x = Failure.new; 1` | no | `1` |
+| `my $x = Failure.new; 1` | **yes** | `1` |
+| `sub f { fail "z" }; my $r = f(); 1` | either | `1` |
+| `use fatal; my $x = Failure.new; 1` | either | **dies** |
+| `Failure.new` | either | **dies** |
+| `my $x = Failure.new` | either | **dies** |
+
+Only the snippet's own `use fatal` matters. The last two rows are not about
+`fatal` at all: the `Failure` is the EVAL's *return value* and is thrown when the
+caller sinks it — which is why the fix must clear the flag rather than suppress
+the throw.
+
+## The comment that argued the other way was wrong
+
+The code carried a comment claiming the caller's `fatal` is "a runtime
+dynamic-scope check the EVAL'd unit legitimately inherits", citing
+`use fatal; try { EVAL q["bar"[5]] }` reporting `X::OutOfRange`. That evidence
+proves nothing: an out-of-range subscript throws there **with or without**
+`fatal` — measured both ways. A test whose outcome does not change with the
+variable under test cannot be evidence about it.
+
+## What it freed
+
+`roast/S02-names/is_default.t` passes under both providers. Its assertion is
+`eval-lives-ok 'my $a is default(Failure.new); 1'`, and under
+`MUTSU_REAL_TEST=1` the real `Test` module's `eval-lives-ok` really EVALs the
+string from inside a `try`, so the implicit `fatal` reached the snippet and the
+`Failure` used as a default value threw. mutsu's native provider does not take
+that path, which is why the file passed there — the ordinary shape of this
+campaign's residue (`todo/deep/vendor-real-test-module.md`).
+
+Pin: `t/eval-unit-does-not-inherit-fatal.t`, 14 assertions covering both
+directions (the caller's `fatal` not reaching in, the snippet's not leaking out),
+`try`'s implicit `fatal` as well as an explicit `use fatal`, and the two cases
+that must still throw because the `Failure` is the EVAL's value — green under
+real `raku` unchanged.

--- a/src/runtime/system_eval_string.rs
+++ b/src/runtime/system_eval_string.rs
@@ -308,6 +308,17 @@ impl Interpreter {
         // long after the EVAL returned. (`throws-like 'use fatal; ...'` is a
         // common assertion shape, so one of them poisoned the rest of the file.)
         let saved_fatal_mode = self.fatal_mode;
+        // ... and the EVAL'd unit does not INHERIT one either. `fatal` is
+        // lexical to a compilation unit and EVAL compiles a fresh one, so a
+        // caller's `use fatal` — or `try`'s implicit one — must not fatalize the
+        // snippet. Measured against rakudo: `use fatal; try EVAL 'my $x =
+        // Failure.new; 1'` answers 1, and so does the same without `use fatal`;
+        // only `EVAL 'use fatal; my $x = Failure.new; 1'`, where the snippet
+        // turns it on itself, dies. (The `use fatal; try { EVAL q["bar"[5]] }`
+        // -> X::OutOfRange case that once argued for inheriting it proves
+        // nothing: an out-of-range subscript throws there with or without
+        // `fatal`.)
+        self.fatal_mode = false;
         // Unlike `fatal` (a runtime dynamic-scope check the EVAL'd unit
         // legitimately inherits from its caller -- `raku -e 'use
         // MONKEY-SEE-NO-EVAL; use fatal; try { EVAL q["bar"[5]] }; say

--- a/t/eval-unit-does-not-inherit-fatal.t
+++ b/t/eval-unit-does-not-inherit-fatal.t
@@ -1,0 +1,74 @@
+use Test;
+use MONKEY-SEE-NO-EVAL;
+
+# `fatal` is lexical to a compilation unit, and EVAL compiles a fresh one, so an
+# EVAL'd snippet does NOT inherit the caller's `fatal` -- neither an explicit
+# `use fatal` nor the implicit one a `try` block turns on. Only a snippet that
+# says `use fatal` itself is fatal.
+#
+# Under `fatal`, assigning an unhandled Failure to a variable throws; without it
+# the Failure just sits in the variable. That difference is what makes this
+# observable.
+#
+# Verified assertion-for-assertion against rakudo.
+
+plan 14;
+
+# --- the caller's fatal does not reach the snippet ------------------------
+is (try EVAL 'my $x = Failure.new; 1'), 1,
+   'a plain EVAL does not fatalize an assigned Failure';
+is (try EVAL 'sub f { fail "z" }; my $r = f(); 1'), 1,
+   'nor one that came from fail()';
+is (try EVAL 'my $x = Failure.new; 42'), 42,
+   'the snippet returns its own last value';
+is (try EVAL '{ my $x = Failure.new; }; 1'), 1,
+   'the same inside a nested block in the snippet';
+is (try EVAL 'my $z is default(Failure.new); 1'), 1,
+   'a Failure used as an `is default` value does not throw';
+
+{
+    use fatal;
+    is (try EVAL 'my $x = Failure.new; 1'), 1,
+       'an enclosing `use fatal` does not reach the snippet either';
+    is (try EVAL 'sub f { fail "z" }; my $r = f(); 1'), 1,
+       'nor for a fail()-produced Failure';
+}
+
+# --- a snippet that turns fatal on itself IS fatal ------------------------
+{
+    my $ok = (try EVAL 'use fatal; my $x = Failure.new; 1').defined;
+    nok $ok, 'a snippet with its own `use fatal` throws on the assignment';
+}
+{
+    my $ok = (try EVAL 'use fatal; sub f { fail "z" }; my $r = f(); 1').defined;
+    nok $ok, 'and on a fail()-produced Failure';
+}
+
+# --- an unhandled Failure as the snippet's VALUE still throws -------------
+# This is not about `fatal` at all: the Failure becomes EVAL's return value and
+# is then sunk by the caller.
+{
+    my $ok = (try EVAL 'Failure.new').defined;
+    nok $ok, 'a Failure as the last statement still throws';
+}
+{
+    my $ok = (try EVAL 'my $x = Failure.new').defined;
+    nok $ok, 'so does an assignment as the last statement, whose value it is';
+}
+
+# --- the caller's own fatal is unchanged afterwards -----------------------
+{
+    use fatal;
+    EVAL '1';
+    my $threw = False;
+    { my $x = Failure.new; 1; CATCH { default { $threw = True } } }
+    ok $threw, 'the caller keeps its own `use fatal` after an EVAL returns';
+}
+{
+    EVAL 'use fatal; 1';
+    my $x = Failure.new;
+    ok True, 'a snippet turning `use fatal` on does not leak it to the caller';
+    is $x.defined, False, 'and the caller can still hold a Failure';
+}
+
+# vim: expandtab shiftwidth=4

--- a/todo/deep/procasync-stress-segv.md
+++ b/todo/deep/procasync-stress-segv.md
@@ -421,3 +421,30 @@ bodies), which touches class-level attribute storage and has no connection to th
 unrelated PRs (§7.3, and the roast test's own `sometimes hangs, sometimes segfaults` skip comment),
 and the same job passed the file cleanly on re-run. Recorded here so the evidence is not lost to a
 green re-run, per `CLAUDE.md`'s rule that a crash-class failure is never dismissed as noise.
+
+## §8.4 Third recurrence, and it confirms §8.2's diagnostics gap exactly
+
+CI run **33154831894** (gc-stress, PR #7089 — an `EVAL`/`fatal` change with no connection to
+threads, `Supplier`, or the scheduler):
+
+```
+roast/integration/advent2014-day05.t   (Wstat: 35584 (exited 139) Tests: 5 Failed: 0)
+  Non-zero exit status: 139
+Result: FAIL
+```
+
+Same shape as §8.2: SIGSEGV, `Failed: 0` (it died five assertions in), and **no crash report for it**
+— the only report in `tmp/crash/` was the allowlisted deliberate `strdup(0)` subprocess from
+`roast/S29-os/system.t`, so the collector step passed and the diagnostic this ticket exists for
+again captured nothing.
+
+Not a regression from that PR: the file contains no `EVAL` and no `fatal`, so the change under test
+cannot reach it. Re-measured on the PR's own branch with the job's exact environment
+(`MUTSU_GC=on MUTSU_GC_EVERY_CANDIDATE=1024 MUTSU_GC_VERIFY=1 MUTSU_ROAST_TIMEOUT_SCALE=2`,
+release): the file alone 8/8 clean, the whole `integration/` whitelist under `prove -j4` 3/3 clean,
+and the full `t/` suite (3529 files) clean.
+
+The actionable item is unchanged and is §8.2's, not the crash itself: **make a fatal signal on a
+non-`mutsu-main` thread actually produce a report.** Three recurrences have now each cost a red CI
+and yielded no backtrace. Extending `tests/crash_report.rs` to fault each thread class mutsu spawns
+is contained work that does not need the underlying race to reproduce.

--- a/todo/deep/vendor-real-test-module.md
+++ b/todo/deep/vendor-real-test-module.md
@@ -4356,3 +4356,41 @@ installation and mutsu defers the mainline's own ENDs). It is deliberately NOT
 fixed here — `news/2026-08/end-phasers-run-in-install-order.md` made mutsu
 install-ordered on purpose — and is filed as
 `todo/tickets/end-phaser-run-order-is-not-reverse-installation.md`.
+
+
+## 2026-08-29: an EVAL'd unit does not inherit the caller's `fatal` (`S02-names/is_default.t`)
+
+`roast/S02-names/is_default.t` regressed on the assertion
+`eval-lives-ok 'my $a is default(Failure.new); 1'`. Under `MUTSU_REAL_TEST=1`
+the real module's `eval-lives-ok` really EVALs its string from inside a `try`,
+and `try` turns `fatal` on implicitly — which mutsu let through into the EVAL'd
+unit, where assigning an unhandled `Failure` to a variable throws. The native
+provider does not take that path.
+
+`fatal` is lexical to a compilation unit and EVAL compiles a fresh one, so
+neither an explicit `use fatal` nor `try`'s implicit one reaches the snippet;
+only a snippet that says `use fatal` itself is fatal. `eval_eval_string` saved
+and restored `fatal_mode` (so a snippet's own pragma correctly stopped at the
+boundary) but never cleared it on the way in.
+
+**The in-code comment that argued for inheriting it was wrong, and worth
+recording as a method lesson.** It cited `use fatal; try { EVAL q["bar"[5]] }`
+reporting `X::OutOfRange` as proof the caller's `fatal` is live inside. Measured
+both ways, that snippet reports `X::OutOfRange` **with or without** `fatal` — a
+test whose outcome does not change with the variable under test is not evidence
+about it. Re-deriving the whole matrix against rakudo gave the real rule in one
+pass.
+
+| file | real Test before | after | native before | after |
+| --- | --- | --- | --- | --- |
+| `S02-names/is_default.t` | 1 failure (#140) | **PASS** | PASS | PASS |
+
+Fix and pin: `news/2026-08/eval-unit-does-not-inherit-fatal.md`,
+`t/eval-unit-does-not-inherit-fatal.t` (14 assertions, green under real `raku`).
+Verification: `make test` green (3527 files, 35246 tests); a 505-file targeted
+roast sweep across `S02-names`, `S04-exception*`, `S32-exceptions`, `S06-*`,
+`S12-*`, `S24-testing`, `S32-num`, `S29-context`, `S05-*` and `integration`
+green on the native provider.
+
+Per the counting note above, this closes **one** named file; re-measure rather
+than trusting a running total.


### PR DESCRIPTION
`fatal` is lexical to a compilation unit, and `EVAL` compiles a fresh one — so a caller's `use fatal`, or the implicit one a `try` block turns on, does not reach the snippet. mutsu let it through, which made every `try EVAL '…'` fatal:

```raku
try EVAL 'my $x = Failure.new; 1';                # rakudo: 1   mutsu: died
try EVAL 'sub f { fail "z" }; my $r = f(); 1';    # rakudo: 1   mutsu: died
```

Under `fatal`, assigning an unhandled `Failure` to a variable throws (`exec_set_local_op_inner` gates exactly that on `self.fatal_mode`); without it the `Failure` simply sits in the variable. `eval_eval_string` saved and restored `fatal_mode` — so a snippet's **own** `use fatal` correctly stopped at the EVAL boundary — but never *cleared* it on the way in, so the caller's setting stayed live inside.

Re-derived against rakudo across the whole matrix:

| snippet | outer `use fatal`? | rakudo |
| --- | --- | --- |
| `my $x = Failure.new; 1` | no | `1` |
| `my $x = Failure.new; 1` | **yes** | `1` |
| `sub f { fail "z" }; my $r = f(); 1` | either | `1` |
| `use fatal; my $x = Failure.new; 1` | either | **dies** |
| `Failure.new` | either | **dies** |
| `my $x = Failure.new` | either | **dies** |

Only the snippet's own `use fatal` matters. The last two rows are not about `fatal` at all — the `Failure` is the EVAL's *return value* and the caller sinks it — which is why the fix clears the flag rather than suppressing the throw.

## The comment that argued the other way was wrong

The code carried a comment claiming the caller's `fatal` is "a runtime dynamic-scope check the EVAL'd unit legitimately inherits", citing `use fatal; try { EVAL q["bar"[5]] }` reporting `X::OutOfRange`. Measured both ways, that snippet reports `X::OutOfRange` **with or without** `fatal` — a test whose outcome does not change with the variable under test is not evidence about it.

## What it frees

`roast/S02-names/is_default.t` under the real `Test` module (the campaign in `todo/deep/vendor-real-test-module.md`). Its assertion is `eval-lives-ok 'my $a is default(Failure.new); 1'`, and the real `eval-lives-ok` really EVALs the string from inside a `try`, so the implicit `fatal` reached the snippet and the `Failure` used as a default value threw. mutsu's native provider does not take that path, which is why the file passed there.

| file | real Test before | after | native before | after |
| --- | --- | --- | --- | --- |
| `S02-names/is_default.t` | 1 failure (#140) | **PASS** | PASS | PASS |

## Verification

* `make test` green — 3527 files, 35246 tests.
* Targeted roast sweep over the EVAL/exception consumers (`S02-names`, `S04-exception*`, `S32-exceptions`, `S06-*`, `S12-*`, `S24-testing`, `S32-num`, `S29-context`, `S05-*`, `integration`) — **505 files, 16865 tests, PASS**.
* The roast file green under **both** providers.
* Pin `t/eval-unit-does-not-inherit-fatal.t` — 14 assertions covering both directions (the caller's `fatal` not reaching in, the snippet's not leaking out), `try`'s implicit `fatal` as well as an explicit `use fatal`, and the two cases that must still throw — **green under real `raku`** as well as mutsu.