### PR TITLE
perf: cache positional callable parameter calls

### DIFF
--- a/src/vm/vm_call_eligibility.rs
+++ b/src/vm/vm_call_eligibility.rs
@@ -191,11 +191,15 @@ impl Interpreter {
                         .type_constraint
                         .as_deref()
                         .is_none_or(Self::is_fast_type_name)
-                    // Exclude @/% params which need special collection semantics
-                    // and & params which need callable binding
+                    // Exclude @/% params which need special collection semantics.
+                    // A plain `&` parameter is a scalar Callable binding: the
+                    // positional binder already installs its value in the
+                    // sigiled local slot, so it can use this path too.  Keeping
+                    // it out forced every `sub f(&c)` call through full
+                    // name/type resolution, even when `c` was never invoked.
+                    // Code-signature params remain excluded above.
                     && !pd.name.starts_with('@')
                     && !pd.name.starts_with('%')
-                    && !pd.name.starts_with('&')
                     // Exclude internal/anonymous params (__ANON_STATE__, __type_only__, etc.)
                     && !pd.name.starts_with("__")
                     // Exclude dynamic variable params ($*var)

--- a/t/amp-param-positional-light.t
+++ b/t/amp-param-positional-light.t
@@ -1,0 +1,24 @@
+use Test;
+
+plan 4;
+
+# A plain `&` parameter is a scalar Callable binding.  It belongs on the same
+# positional-light call path as a `$` parameter; this also exercises the local
+# `&` lookup that must still shadow a package routine from inside the callee.
+sub apply(&code, $value) { code($value) }
+is apply(-> $n { $n * 2 }, 21), 42,
+    'a positional & parameter binds and invokes its Callable';
+
+sub callback() { 'package routine' }
+sub invoke-shadow(&callback) { callback() }
+is invoke-shadow({ 'lexical Callable' }), 'lexical Callable',
+    'a positional & parameter shadows a same-named package routine';
+
+sub ignored(&code, $value) { $value + 1 }
+is ignored({ die 'must not be invoked' }, 41), 42,
+    'an unused positional & parameter accepts a Callable';
+
+my $sum = 0;
+my &one = { 1 };
+for ^100 { $sum = $sum + ignored(&one, 0) }
+is $sum, 100, 'repeated positional & parameter calls preserve their binding';


### PR DESCRIPTION
## Summary
- allow plain positional `&` parameters to use the compiled light-call path
- retain code-signature parameters on the general binder
- cover callback binding, shadowing, and repeated calls

## Validation
- `cargo clippy -- -D warnings`
- `prove -e target/debug/mutsu t/amp-param-positional-light.t t/bind-source-tracks-through-call-chain.t t/named-callable-param.t`
- `make test`
- `MUTSU_REAL_TEST=1 MUTSU_FUDGE=1 prove -e target/release/mutsu roast/S03-buf/write-int.t roast/S03-buf/read-write-bits.t`