### PR TITLE
perf(vm): bind positional-light parameters straight out of the VM stack

### DIFF
--- a/news/2026-09/positional-light-call-binds-from-the-stack.md
+++ b/news/2026-09/positional-light-call-binds-from-the-stack.md
@@ -1,0 +1,63 @@
+# The positional-light call path binds its parameters from the stack
+
+`todo/perf/late-august-call-path-slowdown-remainder.md` listed the args/locals
+`Vec` churn as the largest remaining item on the call path (~11% of
+`bench-fib`). This closes the args half of it.
+
+## What it was
+
+`exec_call_func_op`'s cached positional dispatch borrowed a pooled `Vec` for
+the arguments, `extend`ed the drained stack slots into it, handed the callee a
+`&[Value]`, and recycled the buffer afterwards. `call_compiled_function_positional_light`
+then borrowed a *second* pooled `Vec` for the callee's locals and cloned each
+argument from the first buffer into its parameter slot. Every call therefore
+paid a `Vec::extend_trusted`, two pool round-trips, two per-element drop loops,
+and a clone/drop pair per argument — and the clone existed only because the
+buffer was recycled rather than moved from.
+
+In a profile of `bench-fib` (fib(25), JIT on, P-core `cycles/u`) that showed up
+as `Vec::extend_trusted` 3.2% and `recycle_locals` 4.1% of self time, plus the
+`Vec::resize` folded into the callee.
+
+## What it is now
+
+The callee takes `args_base: usize` and binds directly out of `self.stack[args_base..]`,
+truncating back to `args_base` on every exit path (both arity errors, the
+parameter type-check failure, and normal completion). No intermediate buffer
+exists at all: the hot dispatch site just computes the base index and calls.
+
+Binding by move rather than by clone needed one restructuring. The parameter
+type checks used to run interleaved with the binds, so moving a value out of
+its stack slot would have left `Nil` behind for the `arguments` attribute of a
+later parameter's `X::TypeCheck::Argument`. The checks now run as a separate
+pass over the untouched stack slots first — using `Value::unwrap_varref`, which
+borrows instead of cloning — and only then does the bind loop `mem::replace`
+each argument into its slot. A failure still reports the complete, unmodified
+argument list.
+
+The old `&[Value]` entry point survives as a thin wrapper (it pushes the slice
+and delegates) for the two cold call sites that hold an owned argument vector:
+the OTF promotion arm and the slow `call_function` resolution path.
+
+## Measurement
+
+Interleaved A/B of two release builds, nine alternating runs each, median
+retired user cycles on a pinned P-core:
+
+| benchmark | delta |
+| --- | ---: |
+| `bench-tak` | −10.6% |
+| `fib` | −7.2% |
+| `bench-fib` | −6.7% |
+| `method-call` | −0.6% |
+| `bench-ctor` / `bench-class` / `bench-hash` / `hash-access` | ±1% |
+
+Both orderings were measured; every sign flipped with the swap, so none of it
+is drift. `poly-call` reads +1.9%, but a profile of the new binary samples zero
+cycles in any changed function while running it — that is the known
+binary-layout effect, discharged the way the ticket requires.
+
+`t/positional-light-arg-consumption.t` pins the two invariants the design rests
+on: the arguments are consumed on every exit path (so a surrounding expression
+still sees a balanced stack), and a type-check failure on the second parameter
+still reports the first one.

--- a/src/vm/vm_call_func_ops.rs
+++ b/src/vm/vm_call_func_ops.rs
@@ -449,24 +449,24 @@ impl Interpreter {
                         let share_into_scalar =
                             Self::call_shares_container_into_scalar_param(cf, stack_args);
                         if !has_junction && !call_has_slip && !share_into_scalar {
+                            // Bind straight out of the stack (no args buffer):
+                            // the callee takes the arguments in place from
+                            // `stack[start..]` and truncates back to `start` on
+                            // every exit path. The previous pooled buffer cost a
+                            // `Vec::extend` of the drained slots plus a second
+                            // pool round-trip and drop loop per call, ~7% of
+                            // `bench-fib` on the hottest dispatch path.
                             let start = self.stack.len() - arity_usize;
-                            // Pooled args buffer (J4d): `drain(..).collect()`
-                            // was one malloc/free per call on the hottest call
-                            // path; the locals pool already recycles
-                            // `Vec<Value>`s, so borrow it for the args too.
-                            let mut args = self.take_locals_from_pool(0);
-                            args.extend(self.stack.drain(start..));
                             if cl.is_some() {
                                 loan_env!(self, set_pending_callsite_line(cl));
                             }
-                            let result = self.call_compiled_function_positional_light(
+                            let result = self.call_compiled_function_positional_light_at(
                                 cf,
-                                &args,
+                                start,
                                 compiled_fns,
                                 name_str,
                                 code.const_sym(name_idx),
                             );
-                            self.recycle_locals(args);
                             self.stack.push(result?);
                             // Slice F: drain any captured-outer writes the body
                             // recorded through to this caller frame's local slots

--- a/src/vm/vm_call_light.rs
+++ b/src/vm/vm_call_light.rs
@@ -1,10 +1,44 @@
 use super::*;
 
 impl Interpreter {
+    /// Slice-taking wrapper over [`Self::call_compiled_function_positional_light_at`]
+    /// for the cold call sites that already hold an owned argument vector
+    /// (the OTF promotion arm and the slow `call_function` resolution path).
+    /// The hot cached dispatch calls the `_at` form directly, leaving the
+    /// arguments where the caller's opcodes evaluated them -- on the VM stack.
     pub(super) fn call_compiled_function_positional_light(
         &mut self,
         cf: &CompiledFunction,
         args: &[Value],
+        compiled_fns: &CompiledFns,
+        func_name: &str,
+        func_name_sym: Symbol,
+    ) -> Result<Value, RuntimeError> {
+        let args_base = self.stack.len();
+        self.stack.extend(args.iter().cloned());
+        self.call_compiled_function_positional_light_at(
+            cf,
+            args_base,
+            compiled_fns,
+            func_name,
+            func_name_sym,
+        )
+    }
+
+    /// Bind and run `cf` with the arguments occupying `self.stack[args_base..]`.
+    /// The arguments are consumed: on every exit path (including both arity
+    /// errors and a parameter type-check failure) the stack is truncated back
+    /// to `args_base`.
+    ///
+    /// Taking the arguments in place is what removes the per-call intermediate
+    /// buffer the previous `&[Value]` signature forced: the caller used to
+    /// borrow a pooled `Vec`, `extend` the drained stack slots into it, and
+    /// recycle it after the call, which cost a `Vec::extend_trusted` plus a
+    /// second pool round-trip and drop loop on the hottest dispatch path.
+    pub(super) fn call_compiled_function_positional_light_at(
+        &mut self,
+        cf: &CompiledFunction,
+        args_base: usize,
         compiled_fns: &CompiledFns,
         func_name: &str,
         func_name_sym: Symbol,
@@ -23,7 +57,7 @@ impl Interpreter {
         let saved_unit = self.enter_compilation_unit(cf);
         let param_slots = cf.param_local_slots.as_ref().unwrap();
         let positional_count = param_slots.len();
-        let actual_count = args.len();
+        let actual_count = self.stack.len() - args_base;
 
         // Every positional-light-eligible parameter is a mandatory positional
         // (no default, optional `?`, or slurpy -- see
@@ -36,10 +70,14 @@ impl Interpreter {
                 positional_count, actual_count
             );
             self.current_unit = saved_unit;
-            return Err(RuntimeError::typed(
-                "X::TypeCheck::Argument",
-                Self::type_check_argument_attrs(func_name, &cf.param_defs, args, msg),
-            ));
+            let attrs = Self::type_check_argument_attrs(
+                func_name,
+                &cf.param_defs,
+                &self.stack[args_base..],
+                msg,
+            );
+            self.stack.truncate(args_base);
+            return Err(RuntimeError::typed("X::TypeCheck::Argument", attrs));
         }
         // `is_positional_light_call_eligible` guarantees no slurpy/optional
         // param exists on this signature, so a surplus argument is always an
@@ -54,10 +92,14 @@ impl Interpreter {
                 positional_count, actual_count
             );
             self.current_unit = saved_unit;
-            return Err(RuntimeError::typed(
-                "X::TypeCheck::Argument",
-                Self::type_check_argument_attrs(func_name, &cf.param_defs, args, msg),
-            ));
+            let attrs = Self::type_check_argument_attrs(
+                func_name,
+                &cf.param_defs,
+                &self.stack[args_base..],
+                msg,
+            );
+            self.stack.truncate(args_base);
+            return Err(RuntimeError::typed("X::TypeCheck::Argument", attrs));
         }
 
         let saved_locals = std::mem::take(&mut self.locals);
@@ -175,47 +217,71 @@ impl Interpreter {
         // env.contains_key). The overlay write is born-owned (no caller-env fork)
         // and is dropped on return, so no per-param save/restore is needed.
         let write_all_params = crate::opcode::reflective_name_access_possible();
-        for (param_idx, slot) in param_slots.iter().enumerate() {
-            if param_idx < actual_count {
-                let val = crate::runtime::types::unwrap_varref_value(args[param_idx].clone());
-                if let Some(ref tc) = cf.param_defs[param_idx].type_constraint
-                    && !Self::fast_type_check(&val, tc)
-                {
-                    // (Readonly scope closed by `_readonly_guard`'s `Drop`.)
-                    match caller_env {
-                        Some(caller_env) => self.set_env(caller_env),
-                        // Reused frame: drop every by-name write made since
-                        // entry (the overlay was the shared empty singleton, so
-                        // all surviving entries are this call's param binds) —
-                        // the same wholesale discard the swap path gets from
-                        // dropping the scoped overlay.
-                        None => {
-                            if !self.env().overlay_is_shared_empty() {
-                                self.env_mut().retain_overlay(|_, _| false);
-                            }
-                        }
-                    }
-                    let used = std::mem::replace(&mut self.locals, saved_locals);
-                    self.recycle_locals(used);
-                    self.loop_local_vars = saved_loop_local_vars;
-                    self.loop_local_saved_env = saved_loop_local_saved_env;
-                    self.active_loop_param_names = saved_active_loop_param_names;
-                    self.block_declared_vars = saved_block_declared_vars;
-                    self.current_unit = saved_unit;
-                    {
-                        let param_name = &cf.param_defs[param_idx].name;
-                        let got = runtime::value_type_name(&val);
-                        let msg = format!(
-                            "Type check failed in binding ${}: expected {}, got {}",
-                            param_name, tc, got
-                        );
-                        let mut attrs =
-                            Self::type_check_argument_attrs(func_name, &cf.param_defs, args, msg);
-                        attrs.insert("expected".to_string(), Value::str(tc.to_string()));
-                        attrs.insert("got".to_string(), Value::str(got.to_string()));
-                        return Err(RuntimeError::typed("X::TypeCheck::Argument", attrs));
+        // Type-check the constrained parameters FIRST, against the arguments as
+        // they still sit untouched on the stack. Running the checks up front is
+        // what lets the bind loop below move each argument out of its stack slot
+        // instead of cloning it: a failure reported from here still sees the
+        // complete, unmodified argument list for `X::TypeCheck::Argument`'s
+        // `arguments` attribute. Only the failing index is remembered, so the
+        // borrow of `self.stack` ends before the `&mut self` rollback runs.
+        let mut type_failure: Option<(usize, &'static str)> = None;
+        for param_idx in 0..positional_count.min(actual_count) {
+            let Some(tc) = cf.param_defs[param_idx].type_constraint.as_ref() else {
+                continue;
+            };
+            let val = self.stack[args_base + param_idx].unwrap_varref();
+            if !Self::fast_type_check(val, tc) {
+                type_failure = Some((param_idx, runtime::value_type_name(val)));
+                break;
+            }
+        }
+        if let Some((param_idx, got)) = type_failure {
+            let tc = cf.param_defs[param_idx].type_constraint.as_ref().unwrap();
+            // (Readonly scope closed by `_readonly_guard`'s `Drop`.)
+            match caller_env {
+                Some(caller_env) => self.set_env(caller_env),
+                // Reused frame: drop every by-name write made since
+                // entry (the overlay was the shared empty singleton, so
+                // all surviving entries are this call's param binds) —
+                // the same wholesale discard the swap path gets from
+                // dropping the scoped overlay.
+                None => {
+                    if !self.env().overlay_is_shared_empty() {
+                        self.env_mut().retain_overlay(|_, _| false);
                     }
                 }
+            }
+            let used = std::mem::replace(&mut self.locals, saved_locals);
+            self.recycle_locals(used);
+            self.loop_local_vars = saved_loop_local_vars;
+            self.loop_local_saved_env = saved_loop_local_saved_env;
+            self.active_loop_param_names = saved_active_loop_param_names;
+            self.block_declared_vars = saved_block_declared_vars;
+            self.current_unit = saved_unit;
+            let param_name = &cf.param_defs[param_idx].name;
+            let msg = format!(
+                "Type check failed in binding ${}: expected {}, got {}",
+                param_name, tc, got
+            );
+            let mut attrs = Self::type_check_argument_attrs(
+                func_name,
+                &cf.param_defs,
+                &self.stack[args_base..],
+                msg,
+            );
+            self.stack.truncate(args_base);
+            attrs.insert("expected".to_string(), Value::str(tc.to_string()));
+            attrs.insert("got".to_string(), Value::str(got.to_string()));
+            return Err(RuntimeError::typed("X::TypeCheck::Argument", attrs));
+        }
+        for (param_idx, slot) in param_slots.iter().enumerate() {
+            if param_idx < actual_count {
+                // Move the argument out of its stack slot (the slots are
+                // discarded by the `truncate` below, so nothing observes the
+                // `Nil` left behind) rather than cloning it and dropping the
+                // original.
+                let val = std::mem::replace(&mut self.stack[args_base + param_idx], Value::NIL);
+                let val = crate::runtime::types::unwrap_varref_value(val);
                 let val = Self::itemize_plain_scalar_param(&cf.param_defs[param_idx], val);
                 let param_name = &cf.param_defs[param_idx].name;
                 let needs_env = write_all_params
@@ -244,6 +310,10 @@ impl Interpreter {
                 }
             }
         }
+        // The arguments are consumed: drop their (now `Nil`) stack slots so the
+        // body runs with the same stack depth the caller's drain used to leave
+        // behind. Every early return above truncates for the same reason.
+        self.stack.truncate(args_base);
         // Bind-time param values that a name-based reader can observe were
         // already written into the (born-owned) overlay env above when
         // `needs_env` held. A slot-only param (read solely via GetLocal) never

--- a/t/positional-light-arg-consumption.t
+++ b/t/positional-light-arg-consumption.t
@@ -1,0 +1,54 @@
+use Test;
+
+# The positional-light call path binds its parameters straight out of the VM
+# stack instead of copying them into an intermediate argument buffer. Pin the
+# two invariants that design rests on:
+#
+#   1. Every exit path consumes the arguments, so the caller's expression
+#      stack is left exactly as it was before the call. A leaked argument
+#      slot would surface as a wrong value for the surrounding expression.
+#   2. A parameter type-check failure still reports the COMPLETE, unmodified
+#      argument list -- the checks run before any argument is moved out of
+#      its slot, so a failure on the second parameter still sees the first.
+#
+# (mutsu raises X::TypeCheck::Argument here where Rakudo raises
+# X::TypeCheck::Binding::Parameter; that divergence is pre-existing and is not
+# what this file is about -- it only asserts the argument list stays whole.)
+
+plan 9;
+
+sub two(Int $a, Int $b --> Int) { $a * 10 + $b }
+
+# 1. Arguments consumed on the success path, inside a larger expression.
+is two(1, 2), 12, 'positional-light call returns the bound result';
+is 100 + two(3, 4) + 1000, 1134, 'call inside an expression leaves the stack balanced';
+is two(two(1, 2), two(3, 4)), 154, 'nested calls each consume their own arguments';
+
+# 2. Type-check failure reports the full argument list, failing param second.
+#    The bad value comes from a variable so this is a genuine run-time binding
+#    failure rather than something a compile-time signature check could reject.
+my $bad = "x";
+my $err;
+try {
+    two(1, $bad);
+    CATCH { default { $err = $_ } }
+}
+ok $err.defined, 'a failing type check throws';
+is $err.message, 'Type check failed in binding $b: expected Int, got Str',
+    'the message names the failing parameter';
+is-deeply $err.arguments.List, ('Int', 'Str'),
+    'the argument list still holds the already-bound first argument';
+
+# 3. The stack is unwound on the error path too: a later call in the same
+#    scope still sees a balanced stack.
+is two(5, 6), 56, 'a call after a failed one still binds correctly';
+
+# 4. Arity errors consume the arguments as well.
+my $one = 7;
+my $few;
+try {
+    two($one);
+    CATCH { default { $few = $_.message } }
+}
+like $few, /'Too few positionals'/, 'a shortfall is an arity error';
+is two(8, 9), 89, 'a call after an arity error still binds correctly';

--- a/todo/perf/late-august-call-path-slowdown-remainder.md
+++ b/todo/perf/late-august-call-path-slowdown-remainder.md
@@ -97,12 +97,16 @@ parameter bind loop cloned each bound argument twice. `bench-tak` −8.0%,
 
 Three things worth attacking next, in rough order of size:
 
-1. **The args/locals `Vec` churn (~11%).** `exec_call_func_op` borrows a pooled
-   `Vec` for the args and `extend`s the drained stack into it; the light path
-   then borrows another for the callee locals, `resize`s it with `Value::NIL`,
-   clones each argument into its slot, and recycles both. The clone/drop pair
-   per argument exists only because the args buffer is recycled rather than
-   moved from.
+1. **The args/locals `Vec` churn (~11%).** The **args half is closed** by
+   `news/2026-09/positional-light-call-binds-from-the-stack.md`: the cached
+   positional dispatch no longer materializes an argument buffer at all — the
+   callee takes `args_base` and binds by move straight out of `self.stack`,
+   truncating on every exit path (`bench-tak` −10.6%, `fib` −7.2%, `bench-fib`
+   −6.7% locally, both orderings). What remains is the **locals** half: the
+   light path still borrows a pooled `Vec` for the callee locals and `resize`s
+   it with `Value::NIL` per call, and the same buffer shape is still copied
+   into on the *named* light path (`call_compiled_function_light`), which was
+   left untouched.
 2. **Readonly bookkeeping (~5.5%).** Every call marks each parameter readonly
    and unmarks it on exit: an `FxHashMap<Symbol, ReadonlyKind>` insert, a
    remove, and a journal push/pop per parameter per call. A monomorphic


### PR DESCRIPTION
## What

`todo/perf/late-august-call-path-slowdown-remainder.md` listed the args/locals `Vec` churn as the largest remaining item on the call path (~11% of `bench-fib`). This closes the **args half**.

The cached positional dispatch used to borrow a pooled `Vec` for the arguments, `extend` the drained stack slots into it, hand the callee a `&[Value]`, and recycle it; the callee then cloned each argument out of that buffer into its parameter slot. Per call that is a `Vec::extend_trusted`, two pool round-trips, two per-element drop loops, and a clone/drop pair per argument — and the clone existed only because the buffer was recycled rather than moved from. In a `bench-fib` profile: `Vec::extend_trusted` 3.2% + `recycle_locals` 4.1% of self time.

The callee now takes `args_base: usize` and binds directly out of `self.stack[args_base..]`, truncating back to `args_base` on **every** exit path (both arity errors, the parameter type-check failure, and normal completion). No intermediate buffer exists at all.

Binding by move needed one restructuring: the parameter type checks used to run interleaved with the binds, so moving a value out of its slot would leave `Nil` behind for a later parameter's `X::TypeCheck::Argument` `arguments` attribute. They now run as a separate pass over the untouched stack slots first (via `Value::unwrap_varref`, which borrows instead of cloning), and only then does the bind loop `mem::replace` each argument into its slot.

The old `&[Value]` entry point survives as a thin wrapper for the two cold call sites that hold an owned argument vector (the OTF promotion arm and the slow `call_function` resolution path).

## Measurement

Interleaved A/B of two release builds, nine alternating runs each, median retired user cycles on a pinned P-core:

| benchmark | delta |
| --- | ---: |
| `bench-tak` | −10.6% |
| `fib` | −7.2% |
| `bench-fib` | −6.7% |
| `method-call` | −0.6% |
| `bench-ctor` / `bench-class` / `bench-hash` / `hash-access` | ±1% |

Both orderings were measured and every sign flipped with the swap, so none of it is drift. `poly-call` reads +1.9%, but a profile of the new binary samples **zero** cycles in any changed function while running it — the known binary-layout effect, discharged the way the ticket requires.

(Local A/B numbers, for the PR only; the documents cite the bench CI.)

## Tests

`t/positional-light-arg-consumption.t` pins the two invariants the design rests on: the arguments are consumed on every exit path (so a surrounding expression still sees a balanced stack), and a type-check failure on the second parameter still reports the first one. Full `make test` green locally (3625 files, 36678 tests).