### PR TITLE
rakuast: support hyper function infix nodes

### DIFF
--- a/docs/adr/0011-rakuast-model-layer-and-phasing.md
+++ b/docs/adr/0011-rakuast-model-layer-and-phasing.md
@@ -666,11 +666,13 @@ earlier ones.
   [dwim-right => True]), right)`, and `EVAL` lowers it back. mutsu's `HyperOp` already stores the
   operator text plus both dwim flags, so the mapping is 1:1; raku omits a dwim field whose value is
   False, which the converter reproduces by simply not emitting it (and the lowerer reads a missing
-  field as False). Tests: `t/rakuast-hyper-infix.t`. Remaining hyper boundary: hyper *prefix*
+  field as False). Tests: `t/rakuast-hyper-infix.t`. Hyper function infix (`>>[&f]<<`,
+  `Expr::HyperFuncOp`) now uses the same wrapper with a `FunctionInfix(Var::Lexical)` child and
+  lowers back through the existing execution path; tests are in
+  `t/rakuast-hyper-function-infix.t`. Remaining hyper boundary: hyper *prefix*
   (`-<<@a`, desugared to a `__mutsu_hyper_prefix` call), hyper *postcircumfix* (`@a>>[1]`,
-  desugared to a hyper `AT-POS` method call), hyper *function* infix (`>>[&f]<<`, raku's
-  `MetaInfix::Hyper(FunctionInfix)`; mutsu has `Expr::HyperFuncOp`), and `@a<<.abs` (which mutsu's
-  parser currently reads as a quote-words subscript).
+  desugared to a hyper `AT-POS` method call), and `@a<<.abs` (which mutsu's parser currently
+  reads as a quote-words subscript).
 - **Reduction metaoperator (Phase 2 slice 25).** `[+] @a` (`Expr::Reduction`) → `Term::Reduce(
   triangle => False, infix => Infix("+"), args => ArgList(@a))`. The triangle form `[\+] @a`
   (mutsu stores its op as `"\+"`) sets `triangle => True` with the backslash stripped from the infix.

--- a/news/2026-09/rakuast-hyper-function-infix.md
+++ b/news/2026-09/rakuast-hyper-function-infix.md
@@ -1,0 +1,11 @@
+# RakuAST hyper function infix
+
+The remaining RakuAST hyper-function infix gap is closed in both directions.
+
+`>>[&infix:<+>]<<` now renders as
+`ApplyInfix(MetaInfix::Hyper(FunctionInfix(Var::Lexical)))`, preserving the
+left/right DWIM flags exactly as Rakudo does. `EVAL` lowers the model back to
+mutsu's existing `HyperFuncOp` execution path, so strict, left-DWIM,
+right-DWIM, and both-DWIM forms round-trip.
+
+The dual-oracle coverage is in `t/rakuast-hyper-function-infix.t`.

--- a/src/rakuast/convert.rs
+++ b/src/rakuast/convert.rs
@@ -1064,6 +1064,54 @@ fn convert_expr(expr: &Expr) -> Result<RakuAstNode, RuntimeError> {
                 ],
             })
         }
+        // A hyper infix function `@a >>[&infix:<+>]<< @b` uses the same
+        // MetaInfix::Hyper wrapper as an ordinary hyper operator, but its base
+        // infix is a FunctionInfix containing the referenced code variable.
+        Expr::HyperFuncOp {
+            func_name,
+            left,
+            right,
+            dwim_left,
+            dwim_right,
+        } => {
+            let mut hyper_fields = Vec::with_capacity(3);
+            if *dwim_left {
+                hyper_fields.push(RakuAstField {
+                    name: Some("dwim-left"),
+                    value: RakuAstFieldValue::Node(Value::truth(true)),
+                });
+            }
+            hyper_fields.push(node_field(
+                Some("infix"),
+                RakuAstNode {
+                    class: RakuAstClass::FunctionInfix,
+                    fields: vec![node_field(
+                        None,
+                        var_lexical("&", func_name.strip_prefix('&').unwrap_or(func_name)),
+                    )],
+                },
+            ));
+            if *dwim_right {
+                hyper_fields.push(RakuAstField {
+                    name: Some("dwim-right"),
+                    value: RakuAstFieldValue::Node(Value::truth(true)),
+                });
+            }
+            Ok(RakuAstNode {
+                class: RakuAstClass::ApplyInfix,
+                fields: vec![
+                    node_field(Some("left"), convert_expr(left)?),
+                    node_field(
+                        Some("infix"),
+                        RakuAstNode {
+                            class: RakuAstClass::MetaInfixHyper,
+                            fields: hyper_fields,
+                        },
+                    ),
+                    node_field(Some("right"), convert_expr(right)?),
+                ],
+            })
+        }
         Expr::Unary { op, expr } => Ok(RakuAstNode {
             class: RakuAstClass::ApplyPrefix,
             fields: vec![

--- a/src/rakuast/lower.rs
+++ b/src/rakuast/lower.rs
@@ -832,16 +832,37 @@ fn lower_expr(node: &RakuAstNode) -> Result<Expr, RuntimeError> {
                 .is_ok_and(|i| i.class == RakuAstClass::MetaInfixHyper) =>
         {
             let hyper = named_child(node, "infix")?;
-            let op_value = positional_leaf(named_child(hyper, "infix")?)?;
+            let infix = named_child(hyper, "infix")?;
+            let left = Box::new(lower_expr(named_child(node, "left")?)?);
+            let right = Box::new(lower_expr(named_child(node, "right")?)?);
+            let dwim_left = bool_field(hyper, "dwim-left")?;
+            let dwim_right = bool_field(hyper, "dwim-right")?;
+            if infix.class == RakuAstClass::FunctionInfix {
+                let function = positional_leaf(infix)?;
+                let ValueView::RakuAst(function) = function.view() else {
+                    return Err(unsupported(node));
+                };
+                let Expr::CodeVar(func_name) = lower_expr(function)? else {
+                    return Err(unsupported(node));
+                };
+                return Ok(Expr::HyperFuncOp {
+                    func_name,
+                    left,
+                    right,
+                    dwim_left,
+                    dwim_right,
+                });
+            }
+            let op_value = positional_leaf(infix)?;
             let ValueView::Str(op) = op_value.view() else {
                 return Err(unsupported(node));
             };
             Ok(Expr::HyperOp {
                 op: op.to_string(),
-                left: Box::new(lower_expr(named_child(node, "left")?)?),
-                right: Box::new(lower_expr(named_child(node, "right")?)?),
-                dwim_left: bool_field(hyper, "dwim-left")?,
-                dwim_right: bool_field(hyper, "dwim-right")?,
+                left,
+                right,
+                dwim_left,
+                dwim_right,
             })
         }
         RakuAstClass::ApplyInfix => {

--- a/src/rakuast/mod.rs
+++ b/src/rakuast/mod.rs
@@ -66,6 +66,7 @@ pub enum RakuAstClass {
     InitializerAssign,
     ApplyInfix,
     Infix,
+    FunctionInfix,
     ApplyPrefix,
     Prefix,
     ApplyPostfix,
@@ -189,6 +190,7 @@ impl RakuAstClass {
             InitializerAssign => "RakuAST::Initializer::Assign",
             ApplyInfix => "RakuAST::ApplyInfix",
             Infix => "RakuAST::Infix",
+            FunctionInfix => "RakuAST::FunctionInfix",
             ApplyPrefix => "RakuAST::ApplyPrefix",
             Prefix => "RakuAST::Prefix",
             ApplyPostfix => "RakuAST::ApplyPostfix",
@@ -467,6 +469,7 @@ const RAKUAST_CLASSES: &[RakuAstClass] = &[
     RakuAstClass::InitializerAssign,
     RakuAstClass::ApplyInfix,
     RakuAstClass::Infix,
+    RakuAstClass::FunctionInfix,
     RakuAstClass::ApplyPrefix,
     RakuAstClass::Prefix,
     RakuAstClass::ApplyPostfix,
@@ -933,6 +936,7 @@ fn single_positional_class(class_name: &str, method: &str) -> Option<RakuAstClas
         ("RakuAST::Name", "from-identifier") => RakuAstClass::Name,
         ("RakuAST::Term::Enum", "from-identifier") => RakuAstClass::TermEnum,
         ("RakuAST::Infix", "new") => RakuAstClass::Infix,
+        ("RakuAST::FunctionInfix", "new") => RakuAstClass::FunctionInfix,
         ("RakuAST::MetaInfix::Assign", "new") => RakuAstClass::MetaInfixAssign,
         ("RakuAST::Prefix", "new") => RakuAstClass::Prefix,
         ("RakuAST::Var::Lexical", "new") => RakuAstClass::VarLexical,
@@ -1011,6 +1015,7 @@ pub fn node_accessor(node: &RakuAstNode, method: &str) -> Option<Value> {
         RakuAstClass::IntLiteral | RakuAstClass::RatLiteral | RakuAstClass::StrLiteral => {
             Some("value")
         }
+        RakuAstClass::FunctionInfix => Some("function"),
         RakuAstClass::VarLexical => Some("name"),
         RakuAstClass::Blockoid => Some("statement-list"),
         RakuAstClass::InitializerAssign => Some("expression"),
@@ -1086,6 +1091,7 @@ fn constructor_is_supported(class: RakuAstClass) -> bool {
             | RakuAstClass::ApplyInfix
             | RakuAstClass::ApplyPrefix
             | RakuAstClass::ApplyPostfix
+            | RakuAstClass::FunctionInfix
             | RakuAstClass::Postfix
             | RakuAstClass::MetaInfixAssign
             | RakuAstClass::Block
@@ -1111,6 +1117,7 @@ fn accessor_names(class: RakuAstClass) -> &'static [&'static str] {
         IntLiteral | RatLiteral | StrLiteral => &["value"],
         VarLexical => &["name"],
         ApplyInfix => &["left", "infix", "right"],
+        FunctionInfix => &["function"],
         ApplyPrefix => &["prefix", "operand"],
         ApplyPostfix => &["operand", "postfix"],
         Postfix => &["operator"],

--- a/t/rakuast-hyper-function-infix.t
+++ b/t/rakuast-hyper-function-infix.t
@@ -1,0 +1,57 @@
+use v6;
+use MONKEY-SEE-NO-EVAL;
+use experimental :rakuast;
+use Test;
+
+# RakuAST hyper function infix operators (ADR-0011). The internal
+# HyperFuncOp maps to MetaInfix::Hyper(FunctionInfix(Var::Lexical(...))) and
+# lowers back through the existing hyper-function execution path.
+
+plan 19;
+
+# --- read side --------------------------------------------------------------
+my $strict = Q[my @a; my @b; @a >>[&infix:<+>]<< @b].AST.gist;
+ok $strict.contains('RakuAST::FunctionInfix.new('),
+    'a hyper function infix renders a FunctionInfix';
+ok $strict.contains('RakuAST::Var::Lexical.new("\\&infix:<+>")'),
+    'FunctionInfix retains the referenced code variable';
+nok $strict.contains('dwim-left'), 'strict form sets no dwim-left';
+nok $strict.contains('dwim-right'), 'strict form sets no dwim-right';
+
+my $both = Q[my @a; @a <<[&infix:<+>]>> 1].AST.gist;
+ok $both.contains('dwim-left') && $both.contains('=> True'), '<<[&f]>> sets dwim-left';
+ok $both.contains('dwim-right => True'), '<<[&f]>> sets dwim-right';
+
+my $right = Q[my @a; @a >>[&infix:<+>]>> 1].AST.gist;
+nok $right.contains('dwim-left'), '>>[&f]>> sets no dwim-left';
+ok $right.contains('dwim-right => True'), '>>[&f]>> sets dwim-right';
+
+my $left = Q[my @a; @a <<[&infix:<+>]<< 1].AST.gist;
+ok $left.contains('dwim-left => True'), '<<[&f]<< sets dwim-left';
+nok $left.contains('dwim-right'), '<<[&f]<< sets no dwim-right';
+
+# --- introspection ----------------------------------------------------------
+my $function = Q[1 >>[&infix:<+>]<< 2].AST.statements[0].expression.infix.infix;
+is $function.^name, 'RakuAST::FunctionInfix', 'the base node is FunctionInfix';
+is $function.function.^name, 'RakuAST::Var::Lexical',
+    'FunctionInfix.function is a lexical code variable';
+is $function.function.name, '&infix:<+>',
+    'FunctionInfix.function retains its &-sigiled name';
+
+# --- write side -------------------------------------------------------------
+is EVAL(Q[my @a = 1, 2, 3; my @b = 10, 20, 30;
+    (@a >>[&infix:<+>]<< @b).join(",")].AST),
+    '11,22,33', 'a strict hyper function infix round-trips through EVAL';
+is EVAL(Q[my @a = 1, 2, 3; (@a >>[&infix:<+>]>> 1).join(",")].AST),
+    '2,3,4', 'a right-dwim hyper function infix round-trips through EVAL';
+is EVAL(Q[my @a = 1, 2, 3; my @b = 10, 20, 30;
+    (@a <<[&infix:<+>]<< @b).join(",")].AST),
+    '11,22,33', 'a strict-left hyper function infix round-trips through EVAL';
+is EVAL(Q[my @a = 1, 2, 3; (@a <<[&infix:<+>]>> 1).join(",")].AST),
+    '2,3,4', 'a both-dwim hyper function infix round-trips through EVAL';
+
+# The model metadata remains available for a hand-built FunctionInfix node.
+ok RakuAST::FunctionInfix.^can('new').elems,
+    'FunctionInfix advertises its constructor';
+ok RakuAST::FunctionInfix.^can('function').elems,
+    'FunctionInfix advertises its function accessor';

--- a/todo/deep/rakuast-remaining.md
+++ b/todo/deep/rakuast-remaining.md
@@ -57,6 +57,13 @@ the parser/internal AST, not guessing during RakuAST conversion.
   and lowers back. mutsu's `Expr::HyperOp` already kept the operator text and
   both dwim flags, so this is a 1:1 mapping.
 
+**Closed 2026-09-03** (both directions, pinned by
+`t/rakuast-hyper-function-infix.t`):
+
+- *Hyper function infix operators.* `@a >>[&infix:<+>]<< @b` now renders
+  `MetaInfix::Hyper(FunctionInfix(Var::Lexical))` with the measured DWIM fields,
+  and lowers back through the existing `Expr::HyperFuncOp` execution path.
+
 Still open:
 
 - `.=` and Whatever compound autoprime. `$x .= Str` desugars to a plain `=` over
@@ -75,10 +82,8 @@ Still open:
   loop (`registration_class_body_method.rs`) to skip `__`-prefixed names.
 - The remaining hyper forms: hyper *prefix* (`-<<@a`, desugared to a
   `__mutsu_hyper_prefix` call), hyper *postcircumfix* (`@a>>[1]`, desugared to a
-  hyper `AT-POS` method call), hyper *function* infix (`>>[&f]<<`, raku's
-  `MetaInfix::Hyper(FunctionInfix)` — mutsu has `Expr::HyperFuncOp` and could map
-  it), and `@a<<.abs` (which mutsu's parser currently reads as a quote-words
-  subscript).
+  hyper `AT-POS` method call), and `@a<<.abs` (which mutsu's parser currently
+  reads as a quote-words subscript).
 - Anonymous subs with explicit signatures. `sub ($x) { }` and `-> $a, $b { }` are
   both `Expr::AnonSubParams`, so the former renders as a `PointyBlock`. Needs a
   distinguishing flag on that node (~73 construction sites).


### PR DESCRIPTION
## Summary

- model hyper function infix operators as `MetaInfix::Hyper(FunctionInfix(Var::Lexical))`
- lower the model back through the existing `Expr::HyperFuncOp` execution path
- add dual-oracle regression coverage and close this slice in the RakuAST deep-work tracker

## Validation

- `cargo fmt --all`
- `cargo clippy -- -D warnings`
- `make test`
- `make roast`
- all RakuAST tests (665 tests)