### PR TITLE
fix: preprocess Rakudo-only eval directives

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -1003,7 +1003,6 @@ roast/S24-testing/14-like-unlike.t
 roast/S24-testing/15-done-testing.t
 roast/S24-testing/2-force_todo.t
 roast/S24-testing/3-output.t
-roast/S24-testing/6-done_testing.t
 roast/S24-testing/7-bail_out.t
 roast/S24-testing/8-die_on_fail.t
 roast/S24-testing/9-is_deeply.t

--- a/src/runtime/run_dist.rs
+++ b/src/runtime/run_dist.rs
@@ -421,6 +421,15 @@ mod tests {
     }
 
     #[test]
+    fn preprocess_rakudo_eval_skips_the_following_block() {
+        let src = "use Test; plan 2;\n#?rakudo eval\n{\n    pass 'one';\n    flunk 'two';\n}\n";
+        let out = Interpreter::preprocess_roast_directives(src);
+        assert_eq!(out.matches("skip 'Rakudo-only eval', 1;").count(), 2);
+        assert!(!out.contains("pass 'one'"));
+        assert!(!out.contains("flunk 'two'"));
+    }
+
+    #[test]
     fn preprocess_block_skip_counts_tap_ok_as_test_assertion() {
         let src = "#?rakudo skip 'reason'\n{\n    tap-ok $s, [1], 'tap';\n    ok True, 'ok';\n}\n";
         let out = Interpreter::preprocess_roast_directives(src);

--- a/src/runtime/run_roast_preprocess.rs
+++ b/src/runtime/run_roast_preprocess.rs
@@ -108,6 +108,7 @@ impl Interpreter {
             "pass ",
             "pass(",
             "flunk ",
+            "flunk(",
             "is-deeply",
             "is-approx",
             "is-primed-sig",
@@ -290,6 +291,16 @@ impl Interpreter {
                 || trimmed.starts_with("#?rakudo.js.browser emit"))
                 && !trimmed.contains(".moar")
             {
+                output.push('\n');
+                continue;
+            }
+
+            // `#?rakudo eval` marks a statement that roast evaluates only on
+            // Rakudo. mutsu is not Rakudo, so preserve the TAP plan by
+            // skipping the following assertion or block. This also keeps
+            // Rakudo-specific Test extensions out of the upstream Test module.
+            if trimmed == "#?rakudo eval" || trimmed.starts_with("#?rakudo eval ") {
+                skip_block_pending = Some("Rakudo-only eval".to_string());
                 output.push('\n');
                 continue;
             }

--- a/todo/deep/vendor-real-test-module.md
+++ b/todo/deep/vendor-real-test-module.md
@@ -79,11 +79,12 @@ or special-case `Test` to hide it.
 
 ### Native-provider-only whitelist rows
 
-`S24-testing/2-force_todo.t` and `S24-testing/6-done_testing.t` rely on the
-native provider's handling of `#?rakudo eval`. Resolve this by implementing the
-needed fudge support or by removing the rows from the whitelist if they are not
-valid for mutsu's supported fudge subset. This is not a vendored-`Test`
-interpreter compatibility fix.
+`S24-testing/2-force_todo.t` uses `#?rakudo eval` around Rakudo-only
+`force_todo` calls. The roast preprocessor must skip that backend-specific
+block while preserving its TAP plan. `S24-testing/6-done_testing.t` is not a
+valid whitelist row: current Rakudo also rejects its `ok 0, :todo(1)` call
+against `Test`'s signature, so it must remain out of the whitelist. Neither is
+a vendored-`Test` interpreter compatibility fix.
 
 ## Completion criteria
 


### PR DESCRIPTION
## Summary
- skip `#?rakudo eval` blocks while preserving their TAP plan
- recognize parenthesized `flunk(...)` assertions in skipped blocks
- remove the invalid `6-done_testing.t` whitelist row; current Rakudo rejects it too

## Validation
- `cargo clippy -- -D warnings`
- `cargo test preprocess_rakudo_eval_skips_the_following_block`
- `MUTSU_REAL_TEST=1 MUTSU_FUDGE=1 prove -e target/release/mutsu roast/S24-testing/2-force_todo.t`
- sequential real-Test release checks for `sprintf-{b,d,e,f,x}.t` and `S03-buf/{read-write-bits,write-int}.t`
- `LC_ALL=C sort -c roast-whitelist.txt`