### PR TITLE
fix(web): translate the embedding guide

### DIFF
--- a/news/2026-08/embed-guide-japanese.md
+++ b/news/2026-08/embed-guide-japanese.md
@@ -1,0 +1,5 @@
+# The browser embedding guide supports Japanese
+
+The GitHub Pages embedding guide now follows the site's shared language switch.
+Its introduction and CDN, npm, JavaScript API, and reference sections are
+available in both English and Japanese.

--- a/site/content/embed.en.js
+++ b/site/content/embed.en.js
@@ -1,0 +1,11 @@
+export default {
+  title: 'Embed mutsu in a web page',
+  intro: 'The GitHub Pages site uses the published <code>@tokuhirom/mutsu</code> npm package. The runnable component below is the same Web Component that applications install.',
+  cdnTitle: 'Use it directly from a CDN',
+  cdnBody: 'For a static page, add the component and load its module from jsDelivr. Pin a released version in production so an existing page does not change unexpectedly.',
+  npmTitle: 'Install it with npm',
+  npmBody: 'Bundled applications can import the component from the package. Its WebAssembly binary is included; users do not need Rust or wasm-pack.',
+  apiTitle: 'Use the JavaScript API',
+  apiBody: 'Use the lower-level API when the application provides its own editor or output UI.',
+  reference: 'The component also supports <code>readonly</code> and <code>session</code> attributes and emits a <code>mutsu-run</code> event. See the <a href="https://github.com/tokuhirom/mutsu/blob/main/docs/browser-embedding.md">complete embedding reference</a> for those options and the browser limitations.',
+};

--- a/site/content/embed.ja.js
+++ b/site/content/embed.ja.js
@@ -1,0 +1,11 @@
+export default {
+  title: 'mutsu を Web ページに組み込む',
+  intro: 'この GitHub Pages サイトは、npm で公開されている <code>@tokuhirom/mutsu</code> パッケージを使っています。下の実行可能な例は、アプリケーションからインストールできるものと同じ Web Component です。',
+  cdnTitle: 'CDN から直接使う',
+  cdnBody: '静的なページでは、コンポーネントを配置して jsDelivr からモジュールを読み込みます。本番環境ではリリースバージョンを固定すると、将来のリリースで既存ページの動作が変わるのを防げます。',
+  npmTitle: 'npm でインストールする',
+  npmBody: 'バンドラを使うアプリケーションでは、パッケージからコンポーネントを import できます。WebAssembly バイナリも含まれているため、利用者側に Rust や wasm-pack は必要ありません。',
+  apiTitle: 'JavaScript API を使う',
+  apiBody: '独自のエディタや出力 UI を用意する場合は、低レベル API を使います。',
+  reference: 'コンポーネントは <code>readonly</code> と <code>session</code> 属性にも対応し、実行完了時には <code>mutsu-run</code> イベントを発行します。各オプションとブラウザ版の制約については、<a href="https://github.com/tokuhirom/mutsu/blob/main/docs/browser-embedding.md">組み込みリファレンス</a>を参照してください。',
+};

--- a/site/e2e.test.mjs
+++ b/site/e2e.test.mjs
@@ -513,6 +513,12 @@ try {
          'the demo includes npm installation guidance');
   assert(await page.locator('a[aria-current="page"]').textContent() === 'Embed',
          'the embedding guide is linked from the site navigation');
+  await page.locator('.lang-switch button[data-lang="ja"]').click();
+  assert(await page.locator('#embed-title').textContent() === 'mutsu を Web ページに組み込む',
+         'switching to Japanese translates the embedding guide');
+  assert((await page.locator('#npm-body').textContent()).includes('WebAssembly バイナリ'),
+         'the Japanese view translates the integration instructions');
+  await page.locator('.lang-switch button[data-lang="en"]').click();
   const component = page.locator('mutsu-code');
   await component.locator('output').waitFor({ state: 'visible', timeout: 30000 });
   await page.waitForFunction(

--- a/site/embed-demo.html
+++ b/site/embed-demo.html
@@ -10,10 +10,8 @@
 <nav class="site-nav"></nav>
 
 <main class="manual section">
-  <h1>Embed mutsu in a web page</h1>
-  <p class="page-intro">The GitHub Pages site uses the published
-    <code>@tokuhirom/mutsu</code> npm package. The runnable component below is
-    the same Web Component that applications install.</p>
+  <h1 id="embed-title"></h1>
+  <p class="page-intro" id="embed-intro"></p>
 
   <mutsu-code autorun>
     <script type="text/raku">
@@ -23,10 +21,8 @@ say (^10).grep(* %% 2).sum;
   </mutsu-code>
 
   <section class="manual-section manual-body" id="cdn">
-    <h2><a href="#cdn">Use it directly from a CDN</a></h2>
-    <p>For a static page, add the component and load its module from jsDelivr.
-      Pin a released version in production so an existing page does not change
-      unexpectedly.</p>
+    <h2><a href="#cdn" id="cdn-title"></a></h2>
+    <p id="cdn-body"></p>
     <pre><code>&lt;mutsu-code autorun&gt;
   &lt;script type="text/raku"&gt;
 say "Hello from mutsu!";
@@ -39,17 +35,15 @@ say "Hello from mutsu!";
   </section>
 
   <section class="manual-section manual-body" id="npm">
-    <h2><a href="#npm">Install it with npm</a></h2>
-    <p>Bundled applications can import the component from the package. Its
-      WebAssembly binary is included; users do not need Rust or wasm-pack.</p>
+    <h2><a href="#npm" id="npm-title"></a></h2>
+    <p id="npm-body"></p>
     <pre><code>npm install @tokuhirom/mutsu</code></pre>
     <pre><code>import '@tokuhirom/mutsu/element';</code></pre>
   </section>
 
   <section class="manual-section manual-body" id="api">
-    <h2><a href="#api">Use the JavaScript API</a></h2>
-    <p>Use the lower-level API when the application provides its own editor or
-      output UI.</p>
+    <h2><a href="#api" id="api-title"></a></h2>
+    <p id="api-body"></p>
     <pre><code>import init, { evaluate, Repl } from '@tokuhirom/mutsu';
 
 await init();
@@ -58,18 +52,37 @@ console.log(evaluate('say "Hello"'));
 const repl = new Repl();
 console.log(JSON.parse(repl.evalLine('my $answer = 40')));
 console.log(JSON.parse(repl.evalLine('$answer + 2')));</code></pre>
-    <p>The component also supports <code>readonly</code> and
-      <code>session</code> attributes and emits a <code>mutsu-run</code> event.
-      See the <a href="https://github.com/tokuhirom/mutsu/blob/main/docs/browser-embedding.md">complete embedding reference</a>
-      for those options and the browser limitations.</p>
+    <p id="embed-reference"></p>
   </section>
 </main>
 
 <footer class="site-footer"></footer>
 <script type="module" src="pkg/embed.js"></script>
 <script type="module">
-import { renderChrome } from './assets/i18n.js';
+import { renderChrome, currentLang } from './assets/i18n.js';
+import embedEn from './content/embed.en.js';
+import embedJa from './content/embed.ja.js';
+
+const TEXT = { en: embedEn, ja: embedJa };
+
+function paint() {
+  const T = TEXT[currentLang()];
+  document.title = `${T.title} — mutsu`;
+  document.getElementById('embed-title').textContent = T.title;
+  document.getElementById('embed-intro').innerHTML = T.intro;
+  document.getElementById('cdn-title').textContent = T.cdnTitle;
+  document.getElementById('cdn-body').textContent = T.cdnBody;
+  document.getElementById('npm-title').textContent = T.npmTitle;
+  document.getElementById('npm-body').textContent = T.npmBody;
+  document.getElementById('api-title').textContent = T.apiTitle;
+  document.getElementById('api-body').textContent = T.apiBody;
+  document.getElementById('embed-reference').innerHTML = T.reference;
+}
+
 renderChrome('embed');
+paint();
+window.addEventListener('langchange', paint);
+document.body.dataset.ready = '1';
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Problem

The new GitHub Pages embedding guide rendered its navigation label in Japanese, but left the page title and all integration instructions fixed in English.

## Approach

- split embedding-guide copy into English and Japanese content modules
- repaint the title, introduction, CDN, npm, JavaScript API, and reference sections through the shared language state
- add browser E2E assertions for the Japanese view

## Test evidence

- `node site/e2e.test.mjs` — 116 passed
- `cargo fmt --all --check`
- `cargo clippy -- -D warnings`
- `MUTSU_PRECOMP=0 make test` — 3,577/3,578 files passed; only the test that deliberately expects precomp to be enabled differed
- targeted `t/precompilation.t` under the normal environment — 8 tests passed