### PR TITLE
feat: ADR-0065 S1 — a language server that reports what mutsu makes of a document

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,6 +144,18 @@ jobs:
         env:
           RUST_MIN_STACK: 8388608
 
+      - name: Language server crate (ADR-0065)
+        # The server lives in this repository precisely so a parser change that
+        # breaks it fails here rather than silently in a separate repo
+        # (ADR-0065 D7). `cargo build`/`cargo test` at the root build only the
+        # `mutsu` package (see `default-members` in the root Cargo.toml), so the
+        # crate needs its own step. `--all-targets` lints its tests too: the
+        # positional assertions are the only thing standing between a wrong
+        # range and a consumer that will never report one (D5).
+        run: |
+          cargo clippy -p mutsu-lsp --all-targets -- -D warnings
+          cargo test -p mutsu-lsp
+
       - name: Build (debug, for TAP tests)
         run: cargo build
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -304,6 +304,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48ed47e602652e3410f9387fc0db70fefadcee4d78a78881421aabcab4e26b89"
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
+
+[[package]]
 name = "displaydoc"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -366,6 +381,15 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fluent-uri"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17c704e9dbe1ddd863da1e6ff3567795087b1eb201ce80d8fa81162e1516500d"
+dependencies = [
+ "bitflags 1.3.2",
+]
 
 [[package]]
 name = "fnv"
@@ -657,6 +681,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
+name = "lsp-server"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ee25a31f2e571e426eef2896179450cafc7e2f5be00d8a93b1c2d21c0ff7656"
+dependencies = [
+ "crossbeam-channel",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+]
+
+[[package]]
+name = "lsp-types"
+version = "0.97.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53353550a17c04ac46c585feb189c2db82154fc84b79c7a66c96c2c644f66071"
+dependencies = [
+ "bitflags 1.3.2",
+ "fluent-uri",
+ "serde",
+ "serde_json",
+ "serde_repr",
+]
+
+[[package]]
 name = "mach2"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -712,6 +762,17 @@ dependencies = [
  "unicode-segmentation",
  "unicode_names2",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "mutsu-lsp"
+version = "0.1.0"
+dependencies = [
+ "lsp-server",
+ "lsp-types",
+ "mutsu",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -1067,6 +1128,17 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d3b1629de253c70a0508c3899572da79ca359fdab27c7920ff00406df418906"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,16 @@
+[workspace]
+# The language server (ADR-0065 D7) must track mutsu's parser in lock-step, so it
+# lives in this repository rather than its own — but in its own crate, so its
+# JSON-RPC dependencies stay out of the interpreter's dependency tree, in the
+# style of the existing native/wasm/jit feature split.
+#
+# `default-members` keeps a bare `cargo build` / `cargo test` at the repo root
+# meaning exactly what it meant before this became a workspace: the `mutsu`
+# package. The server is built and tested explicitly (`-p mutsu-lsp`), which is
+# what CI does.
+members = ["crates/mutsu-lsp"]
+default-members = ["."]
+
 [package]
 name = "mutsu"
 version = "0.23.0"

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,11 @@ PROVE_JOBS ?= 4
 # do the same everywhere instead of leaving the default-config runs to chance.
 # Costs ~1s.
 #
+# `cargo test -p mutsu-lsp`: the language server is a separate workspace member
+# (ADR-0065 D7), so the root `cargo test` -- which builds `default-members`, the
+# `mutsu` package alone -- does not reach it. CI runs it as its own step; run it
+# here too so `make test` still means the same thing locally.
+#
 # `prove -e scripts/run-t-test.sh`: routes t/ through the same per-file timeout
 # + flaky-quarantine wrapper the roast suite uses (docs/flaky-test-policy.md).
 #
@@ -30,7 +35,7 @@ PROVE_JOBS ?= 4
 # docs/adr/0014-make-test-runs-tap-on-debug-binary.md.
 test: check-value-wall check-flaky-list
 	@mkdir -p tmp
-	(cargo build && cargo test -- --test-threads=1 && MUTSU_BIN='$(CARGO_TARGET_DIR)/debug/mutsu' MUTSU_T_TIMEOUT=60 prove -e 'scripts/run-t-test.sh' t/) 2>&1 | tee tmp/make-test.log
+	(cargo build && cargo test -- --test-threads=1 && cargo test -p mutsu-lsp && MUTSU_BIN='$(CARGO_TARGET_DIR)/debug/mutsu' MUTSU_T_TIMEOUT=60 prove -e 'scripts/run-t-test.sh' t/) 2>&1 | tee tmp/make-test.log
 
 check-value-wall:
 	scripts/check-value-wall.sh

--- a/PLAN.md
+++ b/PLAN.md
@@ -81,11 +81,13 @@ work; see the CLAUDE.md "mzef package manager and distribution" section. The **R
 
 - [ ] **Language server** — designed in [docs/adr/0065-language-server-targets-ai-agents.md](docs/adr/0065-language-server-targets-ai-agents.md)
       (an AI agent is the primary consumer, so only the methods an agent consumes are implemented,
-      and "does mutsu support this?" is a first-class diagnostic). **S0 (the long-lived-process
-      viability gate) is done and passes** — `tests/long_lived_parse.rs`,
-      `news/2026-09/adr0065-s0-long-lived-parse-probe.md`. Next is **S1: the workspace crate, the
-      server skeleton, and diagnostics from the existing single-error path**; the ADR's phasing table
-      carries S2-S5.
+      and "does mutsu support this?" is a first-class diagnostic). **S0 (viability gate) and S1
+      (server skeleton + diagnostics) are done** — `crates/mutsu-lsp/`, `src/analysis.rs`,
+      [docs/language-server.md](docs/language-server.md). Next is **S2: make mutsu's built-in
+      method/routine names enumerable from one source, so "mutsu does not implement this" becomes a
+      first-class diagnostic (D4)** — the capability unique to mutsu, and it depends on no span
+      work. Then S3 (multiple diagnostics + recovery), S4 (symbols/definition), S5
+      (references/hover).
 - [ ] Debugger.
 - [ ] Native binary output.
 

--- a/crates/mutsu-lsp/Cargo.toml
+++ b/crates/mutsu-lsp/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "mutsu-lsp"
+# Versioned independently of the interpreter. `tag-release.yml` bumps only the
+# root `Cargo.toml`, and the server is not part of the release tarball yet;
+# tying the two together is a decision for whenever it ships.
+version = "0.1.0"
+edition = "2024"
+rust-version = "1.94.0"
+license = "Artistic-2.0"
+description = "Language server for mutsu, targeting AI agents (ADR-0065)"
+
+[[bin]]
+name = "mutsu-lsp"
+path = "src/main.rs"
+
+[dependencies]
+# `lsp-server` + `lsp-types` rather than `tower-lsp`: ADR-0065 D3 drops
+# incremental document sync and every latency-sensitive method, so there is
+# nothing here that needs async. These are rust-analyzer's crates — a
+# synchronous thread-and-channels loop with no runtime — which keeps `tokio` out
+# of this repository entirely.
+lsp-server = "0.10"
+lsp-types = "0.97"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+
+# The interpreter is a dependency purely for its parser, so linking the JIT and
+# the native FFI stack is pure weight — but it is deliberately taken with
+# mutsu's DEFAULT features anyway. A different feature set is a different build
+# of the whole interpreter, which would make CI compile mutsu a third time
+# (it already builds debug and release) for a binary that is merely smaller.
+# Sharing the artifact is worth more than dropping a code generator the server
+# never reaches.
+mutsu = { path = "../.." }

--- a/crates/mutsu-lsp/src/diagnostics.rs
+++ b/crates/mutsu-lsp/src/diagnostics.rs
@@ -1,0 +1,84 @@
+//! Turning `mutsu::analysis::Diagnostic` into `lsp_types::Diagnostic`.
+
+use lsp_types::{Diagnostic, DiagnosticSeverity, NumberOrString};
+use mutsu::analysis::{self, Severity};
+
+use crate::positions::diagnostic_range;
+
+/// The `source` field every diagnostic carries, so a client showing several
+/// language servers can tell whose opinion this is — and, more to the point for
+/// an agent, that the verdict is *mutsu's* rather than rakudo's (ADR-0065 D4).
+pub const SOURCE: &str = "mutsu";
+
+/// Analyse `text` and return what LSP should be told about it.
+pub fn diagnostics_for(text: &str) -> Vec<Diagnostic> {
+    analysis::check(text)
+        .into_iter()
+        .map(|d| to_lsp(text, d))
+        .collect()
+}
+
+fn to_lsp(text: &str, d: analysis::Diagnostic) -> Diagnostic {
+    Diagnostic {
+        range: diagnostic_range(text, d.line, d.column),
+        severity: Some(match d.severity {
+            Severity::Error => DiagnosticSeverity::ERROR,
+            Severity::Warning => DiagnosticSeverity::WARNING,
+        }),
+        code: d.code.map(|c| NumberOrString::String(c.to_string())),
+        source: Some(SOURCE.to_string()),
+        message: d.message,
+        ..Default::default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use lsp_types::Position;
+
+    #[test]
+    fn a_clean_document_produces_no_diagnostics() {
+        assert!(diagnostics_for("my $x = 1;\nsay $x;\n").is_empty());
+    }
+
+    #[test]
+    fn a_parse_error_lands_on_the_offending_line() {
+        let text = "my $x = 1;\n}\nsay $x;\n";
+        let diagnostics = diagnostics_for(text);
+        assert_eq!(diagnostics.len(), 1, "{diagnostics:#?}");
+        let d = &diagnostics[0];
+        assert_eq!(d.severity, Some(DiagnosticSeverity::ERROR));
+        assert_eq!(d.source.as_deref(), Some("mutsu"));
+        assert_eq!(
+            d.range.start,
+            Position {
+                line: 1,
+                character: 0
+            },
+            "the stray brace is the first character of the second line"
+        );
+        assert_eq!(
+            d.code,
+            Some(NumberOrString::String("ParseUnparsed".to_string()))
+        );
+    }
+
+    #[test]
+    fn a_sink_context_warning_is_a_warning_not_an_error() {
+        let text = "my $x = 1;\n$x == 1;\nsay $x;\n";
+        let diagnostics = diagnostics_for(text);
+        assert_eq!(diagnostics.len(), 1, "{diagnostics:#?}");
+        assert_eq!(diagnostics[0].severity, Some(DiagnosticSeverity::WARNING));
+        assert_eq!(diagnostics[0].range.start.line, 1);
+    }
+
+    #[test]
+    fn a_document_that_crashes_the_parser_is_reported_not_propagated() {
+        // Whatever input does this, if any does, must come back as a
+        // diagnostic. The assertion is that `diagnostics_for` returns at all.
+        let _ = diagnostics_for("}}}}}}}}\n");
+        let _ = diagnostics_for("sub \0 { }\n");
+        let _ = diagnostics_for("");
+    }
+}

--- a/crates/mutsu-lsp/src/documents.rs
+++ b/crates/mutsu-lsp/src/documents.rs
@@ -1,0 +1,97 @@
+//! The set of documents the client currently has open.
+//!
+//! Deliberately a plain `Uri -> text` map. ADR-0065 D3 rejects incremental
+//! document sync — a full re-parse costs about 1.3 ms in process, measured by
+//! the S0 probe — so there is no diffing, no rope, and no edit application here.
+//! Every `didChange` replaces the text outright.
+
+use std::collections::HashMap;
+
+use lsp_types::Uri;
+
+#[derive(Debug, Default)]
+pub struct Documents {
+    open: HashMap<Uri, Document>,
+}
+
+#[derive(Debug, Clone)]
+pub struct Document {
+    pub text: String,
+    /// The client's version for this document. Echoed back on
+    /// `publishDiagnostics` so a client can discard a report it has already
+    /// superseded.
+    pub version: i32,
+}
+
+impl Documents {
+    /// Record a newly opened document and hand back the stored copy, so the
+    /// caller analyses exactly what the store holds rather than a parallel one.
+    pub fn open(&mut self, uri: Uri, text: String, version: i32) -> &Document {
+        self.open
+            .entry(uri)
+            .insert_entry(Document { text, version })
+            .into_mut()
+    }
+
+    /// Apply a full-document change. Returns `None` for a document the server
+    /// was never told about, which is a client protocol violation rather than
+    /// something to paper over with an empty document.
+    pub fn replace(&mut self, uri: &Uri, text: String, version: i32) -> Option<&Document> {
+        let doc = self.open.get_mut(uri)?;
+        doc.text = text;
+        doc.version = version;
+        Some(doc)
+    }
+
+    pub fn close(&mut self, uri: &Uri) {
+        self.open.remove(uri);
+    }
+
+    pub fn get(&self, uri: &Uri) -> Option<&Document> {
+        self.open.get(uri)
+    }
+
+    pub fn len(&self) -> usize {
+        self.open.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.open.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::str::FromStr;
+
+    fn uri(s: &str) -> Uri {
+        Uri::from_str(s).expect("valid uri")
+    }
+
+    #[test]
+    fn open_then_replace_then_close() {
+        let mut docs = Documents::default();
+        let u = uri("file:///tmp/a.raku");
+
+        docs.open(u.clone(), "say 1;\n".to_string(), 1);
+        assert_eq!(docs.get(&u).map(|d| d.text.as_str()), Some("say 1;\n"));
+
+        let replaced = docs.replace(&u, "say 2;\n".to_string(), 2).cloned();
+        assert_eq!(replaced.as_ref().map(|d| d.version), Some(2));
+        assert_eq!(docs.get(&u).map(|d| d.text.as_str()), Some("say 2;\n"));
+
+        docs.close(&u);
+        assert!(docs.is_empty());
+    }
+
+    #[test]
+    fn replacing_an_unopened_document_reports_the_miss() {
+        let mut docs = Documents::default();
+        assert!(
+            docs.replace(&uri("file:///tmp/never-opened.raku"), String::new(), 1)
+                .is_none()
+        );
+        assert_eq!(docs.len(), 0);
+    }
+}

--- a/crates/mutsu-lsp/src/lib.rs
+++ b/crates/mutsu-lsp/src/lib.rs
@@ -1,0 +1,15 @@
+//! The mutsu language server (ADR-0065).
+//!
+//! A language server *for mutsu*: it reports what mutsu makes of a document,
+//! and its intended consumer is an AI agent writing Raku that will run on
+//! mutsu. That consumer shapes every decision in here — see
+//! `docs/adr/0065-language-server-targets-ai-agents.md`. The two that show up
+//! most in this code are D3 (only the methods an agent consumes are
+//! implemented, which removes incremental sync, completion and semantic tokens)
+//! and D5 (the message matters more than the range, and the range must be
+//! pinned by tests because an agent will never report that it is wrong).
+
+pub mod diagnostics;
+pub mod documents;
+pub mod positions;
+pub mod server;

--- a/crates/mutsu-lsp/src/main.rs
+++ b/crates/mutsu-lsp/src/main.rs
@@ -1,0 +1,61 @@
+//! `mutsu-lsp` — the mutsu language server (ADR-0065).
+//!
+//! Speaks LSP over stdio, which is what every client and agent harness expects.
+//! Diagnostics go to the client; anything the server has to say about itself
+//! goes to stderr, because stdout is the protocol channel and a stray `println!`
+//! there corrupts the stream.
+
+use std::process::ExitCode;
+
+use lsp_server::Connection;
+
+const USAGE: &str = "\
+mutsu-lsp — the language server for mutsu
+
+USAGE:
+    mutsu-lsp [--stdio]
+
+The server speaks LSP over stdin/stdout. `--stdio` is accepted because most
+clients pass it, and is the only supported transport.
+
+OPTIONS:
+    --stdio        Use stdio as the transport (the default).
+    -h, --help     Print this help.
+    -V, --version  Print the version.
+";
+
+fn main() -> ExitCode {
+    for arg in std::env::args().skip(1) {
+        match arg.as_str() {
+            "--stdio" => {}
+            "-h" | "--help" => {
+                print!("{USAGE}");
+                return ExitCode::SUCCESS;
+            }
+            "-V" | "--version" => {
+                println!("mutsu-lsp {}", env!("CARGO_PKG_VERSION"));
+                return ExitCode::SUCCESS;
+            }
+            other => {
+                eprintln!("mutsu-lsp: unrecognized argument {other:?}\n\n{USAGE}");
+                return ExitCode::FAILURE;
+            }
+        }
+    }
+
+    let (connection, io_threads) = Connection::stdio();
+    let result = mutsu_lsp::server::run(connection);
+    // Join before reporting: the writer thread must finish flushing whatever
+    // the loop queued, including the response to `shutdown`.
+    let joined = io_threads.join();
+
+    if let Err(e) = result {
+        eprintln!("mutsu-lsp: {e}");
+        return ExitCode::FAILURE;
+    }
+    if let Err(e) = joined {
+        eprintln!("mutsu-lsp: transport: {e}");
+        return ExitCode::FAILURE;
+    }
+    ExitCode::SUCCESS
+}

--- a/crates/mutsu-lsp/src/positions.rs
+++ b/crates/mutsu-lsp/src/positions.rs
@@ -1,0 +1,194 @@
+//! Converting mutsu's positions into LSP's.
+//!
+//! This is the module ADR-0065 D5 warns about most. mutsu numbers lines and
+//! columns from 1 and counts columns in **characters**; LSP numbers lines and
+//! characters from 0 and counts characters in **UTF-16 code units**. Every
+//! diagnostic the server emits passes through here, and the intended consumer —
+//! an AI agent — will absorb an off-by-one silently and never complain. So the
+//! conversion is pinned by tests rather than by looking at an editor.
+
+use lsp_types::{Position, Range};
+
+/// The line `line_1based` of `text` and its 0-based index, or the last line
+/// when the position is past the end — a diagnostic must still land somewhere
+/// in the document rather than be dropped.
+fn line_text(text: &str, line_1based: u32) -> (&str, u32) {
+    let wanted = line_1based.max(1) - 1;
+    // `split` always yields at least one item, so `found` is always assigned.
+    let mut found = ("", 0);
+    for (index, line) in text.split('\n').enumerate() {
+        found = (line, index as u32);
+        if index as u32 == wanted {
+            break;
+        }
+    }
+    found
+}
+
+/// UTF-16 code units in the first `chars` characters of `line`.
+fn utf16_offset(line: &str, chars: u32) -> u32 {
+    line.chars()
+        .take(chars as usize)
+        .map(|c| c.len_utf16() as u32)
+        .sum()
+}
+
+/// mutsu's 1-based (line, character column) to LSP's 0-based (line, UTF-16
+/// offset). A column past the end of the line clamps to the line's end.
+pub fn to_position(text: &str, line_1based: u32, column_1based: u32) -> Position {
+    let (line, line_index) = line_text(text, line_1based);
+    Position {
+        line: line_index,
+        character: utf16_offset(line, column_1based.saturating_sub(1)),
+    }
+}
+
+/// The range a diagnostic covers, given the point mutsu reported.
+///
+/// mutsu reports a *point*, not a span: the AST has no positions at all
+/// (ADR-0065 D6) and a parse failure carries only the offset it ejected at. The
+/// choice made here is **from that point to the end of the line**, because for a
+/// parse failure the remainder of the line is precisely the text mutsu could not
+/// make sense of. A warning, which has no column, covers the whole line.
+///
+/// A zero-width range would also be defensible and is what a caret-accurate
+/// server would emit; it is rejected because the consumer is an agent reading a
+/// range out of JSON, not a human watching a squiggle, and "this much of the
+/// line is the problem" carries more information than "the problem starts here".
+pub fn diagnostic_range(text: &str, line_1based: u32, column_1based: Option<u32>) -> Range {
+    let (line, line_index) = line_text(text, line_1based);
+    let line_end = utf16_offset(line, line.chars().count() as u32);
+    // A warning carries no column, and column 1 converts to offset 0 — the
+    // start of the line — which is exactly the "whole line" answer it wants.
+    let start = to_position(text, line_1based, column_1based.unwrap_or(1)).character;
+    // A point at (or past) the end of the line would produce an empty range at
+    // the far right, which renders as nothing and reads as nothing. Fall back to
+    // the whole line, which is the honest answer: the problem is on this line
+    // and mutsu cannot narrow it further.
+    let (start, end) = if start >= line_end {
+        (0, line_end)
+    } else {
+        (start, line_end)
+    };
+    Range {
+        start: Position {
+            line: line_index,
+            character: start,
+        },
+        end: Position {
+            line: line_index,
+            character: end,
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn first_column_of_the_first_line_is_the_origin() {
+        let p = to_position("say 1;\n", 1, 1);
+        assert_eq!(
+            p,
+            Position {
+                line: 0,
+                character: 0
+            }
+        );
+    }
+
+    #[test]
+    fn lines_and_columns_both_lose_one() {
+        let p = to_position("say 1;\nsay 2;\n", 2, 5);
+        assert_eq!(
+            p,
+            Position {
+                line: 1,
+                character: 4
+            }
+        );
+    }
+
+    #[test]
+    fn columns_are_utf16_code_units_not_characters() {
+        // Four astral-plane characters, each two UTF-16 code units. mutsu's
+        // column 5 is the 5th *character*, which LSP calls character 8.
+        let text = "my $x = '🐪🐪🐪🐪';\n";
+        assert_eq!(to_position(text, 1, 5).character, 4, "ASCII prefix is 1:1");
+        let camels = "🐪🐪🐪🐪 rest";
+        assert_eq!(utf16_offset(camels, 4), 8);
+        assert_eq!(utf16_offset(camels, 5), 9, "the space after four camels");
+    }
+
+    #[test]
+    fn a_column_past_the_end_of_the_line_clamps_to_the_end() {
+        let p = to_position("ab\n", 1, 99);
+        assert_eq!(
+            p,
+            Position {
+                line: 0,
+                character: 2
+            }
+        );
+    }
+
+    #[test]
+    fn a_line_past_the_end_of_the_document_clamps_to_the_last_line() {
+        // A trailing newline makes a final empty line, which is where this lands.
+        let p = to_position("ab\n", 99, 1);
+        assert_eq!(p.line, 1);
+    }
+
+    #[test]
+    fn a_range_runs_from_the_point_to_the_end_of_its_line() {
+        let r = diagnostic_range("my $x = 1;\nsay + ;\n", 2, Some(5));
+        assert_eq!(
+            r.start,
+            Position {
+                line: 1,
+                character: 4
+            }
+        );
+        assert_eq!(
+            r.end,
+            Position {
+                line: 1,
+                character: 7
+            }
+        );
+    }
+
+    #[test]
+    fn a_range_without_a_column_covers_the_whole_line() {
+        let r = diagnostic_range("my $x = 1;\n$x == 1;\n", 2, None);
+        assert_eq!(
+            r.start,
+            Position {
+                line: 1,
+                character: 0
+            }
+        );
+        assert_eq!(
+            r.end,
+            Position {
+                line: 1,
+                character: 8
+            }
+        );
+    }
+
+    #[test]
+    fn a_point_at_the_end_of_a_line_falls_back_to_the_whole_line() {
+        let r = diagnostic_range("say 1;\n", 1, Some(7));
+        assert_eq!(r.start.character, 0);
+        assert_eq!(r.end.character, 6);
+    }
+
+    #[test]
+    fn an_empty_line_yields_an_empty_range_rather_than_a_panic() {
+        let r = diagnostic_range("\n\n", 2, Some(1));
+        assert_eq!(r.start, r.end);
+        assert_eq!(r.start.line, 1);
+    }
+}

--- a/crates/mutsu-lsp/src/server.rs
+++ b/crates/mutsu-lsp/src/server.rs
@@ -1,0 +1,159 @@
+//! The protocol loop.
+//!
+//! Synchronous and single-threaded on purpose. ADR-0065 D3 drops every
+//! latency-sensitive method, so there is no keystroke budget to defend and
+//! nothing to overlap; parsing on the loop thread also keeps the parser's
+//! thread-local caches warm, which is the exact configuration the S0 probe
+//! validated for a long-lived process. A parser panic is caught inside
+//! `mutsu::analysis::check` and reported as a diagnostic, so one bad document
+//! cannot take the session down.
+
+use std::error::Error;
+
+use lsp_server::{Connection, ErrorCode, Message, Notification, Response};
+use lsp_types::notification::{
+    DidChangeTextDocument, DidCloseTextDocument, DidOpenTextDocument,
+    Notification as NotificationTrait, PublishDiagnostics,
+};
+use lsp_types::{
+    PositionEncodingKind, PublishDiagnosticsParams, ServerCapabilities, TextDocumentSyncCapability,
+    TextDocumentSyncKind, TextDocumentSyncOptions, Uri,
+};
+
+use crate::diagnostics::diagnostics_for;
+use crate::documents::Documents;
+
+pub type BoxError = Box<dyn Error + Send + Sync>;
+
+/// What this server tells the client it can do.
+///
+/// The list is short by design (ADR-0065 D3): an agent does not type character
+/// by character, so `completion`, `semanticTokens`, `signatureHelp` and
+/// `inlayHint` are absent, and document sync is full-text rather than
+/// incremental.
+pub fn server_capabilities() -> ServerCapabilities {
+    ServerCapabilities {
+        // UTF-16 is the one encoding every client must support. Negotiating
+        // UTF-8 when offered would save a conversion; it would also make the
+        // server's output depend on the client, which is the last thing a
+        // consumer that never notices a bad range needs (D5).
+        position_encoding: Some(PositionEncodingKind::UTF16),
+        text_document_sync: Some(TextDocumentSyncCapability::Options(
+            TextDocumentSyncOptions {
+                open_close: Some(true),
+                change: Some(TextDocumentSyncKind::FULL),
+                ..Default::default()
+            },
+        )),
+        ..Default::default()
+    }
+}
+
+/// Serve one client to completion over `connection`.
+pub fn run(connection: Connection) -> Result<(), BoxError> {
+    let capabilities = serde_json::to_value(server_capabilities())?;
+    let _initialize_params = connection.initialize(capabilities)?;
+
+    let mut documents = Documents::default();
+    for message in &connection.receiver {
+        match message {
+            Message::Request(request) => {
+                if connection.handle_shutdown(&request)? {
+                    return Ok(());
+                }
+                // Nothing else is implemented yet (S1). Answering
+                // MethodNotFound is the honest reply, and better than silence:
+                // a client that waits forever for a response it will never get
+                // is a worse failure than one told plainly it asked for
+                // something this server does not do.
+                connection.sender.send(Message::Response(Response::new_err(
+                    request.id,
+                    ErrorCode::MethodNotFound as i32,
+                    format!("mutsu-lsp does not implement {}", request.method),
+                )))?;
+            }
+            Message::Response(_) => {}
+            Message::Notification(notification) => {
+                // A malformed notification is the client's bug, and killing the
+                // session over it would lose every other open document. Report
+                // it on stderr (where a client shows the server's log) and keep
+                // serving.
+                let method = notification.method.clone();
+                if let Err(e) = handle_notification(&connection, &mut documents, notification) {
+                    eprintln!("mutsu-lsp: ignoring {method}: {e}");
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+fn handle_notification(
+    connection: &Connection,
+    documents: &mut Documents,
+    notification: Notification,
+) -> Result<(), BoxError> {
+    match notification.method.as_str() {
+        DidOpenTextDocument::METHOD => {
+            let params: lsp_types::DidOpenTextDocumentParams =
+                serde_json::from_value(notification.params)?;
+            let opened = params.text_document;
+            let uri = opened.uri;
+            let version = opened.version;
+            let stored = documents.open(uri.clone(), opened.text, version);
+            let diagnostics = diagnostics_for(&stored.text);
+            publish(connection, &uri, diagnostics, Some(version))?;
+        }
+        DidChangeTextDocument::METHOD => {
+            let params: lsp_types::DidChangeTextDocumentParams =
+                serde_json::from_value(notification.params)?;
+            // Sync is full-text (D3), so the last change carries the whole
+            // document. A client that ignores the negotiated sync kind and
+            // sends ranged edits would land here with a partial text; taking
+            // the last entry is what the protocol prescribes for FULL sync.
+            let Some(change) = params.content_changes.into_iter().next_back() else {
+                return Ok(());
+            };
+            let uri = params.text_document.uri;
+            let version = params.text_document.version;
+            // A change to a document the server was never told about is a
+            // client protocol violation; there is nothing sensible to analyse.
+            let Some(stored) = documents.replace(&uri, change.text, version) else {
+                return Ok(());
+            };
+            let diagnostics = diagnostics_for(&stored.text);
+            publish(connection, &uri, diagnostics, Some(version))?;
+        }
+        DidCloseTextDocument::METHOD => {
+            let params: lsp_types::DidCloseTextDocumentParams =
+                serde_json::from_value(notification.params)?;
+            documents.close(&params.text_document.uri);
+            // A closed document's diagnostics must be withdrawn explicitly, by
+            // publishing an empty list; clients keep showing the last report
+            // otherwise.
+            publish(connection, &params.text_document.uri, Vec::new(), None)?;
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+fn publish(
+    connection: &Connection,
+    uri: &Uri,
+    diagnostics: Vec<lsp_types::Diagnostic>,
+    version: Option<i32>,
+) -> Result<(), BoxError> {
+    let params = PublishDiagnosticsParams {
+        uri: uri.clone(),
+        diagnostics,
+        version,
+    };
+    connection
+        .sender
+        .send(Message::Notification(Notification::new(
+            PublishDiagnostics::METHOD.to_string(),
+            params,
+        )))?;
+    Ok(())
+}

--- a/crates/mutsu-lsp/tests/protocol.rs
+++ b/crates/mutsu-lsp/tests/protocol.rs
@@ -1,0 +1,343 @@
+//! End-to-end protocol tests: drive the real loop over an in-memory transport.
+//!
+//! `lsp_server::Connection::memory()` gives a client/server channel pair, so
+//! these exercise the same `server::run` a real editor talks to — the
+//! initialize handshake, document sync, diagnostic publication and shutdown —
+//! without a subprocess.
+//!
+//! These are also where ADR-0065 D5's mandate lands: the intended consumer is an
+//! AI agent, which absorbs an off-by-one range silently and never reports it, so
+//! positions must be pinned by assertions from the first slice.
+
+use std::str::FromStr;
+use std::time::Duration;
+
+use lsp_server::{Connection, Message, Notification, Request, RequestId, Response};
+use lsp_types::{DiagnosticSeverity, Position, PublishDiagnosticsParams, Uri};
+
+const TIMEOUT: Duration = Duration::from_secs(30);
+
+fn uri(s: &str) -> Uri {
+    Uri::from_str(s).expect("valid uri")
+}
+
+/// A client driving `server::run` on a worker thread.
+struct Client {
+    connection: Connection,
+    server: Option<std::thread::JoinHandle<Result<(), String>>>,
+    next_id: i32,
+}
+
+impl Client {
+    /// Connect and complete the initialize handshake.
+    fn start() -> Client {
+        let (server_connection, client_connection) = Connection::memory();
+        let server = std::thread::spawn(move || {
+            mutsu_lsp::server::run(server_connection).map_err(|e| e.to_string())
+        });
+        let mut client = Client {
+            connection: client_connection,
+            server: Some(server),
+            next_id: 0,
+        };
+
+        let id = client.request("initialize", serde_json::json!({ "capabilities": {} }));
+        let result = client
+            .recv_response(id)
+            .response_result
+            .expect("initialize must succeed");
+        let capabilities = &result["capabilities"];
+        assert_eq!(
+            capabilities["positionEncoding"], "utf-16",
+            "the server must announce the encoding its ranges are in"
+        );
+        assert_eq!(
+            capabilities["textDocumentSync"]["change"], 1,
+            "full-document sync (ADR-0065 D3 rejects incremental sync)"
+        );
+        assert!(
+            capabilities.get("completionProvider").is_none(),
+            "completion is out of scope (D3) and must not be advertised"
+        );
+        assert!(
+            capabilities.get("semanticTokensProvider").is_none(),
+            "semantic tokens are out of scope (D3) and must not be advertised"
+        );
+
+        client.notify("initialized", serde_json::json!({}));
+        client
+    }
+
+    fn request(&mut self, method: &str, params: serde_json::Value) -> RequestId {
+        let id = RequestId::from(self.next_id);
+        self.next_id += 1;
+        self.connection
+            .sender
+            .send(Message::Request(Request {
+                id: id.clone(),
+                method: method.to_string(),
+                params,
+            }))
+            .expect("send request");
+        id
+    }
+
+    fn notify(&self, method: &str, params: serde_json::Value) {
+        self.connection
+            .sender
+            .send(Message::Notification(Notification {
+                method: method.to_string(),
+                params,
+            }))
+            .expect("send notification");
+    }
+
+    fn recv(&self) -> Message {
+        self.connection
+            .receiver
+            .recv_timeout(TIMEOUT)
+            .expect("server must answer")
+    }
+
+    fn recv_response(&self, expected: RequestId) -> Response {
+        match self.recv() {
+            Message::Response(r) => {
+                assert_eq!(r.id, expected);
+                r
+            }
+            other => panic!("expected a response, got {other:?}"),
+        }
+    }
+
+    /// Read the next `textDocument/publishDiagnostics` notification.
+    fn recv_diagnostics(&self) -> PublishDiagnosticsParams {
+        match self.recv() {
+            Message::Notification(n) => {
+                assert_eq!(n.method, "textDocument/publishDiagnostics");
+                serde_json::from_value(n.params).expect("diagnostics params")
+            }
+            other => panic!("expected publishDiagnostics, got {other:?}"),
+        }
+    }
+
+    fn open(&self, path: &str, text: &str, version: i32) -> PublishDiagnosticsParams {
+        self.notify(
+            "textDocument/didOpen",
+            serde_json::json!({
+                "textDocument": {
+                    "uri": path,
+                    "languageId": "raku",
+                    "version": version,
+                    "text": text,
+                }
+            }),
+        );
+        self.recv_diagnostics()
+    }
+
+    fn change(&self, path: &str, text: &str, version: i32) -> PublishDiagnosticsParams {
+        self.notify(
+            "textDocument/didChange",
+            serde_json::json!({
+                "textDocument": { "uri": path, "version": version },
+                "contentChanges": [{ "text": text }],
+            }),
+        );
+        self.recv_diagnostics()
+    }
+
+    fn close(&self, path: &str) -> PublishDiagnosticsParams {
+        self.notify(
+            "textDocument/didClose",
+            serde_json::json!({ "textDocument": { "uri": path } }),
+        );
+        self.recv_diagnostics()
+    }
+
+    fn shutdown(mut self) {
+        let id = self.request("shutdown", serde_json::Value::Null);
+        self.recv_response(id)
+            .response_result
+            .expect("shutdown must succeed");
+        self.notify("exit", serde_json::Value::Null);
+        let server = self.server.take().expect("server thread");
+        server
+            .join()
+            .expect("the server thread must not panic")
+            .expect("the server must exit cleanly");
+    }
+}
+
+impl Drop for Client {
+    fn drop(&mut self) {
+        // A test that fails mid-way must not wedge the harness waiting on a
+        // server thread that is still blocked on `recv`.
+        if let Some(server) = self.server.take() {
+            drop(std::mem::replace(
+                &mut self.connection,
+                Connection::memory().0,
+            ));
+            let _ = server.join();
+        }
+    }
+}
+
+#[test]
+fn opening_a_broken_document_reports_where_it_broke() {
+    let client = Client::start();
+    let path = "file:///tmp/broken.raku";
+
+    let published = client.open(path, "my $x = 1;\n}\nsay $x;\n", 1);
+    assert_eq!(published.uri, uri(path));
+    assert_eq!(published.version, Some(1));
+    assert_eq!(
+        published.diagnostics.len(),
+        1,
+        "{:#?}",
+        published.diagnostics
+    );
+
+    let d = &published.diagnostics[0];
+    assert_eq!(d.severity, Some(DiagnosticSeverity::ERROR));
+    assert_eq!(d.source.as_deref(), Some("mutsu"));
+    assert_eq!(
+        d.range.start,
+        Position {
+            line: 1,
+            character: 0
+        },
+        "the stray brace opens line 2 (0-based line 1)"
+    );
+    assert!(
+        !d.message.is_empty(),
+        "an agent acts on the message, so it must never be blank"
+    );
+
+    client.shutdown();
+}
+
+#[test]
+fn fixing_a_document_withdraws_the_diagnostic() {
+    let client = Client::start();
+    let path = "file:///tmp/fixed.raku";
+
+    let broken = client.open(path, "my $x = 1;\n}\n", 1);
+    assert_eq!(broken.diagnostics.len(), 1);
+
+    let fixed = client.change(path, "my $x = 1;\nsay $x;\n", 2);
+    assert!(
+        fixed.diagnostics.is_empty(),
+        "a clean document must publish an empty list, not silence: {:#?}",
+        fixed.diagnostics
+    );
+    assert_eq!(fixed.version, Some(2));
+
+    client.shutdown();
+}
+
+#[test]
+fn closing_a_document_withdraws_its_diagnostics() {
+    let client = Client::start();
+    let path = "file:///tmp/closed.raku";
+
+    assert_eq!(client.open(path, "}\n", 1).diagnostics.len(), 1);
+    let cleared = client.close(path);
+    assert!(cleared.diagnostics.is_empty());
+    assert_eq!(cleared.version, None);
+
+    client.shutdown();
+}
+
+#[test]
+fn diagnostic_columns_are_utf16_offsets() {
+    let client = Client::start();
+    let path = "file:///tmp/unicode.raku";
+
+    // Four astral-plane characters ahead of the error: 4 characters, but 8
+    // UTF-16 code units. A server that reported characters would say 20 here.
+    let text = "my $s = '🐪🐪🐪🐪';\nmy $t = '🐪🐪🐪🐪' }\n";
+    let published = client.open(path, text, 1);
+    assert_eq!(
+        published.diagnostics.len(),
+        1,
+        "{:#?}",
+        published.diagnostics
+    );
+
+    // mutsu reports the stray `}` at line 2, column 16 — the 16th *character*
+    // of `my $t = '<4 camels>' }`. In UTF-16 that is offset 19: nine BMP
+    // characters (`my $t = '`), then four astral camels at two code units each
+    // (8), then `' ` (2). A server that passed the character column straight
+    // through would say 15, and its consumer would never notice.
+    let d = &published.diagnostics[0];
+    assert_eq!(
+        d.range.start,
+        Position {
+            line: 1,
+            character: 19
+        },
+        "message was: {}",
+        d.message
+    );
+    let line = text.lines().nth(1).expect("second line");
+    let utf16_len: u32 = line.chars().map(|c| c.len_utf16() as u32).sum();
+    assert_eq!(
+        d.range.end.character, utf16_len,
+        "the range runs to end of line"
+    );
+    assert!(
+        (line.chars().count() as u32) < d.range.start.character,
+        "the whole point: the UTF-16 offset exceeds what a character count would give"
+    );
+
+    client.shutdown();
+}
+
+#[test]
+fn an_unimplemented_request_is_answered_rather_than_ignored() {
+    let mut client = Client::start();
+    client.open("file:///tmp/hover.raku", "say 1;\n", 1);
+
+    let id = client.request(
+        "textDocument/hover",
+        serde_json::json!({
+            "textDocument": { "uri": "file:///tmp/hover.raku" },
+            "position": { "line": 0, "character": 0 },
+        }),
+    );
+    let error = client
+        .recv_response(id)
+        .response_result
+        .expect_err("an unimplemented method must error");
+    assert_eq!(error.code, lsp_server::ErrorCode::MethodNotFound as i32);
+    assert!(error.message.contains("textDocument/hover"), "{error:?}");
+
+    client.shutdown();
+}
+
+#[test]
+fn the_session_survives_a_document_that_breaks_the_parser() {
+    let client = Client::start();
+    let path = "file:///tmp/hostile.raku";
+
+    // Whatever these do to the parser, the server must still be answering
+    // afterwards: a resident process cannot die on one bad document.
+    let _ = client.open(path, "}}}}}}}}}}\n", 1);
+    for (version, text) in [
+        (2, "sub { { { { {\n"),
+        (3, "my $x = '\n"),
+        (4, "\u{0}\u{1}\u{2}\n"),
+        (5, ""),
+    ] {
+        let _ = client.change(path, text, version);
+    }
+    // The server is still there and still analysing.
+    let published = client.change(path, "my $x = 1;\nsay $x;\n", 6);
+    assert!(
+        published.diagnostics.is_empty(),
+        "{:#?}",
+        published.diagnostics
+    );
+
+    client.shutdown();
+}

--- a/docs/adr/0065-language-server-targets-ai-agents.md
+++ b/docs/adr/0065-language-server-targets-ai-agents.md
@@ -1,6 +1,7 @@
 # ADR-0065: mutsu's language server targets AI agents, and is scoped to the protocol surface an agent actually consumes
 
-- **Status**: Proposed (2026-09-02). Design only — no implementation has started.
+- **Status**: Accepted (2026-09-02); S0 and S1 shipped 2026-09-03. See the phasing table
+  and the S0/S1 findings sections below for what has actually been built.
 - **Context**: The user asked for a language server built on mutsu, *for mutsu* — a tool
   for people (and agents) writing Raku that is meant to run on mutsu. This is a deliberate
   **new capability** direction with zero roast payoff, in the same category as ADR-0011
@@ -287,6 +288,56 @@ snapshot/restore discipline in `parse_program_partial` holds under repetition. S
 `Stmt::SetLine` is the only positional information mutsu has (D6), this is the load-bearing
 property for every diagnostic the server will emit.
 
+## S1 findings (2026-09-03)
+
+Shipped: `crates/mutsu-lsp` (the server), `src/analysis.rs` (mutsu's non-executing
+frontend), `docs/language-server.md` (usage and layout). The repository is now a Cargo
+workspace. Four things are worth recording because they either settled a "not decided
+here" item or came out differently from the design.
+
+### 1. `lsp-server` + `lsp-types`, not `tower-lsp` — D3 removed the need for async
+
+D7 anticipated keeping `tower-lsp`/`tokio` out of mutsu's dependency tree by putting the
+server in its own crate. With D3 in hand that turns out to be unnecessary: dropping every
+latency-sensitive method leaves nothing to overlap, so the server is a synchronous
+thread-and-channels loop over rust-analyzer's `lsp-server`, and **no async runtime enters
+this repository at all**. Parsing runs on the loop thread, which also keeps the parser's
+thread-local caches warm — the exact configuration S0 validated.
+
+### 2. Warnings were free, and they carry their own line
+
+The design assumed S1 would ship the single parse error and that everything else waited for
+S3. In fact `PARSE_WARNINGS` already collects the parser's warnings with a
+`"\n    at FILE:LINE"` suffix baked into the message text (it has to survive the
+precompilation cache, which persists text only). Splitting that suffix back off recovers a
+line number, so sink-context warnings and VCS conflict markers ship in S1 at line
+granularity. S3 remains about *multiple errors* and recovery, which is the hard part.
+
+### 3. A parser panic is a diagnostic, not an abort
+
+Not in the design, and load-bearing for a resident process: mutsu's parser is not
+panic-free, and a server must outlive a document that trips it. `analysis::check` catches
+the unwind and reports it as "mutsu's parser crashed on this document ... this is a bug in
+mutsu", which is D4's signal in its bluntest form — an agent must not go looking for a
+mistake in its own code. Pinned by a protocol test that feeds a sequence of hostile
+documents and then asserts the session is still analysing.
+
+### 4. The workspace split cost less than expected
+
+`mutsu` stays the root package with `crates/mutsu-lsp` as a member and
+`default-members = ["."]`, so a bare `cargo build` / `cargo test` at the root means exactly
+what it meant before, and every existing CI, release, container and wasm invocation is
+untouched. The server needs one CI step of its own (`cargo clippy -p mutsu-lsp
+--all-targets` + `cargo test -p mutsu-lsp`), mirrored in `make test`.
+
+It takes mutsu with **default** features, JIT included. A leaner feature set is a different
+build of the whole interpreter, which would make CI compile mutsu a third time (it already
+builds debug and release) for a binary that is merely smaller.
+
+Two items from "Not decided here" are now decided in passing: `mutsu-lsp` is versioned
+independently of the interpreter (`tag-release.yml` bumps only the root `Cargo.toml`) and
+is **not** in the release tarball yet; transport is stdio only.
+
 ## Rejected alternatives
 
 - **A lossless CST / red-green tree (rust-analyzer, rowan).** The correct architecture for
@@ -312,7 +363,7 @@ property for every diagnostic the server will emit.
 | Slice | Content | Depends on |
 | --- | --- | --- |
 | **S0** | Long-lived-process viability probe (D8) — **done 2026-09-03**, `tests/long_lived_parse.rs` | — |
-| **S1** | Server skeleton, full-document reparse, diagnostics from the existing single-error path | S0 |
+| **S1** | Server skeleton, full-document reparse, diagnostics from the existing single-error path — **done 2026-09-03**, `crates/mutsu-lsp/`, `src/analysis.rs`, `docs/language-server.md` | S0 |
 | **S2** | Enumerable built-in name tables → "mutsu does not support this" diagnostics (D4) | S1 |
 | **S3** | Multiple diagnostics per document + error recovery (give `parse_program_partial` positions and errors) | S1 |
 | **S4** | `documentSymbol` / `workspaceSymbol` / `definition` at line granularity | S1 |

--- a/docs/language-server.md
+++ b/docs/language-server.md
@@ -1,0 +1,129 @@
+# The mutsu language server
+
+`mutsu-lsp` is a language server **for mutsu**: it reports what *mutsu* makes of
+a Raku document. Its design, and the reasoning behind every scoping decision
+below, is [ADR-0065](adr/0065-language-server-targets-ai-agents.md). The short
+version: the primary consumer is an AI agent writing Raku that is meant to run
+on mutsu, and that consumer decides which parts of the protocol are worth
+implementing.
+
+## Building and running
+
+```
+cargo build -p mutsu-lsp                  # debug
+cargo build --release -p mutsu-lsp        # release
+target/debug/mutsu-lsp --stdio
+```
+
+The repository is a Cargo workspace with two members: `mutsu` (the root package)
+and `crates/mutsu-lsp`. A bare `cargo build` / `cargo test` at the root still
+means the `mutsu` package alone — `default-members` in the root `Cargo.toml`
+keeps that unchanged — so the server is built and tested explicitly with `-p
+mutsu-lsp`, which is what CI's "Language server crate" step does.
+
+The transport is stdio; `--stdio` is accepted (most clients pass it) and is the
+only transport. Everything the server has to say about itself goes to stderr,
+because stdout is the protocol channel.
+
+The server is not part of the release tarball yet, and is versioned
+independently of the interpreter (`tag-release.yml` bumps only the root
+`Cargo.toml`). Shipping it is a decision for when it is worth shipping.
+
+## What it does
+
+| Method | Status |
+| --- | --- |
+| `initialize` / `shutdown` / `exit` | Yes |
+| `textDocument/didOpen`, `didChange`, `didClose` | Yes, **full-document sync** |
+| `textDocument/publishDiagnostics` | Yes — parse errors and parse warnings |
+| `documentSymbol`, `workspaceSymbol`, `definition`, `references`, `hover` | Planned (ADR-0065 S4/S5) |
+| `completion`, `semanticTokens`, `signatureHelp`, `inlayHint` | **Out of scope** (D3) |
+| Incremental document sync | **Out of scope** (D3) |
+
+The exclusions are structural, not cosmetic. Dropping `semanticTokens` removes
+the need to write a lexer, which mutsu does not have. Dropping `completion`
+removes caret-position scope resolution, the hardest form of positional
+analysis. Dropping incremental sync deletes the document-diffing subsystem
+outright — a full re-parse costs about 1.3 ms in process, measured by the S0
+probe (`tests/long_lived_parse.rs`).
+
+A request for a method the server does not implement is answered with
+`MethodNotFound` rather than ignored: a client waiting forever for a response it
+will never get is a worse failure than one told plainly.
+
+## What the diagnostics mean
+
+Diagnostics carry `source: "mutsu"`, because the whole point is that this is
+*mutsu's* verdict, not rakudo's. A construct rakudo accepts and mutsu does not
+is a true positive here — an agent writing code for mutsu has no other way to
+learn mutsu's coverage short of running it (D4).
+
+Today the server reports:
+
+- **One parse error per document.** mutsu's parser stops at the first failure
+  and discards the partial result. Multiple diagnostics need
+  `parse_program_partial` to grow positions and errors first (S3).
+- **Parse warnings**, at line granularity — sink-context warnings, VCS conflict
+  markers, and the rest of what the parser collects while reading a unit.
+- **A parser crash, as a diagnostic**, phrased as a mutsu bug rather than a
+  syntax error. `mutsu::analysis::check` catches the panic; a resident server
+  cannot die on one bad document.
+
+A parse failure inside a `use`d module is anchored at line 1 of the *open*
+document and names the other file in its message. Reporting that module's
+line and column against this document would point at an unrelated line, which
+under D5 is worse than pointing at nothing.
+
+## Nothing is executed
+
+`mutsu::analysis::check` parses and throws the AST away. It never compiles and
+never runs, so opening a document with `unlink "/etc/passwd"` in it is safe.
+Parsing a `use` *does* read the imported module's source off disk — Raku's
+grammar is not context-free with respect to the imported symbol table, so the
+exported names have to be harvested to parse the importer correctly — but it
+does not run that module either.
+
+## Positions
+
+LSP positions are 0-based with **UTF-16 code unit** columns; mutsu's are 1-based
+with character columns. Every diagnostic passes through
+`crates/mutsu-lsp/src/positions.rs`, and that conversion is pinned by tests
+rather than checked by looking at an editor.
+
+That is not fussiness. An agent tolerates a range that is off by a few
+characters — it re-reads the line — and therefore never reports one. A human
+would notice the squiggle in the wrong place; the intended consumer will absorb
+it silently while the quality of the server rots unobserved. So positional
+assertions are mandatory from the first slice (D5), including at least one
+document with astral-plane characters, where a character count and a UTF-16
+offset disagree.
+
+mutsu reports a *point*, not a span: the AST carries no positions at all (D6),
+and a parse failure carries only the offset it ejected at. A diagnostic's range
+therefore runs from that point to the end of its line — for a parse failure the
+remainder of the line is precisely what mutsu could not make sense of. A warning,
+which has no column, covers the whole line.
+
+## Layout
+
+| File | What lives there |
+| --- | --- |
+| `src/analysis.rs` (in `mutsu`) | The non-executing frontend: `check(source) -> Vec<Diagnostic>`. The only entry point in the interpreter that parses a document and keeps nothing but what it learned. |
+| `crates/mutsu-lsp/src/server.rs` | The protocol loop: capabilities, document sync, diagnostic publication, shutdown. |
+| `crates/mutsu-lsp/src/positions.rs` | mutsu positions to LSP positions. |
+| `crates/mutsu-lsp/src/diagnostics.rs` | `mutsu::analysis::Diagnostic` to `lsp_types::Diagnostic`. |
+| `crates/mutsu-lsp/src/documents.rs` | The open-document map. No rope, no diffing — sync is full-text. |
+| `crates/mutsu-lsp/tests/protocol.rs` | End-to-end tests over `lsp_server::Connection::memory()`, driving the real loop. |
+
+The loop is synchronous and single-threaded on purpose: D3 leaves nothing
+latency-sensitive to overlap, and parsing on the loop thread keeps the parser's
+thread-local caches warm — the exact configuration the S0 probe validated for a
+long-lived process. `lsp-server` + `lsp-types` (rust-analyzer's crates) rather
+than `tower-lsp`, so no async runtime enters this repository at all.
+
+## Why it lives in this repository
+
+The server has to track mutsu's parser in lock-step. In a separate repository it
+would break silently on a parser change; in-tree, CI catches it (D7). Editor
+extensions are the opposite case — different language, different registry,
+different cadence — and belong in their own repository.

--- a/news/2026-09/adr0065-s1-language-server-skeleton.md
+++ b/news/2026-09/adr0065-s1-language-server-skeleton.md
@@ -1,0 +1,92 @@
+# mutsu has a language server, and it tells you what *mutsu* thinks of your code
+
+ADR-0065 S1 has landed: `mutsu-lsp` speaks LSP over stdio, holds documents open,
+re-parses them in full on every change, and publishes diagnostics. The
+repository is now a Cargo workspace, and mutsu itself has grown a public
+non-executing analysis frontend.
+
+The point is not that mutsu has an editor integration. It is that a diagnostic
+saying "mutsu cannot do this" is now something you can get without running the
+code. An agent writing Raku targeted at mutsu previously had exactly one way to
+discover mutsu's coverage: execute and see what broke.
+
+## `mutsu::analysis::check` — the one entry point that parses and keeps nothing
+
+Every other place in the crate that parses Raku does so on the way to running
+it. `src/analysis.rs` parses a document, throws the AST away and reports what it
+learned: parse errors with line and column, parse warnings at line granularity,
+and — importantly — a parser *crash*, phrased as a mutsu bug rather than as a
+syntax error in your code. A resident server outlives any one document, so a
+panic on malformed input has to become a diagnostic, not an abort.
+
+Nothing executes. Opening a file with `unlink "/etc/passwd"` in it is safe.
+Parsing a `use` does read the imported module's source off disk — Raku's grammar
+is not context-free with respect to the imported symbol table, so the exported
+names have to be harvested before the importer can be parsed correctly — but it
+does not run that module either.
+
+Warnings turned out to be free: the parser already collects them, tagged with a
+`"\n    at FILE:LINE"` suffix baked into the message text (it has to survive the
+precompilation cache, which persists text only). Splitting that suffix back off
+recovers the line, so sink-context warnings and VCS conflict markers reach the
+editor already.
+
+## The scope is set by who reads it
+
+ADR-0065 D3 implements only the methods an AI agent consumes, and the exclusions
+are structural rather than cosmetic. Dropping `semanticTokens` removes the need
+to write a lexer, which mutsu does not have. Dropping `completion` removes
+caret-position scope resolution, the hardest form of positional analysis.
+Dropping incremental document sync deletes the document-diffing subsystem
+outright — the S0 probe measured a full in-process re-parse at about 1.3 ms, so
+there is nothing to optimize.
+
+What is left is small enough to be synchronous and single-threaded.
+`lsp-server` + `lsp-types` — rust-analyzer's crates, a thread-and-channels loop
+with no runtime — rather than `tower-lsp`, so no async runtime enters this
+repository at all. Parsing happens on the loop thread, which also keeps the
+parser's thread-local caches warm: exactly the configuration S0 validated.
+
+A request for an unimplemented method gets `MethodNotFound` rather than silence.
+A client waiting forever for a response it will never receive is a worse failure
+than one told plainly.
+
+## Positions are pinned by tests, because the consumer will never complain
+
+LSP counts columns in UTF-16 code units from 0; mutsu counts characters from 1.
+Every diagnostic passes through one conversion, and that conversion is asserted
+in tests rather than eyeballed in an editor — including a document with
+astral-plane characters, where the two disagree. mutsu reports the stray `}` in
+`my $t = '🐪🐪🐪🐪' }` at character column 16; LSP has to be told 19.
+
+This is D5's hazard made concrete. A human notices a squiggle in the wrong
+place. An agent re-reads the line, absorbs the imprecision, and never reports
+it — so the server's quality can rot completely unobserved. Positional
+assertions are therefore mandatory from the first slice, not a later polish.
+
+Since mutsu reports a *point* rather than a span (the AST has no positions at
+all, D6), a diagnostic's range runs from that point to the end of its line: for a
+parse failure the remainder of the line is precisely what mutsu could not make
+sense of. A warning, which carries no column, covers the whole line.
+
+## The repository is a workspace now
+
+`mutsu` stays the root package and `crates/mutsu-lsp` joins it as a member, with
+`default-members = ["."]` so a bare `cargo build` or `cargo test` at the root
+means exactly what it meant before. The server is built and tested explicitly
+(`-p mutsu-lsp`), which CI does as its own step and `make test` now mirrors.
+
+It lives in-tree because it has to track mutsu's parser in lock-step: in a
+separate repository it would break silently on a parser change (D7). It takes
+mutsu with default features, JIT included — a leaner feature set would be a
+different build of the whole interpreter, making CI compile mutsu a third time
+for a binary that is merely smaller.
+
+The end-to-end tests drive the real loop over `lsp_server::Connection::memory()`,
+so the initialize handshake, document sync, diagnostic withdrawal on close, and
+shutdown are all exercised as a client sees them — including a document sequence
+designed to break the parser, after which the server must still be answering.
+
+Usage and layout: `docs/language-server.md`. Next up is S2, the capability that
+is unique to mutsu: making the built-in name tables enumerable so "mutsu does not
+implement this method" becomes a first-class diagnostic (D4).

--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -1,0 +1,274 @@
+//! A non-executing analysis frontend over mutsu's parser (ADR-0065).
+//!
+//! Everything else that parses Raku in this crate does so on the way to running
+//! it. This module is the one entry point that parses a document and throws the
+//! AST away, reporting only what it learned — which is what a language server
+//! needs, and what neither `Interpreter` (it runs the code) nor `dump_ast` (it
+//! returns a formatted AST or one error) provides.
+//!
+//! Three properties are load-bearing, in the order ADR-0065 ranks them:
+//!
+//! - **Nothing executes.** `check` parses; it never compiles or runs. A
+//!   document with `unlink "/etc/passwd"` in it is safe to open in an editor.
+//!   (Parsing a `use` *does* read the imported module's source off disk, to
+//!   harvest its exported names — Raku's grammar is not context-free with
+//!   respect to the imported symbol table — but it does not run it.)
+//! - **The message matters more than the range** (D5). An agent tolerates a
+//!   range that is off by a few characters; it does not tolerate a wrong
+//!   message, because it believes it. So the text comes through verbatim from
+//!   the parser's own diagnosis, hint included.
+//! - **It cannot take the process down.** A resident server outlives any one
+//!   document, so a parser panic on malformed input has to become a diagnostic
+//!   rather than an abort. mutsu is under active development and its parser is
+//!   not panic-free; `check` catches it.
+
+use crate::value::{RuntimeError, RuntimeErrorCode};
+
+/// How much a [`Diagnostic`] should be believed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Severity {
+    /// The document does not parse, or mutsu cannot handle it.
+    Error,
+    /// The document parses, and mutsu has something to say about it.
+    Warning,
+}
+
+/// One thing mutsu has to report about a document.
+///
+/// Positions are **1-based line and column**, matching the parser's own
+/// numbering and the way errors are rendered on the CLI. A consumer that needs
+/// LSP's 0-based `Position` converts at the boundary.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Diagnostic {
+    pub severity: Severity,
+    /// The parser's own message, with its hint appended when it has one.
+    pub message: String,
+    /// 1-based line. Falls back to 1 when the parser could not place the
+    /// problem — never omitted, because a diagnostic with no anchor is one a
+    /// consumer cannot act on.
+    pub line: u32,
+    /// 1-based column, or `None` when only the line is known. mutsu's AST has
+    /// no positions at all (ADR-0065 D6); columns exist only on parse failures,
+    /// which carry their own offset.
+    pub column: Option<u32>,
+    /// The parser's classification, where it has one: `ParseUnparsed`,
+    /// `ParseExpected`, `ParseGeneric`. Stable enough to key a client-side
+    /// rule on, unlike the message text.
+    pub code: Option<&'static str>,
+    /// Set when the problem is really in a *different* file than the one being
+    /// checked — a parse failure inside a `use`d module. The position then
+    /// refers to that file, not to this document, and the diagnostic is
+    /// anchored at line 1 of this one.
+    pub in_other_file: Option<String>,
+}
+
+impl Diagnostic {
+    fn error(message: String) -> Self {
+        Diagnostic {
+            severity: Severity::Error,
+            message,
+            line: 1,
+            column: None,
+            code: None,
+            in_other_file: None,
+        }
+    }
+}
+
+/// Deliberately exhaustive: a new `RuntimeErrorCode` variant should fail to
+/// compile here rather than silently reach a consumer as `None`.
+fn code_name(code: RuntimeErrorCode) -> &'static str {
+    match code {
+        RuntimeErrorCode::ParseUnparsed => "ParseUnparsed",
+        RuntimeErrorCode::ParseExpected => "ParseExpected",
+        RuntimeErrorCode::ParseGeneric => "ParseGeneric",
+    }
+}
+
+/// Turn a parse failure into the single diagnostic it is.
+fn diagnostic_from_parse_error(err: &RuntimeError) -> Diagnostic {
+    let mut message = err.message.clone();
+    if let Some(hint) = err.hint() {
+        message.push_str("\nhint: ");
+        message.push_str(hint);
+    }
+
+    // A failure raised while parsing a `use`d module carries that module's
+    // file, and its line/column are relative to *that* file. Reporting those
+    // coordinates against the open document would point at an unrelated line,
+    // which under D5 is worse than pointing at nothing: an agent would edit the
+    // wrong place. Anchor at line 1 and say which file it actually is.
+    if let Some(other) = err.source_file() {
+        let where_ = match (err.line(), err.column()) {
+            (Some(l), Some(c)) => format!("{other}:{l}:{c}"),
+            (Some(l), None) => format!("{other}:{l}"),
+            _ => other.to_string(),
+        };
+        return Diagnostic {
+            severity: Severity::Error,
+            message: format!("in an imported file ({where_}): {message}"),
+            line: 1,
+            column: None,
+            code: err.code().map(code_name),
+            in_other_file: Some(other.to_string()),
+        };
+    }
+
+    Diagnostic {
+        severity: Severity::Error,
+        message,
+        line: err.line().unwrap_or(1) as u32,
+        column: err.column().map(|c| c as u32),
+        code: err.code().map(code_name),
+        in_other_file: None,
+    }
+}
+
+/// Split the `"\n    at FILE:LINE"` suffix `add_parse_warning` bakes into every
+/// parse warning back into (message, line).
+///
+/// The suffix is a rendering detail of the CLI's warning output that happens to
+/// be the only positional information a warning carries — it is not kept as a
+/// separate field, because it has to survive the precompilation cache, which
+/// persists message text only. Parsing it back is therefore the supported way
+/// to recover the line, not a hack around a missing accessor.
+fn split_warning_location(warning: &str) -> (String, Option<u32>, Option<String>) {
+    let Some((message, location)) = warning.rsplit_once("\n    at ") else {
+        return (warning.to_string(), None, None);
+    };
+    let Some((file, line)) = location.rsplit_once(':') else {
+        return (warning.to_string(), None, None);
+    };
+    let Ok(line) = line.trim().parse::<u32>() else {
+        return (warning.to_string(), None, None);
+    };
+    let file = (file != "-e").then(|| file.to_string());
+    (message.to_string(), Some(line), file)
+}
+
+/// Parse `source` and report everything mutsu has to say about it, without
+/// running any of it.
+///
+/// Returns an empty vector for a document that parses cleanly and raises no
+/// warnings. A document that fails to parse yields exactly one error: mutsu's
+/// parser stops at the first failure and discards the partial result, so
+/// multiple diagnostics per document need `parse_program_partial` to grow
+/// positions and errors first (ADR-0065 S3).
+pub fn check(source: &str) -> Vec<Diagnostic> {
+    // The parser is not panic-free, and a language server must outlive a
+    // document that trips it. `AssertUnwindSafe` is the honest annotation here:
+    // the parser's state is thread-local and every entry point resets what it
+    // owns (`parse_program` clears the warning buffers, resets the memo
+    // generation and the user-operator table, and re-points `ORIGINAL_SOURCE`),
+    // so a caught panic leaves the *next* parse well-defined even though it may
+    // leave this one's intermediate state torn.
+    //
+    // `parse_source` rather than `parse_compilation_unit`: the document is
+    // parsed under whatever `use vX` it declares, but that version is restored
+    // afterwards instead of being left behind. In a one-shot process the
+    // difference is invisible; in a resident one it is the difference between
+    // documents being analysed independently and a `use v6.e.PREVIEW` in the
+    // first file silently changing how every later file is read.
+    let parsed = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        crate::parse_dispatch::parse_source(source)
+    }));
+
+    let mut diagnostics = Vec::new();
+    match parsed {
+        Ok(Ok(_stmts)) => {}
+        Ok(Err(err)) => diagnostics.push(diagnostic_from_parse_error(&err)),
+        Err(payload) => {
+            // "mutsu cannot handle this" is the single most valuable thing this
+            // server reports (D4), and a panic is its bluntest form. Say so
+            // plainly rather than dressing it up as a syntax error, so a
+            // consumer does not go looking for a mistake in its own code.
+            let detail = payload
+                .downcast_ref::<&str>()
+                .map(|s| (*s).to_string())
+                .or_else(|| payload.downcast_ref::<String>().cloned())
+                .unwrap_or_else(|| "unknown panic".to_string());
+            diagnostics.push(Diagnostic::error(format!(
+                "mutsu's parser crashed on this document: {detail}. This is a bug in mutsu, \
+                 not necessarily in your code."
+            )));
+            return diagnostics;
+        }
+    }
+
+    // Warnings are collected during the parse and drained here. Draining is
+    // mandatory even when the parse failed: the buffer is thread-local and
+    // process-lifetime, so anything left behind would resurface against an
+    // unrelated document later in the same session.
+    for (_file, warning) in crate::parser::take_parse_warnings() {
+        let (message, line, other_file) = split_warning_location(&warning);
+        diagnostics.push(Diagnostic {
+            severity: Severity::Warning,
+            message,
+            line: line.unwrap_or(1),
+            column: None,
+            code: None,
+            in_other_file: other_file,
+        });
+    }
+
+    diagnostics
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_clean_document_reports_nothing() {
+        assert_eq!(check("my $x = 1;\nsay $x;\n"), Vec::new());
+    }
+
+    #[test]
+    fn a_parse_failure_reports_one_error_with_a_position() {
+        let diagnostics = check("my $x = 1;\n}\n");
+        assert_eq!(diagnostics.len(), 1, "{diagnostics:#?}");
+        let d = &diagnostics[0];
+        assert_eq!(d.severity, Severity::Error);
+        assert_eq!(d.line, 2, "the stray brace is on line 2");
+        assert_eq!(d.column, Some(1));
+        assert_eq!(d.code, Some("ParseUnparsed"));
+    }
+
+    #[test]
+    fn nothing_executes() {
+        // If `check` ran the document, this would print. It parses fine, so a
+        // clean report is also the proof that parsing is all that happened.
+        assert_eq!(check("say 'THIS MUST NOT BE PRINTED';\n"), Vec::new());
+    }
+
+    #[test]
+    fn a_warning_keeps_its_line_and_loses_its_location_suffix() {
+        // A statement in mainline sink context whose value is discarded.
+        let diagnostics = check("my $x = 1;\n$x == 1;\nsay $x;\n");
+        let warnings: Vec<_> = diagnostics
+            .iter()
+            .filter(|d| d.severity == Severity::Warning)
+            .collect();
+        assert_eq!(warnings.len(), 1, "{diagnostics:#?}");
+        assert_eq!(warnings[0].line, 2);
+        assert!(
+            !warnings[0].message.contains("\n    at "),
+            "the location suffix must be split out, not left in the message: {:?}",
+            warnings[0].message
+        );
+    }
+
+    #[test]
+    fn warnings_do_not_leak_into_the_next_document() {
+        check("my $x = 1;\n$x == 1;\n");
+        assert_eq!(check("my $y = 2;\nsay $y;\n"), Vec::new());
+    }
+
+    #[test]
+    fn split_warning_location_handles_a_message_without_a_suffix() {
+        let (message, line, file) = split_warning_location("plain warning");
+        assert_eq!(message, "plain warning");
+        assert_eq!(line, None);
+        assert_eq!(file, None);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod analysis;
 mod ast;
 mod builtins;
 pub(crate) mod chain_compare;


### PR DESCRIPTION
ADR-0065 S1. The point is not that mutsu gains an editor integration — it is that **"mutsu cannot do this" becomes something you can learn without running the code**. An agent writing Raku targeted at mutsu previously had exactly one way to discover mutsu's coverage: execute and see what broke.

Usage and layout: [`docs/language-server.md`](https://github.com/tokuhirom/mutsu/blob/feat/adr0065-s1-language-server-skeleton/docs/language-server.md).

## `mutsu::analysis::check` — the interpreter's first non-executing frontend

Every other place in the crate that parses Raku does so on the way to running it. `src/analysis.rs` parses a document, throws the AST away and reports what it learned. Nothing executes, so opening a file with `unlink "/etc/passwd"` in it is safe. (Parsing a `use` *does* read the imported module's source, because Raku's grammar is not context-free with respect to the imported symbol table — but it does not run it.)

It goes through `parse_source`, so a document's `use vX` applies to that document and is not left behind for the next one. In a one-shot process that is invisible; in a resident one it is the difference between documents being analysed independently and the first file opened silently changing how every later file is read.

## `crates/mutsu-lsp` — synchronous, and no async runtime enters the repo

`lsp-server` + `lsp-types` (rust-analyzer's crates) rather than `tower-lsp`. D7 anticipated keeping `tokio` out of *mutsu's* dependency tree by isolating the server in its own crate; with D3 dropping every latency-sensitive method there turns out to be nothing to overlap, so **tokio does not enter this repository at all**. Parsing runs on the loop thread, which also keeps the parser's thread-local caches warm — the configuration S0 validated.

Implemented: `initialize`/`shutdown`/`exit`, `didOpen`/`didChange`/`didClose` with full-document sync, `publishDiagnostics`. An unimplemented request gets `MethodNotFound` rather than silence — a client waiting forever for a response it will never get is a worse failure than one told plainly.

## Two things came out differently from the design

**Warnings were free.** S1 was supposed to ship only the single parse error. But `PARSE_WARNINGS` already collects the parser's warnings with a `"\n    at FILE:LINE"` suffix baked into the message text (it has to survive the precompilation cache, which persists text only), so splitting that back off recovers a line. Sink-context warnings and VCS conflict markers ship now, at line granularity. S3 remains about *multiple errors* and recovery, which is the hard part.

**A parser panic had to become a diagnostic.** Not in the design, and load-bearing: mutsu's parser is not panic-free and a resident server must outlive a document that trips it. `check` catches the unwind and says plainly that this is a bug in mutsu, not necessarily in your code — D4's signal in its bluntest form, and an agent must not go looking for a mistake of its own. Pinned by a protocol test that feeds a sequence of hostile documents and then asserts the session is still analysing.

## Positions are pinned by tests, not eyeballed

LSP counts UTF-16 code units from 0; mutsu counts characters from 1. D5's hazard is that the intended consumer re-reads the line, absorbs an off-by-one, and never reports it — so quality can rot unobserved. One test pins the exact offset for a line of astral-plane characters, where the two counts disagree: for the stray `}` in `my $t = '🐪🐪🐪🐪' }`, mutsu says character column 16 and LSP must be told **19**.

Since mutsu reports a *point* rather than a span (the AST has no positions at all, D6), a range runs from that point to the end of its line — for a parse failure the rest of the line is precisely what mutsu could not make sense of. A warning, which has no column, covers the whole line.

## The workspace split

`mutsu` stays the root package, `crates/mutsu-lsp` joins as a member, `default-members = ["."]`. A bare `cargo build`/`cargo test` at the root means exactly what it meant before, so every existing CI, release, container and wasm invocation is untouched — **`wasm-pack build` verified locally under the workspace** (exit 0, pkg produced). The server gets one CI step of its own (`cargo clippy -p mutsu-lsp --all-targets` + `cargo test -p mutsu-lsp`), mirrored in `make test`.

It takes mutsu with **default** features, JIT included: a leaner feature set is a different build of the whole interpreter, which would make CI compile mutsu a third time (it already builds debug and release) for a binary that is merely smaller.

`mutsu-lsp` is versioned independently (`tag-release.yml` bumps only the root `Cargo.toml`) and is not in the release tarball yet — both were open items under the ADR's "Not decided here".

## Verification

- `make test` — 36634 tests, `Result: PASS`.
- `cargo test -p mutsu-lsp` — 21 tests (15 unit + 6 end-to-end protocol tests driving the real loop over `lsp_server::Connection::memory()`).
- `cargo clippy -p mutsu-lsp --all-targets -- -D warnings` clean; `cargo clippy -- -D warnings` clean; `cargo fmt --all -- --check` clean.
- `wasm-pack build --target web --no-default-features --features wasm` — exit 0 under the new workspace.
- The built binary answers a real framed stdio session (initialize → didOpen → publishDiagnostics → shutdown).

Next is S2, the capability unique to mutsu: making the built-in method/routine names enumerable from one source so "mutsu does not implement this" becomes a first-class diagnostic (D4). It depends on no span work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)