### PR TITLE
perf(vm): pre-intern the call path's fixed names and stop double-cloning a bound argument

### DIFF
--- a/news/2026-09/hot-path-well-known-symbols-and-param-bind-move.md
+++ b/news/2026-09/hot-path-well-known-symbols-and-param-bind-move.md
@@ -1,0 +1,64 @@
+# The call path stopped re-interning `"_"` and `"Any"`, and stopped cloning a bound argument twice
+
+A `perf` profile of `benchmarks/bench-fib.raku` still showed `Symbol::intern`
+and `std::thread::local::LocalKey::with` in the top twenty after the ADR-0037
+frame-push work. Neither belongs on a call path that resolves no user names:
+`Symbol::intern` hashes the whole string and takes a thread-local borrow, so
+re-interning a *fixed* name once per call is pure overhead.
+
+Three fixed names were being re-interned on every compiled call:
+
+- `unmark_readonly("_")` — every routine entry clears any readonly mark the
+  caller's topic left on `$_`, and the `&str` overload interns `"_"` to get
+  there (`vm_call_light.rs`, `vm_call_light_typed.rs`).
+- `Symbol::intern("Any")` — the value a routine's fresh topic is seeded with
+  (`vm_call_light.rs`, `vm_call_light_typed.rs`, `vm_call_fast.rs`).
+- `env.insert("_".to_string(), …)` / `env.get("_")` / `env.remove("_")` —
+  `Env`'s `&str`-keyed methods are all `…_sym(Symbol::intern(key))`, so each
+  one interned `"_"` again, and the `insert` also allocated a `String` per
+  call.
+
+`crate::symbol::wk` now holds these as process-wide pre-interned symbols
+(`wk::topic()`, `wk::any()`, `wk::file()`), resolved once behind a `OnceLock`
+and a plain load afterwards. Interned ids are global and append-only, so
+caching one is valid for the life of the process and across threads.
+`Env::file_key` — added the same day for
+`news/2026-09/env-carries-its-source-file-symbol.md` — moved into the same
+module rather than keeping a second private copy.
+
+## The double clone in the parameter bind loop
+
+The positional-light bind loop also cloned each bound argument twice:
+
+```rust
+self.locals[*slot] = val.clone();
+let needs_env = …;
+if needs_env {
+    self.env_mut().insert(param_name.clone(), val);
+}
+```
+
+When `needs_env` is false — the common case for a routine whose parameters are
+read only through their local slots — `val` was cloned into the slot and then
+dropped, where a move would do. When it is true, the env mirror was keyed by a
+freshly allocated `String` that `Env::insert` then interned, even though
+`CompiledFunction::param_name_syms` already holds the parameter name
+pre-interned for exactly this reason.
+
+Now the `needs_env` branch writes the slot and mirrors through `insert_sym`
+with the pre-interned name (calling `note_env_key` on a borrow so the key-shape
+bookkeeping `Env::insert` performs is preserved), and the common branch moves
+the value straight into the slot.
+
+## Result
+
+Local interleaved release A/B (median of 15 alternating runs, idle box):
+`bench-tak` −8.0%, `bench-fib` −5.2%, `fib` −4.2%, `bench-ctor` −2.0%;
+`hash-access`, `method-call` and `word-count` neutral (each re-measured in both
+orderings — a single ordering showed a 3.9% swing that reversed). `bench-tak`
+gains most because it takes three parameters, and the bind-loop saving is per
+parameter per call.
+
+`make test` (3625 files) and a targeted roast sweep of the 440 whitelisted
+`S02` / `S03` / `S04` / `S06` / `S32-exceptions` files pass. The bench CI is the
+authority for figures that end up in documents.

--- a/src/env.rs
+++ b/src/env.rs
@@ -402,8 +402,7 @@ fn empty_overlay_ref() -> &'static Arc<SymMap> {
 /// every `Env` mutator down to a `u32` compare — see [`Env::source_file_sym`].
 #[inline(always)]
 fn file_key() -> Symbol {
-    static FILE_KEY: std::sync::OnceLock<Symbol> = std::sync::OnceLock::new();
-    *FILE_KEY.get_or_init(|| Symbol::intern("?FILE"))
+    crate::symbol::wk::file()
 }
 
 /// Intern a `?FILE` value. A non-`Str` `?FILE` has no file symbol, matching

--- a/src/symbol.rs
+++ b/src/symbol.rs
@@ -74,6 +74,38 @@ thread_local! {
     static RESOLVE_CACHE: RefCell<Vec<Option<&'static str>>> = const { RefCell::new(Vec::new()) };
 }
 
+/// Pre-interned symbols for names the VM resolves on hot paths.
+///
+/// [`Symbol::intern`] hashes the whole string and takes a thread-local borrow,
+/// so re-interning a fixed name inside a per-call code path is pure overhead —
+/// it showed up as `Symbol::intern` + `LocalKey::with` in a `bench-fib`
+/// profile. Each accessor resolves once per process and is a plain load
+/// afterwards. Interned ids are global and append-only, so caching them in a
+/// `OnceLock` is valid for the life of the process and across threads.
+pub(crate) mod wk {
+    use super::Symbol;
+
+    macro_rules! well_known {
+        ($($(#[$m:meta])* $f:ident => $s:literal;)*) => {$(
+            $(#[$m])*
+            #[inline(always)]
+            pub(crate) fn $f() -> Symbol {
+                static CELL: std::sync::OnceLock<Symbol> = std::sync::OnceLock::new();
+                *CELL.get_or_init(|| Symbol::intern($s))
+            }
+        )*};
+    }
+
+    well_known! {
+        /// The topic `$_`. Env keys are stored sigil-less, so this is `"_"`.
+        topic => "_";
+        /// The `Any` type object, the value a routine's fresh topic is seeded with.
+        any => "Any";
+        /// The dynamic `$?FILE`, stored sigil-less with its twigil.
+        file => "?FILE";
+    }
+}
+
 impl Symbol {
     /// The raw interned id. Only for storing a `Symbol` where a plain integer is
     /// needed (an `AtomicU32` slot); pair with [`Symbol::from_raw`].

--- a/src/vm/vm_call_fast.rs
+++ b/src/vm/vm_call_fast.rs
@@ -117,10 +117,10 @@ impl Interpreter {
 
         // Raku: routines get their own $_ initialized to (Any).
         let saved_topic = if cf.code.is_routine {
-            let old = self.env().get("_").cloned();
-            self.env_mut().insert(
-                "_".to_string(),
-                Value::package(crate::symbol::Symbol::intern("Any")),
+            let old = self.env().get_sym(crate::symbol::wk::topic()).cloned();
+            self.env_mut().insert_sym(
+                crate::symbol::wk::topic(),
+                Value::package(crate::symbol::wk::any()),
             );
             old
         } else {
@@ -353,10 +353,10 @@ impl Interpreter {
         if cf.code.is_routine && !use_scoped {
             match saved_topic {
                 Some(v) => {
-                    self.env_mut().insert("_".to_string(), v);
+                    self.env_mut().insert_sym(crate::symbol::wk::topic(), v);
                 }
                 None => {
-                    self.env_mut().remove("_");
+                    self.env_mut().remove_sym(crate::symbol::wk::topic());
                 }
             }
         }

--- a/src/vm/vm_call_light.rs
+++ b/src/vm/vm_call_light.rs
@@ -166,7 +166,7 @@ impl Interpreter {
         // the param loop below, which re-marks `_` if the routine has an
         // explicit (readonly) `$_` parameter.
         if cf.code.is_routine && !self.no_readonly_vars() {
-            self.unmark_readonly("_");
+            self.unmark_readonly_sym(crate::symbol::wk::topic());
         }
         // Bind params to slots. Also write the param into the overlay when a
         // name-based reader needs it (reflective access anywhere / GetGlobal /
@@ -218,12 +218,25 @@ impl Interpreter {
                 }
                 let val = Self::itemize_plain_scalar_param(&cf.param_defs[param_idx], val);
                 let param_name = &cf.param_defs[param_idx].name;
-                self.locals[*slot] = val.clone();
                 let needs_env = write_all_params
                     || val.is_nil()
                     || cf.code.needs_env_sync.get(*slot).copied().unwrap_or(true);
                 if needs_env {
-                    self.env_mut().insert(param_name.clone(), val);
+                    // The env mirror is keyed by the pre-interned param name
+                    // (`param_name_syms`), so this costs neither a `String`
+                    // clone nor a re-intern of the name on every call. The
+                    // key-shape bookkeeping `Env::insert` would have done is
+                    // still performed, on a borrow.
+                    crate::env::note_env_key(param_name);
+                    self.locals[*slot] = val.clone();
+                    match cf.param_name_syms.get(param_idx) {
+                        Some(sym) => self.env_mut().insert_sym(*sym, val),
+                        None => self.env_mut().insert(param_name.clone(), val),
+                    };
+                } else {
+                    // No env mirror: move the bound value straight into the
+                    // slot instead of cloning it and dropping the original.
+                    self.locals[*slot] = val;
                 }
                 match cf.param_name_syms.get(param_idx) {
                     Some(sym) => self.mark_readonly_sym(*sym),
@@ -250,11 +263,12 @@ impl Interpreter {
             && cf.code.is_routine
             && !cf.param_defs.iter().any(|pd| pd.name == "_")
         {
-            let any_val = Value::package(crate::symbol::Symbol::intern("Any"));
+            let any_val = Value::package(crate::symbol::wk::any());
             if let Some(slot) = cf.code.locals.iter().position(|n| n == "_") {
                 self.locals[slot] = any_val.clone();
             }
-            self.env_mut().insert("_".to_string(), any_val);
+            self.env_mut()
+                .insert_sym(crate::symbol::wk::topic(), any_val);
         }
 
         let saved_stack_depth = self.stack.len();

--- a/src/vm/vm_call_light_typed.rs
+++ b/src/vm/vm_call_light_typed.rs
@@ -399,7 +399,7 @@ impl Interpreter {
         // from the caller's topic (see vm_call_light.rs for the full rationale);
         // the param loop below re-marks `_` for an explicit `$_` param.
         if cf.code.is_routine && !self.no_readonly_vars() {
-            self.unmark_readonly("_");
+            self.unmark_readonly_sym(crate::symbol::wk::topic());
         }
         // Raku: a routine gets its own `$_` = `(Any)`, not the caller's topic.
         // Shadow the caller's topic with Any before the body reads it (gated on
@@ -408,11 +408,12 @@ impl Interpreter {
             && cf.code.is_routine
             && !cf.param_defs.iter().any(|pd| pd.name == "_")
         {
-            let any_val = Value::package(crate::symbol::Symbol::intern("Any"));
+            let any_val = Value::package(crate::symbol::wk::any());
             if let Some(slot) = cf.code.locals.iter().position(|n| n == "_") {
                 self.locals[slot] = any_val.clone();
             }
-            self.env_mut().insert("_".to_string(), any_val);
+            self.env_mut()
+                .insert_sym(crate::symbol::wk::topic(), any_val);
         }
         for (i, pd) in cf.param_defs.iter().enumerate() {
             if !pd.name.is_empty()

--- a/todo/perf/late-august-call-path-slowdown-remainder.md
+++ b/todo/perf/late-august-call-path-slowdown-remainder.md
@@ -86,8 +86,14 @@ both gone from the top of the profile.
 | 10.3% | `mutsu_jit_1` |
 | 11.3% | `Vec::extend_trusted` + `recycle_locals` + `Vec::resize` — the args/locals pool |
 | 5.5% | `replay_readonly_undo` + `HashMap::insert` + `unmark_readonly_sym` — readonly bookkeeping |
-| 2.6% | `LocalKey::with` |
+| 2.6% | `LocalKey::with` — **closed**, see below |
 | 1.8% | `resolve_let_saves_on_success` |
+
+The `Symbol::intern` / `LocalKey::with` rows are closed by
+`news/2026-09/hot-path-well-known-symbols-and-param-bind-move.md`: the call
+path re-interned the fixed names `"_"` and `"Any"` on every call, and the
+parameter bind loop cloned each bound argument twice. `bench-tak` −8.0%,
+`bench-fib` −5.2%, `fib` −4.2% locally.
 
 Three things worth attacking next, in rough order of size:
 


### PR DESCRIPTION
Profile-driven follow-up to #7259 / #7261.

## What the profile showed

`Symbol::intern` and `std::thread::local::LocalKey::with` were still in the top twenty of a `bench-fib` profile. Neither belongs on a call path that resolves no user names — `Symbol::intern` hashes the whole string and takes a thread-local borrow, so re-interning a **fixed** name once per call is pure overhead. Three were doing exactly that:

- `unmark_readonly("_")` — every routine entry clears any readonly mark the caller's topic left on `$_`, and the `&str` overload interns `"_"` to get there.
- `Symbol::intern("Any")` — the value a routine's fresh topic is seeded with.
- `env.insert("_".to_string(), …)` / `env.get("_")` / `env.remove("_")` — every `&str`-keyed `Env` method is `…_sym(Symbol::intern(key))`, and the `insert` also allocated a `String` per call.

`crate::symbol::wk` now holds these pre-interned behind a `OnceLock` (`wk::topic()`, `wk::any()`, `wk::file()`). Interned ids are global and append-only, so caching one is valid for the life of the process and across threads. `Env::file_key` — added in #7261 — moved into the same module rather than keeping a second private copy.

## The double clone in the bind loop

```rust
self.locals[*slot] = val.clone();
let needs_env = …;
if needs_env {
    self.env_mut().insert(param_name.clone(), val);
}
```

When `needs_env` is false (the common case — parameters read only through their local slots) the value was cloned into the slot and then dropped, where a move would do. When it is true, the env mirror was keyed by a freshly allocated `String` that `Env::insert` then interned, even though `CompiledFunction::param_name_syms` already holds the name pre-interned for exactly this purpose.

Now the mirror branch uses `insert_sym` with that pre-interned name (calling `note_env_key` on a borrow so `Env::insert`'s key-shape bookkeeping is preserved), and the common branch moves the value straight into the slot.

## Measurements

Local interleaved release A/B, median of 15 alternating runs on an idle box (bench CI is the authority):

| bench | before | after | |
| --- | --- | --- | --- |
| `bench-tak` | 0.17755 | 0.16330 | −8.0% |
| `bench-fib` | 0.14766 | 0.14000 | −5.2% |
| `fib` | 0.06153 | 0.05893 | −4.2% |
| `bench-ctor` | 0.23303 | 0.22840 | −2.0% |
| `hash-access`, `method-call`, `word-count` | | | neutral |

`bench-tak` gains most because it takes three parameters and the bind-loop saving is per parameter per call. The three "neutral" benchmarks were each re-measured in **both** orderings — one ordering showed a 3.9% swing on `hash-access` that reversed when the order flipped, i.e. noise.

## Tests

- `make test`: 3625 files / 36678 tests pass.
- Targeted roast sweep, 440 whitelisted `S02` / `S03` / `S04` / `S06` / `S32-exceptions` files: pass. (`$_` topic handling is the semantically sensitive part of this change, so the sweep is weighted toward the topic/given-when suites.)