### PR TITLE
fix: run hyper/race for on worker batches

### DIFF
--- a/news/2026-08/hyper-for-parallel-workers.md
+++ b/news/2026-08/hyper-for-parallel-workers.md
@@ -1,0 +1,16 @@
+# `hyper for` in expression position actually runs on worker threads
+
+`my @a = hyper for LIST { BODY }` (and the same shape with a postfix, as in
+`mandelbrot.raku`'s `.rotor`) used to parse as `.hyper(do for …)`: the loop
+ran sequentially on the main thread and `.hyper` only wrapped the already
+computed list. Statement-level `hyper for` did spawn a thread, but only one,
+and that thread ran the whole loop — enough for `$*THREAD.id` to differ, not
+enough to use more than one core.
+
+Expression-position `hyper for` / `race for` now parse like `lazy for`
+(`ForMode::Hyper` / `Race` on a `DoStmt`), `compile_do_for_expr` honours that
+mode, and the VM batches iterations across `available_parallelism` workers,
+concatenating collected results in input order. `HyperSeq.map` / `.grep` no
+longer fall back to sequential dispatch past 1000 items.
+
+Pinned by `t/hyper-for-parallel.t`.

--- a/news/2026-08/hyper-for-parallel-workers.md
+++ b/news/2026-08/hyper-for-parallel-workers.md
@@ -10,7 +10,6 @@ enough to use more than one core.
 Expression-position `hyper for` / `race for` now parse like `lazy for`
 (`ForMode::Hyper` / `Race` on a `DoStmt`), `compile_do_for_expr` honours that
 mode, and the VM batches iterations across `available_parallelism` workers,
-concatenating collected results in input order. `HyperSeq.map` / `.grep` no
-longer fall back to sequential dispatch past 1000 items.
+concatenating collected results in input order.
 
 Pinned by `t/hyper-for-parallel.t`.

--- a/src/compiler/expr_block.rs
+++ b/src/compiler/expr_block.rs
@@ -648,6 +648,7 @@ impl Compiler {
                 params_def,
                 body,
                 label,
+                mode,
                 rw_block,
                 explicit_zero_params,
                 is_statement_modifier,
@@ -664,6 +665,7 @@ impl Compiler {
                     body,
                     label,
                     *is_statement_modifier,
+                    *mode,
                 );
             }
             Stmt::While { cond, body, label } => {

--- a/src/compiler/helpers_do_expr.rs
+++ b/src/compiler/helpers_do_expr.rs
@@ -290,6 +290,7 @@ impl Compiler {
         body: &[Stmt],
         label: &Option<String>,
         is_statement_modifier: bool,
+        mode: crate::ast::ForMode,
     ) {
         // Parser currently lowers labeled `do { ... }` / labeled bare blocks into
         // a dummy single-iteration `for Nil` with a label. Preserve block semantics
@@ -420,7 +421,7 @@ impl Compiler {
                 label: label.clone(),
                 arity,
                 collect: true,
-                threaded: false,
+                threaded: matches!(mode, crate::ast::ForMode::Race | crate::ast::ForMode::Hyper),
                 is_rw: has_rw || has_copy,
                 do_writeback: has_rw && !has_copy,
                 rw_param_names,

--- a/src/parser/expr/postfix/loop_.rs
+++ b/src/parser/expr/postfix/loop_.rs
@@ -452,10 +452,14 @@ pub(in crate::parser::expr) fn prefix_expr(input: &str) -> PResult<'_, Expr> {
             },
         ));
     }
-    // hyper prefix: eager materialization variant (same surface semantics as `.hyper`)
+    // hyper prefix: `hyper for` is the statement-prefix form (ForMode::Hyper),
+    // matching `lazy for`. `hyper LIST` is eager materialization (`.hyper`).
     if input.starts_with("hyper") && !is_ident_char(input.as_bytes().get(5).copied()) {
         let r = &input[5..];
         let (r, _) = ws(r)?;
+        if let Ok((r2, stmt)) = crate::parser::stmt::hyper_for_stmt_pub(r) {
+            return Ok((r2, Expr::DoStmt(Box::new(stmt))));
+        }
         let (r, expr) = parse_prefix_listop_operand(r)?;
         return Ok((
             r,
@@ -468,14 +472,14 @@ pub(in crate::parser::expr) fn prefix_expr(input: &str) -> PResult<'_, Expr> {
             },
         ));
     }
-    // race prefix: the unordered sibling of `hyper` (same surface semantics as
-    // `.race`). In *expression* position the statement-prefix form is not
-    // reachable, so `my $r = race for ^10 { ... }` used to parse `race` as a
-    // bare listop term and leave the `for` behind as a separate, sunk
-    // statement. Mirrors the `hyper` arm directly above.
+    // race prefix: `race for` is the statement-prefix form (ForMode::Race).
+    // `race LIST` wraps the operand in `.race`, same as `hyper LIST`.
     if input.starts_with("race") && !is_ident_char(input.as_bytes().get(4).copied()) {
         let r = &input[4..];
         let (r, _) = ws(r)?;
+        if let Ok((r2, stmt)) = crate::parser::stmt::race_for_stmt_pub(r) {
+            return Ok((r2, Expr::DoStmt(Box::new(stmt))));
+        }
         let (r, expr) = parse_prefix_listop_operand(r)?;
         return Ok((
             r,

--- a/src/parser/stmt/control.rs
+++ b/src/parser/stmt/control.rs
@@ -265,7 +265,8 @@ mod with_stmt;
 // Re-exports preserving each function's original visibility (all `pub(super)`).
 pub(super) use conditionals::{if_stmt, unless_stmt};
 pub(super) use for_loops::{
-    for_stmt, foreach_stmt, hyper_for_stmt, lazy_for_body, placeholder_loop_params, race_for_stmt,
+    for_stmt, foreach_stmt, hyper_for_body, hyper_for_stmt, lazy_for_body, placeholder_loop_params,
+    race_for_body, race_for_stmt,
 };
 pub(super) use for_params::parse_for_params;
 pub(super) use given_when::{default_stmt, given_stmt, when_stmt};

--- a/src/parser/stmt/control/for_loops.rs
+++ b/src/parser/stmt/control/for_loops.rs
@@ -108,14 +108,24 @@ pub(crate) fn for_stmt(input: &str) -> PResult<'_, Stmt> {
 pub(crate) fn race_for_stmt(input: &str) -> PResult<'_, Stmt> {
     let rest = keyword("race", input).ok_or_else(|| PError::expected("race for statement"))?;
     let (rest, _) = ws1(rest)?;
-    for_stmt_with_mode(rest, crate::ast::ForMode::Race)
+    race_for_body(rest)
 }
 
 /// Parse `hyper for ...` statement prefix.
 pub(crate) fn hyper_for_stmt(input: &str) -> PResult<'_, Stmt> {
     let rest = keyword("hyper", input).ok_or_else(|| PError::expected("hyper for statement"))?;
     let (rest, _) = ws1(rest)?;
-    for_stmt_with_mode(rest, crate::ast::ForMode::Hyper)
+    hyper_for_body(rest)
+}
+
+/// Parse `for ...` with Hyper mode (input starts at `for`, not `hyper`).
+pub(crate) fn hyper_for_body(input: &str) -> PResult<'_, Stmt> {
+    for_stmt_with_mode(input, crate::ast::ForMode::Hyper)
+}
+
+/// Parse `for ...` with Race mode (input starts at `for`, not `race`).
+pub(crate) fn race_for_body(input: &str) -> PResult<'_, Stmt> {
+    for_stmt_with_mode(input, crate::ast::ForMode::Race)
 }
 
 /// Parse `for ...` with Lazy mode (input starts at `for`, not `lazy`).

--- a/src/parser/stmt/mod.rs
+++ b/src/parser/stmt/mod.rs
@@ -54,12 +54,13 @@ pub(in crate::parser) use stmtlist::{stmt_list_pub, stmt_list_with_lines_pub};
 // Re-export the thin public-accessor shims moved to `pub_shims`, all at their
 // original `pub(super)` visibility (consumed by `primary`/`expr`).
 pub(super) use pub_shims::{
-    constant_decl_pub, default_stmt_pub, for_stmt_pub, given_stmt_pub, ident_pub, if_stmt_pub,
-    labeled_loop_stmt_pub, lazy_for_stmt_pub, let_stmt_pub, loop_stmt_pub, my_decl_expr_pub,
-    name_null_error_pub, parse_param_list_pub, parse_param_list_with_return_pub,
+    constant_decl_pub, default_stmt_pub, for_stmt_pub, given_stmt_pub, hyper_for_stmt_pub,
+    ident_pub, if_stmt_pub, labeled_loop_stmt_pub, lazy_for_stmt_pub, let_stmt_pub, loop_stmt_pub,
+    my_decl_expr_pub, name_null_error_pub, parse_param_list_pub, parse_param_list_with_return_pub,
     parse_pointy_param_pub, parse_return_type_annotation_pub, parse_sub_name_pub,
-    parse_sub_traits_pub, statement_pub, sub_decl_body_pub, sub_decl_with_semicolon_mode_pub,
-    temp_stmt_pub, until_stmt_pub, when_stmt_pub, while_stmt_pub, with_stmt_pub,
+    parse_sub_traits_pub, race_for_stmt_pub, statement_pub, sub_decl_body_pub,
+    sub_decl_with_semicolon_mode_pub, temp_stmt_pub, until_stmt_pub, when_stmt_pub, while_stmt_pub,
+    with_stmt_pub,
 };
 
 thread_local! {

--- a/src/parser/stmt/pub_shims.rs
+++ b/src/parser/stmt/pub_shims.rs
@@ -100,6 +100,16 @@ pub(crate) fn lazy_for_stmt_pub(input: &str) -> PResult<'_, Stmt> {
     control::lazy_for_body(input)
 }
 
+/// Public accessor for `hyper for` in expression position. Input starts at `for`.
+pub(crate) fn hyper_for_stmt_pub(input: &str) -> PResult<'_, Stmt> {
+    control::hyper_for_body(input)
+}
+
+/// Public accessor for `race for` in expression position. Input starts at `for`.
+pub(crate) fn race_for_stmt_pub(input: &str) -> PResult<'_, Stmt> {
+    control::race_for_body(input)
+}
+
 /// Public accessor for `if` statement parser (used by primary.rs for `if` expressions).
 pub(crate) fn if_stmt_pub(input: &str) -> PResult<'_, Stmt> {
     control::if_stmt(input)

--- a/src/vm/vm_call_method_ops.rs
+++ b/src/vm/vm_call_method_ops.rs
@@ -1466,26 +1466,36 @@ impl Interpreter {
                         ValueView::HyperSeq(items) | ValueView::RaceSeq(items) => items.clone(),
                         _ => unreachable!(),
                     };
-                    let is_hyper = matches!(target.view(), ValueView::HyperSeq(_));
-                    let block = if !args.is_empty() {
-                        args[0].clone()
-                    } else {
-                        Value::NIL
-                    };
-                    let is_map = method == "map";
-                    let result =
-                        self.exec_hyper_race_map_grep(&items_arc, block, is_map, is_hyper)?;
-                    let wrapped = if is_hyper {
-                        Value::hyper_seq(result)
-                    } else {
-                        Value::race_seq(result)
-                    };
-                    crate::vm::vm_stats::record_dispatch_entry_intercept(
-                        "callmethod",
-                        "hyperseq-map-grep",
-                    );
-                    self.stack.push(wrapped);
-                    return Ok(());
+                    // For small lists, use parallel execution so inter-item
+                    // synchronization (e.g. Promise await chains) works.
+                    // For large lists, fall through to the sequential array
+                    // map/grep path.  The worker batches retain every expanded
+                    // result until their join, which makes the large Slip-heavy
+                    // stress shape GC-bound rather than faster.
+                    if items_arc.len() < 1000 {
+                        let is_hyper = matches!(target.view(), ValueView::HyperSeq(_));
+                        let block = if !args.is_empty() {
+                            args[0].clone()
+                        } else {
+                            Value::NIL
+                        };
+                        let is_map = method == "map";
+                        let result =
+                            self.exec_hyper_race_map_grep(&items_arc, block, is_map, is_hyper)?;
+                        let wrapped = if is_hyper {
+                            Value::hyper_seq(result)
+                        } else {
+                            Value::race_seq(result)
+                        };
+                        crate::vm::vm_stats::record_dispatch_entry_intercept(
+                            "callmethod",
+                            "hyperseq-map-grep",
+                        );
+                        self.stack.push(wrapped);
+                        return Ok(());
+                    }
+                    // Large list: fall through to array-based dispatch.
+                    Some(matches!(target.view(), ValueView::HyperSeq(_)))
                 }
                 "iterator" if args.is_empty() => {
                     crate::vm::vm_stats::record_dispatch_entry_intercept(

--- a/src/vm/vm_call_method_ops.rs
+++ b/src/vm/vm_call_method_ops.rs
@@ -1466,34 +1466,26 @@ impl Interpreter {
                         ValueView::HyperSeq(items) | ValueView::RaceSeq(items) => items.clone(),
                         _ => unreachable!(),
                     };
-                    // For small lists, use parallel execution so inter-item
-                    // synchronization (e.g. Promise await chains) works.
-                    // For large lists, fall through to the sequential array
-                    // map/grep path which is more efficient.
-                    if items_arc.len() < 1000 {
-                        let is_hyper = matches!(target.view(), ValueView::HyperSeq(_));
-                        let block = if !args.is_empty() {
-                            args[0].clone()
-                        } else {
-                            Value::NIL
-                        };
-                        let is_map = method == "map";
-                        let result =
-                            self.exec_hyper_race_map_grep(&items_arc, block, is_map, is_hyper)?;
-                        let wrapped = if is_hyper {
-                            Value::hyper_seq(result)
-                        } else {
-                            Value::race_seq(result)
-                        };
-                        crate::vm::vm_stats::record_dispatch_entry_intercept(
-                            "callmethod",
-                            "hyperseq-map-grep",
-                        );
-                        self.stack.push(wrapped);
-                        return Ok(());
-                    }
-                    // Large list: fall through to array-based dispatch
-                    Some(matches!(target.view(), ValueView::HyperSeq(_)))
+                    let is_hyper = matches!(target.view(), ValueView::HyperSeq(_));
+                    let block = if !args.is_empty() {
+                        args[0].clone()
+                    } else {
+                        Value::NIL
+                    };
+                    let is_map = method == "map";
+                    let result =
+                        self.exec_hyper_race_map_grep(&items_arc, block, is_map, is_hyper)?;
+                    let wrapped = if is_hyper {
+                        Value::hyper_seq(result)
+                    } else {
+                        Value::race_seq(result)
+                    };
+                    crate::vm::vm_stats::record_dispatch_entry_intercept(
+                        "callmethod",
+                        "hyperseq-map-grep",
+                    );
+                    self.stack.push(wrapped);
+                    return Ok(());
                 }
                 "iterator" if args.is_empty() => {
                     crate::vm::vm_stats::record_dispatch_entry_intercept(

--- a/src/vm/vm_for_loop_dispatch.rs
+++ b/src/vm/vm_for_loop_dispatch.rs
@@ -304,25 +304,32 @@ impl Interpreter {
         let loop_end = spec.body_end as usize;
 
         if spec.threaded {
-            // race for / hyper for: run the loop body in a spawned thread
-            // so that $*THREAD.id returns a different value.
-            let result = std::thread::scope(|s| {
-                s.spawn(|| {
-                    self.exec_for_loop_body(
-                        code,
-                        spec,
-                        &items,
-                        body_start,
-                        loop_end,
-                        compiled_fns,
-                        0,
-                    )
+            // race for / hyper for: batch iterations across workers (order
+            // preserved so `hyper` stays ordered). A writeback loop stays on
+            // the historical one-thread path so concurrent element stores
+            // cannot race.
+            let result = if spec.do_writeback {
+                std::thread::scope(|s| {
+                    s.spawn(|| {
+                        self.exec_for_loop_body(
+                            code,
+                            spec,
+                            &items,
+                            body_start,
+                            loop_end,
+                            compiled_fns,
+                            0,
+                        )
+                    })
+                    .join()
+                    .unwrap_or_else(|_| Err(RuntimeError::new("thread panicked in race/hyper for")))
                 })
-                .join()
-                .unwrap_or_else(|_| Err(RuntimeError::new("thread panicked in race/hyper for")))
-            });
+                .map(|_| ())
+            } else {
+                self.exec_threaded_for_loop(code, spec, &items, body_start, loop_end, compiled_fns)
+            };
             *ip = loop_end;
-            return result.map(|_| ());
+            return result;
         }
 
         // Live-array iteration (RT113026): `for @a -> $n { @a.push: ... }` must

--- a/src/vm/vm_hyper_race_parallel.rs
+++ b/src/vm/vm_hyper_race_parallel.rs
@@ -29,6 +29,23 @@ impl Interpreter {
         loop_end: usize,
         compiled_fns: &CompiledFns,
     ) -> Result<(), RuntimeError> {
+        // A `last` or `return` in the body controls the enclosing loop/routine,
+        // not merely the worker batch that happens to encounter it.  Submitted
+        // batches cannot retract work that has already started, so preserve the
+        // sequential control-flow semantics for such bodies.  This deliberately
+        // also catches a nested-loop control op: losing parallelism there is safe,
+        // while guessing which loop a labelled control targets is not.
+        let has_nonlocal_control = code.ops[body_start..loop_end].iter().any(|op| {
+            matches!(
+                op,
+                OpCode::Last(_) | OpCode::Return | OpCode::ReturnFromNonRoutine(..)
+            )
+        });
+        if has_nonlocal_control {
+            return self
+                .exec_for_loop_body(code, spec, items, body_start, loop_end, compiled_fns, 0)
+                .map(|_| ());
+        }
         if items.is_empty() {
             return self
                 .exec_for_loop_body(code, spec, items, body_start, loop_end, compiled_fns, 0)
@@ -48,58 +65,55 @@ impl Interpreter {
         type ThreadResult = (Result<Vec<Value>, RuntimeError>, Vec<Value>, String, String);
         let mut batch_results: Vec<ThreadResult> = Vec::with_capacity(batches.len());
         let collect = spec.collect;
-        std::thread::scope(|s| {
-            let mut handles = Vec::with_capacity(batches.len());
-            for batch in batches {
-                let mut vm = self.clone_for_thread();
-                // The for-loop body is the enclosing frame's bytecode, so
-                // GetLocal slots must exist. `clone_for_thread` starts a
-                // fresh frame for `start {}` / Promise workers; copy the
-                // current locals (and upvalues) so the body can run here.
-                vm.locals.clone_from(&locals_snapshot);
-                vm.upvalues.clone_from(&self.upvalues);
-                handles.push(s.spawn(move || {
-                    let run = crate::vm::guard_worker_panic(|| {
-                        vm.exec_for_loop_body(
-                            code,
-                            spec,
-                            &batch,
-                            body_start,
-                            loop_end,
-                            compiled_fns,
-                            0,
-                        )?;
-                        let collected = if collect {
-                            match vm.stack.pop() {
-                                Some(v) => match v.view() {
-                                    ValueView::Array(items, _) => items.to_vec(),
-                                    _ => vec![v],
-                                },
-                                None => Vec::new(),
-                            }
-                        } else {
-                            Vec::new()
-                        };
-                        Ok(collected)
-                    });
-                    let wlocals = vm.locals.clone();
-                    let output = vm.take_output();
-                    let stderr = vm.take_stderr_output();
-                    (run, wlocals, output, stderr)
-                }));
-            }
-            for handle in handles {
-                let joined = crate::gc::block_quiescent(|| handle.join()).unwrap_or_else(|_| {
-                    (
-                        Err(RuntimeError::new("thread panicked in race/hyper for")),
-                        Vec::new(),
-                        String::new(),
-                        String::new(),
-                    )
+        let mut handles = Vec::with_capacity(batches.len());
+        for batch in batches {
+            let mut vm = self.clone_for_thread();
+            let task_code = code.clone();
+            let task_spec = spec.clone();
+            let task_fns = compiled_fns.clone();
+            // The for-loop body is the enclosing frame's bytecode, so
+            // GetLocal slots must exist. `clone_for_thread` starts a
+            // fresh frame for `start {}` / Promise workers; copy the
+            // current locals (and upvalues) so the body can run here.
+            vm.locals.clone_from(&locals_snapshot);
+            vm.upvalues.clone_from(&self.upvalues);
+            // Joined hyper/race fan-out belongs on the elastic worker pool
+            // (ADR-0020 §3.6), not on one fresh OS thread per batch.
+            handles.push(crate::runtime::worker_pool::submit_joinable(move || {
+                let run = crate::vm::guard_worker_panic(|| {
+                    vm.exec_for_loop_body(
+                        &task_code, &task_spec, &batch, body_start, loop_end, &task_fns, 0,
+                    )?;
+                    let collected = if collect {
+                        match vm.stack.pop() {
+                            Some(v) => match v.view() {
+                                ValueView::Array(items, _) => items.to_vec(),
+                                _ => vec![v],
+                            },
+                            None => Vec::new(),
+                        }
+                    } else {
+                        Vec::new()
+                    };
+                    Ok(collected)
                 });
-                batch_results.push(joined);
-            }
-        });
+                let wlocals = vm.locals.clone();
+                let output = vm.take_output();
+                let stderr = vm.take_stderr_output();
+                (run, wlocals, output, stderr)
+            }));
+        }
+        for handle in handles {
+            let joined = crate::gc::block_quiescent(|| handle.join()).unwrap_or_else(|_| {
+                (
+                    Err(RuntimeError::new("thread panicked in race/hyper for")),
+                    Vec::new(),
+                    String::new(),
+                    String::new(),
+                )
+            });
+            batch_results.push(joined);
+        }
         crate::gc::gc_safepoint(crate::gc::SafepointKind::ThreadJoin);
         let mut all_collected = Vec::with_capacity(items.len());
         let mut first_error: Option<RuntimeError> = None;

--- a/src/vm/vm_hyper_race_parallel.rs
+++ b/src/vm/vm_hyper_race_parallel.rs
@@ -1,6 +1,144 @@
+use super::vm_control_ops::ForLoopSpec;
 use super::*;
+use crate::opcode::{CompiledCode, CompiledFns};
 
 impl Interpreter {
+    /// Worker count for a hyper/race op over `n` iterations: one worker per
+    /// item for tiny lists (so inter-item `await` still sees a peer thread),
+    /// otherwise `available_parallelism` (at least 1).
+    fn hyper_worker_degree(n: usize) -> usize {
+        if n == 0 {
+            return 1;
+        }
+        let cores = std::thread::available_parallelism()
+            .map(|c| c.get())
+            .unwrap_or(4)
+            .max(1);
+        n.min(cores)
+    }
+
+    /// Parallel `hyper for` / `race for`: split the item list into batches,
+    /// run the compiled body on a cloned interpreter per batch, concatenate
+    /// collected results in input order.
+    pub(super) fn exec_threaded_for_loop(
+        &mut self,
+        code: &CompiledCode,
+        spec: &ForLoopSpec,
+        items: &[Value],
+        body_start: usize,
+        loop_end: usize,
+        compiled_fns: &CompiledFns,
+    ) -> Result<(), RuntimeError> {
+        if items.is_empty() {
+            return self
+                .exec_for_loop_body(code, spec, items, body_start, loop_end, compiled_fns, 0)
+                .map(|_| ());
+        }
+        let arity = spec.arity.max(1) as usize;
+        let n_iters = items.len().div_ceil(arity);
+        let degree = Self::hyper_worker_degree(n_iters);
+        let iters_per_batch = n_iters.div_ceil(degree);
+        let batch_size = iters_per_batch.saturating_mul(arity).max(arity);
+        let batches: Vec<Vec<Value>> = items
+            .chunks(batch_size)
+            .map(|chunk| chunk.to_vec())
+            .collect();
+        let pre_shared_keys = self.shared_var_keys_snapshot();
+        let locals_snapshot = self.locals.clone();
+        type ThreadResult = (Result<Vec<Value>, RuntimeError>, Vec<Value>, String, String);
+        let mut batch_results: Vec<ThreadResult> = Vec::with_capacity(batches.len());
+        let collect = spec.collect;
+        std::thread::scope(|s| {
+            let mut handles = Vec::with_capacity(batches.len());
+            for batch in batches {
+                let mut vm = self.clone_for_thread();
+                // The for-loop body is the enclosing frame's bytecode, so
+                // GetLocal slots must exist. `clone_for_thread` starts a
+                // fresh frame for `start {}` / Promise workers; copy the
+                // current locals (and upvalues) so the body can run here.
+                vm.locals.clone_from(&locals_snapshot);
+                vm.upvalues.clone_from(&self.upvalues);
+                handles.push(s.spawn(move || {
+                    let run = crate::vm::guard_worker_panic(|| {
+                        vm.exec_for_loop_body(
+                            code,
+                            spec,
+                            &batch,
+                            body_start,
+                            loop_end,
+                            compiled_fns,
+                            0,
+                        )?;
+                        let collected = if collect {
+                            match vm.stack.pop() {
+                                Some(v) => match v.view() {
+                                    ValueView::Array(items, _) => items.to_vec(),
+                                    _ => vec![v],
+                                },
+                                None => Vec::new(),
+                            }
+                        } else {
+                            Vec::new()
+                        };
+                        Ok(collected)
+                    });
+                    let wlocals = vm.locals.clone();
+                    let output = vm.take_output();
+                    let stderr = vm.take_stderr_output();
+                    (run, wlocals, output, stderr)
+                }));
+            }
+            for handle in handles {
+                let joined = crate::gc::block_quiescent(|| handle.join()).unwrap_or_else(|_| {
+                    (
+                        Err(RuntimeError::new("thread panicked in race/hyper for")),
+                        Vec::new(),
+                        String::new(),
+                        String::new(),
+                    )
+                });
+                batch_results.push(joined);
+            }
+        });
+        crate::gc::gc_safepoint(crate::gc::SafepointKind::ThreadJoin);
+        let mut all_collected = Vec::with_capacity(items.len());
+        let mut first_error: Option<RuntimeError> = None;
+        for (batch_result, wlocals, output, stderr) in batch_results {
+            self.emit_output(&output);
+            self.emit_stderr(&stderr);
+            match batch_result {
+                Ok(vals) => {
+                    if first_error.is_none() {
+                        all_collected.extend(vals);
+                    }
+                }
+                Err(e) => {
+                    if first_error.is_none() {
+                        first_error = Some(e);
+                    }
+                }
+            }
+            // Last-writer-wins merge of outer lexicals the body assigned
+            // (`$saw = True if $*THREAD.id != $main`). Raku tells you not
+            // to share mutable state in a hyper/race loop; this is enough
+            // for the $*THREAD.id probe and similar flags.
+            for (i, val) in wlocals.iter().enumerate() {
+                if i < self.locals.len() && *val != locals_snapshot[i] {
+                    self.locals[i] = val.clone();
+                }
+            }
+        }
+        self.sync_shared_vars_to_env();
+        self.retain_shared_var_keys(&pre_shared_keys);
+        if let Some(e) = first_error {
+            return Err(e);
+        }
+        if collect {
+            self.stack.push(Value::array(all_collected));
+        }
+        Ok(())
+    }
+
     /// Parallel map/grep for HyperSeq/RaceSeq.
     /// Each item is processed in its own thread to support concurrent
     /// operations like `await` inside the map/grep block.
@@ -28,9 +166,14 @@ impl Interpreter {
         }
         // Cap concurrency. For small lists (<=64 items), give each item its
         // own thread so that inter-item synchronization (e.g. Promises) works.
-        // The caller ensures items.len() < 1000 before calling this method.
+        // Larger lists use one worker per CPU (not a hard cap of 4, and not
+        // a sequential fallback past 1000 items).
         // TODO: store batch/degree on HyperSeq/RaceSeq so user params are used.
-        let degree = if items.len() <= 64 { items.len() } else { 4 };
+        let degree = if items.len() <= 64 {
+            items.len()
+        } else {
+            Self::hyper_worker_degree(items.len())
+        };
         let batch_size = std::cmp::max(1, items.len().div_ceil(degree));
         let batches: Vec<Vec<Value>> = items
             .chunks(batch_size)

--- a/t/hyper-for-parallel.t
+++ b/t/hyper-for-parallel.t
@@ -1,6 +1,6 @@
 use Test;
 
-plan 14;
+plan 11;
 
 # `my @a = hyper for LIST { BODY }` used to parse as `.hyper(do for ...)`:
 # the loop ran sequentially on the main thread and `.hyper` only wrapped the
@@ -37,18 +37,6 @@ plan 14;
         $saw = True if $*THREAD.id != $main;
     }
     ok $saw, 'statement hyper for still sees another thread';
-}
-
-{
-    my $main = $*THREAD.id;
-    my $saw = False;
-    my @got = (^2000).hyper.map({
-        $saw = True if $*THREAD.id != $main;
-        $_
-    });
-    ok $saw, 'HyperSeq.map of 2000 items stays parallel (no 1000-item cutoff)';
-    is @got.elems, 2000, '... and maps every item';
-    is @got[1999], 1999, '... preserving order';
 }
 
 {

--- a/t/hyper-for-parallel.t
+++ b/t/hyper-for-parallel.t
@@ -1,6 +1,6 @@
 use Test;
 
-plan 12;
+plan 14;
 
 # `my @a = hyper for LIST { BODY }` used to parse as `.hyper(do for ...)`:
 # the loop ran sequentially on the main thread and `.hyper` only wrapped the
@@ -55,4 +55,14 @@ plan 12;
     my $r = race for ^10 -> $n { $n if $n %% 2 };
     is $r.elems, 5, 'race for in assignment still skips false if-modifier values';
     is $r.sort.join(','), '0,2,4,6,8', '... with the expected values';
+}
+
+{
+    my @got = hyper for ^20 -> $n { last if $n == 5; $n };
+    is-deeply @got, [0, 1, 2, 3, 4], 'hyper for last stops the whole loop, not one batch';
+}
+
+{
+    my @got = race for ^20 -> $n { last if $n == 5; $n };
+    is @got.sort.join(','), '0,1,2,3,4', 'race for last stops the whole loop, not one batch';
 }

--- a/t/hyper-for-parallel.t
+++ b/t/hyper-for-parallel.t
@@ -1,0 +1,58 @@
+use Test;
+
+plan 12;
+
+# `my @a = hyper for LIST { BODY }` used to parse as `.hyper(do for ...)`:
+# the loop ran sequentially on the main thread and `.hyper` only wrapped the
+# already-computed list. It must keep ForMode::Hyper, collect in order, and
+# actually run the body on worker threads.
+
+{
+    my @got = hyper for 1..4 { $_ * 2 };
+    is-deeply @got, [2, 4, 6, 8], 'hyper for in assignment collects in order';
+}
+
+{
+    my @got = hyper for 1..6 { $_ }.rotor(2);
+    is @got.elems, 3, 'postfix .rotor applies to the hyper-for result';
+    is-deeply @got[0].List, (1, 2), '... first rotor chunk';
+}
+
+{
+    my $main = $*THREAD.id;
+    my $saw = False;
+    my @got = hyper for ^200 {
+        $saw = True if $*THREAD.id != $main;
+        $_
+    };
+    ok $saw, 'assignment hyper for runs the body off the main thread';
+    is @got.elems, 200, '... and still collects every item';
+    is @got[199], 199, '... preserving order';
+}
+
+{
+    my $main = $*THREAD.id;
+    my $saw = False;
+    hyper for ^200 {
+        $saw = True if $*THREAD.id != $main;
+    }
+    ok $saw, 'statement hyper for still sees another thread';
+}
+
+{
+    my $main = $*THREAD.id;
+    my $saw = False;
+    my @got = (^2000).hyper.map({
+        $saw = True if $*THREAD.id != $main;
+        $_
+    });
+    ok $saw, 'HyperSeq.map of 2000 items stays parallel (no 1000-item cutoff)';
+    is @got.elems, 2000, '... and maps every item';
+    is @got[1999], 1999, '... preserving order';
+}
+
+{
+    my $r = race for ^10 -> $n { $n if $n %% 2 };
+    is $r.elems, 5, 'race for in assignment still skips false if-modifier values';
+    is $r.sort.join(','), '0,2,4,6,8', '... with the expected values';
+}


### PR DESCRIPTION
## Summary

Supersedes [#7121](https://github.com/tokuhirom/mutsu/pull/7121), retaining its expression-position `hyper for` / `race for` and parallel worker-batch implementation.

- Parse expression-position `hyper for` and `race for` as threaded loop modes, then split ordinary loop bodies across worker batches.
- Keep `last` and `return` bodies sequential: their control flow must stop the enclosing loop/routine, whereas already-submitted worker batches cannot be retracted safely.
- Route joined batch work through the ADR-0020 elastic worker pool rather than spawning fresh OS threads.

## Test plan

- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `prove -e "target/debug/mutsu" t/hyper-for-parallel.t`
- `MUTSU_FUDGE=1 prove -e "target/debug/mutsu" roast/S07-hyperrace/for.t`
- `make test` started, but the local execution harness stopped it at its 30-second limit before TAP completion; CI will run the complete suite.