### PR TITLE
fix: preserve lvalues in sigilless destructuring

### DIFF
--- a/src/parser/stmt/decl/destructure.rs
+++ b/src/parser/stmt/decl/destructure.rs
@@ -4,6 +4,7 @@ use super::super::super::parse_result::{PError, PResult, opt_char, parse_char};
 use super::super::parse_statement_modifier;
 use super::super::{ident, keyword};
 use super::helpers::register_term_symbol_from_decl_name;
+use super::my_decl_helpers::build_sigilless_bind_stmt;
 use super::parse_decl_type_constraint;
 use crate::ast::{Expr, Stmt};
 use crate::symbol::Symbol;
@@ -459,6 +460,30 @@ fn parse_destructuring_with_rhs(
 
     let has_named = vars.iter().any(|v| v.is_named);
 
+    // A positional sigilless binding must preserve the containers carried by
+    // its RHS elements. Staging `($x, $y)` in an Array and then reading its
+    // elements binds `\a`/`\b` to copies, so assignments through those terms
+    // cannot reach `$x`/`$y`. Desugar directly representable variable
+    // references to the same individual bind declarations that
+    // `my \a := $x` already uses.
+    // Mixed/computed destructuring stays on the general staging path, which
+    // retains its existing readonly, default, slurpy, and constraint handling.
+    if is_binding
+        && !has_named
+        && vars.iter().all(is_direct_sigilless_destructure_var)
+        && let Some(sources) = direct_sigilless_bind_sources(&raw_rhs, vars.len())
+    {
+        return parse_direct_sigilless_binding(
+            rest,
+            vars,
+            sources,
+            is_state,
+            is_our,
+            type_constraint,
+            has_following_block || block_rhs_ends_at_newline,
+        );
+    }
+
     // List-assignment iterates the RHS with one level of decont (Rakudo
     // List.STORE): `my ($a, $b) = $row` where `$row` holds an itemized Array
     // flattens into its elements, while `= $row,` (a comma list) keeps the
@@ -654,6 +679,88 @@ fn parse_destructuring_with_rhs(
     if has_following_block || block_rhs_ends_at_newline {
         // In `if my ($a, $b) = f() { ... }`, the braced block belongs to the
         // surrounding conditional, not to this declaration's modifier parser.
+        Ok((rest, block))
+    } else {
+        parse_statement_modifier(rest, block)
+    }
+}
+
+/// Whether a destructure leaf can use the plain sigilless declaration path.
+/// Defaults, slurpy elements, and constraints need the staged destructuring
+/// machinery because they change positional binding semantics.
+fn is_direct_sigilless_destructure_var(var: &DestructureVar) -> bool {
+    var.sigilless
+        && !var.is_slurpy
+        && !var.is_optional
+        && !var.is_named
+        && var.default.is_none()
+        && var.where_constraint.is_none()
+        && var.literal_value.is_none()
+}
+
+/// Extract the individual lvalues represented by a positional RHS. An Array
+/// literal is the parser's representation of a parenthesized/comma list;
+/// Plain variable references retain their source containers so they can be
+/// bound rather than copied through a staging array.
+fn direct_sigilless_bind_sources(rhs: &Expr, count: usize) -> Option<Vec<Expr>> {
+    if count == 0 {
+        return Some(Vec::new());
+    }
+    match rhs {
+        Expr::ArrayLiteral(elements) if elements.len() >= count => {
+            let sources = elements[..count].to_vec();
+            sources
+                .iter()
+                .all(is_direct_sigilless_bind_source)
+                .then_some(sources)
+        }
+        Expr::Grouped(inner) => direct_sigilless_bind_sources(inner, count),
+        _ => None,
+    }
+}
+
+fn is_direct_sigilless_bind_source(expr: &Expr) -> bool {
+    matches!(expr, Expr::Var(_) | Expr::Literal(_))
+}
+
+/// Build a positional sigilless binding without copying its RHS through an
+/// intermediate Array. Each helper block is flattened so the compiler sees
+/// the same `MarkBind` immediately before each declaration as it does for a
+/// standalone `my \\name := $source`.
+fn parse_direct_sigilless_binding(
+    rest: &str,
+    vars: Vec<DestructureVar>,
+    sources: Vec<Expr>,
+    is_state: bool,
+    is_our: bool,
+    type_constraint: Option<String>,
+    preserve_rest: bool,
+) -> PResult<'_, Stmt> {
+    let mut stmts = Vec::new();
+    for (var, source) in vars.iter().zip(sources) {
+        let stmt = build_sigilless_bind_stmt(
+            var.name.clone(),
+            source,
+            var.per_var_type_constraint
+                .clone()
+                .or_else(|| type_constraint.clone()),
+            is_state,
+            is_our,
+        );
+        match stmt {
+            Stmt::SyntheticBlock(inner) => stmts.extend(inner),
+            other => stmts.push(other),
+        }
+    }
+    // A declaration in expression position yields the bound values as a list,
+    // matching the staged destructuring block's trailing ArrayVar expression.
+    stmts.push(Stmt::Expr(Expr::ArrayLiteral(
+        vars.iter()
+            .map(|var| Expr::BareWord(var.name.clone()))
+            .collect(),
+    )));
+    let block = Stmt::SyntheticBlock(stmts);
+    if preserve_rest {
         Ok((rest, block))
     } else {
         parse_statement_modifier(rest, block)

--- a/src/parser/stmt/decl/my_decl_helpers.rs
+++ b/src/parser/stmt/decl/my_decl_helpers.rs
@@ -38,7 +38,7 @@ use super::parse_assign_expr_or_comma;
 ///
 /// This does NOT depend on whether a type constraint was written — `my Mu
 /// \a := $a` and `my \a := $a` behave the same way in raku.
-fn build_sigilless_bind_stmt(
+pub(super) fn build_sigilless_bind_stmt(
     name: String,
     expr: Expr,
     type_constraint: Option<String>,

--- a/t/list-destructuring-sigilless-bind.t
+++ b/t/list-destructuring-sigilless-bind.t
@@ -1,0 +1,27 @@
+use v6;
+use Test;
+
+# A sigilless variable in a positional binding is a writable alias when its
+# corresponding RHS element is an lvalue. Destructuring must not copy those
+# elements through a temporary Array first.
+
+plan 3;
+
+{
+    my ($x, $y) = 1, 2;
+    my (\a, \b) := ($x, $y);
+    a = 10;
+    b = 20;
+    is-deeply ($x, $y), (10, 20),
+        'list destructuring binds sigilless names to scalar lvalues';
+}
+
+dies-ok {
+    my (\a, \b) := (1, 2);
+    a = 10;
+}, 'binding a literal still produces a readonly sigilless term';
+
+dies-ok {
+    my (\a, \b) := (1 + 1, 2);
+    a = 10;
+}, 'binding a computed value still produces a readonly sigilless term';


### PR DESCRIPTION
## Summary

- desugar positional sigilless bindings directly to plain variable RHS lvalues
- preserve readonly behavior for literals and computed RHS values
- add a regression test for write-through list destructuring

## Validation

- cargo fmt --all
- cargo clippy -- -D warnings
- make test
- make roast