### PR TITLE
perf(vm): inline the hot-path no-op guards of three per-call helpers

### DIFF
--- a/news/2026-09/hot-path-noop-guards-are-now-inlined.md
+++ b/news/2026-09/hot-path-noop-guards-are-now-inlined.md
@@ -1,0 +1,49 @@
+# Three hot-path helpers paid a function call to discover they had nothing to do
+
+Every compiled call runs `apply_pending_rw_writeback`,
+`apply_pending_caller_var_writeback` and `resolve_let_saves_on_success`. All
+three begin with a guard that is true in the overwhelmingly common case — the
+pending list is empty, or no `let`/`temp` was pushed — and their comments say
+as much ("no cost for any program that never made a runtime-name write").
+
+But the guard lived *inside* an out-of-line function, so the common case was
+never free: it cost a call, argument setup and a return, plus (for
+`resolve_let_saves_on_success`) the construction and drop of an empty `Vec`.
+On `bench-fib` the three showed up at 1.31% + 1.27% + 1.26% of self time —
+entirely to answer "nothing to do".
+
+Each is now an `#[inline]` wrapper holding just the guard, delegating to an
+`#[inline(never)]` body. The guard compiles into the caller as a load and a
+branch.
+
+## The bug this nearly shipped with
+
+`apply_pending_rw_writeback`'s trailing statement —
+`self.apply_pending_caller_var_writeback(code)` — sat *outside* the
+`if !...is_empty()` block, so it ran unconditionally. Moving the block wholesale
+into the slow body captured that call with it, and the caller-var drain then
+only ran when the *rw* list happened to be non-empty. `make test` caught it
+immediately (16 files, including `t/runtime-name-write-to-outer-lexical.t` and
+the `warn`-resume family). The wrapper now keeps the unconditional drain where
+it belongs.
+
+Worth noting for the next such split: the first A/B was run against the broken
+binary, and it looked *better* (`bench-fib` −12.2%) precisely because it was
+skipping work. Re-measuring after the fix is not optional.
+
+## Measurement
+
+Interleaved A/B of two release builds, median over nine alternating runs on a
+pinned P-core, measured after the fix:
+
+| benchmark | cycles | instructions |
+| --- | ---: | ---: |
+| `fib` | −8.7% | −5.1% |
+| `bench-fib` | −8.2% | −5.1% |
+| `bench-tak` | −5.3% | −2.6% |
+| `bench-hash` | −0.6% | |
+| `bench-class` | +0.7% | |
+
+Both orderings were measured on `bench-fib` and `bench-tak`; both signs
+flipped. Retired instructions drop 2.6–5.1%, confirming the call overhead was
+real work and not a layout artefact.

--- a/src/runtime/accessors_misc.rs
+++ b/src/runtime/accessors_misc.rs
@@ -531,7 +531,21 @@ impl Interpreter {
 
     /// On successful block exit: restore `temp` saves, discard `let` saves.
     /// For `let`, only restore if the block returned an unsuccessful value.
+    /// The empty-range guard is inlined and the body is not: a routine with no
+    /// `let`/`temp` in scope -- the overwhelmingly common case on the hot call
+    /// path -- must not pay a call plus a `Vec` construction to discover it has
+    /// nothing to restore (1.3% of `bench-fib`'s self time).
+    #[inline]
     pub(crate) fn resolve_let_saves_on_success(&mut self, mark: usize, success: bool) {
+        if mark >= self.let_saves.len() {
+            self.let_saves.truncate(mark);
+            return;
+        }
+        self.resolve_let_saves_on_success_slow(mark, success);
+    }
+
+    #[inline(never)]
+    fn resolve_let_saves_on_success_slow(&mut self, mark: usize, success: bool) {
         // Collect restore actions first to avoid borrow conflicts.
         let restores: Vec<(String, Value, Option<u32>)> = (mark..self.let_saves.len())
             .rev()

--- a/src/vm/vm_env_helpers.rs
+++ b/src/vm/vm_env_helpers.rs
@@ -1852,8 +1852,24 @@ impl Interpreter {
     /// is handled by the env_dirty-gated `reconcile_locals_from_env_at_site` that
     /// `drain_and_reconcile_after_cached_call` (and the slow call path) runs at
     /// each frame's call site.
+    /// The `is_empty` guard is inlined and the body is not: this runs on the
+    /// hottest call path, where the pending list is almost always empty, so an
+    /// out-of-line call whose whole work is one `is_empty()` was pure call
+    /// overhead (1.3% of `bench-fib`'s self time).
+    #[inline]
     pub(super) fn apply_pending_rw_writeback(&mut self, code: &CompiledCode) {
         if !self.pending_rw_writeback_sources.is_empty() {
+            self.apply_pending_rw_writeback_slow(code);
+        }
+        // Runs unconditionally: the rw drain above may PUSH into the caller-var
+        // list, but that list is also filled by `$CALLER::x = v` writers that
+        // never touch `pending_rw_writeback_sources` at all.
+        self.apply_pending_caller_var_writeback(code);
+    }
+
+    #[inline(never)]
+    fn apply_pending_rw_writeback_slow(&mut self, code: &CompiledCode) {
+        {
             let sources = std::mem::take(&mut self.pending_rw_writeback_sources);
             for source in sources {
                 // §1.4/§1.5: prefer the compiler-baked caller slot for this source
@@ -1911,7 +1927,6 @@ impl Interpreter {
                 }
             }
         }
-        self.apply_pending_caller_var_writeback(code);
     }
 
     /// Carry a still-unclaimed RUNTIME-NAME write ACROSS a frame boundary.
@@ -1960,10 +1975,18 @@ impl Interpreter {
     /// *deeper* call (whose code lacks the slot) before returning to the frame that
     /// owns it, and that deeper call's drain must not consume the pending write.
     /// Each matched source is removed so it is applied exactly once.
+    /// Guard inlined, body out of line -- see
+    /// [`Self::apply_pending_rw_writeback`] for why.
+    #[inline]
     pub(super) fn apply_pending_caller_var_writeback(&mut self, code: &CompiledCode) {
         if self.pending_caller_var_writeback.is_empty() {
             return;
         }
+        self.apply_pending_caller_var_writeback_slow(code);
+    }
+
+    #[inline(never)]
+    fn apply_pending_caller_var_writeback_slow(&mut self, code: &CompiledCode) {
         let sources = std::mem::take(&mut self.pending_caller_var_writeback);
         let mut retained = Vec::new();
         for source in sources {


### PR DESCRIPTION
## What

Every compiled call runs `apply_pending_rw_writeback`, `apply_pending_caller_var_writeback` and `resolve_let_saves_on_success`. All three begin with a guard that is true in the overwhelmingly common case — the pending list is empty, or no `let`/`temp` was pushed — and their comments say as much ("No cost … for any program that never made a runtime-name write").

It was not free. The guard lived *inside* an out-of-line function, so the common case still paid a call, argument setup and a return, plus (for `resolve_let_saves_on_success`) the construction and drop of an empty `Vec`. On `bench-fib` the three showed up at **1.31% + 1.27% + 1.26%** of self time, entirely to answer "nothing to do".

Each is now an `#[inline]` wrapper holding just the guard, delegating to an `#[inline(never)]` body.

## The bug this nearly shipped with

`apply_pending_rw_writeback`'s trailing statement — `self.apply_pending_caller_var_writeback(code)` — sits *outside* the `if !...is_empty()` block, so it runs unconditionally (the caller-var list is also filled by `$CALLER::x = v` writers that never touch the rw list). Moving the block wholesale into the slow body captured that call with it. `make test` caught it immediately: 16 files, including `t/runtime-name-write-to-outer-lexical.t` and the `warn`-resume family. The wrapper now keeps the drain where it belongs.

Worth recording: the *first* A/B was run against that broken binary and looked **better** (`bench-fib` −12.2%) precisely because it was skipping work. Everything below was re-measured after the fix.

## Measurement

Interleaved A/B of two release builds, median over nine alternating runs on a pinned P-core:

| benchmark | cycles | instructions |
| --- | ---: | ---: |
| `fib` | −8.7% | −5.1% |
| `bench-fib` | −8.2% | −5.1% |
| `bench-tak` | −5.3% | −2.6% |
| `bench-hash` | −0.6% | |
| `bench-class` | +0.7% | |

Both orderings were measured on `bench-fib` and `bench-tak`; both signs flipped. Retired instructions drop 2.6–5.1%, so this is real call overhead removed, not a layout artefact.

(Local A/B, for the PR only; the documents cite the bench CI.)

## Tests

No behaviour change intended; `make test` green locally (3627 files, 36691 tests) — and it is what caught the drain bug above, so it is exercising exactly the paths at issue.