### PR TITLE
fix: a closure over a `for` parameter is no longer hijacked by a later `my`

### DIFF
--- a/news/2026-09/closure-capture-slot-name-search-finds-a-later-my.md
+++ b/news/2026-09/closure-capture-slot-name-search-finds-a-later-my.md
@@ -1,0 +1,69 @@
+# A closure over a `for` parameter was hijacked by a later same-named `my`
+
+Found while working
+`todo/tickets/for-kv-multi-param-bind-decontainerizes.md`: the `.kv` fix it
+prescribes emits a `my $v := ...` binding, which turned out to break unrelated,
+already-passing ADR-0045 rows. The trigger was not the new binding — it was a
+pre-existing bug that any same-named `my` exposes.
+
+## The bug
+
+A closure created inside a `for` loop captures the loop's **parameter**. That
+capture is resolved at run time by `resolve_capture_slot`
+(`src/vm/vm_register_ops.rs`), whose fallback is a name search over the creating
+frame's local slots:
+
+```rust
+sym.with_str(|s| code.locals.iter().rposition(|n| n == s))
+```
+
+A frame's local slots are flat — there is no per-block scope and no record of
+*where* in the frame a slot was declared — so the search happily found a slot
+declared **later** in the same compilation unit. A sibling block's `my $v` is a
+different lexical entirely, but it shares the name:
+
+```raku
+{
+    my @a = 10, 20;
+    my @c;
+    for @a -> $v is rw { @c.push(-> { $v = $v + 1 }) }
+    @c[0](); @c[1]();
+    say @a;          # raku [11 21]   mutsu [10 20]
+}
+{
+    my $v = 1;       # <- deleting this block makes the one above pass
+    say $v;
+}
+```
+
+The read-only form diverges the same way (`-> { $v }` yielded `Nil Nil`). Both
+blocks in isolation were correct, which is why it went unnoticed: it takes two
+sibling scopes reusing one name, in one file, to show.
+
+`CompiledCode::for_loop_param_syms` already exists for exactly this hazard — a
+`for` parameter is the loop's own binding, never a slot to capture from the
+enclosing frame — but it was applied only to the compile-time free-variable
+analysis, not to this runtime resolution.
+
+## Fix
+
+`resolve_capture_slot` declines the name search when **both** hold:
+
+* the symbol is a `for` loop parameter of the running frame
+  (`code.for_loop_param_syms`), and
+* the emit-time bake (`free_var_parent_slots`, the creating frame's `local_map`
+  *at the closure's creation point*) says `None` — the frame had no such local
+  then.
+
+The bake supplies exactly the position information the name search lacks, so
+the test is precise rather than heuristic: a genuine capture of a `my` declared
+*before* the closure bakes `Some(slot)` and is untouched. Only the "there was no
+such local yet" case changes, and there the correct answer is the loop's own
+binding, reached through the name's env entry.
+
+Pinned by `t/closure-capture-not-hijacked-by-later-my.t` (4 tests: the rw and
+read-only closure forms, the sibling `my` that triggers it, and the
+capture-of-an-earlier-`my` control).
+
+Verified with `make test`, the full whitelisted roast sweep (1435 files,
+218 833 tests) and the bundled-library gate (274/297, `GATE PASSED`).

--- a/src/vm/vm_register_ops.rs
+++ b/src/vm/vm_register_ops.rs
@@ -228,6 +228,29 @@ impl Interpreter {
         {
             return Some(baked as usize);
         }
+        // A name the running frame binds as a `for` loop PARAMETER is the
+        // loop's own per-iteration binding, never a slot to capture from this
+        // frame (`CompiledCode::for_loop_param_syms`). The name search below
+        // does not know where in the frame a slot was declared, so a
+        // same-named `my` appearing LATER in the same compilation unit -- a
+        // sibling block's `my $v`, which is a different lexical entirely --
+        // was found and captured instead of the loop's binding, and the
+        // closure read `Nil`:
+        //
+        //     { my @a = 10, 20; my @c;
+        //       for @a -> $v is rw { @c.push(-> { $v = $v + 1 }) }
+        //       @c[0](); @c[1](); say @a }    # [10 20], raku says [11 21]
+        //     { my $v = 1; say $v }           # <- adding this broke the above
+        //
+        // The emit-time bake is what supplies the missing position: it is the
+        // creating frame's `local_map` AT THE CLOSURE'S CREATION POINT, so a
+        // baked `None` means the frame had no such local *then*. Combined with
+        // the loop-parameter test that is precise -- a genuine capture of a
+        // `my` declared before the closure bakes `Some(slot)` and is
+        // unaffected.
+        if matches!(parent_slots.get(i), Some(None)) && code.for_loop_param_syms.contains(&sym) {
+            return None;
+        }
         sym.with_str(|s| code.locals.iter().rposition(|n| n == s))
     }
 

--- a/t/closure-capture-not-hijacked-by-later-my.t
+++ b/t/closure-capture-not-hijacked-by-later-my.t
@@ -1,0 +1,42 @@
+use Test;
+
+plan 4;
+
+# A closure created inside a `for` loop captures the loop's PARAMETER. The
+# runtime capture path resolved that name by searching the creating frame's
+# local slots, which does not know where in the frame a slot was declared -- so
+# a same-named `my` appearing LATER in the same compilation unit (a sibling
+# block's `my $v`, a different lexical entirely) was found and captured instead.
+
+{
+    my @a = 10, 20;
+    my @c;
+    for @a -> $v is rw { @c.push(-> { $v = $v + 1 }) }
+    @c[0]();
+    @c[1]();
+    is-deeply @a, [11, 21],
+        'an escaping closure over an `is rw` for param is not hijacked by a later `my`';
+}
+{
+    my @a = 10, 20;
+    my @c;
+    for @a -> $v { @c.push(-> { $v }) }
+    is-deeply (@c[0](), @c[1]()), (10, 20),
+        'a read-only closure over a for param is not hijacked by a later `my`';
+}
+
+# The trigger: a sibling block declaring (and using) the same name. Without it
+# both blocks above passed, which is why this went unnoticed.
+{
+    my $v = 1;
+    is $v, 1, 'the later same-named `my` still works';
+}
+
+# A genuine capture of a `my` declared BEFORE the closure is unaffected: the
+# emit-time bake records its slot, so only the "no such local yet" case changes.
+{
+    my $w = 7;
+    my $f = -> { $w };
+    for 1, 2 -> $w { }
+    is $f(), 7, 'a closure over an earlier same-named `my` still captures it';
+}


### PR DESCRIPTION
## The bug

A closure created inside a `for` loop captures the loop's **parameter**. That capture is resolved at run time by `resolve_capture_slot` (`src/vm/vm_register_ops.rs`), whose fallback is a name search over the creating frame's local slots:

```rust
sym.with_str(|s| code.locals.iter().rposition(|n| n == s))
```

A frame's local slots are flat — no per-block scope, no record of *where* in the frame a slot was declared — so the search found a slot declared **later** in the same compilation unit. A sibling block's `my $v` is a different lexical entirely, but it shares the name:

```raku
{
    my @a = 10, 20;
    my @c;
    for @a -> $v is rw { @c.push(-> { $v = $v + 1 }) }
    @c[0](); @c[1]();
    say @a;          # raku [11 21]   mutsu [10 20]
}
{
    my $v = 1;       # <- deleting this block makes the one above pass
    say $v;
}
```

The read-only form diverges the same way (`-> { $v }` yielded `Nil Nil`). Both blocks **in isolation** were correct, which is why it went unnoticed: it takes two sibling scopes reusing one name, in one file, to show.

`CompiledCode::for_loop_param_syms` already exists for exactly this hazard — a `for` parameter is the loop's own binding, never a slot to capture from the enclosing frame — but it was applied only to the compile-time free-variable analysis, not to this runtime resolution.

## Fix

Decline the name search when **both** hold:

* the symbol is a `for` loop parameter of the running frame (`code.for_loop_param_syms`), and
* the emit-time bake (`free_var_parent_slots` — the creating frame's `local_map` *at the closure's creation point*) says `None`, i.e. the frame had no such local then.

The bake supplies exactly the position information the name search lacks, so the test is precise rather than heuristic: a genuine capture of a `my` declared *before* the closure bakes `Some(slot)` and is untouched. Only the "there was no such local yet" case changes, and there the correct answer is the loop's own binding, reached through the name's env entry.

## How it was found

Working `todo/tickets/for-kv-multi-param-bind-decontainerizes.md`. That ticket's prescribed fix (a raw `my $v := ...` bind for an rw scalar multi-parameter) works — row 16 and its hash twin pass — but it broke seven unrelated, already-green ADR-0045 rows, because the new declaration is what puts a same-named slot in the frame. Reduced to the repro above, it reproduces on a clean `main` with no `.kv` involved at all. The `.kv` ticket stays open and is unblocked by this.

## Tests

- New `t/closure-capture-not-hijacked-by-later-my.t` (4 tests: rw and read-only closure forms, the sibling `my` that triggers it, and a capture-of-an-earlier-`my` control), verified against raku.
- `make test` green.
- Full whitelisted roast sweep green (1435 files, 218 833 tests).
- Bundled-library gate: 274/297, `GATE PASSED`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)