### PR TITLE
test: tolerate unavailable Rakudo precomp cache

### DIFF
--- a/t/tap-planned-zero-ran-stream.t
+++ b/t/tap-planned-zero-ran-stream.t
@@ -17,7 +17,7 @@ is_run 'use Test; plan 1; say "done";',
     {
         status => 255,
         out    => "1..1\ndone\n# You planned 1 test, but ran 0\n",
-        err    => '',
+        err    => -> $err { $err eq '' || $err eq "Warning: precompilation cache is unavailable: Read-only file system (os error 30)\n" },
     },
     'a plan with zero tests run prints the summary on stdout, matching raku';
 
@@ -25,6 +25,9 @@ is_run 'use Test; plan 2; ok True, "one"; say "done";',
     {
         status => 255,
         out    => "1..2\nok 1 - one\ndone\n",
-        err    => "# You planned 2 tests, but ran 1\n",
+        err    => -> $err {
+            $err eq "# You planned 2 tests, but ran 1\n"
+                || $err eq "Warning: precompilation cache is unavailable: Read-only file system (os error 30)\n# You planned 2 tests, but ran 1\n"
+        },
     },
     'a plan with at least one test run still prints the summary on stderr';


### PR DESCRIPTION
## Problem\nThe real-Test subprocess test treated Rakudo\s read-only precomp-cache warning as a behavioral stderr difference.\n\n## Approach\nAccept that environment warning while continuing to assert the planned-versus-ran diagnostics and their stream.\n\n## Testing\n- `prove -e target/debug/mutsu t/tap-planned-zero-ran-stream.t`\n- `MUTSU_REAL_TEST=1 prove -e 'target/debug/mutsu -I roast/packages/Test-Helpers/lib' t/tap-planned-zero-ran-stream.t`\n- `raku t/tap-planned-zero-ran-stream.t`\n- `cargo fmt --all`\n- `cargo clippy -- -D warnings`