### PR TITLE
perf(vm): answer a repeat call from a direct-mapped dispatch cache (ADR-0066)

### DIFF
--- a/docs/adr/0066-call-dispatch-inline-cache.md
+++ b/docs/adr/0066-call-dispatch-inline-cache.md
@@ -1,6 +1,6 @@
 # ADR-0066: Call dispatch should resolve through a per-callsite inline cache, not a name-keyed hash map
 
-- Status: **Proposed**
+- Status: **Accepted** (implemented 2026-09-03)
 - Date: 2026-09-03
 - Related: [ADR-0004](0004-jit-strategy.md) (J4d light-call caches),
   [ADR-0006](0006-baseline-interpreter-optimizations.md) (baseline interpreter
@@ -37,9 +37,19 @@ symbol twice each time.
 This is the classic case for a *monomorphic inline cache*: cache the resolved
 target **at the call site**, not in a global map keyed by name.
 
-## Decision (proposed)
+## Decision
 
-Add a per-callsite inline cache to the call opcodes.
+Resolve a repeat call from a cache the dispatcher can read without hashing,
+instead of from two name-keyed hash probes.
+
+The mechanics proposed below were superseded during implementation — the
+per-callsite addressing they describe was built, measured, and found no faster
+than the probes it replaced. **Read "What was actually built" for the shipped
+design**; this section is kept because the reasoning that follows it (and the
+"Why the existing fingerprint check cannot simply be dropped" section) is what
+the shipped design had to satisfy.
+
+Original proposal — add a per-callsite inline cache to the call opcodes:
 
 1. `OpCode::CallFunc` (and `CallFuncNamed`, and later `CallMethod`) gains a
    `cache_idx: u32`, assigned by the compiler — one slot per call site in a
@@ -137,6 +147,13 @@ strengthen the name-keyed one, and it is the reason step 4 of the decision says
 the cached target must be a handle plus enough identity to prove it belongs
 here.
 
+*As built, the constraint is discharged more directly than by either route:*
+the table itself now carries a version token, so the slot proves it is holding
+the right unit's body by comparing one `u64` rather than by re-deriving the body
+from a key. See "What was actually built" below. The reasoning above still
+explains why the check cannot simply be deleted — only what replaced it
+changed.
+
 ## Alternatives considered
 
 - **Do nothing.** The two probes are ~14% of a call-dominated benchmark and
@@ -152,19 +169,147 @@ here.
   megamorphic site simply keeps falling back to the current path, which is
   what it does today anyway.
 
+## What was actually built
+
+The decision's *goal* stands — the two hash probes are gone from a repeat call —
+but the structure that replaced them is not the per-callsite one this ADR
+proposed, because that structure was built, measured, and found to be no faster
+than the probes. Both the shipped design and the discarded one are recorded
+here.
+
+**1. Per-callsite addressing was built first, and it did not pay.** A call site
+was identified by its opcode index (which both the interpreter dispatch arm and
+the JIT's `call_func` shim already have, so no `OpCode` field and no compiler
+change was needed), a lazily-built `OnceLock` side table on `CompiledCode`
+mapped that index to a slot number, and the slots lived in a `Vec` on the
+`Interpreter`. It worked — on `benchmarks/fib.raku` the name-keyed cache was
+consulted twice in 242,785 calls and the inline cache answered the rest — and it
+**removed no retired instructions at all** (+0.07%).
+
+The reason is the one thing the ADR did not account for: *what the two probes
+cost is their dependent loads*, not their instruction count. A SwissTable probe
+is only about 15 instructions. Reaching a per-callsite slot through
+`OnceLock` → side table → index array → slot vector → slot is five dependent
+loads, which is what two probes cost. Trading a hash for an equally long pointer
+chase buys nothing.
+
+**2. What shipped is direct-mapped and inline in the interpreter.** The cache is
+a fixed 128-way `[CallIcSlot; N]` array *embedded in the `Interpreter`*, indexed
+by `name_sym.id() & (N - 1)`. A lookup is one masked load of a 32-byte entry —
+one dependent load — and four integer comparisons against tokens that all live
+in that same entry. Nothing is per-chunk, so `CompiledCode`, `OpCode`, the
+compiler and the opcode-index threading are all untouched. Colliding names
+evict each other, which costs a miss and nothing else.
+
+The ADR rejected an "interpreter-side cache" on the grounds that it "is itself a
+hash lookup". A direct-mapped array is not: there is no hashing, no probe
+sequence, and no bucket comparison — the mask *is* the lookup.
+
+**3. Validity is a version token on the table, not an `Arc` handle.** The ADR
+rejected caching a raw `*const CompiledFunction` because "any insertion that
+grows or rehashes the map invalidates every such pointer". That objection is
+answered by making the invalidation observable: `CompiledFns` is now a newtype
+over the map carrying an `id` drawn from a process-global counter and **re-drawn
+on every mutation**. Ids are never reused, so a single `u64` comparison proves
+both halves of what the pointer needs — that the table in hand is the very table
+the address came from, and that it has not been mutated since. That is strictly
+stronger than the fingerprint re-check it replaces (which proved neither), and
+it costs a compare instead of a probe. `id() == 0` marks a table that has never
+been mutated — the state of the several empty scratch tables the dispatch paths
+build — and can never validate an entry.
+
+An entry therefore carries four tokens: the epoch (below), the table id, the
+callee name, and the package the call ran under.
+
+**4. The name-keyed cache it memoises got an epoch.** `pos_light_call_cache` is
+still filled by the slow path; the dispatch cache is a memo of its answer, valid
+exactly while that cache has not moved. One counter, bumped on every insert and
+on the generation clear, expresses that — so the new cache adds no invalidation
+surface of its own. Everything that already retired the name-keyed cache
+(`fn_resolve_gen`, and thus `require`, module load, `EVAL`, class-body
+registration, `wrap`) retires the dispatch cache with it.
+
+## The bug this uncovered: the name-keyed caches were package-blind
+
+Writing the ADR's own adversarial case — "a call site reached from two different
+packages" — found a live, pre-existing wrong answer:
+
+```raku
+module PkgA { our sub which() { 'A' }; our sub probe() { which() } }
+module PkgB { our sub which() { 'B' }; our sub probe() { which() } }
+say PkgB::probe();  # B
+say PkgA::probe();  # B  -- rakudo says A
+```
+
+`which` is a *different routine* in each package, and the full resolver
+(`resolve_function_with_types`) knows that — it reads `current_package`. But
+three caches in front of it did not: `fn_resolve_cache` (keyed by name, arity
+and argument types), `light_call_cache` and `pos_light_call_cache` (keyed by
+name). Whichever package called a given bare name first therefore answered for
+every other package, in both directions, for the rest of the run. All three are
+now keyed by `(name, callsite package)`, which is the key their *contents*
+already assumed — `PosLightTarget::Otf` had been carrying a `callsite_package`
+field and checking it by hand, and that field is now redundant with the key and
+gone. Pinned by `t/call-inline-cache.t`.
+
+## Measured
+
+Retired instructions are the primary result. Cycles measured **across two
+builds** cannot support a conclusion at this effect size on this box: the same
+source built twice differs by more than the change is worth (the shipped
+binary's own IC-disabled run of `fib` was 151.3 Mcycles against the baseline
+binary's 141.9 — 6.6% apart with identical semantics, and a cross-build A/B of
+this change reported anywhere from −1.5% to +3.1% depending on which pair of
+builds was compared, `codegen-units=1` included).
+
+So the cycle figures below come from a **same-binary** A/B: one build carrying a
+temporary `MUTSU_CALL_IC=0` switch that skips the cache lookup, alternated
+against itself. That holds codegen, inlining and layout exactly fixed and leaves
+only the cache's own effect. (The switch was removed before merge.) Nine
+alternating pairs, P-core pinned, medians:
+
+| benchmark | instructions | cycles |
+| --- | ---: | ---: |
+| `fib` | −2.8% | −2.9% |
+| `bench-fib` | −2.8% | −2.5% |
+| `bench-tak` | −1.5% | −1.4% |
+| `method-call` | ~0 | ~0 |
+| `bench-class` | ~0 | ~0 |
+
+Instructions and cycles move together, which is the shape to expect from work
+that is simply removed. `method-call` and `bench-class` are unmoved because they
+dispatch through the method path, which this cache does not serve yet.
+
+Within the dispatcher, `exec_call_func_op` falls from 15.9% to 7.1% of a
+`bench-fib` profile.
+
+## Still open
+
+- The **named** light-call path (`light_call_cache`) and `CallMethod` still pay
+  two probes each. `CallMethod` is why `method-call` and `bench-class` show
+  nothing here, and is the obvious next consumer of the same table.
+- The cache is monomorphic per name. A megamorphic name evicts itself and falls
+  back to today's path, which is what it does now anyway.
+
 ## Consequences
 
-- The compiler must allocate and thread `cache_idx` through every call-opcode
-  emission site, and `CompiledCode::finalize` must size the side table.
-- Hand-built chunks (the ones that already skip `finalize`'s `locals_sym`
-  pre-interning) must degrade gracefully — an absent or short table means "no
-  cache", exactly as `const_sym` already handles a short slot table.
-- Cache validity becomes a correctness surface. Every mechanism that can
-  change what a name resolves to must invalidate: `fn_resolve_gen` covers
-  registration/`require`/module load today, and the fingerprint check covers
-  a same-key body swap. Anything that changes resolution *without* touching
-  either would be a live bug — the ADR's main risk, and the reason the
-  validation plan below is not optional.
+- Cache validity is a correctness surface. Every mechanism that can change what
+  a name resolves to must invalidate: `fn_resolve_gen` covers
+  registration/`require`/module load/`wrap`, and the table's `id` covers a body
+  swap or a different compilation unit. Anything that changes resolution
+  *without* touching either would be a live bug — the ADR's main risk, and the
+  reason the validation plan below is not optional.
+- `CompiledFns` no longer implements `DerefMut`. Every mutating entry point
+  lives on the newtype and re-draws the `id`; adding one that does not would
+  silently leave stale addresses validating. There are few (`insert`, `retain`,
+  `extend`) and they are all compile-time paths.
+- The dispatch cache holds raw addresses into a table it does not own, read
+  through `unsafe`. The invariant is documented at both the `CompiledFns` type
+  and the read site, and it is a *single* condition — `id` equality — rather
+  than a set of conditions a future change could partially break.
+- The shipped design needs nothing from the compiler or from `OpCode`, so the
+  original consequences about threading `cache_idx` and sizing a per-chunk side
+  table do not apply.
 
 ## Validation plan
 

--- a/news/2026-09/call-dispatch-inline-cache.md
+++ b/news/2026-09/call-dispatch-inline-cache.md
@@ -1,0 +1,98 @@
+# The call dispatcher now answers a repeat call without hashing
+
+`exec_call_func_op`, the VM's function-call dispatcher, used to re-derive the
+callee from its name on every single call: one hash probe into the name-keyed
+`pos_light_call_cache`, then a second into `compiled_fns` to turn the cached key
+back into a body. On `benchmarks/bench-fib.raku` those two probes were about
+60% of the dispatcher's self time — the dispatcher itself being the
+second-largest symbol in the profile, behind only the callee-entry path.
+
+Both probes answer a question that barely changes. `fib`'s recursive call site
+resolves to the same `CompiledFunction` on all 242,785 executions and hashed a
+symbol twice to find out each time. ADR-0066 called for a cache the dispatcher
+can read without hashing; this is its implementation.
+
+## One masked load, four comparisons
+
+The cache is a fixed 128-way array of 32-byte entries embedded directly in the
+`Interpreter`, indexed by `name_sym.id() & 127`. A lookup is one masked load and
+four integer comparisons against tokens that all live in the entry it just
+loaded. Colliding names evict each other, which costs a miss and nothing else.
+
+That shape was not the first attempt, and the first attempt is the interesting
+part. ADR-0066 proposed a *per-callsite* inline cache, and one was built: the
+call site addressed by its opcode index, a lazily-built side table on
+`CompiledCode` mapping that index to a slot, and the slots in a `Vec` on the
+interpreter. It worked exactly as designed — the name-keyed cache was consulted
+twice in 242,785 calls of `fib` — and it removed **no retired instructions at
+all**, +0.07%.
+
+The reason is what the ADR had not accounted for: what the two probes cost is
+their *dependent loads*, not their instruction count. A SwissTable probe is only
+about fifteen instructions. Reaching a per-callsite slot through
+`OnceLock` → side table → index array → slot vector → slot is five dependent
+loads, which is what two probes cost. Trading a hash for an equally long pointer
+chase buys nothing. Flattening the structure to a single load is what turned the
+change from a wash into a win.
+
+## Reusing an address into a table you do not own
+
+An entry holds the *address* of the resolved `CompiledFunction`, which is only
+meaningful while the table in hand is the same table the address came from and
+that table has not been mutated since (a rehash moves every value). `CompiledFns`
+is now a newtype over the map carrying an `id` drawn from a process-global
+counter and re-drawn on every mutation. Ids are never reused, so one `u64`
+comparison proves both facts at once — strictly stronger than the fingerprint
+re-check it replaces, which proved neither, and it costs a compare instead of a
+hash probe. `DerefMut` is deliberately not implemented, so every mutation has to
+go through an entry point that re-draws the id.
+
+Three further tokens ride along: an epoch bumped whenever the name-keyed cache
+this memoises changes at all, and the callee name and callsite package.
+
+## The wrong answer this turned up
+
+Writing the ADR's own adversarial case — "a call site reached from two different
+packages" — found a live bug that had nothing to do with the new machinery:
+
+```raku
+module PkgA { our sub which() { 'A' }; our sub probe() { which() } }
+module PkgB { our sub which() { 'B' }; our sub probe() { which() } }
+say PkgB::probe();  # B
+say PkgA::probe();  # B  -- rakudo says A
+```
+
+`which` is a different routine in each package and the full resolver knows it,
+because it reads `current_package`. Three caches in front of the resolver did
+not: `fn_resolve_cache`, `light_call_cache` and `pos_light_call_cache` were all
+keyed by name alone, so whichever package called a given bare name first
+answered for every other package for the rest of the run — in both directions,
+and for the whole program. All three are now keyed by
+`(name, callsite package)`, which is the key their contents already assumed:
+`PosLightTarget::Otf` had been carrying a `callsite_package` field and checking
+it by hand, and that field is now redundant with the key and gone.
+
+`t/call-inline-cache.t` pins this together with the rest of ADR-0066's
+validation list: two packages sharing a bare name, `wrap`/`unwrap` around an
+already-hot call site, the same name called from a separate `EVAL` compilation
+unit, and a block-local routine shadowing an outer one.
+
+## Measured, and how
+
+Retired instructions: −2.8% on `fib` and `bench-fib`, −1.5% on `bench-tak`,
+unmoved on `method-call` and `bench-class` (which dispatch through the method
+path this cache does not serve yet). `exec_call_func_op` falls from 15.9% to
+7.1% of a `bench-fib` profile.
+
+The cycle figures come from a **same-binary** A/B, and that detail is the
+methodological point worth keeping. Comparing cycles across two builds could not
+support any conclusion at this effect size: the same source built twice differs
+by more than the change is worth — the shipped binary's own cache-disabled run
+of `fib` measured 151.3 Mcycles against the baseline binary's 141.9, 6.6% apart
+with identical semantics, and a cross-build A/B of this change reported anywhere
+from −1.5% to +3.1% depending on which pair of builds was compared, with
+`codegen-units=1` no help. Building one binary with a temporary
+`MUTSU_CALL_IC=0` switch and alternating it against itself holds codegen,
+inlining and layout exactly fixed: −2.9% cycles on `fib`, −2.5% on `bench-fib`,
+−1.4% on `bench-tak`, tracking the instruction counts. The switch was removed
+before merge.

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -4464,6 +4464,56 @@ pub(crate) struct CompiledCode {
     pub(crate) jit: JitCodeState,
 }
 
+/// Number of ways in the direct-mapped call-dispatch cache (ADR-0066). A power
+/// of two so the index is a mask, and small enough that the whole table lives
+/// inline in the `Interpreter` — the point of the structure is that a lookup is
+/// ONE dependent load, which any pointer chase to reach the slots would undo.
+pub(crate) const CALL_IC_WAYS: usize = 128;
+
+/// One monomorphic call-dispatch cache entry (ADR-0066).
+///
+/// A filled entry records the `CompiledFunction` a callee name resolved to, as
+/// a raw address into the `CompiledFns` table it was resolved against. Four
+/// tokens, all in this one 32-byte line, have to agree before that address may
+/// be used again:
+///
+/// * `epoch` — `Interpreter::pos_light_ic_epoch`, bumped whenever the
+///   name-keyed `pos_light_call_cache` this entry memoises changes at all
+///   (including the wholesale clear that a `fn_resolve_gen` change triggers);
+/// * `fns_id` — [`CompiledFns::id`], which changes if the table in hand is a
+///   different one, or the same one after any mutation;
+/// * `name` and `pkg` — the callee symbol and the package the call ran under,
+///   which is the full key of the name-keyed cache. The table is direct-mapped
+///   on `name`, so two names that collide simply evict each other.
+#[derive(Clone, Copy, Default, Debug)]
+pub(crate) struct CallIcSlot {
+    /// 0 = empty; otherwise the `pos_light_ic_epoch` this entry was filled at.
+    pub(crate) epoch: u64,
+    pub(crate) fns_id: u64,
+    /// `*const CompiledFunction` into the table identified by `fns_id`.
+    pub(crate) target: usize,
+    /// `Symbol::id()` of the callee name this entry resolved.
+    pub(crate) name: u32,
+    /// `Symbol::id()` of the package the call ran under.
+    pub(crate) pkg: u32,
+}
+
+impl CallIcSlot {
+    pub(crate) const EMPTY: Self = Self {
+        epoch: 0,
+        fns_id: 0,
+        target: 0,
+        name: 0,
+        pkg: 0,
+    };
+
+    /// Which way of the table a callee name maps to.
+    #[inline]
+    pub(crate) fn way(name: crate::symbol::Symbol) -> usize {
+        (name.id() as usize) & (CALL_IC_WAYS - 1)
+    }
+}
+
 /// The per-local-slot attribute-key table of a chunk (see
 /// [`CompiledCode::local_attr_keys`]): one entry per slot, `Some((bare attribute
 /// `Symbol`, is_private))` for an attribute twigil and `None` otherwise.
@@ -7606,7 +7656,123 @@ impl CompiledCode {
 /// allocation). The slow resolution path probes candidate keys via
 /// `Symbol::lookup` (no interning of names that turn out not to exist), so a
 /// missed probe never grows the global symbol table.
-pub(crate) type CompiledFns = rustc_hash::FxHashMap<crate::symbol::Symbol, CompiledFunction>;
+pub(crate) type CompiledFnMap = rustc_hash::FxHashMap<crate::symbol::Symbol, CompiledFunction>;
+
+/// The table itself, wrapped so that it carries a **version token** (`id`).
+///
+/// The token is what makes the per-callsite inline cache (ADR-0066) sound. A
+/// cache slot remembers the *address* of the `CompiledFunction` a call site
+/// resolved to, which is only meaningful while (a) the map in hand is the very
+/// same map instance the address was taken from, and (b) that map has not been
+/// mutated since (a rehash moves every value). One monotonically increasing
+/// `u64`, drawn from a process-global counter and re-drawn on every mutation,
+/// answers both: ids are never reused, so `fns.id() == slot.fns_id` proves both
+/// facts at once, in a single comparison and with no hashing.
+///
+/// `id() == 0` means "no identity yet" — the state of a freshly created, still
+/// empty table. It never compares equal to a filled slot, so an empty scratch
+/// table (`CompiledFns::default()`, of which the dispatch paths build several)
+/// can never be mistaken for the program's real table.
+///
+/// Reads go through `Deref` to the underlying map. Mutation deliberately does
+/// NOT (`DerefMut` is not implemented): every mutating entry point lives on
+/// this type and re-draws the token, so no mutation can silently leave a stale
+/// pointer validating.
+#[derive(Debug, Default)]
+pub(crate) struct CompiledFns {
+    map: CompiledFnMap,
+    id: u64,
+}
+
+impl CompiledFns {
+    /// The current version token; 0 for a table that has never been mutated.
+    #[inline]
+    pub(crate) fn id(&self) -> u64 {
+        self.id
+    }
+
+    fn next_id() -> u64 {
+        static NEXT: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(1);
+        NEXT.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+    }
+
+    pub(crate) fn insert(&mut self, key: crate::symbol::Symbol, value: CompiledFunction) {
+        self.id = Self::next_id();
+        self.map.insert(key, value);
+    }
+
+    pub(crate) fn retain(
+        &mut self,
+        f: impl FnMut(&crate::symbol::Symbol, &mut CompiledFunction) -> bool,
+    ) {
+        self.id = Self::next_id();
+        self.map.retain(f);
+    }
+
+    pub(crate) fn into_values(self) -> impl Iterator<Item = CompiledFunction> {
+        self.map.into_values()
+    }
+}
+
+impl std::ops::Deref for CompiledFns {
+    type Target = CompiledFnMap;
+    #[inline]
+    fn deref(&self) -> &CompiledFnMap {
+        &self.map
+    }
+}
+
+impl Clone for CompiledFns {
+    fn clone(&self) -> Self {
+        // A clone is a different allocation, so it must not inherit the
+        // original's token (an inline-cache slot pointing into the original
+        // would otherwise validate against the copy).
+        Self {
+            map: self.map.clone(),
+            id: if self.map.is_empty() {
+                0
+            } else {
+                Self::next_id()
+            },
+        }
+    }
+}
+
+impl FromIterator<(crate::symbol::Symbol, CompiledFunction)> for CompiledFns {
+    fn from_iter<T: IntoIterator<Item = (crate::symbol::Symbol, CompiledFunction)>>(
+        iter: T,
+    ) -> Self {
+        let map: CompiledFnMap = iter.into_iter().collect();
+        let id = if map.is_empty() { 0 } else { Self::next_id() };
+        Self { map, id }
+    }
+}
+
+impl Extend<(crate::symbol::Symbol, CompiledFunction)> for CompiledFns {
+    fn extend<T: IntoIterator<Item = (crate::symbol::Symbol, CompiledFunction)>>(
+        &mut self,
+        iter: T,
+    ) {
+        self.id = Self::next_id();
+        self.map.extend(iter);
+    }
+}
+
+impl IntoIterator for CompiledFns {
+    type Item = (crate::symbol::Symbol, CompiledFunction);
+    type IntoIter = <CompiledFnMap as IntoIterator>::IntoIter;
+    fn into_iter(self) -> Self::IntoIter {
+        self.map.into_iter()
+    }
+}
+
+impl<'a> IntoIterator for &'a CompiledFns {
+    type Item = (&'a crate::symbol::Symbol, &'a CompiledFunction);
+    type IntoIter = <&'a CompiledFnMap as IntoIterator>::IntoIter;
+    fn into_iter(self) -> Self::IntoIter {
+        self.map.iter()
+    }
+}
 
 /// Out-of-band named-argument spec for a `CallFuncNamed` site: which of the
 /// call's stack values are named-arg values, and under which keys.
@@ -8085,5 +8251,108 @@ impl CompiledFunction {
                 Self::collect_param_names(sub_sig, declared);
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod compiled_fns_identity {
+    use super::*;
+
+    // The whole soundness argument for the dispatch cache (ADR-0066) rests on
+    // one property of this token: `fns.id() == slot.fns_id` implies `fns` is the
+    // very table the cached address was taken from AND that it has not been
+    // mutated since. These pin both halves.
+
+    fn dummy() -> CompiledFunction {
+        CompiledFunction {
+            code: CompiledCode::new(),
+            source_file: None,
+            params: Vec::new(),
+            param_defs: Vec::new(),
+            return_type: None,
+            fingerprint: 1,
+            empty_sig: false,
+            is_rw: false,
+            is_cached: false,
+            is_raw: false,
+            param_local_slots: None,
+            has_inner_subs: false,
+            declares_inner_routines: false,
+            named_call_plan: None,
+            deprecated_info: None,
+            declared_locals: None,
+            param_name_syms: Vec::new(),
+            package: "GLOBAL".to_string(),
+            compiled_fns: None,
+            memo_cache: std::sync::Arc::new(std::sync::Mutex::new(Vec::new())),
+            package_sym_cache: std::sync::OnceLock::new(),
+            source_file_sym_cache: std::sync::OnceLock::new(),
+        }
+    }
+
+    #[test]
+    fn a_never_mutated_table_has_no_identity() {
+        // Several dispatch paths build an empty scratch table; none of them may
+        // ever validate a cached address, so they must all read as "no id".
+        assert_eq!(CompiledFns::default().id(), 0);
+        assert_eq!(CompiledFns::default().clone().id(), 0);
+        assert_eq!(CompiledFns::default().id(), CompiledFns::default().id());
+    }
+
+    #[test]
+    fn every_mutation_draws_a_fresh_id() {
+        let k = crate::symbol::Symbol::intern("f");
+        let mut fns = CompiledFns::default();
+        fns.insert(k, dummy());
+        let after_first = fns.id();
+        assert_ne!(after_first, 0, "a populated table has an identity");
+
+        // A second insert of the SAME key -- the body-swap case the fingerprint
+        // re-check used to cover -- must still retire cached addresses.
+        fns.insert(k, dummy());
+        assert_ne!(fns.id(), after_first, "insert re-draws the token");
+
+        let after_second = fns.id();
+        fns.extend(std::iter::empty());
+        assert_ne!(fns.id(), after_second, "extend re-draws the token");
+
+        let after_extend = fns.id();
+        fns.retain(|_, _| true);
+        assert_ne!(fns.id(), after_extend, "retain re-draws the token");
+    }
+
+    #[test]
+    fn a_clone_is_a_different_table() {
+        // A clone has its own storage, so an address into the original must not
+        // validate against it.
+        let mut fns = CompiledFns::default();
+        fns.insert(crate::symbol::Symbol::intern("g"), dummy());
+        let copy = fns.clone();
+        assert_ne!(copy.id(), fns.id());
+        assert_ne!(copy.id(), 0);
+    }
+
+    #[test]
+    fn ids_are_never_reused() {
+        // Uniqueness across the process is what rules out an ABA: a table that
+        // has been dropped can never have its id turn up on a live one.
+        let mut seen = std::collections::HashSet::new();
+        for _ in 0..64 {
+            let mut fns = CompiledFns::default();
+            fns.insert(crate::symbol::Symbol::intern("h"), dummy());
+            assert!(
+                seen.insert(fns.id()),
+                "id {} was handed out twice",
+                fns.id()
+            );
+        }
+    }
+
+    #[test]
+    fn cache_ways_are_a_power_of_two() {
+        // `CallIcSlot::way` masks instead of dividing, which is only an index if
+        // the table size is a power of two.
+        assert!(CALL_IC_WAYS.is_power_of_two());
+        assert!(CallIcSlot::way(crate::symbol::Symbol::intern("anything")) < CALL_IC_WAYS);
     }
 }

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1332,7 +1332,7 @@ pub(crate) mod end_order {
     }
 }
 
-/// What a name in `pos_light_call_cache` resolves to.
+/// What a `(name, callsite package)` pair in `pos_light_call_cache` resolves to.
 ///
 /// Both variants denote a body that `is_positional_light_call_eligible` has
 /// already accepted for this name, so the hot `CallFunc` path can dispatch to
@@ -1350,12 +1350,10 @@ pub(crate) enum PosLightTarget {
     /// ultra-fast path: it hit `otf_call_cache` further down `exec_call_func_op`
     /// and re-derived the callsite analysis on every single call, which made a
     /// block-local sub 1.7x more expensive to call than an identical file-scope
-    /// one. `callsite_package` mirrors `otf_call_cache`'s package keying (the
-    /// same bare name means different routines in different packages).
-    Otf {
-        callsite_package: Symbol,
-        cf: Arc<CompiledFunction>,
-    },
+    /// one. The package half of the map key mirrors `otf_call_cache`'s package
+    /// keying (the same bare name means different routines in different
+    /// packages).
+    Otf { cf: Arc<CompiledFunction> },
 }
 
 pub struct Interpreter {
@@ -2878,8 +2876,13 @@ pub struct Interpreter {
     /// by its registration clone id (per-clone `state` in nested named subs).
     pub(crate) pending_nested_state_scope: Option<u64>,
     #[allow(clippy::type_complexity)]
+    /// Keyed by `(callee name, callsite package, arity, argument type names)`.
+    /// The package is part of the key because `resolve_function_with_types` is
+    /// package-sensitive: `PkgA::which` and `PkgB::which` are different
+    /// routines reached by the same bare name, and a package-blind key let
+    /// whichever package called first answer for both.
     pub(crate) fn_resolve_cache:
-        rustc_hash::FxHashMap<(Symbol, usize, Vec<String>), (Symbol, u64, String)>,
+        rustc_hash::FxHashMap<(Symbol, Symbol, usize, Vec<String>), (Symbol, u64, String)>,
     pub(crate) fn_resolve_gen: u64,
     pub(crate) fn_resolve_cache_gen: u64,
     pub(crate) multi_candidates_cache: rustc_hash::FxHashMap<Symbol, bool>,
@@ -2913,9 +2916,14 @@ pub struct Interpreter {
     /// `fn_resolve_gen` like `multi_candidates_cache`.
     pub(crate) fn_base_name_cache: rustc_hash::FxHashMap<Symbol, bool>,
     pub(crate) fn_base_name_cache_gen: u64,
-    pub(crate) light_call_cache: rustc_hash::FxHashMap<Symbol, (Symbol, u64)>,
+    /// Keyed by `(callee name, callsite package)` for the same reason as
+    /// [`Self::pos_light_call_cache`] below.
+    pub(crate) light_call_cache: rustc_hash::FxHashMap<(Symbol, Symbol), (Symbol, u64)>,
     pub(crate) light_call_cache_gen: u64,
-    pub(crate) pos_light_call_cache: rustc_hash::FxHashMap<Symbol, PosLightTarget>,
+    /// Keyed by `(callee name, callsite package)`: the same bare name means
+    /// different routines in two packages (`PkgA::which` vs `PkgB::which`), and
+    /// a name-only key made whichever package called first answer for both.
+    pub(crate) pos_light_call_cache: rustc_hash::FxHashMap<(Symbol, Symbol), PosLightTarget>,
     pub(crate) pos_light_call_cache_gen: u64,
     /// Bare names that appear as a `&`-sigil parameter in some registered sub
     /// (e.g. `foo` from `sub callit(&foo) {...}`). A call to such a name may be
@@ -3206,6 +3214,19 @@ pub struct Interpreter {
     /// around each pull, so nested pulls compare against their own entry.
     pub(crate) lazy_pull_entry_call_depth: Option<usize>,
     pub(crate) rw_map_topic_capture: Option<Value>,
+    /// Direct-mapped call-dispatch cache (ADR-0066): what each callee name last
+    /// resolved to, so a repeat call skips both hash probes the name-keyed path
+    /// pays (`pos_light_call_cache`, then `compiled_fns`) — together about 60%
+    /// of `exec_call_func_op`'s self time on a call-dominated program. Inline
+    /// in the interpreter and indexed by a mask, so a lookup is one dependent
+    /// load; per-interpreter (hence per-thread), so the entries need no
+    /// synchronisation.
+    pub(crate) call_ic: [crate::opcode::CallIcSlot; crate::opcode::CALL_IC_WAYS],
+    /// Version stamp every filled [`Self::call_ic`] slot carries. Bumped on any
+    /// change to `pos_light_call_cache` (insert or the generation clear), which
+    /// makes a slot's validity exactly "the name-keyed cache has not moved
+    /// since I read it" — the property that lets the slot stand in for it.
+    pub(crate) pos_light_ic_epoch: u64,
 }
 
 /// Metadata stored per custom type created by Metamodel::Primitives.

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -3077,6 +3077,8 @@ impl Interpreter {
             light_call_cache_gen: 0,
             pos_light_call_cache: Default::default(),
             pos_light_call_cache_gen: 0,
+            call_ic: [crate::opcode::CallIcSlot::EMPTY; crate::opcode::CALL_IC_WAYS],
+            pos_light_ic_epoch: 1,
             amp_param_shadowed_names: std::collections::HashSet::new(),
             empty_sig_proto_names: std::collections::HashSet::new(),
             registered_fn_fingerprints: Default::default(),

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -918,6 +918,8 @@ impl Interpreter {
             light_call_cache_gen: 0,
             pos_light_call_cache: Default::default(),
             pos_light_call_cache_gen: 0,
+            call_ic: [crate::opcode::CallIcSlot::EMPTY; crate::opcode::CALL_IC_WAYS],
+            pos_light_ic_epoch: 1,
             amp_param_shadowed_names: std::collections::HashSet::new(),
             empty_sig_proto_names: std::collections::HashSet::new(),
             registered_fn_fingerprints: Default::default(),

--- a/src/vm/vm_call_func_ops.rs
+++ b/src/vm/vm_call_func_ops.rs
@@ -2,6 +2,86 @@ use super::*;
 use crate::symbol::Symbol;
 
 impl Interpreter {
+    /// Record a name-keyed positional-light target, retiring every filled
+    /// dispatch-cache entry that memoised the old table (ADR-0066).
+    #[inline]
+    pub(crate) fn pos_light_cache_insert(
+        &mut self,
+        name: Symbol,
+        pkg: Symbol,
+        target: crate::runtime::PosLightTarget,
+    ) {
+        self.bump_pos_light_ic_epoch();
+        self.pos_light_call_cache.insert((name, pkg), target);
+    }
+
+    /// Retire every filled dispatch-cache entry. Cheap: the entries carry the
+    /// epoch, so advancing it invalidates them all without touching the table.
+    #[inline]
+    pub(crate) fn bump_pos_light_ic_epoch(&mut self) {
+        // 0 is the "empty entry" marker, so never land on it.
+        self.pos_light_ic_epoch = match self.pos_light_ic_epoch.wrapping_add(1) {
+            0 => 1,
+            e => e,
+        };
+    }
+
+    /// The `CompiledFunction` address this name last resolved to, when all four
+    /// validity tokens still agree (see `CallIcSlot`).
+    #[inline]
+    fn call_ic_hit(
+        &self,
+        name_sym: Symbol,
+        pkg_sym: Symbol,
+        fns_id: u64,
+    ) -> Option<*const CompiledFunction> {
+        // Masked index: in bounds by construction, so no bounds check survives.
+        let slot = &self.call_ic[crate::opcode::CallIcSlot::way(name_sym)];
+        if slot.epoch == self.pos_light_ic_epoch
+            && slot.fns_id == fns_id
+            && slot.name == name_sym.id()
+            && slot.pkg == pkg_sym.id()
+        {
+            Some(slot.target as *const CompiledFunction)
+        } else {
+            None
+        }
+    }
+
+    /// Bind a cached target's lifetime to the table that vouches for it.
+    ///
+    /// # Safety
+    /// `ptr` must have been taken from `fns` while `fns.id()` had the value the
+    /// caller compared against, and `fns` must not have been mutated since.
+    #[inline]
+    unsafe fn ic_target(_fns: &CompiledFns, ptr: *const CompiledFunction) -> &CompiledFunction {
+        unsafe { &*ptr }
+    }
+
+    /// Remember what this name resolved to, for the current epoch.
+    #[inline]
+    fn call_ic_fill(
+        &mut self,
+        name_sym: Symbol,
+        pkg_sym: Symbol,
+        fns_id: u64,
+        target: &CompiledFunction,
+    ) {
+        // A table that has never been mutated has no identity to vouch for the
+        // address (id 0 is shared by every empty scratch table), so it cannot
+        // be cached. In practice such a table has nothing to resolve either.
+        if fns_id == 0 {
+            return;
+        }
+        self.call_ic[crate::opcode::CallIcSlot::way(name_sym)] = crate::opcode::CallIcSlot {
+            epoch: self.pos_light_ic_epoch,
+            fns_id,
+            target: target as *const CompiledFunction as usize,
+            name: name_sym.id(),
+            pkg: pkg_sym.id(),
+        };
+    }
+
     /// ADR-0024: `mainline_lexical_frame_active` (the read/write resolver for
     /// a mainline named sub's captured free variables) keys off the LAST
     /// `routine_stack` frame. This predicate predates ADR-0037 Slice 1, which
@@ -205,7 +285,9 @@ impl Interpreter {
                     .contains(&code.const_sym(name_idx)))
         {
             let name_sym = code.const_sym(name_idx);
-            if let Some((cached_key, cached_fp)) = self.light_call_cache.get(&name_sym)
+            let cur_pkg_sym = self.current_package_sym();
+            if let Some((cached_key, cached_fp)) =
+                self.light_call_cache.get(&(name_sym, cur_pkg_sym))
                 && let Some(cf) = compiled_fns.get(cached_key)
                 && cf.fingerprint == *cached_fp
             {
@@ -403,26 +485,50 @@ impl Interpreter {
                 // `compiled_fns`, so take an `Arc` handle to it and let the
                 // borrow on `self` end before the call below.
                 let mut otf_hold: Option<Arc<CompiledFunction>> = None;
+                // ADR-0066: ask the direct-mapped dispatch cache first. A hit
+                // answers exactly what the two hash probes below would have —
+                // the name-keyed `pos_light_call_cache`, then `compiled_fns` —
+                // in one masked load and four integer comparisons, with no
+                // hashing at all. Those two probes are ~60% of this function's
+                // self time on a call-dominated program, and the cost is their
+                // dependent loads, so the replacement has to be one load: an
+                // earlier per-callsite design that reached its slots through a
+                // chunk-side index table measured no better than the probes.
+                let fns_id = compiled_fns.id();
                 let cur_pkg_sym = self.current_package_sym();
-                let cached: Option<&CompiledFunction> =
-                    match self.pos_light_call_cache.get(&name_sym) {
+                let mut cached: Option<&CompiledFunction> = self
+                    .call_ic_hit(name_sym, cur_pkg_sym, fns_id)
+                    // SAFETY: `call_ic_hit` yields the address only when the
+                    // slot's `fns_id` equals this table's — which proves both
+                    // that `compiled_fns` IS the table the address was taken
+                    // from (ids come from a global counter and are never
+                    // reused) and that it has not been mutated since (every
+                    // mutating entry point re-draws the id), so no rehash can
+                    // have moved the value. The referent therefore lives at
+                    // that address for as long as the borrow of the table.
+                    .map(|p| unsafe { Self::ic_target(compiled_fns, p) });
+                if cached.is_none() {
+                    cached = match self.pos_light_call_cache.get(&(name_sym, cur_pkg_sym)) {
                         Some(crate::runtime::PosLightTarget::Compiled { key, fingerprint }) => {
                             let (key, fingerprint) = (*key, *fingerprint);
                             compiled_fns
                                 .get(&key)
                                 .filter(|cf| cf.fingerprint == fingerprint)
                         }
-                        Some(crate::runtime::PosLightTarget::Otf {
-                            callsite_package,
-                            cf,
-                        }) => {
-                            if *callsite_package == cur_pkg_sym {
-                                otf_hold = Some(Arc::clone(cf));
-                            }
+                        Some(crate::runtime::PosLightTarget::Otf { cf }) => {
+                            otf_hold = Some(Arc::clone(cf));
                             None
                         }
                         None => None,
                     };
+                    // Only an ahead-of-time body is cached: an OTF body is
+                    // owned by the name-keyed cache (not by `compiled_fns`),
+                    // so it has no address this slot's `fns_id` could vouch
+                    // for, and it already skips the second probe anyway.
+                    if let Some(cf) = cached {
+                        self.call_ic_fill(name_sym, cur_pkg_sym, fns_id, cf);
+                    }
+                }
                 if let Some(cf) = cached.or(otf_hold.as_deref()) {
                     let arity_usize = arity as usize;
                     if self.stack.len() >= arity_usize {
@@ -484,6 +590,7 @@ impl Interpreter {
                 }
             } else {
                 self.pos_light_call_cache.clear();
+                self.bump_pos_light_ic_epoch();
                 self.pos_light_call_cache_gen = self.fn_resolve_gen;
             }
         }
@@ -492,7 +599,9 @@ impl Interpreter {
         if !skip_name_caches {
             let name_sym = code.const_sym(name_idx);
             if self.light_call_cache_gen == self.fn_resolve_gen {
-                if let Some((cached_key, cached_fp)) = self.light_call_cache.get(&name_sym)
+                let cur_pkg_sym = self.current_package_sym();
+                if let Some((cached_key, cached_fp)) =
+                    self.light_call_cache.get(&(name_sym, cur_pkg_sym))
                     && let Some(cf) = compiled_fns.get(cached_key)
                     && cf.fingerprint == *cached_fp
                 {
@@ -661,10 +770,10 @@ impl Interpreter {
                             // `stack_args_have_slip` / the share checks above are
                             // per-CALL properties, and that path re-checks all of
                             // them in its own fused scan before dispatching.
-                            self.pos_light_call_cache.insert(
+                            self.pos_light_cache_insert(
                                 name_sym,
+                                cur_pkg_sym,
                                 crate::runtime::PosLightTarget::Otf {
-                                    callsite_package: cur_pkg_sym,
                                     cf: Arc::clone(&cf),
                                 },
                             );
@@ -759,7 +868,12 @@ impl Interpreter {
         if !has_lexical_override && arity <= 1 {
             let name_str = Self::const_str(code, name_idx);
             let name_sym = code.const_sym(name_idx);
-            let cache_key = (name_sym, 0usize, Vec::<String>::new());
+            let cache_key = (
+                name_sym,
+                self.current_package_sym(),
+                0usize,
+                Vec::<String>::new(),
+            );
             let use_cache = !self.has_multi_candidates_cached(name_str);
             if use_cache
                 && self.fn_resolve_cache_gen == self.fn_resolve_gen
@@ -1260,18 +1374,27 @@ impl Interpreter {
                     && !self.light_call_blocked_by_mainline_capture(name)
                 {
                     let name_sym = Symbol::intern(name);
-                    if !self.pos_light_call_cache.contains_key(&name_sym) {
-                        for (key, func) in compiled_fns {
+                    let cur_pkg_sym = self.current_package_sym();
+                    if !self
+                        .pos_light_call_cache
+                        .contains_key(&(name_sym, cur_pkg_sym))
+                    {
+                        let mut found: Option<Symbol> = None;
+                        for (key, func) in compiled_fns.iter() {
                             if std::ptr::eq(func, cf) {
-                                self.pos_light_call_cache.insert(
-                                    name_sym,
-                                    crate::runtime::PosLightTarget::Compiled {
-                                        key: *key,
-                                        fingerprint: cf.fingerprint,
-                                    },
-                                );
+                                found = Some(*key);
                                 break;
                             }
+                        }
+                        if let Some(key) = found {
+                            self.pos_light_cache_insert(
+                                name_sym,
+                                cur_pkg_sym,
+                                crate::runtime::PosLightTarget::Compiled {
+                                    key,
+                                    fingerprint: cf.fingerprint,
+                                },
+                            );
                         }
                     }
                     let result = self.call_compiled_function_positional_light(
@@ -1311,12 +1434,13 @@ impl Interpreter {
                 {
                     // Populate light-call cache so subsequent calls skip resolution
                     let name_sym = Symbol::intern(name);
-                    if !self.light_call_cache.contains_key(&name_sym) {
+                    let cur_pkg_sym = self.current_package_sym();
+                    if !self.light_call_cache.contains_key(&(name_sym, cur_pkg_sym)) {
                         // Find the compiled_fns key for this function
-                        for (key, func) in compiled_fns {
+                        for (key, func) in compiled_fns.iter() {
                             if std::ptr::eq(func, cf) {
                                 self.light_call_cache
-                                    .insert(name_sym, (*key, cf.fingerprint));
+                                    .insert((name_sym, cur_pkg_sym), (*key, cf.fingerprint));
                                 break;
                             }
                         }

--- a/src/vm/vm_call_resolve.rs
+++ b/src/vm/vm_call_resolve.rs
@@ -35,7 +35,12 @@ impl Interpreter {
             .iter()
             .map(|v| runtime::value_type_name(v).to_string())
             .collect();
-        let cache_key = (name_sym, arity, type_sig.clone());
+        let cache_key = (
+            name_sym,
+            self.current_package_sym(),
+            arity,
+            type_sig.clone(),
+        );
         // Check the resolution cache first to avoid expensive resolve_function_with_types.
         // Skip cache for multi functions since subset type dispatch depends on values.
         let use_cache = !self.has_multi_candidates_cached(name);

--- a/t/call-inline-cache.t
+++ b/t/call-inline-cache.t
@@ -1,0 +1,62 @@
+use v6;
+use Test;
+
+# ADR-0066: a call site caches the routine it resolved to. Every mechanism that
+# can change what a name resolves to must retire that cache. These are the
+# adversarial shapes named in the ADR's validation plan.
+
+plan 13;
+
+# 1. A plain repeated call site keeps resolving to the same routine.
+sub twice($n) { $n * 2 }
+sub call-twice-many() {
+    my $sum = 0;
+    $sum += twice($_) for 1 .. 5;
+    $sum;
+}
+is call-twice-many(), 30, 'repeated call site resolves consistently';
+
+# 2. The same bare name in two packages is two different routines, even though
+#    both call sites are compiled from the same source text shape.
+module PkgA {
+    our sub which() { 'A' }
+    our sub probe() { which() }
+}
+module PkgB {
+    our sub which() { 'B' }
+    our sub probe() { which() }
+}
+is PkgA::probe(), 'A', 'package A call site resolves to its own sub';
+is PkgB::probe(), 'B', 'package B call site resolves to its own sub';
+is PkgA::probe(), 'A', 'package A still resolves to its own sub after B ran';
+
+# 3. `wrap` replaces what a name dispatches to, mid-run, after the site is hot.
+sub wrapped($n) { $n + 1 }
+sub call-wrapped($n) { wrapped($n) }
+is call-wrapped(1), 2, 'pre-wrap dispatch';
+my $handle = &wrapped.wrap(-> $n { callsame() * 10 });
+is call-wrapped(1), 20, 'wrap is visible at an already-executed call site';
+&wrapped.unwrap($handle);
+is call-wrapped(1), 2, 'unwrap restores the original at the same call site';
+
+# 4. The same routine name called from two different compilation units: the
+#    mainline's table and the EVAL's are different tables, and a call site may
+#    not answer for one with what it resolved in the other.
+sub shared($n) { $n * 3 }
+sub call-shared($n) { shared($n) }
+is call-shared(2), 6, 'mainline unit resolves its own sub';
+is EVAL('shared(3)'), 9, 'the same name called from an EVAL unit';
+is call-shared(2), 6, 'the mainline call site is unaffected by the EVAL unit';
+
+# 5. A block-local routine shadows an outer same-named one for calls inside the
+#    block, without disturbing the outer call site that already ran.
+sub picked() { 'outer' }
+sub pick() { picked() }
+is pick(), 'outer', 'outer site before the shadow exists';
+{
+    sub picked() { 'inner' }
+    is picked(), 'inner', 'the block-local declaration shadows inside the block';
+}
+is pick(), 'outer', 'the outer call site still reaches the outer routine';
+
+done-testing;


### PR DESCRIPTION
Implements ADR-0066, and fixes a live wrong answer that writing its own adversarial test case turned up.

## What the dispatcher was doing

`exec_call_func_op` re-derived the callee from its name on every call: a hash probe into the name-keyed `pos_light_call_cache`, then a second into `compiled_fns` to turn the cached key back into a body. Those two probes were **~60% of the dispatcher's self time** on `bench-fib` — and they answer a question that barely changes. `fib`'s recursive call site resolves to the same `CompiledFunction` on all 242,785 executions.

## What replaced them

A 128-way direct-mapped cache embedded in the `Interpreter`, indexed by `name_sym.id() & 127`: one masked load of a 32-byte entry, then four integer comparisons against tokens that all live in that entry. Nothing per-chunk, so `OpCode`, `CompiledCode` and the compiler are untouched.

**The first attempt is the interesting part.** ADR-0066 proposed a *per-callsite* cache and one was built: the site addressed by its opcode index, a lazily-built side table on `CompiledCode`, slots in a `Vec` on the interpreter. It worked exactly as designed — the name-keyed cache was consulted twice in 242,785 calls of `fib` — and it removed **no retired instructions at all** (+0.07%). What the probes cost is their *dependent loads*, not their instruction count: a SwissTable probe is only ~15 instructions, while reaching a per-callsite slot through `OnceLock` → side table → index array → vector → slot is five dependent loads, which is what two probes cost. Flattening to a single load is what turned the change from a wash into a win. Both designs are recorded in the ADR.

## Reusing an address into a table you don't own

An entry holds the *address* of the resolved `CompiledFunction`. That is only sound while the table in hand is the same table the address came from and has not been mutated since. `CompiledFns` is now a newtype over the map carrying an `id` drawn from a process-global counter and **re-drawn on every mutation**; ids are never reused, so one `u64` comparison proves both — strictly stronger than the fingerprint re-check it replaces, which proved neither. `DerefMut` is deliberately not implemented so no mutation can bypass the id.

## The bug this uncovered

`fn_resolve_cache`, `light_call_cache` and `pos_light_call_cache` were all keyed by **name alone**, while the resolver behind them reads `current_package`. Two packages declaring the same bare sub name shared one entry, and whichever called first answered for both, in both directions, for the rest of the run:

```raku
module PkgA { our sub which() { 'A' }; our sub probe() { which() } }
module PkgB { our sub which() { 'B' }; our sub probe() { which() } }
say PkgB::probe();  # B
say PkgA::probe();  # B   <- rakudo says A
```

All three are now keyed by `(name, callsite package)` — the key their contents already assumed, since `PosLightTarget::Otf` carried a `callsite_package` field and checked it by hand (now redundant with the key, and removed).

## Measured

Retired instructions are the primary oracle:

| benchmark | instructions | cycles (same-binary) |
| --- | ---: | ---: |
| `fib` | −2.8% | −2.9% |
| `bench-fib` | −2.8% | −2.5% |
| `bench-tak` | −1.5% | −1.4% |
| `method-call` | ~0 | ~0 |
| `bench-class` | ~0 | ~0 |

`exec_call_func_op` falls from 15.9% to 7.1% of a `bench-fib` profile. `method-call` / `bench-class` are unmoved because they dispatch through the method path, which this cache does not serve yet.

The cycle column comes from a **same-binary** A/B (one build carrying a temporary `MUTSU_CALL_IC=0` switch, alternated against itself; removed before merge). Cross-build cycle comparisons cannot resolve an effect this size on this box: the shipped binary's own cache-disabled `fib` run measured 151.3 Mcycles against the baseline binary's 141.9 — 6.6% apart with identical semantics — and a cross-build A/B of this change reported anywhere from −1.5% to +3.1% depending on which pair of builds was compared, `codegen-units=1` included.

## Testing

- `make test`: PASS (3628 files, 36704 tests).
- Targeted roast sweep, `S06`/`S10`/`S11`/`S12` whitelisted files (216 files, 4783 tests): PASS.
- New pin `t/call-inline-cache.t` covers ADR-0066's validation list: two packages sharing a bare name, `wrap`/`unwrap` around an already-hot call site, the same name called from a separate `EVAL` compilation unit, and a block-local routine shadowing an outer one. Verified against `raku` first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)