### PR TITLE
docs: record what the `.kv` multi-param bind measurement found

### DIFF
--- a/todo/tickets/for-kv-multi-param-bind-decontainerizes.md
+++ b/todo/tickets/for-kv-multi-param-bind-decontainerizes.md
@@ -68,6 +68,46 @@ form is already `todo`-marked in `t/subscript-pair-element-container.t` for a
 *different* reason — `.VAR` on an anonymous computed index target, see
 `todo/tickets/var-on-a-containerref-is-not-distinguishable.md`.)
 
+## Measured 2026-09-01: the prescribed fix works, and what it uncovered
+
+The "raw bind for an rw scalar multi-parameter" above was implemented and
+measured. It is the right fix and it works:
+
+* `build_for_bind_stmts` (`src/compiler/mod.rs`) gains `rw_block: bool`, and a
+  multi-parameter that is rw (`<->`, `is rw`, or sigilless), positional, with no
+  default, emits `Stmt::SyntheticBlock([Stmt::MarkBind, decl])` instead of
+  `Stmt::Assign` -- the same shape the `@`/`%` case already uses.
+* `array_slot_ref` is idempotent (`value_methods_b.rs:258-260` returns the cell
+  the slot already holds rather than wrapping it), so `my $v := @_[1]` over a
+  chunk that carries a source cell aliases the **source** element, not the
+  temporary chunk. That is what makes the routing work at all.
+* With that alone -- *before* adding `"kv"` to `ELEMENT_PRODUCERS` -- both
+  deferred-closure snippets above already produce raku's answer.
+
+**But it broke seven unrelated, already-green ADR-0045 rows** (01, 02, 03, 12,
+13, 14, 08), and the cause was not the routing. The new `my $v := ...` puts a
+slot named `v` in the enclosing frame's flat local map, and *any* same-named
+`my` did that. Reduced:
+
+```raku
+{ my @a = 10, 20; my @c;
+  for @a -> $v is rw { @c.push(-> { $v = $v + 1 }) }
+  @c[0](); @c[1](); say @a }    # raku [11 21]   mutsu [10 20]
+{ my $v = 1; say $v }           # <- deleting this block made the above pass
+```
+
+That reproduced on a clean `main` with no `.kv` involved, and is fixed
+separately -- `news/2026-09/closure-capture-slot-name-search-finds-a-later-my.md`
+(`resolve_capture_slot`'s name search over the creating frame's local slots
+found a slot declared LATER in the same compilation unit). **This ticket is
+unblocked by that fix**; re-apply the compiler change above, add `"kv"` to
+`ELEMENT_PRODUCERS` (both the array and hash arms -- the array arm must yield a
+flat `index, cell, index, cell, ...` and the hash arm `key, cell, ...`, since
+the loop chunks the flat list by 2), and un-`todo` row 16.
+
+Note also that `(@a.kv)[1].VAR.^name` reports `Int`, not the `Str` this ticket
+records.
+
 ## Reproduce
 
 The three snippets above, no fixtures.


### PR DESCRIPTION
Updates `todo/tickets/for-kv-multi-param-bind-decontainerizes.md` with a measured status section.

The prescribed fix (a raw bind for an rw scalar multi-parameter) **works** — with the compiler change alone, before even adding `"kv"` to `ELEMENT_PRODUCERS`, both deferred-closure snippets in the ticket produce raku's answer. `array_slot_ref`'s idempotence is the reason: `my $v := @_[1]` over a chunk carrying a source cell aliases the *source* element, not the temporary chunk.

It also broke seven unrelated, already-green ADR-0045 rows — via a **pre-existing** bug that any same-named `my` exposes, fixed separately in #7191. The ticket is unblocked by that; the remaining work and its exact shape are now written down.

Docs-only, so the four heavy CI jobs skip by design (`scripts/ci-docs-only.sh`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)