### PR TITLE
docs(adr): correct ADR-0066 — the map's value size is not what costs time

### DIFF
--- a/docs/adr/0066-call-dispatch-inline-cache.md
+++ b/docs/adr/0066-call-dispatch-inline-cache.md
@@ -23,11 +23,11 @@ instruction inside the function at 13.1% of its self time):
    cache, `FxHashMap<Symbol, PosLightTarget>`.
 2. `compiled_fns.get(&key)` — resolving the cached key to the callee body.
 
-The second probe is worse than an ordinary one. `CompiledFns` is
-`FxHashMap<Symbol, CompiledFunction>` and `CompiledFunction` is **2440 bytes**
-(`imul $0x988` appears in the generated probe as the bucket stride), so the
-table stores 2.4 KB values inline: every probe step touches a fresh cache line
-region, and every rehash memcpys kilobytes per entry.
+`CompiledFns` is `FxHashMap<Symbol, CompiledFunction>` and `CompiledFunction`
+embeds a whole `CompiledCode` by value, so it is **2440 bytes** (`imul $0x988`
+appears in the generated probe as the bucket stride). That is a real smell —
+a rehash memcpys kilobytes per entry — but see "What step 1 actually measured"
+below before assuming it is what costs time here.
 
 Both probes exist to answer a question that is **fixed per call site** in the
 overwhelmingly common case. `fib`'s recursive call site resolves to the same
@@ -60,23 +60,82 @@ Add a per-callsite inline cache to the call opcodes.
 4. The cached target must be a *handle*, not a raw pointer into the map's
    storage (see Alternatives).
 
-## Step 1, independent of the above: `CompiledFns` values behind `Arc`
+## What step 1 actually measured — and the reasoning it corrected
 
-Changing `CompiledFns` to `FxHashMap<Symbol, Arc<CompiledFunction>>` is a
-smaller, self-contained change that:
+The first draft of this ADR proposed an easy first step: change `CompiledFns`
+to `FxHashMap<Symbol, Arc<CompiledFunction>>`, on the theory that 2440-byte
+inline values made "every probe step walk kilobytes". **That theory was
+wrong**, and the change was prototyped, measured and then dropped rather than
+shipped.
 
-- makes probe (2) touch 8-byte values instead of 2440-byte ones, and makes
-  rehashing cheap;
-- lets `PosLightTarget::Compiled` hold an `Arc<CompiledFunction>` directly —
-  exactly what `PosLightTarget::Otf` already does — which **eliminates probe
-  (2) entirely** on a cache hit, leaving one hash lookup per call instead of
-  two.
+*Why the theory was wrong.* hashbrown is a SwissTable: the group scan reads the
+**control-byte array**, which is contiguous and independent of the value type.
+`perf annotate` on the current build shows exactly that shape —
+`movdqu (ctrl)` / `pcmpeqb` / `pmovmskb` / `tzcnt`, and only then the
+`imul $0x988` that computes the matched bucket's address. The value size
+therefore costs one cache line on the *matched* bucket, not on the scan. What
+is expensive is **the two probes themselves** — two hash computations and two
+group scans per call — which is precisely what an inline cache removes and
+what a value-type change cannot touch.
 
-That alone is expected to recover a large share of the 14.1%, and it is a
-prerequisite for step 4 above (an inline cache needs a target it can hold
-without pinning the map's memory). It needs no ADR of its own; it is recorded
-here so the ordering is explicit. **Do it first, measure, and only then decide
-whether the full inline cache is still worth its complexity.**
+*What it measured.* Interleaved A/B of two release builds, nine alternating
+runs each, both orderings (every sign flipped):
+
+| benchmark | cycles | instructions |
+| --- | ---: | ---: |
+| `fib` | −3.5% | |
+| `bench-fib` | −3.1% | −0.2% |
+| `bench-tak` | −1.5% | |
+| `bench-class` | +0.7% | |
+| `method-call` | **+2.1%** | |
+
+Retired instructions barely move (−0.2%), confirming no work was removed: the
+small win is pure locality on the matched bucket, and it is paid back on
+`method-call`, where the extra pointer hop to reach `CompiledFunction`'s fields
+costs more than the smaller table saves. A mixed result with a disproven
+rationale is not worth shipping, so it was not.
+
+*What survives from the experiment.* Two things worth knowing:
+
+- The migration is **small**: 12 compile errors, all mechanical
+  (`insert(k, Arc::new(cf))`, `.map(|cf| &**cf)`, `std::ptr::eq(&**func, cf)`).
+  Whoever implements the inline cache and needs an `Arc` handle to store can
+  do it in an hour.
+- `vm_call_named_inner.rs`'s multi-dispatch arm currently writes
+  `Arc::new(compiled.clone())` — a **deep clone of the whole 2440-byte
+  `CompiledFunction`, `CompiledCode` included**, on every call that takes it.
+  Arc-valued `CompiledFns` turns that into a refcount bump. That site was not
+  hot in any benchmark measured here, but it is a genuine per-call kilobyte
+  copy on the multi path and deserves its own look.
+
+If a value-type change is revisited, the better shape is probably
+`Box<CompiledCode>` *inside* `CompiledFunction` — it shrinks the map's value to
+a few hundred bytes while keeping the fields the dispatcher reads next
+(`fingerprint`, `param_defs`, `param_local_slots`) inline, which is what the
+`Arc` version gave up. That is a hypothesis, not a measurement.
+
+## Why the existing fingerprint check cannot simply be dropped
+
+It is tempting to read `PosLightTarget::Compiled { key, fingerprint }` as "a
+key plus a redundant sanity check" and conclude that holding the resolved body
+directly would be equivalent. It would not be, and this is the constraint the
+inline-cache design has to respect.
+
+`exec_call_func_op` receives `compiled_fns` **as a parameter**. Different
+compilation units — an `EVAL`, a module body, a class body — run against
+*different* `CompiledFns` maps, while `pos_light_call_cache` is keyed only by
+the callee's `Symbol`. A cache entry filled while running one unit can
+therefore be consulted while running another, and the fingerprint re-check
+against the *current* map is what stops it from handing back the wrong unit's
+body. `fn_resolve_gen` does not cover this: it tracks registration changes, not
+which map is in hand.
+
+A per-callsite cache does not have the problem at all — the slot lives in the
+`CompiledCode` that owns the call site, so the unit is implicit in the
+addressing. That is an argument *for* the inline cache over any attempt to
+strengthen the name-keyed one, and it is the reason step 4 of the decision says
+the cached target must be a handle plus enough identity to prove it belongs
+here.
 
 ## Alternatives considered
 

--- a/todo/perf/late-august-call-path-slowdown-remainder.md
+++ b/todo/perf/late-august-call-path-slowdown-remainder.md
@@ -115,9 +115,11 @@ locally. A fresh `bench-fib` profile now reads:
 **The biggest single remaining item is now `exec_call_func_op`'s two hash
 probes per call**, which is the subject of
 [ADR-0066](../../docs/adr/0066-call-dispatch-inline-cache.md) (Proposed). Read
-that before touching call dispatch: it also records the smaller, no-ADR-needed
-first step — putting `CompiledFns` values behind `Arc` — which on its own
-removes one of the two probes and makes the other cheap.
+that before touching call dispatch — including its "What step 1 actually
+measured" section, which records a prototyped-and-dropped shortcut (Arc-valued
+`CompiledFns`) and corrects the reasoning behind it: the cost is the two hash
+probes themselves, not the size of the map's values, because hashbrown's group
+scan reads the control-byte array and never touches a value.
 
 ## The rest, in rough order of size
 


### PR DESCRIPTION
Documentation only. Follows #7270.

ADR-0066 proposed an easy first step before the inline cache: put `CompiledFns` values behind `Arc`, on the theory that 2440-byte inline values made "every probe step walk kilobytes". **That theory is wrong.** This PR records the correction and the measurement that produced it, so the next person does not redo the experiment.

## Why it was wrong

hashbrown is a SwissTable: the group scan reads the **control-byte array**, which is contiguous and independent of the value type. `perf annotate` on the current build shows exactly that shape — `movdqu (ctrl)` / `pcmpeqb` / `pmovmskb` / `tzcnt`, and only *then* the `imul $0x988` that computes the matched bucket's address. The value size costs one cache line on the matched bucket, not on the scan.

What is expensive is **the two probes themselves** — two hash computations and two group scans per call — which is precisely what an inline cache removes and what a value-type change cannot touch. The ADR's core proposal is unaffected; only its "easy first step" is.

## What was measured

The change was prototyped, measured, and dropped rather than shipped. Interleaved A/B of two release builds, nine alternating runs each, both orderings (every sign flipped):

| benchmark | cycles | instructions |
| --- | ---: | ---: |
| `fib` | −3.5% | |
| `bench-fib` | −3.1% | −0.2% |
| `bench-tak` | −1.5% | |
| `bench-class` | +0.7% | |
| `method-call` | **+2.1%** | |

Retired instructions barely move (−0.2%): no work was removed, the small win is pure locality on the matched bucket, and it is paid back on `method-call` where the extra pointer hop to reach `CompiledFunction`'s fields costs more than the smaller table saves. A mixed result on a disproven rationale is not worth shipping.

Two findings from the prototype are kept in the ADR: the migration is small (12 mechanical compile errors) for whoever needs an `Arc` handle to store in the inline cache, and `vm_call_named_inner.rs`'s multi-dispatch arm does `Arc::new(compiled.clone())` — a deep clone of the whole 2440-byte `CompiledFunction`, `CompiledCode` included — on every call that takes it.

## New section: why the fingerprint check cannot simply be dropped

Also adds the invalidation constraint the inline cache has to respect. `PosLightTarget::Compiled { key, fingerprint }` looks like a key plus a redundant sanity check, but it is not: `compiled_fns` arrives as a **parameter** and differs per compilation unit (`EVAL`, module body, class body), while `pos_light_call_cache` is keyed only by `Symbol`. The fingerprint re-check against the *current* map is what stops one unit's cache entry from resolving against another unit's map — `fn_resolve_gen` tracks registration changes, not which map is in hand. A per-callsite cache avoids the problem entirely, since the slot lives in the `CompiledCode` that owns the site, which is itself an argument for the inline cache.

CI's four heavy jobs skip on a docs-only diff by design, so `skipped` here is correct.