### PR TITLE
feat: ADR-0065 S2 — report routines mutsu does not have, and fix what that exposed

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -81,13 +81,14 @@ work; see the CLAUDE.md "mzef package manager and distribution" section. The **R
 
 - [ ] **Language server** — designed in [docs/adr/0065-language-server-targets-ai-agents.md](docs/adr/0065-language-server-targets-ai-agents.md)
       (an AI agent is the primary consumer, so only the methods an agent consumes are implemented,
-      and "does mutsu support this?" is a first-class diagnostic). **S0 (viability gate) and S1
-      (server skeleton + diagnostics) are done** — `crates/mutsu-lsp/`, `src/analysis.rs`,
-      [docs/language-server.md](docs/language-server.md). Next is **S2: make mutsu's built-in
-      method/routine names enumerable from one source, so "mutsu does not implement this" becomes a
-      first-class diagnostic (D4)** — the capability unique to mutsu, and it depends on no span
-      work. Then S3 (multiple diagnostics + recovery), S4 (symbols/definition), S5
-      (references/hover).
+      and "does mutsu support this?" is a first-class diagnostic). **S0 (viability gate), S1 (server
+      skeleton + diagnostics) and S2's routine half are done** — `crates/mutsu-lsp/`,
+      `src/analysis.rs`, [docs/language-server.md](docs/language-server.md). Next is **S3: multiple
+      diagnostics per document — give `parse_program_partial` positions and errors** (today a
+      document reports only its first parse failure). Then S4 (symbols/definition), S5
+      (references/hover). **S2's method half is deferred with a real design question**: `$x.foo`
+      needs the receiver type, which the AST does not carry, and the existing `(owner, name)`
+      catalog is conservative in the false-positive direction — see the ADR's S2 findings.
 - [ ] Debugger.
 - [ ] Native binary output.
 

--- a/crates/mutsu-lsp/src/diagnostics.rs
+++ b/crates/mutsu-lsp/src/diagnostics.rs
@@ -73,6 +73,29 @@ mod tests {
         assert_eq!(diagnostics[0].range.start.line, 1);
     }
 
+    /// ADR-0065 D4, the capability unique to a server built on the target
+    /// runtime: a name mutsu does not have is reported as such, and carries the
+    /// replacement mutsu already knows about.
+    #[test]
+    fn a_routine_mutsu_does_not_have_is_reported_with_its_own_code() {
+        let text = "sub greeting() { 1 }\nsay greetng();\n";
+        let diagnostics = diagnostics_for(text);
+        assert_eq!(diagnostics.len(), 1, "{diagnostics:#?}");
+        let d = &diagnostics[0];
+        assert_eq!(d.severity, Some(DiagnosticSeverity::ERROR));
+        assert_eq!(
+            d.code,
+            Some(NumberOrString::String("UndeclaredRoutine".to_string())),
+            "a consumer keying on the code must be able to tell this from a syntax error"
+        );
+        assert_eq!(d.range.start.line, 1, "0-based line of the call");
+        assert!(
+            d.message.contains("greetng") && d.message.contains("greeting"),
+            "the diagnostic must name the unknown routine and the replacement: {:?}",
+            d.message
+        );
+    }
+
     #[test]
     fn a_document_that_crashes_the_parser_is_reported_not_propagated() {
         // Whatever input does this, if any does, must come back as a

--- a/docs/adr/0065-language-server-targets-ai-agents.md
+++ b/docs/adr/0065-language-server-targets-ai-agents.md
@@ -338,6 +338,85 @@ Two items from "Not decided here" are now decided in passing: `mutsu-lsp` is ver
 independently of the interpreter (`tag-release.yml` bumps only the root `Cargo.toml`) and
 is **not** in the release tarball yet; transport is stdio only.
 
+## S2 findings (2026-09-03)
+
+D4 said the work here was to make mutsu's built-in names enumerable: "they are
+currently string literals in `match method { ... }` arms ... the fix is to derive the
+dispatch arms and a name table from one source". Both halves of that turned out to be
+wrong, in opposite directions.
+
+### 1. The table already exists — and is the wrong shape for a diagnostic
+
+`src/builtins/native_method_row.rs` (ADR-0019 Phase E box E2a) is an `(owner, name)`
+catalog with per-arity recognition flags, already read in production by `.^methods` and
+`.^can`. So no enumeration work was needed.
+
+It cannot back a diagnostic, though, because it is **deliberately conservative in the
+direction that produces false positives**. A pair with no row reports "not servable", and
+whole owners are uncovered by construction — `Sub`, `Signature`, `IO::Path`, `IO::Handle`,
+`Cool`, and the untouched majority of `Any`/`Mu`'s surface. Absence from the table means
+"the 2026-08-10 probe did not classify this", not "mutsu does not have it". Reporting
+absence as a defect would tell an agent that a method mutsu implements does not exist,
+which is precisely the failure D5 says is unrecoverable.
+
+### 2. The real blocker for method diagnostics is the receiver type, not the name list
+
+`$x.foo` cannot be judged without knowing what `$x` is, and mutsu's AST carries no type
+information for the same reason it carries no positions. D4 did not account for this. The
+honest scope for method-name diagnostics is therefore the subset where the receiver is
+statically known — a literal, or a bareword type object (`Int.frobnicate`) — plus a table
+that distinguishes "known absent" from "unclassified". That is a separate slice with a
+real design question in it, and it is not what shipped here.
+
+### 3. The routine half needs no receiver, and mutsu already had it
+
+A call with no receiver has no ambiguity, so D4's signal is available immediately there:
+a core routine rakudo has and mutsu lacks reports exactly as a typo does, which is the
+point. And `src/runtime/undeclared_routines.rs` already implements rakudo's CHECK-time
+`X::Undeclared::Symbols` scan, with the contract a diagnostic needs stated in its own
+module docs: declarations are collected scope-blind across the unit and the check
+abandons a unit that imports names it cannot see through, so *"a missed construct can
+only produce a false negative, never a false positive"*.
+
+S2 therefore ships the routine half by wiring that existing analysis into
+`analysis::check`, and leaves the method half to a later slice.
+
+### 4. The analysis path constructs no `Interpreter`, and that is load-bearing
+
+The obvious implementation — build an `Interpreter` and call the runtime's own
+`check_undeclared_routines_mainline` — measured at **9.2 ms and ~7.2 KiB retained per
+construction** (debug, 4000 constructions, linear, unaffected by `MUTSU_GC=on`). On the
+same build that is twice the cost of parsing the whole document and fifteen times its
+memory, paid on every keystroke.
+
+Since every lookup the runtime path adds is per-interpreter registry state that a *fresh*
+interpreter has none of, the verdict is identical without one. The static predicates were
+factored into a single shared function so the two paths cannot drift, and
+`check_undeclared_routines_without_interpreter` is what the frontend calls. Analysis is
+now 5.0 ms per document with 0.52 KiB/call retained — the same memory profile as a plain
+parse, and cheaper than `dump_ast`, which additionally formats the AST.
+
+The interpreter-construction cost is recorded separately
+(`todo/perf/interpreter-new-is-expensive-and-retains-memory.md`): it is not an
+LSP-specific problem.
+
+### 5. D4's "carry the replacement" exposed a rakudo-parity gap in mutsu itself
+
+mutsu suggested a replacement for a core routine (`elem` → `elems`) but never for the
+unit's own: `sub greeting() { }; greetng()` reported the typo with no way to see what was
+meant, where rakudo answers "Did you mean 'greeting'?". Its suggestion candidates came
+from the interpreter's registry, which does not hold the unit's declarations at the point
+the check runs — while the walker had already collected them.
+
+The walker now tracks routine declarations separately from the names it collects to
+*suppress* calls. That distinction matters: the suppressing set deliberately absorbs
+variables and types, so drawing suggestions from it would offer a `my $greeting` as the
+routine you meant, which rakudo never does. Pinned by
+`t/undeclared-routine-suggests-unit-own-subs.t`, which passes unmodified under real raku.
+
+This is the D7 property in practice — the language server's requirements improving mutsu's
+own diagnostics rather than taxing them.
+
 ## Rejected alternatives
 
 - **A lossless CST / red-green tree (rust-analyzer, rowan).** The correct architecture for
@@ -364,7 +443,7 @@ is **not** in the release tarball yet; transport is stdio only.
 | --- | --- | --- |
 | **S0** | Long-lived-process viability probe (D8) — **done 2026-09-03**, `tests/long_lived_parse.rs` | — |
 | **S1** | Server skeleton, full-document reparse, diagnostics from the existing single-error path — **done 2026-09-03**, `crates/mutsu-lsp/`, `src/analysis.rs`, `docs/language-server.md` | S0 |
-| **S2** | Enumerable built-in name tables → "mutsu does not support this" diagnostics (D4) | S1 |
+| **S2** | Enumerable built-in name tables → "mutsu does not support this" diagnostics (D4) — **routine half done 2026-09-03**; the method half is blocked on receiver types, see the S2 findings | S1 |
 | **S3** | Multiple diagnostics per document + error recovery (give `parse_program_partial` positions and errors) | S1 |
 | **S4** | `documentSymbol` / `workspaceSymbol` / `definition` at line granularity | S1 |
 | **S5** | `references` / `hover`; expression spans on the variants these require (D6) | S4 |

--- a/docs/language-server.md
+++ b/docs/language-server.md
@@ -65,9 +65,26 @@ Today the server reports:
   `parse_program_partial` to grow positions and errors first (S3).
 - **Parse warnings**, at line granularity — sink-context warnings, VCS conflict
   markers, and the rest of what the parser collects while reading a unit.
+- **Calls to routines mutsu does not have** (`code: "UndeclaredRoutine"`), with
+  the replacement mutsu already computes: `sub greeting() { }; greetng()`
+  answers "Did you mean 'greeting'?". This is the D4 signal — a core routine
+  rakudo has and mutsu lacks reports exactly as a typo does, which is the point.
+  It is mutsu's own CHECK-time `X::Undeclared::Symbols` scan, and it inherits
+  that scan's contract: declarations are collected scope-blind across the unit,
+  and a unit that imports names the walker cannot see through is abandoned
+  rather than second-guessed, so a missed construct is a false negative and
+  never a false positive. No `Interpreter` is constructed for it.
 - **A parser crash, as a diagnostic**, phrased as a mutsu bug rather than a
   syntax error. `mutsu::analysis::check` catches the panic; a resident server
   cannot die on one bad document.
+
+Unknown *method* names are not reported. `$x.foo` cannot be judged without
+knowing what `$x` is, and mutsu's AST carries no type information — the same
+reason it carries no positions. The existing `(owner, name)` catalog
+(`src/builtins/native_method_row.rs`) cannot stand in for that: it is
+deliberately conservative, so absence from it means "unclassified", not "mutsu
+does not have it", and reporting absence as a defect would be a false positive.
+See the ADR's S2 findings.
 
 A parse failure inside a `use`d module is anchored at line 1 of the *open*
 document and names the other file in its message. Reporting that module's
@@ -109,6 +126,7 @@ which has no column, covers the whole line.
 | File | What lives there |
 | --- | --- |
 | `src/analysis.rs` (in `mutsu`) | The non-executing frontend: `check(source) -> Vec<Diagnostic>`. The only entry point in the interpreter that parses a document and keeps nothing but what it learned. |
+| `src/runtime/undeclared_routines.rs` (in `mutsu`) | The CHECK-time undeclared-routine walker, shared by the interpreter and the frontend. `check_undeclared_routines_without_interpreter` is the frontend's entry point; the static name predicates live in one function so the two paths cannot drift. |
 | `crates/mutsu-lsp/src/server.rs` | The protocol loop: capabilities, document sync, diagnostic publication, shutdown. |
 | `crates/mutsu-lsp/src/positions.rs` | mutsu positions to LSP positions. |
 | `crates/mutsu-lsp/src/diagnostics.rs` | `mutsu::analysis::Diagnostic` to `lsp_types::Diagnostic`. |

--- a/news/2026-09/adr0065-s2-undeclared-routine-diagnostics.md
+++ b/news/2026-09/adr0065-s2-undeclared-routine-diagnostics.md
@@ -1,0 +1,87 @@
+# "mutsu does not have this routine" is now a diagnostic, and the plan for saying it about methods was wrong
+
+ADR-0065 S2 is the capability that makes a language server *for mutsu* worth
+building: a construct rakudo accepts and mutsu does not is a true positive here,
+and an agent writing Raku for mutsu otherwise has exactly one way to find out —
+run it and see what breaks.
+
+The ADR said the work was to make mutsu's built-in names enumerable: "they are
+currently string literals in `match method { ... }` arms ... the fix is to derive
+the dispatch arms and a name table from one source." Both halves of that turned
+out to be wrong, in opposite directions.
+
+## The table already existed, and is the wrong shape for a diagnostic
+
+`src/builtins/native_method_row.rs` — ADR-0019 Phase E, already read in
+production by `.^methods` and `.^can` — is an `(owner, name)` catalog with
+per-arity recognition flags. No enumeration work was needed.
+
+It cannot back a diagnostic, though, because it is **deliberately conservative in
+the direction that produces false positives**. A pair with no row reports "not
+servable", and whole owners are uncovered by construction: `Sub`, `Signature`,
+`IO::Path`, `IO::Handle`, `Cool`, and most of `Any`/`Mu`. Absence means "the
+2026-08-10 probe did not classify this", not "mutsu does not have it". Reporting
+absence as a defect would tell an agent that a method mutsu implements does not
+exist — the one failure D5 says is unrecoverable, because the agent believes it.
+
+## And the real blocker is the receiver type, which the ADR did not account for
+
+`$x.foo` cannot be judged without knowing what `$x` is, and mutsu's AST carries
+no type information for the same reason it carries no positions. The honest scope
+for method diagnostics is the subset where the receiver is statically known — a
+literal, or a bareword type object — plus a table that distinguishes "known
+absent" from "unclassified". That is a separate slice with a real design question
+in it, and it is not what shipped.
+
+## The routine half has no receiver, and mutsu already had it
+
+A call with no receiver has no ambiguity, so the signal is available immediately
+there. And `src/runtime/undeclared_routines.rs` already implements rakudo's
+CHECK-time `X::Undeclared::Symbols` scan, with exactly the contract a diagnostic
+needs written in its own module docs: declarations are collected scope-blind
+across the unit, the check abandons a unit that imports names it cannot see
+through, and *"a missed construct can only produce a false negative, never a false
+positive"*.
+
+So S2 wires that existing analysis into `analysis::check`. `nosuchsub()` now
+comes back as `code: "UndeclaredRoutine"` on the right line, with mutsu's own
+"Did you mean" attached.
+
+## Building it exposed two things worth having found
+
+**Constructing an `Interpreter` costs 9.2 ms and retains 7.2 KiB.** The obvious
+implementation was to build one and call the runtime's own
+`check_undeclared_routines_mainline`. Measured over 4000 construct-and-drop
+cycles on a debug build, that is twice the cost of parsing the whole document and
+fifteen times its memory — linear, and unaffected by `MUTSU_GC=on`, so not a GC
+cycle waiting for a collector. Paid on every keystroke, it would have made the
+server's memory profile sixteen times worse than a plain parse.
+
+Every lookup the runtime path adds is per-interpreter registry state that a
+*fresh* interpreter has none of, so the verdict is identical without one. The
+static predicates moved into a single shared function — one list, so the two
+paths cannot drift — and the frontend calls
+`check_undeclared_routines_without_interpreter`. Analysis is now 5.0 ms per
+document retaining 0.52 KiB: the same memory profile as a plain parse, and
+cheaper than `dump_ast`, which additionally formats the AST into a string. The
+interpreter-construction cost is recorded on its own
+(`todo/perf/interpreter-new-is-expensive-and-retains-memory.md`); it is not an
+LSP problem.
+
+**mutsu did not suggest the unit's own routines.** D4 asks for the replacement to
+travel with the diagnostic, and mutsu already computed one — for core routines
+only. `sub greeting() { }; greetng()` reported the typo with no way to see what
+was meant, where rakudo answers "Did you mean 'greeting'?". The candidates came
+from the interpreter's registry, which does not hold the unit's declarations at
+the point the check runs, while the walker had already collected them.
+
+The walker now tracks routine declarations separately from the names it collects
+in order to *suppress* calls. That distinction is the whole subtlety: the
+suppressing set deliberately absorbs variables and types, because suppressing on
+any of them is the safe direction — but drawing suggestions from it would offer a
+`my $greeting` as the routine you meant, which rakudo never does.
+`t/undeclared-routine-suggests-unit-own-subs.t` pins both halves and passes
+unmodified under real raku.
+
+That is the D7 property working as intended: the language server's requirements
+improving mutsu's own diagnostics rather than taxing them.

--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -22,6 +22,7 @@
 //!   rather than an abort. mutsu is under active development and its parser is
 //!   not panic-free; `check` catches it.
 
+use crate::ast::Stmt;
 use crate::value::{RuntimeError, RuntimeErrorCode};
 
 /// How much a [`Diagnostic`] should be believed.
@@ -73,6 +74,46 @@ impl Diagnostic {
             in_other_file: None,
         }
     }
+}
+
+/// mutsu's CHECK-time undeclared-routine analysis, run without executing
+/// anything (ADR-0065 D4).
+///
+/// This is the first diagnostic that answers "does mutsu support this?" rather
+/// than "does this parse?". A core routine rakudo has and mutsu does not shows
+/// up here exactly as a typo does — which is the point: an agent writing Raku
+/// for mutsu has no other way to learn the difference short of running the
+/// code.
+///
+/// It shares the runtime's own walker and static name tables rather than
+/// reimplementing the rule, so the server and the interpreter cannot disagree
+/// about what counts as declared. That walker's contract is exactly the one a
+/// diagnostic needs: declarations are collected scope-blind across the whole
+/// unit and the check abandons a unit that imports names it cannot see through,
+/// so a missed construct yields a false *negative*, never a false positive.
+///
+/// No `Interpreter` is constructed. Everything the runtime entry point
+/// additionally consults is per-interpreter registry state that a fresh one has
+/// none of, so the verdict is identical — and constructing one would cost about
+/// 9 ms and retain roughly 7 KiB, on every keystroke.
+fn undeclared_routine_diagnostic(stmts: &[Stmt]) -> Option<Diagnostic> {
+    let err =
+        crate::runtime::undeclared_routines::check_undeclared_routines_without_interpreter(stmts)
+            .err()?;
+    let line = err.line().unwrap_or(1) as u32;
+    Some(Diagnostic {
+        severity: Severity::Error,
+        message: err.message,
+        line,
+        // The walker records the statement line, not an offset; `Stmt::SetLine`
+        // is the only positional information mutsu has (D6).
+        column: None,
+        // Its own code, not the `ParseGeneric` the error carries for the CLI's
+        // "===SORRY!===" rendering: a consumer keying on the code must be able
+        // to tell an unknown name from a syntax error.
+        code: Some("UndeclaredRoutine"),
+        in_other_file: None,
+    })
 }
 
 /// Deliberately exhaustive: a new `RuntimeErrorCode` variant should fail to
@@ -170,12 +211,13 @@ pub fn check(source: &str) -> Vec<Diagnostic> {
     // documents being analysed independently and a `use v6.e.PREVIEW` in the
     // first file silently changing how every later file is read.
     let parsed = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        crate::parse_dispatch::parse_source(source)
+        let (stmts, _finish) = crate::parse_dispatch::parse_source(source)?;
+        Ok::<Option<Diagnostic>, RuntimeError>(undeclared_routine_diagnostic(&stmts))
     }));
 
     let mut diagnostics = Vec::new();
     match parsed {
-        Ok(Ok(_stmts)) => {}
+        Ok(Ok(undeclared)) => diagnostics.extend(undeclared),
         Ok(Err(err)) => diagnostics.push(diagnostic_from_parse_error(&err)),
         Err(payload) => {
             // "mutsu cannot handle this" is the single most valuable thing this
@@ -262,6 +304,70 @@ mod tests {
     fn warnings_do_not_leak_into_the_next_document() {
         check("my $x = 1;\n$x == 1;\n");
         assert_eq!(check("my $y = 2;\nsay $y;\n"), Vec::new());
+    }
+
+    /// ADR-0065 D4: "mutsu does not have this" is the diagnostic the server
+    /// exists to deliver, and a name nobody declared is its first form.
+    #[test]
+    fn a_call_to_a_routine_nobody_declared_is_reported() {
+        let diagnostics = check("say 1;\nnosuchsub();\n");
+        assert_eq!(diagnostics.len(), 1, "{diagnostics:#?}");
+        let d = &diagnostics[0];
+        assert_eq!(d.severity, Severity::Error);
+        assert_eq!(d.code, Some("UndeclaredRoutine"));
+        assert_eq!(d.line, 2);
+        assert!(
+            d.message.contains("Undeclared routine") && d.message.contains("nosuchsub"),
+            "{:?}",
+            d.message
+        );
+    }
+
+    #[test]
+    fn a_declared_routine_is_not_reported() {
+        assert_eq!(check("sub greet() { 1 }\ngreet();\n"), Vec::new());
+    }
+
+    #[test]
+    fn a_builtin_routine_is_not_reported() {
+        assert_eq!(check("say uc('x');\nsay elems([1, 2]);\n"), Vec::new());
+    }
+
+    /// D4 asks for the replacement to travel with the diagnostic. mutsu
+    /// computes one for its own CLI error, so it comes through here for free —
+    /// once the candidates include the unit's own subs, which they did not
+    /// until this slice (pinned against real raku by
+    /// `t/undeclared-routine-suggests-unit-own-subs.t`).
+    #[test]
+    fn a_near_miss_carries_a_suggestion() {
+        let diagnostics = check("sub greeting() { 1 }\ngreetng();\n");
+        assert_eq!(diagnostics.len(), 1, "{diagnostics:#?}");
+        assert!(
+            diagnostics[0].message.contains("greeting"),
+            "expected a 'Did you mean' pointing at the real name: {:?}",
+            diagnostics[0].message
+        );
+    }
+
+    /// The conservativeness contract, pinned. A unit that imports names the
+    /// walker cannot see through is abandoned rather than second-guessed: a
+    /// false positive here would be read by an agent as fact and acted on.
+    #[test]
+    fn a_unit_that_imports_unseen_names_is_not_second_guessed() {
+        let diagnostics = check("use Test;\nnosuchsub();\n");
+        assert!(
+            diagnostics
+                .iter()
+                .all(|d| d.code != Some("UndeclaredRoutine")),
+            "{diagnostics:#?}"
+        );
+    }
+
+    /// Still true with the analysis running: `check` reads the interpreter's
+    /// tables, it does not run the document.
+    #[test]
+    fn the_undeclared_check_does_not_run_the_document() {
+        assert_eq!(check("say 'THIS MUST NOT BE PRINTED';\n"), Vec::new());
     }
 
     #[test]

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -662,7 +662,9 @@ mod test_functions;
 pub(crate) use test_functions::TEST_MODULE_EXPORTS;
 pub(crate) mod thread_compat;
 pub(crate) mod types;
-mod undeclared_routines;
+// `pub(crate)`: the analysis frontend (`crate::analysis`, ADR-0065) calls the
+// interpreter-free entry point directly.
+pub(crate) mod undeclared_routines;
 mod unicode;
 pub(crate) mod utf8_c8;
 pub(crate) mod utils;

--- a/src/runtime/system.rs
+++ b/src/runtime/system.rs
@@ -584,6 +584,48 @@ impl Interpreter {
         Self::suggest_from_candidates(name, &candidates)
     }
 
+    /// [`suggest_routine_names`](Self::suggest_routine_names) plus names the
+    /// caller knows are routines but the registry does not hold — the
+    /// compilation unit's own `sub` declarations, as collected by the
+    /// CHECK-time walker (`runtime/undeclared_routines.rs`). Rakudo suggests
+    /// those, and without them `sub greeting {}; greetng()` reports the typo
+    /// with no way to see what was meant.
+    pub(crate) fn suggest_routine_names_including(
+        &self,
+        name: &str,
+        extra: &HashSet<String>,
+    ) -> Vec<String> {
+        let mut candidates = Self::static_routine_candidates(extra);
+        candidates.extend(self.registry().functions.keys().map(|s| s.resolve()));
+        Self::suggest_from_candidates(name, &candidates)
+    }
+
+    /// The suggestion candidates that need no interpreter: the built-in routine
+    /// names, the phasers, and `extra` (the compilation unit's own routines).
+    /// Shared with [`suggest_routine_names_including`](Self::suggest_routine_names_including)
+    /// so the two paths cannot drift apart.
+    fn static_routine_candidates(extra: &HashSet<String>) -> Vec<String> {
+        let mut candidates: Vec<String> = extra.iter().cloned().collect();
+        candidates.extend(
+            crate::runtime::builtins::BUILTIN_FUNCTION_NAMES
+                .iter()
+                .map(|s| s.to_string()),
+        );
+        candidates.extend(
+            crate::runtime::undeclared_routines::PHASER_SUGGESTION_NAMES
+                .iter()
+                .map(|s| s.to_string()),
+        );
+        candidates
+    }
+
+    /// [`suggest_routine_names_including`](Self::suggest_routine_names_including)
+    /// for the analysis frontend, which has no interpreter to read a registry
+    /// from (ADR-0065 S2).
+    pub(crate) fn static_routine_suggestions(name: &str, extra: &HashSet<String>) -> Vec<String> {
+        Self::suggest_from_candidates(name, &Self::static_routine_candidates(extra))
+    }
+
     /// Suggest close type names (registered classes/roles) for an undeclared
     /// type `name`. Used for X::Undeclared::Symbols `.type_suggestion`.
     pub(crate) fn suggest_type_names(&self, name: &str) -> Vec<String> {

--- a/src/runtime/undeclared_routines.rs
+++ b/src/runtime/undeclared_routines.rs
@@ -92,6 +92,12 @@ pub(crate) const PHASER_SUGGESTION_NAMES: &[&str] = &[
 #[derive(Default)]
 struct Scan {
     declared: HashSet<String>,
+    /// The subset of `declared` that is a *routine* declaration (`sub`, `multi
+    /// sub`). `declared` deliberately also absorbs variables and types, because
+    /// suppressing a call on any of them is the safe direction — but a
+    /// suggestion drawn from it would propose a variable as the routine the
+    /// user meant, which rakudo never does. Suggestions read this instead.
+    declared_routines: HashSet<String>,
     calls: Vec<(String, i64)>,
     line: i64,
     /// The unit imports names the walker cannot see (use/require/...): skip
@@ -99,13 +105,27 @@ struct Scan {
     bail: bool,
 }
 
+/// A declared name with its sigil and twigil removed.
+fn bare_name(name: &str) -> &str {
+    let bare = name.strip_prefix('\\').unwrap_or(name);
+    bare.strip_prefix(['$', '@', '%', '&'])
+        .unwrap_or(bare)
+        .trim_start_matches(['!', '.', '*', '^', ':'])
+}
+
 impl Scan {
+    /// Record a routine declaration: both a suppressor (like any other name)
+    /// and a suggestion candidate.
+    fn declare_routine(&mut self, name: &str) {
+        self.declare(name);
+        let bare = bare_name(name);
+        if !bare.is_empty() {
+            self.declared_routines.insert(bare.to_string());
+        }
+    }
+
     fn declare(&mut self, name: &str) {
-        let bare = name.strip_prefix('\\').unwrap_or(name);
-        let bare = bare
-            .strip_prefix(['$', '@', '%', '&'])
-            .unwrap_or(bare)
-            .trim_start_matches(['!', '.', '*', '^', ':']);
+        let bare = bare_name(name);
         if bare.is_empty() {
             return;
         }
@@ -229,7 +249,7 @@ fn walk_stmt(stmt: &Stmt, scan: &mut Scan) {
                 scan.bail = true;
                 return;
             }
-            scan.declare(&name.resolve());
+            scan.declare_routine(&name.resolve());
             walk_params(params, param_defs, scan);
             for (alt_params, alt_defs) in signature_alternates {
                 walk_params(alt_params, alt_defs, scan);
@@ -627,6 +647,84 @@ fn walk_expr(expr: &Expr, scan: &mut Scan) {
     }
 }
 
+/// Whether `name` is a routine mutsu knows about from *static* tables alone —
+/// the compilation unit's own declarations, the built-in and Test routine
+/// name lists, the native type-name coercions, the compiler's special call
+/// names, and whatever the parser harvested from this unit's imports.
+///
+/// Split out so the analysis frontend (`crate::analysis`, ADR-0065) can reach
+/// the same verdict without an `Interpreter`. Everything the *runtime* entry
+/// point additionally consults is per-interpreter registry state, which is
+/// empty in a freshly constructed one — so the two paths agree on any unit the
+/// frontend sees, and the one list of static predicates lives here rather than
+/// being duplicated and left to drift.
+fn known_without_an_interpreter(name: &str, declared: &HashSet<String>) -> bool {
+    declared.contains(name)
+        || Interpreter::is_builtin_function(name)
+        || Interpreter::is_test_function_name(name)
+        || super::system_eval_names::EVAL_KNOWN_ROUTINE_NAMES.contains(&name)
+        || NATIVE_TYPE_NAMES.contains(&name)
+        || COMPILER_SPECIAL_CALL_NAMES.contains(&name)
+        || crate::parser::is_imported_function(name)
+}
+
+/// What the walker found: every call the static tables cannot explain, in
+/// source order, plus the unit's own routine declarations for suggestions.
+///
+/// `None` means the unit must not be judged at all — it imports names the
+/// walker cannot see through, so any verdict would risk a false positive.
+struct Unexplained {
+    calls: Vec<(String, i64)>,
+    declared_routines: HashSet<String>,
+}
+
+fn unexplained_calls(stmts: &[Stmt]) -> Option<Unexplained> {
+    let mut scan = Scan {
+        line: 1,
+        ..Default::default()
+    };
+    walk_stmts(stmts, &mut scan);
+    if scan.bail {
+        return None;
+    }
+    let calls = scan
+        .calls
+        .into_iter()
+        .filter(|(name, _)| !known_without_an_interpreter(name, &scan.declared))
+        .collect();
+    Some(Unexplained {
+        calls,
+        declared_routines: scan.declared_routines,
+    })
+}
+
+/// The CHECK-time undeclared-routine analysis, without constructing an
+/// `Interpreter`.
+///
+/// This is what a language server calls (ADR-0065 S2). Running the ordinary
+/// entry point against a *fresh* `Interpreter` would reach the same verdict —
+/// its extra lookups are all registry state a new interpreter has none of — but
+/// constructing one costs about 9 ms and retains roughly 7 KiB (measured on a
+/// debug build, 2026-09-03, `tests/long_lived_parse.rs`), which a resident
+/// process would pay on every keystroke. See
+/// `todo/perf/interpreter-new-is-expensive-and-retains-memory.md`.
+pub(crate) fn check_undeclared_routines_without_interpreter(
+    stmts: &[Stmt],
+) -> Result<(), RuntimeError> {
+    let Some(found) = unexplained_calls(stmts) else {
+        return Ok(());
+    };
+    let Some((name, line)) = found.calls.first() else {
+        return Ok(());
+    };
+    let suggestions = Interpreter::static_routine_suggestions(name, &found.declared_routines);
+    Err(Interpreter::undeclared_routine_error(
+        name,
+        *line,
+        suggestions,
+    ))
+}
+
 impl Interpreter {
     /// Build the X::Undeclared::Symbols error for an undeclared routine call,
     /// rakudo-style: `Undeclared routine:\n    <name> used at line <N>` plus
@@ -658,25 +756,15 @@ impl Interpreter {
         &self,
         stmts: &[Stmt],
     ) -> Result<(), RuntimeError> {
-        let mut scan = Scan {
-            line: 1,
-            ..Default::default()
-        };
-        walk_stmts(stmts, &mut scan);
-        if scan.bail {
+        let Some(found) = unexplained_calls(stmts) else {
             return Ok(());
-        }
-        for (name, line) in &scan.calls {
-            if scan.declared.contains(name)
-                || self.has_function(name)
+        };
+        for (name, line) in &found.calls {
+            // Everything beyond the static tables is per-interpreter registry
+            // state, which is why the analysis frontend can skip it entirely.
+            if self.has_function(name)
                 || self.has_multi_function(name)
                 || self.has_proto(name)
-                || Self::is_builtin_function(name)
-                || Self::is_test_function_name(name)
-                || super::system_eval_names::EVAL_KNOWN_ROUTINE_NAMES.contains(&name.as_str())
-                || NATIVE_TYPE_NAMES.contains(&name.as_str())
-                || COMPILER_SPECIAL_CALL_NAMES.contains(&name.as_str())
-                || crate::parser::is_imported_function(name)
                 || self.env().contains_key(&format!("&{}", name))
                 || self.env().contains_key(name.as_str())
                 || self.get_our_var(name).is_some()
@@ -687,7 +775,12 @@ impl Interpreter {
             {
                 continue;
             }
-            let suggestions = self.suggest_routine_names(name);
+            // Rakudo suggests the unit's own routines, not just core ones:
+            // `sub greeting {}; greetng()` answers "Did you mean 'greeting'?".
+            // The interpreter's registry does not hold them at this point for
+            // every declaration form, and the walker has already collected
+            // them, so pass them along as extra candidates.
+            let suggestions = self.suggest_routine_names_including(name, &found.declared_routines);
             return Err(Self::undeclared_routine_error(name, *line, suggestions));
         }
         Ok(())

--- a/t/undeclared-routine-suggests-unit-own-subs.t
+++ b/t/undeclared-routine-suggests-unit-own-subs.t
@@ -1,0 +1,44 @@
+use Test;
+
+# Rakudo's CHECK-time "Undeclared routine" error suggests a close name, and the
+# candidates include the compilation unit's OWN subs, not only core routines:
+#
+#   sub greeting() { 1 }; greetng()
+#     -> Undeclared routine:
+#            greetng used at line 1. Did you mean 'greeting'?
+#
+# mutsu drew its candidates from the interpreter's registered routines, which do
+# not hold the unit's own declarations at the point the check runs, so it
+# reported the typo with no way to see what was meant. The CHECK-time walker had
+# already collected those names; it now passes them along as suggestion
+# candidates.
+#
+# The distinction that matters: the walker collects every declared name
+# scope-blind -- variables and types included -- because suppressing a call on
+# any of them is the safe direction. Suggestions must come from the *routine*
+# subset only, or a `my $greeting` would be offered as the routine you meant,
+# which rakudo never does.
+
+plan 4;
+
+throws-like 'sub greeting() { 1 }; greetng()', X::Undeclared::Symbols,
+    "a typo'd call suggests the unit's own sub",
+    message => /"Did you mean 'greeting'"/;
+
+throws-like 'multi sub handle(Int) { 1 }; handel(1)', X::Undeclared::Symbols,
+    'a multi candidate is a suggestion candidate too',
+    message => /"Did you mean 'handle'"/;
+
+# Core routines were already suggested and must stay so.
+throws-like 'elem([1, 2])', X::Undeclared::Symbols,
+    'a core routine is still suggested',
+    message => /"Did you mean 'elems'"/;
+
+# A variable of the near-miss name must NOT be offered as a routine.
+my $message = '';
+try {
+    EVAL 'my $greeting = 1; greetng()';
+    CATCH { default { $message = .message } }
+}
+nok $message.contains('Did you mean'),
+    'a same-named variable is not offered as the routine you meant';

--- a/tests/long_lived_parse.rs
+++ b/tests/long_lived_parse.rs
@@ -442,6 +442,69 @@ fn line_numbers_survive_repeated_parses_of_differently_sized_buffers() {
     );
 }
 
+/// The same gate, on the entry point a language server actually calls.
+/// `mutsu::analysis::check` parses *and* runs the CHECK-time undeclared-routine
+/// analysis against a freshly constructed `Interpreter` — more per-call work
+/// than `dump_ast`, and therefore the one that has to hold up under repetition.
+#[test]
+fn repeated_analysis_of_an_unchanged_document_is_stable() {
+    let _guard = exclusive();
+    let n = iterations();
+
+    let baseline = mutsu::analysis::check(DOCUMENT);
+    for _ in 0..2 {
+        mutsu::analysis::check(DOCUMENT);
+    }
+
+    let symbols_before = mutsu::symbol::interned_count();
+    let rss_before = rss_kib();
+    let started = Instant::now();
+    for _ in 0..n {
+        let got = mutsu::analysis::check(DOCUMENT);
+        assert_eq!(
+            baseline, got,
+            "re-analysing an unchanged document produced a different report"
+        );
+    }
+    let elapsed = started.elapsed();
+    let symbol_growth = mutsu::symbol::interned_count() - symbols_before;
+    let rss_after = rss_kib();
+
+    println!("--- ADR-0065 S0 probe: {n} analysis::check calls ---");
+    println!(
+        "  wall clock      : {elapsed:?} total, {:?} per check",
+        elapsed / n as u32
+    );
+    println!(
+        "  interned symbols: +{symbol_growth} ({:.2}/check)",
+        symbol_growth as f64 / n as f64
+    );
+    if let (Some(before), Some(after)) = (rss_before, rss_after) {
+        println!(
+            "  resident memory : {:+} KiB ({:.3} KiB/check)",
+            after as isize - before as isize,
+            (after as f64 - before as f64) / n as f64,
+        );
+    }
+
+    // Same bound as the parse gate: one interned name per anonymous declaration
+    // per pass, and nothing else. A fresh `Interpreter` per check must not add
+    // a second source of permanent interning.
+    let anon_declarations_in_document = 1;
+    assert!(
+        symbol_growth <= anon_declarations_in_document * n,
+        "analysing an unchanged document interned {symbol_growth} new names over {n} checks          ({:.2}/check), above the {anon_declarations_in_document:.2}/check the document's          anonymous declaration accounts for",
+        symbol_growth as f64 / n as f64,
+    );
+    if let (Some(before), Some(after)) = (rss_before, rss_after) {
+        let growth = after.saturating_sub(before);
+        assert!(
+            growth < 32 * 1024,
+            "resident memory grew {growth} KiB over {n} analyses of an unchanged document"
+        );
+    }
+}
+
 /// D8's open question: whether documents can be analysed on more than one
 /// thread. The parser's working state (`SCOPES`, the memo tables,
 /// `ORIGINAL_SOURCE`) is thread-local and the symbol table is behind an

--- a/todo/perf/interpreter-new-is-expensive-and-retains-memory.md
+++ b/todo/perf/interpreter-new-is-expensive-and-retains-memory.md
@@ -1,0 +1,69 @@
+# `Interpreter::new()` costs ~9 ms and retains ~7 KiB per construction
+
+Measured 2026-09-03 while building ADR-0065 S2, which briefly constructed one
+`Interpreter` per document analysis and made both properties visible:
+
+| Metric (debug build, 4000 constructions, construct-and-drop) | Value |
+| --- | --- |
+| Wall clock | **9.17 ms per `Interpreter::new()`** |
+| Resident memory | **+7.2 KiB per construction**, linear (28.9 MB over 4000) |
+| Interned symbols | +0 |
+
+The memory is *retained*, not merely slow to return: growth stayed linear from
+1000 to 4000 constructions (7.46 → 7.22 KiB/call), so the allocator is not
+recycling it. `MUTSU_GC=on` changes nothing (9.26 ms, 7.31 KiB/call), so this is
+not a GC cycle waiting for a collector that never runs in that loop.
+
+For scale: on the same build, parsing a 1140-byte document costs about 5 ms and
+retains 0.5 KiB. **Constructing an interpreter is roughly twice as expensive as
+parsing a whole document, and leaks fifteen times as much.**
+
+## Why it matters beyond the language server
+
+S2 dodged it — the analysis frontend now reaches the same verdict through
+`check_undeclared_routines_without_interpreter`, with no `Interpreter` at all —
+so nothing is currently blocked. But the cost is paid elsewhere:
+
+- `Interpreter::new_regex_scratch` (`runtime/runtime_init.rs`) constructs one
+  per regex scratch use. Whether that is on a hot path is unmeasured.
+- Any embedder driving mutsu per request pays it per request.
+- A future language-server slice that genuinely needs interpreter state (S4's
+  `workspaceSymbol` across many files, say) will hit it again.
+
+## Where to look
+
+`Interpreter::new` (`src/runtime/runtime_init.rs:44`) reads as pure data setup:
+the dynamic-variable environment (including a full `std::env::vars()` sweep into
+`%*ENV`, skipped only for `is_building_scratch`), then the core class registry
+built as a long series of `ClassDef` literals. Nothing in the part that was read
+during this investigation obviously *retains*, so the retention is the part
+worth chasing first — a `Box::leak`, a push into a process-global registry, or a
+`Gc` allocation that outlives the drop.
+
+The `%*ENV` sweep is the obvious wall-clock suspect and already has a bypass
+(`BUILDING_SCRATCH`); whether it dominates the 9 ms is unmeasured.
+
+## Repro
+
+Add to `tests/long_lived_parse.rs` (it already has `rss_kib`, `iterations` and
+the serialization guard) and run with `MUTSU_S0_ITERATIONS=4000`:
+
+```rust
+#[test]
+fn interpreter_new_cost() {
+    let _guard = exclusive();
+    let n = iterations();
+    for _ in 0..3 { let _ = mutsu::Interpreter::new(); }
+    let r0 = rss_kib();
+    let t0 = Instant::now();
+    for _ in 0..n {
+        std::hint::black_box(mutsu::Interpreter::new());
+    }
+    println!("{:?}/call, rss {:+} KiB", t0.elapsed() / n as u32,
+        rss_kib().unwrap_or(0) as isize - r0.unwrap_or(0) as isize);
+}
+```
+
+Per `todo/README.md` these are debug-build numbers; re-measure in release before
+designing a fix, and take any figure that ends up in a document from the bench
+CI rather than from a local run.


### PR DESCRIPTION
ADR-0065 S2 is the capability that makes a language server *for mutsu* worth building: a construct rakudo accepts and mutsu does not is a true positive here, and an agent writing Raku for mutsu otherwise has exactly one way to find out — run it and see what breaks.

**D4's plan for how to do that was wrong in both halves, in opposite directions.**

## The table already existed, and is the wrong shape for a diagnostic

D4 said built-in names "are currently string literals in `match method { ... }` arms ... the fix is to derive the dispatch arms and a name table from one source". But `src/builtins/native_method_row.rs` (ADR-0019 Phase E) is already an `(owner, name)` catalog with per-arity flags, read in production by `.^methods` and `.^can`. No enumeration work was needed.

It cannot back a diagnostic, though, because it is **deliberately conservative in the direction that produces false positives**. A pair with no row reports "not servable", and whole owners are uncovered by construction — `Sub`, `Signature`, `IO::Path`, `IO::Handle`, `Cool`, and most of `Any`/`Mu`. Absence means "the 2026-08-10 probe did not classify this", not "mutsu does not have it". Reporting absence as a defect would tell an agent that a method mutsu implements does not exist, which is the one failure D5 says is unrecoverable, because the agent believes it.

## And the real blocker is the receiver type

`$x.foo` cannot be judged without knowing what `$x` is, and mutsu's AST carries no type information for the same reason it carries no positions. D4 did not account for this. The honest scope for method diagnostics is the subset where the receiver is statically known — a literal, or a bareword type object — plus a table that distinguishes "known absent" from "unclassified". That is a separate slice with a real design question in it, and it is deferred with that reasoning recorded.

## The routine half has no receiver, and mutsu already had it

`src/runtime/undeclared_routines.rs` already implements rakudo's CHECK-time `X::Undeclared::Symbols` scan, with exactly the contract a diagnostic needs written in its own module docs: declarations are collected scope-blind across the unit, a unit that imports names the walker cannot see through is abandoned, and *"a missed construct can only produce a false negative, never a false positive"*. So S2 wires that into `analysis::check` as `code: "UndeclaredRoutine"`.

## Building it exposed two things

### `Interpreter::new()` costs 9.2 ms and retains 7.2 KiB

The obvious implementation was to construct one and call the runtime's own `check_undeclared_routines_mainline`. Measured over 4000 construct-and-drop cycles (debug): **9.17 ms/call, +7.2 KiB retained, linear, unaffected by `MUTSU_GC=on`**. On the same build that is twice the cost of parsing the whole document and fifteen times its memory — paid on every keystroke.

Every lookup the runtime path adds beyond the static tables is per-interpreter registry state that a *fresh* interpreter has none of, so the verdict is identical without one. The static predicates moved into one shared function (so the two paths cannot drift) and the frontend calls `check_undeclared_routines_without_interpreter`.

| | before | after |
| --- | --- | --- |
| `analysis::check` | 15.2 ms, 8.0 KiB retained | **5.0 ms, 0.52 KiB retained** |

0.52 KiB/call is the same profile as a plain parse, and 5.0 ms is cheaper than `dump_ast`, which additionally formats the AST into a string. The interpreter-construction cost is filed on its own (`todo/perf/interpreter-new-is-expensive-and-retains-memory.md`); it is not an LSP problem — `new_regex_scratch` and any embedder pay it too.

### mutsu did not suggest the unit's own routines

D4 asks for the replacement to travel with the diagnostic, and mutsu computed one — for **core** routines only:

```
$ mutsu -e 'sub greeting() { 1 }; greetng()'     # before
Undeclared routine:
    greetng used
$ raku  -e 'sub greeting() { 1 }; greetng()'
Undeclared routine:
    greetng used at line 1. Did you mean 'greeting'?
```

The candidates came from the interpreter's registry, which does not hold the unit's declarations at the point the check runs — while the walker had already collected them. The walker now tracks routine declarations separately from the names it collects in order to *suppress* calls. That distinction is the whole subtlety: the suppressing set deliberately absorbs variables and types, because suppressing on any of them is the safe direction, but drawing suggestions from it would offer a `my $greeting` as the routine you meant, which rakudo never does.

`t/undeclared-routine-suggests-unit-own-subs.t` pins both halves and **passes unmodified under real raku**. This is the D7 property working as intended: the language server's requirements improving mutsu's own diagnostics rather than taxing them.

## Verification

- `make test` — 36657 tests, `Result: PASS`.
- The 47 whitelisted roast files mentioning undeclared symbols or "Did you mean" — 3272 tests, all pass on a release build. (This change alters mutsu's own error text, so a targeted sweep of its consumers ran before pushing.)
- `cargo test -p mutsu-lsp` — 22 tests; `cargo clippy -p mutsu-lsp --all-targets -- -D warnings` and `cargo clippy -- -D warnings` clean.
- `tests/long_lived_parse.rs` gains a gate on `analysis::check` itself — the entry point a resident server actually calls, and the one that would have caught the interpreter regression.

Next is **S3**: multiple diagnostics per document, which needs `parse_program_partial` to grow positions and errors. Today a document reports only its first parse failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)