### PR TITLE
fix: yield Tap from do whenever

### DIFF
--- a/src/compiler/expr_block.rs
+++ b/src/compiler/expr_block.rs
@@ -729,18 +729,13 @@ impl Compiler {
                 // Map as the declaration's value.
                 self.compile_stmt(stmt);
             }
-            Stmt::Whenever { supply, .. } => {
-                // Expression-position `do whenever $s {...}`: bind the tap handle
-                // to `env[$s]` so it can be read back as the do-block's value.
-                let saved = self.whenever_bind_target;
-                self.whenever_bind_target = true;
+            Stmt::Whenever { .. } => {
+                // A `do whenever` expression gets its Tap directly from the
+                // opcode, just like every other value-producing expression.
+                let saved = self.do_stmt_yields_value;
+                self.do_stmt_yields_value = true;
                 self.compile_stmt(stmt);
-                self.whenever_bind_target = saved;
-                if let Expr::Var(name) = supply {
-                    self.compile_expr(&Expr::Var(name.clone()));
-                } else {
-                    self.code.emit(OpCode::LoadNil);
-                }
+                self.do_stmt_yields_value = saved;
             }
             // A `when`/`default` clause used as a TERM. A clause that MATCHES
             // never falls through to the next op: it raises `succeed` carrying

--- a/src/compiler/helpers_block_inline.rs
+++ b/src/compiler/helpers_block_inline.rs
@@ -252,14 +252,13 @@ impl Compiler {
                         self.pop_dynamic_scope_lexical(saved);
                         return;
                     }
-                    Stmt::Whenever { supply, .. } => {
-                        // `do whenever ...` should produce the created Tap in expression context.
+                    Stmt::Whenever { .. } => {
+                        // A block-final `whenever` is the value of `do { ... }`.
+                        // Let the opcode put its Tap on the ordinary value stack.
+                        let saved_yields_value = self.do_stmt_yields_value;
+                        self.do_stmt_yields_value = true;
                         self.compile_stmt(stmt);
-                        if let Expr::Var(name) = supply {
-                            self.compile_expr(&Expr::Var(name.clone()));
-                        } else {
-                            self.code.emit(OpCode::LoadNil);
-                        }
+                        self.do_stmt_yields_value = saved_yields_value;
                         self.pop_dynamic_scope_lexical(saved);
                         return;
                     }

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -1313,15 +1313,9 @@ pub(crate) struct Compiler {
     pub(crate) self_is_signature_param: bool,
     /// When true, the current VarDecl is from a `:=` bind declaration.
     bind_vardecl: bool,
-    /// True while compiling a `do whenever $s {...}` in expression position
-    /// (e.g. `my $tap = do whenever $s {...}`). The whenever's tap handle is
-    /// bridged out through `env[$s]` (see `run_whenever_with_value`), so the
-    /// `WheneverScope` op is emitted with the supply-var name as its target so
-    /// the enclosing `do` can read the tap back. A bare `whenever $s {...}`
-    /// statement leaves this false, so it does NOT clobber `$s` — important when
-    /// the same `$s` is tapped again on a later iteration (e.g. a nested
-    /// `whenever` inside `whenever Supply.interval(...)`).
-    whenever_bind_target: bool,
+    /// True only while compiling the statement operand of `do`. `WheneverScope`
+    /// reads this to leave its Tap on the ordinary value stack.
+    do_stmt_yields_value: bool,
     /// When true, Index expressions should emit IndexAutovivify instead of
     /// Index.  Set only during scalar `:=` bind VarDecl compilation so that
     /// `my $b := %h<foo><baz>` creates a HashEntryRef.
@@ -1614,7 +1608,7 @@ impl Compiler {
             lexically_in_method: false,
             self_is_signature_param: false,
             bind_vardecl: false,
-            whenever_bind_target: false,
+            do_stmt_yields_value: false,
             scalar_bind_autovivify: false,
             bind_terminal: false,
             rw_return_operand: false,

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -4563,24 +4563,11 @@ impl Compiler {
                 let param_type_idx = param_type
                     .as_ref()
                     .map(|t| self.code.add_constant(Value::str(t.clone())));
-                // Only bridge the tap handle out through `env[$s]` when this
-                // whenever is the value of a `do whenever $s {...}` expression
-                // (`whenever_bind_target`). A bare `whenever $s {...}` statement
-                // must NOT clobber `$s` with its Tap — otherwise re-tapping the
-                // same supply on a later iteration (a nested `whenever` inside
-                // `whenever Supply.interval(...)`) would see a Tap, not the Supply.
-                let target_var_idx = if self.whenever_bind_target
-                    && let Expr::Var(name) = supply
-                {
-                    Some(self.code.add_constant(Value::str(name.clone())))
-                } else {
-                    None
-                };
                 self.code.emit(OpCode::WheneverScope {
                     body_idx,
                     analysis_cc_idx,
                     param_idx,
-                    target_var_idx,
+                    yields_value: self.do_stmt_yields_value,
                     param_type_idx,
                 });
             }

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -2084,7 +2084,10 @@ pub(crate) enum OpCode {
         /// ADR-0018's env-consumer analysis.
         analysis_cc_idx: u32,
         param_idx: Option<u32>,
-        target_var_idx: Option<u32>,
+        /// Whether this statement is the operand of `do` and therefore leaves
+        /// the newly-created Tap on the value stack. A statement-form
+        /// `whenever` deliberately sinks that value.
+        yields_value: bool,
         /// Constant index of the pointy param's declared type constraint
         /// (`whenever $s -> Int $x { }`), if any.
         param_type_idx: Option<u32>,

--- a/src/runtime/native_methods/mod.rs
+++ b/src/runtime/native_methods/mod.rs
@@ -27,7 +27,8 @@ mod system;
 
 // Re-export pub(crate) items accessed from outside `runtime` module
 pub(crate) use state::{
-    SupplyEvent, has_supply_channel, split_supply_chunks_into_lines, take_supply_channel,
+    SupplyEvent, has_supply_channel, is_whenever_closed, next_whenever_id,
+    split_supply_chunks_into_lines, take_supply_channel,
 };
 pub(crate) use state_lock::{acquire_lock, current_thread_id, lock_runtime_by_id, release_lock};
 

--- a/src/runtime/native_methods/scheduler.rs
+++ b/src/runtime/native_methods/scheduler.rs
@@ -171,6 +171,11 @@ impl Interpreter {
     ) -> Result<Value, RuntimeError> {
         match method {
             "cancel" | "close" => {
+                if let Some(ValueView::Int(whenever_id)) =
+                    attributes.get("whenever_id").map(Value::view)
+                {
+                    close_whenever(whenever_id as u64);
+                }
                 if let Some(ValueView::Int(listener_id)) =
                     attributes.get("listener-id").map(Value::view)
                 {

--- a/src/runtime/native_methods/socket_async.rs
+++ b/src/runtime/native_methods/socket_async.rs
@@ -485,8 +485,8 @@ impl Interpreter {
                 // TcpStream, so a client on the main thread sees the data over the
                 // OS socket).
                 if !self.supply_emit_buffer.is_empty() {
-                    // Same 4-element shape as every other whenever subscription
-                    // marker ([source, body, [LAST…], [QUIT…]]) so the supply-
+                    // Same 5-element shape as every other whenever subscription
+                    // marker ([source, body, [LAST…], [QUIT…], id]) so the supply-
                     // block tap path recognises it; a 2-element array fell
                     // through as a plain emitted value there. The listener
                     // whenever's own LAST/QUIT phasers are not routed here.
@@ -496,6 +496,7 @@ impl Interpreter {
                         callback,
                         Value::array(Vec::new()),
                         Value::array(Vec::new()),
+                        Value::NIL,
                     ]);
                     if let Some(last) = self.supply_emit_buffer.last_mut() {
                         last.push(sub);

--- a/src/runtime/native_methods/state.rs
+++ b/src/runtime/native_methods/state.rs
@@ -14,6 +14,30 @@ pub(in crate::runtime) fn proc_stdin_map() -> &'static StdinMap {
 
 type SupplyTapsMap = std::sync::Mutex<HashMap<u64, Vec<Value>>>;
 
+type ClosedWheneverMap = std::sync::Mutex<std::collections::HashSet<u64>>;
+
+fn closed_whenever_map() -> &'static ClosedWheneverMap {
+    static MAP: OnceLock<ClosedWheneverMap> = OnceLock::new();
+    MAP.get_or_init(|| std::sync::Mutex::new(std::collections::HashSet::new()))
+}
+
+pub(crate) fn next_whenever_id() -> u64 {
+    static NEXT: AtomicU64 = AtomicU64::new(1);
+    NEXT.fetch_add(1, Ordering::Relaxed)
+}
+
+pub(crate) fn close_whenever(id: u64) {
+    if let Ok(mut closed) = closed_whenever_map().lock() {
+        closed.insert(id);
+    }
+}
+
+pub(crate) fn is_whenever_closed(id: u64) -> bool {
+    closed_whenever_map()
+        .lock()
+        .is_ok_and(|closed| closed.contains(&id))
+}
+
 fn supply_taps_map() -> &'static SupplyTapsMap {
     static MAP: OnceLock<SupplyTapsMap> = OnceLock::new();
     MAP.get_or_init(|| std::sync::Mutex::new(HashMap::new()))

--- a/src/runtime/native_supply_mut_methods.rs
+++ b/src/runtime/native_supply_mut_methods.rs
@@ -431,7 +431,7 @@ impl Interpreter {
                         .iter()
                         .filter(|item| {
                             if let ValueView::Array(arr, ..) = item.view()
-                                && arr.len() == 4
+                                && arr.len() == 5
                                 && let ValueView::Instance {
                                     class_name,
                                     attributes,
@@ -478,7 +478,7 @@ impl Interpreter {
                     let body_done = body_ran_done;
                     for item in emitted {
                         if let ValueView::Array(arr, ..) = item.view()
-                            && arr.len() == 4
+                            && arr.len() == 5
                             && matches!(arr[0].view(), ValueView::Instance { class_name, .. } if class_name == "Supply")
                         {
                             let inner_supply = &arr[0];

--- a/src/runtime/subtest.rs
+++ b/src/runtime/subtest.rs
@@ -4,6 +4,7 @@ use crate::symbol::Symbol;
 
 /// A subscription registered by a `whenever` block inside a `react` block.
 pub(crate) struct ReactSubscription {
+    pub whenever_id: Option<u64>,
     pub receiver: Option<SupplyReceiver>,
     pub supplier_id: Option<u64>,
     pub callback: Value,
@@ -52,6 +53,7 @@ impl ReactSubscription {
     /// phaser callbacks via struct-update syntax (`..ReactSubscription::new(cb)`).
     pub(crate) fn new(callback: Value) -> Self {
         ReactSubscription {
+            whenever_id: None,
             receiver: None,
             supplier_id: None,
             callback,
@@ -358,12 +360,21 @@ impl Interpreter {
     pub(crate) fn run_whenever_with_value(
         &mut self,
         supply_val: Value,
-        target_var: Option<&str>,
+        yields_value: bool,
         param: &Option<String>,
         param_type: &Option<String>,
         body: &[Stmt],
         owned_lexicals: &[Symbol],
-    ) -> Result<(), RuntimeError> {
+    ) -> Result<Value, RuntimeError> {
+        let whenever_id = crate::runtime::native_methods::next_whenever_id();
+        let stamp_tap = |tap: Value| Self::stamp_whenever_tap(tap, whenever_id);
+        let result_tap = |tap: Value| {
+            if yields_value {
+                stamp_tap(tap)
+            } else {
+                Value::NIL
+            }
+        };
         // If the source is a Supplier, convert it to its associated Supply
         // so that subscription registration and tap dispatch work correctly.
         // Without this, `whenever $supplier { ... }` inside a `supply` block
@@ -479,17 +490,27 @@ impl Interpreter {
                     "act",
                     vec![callback.clone()],
                 )?;
-                if let Some(name) = target_var {
-                    self.env.insert(name.to_string(), tap);
-                }
-                return Ok(());
+                // Listener taps already carry their close identity
+                // (`listener-id`), so preserve the object `.act` returned.
+                return Ok(result_tap(tap));
             }
+            // Proc::Async's legacy direct-tap path dispatches the callback
+            // without entering the react drive loop. Mark this non-listener
+            // callback so `Tap.close` can suppress it too. Do this only after
+            // the listener return above: sub_with_env_key shares closure state,
+            // and listener `.act` needs its original lexical `self`.
+            let callback_with_id = Self::sub_with_env_key(
+                &callback,
+                "__mutsu_whenever_id",
+                Value::int(whenever_id as i64),
+            );
             // In react mode: register the subscription for the event loop
             let sub = Value::array(vec![
                 supply_val.clone(),
-                callback.clone(),
+                callback_with_id.clone(),
                 Value::array(last_callbacks.clone()),
                 Value::array(quit_callbacks.clone()),
+                Value::int(whenever_id as i64),
             ]);
             if let Some(last) = self.supply_emit_buffer.last_mut() {
                 last.push(sub);
@@ -513,7 +534,7 @@ impl Interpreter {
                 {
                     crate::runtime::native_methods::register_supply_tap(
                         sid as u64,
-                        callback.clone(),
+                        callback_with_id.clone(),
                     );
                 }
                 // Also register on parent for lines supplies
@@ -522,15 +543,12 @@ impl Interpreter {
                 {
                     crate::runtime::native_methods::register_supply_tap(
                         pid as u64,
-                        callback.clone(),
+                        callback_with_id.clone(),
                     );
                 }
             }
 
-            if let Some(name) = target_var {
-                self.env.insert(name.to_string(), supply_val);
-            }
-            return Ok(());
+            return Ok(result_tap(Self::new_whenever_tap(whenever_id)));
         }
 
         // Not in react mode: original behavior.
@@ -573,16 +591,12 @@ impl Interpreter {
                 tap_args.push(Value::pair("quit".to_string(), quit_cb));
             }
             let updated = self.call_method_with_values(supply_val.clone(), "tap", tap_args)?;
-            if let Some(name) = target_var {
-                self.env.insert(name.to_string(), updated);
-            }
+            return Ok(result_tap(updated));
         } else if let ValueView::Instance { class_name, .. } = supply_val.view()
             && class_name == "IO::Socket::Async::Listener"
         {
             let tap = self.call_method_with_values(supply_val.clone(), "act", vec![callback])?;
-            if let Some(name) = target_var {
-                self.env.insert(name.to_string(), tap);
-            }
+            return Ok(result_tap(tap));
         } else if let ValueView::Promise(shared) = supply_val.view() {
             // A promise source is a one-shot supply: run the body once with the
             // kept result, then the LAST phasers; a broken promise runs the QUIT
@@ -641,6 +655,26 @@ impl Interpreter {
             // group join so the enclosing supply's done is not held hostage.
             self.invoke_done_callback(marker)?;
         }
-        Ok(())
+        Ok(result_tap(Self::new_whenever_tap(whenever_id)))
+    }
+
+    fn new_whenever_tap(whenever_id: u64) -> Value {
+        let mut attributes = HashMap::new();
+        attributes.insert("whenever_id".to_string(), Value::int(whenever_id as i64));
+        Value::make_instance(Symbol::intern("Tap"), attributes)
+    }
+
+    fn stamp_whenever_tap(tap: Value, whenever_id: u64) -> Value {
+        let ValueView::Instance {
+            class_name,
+            attributes,
+            ..
+        } = tap.view()
+        else {
+            return Self::new_whenever_tap(whenever_id);
+        };
+        let mut attributes = attributes.as_map().clone();
+        attributes.insert("whenever_id".to_string(), Value::int(whenever_id as i64));
+        Value::make_instance(class_name, attributes)
     }
 }

--- a/src/runtime/supply_promise.rs
+++ b/src/runtime/supply_promise.rs
@@ -46,6 +46,14 @@ impl Interpreter {
         } else {
             tap
         };
+        if tap.as_sub().is_some_and(|data| {
+            matches!(
+                data.env.get("__mutsu_whenever_id").map(Value::view),
+                Some(ValueView::Int(id)) if crate::runtime::native_methods::is_whenever_closed(id as u64)
+            )
+        }) {
+            return Ok(Value::NIL);
+        }
         // `(emitter, is_stamped)`: only a stamped emitter is authoritative.
         let (emitter, stamped) = Self::whenever_tap_emitter(&tap);
         if let Some(ref e) = emitter {
@@ -251,7 +259,13 @@ impl Interpreter {
                 });
                 self.pending_promise_whenever_arms
                     .push((promise.clone(), supplier));
-                Value::array(vec![supply, arr[1].clone(), arr[2].clone(), arr[3].clone()])
+                Value::array(vec![
+                    supply,
+                    arr[1].clone(),
+                    arr[2].clone(),
+                    arr[3].clone(),
+                    arr[4].clone(),
+                ])
             })
             .collect()
     }
@@ -259,7 +273,7 @@ impl Interpreter {
     /// True for a `whenever` subscription marker whose source is a `Promise`.
     pub(crate) fn is_promise_whenever_marker(item: &Value) -> bool {
         matches!(item.view(), ValueView::Array(arr, ..)
-            if arr.len() == 4 && matches!(arr[0].view(), ValueView::Promise(_)))
+            if arr.len() == 5 && matches!(arr[0].view(), ValueView::Promise(_)))
     }
 
     /// Arm every promise parked by [`Self::normalize_promise_whenever_markers`]:
@@ -487,7 +501,7 @@ impl Interpreter {
         let mut plain_values = Vec::new();
         for item in emitted {
             let is_supply_sub = if let ValueView::Array(arr, ..) = item.view() {
-                arr.len() == 4
+                arr.len() == 5
                     && matches!(arr[0].view(), ValueView::Instance { class_name, .. } if class_name == "Supply")
             } else {
                 false

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -5095,7 +5095,7 @@ impl Interpreter {
                 body_idx,
                 analysis_cc_idx,
                 param_idx,
-                target_var_idx,
+                yields_value,
                 param_type_idx,
             } => {
                 self.sync_source_line(code, *ip);
@@ -5104,7 +5104,7 @@ impl Interpreter {
                     *body_idx,
                     *analysis_cc_idx,
                     param_idx,
-                    target_var_idx,
+                    *yields_value,
                     param_type_idx,
                 )?;
                 *ip += 1;

--- a/src/vm/vm_react_loop.rs
+++ b/src/vm/vm_react_loop.rs
@@ -217,6 +217,10 @@ impl Interpreter {
                     .get(3)
                     .and_then(crate::runtime::Interpreter::value_array_items)
                     .unwrap_or_default();
+                let whenever_id = items.get(4).and_then(|value| match value.view() {
+                    ValueView::Int(id) if id >= 0 => Some(id as u64),
+                    _ => None,
+                });
 
                 match source.view() {
                     // Supply with a channel
@@ -244,6 +248,7 @@ impl Interpreter {
                                 .and_then(crate::runtime::Interpreter::value_array_items)
                                 .unwrap_or_default();
                             react_subs.push(ReactSubscription {
+                                whenever_id,
                                 receiver: Some(rx),
                                 close_callbacks: Self::extract_supply_on_close_callbacks(
                                     &(attributes).as_map(),
@@ -268,6 +273,7 @@ impl Interpreter {
                                 .and_then(crate::runtime::Interpreter::value_array_items)
                                 .unwrap_or_default();
                             react_subs.push(ReactSubscription {
+                                whenever_id,
                                 supplier_id: Some(supplier_id as u64),
                                 close_callbacks: Self::extract_supply_on_close_callbacks(
                                     &(attributes).as_map(),
@@ -451,6 +457,7 @@ impl Interpreter {
                                     // poll in `vm_react_subscriptions.rs` can reach
                                     // them.
                                     react_subs.push(ReactSubscription {
+                                        whenever_id,
                                         close_callbacks: close_cbs,
                                         quit_callbacks: quit_callbacks.clone(),
                                         on_demand_done: Some(done_promise.clone()),
@@ -511,6 +518,7 @@ impl Interpreter {
                             },
                         );
                         react_subs.push(ReactSubscription {
+                            whenever_id,
                             receiver: Some(rx),
                             promise: Some(shared.clone()),
                             ..ReactSubscription::new(callback)
@@ -523,6 +531,7 @@ impl Interpreter {
                             .and_then(crate::runtime::Interpreter::value_array_items)
                             .unwrap_or_default();
                         react_subs.push(ReactSubscription {
+                            whenever_id,
                             last_callbacks,
                             channel: Some(ch.clone()),
                             ..ReactSubscription::new(callback)

--- a/src/vm/vm_react_subscriptions.rs
+++ b/src/vm/vm_react_subscriptions.rs
@@ -51,6 +51,13 @@ impl Interpreter {
                 if key >= react_subs.len() || react_subs[key].done {
                     continue;
                 }
+                if react_subs[key]
+                    .whenever_id
+                    .is_some_and(crate::runtime::native_methods::is_whenever_closed)
+                {
+                    react_subs[key].done = true;
+                    continue;
+                }
                 match event {
                     SinkEvent::Emit(value) => {
                         if let Some(limit) = react_subs[key].head_limit
@@ -365,18 +372,26 @@ impl Interpreter {
         result
     }
 
-    /// Is this value one of the 4-element `[source, body, [LAST…], [QUIT…]]`
+    /// Is this value one of the 5-element `[source, body, [LAST…], [QUIT…], id]`
     /// arrays `whenever` registers, rather than a value a supply body emitted?
     fn is_whenever_subscription_marker(value: &Value) -> bool {
         let ValueView::Array(items, ..) = value.view() else {
             return false;
         };
-        items.len() == 4
+        items.len() == 5
             && matches!(
                 items[0].view(),
                 ValueView::Promise(_) | ValueView::Channel(_) | ValueView::Instance { .. }
             )
             && matches!(items[1].view(), ValueView::Sub(_))
+    }
+
+    fn whenever_marker_is_closed(marker: &Value) -> bool {
+        let ValueView::Array(items, ..) = marker.view() else {
+            return false;
+        };
+        matches!(items.get(4).map(Value::view), Some(ValueView::Int(id)) if id >= 0
+            && crate::runtime::native_methods::is_whenever_closed(id as u64))
     }
 
     /// Adopt any `whenever` subscription registered while the drive loop was
@@ -392,7 +407,10 @@ impl Interpreter {
         if self.pending_react_subscriptions.is_empty() {
             return Ok(false);
         }
-        let pending = std::mem::take(&mut self.pending_react_subscriptions);
+        let pending: Vec<Value> = std::mem::take(&mut self.pending_react_subscriptions)
+            .into_iter()
+            .filter(|marker| !Self::whenever_marker_is_closed(marker))
+            .collect();
         for marker in &pending {
             if let ValueView::Array(items, ..) = marker.view()
                 && items.len() >= 2
@@ -459,6 +477,14 @@ impl Interpreter {
             // never fired at all).
             if self.adopt_newly_registered_subscriptions(react_subs, waker, sink_regs)? {
                 break 'react_loop;
+            }
+            for sub in react_subs.iter_mut() {
+                if sub
+                    .whenever_id
+                    .is_some_and(crate::runtime::native_methods::is_whenever_closed)
+                {
+                    sub.done = true;
+                }
             }
             // GC park point: an idle react loop blocks on the waker without
             // dispatching bytecode, so it would never reach the backedge

--- a/src/vm/vm_scope_ops.rs
+++ b/src/vm/vm_scope_ops.rs
@@ -170,12 +170,11 @@ impl Interpreter {
         body_idx: u32,
         analysis_cc_idx: u32,
         param_idx: &Option<u32>,
-        target_var_idx: &Option<u32>,
+        yields_value: bool,
         param_type_idx: &Option<u32>,
     ) -> Result<(), RuntimeError> {
         let supply_val = self.stack.pop().unwrap_or(Value::NIL);
         let param = param_idx.map(|idx| Self::const_str(code, idx).to_string());
-        let target_var = target_var_idx.map(|idx| Self::const_str(code, idx));
         let param_type = param_type_idx.map(|idx| Self::const_str(code, idx).to_string());
         let stmt = &code.stmt_pool[body_idx as usize];
         if let Stmt::Block(body) = stmt {
@@ -265,37 +264,19 @@ impl Interpreter {
                 }
                 self.share_supply_block_lexicals(code);
             }
-            loan_env!(
+            let tap = loan_env!(
                 self,
                 run_whenever_with_value(
                     supply_val,
-                    target_var,
+                    yields_value,
                     &param,
                     &param_type,
                     body,
                     &owned_lexicals
                 )
             )?;
-            // Slice F (env<->locals coherence): a `my $tap = do whenever $sup {…}`
-            // binds the tap handle by writing `env[target_var]` directly (see
-            // `run_whenever_with_value`), but never updates the caller's local
-            // slot. With the reverse env->locals pull disabled, a later read of
-            // that variable *within the same react block* (e.g.
-            // `isa-ok $tap, Tap`) sees the stale slot (the `do` block's own
-            // result) instead of the bound tap. Reconcile the caller's slots from
-            // env here so the binding is visible immediately. Byte-identical with
-            // the reverse pull enabled.
-            //
-            // env_dirty substrate (docs/captured-outer-cell-sharing.md §10): the
-            // bound name is known exactly (`target_var`), so write just that slot
-            // through from env — the precise form of the blanket reconcile below.
-            // Armed only under boxing; the default build keeps the blanket pull.
-            if let Some(name) = target_var
-                && let Some(slot) = self.find_local_slot(code, name)
-                && !matches!(self.locals[slot].view(), ValueView::HashEntryRef { .. })
-                && let Some(val) = self.env().get(name).cloned()
-            {
-                self.locals[slot] = val;
+            if yields_value {
+                self.stack.push(tap);
             }
             Ok(())
         } else {

--- a/t/react-do-whenever-tap-coherence.t
+++ b/t/react-do-whenever-tap-coherence.t
@@ -1,12 +1,9 @@
 use Test;
 
-# Slice F (env<->locals coherence): `my $tap = do whenever $sup {…}` inside a
-# react block binds the tap handle by writing env[target_var] directly (see
-# run_whenever_with_value), without updating the caller's local slot. With the
-# reverse env->locals pull disabled (single-store default), a read of that
-# variable later in the SAME react block saw the stale slot. The whenever scope
-# op must reconcile the caller's slots from env after binding. Regression:
-# roast/S32-io/IO-Socket-Async.t ('listen tap is a Tap').
+# `do whenever` leaves the Tap on the ordinary value stack, so a later read of
+# the lexical in the same react block sees the value assigned by `my` without
+# any env-to-local reconciliation. Regression: roast/S32-io/IO-Socket-Async.t
+# ('listen tap is a Tap').
 
 plan 2;
 

--- a/t/react-do-whenever-tap-value.t
+++ b/t/react-do-whenever-tap-value.t
@@ -1,0 +1,54 @@
+use Test;
+
+# `do whenever` is the legal expression form of the statement control word.
+# It must yield the subscription Tap on the ordinary value stack, irrespective
+# of whether the source is a lexical Supply or a computed `.Supply` call.
+
+plan 8;
+
+{
+    my $supplier = Supplier.new;
+    my $s = $supplier.Supply;
+    react {
+        my $tap = do whenever $s -> $value { }
+        isa-ok $tap, Tap, 'react do-whenever over a lexical Supply yields Tap';
+        isa-ok $s, Supply, 'react do-whenever does not clobber its source';
+        done;
+    }
+}
+
+{
+    my $supplier = Supplier.new;
+    react {
+        my $tap = do whenever $supplier.Supply -> $value { }
+        isa-ok $tap, Tap, 'react do-whenever over a method call yields Tap';
+        done;
+    }
+}
+
+{
+    my $supplier = Supplier.new;
+    my $s = $supplier.Supply;
+    react {
+        my $tap = do { whenever $s -> $value { } }
+        isa-ok $tap, Tap, 'braced do-whenever yields Tap';
+        isa-ok $s, Supply, 'braced do-whenever does not clobber its source';
+        done;
+    }
+}
+
+{
+    my $supplier = Supplier.new;
+    my $s = $supplier.Supply;
+    my $outer = supply {
+        my $tap = do whenever $s -> $value { }
+        isa-ok $tap, Tap, 'supply do-whenever over a lexical Supply yields Tap';
+        isa-ok $s, Supply, 'supply do-whenever does not clobber its source';
+        my $method-tap = do whenever $supplier.Supply -> $value { }
+        isa-ok $method-tap, Tap, 'supply do-whenever over a method call yields Tap';
+    };
+    react {
+        whenever $outer { }
+        whenever Promise.in(0.01) { done }
+    }
+}

--- a/t/react-nested-whenever-on-demand-close.t
+++ b/t/react-nested-whenever-on-demand-close.t
@@ -88,8 +88,8 @@ plan 4;
 }
 
 # A bare `whenever $sup { }` statement must NOT clobber `$sup` with its Tap: the
-# supply variable stays a Supply and can be tapped again. (The `do whenever`
-# expression bridge is covered by t/react-do-whenever-tap-coherence.t.)
+# supply variable stays a Supply and can be tapped again. (`do whenever`
+# expression values are covered by t/react-do-whenever-tap-value.t.)
 {
     my $sup = Supplier.new.Supply;
     react {

--- a/t/react-whenever-tap-close.t
+++ b/t/react-whenever-tap-close.t
@@ -1,0 +1,42 @@
+use Test;
+
+plan 2;
+
+# A Tap returned by `do whenever` can close its own subscription while its
+# callback is running. Queued later emissions must observe the closed id.
+{
+    my $supplier = Supplier.new;
+    my $seen = 0;
+    react {
+        my $tap;
+        $tap = do whenever $supplier.Supply -> $value {
+            $seen++;
+            $tap.close;
+        }
+        $supplier.emit(1);
+        $supplier.emit(2);
+        $supplier.emit(3);
+        whenever Promise.in(0.05) {
+            is $seen, 1, 'closing a whenever Tap stops queued later emissions';
+            done;
+        }
+    }
+}
+
+# A sibling whenever can close another subscription before it consumes an
+# event, the form used to shut down a listener from a signal subscription.
+{
+    my $left = Supplier.new;
+    my $right = Supplier.new;
+    my $left-seen = 0;
+    react {
+        my $left-tap = do whenever $left.Supply -> $value { $left-seen++ }
+        my $right-tap = do whenever $right.Supply -> $value { $left-tap.close }
+        $right.emit('stop');
+        $left.emit('late');
+        whenever Promise.in(0.05) {
+            is $left-seen, 0, 'a sibling whenever can close another Tap';
+            done;
+        }
+    }
+}


### PR DESCRIPTION
## Problem

`do whenever` used a source-variable name bridge, so it returned the source `Supply` or `Nil` instead of the registered `Tap`, and could clobber the source binding.

## Approach

- make `WheneverScope` yield its Tap directly on the VM stack for `do` expressions
- give every non-listener subscription a stable `whenever_id` and make `Tap.close` retire it
- widen internal subscription markers consistently, including the socket-listener path
- preserve statement-form sink semantics and source bindings

## Test evidence

- `cargo check`
- `cargo fmt --all -- --check`
- `cargo clippy -- -D warnings`
- targeted TAP: `t/closure-lexical-self-native-dispatch.t`, `t/react-do-whenever-tap-value.t`, `t/react-whenever-tap-close.t`, `t/react-do-whenever-tap-coherence.t`, `t/react-nested-whenever-on-demand-close.t`
- `make test` was run once; its saved log records two listener failures from the intermediate 4-vs-5 marker mismatch, fixed afterwards and covered by the targeted listener regression above. Per repository policy, the full suite was not re-run.