### PR TITLE
test: avoid native Test todo adverb

### DIFF
--- a/t/exec-call-mixed-block.t
+++ b/t/exec-call-mixed-block.t
@@ -1,5 +1,9 @@
 use Test;
-plan 2;
+plan 3;
 
-dies-ok { die "boom" }, 'dies-ok accepts block with named arg path', :todo(False);
+my $todo-seen = True;
+sub record-todo(:$todo) { $todo-seen = $todo }
+record-todo :todo(False);
+dies-ok { die "boom" }, 'dies-ok accepts a block in sink position';
+ok !$todo-seen, 'a mixed statement call binds its named argument';
 ok True, 'execution continues after dies-ok with block arg';

--- a/t/exec-call-pairs.t
+++ b/t/exec-call-pairs.t
@@ -2,7 +2,10 @@ use Test;
 plan 3;
 
 my $x = 0;
-dies-ok { die "x" }, 'dies-ok via pair-encoded named args', :todo(False);
+my $todo-seen = True;
+sub record-todo(:$todo) { $todo-seen = $todo }
+record-todo :todo(False);
+dies-ok { die "x" }, 'dies-ok via pair-encoded arguments';
 ok True, 'dies-ok ran and returned';
 
-ok 1, 'ok with named todo via pair-encoded args', :todo(False);
+ok !$todo-seen, 'a pair-encoded named argument reaches a user routine';


### PR DESCRIPTION
## Summary
- make sink-position `dies-ok` tests use upstream Test signatures
- retain named-call coverage with a user routine that declares `:$todo`

## Validation
- `cargo clippy -- -D warnings`
- `prove -e target/debug/mutsu t/exec-call-mixed-block.t t/exec-call-pairs.t`
- `MUTSU_REAL_TEST=1 prove -e target/debug/mutsu t/exec-call-mixed-block.t t/exec-call-pairs.t`