### PR TITLE
fix: a Pair captures an uninitialized scalar's container (ADR-0036 slice 4 prerequisite)

### DIFF
--- a/docs/adr/0036-element-container-pairs-from-subscripts-and-pairs.md
+++ b/docs/adr/0036-element-container-pairs-from-subscripts-and-pairs.md
@@ -400,8 +400,43 @@ rather than part of it.
 **Row 11 moves from slice 3 to slice 4.** Slice 3 does the half it owns: a `List` receiver keeps the
 snapshot producer, so its pair value is a bare item with nothing to alias, which §2.2 says is the
 whole of the immutability story. What still swallows `$l.pairs[0].value = 3` is the *other* half —
-the env-scan compensator finds `$l`'s own list as a candidate container, rebuilds it, and reports
-success. The read-only guard is only reachable once that scan is deleted, which is slice 4's job.
+a compensator that fakes container semantics for a Pair that has none.
+
+> **Correction (2026-09-01, measured).** This paragraph originally said the *env-scan* compensator
+> "finds `$l`'s own list as a candidate container, rebuilds it, and reports success". **It does not.**
+> Instrumenting every branch of `assign_method_lvalue_with_values` and running the repro shows the
+> env-scan never fires for a `List` receiver, and `$l` is never touched. The write is swallowed one
+> block further down, by the **standalone-pair env rebind**: with no backing container selected, the
+> code scans `env` for any binding holding a `Pair` with the same key and old value and rebinds those
+> to a fresh `Pair` (for the row-11 repro it finds two — both temporaries — and rebinds them
+> invisibly), then returns `Ok`. Its sibling branch does the same for a named `target_var`. So the
+> read-only guard slice 4 needs is not blocked on deleting the env-scan; it is blocked on deleting
+> **those two rebinds**, and the existing guard next to them is the shape to generalize — it already
+> raises `X::Assignment::RO` correctly, but only for a `Bool` value (`Set.pairs[0].value = 0`).
+>
+> The same two rebinds are why `my $p = (k => 5); $p.value = 9` succeeds where raku raises
+> `Cannot modify an immutable Int (5)`
+> (`todo/tickets/pair-value-assign-does-not-enforce-immutable-value.md`). **Row 11 and that ticket
+> are one bug**, and one guard closes both.
+>
+> Deleting the rebinds needs two prerequisites, both measured at the same time:
+>
+> 1. **An uninitialized declared scalar must be captured as a container.** `my Int $x;
+>    my $p = (k => $x); $p.value = 5` leaves `$x` at `5` in raku; mutsu captured the bare type object
+>    `Int`, so the Pair had nothing to write through to and the rebind faked it — printing `k => 5`
+>    while `$x` stayed `Int`. **Fixed 2026-09-01**: `MakePair`/`MakeNamedArg` capture with
+>    `box_type_objects` set, the same way List aliasing already did. Pinned in
+>    `t/pair-value-container.t`, including that two undefined scalars stay two distinct containers.
+> 2. **`Pair.new("k", $x)` must capture too.** The method-argument form does not go through the
+>    fat-arrow compile-time capture, so it still binds the bare value and still relies on the rebind.
+>    Not fixed — `todo/tickets/pair-new-argument-does-not-capture-its-scalar-container.md`.
+>
+> The blast radius is small and was measured, not guessed: across the **whole roast whitelist** the
+> compensator fires **4 times in 3 files** (`S02-types/pair.t`, `S02-types/array-shapes.t`,
+> `S06-traits/is-rw.t`), and in `t/` about 40 times in 10 files — several of which pin expectations
+> that **raku rejects outright** (`my $p = a => 5; $p.value--` and `my $q = x => 0; $q.value = 1`
+> both die in raku). Those local tests were written around the compensator, so deleting it means
+> correcting them, which the "roast is authoritative" rule allows.
 
 **§5's open questions, as measured by slice 3:**
 

--- a/src/vm/vm_data_ops.rs
+++ b/src/vm/vm_data_ops.rs
@@ -308,6 +308,20 @@ impl Interpreter {
         self.capture_var_cell_inner(code, name, inner, false, slot_hint)
     }
 
+    /// [`Self::capture_var_cell`] with `box_type_objects` set: a Pair built from
+    /// `key => $var` must alias `$var` even when `$var` is an *uninitialized*
+    /// declared scalar holding a bare type object, because that is still a
+    /// container in raku and `$p.value = X` writes through to it.
+    pub(super) fn capture_var_cell_boxing_type_objects(
+        &mut self,
+        code: &CompiledCode,
+        name: &str,
+        inner: Value,
+        slot_hint: Option<u32>,
+    ) -> Value {
+        self.capture_var_cell_inner(code, name, inner, true, slot_hint)
+    }
+
     /// Like `capture_var_cell`, but when `box_type_objects` is set a plain type
     /// object (an uninitialized `my $a` holds `Any`) is also boxed into a fresh
     /// `ContainerRef` cell. This is required for List container aliasing: four

--- a/src/vm/vm_mixin_does_ops.rs
+++ b/src/vm/vm_mixin_does_ops.rs
@@ -524,7 +524,14 @@ impl Interpreter {
             let source_name = source_name.resolve();
             let inner = inner.clone();
             let slot_hint = right.varref_slot();
-            right = self.capture_var_cell(code, &source_name, inner, slot_hint);
+            // `box_type_objects` is set: an UNINITIALIZED declared scalar
+            // (`my Int $x`, which holds the bare type object `Int`) is still a
+            // container, and raku aliases it — `my Int $x; my $p = ("k" => $x);
+            // $p.value = 5` leaves `$x` at 5. Without boxing, the Pair captured
+            // the bare type object, `$p.value = 5` had nothing to write
+            // through to, and the write was faked by rebinding `$p`'s own env
+            // entry: the Pair printed `k => 5` while `$x` stayed `Int`.
+            right = self.capture_var_cell_boxing_type_objects(code, &source_name, inner, slot_hint);
         }
         (left, right)
     }

--- a/t/pair-value-container.t
+++ b/t/pair-value-container.t
@@ -1,6 +1,6 @@
 use Test;
 
-plan 9;
+plan 15;
 
 # `key => $var` captures $var's container, so the Pair's value aliases the
 # variable: assigning `.value` writes through to the source variable, and the
@@ -40,10 +40,49 @@ plan 9;
 }
 
 # A literal value is not a container; assignment still updates the pair.
+#
+# NOTE: this is a DIVERGENCE, pinned as-is only to record the current
+# behaviour. raku dies here -- `my $p = (k => 5); $p.value = 9` raises
+# "Cannot modify an immutable Int (5)", because a Pair built from a literal
+# has no container behind its value. mutsu fakes the write by rebinding `$p`'s
+# own env entry. Removing that fake is ADR-0036 slice 4's remaining half; see
+# todo/tickets/pair-value-assign-does-not-enforce-immutable-value.md.
 {
     my $p = (k => 5);
     $p.value = 9;
-    is $p.value, 9, 'pair built from a literal still allows .value assignment';
+    is $p.value, 9, 'pair built from a literal still allows .value assignment (DIVERGES: raku dies)';
+}
+
+# An UNINITIALIZED declared scalar is still a container, so the Pair aliases
+# it and `.value = X` writes through -- exactly as it does for an initialized
+# one above. mutsu used to capture the bare type object instead, so the write
+# had nothing to reach: the Pair printed `k => 5` while `$x` stayed `Int`.
+{
+    my Int $x;
+    my $p = (k => $x);
+    $p.value = 5;
+    is $x, 5, 'an uninitialized declared scalar is captured as a container';
+    is $p.value, 5, 'the pair reads back the value it wrote through';
+}
+{
+    # Untyped, and the write comes back out through a second read of the pair.
+    my $y;
+    my $p = (k => $y);
+    $p.value = "set";
+    is $y, "set", 'an uninitialized UNTYPED scalar is captured too';
+}
+{
+    # Boxing each uninitialized scalar into its OWN cell is what keeps distinct
+    # variables distinct -- two pairs over two undefined scalars must not share.
+    my $a;
+    my $b;
+    my $pa = (k => $a);
+    my $pb = (k => $b);
+    $pa.value = 1;
+    is $b, Any, 'a sibling undefined scalar is untouched by the other pair';
+    $pb.value = 2;
+    is $a, 1, 'and the first pair still owns its own container';
+    is $b, 2, 'while the second owns its own';
 }
 
 # Storing a captured pair into a Hash decontainerizes the value (Raku copies

--- a/todo/tickets/pair-new-argument-does-not-capture-its-scalar-container.md
+++ b/todo/tickets/pair-new-argument-does-not-capture-its-scalar-container.md
@@ -1,0 +1,88 @@
+# `Pair.new("k", $x)` does not capture `$x`'s container, so `.value = X` does not write through
+
+## Symptom
+
+The fat-arrow form and the `Pair.new` form are the same construct in raku, and
+both alias the scalar they are handed:
+
+```
+$ raku -e 'my Int $x; my $p = Pair.new("k", $x); $p.value = 5; say $x.raku'   # 5
+$ raku -e 'my Int $x; my $p = ("k" => $x);       $p.value = 5; say $x.raku'   # 5
+```
+
+mutsu gets the fat-arrow form right (fixed 2026-09-01, ADR-0036's slice 4
+prerequisite 1) but not the `Pair.new` form:
+
+```
+$ mutsu -e 'my Int $x; my $p = ("k" => $x);       $p.value = 5; say $x.raku'   # 5   ✓
+$ mutsu -e 'my Int $x; my $p = Pair.new("k", $x); $p.value = 5; say $x.raku'   # Int ✗
+```
+
+The Pair itself still *prints* `k => 5`, because the write is faked by the
+standalone-pair env rebind in `assign_method_lvalue_with_values` — the
+compensator ADR-0036 slice 4 wants to delete. So the visible damage today is
+limited to the source variable, but it becomes a hard failure the moment that
+rebind goes.
+
+An *initialized* scalar works in both forms, which is the tell: what is missing
+is the capture of a scalar whose slot currently holds a bare type object.
+
+```
+$ mutsu -e 'my Int $x = 1; my $p = Pair.new("k", $x); $p.value = 5; say $x'    # 5   ✓
+```
+
+## Root cause
+
+`key => $var` is captured at **compile** time: `compile_binary` tags the RHS
+with `WrapVarRef` (`src/compiler/expr_binary.rs`, the `TokenKind::FatArrow` arm
+calling `scalar_container_alias_name` + `emit_wrap_var_ref`), and
+`MakePair`/`MakeNamedArg` box the named local into a shared `ContainerRef`
+(`pop_pair_operands_capturing`, `src/vm/vm_mixin_does_ops.rs`).
+
+`Pair.new("k", $x)` is an ordinary method call. Its argument is compiled as a
+plain expression, so nothing tags `$x` and the constructor receives the
+dereferenced value. There is no `WrapVarRef` for the constructor to unbox.
+
+## Why it is a ticket and not a one-liner
+
+The fix is not "tag every `Pair.new` argument": the general question is which
+method arguments capture their scalar's container, and mutsu already has
+machinery for the `is rw` / `\(...)` capture cases. The narrow, defensible
+version is to give `Pair.new`'s second positional the same compile-time
+treatment the fat arrow gets — recognising the receiver as the `Pair` type
+object at compile time — which is a special case that should be justified
+against ADR-0021 (Pair namedness) before being written.
+
+## Where to look
+
+- `src/compiler/expr_binary.rs` — the `FatArrow` capture arm, and
+  `Self::scalar_container_alias_name`, which is the "is this RHS a plain scalar
+  variable?" test to reuse.
+- `src/compiler/expr_call.rs` — `emit_wrap_var_ref` / `emit_wrap_var_ref_arg_tag`;
+  the latter exists precisely for a consumer that reads its target through a
+  different op.
+- `src/vm/vm_mixin_does_ops.rs` — `pop_pair_operands_capturing`, which is what
+  the constructor path would need an equivalent of.
+
+## Repro to pin when fixed
+
+```raku
+{
+    my Int $x;
+    my $p = Pair.new("k", $x);
+    $p.value = 5;
+    is $x, 5, 'Pair.new captures its scalar argument as a container';
+}
+{
+    my $a;
+    my $b;
+    my $pa = Pair.new("k", $a);
+    my $pb = Pair.new("k", $b);
+    $pa.value = 1;
+    is $b, Any, 'two undefined scalars stay two distinct containers';
+}
+```
+
+Related: `todo/tickets/pair-value-assign-does-not-enforce-immutable-value.md`
+(the guard that this must land before), and ADR-0036's slice 4 note, which
+records both as prerequisites for deleting the compensator.

--- a/todo/tickets/pair-value-assign-does-not-enforce-immutable-value.md
+++ b/todo/tickets/pair-value-assign-does-not-enforce-immutable-value.md
@@ -44,6 +44,36 @@ divergence reproduces with no loop at all (the first snippet above), so it is a
 `Pair.value` lvalue gap, not a for-loop one. It is recorded here rather than in
 the ADR so the ADR's closeout is not held up by it.
 
+## This is ADR-0036 §1.3 row 11, and the same guard closes both
+
+Confirmed 2026-09-01 by instrumenting every branch of
+`assign_method_lvalue_with_values`. Row 11 (`my $l = (1, 2);
+$l.pairs[0].value = 3` must die) and this ticket are **one bug**: both write
+through the *standalone-pair env rebind* at the bottom of the Pair `.value`
+arm, which scans `env` for a binding holding a `Pair` with the same key and old
+value and rebinds it to a fresh `Pair` — faking an alias that raku does not
+have for a bare pair value. The `X::Assignment::RO` guard sitting immediately
+above it is already the right shape; it just only fires for a `Bool`
+(`Set.pairs[0].value = 0`, which passes today). Generalising it to "the pair
+value has no container behind it" closes both rows.
+
+ADR-0036 slice 4's note carries the corrected root cause (its original text
+blamed the env-scan compensator, which measurement showed never fires here) and
+the measured blast radius: 4 hits in 3 whitelisted roast files, ~40 in 10 `t/`
+files.
+
+**One prerequisite is left.** `Pair.new("k", $x)` still does not capture its
+scalar's container, so deleting the rebind would turn its currently-faked write
+into a hard failure —
+`todo/tickets/pair-new-argument-does-not-capture-its-scalar-container.md`. The
+fat-arrow form's half of that prerequisite landed 2026-09-01.
+
+**`t/` tests to correct when the guard lands** (each verified against raku,
+which dies on all of them, so they encode the compensator rather than the
+spec): `t/pair-value-container.t`'s literal-Pair row (already marked DIVERGES),
+and `t/lvalue-method-writeback-coherence.t`'s `my $p = a => 5; $p.value--` and
+`my $q = x => 0; $q.value = 1` blocks.
+
 ## Where to look
 
 The `.value` lvalue path — `runtime/methods_mut_method_lvalue.rs` and the


### PR DESCRIPTION
## The bug

`key => $var` captures the RHS scalar's container so the Pair's value aliases it — that is what makes `$p.value = X` write through to `$var` (S02:1704). It did not do so when `$var` was an **uninitialized** declared scalar:

```
my Int $x; my $p = ("k" => $x); $p.value = 5; say $x.raku
raku:  5
mutsu: Int
```

An uninitialized `my Int $x` holds the bare type object `Int`, and `capture_var_cell_inner` refuses to box a type object unless `box_type_objects` is set — which only List aliasing passed. So the Pair captured the type object, the write had nothing to reach, and the Pair still *printed* `k => 5` because the standalone-pair env rebind faked it.

`MakePair`/`MakeNamedArg` now capture with `box_type_objects` set. Boxing each such scalar into its **own** cell is exactly what keeps distinct undefined variables distinct — the same reason List aliasing needed it — so two pairs over two undefined scalars do not share, which the new pins assert.

## It also corrects ADR-0036

This was found while measuring slice 4, and the measurement **contradicted the ADR**.

Slice 4's note said the *env-scan compensator* was what swallowed `$l.pairs[0].value = 3` (§1.3 row 11), and therefore had to be deleted before the read-only guard became reachable. Instrumenting every branch of `assign_method_lvalue_with_values` shows the env-scan **never fires** for a `List` receiver, and `$l` is never touched. The write is swallowed one block lower, by the **standalone-pair env rebind** — it scans `env` for any binding holding a `Pair` with the same key and old value and rebinds it to a fresh `Pair` (for the row-11 repro it finds two temporaries and rebinds them invisibly), then returns `Ok`.

That is also why `my $p = (k => 5); $p.value = 9` succeeds where raku raises `Cannot modify an immutable Int (5)`. **Row 11 and that ticket are one bug**, and the `X::Assignment::RO` guard already sitting immediately above the rebind — today firing only for a `Bool` (`Set.pairs[0].value = 0`, which passes) — is the shape that closes both.

**Blast radius, measured rather than guessed:** across the whole roast whitelist the compensator fires **4 times in 3 files** (`S02-types/pair.t`, `S02-types/array-shapes.t`, `S06-traits/is-rw.t`); in `t/` about 40 times in 10 files — several of which pin expectations **raku rejects outright** (`my $p = a => 5; $p.value--` and `my $q = x => 0; $q.value = 1` both die in raku), so they encode the compensator rather than the spec.

## What this PR does and does not do

Lands the **first of two prerequisites** for deleting that rebind. The second — `Pair.new("k", $x)` capturing its argument, which the fat-arrow path handles at compile time but the method-call path does not — is filed as `todo/tickets/pair-new-argument-does-not-capture-its-scalar-container.md`. The guard itself stays on `todo/tickets/pair-value-assign-does-not-enforce-immutable-value.md`, now cross-referenced with row 11 and listing the `t/` expectations to correct when it lands.

`t/pair-value-container.t`'s literal-Pair row is marked `DIVERGES: raku dies` rather than silently reading as intended behaviour.

## Verification

- `t/pair-value-container.t` 9 → **15 tests**, all passing; every new assertion checked against raku first.
- `make test`: **PASS**.
- Targeted roast sweep of every whitelisted file mentioning `Pair` / `=> $` / `.value` / `.pairs` — **242 files, 72 614 tests, PASS**.
- Full `make roast` delegated to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)