### PR TITLE
docs: record that a QuantHash `.pairs` weight write needs a `for` loop to reach its source

### DIFF
--- a/todo/tickets/quanthash-pairs-value-write-needs-a-for-loop-to-reach-the-source.md
+++ b/todo/tickets/quanthash-pairs-value-write-needs-a-for-loop-to-reach-the-source.md
@@ -1,0 +1,98 @@
+# A mutable QuantHash's `.pairs` value only writes back when the pair is a `for` loop's topic
+
+## Symptom
+
+`BagHash`/`MixHash`/`SetHash` weights are mutable through the `Pair` their
+`.pairs` hands out. mutsu implements that, but only for the shape where the
+pair is a `for` loop's topic — bind the same pair to a variable and the write
+is lost:
+
+```
+$ raku  -e 'my $b = BagHash.new("a" xx 5); for $b.pairs { .value = 9 }; say $b<a>'   # 9
+$ mutsu -e 'my $b = BagHash.new("a" xx 5); for $b.pairs { .value = 9 }; say $b<a>'   # 9   ✓
+
+$ raku  -e 'my $b = BagHash.new("a" xx 5); my $p = $b.pairs[0]; $p.value = 9; say $b<a>'   # 9
+$ mutsu -e 'my $b = BagHash.new("a" xx 5); my $p = $b.pairs[0]; $p.value = 9; say $b<a>'   # 5   ✗
+```
+
+`.value--` diverges the same way (`raku: 4`, `mutsu: 5`), which is how this was
+found: `t/for-pairs-value-quanthash-writeback.t`'s first block uses a *literal*
+Pair (`my $p = a => 5; $p.value--`) to test the `.value--` **parse**, and that
+literal shape is itself a divergence (raku rejects it — see
+`pair-value-assign-does-not-enforce-immutable-value.md`). Rewriting that block
+onto a real BagHash, which is what it should have used, exposes this gap.
+
+## Root cause
+
+The QuantHash weight writeback in `assign_method_lvalue_with_values`
+(`src/runtime/methods_mut_method_lvalue.rs`) is keyed on `self.topic_source_var`:
+
+```rust
+if let Some(source) = self.topic_source_var.clone()
+    && matches!(self.env.get(&source).map(Value::view),
+                Some(ValueView::Bag(_, true) | ValueView::Mix(_, true) | ValueView::Set(_, true)))
+{
+    self.quanthash_set_weight_elem(&code, &source, &key_elem, &value)?;
+    return Ok(value);
+}
+```
+
+`topic_source_var` is set by the `for` loop (`exec_for_loop_body`) and names the
+container being iterated. Outside a loop it is `None`, so nothing identifies
+which QuantHash the pair came from and the write falls through to the
+standalone-pair compensator, which rebinds `$p` and leaves `$b` alone.
+
+So the writeback is not attached to the **pair**; it is attached to the
+**loop**. The pair `.pairs` hands out carries no back-reference to its source
+container.
+
+## Why this is not a one-liner
+
+Fixing it properly means the `Pair` a mutable QuantHash's `.pairs` produces has
+to know its source, the way ADR-0036's element containers know theirs — which
+is exactly the "route `.pairs` at the producer" work that ADR-0036 slice 3
+implemented, measured, and **deliberately backed out**
+(`todo/deep/pairs-element-containers-leak-through-pair-value-consumers.md`).
+A QuantHash weight is not a stored element container, though, and
+`.value = 0` *removes* the key, so it cannot simply become a `ContainerRef`
+either — ADR-0036 §5 Q2 records the decision to keep the weight on its own arm.
+What is missing is a narrower carrier: a weight-flavoured back-reference on the
+Pair, checked by the same `.value` lvalue arm that checks `topic_source_var`
+today.
+
+## Interaction with the pending read-only guard
+
+`todo/tickets/pair-value-assign-does-not-enforce-immutable-value.md` will delete
+the standalone-pair compensator that currently swallows this write. The guard is
+designed to fire **only for an immutable scalar pair value**, and a BagHash
+weight is an `Int`, so once it lands this shape turns from a silent no-op into a
+spurious `X::Assignment::RO`. **Land this ticket's fix first, or make the guard
+skip a pair whose key exists in a mutable QuantHash named by any live binding.**
+The former is correct; the latter is another scan.
+
+## Also found
+
+`MixHash.new-from-pairs(a => 2.5).pairs[0]` returns something mutsu answers
+`.value` on but raku does not (`No such method 'value' for invocant of type
+'Any'`) — raku has no `new-from-pairs` on `MixHash`, so that is a mutsu-only
+constructor rather than a divergence in `.pairs`. Not part of this ticket, but
+worth not mistaking for one.
+
+## Repro to pin when fixed
+
+```raku
+{
+    my $b = BagHash.new("a" xx 5);
+    my $p = $b.pairs[0];
+    $p.value = 9;
+    is $b<a>, 9, 'a bound QuantHash pair writes its weight back';
+    $p.value--;
+    is $b<a>, 8, 'and so does .value-- on it';
+}
+{
+    my $b = BagHash.new("a" xx 5);
+    my $p = $b.pairs[0];
+    $p.value = 0;
+    nok $b<a>:exists, 'weight 0 removes the key, as it does through the loop form';
+}
+```


### PR DESCRIPTION
A finding from checking which `t/` expectations the pending Pair `.value` read-only guard will have to correct — recorded so it does not evaporate with the session.

```
my $b = BagHash.new("a" xx 5); my $p = $b.pairs[0]; $p.value = 9; say $b<a>
raku:  9
mutsu: 5
```

The loop form is right (`for $b.pairs { .value = 9 }` gives 9). The weight writeback in `assign_method_lvalue_with_values` is keyed on `self.topic_source_var`, which only the `for` loop sets — so a pair bound to a variable has nothing naming its source container and falls through to the standalone-pair compensator, which rebinds `$p` and leaves `$b` alone. **The writeback is attached to the loop, not to the pair.**

## Why it is filed as a blocker, not just a bug

`todo/tickets/pair-value-assign-does-not-enforce-immutable-value.md` (ADR-0036 slice 4's remaining half, whose two prerequisites landed in #7200 and #7201) deletes that compensator and raises `X::Assignment::RO` for an **immutable scalar** pair value. A BagHash weight is an `Int`, so once the guard lands this shape turns from a silent no-op into a *spurious* die unless this is fixed first. The ticket records that ordering explicitly, and notes the two candidate resolutions — give the pair a weight-flavoured back-reference to its source (correct), or make the guard consult live bindings (another scan).

Also notes that `t/for-pairs-value-quanthash-writeback.t`'s first block tests the `.value--` **parse** on a literal Pair — a shape raku itself rejects — and that moving it onto a real BagHash is what exposed this gap.

Docs-only, so the four heavy CI jobs skip by design (`scripts/ci-docs-only.sh`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)