### PR TITLE
fix: resolve imported proto multis through code variables

### DIFF
--- a/src/runtime/accessors_resolve.rs
+++ b/src/runtime/accessors_resolve.rs
@@ -435,19 +435,16 @@ impl Interpreter {
                     None
                 }
             });
-        // Whether concrete multi-candidate bodies exist for this name (stored
-        // with arity/type-mangled `name/N` suffixes), regardless of whether it
-        // also has an explicit `proto sub`. A cheap key-prefix scan first, so
-        // the common non-multi resolution (most `&name` lookups) pays only
-        // this scan and not the fuller candidate walk below.
-        let has_multi_keys = def.is_none() && {
-            let prefix_local = format!("{}::{}/", self.current_package(), lookup_name);
-            let prefix_global = format!("GLOBAL::{}/", lookup_name);
-            self.registry().functions.keys().any(|k| {
-                let ks = k.resolve();
-                ks.starts_with(&prefix_local) || ks.starts_with(&prefix_global)
-            })
-        };
+        // Whether concrete multi-candidate bodies exist for this name,
+        // regardless of whether it also has an explicit `proto sub`. This
+        // must use the normal lexical package search, rather than checking
+        // only the current and GLOBAL registry-key prefixes: an imported
+        // multi lives in its defining package (for example `Test::skip`) but
+        // is callable through its lexical short-name alias.  Otherwise
+        // `.&skip` resolves its CodeVar to core `skip` before reaching the
+        // imported Test multi.
+        let has_multi_keys =
+            def.is_none() && !self.resolve_all_multi_candidates(lookup_name).is_empty();
         if has_multi_keys {
             // Multi subs (with or without an explicit proto): create a Sub
             // that captures all candidate bodies BY VALUE now, so the

--- a/src/runtime/dispatch_proto.rs
+++ b/src/runtime/dispatch_proto.rs
@@ -6,8 +6,20 @@ impl Interpreter {
     /// callwith(), which may re-dispatch with different arguments.
     pub(crate) fn resolve_all_multi_candidates(&self, name: &str) -> Vec<Arc<FunctionDef>> {
         let mut all: Vec<(String, Arc<FunctionDef>)> = Vec::new();
-        let prefixes: Vec<String> = self
-            .bare_name_packages()
+        let mut packages = self.bare_name_packages();
+        // An imported proto is registered under the importing lexical scope,
+        // while its multi candidates remain in the defining module. Include
+        // that owner so a first-class `&name` can materialize the same
+        // candidates an ordinary `name(...)` call reaches. This matters for
+        // real Test's `proto sub skip(|)`: `.&skip` must invoke Test::skip,
+        // not the core list builtin of the same name.
+        if let Some(proto) = self.resolve_proto_function(name) {
+            let owner = proto.package.resolve();
+            if !packages.iter().any(|pkg| pkg == &owner) {
+                packages.insert(0, owner);
+            }
+        }
+        let prefixes: Vec<String> = packages
             .iter()
             .map(|pkg| format!("{}::{}/", pkg, name))
             .collect();

--- a/src/vm/vm_dispatch_helpers.rs
+++ b/src/vm/vm_dispatch_helpers.rs
@@ -659,6 +659,29 @@ impl Interpreter {
             target
         };
 
+        // A CodeVar referring to an imported proto/multi is materialized as a
+        // dispatcher Sub whose candidates are captured by value. Its dispatch
+        // needs the same scope-aware proto resolution as callwith/nextsame;
+        // otherwise a same-named core builtin (notably `skip`) wins an
+        // indirect call such as `.&skip`.
+        if let ValueView::Sub(data) = target.view()
+            && data.env.contains_key("__mutsu_multi_dispatch_candidates")
+        {
+            if let Some(ValueView::Str(name)) =
+                data.env.get("__mutsu_multi_dispatch_name").map(Value::view)
+                && self.has_proto_cached(&name)
+                && let Some(def) = self.vm_resolve_trivial_proto_candidate(&name, &args)
+            {
+                let empty_fns = CompiledFns::default();
+                return self.compile_and_call_function_def(
+                    &def,
+                    args,
+                    compiled_fns.unwrap_or(&empty_fns),
+                );
+            }
+            return self.call_sub_value(target, args, false);
+        }
+
         // NativeCall: a sub declared `is native(...)` carries a `{ * }` stub
         // body, so it must be dispatched over C FFI no matter how the callsite
         // reached it — including through a code object (`my &f = &dlsym; f(...)`).

--- a/t/dynamic-code-var-imported-test-multi.t
+++ b/t/dynamic-code-var-imported-test-multi.t
@@ -1,0 +1,6 @@
+use v6;
+use Test;
+
+plan 1;
+
+'indirect Test skip'.&skip;

--- a/todo/deep/vendor-real-test-module.md
+++ b/todo/deep/vendor-real-test-module.md
@@ -5417,3 +5417,32 @@ because the native Test provider's older `throws-like` path can accept the
 generic error whereas the vendored Test module checks the actual exception
 type. All 28 assertions pass under raku, the native provider, and
 `MUTSU_REAL_TEST=1`.
+
+## 2026-08-30: first-class imported proto/multis keep their defining candidates (`S24-testing/fails-like.t`)
+
+The freshly re-run release sweep found one correctness regression beyond the
+known timeout and native-only rows: `S24-testing/fails-like.t` stopped in the
+first `fails-like` error-path subtest. Upstream `Test.rakumod` uses `. &skip`
+there to turn the second assertion into a skipped TAP line. Mutsu resolved the
+code variable `&skip` to the core list builtin, rather than the lexically
+imported `Test` proto/multi; calling it with no list raised `Too few
+positionals passed to 'skip'`.
+
+An imported proto is registered in the importer's scope but its multi
+candidates remain under the defining module. `resolve_all_multi_candidates`
+now includes that proto owner, so `&skip` captures the actual `Test` candidates.
+The VM recognizes that captured dispatcher and uses its native trivial-proto
+dispatch, which retains the multi-dispatch frame required by `nextsame` while
+avoiding a same-named builtin fallback.
+
+Pin: `t/dynamic-code-var-imported-test-multi.t`, which exercises
+`'indirect Test skip'.&skip` under both providers and real raku. The target
+roast file passes with `MUTSU_REAL_TEST=1`; the existing
+`t/nextsame-in-the-only-candidate.t` and `t/vendored-real-test-module.t` pins
+remain green.
+
+The 2026-08-30 release sweep reported 1427 files passing under both providers,
+8 initial regressions, and 1 pre-existing failure. This fix removes the sole
+correctness regression: the remaining 7 are the five known performance
+timeouts (`sprintf-{b,d,x}.t`, `read-write-bits.t`, `write-int.t`) and the two
+native-provider-only fudge cases (`2-force_todo.t`, `6-done_testing.t`).


### PR DESCRIPTION
Fixes indirect code-variable dispatch for imported proto/multi routines, including the vendored Test module’s `.&skip` path used by `fails-like`.

Validation:
- `cargo clippy -- -D warnings`
- focused native and `MUTSU_REAL_TEST=1` TAP/roast tests
- fresh release real-Test sweep (1427 pass under both; this removes the only remaining correctness regression)