### PR TITLE
fix(modules): a required module's top-level MAIN no longer collides with the caller's

### DIFF
--- a/news/2026-08/require-toplevel-routine-scoped-to-compunit.md
+++ b/news/2026-08/require-toplevel-routine-scoped-to-compunit.md
@@ -1,0 +1,115 @@
+# A required module's top-level MAIN no longer collides with the caller's
+
+`require`-ing (or `use`-ing) a module whose own top-level `sub MAIN` collided
+with the requiring script's own top-level `sub MAIN` raised a spurious
+`X::Redeclaration`:
+
+```
+$ mutsu -e 'sub MAIN($a, $b, *@c) { say "main called" }; require HasMain;' a b c
+Redeclaration of routine 'MAIN'. Did you mean to declare a multi-sub?
+```
+
+`raku` raises nothing: the loaded module's own `sub MAIN` never runs (a
+non-exported `sub MAIN` in a `require`d/`use`d module is never the program's
+MAIN), and the caller's own MAIN still dispatches normally afterward. This is
+`roast/S06-other/main.t` test 2, `lives-ok { require HasMain }, 'MAIN in a
+module did not get executed'`, which fails only under `MUTSU_REAL_TEST=1`
+(the vendored upstream `Test.rakumod` actually asserts the message the native
+`lives-ok` provider was papering over).
+
+## Root cause: not MAIN-specific
+
+Reducing the case with no `Test` involved at all showed the bug has nothing
+to do with `MAIN` in particular — an ordinary top-level `sub helper` collides
+identically:
+
+```
+# HelperMod.rakumod: sub helper() { say "mod helper" }
+$ mutsu -e 'sub helper() { say "caller helper" }; require HelperMod; helper();'
+Redeclaration of routine 'helper'. Did you mean to declare a multi-sub?
+```
+
+Raku scopes a package-less top-level `sub name {...}` **lexically to its own
+compilation unit** — it is not installed as a shared package-stash entry the
+way an `our sub`/package-scoped routine is. Two independent compunits (a
+script and a module it requires, or two sibling modules) that happen to
+declare a same-named top-level routine must not collide with each other, and
+neither's own declarations should overwrite the other's.
+
+mutsu, however, always registers a package-less top-level routine under the
+literal `GLOBAL::<name>` function-registry key and, for a block-scoped load,
+under the bare `&name` env key too — the *same* keys the requiring/using
+script's own top-level declarations use. Loading a module whose body
+registered a same-named routine under that shared key either collided with
+(raised `X::Redeclaration` against) or silently overwrote the caller's own
+binding.
+
+This is the same root mechanism as the previously-recorded
+"cross-module-private-sub-redeclaration" finding (two sibling modules sharing
+a private helper name), just triggered from the caller-vs-module direction
+instead of module-vs-module.
+
+## Fix
+
+`Interpreter::hide_toplevel_global_routines` temporarily removes every
+already-registered package-less top-level **single** (non-`multi`) routine
+(and its bare `&name` env binding) before a `require`d/`use`d compunit's own
+body runs, so that compunit's own registrations land on a clean slate — no
+collision, and no risk of clobbering what was hidden.
+`Interpreter::restore_toplevel_global_routines` puts the hidden entries back
+once the body finishes (success or failure), so the caller's own bindings are
+exactly what they were before the load.
+
+**Multi candidates are deliberately left alone entirely** by this hide/restore
+— exported or not. A `multi` is additive across compilation units by design:
+several independent modules legitimately contribute candidates to the same
+shared name (a custom `multi trait_mod:<is>(...) is export` alongside
+`Test.rakumod`'s own `trait_mod:<is>` candidate is exactly this shape, and
+`roast/integration/advent2011-day14.t`'s `Advent::MetaBoundaryAspect` fixture
+does exactly that). Hiding a multi's existing candidates before a module's own
+body registers a new one, then blindly restoring the old ones by key
+afterward, silently overwrote the new candidate whenever it landed on the
+same derived slot key as an old one — which is exactly what an earlier
+version of this fix did, breaking the custom trait `MetaBoundaryAspect`
+registers (its `entry`/`exit` method-boundary hooks stopped firing). `EXPORT`
+is excluded from hide/restore for the same "ambient shared mechanism, don't
+touch it" reason — see below.
+
+**The generalized "reap a module's own non-exported top-level routines after
+it loads" cleanup this fix originally attempted was reverted.** It repeatedly
+collided with other ambient/ephemeral top-level mechanisms already in the
+codebase — a module's own `sub EXPORT`, and the helper subs its body commonly
+reads before installing exports (`t/sub-export.t`); NativeCall's prelude
+helpers (`nativesizeof`/`nativecast`/...), spliced as package-less `GLOBAL::`
+routines into every compunit that uses NativeCall and never themselves `is
+export`ed (`t/add-method-qualified-and-invocant.t`,
+`t/bare-array-type-match.t`) — each only discovered by a fresh `make test`
+regression after the previous exemption was added. Rather than keep
+discovering ambient mechanisms case-by-case, that generalization is deferred
+to `todo/deep/module-toplevel-private-sub-leak-cleanup.md`, and the leak
+cleanup this PR ships stays scoped to `MAIN` only — the pre-existing,
+long-safe `remove_leaked_main_routines` behavior, unchanged: a leaked,
+non-exported `MAIN` candidate must never remain reachable at the dispatchable
+auto-dispatch key, which is a distinct safety concern from ordinary
+leak-prevention. **A module's own non-exported top-level `sub` (other than
+`MAIN`) can still leak into the caller's scope after a successful load** —
+that is the known, still-open gap the follow-up ticket tracks; it predates
+this fix and is not made worse by it.
+
+## Verification
+
+- `roast/S06-other/main.t`: all 23 assertions pass under both the native TAP
+  provider and `MUTSU_REAL_TEST=1`.
+- `roast/integration/advent2011-day14.t`: all 8 assertions pass under both
+  providers (was regressed by an earlier version of this fix, see above).
+- New pins (both green under real `raku`):
+  `t/require-toplevel-routine-scoped-to-compunit.t` (4 assertions), covering
+  both `require` and `use`, and both `sub MAIN` and an ordinary `sub helper`
+  (fixtures: `t/lib/ToplevelMainCollision.rakumod`,
+  `t/lib/ToplevelHelperCollision.rakumod`);
+  `t/require-toplevel-multi-candidate-not-leaked.t` (2 assertions), covering
+  the multi-candidate-across-modules case (fixtures:
+  `t/lib/SharedMultiHost.rakumod`, `t/lib/SharedMultiContrib.rakumod`).
+- `make test` (3551 files) and a targeted native-provider roast sweep passed;
+  see the 2026-08-29 entry in `todo/deep/vendor-real-test-module.md` for the
+  full before/after sweep numbers under both providers.

--- a/src/runtime/builtins_system_require.rs
+++ b/src/runtime/builtins_system_require.rs
@@ -1,6 +1,14 @@
 use super::*;
 use crate::value::ValueView;
 
+/// What [`Interpreter::hide_toplevel_global_routines`] set aside, to be
+/// handed back to [`Interpreter::restore_toplevel_global_routines`] once the
+/// loaded compunit's own body has finished running.
+pub(crate) struct HiddenToplevelRoutines {
+    functions: Vec<(Symbol, std::sync::Arc<FunctionDef>)>,
+    amp_env: Vec<(String, Value)>,
+}
+
 impl Interpreter {
     fn missing_symbol_name_from_failure(value: &Value) -> Option<String> {
         let ValueView::Instance {
@@ -162,23 +170,31 @@ impl Interpreter {
             }
             _ => self.set_current_package("GLOBAL".to_string()),
         }
+        // See `hide_toplevel_global_routines`: a package-less top-level routine
+        // in the required file (e.g. its own `sub MAIN`) must not collide with
+        // -- or silently overwrite -- a same-named one the requiring scope
+        // already declared.
+        let hidden_toplevel = self.hide_toplevel_global_routines();
         let run_result = self.run_block(&stmts);
         self.set_current_package(saved_package);
-        run_result?;
-
-        // A `sub MAIN` defined in a required module is NOT the program's MAIN
-        // and must not be auto-dispatched at program end -- unless the module
-        // *exported* MAIN (`proto MAIN(|) is export`, as zef does), in which case
-        // it becomes the importer's MAIN. Remove only non-exported leaked MAINs.
-        self.promote_exported_main_to_global();
-        let main_exported = self.exported_subs.values().any(|m| m.contains_key("MAIN"));
-        Self::remove_leaked_main_routines(
-            &mut self.registry_mut().functions,
-            &before_function_keys,
-            main_exported,
-        );
+        if run_result.is_ok() {
+            // A `sub MAIN` defined in a required module is NOT the program's MAIN
+            // and must not be auto-dispatched at program end -- unless the module
+            // *exported* MAIN (`proto MAIN(|) is export`, as zef does), in which
+            // case it becomes the importer's MAIN. Remove only non-exported
+            // leaked MAINs.
+            self.promote_exported_main_to_global();
+            let main_exported = self.exported_subs.values().any(|m| m.contains_key("MAIN"));
+            Self::remove_leaked_main_routines(
+                &mut self.registry_mut().functions,
+                &before_function_keys,
+                main_exported,
+            );
+        }
+        self.restore_toplevel_global_routines(hidden_toplevel);
         // Invalidate name-keyed resolution caches.
         self.fn_resolve_gen += 1;
+        run_result?;
 
         if let Some(pkg) = package_hint
             && !pkg.is_empty()
@@ -296,6 +312,146 @@ impl Interpreter {
         }
     }
 
+    /// True when `key` is a bare, package-less **single** (non-multi)
+    /// top-level routine's registry key: `GLOBAL::<name>`, with no further
+    /// `::` and no multi-candidate `/<sig>` suffix in `<name>`.
+    ///
+    /// Deliberately excludes two shapes: a `package Foo { ... }`-scoped
+    /// routine (`GLOBAL::Foo::bar`, or one declared directly under a named
+    /// package) is a real, shared global stash entry, not the package-less
+    /// declaration this machinery targets. And a **multi** candidate slot
+    /// (`GLOBAL::<name>/<sig>`) is deliberately additive across compunits --
+    /// unlike a plain `sub`, several independent modules contributing a
+    /// candidate to the same package-less multi (e.g. a custom
+    /// `multi trait_mod:<is>(...) is export` from one module alongside
+    /// another module's own candidates of the same name) is the intended,
+    /// legitimate pattern, not a collision to guard against. Hiding a
+    /// multi's existing candidates before a module's own body registers a
+    /// new one -- then blindly restoring the old ones by key afterward --
+    /// would silently overwrite the new candidate whenever it lands on the
+    /// same derived slot key as an old one (`roast/integration/advent2011-day14.t`'s
+    /// `Advent::MetaBoundaryAspect` fixture, whose own `multi trait_mod:<is>`
+    /// candidate was getting clobbered by Test.rakumod's own candidates this
+    /// way). So multi routines are left alone entirely: only a genuinely
+    /// `!multi` package-less top-level `sub` is ever hidden/restored/reaped.
+    ///
+    /// Also excludes `EXPORT`: a `sub EXPORT {...}` always registers as
+    /// `GLOBAL::EXPORT` regardless of the module's own package (see
+    /// `Interpreter::apply_module_export`), but it is a transient, per-load
+    /// magic name that `apply_module_export` calls and then immediately
+    /// deletes via `remove_export_routine`, entirely *after* this module's
+    /// own `run_block` (and this hide/restore) has already finished. Hiding
+    /// it like an ordinary top-level sub, for a nested `use` reached from
+    /// inside another module's own `EXPORT` call, restored an *outer*
+    /// module's stale `GLOBAL::EXPORT` over the inner module's fresh one
+    /// before `apply_module_export` got to read it, silently breaking every
+    /// `is export`/`sub EXPORT` symbol in that shape (`t/sub-export.t`).
+    fn is_toplevel_global_routine_key(key: &str) -> bool {
+        key.strip_prefix("GLOBAL::")
+            .is_some_and(|tail| !tail.contains("::") && !tail.contains('/') && tail != "EXPORT")
+    }
+
+    /// Temporarily remove every already-registered package-less top-level
+    /// routine (and its bare `&name` env binding, if any) before a
+    /// `require`d/`use`d compunit's own body runs. Pair with
+    /// [`Self::restore_toplevel_global_routines`] once that body finishes.
+    ///
+    /// Raku scopes a package-less top-level `sub name {...}` lexically to its
+    /// own compilation unit -- it is NOT installed as a shared `GLOBAL::name`
+    /// stash entry the way an `our sub`/package-scoped routine is, even
+    /// though mutsu currently registers it that way (both here and in the
+    /// calling script). Two independent compunits that happen to declare a
+    /// same-named top-level routine -- a script and a module it requires both
+    /// declaring `sub MAIN`, or two sibling modules each with a private `sub
+    /// helper` -- must not collide with each other, and the loaded compunit's
+    /// own routines must not silently overwrite the calling scope's. Hiding
+    /// the calling scope's entries while the loaded compunit's own body runs
+    /// (so its own registrations land on a clean slate, without erroring) and
+    /// restoring them afterward achieves both at once.
+    pub(crate) fn hide_toplevel_global_routines(&mut self) -> HiddenToplevelRoutines {
+        let keys: Vec<Symbol> = self
+            .registry()
+            .functions
+            .keys()
+            .filter(|k| Self::is_toplevel_global_routine_key(&k.resolve()))
+            .copied()
+            .collect();
+        let mut functions = Vec::with_capacity(keys.len());
+        for k in keys {
+            if let Some(v) = self.registry_mut().functions.remove(&k) {
+                functions.push((k, v));
+            }
+        }
+        let amp_keys: Vec<String> = self
+            .env
+            .keys()
+            .map(|k| k.resolve())
+            .filter(|k| {
+                k.strip_prefix('&').is_some_and(|name| {
+                    !name.is_empty()
+                        && Self::is_toplevel_global_routine_key(&format!("GLOBAL::{name}"))
+                })
+            })
+            .collect();
+        let mut amp_env = Vec::with_capacity(amp_keys.len());
+        for k in amp_keys {
+            if let Some(v) = self.env.remove(&k) {
+                amp_env.push((k, v));
+            }
+        }
+        if !functions.is_empty() || !amp_env.is_empty() {
+            self.fn_resolve_gen += 1;
+        }
+        HiddenToplevelRoutines { functions, amp_env }
+    }
+
+    /// Restore what [`Self::hide_toplevel_global_routines`] hid, undoing any
+    /// same-keyed registration the loaded compunit's own body made -- its own
+    /// top-level routines are private to it. An `is export`ed one reaches the
+    /// caller through the separate `register_exported_sub`/
+    /// `apply_module_export` path (and, for the `MAIN`-dispatch case,
+    /// `promote_exported_main_to_global`), independent of this restore.
+    pub(crate) fn restore_toplevel_global_routines(&mut self, hidden: HiddenToplevelRoutines) {
+        let HiddenToplevelRoutines { functions, amp_env } = hidden;
+        if !functions.is_empty() {
+            for (k, v) in functions {
+                self.registry_mut().functions.insert(k, v);
+            }
+            self.fn_resolve_gen += 1;
+        }
+        for (k, v) in amp_env {
+            self.env.insert(k, v);
+        }
+    }
+
+    /// Remove top-level `MAIN` routines that were registered while loading a
+    /// module (via `require`/`use`). A `sub MAIN` declared in a loaded module
+    /// is not the program's MAIN and must not be auto-dispatched at program
+    /// end. `before_keys` is the set of function-registry keys that existed
+    /// before the module body ran; only newly-added MAIN keys are removed.
+    ///
+    /// Deliberately scoped to `MAIN` only, not every package-less top-level
+    /// routine a module declares. An earlier version of this fix generalized
+    /// it to sweep any newly-registered, non-`is export`ed top-level name,
+    /// matching how raku scopes a package-less `sub name {...}` lexically to
+    /// its own compilation unit -- but that generalization kept colliding
+    /// with other ambient/ephemeral top-level mechanisms this codebase
+    /// already relies on: a module's own private helper subs its `sub
+    /// EXPORT` body reads before installing its exports
+    /// (`t/sub-export.t`), and NativeCall's prelude helpers
+    /// (`nativesizeof`/`nativecast`/...), which are deliberately spliced as
+    /// package-less `GLOBAL::` routines into every compunit that uses
+    /// NativeCall and are never `is export`ed themselves
+    /// (`PRELUDE_SUB_TRAIT` in `runtime/mod.rs`). Each fix widened the
+    /// exemption list; rather than keep discovering new ambient mechanisms
+    /// case-by-case, the general "reap a module's non-exported package-less
+    /// top-level routines after it loads" cleanup is left as a follow-up
+    /// (`todo/deep/module-toplevel-private-sub-leak-cleanup.md`) and only the
+    /// MAIN-specific removal -- proven safe for years -- is kept here.
+    /// [`Self::hide_toplevel_global_routines`] /
+    /// [`Self::restore_toplevel_global_routines`] still fix the acute bug
+    /// (the false `X::Redeclaration` and the caller-binding clobber) for
+    /// every package-less top-level single routine, not just MAIN.
     pub(crate) fn remove_leaked_main_routines(
         functions: &mut rustc_hash::FxHashMap<Symbol, std::sync::Arc<FunctionDef>>,
         before_keys: &std::collections::HashSet<Symbol>,

--- a/src/runtime/run_modules.rs
+++ b/src/runtime/run_modules.rs
@@ -818,6 +818,11 @@ impl Interpreter {
             // mainline runs in this interpreter, so restore the caller's mode
             // after it finishes instead of letting `use strict` leak outward.
             let saved_strict_mode = self.strict_mode;
+            // See `hide_toplevel_global_routines`: a package-less top-level
+            // routine in the module (e.g. its own `sub MAIN`) must not collide
+            // with -- or silently overwrite -- a same-named one the loading
+            // scope already declared.
+            let hidden_toplevel = self.hide_toplevel_global_routines();
             let result = self.run_block(&stmts);
             self.strict_mode = saved_strict_mode;
             let imported = std::mem::replace(&mut self.module_imported_names, saved_imports);
@@ -871,19 +876,27 @@ impl Interpreter {
                 self.unit_module_loading_stack.pop();
             }
             self.set_current_package(saved_package);
-            result?;
-            // A `sub MAIN` defined in a used module is NOT the program's MAIN
-            // and must not be auto-dispatched at program end -- unless the module
-            // *exported* MAIN (`proto MAIN(|) is export`, as zef's CLI does).
-            self.promote_exported_main_to_global();
-            let main_exported = self.exported_subs.values().any(|m| m.contains_key("MAIN"));
-            Self::remove_leaked_main_routines(
-                &mut self.registry_mut().functions,
-                &before_function_keys,
-                main_exported,
-            );
+            if result.is_ok() {
+                // A `sub MAIN` defined in a used module is NOT the program's MAIN
+                // and must not be auto-dispatched at program end -- unless the
+                // module *exported* MAIN (`proto MAIN(|) is export`, as zef's CLI
+                // does). Remove only non-exported leaked MAINs.
+                self.promote_exported_main_to_global();
+                let main_exported = self.exported_subs.values().any(|m| m.contains_key("MAIN"));
+                Self::remove_leaked_main_routines(
+                    &mut self.registry_mut().functions,
+                    &before_function_keys,
+                    main_exported,
+                );
+            }
+            // See `hide_toplevel_global_routines`: restore the loading scope's
+            // own top-level routines regardless of whether the module's body
+            // ran to completion -- a partial/aborted load must not leave them
+            // hidden.
+            self.restore_toplevel_global_routines(hidden_toplevel);
             // Invalidate name-keyed resolution caches.
             self.fn_resolve_gen += 1;
+            result?;
             // If the module defined `sub EXPORT`, call it with the `use` args and
             // install the symbols it returns into the caller's scope.
             self.apply_module_export(export_args.unwrap_or_default())?;

--- a/t/lib/SharedMultiContrib.rakumod
+++ b/t/lib/SharedMultiContrib.rakumod
@@ -1,0 +1,6 @@
+# Package-less (no `unit module`) on purpose: this contributes a second
+# candidate to a multi another, already-loaded module (SharedMultiHost) also
+# exports under the same bare name -- the shape
+# roast/packages/Advent/lib/Advent/MetaBoundaryAspect.rakumod uses for its
+# own `multi trait_mod:<is>`.
+multi sub shared-multi(Str $x) is export { "str:$x" }

--- a/t/lib/SharedMultiHost.rakumod
+++ b/t/lib/SharedMultiHost.rakumod
@@ -1,0 +1,2 @@
+unit module SharedMultiHost;
+multi sub shared-multi(Int $x) is export { "int:$x" }

--- a/t/lib/ToplevelHelperCollision.rakumod
+++ b/t/lib/ToplevelHelperCollision.rakumod
@@ -1,0 +1,5 @@
+# A package-less, non-exported top-level `sub helper` -- lexically scoped to
+# this compunit in raku. It must not collide with (or overwrite) a same-named
+# top-level sub in the requiring/using scope, and must not leak into that
+# scope as a bare, callable name when there was no such collision.
+sub helper() { "module helper" }

--- a/t/lib/ToplevelMainCollision.rakumod
+++ b/t/lib/ToplevelMainCollision.rakumod
@@ -1,0 +1,9 @@
+# A package-less top-level `sub MAIN`, plus one nested in a `module { ... }`
+# block -- mirrors roast/packages/HasMain/lib/HasMain.rakumod. Neither is
+# `is export`, so neither should ever run, and neither should collide with a
+# same-named top-level `sub MAIN` in the requiring/using scope: raku scopes a
+# package-less top-level routine lexically to its own compilation unit.
+module ToplevelMainCollision {
+    sub MAIN() { say "should-not-run nested MAIN" }
+}
+sub MAIN() { say "should-not-run toplevel MAIN" }

--- a/t/require-toplevel-multi-candidate-not-leaked.t
+++ b/t/require-toplevel-multi-candidate-not-leaked.t
@@ -1,0 +1,33 @@
+use v6;
+use Test;
+use lib 't/lib';
+
+# A package-less top-level `multi sub` contributed by a module must NOT be
+# treated as a "leaked" declaration and swept away, even when it shares its
+# bare name with a multi another, already-loaded module also exports.
+#
+# Multi routines are additive across compilation units by design (many
+# modules legitimately contribute candidates to the same shared name -- e.g.
+# a custom `multi trait_mod:<is>` alongside Test.rakumod's own). Export
+# bookkeeping is a per-name set, not a per-candidate one, so "was this name
+# already exported by an earlier module" cannot be told apart from "this
+# module's own new candidate happens to share that name" by a naive diff --
+# which is exactly the bug this pins.
+#
+# See roast/integration/advent2011-day14.t's `Advent::MetaBoundaryAspect`
+# fixture (a package-less `multi trait_mod:<is>(...) is export` that lost its
+# own candidate the same way, silently breaking the custom trait it
+# registers) and todo/deep/vendor-real-test-module.md's 2026-08-29 entry.
+
+plan 2;
+
+my $exe = $*EXECUTABLE;
+
+my $r = run(
+    $exe, '-I', 't/lib', '-e',
+    'use SharedMultiHost; use SharedMultiContrib; say shared-multi(1); say shared-multi("a");',
+    :out, :err,
+);
+is $r.out.slurp(:close), "int:1\nstr:a\n",
+    'both modules\' candidates for the shared multi are callable after loading';
+is $r.err.slurp(:close), '', 'no error output';

--- a/t/require-toplevel-routine-scoped-to-compunit.t
+++ b/t/require-toplevel-routine-scoped-to-compunit.t
@@ -1,0 +1,62 @@
+use v6;
+use Test;
+
+# A `require`d/`use`d compunit's own package-less top-level routines (its own
+# `sub MAIN`, or an ordinary `sub helper`) must not collide with -- or
+# silently overwrite -- a same-named routine the loading scope already
+# declared. Raku scopes such a routine lexically to its own compilation unit,
+# even though mutsu currently installs it at the shared `GLOBAL::<name>`
+# registry key both scopes use for a package-less top-level declaration.
+#
+# See roast/S06-other/main.t ("MAIN in a module did not get executed") and
+# todo/deep/vendor-real-test-module.md's 2026-08-29 entry for the bug this
+# pins, and the related cross-module-private-sub-redeclaration finding for
+# the sibling case (two modules, not caller-vs-module).
+#
+# This does NOT pin the mirror-image "a module's own non-exported top-level
+# routine must not leak into the loading scope" behavior -- that is a
+# separate, still-open gap tracked in
+# todo/deep/module-toplevel-private-sub-leak-cleanup.md.
+
+plan 4;
+
+my $exe = $*EXECUTABLE;
+
+# `require`-ing a module whose own top-level `sub MAIN` collides with the
+# caller's own top-level `sub MAIN` must not raise X::Redeclaration, and the
+# module's MAIN (neither the nested-package one nor the top-level one) must
+# ever be auto-dispatched -- the caller's own MAIN wins.
+{
+    my $r = run(
+        $exe, '-I', 't/lib', '-e',
+        'sub MAIN($a, $b, *@c) { say "main called $a $b @c[]" }; require ToplevelMainCollision; say "lived";',
+        'a', 'b', 'c', :out, :err,
+    );
+    is $r.out.slurp(:close), "lived\nmain called a b c\n",
+        'require-ing a module with a colliding top-level MAIN keeps the caller\'s own MAIN';
+    is $r.err.slurp(:close), '', 'no error output';
+}
+
+# Same, via `use` instead of `require`.
+{
+    my $r = run(
+        $exe, '-I', 't/lib', '-e',
+        'sub MAIN($a, $b, *@c) { say "main called $a $b @c[]" }; use ToplevelMainCollision; say "lived";',
+        'a', 'b', 'c', :out, :err,
+    );
+    is $r.out.slurp(:close), "lived\nmain called a b c\n",
+        'use-ing a module with a colliding top-level MAIN keeps the caller\'s own MAIN';
+}
+
+# A plain (non-MAIN) top-level routine collides the same way: requiring a
+# module with its own private top-level `sub helper` must not clobber the
+# caller's own same-named routine.
+{
+    my $r = run(
+        $exe, '-I', 't/lib', '-e',
+        'sub helper() { "caller helper" }; require ToplevelHelperCollision; say helper();',
+        :out, :err,
+    );
+    is $r.out.slurp(:close).trim, 'caller helper',
+        'require-ing a module with a colliding top-level sub keeps the caller\'s own binding';
+}

--- a/todo/deep/module-toplevel-private-sub-leak-cleanup.md
+++ b/todo/deep/module-toplevel-private-sub-leak-cleanup.md
@@ -1,0 +1,109 @@
+# A module's own non-exported top-level routine leaks into the loading scope
+
+`require`-ing or `use`-ing a module whose own package-less top-level `sub`
+declaration is NOT `is export`ed still leaves that sub permanently callable,
+bare, from the loading scope after the load finishes -- which raku does not
+do (a package-less top-level `sub name {...}` is lexically scoped to its own
+compilation unit).
+
+Minimal repro (no deps):
+
+```
+# HelperMod.rakumod: sub helper() { say "mod helper" }
+$ mutsu -e 'require HelperMod; helper();'
+mod helper                      # raku: compile-time "Undeclared routine: helper"
+```
+
+`raku -e '...'` for the same source dies at compile time with `Undeclared
+routine: helper`; mutsu prints `mod helper` and exits 0.
+
+## Root cause
+
+mutsu always registers a package-less top-level routine under the literal
+`GLOBAL::<name>` function-registry key (see
+`Interpreter::hide_toplevel_global_routines`'s doc comment in
+`src/runtime/builtins_system_require.rs` for the full picture) -- the same
+key any OTHER package-less top-level declaration, including the loading
+scope's own, would use. Nothing currently distinguishes "this routine was
+exported and should reach the importer" from "this routine was merely
+declared, non-exported, and should stay private to its own compunit" at the
+level of what remains reachable after a load finishes.
+
+## Why this is filed separately, not fixed inline
+
+`fix/require-mod-main-redeclaration` (PR landing alongside this ticket) fixed
+the sibling, acute bug: a same-named package-less top-level routine in the
+requiring script AND the required module raised a false `X::Redeclaration`
+(or silently overwrote the caller's own binding when it didn't). That fix
+added `Interpreter::hide_toplevel_global_routines` /
+`restore_toplevel_global_routines`, which temporarily hide the loading
+scope's own package-less top-level routines while the loaded compunit's body
+runs, then restore them -- this alone is sufficient to stop the collision and
+protect the caller's own bindings, and does not need to know anything about
+export status.
+
+Fixing (or leaking) a module's own NON-exported top-level routine was
+initially attempted as a bonus generalization of the old `MAIN`-only
+`remove_leaked_main_routines` sweep (delete any newly-registered,
+non-`is export`ed top-level routine after a successful load). That
+generalization repeatedly collided with other ambient/ephemeral top-level
+mechanisms already in the codebase, each discovered only by a full `make
+test` regression after the previous fix:
+
+- **`sub EXPORT` itself** (`Interpreter::apply_module_export`) always
+  registers as `GLOBAL::EXPORT`, is never itself `is export`ed, and is
+  read+deleted by `apply_module_export` strictly *after* the module's own
+  `run_block` returns -- a naive sweep deleted it before that call, and
+  `apply_module_export`'s own `EXPORT` invocation commonly reads the
+  module's OTHER private top-level subs too (`sub EXPORT($lang) { ... &greet-fr
+  ... }`, `t/sub-export.t` "EXPORT selects among existing module subs by
+  argument") -- sweeping those before the call also broke it.
+- **NativeCall's prelude helpers** (`nativesizeof`, `nativecast`, `cglobal`,
+  ...) are deliberately spliced as package-less `GLOBAL::` routines into
+  every compunit that uses NativeCall (`PRELUDE_SUB_TRAIT` in
+  `src/runtime/mod.rs`) and are never `is export`ed themselves -- a naive
+  sweep deleted the first module's copy once a LATER, unrelated module
+  finished loading (`t/add-method-qualified-and-invocant.t`,
+  `t/bare-array-type-match.t`).
+- **Multi candidates** are additive across compunits by design (several
+  modules legitimately contribute candidates to the same shared name, e.g. a
+  custom `multi trait_mod:<is>(...) is export` alongside `Test.rakumod`'s
+  own) and export bookkeeping (`exported_subs`) is a per-name *set*, not a
+  per-candidate record, so a before/after diff of it cannot tell "this name
+  was already exported by an earlier module" from "this module's own new
+  candidate happens to share that name" (`roast/integration/advent2011-day14.t`'s
+  `Advent::MetaBoundaryAspect` fixture).
+
+Each fix widened the exemption list without any confidence the list was now
+exhaustive. Rather than keep discovering ambient mechanisms case-by-case
+under `make test`, the generalization was reverted: `remove_leaked_main_routines`
+stays scoped to `MAIN` only (the one name whose leak has a distinct, narrow
+safety concern -- an un-exported leaked `MAIN` candidate must never remain
+reachable at the dispatchable auto-dispatch key), and this repro is left
+unfixed. See `news/2026-08/require-toplevel-routine-scoped-to-compunit.md`
+for the full writeup of what shipped and what did not.
+
+## What a real fix needs
+
+An exhaustive audit of every mechanism that installs a package-less
+`GLOBAL::<name>` function-registry entry outside of an ordinary user
+`sub`/`multi sub` declaration, so a leak-sweep can positively identify "this
+is one of the known persistent/ambient kinds, never touch it" rather than
+guessing from a `newly-registered && not is-export` heuristic that keeps
+being wrong. Candidates to grep for: `PRELUDE_SUB_TRAIT`, `EXPORT`-shaped
+runtime hooks (`EXPORTHOW`, `sub EXPORT`), anything the compiler/registration
+path treats as "GLOBAL regardless of package" by convention rather than by
+explicit `unit module`/`package` declaration. Once that list is closed, the
+same `remove_leaked_toplevel_routines` shape this ticket's PR tried (diff of
+`exported_subs` before/after a specific load, scoped to package-less single
+routines, explicitly excluding known-ambient names) should work.
+
+## Impact
+
+Narrow in practice: the leaked routine is only reachable if the caller
+happens to call it bare by the exact same name the module used internally,
+and roast's own suite did not surface this as a failure (no whitelisted file
+regressed from leaving it unfixed). It is nonetheless a genuine
+lexical-scoping divergence from raku, and the same root mechanism as the
+already-recorded (fixed, but only for the module-vs-module direction)
+cross-module-private-sub-redeclaration finding.

--- a/todo/deep/vendor-real-test-module.md
+++ b/todo/deep/vendor-real-test-module.md
@@ -5320,3 +5320,66 @@ under real `raku`). Verification: `make test` green; a targeted
 native-provider roast sweep over `S32-list`, `S11-modules`, `S10-packages`,
 `S02-names`, `S06-*`, `S04-phasers`, `integration` green;
 `scripts/battery-testsuite.sh` gate passed.
+
+## 2026-08-29/30: `S06-other/main.t` closed -- a `require`d module's top-level MAIN collided with the caller's
+
+`require`-ing (or `use`-ing) a module whose own top-level `sub MAIN` collided
+with the requiring script's own top-level `sub MAIN` raised a spurious
+`X::Redeclaration`, which is test 2 of this file
+(`lives-ok { require HasMain }, 'MAIN in a module did not get executed'`).
+Reducing the case showed the bug is not MAIN-specific at all: an ordinary
+top-level `sub helper` collides identically, because mutsu always registers a
+package-less top-level routine under the literal `GLOBAL::<name>`
+function-registry key -- the same key the requiring script's own top-level
+declarations use, and raku instead scopes lexically to each compilation unit.
+
+Fix: `Interpreter::hide_toplevel_global_routines` /
+`restore_toplevel_global_routines` (`src/runtime/builtins_system_require.rs`)
+temporarily hide the loading scope's own package-less top-level **single**
+(non-`multi`) routines while a `require`d/`use`d compunit's own body runs, and
+restore them afterward -- no collision, and no risk of clobbering what was
+hidden. Two iterations of this fix regressed other whitelisted files before
+landing (both caught by `make test`, not by this sweep):
+
+- Hiding/leak-sweeping **multi** candidates too broke
+  `roast/integration/advent2011-day14.t`: multis are additive across
+  compunits by design (`Advent::MetaBoundaryAspect`'s own
+  `multi trait_mod:<is>(...) is export` candidate alongside `Test.rakumod`'s
+  own), so multis are now left alone entirely by this mechanism.
+- A generalized "reap a module's own non-exported top-level routines after
+  loading" cleanup (an attempted bonus fix for the sibling leak direction)
+  broke `t/sub-export.t` and NativeCall-using tests by deleting a module's own
+  `sub EXPORT` and its helper subs before `apply_module_export` could read
+  them, and NativeCall's prelude helpers (`nativesizeof`/`nativecast`/...)
+  once an unrelated later module finished loading. That generalization was
+  reverted; the leak-cleanup this PR ships stays scoped to `MAIN` only,
+  matching the pre-existing, long-safe `remove_leaked_main_routines`
+  behavior. The general non-`MAIN` leak (a module's own non-exported
+  top-level `sub` can still become reachable bare from the loading scope) is
+  a known, still-open gap filed as
+  `todo/deep/module-toplevel-private-sub-leak-cleanup.md`.
+
+| file | real Test before | after | native before | after |
+| --- | --- | --- | --- | --- |
+| `S06-other/main.t` | 1 failure (test 2, `X::Redeclaration`) | **PASS** (23/23) | PASS | PASS |
+| `integration/advent2011-day14.t` | PASS | PASS (8/8, regressed then re-fixed mid-PR) | PASS | PASS |
+
+Fix and pin: `news/2026-08/require-toplevel-routine-scoped-to-compunit.md`,
+`t/require-toplevel-routine-scoped-to-compunit.t` (4 assertions) and
+`t/require-toplevel-multi-candidate-not-leaked.t` (2 assertions), both green
+under real `raku`. Verification: `make test` green (3551 files, 35583 tests);
+a 254-file targeted native-provider roast sweep (`S06-*`, `S11-modules`,
+`S10-packages`, `S02-names`, `S32-exceptions`, `integration`) on a release
+build PASS (5150 tests); `scripts/battery-testsuite.sh` GATE PASSED
+(273/297); a full `scripts/roast-test-module-sweep.sh` re-run (1436
+whitelisted files, both providers, release): `pass under both` 1425,
+`regressed under the real Test` 11 -- all 11 are the pre-existing, already
+documented residue (4 `exit 124` timeout artifacts under `-j6` load in the
+sprintf/buf family, plus `S24-testing/{10-is-approx,2-force_todo,3-output,
+6-done_testing}.t`, `S32-io/io-cathandle.t`, `S32-list/skip.t`,
+`S32-num/rat.t`), `fail under both` 0. Closes this file's row in the
+"Remaining, and what each is" table above. `S32-list/skip.t` was in that
+residue list at measurement time; a sibling PR closed it independently in the
+same window (see the "routine-value self-recursion" entry immediately above)
+-- re-verify before trusting this file's residue count going forward, per
+this ticket's own standing rule.


### PR DESCRIPTION
## Summary

- `require`-ing (or `use`-ing) a module whose own top-level `sub MAIN` collided with the requiring script's own top-level `sub MAIN` raised a spurious `X::Redeclaration`. Fixes `roast/S06-other/main.t` test 2 (`lives-ok { require HasMain }, 'MAIN in a module did not get executed'`), which fails only under `MUTSU_REAL_TEST=1`.
- Root cause is not MAIN-specific: mutsu always registers a package-less top-level routine under the literal `GLOBAL::<name>` function-registry key -- the same key the requiring script's own top-level declarations use -- while raku scopes such a declaration lexically to its own compilation unit.
- `Interpreter::hide_toplevel_global_routines` / `restore_toplevel_global_routines` (`src/runtime/builtins_system_require.rs`) temporarily hide the loading scope's own package-less top-level **single** (non-`multi`) routines while a `require`d/`use`d compunit's own body runs, and restore them afterward, so registration never collides and never clobbers the caller's own binding.
- **Multi candidates are deliberately left untouched** by this mechanism -- they are additive across compunits by design. An earlier iteration of this fix broke `roast/integration/advent2011-day14.t`'s custom `multi trait_mod:<is>(...) is export` by hiding/restoring multi candidates too.
- A generalized non-`MAIN` leak-cleanup (deleting a module's own non-exported top-level routines after it loads) was also attempted and reverted: it broke `t/sub-export.t` (deleting a module's own `sub EXPORT` and the helper subs its body reads) and NativeCall-using tests (deleting `nativesizeof`/`nativecast`/... prelude helpers). That leak direction is filed as a follow-up in `todo/deep/module-toplevel-private-sub-leak-cleanup.md`; the cleanup this PR ships stays scoped to `MAIN` only, matching the pre-existing `remove_leaked_main_routines` behavior unchanged.

## Test plan

- [x] New pins: `t/require-toplevel-routine-scoped-to-compunit.t` (4 assertions) and `t/require-toplevel-multi-candidate-not-leaked.t` (2 assertions), both green under real `raku`.
- [x] `roast/S06-other/main.t`: all 23 assertions pass under both the native TAP provider and `MUTSU_REAL_TEST=1`.
- [x] `roast/integration/advent2011-day14.t`: all 8 assertions pass under both providers.
- [x] `make test` green (3552 files, 35591 tests).
- [x] A 254-file targeted native-provider roast sweep (`S06-*`, `S11-modules`, `S10-packages`, `S02-names`, `S32-exceptions`, `integration`) on a release build: PASS (5150 tests).
- [x] A full `scripts/roast-test-module-sweep.sh` re-run (1436 whitelisted files, both providers, release): `pass under both` 1425, `regressed under the real Test` 11 -- all pre-existing, already-documented residue (timeout artifacts + `S24-testing`/`S32-io`/`S32-num` gaps unrelated to this fix), `fail under both` 0.
- [x] `scripts/battery-testsuite.sh`: GATE PASSED (273/297).
- [x] `cargo fmt` + `cargo clippy -- -D warnings`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)