### PR TITLE
fix(vm): defer bound array slice vivification

### DIFF
--- a/src/builtins/methods_0arg/raku_repr.rs
+++ b/src/builtins/methods_0arg/raku_repr.rs
@@ -489,6 +489,9 @@ fn raku_value_as_element(v: &Value) -> String {
             let inner = cell.lock().unwrap().clone();
             raku_value_as_element(&inner)
         }
+        // An out-of-range `:=`-bound slice element is a deferred entry token.
+        // Render its read-only hole value, never the implementation token.
+        ValueView::HashEntryRef { .. } => raku_value_as_element(&v.hash_entry_read()),
         _ => raku_value(v),
     }
 }
@@ -600,6 +603,7 @@ pub fn raku_value(v: &Value) -> String {
             let inner = cell.lock().unwrap().clone();
             raku_value(&inner)
         }
+        ValueView::HashEntryRef { .. } => raku_value(&v.hash_entry_read()),
         ValueView::Array(items, kind) => {
             // Lazy arrays should not be materialized
             if kind == crate::value::ArrayKind::Lazy {

--- a/src/value/value_methods_a.rs
+++ b/src/value/value_methods_a.rs
@@ -486,7 +486,13 @@ impl Value {
     /// Non-ContainerRef values are cloned as-is. Use [`Value::with_deref`] instead
     /// when you only need to read the inner value (it avoids the clone).
     pub fn deref_container(&self) -> Value {
-        self.with_deref(Value::clone)
+        self.with_deref(|inner| {
+            if matches!(inner.view(), ValueView::HashEntryRef { .. }) {
+                inner.hash_entry_read()
+            } else {
+                inner.clone()
+            }
+        })
     }
 
     /// Owned counterpart of [`Value::deref_container`]: read through a

--- a/src/vm/vm_helpers_junction.rs
+++ b/src/vm/vm_helpers_junction.rs
@@ -250,14 +250,24 @@ impl Interpreter {
     /// live value instead of the cell.
     pub(super) fn resolve_bound_array_elements(&self, val: Value) -> Value {
         if let ValueView::Array(items, kind) = val.view() {
-            let needs_resolve = items.iter().any(Value::is_container_ref);
+            let needs_resolve = items
+                .iter()
+                .any(|v| v.is_container_ref() || v.is_hash_entry_ref_value());
             if !needs_resolve {
                 return val;
             }
             let resolved: Vec<Value> = items
                 .iter()
                 .map(|v| match v.view() {
-                    ValueView::ContainerRef(cell) => cell.lock().unwrap().clone(),
+                    ValueView::ContainerRef(cell) => {
+                        let inner = cell.lock().unwrap().clone();
+                        if matches!(inner.view(), ValueView::HashEntryRef { .. }) {
+                            inner.hash_entry_read()
+                        } else {
+                            inner
+                        }
+                    }
+                    ValueView::HashEntryRef { .. } => v.hash_entry_read(),
                     _ => v.clone(),
                 })
                 .collect();

--- a/src/vm/vm_var_assign_local.rs
+++ b/src/vm/vm_var_assign_local.rs
@@ -118,7 +118,9 @@ impl Interpreter {
                 Some(ValueView::Bool(true))
             )
             && let ValueView::Array(items, ..) = self.locals[idx].view()
-            && items.iter().any(Value::is_container_ref)
+            && items
+                .iter()
+                .any(|v| v.is_container_ref() || v.is_hash_entry_ref_value())
         {
             let cells: Vec<Value> = items.iter().cloned().collect();
             let rhs_vals = self.assignment_rhs_values(&raw_val)?;
@@ -129,7 +131,12 @@ impl Interpreter {
                     .cloned()
                     .unwrap_or_else(|| Value::package(Symbol::intern("Any")));
                 if let ValueView::ContainerRef(cell) = cell_val.view() {
-                    *cell.lock().unwrap() = v.clone();
+                    Value::store_through_cell(&cell, &v);
+                } else if matches!(cell_val.view(), ValueView::HashEntryRef { .. }) {
+                    let cell =
+                        crate::gc::Gc::new(crate::value::ContainerCell::new(cell_val.clone()));
+                    Value::store_through_cell(&cell, &v);
+                    self.locals[idx].array_set_in_place(i, Value::container_ref(cell));
                 }
                 result.push(v);
             }

--- a/src/vm/vm_var_assign_local_get.rs
+++ b/src/vm/vm_var_assign_local_get.rs
@@ -338,6 +338,17 @@ impl Interpreter {
         // early return AND keep the non-container hot path move-only (into_deref is
         // never reached for non-ContainerRef values).
         if val.is_container_ref() {
+            // A deferred array entry carried by a bound slice lives inside a
+            // temporary cell until its first write. In value context unwrap it
+            // one more step so callers see the array hole, while lvalue context
+            // keeps the cell for `store_through_cell` to materialize.
+            if !keep_deferred_entry {
+                let inner = val.with_deref(|inner| inner.clone());
+                if matches!(inner.view(), ValueView::HashEntryRef { .. }) {
+                    self.stack.push(inner.hash_entry_read());
+                    return Ok(());
+                }
+            }
             // In container mode, an EMPTY cell is a live link of the lvalue
             // chain, not a value: `my @a; my $x := @a[0]; my $y := $x<k>`
             // promoted the array hole to a cell holding `Any`, and dereferencing

--- a/src/vm/vm_var_assign_set_local.rs
+++ b/src/vm/vm_var_assign_set_local.rs
@@ -46,7 +46,10 @@ impl Interpreter {
         }
         let cells: Vec<Value> = match holder.view() {
             ValueView::Array(items, ..)
-                if !items.is_empty() && items.iter().all(Value::is_container_ref) =>
+                if !items.is_empty()
+                    && items
+                        .iter()
+                        .all(|v| v.is_container_ref() || v.is_hash_entry_ref_value()) =>
             {
                 items.iter().cloned().collect()
             }
@@ -62,7 +65,11 @@ impl Interpreter {
                 .cloned()
                 .unwrap_or_else(|| Value::package(crate::symbol::Symbol::intern("Any")));
             if let ValueView::ContainerRef(cell) = cell_val.view() {
-                cell.lock().unwrap().clone_from(&v);
+                Value::store_through_cell(&cell, &v);
+            } else if matches!(cell_val.view(), ValueView::HashEntryRef { .. }) {
+                let cell = crate::gc::Gc::new(crate::value::ContainerCell::new(cell_val.clone()));
+                Value::store_through_cell(&cell, &v);
+                holder.array_set_in_place(i, Value::container_ref(cell));
             }
         }
         Some(Ok(()))
@@ -714,7 +721,9 @@ impl Interpreter {
                 Some(ValueView::Bool(true))
             )
             && let ValueView::Array(items, ..) = self.locals[idx].view()
-            && items.iter().any(Value::is_container_ref)
+            && items
+                .iter()
+                .any(|v| v.is_container_ref() || v.is_hash_entry_ref_value())
         {
             let cells: Vec<Value> = items.iter().cloned().collect();
             let rhs_vals = self.assignment_rhs_values(&raw_popped)?;
@@ -724,7 +733,16 @@ impl Interpreter {
                         .get(i)
                         .cloned()
                         .unwrap_or_else(|| Value::package(Symbol::intern("Any")));
-                    *cell.lock().unwrap() = v;
+                    Value::store_through_cell(&cell, &v);
+                } else if matches!(cell_val.view(), ValueView::HashEntryRef { .. }) {
+                    let v = rhs_vals
+                        .get(i)
+                        .cloned()
+                        .unwrap_or_else(|| Value::package(Symbol::intern("Any")));
+                    let cell =
+                        crate::gc::Gc::new(crate::value::ContainerCell::new(cell_val.clone()));
+                    Value::store_through_cell(&cell, &v);
+                    self.locals[idx].array_set_in_place(i, Value::container_ref(cell));
                 }
             }
             return Ok(());
@@ -1113,7 +1131,8 @@ impl Interpreter {
             }
             // Mark a genuine bound array SLICE (`@slice := @array[1,2]`, §4
             // BLOCKERS.md test 15): its OWN elements are shared `ContainerRef`
-            // cells from the bind-time slice promotion (`vm_var_index_ops.rs`).
+            // cells or deferred entry tokens from the bind-time slice promotion
+            // (`vm_var_index_ops.rs`).
             // This marker is the ONLY safe trigger for the write-through
             // behavior in `vm_var_assign_local.rs`/this file's non-bind path —
             // "elements are cells" alone is NOT a safe signal, since unrelated
@@ -1123,7 +1142,9 @@ impl Interpreter {
             if is_bind
                 && name.starts_with('@')
                 && let ValueView::Array(items, ..) = assigned.view()
-                && items.iter().any(Value::is_container_ref)
+                && items
+                    .iter()
+                    .any(|v| v.is_container_ref() || v.is_hash_entry_ref_value())
             {
                 self.env_mut()
                     .insert(Self::bound_array_slice_marker_key(name), Value::TRUE);

--- a/src/vm/vm_var_index_ops.rs
+++ b/src/vm/vm_var_index_ops.rs
@@ -297,17 +297,15 @@ impl Interpreter {
                     let cells = indices
                         .into_iter()
                         .map(|idx| {
-                            // TODO: compile to a deferred token like the
-                            // single-index bind above. A bound slice stays
-                            // EAGER for now: its promoted cells live in the
-                            // slice array itself, and an out-of-range index
-                            // would put a `HashEntryRef` vivification token
-                            // there, which the array read/display chokepoints
-                            // do not decontainerize. Growing first keeps the
-                            // aliasing exact at the cost of `my @s := @a[1,5]`
-                            // extending `@a` at bind time (raku defers).
-                            resolved.array_grow_to(idx);
-                            resolved.array_slot_ref(idx, true).unwrap_or(Value::NIL)
+                            // An out-of-range index is a deferred entry token.
+                            // Array reads and bound-slice assignment both handle
+                            // it, preserving the source array until first write.
+                            let slot = resolved.array_slot_ref(idx, true).unwrap_or(Value::NIL);
+                            if matches!(slot.view(), ValueView::HashEntryRef { .. }) {
+                                slot.into_container_ref()
+                            } else {
+                                slot
+                            }
                         })
                         .collect();
                     self.stack.push(Value::array(cells));

--- a/src/vm/vm_var_multidim_ops.rs
+++ b/src/vm/vm_var_multidim_ops.rs
@@ -85,7 +85,12 @@ impl Interpreter {
             // single-index `:=` bind (`my $s := @a[5]`). Restricted to holes by
             // `ensure_array_child` / `array_slot_ref`, so a read-only use over an
             // existing structure is untouched.
-            self.stack.push(cell);
+            self.stack
+                .push(if matches!(cell.view(), ValueView::HashEntryRef { .. }) {
+                    cell.into_container_ref()
+                } else {
+                    cell
+                });
             return Ok(());
         }
         let result = self.multi_dim_index_read(&target, &dims)?;
@@ -118,14 +123,9 @@ impl Interpreter {
                 .unwrap_or_else(|| dim.clone());
             let idx = Self::index_to_usize(&resolved)?;
             if terminal {
-                // TODO: hand out the deferred array token here too. This path is
-                // explicitly the EAGER one (see the caller's comment): its result
-                // is pushed straight onto the stack for `MultiDimIndexBindRef`,
-                // where a `HashEntryRef` token would leak into a plain read
-                // (`roast/S32-array/multislice-6e.t`'s `@array[0;0;3] gives Any`
-                // rows read the raw token instead of the hole). Grow first so the
-                // promotion still yields a cell.
-                cur.array_grow_to(idx);
+                // A missing terminal leaf stays deferred until a write through
+                // the bind. The normal token read and store paths supply its hole
+                // value and materialize the path when needed.
                 return cur.array_slot_ref(idx, true);
             }
             cur = cur.ensure_array_child(idx)?;
@@ -232,15 +232,15 @@ impl Interpreter {
         // dim) autovivifies, matching the assignment semantics.
         for i in indices {
             if terminal {
-                // TODO: hand out the deferred array token here too. Like the
-                // all-scalar autoviv path, this one is EAGER on purpose: the
-                // cells it collects become the elements of the slice list the
-                // caller pushes, and a `HashEntryRef` token there is neither
-                // decontainerized on read nor written through on assignment
-                // (`roast/S32-array/multislice-6e.t`'s `@array[*;0;3] = 999`).
-                // Grow first so the promotion still yields a cell.
-                cur.array_grow_to(i);
-                out.push(cur.array_slot_ref(i, true)?);
+                // Slice holders can carry deferred terminal tokens. Reads see
+                // their hole value and the first write replaces each token with
+                // its shared cell, so do not grow the source array here.
+                let slot = cur.array_slot_ref(i, true)?;
+                out.push(if matches!(slot.view(), ValueView::HashEntryRef { .. }) {
+                    slot.into_container_ref()
+                } else {
+                    slot
+                });
             } else {
                 let child = cur.ensure_array_child(i)?;
                 self.collect_multi_dim_leaf_cells(&child, rest, out)?;

--- a/src/vm/vm_var_ops.rs
+++ b/src/vm/vm_var_ops.rs
@@ -79,7 +79,14 @@ impl Interpreter {
                 }
                 // Phase 2 element container: a `:=`-bound entry holds a shared
                 // `ContainerRef` cell; decontainerize on read (the chokepoint).
-                ValueView::ContainerRef(cell) => cell.lock().unwrap().clone(),
+                ValueView::ContainerRef(cell) => {
+                    let inner = cell.lock().unwrap().clone();
+                    if matches!(inner.view(), ValueView::HashEntryRef { .. }) {
+                        inner.hash_entry_read()
+                    } else {
+                        inner
+                    }
+                }
                 _ => value.clone(),
             },
             None => Value::NIL,
@@ -145,6 +152,10 @@ impl Interpreter {
                 // `ContainerRef` cell. Reading the element decontainerizes it (the
                 // single read chokepoint), so value contexts never see the cell.
                 ValueView::ContainerRef(cell) => cell.lock().unwrap().clone(),
+                // A bound slice can hold a deferred array-entry token for an
+                // out-of-range element. Resolve it here just like a scalar bind:
+                // the read must report the array hole without growing the array.
+                ValueView::HashEntryRef { .. } => value.hash_entry_read(),
                 _ => value.clone(),
             },
             None => default,

--- a/t/array-slot-ref-deferred-vivification.t
+++ b/t/array-slot-ref-deferred-vivification.t
@@ -5,7 +5,7 @@ use Test;
 # grow the array at bind time (`array_slot_ref` pushed holes unconditionally),
 # so `@a.elems` reported 6 where rakudo reports 2.
 
-plan 23;
+plan 28;
 
 # --- bind without write: no growth, no pollution -------------------------
 {
@@ -86,4 +86,20 @@ plan 23;
     nok %h<zz>:exists, 'the hash :exists is still not polluted';
     $v = 5;
     is %h.raku, '{:a(1), :zz(5)}', 'the hash write still vivifies the key';
+}
+
+# --- bound slices defer out-of-range elements too ------------------------
+{
+    my @a = 1, 2;
+    my @s := @a[1,5];
+    is @a.raku, '[1, 2]', 'a bound slice does not grow its source at bind time';
+    is @s.raku, '(2, Any)', 'the deferred slice entry reads as its hole value';
+    @s = 8, 9;
+    is @a.raku, '[1, 8, Any, Any, Any, 9]',
+        'the first slice write fills the gap and writes through';
+    @a[5] = 99;
+    is @s.raku, '(8, 99)', 'a source write remains visible through the slice';
+    @s[1] = 77;
+    is @a.raku, '[1, 8, Any, Any, Any, 77]',
+        'an element write through the slice remains an alias';
 }


### PR DESCRIPTION
## Summary
- keep out-of-range bound slice and multidimensional leaves deferred until first write
- preserve read rendering and bidirectional write-through aliases with deferred cell holders
- add a bound slice regression test

## Validation
- `cargo clippy -- -D warnings`
- `make test` (one unrelated root-permission failure in `t/io-path-smartmatch-permissions.t`)
- `make roast`
- `MUTSU_FUDGE=1 prove -e 'target/debug/mutsu' roast/S32-array/multislice-6e.t`