### PR TITLE
fix(types): resolve a package-scoped type's short name without env

### DIFF
--- a/news/2026-08/package-type-short-name-vs-same-named-lexical.md
+++ b/news/2026-08/package-type-short-name-vs-same-named-lexical.md
@@ -1,0 +1,93 @@
+# A same-named lexical no longer shadows its own package-scoped class
+
+`roast/S12-construction/autopairs.t` passed under the native `Test` provider and
+failed under `MUTSU_REAL_TEST=1` with
+
+```
+# Error: Unknown method value dispatch (fallback disabled): new on Tb
+```
+
+The test's *name* is a red herring twice over: the failure has nothing to do
+with autopairs (`:$a`) and nothing to do with the space in `:$a )` that
+distinguishes the failing subtest from its passing sibling. It also has nothing
+to do with `Test`. What the real `Test.rakumod` changes is only *where the
+snippet runs*: `eval-lives-ok` routes through `eval_exception`, a sub of a
+separate compilation unit, so the `EVAL`'d `class Tb { … }` is compiled while a
+module's routine is on the stack and is therefore registered under **that
+module's package**. Rakudo agrees with that placement (`Test::Tb`); what mutsu
+got wrong was every subsequent reference to the short name.
+
+## Root cause: `env` is the only bridge from a short type name to its package
+
+A type declared inside a package is registered under its qualified name only
+(`M::C`). mutsu made the short name `C` work by relying on an `env` alias — but
+`env` stores a `$`-sigiled scalar under its **sigil-stripped** key, so `C` and
+`$C` are the same env slot. A `my C $C` declaration therefore *overwrote the very
+alias* that made its own type name resolvable, and every short-name reference
+afterwards degraded to a bare, never-registered `C` type object with no methods.
+`my C $C .= new(...)` is the fused form, which calls `.new` on the **bareword**,
+so it died on exactly that dead object.
+
+Reduced, with no `Test` anywhere (`EvHelper` is any module with a sub that
+`EVAL`s its argument):
+
+```raku
+eval-in-module 'class N1 { has $.a }; my N1 $N1 .= new(:a(1))'   # died
+eval-in-module 'class N2 { has $.a }; my N2 $z  .= new(:a(2))'   # lived
+```
+
+Three distinct sites all resolved the short name through `env`, and all three had
+to grow the same registry fallback:
+
+1. **The declaration seed.** `nominal_type_object_name_for_constraint` returned
+   the constraint's short spelling once the `env` alias was gone, so even the
+   *other-named* control stored a dead `Package("C")` — `my C $z; $z.^name` said
+   `C` where rakudo says `M::C`. It now falls back to `package_type_alias` and
+   the running package's chain.
+2. **The block-entry hoist.** `hoist_typed_var_decls` emits a `SetVarType` for
+   every top-level `my TYPE $x` *before* the `class` statements of the same
+   block, so it seeded from a constraint that was not resolvable yet and the
+   later, real declaration saw a non-`Nil` value and left the dead seed in place.
+   `exec_set_var_type` now treats such a value as uninitialised: a `Package`
+   naming a type that exists nowhere is never a legitimate value (no assignment
+   can produce one), and re-seeding an already-correct value is a no-op because
+   the seed is a pure function of the constraint. Deleting the hoist's seeding
+   instead was tried and rejected — it is load-bearing for `my Int $Int`, whose
+   `env` slot would otherwise keep the `Package(Any)` declaration placeholder.
+3. **The bareword read.** `GetBareWord`'s three "this name is a type" branches
+   spelled the resolution as `package_type_alias(name)` *or the name itself*,
+   which cannot reach a package-scoped registration; and its `Package(Any)`
+   placeholder guard — the rule that a not-yet-assigned `my $Buf` must not shadow
+   `Buf` — tested only `has_type_direct`, so a lexical `class` inside a routine
+   (registered under an ADR-0047-mangled qualified key) still lost to the
+   placeholder and `my C $C .= new` built an `Any` instance whose `.raku` read
+   `Any.new`. Both now go through one `resolve_bareword_type_name` probe that is
+   deliberately blind to `env[name]` — that key is the contested one — and
+   consults the registry, import aliases, and the running package's chain.
+
+## Measured against rakudo
+
+| snippet, run from a module sub's `EVAL` | rakudo | mutsu before | mutsu after |
+| --- | --- | --- | --- |
+| `class C { has $.a }; my C $C .= new(:a(1))` | lives | **dies** | lives |
+| `class C { has $.a }; my C $z; $z.^name` | `M::C` | `C` | `M::C` |
+| `class C { has $.a }; my C $C; C.^name` | `M::C` | `C` (0 methods) | `M::C` |
+| `my Int $Int; $Int.^name` | `Int` | `Int` | `Int` |
+
+and, in a module's own routine (no `EVAL` at all), `class C { … }; my C $C .= new(:a(7))`
+went from dying to producing a real `M::C` whose `.^name`, `.WHAT` and `.raku`
+all agree with rakudo.
+
+## Result
+
+`roast/S12-construction/autopairs.t` now passes under **both** providers
+(4/4 native, 4/4 `MUTSU_REAL_TEST=1`), taking the real-`Test` regression list
+down by one. Pinned by `t/package-type-short-name-vs-same-named-lexical.t`
+(35 assertions, green under real `raku` too): the same-named typed declaration
+at mainline, in a plain sub, in a module sub, and inside an `EVAL` from each of
+those, plus the other-name / untyped / nested-block / builtin controls.
+
+A second, unrelated divergence noticed in the same file — a punned-role
+instance's `.raku` dropping its attributes (`Tc.new` vs `Tc.new(a => Any)`) —
+gates nothing there and is filed as
+`todo/tickets/punned-role-raku-drops-undefined-attributes.md`.

--- a/src/runtime/types/mod.rs
+++ b/src/runtime/types/mod.rs
@@ -701,6 +701,27 @@ impl Interpreter {
                 return self.nominal_type_object_name_for_constraint(&resolved);
             }
         }
+        // A short type name declared INSIDE a package (`module M { class C {…} }`,
+        // and anything an `EVAL` compiles while a module's sub is on the stack) is
+        // registered under its QUALIFIED name only. The short name normally works
+        // because `env` carries an alias to the qualified one — but that alias
+        // lives under the sigil-stripped key `C`, which a same-named `$`-sigiled
+        // lexical (`my C $C`) overwrites, and inside an `EVAL`'d unit it is absent
+        // altogether. Fall back to the type registry, exactly as `GetBareWord`
+        // does, so an uninitialised `my C $x` holds the real `M::C` type object
+        // instead of a bare, never-registered `C` with no methods (on which
+        // `.new` then fails). Builtin and already-registered names keep their
+        // spelling, so a core type is never re-anchored onto a package.
+        if !base_name.contains("::")
+            && !self.has_type_direct(&base_name)
+            && !Self::is_builtin_type(&base_name)
+            && let Some(qualified) = self
+                .package_type_alias(&base_name)
+                .or_else(|| self.resolve_type_in_current_package(&base_name))
+            && qualified != base_name
+        {
+            return self.nominal_type_object_name_for_constraint(&qualified);
+        }
         if let Some(subset) = self.registry().subsets.get(&base_name) {
             if language_version_is_6e_or_newer(&subset.version) {
                 // In v6.e, the default for a subset variable is the base type's

--- a/src/runtime/types/type_registry.rs
+++ b/src/runtime/types/type_registry.rs
@@ -503,6 +503,28 @@ impl Interpreter {
             })
     }
 
+    /// Whether a type object *named exactly* `name` exists: a builtin, a native
+    /// type, or something the registry holds under that key (directly or through
+    /// an `env`/import alias). Deliberately NOT package-chain resolution
+    /// (`resolve_type_in_current_package`): that answers "does this REFERENCE
+    /// resolve", which is true for the short name `C` of an `M::C` — while the
+    /// question here is whether the *stored identity* `C` is a real type object.
+    ///
+    /// A `Package` value failing this is a DEAD type object: nothing can
+    /// dispatch on it, and no assignment can produce one, since every bareword
+    /// that yields a `Package` resolves through one of the tables above. It is
+    /// only ever produced by seeding a declaration from a constraint that was
+    /// not resolvable yet. See `exec_set_var_type`'s dead-seed re-seeding.
+    pub(crate) fn type_name_is_known(&self, name: &str) -> bool {
+        let (base, _) = crate::runtime::types::strip_type_smiley(name);
+        if base.is_empty() {
+            return false;
+        }
+        Interpreter::is_builtin_type(base)
+            || crate::runtime::native_types::is_native_array_element_type(base)
+            || self.has_type(base)
+    }
+
     /// Resolve `qualified` against the type registry, tolerating ADR-0047's
     /// unconditional lexical site-key mangling (`Foo\u{0}<decl-id>`). A caller
     /// that RECONSTRUCTS a qualified name from a package/short-name pair

--- a/src/vm/vm_var_get_ops.rs
+++ b/src/vm/vm_var_get_ops.rs
@@ -1,6 +1,38 @@
 use super::*;
 
 impl Interpreter {
+    /// The name of the type object a bareword that `has_type`/`is_builtin_type`
+    /// already accepted must resolve to.
+    ///
+    /// A short name is only its own type object when something is registered
+    /// under exactly that name (or it is a builtin). Otherwise the name is a
+    /// REFERENCE that has to be resolved: through the declaring module's import
+    /// aliases (`package_type_alias`), and — the case this exists for — through
+    /// the running package's chain, because a type declared inside a package
+    /// (`module M { class C {…} }`, and anything an `EVAL` compiles while a
+    /// module's sub is on the stack) is registered ONLY as `M::C`. `has_type`
+    /// accepts the short `C` there, so without this the bareword bound a bare,
+    /// never-registered `C` type object with no methods and `C.new` died with
+    /// "Unknown method ... new on C".
+    pub(super) fn type_object_name_for_bareword(&self, name: &str) -> String {
+        self.resolve_bareword_type_name(name)
+            .unwrap_or_else(|| Self::resolve_type_alias(name).to_string())
+    }
+
+    /// [`Self::type_object_name_for_bareword`] as a probe: `Some(qualified)`
+    /// when the bareword really does name a type, `None` when nothing accounts
+    /// for it. Deliberately never consults `env[name]` for the name itself —
+    /// that key is shared with a same-named `$`-sigiled lexical, and the whole
+    /// point of the callers is to decide whether such a lexical's value is
+    /// shadowing a type.
+    pub(super) fn resolve_bareword_type_name(&self, name: &str) -> Option<String> {
+        if self.has_type_direct(name) || Self::is_builtin_type(name) {
+            return Some(Self::resolve_type_alias(name).to_string());
+        }
+        self.package_type_alias(name)
+            .or_else(|| self.resolve_type_in_current_package(name))
+    }
+
     pub(super) fn exec_get_bare_word_op(
         &mut self,
         code: &CompiledCode,
@@ -143,12 +175,18 @@ impl Interpreter {
             // placeholder `Package(Any)` before its RHS runs (closure
             // capture-by-reference support in SetVarDynamic); the RHS bareword
             // still names the TYPE — without this it fell into the alias
-            // branch below and returned Any. `has_type_direct` (no alias
-            // resolution) is required here: the plain `has_type` treats the
-            // very placeholder as an import alias to Any and reports ANY name
-            // as a type (`my $x .= new` would resolve `x` to Package("x")).
+            // branch below and returned Any. The plain `has_type` must NOT be
+            // used here: it treats the very placeholder as an import alias to
+            // Any and reports ANY name as a type (`my $x .= new` would resolve
+            // `x` to Package("x")). `resolve_bareword_type_name` is the
+            // env-blind probe that avoids exactly that while still finding a
+            // type declared inside a package (`module M { class C {…} }`,
+            // including a lexical `class` in a routine, which is registered
+            // only under a qualified — possibly ADR-0047-mangled — key): with
+            // the plain `has_type_direct` alone, `my C $C .= new` resolved its
+            // own bareword to the placeholder and built an `Any` instance.
             Some(ValueView::Package(p)) if p == "Any" && name != "Any" => {
-                Self::is_builtin_type(name) || self.has_type_direct(name)
+                self.resolve_bareword_type_name(name).is_some()
             }
             _ => false,
         } {
@@ -158,10 +196,7 @@ impl Interpreter {
             // (Nil) it must NOT shadow the type — `$foo` and `foo` are distinct
             // symbols in Raku. This notably affects `my $foo = foo.new`, whose RHS
             // resolves `foo` before the `$foo` slot is assigned.
-            match self.package_type_alias(name) {
-                Some(qualified) => Value::package(Symbol::intern(&qualified)),
-                None => Value::package(Symbol::intern(Self::resolve_type_alias(name))),
-            }
+            Value::package(Symbol::intern(&self.type_object_name_for_bareword(name)))
         } else if let Some(v) = self.env().get(name) {
             if matches!(v.view(), ValueView::Enum { .. } | ValueView::Nil)
                 || matches!(v.view(), ValueView::Package(pkg) if pkg.resolve() != name)
@@ -195,7 +230,7 @@ impl Interpreter {
                 }
                 v.clone()
             } else if self.has_type(name) || Self::is_builtin_type(name) {
-                Value::package(Symbol::intern(Self::resolve_type_alias(name)))
+                Value::package(Symbol::intern(&self.type_object_name_for_bareword(name)))
             } else if name.contains("::")
                 && !name.starts_with('$')
                 && !name.starts_with('@')
@@ -245,10 +280,7 @@ impl Interpreter {
             // declaring module's own import aliases (`package_type_aliases`); such
             // a name must become the QUALIFIED type, since the short name is not
             // registered anywhere.
-            match self.package_type_alias(name) {
-                Some(qualified) => Value::package(Symbol::intern(&qualified)),
-                None => Value::package(Symbol::intern(Self::resolve_type_alias(name))),
-            }
+            Value::package(Symbol::intern(&self.type_object_name_for_bareword(name)))
         } else if let Some(qualified) = self.resolve_type_in_current_package(name) {
             // A short type name declared in the (dynamically) current package.
             // Checked BEFORE the built-in-type fallback so a module-local

--- a/src/vm/vm_var_type_ops.rs
+++ b/src/vm/vm_var_type_ops.rs
@@ -48,7 +48,26 @@ impl Interpreter {
                 self.env().get(&name).map(Value::view),
                 Some(ValueView::Nil) | None
             );
-            if is_nil {
+            // ... or the variable still holds a DEAD seed: a type object for a
+            // name nothing has registered. `hoist_typed_var_decls` emits a
+            // block-entry `SetVarType` for every top-level `my TYPE $x`, which
+            // runs BEFORE the `class`/`role` statements of the same block, so
+            // for a type declared inside a package (`module M { class C {…} }`,
+            // and anything an `EVAL` compiles while a module's sub is running)
+            // the constraint was not yet resolvable and the hoist seeded a bare,
+            // never-registered `C` with no methods. That value is not a
+            // legitimate one — no assignment can produce a type object for an
+            // unknown type — so the declaration itself re-seeds it now that the
+            // type exists. Without this the dead seed lives in `env` under the
+            // sigil-stripped key a bareword `C` also reads, so `my C $C .= new`
+            // (the fused form calls `.new` on the *bareword*) died with
+            // "Unknown method ... new on C". Re-seeding an already-correct value
+            // is a no-op: the seed is a pure function of the constraint.
+            let is_dead_seed = matches!(
+                self.env().get(&name).map(Value::view),
+                Some(ValueView::Package(p)) if !self.type_name_is_known(&p.resolve())
+            );
+            if is_nil || is_dead_seed {
                 let init_val = self.typed_scalar_nil_seed_value(&name, &constraint);
                 self.set_env_with_main_alias(&name, init_val.clone());
                 self.update_local_if_exists(code, &name, &init_val);

--- a/t/lib/PackageTypeShortName.rakumod
+++ b/t/lib/PackageTypeShortName.rakumod
@@ -1,0 +1,34 @@
+unit module PackageTypeShortName;
+
+use MONKEY-SEE-NO-EVAL;
+
+# A type declared inside a package is registered under its QUALIFIED name only,
+# so every bareword reference to its SHORT name is a reference that has to be
+# resolved through the running package's chain. The declaration `my Modish $Modish`
+# is the stress case: the scalar and the type share the sigil-stripped lexical
+# key, so the variable must not be mistaken for the type (and vice versa).
+
+class Modish { has $.a }
+
+# A same-named typed declaration at module scope, outside any routine.
+my Modish $Modish;
+
+sub module-scope-decl-name() is export { $Modish.^name }
+
+sub module-scope-bareword-name() is export { Modish.^name }
+
+sub in-module-sub() is export {
+    class Subbish { has $.a }
+    my Subbish $Subbish .= new(:a(7));
+    ($Subbish.a, $Subbish.^name, Subbish.^name)
+}
+
+# `EVAL` called from a sub of a separate compilation unit: the snippet's own
+# `class` lands in this module's package, which is exactly where the short-name
+# resolution used to be lost.
+sub eval-in-module($code) is export { EVAL $code }
+
+sub eval-exception($code) is export {
+    try { EVAL $code }
+    $!
+}

--- a/t/package-type-short-name-vs-same-named-lexical.t
+++ b/t/package-type-short-name-vs-same-named-lexical.t
@@ -1,0 +1,132 @@
+use lib 't/lib';
+use Test;
+use MONKEY-SEE-NO-EVAL;
+use PackageTypeShortName;
+
+# A type declared INSIDE a package is registered under its qualified name only
+# (`M::C`), so a bareword `C` is a reference that has to be resolved through the
+# running package chain. A `my C $C` declaration stores the scalar under the
+# SAME sigil-stripped lexical key as that bareword, which used to make the
+# bareword resolve to a bare, never-registered `C` type object with no methods —
+# so `my C $C .= new(...)` (the fused form calls `.new` on the bareword) died
+# with "Unknown method ... new on C". Everything below is the matrix of where
+# such a declaration can appear.
+
+plan 35;
+
+# --- mainline, no package involved -------------------------------------------
+
+class Main1 { has $.a }
+my Main1 $Main1;
+is $Main1.^name, Main1.^name, 'mainline: same-named typed decl keeps the class identity';
+is Main1.new(:a(1)).a, 1, 'mainline: bareword .new still works after a same-named decl';
+
+class Main2 { has $.a }
+my Main2 $Main2 .= new(:a(2));
+is $Main2.a, 2, 'mainline: fused `.= new` on a same-named typed decl';
+is $Main2.^name, Main2.^name, 'mainline: fused `.= new` produces the real class';
+
+# Other-name control.
+class Main3 { has $.a }
+my Main3 $other .= new(:a(3));
+is $other.a, 3, 'mainline: other-named typed decl (control)';
+
+# Untyped control.
+class Main4 { has $.a }
+my $Main4 = Main4.new(:a(4));
+is $Main4.a, 4, 'mainline: untyped same-named decl (control)';
+
+# Nested-block control: the declaration is confined to the block.
+class Main5 { has $.a }
+{ my Main5 $Main5; }
+is Main5.new(:a(5)).a, 5, 'mainline: same-named decl in a nested block (control)';
+
+# Builtin control: a same-named lexical must not shadow a core type either.
+my Int $Int;
+is $Int.^name, 'Int', 'mainline: `my Int $Int` still holds the Int type object';
+is Int.^name, 'Int', 'mainline: bareword Int after `my Int $Int`';
+
+# --- inside a plain sub of this compilation unit ------------------------------
+
+sub in-plain-sub() {
+    class Sub1 { has $.a }
+    my Sub1 $Sub1 .= new(:a(11));
+    ($Sub1.a, $Sub1.^name, Sub1.^name)
+}
+my ($sa, $sn, $sb) = in-plain-sub();
+is $sa, 11, 'plain sub: fused `.= new` on a same-named typed decl';
+is $sn, $sb, 'plain sub: the value and the bareword name the same type';
+
+# --- inside a sub of a SEPARATE compilation unit (a module) -------------------
+
+is module-scope-decl-name(), module-scope-bareword-name(),
+    'module scope: `my Modish $Modish` keeps the class identity';
+is module-scope-bareword-name(), 'PackageTypeShortName::Modish',
+    'module scope: the bareword resolves to the package-qualified class';
+
+my ($ma, $mn, $mb) = in-module-sub();
+is $ma, 7, 'module sub: fused `.= new` on a same-named typed decl';
+is $mn, $mb, 'module sub: the value and the bareword name the same type';
+
+# --- EVAL from mainline -------------------------------------------------------
+
+is EVAL('class Ev1 { has $.a }; my Ev1 $Ev1 .= new(:a(21)); $Ev1.a'), 21,
+    'EVAL at mainline: fused `.= new` on a same-named typed decl';
+is EVAL('class Ev2 { has $.a }; my Ev2 $Ev2; $Ev2.^name eq Ev2.^name'), True,
+    'EVAL at mainline: the value and the bareword name the same type';
+is EVAL('class Ev3 { has $.a }; my Ev3 $z .= new(:a(23)); $z.a'), 23,
+    'EVAL at mainline: other-named typed decl (control)';
+
+# --- EVAL from a plain sub of this compilation unit ---------------------------
+
+sub eval-in-plain-sub($code) { EVAL $code }
+
+is eval-in-plain-sub('class Ep1 { has $.a }; my Ep1 $Ep1 .= new(:a(31)); $Ep1.a'), 31,
+    'EVAL from a plain sub: fused `.= new` on a same-named typed decl';
+is eval-in-plain-sub('class Ep2 { has $.a }; my Ep2 $Ep2; $Ep2.^name eq Ep2.^name'), True,
+    'EVAL from a plain sub: the value and the bareword name the same type';
+is eval-in-plain-sub('class Ep3 { has $.a }; my Ep3 $z .= new(:a(33)); $z.a'), 33,
+    'EVAL from a plain sub: other-named typed decl (control)';
+
+# --- EVAL from a sub of a SEPARATE compilation unit ---------------------------
+# This is the shape the real `Test.rakumod` uses: its `eval_exception` runs the
+# snippet from a sub of another compunit, so the snippet's `class` is registered
+# under THAT module's package.
+
+is eval-in-module('class Em1 { has $.a }; my Em1 $Em1 .= new(:a(41)); $Em1.a'), 41,
+    'EVAL from a module sub: fused `.= new` on a same-named typed decl';
+is eval-in-module('class Em2 { has $.a }; my Em2 $Em2; $Em2.^name eq Em2.^name'), True,
+    'EVAL from a module sub: the value and the bareword name the same type';
+is eval-in-module('class Em3 { has $.a }; my Em3 $z .= new(:a(43)); $z.a'), 43,
+    'EVAL from a module sub: other-named typed decl (control)';
+is eval-in-module('class Em4 { has $.a }; my $Em4 = Em4.new(:a(44)); $Em4.a'), 44,
+    'EVAL from a module sub: untyped same-named decl (control)';
+is eval-in-module('class Em5 { has $.a }; { my Em5 $Em5; }; Em5.new(:a(45)).a'), 45,
+    'EVAL from a module sub: same-named decl in a nested block (control)';
+is eval-in-module('my Int $Int; $Int.^name'), 'Int',
+    'EVAL from a module sub: `my Int $Int` still holds the Int type object';
+
+# The class an EVAL declares from a module sub is a member of that module's
+# package, and its accessor must survive the same-named declaration.
+is eval-in-module('class Em6 { has $.a }; my Em6 $Em6; Em6.^name'),
+   eval-in-module('class Em7 { has $.a }; my Em7 $z; Em7.^name').subst('Em7', 'Em6'),
+    'EVAL from a module sub: same-named and other-named decls resolve alike';
+is eval-in-module('class Em8 { has $.a }; my Em8 $Em8; Em8.new(:a(48)).a'), 48,
+    'EVAL from a module sub: bareword .new after a same-named decl';
+
+# Nothing above may leave the snippet dying.
+ok !eval-exception('class Em9 { has $.a }; my Em9 $Em9 .= new(:a(9))').defined,
+    'EVAL from a module sub: the fused declaration does not throw';
+
+# --- the type object itself ---------------------------------------------------
+
+class Undef1 { has $.a }
+my Undef1 $Undef1;
+nok $Undef1.defined, 'an uninitialized same-named typed scalar is undefined';
+isa-ok $Undef1, Undef1, 'an uninitialized same-named typed scalar IS the declared type';
+ok Undef1.^can('a'), 'the class resolved from the bareword has its accessor';
+
+class Undef2 { has $.a }
+my Undef2 $Undef2;
+is $Undef2.WHAT.^name, Undef2.^name, '.WHAT of the seeded type object names the class';
+ok $Undef2.^can('a'), 'the seeded type object carries the class methods';

--- a/todo/deep/vendor-real-test-module.md
+++ b/todo/deep/vendor-real-test-module.md
@@ -4567,3 +4567,69 @@ env, and `Any` is the one type name that has an env entry (a `Value::NIL`
 sentinel installed by `runtime_init.rs`). No roast file in the current residue
 gates it. Filed as
 `todo/tickets/anonymous-any-parameter-never-matches-in-multi-dispatch.md`.
+
+## 2026-08-29 — `S12-construction/autopairs.t`: the file name lied twice
+
+Slice for one whitelisted file that regressed under `MUTSU_REAL_TEST=1`.
+
+**Read this if you are triaging another file on the residue list: the roast
+file's NAME had nothing to do with the failure.** `autopairs.t` failed on
+test 2, "class instantiation with autopair, spaces", and neither the autopair
+(`:$a`) nor the space that distinguishes that subtest from the passing one
+was involved. Nor was `Test` itself. The only thing the real module changes is
+*where the snippet runs*: `eval-lives-ok` goes through `eval_exception`, a sub of
+a separate compilation unit, so the `EVAL`'d `class Tb { … }` is registered under
+that module's package — which rakudo does too. The bug was that every later
+reference to the class's SHORT name then broke.
+
+Root cause: `env` was the only bridge from a short type name to its
+package-qualified registration, and `env` stores `$C` under the sigil-stripped
+key `C` — the same key. So `my C $C` overwrote the alias that made its own type
+name resolvable, and `my C $C .= new(...)` (which calls `.new` on the bareword)
+died on a bare, never-registered `C` with no methods. Three sites needed the same
+registry fallback: the declaration seed
+(`nominal_type_object_name_for_constraint`), the block-entry hoist's stale seed
+(`exec_set_var_type` now re-seeds a `Package` naming a type that exists nowhere),
+and `GetBareWord`'s three "this is a type" branches plus its `Package(Any)`
+placeholder guard (one env-blind `resolve_bareword_type_name` probe now).
+
+Full write-up: `news/2026-08/package-type-short-name-vs-same-named-lexical.md`.
+Pin: `t/package-type-short-name-vs-same-named-lexical.t` (35 assertions, green
+under real `raku` too).
+
+### Measured, file by file (release build, `scripts/run-roast-test.sh`, both providers)
+
+| file | before (real) | after (real) | native |
+| --- | --- | --- | --- |
+| `S12-construction/autopairs.t` | 1 failure (#2 "class instantiation with autopair, spaces") | **PASS** (4/4) | still PASS (4/4) |
+
+So: roast correctness regressions under the real provider **-1**.
+
+### Two things worth carrying forward
+
+**The hoist's seeding is load-bearing, even though its own doc comment says it
+only registers the constraint.** The obvious fix — make `hoist_typed_var_decls`
+emit a type-only op — was implemented, measured, and reverted: without the
+hoisted seed, `my Int $Int` keeps the `Package(Any)` placeholder that
+`SetVarDynamic` writes for every `my`, and `$Int.^name` regresses to `Any` at
+plain mainline. The two mechanisms are fighting over the same env key; correcting
+the stale seed at the real declaration is the version that satisfies both.
+
+**A same-named lexical also defeats resolution for a LEXICAL class in a routine.**
+`module M { sub f { class C {…}; my C $C .= new(:a(7)) } }` did not merely fail to
+find the class — after the first fix round it silently built an `Any` instance
+whose `.a` worked but whose `.^name`/`.WHAT`/`.raku` all said `Any`. The tell was
+`.raku` reading `Any.new` while `.defined` was `True`; the cause was
+`GetBareWord`'s `Package(Any)` placeholder guard testing `has_type_direct`, which
+cannot see an ADR-0047-mangled qualified key. Any future work in this area should
+assume "the short name resolves" and "a type object named exactly this exists"
+are different questions.
+
+### Deferred from this file
+
+`EVAL 'my $a; role Tc { has $.a }; my Tc $c .= new(:$a)'` returns an object whose
+`.raku` is `Tc.new` in mutsu and `Tc.new(a => Any)` in rakudo — a punned role
+loses its attributes in `.raku` (the class form is already correct, and it
+reproduces without `EVAL`). The roast assertion is only `eval-lives-ok`, so it
+gates nothing here. Filed as
+`todo/tickets/punned-role-raku-drops-undefined-attributes.md`.

--- a/todo/tickets/punned-role-raku-drops-undefined-attributes.md
+++ b/todo/tickets/punned-role-raku-drops-undefined-attributes.md
@@ -1,0 +1,37 @@
+# `.raku` on a punned-role instance drops its attributes
+
+An instance built by punning a role (`role R { has $.a }; R.new(:a($x))`) renders
+its `.raku` without any attribute, while rakudo renders every attribute the way
+it does for a class.
+
+## Repro
+
+```
+$ raku  -e 'my $a; role Tc { has $.a }; my Tc $c .= new(:$a); say $c.raku'
+Tc.new(a => Any)
+$ mutsu -e 'my $a; role Tc { has $.a }; my Tc $c .= new(:$a); say $c.raku'
+Tc.new
+```
+
+The same holds inside an `EVAL`, and it is not about the value being undefined —
+`my $a = 5` gives rakudo `Tc.new(a => 5)` and mutsu still `Tc.new`. The class
+form is already correct: `class Tc { has $.a }` renders `Tc.new(a => Any)` in
+both. So the gap is specific to the *punned role* instance: whatever `.raku`
+uses to enumerate an instance's attributes finds the class's `has` declarations
+but not the ones a punned role contributed.
+
+## Where to look
+
+The `.raku`/`.gist` renderer for `ValueView::Instance` enumerates attributes from
+the class registry entry for `class_name`. A punned role creates its class shell
+from the `RoleDef`, so the question is whether that shell carries the role's
+attribute list at the point `.raku` reads it (and whether it should be read from
+the role instead).
+
+## Why it is filed rather than fixed
+
+Found while fixing
+`news/2026-08/package-type-short-name-vs-same-named-lexical.md` (the
+`S12-construction/autopairs.t` real-`Test` regression). That file's role
+assertions only use `eval-lives-ok`, so this divergence gates nothing there and
+folding it in would have mixed two unrelated root causes into one PR.


### PR DESCRIPTION
## What was wrong

`roast/S12-construction/autopairs.t` passed under the native `Test` provider and
failed test 2 under `MUTSU_REAL_TEST=1` with `Unknown method value dispatch
(fallback disabled): new on Tb`.

**The file's name is a red herring twice over.** The failure has nothing to do
with autopairs (`:$a`), nothing to do with the space in `:$a )` that separates
the failing subtest from its passing sibling, and nothing to do with `Test`. The
only thing the real `Test.rakumod` changes is *where the snippet runs*:
`eval-lives-ok` goes through `eval_exception`, a sub of a separate compilation
unit, so the `EVAL`'d `class Tb { … }` is compiled while a module's routine is on
the stack and is registered under **that module's package** — which rakudo does
too (`Test::Tb`).

## Root cause

A type declared inside a package is registered under its qualified name only
(`M::C`). mutsu made the short name `C` resolvable by relying on an `env` alias —
but `env` stores a `$`-sigiled scalar under its **sigil-stripped** key, so `C`
and `$C` are one slot. `my C $C` therefore overwrote the very alias that made its
own type name resolvable, and every short-name reference afterwards degraded to a
bare, never-registered `C` type object with no methods. `my C $C .= new(...)` is
the fused form, which calls `.new` on the **bareword**, so it died on exactly
that dead object.

Reduced with no `Test` anywhere (any module with a sub that `EVAL`s its argument):

```raku
eval-in-module 'class N1 { has $.a }; my N1 $N1 .= new(:a(1))'   # died
eval-in-module 'class N2 { has $.a }; my N2 $z  .= new(:a(2))'   # lived
```

## The fix — three sites, one registry fallback

* **`nominal_type_object_name_for_constraint`** (the declaration seed) falls back
  to `package_type_alias` / the running package's chain, so `my C $z; $z.^name`
  reports `M::C` like rakudo instead of a dead `C`.
* **`exec_set_var_type`** re-seeds a variable still holding a *dead* seed — a
  `Package` naming a type that exists nowhere. `hoist_typed_var_decls` emits a
  block-entry `SetVarType` before the `class` statements of the same block, so it
  seeds from a constraint that is not resolvable yet, and the real declaration
  then saw a non-`Nil` value and kept it. Such a value can never be legitimate
  (no assignment produces a type object for an unknown type), and re-seeding a
  correct one is a no-op because the seed is a pure function of the constraint.
* **`GetBareWord`**'s three "this name is a type" branches, and its
  `Package(Any)` placeholder guard, now share one env-blind
  `resolve_bareword_type_name` probe. The guard previously tested
  `has_type_direct`, which cannot see a lexical `class` in a routine (registered
  under an ADR-0047-mangled qualified key), so `my C $C .= new` built an `Any`
  instance whose `.a` worked but whose `.^name` / `.WHAT` / `.raku` all said
  `Any`.

Removing the hoist's seeding instead was implemented, measured, and **reverted**:
it is load-bearing for `my Int $Int`, which would otherwise keep
`SetVarDynamic`'s `Package(Any)` placeholder and report `Any` at plain mainline.

## Measured against rakudo

| snippet, run from a module sub's `EVAL` | rakudo | before | after |
| --- | --- | --- | --- |
| `class C { has $.a }; my C $C .= new(:a(1))` | lives | **dies** | lives |
| `class C { has $.a }; my C $z; $z.^name` | `M::C` | `C` | `M::C` |
| `class C { has $.a }; my C $C; C.^name` | `M::C` | `C` (0 methods) | `M::C` |
| `my Int $Int; $Int.^name` | `Int` | `Int` | `Int` |

`roast/S12-construction/autopairs.t`: **4/4 native, 4/4 `MUTSU_REAL_TEST=1`**
(was 3/4 under the real provider).

## Verification

* `make test` — PASS
* Targeted roast sweep, native provider, release build: all 415 whitelisted files
  under `S12-*`, `S02-names*`, `S02-types`, `S04-declarations`, `S06-signature`,
  `S09-typed-arrays`, `S11-*`, `S14-roles`, `integration` — `Result: PASS`
* `scripts/battery-testsuite.sh` on a release build — `GATE PASSED`
* `cargo fmt` / `cargo clippy -- -D warnings` clean

## Tests

`t/package-type-short-name-vs-same-named-lexical.t` — 35 assertions, **green
under real `raku` too**: the same-named typed declaration at mainline, in a plain
sub, in a module sub, and inside an `EVAL` from each of those, plus other-name,
untyped, nested-block and builtin (`my Int $Int`) controls.

## Deferred

A punned-role instance's `.raku` drops its attributes (`Tc.new` vs
`Tc.new(a => Any)`); it reproduces without `EVAL`, the class form is already
correct, and the roast assertion is only `eval-lives-ok`, so it gates nothing
here. Filed as `todo/tickets/punned-role-raku-drops-undefined-attributes.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
