### PR TITLE
perf(vm): probe the rebound `&return` by a pre-interned symbol

### DIFF
--- a/news/2026-09/jit-return-probes-a-pre-interned-symbol.md
+++ b/news/2026-09/jit-return-probes-a-pre-interned-symbol.md
@@ -1,0 +1,51 @@
+# Every routine return re-interned `&return`
+
+`return` can be lexically rebound (`my &return = sub ($v) {...}`), so both the
+interpreter's `OpCode::Return` arm and the JIT's `ret` shim probe the
+environment for a `&return` binding before raising the return signal. Both
+probes were written as `env().get("&return")` — and `Env::get(&str)` interns
+its key, which is a thread-local, string-keyed hash lookup.
+
+That put `Symbol::intern` on **every single return out of natively-compiled
+code**. In a `bench-fib` profile (fib(25), JIT on, P-core `cycles/u`), a
+call-graph record attributed it exactly:
+
+```
+mutsu_jit_1
+  mutsu::vm::vm_jit_helpers::ret
+    mutsu::symbol::Symbol::intern
+      std::thread::local::LocalKey<T>::with     4.23%
+```
+
+`LocalKey::with` was 5.3% of self time overall, plus its share of
+`__memcmp_avx2_movbe` (1.1%) from comparing the key inside the intern cache.
+
+The name is now a well-known symbol (`crate::symbol::wk::rebound_return`) and
+both sites use `get_sym`, so the probe is a chain walk on a `u32` key with no
+interning at all.
+
+## Measurement
+
+Interleaved A/B of two release builds, nine alternating runs each, median
+retired user cycles on a pinned P-core:
+
+| benchmark | delta |
+| --- | ---: |
+| `fib` | −6.8% |
+| `bench-fib` | −6.6% |
+| `bench-tak` | −4.8% |
+| `method-call` / `bench-class` / `bench-ctor` / `bench-hash` | +0.2% .. +0.8% |
+
+Both orderings were measured on `bench-fib` and `bench-hash`; both signs
+flipped with the swap, so the sub-1% readings on the untouched benchmarks are
+binary layout, not a real cost.
+
+`t/rebound-return-hot-loop.t` pins that the rebinding still takes effect after
+the routine has gone hot enough to be natively compiled, and that a sibling
+routine without the rebinding is unaffected.
+
+This is the third instance of the same shape (after the ADR-0037 routine-frame
+symbols and the `"_"`/`"Any"` parameter-bind names): a fixed, known-at-compile-
+time name being re-interned on a per-call path. `todo/perf/late-august-call-path-slowdown-remainder.md`
+now tracks the 75 remaining `env().get("<literal>")` call sites, which need a
+profile of a non-`fib` benchmark to rank.

--- a/src/symbol.rs
+++ b/src/symbol.rs
@@ -103,6 +103,11 @@ pub(crate) mod wk {
         any => "Any";
         /// The dynamic `$?FILE`, stored sigil-less with its twigil.
         file => "?FILE";
+        /// A lexically rebound `&return`. Probed on EVERY routine return (both
+        /// the interpreter's `OpCode::Return` and the JIT's `ret` shim), so it
+        /// must never be re-interned there -- the thread-local intern cache is
+        /// a string-keyed hash lookup, which showed up as 5.3% of `bench-fib`.
+        rebound_return => "&return";
     }
 }
 

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -4408,7 +4408,12 @@ impl Interpreter {
                 let val = self.stack.pop().unwrap_or(Value::NIL);
                 // Check if &return has been lexically rebound; if so, call
                 // the rebound function instead of performing a built-in return.
-                if let Some(rebound) = self.env().get("&return").cloned()
+                // Pre-interned: this runs on every return (see the matching
+                // probe in `vm_jit_helpers::ret`).
+                if let Some(rebound) = self
+                    .env()
+                    .get_sym(crate::symbol::wk::rebound_return())
+                    .cloned()
                     && matches!(
                         rebound.view(),
                         ValueView::Sub(_) | ValueView::WeakSub(_) | ValueView::Routine { .. }

--- a/src/vm/vm_jit_helpers.rs
+++ b/src/vm/vm_jit_helpers.rs
@@ -328,7 +328,13 @@ pub(super) unsafe extern "C" fn ret(interp: *mut Interpreter) -> u32 {
     let interp = unsafe { &mut *interp };
     panic_boundary(|| {
         let val = interp.stack.pop().unwrap_or(Value::NIL);
-        if let Some(rebound) = interp.env().get("&return").cloned()
+        // Pre-interned (`wk::rebound_return`): this probe runs on every return
+        // out of natively-compiled code, and `Env::get(&str)` would re-intern
+        // the name -- a thread-local string-keyed hash lookup per return.
+        if let Some(rebound) = interp
+            .env()
+            .get_sym(crate::symbol::wk::rebound_return())
+            .cloned()
             && matches!(
                 rebound.view(),
                 ValueView::Sub(_) | ValueView::WeakSub(_) | ValueView::Routine { .. }

--- a/t/rebound-return-hot-loop.t
+++ b/t/rebound-return-hot-loop.t
@@ -1,0 +1,32 @@
+use Test;
+
+# `return` can be lexically rebound (`my &return = ...`), so every routine
+# return probes the environment for `&return` before raising the return
+# signal. That probe is keyed by a pre-interned symbol rather than by name,
+# on both the interpreter's `OpCode::Return` and the JIT's `ret` shim -- pin
+# that the rebinding still takes effect after the routine has gone hot enough
+# to be natively compiled, and that a routine WITHOUT the rebinding is
+# unaffected by a sibling one that has it.
+
+plan 4;
+
+sub rebound($n) {
+    my &return = sub ($v) { $v + 1000 };
+    return $n;
+}
+
+sub plain($n) {
+    return $n * 2;
+}
+
+is rebound(1), 1001, 'a rebound &return runs instead of the built-in return';
+is plain(1), 2, 'a routine without the rebinding returns normally';
+
+my $hot = 0;
+my $cold = 0;
+for ^20000 {
+    $hot += rebound(1);
+    $cold += plain(1);
+}
+is $hot, 20020000, 'the rebinding still applies once the routine is hot';
+is $cold, 40000, 'a plain return is unaffected by the sibling rebinding';

--- a/todo/perf/late-august-call-path-slowdown-remainder.md
+++ b/todo/perf/late-august-call-path-slowdown-remainder.md
@@ -115,7 +115,19 @@ Three things worth attacking next, in rough order of size:
    operations.
 3. **`mutsu_jit_1` +50% since August.** The natively-compiled body itself got
    slower, which nothing in the interpreter explains. Dump the generated code
-   for both builds before guessing.
+   for both builds before guessing. (Note that `vm_jit_helpers::ret`, the shim
+   the generated code calls on every return, was separately fixed — see below —
+   so re-measure `mutsu_jit_1` itself before assuming the +50% is still there.)
+4. **The remaining `env().get("<fixed name>")` probes.** Closed for `&return`
+   by `news/2026-09/jit-return-probes-a-pre-interned-symbol.md`: the rebound-
+   `&return` probe on every routine return re-interned the name, a thread-local
+   string-keyed hash lookup that was 5.3% of `bench-fib` under `LocalKey::with`
+   plus its share of `__memcmp_avx2_movbe` (`bench-fib` −6.6%, `fib` −6.8%,
+   `bench-tak` −4.8% locally, both orderings). **75 more `env().get("...")`
+   call sites remain** with a literal key — `"_"` (which already has
+   `wk::topic()`), `"/"`, `"!"`, `"__mutsu_in_eval"`. None are on `fib`'s path,
+   so they need a profile of a different benchmark (loops, smartmatch,
+   substitution, `try`) to rank before sweeping.
 
 ## Method notes for whoever picks this up
 


### PR DESCRIPTION
## What

`return` can be lexically rebound (`my &return = sub ($v) {...}`), so both the interpreter's `OpCode::Return` arm and the JIT's `ret` shim probe the environment for a `&return` binding before raising the return signal. Both probes were written as `env().get("&return")` — and `Env::get(&str)` interns its key, which is a thread-local, string-keyed hash lookup.

That put `Symbol::intern` on **every single return out of natively-compiled code**. A call-graph profile of `bench-fib` (fib(25), JIT on, P-core `cycles/u`) attributed it exactly:

```
mutsu_jit_1
  mutsu::vm::vm_jit_helpers::ret
    mutsu::symbol::Symbol::intern
      std::thread::local::LocalKey<T>::with     4.23%
```

`LocalKey::with` was 5.3% of self time overall, plus its share of `__memcmp_avx2_movbe` (1.1%) from the intern cache's key comparison.

The name is now a well-known symbol (`symbol::wk::rebound_return`) and both sites use `get_sym`, so the probe is a chain walk on a `u32` key with no interning at all.

This is the third instance of the same shape, after the ADR-0037 routine-frame symbols (#7259) and the `"_"`/`"Any"` parameter-bind names (#7262). The ticket now records the 75 remaining `env().get("<literal>")` call sites, which need a profile of a non-`fib` benchmark to rank.

## Measurement

Interleaved A/B of two release builds, nine alternating runs each, median retired user cycles on a pinned P-core:

| benchmark | delta |
| --- | ---: |
| `fib` | −6.8% |
| `bench-fib` | −6.6% |
| `bench-tak` | −4.8% |
| `method-call` / `bench-class` / `bench-ctor` / `bench-hash` | +0.2% … +0.8% |

Both orderings were measured on `bench-fib` and `bench-hash`; both signs flipped with the swap, so the sub-1% readings on the untouched benchmarks are binary layout, not a real cost. (Local A/B, for the PR only; the documents cite the bench CI.)

## Tests

`t/rebound-return-hot-loop.t` pins that the rebinding still takes effect after the routine has gone hot enough to be natively compiled, and that a sibling routine without the rebinding is unaffected. It passes under real `raku` too. Full `make test` green locally (3627 files, 36691 tests).