### PR TITLE
fix: copy sprintf format literals as UTF-8, not Latin-1

### DIFF
--- a/news/2026-08/sprintf-utf8-literal.md
+++ b/news/2026-08/sprintf-utf8-literal.md
@@ -1,0 +1,20 @@
+# sprintf copies UTF-8 format literals as UTF-8, not Latin-1
+
+`printf "√2 ≈%.9f\n", $x` wrote mojibake (`â2 â1.414…`, `Ï` for `π`) because
+`format_sprintf_impl` walked the format string a byte at a time and pushed each
+byte as a Latin-1 codepoint:
+
+```
+√  U+221A  UTF-8 E2 88 9A  →  U+00E2 U+0088 U+009A  →  UTF-8 C3 A2 C2 88 C2 9A
+```
+
+A UTF-8 terminal then shows `â` and swallows the C1 continuation bytes, which
+is exactly the first-run output of `contfrac.raku`. `say "√2 ≈ π"` was already
+correct — only sprintf/printf format *literals* were wrong; `%s` arguments
+were fine.
+
+The formatter now copies each run of literal text as a UTF-8 slice up to the
+next ASCII `%`. Directive letters are consumed as a whole Unicode scalar so
+the scan stays on a character boundary.
+
+Pinned by `t/sprintf-utf8-literal.t`.

--- a/src/runtime/sprintf.rs
+++ b/src/runtime/sprintf.rs
@@ -63,8 +63,14 @@ fn format_sprintf_impl(fmt: &str, args: &[Value], z_mode: bool) -> String {
     let v6e = v6e_active();
     while pos < len {
         if bytes[pos] != b'%' {
-            out.push(bytes[pos] as char);
-            pos += 1;
+            // Literal text is UTF-8. Copy through to the next ASCII `%` (which
+            // cannot sit inside a multi-byte sequence) so glyphs such as √/≈/π
+            // survive, rather than each byte becoming a Latin-1 codepoint.
+            let start = pos;
+            while pos < len && bytes[pos] != b'%' {
+                pos += 1;
+            }
+            out.push_str(&fmt[start..pos]);
             continue;
         }
         pos += 1; // skip '%'
@@ -139,8 +145,10 @@ fn format_sprintf_impl(fmt: &str, args: &[Value], z_mode: bool) -> String {
             }
         }
         let spec = if pos < len {
-            let s = bytes[pos] as char;
-            pos += 1;
+            // Directives are ASCII; consume a full scalar so a stray non-ASCII
+            // after `%` cannot leave `pos` in the middle of a UTF-8 sequence.
+            let s = fmt[pos..].chars().next().unwrap();
+            pos += s.len_utf8();
             s
         } else {
             's'

--- a/t/sprintf-utf8-literal.t
+++ b/t/sprintf-utf8-literal.t
@@ -1,0 +1,17 @@
+use Test;
+
+# sprintf used to walk the format string a byte at a time and push each byte as
+# a Latin-1 codepoint. UTF-8 literals such as √ (E2 88 9A) then double-encoded
+# to â plus two C1 controls, which a UTF-8 terminal renders as "â2".
+# Arguments (%s) were already fine; only literal text between directives broke.
+
+plan 8;
+
+is sprintf("√2"), "√2", 'UTF-8 literal with no directive';
+is sprintf("√2 ≈%.1f", 1.5), "√2 ≈1.5", '√ and ≈ around %.1f';
+is sprintf("e  ≈%.1f", 2.5), "e  ≈2.5", 'ASCII prefix plus ≈';
+is sprintf("π  ≈%.1f", 3.5), "π  ≈3.5", 'π and ≈ around %.1f';
+is sprintf("%s", "√2 ≈ π"), "√2 ≈ π", '%s still emits a UTF-8 argument';
+is sprintf("α%sω", "β"), "αβω", 'UTF-8 literals on both sides of %s';
+is sprintf("%%√"), "%√", '%% then a UTF-8 literal';
+is sprintf("√%%π"), "√%π", 'UTF-8 literals around %%';


### PR DESCRIPTION
## Summary

`printf "√2 ≈%.9f\n", $x` wrote mojibake (`â2 â1.414…`, `Ï` for `π`) because `format_sprintf_impl` walked the format string a byte at a time and pushed each byte as a Latin-1 codepoint:

```
√  U+221A  UTF-8 E2 88 9A  →  U+00E2 U+0088 U+009A  →  UTF-8 C3 A2 C2 88 C2 9A
```

A UTF-8 terminal then shows `â` and swallows the C1 continuation bytes. `say "√2 ≈ π"` was already correct — only sprintf/printf format *literals* were wrong; `%s` arguments were fine.

The formatter now copies each run of literal text as a UTF-8 slice up to the next ASCII `%`. Directive letters are consumed as a whole Unicode scalar so the scan stays on a character boundary.

Pinned by `t/sprintf-utf8-literal.t`.

## Attribution

This PR is opened from the `grondilu/mutsu` fork by GitHub user **grondilu**.

The change itself was authored by **Grok** (xAI, `Grok <grok@x.ai>`). I am Grok, acting only on grondilu's behalf — not as tokuhirom or any other account.

## Test plan

- [x] `t/sprintf-utf8-literal.t` covers UTF-8 literals around directives, `%s` arguments, and `%%`
- [ ] CI: `make test` + `make roast`