### PR TITLE
fix(parser): accept an empty or trailing-comma colonpair arglist in a hash literal

### DIFF
--- a/src/parser/primary/misc/hash.rs
+++ b/src/parser/primary/misc/hash.rs
@@ -317,6 +317,14 @@ fn parse_colon_pair_entry(input: &str) -> PResult<'_, (String, Option<Expr>)> {
     if r.starts_with('(') {
         let (r, _) = parse_char(r, '(')?;
         let (r, _) = ws_inner(r);
+        // `:name()` — an EMPTY argument list. There is no expression to parse,
+        // so the general path below would fail the whole brace body and the
+        // enclosing statement with it (`my @a = { :op<replace>, :path(), ... }`
+        // used to be a parse error). The value is the empty list, matching the
+        // colonpair parser used outside a hash literal.
+        if let Some(after) = r.strip_prefix(')') {
+            return Ok((after, (name, Some(Expr::ArrayLiteral(Vec::new())))));
+        }
         let (r, first) = expression(r)?;
         let (r, _) = ws_inner(r);
         if r.starts_with(',') {
@@ -325,6 +333,13 @@ fn parse_colon_pair_entry(input: &str) -> PResult<'_, (String, Option<Expr>)> {
             while r.starts_with(',') {
                 let (r2, _) = parse_char(r, ',')?;
                 let (r2, _) = ws_inner(r2);
+                // A TRAILING comma (`:path('a',)`) closes the list. Raku reads
+                // it as a one-element List, so keep the collected items and
+                // stop rather than demanding another expression.
+                if r2.starts_with(')') {
+                    r = r2;
+                    break;
+                }
                 let (r2, next) = expression(r2)?;
                 let (r2, _) = ws_inner(r2);
                 items.push(next);

--- a/t/hash-literal-colonpair-arglist-edges.t
+++ b/t/hash-literal-colonpair-arglist-edges.t
@@ -1,0 +1,69 @@
+use Test;
+
+# Inside a `{ ... }` hash literal the colonpair parser has its own argument-list
+# reader, and it demanded at least one expression between the parens. Two shapes
+# that rakudo accepts therefore failed the WHOLE enclosing statement with
+# "Confused. expected statement":
+#
+#   my $h = { :a() };            # an EMPTY argument list
+#   my $h = { :a('x',) };        # a TRAILING comma
+#
+# Both come straight out of Crane's `t/patch.rakutest`
+# (`{ :op<replace>, :path(), :value(1) }`), which could not be compiled at all.
+# Outside a hash literal the general colonpair parser already accepted both.
+
+plan 14;
+
+# --- empty argument list -------------------------------------------------
+{
+    my $h = { :a() };
+    is $h.raku, '${:a($( ))}', 'an empty colonpair arglist parses in a hash literal';
+    is $h<a>.elems, 0, 'the value is the empty list';
+}
+{
+    my $h = { :a(), :b(2) };
+    is $h.raku, '${:a($( )), :b(2)}', 'an empty arglist mixes with ordinary pairs';
+}
+{
+    my $h = { :a(), };
+    is $h.raku, '${:a($( ))}', 'a trailing comma after the pair is fine too';
+}
+
+# --- trailing comma in the argument list ---------------------------------
+{
+    my $h = { :p('a',) };
+    is $h.raku, '${:p($("a",))}', 'a trailing comma keeps a one-element list';
+    is $h<p>.elems, 1, 'the one-element list has one element';
+}
+{
+    my $h = { :p(1, 2,) };
+    is $h.raku, '${:p($(1, 2))}', 'a trailing comma after several items';
+    is $h<p>.elems, 2, 'the multi-element list is unchanged';
+}
+
+# --- both shapes together, as Crane spells them --------------------------
+{
+    my @patch = { :op<replace>, :path(), :value(1) },;
+    is @patch.raku, '[{:op("replace"), :path($( )), :value(1)},]',
+        'the empty-path patch element from Crane parses';
+    is @patch.elems, 1, 'the trailing comma makes it a one-element array';
+}
+{
+    my @patch = { :op<replace>, :path('a',), :value<Alpha> },;
+    is @patch.raku, '[{:op("replace"), :path($("a",)), :value("Alpha")},]',
+        'the one-element-path patch element from Crane parses';
+}
+
+# --- non-regression: the shapes that already worked ----------------------
+{
+    my $h = { :a(1) };
+    is $h.raku, '${:a(1)}', 'a single argument is still a plain value, not a list';
+}
+{
+    my $h = { :a(1, 2) };
+    is $h.raku, '${:a($(1, 2))}', 'several arguments still make a list';
+}
+{
+    my $h = { :a[], :b{} };
+    is $h.raku, '${:a($[]), :b(${})}', 'the [] and {} colonpair forms are untouched';
+}

--- a/todo/tickets/bundle-config-toml-once-parser-fixed.md
+++ b/todo/tickets/bundle-config-toml-once-parser-fixed.md
@@ -15,7 +15,24 @@ as an actual battery — once its blockers clear. It is intentionally separate
 from the blockers themselves so none of those interpreter fixes is scoped to
 also cover packaging/docs/CI work.
 
-## Current measurement (2026-08-26)
+## Current measurement (2026-08-31)
+
+Re-run of the `Crane` v0.1.2 suite against a debug build: still **3/15**
+(`at`, `exists`, `test` — the ticket's earlier list named `flatten` instead of
+`exists`, so the passing set has shifted without the count moving). The gate is
+still closed; do not start the vendoring steps.
+
+What did change: blocker 2 below (`t/patch.rakutest` fails to *parse*) is
+**fixed**. It bisected to the hash-literal colonpair argument reader, which
+demanded at least one expression between the parens and so rejected both
+`{ :path() }` (an empty argument list) and `{ :path('a',) }` (a trailing
+comma) — the two shapes every `Crane` patch element is written in. Both are
+general parser bugs unrelated to `Crane`; fixed with
+`t/hash-literal-colonpair-arglist-edges.t` as the pin. `t/patch.rakutest` now
+compiles and runs, and fails on blocker 1 (the array-path descent) like the
+rest of the suite.
+
+## Previous measurement (2026-08-26)
 
 Re-measured from a fresh REA fetch of both dists, running each upstream suite
 from its own directory (`Config::TOML` with `Crane` on `MUTSULIB`) against a
@@ -52,7 +69,9 @@ first:
    vivification token both landed 2026-08-22 — ADR-0059 and
    `news/2026-08/deferred-vivification-path-steps-are-typed.md` — so those two
    are no longer the gate.)
-2. `t/patch.rakutest` fails to *parse* under mutsu; not yet bisected.
+2. ~~`t/patch.rakutest` fails to *parse* under mutsu; not yet bisected.~~
+   **Fixed 2026-08-31** — see the measurement note above. The file parses and
+   runs now; it fails on blocker 1.
 3. The 8-hex `\UXXXXXXXX` string escape still reports
    "bad string escape sequence 「U」", blocking `grammar/04` and
    `grammar-actions/04`.


### PR DESCRIPTION
## Symptom

Inside a `{ ... }` hash literal the colonpair parser has its own argument-list reader (`parse_colon_pair_entry`), and it called `expression()` unconditionally after the opening paren. Two shapes rakudo accepts therefore failed the **whole enclosing statement** with `Confused. expected statement`:

```raku
my $h = { :a() };        # an EMPTY argument list
my $h = { :a('x',) };    # a TRAILING comma
```

The general colonpair parser used *outside* a hash literal already accepted both, so `(:a())` worked while `{ :a() }` did not.

## Fix

- `:name()` yields the empty list (`Expr::ArrayLiteral(vec![])`) — the same node the outside-braces parser already produces.
- The argument loop treats a comma followed by `)` as the end of the list instead of demanding another expression, so `:p('a',)` stays the one-element List raku makes of it.

## How it was found

Re-measuring `todo/tickets/bundle-config-toml-once-parser-fixed.md`. Crane writes every patch element as `{ :op<replace>, :path(), :value(1) }`, so `t/patch.rakutest` could not be compiled at all (blocker 2 on that ticket). It parses and runs now, and fails on the ticket's remaining blocker (the array-path descent) like the rest of the suite.

The ticket is updated with the re-measurement — **Crane is still 3/15, so its vendoring gate stays closed** — and blocker 2 is struck through.

## Testing

- New `t/hash-literal-colonpair-arglist-edges.t`, 14 assertions covering both shapes, their combinations, the two Crane spellings verbatim, and the already-working `:a(1)` / `:a(1,2)` / `:a[]` / `:a{}` forms. **The whole file passes under `raku` as well as mutsu.**
- `make test`: 3583 files / 35881 tests PASS.
- Targeted roast sweeps: `S02-types` `S32-hash` `S06-*` `S03-operators` `S12-*` (339 files) and `S02-literals` `S04-*` `S05-*` `S09-*` (220 files): all PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)