### PR TITLE
fix: coercion parameters in dispatch, and junction args bound by a slurpy

### DIFF
--- a/src/runtime/class_introspection.rs
+++ b/src/runtime/class_introspection.rs
@@ -43,10 +43,15 @@ impl Interpreter {
                     let has_matching_positional = method.param_defs.iter().any(|pd| {
                         !pd.named
                             && !pd.is_invocant
+                            // An UNTYPED positional is an `Any` parameter, which
+                            // accepts the value: `method new($v) { self.bless(:$v) }`
+                            // is an explicit positional constructor and rakudo
+                            // coerces through it. Only the default constructor
+                            // (named-only params) must stay out of coercion.
                             && pd
                                 .type_constraint
                                 .as_deref()
-                                .is_some_and(|tc| self.type_matches_value(tc, value))
+                                .is_none_or(|tc| self.type_matches_value(tc, value))
                     });
                     if has_matching_positional {
                         return true;
@@ -55,6 +60,19 @@ impl Interpreter {
             }
         }
         false
+    }
+
+    /// Whether any class in `class_name`'s MRO declares a user-written `new`.
+    /// `false` means every `new` reachable on it is the native/default
+    /// constructor, whose signature is not in the method registry — so
+    /// [`Self::class_has_new_accepting_positional`], which only inspects user
+    /// overloads, cannot answer for it.
+    pub(super) fn class_declares_user_new(&mut self, class_name: &str) -> bool {
+        self.class_mro(class_name).iter().any(|cn| {
+            self.registry()
+                .user_method_overloads(cn.as_str(), "new")
+                .is_some()
+        })
     }
 
     /// Hardcoded native-method names for the handful of built-in classes

--- a/src/runtime/types/args_matching.rs
+++ b/src/runtime/types/args_matching.rs
@@ -53,6 +53,14 @@ impl Interpreter {
 
     fn coercion_dispatch_value(&mut self, constraint: &str, arg: &Value) -> Option<Value> {
         let (target, source) = parse_coercion_type(constraint)?;
+        // Rakudo compiles `T(F)` into TWO candidates — one taking `T` directly
+        // and one taking `F` and coercing (see `effective_dispatch_constraint`).
+        // An argument that is already a `T` therefore binds without any
+        // coercion: `multi sub open-xml (IO::Path(Str) $src)` accepts an
+        // `IO::Path` as well as a `Str`.
+        if self.type_matches_value(target, arg) {
+            return Some(arg.clone());
+        }
         if let Some(src) = source
             && !self.type_matches_value(src, arg)
         {
@@ -285,6 +293,12 @@ impl Interpreter {
                 {
                     return false;
                 }
+                // A coercion parameter's `where` (and sub-/code-signature) runs
+                // against the COERCED value in rakudo, not the raw argument:
+                // `IO::Path(Str) $s where :f` calls `.f` on the IO::Path.
+                // Filled in by the type-constraint block below, applied to
+                // `arg_for_checks` once its borrow of it has ended.
+                let mut coerced_for_checks: Option<Value> = None;
                 if let Some(constraint) = &pd.type_constraint
                     && let Some(arg) = arg_for_checks.as_ref()
                 {
@@ -385,6 +399,12 @@ impl Interpreter {
                     } else if !self.type_matches_value(&resolved_constraint, &dispatch_arg) {
                         return false;
                     }
+                    if is_coercion_constraint(&resolved_constraint) {
+                        coerced_for_checks = Some(dispatch_arg);
+                    }
+                }
+                if let Some(coerced) = coerced_for_checks {
+                    arg_for_checks = Some(coerced);
                 }
                 // Implicit Any constraint: untyped $ parameters reject Junction type objects
                 if pd.type_constraint.is_none()

--- a/src/runtime/types/coercion.rs
+++ b/src/runtime/types/coercion.rs
@@ -298,7 +298,20 @@ impl Interpreter {
             // but only if there's an explicit `new` variant that accepts a
             // positional parameter matching the value type.  The default
             // constructor (named-only params) must NOT be used for coercion.
-            if self.class_has_new_accepting_positional(&remapped_base_target, &value)
+            // A class whose MRO declares no user `new` at all is a NATIVE class
+            // (`IO::Path`, `Version`, ...). `class_has_new_accepting_positional`
+            // only inspects user overloads, so it can never say yes for one, and
+            // its `new` is a native constructor whose signature is not in the
+            // registry to inspect. Rakudo's coercion protocol ends in
+            // `TargetType.new($value)` either way — `IO::Path(Str)` binds through
+            // `IO::Path.new("...")` (`XML`'s
+            // `multi sub open-xml (IO::Path(Str) $src where :f)`), which mutsu
+            // used to reject with X::Coerce::Impossible. The result still has to
+            // type-match the target, so a `new` that does not build one falls
+            // through to the error below exactly as before.
+            let try_new = self.class_has_new_accepting_positional(&remapped_base_target, &value)
+                || !self.class_declares_user_new(&remapped_base_target);
+            if try_new
                 && let Ok(coerced) = self.call_method_with_values(
                     Value::package(Symbol::intern(&remapped_base_target)),
                     "new",

--- a/src/vm/vm_call_autothread.rs
+++ b/src/vm/vm_call_autothread.rs
@@ -136,73 +136,7 @@ impl Interpreter {
         let pds = param_defs.unwrap();
 
         // Filter to only junction args whose parameter does NOT accept Junction
-        let autothread_indices: Vec<usize> = junction_indices
-            .into_iter()
-            .filter(|&idx| {
-                // Check if the arg is a named arg (Pair) — find matching named param
-                if let ValueView::Pair(key, _) = args[idx].view() {
-                    if let Some(pd) = pds
-                        .iter()
-                        .find(|pd| pd.named && !pd.slurpy && !pd.double_slurpy && pd.name == *key)
-                    {
-                        if let Some(tc) = &pd.type_constraint {
-                            let nominal = Self::nominal_type(tc.as_str());
-                            if matches!(nominal, "Mu" | "Junction") {
-                                return false;
-                            }
-                            let resolved_base = self.resolve_subset_base_type(nominal);
-                            return !matches!(resolved_base.as_str(), "Mu" | "Junction");
-                        }
-                        return true; // No type constraint = default Any
-                    }
-                    // No explicit named param matched. A slurpy hash (`*%h`, the
-                    // implicit `%_`, `+%h`) captures the named argument as a raw
-                    // value, so a Junction is stored as-is rather than threaded.
-                    // A slurpy hash is a slurpy param whose sigil is `%` (a
-                    // slurpy `*@a` only collects positionals, not named args).
-                    if pds.iter().any(|pd| {
-                        (pd.slurpy || pd.double_slurpy || pd.onearg) && pd.name.starts_with('%')
-                    }) {
-                        return false;
-                    }
-                    return true; // No slurpy hash to collect it — auto-thread
-                }
-
-                // Positional arg — find corresponding positional param
-                let positional_pds: Vec<&crate::ast::ParamDef> =
-                    pds.iter().filter(|pd| !pd.named).collect();
-                if let Some(pd) = positional_pds.get(idx) {
-                    // A slurpy param (`*@a`, `+@a`, `**@a`) collects its elements
-                    // as raw Mu values, so a Junction argument is captured as-is
-                    // rather than auto-threaded.
-                    if pd.slurpy || pd.onearg || pd.double_slurpy {
-                        return false;
-                    }
-                    // Don't auto-thread if param accepts Mu or Junction.
-                    // For coercion types like `Bool(Mu)`, the nominal type is the
-                    // inner type (Mu here) — autothreading is based on the nominal.
-                    if let Some(tc) = &pd.type_constraint {
-                        let nominal = Self::nominal_type(tc.as_str());
-                        if matches!(nominal, "Mu" | "Junction") {
-                            return false;
-                        }
-                        // Don't auto-thread if the type constraint is a subset
-                        // whose ultimate base type is Mu or Junction — the
-                        // junction should be passed as-is to the subset's
-                        // where-clause check.
-                        let resolved_base = self.resolve_subset_base_type(nominal);
-                        if matches!(resolved_base.as_str(), "Mu" | "Junction") {
-                            return false;
-                        }
-                        return true;
-                    }
-                    // No type constraint means default Any — needs auto-threading
-                    return true;
-                }
-                // If param is slurpy or we're past the defined params, don't auto-thread
-                false
-            })
-            .collect();
+        let autothread_indices = self.autothread_indices_for_params(args, &junction_indices, &pds);
 
         if autothread_indices.is_empty() {
             return Ok(None);
@@ -435,6 +369,33 @@ impl Interpreter {
             return Ok(None);
         }
 
+        // When the receiver is a user class instance whose method we can resolve,
+        // apply the same parameter rules the sub path uses: a junction bound by a
+        // slurpy (`*%query`, `*@a`) or by a `Mu`/`Junction`-typed parameter is
+        // passed whole, not threaded. Without this a junction NAMED argument to a
+        // `method m(*%query)` called the method once per eigenstate and handed
+        // back a junction of results (`XML::Element.lookfor(:class(Nil | "skip"))`
+        // answered `any(elem, elem)` instead of the two matching elements).
+        // A method we cannot resolve — a native method, a non-instance receiver —
+        // keeps the previous "thread every junction argument" behaviour.
+        let junction_indices = match target.view() {
+            ValueView::Instance { class_name, .. } => {
+                let resolved_args: Vec<Value> =
+                    args.iter().map(Self::unwrap_junction_deep).collect();
+                match self.resolve_method_with_owner(&class_name.resolve(), method, &resolved_args)
+                {
+                    Some((_, def)) => {
+                        self.autothread_indices_for_params(args, &junction_indices, &def.param_defs)
+                    }
+                    std::option::Option::None => junction_indices,
+                }
+            }
+            _ => junction_indices,
+        };
+        if junction_indices.is_empty() {
+            return Ok(None);
+        }
+
         // Pick the junction to thread over based on priority
         let thread_idx = self.pick_autothread_junction_index(args, &junction_indices);
 
@@ -537,6 +498,80 @@ impl Interpreter {
     }
 
     /// Try to get param_defs for a function to determine which params accept Junction.
+    /// Narrow `junction_indices` to the arguments whose *parameter* does not
+    /// accept a `Junction` — the ones Raku actually auto-threads over. A
+    /// parameter typed `Mu`/`Junction` (or a subset resolving to one) binds the
+    /// junction whole, and so does any slurpy: `*@a` / `+@a` / `**@a` collect
+    /// positionals as raw values, and a slurpy hash (`*%h`, `+%h`, the implicit
+    /// `%_`) collects named arguments the same way. Shared by the sub and the
+    /// method call paths so both obey one rule.
+    fn autothread_indices_for_params(
+        &mut self,
+        args: &[Value],
+        junction_indices: &[usize],
+        pds: &[crate::ast::ParamDef],
+    ) -> Vec<usize> {
+        let accepts_junction = |me: &Self, pd: &crate::ast::ParamDef| -> bool {
+            let Some(tc) = &pd.type_constraint else {
+                // No type constraint means default Any — needs auto-threading.
+                return false;
+            };
+            // For coercion types like `Bool(Mu)`, the nominal type is the inner
+            // type (Mu here) — autothreading is based on the nominal. A subset
+            // whose ultimate base type is Mu/Junction passes the junction
+            // through to its where-clause check as well.
+            let nominal = Self::nominal_type(tc.as_str());
+            if matches!(nominal, "Mu" | "Junction") {
+                return true;
+            }
+            matches!(
+                me.resolve_subset_base_type(nominal).as_str(),
+                "Mu" | "Junction"
+            )
+        };
+        let mut out = Vec::new();
+        for &idx in junction_indices {
+            // A named arg (Pair) — find the matching named param.
+            if let ValueView::Pair(key, _) = args[idx].view() {
+                if let Some(pd) = pds
+                    .iter()
+                    .find(|pd| pd.named && !pd.slurpy && !pd.double_slurpy && pd.name == *key)
+                {
+                    if !accepts_junction(self, pd) {
+                        out.push(idx);
+                    }
+                    continue;
+                }
+                // No explicit named param matched. A slurpy hash (`*%h`, the
+                // implicit `%_`, `+%h`) captures the named argument as a raw
+                // value, so a Junction is stored as-is rather than threaded.
+                // A slurpy hash is a slurpy param whose sigil is `%` (a slurpy
+                // `*@a` only collects positionals, not named args).
+                let has_slurpy_hash = pds.iter().any(|pd| {
+                    (pd.slurpy || pd.double_slurpy || pd.onearg) && pd.name.starts_with('%')
+                });
+                if !has_slurpy_hash {
+                    out.push(idx); // No slurpy hash to collect it — auto-thread
+                }
+                continue;
+            }
+
+            // Positional arg — find the corresponding positional param.
+            let positional_pds: Vec<&crate::ast::ParamDef> =
+                pds.iter().filter(|pd| !pd.named).collect();
+            // A positional past the last declared one is collected by a slurpy
+            // if there is one, and is an arity error otherwise; either way it is
+            // not threaded.
+            if let Some(pd) = positional_pds.get(idx)
+                && !(pd.slurpy || pd.onearg || pd.double_slurpy)
+                && !accepts_junction(self, pd)
+            {
+                out.push(idx);
+            }
+        }
+        out
+    }
+
     fn get_func_param_defs_for_autothread(
         &mut self,
         name: &str,

--- a/t/coercion-param-dispatch-and-where.t
+++ b/t/coercion-param-dispatch-and-where.t
@@ -1,0 +1,115 @@
+use Test;
+
+# Three separate defects in how a coercion parameter `T(F)` takes part in
+# dispatch and binding, all found while re-measuring the `XML` battery
+# (`todo/tickets/bundle-xml-battery.md`); `XML` spells its entry point
+#
+#     multi sub open-xml (IO::Path(Str) $src where :f) { ... }
+#     multi sub open-xml (Str $src)                    { ... }
+#     multi sub open-xml (IO::Handle $src)             { ... }
+#
+# and mutsu answered the plain-`Str` candidate for a path string, then failed
+# outright for an `IO::Path` argument.
+
+plan 17;
+
+# --- 1. `T.new($value)` completes the coercion protocol for a NATIVE class ---
+# Rakudo's coercion protocol ends in `TargetType.new($value)`. mutsu only tried
+# it for classes in its own class registry with a user-written `new`, so every
+# native target (`IO::Path`) raised X::Coerce::Impossible.
+{
+    sub takes-path(IO::Path(Str) $p) { $p.^name }
+    is takes-path('/etc/hostname'), 'IO::Path',
+        'a Str coerces to a native IO::Path parameter';
+}
+{
+    sub takes-path(IO::Path(Str) $p) { $p.Str }
+    is takes-path('/etc/hostname'), '/etc/hostname',
+        'the coerced value carries the original string';
+}
+# A USER class with no positional `new` still cannot be coerced into — the
+# behaviour rakudo has, and the reason the fallback is gated on the target
+# declaring no user `new` at all.
+{
+    my class Bare { has $.v }
+    sub takes-bare(Bare(Str) $b) { $b.^name }
+    dies-ok { takes-bare('x') },
+        'a user class with no positional new is still an impossible coercion';
+}
+{
+    my class Made { has $.v; method new($v) { self.bless(:$v) } }
+    sub takes-made(Made(Str) $m) { $m.v }
+    is takes-made('x'), 'x', 'a user class with a positional new still coerces';
+}
+
+# --- 2. a `where` on a coercion parameter runs against the COERCED value ---
+# `IO::Path(Str) $src where :f` means "coerce to IO::Path, then ask it `.f`".
+# mutsu ran the predicate against the raw Str, where `.f` does not exist, so
+# the candidate was silently rejected at dispatch time.
+{
+    multi sub only-file(IO::Path(Str) $p where :f) { 'file:' ~ $p.^name }
+    multi sub only-file(IO::Handle $p) { 'handle' }
+    is only-file('/etc/hostname'), 'file:IO::Path',
+        'the where predicate sees the coerced IO::Path';
+}
+{
+    multi sub pick(IO::Path(Str) $p where :f) { 'path' }
+    multi sub pick(Str $p) { 'str' }
+    is pick('/etc/hostname'), 'path',
+        'the where-constrained coercion candidate wins for an existing file';
+    is pick('this-file-does-not-exist-98765'), 'str',
+        'and yields to the plain Str candidate when the predicate fails';
+}
+
+# --- 3. a coercion parameter accepts the TARGET type directly ---
+# Rakudo compiles `T(F)` into two candidates, one taking `T` itself. mutsu only
+# accepted `F`, so an `IO::Path` argument matched no candidate at all.
+{
+    multi sub pick2(IO::Path(Str) $p) { 'path:' ~ $p.^name }
+    multi sub pick2(IO::Handle $p) { 'handle' }
+    is pick2('/etc/hostname'.IO), 'path:IO::Path',
+        'an IO::Path binds the IO::Path(Str) parameter without coercion';
+    is pick2('/etc/hostname'), 'path:IO::Path',
+        'and a Str still coerces into it';
+}
+{
+    sub num-or-str(Int(Str) $n) { $n }
+    is num-or-str('42'), 42, 'Int(Str) still coerces a Str';
+    is num-or-str(7), 7, 'Int(Str) accepts an Int directly';
+}
+
+# --- 4. a junction argument bound by a SLURPY is not auto-threaded ----------
+# `method m(*%q)` slurps its named arguments as raw values, so a Junction is
+# stored whole. mutsu auto-threaded it, calling the method once per eigenstate
+# and handing back `any(result, result)` — which is how
+# `XML::Element.lookfor(:class(Nil | "skip"))` answered one junction instead of
+# the two matching elements.
+{
+    my $calls = 0;
+    my class C {
+        method slurpy-hash(*%q) { $calls++; %q<k> }
+        method slurpy-pos(*@a) { $calls++; @a.elems }
+        method plain($x) { $calls++; $x }
+        method named(:$k) { $calls++; $k }
+    }
+    my $c = C.new;
+
+    $calls = 0;
+    my $h = $c.slurpy-hash(:k(1 | 2));
+    is $calls, 1, 'a slurpy hash parameter is called once, not per eigenstate';
+    ok $h ~~ Junction, 'and receives the junction whole';
+
+    $calls = 0;
+    my $p = $c.slurpy-pos(1 | 2);
+    is $calls, 1, 'a slurpy positional parameter is called once too';
+    is $p, 1, 'and collects the junction as a single element';
+
+    # The shapes that DO auto-thread must keep doing so.
+    $calls = 0;
+    $c.plain(1 | 2);
+    is $calls, 2, 'a plain positional parameter still auto-threads';
+
+    $calls = 0;
+    $c.named(:k(1 | 2));
+    is $calls, 2, 'a declared named parameter still auto-threads';
+}

--- a/todo/tickets/bundle-xml-battery.md
+++ b/todo/tickets/bundle-xml-battery.md
@@ -77,7 +77,43 @@ and [proxy-what-reports-proxy-instead-of-fetching.md](proxy-what-reports-proxy-i
 **Re-measure before starting** — per `selection-method.md`, a readiness claim
 nobody just re-measured is not evidence.
 
-## Follow-up re-measurement (2026-08-31): still blocked at 9/15
+## Follow-up re-measurement (2026-08-31, later the same day): 13/15
+
+The 9/15 measurement recorded below was superseded within the day. Re-run of
+the v0.3.6 suite (`mutsu -I lib t/*.rakutest` from the dist's own checkout):
+mutsu now reaches **13/15** files and **149** assertions — the same assertion
+count `raku -I lib` reaches at 15/15.
+
+`example`, `proxies`, `query-methods` and `open-xml` were cleared by fixes that
+came out of this re-measurement, each a general interpreter defect:
+
+- **A junction argument bound by a SLURPY was auto-threaded.** `method m(*%q)`
+  slurps its named arguments as raw values, so rakudo passes a `Junction`
+  whole; mutsu's *method* autothread path inspected no parameters at all and
+  called the method once per eigenstate.
+  `XML::Element.lookfor(:class(Nil | "skip"))` therefore answered
+  `any(elem, elem)` — one junction — instead of the two matching elements. The
+  sub path already had the rule; both share one helper now.
+- **`IO::Path(Str)` was an impossible coercion.** Rakudo's coercion protocol
+  ends in `TargetType.new($value)`; mutsu only tried it for classes with a
+  *user-written* `new`, so every native target failed.
+- **A `where` on a coercion parameter ran against the RAW argument.**
+  `IO::Path(Str) $src where :f` means "coerce, then ask the IO::Path `.f`";
+  mutsu called `.f` on the Str, so `multi sub open-xml (IO::Path(Str) $src
+  where :f)` was silently rejected and the plain-`Str` candidate answered
+  instead.
+- **A coercion parameter did not accept its TARGET type.** Rakudo compiles
+  `T(F)` into two candidates, one taking `T` directly, so `open-xml($path.IO)`
+  binds; mutsu accepted only `F` and matched no candidate at all.
+
+### What still blocks it
+
+Two files: `t/make.rakutest` (`make-xml worked.` fails) and
+`t/namespaces.rakutest` (2 assertions: default-namespace content,
+`elements(:URI)`). Neither is bisected yet. Re-measure before starting the
+vendoring steps.
+
+## Superseded re-measurement (2026-08-31, earlier): blocked at 9/15
 
 The required fresh measurement was repeated from the v0.3.6 tag
 (`0349d282e257be61075f55abfde4c42a01bc8f10`) with a release mutsu build, from


### PR DESCRIPTION
Four general defects found while re-measuring the `XML` battery (`todo/tickets/bundle-xml-battery.md`). `XML` spells its entry point

```raku
multi sub open-xml (IO::Path(Str) $src where :f) { ... }
multi sub open-xml (Str $src)                    { ... }
multi sub open-xml (IO::Handle $src)             { ... }
```

and mutsu answered the plain-`Str` candidate for a path string, then failed outright for an `IO::Path` argument.

## 1. A junction argument bound by a SLURPY was auto-threaded

`method m(*%q)` slurps its named arguments as raw values, so rakudo passes a `Junction` whole. `maybe_autothread_method_args` inspected **no parameters at all** and threaded every junction argument, calling the method once per eigenstate and returning a junction of results:

```raku
class C { method m(*%q) { say "called"; 1 } }
C.new.m(:k(1|2));   # raku: called once, 1.   mutsu: called twice, any(1, 1)
```

That is how `XML::Element.lookfor(:class(Nil | "skip"))` answered `any(elem, elem)` — one junction — instead of the two matching elements. The sub path already had the rule; the filter is extracted into `autothread_indices_for_params` and **both paths share it** now.

## 2. `IO::Path(Str)` was an impossible coercion

Rakudo's coercion protocol ends in `TargetType.new($value)`. mutsu only tried it for a target with a user-written positional `new` — which no NATIVE class has, since `class_has_new_accepting_positional` reads the user-overload registry. A target whose MRO declares no user `new` at all now takes the `new` step too. The result must still type-match, so a user class with no positional `new` still raises `X::Coerce::Impossible`, matching rakudo (pinned in the test).

## 3. A `where` on a coercion parameter ran against the RAW argument

`IO::Path(Str) $src where :f` means "coerce to IO::Path, **then** ask it `.f`". `args_match_param_types` evaluated the predicate against the Str, where `.f` does not exist, so the candidate was silently rejected at dispatch time. The coerced value now replaces `arg_for_checks` before the `where` / sub-signature / code-signature checks.

## 4. A coercion parameter did not accept its TARGET type

Rakudo compiles `T(F)` into two candidates, one taking `T` directly, so `open-xml($path.IO)` binds. `coercion_dispatch_value` required the argument to match `F` and returned `None` for an `IO::Path`, so no candidate matched.

Also: `class_has_new_accepting_positional` demanded a *typed* positional, so `method new($v) { self.bless(:$v) }` did not qualify as a coercion constructor. An untyped positional is an `Any` parameter and accepts the value.

## Result

XML v0.3.6 goes from **9/15 to 13/15** files — **149 assertions**, the same count `raku` reaches at 15/15. `example`, `proxies`, `query-methods` and `open-xml` all pass now. The ticket records the re-measurement and the two files still failing (`make`, `namespaces`).

## Testing

- New `t/coercion-param-dispatch-and-where.t`, 17 assertions across all four defects plus the behaviour that must NOT change (a user class with no positional `new` still errors; plain positional and declared named parameters still auto-thread). **The whole file passes under `raku` as well as mutsu.**
- `make test`: 3583 files / 35894 tests PASS.
- Targeted roast sweeps via `scripts/run-roast-test.sh`: `S06-*` `S12-*` `S02-types` `S32-*` `S03-operators` (583 files / 70687 tests) and `S02-names*` `S04-*` `S05-*` `S09-*` `S14-*` `S17-*` (336 files / 14736 tests): all PASS.
- `scripts/battery-testsuite.sh` on a release build: **GATE PASSED**, 273/297 bundled-library test files (unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)