### PR TITLE
fix: scope `proto`/`multi sub` declarations lexically

### DIFF
--- a/news/2026-09/proto-multi-lexical-scope.md
+++ b/news/2026-09/proto-multi-lexical-scope.md
@@ -1,0 +1,78 @@
+# `proto`/`multi sub` declarations are lexically scoped again
+
+An inner lexical scope that declares its own `proto` was rejected outright:
+
+```raku
+proto sub foo($) {*}
+multi sub foo(Int $x) { "outer" }
+{ proto sub foo($) {*}; multi sub foo(Int $x) { "inner" }; say foo(5); }
+say foo(5);
+# raku:  inner / outer
+# mutsu: Runtime error "Redeclaration of routine 'foo'. Did you mean to declare a multi-sub?"
+```
+
+The same shape inside a routine body (`sub bar() { proto sub foo($){*}; multi sub
+foo(Int $x){...} }`) failed identically. This is valid Raku refused at declaration
+time, so nothing downstream of it could run.
+
+## Root cause
+
+mutsu's routine registry is keyed by the fully-qualified `Package::name`, so an
+inner `proto foo` and an outer `proto foo` collide on one key (`GLOBAL::foo`).
+Plain single subs already survive this: the block-scope routine-registry
+snapshot/restore (`snapshot_routine_registry` / `restore_routine_registry`, taken
+around every `BlockScope` and every routine call) puts the outer routine back when
+the scope exits, and `register_sub_decl_with_metadata` has an explicit
+`allow_lexical_shadow` exemption so the inner declaration is not reported as a
+redeclaration on the way in.
+
+`register_proto_decl` never got that exemption. It raised `X::Redeclaration`
+unconditionally whenever `functions` or `proto_subs` already held the key — with
+no notion of which scope the existing entry belonged to. (ADR-0041 §1.2 described
+this defect as "the redeclaration check is name-based and scope-blind for plain
+subs"; measured on 2026-09-04, plain subs shadow correctly and it is `proto` that
+was scope-blind.)
+
+The proto side needed one more piece than the sub side: a `proto` declared
+directly in a *routine body* is not covered by `block_scope_depth`, because a sub
+body's declarations are hoisted and registered at a point where the depth counter
+is still zero. `Stmt::SubDecl` solves that with the compiler-set `__lexical_hoist`
+marker; `Stmt::ProtoDecl` carried no such marker.
+
+## What changed
+
+- `register_proto_decl` takes an `is_lexical_hoist` flag and computes the same
+  `allow_lexical_shadow` predicate as `register_sub_decl_with_metadata`
+  (`block_scope_depth > 0 || is_lexical_hoist`, minus the EVAL cases). When
+  shadowing is allowed, the two redeclaration checks are skipped; the purge of the
+  outer name's candidates that already followed them gives the inner proto a fresh
+  candidate set, and the snapshot/restore brings the outer one back.
+- The compiler marks a body-local `Stmt::ProtoDecl` `__lexical_hoist`, the way
+  `hoist_sub_decls` marks a body-local `Stmt::SubDecl`.
+- `mark_lexical_body` now tallies protos as well as singles and multis, so a
+  *genuine* same-scope redeclaration (two protos of one name, or a proto plus a
+  single sub of one name) still raises `X::Redeclaration` exactly as raku does.
+  One proto plus any number of `multi`s stays one routine.
+
+Two hoist passes were also emitting registrations that did not identify
+themselves as hoist passes, which made a perfectly valid
+`{ our proto f($) {*}; our multi f(Int $x) {...} }` die with "Cannot declare
+individual multi candidates in 'our' scope" — the hoisted `our multi` registered
+before the block's own `our proto` had run. `hoist_nested_our_subs` and the
+statement-form bare block's own hoist loop in `Stmt::Block` now add the `__hoisted`
+marker that `hoist_sub_decls` has always added, so the check is enforced by the
+in-sequence registration (which runs after the proto) instead of by the pre-pass.
+
+## Verified against raku
+
+`t/multi-proto-lexical-scope.t` pins 18 assertions, all measured against Rakudo
+v2026.06 first: inner-proto shadowing in a bare block and in a routine body, a
+differently-shaped inner proto, an inner `multi` with no inner proto *extending*
+the enclosing proto (the common Raku pattern — it must stay a merge), an inner
+proto shadowing an outer single sub, both same-scope redeclaration errors,
+`our proto`/`our multi` in a nested block, and operator-name candidates merging
+across scopes.
+
+An inner `multi` with no inner proto was already correct before this change: raku
+merges it into the enclosing proto's candidate set and reports `Ambiguous call` for
+two identical signatures, and so did mutsu.

--- a/src/compiler/helpers_ast_utils.rs
+++ b/src/compiler/helpers_ast_utils.rs
@@ -373,6 +373,18 @@ impl Compiler {
                     custom_traits.retain(|(t, _)| {
                         t.starts_with("__") || t == "default" || t.starts_with("DEPRECATED")
                     });
+                    // This IS a hoist-pass registration, so say so — exactly as
+                    // `hoist_sub_decls` does. Without the marker an `our multi`
+                    // lifted out of a nested block registered here, at the
+                    // compunit head, long before the block's own `our proto` had
+                    // run, and the "Cannot declare individual multi candidates in
+                    // 'our' scope" check fired on a perfectly valid
+                    // `{ our proto f(...) {*}; our multi f(...) {...} }`. The
+                    // in-sequence registration inside the block runs after the
+                    // proto and enforces the check for real.
+                    if !custom_traits.iter().any(|(t, _)| t == "__hoisted") {
+                        custom_traits.push(("__hoisted".to_string(), None));
+                    }
                     *name
                 }
                 _ => unreachable!("collect() only pushes SubDecl statements"),
@@ -443,22 +455,27 @@ impl Compiler {
     /// [`Compiler::lexical_dup_routines`].
     pub(super) fn mark_lexical_body(&mut self, body: &[Stmt]) {
         self.in_lexical_scope = true;
-        let mut all_multi: HashMap<String, bool> = HashMap::new();
+        // Per name: (protos, singles, multis) declared directly in this body.
+        // One `proto` plus any number of `multi`s is ONE routine, not a
+        // redeclaration; a second `proto`, a second single, or a single mixed
+        // with either really is one (raku raises X::Redeclaration for all three).
+        let mut tally: HashMap<String, (usize, usize, usize)> = HashMap::new();
         for stmt in body {
-            if let Stmt::SubDecl { name, multi, .. } = stmt {
-                let name = name.resolve();
-                match all_multi.get(&name) {
-                    None => {
-                        all_multi.insert(name, *multi);
-                    }
-                    Some(prev_all_multi) => {
-                        // Several `multi`s of one name are one routine, not a
-                        // redeclaration; anything else in the mix conflicts.
-                        if !(*prev_all_multi && *multi) {
-                            self.lexical_dup_routines.insert(name);
-                        }
-                    }
-                }
+            let (name, is_proto, is_multi) = match stmt {
+                Stmt::ProtoDecl { name, .. } => (name.resolve(), true, false),
+                Stmt::SubDecl { name, multi, .. } => (name.resolve(), false, *multi),
+                _ => continue,
+            };
+            let (protos, singles, multis) = tally.entry(name.clone()).or_default();
+            if is_proto {
+                *protos += 1;
+            } else if is_multi {
+                *multis += 1;
+            } else {
+                *singles += 1;
+            }
+            if *protos > 1 || *singles > 1 || (*singles == 1 && *protos + *multis > 0) {
+                self.lexical_dup_routines.insert(name);
             }
         }
     }

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -1141,6 +1141,23 @@ impl Compiler {
                                         || t == "default"
                                         || t.starts_with("DEPRECATED")
                                 });
+                                // Mark this copy as a hoist-pass registration,
+                                // exactly as `hoist_sub_decls` does for the
+                                // value-position (inline) block path. Without the
+                                // marker the pre-pass looked like a real
+                                // declaration, and an `our multi` inside a
+                                // statement-form bare block hit the "Cannot
+                                // declare individual multi candidates in 'our'
+                                // scope" check here — before the block's own
+                                // `our proto` had run. The in-sequence
+                                // registration below runs after the proto and
+                                // enforces the check for real.
+                                if !custom_traits.iter().any(|(t, _)| t == "__lexical_hoist") {
+                                    custom_traits.push(("__lexical_hoist".to_string(), None));
+                                }
+                                if !custom_traits.iter().any(|(t, _)| t == "__hoisted") {
+                                    custom_traits.push(("__hoisted".to_string(), None));
+                                }
                             }
                             self.compile_stmt(&hoisted);
                         }
@@ -4293,10 +4310,31 @@ impl Compiler {
                 return_type,
                 body,
                 is_method,
+                custom_traits,
                 ..
             } => {
                 self.note_operator_decl(&name.resolve());
-                let idx = self.code.add_proto_decl_plan(stmt);
+                // A `proto` declared inside a routine/closure BODY is lexical to
+                // that body and shadows an outer routine of the same name rather
+                // than redeclaring it. The registry is keyed by `Package::name`,
+                // so registration cannot tell the two apart on its own — mark the
+                // plan the same way `hoist_sub_decls` marks a body-local
+                // `SubDecl`. (A bare block needs no marker: `block_scope_depth`
+                // is already non-zero while its body runs.) The marker is
+                // internal, so the `trait_mod:<is>` loop in
+                // `exec_register_proto_sub_op` skips it like every other `__`
+                // trait.
+                let body_local =
+                    self.in_lexical_scope && !self.lexical_dup_routines.contains(&name.resolve());
+                let idx = if body_local && !custom_traits.iter().any(|t| t == "__lexical_hoist") {
+                    let mut marked = stmt.clone();
+                    if let Stmt::ProtoDecl { custom_traits, .. } = &mut marked {
+                        custom_traits.push("__lexical_hoist".to_string());
+                    }
+                    self.code.add_proto_decl_plan(&marked)
+                } else {
+                    self.code.add_proto_decl_plan(stmt)
+                };
                 // A trivial proto body (empty, or a bare `{*}`) dispatches
                 // implicitly and has no candidate body of its own to compile
                 // (mirrors `vm_resolve_trivial_proto_candidate`'s gate). A

--- a/src/runtime/registration_sub.rs
+++ b/src/runtime/registration_sub.rs
@@ -1705,6 +1705,7 @@ impl Interpreter {
         body: &[Stmt],
         is_our: bool,
         compiled: Option<&crate::opcode::CompiledFunction>,
+        is_lexical_hoist: bool,
     ) -> Result<(), RuntimeError> {
         let key = format!("{}::{}", self.current_package(), name);
         // `our proto sub f(|) {*}` makes the whole multi a package symbol. Its
@@ -1716,15 +1717,38 @@ impl Interpreter {
         if is_our {
             self.mark_our_scoped_package_item(key.clone());
         }
-        if self
-            .registry()
-            .functions
-            .contains_key(&Symbol::intern(&key))
-        {
-            return Err(RuntimeError::redeclaration_routine(name));
-        }
-        if self.registry().proto_subs_contains(&key) {
-            return Err(RuntimeError::redeclaration_routine(name));
+        // A `proto` declared inside an inner lexical scope SHADOWS an outer
+        // routine of the same name instead of redeclaring it: raku gives the
+        // inner proto a fresh candidate set, and the outer routine comes back
+        // when the scope exits. mutsu's registry is keyed by the fully-qualified
+        // `Package::name`, so both protos collide on one key; the block-scope
+        // routine-registry snapshot/restore (`snapshot_routine_registry`) is what
+        // makes the shadow come back, exactly as it does for a plain `my sub`.
+        // Without this exemption a perfectly valid inner `proto` was rejected
+        // outright with "Redeclaration of routine". Mirrors the identical
+        // exemption in `register_sub_decl_with_metadata`; EVAL is excluded there
+        // for the same reason (an EVAL'd declaration has its own restore path and
+        // its own outer-name bookkeeping).
+        let allow_lexical_shadow = (self.block_scope_depth > 0 || is_lexical_hoist)
+            && !matches!(
+                self.env.get("__mutsu_in_eval").map(Value::view),
+                Some(ValueView::Bool(true))
+            )
+            && !matches!(
+                self.env.get("__mutsu_eval_wrapped_decls").map(Value::view),
+                Some(ValueView::Bool(true))
+            );
+        if !allow_lexical_shadow {
+            if self
+                .registry()
+                .functions
+                .contains_key(&Symbol::intern(&key))
+            {
+                return Err(RuntimeError::redeclaration_routine(name));
+            }
+            if self.registry().proto_subs_contains(&key) {
+                return Err(RuntimeError::redeclaration_routine(name));
+            }
         }
         let prefix = format!("{key}/");
         self.registry_mut().functions.retain(|existing, _| {

--- a/src/vm/vm_register_sub_ops.rs
+++ b/src/vm/vm_register_sub_ops.rs
@@ -1160,6 +1160,10 @@ impl Interpreter {
         // pattern, SBOM::CycloneDX). Skip the package-level registration for
         // method protos; the method-table path already handles them.
         if !*is_method {
+            // Marked by the compiler when this `proto` is declared directly in a
+            // routine/closure body, where it lexically shadows an outer routine
+            // of the same name instead of redeclaring it.
+            let is_lexical_hoist = custom_traits.iter().any(|t| t == "__lexical_hoist");
             self.register_proto_decl(
                 &name_str,
                 params,
@@ -1168,6 +1172,7 @@ impl Interpreter {
                 body,
                 *is_our,
                 compiled,
+                is_lexical_hoist,
             )?;
         }
         if *is_export {

--- a/t/multi-proto-lexical-scope.t
+++ b/t/multi-proto-lexical-scope.t
@@ -1,0 +1,131 @@
+use Test;
+
+# `proto`/`multi sub` declarations are lexically scoped, exactly like a plain
+# `sub`. mutsu's routine registry is keyed by the fully-qualified
+# `Package::name`, so an inner scope's `proto` collided with an outer one and
+# was rejected outright with "Redeclaration of routine 'foo'" -- valid Raku
+# refused at declaration time. Every expectation below was measured against
+# Rakudo v2026.06 (2026-09-04) first; raku is the oracle.
+#
+# The inner scopes below are statement-form bare blocks on purpose: a
+# value-position `do { ... }` block does not yet restore the routine registry
+# in mutsu (it leaks a block-local plain `sub` too), which is a separate
+# defect -- see todo/tickets/do-block-does-not-scope-routine-declarations.md.
+
+plan 18;
+
+# --- 1. plain single sub shadowing (was already correct; guard it) ----------
+{
+    sub s1() { "outer" }
+    my $inner;
+    { sub s1() { "inner" }; $inner = s1(); }
+    is $inner, "inner", "plain sub shadows in an inner block";
+    is s1(), "outer", "the outer plain sub comes back after the block";
+}
+
+# --- 2. proto+multi shadowed in an inner block ------------------------------
+{
+    proto sub s2($) {*}
+    multi sub s2(Int $x) { "outer" }
+    my $inner;
+    {
+        proto sub s2($) {*}
+        multi sub s2(Int $x) { "inner" }
+        $inner = s2(5);
+    }
+    is $inner, "inner", "an inner proto+multi shadows the outer one";
+    is s2(5), "outer", "the outer proto+multi comes back after the block";
+}
+
+# --- 3. the same, inside a routine body instead of a bare block -------------
+{
+    proto sub s3($) {*}
+    multi sub s3(Int $x) { "outer" }
+    sub s3-caller() {
+        proto sub s3($) {*}
+        multi sub s3(Int $x) { "inner" }
+        s3(5);
+    }
+    is s3-caller(), "inner", "an inner proto+multi in a sub body shadows the outer one";
+    is s3(5), "outer", "the outer proto+multi survives the sub body";
+}
+
+# --- 4. a differently-shaped inner proto (`|`) shadows just as well ---------
+{
+    proto sub s4($) {*}
+    multi sub s4(Int $x) { "outer" }
+    my $inner;
+    {
+        proto sub s4(|) {*}
+        multi sub s4(Int $x) { "inner" }
+        $inner = s4(5);
+    }
+    is $inner, "inner", "an inner proto with a different signature shadows too";
+    is s4(5), "outer", "the outer proto comes back after that block";
+}
+
+# --- 5. an inner `multi` with NO inner proto EXTENDS the outer proto --------
+# This is the common Raku pattern: a nested scope adds a candidate to the
+# proto already in scope. It must keep working.
+{
+    proto sub s5($) {*}
+    multi sub s5(Int $x) { "outer-int" }
+    my @seen;
+    {
+        multi sub s5(Str $x) { "inner-str" }
+        @seen = s5(5), s5("a");
+    }
+    is @seen.join("|"), "outer-int|inner-str",
+        "an inner multi adds a candidate to the enclosing proto";
+    is s5(5), "outer-int", "the outer candidate still answers after the block";
+}
+
+# --- 6. an inner proto shadowing an outer *single* sub ----------------------
+{
+    sub s6($x) { "outer-single" }
+    my $inner;
+    {
+        proto sub s6($) {*}
+        multi sub s6(Int $x) { "inner-multi" }
+        $inner = s6(5);
+    }
+    is $inner, "inner-multi", "an inner proto+multi shadows an outer single sub";
+    is s6(5), "outer-single", "the outer single sub comes back after the block";
+}
+
+# --- 7. a genuine redeclaration inside ONE scope is still an error ----------
+dies-ok { EVAL 'sub s7a() { proto d7a($) {*}; proto d7a($) {*}; multi d7a(Int $x) { 1 }; d7a(2) }; s7a()' },
+    "two protos of one name in one lexical scope still redeclare";
+dies-ok { EVAL 'sub s7b() { proto d7b($) {*}; sub d7b($x) { 1 }; d7b(2) }; s7b()' },
+    "a proto plus a single sub of one name in one scope still redeclare";
+
+# --- 8. `our proto` / `our multi` -------------------------------------------
+# `our multi` needs an our-scoped proto at every scope level; with one it is
+# fine, including inside a nested block.
+{
+    my $r;
+    {
+        our proto s8($) {*}
+        our multi s8(Int $x) { "inner" }
+        $r = s8(5);
+    }
+    is $r, "inner", "our proto + our multi inside a nested block works";
+}
+dies-ok { EVAL 'our multi d8(Int $x) { 1 }' },
+    "a bare `our multi` with no our-scoped proto is still rejected";
+
+# --- 9. operator names keep merging candidates across scopes ----------------
+# Many modules independently add candidates under one operator name; that must
+# stay a merge, not a shadow.
+{
+    multi sub infix:<mplsop>(Int $a, Int $b) { "ii" }
+    multi sub infix:<mplsop>(Str $a, Str $b) { "ss" }
+    my @seen;
+    {
+        multi sub infix:<mplsop>(Num $a, Num $b) { "nn" }
+        @seen = (1e0 mplsop 2e0), (1 mplsop 2), ("a" mplsop "b");
+    }
+    is @seen.join("|"), "nn|ii|ss",
+        "an inner operator candidate merges with the enclosing ones";
+    is (1 mplsop 2), "ii", "the outer operator candidates survive the block";
+}

--- a/todo/tickets/do-block-does-not-scope-routine-declarations.md
+++ b/todo/tickets/do-block-does-not-scope-routine-declarations.md
@@ -1,0 +1,65 @@
+# A `do { ... }` block does not scope the routine declarations inside it
+
+A routine declared inside a value-position `do { ... }` block leaks into the
+enclosing scope and permanently replaces a same-named outer routine. The
+statement-form bare block `{ ... }` gets this right; only the `do` form does not.
+
+Measured against Rakudo v2026.06 on 2026-09-04:
+
+```raku
+sub foo() { "outer" }
+my $inner = do { sub foo() { "inner" }; foo() };
+say $inner;   # raku: inner   mutsu: inner
+say foo();    # raku: outer   mutsu: inner   <-- WRONG
+```
+
+The statement form is correct today:
+
+```raku
+sub foo() { "outer" }
+my $inner;
+{ sub foo() { "inner" }; $inner = foo(); }
+say $inner;   # inner
+say foo();    # outer   <-- correct in both
+```
+
+This is not specific to `multi`/`proto` — a plain single `sub` leaks the same way,
+and so does the whole proto/candidate family (an inner `proto`+`multi` inside a
+`do` block keeps answering calls made after the block).
+
+## Root cause
+
+The block-scope machinery that makes lexical routine declarations work is the
+routine-registry snapshot/restore pair `snapshot_routine_registry` /
+`restore_routine_registry` (`src/runtime/accessors_misc.rs`). `OpCode::BlockScope`
+takes it unconditionally (`src/vm/vm_misc_scope.rs`, around the
+`routine_snapshot` binding), and so does every routine call and every for-loop body
+that declares routines (`src/vm/vm_for_loop_dispatch.rs`, gated on
+`Compiler::stmts_declare_routines`).
+
+`OpCode::DoBlockExpr` takes none of it. `Compiler::compile_do_block_expr`
+(`src/compiler/helpers_do_expr.rs`) emits `DoBlockExpr { scope_isolate: false, ... }`
+and then `compile_block_inline`s the body straight into the enclosing code; the VM
+side (`src/vm/vm_misc_block.rs`) only saves/restores `env` when `scope_isolate` is
+set, and the registry is never involved either way. So the body's `RegisterDecl`s
+write into the enclosing scope's registry and nothing puts the outer entries back.
+
+## Why this is more than a one-liner
+
+The obvious fix is to snapshot/restore the routine registry around `DoBlockExpr`
+when the body declares routines — `Compiler::stmts_declare_routines` already exists
+for exactly this decision, and the for-loop path is the precedent to copy. But:
+
+- it needs a new compile-time flag on `OpCode::DoBlockExpr` (watch the 48-byte
+  `opcode_size_guard`; the variant currently has spare padding), and
+- `do { ... }` is everywhere in the corpus, so any routine that a `do` block
+  currently leaks into an enclosing scope and that something later calls will stop
+  resolving. That is the correct semantics, but the blast radius wants a full
+  roast + batteries run, not a targeted sweep.
+
+## Repro files
+
+The four-line repro above. `t/multi-proto-lexical-scope.t` deliberately uses
+statement-form bare blocks with an outer `my $x` instead of `do { ... }` because of
+this bug; when it is fixed, that test can be simplified back to the `do` form (raku
+passes both shapes).

--- a/todo/tickets/package-body-proto-multi-not-lexical-to-the-package.md
+++ b/todo/tickets/package-body-proto-multi-not-lexical-to-the-package.md
@@ -1,0 +1,90 @@
+# A `proto`/`multi sub` declared in a class or module body is not lexical to it
+
+A plain `sub` declared in a `class`/`module` body is lexical to that body: the
+package's own methods see it, and it neither collides with nor shadows a
+same-named mainline sub. mutsu gets this right for a single `sub` and wrong for a
+`proto`+`multi` family.
+
+All measured against Rakudo v2026.06 on 2026-09-04.
+
+## Correct today (the single-sub baseline)
+
+```raku
+sub foo($x) { "mainline" }
+class C {
+    sub foo($x) { "in-class" }
+    method m() { foo(5) }
+}
+say C.m();    # raku: in-class   mutsu: in-class
+say foo(5);   # raku: mainline   mutsu: mainline
+```
+
+The `module M { sub foo(...); our sub go() { foo(5) } }` twin is correct too.
+
+## Wrong: class body
+
+```raku
+class C {
+    proto sub foo($) {*}
+    multi sub foo(Int $x) { "in-class" }
+    method m() { foo(5) }
+}
+say C.m();
+# raku:  in-class
+# mutsu: Unknown function: foo   (in sub m)
+```
+
+A class-body `proto`+`multi` family is not reachable from the class's own methods
+at all, even with no mainline `foo` in the picture. Add a mainline `foo` and the
+method silently calls *that* one instead:
+
+```raku
+sub foo($x) { "mainline" }
+class C {
+    proto sub foo($) {*}
+    multi sub foo(Int $x) { "in-class" }
+    method m() { foo(5) }
+}
+say C.m();    # raku: in-class   mutsu: mainline
+say foo(5);   # raku: mainline   mutsu: mainline
+```
+
+## Wrong: module body
+
+```raku
+module M {
+    proto sub foo($) {*}
+    multi sub foo(Int $x) { "in-module" }
+    our sub go() { foo(5) }
+}
+proto sub foo($) {*}
+multi sub foo(Int $x) { "mainline" }
+say M::go();
+# raku:  in-module
+# mutsu: Ambiguous call to foo(Int); these signatures all match: (Int $x), (Int $x)
+say foo(5);   # raku: mainline
+```
+
+Without the mainline `foo` this works (`M::go()` returns `in-module`), so the two
+candidate sets are being *merged* across the package boundary rather than one
+shadowing the other. The registry keys differ (`M::foo/1:Int` vs
+`GLOBAL::foo/1:Int`), so this is a resolution-side problem, not a registration
+collision: multi resolution for a bare name reached from inside `M` gathers
+candidates from both `M::` and `GLOBAL::` and ranks them together.
+
+## Why this is not the lexical-shadow fix
+
+`news/2026-09/proto-multi-lexical-scope.md` fixed the *registration* side: an inner
+lexical scope may now declare its own `proto` without a spurious
+`X::Redeclaration`, and the block-scope registry snapshot/restore brings the outer
+one back. That machinery is keyed on `block_scope_depth` / `__lexical_hoist` and on
+the `Package::name` registry key, and it works because both declarations share one
+key. A package body registers under a *different* key, so nothing shadows and the
+defect surfaces in `resolve_function_with_types` / the multi-candidate gather
+instead — a different code path with a different fix.
+
+Start from `src/runtime/dispatch_resolve.rs` and the multi-candidate gather in
+`src/runtime/registration_sub.rs` (`insert_multi_overload`'s `Pkg::name/arity:types`
+keys), and work out how a bare-name call inside package `P` should rank `P::`
+candidates against `GLOBAL::` ones. The single-sub path already answers that
+question correctly for one key; the multi gather does not.


### PR DESCRIPTION
## The bug

An inner lexical scope that declares its own `proto` was rejected outright:

```raku
proto sub foo($) {*}
multi sub foo(Int $x) { "outer" }
{ proto sub foo($) {*}; multi sub foo(Int $x) { "inner" }; say foo(5); }
say foo(5);
# raku:  inner / outer
# mutsu: Redeclaration of routine 'foo'. Did you mean to declare a multi-sub?
```

The same shape inside a routine body (`sub bar() { proto sub foo($){*}; multi sub
foo(Int $x){...} }`) failed identically. This is valid Raku refused at declaration
time, so nothing after it could run.

## Root cause

The routine registry is keyed by the fully-qualified `Package::name`, so an inner
`proto foo` and an outer `proto foo` collide on one key (`GLOBAL::foo`). Plain
single subs already survive that: the block-scope routine-registry
snapshot/restore (`snapshot_routine_registry` / `restore_routine_registry`, taken
around every `BlockScope` and every routine call) puts the outer routine back when
the scope exits, and `register_sub_decl_with_metadata` has an explicit
`allow_lexical_shadow` exemption so the inner declaration is not reported as a
redeclaration on the way in.

`register_proto_decl` never got that exemption. It raised `X::Redeclaration`
unconditionally whenever `functions` or `proto_subs` already held the key, with no
notion of which scope the existing entry belonged to.

The proto side needed one piece more than the sub side: a `proto` declared
directly in a *routine body* is not covered by `block_scope_depth`, because a sub
body's declarations register at a point where that counter is still zero.
`Stmt::SubDecl` solves that with the compiler-set `__lexical_hoist` marker;
`Stmt::ProtoDecl` carried no such marker.

### Note for ADR-0041 §1.2 (not edited here — you have it open in a parallel branch)

§1.2 describes this as *"the redeclaration check is name-based and scope-blind for
plain subs"*. Measured on a fresh debug build of `main` (b0a4fdae0) against Rakudo
v2026.06 on 2026-09-04, that attribution is inverted: **plain single subs shadow
correctly**; it is `proto`/`multi` that was scope-blind. Also worth folding in:
case 4 of the family (an inner `multi` with **no** inner proto) was **already
correct** — raku merges it into the enclosing proto's candidate set and reports
`Ambiguous call` for two identical signatures, and so did mutsu.

## What changed

- `register_proto_decl` takes an `is_lexical_hoist` flag and computes the same
  `allow_lexical_shadow` predicate as `register_sub_decl_with_metadata`
  (`block_scope_depth > 0 || is_lexical_hoist`, minus the EVAL cases). When
  shadowing is allowed the two redeclaration checks are skipped; the purge of the
  outer name's candidates that already followed them gives the inner proto a fresh
  candidate set, and the snapshot/restore brings the outer one back.
- The compiler marks a body-local `Stmt::ProtoDecl` `__lexical_hoist`, the way
  `hoist_sub_decls` marks a body-local `Stmt::SubDecl`.
- `mark_lexical_body` now tallies protos as well as singles and multis, so a
  **genuine** same-scope redeclaration (two protos of one name, or a proto plus a
  single sub of one name) still raises `X::Redeclaration` exactly as raku does. One
  proto plus any number of `multi`s stays one routine.

Two hoist passes were also emitting registrations that did not identify themselves
as hoist passes, which made a valid
`{ our proto f($) {*}; our multi f(Int $x) {...} }` die with "Cannot declare
individual multi candidates in 'our' scope" — the hoisted `our multi` registered
before the block's own `our proto` had run. `hoist_nested_our_subs` and the
statement-form bare block's own hoist loop in `Stmt::Block` now add the `__hoisted`
marker that `hoist_sub_decls` has always added, so the check is enforced by the
in-sequence registration (which runs after the proto) instead of by the pre-pass.

## Verification

- `t/multi-proto-lexical-scope.t`: 18 assertions, **every one measured against
  Rakudo v2026.06 first**. Inner-proto shadowing in a bare block and in a routine
  body; a differently-shaped inner proto (`(|)` over `($)`); an inner `multi` with
  no inner proto *extending* the enclosing proto (the common Raku pattern — it must
  stay a merge, not a shadow); an inner proto shadowing an outer single sub; both
  same-scope redeclaration errors; `our proto`/`our multi` in a nested block and a
  bare `our multi` still rejected; operator-name (`infix:<…>`) candidates merging
  across scopes.
- `make test`: **All tests successful** — Files=3631, Tests=36756, Result: PASS.
- Targeted roast sweep over the declaration/multi-dispatch area (every whitelisted
  `S04-declarations`, `S06*`, `S10-packages`, `S11-modules`, `S14*` file):
  **Files=148, Tests=3528, Result: PASS**.
- `cargo fmt` clean, `cargo clippy -- -D warnings` clean.

## Filed, not fixed here

Two neighbouring defects found while measuring, both distinct root causes:

- `todo/tickets/do-block-does-not-scope-routine-declarations.md` — a
  value-position `do { ... }` block does not restore the routine registry at all
  (`compile_do_block_expr` inlines the body with no snapshot), so a plain `sub`
  declared inside one leaks into the enclosing scope. Not proto-specific.
  `t/multi-proto-lexical-scope.t` uses statement-form bare blocks because of this.
- `todo/tickets/package-body-proto-multi-not-lexical-to-the-package.md` — a
  `proto`+`multi` in a class body is unreachable from that class's own methods
  ("Unknown function"), and a module-body one *merges* with a same-named mainline
  family instead of shadowing it. The single-sub equivalents are correct today, so
  this is a resolution-side problem across differing registry keys, not the
  same-key shadow this PR fixes.
