### PR TITLE
feat: ADR-0065 S5a — hover, showing a signature and whether mutsu has the name

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -82,11 +82,13 @@ work; see the CLAUDE.md "mzef package manager and distribution" section. The **R
 - [ ] **Language server** — designed in [docs/adr/0065-language-server-targets-ai-agents.md](docs/adr/0065-language-server-targets-ai-agents.md)
       (an AI agent is the primary consumer, so only the methods an agent consumes are implemented,
       and "does mutsu support this?" is a first-class diagnostic). **S0 (viability gate), S1 (server
-      skeleton), S2's routine half, S3 (error recovery) and S4 (symbols/definition) are done** — `crates/mutsu-lsp/`,
-      `src/analysis/`, [docs/language-server.md](docs/language-server.md). Next is **S5:
-      `references` and `hover`** — `references` is the first method that genuinely needs
-      per-occurrence positions, since a line may hold several and text scanning cannot rank them
-      soundly. **S2's method half is deferred with a real design question**: `$x.foo` needs the
+      skeleton), S2's routine half, S3 (error recovery), S4 (symbols/definition) and S5a (hover) are done** — `crates/mutsu-lsp/`,
+      `src/analysis/`, [docs/language-server.md](docs/language-server.md). Next is **S5b:
+      `references`** — the one remaining method that genuinely needs per-occurrence positions,
+      since a line may hold several and text scanning cannot rank them soundly. It is where D6's
+      "spans only on the variants a feature demands" finally gets exercised, so settle the target
+      variants (~5 reference nodes) before touching the parser's hot path or the bincode AST
+      cache. **S2's method half is deferred with a real design question**: `$x.foo` needs the
       receiver type, which the AST does not carry, and the existing `(owner, name)` catalog is
       conservative in the false-positive direction — see the ADR's S2 findings.
 - [ ] Debugger.

--- a/crates/mutsu-lsp/src/hover.rs
+++ b/crates/mutsu-lsp/src/hover.rs
@@ -1,0 +1,188 @@
+//! What mutsu can say about the name under the caret (ADR-0065 D3's `hover`:
+//! "type/signature, and mutsu coverage status").
+//!
+//! The coverage half is the part that only a server built on the target runtime
+//! can offer. Hovering a routine mutsu does not have says so, in the place a
+//! reader is already looking, before the code is ever run.
+
+use lsp_types::{Hover, HoverContents, MarkupContent, MarkupKind, Range};
+use mutsu::analysis::{Symbol, SymbolKind};
+
+/// What was found out about a name.
+pub enum Known {
+    /// Declared somewhere the server can see. `origin` says where, in words —
+    /// "in this document", or a path.
+    Declared { symbol: Symbol, origin: String },
+    /// Not declared anywhere, but mutsu provides it.
+    Builtin,
+    /// mutsu has no routine by this name. The suggestions are mutsu's own.
+    Unknown { suggestions: Vec<String> },
+}
+
+/// The Raku declarator for a kind, for the code block's opening word.
+fn declarator(kind: SymbolKind) -> &'static str {
+    match kind {
+        SymbolKind::Module => "module",
+        SymbolKind::Package => "package",
+        SymbolKind::Class => "class",
+        SymbolKind::Grammar => "grammar",
+        SymbolKind::Role => "role",
+        SymbolKind::Subset => "subset",
+        SymbolKind::Enum => "enum",
+        SymbolKind::EnumMember => "enum value",
+        SymbolKind::Sub => "sub",
+        SymbolKind::Method => "method",
+        SymbolKind::PrivateMethod => "method !",
+        SymbolKind::Token => "token",
+        SymbolKind::Rule => "rule",
+        SymbolKind::Attribute => "has",
+        SymbolKind::Variable => "my",
+    }
+}
+
+/// Render what is known into the hover a client shows.
+pub fn render(name: &str, known: Known, range: Range) -> Hover {
+    let markdown = match known {
+        Known::Declared { symbol, origin } => {
+            let signature = symbol.signature.clone().unwrap_or_default();
+            format!(
+                "```raku\n{} {}{}\n```\n\nDeclared {} on line {}.",
+                declarator(symbol.kind),
+                symbol.name,
+                signature,
+                origin,
+                symbol.line,
+            )
+        }
+        // The affirmative half of the coverage answer. Worth saying rather than
+        // staying silent: "mutsu has this" is exactly what a writer targeting
+        // mutsu wants confirmed, and silence is indistinguishable from "the
+        // server did not understand the question".
+        Known::Builtin => {
+            format!("```raku\n{name}\n```\n\nA built-in routine. **mutsu implements this.**")
+        }
+        Known::Unknown { suggestions } => {
+            let mut text = format!(
+                "**mutsu has no routine named `{name}`.**\n\n\
+                 It is declared nowhere in this document or workspace, and mutsu \
+                 provides no built-in by that name."
+            );
+            if !suggestions.is_empty() {
+                text.push_str(&format!(
+                    "\n\nDid you mean {}?",
+                    suggestions
+                        .iter()
+                        .map(|s| format!("`{s}`"))
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                ));
+            }
+            text
+        }
+    };
+    Hover {
+        contents: HoverContents::Markup(MarkupContent {
+            kind: MarkupKind::Markdown,
+            value: markdown,
+        }),
+        range: Some(range),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use lsp_types::Position;
+
+    fn any_range() -> Range {
+        Range {
+            start: Position {
+                line: 0,
+                character: 0,
+            },
+            end: Position {
+                line: 0,
+                character: 1,
+            },
+        }
+    }
+
+    fn text_of(hover: &Hover) -> &str {
+        match &hover.contents {
+            HoverContents::Markup(m) => &m.value,
+            _ => panic!("expected markdown"),
+        }
+    }
+
+    fn symbol_of(source: &str, name: &str) -> Symbol {
+        mutsu::analysis::symbols::find(&mutsu::analysis::symbols(source), name).expect("declared")
+    }
+
+    #[test]
+    fn a_declared_routine_shows_its_signature_and_where_it_lives() {
+        let symbol = symbol_of("sub add(Int $a, Int $b --> Int) { $a + $b }\n", "add");
+        let hover = render(
+            "add",
+            Known::Declared {
+                symbol,
+                origin: "in this document".to_string(),
+            },
+            any_range(),
+        );
+        let text = text_of(&hover);
+        assert!(text.contains("sub add(Int $a, Int $b --> Int)"), "{text}");
+        assert!(
+            text.contains("Declared in this document on line 1."),
+            "{text}"
+        );
+    }
+
+    #[test]
+    fn a_declared_class_reads_as_a_class() {
+        let symbol = symbol_of("class Widget { }\n", "Widget");
+        let text = text_of(&render(
+            "Widget",
+            Known::Declared {
+                symbol,
+                origin: "in lib/Widget.rakumod".to_string(),
+            },
+            any_range(),
+        ))
+        .to_string();
+        assert!(text.contains("class Widget"), "{text}");
+        assert!(text.contains("in lib/Widget.rakumod"), "{text}");
+    }
+
+    /// ADR-0065 D4, in the place a reader is already looking.
+    #[test]
+    fn a_builtin_is_confirmed_rather_than_left_silent() {
+        let text = text_of(&render("uc", Known::Builtin, any_range())).to_string();
+        assert!(text.contains("mutsu implements this"), "{text}");
+    }
+
+    #[test]
+    fn an_unknown_routine_says_so_and_offers_what_mutsu_does_have() {
+        let hover = render(
+            "elem",
+            Known::Unknown {
+                suggestions: vec!["elems".to_string()],
+            },
+            any_range(),
+        );
+        let text = text_of(&hover);
+        assert!(text.contains("mutsu has no routine named `elem`"), "{text}");
+        assert!(text.contains("Did you mean `elems`?"), "{text}");
+    }
+
+    #[test]
+    fn an_unknown_routine_with_no_near_miss_offers_nothing() {
+        let hover = render(
+            "zzzzzz",
+            Known::Unknown {
+                suggestions: Vec::new(),
+            },
+            any_range(),
+        );
+        assert!(!text_of(&hover).contains("Did you mean"));
+    }
+}

--- a/crates/mutsu-lsp/src/lib.rs
+++ b/crates/mutsu-lsp/src/lib.rs
@@ -11,6 +11,7 @@
 
 pub mod diagnostics;
 pub mod documents;
+pub mod hover;
 pub mod positions;
 pub mod server;
 pub mod symbols;

--- a/crates/mutsu-lsp/src/server.rs
+++ b/crates/mutsu-lsp/src/server.rs
@@ -16,7 +16,8 @@ use lsp_types::notification::{
     Notification as NotificationTrait, PublishDiagnostics,
 };
 use lsp_types::request::{
-    DocumentSymbolRequest, GotoDefinition, Request as RequestTrait, WorkspaceSymbolRequest,
+    DocumentSymbolRequest, GotoDefinition, HoverRequest, Request as RequestTrait,
+    WorkspaceSymbolRequest,
 };
 use lsp_types::{
     DocumentSymbolResponse, GotoDefinitionResponse, Location, OneOf, PositionEncodingKind,
@@ -52,6 +53,7 @@ pub fn server_capabilities() -> ServerCapabilities {
             },
         )),
         document_symbol_provider: Some(OneOf::Left(true)),
+        hover_provider: Some(lsp_types::HoverProviderCapability::Simple(true)),
         workspace_symbol_provider: Some(OneOf::Left(true)),
         definition_provider: Some(OneOf::Left(true)),
         ..Default::default()
@@ -101,6 +103,7 @@ fn handle_request(documents: &Documents, workspace: &mut Workspace, request: Req
         DocumentSymbolRequest::METHOD => document_symbol(documents, request),
         WorkspaceSymbolRequest::METHOD => workspace_symbol(workspace, request),
         GotoDefinition::METHOD => definition(documents, workspace, request),
+        HoverRequest::METHOD => hover(documents, workspace, request),
         method => {
             return Response::new_err(
                 id,
@@ -205,6 +208,68 @@ fn definition(
         }
     }
     Ok(serde_json::Value::Null)
+}
+
+/// Answer `textDocument/hover`: what mutsu knows about the name under the caret.
+///
+/// The lookup order mirrors `definition` — open document, then workspace — and
+/// then asks the question only a server built on the target runtime can:
+/// whether mutsu provides this routine at all (ADR-0065 D3/D4).
+fn hover(
+    documents: &Documents,
+    workspace: &mut Workspace,
+    request: Request,
+) -> Result<serde_json::Value, BoxError> {
+    let params: lsp_types::HoverParams = serde_json::from_value(request.params)?;
+    let uri = params.text_document_position_params.text_document.uri;
+    let position = params.text_document_position_params.position;
+    let Some(document) = documents.get(&uri) else {
+        return Ok(serde_json::Value::Null);
+    };
+    let Some(name) = crate::positions::identifier_at(&document.text, position) else {
+        return Ok(serde_json::Value::Null);
+    };
+    let range = crate::positions::name_range(&document.text, position.line + 1, &name);
+
+    if let Some(symbol) =
+        mutsu::analysis::symbols::find(&mutsu::analysis::symbols(&document.text), &name)
+    {
+        return Ok(serde_json::to_value(crate::hover::render(
+            &name,
+            crate::hover::Known::Declared {
+                symbol,
+                origin: "in this document".to_string(),
+            },
+            range,
+        ))?);
+    }
+    for path in workspace.files() {
+        let label = path.display().to_string();
+        let Some(text) = workspace.text_of(&path) else {
+            continue;
+        };
+        if let Some(symbol) = mutsu::analysis::symbols::find(&mutsu::analysis::symbols(text), &name)
+        {
+            return Ok(serde_json::to_value(crate::hover::render(
+                &name,
+                crate::hover::Known::Declared {
+                    symbol,
+                    origin: format!("in {label}"),
+                },
+                range,
+            ))?);
+        }
+    }
+    let known = if mutsu::analysis::is_builtin_routine(&name) {
+        crate::hover::Known::Builtin
+    } else {
+        crate::hover::Known::Unknown {
+            suggestions: mutsu::analysis::suggest_routines(&name),
+        }
+    };
+    Ok(serde_json::to_value(crate::hover::render(
+        &name, known, range,
+    ))?)
 }
 
 fn uri_of_path(path: &std::path::Path) -> Option<Uri> {

--- a/crates/mutsu-lsp/tests/protocol.rs
+++ b/crates/mutsu-lsp/tests/protocol.rs
@@ -336,12 +336,15 @@ fn every_failure_in_the_document_reaches_the_client() {
 #[test]
 fn an_unimplemented_request_is_answered_rather_than_ignored() {
     let mut client = Client::start();
-    client.open("file:///tmp/hover.raku", "say 1;\n", 1);
+    client.open("file:///tmp/unimplemented.raku", "say 1;\n", 1);
 
+    // `completion` is out of scope by decision, not by omission (ADR-0065 D3):
+    // an agent does not type character by character, and implementing it would
+    // require caret-position scope resolution.
     let id = client.request(
-        "textDocument/hover",
+        "textDocument/completion",
         serde_json::json!({
-            "textDocument": { "uri": "file:///tmp/hover.raku" },
+            "textDocument": { "uri": "file:///tmp/unimplemented.raku" },
             "position": { "line": 0, "character": 0 },
         }),
     );
@@ -350,7 +353,10 @@ fn an_unimplemented_request_is_answered_rather_than_ignored() {
         .response_result
         .expect_err("an unimplemented method must error");
     assert_eq!(error.code, lsp_server::ErrorCode::MethodNotFound as i32);
-    assert!(error.message.contains("textDocument/hover"), "{error:?}");
+    assert!(
+        error.message.contains("textDocument/completion"),
+        "{error:?}"
+    );
 
     client.shutdown();
 }
@@ -627,4 +633,87 @@ fn definition_falls_back_to_the_workspace_when_the_open_document_does_not_declar
 
     client.shutdown();
     let _ = std::fs::remove_dir_all(&root);
+}
+
+/// ADR-0065 D3's `hover`: "type/signature, and mutsu coverage status". The
+/// coverage half is what only a server built on the target runtime can offer.
+#[test]
+fn hover_shows_a_signature_for_a_declared_routine() {
+    let mut client = Client::start();
+    let path = "file:///tmp/hover-sig.raku";
+    client.open(
+        path,
+        "sub add(Int $a, Int $b --> Int) { $a + $b }\nsay add(1, 2);\n",
+        1,
+    );
+
+    let id = client.request(
+        "textDocument/hover",
+        serde_json::json!({
+            "textDocument": { "uri": path },
+            "position": { "line": 1, "character": 5 },
+        }),
+    );
+    let result = client
+        .recv_response(id)
+        .response_result
+        .expect("hover must succeed");
+    let text = result["contents"]["value"].as_str().expect("markdown");
+    assert!(text.contains("sub add(Int $a, Int $b --> Int)"), "{text}");
+    assert!(text.contains("line 1"), "{text}");
+
+    client.shutdown();
+}
+
+#[test]
+fn hover_says_whether_mutsu_has_the_routine_at_all() {
+    let mut client = Client::start();
+    let path = "file:///tmp/hover-coverage.raku";
+    client.open(path, "say uc('x');\nsay elem([1, 2]);\n", 1);
+
+    // A routine mutsu provides.
+    let id = client.request(
+        "textDocument/hover",
+        serde_json::json!({
+            "textDocument": { "uri": path },
+            "position": { "line": 0, "character": 5 },
+        }),
+    );
+    let result = client.recv_response(id).response_result.expect("hover");
+    let text = result["contents"]["value"].as_str().expect("markdown");
+    assert!(text.contains("mutsu implements this"), "{text}");
+
+    // A routine it does not, with mutsu's own suggestion attached.
+    let id = client.request(
+        "textDocument/hover",
+        serde_json::json!({
+            "textDocument": { "uri": path },
+            "position": { "line": 1, "character": 6 },
+        }),
+    );
+    let result = client.recv_response(id).response_result.expect("hover");
+    let text = result["contents"]["value"].as_str().expect("markdown");
+    assert!(text.contains("mutsu has no routine named `elem`"), "{text}");
+    assert!(text.contains("elems"), "{text}");
+
+    client.shutdown();
+}
+
+#[test]
+fn hover_on_nothing_answers_null() {
+    let mut client = Client::start();
+    let path = "file:///tmp/hover-nothing.raku";
+    client.open(path, "  ;\n", 1);
+
+    let id = client.request(
+        "textDocument/hover",
+        serde_json::json!({
+            "textDocument": { "uri": path },
+            "position": { "line": 0, "character": 2 },
+        }),
+    );
+    let result = client.recv_response(id).response_result.expect("hover");
+    assert!(result.is_null(), "{result:#}");
+
+    client.shutdown();
 }

--- a/docs/adr/0065-language-server-targets-ai-agents.md
+++ b/docs/adr/0065-language-server-targets-ai-agents.md
@@ -533,6 +533,39 @@ clients still send them, and a server that understood only the current spelling 
 silently have no workspace at all — a failure that looks like "no results" rather than like
 a bug.
 
+## S5a findings (2026-09-03)
+
+S5 was scheduled as one slice, "`references` / `hover`". Splitting it was the first thing
+S4 made obvious: `hover` is `definition`'s machinery with a different answer attached
+(position → identifier → symbol) and needs no spans at all, while `references` is the *only*
+method that genuinely does. Shipping them together would have held a cheap, useful method
+behind the heaviest engineering in the plan.
+
+### 1. Signatures are reconstructed from the parse, not lifted from the source
+
+`hover` shows `sub add(Int $a, Int $b --> Int)` by rendering the parsed `ParamDef`s back to
+Raku source form. Copying the declaration's source text would have been easier and is the
+wrong answer: what a writer targeting mutsu needs to see is **what mutsu understood the
+signature to be**, which is exactly where a divergence would show up.
+
+The rendering is deliberately partial. `where` clauses, sub-signatures and default
+*expressions* are dropped — rendering an expression back to source needs a printer mutsu
+does not have, and a half-rendered default would be a hover that lies. A default is shown
+as `= ...`, which says "there is one" without claiming what it is.
+
+Two AST details had to be recovered rather than assumed: `ParamDef::name` stores `@rest`
+for an array but a bare `a` for `$a` (the scalar sigil is stripped at parse time), and
+`required` only ever means "a named parameter written with `!`" — a mandatory positional
+carries no flag at all, so positional optionality reads `optional_marker` instead.
+
+### 2. "mutsu implements this" is worth saying out loud
+
+The obvious design reports only the negative — hovering a routine mutsu lacks says so. The
+affirmative case is reported too, because to this consumer silence is indistinguishable
+from "the server did not understand the question", and "mutsu has this" is precisely what
+someone writing for mutsu wants confirmed. It is the same D4 signal as S2's diagnostic,
+delivered where a reader is already looking and before the code is ever run.
+
 ## Rejected alternatives
 
 - **A lossless CST / red-green tree (rust-analyzer, rowan).** The correct architecture for
@@ -562,7 +595,8 @@ a bug.
 | **S2** | Enumerable built-in name tables → "mutsu does not support this" diagnostics (D4) — **routine half done 2026-09-03**; the method half is blocked on receiver types, see the S2 findings | S1 |
 | **S3** | Multiple diagnostics per document + error recovery (give `parse_program_partial` positions and errors) — **done 2026-09-03** | S1 |
 | **S4** | `documentSymbol` / `workspaceSymbol` / `definition` at line granularity — **done 2026-09-03** | S1 |
-| **S5** | `references` / `hover`; expression spans on the variants these require (D6) | S4 |
+| **S5a** | `hover` — signature and mutsu coverage status; needs no spans — **done 2026-09-03** | S4 |
+| **S5b** | `references`; expression spans on the variants it requires (D6) | S4 |
 
 S2 delivers the capability unique to mutsu and depends on no span work, so the ordering
 front-loads distinctive value ahead of the heaviest engineering.

--- a/docs/language-server.md
+++ b/docs/language-server.md
@@ -39,7 +39,8 @@ independently of the interpreter (`tag-release.yml` bumps only the root
 | `textDocument/documentSymbol` | Yes — nested, with the Raku declarator in `detail` |
 | `workspace/symbol` | Yes — reads the workspace on demand, case-insensitive substring match |
 | `textDocument/definition` | Yes — the open document first, then the workspace |
-| `references`, `hover` | Planned (ADR-0065 S5) |
+| `textDocument/hover` | Yes — signature, and whether mutsu implements the name |
+| `references` | Planned (ADR-0065 S5b — the one method that needs per-occurrence spans) |
 | `completion`, `semanticTokens`, `signatureHelp`, `inlayHint` | **Out of scope** (D3) |
 | Incremental document sync | **Out of scope** (D3) |
 
@@ -125,6 +126,15 @@ against the file removes a class of staleness bug. The walk is capped at 4000
 files, because a query over an unbounded tree is a hang and a hung server is
 worse than a truncated answer.
 
+`hover` answers with the declaration's signature where there is one, and with
+mutsu's coverage otherwise: a built-in mutsu provides is confirmed as such, and
+a name mutsu has never heard of says so, with mutsu's own "Did you mean"
+attached. Signatures are *reconstructed from the parse* rather than copied out
+of the source, because what a writer targeting mutsu needs to see is what mutsu
+understood the signature to be. The rendering drops `where` clauses,
+sub-signatures and default expressions — a default shows as `= ...`, which says
+there is one without claiming what it is.
+
 A parse failure inside a `use`d module is anchored at line 1 of the *open*
 document and names the other file in its message. Reporting that module's
 line and column against this document would point at an unrelated line, which
@@ -173,6 +183,7 @@ which has no column, covers the whole line.
 | `src/analysis/symbols.rs` (in `mutsu`) | The declarations a document contains, nested, at line granularity. Runs over a recovering parse, so a broken document still has an outline. |
 | `crates/mutsu-lsp/src/symbols.rs` | mutsu's declarations to LSP symbols, and the `SymbolKind` mapping. |
 | `crates/mutsu-lsp/src/workspace.rs` | The files a workspace-wide query reads, and their cache. |
+| `crates/mutsu-lsp/src/hover.rs` | What mutsu can say about the name under the caret, rendered as markdown. |
 | `crates/mutsu-lsp/tests/protocol.rs` | End-to-end tests over `lsp_server::Connection::memory()`, driving the real loop. |
 
 The loop is synchronous and single-threaded on purpose: D3 leaves nothing

--- a/news/2026-09/adr0065-s5a-hover.md
+++ b/news/2026-09/adr0065-s5a-hover.md
@@ -1,0 +1,54 @@
+# Hover tells you whether mutsu has the thing you are hovering
+
+ADR-0065 scheduled S5 as one slice, "`references` / `hover`". Splitting it was
+the first thing S4 made obvious: `hover` is `definition`'s machinery with a
+different answer attached — position → identifier → symbol — and needs no spans
+at all, while `references` is the *only* method that genuinely does. Shipping
+them together would have held a cheap, useful method behind the heaviest
+engineering left in the plan.
+
+So `hover` ships now, and `references` becomes S5b.
+
+## Signatures are reconstructed from the parse, not lifted from the source
+
+Hovering `add` shows `sub add(Int $a, Int $b --> Int)`, rendered from the parsed
+`ParamDef`s back into Raku source form. Copying the declaration's source text
+would have been easier and is the wrong answer: what a writer targeting mutsu
+needs to see is **what mutsu understood the signature to be**, which is exactly
+where a divergence from rakudo would show up.
+
+The rendering is deliberately partial. `where` clauses, sub-signatures and
+default *expressions* are dropped, because rendering an expression back to source
+needs a printer mutsu does not have and a half-rendered default would be a hover
+that lies. A default shows as `= ...`, which says there is one without claiming
+what it is.
+
+Two AST details had to be recovered rather than assumed, and the tests caught
+both immediately: `ParamDef::name` stores `@rest` for an array but a bare `a` for
+`$a` — the scalar sigil is stripped at parse time — and `required` only ever
+means "a named parameter written with `!`". A mandatory positional carries no
+flag at all, so positional optionality reads `optional_marker` instead. The first
+draft rendered `(Int a?, Int b?) --> Int` for `(Int $a, Int $b --> Int)`: wrong
+sigils, wrong optionality, and the return type outside the parentheses.
+
+## "mutsu implements this" is worth saying out loud
+
+The obvious design reports only the negative: hovering a routine mutsu lacks says
+so, with mutsu's own "Did you mean" attached. The affirmative case is reported
+too — hovering `uc` says it is a built-in and that **mutsu implements it**.
+
+That is not padding. To this consumer, silence is indistinguishable from "the
+server did not understand the question", and "mutsu has this" is precisely what
+someone writing Raku for mutsu wants confirmed. It is the same D4 signal as S2's
+diagnostic, delivered where a reader is already looking and before the code is
+ever run.
+
+## What is left
+
+`references` (S5b) is the one method that cannot be done this way. `definition`
+gets away without positions because it only needs to know what *one* word is;
+`references` must find every occurrence and rank them, which text scanning cannot
+do soundly. It is where D6's "spans only on the variants a feature demands"
+finally gets exercised — and where the parser's hot path and the bincode AST
+precompilation cache come into range, so the target variants want settling before
+any code is written.

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -27,6 +27,7 @@ pub mod symbols;
 pub use symbols::{Symbol, SymbolKind, symbols};
 
 use crate::ast::Stmt;
+use crate::interpreter::Interpreter;
 use crate::value::{RuntimeError, RuntimeErrorCode};
 
 /// How much a [`Diagnostic`] should be believed.
@@ -78,6 +79,23 @@ impl Diagnostic {
             in_other_file: None,
         }
     }
+}
+
+/// Whether mutsu implements a built-in routine by this name.
+///
+/// The other half of D4's coverage question, in the form `hover` needs: a name
+/// that is declared nowhere in the workspace is either a routine mutsu provides
+/// or one it does not have at all, and those are very different answers to
+/// someone writing Raku for mutsu.
+pub fn is_builtin_routine(name: &str) -> bool {
+    Interpreter::is_builtin_function(name) || Interpreter::is_test_function_name(name)
+}
+
+/// Names close to `name` that mutsu does have — the same "Did you mean"
+/// candidates its own error carries, exposed for a consumer that wants to offer
+/// them before the code is run.
+pub fn suggest_routines(name: &str) -> Vec<String> {
+    Interpreter::static_routine_suggestions(name, &std::collections::HashSet::new())
 }
 
 /// mutsu's CHECK-time undeclared-routine analysis, run without executing

--- a/src/analysis/symbols.rs
+++ b/src/analysis/symbols.rs
@@ -18,7 +18,7 @@
 //! a file with a syntax error still yields the symbols around it — which is the
 //! point, since a document under edit is broken most of the time (S3).
 
-use crate::ast::{PackageKind, Stmt};
+use crate::ast::{PackageKind, ParamDef, Stmt};
 
 /// What a declaration declares. Deliberately mutsu's own vocabulary rather than
 /// LSP's `SymbolKind`, which has no spelling for a role, a grammar token or a
@@ -70,6 +70,11 @@ pub struct Symbol {
     /// 1-based last line the declaration covers, best effort: the deepest
     /// `Stmt::SetLine` seen inside its body. Never less than `line`.
     pub end_line: u32,
+    /// The rendered signature, for a routine that has one: `(Int $n, :$verbose
+    /// --> Str)`. Reconstructed from the parsed parameters rather than from the
+    /// source text, so it reflects what mutsu actually understood the signature
+    /// to be — which is the useful thing to show someone writing for mutsu.
+    pub signature: Option<String>,
     pub children: Vec<Symbol>,
 }
 
@@ -134,13 +139,20 @@ fn collect(stmts: &[Stmt], line: &mut u32, in_routine: bool) -> Vec<Symbol> {
                 };
                 out.push(declaration(name.resolve(), kind, line, body, false));
             }
-            Stmt::SubDecl { name, body, .. } => {
-                out.push(declaration(
+            Stmt::SubDecl {
+                name,
+                body,
+                param_defs,
+                return_type,
+                ..
+            } => {
+                out.push(declaration_with_signature(
                     name.resolve(),
                     SymbolKind::Sub,
                     line,
                     body,
                     true,
+                    render_signature(param_defs, return_type.as_deref()),
                 ));
             }
             Stmt::ProtoDecl {
@@ -160,6 +172,8 @@ fn collect(stmts: &[Stmt], line: &mut u32, in_routine: bool) -> Vec<Symbol> {
                 name,
                 body,
                 is_private,
+                param_defs,
+                return_type,
                 ..
             } => {
                 let kind = if *is_private {
@@ -167,7 +181,14 @@ fn collect(stmts: &[Stmt], line: &mut u32, in_routine: bool) -> Vec<Symbol> {
                 } else {
                     SymbolKind::Method
                 };
-                out.push(declaration(name.resolve(), kind, line, body, true));
+                out.push(declaration_with_signature(
+                    name.resolve(),
+                    kind,
+                    line,
+                    body,
+                    true,
+                    render_signature(param_defs, return_type.as_deref()),
+                ));
             }
             Stmt::TokenDecl { name, body, .. } => {
                 out.push(declaration(
@@ -217,7 +238,83 @@ fn leaf(name: String, kind: SymbolKind, line: u32) -> Symbol {
         kind,
         line,
         end_line: line,
+        signature: None,
         children: Vec::new(),
+    }
+}
+
+/// Render a parsed signature back to Raku source form.
+///
+/// An approximation on purpose: `where` clauses, sub-signatures and default
+/// *expressions* are dropped, because rendering an expression back to source
+/// needs a printer mutsu does not have, and a half-rendered default would be a
+/// diagnostic that lies. What is kept — type, sigil, name, optionality,
+/// namedness, slurpiness, return type — is what a caller needs.
+pub(crate) fn render_signature(params: &[ParamDef], return_type: Option<&str>) -> Option<String> {
+    let rendered: Vec<String> = params
+        .iter()
+        .filter(|p| !p.is_invocant)
+        .map(render_param)
+        .collect();
+    if rendered.is_empty() && return_type.is_none() {
+        return Some("()".to_string());
+    }
+    let mut inner = rendered.join(", ");
+    if let Some(ret) = return_type {
+        if !inner.is_empty() {
+            inner.push(' ');
+        }
+        inner.push_str(&format!("--> {ret}"));
+    }
+    Some(format!("({inner})"))
+}
+
+fn render_param(param: &ParamDef) -> String {
+    let mut out = String::new();
+    if let Some(constraint) = &param.type_constraint {
+        out.push_str(constraint);
+        out.push(' ');
+    }
+    if param.named {
+        out.push(':');
+    }
+    let prefix = if param.double_slurpy {
+        "**"
+    } else if param.onearg {
+        "+"
+    } else if param.slurpy {
+        "*"
+    } else {
+        ""
+    };
+    out.push_str(prefix);
+    out.push_str(&sigil_name(param));
+    // Raku spells the two optionality cases differently: a *named* parameter is
+    // optional unless marked `!`, a positional is required unless marked `?`.
+    // `required` in the AST only ever means "a named parameter written with
+    // `!`" — a mandatory positional carries no flag at all, which is why the
+    // positional case reads `optional_marker` instead.
+    if param.named && param.required {
+        out.push('!');
+    } else if !param.named && param.optional_marker {
+        out.push('?');
+    }
+    if param.default.is_some() {
+        out.push_str(" = ...");
+    }
+    out
+}
+
+/// A parameter's name with its sigil.
+///
+/// `ParamDef::name` holds `@rest` for an array but a bare `a` for `$a`: the
+/// scalar sigil is stripped at parse time. Putting it back is what makes a
+/// rendered signature read like the source it came from.
+fn sigil_name(param: &ParamDef) -> String {
+    if param.sigilless || param.name.starts_with(['$', '@', '%', '&']) {
+        param.name.clone()
+    } else {
+        format!("${}", param.name)
     }
 }
 
@@ -230,6 +327,17 @@ fn declaration(
     body: &[Stmt],
     body_is_routine: bool,
 ) -> Symbol {
+    declaration_with_signature(name, kind, line, body, body_is_routine, None)
+}
+
+fn declaration_with_signature(
+    name: String,
+    kind: SymbolKind,
+    line: &mut u32,
+    body: &[Stmt],
+    body_is_routine: bool,
+    signature: Option<String>,
+) -> Symbol {
     let start = *line;
     // The body's own `SetLine` markers advance the shared cursor; wherever it
     // ends up is the last line the declaration demonstrably covers. The closing
@@ -241,6 +349,7 @@ fn declaration(
         kind,
         line: start,
         end_line,
+        signature,
         children,
     }
 }
@@ -420,6 +529,47 @@ class Foo {
             .find(|(s, _)| s.name == "Foo")
             .expect("Foo is present");
         assert_eq!(foo.1, None);
+    }
+
+    #[test]
+    fn a_routine_carries_its_rendered_signature() {
+        let found = symbols("sub add(Int $a, Int $b --> Int) { $a + $b }\n");
+        assert_eq!(
+            found[0].signature.as_deref(),
+            Some("(Int $a, Int $b --> Int)")
+        );
+    }
+
+    #[test]
+    fn optional_named_and_slurpy_parameters_keep_their_spelling() {
+        let found = symbols("sub f($a, $b?, :$verbose, :$name!, *@rest) { 1 }\n");
+        assert_eq!(
+            found[0].signature.as_deref(),
+            Some("($a, $b?, :$verbose, :$name!, *@rest)")
+        );
+    }
+
+    #[test]
+    fn a_routine_with_no_parameters_renders_empty_parentheses() {
+        let found = symbols("sub nothing() { 1 }\n");
+        assert_eq!(found[0].signature.as_deref(), Some("()"));
+    }
+
+    #[test]
+    fn a_default_is_shown_as_present_without_rendering_the_expression() {
+        // Rendering an expression back to source needs a printer mutsu does not
+        // have, and a half-rendered default would be worse than an honest
+        // ellipsis.
+        let found = symbols("sub f($a = 42) { $a }\n");
+        let signature = found[0].signature.as_deref().unwrap_or_default();
+        assert!(signature.contains("= ..."), "{signature:?}");
+    }
+
+    #[test]
+    fn a_class_has_no_signature_but_its_methods_do() {
+        let found = symbols("class C {\n    method m(Str $s) { $s }\n}\n");
+        assert_eq!(found[0].signature, None);
+        assert_eq!(found[0].children[0].signature.as_deref(), Some("(Str $s)"));
     }
 
     #[test]


### PR DESCRIPTION
S5 was scheduled as one slice, "`references` / `hover`". **Splitting it was the first thing S4 made obvious**: `hover` is `definition`'s machinery with a different answer attached (position → identifier → symbol) and needs no spans at all, while `references` is the *only* method that genuinely does. Shipping them together would have held a cheap, useful method behind the heaviest engineering left in the plan. `references` becomes S5b.

## Signatures are reconstructed from the parse, not lifted from the source

Hovering `add` shows `sub add(Int $a, Int $b --> Int)`, rendered from the parsed `ParamDef`s back into Raku source form. Copying the declaration's source text would have been easier and is the wrong answer: what a writer targeting mutsu needs to see is **what mutsu understood the signature to be**, which is exactly where a divergence from rakudo would show up.

The rendering is deliberately partial. `where` clauses, sub-signatures and default *expressions* are dropped — rendering an expression back to source needs a printer mutsu does not have, and a half-rendered default would be a hover that lies. A default shows as `= ...`, which says there is one without claiming what it is.

Two AST details had to be recovered rather than assumed, and the tests caught both immediately:

- `ParamDef::name` stores `@rest` for an array but a bare `a` for `$a` — the scalar sigil is stripped at parse time.
- `required` only ever means "a named parameter written with `!`". A mandatory positional carries no flag at all, so positional optionality reads `optional_marker`.

The first draft rendered `(Int a?, Int b?) --> Int` for `(Int $a, Int $b --> Int)`: wrong sigils, wrong optionality, return type outside the parentheses.

## "mutsu implements this" is worth saying out loud

The obvious design reports only the negative — hovering a routine mutsu lacks says so, with mutsu's own "Did you mean" attached. The affirmative case is reported too: hovering `uc` says it is a built-in and that **mutsu implements it**.

That is not padding. To this consumer silence is indistinguishable from "the server did not understand the question", and "mutsu has this" is precisely what someone writing Raku for mutsu wants confirmed. Same D4 signal as S2's diagnostic, delivered where a reader is already looking and before the code is ever run.

## Also

The protocol test for an unimplemented method moves from `textDocument/hover` (now implemented) to `textDocument/completion`, which is out of scope **by decision rather than by omission** (D3) and is therefore the better thing to pin.

## Verification

- `make test` — 36666 tests, `Result: PASS`.
- `cargo test -p mutsu-lsp` — 56 tests, including end-to-end hover for a declared routine's signature, for a built-in mutsu has, and for a name it does not.
- `cargo clippy -- -D warnings`, `cargo clippy -p mutsu-lsp --all-targets -- -D warnings`, `cargo fmt --all -- --check` clean.
- No parser or runtime behaviour changes: `src/analysis/` gains a field and two public wrappers over existing associated functions, so the full roast suite in CI is the appropriate net rather than a targeted sweep.

Next is **S5b**: `references`. `definition` gets away without positions because it only needs to know what *one* word is; `references` must find every occurrence and rank them, which text scanning cannot do soundly. It is where D6's "spans only on the variants a feature demands" finally gets exercised, and where the parser's hot path and the bincode AST precompilation cache come into range — so the target variants want settling before any code is written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)