### PR TITLE
feat: ADR-0065 S3 — keep analysing past the first parse error, on a stack that survives it

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -82,13 +82,14 @@ work; see the CLAUDE.md "mzef package manager and distribution" section. The **R
 - [ ] **Language server** — designed in [docs/adr/0065-language-server-targets-ai-agents.md](docs/adr/0065-language-server-targets-ai-agents.md)
       (an AI agent is the primary consumer, so only the methods an agent consumes are implemented,
       and "does mutsu support this?" is a first-class diagnostic). **S0 (viability gate), S1 (server
-      skeleton + diagnostics) and S2's routine half are done** — `crates/mutsu-lsp/`,
-      `src/analysis.rs`, [docs/language-server.md](docs/language-server.md). Next is **S3: multiple
-      diagnostics per document — give `parse_program_partial` positions and errors** (today a
-      document reports only its first parse failure). Then S4 (symbols/definition), S5
-      (references/hover). **S2's method half is deferred with a real design question**: `$x.foo`
-      needs the receiver type, which the AST does not carry, and the existing `(owner, name)`
-      catalog is conservative in the false-positive direction — see the ADR's S2 findings.
+      skeleton), S2's routine half and S3 (error recovery) are done** — `crates/mutsu-lsp/`,
+      `src/analysis.rs`, [docs/language-server.md](docs/language-server.md). Next is **S4:
+      `documentSymbol` / `workspaceSymbol` / `definition` at line granularity** — exact answers
+      where an agent would otherwise grep, and now usable mid-edit since S3 keeps analysing past
+      the first failure. Then S5 (references/hover, which needs per-occurrence spans). **S2's
+      method half is deferred with a real design question**: `$x.foo` needs the receiver type,
+      which the AST does not carry, and the existing `(owner, name)` catalog is conservative in
+      the false-positive direction — see the ADR's S2 findings.
 - [ ] Debugger.
 - [ ] Native binary output.
 

--- a/crates/mutsu-lsp/src/lib.rs
+++ b/crates/mutsu-lsp/src/lib.rs
@@ -13,3 +13,38 @@ pub mod diagnostics;
 pub mod documents;
 pub mod positions;
 pub mod server;
+
+/// The stack an analysis thread gets.
+///
+/// mutsu's parser is deeply recursive — grammar matching and nested expression
+/// parsing each consume a sizeable native frame — which is why the interpreter's
+/// own CLI (`src/main.rs`) does not run on the OS main thread either: it spawns
+/// a 256 MB-stack thread and runs everything there.
+///
+/// The server must do the same, and this is not a nicety. A stack overflow
+/// **aborts the process**; `catch_unwind` cannot turn it into a diagnostic the
+/// way `mutsu::analysis::check` turns a panic into one. A resident server that
+/// parses on a default 8 MB stack would die outright on a document the CLI reads
+/// without complaint, taking every other open document with it.
+pub const ANALYSIS_STACK_SIZE: usize = 256 * 1024 * 1024;
+
+/// Run `f` on a thread with [`ANALYSIS_STACK_SIZE`], propagating a panic.
+///
+/// The binary runs its whole protocol loop inside this, so every parse the
+/// session performs is on that stack; tests that analyse deep documents use it
+/// for the same reason.
+pub fn on_analysis_stack<F, R>(f: F) -> R
+where
+    F: FnOnce() -> R + Send + 'static,
+    R: Send + 'static,
+{
+    let handle = std::thread::Builder::new()
+        .name("mutsu-lsp-analysis".to_string())
+        .stack_size(ANALYSIS_STACK_SIZE)
+        .spawn(f)
+        .expect("failed to spawn the analysis thread");
+    match handle.join() {
+        Ok(value) => value,
+        Err(payload) => std::panic::resume_unwind(payload),
+    }
+}

--- a/crates/mutsu-lsp/src/main.rs
+++ b/crates/mutsu-lsp/src/main.rs
@@ -44,7 +44,9 @@ fn main() -> ExitCode {
     }
 
     let (connection, io_threads) = Connection::stdio();
-    let result = mutsu_lsp::server::run(connection);
+    // Not the OS main thread: mutsu's parser needs the same deep stack the
+    // interpreter's own CLI gives it. See `mutsu_lsp::ANALYSIS_STACK_SIZE`.
+    let result = mutsu_lsp::on_analysis_stack(move || mutsu_lsp::server::run(connection));
     // Join before reporting: the writer thread must finish flushing whatever
     // the loop queued, including the response to `shutdown`.
     let joined = io_threads.join();

--- a/crates/mutsu-lsp/tests/protocol.rs
+++ b/crates/mutsu-lsp/tests/protocol.rs
@@ -32,9 +32,14 @@ impl Client {
     /// Connect and complete the initialize handshake.
     fn start() -> Client {
         let (server_connection, client_connection) = Connection::memory();
-        let server = std::thread::spawn(move || {
-            mutsu_lsp::server::run(server_connection).map_err(|e| e.to_string())
-        });
+        // The same stack the binary gives the loop. mutsu's parser is deeply
+        // recursive enough that this is not a formality: on a default stack it
+        // overflows — and *aborts*, which no `catch_unwind` can rescue — on a
+        // document with about fifty nested parentheses.
+        let server = std::thread::Builder::new()
+            .stack_size(mutsu_lsp::ANALYSIS_STACK_SIZE)
+            .spawn(move || mutsu_lsp::server::run(server_connection).map_err(|e| e.to_string()))
+            .expect("spawn the server thread");
         let mut client = Client {
             connection: client_connection,
             server: Some(server),
@@ -293,6 +298,29 @@ fn diagnostic_columns_are_utf16_offsets() {
     client.shutdown();
 }
 
+/// ADR-0065 S3: a document under edit is broken most of the time, and a report
+/// that goes quiet after the first failure hides everything below it.
+#[test]
+fn every_failure_in_the_document_reaches_the_client() {
+    let client = Client::start();
+    let path = "file:///tmp/two-errors.raku";
+
+    let published = client.open(
+        path,
+        "say 1;\nsay $c.f (1, 2);\nsay 2;\nsay $d.g (3, 4);\nsay 3;\n",
+        1,
+    );
+    let lines: Vec<u32> = published
+        .diagnostics
+        .iter()
+        .filter(|d| d.severity == Some(DiagnosticSeverity::ERROR))
+        .map(|d| d.range.start.line)
+        .collect();
+    assert_eq!(lines, vec![1, 3], "{:#?}", published.diagnostics);
+
+    client.shutdown();
+}
+
 #[test]
 fn an_unimplemented_request_is_answered_rather_than_ignored() {
     let mut client = Client::start();
@@ -338,6 +366,40 @@ fn the_session_survives_a_document_that_breaks_the_parser() {
         "{:#?}",
         published.diagnostics
     );
+
+    client.shutdown();
+}
+
+/// A stack overflow aborts the process, so `mutsu::analysis::check`'s
+/// panic-catching cannot turn one into a diagnostic the way it does an ordinary
+/// panic. The server therefore runs on the same deep stack the interpreter's own
+/// CLI uses. Measured on a debug build: with an 8 MB stack this document
+/// overflows at about fifty nested parentheses; with the analysis stack a
+/// thousand are fine.
+///
+/// If the big stack is ever removed, this test does not fail politely — it
+/// aborts the test binary, which is exactly the visibility the defect deserves.
+#[test]
+fn a_deeply_nested_document_does_not_take_the_server_down() {
+    let client = Client::start();
+    let path = "file:///tmp/deep.raku";
+
+    let depth = 200;
+    let text = format!(
+        "my $x = {}1{};\nsay $x;\n",
+        "(".repeat(depth),
+        ")".repeat(depth)
+    );
+    let published = client.open(path, &text, 1);
+    assert!(
+        published.diagnostics.is_empty(),
+        "{depth} nested parentheses are valid Raku: {:#?}",
+        published.diagnostics
+    );
+
+    // Still serving afterwards.
+    let after = client.change(path, "say 1;\n", 2);
+    assert!(after.diagnostics.is_empty());
 
     client.shutdown();
 }

--- a/docs/adr/0065-language-server-targets-ai-agents.md
+++ b/docs/adr/0065-language-server-targets-ai-agents.md
@@ -417,6 +417,65 @@ routine you meant, which rakudo never does. Pinned by
 This is the D7 property in practice — the language server's requirements improving mutsu's
 own diagnostics rather than taxing them.
 
+## S3 findings (2026-09-03)
+
+### 1. The slice is better understood as "keep analysing past the first failure"
+
+Framed as "multiple diagnostics per document" this looks like a nicety: a document usually
+has one syntax error. The framing that matters is the other one — **a document under edit
+is broken most of the time**, and a report that goes quiet after the first failure hides
+everything below it. That also makes S3 a prerequisite for S4 being useful at all: symbols
+and definitions are wanted *while* the file is mid-edit, not only when it is complete.
+
+### 2. Recovery reuses the strict parser's diagnosis rather than a lower tier
+
+`parse_program`'s ~110-line failure-rendering block was extracted as `render_parse_error`,
+so a skipped statement is diagnosed to exactly the same standard as the first failure —
+typed `X::` message where an alternative diagnosed one, rakudo's `.pre`/`.post` context,
+the hint. Under D5 that matters more than the count: a second diagnostic of lower quality
+would be worse than no second diagnostic.
+
+This needed no offset arithmetic. A `PError`'s `remaining_len` measures the *shared
+buffer's* unconsumed tail, not an offset within whichever suffix the failing parser was
+called on, so a failure raised inside `statement(rest)` already locates itself in the whole
+source.
+
+### 3. Cascade risk was measured, not assumed, and is low
+
+Over the 217 files of `modules/`, 11 fail to parse, **2 report more than one failure**, for
+11 extra diagnostics. Inspecting those two: every extra points at a distinct real
+construct on its own line, not at debris from the previous skip. Recovery is deduplicated
+by line against what is already reported — the recovering pass re-parses from scratch, so
+its first failure is the strict parse's failure seen again, and a second failure on a line
+already accounted for is far more likely to be a cascade than a second defect. The tie is
+broken toward saying less.
+
+The undeclared-routine analysis deliberately does **not** run on a recovered parse. Its
+false-positive direction inverts there: a skipped statement may have held the very `sub`
+declaration that explains a later call. `stmt_list_partial`'s existing
+`note_partial_parse_skip` exists for exactly this class of consumer.
+
+### 4. The server was one deep document away from dying, and S1 shipped it that way
+
+The survey overflowed its stack before it produced a single number, which exposed a defect
+in S1: `mutsu-lsp` parsed on the OS main thread. mutsu's own CLI does not — `src/main.rs`
+spawns a 256 MB-stack thread because grammar matching and nested expression parsing are
+deeply recursive.
+
+Measured on a debug build: with an 8 MB stack, `my $x = ((( ... )))` **overflows at about
+fifty nested parentheses**; twenty are fine. With the analysis stack, a thousand are fine.
+Fifty is not exotic — a nested data literal reaches it.
+
+A stack overflow **aborts the process**. `analysis::check`'s `catch_unwind`, which turns a
+parser panic into a diagnostic (S1 finding 3), cannot rescue it, so the whole session would
+have died — every open document with it — on a file the CLI reads without complaint. The
+server now runs its loop inside `mutsu_lsp::on_analysis_stack`, and the protocol tests
+spawn their server the same way, so a regression aborts the test binary rather than passing
+quietly.
+
+The general lesson is worth stating: **any new front end for mutsu's parser inherits the
+CLI's stack requirement.** It is not a property of the CLI; it is a property of the parser.
+
 ## Rejected alternatives
 
 - **A lossless CST / red-green tree (rust-analyzer, rowan).** The correct architecture for
@@ -444,7 +503,7 @@ own diagnostics rather than taxing them.
 | **S0** | Long-lived-process viability probe (D8) — **done 2026-09-03**, `tests/long_lived_parse.rs` | — |
 | **S1** | Server skeleton, full-document reparse, diagnostics from the existing single-error path — **done 2026-09-03**, `crates/mutsu-lsp/`, `src/analysis.rs`, `docs/language-server.md` | S0 |
 | **S2** | Enumerable built-in name tables → "mutsu does not support this" diagnostics (D4) — **routine half done 2026-09-03**; the method half is blocked on receiver types, see the S2 findings | S1 |
-| **S3** | Multiple diagnostics per document + error recovery (give `parse_program_partial` positions and errors) | S1 |
+| **S3** | Multiple diagnostics per document + error recovery (give `parse_program_partial` positions and errors) — **done 2026-09-03** | S1 |
 | **S4** | `documentSymbol` / `workspaceSymbol` / `definition` at line granularity | S1 |
 | **S5** | `references` / `hover`; expression spans on the variants these require (D6) | S4 |
 

--- a/docs/language-server.md
+++ b/docs/language-server.md
@@ -60,9 +60,13 @@ learn mutsu's coverage short of running it (D4).
 
 Today the server reports:
 
-- **One parse error per document.** mutsu's parser stops at the first failure
-  and discards the partial result. Multiple diagnostics need
-  `parse_program_partial` to grow positions and errors first (S3).
+- **Every parse failure in the document.** mutsu's strict parser stops at the
+  first one, so the server reports that (its diagnosis is the richest available:
+  typed `X::` message, source context, hint) and then re-parses with recovery to
+  find what else is wrong. Recovered failures are rendered through the same code
+  path, so they are the same quality — and deduplicated by line, because the
+  recovering pass sees the first failure again and a repeat on an
+  already-reported line is more likely to be debris than a second defect.
 - **Parse warnings**, at line granularity — sink-context warnings, VCS conflict
   markers, and the rest of what the parser collects while reading a unit.
 - **Calls to routines mutsu does not have** (`code: "UndeclaredRoutine"`), with
@@ -136,7 +140,15 @@ which has no column, covers the whole line.
 The loop is synchronous and single-threaded on purpose: D3 leaves nothing
 latency-sensitive to overlap, and parsing on the loop thread keeps the parser's
 thread-local caches warm — the exact configuration the S0 probe validated for a
-long-lived process. `lsp-server` + `lsp-types` (rust-analyzer's crates) rather
+long-lived process.
+
+It is **not** the OS main thread, though. mutsu's parser is deeply recursive
+enough that on a default 8 MB stack it overflows at about fifty nested
+parentheses, and a stack overflow aborts the process — `catch_unwind` cannot turn
+that into a diagnostic the way it does an ordinary panic. The interpreter's own
+CLI spawns a 256 MB-stack thread for the same reason; the server runs its loop
+inside `mutsu_lsp::on_analysis_stack`. Any new front end for mutsu's parser
+inherits this requirement: it is a property of the parser, not of the CLI. `lsp-server` + `lsp-types` (rust-analyzer's crates) rather
 than `tower-lsp`, so no async runtime enters this repository at all.
 
 ## Why it lives in this repository

--- a/news/2026-09/adr0065-s3-parse-error-recovery.md
+++ b/news/2026-09/adr0065-s3-parse-error-recovery.md
@@ -1,0 +1,75 @@
+# The language server keeps analysing past the first error — and stops dying on deep documents
+
+ADR-0065 S3 was scheduled as "multiple diagnostics per document", which sounds
+like a nicety: a file usually has one syntax error. The framing that matters is
+the other one. **A document under edit is broken most of the time**, and a report
+that goes quiet after the first failure hides everything below it. That also
+makes this a prerequisite for S4: symbols and definitions are wanted *while* the
+file is mid-edit, not only once it is complete.
+
+## Recovery reuses the strict parser's diagnosis, not a lower tier
+
+`parse_program`'s failure-rendering block — the one that produces the typed `X::`
+message where an alternative diagnosed the input precisely, rakudo's
+`.pre`/`.post` source context, and the hint — was extracted as
+`render_parse_error`. A statement skipped by recovery is now diagnosed to exactly
+that standard. Under D5 that matters more than the count: a second diagnostic of
+lower quality would be worse than no second diagnostic.
+
+It needed no offset arithmetic, which was the pleasant surprise. A `PError`'s
+`remaining_len` measures the *shared buffer's* unconsumed tail rather than an
+offset within whichever suffix the failing parser was invoked on, so a failure
+raised inside `statement(rest)` already locates itself in the whole source.
+
+The strict parse still produces diagnostic #1 — it stops at the first failure,
+but its diagnosis of that failure is the richest available. Recovery then
+re-parses and contributes what comes after, deduplicated by line.
+
+## Cascade risk was measured rather than assumed
+
+The obvious hazard is that skipping a statement leaves the parser mid-construct
+and manufactures follow-on errors that are not real — the reason rakudo has a
+sorrows/worries model. Over the 217 files of `modules/`, 11 fail to parse, **2
+report more than one failure**, for 11 extra diagnostics. Inspecting those two:
+every extra points at a distinct real construct on its own line, not at debris
+from the previous skip.
+
+Deduplication by line handles the one systematic repeat: the recovering pass
+starts over, so its first failure is the strict parse's failure seen again. A
+second failure on a line already accounted for is far more likely to be cascade
+debris than a second defect, so the tie is broken toward saying less.
+
+The undeclared-routine analysis deliberately does *not* run on a recovered parse.
+Its false-positive direction inverts there — a skipped statement may have held
+the very `sub` declaration that explains a later call — and
+`stmt_list_partial`'s existing `note_partial_parse_skip` exists for exactly this
+class of consumer.
+
+## The survey overflowed its stack, which found a much worse bug
+
+Before producing a single number, the corpus survey died with `fatal runtime
+error: stack overflow`. That exposed a defect S1 had shipped: `mutsu-lsp` parsed
+on the OS main thread.
+
+mutsu's own CLI does not. `src/main.rs` spawns a 256 MB-stack thread because
+grammar matching and nested expression parsing are deeply recursive. Measured on
+a debug build with an 8 MB stack, `my $x = ((( … )))` **overflows at about fifty
+nested parentheses**; twenty are fine. With the analysis stack, a thousand are
+fine.
+
+Fifty nested parentheses is not exotic — a nested data literal reaches it. And a
+stack overflow *aborts the process*: `analysis::check`'s `catch_unwind`, which
+turns a parser panic into a diagnostic, cannot rescue one. The whole session
+would have died, every open document with it, on a file the CLI reads without
+complaint.
+
+The server now runs its loop inside `mutsu_lsp::on_analysis_stack`, and the
+protocol tests spawn their server the same way, so a regression aborts the test
+binary rather than passing quietly. The general lesson is worth stating plainly:
+**any new front end for mutsu's parser inherits the CLI's stack requirement.** It
+is a property of the parser, not of the CLI.
+
+That is twice now that building the language server has found something wrong
+with mutsu rather than merely consuming it — after S2's missing "Did you mean"
+suggestions for a unit's own routines. D7 predicted the core-layer work would not
+be an LSP-only tax; so far it has been the reverse.

--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -165,6 +165,42 @@ fn diagnostic_from_parse_error(err: &RuntimeError) -> Diagnostic {
     }
 }
 
+/// The failures a *recovering* parse finds beyond the ones already reported.
+///
+/// mutsu's strict parser stops at the first failure, which for an editor is the
+/// wrong shape: a document under edit is broken most of the time, and a report
+/// that goes quiet after line 3 hides everything below it.
+/// `parse_program_recovering` skips each unparseable statement and keeps going,
+/// rendering every skipped one through the same path the strict error takes —
+/// so the extra diagnostics are the same quality as the first, not a lower tier.
+///
+/// **Deduplicated by line against what is already reported.** The recovery pass
+/// re-parses from scratch, so its first failure is almost always the strict
+/// parse's failure seen again; and a statement skipped by recovery can leave the
+/// parser mid-construct, so a second failure on a line already accounted for is
+/// far more likely to be a cascade than a second real defect. Under D5 a
+/// plausible-looking wrong diagnostic is the expensive kind of mistake, so the
+/// tie is broken toward saying less.
+fn recovered_parse_errors(source: &str, already: &[Diagnostic]) -> Vec<Diagnostic> {
+    let recovered = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        crate::parser::parse_program_recovering(source)
+    }));
+    let Ok((_stmts, _finish, errors)) = recovered else {
+        return Vec::new();
+    };
+    let mut reported: Vec<u32> = already.iter().map(|d| d.line).collect();
+    let mut out = Vec::new();
+    for err in &errors {
+        let diagnostic = diagnostic_from_parse_error(err);
+        if reported.contains(&diagnostic.line) {
+            continue;
+        }
+        reported.push(diagnostic.line);
+        out.push(diagnostic);
+    }
+    out
+}
+
 /// Split the `"\n    at FILE:LINE"` suffix `add_parse_warning` bakes into every
 /// parse warning back into (message, line).
 ///
@@ -211,14 +247,23 @@ pub fn check(source: &str) -> Vec<Diagnostic> {
     // documents being analysed independently and a `use v6.e.PREVIEW` in the
     // first file silently changing how every later file is read.
     let parsed = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        let (stmts, _finish) = crate::parse_dispatch::parse_source(source)?;
-        Ok::<Option<Diagnostic>, RuntimeError>(undeclared_routine_diagnostic(&stmts))
+        match crate::parse_dispatch::parse_source(source) {
+            Ok((stmts, _finish)) => Ok(undeclared_routine_diagnostic(&stmts)),
+            Err(err) => Err(err),
+        }
     }));
 
     let mut diagnostics = Vec::new();
     match parsed {
         Ok(Ok(undeclared)) => diagnostics.extend(undeclared),
-        Ok(Err(err)) => diagnostics.push(diagnostic_from_parse_error(&err)),
+        Ok(Err(err)) => {
+            // The strict parse's diagnosis of the *first* failure is the best
+            // one available: it carries the typed `X::` message, the
+            // surrounding source context and the hint. Report it, then recover
+            // past it to find what else is wrong.
+            diagnostics.push(diagnostic_from_parse_error(&err));
+            diagnostics.extend(recovered_parse_errors(source, &diagnostics));
+        }
         Err(payload) => {
             // "mutsu cannot handle this" is the single most valuable thing this
             // server reports (D4), and a panic is its bluntest form. Say so
@@ -304,6 +349,47 @@ mod tests {
     fn warnings_do_not_leak_into_the_next_document() {
         check("my $x = 1;\n$x == 1;\n");
         assert_eq!(check("my $y = 2;\nsay $y;\n"), Vec::new());
+    }
+
+    fn errors(source: &str) -> Vec<Diagnostic> {
+        check(source)
+            .into_iter()
+            .filter(|d| d.severity == Severity::Error)
+            .collect()
+    }
+
+    /// ADR-0065 S3: mutsu's strict parser stops at the first failure, which for
+    /// a document under edit hides everything below it.
+    #[test]
+    fn a_second_failure_further_down_the_document_is_reported_too() {
+        let text = "say 1;\nsay $c.f (1, 2);\nsay 2;\nsay $d.g (3, 4);\nsay 3;\n";
+        let errors = errors(text);
+        assert_eq!(errors.len(), 2, "{errors:#?}");
+        assert_eq!(errors[0].line, 2);
+        assert_eq!(errors[1].line, 4);
+    }
+
+    /// The recovering pass re-parses from scratch, so its first failure is the
+    /// strict parse's failure seen again. Reporting it twice would be noise a
+    /// consumer has to learn to ignore.
+    #[test]
+    fn the_first_failure_is_not_reported_twice() {
+        let errors = errors("say 1;\nsay $c.f (1, 2);\nsay 2;\n");
+        assert_eq!(errors.len(), 1, "{errors:#?}");
+        assert_eq!(errors[0].line, 2);
+    }
+
+    /// The first diagnostic keeps the strict parser's own diagnosis, which is
+    /// the richest one available (typed `X::` message, source context, hint).
+    #[test]
+    fn the_first_diagnostic_is_still_the_strict_parsers_own() {
+        let errors = errors("my $x = 1;\n}\nsay $x;\n");
+        assert_eq!(errors[0].code, Some("ParseUnparsed"));
+        assert_eq!(
+            errors[0].column,
+            Some(1),
+            "the strict path knows the column"
+        );
     }
 
     /// ADR-0065 D4: "mutsu does not have this" is the diagnostic the server

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -110,6 +110,7 @@ pub(crate) fn with_user_sub_preseed<R>(names: Vec<String>, f: impl FnOnce() -> R
 use std::cell::RefCell;
 
 use crate::ast::Stmt;
+use crate::parser::parse_result::PError;
 use crate::value::RuntimeErrorCode;
 use crate::value::{RuntimeError, Value};
 
@@ -412,6 +413,136 @@ fn with_parse_hint(mut err: RuntimeError) -> RuntimeError {
     err
 }
 
+/// Render one parser failure into the `RuntimeError` every consumer sees: its
+/// position in `source`, the `X::`-typed message where one of the failed
+/// alternatives diagnosed the input precisely, rakudo's `.pre`/`.post` context,
+/// and a hint where the message shape admits one.
+///
+/// Extracted from [`parse_program`] so error *recovery* can render the failures
+/// it skips over to exactly the same standard (ADR-0065 S3). A `PError`'s
+/// `remaining_len` is the length of the unconsumed tail, which is a property of
+/// the shared buffer rather than of whichever suffix the failing parser was
+/// invoked on — so this renders a failure from a nested `statement(rest)` call
+/// against the whole `source` correctly, with no offset arithmetic at the call
+/// site.
+///
+/// The caller decides what a *fatal* diagnosis means; this only builds the
+/// error.
+fn render_parse_error(source: &str, e: PError) -> RuntimeError {
+    if e.is_fatal() {
+        // Fatal parse errors (e.g. bare say/print/put) pass through directly
+        let mut err = RuntimeError::new(format!("{}", e));
+        err.set_code(Some(RuntimeErrorCode::ParseGeneric));
+        // A fatal raised with `fatal_at` carries the failure position;
+        // surface it as line/column so the CLI/`is_run` render the
+        // ===SORRY!=== snippet with the offending line.
+        if let Some(consumed) = e.consumed_from(source.len()) {
+            let tail = &source[consumed..];
+            let near_offset = consumed + leading_ws_bytes(tail);
+            let (line_num, col_num) = line_col_at_offset(source, near_offset);
+            err.set_line(Some(line_num));
+            err.set_column(Some(col_num));
+        }
+        if let Some(ex) = e.exception {
+            // A fatal diagnosis's own exception (built far from here,
+            // e.g. `pod_begin_without_identifier_error`) usually carries
+            // only `message`. `err.set_line` above computed the real
+            // `line`/`column` from the failure position; without also
+            // copying them onto the exception's own attributes here,
+            // `$!.line`/`$!.column` (the actual X::Comp accessors, read
+            // straight from the instance) stayed unset even though the
+            // CLI's own `===SORRY!===` rendering (which reads `err`
+            // directly) already had them. Other X::Comp builders in this
+            // file (`build_vcs_conflict_error`, etc.) set `line` on their
+            // exception's attrs by hand at construction; this generalizes
+            // that for every site that instead relies on `remaining_len`.
+            if let crate::value::ValueView::Instance { attributes, .. } = ex.view() {
+                if let Some(line) = err.line() {
+                    attributes.insert_if_absent(
+                        "line".to_string(),
+                        crate::value::Value::int(line as i64),
+                    );
+                }
+                if let Some(column) = err.column() {
+                    attributes.insert_if_absent(
+                        "column".to_string(),
+                        crate::value::Value::int(column as i64),
+                    );
+                }
+            }
+            err.exception = Some(ex);
+        }
+        return err;
+    }
+    if let Some(consumed) = e.consumed_from(source.len()) {
+        let tail = &source[consumed..];
+        let near_offset = consumed + leading_ws_bytes(tail);
+        let (line_num, col_num) = line_col_at_offset(source, near_offset);
+        // One of the alternatives that failed here may have diagnosed the
+        // input precisely and named its Raku exception class in the
+        // `"X::Type: text"` convention (`X::Syntax::CannotMeta: Cannot do
+        // . because it is too fiddly`). Every message merged into a
+        // `PError` shares the same furthest failure position
+        // (`update_best_error` only merges at an equal score), so such a
+        // message describes *this* failure and is strictly better than
+        // the generic "Confused." wrapper — which would otherwise bury it
+        // inside an "expected A or B or …" list and leave the exception
+        // classed `X::Syntax::Confused`.
+        if let Some(typed) = e.typed_convention_message() {
+            let mut err = RuntimeError::with_location(
+                typed.to_string(),
+                RuntimeErrorCode::ParseExpected,
+                line_num,
+                col_num,
+            );
+            // A SOFT diagnosis may still carry a structured exception —
+            // the message convention preserves only the class, and some
+            // sites also need the attributes rakudo's exception has
+            // (`X::UnitScope::Invalid.what`). The fatal branch above
+            // already forwards it; without the same here, a
+            // `throws-like …, X::…, what => …` matched the class and
+            // then died on `No such method 'what'`.
+            if let Some(ex) = e.exception {
+                err.exception = Some(ex);
+            }
+            // rakudo's X::Comp family also carries `.pre`/`.post` (the
+            // source text immediately around the eject point, current
+            // line only). This is the one place both the full original
+            // source and the failure offset are unambiguously known, so
+            // compute it here rather than at each individual raise site.
+            let pre_full = &source[..consumed];
+            let pre = pre_full.rsplit('\n').next().unwrap_or(pre_full).to_string();
+            let post = tail.split('\n').next().unwrap_or(tail).to_string();
+            err.set_pre_post_context(pre, post);
+            with_parse_hint(err)
+        } else if let Some(context) = near_snippet(tail, 60) {
+            with_parse_hint(RuntimeError::with_location(
+                format!(
+                    "Confused. parse error at line {}, column {}: {} — near: {:?}",
+                    line_num, col_num, e, context
+                ),
+                RuntimeErrorCode::ParseExpected,
+                line_num,
+                col_num,
+            ))
+        } else {
+            with_parse_hint(RuntimeError::with_location(
+                format!(
+                    "Confused. parse error at line {}, column {}: {}",
+                    line_num, col_num, e
+                ),
+                RuntimeErrorCode::ParseExpected,
+                line_num,
+                col_num,
+            ))
+        }
+    } else {
+        let mut err = RuntimeError::new(format!("Confused. parse error: {}", e));
+        err.set_code(Some(RuntimeErrorCode::ParseGeneric));
+        with_parse_hint(err)
+    }
+}
+
 /// Parse a full program using the nom-based parser.
 /// Returns `(statements, Option<finish_content>)`.
 pub(crate) fn parse_program(input: &str) -> Result<(Vec<Stmt>, Option<String>), RuntimeError> {
@@ -490,118 +621,14 @@ pub(crate) fn parse_program(input: &str) -> Result<(Vec<Stmt>, Option<String>), 
             }
         }
         Err(e) => {
-            if e.is_fatal() {
-                // Fatal parse errors (e.g. bare say/print/put) pass through directly
-                let mut err = RuntimeError::new(format!("{}", e));
-                err.set_code(Some(RuntimeErrorCode::ParseGeneric));
-                // A fatal raised with `fatal_at` carries the failure position;
-                // surface it as line/column so the CLI/`is_run` render the
-                // ===SORRY!=== snippet with the offending line.
-                if let Some(consumed) = e.consumed_from(source.len()) {
-                    let tail = &source[consumed..];
-                    let near_offset = consumed + leading_ws_bytes(tail);
-                    let (line_num, col_num) = line_col_at_offset(source, near_offset);
-                    err.set_line(Some(line_num));
-                    err.set_column(Some(col_num));
-                }
-                if let Some(ex) = e.exception {
-                    // A fatal diagnosis's own exception (built far from here,
-                    // e.g. `pod_begin_without_identifier_error`) usually carries
-                    // only `message`. `err.set_line` above computed the real
-                    // `line`/`column` from the failure position; without also
-                    // copying them onto the exception's own attributes here,
-                    // `$!.line`/`$!.column` (the actual X::Comp accessors, read
-                    // straight from the instance) stayed unset even though the
-                    // CLI's own `===SORRY!===` rendering (which reads `err`
-                    // directly) already had them. Other X::Comp builders in this
-                    // file (`build_vcs_conflict_error`, etc.) set `line` on their
-                    // exception's attrs by hand at construction; this generalizes
-                    // that for every site that instead relies on `remaining_len`.
-                    if let crate::value::ValueView::Instance { attributes, .. } = ex.view() {
-                        if let Some(line) = err.line() {
-                            attributes.insert_if_absent(
-                                "line".to_string(),
-                                crate::value::Value::int(line as i64),
-                            );
-                        }
-                        if let Some(column) = err.column() {
-                            attributes.insert_if_absent(
-                                "column".to_string(),
-                                crate::value::Value::int(column as i64),
-                            );
-                        }
-                    }
-                    err.exception = Some(ex);
-                }
+            let fatal = e.is_fatal();
+            let err = render_parse_error(source, e);
+            if fatal {
+                // A fatal diagnosis is the answer outright: return before the
+                // VCS-conflict override below, as this arm always has.
                 return Err(err);
             }
-            if let Some(consumed) = e.consumed_from(source.len()) {
-                let tail = &source[consumed..];
-                let near_offset = consumed + leading_ws_bytes(tail);
-                let (line_num, col_num) = line_col_at_offset(source, near_offset);
-                // One of the alternatives that failed here may have diagnosed the
-                // input precisely and named its Raku exception class in the
-                // `"X::Type: text"` convention (`X::Syntax::CannotMeta: Cannot do
-                // . because it is too fiddly`). Every message merged into a
-                // `PError` shares the same furthest failure position
-                // (`update_best_error` only merges at an equal score), so such a
-                // message describes *this* failure and is strictly better than
-                // the generic "Confused." wrapper — which would otherwise bury it
-                // inside an "expected A or B or …" list and leave the exception
-                // classed `X::Syntax::Confused`.
-                if let Some(typed) = e.typed_convention_message() {
-                    let mut err = RuntimeError::with_location(
-                        typed.to_string(),
-                        RuntimeErrorCode::ParseExpected,
-                        line_num,
-                        col_num,
-                    );
-                    // A SOFT diagnosis may still carry a structured exception —
-                    // the message convention preserves only the class, and some
-                    // sites also need the attributes rakudo's exception has
-                    // (`X::UnitScope::Invalid.what`). The fatal branch above
-                    // already forwards it; without the same here, a
-                    // `throws-like …, X::…, what => …` matched the class and
-                    // then died on `No such method 'what'`.
-                    if let Some(ex) = e.exception {
-                        err.exception = Some(ex);
-                    }
-                    // rakudo's X::Comp family also carries `.pre`/`.post` (the
-                    // source text immediately around the eject point, current
-                    // line only). This is the one place both the full original
-                    // source and the failure offset are unambiguously known, so
-                    // compute it here rather than at each individual raise site.
-                    let pre_full = &source[..consumed];
-                    let pre = pre_full.rsplit('\n').next().unwrap_or(pre_full).to_string();
-                    let post = tail.split('\n').next().unwrap_or(tail).to_string();
-                    err.set_pre_post_context(pre, post);
-                    Err(with_parse_hint(err))
-                } else if let Some(context) = near_snippet(tail, 60) {
-                    Err(with_parse_hint(RuntimeError::with_location(
-                        format!(
-                            "Confused. parse error at line {}, column {}: {} — near: {:?}",
-                            line_num, col_num, e, context
-                        ),
-                        RuntimeErrorCode::ParseExpected,
-                        line_num,
-                        col_num,
-                    )))
-                } else {
-                    Err(with_parse_hint(RuntimeError::with_location(
-                        format!(
-                            "Confused. parse error at line {}, column {}: {}",
-                            line_num, col_num, e
-                        ),
-                        RuntimeErrorCode::ParseExpected,
-                        line_num,
-                        col_num,
-                    )))
-                }
-            } else {
-                let mut err = RuntimeError::new(format!("Confused. parse error: {}", e));
-                err.set_code(Some(RuntimeErrorCode::ParseGeneric));
-                Err(with_parse_hint(err))
-            }
+            Err(err)
         }
     };
 
@@ -702,10 +729,17 @@ pub(crate) fn parse_program_partial_with_operators(
     result
 }
 
-/// Best-effort parse: returns all statements that could be parsed before the
-/// first error.  Used for loading `.rakumod` modules that may contain syntax
-/// mutsu does not yet support.
-pub(crate) fn parse_program_partial(input: &str) -> (Vec<Stmt>, Option<String>) {
+/// Best-effort parse: keeps every statement that parsed, skips the ones that
+/// did not, and reports each skipped one as a rendered `RuntimeError`.
+///
+/// Used for loading `.rakumod` modules that may contain syntax mutsu does not
+/// yet support (which wants only the statements — see [`parse_program_partial`])
+/// and by the analysis frontend, which wants the errors too: a document being
+/// edited is broken most of the time, and everything downstream of the first
+/// failure is still worth analysing (ADR-0065 S3).
+pub(crate) fn parse_program_recovering(
+    input: &str,
+) -> (Vec<Stmt>, Option<String>, Vec<RuntimeError>) {
     let memo_enabled = parse_memo_enabled();
     if memo_enabled {
         expr::reset_expression_memo();
@@ -743,9 +777,21 @@ pub(crate) fn parse_program_partial(input: &str) -> (Vec<Stmt>, Option<String>) 
     } else {
         (input, None)
     };
-    let (stmts, _) = stmt::stmt_list_partial(source);
+    let (stmts, skipped) = stmt::stmt_list_partial(source);
+    let errors = skipped
+        .into_iter()
+        .map(|e| render_parse_error(source, e))
+        .collect();
     primary::restore_source_state(saved_source_state);
     stmt::simple::set_current_language_version(&saved_language_version);
+    (stmts, finish_content, errors)
+}
+
+/// Best-effort parse, keeping the statements that parsed and dropping the rest.
+/// See [`parse_program_recovering`] for the variant that also reports what it
+/// could not parse.
+pub(crate) fn parse_program_partial(input: &str) -> (Vec<Stmt>, Option<String>) {
+    let (stmts, finish_content, _errors) = parse_program_recovering(input);
     (stmts, finish_content)
 }
 

--- a/src/parser/stmt/stmtlist.rs
+++ b/src/parser/stmt/stmtlist.rs
@@ -6,6 +6,7 @@
 //! `mod.rs` at their original visibility.
 
 use super::*;
+use crate::parser::parse_result::PError;
 
 /// Parse a block: { stmts }
 /// Pushes/pops a lexical import scope so that `use` inside a block
@@ -58,8 +59,9 @@ pub(in crate::parser) fn stmt_list_with_lines_pub(input: &str) -> PResult<'_, Ve
 /// When a statement fails to parse, skip forward to the next statement
 /// boundary and continue parsing. Used by `load_module` so that
 /// partially-parseable `.rakumod` files still export their functions.
-pub(crate) fn stmt_list_partial(input: &str) -> (Vec<Stmt>, Option<String>) {
+pub(crate) fn stmt_list_partial(input: &str) -> (Vec<Stmt>, Vec<PError>) {
     let mut stmts = Vec::new();
+    let mut skipped = Vec::new();
     let mut rest = input;
     while let Ok((r, _)) = ws_bol(rest) {
         let r = consume_semicolons(r);
@@ -72,7 +74,7 @@ pub(crate) fn stmt_list_partial(input: &str) -> (Vec<Stmt>, Option<String>) {
                 stmts.push(stmt);
                 rest = r;
             }
-            Err(_) => {
+            Err(e) => {
                 // Skip to next statement boundary and continue. Whatever was
                 // skipped is missing from the result, declarations included, so
                 // record it: a consumer that reasons about what a source file
@@ -80,6 +82,13 @@ pub(crate) fn stmt_list_partial(input: &str) -> (Vec<Stmt>, Option<String>) {
                 // `when`-matcher gobbled-block check) must know its view is
                 // partial rather than exhaustive.
                 note_partial_parse_skip();
+                // The failure itself is kept too, for the consumer that wants to
+                // *report* what could not be parsed rather than merely know that
+                // something could not be (ADR-0065 S3). A `PError`'s
+                // `remaining_len` measures the shared buffer's unconsumed tail,
+                // so each one still locates itself in the whole source with no
+                // offset bookkeeping here.
+                skipped.push(e);
                 match skip_to_next_statement(r) {
                     Some(next) => rest = next,
                     None => break,
@@ -87,7 +96,7 @@ pub(crate) fn stmt_list_partial(input: &str) -> (Vec<Stmt>, Option<String>) {
             }
         }
     }
-    (stmts, None)
+    (stmts, skipped)
 }
 
 thread_local! {


### PR DESCRIPTION
S3 was scheduled as "multiple diagnostics per document", which reads like a nicety — a file usually has one syntax error. **The framing that matters is the other one: a document under edit is broken most of the time**, and a report that goes quiet after the first failure hides everything below it. That also makes this a prerequisite for S4, since symbols and definitions are wanted *while* the file is mid-edit.

## Recovered failures are diagnosed to the strict parser's standard, not a lower tier

`parse_program`'s failure-rendering block — typed `X::` message where an alternative diagnosed the input precisely, rakudo's `.pre`/`.post` source context, the hint — is extracted as `render_parse_error` and reused for every statement recovery skips. Under D5 that matters more than the count: a second diagnostic of lower quality would be worse than no second diagnostic.

It needed no offset arithmetic, which was the pleasant surprise. A `PError`'s `remaining_len` measures the **shared buffer's** unconsumed tail rather than an offset within whichever suffix the failing parser was invoked on, so a failure raised inside `statement(rest)` already locates itself in the whole source.

The strict parse still produces diagnostic #1 (its diagnosis of the first failure is the richest available); recovery contributes what comes after.

## Cascade risk was measured, not assumed

The obvious hazard is that skipping a statement leaves the parser mid-construct and manufactures follow-on errors — the reason rakudo has a sorrows/worries model. Over the **217 files of `modules/`: 11 fail to parse, 2 report more than one failure, 11 extra diagnostics**. Inspecting those two, every extra points at a distinct real construct on its own line, not at debris from the previous skip.

Deduplication by line handles the one systematic repeat: the recovering pass starts over, so its first failure is the strict parse's failure seen again. A second failure on an already-reported line is more likely to be cascade debris than a second defect, so the tie is broken toward saying less.

The undeclared-routine analysis deliberately does **not** run on a recovered parse — its false-positive direction inverts there, because a skipped statement may have held the very `sub` declaration that explains a later call. `stmt_list_partial`'s existing `note_partial_parse_skip` exists for exactly this class of consumer.

## The survey overflowed its stack, which found a much worse bug

Before producing a single number, the corpus survey died with `fatal runtime error: stack overflow`. That exposed a defect **S1 had shipped**: `mutsu-lsp` parsed on the OS main thread. mutsu's own CLI does not — `src/main.rs` spawns a 256 MB-stack thread because grammar matching and nested expression parsing are deeply recursive.

Measured on a debug build:

| stack | `my $x = ((( … )))` |
| --- | --- |
| 8 MB (default) | 20 nested parens fine, **~50 aborts** |
| `ANALYSIS_STACK_SIZE` (256 MB) | 1000 fine |

Fifty nested parentheses is not exotic — a nested data literal reaches it. And a stack overflow **aborts the process**: `analysis::check`'s `catch_unwind`, which turns a parser panic into a diagnostic (S1), cannot rescue one. The whole session would have died, every open document with it, on a file the CLI reads without complaint.

The server now runs its loop inside `mutsu_lsp::on_analysis_stack`, and the protocol tests spawn their server the same way — so a regression aborts the test binary rather than passing quietly. The general lesson: **any new front end for mutsu's parser inherits the CLI's stack requirement.** It is a property of the parser, not of the CLI.

That is twice that building the server has found something wrong with mutsu rather than merely consuming it, after S2's missing "Did you mean" suggestions. D7 predicted the core-layer work would not be an LSP-only tax; so far it has been the reverse.

## Verification

- `make test` — 36657 tests, `Result: PASS`.
- **206 whitelisted roast files** exercising parse errors, `X::Syntax`/`X::Comp` or `EVAL` — 16395 tests, all pass on a release build. The `render_parse_error` extraction touches every parse error mutsu emits, so it warrants a sweep wider than the change's own tests.
- `cargo test -p mutsu-lsp` — 24 tests, including an end-to-end test that two failures in one document reach the client, and one that a 200-deep nested document does not take the server down.
- `cargo clippy -- -D warnings`, `cargo clippy -p mutsu-lsp --all-targets -- -D warnings`, `cargo fmt --all -- --check` clean.

Next is **S4**: `documentSymbol` / `workspaceSymbol` / `definition` at line granularity — exact answers where an agent would otherwise grep, and usable mid-edit now that analysis survives the first failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)