### PR TITLE
fix: stringifying a list calls each element's own Str

### DIFF
--- a/news/2026-09/list-str-calls-element-str.md
+++ b/news/2026-09/list-str-calls-element-str.md
@@ -1,0 +1,46 @@
+# Stringifying a list calls each element's own `Str`
+
+```raku
+class C { has $.t; method Str { $!t } }
+my @a = (C.new(t => "hi"),);
+say ~@a;            # raku: hi     mutsu: C()   (before)
+say @a.join("");    # raku: hi     mutsu: hi
+```
+
+`Value::to_string_value` is a *pure* renderer: it knows the list-shape rules
+(space-separated, nested lists flattened) but cannot dispatch a user-defined
+method, so an `Instance` element came out as the `ClassName()` fallback.
+`.join` had always resolved its elements through the interpreter; every other
+string-context entry point had not, so the two disagreed about the same array.
+
+Rather than duplicate the shape rules in an interpreter-aware renderer, the
+elements are resolved **in place** — each `Instance` replaced by the string its
+class dispatches, recursing into nested lists — and the resulting list handed to
+the same pure renderer (`src/runtime/list_element_stringify.rs`). The shape
+rules stay in one place; only the per-element stringification moves.
+
+Five entry points needed it, which is why the bug survived: the `.Str`/
+`.Stringy` method (the native fast path now declines a list holding an
+`Instance` and `dispatch_list_str_method` handles it), prefix `~`
+(`exec_str_coerce_op`), string interpolation (`exec_string_concat_op`), infix
+string operands (`coerce_stringy_operand`, which is how `eq` sees it), and the
+native TAP `is` (`stringify_test_value` plus its `value_for_diag`, so the
+diagnostic shows what the comparison actually compared).
+
+Found while re-measuring the `XML` battery candidate
+(`todo/tickets/bundle-xml-battery.md`): `t/namespaces.rakutest` asserts
+`is @items[3].contents, 'A nested item, oh boy.'`, and `.contents` is a list of
+`XML::Text` nodes whose `Str` returns the text. mutsu compared `XML::Text()`.
+With this and the Capture-slip fix
+(`news/2026-09/slip-array-element-capture-not-respread.md`) the upstream suite
+reaches **15/15**, matching `raku`.
+
+A neighbouring difference this surfaced but did not change: mutsu's `.Str`
+dispatch falls back to `Stringy`, so a class defining only `Stringy` answers
+that where raku answers the `Mu.Str` default. `.join` has always had it too, so
+the new path deliberately reuses `.join`'s exact call and the two agree; filed
+as `todo/tickets/str-method-falls-back-to-stringy.md`.
+
+Pin: `t/list-str-calls-element-str.t` (12 subtests, passes under `raku` too),
+covering all five entry points, nested lists, mixed elements, `.gist`/`.raku`
+staying object-shaped, and a plain list keeping the untouched fast path.

--- a/news/2026-09/list-str-calls-element-str.md
+++ b/news/2026-09/list-str-calls-element-str.md
@@ -27,6 +27,15 @@ string operands (`coerce_stringy_operand`, which is how `eq` sees it), and the
 native TAP `is` (`stringify_test_value` plus its `value_for_diag`, so the
 diagnostic shows what the comparison actually compared).
 
+Missing one of them is not a partial fix but a *new* inconsistency, which is
+how `roast/integration/advent2009-day20.t` caught the first attempt: its
+`is @b, (@people.sort: {...})` compared an Array on one side and a Seq on the
+other, and only the Array side had been converted. `stringify_test_value`'s
+Seq/LazyList arms now re-enter through the list arm rather than mapping
+`to_string_value` themselves, and the resolver handles an already-reified
+Seq/HyperSeq/RaceSeq (a still-deferred one is left to the caller's own reify
+guard, which hands the reified value back).
+
 Found while re-measuring the `XML` battery candidate
 (`todo/tickets/bundle-xml-battery.md`): `t/namespaces.rakutest` asserts
 `is @items[3].contents, 'A nested item, oh boy.'`, and `.contents` is a list of

--- a/src/builtins/methods_0arg/dispatch_core_coerce.rs
+++ b/src/builtins/methods_0arg/dispatch_core_coerce.rs
@@ -648,6 +648,12 @@ pub(super) fn dispatch(
                 // Zero-denominator Rat/FatRat .Str throws X::Numeric::DivideByZero
                 None // fall through to runtime for exception with proper context
             }
+            // A list holding an `Instance` element needs the interpreter: the
+            // element's class may define its own `Str`, which this pure
+            // renderer cannot call (it would print the `ClassName()` fallback
+            // -- `~@a` then disagreed with `@a.join("")` for the same array).
+            // `dispatch_list_str_method` resolves the elements and re-renders.
+            _ if crate::Interpreter::list_str_needs_interpreter(target) => None,
             _ => Some(Ok(Value::str(target.to_string_value()))),
         }),
         "Int" => {

--- a/src/runtime/list_element_stringify.rs
+++ b/src/runtime/list_element_stringify.rs
@@ -28,6 +28,13 @@ impl crate::Interpreter {
         match value.view() {
             ValueView::Array(items, ..) => items.iter().any(Self::element_needs_interpreter),
             ValueView::Slip(items) => items.iter().any(Self::element_needs_interpreter),
+            // An already-reified Seq stringifies its elements like an Array;
+            // one still holding a deferred source is left to the caller's own
+            // reify guard (`reify_or_consume_seq_target`), which hands the
+            // reified value back here.
+            ValueView::Seq(..) | ValueView::HyperSeq(..) | ValueView::RaceSeq(..) => value
+                .as_list_items_with_hyper()
+                .is_some_and(|items| items.iter().any(Self::element_needs_interpreter)),
             _ => false,
         }
     }
@@ -58,6 +65,13 @@ impl crate::Interpreter {
                 ))
             }
             ValueView::Slip(items) => Ok(Value::slip(self.resolve_elements(items.iter())?)),
+            ValueView::Seq(..) | ValueView::HyperSeq(..) | ValueView::RaceSeq(..) => {
+                let items: Vec<Value> = value
+                    .as_list_items_with_hyper()
+                    .map(<[Value]>::to_vec)
+                    .unwrap_or_default();
+                Ok(Value::seq(self.resolve_elements(items.iter())?))
+            }
             _ => Ok(value.clone()),
         }
     }

--- a/src/runtime/list_element_stringify.rs
+++ b/src/runtime/list_element_stringify.rs
@@ -1,0 +1,86 @@
+//! Stringifying a list whose elements define their own `Str`.
+//!
+//! `Value::to_string_value` is a pure renderer: it knows the list shape rules
+//! (space-separated, nested lists flattened) but cannot call a user-defined
+//! `Str` method, so an `Instance` element rendered as the `ClassName()`
+//! fallback. `.join` had always resolved elements through the interpreter;
+//! `.Str` / `.Stringy` / prefix `~` had not, so `~@a` and `@a.join("")`
+//! disagreed for the same array.
+//!
+//! Rather than duplicate the shape rules in an interpreter-aware renderer,
+//! the elements are resolved *in place* — each `Instance` replaced by the
+//! `Str` its class dispatches — and the resulting list handed to the same
+//! pure renderer.
+
+use crate::value::{RuntimeError, Value, ValueView};
+
+impl crate::Interpreter {
+    /// Whether stringifying this value needs the interpreter: it is a list
+    /// (at any nesting depth) holding an `Instance` element. Everything else
+    /// renders correctly from the pure `to_string_value`, so the native fast
+    /// path keeps it.
+    pub(crate) fn list_str_needs_interpreter(value: &Value) -> bool {
+        // The list may arrive itemized (`$[...]`, e.g. bound to a `Mu $got`
+        // parameter) or behind a `ContainerRef` cell; stringification looks
+        // through both.
+        let value = value.deref_container();
+        let value = value.descalarize();
+        match value.view() {
+            ValueView::Array(items, ..) => items.iter().any(Self::element_needs_interpreter),
+            ValueView::Slip(items) => items.iter().any(Self::element_needs_interpreter),
+            _ => false,
+        }
+    }
+
+    fn element_needs_interpreter(item: &Value) -> bool {
+        let item = item.deref_container();
+        matches!(item.view(), ValueView::Instance { .. }) || Self::list_str_needs_interpreter(&item)
+    }
+
+    /// Replace every `Instance` element with the string its class's `Str`
+    /// dispatches, recursing into nested lists. Non-list values, and lists
+    /// with no such element, are returned unchanged.
+    pub(crate) fn resolve_list_element_stringifiers(
+        &mut self,
+        value: &Value,
+    ) -> Result<Value, RuntimeError> {
+        if !Self::list_str_needs_interpreter(value) {
+            return Ok(value.clone());
+        }
+        let value = value.deref_container();
+        let value = value.descalarize();
+        match value.view() {
+            ValueView::Array(items, kind) => {
+                let resolved = self.resolve_elements(items.iter())?;
+                Ok(Value::array_with_kind(
+                    crate::gc::Gc::new(crate::value::ArrayData::new(resolved)),
+                    kind,
+                ))
+            }
+            ValueView::Slip(items) => Ok(Value::slip(self.resolve_elements(items.iter())?)),
+            _ => Ok(value.clone()),
+        }
+    }
+
+    fn resolve_elements<'a>(
+        &mut self,
+        items: impl Iterator<Item = &'a Value>,
+    ) -> Result<Vec<Value>, RuntimeError> {
+        let mut out = Vec::new();
+        for item in items {
+            // Decontainerize a `ContainerRef` element (a `:=`-bound slot, a
+            // grep rw alias) so a cell-wrapped Instance still gets its
+            // user-defined `.Str` -- the same decont `.join` does.
+            let item = item.deref_container();
+            if matches!(item.view(), ValueView::Instance { .. }) {
+                let s = self.call_method_with_values(item.clone(), "Str", vec![])?;
+                out.push(Value::str(s.to_string_value()));
+            } else if Self::list_str_needs_interpreter(&item) {
+                out.push(self.resolve_list_element_stringifiers(&item)?);
+            } else {
+                out.push(item);
+            }
+        }
+        Ok(out)
+    }
+}

--- a/src/runtime/methods_dispatch_match3.rs
+++ b/src/runtime/methods_dispatch_match3.rs
@@ -323,6 +323,7 @@ impl Interpreter {
                 }
                 None
             }
+            "Str" | "Stringy" if args.is_empty() => self.dispatch_list_str_method(target),
             "join" if args.len() <= 1 => {
                 // `.join` on a Thread blocks until the thread completes and syncs
                 // its shared captured variables back to the parent (Raku
@@ -653,6 +654,28 @@ impl Interpreter {
         };
         let result: Vec<Value> = items.into_iter().skip(n).collect();
         Ok(Value::seq(result))
+    }
+
+    /// Dispatch `.Str`/`.Stringy` on a list whose elements need the
+    /// interpreter: an `Instance` element may define its own `Str`, which the
+    /// pure `to_string_value` renderer cannot call (it would print the
+    /// `C()` fallback instead). The native fast path returns `None` for
+    /// exactly those lists (`dispatch_core_coerce`), so anything reaching
+    /// here is one.
+    ///
+    /// The elements are resolved in place and the list is then handed to the
+    /// SAME pure renderer, so the list-shape rules (space separation, nested
+    /// flattening) stay in one place -- only the per-element stringification
+    /// moves.
+    fn dispatch_list_str_method(&mut self, target: Value) -> Option<Result<Value, RuntimeError>> {
+        if !Self::list_str_needs_interpreter(&target) {
+            return None;
+        }
+        let resolved = match self.resolve_list_element_stringifiers(&target) {
+            Ok(v) => v,
+            Err(e) => return Some(Err(e)),
+        };
+        Some(Ok(Value::str(resolved.to_string_value())))
     }
 
     /// Dispatch the "join" method.

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -467,6 +467,7 @@ mod io_sysinfo_user;
 mod io_sysinfo_vm_config;
 mod iterator_protocol;
 pub(crate) mod json;
+mod list_element_stringify;
 mod listop_functions;
 mod lock_async_recursion;
 mod lock_reentry;

--- a/src/runtime/test_functions/basic.rs
+++ b/src/runtime/test_functions/basic.rs
@@ -111,23 +111,22 @@ impl Interpreter {
 
     pub(crate) fn stringify_test_value(&mut self, value: &Value) -> Result<String, RuntimeError> {
         match value.view() {
-            ValueView::LazyList(list) => Ok(self
-                .force_lazy_list(&list)?
-                .iter()
-                .map(|v| v.to_string_value())
-                .collect::<Vec<_>>()
-                .join(" ")),
+            // Re-enter through the list arm below so each element is
+            // stringified the same way a plain Array's is -- an `Instance`
+            // element gets its own `Str` (`is @a, @seq` compared one side
+            // through the element's `Str` and the other through the pure
+            // renderer otherwise).
+            ValueView::LazyList(list) => {
+                let items = self.force_lazy_list(&list)?;
+                self.stringify_test_value(&Value::array(items))
+            }
             // A deferred Seq (e.g. `$fh.lines`, `Seq.new($iter)`) must be
             // reified before comparison so it stringifies as its contents
             // rather than the empty seed (ADR-0034).
             ValueView::Seq(body) if body.needs_touch() => {
                 let body = std::sync::Arc::clone(&body);
                 let items = self.reify_seq_body(&body)?;
-                Ok(items
-                    .iter()
-                    .map(|v| v.to_string_value())
-                    .collect::<Vec<_>>()
-                    .join(" "))
+                self.stringify_test_value(&Value::array(items))
             }
             // `is $got, $expected` compares via Raku's `eq` (Str coercion), so an
             // object whose class defines a user `Stringy`/`Str` must be compared

--- a/src/runtime/test_functions/basic.rs
+++ b/src/runtime/test_functions/basic.rs
@@ -157,6 +157,14 @@ impl Interpreter {
                     None => Ok(value.to_string_value()),
                 }
             }
+            // A list holding an Instance element: the element's class may
+            // define its own `Str`, which the pure renderer cannot call. This
+            // is the same resolution `eq` performs, and `is` compares via `eq`
+            // (`runtime/list_element_stringify.rs`).
+            _ if Self::list_str_needs_interpreter(value) => {
+                let resolved = self.resolve_list_element_stringifiers(value)?;
+                Ok(resolved.to_string_value())
+            }
             _ => Ok(value.to_string_value()),
         }
     }

--- a/src/runtime/test_functions/mod.rs
+++ b/src/runtime/test_functions/mod.rs
@@ -287,6 +287,14 @@ impl Interpreter {
                 return result.to_string_value();
             }
         }
+        // A list holding an Instance element renders through the element's own
+        // `Str` (`runtime/list_element_stringify.rs`) -- the same value `is`
+        // compared, so the diagnostic shows what the comparison saw.
+        if Self::list_str_needs_interpreter(val)
+            && let Ok(resolved) = self.resolve_list_element_stringifiers(val)
+        {
+            return resolved.to_string_value();
+        }
         val.to_string_value()
     }
 

--- a/src/vm/vm_coerce_concat_ops.rs
+++ b/src/vm/vm_coerce_concat_ops.rs
@@ -262,6 +262,14 @@ impl Interpreter {
         if let Some(r) = self.mixin_user_stringifier(&v) {
             return Ok(Value::str(r?.to_string_value()));
         }
+        // A list element that is an Instance may define its own `Str`, which
+        // the pure stringifier the caller falls back to cannot call -- resolve
+        // those first, the same way `.Str` / prefix `~` / interpolation do
+        // (`runtime/list_element_stringify.rs`). `is @list, 'text'` in the
+        // vendored Test module lands here through infix `eq`.
+        if Self::list_str_needs_interpreter(&v) {
+            return self.resolve_list_element_stringifiers(&v);
+        }
         let (cn, is_type_object) = match v.view() {
             ValueView::Instance { class_name, .. } => (class_name.resolve().to_string(), false),
             ValueView::Package(name) => (name.resolve().to_string(), true),

--- a/src/vm/vm_misc_coerce.rs
+++ b/src/vm/vm_misc_coerce.rs
@@ -285,6 +285,10 @@ impl Interpreter {
         }
         // Resolve bound-element sentinels inside arrays before stringification
         let val = self.resolve_bound_array_elements(val);
+        // A list element that is an Instance may define its own `Str`, which
+        // the pure stringifier below cannot call -- resolve those first, the
+        // same way the `.Str` method path does (`list_element_stringify.rs`).
+        let val = self.resolve_list_element_stringifiers(&val)?;
         self.stack
             .push(Value::str(crate::runtime::utils::coerce_to_str(&val)));
         Ok(())

--- a/src/vm/vm_var_assign_typed.rs
+++ b/src/vm/vm_var_assign_typed.rs
@@ -754,6 +754,11 @@ impl Interpreter {
                 result.push_str(&resumed.to_string_value());
                 continue;
             }
+            // A list element that is an Instance may define its own `Str`,
+            // which the pure stringifier below cannot call -- resolve those
+            // first, the same way `.Str` / prefix `~` do
+            // (`runtime/list_element_stringify.rs`).
+            let v = self.resolve_list_element_stringifiers(&v)?;
             result.push_str(&crate::runtime::utils::coerce_to_str(&v));
         }
         self.reconcile_caller_after_internal_dispatch(caller_code);

--- a/t/list-str-calls-element-str.t
+++ b/t/list-str-calls-element-str.t
@@ -7,7 +7,7 @@ use Test;
 # the elements first and hands the result to the same renderer, so the
 # list-shape rules (space separation, nested flattening) stay in one place.
 
-plan 12;
+plan 15;
 
 class C { has $.t; method Str { $!t } }
 class D { has $.t; method Stringy { "S:" ~ $!t } }
@@ -48,6 +48,16 @@ class D { has $.t; method Stringy { "S:" ~ $!t } }
     my @a = (C.new(t => "hi"),);
     is @a.gist, '[C.new(t => "hi")]', '.gist still shows the object';
     is @a.raku, '[C.new(t => "hi")]', '.raku still shows the object';
+}
+
+# A Seq / lazy list must stringify its elements the SAME way, or `is` compares
+# one side through the element's `Str` and the other through the pure renderer
+# (roast/integration/advent2009-day20.t's `is @b, (@people.sort: {...})`).
+{
+    my @a = (C.new(t => "a"), C.new(t => "b"));
+    is @a, @a.Seq, 'a Seq stringifies its elements like an Array';
+    is ~@a.Seq, 'a b', 'and prefix ~ on that Seq agrees';
+    is @a, @a.map({ $_ }), 'a mapped Seq agrees too';
 }
 
 # A list with no such element takes the untouched fast path.

--- a/t/list-str-calls-element-str.t
+++ b/t/list-str-calls-element-str.t
@@ -1,0 +1,56 @@
+use Test;
+
+# Stringifying a LIST must call each element's own `Str`. mutsu's pure
+# renderer (`to_string_value`) cannot dispatch a user method, so an Instance
+# element rendered as the `ClassName()` fallback -- `~@a` and `@a.join("")`
+# disagreed for the same array. Every string-context entry point now resolves
+# the elements first and hands the result to the same renderer, so the
+# list-shape rules (space separation, nested flattening) stay in one place.
+
+plan 12;
+
+class C { has $.t; method Str { $!t } }
+class D { has $.t; method Stringy { "S:" ~ $!t } }
+
+{
+    my @a = (C.new(t => "hi"),);
+    is @a.Str, 'hi', '.Str on a list';
+    is ~@a, 'hi', 'prefix ~ on a list';
+    is "x{@a}y", 'xhiy', 'interpolation of a list';
+    is @a.join(","), 'hi', '.join still agrees';
+    ok @a eq 'hi', 'infix eq on a list';
+    is @a, 'hi', 'Test is() on a list';
+}
+
+{
+    my @a = (1, C.new(t => "hi"), "z");
+    is ~@a, '1 hi z', 'mixed elements are space-separated';
+}
+
+{
+    my @a = ([C.new(t => "a"), C.new(t => "b")], C.new(t => "c"));
+    is ~@a, 'a b c', 'nested lists flatten as usual';
+}
+
+{
+    my $d = D.new(t => "q");
+    # A class defining only `Stringy` exposes a pre-existing dispatch
+    # difference (mutsu's `.Str` falls back to `Stringy`, raku's does not), and
+    # `.join` has always had it too -- see
+    # todo/tickets/str-method-falls-back-to-stringy.md. What matters here is
+    # that the list path and `.join` give the SAME answer, which holds under
+    # both implementations.
+    is ~($d,), ($d,).join(""), 'the list path agrees with .join';
+}
+
+# gist/raku are unchanged -- they are the object-inspection renderers.
+{
+    my @a = (C.new(t => "hi"),);
+    is @a.gist, '[C.new(t => "hi")]', '.gist still shows the object';
+    is @a.raku, '[C.new(t => "hi")]', '.raku still shows the object';
+}
+
+# A list with no such element takes the untouched fast path.
+{
+    is ~(1, 2, 3), '1 2 3', 'a plain list is unaffected';
+}

--- a/todo/tickets/str-method-falls-back-to-stringy.md
+++ b/todo/tickets/str-method-falls-back-to-stringy.md
@@ -1,0 +1,42 @@
+# `.Str` falls back to `Stringy` for a class that defines only `Stringy`
+
+```raku
+class D { has $.t; method Stringy { "S:" ~ $!t } }
+my $d = D.new(t => "q");
+say ($d,).join("");   # raku: D<6169564731160>   mutsu: S:q
+say ~$d;              # raku: S:q                mutsu: S:q     (agree)
+```
+
+Raku's `prefix:<~>` calls `Stringy`, which defaults to `Str`. The reverse is
+not true: `.Str` on a class that defines only `Stringy` gets `Mu.Str`, so it
+renders the default `D<address>`. mutsu's `.Str` dispatch tries `Stringy`
+first, so anything that stringifies *by calling `.Str`* — `.join`, and now the
+list-stringification path of `news/2026-09/list-str-calls-element-str.md` —
+answers the `Stringy` result where raku answers the default.
+
+Found 2026-09-02 while making list stringification dispatch each element's
+`Str`. The new path deliberately reuses `.join`'s exact call
+(`call_method_with_values(elem, "Str")`), so the two agree with each other;
+`t/list-str-calls-element-str.t` pins that agreement rather than a literal, and
+passes under `raku` too.
+
+## Why it is not a one-line fix
+
+The `Str`→`Stringy` fallback is deliberate in several places (the prefix-`~`
+opcode, `coerce_stringy_operand`, `stringify_test_value` all try `Stringy`
+before `Str`, and that IS correct for those — they implement `~`, not `.Str`).
+Only the sites that implement the `.Str` *method* should stop falling back.
+Separating them needs an audit of every `has_user_method(cn, "Stringy")` /
+`try_compiled_method_or_interpret(.., "Stringy")` caller against which Raku
+operation it implements.
+
+Low impact on its own: a class defining `Stringy` without `Str` is rare (all of
+`modules/` has none). Worth doing when the string-coercion sites are touched
+for another reason.
+
+## Repro
+
+```
+raku  -e 'class D { has $.t; method Stringy { "S:" ~ $!t } }; say (D.new(t=>"q"),).join("")'
+mutsu -e 'class D { has $.t; method Stringy { "S:" ~ $!t } }; say (D.new(t=>"q"),).join("")'
+```


### PR DESCRIPTION
## What

```raku
class C { has $.t; method Str { $!t } }
my @a = (C.new(t => "hi"),);
say ~@a;            # raku: hi     mutsu: C()   (before)
say @a.join("");    # raku: hi     mutsu: hi
```

`Value::to_string_value` is a *pure* renderer: it knows the list-shape rules (space-separated, nested lists flattened) but cannot dispatch a user-defined method, so an `Instance` element came out as the `ClassName()` fallback. `.join` had always resolved its elements through the interpreter; every other string-context entry point had not, so the two disagreed about the same array.

Rather than duplicate the shape rules in an interpreter-aware renderer, the elements are resolved **in place** — each `Instance` replaced by the string its class dispatches, recursing into nested lists — and the resulting list handed to the same pure renderer (`src/runtime/list_element_stringify.rs`). The shape rules stay in one place; only the per-element stringification moves.

Five entry points needed it, which is why the bug survived:

| entry point | site |
| --- | --- |
| `.Str` / `.Stringy` method | native fast path declines a list holding an `Instance`; `dispatch_list_str_method` handles it |
| prefix `~` | `exec_str_coerce_op` |
| string interpolation | `exec_string_concat_op` |
| infix string operands (`eq`, `~`) | `coerce_stringy_operand` |
| native TAP `is` | `stringify_test_value` + `value_for_diag` |

## Why it matters

Found while re-measuring the `XML` battery candidate (`todo/tickets/bundle-xml-battery.md`). `t/namespaces.rakutest` asserts `is @items[3].contents, 'A nested item, oh boy.'`, and `.contents` is a list of `XML::Text` nodes whose `Str` returns the text — mutsu compared `XML::Text()`. With this and #7233 the upstream suite reaches **15/15**, matching `raku`.

## Tests

- New `t/list-str-calls-element-str.t` (12 subtests) — passes under `raku` too. Covers all five entry points, nested lists, mixed elements, `.gist`/`.raku` staying object-shaped, and a plain list keeping the untouched fast path.
- `make test` green.
- A 417-file roast sweep over `S02-types` / `S03-operators` / `S12*` / `S32-list` / `S32-str` / `S04*` (56171 tests) green — the only failures were three `S32-str/*-encode-decode.t` files that need `make roast`'s `t/spec` symlink for their sample data, unrelated to this change.

## Also filed

`todo/tickets/str-method-falls-back-to-stringy.md` — mutsu's `.Str` dispatch falls back to `Stringy`, so a class defining only `Stringy` answers that where raku answers the `Mu.Str` default. `.join` has always had it too, so the new path deliberately reuses `.join`'s exact call and the two agree; the test pins that agreement rather than a literal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)