### PR TITLE
fix: a typed array refuses an autovivified nested intermediate

### DIFF
--- a/news/2026-09/typed-array-nested-autoviv-type-check.md
+++ b/news/2026-09/typed-array-nested-autoviv-type-check.md
@@ -1,0 +1,52 @@
+# A typed array now refuses an autovivified nested intermediate
+
+Descending a second subscript through an element that does not exist
+autovivifies an `Array`/`Hash` *into* that element, and a typed container has to
+refuse it:
+
+```
+$ raku -e 'my Int @a; @a[0][1] = 5'
+Type check failed for an element of @a[0]; expected Int but got Array ([])
+```
+
+mutsu accepted it silently and left `[[(Int) 5]]`. The hash-rooted twin already
+threw (`my Int %h; %h<a><b> = 5`); only the array root was missing the check.
+
+## The check is read off the container, not off the declaration
+
+The existing hash check is keyed on the *variable*: it tests
+`var_name.starts_with('%')` and looks the constraint up with
+`var_type_constraint(&var_name)`. That cannot work for a root that has no
+declaration to consult — a `:=`-bound alias, or the shared array an attribute
+accessor hands back.
+
+The new array check reads `ArrayData::value_type` off the container the store is
+about to autovivify into, so it is root-agnostic:
+
+```raku
+class A { has Int @.a }
+my $o = A.new;
+my $t := $o.a;
+$t[0]<x> = 5;     # now: Type check failed for an element of $t[0]; expected Int
+```
+
+It returns early — before any allocation — when the root is not a typed array,
+when the element already holds a container (nothing is autovivified, the
+existing one is descended into), or when the constraint accepts the
+intermediate. `my @a`, `my Any @a` and `my Array @a` are all unaffected.
+
+## Why this slice exists
+
+It is the prerequisite for closing
+`todo/tickets/method-rooted-subscript-chain-autoviv-is-dropped.md` (Tier S:
+`$o.a[0]<x> = 5` silently loses the write). The fix there is to route a
+method-call-rooted chain through the *variable*-rooted chain walk, which already
+autovivifies into the accessor's shared container correctly. That routing was
+blocked because the accessor-keyed slow path
+(`__mutsu_index_assign_method_lvalue_nested`) was the only thing performing the
+typed-container check; moving the check onto the container removes the blocker,
+and fixes the `my Int @a` case on its own.
+
+Pinned in `t/typed-array-nested-autoviv-type-check.t` (10 tests), which passes
+verbatim under both `mutsu` and `raku`. Validated with `make test` and a full
+local `make roast`, since the change makes mutsu stricter.

--- a/src/vm/vm_var_assign_index_named.rs
+++ b/src/vm/vm_var_assign_index_named.rs
@@ -3080,6 +3080,24 @@ impl Interpreter {
             }
         }
 
+        // The array twin of the check above. `my Int @a; @a[0][1] = 5` must die
+        // for the same reason -- descending a second subscript through an
+        // element that does not exist autovivifies an Array/Hash *into* that
+        // element, and a typed container refuses it. mutsu silently accepted it
+        // and left `[[(Int) 5]]` where raku throws "Type check failed for an
+        // element of @a[0]; expected Int but got Array ([])".
+        //
+        // Unlike the hash check above, this one reads the constraint off the
+        // CONTAINER (`ArrayData::value_type`) rather than off the variable's
+        // declaration, so it fires for any root that reaches this op -- a `my`
+        // array, a `:=`-bound alias, or the shared array an attribute accessor
+        // hands back.
+        if let Some(err) =
+            self.typed_array_element_autoviv_error(&var_name, &inner_key, outer_positional)
+        {
+            return Err(err);
+        }
+
         // Autovivify the root. A declared-but-undefined scalar (`my $x;` holds
         // the `Any` type object) needs this just as much as a wholly absent
         // variable does: raku vivifies a *chained* subscript write through an
@@ -3451,6 +3469,56 @@ impl Interpreter {
     /// Stack order: [value, idx_outermost, ..., idx_innermost] (innermost on top).
     /// positional_flags_idx is a constant index holding an array of booleans
     /// (innermost to outermost) indicating whether each subscript is positional.
+    /// The `X::TypeCheck::Assignment` a nested subscript store must raise when
+    /// descending through a *missing* element of a **typed** array would
+    /// autovivify an Array/Hash there (`my Int @a; @a[0][1] = 5`).
+    ///
+    /// The constraint is read from the container's own `value_type`, not from
+    /// the variable's declaration, so the check is root-agnostic. Returns
+    /// `None` -- the overwhelmingly common case -- when the root is not a typed
+    /// array, when the element already holds a container (nothing is
+    /// autovivified), or when the constraint accepts the intermediate.
+    fn typed_array_element_autoviv_error(
+        &mut self,
+        var_name: &str,
+        inner_key: &str,
+        outer_positional: bool,
+    ) -> Option<RuntimeError> {
+        let inner_i = inner_key.parse::<usize>().ok()?;
+        let root = self.env().get(var_name)?.deref_container();
+        let ValueView::Array(arr, _) = root.view() else {
+            return None;
+        };
+        let ty = arr.value_type.clone()?;
+        if matches!(ty.as_str(), "Any" | "Mu") {
+            return None;
+        }
+        // An element that is already a container is descended into, not
+        // autovivified, so no intermediate is stored and nothing is checked.
+        if let Some(existing) = arr.items().get(inner_i)
+            && matches!(
+                existing.view(),
+                ValueView::Array(..) | ValueView::Hash(..) | ValueView::ContainerRef(_)
+            )
+        {
+            return None;
+        }
+        drop(root);
+        let probe = if outer_positional {
+            Value::real_array(Vec::new())
+        } else {
+            Value::hash(std::collections::HashMap::new())
+        };
+        if loan_env!(self, type_matches_value(&ty, &probe)) {
+            return None;
+        }
+        Some(crate::runtime::utils::type_check_element_typed_error(
+            &format!("{var_name}[{inner_i}]"),
+            &ty,
+            &probe,
+        ))
+    }
+
     pub(super) fn exec_index_assign_deep_nested_op(
         &mut self,
         code: &CompiledCode,

--- a/t/typed-array-nested-autoviv-type-check.t
+++ b/t/typed-array-nested-autoviv-type-check.t
@@ -1,0 +1,62 @@
+use Test;
+
+# Descending a second subscript through an element that does not exist
+# autovivifies an Array/Hash *into* that element. A typed container refuses it:
+#
+#   my Int @a; @a[0][1] = 5;
+#   # Type check failed for an element of @a[0]; expected Int but got Array ([])
+#
+# mutsu accepted it silently and left `[[(Int) 5]]`. The hash-rooted twin
+# (`my Int %h; %h<a><b> = 5`) already threw; only the array root was missing the
+# check. Measured against Rakudo v2026.06 (2026-09-04); raku is the oracle and
+# this file passes verbatim under both.
+
+plan 10;
+
+# --- 1. a typed array refuses an autovivified intermediate ------------------
+dies-ok { my Int @a; @a[0][1] = 5 },
+    "a typed array refuses an autovivified inner Array";
+dies-ok { my Int @a; @a[0]<x> = 5 },
+    "a typed array refuses an autovivified inner Hash";
+dies-ok { my Str @s; @s[2][0] = "x" },
+    "the check is not Int-specific";
+
+# --- 2. the message names the element, like rakudo --------------------------
+{
+    my $msg = "";
+    { my Int @a; @a[0][1] = 5; CATCH { default { $msg = .message } } }
+    ok $msg.contains('element of @a[0]'),
+        'the message names the element slot';
+    ok $msg.contains('expected Int'), "the message names the expected type";
+}
+
+# --- 3. an UNtyped array still autovivifies --------------------------------
+{
+    my @a;
+    @a[0][1] = 5;
+    is @a.raku, [[Any, 5],].raku, "an untyped array still autovivifies an inner Array";
+}
+{
+    my @a;
+    @a[0]<x> = 5;
+    is @a[0]<x>, 5, "an untyped array still autovivifies an inner Hash";
+}
+
+# --- 4. a constraint that ACCEPTS the intermediate is fine -----------------
+{
+    my Any @a;
+    @a[0][1] = 5;
+    is @a[0][1], 5, "an `Any` element constraint still autovivifies";
+}
+
+# --- 5. an element that already holds a container is descended, not vivified -
+{
+    my Array @a;
+    @a[0] = Array.new;
+    @a[0][1] = 5;
+    is @a[0][1], 5, "an existing inner container is written through, not re-vivified";
+}
+
+# --- 6. the hash-rooted twin keeps dying -----------------------------------
+dies-ok { my Int %h; %h<a><b> = 5 },
+    "a typed hash still refuses an autovivified inner Hash";

--- a/todo/tickets/method-rooted-subscript-chain-autoviv-is-dropped.md
+++ b/todo/tickets/method-rooted-subscript-chain-autoviv-is-dropped.md
@@ -55,3 +55,95 @@ patch.
 - `src/runtime/builtins.rs` (dispatch) and
   `src/runtime/builtins_multidim_assign.rs` --
   `__mutsu_index_assign_method_lvalue_nested`'s implementation.
+
+## Re-investigated 2026-09-04 (second pass): what is actually measured
+
+Re-run on `main` (`cc5a39584`) against `raku` v2026.06. The repro stands, and
+the surface is **wider** than this file said. Four findings change the plan.
+
+### 1. The loss is not multi-dim-specific and not two-level-specific
+
+```raku
+class A { has @.a; }
+my $o = A.new;
+$o.a[0]<x>   = 5;   # raku [{x => 5}]           mutsu []
+$o.a[0][1]   = 5;   # raku [[(Any) 5]]          mutsu []
+$o.a[0]<x><y>= 5;   # raku [{x => {y => 5}}]    mutsu []
+class B { has %.h; }
+B.new.h<a><b> = 5;  # raku {a => {b => 5}}      mutsu {}
+```
+
+A single-level `$o.a[0] = 5` works. So the rule is: **a method-rooted chain of
+depth >= 2 that must autovivify loses the whole write.**
+
+### 2. Deleting the compiler arm does not help
+
+Disabling the `Expr::Index { target: MethodCall }` arm (so the chain falls
+through to the generic path) leaves all four shapes still answering `[]`/`{}`.
+The generic fallback is not container-aware for a method root either, so this is
+not a matter of removing a wrong special case.
+
+### 3. The mechanism that *does* work is already there — via a name
+
+```raku
+class A { has @.a; }
+my $o = A.new;
+my $t := $o.a;
+$t[0]<x> = 5;   say $o.a;   # [{x => 5}]  -- correct, and it reaches the attribute
+$t[0][1] = 5;               # correct
+```
+
+The accessor already hands back the attribute's **shared** container (that is
+why `$o.a.push(1)` works), and the variable-rooted chain walk autovivifies into
+it in place and the mutation reaches the attribute. So the fix is a *routing*
+problem: evaluate the accessor once, give the result a name (a synthetic
+lexical), and run the ordinary variable-rooted chain against it. No new chain
+walker is needed.
+
+### 4. The blocker for that routing is the typed check — and the builtin's own
+### typed check is what the variable-rooted path is missing
+
+The builtin exists to reject `class A { has Int @.a }; $o.a[0]<x> = 5`. The
+variable-rooted path did not perform that check at all (`my Int @a; @a[0][1] = 5`
+silently produced `[[(Int) 5]]`), so routing the method root through it would
+have traded a Tier S data loss for a permissive divergence.
+
+**That half is now fixed** and is the prerequisite slice:
+`news/2026-09/typed-array-nested-autoviv-type-check.md` — the check is read off
+the container's own `ArrayData::value_type`, not off the variable's declaration,
+so it is root-agnostic and fires for a `my` array, a `:=`-bound alias, or an
+accessor's shared array alike. (The hash-rooted twin, `my Int %h; %h<a><b> = 5`,
+already threw.)
+
+### 5. The builtin's `Instance` branch does not work either
+
+The `AT-POS`/`AT-KEY` branch this file's "why it is not a one-liner" section
+treats as load-bearing is broken in both directions today:
+
+```raku
+class Q { has %.d is rw; method AT-KEY($k) is rw { %!d{$k} } }
+class U { has Q $.query = Q.new(d => {foo => [1,2]}) }
+my $u = U.new;
+$u.query<foo>[0] = 99;              # raku {foo => [99 2]}
+                                    # mutsu: bogus "Type check failed for an element
+                                    #        of @query (no autovivification in typed
+                                    #        container); expected Q but got Hash"
+my $t := $u.query; $t<foo>[0] = 99; # raku {foo => [99 2]}   mutsu: silently dropped
+```
+
+The branch runs, finds no `Proxy` element, falls through, and the typed check
+below it then fires on `target` (the `U` instance) whose `.query` attribute is
+typed `Q` — producing a type error for a shape that has no type problem. So
+preserving that branch is not a constraint on the redesign; it is a third bug.
+
+### Remaining plan
+
+- **Slice A (done)** — container-based typed-element autoviv check on the
+  variable-rooted chain.
+- **Slice B** — desugar a method-call-rooted lvalue subscript chain to
+  "bind the accessor result to a synthetic lexical, then run the variable-rooted
+  chain", and delete the plain-container half of
+  `__mutsu_index_assign_method_lvalue_nested`. This is what closes the Tier S
+  data loss.
+- **Slice C** — an `Instance` root with `AT-POS`/`AT-KEY` in an lvalue chain
+  (finding 5). Broken both ways today, independent of B.


### PR DESCRIPTION
## Problem

Descending a second subscript through an element that does not exist autovivifies an `Array`/`Hash` **into** that element, and a typed container has to refuse it:

```
$ raku -e 'my Int @a; @a[0][1] = 5'
Type check failed for an element of @a[0]; expected Int but got Array ([])

$ mutsu -e 'my Int @a; @a[0][1] = 5; say @a'
[[(Int) 5]]
```

The hash-rooted twin (`my Int %h; %h<a><b> = 5`) already threw; only the array root was missing the check.

## Fix — read the constraint off the container, not the declaration

The existing hash check is keyed on the *variable*: it tests `var_name.starts_with('%')` and looks the constraint up with `var_type_constraint(&var_name)`. That cannot work for a root with no declaration to consult — a `:=`-bound alias, or the shared array an attribute accessor hands back.

The new array check reads `ArrayData::value_type` off the container the store is about to autovivify into, so it is root-agnostic:

```raku
class A { has Int @.a }
my $o = A.new;
my $t := $o.a;
$t[0]<x> = 5;     # now throws, as raku does
```

It returns before any allocation when the root is not a typed array, when the element already holds a container (nothing is autovivified — the existing one is descended into), or when the constraint accepts the intermediate. `my @a`, `my Any @a` and `my Array @a` are unaffected.

## Why this slice exists

It is the prerequisite for closing `todo/tickets/method-rooted-subscript-chain-autoviv-is-dropped.md` — the last actionable **Tier S** row (`$o.a[0]<x> = 5` silently loses the write). That ticket is updated in this PR with a second-pass measurement that changes its plan; two of its own premises did not hold up:

- The loss is **not** multi-dim- or two-level-specific: every method-rooted chain of depth ≥ 2 that must autovivify loses the whole write. Deleting the special-case compiler arm does not help — the generic path is not container-aware for a method root either.
- The mechanism that works is already there, reached **via a name**: `my $t := $o.a; $t[0]<x> = 5` writes through to the attribute, because the accessor already hands back the attribute's *shared* container. So the fix is routing, not a new chain walker.
- The blocker for that routing was the typed check — which this PR moves onto the container.
- The builtin's `Instance`/`AT-KEY` branch that the ticket treated as load-bearing is **broken both ways today** (a bogus type error in one spelling, a silently dropped write in the other). It is a third bug, not a constraint on the redesign.

## Tests

`t/typed-array-nested-autoviv-type-check.t` (10 tests), passing verbatim under **both** `mutsu` and `raku`. Gates: `make test` (3639 files, 36882 tests) and a **full local `make roast`** (1436 files, 218962 tests, `Result: PASS`), since the change makes mutsu stricter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)