### PR TITLE
fix(crash-report): give every spawned thread an alternate stack the handler fits in

### DIFF
--- a/news/2026-09/crash-reports-from-worker-threads.md
+++ b/news/2026-09/crash-reports-from-worker-threads.md
@@ -1,0 +1,74 @@
+# A fatal signal on a worker thread finally writes a crash report
+
+mutsu writes a crash report for a fatal signal (`src/crash_report/`) so that the one time a rare
+SIGSEGV fires on CI it leaves a thread name, an argv line and a backtrace behind instead of a bare
+`Wstat: 11`. Three times — CI runs 32968762746, 33154831894 and the original 30590633128 — the
+mechanism failed to capture the very crash it was installed for, and each recurrence cost a red CI
+run and yielded nothing (`todo/deep/procasync-stress-segv.md` §8.2).
+
+## It reproduces in one line
+
+No race needed:
+
+```
+$ MUTSU_CRASH_DIR=$PWD/tmp/crash mutsu -e 'use NativeCall; sub strdup(int64) is native(Str) {*}; strdup(0)'
+tmp/crash/1034030.txt        # main thread: report written
+$ MUTSU_CRASH_DIR=$PWD/tmp/crash mutsu -e 'use NativeCall; sub strdup(int64) is native(Str) {*}; await start { strdup(0) }'
+(nothing)                    # worker thread: no report
+```
+
+## The cause: the handler overflowed its own alternate signal stack
+
+`strace -f -e trace=sigaltstack` settles it in four lines (the worker is pid 1035196):
+
+```
+1035196 sigaltstack({ss_sp=0x72daeb614000, ss_flags=0, ss_size=8192}, NULL) = 0
+1035196 --- SIGSEGV {si_signo=SIGSEGV, si_code=SEGV_MAPERR, si_addr=NULL} ---
+1035196 --- SIGSEGV {si_signo=SIGSEGV, si_code=SEGV_ACCERR, si_addr=0x72daeb613848} ---
+1035196 +++ killed by SIGSEGV (core dumped) +++
+```
+
+`ss_size=8192` is **`std`'s** alternate signal stack: Rust installs a `SIGSTKSZ`-sized one on every
+thread it spawns, sized for its own guard-page check. mutsu's 256 KiB stack was installed only by
+the threads that call `crash_report::install()` — the process's first thread and `mutsu-main` — so a
+worker kept `std`'s. mutsu's handler needs more than 8 KiB (a 4 KiB path buffer, a 2 KiB header
+buffer, and the raw-backtrace frames), so on a worker it overflowed the alternate stack: the second
+SIGSEGV is at `0x…613848`, 0x7b8 bytes *below* the alternate stack's base. A fault inside a signal
+handler is fatal and silent, so the process died with nothing written.
+
+The signal *disposition* was never the problem. It is process-wide, and a `rust-gdb` breakpoint on
+the handler confirmed it did run on the worker — it just could not survive long enough to open the
+file. Of §8.2's three candidates this is the second one; the first ("no handler on that thread") and
+third ("`MUTSU_CRASH_DIR` did not reach the process") are both eliminated.
+
+## The fix
+
+Every thread mutsu spawns goes through one funnel, `builtins_system::spawn_registered_thread`, so
+that is where each worker now takes `crash_report::install_thread_alt_stack()` — an RAII guard that
+installs the 256 KiB stack and puts the previous one back when the thread exits, so a short-lived
+worker leaks nothing. It installs no handler: that half is process-wide and already done.
+
+| crash | before | after |
+| --- | --- | --- |
+| main thread | `thread: mutsu-main` | unchanged |
+| `start` block | *no report* | `thread: pool` |
+| `Thread.start` | *no report* | `thread: raku-thread` |
+| worker stack overflow | *no report*, bare SIGSEGV | `thread: pool` — **and** `std`'s "thread 'pool' has overflowed its stack" message, which the too-small stack was swallowing too |
+
+That last row is a second bug fixed by the same change: a worker's stack overflow used to die as an
+uninformative SIGSEGV, where the main thread's aborts with a diagnosis.
+
+## Pins
+
+`tests/crash_report.rs` grew `a_segv_on_a_worker_thread_is_reported` and
+`an_abort_on_a_worker_thread_is_reported`, driven by two new selftest modes
+(`MUTSU_CRASH_SELFTEST=segv-thread` / `abort-thread`) that fault on a thread spawned through the
+production `spawn_user_thread` path — so the test proves the *real* spawn installs the stack, not
+merely that one can be installed. Both assert the report's `thread:` field names the worker and its
+`tid:` differs from `pid:`.
+
+## What this does not fix
+
+`todo/deep/procasync-stress-segv.md` stays open: the underlying `advent2014-day05.t` / `stress.t`
+crash is still un-root-caused. What changed is that its next recurrence arrives with a thread name
+and a backtrace.

--- a/src/crash_report/handler.rs
+++ b/src/crash_report/handler.rs
@@ -44,8 +44,9 @@ pub(super) fn install() {
     if std::env::var("MUTSU_CRASH_REPORT").as_deref() == Ok("0") {
         return;
     }
-    // Per-thread: every caller gets its own alternate stack.
-    install_alt_stack();
+    // Per-thread: every caller gets its own alternate stack. The main thread's
+    // is never given back, so the previous one is dropped on the floor.
+    std::mem::forget(install_alt_stack());
     if INSTALLED.swap(true, Ordering::SeqCst) {
         return;
     }
@@ -70,21 +71,70 @@ pub(super) fn install() {
 }
 
 /// Give the calling thread a large alternate stack, so the handler still has
-/// somewhere to run when the fault *is* the stack running out. Without this a
-/// stack-overflow SIGSEGV would simply never reach the handler.
-fn install_alt_stack() {
+/// somewhere to run when the fault *is* the stack running out — and, just as
+/// importantly, so it has room to run *at all*.
+///
+/// Rust's runtime already installs an alternate stack on every thread it
+/// spawns, but it is `SIGSTKSZ`-sized (8 KiB on glibc/x86-64), sized for
+/// `std`'s own guard-page check. Our handler needs more than that (a 4 KiB
+/// path buffer, a 2 KiB header buffer and the raw-backtrace frames), so on a
+/// thread that keeps `std`'s stack the handler *overflows it and faults again*
+/// — silently, since a second fault inside the handler is fatal. That is
+/// exactly why a SIGSEGV on a worker thread used to leave no report at all
+/// (`todo/deep/procasync-stress-segv.md` §8.2, candidate 2).
+///
+/// Returns the stack this one replaced, wrapped in a guard: dropping it frees
+/// our stack and puts the previous one back, so a short-lived thread does not
+/// leak. Leak it with `std::mem::forget` for a thread that lives as long as
+/// the process.
+#[must_use = "dropping the guard immediately gives the alternate stack back"]
+fn install_alt_stack() -> AltStack {
     let mut stack = Vec::<u8>::with_capacity(ALT_STACK_SIZE);
     let ptr = stack.as_mut_ptr();
-    std::mem::forget(stack); // lives for the rest of the process
-    // SAFETY: `ptr` owns ALT_STACK_SIZE bytes that are never freed.
-    unsafe {
+    std::mem::forget(stack); // owned by the returned guard from here on
+    // SAFETY: `ptr` owns ALT_STACK_SIZE bytes, kept alive by the guard.
+    let previous = unsafe {
         let ss = libc::stack_t {
             ss_sp: ptr.cast(),
             ss_flags: 0,
             ss_size: ALT_STACK_SIZE,
         };
-        libc::sigaltstack(&ss, std::ptr::null_mut());
+        let mut old: libc::stack_t = std::mem::zeroed();
+        libc::sigaltstack(&ss, &mut old);
+        old
+    };
+    AltStack { ptr, previous }
+}
+
+/// Owns one thread's alternate signal stack; see [`install_alt_stack`].
+pub struct AltStack {
+    ptr: *mut u8,
+    previous: libc::stack_t,
+}
+
+impl Drop for AltStack {
+    fn drop(&mut self) {
+        // Restore first, so nothing is running on the memory we free next.
+        // A thread only reaches here on its own normal exit, never from inside
+        // the handler.
+        // SAFETY: `previous` is what `sigaltstack` handed back at install
+        // time, and `ptr` is the allocation made there.
+        unsafe {
+            libc::sigaltstack(&self.previous, std::ptr::null_mut());
+            drop(Vec::from_raw_parts(self.ptr, 0, ALT_STACK_SIZE));
+        }
     }
+}
+
+/// Give the calling thread its own alternate signal stack for as long as the
+/// guard lives. Unlike [`install`] this installs no handler — the disposition
+/// is process-wide and already set by the main thread — so it is exactly the
+/// per-thread half, and cheap enough to run on every worker mutsu spawns.
+pub(super) fn install_thread_alt_stack() -> Option<AltStack> {
+    if std::env::var("MUTSU_CRASH_REPORT").as_deref() == Ok("0") {
+        return None;
+    }
+    Some(install_alt_stack())
 }
 
 fn report_dir() -> Box<[u8]> {
@@ -180,12 +230,31 @@ fn hand_off(sig: c_int, si_code: c_int) {
 
 pub(super) fn selftest_if_requested() {
     match std::env::var("MUTSU_CRASH_SELFTEST").as_deref() {
-        Ok("segv") => {
-            // A real fault, so the report's si_addr is a real fault address.
-            // SAFETY: none — deliberately dereferencing null.
-            unsafe { std::ptr::null_mut::<u8>().write_volatile(1) };
-        }
+        Ok("segv") => crash_segv(),
         Ok("abort") => std::process::abort(),
+        // The same two faults, but on a worker spawned exactly the way a
+        // `start` block or a Supply tap is. That is the half the mechanism
+        // silently lacked: the handler is process-wide, so it *ran* on such a
+        // thread, then overflowed `std`'s 8 KiB alternate stack and died
+        // without writing anything. Faulting here goes through the real
+        // `spawn_user_thread` path, so the test proves the production spawn
+        // installs the stack — not merely that a stack can be installed.
+        Ok("segv-thread") => {
+            let _ =
+                crate::runtime::builtins_system::spawn_user_thread("selftest", crash_segv).join();
+        }
+        Ok("abort-thread") => {
+            let _ = crate::runtime::builtins_system::spawn_user_thread("selftest", || {
+                std::process::abort()
+            })
+            .join();
+        }
         _ => {}
     }
+}
+
+/// A real fault, so the report's `si_addr` is a real fault address.
+fn crash_segv() {
+    // SAFETY: none — deliberately dereferencing null.
+    unsafe { std::ptr::null_mut::<u8>().write_volatile(1) };
 }

--- a/src/crash_report/mod.rs
+++ b/src/crash_report/mod.rs
@@ -32,6 +32,15 @@
 //! `[profile.release]` sets `debug = false` — but the raw frame addresses can
 //! still be resolved offline with `addr2line -f -e target/release/mutsu`.
 //!
+//! The *alternate signal stack* is per-thread, and it is not optional: the
+//! handler needs more room than the 8 KiB `SIGSTKSZ` stack `std` gives every
+//! thread it spawns, so on a thread that keeps `std`'s it overflows and faults
+//! a second time — fatally and silently. Every thread mutsu spawns therefore
+//! takes [`install_thread_alt_stack`] in
+//! `builtins_system::spawn_registered_thread`. A thread mutsu does *not* spawn
+//! (a dependency's own worker) still gets no report; there is no portable hook
+//! for that, and mutsu has no such threads today.
+//!
 //! The default `tmp/crash` is resolved against the process's **startup**
 //! working directory, so a later `chdir` cannot move it — but a process that
 //! *starts* elsewhere (a subprocess spawned with `:cwd`, or one inheriting a
@@ -50,9 +59,10 @@ mod report;
 /// Install the fatal-signal handler and an alternate signal stack for the
 /// calling thread.
 ///
-/// Idempotent for the process-wide part; the alternate stack is per-thread, so
-/// calling this from a second thread gives that thread its own (leaking one
-/// stack allocation per call — call it from long-lived threads only).
+/// Idempotent for the process-wide part; the alternate stack is per-thread and
+/// this entry point never gives it back, so call it only from a thread that
+/// lives as long as the process. Worker threads take
+/// [`install_thread_alt_stack`] instead, whose guard frees the stack on exit.
 ///
 /// Disabled entirely by `MUTSU_CRASH_REPORT=0`. Reports are written to
 /// `tmp/crash` relative to the startup working directory, or to
@@ -62,11 +72,34 @@ pub fn install() {
     handler::install();
 }
 
+/// Give the calling thread the larger alternate signal stack the handler needs,
+/// for as long as the returned guard lives.
+///
+/// The signal *disposition* is process-wide and [`install`] has already set it,
+/// so a worker thread needs only this half. It is not optional: Rust gives every
+/// thread it spawns an 8 KiB `SIGSTKSZ` alternate stack, which the handler
+/// overflows — faulting a second time, fatally and silently, so the crash that
+/// most needs a report is the one that leaves none. Every thread mutsu spawns
+/// takes this guard in `builtins_system::spawn_registered_thread`.
+///
+/// Dropping the guard restores the previous alternate stack and frees ours, so
+/// a finished worker leaves nothing behind.
+#[cfg(all(unix, feature = "native"))]
+pub(crate) fn install_thread_alt_stack() -> Option<handler::AltStack> {
+    handler::install_thread_alt_stack()
+}
+
+/// No-op stand-in for the builds with no signal handling (wasm, non-unix).
+#[cfg(not(all(unix, feature = "native")))]
+pub(crate) fn install_thread_alt_stack() {}
+
 /// Deliberately crash when `MUTSU_CRASH_SELFTEST` asks for it, so the report
 /// pipeline itself can be tested end to end (`tests/crash_report.rs`).
 ///
 /// `segv` dereferences a null pointer (a real fault, with a real `si_addr`),
-/// `abort` calls `abort()`. Any other value is ignored.
+/// `abort` calls `abort()`. The `-thread` variants do the same thing on a
+/// worker spawned exactly the way `start` blocks and Supply taps are, which is
+/// what pins the per-thread half of the mechanism.
 pub fn selftest_if_requested() {
     #[cfg(all(unix, feature = "native"))]
     handler::selftest_if_requested();

--- a/src/runtime/builtins_system.rs
+++ b/src/runtime/builtins_system.rs
@@ -85,6 +85,12 @@ where
             }
         }
         let _guard = WorkerGuard;
+        // This thread's own alternate signal stack. `std` already gave it an
+        // 8 KiB one, which the crash handler overflows — so without this a
+        // fatal signal on a worker faults a second time inside the handler and
+        // the process dies leaving no crash report at all
+        // (`todo/deep/procasync-stress-segv.md` §8.2). Dropped with the thread.
+        let _alt_stack = crate::crash_report::install_thread_alt_stack();
         // Registered-mutator flag + leave the parent-granted quiescent
         // state (parking first if a scan is in progress): this thread's
         // quiescence now counts toward (and is required by) the STW

--- a/tests/crash_report.rs
+++ b/tests/crash_report.rs
@@ -103,6 +103,48 @@ fn abort_is_reported_too() {
     let _ = std::fs::remove_dir_all(&dir);
 }
 
+/// The half that used to be missing: a fatal signal on a *worker* thread.
+///
+/// The handler's disposition is process-wide, so it always ran on such a
+/// thread — and then overflowed the 8 KiB `SIGSTKSZ` alternate stack `std`
+/// installs, faulting a second time and dying with nothing written. Three CI
+/// recurrences of `roast/integration/advent2014-day05.t` each cost a red run
+/// and yielded no backtrace for exactly this reason
+/// (`todo/deep/procasync-stress-segv.md` §8.2).
+///
+/// The selftest faults on a thread spawned through the production
+/// `spawn_user_thread` path, so this asserts the real spawn installs the
+/// larger stack, not merely that one can be installed.
+#[test]
+fn a_segv_on_a_worker_thread_is_reported() {
+    let (signal, dir) = run_crashing("segv-thread", "segv-thread", &[]);
+    assert_eq!(signal, Some(libc::SIGSEGV));
+
+    let report = read_report(&dir);
+    assert_eq!(field(&report, "signal:"), "11 (SIGSEGV)");
+    assert_eq!(field(&report, "fault-addr:"), "0x0000000000000000");
+    // The `thread:` field is what makes a worker crash actionable at all: it
+    // says which subsystem died. It must NOT be the main thread here.
+    assert_eq!(field(&report, "thread:"), "selftest");
+    // ... and the tid must be the worker's, not the process's.
+    assert_ne!(field(&report, "tid:"), field(&report, "pid:"));
+    assert!(report.contains("--- backtrace (raw) ---"));
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// The sent-signal counterpart, so both hand-off paths (`si_code > 0` returns
+/// and re-faults; `si_code <= 0` re-raises) are covered off the main thread.
+#[test]
+fn an_abort_on_a_worker_thread_is_reported() {
+    let (signal, dir) = run_crashing("abort-thread", "abort-thread", &[]);
+    assert_eq!(signal, Some(libc::SIGABRT));
+    let report = read_report(&dir);
+    assert_eq!(field(&report, "signal:"), "6 (SIGABRT)");
+    assert_eq!(field(&report, "thread:"), "selftest");
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
 #[test]
 fn reporting_can_be_switched_off() {
     let (signal, dir) = run_crashing("segv", "off", &[("MUTSU_CRASH_REPORT", "0")]);

--- a/todo/deep/procasync-stress-segv.md
+++ b/todo/deep/procasync-stress-segv.md
@@ -448,3 +448,55 @@ The actionable item is unchanged and is §8.2's, not the crash itself: **make a 
 non-`mutsu-main` thread actually produce a report.** Three recurrences have now each cost a red CI
 and yielded no backtrace. Extending `tests/crash_report.rs` to fault each thread class mutsu spawns
 is contained work that does not need the underlying race to reproduce.
+
+## §9 The diagnostics gap is closed, 2026-09-04 — and it was candidate 2
+
+§8.2 listed three candidate explanations for "the crash left no report". It is the second one:
+**the handler ran and then faulted itself.** The gap reproduces deterministically, with no need
+for the underlying race — `await start { <anything that segfaults> }` is enough:
+
+```
+$ MUTSU_CRASH_DIR=$PWD/tmp/crash mutsu -e 'use NativeCall; sub strdup(int64) is native(Str) {*}; strdup(0)'
+tmp/crash/1034030.txt        # main thread: report written
+$ MUTSU_CRASH_DIR=$PWD/tmp/crash mutsu -e 'use NativeCall; sub strdup(int64) is native(Str) {*}; await start { strdup(0) }'
+(nothing)                    # worker thread: no report
+```
+
+`strace -f -e trace=sigaltstack` says the rest in four lines (the worker is pid 1035196):
+
+```
+1035196 sigaltstack({ss_sp=0x72daeb614000, ss_flags=0, ss_size=8192}, NULL) = 0
+1035196 --- SIGSEGV {si_signo=SIGSEGV, si_code=SEGV_MAPERR, si_addr=NULL} ---
+1035196 --- SIGSEGV {si_signo=SIGSEGV, si_code=SEGV_ACCERR, si_addr=0x72daeb613848} ---
+1035196 +++ killed by SIGSEGV (core dumped) +++
+```
+
+`ss_size=8192` is **`std`'s** alternate signal stack — Rust installs a `SIGSTKSZ`-sized one on
+every thread it spawns, for its own guard-page check. mutsu's 256 KiB stack was installed only by
+threads that called `crash_report::install()` (the process's first thread and `mutsu-main`), and a
+worker kept `std`'s. The handler needs more than 8 KiB (a 4 KiB path buffer, a 2 KiB header buffer,
+and the raw-backtrace frames), so on a worker it **overflowed the alternate stack** — the second
+SIGSEGV above, at `0x…613848`, is 0x7b8 bytes below the alternate stack's base — and a fault inside
+the handler is fatal and silent. The signal disposition was never the problem: the handler is
+process-wide and did run (confirmed with a `rust-gdb` breakpoint on it).
+
+The fix is the per-thread half, applied at the one funnel every mutsu thread goes through
+(`builtins_system::spawn_registered_thread`): each worker takes
+`crash_report::install_thread_alt_stack()`, an RAII guard that installs the 256 KiB stack and gives
+the previous one back when the thread exits, so nothing leaks. Every thread class now reports:
+
+| crash | before | after |
+| --- | --- | --- |
+| main thread | `thread: mutsu-main` | unchanged |
+| `start` block | *no report* | `thread: pool` |
+| `Thread.start` | *no report* | `thread: raku-thread` |
+| worker stack overflow | *no report*, bare SIGSEGV | `thread: pool`, **and** `std`'s "has overflowed its stack" message |
+
+Pinned by two new `tests/crash_report.rs` cases driven by `MUTSU_CRASH_SELFTEST=segv-thread` /
+`abort-thread`, which fault on a thread spawned through the production `spawn_user_thread` path —
+so the test proves the real spawn installs the stack, not merely that one can be installed. See
+`news/2026-09/crash-reports-from-worker-threads.md`.
+
+**This ticket stays open.** The underlying `advent2014-day05.t` / `stress.t` crash is still
+un-root-caused; what changed is that the *next* recurrence will finally arrive with a thread name
+and a backtrace instead of a bare `Wstat: 11`.


### PR DESCRIPTION
Closes `todo/deep/procasync-stress-segv.md` §8.2 — the actionable slice the ticket has named for three CI recurrences. (The ticket itself stays open; the underlying crash is still un-root-caused.)

## The gap

A fatal signal on a worker thread produced **no crash report**. Runs [30590633128](https://github.com/tokuhirom/mutsu/actions/runs/30590633128), [32968762746](https://github.com/tokuhirom/mutsu/actions/runs/32968762746) and [33154831894](https://github.com/tokuhirom/mutsu/actions/runs/33154831894) each cost a red CI and yielded nothing, because the diagnostic installed for exactly that case was not capturing it.

It turns out to reproduce in one line, with no need for the underlying race:

```
$ MUTSU_CRASH_DIR=$PWD/tmp/crash mutsu -e 'use NativeCall; sub strdup(int64) is native(Str) {*}; strdup(0)'
tmp/crash/1034030.txt        # main thread: report written
$ MUTSU_CRASH_DIR=$PWD/tmp/crash mutsu -e 'use NativeCall; sub strdup(int64) is native(Str) {*}; await start { strdup(0) }'
(nothing)                    # worker thread: no report
```

## Root cause — §8.2's candidate 2: the handler faulted itself

`strace -f -e trace=sigaltstack`, worker pid 1035196:

```
1035196 sigaltstack({ss_sp=0x72daeb614000, ss_flags=0, ss_size=8192}, NULL) = 0
1035196 --- SIGSEGV {si_signo=SIGSEGV, si_code=SEGV_MAPERR, si_addr=NULL} ---
1035196 --- SIGSEGV {si_signo=SIGSEGV, si_code=SEGV_ACCERR, si_addr=0x72daeb613848} ---
1035196 +++ killed by SIGSEGV (core dumped) +++
```

`ss_size=8192` is **std's** alternate signal stack — Rust installs a `SIGSTKSZ`-sized one on every thread it spawns, for its own guard-page check. mutsu's 256 KiB stack was installed only by threads that call `crash_report::install()` (the process's first thread and `mutsu-main`), so a worker kept std's. Our handler needs more than 8 KiB (a 4 KiB path buffer, a 2 KiB header buffer, the raw-backtrace frames), so it **overflowed the alternate stack** — the second SIGSEGV is `0x7b8` bytes *below* its base — and a fault inside a handler is fatal and silent.

The signal *disposition* was never the problem: it is process-wide, and a `rust-gdb` breakpoint on the handler confirmed it did run on the worker. §8.2's other two candidates (no handler on the thread; `MUTSU_CRASH_DIR` not reaching the process) are eliminated.

## The fix

Every thread mutsu spawns goes through one funnel, so `builtins_system::spawn_registered_thread` now takes `crash_report::install_thread_alt_stack()` — an RAII guard that installs the 256 KiB stack and restores the previous one when the thread exits, so a short-lived worker leaks nothing. It installs no handler; that half is process-wide and already done.

| crash | before | after |
| --- | --- | --- |
| main thread | `thread: mutsu-main` | unchanged |
| `start` block | *no report* | `thread: pool` |
| `Thread.start` | *no report* | `thread: raku-thread` |
| worker stack overflow | *no report*, bare SIGSEGV | `thread: pool` — **and** std's `thread 'pool' has overflowed its stack` message |

That last row is a second bug the same change fixes: a worker's stack overflow used to die as an uninformative SIGSEGV, where the main thread's aborts with a diagnosis. The too-small alternate stack was swallowing that too.

## Verification

- `tests/crash_report.rs` — two new cases (`a_segv_on_a_worker_thread_is_reported`, `an_abort_on_a_worker_thread_is_reported`) driven by new `MUTSU_CRASH_SELFTEST=segv-thread` / `abort-thread` modes that fault on a thread spawned through the **production** `spawn_user_thread` path, so the test proves the real spawn installs the stack rather than that one can be installed. Both assert `thread:` names the worker and `tid:` differs from `pid:`. 7/7 pass.
- `make test`: PASS (3636 files, 36824 tests).
- `make roast` locally on a release build: PASS (1436 files, 218962 tests) — run locally because the change touches every thread spawn.

Recorded in `news/2026-09/crash-reports-from-worker-threads.md` and as §9 of the ticket.