### PR TITLE
docs: add RakuAST implementation workflow

### DIFF
--- a/.agents/skills/rakuast-implementation/SKILL.md
+++ b/.agents/skills/rakuast-implementation/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: rakuast-implementation
+description: Implement or investigate mutsu RakuAST compatibility slices using Rakudo oracle measurements, bidirectional conversion, lowering, and focused regression tests.
+metadata:
+  short-description: Work through a bounded mutsu RakuAST compatibility slice
+---
+
+# RakuAST implementation
+
+Use this skill for work involving `src/rakuast/`, `t/rakuast*.t`,
+`todo/deep/rakuast-remaining.md`, or RakuAST-specific ADR/design work.
+It covers the RakuAST-specific investigation and implementation details; use
+the repository's normal ticket and PR workflow for branching, validation, and
+publication.
+
+## Establish the slice
+
+Before changing code:
+
+1. Read `AGENTS.md`, the selected todo entry, every linked ADR/design document,
+   and the affected parser, internal AST, compiler/VM, and tests. Re-check ADR
+   status lines against the current tree.
+2. Identify the existing `Expr`/`Stmt` representation and whether ordinary
+   execution already works. Prefer a slice where the parser and execution path
+   exist and only the RakuAST boundary is missing.
+3. Probe a minimal equivalent program with the bare `raku` executable. Record
+   the node class names, fields, omitted defaults, accessor results, constructor
+   shape, and the result of `EVAL($ast)`.
+
+Treat the Rakudo result as an oracle for the measured construct, not as proof
+that arbitrary RakuAST programs are equivalent.
+
+## Implement both directions
+
+RakuAST is a model layer over the existing execution pipeline:
+
+- In `src/rakuast/convert.rs`, map the internal AST to the measured RakuAST
+  shape. Do not reconstruct distinctions that the parser or internal AST has
+  already discarded; preserve them in the parser/internal representation or
+  file a design/deep item first.
+- In `src/rakuast/mod.rs`, add class names, registry entries, constructor
+  metadata, and accessors together. Match Rakudo's positional versus named
+  fields and omitted false/default values.
+- In `src/rakuast/lower.rs`, accept the supported hand-built RakuAST shape and
+  lower it to the existing `Expr`/`Stmt` path. Reuse the compiler and VM.
+- Do not add a second interpreter or a VM/runtime slow path such as
+  `call_method_with_values`, `run_instance_method`, or `eval_block` to make the
+  RakuAST case work.
+
+If a feature needs a new semantic distinction, make that a bounded parser /
+internal-AST design slice and link its ADR rather than guessing in the
+converter.
+
+## Test the contract
+
+Add a focused `t/rakuast-<slice>.t` test with three kinds of assertions:
+
+- read direction: measured node classes, accessors, and relevant field
+  omission/presence;
+- write direction: `EVAL` of the hand-built or round-tripped AST;
+- semantics: strict and flag/adverb variants that exercise the existing
+  execution path.
+
+Prefer structural assertions over snapshots of an entire `.gist` when the
+format contains incidental detail, while pinning exact field names and values
+where they are part of the compatibility contract. Keep probes minimal and
+English comments/test descriptions. For an individual roast test use
+`MUTSU_FUDGE=1`; never set it for ordinary Raku programs.
+
+## Track the campaign
+
+Do not create a fourth `todo/rakuast/` category. Keep the campaign overview in
+`todo/deep/rakuast-remaining.md`, put a self-contained implementation slice in
+`todo/tickets/rakuast-<slug>.md`, and keep architectural blockers in
+`todo/deep/rakuast-<slug>.md`. Use `docs/rakuast/README.md` for stable workflow
+guidance, ADRs for decisions, `news/YYYY-MM/` for completed work, and the
+focused test as the executable record. Avoid making every small slice edit a
+shared campaign ledger; the per-slice todo/news file is the source of truth.
+
+For an implementation PR, follow the repository's required full validation and
+inspect `tmp/make-test.log` and `tmp/make-roast.log` before publication.

--- a/.agents/skills/rakuast-implementation/agents/openai.yaml
+++ b/.agents/skills/rakuast-implementation/agents/openai.yaml
@@ -1,0 +1,3 @@
+interface:
+  display_name: "RakuAST Implementation"
+  short_description: "Implement bounded mutsu RakuAST slices"

--- a/docs/rakuast/README.md
+++ b/docs/rakuast/README.md
@@ -1,0 +1,48 @@
+# RakuAST work
+
+RakuAST work is organized by implementation scope, not in a separate
+`todo/rakuast/` category. RakuAST is a reflection/model layer over mutsu's
+internal `Expr`/`Stmt` AST, so each completed slice should preserve the normal
+`Parser -> Compiler -> VM` pipeline.
+
+## Where work lives
+
+- `todo/deep/rakuast-remaining.md` is the campaign overview and records broad
+  representation gaps.
+- `todo/tickets/rakuast-<slug>.md` contains a self-contained implementation
+  slice that can be completed in one PR.
+- `todo/deep/rakuast-<slug>.md` contains a slice that needs an ADR, parser or
+  internal-AST redesign, or a broader execution campaign.
+- `docs/adr/` contains architectural decisions and their current phase/status.
+- `t/rakuast-<slice>.t` is the focused dual-oracle regression test.
+- `news/YYYY-MM/` records completed slices after they merge.
+
+The per-slice todo or news entry is the source of truth. The campaign overview
+should remain an index rather than a second detailed ledger, so small slices do
+not all need to edit the same shared file.
+
+## Slice checklist
+
+For each construct, investigate the smallest useful program under both a bare
+`raku` and mutsu:
+
+1. Measure the Rakudo `.AST` class tree, field names, omitted defaults,
+   accessors, constructor shape, and `EVAL($ast)` result.
+2. Locate the existing parser/internal `Expr` or `Stmt` and confirm ordinary
+   execution behavior.
+3. Implement the read direction in `src/rakuast/convert.rs`.
+4. Add or complete class, constructor, and accessor metadata in
+   `src/rakuast/mod.rs`.
+5. Implement the write direction in `src/rakuast/lower.rs`, lowering into the
+   existing compiler/VM path.
+6. Add read, write, and semantic assertions in a focused `t/rakuast-*.t` file.
+7. Update the relevant ADR, campaign entry, or news record only with measured
+   facts.
+
+If the parser/internal AST has already erased a distinction, do not guess it
+inside RakuAST conversion. Preserve the distinction upstream or turn it into a
+design/deep slice first. Do not add an alternate interpreter or a VM/runtime
+slow path for RakuAST.
+
+The reusable agent procedure for this work is in
+`.agents/skills/rakuast-implementation/SKILL.md`.

--- a/todo/deep/rakuast-remaining.md
+++ b/todo/deep/rakuast-remaining.md
@@ -16,6 +16,17 @@ implemented so far; they do not imply that an arbitrary source program has the
 same `.AST` shape or that every construct can be lowered through `EVAL`. As of
 2026-09-02, the suite covered 93 files and 646 assertions.
 
+## Campaign organization
+
+This file is the campaign overview, not a fourth `todo/rakuast/` category.
+Self-contained slices belong in `todo/tickets/rakuast-<slug>.md`; parser,
+internal-AST, or execution redesigns belong in `todo/deep/rakuast-<slug>.md`.
+Stable workflow guidance is in [`docs/rakuast/README.md`](../../docs/rakuast/README.md),
+and the reusable implementation procedure is in
+[`.agents/skills/rakuast-implementation/SKILL.md`](../../.agents/skills/rakuast-implementation/SKILL.md).
+Each slice should close both RakuAST directions and add focused dual-oracle
+coverage before it is marked complete.
+
 The 2026-09-02 direct probes against the system `raku` established the current
 boundary:
 


### PR DESCRIPTION
## Summary

- keep RakuAST work in the existing `todo/deep` / `todo/tickets` taxonomy
- add maintainer guidance under `docs/rakuast/`
- add the reusable `rakuast-implementation` skill for Rakudo oracle measurement, bidirectional conversion, lowering, and tests

## Validation

- `python3 /home/tokuhirom/.codex/skills/.system/skill-creator/scripts/quick_validate.py .agents/skills/rakuast-implementation`
- `git diff --cached --check`

This is documentation and agent-workflow only; no Rust or test behavior changed.