### PR TITLE
fix: `.VAR` on a slice, and on a container with `is default(...)`

### DIFF
--- a/news/2026-09/var-on-a-subscript-slice-and-is-default.md
+++ b/news/2026-09/var-on-a-subscript-slice-and-is-default.md
@@ -1,0 +1,61 @@
+# `.VAR` on a slice, and on a container with `is default(...)`
+
+ADR-0040 slice 3 established the model for `.VAR` on a subscript: which of the
+element's *container* and the element *itself* you get is decided by the source
+container. Two shapes that model did not reach are fixed here, both split out of
+`todo/deep/var-on-a-real-element-is-an-opaque-descriptor-not-the-container.md`.
+
+## A slice hands back a `List`, not an element
+
+```
+raku  -e 'my @a = 1,2; say @a[0,1].VAR.^name'   # List
+mutsu -e 'my @a = 1,2; say @a[0,1].VAR.^name'   # Scalar  (before)
+```
+
+In raku a slice subscript hands back a `List` of containers, and `.VAR` on a
+`List` is identity — so the answer is `List`. mutsu routed *every* named-container
+subscript to the element-descriptor path, slices included.
+
+The runtime cannot tell the difference: mutsu's elements are not real containers,
+so a slice's `List` result is indistinguishable from an element that happens to
+hold a `List`. The compiler is the only place that knows, so the fix is a
+compile-side gate (`Compiler::index_expr_is_slice`) on the statically
+recognizable slice spellings — a comma list (`@a[0,1]`, `%h<a b>`), a range
+(`@a[0..1]`, `@a[^2]`), and an `@`-sigiled index (`@a[@i]`). Those compile as
+ordinary subscripts and let `.VAR`'s normal dispatch answer.
+
+An index whose *runtime* value happens to be a list (`my $i = (0,1); @a[$i]`)
+still takes the element path. The compiler cannot see that — and neither can the
+runtime, which is the whole reason the gate lives in the compiler.
+
+## `is default(...)` is a property of the container
+
+```
+raku  -e 'my @a is default(0) = 1,2; say @a[0].VAR.default'   # 0
+mutsu -e 'my @a is default(0) = 1,2; say @a[0].VAR.default'   # (Any)  (before)
+```
+
+`builtin_index_var_meta` built the descriptor's `default` from the *variable's
+declared type*, which never sees the `is default(...)` trait — that lives on the
+container (`ArrayData::default` / `HashData::default`, already read by
+`typed_container_default` for missing-key reads). It consults the container
+first now, and falls back to the declared element type, else `Any`. Arrays and
+hashes both.
+
+## Verification
+
+`t/var-on-subscript.t` pins sixteen assertions and its output is byte-identical
+to `raku` v2026.07's: the five slice spellings, the single-element shapes that
+must not move (a literal index, a `$` variable index, a `*-1` Whatever index,
+and `.VAR.name` still naming the container), and the three default cases
+(`is default`, a typed array, an untyped array/hash).
+
+## Still open in the parent ticket
+
+Native arrays (`@ints[0].VAR.^name` is `IntPosRef` in raku — mutsu has no
+representation for a per-element-type positional ref) and nested subscripts
+(`@sh[0;0]`, `%d<a><b>`), which turned out to be bigger than the parent ticket's
+note said: raku answers `Scalar` / name `element` / default `(Any)` uniformly for
+every nested element, and reaching that needs the *parent* container at runtime,
+which a nested subscript has no name for. The parent ticket now records the
+measurement and why it belongs with the descriptor rework.

--- a/src/compiler/expr.rs
+++ b/src/compiler/expr.rs
@@ -450,15 +450,20 @@ impl Compiler {
                 && args.is_empty()
                 && modifier.is_none()
                 && !quoted
-                && matches!(target.as_ref(), Expr::Index { target: it, .. }
-                    if Self::index_assign_target_name(it).is_some()) =>
+                && matches!(target.as_ref(), Expr::Index { target: it, index, .. }
+                    if Self::index_assign_target_name(it).is_some()
+                        && !Self::index_expr_is_slice(index)) =>
             {
                 // `.VAR` on `@a[0]` / `%h<k>` (a *named* container's element) needs
                 // the element-variable metadata path. A `.VAR` on a subscript of a
                 // literal (`[1,2,3][1].VAR`) has no named source, so it falls
                 // through to the general method dispatch below — otherwise the
                 // special path emitted no value and the next chained method
-                // (`.VAR.^name`) underflowed the stack.
+                // (`.VAR.^name`) underflowed the stack. A *slice* subscript
+                // (`@a[0,1]`, `%h<a b>`, `@a[0..1]`) falls through too: raku
+                // hands back a `List` of containers there and `.VAR` on a `List`
+                // is identity, so the element-descriptor path would answer
+                // `Scalar` where raku says `List`.
                 self.compile_expr_method_var_on_index(target);
             }
             // `$m.return-rw` is the method spelling of `return-rw $m`: the

--- a/src/compiler/expr_method.rs
+++ b/src/compiler/expr_method.rs
@@ -3,6 +3,38 @@ use crate::symbol::Symbol;
 use crate::value::ValueView;
 
 impl Compiler {
+    /// Is this subscript's index a *slice* rather than a single element?
+    ///
+    /// raku answers `.VAR` from the subscript's result: `@a[0]` hands back the
+    /// element's `Scalar` container, while `@a[0,1]` hands back a `List` of
+    /// containers, and `.VAR` on a `List` is identity — so `@a[0,1].VAR.^name`
+    /// is `List`, not `Scalar`. mutsu's elements are not real containers, so
+    /// the runtime cannot tell a slice's `List` from an element that happens to
+    /// hold one; the compiler is the only place that knows, and this is that
+    /// gate. A slice compiles as an ordinary subscript and lets `.VAR`'s normal
+    /// dispatch (identity on a `List`) answer.
+    ///
+    /// Only the statically-recognizable slice spellings are covered:
+    /// `@a[0,1]` / `%h<a b>` (an `ArrayLiteral` index — a single `<a>`
+    /// collapses to a `Literal`, so it is not caught here), a range
+    /// (`@a[0..1]`, `@a[^2]`), and an `@`-sigiled index (`@a[@idx]`). An index
+    /// whose *runtime* value happens to be a list (`my $i = (0,1); @a[$i]`)
+    /// still takes the element path — the compiler cannot see that, and it is
+    /// the same information the runtime lacks.
+    pub(super) fn index_expr_is_slice(index: &Expr) -> bool {
+        match index {
+            Expr::ArrayLiteral(_) | Expr::ArrayVar(_) => true,
+            Expr::Binary { op, .. } => matches!(
+                op,
+                TokenKind::DotDot
+                    | TokenKind::DotDotCaret
+                    | TokenKind::CaretDotDot
+                    | TokenKind::CaretDotDotCaret
+            ),
+            _ => false,
+        }
+    }
+
     /// Compile method call on indexed target: .VAR on @a[0] / %h<k>
     pub(super) fn compile_expr_method_var_on_index(&mut self, target: &Expr) {
         if let Expr::Index {

--- a/src/runtime/builtins.rs
+++ b/src/runtime/builtins.rs
@@ -183,11 +183,22 @@ impl Interpreter {
             "dynamic".to_string(),
             Value::truth(self.is_var_dynamic(&source_name)),
         );
-        let default_val = if let Some(tc) = self.var_type_constraint(&source_name) {
-            Value::package(Symbol::intern(&tc))
-        } else {
-            Value::package(Symbol::intern("Any"))
-        };
+        // An element's default is its *container's* `is default(...)` when the
+        // container has one — that is a property of the container, not of the
+        // variable's declared type, so the type-constraint fallback below never
+        // saw it (`my @a is default(0) = 1,2; @a[0].VAR.default` is `0` in raku,
+        // and the same for a hash).
+        let default_val = self
+            .env
+            .get(&source_name)
+            .and_then(|c| self.container_default(c))
+            .unwrap_or_else(|| {
+                if let Some(tc) = self.var_type_constraint(&source_name) {
+                    Value::package(Symbol::intern(&tc))
+                } else {
+                    Value::package(Symbol::intern("Any"))
+                }
+            });
         attributes.insert("default".to_string(), default_val);
         Ok(Value::make_instance(Symbol::intern("Scalar"), attributes))
     }

--- a/t/var-on-subscript.t
+++ b/t/var-on-subscript.t
@@ -1,0 +1,55 @@
+use v6;
+use Test;
+
+# `.VAR` on a subscript. ADR-0040 slice 3 established the model: which of the
+# element's container / the element itself you get is decided by the SOURCE
+# container. These are the two shapes that model did not reach — a slice, and a
+# container carrying `is default(...)`. Every expectation is `raku` v2026.07's.
+
+plan 16;
+
+# --- a slice hands back a List of containers, and `.VAR` on a List is identity
+{
+    my @a = 1, 2;
+    is @a[0, 1].VAR.^name, 'List', 'a comma slice answers List, not Scalar';
+    is @a[0 .. 1].VAR.^name, 'List', 'a range slice too';
+    is @a[^2].VAR.^name, 'List', '...including the `^n` spelling';
+    is @a[0, 1].VAR.raku, '(1, 2)', 'and the slice VAR is the slice itself';
+    my @i = 0, 1;
+    is @a[@i].VAR.^name, 'List', 'an @-sigiled index is a slice too';
+}
+{
+    my %h = a => 1, b => 2;
+    is %h<a b>.VAR.^name, 'List', 'a multi-word <> slice answers List';
+}
+
+# --- the single-element path must NOT move -------------------------------
+{
+    my @a = 1, 2;
+    my %h = a => 1;
+    is @a[0].VAR.^name, 'Scalar', 'a single positional subscript still answers Scalar';
+    is %h<a>.VAR.^name, 'Scalar', 'a single <> subscript too (it is not a slice)';
+    is @a[0].VAR.name, '@a', '...and still names the container it lives in';
+    my $i = 1;
+    is @a[$i].VAR.^name, 'Scalar', 'a variable index is a single element';
+    is @a[*-1].VAR.^name, 'Scalar', 'so is a Whatever index';
+}
+
+# --- `is default(...)` is a property of the container, so the element reports it
+{
+    my @nat is default(0) = 1, 2;
+    is @nat[0].VAR.default, 0, 'an array element reports the container is-default';
+    my %hd is default(5) = a => 1;
+    is %hd<a>.VAR.default, 5, 'a hash element reports it too';
+}
+{
+    # ...and without the trait, the declared element type, else Any.
+    my @a = 1, 2;
+    is @a[0].VAR.default.gist, '(Any)', 'an untyped array element defaults to Any';
+    my Int @t = 1, 2;
+    is @t[0].VAR.default.gist, '(Int)', 'a typed array element defaults to its type';
+    my %p = a => 1;
+    is %p<a>.VAR.default.gist, '(Any)', 'an untyped hash element defaults to Any';
+}
+
+done-testing;

--- a/todo/deep/var-on-a-real-element-is-an-opaque-descriptor-not-the-container.md
+++ b/todo/deep/var-on-a-real-element-is-an-opaque-descriptor-not-the-container.md
@@ -41,29 +41,54 @@ returned by `array_slot_ref` cannot answer them on its own. Whatever replaces
 `builtin_index_var_meta` (`src/runtime/builtins.rs`) has to carry both — which
 is a representation decision, i.e. an ADR-shaped question, not a patch.
 
-## Three smaller siblings found in the same measurement
+## The smaller siblings found in the same measurement
 
-These are independent and could each be a ticket:
+Two of the four are **fixed** (2026-09-02,
+`news/2026-09/var-on-a-subscript-slice-and-is-default.md`, pinned by
+`t/var-on-subscript.t`):
 
-- **Multi-dim subscript.** `my @sh[2;2]; @sh[0;0].VAR.^name` is `Scalar` in
-  raku, `Array` in mutsu — the `@a[i;j]` subscript never reaches
-  `compile_expr_method_var_on_index` (`src/compiler/expr_method.rs`), so the
-  element-`.VAR` path is not entered at all.
-- **`is default`.** `my @nat is default(0) = 1,2; @nat[0].VAR.default` is `0`
-  in raku, `(Any)` in mutsu — `builtin_index_var_meta` reads
-  `var_type_constraint` for the default but never the variable's `is default`
-  trait.
+- ~~**`is default`.**~~ `builtin_index_var_meta` consults the container's
+  `is default(...)` before falling back to the declared element type.
+- ~~**Slice subscripts.**~~ The compiler gates the element-descriptor path on
+  `Compiler::index_expr_is_slice`, so `@a[0,1]` / `%h<a b>` / `@a[0..1]` /
+  `@a[^2]` / `@a[@i]` compile as ordinary subscripts and `.VAR`'s normal
+  identity-on-a-`List` dispatch answers. An index whose *runtime* value happens
+  to be a list (`my $i = (0,1); @a[$i]`) still takes the element path — the
+  compiler cannot see that, and neither can the runtime.
+
+Two remain:
+
 - **Native arrays.** `my int @ints = 1,2; @ints[0].VAR.^name` is `IntPosRef`
   in raku, `Scalar` in mutsu. A native array's element "container" is a
   positional ref type per element type (`IntPosRef`/`NumPosRef`/…), which mutsu
-  has no representation for.
-- **Slice subscripts.** `my @a = 1,2; @a[0,1].VAR.^name` is `List` in raku
-  (a slice hands back a `List` of containers, and `.VAR` on a `List` is
-  identity), `Scalar` in mutsu -- `compile_expr_method_var_on_index` routes
-  every subscript to the element-descriptor path, slices included, and a
-  slice's `List` result is indistinguishable at runtime from an element that
-  happens to hold a `List`. The compiler is the only place that knows, so this
-  one is a compile-side gate rather than part of the descriptor rework.
+  has no representation for. (`@ints[0].VAR.default` is `Nil` in raku, `(int)`
+  in mutsu — the same gap.)
+- **Multi-dim and chained subscripts** — bigger than the original note said.
+  Re-measured 2026-09-02:
+
+  | program | raku | mutsu |
+  | --- | --- | --- |
+  | `my @sh[2;2]; @sh[0;0].VAR.^name` | `Scalar` | `Any` |
+  | `@sh[0;0].VAR.name` | `element` | `Nil` |
+  | `my %d; %d<a><b>=1; %d<a><b>.VAR.^name` | `Scalar` | `Int` |
+  | `%d<a><b>.VAR.name` | `element` | `Nil` |
+  | `my @g; @g[0][1]=2; @g[0][1].VAR.name` | `element` | `Nil` |
+
+  raku's answer is **uniform** for every nested element: `Scalar` / name
+  `element` / default `(Any)` / dynamic `False` — the inner container is
+  anonymous, so `.VAR.name` is NOT the outer variable's name even when the
+  outer variable is named (`@sh[0;0]` is `element`, not `@sh`).
+
+  It is not a compiler-routing patch, which is why it did not ship with the two
+  above. `MultiDimIndex` and a chained `Index` have no `index_assign_target_name`
+  to hand `__mutsu_index_var_meta`, and the builtin's whole job is to decide
+  from the *source container* whether the element is a container — for a nested
+  subscript that source is the intermediate value (`%d<a>`), which is not in
+  the environment under any name. Handing it over would mean compiling the
+  parent subscript a second time, which is exactly the double evaluation slice
+  3 restructured the hook to avoid. So it belongs with the descriptor rework
+  below: whatever replaces `builtin_index_var_meta` has to be able to name the
+  parent container it came from.
 
 ## Repro
 


### PR DESCRIPTION
Two shapes ADR-0040 slice 3's `.VAR` model did not reach, split out of
`todo/deep/var-on-a-real-element-is-an-opaque-descriptor-not-the-container.md`.

## A slice hands back a `List`, not an element

```
raku  -e 'my @a = 1,2; say @a[0,1].VAR.^name'   # List
mutsu -e 'my @a = 1,2; say @a[0,1].VAR.^name'   # Scalar  (before)
```

In raku a slice subscript hands back a `List` of containers, and `.VAR` on a
`List` is identity. mutsu routed *every* named-container subscript to the
element-descriptor path, slices included.

The runtime cannot tell the difference — mutsu's elements are not real
containers, so a slice's `List` result is indistinguishable from an element
that happens to hold a `List`. The compiler is the only place that knows, so
the fix is a compile-side gate (`Compiler::index_expr_is_slice`) on the
statically recognizable slice spellings: a comma list (`@a[0,1]`, `%h<a b>`), a
range (`@a[0..1]`, `@a[^2]`), and an `@`-sigiled index (`@a[@i]`). Those compile
as ordinary subscripts and let `.VAR`'s normal dispatch answer.

An index whose *runtime* value happens to be a list (`my $i = (0,1); @a[$i]`)
still takes the element path. The compiler cannot see that — and neither can the
runtime, which is exactly why the gate belongs in the compiler.

## `is default(...)` is a property of the container

```
raku  -e 'my @a is default(0) = 1,2; say @a[0].VAR.default'   # 0
mutsu -e 'my @a is default(0) = 1,2; say @a[0].VAR.default'   # (Any)  (before)
```

`builtin_index_var_meta` built the descriptor's `default` from the *variable's
declared type*, which never sees the trait — it lives on the container
(`ArrayData::default` / `HashData::default`, already read by
`typed_container_default` for missing-key reads). It consults the container
first now, falling back to the declared element type, else `Any`. Arrays and
hashes both.

## What stays in the parent ticket

Native arrays (`@ints[0].VAR.^name` is `IntPosRef` in raku; mutsu has no
representation for a per-element-type positional ref) and nested subscripts —
and the nested one turned out **bigger than the ticket assumed**. Re-measured:
raku answers `Scalar` / name `element` / default `(Any)` uniformly for every
nested element, and `.VAR.name` is `element` even when the outer variable is
named (`@sh[0;0]`, not `@sh`). It is not a compiler-routing patch:
`MultiDimIndex` and a chained `Index` have no name to hand the builtin, and
deciding container-ness needs the *parent* container (`%d<a>`) at runtime, which
is not in the environment under any name — handing it over would mean compiling
the parent subscript twice, the double evaluation slice 3 restructured the hook
to avoid. The ticket now records that measurement.

## Verification

- `t/var-on-subscript.t`: 16 assertions, and the file's whole output is
  **byte-identical to `raku` v2026.07's** — the five slice spellings, the
  single-element shapes that must not move (a literal index, a `$` variable
  index, a `*-1` Whatever index, `.VAR.name` still naming the container), and
  the three default cases.
- `cargo fmt --check`, `cargo clippy -- -D warnings`, unit tests: clean.
- Full local `t/` suite: PASS (3603 files, 36321 tests).
- Full roast whitelist on a release build: PASS (1436 files, 218962 tests).
- `scripts/battery-testsuite.sh`: GATE PASSED (274/297).
