### PR TITLE
fix: a Capture inside a slipped container is one argument

### DIFF
--- a/news/2026-09/slip-array-element-capture-not-respread.md
+++ b/news/2026-09/slip-array-element-capture-not-respread.md
@@ -1,0 +1,45 @@
+# A Capture inside a slipped container is one argument, not an argument list
+
+`|EXPR` spreads the container it is applied to, one level. mutsu spread it
+twice: `append_slip_item` re-examined every item the Slip carried and, if the
+item was itself a `Capture`, replayed its positional and named lanes into the
+argument list as well. So a Capture that merely *sat in* a slipped array was
+dissolved:
+
+```raku
+sub inner(Str $n, *@c, *%a) { say @c.raku; say %a.raku }
+sub outer(Str $n, *@contents, *%attribs) { inner($n, |@contents, |%attribs) }
+outer('test', :type<embedded>, \('hello', :lang<en>, "world"));
+
+# raku : [\("hello", "world", :lang("en"))] / {:type("embedded")}
+# mutsu: ["hello", "world"]                 / {:lang("en"), :type("embedded")}
+```
+
+`exec_make_slip_op` already replays a genuine `|$capture`'s lanes into the
+Slip's items when the Slip is built, so by the time `append_slip_item` runs
+every remaining `Capture` item can only have come from a *container element* —
+where `|` was applied to the container, not to the Capture. The re-spread arm
+is gone; such an item is now pushed as one argument.
+
+Found while re-measuring the `XML` battery candidate
+(`todo/tickets/bundle-xml-battery.md`). `XML`'s `make-xml` is built on exactly
+this relay:
+
+```raku
+sub make-xml (Str $name, *@contents, *%attribs) {
+    XML::Element.craft($name, |@contents, |%attribs);
+}
+```
+
+and `craft-new` branches on `$what ~~ Capture` to recurse into a nested
+element. With the Capture dissolved, that arm never fired, so
+`make-xml('test', :type<embedded>, \('hello', :lang<en>, "world"))` produced
+`<test type="embedded" lang="fr">hello world …</test>` — the children's text
+and attributes hoisted into the parent — instead of nested `<hello>` /
+`<aurevoir>` elements. The suite moves from **13/15 to 14/15** files
+(`raku`: 15/15); the one remaining failure, `t/namespaces.rakutest`, is an
+unrelated defect in stringifying a list of objects that define `Str`.
+
+Pin: `t/slip-array-element-capture.t`, which also covers the shapes that must
+not change (`|$capture`, `|@array`, `|%hash`, `|(list)`, and a `Pair` element of
+a slipped array staying positional).

--- a/src/vm/vm_call_helpers.rs
+++ b/src/vm/vm_call_helpers.rs
@@ -33,15 +33,16 @@ impl Interpreter {
 
     pub(super) fn append_slip_item(args: &mut Vec<Value>, item: &Value) {
         match item.view() {
-            ValueView::Capture { positional, named } => {
-                // I5: containerize on append rather than trusting the stored
-                // flavour — the positional lane must stay positional even if
-                // an element was minted with the named flavour upstream.
-                args.extend(positional.iter().cloned().map(Self::containerize_pair_item));
-                for (k, v) in named.iter() {
-                    args.push(Value::pair(k.clone(), v.clone()));
-                }
-            }
+            // A Capture that reached the argument list as an ELEMENT of a
+            // slipped container is one argument, not an argument list: `|` was
+            // applied to the container, not to the Capture. `f(|@a)` where
+            // `@a[0]` is `\("x", :k<v>)` passes that Capture whole (XML's
+            // `make-xml` relies on it: `craft($name, |@contents)` must hand
+            // `craft-new` the Capture so its `$what ~~ Capture` arm recurses).
+            // Only `|$capture` itself spreads, and `exec_make_slip_op` has
+            // already replayed those lanes into the Slip's items by the time
+            // this runs.
+            //
             // Hash values inside a Slip are kept as single positional args.
             // Top-level `|%hash` flattening is handled by MakeSlip, which converts
             // a bare Hash into pairs before wrapping in a Slip. A Hash that is already

--- a/t/slip-array-element-capture.t
+++ b/t/slip-array-element-capture.t
@@ -1,0 +1,42 @@
+use Test;
+
+# `|EXPR` spreads the CONTAINER it is applied to, one level. A Capture that
+# happens to be an element of that container is one argument, not a nested
+# argument list -- `|` was applied to the array, not to the Capture. mutsu used
+# to re-spread it, so XML's `make-xml('test', \('hello', :lang<en>, 'world'))`
+# lost the nesting: `craft($name, |@contents)` handed `craft-new` the Capture's
+# contents rather than the Capture, and its `$what ~~ Capture` arm never fired.
+
+plan 8;
+
+sub probe(*@pos, *%named) { (@pos.raku, %named.raku).join(' | ') }
+
+{
+    my $c = \('x', :k<v>, 'y');
+    is probe(|$c), '["x", "y"] | {:k("v")}',
+        '|$capture spreads its own lanes';
+    is probe(|[$c]), '[\\("x", "y", :k("v"))] | {}',
+        '|@array hands a Capture element over whole';
+    is probe(|($c,)), '[\\("x", "y", :k("v"))] | {}',
+        'and so does a slipped list';
+}
+
+# The relay shape XML uses: a slurpy re-splatted into another slurpy.
+{
+    sub inner(Str $n, *@c, *%a) { ($n, @c.raku, %a.raku).join(' | ') }
+    sub outer(Str $n, *@contents, *%attribs) { inner($n, |@contents, |%attribs) }
+    is outer('test', :type<embedded>, \('hello', :lang<en>, 'world')),
+        'test | [\\("hello", "world", :lang("en"))] | {:type("embedded")}',
+        'a Capture survives being relayed through two slurpy hops';
+}
+
+# The other slip shapes are unchanged.
+{
+    my @a = 1, 2;
+    is probe(|@a), '[1, 2] | {}', '|@array spreads its elements';
+    my %h = z => 9;
+    is probe(|%h), '[] | {:z(9)}', '|%hash mints named arguments';
+    is probe(|(3, 4)), '[3, 4] | {}', '|(list) spreads';
+    my @p = (x => 1),;
+    is probe(|@p), '[:x(1)] | {}', 'a Pair element of a slipped array stays positional';
+}


### PR DESCRIPTION
## What

`|EXPR` spreads the container it is applied to, one level. mutsu spread it twice — `append_slip_item` re-examined every item the Slip carried and, when the item was itself a `Capture`, replayed its lanes into the argument list too:

```raku
sub inner(Str $n, *@c, *%a) { say @c.raku; say %a.raku }
sub outer(Str $n, *@contents, *%attribs) { inner($n, |@contents, |%attribs) }
outer('test', :type<embedded>, \('hello', :lang<en>, "world"));

# raku : [\("hello", "world", :lang("en"))] / {:type("embedded")}
# mutsu: ["hello", "world"]                 / {:lang("en"), :type("embedded")}
```

`exec_make_slip_op` already replays a genuine `|$capture`'s lanes into the Slip's items when the Slip is built, so every `Capture` item still present by the time `append_slip_item` runs can only have come from a *container element* — where `|` was applied to the container, not to the Capture. The re-spread arm is removed.

## Why it matters

Found while re-measuring the `XML` battery candidate (`todo/tickets/bundle-xml-battery.md`). `XML`'s `make-xml` is exactly this relay:

```raku
sub make-xml (Str $name, *@contents, *%attribs) {
    XML::Element.craft($name, |@contents, |%attribs);
}
```

and `craft-new` branches on `$what ~~ Capture` to recurse into a nested element. With the Capture dissolved that arm never fired, so `make-xml('test', :type<embedded>, \('hello', :lang<en>, "world"))` produced `<test type="embedded" lang="fr">hello world …</test>` — children's text and attributes hoisted into the parent — instead of nested elements. The upstream suite goes **13/15 → 14/15** files (`raku`: 15/15). The remaining failure, `t/namespaces.rakutest`, is an unrelated defect in stringifying a list of objects that define `Str`, which I'll file/fix separately.

## Tests

- New `t/slip-array-element-capture.t` (8 subtests) — passes under `raku` too. It covers the fix plus every shape that must NOT change: `|$capture`, `|@array`, `|%hash`, `|(list)`, and a `Pair` element of a slipped array staying positional.
- `make test` green.
- A 373-file roast sweep over `S06*` / `S02-types` / `S03-operators` / `S32-list` / `S12*` (26673 tests) green — the argument-binding-heavy synopses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)