### PR TITLE
feat: complete ADR-0036 — delete the `Pair.value` env-scan compensator, then sweep

### DIFF
--- a/docs/adr/0036-element-container-pairs-from-subscripts-and-pairs.md
+++ b/docs/adr/0036-element-container-pairs-from-subscripts-and-pairs.md
@@ -1,10 +1,10 @@
 # ADR-0036: A Pair produced by a subscript adverb or `.pairs` carries the element *container*, not a snapshot
 
-- **Status**: Slices 1-4 implemented — slices 1-2 landed (2026-08-20); slice 3 completed 2026-09-01
-  when `.pairs` finally routed (see "Implementation status — slice 3, `.pairs` (2026-09-01)");
-  slice 4 completed 2026-09-01 (enforcement with #7190, reporting and then the compensator
-  deletion — see "Implementation status — slice 4, the deletion"). Slice 5 (the sweep) is what
-  is left
+- **Status**: **Implemented — every slice landed.** Slices 1-2 landed 2026-08-20; slice 3 completed
+  2026-09-01 when `.pairs` finally routed; slice 4 completed 2026-09-01 (enforcement with #7190,
+  then reporting, then the compensator deletion); slice 5's sweep re-measured §1.3 at 12/12 and
+  swept 69 rows across the whole surface. The three residual divergences it found are tracked as
+  tickets, not as further slices — see "Implementation status — slice 5, the sweep"
 - **Date**: 2026-08-20
 - **Deciders**: tokuhirom, Claude
 - **Related**: [ADR-0013](0013-container-interior-mutability-cellvalue.md) §5 open question 3 (element-level cells, "2c / Track B proper" — deferred there, and this ADR is the correctness driver that reopens it in a scoped form), [ADR-0001](0001-gc-strategy-and-phasing.md) (layer 3a / Track B framing), [ADR-0021](0021-argument-namedness-is-a-call-site-property.md) (Pair flavour unification — `.pairs`' output is data, not a call site), `todo/deep/subscript-p-pair-is-a-snapshot-not-a-container.md` (the originating finding)
@@ -690,6 +690,67 @@ container's name (`Type check failed for an element of @` where raku says `@a`) 
 site retagged it — `todo/tickets/promoted-element-cell-does-not-know-its-container-name.md`. The
 bound-slice eager vivification noted above is likewise unchanged
 (`todo/tickets/bound-array-slice-still-vivifies-eagerly.md`).
+
+---
+
+## Implementation status — slice 5, the sweep (2026-09-01)
+
+**§1.3 re-measured: 12/12 rows reach raku's answer**, plus the two `.VAR.^name`
+probes from §1.1. Each row was run as its own one-line program and raku's and
+mutsu's `stdout`+`stderr` compared verbatim (`tmp/comp/s13.sh` at the time of
+writing), so the `dies` rows are checked on their message, not just on dying.
+
+The sweep then went past the table, because TRIAGE's standing advice after
+ADR-0045 slice 6 is that a divergence matrix cannot see what an ADR's own
+mechanism does off the rows it was written from. **69 rows over the whole
+surface this ADR owns** — subscript adverbs on arrays and hashes (single,
+slice, out-of-range, `:exists`/`:delete`), every producer and its `for`-loop
+consumption, immutable sources, element type constraints, 1-D and multi-dim
+shaped arrays, QuantHash weights, the "a Pair value is read as DATA" rule from
+slice 3, and subscripting a producer's result. Twelve rows differ, in three
+groups, **none of them a regression** — every one was re-run against `main` at
+`f03b85978` and behaves identically there:
+
+1. **Five rows are the blame *name* only** (§1.3 row 12, and the `:p`/`.pairs`/
+   `:=` forms of the same check on a typed array or hash). The class is right,
+   the type is right, the container is not: mutsu says `an element of @` where
+   raku says `an element of @a`. Already tracked as
+   `todo/tickets/promoted-element-cell-does-not-know-its-container-name.md`.
+   One of the five (`my Int @a[2]`) additionally shows raku itself wording a
+   shaped typed array's failure as `Type check failed in assignment to ;` —
+   with an empty name — so that row is not a straightforward target.
+
+2. **One row is the QuantHash weight arm's known keying.**
+   `for $b.pairs -> $p { $p.value = 5 }` dies where the *implicit-topic* form
+   `for $b.pairs { .value = 5 }` works, because `topic_source_var` is set when
+   the loop binds the topic and `-> $p` binds a named parameter instead. This is
+   the sharpest repro yet of
+   `todo/tickets/quanthash-pairs-value-write-needs-a-for-loop-to-reach-the-source.md`
+   (two programs differing only in the loop's parameter form), and it has been
+   added there. §5 Q2's decision to keep the weight arm stands; what is wrong is
+   how the arm finds its source.
+
+3. **Five rows are one genuinely new finding: subscripting a producer's `Seq`
+   drops the element container.** `(@a.values)[0].VAR.^name` is `Str` where raku
+   says `Scalar`, and `(@a.values)[0] = "x"`, `(@a.kv)[1] = "x"` and
+   `my $c := (@a.values)[0]; $c = "x"` are all **silent no-ops**. The producer is
+   fine (`for @a.values -> $v is rw` works, `.head` keeps the cell) and the
+   consumer is fine (`@a.pairs[0].value` keeps it); it is the positional
+   subscript in between. `exec_index_op_with_positional` normalizes a `Seq`
+   receiver to an `ArrayKind::List` array and the read then goes through
+   `resolve_array_entry` — the decontainerization chokepoint — which is correct
+   for every other array read and wrong for this one. Filed as
+   `todo/tickets/producer-seq-index-read-decontainerizes-the-element-cell.md`.
+
+That third group is this ADR's §6 blast-radius consequence seen from the other
+side: the chokepoint that stops a cell leaking into `.raku`/`.WHAT` also stops
+it reaching a place that wants it. Fixing it needs the `Seq` to record that its
+items *are* element containers, which no slice of this ADR gives it — hence a
+ticket rather than a slice 6.
+
+Whitelisted roast families: the whole suite was run, not just S02/S09/S32 —
+`make roast` PASS, 1435 files / 218,833 tests, together with `make test` and the
+bundled-battery gate (274/297).
 
 ## 5. Open questions (the forks for the deciders)
 

--- a/docs/adr/0036-element-container-pairs-from-subscripts-and-pairs.md
+++ b/docs/adr/0036-element-container-pairs-from-subscripts-and-pairs.md
@@ -1,9 +1,10 @@
 # ADR-0036: A Pair produced by a subscript adverb or `.pairs` carries the element *container*, not a snapshot
 
-- **Status**: Partially implemented — slices 1-2 landed (2026-08-20); slice 3 completed 2026-09-01
+- **Status**: Slices 1-4 implemented — slices 1-2 landed (2026-08-20); slice 3 completed 2026-09-01
   when `.pairs` finally routed (see "Implementation status — slice 3, `.pairs` (2026-09-01)");
-  slice 4's enforcement half landed with #7190 and its reporting half 2026-09-01, its compensator
-  deletion is still open
+  slice 4 completed 2026-09-01 (enforcement with #7190, reporting and then the compensator
+  deletion — see "Implementation status — slice 4, the deletion"). Slice 5 (the sweep) is what
+  is left
 - **Date**: 2026-08-20
 - **Deciders**: tokuhirom, Claude
 - **Related**: [ADR-0013](0013-container-interior-mutability-cellvalue.md) §5 open question 3 (element-level cells, "2c / Track B proper" — deferred there, and this ADR is the correctness driver that reopens it in a scoped form), [ADR-0001](0001-gc-strategy-and-phasing.md) (layer 3a / Track B framing), [ADR-0021](0021-argument-namedness-is-a-call-site-property.md) (Pair flavour unification — `.pairs`' output is data, not a call site), `todo/deep/subscript-p-pair-is-a-snapshot-not-a-container.md` (the originating finding)
@@ -617,13 +618,78 @@ env-scan skips `ArrayKind::List`/`ItemList`.
 > the command line and failed in its test file for this reason. Excluding the immutable array kinds
 > from both array lookups is what made the guard reachable there.
 
-The `__mutsu_hash_ref` branch is still untouched, and the rest of the compensator survives for
-reference-valued pairs, which are mutable in place -- `S02-types/pair.t`'s
-`(%(<a b c d>) => %(<e f g h>)).invert` is its one remaining consumer across the whole whitelist.
+The `__mutsu_hash_ref` branch is still untouched at this point, and the rest of the compensator
+survives for reference-valued pairs -- all of which the deletion below retires.
 
 Verified with `make test`, a **full local `make roast`** (required by the "universal property of
 values" rule, since this changes what is inside every promoted container), and the bundled-battery
 gate.
+
+---
+
+## Implementation status — slice 4, the deletion (2026-09-01)
+
+The compensator is gone. `methods_mut_method_lvalue.rs`'s `method == "value"` arm is now the short
+list of container kinds §6 predicted: `HashEntryRef` node, `ContainerRef` cell, mutable-QuantHash
+weight, reference value, then die. The `env` scans (both element lookups, the shaped-array index
+tuple scan and the standalone-Pair rebind), the dead `__mutsu_hash_ref` branch and its only other
+reader in `builtins/methods_0arg/coercion.rs` are deleted — about 220 lines.
+
+**What the deletion actually cost was measured first, not guessed.** Instrumenting each of the ten
+exits of the compensator and sweeping *every* `t/` file and *every* whitelisted roast file found it
+firing in exactly five `t/` files and two roast files:
+
+| exit | fires in |
+| --- | --- |
+| `standalone_rebind_multi` | `t/bound-container-pair-writethrough.t`, `t/pair-value-element-writethrough.t`, `t/pair-value-writethrough-coherence.t`, `roast/S02-types/pair.t` |
+| `scan_array` + `array_writeback` | `t/pairs-value-writeback-array-kind.t` (the 1-D shaped-array row) |
+| `multidim` | `t/shaped-array-pairs-zip-assign.t`, `roast/S02-types/array-shapes.t` |
+| `hashref`, `target_var_hash`, `target_var_array`, `scan_hash`, `hash_writeback` | **never** |
+
+Five of the ten exits were already dead — slice 3's `.pairs` routing had taken every hash-backed
+shape. Three real gaps remained, and each is a piece of the model this ADR is about rather than a
+special case:
+
+1. **A shaped array's `.pairs` did not hand out element containers.** `array_element_producer`
+   declined on `data.shape.is_some()`. A **1-D** shape stores its leaves flat, so it needed only to
+   be let in (its `ArrayKind` is `Shaped`, which the kind filter also had to admit). A
+   **multi-dimensional** shape keeps its leaves in nested inner arrays, so `array_slot_ref` on the
+   outer array would have handed out rows; `.pairs` over it now walks to each leaf and promotes it
+   *there*, keyed by the index tuple raku uses (`(0 1) => …`). The other producers keep their
+   current behaviour for a multi-dim shape.
+
+2. **A reference-valued Pair now assigns INTO its value.** Rakudo's `Pair` binds
+   (`$!value := value`), so `my @a = 1,2; my $p = (a => @a); $p.value = (3,4)` leaves `@a` as
+   `[3 4]`. mutsu already shares the `Gc` there (`$p.value.push` wrote through), so
+   `replace_container_contents` reaches every alias. This *fixed* four divergences the env rebind
+   had been papering over: the write did not reach `@a`/`%h` at all, an Array value came back as a
+   `List`, and `(a => C.new)` / `(a => (1,2))` silently succeeded where raku dies. An empty `List`
+   value is the one shape where raku neither writes nor dies (nothing to assign into), and that is
+   preserved.
+
+3. **`$p.value<k> = v` cloned the container and rebound by name.**
+   `assign_method_lvalue_indexed` built a fresh `Gc`, moved every variable holding the old one onto
+   it, then called the `.value` setter. With the compensator gone that forks the pair away from the
+   variable it aliases, and only the first write is visible through both. For a Pair accessor the
+   element write is now done **in place** on the container the pair holds, which is what "a Pair
+   binds its value" means and what `t/pair-value-writethrough-coherence.t` was always asserting.
+
+**The enforcement half also reached the deferred slots.** `array_slot_ref`/`hash_slot_ref` seed a
+promoted cell with the container's `value_type`, but a `:=` bind to a slot that does not exist yet
+(`my Str @a; my $r := @a[2]`) never reaches them — it materializes a *fresh* cell at the first write,
+which carried no constraint, so `$r = 42` silently stored an `Int` in a `Str` array. All three
+materialization sites now go through `Interpreter::materialize_entry_cell`, which reads the
+constraint off the `EntryTerminal` and checks the write before installing anything. The equivalent
+missing-key hash bind is fixed by the same change.
+
+`t/pair-value-assign-binds-container.t` pins all of the above (21 tests, all verified against real
+raku).
+
+**Still open, and now purely cosmetic:** the promoted cell reports the bare sigil rather than the
+container's name (`Type check failed for an element of @` where raku says `@a`) unless a promotion
+site retagged it — `todo/tickets/promoted-element-cell-does-not-know-its-container-name.md`. The
+bound-slice eager vivification noted above is likewise unchanged
+(`todo/tickets/bound-array-slice-still-vivifies-eagerly.md`).
 
 ## 5. Open questions (the forks for the deciders)
 

--- a/news/2026-09/adr-0036-closed-by-a-69-row-sweep.md
+++ b/news/2026-09/adr-0036-closed-by-a-69-row-sweep.md
@@ -1,0 +1,72 @@
+# ADR-0036 closes, and its sweep pays for itself again
+
+[ADR-0036](../../docs/adr/0036-element-container-pairs-from-subscripts-and-pairs.md)
+— "a Pair produced by a subscript adverb or `.pairs` carries the element
+*container*, not a snapshot" — is fully implemented. Slice 5 is the sweep, and
+its job was to prove that rather than assume it.
+
+## The table it was written from
+
+All twelve rows of the ADR's §1.3 divergence table now reach raku's answer, as
+do the two `.VAR.^name` probes from §1.1. Each was run as its own one-line
+program with raku's and mutsu's `stdout`+`stderr` compared verbatim, so the rows
+that die are checked on their message rather than merely on dying.
+
+## The rows it was not written from
+
+After ADR-0045 slice 6, the standing advice in `todo/TRIAGE.md` is that an ADR's
+own divergence matrix cannot see what its mechanism does off the rows it was
+written from. So the sweep went to **69 rows** across the whole surface this ADR
+owns: subscript adverbs on arrays and hashes (single, slice, out-of-range,
+`:exists`/`:delete`), every producer and its `for`-loop consumption, immutable
+sources, element type constraints, 1-D and multi-dimensional shaped arrays,
+QuantHash weights, the "a Pair value is read as DATA" rule from slice 3, and —
+the one nobody had written a row for — subscripting a producer's result.
+
+Twelve rows differ. **None is a regression**: every one was re-run against `main`
+before the slice-4 branch and behaves identically there. They fall into three
+groups, two of which were already on file:
+
+- **Five are the blame *name* only.** The class, the type and the check are
+  right; mutsu says `an element of @` where raku says `an element of @a`.
+- **One is the QuantHash weight arm's keying**, in its sharpest form yet:
+  `for $b.pairs -> $p { $p.value = 5 }` dies where `for $b.pairs { .value = 5 }`
+  works. The two programs differ only in the loop's parameter form —
+  `topic_source_var` is set when the loop binds the *topic*, and `-> $p` binds a
+  named parameter instead.
+- **Five are one new finding**, and three of those are silent no-ops.
+
+## The new one
+
+Subscripting an element producer's `Seq` drops the container:
+
+```raku
+my @a = <A B>;
+say (@a.values)[0].VAR.^name;   # raku: Scalar    mutsu: Str
+(@a.values)[0] = "x"; say @a;   # raku: [x B]     mutsu: [A B]   silent
+(@a.kv)[1]     = "x"; say @a;   # raku: [x B]     mutsu: [A B]   silent
+my $c := (@a.values)[0]; $c = "x";  # raku: [x B] mutsu: [A B]   silent
+```
+
+The producer is fine — `for @a.values -> $v is rw` writes through, and
+`.head` keeps the cell. The consumer is fine — `@a.pairs[0].value` keeps it. It
+is the positional subscript in between: `exec_index_op_with_positional`
+normalizes a `Seq` receiver to an `ArrayKind::List` array, and the read then goes
+through `resolve_array_entry`, the decontainerization chokepoint.
+
+That is ADR-0036 §6's blast-radius consequence seen from the other side. The
+chokepoint that stops a cell leaking into `.raku`/`.WHAT` also stops it reaching
+the one caller that wants it, and telling those apart needs the `Seq` to record
+that its items *are* element containers — which no slice of this ADR gives it.
+So it is `todo/tickets/producer-seq-index-read-decontainerizes-the-element-cell.md`,
+not a slice 6.
+
+## A blocker attribution corrected on the way out
+
+`todo/deep/immutable-lvalues-that-mutsu-still-lets-you-assign-to.md` has been
+blocked on this ADR since 2026-08-27, when ADR-0040 was ruled out as its blocker
+and ADR-0036 named in its place. Its seven-row harness was re-run against the
+finished ADR: **no row moved.** The remaining rows are an immutable-container
+check on the element *store* and the closure-call topic marking, and neither of
+those is a pair producer. The file says so now, so the next reader does not
+re-derive the same wrong attribution a third time.

--- a/news/2026-09/pair-value-lvalue-drops-the-env-scan.md
+++ b/news/2026-09/pair-value-lvalue-drops-the-env-scan.md
@@ -1,0 +1,68 @@
+# `Pair.value` as an lvalue stops searching the environment (ADR-0036 slice 4)
+
+`$p.value = X` used to work by *looking for* the container the pair came from. Because a mutsu Pair
+held a snapshot of its value rather than the element's `Scalar`, the assignment path scanned
+`self.env` for a `Hash` whose entry at the pair's key — or an `Array` whose element at the pair's
+integer index — happened to compare equal, required the match to be unique, rebuilt the whole
+container and wrote it back by identity. Adjacent arms extended the same trick to shaped arrays by
+index tuple and to standalone pairs by scanning every binding that held "a Pair with the same key and
+the same old value".
+
+That search is deleted. [ADR-0036](../../docs/adr/0036-element-container-pairs-from-subscripts-and-pairs.md)'s
+earlier slices had already made every element producer hand out the element's own container, so by
+the time a pair reaches the setter it is carrying the thing to write into. What is left is a short
+list of container kinds: a live hash-node ref, a shared cell, a mutable QuantHash weight, a
+reference value — and otherwise the assignment dies, the way raku's `rw` `Pair.value` accessor dies
+when there is no container behind the value.
+
+## Measuring before deleting
+
+Each of the compensator's ten exits was instrumented and every `t/` file and every whitelisted roast
+file was run under it. It fired in five `t/` files and two roast files; five of the ten exits — the
+whole `__mutsu_hash_ref` branch, both `target_var`-keyed lookups, the hash scan and the hash
+writeback — never fired at all, because slice 3's `.pairs` routing had already taken every
+hash-backed shape. That left three real gaps, each a piece of the same model rather than a special
+case.
+
+**A shaped array's `.pairs` did not hand out element containers.** The producer declined on
+`data.shape.is_some()`. A one-dimensional shape stores its leaves flat and only needed to be let in;
+a multi-dimensional shape keeps them in nested inner arrays, so `.pairs` over it now walks down to
+each leaf and promotes it there, keyed by the index tuple raku uses (`(0 1) => …`).
+
+**A reference-valued Pair now assigns into its value.** Rakudo's `Pair` binds its value
+(`$!value := value`), so the pair and the variable it was built from are the same container:
+
+```raku
+my @a = 1, 2;
+my $p = (a => @a);
+$p.value = (3, 4);
+say @a;             # [3 4]
+```
+
+mutsu used to print `[1 2]` here and give the pair a bare `List`. Three more rows moved to raku's
+answer at the same time: `%h` likewise gets the new contents, and `(a => C.new).value = 5` and
+`(a => (1,2)).value = 5` now die instead of silently rebinding. An empty `List` value is the one
+shape where raku neither writes nor dies, and that is preserved.
+
+**`$p.value<k> = v` cloned the container and rebound it by name.** With the search gone that forked
+the pair away from the variable it aliases, so only the first write was visible through both. For a
+Pair accessor the element write now happens in place, in the container the pair holds.
+
+## Element type constraints reach the deferred slots
+
+The enforcement half of the slice seeds a promoted element cell with its container's `of`-type, but a
+`:=` bind to a slot that does not exist yet never reaches the promotion primitives — it materializes
+a fresh cell at the first write, and that cell carried no constraint:
+
+```raku
+my Str @a;
+my $r := @a[2];
+$r = 42;            # silently stored an Int in a Str array
+```
+
+All three materialization sites now go through one checked helper that reads the constraint off the
+deferred path's terminal and refuses the write before installing anything. The missing-key hash bind
+(`my Int %h; my $r := %h<k>; $r = "s"`) is fixed by the same change.
+
+`t/pair-value-assign-binds-container.t` pins the whole surface — 21 assertions, every one of them
+checked against real raku first.

--- a/src/builtins/methods_0arg/coercion.rs
+++ b/src/builtins/methods_0arg/coercion.rs
@@ -207,20 +207,11 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
                 class_name,
                 attributes,
                 ..
-            } if class_name == "Pair" => {
-                if let (Some(ValueView::Hash(hash)), Some(ValueView::Str(key))) = (
-                    attributes.as_map().get("__mutsu_hash_ref").map(Value::view),
-                    attributes.as_map().get("key").map(Value::view),
-                ) {
-                    Some(Ok(hash.get(key.as_str()).cloned().unwrap_or(Value::NIL)))
-                } else {
-                    Some(Ok(attributes
-                        .as_map()
-                        .get("value")
-                        .cloned()
-                        .unwrap_or(Value::NIL)))
-                }
-            }
+            } if class_name == "Pair" => Some(Ok(attributes
+                .as_map()
+                .get("value")
+                .cloned()
+                .unwrap_or(Value::NIL))),
             ValueView::Bool(b) => Some(Ok(Value::int(if b { 1 } else { 0 }))),
             _ => None,
         },

--- a/src/runtime/builtins_multidim_assign.rs
+++ b/src/runtime/builtins_multidim_assign.rs
@@ -300,6 +300,42 @@ impl Interpreter {
             }
         }
 
+        // ADR-0036: `$p.value<k> = v` / `$p.value[i] = v` on a Pair. A Pair
+        // BINDS its value (rakudo's BUILD does `$!value := value`), so the pair
+        // and the variable it was built from are the *same* container and the
+        // element write belongs in it, in place. The clone-and-rebind below
+        // would fork them: `overwrite_*_bindings_by_identity` moves the
+        // variable onto the fresh `Gc` while the pair keeps the old one, so
+        // only the first write is ever visible through both
+        // (`t/pair-value-writethrough-coherence.t`).
+        if matches!(method.as_str(), "value" | "key")
+            && matches!(
+                target.view(),
+                ValueView::Pair(..) | ValueView::ValuePair(..)
+            )
+            && dims.len() < 2
+        {
+            match current.view() {
+                ValueView::Hash(h) if h.key_type.is_none() => {
+                    let key = index.to_string_value();
+                    if let Some(entry) = current.hash_autovivify(&key) {
+                        entry.hash_entry_write(effective_value.clone());
+                        return Ok(effective_value);
+                    }
+                }
+                ValueView::Array(items, _) => {
+                    let idx = crate::runtime::to_int(&index) as usize;
+                    if idx >= items.len() && !crate::runtime::utils::is_shaped_array(&current) {
+                        current.array_grow_to(idx);
+                    }
+                    if current.array_set_in_place(idx, effective_value.clone()) {
+                        return Ok(effective_value);
+                    }
+                }
+                _ => {}
+            }
+        }
+
         // Modify the container
         let updated = if dims.len() >= 2 {
             // Multi-dimensional index assignment (e.g., $c.a[2;1] = value)

--- a/src/runtime/methods_mut_method_lvalue.rs
+++ b/src/runtime/methods_mut_method_lvalue.rs
@@ -133,9 +133,9 @@ impl Interpreter {
     /// to. `List`/`ItemList` are raku's immutable list types: `my $l = (1, 2);
     /// $l.pairs[0].value = 3` raises "Cannot modify an immutable Int (1)",
     /// while the `Array` kinds write through (`my $l = [1, 2]` gives `[3 2]`).
-    /// The Pair `.value` lvalue path uses this to decide whether an array found
-    /// in `env` may back a pair write; a `List` may not, and the write falls
-    /// through to the read-only guard instead.
+    /// The Pair `.value` lvalue path uses this to decide whether an Array-valued
+    /// pair may be assigned INTO; a `List` may not, and the write falls through
+    /// to the read-only guard instead.
     fn array_kind_is_mutable(kind: crate::value::ArrayKind) -> bool {
         !matches!(
             kind,
@@ -493,23 +493,6 @@ impl Interpreter {
             }
             return Ok(value);
         }
-        if method == "value"
-            && let ValueView::Instance {
-                class_name,
-                attributes,
-                ..
-            } = target.view()
-            && class_name == "Pair"
-            && let Some(ValueView::Str(key)) = attributes.as_map().get("key").map(Value::view)
-            && let Some(ValueView::Hash(source_hash)) =
-                attributes.as_map().get("__mutsu_hash_ref").map(Value::view)
-        {
-            let mut updated = (**source_hash).clone();
-            updated.insert(key.to_string(), value.clone());
-            let replacement = Value::hash(updated);
-            self.overwrite_hash_bindings_by_identity(&source_hash, replacement);
-            return Ok(value);
-        }
         if method == "value" {
             let pair_data = match target.view() {
                 ValueView::Pair(key, current_value) => Some((
@@ -524,7 +507,7 @@ impl Interpreter {
                 )),
                 _ => None,
             };
-            if let Some((key, key_elem, current_value)) = pair_data {
+            if let Some((_key, key_elem, current_value)) = pair_data {
                 // A Pair whose value is a live `HashEntryRef` (a `for %h -> $p`
                 // loop pair) writes `.value` straight through to the shared hash
                 // node in place, so `$p.value = X` updates `%h{$p.key}` and the
@@ -572,8 +555,8 @@ impl Interpreter {
                 // `$b` a BagHash/MixHash/SetHash) writes the new weight back to
                 // the source container. `topic_source_var` names that container
                 // (set by the for-loop). Weight 0 removes the key; a non-numeric
-                // Str coercion raises X::Str::Numeric. Immutable Bag/Mix/Set fall
-                // through to the read-only Bool guard below.
+                // Str coercion raises X::Str::Numeric. An immutable Bag/Mix/Set
+                // falls through to the read-only guard below.
                 if let Some(source) = self.topic_source_var.clone()
                     && matches!(
                         self.env.get(&source).map(Value::view),
@@ -592,225 +575,59 @@ impl Interpreter {
                     self.quanthash_set_weight_elem(&code, &source, &key_elem, &value)?;
                     return Ok(value);
                 }
-                let mut selected_hash: Option<crate::gc::Gc<crate::value::HashData>> = None;
-                // Track the source array's `ArrayKind` so the rebuilt array keeps
-                // its Array/Shaped identity (`for @a.pairs { .value = X }` must not
-                // demote `@a` to a bare List).
-                let mut selected_array: Option<(
-                    crate::gc::Gc<crate::value::ArrayData>,
-                    ArrayKind,
-                )> = None;
-
-                if let Some(var_name) = target_var
-                    && let Some(ValueView::Hash(candidate)) =
-                        self.env.get(var_name).map(Value::view)
-                    && candidate.contains_key(&key)
-                {
-                    selected_hash = Some(candidate.clone());
-                }
-                if selected_hash.is_none()
-                    && let Ok(i) = key.parse::<usize>()
-                    && let Some(var_name) = target_var
-                    && let Some(ValueView::Array(candidate, kind)) =
-                        self.env.get(var_name).map(Value::view)
-                    && Self::array_kind_is_mutable(kind)
-                    && candidate.get(i) == Some(current_value.as_ref())
-                {
-                    selected_array = Some((candidate.clone(), kind));
-                }
-
-                if selected_hash.is_none() {
-                    let mut candidates = self.env.values().filter_map(|bound| match bound.view() {
-                        ValueView::Hash(map)
-                            if map
-                                .get(&key)
-                                .is_some_and(|existing| existing == current_value.as_ref()) =>
-                        {
-                            Some(map.clone())
-                        }
-                        _ => None,
-                    });
-                    if let Some(first) = candidates.next()
-                        && candidates.all(|other| crate::gc::Gc::ptr_eq(&first, &other))
-                    {
-                        selected_hash = Some(first);
-                    }
-                }
-                if selected_array.is_none()
-                    && let Ok(i) = key.parse::<usize>()
-                {
-                    let mut candidates = self.env.values().filter_map(|bound| match bound.view() {
-                        ValueView::Array(arr, kind)
-                            if Self::array_kind_is_mutable(kind)
-                                && arr.get(i) == Some(current_value.as_ref()) =>
-                        {
-                            Some((arr.clone(), kind))
-                        }
-                        _ => None,
-                    });
-                    if let Some(first) = candidates.next()
-                        && candidates.all(|(other, _)| crate::gc::Gc::ptr_eq(&first.0, &other))
-                    {
-                        selected_array = Some(first);
-                    }
-                }
-
-                // A multidimensional shaped-array pair has an Array key such as
-                // `(0, 1)`, not a stringifiable one-dimensional index. Locate
-                // the unique backing shaped array by that full index tuple and
-                // current leaf value, then rebuild it through the existing
-                // multidimensional assignment path.
-                if selected_array.is_none()
-                    && let ValueView::Array(indices, _) = key_elem.view()
-                {
-                    let dims: Option<Vec<usize>> = indices
-                        .iter()
-                        .map(|index| usize::try_from(crate::runtime::to_int(index)).ok())
-                        .collect();
-                    if let Some(dims) = dims {
-                        let dims_i64: Vec<i64> = dims.iter().map(|&index| index as i64).collect();
-                        let mut candidates = self.env.values().filter_map(|bound| {
-                            let ValueView::Array(arr, kind) = bound.view() else {
-                                return None;
-                            };
-                            if !crate::runtime::utils::is_shaped_array(bound) {
-                                return None;
-                            }
-                            crate::runtime::utils::shaped_array_indexed_leaves(bound)
-                                .into_iter()
-                                .find(|(index, leaf)| {
-                                    index == &dims_i64 && leaf == current_value.as_ref()
-                                })
-                                .map(|_| (arr.clone(), kind, bound.clone()))
-                        });
-                        if let Some(first) = candidates.next()
-                            && candidates
-                                .all(|(other, _, _)| crate::gc::Gc::ptr_eq(&first.0, &other))
-                        {
-                            let replacement =
-                                Self::multidim_assign_nested(first.2, &dims, value.clone())?;
-                            self.overwrite_array_bindings_by_identity(&first.0, replacement);
+                // A reference-valued Pair *binds* its value — rakudo's `Pair`
+                // BUILD does `$!value := value`, so the pair holds the
+                // Array/Hash container itself and `.value = X` assigns INTO
+                // that container rather than rebinding the pair:
+                // `my @a = 1,2; my $p = (a => @a); $p.value = (3,4)` leaves
+                // `@a` as `[3 4]`. mutsu already shares the `Gc` here (a
+                // `$p.value.push` writes through), so replacing the contents in
+                // place reaches every alias. An immutable `List`/`ItemList`
+                // value is not assignable: raku list-assigns into it and dies on
+                // the first element (`(a => (1,2))`), or does nothing at all
+                // when it is empty (`(a => ())`).
+                match current_value.as_ref().view() {
+                    ValueView::Array(_, kind) if Self::array_kind_is_mutable(kind) => {
+                        let src = crate::runtime::coerce_to_array(value.clone());
+                        if current_value.as_ref().replace_container_contents(&src) {
                             return Ok(value);
                         }
                     }
-                }
-
-                if let Some(source_hash) = selected_hash {
-                    let mut updated = (*source_hash).clone();
-                    updated.insert(key, value.clone());
-                    let replacement = Value::hash(updated);
-                    self.overwrite_hash_bindings_by_identity(&source_hash, replacement);
-                    return Ok(value);
-                }
-                if let Some((source_array, source_kind)) = selected_array
-                    && let Ok(i) = key.parse::<usize>()
-                {
-                    let mut updated = (*source_array).clone();
-                    if i < updated.len() {
-                        updated[i] = value.clone();
-                        // Preserve the source array's kind (Array/Shaped/…) so the
-                        // writeback does not demote it to a List.
-                        let replacement =
-                            Value::array_with_kind(crate::gc::Gc::new(updated), source_kind);
-                        self.overwrite_array_bindings_by_identity(&source_array, replacement);
-                        return Ok(value);
+                    ValueView::Array(list_items, _) => {
+                        let Some(first) = list_items.first().cloned() else {
+                            return Ok(value);
+                        };
+                        let type_name = crate::value::what_type_name(&first);
+                        return Err(RuntimeError::assignment_ro_typename(
+                            &type_name,
+                            &first.to_string_value(),
+                        ));
                     }
+                    ValueView::Hash(..) => {
+                        let src = crate::runtime::utils::coerce_to_hash(value.clone());
+                        if current_value.as_ref().replace_container_contents(&src) {
+                            return Ok(value);
+                        }
+                    }
+                    _ => {}
                 }
 
                 // Everything that could put a container behind the pair value
                 // has now been tried: a `ContainerRef` wrote through its cell
-                // far above, a mutable QuantHash weight went through
-                // `topic_source_var`, and a backing hash/array was searched for
-                // just now. What is left is a pair holding a *bare* value, and
-                // raku's `rw` `Pair.value` accessor has nothing to assign into:
-                // `my $p = (1 => "a"); $p.value = "z"` dies with
-                // "Cannot modify an immutable Str (a)".
-                //
-                // Fire only for the immutable scalar leaves. A reference value
-                // (Array/Hash/Instance/Proxy/...) is mutable in place and must
-                // still reach the env rebinds below — the one whitelisted roast
-                // consumer of them, `S02-types/pair.t`'s
-                // `(%(<a b c d>) => %(<e f g h>)).invert`, has a Hash value.
-                // The old `Bool`-only guard (`Set.pairs[0].value = 0`) is the
-                // narrowest case of this rule.
-                if matches!(
-                    current_value.as_ref().view(),
-                    ValueView::Int(_)
-                        | ValueView::BigInt(_)
-                        | ValueView::Num(_)
-                        | ValueView::Str(_)
-                        | ValueView::Bool(_)
-                        | ValueView::Rat(..)
-                        | ValueView::FatRat(..)
-                        | ValueView::BigRat(..)
-                        | ValueView::Complex(..)
-                        | ValueView::Enum { .. }
-                        | ValueView::Nil
-                        | ValueView::Package(_)
-                ) {
-                    let has_backing_hash = target_var.is_some_and(|vn| {
-                        matches!(self.env.get(vn).map(Value::view), Some(ValueView::Hash(_)))
-                    });
-                    if !has_backing_hash {
-                        let type_name = crate::value::what_type_name(current_value.as_ref());
-                        return Err(RuntimeError::assignment_ro_typename(
-                            &type_name,
-                            &current_value.to_string_value(),
-                        ));
-                    }
-                }
-
-                // Standalone pair (not derived from a hash or array): update the
-                // pair value directly by replacing the variable binding, and also
-                // propagate to any other environment bindings that hold a pair
-                // with the same key and same original value (simulating Raku
-                // container semantics where pair values are aliases).
-                {
-                    let old_value = current_value.as_ref().clone();
-                    // Collect all variable names in the environment that hold an
-                    // equivalent pair (same key and same old value).
-                    let vars_to_update: Vec<Symbol> = self
-                        .env
-                        .iter()
-                        .filter_map(|(name, val)| {
-                            let matches = match val.view() {
-                                ValueView::Pair(k, v) => k == &key && v == &old_value,
-                                ValueView::ValuePair(k, v) => {
-                                    k.to_string_value() == key && v == &old_value
-                                }
-                                _ => false,
-                            };
-                            if matches { Some(*name) } else { None }
-                        })
-                        .collect();
-
-                    if !vars_to_update.is_empty() {
-                        for var_name in &vars_to_update {
-                            let current = self.env.get_sym(*var_name).cloned();
-                            let new_pair = match current.as_ref().map(Value::view) {
-                                Some(ValueView::Pair(k, _)) => {
-                                    Value::pair(k.clone(), value.clone())
-                                }
-                                Some(ValueView::ValuePair(k, _)) => {
-                                    Value::value_pair(k.clone(), value.clone())
-                                }
-                                _ => continue,
-                            };
-                            self.env.insert_through_sym(*var_name, new_pair);
-                        }
-                        return Ok(value);
-                    } else if let Some(var_name) = target_var {
-                        let new_pair = match target.view() {
-                            ValueView::Pair(k, _) => Value::pair(k.clone(), value.clone()),
-                            ValueView::ValuePair(k, _) => {
-                                Value::value_pair(k.clone(), value.clone())
-                            }
-                            _ => unreachable!(),
-                        };
-                        self.env.insert_through(var_name.to_string(), new_pair);
-                        return Ok(value);
-                    }
-                }
+                // above (ADR-0036 — every element producer hands out the
+                // element's container, so a pair derived from an array or hash
+                // element arrives here already carrying that cell), a live
+                // `HashEntryRef` wrote through its node, a mutable QuantHash
+                // weight went through `topic_source_var`, and a reference value
+                // was assigned into just now. What is left is a pair holding a
+                // *bare* value, and raku's `rw` `Pair.value` accessor has
+                // nothing to assign into: `my $p = (1 => "a"); $p.value = "z"`
+                // dies with "Cannot modify an immutable Str (a)".
+                let type_name = crate::value::what_type_name(current_value.as_ref());
+                return Err(RuntimeError::assignment_ro_typename(
+                    &type_name,
+                    &current_value.to_string_value(),
+                ));
             }
         }
 

--- a/src/value/entry_path.rs
+++ b/src/value/entry_path.rs
@@ -213,6 +213,32 @@ impl EntryTerminal {
         }
     }
 
+    /// The element type constraint of the container this terminal writes into,
+    /// as `(of-type, owner-sigil)` — the same pair `array_slot_ref` /
+    /// `hash_slot_ref` seed onto a cell they promote (ADR-0036 slice 4).
+    ///
+    /// A DEFERRED vivification token (`my Str @a; my $r := @a[5]`) never
+    /// reaches those primitives: the slot does not exist yet, so the token
+    /// materializes into a *fresh* cell at the first write. Without picking the
+    /// constraint up here that write bypasses the element type check the
+    /// equivalent in-range bind and the direct `@a[5] = v` store both perform.
+    pub(crate) fn element_constraint(&self) -> Option<(String, &'static str)> {
+        match self {
+            // SAFETY: a shared read of the aliased container, mirroring `peek`.
+            // The clone ends the borrow before any caller can mutate through
+            // `gc_contents_mut`.
+            EntryTerminal::Hash(arc, _) => {
+                let data: &HashData = unsafe { &*Gc::as_ptr(arc) };
+                data.value_type.clone().map(|ty| (ty, "%"))
+            }
+            // SAFETY: as above.
+            EntryTerminal::Array(arc, _) => {
+                let data: &ArrayData = unsafe { &*Gc::as_ptr(arc) };
+                data.value_type.clone().map(|ty| (ty, "@"))
+            }
+        }
+    }
+
     /// The raw value currently stored at this slot, without decontainerizing
     /// and without creating anything.
     pub(crate) fn peek(&self) -> Option<Value> {

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -263,6 +263,7 @@ pub(crate) use aliased_mut::gc_data_mut;
 pub(crate) use attr_map::{AttrKey, AttrMap, attr_twigil_base};
 pub(crate) use entry_path::EntryRoot;
 pub use entry_path::EntryStep;
+pub(crate) use entry_path::EntryTerminal;
 pub(crate) use entry_path::is_container_hole;
 pub use guards::{ArcRef, GcRef, RefGuard, WeakGcRef};
 pub(in crate::value) use nanbox::NanBox;

--- a/src/vm/vm_element_producers.rs
+++ b/src/vm/vm_element_producers.rs
@@ -128,11 +128,24 @@ impl Interpreter {
                 // immutable sequences whose items must stay bare items.
                 if !matches!(
                     kind,
-                    crate::value::ArrayKind::Array | crate::value::ArrayKind::ItemArray
-                ) || data.shape.is_some()
-                    || data.native_storage_node().is_some()
+                    crate::value::ArrayKind::Array
+                        | crate::value::ArrayKind::ItemArray
+                        | crate::value::ArrayKind::Shaped
+                ) || data.native_storage_node().is_some()
                 {
                     return None;
+                }
+                // A MULTI-dimensional shaped array keeps its leaves in nested
+                // inner arrays, so they are not this array's own slots and
+                // `array_slot_ref` would hand out the rows. `.pairs` over it is
+                // keyed by index tuple and takes the recursive path below; the
+                // other producers keep whatever they do today. A ONE-dimensional
+                // shape stores its leaves flat, so it needs nothing special.
+                if data.shape.as_ref().is_some_and(|s| s.len() > 1) {
+                    return match method {
+                        "pairs" => self.shaped_multidim_pairs(target),
+                        _ => None,
+                    };
                 }
                 data.len()
             }
@@ -192,6 +205,60 @@ impl Interpreter {
             }
             _ => return None,
         })
+    }
+
+    /// `.pairs` over a multi-dimensional shaped array. Raku keys each pair by
+    /// the full index *tuple* (`(0 1) => …`) and the value is the LEAF
+    /// element's container — which lives in an inner array, not in `target`'s
+    /// own slot vector, so the promotion has to walk down to it. The nested
+    /// arrays share their `Gc` with the outer array's items, so promoting a
+    /// leaf there is visible through `@a[0;1]` and through any other alias.
+    ///
+    /// Key shape and leaf order mirror the pure-value producer in
+    /// `builtins/methods_0arg/collection.rs` (`shaped_array_indexed_leaves`),
+    /// which is what this replaces for a mutable shaped array.
+    fn shaped_multidim_pairs(&mut self, target: &Value) -> Option<Value> {
+        let mut pairs = Vec::new();
+        let mut indices = Vec::new();
+        Self::collect_leaf_cell_pairs(target, &mut indices, &mut pairs)?;
+        Some(Value::seq(pairs))
+    }
+
+    fn collect_leaf_cell_pairs(
+        node: &Value,
+        indices: &mut Vec<i64>,
+        out: &mut Vec<Value>,
+    ) -> Option<()> {
+        let ValueView::Array(items, _) = node.view() else {
+            return None;
+        };
+        // Clone the children out before promoting: `array_slot_ref` mutates the
+        // node's item vector in place, so no borrow into it may be live.
+        let children: Vec<Value> = items.iter().cloned().collect();
+        if children
+            .iter()
+            .any(|v| matches!(v.view(), ValueView::Array(..)))
+        {
+            for (i, child) in children.iter().enumerate() {
+                indices.push(i as i64);
+                let walked = Self::collect_leaf_cell_pairs(child, indices, out);
+                indices.pop();
+                walked?;
+            }
+        } else {
+            for i in 0..children.len() {
+                let cell = node.array_slot_ref(i, true)?;
+                let mut key = indices.clone();
+                key.push(i as i64);
+                let key = if key.len() == 1 {
+                    Value::int(key[0])
+                } else {
+                    Value::array(key.into_iter().map(Value::int).collect())
+                };
+                out.push(Value::value_pair(key, cell));
+            }
+        }
+        Some(())
     }
 
     fn hash_element_producer(&mut self, target: &Value, method: &str) -> Option<Value> {

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -1713,9 +1713,7 @@ impl Interpreter {
                         && matches!(token.view(), ValueView::HashEntryRef { .. })
                         && let Some(terminal) = token.hash_entry_terminal()
                     {
-                        let cell =
-                            crate::gc::Gc::new(crate::value::ContainerCell::new(val.clone()));
-                        terminal.insert(Value::container_ref(cell.clone()));
+                        let cell = self.materialize_entry_cell(&terminal, val.clone())?;
                         self.set_env_with_main_alias(&name, Value::container_ref(cell));
                         *ip += 1;
                         return Ok(());

--- a/src/vm/vm_helpers.rs
+++ b/src/vm/vm_helpers.rs
@@ -112,6 +112,28 @@ impl Interpreter {
         Ok(())
     }
 
+    /// Materialize a deferred vivification token's terminal slot into a fresh
+    /// shared `ContainerCell` holding `val`, and install it at the slot.
+    ///
+    /// The cell carries the container's element constraint (ADR-0036 slice 4)
+    /// and this first write is checked against it, so a `:=` bind to a slot
+    /// that did not exist yet (`my Str @a; my $r := @a[5]; $r = 42`) is
+    /// refused exactly like the in-range bind and the direct store are. The
+    /// terminal is only written when the check passes.
+    pub(crate) fn materialize_entry_cell(
+        &mut self,
+        terminal: &crate::value::EntryTerminal,
+        val: Value,
+    ) -> Result<crate::gc::Gc<crate::value::ContainerCell>, RuntimeError> {
+        let cell = crate::gc::Gc::new(crate::value::ContainerCell::new(val.clone()));
+        if let Some((ty, owner)) = terminal.element_constraint() {
+            crate::value::register_element_constraint(&cell, &ty, owner);
+            self.check_container_cell_constraint(&cell, &val)?;
+        }
+        terminal.insert(Value::container_ref(cell.clone()));
+        Ok(cell)
+    }
+
     /// Enforce a NAME-keyed scalar's registered `var_type_constraint` before a
     /// write reaches it through the `__mutsu_sigilless_alias::` forward chain
     /// (a sigilless `\x := $a` bind, a sigilless routine parameter aliasing a

--- a/src/vm/vm_misc_assign.rs
+++ b/src/vm/vm_misc_assign.rs
@@ -455,8 +455,7 @@ impl Interpreter {
                 && let Some(token) = current.as_ref()
                 && let Some(terminal) = token.hash_entry_terminal()
             {
-                let cell = crate::gc::Gc::new(crate::value::ContainerCell::new(val.clone()));
-                terminal.insert(Value::container_ref(cell.clone()));
+                let cell = self.materialize_entry_cell(&terminal, val.clone())?;
                 let cell_val = Value::container_ref(cell);
                 if let Some(idx) = code.locals.iter().position(|n| n == &name)
                     && idx < self.locals.len()

--- a/src/vm/vm_var_assign_computed_attr.rs
+++ b/src/vm/vm_var_assign_computed_attr.rs
@@ -75,21 +75,19 @@ impl Interpreter {
         code: &CompiledCode,
         idx: usize,
         val: Value,
-    ) -> bool {
+    ) -> Result<bool, RuntimeError> {
         let cell = if matches!(self.locals[idx].view(), ValueView::HashEntryRef { .. }) {
-            let token = &self.locals[idx];
+            let token = self.locals[idx].clone();
             // Walk-create the deferred path (single key for `$e := %m<solo>`,
             // multi-key for `$d := %k<p><q>`) and install the shared cell at
             // the terminal entry so the bound var and the hash entry alias
             // bidirectionally afterwards.
             let Some(terminal) = token.hash_entry_terminal() else {
-                return false;
+                return Ok(false);
             };
-            let cell = crate::gc::Gc::new(crate::value::ContainerCell::new(val));
-            terminal.insert(Value::container_ref(cell.clone()));
-            cell
+            self.materialize_entry_cell(&terminal, val)?
         } else {
-            return false;
+            return Ok(false);
         };
         let cell_val = Value::container_ref(cell);
         self.locals[idx] = cell_val.clone();
@@ -107,7 +105,7 @@ impl Interpreter {
                 self.set_env_with_main_alias(&root, cell_val);
             }
         }
-        true
+        Ok(true)
     }
 
     // --- Phase 3 Stage 2: scalar instance attributes as cell-direct (slice 1) ---

--- a/src/vm/vm_var_assign_local.rs
+++ b/src/vm/vm_var_assign_local.rs
@@ -93,7 +93,7 @@ impl Interpreter {
         // (`(target = v)`) replaces the token and the hash never sees the write.
         if matches!(self.locals[idx].view(), ValueView::HashEntryRef { .. }) {
             let val = self.stack.pop().unwrap_or(Value::NIL);
-            if self.materialize_bound_slot_to_cell(code, idx, val.clone()) {
+            if self.materialize_bound_slot_to_cell(code, idx, val.clone())? {
                 self.stack.push(val);
                 return Ok(());
             }

--- a/src/vm/vm_var_assign_set_local.rs
+++ b/src/vm/vm_var_assign_set_local.rs
@@ -1843,7 +1843,7 @@ impl Interpreter {
             && !is_rebind
             && matches!(self.locals[idx].view(), ValueView::HashEntryRef { .. })
         {
-            self.materialize_bound_slot_to_cell(code, idx, val);
+            self.materialize_bound_slot_to_cell(code, idx, val)?;
             return Ok(());
         }
         // When binding a Proxy to a variable, update FETCH/STORE closures' captured envs

--- a/src/vm/vm_var_deferred_token.rs
+++ b/src/vm/vm_var_deferred_token.rs
@@ -102,8 +102,10 @@ impl Interpreter {
         // The token's own slot now holds the outermost created container:
         // promote the bound variable to a shared cell over it so the two alias.
         let created = token.hash_entry_locate().and_then(|t| t.peek())?;
-        if !self.materialize_bound_slot_to_cell(code, slot, created) {
-            return None;
+        match self.materialize_bound_slot_to_cell(code, slot, created) {
+            Ok(true) => {}
+            Ok(false) => return None,
+            Err(e) => return Some(Err(e)),
         }
         for _ in 0..depth + 1 {
             self.stack.pop();

--- a/t/pair-value-assign-binds-container.t
+++ b/t/pair-value-assign-binds-container.t
@@ -1,0 +1,140 @@
+use Test;
+
+# ADR-0036 slice 4. A Pair BINDS its value (rakudo's `Pair` BUILD does
+# `$!value := value`), so `$p.value = X`:
+#   * assigns INTO the container when the value is a mutable Array/Hash,
+#   * writes through the cell when the value is an element/scalar container,
+#   * and otherwise dies, because a bare immutable value has nothing to assign
+#     into.
+# Every row below was checked against real raku.
+#
+# This is what replaced the `env`-wide search for "an array/hash whose element
+# happens to compare equal to this pair's value", which is deleted.
+
+plan 21;
+
+# --- reference values assign INTO the container -----------------------------
+
+{
+    my @a = 1, 2;
+    my $p = (a => @a);
+    $p.value = (3, 4);
+    is-deeply @a, [3, 4], 'assigning a list through .value list-assigns into the bound array';
+    is $p.value.raku, '[3, 4]', 'the pair still holds that same Array';
+}
+
+{
+    my %h = x => 1;
+    my $p = (a => %h);
+    $p.value = (y => 2);
+    is-deeply %h, {y => 2}, 'assigning through .value replaces the bound hash contents';
+}
+
+{
+    my @a;
+    my $p = (a => @a);
+    $p.value = 5;
+    is-deeply @a, [5], 'a scalar assigned through .value list-assigns into an empty array';
+}
+
+{
+    my $p = (a => [1, 2]);
+    $p.value = [3, 4];
+    is $p.gist, 'a => [3 4]', 'an anonymous Array value is assigned into, not rebound';
+}
+
+# --- element writes through the value keep ONE container --------------------
+
+{
+    my $h = { :a(1) };
+    my $p = ($h => $h);
+    $p.value<b> = 2;
+    $p.value<c> = 3;
+    is-deeply $h, {a => 1, b => 2, c => 3},
+        'repeated element writes through .value all land in the source hash';
+    ok $p.value =:= $h, 'the pair value and the source stay the same container';
+}
+
+# --- immutable values die ---------------------------------------------------
+
+{
+    my $p = (1 => "a");
+    throws-like { $p.value = "z" }, X::Assignment::RO,
+        'a Str-valued pair has nothing to assign into';
+}
+
+{
+    my $p = (a => 1);
+    throws-like { $p.value = 2 }, X::Assignment::RO,
+        'an Int-valued pair has nothing to assign into';
+}
+
+{
+    # A List is immutable: raku list-assigns into it and dies on the first
+    # element.
+    my $p = (a => (1, 2));
+    throws-like { $p.value = 5 }, X::Assignment::RO,
+        'a List-valued pair dies on its first element';
+}
+
+{
+    # ... but an EMPTY list has no element to fail on, so the assignment is a
+    # no-op rather than an error.
+    my $p = (a => ());
+    lives-ok { $p.value = 5 }, 'assigning into an empty List is a no-op';
+    is $p.gist, 'a => ()', 'the empty List is unchanged';
+}
+
+# --- a captured scalar container still writes through -----------------------
+
+{
+    my $v = 1;
+    my $p = (a => $v);
+    $p.value = 2;
+    is $v, 2, '`key => $var` aliases the variable container';
+    is $p.value, 2, 'and the pair reads the new value';
+}
+
+# --- shaped arrays hand out element containers too --------------------------
+
+{
+    my @a[3];
+    is @a.pairs[0].value.VAR.^name, 'Scalar',
+        'a 1-D shaped array .pairs value is the element container';
+    for @a.pairs -> $p { $p.value = 7 }
+    is @a.raku, 'Array.new(:shape(3,), [7, 7, 7])',
+        '1-D shaped .pairs writeback keeps the shape';
+}
+
+{
+    my @a[1; 2];
+    for @a.pairs -> $p { $p.value = $p.key[1] + 40 }
+    is @a[0; 0], 40, 'multi-dim shaped .pairs writes through the leaf container';
+    is @a[0; 1], 41, 'the tuple key selects the right leaf';
+}
+
+# --- a `:=`-bound element enforces the container element type ---------------
+# The bind promotes the slot to a cell that carries the container's `of`-type,
+# including when the slot did not exist yet and the bind is deferred.
+
+{
+    my Str @a;
+    my $r := @a[2];
+    throws-like { $r = 42 }, X::TypeCheck::Assignment,
+        'a deferred array-element bind still checks the element type';
+}
+
+{
+    my Int %h;
+    my $r := %h<k>;
+    throws-like { $r = "s" }, X::TypeCheck::Assignment,
+        'a deferred hash-element bind still checks the element type';
+}
+
+{
+    my Str @a;
+    my $r := @a[2];
+    $r = "x";
+    is-deeply @a, Array[Str].new(Str, Str, "x"),
+        'a well-typed deferred write fills the gap with the element type object';
+}

--- a/todo/TRIAGE.md
+++ b/todo/TRIAGE.md
@@ -122,7 +122,7 @@ one landed slice closes several rows at once. Every ADR below had its
 | ADR | Status (verified 2026-09-01) | Deep/ticket rows it would close |
 |---|---|---|
 | [ADR-0045](../docs/adr/0045-for-loop-parameters-bind-the-element-container.md) for-param binds the element container | **CLOSED 2026-09-01 — every slice landed**, §1.3 re-measured 45/45 green | Nothing. The originating deep finding retired to `news/2026-09/for-loop-parameters-bind-the-element-container.md`; slice 6's sweep also filed `pair-value-assign-does-not-enforce-immutable-value`. |
-| [ADR-0036](../docs/adr/0036-element-container-pairs-from-subscripts-and-pairs.md) element container cells | Slices 1-3 landed (`.pairs` routed 2026-09-01); slice 4's compensator deletion open | `immutable-lvalues-...` (6 rows), row 28 of the for-loop matrix (element type constraint — ADR-0036 slice 4 is the natural owner, shared with ADR-0045 slice 5 and ADR-0042) |
+| [ADR-0036](../docs/adr/0036-element-container-pairs-from-subscripts-and-pairs.md) element container cells | **Slices 1-4 landed** (slice 4's compensator deletion 2026-09-01, measured over all of `t/` + the whole whitelist first); only slice 5 (the sweep) is left | `immutable-lvalues-...` (6 rows), row 28 of the for-loop matrix (element type constraint — now enforced, including on deferred `:=`-bound slots) |
 | [ADR-0059](../docs/adr/0059-is-rw-routines-return-a-container.md) `is rw` routines return a container | Slices 1-2 landed **except the bare-`is rw`-tail half**; slice 3 open | `is-rw-sub-implicit-return-element-not-mutable` (Tier S — it *is* the bare-tail half), `rakuast-nodes-...`'s latent crash path (slice 3) |
 | [ADR-0055](../docs/adr/0055-closure-free-vars-resolve-to-their-own-binding.md) closure free vars bind their own | **Slice 1 landed 2026-08-28; slices 2-5 not started**; slice 2's prerequisite is the `unvouched-capture-cells` ticket | `call-compiled-closure-lacks-merge-all-...` (Gap 1: `OUTER` vs `CALLER`), `unvouched-capture-cells-leak-state-across-cro-client-requests` |
 | [ADR-0040](../docs/adr/0040-array-hash-elements-are-itemized-at-the-store.md) element itemization at the store | Slices 0-2 landed; **only row 24 (`.VAR`, slice 3) still diverges**; slices 4-5 = constraint + compensator deletion | `element-itemization-lost-in-scalar-binding` (row 24 only), `slurpy-hash-named-arg-...` (fold in) |
@@ -145,8 +145,8 @@ simple case and diverged only on a read through the alias, on a wholesale
 rebind, and on the clock. Consider the same treatment for ADR-0036 and
 ADR-0040 before declaring either done.
 
-What remains in the element-container cluster: **ADR-0036 slice 4** (`.pairs`
-routing, still backed out) and **ADR-0040 row 24** (`.VAR` on a `:=`-bound
+What remains in the element-container cluster: **ADR-0036 slice 5** (the
+sweep — slices 1-4 are in) and **ADR-0040 row 24** (`.VAR` on a `:=`-bound
 list). Then **ADR-0059's bare-tail half** (Tier S below), then **ADR-0055
 slice 2's prerequisite** (the Cro-blocking cell-freshness fix).
 

--- a/todo/TRIAGE.md
+++ b/todo/TRIAGE.md
@@ -122,7 +122,7 @@ one landed slice closes several rows at once. Every ADR below had its
 | ADR | Status (verified 2026-09-01) | Deep/ticket rows it would close |
 |---|---|---|
 | [ADR-0045](../docs/adr/0045-for-loop-parameters-bind-the-element-container.md) for-param binds the element container | **CLOSED 2026-09-01 — every slice landed**, §1.3 re-measured 45/45 green | Nothing. The originating deep finding retired to `news/2026-09/for-loop-parameters-bind-the-element-container.md`; slice 6's sweep also filed `pair-value-assign-does-not-enforce-immutable-value`. |
-| [ADR-0036](../docs/adr/0036-element-container-pairs-from-subscripts-and-pairs.md) element container cells | **Slices 1-4 landed** (slice 4's compensator deletion 2026-09-01, measured over all of `t/` + the whole whitelist first); only slice 5 (the sweep) is left | `immutable-lvalues-...` (6 rows), row 28 of the for-loop matrix (element type constraint — now enforced, including on deferred `:=`-bound slots) |
+| [ADR-0036](../docs/adr/0036-element-container-pairs-from-subscripts-and-pairs.md) element container cells | **CLOSED 2026-09-01 — every slice landed.** §1.3 re-measured 12/12; slice 5's 69-row sweep found 3 residuals, all ticketed, none a regression | Nothing. Residuals: `producer-seq-index-read-decontainerizes-the-element-cell` (new), `promoted-element-cell-does-not-know-its-container-name`, `quanthash-pairs-value-write-needs-a-for-loop-...`. `immutable-lvalues-...` is **no longer blocked on this ADR** — re-measured, no row moved |
 | [ADR-0059](../docs/adr/0059-is-rw-routines-return-a-container.md) `is rw` routines return a container | Slices 1-2 landed **except the bare-`is rw`-tail half**; slice 3 open | `is-rw-sub-implicit-return-element-not-mutable` (Tier S — it *is* the bare-tail half), `rakuast-nodes-...`'s latent crash path (slice 3) |
 | [ADR-0055](../docs/adr/0055-closure-free-vars-resolve-to-their-own-binding.md) closure free vars bind their own | **Slice 1 landed 2026-08-28; slices 2-5 not started**; slice 2's prerequisite is the `unvouched-capture-cells` ticket | `call-compiled-closure-lacks-merge-all-...` (Gap 1: `OUTER` vs `CALLER`), `unvouched-capture-cells-leak-state-across-cro-client-requests` |
 | [ADR-0040](../docs/adr/0040-array-hash-elements-are-itemized-at-the-store.md) element itemization at the store | Slices 0-2 landed; **only row 24 (`.VAR`, slice 3) still diverges**; slices 4-5 = constraint + compensator deletion | `element-itemization-lost-in-scalar-binding` (row 24 only), `slurpy-hash-named-arg-...` (fold in) |
@@ -145,10 +145,12 @@ simple case and diverged only on a read through the alias, on a wholesale
 rebind, and on the clock. Consider the same treatment for ADR-0036 and
 ADR-0040 before declaring either done.
 
-What remains in the element-container cluster: **ADR-0036 slice 5** (the
-sweep — slices 1-4 are in) and **ADR-0040 row 24** (`.VAR` on a `:=`-bound
-list). Then **ADR-0059's bare-tail half** (Tier S below), then **ADR-0055
-slice 2's prerequisite** (the Cro-blocking cell-freshness fix).
+What remains in the element-container cluster: **ADR-0040 row 24** (`.VAR` on
+a `:=`-bound list) — ADR-0036 closed 2026-09-01, and its sweep is the second
+consecutive one to pay for itself (three residuals the 12-row divergence table
+could not see, one of them three silent no-ops). Then **ADR-0059's bare-tail
+half** (Tier S below), then **ADR-0055 slice 2's prerequisite** (the
+Cro-blocking cell-freshness fix).
 
 **One measured process exception, kept from the previous regen:** when a
 change alters a *universal property of values* ("what is in every

--- a/todo/deep/immutable-lvalues-that-mutsu-still-lets-you-assign-to.md
+++ b/todo/deep/immutable-lvalues-that-mutsu-still-lets-you-assign-to.md
@@ -290,3 +290,30 @@ elem, map literal topic, grep topic, block arg topic, bind list assign; plus
 an immutable value (1 2 3)` where raku says `... immutable Range (1..3)`, so it
 belongs in the "close but not exact" section rather than the live harness.
 Blocker attribution (ADR-0036, not ADR-0040) unchanged.
+
+## Status update (2026-09-01): ADR-0036 slice 4 landed and did NOT move these rows either
+
+Slice 4 (the `env`-scan compensator deletion, plus element type constraints on
+deferred `:=`-bound slots — `news/2026-09/pair-value-lvalue-drops-the-env-scan.md`)
+completed ADR-0036's implementation. The harness above was re-run against it:
+**all seven rows answer exactly as they did on 2026-09-01 before the slice.**
+
+So the ADR-0036 attribution needs the same correction ADR-0040's did. ADR-0036
+is about what a *pair producer* hands out; every row here is about what the
+*subscript store path* and the *closure-call topic binding* accept, and neither
+of those is a pair producer. Concretely:
+
+- `(1,2,3)[0] = 9` / the `Seq` element never build a Pair at all — they need the
+  element **store** to know its container is immutable. `array_slot_ref` already
+  declines `ArrayKind::List`/`ItemList`, so the information exists; nothing on the
+  store path consults it.
+- the four topic rows are the closure-call readonly marking this ticket's own
+  "Why `-> $v { $v = 1 }` was fixable" section describes, unchanged.
+- `my $x := (1,2,3); $x = 5` is the bind-side whitelist in
+  `vm_var_assign_set_local.rs`, also untouched by any ADR-0036 slice.
+
+**Do not block this survey on ADR-0036 any longer** — it is finished and these
+rows are still open. The remaining work is two independent, and individually
+small, surfaces: an immutable-container check on the element store, and
+separating the direct-call and native-map callers of
+`call_compiled_closure_with_topic`.

--- a/todo/tickets/producer-seq-index-read-decontainerizes-the-element-cell.md
+++ b/todo/tickets/producer-seq-index-read-decontainerizes-the-element-cell.md
@@ -1,0 +1,83 @@
+# Indexing an element producer's `Seq` drops the element container
+
+Found by ADR-0036 slice 5's sweep (2026-09-01), which compared 69 rows of the
+whole element-container surface against `raku`. Five of them are this one bug,
+three of them silent no-ops. **Not a regression** — verified identical on `main`
+at `f03b85978`, i.e. before ADR-0036 slice 4.
+
+## Symptom
+
+`.values` / `.kv` / `.pairs` hand out the element's `Scalar` container
+(ADR-0036 slice 3). Consuming that result with a `for` loop keeps the container,
+but **subscripting it does not**:
+
+```
+$ raku  -e 'my @a = <A B>; say (@a.values)[0].VAR.^name'          # Scalar
+$ mutsu -e 'my @a = <A B>; say (@a.values)[0].VAR.^name'          # Str      X
+
+$ raku  -e 'my @a = <A B>; (@a.values)[0] = "x"; say @a'          # [x B]
+$ mutsu -e 'my @a = <A B>; (@a.values)[0] = "x"; say @a'          # [A B]    X  silent
+
+$ raku  -e 'my @a = <A B>; (@a.kv)[1] = "x"; say @a'              # [x B]
+$ mutsu -e 'my @a = <A B>; (@a.kv)[1] = "x"; say @a'              # [A B]    X  silent
+
+$ raku  -e 'my @a = <A B>; my $c := (@a.values)[0]; $c = "x"; say @a'   # [x B]
+$ mutsu -e 'my @a = <A B>; my $c := (@a.values)[0]; $c = "x"; say @a'   # [A B]  X  silent
+```
+
+Adjacent shapes that *do* work, and are the useful contrast:
+
+```
+my @a = <A B>; say @a.values.head.VAR.^name            # Scalar in both  (.head keeps it)
+my @a = <A B>; say @a.pairs[0].value.VAR.^name         # Scalar in both  (.value returns the cell)
+my @a = <A B>; (@a[0]:kv)[1] = "x"; say @a             # [x B] in both   (subscript adverb)
+my @a = <A B>; for @a.values -> $v is rw { $v = "x" }  # works in both
+```
+
+So it is specifically the **positional subscript of the producer's `Seq`**, not
+the producer and not the consumer.
+
+## Root cause
+
+`Interpreter::exec_index_op_with_positional` (`src/vm/vm_var_index_ops.rs`)
+normalizes a `Seq` receiver to an `ArrayKind::List` array before the index
+match:
+
+```rust
+if let ValueView::Seq(items) = target.view() {
+    ...
+    target = Value::array_with_kind(
+        crate::value::Value::array_arc(items.to_vec()),
+        crate::value::ArrayKind::List,
+    );
+}
+```
+
+The `(Array, Int)` arm then reads through `resolve_array_entry`, which is *the*
+decontainerization chokepoint — the thing that keeps `.raku` / `.WHAT` / `.gist`
+honest when a slot holds a `ContainerRef`. It does its job here too, and that is
+exactly the problem: for a producer `Seq` the cell *is* the answer.
+
+Note the receiver shape matters because the two forms compile differently.
+`(@a.values)[0]` emits `CallMethodMut` then `OpCode::Index`, which is the path
+above; `my \s = @a.values; s[0]` goes through the name-keyed index path and
+keeps the cell on the read (though its *write* is lost separately, row 67).
+
+## Why this is not a one-line fix
+
+Two halves, and the first one has real blast radius:
+
+1. **Read.** Skipping `resolve_array_entry` for a `Seq`-sourced subscript hands
+   a `ContainerRef` to every consumer of `seq[i]`. ADR-0036 §6 names this as the
+   change with real blast radius, and §5 Q4/Q5 exist to bound it. It probably
+   has to be narrowed to "the `Seq` came from an element producer", which the
+   value does not currently record.
+2. **Write.** `(@a.values)[0] = "x"` is an index-assign whose target is an
+   expression, not a named variable; making the read hand out a cell does not by
+   itself make that store write *through* it.
+
+## Suggested acceptance rows
+
+The five rows above, plus the four contrast rows, as a `t/` file checked against
+real raku. Note `(@a.values)[0].WHAT` must stay `(Str)` — raku decontainerizes
+there — so the pin has to assert both directions.

--- a/todo/tickets/quanthash-pairs-value-write-needs-a-for-loop-to-reach-the-source.md
+++ b/todo/tickets/quanthash-pairs-value-write-needs-a-for-loop-to-reach-the-source.md
@@ -97,3 +97,31 @@ worth not mistaking for one.
     nok $b<a>:exists, 'weight 0 removes the key, as it does through the loop form';
 }
 ```
+
+## A third failing shape, found by ADR-0036 slice 5's sweep (2026-09-01)
+
+The title says "only when the pair is a `for` loop's topic", and that is exact:
+a `for` loop with an **explicit named parameter** fails too, even though it
+looks like the working shape.
+
+```
+$ raku  -e 'my $b = <a a b>.BagHash; for $b.pairs -> $p { $p.value = 5 }; say $b'
+BagHash(a(5) b(5))
+$ mutsu -e 'my $b = <a a b>.BagHash; for $b.pairs -> $p { $p.value = 5 }; say $b'
+Cannot modify an immutable Int (2)
+
+$ mutsu -e 'my $b = <a a b>.BagHash; for $b.pairs { .value = 5 }; say $b'
+BagHash(a(5) b(5))          # the implicit-topic form works
+```
+
+`topic_source_var` is set when the loop binds the **topic**; `-> $p` binds a
+named parameter instead, so the arm never fires and the write falls through to
+the read-only guard. This is the sharpest repro of the three, because the two
+programs differ only in the loop's parameter form — and it is the shape
+`t/for-pairs-value-quanthash-writeback.t` happens not to use.
+
+Verified identical on `main` at `f03b85978`, so it is not a regression from
+ADR-0036 slice 4. Any fix should carry the source *with the pair* rather than in
+a loop-scoped side channel; that is the same "the name has to travel with the
+container" shape as
+`promoted-element-cell-does-not-know-its-container-name.md`.


### PR DESCRIPTION
Completes [ADR-0036](docs/adr/0036-element-container-pairs-from-subscripts-and-pairs.md)'s implementation: slice 4's compensator deletion. Only slice 5 (the sweep) is left after this.

## What is deleted

`$p.value = X` used to work by *searching* for the container the pair came from. Because a mutsu Pair held a snapshot of its value rather than the element's `Scalar`, the assignment path scanned `self.env` for a `Hash` whose entry at the pair's key — or an `Array` whose element at the pair's integer index — happened to compare equal, required the match to be unique by `Gc::ptr_eq`, rebuilt the whole container, and wrote it back by identity. Adjacent arms extended the same trick to shaped arrays by index tuple and to *standalone* pairs by scanning every binding holding "a Pair with the same key and the same old value".

That search is gone (~220 lines), together with the dead `__mutsu_hash_ref` branch and its only other reader in `builtins/methods_0arg/coercion.rs`. The surviving `method == "value"` arm is the short list of container kinds ADR-0036 §6 predicted: `HashEntryRef` node, `ContainerRef` cell, mutable QuantHash weight, reference value, then die.

## Measured before deleting, not guessed

Each of the compensator's ten exits was instrumented and **every `t/` file plus every whitelisted roast file** was run under it:

| exit | fires in |
| --- | --- |
| `standalone_rebind_multi` | `t/bound-container-pair-writethrough.t`, `t/pair-value-element-writethrough.t`, `t/pair-value-writethrough-coherence.t`, `roast/S02-types/pair.t` |
| `scan_array` + `array_writeback` | `t/pairs-value-writeback-array-kind.t` (the 1-D shaped-array row) |
| `multidim` | `t/shaped-array-pairs-zip-assign.t`, `roast/S02-types/array-shapes.t` |
| `hashref`, `target_var_hash`, `target_var_array`, `scan_hash`, `hash_writeback` | **never** |

Half the exits were already dead — slice 3's `.pairs` routing had taken every hash-backed shape. Three real gaps remained, each a piece of the model rather than a special case.

**1. A shaped array's `.pairs` did not hand out element containers.** `array_element_producer` declined on `data.shape.is_some()`, and its kind filter did not admit `ArrayKind::Shaped`. A **1-D** shape stores its leaves flat and only needed to be let in. A **multi-dimensional** shape keeps them in nested inner arrays, so `array_slot_ref` on the outer array would have handed out rows; `.pairs` now walks down to each leaf and promotes it *there*, keyed by the index tuple raku uses (`(0 1) => …`).

**2. A reference-valued Pair now assigns INTO its value.** Rakudo's `Pair` binds (`$!value := value`), so the pair and the variable it was built from are the same container:

```raku
my @a = 1, 2;
my $p = (a => @a);
$p.value = (3, 4);
say @a;             # raku: [3 4]   mutsu before: [1 2]
```

mutsu already shares the `Gc` there (`$p.value.push` wrote through), so `replace_container_contents` reaches every alias. This **fixed four divergences** the env rebind had been papering over: the write did not reach `@a`/`%h` at all, an Array value came back as a bare `List`, and `(a => C.new).value = 5` / `(a => (1,2)).value = 5` silently succeeded where raku dies. An empty `List` value — the one shape where raku neither writes nor dies — is preserved.

**3. `$p.value<k> = v` cloned the container and rebound it by name.** With the search gone that forks the pair away from the variable it aliases, so only the first write is visible through both. For a Pair accessor the element write now happens in place, in the container the pair holds — which is what `t/pair-value-writethrough-coherence.t` was always asserting.

## Element type constraints now reach the deferred slots

`array_slot_ref`/`hash_slot_ref` seed a promoted cell with the container's `value_type`, but a `:=` bind to a slot that does not exist yet never reaches them — it materializes a *fresh* cell at the first write, and that cell carried no constraint:

```raku
my Str @a;
my $r := @a[2];
$r = 42;            # silently stored an Int in a Str array
```

All three materialization sites now go through `Interpreter::materialize_entry_cell`, which reads the constraint off the deferred path's `EntryTerminal` and refuses the write before installing anything. The missing-key hash bind (`my Int %h; my $r := %h<k>; $r = "s"`) is fixed by the same change.

## Verification

- `make test` — PASS (exit 0)
- **full local `make roast`** — PASS, 1435 files / 218,833 tests (required by the "universal property of values" rule: this changes what is inside every shaped-array container)
- `scripts/battery-testsuite.sh` — GATE PASSED, 274/297
- `t/pair-value-assign-binds-container.t` — 21 new assertions, every one verified against real `raku` first

## Still open (unchanged, and now purely cosmetic)

- `todo/tickets/promoted-element-cell-does-not-know-its-container-name.md` — the failure says `an element of @` where raku says `@a`, unless a promotion site retagged the cell.
- `todo/tickets/bound-array-slice-still-vivifies-eagerly.md` — untouched.
- `todo/deep/immutable-lvalues-that-mutsu-still-lets-you-assign-to.md` — re-measured against this branch; **no row moved**, so its ADR-0036 blocker attribution is corrected in the file: the remaining rows are an immutable-container check on the element *store* and the closure-call topic marking, neither of which is a pair producer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
