### PR TITLE
perf(vm): outline the light call path's cold error construction

### DIFF
--- a/news/2026-09/light-call-cold-error-paths-outlined.md
+++ b/news/2026-09/light-call-cold-error-paths-outlined.md
@@ -1,0 +1,41 @@
+# The hot call path carried its error messages in its stack frame
+
+`call_compiled_function_positional_light_at` is the hottest dispatch path in
+the VM (36.7% of `bench-fib`'s self time). Its stack frame was **1064 bytes**,
+and a recursive benchmark touches that whole frame once per call.
+
+A large part of it was dead weight. Four error paths were written inline in the
+function body — two arity mismatches, a parameter type-check failure, and a
+return-type-check failure — each with a `format!` and, for three of them, an
+`X::TypeCheck::Argument` attribute map. None of that runs on a successful call,
+but LLVM still reserves the stack slots for the `format_args!` argument arrays,
+the `String`s, and the `HashMap`s in the one frame every call pays for. The
+`perf annotate` symptom was a run of `movaps %xmm0,N(%rsp)` spill stores
+carrying double-digit percentages of the function's self time.
+
+All four are now `#[cold] #[inline(never)]` free functions taking exactly what
+they need. The frame is **984 bytes**, and the behaviour is byte-identical —
+the message construction moved verbatim.
+
+## Measurement
+
+Interleaved A/B of two release builds, median over 11 alternating runs on a
+pinned P-core:
+
+| benchmark | cycles | instructions |
+| --- | ---: | ---: |
+| `fib` | −7.3% | −1.7% |
+| `bench-fib` | −4.5% | −1.7% |
+| `bench-tak` | −0.7% | −1.2% |
+
+The cold code this change moves is **never executed** by these benchmarks,
+which is normally the signature of a binary-layout artefact rather than a real
+win (see the discharge rule in
+`todo/perf/late-august-call-path-slowdown-remainder.md`). Retired
+**instructions** settle it: they are layout-insensitive, and they drop by
+1.2–1.7%, so real work — the prologue/epilogue spill traffic for those slots —
+is genuinely gone. The larger cycle delta on top of that is the frame and
+I-cache behaviour the smaller frame buys.
+
+984 bytes is still a large frame; whatever else fills it has not been
+identified. `perf annotate` on the function is the way in.

--- a/src/vm/vm_call_light.rs
+++ b/src/vm/vm_call_light.rs
@@ -1,5 +1,71 @@
 use super::*;
 
+/// Build the `X::TypeCheck::Argument` for a positional-light arity mismatch.
+///
+/// Outlined and `#[cold]` on purpose: the message `format!` and the attribute
+/// map are dead weight on the hot path, but LLVM still reserves their stack
+/// slots in [`Interpreter::call_compiled_function_positional_light_at`]'s
+/// frame, which every recursive call touches. Keeping them out of that frame
+/// is the point — do not inline these back in.
+#[cold]
+#[inline(never)]
+fn positional_light_arity_error(
+    func_name: &str,
+    param_defs: &[crate::ast::ParamDef],
+    args: &[Value],
+    expected: usize,
+    actual: usize,
+    too_many: bool,
+) -> RuntimeError {
+    // Several call sites pattern-match on these exact messages (the general
+    // binder in `binding_signature.rs` produces the same two).
+    let msg = if too_many {
+        format!("Too many positionals passed; expected {expected} arguments but got {actual}")
+    } else {
+        format!("Too few positionals passed; expected {expected} arguments but got {actual}")
+    };
+    RuntimeError::typed(
+        "X::TypeCheck::Argument",
+        Interpreter::type_check_argument_attrs(func_name, param_defs, args, msg),
+    )
+}
+
+/// Build the `X::TypeCheck::Argument` for a positional-light parameter whose
+/// argument failed its type constraint. `#[cold]` for the same reason as
+/// [`positional_light_arity_error`].
+#[cold]
+#[inline(never)]
+fn positional_light_type_error(
+    func_name: &str,
+    param_defs: &[crate::ast::ParamDef],
+    args: &[Value],
+    param_idx: usize,
+    tc: &str,
+    got: &str,
+) -> RuntimeError {
+    let msg = format!(
+        "Type check failed in binding ${}: expected {}, got {}",
+        param_defs[param_idx].name, tc, got
+    );
+    let mut attrs = Interpreter::type_check_argument_attrs(func_name, param_defs, args, msg);
+    attrs.insert("expected".to_string(), Value::str(tc.to_string()));
+    attrs.insert("got".to_string(), Value::str(got.to_string()));
+    RuntimeError::typed("X::TypeCheck::Argument", attrs)
+}
+
+/// Build the error for a positional-light routine whose return value failed
+/// the declared return type. `#[cold]` for the same reason as
+/// [`positional_light_arity_error`].
+#[cold]
+#[inline(never)]
+fn positional_light_return_type_error(rt: &str, got: &Value) -> RuntimeError {
+    RuntimeError::new(format!(
+        "Type check failed for return value; expected {}, got {}",
+        rt,
+        runtime::value_type_name(got)
+    ))
+}
+
 impl Interpreter {
     /// Slice-taking wrapper over [`Self::call_compiled_function_positional_light_at`]
     /// for the cold call sites that already hold an owned argument vector
@@ -65,19 +131,17 @@ impl Interpreter {
         // positionals" arity error. Report it as a typed X::TypeCheck::Argument
         // carrying objname/signature/arguments, matching the interpreter path.
         if actual_count < positional_count {
-            let msg = format!(
-                "Too few positionals passed; expected {} arguments but got {}",
-                positional_count, actual_count
-            );
             self.current_unit = saved_unit;
-            let attrs = Self::type_check_argument_attrs(
+            let err = positional_light_arity_error(
                 func_name,
                 &cf.param_defs,
                 &self.stack[args_base..],
-                msg,
+                positional_count,
+                actual_count,
+                false,
             );
             self.stack.truncate(args_base);
-            return Err(RuntimeError::typed("X::TypeCheck::Argument", attrs));
+            return Err(err);
         }
         // `is_positional_light_call_eligible` guarantees no slurpy/optional
         // param exists on this signature, so a surplus argument is always an
@@ -87,19 +151,17 @@ impl Interpreter {
         // (`binding_signature.rs`'s "Too many positionals passed" check) --
         // several call sites pattern-match on this exact message.
         if actual_count > positional_count {
-            let msg = format!(
-                "Too many positionals passed; expected {} arguments but got {}",
-                positional_count, actual_count
-            );
             self.current_unit = saved_unit;
-            let attrs = Self::type_check_argument_attrs(
+            let err = positional_light_arity_error(
                 func_name,
                 &cf.param_defs,
                 &self.stack[args_base..],
-                msg,
+                positional_count,
+                actual_count,
+                true,
             );
             self.stack.truncate(args_base);
-            return Err(RuntimeError::typed("X::TypeCheck::Argument", attrs));
+            return Err(err);
         }
 
         let saved_locals = std::mem::take(&mut self.locals);
@@ -258,21 +320,16 @@ impl Interpreter {
             self.active_loop_param_names = saved_active_loop_param_names;
             self.block_declared_vars = saved_block_declared_vars;
             self.current_unit = saved_unit;
-            let param_name = &cf.param_defs[param_idx].name;
-            let msg = format!(
-                "Type check failed in binding ${}: expected {}, got {}",
-                param_name, tc, got
-            );
-            let mut attrs = Self::type_check_argument_attrs(
+            let err = positional_light_type_error(
                 func_name,
                 &cf.param_defs,
                 &self.stack[args_base..],
-                msg,
+                param_idx,
+                tc,
+                got,
             );
             self.stack.truncate(args_base);
-            attrs.insert("expected".to_string(), Value::str(tc.to_string()));
-            attrs.insert("got".to_string(), Value::str(got.to_string()));
-            return Err(RuntimeError::typed("X::TypeCheck::Argument", attrs));
+            return Err(err);
         }
         for (param_idx, slot) in param_slots.iter().enumerate() {
             if param_idx < actual_count {
@@ -591,11 +648,7 @@ impl Interpreter {
         {
             let check_val = explicit_return.as_ref().unwrap_or(&ret_val);
             if !Self::light_return_type_check(check_val, rt) {
-                return Err(RuntimeError::new(format!(
-                    "Type check failed for return value; expected {}, got {}",
-                    rt,
-                    runtime::value_type_name(check_val)
-                )));
+                return Err(positional_light_return_type_error(rt, check_val));
             }
         }
 

--- a/todo/perf/late-august-call-path-slowdown-remainder.md
+++ b/todo/perf/late-august-call-path-slowdown-remainder.md
@@ -128,6 +128,28 @@ Three things worth attacking next, in rough order of size:
    `wk::topic()`), `"/"`, `"!"`, `"__mutsu_in_eval"`. None are on `fib`'s path,
    so they need a profile of a different benchmark (loops, smartmatch,
    substitution, `try`) to rank before sweeping.
+5. **`call_compiled_function_positional_light_at`'s stack frame.** It was 1064
+   bytes and every recursive call touches all of it.
+   `news/2026-09/light-call-cold-error-paths-outlined.md` took it to 984 by
+   moving the four inline error constructions (`format!` + attribute maps) into
+   `#[cold] #[inline(never)]` helpers — `fib` −7.3% cycles / −1.7% retired
+   instructions. **984 bytes is still large and nothing else has been
+   identified as filling it**; `perf annotate` on the function shows the
+   remaining cost as `movaps ...,N(%rsp)` spill stores. Note that the retired-
+   instruction count is the honest oracle for this kind of change: the code
+   being moved never executes in the benchmark, so a cycles-only measurement
+   cannot be told apart from the layout lottery.
+6. **`RuntimeError::return_signal` allocates a `String` per return.** It sets
+   `message: "CX::Return".to_string()`, so every routine return mallocs and
+   frees a 10-byte string. A call-graph profile attributes essentially all of
+   `bench-fib`'s `malloc` (2.2%) to it, with a matching share of `_int_free`
+   (2.0%) and `return_signal` itself (0.8%) — call it 4-5%. The clean fix is
+   `RuntimeError::message: Cow<'static, str>`, which would also stop the many
+   `RuntimeError::new("literal")` sites from allocating; it is a wide but
+   mechanical change (~337 `.message` reads, ~153 `message:` initializers) and
+   grows `RuntimeError` by 8 bytes, which wants its own measurement. The four
+   sites that compare `message` against `"CX::Return"` use it as the exception
+   *type name*, so it cannot simply be left empty.
 
 ## Method notes for whoever picks this up
 


### PR DESCRIPTION
## What

`call_compiled_function_positional_light_at` is the hottest dispatch path in the VM (36.7% of `bench-fib`'s self time), and its stack frame was **1064 bytes** — touched in full once per recursive call.

Much of that was dead weight. Four error paths were written inline in the function body (two arity mismatches, a parameter type-check failure, a return-type-check failure), each with a `format!` and, for three of them, an `X::TypeCheck::Argument` attribute map. None of it runs on a successful call, but LLVM still reserves the stack slots for the `format_args!` argument arrays, the `String`s and the `HashMap`s in the one frame every call pays for. `perf annotate` showed it as a run of `movaps %xmm0,N(%rsp)` spill stores carrying double-digit percentages of the function's self time.

All four are now `#[cold] #[inline(never)]` free functions taking exactly what they need. The frame is **984 bytes** and the messages are byte-identical — the construction moved verbatim.

## Measurement

Interleaved A/B of two release builds, median over 11 alternating runs on a pinned P-core:

| benchmark | cycles | instructions |
| --- | ---: | ---: |
| `fib` | −7.3% | −1.7% |
| `bench-fib` | −4.5% | −1.7% |
| `bench-tak` | −0.7% | −1.2% |

**Why the instruction column is there:** the code this change moves is *never executed* by these benchmarks, which is normally the signature of a binary-layout artefact rather than a real win (the discharge rule the ticket itself imposes). Retired instructions are layout-insensitive, and they drop 1.2–1.7% — so real work, the prologue/epilogue spill traffic for those slots, is genuinely gone. The larger cycle delta on top is the frame/I-cache behaviour the smaller frame buys. Both orderings were measured on the earlier iteration of this change and the signs flipped cleanly.

(Local A/B, for the PR only; the documents cite the bench CI.)

## Tests

No behaviour change — the error messages moved verbatim, and `t/positional-light-arg-consumption.t` (landed in #7265) already pins all three argument-side messages. Return-type-check failure spot-checked against real `raku`. Full `make test` green locally (3627 files, 36691 tests).