### PR TITLE
feat(rakuast): construct return type nodes

### DIFF
--- a/docs/adr/0011-rakuast-model-layer-and-phasing.md
+++ b/docs/adr/0011-rakuast-model-layer-and-phasing.md
@@ -234,6 +234,12 @@ earlier ones.
     constructor form like Rakudo, and lowers it to the existing `ParamDef.where_constraint` path
     through `EVAL`. Tests in `t/rakuast-construct-where.t`. Next: sub-signatures, type captures,
     array shapes, and signature constraints.
+  - **Slice 12 (signature return construction) — done (2026-09-02).** `Signature.new(:returns)`
+    now retains its return node, and `Trait::Returns.new($type)` / `Trait::Of.new($type)` build
+    the positional trait nodes already emitted by the converter. `Sub.new(:traits)` accepts those
+    return traits so hand-constructed signatures and traits can flow through the existing lowerer
+    and compiler under `EVAL`. Tests in `t/rakuast-construct-return-type.t` pass under both mutsu
+    and Rakudo.
 - **Phase 5 — EVAL / compilation.** `lower(RakuAstNode) -> Vec<Stmt>/Expr`, then the
   **existing** compiler. `EVAL($rakuast)` and any code that yields a RakuAST tree runs
   through this. No new execution engine.

--- a/news/2026-09/rakuast-return-constructors.md
+++ b/news/2026-09/rakuast-return-constructors.md
@@ -1,0 +1,16 @@
+# Construct RakuAST return types
+
+RakuAST construction now covers routine return-type nodes in addition to the
+read-side and lowering support that already existed:
+
+- `RakuAST::Signature.new(:parameters(()), :returns($type))` retains a
+  `Signature.returns` node.
+- `RakuAST::Trait::Returns.new($type)` and `RakuAST::Trait::Of.new($type)`
+  construct the positional trait forms emitted by `.AST`.
+- `RakuAST::Sub.new(:traits)` attaches those traits, allowing a hand-built
+  routine to pass through the existing RakuAST lowerer and compiler under
+  `EVAL`.
+
+The implementation keeps the model-layer representation unchanged and is
+pinned by `t/rakuast-construct-return-type.t`, which passes unchanged under
+both mutsu and Rakudo.

--- a/src/rakuast/mod.rs
+++ b/src/rakuast/mod.rs
@@ -539,8 +539,8 @@ pub fn node_gist(node: &RakuAstNode) -> String {
 /// Construction (Phase 4): build a `Value::RakuAst` from a `RakuAST::*.new(...)`
 /// / `.from-identifier(...)` call. Returns `Ok(None)` when the class/method is
 /// not a supported constructor yet (so normal dispatch handles it). Covers the
-/// single-positional-argument constructors: the literals (`.new`) and
-/// `Name.from-identifier`.
+/// single-positional-argument constructors such as literals, names, and
+/// return-type traits, plus the supported named-field constructors.
 pub fn construct(
     class_name: &str,
     method: &str,
@@ -585,6 +585,26 @@ pub fn construct(
         if let Some(value) = &signature {
             require_rakuast_class(value, RakuAstClass::Signature, "RakuAST::Sub.new")?;
         }
+        let traits = named_arg(args, "traits")
+            .map(|value| {
+                value.as_list_items().map(<[Value]>::to_vec).ok_or_else(|| {
+                    RuntimeError::new("RakuAST::Sub.new expects `traits` to be a list")
+                })
+            })
+            .transpose()?;
+        if let Some(traits) = &traits {
+            for trait_node in traits {
+                if !matches!(
+                    trait_node.view(),
+                    ValueView::RakuAst(node)
+                        if matches!(node.class, RakuAstClass::TraitReturns | RakuAstClass::TraitOf)
+                ) {
+                    return Err(RuntimeError::new(
+                        "RakuAST::Sub.new expects `traits` to contain return-type traits",
+                    ));
+                }
+            }
+        }
         let body = match named_arg(args, "body") {
             Some(value) => {
                 require_rakuast_class(&value, RakuAstClass::Blockoid, "RakuAST::Sub.new")?;
@@ -592,7 +612,7 @@ pub fn construct(
             }
             None => empty_blockoid(),
         };
-        let mut fields = Vec::with_capacity(3);
+        let mut fields = Vec::with_capacity(4);
         if let Some(name) = name {
             fields.push(RakuAstField {
                 name: Some("name"),
@@ -603,6 +623,12 @@ pub fn construct(
             fields.push(RakuAstField {
                 name: Some("signature"),
                 value: RakuAstFieldValue::Node(signature),
+            });
+        }
+        if let Some(traits) = traits {
+            fields.push(RakuAstField {
+                name: Some("traits"),
+                value: RakuAstFieldValue::List(traits),
             });
         }
         fields.push(RakuAstField {
@@ -626,12 +652,23 @@ pub fn construct(
         for parameter in &parameters {
             require_rakuast_class(parameter, RakuAstClass::Parameter, "RakuAST::Signature.new")?;
         }
+        let returns = named_arg(args, "returns");
+        if let Some(returns) = &returns {
+            require_any_rakuast(returns, "RakuAST::Signature.new", "returns")?;
+        }
+        let mut fields = vec![RakuAstField {
+            name: Some("parameters"),
+            value: RakuAstFieldValue::List(parameters),
+        }];
+        if let Some(returns) = returns {
+            fields.push(RakuAstField {
+                name: Some("returns"),
+                value: RakuAstFieldValue::Node(returns),
+            });
+        }
         return Ok(Some(Value::rakuast(Box::new(RakuAstNode {
             class: RakuAstClass::Signature,
-            fields: vec![RakuAstField {
-                name: Some("parameters"),
-                value: RakuAstFieldValue::List(parameters),
-            }],
+            fields,
         }))));
     }
     if class_name == "RakuAST::Parameter" && method == "new" {
@@ -898,6 +935,8 @@ fn single_positional_class(class_name: &str, method: &str) -> Option<RakuAstClas
         ("RakuAST::Initializer::Assign", "new") => RakuAstClass::InitializerAssign,
         ("RakuAST::Type::Simple", "new") => RakuAstClass::TypeSimple,
         ("RakuAST::Type::Setting", "new") => RakuAstClass::TypeSetting,
+        ("RakuAST::Trait::Returns", "new") => RakuAstClass::TraitReturns,
+        ("RakuAST::Trait::Of", "new") => RakuAstClass::TraitOf,
         _ => return None,
     })
 }
@@ -1047,6 +1086,8 @@ fn constructor_is_supported(class: RakuAstClass) -> bool {
             | RakuAstClass::Blockoid
             | RakuAstClass::Sub
             | RakuAstClass::Signature
+            | RakuAstClass::TraitReturns
+            | RakuAstClass::TraitOf
             | RakuAstClass::Parameter
             | RakuAstClass::ParameterTargetVar
             | RakuAstClass::VarDeclarationSimple

--- a/t/rakuast-construct-return-type.t
+++ b/t/rakuast-construct-return-type.t
@@ -1,0 +1,110 @@
+use v6;
+use experimental :rakuast;
+use MONKEY-SEE-NO-EVAL;
+use Test;
+
+# RakuAST construction of signature return types and return traits.
+# The resulting nodes must remain usable by the existing lowerer, not just
+# render like Rakudo's model.
+
+plan 19;
+
+my $type = RakuAST::Type::Simple.new(
+    RakuAST::Name.from-identifier('Int'),
+);
+
+my $signature = RakuAST::Signature.new(
+    parameters => (),
+    returns => $type,
+);
+isa-ok $signature, RakuAST::Signature,
+    'Signature.new constructs a signature with a return type';
+is $signature.returns, $type,
+    'Signature.returns exposes the constructed type node';
+is $signature.returns.name.gist, 'RakuAST::Name.from-identifier("Int")',
+    'the return type remains walkable';
+is $signature.gist, q:to/END/.chomp, 'Signature.gist renders returns like Rakudo';
+    RakuAST::Signature.new(
+      parameters => $( ),
+      returns    => RakuAST::Type::Simple.new(
+        RakuAST::Name.from-identifier("Int")
+      )
+    )
+    END
+my @signature-methods = RakuAST::Signature.^methods(:local)>>.name;
+ok 'new' (elem) @signature-methods && 'returns' (elem) @signature-methods,
+    'Signature introspection exposes its constructor and return accessor';
+
+my $returns-trait = RakuAST::Trait::Returns.new($type);
+isa-ok $returns-trait, RakuAST::Trait::Returns,
+    'Trait::Returns.new constructs a return trait';
+is $returns-trait.type, $type,
+    'Trait::Returns.type exposes the constructed type node';
+is $returns-trait.gist, q:to/END/.chomp, 'Trait::Returns.gist renders like Rakudo';
+    RakuAST::Trait::Returns.new(
+      RakuAST::Type::Simple.new(
+        RakuAST::Name.from-identifier("Int")
+      )
+    )
+    END
+
+my $of-trait = RakuAST::Trait::Of.new($type);
+isa-ok $of-trait, RakuAST::Trait::Of,
+    'Trait::Of.new constructs an of trait';
+is $of-trait.type, $type,
+    'Trait::Of.type exposes the constructed type node';
+is $of-trait.gist, q:to/END/.chomp, 'Trait::Of.gist renders like Rakudo';
+    RakuAST::Trait::Of.new(
+      RakuAST::Type::Simple.new(
+        RakuAST::Name.from-identifier("Int")
+      )
+    )
+    END
+ok RakuAST::Trait::Returns.^can('new').elems > 0
+    && RakuAST::Trait::Of.^can('new').elems > 0,
+    'return traits advertise their constructors';
+
+sub body($value) {
+    my $statements = RakuAST::StatementList.new;
+    $statements.add-statement(
+        RakuAST::Statement::Expression.new(
+            expression => RakuAST::IntLiteral.new($value),
+        ),
+    );
+    RakuAST::Blockoid.new($statements);
+}
+
+my $arrow-sub = RakuAST::Sub.new(
+    name => RakuAST::Name.from-identifier('rakuast-constructed-arrow-return'),
+    signature => $signature,
+    body => body(42),
+);
+is $arrow-sub.signature.returns, $type,
+    'Sub.new retains a constructed Signature.returns node';
+my $arrow-callable = EVAL($arrow-sub);
+is $arrow-callable(), 42,
+    'a constructed Signature.returns lowers and executes';
+
+my $trait-sub = RakuAST::Sub.new(
+    name => RakuAST::Name.from-identifier('rakuast-constructed-returns-trait'),
+    traits => [$returns-trait],
+    body => body(42),
+);
+is $trait-sub.traits[0], $returns-trait,
+    'Sub.new retains a constructed Trait::Returns node';
+ok $trait-sub.gist.contains('traits'),
+    'Sub.gist renders constructed return traits';
+my $trait-callable = EVAL($trait-sub);
+is $trait-callable(), 42,
+    'a constructed Trait::Returns lowers and executes';
+
+my $of-sub = RakuAST::Sub.new(
+    name => RakuAST::Name.from-identifier('rakuast-constructed-of-trait'),
+    traits => [$of-trait],
+    body => body(42),
+);
+is $of-sub.traits[0], $of-trait,
+    'Sub.new retains a constructed Trait::Of node';
+my $of-callable = EVAL($of-sub);
+is $of-callable(), 42,
+    'a constructed Trait::Of lowers and executes';

--- a/todo/deep/rakuast-remaining.md
+++ b/todo/deep/rakuast-remaining.md
@@ -92,9 +92,11 @@ These must validate, render, expose through introspection, and lower through
 
 `RakuAST::Signature.new` accepts no `returns` argument yet, and
 `RakuAST::Trait::Returns` / `Trait::Of` are read-and-lower-only (the converter
-builds them, `EVAL` lowers them, but there is no `.new` constructor). Both are
-straightforward extensions of the existing per-class schema now that the node
-kinds exist.
+builds them, `EVAL` lowers them, but there is no `.new` constructor). **Closed
+2026-09-02:** `Signature.new(:returns)`, `Trait::Returns.new($type)`, and
+`Trait::Of.new($type)` now construct the existing node shapes; `Sub.new(:traits)`
+can attach the return traits so hand-built nodes reach the existing lowerer.
+Regression coverage is in `t/rakuast-construct-return-type.t`.
 
 ## Lowering and EVAL
 


### PR DESCRIPTION
## Summary

- retain `returns` in `RakuAST::Signature.new`
- add positional constructors for `Trait::Returns` and `Trait::Of`
- allow supported return traits in `RakuAST::Sub.new(:traits)`
- add dual-oracle regression coverage and update the ADR, deep roadmap, and news

## Validation

- `cargo fmt --all`
- `cargo clippy -- -D warnings`
- `make test`
- `make roast`

Both full suites passed.