### PR TITLE
rakuast: preserve compound assignment nodes

### DIFF
--- a/docs/adr/0033-whatever-priming-leaf-and-derived-scope.md
+++ b/docs/adr/0033-whatever-priming-leaf-and-derived-scope.md
@@ -811,11 +811,13 @@ closure. Keep the runtime behaviour pinned: `(* ~~ Int).WHAT`, `(Int ~~ *).WHAT`
 `SmartMatch`/`BangTilde` to look at the **left** operand only, so routing an `Int ~~ *`
 through `build_closure` needs that asymmetry re-checked rather than assumed.
 
-The **compound-assignment** family stays a boundary in Phase 2: raku models `* += 1` as
-`ApplyInfix(…, infix => RakuAST::MetaInfix::Assign.new(RakuAST::Infix.new("+")), …)`, and
-mutsu has no `MetaInfix::Assign` class. Adding one is an independent read-direction slice
-(it is not Whatever-specific — every `$x += 1` has the same gap), so it belongs with the
-operator cluster, not here.
+The **compound-assignment** family stayed a boundary in Phase 2. An independent
+operator-cluster slice subsequently added `RakuAST::MetaInfix::Assign` for core
+compound assignments (`$x += 1`, indexed lvalues, and `AT-POS` lvalues), while
+retaining the existing execution expansion. The `* += 1` Whatever autoprime path
+is still a boundary here: it builds a closure before conversion and needs the
+Whatever leaf/scope work described by this ADR rather than the ordinary compound
+assignment marker.
 
 ### 2.6 Divergences Phase 2 documents rather than closes
 

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -715,6 +715,21 @@ pub(crate) enum Expr {
         /// than write through any existing alias.
         is_bind: bool,
     },
+    /// A compound assignment with its source-level operator preserved.
+    ///
+    /// The parser normally expands `x += y` into an ordinary assignment whose
+    /// RHS is `x + y`, because that is the shape consumed by the existing
+    /// compiler. RakuAST needs the original `+=` distinction, however: raku
+    /// exposes it as `MetaInfix::Assign(Infix("+"))`. The expanded expression
+    /// remains the execution representation; this marker is transparent to
+    /// the compiler and exists so model-layer conversion can recover the
+    /// source construct without guessing from the expansion.
+    CompoundAssign {
+        target: Box<Expr>,
+        op: String,
+        rhs: Box<Expr>,
+        expanded: Box<Expr>,
+    },
     Unary {
         op: TokenKind,
         expr: Box<Expr>,
@@ -2331,6 +2346,16 @@ fn collect_ph_expr(expr: &Expr, out: &mut Vec<String>) {
         Expr::AssignExpr { expr, .. } | Expr::PositionalPair(expr) | Expr::ZenSlice(expr) => {
             collect_ph_expr(expr, out)
         }
+        Expr::CompoundAssign {
+            target,
+            rhs,
+            expanded,
+            ..
+        } => {
+            collect_ph_expr(target, out);
+            collect_ph_expr(rhs, out);
+            collect_ph_expr(expanded, out);
+        }
         Expr::Exists { target, arg, .. } => {
             collect_ph_expr(target, out);
             if let Some(a) = arg {
@@ -2949,6 +2974,16 @@ fn collect_ph_expr_shallow(expr: &Expr, out: &mut Vec<String>) {
         }
         Expr::AssignExpr { expr, .. } | Expr::PositionalPair(expr) | Expr::ZenSlice(expr) => {
             collect_ph_expr_shallow(expr, out)
+        }
+        Expr::CompoundAssign {
+            target,
+            rhs,
+            expanded,
+            ..
+        } => {
+            collect_ph_expr_shallow(target, out);
+            collect_ph_expr_shallow(rhs, out);
+            collect_ph_expr_shallow(expanded, out);
         }
         Expr::Exists { target, arg, .. } => {
             collect_ph_expr_shallow(target, out);

--- a/src/compiler/expr.rs
+++ b/src/compiler/expr.rs
@@ -743,6 +743,13 @@ impl Compiler {
                 let name = self.resolve_self_lexical(name);
                 self.compile_expr_assign(name, expr, *is_bind);
             }
+            // Source-preserving annotation for `x += y` and friends. The
+            // parser has already built the ordinary assignment expansion;
+            // compile that proven execution shape and keep the annotation
+            // available to the RakuAST converter.
+            Expr::CompoundAssign { expanded, .. } => {
+                self.compile_expr(expanded);
+            }
             // Capture variable ($0, $1, etc.)
             Expr::CaptureVar(name) => {
                 self.compile_expr_capture_var(name);

--- a/src/compiler/helpers_call_args.rs
+++ b/src/compiler/helpers_call_args.rs
@@ -349,6 +349,7 @@ impl Compiler {
             Expr::ArrayVar(_) => true,
             // Assignment to @-variable returns an array
             Expr::AssignExpr { name, .. } => name.starts_with('@'),
+            Expr::CompoundAssign { expanded, .. } => Self::needs_decont(expanded),
             // VarDecl/Assign in expression position (my @a = ...)
             Expr::DoStmt(stmt) => match stmt.as_ref() {
                 Stmt::VarDecl { name, .. } | Stmt::Assign { name, .. } => name.starts_with('@'),
@@ -445,6 +446,10 @@ impl Compiler {
             // Anonymous scalar assignment (`$ = value`) produces a writable
             // container, so wrap it with VarRef so `is rw` dispatch can match.
             Expr::AssignExpr { name, .. } => Some(name.clone()),
+            Expr::CompoundAssign { expanded, .. } => match expanded.as_ref() {
+                Expr::AssignExpr { name, .. } => Some(name.clone()),
+                _ => None,
+            },
             // An inline declaration used as an argument (`$y := my $x`,
             // `f(my $z)`) parses to `DoStmt(VarDecl { .. })`. Compiling it
             // declares the variable in the enclosing scope and leaves its value

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -2162,6 +2162,27 @@ impl Compiler {
                 if matches!(op, AssignOp::Assign) {
                     self.maybe_emit_dynamic_var_check(effective_name);
                 }
+                // A source-preserving compound assignment still uses the
+                // ordinary Stmt::Assign execution path. Feed its expanded
+                // expression to the fused RMW and assignment helpers; the
+                // marker is for RakuAST conversion and must not disable the
+                // atomic scalar fast path.
+                let execution_expr = match expr {
+                    Expr::CompoundAssign { expanded, .. } => match expanded.as_ref() {
+                        Expr::AssignExpr {
+                            name: expanded_name,
+                            expr,
+                            ..
+                        } if expanded_name == effective_name => expr.as_ref(),
+                        // A marker can also be the RHS of an outer assignment,
+                        // e.g. `@p = $a or= 3, 4`. In that case the inner
+                        // assignment must execute as part of the RHS; only
+                        // unwrap the assignment when it is this statement's
+                        // own compound target.
+                        expanded => expanded,
+                    },
+                    _ => expr,
+                };
                 // Emit readonly check for assignment to potentially readonly params.
                 // Skip the check for `:=` (rebinding replaces the container).
                 let name_idx = self
@@ -2216,11 +2237,11 @@ impl Compiler {
                     // atomic RMW for plain env-named scalars (Track C). The fused
                     // op leaves the result on the stack; statement context wants
                     // nothing, so discard it.
-                    if self.try_compile_fused_compound_assign(effective_name, expr) {
+                    if self.try_compile_fused_compound_assign(effective_name, execution_expr) {
                         self.code.emit(OpCode::Pop);
                         return;
                     }
-                    self.compile_assignment_rhs_for_target(effective_name, expr);
+                    self.compile_assignment_rhs_for_target(effective_name, execution_expr);
                 }
                 // An assignment whose target is a sigilless binding (`-> \v`
                 // loop-param bind stmts — `build_for_bind_stmts` strips the

--- a/src/parser/expr/mod.rs
+++ b/src/parser/expr/mod.rs
@@ -342,6 +342,29 @@ fn wrap_finished_expr(expr: Expr) -> Expr {
 pub(in crate::parser) fn listop_arg_expr(input: &str) -> PResult<'_, Expr> {
     let (rest, expr) = precedence::ternary_mode(input, operators::ExprMode::ListopArg)?;
     let (r, _) = ws(rest)?;
+
+    // `assign_not_expr_mode` deliberately leaves compound assignment for the
+    // call-argument modes so their RHS cannot absorb the comma separating
+    // listop arguments. Rebuild that operator here, preserving the same
+    // source marker as the parenthesized call-argument path.
+    if let Some((after_op, op)) = crate::parser::stmt::assign::parse_compound_assign_op(r) {
+        let (after_ws, _) = ws(after_op)?;
+        if let Ok((r2, rhs)) = precedence::ternary_mode(after_ws, operators::ExprMode::ListopArg)
+            && let Ok(result) = crate::parser::stmt::assign::build_compound_assign_expr(
+                expr.clone(),
+                op,
+                rhs.clone(),
+            )
+        {
+            return Ok((
+                r2,
+                wrap_finished_expr(crate::parser::stmt::assign::compound_assign_marker(
+                    expr, op, rhs, result,
+                )),
+            ));
+        }
+    }
+
     if r.starts_with("=>") && !r.starts_with("==>") {
         let r = &r[2..];
         let (r, _) = ws(r)?;

--- a/src/parser/expr/precedence.rs
+++ b/src/parser/expr/precedence.rs
@@ -1,9 +1,9 @@
 use super::super::helpers::{is_ident_char, ws};
 use super::super::parse_result::{PError, PResult, merge_expected_messages, parse_char, parse_tag};
 use super::super::stmt::assign::{
-    build_compound_assign_expr, build_custom_compound_assign_expr, compound_assign_op_from_name,
-    compound_assigned_value_expr, parse_assign_expr_or_comma, parse_compound_assign_op,
-    parse_custom_compound_assign_op, parse_meta_compound_assign_op,
+    build_compound_assign_expr, build_custom_compound_assign_expr, compound_assign_marker,
+    compound_assign_op_from_name, compound_assigned_value_expr, parse_assign_expr_or_comma,
+    parse_compound_assign_op, parse_custom_compound_assign_op, parse_meta_compound_assign_op,
     short_circuit_compound_assign_expr,
 };
 

--- a/src/parser/expr/precedence/assign.rs
+++ b/src/parser/expr/precedence/assign.rs
@@ -145,6 +145,12 @@ pub(crate) fn assign_to_target_expr(target: Expr, value: Expr) -> Expr {
             name: Symbol::intern("__mutsu_assign_callable_lvalue"),
             args: vec![*target, Expr::ArrayLiteral(args), value],
         },
+        // A compound assignment is transparent to the execution AST marker.
+        // When its result is itself used as an lvalue (for example the RHS of
+        // a reverse meta compound assignment), apply the writeback to the
+        // established expansion so short-circuiting still preserves the
+        // original assignment semantics.
+        Expr::CompoundAssign { expanded, .. } => assign_to_target_expr(*expanded, value),
         // `(cond ?? $a !! $b) = rhs`: the ternary selects an lvalue branch; the
         // assignment writes through to whichever branch is taken. Desugar to
         // `cond ?? ($a = rhs) !! ($b = rhs)`. A non-lvalue branch recurses to the
@@ -219,6 +225,12 @@ pub(crate) fn build_compound_assign_target_expr(target: Expr, op_name: &str, val
             is_whatever_code: true,
             param_sigilless: false,
         };
+    }
+    if let Expr::CompoundAssign { expanded, .. } = target {
+        // The marker is transparent to the execution AST. A compound result
+        // can still be the lvalue of a reverse meta compound assignment, so
+        // continue through its established writeback expansion.
+        return build_compound_assign_target_expr(*expanded, op_name, value);
     }
     match target {
         Expr::Var(name) => {

--- a/src/parser/expr/precedence/logic.rs
+++ b/src/parser/expr/precedence/logic.rs
@@ -246,12 +246,28 @@ pub(crate) fn assign_not_expr_mode(input: &str, mode: ExprMode) -> PResult<'_, E
     }
 
     // Try compound assignment operators (+=, *=, //=, etc.) before simple =
-    if let Some((after_op, op)) = parse_compound_assign_op(r) {
+    if !matches!(mode, ExprMode::NoSequenceNoFeed | ExprMode::ListopArg)
+        && let Some((after_op, op)) = parse_compound_assign_op(r)
+    {
         let (after_ws, _) = ws(after_op)?;
         if let Ok((r, rhs)) = parse_assignment_rhs_mode(after_ws, mode)
-            && let Ok(result) = build_compound_assign_expr(expr.clone(), op, rhs)
+            && let Ok(result) = build_compound_assign_expr(expr.clone(), op, rhs.clone())
         {
-            return Ok((r, result));
+            // The established nested-lvalue expansion consumes the inner
+            // marker when `($x += 2) *= 3` is parsed. Keep its historical
+            // `AssignExpr` shape so the outer writeback machinery (and its
+            // parser contract) continues to see the inner assignment.
+            if matches!(
+                &expr,
+                Expr::Grouped(inner)
+                    if matches!(inner.as_ref(), Expr::CompoundAssign { .. })
+            ) {
+                return Ok((r, result));
+            }
+            // Preserve the original lvalue for RakuAST. The marker is
+            // transparent to execution and keeps the established expansion
+            // (including dedicated index/method writeback) underneath it.
+            return Ok((r, compound_assign_marker(expr, op, rhs, result)));
         }
     }
 

--- a/src/parser/expr/precedence/ternary.rs
+++ b/src/parser/expr/precedence/ternary.rs
@@ -4,7 +4,10 @@ use crate::parser::primary::misc::colonpair_expr;
 pub(crate) fn is_assignment_expr(expr: &Expr) -> bool {
     matches!(
         expr,
-        Expr::AssignExpr { .. } | Expr::IndexAssign { .. } | Expr::MultiDimIndexAssign { .. }
+        Expr::AssignExpr { .. }
+            | Expr::CompoundAssign { .. }
+            | Expr::IndexAssign { .. }
+            | Expr::MultiDimIndexAssign { .. }
     )
 }
 
@@ -239,9 +242,12 @@ pub(crate) fn call_arg_expr(input: &str) -> PResult<'_, Expr> {
     if let Some((after_op, op)) = parse_compound_assign_op(r) {
         let (after_ws, _) = ws(after_op)?;
         if let Ok((r2, rhs)) = call_arg_ternary_expr(after_ws)
-            && let Ok(result) = build_compound_assign_expr(expr.clone(), op, rhs)
+            && let Ok(result) = build_compound_assign_expr(expr.clone(), op, rhs.clone())
         {
-            return Ok((r2, result));
+            return Ok((
+                r2,
+                crate::parser::stmt::assign::compound_assign_marker(expr, op, rhs, result),
+            ));
         }
     }
 

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -16,6 +16,25 @@ mod primary;
 mod quote_shadow;
 mod sink_warn;
 mod stmt;
+pub(crate) use stmt::assign::compound_assign_op_from_name;
+
+/// Reuse the parser's proven compound-assignment expansion from consumers that
+/// cannot name the parser's private parse-error type (such as RakuAST lowering).
+pub(crate) fn expand_compound_assign_expr(
+    lhs: crate::ast::Expr,
+    op: &str,
+    rhs: crate::ast::Expr,
+) -> Result<crate::ast::Expr, String> {
+    let op = compound_assign_op_from_name(op)
+        .ok_or_else(|| format!("unknown compound operator: {op}"))?;
+    if let crate::ast::Expr::Var(name) = &lhs
+        && let Some(short) =
+            stmt::assign::short_circuit_compound_assign_expr(name, lhs.clone(), op, rhs.clone())
+    {
+        return Ok(short);
+    }
+    stmt::assign::build_compound_assign_expr(lhs, op, rhs).map_err(|error| error.to_string())
+}
 pub(crate) mod stmt_ending_brace;
 pub(crate) mod term_boundary;
 mod whenever_scope;

--- a/src/parser/primary/container/paren.rs
+++ b/src/parser/primary/container/paren.rs
@@ -296,6 +296,7 @@ fn paren_expr_inner(input: &str) -> PResult<'_, Expr> {
             || matches!(
                 &result,
                 Expr::AssignExpr { .. }
+                    | Expr::CompoundAssign { .. }
                     | Expr::IndexAssign { .. }
                     | Expr::MultiDimIndexAssign { .. }
             )

--- a/src/parser/stmt/assign.rs
+++ b/src/parser/stmt/assign.rs
@@ -85,6 +85,7 @@ pub(in crate::parser) use try_assign::{paren_assign_rhs_is_complete, try_parse_a
 pub(crate) use bracket::parse_bracket_meta_assign_op;
 pub(crate) use compound_expr::{
     build_compound_assign_expr, build_custom_compound_assign_expr, build_meta_assign_expr,
+    compound_assign_marker, preserve_compound_assign,
 };
 pub(crate) use lvalue::{
     callable_lvalue_assign_expr, dynamic_method_lvalue_assign_expr, list_lvalue_assign_expr,

--- a/src/parser/stmt/assign/assign_stmt.rs
+++ b/src/parser/stmt/assign/assign_stmt.rs
@@ -93,26 +93,32 @@ pub(in crate::parser) fn assign_stmt(input: &str) -> PResult<'_, Stmt> {
         if let Some((after_op, op)) = parse_compound_assign_op(after_name) {
             let (after_op, _) = ws(after_op)?;
             let (rest, rhs) = parse_assign_expr_or_comma(after_op)?;
-            let current_value = Expr::MethodCall {
+            let source_target = Expr::MethodCall {
                 target: Box::new(var_expr.clone()),
                 name: Symbol::intern(&method_name),
                 args: Vec::new(),
                 modifier: None,
                 quoted: false,
             };
-            let updated_value = compound_assigned_value_expr(current_value, op, rhs);
+            let marker_rhs = rhs.clone();
+            let updated_value = compound_assigned_value_expr(source_target.clone(), op, rhs);
             let assign_call = Expr::Call {
                 name: Symbol::intern("__mutsu_assign_method_lvalue"),
                 args: vec![
                     var_expr,
-                    Expr::Literal(Value::str(method_name)),
+                    Expr::Literal(Value::str(method_name.clone())),
                     Expr::ArrayLiteral(Vec::new()),
                     updated_value,
                     Expr::Literal(Value::str(name.clone())),
                     Expr::Literal(Value::truth(true)),
                 ],
             };
-            let stmt = Stmt::Expr(assign_call);
+            let stmt = Stmt::Expr(compound_assign_marker(
+                source_target,
+                op,
+                marker_rhs,
+                assign_call,
+            ));
             return parse_statement_modifier(rest, stmt);
         }
     }
@@ -265,11 +271,16 @@ pub(in crate::parser) fn assign_stmt(input: &str) -> PResult<'_, Stmt> {
             && let Some(short) =
                 short_circuit_compound_assign_expr(&name, var_expr.clone(), op, rhs.clone())
         {
-            Stmt::Expr(short)
+            Stmt::Expr(compound_assign_marker(
+                var_expr.clone(),
+                op,
+                rhs.clone(),
+                short,
+            ))
         } else {
             Stmt::Assign {
                 name: name.clone(),
-                expr: compound_assigned_value_expr(var_expr, op, rhs),
+                expr: preserve_compound_assign(var_expr, op, rhs)?,
                 op: AssignOp::Assign,
             }
         };

--- a/src/parser/stmt/assign/compound_expr.rs
+++ b/src/parser/stmt/assign/compound_expr.rs
@@ -75,6 +75,13 @@ pub(crate) fn build_compound_assign_expr(
                 param_sigilless: false,
             }
         }
+        Expr::CompoundAssign { expanded, .. } => {
+            // The source marker is transparent to the execution AST. Reuse the
+            // established nested-assignment handling when another compound op
+            // applies to `($x OP= y)`; retaining the inner marker here would make
+            // the outer lvalue look immutable to the existing expansion logic.
+            return build_compound_assign_expr(*expanded, op, rhs);
+        }
         Expr::AssignExpr {
             name,
             expr,
@@ -403,6 +410,35 @@ pub(crate) fn build_compound_assign_expr(
             }
         }
     })
+}
+
+/// Preserve a compound assignment's source-level shape while retaining the
+/// already-proven execution expansion used by the compiler.
+pub(crate) fn preserve_compound_assign(
+    lhs: Expr,
+    op: CompoundAssignOp,
+    rhs: Expr,
+) -> Result<Expr, PError> {
+    let expanded = build_compound_assign_expr(lhs.clone(), op, rhs.clone())?;
+    Ok(compound_assign_marker(lhs, op, rhs, expanded))
+}
+
+/// Wrap an already-built execution expansion with the source-level compound
+/// assignment metadata. This variant is used for short-circuit compound
+/// assignments, whose expansion is intentionally different from the ordinary
+/// METAOP_ASSIGN path.
+pub(crate) fn compound_assign_marker(
+    lhs: Expr,
+    op: CompoundAssignOp,
+    rhs: Expr,
+    expanded: Expr,
+) -> Expr {
+    Expr::CompoundAssign {
+        target: Box::new(lhs),
+        op: op.symbol().to_string(),
+        rhs: Box::new(rhs),
+        expanded: Box::new(expanded),
+    }
 }
 
 pub(crate) fn build_custom_compound_assign_expr(

--- a/src/parser/stmt/assign/try_assign.rs
+++ b/src/parser/stmt/assign/try_assign.rs
@@ -471,16 +471,9 @@ pub(in crate::parser) fn try_parse_assign_expr(input: &str) -> PResult<'_, Expr>
             && let Some(short) =
                 short_circuit_compound_assign_expr(&name, lhs_expr.clone(), op, rhs.clone())
         {
-            return Ok((rest, short));
+            return Ok((rest, compound_assign_marker(lhs_expr, op, rhs, short)));
         }
-        return Ok((
-            rest,
-            Expr::AssignExpr {
-                name,
-                expr: Box::new(compound_assigned_value_expr(lhs_expr, op, rhs)),
-                is_bind: false,
-            },
-        ));
+        return Ok((rest, preserve_compound_assign(lhs_expr, op, rhs)?));
     }
     if let Some((stripped, meta, op)) = parse_meta_compound_assign_op(r2) {
         let (rest, _) = ws(stripped)?;

--- a/src/parser/stmt/simple_expr_stmt/core.rs
+++ b/src/parser/stmt/simple_expr_stmt/core.rs
@@ -8,9 +8,9 @@ use crate::parser::parse_result::{
 };
 use crate::parser::primary::parse_call_arg_list;
 use crate::parser::stmt::assign::{
-    CompoundAssignOp, build_compound_assign_expr, compound_assigned_value_expr,
-    parse_assign_expr_or_comma, parse_comma_or_expr, parse_compound_assign_op,
-    parse_set_compound_assign_op,
+    CompoundAssignOp, build_compound_assign_expr, compound_assign_marker,
+    compound_assigned_value_expr, parse_assign_expr_or_comma, parse_comma_or_expr,
+    parse_compound_assign_op, parse_set_compound_assign_op,
 };
 use crate::parser::stmt::modifier::{is_stmt_modifier_keyword, parse_statement_modifier};
 use crate::parser::stmt::simple::{
@@ -1388,6 +1388,7 @@ pub(crate) fn expr_stmt(input: &str) -> PResult<'_, Stmt> {
                 index: Box::new(tmp_idx_expr.clone()),
                 is_positional: *is_positional,
             };
+            let marker_rhs = rhs.clone();
             let assigned_value = if matches!(op, CompoundAssignOp::DefinedOr) {
                 Expr::Ternary {
                     cond: Box::new(Expr::Call {
@@ -1404,7 +1405,7 @@ pub(crate) fn expr_stmt(input: &str) -> PResult<'_, Stmt> {
                     right: Box::new(rhs),
                 }
             };
-            let stmt = Stmt::Expr(Expr::DoBlock {
+            let expanded = Expr::DoBlock {
                 body: vec![
                     Stmt::VarDecl {
                         name: tmp_idx.clone(),
@@ -1426,7 +1427,13 @@ pub(crate) fn expr_stmt(input: &str) -> PResult<'_, Stmt> {
                     }),
                 ],
                 label: None,
-            });
+            };
+            let stmt = Stmt::Expr(compound_assign_marker(
+                expr.clone(),
+                op,
+                marker_rhs,
+                expanded,
+            ));
             return parse_statement_modifier(r, stmt);
         }
         // Handle method call compound assignment: .key //= val, .key += val, etc.
@@ -1438,6 +1445,7 @@ pub(crate) fn expr_stmt(input: &str) -> PResult<'_, Stmt> {
             ..
         } = expr
         {
+            let marker_rhs = rhs.clone();
             let assigned_value = compound_assigned_value_expr(expr.clone(), op, rhs);
             // Determine the topic variable name for writeback
             let topic_name = if let Expr::Var(ref v) = **target {
@@ -1450,7 +1458,7 @@ pub(crate) fn expr_stmt(input: &str) -> PResult<'_, Stmt> {
             } else {
                 name.resolve()
             };
-            let stmt = Stmt::Expr(Expr::Call {
+            let expanded = Expr::Call {
                 name: Symbol::intern("__mutsu_assign_method_lvalue"),
                 args: vec![
                     (**target).clone(),
@@ -1460,7 +1468,13 @@ pub(crate) fn expr_stmt(input: &str) -> PResult<'_, Stmt> {
                     Expr::Literal(crate::value::Value::str(topic_name)),
                     Expr::Literal(crate::value::Value::truth(true)),
                 ],
-            });
+            };
+            let stmt = Stmt::Expr(compound_assign_marker(
+                expr.clone(),
+                op,
+                marker_rhs,
+                expanded,
+            ));
             return parse_statement_modifier(r, stmt);
         }
         // `(cond ?? $a !! $b) op= rhs` (unparenthesized): the ternary is an

--- a/src/rakuast/convert.rs
+++ b/src/rakuast/convert.rs
@@ -576,11 +576,17 @@ fn convert_stmt(stmt: &Stmt) -> Result<Option<RakuAstNode>, RuntimeError> {
             )?)))
         }
         Stmt::Assign { name, expr, op } => match op {
-            // `$x = EXPR` — the special `Assignment` infix (slice 2). Note mutsu
-            // desugars `$x += 3` to `$x = $x + 3` (op stays `Assign`), so a
-            // compound assignment renders as a plain `=` over a binop rather than
-            // raku's `MetaInfix::Assign` — a documented divergence.
-            AssignOp::Assign => Ok(Some(statement_expression(assignment_infix(name, expr)?))),
+            // `$x = EXPR` — the special `Assignment` infix (slice 2). A compound
+            // assignment keeps its source-level metaop marker inside the ordinary
+            // assignment expansion used by the compiler.
+            AssignOp::Assign => match expr {
+                Expr::CompoundAssign {
+                    target, op, rhs, ..
+                } if compound_target_matches_name(target, name) => Ok(Some(statement_expression(
+                    compound_assignment_infix(target, op, rhs)?,
+                ))),
+                _ => Ok(Some(statement_expression(assignment_infix(name, expr)?))),
+            },
             // `$x := EXPR` — a plain `:=` infix (slice 9).
             AssignOp::Bind => Ok(Some(statement_expression(bind_infix(name, expr)?))),
             AssignOp::MatchAssign => Err(unsupported("`~~` match-assignment")),
@@ -646,6 +652,40 @@ fn plain_infix(op: &str) -> RakuAstNode {
     RakuAstNode {
         class: RakuAstClass::Infix,
         fields: vec![leaf_field(None, Value::str(op.to_string()))],
+    }
+}
+
+/// `$x OP= EXPR` -> `ApplyInfix(left, MetaInfix::Assign(Infix(OP)), right)`.
+fn compound_assignment_infix(
+    target: &Expr,
+    op: &str,
+    rhs: &Expr,
+) -> Result<RakuAstNode, RuntimeError> {
+    let base_op = op.strip_suffix('=').unwrap_or(op);
+    let meta_assign = RakuAstNode {
+        class: RakuAstClass::MetaInfixAssign,
+        fields: vec![node_field(None, plain_infix(base_op))],
+    };
+    Ok(RakuAstNode {
+        class: RakuAstClass::ApplyInfix,
+        fields: vec![
+            node_field(Some("left"), convert_expr(target)?),
+            node_field(Some("infix"), meta_assign),
+            node_field(Some("right"), convert_expr(rhs)?),
+        ],
+    })
+}
+
+/// A compound marker may be nested in the RHS of a separate assignment. Only
+/// the marker that names the statement's own target replaces `Assignment` with
+/// `MetaInfix::Assign`; nested markers stay under the outer assignment node.
+fn compound_target_matches_name(target: &Expr, name: &str) -> bool {
+    match target {
+        Expr::Var(target_name) => target_name == name,
+        Expr::ArrayVar(target_name) => name == format!("@{target_name}"),
+        Expr::HashVar(target_name) => name == format!("%{target_name}"),
+        Expr::CodeVar(target_name) => name == format!("&{target_name}"),
+        _ => false,
     }
 }
 
@@ -931,6 +971,9 @@ fn convert_expr(expr: &Expr) -> Result<RakuAstNode, RuntimeError> {
             }
             assignment_infix(name, expr)
         }
+        Expr::CompoundAssign {
+            target, op, rhs, ..
+        } => compound_assignment_infix(target, op, rhs),
         Expr::ArrayVar(name) => Ok(var_lexical("@", name)),
         Expr::HashVar(name) => Ok(var_lexical("%", name)),
         Expr::CodeVar(name) => Ok(var_lexical("&", name)),

--- a/src/rakuast/lower.rs
+++ b/src/rakuast/lower.rs
@@ -90,6 +90,12 @@ fn lower_stmt_inner(node: &RakuAstNode) -> Result<Stmt, RuntimeError> {
         RakuAstClass::StatementDefault => {
             Ok(Stmt::Default(lower_block(named_child(node, "body")?)?))
         }
+        // `$x OP= EXPR` is represented by a `MetaInfix::Assign` child. Keep the
+        // source-level marker while reusing the parser's existing execution
+        // expansion.
+        RakuAstClass::ApplyInfix if infix_is_compound_assignment(node) => {
+            Ok(Stmt::Expr(lower_compound_assign_expr(node)?))
+        }
         // `$x = EXPR` is an `ApplyInfix` whose infix is an `Assignment` node; it is
         // a `Stmt::Assign`, not a general binary expression.
         RakuAstClass::ApplyInfix if infix_is_assignment(node) => lower_assign(node),
@@ -506,6 +512,33 @@ fn infix_is_assignment(node: &RakuAstNode) -> bool {
         .unwrap_or(false)
 }
 
+/// Whether an `ApplyInfix` uses Raku's compound-assignment metaoperator.
+fn infix_is_compound_assignment(node: &RakuAstNode) -> bool {
+    named_child(node, "infix")
+        .map(|child| child.class == RakuAstClass::MetaInfixAssign)
+        .unwrap_or(false)
+}
+
+/// Lower `ApplyInfix(MetaInfix::Assign(Infix(OP)))` to the parser's existing
+/// compound-assignment execution shape while retaining the source marker.
+fn lower_compound_assign_expr(node: &RakuAstNode) -> Result<Expr, RuntimeError> {
+    let target = lower_expr(named_child(node, "left")?)?;
+    let meta = named_child(node, "infix")?;
+    let op = match positional_leaf(named_child_or_positional(meta)?)?.view() {
+        ValueView::Str(value) => value.to_string(),
+        _ => return Err(unsupported(node)),
+    };
+    let rhs = lower_expr(named_child(node, "right")?)?;
+    let expanded = crate::parser::expand_compound_assign_expr(target.clone(), &op, rhs.clone())
+        .map_err(RuntimeError::new)?;
+    Ok(Expr::CompoundAssign {
+        target: Box::new(target),
+        op: format!("{op}="),
+        rhs: Box::new(rhs),
+        expanded: Box::new(expanded),
+    })
+}
+
 /// The `(name, right)` of an `ApplyInfix(Assignment)`: the target variable name
 /// (`$` sigil stripped to match the parser's naming; `@`/`%`/`&` kept) and the
 /// lowered right-hand side.
@@ -775,6 +808,10 @@ fn lower_expr(node: &RakuAstNode) -> Result<Expr, RuntimeError> {
                 "&" => Expr::CodeVar(bare.to_string()),
                 _ => Expr::Var(bare.to_string()),
             })
+        }
+        // `($x OP= EXPR)` in expression position -> a compound assignment.
+        RakuAstClass::ApplyInfix if infix_is_compound_assignment(node) => {
+            lower_compound_assign_expr(node)
         }
         // `($x = EXPR)` in expression position -> an assignment expression.
         RakuAstClass::ApplyInfix if infix_is_assignment(node) => {

--- a/src/rakuast/mod.rs
+++ b/src/rakuast/mod.rs
@@ -71,6 +71,7 @@ pub enum RakuAstClass {
     ApplyPostfix,
     Postfix,
     Assignment,
+    MetaInfixAssign,
     CallMethod,
     // Phase 2 slice 23: quoted method names.
     CallQuotedMethod,
@@ -193,6 +194,7 @@ impl RakuAstClass {
             ApplyPostfix => "RakuAST::ApplyPostfix",
             Postfix => "RakuAST::Postfix",
             Assignment => "RakuAST::Assignment",
+            MetaInfixAssign => "RakuAST::MetaInfix::Assign",
             CallMethod => "RakuAST::Call::Method",
             CallQuotedMethod => "RakuAST::Call::QuotedMethod",
             MetaPostfixHyper => "RakuAST::MetaPostfix::Hyper",
@@ -470,6 +472,7 @@ const RAKUAST_CLASSES: &[RakuAstClass] = &[
     RakuAstClass::ApplyPostfix,
     RakuAstClass::Postfix,
     RakuAstClass::Assignment,
+    RakuAstClass::MetaInfixAssign,
     RakuAstClass::CallMethod,
     RakuAstClass::CallQuotedMethod,
     RakuAstClass::MetaPostfixHyper,
@@ -930,6 +933,7 @@ fn single_positional_class(class_name: &str, method: &str) -> Option<RakuAstClas
         ("RakuAST::Name", "from-identifier") => RakuAstClass::Name,
         ("RakuAST::Term::Enum", "from-identifier") => RakuAstClass::TermEnum,
         ("RakuAST::Infix", "new") => RakuAstClass::Infix,
+        ("RakuAST::MetaInfix::Assign", "new") => RakuAstClass::MetaInfixAssign,
         ("RakuAST::Prefix", "new") => RakuAstClass::Prefix,
         ("RakuAST::Var::Lexical", "new") => RakuAstClass::VarLexical,
         ("RakuAST::Initializer::Assign", "new") => RakuAstClass::InitializerAssign,
@@ -1010,6 +1014,7 @@ pub fn node_accessor(node: &RakuAstNode, method: &str) -> Option<Value> {
         RakuAstClass::VarLexical => Some("name"),
         RakuAstClass::Blockoid => Some("statement-list"),
         RakuAstClass::InitializerAssign => Some("expression"),
+        RakuAstClass::MetaInfixAssign => Some("infix"),
         RakuAstClass::TypeSimple | RakuAstClass::TypeSetting => Some("name"),
         RakuAstClass::TraitReturns | RakuAstClass::TraitOf => Some("type"),
         _ => None,
@@ -1082,6 +1087,7 @@ fn constructor_is_supported(class: RakuAstClass) -> bool {
             | RakuAstClass::ApplyPrefix
             | RakuAstClass::ApplyPostfix
             | RakuAstClass::Postfix
+            | RakuAstClass::MetaInfixAssign
             | RakuAstClass::Block
             | RakuAstClass::Blockoid
             | RakuAstClass::Sub
@@ -1112,6 +1118,7 @@ fn accessor_names(class: RakuAstClass) -> &'static [&'static str] {
         Blockoid => &["statement-list"],
         Sub => &["name", "signature", "traits", "body"],
         Signature => &["parameters", "returns"],
+        MetaInfixAssign => &["infix"],
         MetaInfixHyper => &["dwim-left", "infix", "dwim-right"],
         TraitReturns | TraitOf => &["type"],
         Parameter => &[

--- a/src/runtime/dispatch_proto_rewrite.rs
+++ b/src/runtime/dispatch_proto_rewrite.rs
@@ -218,6 +218,21 @@ impl Interpreter {
                 expr: Box::new(Self::rewrite_proto_dispatch_expr(expr)),
                 is_bind: *is_bind,
             },
+            // Source-preserving compound assignments keep the executable
+            // expansion under a marker. Proto bodies still need `{*}` in that
+            // expansion rewritten to `__PROTO_DISPATCH__`, just as the
+            // pre-marker assignment tree was.
+            Expr::CompoundAssign {
+                target,
+                op,
+                rhs,
+                expanded,
+            } => Expr::CompoundAssign {
+                target: Box::new(Self::rewrite_proto_dispatch_expr(target)),
+                op: op.clone(),
+                rhs: Box::new(Self::rewrite_proto_dispatch_expr(rhs)),
+                expanded: Box::new(Self::rewrite_proto_dispatch_expr(expanded)),
+            },
             Expr::Block(stmts) => Expr::Block(Self::rewrite_proto_dispatch_stmts(stmts)),
             Expr::DoBlock { body, label } => Expr::DoBlock {
                 body: Self::rewrite_proto_dispatch_stmts(body),

--- a/src/whatever_curry/mark/expr.rs
+++ b/src/whatever_curry/mark/expr.rs
@@ -173,6 +173,20 @@ pub(super) fn mark_expr(expr: &mut Expr) {
         }
         // `($x = *)` / `($x := *)` in expression position.
         Expr::AssignExpr { expr, .. } => mark_value_leaf(expr),
+        // A source-preserving compound assignment has three views of its
+        // children: the source target/RHS used by RakuAST and the expanded
+        // execution expression used by the compiler. Mark all of them so a
+        // Whatever leaf has the same role whichever view is later consumed.
+        Expr::CompoundAssign {
+            target,
+            rhs,
+            expanded,
+            ..
+        } => {
+            mark_expr(target);
+            mark_value_leaf(rhs);
+            mark_expr(expanded);
+        }
         Expr::Call { args, .. } | Expr::UserRoutineCall { args, .. } => {
             for a in args {
                 mark_value_leaf(a);

--- a/t/rakuast-compound-assign.t
+++ b/t/rakuast-compound-assign.t
@@ -1,0 +1,60 @@
+use v6;
+use experimental :rakuast;
+use MONKEY-SEE-NO-EVAL;
+use Test;
+
+# Compound assignment keeps its RakuAST metaoperator instead of exposing the
+# parser's execution-only assignment expansion.
+plan 19;
+
+my $ast = Q[my $x = 1; $x += 3].AST;
+ok $ast.gist.contains('RakuAST::MetaInfix::Assign.new'),
+    'compound assignment renders its metaoperator';
+ok $ast.gist.contains('RakuAST::Infix.new("+")'),
+    'compound assignment renders the base infix';
+is $ast.statements[1].expression.infix.^name,
+    'RakuAST::MetaInfix::Assign',
+    'compound assignment exposes MetaInfix::Assign';
+is $ast.statements[1].expression.infix.infix.gist,
+    'RakuAST::Infix.new("+")',
+    'compound assignment exposes its base infix node';
+
+my $indexed = Q[my @a = 1; @a[0] += 3].AST;
+is $indexed.statements[1].expression.infix.^name,
+    'RakuAST::MetaInfix::Assign',
+    'indexed compound assignment exposes MetaInfix::Assign';
+is EVAL(Q[my @a = 1; @a[0] += 3; @a[0]].AST), 4,
+    'EVAL of an indexed compound assignment executes';
+
+my $at-pos = Q[my @a = 1; @a.AT-POS(0) += 2].AST;
+is $at-pos.statements[1].expression.infix.^name,
+    'RakuAST::MetaInfix::Assign',
+    'AT-POS compound assignment exposes MetaInfix::Assign';
+is EVAL(Q[my @a = 1; @a.AT-POS(0) += 2; @a[0]].AST), 3,
+    'EVAL of an AT-POS compound assignment executes';
+
+my $meta = RakuAST::MetaInfix::Assign.new(RakuAST::Infix.new('+'));
+isa-ok $meta, RakuAST::MetaInfix::Assign,
+    'MetaInfix::Assign can be constructed';
+is $meta.infix.gist, 'RakuAST::Infix.new("+")',
+    'constructed MetaInfix::Assign exposes its infix';
+ok 'new' (elem) RakuAST::MetaInfix::Assign.^methods(:local)>>.name
+    && 'infix' (elem) RakuAST::MetaInfix::Assign.^methods(:local)>>.name,
+    'MetaInfix::Assign advertises constructor and accessor';
+
+is EVAL(Q[my $x = 1; $x += 3; $x].AST), 4,
+    'EVAL of a constructed + assignment executes';
+is EVAL(Q[my $x = 7; $x -= 2; $x].AST), 5,
+    'EVAL of a constructed - assignment executes';
+is EVAL(Q[my $x = 4; $x *= 3; $x].AST), 12,
+    'EVAL of a constructed * assignment executes';
+is EVAL(Q[my $x = 'a'; $x ~= 'b'; $x].AST), 'ab',
+    'EVAL of a constructed ~ assignment executes';
+is EVAL(Q[my $x; $x //= 9; $x].AST), 9,
+    'EVAL of a constructed // assignment executes';
+is EVAL(Q[my $x = 0; $x ||= 9; $x].AST), 9,
+    'EVAL of a constructed || assignment executes';
+is EVAL(Q[my $x = 1; $x &&= 9; $x].AST), 9,
+    'EVAL of a constructed && assignment executes';
+is EVAL(Q[my $x = 2; ($x += 3) * 2].AST), 10,
+    'compound assignment remains usable in expression position';

--- a/todo/deep/rakuast-remaining.md
+++ b/todo/deep/rakuast-remaining.md
@@ -36,12 +36,14 @@ the parser/internal AST, not guessing during RakuAST conversion.
 
 Still open:
 
-- `.=` and compound assignment. `$x += 3` desugars to
-  `$x = MetaAssignIdentity(Zero)($x) + 3` (raku: `MetaInfix::Assign(Infix("+"))`)
-  and `$x .= Str` desugars to a plain `=` over a method call (raku:
-  `ApplyDottyInfix` + `DottyInfix::CallAssign`). Both need the parser to keep
-  the meta-operator instead of expanding it. ADR-0033 §2.5 already blocks the
-  `* += 1` Whatever autoprime path on the same missing `MetaInfix::Assign`.
+- `.=` and Whatever compound autoprime. `$x .= Str` desugars to a plain `=` over
+  a method call (raku: `ApplyDottyInfix` + `DottyInfix::CallAssign`) and still
+  needs the parser to retain its dotty-infix form. Core compound assignment is
+  now closed: `+=`, `-=`, `*=`, `~=`, `//=`, `||=`, `&&=`, indexed lvalues, and
+  `AT-POS` lvalues preserve `MetaInfix::Assign(Infix(...))` for `.AST`, while
+  `EVAL` reuses the existing execution expansion. The `* += 1` Whatever
+  autoprime path remains a separate boundary because it still builds its
+  closure before conversion; ADR-0033 §2.5 tracks that case.
 - Signature return types **on methods**. `method m(--> Int)` is still deferred:
   `src/parser/stmt/sub_param/method_decl.rs` filters every `__`-prefixed marker
   out of `MethodDecl.custom_traits`, so `-->` and `returns` are indistinguishable


### PR DESCRIPTION
## Summary

- Preserve ordinary compound assignments as Expr::CompoundAssign markers so RakuAST renders MetaInfix::Assign(Infix(...)).
- Reuse the existing parser/compiler execution expansion, including indexed and AT-POS lvalues, short-circuit forms, proto dispatch, and Whatever/placeholder traversal.
- Add construction, EVAL, and dual-oracle regression coverage; document remaining .= and Whatever autoprime gaps.

## Validation

- cargo fmt --all
- cargo clippy -- -D warnings
- make test
- make roast
- MUTSU_BIN=target/debug/mutsu MUTSU_T_TIMEOUT=60 prove -e 'scripts/run-t-test.sh' t/rakuast*.t