### PR TITLE
fix: retire the last two writeback arms (ADR-0045 slice 6)

### DIFF
--- a/docs/adr/0045-for-loop-parameters-bind-the-element-container.md
+++ b/docs/adr/0045-for-loop-parameters-bind-the-element-container.md
@@ -1,7 +1,8 @@
 # ADR-0045: A `for` loop parameter binds the element *container*; the per-iteration writeback is retired
 
-- **Status**: Accepted — slices 0-5 implemented (0-4 on 2026-08-27, 5 on 2026-09-01); only slice 6's
-  sweep remains, see §8 "Implementation status"
+- **Status**: Accepted — **fully implemented** (slices 0-4 on 2026-08-27, 5-6 on 2026-09-01). §1.3's
+  whole table was re-measured against raku at slice 6 and all 45 rows agree; see §8 "Implementation
+  status"
 - **Date**: 2026-08-20
 - **Deciders**: tokuhirom, Claude
 - **Related**: [ADR-0036](0036-element-container-pairs-from-subscripts-and-pairs.md) §7 (which names
@@ -772,14 +773,120 @@ read half of rows 11/20 for the multi-parameter shapes. It is pre-existing and m
 `todo/tickets/proxy-assigned-into-an-array-is-not-fetched.md`, which is why
 `t/for-loop-element-alias.t`'s new multi-parameter row names its parameters `$p`/`$q`.
 
-### What slices 5-6 still own
+### Slice 6 — the sweep, 2026-09-01
+
+**§1.3 re-measured end to end: 45 of 45 rows agree with raku.** Each row was rebuilt as its own
+one-liner (`tmp/rwalias/rowNN.raku`, one file per row so no earlier statement contaminates the next)
+and run under both `raku` and a release `mutsu`, comparing stdout and stderr verbatim; the three
+`dies` rows (19, 28, 30) match raku's message text as well as the fact of dying. Nothing from the
+divergence table survives, and every invariant row still holds.
+
+**§1.5 re-measured.** `for @a <-> $x { $x = $x + 1 }`, release build, best of three:
+
+| n | before slice 1 | now |
+| --- | --- | --- |
+| 5 000 | 0.073 s | 0.01 s |
+| 10 000 | 0.276 s | 0.01 s |
+| 20 000 | 1.095 s | 0.02 s |
+| 40 000 | 5.157 s | 0.03 s |
+| 80 000 | — | 0.07 s |
+| 160 000 | — | 0.15 s |
+
+Each doubling roughly doubles the time. The quadratic is gone.
+
+#### What the sweep actually found — two shapes still on the writeback
+
+The sweep is what justified doing this slice as measurement rather than as a paperwork exercise.
+`write_back_container_source` — the one function every element writeback funnels its store through —
+was instrumented behind an env var and every file in `t/` and in `roast-whitelist.txt` was run under
+it. **140 251 stores across 766 whitelisted roast files** were still happening, and they fell into
+exactly two shapes, both of which had been invisible to §1.3 because both produced raku's answer for
+the *simple* write:
+
+1. **A `Pair` element — 137 808 of the 140 251 stores.** `loop_var_unchanged` had no `Pair` arm, so
+   an array of `Pair`s failed the identity test in two places at once: `items_are_source_elements`
+   declined the loop, so the topic was **never promoted** over a Pair element, and the writeback's
+   own unchanged-guard never fired, so **even a read-only loop rebuilt the whole backing
+   `ArrayData` once per iteration**. A read-only `$sum += .key for @pairs` was O(n²) — 1.87 s at
+   n = 8 000 against raku's flat 0.02 s. A `Pair` is a by-value variant, so there is no pointer
+   identity to test, but equal key *and* equal value means the store is a no-op, exactly like the
+   `Str`/`Int`/`Rat` arms already there. With that arm the topic promotes, the writeback retires, and
+   the same loop runs in 0.03 s at n = 8 000 and 0.04 s at n = 16 000 — flat. `roast/S32-str/`'s
+   `sprintf-*.t` family alone accounted for over 100 000 of the stores, through one
+   `... for @tests;` statement modifier.
+
+2. **The multi-parameter rw loop.** A multi-parameter loop binds through `build_for_bind_stmts`'s
+   `MarkBind` declarations, which read `_[i]` out of a **chunk** — a fresh `Array` built by
+   `items.chunks(arity)`. Promoting the chunk would alias the temporary, so slice 4 had converted
+   only `.kv`, whose *producer* hands out the source's cells. A plain `for @a -> $x, $y is rw`
+   therefore stayed on the writeback, and reached raku's write answer **by accident**: the retained
+   writeback stored the chunk's own cell *into* the source element, so a later write through the
+   parameter did land in `@a`, only after the iteration had ended. Three things followed from that
+   accident, and the sweep found all three:
+
+   - the **read** direction stayed stale — `for @a -> $p is rw, $q is rw { @a[1] = 55; say $q }`
+     printed `2` where raku prints `55` (row 41's multi-parameter twin);
+   - **class 3 survived** — `for @a -> $x, $y is rw { $y = 9; @a = 7,8,7,8 }` gave `[1 9 7 8]`
+     against raku's `[7 8 7 8]` (row 38's twin), silent corruption with no closure involved;
+   - and the shape stayed **O(n²)**: 45.7 s at n = 40 000, the one place §1.5's quadratic had
+     survived slice 1.
+
+   The fix is the same routing as everywhere else, applied one step earlier:
+   `promote_multi_param_elements` promotes the source's elements **before** the item vector is
+   chunked, so the chunk carries `@a`'s cells and `array_slot_ref`'s idempotence makes the
+   `MarkBind` bind alias the source element. `binding_carries_element_cell` then fires and the
+   writeback retires for the iteration. Only positions whose parameter genuinely aliases are
+   promoted — `rw_param_names` is positionally aligned with the chunk and holds `""` for a non-rw
+   slot, the same distinction `build_for_bind_stmts` already makes, so `for @e -> \a, @b { }` leaves
+   `@b`'s slot alone and rows 45/46's "a plain parameter must not alias" still holds. Measured after:
+   0.01 s / 0.03 s / 0.05 s / 0.11 s / 0.20 s at n = 5 000 … 80 000. Flat.
+
+Both are pinned at the end of `t/for-loop-element-alias.t`, each with its own O(n) bound.
+
+#### What survives, and why it is not debt
+
+The writeback family is **not** deleted, and should not be. What remains is the fallback for the
+shapes this ADR deliberately excluded, each with its own pin:
+
+| surviving arm | serves | why it stays |
+| --- | --- | --- |
+| `write_back_for_rw_param` / `write_back_for_topic_item` | shaped, lazy and native-backed arrays; a `Proxy` element; an iteration whose index/key the body removed | §5 Q5 and Q6. Retiring per *loop* rather than per *iteration* silently drops these writes. |
+| `write_back_hash_value_item` | a hash iteration that could not be promoted | same, for `%h.values`. |
+| `write_back_to_source_var` | a scalar-source loop (`for $x { … }`) and `for ($a, $b, $c) { $_++ }` | not an element source at all; there is no container whose element could be promoted. |
+| `write_back_quanthash_rw` / `write_back_quanthash_value_item` | QuantHash **weights** | §2.4. A weight is not a stored element container and `.value = 0` *removes* the key, so it is a different operation. |
+| `write_back_element_source` | `given`/`when` topic writeback | a different construct that happens to share the store. |
+
+`loop_var_unchanged` also stays: it is now the *promotion* discriminator
+(`items_are_source_elements` consults it) as much as the writeback's skip guard, which is what made
+its missing `Pair` arm cost so much.
+
+#### Two findings recorded rather than fixed here
+
+- **`Pair.value = X` does not enforce an immutable value.** `my $p = (1 => "a"); $p.value = "z"`
+  succeeds in mutsu; raku throws `Cannot modify an immutable Str (a)`. Verified loop-independent (it
+  reproduces with no `for` at all), so it is a `Pair.value` lvalue gap, not this ADR's —
+  `todo/tickets/pair-value-assign-does-not-enforce-immutable-value.md`.
+- **`for $a, 1, $b, 2 -> \x, $v { x = $v }` still writes through to nothing.** The source is a
+  comma-list of *variables*, not a container, so no element exists to promote and §1.3 has no row for
+  it. It stays `todo/deep/for-loop-pointy-sigilless-param-write-through-missing.md`, explicitly out
+  of this ADR's scope.
+- The multi-parameter **read-only closure capture** (`$c = -> { $v }` over a multi-parameter, which
+  snapshots by value) is unchanged by slice 6 and remains
+  `todo/tickets/multi-param-read-only-closure-capture-snapshots-the-element.md`. It is a
+  closure-capture mechanism, not a bind-site one.
+
+### What slices 5-6 owned, as recorded before the sweep
 
 Nothing from §1.3: rows 16, 19, 28 and 30 all landed 2026-09-01, and
-`t/for-loop-element-alias.t` has no `todo`-marked row left. **Slice 6 (the sweep) is what remains** —
-re-run §1.5's bench, re-read §1.3's table end to end, and retire the writeback family's surviving
-arms. The writeback family survives only as the fallback for shapes not yet converted:
-`write_back_for_rw_param`'s `kv_mode`, multi-parameter and scalar arms, and
-`write_back_hash_value_item` for a hash iteration that could not be promoted.
+`t/for-loop-element-alias.t` has no `todo`-marked row left, which is what left slice 6 as a sweep.
+
+This paragraph's guess at what the sweep would find was **half wrong, in the direction that
+mattered**. It expected the surviving writeback arms to be a residue of shapes "not yet converted",
+i.e. bookkeeping. Two of them were live defects instead — the multi-parameter arm and the `Pair`
+element — and neither was visible from §1.3, because both produced raku's answer for the simple
+write and diverged only on a *read* through the alias, on a wholesale rebind, and on the clock. It is
+recorded verbatim as a caution: a table of known divergences is not a proof that a mechanism has been
+retired, and "which code still runs" is a question only instrumentation answers.
 
 **Row 28 turned green on 2026-09-01**: the promoted element cell carries its array's `value_type`
 (landed with ADR-0059's bare-tail half, `news/2026-09/is-rw-bare-tail-returns-container.md`), so
@@ -808,5 +915,5 @@ independent of this ADR — recorded as
 
 ---
 
-*Slices 0-4 of this ADR are implemented; the decision stands. If the mechanism judgment changes
-later, supersede it rather than rewriting it.*
+*Every slice of this ADR is implemented and its §1.3 table re-measured green; the decision stands. If
+the mechanism judgment changes later, supersede it rather than rewriting it.*

--- a/news/2026-09/for-loop-parameters-bind-the-element-container.md
+++ b/news/2026-09/for-loop-parameters-bind-the-element-container.md
@@ -1,52 +1,69 @@
-# `for @arr -> $v is rw { ... }` element aliasing doesn't survive into a closure called after the loop
+# A `for` loop parameter binds the element container (ADR-0045, closed)
 
-## Status
+## Outcome
 
-**Partially fixed (2026-08-27) — ADR-0045 slices 0-3 landed.** The headline symptom below is gone:
-`for @list -> $v is rw { @callbacks.push(-> { $v = $v + 1 }) }` now binds `$v` to the element's own
-`ContainerRef` (`array_slot_ref`) at the bind site, so a closure called after the loop writes through
-and the repro prints raku's `[11 21]`.
+**Closed 2026-09-01.** This began as a bug report — a closure that escaped a
+`for @a -> $v is rw` loop no longer wrote through to `@a` — and grew into
+[ADR-0045](../../docs/adr/0045-for-loop-parameters-bind-the-element-container.md),
+whose §1.3 measured **27 divergences from raku in five classes**, only one of
+which this file had described. All of them are now gone: the ADR's slice 6 sweep
+(2026-09-01) re-ran the whole table against `raku` row by row and **all 45 rows
+agree**, and `t/for-loop-element-alias.t` pins every one of them, with no
+`todo`-marked row left.
 
-Slice 1 turned these ADR-0045 §1.3 rows green: **01, 02, 03, 04, 07, 11, 12, 13, 14, 20, 27, 36, 38,
-41, 43** — the whole deferred-closure class for a direct array source, the stale-read class for it,
-and the class-3 clobber (including row 38, the body rebinding `@a` wholesale). Slices 2 and 3 added
-**08** (hash sources, via `hash_slot_ref`), **21, 42, 44** (the implicit topic, which promotes) and
-**22** (the plain named parameter, which turned out to be a pure deletion — `for @a -> $v { @a[1] =
-99 }`, silent corruption in code using no advanced feature at all).
+The decision was to stop copying the loop variable back into the source at the
+end of each iteration, and instead bind the parameter to the element's own
+`ContainerRef` (`array_slot_ref` / `hash_slot_ref`) at the bind site — the
+primitive [ADR-0036](../../docs/adr/0036-element-container-pairs-from-subscripts-and-pairs.md)
+had already shipped for `:=`-bound elements. That is what Raku specifies: `for`
+binds the *item the iterator yields*, and for a real mutable `Array`/`Hash` that
+item **is** the element's `Scalar`.
 
-Three measured quadratics went with them: the mutating `<->` loop (160 000 elements: 39.8 s →
-0.16 s), the mutating *topic* loop (43.1 s → 0.16 s) and `for %h.values -> $v is rw` (20 000
-elements: 17.3 s → 0.04 s).
+Three of the five divergence classes needed no closure and no `is rw` at all:
+`for @a -> $v { @a[1] = 99 }` silently lost the write, `for @a.reverse -> $v is
+rw` wrote each value to the *mirror-image* index, and every mutating loop was
+**O(n²)** because each iteration rebuilt the entire backing `ArrayData` to
+change one element. The last of those is the headline number: a mutating `<->`
+loop over 160 000 elements went from 39.4 s to 0.11 s, and it is flat now rather
+than merely faster.
 
-**Still open**, and why this file stays here: rows 16, 17, 24, 39 (derived producers —
-`.kv`/`.reverse`/`.sort`/`@$s`, slice 4) and rows 19, 28, 30 (bind-time enforcement, slice 5). Each
-is `todo`-marked in `t/for-loop-element-alias.t` with its owning slice named. Retire this file to
-`news/2026-08/` when ADR-0045's slice 6 lands, per the note below.
+The slices, and where each is written up:
 
-The mechanism decision lives in
-[ADR-0045](../../docs/adr/0045-for-loop-parameters-bind-the-element-container.md) (2026-08-20):
-bind the loop parameter to the element's `ContainerRef` (`array_slot_ref` / `hash_slot_ref`) at the
-bind site and retire the per-iteration writeback family. Read ADR-0045 before starting — it carries a
-27-row divergence matrix re-measured on `main` (33f75a62f), the invariant table that bounds it, the
-writeback-family inventory, the phasing, and the open questions. This file stays open only as the
-tracking record; retire it to `news/2026-08/` when ADR-0045's slice 6 lands.
+| slice | what | landed |
+| --- | --- | --- |
+| 0-1 | the pin file; the direct array source with a writable aliasing parameter | 2026-08-27 |
+| 2-3 | hash sources; the implicit topic — and the plain named parameter, which turned out to be a *pure deletion* | 2026-08-27 |
+| 4 | derived producers (`.values`, `.reverse`, `.sort`, `.kv`), routed at the producer with ADR-0036 slice 3 | 2026-08-27 / 2026-09-01 |
+| 5 | bind-time rejection of an `is rw` bind against an immutable source, and the element type constraint | 2026-09-01 |
+| 6 | the sweep — and the two shapes it found still on the writeback | 2026-09-01 |
 
-**Two claims below are now known to be wrong, and are kept only for the record:**
+**Slice 6 was not paperwork.** Instrumenting the one function every element
+writeback stores through, and running all of `t/` and the whole roast whitelist
+under it, found **140 251 stores still happening** — and they were not residue.
+An array of `Pair`s had never been promoted at all (`loop_var_unchanged` had no
+`Pair` arm, so the identity test failed twice over), which left even a
+*read-only* `$sum += .key for @pairs` quadratic at 1.87 s for 8 000 elements;
+and the multi-parameter rw loop was reaching raku's write answer **by accident**,
+its retained writeback storing the chunk's own cell into the source element after
+the fact — so a read through the alias stayed stale, a wholesale rebind was still
+clobbered, and that shape stayed O(n²) at 45.7 s for 40 000 elements. Both are
+fixed and pinned. ADR-0045 §8 has the detail.
 
-1. **The stated blocker does not exist.** This file concluded that a fix must wait on a
-   *share-vs-bind distinction at the element-store layer*, because an element store write-throughs
-   any `ContainerRef` element unconditionally. [ADR-0036](../../docs/adr/0036-element-container-pairs-from-subscripts-and-pairs.md)
-   §7 answers this directly: unconditional write-through **is** the Raku semantics (`@a[0] = "Q"`
-   assigns *into* the element's `Scalar`, it never replaces it), so the distinction must not be
-   built. Re-measured on `main`, the hand-written form of the fix — a `:=`-bound element captured by
-   a closure that escapes and is called later — already produces raku's answer on every probe,
-   including the `.raku`/`.elems` invisibility invariant. The primitive shipped; the work is routing.
-2. **The symptom is much wider than a deferred closure.** The deferred-closure case is one of five
-   divergence classes. Three of the others need no closure and no `is rw` at all: an end-of-iteration
-   whole-container rebuild **clobbers writes the body made directly to the source**
-   (`for @a -> $v { @a[1] = 99 }` loses the write), `for @a.reverse -> $v is rw` writes each value to
-   the *mirror-image* index, and the mutating `<->` loop is **O(n²)** (5.2 s for 40 000 elements
-   against raku's 0.012 s) because of that same rebuild. See ADR-0045 §1.3 and §1.5.
+The two claims this file originally made that turned out to be wrong are kept
+below, verbatim, because they are the useful part of the record.
+
+**Wrong claim 1 — "the fix is blocked on a share-vs-bind distinction at the
+element-store layer."** It is not, and building that distinction would have been
+a bug: unconditional write-through **is** the Raku semantics (`@a[0] = "Q"`
+assigns *into* the element's `Scalar`, it never replaces it), which ADR-0036 §7
+says directly. The hand-written form of the fix already produced raku's answer on
+every probe before a line was written. The work was routing, not invention.
+
+**Wrong claim 2 — "this is about deferred closures."** It was one of five
+classes, and the three that mattered most to ordinary code involved no closure,
+no `rw`, and no concurrency.
+
+The original report follows.
 
 ## Symptom
 
@@ -180,27 +197,26 @@ ticket — see "Where this connects" below before starting design.
 The repro above, no fixtures needed. Expected (raku): `11`, `21`,
 `[11 21]`. Actual (mutsu): `11`, `21`, `[10 20]`.
 
-## Re-verified 2026-09-01 (TRIAGE regeneration)
+## What was still open at the last triage, and where it went
 
-Headline repro prints raku's `11` / `21` / `[11 21]`. `.reverse` and `.sort`
-sources now write through as well, so **rows 17 and 24 pass** — the "still
-open: 16, 17, 24, 39" line above is stale by two rows. What
-`t/for-loop-element-alias.t` still `todo`-marks:
+Recorded 2026-09-01, just before slice 6 closed this file:
 
-- row 16 (`.kv` + escaping closure) — **landed 2026-09-01**,
+- row 16 (`.kv` + escaping closure) — landed,
   `news/2026-09/kv-hands-out-element-containers-to-a-multi-param-loop.md`;
-- rows 19/30 (`is rw` over a List/Range must die at bind) — **landed
-  2026-09-01**, `news/2026-09/for-loop-is-rw-over-an-immutable-source-fails-at-bind.md`;
-- row 28 (typed-array element constraint through the alias) — **landed
-  2026-09-01** as ADR-0036 slice 4,
+- rows 19/30 (`is rw` over a List/Range must die at bind) — landed,
+  `news/2026-09/for-loop-is-rw-over-an-immutable-source-fails-at-bind.md`;
+- row 28 (typed-array element constraint through the alias) — landed as
+  ADR-0036 slice 4,
   `news/2026-09/element-type-check-failures-name-their-container.md`;
-- rows 39/39b (`for @$s`) — deliberately backed out and owned by its own file,
-  `todo/tickets/for-deref-container-source-promotion-breaks-nqp-type-tests.md`.
+- rows 39/39b (`for @$s`) — the promotion was deliberately backed out once and
+  re-landed through `ForElementAlias::ArrayValue`; the nqp-type-test fallout it
+  caused is its own file.
 
-**As of 2026-09-01 this file has no residue of its own.** `t/for-loop-element-alias.t`
-carries no `todo` at all, and every row it still names is another file's. It is
-kept open only because ADR-0045 slice 6 (the sweep) is what closes it out to
-`news/`; do not dispatch it as a bug.
+Two neighbouring gaps stay open and are explicitly **not** this ADR's:
 
-A further producer with the same gap: `for @a.Seq { $_++ }`
-(`todo/tickets/array-seq-view-does-not-carry-element-containers.md`).
+- `for $a, 1, $b, 2 -> \x, $v { x = $v }` writes through to nothing. The source
+  is a comma-list of *variables*, not a container, so there is no element to
+  promote — `todo/deep/for-loop-pointy-sigilless-param-write-through-missing.md`.
+- `Pair.value = X` does not enforce an immutable value. Found during the sweep,
+  verified loop-independent —
+  `todo/tickets/pair-value-assign-does-not-enforce-immutable-value.md`.

--- a/src/vm/vm_for_loop_alias.rs
+++ b/src/vm/vm_for_loop_alias.rs
@@ -23,7 +23,22 @@
 //! Slices landed here: 1 (direct array source, writable aliasing parameter),
 //! 2 (`%h.values`), 3 (the implicit topic; the plain named parameter is a pure
 //! deletion with no promotion at all — rows 45/46 pin that `-> $v` binds the
-//! *value*).
+//! *value*), and the `$`-tagged deref'd-container shape of slice 4
+//! ([`ForElementAlias::ArrayValue`], row 39).
+//!
+//! **The other half of slice 4 is deliberately NOT here.** `.kv`, `.reverse`,
+//! `.sort` and `.values` alias through their *producers*
+//! (`vm_element_producers.rs`, ADR-0036 slice 3's routing): the producer hands
+//! out the element container, so the item the loop binds already carries its
+//! own identity and this discriminator has nothing left to decide. That is why
+//! `kv_mode` / `container_reversed` / `values_mode` still return
+//! [`ForElementAlias::None`] below — not "not yet supported", but "already
+//! handled one layer up". The bind site recognises such an item with
+//! `binding_carries_element_cell` and retires the writeback for it just the
+//! same (`vm_for_loop_body.rs`).
+//!
+//! Slice 6's sweep (2026-09-01) re-measured the whole of ADR-0045 §1.3 against
+//! raku: all 45 rows agree.
 
 use super::vm_control_ops::ForLoopSpec;
 use super::*;
@@ -76,13 +91,18 @@ impl Interpreter {
     /// here on purpose: `for @a -> $v { @a[0] = 9; say $v }` prints `1` in
     /// raku, and the deferred-read form prints `1 2` (rows 45/46).
     ///
-    /// **Which sources alias**: a direct, real, mutable, plain `Array`, or a
-    /// `%h.values` over a real mutable `Hash`. Derived producers
-    /// (`.kv`/`.pairs`/`.reverse`/`.sort`, and the `$`-tagged `for @$s` shape)
-    /// are excluded until slice 4 makes those producers hand out element
-    /// containers themselves; a multi-parameter loop binds through the
-    /// bind-prefix `Stmt::Assign`s rather than this native bind site, so it is
-    /// excluded too.
+    /// **Which sources alias here**: a direct, real, mutable, plain `Array`, the
+    /// `$`-tagged deref'd-container shape (`for @$s`), or a `%h.values` over a
+    /// real mutable `Hash`.
+    ///
+    /// The order-derived producers (`.kv`, `.reverse`, `.sort`, `.values`) are
+    /// excluded on purpose and permanently: slice 4 routed them at the
+    /// *producer*, so the item they yield already IS the element container and
+    /// there is no index for this discriminator to reconstruct. `.pairs` /
+    /// `.antipairs` yield a `Pair` *wrapping* the element, so the binding is
+    /// not the element at all. A multi-parameter loop binds through the
+    /// bind-prefix `Stmt::Assign`s rather than this native bind site, so it too
+    /// aliases via the producer (row 16).
     #[allow(clippy::too_many_arguments)]
     pub(super) fn plan_for_element_alias(
         &self,
@@ -118,8 +138,9 @@ impl Interpreter {
                 writes_back_topic && !topic_readonly
             };
         // `.pairs`/`.antipairs` yield a `Pair` *wrapping* the element, so the
-        // binding is not the element; `.kv` and `.reverse` are derived orders
-        // whose producers do not hand out containers yet (slice 4).
+        // binding is not the element. `.kv` and `.reverse` are derived orders
+        // that alias at the producer instead (slice 4) — declining here is what
+        // lets the producer's cell reach the bind site unmodified.
         if !aliasing_param || spec.loop_var_wraps_element || spec.kv_mode || container_reversed {
             return ForElementAlias::None;
         }
@@ -134,28 +155,16 @@ impl Interpreter {
         // the array is captured here rather than re-resolved per iteration (see
         // `ForElementAlias::ArrayValue`).
         if source.starts_with('@') || source.starts_with('$') {
-            // `@a.values` is an identity-ordered derived producer, but its
-            // routing belongs with `.reverse`/`.sort`; keep it on the writeback
-            // so the array producers convert together.
+            // `@a.values` is an identity-ordered derived producer, and its
+            // routing lives with `.reverse`/`.sort` at the producer (slice 4),
+            // so it is declined here for the same reason they are.
             if spec.values_mode {
                 return ForElementAlias::None;
             }
-            let arr = self.resolve_for_source_array(code, source);
-            let (len, first) = match arr.as_ref().map(Value::view) {
-                Some(ValueView::Array(data, kind))
-                    if !matches!(
-                        kind,
-                        crate::value::ArrayKind::Shaped | crate::value::ArrayKind::Lazy
-                    ) && data.shape.is_none()
-                        && data.native_storage_node().is_none() =>
-                {
-                    (data.len(), data.items().first().cloned())
-                }
-                _ => return ForElementAlias::None,
-            };
-            if items.len() != len || !Self::items_are_source_elements(items, first) {
+            let Some(arr) = self.aliasable_source_array(code, source, items) else {
                 return ForElementAlias::None;
-            }
+            };
+            let arr = Some(arr);
             return match arr {
                 Some(arr) if source.starts_with('$') => ForElementAlias::ArrayValue(arr),
                 _ => ForElementAlias::ArrayIndex(source.to_string()),
@@ -183,6 +192,132 @@ impl Interpreter {
             return ForElementAlias::HashValue(source.to_string(), keys.to_vec());
         }
         ForElementAlias::None
+    }
+
+    /// The `Array` behind a tagged `for` source when this loop may promote its
+    /// elements: a real, mutable, plain `Array` (not shaped, lazy, or
+    /// native-backed) whose elements the loop iterates **one-for-one**.
+    ///
+    /// Factored out of [`Self::plan_for_element_alias`] so the multi-parameter
+    /// plan below applies exactly the same discriminator; the two differ only in
+    /// which positions they promote, never in which sources they accept.
+    fn aliasable_source_array(
+        &self,
+        code: &CompiledCode,
+        source: &str,
+        items: &[Value],
+    ) -> Option<Value> {
+        let arr = self.resolve_for_source_array(code, source)?;
+        let (len, first) = match arr.view() {
+            ValueView::Array(data, kind)
+                if !matches!(
+                    kind,
+                    crate::value::ArrayKind::Shaped | crate::value::ArrayKind::Lazy
+                ) && data.shape.is_none()
+                    && data.native_storage_node().is_none() =>
+            {
+                (data.len(), data.items().first().cloned())
+            }
+            _ => return None,
+        };
+        if items.len() != len || !Self::items_are_source_elements(items, first) {
+            return None;
+        }
+        Some(arr)
+    }
+
+    /// ADR-0045 slice 6: promote a **multi-parameter** rw loop's source elements
+    /// before the item vector is chunked, so the chunk the bind-prefix
+    /// statements read from carries the SOURCE's element containers.
+    ///
+    /// A multi-parameter loop does not bind at the native bind site — it binds
+    /// through `build_for_bind_stmts`'s `MarkBind` declarations, which read
+    /// `_[i]` out of a chunk built by `items.chunks(arity)`. That chunk is a
+    /// fresh `Array`, so promoting *it* would alias the temporary, not `@a`.
+    /// Promoting the items first makes `array_slot_ref`'s idempotence do the
+    /// rest: the chunk holds the source's cells, the bind aliases them, and
+    /// `binding_carries_element_cell` retires the writeback for the iteration.
+    ///
+    /// Before this, the multi-parameter arm reached raku's *write* answer by
+    /// accident: the retained writeback stored the chunk's own cell **into** the
+    /// source element, so a later write through the parameter did land in `@a` —
+    /// but only after the iteration ended. The read direction stayed stale
+    /// (`for @a -> $p is rw, $q is rw { @a[1] = 55; say $q }` printed the old
+    /// value), a body that rebound the source wholesale was still clobbered by
+    /// the snapshot (§1.3 class 3), and every iteration still rebuilt the whole
+    /// backing `ArrayData`, so a mutating multi-parameter loop stayed O(n²)
+    /// after slice 1 had removed the quadratic from every other shape.
+    ///
+    /// Only the positions whose parameter actually aliases are promoted.
+    /// `rw_param_names` is positionally aligned with the chunk and holds `""`
+    /// for a slot that is not genuinely rw, which is the same distinction
+    /// `build_for_bind_stmts` makes when it decides between a raw `MarkBind`
+    /// declaration and a coercing `Stmt::Assign`. Promoting a non-rw slot would
+    /// make a plain `-> $x` read-alias, which rows 45/46 forbid.
+    pub(super) fn promote_multi_param_elements(
+        &mut self,
+        code: &CompiledCode,
+        spec: &ForLoopSpec,
+        container_binding: Option<&str>,
+        container_reversed: bool,
+        items: &[Value],
+    ) -> Option<Vec<Value>> {
+        if !spec.chunks_items()
+            || !spec.do_writeback
+            || spec.kv_mode
+            || spec.values_mode
+            || spec.loop_var_wraps_element
+            || container_reversed
+        {
+            return None;
+        }
+        let arity = spec.arity.max(1) as usize;
+        // Nothing to align the chunk positions against, so nothing to promote.
+        if spec.rw_param_names.len() != arity {
+            return None;
+        }
+        // An `@`/`%`/`&`-sigil parameter binds a Positional/Associative, not a
+        // scalar slot — the same carve-out `plan_for_element_alias` makes.
+        let promotable: Vec<bool> = spec
+            .rw_param_names
+            .iter()
+            .enumerate()
+            .map(|(i, n)| {
+                !n.is_empty()
+                    && !spec
+                        .multi_param_names
+                        .get(i)
+                        .is_some_and(|m| m.starts_with(['@', '%', '&']))
+            })
+            .collect();
+        if !promotable.iter().any(|p| *p) {
+            return None;
+        }
+        // Only a direct `@`-array source. The `$`-tagged deref'd shape and the
+        // hash shapes keep the single-parameter routing; a multi-parameter loop
+        // over them is rare and its chunk mapping is not the same one-for-one.
+        let source = container_binding.filter(|s| s.starts_with('@'))?;
+        let arr = self.aliasable_source_array(code, source, items)?;
+        let mut out = items.to_vec();
+        let mut promoted_any = false;
+        for (i, slot) in out.iter_mut().enumerate() {
+            if !promotable[i % arity] {
+                continue;
+            }
+            // A `Proxy` element mediates its own STORE; a cell bound around one
+            // would take a plain write instead of calling it (§5 Q6).
+            if matches!(slot.view(), ValueView::Proxy { .. }) {
+                continue;
+            }
+            if !Self::array_is_aliasable(&arr, Some(i)) {
+                continue;
+            }
+            if let Some(cell) = arr.array_slot_ref(i, true) {
+                *slot = Self::name_element_owner(cell, source);
+                promoted_any = true;
+            }
+        }
+        promoted_any.then_some(out)
     }
 
     /// The element container this iteration's binding should alias, or `None`

--- a/src/vm/vm_for_loop_body.rs
+++ b/src/vm/vm_for_loop_body.rs
@@ -178,14 +178,6 @@ impl Interpreter {
         // alias handles propagation (and immutability for Mix), so suppress the
         // plain writeback here while keeping the source tag.
         let writes_back_loop_var = writes_back_topic && !spec.loop_var_wraps_element;
-        let chunked_items: Vec<Value> = if spec.chunks_items() {
-            items
-                .chunks(arity)
-                .map(|chunk| Value::array(chunk.to_vec()))
-                .collect()
-        } else {
-            items.to_vec()
-        };
         // ADR-0052 Slice 1: a construct that runs a body owns a stack base and
         // truncates to it at the end of EVERY iteration, not only when it is
         // collecting. A sink-position loop used to establish no base at all, so
@@ -246,6 +238,28 @@ impl Interpreter {
         });
         let container_reversed = self.container_ref_reversed;
         self.container_ref_reversed = false;
+        // ADR-0045 slice 6: a multi-parameter rw loop binds through the
+        // bind-prefix `MarkBind` declarations, which read out of the CHUNK. So
+        // the source's elements must be promoted before the chunk is built —
+        // promoting the chunk itself would alias the temporary. Doing it here
+        // is what retires the last surviving arm of the writeback family; see
+        // `promote_multi_param_elements` for what the old arm got wrong.
+        let promoted_items = self.promote_multi_param_elements(
+            code,
+            spec,
+            container_binding.as_deref(),
+            container_reversed,
+            items,
+        );
+        let items: &[Value] = promoted_items.as_deref().unwrap_or(items);
+        let chunked_items: Vec<Value> = if spec.chunks_items() {
+            items
+                .chunks(arity)
+                .map(|chunk| Value::array(chunk.to_vec()))
+                .collect()
+        } else {
+            items.to_vec()
+        };
         // Capture hash key order before the loop so writeback uses the
         // original key order even after the hash is mutated during iteration.
         // Needed for the rw-param `%h.values -> $v is rw` writeback and for the

--- a/src/vm/vm_loop_writeback.rs
+++ b/src/vm/vm_loop_writeback.rs
@@ -190,6 +190,26 @@ impl Interpreter {
                 },
             ) => ta == tb && ka == kb && ia == ib,
             (ValueView::Nil, ValueView::Nil) => true,
+            // A `Pair` is a by-value variant, so the item vector holds a clone
+            // of the source element and there is no pointer identity to test —
+            // but equal key AND equal value means writing it back would store
+            // the same thing, exactly like the `Str`/`Int`/`Rat` arms above.
+            //
+            // Without this arm every read-only `for` over an array of `Pair`s
+            // rebuilt the whole backing `ArrayData` once per iteration (O(n²);
+            // measured at 1.87s for 8 000 elements against raku's flat 0.02s),
+            // AND — because `items_are_source_elements` consults this same
+            // predicate — the topic was never promoted to the element container
+            // in the first place, so ADR-0045's alias did not apply to a `Pair`
+            // element at all. This was the single largest surviving consumer of
+            // the writeback family: 137 808 of the 140 251 stores a slice-6
+            // sweep of the whole roast whitelist recorded.
+            //
+            // A body that rebinds the topic (`$_ = other-pair`) or mutates
+            // `.value` on the clone leaves the two unequal, so it still falls
+            // through to the full writeback.
+            (ValueView::Pair(ak, av), ValueView::Pair(bk, bv)) => ak == bk && av == bv,
+            (ValueView::ValuePair(ak, av), ValueView::ValuePair(bk, bv)) => ak == bk && av == bv,
             // A shared `ContainerRef` element (the rw-alias cell `.grep` leaves
             // in its source array, or a `:=`-bound element): mutations through
             // the alias write through the cell itself, so the source element

--- a/t/for-loop-element-alias.t
+++ b/t/for-loop-element-alias.t
@@ -21,7 +21,7 @@ use Test;
 # (derived producers — `.kv`/`.reverse`/`.sort`/`@$s`) and slice 5 (bind-time
 # enforcement).
 
-plan 102;
+plan 115;
 
 # ---------------------------------------------------------------------------
 # Class 1 — a binding that outlives the loop body still writes through.
@@ -726,6 +726,99 @@ plan 102;
     for @a -> $v is rw { @p.push(start { $v = $v + 1 }) }
     await @p;
     is-deeply @a, [11, 21], 'row 27: a `start` block over an `is rw` param writes through';
+}
+
+# ---------------------------------------------------------------------------
+# Slice 6 — the two shapes the sweep found still on the writeback.
+#
+# Both reached raku's answer for the SIMPLE write and were therefore invisible
+# to every row above; the sweep found them by tracing which loops still stored a
+# rebuilt container. Both are ordinary ADR-0045 defects, not exotica.
+# ---------------------------------------------------------------------------
+
+# The MULTI-PARAMETER rw loop. It used to reach the write answer by accident:
+# the retained writeback stored the CHUNK's own cell into the source element, so
+# a later write through the parameter did land in `@a` — but only after the
+# iteration had ended. Three things followed, and all three are pinned here.
+{
+    # The read direction (row 41's multi-parameter twin). Before slice 6 this
+    # printed the pre-write value, because the chunk's cell was not `@a`'s yet.
+    my @a = 1, 2, 3, 4;
+    my $seen;
+    for @a -> $p is rw, $q is rw { @a[1] = 55; $seen = $q; last }
+    is $seen, 55, 'multi-param rw: a direct write to the element is seen through the alias';
+}
+{
+    # Class 3 (row 38's multi-parameter twin): the body rebinds the source
+    # wholesale, and the iteration-end snapshot used to clobber it.
+    my @a = 1, 2, 3, 4;
+    for @a -> $x, $y is rw { $y = 9; @a = 7, 8, 7, 8; last }
+    is-deeply @a, [7, 8, 7, 8], 'multi-param rw: a wholesale rebind is not reverted by a snapshot';
+}
+{
+    # The write directions that must keep working with the writeback retired.
+    my @a = 1, 2, 3, 4;
+    for @a -> $x, $y is rw { $y = 0 }
+    is-deeply @a, [1, 0, 3, 0], 'multi-param rw: the direct write still lands';
+
+    my @b = 1, 2, 3, 4;
+    my $c;
+    for @b -> $p is rw, $q is rw { $c = -> { $p = 77 } if $p == 3 }
+    $c();
+    is-deeply @b, [1, 2, 77, 4], 'multi-param rw: an escaping closure writes to its own element';
+}
+{
+    # Only a GENUINELY rw slot may alias. `for @e -> \a, @b {}` forces the loop
+    # into rw mode through the sigilless `\a`, but `@b` binds a Positional and
+    # promoting its slot would hand it a container where a list is expected.
+    my @e = 1, 2, 3, 4;
+    for @e -> \a, @b { }
+    is-deeply @e, [1, 2, 3, 4], 'multi-param: a non-rw sibling slot is left alone';
+}
+{
+    # §1.5's acceptance number, for the multi-parameter shape: it was the ONE
+    # shape slice 1 left quadratic (45.7 s at n=40 000 on a release build).
+    my @big = ^20000;
+    my $t0 = now;
+    for @big -> $x, $y is rw { $y = $y + 1 }
+    my $elapsed = now - $t0;
+    ok $elapsed < 20, "a mutating multi-param rw loop is O(n) ({$elapsed.round(0.01)}s)";
+    is @big[19999], 20000, 'the mutating multi-param loop actually wrote every element';
+}
+
+# A `Pair` ELEMENT. `Pair` is a by-value variant, so the item vector holds a
+# clone and `loop_var_unchanged` had no arm for it — which meant the topic was
+# never promoted over an array of Pairs AND every iteration of even a read-only
+# loop rebuilt the whole backing array. This was the largest surviving consumer
+# of the writeback family by a factor of 400.
+{
+    my @t = (1 => 'a'), (2 => 'b');
+    my @c;
+    for @t { @c.push(-> { $_ = (9 => 'q') }) }
+    @c[0]();
+    is-deeply @t, [(9 => 'q'), (2 => 'b')],
+        'Pair element: an escaping closure over the topic writes through';
+}
+{
+    my @t = (1 => 'a'), (2 => 'b');
+    for @t { $_ = (9 => 'q') }
+    is-deeply @t, [(9 => 'q'), (9 => 'q')], 'Pair element: a direct topic assign still lands';
+
+    my @u = (1 => 'a'), (2 => 'b');
+    my @keys;
+    @keys.push(.key) for @u;
+    is-deeply @keys, [1, 2], 'Pair element: a read-only loop reads the right keys';
+    is-deeply @u, [(1 => 'a'), (2 => 'b')], 'Pair element: a read-only loop mutates nothing';
+}
+{
+    # The same §1.5 bound, for the Pair-element shape: 1.87 s at n=8 000 before.
+    my @big = (^8000).map({ $_ => 'v' }).Array;
+    my $t0 = now;
+    my $sum = 0;
+    $sum += .key for @big;
+    my $elapsed = now - $t0;
+    ok $elapsed < 20, "a read-only loop over Pair elements is O(n) ({$elapsed.round(0.01)}s)";
+    is $sum, 31996000, 'the read-only Pair loop actually visited every element';
 }
 
 done-testing;

--- a/todo/TRIAGE.md
+++ b/todo/TRIAGE.md
@@ -34,7 +34,6 @@ Surveyed 2026-09-01: **67 files** after this regen's own closures — 45
   → `news/2026-08/`; `eval-declared-my-role-...`, `proxy-at-pos-...`,
   `range-assigned-to-named-scalar-...` → `news/2026-09/`. The one residual
   finding inside `take-rw` was re-filed as
-  `tickets/array-seq-view-does-not-carry-element-containers.md`.
 - The one fixed `deep/` file (`bare-name-type-constraint-store-is-scope-blind`)
   is *not* closed: it has no failing repro left but still tracks ADR-0042
   slices 2-3 (delete the name-keyed map). It moves to the Icebox as a cleanup
@@ -80,8 +79,6 @@ means *the order is wrong*.
 | Ticket | Tier | Note |
 |---|---|---|
 | [gather-block-state-is-shared-across-instances](tickets/gather-block-state-is-shared-across-instances.md) | N, **S effort** | `state` inside a `gather` body is one cell for every instance (`a=1 b=2`, raku `a=1 b=1`). map/grep already scope `state` per closure instance (`state_scope_id`); the gather forcing path has no equivalent. Cheapest real fix in the queue; check the lazily-resumed coroutine path too. |
-| [for-kv-multi-param-bind-decontainerizes](tickets/for-kv-multi-param-bind-decontainerizes.md) | B1 | ADR-0045 row 16. Needs a raw (non-decontainerizing) bind for an rw scalar multi-parameter in `build_for_bind_stmts`; the shape exists for `@`/`%` params. Then re-add `"kv"` to `ELEMENT_PRODUCERS`. |
-| [array-seq-view-does-not-carry-element-containers](tickets/array-seq-view-does-not-carry-element-containers.md) | B1 | `for @a.Seq { $_++ }` writes nothing back. ADR-0045 seen from the `.Seq` producer; probably one more `ELEMENT_PRODUCERS` arm. Filed 2026-09-01. |
 | [rakuast-nodes-have-no-stable-identity](tickets/rakuast-nodes-have-no-stable-identity.md) | N | `$p === $p` is `False` for a RakuAST node. The `===` half (identity-backed `WHICH` for `ValueView::RakuAst`) is small and self-contained; `eqv` is a separate structural question. The crash path it guards is dead today but ADR-0059 slice 3 would re-open it. |
 | [io-listops-bind-colonpair-args-as-positional](tickets/io-listops-bind-colonpair-args-as-positional.md) | N | `say :d, "x"` prints `d => Truex`; raku prints `x`. `Stmt::Say(Vec<Expr>)` has no named/positional slot. ADR-0021 territory (P5 remains) but no design decision is needed — give the four io statements the `CallArg::Named` representation and have the print ops skip named args. `(a => 1)` must stay positional. |
 | [lazy-list-in-scalar-loses-itemization](tickets/lazy-list-in-scalar-loses-itemization.md) | N | Only the inline `(gather ...).List` spelling renders `(1, 2)` instead of `$(1, 2)`; the type half is already fixed. Look at ADR-0038 phase 4's context-flag family before adding a third flag. |
@@ -94,7 +91,6 @@ means *the order is wrong*.
 |---|---|---|
 | [immutable-lvalues-that-mutsu-still-lets-you-assign-to](tickets/immutable-lvalues-that-mutsu-still-lets-you-assign-to.md) | [ADR-0036](../docs/adr/0036-element-container-pairs-from-subscripts-and-pairs.md) slices 3-4, plus a readonly marking on the closure-call topic binding that no ADR owns yet | 6 of 7 rows still silently succeed (re-verified). `(1..3)[0] = 9` now throws the right class with the wrong rendering. *Itemization is not container-ness* — ADR-0040 landing moved none of the rows, so do not re-attribute it. |
 | [free-var-read-in-callee-resolves-through-dynamic-caller-chain](tickets/free-var-read-in-callee-resolves-through-dynamic-caller-chain.md) | Its own ADR: "a routine's env parent is its lexical scope, not its caller" | `f sees 1` where raku says `5`, unchanged by ADR-0055 slice 1 and by a slice-2 prototype; ADR-0055 §7.5 records it as out of scope. Silent wrong *read* in ordinary code — the highest-leverage un-owned finding in `tickets/`. Its cheaper half ("why is `f`'s own `my $var` not visible in `f`'s env tier when a callee reads the name") is worth isolating first. |
-| [for-deref-container-source-promotion-breaks-nqp-type-tests](tickets/for-deref-container-source-promotion-breaks-nqp-type-tests.md) | An audit of every `nqp::` op that type-tests a value (`src/runtime/nqp_ops.rs`) | ADR-0045 row 39, implemented and **deliberately backed out** — routing it breaks `CBOR::Simple`'s Capture round-trips in the bundled-library gate. Also: the named `<-> $x` form loses even the *direct* write, which the ticket's "direct case stays correct" claim does not cover. |
 
 ### B — Deliberate non-divergence record (1)
 
@@ -125,7 +121,7 @@ one landed slice closes several rows at once. Every ADR below had its
 
 | ADR | Status (verified 2026-09-01) | Deep/ticket rows it would close |
 |---|---|---|
-| [ADR-0045](../docs/adr/0045-for-loop-parameters-bind-the-element-container.md) for-param binds the element container | **Slices 0-4 landed 2026-08-27; 5-6 open** | `for-loop-rw-element-alias-...` rows 16/19/28/30/39, tickets `for-kv-multi-param-bind`, `array-seq-view-...`, `for-deref-...` (row 39, needs the nqp audit) |
+| [ADR-0045](../docs/adr/0045-for-loop-parameters-bind-the-element-container.md) for-param binds the element container | **CLOSED 2026-09-01 — every slice landed**, §1.3 re-measured 45/45 green | Nothing. The originating deep finding retired to `news/2026-09/for-loop-parameters-bind-the-element-container.md`; slice 6's sweep also filed `pair-value-assign-does-not-enforce-immutable-value`. |
 | [ADR-0036](../docs/adr/0036-element-container-pairs-from-subscripts-and-pairs.md) element container cells | Slices 1-2 landed; slice 3's producer layer landed but **`.pairs` backed out**; slice 4 open | `pairs-element-containers-leak-...`, `immutable-lvalues-...` (6 rows), row 28 of the for-loop matrix (element type constraint — ADR-0036 slice 4 is the natural owner, shared with ADR-0045 slice 5 and ADR-0042) |
 | [ADR-0059](../docs/adr/0059-is-rw-routines-return-a-container.md) `is rw` routines return a container | Slices 1-2 landed **except the bare-`is rw`-tail half**; slice 3 open | `is-rw-sub-implicit-return-element-not-mutable` (Tier S — it *is* the bare-tail half), `rakuast-nodes-...`'s latent crash path (slice 3) |
 | [ADR-0055](../docs/adr/0055-closure-free-vars-resolve-to-their-own-binding.md) closure free vars bind their own | **Slice 1 landed 2026-08-28; slices 2-5 not started**; slice 2's prerequisite is the `unvouched-capture-cells` ticket | `call-compiled-closure-lacks-merge-all-...` (Gap 1: `OUTER` vs `CALLER`), `unvouched-capture-cells-leak-state-across-cro-client-requests` |
@@ -139,14 +135,20 @@ one landed slice closes several rows at once. Every ADR below had its
 | [ADR-0039](../docs/adr/0039-container-lexicals-resolve-lexically.md) container lexicals resolve lexically | Slice 1 landed; slice 2 open | `module-file-scope-array-and-hash-...` (two concrete slice-2 acceptance rows added 2026-09-01) |
 | [ADR-0047](../docs/adr/0047-type-identity-is-a-declaration-site-not-a-registry-name.md) type identity | P1-P2 landed; P3-P4 open | `subtest-compiled-dispatch-async-middleware-regression` (P4 re-lands #6499; the regression itself is independent) |
 
-**Recommended next campaign.** The element-container model is still the
-cluster with the most rows: **ADR-0045 slices 5-6 together with ADR-0036
-slice 4** (the element type constraint on the promoted cell is shared three
-ways and ADR-0036 slice 4 is its natural owner) closes rows 19/28/30 of the
-for-loop matrix, the `is rw`-over-List bind rejection, and one `immutable-
-lvalues` row, and unblocks the two `ELEMENT_PRODUCERS` tickets. Then
-**ADR-0059's bare-tail half** (Tier S below), then **ADR-0055 slice 2's
-prerequisite** (the Cro-blocking cell-freshness fix).
+**Recommended next campaign.** ADR-0045 closed on 2026-09-01 (all six slices,
+§1.3 re-measured 45/45 against raku), which retires the largest row in this
+cluster. Its sweep is worth copying as a *method*: instrumenting the single
+function a mechanism stores through, and running all of `t/` plus the whole
+roast whitelist under it, found two live defects that the ADR's own
+27-row divergence matrix could not see — both produced raku's answer for the
+simple case and diverged only on a read through the alias, on a wholesale
+rebind, and on the clock. Consider the same treatment for ADR-0036 and
+ADR-0040 before declaring either done.
+
+What remains in the element-container cluster: **ADR-0036 slice 4** (`.pairs`
+routing, still backed out) and **ADR-0040 row 24** (`.VAR` on a `:=`-bound
+list). Then **ADR-0059's bare-tail half** (Tier S below), then **ADR-0055
+slice 2's prerequisite** (the Cro-blocking cell-freshness fix).
 
 **One measured process exception, kept from the previous regen:** when a
 change alters a *universal property of values* ("what is in every
@@ -175,7 +177,6 @@ parser/operator/dispatch fixes still delegate to CI.
 | [call-compiled-closure-lacks-merge-all-and-dual-persistence-store](deep/call-compiled-closure-lacks-merge-all-and-dual-persistence-store.md) | XL | Closure free var resolves to `CALLER` where raku says `OUTER` (re-verified). ADR-0055 slices 2-5; the `merge_all` knob the file proposed is rejected by the ADR. |
 | [unvouched-capture-cells-leak-state-across-cro-client-requests](deep/unvouched-capture-cells-leak-state-across-cro-client-requests.md) | M-L | The mechanism that closes ADR-0055 §1.2(b) was built, validated (full roast green) and **removed** because a stale cell leaks request state across `Cro::HTTP::Client.request`'s recursive redirect. Two candidate fixes, both need a cell-freshness design. Gate: the batteries suite, which `make test` does not run. |
 | [residual-try-cell-eager-seq-reification-divergences](deep/residual-try-cell-eager-seq-reification-divergences.md) | L | `.map`/`.grep` run their callback eagerly (side effects before `say "before"`). ADR-0058's target; implementing it makes mutsu stricter, so full local `make roast` is mandatory. |
-| [for-loop-rw-element-alias-lost-through-deferred-closure](deep/for-loop-rw-element-alias-lost-through-deferred-closure.md) | M | Headline fixed; rows 17/24 now pass too (file updated). Residue: rows 16/19/28/30/39 — ADR-0045 slices 5-6. |
 | [element-itemization-lost-in-scalar-binding](deep/element-itemization-lost-in-scalar-binding.md) | M | Nearly closed: only ADR-0040 row 24 (`.VAR` on a `:=`-bound list) diverges. Retire when slice 5 lands. |
 | [pairs-element-containers-leak-through-pair-value-consumers](deep/pairs-element-containers-leak-through-pair-value-consumers.md) | L | Latent: `.pairs` is deliberately unrouted because a cell-valued Pair aliases hashes and collapses BagHash weights through 15+ structural consumers. Needs the Pair-value read-boundary decision (ADR-0036 slice 3). Note hash `.pairs[0].value.VAR` is `Int` while array `.pairs` already answers `Scalar`. |
 | [dollar-dot-attr-compound-assign-spurious-ro-error](deep/dollar-dot-attr-compound-assign-spurious-ro-error.md) | L | **Symptom moved**: `$.x *= 2` no longer throws — it now *mutates* a non-`rw` attribute (raku: silent no-op), and `$.x = 9` still mutates (raku: throws). Both halves are silent over-mutation now. Needs the "accessor read is an itemized copy" ADR; explicitly not ADR-0040. |

--- a/todo/tickets/pair-value-assign-does-not-enforce-immutable-value.md
+++ b/todo/tickets/pair-value-assign-does-not-enforce-immutable-value.md
@@ -1,0 +1,75 @@
+# `Pair.value = X` succeeds where raku throws "Cannot modify an immutable Str"
+
+## Symptom
+
+Raku's `Pair.value` is an `rw` accessor onto whatever the Pair holds, so
+assigning through it is only legal when the Pair's value is itself a container.
+A Pair built from a literal holds the bare value, and the assignment throws:
+
+```
+$ raku -e 'my $p = (1 => "a"); $p.value = "z"; say $p'
+Cannot modify an immutable Str (a)
+```
+
+mutsu accepts the assignment and mutates the Pair in place:
+
+```
+$ mutsu -e 'my $p = (1 => "a"); $p.value = "z"; say $p'
+1 => z
+```
+
+It is not specific to a bare scalar. The same gap shows through an array
+element and through a `for` loop's topic:
+
+```
+$ raku  -e 'my @t = (1 => "a"); @t[0].value = "z"; say @t'   # Cannot modify an immutable Str (a)
+$ mutsu -e 'my @t = (1 => "a"); @t[0].value = "z"; say @t'   # [1 => z]
+
+$ raku  -e 'my @t = (1 => "a"), (2 => "b"); .value = "z" for @t; say @t'
+Cannot modify an immutable Str (a)
+$ mutsu -e 'my @t = (1 => "a"), (2 => "b"); .value = "z" for @t; say @t'
+[1 => z 2 => z]
+```
+
+The mirror case is right, which is what makes this a missing *check* rather
+than a missing feature: `my $v = 1; my $p = (1 => $v); $p.value = 2` must
+succeed and write through to `$v`, and a Pair whose value came from a container
+already behaves that way in mutsu.
+
+## Why this is not ADR-0045's
+
+Found during ADR-0045 slice 6's sweep, while checking that the new `Pair` arm
+of `loop_var_unchanged` had not changed Pair semantics. It had not: the
+divergence reproduces with no loop at all (the first snippet above), so it is a
+`Pair.value` lvalue gap, not a for-loop one. It is recorded here rather than in
+the ADR so the ADR's closeout is not held up by it.
+
+## Where to look
+
+The `.value` lvalue path — `runtime/methods_mut_method_lvalue.rs` and the
+`Pair` arm of the method-lvalue dispatch. What is missing is the same
+"is the target a container?" gate that a plain `1 = 2` assignment already
+applies: a Pair holding a bare `Str`/`Int` has no container to assign into, so
+the store must raise `X::Assignment::RO` ("Cannot modify an immutable Str (a)")
+instead of replacing the Pair's value slot.
+
+[ADR-0036](../../docs/adr/0036-element-container-pairs-from-subscripts-and-pairs.md)
+is the neighbouring decision: its slice 3 deferred `.pairs` precisely because a
+`Pair` wrapping an element leaks its container through `Pair.value` consumers,
+and `todo/deep/pairs-element-containers-leak-through-pair-value-consumers.md`
+carries that thread. This ticket is the *other* direction — a Pair with **no**
+container behind its value — so the two should be checked together but are not
+the same bug.
+
+## Repro to pin when fixed
+
+```raku
+dies-ok { my $p = (1 => "a"); $p.value = "z" }, 'a bare Pair value is immutable';
+lives-ok { my $v = 1; my $p = (1 => $v); $p.value = 2 }, 'a container Pair value is assignable';
+{
+    my $v = 1;
+    my $p = (1 => $v);
+    $p.value = 2;
+    is $v, 2, 'the assignment writes through to the container';
+}
+```


### PR DESCRIPTION
Closes ADR-0045. Slice 6 is its sweep: re-measure §1.3's divergence table against raku, re-measure §1.5's bench, retire the writeback family's surviving arms, and retire the originating finding to `news/`.

## The table is green

All **45 rows of §1.3 agree with raku** — each rebuilt as its own one-liner (so no earlier statement contaminates the next) and run under both interpreters comparing stdout and stderr verbatim, with the three `dies` rows (19, 28, 30) matching raku's message text as well as the fact of dying.

`for @a <-> $x { $x = $x + 1 }`, release, best of three:

| n | before slice 1 | now |
| --- | --- | --- |
| 20 000 | 1.095 s | 0.02 s |
| 40 000 | 5.157 s | 0.03 s |
| 160 000 | 39.44 s | 0.15 s |

## But the sweep was not paperwork

Instrumenting `write_back_container_source` — the one function every element writeback stores through — and running all of `t/` plus the whole roast whitelist under it found **140 251 stores still happening across 766 whitelisted files**, in two shapes §1.3's 27-row matrix could not see. Both produced raku's answer for the *simple* write, and diverged only on a read through the alias, on a wholesale rebind, and on the clock.

### 1. A `Pair` element — 137 808 of the 140 251

`loop_var_unchanged` had no `Pair` arm, so an array of `Pair`s failed the identity test twice over: `items_are_source_elements` declined the loop, so the topic was **never promoted** over a Pair element, and the writeback's own unchanged-guard never fired, so **even a read-only loop rebuilt the whole backing `ArrayData` once per iteration**.

```
$sum += .key for @pairs;   # n=8000: mutsu 1.87s, raku 0.02s — O(n²), read-only
```

A `Pair` is by-value so there is no pointer identity, but equal key *and* value means the store is a no-op — exactly like the `Str`/`Int`/`Rat` arms already there. With the arm, the topic promotes, the writeback retires, and the loop is flat: 0.03 s at n=8 000, 0.04 s at n=16 000. `roast/S32-str/sprintf-*.t` alone contributed over 100 000 stores, through one `... for @tests;` statement modifier.

### 2. The multi-parameter rw loop

It binds through `build_for_bind_stmts`'s `MarkBind` declarations, which read `_[i]` out of a **chunk** — a fresh `Array` — so promoting the chunk would alias the temporary. Slice 4 had converted only `.kv`, whose *producer* hands out the source's cells. A plain `for @a -> $x, $y is rw` therefore stayed on the writeback and reached raku's write answer **by accident**: the retained writeback stored the chunk's own cell *into* the source element after the fact. Three things followed:

```raku
# read stays stale (row 41's twin)
for @a -> $p is rw, $q is rw { @a[1] = 55; say $q }   # raku 55, mutsu 2

# class 3 survives (row 38's twin) — silent corruption, no closure involved
for @a -> $x, $y is rw { $y = 9; @a = 7,8,7,8 }       # raku [7 8 7 8], mutsu [1 9 7 8]

# and O(n²): 45.7s at n=40000 — the one place §1.5's quadratic survived slice 1
```

`promote_multi_param_elements` applies the same routing one step earlier: promote the source's elements **before** the vector is chunked, so the chunk carries `@a`'s cells and `array_slot_ref`'s idempotence makes the bind alias the source element. Only positions whose parameter genuinely aliases are promoted (`rw_param_names` is positionally aligned and holds `""` for a non-rw slot — the same distinction the compiler makes), so `for @e -> \a, @b { }` leaves `@b` alone and rows 45/46 still hold. After: 0.01 / 0.03 / 0.05 / 0.11 / 0.20 s at n = 5 000 … 80 000.

## What survives, and why it is not debt

ADR-0045 §8 now tabulates it per arm: shaped / lazy / native-backed arrays, `Proxy` elements, scalar sources and QuantHash weights are shapes the ADR deliberately excluded, and retiring them per *loop* rather than per *iteration* would silently drop their writes.

## Also

- Corrects `vm_for_loop_alias.rs`'s module docs, which still said the derived producers were "excluded until slice 4". They are excluded **permanently** — slice 4 routed them one layer up, at the producer.
- Retires `todo/deep/for-loop-rw-element-alias-lost-through-deferred-closure.md` to `news/2026-09/`, rewritten as an accomplishment. Its two originally-wrong claims are kept verbatim; so is the pre-sweep paragraph that guessed the surviving arms were mere residue, as a caution.
- Files `todo/tickets/pair-value-assign-does-not-enforce-immutable-value.md` — `my $p = (1 => "a"); $p.value = "z"` succeeds where raku throws. Verified loop-independent, so not this ADR's.
- Drops four `todo/TRIAGE.md` rows pointing at tickets that no longer exist (each re-verified against raku first).

## Verification

- `t/for-loop-element-alias.t` 102 → **115 tests**, all passing; the new rows pin both shapes plus an O(n) bound each.
- `make test`: **PASS** (3596 files, 36 086 tests).
- Targeted roast sweep of 201 whitelisted files (every file the trace implicated, plus every whitelisted file using a multi-param `for`, `.pairs`, `.kv` or `Pair`): **PASS**, 80 935 tests.
- Full `make roast` delegated to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)