### PR TITLE
perf(vm): a `gather` body is compiled once, not on every creation

### DIFF
--- a/news/2026-08/gather-body-compiled-once.md
+++ b/news/2026-08/gather-body-compiled-once.md
@@ -1,0 +1,53 @@
+# A `gather` body is compiled once, not on every creation
+
+`exec_make_gather_op` compiles the `gather` block's body to bytecode so the
+interpreter can force it natively. That compile ran **every time the `gather`
+expression was evaluated** — so a `gather` inside a loop re-ran the whole
+compiler on every iteration. It is the same shape as the `eval_map_over_items_rw`
+bug fixed a few hours earlier (#7109), found by the same cheap oracle: on a
+steady-state loop, `MUTSU_VM_STATS`'s `const-pool: add_constant=` must not grow
+with the iteration count. It grew by **3 per gather creation** (60013 over a
+20000-iteration loop).
+
+## Measurement
+
+20000 `gather` creations, each forced (release, `taskset -c 2`, best of 5):
+
+| gather body | before | after | raku |
+|---|---|---|---|
+| 3 `take`s | 0.1003 | **0.0664** (−34%) | 0.2308 |
+| + 20 extra statements | 0.7997 | **0.2344** (−71%) | 0.2747 |
+
+The second row is the tell: mutsu's cost grew 8x with the body while rakudo's
+grew 1.2x, because mutsu was paying a *compile* per creation and rakudo was not.
+Afterwards mutsu is faster than rakudo on both. `add_constant` over the same run:
+**60013 → 16**.
+
+## The change
+
+`Interpreter::gather_compile_cache` keys the compiled body on the pointer
+identity of the body's analysis `CompiledCode` — the same key shape
+`map_grep_compile_cache` uses, and for the same reason (the `Arc` is cloned into
+the key so the address cannot be recycled under a live entry). It is a separate
+map rather than a shared one because the compile *target* differs: a body that
+declares routines is compiled through a wrapping `Stmt::Block`, whose
+`BlockScope` restores the routine registry, so two sibling
+`gather { sub foo {…} }` blocks do not collide. That decision is itself a pure
+function of the body, so it stays inside the cached computation.
+
+A `gather` whose body has no analysis chunk (an `EVAL`-built one) compiles fresh
+— uncached but correct, exactly like the map/grep sibling.
+
+Pin: `t/gather-body-compile-cache.t` — 15 assertions covering per-instance
+capture, laziness (the body must not run eagerly), a body that declares a routine
+(twice, with the same name, checking neither collides nor escapes), nested
+gathers, `next`/`last` inside the body, empty and single-`take` gathers, and
+re-reading a `.cache`d gather. Green under real `raku`.
+
+## Found while here, not fixed
+
+`state` inside a `gather` body is shared across gather instances in mutsu
+(`loop=1,2,3` where rakudo gives `loop=1,1,1`). Verified to predate this cache
+and be independent of it — mutsu compiled the body fresh each time and still
+shared the cell, so the state key resolves by name rather than by chunk. Filed as
+`todo/tickets/gather-block-state-is-shared-across-instances.md`.

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1760,6 +1760,18 @@ pub struct Interpreter {
     /// recomputable optimization).
     map_grep_compile_cache:
         HashMap<MapGrepCacheKey, (std::sync::Arc<CompiledCode>, std::sync::Arc<CompiledFns>)>,
+    /// Compiled bytecode for `gather` block bodies, keyed the same way (pointer
+    /// identity of the body's analysis `CompiledCode`). `exec_make_gather_op`
+    /// used to run the whole compiler on the body every time the `gather`
+    /// EXPRESSION was evaluated, so a `gather` inside a loop re-compiled per
+    /// iteration: 3 constant-pool additions per creation, and ~1.75us per body
+    /// statement per creation. Kept separate from `map_grep_compile_cache`
+    /// because the compile target differs (a body that declares routines is
+    /// wrapped in a `Stmt::Block` first), so the two must never share a slot for
+    /// the same origin chunk. Starts empty per thread (a pure recomputable
+    /// optimization).
+    gather_compile_cache:
+        HashMap<MapGrepCacheKey, (std::sync::Arc<CompiledCode>, std::sync::Arc<CompiledFns>)>,
     /// Compiled bytecode for subset `where` predicates, keyed by subset name.
     /// A subset's predicate is a fixed `Expr`, so it is compiled once and reused
     /// across all type checks instead of recompiling + cloning the entire

--- a/src/runtime/resolution_map_grep.rs
+++ b/src/runtime/resolution_map_grep.rs
@@ -253,6 +253,58 @@ impl Interpreter {
         (code, fns)
     }
 
+    /// Compiled bytecode for a `gather` block body, cached on the body's
+    /// analysis chunk (see `Interpreter::gather_compile_cache`).
+    ///
+    /// `exec_make_gather_op` compiles the body for Interpreter-native forcing.
+    /// That compile is a pure function of the body, but it ran on every
+    /// evaluation of the `gather` EXPRESSION -- so a `gather` inside a loop
+    /// re-ran the whole compiler per iteration. Measured before this cache:
+    /// `add_constant` grew by 3 per gather creation, and adding 20 statements to
+    /// the body took a 20000-iteration loop from 0.11s to 0.81s (rakudo: 0.23s
+    /// to 0.27s).
+    ///
+    /// A body that declares routines is compiled through a wrapping
+    /// `Stmt::Block`, whose `BlockScope` restores the routine registry -- that
+    /// decision is itself a pure function of the body, so it stays inside the
+    /// cached computation. A gather with no analysis chunk (an `EVAL`-built one)
+    /// compiles fresh, exactly like the map/grep sibling.
+    pub(crate) fn compile_gather_body_cached(
+        &mut self,
+        analysis_cc: &Option<std::sync::Arc<crate::opcode::CompiledCode>>,
+        body: &[crate::ast::Stmt],
+    ) -> (
+        std::sync::Arc<crate::opcode::CompiledCode>,
+        std::sync::Arc<crate::opcode::CompiledFns>,
+    ) {
+        let key = analysis_cc.as_ref().map(|cc| MapGrepCacheKey {
+            origin: cc.clone(),
+            lexically_in_routine: false,
+        });
+        if let Some(key) = &key
+            && let Some((code, fns)) = self.gather_compile_cache.get(key)
+        {
+            return (code.clone(), fns.clone());
+        }
+        let compiler = crate::compiler::Compiler::new();
+        let scoped_body: Vec<crate::ast::Stmt>;
+        let compile_target: &[crate::ast::Stmt] =
+            if crate::compiler::Compiler::stmts_declare_routines(body) {
+                scoped_body = vec![crate::ast::Stmt::Block(body.to_vec())];
+                &scoped_body
+            } else {
+                body
+            };
+        let (code, fns) = compiler.compile(compile_target);
+        let code = std::sync::Arc::new(code);
+        let fns = std::sync::Arc::new(fns);
+        if let Some(key) = key {
+            self.gather_compile_cache
+                .insert(key, (code.clone(), fns.clone()));
+        }
+        (code, fns)
+    }
+
     pub(super) fn eval_map_over_items(
         &mut self,
         func: Option<Value>,

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -2874,6 +2874,7 @@ impl Interpreter {
             carrier_compile_cache: HashMap::new(),
             subst_repl_plans: HashMap::new(),
             map_grep_compile_cache: HashMap::new(),
+            gather_compile_cache: HashMap::new(),
             subset_predicate_cache: HashMap::new(),
             subset_where_fail: None,
             private_zeroarg_method_cache: HashMap::new(),

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -644,6 +644,7 @@ impl Interpreter {
             carrier_compile_cache: HashMap::new(),
             subst_repl_plans: HashMap::new(),
             map_grep_compile_cache: HashMap::new(),
+            gather_compile_cache: HashMap::new(),
             subset_predicate_cache: HashMap::new(),
             subset_where_fail: None,
             private_zeroarg_method_cache: HashMap::new(),

--- a/src/vm/vm_register_ops.rs
+++ b/src/vm/vm_register_ops.rs
@@ -1,5 +1,4 @@
 use super::*;
-use crate::compiler::Compiler;
 use crate::symbol::Symbol;
 
 impl Interpreter {
@@ -143,22 +142,22 @@ impl Interpreter {
             // `Stmt::Block` (whose `BlockScope` restores the routine registry) when there
             // is one. Without it two sibling `gather { sub foo {...} }` blocks collided
             // with X::Redeclaration, and the first block's `foo` stayed callable outside.
-            let compiler = Compiler::new();
-            let scoped_body: Vec<Stmt>;
-            let compile_target: &[Stmt] = if Compiler::stmts_declare_routines(body) {
-                scoped_body = vec![Stmt::Block(body.clone())];
-                &scoped_body
-            } else {
-                body
-            };
-            let (compiled_code, compiled_fns) = compiler.compile(compile_target);
+            //
+            // Cached on the body's analysis chunk (`gather_compile_cache`): the
+            // compile is a pure function of the body, but this runs every time
+            // the `gather` EXPRESSION is evaluated, so a `gather` in a loop used
+            // to re-run the whole compiler per iteration -- ~1.75us per body
+            // statement per creation, and 3 constant-pool additions each. A
+            // gather whose body has no analysis chunk (an `EVAL`-built one)
+            // compiles fresh, exactly as the map/grep sibling does.
+            let (compiled_code, compiled_fns) = self.compile_gather_body_cached(&analysis_cc, body);
             let list = LazyList {
                 body: body.clone(),
                 env,
                 cache: std::sync::Mutex::new(None),
                 generation_state: std::sync::Mutex::new(None),
-                compiled_code: Some(std::sync::Arc::new(compiled_code)),
-                compiled_fns: Some(std::sync::Arc::new(compiled_fns)),
+                compiled_code: Some(compiled_code),
+                compiled_fns: Some(compiled_fns),
                 elems_count: None,
                 scan_spec: None,
                 sequence_spec: None,

--- a/t/gather-body-compile-cache.t
+++ b/t/gather-body-compile-cache.t
@@ -1,0 +1,73 @@
+use Test;
+
+# Pin for `Interpreter::gather_compile_cache`: a `gather` body's bytecode is now
+# compiled once per body and reused, instead of running the whole compiler on
+# every evaluation of the `gather` expression. Nothing observable may change, and
+# in particular each gather instance must still be independent.
+
+plan 15;
+
+# --- A gather in a loop: each instance is independent ------------------------
+my @sums;
+for 1, 2, 3 -> $i {
+    my @g = gather {
+        take $i;
+        take $i * 10;
+    };
+    @sums.push: @g.join('/');
+}
+is @sums.join(','), '1/10,2/20,3/30', 'each gather instance captures its own lexical';
+
+# The same literal evaluated twice from a routine.
+sub two($n) { return gather { take $n; take $n + 1 } }
+is two(5).join(','), '5,6', 'first call';
+is two(9).join(','), '9,10', 'second call is independent';
+
+# --- Laziness is preserved ---------------------------------------------------
+my $pulled = 0;
+my $lazy = gather {
+    for 1 .. 100 {
+        $pulled++;
+        take $_;
+    }
+};
+is $lazy[0], 1, 'first element of a lazy gather';
+is $lazy[1], 2, 'second element';
+ok $pulled < 100, 'the gather did not eagerly run its whole body';
+is $lazy[4], 5, 'later elements still come out in order';
+
+# --- A gather whose body declares a routine ----------------------------------
+# Such a body compiles through a wrapping `Stmt::Block` so the declaration stays
+# lexical to it; that decision is part of the cached computation.
+my @r1 = gather { sub helper() { 'h1' }; take helper(); };
+is @r1.join(','), 'h1', 'a gather body may declare a routine';
+my @r2 = gather { sub helper() { 'h2' }; take helper(); };
+is @r2.join(','), 'h2', 'a sibling gather declaring the same name does not collide';
+nok defined(::('helper')), 'the routine stayed lexical to its gather body';
+
+# --- Nested and repeated gathers ---------------------------------------------
+my @nested = gather {
+    for 1, 2 -> $x {
+        take [gather { take $x; take $x * 2 }].join('-');
+    }
+};
+is @nested.join(','), '1-2,2-4', 'a gather nested inside a gather';
+
+# --- Control flow inside a gather body ---------------------------------------
+my @ctl = gather {
+    for 1 .. 5 {
+        next if $_ %% 2;
+        last if $_ > 3;
+        take $_;
+    }
+};
+is @ctl.join(','), '1,3', 'next/last inside a gather body';
+
+# --- Empty and single-element gathers ----------------------------------------
+is gather { }.elems, 0, 'an empty gather yields nothing';
+is gather { take 42 }.join(','), '42', 'a one-take gather';
+
+# --- A cached gather can be read twice ---------------------------------------
+my $g = (gather { take 'a'; take 'b' }).cache;
+is "{$g.join(',')}|{$g.join(',')}", 'a,b|a,b',
+    'reading a cached gather twice yields the same values';

--- a/todo/perf/closure-literal-creation-cost.md
+++ b/todo/perf/closure-literal-creation-cost.md
@@ -87,12 +87,15 @@ micro dropped 70%; `bench-ctor` −11.2%, `word-count` −5.2%.
   but the same shape — both are pool-owned and immutable).
 - `Symbol::intern(&self.lexical_closure_package())` allocates a `String` per
   creation just to intern it.
-- **`exec_make_gather_op` runs `Compiler::new().compile(...)` on every `gather`
-  block creation** — the identical per-creation-compile shape that
-  `eval_map_over_items_rw` had (fixed in #7109). It compiles the gather body to
-  bytecode each time the `gather` expression is evaluated, so a `gather` inside a
-  loop re-runs the compiler per iteration. Same fix shape: cache keyed on the
-  chunk + pool slot. Not measured yet — measure before assuming it is hot.
+- ~~`exec_make_gather_op` runs `Compiler::new().compile(...)` on every `gather`
+  block creation~~ — **DONE (2026-08-29)**. It was the identical
+  per-creation-compile shape `eval_map_over_items_rw` had (#7109), and it was
+  hot: `add_constant` grew by 3 per gather creation (60013 over a 20000-iteration
+  loop), and adding 20 statements to the body took that loop from 0.11s to 0.81s
+  while rakudo went 0.23s to 0.27s. `Interpreter::gather_compile_cache` keys the
+  compile on the body's analysis chunk: `add_constant` 60013 → 16, the small-body
+  loop −34%, the large-body loop −71% (0.80s → 0.23s, now faster than rakudo's
+  0.27s).
 
 ## Repro
 

--- a/todo/tickets/gather-block-state-is-shared-across-instances.md
+++ b/todo/tickets/gather-block-state-is-shared-across-instances.md
@@ -1,0 +1,51 @@
+# `state` inside a `gather` block is shared across gather instances
+
+A `state` variable declared inside a `gather { ... }` body should belong to the
+gather **instance** (each evaluation of the `gather` expression makes a fresh
+block closure, and `state` is per closure clone). mutsu shares one cell across
+every gather created from the same literal.
+
+## Repro
+
+```raku
+sub make() {
+    return gather {
+        state $n = 0;
+        $n++;
+        take $n;
+    };
+}
+my @a = make();
+my @b = make();
+say "a={@a.join(',')} b={@b.join(',')}";
+
+my @seen;
+for ^3 {
+    my @g = gather { state $m = 0; $m++; take $m; };
+    @seen.push: @g[0];
+}
+say "loop={@seen.join(',')}";
+```
+
+| | raku v2026.06 | mutsu |
+|---|---|---|
+| first line | `a=1 b=1` | `a=1 b=2` |
+| second line | `loop=1,1,1` | `loop=1,2,3` |
+
+## Notes
+
+Found on 2026-08-29 while adding `Interpreter::gather_compile_cache` (the
+`gather` body used to be re-compiled on every creation). **The divergence
+predates that cache and is independent of it**: mutsu compiled the body fresh
+each time and still shared the state cell, so the state key is resolved by NAME
+in the env rather than by the compiled chunk. Verified before and after the cache
+landed — identical wrong output both ways.
+
+The map/grep loops solve the analogous problem by scoping state to the closure
+instance (`vm.state_scope_id.set(Some(data.id))` in
+`runtime/resolution_map_grep.rs`, with the comment "Scope `state` variables to
+the closure instance"). The gather forcing path has no equivalent. That is the
+shape of the likely fix — give the `LazyList` an instance id and set
+`state_scope_id` around the forcing run — but it needs checking against a
+`gather` that is forced lazily and resumed (the coroutine path), where the scope
+has to be re-established on each resume, not just on the first pull.


### PR DESCRIPTION
## Problem

`exec_make_gather_op` compiles the `gather` block's body to bytecode so the interpreter can
force it natively — and that compile ran **every time the `gather` expression was
evaluated**, so a `gather` inside a loop re-ran the whole compiler on every iteration.

Same shape as the `eval_map_over_items_rw` bug fixed in #7109, and found with the same
cheap oracle recorded there: on a steady-state loop, `MUTSU_VM_STATS`'s
`const-pool: add_constant=` must not grow with the iteration count. It grew by **3 per
gather creation** — 60013 over a 20000-iteration loop.

## Measurement

20000 `gather` creations, each forced (release, `taskset -c 2`, best of 5):

| gather body | before | after | raku |
|---|---|---|---|
| 3 `take`s | 0.1003 | **0.0664** (−34%) | 0.2308 |
| + 20 extra statements | 0.7997 | **0.2344** (−71%) | 0.2747 |

The second row is the tell: mutsu's cost grew 8x with the body size while rakudo's grew
1.2x, because mutsu was paying a *compile* per creation and rakudo was not. Afterwards
mutsu is faster than rakudo on both rows. `add_constant` over the same run: **60013 → 16**.

## Approach

`Interpreter::gather_compile_cache` keys the compiled body on the pointer identity of the
body's analysis `CompiledCode` — the same key shape `map_grep_compile_cache` uses, and for
the same reason (the `Arc` is cloned into the key so the address cannot be recycled under a
live entry).

It is a **separate** map rather than a shared one because the compile *target* differs: a
body that declares routines is compiled through a wrapping `Stmt::Block`, whose
`BlockScope` restores the routine registry, so two sibling `gather { sub foo {…} }` blocks
do not collide and neither leaks its `foo`. That decision is itself a pure function of the
body, so it stays inside the cached computation.

A `gather` whose body has no analysis chunk (an `EVAL`-built one) compiles fresh —
uncached but correct, exactly like the map/grep sibling.

## Found while here, not fixed

`state` inside a `gather` body is shared across gather instances in mutsu: `loop=1,2,3`
where rakudo gives `loop=1,1,1`. Verified to **predate this cache and be independent of
it** — mutsu compiled the body fresh each time and still shared the cell, so the state key
resolves by name rather than by chunk. Filed as
`todo/tickets/gather-block-state-is-shared-across-instances.md` with the repro, the
raku-vs-mutsu table, and a note on the likely fix (the map/grep loops solve the analogous
problem with `state_scope_id`; the gather forcing path has no equivalent, and the coroutine
resume path needs checking).

## Verification

- `make test`: **3558 files / 35674 tests, PASS**
- `cargo fmt --all`, `cargo clippy -- -D warnings` clean (re-run after `touch src/lib.rs` —
  clippy straight after a build reuses a cached result and never re-lints)
- Pin: `t/gather-body-compile-cache.t` — 15 assertions covering per-instance capture,
  laziness (the body must not run eagerly), a body that declares a routine (twice, same
  name, checking neither collides nor escapes its gather), nested gathers, `next`/`last`
  inside the body, empty and single-`take` gathers, and re-reading a `.cache`d gather.
  Green under real `raku`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
