### PR TITLE
ci(pages): deploy the site daily so it cannot go stale

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -10,6 +10,15 @@ on:
   # runs the interpreter from the last deploy, not from HEAD — when you want it
   # to pick up interpreter changes, trigger this workflow by hand
   # (`gh workflow run pages.yml`, or the "Run workflow" button).
+  #
+  # The daily schedule below is the safety net for everything the push filter
+  # deliberately ignores: a newly published npm package, roast-whitelist.txt
+  # growth (the landing page's "N% of the spec passes" figure), a module
+  # vendored into modules/ outside a site change, and the bench-data history
+  # that bench-trend.html renders. Without it the deployed site can sit stale
+  # for weeks until someone remembers to press "Run workflow".
+  schedule:
+    - cron: '17 21 * * *'
   push:
     branches: [main]
     paths:


### PR DESCRIPTION
## What

Add a daily `schedule` trigger (`17 21 * * *`) to `.github/workflows/pages.yml`.

## Why

The Pages deploy only ran on a `site/**` (and friends) push, a successful `Release`, or a manual `workflow_dispatch`. But the deployed site derives four things from *outside* those paths, all of which move on ordinary merges:

- **The interpreter** — installed from `@tokuhirom/mutsu@latest` at deploy time. `src/**` is deliberately excluded from the push filter (nearly every commit touches it), so the playground runs whatever was `latest` at the last deploy.
- **The roast pass figure** — the landing page headlines "N% of the official spec files pass", counted from `roast-whitelist.txt` in the build job. Every whitelist addition makes the published number stale.
- **The batteries listing** — regenerated from the vendored `modules/` tree at deploy time.
- **bench-trend.html** — rendered from `bench-history.tsv` on the `bench-data` branch, which gains a row on every main push.

In practice the site only caught up when someone remembered to press "Run workflow". A daily run is a floor on freshness; the narrow push filter is left untouched so a `site/**` change still deploys immediately.

The `build` job's `if` is `github.event_name != 'workflow_run' || ...`, so a scheduled run is already admitted and needs no guard. The existing `concurrency: pages` group keeps a scheduled run from racing a push-triggered one.

Docs/CI-only change; `ci.yml`'s docs-only classifier does **not** cover `.github/**`, so the full suite runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)