### PR TITLE
fix: scope gather state per instance

### DIFF
--- a/news/2026-09/gather-state-per-instance.md
+++ b/news/2026-09/gather-state-per-instance.md
@@ -1,4 +1,20 @@
-# `state` inside a `gather` block is shared across gather instances
+# `state` inside a `gather` block is now scoped per gather instance
+
+Resolved 2026-09-01. A `gather` coroutine already carried a unique
+`state_scope_id`, and bounded lazy pulls installed it correctly. The strict
+force path (`my @a = gather { ... }`) omitted that installation, so every
+strictly forced sibling used the raw compile-position state key instead.
+
+Strict forcing now installs and restores the gather's coroutine scope just as
+the pull/resume path does. `t/gather-state-per-instance.t` pins strict sibling
+gathers, repeated evaluations in a loop, and independently resumed lazy
+gathers.
+
+Validation: `cargo fmt --all`, `cargo clippy -- -D warnings`, `make test`
+(3,597 files / 36,101 assertions), and `make roast` (1,435 files / 218,833
+assertions) all pass.
+
+## Original finding
 
 A `state` variable declared inside a `gather { ... }` body should belong to the
 gather **instance** (each evaluation of the `gather` expression makes a fresh

--- a/src/vm/vm_helpers_lazy.rs
+++ b/src/vm/vm_helpers_lazy.rs
@@ -869,6 +869,23 @@ impl Interpreter {
         // todo/tickets/inline-closure-exec-sites-skip-upvalue-array-install.md.
         let saved_upvalues = std::mem::take(&mut self.upvalues);
 
+        // Each `gather` expression evaluation creates a fresh block clone, so
+        // its `state` variables need the coroutine's per-instance scope even
+        // when a finite gather is forced to completion in this strict path.
+        // The bounded pull/resume sibling installs the same scope around every
+        // coroutine run; without it, strict `my @a = gather { state ... }`
+        // forces use the raw, compile-position-only key and sibling gathers
+        // share a state cell.
+        let saved_state_scope = self.state_scope_id.get();
+        let gather_scope_id = list
+            .coroutine
+            .as_ref()
+            .map(|m| m.lock().unwrap().state_scope_id)
+            .unwrap_or(0);
+        if gather_scope_id != 0 {
+            self.state_scope_id.set(Some(gather_scope_id));
+        }
+
         // Set up the lazy list's environment as a scoped overlay's parent: the
         // gather body reads its captured lexicals through to `list.env` and its
         // own writes land in a fresh born-owned overlay (no fork of `list.env`).
@@ -989,6 +1006,7 @@ impl Interpreter {
         self.record_eager_block_free_var_writeback(cc.as_ref(), &[]);
 
         // Restore Interpreter state
+        self.state_scope_id.set(saved_state_scope);
         self.locals = saved_locals;
         self.stack = saved_stack;
         self.upvalues = saved_upvalues;

--- a/t/gather-state-per-instance.t
+++ b/t/gather-state-per-instance.t
@@ -1,0 +1,35 @@
+use v6;
+use Test;
+
+# Every evaluation of a gather expression creates a distinct block clone. Its
+# `state` variables persist while that one gather is forced, but never collide
+# with a sibling created from the same compiled body.
+plan 4;
+
+sub make() {
+    gather {
+        state $n = 0;
+        take ++$n;
+    }
+}
+
+is (make(), make()).map(*.head).join(','), '1,1',
+    'strictly forced sibling gathers have separate state';
+
+my @seen;
+for ^3 {
+    my @g = gather { state $n = 0; take ++$n; };
+    @seen.push: @g[0];
+}
+is @seen.join(','), '1,1,1',
+    'a gather literal evaluated in a loop gets a fresh state clone each time';
+
+sub lazy-counter() {
+    lazy gather { state $n = 0; loop { take ++$n } }
+}
+
+my $left = lazy-counter();
+my $right = lazy-counter();
+is $left[0], 1, 'first lazy gather starts its own state';
+is "{$left[1]},{$right[0]},{$right[1]}", '2,1,2',
+    'resuming either lazy gather retains only its own state';


### PR DESCRIPTION
## Summary
- scope strict gather forcing to the coroutine instance
- add strict, loop, and lazy-resume regressions
- retire the resolved gather-state ticket

## Validation
- cargo fmt --all
- cargo clippy -- -D warnings
- make test
- make roast