### PR TITLE
perf(vm): inline five more per-call no-op guards on the dispatch path

### DIFF
--- a/news/2026-09/per-call-noop-guards-inlined-round2.md
+++ b/news/2026-09/per-call-noop-guards-inlined-round2.md
@@ -1,0 +1,48 @@
+# Five more per-call helpers stopped costing a call to answer "nothing to do"
+
+A second pass in the spirit of `news/2026-09/hot-path-noop-guards-are-now-inlined.md`.
+`perf` on `bench-fib` showed a cluster of small out-of-line symbols on the
+positional-light dispatch path, each of which answers "no" for essentially every
+call and costs more to *reach* than to compute:
+
+| helper | self time | what it decides |
+| --- | ---: | --- |
+| `record_cf_deprecation` | 1.32% | is this routine deprecated? (almost never) |
+| `unwrap_varref_value` | 1.44% | is this argument a varref capture? |
+| `arg_is_container_value` | 0.90% | is this argument an `@`/`%` variable? |
+| `decode_arg_slip_positions` | 0.72% | does this call site have an argument-source table? |
+| `enter_routine_package` | 0.72% | is this routine's package non-`GLOBAL`? |
+
+Each now keeps only its cheap test at the call site and outlines the rest:
+
+- `record_cf_deprecation` inlines the `is_some` test; the env lookup and
+  `String` build move into a `#[cold] #[inline(never)]` half, so they neither
+  cost a call nor reserve stack slots in
+  `call_compiled_function_positional_light_at`'s already-large frame.
+- `enter_routine_package` inlines only the emptiness test and the 6-byte
+  `"GLOBAL"` compare; the `"::&"` substring search and the two `String` clones
+  live in the outlined half.
+- `decode_arg_slip_positions` inlines down to the `Option<u32>` test; the
+  constant-pool scan that builds the position vector stays outlined.
+- `unwrap_varref_value` / `unwrap_var_ref_value` / `arg_is_container_value` are
+  a single tag test each, so they are simply `#[inline]`.
+
+Measured cross-build against `main`, release, pinned to one core (retired
+instructions -- the layout-insensitive oracle, since inlining cannot be toggled
+by an env switch the way the other changes in this series were):
+
+| benchmark | retired instructions |
+| --- | ---: |
+| `bench-fib` | **-2.37%** |
+| `bench-tak` | **-1.93%** |
+| `poly-call` | -0.14% |
+| `bench-ctor` | -0.05% |
+| `bench-mandelbrot` / `bench-string` | -0.01..0.00% |
+| `bench-class` | +0.10% |
+| `method-call` | +0.32% |
+
+`method-call` is the one row that moves the wrong way; the method path takes a
+different dispatch route, so the inlined argument helpers grow its code without
+removing calls from its hot loop. At +0.3% against -2.4% on the call-heavy
+benchmarks it is a clear net win, but it is real, not noise -- worth knowing if
+a later change makes the method path the bottleneck.

--- a/src/runtime/types/signature.rs
+++ b/src/runtime/types/signature.rs
@@ -115,6 +115,7 @@ pub(in crate::runtime) fn wrap_native_int_for_binding(
 /// Strip the [`Value::varref`] wrapper the caller tagged an lvalue argument
 /// with, once the binder has taken the source name it needs. On the light-call
 /// path this runs once per parameter, so it must not materialize the name.
+#[inline]
 pub(crate) fn unwrap_varref_value(value: Value) -> Value {
     match value.as_varref() {
         Some((_, inner, _)) => inner.clone(),

--- a/src/vm/vm_call_dispatch.rs
+++ b/src/vm/vm_call_dispatch.rs
@@ -18,17 +18,33 @@ fn global_otf_cache() -> &'static std::sync::Mutex<rustc_hash::FxHashMap<u64, Ar
 
 impl Interpreter {
     /// Record a deprecation event for a compiled function if it has deprecation info.
+    ///
+    /// Every call on the hottest dispatch path runs this, and virtually no
+    /// routine is deprecated -- so only the `is_some` test belongs at the call
+    /// site. The body (an env lookup by name plus a `String` build) is outlined
+    /// `#[cold]` so it neither costs a call nor reserves stack slots in
+    /// `call_compiled_function_positional_light_at`'s frame.
+    #[inline]
     pub(super) fn record_cf_deprecation(&self, cf: &CompiledFunction) {
-        if let Some((ref kind, ref name, ref package, ref msg)) = cf.deprecated_info {
-            let cl = self.pending_callsite_line();
-            let file = self
-                .env()
-                .get("*PROGRAM-NAME")
-                .map(|v| v.to_string_value())
-                .unwrap_or_default();
-            let line = cl.unwrap_or(self.cur_source_line);
-            crate::runtime::deprecation::record_deprecation(kind, name, package, msg, &file, line);
+        if cf.deprecated_info.is_some() {
+            self.record_cf_deprecation_cold(cf);
         }
+    }
+
+    #[cold]
+    #[inline(never)]
+    fn record_cf_deprecation_cold(&self, cf: &CompiledFunction) {
+        let Some((kind, name, package, msg)) = cf.deprecated_info.as_ref() else {
+            return;
+        };
+        let cl = self.pending_callsite_line();
+        let file = self
+            .env()
+            .get("*PROGRAM-NAME")
+            .map(|v| v.to_string_value())
+            .unwrap_or_default();
+        let line = cl.unwrap_or(self.cur_source_line);
+        crate::runtime::deprecation::record_deprecation(kind, name, package, msg, &file, line);
     }
 
     /// Cached version of the Interpreter-native [`Self::has_multi_candidates`].

--- a/src/vm/vm_call_eligibility.rs
+++ b/src/vm/vm_call_eligibility.rs
@@ -10,17 +10,31 @@ impl Interpreter {
     /// positional-light — not just the OTF/named path that already set it. The
     /// gate (real, non-mangled, non-GLOBAL package) keeps the hot GLOBAL-function
     /// path (fib, ...) free of any lock/string churn: it returns `None` cheaply.
+    ///
+    /// Only the two cheap halves of that gate are inlined here (an emptiness
+    /// test and a 6-byte compare); the `"::&"` substring search and the two
+    /// `String` clones live in the outlined slow half, so a GLOBAL routine's
+    /// call site does not even pay a call.
+    #[inline]
     pub(super) fn enter_routine_package(&mut self, cf: &CompiledFunction) -> Option<String> {
-        if !cf.package.is_empty() && cf.package != "GLOBAL" && !cf.package.contains("::&") {
-            let saved = self.current_package();
-            self.set_current_package(cf.package.clone());
-            Some(saved)
-        } else {
-            None
+        if cf.package.is_empty() || cf.package == "GLOBAL" {
+            return None;
         }
+        self.enter_routine_package_outlined(cf)
+    }
+
+    #[inline(never)]
+    fn enter_routine_package_outlined(&mut self, cf: &CompiledFunction) -> Option<String> {
+        if cf.package.contains("::&") {
+            return None;
+        }
+        let saved = self.current_package();
+        self.set_current_package(cf.package.clone());
+        Some(saved)
     }
 
     /// Restore the package saved by [`enter_routine_package`].
+    #[inline]
     pub(super) fn leave_routine_package(&mut self, saved: Option<String>) {
         if let Some(s) = saved {
             self.set_current_package(s);
@@ -246,6 +260,11 @@ impl Interpreter {
     /// and a non-variable literal (`f([1,2])`) has no caller to share with — both
     /// must keep the fast path. A variable arg reaches the binder as a `VarRef`,
     /// so peek inside without cloning.
+    ///
+    /// Inlined: this runs per argument on every call, and for the ordinary
+    /// non-varref argument the whole answer is one tag test -- as an outlined
+    /// call it cost more to reach than to compute.
+    #[inline]
     pub(super) fn arg_is_container_value(arg: &Value) -> bool {
         let ValueView::VarRef { name, value, .. } = arg.view() else {
             return false;

--- a/src/vm/vm_call_helpers.rs
+++ b/src/vm/vm_call_helpers.rs
@@ -203,11 +203,22 @@ impl Interpreter {
     /// compiled argument list, i.e. exactly the arity the call op carries,
     /// before any position's value is spread into zero or more runtime
     /// arguments. `None` when there is no descriptor or no `|` argument.
+    ///
+    /// Inlined down to the `arg_sources_idx` test: a call site with no
+    /// argument-source table (the common one) answers `None` without a call,
+    /// and the constant-pool scan that builds the position vector stays
+    /// outlined.
+    #[inline]
     pub(super) fn decode_arg_slip_positions(
         code: &CompiledCode,
         arg_sources_idx: Option<u32>,
     ) -> Option<Vec<usize>> {
         let idx = arg_sources_idx?;
+        Self::decode_arg_slip_positions_at(code, idx)
+    }
+
+    #[inline(never)]
+    fn decode_arg_slip_positions_at(code: &CompiledCode, idx: u32) -> Option<Vec<usize>> {
         let ValueView::Array(items, ..) = code.constants[idx as usize].view() else {
             return None;
         };
@@ -224,6 +235,7 @@ impl Interpreter {
         }
     }
 
+    #[inline]
     pub(super) fn unwrap_var_ref_value(value: Value) -> Value {
         match value.as_varref() {
             Some((_, inner, _)) => inner.clone(),


### PR DESCRIPTION
## What

A second pass in the spirit of #7269. `perf` on `bench-fib` showed a cluster of
small out-of-line symbols on the positional-light dispatch path, each of which
answers "no" for essentially every call and costs more to **reach** than to
compute:

| helper | self time | what it decides |
| --- | ---: | --- |
| `record_cf_deprecation` | 1.32% | is this routine deprecated? (almost never) |
| `unwrap_varref_value` | 1.44% | is this argument a varref capture? |
| `arg_is_container_value` | 0.90% | is this argument an `@`/`%` variable? |
| `decode_arg_slip_positions` | 0.72% | does this call site have an argument-source table? |
| `enter_routine_package` | 0.72% | is this routine's package non-`GLOBAL`? |

## How

Each keeps only its cheap test at the call site and outlines the rest:

- `record_cf_deprecation` inlines the `is_some` test; the env lookup and
  `String` build move to a `#[cold] #[inline(never)]` half, so they neither cost
  a call nor reserve stack slots in
  `call_compiled_function_positional_light_at`'s already-large frame.
- `enter_routine_package` inlines only the emptiness test and the 6-byte
  `"GLOBAL"` compare; the `"::&"` substring search and the two `String` clones
  live in the outlined half.
- `decode_arg_slip_positions` inlines down to the `Option<u32>` test; the
  constant-pool scan that builds the position vector stays outlined.
- `unwrap_varref_value` / `unwrap_var_ref_value` / `arg_is_container_value` are
  a single tag test each, so they are simply `#[inline]`.

No behaviour changes -- every guard evaluates the same predicate in the same
order.

## Measurement

Cross-build against `main`, release, pinned to one core. **Retired
instructions**, not cycles: inlining cannot be toggled by a same-binary env
switch the way the other changes in this series were, and instructions is the
layout-insensitive oracle.

| benchmark | retired instructions |
| --- | ---: |
| `bench-fib` | **-2.37%** |
| `bench-tak` | **-1.93%** |
| `poly-call` | -0.14% |
| `bench-ctor` | -0.05% |
| `bench-mandelbrot` / `bench-string` | -0.01..0.00% |
| `bench-class` | +0.10% |
| `method-call` | +0.32% |

`method-call` is the one row moving the wrong way, and it is called out in the
news entry rather than rounded away: the method path routes differently, so the
inlined argument helpers grow its code without removing calls from its hot loop.
At +0.3% against -2.4% on the call-heavy benchmarks it is a clear net win, but
worth knowing if a later change makes the method path the bottleneck.

`make test` passes (3629 files, 36730 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)