### PR TITLE
fix: normalize EVAL parse diagnostics

### DIFF
--- a/src/runtime/system_eval_string.rs
+++ b/src/runtime/system_eval_string.rs
@@ -584,6 +584,20 @@ impl Interpreter {
         }
         crate::runtime::registration_sub::pop_eval_outer_amp_names();
         crate::runtime::registration_sub::pop_eval_outer_routine_keys();
+        // An EVAL parse failure is exposed as `$!`, whose string form is what
+        // Test.rakumod's `eval-lives-ok` prints after `# Error:`.  The raw
+        // parser diagnostic is useful to the CLI renderer, but starts with an
+        // internal "Confused. parse error ..." wrapper that is neither useful
+        // nor compatible with Raku's EVAL diagnostic.  Keep the structured
+        // parse code and location intact while giving the caught exception the
+        // EVAL-facing prefix Raku uses.
+        if let Err(err) = &mut result
+            && err.code().is_some_and(|code| code.is_parse())
+            && err.message.starts_with("Confused. parse error")
+            && !err.message.starts_with("Unable to parse")
+        {
+            err.message = format!("Unable to parse expression; {}", err.message);
+        }
         result
     }
 }

--- a/t/eval-parse-error-diagnostic.t
+++ b/t/eval-parse-error-diagnostic.t
@@ -1,0 +1,13 @@
+use Test;
+use lib $*PROGRAM.parent(2).add("roast/packages/Test-Helpers/lib");
+use Test::Util;
+
+plan 1;
+
+is_run 'use Test; eval-lives-ok q[foo<bar], "broken EVAL";',
+    {
+        :out(/'not ok 1 - broken EVAL'/),
+        :err(/'# Error: Unable to parse'/),
+        :status({ $_ != 0 }),
+    },
+    'an EVAL parse failure has Raku-compatible diagnostic prefix';

--- a/todo/deep/vendor-real-test-module.md
+++ b/todo/deep/vendor-real-test-module.md
@@ -5383,3 +5383,19 @@ residue list at measurement time; a sibling PR closed it independently in the
 same window (see the "routine-value self-recursion" entry immediately above)
 -- re-verify before trusting this file's residue count going forward, per
 this ticket's own standing rule.
+
+## 2026-08-29: `S24-testing/3-output.t` — EVAL exposed a parser-internal diagnostic
+
+`Test.rakumod`'s `eval-lives-ok` catches an EVAL parse failure in `$!` and
+prints it through `_diag("Error: $ee")`. Mutsu exposed the raw parser text
+(`Confused. parse error ... expected expected statement ...`) there, including
+internal location and duplicated `near` context. Rakudo's equivalent
+diagnostic begins `Unable to parse`, which the spec test matches.
+
+`eval_eval_string` now normalizes only untyped `Confused. parse error` results
+to begin `Unable to parse expression;`, retaining the structured parse code
+and location. Typed parser errors are deliberately excluded: their `X::...`
+message is needed to recover the exception class for `throws-like`. Pin:
+`t/eval-parse-error-diagnostic.t`, green under both providers and Rakudo. The
+target roast file passes with `MUTSU_REAL_TEST=1`; the typed-error coverage in
+`S02-lexical-conventions/comments.t` remains green.


### PR DESCRIPTION
Normalizes untyped EVAL parser failures before they reach Test.rakumod diagnostics, while preserving typed parse-error messages for exception recovery.

Validation:
- cargo clippy -- -D warnings
- targeted native and MUTSU_REAL_TEST regression tests
- MUTSU_REAL_TEST=1 roast/S24-testing/3-output.t
- roast/S02-lexical-conventions/comments.t
- raku regression test