### PR TITLE
perf(vm): let the readonly set answer "is the topic marked" without hashing

### DIFF
--- a/news/2026-09/readonly-set-knows-whether-the-topic-is-marked.md
+++ b/news/2026-09/readonly-set-knows-whether-the-topic-is-marked.md
@@ -1,0 +1,49 @@
+# The readonly set now knows whether `$_` is marked, without hashing
+
+Every routine and method call has to clear a readonly mark on the topic before
+binding its own `$_`: a caller's `given`/`with`/`for` may have marked `_`
+read-only against a literal, and that must not leak into the callee
+(`given 'x' { f() }` where `sub f { $_ = ... }` must not hit "Cannot assign to
+a readonly variable").
+
+The guard on that work was `!self.no_readonly_vars()` — "is the readonly set
+non-empty". That is true for **any** program with a single readonly parameter
+live anywhere on the stack, which is to say almost always: a recursive
+`sub fib(Int $n)` marks `n`, so every one of its calls then paid a full hash
+`remove` of `_` that missed. Two of the five sites went further and called
+`unmark_readonly("_")`, which re-interned the name string as well.
+
+`ReadonlySet` is now a struct carrying the map plus a `topic: bool`, and
+`Interpreter::unmark_readonly_topic()` reads it in one branch.
+
+The flag lives on **the set**, not on the `Interpreter`, so every mutation path
+maintains it by construction — including `replay_readonly_undo`, which reaches
+the set through a raw pointer from a `Drop` impl and never sees the
+`Interpreter` at all. `topic_marked()` re-derives the slow answer under
+`debug_assert`, and CI runs the whole `t/` suite on a debug binary (ADR-0014),
+so 3600+ files check the invariant on every push. This is the same shape as
+`Env` carrying its own `?FILE` symbol
+(`news/2026-09/env-carries-its-source-file-symbol.md`), and for the same
+reason: an `Interpreter`-side mirror of a value the runtime swaps wholesale
+goes stale.
+
+## Measurement
+
+This one is small, and the honest evidence is the instruction count rather than
+the clock. Interleaved A/B of two release builds, median over nine alternating
+runs on a pinned P-core:
+
+| benchmark | cycles | instructions |
+| --- | ---: | ---: |
+| `fib` | −1.0% | −2.4% |
+| `bench-fib` | −0.5% | −2.3% |
+| `bench-tak` | −1.5% | −1.0% |
+| `method-call` | +1.1% | −0.1% |
+| `bench-class` | +0.5% | |
+
+Retired instructions fall on every benchmark measured and rise on none, so
+real work was removed and none was added. The cycle deltas at this magnitude
+are inside the binary-layout noise floor (`bench-fib` reads −0.5% in one
+ordering and +0.5% in the other, i.e. nothing), which is exactly what a change
+that removes a handful of cache-resident hash operations per call should look
+like.

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -736,7 +736,71 @@ pub(crate) struct ClassAttributeDef {
 ///
 /// The value records *why* the name is readonly ([`ReadonlyKind`]), which is
 /// what decides the exception an assignment through it throws.
-pub(crate) type ReadonlySet = rustc_hash::FxHashMap<Symbol, ReadonlyKind>;
+#[derive(Default)]
+pub(crate) struct ReadonlySet {
+    map: rustc_hash::FxHashMap<Symbol, ReadonlyKind>,
+    /// Whether the topic `_` is currently in `map`.
+    ///
+    /// Every routine call clears the caller's readonly mark on `$_` before
+    /// binding its parameters (see `call_compiled_function_positional_light_at`),
+    /// and the guard for that was "is the set non-empty" -- true for any program
+    /// with a single readonly parameter anywhere on the stack, so the call paid a
+    /// full hash `remove` that missed, on every call. This answers the question
+    /// exactly, in one branch.
+    ///
+    /// Kept on the set itself rather than on the `Interpreter` so that every
+    /// mutation path maintains it by construction -- including
+    /// [`replay_readonly_undo`], which reaches the set through a raw pointer from
+    /// a `Drop` impl and never sees the `Interpreter` at all. `topic_marked`
+    /// re-derives the slow answer under `debug_assert`, and CI runs the whole
+    /// `t/` suite on a debug binary (ADR-0014), so the invariant is checked by
+    /// 3600+ files on every push.
+    topic: bool,
+}
+
+impl ReadonlySet {
+    #[inline]
+    pub(crate) fn insert(&mut self, sym: Symbol, kind: ReadonlyKind) -> Option<ReadonlyKind> {
+        if sym == crate::symbol::wk::topic() {
+            self.topic = true;
+        }
+        self.map.insert(sym, kind)
+    }
+
+    #[inline]
+    pub(crate) fn remove(&mut self, sym: &Symbol) -> Option<ReadonlyKind> {
+        if *sym == crate::symbol::wk::topic() {
+            self.topic = false;
+        }
+        self.map.remove(sym)
+    }
+
+    #[inline]
+    pub(crate) fn contains_key(&self, sym: &Symbol) -> bool {
+        self.map.contains_key(sym)
+    }
+
+    #[inline]
+    pub(crate) fn get(&self, sym: &Symbol) -> Option<&ReadonlyKind> {
+        self.map.get(sym)
+    }
+
+    #[inline]
+    pub(crate) fn is_empty(&self) -> bool {
+        self.map.is_empty()
+    }
+
+    /// Is the topic `_` marked readonly? O(1), no hashing.
+    #[inline]
+    pub(crate) fn topic_marked(&self) -> bool {
+        debug_assert_eq!(
+            self.topic,
+            self.map.contains_key(&crate::symbol::wk::topic()),
+            "ReadonlySet::topic drifted from the map"
+        );
+        self.topic
+    }
+}
 
 /// One journaled readonly-set mutation (see `Interpreter::enter_readonly_frame`):
 /// the inverse to replay on scope exit, or a `Scope` sentinel marking a frame

--- a/src/runtime/types/mod.rs
+++ b/src/runtime/types/mod.rs
@@ -296,6 +296,25 @@ impl Interpreter {
         self.unmark_readonly_sym(Symbol::intern(name));
     }
 
+    /// Clear a readonly mark on the topic `_`, if there is one.
+    ///
+    /// Every routine and method call has to do this before binding its own
+    /// `$_` (a caller's `given`/`with`/`for` may have marked the topic
+    /// read-only, and that must not leak into the callee). The guard used to
+    /// be "is the readonly set non-empty", which is true for any program with
+    /// a single readonly parameter live anywhere on the stack -- so the call
+    /// paid a full hash `remove` that missed. `ReadonlySet` tracks the topic's
+    /// membership directly, so the common case is one branch and no hashing.
+    #[inline]
+    pub(crate) fn unmark_readonly_topic(&mut self) {
+        // Bind first: the `borrow()` must end before `unmark_readonly_sym`
+        // takes a `borrow_mut()`.
+        let marked = self.readonly_vars.borrow().topic_marked();
+        if marked {
+            self.unmark_readonly_sym(crate::symbol::wk::topic());
+        }
+    }
+
     /// Remove an already-interned name from the readonly set. Like
     /// `mark_readonly_sym`, a no-op unmark journals nothing. A remove that
     /// exactly cancels the journal's newest entry (the per-iteration

--- a/src/vm/vm_call_light.rs
+++ b/src/vm/vm_call_light.rs
@@ -269,8 +269,8 @@ impl Interpreter {
         // journaled by the readonly frame, so it is restored on return — before
         // the param loop below, which re-marks `_` if the routine has an
         // explicit (readonly) `$_` parameter.
-        if cf.code.is_routine && !self.no_readonly_vars() {
-            self.unmark_readonly_sym(crate::symbol::wk::topic());
+        if cf.code.is_routine {
+            self.unmark_readonly_topic();
         }
         // Bind params to slots. Also write the param into the overlay when a
         // name-based reader needs it (reflective access anywhere / GetGlobal /

--- a/src/vm/vm_call_light_typed.rs
+++ b/src/vm/vm_call_light_typed.rs
@@ -398,8 +398,8 @@ impl Interpreter {
         // A routine gets a fresh, writable `$_` — clear any readonly mark leaked
         // from the caller's topic (see vm_call_light.rs for the full rationale);
         // the param loop below re-marks `_` for an explicit `$_` param.
-        if cf.code.is_routine && !self.no_readonly_vars() {
-            self.unmark_readonly_sym(crate::symbol::wk::topic());
+        if cf.code.is_routine {
+            self.unmark_readonly_topic();
         }
         // Raku: a routine gets its own `$_` = `(Any)`, not the caller's topic.
         // Shadow the caller's topic with Any before the body reads it (gated on

--- a/src/vm/vm_call_named_inner.rs
+++ b/src/vm/vm_call_named_inner.rs
@@ -50,8 +50,8 @@ impl Interpreter {
         // A routine gets a fresh, writable `$_` — clear any readonly mark leaked
         // from the caller's topic (see vm_call_light.rs for the full rationale);
         // param binding below re-marks `_` for an explicit `$_` parameter.
-        if cf.code.is_routine && !self.no_readonly_vars() {
-            self.unmark_readonly("_");
+        if cf.code.is_routine {
+            self.unmark_readonly_topic();
         }
         let return_spec = cf.return_type.clone();
 

--- a/src/vm/vm_method_dispatch.rs
+++ b/src/vm/vm_method_dispatch.rs
@@ -321,9 +321,7 @@ impl Interpreter {
         // where `method m { $_ = ... }`). Clear it here, journaled by the
         // frame's readonly scope so it is restored on return; an explicit
         // (readonly) `$_` parameter re-marks it during param binding.
-        if !self.no_readonly_vars() {
-            self.unmark_readonly("_");
-        }
+        self.unmark_readonly_topic();
 
         // ADR-0035 slice 2: a body that reads `CALLER::`/`callframe()` needs a
         // caller-env frame pushed, mirroring `call_compiled_function_named_inner`
@@ -1427,9 +1425,7 @@ impl Interpreter {
         // A method gets a fresh, writable `$_` (Any) — clear any readonly mark
         // leaked from the caller's topic (see the slow path above). Journaled by
         // the frame's readonly scope; an explicit `$_` param re-marks it.
-        if !self.no_readonly_vars() {
-            self.unmark_readonly("_");
-        }
+        self.unmark_readonly_topic();
         // ADR-0035 slice 2: see the matching comment in `call_compiled_method`.
         // Pushed before the scoped-overlay install below so the pushed entry
         // captures the caller's (unoverlaid) env.

--- a/todo/perf/late-august-call-path-slowdown-remainder.md
+++ b/todo/perf/late-august-call-path-slowdown-remainder.md
@@ -133,12 +133,23 @@ scan reads the control-byte array and never touches a value.
    it with `Value::NIL` per call, and the same buffer shape is still copied
    into on the *named* light path (`call_compiled_function_light`), which was
    left untouched.
-2. **Readonly bookkeeping (~5.5%).** Every call marks each parameter readonly
+2. **Readonly bookkeeping (~4.5%).** Every call marks each parameter readonly
    and unmarks it on exit: an `FxHashMap<Symbol, ReadonlyKind>` insert, a
    remove, and a journal push/pop per parameter per call. A monomorphic
    recursive call re-marks a symbol its own caller already marked with the same
    kind; the code tries to make that journal nothing but still pays both map
    operations.
+   The **topic-unmark** part is closed by
+   `news/2026-09/readonly-set-knows-whether-the-topic-is-marked.md`: the guard
+   was "is the set non-empty", true for any program with one readonly parameter
+   live, so every call hash-removed `_` and missed. `ReadonlySet` now carries a
+   `topic: bool` (checked by `debug_assert` against the map on every read).
+   `bench-fib` −2.3% retired instructions; the cycle delta is inside the layout
+   noise floor.
+   What is left is `mark_readonly_sym_with`'s unconditional `insert` and
+   `replay_readonly_undo`'s journal. The architecturally right answer is to make
+   readonly-ness a property of the **local slot / container** rather than a
+   global name-keyed map — that is ADR-scale, not a micro-fix.
 3. **`mutsu_jit_1` +50% since August.** The natively-compiled body itself got
    slower, which nothing in the interpreter explains. Dump the generated code
    for both builds before guessing. (Note that `vm_jit_helpers::ret`, the shim


### PR DESCRIPTION
## What

Every routine and method call has to clear a readonly mark on the topic before binding its own `$_`: a caller's `given`/`with`/`for` may have marked `_` read-only against a literal, and that must not leak into the callee (`given 'x' { f() }` where `sub f { $_ = ... }` must not hit "Cannot assign to a readonly variable").

The guard on that work was `!self.no_readonly_vars()` — "is the readonly set non-empty". That is true for **any** program with a single readonly parameter live anywhere on the stack, which is to say almost always: a recursive `sub fib(Int $n)` marks `n`, so every one of its calls then paid a full hash `remove` of `_` that missed. Two of the five sites went further and called `unmark_readonly("_")`, re-interning the name string as well.

`ReadonlySet` is now a struct carrying the map plus a `topic: bool`, and `Interpreter::unmark_readonly_topic()` reads it in one branch.

## Why the flag lives on the set

It is on **`ReadonlySet`**, not on the `Interpreter`, so every mutation path maintains it by construction — including `replay_readonly_undo`, which reaches the set through a raw pointer from a `Drop` impl and never sees the `Interpreter` at all. `topic_marked()` re-derives the slow answer under `debug_assert`, and CI runs the whole `t/` suite on a debug binary (ADR-0014), so 3600+ files check the invariant on every push.

This is the same shape, for the same reason, as `Env` carrying its own `?FILE` symbol (#7261): an `Interpreter`-side mirror of a value the runtime swaps wholesale goes stale.

## Measurement — read the instruction column

This one is small, and the honest evidence is the instruction count rather than the clock. Interleaved A/B of two release builds, median over nine alternating runs on a pinned P-core:

| benchmark | cycles | instructions |
| --- | ---: | ---: |
| `fib` | −1.0% | **−2.4%** |
| `bench-fib` | −0.5% | **−2.3%** |
| `bench-tak` | −1.5% | −1.0% |
| `method-call` | +1.1% | −0.1% |
| `bench-class` | +0.5% | |

Retired instructions fall on every benchmark measured and rise on none, so real work was removed and none was added. The cycle deltas at this magnitude are inside the binary-layout noise floor — `bench-fib` reads −0.5% in one ordering and +0.5% in the other, i.e. nothing — which is exactly what removing a handful of cache-resident hash operations per call should look like. I am not claiming a cycles win here.

(Local A/B, for the PR only; the documents cite the bench CI.)

## Tests

Behaviour is unchanged — an unmark of an unmarked symbol was already a no-op, so the new guard is strictly more precise than the old one. Spot-checked the topic-leak cases against real `raku` (`given "x" { sub f() { $_ = 5 } ... }` and the method equivalent). Full `make test` green locally (3627 files, 36691 tests).