### PR TITLE
fix(types): punned-role isa/smartmatch, Promise subclass factories, mixin type-object gist/definedness

### DIFF
--- a/news/2026-08/mixin-type-object-gist-and-definedness.md
+++ b/news/2026-08/mixin-type-object-gist-and-definedness.md
@@ -1,0 +1,50 @@
+# A mixin on a type object was lost by .gist/.raku, and by :U parameter binding
+
+`.^name` on a role-mixed type object already correctly composed the mixed
+name, but `.gist`/`.raku` dropped it entirely:
+
+```raku
+my $m = Any but role Meows { method Bool { True } };
+say $m.gist;   # was "(Any)", raku: "(Any+{Meows})"
+say $m.^name;  # already correct: "Any+{Meows}"
+```
+
+Root cause #1: the fast-path method dispatch for a role-mixed value
+(`src/builtins/methods_0arg/mod.rs`) had a special case that re-attached the
+composed name for `gist`/`raku`/`perl` on a Set/Bag/Mix inner, but every
+other inner (including a plain type-object `Package`) fell straight through
+to `native_method_0arg(inner, ...)` — delegating to the BARE inner value and
+discarding the mixin wrapper, since a type object has no further user-class
+dispatch step to fall back into (unlike an instance, which reaches a
+separate composed-name-aware retargeting step in
+`methods_call_dispatch.rs`). Added a matching fast-path arm for a `Package`
+inner.
+
+While chasing why the fix alone didn't close
+`roast/6.c/S14-roles/mixin-6c.t` under `MUTSU_REAL_TEST=1`, root cause #2
+surfaced: the real `Test.rakumod`'s `is(Mu $got, Mu:U $expected, ...)` multi
+(selected because `$m` is a type object, hence undefined) couldn't even bind
+`$m` to its `Mu:U $expected` parameter. `Value::isa_check`-level checks
+already handled a mixin correctly, but the definedness predicate
+`value_is_defined` (`src/runtime/types/mod.rs`) had no `Mixin` arm at all —
+every mixin, whether wrapping an undefined type-object `Package` or a defined
+`Instance`, fell through to its `_ => true` default and was reported as
+*defined*. That's a plain `sub f(Mu:U $x) {...}; f($m)` bug independent of
+`.gist`, not specific to Test.rakumod:
+
+```raku
+sub f(Mu:U $x) { $x.^name }
+my $m = Any but role Meows { method Bool { True } };
+say f($m);   # was a signature-binding error, raku: "Any+{Meows}"
+```
+
+Fixed by adding `ValueView::Mixin(inner, _) => value_is_defined(inner)`,
+mirroring the existing `ContainerRef` arm — a mixin's definedness is exactly
+its wrapped value's definedness, nothing more.
+
+Both fixes were needed to close `roast/6.c/S14-roles/mixin-6c.t` tests 48-49
+("method/submethod Bool in mixin is used") under `MUTSU_REAL_TEST=1`; the
+native `Test` provider's `is` doesn't route through this multi/parameter-
+binding path, so it already passed there. Regression tests:
+`t/mixin-type-object-gist.t` and `t/mixin-type-object-definedness.t` (green
+under `raku` too).

--- a/news/2026-08/promise-subclass-factory-methods.md
+++ b/news/2026-08/promise-subclass-factory-methods.md
@@ -1,0 +1,49 @@
+# Promise factory methods now respect a user subclass
+
+`class Meows is Promise {}`'s `.new` already produced a `Meows`-typed
+instance, but every OTHER Promise-constructing class method
+(`.start`/`.in`/`.at`/`.anyof`/`.allof`, and `.then` on an existing Promise)
+ignored the invocant's subclass:
+
+```raku
+my class Meows is Promise {};
+say Meows.start({1}).^name;   # was "Promise", raku: Meows
+```
+
+Two independent bugs, plus a third that only surfaced once the first two were
+fixed:
+
+1. `promise_class_name` (`src/runtime/methods_collection_ops/socket_inet_proc.rs`)
+   already threaded the invocant's class name through to
+   `SharedPromise::new_with_class`, but for a *lexically-scoped* subclass
+   (`my class Meows is Promise {}`) that name is the raw, ADR-0047-mangled
+   internal storage key (`Meows\u{0}<decl-id>`), not the clean user-facing
+   "Meows" — this is architecturally correct (every other comparison against
+   the same class, `class_mro`, `isa_check`, etc., also operates on the
+   mangled form), but nothing stripped it for *display*.
+2. `Interpreter::dispatch_caret_name`'s `Promise` arm
+   (`src/runtime/methods_introspect.rs`) read that mangled name straight into
+   `.^name`'s output, unlike the `Package`/`Instance` arms right above it
+   (which both call `user_facing_type_name` first) — so `.^name` rendered a
+   stray embedded NUL byte + decl-id. Fixed by routing through
+   `user_facing_type_name` the same way. `.WHAT`'s hardcoded `"Promise"`
+   literal (same file) was also replaced with the Promise's own
+   `class_name()`, though the pre-existing Promise-specific `"WHAT"` handler
+   in `methods_promise.rs` already got this right on its own.
+3. Once `.^name` displayed the clean "Meows", `.isa(Meows)` and (crucially)
+   `nqp::istype($meows_promise, Meows)` still disagreed with it, because
+   `Interpreter::dispatch_mro`'s catch-all fallback for a `ValueView::Promise`
+   (`src/runtime/receiver_class.rs`) used `value_type_name`, which is
+   hardcoded to the literal string `"Promise"` for every Promise value,
+   subclassed or not. Added a dedicated `Promise` arm that routes through
+   `class_chain(&p.class_name().resolve())` — the same registry-MRO
+   mechanism already used for `Instance`/`Package`, and for a user class
+   `is Array`/`is List`. This is what actually mattered for the roast
+   regression: the vendored real `Test.rakumod`'s `isa-ok` calls
+   `nqp::istype($var, $type.WHAT)` for a non-`Str` expected type, not `.isa`
+   directly, so this fix was required even though `.isa` alone (fix #1+#2)
+   already agreed with `.^name`.
+
+Closes `roast/S17-promise/basic.t`'s "subclasses create subclassed Promises"
+subtest under both the native and the real `Test` provider. Regression test:
+`t/promise-subclass-factory-methods.t` (green under `raku` too).

--- a/news/2026-08/punned-role-isa-and-smartmatch.md
+++ b/news/2026-08/punned-role-isa-and-smartmatch.md
@@ -1,0 +1,45 @@
+# A punned role's instance did not isa/smartmatch its pun
+
+`R.^pun` — the concrete class a role generates for its instances — is
+represented internally as `Mixin(Package(role_name), overrides)` (see
+`punned_role_type_object` in `methods_mixin_what_cache.rs`, ADR-0060). Three
+independent places that extract a "type name" from an isa/smartmatch argument
+enumerated `Package`/`Str`/`Instance` but had no case for a `Mixin`, so a pun
+used as the RHS silently fell through to a generic display-string comparison
+that could never match:
+
+```raku
+role R1 { }
+my $o = R1.new;
+say $o.isa(R1.^pun);   # was False, raku: True
+say $o ~~ R1.^pun;     # was False, raku: True
+```
+
+Note that `$o.isa(R1)` (the bare role, not its pun) is correctly `False` in
+both implementations — roles are excluded from nominal `.isa` checks — and
+that exclusion had to be *preserved* for the bare-role argument while being
+*skipped* for the pun, since both stringify to the same name "R1" but only
+the bare role is excluded in raku.
+
+Three fixes, all following the same pattern (unwrap the `Mixin` to its inner
+`Package`/`Instance`, then proceed with the existing name-based logic):
+
+- `Value::isa` (`src/runtime/methods_mixin_dispatch.rs`): added a `Mixin` arm
+  that unwraps to the inner name and skips the "roles are excluded" rule
+  (that rule now only fires when the argument is a bare `Package`, i.e. the
+  literal role, not its pun).
+- Smartmatch (`src/runtime/seq_helpers/smart_match.rs`): added a
+  `(_, ValueView::Mixin(pun_inner, pun_mixins))` arm (gated on a
+  `__mutsu_role__*` marker, i.e. only for a role pun) that recurses into
+  `smart_match_inner(left, pun_inner)`.
+- `nqp::istype` (`src/runtime/nqp_ops.rs`): its type-name extraction gained
+  the same `Mixin` unwrap. This mattered beyond the pun case itself: the
+  vendored real `Test.rakumod`'s `isa-ok` calls `nqp::istype($var,
+  $type.WHAT)` whenever its expected type isn't a `Str`, and a pun's own
+  `.WHAT` is *also* a `Mixin` (via the same ADR-0060 composition cache), so
+  `isa-ok $obj, R1.^pun, "..."` was False under `MUTSU_REAL_TEST=1` even
+  after the plain `.isa`/`~~` fixes above. This closed
+  `roast/S12-coercion/coercion-methods.t`'s "Roles" subtest under both the
+  native and the real `Test` provider.
+
+Regression test: `t/role-pun-isa-smartmatch.t` (green under `raku` too).

--- a/src/builtins/methods_0arg/mod.rs
+++ b/src/builtins/methods_0arg/mod.rs
@@ -652,6 +652,30 @@ pub(crate) fn native_method_0arg(
                 return Some(Ok(Value::str(rendered)));
             }
         }
+        // A type object (a bare `Package`, e.g. `Any but role Meows {...}`)
+        // names its own composed type in `.gist`/`.raku`/`.perl`, the same
+        // way a Set/Bag/Mix does just above — but unlike an INSTANCE (which
+        // reaches a composed-name-aware retargeting step further down the
+        // slow path, in `methods_call_dispatch.rs`, when this fast path
+        // returns `None`), a bare type object's `inner` here IS the terminal
+        // value (there's no user-class dispatch below it to fall through
+        // to), so without this arm it fell straight to `native_method_0arg
+        // (inner, ...)` at the bottom of this function and rendered the
+        // plain base type, silently dropping the mixin (`(Any but role
+        // Meows{}).gist` was `(Any)`, losing the `+{Meows}` that `.^name`
+        // already reports correctly via `what_type_name`).
+        if matches!(method, "raku" | "perl" | "gist")
+            && matches!(inner.view(), ValueView::Package(_))
+            && crate::value::role_mixin_suffix(mixins).is_some()
+        {
+            let composed = crate::value::what_type_name(target);
+            let rendered = if method == "gist" {
+                format!("({composed})")
+            } else {
+                composed
+            };
+            return Some(Ok(Value::str(rendered)));
+        }
         // `^name` on a role-mixed value is deliberately NOT fast-pathed here
         // (ADR-0060): a rename can live on the composition-keyed shared
         // `.WHAT` node instead of this instance's own `overrides` (e.g.

--- a/src/runtime/methods_collection_ops/socket_inet_proc.rs
+++ b/src/runtime/methods_collection_ops/socket_inet_proc.rs
@@ -497,6 +497,15 @@ impl Interpreter {
                     .class_mro(&name.resolve())
                     .contains(&crate::symbol::Symbol::intern("Promise"))
                 {
+                    // Keep the raw (possibly ADR-0047-mangled, e.g.
+                    // `Meows\u{0}<decl-id>` for a `my class`) internal storage
+                    // name here, consistent with how `ValueView::Instance`
+                    // stores its `class_name` — every internal comparison
+                    // (`class_mro`, `isa_check`, another `.isa(Meows)` whose
+                    // `Meows` argument resolves to the same mangled key) must
+                    // see the same representation on both sides. Only
+                    // *display* sites (`.^name`, `.WHAT`'s `Package` value)
+                    // strip the mangling, via `user_facing_type_name`.
                     Some(name.resolve())
                 } else {
                     None

--- a/src/runtime/methods_introspect.rs
+++ b/src/runtime/methods_introspect.rs
@@ -144,7 +144,14 @@ impl Interpreter {
             ValueView::Seq(_) => crate::runtime::value_type_name(target),
             ValueView::HyperSeq(_) => "HyperSeq",
             ValueView::RaceSeq(_) => "RaceSeq",
-            ValueView::Promise(_) => "Promise",
+            // A Promise carries its own (possibly subclassed, e.g. `class
+            // Meows is Promise {}`) class name, set at construction time by
+            // the factory methods (`promise_class_name` in
+            // `socket_inet_proc.rs`). `.WHAT`/`.WHAT.^name` must honour it,
+            // not hardcode the base "Promise".
+            ValueView::Promise(p) => {
+                return Ok(Value::package(p.class_name()));
+            }
             ValueView::Channel(_) => "Channel",
             ValueView::Whatever => "Whatever",
             ValueView::HyperWhatever => "HyperWhatever",
@@ -796,7 +803,14 @@ impl Interpreter {
                     None => crate::value::types::what_type_name(target),
                 }
             }
-            ValueView::Promise(p) => p.class_name().resolve(),
+            // `p.class_name()` is the raw internal storage name, which for a
+            // lexical Promise subclass (`my class Meows is Promise {}`)
+            // carries an ADR-0047 mangling suffix (`Meows\u{0}<decl-id>`),
+            // same as `ValueView::Instance`'s `class_name` above — strip it
+            // for display the same way.
+            ValueView::Promise(p) => {
+                crate::value::user_facing_type_name(&p.class_name().resolve()).to_string()
+            }
             ValueView::ParametricRole {
                 base_name,
                 type_args,

--- a/src/runtime/methods_mixin_dispatch.rs
+++ b/src/runtime/methods_mixin_dispatch.rs
@@ -454,16 +454,35 @@ impl Interpreter {
         }
         if method == "isa" && args.len() == 1 {
             let arg0 = args.first().cloned().unwrap_or(Value::NIL);
-            let target_name = match arg0.view() {
-                ValueView::Package(name) => name.resolve(),
-                ValueView::Str(name) => name.to_string(),
-                ValueView::Instance { class_name, .. } => class_name.resolve(),
-                _ => arg0.to_string_value(),
+            // `R.^pun` (a role's pun) is the concrete class the role
+            // generates for its instances, wrapped as `Mixin(Package(role),
+            // {__mutsu_role__role: ...})` (see `punned_role_type_object`).
+            // It stringifies the same as the bare role name, but unlike the
+            // bare role it IS a real class — `raku` accepts `.isa(R.^pun)`
+            // while rejecting `.isa(R)` (see "Roles are excluded" below).
+            // Unwrap it here so `target_name` resolves from the pun's inner
+            // Package/Instance, and skip the role-exclusion rule for it.
+            let (target_name, is_bare_role_arg) = match arg0.view() {
+                ValueView::Package(name) => (name.resolve(), true),
+                ValueView::Str(name) => (name.to_string(), false),
+                ValueView::Instance { class_name, .. } => (class_name.resolve(), false),
+                ValueView::Mixin(pun_inner, _) => {
+                    let name = match pun_inner.view() {
+                        ValueView::Package(name) => name.resolve(),
+                        ValueView::Instance { class_name, .. } => class_name.resolve(),
+                        _ => arg0.to_string_value(),
+                    };
+                    (name, false)
+                }
+                _ => (arg0.to_string_value(), false),
             };
-            // Roles are excluded from isa checks
-            let role_key = format!("__mutsu_role__{}", target_name);
-            if mixins.contains_key(&role_key) {
-                return Some(Ok(Value::FALSE));
+            // Roles are excluded from isa checks, but only when the argument
+            // is literally the bare role (a `Package`) — not its pun.
+            if is_bare_role_arg {
+                let role_key = format!("__mutsu_role__{}", target_name);
+                if mixins.contains_key(&role_key) {
+                    return Some(Ok(Value::FALSE));
+                }
             }
             // Delegate to inner value's isa check using class MRO
             let result = match inner.as_ref().view() {

--- a/src/runtime/nqp_ops.rs
+++ b/src/runtime/nqp_ops.rs
@@ -180,6 +180,19 @@ impl Interpreter {
                     // encoding (`nqp::istype($_, Nil)` on an array element bound
                     // to Nil via BIND-POS) hit exactly this gap, always False.
                     Some(ValueView::Nil) => "Nil".to_string(),
+                    // A role's pun (`R.^pun`) — and `R.^pun.WHAT`, which the
+                    // real `Test.rakumod`'s `isa-ok` calls when its expected
+                    // type isn't a `Str:D` (`nqp::istype($var, $type.WHAT)`)
+                    // — is a `Mixin`-wrapped `Package`/`Instance` (see
+                    // `punned_role_type_object`), not a bare `Package`.
+                    // Unwrap it so a pun used as a type argument here behaves
+                    // like the class it puns to, exactly as the `isa`/`~~`
+                    // fixes for the same shape do.
+                    Some(ValueView::Mixin(inner, _)) => match inner.view() {
+                        ValueView::Package(p) => p.resolve().to_string(),
+                        ValueView::Instance { class_name, .. } => class_name.resolve().to_string(),
+                        _ => String::new(),
+                    },
                     _ => String::new(),
                 };
                 Ok(bool_int(

--- a/src/runtime/receiver_class.rs
+++ b/src/runtime/receiver_class.rs
@@ -175,6 +175,20 @@ impl Interpreter {
             ValueView::Package(name) => self.class_chain(name.as_str()),
             ValueView::ParametricRole { base_name, .. } => self.class_chain(base_name.as_str()),
 
+            // A `Promise` carries its own (possibly subclassed, e.g. `class
+            // Meows is Promise {}`) class name (see `promise_class_name` in
+            // `socket_inet_proc.rs`). Route through `class_chain` the same
+            // way `Instance`/`Package` do above, so a subclass's chain is
+            // `[Meows, Promise, Any, Mu]` rather than the catch-all default
+            // below, which uses `value_type_name` -- hardcoded to the
+            // literal string "Promise" for every Promise value, subclassed
+            // or not, and so cannot see "Meows" at all. Without this arm,
+            // `nqp::istype($meows_promise, Meows)` (exactly what the real
+            // `Test.rakumod`'s `isa-ok` calls for a non-`Str` expected type)
+            // was False even though `.isa(Meows)` (a separate, Promise-aware
+            // code path in `Value::isa_check`) was already True.
+            ValueView::Promise(p) => self.class_chain(&p.class_name().resolve()),
+
             // Enum (V3): raku puts the enum type itself ahead of Int, unlike
             // `value_type_name`'s "Int" answer for every enum value.
             ValueView::Enum { enum_type, .. } => {

--- a/src/runtime/seq_helpers/smart_match.rs
+++ b/src/runtime/seq_helpers/smart_match.rs
@@ -1453,6 +1453,32 @@ impl Interpreter {
                     .zip(rhs_args.iter())
                     .all(|(lhs, rhs)| self.parametric_arg_subtypes(lhs, rhs))
             }
+            // `R.^pun` (a role's pun) is a `Mixin`-wrapped Package/Instance
+            // carrying an `__mutsu_role__*` marker (see
+            // `punned_role_type_object` in `methods_mixin_what_cache.rs`).
+            // Unwrap it and recurse so `$o ~~ R.^pun` matches exactly like
+            // `$o ~~ R` (the role it puns to) instead of falling through to
+            // the generic string-equality fallback below, which compares the
+            // Mixin's own `(R)`-style gist against the instance's stringification
+            // and can never match.
+            //
+            // EXCEPT when `left` is itself the bare role (the same
+            // `ParametricRoleGroupHOW` `Package` the pun was generated from):
+            // raku says `R ~~ R.^pun` is False even though `R.^pun ~~ R` and
+            // `$o ~~ R.^pun` (an instance) are both True -- the role group
+            // itself is not an instance/subtype of the `ClassHOW`-backed pun
+            // it generates (asymmetric, like normal isa: a supertype does not
+            // isa its subtype). Recursing with the unwrapped inner would
+            // compare `Package("R")` against `Package("R")` and wrongly
+            // report True by identity, so this case is excluded and falls
+            // through to the generic fallback below instead.
+            (_, ValueView::Mixin(pun_inner, pun_mixins))
+                if pun_mixins.keys().any(|k| k.starts_with("__mutsu_role__"))
+                    && !matches!(left.view(), ValueView::Package(name)
+                        if pun_mixins.contains_key(&format!("__mutsu_role__{}", name.resolve()))) =>
+            {
+                self.smart_match_inner(left, pun_inner.as_ref())
+            }
             // When RHS is a CustomType, use Raku type checking protocol
             (_, ValueView::CustomType(c)) => self.custom_type_check(left, c.id, &c.how),
             // When LHS is a CustomType (type object), check type cache or HOW.type_check

--- a/src/runtime/types/mod.rs
+++ b/src/runtime/types/mod.rs
@@ -118,6 +118,16 @@ pub(crate) fn value_is_defined(value: &Value) -> bool {
         // test the *inner* value, not the wrapper, so an undefined element still
         // triggers the `//` fallback even when it has been promoted to a cell.
         ValueView::ContainerRef(arc) => value_is_defined(&arc.lock().unwrap()),
+        // A role-mixed value (`but`/`does`) is only as defined as what it
+        // wraps: `Any but role {...}` is a type object (`:U`), while
+        // `Any.new but role {...}` is a concrete instance (`:D`) -- the
+        // mixin wrapper itself carries no definedness of its own. Without
+        // this arm, EVERY `Mixin` (including one wrapping an undefined
+        // `Package`) fell through to the `_ => true` default below and was
+        // reported as defined, which broke `:U`-constrained parameter
+        // binding for a role-mixed type object (`sub f(Mu:U $x) {...}`
+        // rejected `Any but role {...}` as "not a type object").
+        ValueView::Mixin(inner, _) => value_is_defined(inner),
         _ => true,
     }
 }

--- a/t/mixin-type-object-definedness.t
+++ b/t/mixin-type-object-definedness.t
@@ -1,0 +1,56 @@
+use v6;
+use Test;
+
+# A role-mixed value's definedness (`.defined`, and `:U`/`:D` signature
+# smileys) must follow what it wraps: `Any but role {...}` is a type object
+# (undefined, `:U`), while `Any.new but role {...}` is a concrete instance
+# (defined, `:D`) -- the mixin wrapper itself carries no definedness of its
+# own.
+#
+# Regression: `value_is_defined` had no `Mixin` arm, so EVERY mixin (whether
+# wrapping an undefined type-object `Package` or a defined `Instance`) fell
+# through to its `_ => true` default and was reported as defined. This broke
+# `:U`-constrained parameter binding for a role-mixed type object -- e.g. the
+# real Test.rakumod's `is(Mu $got, Mu:U $expected, ...)` multi candidate,
+# selected for an undefined `$expected`, could never bind a mixin type
+# object, so the WRONG `is` multi ran and mis-rendered its diagnostic. See
+# roast/6.c/S14-roles/mixin-6c.t tests 48-49, which only fail under
+# MUTSU_REAL_TEST=1 (the vendored real Test.rakumod), not the native
+# provider, since the native provider's `is` doesn't dispatch through this
+# multi/parameter-binding path at all.
+
+plan 8;
+
+my $type_obj = Any but role Meows { method Bool { True } };
+is $type_obj.defined, False, 'a mixin on a type object is still undefined';
+
+sub wants-undefined(Mu:U $x) { $x.^name }
+is wants-undefined($type_obj), 'Any+{Meows}',
+    'a :U-constrained parameter accepts a mixin type object';
+
+my $instance = Any.new but role Meows2 { method Bool { True } };
+is $instance.defined, True, 'a mixin on an instance is still defined';
+
+sub wants-defined(Mu:D $x) { $x.^name }
+is wants-defined($instance), 'Any+{Meows2}',
+    'a :D-constrained parameter accepts a mixin instance';
+
+# `//` and `orelse` must also see the mixin type object as "nothing here".
+my $fallback = $type_obj // 'fallback';
+is $fallback, 'fallback', '// falls through for an undefined mixin type object';
+
+my $kept = $instance // 'fallback';
+is $kept.^name, 'Any+{Meows2}', '// keeps a defined mixin instance';
+
+# A custom `method defined` override on the mixed-in role still wins over
+# the structural check (pre-existing behavior, pinned so it can't regress
+# alongside the structural fix above).
+my $forced-defined = Any but role Forced { method defined { True } };
+is $forced-defined.defined, True,
+    'a role-supplied .defined override on a type object mixin still wins';
+
+my $forced-undefined = Any.new but role ForcedU { method defined { False } };
+is $forced-undefined.defined, False,
+    'a role-supplied .defined override on an instance mixin still wins';
+
+done-testing;

--- a/t/mixin-type-object-gist.t
+++ b/t/mixin-type-object-gist.t
@@ -1,0 +1,43 @@
+use v6;
+use Test;
+
+# A role mixed onto a TYPE OBJECT (`Any but role Meows {...}`, as opposed to
+# an instance) must keep the mixin visible in `.gist`/`.raku`, not just
+# `.^name`. Regression: mutsu's `.^name` already correctly composed
+# "Any+{Meows}", but `.gist`/`.raku` dropped the mixin entirely and rendered
+# the bare base type ("(Any)"/"Any"), because the fast-path method dispatch
+# for a role-mixed value delegated straight to the wrapped `inner` Package
+# for `gist`/`raku`/`perl` without re-attaching the composed name -- a
+# special case already existed for Set/Bag/Mix inners, but not for a plain
+# type-object (`Package`) inner.
+#
+# See roast/6.c/S14-roles/mixin-6c.t tests 48-49 ("method/submethod Bool in
+# mixin is used"), whose assertions are `is $m || 42, $m` -- the real
+# Test.rakumod's `is` renders both sides via `.gist`, so mutsu's own
+# `.^name`-vs-`.gist` disagreement made the two sides of that `is` disagree
+# with each other.
+
+plan 8;
+
+my $type_obj = Any but role Meows { method Bool { True } };
+
+is $type_obj.^name, 'Any+{Meows}', 'type object .^name composes the mixin (was already correct)';
+is $type_obj.gist, '(Any+{Meows})', 'type object .gist composes the mixin too';
+is $type_obj.raku, 'Any+{Meows}', 'type object .raku composes the mixin too';
+
+# The instance case (a role mixed onto a defined value) was already correct
+# for .gist/.raku via a different code path -- pin it too so it can't
+# silently regress alongside the type-object fix above.
+my $instance = Any.new but role Meows2 { method Bool { True } };
+is $instance.^name, 'Any+{Meows2}', 'instance .^name composes the mixin';
+like $instance.gist, /^ 'Any+{Meows2}.new'/, 'instance .gist composes the mixin';
+like $instance.raku, /^ 'Any+{Meows2}.new'/, 'instance .raku composes the mixin';
+
+# A mixin on a builtin numeric/string type object still renders its own
+# (unrelated) fast path correctly -- exercise a second, differently-shaped
+# base to make sure the fix is general rather than Any-specific.
+my $int_type_obj = Int but role Purrs { };
+is $int_type_obj.^name, 'Int+{Purrs}', 'Int type object .^name composes the mixin';
+is $int_type_obj.gist, '(Int+{Purrs})', 'Int type object .gist composes the mixin';
+
+done-testing;

--- a/t/promise-subclass-factory-methods.t
+++ b/t/promise-subclass-factory-methods.t
@@ -1,0 +1,70 @@
+use v6;
+use Test;
+use nqp;
+
+# `Promise` factory/class methods (`.start`, `.in`, `.at`, `.anyof`, `.allof`,
+# `.then`) must respect the invocant when it is a user subclass of Promise
+# (`my class Meows is Promise {}`), the same way `.new` already did.
+#
+# Three independent bugs, all regressed here:
+#  - the factory methods baked in a plain "Promise" instead of threading the
+#    subclass name through (`.WHAT`/`.WHAT.^name` stayed "Promise");
+#  - the subclass name that WAS threaded through was the raw, ADR-0047-
+#    mangled internal storage key for a `my class` declaration
+#    (`Meows\u{0}<decl-id>`), not the clean user-facing "Meows" -- so
+#    `.^name` rendered a stray embedded NUL + decl-id ("Meows\09", visible in
+#    a terminal as "Meows" bleeding into whatever printed next), and
+#    `.isa(Meows)` was False because the mangled name baked into the Promise
+#    no longer matched the mangled name `Meows` (the argument) resolves to;
+#  - separately, `Interpreter::dispatch_mro`'s catch-all fallback for a
+#    `ValueView::Promise` used `value_type_name`, which is hardcoded to the
+#    literal string "Promise" for every Promise value regardless of
+#    subclass -- so `nqp::istype($meows_promise, Meows)` was False even
+#    after the first two fixes made `.isa(Meows)` (a separate, Promise-aware
+#    code path) True. This is exactly what the real Test.rakumod's
+#    `isa-ok` calls for a non-Str expected type
+#    (`nqp::istype($var, $type.WHAT)`), so it only surfaced under
+#    `MUTSU_REAL_TEST=1`, not the native Test provider.
+#
+# See roast/S17-promise/basic.t's "subclasses create subclassed Promises"
+# subtest.
+
+plan 17;
+
+my class Meows is Promise {};
+
+my $started = Meows.start({ 42 });
+is $started.^name, 'Meows', '.start returns an instance of the subclass (.^name)';
+is $started.WHAT.^name, 'Meows', '.start .WHAT.^name is the subclass';
+isa-ok $started, Meows, '.start isa-oks against the subclass';
+
+my $chained = $started.then({ 1 });
+is $chained.^name, 'Meows', '.then (while waiting) returns the subclass';
+
+await $started;
+my $chained2 = $started.then({ 1 });
+is $chained2.^name, 'Meows', '.then (already completed) returns the subclass';
+
+is Meows.in(1).^name, 'Meows', '.in returns the subclass';
+is Meows.at(now).^name, 'Meows', '.at returns the subclass';
+is Meows.anyof(start {}).^name, 'Meows', '.anyof returns the subclass';
+is Meows.allof(start {}).^name, 'Meows', '.allof returns the subclass';
+is Meows.new.^name, 'Meows', '.new (already worked) still returns the subclass';
+
+# A plain (non-subclassed) Promise is unaffected.
+my $plain = Promise.start({ 1 });
+is $plain.^name, 'Promise', 'a plain Promise.start still reports "Promise"';
+is $plain.WHAT.^name, 'Promise', 'a plain Promise.start.WHAT.^name is "Promise"';
+
+is Meows.start({1}).isa(Meows), True, '.start-produced instance isa(Meows)';
+is Meows.in(1).isa(Meows), True, '.in-produced instance isa(Meows)';
+is Meows.start({1}).isa(Promise), True, '.start-produced instance still isa(Promise)';
+
+# `nqp::istype` (what the real Test.rakumod's isa-ok actually calls for a
+# non-Str expected type) must agree with `.isa` -- see dispatch_mro above.
+is so(nqp::istype(Meows.start({1}), Meows)), True,
+    'nqp::istype(subclass-Promise, Meows) is True';
+is so(nqp::istype(Meows.start({1}), Meows.WHAT)), True,
+    'nqp::istype(subclass-Promise, Meows.WHAT) is True';
+
+done-testing;

--- a/t/role-pun-isa-smartmatch.t
+++ b/t/role-pun-isa-smartmatch.t
@@ -1,0 +1,58 @@
+use v6;
+use Test;
+use nqp;
+
+# A punned role's instance must `isa`/smartmatch its pun (the concrete class
+# the role generates for its instances, `R.^pun`), even though the bare role
+# itself is correctly excluded from `.isa` (roles are not nominal ancestors).
+#
+# Regression for a bug where `R.new.isa(R.^pun)` and `R.new ~~ R.^pun` were
+# both False in mutsu (raku: True) because `R.^pun` is represented internally
+# as a `Mixin`-wrapped `Package`, and the `isa`/smartmatch/`nqp::istype` code
+# paths that extract a type name from their argument did not know how to
+# unwrap a `Mixin` — they fell through to a generic string-fallback that
+# could never match. See roast/S12-coercion/coercion-methods.t (the "Roles"
+# subtest), which additionally exercises this through `Test.rakumod`'s real
+# `isa-ok`, which for a non-`Str` expected type calls
+# `nqp::istype($var, $type.WHAT)` rather than `.isa` directly.
+
+plan 12;
+
+role R1 { }
+
+my $o = R1.new;
+
+is $o.^name, 'R1', 'instance of a role reports the role name via .^name';
+is R1.^pun.^name, 'R1', "R.^pun's own .^name is the role name too";
+
+# The bare role itself is correctly excluded from nominal isa checks.
+is $o.isa(R1), False, '.isa(R1) (the bare role) is False -- roles are not nominal ancestors';
+
+# But the pun IS a real class, and isa/does/smartmatch against it must work.
+is $o.isa(R1.^pun), True, '.isa(R1.^pun) is True';
+is $o ~~ R1.^pun, True, '~~ R1.^pun is True';
+is $o ~~ R1, True, '~~ R1 (the bare role) is still True (unaffected by this fix)';
+
+# nqp::istype with a Mixin-wrapped type (a pun, or a pun's own .WHAT, which is
+# also a Mixin) must unwrap the same way -- this is exactly what the real
+# Test.rakumod's isa-ok does for a non-Str expected type.
+is so(nqp::istype($o, R1.^pun)), True, 'nqp::istype($o, R1.^pun) is True';
+is so(nqp::istype($o, R1.^pun.WHAT)), True, 'nqp::istype($o, R1.^pun.WHAT) is True';
+
+# A role with a required attribute and custom new/COERCE, matching the
+# exact shape in the roast regression.
+role R2 {
+    has Str:D $.attr is required;
+    multi method new(Int:D $n) { self.new(attr => $n.Str) }
+    multi method COERCE(Str:D $s) { R2.new(attr => $s) }
+}
+
+my $coerced = R2("hello");
+is $coerced.attr, 'hello', 'COERCE-based construction works';
+is $coerced.isa(R2.^pun), True, 'coerced instance isa its role pun';
+
+my $newed = R2(42);
+is $newed.attr, '42', 'Int-argument new() overload works';
+is $newed.isa(R2.^pun), True, 'new()-built instance isa its role pun too';
+
+done-testing;

--- a/todo/deep/vendor-real-test-module.md
+++ b/todo/deep/vendor-real-test-module.md
@@ -4857,3 +4857,92 @@ verdict) merely prevented the RIGHT value from ever being computed. Re-derive
 the root cause from a from-scratch, `use Test`-free repro every time, even
 when the roast test's own `throws-like` line makes the exception-object
 explanation look obvious.
+
+## 2026-08-28 — three type-identity divergences, all reproduce without `Test`
+
+Three files, all closed. Unusually for this campaign, each repro reduced to a
+plain one-liner with no `Test` involved — real language bugs the real
+module's `isa-ok`/`is` happened to gate. All three touch "what type is this
+value really" machinery (a `Mixin`-wrapped `Package`/`Instance` not being
+recognized where a bare one was, and `Promise`'s hardcoded type name), so
+they turned out to share more plumbing than expected, though each has a
+distinct root cause.
+
+**1. A punned role's instance did not `isa`/smartmatch its pun.** `R.^pun`
+(`Mixin(Package(role), overrides)`, ADR-0060) was invisible to three
+argument-side type-name extractors that enumerated `Package`/`Str`/`Instance`
+but not `Mixin`: `Value::isa` (`methods_mixin_dispatch.rs`), smartmatch
+(`seq_helpers/smart_match.rs`), and `nqp::istype` (`nqp_ops.rs`). The last one
+mattered most for the roast regression: the real `Test.rakumod`'s `isa-ok`
+calls `nqp::istype($var, $type.WHAT)` for a non-`Str` expected type, and a
+pun's own `.WHAT` is *also* a `Mixin`. Fixed all three to unwrap a `Mixin`
+argument to its inner `Package`/`Instance` name — for `isa`, only when the
+argument is NOT a bare `Package` (the literal role stays excluded from
+nominal isa checks, unchanged); for smartmatch, only when `left` is not
+itself the bare role Package the pun was generated from (`R ~~ R.^pun` is
+correctly `False` even though `R.^pun ~~ R` and `$o ~~ R.^pun` are both
+`True` — asymmetric, like ordinary isa). Full write-up:
+`news/2026-08/punned-role-isa-and-smartmatch.md`. Pin:
+`t/role-pun-isa-smartmatch.t` (green under `raku`).
+
+**2. `Promise` factory methods ignored the invocant subclass.**
+`.start`/`.in`/`.at`/`.anyof`/`.allof`/`.then` on `class Meows is Promise {}`
+built a plain `Promise`, and even after that was fixed, the subclass name
+reaching `.^name` carried a raw ADR-0047 lexical-mangling suffix (visible as
+a stray embedded NUL). Fixed by threading the (still internally mangled, for
+consistency with `Instance`) class name through `promise_class_name`
+(`methods_collection_ops/socket_inet_proc.rs`) and stripping it only at
+display time in `dispatch_caret_name`'s `Promise` arm
+(`methods_introspect.rs`), mirroring the `Instance`/`Package` arms beside it.
+A third, independent bug surfaced once the first two were fixed:
+`Interpreter::dispatch_mro`'s `Promise` fallback (`receiver_class.rs`) used
+`value_type_name`, hardcoded to the literal `"Promise"` for every Promise
+value — so `nqp::istype($meows_promise, Meows)` (again, what the real
+`isa-ok` actually calls) stayed `False` even after `.isa(Meows)` (a separate
+code path) agreed with `.^name`. Added a dedicated `Promise` arm routing
+through the existing `class_chain` registry-MRO mechanism. Full write-up:
+`news/2026-08/promise-subclass-factory-methods.md`. Pin:
+`t/promise-subclass-factory-methods.t` (green under `raku`).
+
+**3. A mixin on a type object was lost by `.gist`/`.raku`, and by `:U`
+parameter binding.** `.^name` on `Any but role Meows {...}` already composed
+correctly ("Any+{Meows}"), but `.gist`/`.raku` delegated straight to the bare
+inner `Package`, dropping the mixin ("(Any)") — the fast-path mixin method
+dispatch (`builtins/methods_0arg/mod.rs`) had a Set/Bag/Mix-inner special
+case for this but none for a plain type-object `Package` inner. Fixing that
+alone did not close the roast file under `MUTSU_REAL_TEST=1`: the real
+`Test.rakumod`'s `is(Mu $got, Mu:U $expected, ...)` multi (selected because
+the operand is undefined) could not even *bind* a mixin type object to its
+`Mu:U` parameter, because `value_is_defined` (`runtime/types/mod.rs`) had no
+`Mixin` arm and treated every mixin — instance or type object alike — as
+defined. Added `ValueView::Mixin(inner, _) => value_is_defined(inner)`,
+mirroring the existing `ContainerRef` arm. This second bug is general (a
+plain `sub f(Mu:U $x) {...}; f(Any but role {...})` failed to bind, nothing
+Test-specific), so it is a distinct root cause from the `.gist` fix, not a
+symptom of it. Full write-up:
+`news/2026-08/mixin-type-object-gist-and-definedness.md`. Pins:
+`t/mixin-type-object-gist.t`, `t/mixin-type-object-definedness.t` (both
+green under `raku`).
+
+**A regression caught by an existing pin, not roast**: the first
+`smart_match.rs` fix above initially recursed unconditionally on any `Mixin`
+RHS carrying a `__mutsu_role__*` marker, which flipped
+`t/role-pun-metamethod-identity.t` test 8 (`nok R ~~ R.^pun`, "the role
+itself does not smartmatch its own pun") to a false `True` — confirmed with
+`raku t/role-pun-metamethod-identity.t` (13/13 pass on `raku`, so the
+assertion was correct and the interpreter regressed). The asymmetry guard
+described above fixes it; all 13 assertions in that file pass again.
+
+### Measured, file by file (release build, `scripts/run-roast-test.sh`, both providers)
+
+| file | before (native) | after (native) | before (real) | after (real) |
+| --- | --- | --- | --- | --- |
+| `S12-coercion/coercion-methods.t` | PASS | PASS | 2 failures (Roles subtest, tests 2 &amp; 5) | **PASS** |
+| `S17-promise/basic.t` | PASS | PASS | 7 failures (subclasses subtest, all 7) | **PASS** |
+| `6.c/S14-roles/mixin-6c.t` | PASS | PASS | 2 failures (tests 48-49) | **PASS** |
+
+So: roast correctness regressions under the real provider closed for these
+three files; native-provider behavior unaffected (still PASS, and the
+`role-pun-metamethod-identity.t`/`promise-subclass-factory-methods.t`/
+`mixin-type-object-*.t` local pins cover the underlying language bugs
+directly, independent of either `Test` provider).


### PR DESCRIPTION
## Summary

Three independent type-identity bugs found while sweeping `MUTSU_REAL_TEST=1` roast regressions (`todo/deep/vendor-real-test-module.md`). All three reproduce from a plain one-liner with no `Test` module involved — real language bugs the real `Test.rakumod`'s `isa-ok`/`is` happened to gate.

1. **A punned role's instance did not `isa`/smartmatch its pun.** `R.^pun` is `Mixin(Package(role), overrides)`; three argument-side type-name extractors (`Value::isa`, smartmatch, `nqp::istype`) had no case for a `Mixin` and fell through to an unmatchable string comparison. Fixed all three to unwrap a `Mixin` argument — for `isa`, only when the argument is not a bare `Package` (the literal role stays excluded from nominal isa checks); for smartmatch, only when `left` is not itself the bare role Package the pun was generated from (`R ~~ R.^pun` stays False even though `R.^pun ~~ R` and `$o ~~ R.^pun` are both True — asymmetric, like ordinary isa).

2. **Promise factory methods (`.start`/`.in`/`.at`/`.anyof`/`.allof`/`.then`) ignored the invocant subclass.** Fixed `promise_class_name` to thread the (internally still mangled, for consistency with `Instance`) subclass name through, `dispatch_caret_name`'s `Promise` arm to strip the ADR-0047 mangling only at display time, and added a dedicated `Promise` arm to `dispatch_mro` (previously fell back to `value_type_name`, hardcoded to `"Promise"`) so `nqp::istype` agrees with `.isa`/`.^name`.

3. **A mixin on a type object was lost by `.gist`/`.raku`.** `Any but role Meows {...}` gisted as `(Any)`, not `(Any+{Meows})`, because the fast-path mixin dispatch had a Set/Bag/Mix-inner special case but none for a plain `Package` inner. Separately, `value_is_defined` had no `Mixin` arm at all, so every mixin — type object or instance alike — was reported as defined, breaking `:U`-constrained parameter binding for a role-mixed type object (a plain `sub f(Mu:U $x) {...}` bug, not Test-specific).

Closes `roast/S12-coercion/coercion-methods.t`, `roast/S17-promise/basic.t`, and `roast/6.c/S14-roles/mixin-6c.t` under `MUTSU_REAL_TEST=1`; all three already passed under the native `Test` provider and still do.

A regression in the first (`smart_match.rs`) fix was caught by an existing pin, `t/role-pun-metamethod-identity.t` (test 8, `nok R ~~ R.^pun`) — confirmed with `raku` that the assertion was correct — and fixed by the asymmetry guard described above.

## Test plan

- [x] `make test` — 3537 files / 35460 tests, all pass
- [x] `cargo fmt --check` / `cargo clippy -- -D warnings` — clean
- [x] Targeted native-provider roast sweep (`S12-*`, `S14-*`, `S17-*`, `S02-types`, `S13-*`, `6.c/*`, `integration`, 439 files) — all pass, both debug and release binaries
- [x] All three named roast files verified before/after under both `Test` providers (see `todo/deep/vendor-real-test-module.md`'s 2026-08-28 entry)
- [x] `./scripts/battery-testsuite.sh` (release build) — GATE PASSED, 273/297 test files pass (2 excluded), matching the existing baseline
- [x] New pins (`t/role-pun-isa-smartmatch.t`, `t/promise-subclass-factory-methods.t`, `t/mixin-type-object-gist.t`, `t/mixin-type-object-definedness.t`) all green under `raku` too
- [x] Pre-existing pin `t/role-pun-metamethod-identity.t` (13/13) still green after the asymmetry-guard fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)