### PR TITLE
fix: preserve proxy AT-POS lvalue captures

### DIFF
--- a/src/runtime/methods_mut_proxy.rs
+++ b/src/runtime/methods_mut_proxy.rs
@@ -12,6 +12,19 @@ impl Interpreter {
         instance_attrs: &AttrMap,
     ) -> Result<(Value, AttrMap), RuntimeError> {
         if let ValueView::Sub(data) = callback.view() {
+            // A Proxy callback is an ordinary escaping closure.  Its compiled
+            // body owns the lexical/upvalue bindings captured at construction;
+            // running the AST body below re-merges by name and can therefore
+            // replace a method-local capture with a same-named caller lexical.
+            // Keep the legacy path for uncompiled callbacks, but use the VM
+            // closure dispatcher whenever bytecode is available.
+            if let Some(compiled_code) = &data.compiled_code {
+                let empty_fns = crate::opcode::CompiledFns::default();
+                let compiled_fns = data.compiled_fns.as_deref().unwrap_or(&empty_fns);
+                let result =
+                    self.call_compiled_closure(&data, compiled_code, args, compiled_fns)?;
+                return Ok((result, instance_attrs.clone()));
+            }
             let saved_env = self.env.clone();
             let mut new_env = saved_env.clone();
             // Merge captured env. For user variables that already exist in the
@@ -127,7 +140,14 @@ impl Interpreter {
             self.call_proxy_callback(storer, vec![proxy_val, new_value.clone()], attributes)?;
         // Propagate attribute changes back to the instance's live cell.
         if let Some(var_name) = target_var {
-            attrs_cell.commit_attrs(updated);
+            // A VM-dispatched callback mutates captured instance cells directly.
+            // It returns the input snapshot here because it has no AST-env
+            // attribute overlay to merge; committing that unchanged snapshot
+            // would roll the just-completed STORE back. The legacy callback path
+            // still returns a changed map when it performed an overlay write.
+            if &updated != attributes {
+                attrs_cell.commit_attrs(updated);
+            }
             self.env.insert(
                 var_name.to_string(),
                 Value::instance_sharing_cell(attrs_cell, class_name, attrs_cell.instance_id()),

--- a/src/vm/vm_var_assign_index_named.rs
+++ b/src/vm/vm_var_assign_index_named.rs
@@ -353,6 +353,35 @@ impl Interpreter {
             && let ValueView::Instance { class_name, .. } = target.view()
         {
             let cls = class_name.resolve();
+            // A user-defined `is rw` AT-POS/AT-KEY owns the element container
+            // it returns.  In particular it may be a Proxy: evaluating the
+            // accessor as a normal rvalue FETCHes the Proxy before this store
+            // path can discover it, silently dropping its STORE callback.
+            // Route the indexed spelling through the established method-lvalue
+            // machinery, which invokes the accessor in lvalue context and
+            // writes through its returned container exactly once.
+            let at_method = if is_positional { "AT-POS" } else { "AT-KEY" };
+            let idx_arg = match idx.view() {
+                ValueView::Array(items, _) if items.len() == 1 => items[0].clone(),
+                _ => idx.clone(),
+            };
+            if self
+                .resolve_method_with_owner(&cls, at_method, std::slice::from_ref(&idx_arg))
+                .is_some_and(|(_, def)| def.is_rw)
+            {
+                let raw_val = self.stack.pop().unwrap_or(Value::NIL);
+                let (val, _) = Self::unwrap_bind_index_value(raw_val);
+                let assigned = self.assign_method_lvalue_with_values(
+                    Some(&var_name),
+                    target,
+                    at_method,
+                    vec![idx_arg],
+                    val,
+                    false,
+                )?;
+                self.stack.push(assigned);
+                return Ok(());
+            }
             // A `:=` element bind (`%h<c> := $x`) arrives with the RHS wrapped in
             // a `__mutsu_bind_index_value` marker; route it to the class's
             // BIND-KEY/BIND-POS when declared, so the class controls the bind

--- a/t/lexical-self-vs-invocant.t
+++ b/t/lexical-self-vs-invocant.t
@@ -8,7 +8,7 @@ use Test;
 # the closure was next called with, and the `Proxy` form of that recursed into
 # `FETCH` until the process died. ADR-0061 gives the lexical its own key.
 
-plan 29;
+plan 32;
 
 class Outer { method tag { 'OUTER' } }
 class Inner { method tag { 'INNER' } }
@@ -91,6 +91,27 @@ class Inner { method tag { 'INNER' } }
     }
     my $doc = C5b.new(attribs => { a => 1 });
     is $doc<a>, 1, 'a `my $self` + Proxy AT-KEY reads through FETCH';
+}
+
+# --- 5c. An ordinary same-named outer lexical must not replace a method-local
+#        capture in a deferred Proxy callback; the indexed lvalue must retain
+#        that Proxy long enough to invoke STORE.
+{
+    my $slf = 'mainline';
+    class C5c {
+        has @.nodes;
+        method AT-POS($offset) is rw {
+            my $slf = self;
+            Proxy.new(
+                FETCH => method () { $slf.nodes[$offset] },
+                STORE => method ($val) { $slf.nodes[$offset] = $val },
+            )
+        }
+    }
+    my $doc = C5c.new(nodes => ['x', 'y']);
+    is $doc[1], 'y', 'a Proxy FETCH keeps its method-local ordinary lexical capture';
+    is ($doc[0] = 'z'), 'z', 'an indexed rw AT-POS assignment invokes Proxy STORE';
+    is $doc[0], 'z', 'Proxy STORE persists through the captured method-local object';
 }
 
 # --- 6. NEGATIVE: an explicit invocant parameter genuinely named `self`.


### PR DESCRIPTION
## Problem
An `is rw` `AT-POS` Proxy could lose both its deferred method-local capture and its `STORE` write-back when accessed through indexed syntax.

## Approach
Dispatch compiled Proxy callbacks through the VM closure path and retain raw Proxy containers for indexed rw accessor assignment.

## Validation
- `make test`
- `make roast`
- `cargo clippy -- -D warnings`