### PR TITLE
feat: `.VAR` on an element answers from the source container (ADR-0040 slice 3)

### DIFF
--- a/docs/adr/0040-array-hash-elements-are-itemized-at-the-store.md
+++ b/docs/adr/0040-array-hash-elements-are-itemized-at-the-store.md
@@ -1,6 +1,6 @@
 # ADR-0040: Array and Hash elements are itemized at the *store*, not compensated at the read
 
-- **Status**: Accepted (Slices 0-2 implemented; see "Implementation status" below)
+- **Status**: Accepted (Slices 0-3 implemented; see "Implementation status" below)
 - **Date**: 2026-08-20
 - **Deciders**: tokuhirom, Claude
 - **Related**: [ADR-0013](0013-container-interior-mutability-cellvalue.md) §5 open question 3 / §7 (the
@@ -477,13 +477,14 @@ approximates each separately. Recorded here so a future reader can see the whole
 
 ---
 
-## 8. Implementation status (2026-08-21; slice 2 added 2026-08-27)
+## 8. Implementation status (2026-08-21; slice 2 added 2026-08-27; slice 3 added 2026-09-01)
 
-Slices 0-2 landed in full. Slice 1 covered every mutation-site shape named in §2/§4's Slice 1
+Slices 0-3 landed in full. Slice 1 covered every mutation-site shape named in §2/§4's Slice 1
 description (element assign, autovivification — both single- and nested-level — and
 `push`/`unshift`/`append`/`prepend`/`splice` for a real `Array` or `Hash`). Slice 2 covered the
-construction sites, turning §1.3's rows 01-18 and 23 green; **only row 24 (`.VAR` reflection,
-Slice 3) is still `todo`-marked** in the acceptance oracle.
+construction sites, turning §1.3's rows 01-18 and 23 green. Slice 3 covered the reflection side,
+turning row 24 green — **every row of §1.3 now agrees with raku**, and nothing in the acceptance
+oracle is `todo`-marked any more.
 
 - **Slice 0** (acceptance oracle): `t/element-store-itemization.t` — the full §1.3 divergence
   matrix (rows 01-25, dual-oracled against `raku`), the §1.6 agreeing-source rows, the §2.3 arity
@@ -494,8 +495,8 @@ Slice 3) is still `todo`-marked** in the acceptance oracle.
   array/hash autovivification (`@a[5][0] = 1`, `%h<a><b> = 1`), `Hash.push`, and reference-shared
   push (`@a.push(@b)`) including that `@b` read directly stays bare while `@a[0]` is itemized, and
   that a later mutation of `@b` still propagates through the shared cell. 46 assertions total; rows
-  01-18, 23 (construction-site itemization, Slice 2) and 24 (`.VAR` reflection, Slice 3) stay
-  `todo`-marked.
+  01-18, 23 (construction-site itemization, Slice 2) and 24 (`.VAR` reflection, Slice 3) started
+  `todo`-marked and were un-marked by their own slices.
 
 - **Slice 1** (the mutation sites), in two composed layers:
 
@@ -782,6 +783,88 @@ whitelisted files, including `push`/`unshift`/`splice`/`create`/`delete*`/`multi
 variants), `S02-types/{array,array_extending,array_ref,assigning-refs,autovivification,
 flattening,hash,hash_ref,list,multi_dimensional_array}.t`, `S32-list/{pick,roll}.t`, and **all 119
 whitelisted `roast/integration/*.t` files** (release build) — all pass.
+
+### Slice 3 (2026-09-01) — the reflection side
+
+Row 24 is the same model seen through `.VAR`, and it is the one place the *value* cannot carry the
+answer. Slices 1-2 put the property on the stored value, so an element that is an aggregate already
+reflected correctly with no reflection-specific work (`[1,(2,3)][1].VAR.^name` was already `Scalar`,
+because slice 2 itemizes an array literal's elements, and `(1,(2,3))[1].VAR.^name` was already
+`List`). But a bare `Int` element has no flag to carry: `my @c = 1, …` and `my @l := 1, …` hold a
+byte-identical first element and must answer `Scalar` and `Int` respectively. The answer therefore
+has to be read off the **source container's kind** — exactly the discriminator §1.6 established, now
+stated once in code.
+
+**`Value::elements_are_containers`** (`src/value/value_methods_a.rs`), beside slice 1's
+`itemize_for_element_store` and slice 2's `needs_element_itemization`/`deitemize_element`:
+`Array`/`Shaped`/`Lazy`/`ItemArray` and every `Hash` answer `true`; `List`/`ItemList`, `Seq`,
+`Range` and everything else answer `false`; a `Scalar` wrapper recurses into what it holds, so a
+`List` living in a `$` (`my $sl = (1,(1,2),[3,4]); $sl[1].VAR.^name` is `List`) answers from the
+List. `Shaped` and `Lazy` are included even though `ArrayKind::itemize()` is a no-op on them — they
+are real `Array`s, and raku agrees (`my @a = ^Inf; @a[1].VAR.^name` is `Scalar`).
+
+**The consumer is `builtin_index_var_meta`** (`src/runtime/builtins.rs`), the runtime half of the
+compiler's `.VAR`-on-a-subscript rewrite (`compile_expr_method_var_on_index`,
+`src/compiler/expr_method.rs`). It used to synthesize an opaque `Scalar` descriptor
+*unconditionally*, the one pre-existing exception being `Map` — whose values are famously not
+containers, which is the same rule this slice generalizes.
+
+**The compiler hook was rewired rather than the builtin taught to index.** The old shape compiled
+the subscript's *target* purely for side effects, `Pop`ped it, and passed `(name, index)` so the
+builtin could re-derive a `Map` value by key. Re-deriving the element inside a reflection builtin
+would have been a hand-rolled duplicate of the subscript machinery — the compensator-per-site shape
+this ADR exists to avoid, and one that would have had to grow arms for negative indices, `Seq`
+reification, `Range` arithmetic and so on. The hook now compiles the **whole subscript** and passes
+`(element, name)`, so the element is read once by the ordinary machinery and the builtin's only job
+is to decide which of the two things to hand back. That also collapses the `Map` special case into
+the general rule and made the `Seq`- and `Range`-sourced rows fall out for free
+(`my $sq = (…).Seq; $sq[2].VAR.^name`, `my @r := 1..3; @r[1].VAR.^name`), where the hand-rolled
+version answered only `List`.
+
+**One representation ambiguity had to be resolved by the sigil.** mutsu's `ValueView::LazyList` is
+the reified form of *both* a real `Array` assigned a lazy source (`my @a = ^Inf`, `my @a = lazy
+gather {…}` — raku reports `Scalar` elements) and a lazy `Seq` (`my $s = lazy gather {…}` — raku
+reports the values), so the value alone cannot answer. The variable's sigil resolves it, and does
+so soundly rather than heuristically: raku **rejects** binding a `Seq` to an `@` variable outright
+("Type check failed in binding; expected Positional but got Seq"), so an `@`-sigiled `LazyList` can
+only have got there by assignment, i.e. it is a real `Array`. That, plus the `Map` declared-type
+check, is why the two container-level distinctions live in an `Interpreter` wrapper
+(`container_elements_are_containers`) and not in the `Value` method — both need context a `Value`
+does not carry. `@`-assigned `Seq` and `Range` sources need no such rule: mutsu already reifies
+those into a real `Array` at the store (slice 2), so their kind is faithful.
+
+**`.VAR.name` was wrong in the same function and is fixed with it.** Rakudo names an element's
+container after the container it lives in — `@real[0].VAR.name` is `@real`, `%h<a>.VAR.name` is
+`%h` — where mutsu synthesized `@real[]` / `%h[]`. Nothing keyed off the suffix (a `.VAR` reflection
+object is identified by its `__mutsu_var_target` attribute, not by its `name`), and no `t/` or roast
+test pinned it.
+
+**No counter-currents.** Unlike slices 1 and 2 — where the recurring trap was a reader asking a
+question *about the value* while holding something itemized *because it is an element*, 17 such
+sites in slice 2 alone — this slice changes no stored value and no flattening decision. It changes
+what one reflection builtin returns, and the extra element read the rewired hook performs replaces
+a read the subscript would have done anyway in every other context.
+
+**Known remaining `.VAR` divergences, deliberately not chased here**, all of one family: mutsu's
+`.VAR` on a *real* element returns an opaque descriptor carrying `name`/`dynamic`/`default`, while
+raku returns the element's actual container, which delegates value methods through
+(`@real[1].VAR.raku` is `[3, 4]` / `Scalar.new`, `.VAR.elems` `2` / `1`, `.VAR.gist` `$[3, 4]` /
+`Scalar.new`). Fixing that means `.VAR` returning ADR-0036's `ContainerRef` element cell instead of
+a descriptor — the *aliasing* surface, and a representation decision of its own. Recorded with its
+three smaller siblings (the `@a[i;j]` multi-dim subscript never reaching this path at all, `is
+default(0)` not reflected in `.VAR.default`, and native `int @a` elements needing an `IntPosRef`
+mutsu has no representation for) as
+`todo/deep/var-on-a-real-element-is-an-opaque-descriptor-not-the-container.md`.
+
+**Verification**: `cargo fmt --check` and `cargo clippy -- -D warnings` clean.
+`t/element-store-itemization.t` grew from 121 to 149 assertions and is `todo`-free for the first
+time: row 24 un-marked, plus a dedicated slice-3 section dual-oracled against `raku` covering the
+three real-Array-element shapes, seven non-container sources (`:=`-bound List, a List in a `$`, a
+sigilless alias, a cached `Seq`, a raw `Seq` in a `$`, a bound `Range`, a `Range` in a `$`, a lazy
+`gather` in a `$`), the real-`Array` kinds whose lazy or reified source could have been mistaken for
+one of those (`^Inf`, an `@`-assigned lazy `gather`/`Seq`/`Range`, an unfilled element), `Hash` vs
+`Map`, the two unnamed-subscript invariants, and the `.VAR.name` correction. Full local `t/` suite
+passes; `make roast` delegated to CI.
 
 ---
 

--- a/news/2026-09/adr0040-slice3-var-reflection.md
+++ b/news/2026-09/adr0040-slice3-var-reflection.md
@@ -1,0 +1,75 @@
+# ADR-0040 slice 3 — `.VAR` on an element answers from the source container
+
+The last `todo`-marked row of ADR-0040's acceptance oracle is green, and the
+ADR is now implemented end to end (slices 0-3).
+
+Raku's model is that a real, mutable `Array`/`Hash` stores each element in a
+`Scalar` container, while a `List`/`Seq`/`Range` stores the values themselves.
+Slices 1 and 2 put the *representation* half of that at the element store: a
+stored aggregate is itemized, so it renders `$[1, 2]` and counts as one item in
+list context. Slice 3 covers the *reflection* half — `.VAR` — which is the one
+place the stored value cannot carry the answer on its own:
+
+```
+my @c = 1, (1,2), [3,4];    @c[0].VAR.^name, @c[1].VAR.^name, @c[2].VAR.^name
+my @l := 1, (1,2), [3,4];   @l[0].VAR.^name, @l[1].VAR.^name, @l[2].VAR.^name
+```
+
+raku answers `Scalar Scalar Scalar` for the first and `Int List Array` for the
+second. The two first elements are a byte-identical bare `Int`, so no flag on
+the value can distinguish them — the answer has to come from the *source
+container's* kind. mutsu answered `Scalar` for both.
+
+## What changed
+
+`Value::elements_are_containers` (`src/value/value_methods_a.rs`) states the
+discriminator once, beside the itemization helpers the earlier slices added:
+`Array`/`Shaped`/`Lazy`/`ItemArray` and every `Hash` have container elements;
+`List`/`ItemList`, `Seq`, `Range` and everything else do not; a `Scalar` wrapper
+recurses into what it holds, so a `List` living in a `$` answers from the List.
+
+Its consumer is `builtin_index_var_meta` (`src/runtime/builtins.rs`), the
+runtime half of the compiler's `.VAR`-on-a-subscript rewrite. That function used
+to synthesize an opaque `Scalar` descriptor unconditionally — its one
+pre-existing exception being `Map`, whose values are famously not containers,
+which is exactly the rule this slice generalizes.
+
+The compiler hook was **rewired rather than the builtin taught to index**. It
+used to compile the subscript's target purely for side effects, throw the result
+away, and pass `(name, index)` so the builtin could re-derive a `Map` value by
+key. Re-deriving the element inside a reflection builtin is a hand-rolled
+duplicate of the subscript machinery — the compensator-per-site shape this ADR
+exists to avoid, and one that would have needed its own arms for negative
+indices, `Seq` reification and `Range` arithmetic. The hook now compiles the
+whole subscript and passes `(element, name)`, so the element is read once by the
+ordinary machinery and the builtin only decides which of the two to hand back.
+`Seq`- and `Range`-sourced elements then fell out for free.
+
+One representation ambiguity needed the variable's sigil: mutsu's `LazyList` is
+the reified form of both a real `Array` assigned a lazy source (`my @a = ^Inf`)
+and a lazy `Seq` (`my $s = lazy gather {…}`), which raku answers differently.
+The sigil resolves it soundly rather than heuristically — raku rejects binding a
+`Seq` to an `@` variable outright, so an `@`-sigiled lazy list can only have got
+there by assignment.
+
+Fixed in the same function: `@real[0].VAR.name` and `%h<a>.VAR.name` are
+`@real` / `%h` in raku (Rakudo names an element's container after the container
+it lives in), where mutsu synthesized `@real[]` / `%h[]`.
+
+Unlike slices 1 and 2, this one had no counter-currents. Their recurring trap
+was a reader asking a question *about the value* while holding something
+itemized *because it is an element* — 17 such sites in slice 2 alone. Slice 3
+changes no stored value and no flattening decision.
+
+## What is left
+
+`.VAR` on a *real* element still returns an opaque descriptor carrying
+`name`/`dynamic`/`default`, where raku returns the element's actual container
+and delegates value methods through it (`@real[1].VAR.raku` is `[3, 4]`, not
+`Scalar.new`; `.VAR.elems` is `2`, not `1`). Fixing that means `.VAR` returning
+ADR-0036's `ContainerRef` element cell instead of a descriptor — the *aliasing*
+surface, and a representation decision of its own. Recorded with three smaller
+siblings found in the same measurement (the `@a[i;j]` multi-dim subscript never
+reaching this path, `is default(0)` not reflected in `.VAR.default`, and native
+`int @a` elements needing an `IntPosRef`) as
+`todo/deep/var-on-a-real-element-is-an-opaque-descriptor-not-the-container.md`.

--- a/src/compiler/expr_method.rs
+++ b/src/compiler/expr_method.rs
@@ -7,20 +7,22 @@ impl Compiler {
     pub(super) fn compile_expr_method_var_on_index(&mut self, target: &Expr) {
         if let Expr::Index {
             target: index_target,
-            index,
             ..
         } = target
             && let Some(source_name) = Self::index_assign_target_name(index_target)
         {
-            // Preserve side effects of the indexed expression before producing
-            // element variable metadata for .VAR on @a[0] / %h<k>.
-            self.compile_expr(index_target);
-            self.code.emit(OpCode::Pop);
-            // Pass the index key so __mutsu_index_var_meta can look up the
-            // actual value for Map containers (which decontainerize values).
+            // Read the element with the ordinary subscript machinery and hand
+            // the result to `__mutsu_index_var_meta` along with the name of the
+            // container it came from. The builtin needs the value itself for
+            // every source whose elements are NOT `Scalar` containers -- a
+            // `Map`, and (ADR-0040 slice 3) a `List`/`Seq`/`Range` -- where
+            // `.VAR` IS the element; for a real `Array`/`Hash` it discards the
+            // value and answers from the container's metadata. Compiling the
+            // whole subscript here also keeps the indexed expression's side
+            // effects to exactly one evaluation.
+            self.compile_expr(target);
             let name_idx = self.code.add_constant(Value::str(source_name));
             self.code.emit(OpCode::LoadConst(name_idx));
-            self.compile_expr(index);
             let builtin_idx = self
                 .code
                 .add_constant(Value::str("__mutsu_index_var_meta".to_string()));

--- a/src/runtime/builtins.rs
+++ b/src/runtime/builtins.rs
@@ -144,30 +144,37 @@ pub(crate) const BUILTIN_FUNCTION_NAMES: &[&str] = &[
 ];
 
 impl Interpreter {
+    /// `.VAR` on a subscript of a NAMED container (`@a[0]`, `%h<k>`). The
+    /// compiler (`compile_expr_method_var_on_index`) hands us the element the
+    /// ordinary subscript machinery read, plus the name of the container it
+    /// came from.
+    ///
+    /// ADR-0040 slice 3: which of the two we return is decided by the *source
+    /// container*, not by the element. A real, mutable `Array`/`Hash` stores
+    /// each element in a `Scalar` container, so `.VAR` is a container
+    /// descriptor; a `List`/`Seq`/`Range` -- and a `Map`, whose values are
+    /// famously not containers -- stores the values themselves, so `.VAR` IS
+    /// the element. The value side of that model is already carried by the
+    /// store's itemization (slices 1-2), but a bare `Int` element has no flag
+    /// to carry it: `my @c = 1, ...` and `my @l := 1, ...` hold a
+    /// byte-identical first element and must answer `Scalar` and `Int`
+    /// respectively.
     fn builtin_index_var_meta(&mut self, args: &[Value]) -> Result<Value, RuntimeError> {
-        let source_name = args.first().map(Value::to_string_value).unwrap_or_default();
-        let index_key = args.get(1);
+        let element = args.first().cloned().unwrap_or(Value::NIL);
+        let source_name = args.get(1).map(Value::to_string_value).unwrap_or_default();
 
-        // For Map containers, .VAR returns the value itself (no Scalar container)
-        // since Map decontainerizes all values.
         if let Some(container) = self.env.get(&source_name)
-            && let ValueView::Hash(map) = container.view()
+            && !self.container_elements_are_containers(container, &source_name)
         {
-            let is_map = self
-                .container_type_metadata(container)
-                .and_then(|info| info.declared_type)
-                .is_some_and(|dt| dt == "Map");
-            if is_map {
-                if let Some(key) = index_key {
-                    let key_str = key.to_string_value();
-                    return Ok(map.get(&key_str).cloned().unwrap_or(Value::NIL));
-                }
-                return Ok(Value::NIL);
-            }
+            return Ok(element);
         }
 
         let mut attributes = std::collections::HashMap::new();
-        attributes.insert("name".to_string(), Value::str(format!("{source_name}[]")));
+        // Rakudo names an element's container after the container it lives in:
+        // `@real[0].VAR.name` and `%h<a>.VAR.name` are `@real` / `%h`, not a
+        // synthesized `@real[]`. Nothing keys off the old suffix — a `.VAR`
+        // reflection object is identified by `__mutsu_var_target`.
+        attributes.insert("name".to_string(), Value::str(source_name.clone()));
         attributes.insert(
             "__mutsu_var_target".to_string(),
             Value::str(source_name.clone()),
@@ -183,6 +190,34 @@ impl Interpreter {
         };
         attributes.insert("default".to_string(), default_val);
         Ok(Value::make_instance(Symbol::intern("Scalar"), attributes))
+    }
+
+    /// [`Value::elements_are_containers`] plus the two distinctions a bare
+    /// `Value` cannot make.
+    ///
+    /// A `Map` is a `Hash` whose values are NOT containers, and mutsu tells it
+    /// from a real `Hash` by the container's declared type, not its
+    /// representation.
+    ///
+    /// A `LazyList` is genuinely ambiguous in mutsu: it is the reified form of
+    /// BOTH a real `Array` assigned a lazy source (`my @a = ^Inf`, whose
+    /// elements raku reports as `Scalar`) and a lazy `Seq` (`my $s = lazy
+    /// gather {...}`, whose elements are the values). The variable's sigil
+    /// resolves it, and does so soundly: raku rejects binding a `Seq` to an
+    /// `@` variable outright ("expected Positional but got Seq"), so an
+    /// `@`-sigiled `LazyList` can only have got there by assignment -- i.e. it
+    /// is a real `Array`.
+    fn container_elements_are_containers(&self, container: &Value, source_name: &str) -> bool {
+        match container.view() {
+            ValueView::Hash(_) => !matches!(
+                self.container_type_metadata(container)
+                    .and_then(|info| info.declared_type)
+                    .as_deref(),
+                Some("Map")
+            ),
+            ValueView::LazyList(_) => source_name.starts_with('@'),
+            _ => container.elements_are_containers(),
+        }
     }
 
     /// `sprintf`/`printf` declare their format as `Str(Cool) $format`, and a

--- a/src/value/value_methods_a.rs
+++ b/src/value/value_methods_a.rs
@@ -473,6 +473,39 @@ impl Value {
         }
     }
 
+    /// ADR-0040 slice 3: the discriminator, stated once. Are this container's
+    /// elements `Scalar` containers of their own?
+    ///
+    /// Raku's model is that a real, mutable `Array`/`Hash` stores each element
+    /// in a `Scalar` container, while a `List`/`Seq`/`Range` stores the values
+    /// themselves. The *representation* consequence of that (one item in list
+    /// context, a `$` in `.raku`) is what slices 1-2 put at the element store;
+    /// this is the same fact seen from the *reflection* side, which is the one
+    /// place a bare `Int` element still needs the container kind to answer:
+    ///
+    /// ```text
+    /// my @c = 1, (1,2), [3,4];   @c[0..2]>>.VAR>>.^name  is  Scalar Scalar Scalar
+    /// my @l := 1, (1,2), [3,4];  @l[0..2]>>.VAR>>.^name  is  Int    List   Array
+    /// ```
+    ///
+    /// `Shaped` and `Lazy` are real `Array` kinds (`my @a[2;2]`, `my @a = ^Inf`)
+    /// and so answer `true`, even though `ArrayKind::itemize()` is a no-op on
+    /// them. `ItemArray`/`ItemList` are `$[…]`/`$(…)` — the itemization
+    /// describes how the aggregate behaves as somebody else's element and says
+    /// nothing about its own elements, so they answer the same as the kind they
+    /// decontainerize to.
+    pub fn elements_are_containers(&self) -> bool {
+        match self.view() {
+            ValueView::Array(_, kind) => matches!(
+                kind,
+                ArrayKind::Array | ArrayKind::Shaped | ArrayKind::Lazy | ArrayKind::ItemArray
+            ),
+            ValueView::Hash(_) => true,
+            ValueView::Scalar(inner) => inner.elements_are_containers(),
+            _ => false,
+        }
+    }
+
     /// Read through a `ContainerRef` or explicit `.VAR` container view and apply
     /// `f` to the inner value WITHOUT cloning it.
     pub fn with_deref<R>(&self, f: impl FnOnce(&Value) -> R) -> R {

--- a/t/element-store-itemization.t
+++ b/t/element-store-itemization.t
@@ -13,13 +13,12 @@ use Test;
 # Array/Hash), turning rows 19-22 green. Slice 2 fixes the *construction*
 # sites (list-assign into `@a`/`%h`, real-container literal construction,
 # `.Array`/`.Hash` coercion), turning rows 01-18 and 23 green -- every
-# downstream element producer inherits the flag (SS1.6.3). Only row 24
-# (`.VAR` reflection) is still `todo`-marked; it is Slice 3. Row 25 (and the
-# SS1.6 rows) are invariants that must NOT move -- they are what stops a
-# later slice from "fixing" the divergence by over-itemizing.
+# downstream element producer inherits the flag (SS1.6.3). Slice 3 states the
+# same model on the *reflection* side (`.VAR`), turning row 24 green. Row 25
+# (and the SS1.6 rows) are invariants that must NOT move -- they are what
+# stops a later slice from "fixing" the divergence by over-itemizing.
 
 # === SS1.3 divergent rows (25) ===
-# Row 24 is the `.VAR` reflection side and still diverges (Slice 3).
 
 my @c = [<a b>],[<c d>];
 my %h = a => [1,2];
@@ -111,7 +110,6 @@ sub takes(*@a) { @a.elems }
     is takes(@a23[0]), 1, 'row 23: my @a = (1..3),(4..6); takes(@a[0])';
 }
 {
-    todo 'row 24: .VAR reflection is ADR-0040 slice 3';
     my @l := 1, (1, 2), [3, 4];
     is "{@l[1].VAR.^name} {@l[2].VAR.^name}", 'List Array',
         'row 24: @l[1].VAR.^name, @l[2].VAR.^name';
@@ -567,6 +565,75 @@ is @c.raku, '[["a", "b"], ["c", "d"]]', 'row 25: @c.raku stays bare (invariant)'
     is @xs.raku, '[1, 2, 3]', 'staging temp: a := @ target aliases its source';
     my ($b) = ();
     is $b.^name, 'Any', 'staging temp: a missing untyped target is Any, not Nil';
+}
+
+# === Slice 3: `.VAR` reflection -- the discriminator, seen from the
+# reflection side (ADR-0040 SS4 slice 3) ===
+#
+# A real, mutable Array/Hash stores each element in a Scalar container; a
+# List/Seq stores the values themselves. Slices 1-2 put the *representation*
+# half of that at the store (an itemized element renders `$[...]` and counts
+# as one item), but a bare `Int` element cannot carry a flag, so `.VAR` has to
+# read the answer off the SOURCE container's kind --
+# `Value::elements_are_containers`. Every expectation below is dual-oracled
+# against `raku`.
+{
+    my @real = 1, (1, 2), [3, 4];
+    is @real[0].VAR.^name, 'Scalar', 'slice 3: real Array element is a Scalar (Int)';
+    is @real[1].VAR.^name, 'Scalar', 'slice 3: real Array element is a Scalar (List)';
+    is @real[2].VAR.^name, 'Scalar', 'slice 3: real Array element is a Scalar (Array)';
+
+    my @bound := 1, (1, 2), [3, 4];
+    is @bound[0].VAR.^name, 'Int', 'slice 3: bound List element is its own value (Int)';
+    is @bound[1].VAR.^name, 'List', 'slice 3: bound List element is its own value (List)';
+    is @bound[2].VAR.^name, 'Array', 'slice 3: bound List element is its own value (Array)';
+    is @bound[2].VAR.raku, '[3, 4]', 'slice 3: .VAR on a List element is the value itself';
+    is @bound[2].VAR.elems, 2, 'slice 3: .VAR on a List element keeps the value methods';
+
+    # The source container, not the syntax that reads it (SS1.6.2).
+    my $sl = (1, (1, 2), [3, 4]);
+    is $sl[1].VAR.^name, 'List', 'slice 3: a List in a $ scalar still has bare elements';
+    my \sless = (1, (1, 2), [3, 4]);
+    is sless[2].VAR.^name, 'Array', 'slice 3: a sigilless List alias has bare elements';
+    my @cached := (1, (1, 2), [3, 4]).Seq.cache;
+    is @cached[2].VAR.^name, 'Array', 'slice 3: a cached Seq has bare elements';
+    my $sq = (1, (2, 3), [4, 5]).Seq;
+    is $sq[2].VAR.^name, 'Array', 'slice 3: a Seq in a $ scalar has bare elements';
+    my @rb := 1 .. 3;
+    is @rb[1].VAR.^name, 'Int', 'slice 3: a bound Range has bare elements';
+    my $rs = 1 .. 3;
+    is $rs[1].VAR.^name, 'Int', 'slice 3: a Range in a $ scalar has bare elements';
+    my $lz = lazy gather { take $_ for 1, (2, 3) };
+    is $lz[1].VAR.^name, 'List', 'slice 3: a lazy Seq in a $ scalar has bare elements';
+
+    # Real-Array kinds all keep Scalar elements, including the ones on which
+    # `ArrayKind::itemize()` is a no-op, and the lazy sources an `@`-assign
+    # reifies (raku rejects binding a Seq to `@`, so an `@`-sigiled lazy list
+    # can only be a real Array).
+    my @lazy = ^Inf;
+    is @lazy[1].VAR.^name, 'Scalar', 'slice 3: a lazy Array element is a Scalar';
+    my @lza = lazy gather { take $_ for 1, (2, 3) };
+    is @lza[1].VAR.^name, 'Scalar', 'slice 3: an @-assigned lazy gather element is a Scalar';
+    my @sqa = (1, (2, 3)).Seq;
+    is @sqa[1].VAR.^name, 'Scalar', 'slice 3: an @-assigned Seq element is a Scalar';
+    my @rga = 1 .. 3;
+    is @rga[1].VAR.^name, 'Scalar', 'slice 3: an @-assigned Range element is a Scalar';
+    my @empty;
+    is @empty[0].VAR.^name, 'Scalar', 'slice 3: an unfilled Array element is a Scalar';
+    my %hh = a => [1, 2];
+    is %hh<a>.VAR.^name, 'Scalar', 'slice 3: a Hash element is a Scalar';
+    my %mm := Map.new((a => [1, 2]));
+    is %mm<a>.VAR.^name, 'Array', 'slice 3: a Map value is NOT a container';
+
+    # An unnamed subscript answers from the value side alone, and already
+    # agreed before this slice -- it must keep agreeing.
+    is (1, (2, 3))[1].VAR.^name, 'List', 'slice 3: List literal element (invariant)';
+    is [1, (2, 3)][1].VAR.^name, 'Scalar', 'slice 3: Array literal element (invariant)';
+
+    # Rakudo names an element container after the container it lives in.
+    is @real[0].VAR.name, '@real', 'slice 3: an Array element .VAR.name is the array name';
+    is %hh<a>.VAR.name, '%hh', 'slice 3: a Hash element .VAR.name is the hash name';
+    is @real.VAR.name, '@real', 'slice 3: the array own .VAR.name is unchanged';
 }
 
 done-testing;

--- a/todo/deep/var-on-a-real-element-is-an-opaque-descriptor-not-the-container.md
+++ b/todo/deep/var-on-a-real-element-is-an-opaque-descriptor-not-the-container.md
@@ -1,0 +1,76 @@
+# `.VAR` on a real Array/Hash element is an opaque descriptor, not the element's container
+
+`@a[0].VAR` / `%h<k>.VAR` in raku hands back the element's actual `Scalar`
+container, which delegates almost everything to the value it holds. mutsu
+synthesizes an opaque `Scalar` *instance* carrying three attributes
+(`name`, `dynamic`, `default`) and nothing else, so every method that raku
+answers from the contained value answers wrongly.
+
+Measured 2026-09-01 on `main` + ADR-0040 slice 3 (`tmp/var24f.raku`,
+`my @real = 1, [3,4]; my %h = a => [1,2]`):
+
+| program | raku | mutsu |
+| --- | --- | --- |
+| `@real[1].VAR.raku` | `[3, 4]` | `Scalar.new` |
+| `@real[1].VAR.gist` | `$[3, 4]` | `Scalar.new` |
+| `@real[1].VAR.elems` | `2` | `1` |
+| `@real[1].VAR[0]` | `[3 4]` | `(Any)` |
+| `@real[1].VAR.Str` | `Array<…>` | `Scalar()` |
+| `%h<a>.VAR.raku` | `[1, 2]` | `Scalar.new` |
+
+`.VAR.^name` (`Scalar`), `.VAR.WHAT` (`(Scalar)`), `.VAR.name`, `.VAR.dynamic`
+and the ADR-0040 slice-3 container-vs-value discriminator all agree — this is
+only about the *contents* of the object `.VAR` returns.
+
+## Why it is deep, not a ticket
+
+The honest fix is for `.VAR` on an element to return the element's real
+container — the `ContainerRef` cell ADR-0036 already promotes elements to via
+`array_slot_ref` / `hash_slot_ref` — instead of a descriptor built out of
+variable metadata. That is the *aliasing* surface
+(`docs/adr/0036-element-container-pairs-from-subscripts-and-pairs.md`), and it
+collides with the read chokepoint that deliberately decontainerizes a
+`ContainerRef` on every element read (`resolve_array_entry`,
+`src/vm/vm_var_ops.rs`) — `.VAR` would need to become one of the few readers
+that does *not* decont, alongside the existing `raku`/`gist`/`perl` exceptions
+in `exec_call_method_op_impl`.
+
+The descriptor also carries information the cell does not: `.VAR.name` and
+`.VAR.dynamic` are properties of the *variable*, not of the element, so a cell
+returned by `array_slot_ref` cannot answer them on its own. Whatever replaces
+`builtin_index_var_meta` (`src/runtime/builtins.rs`) has to carry both — which
+is a representation decision, i.e. an ADR-shaped question, not a patch.
+
+## Three smaller siblings found in the same measurement
+
+These are independent and could each be a ticket:
+
+- **Multi-dim subscript.** `my @sh[2;2]; @sh[0;0].VAR.^name` is `Scalar` in
+  raku, `Array` in mutsu — the `@a[i;j]` subscript never reaches
+  `compile_expr_method_var_on_index` (`src/compiler/expr_method.rs`), so the
+  element-`.VAR` path is not entered at all.
+- **`is default`.** `my @nat is default(0) = 1,2; @nat[0].VAR.default` is `0`
+  in raku, `(Any)` in mutsu — `builtin_index_var_meta` reads
+  `var_type_constraint` for the default but never the variable's `is default`
+  trait.
+- **Native arrays.** `my int @ints = 1,2; @ints[0].VAR.^name` is `IntPosRef`
+  in raku, `Scalar` in mutsu. A native array's element "container" is a
+  positional ref type per element type (`IntPosRef`/`NumPosRef`/…), which mutsu
+  has no representation for.
+- **Slice subscripts.** `my @a = 1,2; @a[0,1].VAR.^name` is `List` in raku
+  (a slice hands back a `List` of containers, and `.VAR` on a `List` is
+  identity), `Scalar` in mutsu -- `compile_expr_method_var_on_index` routes
+  every subscript to the element-descriptor path, slices included, and a
+  slice's `List` result is indistinguishable at runtime from an element that
+  happens to hold a `List`. The compiler is the only place that knows, so this
+  one is a compile-side gate rather than part of the descriptor rework.
+
+## Repro
+
+```
+raku   tmp/var24f.raku
+mutsu  tmp/var24f.raku
+```
+
+(recreate `tmp/var24f.raku` from the table above; `sub p($l, &c) { say "$l = ",
+(try c()).gist }`).


### PR DESCRIPTION
ADR-0040's last `todo`-marked row is green, and the ADR is now implemented end to end (slices 0-3).

## The divergence

Raku's model is that a real, mutable `Array`/`Hash` stores each element in a `Scalar` container, while a `List`/`Seq`/`Range` stores the values themselves. Slices 1-2 put the *representation* half of that at the element store (a stored aggregate is itemized, so it renders `$[1, 2]` and counts as one item). This slice covers the *reflection* half — `.VAR` — which is the one place the stored value cannot carry the answer on its own:

```
my @c = 1, (1,2), [3,4];    # raku: @c[0..2]>>.VAR>>.^name = Scalar Scalar Scalar
my @l := 1, (1,2), [3,4];   # raku: @l[0..2]>>.VAR>>.^name = Int    List   Array
```

The two first elements are a byte-identical bare `Int`, so no flag on the value can distinguish them — the answer has to come from the **source container's** kind. mutsu answered `Scalar` for both.

## Root cause

`builtin_index_var_meta` (`src/runtime/builtins.rs`) synthesized an opaque `Scalar` descriptor for every subscript of a named container, with one pre-existing exception for `Map` — whose values are famously not containers, which is exactly the rule this slice generalizes.

## The fix

- **`Value::elements_are_containers`** (`src/value/value_methods_a.rs`) states the discriminator once, beside slice 1's `itemize_for_element_store` and slice 2's `needs_element_itemization`/`deitemize_element`.

- **The compiler hook was rewired rather than the builtin taught to index.** `compile_expr_method_var_on_index` used to compile the subscript's *target* purely for side effects, `Pop` it, and pass `(name, index)` so the builtin could re-derive a `Map` value by key. Re-deriving the element inside a reflection builtin is a hand-rolled duplicate of the subscript machinery — the compensator-per-site shape this ADR exists to avoid, and one that would have needed its own arms for negative indices, `Seq` reification and `Range` arithmetic. The hook now compiles the **whole subscript** and passes `(element, name)`, so the element is read once by the ordinary machinery and the builtin only decides which of the two to hand back. `Seq`- and `Range`-sourced elements then fell out for free, the index is still evaluated exactly once (`@b[$i++].VAR` leaves `$i` at 1), and nothing autovivifies (`@a[5].VAR` does not grow `@a`).

- **One representation ambiguity needed the variable's sigil.** mutsu's `ValueView::LazyList` is the reified form of *both* a real `Array` assigned a lazy source (`my @a = ^Inf`, raku reports `Scalar` elements) and a lazy `Seq` (`my $s = lazy gather {…}`, raku reports the values). The sigil resolves it soundly rather than heuristically: raku **rejects** binding a `Seq` to an `@` variable outright ("expected Positional but got Seq"), so an `@`-sigiled `LazyList` can only have got there by assignment. That, plus the `Map` declared-type check, is why the two container-level distinctions live in an `Interpreter` wrapper (`container_elements_are_containers`) rather than in the `Value` method.

## Also fixed in the same function

Rakudo names an element's container after the container it lives in — `@real[0].VAR.name` is `@real`, `%h<a>.VAR.name` is `%h` — where mutsu synthesized `@real[]` / `%h[]`. Nothing keyed off the suffix (a `.VAR` reflection object is identified by its `__mutsu_var_target` attribute), and no `t/` or roast test pinned it.

## No counter-currents

Unlike slices 1 and 2 — where the recurring trap was a reader asking a question *about the value* while holding something itemized *because it is an element*, 17 such sites in slice 2 alone — this slice changes no stored value and no flattening decision.

## What is left (filed, not fixed)

`todo/deep/var-on-a-real-element-is-an-opaque-descriptor-not-the-container.md`: mutsu's `.VAR` on a *real* element returns an opaque descriptor carrying `name`/`dynamic`/`default`, while raku returns the element's actual container and delegates value methods through it (`@real[1].VAR.raku` is `[3, 4]` / `Scalar.new`, `.VAR.elems` `2` / `1`). Fixing that means `.VAR` returning ADR-0036's `ContainerRef` element cell — the *aliasing* surface, and a representation decision of its own. Filed with four smaller siblings found in the same measurement (`@a[i;j]` multi-dim subscripts never reaching this path, `is default(0)` not reflected in `.VAR.default`, native `int @a` needing an `IntPosRef`, and slice subscripts).

## Verification

- `cargo fmt --check` and `cargo clippy -- -D warnings` clean.
- `t/element-store-itemization.t` 121 → 149 assertions and **`todo`-free for the first time**. The new slice-3 section is dual-oracled against `raku`: the three real-Array-element shapes, seven non-container sources (`:=`-bound List, a List in a `$`, a sigilless alias, a cached `Seq`, a raw `Seq` in a `$`, a bound `Range`, a `Range` in a `$`, a lazy `gather` in a `$`), the real-`Array` kinds whose lazy or reified source could be mistaken for one of those (`^Inf`, `@`-assigned lazy `gather`/`Seq`/`Range`, an unfilled element), `Hash` vs `Map`, the two unnamed-subscript invariants, and the `.VAR.name` correction.
- Full local `t/` suite: **3601 files, 36214 tests, PASS**.
- Targeted roast: all **33 whitelisted files that use `.VAR`** pass, plus a **107-file** `S32-array`/`S32-hash`/`S32-list`/`S09-typed-arrays`/`S02-types` sweep (11380 tests, PASS). Full `make roast` delegated to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
