### PR TITLE
fix(vm): a class-decl expression pushes the type object, not a name lookup

### DIFF
--- a/news/2026-08/class-decl-expr-is-not-a-name-lookup.md
+++ b/news/2026-08/class-decl-expr-is-not-a-name-lookup.md
@@ -1,0 +1,61 @@
+# A class declaration used as an expression no longer does a name lookup
+
+`(class A { ... })` in expression position used to compile to "register the
+class, then resolve the bareword `A`" — a plain `GetBareWord` lookup of the
+declaration's own source name. That is wrong in general: a class declaration
+used as an expression must evaluate to the type object the declaration just
+created, full stop, regardless of what else happens to be registered under
+the same bare name elsewhere.
+
+The bug surfaced as `roast/S12-class/attributes.t` test 23 failing under
+`MUTSU_REAL_TEST=1` (real vendored `Test.rakumod`): `eval-lives-ok
+'(class A { has $.x }).new.x.HOW'` died with `No such method 'x' for
+invocant of type 'A'`. `Test.rakumod`'s `eval-lives-ok` runs the code through
+a plain `EVAL` call inside `sub eval_exception`, a routine defined in a
+*different* compilation unit (a different module) than the test file — and
+that routine's package (not the caller's) is what `class A` gets registered
+under, exactly like `module M { class A { ... } }` registers `M::A`. The
+freshly-declared class was therefore a genuinely distinct registry entry
+(`Test::A`, in the real case) from any earlier, unrelated `A` the caller's
+own script had declared — but the expression's own bareword lookup still
+just asked "what does the name `A` resolve to right now", found the
+CALLER's pre-existing `A` first (a direct bare-name hit wins over a
+package-qualified one in `resolve_bareword_type_name`), and returned that
+instead.
+
+Crucially, no `EVAL` is required to hit this: any `class A { ... }` used as
+an expression inside a nested `module`/`package` scope that shares a bare
+name with an outer class has the same problem, since both shapes go through
+the same `current_package`-based qualification in
+`exec_register_class_op`. `EVAL`-from-another-compilation-unit is simply the
+shape `Test.rakumod` happens to hit.
+
+The fix removes the bareword lookup entirely for a named
+(non-`name_expr`) class declaration in expression position. `Interpreter::
+exec_register_class_op` now records the exact registry key it just stored
+the class under (`last_registered_class_key` — the same `storage_name` used
+for every other post-registration reference in that function, already
+correctly package-qualified and/or lexically mangled) into a new
+`Interpreter` field, and the compiler emits a new `PushLastRegisteredClass`
+opcode immediately after `RegisterClass` to push that type object directly.
+No opcode can run between the two (they are always emitted back to back for
+this one statement), so the field is always fresh, and re-entrant nested
+class declarations (a class body that itself declares a class) cannot
+clobber it: each `exec_register_class_op` call writes its own
+`storage_name` right before it returns, after any nested registrations
+inside its own body have already run and settled.
+
+Fixed in `src/opcode.rs` (new `PushLastRegisteredClass` opcode),
+`src/vm/vm_typedecl_ops.rs` (`exec_push_last_registered_class_op`,
+and the `last_registered_class_key` write at the end of
+`exec_register_class_op`), `src/runtime/mod.rs` (the new field), and
+`src/compiler/expr_block.rs` (`Stmt::ClassDecl`'s expression-position
+compile arm). Pinned by `t/class-decl-expr-value.t`, which is also green
+under real `raku` and covers the mainline, in-a-routine, nested-module, and
+EVAL-in-a-different-compilation-unit shapes, plus the pre-existing anonymous
+`(class { ... })` path.
+
+The analogous `Stmt::RoleDecl` (and likely `Stmt::Package`) expression-
+position arms have the same latent bug — verified with a `role`-flavored
+repro of the exact same shape — but fixing them is out of scope for this
+slice; see `todo/tickets/role-decl-expr-value-name-lookup.md`.

--- a/src/compiler/expr_block.rs
+++ b/src/compiler/expr_block.rs
@@ -679,17 +679,29 @@ impl Compiler {
             } if !*repeat => {
                 self.compile_do_loop_expr(init, cond, step, body, label);
             }
-            Stmt::ClassDecl {
-                name, name_expr, ..
-            } => {
-                // Register the class and return the type object
+            Stmt::ClassDecl { name_expr, .. } => {
+                // Register the class and return the type object.
+                //
+                // `PushLastRegisteredClass` pushes the type object the
+                // `RegisterClass` op immediately above JUST created, read
+                // off `Interpreter::last_registered_class_key` — the actual
+                // registry key it was stored under (package-qualified
+                // and/or lexically mangled per `exec_register_class_op`),
+                // not a fresh bareword lookup of the source-level name. A
+                // bareword lookup here can resolve to an unrelated,
+                // same-named class from a completely different scope: e.g.
+                // `class A { has $.x }` written as an expression inside
+                // `EVAL`'d code that executes in a different package than
+                // the caller resolves the bare name `A` to whichever `A`
+                // the CALLER already declared, not the class this
+                // declaration just created (see
+                // `news/2026-08/class-decl-expr-is-not-a-name-lookup.md`).
                 self.compile_stmt(stmt);
                 if let Some(expr) = name_expr {
                     self.compile_expr(expr);
                     self.code.emit(OpCode::IndirectTypeLookup);
                 } else {
-                    let name_idx = self.code.add_constant(Value::str(name.resolve()));
-                    self.code.emit(OpCode::GetBareWord(name_idx));
+                    self.code.emit(OpCode::PushLastRegisteredClass);
                 }
             }
             Stmt::RoleDecl { name, .. } => {

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -773,6 +773,17 @@ pub(crate) enum OpCode {
     /// does in Rakudo, while the installed name `R` keeps resolving to the
     /// `ParametricRoleGroupHOW` group.
     RoleGroupToCandidate,
+    /// Push the type object of the class most recently registered by
+    /// `RegisterClass` in THIS bytecode stream (no intervening opcode may run
+    /// between the two). Emitted right after a NAMED `class` declaration used
+    /// in expression position (`(class A { ... })`), so the expression
+    /// evaluates to the type object the declaration just created — never a
+    /// name-based lookup of the bareword `A`, which can resolve to an
+    /// unrelated, same-named class from a completely different scope (e.g. a
+    /// class re-declared inside `EVAL`'d code that runs in a different
+    /// package than the caller — see
+    /// `news/2026-08/class-decl-expr-is-not-a-name-lookup.md`).
+    PushLastRegisteredClass,
 
     // -- Arithmetic --
     Add,

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1403,6 +1403,21 @@ pub struct Interpreter {
     /// evaluating typed-attribute default type objects so a suppressed nested
     /// class name resolves within its owning class (see `resolve_suppressed_type`).
     constructing_class: Option<String>,
+    /// The registry storage key (the fully-qualified/mangled name actually
+    /// used as the registry key, NOT the source-level bare name) of the
+    /// class most recently registered by `exec_register_class_op`. Set right
+    /// before that function returns `Ok`, and consumed immediately by the
+    /// very next opcode when it is `PushLastRegisteredClass` — the compiler
+    /// only ever emits that opcode directly after `RegisterClass` for a
+    /// NAMED `class` declaration used in expression position (`(class A
+    /// { ... })`), so nothing else can run between the write and the read.
+    /// Exists so that expression evaluates to the type object the
+    /// declaration just created, rather than a bareword lookup of `A` that
+    /// can resolve to an unrelated, same-named class from a different scope
+    /// (e.g. one declared inside `EVAL`'d code running in a different
+    /// package than the caller). See
+    /// `news/2026-08/class-decl-expr-is-not-a-name-lookup.md`.
+    pub(crate) last_registered_class_key: Option<String>,
     /// Attribute writes observed through an instance's shared cell while its
     /// BUILD phase runs, one frame per instance under construction (BUILD may
     /// itself construct objects, so the frames nest). A frame is keyed by the

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -2444,6 +2444,7 @@ impl Interpreter {
             callframe_stack: Vec::new(),
             method_class_stack: Vec::new(),
             constructing_class: None,
+            last_registered_class_key: None,
             build_attr_writes: std::cell::RefCell::new(Vec::new()),
             defining_class: None,
             pending_call_arg_sources: None,

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -574,6 +574,7 @@ impl Interpreter {
             callframe_stack: Vec::new(),
             method_class_stack: Vec::new(),
             constructing_class: None,
+            last_registered_class_key: None,
             build_attr_writes: std::cell::RefCell::new(Vec::new()),
             defining_class: None,
             pending_call_arg_sources: None,

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -802,6 +802,10 @@ impl Interpreter {
                 self.exec_role_group_to_candidate_op();
                 *ip += 1;
             }
+            OpCode::PushLastRegisteredClass => {
+                self.exec_push_last_registered_class_op();
+                *ip += 1;
+            }
             OpCode::GetOurVar(name_idx) => {
                 let name = Self::const_str(code, *name_idx);
                 let val = self

--- a/src/vm/vm_typedecl_ops.rs
+++ b/src/vm/vm_typedecl_ops.rs
@@ -636,10 +636,31 @@ impl Interpreter {
             // outer `code`.
             self.apply_pending_rw_writeback(code);
 
+            // Record the actual registry key this declaration ended up
+            // stored under (the qualified/lexical-mangled `storage_name`,
+            // NOT the source-level bare `name`) for `PushLastRegisteredClass`
+            // to consume — see `Interpreter::last_registered_class_key`.
+            self.last_registered_class_key = Some(storage_name.clone());
+
             Ok(())
         } else {
             Err(RuntimeError::new("RegisterClass expects ClassDecl"))
         }
+    }
+
+    /// Push the type object of the class most recently registered by
+    /// `exec_register_class_op` (`Interpreter::last_registered_class_key`).
+    /// The compiler only ever emits this directly after `RegisterClass` for
+    /// a NAMED `class` declaration used in expression position, so the field
+    /// is always fresh here — see its doc comment. Falls back to `Nil` if
+    /// somehow nothing was registered (defensive; should not happen given
+    /// the emission discipline above).
+    pub(super) fn exec_push_last_registered_class_op(&mut self) {
+        let val = match self.last_registered_class_key.take() {
+            Some(key) => Value::package(crate::symbol::Symbol::intern(&key)),
+            None => Value::NIL,
+        };
+        self.stack.push(val);
     }
 
     /// Whether a *typed* user `trait_mod:<is>` candidate matches `call_args`

--- a/t/class-decl-expr-value.t
+++ b/t/class-decl-expr-value.t
@@ -1,0 +1,70 @@
+use v6;
+use Test;
+use lib 't/lib';
+use EvalContext;
+
+# A `class Name { ... }` used as an EXPRESSION must evaluate to the type
+# object the declaration just created -- never to a bareword lookup of
+# `Name`. A bareword lookup can resolve to a completely unrelated,
+# same-named class from a different scope (see
+# news/2026-08/class-decl-expr-is-not-a-name-lookup.md).
+
+plan 5;
+
+# 1. Mainline, no conflicting same-named class: baseline sanity.
+subtest 'mainline, no conflict' => {
+    plan 1;
+    my $t = (class MainlineFoo { has $.x = 42 });
+    is $t.new.x, 42, 'class-decl-as-expr yields a usable type object';
+}
+
+# 2. Inside a routine, no conflicting same-named class.
+subtest 'inside a routine, no conflict' => {
+    plan 1;
+    sub make-it() {
+        return (class RoutineFoo { has $.y = 7 });
+    }
+    is make-it().new.y, 7, 'class-decl-as-expr inside a sub body works';
+}
+
+# 3. A same-named class already exists in an ENCLOSING scope (a `module`),
+# and the expression-position declaration runs inside that module: current
+# package prefixing means the two are genuinely different registry entries
+# even though they share a bare name -- the expression must yield the NEW
+# one, not the pre-existing outer one.
+class SameNameOuter { }
+subtest 'same-named class in enclosing scope, nested module' => {
+    plan 2;
+    module SameNameHolder {
+        my $inner = (class SameNameOuter { has $.w = 99 });
+        is $inner.new.w, 99,
+            'nested-module class-decl-as-expr yields the NEW class';
+    }
+    isa-ok SameNameOuter.new, SameNameOuter,
+        'the outer same-named class is untouched';
+}
+
+# 4. Inside EVAL'd code that runs in a DIFFERENT compilation unit (a `sub`
+# defined in another module -- t/lib/EvalContext.rakumod), while a
+# same-named class already exists at the caller's mainline scope. This is
+# the exact shape roast/S12-class/attributes.t's "HOW on attributes lives,
+# custom class" subtest hits via Test.rakumod's `eval-lives-ok`.
+class SameNameEvalOuter { }
+subtest 'same-named class, EVAL in a different compilation unit' => {
+    plan 2;
+    my $got = run-plain(
+        '(class SameNameEvalOuter { has $.z = 123 }).new.z'
+    );
+    is $got, 123,
+        'EVAL-in-another-unit class-decl-as-expr yields the NEW class';
+    isa-ok SameNameEvalOuter.new, SameNameEvalOuter,
+        'the outer same-named class is still untouched';
+}
+
+# 5. An UNNAMED (anonymous) class-decl expression still works -- the fix
+# must not regress the existing `(class { ... })` / `class :: { ... }` path.
+subtest 'anonymous class-decl expression' => {
+    plan 1;
+    my $t = (class { has $.v = 5 });
+    is $t.new.v, 5, 'anonymous class-decl-as-expr still works';
+}

--- a/todo/deep/vendor-real-test-module.md
+++ b/todo/deep/vendor-real-test-module.md
@@ -4999,3 +4999,75 @@ never happens, rather than happening and being misdelivered) — filed
 separately as `todo/tickets/lazylist-sink-method-does-not-force-gather-body.md`
 rather than folded into this fix, since it is not required by any
 currently-tracked roast test.
+
+## 2026-08-29/30 — `S12-class/attributes.t`: a class-decl EXPRESSION did a name lookup, not a value
+
+Closes the row this file already carried: `S12-class/attributes.t`, "HOW on
+attributes lives, custom class" / `No such method 'x' for invocant of type
+'A'`. NOT a `Test.rakumod`/exception-object gap at all — a genuine, general
+VM bug in how `(class A { ... })` used as an EXPRESSION is compiled, that the
+real Test module's `eval-lives-ok` merely happened to be the first thing to
+surface.
+
+**Root cause:** the compiler's expression-position arm for `Stmt::ClassDecl`
+(`compile_expr_do_stmt` in `src/compiler/expr_block.rs`) compiled `(class A
+{ ... })` as "run `RegisterClass`, then look up the bareword `A`"
+(`GetBareWord`). That is wrong in general, not just under `EVAL`: Raku says a
+class declaration used as an expression evaluates to the type object the
+declaration just created, full stop — no name lookup, so an unrelated
+same-named class anywhere else is irrelevant. mutsu's bareword resolution
+(`resolve_bareword_type_name`) checks a direct bare-name hit FIRST, before
+ever considering the current package — so whenever the class body registers
+under a package-qualified key (`current_package`-based qualification in
+`exec_register_class_op`, same mechanism as `module M { class A {...} }`
+registering `M::A`), the bareword lookup found the CALLER's pre-existing,
+unrelated `A` instead of the freshly-declared one.
+
+**`EVAL` was a red herring, confirmed the hard way**: the bug reproduces with
+NO `EVAL` at all —
+
+```raku
+class A { }
+module M {
+    my $t = (class A { has $.x = 42 });
+    say $t.new.x;          # mutsu (pre-fix): "No such method 'x'"; raku: 42
+}
+```
+
+`Test.rakumod`'s `eval-lives-ok` hits it only because it calls `EVAL` from
+inside `sub eval_exception`, a routine defined in the *separate compilation
+unit* `Test.rakumod` — so the class the `EVAL`'d code declares registers
+under `Test::A` (verified with `rust-gdb`: `register_class_decl`'s `name`
+argument was literally `"Test::A"`), a different scope's `A` from whatever
+the caller's own script had already declared, hitting the exact same
+package-qualification path as the module repro above.
+
+**Fix**: removed the bareword lookup for a named class-decl expression
+entirely. `exec_register_class_op` now records the *actual* registry key it
+just stored the class under (`storage_name` — already correctly qualified/
+lexically-mangled, the same value every other post-registration reference in
+that function uses) into a new `Interpreter::last_registered_class_key`
+field, and the compiler emits a new payload-free `PushLastRegisteredClass`
+opcode immediately after `RegisterClass` to push that type object directly —
+no lookup, so no way to hit the wrong same-named entry. Write-up:
+`news/2026-08/class-decl-expr-is-not-a-name-lookup.md`. Pin:
+`t/class-decl-expr-value.t` (5 subtests: mainline, inside a routine, a
+same-named class in an enclosing `module`, `EVAL` from a different
+compilation unit with a same-named caller-scope class, and the pre-existing
+anonymous `(class { ... })` path — all green under real `raku` too).
+
+`Stmt::RoleDecl` (and possibly `Stmt::Package`) has the identical bug shape
+— verified with an analogous `role` repro — but fixing those was out of
+scope for this slice; filed as
+`todo/tickets/role-decl-expr-value-name-lookup.md`.
+
+### Measured, file by file (release build, `scripts/run-roast-test.sh`, both providers)
+
+| file | before (real, `MUTSU_REAL_TEST=1`) | after (real) | native (`roast-whitelist.txt`) |
+| --- | --- | --- | --- |
+| `S12-class/attributes.t` | fails test 23/44 ("HOW on attributes lives, custom class": `No such method 'x' for invocant of type 'A'`) | **PASS** (44/44) | still PASS (44/44), unaffected by the fix |
+
+Also re-swept the full whitelisted `S12-*`, `S02-*`, `S10-packages`,
+`S11-modules`, `S14-*`, `S32-exceptions`, and `integration` directories (407
+files) under the native provider with the fix applied — all still PASS, so
+the `PushLastRegisteredClass` change is not a native-provider regression.

--- a/todo/tickets/role-decl-expr-value-name-lookup.md
+++ b/todo/tickets/role-decl-expr-value-name-lookup.md
@@ -1,0 +1,68 @@
+# `(role R { ... })` as an expression can also yield the wrong same-named role
+
+`Stmt::ClassDecl` used to have this bug (fixed 2026-08 — see
+`news/2026-08/class-decl-expr-is-not-a-name-lookup.md`): the compiler's
+expression-position arm registered the declaration and then did a NAME
+LOOKUP of the bareword (`GetBareWord`) to get the "return value" of the
+expression, instead of pushing the type object the declaration just
+created. A bareword lookup can resolve to a completely unrelated, same-named
+type from a different scope — e.g. a nested `module`/`package` (or `EVAL`'d
+code running in a different compilation unit) declares the SAME bare name
+that an outer scope already has, and `register_class_decl`/-role/-package
+qualify the new declaration by `current_package`, so it is a genuinely
+distinct registry entry that the bareword lookup never finds (a direct
+bare-name hit on the OUTER entry wins first in
+`resolve_bareword_type_name`).
+
+`Stmt::RoleDecl`'s expression-position arm
+(`src/compiler/expr_block.rs`, the `Stmt::RoleDecl { name, .. }` match arm
+inside `compile_expr_do_stmt`) has the exact same shape: it does
+`self.compile_stmt(stmt)` (registers the role), then `GetBareWord(name_idx)`
++ `RoleGroupToCandidate`. Verified with a repro mirroring the class-decl
+one:
+
+```raku
+unit module MyMod2;
+sub my_eval($code) is export { EVAL($code); }
+```
+
+```raku
+use lib "./tmp/lib";
+use MyMod2;
+role R { };
+say my_eval('(role R { method x { 42 } }).^methods.map(*.name)');
+```
+
+prints `()` on mutsu (the pre-existing, methodless outer `R`) instead of
+`(x)` (the new role's method) — same root cause, same fix shape available.
+
+`Stmt::Package` (the `class`/`module`/`package` bare-package expression
+form) likely has the identical bug too, but was not independently verified
+in the class-decl slice; check it with the same repro pattern
+(`(package Foo { ... })`/`(module Foo { ... })` — whichever syntax mutsu
+accepts in expression position, if any) before assuming it applies.
+
+## Suggested fix
+
+Generalize the mechanism the class-decl fix introduced:
+`Interpreter::last_registered_class_key` (set at the end of
+`exec_register_class_op`, consumed by the new `PushLastRegisteredClass`
+opcode emitted immediately after `RegisterClass` in expression position).
+Add the analogous field/opcode for role registration (`exec_register_role_op`
+would need to record its own `storage_name`-equivalent), and have the
+`Stmt::RoleDecl` expr arm push that INSTEAD of the `GetBareWord` lookup —
+`RoleGroupToCandidate` still runs afterward exactly as it does today (it
+already correctly converts a role GROUP type object into the specific
+candidate; the only change needed is starting from the CORRECT group object
+rather than a possibly-wrong bareword hit). Do the same for `Stmt::Package`
+if the repro above confirms it needs it.
+
+## Why this is a separate ticket
+
+The class-decl slice's roast repro (`roast/S12-class/attributes.t`) only
+exercised the `class` shape; fixing `role`/`package` too was out of scope
+for that PR (CLAUDE.md's principle of matching fix size to the actual
+failing test, while still recording the adjacent finding rather than losing
+it). No roast test currently exercises the role/package shape as a hard
+regression, so this is priority-worthy but not urgent — pick it up in the
+normal `todo/tickets` oldest-first sweep.


### PR DESCRIPTION
## Summary

- `(class A { ... })` used as an EXPRESSION compiled to "register the class, then look up the bareword `A`" (`GetBareWord`) — wrong in general, since Raku says the expression evaluates to the type object the declaration just created, regardless of what else is registered under the same bare name.
- Whenever the class body registers under a package-qualified key (the same `current_package`-based qualification that makes `module M { class A {} }` register `M::A`), the bareword lookup found the CALLER's pre-existing, unrelated `A` instead of the freshly-declared one — `resolve_bareword_type_name` checks a direct bare-name hit before ever considering the current package.
- Surfaced as `roast/S12-class/attributes.t` test 23 failing under `MUTSU_REAL_TEST=1` ("HOW on attributes lives, custom class"): `Test.rakumod`'s `eval-lives-ok` calls `EVAL` from `sub eval_exception`, a routine in a *different compilation unit*, so the `EVAL`'d `class A` registers as `Test::A`. But no `EVAL` is actually required — the same bug reproduces with plain `module M { class A { ... } }` sharing a bare name with an outer `A` (added as a regression case).
- Fix: `exec_register_class_op` now records the actual registry key it just stored the class under (`Interpreter::last_registered_class_key`), and the compiler emits a new `PushLastRegisteredClass` opcode immediately after `RegisterClass` to push that type object directly — no lookup, so no way to hit the wrong same-named entry.
- `Stmt::RoleDecl` has the identical latent bug shape (verified with an analogous repro); filed as `todo/tickets/role-decl-expr-value-name-lookup.md` rather than expanding this slice.

## Test plan

- [x] New pin `t/class-decl-expr-value.t` (5 subtests: mainline, inside a routine, same-named class in an enclosing `module`, `EVAL` from a different compilation unit with a same-named caller-scope class, anonymous class-decl-as-expr) — fails deterministically pre-fix, passes post-fix, and is green under real `raku` too.
- [x] `roast/S12-class/attributes.t` passes fully (44/44) under both `MUTSU_REAL_TEST=1` and the native provider, release build.
- [x] Targeted native-provider sweep of the whitelisted `S12-*`, `S02-*`, `S10-packages`, `S11-modules`, `S14-*`, `S32-exceptions`, `integration` directories (407 files) — all still PASS.
- [x] `make test` — 3540 files / 35484 tests, all pass.
- [x] `cargo fmt` + `cargo clippy --all-targets -- -D warnings` clean.
- [x] `scripts/battery-testsuite.sh` (release build) — GATE PASSED, no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)