### PR TITLE
fix(vm): `$/` and the capture variables are routine-scoped, like `$!`

### DIFF
--- a/news/2026-08/match-vars-are-routine-scoped.md
+++ b/news/2026-08/match-vars-are-routine-scoped.md
@@ -1,0 +1,73 @@
+# `$/` and the capture variables are scoped per routine, like `$!`
+
+Three whitelisted roast files regressed under `MUTSU_REAL_TEST=1` for one
+reason: a routine that performed a regex match internally overwrote its
+**caller's** `$/`, `$0` and `$1`. In Raku those are implicitly `my`-declared in
+every routine, exactly like `$!`, so the caller's values must survive the call.
+
+## The repro has nothing to do with `Test`
+
+```raku
+sub inner() { "zz" ~~ /(z)/; 1 }
+"abc" ~~ /(b)(c)/;
+say ~$/, ' ', ~$0;    # bc b
+inner();
+say ~$/, ' ', ~$0;    # was `z z`, must stay `bc b`
+```
+
+## Why only the real `Test` provider saw it
+
+mutsu's native `Test` is Rust and never runs Raku-level code between two
+statements of a test file. The vendored `Test.rakumod` does — and on a
+**failing** assertion it runs a good deal more of it, because rendering the
+diagnostics (`# expected: …` / `# got: …`, and `diag`'s indentation, which
+splits and re-joins on newlines) matches internally. So the pattern that broke
+was always the same shape: an assertion fails, and the *next* statement in the
+test file reads a `$/` that the failure's own diagnostics had clobbered.
+
+```
+ok 1 - matched
+not ok 2 - first entry (deliberately failing)
+Use of Nil in string context      <-- the next statement's $/[1] is gone
+not ok 3 - second entry
+```
+
+That is why all three files had a `#?rakudo todo`-marked failing assertion
+immediately before the assertion that actually regressed:
+`S05-modifier/repetition-exhaustive.t` reads `$/[1]` after `$/[0]`,
+`S05-modifier/pos.t` reads `$/.to` after an interpolation test that rakudo also
+fails, and `S05-metachars/closure.t` reads `$0` after a `make`-inside-a-closure
+test that is likewise TODO-marked.
+
+## The fix
+
+`runtime::utils::is_routine_scoped_error_var` — the predicate every return-side
+env merge consults to decide which magic names must *not* be copied from callee
+to caller — knew only about `$!`. It is now
+`is_routine_scoped_implicit_var` and covers `$/` as well, plus the capture
+variables that are views into it: mutsu stores `$0`, `$1`, … under the env keys
+`0`, `1`, … and `$<name>` under `<name>`, so scoping `$/` alone left the caller
+with the right `$/` and the wrong `$0`.
+
+The predicate is applied only where the callee is a routine
+(`cf.code.is_routine`). A bare block deliberately keeps sharing its enclosing
+routine's `$/` and `$!` — `if $x ~~ /y/ { }` must leave `$/` visible after the
+`if`, and a `CATCH` block writes `$!` in the routine that owns it — so extending
+this to blocks would break `try`/`CATCH` and ordinary conditional matches. The
+pin asserts both directions.
+
+## Two neighbouring gaps split off rather than folded in
+
+Both were verified to predate this change (by reverting the predicate to its old
+body and rebuilding), and neither is gated by any roast file in the current
+residue:
+
+- A routine's named-capture reset *removes* the caller's `$<name>` slot rather
+  than shadowing it, so the merge has nothing to skip —
+  `todo/tickets/named-capture-reset-removes-the-callers-slot.md`.
+- A block invoked through a `&`-parameter from inside another routine does not
+  publish its match to the scope the block was written in —
+  `todo/tickets/a-blocks-match-does-not-reach-its-defining-scope-through-a-callable.md`.
+
+Pin: `t/match-vars-are-routine-scoped.t` (14 assertions, green under real `raku`
+as well as mutsu).

--- a/src/runtime/utils.rs
+++ b/src/runtime/utils.rs
@@ -80,17 +80,43 @@ pub(crate) fn is_index_rw_call_temp(name: &str) -> bool {
     name.starts_with("__mutsu_index_rw_") || name.starts_with("__mutsu_call_result_")
 }
 
-/// True for `$!`'s env key. `$!` is scoped **per routine** in raku: a sub or
-/// method gets a fresh `Nil` on entry (which every routine-entry path already
-/// does) and the CALLER's value must survive the call — so the return-side env
-/// merge has to treat `!` like the other per-routine magic names (`_`, `@_`,
-/// `%_`, `__mutsu_callable_id`) and never copy the callee's back.
+/// True for the env keys of `$!` and `$/`. Both are scoped **per routine** in
+/// raku — every sub and method gets its own implicit `my $!` / `my $/` — so the
+/// CALLER's value must survive the call, and the return-side env merge has to
+/// treat them like the other per-routine magic names (`_`, `@_`, `%_`,
+/// `__mutsu_callable_id`) and never copy the callee's back.
+///
+/// `$/` was missing here, which is why a routine that matched internally
+/// clobbered its caller's match:
+///
+/// ```raku
+/// sub inner() { "zz" ~~ /(z)/; 1 }
+/// "abc" ~~ /(b)(c)/;   say ~$/;   # bc
+/// inner();             say ~$/;   # was `z`, must stay `bc`
+/// ```
+///
+/// The real `Test.rakumod` hits this on every FAILING assertion (its diagnostic
+/// rendering matches internally), so the next statement in the test file read a
+/// clobbered `$/` — invisible to the native Rust provider, which never runs
+/// Raku-level code.
 ///
 /// Deliberately NOT applied on the block/closure path: a bare block shares its
-/// enclosing routine's `$!`, and a `CATCH` block *writes* it there, so skipping
-/// the merge for blocks would break `try`/`CATCH`.
-pub(crate) fn is_routine_scoped_error_var(name: &str) -> bool {
-    name == "!"
+/// enclosing routine's `$!` and `$/` — a `CATCH` block *writes* `$!` there, and
+/// `if $x ~~ /y/ { }` must leave `$/` visible to the enclosing scope — so
+/// skipping the merge for blocks would break `try`/`CATCH` and ordinary
+/// conditional matches.
+pub(crate) fn is_routine_scoped_implicit_var(name: &str) -> bool {
+    match name {
+        "!" | "/" => true,
+        // The capture variables are views into `$/` and mutsu stores them in
+        // their own env slots (`0`, `1`, ... for `$0`/`$1`, `<name>` for
+        // `$<name>`), so they have to be scoped exactly like the `$/` they
+        // belong to or the caller keeps `$/` and loses `$0`.
+        _ => {
+            let digits = !name.is_empty() && name.bytes().all(|b| b.is_ascii_digit());
+            digits || (name.starts_with('<') && name.ends_with('>'))
+        }
+    }
 }
 
 /// Build the `Failure` value raku yields when a count/numeric coercion is

--- a/src/vm/vm_call_fast.rs
+++ b/src/vm/vm_call_fast.rs
@@ -297,7 +297,7 @@ impl Interpreter {
                     || *k == "%_"
                     || *k == "__mutsu_callable_id"
                     || (bang_is_callee_private
-                        && k.with_str(crate::runtime::utils::is_routine_scoped_error_var))
+                        && k.with_str(crate::runtime::utils::is_routine_scoped_implicit_var))
                 {
                     continue;
                 }
@@ -314,7 +314,7 @@ impl Interpreter {
                 let mut restored_env = saved_env;
                 for (k, v) in self.env().iter() {
                     if bang_is_callee_private
-                        && k.with_str(crate::runtime::utils::is_routine_scoped_error_var)
+                        && k.with_str(crate::runtime::utils::is_routine_scoped_implicit_var)
                     {
                         continue;
                     }

--- a/src/vm/vm_call_light.rs
+++ b/src/vm/vm_call_light.rs
@@ -574,7 +574,7 @@ impl Interpreter {
                         || *k == "__mutsu_callable_id"
                         || k.with_str(|s| s.starts_with('?'))
                         || (bang_is_callee_private
-                            && k.with_str(crate::runtime::utils::is_routine_scoped_error_var))
+                            && k.with_str(crate::runtime::utils::is_routine_scoped_implicit_var))
                     {
                         continue;
                     }
@@ -605,7 +605,9 @@ impl Interpreter {
                             || *k == "__mutsu_callable_id"
                             || k.with_str(|s| s.starts_with('?'))
                             || (bang_is_callee_private
-                                && k.with_str(crate::runtime::utils::is_routine_scoped_error_var))
+                                && k.with_str(
+                                    crate::runtime::utils::is_routine_scoped_implicit_var,
+                                ))
                             || cf.is_callee_local_sym(*k)
                             || cf.code.my_declared_enum_sym.contains(k))
                     });

--- a/src/vm/vm_call_light_typed.rs
+++ b/src/vm/vm_call_light_typed.rs
@@ -723,7 +723,7 @@ impl Interpreter {
                         || *k == "__mutsu_callable_id"
                         || k.with_str(|s| s.starts_with('?'))
                         || (bang_is_callee_private
-                            && k.with_str(crate::runtime::utils::is_routine_scoped_error_var))
+                            && k.with_str(crate::runtime::utils::is_routine_scoped_implicit_var))
                     {
                         continue;
                     }
@@ -748,7 +748,9 @@ impl Interpreter {
                             || *k == "__mutsu_callable_id"
                             || k.with_str(|s| s.starts_with('?'))
                             || (bang_is_callee_private
-                                && k.with_str(crate::runtime::utils::is_routine_scoped_error_var))
+                                && k.with_str(
+                                    crate::runtime::utils::is_routine_scoped_implicit_var,
+                                ))
                             || cf.is_callee_local_sym(*k))
                     });
                 }

--- a/src/vm/vm_call_named_inner.rs
+++ b/src/vm/vm_call_named_inner.rs
@@ -683,7 +683,7 @@ impl Interpreter {
                     continue;
                 }
                 if bang_is_callee_private
-                    && k.with_str(crate::runtime::utils::is_routine_scoped_error_var)
+                    && k.with_str(crate::runtime::utils::is_routine_scoped_implicit_var)
                 {
                     continue;
                 }
@@ -726,7 +726,7 @@ impl Interpreter {
                         || s == "%_"
                         // `$!` is per-routine; see the merge loop above.
                         || (bang_is_callee_private
-                            && crate::runtime::utils::is_routine_scoped_error_var(s))
+                            && crate::runtime::utils::is_routine_scoped_implicit_var(s))
                         || rw_sources.contains(s)
                         // Compiler-internal bookkeeping symbols (e.g. the
                         // `__mutsu_sigilless_readonly::p` marker emitted for a

--- a/src/vm/vm_method_dispatch.rs
+++ b/src/vm/vm_method_dispatch.rs
@@ -2249,7 +2249,7 @@ fn merge_method_env(
                     // `$!` is scoped per routine: the method frame reset it to
                     // Nil on entry, so merging it back would wipe the caller's
                     // error variable (`$!.message; $!.rc` must both see it).
-                    || crate::runtime::utils::is_routine_scoped_error_var(s)
+                    || crate::runtime::utils::is_routine_scoped_implicit_var(s)
                     // Per-frame non-local-return target marker: writing the
                     // callee's id back would retarget blocks the caller creates
                     // afterwards (a later closure's `return` then escapes its

--- a/t/match-vars-are-routine-scoped.t
+++ b/t/match-vars-are-routine-scoped.t
@@ -1,0 +1,70 @@
+use Test;
+
+# `$/` — and the capture variables `$0`, `$1`, `$<name>` that are views into it
+# — are implicitly `my`-declared in every routine, exactly like `$!`. A routine
+# that matches internally therefore must NOT clobber its caller's match. A bare
+# block is the opposite case: it shares its enclosing routine's `$/`, so a match
+# inside `if`/`for`/`{ }` must stay visible to the enclosing scope.
+
+plan 14;
+
+sub inner-match() { "zz" ~~ /(z)/; 1 }
+method-holder-check();
+
+"abc" ~~ /(b)(c)/;
+is ~$/,  'bc', 'baseline $/';
+is ~$0,  'b',  'baseline $0';
+is ~$1,  'c',  'baseline $1';
+
+inner-match();
+is ~$/,  'bc', 'a sub that matches internally does not clobber the caller $/';
+is ~$0,  'b',  '... nor the caller $0';
+is ~$1,  'c',  '... nor the caller $1';
+
+# A named capture's own slot survives a routine call that has no named
+# captures of its own. (The stronger assertion -- that a routine which RESETS
+# named captures does not delete the caller's -- fails for an unrelated reason
+# and is tracked in todo/tickets/named-capture-reset-removes-the-callers-slot.md.)
+"abc" ~~ /$<first>=(b)(c)/;
+is ~$<first>, 'b', 'baseline $<first>';
+
+# A method is a routine too.
+class Matcher { method m() { "yy" ~~ /(y)/; 1 } }
+"abc" ~~ /(b)(c)/;
+Matcher.new.m();
+is ~$/, 'bc', 'a method that matches internally does not clobber the caller $/';
+is ~$0, 'b',  '... nor the caller $0';
+
+# A Callable invoked through another routine is still a routine boundary for
+# the routine, and the block itself is not.
+# (A BLOCK invoked through a routine should publish its match to the scope the
+# block was written in; mutsu does not yet -- see
+# todo/tickets/a-blocks-match-does-not-reach-its-defining-scope-through-a-callable.md.)
+sub call-it(&c) { c() }
+"abc" ~~ /(b)(c)/;
+call-it(&inner-match);
+is ~$/, 'bc', 'a SUB invoked through a Callable still keeps its match private';
+
+# The converse the routine gate must preserve: a bare block writes the
+# enclosing routine's `$/`, and so does a conditional.
+sub block-writes-mine() {
+    "abc" ~~ /(b)(c)/;
+    { "yy" ~~ /(y)/ }
+    ~$/;
+}
+is block-writes-mine(), 'y', 'a bare block writes its enclosing routine $/';
+
+sub if-writes-mine() {
+    if "abc" ~~ /(b)(c)/ { }
+    ~$/;
+}
+is if-writes-mine(), 'bc', 'an `if` condition match is visible after the `if`';
+
+# `$!` keeps working the same way (it shares the mechanism).
+sub dies-inside() { try { die "boom" }; 1 }
+try { die "outer" };
+dies-inside();
+is $!.message, 'outer', 'a sub that catches internally does not clobber the caller $!';
+
+sub method-holder-check() { True }
+is method-holder-check(), True, 'sanity';

--- a/todo/deep/vendor-real-test-module.md
+++ b/todo/deep/vendor-real-test-module.md
@@ -5071,3 +5071,60 @@ Also re-swept the full whitelisted `S12-*`, `S02-*`, `S10-packages`,
 `S11-modules`, `S14-*`, `S32-exceptions`, and `integration` directories (407
 files) under the native provider with the fix applied — all still PASS, so
 the `PushLastRegisteredClass` change is not a native-provider regression.
+
+## 2026-08-29: `$/` and the capture variables are routine-scoped, like `$!` (`S05-modifier/pos.t`, `S05-modifier/repetition-exhaustive.t`, `S05-metachars/closure.t`)
+
+Three whitelisted files, one root cause. A routine that performed a regex match
+internally overwrote its **caller's** `$/`, `$0` and `$1`. In Raku those are
+implicitly `my`-declared in every routine, exactly like `$!`.
+
+The reason this is a real-`Test`-only regression is worth recording, because it
+explains the shape of all three files. mutsu's native `Test` is Rust and runs no
+Raku-level code between two statements of a test file. The vendored
+`Test.rakumod` does — and on a **failing** assertion it runs a good deal more of
+it, because rendering the diagnostics (`# expected:` / `# got:`, and `diag`'s
+indentation, which splits and re-joins on newlines) matches internally. So each
+of the three files has a `#?rakudo todo`-marked *failing* assertion immediately
+before the assertion that regressed, and the failure's own diagnostics clobbered
+the `$/` the next statement reads:
+
+```
+ok 1 - matched
+not ok 2 - first entry (deliberately failing)
+Use of Nil in string context      <-- the next statement's $/[1] is gone
+not ok 3 - second entry
+```
+
+`runtime::utils::is_routine_scoped_error_var` — the predicate every return-side
+env merge consults for names that must NOT be copied callee->caller — knew only
+about `$!`. It is now `is_routine_scoped_implicit_var` and covers `$/` plus the
+capture variables that are views into it (`0`, `1`, ... and `<name>` env keys);
+scoping `$/` alone left the caller with the right `$/` and the wrong `$0`. It
+stays gated on `cf.code.is_routine`, so a bare block still shares its enclosing
+routine's `$/` and `$!`.
+
+| file | real Test before | after | native before | after |
+| --- | --- | --- | --- | --- |
+| `S05-modifier/pos.t` | 1 failure (#12) | **PASS** | PASS | PASS |
+| `S05-modifier/repetition-exhaustive.t` | 1 failure (#3) | **PASS** | PASS | PASS |
+| `S05-metachars/closure.t` | 1 failure (#12) | **PASS** | PASS | PASS |
+
+Fix and pin: `news/2026-08/match-vars-are-routine-scoped.md`,
+`t/match-vars-are-routine-scoped.t` (14 assertions, green under real `raku`).
+Verification: `make test` green (3540 files, 35494 tests); a 1162-file targeted
+native-provider roast sweep (`S02-*`, `S03-*`, `S04-*`, `S05-*`, `S06-*`,
+`S07-*`, `S12-*`, `S17-*`, `S24-*`, `S32-*`, `6.*`, `integration`) PASS
+(119011 tests); `scripts/battery-testsuite.sh` GATE PASSED (273/297).
+
+Two neighbouring gaps the pin surfaced were split off rather than folded in.
+Both were verified to predate this change by reverting the predicate to its old
+body and rebuilding, and neither is gated by any roast file in the residue:
+`todo/tickets/named-capture-reset-removes-the-callers-slot.md` (a routine's
+named-capture reset *removes* the caller's `$<name>` slot, so the merge has
+nothing to skip) and
+`todo/tickets/a-blocks-match-does-not-reach-its-defining-scope-through-a-callable.md`
+(a block invoked through a `&`-parameter does not publish its match to the scope
+it was written in).
+
+Per the counting note above, this closes **three** named files; re-measure the
+sweep rather than trusting a running total.

--- a/todo/tickets/a-blocks-match-does-not-reach-its-defining-scope-through-a-callable.md
+++ b/todo/tickets/a-blocks-match-does-not-reach-its-defining-scope-through-a-callable.md
@@ -1,0 +1,44 @@
+# A block's match does not reach its defining scope when a routine invokes it
+
+A bare block shares its enclosing routine's `$/` — it is not a routine, so it
+has no implicit `my $/` of its own. That stays true when the block is passed to
+another routine and invoked there: the block was *written* in the caller's
+scope, so the match it performs must be visible in that scope afterwards.
+
+## Minimal repro
+
+```raku
+sub call-it(&c) { c() }
+"abc" ~~ /(b)(c)/;
+call-it({ "yy" ~~ /(y)/ });
+say ~$/;      # mutsu: bc     rakudo: y
+```
+
+Directly inlined, mutsu gets it right — `{ "yy" ~~ /(y)/ }` at the mainline, or
+inside the same routine, does publish to the enclosing scope (pinned by
+`t/match-vars-are-routine-scoped.t`, "a bare block writes its enclosing routine
+$/"). It is specifically the round trip through a `&`-parameter and a call from
+inside another routine that loses it.
+
+## Not caused by the routine-scoping fix
+
+Verified by reverting `runtime::utils::is_routine_scoped_implicit_var` to its
+pre-fix body (`name == "!"`) and rebuilding: the assertion fails identically, so
+this predates `news/2026-08/match-vars-are-routine-scoped.md`. The routine-side
+exclusions are gated on `cf.code.is_routine`, which is false for a block, so
+they are not what drops the write.
+
+## Where to look
+
+The closure invocation path (`Interpreter::call_compiled_closure` /
+`call_compiled_closure_with_topic` in `src/vm/vm_closure_dispatch.rs`) and how
+its env is merged back. The block runs with the invoking routine's env in place,
+so its `$/` write most likely lands in that routine's frame and is discarded
+with it, instead of reaching the env the closure captured.
+
+## Why it matters beyond `$/`
+
+Any implicit write a block makes to a variable of its *defining* scope has the
+same question mark over it when the block is invoked from another routine. `$/`
+is simply the case with a crisp rakudo-verified expectation. No roast file in
+the current `MUTSU_REAL_TEST=1` residue gates it.

--- a/todo/tickets/named-capture-reset-removes-the-callers-slot.md
+++ b/todo/tickets/named-capture-reset-removes-the-callers-slot.md
@@ -1,0 +1,60 @@
+# A routine's named-capture reset deletes the CALLER's `$<name>` slot
+
+`$/` and the numeric capture variables are now scoped per routine
+(`runtime::utils::is_routine_scoped_implicit_var`, see
+`news/2026-08/match-vars-are-routine-scoped.md`), so a routine that matches
+internally no longer clobbers its caller's `$/`, `$0` or `$1`. A **named**
+capture still leaks, and it leaks by *deletion* rather than by overwrite.
+
+## Minimal repro
+
+```raku
+sub inner-match() { "zz" ~~ /(z)/; 1 }
+"abc" ~~ /$<first>=(b)(c)/;
+say ~$<first>;      # b
+inner-match();
+say ~$<first>;      # mutsu: '' (empty)   rakudo: b
+```
+
+`inner-match` has no named captures of its own, so nothing should touch
+`$<first>` at all.
+
+## Root cause (as far as diagnosed — verify before trusting it)
+
+`Interpreter::reset_capture_env_vars`
+(`src/runtime/seq_helpers/regex_captures.rs`) clears stale capture slots before
+each match. Numeric slots are *set to `Nil`*, but angle-bracket slots are
+**removed**:
+
+```rust
+for key in angle_keys {
+    self.env.remove_sym(key);
+}
+```
+
+The doc comment above it explains why removal rather than Nil-ing is
+load-bearing there (a present-but-`Nil` entry would shadow the local-slot `$/`
+fallback that action methods rely on — pinned by `t/capture-var-topic-slot.t`).
+
+The return-side env merges skip keys listed by
+`is_routine_scoped_implicit_var`, which already covers `<name>`. That handles a
+callee *writing* the slot. It does not handle a callee *removing* it: the
+removal appears to reach the caller's base env directly rather than being
+confined to the callee's overlay, so there is nothing left for the merge to
+skip.
+
+## Why it is not a one-liner
+
+Making removal overlay-scoped is env-representation work (a tombstone in the
+overlay that the merge can then discard), and the `t/capture-var-topic-slot.t`
+constraint means the removal cannot simply become a `Nil` write. Both the
+scoped-overlay path (`finish_light_env` and friends) and the
+copy-and-restore paths would need to agree on the tombstone.
+
+## Where it shows up
+
+`t/match-vars-are-routine-scoped.t` documents the gap in a comment and asserts
+only the baseline. No roast file in the current `MUTSU_REAL_TEST=1` residue
+gates it — the three files that motivated the routine-scoping fix
+(`S05-modifier/pos.t`, `S05-modifier/repetition-exhaustive.t`,
+`S05-metachars/closure.t`) all use numeric captures.


### PR DESCRIPTION
Three whitelisted roast files regressed under `MUTSU_REAL_TEST=1` (the vendored upstream `Test.rakumod`) for one reason: a routine that performed a regex match internally overwrote its **caller's** `$/`, `$0` and `$1`. In Raku those are implicitly `my`-declared in every routine, exactly like `$!`, so the caller's values must survive the call.

## The repro needs no `Test` at all

```raku
sub inner() { "zz" ~~ /(z)/; 1 }
"abc" ~~ /(b)(c)/;
say ~$/, ' ', ~$0;    # bc b
inner();
say ~$/, ' ', ~$0;    # was `z z`, must stay `bc b`
```

## Why only the real `Test` provider sees it — and why all three files have the same shape

mutsu's native `Test` is Rust and runs no Raku-level code between two statements of a test file. The vendored `Test.rakumod` does — and on a **failing** assertion it runs a good deal more of it, because rendering the diagnostics (`# expected:` / `# got:`, and `diag`'s indentation, which splits and re-joins on newlines) matches internally. So each of the three files has a `#?rakudo todo`-marked *failing* assertion immediately before the assertion that regressed, and that failure's own diagnostics clobbered the `$/` the next statement reads:

```
ok 1 - matched
not ok 2 - first entry (deliberately failing)
Use of Nil in string context      <-- the next statement's $/[1] is gone
not ok 3 - second entry
```

## The fix

`runtime::utils::is_routine_scoped_error_var` — the predicate every return-side env merge consults to decide which magic names must **not** be copied from callee to caller — knew only about `$!`. It is now `is_routine_scoped_implicit_var` and covers `$/` as well, plus the capture variables that are views into it: mutsu stores `$0`, `$1`, … under the env keys `0`, `1`, … and `$<name>` under `<name>`, so scoping `$/` alone left the caller with the right `$/` and the wrong `$0`.

It stays gated on `cf.code.is_routine`. A bare block deliberately keeps sharing its enclosing routine's `$/` and `$!` — `if $x ~~ /y/ { }` must leave `$/` visible after the `if`, and a `CATCH` block writes `$!` in the routine that owns it — so extending this to blocks would break `try`/`CATCH` and ordinary conditional matches. The pin asserts both directions.

## Verification

| file | real Test before | after | native before | after |
| --- | --- | --- | --- | --- |
| `S05-modifier/pos.t` | 1 failure (#12) | **PASS** | PASS | PASS |
| `S05-modifier/repetition-exhaustive.t` | 1 failure (#3) | **PASS** | PASS | PASS |
| `S05-metachars/closure.t` | 1 failure (#12) | **PASS** | PASS | PASS |

- `make test` green: 3540 files, 35494 tests.
- Targeted native-provider roast sweep, 1162 files / 119011 tests (`S02-*`, `S03-*`, `S04-*`, `S05-*`, `S06-*`, `S07-*`, `S12-*`, `S17-*`, `S24-*`, `S32-*`, `6.*`, `integration`): PASS.
- `./scripts/battery-testsuite.sh`: **GATE PASSED** (273/297).
- Pin: `t/match-vars-are-routine-scoped.t`, 14 assertions, green under real `raku` as well as mutsu.

## Two neighbouring gaps split off rather than folded in

Both were verified to **predate** this change — by reverting the predicate to its old body (`name == "!"`), rebuilding, and confirming the same two assertions fail identically — and neither is gated by any roast file in the current residue:

- `todo/tickets/named-capture-reset-removes-the-callers-slot.md` — a routine's named-capture reset *removes* the caller's `$<name>` slot rather than shadowing it, so the merge has nothing to skip.
- `todo/tickets/a-blocks-match-does-not-reach-its-defining-scope-through-a-callable.md` — a block invoked through a `&`-parameter from inside another routine does not publish its match to the scope the block was written in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)