### PR TITLE
feat(web): deploy Pages from npm package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -501,9 +501,9 @@ jobs:
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
 
-      - name: Build WASM
+      - name: Build npm package
         run: |
-          wasm-pack build --target web --no-default-features --features wasm
+          scripts/build-npm-package.sh
           mv pkg site/pkg
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,10 +1,9 @@
 name: Deploy WASM Demo to GitHub Pages
 
 on:
-  # A deploy is a full `wasm-pack build` — ~3 min to compile plus ~9 min of
-  # `wasm-opt` on the 17 MB artifact. Running that on every main push costs
-  # ~12 min of CI per merge to republish a byte-identical page, so the push
-  # trigger is narrowed to the files the deployed site is actually built from.
+  # The interpreter comes from the latest published npm package. Keep the push
+  # trigger narrowed to files that change the site itself; a newly published
+  # interpreter can be picked up immediately with workflow_dispatch.
   #
   # Deliberately NOT listed: `src/**`. Nearly every commit touches it, which
   # would restore the every-merge build. The consequence is that the playground
@@ -19,6 +18,11 @@ on:
       - 'scripts/bench-visualize.py'   # renders bench-trend.html
       - 'scripts/gen-batteries-manifest.py'
       - '.github/workflows/pages.yml'
+  # A successful tagged release publishes npm before the Release workflow
+  # completes, so this deploy picks up the new `latest` package automatically.
+  workflow_run:
+    workflows: [Release]
+    types: [completed]
   workflow_dispatch:
 
 permissions:
@@ -32,21 +36,25 @@ concurrency:
 
 jobs:
   build:
+    if: >-
+      github.event_name != 'workflow_run' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.event == 'push')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: dtolnay/rust-toolchain@01ba1edad32c6f80dbcce879d3e0fa5a00b2a84e # 1.96.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          targets: wasm32-unknown-unknown
+          node-version: 24
 
-      - name: Install wasm-pack
-        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
-
-      - name: Build WASM
+      - name: Install the published browser package
         run: |
-          wasm-pack build --target web --no-default-features --features wasm
-          mv pkg site/pkg
+          npm install --prefix tmp/pages-package --ignore-scripts --no-audit --no-fund \
+            @tokuhirom/mutsu@latest
+          mkdir -p site/pkg
+          cp -R tmp/pages-package/node_modules/@tokuhirom/mutsu/. site/pkg/
+          node -e 'const p = require("./site/pkg/package.json"); console.log(`using ${p.name}@${p.version}`)'
 
       - name: Generate the batteries listing
         # The batteries page (batteries.html) is generated from the vendored

--- a/news/2026-08/pages-uses-npm-wasm-package.md
+++ b/news/2026-08/pages-uses-npm-wasm-package.md
@@ -1,0 +1,9 @@
+# GitHub Pages uses the published npm package
+
+The GitHub Pages deployment now installs `@tokuhirom/mutsu` from npm instead
+of rebuilding the WebAssembly package with wasm-pack. The site therefore
+exercises the same published artifact that downstream browser applications use.
+Successful release workflows automatically redeploy Pages after npm publication.
+
+The runnable embedding demo is now linked from the shared navigation and also
+documents CDN, npm/bundler, and lower-level JavaScript API integration paths.

--- a/site/README.md
+++ b/site/README.md
@@ -17,7 +17,10 @@ one page — an editor whose Run button fed the REPL's transcript and its interp
 which made neither question easy to ask.
 
 The site is deliberately **build-step free**: plain HTML, ES modules and CSS, served
-as-is. The only generated input is `pkg/`, the `wasm-pack` output.
+as-is. The only generated input is `pkg/`, copied from the published
+`@tokuhirom/mutsu` npm package by the Pages workflow.
+Successful tagged releases trigger that workflow after npm publication, so the
+deployed interpreter follows the package's `latest` dist-tag.
 
 ## Layout
 
@@ -27,6 +30,7 @@ index.html          landing page — what mutsu is, install, what is inside,
 tutorial.html       the tutorial: chapter/lesson navigation + one runnable lesson
 playground.html     editor + Run + output: whole programs, one clean run each
 repl.html           the interactive session: one line at a time, state kept
+embed-demo.html     runnable installed-package demo and browser integration guide
 assets/
   site.css          all styling
   i18n.js           language selection, UI strings, shared nav + footer
@@ -46,7 +50,7 @@ content/
   landing.ja.js     landing-page copy (Japanese)
   stats.json        compatibility numbers — generated, git-ignored (see below)
 bench-trend.html    benchmark dashboard — generated, git-ignored (see below)
-pkg/                wasm-pack output — generated, git-ignored
+pkg/                installed npm package — generated, git-ignored
 ```
 
 ## The compatibility headline
@@ -146,10 +150,14 @@ e2e lesson sweep are all derived from the corpus.
 ## Running locally
 
 ```sh
-wasm-pack build --target web --no-default-features --features wasm
-mv pkg site/pkg
+npm install --prefix tmp/pages-package @tokuhirom/mutsu
+mkdir -p site/pkg
+cp -R tmp/pages-package/node_modules/@tokuhirom/mutsu/. site/pkg/
 python3 -m http.server 8000 -d site    # then open http://localhost:8000/
 ```
+
+Use `scripts/build-npm-package.sh` and copy its `pkg/` directory to `site/pkg/`
+instead when testing an unpublished local package change.
 
 ## Tests
 

--- a/site/assets/i18n.js
+++ b/site/assets/i18n.js
@@ -15,6 +15,7 @@ const STRINGS = {
     'nav.tutorial': 'Tutorial',
     'nav.playground': 'Playground',
     'nav.repl': 'REPL',
+    'nav.embed': 'Embed',
     'nav.batteries': 'Bundled Libraries',
     'nav.bench': 'Benchmarks',
     'nav.github': 'GitHub',
@@ -110,6 +111,7 @@ const STRINGS = {
     'nav.tutorial': 'チュートリアル',
     'nav.playground': 'プレイグラウンド',
     'nav.repl': 'REPL',
+    'nav.embed': '組み込み',
     'nav.batteries': '同梱ライブラリ',
     'nav.bench': 'ベンチマーク',
     'nav.github': 'GitHub',
@@ -246,6 +248,7 @@ const NAV = [
   { key: 'nav.tutorial', href: 'tutorial.html', page: 'tutorial' },
   { key: 'nav.playground', href: 'playground.html', page: 'playground' },
   { key: 'nav.repl', href: 'repl.html', page: 'repl' },
+  { key: 'nav.embed', href: 'embed-demo.html', page: 'embed' },
   { key: 'nav.batteries', href: 'batteries.html', page: 'batteries' },
   { key: 'nav.bench', href: 'bench-trend.html', page: 'bench' },
 ];

--- a/site/e2e.test.mjs
+++ b/site/e2e.test.mjs
@@ -509,6 +509,10 @@ try {
 
   console.log('Test: drop-in mutsu-code component');
   await page.goto(`${BASE}/embed-demo.html`, { waitUntil: 'networkidle' });
+  assert((await page.locator('main').textContent()).includes('npm install @tokuhirom/mutsu'),
+         'the demo includes npm installation guidance');
+  assert(await page.locator('a[aria-current="page"]').textContent() === 'Embed',
+         'the embedding guide is linked from the site navigation');
   const component = page.locator('mutsu-code');
   await component.locator('output').waitFor({ state: 'visible', timeout: 30000 });
   await page.waitForFunction(

--- a/site/embed-demo.html
+++ b/site/embed-demo.html
@@ -7,11 +7,13 @@
 <link rel="stylesheet" href="assets/site.css">
 </head>
 <body>
-<div class="container">
-  <header class="page-head">
-    <h1>Embed mutsu</h1>
-    <p class="page-intro">This runnable example is a drop-in <code>&lt;mutsu-code&gt;</code> component.</p>
-  </header>
+<nav class="site-nav"></nav>
+
+<main class="manual section">
+  <h1>Embed mutsu in a web page</h1>
+  <p class="page-intro">The GitHub Pages site uses the published
+    <code>@tokuhirom/mutsu</code> npm package. The runnable component below is
+    the same Web Component that applications install.</p>
 
   <mutsu-code autorun>
     <script type="text/raku">
@@ -20,8 +22,54 @@ say (^10).grep(* %% 2).sum;
     </script>
   </mutsu-code>
 
-  <p>See the <a href="https://github.com/tokuhirom/mutsu/blob/main/docs/browser-embedding.md">embedding guide</a> for the copy-and-paste HTML.</p>
-</div>
-<script type="module" src="assets/embed.js"></script>
+  <section class="manual-section manual-body" id="cdn">
+    <h2><a href="#cdn">Use it directly from a CDN</a></h2>
+    <p>For a static page, add the component and load its module from jsDelivr.
+      Pin a released version in production so an existing page does not change
+      unexpectedly.</p>
+    <pre><code>&lt;mutsu-code autorun&gt;
+  &lt;script type="text/raku"&gt;
+say "Hello from mutsu!";
+  &lt;/script&gt;
+&lt;/mutsu-code&gt;
+
+&lt;script type="module"
+  src="https://cdn.jsdelivr.net/npm/@tokuhirom/mutsu@0.23.0/embed.js"&gt;
+&lt;/script&gt;</code></pre>
+  </section>
+
+  <section class="manual-section manual-body" id="npm">
+    <h2><a href="#npm">Install it with npm</a></h2>
+    <p>Bundled applications can import the component from the package. Its
+      WebAssembly binary is included; users do not need Rust or wasm-pack.</p>
+    <pre><code>npm install @tokuhirom/mutsu</code></pre>
+    <pre><code>import '@tokuhirom/mutsu/element';</code></pre>
+  </section>
+
+  <section class="manual-section manual-body" id="api">
+    <h2><a href="#api">Use the JavaScript API</a></h2>
+    <p>Use the lower-level API when the application provides its own editor or
+      output UI.</p>
+    <pre><code>import init, { evaluate, Repl } from '@tokuhirom/mutsu';
+
+await init();
+console.log(evaluate('say "Hello"'));
+
+const repl = new Repl();
+console.log(JSON.parse(repl.evalLine('my $answer = 40')));
+console.log(JSON.parse(repl.evalLine('$answer + 2')));</code></pre>
+    <p>The component also supports <code>readonly</code> and
+      <code>session</code> attributes and emits a <code>mutsu-run</code> event.
+      See the <a href="https://github.com/tokuhirom/mutsu/blob/main/docs/browser-embedding.md">complete embedding reference</a>
+      for those options and the browser limitations.</p>
+  </section>
+</main>
+
+<footer class="site-footer"></footer>
+<script type="module" src="pkg/embed.js"></script>
+<script type="module">
+import { renderChrome } from './assets/i18n.js';
+renderChrome('embed');
+</script>
 </body>
 </html>


### PR DESCRIPTION
## Problem

GitHub Pages rebuilt mutsu with wasm-pack, so the demo did not exercise the browser artifact users install from npm. The embedding reference was also only discoverable in repository documentation.

## Approach

- install `@tokuhirom/mutsu@latest` in the Pages workflow and deploy that package as `site/pkg`
- redeploy Pages after successful tagged Release workflows
- load the installed package's Web Component directly in the runnable demo
- turn the demo into an on-site CDN/npm/JavaScript API guide and link it from shared navigation
- build the publishable npm package in wasm E2E CI and assert the guide/navigation

## Test evidence

- `node site/e2e.test.mjs` — 114 passed
- `cargo fmt --all --check`
- `cargo clippy -- -D warnings`
- `make test` — Rust tests passed; TAP encountered sandbox read-only precomp-cache failures
- targeted rerun of all 10 affected TAP files with `MUTSU_PRECOMP=0` — 10 files / 38 tests passed