### PR TITLE
docs: scope ticket-flow validation

### DIFF
--- a/.agents/skills/mutsu-ticket-flow/SKILL.md
+++ b/.agents/skills/mutsu-ticket-flow/SKILL.md
@@ -10,9 +10,12 @@ metadata:
 Use this skill for requests to fix or process `todo/tickets/` items. A processed ticket ends as
 either a correctly filed deep item or a PR whose merge is verified on GitHub and in `origin/main`.
 
-Process at most **five tickets in one user-triggered run**. Count a ticket when its documentation
-or implementation PR has merged. After the fifth verified merge, report the next actionable
-filename but do not start it. A later user request starts a new run and resets this limit.
+Process at most **five tickets in one user-triggered run**, and only continue beyond the first
+when the user explicitly asks to process multiple tickets or the queue. Count a ticket when its
+documentation or implementation PR has merged. For a single-ticket request, report the next
+actionable filename after its verified merge but do not start it. After the fifth verified merge,
+report the next actionable filename but do not start it. A later user request starts a new run and
+resets this limit.
 
 ## Triage before implementation
 
@@ -24,6 +27,14 @@ filename but do not start it. A later user request starts a new run and resets t
    invariant across execution layers, a prerequisite campaign, or cannot be bounded as one PR. Use
    `git mv`, preserve repro/root-cause evidence, and add a concise dated note naming the owning
    ADR/campaign. Publish that documentation change through the same merge workflow.
+
+A documentation-only deep triage does **not** need `cargo fmt`, `cargo clippy`,
+`make test`, or `make roast`. Validate the recorded repro and rationale, run
+`git diff --check`, and run a focused check only if the documentation modifies
+generated output, executable scripts, or test configuration.
+
+Never overlap full-suite runs. They share Cargo locks, temporary logs, and
+test-harness state; wait for one to finish before rerunning it for evidence.
 
 Do not special-case one method or test where the ticket establishes a general mechanism.
 
@@ -40,9 +51,10 @@ Then create a fresh focused branch from that updated `main`, without overwriting
 Follow the Parser -> Compiler -> VM architecture, add focused regressions, and run targeted tests
 while iterating.
 
-Before publishing, run `cargo fmt --all`, `cargo clippy -- -D warnings`, `make test`, and
-`make roast` once each. Inspect `tmp/make-test.log` and `tmp/make-roast.log`.
-Do not publish until both full suites succeed.
+Before publishing an implementation PR, run `cargo fmt --all`,
+`cargo clippy -- -D warnings`, `make test`, and `make roast` once each. Inspect
+`tmp/make-test.log` and `tmp/make-roast.log`. Do not publish an implementation
+PR until both full suites succeed.
 
 ## Publish, monitor, and verify merge
 
@@ -75,4 +87,6 @@ After each verified merge, choose the lexicographically next actionable `todo/ti
 after the completed item, wrapping to the first filename as needed. Skip deliberate non-divergence
 records, blocked tickets, and items whose current evidence makes them deep; record or move the
 latter through this workflow. Never start a dependent ticket before its prerequisite merge is
-verified. Stop after five processed tickets in this run.
+verified. For a single-ticket request, report that filename and stop. Continue only when the user
+explicitly requested multiple tickets or queue processing, and stop after five processed tickets
+in that run.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,6 +59,17 @@ once each. After either full command runs, inspect its saved log. A failing
 full test belongs to the branch: diagnose it and use targeted checks as needed
 for further evidence. Keep `roast-whitelist.txt` sorted when changing it.
 
+Documentation-only PRs, including moving a triaged item from `todo/tickets/`
+to `todo/deep/`, do not require Rust formatting, linting, or either full test
+suite. Verify their patch with `git diff --check` and run a focused check only
+when the documentation change affects generated output, executable scripts, or
+test configuration.
+
+Full-suite reruns are allowed when evidence requires them, but never run the
+same full suite concurrently. The suites share Cargo build locks, temporary
+logs, and test-harness state, so overlapping invocations can create spurious
+failures and invalid logs.
+
 For an individual roast test, use `MUTSU_FUDGE=1`; do not set that variable for
 ordinary Raku programs. Do not modify `roast/`, `raku-doc/`, or other upstream
 submodules. Initialize missing submodules with


### PR DESCRIPTION
Clarifies that documentation-only deep triage does not need Rust tooling or full suites, prevents overlapping full-suite runs, and stops after a single requested ticket unless queue processing was explicitly requested.