### PR TITLE
docs(perf): replace the remaining late-August slowdown ticket with a differential profile

### DIFF
--- a/todo/perf/late-august-call-path-slowdown-remainder.md
+++ b/todo/perf/late-august-call-path-slowdown-remainder.md
@@ -1,4 +1,4 @@
-# The late-August call-path slowdown, minus the ADR-0037 step, is still ~24% on `bench-fib`
+# The late-August call-path slowdown, minus the ADR-0037 step, is still ~25% on `bench-fib`
 
 Between 2026-08-19 and 2026-08-31 a broad set of call-path-shaped benchmarks got
 slower while an unrelated set got faster. Daily medians of the bench-CI series
@@ -16,42 +16,90 @@ slower while an unrelated set got faster. Daily medians of the bench-CI series
 `bench-startup` is flat over the window (+0.4 ms), so this is not startup cost
 and is unrelated to `todo/perf/interpreter-new-is-expensive-and-retains-memory.md`.
 
-The first bad commit for the largest step was found and fixed —
+The largest step was found by bisection and fixed —
 `news/2026-09/adr0037-routine-frame-push-intern-cost.md`: #6720 (ADR-0037
-Slice 1) added a `RoutineFrame` push to the light call paths whose five
-per-call `Symbol::intern`s cost 26% of `bench-fib`. That is now ~3%.
+Slice 1) added a `RoutineFrame` push to the light call paths whose five per-call
+`Symbol::intern`s cost 26% of `bench-fib`. That is now ~3%.
 
-**What remains:** with that fix in place, a local release build is still
-~24% slower than a build of `af7c5d6eb4d9` (2026-08-19) on `bench-fib`
-(0.1497 s vs 0.1190 s, interleaved medians of 15 on an idle box). `bench-hash`,
-`hash-access`, `bench-string` and `bench-grammar-parse` show a similar residual.
-So at least one more regression landed in the same two weeks.
+**What remains:** with that fix in place a local release build is still ~25%
+slower than a build of `af7c5d6eb4d9` (2026-08-19) on `bench-fib`. Under `perf`
+(fib(33), JIT on, pinned to a P-core, `profiling` builds of both) the run costs
+**5.504 Gcycles then vs 7.108 Gcycles now, +29.1%**.
 
-## How to continue
+## Do NOT keep bisecting — read this first
 
-Repeat exactly what found the first one — the method is the reusable part:
+Bisection found the 26% step cleanly. It does **not** work for what is left, and
+a second bisect run proved why rather than producing an answer.
 
-1. Build a reference binary at `af7c5d6eb4d9` and one at `main`, and confirm the
-   gap reproduces locally. It does; the bench-CI per-commit rows do **not**
-   attribute anything, because for a sub-0.2 s benchmark they are bimodal
-   (`bench-fib+jit` alternates ~0.17 s / ~0.25 s on adjacent commits). Do not
-   try to bisect the CI series itself.
-2. `git bisect start --first-parent main <good>` with a `bisect run` script that
-   does `cargo build --release` and times `benchmarks/bench-fib.raku` with
-   `MUTSU_JIT=on`, median of 7, exiting non-zero above a threshold placed
-   between the two known medians. ~3.5 min per step, ~9 steps over the 570
-   first-parent commits in the window.
-3. Set the threshold to sit just above the *post-#6720* level (say 0.155 s
-   against a `main` at ~0.166 s) so the bisect finds the next step rather than
-   re-finding #6720. Note the bisect must run on a branch that already contains
-   the #6720 fix, or apply it per-step, otherwise every commit after #6720 is
-   "bad" for the already-known reason.
-4. Once a commit is identified, confirm with a scaffolded build that
-   env-gates the suspect work, so the attribution is a measured delta rather
-   than an inference from the diff.
+That run named #6784 (`fix/bind-alias-reverse-write`) as the next bad commit, and
+an interleaved A/B of its merge against its first parent reproduces a consistent
+**+4.7%** on `bench-fib` in both orderings. But #6784 only touches `:=` bind
+paths, and `perf` on a build containing it samples **zero** cycles in
+`store_through_cell` or `propagate_bind_to_ancestor_frames` while running
+`bench-fib` — that code never executes here. The 4.7% is therefore a
+**code-layout effect** between two separately-built binaries, not a semantic
+regression (the trap is a known one: adding unrelated code moves hot functions).
 
-Run this solo, on an idle box (`uptime`, `pgrep -c -x rustc`), and interleave
-the A/B binaries rather than measuring them in sequence — a non-interleaved
-comparison of two separately-built binaries drifted enough here to invert a
-5% result. Per `todo/README.md` and CLAUDE.md, any number that ends up in a
-document comes from the bench CI, not from the session's local runs.
+Since layout noise is itself ~5%, and the remaining regression appears to be
+several steps of about that size, per-commit bisection cannot separate signal
+from layout. Any commit a further bisect names must be discharged the same way —
+check whether its code is even *sampled* in the benchmark — before it is
+believed.
+
+## Use the differential profile instead
+
+Symbol-level self-cycle delta, aug19 → today (same script, same box, same
+profile). Rust inlining differs between the builds, so treat individual rows as
+pointers to a *cluster*, not as exact attributions:
+
+| Δ Mcycles | aug19 | now | symbol |
+| ---: | ---: | ---: | --- |
+| +509 | 1558 | 2068 | `call_compiled_function_positional_light` (self) |
+| +240 | 0 | 240 | `hashbrown::HashMap::get` (outlined; new) |
+| +212 | 421 | 633 | `mutsu_jit_1` — **the JIT-compiled fib body itself, +50%** |
+| +130 | 874 | 1004 | `exec_call_func_op` (self) |
+| +114 | 66 | 180 | `nanbox::payload_op` |
+| +107 | 0 | 107 | `unmark_readonly_sym` |
+| +90 | 0 | 90 | `current_source_file_sym` (the ADR-0037 frame push's residual) |
+| +88 | 0 | 88 | `replay_readonly_undo` |
+| +83 | 0 | 83 | `finish_positional_light_env` |
+| +60 | 0 | 60 | `Env::get_sym` (outlined) |
+| +48 | 0 | 48 | `mark_readonly_sym_with` |
+| +36 | 0 | 36 | `decode_arg_slip_positions` |
+| −369 | 369 | 0 | `LocalKey::with` — removed by the ADR-0037 fix |
+
+Three clusters stand out, in rough order of size:
+
+1. **Readonly bookkeeping, ~480 Mcycles (~7%)** — `mark_readonly_sym_with` +
+   `unmark_readonly_sym` + `replay_readonly_undo`, plus most of the new
+   outlined `HashMap::get`. Every call marks each parameter readonly and
+   unmarks it on exit: an `FxHashMap<Symbol, ReadonlyKind>` insert, a remove,
+   and a journal push/pop per parameter per call. The set became a *map*
+   (`ReadonlySet = FxHashMap<Symbol, ReadonlyKind>`) when #6981 and #7042 gave
+   readonly-ness a three-way kind for the exception taxonomy, and the undo
+   journal came from #4540 / #6805 / #6789. Worth asking whether a
+   monomorphic-recursion call (`fib` re-marking the same param its own caller
+   already marked with the same kind) can skip the map round-trip entirely —
+   the code already tries to make that case journal nothing, but it still pays
+   the insert and the later remove.
+2. **`mutsu_jit_1` +50%** — the natively-compiled body got slower, which is not
+   explained by anything in the interpreter. Worth dumping the generated code
+   for both builds before guessing.
+3. **`call_compiled_function_positional_light` self time +509 Mcycles** — some
+   of this is inlining shift from the rows above, but 33% growth in the
+   function's own body is large. `finish_positional_light_env` and
+   `decode_arg_slip_positions` are new callees on this path.
+
+## Method notes for whoever picks this up
+
+- Run solo on an idle box (`uptime`, `pgrep -c -x rustc`).
+- **Interleave** the A/B binaries (alternate runs), never measure them in
+  sequence — a non-interleaved comparison drifted enough here to invert a 5%
+  result.
+- This box is a hybrid P/E-core CPU: `perf record` must pin
+  (`taskset -c 0`) and select `-e cpu_core/cycles:u/`, or the samples land on
+  an E-core event with a couple of dozen samples and the profile is worthless.
+- Build both sides with `--profile profiling` (release + debuginfo) for
+  symbolized profiles.
+- Per `todo/README.md` and CLAUDE.md, any number that ends up in a document
+  comes from the bench CI, not from the session's local runs.


### PR DESCRIPTION
Follow-up to #7259, which fixed the 26% ADR-0037 frame-push step but left `bench-fib` ~25% slower than a 2026-08-19 build.

## Why the ticket changed shape

The natural next move was "keep bisecting". It does not work here, and proving that is the substance of this update.

A second bisect named **#6784 (`fix/bind-alias-reverse-write`)**, and an interleaved A/B of that merge against its first parent reproduces **+4.7%** on `bench-fib` in both orderings — a convincing-looking result. But #6784 only touches `:=` bind paths, and `perf` on a build containing it samples **zero** cycles in `store_through_cell` or `propagate_bind_to_ancestor_frames` while running the benchmark. That code never executes there, so the 4.7% is a **code-layout effect**, not a semantic regression.

Layout noise between separately-built binaries is ~5%, which is the same magnitude as the individual steps that remain. Per-commit bisection therefore cannot separate signal from noise at this level, and any commit a future bisect names has to be discharged the same way — check whether its code is even sampled — before it is believed.

## What replaces it

A `perf` differential profile of `profiling` builds of both commits (fib(33), JIT on): **5.504 → 7.108 Gcycles, +29.1%**, with the symbol-level self-cycle delta table. It points at three clusters:

1. **Per-call readonly bookkeeping, ~480 Mcycles (~7%)** — `mark_readonly_sym_with` + `unmark_readonly_sym` + `replay_readonly_undo` plus most of a newly-outlined `HashMap::get`. `ReadonlySet` became an `FxHashMap<Symbol, ReadonlyKind>` when #6981/#7042 gave readonly-ness a three-way kind, so every call now does a map insert + remove + journal push/pop per parameter.
2. **`mutsu_jit_1` +50%** — the natively-compiled body itself got slower, which nothing in the interpreter explains.
3. **`call_compiled_function_positional_light` self time +509 Mcycles**, with two new callees on the path.

The ticket also now records the measurement mechanics that were non-obvious: interleave the A/B binaries (a sequential comparison drifted enough to invert a 5% result), and this hybrid P/E-core box needs `taskset -c 0` plus `-e cpu_core/cycles:u/` or `perf` collects a couple of dozen samples on an E-core event and the profile is worthless.

Docs-only, so the four heavy CI jobs are skipped by design.