### PR TITLE
fix(dispatch): a multi is a dispatcher even with nowhere to defer to

### DIFF
--- a/news/2026-08/nextsame-in-the-only-candidate.md
+++ b/news/2026-08/nextsame-in-the-only-candidate.md
@@ -1,0 +1,91 @@
+# A `multi` is a dispatcher even when it has nowhere to defer to
+
+`roast/S06-multi/redispatch.t` test 9 — "It's ok to call `nextsame` in the
+last/only candidate" — was one of the whitelisted files that regressed under
+`MUTSU_REAL_TEST=1`, the switch from mutsu's native Rust `Test` provider to the
+real vendored `modules/Rakudo-Core/lib/Test.rakumod`. It failed with
+
+```
+nextsame is not in the dynamic scope of a dispatcher
+```
+
+## The real root cause
+
+mutsu's dispatcher stacks were built on the premise that a dispatch frame is
+worth pushing only when there is a *next* candidate to defer to. Both places
+that push a multi-dispatch frame encoded that premise:
+
+* `Interpreter::push_multi_dispatch_frame` (`src/runtime/accessors_state.rs`)
+  bailed out with `if all_candidates.len() <= 1 { return false }`, and then
+  pushed nothing more when the winner filter left `remaining` empty.
+* `Interpreter::call_function_fallback`
+  (`src/runtime/builtins_operators_fallback.rs`) carries an inlined copy of the
+  same logic, gated on `!remaining.is_empty()`.
+
+Rakudo draws the line somewhere else. Being a `multi` is what establishes a
+dispatcher; having somewhere to defer to is a separate question, answered
+afterwards with `Nil`. Measured against rakudo, all four verbs — `nextsame`,
+`callsame`, `nextwith`, `callwith` — are legal in the last (or only) candidate
+and evaluate to `Nil`; `lastcall` is a live no-op there and `nextcallee` yields
+`Nil`. `X::NoDispatcher` is reserved for code that is not in a dispatcher's
+dynamic scope at all: a plain (non-`multi`) `sub`, or the mainline.
+
+Because no frame was pushed, `dispatch_next_candidate` fell past the wrap,
+method and multi branches all the way to its final `Err(no_dispatcher_error)`.
+The multi branch itself already had the right answer — its
+`matched_idx == None` arm returns `Nil` — it just never ran.
+
+## Two gaps, not one
+
+The frame-push guard alone explains a `multi` called **by name**. The roast
+assertion also needs the second, independent gap: a routine invoked through a
+**Callable value** (`lives-ok &e`, `sub s(&c) { c() }`, `my &c = &e; c()`)
+resolves through `call_sub_value` -> `call_function` -> `call_function_fallback`,
+whose inlined copy of the guard was never updated. That path dropped the
+dispatcher for *every* multi, one candidate or many — a two-candidate multi
+called through an `&`-parameter lost its frame just the same. Fixing only one of
+the two left the assertion red.
+
+The fix makes both sites say the same thing: push the frame whenever the name
+has multi candidates at all (with an empty `remaining` when there is nothing to
+defer to), and push nothing when it has none, so a plain `sub` still throws.
+`push_multi_dispatch_frame` keeps a dedicated single-candidate fast path that
+skips the winner resolution and the rw-param capture — with one candidate there
+is nothing to filter out and no rw value to chain forward.
+
+## What the assertion's wording described
+
+Nothing that mattered. "It's ok to call `nextsame` in the last/only candidate"
+is a true statement about the spec, but "last" was never the trigger: `nextsame`
+in the *last of two* candidates already worked, because two candidates meant a
+frame got pushed. The two things that actually broke it were "only" (one
+candidate, hence no frame) and, invisible in the assertion's text, "called
+through a Callable value" — which is simply how the real `Test.rakumod`'s
+`lives-ok` invokes the code it is handed (`try { $code(); 1 }`). That is the
+recurring shape of this campaign's residue: the failing assertion names a
+feature, and the bug is in the plumbing the real module happens to use to reach
+it.
+
+## Result
+
+| file | real Test before | real Test after | native before | native after |
+| --- | --- | --- | --- | --- |
+| `roast/S06-multi/redispatch.t` | 1 failure (#9) | **PASS** | PASS | PASS |
+| `roast/S06-multi/subsignature.t` | 1 failure (#66) | **PASS** | PASS | PASS |
+
+`subsignature.t` carries the identical assertion at test 66. Its remaining
+`not ok` lines (4 and 43) are `# TODO`-marked expected failures both before and
+after, and are unrelated to this change.
+
+Pin: `t/nextsame-in-the-only-candidate.t` (37 assertions, green under real
+`raku` as well as mutsu) — the four verbs, every call position through an
+`&`-parameter (tail, sink, assigned, `try {}`, `try` expression, bare block,
+`do` block, nested anonymous sub), the by-name control, `&`-variable and scalar
+invocation, live redispatch in a multi-candidate multi, single-candidate and
+inherited methods, and the `X::NoDispatcher` cases that must still throw.
+
+One neighbouring bug found in the same area was deliberately **not** folded in,
+because it has a different root cause (argument matching, not the dispatcher
+stacks): an anonymous `Any` parameter never matches, so `multi f(Any)` is dead
+code. Filed as
+`todo/tickets/anonymous-any-parameter-never-matches-in-multi-dispatch.md`.

--- a/src/runtime/accessors_state.rs
+++ b/src/runtime/accessors_state.rs
@@ -1212,8 +1212,31 @@ impl Interpreter {
         // needed because callwith() can re-dispatch with different args, so
         // candidates that don't match the original args may match the new ones.
         let all_candidates = self.resolve_all_multi_candidates(name);
-        if all_candidates.len() <= 1 {
+        // A name with no multi candidates at all is a plain sub: it establishes
+        // no dispatcher, so `nextsame` from its body correctly dies with
+        // X::NoDispatcher (`roast/S06-multi/redispatch.t` test 10).
+        if all_candidates.is_empty() {
             return false;
+        }
+        // A `multi` with a SINGLE candidate is still a dispatcher — it merely
+        // has no NEXT candidate. Rakudo makes `nextsame`/`callsame`/`nextwith`/
+        // `callwith` in the last (or only) candidate legal and Nil-valued, so
+        // the frame must exist with an empty `remaining`; without it
+        // `dispatch_next_candidate` fell all the way through to "nextsame is
+        // not in the dynamic scope of a dispatcher" (roast test 9, "It's ok to
+        // call nextsame in the last/only candidate"). Skip the winner
+        // resolution below: with one candidate there is nothing to filter out
+        // and no rw value to chain forward.
+        if all_candidates.len() == 1 {
+            let dispatch_token = self.next_dispatch_token();
+            self.multi_dispatch_stack.push((
+                name.to_string(),
+                Vec::new(),
+                args.to_vec(),
+                Vec::new(),
+                dispatch_token,
+            ));
+            return true;
         }
         // Identify the candidate currently being called by the DETERMINISTIC
         // dispatch winner (the same resolver the interpreter's inline frame uses),
@@ -1240,26 +1263,25 @@ impl Interpreter {
                 Some(fp) != current_fp
             })
             .collect();
-        let pushed = !remaining.is_empty();
-        if pushed {
-            // Capture the FIRST (winning) candidate's scalar rw params so a
-            // nextsame+rw redispatch can chain the rw value through it (§D).
-            let rw_params = current_def
-                .as_ref()
-                .map(|def| {
-                    super::builtins_dispatch_next::rw_scalar_positional_params(&def.param_defs)
-                })
-                .unwrap_or_default();
-            let dispatch_token = self.next_dispatch_token();
-            self.multi_dispatch_stack.push((
-                name.to_string(),
-                remaining,
-                args.to_vec(),
-                rw_params,
-                dispatch_token,
-            ));
-        }
-        pushed
+        // Capture the FIRST (winning) candidate's scalar rw params so a
+        // nextsame+rw redispatch can chain the rw value through it (§D).
+        let rw_params = current_def
+            .as_ref()
+            .map(|def| super::builtins_dispatch_next::rw_scalar_positional_params(&def.param_defs))
+            .unwrap_or_default();
+        let dispatch_token = self.next_dispatch_token();
+        // Push unconditionally, even when the winner filter left `remaining`
+        // empty (every candidate shares the winner's body fingerprint): being a
+        // multi is what makes this a dispatcher, not having somewhere to defer
+        // to. An empty frame is exactly the "no next candidate -> Nil" case.
+        self.multi_dispatch_stack.push((
+            name.to_string(),
+            remaining,
+            args.to_vec(),
+            rw_params,
+            dispatch_token,
+        ));
+        true
     }
 
     /// Pop a multi dispatch frame (must only be called if push returned true).

--- a/src/runtime/builtins_operators_fallback.rs
+++ b/src/runtime/builtins_operators_fallback.rs
@@ -474,6 +474,17 @@ impl Interpreter {
             // Use all multi candidates (not just matching ones) because callwith()
             // can re-dispatch with different arguments.
             let all_candidates = self.resolve_all_multi_candidates(name);
+            // Being a `multi` at all is what establishes a dispatcher, not
+            // having somewhere to defer to: `nextsame`/`callsame` in the LAST
+            // (or only) candidate is legal in rakudo and evaluates to Nil.
+            // Push the frame whenever this name has multi candidates, even
+            // when the winner filter leaves `remaining` empty — otherwise
+            // `dispatch_next_candidate` falls through to "not in the dynamic
+            // scope of a dispatcher". A plain sub (no multi candidates) still
+            // pushes nothing, so its `nextsame` correctly dies. Mirrors the
+            // same rule in `push_multi_dispatch_frame`; this call path is the
+            // one a Callable *value* (`&e`, `my &c = &e; c()`) takes.
+            let pushed_dispatch = !all_candidates.is_empty();
             let def_fp = def.body_fingerprint();
             let remaining: Vec<std::sync::Arc<FunctionDef>> = all_candidates
                 .into_iter()
@@ -482,7 +493,6 @@ impl Interpreter {
                 // candidate is always recognized and excluded.
                 .filter(|c| c.body_fingerprint() != def_fp)
                 .collect();
-            let pushed_dispatch = !remaining.is_empty();
             if pushed_dispatch {
                 let rw_params =
                     super::builtins_dispatch_next::rw_scalar_positional_params(&def.param_defs);

--- a/t/nextsame-in-the-only-candidate.t
+++ b/t/nextsame-in-the-only-candidate.t
@@ -1,0 +1,165 @@
+use v6;
+use Test;
+
+# A `multi` with a single candidate is still a dispatcher: it merely has no
+# NEXT candidate. `nextsame`/`callsame`/`nextwith`/`callwith` there are legal
+# and evaluate to Nil (they must NOT throw X::NoDispatcher). Only a routine
+# that is not a multi at all -- a plain `sub`, or the mainline -- throws.
+#
+# mutsu used to push a multi-dispatch frame only when there was something to
+# defer to, so a single-candidate multi established no dispatcher at all and
+# every one of the four verbs died with
+# "nextsame is not in the dynamic scope of a dispatcher".
+# The Callable-value call path (`&e`, `my &c = &e; c()`) had the same gap for
+# EVERY multi, one candidate or many, because it duplicated that guard.
+
+plan 37;
+
+# ---------------------------------------------------------------- the verbs
+
+multi v-nextsame() { nextsame }
+multi v-callsame() { callsame }
+multi v-nextwith() { nextwith() }
+multi v-callwith() { callwith() }
+
+is v-nextsame().raku, 'Nil', 'nextsame in the only candidate returns Nil';
+is v-callsame().raku, 'Nil', 'callsame in the only candidate returns Nil';
+is v-nextwith().raku, 'Nil', 'nextwith in the only candidate returns Nil';
+is v-callwith().raku, 'Nil', 'callwith in the only candidate returns Nil';
+
+lives-ok { v-nextsame() }, 'nextsame in the only candidate lives';
+lives-ok { v-callsame() }, 'callsame in the only candidate lives';
+lives-ok { v-nextwith() }, 'nextwith in the only candidate lives';
+lives-ok { v-callwith() }, 'callwith in the only candidate lives';
+
+# ----------------------------------------------- every call position, by value
+
+multi solo() { nextsame }
+
+sub w-tail(&c)     { c() }
+sub w-sink(&c)     { c(); 'lived' }
+sub w-assign(&c)   { my $r = c(); 'lived' }
+sub w-try-block(&c) { my $ok = try { c(); 1 }; $ok ?? 'lived' !! 'died' }
+sub w-try-expr(&c) { try c(); 'lived' }
+sub w-bare(&c)     { { c() }; 'lived' }
+sub w-do(&c)       { do { c() }; 'lived' }
+sub w-nested(&c)   { my $inner = sub { c() }; $inner(); 'lived' }
+
+is w-tail(&solo).raku, 'Nil',
+    'tail position: nextsame through an &-param yields Nil';
+is w-sink(&solo), 'lived',
+    'sink position: nextsame through an &-param does not throw';
+is w-assign(&solo), 'lived',
+    'assigned: nextsame through an &-param does not throw';
+is w-try-block(&solo), 'lived',
+    'inside try {}: nextsame through an &-param does not throw';
+is w-try-expr(&solo), 'lived',
+    'inside a try expression: nextsame through an &-param does not throw';
+is w-bare(&solo), 'lived',
+    'inside a bare block: nextsame through an &-param does not throw';
+is w-do(&solo), 'lived',
+    'inside a do block: nextsame through an &-param does not throw';
+is w-nested(&solo), 'lived',
+    'inside a nested anonymous sub: nextsame through an &-param does not throw';
+
+# The by-name control: same routine, no Callable value in the way.
+sub w-by-name() { solo(); 'lived' }
+is w-by-name(), 'lived', 'by-name control: calling the multi directly lives';
+is solo().raku, 'Nil', 'by-name control: the only candidate yields Nil';
+
+# Bound to a scalar/`&` variable and invoked from there.
+my &bound = &solo;
+is bound().raku, 'Nil', 'invoking the multi through a bound & variable yields Nil';
+my $stored = &solo;
+is $stored().raku, 'Nil', 'invoking the multi through a scalar yields Nil';
+
+# ------------------------------------------- redispatch still actually happens
+
+multi chain(Int $x) { 'int(' ~ (callsame() // 'Nil') ~ ')' }
+multi chain(Cool $x) { 'cool' }
+is chain(1), 'int(cool)', 'callsame still redispatches to the next candidate';
+
+multi chain2(Int $x) { 'int(' ~ (nextsame() // 'Nil') ~ ')' }
+multi chain2(Cool $x) { 'cool' }
+is chain2(1), 'cool', 'nextsame still tail-calls the next candidate';
+
+multi chainw(Int $x) { 'int(' ~ (callwith('s') // 'Nil') ~ ')' }
+multi chainw(Cool $x) { 'cool:' ~ $x }
+is chainw(1), 'int(cool:s)', 'callwith still redispatches with new args';
+
+# The LAST of several candidates has no next one either.
+multi last-of-two(Int $x) { 'int' }
+multi last-of-two(Str $x) { nextsame }
+is last-of-two('s').raku, 'Nil', 'nextsame in the last of two candidates yields Nil';
+is last-of-two(1), 'int', 'the other candidate of that multi still dispatches';
+
+# Through a Callable value, with several candidates.
+sub apply(&c, $arg) { my $r = c($arg); 'lived' }
+is apply(&last-of-two, 'x'), 'lived',
+    'a multi-candidate multi called through an &-param does not throw either';
+
+# --------------------------------------------------------------------- methods
+
+class OnlyMulti {
+    multi method solo() { callsame }
+}
+is OnlyMulti.solo.raku, 'Nil', 'callsame in a single-candidate multi method yields Nil';
+lives-ok { OnlyMulti.solo }, 'callsame in a single-candidate multi method lives';
+
+class PlainOnly {
+    method solo() { nextsame }
+}
+is PlainOnly.solo.raku, 'Nil', 'nextsame in a method with no parent method yields Nil';
+
+class Base { method greet() { 'base' } }
+class Derived is Base { method greet() { 'derived-' ~ callsame() } }
+is Derived.greet, 'derived-base', 'callsame in a method still walks the MRO';
+
+class MethodValue {
+    multi method solo() { nextsame }
+}
+my $mv = MethodValue.new;
+is $mv.solo.raku, 'Nil', 'a single-candidate multi method on an instance yields Nil';
+
+# ------------------------------------- a plain sub / the mainline still throws
+
+# NB: these deliberately use a mainline `try` rather than `dies-ok`/`throws-like`.
+# `nextsame` looks for a dispatcher in the *dynamic* scope, and the Test routine
+# that would invoke the block is itself dispatch-y, so wrapping them in a Test
+# routine changes what they find (verified against rakudo). The roast file
+# `S06-multi/redispatch.t` states the mainline case the same way.
+sub plain-sub() { nextsame }
+{
+    try { plain-sub() };
+    isa-ok $!, X::NoDispatcher,
+        'nextsame in a plain (non-multi) sub throws X::NoDispatcher';
+}
+
+sub plain-sub-cs() { callsame }
+{
+    try { plain-sub-cs() };
+    isa-ok $!, X::NoDispatcher,
+        'callsame in a plain (non-multi) sub throws X::NoDispatcher';
+}
+
+sub plain-through-value(&c) { c(); 'lived' }
+{
+    try { plain-through-value(&plain-sub) };
+    isa-ok $!, X::NoDispatcher,
+        'a plain sub called through an &-param throws X::NoDispatcher';
+}
+
+{
+    try { nextsame };
+    isa-ok $!, X::NoDispatcher, 'nextsame in the mainline throws X::NoDispatcher';
+}
+
+# ------------------------------------------------ lastcall / nextcallee shapes
+
+multi solo-lastcall() { lastcall; 'after' }
+is solo-lastcall(), 'after', 'lastcall in the only candidate is a no-op that lives';
+
+multi solo-nextcallee() { (nextcallee() // 'Nil').raku }
+is solo-nextcallee(), '"Nil"', 'nextcallee in the only candidate yields Nil';
+
+# done

--- a/todo/deep/vendor-real-test-module.md
+++ b/todo/deep/vendor-real-test-module.md
@@ -4454,8 +4454,8 @@ they are.
 | `S05-metachars/closure.t` | One matched | |
 | `S05-modifier/pos.t` | Insensitive repeated continued match pos | |
 | `S05-modifier/repetition-exhaustive.t` | Second entry of prev. generated `$/` | |
-| `S06-multi/redispatch.t` | It's ok to call nextsame in the last/only candidate | in flight |
-| `S06-multi/subsignature.t` | It's ok to call nextsame in the last/only candidate (test 66) | **same cause as the row above** |
+| `S06-multi/redispatch.t` | It's ok to call nextsame in the last/only candidate | **CLOSED** — see the section below |
+| `S06-multi/subsignature.t` | It's ok to call nextsame in the last/only candidate (test 66) | **CLOSED** — same cause as the row above |
 | `S06-operator-overloading/sub.t` | ... basic infix operator overloading worked | |
 | `S06-other/main.t` | MAIN in a module did not get executed | |
 | `S12-class/attributes.t` | HOW on attributes lives, custom class | `No such method 'x' for invocant of type 'A'` |
@@ -4496,3 +4496,74 @@ file's "step 3 needs the call path as well" note. The short version: the `sprint
 **`&`-sigil parameter**. `sub f(&c) { 1 }` called `f(&c)` costs 4.32 µs/iter and re-resolves the
 callee by name on every call; `sub f($c) { 1 }` with an identical callsite, body and arity costs
 0.64 µs and resolves once. Every real-`Test` assertion is the former shape.
+
+## 2026-08-29: a `multi` is a dispatcher even with nowhere to defer to (`S06-multi/redispatch.t`, `S06-multi/subsignature.t`)
+
+`roast/S06-multi/redispatch.t` test 9 ("It's ok to call `nextsame` in the
+last/only candidate") failed under `MUTSU_REAL_TEST=1` with "nextsame is not in
+the dynamic scope of a dispatcher".
+
+Two independent gaps, both needed:
+
+1. `push_multi_dispatch_frame` (`src/runtime/accessors_state.rs`) pushed no
+   frame at all when a multi had a single candidate (`all_candidates.len() <= 1`)
+   or when the winner filter emptied `remaining`. Rakudo makes being a `multi`
+   the thing that establishes a dispatcher; "no next candidate" is answered
+   afterwards with `Nil`, not with `X::NoDispatcher`. All four verbs
+   (`nextsame`/`callsame`/`nextwith`/`callwith`) plus `lastcall`/`nextcallee`
+   were re-derived against rakudo.
+2. `call_function_fallback` (`src/runtime/builtins_operators_fallback.rs`)
+   carries an inlined *copy* of that guard, and it is the path a routine invoked
+   through a **Callable value** takes (`call_sub_value` -> `call_function` ->
+   here). That copy dropped the dispatcher for EVERY multi, one candidate or
+   many — so a two-candidate multi called through an `&`-parameter lost its
+   frame too. Fixing only (1) left the assertion red.
+
+Both sites now push whenever the name has multi candidates at all (empty
+`remaining` when there is nothing to defer to) and push nothing when it has
+none, so a plain `sub` still throws.
+
+### Per-file before/after (release build, `scripts/run-roast-test.sh`, both providers)
+
+| file | real Test before | real Test after | native before | native after |
+| --- | --- | --- | --- | --- |
+| `roast/S06-multi/redispatch.t` | 1 failure (#9) | **PASS** | PASS | PASS |
+| `roast/S06-multi/subsignature.t` | 1 failure (#66) | **PASS** | PASS | PASS |
+
+`roast/S06-multi/subsignature.t` carries the identical assertion at test 66 and
+was the second whitelisted file the switch regressed. Its other two `not ok`
+lines (4 "variable was modified", 43 "[+] overloaded by proto definition") are
+`# TODO`-marked expected failures before and after, under both providers, and
+are unrelated to this change.
+
+Per the counting note above, this closes **two** named files
+(`S06-multi/redispatch.t` and `S06-multi/subsignature.t`); re-measure the sweep
+rather than trusting a running total.
+
+Pin: `t/nextsame-in-the-only-candidate.t` (37 assertions, green under real
+`raku` as well as mutsu). Full write-up:
+`news/2026-08/nextsame-in-the-only-candidate.md`.
+
+### The assertion's wording described neither the trigger nor the fix
+
+"It's ok to call `nextsame` in the last/only candidate" is a true statement
+about the spec, but "last" was never the trigger — `nextsame` in the *last of
+two* candidates already worked, because two candidates meant a frame got pushed.
+What actually broke it was "only" (one candidate, hence no frame) plus a second
+thing the wording does not mention at all: the code was reached through a
+Callable value, because the real `Test.rakumod`'s `lives-ok` invokes what it is
+handed as `try { $code(); 1 }`. That misdirection is the recurring shape of this
+campaign's residue: the assertion names a language feature, and the bug is in
+the plumbing the real module happens to use to reach it.
+
+### One neighbour split off rather than folded in
+
+An anonymous `Any` parameter never matches, so `multi f(Any)` is dead code and
+an `Any` fallback candidate silently disappears (`multi w(Int) { callsame }` /
+`multi w(Any) { "any" }` yields `Nil` instead of `"any"`). Different root cause
+— argument matching, not the dispatcher stacks: `args_match_param_types` treats
+the parser's `__type_only__` placeholder as a bare *term* to resolve from the
+env, and `Any` is the one type name that has an env entry (a `Value::NIL`
+sentinel installed by `runtime_init.rs`). No roast file in the current residue
+gates it. Filed as
+`todo/tickets/anonymous-any-parameter-never-matches-in-multi-dispatch.md`.

--- a/todo/tickets/anonymous-any-parameter-never-matches-in-multi-dispatch.md
+++ b/todo/tickets/anonymous-any-parameter-never-matches-in-multi-dispatch.md
@@ -1,0 +1,102 @@
+# An anonymous `Any` parameter never matches, so `multi f(Any)` is dead code
+
+Found while fixing `nextsame` in a single-candidate multi
+(`news/2026-08/nextsame-in-the-only-candidate.md`). It is a **separate root
+cause** — it lives in argument matching, not in the dispatcher stacks — so it
+was deliberately not folded into that slice.
+
+## Symptom
+
+A multi candidate declared with an **anonymous** (type-only, no variable name)
+`Any` parameter never matches any argument at all:
+
+```raku
+multi a(Any) { "A" }
+say a(42);     # raku: A          mutsu: Cannot resolve caller a(Int:D) ...
+say a("s");    # raku: A          mutsu: Cannot resolve caller a(Str:D) ...
+```
+
+Every other type works — only `Any` is affected:
+
+```raku
+multi b(Cool) { "C" }; say b(42);    # both: C
+multi c(Str)  { "S" }; say c("s");   # both: S
+multi d(Mu)   { "M" }; say d(42);    # both: M
+```
+
+The user-visible consequence is that the idiomatic `Any` fallback candidate
+silently disappears, which shows up most often as a *redispatch* that goes
+nowhere:
+
+```raku
+multi w(Int) { "int:" ~ callsame() }
+multi w(Any) { "any" }
+say w(1);        # raku: int:any     mutsu: "Use of Nil in string context", int:
+```
+
+Naming the parameter (`multi w(Any $x)`) hides the bug entirely, which is why
+this reads at first like an "anonymous parameters do not redispatch" problem.
+It is not: anonymity only matters because it selects the code path below.
+
+## Root cause
+
+The parser gives an anonymous type-only parameter the placeholder name
+`__type_only__` (`src/parser/stmt/sub_param/param_inner.rs`). In
+`src/runtime/types/args_matching.rs` (`args_match_param_types`, the
+`pd.name == "__type_only__"` arm, ~line 348) that name is taken to mean "a bare
+identifier term — e.g. an enum value — so resolve it from the environment and
+compare the argument against it":
+
+```rust
+} else if pd.name == "__type_only__" {
+    // Bare identifier param (e.g., enum value) -- resolve from env and compare
+    if let Some(expected_val) = self.env.get(&resolved_constraint).cloned() {
+        if dispatch_arg != expected_val {
+            return false;
+        }
+    } else if !self.type_matches_value(&resolved_constraint, &dispatch_arg) {
+        return false;
+    }
+}
+```
+
+`Any` is the one type name that *is* present in the environment:
+`src/runtime/runtime_init.rs` (~line 3117) installs a sentinel
+`interpreter.env.insert("Any".to_string(), Value::NIL)`. So the env branch wins,
+the argument is compared against `Nil`, and every non-`Nil` argument is
+rejected. `Cool`/`Str`/`Mu` have no such env entry, fall to
+`type_matches_value`, and behave correctly.
+
+## Suggested fix
+
+Only take the env-term comparison when the constraint is *not* a resolvable type
+name. `Interpreter::is_resolvable_type` (`src/runtime/types/type_registry.rs`,
+~line 838) exists for exactly this discrimination and is already used for
+`__type_only__` params in `src/runtime/types/binding_signature.rs:225`:
+
+```rust
+} else if pd.name == "__type_only__" && !self.is_resolvable_type(&resolved_constraint) {
+    // ... env-term comparison ...
+} else if ... /* fall through to the ordinary type check */
+```
+
+The bug is one condition wide, but the blast radius is not: this arm is on the
+hot multi-dispatch path and is what makes anonymous *enum-value* parameters
+(`multi f(Less) {...}`) dispatch, so the change wants its own targeted roast
+sweep over `S06-*`, `S12-*` and the enum tests, plus
+`scripts/battery-testsuite.sh`.
+
+## Repro
+
+`raku` and `mutsu` disagree on all three lines:
+
+```raku
+multi a(Any) { "A" }
+say (try { a(42) }) // "NOMATCH";      # raku: A     mutsu: NOMATCH
+multi w(Int) { "int:" ~ (callsame() // "Nil") }
+multi w(Any) { "any" }
+say w(1);                               # raku: int:any   mutsu: int:Nil
+```
+
+No roast file in the current `MUTSU_REAL_TEST=1` residue gates this, which is
+why it is filed rather than fixed.


### PR DESCRIPTION
## The bug

`nextsame` / `callsame` / `nextwith` / `callwith` died with

```
nextsame is not in the dynamic scope of a dispatcher
```

in a `multi` that had no NEXT candidate, and in **any** `multi` reached through a
Callable value. Measured against rakudo, all four are legal there and evaluate to
`Nil` (`lastcall` is a live no-op, `nextcallee` yields `Nil`); `X::NoDispatcher`
is reserved for code that is not in a dispatcher's dynamic scope at all — a plain
`sub`, or the mainline.

## Root cause: two sites, one wrong premise

Both places that push a multi-dispatch frame encoded "a dispatch frame is only
worth pushing when there is something to defer to". Rakudo draws the line
elsewhere: being a `multi` is what establishes a dispatcher; "is there a next
candidate?" is a separate question, answered afterwards with `Nil`.

1. **`push_multi_dispatch_frame`** (`src/runtime/accessors_state.rs`) bailed out
   on `all_candidates.len() <= 1`, and pushed nothing further when the winner
   filter left `remaining` empty. A single-candidate multi therefore established
   no dispatcher at all, and `dispatch_next_candidate` fell past its wrap /
   method / multi branches to the final `Err(no_dispatcher_error)` — even though
   the multi branch's own `matched_idx == None` arm already returns `Nil`.
2. **`call_function_fallback`** (`src/runtime/builtins_operators_fallback.rs`)
   carries an inlined *copy* of that guard, and it is the path a routine invoked
   through a **Callable value** takes (`call_sub_value` → `call_function` →
   here). That copy dropped the dispatcher for *every* multi, one candidate or
   many — a two-candidate multi called through an `&`-parameter lost its frame
   just the same. Fixing only (1) left the roast assertion red.

Both sites now push whenever the name has multi candidates at all (with an empty
`remaining` when there is nothing to defer to), and push nothing when it has
none, so a plain `sub` still throws. `push_multi_dispatch_frame` keeps a
single-candidate fast path that skips the winner resolution and the rw-param
capture — neither has anything to do with one candidate.

## Roast files freed

Under `MUTSU_REAL_TEST=1` (the real vendored `Test.rakumod`, whose `lives-ok`
invokes what it is handed as `try { $code(); 1 }` — a Callable-value call):

| file | real Test before | real Test after | native before | native after |
| --- | --- | --- | --- | --- |
| `roast/S06-multi/redispatch.t` | 1 failure (#9) | **PASS** | PASS | PASS |
| `roast/S06-multi/subsignature.t` | 1 failure (#66) | **PASS** | PASS | PASS |

`subsignature.t`'s remaining `not ok` 4 and 43 are `# TODO`-marked expected
failures before and after, under both providers.

The failing assertion's wording — "It's ok to call `nextsame` in the last/only
candidate" — described neither the trigger nor the fix. `nextsame` in the *last
of two* candidates already worked (two candidates meant a frame got pushed).
What broke it was "only" plus a second thing the wording does not mention at
all: the code was reached through a Callable value.

## Tests

Pin: `t/nextsame-in-the-only-candidate.t`, 37 assertions, **green under real
`raku` as well as mutsu** — the four verbs, every call position through an
`&`-parameter (tail, sink, assigned, `try {}`, `try` expression, bare block, `do`
block, nested anonymous sub), the by-name control, `&`-variable and scalar
invocation, live redispatch in a multi-candidate multi, single-candidate and
inherited methods, and the `X::NoDispatcher` cases that must still throw.

## Verification

- `make test` **PASS** — 3531 files, 35365 tests.
- Targeted native-provider roast sweep, **589 files** across `S06-*`, `S12-*`,
  `S14-roles`, `S02-types`, `S04-*`, `S17-*` and `integration`: **PASS**
  (18325 tests).
- Both roast files above green on a **release** build under **both** providers.
- `scripts/battery-testsuite.sh` on a release build: **GATE PASSED**
  (273/297 files, unchanged).
- `cargo fmt --check` clean; `cargo clippy -- -D warnings` clean.

## Filed, not folded in

A neighbouring bug with a different root cause (argument matching, not the
dispatcher stacks): an anonymous `Any` parameter never matches, so `multi f(Any)`
is dead code and an `Any` fallback candidate silently disappears.
`args_match_param_types` treats the parser's `__type_only__` placeholder as a
bare *term* to resolve from the env, and `Any` is the one type name that has an
env entry (a `Value::NIL` sentinel installed by `runtime_init.rs`). No roast file
in the current residue gates it →
`todo/tickets/anonymous-any-parameter-never-matches-in-multi-dispatch.md`.
