### PR TITLE
fix: support topic dotassign colon arguments

### DIFF
--- a/src/parser/stmt/simple_expr_stmt/core.rs
+++ b/src/parser/stmt/simple_expr_stmt/core.rs
@@ -9,8 +9,8 @@ use crate::parser::parse_result::{
 use crate::parser::primary::parse_call_arg_list;
 use crate::parser::stmt::assign::{
     CompoundAssignOp, build_compound_assign_expr, compound_assign_marker,
-    compound_assigned_value_expr, parse_assign_expr_or_comma, parse_comma_or_expr,
-    parse_compound_assign_op, parse_set_compound_assign_op,
+    compound_assigned_value_expr, parse_assign_expr_or_comma, parse_colon_args,
+    parse_comma_or_expr, parse_compound_assign_op, parse_set_compound_assign_op,
 };
 use crate::parser::stmt::modifier::{is_stmt_modifier_keyword, parse_statement_modifier};
 use crate::parser::stmt::simple::{
@@ -119,7 +119,16 @@ pub(crate) fn expr_stmt(input: &str) -> PResult<'_, Stmt> {
             let (r, _) = parse_char(r, ')')?;
             (r, args)
         } else {
-            (rest, Vec::new())
+            // `.=method: args` is the topic form of the same colon-argument
+            // syntax supported by `$var .= method: args`. Keep the original
+            // remainder when there is no argument list so statement modifiers
+            // continue to see their leading whitespace.
+            let (r, _) = ws(rest)?;
+            if r.starts_with(':') && !r.starts_with("::") {
+                parse_colon_args(r)?
+            } else {
+                (rest, Vec::new())
+            }
         };
         // The `.=` metaop on the topic. Route through the `__mutsu_topic_dotassign`
         // marker (compiled to `TopicDotAssign`) so it can reassign a read-only

--- a/src/parser/stmt/tests_2.rs
+++ b/src/parser/stmt/tests_2.rs
@@ -123,6 +123,26 @@ fn parse_topic_mutating_method_stmt() {
 }
 
 #[test]
+fn parse_topic_mutating_method_stmt_with_colon_args() {
+    let src = r#".=trans: { $_ => $_».rotate(13) }({[$_».uc, @$_]}("a".."z"));"#;
+    let (rest, stmts) = program(src).unwrap();
+    assert_eq!(rest, "");
+    assert_eq!(stmts.len(), 1);
+    match &stmts[0] {
+        Stmt::Expr(Expr::Call { name, args }) => {
+            assert_eq!(name.resolve(), "__mutsu_topic_dotassign");
+            assert_eq!(args.len(), 1);
+            assert!(
+                matches!(args[0], Expr::MethodCall { ref name, ref args, .. }
+                if name.resolve() == "trans" && args.len() == 1
+                    && matches!(args[0], Expr::CallOn { .. }))
+            );
+        }
+        other => panic!("expected topic dotassign call, got {other:?}"),
+    }
+}
+
+#[test]
 fn parse_paren_expr_mutating_method_stmt() {
     let (rest, stmts) = program("(class { method foo() { self } }.new).=foo;").unwrap();
     assert_eq!(rest, "");

--- a/src/runtime/methods_trans.rs
+++ b/src/runtime/methods_trans.rs
@@ -110,37 +110,24 @@ fn expand_trans_spec(spec: &str) -> Vec<char> {
     result
 }
 
-/// Convert a Value to a list of strings (for array-based trans pairs).
-/// Arrays are flattened, Ranges are iterated, strings are expanded via `expand_trans_spec`.
+/// Convert a Value to a list of strings (for collection-based trans pairs).
+/// Nested list-like values are flattened, Ranges are iterated, and strings are
+/// expanded via `expand_trans_spec`. `Str.trans` accepts a Pair whose key and
+/// value can be nested collections, as in the Rosetta Code Rot-13 example.
 fn value_to_string_list(v: &Value) -> Vec<String> {
     match v.view() {
-        ValueView::Array(items, ..) => {
-            let mut result = Vec::new();
-            for item in items.iter() {
-                // ADR-0040 slices 1-2: a grouped `trans` operand
-                // (`'a'..'z' => ['n'..'z','a'..'m']`) is an array literal whose
-                // `Range` elements are itemized at the store; the grouping only
-                // means "expand each of these in turn", so the element's own
-                // itemization must be stripped before deciding how to expand it
-                // (otherwise the whole Range stringifies as one replacement).
-                let item = &item.clone().deitemize_element();
-                match item.view() {
-                    ValueView::Array(..)
-                    | ValueView::Range(..)
-                    | ValueView::RangeExcl(..)
-                    | ValueView::RangeExclStart(..)
-                    | ValueView::RangeExclBoth(..)
-                    | ValueView::GenericRange { .. } => {
-                        let expanded = crate::runtime::utils::value_to_list(item);
-                        for i in expanded.iter() {
-                            result.push(i.to_string_value());
-                        }
-                    }
-                    _ => result.push(item.to_string_value()),
-                }
-            }
-            result
-        }
+        ValueView::Array(items, ..) => items
+            .iter()
+            .flat_map(trans_collection_item_to_strings)
+            .collect(),
+        ValueView::Seq(items) | ValueView::HyperSeq(items) | ValueView::RaceSeq(items) => items
+            .iter()
+            .flat_map(trans_collection_item_to_strings)
+            .collect(),
+        ValueView::Slip(items) => items
+            .iter()
+            .flat_map(trans_collection_item_to_strings)
+            .collect(),
         ValueView::Str(s) => {
             let expanded = expand_trans_spec(&s);
             expanded.into_iter().map(|c| c.to_string()).collect()
@@ -159,6 +146,29 @@ fn value_to_string_list(v: &Value) -> Vec<String> {
             let expanded = expand_trans_spec(&s);
             expanded.into_iter().map(|c| c.to_string()).collect()
         }
+    }
+}
+
+/// Expand one item from a collection-valued trans operand. Strings inside a
+/// collection are tokens (so `['el'] => ['ip']` remains a two-character token
+/// mapping); nested collections and ranges are expanded structurally.
+fn trans_collection_item_to_strings(item: &Value) -> Vec<String> {
+    let item = item.clone().deitemize_element();
+    match item.view() {
+        ValueView::Array(..)
+        | ValueView::Seq(..)
+        | ValueView::HyperSeq(..)
+        | ValueView::RaceSeq(..)
+        | ValueView::Slip(..) => value_to_string_list(&item),
+        ValueView::Range(..)
+        | ValueView::RangeExcl(..)
+        | ValueView::RangeExclStart(..)
+        | ValueView::RangeExclBoth(..)
+        | ValueView::GenericRange { .. } => crate::runtime::utils::value_to_list(&item)
+            .iter()
+            .map(|value| value.to_string_value())
+            .collect(),
+        _ => vec![item.to_string_value()],
     }
 }
 

--- a/tests/issue_7228.rs
+++ b/tests/issue_7228.rs
@@ -1,0 +1,34 @@
+//! Regression test for issue #7228: a `-pe` Rot-13 one-liner using the topic
+//! `.=` method-call form with colon arguments must parse and produce the same
+//! output as Rakudo.
+
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+const ROT13: &str = r#".=trans: {$_ => $_».rotate(13)}({[$_».uc, @$_]}("a".."z"))"#;
+
+#[test]
+fn rot13_one_liner_with_topic_dotassign_colon_args() {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_mutsu"))
+        .args(["-pe", ROT13])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to spawn mutsu");
+
+    child
+        .stdin
+        .take()
+        .expect("missing mutsu stdin")
+        .write_all(b"abc\nxyz\n")
+        .expect("failed to write mutsu stdin");
+
+    let output = child.wait_with_output().expect("failed to wait for mutsu");
+    assert!(
+        output.status.success(),
+        "mutsu -pe failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(String::from_utf8_lossy(&output.stdout), "nop\nklm\n");
+}


### PR DESCRIPTION
Fixes #7228

The Rot-13 Rosetta Code one-liner uses the topic `.=trans:` method-call form with colon arguments and nested collection values.

This updates the parser to consume colon arguments in that form and recursively expands nested trans operands while preserving string tokens inside collections. It adds parser and end-to-end CLI regression tests.