### PR TITLE
perf(env): carry the ?FILE symbol on Env so a routine-frame push is O(1)

### DIFF
--- a/news/2026-09/env-carries-its-source-file-symbol.md
+++ b/news/2026-09/env-carries-its-source-file-symbol.md
@@ -1,0 +1,58 @@
+# `Env` carries its own `?FILE` symbol, so a routine-frame push no longer walks the overlay chain
+
+Every `RoutineFrame` push records the file of its call site, and ADR-0037
+Slice 1 put a push on all four compiled-call paths — so
+`Interpreter::current_source_file_sym()` went from a cold-path helper to one of
+the hottest functions in the VM. `news/2026-09/adr0037-routine-frame-push-intern-cost.md`
+removed the `Symbol::intern` of the path from it; what remained was the lookup
+itself, `env.get("?FILE")` walking the scoped-overlay chain on every call.
+Under `perf` that was `Env::get_sym` at 3.7% plus `current_source_file_sym` at
+1.6% of `benchmarks/bench-fib.raku`.
+
+`Env` now carries the answer: a `file_sym: Option<Symbol>` field holding the
+env's visible `?FILE`, read in O(1) through `Env::source_file_sym()`.
+
+## Why on `Env` and not on `Interpreter`
+
+The obvious shape — mirror `?FILE` on the interpreter next to `cur_source_line`,
+maintained by a single write funnel every `?FILE` write goes through — was
+built first and **does not work**. `?FILE` is written at only eight sites, all
+tidy save/insert/restore pairs, so the funnel itself was easy; but the runtime
+swaps whole envs in and out at some fifty sites (`self.env = saved_env`), and a
+mirror on the interpreter silently goes stale at every one of them. A debug
+assertion added at the same time caught it immediately: six `t/` files failed
+with the mirror reading `None` while `env` still held the script path.
+
+Living on `Env` makes all fifty of those swaps correct for free, because the
+answer travels with the env it describes. The maintenance surface collapses to
+`env.rs` itself: the constructors (`new`, `scoped_child`, `flattened`,
+`filtered_flat`, the two `From<HashMap>` impls) and the mutators (`insert_sym`
+— now the single funnel for `insert` and the `entry_or_insert*` family —
+`insert_through_sym`, `remove_sym`, `retain`, `retain_overlay`). A fresh
+`scoped_child` inherits the parent's value, which is correct on the
+empty-tier-reuse and `MAX_OVERLAY_DEPTH` flatten paths too: both only skip or
+collapse tiers that were already invisible to lookups.
+
+## How it is kept honest
+
+`current_source_file_sym()` carries a `debug_assert_eq!` that re-derives the
+answer the slow way — a full chain walk plus an intern — on **every call**. CI
+runs the whole `t/` suite on the debug binary (ADR-0014), so an `Env` mutator
+that forgets the hook fails 3625 test files loudly rather than silently
+mis-attributing backtrace frames in a release build. That is what turned the
+interpreter-mirror design's staleness into a five-minute finding instead of a
+subtly wrong `.backtrace` shipped to users.
+
+The suite passes with the assertion active, including the paths that broke the
+mirror: `require`, `EVAL`, `EVALFILE`, module loading, thread clones, and
+`.run`-style script dispatch.
+
+## Result
+
+Local interleaved release A/B (median of 15 alternating runs, idle box):
+`hash-access` −5.4%, `fib` −4.9%, `bench-fib` −4.6%, `bench-ctor` −4.5%,
+`bench-hash` −3.2%, `bench-tak` −3.0%, `method-call` neutral. Nothing
+regressed. The bench CI is the authority for figures that end up in documents.
+
+`Env::get_sym` and `current_source_file_sym` are both gone from the top of the
+`bench-fib` profile.

--- a/src/env.rs
+++ b/src/env.rs
@@ -371,6 +371,8 @@ pub struct Env {
     /// recursion) stays O(1) while shallow nesting (methods, ~2-5 deep) pays no
     /// flatten.
     depth: u16,
+    /// This env's visible `?FILE`, pre-interned — see [`Env::source_file_sym`].
+    file_sym: Option<Symbol>,
 }
 
 /// Maximum overlay chain length before [`Env::scoped_child`] flattens the parent.
@@ -396,6 +398,24 @@ fn empty_overlay_ref() -> &'static Arc<SymMap> {
     EMPTY.get_or_init(|| Arc::new(SymMap::default()))
 }
 
+/// The interned `"?FILE"` key. Interning it once keeps the maintenance hook in
+/// every `Env` mutator down to a `u32` compare — see [`Env::source_file_sym`].
+#[inline(always)]
+fn file_key() -> Symbol {
+    static FILE_KEY: std::sync::OnceLock<Symbol> = std::sync::OnceLock::new();
+    *FILE_KEY.get_or_init(|| Symbol::intern("?FILE"))
+}
+
+/// Intern a `?FILE` value. A non-`Str` `?FILE` has no file symbol, matching
+/// what a chain walk followed by a `ValueView::Str` match would yield.
+#[inline]
+fn file_sym_of(v: &Value) -> Option<Symbol> {
+    match v.view() {
+        crate::value::ValueView::Str(s) => Some(Symbol::intern(s.as_str())),
+        _ => None,
+    }
+}
+
 impl Env {
     pub(crate) fn new() -> Self {
         Self {
@@ -403,6 +423,7 @@ impl Env {
             parent: None,
             tombstones: None,
             depth: 0,
+            file_sym: None,
         }
     }
 
@@ -416,6 +437,11 @@ impl Env {
     /// to a single tier once it reaches [`MAX_OVERLAY_DEPTH`]. See
     /// docs/vm-dual-store.md.
     pub(crate) fn scoped_child(mut parent: Env) -> Self {
+        // A fresh overlay is empty with no tombstones, so the child's visible
+        // `?FILE` is exactly the parent's -- including on the empty-tier-reuse
+        // and flatten paths below, which only skip/collapse tiers that were
+        // already invisible to lookups. See `source_file_sym`.
+        let file_sym = parent.file_sym;
         // Empty-tier reuse: a scoped parent whose overlay never received a
         // write (and has no tombstones) is invisible to lookups, so chain the
         // new child over the parent's own parent instead of stacking another
@@ -449,6 +475,7 @@ impl Env {
                     depth: flat.depth + 1,
                     parent: Some(Arc::new(flat)),
                     tombstones: None,
+                    file_sym,
                 };
             }
             return Self {
@@ -456,6 +483,7 @@ impl Env {
                 depth: arc.depth + 1,
                 parent: Some(arc),
                 tombstones: None,
+                file_sym,
             };
         }
         let parent = if parent.depth >= MAX_OVERLAY_DEPTH {
@@ -468,7 +496,42 @@ impl Env {
             depth: parent.depth + 1,
             parent: Some(Arc::new(parent)),
             tombstones: None,
+            file_sym,
         }
+    }
+
+    /// This env's visible `?FILE` as a `Symbol`, or `None` when `?FILE` is
+    /// unset or is not a `Str`.
+    ///
+    /// Equivalent to `get("?FILE")` followed by `Symbol::intern`, but O(1):
+    /// every `RoutineFrame` push records the call-site file (ADR-0037 Slice 1
+    /// put a push on all four call paths), and resolving it through the
+    /// overlay chain plus an intern of the whole path was ~5% of
+    /// `benchmarks/bench-fib.raku`.
+    ///
+    /// The value is carried BY the env rather than mirrored on the
+    /// `Interpreter` deliberately: the runtime swaps whole envs in and out at
+    /// ~50 sites (`self.env = saved_env`), and an interpreter-side mirror
+    /// silently went stale at every one of them. Living on `Env` makes those
+    /// swaps correct for free — the answer travels with the env it describes.
+    /// It is maintained by the mutators above; `Interpreter::current_source_file_sym`
+    /// carries a debug assertion that re-derives it from a full chain walk on
+    /// every call, so any mutator that forgets the hook fails the whole `t/`
+    /// suite, which CI runs on the debug binary (ADR-0014).
+    #[inline(always)]
+    pub(crate) fn source_file_sym(&self) -> Option<Symbol> {
+        self.file_sym
+    }
+
+    /// Re-derive [`Self::source_file_sym`] after a bulk overlay edit that may
+    /// have dropped `?FILE` (`retain`, `retain_overlay`): the overlay's own
+    /// entry wins, else the parent chain's.
+    fn refresh_file_sym(&mut self) {
+        self.file_sym = match self.inner.get(&file_key()) {
+            Some(v) => file_sym_of(v),
+            None if self.is_tombstoned(file_key()) => None,
+            None => self.parent.as_ref().and_then(|p| p.file_sym),
+        };
     }
 
     /// True if `key` is tombstoned (removed) in this scoped overlay.
@@ -511,6 +574,7 @@ impl Env {
         if map.is_empty() {
             self.inner = empty_overlay();
         }
+        self.refresh_file_sym();
     }
 
     /// Collapse a scoped env into a flat (`parent=None`) env. For a flat env
@@ -543,6 +607,8 @@ impl Env {
                     parent: None,
                     tombstones: None,
                     depth: 0,
+                    // Flattening preserves every visible value, `?FILE` included.
+                    file_sym: self.file_sym,
                 }
             }
         }
@@ -579,11 +645,14 @@ impl Env {
         }
         let mut out = SymMap::default();
         collect(self, &mut out, keep);
+        // `keep` may have rejected `?FILE`, so re-derive rather than inherit.
+        let file_sym = out.get(&file_key()).and_then(file_sym_of);
         Self {
             inner: Arc::new(out),
             parent: None,
             tombstones: None,
             depth: 0,
+            file_sym,
         }
     }
 
@@ -703,12 +772,14 @@ impl Env {
     pub fn insert(&mut self, key: String, value: Value) -> Option<Value> {
         note_env_key(&key);
         let sym = Symbol::intern(&key);
-        self.untombstone(sym);
-        self.cow_mut().insert(sym, value)
+        self.insert_sym(sym, value)
     }
 
     #[inline]
     pub fn insert_sym(&mut self, key: Symbol, value: Value) -> Option<Value> {
+        if key == file_key() {
+            self.file_sym = file_sym_of(&value);
+        }
         self.untombstone(key);
         self.cow_mut().insert(key, value)
     }
@@ -740,6 +811,9 @@ impl Env {
             && let crate::value::ValueView::ContainerRef(cell) = existing.view()
         {
             let cell = cell.clone();
+            if key == file_key() {
+                self.file_sym = file_sym_of(&value);
+            }
             *cell.lock().unwrap() = value;
             return;
         }
@@ -751,6 +825,11 @@ impl Env {
     }
 
     pub fn remove_sym(&mut self, key: Symbol) -> Option<Value> {
+        if key == file_key() {
+            // Flat: the key is gone. Scoped: the tombstone below stops the
+            // parent tier shadowing through. Either way nothing is visible.
+            self.file_sym = None;
+        }
         // Absent from a flat env's overlay: nothing to remove and no parent tier
         // to tombstone, so the result is `None` either way. Bail before
         // `cow_mut()`, whose `Arc::make_mut` costs an atomic RMW -- and a full
@@ -820,6 +899,7 @@ impl Env {
         F: FnMut(&Symbol, &mut Value) -> bool,
     {
         self.cow_mut().retain(f);
+        self.refresh_file_sym();
     }
 
     pub fn iter(&self) -> std::collections::hash_map::Iter<'_, Symbol, Value> {
@@ -951,7 +1031,7 @@ impl Env {
     /// `entry_or_insert` pays when the caller already holds a Symbol.
     pub fn entry_or_insert_sym(&mut self, key: Symbol, value: Value) {
         if !self.contains_key_sym(key) {
-            self.cow_mut().insert(key, value);
+            self.insert_sym(key, value);
         }
     }
 
@@ -959,7 +1039,7 @@ impl Env {
     pub fn entry_or_insert_with<F: FnOnce() -> Value>(&mut self, key: String, f: F) {
         let sym = Symbol::intern(&key);
         if !self.contains_key_sym(sym) {
-            self.cow_mut().insert(sym, f());
+            self.insert_sym(sym, f());
         }
     }
 
@@ -988,22 +1068,27 @@ impl From<HashMap<String, Value>> for Env {
             .into_iter()
             .map(|(k, v)| (Symbol::intern(&k), v))
             .collect();
+        let file_sym = sym_map.get(&file_key()).and_then(file_sym_of);
         Self {
             inner: Arc::new(sym_map),
             parent: None,
             tombstones: None,
             depth: 0,
+            file_sym,
         }
     }
 }
 
 impl From<HashMap<Symbol, Value>> for Env {
     fn from(map: HashMap<Symbol, Value>) -> Self {
+        let map: SymMap = map.into_iter().collect();
+        let file_sym = map.get(&file_key()).and_then(file_sym_of);
         Self {
-            inner: Arc::new(map.into_iter().collect()),
+            inner: Arc::new(map),
             parent: None,
             tombstones: None,
             depth: 0,
+            file_sym,
         }
     }
 }

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1410,11 +1410,6 @@ pub struct Interpreter {
     /// per thread (see [`io_handles`] module docs and `clone_for_thread`).
     io_handles: Arc<RwLock<io_handles::IoHandleTable>>,
     pub(crate) program_path: Option<String>,
-    /// Memo for [`Interpreter::current_source_file_sym`]: the `?FILE`
-    /// `Arc<String>` last seen and the `Symbol` it interned to. See that
-    /// method for why the intern is worth caching and why holding the `Arc`
-    /// is what makes the identity test sound.
-    pub(crate) file_sym_memo: std::cell::RefCell<Option<(Arc<String>, Symbol)>>,
     /// Name of the package currently in scope (e.g. `GLOBAL`, `Foo::Bar`),
     /// used to build fully-qualified names during function/method dispatch and
     /// declaration. Held behind transitional `Arc<RwLock>` scaffolding so the VM

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -2436,7 +2436,6 @@ impl Interpreter {
                 next_id: 1,
             })),
             program_path: None,
-            file_sym_memo: std::cell::RefCell::new(None),
             current_package: Arc::new(RwLock::new("GLOBAL".to_string())),
             current_package_sym: Arc::new(std::sync::atomic::AtomicU32::new(
                 crate::symbol::Symbol::intern("GLOBAL").id(),

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -571,9 +571,6 @@ impl Interpreter {
                 next_id: cloned_next_handle_id,
             })),
             program_path: self.program_path.clone(),
-            // Per-thread memo (see `current_source_file_sym`): start empty
-            // rather than sharing the parent's `RefCell`, which is not `Sync`.
-            file_sym_memo: std::cell::RefCell::new(None),
             // Snapshot (fresh lock), not a shared handle: thread-local registry
             // semantics — child sees a copy, writes don't leak to the parent.
             current_package: Arc::new(RwLock::new(self.current_package())),

--- a/src/vm/vm_register_ops.rs
+++ b/src/vm/vm_register_ops.rs
@@ -11,14 +11,6 @@ fn captures_pop(
     captures.get(&key).and_then(|envs| envs.borrow_mut().pop())
 }
 
-/// The interned `"?FILE"` env key. `Env::get(&str)` interns its key on every
-/// call, which is pure overhead for a fixed name read on the routine-frame
-/// push path — see [`Interpreter::current_source_file_sym`].
-fn file_key_sym() -> Symbol {
-    static FILE_KEY: std::sync::OnceLock<Symbol> = std::sync::OnceLock::new();
-    *FILE_KEY.get_or_init(|| Symbol::intern("?FILE"))
-}
-
 impl Interpreter {
     /// Get the current source line number from the interpreter.
     pub(crate) fn current_source_line(&self) -> Option<u32> {
@@ -27,50 +19,43 @@ impl Interpreter {
 
     /// Get the current source file from the interpreter env.
     pub(crate) fn current_source_file(&self) -> Option<String> {
-        self.env()
-            .get_sym(file_key_sym())
-            .and_then(|v| match v.view() {
-                ValueView::Str(s) => Some(s.to_string()),
-                _ => None,
-            })
+        self.env().get("?FILE").and_then(|v| match v.view() {
+            ValueView::Str(s) => Some(s.to_string()),
+            _ => None,
+        })
     }
 
-    /// `Symbol` variant of [`Self::current_source_file`]: interns instead of
-    /// allocating a fresh `String`.
+    /// `Symbol` variant of [`Self::current_source_file`] — the file a
+    /// `RoutineFrame` records as its CALL SITE.
     ///
-    /// ADR-0037 Slice 1 made every light/fast call path push a `RoutineFrame`,
-    /// and each push records the call-site file through here — so this went
-    /// from a cold-path helper to one of the hottest functions in the VM. Two
-    /// interns per call (the `"?FILE"` env key, then the path itself) cost
-    /// ~10% of `benchmarks/bench-fib.raku`, since `Symbol::intern` hashes the
-    /// whole string. Both are avoided now: the key is a process-wide
-    /// pre-interned `Symbol`, and the path is memoized on the identity of the
-    /// `Arc<String>` the env handed back.
+    /// ADR-0037 Slice 1 put a `RoutineFrame` push on all four call paths, so
+    /// this is now one of the hottest functions in the VM. It reads the value
+    /// straight off the env ([`crate::env::Env::source_file_sym`]) instead of
+    /// walking the overlay chain and interning the path, which together were
+    /// ~5% of `benchmarks/bench-fib.raku`.
     ///
-    /// The env is still consulted on every call, so a `?FILE` change (module
-    /// load, `EVAL`, `run_from_file`) is observed immediately — the memo only
-    /// short-circuits when the very same `Arc` comes back. Holding that `Arc`
-    /// is also what makes pointer identity sound: the buffer cannot be freed
-    /// and a different string allocated at the same address while cached.
+    /// The debug assertion re-derives the answer the slow way on every call.
+    /// CI runs the whole `t/` suite on the debug binary (ADR-0014), so an
+    /// `Env` mutator that forgets to maintain the field fails loudly there
+    /// rather than silently mis-attributing backtrace frames in release.
+    #[inline]
     pub(crate) fn current_source_file_sym(&self) -> Option<Symbol> {
-        let v = self.env().get_sym(file_key_sym())?;
-        let ValueView::Str(s) = v.view() else {
-            return None;
-        };
-        let arc: &std::sync::Arc<String> = &s;
-        // Read the memo through a `let` so its `Ref` is unambiguously dropped
-        // before the `borrow_mut()` below (a miss falls through to it).
-        let hit = self
-            .file_sym_memo
-            .borrow()
-            .as_ref()
-            .and_then(|(cached, sym)| std::sync::Arc::ptr_eq(cached, arc).then_some(*sym));
-        if let Some(sym) = hit {
-            return Some(sym);
-        }
-        let sym = Symbol::intern(arc.as_str());
-        *self.file_sym_memo.borrow_mut() = Some((std::sync::Arc::clone(arc), sym));
-        Some(sym)
+        debug_assert_eq!(
+            self.env().source_file_sym(),
+            self.source_file_sym_by_walk(),
+            "Env::file_sym diverged from a ?FILE chain walk: an Env mutator \
+             changed the visible ?FILE without maintaining it"
+        );
+        self.env().source_file_sym()
+    }
+
+    /// [`Self::current_source_file_sym`] the slow, authoritative way: a full
+    /// env-chain walk plus an intern. Only the debug assertion uses it.
+    fn source_file_sym_by_walk(&self) -> Option<Symbol> {
+        self.env().get("?FILE").and_then(|v| match v.view() {
+            ValueView::Str(s) => Some(Symbol::intern(s.as_str())),
+            _ => None,
+        })
     }
 
     /// Attach the defining scope to an interpolating regex literal

--- a/todo/perf/late-august-call-path-slowdown-remainder.md
+++ b/todo/perf/late-august-call-path-slowdown-remainder.md
@@ -1,4 +1,4 @@
-# The late-August call-path slowdown, minus the ADR-0037 step, is still ~25% on `bench-fib`
+# The late-August call-path slowdown: profile-driven now, ~20% left on `bench-fib`
 
 Between 2026-08-19 and 2026-08-31 a broad set of call-path-shaped benchmarks got
 slower while an unrelated set got faster. Daily medians of the bench-CI series
@@ -60,35 +60,52 @@ pointers to a *cluster*, not as exact attributions:
 | +130 | 874 | 1004 | `exec_call_func_op` (self) |
 | +114 | 66 | 180 | `nanbox::payload_op` |
 | +107 | 0 | 107 | `unmark_readonly_sym` |
-| +90 | 0 | 90 | `current_source_file_sym` (the ADR-0037 frame push's residual) |
+| +90 | 0 | 90 | `current_source_file_sym` — **closed**, see below |
 | +88 | 0 | 88 | `replay_readonly_undo` |
 | +83 | 0 | 83 | `finish_positional_light_env` |
-| +60 | 0 | 60 | `Env::get_sym` (outlined) |
+| +60 | 0 | 60 | `Env::get_sym` (outlined) — **closed**, see below |
 | +48 | 0 | 48 | `mark_readonly_sym_with` |
 | +36 | 0 | 36 | `decode_arg_slip_positions` |
-| −369 | 369 | 0 | `LocalKey::with` — removed by the ADR-0037 fix |
+| −369 | 369 | 0 | `LocalKey::with` — removed by the ADR-0037 intern fix |
 
-Three clusters stand out, in rough order of size:
+The `?FILE` rows are closed by
+`news/2026-09/env-carries-its-source-file-symbol.md`: `Env` now carries its own
+`?FILE` symbol, so the routine-frame push reads it in O(1) instead of walking
+the overlay chain (`hash-access` −5.4%, `fib` −4.9%, `bench-fib` −4.6%,
+`bench-ctor` −4.5% locally). `Env::get_sym` and `current_source_file_sym` are
+both gone from the top of the profile.
 
-1. **Readonly bookkeeping, ~480 Mcycles (~7%)** — `mark_readonly_sym_with` +
-   `unmark_readonly_sym` + `replay_readonly_undo`, plus most of the new
-   outlined `HashMap::get`. Every call marks each parameter readonly and
-   unmarks it on exit: an `FxHashMap<Symbol, ReadonlyKind>` insert, a remove,
-   and a journal push/pop per parameter per call. The set became a *map*
-   (`ReadonlySet = FxHashMap<Symbol, ReadonlyKind>`) when #6981 and #7042 gave
-   readonly-ness a three-way kind for the exception taxonomy, and the undo
-   journal came from #4540 / #6805 / #6789. Worth asking whether a
-   monomorphic-recursion call (`fib` re-marking the same param its own caller
-   already marked with the same kind) can skip the map round-trip entirely —
-   the code already tries to make that case journal nothing, but it still pays
-   the insert and the later remove.
-2. **`mutsu_jit_1` +50%** — the natively-compiled body got slower, which is not
-   explained by anything in the interpreter. Worth dumping the generated code
+## What is left, from a profile of the current build
+
+`bench-fib` (fib(33), JIT on), self time:
+
+| share | symbol |
+| ---: | --- |
+| 33.0% | `call_compiled_function_positional_light` (self) |
+| 16.8% | `exec_call_func_op` (self) |
+| 10.3% | `mutsu_jit_1` |
+| 11.3% | `Vec::extend_trusted` + `recycle_locals` + `Vec::resize` — the args/locals pool |
+| 5.5% | `replay_readonly_undo` + `HashMap::insert` + `unmark_readonly_sym` — readonly bookkeeping |
+| 2.6% | `LocalKey::with` |
+| 1.8% | `resolve_let_saves_on_success` |
+
+Three things worth attacking next, in rough order of size:
+
+1. **The args/locals `Vec` churn (~11%).** `exec_call_func_op` borrows a pooled
+   `Vec` for the args and `extend`s the drained stack into it; the light path
+   then borrows another for the callee locals, `resize`s it with `Value::NIL`,
+   clones each argument into its slot, and recycles both. The clone/drop pair
+   per argument exists only because the args buffer is recycled rather than
+   moved from.
+2. **Readonly bookkeeping (~5.5%).** Every call marks each parameter readonly
+   and unmarks it on exit: an `FxHashMap<Symbol, ReadonlyKind>` insert, a
+   remove, and a journal push/pop per parameter per call. A monomorphic
+   recursive call re-marks a symbol its own caller already marked with the same
+   kind; the code tries to make that journal nothing but still pays both map
+   operations.
+3. **`mutsu_jit_1` +50% since August.** The natively-compiled body itself got
+   slower, which nothing in the interpreter explains. Dump the generated code
    for both builds before guessing.
-3. **`call_compiled_function_positional_light` self time +509 Mcycles** — some
-   of this is inlining shift from the rows above, but 33% growth in the
-   function's own body is large. `finish_positional_light_env` and
-   `decode_arg_slip_positions` are new callees on this path.
 
 ## Method notes for whoever picks this up
 
@@ -96,9 +113,18 @@ Three clusters stand out, in rough order of size:
 - **Interleave** the A/B binaries (alternate runs), never measure them in
   sequence — a non-interleaved comparison drifted enough here to invert a 5%
   result.
-- This box is a hybrid P/E-core CPU: `perf record` must pin
-  (`taskset -c 0`) and select `-e cpu_core/cycles:u/`, or the samples land on
-  an E-core event with a couple of dozen samples and the profile is worthless.
+- This box is a hybrid P/E-core CPU. The default `cycles` event records BOTH
+  PMUs, so `perf report` prints one section per event — read the `cpu_core`
+  one and ignore the `cpu_atom` section, which typically holds a couple of
+  dozen startup samples. To collect only the P-core event, the syntax is
+  `-e cpu_core/cycles/u` (the modifier goes AFTER the closing slash;
+  `-e cpu_core/cycles:u/` is a syntax error that makes `perf record` fail
+  outright — and if an old `.data` file is lying around, `perf report` will
+  happily analyze *that* instead, which is how the wrong recipe got recorded
+  here in the first place). Pin with `taskset -c 0` either way.
+- The `perf` binary is at
+  `/usr/lib/linux-tools/6.8.0-138-generic/perf` — not on `PATH`, and its
+  version does not match `uname -r`.
 - Build both sides with `--profile profiling` (release + debuginfo) for
   symbolized profiles.
 - Per `todo/README.md` and CLAUDE.md, any number that ends up in a document


### PR DESCRIPTION
Follow-up to #7259. Profile-driven, not bisect-driven — per the ticket's own conclusion that bisection cannot resolve what is left.

## The cost

Every `RoutineFrame` push records the file of its call site, and ADR-0037 Slice 1 put a push on all four compiled-call paths — so `current_source_file_sym()` is one of the hottest functions in the VM. #7259 removed the `Symbol::intern` of the path; what remained was the lookup itself, `env.get("?FILE")` walking the scoped-overlay chain on every call. Under `perf` on `bench-fib`: `Env::get_sym` 3.7% + `current_source_file_sym` 1.6%.

`Env` now carries the answer in a `file_sym: Option<Symbol>` field, read in O(1) through `Env::source_file_sym()`.

## Why on `Env` and not on `Interpreter`

The obvious shape — mirror `?FILE` on the interpreter next to `cur_source_line`, behind a single write funnel — **was built first and does not work**, and that is the more useful half of this PR.

`?FILE` has only eight write sites, all tidy save/insert/restore pairs, so the funnel itself was easy. But the runtime swaps whole envs in and out at some **fifty** sites (`self.env = saved_env`), and an interpreter-side mirror goes stale at every one of them. The debug assertion added alongside caught it within minutes: six `t/` files failed with the mirror reading `None` while `env` still held the script path.

Living on `Env` makes all fifty swaps correct for free — the answer travels with the env it describes — and collapses the maintenance surface to `env.rs` itself:

- constructors: `new`, `scoped_child`, `flattened`, `filtered_flat`, both `From<HashMap>` impls
- mutators: `insert_sym` (now the single funnel for `insert` and the `entry_or_insert*` family), `insert_through_sym`, `remove_sym`, `retain`, `retain_overlay`

A fresh `scoped_child` inherits its parent's value, which stays correct on the empty-tier-reuse and `MAX_OVERLAY_DEPTH` flatten paths too, since both only skip or collapse tiers that were already invisible to lookups.

## How it is kept honest

`current_source_file_sym()` carries a `debug_assert_eq!` that re-derives the answer the slow way — full chain walk plus intern — on **every call**. CI runs the whole `t/` suite on the debug binary (ADR-0014), so an `Env` mutator that forgets the hook fails 3625 test files rather than silently mis-attributing backtrace frames in release.

## Tests

- `make test` with the assertion active: 3625 files / 36678 tests pass, including the paths that broke the interpreter mirror (`require`, `EVAL`, `EVALFILE`, module load, thread clone, script dispatch).
- Targeted roast sweep, 199 whitelisted `S02-names-vars` / `S04` / `S06` / `S11` / `S32-exceptions` files: pass.

## Measurements

Local interleaved release A/B, median of 15 alternating runs on an idle box (bench CI is the authority):

| bench | before | after | |
| --- | --- | --- | --- |
| `hash-access` | 0.03072 | 0.02905 | −5.4% |
| `fib` | 0.06052 | 0.05753 | −4.9% |
| `bench-fib` | 0.14758 | 0.14084 | −4.6% |
| `bench-ctor` | 0.22711 | 0.21682 | −4.5% |
| `bench-hash` | 0.03327 | 0.03222 | −3.2% |
| `bench-tak` | 0.16973 | 0.16471 | −3.0% |
| `method-call` | 0.13698 | 0.13623 | neutral |

Nothing regressed. `Env::get_sym` and `current_source_file_sym` are both gone from the top of the profile.

## Ticket update

`todo/perf/late-august-call-path-slowdown-remainder.md` is refreshed with a profile of the *current* build and the three remaining clusters (args/locals `Vec` churn ~11%, readonly bookkeeping ~5.5%, `mutsu_jit_1` +50% since August).

It also **corrects a recipe I got wrong in #7260**: the P-core event selector is `-e cpu_core/cycles/u`, not `-e cpu_core/cycles:u/`. The latter is a syntax error that makes `perf record` fail outright — and `perf report` then silently analyzes whatever stale `.data` file is lying around, which is exactly how the wrong form got recorded as "the working invocation".