### PR TITLE
perf(vm): answer "already readonly" from a direct-mapped cache on the set

### DIFF
--- a/news/2026-09/readonly-set-direct-mapped-cache.md
+++ b/news/2026-09/readonly-set-direct-mapped-cache.md
@@ -1,0 +1,52 @@
+# Marking a parameter readonly stopped hashing on the recursive steady state
+
+Every routine call marks each of its parameters read-only on entry and unmarks
+them on return. In the recursive / monomorphic steady state -- the shape of any
+hot call site -- that mark is a **pure no-op**: an outer frame already put the
+same name in the set with the same `ReadonlyKind`, so
+`mark_readonly_sym_with`'s `insert` overwrote a value with itself and its
+journal arm fell through to `Some(_) => {}`. mutsu was paying a full SwissTable
+*insert* (probe, write, length bookkeeping) to learn that nothing had changed:
+`perf` on `bench-fib` put `mark_readonly_sym_with` at 3.0% and the
+`hashbrown::HashMap::insert` it called at 3.3%.
+
+Two changes, both on `ReadonlySet` itself:
+
+1. **`marked_with(sym, kind)`** -- the question the mark actually wants to ask.
+   `mark_readonly_sym_with` now asks it first and returns immediately when the
+   answer is yes, so the common case never reaches the map at all.
+2. **A direct-mapped positive cache** (`cache: [Option<(Symbol, ReadonlyKind)>;
+   64]`, indexed by `sym.raw() & 63`) so `marked_with` and `contains_key` answer
+   from one array load instead of a hash probe. The invariant is that an
+   occupied slot `(s, k)` implies `map[s] == k`; a slot never implies *absence*,
+   so any miss -- an empty slot, or one holding the symbol that evicted this
+   one -- falls through to the map. That is what makes it sound under collision:
+   an insert always overwrites its slot, and a remove only clears a slot that
+   still names the symbol being removed.
+
+The cache lives on the set it describes, exactly like the existing `topic`
+flag, so every mutation path maintains it by construction -- including the
+whole-set `mem::take` / assignment in `take_readonly_state` /
+`restore_readonly_state`, which move the cache along with its map. Each read
+re-derives the slow answer under `debug_assert`, and CI runs the whole `t/`
+suite on a debug binary (ADR-0014), so 3600+ files check the invariant on every
+push. Three unit tests pin the parts the asserts cannot reach on their own:
+eviction (a colliding insert must not lose the evicted entry), removal of an
+already-evicted symbol (must not clear the slot its evictor now owns), and
+re-marking with a different kind.
+
+Measured on a release build with a temporary same-binary env switch, pinned to
+one core:
+
+| benchmark | retired instructions |
+| --- | ---: |
+| `bench-tak` | **-3.87%** |
+| `bench-fib` | **-2.67%** (cycles -5.4%) |
+| `bench-class` | -0.12% |
+| `poly-call` | -0.08% |
+| `bench-ctor` | -0.03% |
+| `method-call`, `bench-array`, `bench-hash`, `bench-string` | +0.02..0.04% |
+| `bench-mandelbrot` | +0.19% |
+
+The two recursive call benchmarks are the ones that mark parameters on every
+call; everything else is within layout noise.

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -736,7 +736,6 @@ pub(crate) struct ClassAttributeDef {
 ///
 /// The value records *why* the name is readonly ([`ReadonlyKind`]), which is
 /// what decides the exception an assignment through it throws.
-#[derive(Default)]
 pub(crate) struct ReadonlySet {
     map: rustc_hash::FxHashMap<Symbol, ReadonlyKind>,
     /// Whether the topic `_` is currently in `map`.
@@ -756,14 +755,64 @@ pub(crate) struct ReadonlySet {
     /// `t/` suite on a debug binary (ADR-0014), so the invariant is checked by
     /// 3600+ files on every push.
     topic: bool,
+    /// Direct-mapped *positive* cache over [`Self::map`], indexed by
+    /// `sym.raw() & (READONLY_CACHE_SLOTS - 1)`.
+    ///
+    /// Every routine call marks each of its parameters readonly and unmarks
+    /// them on return, and in the recursive/monomorphic steady state the mark
+    /// is a pure no-op -- the same name is already in the set with the same
+    /// kind, put there by an outer frame. Answering "already marked with this
+    /// kind?" through the hash map cost a full SwissTable probe (plus, before
+    /// this cache, a hash *insert*: probe, write, length bookkeeping) on the
+    /// hottest call path; `bench-fib` spent ~6% of its cycles there.
+    ///
+    /// Invariant: an occupied slot `(s, k)` implies `map[s] == k`. A slot never
+    /// implies *absence*, so a miss (empty slot, or a slot holding a different
+    /// symbol that evicted this one) falls through to the map. That is what
+    /// makes the cache sound under collision: an insert always overwrites its
+    /// slot, and a remove only clears a slot that still names the symbol being
+    /// removed -- an evicted entry simply stops being cached, it is never
+    /// wrongly reported.
+    ///
+    /// Kept on the set itself, like [`Self::topic`], so every mutation path
+    /// maintains it by construction (including the whole-set `mem::take` /
+    /// assignment in `take_readonly_state` / `restore_readonly_state`, which
+    /// move the cache with the map it describes). Each read re-derives the slow
+    /// answer under `debug_assert`, and CI runs the whole `t/` suite on a debug
+    /// binary (ADR-0014), so the invariant is checked by 3600+ files per push.
+    cache: [Option<(Symbol, ReadonlyKind)>; READONLY_CACHE_SLOTS],
+}
+
+/// Slot count of [`ReadonlySet::cache`]. A power of two so the index is a mask.
+/// Sized to hold every readonly name a realistic call stack has live at once
+/// (parameters and loop aliases) without the table itself costing a cache line
+/// per probe.
+const READONLY_CACHE_SLOTS: usize = 64;
+
+impl Default for ReadonlySet {
+    fn default() -> Self {
+        Self {
+            map: rustc_hash::FxHashMap::default(),
+            topic: false,
+            cache: [None; READONLY_CACHE_SLOTS],
+        }
+    }
 }
 
 impl ReadonlySet {
+    #[inline(always)]
+    fn slot(sym: Symbol) -> usize {
+        (sym.raw() as usize) & (READONLY_CACHE_SLOTS - 1)
+    }
+
     #[inline]
     pub(crate) fn insert(&mut self, sym: Symbol, kind: ReadonlyKind) -> Option<ReadonlyKind> {
         if sym == crate::symbol::wk::topic() {
             self.topic = true;
         }
+        // Overwrite unconditionally: whatever this evicts stays correct in the
+        // map, it merely stops being cached.
+        self.cache[Self::slot(sym)] = Some((sym, kind));
         self.map.insert(sym, kind)
     }
 
@@ -772,11 +821,46 @@ impl ReadonlySet {
         if *sym == crate::symbol::wk::topic() {
             self.topic = false;
         }
+        let slot = Self::slot(*sym);
+        // Only clear a slot that still names this symbol -- a slot holding the
+        // symbol that evicted it still describes a live map entry.
+        if let Some((cached, _)) = self.cache[slot]
+            && cached == *sym
+        {
+            self.cache[slot] = None;
+        }
         self.map.remove(sym)
+    }
+
+    /// Is `sym` marked with exactly `kind`? The question every parameter mark
+    /// asks before doing anything, answered from the cache when it can be.
+    #[inline]
+    pub(crate) fn marked_with(&self, sym: Symbol, kind: ReadonlyKind) -> bool {
+        if let Some((cached, cached_kind)) = self.cache[Self::slot(sym)]
+            && cached == sym
+        {
+            debug_assert_eq!(
+                self.map.get(&sym),
+                Some(&cached_kind),
+                "ReadonlySet::cache drifted from the map"
+            );
+            return cached_kind == kind;
+        }
+        self.map.get(&sym) == Some(&kind)
     }
 
     #[inline]
     pub(crate) fn contains_key(&self, sym: &Symbol) -> bool {
+        if let Some((cached, cached_kind)) = self.cache[Self::slot(*sym)]
+            && cached == *sym
+        {
+            debug_assert_eq!(
+                self.map.get(sym),
+                Some(&cached_kind),
+                "ReadonlySet::cache drifted from the map"
+            );
+            return true;
+        }
         self.map.contains_key(sym)
     }
 
@@ -799,6 +883,79 @@ impl ReadonlySet {
             "ReadonlySet::topic drifted from the map"
         );
         self.topic
+    }
+}
+
+#[cfg(test)]
+mod readonly_set_cache_tests {
+    use super::{READONLY_CACHE_SLOTS, ReadonlySet};
+    use crate::ast::ReadonlyKind;
+    use crate::symbol::Symbol;
+
+    /// Two distinct symbols that land in the same `ReadonlySet::cache` slot.
+    /// Interned ids are assigned sequentially, so probing a few hundred names
+    /// always finds a colliding pair.
+    fn colliding_pair() -> (Symbol, Symbol) {
+        let syms: Vec<Symbol> = (0..READONLY_CACHE_SLOTS * 4)
+            .map(|i| Symbol::intern(&format!("__ro_cache_probe_{i}")))
+            .collect();
+        for (i, &a) in syms.iter().enumerate() {
+            for &b in &syms[i + 1..] {
+                if ReadonlySet::slot(a) == ReadonlySet::slot(b) {
+                    return (a, b);
+                }
+            }
+        }
+        unreachable!("no colliding symbol pair among {} names", syms.len());
+    }
+
+    /// The cache is a *positive* cache: an occupied slot proves membership, an
+    /// empty or evicted one proves nothing. Eviction and removal must never
+    /// turn that into a wrong answer.
+    #[test]
+    fn an_evicted_entry_is_still_reported_from_the_map() {
+        let (a, b) = colliding_pair();
+        let mut set = ReadonlySet::default();
+        set.insert(a, ReadonlyKind::Alias);
+        set.insert(b, ReadonlyKind::Alias); // evicts `a` from the shared slot
+        assert!(set.contains_key(&a), "an evicted entry is still a member");
+        assert!(set.contains_key(&b));
+        assert!(set.marked_with(a, ReadonlyKind::Alias));
+        assert!(set.marked_with(b, ReadonlyKind::Alias));
+
+        // Removing the evicted symbol must not clear the slot the *other*
+        // symbol now owns.
+        set.remove(&a);
+        assert!(!set.contains_key(&a));
+        assert!(set.contains_key(&b), "the evicting entry survives");
+        assert!(set.marked_with(b, ReadonlyKind::Alias));
+
+        set.remove(&b);
+        assert!(!set.contains_key(&b));
+        assert!(set.is_empty());
+    }
+
+    /// Re-marking with a different kind must be visible through the cache.
+    #[test]
+    fn a_rekinded_entry_reports_the_new_kind() {
+        let sym = Symbol::intern("__ro_cache_rekind");
+        let mut set = ReadonlySet::default();
+        set.insert(sym, ReadonlyKind::Alias);
+        assert!(set.marked_with(sym, ReadonlyKind::Alias));
+        set.insert(sym, ReadonlyKind::Immutable);
+        assert!(set.marked_with(sym, ReadonlyKind::Immutable));
+        assert!(!set.marked_with(sym, ReadonlyKind::Alias));
+        assert!(set.contains_key(&sym));
+    }
+
+    /// A symbol that was never inserted is not reported by a stale slot.
+    #[test]
+    fn a_never_inserted_symbol_is_not_a_member() {
+        let (a, b) = colliding_pair();
+        let mut set = ReadonlySet::default();
+        set.insert(a, ReadonlyKind::Alias);
+        assert!(!set.contains_key(&b), "a colliding non-member stays absent");
+        assert!(!set.marked_with(b, ReadonlyKind::Alias));
     }
 }
 

--- a/src/runtime/types/mod.rs
+++ b/src/runtime/types/mod.rs
@@ -266,6 +266,15 @@ impl Interpreter {
     /// already marked) journals nothing.
     #[inline]
     pub(crate) fn mark_readonly_sym_with(&mut self, sym: Symbol, kind: ReadonlyKind) {
+        // The steady state of a recursive/monomorphic call: the name is already
+        // in the set with exactly this kind (an outer frame marked it), so the
+        // insert would overwrite a value with itself and the journal arm below
+        // would be `Some(_) => {}`. Answering that from the set's direct-mapped
+        // cache turns a hash insert into one array load on the hottest path.
+        let already = self.readonly_vars.borrow().marked_with(sym, kind);
+        if already {
+            return;
+        }
         let previous = self.readonly_vars.borrow_mut().insert(sym, kind);
         if self.readonly_frames.get() == 0 {
             return;


### PR DESCRIPTION
## What

Every routine call marks each of its parameters read-only on entry and unmarks
them on return. In the recursive / monomorphic steady state -- the shape of any
hot call site -- that mark is a **pure no-op**: an outer frame already put the
same name in the set with the same `ReadonlyKind`, so `mark_readonly_sym_with`'s
`insert` overwrote a value with itself and its journal arm fell through to
`Some(_) => {}`. We were paying a full SwissTable *insert* (probe, write, length
bookkeeping) to learn that nothing had changed: `perf` on `bench-fib` put
`mark_readonly_sym_with` at **3.0%** and the `hashbrown::HashMap::insert` it
called at **3.3%**.

## How

Two changes, both on `ReadonlySet` itself:

1. **`marked_with(sym, kind)`** -- the question the mark actually wants to ask.
   `mark_readonly_sym_with` asks it first and returns immediately on yes, so the
   common case never reaches the map.
2. **A direct-mapped positive cache** (`[Option<(Symbol, ReadonlyKind)>; 64]`,
   indexed by `sym.raw() & 63`) so `marked_with` and `contains_key` answer from
   one array load instead of a hash probe.

The cache invariant is that an occupied slot `(s, k)` implies `map[s] == k`; a
slot never implies *absence*, so any miss -- an empty slot, or one holding the
symbol that evicted this one -- falls through to the map. That is what makes it
sound under collision: an insert always overwrites its slot, and a remove only
clears a slot that still names the symbol being removed.

It lives on the set it describes, exactly like the existing `topic` flag, so
every mutation path maintains it by construction -- including the whole-set
`mem::take` / assignment in `take_readonly_state` / `restore_readonly_state`,
which move the cache along with its map.

## Soundness checks

Each read re-derives the slow answer under `debug_assert`, and CI runs the whole
`t/` suite on a debug binary (ADR-0014), so 3600+ files check the invariant on
every push. Three unit tests pin what the asserts cannot reach on their own:

- eviction: a colliding insert must not lose the evicted entry;
- removal of an already-evicted symbol must not clear the slot its evictor owns;
- re-marking with a different kind must be visible.

## Measurement

Release build, temporary same-binary env switch, pinned to one core:

| benchmark | retired instructions |
| --- | ---: |
| `bench-tak` | **-3.87%** |
| `bench-fib` | **-2.67%** (cycles -5.4%) |
| `bench-class` | -0.12% |
| `poly-call` | -0.08% |
| `bench-ctor` | -0.03% |
| `method-call` / `bench-array` / `bench-hash` / `bench-string` | +0.02..0.04% |
| `bench-mandelbrot` | +0.19% |

The two recursive call benchmarks mark parameters on every call; everything else
is within layout noise. The switch is removed in the committed code.

`make test` passes (3628 files, 36707 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)