### PR TITLE
fix: a chained subscript stores its element bare (ADR-0040 slice 4)

### DIFF
--- a/docs/adr/0040-array-hash-elements-are-itemized-at-the-store.md
+++ b/docs/adr/0040-array-hash-elements-are-itemized-at-the-store.md
@@ -1,6 +1,6 @@
 # ADR-0040: Array and Hash elements are itemized at the *store*, not compensated at the read
 
-- **Status**: Accepted (Slices 0-3 implemented; see "Implementation status" below)
+- **Status**: Accepted (Slices 0-4 implemented; see "Implementation status" below)
 - **Date**: 2026-08-20
 - **Deciders**: tokuhirom, Claude
 - **Related**: [ADR-0013](0013-container-interior-mutability-cellvalue.md) §5 open question 3 / §7 (the
@@ -477,9 +477,10 @@ approximates each separately. Recorded here so a future reader can see the whole
 
 ---
 
-## 8. Implementation status (2026-08-21; slice 2 added 2026-08-27; slice 3 added 2026-09-01)
+## 8. Implementation status (2026-08-21; slice 2 added 2026-08-27; slices 3-4 added 2026-09-01)
 
-Slices 0-3 landed in full. Slice 1 covered every mutation-site shape named in §2/§4's Slice 1
+Slices 0-4 landed. Slice 4 landed its *store* half in full and left the compensator deletion
+blocked on a newly measured class — see its section for the numbers. Slice 1 covered every mutation-site shape named in §2/§4's Slice 1
 description (element assign, autovivification — both single- and nested-level — and
 `push`/`unshift`/`append`/`prepend`/`splice` for a real `Array` or `Hash`). Slice 2 covered the
 construction sites, turning §1.3's rows 01-18 and 23 green. Slice 3 covered the reflection side,
@@ -865,6 +866,88 @@ sigilless alias, a cached `Seq`, a raw `Seq` in a `$`, a bound `Range`, a `Range
 one of those (`^Inf`, an `@`-assigned lazy `gather`/`Seq`/`Range`, an unfilled element), `Hash` vs
 `Map`, the two unnamed-subscript invariants, and the `.VAR.name` correction. Full local `t/` suite
 passes; `make roast` delegated to CI.
+
+### Slice 4 (2026-09-01) — the chained-subscript store, and what the compensators actually cover
+
+Slice 4 was scoped as "delete the compensators, once slices 1-2 make them redundant". **They were
+not redundant, and the reason was a bug, not a leftover.** Instrumenting both compensator sites
+behind an env var and running the whole corpus is what found it — §1.3's divergence matrix could
+not, because the matrix only exercises one subscript level.
+
+**The instrumentation had to be split before it said anything true.** A first pass counted 57
+firings of `raku_hash_value` across `t/` and looked like proof the render compensator was load
+bearing. It was not: `raku_hash_value` has two callers with opposite roles — the three Hash/Map
+rendering sites (the actual compensator) and the `ValueView::Scalar` arm
+(`raku_repr.rs`), which is the **primary** `$(…)` renderer for every itemized value and not a
+compensator at all. Probing only the three Hash/Map sites dropped the count to 22, and every one of
+those was a real defect.
+
+#### The defect: a chained subscript stores bare
+
+Slice 1's own implementation note said "deeper (3+-level) chained assignment
+(`exec_index_assign_deep_nested_op`/`exec_index_assign_generic_op`) was not separately audited". It
+was not covered — and neither was the **leaf of a two-level chain**, nor the intermediate a
+**deferred vivification token** walk-creates. Measured against raku:
+
+| program | raku | mutsu (before) |
+| --- | --- | --- |
+| `my %h; %h<a><b> = [1,2]; %h<a><b>.raku` | `$[1, 2]` | `[1, 2]` |
+| `takes(%h<a><b>)` | `1` | `2` |
+| `my %d; %d<a><b>[2] = "z"; %d<a><b>.raku` | `$[Any, Any, "z"]` | `[Any, Any, "z"]` |
+| `my @g; @g[0][1][2] = 7; takes(@g[0][1])` | `1` | `3` |
+| `my %h; %h<a>[0]<k> = 5; %h<a>.raku` | `$[{:k(5)},]` | `[{:k(5)},]` |
+| `my %h; my $r := %h<a>[1]; $r = "x"; %h<a>.raku` | `$[Any, "x"]` | `[Any, "x"]` |
+
+The render-side compensator made `%h.raku` right while `%h<a><b>.raku`, `.VAR` and list-context
+arity were all wrong — §1.5's "one value, three answers" shape, alive one level down and invisible
+to the ADR's own oracle.
+
+#### The fix — four sites, all "a value entering a parent's element slot"
+
+- **`exec_index_assign_expr_nested_op`** (two-level): the leaf value, hooked once after the
+  junction/slice arm, mirroring slice 1's hook at the single-level op's entry.
+- **`exec_index_assign_deep_nested_op`** (3+): the same hook for the leaf, plus
+  `Interpreter::fresh_autoviv_container` for the four intermediate-vivification sites (two array
+  arms, two hash arms, first attempt and retry). Itemizing an `Array` only flips its `ArrayKind`
+  tag, so the `&mut` the walk takes into the slot to keep descending is unaffected.
+- **`fresh_level_for`** (`src/value/entry_path.rs`): the same for the container a deferred
+  vivification token walk-creates — a different mechanism reaching the same slot.
+- **An itemized-`Hash` arm for `.VAR`** (`methods_call_dispatch.rs`). An itemized `Hash` carries
+  its itemization as a bool on the repr rather than as an `ArrayKind`, so the existing
+  itemized-`Array` arm did not cover it and `%g<a>[0].VAR.^name` answered `Hash`. Only `.VAR` is
+  redirected — unlike the `Array` case there is nothing to decontainerize for other methods.
+
+`:=` through a **two-level** chain now matches raku too (`%h<a><b> := @s` renders `$[1, 2]`, `@s`
+read directly stays bare, and a later `@s.push` still shows through). A **3+-level** bind installs a
+shared `ContainerRef` cell rather than a value, and wrapping *that* in a `Scalar` — slice 1's
+`@a.push(@b)` shape — **breaks the write path**, which does not yet see through a `Scalar`-wrapped
+cell (`t/deep-element-bind-writeback-coherence.t` and `t/element-bind-cell.t` caught it). Left bare
+deliberately; the write-through is pinned instead.
+
+#### The compensators: measured, not deleted
+
+Both sites were instrumented and the **entire** corpus run — `t/` (3601 files) and the full roast
+whitelist (1425 files):
+
+| compensator | before slice 4 | after slice 4 | what still reaches it |
+| --- | --- | --- | --- |
+| render-side (`raku_hash_value` at the 3 Hash/Map sites) | 22 in `t/` | **0 in `t/`**, 1 in roast | a self-referential hash (`:__mutsu_self_hash_ref`), where the value rendered is the cycle sentinel rather than the stored container |
+| read-side (`itemize_hash_value`) | 3 in `t/` | 3 in `t/`, 17 in roast | **natively constructed hashes only** — Pod block `.config` (12 of the 17, `roast/S26-documentation/09-configuration.t`), `gethost(…)<addrs>`, and two exception/`Proc` hashes |
+
+So slice 4's deletion is blocked on one nameable class, and it is the same class slice 2 already hit
+once: **a `Hash` a native Rust builtin constructs directly bypasses every store hook**. Slice 2
+fixed the JSON decoder by hand for exactly this reason; Pod `.config`, `gethost` and their siblings
+are the rest of it. Deleting either compensator before those are routed through the itemizing store
+would turn 20 measured firings into 20 wrong answers. That is the remaining slice-4 work, and it is
+a store-site enumeration, not a mechanism question.
+
+**Verification**: `cargo fmt --check` and `cargo clippy -- -D warnings` clean. Full local `t/`
+suite (3601 files, 36214 tests) passes. `t/element-store-itemization.t` grew from 149 to 175
+assertions and matches `raku` line for line: the chained-leaf shapes (two- and three-level, hash,
+array, and both mixed orders), the autovivified intermediates, the deferred walk-create shapes, the
+two-level bind's itemization *and* write-through, the 3+-level bind's write-through, and the
+invariants (`%h.raku` / `@a.raku` unchanged, chain arity unchanged, the assignment expression's own
+value itemized). The full roast whitelist (1425 files) passes on a release build.
 
 ---
 

--- a/news/2026-09/adr0040-slice4-chained-subscript-store.md
+++ b/news/2026-09/adr0040-slice4-chained-subscript-store.md
@@ -1,0 +1,80 @@
+# ADR-0040 slice 4 — a chained subscript stores its element bare
+
+Slice 4 of ADR-0040 was scoped as "delete the two compensators, now that slices
+1-2 make them redundant". They were not redundant, and the reason turned out to
+be a bug rather than a leftover.
+
+## What the instrumentation found
+
+The way to check "is this mechanism still doing anything?" is to instrument the
+site and run the whole corpus, not to re-read the design's divergence table.
+Doing that here turned up 22 live firings of the render-side compensator across
+`t/`, every one of them a real defect that ADR-0040's own 25-row matrix could
+not see — because the matrix only ever uses **one** subscript level.
+
+Slice 1's implementation note had already flagged the shape of it: "deeper
+(3+-level) chained assignment was not separately audited". It was not covered.
+Neither was the **leaf** of a two-level chain, nor the intermediate container a
+**deferred vivification token** walk-creates. Measured against raku:
+
+| program | raku | mutsu (before) |
+| --- | --- | --- |
+| `my %h; %h<a><b> = [1,2]; %h<a><b>.raku` | `$[1, 2]` | `[1, 2]` |
+| `takes(%h<a><b>)` | `1` | `2` |
+| `my %d; %d<a><b>[2] = "z"; %d<a><b>.raku` | `$[Any, Any, "z"]` | `[Any, Any, "z"]` |
+| `my @g; @g[0][1][2] = 7; takes(@g[0][1])` | `1` | `3` |
+| `my %h; my $r := %h<a>[1]; $r = "x"; %h<a>.raku` | `$[Any, "x"]` | `[Any, "x"]` |
+
+The render-side compensator made `%h.raku` look right while `%h<a><b>.raku`,
+`.VAR` and list-context arity were all wrong — ADR-0040 §1.5's "one value,
+three answers" shape, still alive one level down.
+
+## A note on instrumenting the right thing
+
+A first pass counted 57 firings and looked like proof the compensator was
+load-bearing everywhere. It was not. `raku_hash_value` has two callers with
+opposite roles: the three Hash/Map rendering sites (the actual compensator) and
+the `ValueView::Scalar` arm, which is the *primary* `$(…)` renderer for every
+itemized value. Probing only the compensator's own call sites dropped the count
+to 22 — and made all 22 real.
+
+## The fix
+
+Four sites, all of one shape — a value entering a parent's element slot:
+
+- the leaf of a two-level chained assign (`exec_index_assign_expr_nested_op`),
+- the leaf of a 3+-level one, plus its four intermediate-vivification sites,
+  collapsed onto a new `fresh_autoviv_container` helper
+  (`exec_index_assign_deep_nested_op`),
+- the container a deferred vivification token walk-creates (`fresh_level_for`,
+  `src/value/entry_path.rs`),
+- an itemized-`Hash` arm for `.VAR`, which the existing itemized-`Array` arm did
+  not cover because a `Hash` carries its itemization as a bool on the repr
+  rather than as an `ArrayKind`.
+
+Itemizing an `Array` only flips its kind tag, so the `&mut` the walk takes into
+the slot to keep descending is unaffected.
+
+`:=` through a **two-level** chain now matches raku as well: the element renders
+`$[1, 2]`, the source read directly stays bare, and a later push still shows
+through. A **3+-level** bind installs a shared `ContainerRef` cell rather than a
+value, and wrapping *that* in a `Scalar` (slice 1's `@a.push(@b)` shape) breaks
+the write path, which does not yet see through a `Scalar`-wrapped cell. Left
+bare deliberately; the write-through is pinned instead.
+
+## The compensators: measured, not deleted
+
+Both sites were instrumented and the entire corpus run — `t/` (3601 files) and
+the full roast whitelist (1425 files):
+
+| compensator | before | after | what still reaches it |
+| --- | --- | --- | --- |
+| render-side (`raku_hash_value`) | 22 in `t/` | **0 in `t/`**, 1 in roast | a self-referential hash, where the value rendered is the cycle sentinel |
+| read-side (`itemize_hash_value`) | 3 in `t/` | 3 in `t/`, 17 in roast | **natively constructed hashes only** — Pod block `.config` (12 of 17), `gethost(…)<addrs>`, two exception/`Proc` hashes |
+
+So the deletion is blocked on one nameable class, and it is the same class slice
+2 already hit once: a `Hash` a native Rust builtin constructs directly bypasses
+every store hook. Slice 2 fixed the JSON decoder by hand for exactly this
+reason; Pod `.config`, `gethost` and their siblings are the rest of it. That is
+the remaining slice-4 work, and it is a store-site enumeration rather than a
+mechanism question.

--- a/src/runtime/methods_call_dispatch.rs
+++ b/src/runtime/methods_call_dispatch.rs
@@ -513,6 +513,22 @@ impl Interpreter {
                 return self.call_method_with_values(deconted, method, args);
             }
         }
+        // The Hash half of the same rule. An itemized Hash carries its
+        // itemization as a bool on the repr rather than as an `ArrayKind`, so
+        // it needs its own arm: `.VAR` on `$(%h)` is `Scalar` either way, but
+        // only the `ValueView::Scalar` spelling was covered. Reachable since
+        // ADR-0040 slice 4 started itemizing chained-subscript stores, which
+        // produce the flag form (`my %g; %g<a>[0]<k> = 5; %g<a>[0].VAR.^name`).
+        // Only `.VAR` is redirected: unlike the Array case there is nothing to
+        // decontainerize for other methods -- an itemized Hash is still a Hash,
+        // and `hash_is_itemized` is already consulted by the renderers and the
+        // flattening chokepoints.
+        if method == "VAR"
+            && matches!(target.view(), ValueView::Hash(_))
+            && target.hash_is_itemized()
+        {
+            return Ok(Value::package(Symbol::intern("Scalar")));
+        }
         // `self.rakuseen($id, &code)`: Mu's cyclic-structure guard for
         // `.raku`/`.gist`. A user `.raku` wraps its body in
         // `self.rakuseen(self.^name, { ... })`; on the first sight of an id we run

--- a/src/value/entry_path.rs
+++ b/src/value/entry_path.rs
@@ -170,11 +170,21 @@ pub(crate) fn is_container_hole(value: &Value) -> bool {
 }
 
 /// A fresh, empty container of the kind `step` descends into.
+///
+/// ADR-0040: the walk-create stores this container into an element slot of the
+/// level above it, and an element of a real `Array`/`Hash` is a `Scalar`
+/// container -- so a level vivified on the way down a deferred path itemizes
+/// exactly like one a direct `%h<a><b> = ...` vivifies (raku renders
+/// `my %h; my $r := %h<a>[1]; $r = "x"; %h<a>.raku` as `$[Any, "x"]`).
+/// Itemizing an `Array` only flips its `ArrayKind` tag (a `Hash`, a bool on the
+/// repr), so the shared backing `Gc` the walk keeps descending through is
+/// untouched.
 fn fresh_level_for(step: &EntryStep) -> Value {
-    match step {
+    let fresh = match step {
         EntryStep::Key(_) => Value::hash(std::collections::HashMap::new()),
         EntryStep::Index(_) => Value::real_array(Vec::new()),
-    }
+    };
+    fresh.itemize_for_element_store()
 }
 
 /// The container slot a deferred path terminates at, once located.

--- a/src/vm/vm_var_assign_index_named.rs
+++ b/src/vm/vm_var_assign_index_named.rs
@@ -2946,6 +2946,24 @@ impl Interpreter {
             return Ok(());
         }
 
+        // ADR-0040 slice 4: a value assigned through a chained subscript lands
+        // in an element slot, so it itemizes exactly like a single-level
+        // `%h<a> = [1,2]` does (raku: `%h<a><b> = [1,2]` then `%h<a><b>.raku`
+        // is `$[1, 2]`, and ONE item in list context). Slice 1 hooked the
+        // single-level op's entry; this is the same hook for the two-level one.
+        // A `:=` bind is excluded — a bound element keeps the source's bare
+        // value — and so is a slice/junction inner subscript, whose RHS the
+        // sites below split per element (itemizing it whole would change the
+        // arity).
+        let val = if matches!(
+            inner_idx.view(),
+            ValueView::Junction { .. } | ValueView::Array(..)
+        ) {
+            val
+        } else {
+            val.itemize_for_element_store()
+        };
+
         // A user-defined Associative/Positional object as the chained-subscript
         // base (`$q<foo>[0] = v` where `$q` is a URI::Query instance): read the
         // inner collection via AT-KEY/AT-POS; a Proxy element routes the write
@@ -3288,6 +3306,26 @@ impl Interpreter {
     /// assign so that a write to a container-valued bound element
     /// (`%h<key><inner> = ...` where `%h<key>` is a cell) mutates the shared,
     /// held container in place instead of being silently dropped.
+    /// A freshly autovivified intermediate container, ready to be stored INTO
+    /// an element slot of its parent.
+    ///
+    /// ADR-0040: an element of a real `Array`/`Hash` is a `Scalar` container,
+    /// and that holds for a container mutsu vivified on the way down a chained
+    /// subscript just as much as for one the program assigned — raku renders
+    /// `my %h; %h<a><b>[2] = "z"; %h<a><b>.raku` as `$[Any, Any, "z"]`, and
+    /// counts it as ONE item in list context. Itemizing an `Array` only flips
+    /// its `ArrayKind` tag (a `Hash`, a bool on the repr), so the shared
+    /// backing `Gc` — and therefore the `&mut` the caller takes into the slot
+    /// to keep descending — is untouched.
+    fn fresh_autoviv_container(positional: bool) -> Value {
+        let fresh = if positional {
+            Value::real_array(Vec::new())
+        } else {
+            Value::hash(std::collections::HashMap::new())
+        };
+        fresh.itemize_for_element_store()
+    }
+
     pub(super) fn assign_into_nested_container(
         target: &mut Value,
         outer_key: &str,
@@ -3501,6 +3539,19 @@ impl Interpreter {
         let bind_cell: Option<crate::gc::Gc<crate::value::ContainerCell>> = bind_source
             .as_ref()
             .map(|_| crate::gc::Gc::new(crate::value::ContainerCell::new(val.clone())));
+        // ADR-0040 slice 4: the leaf of a 3+-level chain is an element store
+        // like any other (see the two-level op's hook above). A `:=` bind keeps
+        // its bare source value, and a slice/junction innermost subscript is
+        // split per element by the store sites below.
+        let val = if bind_cell.is_some()
+            || matches!(
+                indices_val[0].view(),
+                ValueView::Junction { .. } | ValueView::Array(..)
+            ) {
+            val
+        } else {
+            val.itemize_for_element_store()
+        };
 
         // Extract positional flags from constant
         let flags_val = code.constants[positional_flags_idx as usize].clone();
@@ -3573,11 +3624,7 @@ impl Interpreter {
                                         | ValueView::ContainerRef(..)
                                 );
                                 if needs_viv {
-                                    arr[i] = if next_positional {
-                                        Value::real_array(Vec::new())
-                                    } else {
-                                        Value::hash(std::collections::HashMap::new())
-                                    };
+                                    arr[i] = Self::fresh_autoviv_container(next_positional);
                                 }
                                 Ok(&mut arr[i] as *mut Value)
                             } else {
@@ -3589,12 +3636,10 @@ impl Interpreter {
                     } else if let Some(next) = cur.with_hash_mut(|hash_arc| {
                         let hash = crate::value::gc_data_mut(hash_arc);
                         if !hash.contains_key(key.as_str()) {
-                            let new_val = if next_positional {
-                                Value::real_array(Vec::new())
-                            } else {
-                                Value::hash(std::collections::HashMap::new())
-                            };
-                            hash.insert(key.clone(), new_val);
+                            hash.insert(
+                                key.clone(),
+                                Self::fresh_autoviv_container(next_positional),
+                            );
                         }
                         hash.get_mut(key.as_str()).unwrap() as *mut Value
                     }) {
@@ -3616,11 +3661,7 @@ impl Interpreter {
                                         i + 1,
                                         Value::package(Symbol::intern("Any")),
                                     )?;
-                                    arr[i] = if next_positional {
-                                        Value::real_array(Vec::new())
-                                    } else {
-                                        Value::hash(std::collections::HashMap::new())
-                                    };
+                                    arr[i] = Self::fresh_autoviv_container(next_positional);
                                     Ok(&mut arr[i] as *mut Value)
                                 } else {
                                     Ok(current)
@@ -3630,12 +3671,10 @@ impl Interpreter {
                             current = next?;
                         } else if let Some(next) = cur.with_hash_mut(|hash_arc| {
                             let hash = crate::value::gc_data_mut(hash_arc);
-                            let new_val = if next_positional {
-                                Value::real_array(Vec::new())
-                            } else {
-                                Value::hash(std::collections::HashMap::new())
-                            };
-                            hash.insert(key.clone(), new_val);
+                            hash.insert(
+                                key.clone(),
+                                Self::fresh_autoviv_container(next_positional),
+                            );
                             hash.get_mut(key.as_str()).unwrap() as *mut Value
                         }) {
                             current = next;

--- a/t/element-store-itemization.t
+++ b/t/element-store-itemization.t
@@ -636,4 +636,97 @@ is @c.raku, '[["a", "b"], ["c", "d"]]', 'row 25: @c.raku stays bare (invariant)'
     is @real.VAR.name, '@real', 'slice 3: the array own .VAR.name is unchanged';
 }
 
+# === Slice 4: chained-subscript and deferred-vivification stores
+# (ADR-0040 SS4 slice 4) ===
+#
+# Slice 1 hooked the single-level element assign and recorded that "deeper
+# (3+-level) chained assignment was not separately audited". It was not
+# covered -- and neither was the LEAF of a TWO-level chain, nor the
+# intermediate a deferred vivification token walk-creates. All three stored
+# bare, and the render-side compensator (`raku_hash_value`) hid it for
+# `%h.raku` while every other reader disagreed: exactly SS1.5's "one value,
+# three answers" shape, still alive one level down. Every expectation below is
+# dual-oracled against `raku`.
+
+# The value assigned through a chained subscript is an element store.
+{
+    my %h1; %h1<a><b> = [1, 2];
+    is %h1<a><b>.raku, '$[1, 2]', 'slice 4: two-level hash chain leaf is itemized';
+    is takes(%h1<a><b>), 1, 'slice 4: two-level hash chain leaf is one item';
+    my @a1; @a1[0][1] = [1, 2];
+    is @a1[0][1].raku, '$[1, 2]', 'slice 4: two-level array chain leaf is itemized';
+    my %h2; %h2<a><b><c> = [1, 2];
+    is %h2<a><b><c>.raku, '$[1, 2]', 'slice 4: three-level hash chain leaf is itemized';
+    my @a2; @a2[0][1][2] = [1, 2];
+    is @a2[0][1][2].raku, '$[1, 2]', 'slice 4: three-level array chain leaf is itemized';
+    my %h3; %h3<a>[0] = (1, 2);
+    is %h3<a>[0].raku, '$(1, 2)', 'slice 4: a List leaf through a mixed chain is itemized';
+    my @a3; @a3[0]<k> = [1, 2];
+    is @a3[0]<k>.raku, '$[1, 2]', 'slice 4: an array-then-hash chain leaf is itemized';
+}
+
+# The container mutsu autovivifies on the way down the chain is itself a
+# stored element, so it itemizes too.
+{
+    my %h4; %h4<a><b><c> = 1;
+    is %h4<a><b>.raku, '${:c(1)}', 'slice 4: a 3-level autovivified hash is itemized';
+    my @a4; @a4[0][1][2] = 7;
+    is @a4[0][1].raku, '$[Any, Any, 7]', 'slice 4: a 3-level autovivified array is itemized';
+    is takes(@a4[0][1]), 1, 'slice 4: a 3-level autovivified array is one item';
+    my %h5; %h5<a><b>[2] = 'z';
+    is %h5<a><b>.raku, '$[Any, Any, "z"]', 'slice 4: hash-hash-array autovivification';
+    my %h6; %h6<a>[0]<k> = 5;
+    is %h6<a>.raku, '$[{:k(5)},]', 'slice 4: hash-array-hash autovivification';
+    is %h6<a>[0].VAR.^name, 'Scalar', 'slice 4: a chained element reflects as a Scalar';
+}
+
+# A deferred vivification token (`my $r := %h<a><b>`) walk-creates the same
+# intermediates at the first write, through a different mechanism.
+{
+    my %d1; my $r1 := %d1<a><b>; $r1 = 'x';
+    is %d1<a>.raku, '${:b("x")}', 'slice 4: deferred 2-level walk-create is itemized';
+    my %d2; my $r2 := %d2<a><b><c>; $r2 = 'x';
+    is %d2<a><b>.raku, '${:c("x")}', 'slice 4: deferred 3-level walk-create is itemized';
+    my %d3; my $r3 := %d3<a>[1]; $r3 = 'x';
+    is %d3<a>.raku, '$[Any, "x"]', 'slice 4: deferred hash-array walk-create is itemized';
+    my @d4; my $r4 := @d4[0][1]; $r4 = 'x';
+    is @d4[0].raku, '$[Any, "x"]', 'slice 4: deferred array-array walk-create is itemized';
+    my %d5; my $r5 := %d5<a><b>; $r5 = 'x';
+    is %d5.raku, '{:a(${:b("x")})}', 'slice 4: the deferred whole-hash render is unchanged';
+}
+
+# A `:=` through a chain binds the source container: the element renders
+# itemized while the source read directly stays bare, and writes still go
+# through -- the same representation slice 1 chose for `@a.push(@b)`.
+{
+    my @s1 = 1, 2;
+    my %b1; %b1<a><b> := @s1;
+    is %b1<a><b>.raku, '$[1, 2]', 'slice 4: a two-level bound chain element is itemized';
+    @s1.push(3);
+    is %b1<a><b>.raku, '$[1, 2, 3]', 'slice 4: the two-level bind still writes through';
+    is @s1.raku, '[1, 2, 3]', 'slice 4: the bind source read directly stays bare';
+    # A 3+-level bind installs a shared `ContainerRef` cell instead of a value,
+    # and wrapping THAT in a `Scalar` (slice 1's `@a.push(@b)` shape) breaks the
+    # write path, which does not yet see through a `Scalar`-wrapped cell. Left
+    # bare and recorded in ADR-0040 SS8; the write-through is what must not move.
+    my @s2 = 4, 5;
+    my %b2; %b2<a><b><c> := @s2;
+    @s2.push(6);
+    is %b2<a><b><c>.elems, 3, 'slice 4: a three-level bind still writes through';
+}
+
+# The invariants: a container's OWN .raku still de-itemizes its elements
+# (row 25), the chain's arity is unchanged, and the assignment expression
+# yields the (itemized) container.
+{
+    my %h7; %h7<a><b><c> = 1;
+    is %h7.raku, '{:a(${:b(${:c(1)})})}', 'slice 4: %h.raku is unchanged (invariant)';
+    my @a7; @a7[0][1][2] = 7;
+    is @a7.raku, '[[Any, [Any, Any, 7]],]', 'slice 4: @a.raku is unchanged (invariant)';
+    my %h8;
+    my $r = (%h8<a><b> = [1, 2]);
+    is $r.raku, '$[1, 2]', 'slice 4: the chained-assign expression value is itemized';
+    is takes($r), 1, 'slice 4: the chained-assign expression value is one item';
+}
+
 done-testing;

--- a/todo/tickets/native-hash-construction-bypasses-element-itemization.md
+++ b/todo/tickets/native-hash-construction-bypasses-element-itemization.md
@@ -1,0 +1,65 @@
+# Natively constructed hashes bypass ADR-0040's element itemization
+
+A `Hash` that a native Rust builtin builds directly — rather than one a Raku
+program assigns or a literal constructs — stores its values **bare**, because
+none of ADR-0040's store hooks are on that path. Two compensators
+(`itemize_hash_value` on the hash-subscript read, `raku_hash_value` in the
+renderer) still paper over it, which is the only thing keeping ADR-0040 slice 4
+from deleting them.
+
+## Measured (2026-09-01, whole corpus, instrumented)
+
+Both compensator sites were instrumented behind `MUTSU_COMP_PROBE` and the
+entire `t/` suite (3601 files) plus the full roast whitelist (1425 files) were
+run. After slice 4's chained-subscript store fix
+(`news/2026-09/adr0040-slice4-chained-subscript-store.md`):
+
+- `raku_hash_value` (render side): **0** firings in `t/`, 1 in roast — a
+  self-referential hash, where what gets rendered is the cycle sentinel
+  (`:__mutsu_self_hash_ref`) rather than a stored container. That one is
+  arguably not this ticket.
+- `itemize_hash_value` (read side): 3 in `t/`, 17 in roast, and **every one is a
+  natively constructed hash**:
+
+| source | firings | value |
+| --- | --- | --- |
+| Pod block `.config` (`roast/S26-documentation/09-configuration.t`) | 12 | `(1, "b c", 2.3e0, Bool::True, Bool::False)` |
+| `gethost(…)<addrs>` (`t/os-functions.t`) | 1 | `("127.0.0.1",)` |
+| an exception group hash (`t/exceptions-comp-group-unknown-parent.t`) | 1 | `("Exception",)` |
+| a `Proc`-shaped hash | 1 | `("…/mutsu", "-e", " ")` |
+| others | 4 | `("uc",)`, `()` |
+
+## Why it matters
+
+It is the same class slice 2 already hit once and fixed by hand: mutsu's native
+`JSON::Fast` provider built `Hash`/`Array` directly and so bypassed every hook,
+which slice 2 patched at `Parser::finish_object` / `finish_array`
+(`src/runtime/json.rs`). Pod `.config`, `gethost` and their siblings are the
+rest of the same set.
+
+The user-visible consequence is the ADR's own "one value, three answers" shape:
+the compensators cover the hash-subscript read and the whole-hash render, but
+not `.values`, `.pairs`, `.kv`, `.head`, a slice, or iteration — so those
+readers disagree with `%h<k>` about the same value.
+
+## What to do
+
+Enumerate the native hash-construction sites and route their values through
+`hash_stored_value` (the slice-2 helper, `decay_nil_hash_value` composed with
+`itemize_for_element_store`), then delete both compensators and re-run the
+instrumented sweep to confirm zero firings. `ArrayData`-building native sites
+need the same treatment for the array half.
+
+Start from the four named above; the instrumented sweep is the way to find the
+rest (see the ADR's slice-4 section for the recipe, including the trap that
+`raku_hash_value` has a second, non-compensator caller that must not be probed).
+
+## Repro
+
+```
+my %h = a => (1,2);  say %h<a>.raku;   # $(1, 2)  -- assigned, itemized
+# a Pod block's .config, or gethost("127.0.0.1")<addrs>, stores the same shape bare
+```
+
+Related: `docs/adr/0040-array-hash-elements-are-itemized-at-the-store.md` §8
+(slice 2's JSON note, and slice 4's measurement table).


### PR DESCRIPTION
ADR-0040 slice 4 was scoped as *"delete the two compensators, now that slices 1-2 make them redundant"*. They were not redundant, and the reason was **a bug rather than a leftover**.

## How it was found

Instrumenting both compensator sites behind an env var and running the whole corpus. The ADR's own 25-row divergence matrix could not find it — every row uses exactly **one** subscript level.

Slice 1's implementation note had already flagged the shape: *"deeper (3+-level) chained assignment was not separately audited"*. It was not covered — and neither was the **leaf of a two-level chain**, nor the intermediate container a **deferred vivification token** walk-creates.

| program | raku | mutsu (before) |
| --- | --- | --- |
| `my %h; %h<a><b> = [1,2]; %h<a><b>.raku` | `$[1, 2]` | `[1, 2]` |
| `takes(%h<a><b>)` | `1` | `2` |
| `my %d; %d<a><b>[2] = "z"; %d<a><b>.raku` | `$[Any, Any, "z"]` | `[Any, Any, "z"]` |
| `my @g; @g[0][1][2] = 7; takes(@g[0][1])` | `1` | `3` |
| `my %h; %h<a>[0]<k> = 5; %h<a>.raku` | `$[{:k(5)},]` | `[{:k(5)},]` |
| `my %h; my $r := %h<a>[1]; $r = "x"; %h<a>.raku` | `$[Any, "x"]` | `[Any, "x"]` |

The render-side compensator made `%h.raku` look right while `%h<a><b>.raku`, `.VAR` and list-context arity were all wrong — ADR-0040 §1.5's *"one value, three answers"* shape, alive one level down.

## The fix — four sites, all "a value entering a parent's element slot"

- **`exec_index_assign_expr_nested_op`** (two-level): the leaf value, hooked once after the junction/slice arm, mirroring slice 1's hook at the single-level op's entry.
- **`exec_index_assign_deep_nested_op`** (3+): the same hook for the leaf, plus a new `Interpreter::fresh_autoviv_container` for the four intermediate-vivification sites (two array arms, two hash arms, first attempt and retry).
- **`fresh_level_for`** (`src/value/entry_path.rs`): the container a deferred vivification token walk-creates — a different mechanism reaching the same slot.
- **An itemized-`Hash` arm for `.VAR`** (`methods_call_dispatch.rs`). An itemized `Hash` carries its itemization as a bool on the repr rather than as an `ArrayKind`, so the existing itemized-`Array` arm did not cover it and `%g<a>[0].VAR.^name` answered `Hash`.

Itemizing an `Array` only flips its kind tag, so the `&mut` the walk takes into the slot to keep descending is unaffected.

`:=` through a **two-level** chain now matches raku too: the element renders `$[1, 2]`, the source read directly stays bare, and a later push still shows through. A **3+-level** bind installs a shared `ContainerRef` cell rather than a value, and wrapping *that* in a `Scalar` (slice 1's `@a.push(@b)` shape) **breaks the write path**, which does not yet see through a `Scalar`-wrapped cell — `t/deep-element-bind-writeback-coherence.t` and `t/element-bind-cell.t` caught it. Left bare deliberately; the write-through is pinned instead.

## The compensators: measured, not deleted

Both sites instrumented, entire corpus run — `t/` (3601 files) and the full roast whitelist (1425 files):

| compensator | before | after | what still reaches it |
| --- | --- | --- | --- |
| render-side (`raku_hash_value`, 3 Hash/Map sites) | 22 in `t/` | **0 in `t/`**, 1 in roast | a self-referential hash, where what is rendered is the cycle sentinel |
| read-side (`itemize_hash_value`) | 3 in `t/` | 3 in `t/`, 17 in roast | **natively constructed hashes only** — Pod block `.config` (12 of 17), `gethost(…)<addrs>`, two exception/`Proc` hashes |

That is the same class slice 2 already hit once and fixed by hand for the JSON decoder: a `Hash` a native Rust builtin builds directly bypasses every store hook. Filed as `todo/tickets/native-hash-construction-bypasses-element-itemization.md`. Deleting either compensator before those are routed through the itemizing store would turn 20 measured firings into 20 wrong answers.

## A note on the instrumentation, since it nearly produced a false conclusion

A first pass counted **57** firings of `raku_hash_value` and looked like proof the compensator was load-bearing everywhere. It was not: that function has two callers with opposite roles — the three Hash/Map rendering sites (the compensator) and the `ValueView::Scalar` arm, which is the **primary** `$(…)` renderer for every itemized value. Probing only the compensator's own call sites dropped the count to 22, and made all 22 real.

## Verification

- `cargo fmt --check` and `cargo clippy -- -D warnings` clean.
- `t/element-store-itemization.t` 149 → **175** assertions, matching `raku` line for line: the chained-leaf shapes (two- and three-level, hash, array, both mixed orders), the autovivified intermediates, the deferred walk-create shapes, the two-level bind's itemization *and* write-through, the 3+-level bind's write-through, and the invariants (`%h.raku` / `@a.raku` unchanged, chain arity unchanged, the assignment expression's own value itemized).
- Full local `t/` suite: **3601 files, 36214 tests, PASS**.
- Full roast whitelist on a release build: **1425 files, PASS** (the 3 encode-decode/indent files that need `scripts/run-roast-test.sh`'s path setup were re-run through it and pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
