### PR TITLE
fix(eval): a placeholder at an EVAL'd unit's mainline is X::Placeholder::Mainline

### DIFF
--- a/news/2026-08/eval-mainline-placeholder-check.md
+++ b/news/2026-08/eval-mainline-placeholder-check.md
@@ -1,0 +1,52 @@
+# A placeholder at an EVAL'd unit's mainline is `X::Placeholder::Mainline`
+
+`EVAL '$^a'` raised nothing at all, and `EVAL '@_'` raised `X::Undeclared`, where
+rakudo raises `X::Placeholder::Mainline` for both. A placeholder parameter used
+outside any sub or block is that error, and `@_` / `%_` are placeholders too —
+which is why the check has to run *before* the undeclared-variable check, or the
+`@_` case is reported as an undeclared variable instead.
+
+## It was already implemented, in only one of two parallel check chains
+
+`Interpreter::check_eval_mainline_placeholders` (`runtime/system_eval_vars.rs`)
+has existed for a while, complete with the `placeholder` attribute and rakudo's
+message text. Its only caller was `runtime/test_functions/throws_like.rs` — the
+**native** `Test` provider's `throws-like`, which parses its code string itself
+and runs its own chain of `check_eval_*` calls. The ordinary EVAL path
+(`parse_and_eval_with_operators`) runs the same chain and was missing this one
+member, so the check simply never fired for real `EVAL`.
+
+That is why `roast/S32-exceptions/misc2.t` passed under the native provider and
+failed under `MUTSU_REAL_TEST=1`: the real `Test.rakumod`'s `throws-like` EVALs
+its string through the ordinary path.
+
+The fix is one line in `parse_and_eval_with_operators`, placed ahead of
+`check_eval_undeclared_vars` for the ordering reason above.
+
+## The native call site is NOT redundant, and removing it was measured wrong
+
+The obvious follow-up — "the native chain's copy is now a duplicate, delete it" —
+was tried and **reverted**, because it is not a duplicate: the native
+`throws-like` never goes through `parse_and_eval_with_operators` at all. With the
+line removed, `roast/S32-exceptions/misc2.t` test 14 (`throws-like '@_',
+X::Placeholder::Mainline`) fails under the *native* provider, since
+`check_eval_undeclared_vars` then reports `X::Undeclared` first. Both chains
+genuinely need the check; the call site now carries a comment saying so and
+naming the test that proves it.
+
+This is worth recording as a shape: a check reachable from only one of two
+parallel chains looks exactly like a native-provider leniency crutch (the kind
+`news/2026-08/parse-error-exception-classes.md` correctly retired), and is not
+one. Measure the removal before believing the label.
+
+## What it freed
+
+`roast/S32-exceptions/misc2.t` passes under both providers — three assertions,
+`throws-like '$^x'` / `'@_'` / `'"foo".{ say $^a }'`, all wanting
+`X::Placeholder::Mainline`.
+
+Pin: `t/eval-mainline-placeholder.t`, 15 assertions covering the mainline cases,
+the `placeholder` attribute and message, the `X::Placeholder::Block` cases that
+must stay distinct, the positions where a placeholder is legal, and an ordinary
+undeclared variable that must still be `X::Undeclared` — green under real `raku`
+unchanged.

--- a/src/runtime/system.rs
+++ b/src/runtime/system.rs
@@ -96,6 +96,15 @@ impl Interpreter {
         crate::parser::clear_parser_lib_paths();
         match parse_result {
             Ok((stmts, _)) => {
+                // A placeholder parameter used directly in the mainline is
+                // `X::Placeholder::Mainline`, and this has to run BEFORE the
+                // undeclared check -- otherwise `@_` / `%_` are reported as
+                // `X::Undeclared`. It lived only in the NATIVE `throws-like`
+                // (`test_functions/throws_like.rs`), which is why
+                // `roast/S32-exceptions/misc2.t` passed there and failed under
+                // the real `Test` module, whose `throws-like` EVALs its string
+                // through this ordinary path.
+                self.check_eval_mainline_placeholders(&stmts)?;
                 self.check_eval_class_redeclarations(&stmts)?;
                 self.check_eval_undeclared_trusts(&stmts)?;
                 self.check_eval_undeclared_type_args(&stmts)?;

--- a/src/runtime/test_functions/throws_like.rs
+++ b/src/runtime/test_functions/throws_like.rs
@@ -202,6 +202,15 @@ impl Interpreter {
                                 }
                             }
                             nested
+                                // NOT redundant with the same call in
+                                // `parse_and_eval_with_operators`: this is a
+                                // PARALLEL check chain -- the native
+                                // `throws-like` parses the string itself and
+                                // never goes through that path -- and without
+                                // it `@_` is reported as `X::Undeclared`
+                                // (measured: removing this line fails
+                                // `roast/S32-exceptions/misc2.t` test 14 under
+                                // the native provider).
                                 .check_eval_mainline_placeholders(&stmts)
                                 .and_then(|()| nested.check_eval_class_redeclarations(&stmts))
                                 .and_then(|()| nested.check_eval_undeclared_trusts(&stmts))

--- a/t/eval-mainline-placeholder.t
+++ b/t/eval-mainline-placeholder.t
@@ -1,0 +1,53 @@
+use Test;
+use MONKEY-SEE-NO-EVAL;
+
+# A placeholder parameter used directly in the MAINLINE -- outside any sub or
+# block -- is `X::Placeholder::Mainline`. `$^x`, `@_` and `%_` are all
+# placeholders, so `@_` at mainline is this error and NOT `X::Undeclared`, which
+# is why the check has to run before the undeclared-variable check.
+#
+# EVAL compiles a fresh compilation unit, so an EVAL'd string is its own
+# mainline and gets the same treatment.
+#
+# Verified assertion-for-assertion against rakudo.
+
+plan 15;
+
+sub class-of($code) { (try EVAL $code); $! ?? $!.^name !! 'no error' }
+
+# --- placeholders at the EVAL'd unit's mainline ---------------------------
+is class-of('$^a'),          'X::Placeholder::Mainline', 'a bare $^a at mainline';
+is class-of('say $^a'),      'X::Placeholder::Mainline', '$^a inside a listop call';
+is class-of('$^a + $^b'),    'X::Placeholder::Mainline', 'two placeholders';
+is class-of('@_'),           'X::Placeholder::Mainline', '@_ is a placeholder, not undeclared';
+is class-of('%_'),           'X::Placeholder::Mainline', '%_ likewise';
+is class-of('"foo".{ say $^a }'), 'X::Placeholder::Mainline',
+   'a postfix-block placeholder is still the mainline one';
+
+# --- and it carries the placeholder's name --------------------------------
+{
+    try EVAL '$^x';
+    is $!.placeholder, '$^x', 'the exception names the placeholder';
+    ok $!.message.contains('outside of a sub or block'), 'and says why';
+}
+{
+    try EVAL '@_';
+    is $!.placeholder, '@_', 'the same for @_';
+}
+
+# --- a BLOCK is a different error -----------------------------------------
+is class-of('do    { $^x }'), 'X::Placeholder::Block',
+   'a placeholder in a `do` block is X::Placeholder::Block';
+is class-of('class { $^x }'), 'X::Placeholder::Block',
+   'and in a class body';
+
+# --- where a placeholder is legal, nothing is raised ----------------------
+is class-of('sub f { $^x }'),     'no error', 'a sub body may declare a placeholder';
+is class-of('my $b = { $^x }'),   'no error', 'so may a block assigned to a variable';
+is class-of('my $b = { @_ }'),    'no error', '@_ inside a block is fine too';
+
+# --- an ordinary undeclared variable is still X::Undeclared ---------------
+is class-of('$undeclared-thing'), 'X::Undeclared',
+   'a plain undeclared variable is unaffected';
+
+# vim: expandtab shiftwidth=4

--- a/todo/deep/vendor-real-test-module.md
+++ b/todo/deep/vendor-real-test-module.md
@@ -4392,5 +4392,41 @@ roast sweep across `S02-names`, `S04-exception*`, `S32-exceptions`, `S06-*`,
 `S12-*`, `S24-testing`, `S32-num`, `S29-context`, `S05-*` and `integration`
 green on the native provider.
 
+## 2026-08-29: a placeholder at an EVAL'd unit's mainline (`S32-exceptions/misc2.t`)
+
+`roast/S32-exceptions/misc2.t` regressed on three `throws-like` assertions
+wanting `X::Placeholder::Mainline` (`'$^x'`, `'@_'`, `'"foo".{ say $^a }'`).
+mutsu raised nothing at all for `$^a` and `X::Undeclared` for `@_`.
+
+**The check was already implemented — in only one of two parallel chains.**
+`check_eval_mainline_placeholders` (`runtime/system_eval_vars.rs`) exists with
+the `placeholder` attribute and rakudo's message text, and its only caller was
+`runtime/test_functions/throws_like.rs` — the **native** provider's
+`throws-like`, which parses its code string itself and runs its own chain of
+`check_eval_*` calls. The ordinary EVAL path (`parse_and_eval_with_operators`)
+runs the same chain and was missing this member, so real `EVAL` never ran it.
+One line, placed ahead of `check_eval_undeclared_vars` (or `@_` is reported as
+an undeclared variable instead).
+
+**The obvious follow-up was measured and reverted.** "The native chain's copy is
+now redundant, delete it" is false: the native `throws-like` never goes through
+`parse_and_eval_with_operators` at all, and removing the line fails this same
+file's test 14 under the *native* provider. Both chains need it; the call site
+now says so and names the test that proves it. Worth carrying forward as a
+shape — **a check reachable from only one of two parallel chains looks exactly
+like a native-provider leniency crutch and is not one.** Measure the removal
+before believing the label.
+
+| file | real Test before | after | native before | after |
+| --- | --- | --- | --- | --- |
+| `S32-exceptions/misc2.t` | 3 failures (#13, #14, #15) | **PASS** | PASS | PASS |
+
+Fix and pin: `news/2026-08/eval-mainline-placeholder-check.md`,
+`t/eval-mainline-placeholder.t` (15 assertions, green under real `raku`).
+Verification: `make test` green (3529 files, 35302 tests); a 483-file targeted
+roast sweep across `S32-exceptions`, `S02-names`, `S02-lexical-conventions`,
+`S04-exception*`, `S06-*`, `S12-*`, `S24-testing`, `S29-context`, `S05-*` and
+`integration` green on the native provider.
+
 Per the counting note above, this closes **one** named file; re-measure rather
 than trusting a running total.


### PR DESCRIPTION
`EVAL '$^a'` raised nothing at all, and `EVAL '@_'` raised `X::Undeclared`, where rakudo raises `X::Placeholder::Mainline` for both. A placeholder parameter used outside any sub or block is that error, and `@_` / `%_` are placeholders too — which is why the check has to run **before** the undeclared-variable check, or the `@_` case is reported as an undeclared variable instead.

## It was already implemented, in only one of two parallel check chains

`check_eval_mainline_placeholders` (`runtime/system_eval_vars.rs`) has existed for a while, complete with the `placeholder` attribute and rakudo's message text. Its only caller was `runtime/test_functions/throws_like.rs` — the **native** `Test` provider's `throws-like`, which parses its code string itself and runs its own chain of `check_eval_*` calls. The ordinary EVAL path (`parse_and_eval_with_operators`) runs the same chain and was missing this one member, so the check never fired for real `EVAL`.

That is why `roast/S32-exceptions/misc2.t` passed under the native provider and failed under `MUTSU_REAL_TEST=1`: the real `Test.rakumod`'s `throws-like` EVALs its string through the ordinary path.

The fix is one line, placed ahead of `check_eval_undeclared_vars`.

## The obvious follow-up was measured and reverted

"The native chain's copy is now a duplicate, delete it" is **false**: the native `throws-like` never goes through `parse_and_eval_with_operators` at all. With the line removed, `roast/S32-exceptions/misc2.t` test 14 (`throws-like '@_', X::Placeholder::Mainline`) fails under the *native* provider, since `check_eval_undeclared_vars` then reports `X::Undeclared` first. Both chains genuinely need the check; the call site now carries a comment saying so and naming the test that proves it.

Worth carrying forward as a shape: **a check reachable from only one of two parallel chains looks exactly like a native-provider leniency crutch** (the kind `news/2026-08/parse-error-exception-classes.md` correctly retired) **and is not one.** Measure the removal before believing the label.

## What it frees

| file | real Test before | after | native before | after |
| --- | --- | --- | --- | --- |
| `S32-exceptions/misc2.t` | 3 failures (#13, #14, #15) | **PASS** | PASS | PASS |

Part of the campaign in `todo/deep/vendor-real-test-module.md`.

## Verification

* `make test` green — 3529 files, 35302 tests.
* Targeted roast sweep over the EVAL/exception consumers (`S32-exceptions`, `S02-names`, `S02-lexical-conventions`, `S04-exception*`, `S06-*`, `S12-*`, `S24-testing`, `S29-context`, `S05-*`, `integration`) — **483 files, 13617 tests, PASS**.
* The roast file green under **both** providers.
* Pin `t/eval-mainline-placeholder.t` — 15 assertions covering the mainline cases, the `placeholder` attribute and message, the `X::Placeholder::Block` cases that must stay distinct, the positions where a placeholder is legal, and an ordinary undeclared variable that must still be `X::Undeclared` — **green under real `raku`** as well as mutsu.