### PR TITLE
perf(vm): decide parameter itemization once per signature, not per bind

### DIFF
--- a/news/2026-09/parameter-itemization-decided-once-per-signature.md
+++ b/news/2026-09/parameter-itemization-decided-once-per-signature.md
@@ -1,0 +1,39 @@
+# Parameter itemization is decided once per signature, not once per bind
+
+Binding an argument to a plain `$` parameter itemizes it -- Raku's binder puts
+the value in a Scalar container, so `f([1, 2])` binds `$v` as `$[1, 2]`, one
+element in list context. Sigilless (`\v`), `is raw` and `is rw` parameters bind
+the raw value, and `@` / `%` / `&` parameters bind the container itself.
+
+That decision depends only on the parameter's *declaration*. Yet
+`itemize_plain_scalar_param` re-derived it on every bind of every call, and the
+derivation is not cheap: two scans of the parameter's `traits: Vec<String>` with
+string compares (`== "invocant"`, then `== "raw" || == "rw"`), a multi-character
+`starts_with`, and then `itemize_scalar_store`'s own name guard (`== "_"`,
+`starts_with('&')`, `starts_with("__mutsu")`) on top. `perf` on `bench-fib` put
+`itemize_plain_scalar_param` at 1.9% and `itemize_scalar_store` at 1.5%.
+
+A routine's signature is fixed, so the answer is now settled once. Following the
+same shape as `param_fast_types` from
+`news/2026-09/light-call-type-checks-answer-from-a-precomputed-tag.md`:
+
+- `Interpreter::param_binds_itemized_scalar(pd)` is the predicate, now written
+  in one place and folding in the name half of `itemize_scalar_store`'s guard so
+  it answers the whole question.
+- `CompiledFunction::param_itemize_on_bind` holds the per-parameter answer,
+  filled by `precompute_param_name_syms` alongside the type tags.
+- `itemize_scalar_store` splits into `name_is_itemize_exempt` (the name half)
+  and `itemize_scalar_store_value` (the value half), so a caller holding the
+  precomputed flag calls straight into the value half.
+- `Interpreter::bind_itemize_param(cf, i, val)` is the one place the three light
+  call sites go through, with a fallback to the per-bind derivation for a
+  hand-built chunk that never ran the precompute.
+
+Measured on a release build with a temporary same-binary env switch, pinned to
+one core: `bench-tak` retired instructions **-2.28%**, `bench-fib` **-1.60%**,
+`method-call` +0.05% and `bench-class` +0.03% (neither takes this path).
+
+`t/param-itemize-on-bind.t` pins the outcome for each declaration shape -- plain
+`$` with an Array, a Hash and a scalar, two parameters itemized independently,
+`is raw`, `is rw`, sigilless, `@`, and `&` -- all verified against `raku`, so
+the precomputed flag cannot drift from the predicate it was derived from.

--- a/src/compiler/helpers_method_body.rs
+++ b/src/compiler/helpers_method_body.rs
@@ -217,6 +217,7 @@ impl Compiler {
             declared_locals: None,
             param_name_syms: Vec::new(),
             param_fast_types: Vec::new(),
+            param_itemize_on_bind: Vec::new(),
             return_fast_type: None,
             package: package_name.to_string(),
             compiled_fns: (!own_compiled_fns.is_empty())

--- a/src/compiler/helpers_sub_body.rs
+++ b/src/compiler/helpers_sub_body.rs
@@ -574,6 +574,7 @@ impl Compiler {
             declared_locals: None,
             param_name_syms: Vec::new(),
             param_fast_types: Vec::new(),
+            param_itemize_on_bind: Vec::new(),
             return_fast_type: None,
             // The declaring package, matching the package component of this
             // function's `compiled_fns` key (built from `key_package` above).

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -7982,6 +7982,11 @@ pub(crate) struct CompiledFunction {
     /// chunk) or when some parameter's constraint is not light-path-checkable;
     /// both cases fall back to the by-name `fast_type_check`.
     pub(crate) param_fast_types: Vec<FastParamCheck>,
+    /// Whether binding each parameter itemizes the incoming value, parallel to
+    /// `param_defs` (see `Interpreter::param_binds_itemized_scalar`). Empty when
+    /// the precompute has not run (a hand-built chunk), which falls back to
+    /// re-deriving it from the `ParamDef`.
+    pub(crate) param_itemize_on_bind: Vec<bool>,
     /// The declared return type's precomputed plan (see [`FastParamCheck`]).
     /// `None` when there is no return type, or when it is not one the light
     /// return check handles by tag.
@@ -8291,6 +8296,11 @@ impl CompiledFunction {
             .return_type
             .as_ref()
             .and_then(|rt| FastParamCheck::of(Some(rt)));
+        self.param_itemize_on_bind = self
+            .param_defs
+            .iter()
+            .map(crate::runtime::Interpreter::param_binds_itemized_scalar)
+            .collect();
     }
 
     /// True if `sym` names a *callee-local* of this function — a parameter, a
@@ -8380,6 +8390,7 @@ mod compiled_fns_identity {
             declared_locals: None,
             param_name_syms: Vec::new(),
             param_fast_types: Vec::new(),
+            param_itemize_on_bind: Vec::new(),
             return_fast_type: None,
             package: "GLOBAL".to_string(),
             compiled_fns: None,

--- a/src/vm/vm_call_dispatch.rs
+++ b/src/vm/vm_call_dispatch.rs
@@ -297,6 +297,7 @@ impl Interpreter {
             declared_locals: None,
             param_name_syms: Vec::new(),
             param_fast_types: Vec::new(),
+            param_itemize_on_bind: Vec::new(),
             return_fast_type: None,
             package: pkg.clone(),
             compiled_fns: (!own_compiled_fns.is_empty())

--- a/src/vm/vm_call_light.rs
+++ b/src/vm/vm_call_light.rs
@@ -353,7 +353,11 @@ impl Interpreter {
                 // original.
                 let val = std::mem::replace(&mut self.stack[args_base + param_idx], Value::NIL);
                 let val = crate::runtime::types::unwrap_varref_value(val);
-                let val = Self::itemize_plain_scalar_param(&cf.param_defs[param_idx], val);
+                // Whether this parameter itemizes its bound value depends only
+                // on its declaration, so it was settled at registration time
+                // (`param_itemize_on_bind`). Re-deriving it per bind scanned the
+                // parameter's `traits: Vec<String>` twice with string compares.
+                let val = Self::bind_itemize_param(cf, param_idx, val);
                 let param_name = &cf.param_defs[param_idx].name;
                 let needs_env = write_all_params
                     || val.is_nil()

--- a/src/vm/vm_call_light_typed.rs
+++ b/src/vm/vm_call_light_typed.rs
@@ -221,7 +221,7 @@ impl Interpreter {
                             bind_err = Some(RuntimeError::typed("X::TypeCheck::Argument", attrs));
                             break 'bind;
                         }
-                        let val = Self::itemize_plain_scalar_param(&cf.param_defs[i], val);
+                        let val = Self::bind_itemize_param(cf, i, val);
                         bind_value!(ppb.slot, ppb.needs_env, val);
                     } else if ppb.required {
                         let got = args
@@ -312,7 +312,7 @@ impl Interpreter {
                 bind_value!(npb.slot, true, seed);
                 continue;
             };
-            let v = Self::itemize_plain_scalar_param(&cf.param_defs[i], v.clone());
+            let v = Self::bind_itemize_param(cf, i, v.clone());
             // A sub_signature rename (`:color(:$colour)`) binds every inner
             // name to the value as well.
             for (alias_name, alias_slot) in &npb.alias_binds {

--- a/src/vm/vm_helpers.rs
+++ b/src/vm/vm_helpers.rs
@@ -43,16 +43,49 @@ impl Interpreter {
     /// not the itemized `$("a", "b", "c")`.
     #[inline]
     pub(crate) fn itemize_plain_scalar_param(pd: &crate::ast::ParamDef, val: Value) -> Value {
-        if !pd.sigilless
+        if Self::param_binds_itemized_scalar(pd) {
+            Self::itemize_scalar_store_value(val)
+        } else {
+            val
+        }
+    }
+
+    /// [`Self::itemize_plain_scalar_param`] for a parameter of a compiled
+    /// routine, answered from the precomputed `param_itemize_on_bind` flag.
+    /// An index past the end means the chunk never ran the precompute (a
+    /// hand-built one), which falls back to deriving the answer per bind.
+    #[inline]
+    pub(crate) fn bind_itemize_param(
+        cf: &crate::opcode::CompiledFunction,
+        param_idx: usize,
+        val: Value,
+    ) -> Value {
+        match cf.param_itemize_on_bind.get(param_idx) {
+            Some(true) => Self::itemize_scalar_store_value(val),
+            Some(false) => val,
+            None => Self::itemize_plain_scalar_param(&cf.param_defs[param_idx], val),
+        }
+    }
+
+    /// Does binding `pd` itemize the incoming value (`my $h = %x` semantics for
+    /// a `$` parameter)?
+    ///
+    /// Depends only on the parameter's declaration -- its sigil, its traits and
+    /// its name -- never on the argument, yet
+    /// [`Self::itemize_plain_scalar_param`] re-derived it on every bind of every
+    /// call, scanning the `traits: Vec<String>` twice with string compares. A
+    /// routine's signature is fixed, so `CompiledFunction::param_itemize_on_bind`
+    /// settles it once at registration time; this is the definition that
+    /// precompute uses, kept here so the two can never drift.
+    pub(crate) fn param_binds_itemized_scalar(pd: &crate::ast::ParamDef) -> bool {
+        !pd.sigilless
             && !pd.is_invocant
             && !pd.traits.iter().any(|t| t == "invocant")
             && !pd.name.starts_with(['@', '%', '&'])
             && !pd.traits.iter().any(|t| t == "raw" || t == "rw")
-        {
-            Self::itemize_scalar_store(&pd.name, val)
-        } else {
-            val
-        }
+            // The name half of `itemize_scalar_store`'s own guard, folded in so
+            // the precomputed flag answers the whole question.
+            && !Self::name_is_itemize_exempt(&pd.name)
     }
 
     /// Snapshot the lexical pragma state (`use fatal`, `use strict`,

--- a/src/vm/vm_run_loop.rs
+++ b/src/vm/vm_run_loop.rs
@@ -973,9 +973,25 @@ impl Interpreter {
     /// excluded (container-alias writeback, see `itemize_scalar_assign_result`),
     /// as are `&`-sigiled and internal `__mutsu_` names.
     pub(crate) fn itemize_scalar_store(name: &str, val: Value) -> Value {
-        if name == "_" || name.starts_with('&') || name.starts_with("__mutsu") {
+        if Self::name_is_itemize_exempt(name) {
             return val;
         }
+        Self::itemize_scalar_store_value(val)
+    }
+
+    /// True when a name is exempt from scalar-store itemization: the topic, a
+    /// `&`-sigiled Callable binding, and the internal `__mutsu*` keys. Purely a
+    /// property of the name, so a caller binding the same name repeatedly (a
+    /// routine parameter, on every call) can settle it once -- see
+    /// `CompiledFunction::param_itemize_on_bind`.
+    #[inline]
+    pub(crate) fn name_is_itemize_exempt(name: &str) -> bool {
+        name == "_" || name.starts_with('&') || name.starts_with("__mutsu")
+    }
+
+    /// The value half of [`Self::itemize_scalar_store`], for a caller that has
+    /// already settled the name half.
+    pub(crate) fn itemize_scalar_store_value(val: Value) -> Value {
         match val.view() {
             ValueView::Array(items, kind) if !kind.is_itemized() => {
                 Value::array_with_kind(items.clone(), kind.itemize())
@@ -1005,7 +1021,7 @@ impl Interpreter {
             // A `but`-mixed container keeps the itemization the `$` confers —
             // see the Mixin arm of `itemize_value`.
             ValueView::Mixin(inner, overrides) => Value::mixin_parts(
-                std::sync::Arc::new(Self::itemize_scalar_store(name, (**inner).clone())),
+                std::sync::Arc::new(Self::itemize_scalar_store_value((**inner).clone())),
                 overrides.clone(),
             ),
             _ => val,

--- a/t/param-itemize-on-bind.t
+++ b/t/param-itemize-on-bind.t
@@ -1,0 +1,38 @@
+use Test;
+
+# Binding an argument to a plain `$` parameter itemizes it (Raku's binder puts
+# the value in a Scalar container), while sigilless / `is raw` / `is rw` /
+# `@` / `%` / `&` parameters bind the value as-is. That decision depends only
+# on the parameter's *declaration*, so the light call paths settle it once at
+# registration time (`CompiledFunction::param_itemize_on_bind`) instead of
+# re-scanning the parameter's trait list on every bind. Pin the outcome for
+# each declaration shape so the precomputed flag can never drift from the
+# predicate it was derived from.
+
+plan 9;
+
+sub plain($x) { $x.raku }
+is plain([1, 2]), '$[1, 2]', 'a plain $ parameter itemizes an Array argument';
+is plain({ a => 1 }), '${:a(1)}', 'a plain $ parameter itemizes a Hash argument';
+is plain(7), '7', 'a plain $ parameter leaves a scalar value alone';
+
+sub two($p, $q) { $p.raku ~ ' ' ~ $q.raku }
+is two([1], { b => 2 }), '$[1] ${:b(2)}', 'each parameter is itemized on its own';
+
+sub raw-param($x is raw) { $x.raku }
+is raw-param([1, 2]), '[1, 2]', 'an `is raw` parameter binds the value unitemized';
+
+# `is rw` binds the caller's container as-is; what shows through here is the
+# itemization `my $rw = [...]` already put on it, not one added by the bind.
+my $rw = [1, 2];
+sub rw-param($x is rw) { $x.raku }
+is rw-param($rw), '$[1, 2]', 'an `is rw` parameter binds the caller container as-is';
+
+sub sigilless-param(\v) { v.raku }
+is sigilless-param([1, 2]), '[1, 2]', 'a sigilless parameter binds the value unitemized';
+
+sub array-param(@x) { @x.raku }
+is array-param([1, 2]), '[1, 2]', 'an @ parameter binds the container itself';
+
+sub callable-param(&c) { c() }
+is callable-param(sub { 7 }), 7, 'a & parameter binds the Callable itself';


### PR DESCRIPTION
## What

Binding an argument to a plain `$` parameter itemizes it -- Raku's binder puts
the value in a Scalar container, so `f([1, 2])` binds `$v` as `$[1, 2]`.
Sigilless (`\v`), `is raw` and `is rw` parameters bind the raw value; `@` / `%`
/ `&` parameters bind the container itself.

That decision depends only on the parameter's **declaration**. Yet
`itemize_plain_scalar_param` re-derived it on every bind of every call, and the
derivation is not cheap: two scans of the parameter's `traits: Vec<String>` with
string compares (`== "invocant"`, then `== "raw" || == "rw"`), a multi-character
`starts_with`, and then `itemize_scalar_store`'s own name guard (`== "_"`,
`starts_with('&')`, `starts_with("__mutsu")`) on top. `perf` on `bench-fib` put
`itemize_plain_scalar_param` at **1.9%** and `itemize_scalar_store` at **1.5%**.

## How

The same shape #7276 established for type constraints:

- `Interpreter::param_binds_itemized_scalar(pd)` is the predicate, now written
  in one place and folding in the name half of `itemize_scalar_store`'s guard so
  it answers the whole question.
- `CompiledFunction::param_itemize_on_bind` holds the per-parameter answer,
  filled by `precompute_param_name_syms` alongside the type tags -- the routine
  every construction site already calls once its signature is final.
- `itemize_scalar_store` splits into `name_is_itemize_exempt` (name half) and
  `itemize_scalar_store_value` (value half), so a caller holding the precomputed
  flag calls straight into the value half. The `Mixin` arm recurses into the
  value half for the same reason.
- `Interpreter::bind_itemize_param(cf, i, val)` is the one entry point the three
  light call sites go through, with a fallback to the per-bind derivation for a
  hand-built chunk that never ran the precompute.

No behaviour change: the predicate is the same conjunction, just evaluated once.

## Measurement

Release build, temporary same-binary env switch, pinned to one core:

| benchmark | retired instructions |
| --- | ---: |
| `bench-tak` | **-2.28%** |
| `bench-fib` | **-1.60%** |
| `method-call` | +0.05% |
| `bench-class` | +0.03% |

The switch is removed in the committed code.

## Tests

`t/param-itemize-on-bind.t` pins the outcome for each declaration shape -- plain
`$` with an Array, a Hash and a scalar, two parameters itemized independently,
`is raw`, `is rw`, sigilless, `@`, and `&` -- all verified against `raku`, so
the precomputed flag cannot drift from the predicate it was derived from. A
direct before/after diff of a script covering all those shapes against a `main`
build is byte-identical. `make test` passes (3630 files, 36739 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)