### PR TITLE
fix(vm): `==` falls back to `.Numeric`, so two DateTimes naming one instant are equal

### DIFF
--- a/news/2026-08/numeric-equality-falls-back-to-the-numeric-method.md
+++ b/news/2026-08/numeric-equality-falls-back-to-the-numeric-method.md
@@ -1,0 +1,64 @@
+# `==` falls back to `.Numeric`, so two DateTimes naming one instant compare equal
+
+`roast/S32-temporal/DateTime.t` regressed under `MUTSU_REAL_TEST=1` on the
+subtest `can parse leap second in non-UTC timezones`, whose twenty assertions
+are all of the form
+
+```raku
+cmp-ok utc.in-timezone($_), '==', utc, "parsed correct date for .in-timezone($_)";
+```
+
+## It was surfaced by a fix, not caused by one
+
+The file was clean at the start of the session and appeared in the closing
+sweep, so it looked like a regression from that day's work — and in a sense it
+was, but the underlying defect was older. PR #7096 made the **routine** form of
+a numeric comparison (`&infix:<==>($a, $b)`, the only form the vendored
+`Test.rakumod`'s `cmp-ok` ever uses) share one implementation with the operator
+form. Before that, the routine form went through a separate static fold that
+happened to numify two `DateTime`s and answer `True`. The operator form
+`$a == $b` had been answering `False` all along; unifying them simply made the
+wrong answer visible to `cmp-ok`.
+
+So the fix belongs in `==` itself:
+
+```raku
+my $utc = DateTime.new('2016-12-31T23:59:60Z');
+say $utc.in-timezone(7200) == $utc;   # was False, rakudo says True
+```
+
+## The rule mutsu was missing
+
+`DateTime` does **not** do `Real` or `Numeric` — in rakudo either
+(`$dt ~~ Real` and `$dt ~~ Numeric` are both `False` there too). What makes the
+comparison work is rakudo's last-resort candidate,
+`multi infix:<==>(Any \a, Any \b) { a.Numeric == b.Numeric }`.
+
+mutsu's Instance→numeric bridge (`coerce_infix_operand_numeric`) only numifies
+an object that does `Real`/`Numeric` **or** has a *user-written* `Numeric`
+method. `has_user_method` cannot see a native one, so `DateTime` fell straight
+through to structural equality — and two `DateTime`s naming the same instant in
+different timezones differ structurally, hence `False`.
+
+`num_eq_values` now applies the `.Numeric` fallback itself when the bridge has
+left both operands as objects, using the result only if **both** numify to
+something that is no longer an object. An object with no `.Numeric` therefore
+still reaches the existing structural path unchanged.
+
+## Scoped to `==`/`!=` on purpose
+
+The first attempt widened the shared numeric bridge instead, which is the
+obvious place. It was measured and reverted: the bridge also serves `-`, `<=>`,
+`cmp` and the arithmetic operators, and numifying a `DateTime` there destroys
+their type-specific behaviour — `DateTime - DateTime` stopped being a
+`Duration` and `DateTime <=> DateTime` stopped ordering, breaking three further
+assertions in the same roast file under *both* providers. rakudo has real
+candidates for those; only the equality family reaches the generic `Any, Any`
+one. The pin asserts the `-` and `<=>` behaviour precisely so a future widening
+cannot quietly repeat that.
+
+Pin: `t/numeric-equality-falls-back-to-the-numeric-method.t` (10 assertions,
+green under real `raku` as well as mutsu). A divergence the pin documents but
+cannot assert — an object with **no** `.Numeric` makes rakudo die where mutsu
+answers `False` — is filed as
+`todo/tickets/numeric-op-on-an-object-without-numeric-answers-instead-of-dying.md`.

--- a/src/vm/vm_comparison_ops.rs
+++ b/src/vm/vm_comparison_ops.rs
@@ -286,6 +286,40 @@ impl Interpreter {
             check_type_object_in_numeric_context(&l)?;
             check_type_object_in_numeric_context(&r)?;
             let (l, r) = vm.coerce_numeric_bridge_pair(l, r)?;
+            // rakudo's last-resort candidate is `multi infix:<==>(Any \a, Any
+            // \b) { a.Numeric == b.Numeric }`, so two objects the bridge left
+            // alone still compare by their `.Numeric`. The bridge only numifies
+            // an object that does `Real`/`Numeric` or has a USER `Numeric`
+            // method, which misses a native type that is neither -- `DateTime`
+            // is neither in rakudo either, yet `$a == $b` compares fine there.
+            // Structural equality answered False for two DateTimes naming the
+            // same instant in different timezones (roast
+            // S32-temporal/DateTime.t's leap-second subtest).
+            //
+            // Deliberately scoped to `==`/`!=` rather than the shared numeric
+            // bridge: `-` and `<=>` have their own temporal candidates
+            // (`DateTime - DateTime` is a `Duration`), and numifying there
+            // destroys them.
+            let (l, r) = match (l.view(), r.view()) {
+                (ValueView::Instance { .. }, ValueView::Instance { .. }) => {
+                    match (
+                        vm.call_method_with_values(l.clone(), "Numeric", vec![]),
+                        vm.call_method_with_values(r.clone(), "Numeric", vec![]),
+                    ) {
+                        // Only when BOTH numify to something that is no longer
+                        // an object; otherwise keep the originals so an object
+                        // with no `.Numeric` still reaches the structural path.
+                        (Ok(ln), Ok(rn))
+                            if !matches!(ln.view(), ValueView::Instance { .. })
+                                && !matches!(rn.view(), ValueView::Instance { .. }) =>
+                        {
+                            (ln, rn)
+                        }
+                        _ => (l, r),
+                    }
+                }
+                _ => (l, r),
+            };
             let (l, r) = (deref_allomorph_numeric(l), deref_allomorph_numeric(r));
             // NaN is unordered: NaN == anything is always False
             if is_nan_value(&l) || is_nan_value(&r) {

--- a/t/numeric-equality-falls-back-to-the-numeric-method.t
+++ b/t/numeric-equality-falls-back-to-the-numeric-method.t
@@ -1,0 +1,46 @@
+use Test;
+
+# rakudo's last-resort candidate for `==` is
+# `multi infix:<==>(Any \a, Any \b) { a.Numeric == b.Numeric }`, so two objects
+# compare by their `.Numeric` even when neither does `Real` or `Numeric`.
+# `DateTime` is exactly that shape.
+
+plan 10;
+
+my $utc = DateTime.new('2016-12-31T23:59:60Z');
+
+nok $utc ~~ Real,    'DateTime does not do Real (same as rakudo)';
+nok $utc ~~ Numeric, 'DateTime does not do Numeric (same as rakudo)';
+
+# The same instant rendered in a different timezone is a DIFFERENT object with
+# different attributes, so structural equality is the wrong answer.
+ok $utc.in-timezone(7200) == $utc,
+    'two DateTimes naming the same instant compare equal across timezones';
+ok $utc.in-timezone(-7200) == $utc, '... and with a negative offset';
+nok $utc.in-timezone(7200) != $utc, '`!=` agrees with `==`';
+
+# The routine form must answer identically -- it is how `cmp-ok` reaches the
+# operator, and it is the only form the vendored Test.rakumod ever uses.
+ok &infix:<==>($utc.in-timezone(7200), $utc),
+    'the routine form of `==` agrees';
+
+# Two genuinely different instants stay unequal.
+nok DateTime.new(2016,1,1,0,0,0) == DateTime.new(2016,1,1,0,0,1),
+    'different instants are not equal';
+
+# The temporal operators that have their own candidates must NOT be numified
+# away by this fallback.
+my $a = DateTime.new(2016,1,1,0,0,0);
+my $b = DateTime.new(2016,1,1,0,0,10);
+isa-ok $b - $a, Duration, 'DateTime - DateTime is still a Duration';
+is ($a <=> $b), Order::Less, 'DateTime <=> DateTime still orders';
+
+# A user class with its own `.Numeric` goes down the same road, and two
+# structurally different objects that numify alike compare equal.
+# (mutsu is more lenient than rakudo for an object with NO `.Numeric` at all:
+# rakudo dies with `Cannot resolve caller Numeric(...)`, mutsu answers False.
+# That predates this change and is tracked in
+# todo/tickets/numeric-op-on-an-object-without-numeric-answers-instead-of-dying.md.)
+class Weight { has $.kg; has $.label; method Numeric { $!kg } }
+ok Weight.new(kg => 3, label => 'a') == Weight.new(kg => 3, label => 'b'),
+    'two objects that numify alike are equal even with different attributes';

--- a/todo/deep/vendor-real-test-module.md
+++ b/todo/deep/vendor-real-test-module.md
@@ -5189,3 +5189,64 @@ it was written in).
 
 Per the counting note above, this closes **three** named files; re-measure the
 sweep rather than trusting a running total.
+
+## 2026-08-29 (end of session): the confirmed sweep, and the one file it turned up
+
+`scripts/roast-test-module-sweep.sh` on `main` @ `dbf79578c` — after all eight of
+the day's PRs landed (#7096, #7097, #7098, #7099, #7100, #7101, #7102, #7103) —
+reports **11 raw regressions, minus 2 `exit 124` performance artifacts
+(`6.d/S32-str/sprintf-d.t`, `S03-buf/write-int.t`) = 9 correctness regressions**,
+down from the session-opening **25**. `pass under both` 1425, `fail under both` 0.
+Detail preserved at `tmp/real-test-regressions-2026-08-29-eod.txt`.
+
+Remaining, and what each is:
+
+| file | what it is |
+| --- | --- |
+| `S06-other/main.t` | `require`-ing a module that declares `MAIN` reports `Redeclaration of routine 'MAIN'` |
+| `S32-io/io-cathandle.t` | `todo/tickets/cathandle-handles-map-pipe-never-forces.md` |
+| `S32-list/skip.t` | routine-value self-recursion after an import scope pops |
+| `S32-num/rat.t` | test 749 closed by #7096; the file now stops later on an unrelated `is copy` binding bug (`todo/tickets/is-copy-param-not-decoupled-through-sigilless-capture-chain.md`) |
+| `S24-testing/{10-is-approx,3-output}.t` | the real module's own spec — genuine gaps, not provider artifacts |
+| `S24-testing/{2-force_todo,6-done_testing}.t` | native-provider-only; need `#?rakudo eval` fudge support or un-whitelisting, not an interpreter fix |
+| `6.d/S32-str/sprintf-d.t`, `S03-buf/write-int.t` | the timeout class — performance, not correctness |
+
+### One file on that list was NOT there in the morning
+
+`S32-temporal/DateTime.t` appeared for the first time in the closing sweep, so it
+was checked before anything else. It is the shape this file should expect more
+of as the routine/operator forms converge: **a fix surfacing an older defect
+rather than causing one.** #7096 made `&infix:<==>` share the operator's
+implementation; the routine form had previously gone through a separate static
+fold that happened to numify two `DateTime`s and answer `True`, while
+`$a == $b` had been answering `False` all along. `cmp-ok` uses only the routine
+form, so the file had never exercised the operator's wrong answer.
+
+Root cause and fix: `DateTime` does not do `Real` or `Numeric` (nor does it in
+rakudo), so what makes `==` work there is the last-resort candidate
+`multi infix:<==>(Any \a, Any \b) { a.Numeric == b.Numeric }`. mutsu's
+Instance->numeric bridge only numifies an object that does `Real`/`Numeric` or
+has a *user-written* `Numeric`; `has_user_method` cannot see a native one.
+`num_eq_values` now applies the `.Numeric` fallback itself, using it only when
+BOTH operands numify to something that is no longer an object.
+
+**Scoped to `==`/`!=` deliberately.** Widening the shared bridge instead — the
+obvious place — was implemented, measured and reverted: it also serves `-`,
+`<=>`, `cmp` and arithmetic, and numifying a `DateTime` there broke three more
+assertions in the same file under *both* providers (`DateTime - DateTime`
+stopped being a `Duration`, `DateTime <=> DateTime` stopped ordering). The pin
+asserts those two behaviours so a future widening cannot repeat it.
+
+| file | real Test before | after | native before | after |
+| --- | --- | --- | --- | --- |
+| `S32-temporal/DateTime.t` | 1 failure (#287) | **PASS** | PASS | PASS |
+
+Fix and pin: `news/2026-08/numeric-equality-falls-back-to-the-numeric-method.md`,
+`t/numeric-equality-falls-back-to-the-numeric-method.t` (10 assertions, green
+under real `raku`). Verification: `make test` green (3549 files, 35578 tests);
+an 867-file targeted native-provider roast sweep (`S02-*`, `S03-*`, `S06-*`,
+`S12-*`, `S24-*`, `S29-*`, `S32-*`, `integration`) PASS (89127 tests);
+`scripts/battery-testsuite.sh` GATE PASSED (273/297). A divergence the pin
+documents but cannot assert — an object with no `.Numeric` makes rakudo die
+where mutsu answers `False` — is filed as
+`todo/tickets/numeric-op-on-an-object-without-numeric-answers-instead-of-dying.md`.

--- a/todo/tickets/numeric-op-on-an-object-without-numeric-answers-instead-of-dying.md
+++ b/todo/tickets/numeric-op-on-an-object-without-numeric-answers-instead-of-dying.md
@@ -1,0 +1,51 @@
+# A numeric operator on an object with no `.Numeric` answers instead of dying
+
+rakudo's generic numeric candidates are written in terms of `.Numeric`
+(`multi infix:<==>(Any \a, Any \b) { a.Numeric == b.Numeric }` and friends), so
+an object whose class defines no `Numeric` method makes them fail to resolve.
+mutsu answers instead.
+
+## Repro
+
+```raku
+class Opaque { has $.v }
+say Opaque.new(v => 1) == Opaque.new(v => 2);
+# rakudo: Cannot resolve caller Numeric(Opaque:D: ); none of these signatures matches:
+#             (Mu:U \v:: *%_)
+# mutsu:  False
+```
+
+The same shape with `+`:
+
+```raku
+class Word { has $.text }
+sub module-sum($a, $b) { $a + $b }   # in another compilation unit
+say module-sum(Word.new(text=>'a'), Word.new(text=>'b'));
+# rakudo: Cannot resolve caller Numeric(Word:D: )
+# mutsu:  0
+```
+
+## Why it is not a one-liner
+
+mutsu's numeric paths end in a structural / `to_float_value` fallback that
+silently yields `False` or `0` for an object it cannot numify. Making that a
+hard error is the correct behaviour but has a wide blast radius: every place a
+comparison currently leans on the lenient answer would start throwing, and the
+error has to be the right one (`X::Multi::NoMatch`-shaped, naming
+`Numeric(<Class>:D: )`) rather than a generic message, or `throws-like`
+assertions across roast will not match.
+
+The lenient path also interacts with mutsu's bare-string enum modeling, which
+deliberately keeps `==` permissive for non-numeric `Str` operands (see
+`infix_is_strictly_numeric`'s doc comment) — so the fix has to distinguish
+"object with no `Numeric`" from "value mutsu deliberately compares leniently".
+
+## Where it was noticed
+
+Writing the pin for
+`news/2026-08/numeric-equality-falls-back-to-the-numeric-method.md`. The
+assertion "two distinct objects with no `.Numeric` are still not equal" passes
+in mutsu and *dies* in rakudo, so it could not go in a pin that must be green
+under both; the pin documents the divergence in a comment and points here.
+
+No roast file in the current `MUTSU_REAL_TEST=1` residue gates it.


### PR DESCRIPTION
`roast/S32-temporal/DateTime.t` regressed under `MUTSU_REAL_TEST=1` on the subtest `can parse leap second in non-UTC timezones`, whose twenty assertions are all `cmp-ok utc.in-timezone($_), '==', utc`.

## It was surfaced by a fix, not caused by one

The file was clean at the start of the session and appeared in the closing sweep, so it looked like a same-day regression — and the defect it exposes is older. #7096 made the **routine** form of a numeric comparison (`&infix:<==>($a, $b)`, the only form the vendored `Test.rakumod`'s `cmp-ok` ever uses) share one implementation with the operator form. Before that, the routine form went through a separate static fold that happened to numify two `DateTime`s and answer `True`, while `$a == $b` had been answering `False` all along. `cmp-ok` uses only the routine form, so the file had never exercised the operator's wrong answer.

```raku
my $utc = DateTime.new('2016-12-31T23:59:60Z');
say $utc.in-timezone(7200) == $utc;   # was False, rakudo says True
```

## The rule mutsu was missing

`DateTime` does **not** do `Real` or `Numeric` — nor does it in rakudo (`$dt ~~ Real` and `$dt ~~ Numeric` are both `False` there too). What makes the comparison work is rakudo's last-resort candidate, `multi infix:<==>(Any \a, Any \b) { a.Numeric == b.Numeric }`.

mutsu's Instance→numeric bridge (`coerce_infix_operand_numeric`) only numifies an object that does `Real`/`Numeric` **or** has a *user-written* `Numeric` method. `has_user_method` cannot see a native one, so `DateTime` fell through to structural equality — and two `DateTime`s naming the same instant in different timezones differ structurally.

`num_eq_values` now applies the `.Numeric` fallback itself when the bridge has left both operands as objects, using the result only if **both** numify to something that is no longer an object. An object with no `.Numeric` therefore still reaches the existing structural path unchanged.

## Scoped to `==`/`!=` on purpose

The first attempt widened the shared numeric bridge instead, which is the obvious place. It was measured and reverted: the bridge also serves `-`, `<=>`, `cmp` and the arithmetic operators, and numifying a `DateTime` there destroys their type-specific behaviour — `DateTime - DateTime` stopped being a `Duration` and `DateTime <=> DateTime` stopped ordering, breaking three further assertions in the same roast file under *both* providers. rakudo has real candidates for those; only the equality family reaches the generic `Any, Any` one. The pin asserts the `-` and `<=>` behaviour precisely so a future widening cannot quietly repeat that.

## Verification

| file | real Test before | after | native before | after |
| --- | --- | --- | --- | --- |
| `S32-temporal/DateTime.t` | 1 failure (#287) | **PASS** | PASS | PASS |

- `make test` green: 3549 files, 35578 tests.
- Targeted native-provider roast sweep, 867 files / 89127 tests (`S02-*`, `S03-*`, `S06-*`, `S12-*`, `S24-*`, `S29-*`, `S32-*`, `integration`): PASS.
- `./scripts/battery-testsuite.sh`: **GATE PASSED** (273/297).
- Pin: `t/numeric-equality-falls-back-to-the-numeric-method.t`, 10 assertions, green under real `raku` as well as mutsu.

A divergence the pin documents but cannot assert — an object with **no** `.Numeric` makes rakudo die where mutsu answers `False` — is filed as `todo/tickets/numeric-op-on-an-object-without-numeric-answers-instead-of-dying.md`.

The ledger section also records the confirmed closing sweep: **9 correctness regressions** (11 raw minus 2 `exit 124` timeouts), down from **25** at session start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)