### PR TITLE
docs(adr): propose ADR-0066, a per-callsite inline cache for call dispatch

### DIFF
--- a/docs/adr/0066-call-dispatch-inline-cache.md
+++ b/docs/adr/0066-call-dispatch-inline-cache.md
@@ -1,0 +1,119 @@
+# ADR-0066: Call dispatch should resolve through a per-callsite inline cache, not a name-keyed hash map
+
+- Status: **Proposed**
+- Date: 2026-09-03
+- Related: [ADR-0004](0004-jit-strategy.md) (J4d light-call caches),
+  [ADR-0006](0006-baseline-interpreter-optimizations.md) (baseline interpreter
+  optimizations), `todo/perf/late-august-call-path-slowdown-remainder.md`
+
+## Context
+
+`exec_call_func_op` is the VM's function-call dispatcher. After the
+2026-09-03 round of call-path fixes (#7259, #7261, #7262, #7265, #7266, #7267,
+#7268, #7269 — cumulatively about −38% on `benchmarks/fib.raku`), it is the
+**second-largest self-time symbol** in a `bench-fib` profile, at 14.1%, behind
+only `call_compiled_function_positional_light_at` at 36.3%.
+
+`perf annotate` shows where that 14.1% goes. It is not the dispatcher's own
+logic — it is **two hash-map probes per call**, both visible as hashbrown's
+SIMD group scan (`movdqa` / `pcmpeqb` / `pmovmskb`, the single hottest
+instruction inside the function at 13.1% of its self time):
+
+1. `self.pos_light_call_cache.get(&name_sym)` — the name-keyed light-call
+   cache, `FxHashMap<Symbol, PosLightTarget>`.
+2. `compiled_fns.get(&key)` — resolving the cached key to the callee body.
+
+The second probe is worse than an ordinary one. `CompiledFns` is
+`FxHashMap<Symbol, CompiledFunction>` and `CompiledFunction` is **2440 bytes**
+(`imul $0x988` appears in the generated probe as the bucket stride), so the
+table stores 2.4 KB values inline: every probe step touches a fresh cache line
+region, and every rehash memcpys kilobytes per entry.
+
+Both probes exist to answer a question that is **fixed per call site** in the
+overwhelmingly common case. `fib`'s recursive call site resolves to the same
+`CompiledFunction` on all 242 785 executions, and re-derives it by hashing a
+symbol twice each time.
+
+This is the classic case for a *monomorphic inline cache*: cache the resolved
+target **at the call site**, not in a global map keyed by name.
+
+## Decision (proposed)
+
+Add a per-callsite inline cache to the call opcodes.
+
+1. `OpCode::CallFunc` (and `CallFuncNamed`, and later `CallMethod`) gains a
+   `cache_idx: u32`, assigned by the compiler — one slot per call site in a
+   `CompiledCode`. `OpCode` has budget: it is currently within the 48-byte cap
+   the `opcode_size_guard` test pins, and `CallFunc`'s payload is
+   `{u32, u32, Option<u32>}`.
+2. `CompiledCode` gains a side table of cache slots, filled lazily.
+   `CompiledCode` is shared behind `Arc` across threads, so the slots must be
+   `Sync`: an `AtomicU64`-based slot, or a `Box<[OnceLock<...>]>` **plus** an
+   invalidation generation. Precedent exists in the same struct — `const_syms`
+   is already a lazily-filled `OnceLock<Box<[OnceLock<Symbol>]>>` side table
+   addressed by a constant index.
+3. A slot holds the resolved target plus everything needed to prove it is
+   still valid: the `fn_resolve_gen` it was filled at, the callsite package
+   symbol (the OTF cache already keys on this), and the callee's
+   `fingerprint`. A miss or a failed validation falls back to today's path and
+   refills the slot.
+4. The cached target must be a *handle*, not a raw pointer into the map's
+   storage (see Alternatives).
+
+## Step 1, independent of the above: `CompiledFns` values behind `Arc`
+
+Changing `CompiledFns` to `FxHashMap<Symbol, Arc<CompiledFunction>>` is a
+smaller, self-contained change that:
+
+- makes probe (2) touch 8-byte values instead of 2440-byte ones, and makes
+  rehashing cheap;
+- lets `PosLightTarget::Compiled` hold an `Arc<CompiledFunction>` directly —
+  exactly what `PosLightTarget::Otf` already does — which **eliminates probe
+  (2) entirely** on a cache hit, leaving one hash lookup per call instead of
+  two.
+
+That alone is expected to recover a large share of the 14.1%, and it is a
+prerequisite for step 4 above (an inline cache needs a target it can hold
+without pinning the map's memory). It needs no ADR of its own; it is recorded
+here so the ordering is explicit. **Do it first, measure, and only then decide
+whether the full inline cache is still worth its complexity.**
+
+## Alternatives considered
+
+- **Do nothing.** The two probes are ~14% of a call-dominated benchmark and
+  scale with every call in every program. Rejected.
+- **Interpreter-side cache keyed by `(code_ptr, cache_idx)`.** Rejected: that
+  is itself a hash lookup, which is the cost being removed.
+- **Cache a raw `*const CompiledFunction` into `compiled_fns`.** Rejected: any
+  insertion that grows or rehashes the map invalidates every such pointer,
+  including insertions for unrelated names (`require`, `EVAL`, module load,
+  class-body method registration all bump `fn_resolve_gen`, but a map mutation
+  need not). An `Arc` handle has no such hazard.
+- **Polymorphic (N-way) inline caches.** Out of scope. Start monomorphic; a
+  megamorphic site simply keeps falling back to the current path, which is
+  what it does today anyway.
+
+## Consequences
+
+- The compiler must allocate and thread `cache_idx` through every call-opcode
+  emission site, and `CompiledCode::finalize` must size the side table.
+- Hand-built chunks (the ones that already skip `finalize`'s `locals_sym`
+  pre-interning) must degrade gracefully — an absent or short table means "no
+  cache", exactly as `const_sym` already handles a short slot table.
+- Cache validity becomes a correctness surface. Every mechanism that can
+  change what a name resolves to must invalidate: `fn_resolve_gen` covers
+  registration/`require`/module load today, and the fingerprint check covers
+  a same-key body swap. Anything that changes resolution *without* touching
+  either would be a live bug — the ADR's main risk, and the reason the
+  validation plan below is not optional.
+
+## Validation plan
+
+- `make test` + `make roast` are the correctness gate, as always.
+- Deliberately adversarial cases to add as `t/` pins: a call site reached from
+  two different packages; a sub redefined by `EVAL` between two calls of the
+  same site; a `require`d module replacing a name mid-run; a multi candidate
+  set growing after the first call; a `wrap`/`unwrap` around a cached callee.
+- Measure with retired **instructions** as well as cycles
+  (`perf stat -e cpu_core/instructions/u`, interleaved A/B, both orderings) —
+  the layout lottery is ~5% on this box and cycles alone cannot discharge it.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -91,3 +91,4 @@ The role of an ADR is to preserve the *context of the judgment* — something th
 | [0063](0063-nativecall-outbound-callback-ownership-and-reentrancy.md) | A NativeCall callback is a process-lifetime closure that re-enters the calling VM | Accepted (implemented) |
 | [0064](0064-var-descriptor-carries-the-contained-value.md) | A `.VAR` container descriptor carries the value its container holds | Accepted (implemented) |
 | [0065](0065-language-server-targets-ai-agents.md) | The language server targets AI agents, and is scoped to the protocol surface an agent actually consumes | Proposed (design only; no implementation) |
+| [0066](0066-call-dispatch-inline-cache.md) | Call dispatch resolves through a per-callsite inline cache, not a name-keyed hash map | Proposed (design only; no implementation) |

--- a/todo/perf/late-august-call-path-slowdown-remainder.md
+++ b/todo/perf/late-august-call-path-slowdown-remainder.md
@@ -95,7 +95,31 @@ path re-interned the fixed names `"_"` and `"Any"` on every call, and the
 parameter bind loop cloned each bound argument twice. `bench-tak` −8.0%,
 `bench-fib` −5.2%, `fib` −4.2% locally.
 
-Three things worth attacking next, in rough order of size:
+## State after the 2026-09-03 round
+
+Eight PRs landed against this ticket (#7259, #7261, #7262, #7265, #7266,
+#7267, #7268, #7269): cumulatively about **−38% on `benchmarks/fib.raku`**
+locally. A fresh `bench-fib` profile now reads:
+
+| share | symbol |
+| ---: | --- |
+| 36.3% | `call_compiled_function_positional_light_at` (self) |
+| 14.1% | `exec_call_func_op` (self) — **now ADR-0066**, see below |
+| 9.2% | `mutsu_jit_1` |
+| 4.3% | `vm_jit::try_enter` |
+| 3.2% | `Env::get_sym` |
+| ~4.5% | `unmark_readonly_sym` + `replay_readonly_undo` + `HashMap::insert` |
+
+`malloc`/`_int_free` have left the top of the profile entirely (item 6).
+
+**The biggest single remaining item is now `exec_call_func_op`'s two hash
+probes per call**, which is the subject of
+[ADR-0066](../../docs/adr/0066-call-dispatch-inline-cache.md) (Proposed). Read
+that before touching call dispatch: it also records the smaller, no-ADR-needed
+first step — putting `CompiledFns` values behind `Arc` — which on its own
+removes one of the two probes and makes the other cheap.
+
+## The rest, in rough order of size
 
 1. **The args/locals `Vec` churn (~11%).** The **args half is closed** by
    `news/2026-09/positional-light-call-binds-from-the-stack.md`: the cached
@@ -148,6 +172,15 @@ Three things worth attacking next, in rough order of size:
    instructions**, `bench-fib` −11.2% / −7.2%, both orderings. `bench-tak`
    barely moved, which is the correct control — its body has no explicit
    `return`.
+7. **Three per-call helpers paid a call to discover they had nothing to do** —
+   **closed** by `news/2026-09/hot-path-noop-guards-are-now-inlined.md`.
+   `apply_pending_rw_writeback`, `apply_pending_caller_var_writeback` and
+   `resolve_let_saves_on_success` each begin with a guard that is true in the
+   common case, but the guard lived inside an out-of-line function, so the
+   common case still paid a call/ret (1.31% + 1.27% + 1.26% of self time).
+   Now `#[inline]` wrapper + `#[inline(never)]` body: `fib` −8.7% cycles /
+   −5.1% retired instructions. **Look for more of this shape** — a comment
+   claiming "no cost when empty" is a hint that the guard is behind a call.
 
 ## Method notes for whoever picks this up
 
@@ -171,3 +204,15 @@ Three things worth attacking next, in rough order of size:
   symbolized profiles.
 - Per `todo/README.md` and CLAUDE.md, any number that ends up in a document
   comes from the bench CI, not from the session's local runs.
+- **Measure retired instructions, not just cycles**
+  (`perf stat -e cpu_core/instructions/u`). When the code a change touches is
+  never executed by the benchmark — an outlined cold path, a shrunk stack
+  frame — a cycles delta is indistinguishable from the ~5% layout lottery, and
+  it flips sign under a swap exactly the way a real win does. Instruction
+  counts are layout-insensitive. Also pick a *control* benchmark the change
+  cannot affect and confirm it does not move (`bench-tak` served this role for
+  the return-signal fix: no explicit `return` in its body).
+- **Run the correctness gate BEFORE the A/B.** A change that accidentally skips
+  work measures *faster*: the first A/B of #7269 read `bench-fib` −12.2%
+  because the split had captured an unconditional trailing call into the
+  guarded slow path. `make test` caught it; the honest number was −8.2%.


### PR DESCRIPTION
Documentation only.

## Why now

After this round of call-path work (#7259, #7261, #7262, #7265, #7266, #7267, #7268, #7269 — cumulatively about **−38% on `benchmarks/fib.raku`** locally), `exec_call_func_op` is the second-largest self-time symbol in a `bench-fib` profile at **14.1%**, behind only `call_compiled_function_positional_light_at` at 36.3%.

`perf annotate` shows the cost is not the dispatcher's own logic. It is **two hash probes per call** — the name-keyed light-call cache, then `compiled_fns.get(&key)` — both visible as hashbrown's SIMD group scan (`movdqa`/`pcmpeqb`/`pmovmskb`, the single hottest instruction inside the function at 13.1% of its self time). The second probe is worse than an ordinary one: `CompiledFns` is `FxHashMap<Symbol, CompiledFunction>` and `CompiledFunction` is **2440 bytes** (`imul $0x988` is the bucket stride in the generated probe), so every probe step walks kilobytes and every rehash memcpys them.

Both probes answer a question that is *fixed per call site*: `fib`'s recursive call resolves to the same body on all 242 785 executions and re-hashes a symbol twice to rediscover it. That is the textbook case for a monomorphic inline cache, and moving dispatch to one is costly to reverse — hence an ADR rather than a silent implementation.

## What the ADR proposes

A `cache_idx: u32` on the call opcodes addressing a `CompiledCode`-owned side table of cache slots — the same shape as the existing `const_syms` `OnceLock` side table — validated by `fn_resolve_gen`, the callsite package, and the callee fingerprint. It records the rejected alternatives (an interpreter-side map keyed by code pointer; caching a raw `*const CompiledFunction`) and the reason each fails.

It also records a **smaller first step that needs no ADR**: putting `CompiledFns` values behind `Arc`. That alone makes the second probe's values 8 bytes instead of 2440 *and* lets `PosLightTarget::Compiled` hold the handle directly — exactly what `PosLightTarget::Otf` already does — eliminating the second probe entirely on a cache hit. The ADR says explicitly: do that, measure, and only then decide whether the full inline cache earns its complexity.

## Also

`todo/perf/late-august-call-path-slowdown-remainder.md` gets the current profile, the items closed this round, and two method notes that cost real time to learn:

- **Measure retired instructions, not just cycles**, whenever the changed code is never executed by the benchmark (an outlined cold path, a shrunk frame). A cycles delta there is indistinguishable from the ~5% layout lottery — it flips sign under a swap exactly the way a real win does. Also pick a control benchmark the change cannot affect and confirm it does not move.
- **Run the correctness gate before the A/B.** A change that accidentally skips work measures *faster*: #7269's first A/B read −12.2% because the split had captured an unconditional trailing call into the guarded slow path. `make test` caught it; the honest number was −8.2%.

CI's four heavy jobs skip on a docs-only diff by design (`scripts/ci-docs-only.sh`), so `skipped` here is correct.