### PR TITLE
fix: a nested Capture literal keeps its nesting

### DIFF
--- a/news/2026-09/nested-capture-literal-flattened.md
+++ b/news/2026-09/nested-capture-literal-flattened.md
@@ -1,0 +1,36 @@
+# A nested Capture literal kept its nesting
+
+```raku
+say \(1, \(2, 3)).raku;   # raku: \(1, \(2, 3))   mutsu: \(1, 2, 3)
+```
+
+`OpCode::MakeCapture` flattened every `Capture` element it was handed, on the
+comment's stated theory that such an element "came from a `|capture` slip". It
+could not have: `|EXPR` compiles to `MakeSlip`, so an interpolated capture
+arrives as a `Slip` and is handled by the arm below it. The only Captures
+reaching the flattening arm were genuine *nested literals* — which Raku nests
+like any other value.
+
+Found while bundling the `XML` battery. `XML::Element!craft-new` branches on
+`$what ~~ Capture` to recurse into a child element, so a nested literal is how
+you write a tree in one expression:
+
+```raku
+say ~make-xml('rss', :version<2.0>, \('channel', \('title', 'mutsu')));
+# raku : <rss version="2.0"><channel><title>mutsu</title></channel></rss>
+# mutsu: <rss version="2.0"><channel>title mutsu</channel></rss>   (before)
+```
+
+The inner capture was dissolved into the outer one before `craft-new` ever saw
+it, so the whole subtree collapsed into text on the parent.
+
+This is the *building* counterpart of
+`news/2026-09/slip-array-element-capture-not-respread.md`, which fixed the same
+mistaken assumption on the *consuming* side (`append_slip_item` re-spreading a
+Capture that merely sat in a slipped array). Both arms assumed "a Capture here
+must be a slip"; neither could be, because `|` has its own opcode.
+
+Pin: `t/nested-capture-literal.t` (10 subtests, passes under `raku` too) —
+covering two and three levels of nesting, `|$capture` still flattening (both
+lanes), a nested capture surviving a slurpy and a re-splatted slurpy, and
+`~~ Capture` matching the element (the predicate `craft-new` uses).

--- a/src/vm/vm_data_ops.rs
+++ b/src/vm/vm_data_ops.rs
@@ -492,14 +492,15 @@ impl Interpreter {
                         named.insert(k.clone(), v.clone());
                     }
                 }
-                ValueView::Capture {
-                    positional: p,
-                    named: n,
-                } => {
-                    // Flatten inner capture (from |capture slip)
-                    positional.extend(p.iter().cloned());
-                    named.extend(n.iter().map(|(k, v)| (k.clone(), v.clone())));
-                }
+                // NOTE: a bare `Capture` element is NOT flattened -- `\(1, \(2,3))`
+                // is a two-element Capture whose second element is a Capture,
+                // exactly like any other nested value. Interpolating one is
+                // spelled `\(1, |$c)`, and `|` compiles to `MakeSlip`, so it
+                // arrives in the arm below. (This arm used to flatten every
+                // Capture element on the theory that it came from a slip, which
+                // silently dissolved every nested capture literal -- XML's
+                // `make-xml('rss', \('channel', \('title', 'x')))` built one
+                // flat element instead of a tree.)
                 ValueView::Slip(items) => {
                     for item in items.iter() {
                         match item.view() {

--- a/t/nested-capture-literal.t
+++ b/t/nested-capture-literal.t
@@ -1,0 +1,47 @@
+use Test;
+
+# A Capture literal nests like any other value: `\(1, \(2,3))` is a
+# two-element Capture whose second element is itself a Capture. mutsu used to
+# flatten every Capture element while BUILDING a capture, on the theory that it
+# could only have come from a `|` slip -- but `|` compiles to its own opcode, so
+# the only Captures reaching that arm were genuine nested literals. XML's
+# `make-xml('rss', \('channel', \('title', 'x')))` built one flat element
+# instead of a tree.
+
+plan 10;
+
+{
+    is \(1, \(2, 3)).raku, '\\(1, \\(2, 3))', 'a nested capture literal keeps its nesting';
+    is \(1, \(2, 3)).elems, 2, 'and counts as two positionals';
+    is \('a', \('b', \('c', 'd'))).raku, '\\("a", \\("b", \\("c", "d")))',
+        'three levels nest too';
+}
+
+# `|` still interpolates -- that is the spelling for flattening one in.
+{
+    my $c = \(2, 3);
+    is \(1, |$c).raku, '\\(1, 2, 3)', '|$capture flattens into the outer capture';
+    my $d = \(:a<x>);
+    is \(1, |$d).raku, '\\(1, :a("x"))', 'and carries its named lane over';
+}
+
+# A nested Capture survives being passed through a slurpy.
+{
+    sub probe(Str $n, *@c, *%a) { ($n, @c.raku, %a.raku).join(' | ') }
+    is probe('rss', \('channel', \('title', 'x'))),
+        'rss | [\\("channel", \\("title", "x"))] | {}',
+        'a slurpy sees the nested capture whole';
+    sub relay(Str $n, *@contents, *%attribs) { probe($n, |@contents, |%attribs) }
+    is relay('rss', :v<yes>, \('channel', \('title', 'x'))),
+        'rss | [\\("channel", \\("title", "x"))] | {:v("yes")}',
+        'and so does a re-splatted slurpy';
+}
+
+# A Capture element is a Capture, so `~~ Capture` sees it (this is how
+# XML::Element!craft-new decides to recurse into a child element).
+{
+    my @parts = \(1, \(2, 3)).list;
+    is @parts.elems, 2, 'the positional lane has both elements';
+    ok @parts[1] ~~ Capture, 'and the second one smartmatches Capture';
+    is @parts[1].raku, '\\(2, 3)', 'with its own contents intact';
+}


### PR DESCRIPTION
## What

```raku
say \(1, \(2, 3)).raku;   # raku: \(1, \(2, 3))   mutsu: \(1, 2, 3)
```

`OpCode::MakeCapture` flattened every `Capture` element it was handed, on the comment's stated theory that such an element *"came from a `|capture` slip"*. It could not have: `|EXPR` compiles to `MakeSlip`, so an interpolated capture arrives as a `Slip` and is handled by the arm right below it. The only Captures reaching the flattening arm were genuine **nested literals** — which Raku nests like any other value.

## Why it matters

Found while bundling the `XML` battery. `XML::Element!craft-new` branches on `$what ~~ Capture` to recurse into a child element, so a nested literal is how you write a tree in one expression:

```raku
say ~make-xml('rss', :version<2.0>, \('channel', \('title', 'mutsu')));
# raku : <rss version="2.0"><channel><title>mutsu</title></channel></rss>
# mutsu: <rss version="2.0"><channel>title mutsu</channel></rss>   (before)
```

The inner capture was dissolved into the outer one before `craft-new` ever saw it, so the subtree collapsed into text on the parent.

This is the **building** counterpart of #7233, which fixed the same mistaken assumption on the **consuming** side (`append_slip_item` re-spreading a Capture that merely sat in a slipped array). Both arms assumed "a Capture here must be a slip"; neither could be, because `|` has its own opcode.

## Tests

- New `t/nested-capture-literal.t` (10 subtests) — passes under `raku` too. Two and three levels of nesting, `|$capture` still flattening (both lanes), a nested capture surviving a slurpy and a re-splatted slurpy, and `~~ Capture` matching the element (the predicate `craft-new` uses).
- `make test` PASS, **full `make roast` PASS** (1436 files, 218962 tests), `scripts/battery-testsuite.sh` GATE PASSED (274/297).

🤖 Generated with [Claude Code](https://claude.com/claude-code)