### PR TITLE
docs: deepen pair value container leak

### DIFF
--- a/docs/adr/0036-element-container-pairs-from-subscripts-and-pairs.md
+++ b/docs/adr/0036-element-container-pairs-from-subscripts-and-pairs.md
@@ -355,7 +355,7 @@ BagHash-from-pairs collapsing every weight to 1 (`roast/S03-metaops/infix.t`, 39
 places, with no accessor to route. `.values`/`.reverse`/`.sort` do not have the problem: they hand
 out a *flat list* of cells, and list consumers decontainerize. It is specifically the **Pair
 wrapper** that carries a cell into code that reads it structurally. Tracked in
-`todo/tickets/pairs-element-containers-leak-through-pair-value-consumers.md`.
+`todo/deep/pairs-element-containers-leak-through-pair-value-consumers.md`.
 
 **This revises §5 Q4's answer.** `resolve_array_entry` is the only chokepoint for *element* reads,
 but bulk iteration (`h.iter()`, `items.iter()`) and `ValueView::Pair(k, v)` destructuring walk the

--- a/src/vm/vm_element_producers.rs
+++ b/src/vm/vm_element_producers.rs
@@ -52,7 +52,7 @@ use super::*;
 /// route. It needs a read chokepoint for a Pair's value, which conflicts with
 /// ADR-0036 row 6 (`(@a[0]:p).value.VAR.^name` must be `Scalar`) and so wants
 /// its own decision. Tracked in
-/// `todo/tickets/pairs-element-containers-leak-through-pair-value-consumers.md`.
+/// `todo/deep/pairs-element-containers-leak-through-pair-value-consumers.md`.
 /// `.values`/`.reverse`/`.sort` do not have the problem: they hand out a flat
 /// list of cells, and list consumers decontainerize.
 ///

--- a/t/subscript-pair-element-container.t
+++ b/t/subscript-pair-element-container.t
@@ -23,7 +23,7 @@ use Test;
 #                               through it. `.pairs` itself is DEFERRED: a Pair
 #                               holding a cell leaks through the many consumers
 #                               that destructure a pair's value as data --
-#                               todo/tickets/pairs-element-containers-leak-through-pair-value-consumers.md.
+#                               todo/deep/pairs-element-containers-leak-through-pair-value-consumers.md.
 #                               `.antipairs` is deliberately NOT routed: it puts
 #                               the element in the pair's KEY, and a pair key is
 #                               never a container in raku (measured below).
@@ -75,7 +75,7 @@ plan 34;
     my @a = <A B>;
     my $p = @a.pairs[0];
     @a[0] = "Q";
-    todo 'row 3 needs .pairs routed -- deferred, see todo/tickets/pairs-element-containers-leak-through-pair-value-consumers.md';
+    todo 'row 3 needs .pairs routed -- deferred, see todo/deep/pairs-element-containers-leak-through-pair-value-consumers.md';
     is $p.value, "Q", '.pairs pair value tracks a later array write (row 3)';
 }
 
@@ -84,7 +84,7 @@ plan 34;
     my %h = a => 1;
     my $p = %h.pairs[0];
     %h<a> = 7;
-    todo 'row 4 needs .pairs routed -- deferred, see todo/tickets/pairs-element-containers-leak-through-pair-value-consumers.md';
+    todo 'row 4 needs .pairs routed -- deferred, see todo/deep/pairs-element-containers-leak-through-pair-value-consumers.md';
     is $p.value, 7, '.pairs pair value tracks a later hash write (row 4)';
 }
 
@@ -116,7 +116,7 @@ plan 34;
 }
 {
     my @a = <A B>;
-    todo '.pairs routing deferred -- see todo/tickets/pairs-element-containers-leak-through-pair-value-consumers.md';
+    todo '.pairs routing deferred -- see todo/deep/pairs-element-containers-leak-through-pair-value-consumers.md';
     is @a.pairs[0].value.VAR.^name, 'Scalar', '.pairs pair.value is a Scalar container';
 }
 
@@ -156,7 +156,7 @@ plan 34;
     my @a = <A B>;
     my @c = <A B>;
     for @a.pairs -> $p { $p.value = "y" }
-    todo 'row 9 needs .pairs routed -- deferred, see todo/tickets/pairs-element-containers-leak-through-pair-value-consumers.md';
+    todo 'row 9 needs .pairs routed -- deferred, see todo/deep/pairs-element-containers-leak-through-pair-value-consumers.md';
     is-deeply @a, ["y", "y"], 'for @a.pairs writes through even with an equal sibling array (row 9)';
 }
 

--- a/todo/deep/pairs-element-containers-leak-through-pair-value-consumers.md
+++ b/todo/deep/pairs-element-containers-leak-through-pair-value-consumers.md
@@ -7,6 +7,14 @@ called for **did** land (`src/vm/vm_element_producers.rs`, 2026-08-27) and carri
 `.values`/`.reverse`/`.sort` for ADR-0045 slice 4. `.pairs` was implemented, measured, and backed out
 of the routing list. Rows 3, 4 and 9 of ADR-0036 §1.3 stay `todo`-marked.
 
+### Deep triage — 2026-08-31
+
+This requires a new Pair-value read-boundary decision, owned by ADR-0036's deferred `.pairs` slice.
+The needed distinction between data reads, lvalue reads, and `.VAR` cannot be safely established by
+changing the producer or auditing a small fixed set of consumers: structural Pair destructuring spans
+the coercion layer and any promoted source can reach it. Keep `.pairs` unrouted until that decision
+defines the shared accessor/view and its migration scope.
+
 ## What happens
 
 Routing `.pairs` makes it hand out Pairs whose value is the element's own `Scalar` container. Every

--- a/todo/tickets/for-deref-container-source-promotion-breaks-nqp-type-tests.md
+++ b/todo/tickets/for-deref-container-source-promotion-breaks-nqp-type-tests.md
@@ -44,7 +44,7 @@ direct-mutation case (`$_ .= uc for @$hdr` — Text::CSV's header munge) and onl
 one.
 
 This is the same *class* as
-`todo/tickets/pairs-element-containers-leak-through-pair-value-consumers.md` — a promoted value
+`todo/deep/pairs-element-containers-leak-through-pair-value-consumers.md` — a promoted value
 reaching code that **type-tests** it rather than reads it — but a different boundary (`nqp::` ops
 rather than Pair-value destructuring), so it wants its own audit.
 


### PR DESCRIPTION
## Summary
- move the `.pairs` container leak item to the deep queue
- record why Pair data/lvalue reads need an ADR-0036 decision
- update ADR, test, and related-ticket references

## Validation
- cargo fmt --all
- cargo clippy -- -D warnings
- targeted `t/subscript-pair-element-container.t`
- make test
- make roast