### PR TITLE
fix: preserve element cells through producer Seq indexing

### DIFF
--- a/src/compiler/expr_closure.rs
+++ b/src/compiler/expr_closure.rs
@@ -892,13 +892,17 @@ impl Compiler {
                             self.compile_expr(target);
                             self.compile_expr(index);
                             self.compile_expr(value);
-                            self.code.emit(OpCode::IndexAssignGeneric);
+                            self.code.emit(OpCode::IndexAssignGeneric {
+                                is_positional: outer_positional,
+                            });
                         }
                     } else {
                         self.compile_expr(target);
                         self.compile_expr(index);
                         self.compile_expr(value);
-                        self.code.emit(OpCode::IndexAssignGeneric);
+                        self.code.emit(OpCode::IndexAssignGeneric {
+                            is_positional: outer_positional,
+                        });
                     }
                 } else {
                     // Multi-index slice: ($foo, 42, $bar, 19)[0, 2] = (23, 24)
@@ -910,7 +914,9 @@ impl Compiler {
                 self.compile_expr(target);
                 self.compile_expr(index);
                 self.compile_expr(value);
-                self.code.emit(OpCode::IndexAssignGeneric);
+                self.code.emit(OpCode::IndexAssignGeneric {
+                    is_positional: outer_positional,
+                });
             }
         } else {
             // Generic fallback: compile target, then index, then value
@@ -918,7 +924,9 @@ impl Compiler {
             self.compile_expr(target);
             self.compile_expr(index);
             self.compile_expr(value);
-            self.code.emit(OpCode::IndexAssignGeneric);
+            self.code.emit(OpCode::IndexAssignGeneric {
+                is_positional: outer_positional,
+            });
         }
     }
 

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -1703,7 +1703,12 @@ pub(crate) enum OpCode {
     /// Generic index assignment on a stack-computed target.
     /// Stack: [target, index, value] → assigns value to target[index].
     /// Supports callframe .my hash writeback for dynamic variables.
-    IndexAssignGeneric,
+    IndexAssignGeneric {
+        /// Whether the computed target was reached through `[...]` rather
+        /// than associative indexing. A producer Seq can only write through
+        /// its positional element cells.
+        is_positional: bool,
+    },
     AssignReadOnly,
     /// Check if a variable is readonly; throw if so (for assignment to readonly params).
     CheckReadOnly(u32),
@@ -6862,7 +6867,7 @@ impl CompiledCode {
                     | OpCode::IndexAssignExprNamed { .. }
                     | OpCode::IndexAssignExprNested { .. }
                     | OpCode::IndexAssignDeepNested { .. }
-                    | OpCode::IndexAssignGeneric
+                    | OpCode::IndexAssignGeneric { .. }
                     | OpCode::IndexAssignPseudoStashNamed { .. }
                     | OpCode::IndexAssignPseudoStashKeyed { .. }
                     | OpCode::IndexElemAutoviv { .. }

--- a/src/runtime/builtins.rs
+++ b/src/runtime/builtins.rs
@@ -198,10 +198,19 @@ impl Interpreter {
         container: Option<Value>,
         source_name: &str,
     ) -> Result<Value, RuntimeError> {
-        if let Some(c) = container.as_ref()
-            && !self.container_elements_are_containers(c, source_name)
-        {
-            return Ok(element);
+        if let Some(c) = container.as_ref() {
+            // A producer Seq can be a flat stream whose value cells occur at
+            // selected positions (`.kv`) or inside Pair values (`.pairs`).
+            // The provenance bit identifies the producer, but the indexed
+            // result still has to be a cell before it can describe a Scalar.
+            // Keys and Pair records remain ordinary values.
+            let producer_seq =
+                matches!(c.view(), ValueView::Seq(body) if body.has_element_containers());
+            if !self.container_elements_are_containers(c, source_name)
+                || (producer_seq && !matches!(element.view(), ValueView::ContainerRef(_)))
+            {
+                return Ok(element);
+            }
         }
 
         // A SLICE subscript (`@a[*]`, and any spelling the compiler's
@@ -330,6 +339,11 @@ impl Interpreter {
     /// is a real `Array`.
     fn container_elements_are_containers(&self, container: &Value, source_name: &str) -> bool {
         match container.view() {
+            // Element-producing Seq values retain the source array's shared
+            // element cells.  The marker is needed here because an ordinary
+            // Seq stores values, while a producer Seq is the anonymous
+            // subscript path's source for a real Scalar element descriptor.
+            ValueView::Seq(body) => body.has_element_containers(),
             ValueView::Hash(data) => {
                 !data.bare_values
                     && !matches!(

--- a/src/value/seq_body.rs
+++ b/src/value/seq_body.rs
@@ -142,6 +142,11 @@ struct SeqCore {
     #[allow(clippy::vec_box)]
     gens: SyncUnsafeCell<Vec<Box<Vec<Value>>>>,
     state: Mutex<SeqState>,
+    /// The elements are live containers handed out by a mutable Array/Hash
+    /// producer, rather than ordinary Seq values. Positional indexing must
+    /// preserve those cells instead of passing them through the normal array
+    /// read chokepoint, which decontainerizes them.
+    element_containers: bool,
 }
 
 /// The reification/consumption state of a `Seq`, `HyperSeq`, or `RaceSeq`.
@@ -178,6 +183,15 @@ impl SeqBody {
     /// Build an already-reified body (the common case: `Value::seq(vec)` and
     /// every eager Seq/HyperSeq/RaceSeq constructor).
     pub(crate) fn reified(items: Vec<Value>) -> Arc<Self> {
+        Self::reified_with_element_containers(items, false)
+    }
+
+    /// Build an already-reified Seq whose elements are live element containers
+    /// from a mutable collection producer (ADR-0036 follow-up).
+    pub(crate) fn reified_with_element_containers(
+        items: Vec<Value>,
+        element_containers: bool,
+    ) -> Arc<Self> {
         Arc::new(SeqBody {
             core: Arc::new(SeqCore {
                 gens: SyncUnsafeCell::new(vec![Box::new(items)]),
@@ -191,6 +205,7 @@ impl SeqBody {
                     retained: false,
                     itemized: false,
                 }),
+                element_containers,
             }),
             view: SeqView::Seq,
         })
@@ -212,6 +227,7 @@ impl SeqBody {
                     retained: false,
                     itemized: false,
                 }),
+                element_containers: false,
             }),
             view: SeqView::Seq,
         })
@@ -243,6 +259,13 @@ impl SeqBody {
     /// (docs/adr/0038 S2), the single oracle for "what type is this value".
     pub(crate) fn view(&self) -> SeqView {
         self.view
+    }
+
+    /// Whether this Seq's elements are live containers belonging to a mutable
+    /// collection. The bit belongs to the shared core so `.cache` and its List
+    /// view retain the same element provenance.
+    pub(crate) fn has_element_containers(&self) -> bool {
+        self.core.element_containers
     }
 
     /// The current generation's elements — `pub(crate)` (rather than

--- a/src/value/view.rs
+++ b/src/value/view.rs
@@ -185,6 +185,13 @@ impl Value {
         Value::Seq(SeqBody::reified(items))
     }
 
+    /// Construct a `Seq` whose elements are live containers produced from a
+    /// mutable Array/Hash. Positional indexing must keep those cells intact.
+    #[inline]
+    pub(crate) fn seq_element_containers(items: Vec<Value>) -> Self {
+        Value::Seq(SeqBody::reified_with_element_containers(items, true))
+    }
+
     /// Construct a `Seq` value from a not-yet-reified source (`Seq.new($iter)`,
     /// `IO::Handle.lines`, or a pre-consumed `Seq.new()` when `source` is
     /// [`SeqSource::Taken`]).

--- a/src/vm/vm_element_producers.rs
+++ b/src/vm/vm_element_producers.rs
@@ -250,9 +250,9 @@ impl Interpreter {
             // container rather than snapshotting its current value. `.List`
             // deliberately remains outside this routing because it
             // decontainerizes Array elements.
-            "Seq" => Value::seq(cells),
-            "values" => Value::seq(cells),
-            "pairs" => Value::seq(
+            "Seq" => Value::seq_element_containers(cells),
+            "values" => Value::seq_element_containers(cells),
+            "pairs" => Value::seq_element_containers(
                 cells
                     .into_iter()
                     .enumerate()
@@ -262,7 +262,7 @@ impl Interpreter {
             // A flat `index, cell, index, cell, ...` list -- the loop chunks it
             // by two, so the value slot of each chunk is the element's own
             // container and `-> $i, $v is rw` aliases it (ADR-0045 row 16).
-            "kv" => Value::seq(
+            "kv" => Value::seq_element_containers(
                 cells
                     .into_iter()
                     .enumerate()
@@ -272,7 +272,7 @@ impl Interpreter {
             "reverse" => {
                 let mut cells = cells;
                 cells.reverse();
-                Value::seq(cells)
+                Value::seq_element_containers(cells)
             }
             "sort" => {
                 // Sort the CELLS, ordered by what they hold. Carrying the cell
@@ -288,7 +288,7 @@ impl Interpreter {
                     })
                     .collect();
                 keyed.sort_by(|a, b| crate::runtime::compare_values(&a.1, &b.1).cmp(&0));
-                Value::seq(keyed.into_iter().map(|(c, _)| c).collect())
+                Value::seq_element_containers(keyed.into_iter().map(|(c, _)| c).collect())
             }
             _ => return None,
         })
@@ -308,7 +308,7 @@ impl Interpreter {
         let mut pairs = Vec::new();
         let mut indices = Vec::new();
         Self::collect_leaf_cell_pairs(target, &mut indices, &mut pairs)?;
-        Some(Value::seq(pairs))
+        Some(Value::seq_element_containers(pairs))
     }
 
     fn collect_leaf_cell_pairs(
@@ -398,6 +398,6 @@ impl Interpreter {
             }
             out.push(cell);
         }
-        Some(Value::seq(out))
+        Some(Value::seq_element_containers(out))
     }
 }

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -5036,8 +5036,8 @@ impl Interpreter {
                 self.exec_make_lambda_op(code, *idx, *cc_idx, *is_wc)?;
                 *ip += 1;
             }
-            OpCode::IndexAssignGeneric => {
-                self.exec_index_assign_generic_op(code)?;
+            OpCode::IndexAssignGeneric { is_positional } => {
+                self.exec_index_assign_generic_op(code, *is_positional)?;
                 *ip += 1;
             }
             OpCode::MakeBlockClosure(idx, cc_idx) => {

--- a/src/vm/vm_var_assign_index_named.rs
+++ b/src/vm/vm_var_assign_index_named.rs
@@ -3766,6 +3766,7 @@ impl Interpreter {
     pub(super) fn exec_index_assign_generic_op(
         &mut self,
         code: &CompiledCode,
+        is_positional: bool,
     ) -> Result<(), RuntimeError> {
         let raw_val = self.stack.pop().unwrap_or(Value::NIL);
         let idx = self.stack.pop().unwrap_or(Value::NIL);
@@ -3819,6 +3820,52 @@ impl Interpreter {
             }
             _ => (raw_val, None, false),
         };
+
+        // A positional subscript of a mutable collection producer keeps the
+        // producer's element cells alive. The normal generic path only knows
+        // how to assign into an Array/Hash target; a Seq target would otherwise
+        // fall through and silently discard the write. Assign through the cell
+        // directly, preserving the producer's source and its element type
+        // constraint.
+        if is_positional
+            && let ValueView::Seq(body) = target.view()
+            && body.has_element_containers()
+        {
+            let indices: Vec<usize> = match idx.view() {
+                ValueView::Array(items, kind) if !kind.is_itemized() => {
+                    items.iter().filter_map(Self::index_to_usize).collect()
+                }
+                ValueView::Range(..)
+                | ValueView::RangeExcl(..)
+                | ValueView::RangeExclStart(..)
+                | ValueView::RangeExclBoth(..)
+                | ValueView::GenericRange { .. } => self
+                    .assignment_rhs_values(&idx)?
+                    .iter()
+                    .filter_map(Self::index_to_usize)
+                    .collect(),
+                _ => Self::index_to_usize(&idx).into_iter().collect(),
+            };
+            let values = self.assignment_rhs_values(&val)?;
+            for (value_index, element_index) in indices.iter().copied().enumerate() {
+                let Some(slot) = body.get(element_index).cloned() else {
+                    continue;
+                };
+                let ValueView::ContainerRef(cell) = slot.view() else {
+                    return Err(RuntimeError::assignment_ro_value(slot.deref_container()));
+                };
+                let assigned = values.get(value_index).cloned().unwrap_or(Value::NIL);
+                self.check_container_cell_constraint(&cell, &assigned)?;
+                *cell.lock().unwrap() = assigned;
+            }
+            let result = if idx_is_single_element {
+                Self::itemize_value(val)
+            } else {
+                val
+            };
+            self.stack.push(result);
+            return Ok(());
+        }
 
         // Phase 2 Stage 2: a `:=` bind to a stack-computed element target
         // (`f()<k> := $s`, `($ref)[i] := $s`) stores a shared `ContainerRef`
@@ -3988,7 +4035,7 @@ impl Interpreter {
                 self.stack.push(resolved);
                 self.stack.push(idx);
                 self.stack.push(val);
-                return self.exec_index_assign_generic_op(code);
+                return self.exec_index_assign_generic_op(code, is_positional);
             }
             ValueView::Instance {
                 class_name,

--- a/src/vm/vm_var_index_ops.rs
+++ b/src/vm/vm_var_index_ops.rs
@@ -615,7 +615,10 @@ impl Interpreter {
             };
             target = Value::array(forced);
         }
-        // Normalize Seq/Slip target to List for uniform handling
+        // Normalize ordinary Seq/Slip targets to List for uniform handling.
+        // A mutable collection producer's Seq is different: its elements are
+        // the source's live Scalar cells, and the Seq arms below must return
+        // those cells without passing through `resolve_array_entry`.
         if let ValueView::Seq(items) = target.view() {
             // Subscript on a consumed Seq throws X::Seq::Consumed.
             // Subscript on any Seq marks it as cached (can be used again).
@@ -623,10 +626,12 @@ impl Interpreter {
                 return Err(crate::value::seq_consumed_error());
             }
             items.mark_cache_requested();
-            target = Value::array_with_kind(
-                crate::value::Value::array_arc(items.to_vec()),
-                crate::value::ArrayKind::List,
-            );
+            if !items.has_element_containers() {
+                target = Value::array_with_kind(
+                    crate::value::Value::array_arc(items.to_vec()),
+                    crate::value::ArrayKind::List,
+                );
+            }
         } else if let ValueView::Slip(items) = target.view() {
             target = Value::array_with_kind(
                 crate::value::Value::array_arc(items.to_vec()),

--- a/t/subscript-pair-element-container.t
+++ b/t/subscript-pair-element-container.t
@@ -38,7 +38,7 @@ use Test;
 # Every expected value below was cross-checked against `raku` (see the ADR's
 # §1.3 table and this file's commit for the exact `raku -e` invocations).
 
-plan 35;
+plan 39;
 
 # --- §1.3 row 1: :p stale read (Slice 2) -----------------------------------
 {
@@ -205,13 +205,27 @@ plan 35;
 # --- Slice 3: the producers that now hand out element containers ------------
 {
     my @a = <A B>;
-    # Same pre-existing `.VAR`-dispatch gap as line 88's `:kv` row: `.VAR` on an
-    # ANONYMOUS computed index target (`@a.values[0]`) goes through the general
-    # index-read chokepoint, which decontainerizes before `.VAR` ever sees the
-    # cell. Not an ADR-0036 row -- see
-    # todo/tickets/var-on-a-containerref-is-not-distinguishable.md.
-    todo '.VAR on an anonymous computed index target does not see a ContainerRef (pre-existing)';
     is @a.values[0].VAR.^name, 'Scalar', '.values hands out the element container';
+}
+{
+    my @a = <A B>;
+    is (@a.values)[0].WHAT.^name, 'Str', '.values index decontainerizes for .WHAT';
+}
+{
+    my @a = <A B>;
+    (@a.values)[0] = 'x';
+    is-deeply @a, ['x', 'B'], 'a positional write through .values updates the source array';
+}
+{
+    my @a = <A B>;
+    (@a.kv)[1] = 'x';
+    is-deeply @a, ['x', 'B'], 'a positional write through .kv updates the source array';
+}
+{
+    my @a = <A B>;
+    my $cell := (@a.values)[0];
+    $cell = 'x';
+    is-deeply @a, ['x', 'B'], 'a binding to a .values element updates the source array';
 }
 # The stale-READ direction, which the `.VAR` gap does not mask: a binding taken
 # from `.values` must see a later write to the element.


### PR DESCRIPTION
## Summary

- Preserve mutable Array/Hash element-cell provenance on producer Seq values during positional reads.
- Route computed positional assignments through producer cells so `.values` and `.kv` writes update their source collection.
- Cover `.VAR`, `.WHAT`, write-through, and bound-cell regressions.

## Validation

- cargo fmt --all
- cargo clippy -- -D warnings
- make test
- make roast
- focused t/subscript-pair-element-container.t (39 tests)

Closes todo/tickets/producer-seq-index-read-decontainerizes-the-element-cell.md