### PR TITLE
fix: match multi-character negated token classes

### DIFF
--- a/src/runtime/regex/regex_match_atom_simple.rs
+++ b/src/runtime/regex/regex_match_atom_simple.rs
@@ -5,6 +5,7 @@ use super::regex_helpers::{
     grapheme_end, is_word_char, matches_named_builtin,
 };
 use super::regex_ltm_rank::{LtmAtomMode, ltm_atom_mode};
+use crate::runtime::regex_parse::RegexParseMode;
 
 impl Interpreter {
     #[allow(dead_code)]
@@ -748,13 +749,12 @@ impl Interpreter {
                             // Fallback: try resolving as a grammar token in the current package.
                             // This runs once per character checked against the class, so use the
                             // cheap STATIC resolver (pattern extracted straight from the token def)
-                            // rather than the heavy `with_args` path, which builds a fresh scratch
-                            // `Interpreter` per call — catastrophic here (profiled ~20% of a grammar
-                            // parse: `token name { <-restricted>+ }` resolved `restricted` per char).
+                            // rather than the heavy `with_args` path. Match against the remaining
+                            // input, not a one-character scratch string: a token excluded from a
+                            // class may itself consume multiple characters.
                             // A non-literal token body is not statically extractable, so fall back to
                             // evaluating it (empty args) only when the static resolver finds nothing.
                             if !pkg.is_empty() {
-                                let char_str = effective_c.to_string();
                                 let mut candidates =
                                     self.resolve_token_patterns_static_in_pkg(n, pkg);
                                 if candidates.is_empty() {
@@ -763,10 +763,13 @@ impl Interpreter {
                                 }
                                 for (sub_pat, sub_pkg, _sym_key) in &candidates {
                                     if self
-                                        .regex_match_len_at_start_in_pkg(
-                                            sub_pat, &char_str, sub_pkg,
-                                        )
-                                        .is_some_and(|len| len > 0)
+                                        .parse_regex_uncached(sub_pat, RegexParseMode::Match)
+                                        .and_then(|pattern| {
+                                            self.regex_match_end_from_caps_in_pkg(
+                                                &pattern, chars, pos, sub_pkg,
+                                            )
+                                        })
+                                        .is_some_and(|(end, _)| end > pos)
                                     {
                                         return true;
                                     }

--- a/t/regex-negated-token-class-multichar.t
+++ b/t/regex-negated-token-class-multichar.t
@@ -1,0 +1,28 @@
+use Test;
+
+plan 4;
+
+# A grammar token used as a negative character-class item may consume more
+# than one character.  The exclusion must be checked against the full input,
+# not against a one-character scratch string.
+grammar Quoted {
+    token TOP { '"""' <body>+ '"""' }
+    token body { <-delimiter> }
+    token delimiter { '"""' }
+}
+
+ok Quoted.parse('"""x"""').defined,
+    'a negated multi-character token leaves the closing delimiter for its caller';
+nok Quoted.parse('"""x"""tail').defined,
+    'the grammar still requires the closing delimiter at the end';
+
+grammar Mixed {
+    token TOP { <allowed>+ }
+    token allowed { <+[a..z] -stop> }
+    token stop { 'end' }
+}
+
+ok Mixed.parse('abc').defined,
+    'a positive class remains available with a negative multi-character token';
+nok Mixed.parse('abend').defined,
+    'a negative multi-character token excludes its complete sequence';


### PR DESCRIPTION
Fix negated grammar-token character classes to match candidates against the remaining input instead of a one-character scratch string. This lets a multi-character delimiter remain visible to its caller and restores Config::TOML document parsing.\n\nValidation:\n- cargo fmt --all\n- cargo clippy -- -D warnings\n- make test\n- make roast\n- Config::TOML t/grammar/04-document.rakutest