### PR TITLE
fix: a `for` loop's `is rw` param over an immutable source fails at bind time (ADR-0045 slice 5)

### DIFF
--- a/docs/adr/0045-for-loop-parameters-bind-the-element-container.md
+++ b/docs/adr/0045-for-loop-parameters-bind-the-element-container.md
@@ -1,7 +1,8 @@
 # ADR-0045: A `for` loop parameter binds the element *container*; the per-iteration writeback is retired
 
-- **Status**: Accepted — partially implemented (slices 0-4 landed 2026-08-27; slices 5-6 open, see
-  §8 "Implementation status")
+- **Status**: Accepted — partially implemented (slices 0-4 landed 2026-08-27, slice 5's bind-time
+  rejection 2026-09-01; slice 5's element constraint and slice 6 open, see §8 "Implementation
+  status")
 - **Date**: 2026-08-20
 - **Deciders**: tokuhirom, Claude
 - **Related**: [ADR-0036](0036-element-container-pairs-from-subscripts-and-pairs.md) §7 (which names
@@ -683,11 +684,41 @@ same shape followed, all of them fed by `.pairs`. Slice 5 should assume that any
 can reach will be found this way — by a full roast sweep, not by reading — and that the tell is a
 `match` on `view()`, not a `.value` read.
 
+### Slice 5, the bind-time rejection half — landed 2026-09-01
+
+Rows 19 and 30 are green: `for (1, 2) -> $v is rw { }` and `for 1 .. 2 -> $v is rw { }` now fail the
+**bind**, before the body runs, with raku's own `X::Parameter::RW` and its exact wording (embedded
+newline included) — where mutsu used to bind a value clone and silently drop the write.
+
+**The gate is the source, not the promotion.** The obvious implementation — "the item was not
+promoted to a cell, so reject the `is rw` bind" — is wrong, and measurably so: `for flat(@a)` and
+`for @a[0, 1]` also fail to promote today (their producers are unrouted), yet raku *aliases* through
+both. Keying the rejection off promotion would have traded a lost write for a spurious death, which
+is the worse divergence. It is keyed instead on the compiler's conservative
+`ForLoopSpec::source_items_are_bare` — a literal list, a word list, `%h.keys`, and (added here) any
+`Range` — which answers `true` only for shapes that can never produce a container. Sources raku also
+rejects but the flag does not yet see (`@a.map(...)`, `.List`, `.Seq`, a sub's return, `%h`'s Pairs)
+keep the old silent behaviour; widening the flag is additive and needs no further decision.
+
+A sigilless `\v` parameter is excluded, because raku treats it differently: it binds the bare item
+happily and only dies if the body *assigns* through it ("Cannot modify an immutable Int"). The AST
+stores `\v` as plain `"v"`, so the name cannot carry that distinction — `ForLoopSpec` gained
+`param_sigilless` for it.
+
+**The wording was shared, not duplicated.** `RuntimeError::parameter_rw_not_container` now backs both
+this bind site and the two routine-signature sites in `runtime/types/binding_signature.rs`, which had
+been raising an invented `X::Parameter::RW: 'x' expects a writable variable argument` (no sigil, no
+`.symbol`/`.got`, not an exception instance at all). `sub f($x is rw) {}; f(1)` matches raku's message
+now too.
+
+**Row 28 is NOT part of this** — the element type constraint stays ADR-0036 slice 4's, as the note
+below says.
+
 ### What slices 5-6 still own
 
-Row 16 (`.kv`), carried over from slice 4 — see above — and rows 19, 28
-and 30 (slice 5 — bind-time enforcement). They are `todo`-marked in `t/for-loop-element-alias.t` with the owning reason named in
-the reason string. The writeback family survives only as the fallback for shapes not yet converted:
+Row 16 (`.kv`), carried over from slice 4 — see above — and row 28 (the element type constraint;
+rows 19/30 landed 2026-09-01, see just above). It is `todo`-marked in `t/for-loop-element-alias.t`
+with the owning reason named in the reason string. The writeback family survives only as the fallback for shapes not yet converted:
 `write_back_for_rw_param`'s `kv_mode`, multi-parameter and scalar arms, and
 `write_back_hash_value_item` for a hash iteration that could not be promoted.
 

--- a/news/2026-09/for-loop-is-rw-over-an-immutable-source-fails-at-bind.md
+++ b/news/2026-09/for-loop-is-rw-over-an-immutable-source-fails-at-bind.md
@@ -1,0 +1,59 @@
+# A `for` loop's `is rw` parameter over an immutable source now fails at bind time
+
+`for (1, 2) -> $v is rw { $v = 5 }` used to run to completion and quietly
+discard every write. Raku does not run it at all: the parameter binds the item
+the iterator yields, an immutable source yields a value with no container behind
+it, and the **bind** fails before the body is entered.
+
+mutsu now raises the same failure, with raku's own exception and wording:
+
+```
+Parameter '$v' expects a writable container (variable) as an argument,
+but got '1' (Int) as a value without a container.
+```
+
+It is a real `X::Parameter::RW` carrying `.symbol` (`$v`) and `.got` (the
+offending item), not a message-only stand-in, and it fires whether or not the
+body ever assigns — an empty body dies too, exactly as raku's does. This closes
+rows 19 and 30 of ADR-0045's divergence table; `t/for-loop-element-alias.t`
+pins them.
+
+## The gate is the source, not the promotion
+
+The tempting implementation is "ADR-0045 did not promote this element to a
+container, so reject the `is rw` bind". That is wrong, and it is wrong in the
+expensive direction. `for flat(@a) -> $v is rw` and `for @a[0, 1] -> $v is rw`
+also fail to promote today — those producers have not been routed through the
+element-container layer yet — but raku aliases through both and mutates the
+array. Rejecting there would have swapped a lost write for a spurious death,
+which is a worse answer than the bug being fixed.
+
+So the rejection keys off the compiler's `ForLoopSpec::source_items_are_bare`
+instead: a flag that already existed to mark the topic read-only, and that
+answers `true` only for shapes which can never produce a container — a literal
+list (`for 1, 2`), a word list (`for <a b>`), `%h.keys`, and now any `Range`,
+whatever its endpoints are (`for $a .. $b` is as immutable as `for 1 .. 2`).
+Sources raku also rejects but the flag does not yet recognise — `@a.map(...)`,
+`.List`, `.Seq`, a sub's returned list, a `Hash`'s Pairs — keep the old silent
+behaviour. Widening the flag later is purely additive.
+
+A sigilless `-> \v` parameter is deliberately exempt: raku binds it to a bare
+item happily and only dies if the body *assigns* through it ("Cannot modify an
+immutable Int"). The AST stores `\v` as the plain name `"v"`, so the parameter
+name cannot carry that distinction — `ForLoopSpec` gained a `param_sigilless`
+flag for it.
+
+## The routine-call form got the same wording for free
+
+mutsu had an invented message for the same exception on the routine path:
+`sub f($x is rw) {}; f(1)` reported `X::Parameter::RW: 'x' expects a writable
+variable argument` — no sigil, no `.symbol`/`.got`, and not an exception
+instance at all, only a class name spelled into the message text. Both
+signature-binder sites now build the shared
+`RuntimeError::parameter_rw_not_container`, so the routine form matches raku
+too, and the arm in `runtime/calls.rs` that must not rewrap this error accepts
+the typed instance alongside the old message convention.
+
+Verified with `make test`, a 454-file targeted roast sweep over every
+whitelisted file mentioning `is rw` / `is raw` / `<->` or a pointy `for`, and
+the bundled-battery gate.

--- a/src/compiler/helpers_do_expr.rs
+++ b/src/compiler/helpers_do_expr.rs
@@ -452,6 +452,7 @@ impl Compiler {
                     .for_single_array_source_local(&Self::for_single_array_source(iterable)),
                 body_declares_routines: Self::stmts_declare_routines(&loop_body),
                 source_items_are_bare: Self::for_iterable_yields_bare_items(iterable),
+                param_sigilless: param_def.as_ref().is_some_and(|d| d.sigilless),
             })));
         // Register sigilless for-params while compiling the (merged) body so
         // their bind statements skip scalar-store itemization — mirrors the

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -3159,6 +3159,16 @@ impl Compiler {
             Expr::ArrayLiteral(items) => {
                 !items.is_empty() && items.iter().all(|i| matches!(i, Expr::Literal(_)))
             }
+            // A `Range` yields immutable endpoints-derived values and never
+            // element containers, whatever its endpoints are -- `for $a..$b
+            // -> $v is rw` fails to bind in raku exactly as `for 1..2` does.
+            Expr::Binary { op, .. } => matches!(
+                op,
+                crate::token_kind::TokenKind::DotDot
+                    | crate::token_kind::TokenKind::DotDotCaret
+                    | crate::token_kind::TokenKind::CaretDotDot
+                    | crate::token_kind::TokenKind::CaretDotDotCaret
+            ),
             // `.keys` on a container yields freshly built keys, never the
             // container's element cells. Restricted to `@`/`%` variables so a
             // user-defined `keys` method returning containers is not affected.

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -2803,6 +2803,7 @@ impl Compiler {
                             ),
                             body_declares_routines: Self::stmts_declare_routines(&loop_body),
                             source_items_are_bare: Self::for_iterable_yields_bare_items(iterable),
+                            param_sigilless: (**param_def).as_ref().is_some_and(|d| d.sigilless),
                         })));
                 // Register sigilless for-params (`-> \v`, `-> \k, \v`) as
                 // sigilless locals while compiling the body so postfix/prefix

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -333,6 +333,17 @@ pub(crate) struct ForLoopSpec {
     /// topics (`for @a[0..1]`, `for @a.map(...)`) read-only. A mixed list
     /// (`for 1, $a`) stays writable, which is lax but never wrong.
     pub(crate) source_items_are_bare: bool,
+    /// Whether the single named loop parameter is *sigilless* (`-> \v`).
+    ///
+    /// ADR-0045 slice 5 rejects an `is rw` / `<->` bind against a source whose
+    /// items are provably bare values, at bind time, with raku's
+    /// `X::Parameter::RW`. A sigilless parameter sets the same
+    /// [`Self::do_writeback`] but must NOT take that rejection: raku binds
+    /// `-> \v` to a bare item happily and only dies if the body *assigns*
+    /// through it ("Cannot modify an immutable Int"). The parameter name alone
+    /// cannot tell the two apart -- the AST stores `\v` as plain `"v"` -- so
+    /// the compiler records the distinction here.
+    pub(crate) param_sigilless: bool,
 }
 
 impl ForLoopSpec {

--- a/src/runtime/calls.rs
+++ b/src/runtime/calls.rs
@@ -391,12 +391,19 @@ impl Interpreter {
         // Likewise `is rw`/`is raw` binding a non-writable argument
         // (`X::Parameter::RW`) is a genuine runtime check, not a compile-time
         // shape mismatch -- and unlike the exception-carrying errors handled
-        // below, this call site only spells its class via the "X::Type: text"
-        // message convention (`RuntimeError::new`, no `.exception` attached),
-        // so wrapping it in "Calling f(Int) will never work..." would destroy
-        // the only place its class is recorded, losing it to the generic
-        // X::AdHoc fallback (`roast/S06-traits/misc.t`).
-        if err.message.starts_with("X::Parameter::RW:") {
+        // below, wrapping it in "Calling f(Int) will never work..." would
+        // destroy the class the error records, losing it to the generic
+        // X::AdHoc fallback (`roast/S06-traits/misc.t`). Both spellings are
+        // accepted: the real `X::Parameter::RW` instance the signature binder
+        // and the `for`-loop bind site now raise, and the older "X::Type:
+        // text" message convention that other sites still use.
+        if err.message.starts_with("X::Parameter::RW:")
+            || err.exception.as_ref().is_some_and(|ex| {
+                matches!(ex.as_ref().view(),
+                    ValueView::Instance { class_name, .. }
+                        if class_name.resolve() == "X::Parameter::RW")
+            })
+        {
             return err;
         }
         // A signature with a generic type capture (`sub c(::T $x, T $y, $z)`)

--- a/src/runtime/types/binding_signature.rs
+++ b/src/runtime/types/binding_signature.rs
@@ -21,6 +21,17 @@ fn is_multidim_slice_cells(value: &crate::value::Value) -> bool {
         if !items.is_empty() && items.iter().all(crate::value::Value::is_container_ref))
 }
 
+/// A parameter as raku spells it in an error message. `ParamDef::name` carries
+/// no sigil for a scalar (`x` for `$x`), so restore it; a name that already has
+/// one (`@a`, `%h`, `&c`) is left alone.
+fn param_display_name(pd: &crate::ast::ParamDef) -> String {
+    if pd.name.starts_with(['$', '@', '%', '&']) {
+        pd.name.clone()
+    } else {
+        format!("${}", pd.name)
+    }
+}
+
 fn legacy_has_plain_positional_param(params: &[String]) -> bool {
     params.iter().any(|p| {
         !p.starts_with(':')
@@ -380,11 +391,7 @@ impl Interpreter {
                     .next()
                     .unwrap_or(&resolved_constraint);
                 if self.registry().subsets.contains_key(base) {
-                    let param_display = if pd.name.starts_with(['$', '@', '%', '&']) {
-                        pd.name.clone()
-                    } else {
-                        format!("${}", pd.name)
-                    };
+                    let param_display = param_display_name(pd);
                     return Err(RuntimeError::typecheck_binding_parameter(
                         &display_name,
                         &resolved_constraint,
@@ -408,10 +415,8 @@ impl Interpreter {
                 // anonymous-parameter twin.
                 let param_display = if pd.name == "__type_only__" {
                     "<anon>".to_string()
-                } else if pd.name.starts_with(['$', '@', '%', '&']) {
-                    pd.name.clone()
                 } else {
-                    format!("${}", pd.name)
+                    param_display_name(pd)
                 };
                 return Err(RuntimeError::typecheck_binding_parameter_with_repr(
                     &param_display,
@@ -1553,10 +1558,10 @@ impl Interpreter {
                                 // A bare cell IS a writable lvalue (mirrors the
                                 // positional arm's deepmap/hyper case).
                             } else if named_is_rw {
-                                return Err(RuntimeError::new(format!(
-                                    "X::Parameter::RW: '{}' expects a writable variable argument",
-                                    pd.name
-                                )));
+                                return Err(RuntimeError::parameter_rw_not_container(
+                                    &param_display_name(pd),
+                                    &bound_value,
+                                ));
                             }
                             // is raw with a non-lvalue: binds readonly (the
                             // trait pass below keeps raw params writable, which
@@ -1851,10 +1856,10 @@ impl Interpreter {
                             // (`*++`, `*--`) write to the source slot. Keep it
                             // mutable (do NOT mark readonly).
                         } else if is_rw {
-                            return Err(RuntimeError::new(format!(
-                                "X::Parameter::RW: '{}' expects a writable variable argument",
-                                pd.name
-                            )));
+                            return Err(RuntimeError::parameter_rw_not_container(
+                                &param_display_name(pd),
+                                &args[positional_idx],
+                            ));
                         } else {
                             // is raw with non-lvalue: param stays readonly
                             // (not added to rw_bindings, will be marked readonly below)

--- a/src/value/error_typed.rs
+++ b/src/value/error_typed.rs
@@ -694,6 +694,31 @@ impl RuntimeError {
         self
     }
 
+    /// `X::Parameter::RW` — an `is rw` / `<->` parameter was handed a value
+    /// that has no container behind it, so there is nothing for the binding to
+    /// alias. Raku raises this at BIND time, before the body runs, both for an
+    /// ordinary routine call (`sub f($x is rw) {}; f(1)`) and for a `for` loop
+    /// over an immutable source (`for (1,2) -> $v is rw { }`, ADR-0045 rows
+    /// 19/30), with one wording; this constructor is that wording.
+    ///
+    /// `symbol` is the parameter as written, sigil included (`$x`), and `.got`
+    /// is the offending value itself — raku renders it with `.gist`, not
+    /// `.raku`, so a `Str` shows unquoted (`but got 'a' (Str)`).
+    pub(crate) fn parameter_rw_not_container(symbol: &str, got: &Value) -> Self {
+        let msg = format!(
+            "Parameter '{}' expects a writable container (variable) as an argument,\n\
+but got '{}' ({}) as a value without a container.",
+            symbol,
+            crate::runtime::utils::gist_value(got),
+            crate::runtime::utils::got_type_name(got),
+        );
+        let mut attrs = HashMap::new();
+        attrs.insert("symbol".to_string(), Value::str(symbol.to_string()));
+        attrs.insert("got".to_string(), got.clone());
+        attrs.insert("message".to_string(), Value::str(msg));
+        Self::typed("X::Parameter::RW", attrs)
+    }
+
     /// Like `typecheck_binding_parameter`, but with raku's exact wording
     /// ("expected T but got U (repr)", not "expected T, got U") and `.got`
     /// carrying the actual offending value. Matches the hand-rolled format

--- a/src/vm/vm_for_loop_body.rs
+++ b/src/vm/vm_for_loop_body.rs
@@ -591,6 +591,31 @@ impl Interpreter {
                     }
                 }
             }
+            // ADR-0045 slice 5: an `is rw` / `<->` parameter binds the item the
+            // iterator YIELDS. When the source can only ever yield bare values
+            // -- a literal list (`for 1, 2`, `for <a b>`), a `Range`, `%h.keys`
+            // -- there is no container to alias and raku fails the BIND, before
+            // the body runs and independently of whether the body ever assigns
+            // (rows 19/30). mutsu used to bind a value clone and silently drop
+            // the write instead.
+            //
+            // Gated on the compiler's conservative `source_items_are_bare`, not
+            // on "promotion did not happen": a producer this ADR has not routed
+            // yet (`flat(@a)`, `@a[0,1]`) also fails to promote, but raku
+            // aliases through it -- dying there would trade a lost write for a
+            // spurious death. A sigilless `\v` parameter is excluded: raku
+            // binds it and dies later, at the assignment ("Cannot modify an
+            // immutable Int"), not here.
+            if spec.do_writeback
+                && spec.source_items_are_bare
+                && !spec.param_sigilless
+                && let Some(ref name) = param_name
+                && !name.starts_with(['@', '%', '&'])
+            {
+                let display = Self::for_param_display_name(name);
+                self.unmask_for_params(&masked_params);
+                return Err(RuntimeError::parameter_rw_not_container(&display, &item));
+            }
             // ADR-0045 slices 1-3: promote this element to its own container
             // and bind THAT, so the binding is a real alias for the lifetime of
             // the binding.

--- a/t/for-loop-element-alias.t
+++ b/t/for-loop-element-alias.t
@@ -21,7 +21,7 @@ use Test;
 # (derived producers — `.kv`/`.reverse`/`.sort`/`@$s`) and slice 5 (bind-time
 # enforcement).
 
-plan 72;
+plan 86;
 
 # ---------------------------------------------------------------------------
 # Class 1 — a binding that outlives the loop body still writes through.
@@ -345,14 +345,54 @@ plan 72;
 
 # row 19
 {
-    todo 'ADR-0045 slice 5: an immutable source must reject an `is rw` bind';
     dies-ok { for (1, 2) -> $v is rw { $v = 5 } }, 'row 19: `is rw` over a List dies at bind time';
 }
 
 # row 30
 {
-    todo 'ADR-0045 slice 5: an immutable source must reject an `is rw` bind';
     dies-ok { for 1 .. 2 -> $v is rw { $v = 5 } }, 'row 30: `is rw` over a Range dies at bind time';
+}
+
+# rows 19/30, the rest of the bind-time rejection (ADR-0045 slice 5). The bind
+# fails BEFORE the body runs, so an empty body dies just as an assigning one
+# does, and the exception is raku's own `X::Parameter::RW` with its wording.
+{
+    dies-ok { for <a b> -> $v is rw { } },
+        'row 19b: `is rw` over a word list dies even with an empty body';
+    dies-ok { for (1, 2) <-> $v { } }, 'row 19c: `<->` over a List dies too';
+    dies-ok { my %h = a => 1; for %h.keys -> $v is rw { } },
+        'row 19d: `%h.keys` yields bare keys, so an `is rw` bind dies';
+    dies-ok { my $a = 1; my $b = 3; for $a .. $b -> $v is rw { } },
+        'row 30b: a Range built from variables is still immutable';
+
+    my $err;
+    try { for (1, 2) -> $v is rw { }; CATCH { default { $err = $_ } } };
+    isa-ok $err, X::Parameter::RW, 'row 19: the bind failure is X::Parameter::RW';
+    is $err.message,
+        "Parameter '\$v' expects a writable container (variable) as an argument,\n"
+        ~ "but got '1' (Int) as a value without a container.",
+        'row 19: ... with raku\'s wording';
+    is $err.symbol, '$v', 'row 19: .symbol names the parameter';
+    is $err.got, 1, 'row 19: .got carries the offending item';
+}
+
+# The rejection is keyed on the SOURCE being provably bare, not on "mutsu did
+# not promote this element": a producer ADR-0045 has not routed yet must keep
+# its (currently lost) write rather than acquire a spurious death, and the
+# forms that raku itself accepts must keep working.
+{
+    lives-ok { for (1, 2) -> $v is copy { $v = 5 } },
+        'invariant: `is copy` over a List is fine -- it binds a fresh container';
+    lives-ok { for () -> $v is rw { } },
+        'invariant: an empty source binds nothing, so there is nothing to reject';
+    lives-ok { for (1, 2) -> \v { my $x = v } },
+        'invariant: a sigilless param binds a bare item and only dies on assignment';
+    lives-ok { my @a = 1, 2; for flat(@a) -> $v is rw { $v = 9 } },
+        'invariant: an unrouted producer over a real Array must not die';
+    lives-ok { my @a = 1, 2; for @a[0, 1] -> $v is rw { $v = 9 } },
+        'invariant: an array slice source must not die';
+    lives-ok { my $x = 1; for $x -> $v is rw { $v = 5 } },
+        'invariant: a scalar source is a container';
 }
 
 # row 28


### PR DESCRIPTION
## What

`for (1, 2) -> $v is rw { $v = 5 }` ran to completion and silently discarded every write. Raku never enters the body: the parameter binds the item the iterator yields, an immutable source yields a value with **no container behind it**, and the *bind* fails.

mutsu now raises raku's own `X::Parameter::RW`, before the body runs and whether or not the body ever assigns:

```
Parameter '$v' expects a writable container (variable) as an argument,
but got '1' (Int) as a value without a container.
```

carrying `.symbol` (`$v`) and `.got` (the offending item). Closes ADR-0045 rows 19 and 30.

## The gate is the source, not the promotion

The tempting implementation — "ADR-0045 did not promote this element to a container, so reject the `is rw` bind" — is wrong in the expensive direction. `for flat(@a) -> $v is rw` and `for @a[0, 1] -> $v is rw` also fail to promote today (unrouted producers), but **raku aliases through both**. Rejecting there would swap a lost write for a spurious death.

So it keys off the compiler's conservative `ForLoopSpec::source_items_are_bare` — literal list, word list, `%h.keys`, and (added here) any `Range`, whatever its endpoints are. Sources raku also rejects but the flag does not yet see (`.map`, `.List`, `.Seq`, a sub's return, a Hash's Pairs) keep the old silent behaviour; widening the flag later is purely additive.

A sigilless `-> \v` is exempt — raku binds it to a bare item and only dies if the body *assigns* through it. The AST stores `\v` as plain `"v"`, so `ForLoopSpec` gained `param_sigilless`.

## The routine-call form got the same wording

`sub f($x is rw) {}; f(1)` was reporting an invented `X::Parameter::RW: 'x' expects a writable variable argument` — no sigil, no attributes, not an exception instance at all. Both signature-binder sites now build the shared `RuntimeError::parameter_rw_not_container`, so the routine form matches raku too.

## Verification

- `make test` — 3593 files / 35994 tests, green
- targeted roast sweep, **454 whitelisted files** mentioning `is rw` / `is raw` / `<->` or a pointy `for` — green
- `scripts/battery-testsuite.sh` — GATE PASSED (274/297)
- `t/for-loop-element-alias.t` un-`todo`s rows 19/30 and adds the exception-shape and must-not-die invariant rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)