### PR TITLE
perf(vm): closure creation stops rebuilding two per-chunk sets every time

### DIFF
--- a/news/2026-08/closure-creation-fixed-cost.md
+++ b/news/2026-08/closure-creation-fixed-cost.md
@@ -1,0 +1,61 @@
+# Closure creation stopped rebuilding two per-chunk sets on every literal
+
+Creating a closure literal is something mutsu does once per `.map({...})` call,
+once per callback, once per `TWEAK` that contains a block — i.e. per *iteration*
+of any loop that mentions one. A micro that builds a `* + 1` WhateverCode 200000
+times without calling it (against a control loop with the creation removed,
+release, `taskset -c 2`, best of 5) measured:
+
+| | mutsu | raku |
+|---|---|---|
+| control loop | 0.1323 | 0.1518 |
+| + 200000 creations | 0.6259 | 0.1847 |
+| **per creation** | **2.47us** | **0.16us** |
+
+~15x. This change takes the fixed part of that down by 20%, to 1.97us. The rest
+is the O(enclosing-env) capture, which needs a design pass and is tracked in
+`todo/perf/closure-literal-creation-cost.md` as Part B.
+
+## What was being redone per creation
+
+`capture_closure_env` (`src/vm/vm_register_ops.rs`) decides what a new closure
+inherits from the frame creating it, using two membership sets:
+
+- the closure's free variables, and
+- the closure's *own* locals/parameters, which must NOT inherit a same-named
+  enclosing binding (a WhateverCode's `_` param must not swallow the creating
+  frame's `for`/map topic and leak it back on return).
+
+Both are pure functions of the block's `CompiledCode`, and both were re-collected
+into fresh `HashSet`s on **every single creation** — two allocations plus their
+fills, per closure. They are now built once per chunk
+(`CompiledCode::capture_free_var_set` / `capture_local_set`, behind the same
+`OnceLock` pattern `const_syms` and `local_attr_keys` already use). The
+own-locals test also compares interned `Symbol`s instead of `&str`: `locals_sym`
+is the interned twin of `locals`, so membership is identical without hashing the
+key's string on every probe.
+
+Three fixed literals were also re-interned per creation: the anonymous closure's
+empty name, `__mutsu_return_type` (removed from the capture, then re-inserted
+when the block declares a return type) and `__mutsu_callable_type` (the
+WhateverCode marker). The `String`-keyed `Env::insert`/`Env::remove` twins
+allocated the literal, hashed it in the intern memo and re-scanned it in
+`note_env_key` — which sets no flag for either name. They now go through
+`symbol::well_known`, a small home for names the runtime interns on a
+per-operation hot path. `sip::Hasher::write` disappeared from the profile
+entirely as a result.
+
+## Effect
+
+Interleaved A/B of the two release binaries, `taskset -c 2`, best of 5: the
+closure micro **−16%**, `bench-array` **−9.8%**, everything else in
+`benchmarks/` within noise. (`bench-startup` is not a usable A/B row here: at
+~4.5ms the *same* binary measures 0.0045s and 0.0086s in consecutive rounds.)
+
+Pin: `t/closure-capture-symbol-sets.t` — 17 assertions over exactly the
+semantics those two sets encode: per-iteration capture of a loop variable, a
+capture tracking a later mutation, a WhateverCode's `_` not taking or leaking the
+caller's topic, a block-local declaration shadowing without writing through,
+uppercase-initial lexicals / dynamics / type names / `self` staying reachable, a
+closure created inside a closure, and a bare block still reporting `Block` (i.e.
+the WhateverCode marker not being inherited). Green under real `raku`.

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -4295,6 +4295,13 @@ pub(crate) struct CompiledCode {
     /// once per chunk keeps the twigil string parse *and* `Symbol::intern` off
     /// the per-access `$!x` / `$.x` read-write path (ADR-0006 §2.4).
     pub(crate) local_attr_keys: std::sync::OnceLock<LocalAttrKeys>,
+    /// Lazily-built `Symbol` sets over [`free_var_syms`](Self::free_var_syms)
+    /// and [`locals_sym`](Self::locals_sym), for `capture_closure_env`'s
+    /// membership tests. Both are pure functions of the chunk, but the capture
+    /// used to rebuild them (two `HashSet` allocations plus their fills) on
+    /// EVERY closure creation — see `capture_free_var_set` / `capture_local_set`.
+    pub(crate) free_var_sym_set: std::sync::OnceLock<rustc_hash::FxHashSet<Symbol>>,
+    pub(crate) local_sym_set: std::sync::OnceLock<rustc_hash::FxHashSet<Symbol>>,
     /// Per-chunk JIT hotness counter and compiled-entry cache (ADR-0004 J1).
     pub(crate) jit: JitCodeState,
 }
@@ -4630,6 +4637,8 @@ impl CompiledCode {
             env_only_decls: Vec::new(),
             const_syms: std::sync::OnceLock::new(),
             local_attr_keys: std::sync::OnceLock::new(),
+            free_var_sym_set: std::sync::OnceLock::new(),
+            local_sym_set: std::sync::OnceLock::new(),
             jit: JitCodeState::default(),
         }
     }
@@ -4649,6 +4658,33 @@ impl CompiledCode {
                 .collect()
         });
         slots.get(idx).copied().flatten()
+    }
+
+    /// This chunk's free variables as a `Symbol` set, built once. The closure
+    /// capture (`capture_closure_env`) tests membership per env key, and used to
+    /// `collect()` this set afresh on every closure creation.
+    pub(crate) fn capture_free_var_set(&self) -> &rustc_hash::FxHashSet<Symbol> {
+        self.free_var_sym_set
+            .get_or_init(|| self.free_var_syms.iter().copied().collect())
+    }
+
+    /// This chunk's own local/parameter names as a `Symbol` set, built once.
+    /// The capture drops a same-named enclosing binding for each of these (a
+    /// WhateverCode's `_` param must not inherit the creating frame's topic), and
+    /// used to `collect()` a `HashSet<&str>` over `locals` per closure creation.
+    /// `locals_sym` is the interned twin of `locals`, so `Symbol` membership is
+    /// exactly string membership — without hashing the string.
+    pub(crate) fn capture_local_set(&self) -> &rustc_hash::FxHashSet<Symbol> {
+        self.local_sym_set.get_or_init(|| {
+            // A hand-built chunk that never ran `compute_locals_sym` has an
+            // empty `locals_sym` (see `local_sym`), so intern from `locals` in
+            // that case rather than silently returning an empty set.
+            if self.locals_sym.len() == self.locals.len() {
+                self.locals_sym.iter().copied().collect()
+            } else {
+                self.locals.iter().map(|s| Symbol::intern(s)).collect()
+            }
+        })
     }
 
     /// The `Symbol` for the string constant at `idx`, interned once per slot

--- a/src/symbol.rs
+++ b/src/symbol.rs
@@ -248,6 +248,42 @@ impl fmt::Display for Symbol {
     }
 }
 
+/// Fixed names the runtime interns over and over on hot paths.
+///
+/// `Symbol::intern` is already memoized per thread, but the memo is a
+/// `FxHashMap<String, Symbol>` — a repeat intern still hashes the whole string
+/// and compares it. For a literal that is re-interned on *every* closure
+/// creation or method dispatch, that is pure waste: symbol ids are process-global
+/// and append-only, so the id can be computed once and copied thereafter.
+///
+/// Add a name here only when a profile shows the intern on a per-operation hot
+/// path; a `LazyLock` read is cheap but not free.
+pub(crate) mod well_known {
+    use super::Symbol;
+    use std::sync::LazyLock;
+
+    /// The empty name every anonymous closure value carries.
+    #[inline]
+    pub(crate) fn anon() -> Symbol {
+        static SYM: LazyLock<Symbol> = LazyLock::new(|| Symbol::intern(""));
+        *SYM
+    }
+
+    /// Closure-identity metadata: the `WhateverCode` marker.
+    #[inline]
+    pub(crate) fn callable_type() -> Symbol {
+        static SYM: LazyLock<Symbol> = LazyLock::new(|| Symbol::intern("__mutsu_callable_type"));
+        *SYM
+    }
+
+    /// The declared return type a routine's env carries for its own body.
+    #[inline]
+    pub(crate) fn return_type() -> Symbol {
+        static SYM: LazyLock<Symbol> = LazyLock::new(|| Symbol::intern("__mutsu_return_type"));
+        *SYM
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/vm/vm_register_ops.rs
+++ b/src/vm/vm_register_ops.rs
@@ -670,7 +670,7 @@ impl Interpreter {
             // mis-treated as a WhateverCode itself — e.g. the `.map` loop would
             // then hold `$_` at the outer topic instead of binding it to the
             // element (`*.map({ $_ })` saw the whole list, not each item).
-            flat.remove_sym(Symbol::intern("__mutsu_callable_type"));
+            flat.remove_sym(crate::symbol::well_known::callable_type());
             // Attribute-twigil keys are per-frame materializations of `self`'s
             // attributes — never snapshot them (see the filtered branch below).
             flat.retain(|k, _| !k.with_str(Self::is_attr_twigil_env_key));
@@ -678,14 +678,18 @@ impl Interpreter {
             self.materialize_frame_self_into_capture(code, &mut flat);
             return flat;
         }
-        let free: std::collections::HashSet<Symbol> = cc.free_var_syms.iter().copied().collect();
+        // Both sets are pure functions of `cc`, so they are built once per chunk
+        // rather than re-collected on every closure creation (this runs for every
+        // `.map({...})` / callback literal in a loop). `own_locals` compares by
+        // `Symbol` instead of by `&str`: `locals_sym` is the interned twin of
+        // `locals`, so membership is identical without hashing the key's string.
+        let free = cc.capture_free_var_set();
         // The closure's own parameters/locals (e.g. a WhateverCode's `_` param)
         // shadow any same-named enclosing binding, so they must NOT be inherited
         // from the creating frame's env. Capturing the enclosing `_` (a `for`/map
         // topic) into a `_`-param WhateverCode would leak that stale topic back to
         // the caller on return (`* ~~ /<$r>/` invoked inside a grep-in-`for`).
-        let own_locals: std::collections::HashSet<&str> =
-            cc.locals.iter().map(|s| s.as_str()).collect();
+        let own_locals = cc.capture_local_set();
         // Keep only the upvalue set, shadow-meta, and system names, walking the
         // env tiers directly (`filtered_flat`) — flattening first (`clone_env`)
         // deep-cloned the entire parent-chain map per lambda creation. The
@@ -695,8 +699,9 @@ impl Interpreter {
         // the genuine closure's own env after capture — never inherit it, or an
         // ordinary inner block would be mis-detected as a WhateverCode (see the
         // by-name path above).
+        let callable_type_sym = crate::symbol::well_known::callable_type();
         let mut env = self.env().filtered_flat(&|k, _v| {
-            if k.with_str(|s| s == "__mutsu_callable_type") {
+            if k == callable_type_sym {
                 return false;
             }
             // Attribute-twigil keys (`!x`, `@!x`, `%.x`, …) are per-frame
@@ -709,7 +714,8 @@ impl Interpreter {
                 return false;
             }
             free.contains(&k)
-                || k.with_str(|s| !crate::env::is_plain_user_lexical(s) && !own_locals.contains(s))
+                || (!own_locals.contains(&k)
+                    && k.with_str(|s| !crate::env::is_plain_user_lexical(s)))
         });
         // Upvalue read: override this frame's own free-var slots with the live
         // local value. Authoritative even after the closure-driven env flush is

--- a/src/vm/vm_register_sub_ops.rs
+++ b/src/vm/vm_register_sub_ops.rs
@@ -92,13 +92,20 @@ impl Interpreter {
             // routine's `__mutsu_return_type`, which would then be enforced on
             // this block's own return (`sub f(--> blob32) { ({ $^a + $^b })[0](…) }`
             // reported the inner block's Int as a bad `blob32` return).
-            env.remove("__mutsu_return_type");
+            // Symbol-keyed: this runs on EVERY closure creation, and the
+            // `String`-keyed twins would allocate the literal, re-hash it in the
+            // intern memo and re-scan it in `note_env_key` (which sets no flag
+            // for either of these names) each time. See `symbol::well_known`.
+            env.remove_sym(crate::symbol::well_known::return_type());
             if let Some(rt) = return_type {
-                env.insert("__mutsu_return_type".to_string(), Value::str(rt.clone()));
+                env.insert_sym(
+                    crate::symbol::well_known::return_type(),
+                    Value::str(rt.clone()),
+                );
             }
             if is_whatever_code {
-                env.insert(
-                    "__mutsu_callable_type".to_string(),
+                env.insert_sym(
+                    crate::symbol::well_known::callable_type(),
                     Value::str_from("WhateverCode"),
                 );
             }
@@ -112,7 +119,7 @@ impl Interpreter {
                 .and_then(|cc| cc.compiled_fns.clone());
             let val = Value::sub_value(crate::gc::Gc::new(crate::value::SubData {
                 package: Symbol::intern(&self.lexical_closure_package()),
-                name: Symbol::intern(""),
+                name: crate::symbol::well_known::anon(),
                 params: params.clone(),
                 param_defs: param_defs.clone(),
                 body: body.clone(),
@@ -171,7 +178,7 @@ impl Interpreter {
                 .and_then(|cc| cc.compiled_fns.clone());
             let val = Value::sub_value(crate::gc::Gc::new(crate::value::SubData {
                 package: Symbol::intern(&self.lexical_closure_package()),
-                name: Symbol::intern(""),
+                name: crate::symbol::well_known::anon(),
                 params: vec![],
                 param_defs: Vec::new(),
                 body: body.clone(),

--- a/t/closure-capture-symbol-sets.t
+++ b/t/closure-capture-symbol-sets.t
@@ -1,0 +1,77 @@
+use Test;
+
+# Pin for the closure-creation fast path: `capture_closure_env` now builds the
+# free-variable and own-locals membership sets ONCE per compiled chunk
+# (`CompiledCode::capture_free_var_set` / `capture_local_set`) instead of
+# re-collecting them on every closure creation, and tests the own-locals set by
+# interned `Symbol` rather than by string. Both sets decide what a closure
+# inherits from the frame that creates it, so the semantics they encode are what
+# this file pins — a stale or mis-keyed set would show up here.
+
+plan 17;
+
+# --- Free variables are captured, and captured per creation ------------------
+my @made;
+for 1, 2, 3 -> $i {
+    @made.push: { $i * 10 };
+}
+is @made.map({ $_.() }).join(','), '10,20,30',
+    'each closure created in a loop keeps its own captured free variable';
+
+my $outer = 5;
+my $adder = -> $n { $n + $outer };
+is $adder(1), 6, 'a free variable is captured';
+$outer = 50;
+is $adder(1), 51, 'the capture tracks a later mutation of the outer binding';
+
+# --- The closure's OWN locals must not inherit the creating frame's binding ---
+# A WhateverCode's `_` param is in `cc.locals`; the enclosing topic must not
+# leak into it, and must not leak back out to the caller afterwards.
+$_ = 'outer-topic';
+my $wc = * ~~ /o/;
+is $_, 'outer-topic', 'creating a WhateverCode leaves the caller topic alone';
+ok $wc('foo'), 'the WhateverCode binds its own argument, not the outer topic';
+is $_, 'outer-topic', 'calling it still leaves the caller topic alone';
+
+for <a b> {
+    my $inner = { $_ };
+    is $inner('x'), 'x', "a block's own \$_ param wins over the enclosing topic ($_)";
+}
+
+# A same-named local declared inside the block shadows the outer one.
+my $shadowed = 'outer';
+my $blk = { my $shadowed = 'inner'; $shadowed };
+is $blk(), 'inner', 'a block-local declaration shadows the same-named outer lexical';
+is $shadowed, 'outer', 'and does not write through to the outer one';
+
+# --- Names that are NOT plain user lexicals stay visible ---------------------
+# Uppercase-initial lexicals, dynamics, `self` and type names all have to remain
+# reachable from inside a closure.
+my $Uppercase = 'U';
+is { $Uppercase }(), 'U', 'an uppercase-initial lexical is visible in a closure';
+
+my $*DYN = 'D';
+is { $*DYN }(), 'D', 'a dynamic variable is visible in a closure';
+
+is { Int }().gist, '(Int)', 'a type name resolves inside a closure';
+
+class Holder {
+    has $.v;
+    method wrapped() { return { self.v } }
+}
+is Holder.new(v => 7).wrapped().(), 7, 'self is reachable through a captured closure';
+
+# --- The same chunk creating many closures (the cached-set path) --------------
+sub make($n) { return { $n * 2 } }
+my @fns = (1 .. 4).map({ make($_) });
+is @fns.map({ $_.() }).join(','), '2,4,6,8',
+    'many closures from one chunk each capture their own value';
+
+# A nested closure created inside another closure.
+sub outer-factory($a) { return -> $b { -> { $a + $b } } }
+is outer-factory(10)(5)(), 15, 'a closure created inside a closure captures both levels';
+
+# A WhateverCode created inside a block must not be mistaken for the block's own
+# callable kind (the `__mutsu_callable_type` marker must not be inherited).
+my $blockish = { $_ };
+is $blockish.WHAT.gist, '(Block)', 'a bare block is a Block, not a WhateverCode';

--- a/todo/perf/closure-literal-creation-cost.md
+++ b/todo/perf/closure-literal-creation-cost.md
@@ -1,0 +1,94 @@
+# Creating a closure literal still costs O(enclosing env)
+
+Found while decomposing `bench-ctor` (2026-08-29). It is not a bench-ctor
+problem — it is paid by every `.map({...})` / `.grep({...})` / callback literal
+created in a loop, anywhere in the language.
+
+## Measurement
+
+`tmp/lambda-create.raku` builds a `* + 1` WhateverCode 200000 times without
+calling it; `tmp/lambda-none.raku` is the same loop with the creation removed
+(release, `taskset -c 2`, best of 5):
+
+| | mutsu (before) | mutsu (after part A) | raku |
+|---|---|---|---|
+| control loop | 0.1323 | 0.1357 | 0.1518 |
+| + 200000 closure creations | 0.6259 | 0.5309 | 0.1847 |
+| **per creation** | **2.47us** | **1.97us** | **0.16us** |
+
+Part A (below) landed the fixed-cost reductions: **−20% per creation**, still
+**~12x rakudo**.
+
+## The remaining cost scales with the enclosing env, not with the closure
+
+Adding 30 lexicals whose names do not start with a lowercase letter
+(`my $Aa1 … my $Ad0`) to the same file — none of them referenced by the closure —
+adds ~29ns per creation per entry (0.531s → 0.706s over 200000 creations).
+
+`capture_closure_env` (`src/vm/vm_register_ops.rs`) captures, in addition to the
+closure's actual free variables, **every env key for which
+`env::is_plain_user_lexical` is false** — i.e. every name that does not start
+(after its sigil) with a lowercase ASCII letter. That rule is deliberately
+conservative because mutsu stores scalars sigil-less, so a user's `my $Foo` and a
+bare type name `Foo` are the *same* env key shape and cannot be told apart; the
+kept set therefore has to include dynamics (`$*x`), magic vars (`$_`, `$!`,
+`$/`, capture digits), `self`, `?CLASS`, all `__mutsu_*` metadata — and, as
+collateral, every uppercase-initial user lexical in scope.
+
+`Env::filtered_flat` then builds a brand-new `SymMap` and inserts each kept
+entry, which is where the profile still lands after part A: `reserve_rehash`
+6.4%, the filter closure 3.8%, `HashMap::insert` 2.5%, `filtered_flat::collect`
+1.8% — ~14% of the run building that map, plus ~13% in `gc_op` and ~3% in
+`Gc::drop` refcounting the captured values.
+
+## Part A — DONE (2026-08-29)
+
+Fixed per-creation costs, all contained and semantics-free:
+
+- `capture_closure_env` rebuilt a `HashSet<Symbol>` of the free vars and a
+  `HashSet<&str>` of the chunk's own locals on **every** creation, although both
+  are pure functions of the `CompiledCode`. Now built once per chunk
+  (`CompiledCode::capture_free_var_set` / `capture_local_set`), and the locals
+  test compares `Symbol`s instead of hashing the key's string.
+- `env.remove("__mutsu_return_type")` / `env.insert("__mutsu_callable_type", …)`
+  and `Symbol::intern("__mutsu_callable_type")` re-interned a fixed literal per
+  creation — the `String`-keyed `Env::insert` also allocated the literal and
+  re-scanned it in `note_env_key`. Now pre-interned via `symbol::well_known`.
+- `Symbol::intern("")` for the anonymous closure name — same treatment.
+
+## Part B — OPEN: the O(kept-env) capture
+
+This is the bigger lever and the riskier one. The kept set is over-broad by
+construction, and narrowing it means deciding that free-variable analysis is
+authoritative for some class of names it currently is not trusted for. That is
+exactly the "incomplete static analysis turns into a *flaky* failure" shape
+CLAUDE.md warns about (the `roles-6e.t` precedent), so it needs a real design
+pass — probably an ADR — not a drive-by: which names are genuinely read by
+*runtime* by-name mechanisms (dynamics, magic vars, `self`/`?CLASS`,
+`__mutsu_*` metadata, `$OUTER::`, `reflective_name_access_possible()`) versus
+which are only ever read through a compiled `GetLocal`/`GetGlobal` the free-var
+pass already sees.
+
+A cheaper alternative worth costing first: keep the capture semantics but stop
+rebuilding the map — e.g. share the system-name portion through the `Env` parent
+chain instead of copying it, if snapshot semantics allow.
+
+Also still unmeasured on this path: `SubData` holds `body: Vec<Stmt>`, so every
+closure creation deep-clones the block's AST (`body.clone()`, plus
+`params.clone()` / `param_defs.clone()`). Making it an `Arc<Vec<Stmt>>` is
+mechanical but wide (every `data.body` reader) and wants its own slice.
+`Symbol::intern(&self.lexical_closure_package())` also allocates a `String` per
+creation.
+
+## Repro
+
+Recreate `tmp/lambda-create.raku`, `tmp/lambda-none.raku` and a variant with 30
+extra uppercase-initial lexicals (`tmp/` is gitignored). Profile with
+`perf record -e cpu_core/cycles/`; the `reserve_rehash` caller was located with a
+`rust-gdb -batch` breakpoint on `hashbrown::raw::RawTable<T,A>::reserve_rehash`
+(backtrace: `HashMap::insert` -> `Env::filtered_flat::collect` ->
+`Env::filtered_flat` -> `capture_closure_env` -> `exec_make_lambda_op`).
+
+**Beware `benchmarks/bench-startup.raku` when A/B-ing here**: at ~4.5ms it is so
+short that the same binary measures 0.0045s and 0.0086s in consecutive rounds. A
+large percentage swing on that one row is noise, not a regression.


### PR DESCRIPTION
## Problem

Creating a closure literal happens once per `.map({...})` call, once per callback, once per
`TWEAK` containing a block — i.e. per *iteration* of any loop that mentions one. It is
~15x slower than rakudo.

A micro that builds a `* + 1` WhateverCode 200000 times **without calling it**, against a
control loop with the creation removed (release, `taskset -c 2`, best of 5):

| | mutsu (before) | mutsu (after) | raku |
|---|---|---|---|
| control loop | 0.1323 | 0.1357 | 0.1518 |
| + 200000 creations | 0.6259 | 0.5309 | 0.1847 |
| **per creation** | **2.47us** | **1.97us** | **0.16us** |

This PR takes the **fixed** part of that cost down by 20%. The remainder is the
O(enclosing-env) capture, which needs a design pass and is filed as Part B of
`todo/perf/closure-literal-creation-cost.md` (new).

## What was being redone on every single creation

`capture_closure_env` (`src/vm/vm_register_ops.rs`) decides what a new closure inherits
from the frame creating it, using two membership sets:

- the closure's free variables, and
- the closure's *own* locals/parameters, which must NOT inherit a same-named enclosing
  binding (a WhateverCode's `_` param must not swallow the creating frame's `for`/map topic
  and leak it back on return).

Both are pure functions of the block's `CompiledCode` — and both were re-collected into
fresh `HashSet`s per creation, two allocations plus their fills. They are now built once
per chunk (`CompiledCode::capture_free_var_set` / `capture_local_set`, behind the same
`OnceLock` pattern `const_syms` and `local_attr_keys` already use). The own-locals test now
compares interned `Symbol`s instead of `&str`: `locals_sym` is the interned twin of
`locals`, so membership is identical without hashing the key's string on every probe.
`capture_local_set` falls back to interning from `locals` for a hand-built chunk that never
ran `compute_locals_sym` (same guard `local_sym` uses), so an unfinalized chunk cannot
silently get an empty set.

Three fixed literals were also re-interned per creation: the anonymous closure's empty
name, `__mutsu_return_type` (removed from the capture, then re-inserted when the block
declares a return type) and `__mutsu_callable_type` (the WhateverCode marker). The
`String`-keyed `Env::insert` / `Env::remove` twins additionally allocated the literal and
re-scanned it in `note_env_key` — which sets no flag for either of those names. They now go
through a new `symbol::well_known`, a small home for names the runtime interns on a
per-operation hot path. `sip::Hasher::write` disappeared from the profile as a result.

## Effect

Interleaved A/B of the two release binaries, `taskset -c 2`, best of 5, over
`benchmarks/`: the closure micro **−16%**, `bench-array` **−9.8%**, everything else within
noise.

`bench-startup` is not a usable A/B row here and was discounted: at ~4.5ms the *same*
binary measures 0.0045s and 0.0086s in consecutive rounds (this is noted in the ticket so
the next person does not chase it).

## Verification

- `make test`: PASS (the new pin included)
- `cargo fmt --all`, `cargo clippy -- -D warnings` clean
- Pin: `t/closure-capture-symbol-sets.t` — 17 assertions over exactly the semantics those
  two sets encode: per-iteration capture of a loop variable, a capture tracking a later
  mutation of the outer binding, a WhateverCode's `_` neither taking nor leaking the
  caller's topic, a block-local declaration shadowing without writing through,
  uppercase-initial lexicals / dynamics / type names / `self` staying reachable from inside
  a closure, a closure created inside a closure capturing both levels, and a bare block
  still reporting `Block` (the WhateverCode marker not being inherited). Green under real
  `raku` as well as mutsu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
