### PR TITLE
fix: isolate roles declared by EVAL

### DIFF
--- a/src/runtime/system_eval_string.rs
+++ b/src/runtime/system_eval_string.rs
@@ -461,12 +461,34 @@ impl Interpreter {
             .keys()
             .filter_map(|key| key.strip_prefix_str("__mutsu_eval_role::"))
             .collect();
+        // An EVAL may return a role type object (`my $r = EVAL 'unit role R;'`).
+        // That object remains usable by its caller, so preserve exactly that
+        // role's registry entries while isolating every other EVAL-local role.
+        let returned_role_names: std::collections::HashSet<String> = result
+            .as_ref()
+            .ok()
+            .and_then(|value| match value.view() {
+                crate::value::ValueView::Package(name)
+                    if eval_role_names.contains(&name.resolve()) =>
+                {
+                    Some(name.resolve().to_string())
+                }
+                _ => None,
+            })
+            .into_iter()
+            .collect();
+        let current_roles = self.registry().roles.clone();
+        let current_role_candidates = self.registry().role_candidates.clone();
+        let current_role_type_params = self.registry().role_type_params.clone();
+        let current_role_parents = self.registry().role_parents.clone();
+        let current_role_hides = self.registry().role_hides.clone();
         let is_eval_role_artifact = |name: &str| {
             eval_role_names.iter().any(|role| {
-                name == role
-                    || name
-                        .strip_prefix(role)
-                        .is_some_and(|suffix| suffix.starts_with('['))
+                !returned_role_names.contains(role)
+                    && (name == role
+                        || name
+                            .strip_prefix(role)
+                            .is_some_and(|suffix| suffix.starts_with('[')))
             })
         };
         let mut current_classes = self.registry().classes.clone();
@@ -517,9 +539,34 @@ impl Interpreter {
         self.registry_mut().class_direct_composed_roles = class_direct_composed_roles_snapshot;
         self.registry_mut().class_role_param_bindings = class_role_param_bindings_snapshot;
         // Roles declared in EVAL, including `my role`, are lexical to that
-        // compilation unit.  Restore the caller's role registries unchanged
-        // so an EVAL-local definition cannot overwrite a same-named role the
-        // caller declares later.
+        // compilation unit. Preserve only a role type object returned directly
+        // from EVAL; every other EVAL-local role must not overwrite a same-named
+        // role the caller declares later.
+        for name in &returned_role_names {
+            if let Some(role) = current_roles.get(name) {
+                self.registry_mut().roles.insert(name.clone(), role.clone());
+            }
+            if let Some(candidates) = current_role_candidates.get(name) {
+                self.registry_mut()
+                    .role_candidates
+                    .insert(name.clone(), candidates.clone());
+            }
+            if let Some(params) = current_role_type_params.get(name) {
+                self.registry_mut()
+                    .role_type_params
+                    .insert(name.clone(), params.clone());
+            }
+            if let Some(parents) = current_role_parents.get(name) {
+                self.registry_mut()
+                    .role_parents
+                    .insert(name.clone(), parents.clone());
+            }
+            if let Some(hides) = current_role_hides.get(name) {
+                self.registry_mut()
+                    .role_hides
+                    .insert(name.clone(), hides.clone());
+            }
+        }
         self.registry_mut().classes.extend(current_classes);
         self.registry_mut()
             .hidden_classes

--- a/src/runtime/system_eval_string.rs
+++ b/src/runtime/system_eval_string.rs
@@ -456,26 +456,35 @@ impl Interpreter {
         self.fatal_mode = saved_fatal_mode;
         self.monkey_typing = saved_monkey_typing;
         self.restore_routine_registry_eval(routine_snapshot);
-        let current_roles = self.registry().roles.clone();
-        let current_role_candidates = self.registry().role_candidates.clone();
-        let current_role_type_params = self.registry().role_type_params.clone();
-        let current_role_parents = self.registry().role_parents.clone();
-        let current_role_hides = self.registry().role_hides.clone();
-        let current_classes = self.registry().classes.clone();
+        let current_env = self.env.clone();
+        let eval_role_names: std::collections::HashSet<String> = current_env
+            .keys()
+            .filter_map(|key| key.strip_prefix_str("__mutsu_eval_role::"))
+            .collect();
+        let is_eval_role_artifact = |name: &str| {
+            eval_role_names.iter().any(|role| {
+                name == role
+                    || name
+                        .strip_prefix(role)
+                        .is_some_and(|suffix| suffix.starts_with('['))
+            })
+        };
+        let mut current_classes = self.registry().classes.clone();
+        current_classes.retain(|name, _| !is_eval_role_artifact(name));
         let current_hidden_classes = self.registry().hidden_classes.clone();
         let current_hidden_defer_parents = self.registry().hidden_defer_parents.clone();
-        let current_class_composed_roles = self.registry().class_composed_roles.clone();
-        let current_class_direct_composed_roles =
+        let mut current_class_composed_roles = self.registry().class_composed_roles.clone();
+        current_class_composed_roles.retain(|name, roles| {
+            !is_eval_role_artifact(name) && !roles.iter().any(|role| eval_role_names.contains(role))
+        });
+        let mut current_class_direct_composed_roles =
             self.registry().class_direct_composed_roles.clone();
-        let current_class_role_param_bindings = self.registry().class_role_param_bindings.clone();
-        let current_env = self.env.clone();
-        let current_type_keys: std::collections::HashSet<String> = self
-            .registry()
-            .roles
-            .keys()
-            .chain(self.registry().classes.keys())
-            .cloned()
-            .collect();
+        current_class_direct_composed_roles.retain(|name, roles| {
+            !is_eval_role_artifact(name) && !roles.iter().any(|role| eval_role_names.contains(role))
+        });
+        let mut current_class_role_param_bindings =
+            self.registry().class_role_param_bindings.clone();
+        current_class_role_param_bindings.retain(|name, _| !is_eval_role_artifact(name));
         let snapshot_type_keys: std::collections::HashSet<String> = roles_snapshot
             .keys()
             .chain(classes_snapshot.keys())
@@ -507,19 +516,10 @@ impl Interpreter {
         self.registry_mut().class_composed_roles = class_composed_roles_snapshot;
         self.registry_mut().class_direct_composed_roles = class_direct_composed_roles_snapshot;
         self.registry_mut().class_role_param_bindings = class_role_param_bindings_snapshot;
-        self.registry_mut().roles.extend(current_roles);
-        // Don't extend user_declared_roles: roles declared in EVAL are EVAL-scoped
-        // and should not affect the parent's redeclaration detection.
-        self.registry_mut()
-            .role_candidates
-            .extend(current_role_candidates);
-        self.registry_mut()
-            .role_type_params
-            .extend(current_role_type_params);
-        self.registry_mut()
-            .role_parents
-            .extend(current_role_parents);
-        self.registry_mut().role_hides.extend(current_role_hides);
+        // Roles declared in EVAL, including `my role`, are lexical to that
+        // compilation unit.  Restore the caller's role registries unchanged
+        // so an EVAL-local definition cannot overwrite a same-named role the
+        // caller declares later.
         self.registry_mut().classes.extend(current_classes);
         self.registry_mut()
             .hidden_classes
@@ -551,7 +551,7 @@ impl Interpreter {
             self.registry_mut().restore_user_method_rows(owner, rows);
             self.registry_mut().sync_accessor_entries(owner);
         }
-        for key in current_type_keys.union(&snapshot_type_keys) {
+        for key in &snapshot_type_keys {
             if let Some(value) = current_env.get(key).cloned() {
                 self.env.insert(key.clone(), value);
             } else if let Some(value) = env_snapshot.get(key).cloned() {
@@ -576,6 +576,8 @@ impl Interpreter {
                 self.env.remove(&key);
             }
         }
+        self.env
+            .retain(|key, _| !key.starts_with("__mutsu_eval_role::"));
         // Restore $_ so EVAL does not clobber the caller's topic variable
         if let Some(topic) = saved_topic {
             self.env.insert("_".to_string(), topic);

--- a/src/runtime/system_eval_string.rs
+++ b/src/runtime/system_eval_string.rs
@@ -482,6 +482,8 @@ impl Interpreter {
         let current_role_type_params = self.registry().role_type_params.clone();
         let current_role_parents = self.registry().role_parents.clone();
         let current_role_hides = self.registry().role_hides.clone();
+        let keep_role =
+            |name: &str| !eval_role_names.contains(name) || returned_role_names.contains(name);
         let is_eval_role_artifact = |name: &str| {
             eval_role_names.iter().any(|role| {
                 !returned_role_names.contains(role)
@@ -507,6 +509,12 @@ impl Interpreter {
         let mut current_class_role_param_bindings =
             self.registry().class_role_param_bindings.clone();
         current_class_role_param_bindings.retain(|name, _| !is_eval_role_artifact(name));
+        let current_type_keys: std::collections::HashSet<String> = current_roles
+            .keys()
+            .filter(|name| keep_role(name))
+            .chain(current_classes.keys())
+            .cloned()
+            .collect();
         let snapshot_type_keys: std::collections::HashSet<String> = roles_snapshot
             .keys()
             .chain(classes_snapshot.keys())
@@ -538,35 +546,34 @@ impl Interpreter {
         self.registry_mut().class_composed_roles = class_composed_roles_snapshot;
         self.registry_mut().class_direct_composed_roles = class_direct_composed_roles_snapshot;
         self.registry_mut().class_role_param_bindings = class_role_param_bindings_snapshot;
-        // Roles declared in EVAL, including `my role`, are lexical to that
-        // compilation unit. Preserve only a role type object returned directly
-        // from EVAL; every other EVAL-local role must not overwrite a same-named
-        // role the caller declares later.
-        for name in &returned_role_names {
-            if let Some(role) = current_roles.get(name) {
-                self.registry_mut().roles.insert(name.clone(), role.clone());
-            }
-            if let Some(candidates) = current_role_candidates.get(name) {
-                self.registry_mut()
-                    .role_candidates
-                    .insert(name.clone(), candidates.clone());
-            }
-            if let Some(params) = current_role_type_params.get(name) {
-                self.registry_mut()
-                    .role_type_params
-                    .insert(name.clone(), params.clone());
-            }
-            if let Some(parents) = current_role_parents.get(name) {
-                self.registry_mut()
-                    .role_parents
-                    .insert(name.clone(), parents.clone());
-            }
-            if let Some(hides) = current_role_hides.get(name) {
-                self.registry_mut()
-                    .role_hides
-                    .insert(name.clone(), hides.clone());
-            }
-        }
+        // Package-scoped roles declared by EVAL remain visible to later EVALs.
+        // Lexical `my role` declarations do not, unless their type object is
+        // returned directly from EVAL and remains reachable by the caller.
+        self.registry_mut().roles.extend(
+            current_roles
+                .into_iter()
+                .filter(|(name, _)| keep_role(name)),
+        );
+        self.registry_mut().role_candidates.extend(
+            current_role_candidates
+                .into_iter()
+                .filter(|(name, _)| keep_role(name)),
+        );
+        self.registry_mut().role_type_params.extend(
+            current_role_type_params
+                .into_iter()
+                .filter(|(name, _)| keep_role(name)),
+        );
+        self.registry_mut().role_parents.extend(
+            current_role_parents
+                .into_iter()
+                .filter(|(name, _)| keep_role(name)),
+        );
+        self.registry_mut().role_hides.extend(
+            current_role_hides
+                .into_iter()
+                .filter(|(name, _)| keep_role(name)),
+        );
         self.registry_mut().classes.extend(current_classes);
         self.registry_mut()
             .hidden_classes
@@ -598,7 +605,7 @@ impl Interpreter {
             self.registry_mut().restore_user_method_rows(owner, rows);
             self.registry_mut().sync_accessor_entries(owner);
         }
-        for key in &snapshot_type_keys {
+        for key in current_type_keys.union(&snapshot_type_keys) {
             if let Some(value) = current_env.get(key).cloned() {
                 self.env.insert(key.clone(), value);
             } else if let Some(value) = env_snapshot.get(key).cloned() {

--- a/src/vm/vm_typedecl_ops.rs
+++ b/src/vm/vm_typedecl_ops.rs
@@ -821,6 +821,10 @@ impl Interpreter {
                     *role_id,
                 )
             )?;
+            if self.env().contains_key("__mutsu_in_eval") {
+                self.env_mut()
+                    .insert(format!("__mutsu_eval_role::{qualified_name}"), Value::TRUE);
+            }
             // Link `is Parent` references on this role to the lexical class visible
             // in this scope (which may be stored under a mangled name), matching
             // the class-parent remapping in `exec_register_class_op`.

--- a/src/vm/vm_typedecl_ops.rs
+++ b/src/vm/vm_typedecl_ops.rs
@@ -821,7 +821,11 @@ impl Interpreter {
                     *role_id,
                 )
             )?;
-            if self.env().contains_key("__mutsu_in_eval") {
+            if self.env().contains_key("__mutsu_in_eval")
+                && custom_traits
+                    .iter()
+                    .any(|(trait_name, _)| trait_name == "__my_scoped")
+            {
                 self.env_mut()
                     .insert(format!("__mutsu_eval_role::{qualified_name}"), Value::TRUE);
             }

--- a/src/vm/vm_typedecl_ops.rs
+++ b/src/vm/vm_typedecl_ops.rs
@@ -822,6 +822,7 @@ impl Interpreter {
                 )
             )?;
             if self.env().contains_key("__mutsu_in_eval")
+                && !name_str.contains("::")
                 && custom_traits
                     .iter()
                     .any(|(trait_name, _)| trait_name == "__my_scoped")


### PR DESCRIPTION
## Problem\nA role declared in an EVAL leaked into the caller registry and could replace a later same-named lexical role.\n\n## Approach\n- restore role registries after EVAL without merging EVAL-local roles\n- discard parameterized-role pun artifacts created by EVAL-local roles\n- keep EVAL-local type aliases out of the caller environment\n\n## Testing\n- `prove -e target/debug/mutsu t/parametric-role-of-type.t`\n- `MUTSU_REAL_TEST=1 prove -e 'target/debug/mutsu -I roast/packages/Test-Helpers/lib' t/parametric-role-of-type.t`\n- `cargo fmt --all`\n- `cargo clippy -- -D warnings`