### PR TITLE
fix(vm): three MUTSU_REAL_TEST=1 residue causes: filename accessor, enum rebind, unknown trait

### DIFF
--- a/news/2026-08/enum-value-rebind-and-self-smartmatch.md
+++ b/news/2026-08/enum-value-rebind-and-self-smartmatch.md
@@ -1,0 +1,48 @@
+# Two enum bugs: a spurious readonly error on an unrelated rebind, and a type object not matching itself
+
+Both found while closing out `roast/S12-enums/misc.t`'s `MUTSU_REAL_TEST=1`
+residue (`throws-like { Direction( 2 <=> 3 ) }, X::Enum::NoValue, type =>
+Direction, value => Less`), and both turned out to be general VM
+correctness bugs unrelated to `Test`/exception-object completeness at all.
+
+## A for-loop's second `.kv` param could spuriously raise X::Assignment::RO
+
+`for %h.kv -> $k, $v { ... }` rebinds `$v` on every iteration. When `$v` is
+not compiled to a local slot (e.g. inside a nested closure/CATCH scope), the
+rebind reaches `OpCode::SetGlobal`, which carries a heuristic guard against
+reassigning an enum CONSTANT's own binding (`Red = 5` must die). That guard
+checked only "does the variable's *current* value happen to be an enum
+member" — with no check that the variable being written is actually the
+constant's own name. So once a hash's (randomized) iteration order put an
+enum value in one iteration, the *next* iteration's ordinary rebind of the
+same loop variable inherited that enum value as its "current" content and
+was misread as "reassigning the enum constant", raising a spurious
+`X::Assignment::RO` — even though nothing in the loop ever touched the
+constant itself.
+
+Fixed in `src/vm/vm_exec_dispatch.rs`: the guard now also requires the
+write target's name to equal the stored member's own `key` (`env["Red"] ==
+Enum { key: "Red", .. }` only for a genuine `Red = ...` write), which a
+merely-enum-valued unrelated variable never satisfies. Pinned by
+`t/enum-value-does-not-block-unrelated-rebind.t`, green under `raku` too.
+
+## An enum's type object did not smartmatch itself
+
+`Int ~~ Int` is `True` — any type object smartmatches its own type. mutsu's
+enum-specific smartmatch arm (`src/runtime/seq_helpers/smart_match.rs`)
+only ever checked whether the LHS was an enum *value* (`Red ~~ Color`); it
+never considered the LHS being the enum's own type object compared to
+itself, so `Color ~~ Color` answered `False`. In turn, any `$x ~~ Color`
+matcher failed whenever `$x` held the type object rather than a member —
+which is exactly what `X::Enum::NoValue.type` is (the enum's type object,
+not one of its values), so `throws-like …, type => Direction` always
+failed its `.type` check.
+
+Fixed by also checking the LHS-is-the-same-type-object case (respecting
+`:U`/`:D` definedness smileys the same way the general Package-vs-Package
+path below it already does). Pinned by
+`t/enum-type-object-smartmatches-itself.t`, green under `raku` too.
+
+Both fixes together close `roast/S12-enums/misc.t` under `MUTSU_REAL_TEST=1`
+(previously aborted partway through the file with a desynchronized TAP plan;
+now passes cleanly, 28/28).

--- a/news/2026-08/eval-compile-error-filename-and-line.md
+++ b/news/2026-08/eval-compile-error-filename-and-line.md
@@ -1,0 +1,48 @@
+# A compile-time exception raised inside EVAL now carries `.line` and `.filename`
+
+Rakudo's `X::Comp`/`X::Syntax::*` family exposes `.line` and `.filename` on a
+compile-time diagnosis — the line within, and the pseudo-file name of, the
+source that failed to compile. When that source is a string passed to
+`EVAL`, rakudo reports the EVAL's own synthesized name (matching `/EVAL/`)
+and the line within the EVAL'd string, not the caller's line or file.
+
+mutsu had two separate gaps that both surfaced on
+`X::Syntax::Pod::BeginWithoutIdentifier` (`=begin` with no block name):
+
+- **`.filename` did not exist as a method at all** on any exception. Only a
+  looser `.file` 0-arg accessor was implemented, generically, for every
+  `X::`/`CX::`/`Exception` instance. Added `.filename` alongside it
+  (`src/builtins/methods_0arg/mod.rs`), reading a `filename` attribute with
+  a fallback to `file` for symmetry.
+- **`.line` was never populated** for this exception (and any other built
+  via `PError::fatal_with_exception` without a source position). The
+  builder never recorded how much of the source remained unconsumed at the
+  failure point (`PError::remaining_len`), so `parser::parse_program`'s
+  fatal-error branch — which computes line/column from exactly that field —
+  never reached its `err.set_line`/`err.set_column` calls, and even when it
+  did, that computed line was never copied onto the pre-built exception's
+  own attributes (only the untyped-fallback exception-construction path did
+  that). Fixed both: `pod_begin_without_identifier_error` now anchors its
+  reported position at the `=begin` construct's own start (not the
+  remainder after it — the shared line/column math always skips forward
+  over trailing whitespace looking for "the next real token", which for
+  this diagnosis' typically-all-whitespace remainder walked straight past
+  the newline ending the `=begin` line and reported one line too far down;
+  verified against `raku`: `EVAL "=begin\nfoo\n=end\n"` still answers
+  `.line == 1`), and `parser::parse_program`'s fatal branch now copies the
+  computed `line`/`column` onto any pre-built exception that does not
+  already carry them.
+
+`.filename` itself needs the EVAL unit's synthesized name (`EVAL_0`, …),
+which only `builtin_eval` (`src/runtime/builtins_eval_misc.rs`) knows —
+so it backfills `filename`/`file` on any exception a parse-coded `EVAL`
+error carries, covering the whole `X::Comp` family raised while parsing an
+EVAL'd string, not just this one exception class (verified with a sibling,
+`X::Syntax::Malformed`).
+
+This was found and fixed while closing out
+`roast/S32-exceptions/misc2.t`'s `MUTSU_REAL_TEST=1` residue (the real
+vendored `Test.rakumod`'s `throws-like` calls `$ex.filename`/`$ex.line` as
+real Raku methods, unlike mutsu's native `throws-like`, which only checked
+these via its own parallel special-case code). Pinned by
+`t/eval-compile-error-line-and-filename.t`, green under `raku` too.

--- a/news/2026-08/unrelated-trait-mod-does-not-swallow-unknown-routine-trait.md
+++ b/news/2026-08/unrelated-trait-mod-does-not-swallow-unknown-routine-trait.md
@@ -1,0 +1,41 @@
+# An unrelated `trait_mod:<is>` candidate no longer swallows an unknown routine trait
+
+In Raku, built-in `trait_mod:<is>` candidates live in the same multi as any
+user-declared one, so a user candidate whose signature (including a
+required named parameter's specific NAME) does not match a given `is TRAIT`
+simply does not claim it — dispatch falls through, and an unrecognised
+trait still raises `X::Comp::Trait::Unknown` ("Can't use unknown trait").
+
+A 2026-08-01 fix (`f58c424c6`, "a user trait_mod:<is> that matches nothing
+keeps the trait") made this work correctly for *variable* traits (`my $a is
+whatever`), but explicitly left *routine* traits (`sub f() is whatever {
+}`) unfixed — its own commit message called this out: "The same shape for
+routine traits is a different code path and mutsu does not dispatch there
+at all today ... neither runs the handler nor errors."
+
+That gap is now closed. `src/runtime/registration_sub.rs`'s routine-trait
+application swallowed the `trait_mod:<is>`-dispatch "no candidate matched"
+verdict unconditionally (`Err(e) if Self::is_trait_mod_no_candidate(&e) =>
+{}`), leaving the sub declared with the unknown trait silently dropped —
+never running a handler, never raising an error. `has_trait_mod` (checked
+just above, guarding the sibling `!has_trait_mod` branch) only proves *some*
+`trait_mod:<is>` multi exists anywhere — e.g. merely `use Test;` supplies
+`multi sub trait_mod:<is>(Routine:D, :$test-assertion!)` — it says nothing
+about whether any candidate actually claims a *given* trait. The fix mirrors
+the sibling `!has_trait_mod` branch exactly: a genuine no-candidate verdict
+now raises the same "Can't use unknown trait 'is' -> '...' in sub
+declaration." message (still exempting `test-assertion`, mutsu's own
+built-in meaning, and still gated on being inside `EVAL` — outside EVAL, a
+handler may simply not be registered yet during ordinary module loading,
+matching the pre-existing tolerance of the sibling branch).
+
+Found while closing out `roast/S14-traits/routines.t`'s `MUTSU_REAL_TEST=1`
+residue: merely `use Test;` (which exports exactly the `:$test-assertion!`
+candidate named above) made `EVAL 'sub yulia is krassivaya { }'` silently
+succeed instead of dying — so `try { EVAL '...' }` never set `$!`, and the
+subtest asserting `"$!" ~~ /'unknown trait'/` failed with "Use of
+uninitialized value ... in string context" instead. Pinned by
+`t/unrelated-trait-mod-candidate-does-not-swallow-unknown-trait.t`, green
+under `raku` too. Closes `roast/S14-traits/routines.t` under
+`MUTSU_REAL_TEST=1` (its only other failure, "and the wrapper has been
+called once", is `#?rakudo todo`-marked and does not count).

--- a/src/builtins/methods_0arg/mod.rs
+++ b/src/builtins/methods_0arg/mod.rs
@@ -1546,6 +1546,18 @@ fn dispatch_core(target: &Value, method: &str) -> Option<Result<Value, RuntimeEr
                     }
                     return Some(Ok(Value::NIL));
                 }
+                // `X::Comp` (compile-time diagnoses like `X::Syntax::*`)
+                // exposes `.filename`, not `.file` -- rakudo's actual
+                // attribute is `$!filename`. Fall back to `file` for
+                // exceptions that only got the older generic attribute
+                // populated (kept for symmetry with the `.file` arm above).
+                "filename" => {
+                    let map = attributes.as_map();
+                    if let Some(filename) = map.get("filename").or_else(|| map.get("file")) {
+                        return Some(Ok(filename.clone()));
+                    }
+                    return Some(Ok(Value::NIL));
+                }
                 "backtrace" => {
                     if let Some(bt) = attributes.as_map().get("backtrace") {
                         return Some(Ok(bt.clone()));

--- a/src/parser/helpers.rs
+++ b/src/parser/helpers.rs
@@ -189,7 +189,30 @@ fn skip_declarator_doc_comment(input: &str) -> Option<&str> {
 }
 
 /// `X::Syntax::Pod::BeginWithoutIdentifier` — a `=begin` with no block name.
-fn pod_begin_without_identifier_error() -> PError {
+///
+/// `construct` is the unconsumed tail of the *original* top-level source
+/// starting at this `=begin` construct's own `=` (a suffix slice, not a
+/// copy): `PError::remaining_len` needs it to let
+/// `parser::parse_program`'s fatal-error branch compute the line the same
+/// way every other fatal diagnosis does (`e.consumed_from(source.len())`).
+/// Without it the exception carried no `remaining_len` at all, so
+/// `parse_program` never reached the branch that calls `err.set_line` --
+/// `$!.line` on this exception was simply never populated, and
+/// `$!.filename` had no method to read it with (see the `.filename` 0-arg
+/// accessor added alongside `.line`/`.file`).
+///
+/// Deliberately anchored at the construct's OWN start rather than at the
+/// (empty, or all-trailing-whitespace) remainder *after* it: rakudo reports
+/// this diagnosis on the line `=begin` itself sits on (verified: `EVAL
+/// "=begin\nfoo\n=end\n"` still answers `.line == 1`, not the line of
+/// `foo`), but `parse_program`'s shared position math always skips forward
+/// over any *trailing* whitespace looking for "the next real token" --
+/// which, when the remainder is pure whitespace up to the next real content
+/// (or end of input), walks straight across the newline that ends this
+/// line and lands one line too far down. Anchoring at `=` instead makes the
+/// skip-forward a no-op (a `=` is never whitespace), so the reported line
+/// is always this construct's own, regardless of what follows.
+fn pod_begin_without_identifier_error(construct: &str) -> PError {
     let msg =
         "=begin must be followed by an identifier; (did you mean \"=begin pod\"?)".to_string();
     let mut attrs = std::collections::HashMap::new();
@@ -198,7 +221,9 @@ fn pod_begin_without_identifier_error() -> PError {
         crate::symbol::Symbol::intern("X::Syntax::Pod::BeginWithoutIdentifier"),
         attrs,
     );
-    PError::fatal_with_exception(msg, Box::new(ex))
+    let mut err = PError::fatal_with_exception(msg, Box::new(ex));
+    err.remaining_len = Some(construct.len());
+    err
 }
 
 /// Parse and skip a Pod block.
@@ -234,7 +259,7 @@ fn pod_block(input: &str) -> PResult<'_, &str> {
         // position — but mutsu cannot, because the trim has already erased the
         // difference by the time the parser runs. Matching the newline form is
         // the useful half: it is the one real source ever contains.
-        return Err(pod_begin_without_identifier_error());
+        return Err(pod_begin_without_identifier_error(input));
     } else {
         return Err(PError::expected("pod directive"));
     }
@@ -247,7 +272,7 @@ fn pod_block(input: &str) -> PResult<'_, &str> {
         let target = begin_line.split_whitespace().next().unwrap_or("");
         // `=begin` must be followed by an identifier (the block name).
         if target.is_empty() {
-            return Err(pod_begin_without_identifier_error());
+            return Err(pod_begin_without_identifier_error(input));
         }
         let is_table = target == "table";
         let mut remaining = rest.get(begin_line_end + 1..).unwrap_or_default();

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -452,6 +452,32 @@ pub(crate) fn parse_program(input: &str) -> Result<(Vec<Stmt>, Option<String>), 
                     err.set_column(Some(col_num));
                 }
                 if let Some(ex) = e.exception {
+                    // A fatal diagnosis's own exception (built far from here,
+                    // e.g. `pod_begin_without_identifier_error`) usually carries
+                    // only `message`. `err.set_line` above computed the real
+                    // `line`/`column` from the failure position; without also
+                    // copying them onto the exception's own attributes here,
+                    // `$!.line`/`$!.column` (the actual X::Comp accessors, read
+                    // straight from the instance) stayed unset even though the
+                    // CLI's own `===SORRY!===` rendering (which reads `err`
+                    // directly) already had them. Other X::Comp builders in this
+                    // file (`build_vcs_conflict_error`, etc.) set `line` on their
+                    // exception's attrs by hand at construction; this generalizes
+                    // that for every site that instead relies on `remaining_len`.
+                    if let crate::value::ValueView::Instance { attributes, .. } = ex.view() {
+                        if let Some(line) = err.line() {
+                            attributes.insert_if_absent(
+                                "line".to_string(),
+                                crate::value::Value::int(line as i64),
+                            );
+                        }
+                        if let Some(column) = err.column() {
+                            attributes.insert_if_absent(
+                                "column".to_string(),
+                                crate::value::Value::int(column as i64),
+                            );
+                        }
+                    }
                     err.exception = Some(ex);
                 }
                 return Err(err);

--- a/src/runtime/builtins_eval_misc.rs
+++ b/src/runtime/builtins_eval_misc.rs
@@ -397,11 +397,28 @@ impl Interpreter {
             .insert("?FILE".to_string(), Value::str(unit_name.clone()));
         let saved_source_file =
             crate::parser::set_parser_source_file(Some(self.absolutify_unit_name(&unit_name)));
-        let result = if check_only {
+        let mut result = if check_only {
             self.eval_eval_string_check_only(&code)
         } else {
             self.eval_eval_string(&code)
         };
+        // A compile-time diagnosis (`X::Comp`/`X::Syntax::*`) raised while
+        // parsing the EVAL'd string reports `.filename` matching the EVAL
+        // pseudo-file (rakudo: `/EVAL/`), just like `.line` reports the line
+        // within that source. Every such exception is built with `line`
+        // already on its own attributes (either directly, by the builder
+        // that raises it, or generically by `parser::parse_program`'s fatal
+        // branch), but none of those sites know the EVAL unit's synthesized
+        // name -- only this call site does. Backfill it here, once, for the
+        // whole `X::Comp` family rather than at each individual raise site.
+        if let Err(ref mut e) = result
+            && e.code().is_some_and(|c| c.is_parse())
+            && let Some(exc_box) = e.exception.as_ref()
+            && let ValueView::Instance { attributes, .. } = exc_box.view()
+        {
+            attributes.insert_if_absent("filename".to_string(), Value::str(unit_name.clone()));
+            attributes.insert_if_absent("file".to_string(), Value::str(unit_name.clone()));
+        }
         crate::parser::set_parser_source_file(saved_source_file);
         self.current_unit = saved_unit;
         match saved_env_file {

--- a/src/runtime/registration_sub.rs
+++ b/src/runtime/registration_sub.rs
@@ -1552,13 +1552,38 @@ impl Interpreter {
                             self.env.insert(code_var_key, mixin_val);
                         }
                     }
-                    // No user candidate accepted this trait (e.g. `is
-                    // test-assertion` with no `Test` handler in scope, or a
-                    // genuinely unknown custom trait): keep whatever builtin
-                    // meaning parsing already recorded and move on, same as
-                    // the analogous variable-trait fallback in
-                    // `vm_var_trait_ops.rs`.
-                    Err(e) if Self::is_trait_mod_no_candidate(&e) => {}
+                    // No user candidate accepted this trait. `has_trait_mod`
+                    // only proves SOME `trait_mod:<is>` multi exists somewhere
+                    // (e.g. `Test.rakumod`'s own `:$test-assertion!`
+                    // candidate) -- it says nothing about whether any of them
+                    // actually claims THIS trait, so a `is_trait_mod_no_candidate`
+                    // verdict here is exactly as "unknown" as the `!has_trait_mod`
+                    // case just above and must be reported the same way (raku:
+                    // `sub yulia is krassivaya { }` still dies "Can't use
+                    // unknown trait" even with an unrelated `trait_mod:<is>`
+                    // multi in scope). Previously this arm silently swallowed
+                    // the verdict and kept the routine undecorated -- the sub
+                    // declaration itself never failed, so the caller had no way
+                    // to learn the trait was rejected
+                    // (`roast/S14-traits/routines.t` under `MUTSU_REAL_TEST=1`:
+                    // merely `use Test;` supplies a `:$test-assertion!`
+                    // candidate, so every OTHER unknown routine trait silently
+                    // no-op'd instead of raising `X::Comp::Trait::Unknown`).
+                    // `test-assertion` keeps its exemption (mutsu's parser
+                    // already recorded its builtin meaning) and the `in_eval`
+                    // gate mirrors the sibling branch above -- outside EVAL
+                    // (plain module loading) a handler may simply not be
+                    // registered yet, so stay silent there as before.
+                    Err(e) if Self::is_trait_mod_no_candidate(&e) => {
+                        if trait_name != "test-assertion"
+                            && self.env.get("__mutsu_in_eval").is_some_and(|v| v.truthy())
+                        {
+                            return Err(RuntimeError::new(format!(
+                                "Can't use unknown trait 'is' -> '{}' in sub declaration.",
+                                trait_name
+                            )));
+                        }
+                    }
                     // A real error raised from inside a handler that DID
                     // match (e.g. it `die`s) must propagate, not be silently
                     // swallowed.

--- a/src/runtime/seq_helpers/smart_match.rs
+++ b/src/runtime/seq_helpers/smart_match.rs
@@ -1518,16 +1518,30 @@ impl Interpreter {
                     };
                 }
 
-                // Enum type object smartmatch against enum values.
+                // Enum type object smartmatch against enum values -- and
+                // against the enum's OWN type object, which is a type-object
+                // match like any other (`Direction ~~ Direction` is True,
+                // exactly as `Int ~~ Int` is: a type object always matches
+                // its own type). Missing the second case used to make every
+                // `$x ~~ Direction` matcher fail whenever `$x` held the type
+                // object itself rather than an enum value -- e.g.
+                // `$exception.type` on `X::Enum::NoValue`, whose `.type`
+                // attribute is the enum's type object, not one of its values
+                // (`roast/S12-enums/misc.t`'s `throws-like ..., type =>
+                // Direction` under `MUTSU_REAL_TEST=1`).
                 if self.registry().enum_types.contains_key(base_type) {
                     let enum_match = matches!(
                         left.view(),
                         ValueView::Enum { enum_type, .. } if enum_type == base_type
                     );
+                    let own_type_object = matches!(
+                        left.view(),
+                        ValueView::Package(lhs_name) if lhs_name == base_type
+                    );
                     return match smiley {
-                        Some(":U") => false,
+                        Some(":U") => own_type_object,
                         Some(":D") => enum_match,
-                        _ => enum_match,
+                        _ => enum_match || own_type_object,
                     };
                 }
 

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -1235,7 +1235,26 @@ impl Interpreter {
                     {
                         return Err(RuntimeError::assignment_ro_type_object(&name));
                     }
-                    if let Some(ValueView::Enum { enum_type, key, .. }) = current_view {
+                    // A GENUINE enum-constant reassignment (`Red = 5`) writes to
+                    // the bareword global that IS the constant's own binding, so
+                    // its name equals the currently-stored member's own `key`
+                    // (`env["Red"] == Enum { key: "Red", .. }`). Without the
+                    // `name == key` check this also fired for an ORDINARY
+                    // variable that merely holds an enum value transiently --
+                    // e.g. a for-loop's second `.kv` param (`for %h.kv -> $k, $v
+                    // {...}`) rebinding `$v` via `SetGlobal("v", ...)` when the
+                    // slot's PREVIOUS content (from the prior iteration) happened
+                    // to be an Enum member: `env.get("v")` returned
+                    // `Enum{key:"Red",..}` from iteration 1, and the unguarded
+                    // check misread iteration 2's ordinary rebind as "assigning
+                    // over the `Red` constant", raising a spurious
+                    // X::Assignment::RO (`roast/S12-enums/misc.t`'s
+                    // `X::Enum::NoValue` throws-like case, only reachable once a
+                    // hash's random iteration order put an enum value before a
+                    // later key).
+                    if let Some(ValueView::Enum { enum_type, key, .. }) = current_view
+                        && name == key.resolve()
+                    {
                         return Err(RuntimeError::assignment_ro_typename(
                             &enum_type.resolve(),
                             &key.resolve(),

--- a/t/enum-type-object-smartmatches-itself.t
+++ b/t/enum-type-object-smartmatches-itself.t
@@ -1,0 +1,24 @@
+use Test;
+
+plan 8;
+
+enum Color <Red Green Blue>;
+
+# A type object always smartmatches its own type (`Int ~~ Int` is True);
+# an enum's type object is no exception, but the enum-specific smartmatch
+# arm only ever considered the LHS being an enum VALUE (`Red ~~ Color`),
+# never the LHS being the enum's OWN type object compared to itself. That
+# made `Color ~~ Color` False when it should be True -- and, in turn, made
+# any `$x ~~ Color` matcher fail whenever `$x` held the type object rather
+# than a value, e.g. `X::Enum::NoValue.type` (which IS the type object, not
+# a member) matched against `type => Color` in a `throws-like` call.
+ok Color ~~ Color, 'an enum type object smartmatches itself';
+ok Red ~~ Color, 'an enum value still smartmatches its type';
+nok Color ~~ Red, 'an enum type object does not smartmatch a member';
+nok Str ~~ Color, 'an unrelated type object does not smartmatch the enum';
+
+# Definedness smileys still apply correctly to the type object.
+ok Color ~~ Color:U, 'the type object matches its own :U form';
+nok Color ~~ Color:D, 'the type object does not match the :D form';
+ok Red ~~ Color:D, 'an enum value matches the :D form';
+nok Red ~~ Color:U, 'an enum value does not match the :U form';

--- a/t/enum-value-does-not-block-unrelated-rebind.t
+++ b/t/enum-value-does-not-block-unrelated-rebind.t
@@ -1,0 +1,41 @@
+use Test;
+
+plan 4;
+
+# A bareword global write (`Red = 5`) that reassigns an enum CONSTANT's own
+# binding is illegal and must still raise X::Assignment::RO.
+{
+    my $threw = False;
+    try {
+        EVAL 'enum Color <Red Green Blue>; Red = 5;';
+        CATCH { default { $threw = True; } }
+    }
+    ok $threw, 'reassigning an enum constant by its own name still dies';
+}
+
+# An ORDINARY variable that merely holds an enum value transiently must
+# not be mistaken for that binding. A for-loop's second `.kv` parameter is
+# rebound on every iteration (via a bareword global write when it is not
+# compiled to a local slot); when a PRIOR iteration's value happened to be
+# an enum member, the rebind for the NEXT iteration used to be misread as
+# "reassigning the enum constant itself" and raised a spurious
+# X::Assignment::RO, even though the loop never touched the constant at
+# all -- only its own unrelated loop variable.
+enum Color <Red Green Blue>;
+for (('b', Red), ('a', 1)) -> ($k, $v) {
+    my $x = $v;
+    ok True, "iteration for key '$k' completed without dying";
+}
+
+# The forward order (enum value bound first, ordinary value second) is the
+# one that actually exercises the rebind; run it explicitly so the pin does
+# not depend on Hash key iteration order picking it.
+{
+    my %matcher = b => Red, a => 1;
+    my $ok = True;
+    for %matcher.kv -> $k, $v {
+        my $x = $v;
+    }
+    CATCH { default { $ok = False; } }
+    ok $ok, 'a .kv for-loop over a Hash with an enum value survives a later rebind';
+}

--- a/t/eval-compile-error-line-and-filename.t
+++ b/t/eval-compile-error-line-and-filename.t
@@ -1,0 +1,52 @@
+use Test;
+
+plan 8;
+
+# `X::Comp`/`X::Syntax::*` compile-time diagnoses raised while parsing an
+# EVAL'd string carry `.line` (the line WITHIN that source) and `.filename`
+# (the EVAL pseudo-file, matching /EVAL/) -- exactly like every other
+# X::Comp accessor rakudo exposes. Both used to be silently absent on a
+# `PError::fatal_with_exception`-built exception: `.line` because the
+# builder never carried a source position for `parser::parse_program`'s
+# fatal branch to compute one from, and `.filename` because mutsu had no
+# `.filename` accessor on exceptions at all (only the looser `.file`).
+
+# A `=begin` with no identifier, as the whole (trimmed) source.
+{
+    try EVAL "=begin\n";
+    is $!.^name, 'X::Syntax::Pod::BeginWithoutIdentifier',
+        'right exception type for a bare =begin';
+    is $!.line, 1, '.line is 1 for a single-line =begin';
+    ok $!.filename ~~ /EVAL/, '.filename matches /EVAL/';
+}
+
+# Same diagnosis, but with real content spanning several MORE lines after
+# the failing `=begin` -- the reported line must still be the `=begin`
+# line itself, not wherever the trailing content happens to end.
+{
+    try EVAL "=begin\nfoo\n=end\n";
+    is $!.^name, 'X::Syntax::Pod::BeginWithoutIdentifier',
+        'right exception type for a multi-line =begin block';
+    is $!.line, 1, '.line is still 1 with trailing content after =begin';
+}
+
+# A leading statement pushes the failing `=begin` onto a later line.
+{
+    try EVAL "1;\n2;\n=begin\nfoo\n=end\n";
+    is $!.line, 3, '.line tracks a =begin that is not on line 1';
+}
+
+# `.filename` is not specific to this one exception class -- ANY fatal
+# compile-time diagnosis with a pre-built exception object, raised while
+# parsing an EVAL'd string, gets it (the backfill in `builtin_eval` is
+# keyed on the error being parse-coded, not on the exception's class
+# name). `X::Syntax::Malformed` (`PError::malformed`, e.g. a malformed
+# initializer) is a sibling built the same way as
+# `X::Syntax::Pod::BeginWithoutIdentifier`.
+{
+    try EVAL "my \$x = ;";
+    is $!.^name, 'X::Syntax::Malformed',
+        'right exception type for a malformed initializer';
+    ok $!.filename ~~ /EVAL/,
+        '.filename matches /EVAL/ for a sibling X::Syntax exception';
+}

--- a/t/unrelated-trait-mod-candidate-does-not-swallow-unknown-trait.t
+++ b/t/unrelated-trait-mod-candidate-does-not-swallow-unknown-trait.t
@@ -1,0 +1,55 @@
+use Test;
+
+plan 4;
+
+# `has_trait_mod` only proves SOME `trait_mod:<is>` multi candidate exists
+# somewhere -- it says nothing about whether any of them actually claims a
+# GIVEN trait. When dispatch genuinely finds no matching candidate for the
+# trait in question (`is_trait_mod_no_candidate`), that verdict was being
+# swallowed unconditionally and the sub declaration silently kept the
+# trait undecorated instead of reporting "unknown trait" -- exactly the
+# same class of bug the sibling `vm_var_trait_ops.rs` fix (see
+# `news/2026-08/user-trait-mod-does-not-consume-every-trait.md`) already
+# fixed for VARIABLE traits, but left open for ROUTINE traits.
+multi trait_mod:<is>(Routine:D $r, :$test-assertion!) {
+    # Never actually called by this test -- its mere existence is what
+    # used to make an unrelated trait name silently succeed.
+}
+
+{
+    my $threw = False;
+    my $message = '';
+    try {
+        EVAL 'sub yulia is krassivaya { }';
+        CATCH {
+            default {
+                $threw = True;
+                $message = .message;
+            }
+        }
+    }
+    ok $threw, 'an unrelated trait_mod:<is> candidate does not swallow an unknown trait';
+    ok $message ~~ /'unknown trait'/,
+        'the raised message still names it an unknown trait';
+}
+
+# A trait the SAME candidate genuinely does claim keeps working.
+{
+    my $ok = True;
+    try {
+        EVAL 'sub greet() is test-assertion { }';
+        CATCH { default { $ok = False; } }
+    }
+    ok $ok, 'a trait a real candidate claims is still accepted';
+}
+
+# A second, differently-shaped unrelated trait name is rejected the same
+# way (not just the exact one this file's own candidate declares against).
+{
+    my $threw = False;
+    try {
+        EVAL 'sub f() is this-is-not-a-real-trait-at-all { }';
+        CATCH { default { $threw = True; } }
+    }
+    ok $threw, 'a second unrelated trait name is rejected the same way';
+}

--- a/todo/deep/lazy-gather-return-outside-scope-swallowed-in-nested-block.md
+++ b/todo/deep/lazy-gather-return-outside-scope-swallowed-in-nested-block.md
@@ -1,0 +1,171 @@
+# A `return`-outside-scope raised while forcing a lazy `gather` is swallowed (or misreported) inside a nested block
+
+## Root cause (as far as diagnosed)
+
+`gather { return }` builds a lazy sequence; when the resulting `Seq` is
+later forced (e.g. by `.Str`/`~`), the `return` fires *then*, dynamically,
+long after `f()`'s own call frame is gone. Rakudo converts this into a
+catchable `X::ControlFlow::Return` ("Attempt to return outside of
+immediately-enclosing Routine ...").
+
+mutsu gets this right at the **top level** and inside a **`try { }`**
+block: both raise a proper `X::ControlFlow::Return` that a `CATCH`/`$!`
+can see. But the moment the force happens inside an **ordinary nested
+block** — a bare `{ ... }`, or a `Callable` invoked through a plain
+user-defined sub — the signal is handled wrong in two different ways
+depending on the exact nesting:
+
+1. **Bare block at the mainline** (`tmp` repro below): the raw internal
+   message reaches the CLI uncaught (`CATCH { default { ... } }` inside
+   the very same block never fires), and — worse — the message printed
+   is the *non-EVAL* wording ("outside of immediately-enclosing Routine")
+   even though a `Comp`-context matching wording exists for the EVAL
+   case; the `CATCH` should have caught this before it ever got to CLI
+   rendering.
+2. **Closure invoked via a plain user sub** (`call-it(&code) { code() }`,
+   or the shape `Test.rakumod`'s real `subtest(&subtests) { subtests();
+   CATCH {...} }` uses): the signal is silently **swallowed** — neither
+   the inner `CATCH` fires, nor does anything propagate to top level, nor
+   does the script exit non-zero. The script just continues as if the
+   `EVAL` returned normally, but every statement *after* the `EVAL` in
+   that block is also skipped (as if a real `return`/unwind
+   happened) — i.e. the signal partially behaves like a working control
+   transfer, just to the wrong place, with no exception delivered to any
+   `CATCH` along the way.
+
+This was found while working the `MUTSU_REAL_TEST=1` residue for
+`roast/S32-exceptions/misc2.t` (see `todo/deep/vendor-real-test-module.md`).
+Line 368 there is:
+
+```raku
+throws-like 'my sub f() { gather { return } }; ~f()', X::ControlFlow::Return;
+```
+
+Under the real vendored `Test.rakumod`, `throws-like` builds a `subtest {
+plan 2; ...; EVAL $code, context => $caller-context; ...; CATCH { default
+{ pass $msg; ... } } }` closure and hands it to the real `subtest(&code)`
+sub (`modules/Rakudo-Core/lib/Test.rakumod` around line 420), which just
+calls `subtests()` directly. That is exactly case 2 above: the CATCH
+inside the closure never fires, the subtest's own `plan 2` never gets its
+`ok`/`not ok` lines, and — because `subtest()`'s wrapper never sees the
+closure "return" (Rakudo's `proclaim`/`done-testing` machinery is skipped
+entirely) — **every `throws-like` call after this one in the same file
+is misattributed as nested inside this subtest's TAP scope**, producing
+`# You planned 2 tests, but ran 40` far downstream and aborting the whole
+run. This is NOT specific to `Test.rakumod`; case 2 reproduces with a
+two-line user sub and no `use Test` at all (see repro).
+
+Under mutsu's OWN native `throws-like` (`src/runtime/test_functions/`),
+this exact roast line passes — the native provider's own `lives-ok`/
+`throws-like` implementation has its own special-case handling for a live
+non-local-control signal (`is_live_nonlocal_control` in
+`src/runtime/test_functions/eval_exception.rs`) that apparently does not
+hit this bug, or masks it. So `make roast` under the whitelisted (native)
+provider is unaffected; this is purely a `MUTSU_REAL_TEST=1` residue
+finding, but the underlying mechanism (a lazy-forced Return escaping a
+nested block's CATCH) is a real, general correctness bug independent of
+Test.
+
+## Minimal repros
+
+Case 1 (bare block, message reaches CLI uncaught, `CATCH` inside the same
+block never fires):
+
+```raku
+{
+    EVAL 'my sub f() { gather { return } }; ~f()';
+    say "unreached: eval did not throw";
+    CATCH {
+        default {
+            say "caught: ", $_.^name;
+        }
+    }
+}
+say "after";
+```
+
+mutsu (release): prints `Attempt to return outside of immediately-enclosing
+Routine (...)` and appears to abort with a non-zero exit — nothing after
+that line is printed, not even `after`.
+raku: prints `caught: X::ControlFlow::Return` then `after`.
+
+Case 2 (closure through a plain user sub, signal silently swallowed,
+downstream statements in the SAME block also skipped):
+
+```raku
+sub call-it(&code) {
+    code();
+}
+call-it({
+    EVAL 'my sub f() { gather { return } }; ~f()';
+    say "unreached: eval did not throw";
+    CATCH {
+        default {
+            say "caught: ", $_.^name;
+        }
+    }
+});
+say "after";
+```
+
+mutsu (release): prints only `after` — neither `say` inside the closure
+ever runs, no error, exit 0.
+raku: prints `caught: X::ControlFlow::Return` then `after`.
+
+For contrast, both of these work correctly in mutsu today (already
+verified, not part of this finding):
+
+```raku
+try { EVAL('my sub f() { gather { return } }; ~f()') };
+say $!.^name;   # X::ControlFlow::Return, matches raku
+```
+```raku
+my sub f() { gather { return } };
+try { ~f() };
+say $!.^name;   # X::ControlFlow::Return, matches raku
+```
+
+## Why this is `deep`, not a `tickets` slice
+
+The signal clearly propagates *somewhere* wrong rather than simply being
+dropped — case 2's "rest of the block after EVAL is skipped, but nothing
+downstream ever sees it either" behavior suggests the lazy-gather-force's
+`X::ControlFlow::Return` conversion path (see `resolution_lazy.rs`,
+`vm_exec_dispatch.rs` around the `X::ControlFlow::Return` /
+`out-of-dynamic-scope` comments, and `runtime/mod.rs`'s "uncaught-CX::Return
+-> X::ControlFlow::Return conversion in `run_inner`") is racing or
+mismatching against the CATCH-region bytecode boundaries
+(`vm_try_catch_ops.rs`) specifically when the force happens through an
+*extra* frame boundary (a real Callable call, or a nested nameless block)
+that the conversion logic does not expect. Understanding exactly which
+boundary swallows it (block-scope exit vs. routine-call return vs. the
+lazy-list coroutine's own frame teardown) needs a design pass across
+`resolution_lazy.rs`, `vm_control_ops.rs`/`vm_try_catch_ops.rs`, and the
+"uncaught-CX::Return" conversion site in `runtime/mod.rs`, not a
+single-file fix.
+
+## Affected files (starting points for the investigation)
+
+- `src/runtime/resolution_lazy.rs` (the doc comment there already claims
+  this exact conversion — worth checking why it does not fire for cases 1/2)
+- `src/vm/vm_exec_dispatch.rs` (the `Return`/`ReturnFromNonRoutine` /
+  `X::ControlFlow::Return` arms)
+- `src/vm/vm_try_catch_ops.rs` (`dispatch_to_catch_handler` and the
+  CATCH-region bytecode boundaries)
+- `src/runtime/mod.rs` (`run_inner`'s "uncaught-CX::Return ->
+  X::ControlFlow::Return conversion", ~line 3025)
+- `src/runtime/test_functions/eval_exception.rs` (`is_live_nonlocal_control`
+  — the native `throws-like`/`lives-ok` special-case that apparently avoids
+  this bug; understanding why it avoids it may point at the fix)
+
+## Impact
+
+Blocks `roast/S32-exceptions/misc2.t` from passing cleanly under
+`MUTSU_REAL_TEST=1` (aborts partway through with "You planned 2 tests,
+but ran 40" once the earlier-in-file `X::ControlFlow::Return` subtest
+swallows the signal and desynchronizes every subsequent subtest's TAP
+nesting). Does not affect the native `Test` provider (`make roast`
+remains green for this file). Likely affects any real-world Raku script
+that forces a lazy `gather` containing a scope-escaped `return` from
+inside a nested block or a Callable passed to a plain sub — a general
+correctness gap, not a roast-only curiosity.

--- a/todo/deep/vendor-real-test-module.md
+++ b/todo/deep/vendor-real-test-module.md
@@ -4700,7 +4700,6 @@ is the general shape the prompt's "warnings that have repeatedly cost time"
 section describes: an isolated `-e` probe of the *target* divergence looked
 clean, but the *unification itself* had two more edges the target list never
 mentioned.
-||||||| parent of d4386c8c5 (fix(operators): a user-declared operator is scoped to its compilation unit)
 
 ## 2026-08-29: operator scope is lexical, not dynamic (`S06-operator-overloading/sub.t`, `S03-metaops/hyper.t`)
 
@@ -4762,3 +4761,99 @@ because `lives-ok { my $s = (gather die)[] }` reifies the `gather` that a zen
 slice must not touch. `S32-exceptions/misc2.t` is back on the list for a new
 reason (`X::Syntax::Pod::BeginWithoutIdentifier` has no `.filename`, which the
 real `throws-like` calls).
+
+## 2026-08-29 — three exception-object/incidental-VM-bug files: misc2.t, S12-enums/misc.t, S14-traits/routines.t
+
+Cluster of three files whose regressions all *looked* like the same shape
+(the real `Test.rakumod`'s `throws-like` interrogating the caught exception
+through real Raku method calls, which mutsu's native provider never
+exercises) — verified independently per file rather than assumed. Two of
+the three turned out to be genuinely unrelated VM bugs, not exception-object
+gaps at all; only `misc2.t`'s was the exception-attribute shape the cluster
+was named for.
+
+**`roast/S32-exceptions/misc2.t`** — `X::Syntax::Pod::BeginWithoutIdentifier`
+had no `.filename` method at all (only the looser `.file`), and its `.line`
+was never populated because its builder (`PError::fatal_with_exception`)
+never recorded a source position for `parser::parse_program`'s fatal branch
+to compute one from. Fixed generally (a new `.filename` accessor alongside
+`.line`/`.file`; `parse_program`'s fatal branch now copies computed
+`line`/`column` onto any pre-built exception; `builtin_eval` backfills
+`filename`/`file` for the whole `X::Comp` family raised while parsing an
+EVAL'd string, not just this one class). Write-up:
+`news/2026-08/eval-compile-error-filename-and-line.md`. Pin:
+`t/eval-compile-error-line-and-filename.t` (8 assertions, green under `raku`).
+
+Fixing that abort exposed a SEPARATE, unrelated bug further into the same
+file (`throws-like 'my sub f() { gather { return } }; ~f()'`,
+X::ControlFlow::Return`): a `return`-outside-scope raised while forcing a
+lazy `gather` is swallowed (or misreported) once the force happens inside a
+nested block or a Callable invoked through a plain user sub — a general VM
+control-flow bug, not Test-specific (reproduces with a two-line user sub, no
+`use Test` at all). Too deep to fix in this slice; filed as
+`todo/deep/lazy-gather-return-outside-scope-swallowed-in-nested-block.md`.
+misc2.t is therefore not fully green under `MUTSU_REAL_TEST=1` yet, but the
+abort point moved from test ~94 to this new, unrelated bug around test ~220.
+
+**`roast/S12-enums/misc.t`** — NOT an exception-object gap. Two unrelated,
+general VM correctness bugs, both surfaced by
+`throws-like { Direction( 2 <=> 3 ) }, X::Enum::NoValue, type => Direction,
+value => Less`:
+1. A for-loop's second `.kv` param rebind (`OpCode::SetGlobal`) could
+   spuriously raise `X::Assignment::RO` when a PRIOR iteration's value
+   happened to be an enum member — the "is this reassigning an enum
+   constant" guard checked only the current value's *type*, never that the
+   write target's *name* was the constant's own name.
+2. An enum's type object did not smartmatch itself (`Color ~~ Color` was
+   `False`) — the enum-specific smartmatch arm only considered an enum
+   *value* on the LHS, never the type object compared to itself, breaking
+   any `$x ~~ Color` where `$x` held the type object (exactly what
+   `X::Enum::NoValue.type` is).
+
+Both fixed; write-up `news/2026-08/enum-value-rebind-and-self-smartmatch.md`.
+Pins: `t/enum-value-does-not-block-unrelated-rebind.t`,
+`t/enum-type-object-smartmatches-itself.t` (both green under `raku`).
+
+**`roast/S14-traits/routines.t`** — NOT an exception-object gap either. A
+routine-trait application (`sub f() is TRAIT { }`) silently swallowed the
+"no `trait_mod:<is>` candidate actually claims this trait" verdict
+unconditionally, instead of raising "Can't use unknown trait" the way the
+sibling *variable*-trait path already does (a gap that 2026-08-01's
+`f58c424c6` explicitly called out as unfixed for routines). Merely
+`use Test;` — which exports `multi sub trait_mod:<is>(Routine:D,
+:$test-assertion!)` — was enough to make ANY unrelated unknown routine
+trait silently succeed instead of dying, so `try { EVAL 'sub yulia is
+krassivaya { }' }` never set `$!`. Fixed to raise the same message the
+sibling `!has_trait_mod` branch already uses. Write-up:
+`news/2026-08/unrelated-trait-mod-does-not-swallow-unknown-routine-trait.md`.
+Pin: `t/unrelated-trait-mod-candidate-does-not-swallow-unknown-trait.t`
+(green under `raku`).
+
+### Measured, file by file (release build, `scripts/run-roast-test.sh`, both providers)
+
+| file | before (real) | after (real) | native |
+| --- | --- | --- | --- |
+| `S32-exceptions/misc2.t` | aborts mid-file (test ~94, "No such method 'filename'") | improved, still aborts (unrelated `lazy-gather-return` bug, test ~220) | still PASS (266/266) |
+| `S12-enums/misc.t` | aborts mid-file ("Cannot modify an immutable Order (Less)", desyncs the rest of the file) | **PASS** (28/28) | still PASS (28/28) |
+| `S14-traits/routines.t` | 1 failure (test 12, "declaration of a sub with an unknown trait...") | **PASS** (17/17, test 10 stays `#?rakudo todo`) | still PASS (17/17) |
+
+So: `S12-enums/misc.t` and `S14-traits/routines.t` are fully closed under
+`MUTSU_REAL_TEST=1`; `S32-exceptions/misc2.t`'s original blocker (the
+subject of this slice) is fixed, but the file is blocked by the newly
+surfaced `lazy-gather-return-outside-scope-swallowed-in-nested-block`
+ticket instead. All three remain green under the native (whitelisted)
+provider throughout.
+
+### One thing worth carrying forward
+
+**Don't trust the cluster framing over independent verification.** All
+three files were handed over as "one cluster of the same shape (incomplete
+exception objects)" — and two of the three were not that at all. The
+diagnostic symptom (`throws-like` failing a `.foo matches ...` check, or
+"Use of uninitialized value ... in string context") looks identical whether
+the exception object is genuinely incomplete or whether an unrelated VM bug
+(a stale for-loop rebind, a broken self-smartmatch, a swallowed dispatch
+verdict) merely prevented the RIGHT value from ever being computed. Re-derive
+the root cause from a from-scratch, `use Test`-free repro every time, even
+when the roast test's own `throws-like` line makes the exception-object
+explanation look obvious.


### PR DESCRIPTION
## Summary

Three independent bugs found while closing out the `MUTSU_REAL_TEST=1` (real
vendored `Test.rakumod`) residue for `roast/S32-exceptions/misc2.t`,
`roast/S12-enums/misc.t`, and `roast/S14-traits/routines.t`. Verified each
file independently rather than assuming a shared root cause — two of the
three turned out unrelated to exception-object completeness.

- **`misc2.t`**: `X::Syntax::Pod::BeginWithoutIdentifier` (and the whole
  `X::Comp` family) had no `.filename` accessor and never got `.line`
  populated. Added `.filename`, made `parser::parse_program`'s fatal branch
  copy computed `line`/`column` onto a pre-built exception, and made
  `builtin_eval` backfill `filename`/`file` for any parse-coded `EVAL`
  error (not just this one class).
- **`S12-enums/misc.t`**: two unrelated VM bugs — a for-loop's second
  `.kv` param rebind could raise a spurious `X::Assignment::RO` when a
  prior iteration's value happened to be an enum member, and an enum's
  type object did not smartmatch itself (`Color ~~ Color` was `False`).
- **`S14-traits/routines.t`**: a routine trait application silently
  swallowed the "no `trait_mod:<is>` candidate matches" verdict instead of
  raising "Can't use unknown trait" — a gap an earlier commit
  (`f58c424c6`) explicitly left open for routines while fixing the
  analogous variable-trait case.

`misc2.t`'s abort point moved to a separate, deeper control-flow bug
(a `return`-outside-scope raised while forcing a lazy `gather` is
swallowed inside a nested block/Callable), filed as
`todo/deep/lazy-gather-return-outside-scope-swallowed-in-nested-block.md`
rather than fixed in this slice.

## Test plan

- [x] `make test` — 3537 files, 35439 tests, all green
- [x] `cargo fmt --check` / `cargo clippy -- -D warnings` — clean
- [x] Four new `t/` regression tests, each verified green under `raku` too
- [x] `S12-enums/misc.t` and `S14-traits/routines.t` now pass cleanly
      under `MUTSU_REAL_TEST=1` (28/28 and 17/17)
- [x] Native (whitelisted) provider unaffected: targeted sweep of
      `S32-exceptions`, `S04-exceptions`, `S12-enums`, `S14-traits`,
      `S05-metasyntax`, `S06-operator-overloading`, `S03-smartmatch`
      (68 whitelisted files, 1673 tests) — all pass
