### PR TITLE
fix(operators): the routine form of a numeric-comparison operator is now the operator

### DIFF
--- a/news/2026-08/infix-routine-form-numeric-comparison.md
+++ b/news/2026-08/infix-routine-form-numeric-comparison.md
@@ -1,0 +1,103 @@
+# The routine form of a numeric-comparison operator now IS the operator
+
+Three whitelisted roast files (`S32-num/rat.t`, `S32-num/int.t`, `S02-types/WHICH.t`)
+regressed under the "real Test" campaign (`MUTSU_REAL_TEST=1`) for one shared
+reason: the real vendored `Test.rakumod`'s `cmp-ok` reaches an operator only
+through its *routine* form — `&CALLER::LEXICAL::("infix:<$op>")($got,
+$expected)` — never through `$a op $b` syntax. mutsu's routine form
+(`Interpreter::call_infix_routine`) folded numeric comparisons with the pure
+static table `apply_reduction_op` plus its own, separate
+`coerce_infix_operand_numeric` bridge — a *reimplementation* of the real
+operator's coercion rules that had drifted from it. So `a == b` and
+`&infix:<==>(a, b)` could disagree:
+
+```
+mutsu -e 'say &infix:<==>(Inf.Rat, Inf)'                 # False   -- raku: True
+mutsu -e 'say &infix:<==>((-Inf).FatRat, -Inf)'          # False   -- raku: True
+mutsu -e 'my @a=1,2,3; my $s=SetHash.new(1,2,3); say &infix:<==>(@a,$s)'   # False -- raku: True
+mutsu -e 'my class Foo is Int {}; say &infix:<==>(Foo.new(42), 42)'        # False -- raku: True
+```
+
+In every case the *operator* form already answered correctly — only the
+routine form was wrong.
+
+This is the same shape of bug fixed for `eqv` in commit `8360b3120`
+("the `.cache` List view is a List everywhere, and `&infix:<eqv>` is the eqv
+operator"): the fix is not to patch the bridge case by case (that is exactly
+the kind of drift this campaign keeps removing), but to route the routine
+form through the interpreter's real operator body, so the two forms cannot
+diverge again.
+
+## The fix
+
+`==`, `!=`, `<`, `>`, `<=`, `>=` and `<=>` all now share one implementation
+each — `Interpreter::num_eq_values` / `num_ne_values` / `num_lt_values` /
+`num_le_values` / `num_gt_values` / `num_ge_values` / `spaceship_values` in
+`src/vm/vm_comparison_ops.rs` and `src/vm/vm_comparison_order_ops.rs` — used
+by both:
+
+- the stack-based `exec_num_*_op` / `exec_spaceship_op` opcodes (the `$a ==
+  $b` operator form), and
+- `call_infix_routine` (`&infix:<==>($a, $b)`) and
+  `eval_reduction_operator_values` (`[==]`, `Z==`, `>>==<<` and the other
+  reduction/metaop forms), in `src/runtime/builtins_operators_infix.rs` and
+  `src/vm/vm_dispatch_helpers.rs` respectively.
+
+`!=` is now literally `num_eq_values` negated (it previously duplicated
+almost the same body, minus an exact-BigInt-equality branch `==` had — a
+second, smaller divergence between the two operators that this unification
+also closed). `<`, `<=`, `>`, `>=` keep their Int/Int and Num/Num fast paths,
+now inside the shared function instead of duplicated per opcode.
+
+A user-defined `multi sub infix:<==>` on an object operand still wins first
+in both `call_infix_routine` and `eval_reduction_operator_values` — the
+redirect to the built-in numeric-comparison body only fires when no
+user-declared candidate matches (mirrored from the existing
+`reduction_op_is_numeric` bridge check).
+
+## A second bug the unification surfaced: `"1" == "1 "` was already broken
+
+Routing `[==]`/`&[==]`/`.unique(with => &[==])` through the real operator
+body initially *regressed* `t/reduce-numeric-string-whitespace.t` (tests 9
+and 10): `("1", 1, "1 ", 2).unique(with => &[==])` stopped deduping `"1"` and
+`"1 "`. The cause was not the redirect — it uncovered a pre-existing bug in
+the operator itself: `"1" == "1 "` (and `"1.0" == "1"`) already answered
+`False` via the plain `$a == $b` operator form, even before this PR. The old
+routine-form fold happened to hide it because its `to_num` helper always
+numified (and trimmed) both operands; the real operator's `exec_num_eq_op`
+took a "same variant → compare raw values" shortcut that, for two `Str`
+operands, compared their literal bytes instead of their numeric value.
+
+Fixed by widening that shortcut's `needs_float` condition: when both
+operands are `Str` and BOTH parse as a number (via the existing
+whitespace-trimming `to_float_value`), compare numerically. Two `Str`s where
+either side is not numeric (mutsu's bare-string enum modeling, e.g. `$status
+== Broken`) still fall through to the raw-string-equality shortcut unchanged
+— `==` stays deliberately lenient there, per `infix_is_strictly_numeric`'s
+existing doc comment.
+
+## A regression caught before it shipped
+
+The reduction-form redirect (`eval_reduction_operator_values`) initially
+bypassed a user-defined `multi sub infix:<==>` entirely — `[==] ($a, $b)` on
+a class with a custom `==` stopped calling it. Caught by testing that
+scenario directly (not in the original repro list) and fixed by preserving
+the existing `try_user_infix` check ahead of the new redirect, gated on
+either operand needing the Instance/ContainerRef bridge — the same condition
+the pre-existing numeric bridge used.
+
+## Verification
+
+- `roast/S32-num/rat.t` test 749 (`±Inf/NaN ⇿ Rat`) now passes under
+  `MUTSU_REAL_TEST=1` (previously failing on 4 inner subtests).
+- `roast/S32-num/int.t` and `roast/S02-types/WHICH.t` now pass completely
+  (exit 0) under both `MUTSU_REAL_TEST=1` and the native provider.
+- `rat.t` still aborts later in the file, in an unrelated subtest ("`eqv`
+  with zero-denominator Rationals") — a genuinely separate, pre-existing `is
+  copy`-parameter-binding bug, reproduces identically before this PR. Filed
+  as `todo/tickets/is-copy-param-not-decoupled-through-sigilless-capture-chain.md`.
+- New regression pin: `t/infix-routine-form-numeric-comparison.t` (27
+  assertions, green under real `raku` too).
+- `make test` green; a native-provider roast sweep across `S03-operators`,
+  `S32-num`, `S02-types`, `S06-*`, `S29-context` and related files is clean;
+  `./scripts/battery-testsuite.sh` unchanged.

--- a/src/runtime/builtins_operators_infix.rs
+++ b/src/runtime/builtins_operators_infix.rs
@@ -440,6 +440,29 @@ impl Interpreter {
                 acc = self.eqv_values(acc, rhs.clone())?;
                 continue;
             }
+            // The numeric-comparison family likewise needs the full
+            // interpreter, not the pure `apply_reduction_op` fold plus this
+            // function's own `coerce_infix_operand_numeric` bridge: that
+            // bridge is a *reimplementation* of the operator's coercion rules
+            // (Inf/-Inf-valued Rat/FatRat, exact BigInt equality, SetHash/Set
+            // structural comparison, a user subclass of Int, ...) and drifts
+            // from the real operator body in `vm_comparison_ops.rs` /
+            // `vm_comparison_order_ops.rs`. `&infix:<==>($a, $b)` — exactly
+            // what the real `Test.rakumod`'s `cmp-ok` reaches through — must
+            // behave identically to `$a == $b`.
+            if let Some(result) = match op {
+                "==" => Some(self.num_eq_values(acc.clone(), rhs.clone())?),
+                "!=" => Some(self.num_ne_values(acc.clone(), rhs.clone())?),
+                "<" => Some(self.num_lt_values(acc.clone(), rhs.clone())?),
+                ">" => Some(self.num_gt_values(acc.clone(), rhs.clone())?),
+                "<=" => Some(self.num_le_values(acc.clone(), rhs.clone())?),
+                ">=" => Some(self.num_ge_values(acc.clone(), rhs.clone())?),
+                "<=>" => Some(self.spaceship_values(acc.clone(), rhs.clone())?),
+                _ => None,
+            } {
+                acc = result;
+                continue;
+            }
             let mut lhs = acc.clone();
             let mut rhs = rhs.clone();
             if self.infix_uses_numeric_bridge(op) {
@@ -499,26 +522,14 @@ impl Interpreter {
         Ok(acc)
     }
 
+    // `==`, `!=`, `<`, `>`, `<=`, `>=` and `<=>` are deliberately absent here:
+    // they are intercepted earlier in `call_infix_routine` and routed through
+    // the real operator body (`num_eq_values` etc.), so they never reach this
+    // bridge.
     pub(super) fn infix_uses_numeric_bridge(&self, op: &str) -> bool {
         matches!(
             op,
-            "+" | "-"
-                | "*"
-                | "/"
-                | "%"
-                | "**"
-                | "=="
-                | "!="
-                | "<"
-                | ">"
-                | "<="
-                | ">="
-                | "<=>"
-                | "cmp"
-                | "before"
-                | "after"
-                | "min"
-                | "max"
+            "+" | "-" | "*" | "/" | "%" | "**" | "cmp" | "before" | "after" | "min" | "max"
         )
     }
 

--- a/src/vm/vm_comparison_ops.rs
+++ b/src/vm/vm_comparison_ops.rs
@@ -270,10 +270,19 @@ impl Interpreter {
         }
     }
 
-    pub(super) fn exec_num_eq_op(&mut self) -> Result<(), RuntimeError> {
-        let right = self.stack.pop().unwrap();
-        let left = self.stack.pop().unwrap();
-        let result = self.eval_binary_with_junctions(left, right, |vm, l, r| {
+    /// The full `infix:<==>` semantics, shared so that calling the operator as
+    /// a routine — `&infix:<==>($a, $b)`, which is exactly what the real
+    /// `Test.rakumod`'s `cmp-ok` does via `&CALLER::LEXICAL::("infix:<$op>")` —
+    /// behaves identically to the `$a == $b` operator form. The routine path
+    /// used to land on the pure `apply_reduction_op` fold (via a separate,
+    /// incomplete numeric-coercion bridge) instead, so e.g. `&infix:<==>(Inf.Rat,
+    /// Inf)` answered `False` where the operator answers `True`.
+    pub(crate) fn num_eq_values(
+        &mut self,
+        left: Value,
+        right: Value,
+    ) -> Result<Value, RuntimeError> {
+        self.eval_binary_with_junctions(left, right, |vm, l, r| {
             check_type_object_in_numeric_context(&l)?;
             check_type_object_in_numeric_context(&r)?;
             let (l, r) = vm.coerce_numeric_bridge_pair(l, r)?;
@@ -299,7 +308,22 @@ impl Interpreter {
                     }
                     _ => {}
                 }
-                let needs_float = !l.same_variant(&r) || l.is_nil();
+                // Two numeric-looking Strs (`"1" == "1 "`, `"1.0" == "1"`) must
+                // compare their NUMERIC value, not their literal bytes — Raku's
+                // numeric-string coercion trims surrounding whitespace, so a
+                // trailing/leading space made two otherwise-equal numbers
+                // compare unequal under the `same_variant` raw-`l == r` shortcut
+                // below. Two non-numeric Strs of the same shape (mutsu's
+                // bare-string enum modeling, e.g. `$status == Broken`) still
+                // fall through to that shortcut unchanged — `==` is
+                // deliberately lenient about non-numeric strings (see
+                // `infix_is_strictly_numeric`'s doc comment), so this only
+                // widens the case where BOTH sides actually parse as numbers.
+                let both_numeric_strs = matches!(l.view(), ValueView::Str(_))
+                    && matches!(r.view(), ValueView::Str(_))
+                    && runtime::to_float_value(&l).is_some()
+                    && runtime::to_float_value(&r).is_some();
+                let needs_float = !l.same_variant(&r) || l.is_nil() || both_numeric_strs;
                 if needs_float {
                     Ok(Value::truth(
                         runtime::to_float_value(&l) == runtime::to_float_value(&r),
@@ -308,43 +332,37 @@ impl Interpreter {
                     Ok(Value::truth(l == r))
                 }
             }
-        })?;
+        })
+    }
+
+    pub(super) fn exec_num_eq_op(&mut self) -> Result<(), RuntimeError> {
+        let right = self.stack.pop().unwrap();
+        let left = self.stack.pop().unwrap();
+        let result = self.num_eq_values(left, right)?;
         self.stack.push(result);
         Ok(())
+    }
+
+    /// `!=` is a negation meta-operator shortcut for `!==`: it evaluates `==`
+    /// (autothreading through junctions via [`Self::num_eq_values`]) and then
+    /// negates the boolean-collapsed result, always returning `Bool`. Sharing
+    /// [`Self::num_eq_values`] is the same "one oracle" reasoning as that
+    /// method's own doc comment — the routine form `&infix:<!=>($a, $b)` must
+    /// answer identically to `$a != $b`.
+    pub(crate) fn num_ne_values(
+        &mut self,
+        left: Value,
+        right: Value,
+    ) -> Result<Value, RuntimeError> {
+        let eq_result = self.num_eq_values(left, right)?;
+        Ok(Value::truth(!eq_result.truthy()))
     }
 
     pub(super) fn exec_num_ne_op(&mut self) -> Result<(), RuntimeError> {
         let right = self.stack.pop().unwrap();
         let left = self.stack.pop().unwrap();
-        // != is a negation meta-operator shortcut for !==.
-        // It first evaluates == (which autothreads through junctions),
-        // then negates the boolean-collapsed result, always returning Bool.
-        let eq_result = self.eval_binary_with_junctions(left, right, |vm, l, r| {
-            check_type_object_in_numeric_context(&l)?;
-            check_type_object_in_numeric_context(&r)?;
-            let (l, r) = vm.coerce_numeric_bridge_pair(l, r)?;
-            let (l, r) = (deref_allomorph_numeric(l), deref_allomorph_numeric(r));
-            // NaN is unordered: NaN == anything is always False
-            if is_nan_value(&l) || is_nan_value(&r) {
-                return Ok(Value::FALSE);
-            }
-            if let (Some(a), Some(b)) =
-                (runtime::to_big_rat_parts(&l), runtime::to_big_rat_parts(&r))
-                && (is_rationalish(&l) || is_rationalish(&r))
-            {
-                Ok(Value::truth(runtime::big_rat_parts_equal(a, b)))
-            } else if !l.same_variant(&r) || l.is_nil() {
-                // Mirror `==` exactly: operands of different shapes (a Str and
-                // an Int, say) compare as floats. Structural equality here made
-                // `"" != 0` answer True while `"" == 0` answered False.
-                Ok(Value::truth(
-                    runtime::to_float_value(&l) == runtime::to_float_value(&r),
-                ))
-            } else {
-                Ok(Value::truth(l == r))
-            }
-        })?;
-        self.stack.push(Value::truth(!eq_result.truthy()));
+        let result = self.num_ne_values(left, right)?;
+        self.stack.push(result);
         Ok(())
     }
 
@@ -399,29 +417,112 @@ impl Interpreter {
         Ok(())
     }
 
-    pub(super) fn exec_num_lt_op(&mut self) -> Result<(), RuntimeError> {
-        let right = self.stack.pop().unwrap();
-        let left = self.stack.pop().unwrap();
-        // Fast path: Int < Int
+    /// Shared body for `<`, used by both the stack-based `exec_num_lt_op`
+    /// opcode and the routine form (`&infix:<<>($a, $b)`), so the two call
+    /// shapes cannot drift — see the doc comment on [`Self::num_eq_values`]
+    /// for why that matters.
+    pub(crate) fn num_lt_values(
+        &mut self,
+        left: Value,
+        right: Value,
+    ) -> Result<Value, RuntimeError> {
+        // Fast path: Int/Int or Num/Num, skipping the generic BigRat-capable
+        // `compare` path (its conversions + allocation are wasted on the
+        // overwhelmingly common case of two native-shaped operands).
         if let ValueView::Int(a) = left.view()
             && let ValueView::Int(b) = right.view()
         {
-            self.stack.push(Value::truth(a < b));
-            return Ok(());
+            return Ok(Value::truth(a < b));
         }
-        // Fast path: Num < Num
         if let ValueView::Num(a) = left.view()
             && let ValueView::Num(b) = right.view()
         {
-            self.stack.push(Value::truth(a < b));
-            return Ok(());
+            return Ok(Value::truth(a < b));
         }
-        let result = self.eval_binary_with_junctions(left, right, |vm, l, r| {
+        self.eval_binary_with_junctions(left, right, |vm, l, r| {
             check_type_object_in_numeric_context(&l)?;
             check_type_object_in_numeric_context(&r)?;
             let (l, r) = vm.coerce_numeric_bridge_pair(l, r)?;
             Interpreter::compare(l, r, |o| o < 0)
-        })?;
+        })
+    }
+
+    /// Shared body for `<=` — see [`Self::num_lt_values`].
+    pub(crate) fn num_le_values(
+        &mut self,
+        left: Value,
+        right: Value,
+    ) -> Result<Value, RuntimeError> {
+        if let ValueView::Int(a) = left.view()
+            && let ValueView::Int(b) = right.view()
+        {
+            return Ok(Value::truth(a <= b));
+        }
+        if let ValueView::Num(a) = left.view()
+            && let ValueView::Num(b) = right.view()
+        {
+            return Ok(Value::truth(a <= b));
+        }
+        self.eval_binary_with_junctions(left, right, |vm, l, r| {
+            check_type_object_in_numeric_context(&l)?;
+            check_type_object_in_numeric_context(&r)?;
+            let (l, r) = vm.coerce_numeric_bridge_pair(l, r)?;
+            Interpreter::compare(l, r, |o| o <= 0)
+        })
+    }
+
+    /// Shared body for `>` — see [`Self::num_lt_values`].
+    pub(crate) fn num_gt_values(
+        &mut self,
+        left: Value,
+        right: Value,
+    ) -> Result<Value, RuntimeError> {
+        if let ValueView::Int(a) = left.view()
+            && let ValueView::Int(b) = right.view()
+        {
+            return Ok(Value::truth(a > b));
+        }
+        if let ValueView::Num(a) = left.view()
+            && let ValueView::Num(b) = right.view()
+        {
+            return Ok(Value::truth(a > b));
+        }
+        self.eval_binary_with_junctions(left, right, |vm, l, r| {
+            check_type_object_in_numeric_context(&l)?;
+            check_type_object_in_numeric_context(&r)?;
+            let (l, r) = vm.coerce_numeric_bridge_pair(l, r)?;
+            Interpreter::compare(l, r, |o| o > 0)
+        })
+    }
+
+    /// Shared body for `>=` — see [`Self::num_lt_values`].
+    pub(crate) fn num_ge_values(
+        &mut self,
+        left: Value,
+        right: Value,
+    ) -> Result<Value, RuntimeError> {
+        if let ValueView::Int(a) = left.view()
+            && let ValueView::Int(b) = right.view()
+        {
+            return Ok(Value::truth(a >= b));
+        }
+        if let ValueView::Num(a) = left.view()
+            && let ValueView::Num(b) = right.view()
+        {
+            return Ok(Value::truth(a >= b));
+        }
+        self.eval_binary_with_junctions(left, right, |vm, l, r| {
+            check_type_object_in_numeric_context(&l)?;
+            check_type_object_in_numeric_context(&r)?;
+            let (l, r) = vm.coerce_numeric_bridge_pair(l, r)?;
+            Interpreter::compare(l, r, |o| o >= 0)
+        })
+    }
+
+    pub(super) fn exec_num_lt_op(&mut self) -> Result<(), RuntimeError> {
+        let right = self.stack.pop().unwrap();
+        let left = self.stack.pop().unwrap();
+        let result = self.num_lt_values(left, right)?;
         self.stack.push(result);
         Ok(())
     }
@@ -429,26 +530,7 @@ impl Interpreter {
     pub(super) fn exec_num_le_op(&mut self) -> Result<(), RuntimeError> {
         let right = self.stack.pop().unwrap();
         let left = self.stack.pop().unwrap();
-        // Fast paths mirroring exec_num_lt_op: without them every `<=` in a
-        // hot loop pays the generic compare (BigRat conversion + alloc).
-        if let ValueView::Int(a) = left.view()
-            && let ValueView::Int(b) = right.view()
-        {
-            self.stack.push(Value::truth(a <= b));
-            return Ok(());
-        }
-        if let ValueView::Num(a) = left.view()
-            && let ValueView::Num(b) = right.view()
-        {
-            self.stack.push(Value::truth(a <= b));
-            return Ok(());
-        }
-        let result = self.eval_binary_with_junctions(left, right, |vm, l, r| {
-            check_type_object_in_numeric_context(&l)?;
-            check_type_object_in_numeric_context(&r)?;
-            let (l, r) = vm.coerce_numeric_bridge_pair(l, r)?;
-            Interpreter::compare(l, r, |o| o <= 0)
-        })?;
+        let result = self.num_le_values(left, right)?;
         self.stack.push(result);
         Ok(())
     }
@@ -456,25 +538,7 @@ impl Interpreter {
     pub(super) fn exec_num_gt_op(&mut self) -> Result<(), RuntimeError> {
         let right = self.stack.pop().unwrap();
         let left = self.stack.pop().unwrap();
-        // Fast paths mirroring exec_num_lt_op (see exec_num_le_op).
-        if let ValueView::Int(a) = left.view()
-            && let ValueView::Int(b) = right.view()
-        {
-            self.stack.push(Value::truth(a > b));
-            return Ok(());
-        }
-        if let ValueView::Num(a) = left.view()
-            && let ValueView::Num(b) = right.view()
-        {
-            self.stack.push(Value::truth(a > b));
-            return Ok(());
-        }
-        let result = self.eval_binary_with_junctions(left, right, |vm, l, r| {
-            check_type_object_in_numeric_context(&l)?;
-            check_type_object_in_numeric_context(&r)?;
-            let (l, r) = vm.coerce_numeric_bridge_pair(l, r)?;
-            Interpreter::compare(l, r, |o| o > 0)
-        })?;
+        let result = self.num_gt_values(left, right)?;
         self.stack.push(result);
         Ok(())
     }
@@ -482,25 +546,7 @@ impl Interpreter {
     pub(super) fn exec_num_ge_op(&mut self) -> Result<(), RuntimeError> {
         let right = self.stack.pop().unwrap();
         let left = self.stack.pop().unwrap();
-        // Fast paths mirroring exec_num_lt_op (see exec_num_le_op).
-        if let ValueView::Int(a) = left.view()
-            && let ValueView::Int(b) = right.view()
-        {
-            self.stack.push(Value::truth(a >= b));
-            return Ok(());
-        }
-        if let ValueView::Num(a) = left.view()
-            && let ValueView::Num(b) = right.view()
-        {
-            self.stack.push(Value::truth(a >= b));
-            return Ok(());
-        }
-        let result = self.eval_binary_with_junctions(left, right, |vm, l, r| {
-            check_type_object_in_numeric_context(&l)?;
-            check_type_object_in_numeric_context(&r)?;
-            let (l, r) = vm.coerce_numeric_bridge_pair(l, r)?;
-            Interpreter::compare(l, r, |o| o >= 0)
-        })?;
+        let result = self.num_ge_values(left, right)?;
         self.stack.push(result);
         Ok(())
     }

--- a/src/vm/vm_comparison_order_ops.rs
+++ b/src/vm/vm_comparison_order_ops.rs
@@ -411,10 +411,16 @@ impl Interpreter {
         }
     }
 
-    pub(super) fn exec_spaceship_op(&mut self) -> Result<(), RuntimeError> {
-        let right = self.stack.pop().unwrap();
-        let left = self.stack.pop().unwrap();
-        let result = self.eval_binary_with_junctions(left, right, |vm, l, r| {
+    /// The full `infix:<<=>>>` semantics, shared so the routine form
+    /// (`&infix:<<=>>>($a, $b)`, reached by the real `Test.rakumod`'s
+    /// `cmp-ok`) behaves identically to the `$a <=> $b` operator form — see
+    /// the doc comment on [`Interpreter::num_eq_values`] for why that matters.
+    pub(crate) fn spaceship_values(
+        &mut self,
+        left: Value,
+        right: Value,
+    ) -> Result<Value, RuntimeError> {
+        self.eval_binary_with_junctions(left, right, |vm, l, r| {
             // `<=>` is numeric (unlike generic `cmp`): a bare numeric type object
             // operand throws X::Numeric::Uninitialized, matching rakudo.
             crate::vm::vm_comparison_ops::check_type_object_in_numeric_context(&l)?;
@@ -429,7 +435,13 @@ impl Interpreter {
             let r = vm.coerce_complex_to_real_if_tolerant(&r)?;
             let ord = Self::numeric_spaceship_ordering(&l, &r)?;
             Ok(runtime::make_order(ord))
-        })?;
+        })
+    }
+
+    pub(super) fn exec_spaceship_op(&mut self) -> Result<(), RuntimeError> {
+        let right = self.stack.pop().unwrap();
+        let left = self.stack.pop().unwrap();
+        let result = self.spaceship_values(left, right)?;
         self.stack.push(result);
         Ok(())
     }

--- a/src/vm/vm_dispatch_helpers.rs
+++ b/src/vm/vm_dispatch_helpers.rs
@@ -163,6 +163,37 @@ impl Interpreter {
         if normalized_op == "eqv" {
             return self.eqv_values(left.clone(), right.clone());
         }
+        // The numeric-comparison family needs the full interpreter for the
+        // same reason `eqv` does above: the pure `apply_reduction_op` table
+        // (and the narrower Instance/ContainerRef bridge a few lines below)
+        // cannot reach an Inf-valued Rat/FatRat, exact BigInt equality,
+        // SetHash/Set structural comparison, or a user subclass of Int the
+        // way the real operator body (`num_eq_values` etc. in
+        // `vm_comparison_ops.rs` / `vm_comparison_order_ops.rs`) does.
+        // `[==] @list`, `@a Z== @b` and `@a >>==<< @b` must all agree with
+        // the plain `$a == $b` operator.
+        //
+        // A user-defined `multi sub infix:<==>` on an object operand still
+        // wins first, mirroring the `reduction_op_is_numeric` bridge below —
+        // `num_eq_values` et al. know nothing about user-declared candidates.
+        if matches!(normalized_op, "==" | "!=" | "<" | ">" | "<=" | ">=" | "<=>") {
+            if Self::value_needs_numeric_bridge(left) || Self::value_needs_numeric_bridge(right) {
+                let infix_name = format!("infix:<{}>", normalized_op);
+                if let Some(v) = self.try_user_infix(&infix_name, left, right)? {
+                    return Ok(v);
+                }
+            }
+            return match normalized_op {
+                "==" => self.num_eq_values(left.clone(), right.clone()),
+                "!=" => self.num_ne_values(left.clone(), right.clone()),
+                "<" => self.num_lt_values(left.clone(), right.clone()),
+                ">" => self.num_gt_values(left.clone(), right.clone()),
+                "<=" => self.num_le_values(left.clone(), right.clone()),
+                ">=" => self.num_ge_values(left.clone(), right.clone()),
+                "<=>" => self.spaceship_values(left.clone(), right.clone()),
+                _ => unreachable!(),
+            };
+        }
         // Range operators are legal metaop bases (`(1,2) Z.. (5,6)`,
         // `(1,2) X..^ (5,6)`) but are not reductions — they build a Range
         // value rather than fold two operands, so they cannot live in the

--- a/t/infix-routine-form-numeric-comparison.t
+++ b/t/infix-routine-form-numeric-comparison.t
@@ -1,0 +1,118 @@
+use Test;
+
+# The numeric-comparison family (`==`, `!=`, `<`, `>`, `<=`, `>=`, `<=>`) must
+# behave identically whether reached as the operator (`$a == $b`) or as the
+# ROUTINE `&infix:<==>($a, $b)` -- exactly how the real vendored upstream
+# `Test.rakumod`'s `cmp-ok` reaches an operator, via
+# `&CALLER::LEXICAL::("infix:<$op>")`. Before this fix, the routine form fell
+# through to a pure static fold with its own, INCOMPLETE numeric-coercion
+# bridge, so it disagreed with the operator on: Inf-valued Rat/FatRat, a
+# SetHash compared against an Array, and an instance of a user subclass of
+# Int. Same story for the reduction/meta forms (`[==]`, `Z==`, `>>==<<`),
+# which shared the same static fold via `eval_reduction_operator_values`.
+
+plan 27;
+
+# --- == -----------------------------------------------------------------
+
+{
+    my $inf-rat = Inf.Rat;
+    ok $inf-rat == Inf, 'operator: Inf.Rat == Inf';
+    ok &infix:<==>($inf-rat, Inf), 'routine: &infix:<==>(Inf.Rat, Inf)';
+}
+
+{
+    my $neg-inf-fatrat = (-Inf).FatRat;
+    ok $neg-inf-fatrat == -Inf, 'operator: (-Inf).FatRat == -Inf';
+    ok &infix:<==>($neg-inf-fatrat, -Inf), 'routine: &infix:<==>((-Inf).FatRat, -Inf)';
+}
+
+{
+    my @a = 1, 2, 3;
+    my $s = SetHash.new(1, 2, 3);
+    ok @a == $s, 'operator: Array == SetHash (same elements)';
+    ok &infix:<==>(@a, $s), 'routine: &infix:<==>(Array, SetHash)';
+}
+
+{
+    my class RoutineFormSubclassOfInt is Int { }
+    my $obj = RoutineFormSubclassOfInt.new(42);
+    ok $obj == 42, 'operator: subclass-of-Int instance == 42';
+    ok &infix:<==>($obj, 42), 'routine: &infix:<==>(subclass-of-Int instance, 42)';
+}
+
+# --- != -------------------------------------------------------------------
+
+{
+    my $inf-rat = Inf.Rat;
+    nok $inf-rat != Inf, 'operator: Inf.Rat != Inf is False';
+    nok &infix:<!=>($inf-rat, Inf), 'routine: &infix:<!=>(Inf.Rat, Inf) is False';
+    ok &infix:<!=>($inf-rat, -Inf), 'routine: &infix:<!=>(Inf.Rat, -Inf) is True';
+}
+
+# --- < > <= >= --------------------------------------------------------------
+
+{
+    my $inf-rat = Inf.Rat;
+    ok 1.Rat < $inf-rat, 'operator: 1.Rat < Inf.Rat';
+    ok &infix:«<»(1.Rat, $inf-rat), 'routine: &infix:«<»(1.Rat, Inf.Rat)';
+
+    ok $inf-rat > 1.Rat, 'operator: Inf.Rat > 1.Rat';
+    ok &infix:«>»($inf-rat, 1.Rat), 'routine: &infix:«>»(Inf.Rat, 1.Rat)';
+
+    ok $inf-rat <= Inf, 'operator: Inf.Rat <= Inf';
+    ok &infix:«<=»($inf-rat, Inf), 'routine: &infix:«<=»(Inf.Rat, Inf)';
+
+    ok $inf-rat >= Inf, 'operator: Inf.Rat >= Inf';
+    ok &infix:«>=»($inf-rat, Inf), 'routine: &infix:«>=»(Inf.Rat, Inf)';
+}
+
+# --- <=> --------------------------------------------------------------------
+
+{
+    my $inf-rat = Inf.Rat;
+    is $inf-rat <=> Inf, Same, 'operator: Inf.Rat <=> Inf is Same';
+    is &infix:«<=>»($inf-rat, Inf), Same, 'routine: &infix:«<=>»(Inf.Rat, Inf) is Same';
+}
+
+# --- reduction / metaop forms share the same fix ---------------------------
+
+{
+    my $inf-rat = Inf.Rat;
+    my $result = [==] ($inf-rat, Inf, Inf);
+    ok $result, '[==] over Inf.Rat, Inf, Inf';
+}
+
+{
+    my @a = Inf.Rat, 1;
+    my @b = Inf, 1;
+    is-deeply (@a Z== @b), (True, True), 'Z== zips == elementwise';
+}
+
+{
+    my @a = Inf.Rat, 1;
+    my @b = Inf, 1;
+    is-deeply (@a >>==<< @b), [True, True], '>>==<< hypers == elementwise';
+}
+
+# --- a user-defined infix:<==> multi still wins over this fix's redirect ---
+#
+# Routing `[==]`/`Z==`/`>>==<<` and `&infix:<==>(...)` through the real
+# operator body must NOT bypass a `multi sub infix:<==>` the user declared
+# for their own class -- that candidate has to keep winning over the
+# built-in numeric-comparison redirect, exactly as it did before this fix.
+
+{
+    my class RoutineFormUserOverrideTarget {
+        has $.v;
+    }
+    multi sub infix:<==>(RoutineFormUserOverrideTarget $a, RoutineFormUserOverrideTarget $b) {
+        $a.v == ($b.v + 1000)
+    }
+    my $a = RoutineFormUserOverrideTarget.new(:v(1));
+    my $b = RoutineFormUserOverrideTarget.new(:v(-999));
+    ok $a == $b, 'operator: user-defined infix:<==> still wins';
+    ok &infix:<==>($a, $b), 'routine: user-defined infix:<==> still wins';
+    my $reduced = [==] ($a, $b);
+    ok $reduced, '[==]: user-defined infix:<==> still wins';
+}

--- a/todo/deep/vendor-real-test-module.md
+++ b/todo/deep/vendor-real-test-module.md
@@ -4633,3 +4633,70 @@ loses its attributes in `.raku` (the class form is already correct, and it
 reproduces without `EVAL`). The roast assertion is only `eval-lives-ok`, so it
 gates nothing here. Filed as
 `todo/tickets/punned-role-raku-drops-undefined-attributes.md`.
+
+## 2026-08-28: the routine form of a numeric-comparison operator was not the operator
+
+Three files from the residue table above shared one root cause: the real
+`Test.rakumod`'s `cmp-ok` reaches an operator only through the ROUTINE form
+(`&CALLER::LEXICAL::("infix:<$op>")`), and `call_infix_routine`'s numeric
+comparison handling (`==`, `!=`, `<`, `>`, `<=`, `>=`, `<=>`) folded through
+the pure static `apply_reduction_op` table plus its own separate
+`coerce_infix_operand_numeric` bridge — a reimplementation of the real
+operator's coercion rules, missing Inf-valued Rat/FatRat, exact BigInt
+equality, SetHash/Set structural comparison, and a user subclass of Int. Same
+fix shape as `eqv` got in `8360b3120`: the routine form and the
+`[==]`/`Z==`/`>>==<<` reduction/metaop forms now share the real operator body
+(`num_eq_values` / `num_ne_values` / `num_lt_values` / `num_le_values` /
+`num_gt_values` / `num_ge_values` / `spaceship_values`) with the `$a == $b`
+operator opcode, instead of a separately-maintained fold. Full write-up:
+`news/2026-08/infix-routine-form-numeric-comparison.md`. Pin:
+`t/infix-routine-form-numeric-comparison.t` (27 assertions, green under real
+`raku` too).
+
+### Measured, file by file (release build, `scripts/run-roast-test.sh`, both providers)
+
+| file | before (real) | after (real) | before (native) | after (native) |
+| --- | --- | --- | --- | --- |
+| `S32-num/int.t` | FAIL (test 118, `.new of subclass of Int`) | **PASS** (exit 0) | PASS | PASS (unchanged) |
+| `S02-types/WHICH.t` | FAIL (test 1655, `ObjAt.raku gives distinct results for different objects`) | **PASS** (exit 0) | PASS | PASS (unchanged) |
+| `S32-num/rat.t` | FAIL (test 749, `±Inf/NaN ⇿ Rat`, plus a later, unrelated abort) | test 749 now passes; file still aborts later (see below) | PASS | PASS (unchanged) |
+
+`S32-num/int.t` and `S02-types/WHICH.t` are fully closed under both
+providers. `S32-num/rat.t`'s named failure (test 749) is fixed, but the file
+still aborts later at an unrelated, pre-existing bug: `eqv with
+zero-denominator Rationals` crashes `Test.rakumod`'s `proclaim` with `Cannot
+modify an immutable Str`, reproducing identically before this change (traced
+to `proclaim`'s `$desc is copy` parameter not decoupling from a value that
+arrives through a chain of sigilless `\`-capture aliases). Filed as
+`todo/tickets/is-copy-param-not-decoupled-through-sigilless-capture-chain.md`
+rather than folded into this fix — it is unrelated to numeric-comparison
+dispatch.
+
+### Two things that cost the most time here
+
+**The redirect regressed a real behavior before it was noticed: user-defined
+`multi sub infix:<==>` stopped winning over the built-in path in the
+reduction/metaop form (`eval_reduction_operator_values`).** The `eqv`
+precedent's redirect runs unconditionally, but `==`/`!=`/etc. already had an
+existing `try_user_infix` check (gated on `value_needs_numeric_bridge`) that
+a naive port of the `eqv` pattern silently dropped. Fixed by preserving that
+check ahead of the new redirect. Caught by testing the scenario directly
+(`class Foo { has $.v }; multi sub infix:<==>(Foo $a, Foo $b) {...}; [==]
+($a, $b)`) — not in the original repro list, so always test the
+"pre-existing feature this touches" axis, not only the target divergence.
+
+**Unifying the routine and operator forms surfaced a THIRD, pre-existing bug
+in the operator itself: `"1" == "1 "` (two `Str` operands) was already
+`False`, not `True`.** `exec_num_eq_op`'s "same variant → compare raw values"
+shortcut compared two `Str` operands' literal bytes, not their numeric value
+— unnoticed because the old routine-form fold's `to_num` always numified
+(and trimmed) both operands, silently masking it. `t/reduce-numeric-string-whitespace.t`
+(`.unique(with => &[==])` on `("1", 1, "1 ", 2)`) caught this the moment the
+routine form stopped taking that separate, accidentally-more-correct code
+path. Fixed by widening the shortcut to also numify when BOTH `Str` operands
+actually parse as numbers, while leaving genuinely non-numeric `Str` pairs
+(mutsu's bare-string enum modeling) on the existing raw-equality path. This
+is the general shape the prompt's "warnings that have repeatedly cost time"
+section describes: an isolated `-e` probe of the *target* divergence looked
+clean, but the *unification itself* had two more edges the target list never
+mentioned.

--- a/todo/tickets/is-copy-param-not-decoupled-through-sigilless-capture-chain.md
+++ b/todo/tickets/is-copy-param-not-decoupled-through-sigilless-capture-chain.md
@@ -1,0 +1,109 @@
+# `is copy` parameter stays aliased to an immutable Str when the argument arrives through a chain of sigilless `\`-captures
+
+## Symptom
+
+Under `MUTSU_REAL_TEST=1`, `roast/S32-num/rat.t`'s `eqv with zero-denominator
+Rationals` subtest aborts the whole file with:
+
+```
+Cannot modify an immutable Str ( NaN Rat,     Inf Rat)
+  in sub proclaim at .../modules/Rakudo-Core/lib/Test.rakumod line 621
+  in sub is-deeply at .../modules/Rakudo-Core/lib/Test.rakumod line 621
+  in sub e-no at roast/S32-num/rat.t line 508
+```
+
+This is unrelated to the infix-routine-form numeric-comparison bug fixed
+alongside this ticket (see `news/2026-08/infix-routine-form-numeric-comparison.md`):
+the `eqv` result itself is correct (`raku -e 'say (0/0).Rat eqv (70/0).Rat'`
+and mutsu both answer `False`), so the test should simply pass (`ok`) — it
+crashes on a passing case, before the `unless $cond` diagnostic-building path
+in `proclaim` is even reached, so it is not about diagnostic-message
+construction either.
+
+## Minimal repro
+
+```raku
+use Test;
+
+plan 1;
+
+sub e-no (\r1, \r2, \desc) { is-deeply r1 eqv r2, False, desc }
+
+subtest 'inner' => {
+    plan 1;
+    e-no <0/0>, <70/0>, ' NaN Rat,     Inf Rat';
+}
+```
+
+`raku` prints:
+
+```
+1..1
+# Subtest: inner
+    1..1
+    ok 1 -  NaN Rat,     Inf Rat
+ok 1 - inner
+```
+
+`MUTSU_REAL_TEST=1 mutsu` (with the real vendored `modules/Rakudo-Core/lib/Test.rakumod`)
+dies with `Cannot modify an immutable Str ( NaN Rat,     Inf Rat)` inside
+`proclaim`.
+
+## Root cause (traced, not fixed)
+
+`modules/Rakudo-Core/lib/Test.rakumod`'s `proclaim` declares:
+
+```raku
+sub proclaim(
+  Bool(Mu) $cond,
+  $desc is copy,
+  $unescaped-prefix = ''
+) is hidden-from-backtrace {
+    ...
+    $desc = $desc ?? nqp::join(...) !! '';
+    ...
+}
+```
+
+`$desc is copy` should give `proclaim` its own writable copy of whatever was
+passed, decoupled from the caller's container. The call chain here is:
+
+1. `e-no (\r1, \r2, \desc) { ... }` — `desc` is a sigilless capture (`\desc`)
+   bound directly to the caller's literal string `' NaN Rat,     Inf Rat'`
+   (a `Str` constant).
+2. `is-deeply(Mu $got, Mu $expected, $reason = '')` — `$reason` is an
+   ordinary (not `is copy`, not `is rw`) parameter, so by spec it is a
+   read-only alias to whatever was passed — here, the sigilless `desc`
+   capture from step 1.
+3. `proclaim($test, $reason)` — `$desc is copy` should snapshot a fresh,
+   writable `Str` at this call boundary.
+
+In mutsu, the assignment inside `proclaim` (`$desc = ...`) instead reaches
+the *original* immutable string literal from step 1 — i.e. mutsu's `is copy`
+parameter binding does not properly decouple from the source value when it
+arrives through a chain of sigilless `\`-capture aliases (a capture parameter
+binding directly to a caller variable/literal, then re-passed positionally
+through an intermediate read-only `$`-sigil parameter).
+
+This was NOT investigated further (no VM/compiler code read for the `is copy`
+parameter-binding path) — this ticket is a traced-but-unfixed finding, not a
+diagnosis of the exact compiler/VM site.
+
+## Affected files (starting points for whoever picks this up)
+
+- Wherever `is copy` parameter binding is compiled/executed (likely
+  `compiler/` signature-binding code and/or `vm/vm_call_ops.rs` parameter
+  materialization) — needs a `git grep -n '"copy"'` / `git grep -n 'is_copy'`
+  sweep to find the exact binding site.
+- Sigilless `\`-capture parameter handling (`indexed_varref_from_value` and
+  related capture-alias plumbing referenced elsewhere in `runtime/`).
+
+## Why this is a ticket, not a fix in this PR
+
+It surfaced as a side effect of fixing `roast/S32-num/rat.t` test 749
+(`±Inf/NaN ⇿ Rat`), which is the actual scope of the PR this ticket is filed
+alongside. `rat.t` test 749 now passes under `MUTSU_REAL_TEST=1`, but the file
+as a whole still aborts later at the point above — a genuinely separate,
+pre-existing bug (reproduces identically on `main` before that PR's changes).
+Fixing `is copy` parameter binding generally is a distinct, self-contained
+unit of work.


### PR DESCRIPTION
## Summary

The real Test.rakumod's `cmp-ok` reaches an operator only through its
**routine** form -- `&CALLER::LEXICAL::("infix:<$op>")($got, $expected)` --
never through `$a op $b` syntax. `call_infix_routine`'s handling of the
numeric-comparison family (`==`, `!=`, `<`, `>`, `<=`, `>=`, `<=>`) folded
through the pure static `apply_reduction_op` table plus its own, separate
`coerce_infix_operand_numeric` bridge: a reimplementation of the real
operator's coercion rules that had drifted from it, so e.g.
`&infix:<==>(Inf.Rat, Inf)` answered `False` where `Inf.Rat == Inf` answers
`True`. Same shape of bug as the `eqv` fix in `8360b3120`.

- `==`, `!=`, `<`, `>`, `<=`, `>=`, `<=>` now share one implementation each
  (`num_eq_values` / `num_ne_values` / `num_lt_values` / `num_le_values` /
  `num_gt_values` / `num_ge_values` / `spaceship_values`) between the
  stack-based operator opcodes, `call_infix_routine` (the routine form), and
  `eval_reduction_operator_values` (`[==]`, `Z==`, `>>==<<`, ...).
- A user-defined `multi sub infix:<==>` on an object operand still wins
  first in both redirect sites, mirroring the existing
  `reduction_op_is_numeric` bridge check.
- Unifying the two forms surfaced a **second, pre-existing** bug the old
  routine-form fold had been silently masking: `"1" == "1 "` (two `Str`
  operands) was already `False` via the plain operator, because
  `exec_num_eq_op`'s same-variant shortcut compared literal bytes instead of
  numeric value. Fixed by widening that shortcut to numify when both `Str`
  operands actually parse as numbers.

Closes `roast/S32-num/int.t` and `roast/S02-types/WHICH.t` under
`MUTSU_REAL_TEST=1` (both now exit 0 under both providers), and
`roast/S32-num/rat.t` test 749; that file still aborts later on an
unrelated, pre-existing `is copy` parameter-binding bug, filed as
`todo/tickets/is-copy-param-not-decoupled-through-sigilless-capture-chain.md`.

Full write-up: `news/2026-08/infix-routine-form-numeric-comparison.md`.
Ledger update: `todo/deep/vendor-real-test-module.md`.

## Test plan

- [x] New pin `t/infix-routine-form-numeric-comparison.t` (27 assertions),
      fails before / passes after, green under real `raku` too.
- [x] `t/reduce-numeric-string-whitespace.t` -- caught a regression from the
      reduction-form redirect, now green (both forms agree).
- [x] `make test` -- PASS (3534 files, 35442 tests).
- [x] Targeted native-provider roast sweep across `S03-operators`,
      `S32-num`, `S02-types`, `S06-*`, `S29-context` (260 files) -- clean.
- [x] `roast/S32-num/rat.t`, `roast/S32-num/int.t`, `roast/S02-types/WHICH.t`
      re-verified before/after under both `MUTSU_REAL_TEST=1` and native.
- [x] `./scripts/battery-testsuite.sh` -- GATE PASSED.
- [x] `cargo fmt` / `cargo clippy -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)