### PR TITLE
fix: make inline module exports available in CHECK

### DIFF
--- a/src/runtime/accessors_stash.rs
+++ b/src/runtime/accessors_stash.rs
@@ -573,7 +573,11 @@ impl Interpreter {
 
         for (key, val) in self.env.iter() {
             let key_s = key.resolve();
-            if key_s.starts_with("__mutsu_callable_id::") {
+            // Internal bookkeeping markers use package-like separators (for
+            // example, the inline-package prepass marker contains
+            // `::Exporter::exported`). They must not appear as pseudo-package
+            // members when a named package's stash is assembled.
+            if key_s.starts_with("__mutsu_") {
                 continue;
             }
             if (package_name == "MY" || package_name == "GLOBAL")

--- a/src/runtime/builtins_dispatch_next.rs
+++ b/src/runtime/builtins_dispatch_next.rs
@@ -47,6 +47,27 @@ enum DispatchFrameKind {
 }
 
 impl Interpreter {
+    /// Return the built-in implementation of an infix operator for the final
+    /// leg of a `callsame` chain.  Core operators are not represented as
+    /// `FunctionDef`s in the multi-dispatch list, but Raku still exposes that
+    /// native candidate after a user-defined operator candidate.  Calling the
+    /// ordinary infix dispatcher here would select the user candidate again,
+    /// so use the pure native reduction implementation directly.
+    fn native_infix_next_candidate(
+        name: &str,
+        args: &[Value],
+    ) -> Option<Result<Value, RuntimeError>> {
+        let op = name.strip_prefix("infix:<")?.strip_suffix('>')?;
+        if args.len() != 2 {
+            return None;
+        }
+        match Self::apply_reduction_op(op, &args[0], &args[1]) {
+            Ok(value) => Some(Ok(value)),
+            Err(error) if error.message.starts_with("Unsupported reduction operator:") => None,
+            Err(error) => Some(Err(error)),
+        }
+    }
+
     /// ADR-0019 E9b-0: `wrap_dispatch_stack`, `method_dispatch_stack`, and
     /// `multi_dispatch_stack` are independent stacks, each stamped with a
     /// shared monotonic `dispatch_token` at push time. `callsame`/`nextsame`/
@@ -1268,6 +1289,16 @@ impl Interpreter {
                 }
             }
             let Some(idx) = matched_idx else {
+                // Core infix operators are implicit final candidates: they do
+                // not occur in `candidates`, but `callsame` from a user
+                // `infix:<op>` must still reach them.
+                if let Some(result) = Self::native_infix_next_candidate(&_name, &call_args) {
+                    let result = result?;
+                    if tail_call {
+                        return Err(RuntimeError::return_signal(result));
+                    }
+                    return Ok(result);
+                }
                 // No candidate matches — return Nil (nowhere to defer to)
                 if tail_call {
                     return Err(RuntimeError::return_signal(Value::NIL));

--- a/src/runtime/registration_sub.rs
+++ b/src/runtime/registration_sub.rs
@@ -1727,9 +1727,23 @@ impl Interpreter {
             return Err(RuntimeError::redeclaration_routine(name));
         }
         let prefix = format!("{key}/");
-        self.registry_mut().functions.retain(|existing, _| {
+        // A CHECK-time inline-package prepass may have installed the package's
+        // multi candidates before the proto's source-order registration. Keep
+        // those candidates when the proto clears stale entries; the ordinary
+        // RegisterDecl opcodes will recognize their pre-registration markers
+        // and skip the duplicate install later.
+        let inline_marker_prefix = format!(
+            "__mutsu_inline_package_sub_preregistered::{}::{}::",
+            self.current_package(),
+            name
+        );
+        let has_inline_markers = self
+            .env
+            .keys()
+            .any(|marker| marker.resolve().starts_with(&inline_marker_prefix));
+        self.registry_mut().functions.retain(|existing, _def| {
             let resolved = existing.resolve();
-            resolved != key && !resolved.starts_with(&prefix)
+            resolved != key && (!resolved.starts_with(&prefix) || has_inline_markers)
         });
         // Invalidate name-keyed resolution caches.
         self.fn_resolve_gen += 1;

--- a/src/runtime/run.rs
+++ b/src/runtime/run.rs
@@ -574,6 +574,7 @@ impl Interpreter {
         self.check_eval_param_type_constraints(&body_main)?;
         self.check_type_capture_inheritance(&body_main)?;
         self.preregister_top_level_subs(&body_main)?;
+        self.preregister_inline_package_subs(&body_main)?;
         // Rakudo rejects a call to a routine declared nowhere in the unit at
         // CHECK time, before anything runs (X::Undeclared::Symbols).
         self.check_undeclared_routines_mainline(&body_main)?;

--- a/src/runtime/run_prelude.rs
+++ b/src/runtime/run_prelude.rs
@@ -361,6 +361,220 @@ impl Interpreter {
         self.otf_compile_function_def(&tmp_def)
     }
 
+    /// Register the routines declared by an inline package before CHECK
+    /// phasers run.  Raku makes an inline package's interface available during
+    /// compilation, but keeps the package body's procedural statements in
+    /// their normal runtime order.  `reorder_phasers` therefore places a
+    /// top-level `module` after CHECK; without this declaration-only pass an
+    /// import from CHECK sees neither the package's routines nor its exports.
+    ///
+    /// This deliberately compiles only routine bodies.  Executing the package
+    /// body here would change observable ordering (for example, a `say` in the
+    /// module must still happen after CHECK), while the routine registry and
+    /// export table are the compile-time interface needed by `import`.
+    pub(crate) fn preregister_inline_package_subs(
+        &mut self,
+        stmts: &[Stmt],
+    ) -> Result<(), RuntimeError> {
+        let mut declarations = Vec::new();
+        Self::collect_inline_package_subs(stmts, "GLOBAL", &mut declarations);
+
+        for (package, stmt) in declarations {
+            let Stmt::SubDecl {
+                name,
+                params,
+                param_defs,
+                return_type,
+                associativity,
+                signature_alternates,
+                body,
+                multi,
+                is_rw,
+                is_raw,
+                is_export,
+                export_tags,
+                is_test_assertion,
+                supersede,
+                custom_traits,
+                ..
+            } = stmt
+            else {
+                unreachable!("package routine collector returned a non-sub declaration");
+            };
+
+            // Declaration-only registration cannot safely apply a user trait:
+            // its argument may need the package body (or a preceding `use`) to
+            // have run. Leave those declarations to the normal package-body
+            // registration pass. Built-in/internal traits below are fully
+            // represented by the metadata passed to the registrar.
+            if custom_traits.iter().any(|(trait_name, _)| {
+                !trait_name.starts_with("__")
+                    && trait_name != "default"
+                    && !trait_name.starts_with("DEPRECATED")
+                    && trait_name != "hidden-from-USAGE"
+            }) {
+                continue;
+            }
+
+            let saved_package = self.current_package();
+            self.set_current_package(package.clone());
+
+            let site_fingerprint = crate::ast::sub_registration_fingerprint(
+                &params,
+                &param_defs,
+                &body,
+                return_type.as_ref(),
+                multi,
+                is_rw,
+                is_raw,
+            );
+
+            let metadata = crate::opcode::compiled_routine_metadata(
+                &params,
+                &param_defs,
+                &body,
+                is_rw,
+                is_raw,
+            );
+            let compiled =
+                self.compile_forward_declared_sub(name, &params, &param_defs, &body, is_rw, is_raw);
+            let traits: Vec<(String, Option<crate::opcode::DeclTraitArg>)> = custom_traits
+                .iter()
+                .filter(|(trait_name, _)| {
+                    trait_name.starts_with("__")
+                        || *trait_name == "default"
+                        || trait_name.starts_with("DEPRECATED")
+                        || *trait_name == "hidden-from-USAGE"
+                })
+                .map(|(trait_name, _)| (trait_name.clone(), None))
+                .collect();
+            let result = (|| {
+                let result = self.register_compiled_sub_decl(
+                    &name.resolve(),
+                    &params,
+                    &param_defs,
+                    return_type.as_ref(),
+                    associativity.as_ref(),
+                    &[],
+                    multi,
+                    is_rw,
+                    is_raw,
+                    is_test_assertion,
+                    supersede,
+                    &traits,
+                    Some(site_fingerprint),
+                    &metadata,
+                    Some(&compiled),
+                );
+
+                if matches!(
+                    &result,
+                    Ok(crate::runtime::registration_sub::SubRegisterOutcome::Installed)
+                ) {
+                    if is_export && !self.suppress_exports {
+                        self.register_exported_sub(package.clone(), name.resolve(), export_tags);
+                    }
+                    for (alt_params, alt_param_defs) in &signature_alternates {
+                        let alt_metadata = crate::opcode::compiled_routine_metadata(
+                            alt_params,
+                            alt_param_defs,
+                            &body,
+                            is_rw,
+                            is_raw,
+                        );
+                        let alt_compiled = self.compile_forward_declared_sub(
+                            name,
+                            alt_params,
+                            alt_param_defs,
+                            &body,
+                            is_rw,
+                            is_raw,
+                        );
+                        self.register_sub_alternate_decl(
+                            &name.resolve(),
+                            alt_params,
+                            alt_param_defs,
+                            return_type.as_ref(),
+                            associativity.as_ref(),
+                            &[],
+                            multi,
+                            is_rw,
+                            is_raw,
+                            is_test_assertion,
+                            supersede,
+                            &traits,
+                            Some(&alt_metadata),
+                            Some(&alt_compiled),
+                        )?;
+                    }
+                }
+                result
+            })();
+
+            let installed = matches!(
+                &result,
+                Ok(crate::runtime::registration_sub::SubRegisterOutcome::Installed)
+            );
+            self.set_current_package(saved_package);
+            if installed {
+                self.env_mut().insert(
+                    format!(
+                        "__mutsu_inline_package_sub_preregistered::{package}::{}::{site_fingerprint}",
+                        name.resolve()
+                    ),
+                    Value::TRUE,
+                );
+            }
+            result?;
+        }
+        Ok(())
+    }
+
+    fn collect_inline_package_subs(
+        stmts: &[Stmt],
+        parent_package: &str,
+        out: &mut Vec<(String, Stmt)>,
+    ) {
+        for stmt in stmts {
+            match stmt {
+                Stmt::Package {
+                    name,
+                    body,
+                    is_unit: false,
+                    is_my: false,
+                    ..
+                } => {
+                    let name = name.resolve();
+                    let package = if let Some(absolute) = name.strip_prefix("GLOBAL::") {
+                        absolute.to_string()
+                    } else if parent_package == "GLOBAL" {
+                        name
+                    } else {
+                        format!("{parent_package}::{name}")
+                    };
+                    Self::collect_package_body_subs(body, &package, out);
+                }
+                Stmt::SyntheticBlock(inner) => {
+                    Self::collect_inline_package_subs(inner, parent_package, out);
+                }
+                _ => {}
+            }
+        }
+    }
+
+    fn collect_package_body_subs(body: &[Stmt], package: &str, out: &mut Vec<(String, Stmt)>) {
+        for stmt in body {
+            match stmt {
+                Stmt::SubDecl { .. } => out.push((package.to_string(), stmt.clone())),
+                Stmt::SyntheticBlock(inner) => Self::collect_package_body_subs(inner, package, out),
+                Stmt::Package { .. } => {
+                    Self::collect_inline_package_subs(std::slice::from_ref(stmt), package, out)
+                }
+                _ => {}
+            }
+        }
+    }
+
     /// Register top-level, non-empty sub bodies before execution so calls that appear
     /// earlier in source can resolve to later definitions.
     pub(crate) fn preregister_top_level_subs(

--- a/src/vm/vm_register_sub_ops.rs
+++ b/src/vm/vm_register_sub_ops.rs
@@ -244,6 +244,21 @@ impl Interpreter {
             } else {
                 name.resolve()
             };
+            // Inline package routines are registered once by the declaration-
+            // only prepass so CHECK can import them before the package body
+            // executes. The package body still contains its ordinary
+            // RegisterDecl opcodes; skip those copies, otherwise duplicate
+            // `multi` candidates make `callsame` redispatch through the same
+            // user routine repeatedly instead of reaching the native base.
+            let preregistered = site_fp.is_some_and(|fingerprint| {
+                self.env()
+                    .get(&format!(
+                        "__mutsu_inline_package_sub_preregistered::{}::{}::{fingerprint}",
+                        self.current_package(),
+                        resolved_name
+                    ))
+                    .is_some()
+            });
             // The hoist pre-pass (see `hoist_sub_decls`) registers this same
             // declaration early, purely so the name is callable before its
             // textual position — but a custom parameter trait like `is query`
@@ -256,6 +271,9 @@ impl Interpreter {
             let is_hoisted_pass = custom_traits.iter().any(|(t, _)| t == "__hoisted");
             if !is_hoisted_pass {
                 self.check_param_custom_traits(param_defs)?;
+            }
+            if preregistered {
+                return Ok(());
             }
             // ADR-0019 C6e-3c: a plan-derived def always registers with an
             // EMPTY body — its identity and dispatch run entirely from the

--- a/t/inline-module-check-import.t
+++ b/t/inline-module-check-import.t
@@ -1,0 +1,17 @@
+module FiniteField {
+    multi infix:<+>(UInt $a, UInt $b) is export { $*modulus Rmod callsame }
+    multi infix:<*>(UInt $a, UInt $b) is export { $*modulus Rmod callsame }
+    multi infix:<**>(UInt $a, Int $b) is export { expmod $a, $b, $*modulus }
+    multi infix:</>(UInt $a, UInt $b) is export { $a * $b**-1 }
+}
+
+CHECK {
+    use Test;
+    plan 1;
+
+    sub f($_) { $_**100 + $_ + 1 }
+
+    import FiniteField;
+    my $*modulus = 13;
+    is f(10), 1, 'an inline module can be imported from CHECK';
+}


### PR DESCRIPTION
Closes #7264

Summary:
- pre-register inline package subroutines and exports before CHECK without executing package bodies
- preserve source-order package registration and callsame fallback to native infix operators
- add a regression test for importing an inline module from CHECK

Tests:
- cargo fmt --all
- cargo clippy -- -D warnings
- make test
- make roast (all assertions passed; catch.t exits 124 after all 33 subtests under parallel timeout, and passes standalone)
- focused inline-module and package/import tests