### PR TITLE
fix: a sigilless bind takes on its sigilless source's binding

### DIFF
--- a/news/2026-09/sigilless-bind-chain-takes-on-its-sources-binding.md
+++ b/news/2026-09/sigilless-bind-chain-takes-on-its-sources-binding.md
@@ -1,0 +1,51 @@
+# A sigilless bind whose source is another sigilless term takes on its binding
+
+`my \y := $a; my \x := y; x = 5` died with `Cannot modify an immutable Int (1)`
+where raku writes `5` through to `$a`. Listed as still open in
+`news/2026-08/sigilless-alias-write-now-type-checked.md` and carried in
+`todo/tickets/for-loop-sigilless-param-writeback-skips-the-type-check.md`'s
+"also still open" section.
+
+The sigiled-target twin (`my $x := y`) has always worked, and so has the
+sigiled-source spelling (`my \x := $y`), which localises it precisely: only a
+sigilless term on BOTH sides failed.
+
+## Two gaps, one per side of the bind
+
+**The parser's filter never admitted the shape.**
+`build_sigilless_bind_stmt` decides between the container-binding statement
+shape and the static-readonly one from the RHS: `Expr::Var`, `Expr::Index`,
+`Expr::MethodCall`. A sigilless source parses as a bareword, so every such bind
+took the readonly path outright. A bareword is now admitted when it is a
+declared sigilless value term (`is_user_declared_value_term`) — an ordinary
+bareword (a type name, a listop call) still takes the readonly path, and the
+runtime settles writability for the ones that are admitted.
+
+**The store resolved the source by name.** With the shape admitted, the source
+reaches the store as a `WrapVarRef` tag, and the bind path resolves it through
+the `__mutsu_sigilless_alias::` chain. That chain only ever records a link to a
+NAMED variable, so:
+
+- an element alias (`my \e := @a[0]; my \f := e`) has no entry in it and the
+  write landed in a copy — a silent drop;
+- a value binding (`my \lit := 5; my \z := lit`) looked writable, because the
+  tag named a real variable.
+
+`OpCode::MarkSigillessBindSource` (added the same day, and emitted only by a
+sigilless declaration bind) now closes both from the one place that sees the
+source: when the tag carries a real slot whose RAW local is a `ContainerRef`, it
+hands that cell to the store instead of the tag — a sigilless term's slot holds
+exactly the binding it took, and `GetLocal` had merely deref'd it for the read.
+And a tag naming a term that itself carries the
+`__mutsu_sigilless_readonly::` marker is not writable; a sigiled source never
+carries that marker, so the ordinary `my \x := $a` case is untouched.
+
+## Coverage
+
+`t/sigilless-bind-chain.t` — 14 assertions, all dual-oracled against raku: two-
+and four-hop chains through a named variable (write-through and live read),
+chains through array- and hash-element aliases, chains rooted at a literal, a
+`constant` and a type name (all still immutable, with the message raku gives),
+and the sigiled-target control. `t/bind-alias-is-a-container.t` (34),
+`t/sigilless-bind-writability-source.t` (16), `make test` (3644 files) and a
+282-file targeted roast sweep are green.

--- a/src/parser/stmt/decl/my_decl_helpers.rs
+++ b/src/parser/stmt/decl/my_decl_helpers.rs
@@ -45,10 +45,18 @@ fn build_sigilless_bind_stmt(
     is_state: bool,
     is_our: bool,
 ) -> Stmt {
-    let binds_a_container = matches!(
-        expr,
-        Expr::Var(_) | Expr::Index { .. } | Expr::MethodCall { .. }
-    );
+    let binds_a_container = match expr {
+        Expr::Var(_) | Expr::Index { .. } | Expr::MethodCall { .. } => true,
+        // A SIGILLESS source (`my \y := $a; my \x := y`) denotes whatever `y`
+        // was bound to, so the chain must be able to reach the first alias's
+        // container. A bareword is only admitted when it is a declared
+        // sigilless value term -- an ordinary bareword (a type name, a listop
+        // call) keeps the readonly path. The sigiled-target twin
+        // (`my $x := y`) already routes this way, through the `__scalar_bind`
+        // branch in `compile_stmt`'s `VarDecl` arm.
+        Expr::BareWord(ref n) => crate::parser::stmt::simple::is_user_declared_value_term(n),
+        _ => false,
+    };
     let decl = Stmt::VarDecl {
         name: name.clone(),
         expr,

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -5373,6 +5373,29 @@ impl Interpreter {
                 // whole `Array`/`Hash` and a `Proxy` all are; everything else —
                 // an `Int`, a `Str`, an instance, a type object — IS the value,
                 // and rakudo refuses an assignment through the name.
+                // A SIGILLESS source (`my \y := $a; my \x := y`) denotes
+                // whatever it was itself bound to, and its own slot already
+                // holds exactly that: the shared cell when it aliases a
+                // container, the bare value when it was bound to one. `GetLocal`
+                // derefs the cell for the ordinary read that produced this
+                // `VarRef`, so recover it here and hand the CELL to the store.
+                // Without this the store falls back to resolving the source by
+                // name through the `__mutsu_sigilless_alias::` chain, which only
+                // records a chain to a NAMED variable — an element alias
+                // (`my \e := @a[0]; my \f := e`) has no entry there, so the
+                // write landed in a copy.
+                if let Some(raw) = self
+                    .stack
+                    .last()
+                    .and_then(Value::varref_slot)
+                    .filter(|slot| *slot != u32::MAX)
+                    .and_then(|slot| self.locals.get(slot as usize))
+                    .filter(|raw| raw.is_container_ref())
+                    .cloned()
+                {
+                    self.stack.pop();
+                    self.stack.push(raw);
+                }
                 let writable = self.stack.last().is_some_and(|bound| {
                     let source = match bound.as_varref() {
                         // A `WrapVarRef` over one of the compiler's synthetic
@@ -5387,8 +5410,21 @@ impl Interpreter {
                             inner
                         }
                         // Over a real variable name it denotes that variable's
-                        // container.
-                        Some(_) => return true,
+                        // container — unless that name is itself an immutable
+                        // sigilless binding (`my \lit := 5; my \z := lit`),
+                        // which has no container to hand on. A sigiled source
+                        // never carries this marker.
+                        Some((name, _, _)) => {
+                            return !name.with_str(|s| {
+                                crate::env::closure_meta_keys_possible()
+                                    && matches!(
+                                        self.env()
+                                            .get(&crate::runtime::sigilless_readonly_key(s))
+                                            .map(Value::view),
+                                        Some(ValueView::Bool(true))
+                                    )
+                            });
+                        }
                         None => bound,
                     };
                     source.is_container_ref()

--- a/t/sigilless-bind-chain.t
+++ b/t/sigilless-bind-chain.t
@@ -1,0 +1,93 @@
+use Test;
+
+# A sigilless bind whose SOURCE is itself a sigilless term takes on that term's
+# binding: the shared container when it aliases one, the bare value when it was
+# bound to one.
+#
+# `my \x := y` used to be refused outright — the parser's "can this RHS denote a
+# container?" filter listed `Expr::Var`/`Index`/`MethodCall` but not a bareword,
+# so a sigilless source took the static readonly path and `x = 5` died with
+# "Cannot modify an immutable Int". The sigiled-target twin (`my $x := y`) has
+# always worked, which is what localised it.
+
+plan 14;
+
+# --- 1. a chain through a named variable writes to the variable -------------
+{
+    my $a = 1;
+    my \y := $a;
+    my \x := y;
+    x = 5;
+    is $a, 5, 'a two-hop chain reaches the source variable';
+}
+{
+    my $s = "q";
+    my \m := $s;
+    my \n := m;
+    my \o := n;
+    o = 42;
+    is $s, 42, 'and so does a four-hop chain';
+}
+{
+    my $b = 3;
+    my \p := $b;
+    is p, 3, 'the alias reads the source';
+    $b = 4;
+    is p, 4, 'and keeps reading it live';
+}
+
+# --- 2. a chain through an ELEMENT alias writes to the element --------------
+{
+    my @a = 1, 2;
+    my \e := @a[0];
+    my \f := e;
+    f = 9;
+    is-deeply @a, [9, 2], 'a chain through an array-element alias writes through';
+}
+{
+    my %h = a => 1;
+    my \g := %h<a>;
+    my \h2 := g;
+    h2 = 9;
+    is %h<a>, 9, 'a chain through a hash-element alias writes through';
+}
+{
+    my @a = 1, 2;
+    my \e2 := @a[1];
+    my \f2 := e2;
+    is f2, 2, 'and the chained element alias reads the element';
+}
+
+# --- 3. ... while a chain rooted at a VALUE stays immutable -----------------
+{
+    my \lit := 5;
+    my \z := lit;
+    is z, 5, 'a chain rooted at a literal reads the value';
+    dies-ok { z = 9 }, 'and refuses a write';
+}
+{
+    my \lit2 := 5;
+    my \z2 := lit2;
+    my $err;
+    { z2 = 9; CATCH { default { $err = .message } } }
+    like $err, /'Cannot modify an immutable Int'/, 'naming the immutable value';
+}
+{
+    constant K = 7;
+    my \k := K;
+    is k, 7, 'a chain rooted at a constant reads it';
+    dies-ok { k = 9 }, 'and refuses a write';
+}
+{
+    my \tn := Int;
+    is tn.^name, 'Int', 'a bareword type name still binds the type object';
+}
+
+# --- 4. the sigiled-target spelling of the same chain (control) -------------
+{
+    my $a = 1;
+    my \y2 := $a;
+    my $x2 := y2;
+    $x2 = 5;
+    is $a, 5, 'control: `my $x := <sigilless>` still aliases';
+}

--- a/todo/tickets/for-loop-sigilless-param-writeback-skips-the-type-check.md
+++ b/todo/tickets/for-loop-sigilless-param-writeback-skips-the-type-check.md
@@ -71,18 +71,16 @@ half.
 
 ## Also still open in the same area
 
-A two-hop sigilless bind chain rejects the write:
+~~A two-hop sigilless bind chain rejects the write~~ — **FIXED 2026-09-04**, see
+`news/2026-09/sigilless-bind-chain-takes-on-its-sources-binding.md`. It was two
+gaps, not one: the parser's container-shape filter never admitted a bareword
+source at all, and the store resolved such a source through the
+`__mutsu_sigilless_alias::` chain, which only links to a NAMED variable (so an
+element alias dropped the write into a copy and a value binding looked
+writable). Pinned by `t/sigilless-bind-chain.t`.
 
-```
-$ raku  -e 'my $a = 1; my \y := $a; my \x := y; x = 5; say $a'
-5
-$ mutsu -e '...same...'
-Cannot modify an immutable Int (1)
-```
-
-Same family (the second bind does not reach the first alias's cell), listed in
-`news/2026-08/sigilless-alias-write-now-type-checked.md`'s "what is still open" and
-unaffected by the 2026-09-04 fix.
+This ticket's own divergence — the LOOP parameter's missing type check — is
+unaffected: it uses `store_loop_source_var`, not the bind path.
 
 ## Reproduce
 


### PR DESCRIPTION
`my \y := $a; my \x := y; x = 5` died with `Cannot modify an immutable Int (1)` where raku writes `5` through to `$a`. The sigiled-target twin (`my $x := y`) and the sigiled-source spelling (`my \x := $y`) both worked, so only a sigilless term on **both** sides failed.

Listed as still open in `news/2026-08/sigilless-alias-write-now-type-checked.md` and carried in `todo/tickets/for-loop-sigilless-param-writeback-skips-the-type-check.md`'s "also still open" section (that ticket's own divergence, the loop parameter's missing type check, is unaffected — it uses `store_loop_source_var`, not the bind path).

## Two gaps, one per side of the bind

**The parser's filter never admitted the shape.** `build_sigilless_bind_stmt` picks between the container-binding statement shape and the static-readonly one from the RHS: `Expr::Var`, `Expr::Index`, `Expr::MethodCall`. A sigilless source parses as a bareword, so every such bind took the readonly path outright. A bareword is now admitted when it is a declared sigilless value term (`is_user_declared_value_term`); an ordinary bareword (a type name, a listop call) still takes the readonly path.

**The store resolved the source by name.** With the shape admitted, the source reaches the store as a `WrapVarRef` tag, which the bind path resolves through the `__mutsu_sigilless_alias::` chain — and that chain only ever records a link to a NAMED variable. So two shapes were still wrong, one of them *silently*:

| | raku | mutsu (parser change alone) |
|---|---|---|
| `my \e := @a[0]; my \f := e; f = 9` | `[9 2]` | `[1 2]` — write dropped |
| `my \lit := 5; my \z := lit; z = 9` | dies | silently succeeds |

That is why the fix lives in `OpCode::MarkSigillessBindSource` (added earlier the same day, and emitted only by a sigilless declaration bind, immediately before its store) rather than the parser. From the one place that sees the source it now:

- hands the store the source slot's **raw `ContainerRef`** when the tag carries a real slot that holds one — a sigilless term's slot holds exactly the binding it took, and `GetLocal` had merely deref'd it for the read that produced the tag;
- treats a tag naming a term that itself carries the `__mutsu_sigilless_readonly::` marker as not writable. A sigiled source never carries that marker, so `my \x := $a` is untouched.

## Tests

- `t/sigilless-bind-chain.t` — 14 assertions, **all dual-oracled against raku**: two- and four-hop chains through a named variable (write-through and live read), chains through array- and hash-element aliases, chains rooted at a literal / a `constant` / a type name (all still immutable, with raku's message), and the sigiled-target control.
- `t/bind-alias-is-a-container.t` (34) and `t/sigilless-bind-writability-source.t` (16) stay green.
- `make test` green (3644 files / 36949 tests); 282-file targeted roast sweep (every whitelisted file using `my \` or `:=`) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)