### PR TITLE
fix(vm): capture routine lexicals in class methods

### DIFF
--- a/src/compiler/decl_plan.rs
+++ b/src/compiler/decl_plan.rs
@@ -233,6 +233,11 @@ impl Compiler {
         } else {
             None
         };
+        let method_outer_lexical_slots = self
+            .local_map
+            .iter()
+            .map(|(name, slot)| (crate::symbol::Symbol::intern(name), *slot))
+            .collect();
         // Class-body methods auto-detect a bare `@_` read the way
         // `class_body_method_decl` does (`apply_auto_positional_slurpy:
         // true`); `is_hidden` gates the implicit `*%_` the same way too.
@@ -252,6 +257,7 @@ impl Compiler {
             method_name_chunks,
             parent_arg_chunks,
             method_compiled_keys,
+            method_outer_lexical_slots,
             body_plan,
         )
     }

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -3050,6 +3050,10 @@ pub(crate) struct CompiledClassDeclPlan {
     /// reads a clone by position instead of calling `CompiledMethodDecl::from_stmt`
     /// on the raw statement every time the class declaration executes.
     pub(crate) method_decls: Vec<CompiledMethodDecl>,
+    /// Lexicals visible in the enclosing frame at this declaration site.
+    /// Method compilation uses a fresh scope, so this distinguishes genuine
+    /// outer lexicals from class-body statics and lexicals declared later.
+    pub(crate) method_outer_lexical_slots: Vec<(Symbol, u32)>,
     /// Names the class body `my`/`state`-declares at its own top level
     /// (ADR-0019 D6-1), precomputed at plan lowering instead of
     /// `persist_class_body_statics` re-walking the raw body on every
@@ -7311,6 +7315,7 @@ impl CompiledCode {
         method_name_chunks: Vec<Option<CompiledDeclExpr>>,
         parent_arg_chunks: Vec<(String, Vec<DeclTraitArg>)>,
         method_compiled_keys: Vec<Option<Symbol>>,
+        method_outer_lexical_slots: Vec<(Symbol, u32)>,
         body_plan: Vec<ClassBodyOp>,
     ) -> u32 {
         let Stmt::ClassDecl {
@@ -7372,6 +7377,7 @@ impl CompiledCode {
             attr_decls,
             method_name_chunks,
             method_decls,
+            method_outer_lexical_slots,
             declared_static_names,
             parent_arg_chunks,
             body_plan,

--- a/src/runtime/decl_types.rs
+++ b/src/runtime/decl_types.rs
@@ -126,15 +126,12 @@ pub(crate) struct MethodDef {
     pub(crate) deprecated_message: Option<String>,
     /// Whether this is a submethod (not inherited by subclasses).
     pub(crate) is_submethod: bool,
-    /// Frozen closure environment for a method installed via `.^add_method`
-    /// with a closure literal (`method { $captured }`). A method AST normally
-    /// carries no captured lexicals, but a meta-programmed method can close over
-    /// its creating scope (e.g. Attribute::Predicate's `is predicate` builds
-    /// `method { attr.get_value(self).defined }`, capturing `attr`). Those
-    /// captures live only in the source `Sub`'s env, which the plain
-    /// body+compiled_code MethodDef would drop. When set, the method dispatch
-    /// merges these names into the body env (params/self take precedence) so a
-    /// by-name read resolves the capture. `None` for ordinary declared methods.
+    /// Captured lexical environment for a method. This is populated for a method
+    /// installed via `.^add_method` with a closure literal and for a class method
+    /// declared inside a routine. In both cases, the plain body+compiled-code
+    /// `MethodDef` would otherwise drop the defining scope. Method dispatch and
+    /// candidate matching overlay these bindings so body reads and declaration-
+    /// time parameter expressions resolve lexically.
     pub(crate) captured_env: Option<crate::env::Env>,
     /// Source file the method body was declared in (None = main script or a
     /// synthetic/native method with no real source). Flows into the pushed

--- a/src/runtime/resolution_method.rs
+++ b/src/runtime/resolution_method.rs
@@ -37,6 +37,26 @@ impl Interpreter {
                 self.env.insert(name.clone(), value.clone());
             }
         }
+        // A declared class method can close over the routine that registered
+        // its class. Candidate matching evaluates `where` constraints before
+        // the method call installs its bytecode environment, so make the
+        // captured lexical scope available here as well.
+        if let Some(captured) = &def.captured_env {
+            let authoritative = captured.contains_key_sym(crate::symbol::Symbol::intern(
+                "__mutsu_declared_method_capture",
+            ));
+            for (sym, value) in captured.iter() {
+                if !sym.with_str(|name| {
+                    matches!(
+                        name,
+                        "self" | "?CLASS" | "?ROLE" | "__mutsu_declared_method_capture"
+                    )
+                }) && (authoritative || !self.env.contains_key_sym(*sym))
+                {
+                    self.env.insert_sym(*sym, value.clone());
+                }
+            }
+        }
         for pd in &def.param_defs {
             if !(pd.is_invocant || pd.traits.iter().any(|t| t == "invocant")) {
                 continue;

--- a/src/vm/vm_method_dispatch.rs
+++ b/src/vm/vm_method_dispatch.rs
@@ -469,15 +469,22 @@ impl Interpreter {
             }
         }
 
-        // A method installed via `.^add_method` with a closure literal
-        // (`anon method { $captured }` — OO::Monitors' POPULATE hook) carries
-        // the frozen creating-scope env so its captures still resolve after
-        // that scope is gone. Merge those names in (self/params inserted
-        // above/below win). Mirrors the same merge in the fast path.
+        // A method can carry its defining lexical environment either from an
+        // `.^add_method` closure literal or from a class declared in a routine.
+        // Install these true lexical captures before parameter binding.
         if let Some(captured) = &method_def.captured_env {
             let env = self.env_mut();
+            let authoritative = captured.contains_key_sym(crate::symbol::Symbol::intern(
+                "__mutsu_declared_method_capture",
+            ));
             for (sym, val) in captured.iter() {
-                if !env.contains_key_sym(*sym) {
+                if !sym.with_str(|name| {
+                    matches!(
+                        name,
+                        "self" | "?CLASS" | "?ROLE" | "__mutsu_declared_method_capture"
+                    )
+                }) && (authoritative || !env.contains_key_sym(*sym))
+                {
                     env.insert_sym(*sym, val.clone());
                 }
             }
@@ -1689,15 +1696,22 @@ impl Interpreter {
             self.env_mut().insert("%_".to_string(), slurpy.clone());
         }
 
-        // A method installed via `.^add_method` with a closure literal
-        // (`method { $captured }`) carries the frozen creating-scope env so its
-        // captures still resolve after that scope is gone. Merge those names in
-        // (params/self/attrs inserted above win) so the locals-population loop
-        // below picks them up via its by-name `self.env().get(name)` fallback.
+        // A method can carry its defining lexical environment either from an
+        // `.^add_method` closure literal or from a class declared in a routine.
+        // The fast path populates free-variable locals from this overlay.
         if let Some(captured) = &method_def.captured_env {
             let env = self.env_mut();
+            let authoritative = captured.contains_key_sym(crate::symbol::Symbol::intern(
+                "__mutsu_declared_method_capture",
+            ));
             for (sym, val) in captured.iter() {
-                if !env.contains_key_sym(*sym) {
+                if !sym.with_str(|name| {
+                    matches!(
+                        name,
+                        "self" | "?CLASS" | "?ROLE" | "__mutsu_declared_method_capture"
+                    )
+                }) && (authoritative || !env.contains_key_sym(*sym))
+                {
                     env.insert_sym(*sym, val.clone());
                 }
             }

--- a/src/vm/vm_register_ops.rs
+++ b/src/vm/vm_register_ops.rs
@@ -266,6 +266,117 @@ impl Interpreter {
         installed
     }
 
+    /// Snapshot the lexical variables a class method closes over at its
+    /// declaration site.  Class registration stores a `MethodDef`, rather than
+    /// a `SubData`, so it does not otherwise go through `capture_closure_env`.
+    /// In particular, a `my` declared in a routine body can exist only in that
+    /// frame's local-slot store when the class is registered.
+    pub(crate) fn capture_declared_method_envs(
+        &mut self,
+        code: &CompiledCode,
+        class: &str,
+        outer_lexical_slots: &[(Symbol, u32)],
+    ) {
+        let method_codes: Vec<(std::sync::Arc<CompiledCode>, Vec<Symbol>)> = {
+            let registry = self.registry();
+            registry
+                .owner_method_names(class)
+                .into_iter()
+                .flat_map(|name| {
+                    registry
+                        .user_method_overloads(class, &name.resolve())
+                        .into_iter()
+                        .flatten()
+                        .filter_map(|def| {
+                            (def.role_origin.is_none())
+                                .then(|| def.compiled_code.clone())
+                                .flatten()
+                                .map(|code| {
+                                    let compiler = crate::compiler::Compiler::new();
+                                    let signature_reads =
+                                        compiler.decl_time_param_free_var_syms(&def.param_defs);
+                                    (code, signature_reads)
+                                })
+                        })
+                })
+                .collect()
+        };
+        let mut captures: std::collections::HashMap<usize, Vec<Env>> =
+            std::collections::HashMap::new();
+        for (method_code, signature_reads) in method_codes {
+            let mut capture_syms = method_code.free_var_syms.clone();
+            for sym in signature_reads {
+                if !capture_syms.contains(&sym) {
+                    capture_syms.push(sym);
+                }
+            }
+            // The method compiler is deliberately independent of its enclosing
+            // scope. Restrict its free reads to lexicals actually in scope at
+            // this class declaration, rather than guessing from every slot in
+            // this chunk: a class static or later `$x` must not replace the
+            // method's normal environment.
+            capture_syms.retain(|sym| outer_lexical_slots.iter().any(|(outer, _)| outer == sym));
+            if capture_syms.is_empty() {
+                continue;
+            }
+            // A class may be used before its declaring routine returns, so this
+            // is a live lexical capture, not merely an escaping-value snapshot.
+            // Put each directly-owned captured slot in a shared cell before the
+            // method environment takes its copy; later stores in the routine and
+            // reads/writes through the method then keep one container.
+            let capture_slots: Vec<(Symbol, usize)> = capture_syms
+                .iter()
+                .filter_map(|sym| {
+                    outer_lexical_slots
+                        .iter()
+                        .find(|(outer, _)| outer == sym)
+                        .map(|(_, slot)| (*sym, *slot as usize))
+                })
+                .collect();
+            for (_, slot) in &capture_slots {
+                self.box_decl_local_cell(code, *slot);
+            }
+            let mut env = Env::new();
+            // Declaration-time parameter expressions are evaluated from their
+            // AST, not from bytecode. Keep their reads in the method capture
+            // even when an older/on-demand compiled body did not fold them into
+            // `free_var_syms` yet.
+            for (sym, slot) in &capture_slots {
+                if let Some(value) = self.locals.get(*slot) {
+                    env.insert_sym(*sym, value.clone());
+                }
+            }
+            let declared_method_capture = Symbol::intern("__mutsu_declared_method_capture");
+            env.insert_sym(declared_method_capture, Value::int(1));
+            env.retain(|sym, _| {
+                *sym == declared_method_capture
+                    || (capture_syms.contains(sym)
+                        && sym.with_str(crate::env::is_plain_user_lexical))
+            });
+            if !env.is_empty() {
+                captures
+                    .entry(std::sync::Arc::as_ptr(&method_code) as usize)
+                    .or_default()
+                    .push(env);
+            }
+        }
+        if captures.is_empty() {
+            return;
+        }
+        self.registry_mut().map_user_methods_in_place(
+            crate::symbol::Symbol::intern(class),
+            |def| {
+                let Some(method_code) = &def.compiled_code else {
+                    return;
+                };
+                let key = std::sync::Arc::as_ptr(method_code) as usize;
+                if let Some(env) = captures.get_mut(&key).and_then(Vec::pop) {
+                    def.captured_env = Some(env);
+                }
+            },
+        );
+    }
+
     pub(super) fn exec_make_anon_sub_op(
         &mut self,
         code: &CompiledCode,

--- a/src/vm/vm_typedecl_ops.rs
+++ b/src/vm/vm_typedecl_ops.rs
@@ -162,6 +162,7 @@ impl Interpreter {
             attr_decls,
             method_name_chunks,
             method_decls,
+            method_outer_lexical_slots,
             declared_static_names,
             parent_arg_chunks,
             body_plan,
@@ -378,6 +379,7 @@ impl Interpreter {
             // compiles that one body on demand.
             if !is_hoisted_shell {
                 self.compile_class_methods(&storage_name);
+                self.capture_declared_method_envs(code, &storage_name, method_outer_lexical_slots);
             }
             // Register the class name in the lexical env so that
             // ::("ClassName") indirect lookups can find it in the current scope.

--- a/t/class-in-routine-lexical-capture.t
+++ b/t/class-in-routine-lexical-capture.t
@@ -1,0 +1,31 @@
+use Test;
+
+plan 5;
+
+sub make-reader() {
+    my $captured = 2;
+    class Reader { method value() { $captured } }
+    Reader.new;
+}
+is make-reader().value, 2, 'a class method captures its declaring routine lexical';
+
+sub make-constrained-reader() {
+    my $allowed = 2;
+    class ConstrainedReader { method value($value where $allowed) { $value } }
+    ConstrainedReader.new;
+}
+lives-ok { is make-constrained-reader().value(2), 2 },
+    'a class method where constraint captures its declaring routine lexical';
+
+my $captured = 99;
+is make-reader().value, 2,
+    'a returned class method capture overrides a same-named caller lexical';
+
+sub read-after-write() {
+    my $value = 1;
+    class LiveReader { method value() { $value } }
+    $value = 3;
+    LiveReader.new.value;
+}
+is read-after-write(), 3,
+    'a class method shares its lexical while the declaring routine is still active';


### PR DESCRIPTION
## Problem
Classes declared inside routines lost routine-local lexicals in their methods and parameter `where` constraints.

## Approach
Capture slot-owned routine lexicals when class methods register, preserve them during candidate matching and dispatch, and share a live cell while the declaring routine remains active.

## Tests
- Targeted TAP regressions
- Method byte-parity subset
- Affected roast binding test
- `cargo clippy -- -D warnings`

Full `make test` and `make roast` were each run once before the final follow-up fixes; repository policy prevented local reruns in the same session.