### PR TITLE
docs(plan): point S5b and the call-path row at what was actually measured

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -85,10 +85,14 @@ work; see the CLAUDE.md "mzef package manager and distribution" section. The **R
       skeleton), S2's routine half, S3 (error recovery), S4 (symbols/definition) and S5a (hover) are done** — `crates/mutsu-lsp/`,
       `src/analysis/`, [docs/language-server.md](docs/language-server.md). Next is **S5b:
       `references`** — the one remaining method that genuinely needs per-occurrence positions,
-      since a line may hold several and text scanning cannot rank them soundly. It is where D6's
-      "spans only on the variants a feature demands" finally gets exercised, so settle the target
-      variants (~5 reference nodes) before touching the parser's hot path or the bincode AST
-      cache. **S2's method half is deferred with a real design question**: `$x.foo` needs the
+      since a line may hold several and text scanning cannot rank them soundly. **Start from
+      [todo/deep/lsp-references-needs-a-side-table-not-ast-spans.md](todo/deep/lsp-references-needs-a-side-table-not-ast-spans.md),
+      not from D6**: reconnaissance during S5a found the parser already knows every byte offset,
+      so a thread-local occurrence table behind the analysis flag is likely cheaper than spans on
+      AST variants and touches neither `Expr`'s size nor the bincode cache. Its blocker is parser
+      **backtracking** (phantom references from failed alternatives), so **the first step is a
+      measurement of the phantom rate over `modules/`/`vendor/`/`t/`** — that number decides the
+      design, and D6/S5b get amended from it. **S2's method half is deferred with a real design question**: `$x.foo` needs the
       receiver type, which the AST does not carry, and the existing `(owner, name)` catalog is
       conservative in the false-positive direction — see the ADR's S2 findings.
 - [ ] Debugger.
@@ -159,6 +163,11 @@ bench CI, never a local run.
 - [ ] **The one axis where mutsu is genuinely slower than raku** — the interpreter function-call path
       in hot loops (the JIT bails at the call boundary):
       [todo/perf/interpreter-call-path-in-hot-loops.md](todo/perf/interpreter-call-path-in-hot-loops.md).
+      Its concrete consumer is retiring the native `Test` provider
+      ([todo/deep/vendor-real-test-module.md](todo/deep/vendor-real-test-module.md)), which is a
+      BATTERIES.md rung-3 retirement and therefore a §1 goal item, not polish. **Read that ticket's
+      2026-09-04 re-measurement first**: the `&`-sigil signature gate it long blamed is closed, while
+      the symptom (~40× raku per real-`Test` assertion) is undiminished.
 - [ ] Grammar/regex per-subrule ceremony (~25× vs raku per matched character; the exponential and
       accumulated-state halves are fixed):
       [ADR-0007](docs/adr/0007-grammar-parse-trail-matcher.md) §Implementation outcome.


### PR DESCRIPTION
Follow-up to #7283 (the 2026-09-04 TRIAGE regeneration). Two PLAN.md pointers were invalidated by that re-survey, and each would have cost a session that followed it.

**S5b (`references`)** told the next reader to settle ~5 AST reference-node variants per ADR-0065 D6. Reconnaissance during S5a concluded that is probably the wrong shape: the parser already derives every byte offset (`current_line_number`'s pointer arithmetic), so a thread-local occurrence table behind the analysis flag costs neither `Expr`'s size nor the bincode AST cache. The real blocker is parser **backtracking** manufacturing phantom references from failed alternatives. The bullet now sends the reader to `todo/deep/lsp-references-needs-a-side-table-not-ast-spans.md` and names the measurement (phantom rate over `modules/`/`vendor/`/`t/`) that has to come before any design.

**The §4 call-path row** named the interpreter call path without naming its consumer. Retiring the native `Test` provider is a BATTERIES.md rung-3 retirement — a §1 goal item, not the §4 polish its placement implies. It also now warns that the ticket's long-standing `&`-sigil attribution is closed (measured 2026-09-04: identical opcode profiles for `sub f(&c)` and `sub f($c)`) while the symptom is not (~40× raku per real-`Test` assertion), so nobody re-derives it.

Documentation only — the four heavy CI jobs skip by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)