### PR TITLE
feat: ADR-0065 S4 — symbols and go-to-definition, without adding a position to the AST

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -82,14 +82,13 @@ work; see the CLAUDE.md "mzef package manager and distribution" section. The **R
 - [ ] **Language server** — designed in [docs/adr/0065-language-server-targets-ai-agents.md](docs/adr/0065-language-server-targets-ai-agents.md)
       (an AI agent is the primary consumer, so only the methods an agent consumes are implemented,
       and "does mutsu support this?" is a first-class diagnostic). **S0 (viability gate), S1 (server
-      skeleton), S2's routine half and S3 (error recovery) are done** — `crates/mutsu-lsp/`,
-      `src/analysis.rs`, [docs/language-server.md](docs/language-server.md). Next is **S4:
-      `documentSymbol` / `workspaceSymbol` / `definition` at line granularity** — exact answers
-      where an agent would otherwise grep, and now usable mid-edit since S3 keeps analysing past
-      the first failure. Then S5 (references/hover, which needs per-occurrence spans). **S2's
-      method half is deferred with a real design question**: `$x.foo` needs the receiver type,
-      which the AST does not carry, and the existing `(owner, name)` catalog is conservative in
-      the false-positive direction — see the ADR's S2 findings.
+      skeleton), S2's routine half, S3 (error recovery) and S4 (symbols/definition) are done** — `crates/mutsu-lsp/`,
+      `src/analysis/`, [docs/language-server.md](docs/language-server.md). Next is **S5:
+      `references` and `hover`** — `references` is the first method that genuinely needs
+      per-occurrence positions, since a line may hold several and text scanning cannot rank them
+      soundly. **S2's method half is deferred with a real design question**: `$x.foo` needs the
+      receiver type, which the AST does not carry, and the existing `(owner, name)` catalog is
+      conservative in the false-positive direction — see the ADR's S2 findings.
 - [ ] Debugger.
 - [ ] Native binary output.
 

--- a/crates/mutsu-lsp/src/lib.rs
+++ b/crates/mutsu-lsp/src/lib.rs
@@ -13,6 +13,8 @@ pub mod diagnostics;
 pub mod documents;
 pub mod positions;
 pub mod server;
+pub mod symbols;
+pub mod workspace;
 
 /// The stack an analysis thread gets.
 ///

--- a/crates/mutsu-lsp/src/positions.rs
+++ b/crates/mutsu-lsp/src/positions.rs
@@ -82,6 +82,144 @@ pub fn diagnostic_range(text: &str, line_1based: u32, column_1based: Option<u32>
     }
 }
 
+/// The full range of one 1-based line.
+pub fn line_range(text: &str, line_1based: u32) -> Range {
+    let (line, line_index) = line_text(text, line_1based);
+    Range {
+        start: Position {
+            line: line_index,
+            character: 0,
+        },
+        end: Position {
+            line: line_index,
+            character: utf16_offset(line, line.chars().count() as u32),
+        },
+    }
+}
+
+/// The range from the start of `first_line` to the end of `last_line`.
+pub fn span(text: &str, first_line: u32, last_line: u32) -> Range {
+    Range {
+        start: line_range(text, first_line).start,
+        end: line_range(text, last_line.max(first_line)).end,
+    }
+}
+
+/// Where `name` appears on `line_1based`, or the whole line when it does not.
+///
+/// LSP wants a declaration's `selectionRange` to cover the *name*, which is
+/// where "go to symbol" puts the caret. mutsu's AST cannot say where the name
+/// is — it has no positions (D6) — but the declaration line is short and the
+/// name is a literal, so finding it in the text is both cheap and exact. The
+/// match must be on an identifier boundary, or `has $.x` would select the `x`
+/// inside `max`.
+pub fn name_range(text: &str, line_1based: u32, name: &str) -> Range {
+    let (line, line_index) = line_text(text, line_1based);
+    if let Some(start_byte) = identifier_occurrence(line, name) {
+        let start = utf16_offset(line, line[..start_byte].chars().count() as u32);
+        let end = start + name.chars().map(|c| c.len_utf16() as u32).sum::<u32>();
+        return Range {
+            start: Position {
+                line: line_index,
+                character: start,
+            },
+            end: Position {
+                line: line_index,
+                character: end,
+            },
+        };
+    }
+    line_range(text, line_1based)
+}
+
+/// Byte offset of `name` in `line` as a whole identifier, if present.
+fn identifier_occurrence(line: &str, name: &str) -> Option<usize> {
+    if name.is_empty() {
+        return None;
+    }
+    let mut from = 0;
+    while let Some(found) = line[from..].find(name) {
+        let start = from + found;
+        let end = start + name.len();
+        let before_ok = line[..start]
+            .chars()
+            .next_back()
+            .is_none_or(|c| !is_identifier_char(c));
+        let after_ok = line[end..]
+            .chars()
+            .next()
+            .is_none_or(|c| !is_identifier_char(c));
+        if before_ok && after_ok {
+            return Some(start);
+        }
+        from = start + name.chars().next().map_or(1, char::len_utf8);
+    }
+    None
+}
+
+fn is_identifier_char(c: char) -> bool {
+    c.is_alphanumeric() || c == '_'
+}
+
+/// The Raku identifier under `position`, if there is one.
+///
+/// `definition` needs to know what the caret is on, and mutsu's AST cannot say:
+/// it has no positions for *references*, only the `Stmt::SetLine` markers that
+/// place declarations (D6). Reading the identifier straight out of the document
+/// text sidesteps that entirely — the server has the text, and an identifier is
+/// a lexical notion that needs no parse.
+///
+/// Hyphens and apostrophes are identifier characters in Raku (`is-prime`,
+/// `don't`), but only between alphanumerics, so a trailing `-` in `$x-` is not
+/// taken.
+pub fn identifier_at(text: &str, position: Position) -> Option<String> {
+    let line = text.split('\n').nth(position.line as usize)?;
+    // LSP characters are UTF-16 code units; walk the line accumulating them to
+    // find the byte offset the caret is at.
+    let mut byte = line.len();
+    let mut units = 0u32;
+    for (offset, c) in line.char_indices() {
+        if units >= position.character {
+            byte = offset;
+            break;
+        }
+        units += c.len_utf16() as u32;
+    }
+    if units < position.character {
+        byte = line.len();
+    }
+
+    let bytes_start = line[..byte]
+        .char_indices()
+        .rev()
+        .take_while(|(i, c)| is_identifier_char(*c) || is_infix_identifier_char(line, *i, *c))
+        .map(|(i, _)| i)
+        .last()
+        .unwrap_or(byte);
+    let mut end = byte;
+    for (i, c) in line[byte..].char_indices() {
+        let absolute = byte + i;
+        if is_identifier_char(c) || is_infix_identifier_char(line, absolute, c) {
+            end = absolute + c.len_utf8();
+        } else {
+            break;
+        }
+    }
+    let word = &line[bytes_start..end];
+    let word = word.trim_matches(|c| !is_identifier_char(c));
+    (!word.is_empty()).then(|| word.to_string())
+}
+
+/// `-` and `'` join an identifier only when they sit between two alphanumerics.
+fn is_infix_identifier_char(line: &str, offset: usize, c: char) -> bool {
+    if c != '-' && c != '\'' {
+        return false;
+    }
+    let before = line[..offset].chars().next_back();
+    let after = line[offset + c.len_utf8()..].chars().next();
+    matches!((before, after), (Some(b), Some(a)) if is_identifier_char(b) && is_identifier_char(a))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -190,5 +328,117 @@ mod tests {
         let r = diagnostic_range("\n\n", 2, Some(1));
         assert_eq!(r.start, r.end);
         assert_eq!(r.start.line, 1);
+    }
+
+    #[test]
+    fn a_name_range_covers_just_the_name() {
+        let text = "class Foo {\n    method bar() { 1 }\n}\n";
+        let r = name_range(text, 2, "bar");
+        assert_eq!(
+            r.start,
+            Position {
+                line: 1,
+                character: 11
+            }
+        );
+        assert_eq!(
+            r.end,
+            Position {
+                line: 1,
+                character: 14
+            }
+        );
+    }
+
+    #[test]
+    fn a_name_range_does_not_match_inside_a_longer_word() {
+        // `x` must not select the `x` inside `max`.
+        let text = "my $max = 1;\nhas $.x;\n";
+        let r = name_range(text, 2, "x");
+        assert_eq!(r.start.character, 6, "the attribute's own x");
+    }
+
+    #[test]
+    fn a_name_that_is_not_on_the_line_falls_back_to_the_whole_line() {
+        let r = name_range("say 1;\n", 1, "elsewhere");
+        assert_eq!(r, line_range("say 1;\n", 1));
+    }
+
+    #[test]
+    fn the_identifier_under_the_caret_is_read_from_the_text() {
+        let text = "say frobnicate(1);\n";
+        let at = |ch| {
+            identifier_at(
+                text,
+                Position {
+                    line: 0,
+                    character: ch,
+                },
+            )
+        };
+        assert_eq!(at(4).as_deref(), Some("frobnicate"));
+        assert_eq!(at(9).as_deref(), Some("frobnicate"));
+        assert_eq!(at(1).as_deref(), Some("say"));
+    }
+
+    #[test]
+    fn a_hyphenated_identifier_is_one_word() {
+        let text = "say is-prime(7);\n";
+        assert_eq!(
+            identifier_at(
+                text,
+                Position {
+                    line: 0,
+                    character: 6
+                }
+            )
+            .as_deref(),
+            Some("is-prime")
+        );
+    }
+
+    #[test]
+    fn a_caret_on_punctuation_yields_nothing() {
+        assert_eq!(
+            identifier_at(
+                "  ;\n",
+                Position {
+                    line: 0,
+                    character: 2
+                }
+            ),
+            None
+        );
+        assert_eq!(
+            identifier_at(
+                "say 1;\n",
+                Position {
+                    line: 9,
+                    character: 0
+                }
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn the_caret_position_is_utf16_when_reading_an_identifier() {
+        let text = "my $s = '🐪🐪'; say frobnicate(1);\n";
+        // `frobnicate` starts after the camels: 4 UTF-16 units for two camels.
+        let camel_units: u32 = "my $s = '🐪🐪'; say "
+            .chars()
+            .map(|c| c.len_utf16() as u32)
+            .sum();
+        assert_eq!(
+            identifier_at(
+                text,
+                Position {
+                    line: 0,
+                    character: camel_units + 2
+                }
+            )
+            .as_deref(),
+            Some("frobnicate")
+        );
     }
 }

--- a/crates/mutsu-lsp/src/server.rs
+++ b/crates/mutsu-lsp/src/server.rs
@@ -10,18 +10,24 @@
 
 use std::error::Error;
 
-use lsp_server::{Connection, ErrorCode, Message, Notification, Response};
+use lsp_server::{Connection, ErrorCode, Message, Notification, Request, Response};
 use lsp_types::notification::{
     DidChangeTextDocument, DidCloseTextDocument, DidOpenTextDocument,
     Notification as NotificationTrait, PublishDiagnostics,
 };
+use lsp_types::request::{
+    DocumentSymbolRequest, GotoDefinition, Request as RequestTrait, WorkspaceSymbolRequest,
+};
 use lsp_types::{
-    PositionEncodingKind, PublishDiagnosticsParams, ServerCapabilities, TextDocumentSyncCapability,
-    TextDocumentSyncKind, TextDocumentSyncOptions, Uri,
+    DocumentSymbolResponse, GotoDefinitionResponse, Location, OneOf, PositionEncodingKind,
+    PublishDiagnosticsParams, ServerCapabilities, SymbolInformation, TextDocumentSyncCapability,
+    TextDocumentSyncKind, TextDocumentSyncOptions, Uri, WorkspaceSymbolResponse,
 };
 
 use crate::diagnostics::diagnostics_for;
 use crate::documents::Documents;
+use crate::symbols;
+use crate::workspace::Workspace;
 
 pub type BoxError = Box<dyn Error + Send + Sync>;
 
@@ -45,6 +51,9 @@ pub fn server_capabilities() -> ServerCapabilities {
                 ..Default::default()
             },
         )),
+        document_symbol_provider: Some(OneOf::Left(true)),
+        workspace_symbol_provider: Some(OneOf::Left(true)),
+        definition_provider: Some(OneOf::Left(true)),
         ..Default::default()
     }
 }
@@ -52,25 +61,18 @@ pub fn server_capabilities() -> ServerCapabilities {
 /// Serve one client to completion over `connection`.
 pub fn run(connection: Connection) -> Result<(), BoxError> {
     let capabilities = serde_json::to_value(server_capabilities())?;
-    let _initialize_params = connection.initialize(capabilities)?;
+    let initialize_params = connection.initialize(capabilities)?;
 
     let mut documents = Documents::default();
+    let mut workspace = Workspace::from_initialize_params(&initialize_params);
     for message in &connection.receiver {
         match message {
             Message::Request(request) => {
                 if connection.handle_shutdown(&request)? {
                     return Ok(());
                 }
-                // Nothing else is implemented yet (S1). Answering
-                // MethodNotFound is the honest reply, and better than silence:
-                // a client that waits forever for a response it will never get
-                // is a worse failure than one told plainly it asked for
-                // something this server does not do.
-                connection.sender.send(Message::Response(Response::new_err(
-                    request.id,
-                    ErrorCode::MethodNotFound as i32,
-                    format!("mutsu-lsp does not implement {}", request.method),
-                )))?;
+                let response = handle_request(&documents, &mut workspace, request);
+                connection.sender.send(Message::Response(response))?;
             }
             Message::Response(_) => {}
             Message::Notification(notification) => {
@@ -86,6 +88,128 @@ pub fn run(connection: Connection) -> Result<(), BoxError> {
         }
     }
     Ok(())
+}
+
+/// Answer one request.
+///
+/// A method this server does not implement is answered with `MethodNotFound`
+/// rather than ignored: a client waiting forever for a response it will never
+/// get is a worse failure than one told plainly.
+fn handle_request(documents: &Documents, workspace: &mut Workspace, request: Request) -> Response {
+    let id = request.id.clone();
+    let result = match request.method.as_str() {
+        DocumentSymbolRequest::METHOD => document_symbol(documents, request),
+        WorkspaceSymbolRequest::METHOD => workspace_symbol(workspace, request),
+        GotoDefinition::METHOD => definition(documents, workspace, request),
+        method => {
+            return Response::new_err(
+                id,
+                ErrorCode::MethodNotFound as i32,
+                format!("mutsu-lsp does not implement {method}"),
+            );
+        }
+    };
+    match result {
+        Ok(value) => Response::new_ok(id, value),
+        // Malformed params are the client's bug. Reporting `InvalidParams`
+        // keeps the session going, where a hard error would end it.
+        Err(e) => Response::new_err(id, ErrorCode::InvalidParams as i32, e.to_string()),
+    }
+}
+
+fn document_symbol(documents: &Documents, request: Request) -> Result<serde_json::Value, BoxError> {
+    let params: lsp_types::DocumentSymbolParams = serde_json::from_value(request.params)?;
+    let outline = documents
+        .get(&params.text_document.uri)
+        .map(|doc| symbols::document_symbols(&doc.text))
+        .unwrap_or_default();
+    Ok(serde_json::to_value(DocumentSymbolResponse::Nested(
+        outline,
+    ))?)
+}
+
+fn workspace_symbol(
+    workspace: &mut Workspace,
+    request: Request,
+) -> Result<serde_json::Value, BoxError> {
+    let params: lsp_types::WorkspaceSymbolParams = serde_json::from_value(request.params)?;
+    let mut found = Vec::new();
+    for path in workspace.files() {
+        let Some(uri) = uri_of_path(&path) else {
+            continue;
+        };
+        let Some(text) = workspace.text_of(&path) else {
+            continue;
+        };
+        for (symbol, container, range) in symbols::flat_symbols(text) {
+            if !symbols::matches_query(&symbol.name, &params.query) {
+                continue;
+            }
+            #[allow(deprecated)] // `SymbolInformation::deprecated` is not optional
+            found.push(SymbolInformation {
+                name: symbol.name,
+                kind: symbols::lsp_kind(symbol.kind),
+                tags: None,
+                deprecated: None,
+                location: Location {
+                    uri: uri.clone(),
+                    range,
+                },
+                container_name: container,
+            });
+        }
+    }
+    Ok(serde_json::to_value(WorkspaceSymbolResponse::Flat(found))?)
+}
+
+fn definition(
+    documents: &Documents,
+    workspace: &mut Workspace,
+    request: Request,
+) -> Result<serde_json::Value, BoxError> {
+    let params: lsp_types::GotoDefinitionParams = serde_json::from_value(request.params)?;
+    let uri = params.text_document_position_params.text_document.uri;
+    let position = params.text_document_position_params.position;
+    let Some(document) = documents.get(&uri) else {
+        return Ok(serde_json::Value::Null);
+    };
+    // What the caret is on comes from the document text, not the AST: mutsu has
+    // positions for declarations (the `SetLine` markers) but none for
+    // references, and an identifier is a lexical notion that needs no parse.
+    let Some(name) = crate::positions::identifier_at(&document.text, position) else {
+        return Ok(serde_json::Value::Null);
+    };
+
+    // The open document first: a definition in the file being edited is both the
+    // likeliest answer and the freshest, since the workspace copy on disk may be
+    // older than what the client is holding.
+    if let Some(location) = symbols::definition_in(&uri, &document.text, &name) {
+        return Ok(serde_json::to_value(GotoDefinitionResponse::Scalar(
+            location,
+        ))?);
+    }
+    for path in workspace.files() {
+        let Some(file_uri) = uri_of_path(&path) else {
+            continue;
+        };
+        if file_uri == uri {
+            continue;
+        }
+        let Some(text) = workspace.text_of(&path) else {
+            continue;
+        };
+        if let Some(location) = symbols::definition_in(&file_uri, text, &name) {
+            return Ok(serde_json::to_value(GotoDefinitionResponse::Scalar(
+                location,
+            ))?);
+        }
+    }
+    Ok(serde_json::Value::Null)
+}
+
+fn uri_of_path(path: &std::path::Path) -> Option<Uri> {
+    use std::str::FromStr;
+    Uri::from_str(&format!("file://{}", path.to_str()?)).ok()
 }
 
 fn handle_notification(

--- a/crates/mutsu-lsp/src/symbols.rs
+++ b/crates/mutsu-lsp/src/symbols.rs
@@ -1,0 +1,231 @@
+//! Turning mutsu's declarations into LSP symbols (ADR-0065 S4).
+
+use lsp_types::{DocumentSymbol, Location, Position, Range, SymbolKind, Uri};
+use mutsu::analysis::{self, Symbol};
+
+use crate::positions::{name_range, span};
+
+/// The nearest LSP kind for one of mutsu's.
+///
+/// LSP's vocabulary predates Raku and has no spelling for a role, a grammar
+/// token or a subset, so several of these are approximations. They are chosen
+/// for what a client *does* with them — pick an icon, group an outline — rather
+/// than for taxonomy: a role behaves like an interface, a grammar token like a
+/// function, a subset like a type alias.
+pub fn lsp_kind(kind: analysis::SymbolKind) -> SymbolKind {
+    use analysis::SymbolKind as K;
+    match kind {
+        K::Module => SymbolKind::MODULE,
+        K::Package => SymbolKind::NAMESPACE,
+        K::Class => SymbolKind::CLASS,
+        K::Grammar => SymbolKind::CLASS,
+        K::Role => SymbolKind::INTERFACE,
+        K::Subset => SymbolKind::TYPE_PARAMETER,
+        K::Enum => SymbolKind::ENUM,
+        K::EnumMember => SymbolKind::ENUM_MEMBER,
+        K::Sub => SymbolKind::FUNCTION,
+        K::Method | K::PrivateMethod => SymbolKind::METHOD,
+        K::Token | K::Rule => SymbolKind::FUNCTION,
+        K::Attribute => SymbolKind::FIELD,
+        K::Variable => SymbolKind::VARIABLE,
+    }
+}
+
+/// The Raku declarator, shown as the symbol's `detail`.
+///
+/// This is where the information LSP's kind cannot carry goes: an outline that
+/// says `INTERFACE` for a role and `CLASS` for a grammar has lost exactly the
+/// distinction a Raku reader wants, and `detail` puts it back.
+fn declarator(kind: analysis::SymbolKind) -> &'static str {
+    use analysis::SymbolKind as K;
+    match kind {
+        K::Module => "module",
+        K::Package => "package",
+        K::Class => "class",
+        K::Grammar => "grammar",
+        K::Role => "role",
+        K::Subset => "subset",
+        K::Enum => "enum",
+        K::EnumMember => "enum value",
+        K::Sub => "sub",
+        K::Method => "method",
+        K::PrivateMethod => "private method",
+        K::Token => "token",
+        K::Rule => "rule",
+        K::Attribute => "has",
+        K::Variable => "variable",
+    }
+}
+
+/// The outline of one document.
+pub fn document_symbols(text: &str) -> Vec<DocumentSymbol> {
+    analysis::symbols(text)
+        .iter()
+        .map(|s| to_document_symbol(text, s))
+        .collect()
+}
+
+fn to_document_symbol(text: &str, symbol: &Symbol) -> DocumentSymbol {
+    let full = span(text, symbol.line, symbol.end_line);
+    let selection = name_range(text, symbol.line, &symbol.name);
+    #[allow(deprecated)] // `DocumentSymbol::deprecated` is deprecated but not optional
+    DocumentSymbol {
+        name: symbol.name.clone(),
+        detail: Some(declarator(symbol.kind).to_string()),
+        kind: lsp_kind(symbol.kind),
+        tags: None,
+        deprecated: None,
+        // The selection range must be inside the full range, and a declaration
+        // whose body is empty has both on one line, so widen rather than risk a
+        // client rejecting the pair.
+        range: contain(full, selection),
+        selection_range: selection,
+        children: Some(
+            symbol
+                .children
+                .iter()
+                .map(|c| to_document_symbol(text, c))
+                .collect(),
+        ),
+    }
+}
+
+/// The smallest range containing both.
+fn contain(a: Range, b: Range) -> Range {
+    Range {
+        start: min_position(a.start, b.start),
+        end: max_position(a.end, b.end),
+    }
+}
+
+fn min_position(a: Position, b: Position) -> Position {
+    if (a.line, a.character) <= (b.line, b.character) {
+        a
+    } else {
+        b
+    }
+}
+
+fn max_position(a: Position, b: Position) -> Position {
+    if (a.line, a.character) >= (b.line, b.character) {
+        a
+    } else {
+        b
+    }
+}
+
+/// Where `name` is declared in `text`, if it is.
+pub fn definition_in(uri: &Uri, text: &str, name: &str) -> Option<Location> {
+    let symbol = analysis::symbols::find(&analysis::symbols(text), name)?;
+    Some(Location {
+        uri: uri.clone(),
+        range: name_range(text, symbol.line, &symbol.name),
+    })
+}
+
+/// Every declaration in `text`, flat, with its container — the shape
+/// `workspaceSymbol` wants.
+pub fn flat_symbols(text: &str) -> Vec<(Symbol, Option<String>, Range)> {
+    analysis::symbols::flatten(&analysis::symbols(text))
+        .into_iter()
+        .map(|(symbol, container)| {
+            let range = name_range(text, symbol.line, &symbol.name);
+            (symbol, container, range)
+        })
+        .collect()
+}
+
+/// Whether `name` matches `query` the way a workspace-symbol picker does:
+/// case-insensitive substring. LSP leaves the matching rule to the server, and
+/// an agent typing an exact name gets an exact hit either way.
+pub fn matches_query(name: &str, query: &str) -> bool {
+    query.is_empty() || name.to_lowercase().contains(&query.to_lowercase())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SOURCE: &str = "\
+class Foo {
+    has $.x;
+    method bar($y) { $y }
+}
+sub baz() { 1 }
+";
+
+    #[test]
+    fn the_outline_nests_a_class_body_under_the_class() {
+        let outline = document_symbols(SOURCE);
+        assert_eq!(outline.len(), 2, "{outline:#?}");
+        assert_eq!(outline[0].name, "Foo");
+        assert_eq!(outline[0].kind, SymbolKind::CLASS);
+        assert_eq!(outline[0].detail.as_deref(), Some("class"));
+        let children = outline[0].children.as_ref().expect("children");
+        assert_eq!(children.len(), 2);
+        assert_eq!(children[0].name, "x");
+        assert_eq!(children[0].kind, SymbolKind::FIELD);
+        assert_eq!(children[1].name, "bar");
+        assert_eq!(children[1].kind, SymbolKind::METHOD);
+        assert_eq!(outline[1].name, "baz");
+        assert_eq!(outline[1].kind, SymbolKind::FUNCTION);
+    }
+
+    #[test]
+    fn the_selection_range_covers_the_name_and_sits_inside_the_full_range() {
+        let outline = document_symbols(SOURCE);
+        let bar = &outline[0].children.as_ref().unwrap()[1];
+        assert_eq!(
+            bar.selection_range.start,
+            Position {
+                line: 2,
+                character: 11
+            }
+        );
+        assert_eq!(
+            bar.selection_range.end,
+            Position {
+                line: 2,
+                character: 14
+            }
+        );
+        assert!(bar.range.start <= bar.selection_range.start);
+        assert!(bar.range.end >= bar.selection_range.end);
+    }
+
+    #[test]
+    fn a_class_range_spans_its_body() {
+        let outline = document_symbols(SOURCE);
+        assert_eq!(outline[0].range.start.line, 0);
+        assert_eq!(
+            outline[0].range.end.line, 2,
+            "the last statement inside Foo is on 0-based line 2"
+        );
+    }
+
+    #[test]
+    fn a_grammar_keeps_its_declarator_where_the_lsp_kind_cannot() {
+        let outline = document_symbols("grammar G {\n    token TOP { <x> }\n}\n");
+        assert_eq!(
+            outline[0].kind,
+            SymbolKind::CLASS,
+            "LSP has no grammar kind"
+        );
+        assert_eq!(outline[0].detail.as_deref(), Some("grammar"));
+    }
+
+    #[test]
+    fn query_matching_is_case_insensitive_substring() {
+        assert!(matches_query("frobnicate", "frob"));
+        assert!(matches_query("Frobnicate", "frob"));
+        assert!(matches_query("anything", ""));
+        assert!(!matches_query("frobnicate", "zzz"));
+    }
+
+    #[test]
+    fn flat_symbols_carry_their_container() {
+        let flat = flat_symbols(SOURCE);
+        let bar = flat.iter().find(|(s, _, _)| s.name == "bar").unwrap();
+        assert_eq!(bar.1.as_deref(), Some("Foo"));
+    }
+}

--- a/crates/mutsu-lsp/src/workspace.rs
+++ b/crates/mutsu-lsp/src/workspace.rs
@@ -1,0 +1,265 @@
+//! The Raku files on disk that a workspace-wide query looks at (ADR-0065 S4).
+//!
+//! `workspaceSymbol` and a cross-file `definition` need more than the documents
+//! the client has open. There is no index maintained in the background: files
+//! are read and parsed when a query asks, and cached by modification time so
+//! repeat queries are cheap. That is the right trade for this consumer — an
+//! agent asks a workspace question occasionally and never while typing — and it
+//! avoids a whole class of staleness bug, since the cache is validated against
+//! the file rather than trusted.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::time::SystemTime;
+
+/// Files with these extensions are analysed. `.t` is included: a test file is
+/// where a routine is most often *used*, and an agent looking for a definition
+/// benefits from the ones declared there too.
+const RAKU_EXTENSIONS: &[&str] = &["raku", "rakumod", "rakutest", "p6", "pm6", "pl6", "t"];
+
+/// Directories never worth walking into.
+const SKIPPED_DIRECTORIES: &[&str] = &[".git", "target", "node_modules", ".precomp", ".cache"];
+
+/// How many files one workspace scan will look at.
+///
+/// A bound rather than a budget: a query that walks an unbounded tree is a
+/// hang, and a hung server is worse to the consumer than a truncated answer.
+const MAX_FILES: usize = 4000;
+
+#[derive(Debug, Default)]
+pub struct Workspace {
+    roots: Vec<PathBuf>,
+    cache: HashMap<PathBuf, CachedFile>,
+}
+
+#[derive(Debug)]
+struct CachedFile {
+    modified: Option<SystemTime>,
+    len: u64,
+    text: String,
+}
+
+impl Workspace {
+    /// Read the roots out of an `initialize` request's params.
+    ///
+    /// `workspaceFolders` is the current spelling and `rootUri`/`rootPath` the
+    /// deprecated ones; clients still send the old ones, and a server that only
+    /// understood the new one would silently have no workspace at all.
+    pub fn from_initialize_params(params: &serde_json::Value) -> Workspace {
+        let mut roots = Vec::new();
+        if let Some(folders) = params.get("workspaceFolders").and_then(|v| v.as_array()) {
+            for folder in folders {
+                if let Some(path) = folder
+                    .get("uri")
+                    .and_then(|u| u.as_str())
+                    .and_then(path_of_uri)
+                {
+                    roots.push(path);
+                }
+            }
+        }
+        if roots.is_empty()
+            && let Some(path) = params
+                .get("rootUri")
+                .and_then(|v| v.as_str())
+                .and_then(path_of_uri)
+        {
+            roots.push(path);
+        }
+        if roots.is_empty()
+            && let Some(path) = params.get("rootPath").and_then(|v| v.as_str())
+        {
+            roots.push(PathBuf::from(path));
+        }
+        Workspace {
+            roots,
+            cache: HashMap::new(),
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.roots.is_empty()
+    }
+
+    /// Every Raku file under the roots, capped at [`MAX_FILES`].
+    pub fn files(&self) -> Vec<PathBuf> {
+        let mut found = Vec::new();
+        for root in &self.roots {
+            walk(root, &mut found);
+            if found.len() >= MAX_FILES {
+                break;
+            }
+        }
+        found.truncate(MAX_FILES);
+        found.sort();
+        found
+    }
+
+    /// The text of `path`, from the cache when the file has not changed.
+    pub fn text_of(&mut self, path: &Path) -> Option<&str> {
+        let metadata = std::fs::metadata(path).ok();
+        let modified = metadata.as_ref().and_then(|m| m.modified().ok());
+        let len = metadata.as_ref().map_or(0, |m| m.len());
+        let fresh = self
+            .cache
+            .get(path)
+            .is_some_and(|c| c.modified == modified && c.len == len);
+        if !fresh {
+            let text = std::fs::read_to_string(path).ok()?;
+            self.cache.insert(
+                path.to_path_buf(),
+                CachedFile {
+                    modified,
+                    len,
+                    text,
+                },
+            );
+        }
+        self.cache.get(path).map(|c| c.text.as_str())
+    }
+}
+
+fn walk(dir: &Path, out: &mut Vec<PathBuf>) {
+    if out.len() >= MAX_FILES {
+        return;
+    }
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        if out.len() >= MAX_FILES {
+            return;
+        }
+        let path = entry.path();
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        if path.is_dir() {
+            if name.starts_with('.') || SKIPPED_DIRECTORIES.contains(&name.as_ref()) {
+                continue;
+            }
+            walk(&path, out);
+        } else if path
+            .extension()
+            .and_then(|e| e.to_str())
+            .is_some_and(|e| RAKU_EXTENSIONS.contains(&e))
+        {
+            out.push(path);
+        }
+    }
+}
+
+/// A `file:` URI's path. Anything else (a client editing over `untitled:` or a
+/// remote scheme) has no path to walk and is skipped.
+fn path_of_uri(uri: &str) -> Option<PathBuf> {
+    let rest = uri.strip_prefix("file://")?;
+    // `file:///path` — the authority is empty for a local path.
+    let rest = rest.strip_prefix('/').map(|r| format!("/{r}"))?;
+    Some(PathBuf::from(percent_decode(&rest)))
+}
+
+/// Minimal percent-decoding: a workspace path with a space or a non-ASCII
+/// character arrives encoded, and treating it literally would silently find no
+/// files at all.
+fn percent_decode(s: &str) -> String {
+    let bytes = s.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'%'
+            && i + 2 < bytes.len()
+            && let Some(byte) = std::str::from_utf8(&bytes[i + 1..i + 3])
+                .ok()
+                .and_then(|hex| u8::from_str_radix(hex, 16).ok())
+        {
+            out.push(byte);
+            i += 3;
+            continue;
+        }
+        out.push(bytes[i]);
+        i += 1;
+    }
+    String::from_utf8_lossy(&out).into_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn workspace_folders_are_read_from_initialize_params() {
+        let params = serde_json::json!({
+            "workspaceFolders": [{ "uri": "file:///tmp/one", "name": "one" },
+                                 { "uri": "file:///tmp/two", "name": "two" }]
+        });
+        let workspace = Workspace::from_initialize_params(&params);
+        assert_eq!(
+            workspace.roots,
+            vec![PathBuf::from("/tmp/one"), PathBuf::from("/tmp/two")]
+        );
+    }
+
+    #[test]
+    fn the_deprecated_root_uri_is_still_understood() {
+        let params = serde_json::json!({ "rootUri": "file:///tmp/only" });
+        let workspace = Workspace::from_initialize_params(&params);
+        assert_eq!(workspace.roots, vec![PathBuf::from("/tmp/only")]);
+        let params = serde_json::json!({ "rootPath": "/tmp/older" });
+        assert_eq!(
+            Workspace::from_initialize_params(&params).roots,
+            vec![PathBuf::from("/tmp/older")]
+        );
+    }
+
+    #[test]
+    fn a_client_with_no_workspace_is_not_an_error() {
+        let workspace = Workspace::from_initialize_params(&serde_json::json!({}));
+        assert!(workspace.is_empty());
+        assert!(workspace.files().is_empty());
+    }
+
+    #[test]
+    fn a_percent_encoded_path_is_decoded() {
+        assert_eq!(
+            path_of_uri("file:///tmp/my%20project"),
+            Some(PathBuf::from("/tmp/my project"))
+        );
+        assert_eq!(path_of_uri("untitled:Untitled-1"), None);
+    }
+
+    #[test]
+    fn the_walk_finds_raku_files_and_skips_noise() {
+        let root = std::env::temp_dir().join(format!("mutsu-lsp-walk-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(root.join("lib")).unwrap();
+        std::fs::create_dir_all(root.join(".git")).unwrap();
+        std::fs::create_dir_all(root.join("target")).unwrap();
+        std::fs::write(root.join("lib/A.rakumod"), "class A { }\n").unwrap();
+        std::fs::write(root.join("script.raku"), "say 1;\n").unwrap();
+        std::fs::write(root.join("notes.md"), "hello\n").unwrap();
+        std::fs::write(root.join(".git/HEAD.raku"), "say 2;\n").unwrap();
+        std::fs::write(root.join("target/built.raku"), "say 3;\n").unwrap();
+
+        let mut workspace = Workspace {
+            roots: vec![root.clone()],
+            cache: HashMap::new(),
+        };
+        let files = workspace.files();
+        let names: Vec<String> = files
+            .iter()
+            .map(|p| p.file_name().unwrap().to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(names, vec!["A.rakumod", "script.raku"], "{files:?}");
+
+        assert_eq!(
+            workspace.text_of(&root.join("script.raku")),
+            Some("say 1;\n")
+        );
+        // Second read comes from the cache and must be identical.
+        assert_eq!(
+            workspace.text_of(&root.join("script.raku")),
+            Some("say 1;\n")
+        );
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+}

--- a/crates/mutsu-lsp/tests/protocol.rs
+++ b/crates/mutsu-lsp/tests/protocol.rs
@@ -29,8 +29,20 @@ struct Client {
 }
 
 impl Client {
-    /// Connect and complete the initialize handshake.
+    /// Connect and complete the initialize handshake with no workspace.
     fn start() -> Client {
+        Client::start_in(serde_json::json!({ "capabilities": {} }))
+    }
+
+    /// Connect with `root` as the workspace root.
+    fn start_in_workspace(root: &std::path::Path) -> Client {
+        Client::start_in(serde_json::json!({
+            "capabilities": {},
+            "rootUri": format!("file://{}", root.display()),
+        }))
+    }
+
+    fn start_in(initialize_params: serde_json::Value) -> Client {
         let (server_connection, client_connection) = Connection::memory();
         // The same stack the binary gives the loop. mutsu's parser is deeply
         // recursive enough that this is not a formality: on a default stack it
@@ -46,7 +58,7 @@ impl Client {
             next_id: 0,
         };
 
-        let id = client.request("initialize", serde_json::json!({ "capabilities": {} }));
+        let id = client.request("initialize", initialize_params);
         let result = client
             .recv_response(id)
             .response_result
@@ -402,4 +414,217 @@ fn a_deeply_nested_document_does_not_take_the_server_down() {
     assert!(after.diagnostics.is_empty());
 
     client.shutdown();
+}
+
+/// ADR-0065 D3 lists `documentSymbol` as in scope because it gives an agent an
+/// exact answer where it would otherwise grep — and grep's false positives (a
+/// mention in a comment, an unrelated same-named method) are what make it a poor
+/// substitute.
+#[test]
+fn the_outline_of_a_document_is_nested_and_placed() {
+    let mut client = Client::start();
+    let path = "file:///tmp/outline.raku";
+    client.open(
+        path,
+        "class Foo {\n    has $.x;\n    method bar() { 1 }\n}\nsub baz() { 2 }\n",
+        1,
+    );
+
+    let id = client.request(
+        "textDocument/documentSymbol",
+        serde_json::json!({ "textDocument": { "uri": path } }),
+    );
+    let result = client
+        .recv_response(id)
+        .response_result
+        .expect("documentSymbol must succeed");
+    let outline = result.as_array().expect("a nested outline");
+    assert_eq!(outline.len(), 2, "{result:#}");
+    assert_eq!(outline[0]["name"], "Foo");
+    assert_eq!(outline[0]["detail"], "class");
+    assert_eq!(outline[0]["selectionRange"]["start"]["line"], 0);
+    let children = outline[0]["children"].as_array().expect("class members");
+    assert_eq!(children.len(), 2);
+    assert_eq!(children[1]["name"], "bar");
+    assert_eq!(
+        children[1]["selectionRange"]["start"],
+        serde_json::json!({ "line": 2, "character": 11 }),
+        "the selection range must land on the name, which is where a client puts the caret"
+    );
+    assert_eq!(outline[1]["name"], "baz");
+
+    client.shutdown();
+}
+
+/// The outline must survive a document that does not parse: that is the state a
+/// file being edited is in most of the time (S3).
+#[test]
+fn the_outline_survives_a_broken_document() {
+    let mut client = Client::start();
+    let path = "file:///tmp/broken-outline.raku";
+    client.open(
+        path,
+        "sub good() { 1 }\nsay $c.f (1, 2);\nclass Later { }\n",
+        1,
+    );
+
+    let id = client.request(
+        "textDocument/documentSymbol",
+        serde_json::json!({ "textDocument": { "uri": path } }),
+    );
+    let result = client
+        .recv_response(id)
+        .response_result
+        .expect("documentSymbol must succeed");
+    let names: Vec<&str> = result
+        .as_array()
+        .expect("outline")
+        .iter()
+        .filter_map(|s| s["name"].as_str())
+        .collect();
+    assert!(names.contains(&"good"), "{result:#}");
+    assert!(names.contains(&"Later"), "{result:#}");
+
+    client.shutdown();
+}
+
+#[test]
+fn definition_finds_a_declaration_in_the_open_document() {
+    let mut client = Client::start();
+    let path = "file:///tmp/definition.raku";
+    client.open(path, "sub frobnicate() { 1 }\nsay frobnicate();\n", 1);
+
+    // The caret sits inside `frobnicate` on the second line.
+    let id = client.request(
+        "textDocument/definition",
+        serde_json::json!({
+            "textDocument": { "uri": path },
+            "position": { "line": 1, "character": 8 },
+        }),
+    );
+    let result = client
+        .recv_response(id)
+        .response_result
+        .expect("definition must succeed");
+    assert_eq!(result["uri"], path, "{result:#}");
+    assert_eq!(result["range"]["start"]["line"], 0);
+    assert_eq!(
+        result["range"]["start"]["character"], 4,
+        "the range covers the name, not the whole declaration line"
+    );
+
+    client.shutdown();
+}
+
+#[test]
+fn definition_on_something_undeclared_answers_null_rather_than_erroring() {
+    let mut client = Client::start();
+    let path = "file:///tmp/no-definition.raku";
+    client.open(path, "say 1;\n", 1);
+
+    let id = client.request(
+        "textDocument/definition",
+        serde_json::json!({
+            "textDocument": { "uri": path },
+            "position": { "line": 0, "character": 5 },
+        }),
+    );
+    let result = client
+        .recv_response(id)
+        .response_result
+        .expect("definition must succeed even with nothing to find");
+    assert!(result.is_null(), "{result:#}");
+
+    client.shutdown();
+}
+
+#[test]
+fn workspace_symbol_searches_files_on_disk() {
+    let root = std::env::temp_dir().join(format!("mutsu-lsp-ws-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&root);
+    std::fs::create_dir_all(root.join("lib")).unwrap();
+    std::fs::write(
+        root.join("lib/Widget.rakumod"),
+        "class Widget {\n    method assemble() { 1 }\n}\n",
+    )
+    .unwrap();
+    std::fs::write(root.join("main.raku"), "sub unrelated() { 1 }\n").unwrap();
+
+    let mut client = Client::start_in_workspace(&root);
+    let id = client.request("workspace/symbol", serde_json::json!({ "query": "widget" }));
+    let result = client
+        .recv_response(id)
+        .response_result
+        .expect("workspace/symbol must succeed");
+    let found = result.as_array().expect("a flat symbol list");
+    assert_eq!(
+        found.len(),
+        1,
+        "case-insensitive substring match: {result:#}"
+    );
+    assert_eq!(found[0]["name"], "Widget");
+    assert!(
+        found[0]["location"]["uri"]
+            .as_str()
+            .unwrap()
+            .ends_with("lib/Widget.rakumod"),
+        "{result:#}"
+    );
+
+    // A member of that class is found by its own name, with its container.
+    let id = client.request(
+        "workspace/symbol",
+        serde_json::json!({ "query": "assemble" }),
+    );
+    let result = client
+        .recv_response(id)
+        .response_result
+        .expect("workspace/symbol must succeed");
+    let found = result.as_array().unwrap();
+    assert_eq!(found.len(), 1, "{result:#}");
+    assert_eq!(found[0]["containerName"], "Widget");
+
+    client.shutdown();
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+#[test]
+fn definition_falls_back_to_the_workspace_when_the_open_document_does_not_declare_it() {
+    let root = std::env::temp_dir().join(format!("mutsu-lsp-xdef-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&root);
+    std::fs::create_dir_all(&root).unwrap();
+    std::fs::write(
+        root.join("Helpers.rakumod"),
+        "sub helper() is export { 1 }\n",
+    )
+    .unwrap();
+    let script = root.join("script.raku");
+    std::fs::write(&script, "use Helpers;\nsay helper();\n").unwrap();
+
+    let mut client = Client::start_in_workspace(&root);
+    let uri = format!("file://{}", script.display());
+    client.open(&uri, "use Helpers;\nsay helper();\n", 1);
+
+    let id = client.request(
+        "textDocument/definition",
+        serde_json::json!({
+            "textDocument": { "uri": uri },
+            "position": { "line": 1, "character": 6 },
+        }),
+    );
+    let result = client
+        .recv_response(id)
+        .response_result
+        .expect("definition must succeed");
+    assert!(
+        result["uri"]
+            .as_str()
+            .unwrap_or("")
+            .ends_with("Helpers.rakumod"),
+        "{result:#}"
+    );
+    assert_eq!(result["range"]["start"]["line"], 0);
+
+    client.shutdown();
+    let _ = std::fs::remove_dir_all(&root);
 }

--- a/docs/adr/0065-language-server-targets-ai-agents.md
+++ b/docs/adr/0065-language-server-targets-ai-agents.md
@@ -476,6 +476,63 @@ quietly.
 The general lesson is worth stating: **any new front end for mutsu's parser inherits the
 CLI's stack requirement.** It is not a property of the CLI; it is a property of the parser.
 
+## S4 findings (2026-09-03)
+
+D6's bet was that line granularity would carry `documentSymbol` and `definition` with no
+span retrofit. It did, and two of the three methods needed less positional machinery than
+expected.
+
+### 1. `Stmt::SetLine` carries the outline on its own — and `definition` needs no positions at all
+
+The parser interleaves a `SetLine` marker before every statement, including inside a class
+or routine body, so walking the statement list while tracking the most recent marker yields
+each declaration's line for free. A declaration's *end* is approximated by the deepest
+marker inside its body, which stops at its last statement rather than at the closing brace
+— accurate enough for an outline, and honest about what the AST knows.
+
+`definition` turned out not to need AST positions in either direction. The *target* is a
+declaration, which `SetLine` places. The *source* is whatever identifier the caret is on,
+and the server has the document text — an identifier is a lexical notion that needs no
+parse. Reading it out of the line sidesteps the whole "no positions for references"
+problem that D6 flagged as `references`'s (S5's) real cost. Note that this does not
+generalize: `references` needs to find *every* occurrence and rank them, which grep-like
+text scanning cannot do soundly.
+
+`selectionRange` is exact rather than line-wide for the same reason: the name is a literal
+and the declaration line is short, so finding it in the text gives the range a client puts
+the caret on. The match is anchored at identifier boundaries, or `has $.x` would select the
+`x` inside a nearby `max`.
+
+### 2. The best-effort parser was not emitting the markers, which S4 depended on
+
+`stmt_list_partial` never emitted `SetLine`; only the strict list did. The outline of a
+*broken* document — the whole point of ordering S3 before S4 — therefore reported every
+declaration on line 1. It now emits them exactly as the strict list does. Consumers of a
+best-effort parse are unaffected: they match on declaration variants and ignore markers,
+which is already what they do for a strict parse.
+
+### 3. LSP's `SymbolKind` has no Raku vocabulary, so the declarator goes in `detail`
+
+There is no kind for a role, a grammar, a grammar token or a subset. The mapping picks the
+nearest behavioural equivalent (a role is an interface, a token is a function, a grammar is
+a class) and puts the real Raku declarator in `detail`, so an outline that says `CLASS`
+still reads "grammar". Losing that distinction would be a quiet downgrade of exactly the
+information a Raku reader is scanning for.
+
+### 4. Workspace queries read on demand rather than maintaining an index
+
+`workspaceSymbol` and a cross-file `definition` walk the roots, parse what they find, and
+cache by modification time and size. No background index is maintained. That is the right
+trade for this consumer — an agent asks a workspace question occasionally and never while
+typing — and it removes a class of staleness bug, since the cache is validated against the
+file rather than trusted. The walk is capped (4000 files): a query over an unbounded tree
+is a hang, and a hung server is worse than a truncated answer.
+
+`rootUri`/`rootPath` are read alongside `workspaceFolders`. They are deprecated, but
+clients still send them, and a server that understood only the current spelling would
+silently have no workspace at all — a failure that looks like "no results" rather than like
+a bug.
+
 ## Rejected alternatives
 
 - **A lossless CST / red-green tree (rust-analyzer, rowan).** The correct architecture for
@@ -504,7 +561,7 @@ CLI's stack requirement.** It is not a property of the CLI; it is a property of 
 | **S1** | Server skeleton, full-document reparse, diagnostics from the existing single-error path — **done 2026-09-03**, `crates/mutsu-lsp/`, `src/analysis.rs`, `docs/language-server.md` | S0 |
 | **S2** | Enumerable built-in name tables → "mutsu does not support this" diagnostics (D4) — **routine half done 2026-09-03**; the method half is blocked on receiver types, see the S2 findings | S1 |
 | **S3** | Multiple diagnostics per document + error recovery (give `parse_program_partial` positions and errors) — **done 2026-09-03** | S1 |
-| **S4** | `documentSymbol` / `workspaceSymbol` / `definition` at line granularity | S1 |
+| **S4** | `documentSymbol` / `workspaceSymbol` / `definition` at line granularity — **done 2026-09-03** | S1 |
 | **S5** | `references` / `hover`; expression spans on the variants these require (D6) | S4 |
 
 S2 delivers the capability unique to mutsu and depends on no span work, so the ordering

--- a/docs/language-server.md
+++ b/docs/language-server.md
@@ -36,7 +36,10 @@ independently of the interpreter (`tag-release.yml` bumps only the root
 | `initialize` / `shutdown` / `exit` | Yes |
 | `textDocument/didOpen`, `didChange`, `didClose` | Yes, **full-document sync** |
 | `textDocument/publishDiagnostics` | Yes — parse errors and parse warnings |
-| `documentSymbol`, `workspaceSymbol`, `definition`, `references`, `hover` | Planned (ADR-0065 S4/S5) |
+| `textDocument/documentSymbol` | Yes — nested, with the Raku declarator in `detail` |
+| `workspace/symbol` | Yes — reads the workspace on demand, case-insensitive substring match |
+| `textDocument/definition` | Yes — the open document first, then the workspace |
+| `references`, `hover` | Planned (ADR-0065 S5) |
 | `completion`, `semanticTokens`, `signatureHelp`, `inlayHint` | **Out of scope** (D3) |
 | Incremental document sync | **Out of scope** (D3) |
 
@@ -90,6 +93,38 @@ deliberately conservative, so absence from it means "unclassified", not "mutsu
 does not have it", and reporting absence as a defect would be a false positive.
 See the ADR's S2 findings.
 
+## Symbols and definitions
+
+`documentSymbol` returns a nested outline: classes, roles, grammars, modules,
+subs, methods, tokens, rules, enums (with their values), subsets, attributes and
+top-level variables. A local inside a routine body is not an outline entry — it
+would bury the outline in noise — but the same declaration at the top of a class
+or a file is.
+
+LSP's `SymbolKind` has no spelling for a role, a grammar, a grammar token or a
+subset, so the mapping picks the nearest behavioural equivalent and puts the real
+Raku declarator in `detail`. An outline entry that says `CLASS` still reads
+"grammar".
+
+Ranges are line-granular, as everything here is: a declaration runs from its line
+to the last line its body demonstrably covers (the deepest `SetLine` marker
+inside it), which stops at its last statement rather than at the closing brace.
+`selectionRange` is exact, though — the name is a literal and the declaration
+line is short, so it is found in the text.
+
+`definition` needs no AST positions in either direction. The target is a
+declaration, which `SetLine` places; the source is whatever identifier the caret
+is on, which the server reads straight out of the document text. It searches the
+open document first (both the likeliest answer and the freshest, since the copy
+on disk may be older than what the client holds), then the workspace.
+
+`workspace/symbol` walks the workspace roots, parses what it finds and caches by
+modification time and size. There is no background index: an agent asks a
+workspace question occasionally and never while typing, and validating the cache
+against the file removes a class of staleness bug. The walk is capped at 4000
+files, because a query over an unbounded tree is a hang and a hung server is
+worse than a truncated answer.
+
 A parse failure inside a `use`d module is anchored at line 1 of the *open*
 document and names the other file in its message. Reporting that module's
 line and column against this document would point at an unrelated line, which
@@ -135,6 +170,9 @@ which has no column, covers the whole line.
 | `crates/mutsu-lsp/src/positions.rs` | mutsu positions to LSP positions. |
 | `crates/mutsu-lsp/src/diagnostics.rs` | `mutsu::analysis::Diagnostic` to `lsp_types::Diagnostic`. |
 | `crates/mutsu-lsp/src/documents.rs` | The open-document map. No rope, no diffing — sync is full-text. |
+| `src/analysis/symbols.rs` (in `mutsu`) | The declarations a document contains, nested, at line granularity. Runs over a recovering parse, so a broken document still has an outline. |
+| `crates/mutsu-lsp/src/symbols.rs` | mutsu's declarations to LSP symbols, and the `SymbolKind` mapping. |
+| `crates/mutsu-lsp/src/workspace.rs` | The files a workspace-wide query reads, and their cache. |
 | `crates/mutsu-lsp/tests/protocol.rs` | End-to-end tests over `lsp_server::Connection::memory()`, driving the real loop. |
 
 The loop is synchronous and single-threaded on purpose: D3 leaves nothing

--- a/news/2026-09/adr0065-s4-document-symbols-and-definition.md
+++ b/news/2026-09/adr0065-s4-document-symbols-and-definition.md
@@ -1,0 +1,68 @@
+# Symbols and go-to-definition, without adding a single position to the AST
+
+ADR-0065 S4 lands `documentSymbol`, `workspace/symbol` and `definition` —
+the methods D3 kept because they give an agent an exact answer where it would
+otherwise grep, and grep's false positives (a mention in a comment, a string, an
+unrelated same-named method) are what make it a poor substitute.
+
+D6's bet was that line granularity would carry them with no span retrofit across
+`src/ast.rs`'s ~80 variants. It did, and two of the three needed less positional
+machinery than the design expected.
+
+## `SetLine` carries the outline, and `definition` needs no positions at all
+
+The parser interleaves a `Stmt::SetLine` marker before every statement, including
+inside a class or routine body. Walking the statement list while tracking the
+most recent marker yields each declaration's line for free. A declaration's *end*
+is approximated by the deepest marker inside its body, so it stops at its last
+statement rather than at the closing brace — accurate enough for an outline, and
+honest about what the AST actually knows.
+
+`definition` turned out to need AST positions in neither direction. The **target**
+is a declaration, which `SetLine` places. The **source** is whatever identifier
+the caret is on — and the server has the document text, where an identifier is a
+lexical notion that needs no parse at all. Reading it straight out of the line
+sidesteps the "no positions for references" problem entirely.
+
+That does not generalize, and it is worth being clear about why: `references`
+(S5) must find *every* occurrence and rank them, which text scanning cannot do
+soundly. `definition` gets away with it because it only needs to know what one
+word is.
+
+`selectionRange` is exact rather than line-wide for the same reason. The name is
+a literal and the declaration line is short, so it is found in the text — which
+is where a client puts the caret on "go to symbol". The match is anchored at
+identifier boundaries, or `has $.x` would select the `x` inside a nearby `max`.
+
+## The best-effort parser was not emitting the markers
+
+S3 was ordered before S4 precisely so the outline would survive a document under
+edit. It did not: `stmt_list_partial` never emitted `SetLine` — only the strict
+statement list did — so a broken document's outline reported every declaration on
+line 1. It now emits them exactly as the strict list does. Consumers of a
+best-effort parse are unaffected, since they match on declaration variants and
+ignore markers, which is already what they do for a strict parse.
+
+## LSP's vocabulary has no Raku in it, so the declarator goes in `detail`
+
+There is no `SymbolKind` for a role, a grammar, a grammar token or a subset. The
+mapping picks the nearest behavioural equivalent — a role is an interface, a
+token is a function, a grammar is a class — and puts the real Raku declarator in
+`detail`, so an outline entry that says `CLASS` still reads "grammar". Dropping
+that would be a quiet downgrade of exactly the information a Raku reader is
+scanning an outline for.
+
+## Workspace queries read on demand instead of maintaining an index
+
+`workspace/symbol` and a cross-file `definition` walk the roots, parse what they
+find, and cache by modification time and size. Nothing runs in the background.
+That is the right trade for this consumer — an agent asks a workspace question
+occasionally and never while typing — and it removes a class of staleness bug,
+because the cache is validated against the file rather than trusted. The walk is
+capped at 4000 files: a query over an unbounded tree is a hang, and a hung server
+is worse to the consumer than a truncated answer.
+
+`rootUri` and `rootPath` are read alongside `workspaceFolders`. They are
+deprecated, but clients still send them, and a server that understood only the
+current spelling would silently have no workspace — a failure that presents as
+"no results" rather than as a bug.

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -22,6 +22,10 @@
 //!   rather than an abort. mutsu is under active development and its parser is
 //!   not panic-free; `check` catches it.
 
+pub mod symbols;
+
+pub use symbols::{Symbol, SymbolKind, symbols};
+
 use crate::ast::Stmt;
 use crate::value::{RuntimeError, RuntimeErrorCode};
 

--- a/src/analysis/symbols.rs
+++ b/src/analysis/symbols.rs
@@ -1,0 +1,429 @@
+//! The declarations a document contains, at line granularity (ADR-0065 S4).
+//!
+//! This is the answer to "where is `Foo` defined" that an agent would otherwise
+//! get by grepping — and grep's false positives (a mention in a comment, a
+//! string, an unrelated same-named method) are exactly what makes it a poor
+//! substitute.
+//!
+//! **Line granularity, on purpose.** mutsu's AST carries no positions at all;
+//! the only positional information is `Stmt::SetLine`, a marker statement the
+//! parser interleaves into every statement list, including the body of a class
+//! or a routine. Walking the statements while tracking the most recent marker
+//! therefore yields a declaration's line for free, with no span retrofit
+//! (ADR-0065 D6). A declaration's *end* is approximated by the deepest marker
+//! seen inside its body, so it stops at the last statement rather than at the
+//! closing brace.
+//!
+//! **Works on a broken document.** Collection runs over a recovering parse, so
+//! a file with a syntax error still yields the symbols around it — which is the
+//! point, since a document under edit is broken most of the time (S3).
+
+use crate::ast::{PackageKind, Stmt};
+
+/// What a declaration declares. Deliberately mutsu's own vocabulary rather than
+/// LSP's `SymbolKind`, which has no spelling for a role, a grammar token or a
+/// subset; the server maps this to the nearest LSP kind at its boundary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SymbolKind {
+    Module,
+    Package,
+    Class,
+    Grammar,
+    Role,
+    Subset,
+    Enum,
+    EnumMember,
+    Sub,
+    Method,
+    /// `method !name` — visible in an outline, but not callable from outside.
+    PrivateMethod,
+    Token,
+    Rule,
+    /// `has $.x`
+    Attribute,
+    Variable,
+}
+
+impl SymbolKind {
+    /// Whether a declaration of this kind holds other declarations worth
+    /// listing — used to decide where a bare `my $x` is an outline entry (a
+    /// class body, a module, the mainline) and where it is a local (a routine).
+    fn is_package_like(self) -> bool {
+        matches!(
+            self,
+            SymbolKind::Module
+                | SymbolKind::Package
+                | SymbolKind::Class
+                | SymbolKind::Grammar
+                | SymbolKind::Role
+        )
+    }
+}
+
+/// One declaration, and the ones nested inside it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Symbol {
+    pub name: String,
+    pub kind: SymbolKind,
+    /// 1-based line the declaration is on.
+    pub line: u32,
+    /// 1-based last line the declaration covers, best effort: the deepest
+    /// `Stmt::SetLine` seen inside its body. Never less than `line`.
+    pub end_line: u32,
+    pub children: Vec<Symbol>,
+}
+
+/// Every declaration in `source`, in source order, nested.
+///
+/// Never fails: a document that does not parse yields the declarations that
+/// survived recovery, and one that parses to nothing yields an empty list.
+pub fn symbols(source: &str) -> Vec<Symbol> {
+    let collected = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        let (stmts, _finish, _errors) = crate::parser::parse_program_recovering(source);
+        let mut line = 1;
+        collect(&stmts, &mut line, false)
+    }));
+    collected.unwrap_or_default()
+}
+
+/// Walk `stmts`, tracking the running line, and return the declarations found.
+///
+/// `in_routine` suppresses plain variable declarations: `my $x` at the top of a
+/// class or a file is an outline entry, the same line inside a `sub` body is a
+/// local and would bury the outline in noise.
+fn collect(stmts: &[Stmt], line: &mut u32, in_routine: bool) -> Vec<Symbol> {
+    let mut out = Vec::new();
+    for stmt in stmts {
+        match stmt {
+            Stmt::SetLine(n) => {
+                if *n > 0 {
+                    *line = *n as u32;
+                }
+            }
+            Stmt::ClassDecl {
+                name,
+                parents,
+                body,
+                ..
+            } => {
+                // A `grammar` parses to a `ClassDecl` whose implicit parent is
+                // `Grammar`; there is no separate variant to match on.
+                let kind = if parents.iter().any(|p| p == "Grammar") {
+                    SymbolKind::Grammar
+                } else {
+                    SymbolKind::Class
+                };
+                out.push(declaration(name.resolve(), kind, line, body, false));
+            }
+            Stmt::RoleDecl { name, body, .. } => {
+                out.push(declaration(
+                    name.resolve(),
+                    SymbolKind::Role,
+                    line,
+                    body,
+                    false,
+                ));
+            }
+            Stmt::Package {
+                name, kind, body, ..
+            } => {
+                let kind = match kind {
+                    PackageKind::Module => SymbolKind::Module,
+                    PackageKind::Package => SymbolKind::Package,
+                    PackageKind::Grammar => SymbolKind::Grammar,
+                };
+                out.push(declaration(name.resolve(), kind, line, body, false));
+            }
+            Stmt::SubDecl { name, body, .. } => {
+                out.push(declaration(
+                    name.resolve(),
+                    SymbolKind::Sub,
+                    line,
+                    body,
+                    true,
+                ));
+            }
+            Stmt::ProtoDecl {
+                name,
+                body,
+                is_method,
+                ..
+            } => {
+                let kind = if *is_method {
+                    SymbolKind::Method
+                } else {
+                    SymbolKind::Sub
+                };
+                out.push(declaration(name.resolve(), kind, line, body, true));
+            }
+            Stmt::MethodDecl {
+                name,
+                body,
+                is_private,
+                ..
+            } => {
+                let kind = if *is_private {
+                    SymbolKind::PrivateMethod
+                } else {
+                    SymbolKind::Method
+                };
+                out.push(declaration(name.resolve(), kind, line, body, true));
+            }
+            Stmt::TokenDecl { name, body, .. } => {
+                out.push(declaration(
+                    name.resolve(),
+                    SymbolKind::Token,
+                    line,
+                    body,
+                    true,
+                ));
+            }
+            Stmt::RuleDecl { name, body, .. } => {
+                out.push(declaration(
+                    name.resolve(),
+                    SymbolKind::Rule,
+                    line,
+                    body,
+                    true,
+                ));
+            }
+            Stmt::ProtoToken { name } => out.push(leaf(name.resolve(), SymbolKind::Token, *line)),
+            Stmt::SubsetDecl { name, .. } => {
+                out.push(leaf(name.resolve(), SymbolKind::Subset, *line))
+            }
+            Stmt::EnumDecl { name, variants, .. } => {
+                let mut symbol = leaf(name.resolve(), SymbolKind::Enum, *line);
+                symbol.children = variants
+                    .iter()
+                    .map(|(variant, _)| leaf(variant.clone(), SymbolKind::EnumMember, *line))
+                    .collect();
+                out.push(symbol);
+            }
+            Stmt::HasDecl { name, .. } => {
+                out.push(leaf(name.resolve(), SymbolKind::Attribute, *line))
+            }
+            Stmt::VarDecl { name, .. } if !in_routine && !name.is_empty() => {
+                out.push(leaf(name.clone(), SymbolKind::Variable, *line))
+            }
+            _ => {}
+        }
+    }
+    out
+}
+
+fn leaf(name: String, kind: SymbolKind, line: u32) -> Symbol {
+    Symbol {
+        name,
+        kind,
+        line,
+        end_line: line,
+        children: Vec::new(),
+    }
+}
+
+/// Build a declaration and walk its body, using the running line cursor to
+/// approximate where the declaration ends.
+fn declaration(
+    name: String,
+    kind: SymbolKind,
+    line: &mut u32,
+    body: &[Stmt],
+    body_is_routine: bool,
+) -> Symbol {
+    let start = *line;
+    // The body's own `SetLine` markers advance the shared cursor; wherever it
+    // ends up is the last line the declaration demonstrably covers. The closing
+    // brace is not counted, because nothing marks it.
+    let children = collect(body, line, body_is_routine || !kind.is_package_like());
+    let end_line = (*line).max(start);
+    Symbol {
+        name,
+        kind,
+        line: start,
+        end_line,
+        children,
+    }
+}
+
+/// Find `name` and its enclosing chain, depth-first, in source order.
+///
+/// Returns the *first* declaration of that name. mutsu's own `multi` dispatch
+/// makes several declarations of one name normal, and picking the first is what
+/// a reader following a reference wants: the rest are found from there.
+pub fn find(symbols: &[Symbol], name: &str) -> Option<Symbol> {
+    for symbol in symbols {
+        if symbol.name == name {
+            return Some(symbol.clone());
+        }
+        if let Some(found) = find(&symbol.children, name) {
+            return Some(found);
+        }
+    }
+    None
+}
+
+/// Flatten the tree, pairing each symbol with the name of its container.
+pub fn flatten(symbols: &[Symbol]) -> Vec<(Symbol, Option<String>)> {
+    let mut out = Vec::new();
+    push_flat(symbols, None, &mut out);
+    out
+}
+
+fn push_flat(symbols: &[Symbol], container: Option<&str>, out: &mut Vec<(Symbol, Option<String>)>) {
+    for symbol in symbols {
+        push_flat(&symbol.children, Some(&symbol.name), out);
+        out.push((
+            Symbol {
+                children: Vec::new(),
+                ..symbol.clone()
+            },
+            container.map(str::to_string),
+        ));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn kinds(symbols: &[Symbol]) -> Vec<(String, SymbolKind, u32)> {
+        symbols
+            .iter()
+            .map(|s| (s.name.clone(), s.kind, s.line))
+            .collect()
+    }
+
+    #[test]
+    fn a_document_yields_its_declarations_in_source_order() {
+        let source = "\
+my $top = 1;
+sub baz() { 1 }
+class Foo {
+    has $.x;
+    method bar($y) { $y }
+}
+";
+        let found = symbols(source);
+        assert_eq!(
+            kinds(&found),
+            vec![
+                ("top".to_string(), SymbolKind::Variable, 1),
+                ("baz".to_string(), SymbolKind::Sub, 2),
+                ("Foo".to_string(), SymbolKind::Class, 3),
+            ],
+            "{found:#?}"
+        );
+        let foo = &found[2];
+        assert_eq!(
+            kinds(&foo.children),
+            vec![
+                ("x".to_string(), SymbolKind::Attribute, 4),
+                ("bar".to_string(), SymbolKind::Method, 5),
+            ]
+        );
+    }
+
+    #[test]
+    fn a_grammar_is_not_reported_as_a_plain_class() {
+        let found = symbols("grammar G {\n    token TOP { <x> }\n    rule x { 'a' }\n}\n");
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0].kind, SymbolKind::Grammar);
+        assert_eq!(
+            kinds(&found[0].children),
+            vec![
+                ("TOP".to_string(), SymbolKind::Token, 2),
+                ("x".to_string(), SymbolKind::Rule, 3),
+            ]
+        );
+    }
+
+    #[test]
+    fn roles_modules_enums_and_subsets_all_appear() {
+        let found = symbols(
+            "role R { method m() {} }\nmodule M { sub s() {} }\nenum E <a b>;\nsubset S of Int;\n",
+        );
+        assert_eq!(
+            kinds(&found),
+            vec![
+                ("R".to_string(), SymbolKind::Role, 1),
+                ("M".to_string(), SymbolKind::Module, 2),
+                ("E".to_string(), SymbolKind::Enum, 3),
+                ("S".to_string(), SymbolKind::Subset, 4),
+            ],
+            "{found:#?}"
+        );
+        assert_eq!(
+            kinds(&found[2].children),
+            vec![
+                ("a".to_string(), SymbolKind::EnumMember, 3),
+                ("b".to_string(), SymbolKind::EnumMember, 3),
+            ]
+        );
+    }
+
+    /// A local inside a routine is not an outline entry; the same declaration
+    /// at the top of a class or a file is.
+    #[test]
+    fn locals_inside_a_routine_are_not_outline_entries() {
+        let found = symbols("sub f() {\n    my $local = 1;\n    $local\n}\nmy $outer = 2;\n");
+        assert_eq!(
+            kinds(&found),
+            vec![
+                ("f".to_string(), SymbolKind::Sub, 1),
+                ("outer".to_string(), SymbolKind::Variable, 5),
+            ],
+            "{found:#?}"
+        );
+        assert!(found[0].children.is_empty(), "{:#?}", found[0]);
+    }
+
+    #[test]
+    fn a_declaration_covers_the_lines_of_its_body() {
+        let found = symbols("class C {\n    method a() { 1 }\n    method b() { 2 }\n}\nsay 1;\n");
+        assert_eq!(found[0].line, 1);
+        assert_eq!(
+            found[0].end_line, 3,
+            "the last statement inside the class is on line 3"
+        );
+    }
+
+    /// ADR-0065 S3's payoff: a document under edit is broken most of the time,
+    /// and its outline must survive that.
+    #[test]
+    fn a_document_that_does_not_parse_still_yields_its_other_declarations() {
+        let found = symbols("sub good() { 1 }\nsay $c.f (1, 2);\nclass Later { }\n");
+        let names: Vec<&str> = found.iter().map(|s| s.name.as_str()).collect();
+        assert!(names.contains(&"good"), "{found:#?}");
+        assert!(names.contains(&"Later"), "{found:#?}");
+    }
+
+    #[test]
+    fn find_returns_a_nested_declaration() {
+        let found = symbols("class Foo {\n    method bar() { 1 }\n}\n");
+        let bar = find(&found, "bar").expect("nested method");
+        assert_eq!(bar.kind, SymbolKind::Method);
+        assert_eq!(bar.line, 2);
+        assert!(find(&found, "nope").is_none());
+    }
+
+    #[test]
+    fn flatten_pairs_each_symbol_with_its_container() {
+        let found = symbols("class Foo {\n    method bar() { 1 }\n}\n");
+        let flat = flatten(&found);
+        let bar = flat
+            .iter()
+            .find(|(s, _)| s.name == "bar")
+            .expect("bar is present");
+        assert_eq!(bar.1.as_deref(), Some("Foo"));
+        let foo = flat
+            .iter()
+            .find(|(s, _)| s.name == "Foo")
+            .expect("Foo is present");
+        assert_eq!(foo.1, None);
+    }
+
+    #[test]
+    fn an_empty_document_yields_nothing() {
+        assert_eq!(symbols(""), Vec::new());
+    }
+}

--- a/src/parser/stmt/stmtlist.rs
+++ b/src/parser/stmt/stmtlist.rs
@@ -69,8 +69,20 @@ pub(crate) fn stmt_list_partial(input: &str) -> (Vec<Stmt>, Vec<PError>) {
         if r.is_empty() || r.starts_with('}') {
             break;
         }
+        // Emit the same `Stmt::SetLine` marker the strict list emits. It is the
+        // only positional information the AST carries, so a consumer of a
+        // best-effort parse that wants to *place* what it found — the language
+        // server's document outline (ADR-0065 S4) — has nothing without it.
+        // Consumers that only look for declarations are unaffected: they match
+        // on specific variants and ignore markers, exactly as they do for the
+        // strict parse.
+        let line = crate::parser::primary::current_line_number(r);
+        let line_valid = crate::parser::primary::is_within_original_source(r);
         match statement(r) {
             Ok((r, stmt)) => {
+                if line_valid {
+                    stmts.push(Stmt::SetLine(line));
+                }
                 stmts.push(stmt);
                 rest = r;
             }


### PR DESCRIPTION
S4 lands `textDocument/documentSymbol`, `workspace/symbol` and `textDocument/definition` — the methods D3 kept because they give an agent an exact answer where it would otherwise grep, and grep's false positives (a mention in a comment, a string, an unrelated same-named method) are what make it a poor substitute.

**D6's bet was that line granularity would carry them with no span retrofit across `src/ast.rs`'s ~80 variants. It did**, and two of the three needed less positional machinery than the design expected.

## `SetLine` carries the outline, and `definition` needs no positions at all

The parser interleaves a `Stmt::SetLine` marker before every statement, including inside a class or routine body, so walking the statement list while tracking the most recent marker yields each declaration's line for free. A declaration's *end* is approximated by the deepest marker inside its body — it stops at the last statement rather than at the closing brace, which is accurate enough for an outline and honest about what the AST knows.

`definition` turned out to need AST positions in **neither** direction. The target is a declaration, which `SetLine` places. The source is whatever identifier the caret is on — and the server has the document text, where an identifier is a lexical notion that needs no parse. That sidesteps the "no positions for references" problem D6 flagged entirely.

It does not generalize, and the PR is explicit about why: `references` (S5) must find *every* occurrence and rank them, which text scanning cannot do soundly. `definition` gets away with it because it only needs to know what one word is.

`selectionRange` is exact rather than line-wide for the same reason — the name is a literal and the declaration line is short — with the match anchored at identifier boundaries, or `has $.x` would select the `x` inside a nearby `max`.

## Ordering S3 before S4 paid off by exposing a defect

S3 came first precisely so the outline would survive a document under edit. It did not: **`stmt_list_partial` never emitted `SetLine`** — only the strict statement list did — so a broken document's outline reported every declaration on line 1. It now emits them exactly as the strict list does. Consumers of a best-effort parse are unaffected: they match on declaration variants and ignore markers, which is already what they do for a strict parse.

## LSP's vocabulary has no Raku in it

There is no `SymbolKind` for a role, a grammar, a grammar token or a subset. The mapping picks the nearest behavioural equivalent (a role is an interface, a token is a function, a grammar is a class) and puts the real Raku declarator in `detail`, so an outline entry that says `CLASS` still reads "grammar". Dropping that would quietly lose exactly what a Raku reader scans an outline for.

## Workspace queries read on demand rather than maintaining an index

`workspace/symbol` and a cross-file `definition` walk the roots, parse what they find, and cache by modification time and size. Nothing runs in the background — the right trade for a consumer that asks a workspace question occasionally and never while typing, and validating the cache against the file removes a class of staleness bug. The walk is capped at 4000 files: a query over an unbounded tree is a hang, and a hung server is worse to the consumer than a truncated answer.

`rootUri`/`rootPath` are read alongside `workspaceFolders`. They are deprecated, but clients still send them, and understanding only the current spelling would present as "no results" rather than as a bug.

## Verification

- `make test` — 36666 tests, `Result: PASS`.
- **1436 whitelisted roast files that load a module — 218962 tests**, all pass on a release build. Every `use` goes through the best-effort export scan, so the `stmt_list_partial` change warrants a sweep this wide.
- `cargo test -p mutsu-lsp` — 48 tests, including end-to-end protocol tests for a nested outline with exact selection ranges, an outline of a document that does not parse, definition in the open document and across the workspace, and `workspace/symbol` against files on disk.
- `cargo clippy -- -D warnings`, `cargo clippy -p mutsu-lsp --all-targets -- -D warnings`, `cargo fmt --all -- --check` clean.

`src/analysis.rs` became `src/analysis/` (mod + `symbols.rs`) to stay under the 500-line file convention.

Next is **S5**: `references` and `hover`. `references` is the first method that genuinely needs per-occurrence positions, which is where D6's "spans only where a feature demands one" finally gets exercised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)