### PR TITLE
feat: ADR-0065 S0 — pin mutsu's viability as a long-lived resident parser

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -79,6 +79,13 @@ work; see the CLAUDE.md "mzef package manager and distribution" section. The **R
 `src/repl.rs`, plus the in-browser one at `site/repl.html`) and the **public WASM playground**
 (`site/playground.html`, deployed to GitHub Pages by `.github/workflows/pages.yml`) both ship.
 
+- [ ] **Language server** — designed in [docs/adr/0065-language-server-targets-ai-agents.md](docs/adr/0065-language-server-targets-ai-agents.md)
+      (an AI agent is the primary consumer, so only the methods an agent consumes are implemented,
+      and "does mutsu support this?" is a first-class diagnostic). **S0 (the long-lived-process
+      viability gate) is done and passes** — `tests/long_lived_parse.rs`,
+      `news/2026-09/adr0065-s0-long-lived-parse-probe.md`. Next is **S1: the workspace crate, the
+      server skeleton, and diagnostics from the existing single-error path**; the ADR's phasing table
+      carries S2-S5.
 - [ ] Debugger.
 - [ ] Native binary output.
 

--- a/docs/adr/0065-language-server-targets-ai-agents.md
+++ b/docs/adr/0065-language-server-targets-ai-agents.md
@@ -187,6 +187,106 @@ documents almost certainly will not, and the server must stay single-threaded fo
 until that is addressed. If this gate fails, the rest of the plan is invalid, so it runs
 first.
 
+**Executed 2026-09-03 — the gate passes.** See "S0 findings" below. Two of this
+paragraph's expectations were wrong, and the findings section carries the corrections:
+concurrent parsing of different documents *does* hold, and byte-identical re-parse is not
+an achievable (or desirable) property.
+
+## S0 findings (2026-09-03)
+
+The probe is `tests/long_lived_parse.rs`, five tests that run as part of `cargo test` and
+stay in the suite as regression gates. Iteration count is `MUTSU_S0_ITERATIONS` (200 by
+default, so the committed gate is cheap); the numbers below are from a debug build at 8000
+iterations, which is what a resident server reaches in a working session. **These are
+feasibility measurements, not bench-CI numbers** — memory and determinism results are
+independent of optimization level, and the wall-clock figures are not the ones to quote.
+
+**The gate passes.** Nothing here invalidates the plan. Five results, two of which correct
+D8 as written above.
+
+### 1. Re-parsing is deterministic, but not byte-identical — and must not be
+
+An unchanged document re-parses to an identical AST **except** for ids the parser is
+*required* to mint uniquely per declaration site:
+
+- `decl_id` — a `my class`'s key in the global type registry. ADR-0047 D1 mangles every
+  lexical declaration to `Foo\u{0}<decl-id>` precisely so that two declaration sites can
+  never share a registry key.
+- `__ANON_CLASS_N__`, `__ANON_ROLE_N__`, `__ANON_SUBSET_N__` — registry *names* for
+  anonymous declarations, drawn from the same process-global counters that the runtime's
+  `but`-mixin path also draws from (`next_anon_role_name`).
+- Desugaring temporaries: `__with_tmp_N`, `__if_bind_tmp_N`, `__take_value_N`, ... These
+  name lexicals inside a desugared block rather than registry entries, so unlike the two
+  above they are *not* known to require process-global uniqueness — but nothing has
+  established that they don't, and they drift the same way.
+
+For the registry ids, resetting per parse would make two declaration sites in two different
+compilation units collide in a process-global table — a correctness bug, not a cleanup. So
+the right gate is *determinism modulo those ids*, and the probe normalizes them before
+comparing. With that normalization, 8000 consecutive re-parses of an 1140-byte document
+are identical. Any other difference is residual parser state and fails the test.
+
+### 2. The only unbounded growth is one interned name per anonymous declaration per parse
+
+`src/symbol.rs` leaks interned strings for the process lifetime by design. Measured over
+8000 re-parses:
+
+| Document | Interned names | Resident memory |
+| --- | --- | --- |
+| No anonymous declarations | **+0** (exactly zero) | +124 KiB at 8000 parses, +136 KiB at 2000 — noise, not growth |
+| One anonymous class | +8000 (exactly 1.00/parse) | +3988 KiB (~0.5 KiB/parse, linear) |
+
+So there is no general per-parse leak: the parse memo tables reset and genuinely release,
+and `Vec`/`String` churn returns to the allocator. The *entire* linear component is the
+freshly minted, interned, permanently leaked registry name for each anonymous declaration.
+At ~0.5 KiB per re-parse of a file containing one `class { }` this is a slow leak — a few
+megabytes over a long editing session — not a blocker.
+
+The structural fix is available and belongs with the server's real entry point, not here:
+**an analysis-only parse never registers a type**, so in that mode these counters can be
+compilation-unit-local instead of process-global. That is a property of the API S1
+introduces, so it is recorded as a follow-up
+(`todo/tickets/analysis-parse-mints-process-unique-registry-names.md`) rather than
+retrofitted onto `dump_ast`.
+
+### 3. Concurrent parsing of different documents holds — D8's expectation was wrong
+
+The parser's entire working set is thread-local (`SCOPES`, the three memo tables,
+`ORIGINAL_SOURCE`, `LEAKED_REGIONS`, the slang modes); the symbol table is behind an
+`RwLock` and the unique-id counters are atomics. Four threads parsing four different
+documents, five rounds, produce ASTs identical to the same documents parsed on the main
+thread. **The server is therefore not forced to serialize parsing.** This is scoped to
+parsing only — it says nothing about concurrently *loading modules* or executing, which
+touch the type registry and the interpreter's globals.
+
+### 4. No residue between documents, and `ORIGINAL_SOURCE` survives re-entry
+
+Parsing a document that declares custom infix/prefix operators, a `use v6.e.PREVIEW`
+pragma, lexicals, a `constant` and a `my class` does not change how the *next* document
+parses (checked in both orders — a B/A/B and an A/B/A sandwich). This is the failure mode
+that a one-shot process can never expose and that would make a resident server's
+diagnostics depend on which file was opened first.
+
+### 5. In-process re-parse costs ~1.3 ms, which re-confirms D3's rejection of incremental sync
+
+The ADR's feasibility table records ~9 ms as the average parse of one ecosystem module,
+measured through the CLI — one process per file, so it includes startup and I/O. Measured
+*in process*, which is what a server actually does, a release build re-parses the 1140-byte
+probe document in **1.29 ms** (8000 iterations, 10.3 s total). Debug is ~10.7 ms.
+
+D3 dropped incremental document sync on the argument that a full reparse is fast enough.
+The in-process figure is roughly seven times better than the number that argument was made
+on, so the decision holds with a wide margin. Memory and determinism results are identical
+between debug and release, as expected.
+
+`ORIGINAL_SOURCE`'s raw `(pointer, len)` pair also survives interleaving parses of
+differently sized buffers, including buffers that trigger nested sub-parses on separate
+allocations (a heredoc and an `EVAL`). Line numbers in the small document stay correct
+after 25 rounds of being interleaved with a 200-line buffer, so the existing
+snapshot/restore discipline in `parse_program_partial` holds under repetition. Since
+`Stmt::SetLine` is the only positional information mutsu has (D6), this is the load-bearing
+property for every diagnostic the server will emit.
+
 ## Rejected alternatives
 
 - **A lossless CST / red-green tree (rust-analyzer, rowan).** The correct architecture for
@@ -211,7 +311,7 @@ first.
 
 | Slice | Content | Depends on |
 | --- | --- | --- |
-| **S0** | Long-lived-process viability probe (D8) | — |
+| **S0** | Long-lived-process viability probe (D8) — **done 2026-09-03**, `tests/long_lived_parse.rs` | — |
 | **S1** | Server skeleton, full-document reparse, diagnostics from the existing single-error path | S0 |
 | **S2** | Enumerable built-in name tables → "mutsu does not support this" diagnostics (D4) | S1 |
 | **S3** | Multiple diagnostics per document + error recovery (give `parse_program_partial` positions and errors) | S1 |

--- a/news/2026-09/adr0065-s0-long-lived-parse-probe.md
+++ b/news/2026-09/adr0065-s0-long-lived-parse-probe.md
@@ -1,0 +1,92 @@
+# The language server's viability gate passes: mutsu holds up as a resident parser
+
+ADR-0065 designed a language server for mutsu and put a gate in front of everything else.
+mutsu has always been a one-shot process — parse once, run, exit — and a language server
+inverts that: one process parses many documents and re-parses each of them thousands of
+times. D8 made that an explicit precondition: *measure it before writing a server
+skeleton, because if it fails the rest of the plan is invalid.*
+
+S0 is now done. The probe is `tests/long_lived_parse.rs` — five tests that run under
+`cargo test` and stay in the suite as regression gates, with the iteration count behind
+`MUTSU_S0_ITERATIONS` so the committed gate is cheap and a deeper sweep is one env var
+away. **The gate passes**, and two of D8's own expectations turned out to be wrong.
+
+## Byte-identical re-parse is the wrong property to want
+
+The first version of the probe asserted that re-parsing an unchanged document yields an
+identical AST. It failed immediately, on three counts: `__with_tmp_N`, `__ANON_CLASS_N__`,
+and `decl_id`.
+
+None of those is a defect. `decl_id` is a `my class`'s key in the global type registry —
+ADR-0047 D1 mangles every lexical declaration to `Foo\u{0}<decl-id>` *precisely* so two
+declaration sites can never share a key. `__ANON_CLASS_N__` and `__ANON_ROLE_N__` are
+registry names, drawn from the same counters the runtime's `but`-mixin path draws from.
+Resetting any of them per parse would make two sites in two different compilation units
+collide in a process-global table.
+
+So the gate is determinism *modulo ids the parser is required to mint uniquely per site*.
+The probe normalizes those and compares everything else; 8000 consecutive re-parses are
+identical, and any other difference fails the test as residual parser state. Aiming at
+byte-identity would have led to exactly the wrong fix.
+
+## The only unbounded growth is one leaked name per anonymous declaration per parse
+
+`src/symbol.rs` leaks interned strings for the process lifetime by design — free for a
+one-shot process, a slow leak for a resident one. Splitting the measurement by whether the
+document contains an anonymous declaration isolated it completely (8000 re-parses, debug
+build):
+
+| Document | Interned names | Resident memory |
+| --- | --- | --- |
+| No anonymous declarations | **+0** | +124 KiB at 8000 parses, +136 KiB at 2000 — noise, not growth |
+| One anonymous class | +8000 (exactly 1.00/parse) | +3988 KiB (~0.5 KiB/parse, linear) |
+
+There is no general per-parse leak. The memo tables reset and genuinely release; `Vec` and
+`String` churn returns to the allocator; a document with no anonymous declaration reaches
+*exactly zero* interning growth, which is now the tighter of the two committed gates. The
+entire linear component is the freshly minted registry name for each anonymous
+declaration.
+
+The fix is structural and belongs with the server's real entry point rather than here: an
+analysis-only parse never registers a type, so in that mode the uniqueness requirement
+drops from process-global to compilation-unit-local. Recorded as
+`todo/tickets/analysis-parse-mints-process-unique-registry-names.md`, to be done with the
+S1 parse API instead of retrofitted onto `dump_ast`.
+
+## Concurrent parsing holds, which D8 did not expect
+
+D8 predicted that concurrency across documents "almost certainly will not" hold and that
+the server would have to serialize parsing. It does hold. The parser's entire working set
+is thread-local — `SCOPES`, the three memo tables, `ORIGINAL_SOURCE`, `LEAKED_REGIONS`,
+the slang modes — the symbol table sits behind an `RwLock`, and the unique-id counters are
+atomics. Four threads parsing four different documents, five rounds, produce ASTs identical
+to the same documents parsed on the main thread. That is now pinned, so a future change
+that promotes parser state to a process-global fails in `cargo test` rather than in a
+server under load. It is scoped to *parsing*: it says nothing about concurrently loading
+modules or executing, which touch the type registry and the interpreter's globals.
+
+## No residue between documents, and line numbers survive re-entry
+
+The failure mode a one-shot process can never expose is document A changing how document B
+parses afterwards — custom operators, a `use v6.e.PREVIEW` pragma, lexicals and a
+`constant` all live in thread-local parser state. Since there is no pristine process to
+compare against inside one test, the probe uses a B/A/B sandwich (and an A/B/A one, so the
+check cannot be satisfied by B failing identically twice). No residue.
+
+`ORIGINAL_SOURCE`, the thread-local `(raw pointer, length)` pair behind `$?LINE`, also
+survives being interleaved across differently sized buffers, including buffers that trigger
+nested sub-parses on separate allocations (a heredoc and an `EVAL`). The small document's
+line numbers stay correct after 25 interleaved rounds, so `parse_program_partial`'s
+snapshot/restore discipline holds under repetition. Since `Stmt::SetLine` is the only
+positional information mutsu has (ADR-0065 D6), that is the load-bearing property under
+every diagnostic the server will emit.
+
+One measurement came out better than the design assumed. ADR-0065's feasibility table put
+a module parse at ~9 ms, measured through the CLI — one process per file, startup and I/O
+included. In process, which is what a server does, a release build re-parses the probe
+document in **1.29 ms**. D3 dropped incremental document sync on the argument that a full
+reparse is fast enough; the real figure is about seven times better than the number that
+argument rested on.
+
+`src/symbol.rs` gained one public function for this, `symbol::interned_count()` — the table
+is append-only and leaked, so its size doubles as the leak gauge the probe reads.

--- a/src/symbol.rs
+++ b/src/symbol.rs
@@ -236,6 +236,17 @@ impl Symbol {
     }
 }
 
+/// How many distinct strings the process has interned so far.
+///
+/// The table is append-only and its entries are leaked for the process
+/// lifetime, so this doubles as a leak gauge: in a long-lived process (the
+/// language server of ADR-0065) a workload that keeps growing this number while
+/// re-analysing the *same* document is manufacturing fresh names, and every one
+/// of them costs permanent memory. Pinned by `tests/long_lived_parse.rs`.
+pub fn interned_count() -> usize {
+    global_table().read().unwrap().id_to_str.len()
+}
+
 impl fmt::Debug for Symbol {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "Symbol({}: {:?})", self.0, self.as_str())

--- a/tests/long_lived_parse.rs
+++ b/tests/long_lived_parse.rs
@@ -1,0 +1,478 @@
+//! ADR-0065 S0: the long-lived-process viability probe (decision D8).
+//!
+//! mutsu has always been a one-shot process: parse once, run, exit. A language
+//! server inverts that — one process parses many documents, and re-parses each
+//! of them thousands of times. Before any server skeleton is written, this file
+//! pins the properties that whole plan rests on.
+//!
+//! **What is deliberately NOT asserted: byte-identical ASTs.** The parser mints
+//! process-unique ids for constructs whose identity outlives the parse — a
+//! `my class`'s `decl_id` is its key in the global type registry (ADR-0047 D1),
+//! and `__ANON_CLASS_N__` / `__ANON_ROLE_N__` are registry names. Those counters
+//! are monotonic *on purpose*: resetting them per parse would let two different
+//! declaration sites in two different compilation units collide in a global
+//! table. So the probe compares ASTs with those ids normalized, and any
+//! remaining difference is genuine residual parser state.
+//!
+//! Iteration count is `MUTSU_S0_ITERATIONS` (default: enough to expose a
+//! per-parse leak, small enough for `cargo test` on a debug build). Run
+//! `cargo test --test long_lived_parse -- --nocapture` to see the measurements.
+
+use std::sync::{Mutex, MutexGuard};
+use std::time::Instant;
+
+/// `cargo test` runs the tests in one binary concurrently by default, and two
+/// of these measure a *process-global* quantity (the symbol table's size, the
+/// process's resident memory). A sibling test parsing at the same time would
+/// silently inflate both. Serialize the whole file.
+static SERIALIZE: Mutex<()> = Mutex::new(());
+
+fn exclusive() -> MutexGuard<'static, ()> {
+    // A panicking test poisons the lock; the later tests are still meaningful.
+    SERIALIZE.lock().unwrap_or_else(|e| e.into_inner())
+}
+
+/// A document shaped like something a language-server client would hold open:
+/// a module with classes, roles, a grammar, and the desugaring-heavy constructs
+/// (`state`, `with`, `given`/`when`, `gather`/`take`, anonymous classes,
+/// chained index assignment) that mint generated names during parsing.
+const DOCUMENT: &str = r#"
+unit module Probe::Doc;
+
+role Greeter {
+    method greet($name) { "hello, $name" }
+}
+
+class Counter does Greeter {
+    has Int $.count is rw = 0;
+    has %.seen;
+
+    method bump(--> Int) {
+        state $calls = 0;
+        $calls++;
+        $!count++;
+        %!seen{$!count} = $calls;
+        return $!count;
+    }
+
+    method describe() {
+        with $!count -> $c {
+            given $c {
+                when 0  { "empty" }
+                when 1  { "single" }
+                default { "many ($c)" }
+            }
+        }
+        else {
+            "undefined"
+        }
+    }
+}
+
+grammar Probe::Grammar {
+    token TOP   { <ident>+ % \s+ }
+    token ident { <[ A..Z a..z _ ]> <[ A..Z a..z 0..9 _ ]>* }
+}
+
+sub collect(@items) is export {
+    gather for @items -> $item {
+        take $item.uc if $item ~~ Str;
+    }
+}
+
+sub tally(%data) is export {
+    my @rows;
+    for %data.sort(*.key) -> $pair {
+        @rows[$pair.value][0] = $pair.key;
+    }
+    my $anon = class { method label() { "anon" } }.new;
+    @rows.map({ $_ // $anon.label }).join(",");
+}
+
+my $c = Counter.new;
+$c.bump for ^3;
+say $c.describe;
+say collect(<a b c>);
+"#;
+
+/// Prefixes whose trailing digit run is a *process-unique* id, not content.
+/// Everything else in the AST dump must be reproducible.
+const GENERATED_ID_PREFIXES: &[&str] = &[
+    "__ANON_CLASS_",
+    "__ANON_ROLE_",
+    "__ANON_SUBSET_",
+    "__with_tmp_",
+    "__if_bind_tmp_",
+    "__take_value_",
+    "__anon_state_",
+    "__anon_array_",
+    "__tmp_index_",
+    "__supply_emitter_",
+    "decl_id: ",
+    // Symbol ids shift as the interner grows, so the numeric half of a
+    // `Symbol(19: "name")` dump is incidental; the name it prints is not.
+    "Symbol(",
+];
+
+/// Replace the digit run following each generated-id prefix with `N`, so two
+/// dumps of the same document compare equal iff they differ only in ids the
+/// parser is *required* to make unique per site.
+fn normalize_generated_ids(dump: &str) -> String {
+    let mut out = String::with_capacity(dump.len());
+    let mut rest = dump;
+    'outer: while !rest.is_empty() {
+        for prefix in GENERATED_ID_PREFIXES {
+            if let Some(after) = rest.strip_prefix(prefix) {
+                let digits =
+                    after.len() - after.trim_start_matches(|c: char| c.is_ascii_digit()).len();
+                if digits > 0 {
+                    out.push_str(prefix);
+                    out.push('N');
+                    rest = &after[digits..];
+                    continue 'outer;
+                }
+            }
+        }
+        let ch = rest.chars().next().expect("non-empty");
+        out.push(ch);
+        rest = &rest[ch.len_utf8()..];
+    }
+    out
+}
+
+/// Resident set size in KiB, or `None` where `/proc` is unavailable.
+fn rss_kib() -> Option<usize> {
+    let statm = std::fs::read_to_string("/proc/self/statm").ok()?;
+    let resident_pages: usize = statm.split_whitespace().nth(1)?.parse().ok()?;
+    Some(resident_pages * 4)
+}
+
+fn iterations() -> usize {
+    std::env::var("MUTSU_S0_ITERATIONS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(200)
+}
+
+fn report_divergence(what: &str, baseline: &str, other: &str) -> String {
+    let mut report = String::new();
+    for (a, b) in baseline.lines().zip(other.lines()).filter(|(a, b)| a != b) {
+        report.push_str(&format!("  first: {}\n  now  : {}\n", a.trim(), b.trim()));
+        if report.len() > 2000 {
+            report.push_str("  ...\n");
+            break;
+        }
+    }
+    if report.is_empty() {
+        report.push_str("  (line counts differ)\n");
+    }
+    format!("{what}\n{report}")
+}
+
+/// The core gate: a resident process that re-analyses an unchanged document
+/// must keep producing the same analysis, and must not grow without bound
+/// while doing so.
+#[test]
+fn repeated_parse_of_an_unchanged_document_is_stable() {
+    let _guard = exclusive();
+    let n = iterations();
+
+    // Warm up: the first parses populate one-time global state (the symbol
+    // table's fixed names, `LazyLock` well-known symbols, the pragma preseeds).
+    // The steady state is what a resident process actually lives in, so the
+    // measurement starts after it is reached.
+    let baseline = normalize_generated_ids(&mutsu::dump_ast(DOCUMENT).expect("document parses"));
+    for _ in 0..2 {
+        mutsu::dump_ast(DOCUMENT).expect("document parses");
+    }
+
+    let symbols_before = mutsu::symbol::interned_count();
+    let rss_before = rss_kib();
+    let started = Instant::now();
+
+    let mut first_divergence: Option<(usize, String)> = None;
+    for i in 0..n {
+        let ast = normalize_generated_ids(&mutsu::dump_ast(DOCUMENT).expect("document parses"));
+        if ast != baseline && first_divergence.is_none() {
+            first_divergence = Some((i, ast));
+        }
+    }
+
+    let elapsed = started.elapsed();
+    let symbols_after = mutsu::symbol::interned_count();
+    let rss_after = rss_kib();
+    let symbol_growth = symbols_after - symbols_before;
+
+    println!(
+        "--- ADR-0065 S0 probe: {n} parses of a {}-byte document ---",
+        DOCUMENT.len()
+    );
+    println!(
+        "  wall clock      : {elapsed:?} total, {:?} per parse",
+        elapsed / n as u32
+    );
+    println!(
+        "  interned symbols: {symbols_before} -> {symbols_after} (+{symbol_growth}, {:.2}/parse)",
+        symbol_growth as f64 / n as f64
+    );
+    match (rss_before, rss_after) {
+        (Some(before), Some(after)) => println!(
+            "  resident memory : {before} KiB -> {after} KiB ({:+} KiB, {:.3} KiB/parse)",
+            after as isize - before as isize,
+            (after as f64 - before as f64) / n as f64,
+        ),
+        _ => println!("  resident memory : unavailable (no /proc)"),
+    }
+
+    if let Some((i, ast)) = first_divergence {
+        panic!(
+            "{}",
+            report_divergence(
+                &format!(
+                    "re-parsing an unchanged document produced a different AST at iteration {i}, \
+                     beyond the process-unique ids this probe normalizes away. That is residual \
+                     parser state: a resident server would report analyses that change without \
+                     the document changing."
+                ),
+                &baseline,
+                &ast,
+            )
+        );
+    }
+
+    // Interning: the document declares one anonymous class, whose registry name
+    // (`__ANON_CLASS_N__`) is minted fresh per parse and interned — and interned
+    // strings are leaked for the process lifetime by design (`src/symbol.rs`).
+    // One name per anonymous declaration per parse is therefore the *expected*
+    // cost, and this bound catches a new source of per-parse interning rather
+    // than that known one. See `docs/adr/0065-...` S0 findings.
+    let anon_declarations_in_document = 1;
+    let allowed = anon_declarations_in_document * n;
+    assert!(
+        symbol_growth <= allowed,
+        "re-parsing an unchanged document interned {symbol_growth} new names over {n} parses \
+         ({:.2}/parse), above the {:.2}/parse expected from its {anon_declarations_in_document} \
+         anonymous declaration(s). Interned strings are leaked for the process lifetime, so a new \
+         per-parse intern is an unbounded leak in a resident server.",
+        symbol_growth as f64 / n as f64,
+        anon_declarations_in_document as f64,
+    );
+
+    // Resident memory is noisier than the symbol table (allocator arenas, memo
+    // tables that hold a bounded working set), so this bound is a regression
+    // tripwire: a genuine per-parse leak grows proportionally to `n`.
+    if let (Some(before), Some(after)) = (rss_before, rss_after) {
+        let growth = after.saturating_sub(before);
+        assert!(
+            growth < 32 * 1024,
+            "resident memory grew {growth} KiB over {n} parses of an unchanged document"
+        );
+    }
+}
+
+/// The tighter half of the same gate. `DOCUMENT` declares an anonymous class,
+/// whose registry name is minted and interned fresh per parse — an expected,
+/// documented cost. A document with no anonymous declaration has no such
+/// excuse, so its interning must reach exactly zero growth: anything else is an
+/// unbounded leak in a resident server, since interned strings are never freed.
+#[test]
+fn a_document_without_anonymous_declarations_interns_nothing_on_reparse() {
+    let _guard = exclusive();
+    const PLAIN: &str = r#"
+unit module Probe::Plain;
+
+class Point {
+    has Int $.x = 0;
+    has Int $.y = 0;
+    method norm(--> Int) { $!x * $!x + $!y * $!y }
+    method shifted(Int $dx, Int $dy) { Point.new(x => $!x + $dx, y => $!y + $dy) }
+}
+
+sub distances(@points) is export {
+    @points.map({ .norm }).sort;
+}
+
+my @pts = Point.new(x => 1, y => 2), Point.new(x => 3, y => 4);
+for distances(@pts) -> $d {
+    say $d if $d > 1;
+}
+"#;
+
+    let n = iterations();
+    let baseline = normalize_generated_ids(&mutsu::dump_ast(PLAIN).expect("document parses"));
+    for _ in 0..2 {
+        mutsu::dump_ast(PLAIN).expect("document parses");
+    }
+
+    let symbols_before = mutsu::symbol::interned_count();
+    let rss_before = rss_kib();
+    for _ in 0..n {
+        let ast = normalize_generated_ids(&mutsu::dump_ast(PLAIN).expect("document parses"));
+        assert_eq!(baseline, ast, "re-parsing an unchanged document diverged");
+    }
+    let symbol_growth = mutsu::symbol::interned_count() - symbols_before;
+    let rss_after = rss_kib();
+
+    println!("--- ADR-0065 S0 probe: {n} parses, no anonymous declarations ---");
+    println!(
+        "  interned symbols: +{symbol_growth} ({:.3}/parse)",
+        symbol_growth as f64 / n as f64
+    );
+    if let (Some(before), Some(after)) = (rss_before, rss_after) {
+        println!(
+            "  resident memory : {:+} KiB ({:.3} KiB/parse)",
+            after as isize - before as isize,
+            (after as f64 - before as f64) / n as f64,
+        );
+    }
+
+    assert_eq!(
+        symbol_growth, 0,
+        "re-parsing a document with no anonymous declarations still interned {symbol_growth}          new names over {n} parses; interned strings are leaked for the process lifetime"
+    );
+}
+
+/// The hazard a one-shot process can never expose: parsing document A must not
+/// change how document B parses afterwards. The parser keeps user-defined
+/// operators, declared lexicals, the language version and slang modes in
+/// thread-local state; any of it surviving a compilation unit would make a
+/// resident server's diagnostics depend on which files were opened first.
+///
+/// There is no pristine process to compare against inside one test, so the
+/// comparison is B-before-A against B-after-A: any difference is residue.
+#[test]
+fn one_document_leaves_no_parser_residue_for_the_next() {
+    let _guard = exclusive();
+    // A declares everything the parser tracks lexically: a custom operator, a
+    // language version pragma, lexical names, a package, a constant, a slang
+    // mode change, and a `sub` whose signature the parser preseeds.
+    const DOC_A: &str = r#"
+use v6.e.PREVIEW;
+sub infix:<qqq>($a, $b) { $a + $b }
+sub prefix:<^^^>($a) { -$a }
+constant ONLY-IN-A = 42;
+my $lexical-of-a = 1;
+my class LexClass { method m() { 1 } }
+say 1 qqq 2;
+"#;
+
+    // B uses names A declared. Whether they parse as operators / known names is
+    // exactly what must not depend on A having been parsed.
+    const DOC_B: &str = r#"
+my $x = 1;
+say $x;
+sub uses-them($a, $b) { $a + $b }
+say uses-them(1, 2);
+say ONLY-IN-A ~~ Any;
+say $lexical-of-a ~~ Any;
+"#;
+
+    let describe = |src: &str| match mutsu::dump_ast(src) {
+        Ok(ast) => normalize_generated_ids(&ast),
+        Err(e) => format!("PARSE ERROR: {}", e.message),
+    };
+
+    let b_first = describe(DOC_B);
+    describe(DOC_A);
+    let b_after_a = describe(DOC_B);
+    assert_eq!(
+        b_first,
+        b_after_a,
+        "{}",
+        report_divergence(
+            "parsing one document changed how the NEXT document parses. The parser's \
+             thread-local lexical state (user-defined operators, declared names, language \
+             version, slang modes) is leaking across compilation units, which in a resident \
+             server means a file's diagnostics depend on which files were opened before it.",
+            &b_first,
+            &b_after_a,
+        )
+    );
+
+    // And the reverse order, so the check is not satisfied by B simply failing
+    // identically both times.
+    let a_first = describe(DOC_A);
+    describe(DOC_B);
+    let a_after_b = describe(DOC_A);
+    assert_eq!(
+        normalize_generated_ids(&a_first),
+        normalize_generated_ids(&a_after_b),
+        "parsing document B changed how document A parses afterwards"
+    );
+
+    // A must actually have parsed — otherwise this test proves nothing.
+    assert!(
+        !a_first.starts_with("PARSE ERROR"),
+        "the residue probe's document A no longer parses: {a_first}"
+    );
+}
+
+/// D8 asks specifically about `ORIGINAL_SOURCE`, the thread-local `(raw pointer,
+/// length)` pair the parser uses for `$?LINE`. A resident server parses many
+/// short-lived buffers, so a stale pointer left behind by one parse would make
+/// the *next* parse's line numbers wrong — and line numbers are what every
+/// diagnostic is anchored to (D6).
+#[test]
+fn line_numbers_survive_repeated_parses_of_differently_sized_buffers() {
+    let _guard = exclusive();
+    let short = "say 1;\nsay 2;\n";
+    // A buffer with a nested sub-parse (heredoc + EVAL) on a different, longer
+    // allocation, which is what historically left the pointer dangling.
+    let with_nested =
+        "my $h = q:to/END/;\nheredoc body\nEND\nsay $h;\nsay EVAL('1 + 1');\nsay 3;\n";
+    let long = format!("{}\nsay 4;\n", "# filler comment line\n".repeat(200));
+
+    let expected_short = mutsu::dump_ast(short).expect("short parses");
+    for _ in 0..25 {
+        mutsu::dump_ast(&long).expect("long parses");
+        mutsu::dump_ast(with_nested).expect("nested parses");
+        let again = mutsu::dump_ast(short).expect("short parses");
+        assert_eq!(
+            expected_short, again,
+            "line-number state leaked from a previous parse into a later one"
+        );
+    }
+
+    // `SetLine` markers are the only positions mutsu has (ADR-0065 D6), so pin
+    // that they are actually present and correct rather than collapsed to 1.
+    let setline_markers = expected_short.matches("SetLine(").count();
+    assert_eq!(
+        setline_markers, 2,
+        "expected one SetLine marker per statement, got {setline_markers}:\n{expected_short}"
+    );
+}
+
+/// D8's open question: whether documents can be analysed on more than one
+/// thread. The parser's working state (`SCOPES`, the memo tables,
+/// `ORIGINAL_SOURCE`) is thread-local and the symbol table is behind an
+/// `RwLock`, so concurrent parsing of *different* documents should hold. This
+/// pins that, so a future change that moves parser state to a process-global
+/// fails here rather than in a server under load.
+#[test]
+fn documents_parse_independently_on_separate_threads() {
+    let _guard = exclusive();
+    let sources: Vec<String> = (0..4).map(|i| format!("{DOCUMENT}\nsay {i};\n")).collect();
+    let expected: Vec<String> = sources
+        .iter()
+        .map(|s| normalize_generated_ids(&mutsu::dump_ast(s).expect("parses")))
+        .collect();
+
+    for _round in 0..5 {
+        let handles: Vec<_> = sources
+            .iter()
+            .cloned()
+            .map(|src| {
+                std::thread::spawn(move || {
+                    normalize_generated_ids(&mutsu::dump_ast(&src).expect("parses"))
+                })
+            })
+            .collect();
+        for (i, handle) in handles.into_iter().enumerate() {
+            let got = handle.join().expect("parser thread must not panic");
+            assert_eq!(
+                expected[i], got,
+                "document {i} parsed differently on a worker thread than on the main thread"
+            );
+        }
+    }
+}

--- a/todo/tickets/analysis-parse-mints-process-unique-registry-names.md
+++ b/todo/tickets/analysis-parse-mints-process-unique-registry-names.md
@@ -1,0 +1,64 @@
+# An analysis-only parse should not mint process-unique registry names
+
+ADR-0065's S0 probe (`tests/long_lived_parse.rs`, 2026-09-03) measured the one thing that
+grows without bound when the same document is parsed over and over in a resident process:
+**each anonymous declaration in the document mints, interns, and permanently leaks one
+fresh registry name per parse.**
+
+Measured over 8000 re-parses of an 1140-byte document on a debug build:
+
+| Document | Interned names | Resident memory |
+| --- | --- | --- |
+| No anonymous declarations | +0 | +124 KiB (noise — the same as at 2000 parses) |
+| One anonymous class | +8000 (1.00/parse) | +3988 KiB (~0.5 KiB/parse, linear) |
+
+Interned strings are leaked for the process lifetime by design (`src/symbol.rs` module
+docs), so every one of those names is permanent. A language server holding one file with a
+`class { }` open through a long editing session leaks a few megabytes. Not fatal — S0
+passed on this — but it is the only unbounded component, and it has a clean fix.
+
+## Why the counters are process-global today, and why that is correct for execution
+
+- `ANON_CLASS_COUNTER` / `ANON_ROLE_COUNTER` (`src/parser/primary/misc/anon_decl.rs:10`)
+  produce `__ANON_CLASS_N__` / `__ANON_ROLE_N__`, which are the *registry names* an
+  anonymous type is stored under. `next_anon_role_name` is deliberately shared with the
+  runtime's `but`-mixin path so a mixed-in anonymous role and a parsed `role { }` cannot
+  render the same `<anon|N>` id.
+- `CLASS_DECL_ID_COUNTER` (`src/ast.rs:34`) produces `decl_id`, which ADR-0047 D1 mangles
+  into every lexical class's registry key (`Foo\u{0}<decl-id>`) so that two declaration
+  sites never share one.
+- `ANON_SUBSET_COUNTER`, `SUPPLY_EMITTER_COUNTER`, and the desugaring temporaries
+  (`__with_tmp_N`, `__if_bind_tmp_N`, `__take_value_N`, `__tmp_index_N`, `__anon_state_N`,
+  `__anon_array_N`) are the same shape, though most are not interned at parse time.
+
+Resetting any of these per parse would let two declaration sites in two different
+compilation units collide in a process-global table. **Do not "fix" this by resetting the
+counters.**
+
+## The fix
+
+An analysis-only parse never registers a type: nothing executes, no `ClassDef` reaches the
+registry, and the names exist only to be printed back as `documentSymbol` entries. So the
+uniqueness requirement drops from process-global to compilation-unit-local exactly when the
+parse is for analysis.
+
+Introduce that as a property of the parse entry point the language server uses (ADR-0065
+S1 must add one anyway — `dump_ast` returning a `String` is not it), with unit-local
+counters in that mode. The mode must be inherited by nested sub-parses within the same
+unit, and must be off for every existing caller.
+
+## Why this is a ticket and not a deep finding
+
+It is bounded and needs no new design once S1 has settled what the server's parse entry
+point looks like. It should be done *with* that entry point, not before it — retrofitting a
+mode flag onto `dump_ast` would be the wrong shape and would have no caller.
+
+## Repro
+
+```
+MUTSU_S0_ITERATIONS=8000 cargo test --test long_lived_parse repeated_parse -- --nocapture
+```
+
+Compare against the anonymous-declaration-free document in the same file
+(`a_document_without_anonymous_declarations_interns_nothing_on_reparse`), which pins the
+zero-growth baseline.


### PR DESCRIPTION
ADR-0065 D8 made long-lived-process viability a gate in front of the whole language-server plan: mutsu has always been a one-shot process (parse once, run, exit), and a server inverts that — one process parses many documents and re-parses each of them thousands of times. This PR runs the gate.

**The gate passes**, and two of D8's own expectations turned out to be wrong.

`tests/long_lived_parse.rs` is five tests that stay in the suite as regression gates, with the iteration count behind `MUTSU_S0_ITERATIONS` (200 by default, so the committed gate costs ~4s; a deeper sweep is one env var away).

## Byte-identical re-parse is the wrong property to assert

The first version of the probe demanded it and failed immediately on `decl_id`, `__ANON_CLASS_N__` and `__with_tmp_N`. The first two are keys in the process-global type registry — ADR-0047 D1 mangles every lexical class to `Foo\0<decl-id>` precisely so two declaration sites cannot collide — so resetting those counters per parse would be a correctness bug, not a cleanup. The gate is therefore determinism *modulo ids the parser must mint uniquely per site*; the probe normalizes them and any remaining difference fails as residual parser state.

## The only unbounded growth is one leaked name per anonymous declaration per parse

Splitting the measurement by whether the document contains an anonymous declaration isolated it completely (8000 re-parses):

| Document | Interned names | Resident memory |
| --- | --- | --- |
| No anonymous declarations | **+0** | +124 KiB at 8000 parses, +136 KiB at 2000 — noise, not growth |
| One anonymous class | +8000 (exactly 1.00/parse) | +3948 KiB (~0.5 KiB/parse, linear) |

There is no general per-parse leak: the memo tables reset and genuinely release. The entire linear component is the freshly minted, interned, permanently leaked registry name for each anonymous declaration. The structural fix belongs with S1's parse API (an analysis-only parse registers no types, so those counters can be compilation-unit-local there) and is recorded as `todo/tickets/analysis-parse-mints-process-unique-registry-names.md` rather than retrofitted onto `dump_ast`.

## Concurrent parsing holds, which D8 predicted it would not

The parser's whole working set is thread-local (`SCOPES`, the memo tables, `ORIGINAL_SOURCE`, `LEAKED_REGIONS`, slang modes); the symbol table is behind an `RwLock` and the id counters are atomics. Four threads × four documents × five rounds produce ASTs identical to the main thread's. Now pinned, so a future change promoting parser state to a process-global fails in `cargo test` rather than in a server under load.

## No residue between documents; `ORIGINAL_SOURCE` survives re-entry

Parsing a document that declares custom operators, a `use v6.e.PREVIEW` pragma, lexicals, a `constant` and a `my class` does not change how the next document parses — checked with a B/A/B *and* an A/B/A sandwich, since there is no pristine process to compare against inside one test. `ORIGINAL_SOURCE`'s raw `(pointer, len)` pair also survives interleaved parses of differently sized buffers including nested sub-parses (heredoc, `EVAL`), so line numbers — the only positional information mutsu has (D6) — stay correct.

## One measurement came out better than the design assumed

In-process re-parse is **1.29 ms** in release. The ADR's ~9 ms was measured through the CLI, one process per file. D3 dropped incremental document sync on the argument that a full reparse is fast enough; the real figure is ~7x better than the number that argument rested on.

## Changes

- `tests/long_lived_parse.rs` — the probe (new).
- `src/symbol.rs` — one public `interned_count()`; the table is append-only and leaked, so its size is the leak gauge.
- `docs/adr/0065-...md` — S0 findings section; D8 and the phasing table marked executed, with its two wrong expectations corrected in place.
- `news/2026-09/adr0065-s0-long-lived-parse-probe.md`, `todo/tickets/analysis-parse-mints-process-unique-registry-names.md`, `PLAN.md` (language-server entry under B3).

Verified: `make test` — 36634 tests, `Result: PASS`. `cargo clippy -- -D warnings` and `cargo clippy --test long_lived_parse -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)