### PR TITLE
fix: an element type-check failure names its container (ADR-0036 slice 4)

### DIFF
--- a/docs/adr/0036-element-container-pairs-from-subscripts-and-pairs.md
+++ b/docs/adr/0036-element-container-pairs-from-subscripts-and-pairs.md
@@ -1,7 +1,9 @@
 # ADR-0036: A Pair produced by a subscript adverb or `.pairs` carries the element *container*, not a snapshot
 
 - **Status**: Partially implemented — slices 1-2 landed (2026-08-20); slice 3's producer layer landed
-  2026-08-27 but `.pairs` itself is deferred (see "Implementation status — slice 3"); slice 4 open
+  2026-08-27 but `.pairs` itself is deferred (see "Implementation status — slice 3"); slice 4's
+  enforcement half landed with #7190 and its reporting half 2026-09-01, its compensator deletion is
+  still open
 - **Date**: 2026-08-20
 - **Deciders**: tokuhirom, Claude
 - **Related**: [ADR-0013](0013-container-interior-mutability-cellvalue.md) §5 open question 3 (element-level cells, "2c / Track B proper" — deferred there, and this ADR is the correctness driver that reopens it in a scoped form), [ADR-0001](0001-gc-strategy-and-phasing.md) (layer 3a / Track B framing), [ADR-0021](0021-argument-namedness-is-a-call-site-property.md) (Pair flavour unification — `.pairs`' output is data, not a call site), `todo/deep/subscript-p-pair-is-a-snapshot-not-a-container.md` (the originating finding)
@@ -461,6 +463,44 @@ recognizes one (measured: `roast/S32-array/multislice-6e.t`). Tracked in
 `todo/tickets/bound-array-slice-still-vivifies-eagerly.md`.
 
 ---
+
+## Implementation status — slice 4, the reporting half (2026-09-01)
+
+The **enforcement** half of this slice landed with ADR-0059's `is rw` bare-tail work (#7190):
+`array_slot_ref`/`hash_slot_ref` seed the promoted cell with the container's `value_type`, so a write
+through any alias -- the `:=` bind, `%h<k>`, the `:p` pair value, ADR-0045's `for`-loop element alias,
+the implicit topic -- is refused instead of silently landing. Row 12 of §1.3 is green.
+
+What that left wrong was the **report**, and this slice finishes it. A cell knew its type but not its
+origin, so every element failure fell through to `RuntimeError::typecheck_assignment(.., None)` and
+came out as `Type check failed in assignment; expected Int but got Str ("s")` -- no symbol at all,
+where raku says `Type check failed for an element of @a` and names the container rather than the
+alias the write came through. `$!.expected` was also a `Str`, not the expected type object, so
+`$!.expected === Int` failed.
+
+`ContainerCell::constraint` went from `Option<String>` to `Option<Box<CellConstraint>>` over
+`{ ty, element_of }` -- rakudo's single `$!descriptor` split into the half that decides legality and
+the half that decides blame, because both are observable and they word their failures differently (a
+typed *scalar*'s cell keeps "in assignment to `$x`"). Boxing makes the field 8 bytes instead of 24,
+so the cell shrank, which matters because ADR-0045 slice 4 promotes eagerly.
+
+The promotion primitives are `Value` methods and cannot see a variable name, so they seed
+`element_of` with the bare sigil -- exactly what raku prints for an anonymous container. Two sites
+that had already resolved the real name for their own routing retag the cell
+(`crate::value::retag_element_owner`): the `for`-loop element alias, and the loop's
+producer-carried-cell arm, which is what makes `for @a.values` / `for @a.reverse` blame `@a` even
+though `vm_element_producers.rs` only ever saw a receiver value. `for @a.sort` (no source tag at
+all), the `:=` bind and the subscript adverbs still report `@`/`%`; closing that needs the name to
+travel *with the container*, which is
+`todo/tickets/promoted-element-cell-does-not-know-its-container-name.md`.
+
+**The compensator deletion (the rest of slice 4) is NOT done** -- `methods_mut_method_lvalue.rs`'s
+env-scan and the `__mutsu_hash_ref` branch are untouched, and §1.3 row 11 is still `todo`-marked in
+`t/subscript-pair-element-container.t`.
+
+Verified with `make test`, a **full local `make roast`** (required by the "universal property of
+values" rule, since this changes what is inside every promoted container), and the bundled-battery
+gate.
 
 ## 5. Open questions (the forks for the deciders)
 

--- a/docs/adr/0045-for-loop-parameters-bind-the-element-container.md
+++ b/docs/adr/0045-for-loop-parameters-bind-the-element-container.md
@@ -1,8 +1,7 @@
 # ADR-0045: A `for` loop parameter binds the element *container*; the per-iteration writeback is retired
 
-- **Status**: Accepted — partially implemented (slices 0-4 landed 2026-08-27, slice 5's bind-time
-  rejection 2026-09-01; slice 5's element constraint and slice 6 open, see §8 "Implementation
-  status")
+- **Status**: Accepted — partially implemented (slices 0-4 landed 2026-08-27, slice 5 landed
+  2026-09-01; only row 16 (`.kv`) and slice 6's sweep remain, see §8 "Implementation status")
 - **Date**: 2026-08-20
 - **Deciders**: tokuhirom, Claude
 - **Related**: [ADR-0036](0036-element-container-pairs-from-subscripts-and-pairs.md) §7 (which names
@@ -711,14 +710,16 @@ been raising an invented `X::Parameter::RW: 'x' expects a writable variable argu
 `.symbol`/`.got`, not an exception instance at all). `sub f($x is rw) {}; f(1)` matches raku's message
 now too.
 
-**Row 28 is NOT part of this** — the element type constraint stays ADR-0036 slice 4's, as the note
-below says.
+**Row 28 landed separately** — the element type constraint belongs to the promoted cell, so ADR-0036
+slice 4 owns it, and it arrived in two pieces: the check with #7190, the raku wording (`for an
+element of @a`, naming the container rather than the alias) on 2026-09-01. The loop's contribution to
+the second piece is a retag — it has already resolved its source name, so it tells the cell which
+container to blame. See ADR-0036's slice-4 status.
 
 ### What slices 5-6 still own
 
-Row 16 (`.kv`), carried over from slice 4 — see above — and row 28 (the element type constraint;
-rows 19/30 landed 2026-09-01, see just above). It is `todo`-marked in `t/for-loop-element-alias.t`
-with the owning reason named in the reason string. The writeback family survives only as the fallback for shapes not yet converted:
+Row 16 (`.kv`), carried over from slice 4 — see above. It is the only `todo`-marked row left in
+`t/for-loop-element-alias.t`; rows 19/30 and 28 all landed 2026-09-01. The writeback family survives only as the fallback for shapes not yet converted:
 `write_back_for_rw_param`'s `kv_mode`, multi-parameter and scalar arms, and
 `write_back_hash_value_item` for a hash iteration that could not be promoted.
 

--- a/news/2026-09/element-type-check-failures-name-their-container.md
+++ b/news/2026-09/element-type-check-failures-name-their-container.md
@@ -1,0 +1,67 @@
+# An element type-check failure names its container again
+
+`#7190` made a promoted element container carry its container's element type
+constraint, which is what finally stopped a typed array from silently accepting
+a wrong-typed element through an alias. The check was right. The report was not:
+
+```
+$ raku  -e 'my Int @a = 1, 2; for @a -> $v is rw { $v = "s" }'
+Type check failed for an element of @a; expected Int but got Str ("s")
+
+$ mutsu -e 'my Int @a = 1, 2; for @a -> $v is rw { $v = "s" }'
+Type check failed in assignment; expected Int but got Str ("s")
+```
+
+Not just a different phrasing — mutsu's form has no symbol at all, so a failure
+in a loop over one of several typed containers said nothing about which one. And
+`$!.expected` came back as the `Str` `"Int"` rather than the `Int` type object,
+so the natural `$!.expected === Int` recovery test failed.
+
+Both are fixed. Every promoted-element path now reports raku's wording, and the
+`for`-loop, `:=`-bind, `:p`-pair and `.values`/`.reverse` paths name the
+container.
+
+## Why the cell had to learn where it came from
+
+`ContainerCell` had one constraint slot holding a type name. That is enough to
+decide whether an assignment is legal, but not enough to word the failure,
+because raku words the two origins differently: a typed *scalar* reports
+`Type check failed in assignment to $x`, while an *element* reports
+`Type check failed for an element of @a` — and names the **container**, not the
+alias the write arrived through.
+
+So the slot became `Option<Box<CellConstraint>>` over `{ ty, element_of }` —
+rakudo's single `$!descriptor` split into the half that decides legality and the
+half that decides blame. Boxing the pair makes the field 8 bytes where the bare
+`Option<String>` was 24, so the cell got *smaller*, which matters because
+ADR-0045 slice 4 promotes elements eagerly across whole containers.
+
+`array_slot_ref` / `hash_slot_ref` / `hash_autovivify_cell` mint the cells and
+are `Value` methods: they can read the container's `value_type` but have no idea
+which variable, if any, it is reachable through. They seed `element_of` with the
+bare sigil — which is exactly what raku prints for an anonymous container, as
+`my $x = (my Int @ = 1, 2); my $r := $x[0]; $r = "s"` shows. Two places then
+retag the cell with the real name, both of them places that had already resolved
+it for their own routing:
+
+- the `for`-loop element alias, which owns the source name in its plan; and
+- the loop's producer-carried-cell arm, so `for @a.values` / `for @a.reverse`
+  blame `@a` even though `vm_element_producers.rs` only ever saw a receiver
+  value.
+
+`for @a.sort` still reports `@`: it has no source tag at all (ADR-0045 §8
+records why routing the producer made one unnecessary), as do the `:=` bind and
+the subscript adverbs, whose opcodes receive the container on the stack with the
+name already discarded by `GetArrayVar`. Carrying the name properly means
+carrying it *on the container*, the way rakudo's descriptor does — filed as
+`todo/tickets/promoted-element-cell-does-not-know-its-container-name.md`, which
+also records the subtle rule that raku blames the *declaring* variable
+(`my Int @z` inside a sub) rather than the alias a caller binds it to.
+
+`hash_autovivify_cell` also seeds the constraint now. No repro is known that
+reaches it with a typed container — a typed hash's element cannot be the
+intermediate Hash that path promotes past — so this is consistency with its two
+siblings rather than a measured fix.
+
+Because it changes what is inside every promoted container, this went through a
+full local `make roast` as well as `make test` and the bundled-battery gate.

--- a/src/runtime/methods_mut_method_lvalue.rs
+++ b/src/runtime/methods_mut_method_lvalue.rs
@@ -538,16 +538,17 @@ impl Interpreter {
                     // Enforce a typed container's `of`-type constraint, so
                     // `Pair.new("foo", my Int $).value = "bar"` raises
                     // X::TypeCheck::Assignment (S02-types/pair.t).
-                    if let Some(constraint) = crate::value::lookup_container_constraint(&cell)
-                        && !matches!(constraint.as_str(), "Any" | "Mu")
+                    if let Some(c) = crate::value::lookup_cell_constraint(&cell)
+                        && !matches!(c.ty.as_str(), "Any" | "Mu")
                         && !value.is_nil()
-                        && !self.type_matches_value(&constraint, &value)
+                        && !self.type_matches_value(&c.ty, &value)
                     {
-                        return Err(RuntimeError::typecheck_assignment(
-                            &constraint,
-                            &value,
-                            None,
-                        ));
+                        return Err(match c.element_of {
+                            Some(owner) => crate::runtime::utils::type_check_element_typed_error(
+                                &owner, &c.ty, &value,
+                            ),
+                            None => RuntimeError::typecheck_assignment(&c.ty, &value, None),
+                        });
                     }
                     *cell.lock().unwrap() = value.clone();
                     return Ok(value);

--- a/src/runtime/utils/errors.rs
+++ b/src/runtime/utils/errors.rs
@@ -283,7 +283,13 @@ pub(crate) fn type_check_element_typed_error(
     let msg = type_check_element_error(var_name, expected, val);
     let display_name = format_var_name_for_error(var_name);
     let mut attrs = std::collections::HashMap::new();
-    attrs.insert("expected".to_string(), Value::str(expected.to_string()));
+    // `.expected` is the expected TYPE OBJECT, as raku's X::TypeCheck exposes
+    // it (`$!.expected.^name` is `Int`, not `Str`) -- matching the sibling
+    // `RuntimeError::typecheck_assignment`, which has always used it.
+    attrs.insert(
+        "expected".to_string(),
+        crate::value::expected_type_object(expected),
+    );
     // `.got` is the offending value itself (e.g. `42`), so `$!.got ~~ Int` holds,
     // matching Rakudo's X::TypeCheck.
     attrs.insert("got".to_string(), val.clone());

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -427,7 +427,27 @@ pub(crate) struct InstanceAttrs {
 #[derive(Debug)]
 pub struct ContainerCell {
     value: Mutex<Value>,
-    constraint: Mutex<Option<String>>,
+    constraint: Mutex<Option<Box<CellConstraint>>>,
+}
+
+/// A cell's `of`-type, plus where it came from.
+///
+/// Rakudo keeps both on one `$!descriptor`, and both are observable: the type
+/// decides whether an assignment is legal, and the origin decides which message
+/// the failure gets. A typed scalar's cell (`my Int $x`) reports "in assignment
+/// to $x"; an ELEMENT's cell reports "for an element of @a" and names the
+/// container, not the alias the write came through.
+#[derive(Debug, Clone)]
+pub struct CellConstraint {
+    /// The `of`-type the cell enforces on assignment.
+    pub ty: String,
+    /// Set when this cell is an *element* of a container: the container's
+    /// display name, as raku's "for an element of ..." wording spells it.
+    /// `array_slot_ref`/`hash_slot_ref` seed it with the bare sigil (`@`/`%`),
+    /// which is exactly what raku prints for an anonymous container; a
+    /// promotion site that knows the source variable overwrites it with the
+    /// real name.
+    pub element_of: Option<String>,
 }
 
 impl ContainerCell {
@@ -452,14 +472,53 @@ pub fn register_container_constraint(
     cell: &crate::gc::Gc<crate::value::ContainerCell>,
     type_name: &str,
 ) {
-    *cell.constraint.lock().unwrap() = Some(type_name.to_string());
+    *cell.constraint.lock().unwrap() = Some(Box::new(CellConstraint {
+        ty: type_name.to_string(),
+        element_of: None,
+    }));
+}
+
+/// Record that `cell` is an ELEMENT of a container whose `of`-type is
+/// `type_name` and whose display name is `owner` — ADR-0036 slice 4. The owner
+/// only shapes the error message; the check itself is `type_name`'s.
+pub fn register_element_constraint(
+    cell: &crate::gc::Gc<crate::value::ContainerCell>,
+    type_name: &str,
+    owner: &str,
+) {
+    *cell.constraint.lock().unwrap() = Some(Box::new(CellConstraint {
+        ty: type_name.to_string(),
+        element_of: Some(owner.to_string()),
+    }));
+}
+
+/// Name the container `cell` is an element of, when it is one and the promotion
+/// site recorded a better name than the bare sigil.
+pub fn retag_element_owner(cell: &crate::gc::Gc<crate::value::ContainerCell>, owner: &str) {
+    if let Some(c) = cell.constraint.lock().unwrap().as_mut()
+        && c.element_of.is_some()
+    {
+        c.element_of = Some(owner.to_string());
+    }
 }
 
 /// Look up the `of`-type constraint of a `ContainerRef` cell, if any.
 pub fn lookup_container_constraint(
     cell: &crate::gc::Gc<crate::value::ContainerCell>,
 ) -> Option<String> {
-    cell.constraint.lock().unwrap().clone()
+    cell.constraint
+        .lock()
+        .unwrap()
+        .as_ref()
+        .map(|c| c.ty.clone())
+}
+
+/// Look up the full constraint record — the `of`-type together with the
+/// container name to blame in an element type-check failure.
+pub fn lookup_cell_constraint(
+    cell: &crate::gc::Gc<crate::value::ContainerCell>,
+) -> Option<CellConstraint> {
+    cell.constraint.lock().unwrap().as_deref().cloned()
 }
 
 /// Cells that have been made read-only via `Pair.freeze`. A frozen `ContainerRef`

--- a/src/value/value_methods_a.rs
+++ b/src/value/value_methods_a.rs
@@ -670,6 +670,9 @@ impl Value {
             // SAFETY: aliased in-place mutation of a shared container; see
             // `gc_contents_mut`. No borrow into the map is live across the write.
             let data = unsafe { crate::value::gc_contents_mut(&arc) };
+            // A typed hash's value constraint rides on the promoted cell (see
+            // `array_slot_ref`).
+            let value_type = data.value_type.clone();
             match data.map.get_mut(key) {
                 Some(elem) => {
                     if let ValueView::ContainerRef(cell) = elem.view() {
@@ -681,6 +684,11 @@ impl Value {
                     let cell = crate::gc::Gc::new(crate::value::ContainerCell::new(
                         std::mem::replace(elem, Value::Nil),
                     ));
+                    // See `array_slot_ref` for why the owner name starts as
+                    // the bare sigil.
+                    if let Some(tc) = value_type.as_deref() {
+                        crate::value::register_element_constraint(&cell, tc, "%");
+                    }
                     *elem = Value::ContainerRef(cell.clone());
                     Some(Value::ContainerRef(cell))
                 }
@@ -738,8 +746,10 @@ impl Value {
                     let cell = crate::gc::Gc::new(crate::value::ContainerCell::new(
                         std::mem::replace(elem, Value::Nil),
                     ));
+                    // See `array_slot_ref` for why the owner name starts as
+                    // the bare sigil.
                     if let Some(tc) = value_type.as_deref() {
-                        crate::value::register_container_constraint(&cell, tc);
+                        crate::value::register_element_constraint(&cell, tc, "%");
                     }
                     *elem = Value::ContainerRef(cell.clone());
                     Some(Value::ContainerRef(cell))

--- a/src/value/value_methods_b.rs
+++ b/src/value/value_methods_b.rs
@@ -276,8 +276,12 @@ impl Value {
                 elem,
                 Value::Nil,
             )));
+            // The owner name defaults to the bare sigil, which is what raku
+            // prints for an anonymous container; a promotion site that knows
+            // the source variable retags it (`retag_element_owner`), so the
+            // failure blames `@a` the way a direct store does.
             if let Some(tc) = value_type.as_deref() {
-                crate::value::register_container_constraint(&cell, tc);
+                crate::value::register_element_constraint(&cell, tc, "@");
             }
             *elem = Value::ContainerRef(cell.clone());
             Some(Value::ContainerRef(cell))

--- a/src/vm/vm_for_loop_alias.rs
+++ b/src/vm/vm_for_loop_alias.rs
@@ -213,7 +213,10 @@ impl Interpreter {
                 if !Self::array_is_aliasable(&arr, Some(idx)) {
                     return None;
                 }
-                arr.array_slot_ref(idx, true)
+                Some(Self::name_element_owner(
+                    arr.array_slot_ref(idx, true)?,
+                    source,
+                ))
             }
             ForElementAlias::ArrayValue(arr) => {
                 if !Self::array_is_aliasable(arr, Some(idx)) {
@@ -232,9 +235,23 @@ impl Interpreter {
                 // which is a path, not an alias — and this loop's key came from
                 // the map, so a miss means the body deleted it.
                 hash.hash_get_str(key)?;
-                hash.hash_slot_ref(key, true)
+                Some(Self::name_element_owner(
+                    hash.hash_slot_ref(key, true)?,
+                    source,
+                ))
             }
         }
+    }
+
+    /// Tell a promoted element cell which container it belongs to, so an
+    /// element type-check failure blames `@a` rather than the bare `@` the
+    /// promotion primitive seeds (ADR-0036 slice 4). A no-op for an untyped
+    /// container, whose cell carries no constraint to name.
+    fn name_element_owner(item: Value, source: &str) -> Value {
+        if let ValueView::ContainerRef(cell) = item.view() {
+            crate::value::retag_element_owner(&cell, source);
+        }
+        item
     }
 
     /// Loop-entry guard: does this loop iterate the tagged source's elements

--- a/src/vm/vm_for_loop_body.rs
+++ b/src/vm/vm_for_loop_body.rs
@@ -647,6 +647,19 @@ impl Interpreter {
             // writeback that bind depends on. Retiring per LOOP instead of per
             // ITERATION silently drops such an iteration's write.
             let aliased = promoted.is_some() || item_carries_cell;
+            // A cell handed out by a container-aware producer (`.values`,
+            // `.reverse`, `.sort`) carries its container's element constraint
+            // but not the container's NAME -- `vm_element_producers.rs` sees a
+            // receiver value, not a variable. The loop resolved that name for
+            // its own routing, so tell the cell, and an element type-check
+            // failure blames `@a` the way a direct store does instead of the
+            // bare `@` the promotion primitive seeds.
+            if item_carries_cell
+                && let Some(ref source) = container_binding
+                && let ValueView::ContainerRef(cell) = item.view()
+            {
+                crate::value::retag_element_owner(&cell, source);
+            }
             rw_writeback = rw_writeback_base && !aliased;
             writes_back_loop_var = topic_writeback_base && !aliased;
             let item = promoted.unwrap_or(item);

--- a/src/vm/vm_helpers.rs
+++ b/src/vm/vm_helpers.rs
@@ -94,12 +94,20 @@ impl Interpreter {
         cell: &crate::gc::Gc<crate::value::ContainerCell>,
         val: &Value,
     ) -> Result<(), RuntimeError> {
-        if let Some(constraint) = crate::value::lookup_container_constraint(cell)
-            && !matches!(constraint.as_str(), "Any" | "Mu")
+        if let Some(c) = crate::value::lookup_cell_constraint(cell)
+            && !matches!(c.ty.as_str(), "Any" | "Mu")
             && !val.is_nil()
-            && !self.type_matches_value(&constraint, val)
+            && !self.type_matches_value(&c.ty, val)
         {
-            return Err(RuntimeError::typecheck_assignment(&constraint, val, None));
+            // An ELEMENT's cell blames the container, exactly as a direct
+            // `@a[0] = v` store does ("Type check failed for an element of
+            // @a"); a plain typed scalar's cell keeps the assignment wording.
+            return Err(match c.element_of {
+                Some(owner) => {
+                    crate::runtime::utils::type_check_element_typed_error(&owner, &c.ty, val)
+                }
+                None => RuntimeError::typecheck_assignment(&c.ty, val, None),
+            });
         }
         Ok(())
     }

--- a/t/for-loop-element-alias.t
+++ b/t/for-loop-element-alias.t
@@ -21,7 +21,7 @@ use Test;
 # (derived producers — `.kv`/`.reverse`/`.sort`/`@$s`) and slice 5 (bind-time
 # enforcement).
 
-plan 86;
+plan 93;
 
 # ---------------------------------------------------------------------------
 # Class 1 — a binding that outlives the loop body still writes through.
@@ -401,6 +401,29 @@ plan 86;
     # `value_type` (news/2026-09/is-rw-bare-tail-returns-container.md).
     dies-ok { my Int @a = 1, 2; for @a -> $v is rw { $v = "s" } },
         'row 28: a typed array rejects a bad element through the alias';
+
+    # ... and the write really is refused, not merely reported.
+    my Int @a = 1, 2;
+    try { for @a -> $v is rw { $v = "s" } };
+    is-deeply @a, Array[Int].new(1, 2), 'row 28: the typed array is unchanged';
+
+    my $err;
+    try { my Int @b = 1, 2; for @b -> $v is rw { $v = "s" }; CATCH { default { $err = $_ } } };
+    isa-ok $err, X::TypeCheck::Assignment, 'row 28: the failure is X::TypeCheck::Assignment';
+    is $err.message,
+        'Type check failed for an element of @b; expected Int but got Str ("s")',
+        'row 28: ... and it blames the container, not the alias';
+
+    # The topic form and a derived producer go through the same promoted cell.
+    dies-ok { my Int @c = 1, 2; for @c { $_ = "s" } },
+        'row 28: the implicit topic is constrained too';
+    dies-ok { my Int @d = 1, 2; for @d.values -> $v is rw { $v = "s" } },
+        'row 28: a `.values` producer hands out a constrained cell';
+    dies-ok { my Int %h = a => 1; for %h.values -> $v is rw { $v = "s" } },
+        'row 28: so does a typed hash';
+
+    lives-ok { my Int @e = 1, 2; for @e -> $v is rw { $v = 9 } },
+        'row 28: a well-typed write through the alias still lands';
 }
 
 # ---------------------------------------------------------------------------

--- a/t/subscript-pair-element-container.t
+++ b/t/subscript-pair-element-container.t
@@ -38,7 +38,7 @@ use Test;
 # Every expected value below was cross-checked against `raku` (see the ADR's
 # §1.3 table and this file's commit for the exact `raku -e` invocations).
 
-plan 34;
+plan 35;
 
 # --- §1.3 row 1: :p stale read (Slice 2) -----------------------------------
 {
@@ -202,6 +202,7 @@ plan 34;
     # Green since 2026-09-01: the promoted element cell carries its array's
     # `value_type` (news/2026-09/is-rw-bare-tail-returns-container.md).
     dies-ok { (@a[0]:p).value = 42 }, 'a typed array element constraint is enforced through :p (row 12)';
+    is-deeply @a, Array[Str].new("A", "B"), '... and the rejected write did not land (row 12)';
 }
 
 # --- Slice 3: the producers that now hand out element containers ------------

--- a/t/typed-element-alias-constraint.t
+++ b/t/typed-element-alias-constraint.t
@@ -1,0 +1,107 @@
+use Test;
+
+# ADR-0036 slice 4: an element promoted to its own container cell carries the
+# CONTAINER's element type constraint, so a write through any alias is checked
+# exactly as a direct `@a[0] = v` store is -- and the failure is REPORTED the
+# way raku reports it, naming the container rather than coming out as a bare
+# "Type check failed in assignment" with no symbol at all.
+
+plan 26;
+
+# --- the bind alias -------------------------------------------------------
+{
+    my Str @a = "x", "y";
+    dies-ok { my $r := @a[0]; $r = 42 }, 'a `:=`-bound element rejects a bad write';
+    is-deeply @a, Array[Str].new("x", "y"), '... and the array is unchanged';
+
+    my Str @b = "x", "y";
+    lives-ok { my $r := @b[0]; $r = "z" }, 'a well-typed write through the bind lands';
+    is-deeply @b, Array[Str].new("z", "y"), '... and reaches the element';
+}
+
+{
+    my Int %h = a => 1;
+    dies-ok { my $r := %h<a>; $r = "s" }, 'a `:=`-bound hash element rejects a bad write';
+    is %h<a>, 1, '... and the hash is unchanged';
+
+    my Int %g = a => 1;
+    lives-ok { my $r := %g<a>; $r = 9 }, 'a well-typed write through the hash bind lands';
+    is %g<a>, 9, '... and reaches the element';
+}
+
+# --- the subscript-adverb Pair -------------------------------------------
+{
+    my Int @a = 1, 2;
+    dies-ok { my $p = @a[0]:p; $p.value = "s" }, '`:p`\'s pair value is constrained';
+    is-deeply @a, Array[Int].new(1, 2), '... and the array is unchanged';
+
+    my Int @b = 1, 2;
+    lives-ok { my $p = @b[0]:p; $p.value = 9 }, 'a well-typed write through `:p` lands';
+    is-deeply @b, Array[Int].new(9, 2), '... and reaches the element';
+}
+
+# --- the `for`-loop element alias (ADR-0045 row 28) ----------------------
+# This path knows the source variable, so the message names it the way raku
+# does rather than falling back to the bare sigil.
+{
+    my $err;
+    my Int @a = 1, 2;
+    try { for @a -> $v is rw { $v = "s" }; CATCH { default { $err = $_ } } };
+    isa-ok $err, X::TypeCheck::Assignment, 'the `for` alias raises X::TypeCheck::Assignment';
+    is $err.message,
+        'Type check failed for an element of @a; expected Int but got Str ("s")',
+        '... naming the container, not the alias';
+    is $err.expected, Int, '.expected is the element type';
+    is $err.got, "s", '.got is the offending value';
+    is-deeply @a, Array[Int].new(1, 2), '... and the array is unchanged';
+
+    my Int %h = a => 1;
+    my $herr;
+    try { for %h.values -> $v is rw { $v = "s" }; CATCH { default { $herr = $_ } } };
+    is $herr.message,
+        'Type check failed for an element of %h; expected Int but got Str ("s")',
+        'a typed hash names itself too';
+}
+
+# --- an UNTYPED container must keep accepting anything -------------------
+{
+    my @a = 1, 2;
+    lives-ok { my $r := @a[0]; $r = "s" }, 'an untyped array element takes any value';
+    is-deeply @a, ["s", 2], '... and the write lands';
+
+    my %h = a => 1;
+    lives-ok { my $r := %h<a>; $r = "s" }, 'an untyped hash element takes any value';
+    is %h<a>, "s", '... and the write lands';
+
+    lives-ok { my @b = 1, 2; for @b -> $v is rw { $v = "s" } },
+        'an untyped `for` alias takes any value';
+}
+
+# --- a producer-handed cell is named by the loop too ----------------------
+# `vm_element_producers.rs` sees a receiver value, not a variable, so the cell
+# it hands out starts with the bare sigil; the loop retags it.
+{
+    my $err;
+    my Int @a = 1, 2;
+    try { for @a.values -> $v is rw { $v = "s" }; CATCH { default { $err = $_ } } };
+    is $err.message,
+        'Type check failed for an element of @a; expected Int but got Str ("s")',
+        '`.values` blames the source array';
+
+    my $rerr;
+    my Int @b = 1, 2;
+    try { for @b.reverse -> $v is rw { $v = "s" }; CATCH { default { $rerr = $_ } } };
+    is $rerr.message,
+        'Type check failed for an element of @b; expected Int but got Str ("s")',
+        '`.reverse` blames the source array';
+}
+
+# --- a plain typed SCALAR keeps its own wording --------------------------
+# Its cell is not an element of anything, so raku reports the assignment form.
+{
+    my $err;
+    try { my Int $x; my $r := $x; $r = "s"; CATCH { default { $err = $_ } } };
+    is $err.message,
+        'Type check failed in assignment to $x; expected Int but got Str ("s")',
+        'a typed scalar cell keeps the assignment wording';
+}

--- a/todo/tickets/promoted-element-cell-does-not-know-its-container-name.md
+++ b/todo/tickets/promoted-element-cell-does-not-know-its-container-name.md
@@ -1,0 +1,79 @@
+# A promoted element cell reports the bare sigil, not the container's name
+
+ADR-0036 slice 4 made a promoted element container carry its container's
+element type constraint, so a wrong-typed write through any alias is now
+refused instead of silently landing. The **check** is right everywhere. The
+**message** names the container only on the `for`-loop path.
+
+## Repro
+
+```
+$ raku  -e 'my Int @a = 1, 2; my $r := @a[0]; $r = "s"'
+Type check failed for an element of @a; expected Int but got Str ("s")
+
+$ mutsu -e 'my Int @a = 1, 2; my $r := @a[0]; $r = "s"'
+Type check failed for an element of @; expected Int but got Str ("s")
+```
+
+Same shape for `%h<a>`, for `(@a[0]:p).value = ...`, and for every other
+promotion site. The `for`-loop alias is correct because
+`vm_for_loop_alias.rs::name_element_owner` retags the cell with the source name
+the loop already resolved:
+
+```
+$ mutsu -e 'my Int @a = 1, 2; for @a -> $v is rw { $v = "s" }'
+Type check failed for an element of @a; expected Int but got Str ("s")   # matches raku
+```
+
+`@` / `%` is not nonsense — it is exactly what raku prints for an anonymous
+container (`my $x = (my Int @ = 1, 2); my $r := $x[0]; $r = "s"`) — so the
+output is well-formed, just less specific than it should be.
+
+## Why it is like this
+
+`Value::array_slot_ref` / `Value::hash_slot_ref` mint the cell, and they are
+`Value` methods: they see the `ArrayData`/`HashData` (hence `value_type`) but
+have no idea which variable, if any, the container is reachable through. They
+seed `CellConstraint::element_of` with the bare sigil, and a promotion site that
+*does* know the name calls `crate::value::retag_element_owner`.
+
+There are ~42 call sites of the two primitives. Only a handful know a name, and
+the ones that matter here (`Index`, the `:p`/`:kv` subscript adverbs, the
+multi-dim bind descent) sit under opcodes that receive the container as a value
+on the stack, with the name already discarded by `GetArrayVar`.
+
+## Two candidate fixes
+
+1. **Carry the name on the container.** Add an owner field next to
+   `ArrayData::value_type` / `HashData::value_type`, set where the typed
+   declaration is compiled. This is what rakudo does (one `$!descriptor` holds
+   `name` and `of` together) and it would fix every site at once, including
+   raku's subtle rule that the name is the *declaring* variable, not the alias
+   the write came through:
+
+   ```
+   $ raku -e 'sub f() { my Int @z = 1, 2; @z }; my @b := f(); my $r := @b[0]; $r = "s"'
+   Type check failed for an element of @z; ...      # @z, not @b
+   ```
+
+   The cost is that `value_type` has ~21 write sites in `src/`, most of them
+   *propagation* (hyper ops, coercions, `methods_mut_dispatch`), and each would
+   have to decide whether the owner travels with it.
+
+2. **Retag at the naming opcodes.** Extend the `retag_element_owner` call the
+   `for` loop already makes to the `Index` / subscript-adverb / bind-descent
+   opcodes, passing the name down from the opcode that resolved the variable.
+   Cheaper, but it cannot express the `@z`-not-`@b` rule, and it has to be
+   repeated for each new promotion site.
+
+Option 1 is the honest one and probably belongs in ADR-0042's orbit (type
+constraints belong to the container, not to a name — this is the *name* half of
+the same descriptor). Option 2 is a fine interim if a concrete test starts
+depending on the wording.
+
+## Not blocking anything measured
+
+No roast test asserts this message text (checked: `grep -rn 'element of' roast/`
+finds only test *descriptions*), and `t/typed-element-alias-constraint.t` pins
+the `for` path's exact wording plus the dies/does-not-land behaviour of the
+others, so a fix here is a strict improvement rather than a repair.


### PR DESCRIPTION
## What

#7190 made a promoted element container carry its container's element type constraint — that is what stopped a typed array from silently accepting a wrong-typed element through an alias. The **check** was right. The **report** was not:

```
raku : Type check failed for an element of @a; expected Int but got Str ("s")
mutsu: Type check failed in assignment; expected Int but got Str ("s")
```

Not merely a different phrasing — mutsu's form carried **no symbol at all**, so a failure inside a loop over one of several typed containers said nothing about which one. `$!.expected` was also the `Str` `"Int"` rather than the `Int` type object, so `$!.expected === Int` failed.

## Why the cell had to learn where it came from

A cell knew its type but not its *origin*, and raku words the two origins differently: a typed **scalar** reports `in assignment to $x`, an **element** reports `for an element of @a` and names the *container*, not the alias the write arrived through.

So `ContainerCell::constraint` goes from `Option<String>` to `Option<Box<CellConstraint>>` over `{ ty, element_of }` — rakudo's single `$!descriptor` split into the half that decides legality and the half that decides blame. Boxing makes the field **8 bytes where the bare `Option<String>` was 24**, so the cell shrank; that matters because ADR-0045 slice 4 promotes eagerly across whole containers.

`array_slot_ref` / `hash_slot_ref` / `hash_autovivify_cell` are `Value` methods and cannot see a variable name, so they seed `element_of` with the bare sigil — exactly what raku prints for an anonymous container (`my $x = (my Int @ = 1, 2); my $r := $x[0]; $r = "s"` really does say `for an element of @`). Two sites that had already resolved the real name retag the cell:

- the `for`-loop element alias, and
- the loop's producer-carried-cell arm, so `for @a.values` / `for @a.reverse` blame `@a` even though `vm_element_producers.rs` only ever saw a receiver value.

`for @a.sort` (no source tag at all), the `:=` bind and the subscript adverbs still report `@`/`%`. Carrying the name properly means carrying it **on the container**, the way rakudo's descriptor does — filed as `todo/tickets/promoted-element-cell-does-not-know-its-container-name.md`, which also records raku's subtle rule that the blame goes to the *declaring* variable, not the alias a caller binds.

`hash_autovivify_cell` seeds the constraint too. No repro is known that reaches it with a typed container, so that arm is consistency with its two siblings rather than a measured fix — stated as such in the code and the news entry.

## Verification

- `make test` — 3596 files / 36064 tests, green
- **full local `make roast`** — 1435 files / 218833 tests, green (required: this changes what is inside every promoted container)
- `scripts/battery-testsuite.sh` — GATE PASSED (274/297)
- new pin `t/typed-element-alias-constraint.t` (26 tests) across the bind / `%h<k>` / `:p` / `for` / producer / untyped / typed-scalar paths; `t/subscript-pair-element-container.t` row 12 gains a "the write did not land" assertion

🤖 Generated with [Claude Code](https://claude.com/claude-code)