### PR TITLE
fix(binding): detach is copy from sigilless metadata

### DIFF
--- a/news/2026-08/is-copy-detaches-sigilless-binding-metadata.md
+++ b/news/2026-08/is-copy-detaches-sigilless-binding-metadata.md
@@ -1,0 +1,10 @@
+# `is copy` parameters detach sigilless binding metadata
+
+A scalar `is copy` parameter now clears inherited sigilless alias and
+readonly metadata before it binds its own detached value. Previously, an
+assignment to an `is copy` parameter with the same name as an outer sigilless
+capture could follow that capture back to an immutable literal.
+
+The regression was exposed by the vendored upstream `Test` module while running
+`roast/S32-num/rat.t`. The generic call-chain shape is pinned by
+`t/is-copy-sigilless-capture-chain.t`.

--- a/src/runtime/types/binding_signature.rs
+++ b/src/runtime/types/binding_signature.rs
@@ -1963,6 +1963,19 @@ impl Interpreter {
                     // detach HERE or `@b.push` inside the sub would reach the
                     // caller's `@a`.
                     if is_copy {
+                        // A sigilless parameter (`\\value`) records an env-level
+                        // alias to its caller so assignments propagate through the
+                        // raw binding. An `is copy` parameter with the same bare
+                        // name must start a new, detached binding instead. Leaving
+                        // the inherited alias or readonly marker in this call frame
+                        // makes a compiled store to the copy follow the caller's
+                        // alias chain (or reject the store outright), which can
+                        // reach an immutable literal through an intermediate plain
+                        // scalar parameter.
+                        self.env
+                            .remove(&crate::runtime::sigilless_alias_key(&pd.name));
+                        self.env
+                            .remove(&crate::runtime::sigilless_readonly_key(&pd.name));
                         value = value.detach_shared_container();
                         // The copy is a fresh container: its descriptor name is
                         // "element" in rakudo, not the source variable's name the

--- a/t/is-copy-sigilless-capture-chain.t
+++ b/t/is-copy-sigilless-capture-chain.t
@@ -1,0 +1,25 @@
+use v6;
+use Test;
+
+plan 3;
+
+sub replace($value is copy) {
+    $value = 'replacement';
+    $value
+}
+
+sub relay($value) {
+    replace($value)
+}
+
+sub capture-and-relay(\value) {
+    relay(value)
+}
+
+is capture-and-relay('original'), 'replacement',
+    'is copy detaches a value received through a sigilless capture';
+
+my $original = 'original';
+is capture-and-relay($original), 'replacement',
+    'is copy does not write through the sigilless capture chain';
+is $original, 'original', 'the caller value remains unchanged';

--- a/todo/tickets/is-copy-param-not-decoupled-through-sigilless-capture-chain.md
+++ b/todo/tickets/is-copy-param-not-decoupled-through-sigilless-capture-chain.md
@@ -89,6 +89,18 @@ This was NOT investigated further (no VM/compiler code read for the `is copy`
 parameter-binding path) — this ticket is a traced-but-unfixed finding, not a
 diagnosis of the exact compiler/VM site.
 
+## Resolution (2026-08-30)
+
+Fixed in `runtime/types/binding_signature.rs`. A sigilless capture stores
+`__mutsu_sigilless_alias::*` and `__mutsu_sigilless_readonly::*` metadata in
+the call environment. An `is copy` parameter begins a detached binding, so its
+binder now removes inherited metadata for its own name before binding the
+copied value. This prevents an assignment in the copy's body from following an
+outer raw alias or inheriting that alias's immutable-literal marker.
+
+Pin: `t/is-copy-sigilless-capture-chain.t`. The originally blocked
+`roast/S32-num/rat.t` completes under `MUTSU_REAL_TEST=1`.
+
 ## Affected files (starting points for whoever picks this up)
 
 - Wherever `is copy` parameter binding is compiled/executed (likely


### PR DESCRIPTION
Fixes is-copy parameter binding when an argument arrives through a sigilless capture and an intermediate scalar parameter. The fresh copy no longer inherits the outer alias or readonly metadata.

Validation:
- cargo fmt --all
- cargo clippy -- -D warnings
- make test
- MUTSU_REAL_TEST=1 target/release roast/S32-num/rat.t
- regression pin under mutsu and raku