### PR TITLE
perf(vm): the rw map loop no longer re-runs the compiler on every call

### DIFF
--- a/news/2026-08/bench-ctor-map-compile-and-atomic-lane-probe.md
+++ b/news/2026-08/bench-ctor-map-compile-and-atomic-lane-probe.md
@@ -1,0 +1,104 @@
+# bench-ctor: the rw map loop re-ran the whole compiler on every call
+
+`bench-ctor` — the heavy-constructor benchmark modelled on `Zef::Distribution`
+(21 attributes, a user `method new(*%_)` delegating to `self.bless`, and `TWEAK`
+submethods at two MRO levels) — had drifted to **1.31x rakudo** in the bench CI.
+Decomposing the benchmark into the four features it layers on top of a plain
+`.new` located the cost precisely.
+
+Interleaved same-session A/B, release builds of this change and of its revert,
+`taskset -c 2`, best of 9, 5000 constructions:
+
+| variant | before | after | raku |
+|---|---|---|---|
+| A: 21-attribute class, plain `.new` | 0.0551 | 0.0562 | 0.2208 |
+| B: + a parent class with `TWEAK` | 0.0737 | 0.0755 | 0.2367 |
+| C: + `method new(*%_) { self.bless(\|%_, :meta(%_)) }` | 0.1365 | 0.1354 | 0.2561 |
+| D: + child `TWEAK` with attributive params and `--> Nil` | 0.1545 | 0.1544 | 0.2691 |
+| full: + `@!resources = @!resources.map(*.flat)` | **0.2515** | **0.2191** | 0.2904 |
+
+The whole win is the last row: one `.map` over an **empty** attribute array.
+Everything above it is unchanged (the ±2% spread on A/B/C is binary-layout
+noise). `perf stat`: 2.172G → 1.951G instructions for the run, i.e. **434k →
+390k per construction (−10.1%)**; wall clock **−12.9%**.
+
+The local raku ratio is deliberately not quoted as the headline: this box's
+rakudo v2026.06 is much faster than the 4-core CI runner's pinned build, so the
+local ratio (well under 1.0 both before and after) is not comparable to the CI
+series. `bench-history.tsv` on `bench-data` is the authority for that number.
+
+## Root cause: `eval_map_over_items_rw` never got the compile cache
+
+`compile_loop_block_cached` (added with the map/grep compile cache, #6710) keys a
+compiled block on its origin `CompiledCode` plus whether a routine is on the
+stack, so a `.map` whose block is the same closure literal compiles once for the
+life of the program. `eval_map_over_items`, `eval_first_over_items` and the rw
+grep loop all go through it — but `eval_map_over_items_rw`, the path every
+`@array.map(...)` and `@!attr.map(...)` takes, still called
+`Compiler::new().compile(&normalized_body)` directly. A `rust-gdb` breakpoint on
+`CompiledCode::add_constant` caught it red-handed: the backtrace ran
+`add_constant` → `compile_expr_var` → `compile_expr` → `compile_unit` →
+`Compiler::compile` → `eval_map_over_items_rw`, on every single iteration.
+`MUTSU_VM_STATS=1` over a 100000-call loop counted **300017 constant-pool
+additions at runtime**; with the cache it is **20**. On `bench-ctor` itself:
+15044 → 44.
+
+Going through the cache also brings this path in line with its siblings on
+`lexically_in_routine`, which is what decides whether a typed `my` inside the
+block is frame-scoped.
+
+## Second cause: an empty `.map` paid the whole setup for nothing
+
+Even with the compile cached, an empty input still walked the block's captured
+env to build the save/restore key list, mirrored those keys into the running env,
+built the nested-register frame and tore it all down again — to run the block
+zero times. Both `Sub` branches of `eval_map_over_items_rw` reach exactly
+`(Value::array(vec![]), false)` for an empty input, so it now returns that
+directly. As a side effect an inner empty map can no longer remove an enclosing
+map's `topic_key` mid-iteration.
+
+`@!resources.map(*.flat)` inside a `TWEAK` — an empty attribute array mapped in
+place — is a shape real code uses, not a benchmark artefact. The isolated micro
+(5000 such calls inside a method) went **0.0985s → 0.0789s, −20%**.
+
+## Third cause: every `@`/`%` read probed the atomic container lane
+
+Concurrent `.push` / element-assign publish an authoritative copy of a container
+under a `__mutsu_atomic_arr::` / `__mutsu_atomic_hash::` key in the cross-thread
+store (#4167), and `get_env_with_main_alias_inner` preferred that copy. To do so
+it built the lane key with `format!` and walked the store chain — on **every**
+array or hash variable read, in every program, whether or not any atomic
+container op had ever run. That is one heap allocation plus a chained hash lookup
+per read; `format!` showed up in the profile of an empty-map loop, and `gdb`
+placed it inside `get_env_with_main_alias_inner`.
+
+`runtime::shared_store` now carries a monotonic `atomic_lane_entries_exist()`
+flag, armed whenever a lane entry is inserted (the four `SharedStore` mutators)
+or a caller reaches for `atomic_lane_scope` to insert one through `own_map()`
+directly. A lane can only be *read* after it has been *written*, and the write
+arms the flag, so concurrent behaviour is unchanged. This is the `@`/`%` twin of
+the atomic *scalar* read gate already pinned by `t/atomic-read-gate.t`, and
+follows the same pattern as `CheckReadOnly`'s `bound_marker_possible()` gate.
+
+Its wall-clock effect on this benchmark is below noise (−1.4% instructions on the
+`.map`-free variant); it is in here because it removes a per-read heap allocation
+on the hottest variable-access path in the interpreter, not for the bench number.
+
+## Why four earlier profiling rounds on this ticket missed it
+
+`todo/perf/bench-ctor-construction-parity.md` rounds 2-4 each concluded "flat
+profile, no dominant function; the cost is spread across malloc / NaN-box /
+hashing". A per-call compile is exactly what that conclusion looks like from a
+flat profile: it spreads across `compile_expr`, `compile_unit`, `add_constant`,
+`ws_inner_with_bol` and the allocation those do. The cheap oracle, recorded in
+the ticket's round-5 update: on a steady-state loop, `MUTSU_VM_STATS`'s
+`const-pool: add_constant=` must not grow with the iteration count.
+
+## Pins
+
+`t/map-rw-empty-and-compile-cache.t` (17 assertions: empty input, write-back,
+`state` scoping, `return`-from-the-enclosing-routine, Slip flattening,
+multi-arity blocks, typed `my` in the block) and
+`t/atomic-container-lane-read-gate.t` (12 assertions: ordinary reads with the
+gate off and on, concurrent array pushes and hash element writes). Both are green
+under real `raku`.

--- a/src/runtime/resolution_map_grep_rw.rs
+++ b/src/runtime/resolution_map_grep_rw.rs
@@ -27,6 +27,19 @@ impl Interpreter {
         if let Some(func_ref) = func.as_ref()
             && let ValueView::Sub(data) = func_ref.view()
         {
+            // Nothing to iterate: the block is never invoked, so no element can
+            // be produced and nothing can be written back. Both branches below
+            // reach exactly this value for an empty input — returning here just
+            // skips the setup they would do first (block compile lookup, the
+            // env save/restore of every key the block captured, the
+            // nested-register frame). `@!resources.map(*.flat)` over an empty
+            // attribute array is the shape a `TWEAK` body uses, and paying that
+            // setup per construction was the single largest component of
+            // bench-ctor. It also stops an inner empty map from removing the
+            // enclosing map's `topic_key` mid-iteration.
+            if list_items.is_empty() {
+                return Ok((Value::array(Vec::new()), false));
+            }
             let data = data.clone();
             let requires_full_binding = data.param_defs.iter().any(|pd| {
                 pd.named
@@ -149,17 +162,24 @@ impl Interpreter {
                 .filter(|pd| pd.traits.iter().any(|t| t == "rw" || t == "raw"));
             let mut result = Vec::new();
 
-            // Compile once, reuse VM for every iteration (same as eval_map_over_items).
+            // Compile once, reuse VM for every iteration (and reuse a cached
+            // compile across repeated calls to this same closure literal — see
+            // `compile_loop_block_cached`, which the List sibling
+            // `eval_map_over_items`, `eval_first_over_items` and the grep loop
+            // below all already go through). Without the cache every single
+            // `@a.map(...)` call re-ran the whole compiler on the block's AST:
+            // `@!resources.map(*.flat)` inside a TWEAK cost ~19us per
+            // construction on an EMPTY array, which was the largest single
+            // component of bench-ctor.
             // Normalize a bare tail `Stmt::Call` carrying named/slip args (how an
             // imported sub call like `f(k => v)` parses) into `Stmt::Expr(Expr::Call)`
             // so its value is preserved as the block's result; otherwise it compiles
             // as a value-discarding statement and the map result wrongly falls back
             // to the topic `$_` (see `eval_map_over_items`).
-            let compiler = crate::compiler::Compiler::new();
             let normalized_body =
                 super::resolution_map_grep::normalize_tail_stmt_for_value(&data.body);
             let tail_is_when = super::resolution_map_grep::tail_is_when_chain(&normalized_body);
-            let (code, compiled_fns) = compiler.compile(&normalized_body);
+            let (code, compiled_fns) = self.compile_loop_block_cached(&data, &normalized_body);
 
             let underscore = "_".to_string();
             let dollar_topic = "$_".to_string();

--- a/src/runtime/shared_store.rs
+++ b/src/runtime/shared_store.rs
@@ -52,6 +52,34 @@ fn atomic_lane_base_name(key: &str) -> Option<&str> {
         .or_else(|| key.strip_prefix("__mutsu_atomic_hash::"))
 }
 
+/// Set once any atomic array/hash lane entry has been created anywhere in the
+/// process. It is never cleared: `remove` leaving it set only restores the old
+/// (always-probe) behaviour, which is correct, just slower.
+static ATOMIC_LANE_ENTRY_EXISTS: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+
+/// Record that `key` is being inserted, arming the lane probe if it is one.
+fn note_inserted_key(key: &str) {
+    if atomic_lane_base_name(key).is_some() {
+        ATOMIC_LANE_ENTRY_EXISTS.store(true, std::sync::atomic::Ordering::Relaxed);
+    }
+}
+
+/// Whether any `__mutsu_atomic_arr::` / `__mutsu_atomic_hash::` lane entry has
+/// ever been created.
+///
+/// Every `@`/`%` variable READ used to build a `format!("__mutsu_atomic_arr::{name}")`
+/// String and walk the store chain for it, to see whether a concurrent CAS/push
+/// had published an authoritative copy. In a program that never runs an atomic
+/// array/hash op — which is nearly every program, and every iteration of
+/// bench-ctor — that is one heap allocation plus a hash lookup per read, for a
+/// lane that cannot exist. Guarding the probe on this flag keeps the
+/// concurrent behaviour identical (the lane must be *written* before any read
+/// can want it, and the write arms the flag) while making the common case free.
+pub(crate) fn atomic_lane_entries_exist() -> bool {
+    ATOMIC_LANE_ENTRY_EXISTS.load(std::sync::atomic::Ordering::Relaxed)
+}
+
 #[derive(Debug)]
 pub(crate) struct SharedStore {
     own: RwLock<HashMap<String, Value>>,
@@ -128,6 +156,11 @@ impl SharedStore {
     /// in `builtins_atomic_shared.rs`). Must stay in lockstep with
     /// `scope_for`'s atomic-lane branch or the two paths split-brain.
     pub(crate) fn atomic_lane_scope(self: &Arc<Self>, base_name: &str) -> Arc<Self> {
+        // Callers that reach for a lane scope go on to lock `own_map()` and
+        // insert the lane entry themselves, bypassing the `set`/`declare`
+        // arming below — so arm here too. Arming on the read-only callers as
+        // well is deliberate: `true` only restores the always-probe behaviour.
+        ATOMIC_LANE_ENTRY_EXISTS.store(true, std::sync::atomic::Ordering::Relaxed);
         let mut cur = Arc::clone(self);
         loop {
             if cur.owns(base_name) {
@@ -179,6 +212,7 @@ impl SharedStore {
     /// Falls back to this lineage when the name is new (a first write with no
     /// prior declaration behaves as a declaration here).
     pub(crate) fn set(&self, key: &str, value: Value) {
+        note_inserted_key(key);
         let target = self.owner_of(key).unwrap_or_else(|| self.scope_for(key));
         target.own.write().unwrap().insert(key.to_string(), value);
     }
@@ -187,6 +221,7 @@ impl SharedStore {
     /// `my`-declaration seeding: a re-declared name is a fresh binding whose
     /// writes must not leak to the lineage that shared the old one.
     pub(crate) fn declare(&self, key: &str, value: Value) {
+        note_inserted_key(key);
         self.scope_for(key)
             .own
             .write()
@@ -203,6 +238,7 @@ impl SharedStore {
         if self.contains_key(key) {
             return false;
         }
+        note_inserted_key(key);
         self.scope_for(key)
             .own
             .write()
@@ -229,6 +265,7 @@ impl SharedStore {
         {
             return existing.clone();
         }
+        note_inserted_key(key);
         let cell = make();
         own.insert(key.to_string(), cell.clone());
         cell

--- a/src/vm/vm_env_helpers.rs
+++ b/src/vm/vm_env_helpers.rs
@@ -1030,8 +1030,17 @@ impl Interpreter {
         // under such a name describe the *shadowed* outer binding, and
         // preferring them makes a routine's (or a worker's) own `my @a` read as
         // the caller's. See `container_name_is_redeclared`.
+        //
+        // The probe is skipped entirely until some atomic array/hash lane entry
+        // has actually been created (`atomic_lane_entries_exist`). A lane can
+        // only be *read* after it has been *written*, and the write arms the
+        // flag, so this changes nothing for concurrent programs — but it keeps
+        // every `@`/`%` read in a program that never runs an atomic container op
+        // from building a `format!` key and walking the store chain for an entry
+        // that cannot exist. That probe was ~1 heap allocation + 1 chained hash
+        // lookup on every array/hash variable read.
         let redeclared = self.container_name_is_redeclared(name);
-        if redeclared {
+        if redeclared || !crate::runtime::shared_store::atomic_lane_entries_exist() {
             // fall through to the env read below
         } else if name.starts_with('@') {
             let atomic_key = format!("__mutsu_atomic_arr::{name}");

--- a/t/atomic-container-lane-read-gate.t
+++ b/t/atomic-container-lane-read-gate.t
@@ -1,0 +1,64 @@
+use Test;
+
+# Regression pin for the `@`/`%` twin of t/atomic-read-gate.t: every array or
+# hash variable READ used to build a `format!("__mutsu_atomic_arr::{name}")`
+# String and walk the cross-thread store for it, to see whether a concurrent
+# push / element assign had published an authoritative copy under that lane.
+# That probe is now gated on a monotonic "an atomic container lane entry has
+# been created" flag (runtime/shared_store.rs), so a program that never runs a
+# concurrent container op pays nothing per read.
+#
+# The gate must not change observable semantics: a lane can only be READ after
+# it has been WRITTEN, and the write arms the flag.
+
+plan 12;
+
+# --- Gate OFF: ordinary container reads are unaffected. -----------------------
+my @a = 1, 2, 3;
+is @a.elems, 3, 'ordinary array read unaffected by the gate';
+is @a[1], 2, 'ordinary array element read unaffected';
+
+my %h = a => 1, b => 2;
+is %h.elems, 2, 'ordinary hash read unaffected by the gate';
+is %h<b>, 2, 'ordinary hash element read unaffected';
+
+# Reads through a closure's captured container (the hot free-variable path).
+my $sum = -> { [+] @a };
+is $sum(), 6, 'closure read of a captured array unaffected';
+
+# A method reading its own `@!`/`%!` attributes — the bench-ctor shape.
+class Holder {
+    has @.items;
+    has %.meta;
+    method total() { @!items.elems + %!meta.elems }
+}
+is Holder.new(items => [1, 2], meta => { x => 1 }).total, 3,
+    'attribute container reads unaffected by the gate';
+
+# --- Arm the gate: concurrent pushes go through the atomic array lane. --------
+my @shared;
+my $lock = Lock.new;
+await (^4).map: {
+    start {
+        for ^25 {
+            $lock.protect: { @shared.push(1) }
+        }
+    }
+};
+is @shared.elems, 100, 'concurrent pushes all landed in the shared array';
+is ([+] @shared), 100, 'shared array contents are intact';
+
+# --- Gate now ON: ordinary reads must still be correct. ----------------------
+is @a.elems, 3, 'ordinary array read still correct after the gate is armed';
+is %h<a>, 1, 'ordinary hash read still correct after the gate is armed';
+is $sum(), 6, 'closure array read still correct after the gate is armed';
+
+# A concurrently-written hash reads back through the same lane.
+my %shared;
+my $hlock = Lock.new;
+await (^4).map: -> $i {
+    start {
+        $hlock.protect: { %shared{"k$i"} = $i }
+    }
+};
+is %shared.elems, 4, 'concurrent hash element writes all visible';

--- a/t/map-rw-empty-and-compile-cache.t
+++ b/t/map-rw-empty-and-compile-cache.t
@@ -1,0 +1,83 @@
+use Test;
+
+# Pins for the two `eval_map_over_items_rw` fixes:
+#
+# 1. The rw map loop now shares `compile_loop_block_cached` with the List
+#    sibling, `first` and the grep loop, instead of running the whole compiler
+#    on the block AST at EVERY `.map` call. The cache is keyed on the block's
+#    origin `CompiledCode` plus whether a routine is on the stack, so `return`
+#    semantics inside the block must stay unchanged.
+# 2. `.map` over an EMPTY array returns immediately, before the block compile,
+#    the env save/restore and the nested-register frame. Nothing observable may
+#    change, including write-back and an enclosing map's own topic.
+
+plan 17;
+
+# --- Empty input -------------------------------------------------------------
+my @empty;
+my @out = @empty.map(* + 1);
+is @out.elems, 0, 'map over an empty array yields no elements';
+
+@empty = @empty.map(*.flat);
+is @empty.elems, 0, 'self-assigning an empty rw map keeps the array empty';
+
+# The TWEAK shape that made this hot: an empty `@!` attribute mapped in place.
+class Dist {
+    has @.resources;
+    submethod TWEAK(:@!resources) { @!resources = @!resources.map(*.flat); }
+}
+is Dist.new.resources.elems, 0, 'empty attribute array maps to empty';
+is Dist.new(resources => [1, 2]).resources.elems, 2,
+    'non-empty attribute array still maps';
+
+# An empty inner map must not disturb the enclosing map's element write-back.
+my @outer = 1, 2, 3;
+my @inner;
+my @res = @outer.map({ $_ = $_ * 10; @inner.map(* + 1); $_ });
+is @res.join(','), '10,20,30', 'inner empty map does not disturb the outer map result';
+is @outer.join(','), '10,20,30', 'inner empty map does not disturb the outer write-back';
+
+# --- Write-back still works --------------------------------------------------
+my @nums = 1, 2, 3;
+my @doubled = @nums.map({ $_ = $_ * 2; $_ });
+is @nums.join(','), '2,4,6', 'rw map writes back into the source array';
+is @doubled.join(','), '2,4,6', 'rw map returns the mapped values';
+
+# --- The compile cache must not change block semantics -----------------------
+# Same closure literal, called repeatedly: the cached compile is reused.
+my @acc;
+for ^3 -> $i {
+    @acc.push: |(1, 2).map(* + $i);
+}
+is @acc.join(','), '1,2,2,3,3,4', 'a repeatedly-compiled map block stays correct';
+
+# `state` inside a map block is scoped to the closure instance, not shared
+# across two distinct blocks that happen to compile to the same shape.
+sub counter(@xs) { @xs.map({ state $n = 0; $n++; $n }) }
+is counter([1, 2, 3]).join(','), '1,2,3', 'state in a map block counts up';
+is counter([1, 2]).join(','), '1,2', 'a fresh call gets a fresh state cell';
+
+# `return` inside a map block ends the ENCLOSING routine (this is the behaviour
+# `compile_loop_block_cached`'s `lexically_in_routine` flag preserves).
+sub find-first-even(@xs) {
+    @xs.map({ return $_ if $_ %% 2 });
+    return -1;
+}
+is find-first-even([1, 3, 4, 5]), 4, 'return inside a map block returns from the routine';
+is find-first-even([1, 3, 5]), -1, 'no match falls through to the routine tail';
+
+# Slips out of a map block still flatten.
+my @flat = (1, 2).map({ ($_, $_) .Slip });
+is @flat.join(','), '1,1,2,2', 'a Slip result flattens into the map output';
+
+# A multi-arity block over an rw array.
+my @pairs = (1, 2, 3, 4);
+is @pairs.map(-> $a, $b { $a + $b }).join(','), '3,7', 'multi-arity map block still works';
+
+# `compile_loop_block_cached` also marks the block as lexically nested in a
+# routine whenever one is on the stack, which is what decides whether a TYPED
+# `my` inside the block is frame-scoped. The rw loop now agrees with the List
+# sibling on this; a typed declaration must stay block-local either way.
+sub typed-in-block(@xs) { @xs.map({ my Int $t = $_ * 2; $t }) }
+is typed-in-block([1, 2, 3]).join(','), '2,4,6', 'typed my inside an rw map block works';
+is typed-in-block([4]).join(','), '8', 'typed my in the block is fresh per call';

--- a/todo/perf/bench-ctor-construction-parity.md
+++ b/todo/perf/bench-ctor-construction-parity.md
@@ -393,6 +393,88 @@ pipeline. Next actionable, if wanted: extend the `fast_method_cache` tier to
 the same named shapes, and look at per-call closure-literal reuse for
 immediately-invoked WhateverCode.
 
+## Update (2026-08-29, round 5 — the `.map` in TWEAK was re-running the COMPILER)
+
+Rounds 2-4 all concluded "no dominant function; the cost is spread across
+malloc/NaN-box/hashing" from flat perf profiles. That conclusion was wrong, and
+the reason it survived four rounds is instructive: **a per-call compile does not
+show up as one hot symbol.** It is spread across `compile_expr`,
+`compile_expr_var`, `compile_unit`, `add_constant`, `ws_inner_with_bol`, plus the
+`Vec`/`HashMap` allocation those do — i.e. it lands in exactly the flat
+"malloc/hashing/no dominant function" bucket the earlier rounds attributed to
+construction itself.
+
+A `rust-gdb -batch` breakpoint on `CompiledCode::add_constant`, skipping the
+startup hits, printed the answer in one run:
+
+```
+#0 CompiledCode::add_constant
+#1 compile_expr_var  #2 compile_expr_method_on_var  #3 compile_expr
+#4 Compiler::compile_unit  #5 Compiler::compile
+#6 eval_map_over_items_rw          <-- per .map CALL, not per program
+```
+
+`eval_map_over_items_rw` was the one map/grep loop that never got
+`compile_loop_block_cached` (added by #6710, which did cover
+`eval_map_over_items`, `eval_first_over_items` and the rw grep loop). Every
+`@array.map(...)` / `@!attr.map(...)` in the whole interpreter re-ran the
+compiler on the block AST. `MUTSU_VM_STATS` over a 100000-call loop:
+`add_constant` **300017 → 20**.
+
+Two more per-call costs found from the same repro:
+
+- an EMPTY `.map` still paid the block compile, the captured-key env
+  save/restore and the nested-register frame to run the block zero times —
+  `@!resources.map(*.flat)` over an empty attribute array is exactly the
+  benchmark's (and real `TWEAK` bodies') shape;
+- every `@`/`%` variable READ built `format!("__mutsu_atomic_arr::{name}")` and
+  walked the cross-thread store for a lane entry that cannot exist unless a
+  concurrent container op has run. Now gated on a monotonic
+  `shared_store::atomic_lane_entries_exist()` flag, the `@`/`%` twin of the
+  atomic-scalar read gate `t/atomic-read-gate.t` already pins.
+
+Result, from an **interleaved same-session A/B** (release builds of the change and
+of its revert, `taskset -c 2`, best of 9 — an earlier cross-session pair gave a
+much larger apparent win purely from machine drift, so it is not quoted):
+
+| variant | before | after | raku |
+|---|---|---|---|
+| 21-attr class, plain `.new` | 0.0551 | 0.0562 | 0.2208 |
+| + parent `TWEAK` | 0.0737 | 0.0755 | 0.2367 |
+| + `method new(*%_) { self.bless(\|%_, :meta(%_)) }` | 0.1365 | 0.1354 | 0.2561 |
+| + child `TWEAK` (attributive params, `--> Nil`) | 0.1545 | 0.1544 | 0.2691 |
+| + `@!resources.map(*.flat)` | **0.2515** | **0.2191** | 0.2904 |
+
+bench-ctor **−12.9% wall clock**, `perf stat` 2.172G → 1.951G instructions
+(**434k → 390k per construction, −10.1%**). The whole win is the last row;
+everything above it is unchanged (the ±2% spread is binary-layout noise). The
+isolated micro — 5000 empty `.map` calls inside a method — went 0.0985s →
+0.0789s (−20%). Do NOT quote a local raku ratio for this bench: this box's rakudo
+v2026.06 is far faster than the CI runner's pinned build, so the local ratio sits
+well under 1.0 both before and after while the CI ratio is 1.31. `bench-data`'s
+`bench-history.tsv` is the authority.
+
+**Lesson for the next round: do not conclude "flat profile, no dominant cost"
+without first proving nothing is being COMPILED per call.** `MUTSU_VM_STATS`'s
+`const-pool: add_constant=` is the cheap oracle — on a steady-state loop it must
+stay near-constant, and any growth with iteration count is a runtime compile.
+
+**Still open after round 5.** The `.map` line is no longer the gap; the largest
+remaining slice is the custom-`new`→`bless` plumbing (row 2→3 above: mutsu pays
++0.059s where raku pays +0.007s, i.e. ~11.6us vs ~1.4us per construction for
+`*%_` slurpy bind → `|%_` spread → `:meta(%_)` → `bless`). Two concrete leads
+inside `dispatch_bless` not yet measured: the named-arg override loop does a
+linear `plan.class_attrs.iter().position(...)` string scan per argument (7 args ×
+21 attributes = ~147 `memcmp`s per construction — `__memcmp_avx2_movbe` is 2.3%
+of the profile), and the no-initializer attribute seeds re-run
+`Symbol::intern("Any")` / `nominal_type_object_name_for_constraint` per attribute
+per construction although `NativeCtorPlan` could precompute them. Also still
+open, from the same repro: `CheckReadOnly` builds
+`format!("__mutsu_sigilless_readonly::{name}")` on every whole-variable
+assignment once `closure_meta_keys_possible()` is armed — and that flag is shared
+with `__mutsu_state_key::` / `__mutsu_sigilless_alias::` / predictive-seq keys, so
+creating any of those arms the readonly probe too; it wants its own flag.
+
 ## Measurement notes
 
 - Iterate counters with the debug build (`MUTSU_VM_STATS=1`, identical to


### PR DESCRIPTION
## Problem

`bench-ctor` — the heavy-constructor benchmark modelled on `Zef::Distribution` (21
attributes, `method new(*%_)` delegating to `self.bless`, `TWEAK` submethods at two MRO
levels) — had drifted to **1.31x rakudo** on the bench CI, the only benchmark slower than
raku.

Decomposing the benchmark into the features it layers on a plain `.new` put the whole gap
in one line of the child `TWEAK`. Interleaved same-session A/B — release builds of this
change and of its revert, `taskset -c 2`, best of 9, 5000 constructions:

| variant | before | after | raku |
|---|---|---|---|
| A: 21-attr class, plain `.new` | 0.0551 | 0.0562 | 0.2208 |
| B: + parent `TWEAK` | 0.0737 | 0.0755 | 0.2367 |
| C: + `method new(*%_) { self.bless(\|%_, :meta(%_)) }` | 0.1365 | 0.1354 | 0.2561 |
| D: + child `TWEAK` (attributive params, `--> Nil`) | 0.1545 | 0.1544 | 0.2691 |
| full: + `@!resources = @!resources.map(*.flat)` | **0.2515** | **0.2191** | 0.2904 |

**bench-ctor −12.9% wall clock**; `perf stat` 2.172G → 1.951G instructions
(**434k → 390k per construction, −10.1%**). The whole win is the last row — one `.map`
over an **empty** attribute array; everything above it is unchanged (the ±2% spread is
binary-layout noise). The isolated micro of 5000 empty `.map` calls inside a method went
**0.0985s → 0.0789s (−20%)**.

No local raku ratio is quoted as a headline: this box's rakudo v2026.06 is far faster than
the 4-core CI runner's pinned build, so the local ratio sits well under 1.0 both before and
after while the CI ratio is 1.31. `bench-history.tsv` on `bench-data` is the authority for
that number.

## Root causes (three, all general)

**1. `eval_map_over_items_rw` never got the compile cache.** It was the one map/grep loop
still calling `Compiler::new().compile(&normalized_body)` directly; #6710 had covered
`eval_map_over_items`, `eval_first_over_items` and the rw grep loop. So *every*
`@array.map(...)` / `@!attr.map(...)` in the interpreter re-ran the whole compiler on the
block's AST. A `rust-gdb -batch` breakpoint on `CompiledCode::add_constant` caught it:

```
#0 CompiledCode::add_constant
#1 compile_expr_var  #2 compile_expr_method_on_var  #3 compile_expr
#4 Compiler::compile_unit  #5 Compiler::compile
#6 eval_map_over_items_rw        <-- per .map CALL
```

`MUTSU_VM_STATS=1` over a 100000-call loop: `const-pool: add_constant` **300017 → 20**
(on bench-ctor itself, 15044 → 44).

Going through `compile_loop_block_cached` also brings this path in line with its siblings
on `lexically_in_routine`, which is what decides whether a typed `my` inside the block is
frame-scoped.

**2. An empty `.map` paid the whole setup for nothing** — block compile, the env
save/restore of every key the block captured, the nested-register frame — to run the block
zero times. Both `Sub` branches reach exactly `(Value::array(vec![]), false)` for an empty
input, so it returns that directly. Side effect: an inner empty map can no longer remove
an enclosing map's `topic_key` mid-iteration.

**3. Every `@`/`%` variable READ probed the atomic container lane.**
`get_env_with_main_alias_inner` built `format!("__mutsu_atomic_arr::{name}")` and walked
the cross-thread store to see whether a concurrent push/element-assign had published an
authoritative copy there (#4167) — one heap allocation plus a chained hash lookup per
read, in every program, for a lane that cannot exist unless an atomic container op has
run. `runtime::shared_store` now carries a monotonic `atomic_lane_entries_exist()` flag,
armed by the four `SharedStore` mutators and by `atomic_lane_scope` (whose callers insert
through `own_map()` directly). A lane can only be *read* after it is *written*, and the
write arms the flag, so concurrent behaviour is unchanged.

This is the `@`/`%` twin of the atomic *scalar* read gate already pinned by
`t/atomic-read-gate.t`, and follows the same pattern as `CheckReadOnly`'s
`bound_marker_possible()` gate. Its own wall-clock effect here is below noise (−1.4%
instructions on the `.map`-free variant); it is in this PR because it removes a per-read
heap allocation from the hottest variable-access path, not for the bench number.

## Why four earlier profiling rounds on this ticket missed it

A per-call compile does not surface as one hot symbol — it spreads across `compile_expr`,
`compile_unit`, `add_constant`, `ws_inner_with_bol` and the allocation they do, i.e. into
exactly the flat "malloc / hashing / no dominant function" bucket rounds 2-4 attributed to
construction itself. `todo/perf/bench-ctor-construction-parity.md`'s round-5 update
records the cheap oracle for next time: on a steady-state loop, `MUTSU_VM_STATS`'s
`const-pool: add_constant=` must not grow with the iteration count.

The ticket stays open. The largest remaining slice is now the custom-`new`→`bless`
plumbing (rows B→C above: mutsu pays +0.063s where raku pays +0.019s); two concrete,
unmeasured leads inside `dispatch_bless` are recorded there, plus a note that
`CheckReadOnly`'s `__mutsu_sigilless_readonly::` probe shares a flag with three unrelated
key families and wants its own.

## Verification

- `make test`: **3554 files / 35621 tests, PASS**
- `cargo fmt --all`, `cargo clippy -- -D warnings` clean
- Targeted roast, release binary: `S32-list/{map,grep,first}.t`, `S02-types/array.t`, and
  25 whitelisted `S17-*` concurrency files — all PASS
- New pins, green under real `raku` as well as mutsu:
  - `t/map-rw-empty-and-compile-cache.t` (17 assertions: empty input, write-back, `state`
    scoping, return-from-the-enclosing-routine, Slip flattening, multi-arity blocks, typed
    `my` in the block)
  - `t/atomic-container-lane-read-gate.t` (12 assertions: ordinary reads with the gate off
    and on, concurrent array pushes and hash element writes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
