### PR TITLE
fix: refuse a store into an immutable List literal

### DIFF
--- a/src/vm/vm_var_assign_index_named.rs
+++ b/src/vm/vm_var_assign_index_named.rs
@@ -3908,6 +3908,38 @@ impl Interpreter {
                 target.descalarize().clone(),
             ));
         }
+        // A `List` is immutable as a CONTAINER: its element slots cannot be
+        // replaced, so `(5, 6)[0] = 10` is "Cannot modify an immutable List
+        // ((5 6))" in rakudo. An element that IS a container stays writable
+        // through that container (`my $a = 1; ($a, 6)[0] = 9` sets `$a`), which
+        // is why the refusal is keyed on the ELEMENT, not on the list.
+        //
+        // The named store (`my @t := (5, 6); @t[0] = 10`) has applied this rule
+        // for a while; the anonymous spelling reached the generic auto-vivify
+        // path below instead and silently succeeded. `[5, 6][0] = 10` is
+        // unaffected -- a bracket array is `ArrayKind::Array`, a real mutable
+        // container.
+        if is_positional
+            && let ValueView::Array(items, kind) = target.descalarize().view()
+            && matches!(
+                kind,
+                crate::value::ArrayKind::List | crate::value::ArrayKind::ItemList
+            )
+            && let Some(i) = Self::index_to_usize(&idx)
+            && !matches!(
+                items.get(i).map(Value::view),
+                Some(ValueView::Scalar(_) | ValueView::ContainerRef(_))
+            )
+        {
+            let display = target.descalarize().to_string_value();
+            let mut attrs = std::collections::HashMap::new();
+            attrs.insert(
+                "message".to_string(),
+                Value::str(format!("Cannot modify an immutable List ({display})")),
+            );
+            attrs.insert("value".to_string(), target.descalarize().clone());
+            return Err(RuntimeError::typed("X::Assignment::RO", attrs));
+        }
         let key = idx.to_string_value();
         // A single scalar index names one element, so the assignment's rvalue is
         // itemized (like a scalar-variable / named single-index assignment);

--- a/t/immutable-list-literal-store.t
+++ b/t/immutable-list-literal-store.t
@@ -1,0 +1,62 @@
+use Test;
+
+# A `List` is immutable as a CONTAINER: its element slots cannot be replaced.
+# `(5, 6)[0] = 10` is "Cannot modify an immutable List ((5 6))" in rakudo, and
+# mutsu enforced that only for the NAMED spelling (`my @t := (5, 6); @t[0] = 10`)
+# — the anonymous one reached the generic auto-vivify store and silently
+# succeeded.
+#
+# The refusal is keyed on the ELEMENT, not on the list: an element that IS a
+# container stays writable through that container, which is what makes
+# `my $a = 1; ($a, 6)[0] = 9` set `$a`.
+
+plan 12;
+
+sub msg(&c) { my $m; { c(); CATCH { default { $m = .message.lines[0] } } }; $m // '' }
+
+# --- 1. a list of plain values refuses ---------------------------------------
+like msg({ (5, 6)[0] = 10 }), /'Cannot modify an immutable List'/,
+  'storing into an anonymous list literal is refused';
+like msg({ (1, 2, 3)[1] = 9 }), /'Cannot modify an immutable List'/,
+  '... at any index';
+throws-like { (5, 6)[0] = 10 }, X::Assignment::RO,
+  'and it is an X::Assignment::RO';
+like msg({ my @t := (5, 6); @t[0] = 10 }), /'Cannot modify an immutable List'/,
+  'control: the named spelling already refused';
+like msg({ my $l := (5, 6); $l[0] = 10 }), /'Cannot modify an immutable List'/,
+  'control: and the scalar-bound one';
+
+# --- 2. ... while an element that is a CONTAINER stays writable --------------
+{
+    my $a = 1;
+    ($a, 6)[0] = 9;
+    is $a, 9, 'a list element that is a variable writes through';
+}
+{
+    my $a = 1;
+    my @l := ($a, 6);
+    @l[0] = 9;
+    is $a, 9, 'control: and so does the named spelling';
+}
+
+# --- 3. ... and a real Array is untouched ------------------------------------
+{
+    is ([5, 6][0] = 10), 10, 'a bracket array is mutable';
+}
+{
+    my @a = 5, 6;
+    @a[0] = 10;
+    is-deeply @a.List, (10, 6), 'and so is an Array variable';
+}
+{
+    my @a = 5, 6;
+    my @b := @a;
+    @b[1] = 9;
+    is-deeply @a.List, (5, 9), 'a `:=` of an Array aliases it, and it is mutable';
+}
+
+# --- 4. reads are unaffected -------------------------------------------------
+{
+    is (5, 6)[0], 5, 'reading a list literal element still works';
+    is-deeply (5, 6, 7)[1, 2].List, (6, 7), 'and so does a slice';
+}

--- a/todo/deep/immutable-list-element-bind-is-writable.md
+++ b/todo/deep/immutable-list-element-bind-is-writable.md
@@ -90,7 +90,7 @@ Two shapes still diverge, and they are the file's remaining scope:
 | | rakudo | mutsu |
 |---|---|---|
 | `my $x := (5, 6)[0]; $x = 10` | `Cannot assign to an immutable value` | silently succeeds |
-| `(5, 6)[0] = 10` | `Cannot modify an immutable List ((5 6))` | silently succeeds |
+| ~~`(5, 6)[0] = 10`~~ | `Cannot modify an immutable List ((5 6))` | **fixed 2026-09-05, see below** |
 
 Both are the `$`-sigil / direct-store side of the same promotion, and neither
 goes through `MarkSigillessBindSource`. The shapes that DO refuse correctly —
@@ -102,3 +102,35 @@ in place.
 (Message nit while here: mutsu renders the refused container with `.gist`
 (`Cannot modify an immutable List (5 6)`) where rakudo uses `.raku`-ish
 parenthesisation (`((5 6))`).)
+
+## The direct-store half landed 2026-09-05
+
+`(5, 6)[0] = 10` now refuses, matching rakudo. The named store had applied this
+rule for a while; the ANONYMOUS spelling reached
+`exec_index_assign_generic_op`'s auto-vivify path instead, which has a guard for
+an immutable `Range` receiver but had none for an immutable `List`. The refusal
+is keyed on the ELEMENT, not on the list — an element that IS a container stays
+writable through it (`my $a = 1; ($a, 6)[0] = 9` sets `$a`) — the same rule the
+named store states. Pinned by `t/immutable-list-literal-store.t`.
+
+What is left of this file is therefore ONE shape, the `$`-sigil bind:
+
+```
+my $x := (5, 6)[0]; $x = 10     # rakudo: Cannot assign to an immutable value
+                                # mutsu: silently succeeds
+```
+
+The sigilless twin (`my \x := (5, 6)[0]`) refuses correctly, because
+`MarkSigillessBindSource` settles writability from the bind source and an
+immutable `List` element arrives there as a plain value. The `$`-sigil bind has
+no such verdict step — it takes the container the promotion primitive minted,
+which is where the over-promotion this file describes still bites.
+
+One neighbouring divergence found while measuring, NOT fixed: rakudo's
+`(my $x = $a, 6)[0] = 10` writes through `$x`, because an inline declaration in
+a list literal denotes the freshly-declared variable's container. mutsu's list
+literal holds a bare value there — before this change the write was silently
+dropped, now it is refused; both diverge. Extending
+`scalar_container_alias_name` to cover `Expr::DoStmt(VarDecl)` was tried and did
+not reach it, so the inline declaration does not arrive in that shape at this
+position; finding what it does arrive as is the next step for that row.


### PR DESCRIPTION
`(5, 6)[0] = 10` silently succeeded where rakudo answers `Cannot modify an immutable List ((5 6))`. A `List` is immutable as a CONTAINER: its element slots cannot be replaced.

The **named** spelling already refused — `my @t := (5, 6); @t[0] = 10` and the scalar-bound `my $l := (5, 6); $l[0] = 10`. The anonymous one reached `exec_index_assign_generic_op`'s auto-vivify path instead, which carries a guard for an immutable `Range` receiver but had none for an immutable `List`.

The refusal is keyed on the **element**, not on the list — the same rule the named store states: an element that IS a container stays writable through that container, so `my $a = 1; ($a, 6)[0] = 9` still sets `$a`. A bracket array is `ArrayKind::Array` and is untouched.

| | rakudo | mutsu before | after |
|---|---|---|---|
| `(5, 6)[0] = 10` | refuses | `10` | refuses |
| `(1, 2, 3)[1] = 9` | refuses | `9` | refuses |
| `[5, 6][0] = 10` | `10` | `10` | `10` |
| `my $a = 1; ($a, 6)[0] = 9` | `$a` is 9 | `$a` is 9 | `$a` is 9 |

## Ticket outcome

Closes the second of the two shapes `todo/deep/immutable-list-element-bind-is-writable.md` had left after #7303. The file now has exactly one:

```
my $x := (5, 6)[0]; $x = 10     # rakudo: Cannot assign to an immutable value; mutsu: succeeds
```

Its sigilless twin (`my \x := (5, 6)[0]`) refuses correctly, because `MarkSigillessBindSource` settles writability from the bind source and an immutable `List` element arrives there as a plain value. The `$`-sigil bind has no such verdict step — which localises what is left.

Also recorded in the file, and deliberately not fixed here: rakudo's `(my $x = $a, 6)[0] = 10` writes through `$x` (an inline declaration in a list literal denotes the declared variable's container); mutsu holds a bare value there, so the write was silently dropped before and is refused now. Extending `scalar_container_alias_name` to `Expr::DoStmt(VarDecl)` was tried and did not reach it.

## Tests

- `t/immutable-list-literal-store.t` — 12 assertions, **all dual-oracled against rakudo**: the refusals with their exception type, the named/scalar-bound controls, the container-element write-through, the mutable-Array rows, and that reads and slices are unaffected.
- `make test` (3653 files / 37100 tests) and a **full local `make roast`** (1436 files / 218962 tests) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
