### PR TITLE
fix(runtime): a captured proto/multi survives its import scope popping

### DIFF
--- a/news/2026-08/begin-selective-import-proto-multi-value-capture.md
+++ b/news/2026-08/begin-selective-import-proto-multi-value-capture.md
@@ -1,0 +1,110 @@
+# A selective import's captured proto/multi now survives its import scope popping
+
+`roast/S32-list/skip.t` deliberately imports `Test` selectively — binding
+`plan`/`subtest`/`is`/`is-deeply`/`throws-like` as `&`-sigil VALUES out of a
+`do` block — precisely so the core `skip` routine keeps its own meaning
+(`Test` also exports a `skip` sub that would otherwise shadow it):
+
+```raku
+BEGIN my (&plan, &subtest, &is, &is-deeply, &throws-like) = do {
+    use Test;
+    (&plan, &subtest, &is, &is-deeply, &throws-like)
+}
+```
+
+Under `MUTSU_REAL_TEST=1` (the vendored upstream `Test.rakumod`, not mutsu's
+native TAP provider — see `todo/deep/vendor-real-test-module.md`) this died
+with `Unknown function: plan` the moment `plan` was called, even though
+`Test::plan` was still perfectly declared. The ledger's own row for the file
+described it as "routine-value self-recursion after an import scope pops" —
+accurate as far as it went, but that recursion turned out to be a downstream
+symptom of two separate, more fundamental bugs, both in how mutsu handles
+capturing a `proto`/`multi` routine as a first-class `&`-sigil value from
+inside an import that is lexically scoped to a block.
+
+## Bug A: a lazy by-name reference outlives the alias it depends on
+
+`resolve_code_var` (`src/runtime/accessors_resolve.rs`), used to evaluate
+`&plan`, had two branches for a name with concrete multi-candidate bodies: a
+name with NO explicit `proto sub` built a `Sub` that captured every candidate
+BY VALUE, so the callable kept working forever; a name WITH an explicit proto
+instead built a lazy `Value::routine_parts(current_package, name)` reference
+that re-resolves the bareword by name at *call* time.
+
+That lazy reference is fine for an ordinarily-declared proto — its package
+registration never goes away — but `has_proto` found `plan` here by searching
+`bare_name_packages()`, which for a mainline call is `GLOBAL`: the
+*importing* package's alias (`GLOBAL::plan`), not the package (`Test`) that
+actually declared the routine. An import is lexically scoped to the block
+that asked for it, so `pop_import_scope` correctly removes `GLOBAL::plan`
+once the `do {}` block ends — after which the captured reference pointed at
+nothing, and the later `plan 1` call died.
+
+The fix unifies the two branches: whenever concrete multi-candidate bodies
+exist — whether or not the name also has an explicit proto — capture them BY
+VALUE at the point `&name` is evaluated, the same way the non-proto branch
+already did. The resulting `Sub` keeps working regardless of what the
+registry does to the name afterward, matching Raku's real semantics: a
+captured `&code` value stays bound to the actual routine, independent of
+whether the short name used to capture it is still lexically visible.
+
+## Bug B: a nested `use` inside a top-level BEGIN was invisible to the hoister
+
+Separately, `run_toplevel_begin_phasers` (`src/runtime/run_prelude.rs`)
+pre-runs a "hoistable" top-level `BEGIN` at compile time through a
+`eval_block_value` sub-interpreter, so a later mainline read sees its side
+effects. `begin_body_is_hoistable` gates this: a body containing a
+declaration (including `use`), a bareword, or a call is excluded. The `use`
+check only looked at the BEGIN's own top-level statements, though — a `use`
+nested inside a `do {}` block slipped past it. `eval_block_value`'s merge-back
+into the shared `env` deliberately does not persist `&`-callable writes (only
+plain lexicals), so a hoisted `BEGIN my &plan = do { use Test; &plan }`
+(single-variable binding) lost its captured value entirely before the
+mainline ever ran.
+
+A list-destructured binding (`BEGIN my (&plan, &is) = do {...}`, the exact
+shape `S32-list/skip.t` uses) happened to dodge this by accident — its
+desugared AST contains the substring `Call` in Debug form, which already
+disqualified hoisting for an unrelated reason — so this bug stayed masked in
+that file and only surfaced once Bug A was isolated with a single-variable
+reduction. The fix extends the same whole-tree Debug-string search the
+`Call`/`BareWord` checks already use to also catch `Use { ` anywhere in the
+body, not just at the top level.
+
+## Fallout: `.arity`/`.count` on a materialized dispatcher
+
+Bug A's fix widened an existing "materialize a multi-dispatcher `Sub`" code
+path (previously used only for a multi with no explicit proto) to also cover
+the proto'd case. That path's `Sub` carries no `param_defs` of its own — the
+real signature information lives in its captured
+`__mutsu_multi_dispatch_candidates`/`__mutsu_multi_dispatch_name` env keys,
+which the `.candidates`/`.signature`/`.cando`/`.wrap` methods already knew to
+consult. `.arity`/`.count` did not, so `make test` caught a real regression:
+`t/signature-arity-count.t`'s `my proto sub a($, $?) {*}` capture started
+answering `0`/`0` for `&a.arity`/`&a.count` instead of `1`/`2`. Fixed by
+teaching the same two handlers the same two-tier lookup
+(`dispatch_routine_method`/`dispatch_sub_method` in
+`src/runtime/methods_sub.rs`, factored into a shared
+`multi_candidate_arity_count` helper in
+`src/runtime/methods_signature_candidates.rs`).
+
+## Verification
+
+- New regression test `t/begin-selective-import-proto-multi.t` (8
+  assertions, green under real `raku`): a local module
+  (`t/lib/ProtoMultiCapture.rakumod`, a plain `proto`+`multi` routine, unaffected
+  by which Test provider is active) across all four combinations of
+  BEGIN/no-BEGIN and single-variable/list-destructured binding, plus the
+  original `Test.rakumod` scenario itself toggled through `MUTSU_REAL_TEST`.
+  All four local-module shapes reproduced the bug before the fix and pass
+  after it.
+- `roast/S32-list/skip.t` passes under `MUTSU_REAL_TEST=1` (previously the
+  file never ran a single assertion, dying at its first `plan` call) and
+  continues to pass under the native provider.
+- `make test` green; a targeted native-provider roast sweep over
+  `S32-list`, `S11-modules`, `S10-packages`, `S02-names`, `S06-*`,
+  `S04-phasers`, `integration` green; `scripts/battery-testsuite.sh` gate
+  passed.
+
+See `todo/deep/vendor-real-test-module.md` for the campaign this closes a row
+in.

--- a/src/runtime/accessors_resolve.rs
+++ b/src/runtime/accessors_resolve.rs
@@ -435,20 +435,47 @@ impl Interpreter {
                     None
                 }
             });
-        let is_multi = if def.is_none() && !self.has_proto(lookup_name) {
-            // Check if there are multi-dispatch variants (stored with arity/type suffixes)
+        // Whether concrete multi-candidate bodies exist for this name (stored
+        // with arity/type-mangled `name/N` suffixes), regardless of whether it
+        // also has an explicit `proto sub`. A cheap key-prefix scan first, so
+        // the common non-multi resolution (most `&name` lookups) pays only
+        // this scan and not the fuller candidate walk below.
+        let has_multi_keys = def.is_none() && {
             let prefix_local = format!("{}::{}/", self.current_package(), lookup_name);
             let prefix_global = format!("GLOBAL::{}/", lookup_name);
             self.registry().functions.keys().any(|k| {
                 let ks = k.resolve();
                 ks.starts_with(&prefix_local) || ks.starts_with(&prefix_global)
             })
-        } else {
-            false
         };
-        if is_multi {
-            // Multi subs: create a Sub that captures all candidates so the
-            // callable works even after the defining scope exits.
+        if has_multi_keys {
+            // Multi subs (with or without an explicit proto): create a Sub
+            // that captures all candidate bodies BY VALUE now, so the
+            // resulting callable keeps working even after the defining scope
+            // exits or the registry entries it was found through change.
+            //
+            // This used to be restricted to a multi with no `proto sub` at
+            // all (`!self.has_proto(lookup_name)`); a proto'd multi instead
+            // captured a lazy `Value::routine_parts(current_package, name)`
+            // reference that re-resolves the name at call time. That is
+            // fine for an ordinarily-declared proto (its package registration
+            // never goes away), but breaks for one reached only through an
+            // import: `my (&plan) = do { use Test; &plan }`
+            // (roast/S32-list/skip.t's selective import, done precisely so
+            // the core `skip` routine stays visible under its own name).
+            // `has_proto`/`bare_name_packages()` found "plan" via the
+            // *importing* package's alias (`GLOBAL::plan`), so the lazy
+            // reference captured that alias, not the routine. An import is
+            // lexically scoped to its block, so `pop_import_scope` correctly
+            // removes `GLOBAL::plan` once the block ends — after which the
+            // dangling reference died with "Unknown function: plan" even
+            // though `Test::plan` was still perfectly declared. Materializing
+            // the candidates now (while the import is still active) instead
+            // sidesteps that: nothing about calling the resulting Sub later
+            // depends on the registry still holding the alias, matching
+            // Raku's real semantics (a captured `&code` value stays bound to
+            // the actual routine regardless of whether the short name used
+            // to capture it is still lexically visible).
             let candidates = self.resolve_all_multi_candidates(lookup_name);
             let mut candidate_subs = Vec::new();
             for cand in &candidates {
@@ -490,6 +517,10 @@ impl Interpreter {
             || self.resolve_token_defs(lookup_name).is_some()
             || self.has_proto_token(lookup_name)
         {
+            // No concrete multi-candidate bodies exist to materialize (an
+            // empty-sig proto with no candidates yet, or a grammar
+            // token/rule) — fall back to the lazy by-name reference; there is
+            // nothing to capture by value instead.
             Value::routine_parts(
                 Symbol::intern(&self.current_package()),
                 Symbol::intern(lookup_name),
@@ -505,12 +536,33 @@ impl Interpreter {
             // just call-syntax macros. They dispatch through the builtin-function
             // path (see `builtins.rs`), so expose them as Routine values here.
             Value::routine_parts(Symbol::intern("GLOBAL"), Symbol::intern(lookup_name), false)
-        } else if self.test_module_loaded() && Self::is_test_function_name(lookup_name) {
+        } else if self.test_module_loaded()
+            && Self::is_test_function_name(lookup_name)
+            && !Self::real_test_module_enabled()
+        {
             // Test-framework functions (&is-deeply, &pass, ...) are implemented
             // as Rust methods (runtime/test_functions.rs), not declared subs, so
             // the function-def lookup above misses them. Expose them as Routine
             // values so `my &fn = &is-deeply; fn(...)` dispatches through the
             // Routine call path, which routes test names to the Test dispatcher.
+            //
+            // Under MUTSU_REAL_TEST=1 there is no such native fallback: `plan`,
+            // `is`, etc. are ordinary Raku subs from the vendored Test.rakumod,
+            // reachable only through the normal declaration/import machinery
+            // (the `def`/`is_multi`/`has_proto` branches above). Synthesizing a
+            // by-name Routine reference here was wrong in that mode — worse,
+            // `test_module_loaded()` reads `loaded_modules`, which (correctly,
+            // matching Raku's own "a module stays loaded forever, only its
+            // exported symbols are lexically scoped" semantics) never rolls
+            // back when a `use Test;` block's import scope pops. So this
+            // branch kept firing for a bareword `plan` at outer scope even
+            // after `pop_import_scope` had correctly removed GLOBAL::plan's
+            // proto/multi registrations, returning a dangling by-name
+            // reference instead of Nil. With Nil, callers like
+            // `exec_call_on_code_var_op` fall back to the frame's own local
+            // slot, which is where a selective import
+            // (`my (&plan) = do { use Test; (&plan) }`, roast/S32-list/skip.t)
+            // actually stores the real imported Sub value.
             Value::routine_parts(Symbol::intern("GLOBAL"), Symbol::intern(lookup_name), false)
         } else if self.json_module_loaded() && matches!(lookup_name, "to-json" | "from-json") {
             // Native JSON routines (runtime/json.rs) have no declared sub either;

--- a/src/runtime/methods_signature_candidates.rs
+++ b/src/runtime/methods_signature_candidates.rs
@@ -2,8 +2,8 @@
 //! candidate routine lookup, and arity/count Value builders.
 use super::*;
 use crate::value::signature::{
-    SubSignatureKey, cache_sub_signature, cached_sub_signature, make_signature_value_with_owner,
-    param_defs_to_sig_info,
+    SubSignatureKey, cache_sub_signature, cached_sub_signature, extract_sig_info,
+    make_signature_value_with_owner, param_defs_to_sig_info,
 };
 
 impl Interpreter {
@@ -486,5 +486,43 @@ impl Interpreter {
             }
         }
         Value::int(max_count)
+    }
+
+    /// `.arity`/`.count` computed from a list of multi-candidate `Sub` VALUES
+    /// (as opposed to re-resolving a name in the registry). Shared by the
+    /// `Routine`-value handler (`dispatch_routine_method`, name-based lookup)
+    /// and the materialized-dispatcher `Sub`-value handler
+    /// (`dispatch_sub_method`, candidates captured at `&name` capture time —
+    /// see `resolve_code_var`, accessors_resolve.rs, and
+    /// `__mutsu_multi_dispatch_candidates`). Returns `None` only when
+    /// `candidates` itself is empty, so a caller can fall through to its own
+    /// default; a non-empty `candidates` whose signatures could not be
+    /// extracted still answers `Some(0)`, matching the pre-existing
+    /// name-based behavior.
+    pub(super) fn multi_candidate_arity_count(
+        &self,
+        candidates: &[Value],
+        method: &str,
+    ) -> Option<Value> {
+        if candidates.is_empty() {
+            return None;
+        }
+        let mut infos = Vec::new();
+        for candidate in candidates {
+            if let ValueView::Sub(data) = candidate.view() {
+                let sig = self.sub_signature_value(&data);
+                if let Some(info) = extract_sig_info(&sig) {
+                    infos.push(info);
+                }
+            }
+        }
+        if infos.is_empty() {
+            return Some(Value::int(0));
+        }
+        Some(if method == "arity" {
+            Self::candidate_arity_value(&infos)
+        } else {
+            Self::candidate_count_value(&infos)
+        })
     }
 }

--- a/src/runtime/methods_sub.rs
+++ b/src/runtime/methods_sub.rs
@@ -346,23 +346,9 @@ impl Interpreter {
         if matches!(method, "arity" | "count") && args.is_empty() {
             let candidates = self.routine_candidate_subs(package, name);
             if !candidates.is_empty() {
-                let mut infos = Vec::new();
-                for candidate in candidates {
-                    if let ValueView::Sub(data) = candidate.view() {
-                        let sig = self.sub_signature_value(&data);
-                        if let Some(info) = extract_sig_info(&sig) {
-                            infos.push(info);
-                        }
-                    }
-                }
-                if infos.is_empty() {
-                    return Some(Ok(Value::int(0)));
-                }
-                return Some(Ok(if method == "arity" {
-                    Self::candidate_arity_value(&infos)
-                } else {
-                    Self::candidate_count_value(&infos)
-                }));
+                return Some(Ok(self
+                    .multi_candidate_arity_count(&candidates, method)
+                    .unwrap_or(Value::int(0))));
             }
 
             let (params, param_defs) = self.callable_signature(target);
@@ -815,6 +801,36 @@ impl Interpreter {
             return Some(Ok(Value::truth(!data.is_rw)));
         }
         if matches!(method, "arity" | "count") && args.is_empty() {
+            // Multi-dispatch dispatcher (`&mm` for a `multi sub mm`, with or
+            // without an explicit `proto`): this Sub's OWN param_defs are
+            // empty (it is a synthesized dispatcher, not a declared body), so
+            // reading `arity`/`count` off `data` directly always answered 0.
+            // Mirrors the "signature"/"candidates"/"cando" handling just
+            // above: try the live name-based candidates first (keeps working
+            // if the name is still declared and picks up any candidate added
+            // since capture), falling back to the candidates captured BY
+            // VALUE at `&name` capture time — the only source left once the
+            // name's own import scope has popped (see `resolve_code_var`,
+            // accessors_resolve.rs).
+            if let Some(ValueView::Str(disp_name)) =
+                data.env.get("__mutsu_multi_dispatch_name").map(Value::view)
+            {
+                let name_based =
+                    self.routine_candidate_subs(&data.package.resolve(), disp_name.as_str());
+                if !name_based.is_empty()
+                    && let Some(result) = self.multi_candidate_arity_count(&name_based, method)
+                {
+                    return Some(Ok(result));
+                }
+            }
+            if let Some(ValueView::Array(cands, _)) = data
+                .env
+                .get("__mutsu_multi_dispatch_candidates")
+                .map(Value::view)
+                && let Some(result) = self.multi_candidate_arity_count(&cands, method)
+            {
+                return Some(Ok(result));
+            }
             let sig = self.sub_signature_value(data);
             if let Some(info) = extract_sig_info(&sig) {
                 return Some(Ok(if method == "arity" {

--- a/src/runtime/run_prelude.rs
+++ b/src/runtime/run_prelude.rs
@@ -543,10 +543,27 @@ impl Interpreter {
     ///   throw — both of which are handled correctly only by the mainline path
     ///   (which wraps BEGIN-time errors in `X::Comp::BeginTime`).
     ///
-    /// The `BareWord(`/`Call` markers are matched in the AST debug form, which
-    /// catches them at any nesting depth without a bespoke full-AST walker. All
-    /// call-shaped `Expr` variants (`Call`, `MethodCall`, `HyperMethodCall`,
-    /// `CallOn`, `DynamicMethodCall`, ...) contain `Call` in their name.
+    /// The `BareWord(`/`Call`/`Use` markers are matched in the AST debug form,
+    /// which catches them at any nesting depth without a bespoke full-AST
+    /// walker. All call-shaped `Expr` variants (`Call`, `MethodCall`,
+    /// `HyperMethodCall`, `CallOn`, `DynamicMethodCall`, ...) contain `Call` in
+    /// their name.
+    ///
+    /// The top-level `matches!` below only sees `body`'s own statements, so a
+    /// `use` NESTED inside a `do {}` (`my &f = do { use Test; &f }` — a
+    /// selective import, done precisely so the module's other exports stay out
+    /// of scope) slipped past it: `Stmt::Use` was listed in the top-level
+    /// match, but this BEGIN's only top-level statement is the `my`
+    /// declaration, and the `use` lives inside the `do` block's own body.
+    /// `has_decl` therefore said "no declarations", and — since there was no
+    /// bareword/call either — this BEGIN was hoisted and pre-run through
+    /// `eval_block_value`, whose merge-back into the shared `env` isolates
+    /// `&`-callable keys (deliberately, to keep a hoisted BEGIN's closures from
+    /// leaking); the imported routine value captured by `&f` never reached the
+    /// mainline, so the later call died with "Unknown function". Search the
+    /// same whole-tree debug string the `Call`/`BareWord` checks already use so
+    /// a `use` anywhere in the body — not just at the top level — disqualifies
+    /// hoisting, exactly like an unqualified top-level `use` already does.
     fn begin_body_is_hoistable(body: &[Stmt]) -> bool {
         let has_decl = body.iter().any(|s| {
             matches!(
@@ -578,7 +595,7 @@ impl Interpreter {
             return false;
         }
         let debug = format!("{body:?}");
-        !debug.contains("BareWord(") && !debug.contains("Call")
+        !debug.contains("BareWord(") && !debug.contains("Call") && !debug.contains("Use {")
     }
 
     /// Remove the no-init reset of plain `my`/`our`-free declarations whose

--- a/t/begin-selective-import-proto-multi.t
+++ b/t/begin-selective-import-proto-multi.t
@@ -1,0 +1,142 @@
+use v6;
+use lib 't/lib';
+use Test;
+use lib $*PROGRAM.parent(2).add("roast/packages/Test-Helpers/lib");
+use Test::Util;
+
+plan 8;
+
+# Regression for todo/deep/vendor-real-test-module.md: `roast/S32-list/skip.t`
+# selectively imports Test's `plan`/`is`/etc. as `&`-sigil VALUES out of a `do`
+# block, precisely so the core `skip` routine stays visible under its own bare
+# name (Test also exports a `skip` sub that would otherwise shadow it):
+#
+#   BEGIN my (&plan, &is) = do {
+#       use Test;
+#       (&plan, &is)
+#   }
+#
+# Under `MUTSU_REAL_TEST=1` (the real vendored Test.rakumod, not mutsu's
+# native TAP provider) this died with "Unknown function: plan" -- even though
+# `Test::plan` was still perfectly declared. Two independent bugs combined to
+# cause it, both in `&`-sigil capture of a proto/multi routine reached only
+# through an import that is lexically scoped to a block:
+#
+# Bug A (src/runtime/accessors_resolve.rs, resolve_code_var): capturing
+# `&plan` as a value built a LAZY `Value::routine_parts(current_package,
+# name)` reference that re-resolves "plan" BY NAME at call time. That name
+# only resolved via the *importing* package's alias (`GLOBAL::plan`), which
+# `pop_import_scope` correctly removes once the `do {}` block ends (an import
+# is lexically scoped to its block) -- leaving the captured reference
+# dangling. Fixed by materializing the actual multi-candidate bodies BY VALUE
+# at capture time (same mechanism the sibling non-proto'd `is_multi` branch
+# already used), so the resulting Sub keeps working regardless of what the
+# registry does afterward.
+#
+# Bug B (src/runtime/run_prelude.rs, begin_body_is_hoistable): a top-level
+# `BEGIN` whose body has no top-level declaration/bareword/call is pre-run at
+# compile time via a separate `eval_block_value` sub-interpreter, which
+# deliberately does NOT persist `&`-callable writes into the shared `env`
+# (only plain lexicals). `begin_body_is_hoistable` only checked for a `use`
+# statement at the BEGIN's own top level, missing one nested inside a `do {}`
+# -- so `BEGIN my &plan = do { use Test; &plan }` (single-variable binding)
+# was wrongly hoisted, and the captured value never reached the mainline. A
+# BEGIN with a LIST-destructured binding (`BEGIN my (&plan, &is) = do {...}`)
+# happened to dodge this by accident (its desugared AST contains "Call" in
+# debug form, which already disqualified hoisting) -- so this bug was masked
+# for the exact shape roast/S32-list/skip.t uses, and only surfaced once Bug A
+# was isolated with a single-variable reduction. Fixed by also disqualifying
+# hoisting when a `use` appears anywhere in the BEGIN body, not just at the
+# top level.
+#
+# This file exercises both bugs directly with a LOCAL proto+multi module
+# (t/lib/ProtoMultiCapture.rakumod) -- which reproduces under the DEFAULT
+# native-provider mutsu too, since a user-defined routine (unlike `plan`/`is`)
+# is never a hardcoded builtin name -- across all four combinations of
+# BEGIN/no-BEGIN and single-variable/list-destructured binding. It then pins
+# the original Test.rakumod scenario directly, toggling
+# `MUTSU_REAL_TEST` via `is_run` so the real regression (only visible under
+# the vendored Test module) is covered too, without changing what `t/`
+# normally exercises.
+
+# --- Bug A: no BEGIN, single-variable binding ---
+{
+    my &f = do {
+        use ProtoMultiCapture;
+        &proto-multi-capture
+    }
+    is-deeply (f(1), f("x")), ("int:1", "str:x"),
+        'no BEGIN, single var: captured proto/multi still dispatches after the import scope pops';
+}
+
+# --- Bug B: BEGIN, single-variable binding ---
+{
+    BEGIN my &f = do {
+        use ProtoMultiCapture;
+        &proto-multi-capture
+    }
+    is-deeply (f(1), f("x")), ("int:1", "str:x"),
+        'BEGIN, single var: captured proto/multi still dispatches (was wrongly hoisted)';
+}
+
+# --- no BEGIN, list-destructured binding ---
+{
+    my (&f) = do {
+        use ProtoMultiCapture;
+        (&proto-multi-capture)
+    }
+    is-deeply (f(1), f("x")), ("int:1", "str:x"),
+        'no BEGIN, list binding: captured proto/multi still dispatches after the import scope pops';
+}
+
+# --- BEGIN, list-destructured binding (roast/S32-list/skip.t's own shape) ---
+{
+    BEGIN my (&f) = do {
+        use ProtoMultiCapture;
+        (&proto-multi-capture)
+    }
+    is-deeply (f(1), f("x")), ("int:1", "str:x"),
+        'BEGIN, list binding: captured proto/multi still dispatches after the import scope pops';
+}
+
+# The selective import must stay selective: the bare name is not visible
+# outside the `do {}` block that imported it. A direct bareword call to an
+# undeclared routine is a COMPILE-time error in Raku (not caught by plain
+# `try`), so the probe goes through EVAL — and EVAL itself still surfaces a
+# compile error as a thrown exception rather than a `Failure`, so wrap that
+# in `try` too.
+ok !(try { EVAL('proto-multi-capture(1)'); True }),
+    'the bare routine name did not leak outside its selective-import do block';
+
+# --- The original roast/S32-list/skip.t shape, against the vendored
+# Test.rakumod (MUTSU_REAL_TEST=1) as well as the native provider. ---
+my $begin_list_probe = q:to/CODE/;
+BEGIN my (&plan, &is) = do {
+    use Test;
+    (&plan, &is)
+}
+plan 1;
+is 1, 1, 'selective import survived';
+CODE
+
+my $begin_single_probe = q:to/CODE/;
+BEGIN my &plan = do {
+    use Test;
+    &plan
+}
+plan 1;
+say "single var ok";
+CODE
+
+%*ENV<MUTSU_REAL_TEST>:delete;
+is_run $begin_list_probe, { status => 0, out => "1..1\nok 1 - selective import survived\n" },
+    'native provider: BEGIN + list-destructured selective import of Test still works';
+
+%*ENV<MUTSU_REAL_TEST> = '1';
+is_run $begin_list_probe, { status => 0, out => "1..1\nok 1 - selective import survived\n" },
+    'vendored Test.rakumod: BEGIN + list-destructured selective import survives the import scope popping';
+is_run $begin_single_probe,
+    { status => 255, out => "1..1\nsingle var ok\n# You planned 1 test, but ran 0\n" },
+    'vendored Test.rakumod: BEGIN + single-variable selective import survives (was wrongly hoisted)';
+
+%*ENV<MUTSU_REAL_TEST>:delete;

--- a/t/lib/ProtoMultiCapture.rakumod
+++ b/t/lib/ProtoMultiCapture.rakumod
@@ -1,0 +1,8 @@
+unit module ProtoMultiCapture;
+
+# A proto + multi routine, used by t/begin-selective-import-proto-multi.t to
+# exercise capturing an imported proto/multi as a first-class `&`-sigil value
+# from inside a selectively-scoped import (`my (&f) = do { use ...; &f }`).
+proto sub proto-multi-capture($x) is export {*}
+multi sub proto-multi-capture(Int $x) { "int:$x" }
+multi sub proto-multi-capture(Str $x) { "str:$x" }

--- a/t/routine-value-self-recursion-after-import-scope-pop.t
+++ b/t/routine-value-self-recursion-after-import-scope-pop.t
@@ -2,27 +2,42 @@ use Test;
 
 plan 3;
 
-# A captured `&name` reference to a popped proto/multi import used to
-# stack-overflow instead of dying. `my (&xrecur) = do { use
-# ProtoRecursionFixture; (&xrecur) }` binds a name-based
-# `Routine{package:"GLOBAL", name:"xrecur"}` value into the outer `&xrecur`
-# local -- a proto/multi has no single candidate to point at, so it is a
-# name reference, not a bound closure. Once the `do` block's import scope
-# pops, `GLOBAL::xrecur` is removed from the proto tables (correctly).
-# Calling `xrecur(...)` afterwards used to recurse forever: call_sub_value's
-# unconditional call_function fallback re-dispatches "xrecur" by name,
-# call_function_fallback's env-based callable lookup finds the SAME Routine
-# value bound to the outer `&xrecur` local, and calls it again -- no base
-# case, so it stack-overflowed instead of raising a catchable error.
-# (`ProtoRecursionFixture`'s export name deliberately does not collide with
-# any mutsu builtin/listop -- unlike e.g. `head` -- so the call is forced
-# through the exact registry/env path this bug lives in.)
+# A captured `&name` reference to a proto/multi export whose import scope has
+# since popped. `my (&xrecur) = do { use lib 't/lib'; use
+# ProtoRecursionFixture; (&xrecur) }` captures `xrecur` -- a `proto`/`multi`
+# pair, so there is no single candidate body to point at -- out of a `do {}`
+# block, exactly the shape a selective import uses (`roast/S32-list/skip.t`:
+# `my (&plan, &subtest, ...) = do { use Test; (&plan, &subtest, ...) }`,
+# done so `Test`'s own exported `&skip` does not shadow the core `skip`
+# routine). Once the `do` block's import scope pops, the importing
+# package's alias for `xrecur` is correctly removed (an import is lexically
+# scoped to its block) -- but `&xrecur` itself must keep working, because
+# Raku's real semantics bind a captured `&code` value to the actual routine,
+# independent of whether the short name used to capture it stays visible.
 #
-# The fix does not make this construct actually WORK (raku itself would
-# have already reported "Undeclared routine" at compile time for the
-# equivalent construct, since it resolves names lexically) -- it only
-# ensures mutsu fails with a normal, catchable runtime error instead of
-# crashing the process.
+# 2026-08-18 (#... commit 1237ce8e8): calling `xrecur(...)` after the import
+# scope popped used to recurse forever and abort with a Rust stack overflow
+# instead of raising a catchable error -- fixed by making
+# `call_function_fallback` recognize a dead-end self-referential `Routine`
+# value instead of redispatching it. That fix stopped the crash but did NOT
+# make the construct actually run: it still died with "Unknown function:
+# xrecur", a regression from real Raku (confirmed directly against `raku`:
+# this exact construct runs cleanly and returns the dispatched candidate's
+# result).
+#
+# 2026-08-29 (todo/deep/vendor-real-test-module.md, "routine-value
+# self-recursion after an import scope pops"): the DANGLING reference itself
+# was the real bug. `resolve_code_var` captured `&xrecur` as a LAZY
+# `Value::routine_parts(current_package, name)` reference that re-resolves
+# "xrecur" BY NAME at call time -- which only worked through the *importing*
+# package's alias, exactly the one `pop_import_scope` correctly removes.
+# Fixed by materializing the actual multi-candidate bodies BY VALUE at
+# capture time instead (mirroring how a multi with no explicit proto was
+# already captured), so the resulting Sub keeps working regardless of what
+# the registry does to the name afterward. See
+# `news/2026-08/begin-selective-import-proto-multi-value-capture.md` and
+# `t/begin-selective-import-proto-multi.t` for the fuller BEGIN/list-binding
+# matrix this also covers.
 
 my $code = q:to/CODE/;
     my (&xrecur) = do {
@@ -30,22 +45,15 @@ my $code = q:to/CODE/;
         use ProtoRecursionFixture;
         (&xrecur)
     };
-    xrecur(1);
+    say xrecur(1);
+    say xrecur("hi");
     CODE
 
 my $proc = run $*EXECUTABLE, '-e', $code, :out, :err;
-$proc.out.slurp(:close);
+my $out = $proc.out.slurp(:close);
 my $err = $proc.err.slurp(:close);
 
-isnt $proc.exitcode, 0, 'the construct still fails (not silently succeeding)';
-# A crashed (aborted/segfaulted) child reports a negative `.exitcode` under
-# mutsu's own `Proc` (confirmed via a direct repro: exitcode -1, stderr
-# containing the Rust "has overflowed its stack" abort message) rather than
-# a shell's usual 128+signal convention. A normal, catchable runtime error
-# exits with mutsu's ordinary positive error status instead -- assert we
-# are in that range, not the crash range, and that the crash's own
-# telltale message is gone from stderr.
-ok $proc.exitcode > 0,
-    'fails with a normal (positive) error exit code, not a crashed/signal-killed process';
-unlike $err, /'overflowed its stack' | 'fatal runtime error'/,
-    'stderr does not contain the stack-overflow abort message';
+is $proc.exitcode, 0, 'the captured proto/multi dispatches after its import scope pops';
+is $out, "xrecur-int(1)\nxrecur-str(hi)\n",
+    'dispatch actually picked the matching multi candidate for each call';
+is $err, '', 'no crash / error output on stderr';

--- a/todo/deep/vendor-real-test-module.md
+++ b/todo/deep/vendor-real-test-module.md
@@ -5250,3 +5250,73 @@ an 867-file targeted native-provider roast sweep (`S02-*`, `S03-*`, `S06-*`,
 documents but cannot assert — an object with no `.Numeric` makes rakudo die
 where mutsu answers `False` — is filed as
 `todo/tickets/numeric-op-on-an-object-without-numeric-answers-instead-of-dying.md`.
+
+## 2026-08-29 (later): `S32-list/skip.t` — the "routine-value self-recursion" was two separate value-capture bugs
+
+The prior sweep's row for this file said "routine-value self-recursion after
+an import scope pops" — an accurate symptom description, but the actual root
+cause was two independent bugs in how `&`-sigil capture of a `proto`/`multi`
+routine interacts with a selective, lexically-scoped import
+(`my (&plan) = do { use Test; &plan }`, done so the core `skip` routine keeps
+its own meaning instead of being shadowed by `Test`'s own exported `&skip`).
+Re-derived from scratch with a minimal 6-line reduction (dropping `Test`
+entirely once the shape was isolated), not from the row's own framing — see
+the working notes below and `news/2026-08/begin-selective-import-proto-multi-value-capture.md`
+for the full account.
+
+**Bug A** (`src/runtime/accessors_resolve.rs`, `resolve_code_var`): a name
+with an explicit `proto sub` captured `&name` as a LAZY
+`Value::routine_parts(current_package, name)` reference that re-resolves the
+bareword by name at call time — fine when the proto is an ordinary
+declaration, wrong when `has_proto` only found it via the *importing*
+package's alias (`GLOBAL::plan`), which `pop_import_scope` correctly removes
+once the importing block ends. The sibling branch for a multi with NO
+explicit proto already captured candidates BY VALUE for exactly this reason;
+extended that same materialization to the proto'd case whenever concrete
+multi-candidate bodies exist.
+
+**Bug B** (`src/runtime/run_prelude.rs`, `begin_body_is_hoistable`): a
+top-level `BEGIN` whose body has no top-level declaration/bareword/call is
+pre-run at compile time via a separate `eval_block_value` sub-interpreter,
+which deliberately does not persist `&`-callable writes into the shared
+`env`. The hoistability check's `use`-detection only looked at the BEGIN's
+own top-level statements, missing one nested inside a `do {}` — so
+`BEGIN my &plan = do { use Test; &plan }` (single-variable binding) was
+wrongly hoisted and lost its captured value before the mainline even ran. A
+list-destructured binding (`BEGIN my (&plan, &is) = do {...}`, the shape this
+file actually uses) happened to dodge hoisting by accident (its desugared AST
+contains `Call` in Debug form, already disqualifying it for an unrelated
+reason) — so Bug B stayed masked here and only surfaced once Bug A was
+isolated with a single-variable reduction. Fixed by extending the same
+whole-tree Debug-string search the `Call`/`BareWord` checks already use to
+also catch a nested `use`.
+
+Neither bug is specific to `Test` — both reproduce with a plain
+user-declared `proto`+`multi` module (`t/lib/ProtoMultiCapture.rakumod`)
+under the DEFAULT native provider too, since a user routine name is never a
+hardcoded builtin the way `plan`/`is` are shielded by
+`is_builtin_function`.
+
+| file | real Test before | real Test after | native before | native after |
+| --- | --- | --- | --- | --- |
+| `S32-list/skip.t` | dies at the first `plan` call (0 assertions run) | **PASS** | PASS | PASS |
+
+Bug A's fix also caught a real, pre-existing gap `make test` surfaced:
+`t/signature-arity-count.t`'s `my proto sub a($, $?) {*}` capture started
+answering `&a.arity`/`&a.count` as `0`/`0` instead of `1`/`2`, because the
+materialized dispatcher `Sub` carries no `param_defs` of its own — the real
+signature lives in its `__mutsu_multi_dispatch_candidates` env key, which
+`.candidates`/`.signature`/`.cando`/`.wrap` already knew to consult but
+`.arity`/`.count` did not. Fixed alongside (`src/runtime/methods_sub.rs`,
+`src/runtime/methods_signature_candidates.rs`); the existing test now covers
+it (was already asserting on it, previously against the non-proto'd-only
+materialization path).
+
+Fix and pin: `news/2026-08/begin-selective-import-proto-multi-value-capture.md`,
+`t/begin-selective-import-proto-multi.t` (8 assertions covering all four
+combinations of BEGIN/no-BEGIN x single-variable/list-destructured binding,
+plus the `Test.rakumod` scenario toggled through `MUTSU_REAL_TEST`; green
+under real `raku`). Verification: `make test` green; a targeted
+native-provider roast sweep over `S32-list`, `S11-modules`, `S10-packages`,
+`S02-names`, `S06-*`, `S04-phasers`, `integration` green;
+`scripts/battery-testsuite.sh` gate passed.


### PR DESCRIPTION
## Summary

`roast/S32-list/skip.t` selectively imports `Test`'s `plan`/`is`/etc. as `&`-sigil VALUES out of a `do` block, so `Test`'s own exported `&skip` does not shadow the core `skip` routine. Under `MUTSU_REAL_TEST=1` (`todo/deep/vendor-real-test-module.md`) this died with `Unknown function: plan` even though `Test::plan` was still declared. The ledger's "routine-value self-recursion after an import scope pops" framing described a real earlier fix (#... `1237ce8e8`, which stopped a stack overflow) but was a downstream symptom, not the root cause. Re-derived from scratch with a minimal 6-line reduction (no `Test` involved). Two independent bugs combined:

- **Bug A** (`resolve_code_var`, `accessors_resolve.rs`): capturing `&plan` built a LAZY `Value::routine_parts(current_package, name)` reference that re-resolves "plan" by name at call time. That name only resolved via the *importing* package's alias (`GLOBAL::plan`), which `pop_import_scope` correctly removes once the `do {}` block ends (imports are lexically scoped). Fixed by materializing the actual multi-candidate bodies BY VALUE at capture time whenever concrete candidates exist — the same mechanism the sibling non-proto'd multi branch already used — so the resulting `Sub` keeps working regardless of what the registry does to the name afterward.
- **Bug B** (`begin_body_is_hoistable`, `run_prelude.rs`): a top-level `BEGIN` with no top-level declaration/bareword/call is pre-run at compile time via a separate `eval_block_value` sub-interpreter, which does not persist `&`-callable writes into the shared `env`. The hoistability check's `use` detection only looked at the BEGIN's own top-level statements, missing one nested inside a `do {}` — so a single-variable BEGIN binding was wrongly hoisted and lost its captured value. A list-destructured binding (the shape `skip.t` actually uses) happened to dodge this by accident, masking the bug until isolated with a single-variable reduction. Fixed by extending the same whole-tree debug-string search already used for `Call`/`BareWord` to also catch a nested `use`.
- **Fallout**: Bug A's fix exposed that the materialized dispatcher `Sub`'s `.arity`/`.count` read an empty signature (the real signature lives in its captured `__mutsu_multi_dispatch_candidates` env key, which `.candidates`/`.signature`/`.cando`/`.wrap` already consulted but `.arity`/`.count` did not) — caught by the existing `t/signature-arity-count.t`, fixed alongside.

Also updates `t/routine-value-self-recursion-after-import-scope-pop.t`, whose prior assertions (`isnt exitcode 0`) encoded the OLD, incorrect behavior — verified directly against real `raku` that the construct is supposed to succeed.

## Test plan

- [x] New `t/begin-selective-import-proto-multi.t` (8 assertions; green under real `raku`): a local `proto`+`multi` module across all four BEGIN/no-BEGIN x single-var/list-binding combinations, plus the `Test.rakumod` scenario toggled via `MUTSU_REAL_TEST`. All local-module shapes reproduced the bug before the fix (verified via `git stash`).
- [x] `roast/S32-list/skip.t`: 55/55 under both `MUTSU_REAL_TEST=1` and native.
- [x] `make test`: green (3550 files, 35585 tests).
- [x] Targeted native + real-test roast sweep over `S32-list`, `S11-modules`, `S10-packages`, `S02-names`, `S06-*`, `S04-phasers`, `integration` (220 files, 4151 tests): PASS both providers.
- [x] `scripts/battery-testsuite.sh`: GATE PASSED (273/297).
- [x] `cargo fmt` + `cargo clippy -- -D warnings`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)