### PR TITLE
fix: preserve INIT phaser placeholder checks

### DIFF
--- a/src/compiler/helpers_block_inline.rs
+++ b/src/compiler/helpers_block_inline.rs
@@ -395,6 +395,10 @@ impl Compiler {
                         // Phasers in block-final position should leave their
                         // last expression value on the stack (e.g. when used
                         // inside string interpolation blocks).
+                        if self.emit_block_placeholder_die(body) {
+                            self.pop_dynamic_scope_lexical(saved);
+                            return;
+                        }
                         self.compile_block_inline(body);
                         self.pop_dynamic_scope_lexical(saved);
                         return;

--- a/src/runtime/phasers.rs
+++ b/src/runtime/phasers.rs
@@ -946,8 +946,19 @@ fn reorder_at_level(
     // TODO: For multiple CHECK PhaserExprs, pairs should be reversed.
     // For now, just extend in forward order (correct for single CHECK).
     stmts.extend(extra_check);
+    // Keep statement-level INIT bodies wrapped as phasers.  Compiling an INIT
+    // node runs its body inline just as the old raw-body expansion did, but
+    // retaining the node preserves compile-time checks that are specific to a
+    // phaser body (notably that it cannot take placeholder parameters).
+    // Expanding the body here made `INIT { $^x }` look like an ordinary
+    // mainline `$^x` to the compiler after reordering, bypassing
+    // `emit_block_placeholder_die`.
     for body in &init {
-        stmts.extend(body.iter().cloned());
+        stmts.push(Stmt::Phaser {
+            kind: PhaserKind::Init,
+            body: body.clone(),
+            condition: None,
+        });
     }
     stmts.extend(extra_init);
     stmts.extend(rest);

--- a/t/placeholder-scope-rejecting.t
+++ b/t/placeholder-scope-rejecting.t
@@ -1,6 +1,6 @@
 use Test;
 
-plan 27;
+plan 28;
 
 # ADR-0048 Phase 2: constructs whose body may NOT take a signature.
 # `raku` gives the exact same `X::Placeholder::Block` for all of these
@@ -62,6 +62,16 @@ throws-like 'CHECK { $^c }', X::Placeholder::Block,
 
 throws-like 'INIT { $^c }', X::Placeholder::Block,
     'INIT {} rejects a placeholder';
+
+# Keep a direct EVAL pin in addition to `throws-like`: mutsu's native Test
+# provider accepts the older generic error, while the vendored Test module
+# checks the exception type.  INIT reordering must therefore preserve enough
+# phaser context for EVAL to create X::Placeholder::Block itself.
+{
+    try EVAL q[INIT { $^c }];
+    is $!.^name, 'X::Placeholder::Block',
+        'EVAL preserves INIT phaser context for the placeholder error';
+}
 
 # PRE {}/POST {} at the true mainline used to be a silent no-op (see
 # `news/2026-08/pre-post-phasers-enforced-at-mainline.md`); now that they are

--- a/todo/deep/vendor-real-test-module.md
+++ b/todo/deep/vendor-real-test-module.md
@@ -5399,3 +5399,21 @@ message is needed to recover the exception class for `throws-like`. Pin:
 `t/eval-parse-error-diagnostic.t`, green under both providers and Rakudo. The
 target roast file passes with `MUTSU_REAL_TEST=1`; the typed-error coverage in
 `S02-lexical-conventions/comments.t` remains green.
+
+## 2026-08-29: `INIT { $^c }` keeps its phaser context through reordering
+
+Closes the final named `t/`-side placeholder gap,
+`todo/tickets/init-phaser-does-not-reject-a-placeholder-parameter.md`.
+`reorder_at_level` used to flatten each statement-level INIT body into the
+ordinary statement list. That let `INIT { $^c }` reach the compiler as a bare
+mainline `$^c`, bypassing `emit_block_placeholder_die`; in an EVAL it therefore
+completed successfully instead of producing `X::Placeholder::Block`. Keeping
+the `Stmt::Phaser { kind: Init, ... }` node preserves the existing compiler
+guard while retaining INIT's execution order. The block-inline tail phaser
+path now applies that guard too.
+
+`t/placeholder-scope-rejecting.t` adds a direct EVAL exception-class pin,
+because the native Test provider's older `throws-like` path can accept the
+generic error whereas the vendored Test module checks the actual exception
+type. All 28 assertions pass under raku, the native provider, and
+`MUTSU_REAL_TEST=1`.

--- a/todo/tickets/init-phaser-does-not-reject-a-placeholder-parameter.md
+++ b/todo/tickets/init-phaser-does-not-reject-a-placeholder-parameter.md
@@ -1,5 +1,13 @@
 # `INIT { $^c }` does not raise `X::Placeholder::Block`
 
+**Closed 2026-08-29.** Phaser reordering had expanded statement-level `INIT`
+bodies into ordinary statements, losing the phaser context before compilation.
+It now retains `Stmt::Phaser { kind: Init, ... }`, so the existing compiler
+guard emits `X::Placeholder::Block`. A tail-position INIT now takes the same
+guard through `compile_block_inline`. Pinned by the direct EVAL assertion in
+`t/placeholder-scope-rejecting.t`; that 28-test file passes under raku and
+under both mutsu Test providers.
+
 A phaser block is not a routine, so a placeholder parameter (`$^c`) in one is
 `X::Placeholder::Block`. mutsu enforces that for every phaser
 `t/placeholder-scope-rejecting.t` covers -- `BEGIN`, `CHECK`, `PRE`, `CATCH`,


### PR DESCRIPTION
## Problem
Phaser reordering flattened statement-level INIT bodies before compilation, so placeholder parameters in EVALed INIT phasers bypassed `X::Placeholder::Block`.

## Approach
Keep reordered INIT bodies as phaser nodes and apply the placeholder guard in the tail-position phaser path.

## Validation
- `cargo fmt --all`
- `cargo clippy -- -D warnings`
- `make test`
- `raku t/placeholder-scope-rejecting.t`
- native and `MUTSU_REAL_TEST=1` runs of `t/placeholder-scope-rejecting.t`
- `make roast` was started but the local runner terminated during release compilation before a test result; CI will run the required roast check.