### PR TITLE
fix: a BEGIN-time name reference sees only the sub declarations reached so far (ADR-0041)

### DIFF
--- a/docs/adr/0041-sub-hoisting-vs-compile-time-name-visibility.md
+++ b/docs/adr/0041-sub-hoisting-vs-compile-time-name-visibility.md
@@ -1,6 +1,6 @@
 # ADR-0041: A sub's *callability* is hoisted for the whole scope, but its *bareword-reference visibility* at `constant`/`BEGIN` time must follow textual order — these are two different questions the current single hoisted registry conflates
 
-- Status: Proposed (investigation only; no implementation plan chosen)
+- Status: Accepted (implemented 2026-09-05 - see SS9)
 - Date: 2026-08-20
 - Related: ADR-0024 (mainline lexicals for named subs), ADR-0039 (`@`/`%`
   lexicals must resolve lexically — the container-side analog of this same
@@ -406,3 +406,107 @@ initializer references are the only two shapes that diverge, ordinary runtime
 references agree with rakudo in every position, and the divergence is `inner`
 where rakudo says `outer` (a block-nested redeclaration) or an accepted program
 where rakudo refuses to compile (a forward reference).
+
+## 9. Closed 2026-09-05: the "reached" signal is the `RegisterDecl` execution, not a registry write
+
+All four rows of §6.3's table now agree with rakudo. The mechanism is §8's —
+"record what a hoist-pass registration displaced, and roll it back while a
+BEGIN-time region is open" — with the one thing §8 was missing: a usable
+answer to *has this declaration been reached?*
+
+### 9.1 Archaeology: where a plain mainline `sub`'s callable identity lives
+
+§8 left an explicit prerequisite for the next attempt: "Where a plain mainline
+sub's callable identity actually lives, and why `GLOBAL::foo` is absent there,
+is the archaeology the next attempt has to do first." It was done first, with
+`rust-gdb -batch` breakpoints and no instrumented build, and the answer is that
+**the premise does not reproduce**.
+
+For `sub foo(){"outer"}` at file scope, `registration_sub.rs`'s single-candidate
+install (`self.registry_mut().functions.insert(fq_sym, arc)`, the `else` arm of
+the `multi` split) executes and `fq` reads `GLOBAL::foo`. Breaking on that
+insert for §8's own repro shows it fire exactly twice — once for the mainline
+hoist of `foo`, once for the inner block's hoist — with `name="foo"` and
+`custom_traits` of size 1 (`__hoisted`) and size 2 (`__hoisted`,
+`__lexical_hoist`) respectively. So the registry entry a displacement record
+needs is there, under the obvious key, at the moment the hoist registers. §8's
+finding 2 was an artifact of its instrumentation, not a property of the
+registry; the campaign it blocked was blocked for no reason.
+
+§8's finding 1, by contrast, reproduces exactly and is the real constraint: the
+in-sequence registration of a declaration whose hoisted twin is byte-identical
+returns `SubRegisterOutcome::Unchanged` and writes nothing, so those same two
+inserts are the *only* registry writes the four `RegisterDecl` ops produce.
+
+### 9.2 The fix
+
+"Has this declaration been reached?" is not derivable from registry writes — but
+it never had to be. `exec_register_sub_op` already computes `is_hoisted_pass`
+(the `__hoisted` marker the hoist pre-pass stamps on its copy) *before* it
+registers anything, and that flag is independent of the registration's outcome.
+The in-sequence copy of a declaration therefore announces itself on every
+execution, `Unchanged` or not. That is the signal, and it needs no source
+positions on `CompiledSubDeclPlan` after all — §8's closing recommendation to
+carry a `source_line` is superseded.
+
+`src/runtime/hoist_visibility.rs` holds the whole mechanism:
+
+- a hoist-pass `RegisterDecl` records, per `Pkg::name`, the registry entries it
+  touched — what it left installed and what it displaced;
+- an in-sequence `RegisterDecl` drops that record, because the program has now
+  genuinely reached the declaration;
+- entering a BEGIN-time region rolls every still-recorded declaration back to
+  what it displaced (removing the key outright when it displaced nothing), and
+  leaving the region puts it back.
+
+This answers §6.4's objection that "suppressing the not-yet-reached declaration
+does not by itself reveal what raku would have found": the displaced def is what
+raku would have found, and the hoist registration is exactly the event that can
+see it. No lexical scope is added to the registry — consistent with §7's lesson
+that "the registry needs lexical scope" was too big a diagnosis for this family.
+
+Two details keep it honest. A record is only acted on when the live entry is
+still the exact `Arc` the hoist installed (`Arc::ptr_eq`), so a record left
+stale by an early return or a scope restore is skipped rather than trusted. And
+the value-position `BEGIN` (`OpCode::BeginOnceExpr`, which unlike
+`CheckPhaserStart` never raised `check_phaser_depth`) opens the same region, so
+`my $x = BEGIN foo()` and `BEGIN say foo()` agree; the BEGIN-time frames are
+therefore unwound by their own entry depth, not by `check_phaser_depth`.
+
+### 9.3 Result
+
+| source | raku | mutsu before | mutsu now |
+|---|---|---|---|
+| `sub foo(){"outer"}; { my constant &old = &foo; say old(); sub foo(){"inner"} }` | `outer` | `inner` | `outer` |
+| `sub foo(){"outer"}; { my $old = &foo; say $old(); sub foo(){"inner"} }` | `inner` | `inner` | `inner` |
+| `say f(); constant X = 1; sub f(){42}` | works | works | works |
+| `constant X = f(); sub f(){42}; say X` | compile error | `42` | compile error |
+
+Row 4's failure is a BEGIN-time throw (`An exception occurred while evaluating a
+CHECK` wrapping `Unknown function: f`) where rakudo reports its CHECK-time
+undeclared-symbol diagnostic (`Undeclared routine: f used at line 1`). Both
+refuse to compile the program; mutsu has no `X::Undeclared::Symbols` collection
+pass to phrase it rakudo's way, and adding one is a separate concern.
+
+Pinned in `t/begin-time-sub-visibility.t`, which carries rows 2 and 3 as
+explicit regression controls — they are the rows §6.3 rejected Option B over,
+and any future rework of this area must keep them green.
+
+### 9.4 What is still open
+
+- The record is keyed by `Pkg::name` and holds one entry per name, so when two
+  nested blocks both hoist the same name and *neither* has been reached, the
+  inner hoist's record replaces the outer's. The BEGIN-time view then shows the
+  outer block's declaration rather than refusing the name. Reaching either
+  declaration clears the record, so this only affects a doubly-unreached name.
+- A non-`multi` hoist tracks only the single `Pkg::name` key (a `multi` family
+  additionally tracks its candidate keys). A plain `sub` that lexically shadows
+  a `multi` family therefore restores the single key but not the candidate keys
+  it retained away.
+- The record is keyed by the package current at registration time, so a
+  declaration whose hoist and in-sequence copies run under different packages
+  (`hoist_nested_our_subs` lifts an `our sub` out of a nested block to the
+  compunit head) never clears. The `Arc::ptr_eq` guard keeps a stale record
+  from acting on a key it no longer owns.
+- §6.2's `proto`/`multi` lexical-shadowing defect is untouched here; `proto`
+  declarations are not part of the hoist pre-pass at all.

--- a/news/2026-09/begin-time-sub-name-visibility.md
+++ b/news/2026-09/begin-time-sub-name-visibility.md
@@ -1,0 +1,63 @@
+# A BEGIN-time name reference now sees only the sub declarations the program has reached
+
+mutsu registers every top-level `sub` of a block through a hoist pre-pass
+emitted at the head of that block, so a name is callable from anywhere in its
+enclosing scope regardless of textual order. Rakudo gets the same effect a
+different way: it installs the routine's pad entry at *compile* time. The two
+models agree for an ordinary runtime reference — which is order-blind in both —
+but they diverge for a reference evaluated at **BEGIN** time, inside a
+`BEGIN`/`CHECK` body or a `constant` initializer, because rakudo's compilation
+has only reached part of the scope at that moment while mutsu's hoist had
+already registered all of it.
+
+ADR-0041 §6.3 tabulated the divergence and §8 recorded a failed attempt at it.
+Both rows are now fixed:
+
+```raku
+sub foo() { "outer" }
+{
+    my constant &old = &foo;   # rakudo: the OUTER foo; mutsu used to capture the inner one
+    say old();
+    sub foo() { "inner" }
+}
+
+constant X = f();              # rakudo refuses to compile; mutsu used to print 42
+sub f() { 42 }
+say X;
+```
+
+The blocker was not the rollback itself but the question it depends on: *has
+this declaration been reached yet?* §8 tried to derive that from registry
+writes and correctly found it undecidable — an in-sequence registration whose
+hoisted twin is byte-identical takes the idempotent
+`SubRegisterOutcome::Unchanged` path and writes nothing at all. Its second
+finding, that a plain mainline `sub` leaves no `registry().functions` entry to
+record a displacement against, does not reproduce: a `rust-gdb` breakpoint on
+the single-candidate install shows it firing with `fq` = `GLOBAL::foo`, exactly
+where a displacement record needs it.
+
+The signal that does work needs no source positions and no registry write at
+all. `exec_register_sub_op` already knows, before it registers anything, whether
+it is running the hoist copy of a declaration (the `__hoisted` marker the
+pre-pass stamps on) or the in-sequence one, and that is true on every execution
+whatever the registration outcome turns out to be. So a hoist-pass registration
+records what it displaced, the in-sequence registration drops that record, and
+a BEGIN-time region rolls every still-recorded declaration back to what it
+displaced — which is precisely the routine rakudo would have found. Restoring
+the displaced def, rather than merely hiding the unreached one, is what makes
+the block-nested case answer `outer` instead of failing to resolve; ADR-0041
+§6.4 had flagged that as the reason a simple suppression could not work.
+
+The mechanism lives in `src/runtime/hoist_visibility.rs`. It guards itself with
+an `Arc::ptr_eq` staleness check, so a record left behind by an early return or
+a scope restore is skipped rather than trusted, and it also covers the
+value-position `BEGIN` (`OpCode::BeginOnceExpr`), which never raised
+`check_phaser_depth` and so was not a BEGIN-time region at all before — making
+`my $x = BEGIN foo()` and `BEGIN say foo()` agree.
+
+`t/begin-time-sub-visibility.t` pins all of it, including the two rows that are
+regression controls rather than fixes: a plain runtime `&name` capture still
+sees a block-local routine declared after it, and a plain forward call still
+resolves across a `constant` declaration. Those are the rows ADR-0041 rejected
+the "register each declaration at its textual position" design over, and they
+must stay green through any future rework of this area.

--- a/src/runtime/hoist_visibility.rs
+++ b/src/runtime/hoist_visibility.rs
@@ -1,0 +1,218 @@
+//! BEGIN-time name visibility for hoisted sub declarations (ADR-0041 §9).
+//!
+//! mutsu registers every top-level `sub` of a block through a hoist pre-pass
+//! emitted at the head of that block (`Compiler::hoist_sub_decls`), so a name
+//! is callable from anywhere in its enclosing scope regardless of textual
+//! order. Rakudo gets the same effect by installing the routine's pad entry at
+//! *compile* time, which means an ordinary **runtime** reference sees the whole
+//! scope — but a reference evaluated at **BEGIN** time (a `BEGIN`/`CHECK`
+//! phaser body, or a `constant` initializer) only sees what compilation has
+//! reached so far.
+//!
+//! This module carries that difference. Every hoist-pass registration records
+//! what it installed and what it displaced; the declaration's own in-sequence
+//! registration clears the record, because the program has now genuinely
+//! reached it. While a BEGIN-time region is open, every still-recorded
+//! declaration is rolled back to what it displaced (removed outright when it
+//! displaced nothing), and reinstated when the region closes.
+//!
+//! Deriving "has this declaration been reached?" from *registry writes* does
+//! not work — a declaration whose hoisted twin is byte-identical takes the
+//! idempotent `SubRegisterOutcome::Unchanged` path and writes nothing (ADR-0041
+//! §8). The signal used here is the `RegisterDecl` execution itself, which
+//! knows whether it is the hoist copy (`__hoisted`) or the in-sequence one,
+//! whatever the registration outcome turns out to be.
+
+use crate::ast::FunctionDef;
+use crate::runtime::Interpreter;
+use crate::symbol::Symbol;
+use std::sync::Arc;
+
+/// One registry entry a hoist-pass registration touched.
+#[derive(Debug, Clone)]
+pub(crate) struct HoistedEntry {
+    pub(crate) key: Symbol,
+    /// What the registry held under `key` immediately after the hoist-pass
+    /// registration. Used as a staleness guard: if the live entry is no longer
+    /// this exact `Arc`, a later declaration or a scope restore has taken the
+    /// key over and the record no longer describes reality.
+    pub(crate) installed: Option<Arc<FunctionDef>>,
+    /// What the registry held under `key` immediately before it.
+    pub(crate) displaced: Option<Arc<FunctionDef>>,
+}
+
+/// Every registry entry one hoisted declaration touched.
+pub(crate) type HoistedDeclRecord = Vec<HoistedEntry>;
+
+/// A registry key and the def to put back under it (`None` = remove).
+type RegistryUndo = Vec<(Symbol, Option<Arc<FunctionDef>>)>;
+
+impl Interpreter {
+    fn hoisted_decl_key(&self, name: &str) -> Symbol {
+        Symbol::intern(&format!("{}::{}", self.current_package(), name))
+    }
+
+    /// Registry keys owned by the routine `name` in the current package. A
+    /// plain (non-`multi`) declaration only ever owns the single key, so it
+    /// costs one intern; a `multi` family additionally spans candidate keys
+    /// (`Pkg::name/2`, `Pkg::name/2:Int`, …) and pays a key scan.
+    fn routine_registry_keys(&self, name: &str, multi: bool) -> Vec<Symbol> {
+        let single = format!("{}::{}", self.current_package(), name);
+        let single_sym = Symbol::intern(&single);
+        if !multi {
+            return vec![single_sym];
+        }
+        let multi_prefix = format!("{}/", single);
+        let mut keys: Vec<Symbol> = self
+            .registry()
+            .functions
+            .keys()
+            .filter(|k| **k != single_sym && k.resolve().starts_with(&multi_prefix))
+            .copied()
+            .collect();
+        keys.push(single_sym);
+        keys
+    }
+
+    /// Snapshot the registry entries a hoist-pass registration of `name` is
+    /// about to overwrite. Paired with [`Self::note_hoisted_decl`].
+    pub(crate) fn capture_pre_hoist_defs(
+        &self,
+        name: &str,
+        multi: bool,
+    ) -> Vec<(Symbol, Arc<FunctionDef>)> {
+        let keys = self.routine_registry_keys(name, multi);
+        let registry = self.registry();
+        keys.into_iter()
+            .filter_map(|k| registry.functions.get(&k).map(|def| (k, def.clone())))
+            .collect()
+    }
+
+    /// Record what a hoist-pass registration of `name` installed and displaced,
+    /// so a BEGIN-time region opening before the declaration's own in-sequence
+    /// registration can roll it back.
+    pub(crate) fn note_hoisted_decl(
+        &mut self,
+        name: &str,
+        multi: bool,
+        before: Vec<(Symbol, Arc<FunctionDef>)>,
+    ) {
+        let mut entries: HoistedDeclRecord = Vec::new();
+        for key in self.routine_registry_keys(name, multi) {
+            let installed = self.registry().functions.get(&key).cloned();
+            let displaced = before
+                .iter()
+                .find(|(k, _)| *k == key)
+                .map(|(_, def)| def.clone());
+            // The hoist did not change this key (same `Arc` before and after,
+            // or nothing on either side): nothing to roll back.
+            match (&installed, &displaced) {
+                (None, None) => continue,
+                (Some(a), Some(b)) if Arc::ptr_eq(a, b) => continue,
+                _ => {}
+            }
+            entries.push(HoistedEntry {
+                key,
+                installed,
+                displaced,
+            });
+        }
+        // A key present before but gone after is a displacement too (a plain
+        // `sub` lexically shadowing a `multi` family clears its candidate keys).
+        for (key, def) in before {
+            if entries.iter().any(|e| e.key == key) || self.registry().functions.contains_key(&key)
+            {
+                continue;
+            }
+            entries.push(HoistedEntry {
+                key,
+                installed: None,
+                displaced: Some(def),
+            });
+        }
+        let record_key = self.hoisted_decl_key(name);
+        if entries.is_empty() {
+            self.hoisted_unreached_decls.remove(&record_key);
+        } else {
+            self.hoisted_unreached_decls.insert(record_key, entries);
+        }
+    }
+
+    /// The declaration has now been reached in source order: its in-sequence
+    /// `RegisterDecl` is executing, so it is visible to any later BEGIN-time
+    /// evaluation exactly as rakudo's compile-time pad install would be.
+    pub(crate) fn mark_hoisted_decl_reached(&mut self, name: &str) {
+        if self.hoisted_unreached_decls.is_empty() {
+            return;
+        }
+        let key = self.hoisted_decl_key(name);
+        self.hoisted_unreached_decls.remove(&key);
+    }
+
+    /// Enter a BEGIN-time region (`CheckPhaserStart`). At the outermost level
+    /// this hides every hoisted-but-not-yet-reached declaration; a nested
+    /// region only keeps the depth aligned.
+    pub(crate) fn begin_time_enter(&mut self) {
+        if !self.begin_time_hidden.is_empty() || self.hoisted_unreached_decls.is_empty() {
+            self.begin_time_hidden.push(Vec::new());
+            return;
+        }
+        let records: Vec<HoistedDeclRecord> =
+            self.hoisted_unreached_decls.values().cloned().collect();
+        let mut undo: RegistryUndo = Vec::new();
+        for entry in records.into_iter().flatten() {
+            let live = self.registry().functions.get(&entry.key).cloned();
+            // Staleness guard: only roll back a key the hoist still owns.
+            let still_owned = match (&live, &entry.installed) {
+                (Some(a), Some(b)) => Arc::ptr_eq(a, b),
+                (None, None) => true,
+                _ => false,
+            };
+            if !still_owned {
+                continue;
+            }
+            undo.push((entry.key, live));
+            self.apply_registry_entry(entry.key, entry.displaced);
+        }
+        if !undo.is_empty() {
+            self.fn_resolve_gen += 1;
+        }
+        self.begin_time_hidden.push(undo);
+    }
+
+    /// Leave a BEGIN-time region (`CheckPhaserEnd`), putting back everything
+    /// [`Self::begin_time_enter`] hid.
+    pub(crate) fn begin_time_leave(&mut self) {
+        let Some(undo) = self.begin_time_hidden.pop() else {
+            return;
+        };
+        if undo.is_empty() {
+            return;
+        }
+        for (key, def) in undo {
+            self.apply_registry_entry(key, def);
+        }
+        self.fn_resolve_gen += 1;
+    }
+
+    fn apply_registry_entry(&mut self, key: Symbol, def: Option<Arc<FunctionDef>>) {
+        match def {
+            Some(def) => {
+                self.registry_mut().functions.insert(key, def);
+            }
+            None => {
+                self.registry_mut().functions.remove(&key);
+            }
+        }
+    }
+
+    /// Unwind BEGIN-time regions left open by a throw, back to `depth` — the
+    /// `begin_time_hidden` length the enclosing scope was entered with. A
+    /// region whose closing opcode is skipped must not leave declarations
+    /// rolled out of the registry for the rest of the program.
+    pub(crate) fn begin_time_unwind_to(&mut self, depth: u32) {
+        while self.begin_time_hidden.len() as u32 > depth {
+            self.begin_time_leave();
+        }
+    }
+}

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -450,6 +450,7 @@ mod handle_io;
 mod handle_open;
 mod handle_read;
 mod handle_read_chars;
+pub(crate) mod hoist_visibility;
 mod incdec_rw_sub;
 mod io;
 mod io_doc;
@@ -3390,6 +3391,17 @@ pub struct Interpreter {
         rustc_hash::FxHashMap<Symbol, (Symbol, Symbol, Arc<CompiledFunction>)>,
     pub(crate) otf_call_cache_gen: u64,
     pub(crate) check_phaser_depth: u32,
+    /// ADR-0041 §9: hoist-pass sub registrations whose own in-sequence
+    /// `RegisterDecl` has not executed yet, keyed by `Pkg::name`. A BEGIN-time
+    /// region (`constant` initializer, `BEGIN`/`CHECK` body) rolls these back
+    /// so a name reference evaluated there sees only what the program has
+    /// textually reached, as rakudo's compile-time pad install does.
+    pub(crate) hoisted_unreached_decls:
+        rustc_hash::FxHashMap<Symbol, crate::runtime::hoist_visibility::HoistedDeclRecord>,
+    /// One frame per open BEGIN-time region: the registry entries that region
+    /// hid, and the defs to put back when it closes. Depth-aligned with
+    /// `check_phaser_depth`.
+    pub(crate) begin_time_hidden: Vec<Vec<(Symbol, Option<Arc<FunctionDef>>)>>,
     /// Depth of `with_nested_registers` re-entry (nested VM runs: closure
     /// bodies dispatched from native code, EVAL, dies-ok blocks, ...). The
     /// uncaught-CX::Return -> X::ControlFlow::Return conversion in `run_inner`

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -3118,6 +3118,8 @@ impl Interpreter {
             otf_call_cache: Default::default(),
             otf_call_cache_gen: 0,
             check_phaser_depth: 0,
+            hoisted_unreached_decls: rustc_hash::FxHashMap::default(),
+            begin_time_hidden: Vec::new(),
             nested_run_depth: 0,
             gather_for_loop_resume: None,
             gather_resume_body_ip: None,

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -964,6 +964,8 @@ impl Interpreter {
             otf_call_cache: Default::default(),
             otf_call_cache_gen: 0,
             check_phaser_depth: 0,
+            hoisted_unreached_decls: rustc_hash::FxHashMap::default(),
+            begin_time_hidden: Vec::new(),
             nested_run_depth: 0,
             gather_for_loop_resume: None,
             gather_resume_body_ip: None,

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -4699,10 +4699,14 @@ impl Interpreter {
             OpCode::CheckPhaserStart { .. } => {
                 self.sync_source_line(code, *ip);
                 self.check_phaser_depth += 1;
+                // ADR-0041 §9: a name reference evaluated at BEGIN time sees
+                // only declarations the program has textually reached.
+                self.begin_time_enter();
                 *ip += 1;
             }
             OpCode::CheckPhaserEnd => {
                 self.check_phaser_depth = self.check_phaser_depth.saturating_sub(1);
+                self.begin_time_leave();
                 *ip += 1;
             }
 

--- a/src/vm/vm_misc_block.rs
+++ b/src/vm/vm_misc_block.rs
@@ -256,7 +256,16 @@ impl Interpreter {
                 let body_start = *ip + 1;
                 let end = body_end as usize;
                 let stack_base = self.stack.len();
-                match self.run_range(code, body_start, end, compiled_fns) {
+                // ADR-0041 §9: a value-position `BEGIN` is as much BEGIN time
+                // as the statement form, so its body sees only the sub
+                // declarations the program has textually reached. (Unlike
+                // `CheckPhaserStart` this does NOT raise `check_phaser_depth`:
+                // whether a throw here should surface as `X::Comp::BeginTime`
+                // is a separate question this opcode has always answered "no".)
+                self.begin_time_enter();
+                let ran = self.run_range(code, body_start, end, compiled_fns);
+                self.begin_time_leave();
+                match ran {
                     Ok(()) => {
                         let value = if self.stack.len() > stack_base {
                             self.stack.pop().unwrap_or(Value::NIL)

--- a/src/vm/vm_register_sub_ops.rs
+++ b/src/vm/vm_register_sub_ops.rs
@@ -271,10 +271,22 @@ impl Interpreter {
             let is_hoisted_pass = custom_traits.iter().any(|(t, _)| t == "__hoisted");
             if !is_hoisted_pass {
                 self.check_param_custom_traits(param_defs)?;
+                // ADR-0041 §9: the program has now textually reached this
+                // declaration, so a later BEGIN-time reference legitimately
+                // sees it. Recorded here rather than off a registry write:
+                // an in-sequence registration whose hoisted twin is
+                // byte-identical takes the idempotent `Unchanged` path and
+                // writes nothing at all (ADR-0041 §8).
+                self.mark_hoisted_decl_reached(&resolved_name);
             }
             if preregistered {
                 return Ok(());
             }
+            // ADR-0041 §9: remember what this hoist-pass registration is about
+            // to displace, so a BEGIN-time region opening before the
+            // declaration's own in-sequence registration can roll it back.
+            let pre_hoist_defs =
+                is_hoisted_pass.then(|| self.capture_pre_hoist_defs(&resolved_name, *multi));
             // ADR-0019 C6e-3c: a plan-derived def always registers with an
             // EMPTY body — its identity and dispatch run entirely from the
             // plan-recorded fingerprints/facts (C6e-3a) and the attached
@@ -323,6 +335,9 @@ impl Interpreter {
                     primary_compiled,
                 )
             })?;
+            if let Some(before) = pre_hoist_defs {
+                self.note_hoisted_decl(&resolved_name, *multi, before);
+            }
             // An idempotent re-registration of an already-installed identical sub
             // leaves the registry untouched, so none of the install bookkeeping
             // below (cache invalidation, `&`-param shadow tracking, export, native

--- a/src/vm/vm_run_loop.rs
+++ b/src/vm/vm_run_loop.rs
@@ -137,6 +137,11 @@ impl Interpreter {
         // X::Comp::BeginTime too. Snapshot the entry depth so every error
         // exit below can restore it after deciding whether to wrap.
         let entry_check_phaser_depth = self.check_phaser_depth;
+        // ADR-0041 §9: the BEGIN-time visibility frames are pushed by
+        // `CheckPhaserStart` AND by the value-position `BEGIN` opcode (which
+        // does not raise `check_phaser_depth`), so unwind them by their own
+        // entry depth rather than by the phaser depth.
+        let entry_begin_time_depth = self.begin_time_hidden.len() as u32;
         let mut ip = 0;
         while ip < code.ops.len() {
             // GC safepoint (design doc §1.2): the dispatch backward edge holds no
@@ -186,17 +191,21 @@ impl Interpreter {
                     if self.check_phaser_depth > 0 {
                         let wrapped = Self::wrap_in_begin_time(inner_err);
                         self.check_phaser_depth = entry_check_phaser_depth;
+                        self.begin_time_unwind_to(entry_begin_time_depth);
                         return Err(wrapped);
                     }
                     self.check_phaser_depth = entry_check_phaser_depth;
+                    self.begin_time_unwind_to(entry_begin_time_depth);
                     return Err(inner_err);
                 }
                 if self.check_phaser_depth > 0 {
                     let wrapped = Self::wrap_in_begin_time(e);
                     self.check_phaser_depth = entry_check_phaser_depth;
+                    self.begin_time_unwind_to(entry_begin_time_depth);
                     return Err(wrapped);
                 }
                 self.check_phaser_depth = entry_check_phaser_depth;
+                self.begin_time_unwind_to(entry_begin_time_depth);
                 return Err(e);
             }
             if self.is_halted() {
@@ -205,6 +214,10 @@ impl Interpreter {
         }
         self.sync_state_locals(code);
         self.pop_once_scope();
+        // ADR-0041 §9 safety net: a BEGIN-time region whose closing opcode was
+        // skipped (a caught throw, a `halt`) would otherwise keep sub
+        // declarations rolled out of the registry for the rest of the program.
+        self.begin_time_unwind_to(entry_begin_time_depth);
         // Sync local variables back to the interpreter's env so that
         // callers (e.g. eval_block_value) can observe side effects.
         self.sync_env_from_locals(code);

--- a/src/vm/vm_try_catch_ops.rs
+++ b/src/vm/vm_try_catch_ops.rs
@@ -50,6 +50,12 @@ impl Interpreter {
         if traps {
             self.fatal_mode = true;
         }
+        // ADR-0041 §9: a BEGIN-time region opened inside the protected body
+        // (`constant X = die ...`, `BEGIN { die }`) never reaches its closing
+        // opcode when the body throws. Unlike `check_phaser_depth`, a leaked
+        // region keeps sub declarations rolled out of the registry, so close
+        // any it left open before the handler resumes ordinary execution.
+        let begin_time_base = self.begin_time_hidden.len() as u32;
         let result = self.exec_try_catch_op_inner(
             code,
             catch_start,
@@ -62,6 +68,7 @@ impl Interpreter {
             ip,
             compiled_fns,
         );
+        self.begin_time_unwind_to(begin_time_base);
         if traps {
             self.fatal_mode = saved_fatal_mode;
         }

--- a/t/begin-time-region-unwind.t
+++ b/t/begin-time-region-unwind.t
@@ -1,0 +1,39 @@
+use Test;
+
+# ADR-0041 section 9: a BEGIN-time region temporarily rolls hoisted-but-not-yet-reached
+# sub declarations out of the routine registry, so a `&name` reference evaluated
+# there sees only what the program has textually reached. If the region's
+# closing opcode is skipped because the body threw and the throw was caught, the
+# rollback must NOT survive into ordinary execution.
+#
+# NOTE: rakudo refuses to compile either program below outright ("An exception
+# X::AdHoc occurred while evaluating a constant / a BEGIN") because it runs
+# BEGIN during compilation; mutsu evaluates it at runtime, where `try` does
+# catch it. The invariant under test is therefore mutsu-internal: whatever the
+# region hid must be back afterwards.
+
+plan 4;
+
+{
+    my $caught = False;
+    try {
+        constant DEAD = die "boom";
+        CATCH { default { $caught = True } }
+    }
+    ok $caught, 'a throw out of a `constant` initializer is caught';
+    is after-dead-constant(), "reachable",
+       'a sub declared after a caught BEGIN-time throw is still callable';
+    sub after-dead-constant() { "reachable" }
+}
+
+{
+    my $caught = False;
+    try {
+        BEGIN { die "boom" }
+        CATCH { default { $caught = True } }
+    }
+    ok $caught, 'a throw out of a BEGIN block is caught';
+    is after-dead-begin(), "reachable",
+       'a sub declared after a caught BEGIN-block throw is still callable';
+    sub after-dead-begin() { "reachable" }
+}

--- a/t/begin-time-sub-visibility.t
+++ b/t/begin-time-sub-visibility.t
@@ -1,0 +1,65 @@
+use Test;
+
+# ADR-0041 section 9: a sub's *callability* is hoisted for the whole enclosing scope,
+# but a name reference evaluated at BEGIN time (a `constant` initializer or a
+# `BEGIN`/`CHECK` body) must see only the declarations the program has
+# textually reached, exactly as rakudo's compile-time pad install does.
+#
+# Every expectation below was verified against real rakudo before being pinned.
+
+plan 8;
+
+# --- BEGIN-time references only see what precedes them ------------------------
+
+sub outer-only() { "outer" }
+
+{
+    my constant &alias = &outer-only;
+    is alias(), "outer",
+       'a `constant &alias = &name` inside a block captures the OUTER routine, not the block-local one declared after it';
+    sub outer-only() { "inner" }
+}
+
+{
+    my $begin-call = BEGIN outer-only();
+    is $begin-call, "outer",
+       'a BEGIN-time call inside a block reaches the OUTER routine, not the block-local one declared after it';
+    sub outer-only() { "shadow" }
+}
+
+sub declared-first() { 42 }
+is (BEGIN declared-first()), 42,
+   'a BEGIN-time call to a routine declared BEFORE it resolves normally';
+
+eval-dies-ok q[constant Z = only-later(); sub only-later() { 1 }; Z],
+   'a BEGIN-time call to a routine declared only LATER is a compile-time failure';
+
+eval-lives-ok q[sub already-there() { 1 }; constant Z = already-there(); Z],
+   'the same call after the declaration compiles';
+
+# --- regression controls: ordinary RUNTIME references still see everything ----
+# These are the two rows ADR-0041 section 6.3 rejected "register at the textual
+# position" over: rakudo installs the pad entry at compile time, so a plain
+# runtime reference is order-blind and must keep seeing the whole scope.
+
+sub runtime-ref() { "outer" }
+
+{
+    my $captured = &runtime-ref;
+    is $captured(), "inner",
+       'a plain runtime `&name` reference sees the block-local routine declared after it';
+    sub runtime-ref() { "inner" }
+}
+
+{
+    my $forward = across-constant();
+    constant ACROSS = 1;
+    is $forward, 7,
+       'a plain runtime forward call still resolves across a `constant` declaration';
+    sub across-constant() { 7 }
+}
+
+sub calls-later() { declared-later() }
+sub declared-later() { 9 }
+is calls-later(), 9,
+   'forward-reference calling between mainline subs is unaffected';


### PR DESCRIPTION
Closes the two remaining divergent rows of ADR-0041 §6.3, and closes the ADR
(Proposed → Accepted).

## The defect

mutsu registers every top-level `sub` of a block through a hoist pre-pass
emitted at the head of that block, so a name is callable from anywhere in its
enclosing scope regardless of textual order. Rakudo reaches the same place by
installing the routine's pad entry at *compile* time — so the two agree for an
ordinary **runtime** reference, but not for one evaluated at **BEGIN** time
(a `BEGIN`/`CHECK` body, or a `constant` initializer), where rakudo's
compilation has only reached part of the scope.

| source | raku | before | after |
|---|---|---|---|
| `sub foo(){"outer"}; { my constant &old = &foo; say old(); sub foo(){"inner"} }` | `outer` | `inner` | `outer` |
| `sub foo(){"outer"}; { my $old = &foo; say $old(); sub foo(){"inner"} }` | `inner` | `inner` | `inner` |
| `say f(); constant X = 1; sub f(){42}` | works | works | works |
| `constant X = f(); sub f(){42}; say X` | compile error | `42` | compile error |

Rows 2 and 3 are regression controls, not fixes — they are the rows §6.3
rejected the "register each declaration at its textual position" design over,
and they stay green.

## Archaeology (ADR-0041 §8 asked for this first)

§8 implemented and withdrew this mechanism, leaving two findings. Both were
re-measured with `rust-gdb -batch` breakpoints, no instrumented build:

1. **Reproduces.** An in-sequence registration whose hoisted twin is
   byte-identical takes the idempotent `SubRegisterOutcome::Unchanged` path and
   performs no registry write, so "has this declaration been reached?" is not
   derivable from registry writes.
2. **Does not reproduce.** "A plain mainline `sub` leaves no
   `registry().functions` entry at the point the registration reports
   `Installed`" was an instrumentation artifact: breaking on
   `registration_sub.rs`'s single-candidate `functions.insert` shows it fire
   with `fq` = `GLOBAL::foo`, exactly the key a displacement record needs. The
   campaign §8 blocked was blocked for no reason.

## The fix

The signal §8 was missing needs no source positions on `CompiledSubDeclPlan`
(superseding §8's closing recommendation). `exec_register_sub_op` already
computes `is_hoisted_pass` (the `__hoisted` marker the pre-pass stamps) *before*
registering, and that is true on every execution whatever the outcome.

`src/runtime/hoist_visibility.rs`:

- a hoist-pass `RegisterDecl` records, per `Pkg::name`, what it left installed
  and what it displaced;
- an in-sequence `RegisterDecl` drops the record — the program has reached it;
- entering a BEGIN-time region rolls every still-recorded declaration back to
  what it displaced (removing the key when it displaced nothing); leaving puts
  it back.

Restoring the *displaced* def, rather than merely hiding the unreached one, is
what answers §6.4's objection that suppression alone cannot reveal the outer
routine. No lexical scope is added to the registry, consistent with §7's lesson
that "the registry needs lexical scope" was too big a diagnosis for this family.

Two details keep it honest:

- a record is only acted on when the live entry is still the exact `Arc` the
  hoist installed (`Arc::ptr_eq`), so a stale record is skipped rather than
  trusted;
- the value-position `BEGIN` (`OpCode::BeginOnceExpr`) opens the same region.
  It never raised `check_phaser_depth`, so it was not a BEGIN-time region at
  all before; `my $x = BEGIN foo()` now agrees with `BEGIN say foo()`. The
  region frames are therefore unwound by their own entry depth, and any region
  whose closing opcode is skipped by a caught throw is closed at the `try` and
  `run` boundaries — otherwise a `try { constant X = die }` would leave
  declarations rolled out of the registry for the rest of the program
  (pinned by `t/begin-time-region-unwind.t`).

## Divergence that remains

Row 4 fails as a BEGIN-time throw (`An exception occurred while evaluating a
CHECK` wrapping `Unknown function: f`) where rakudo reports its CHECK-time
undeclared-symbol diagnostic (`Undeclared routine: f used at line 1`). Both
refuse to compile the program; mutsu has no `X::Undeclared::Symbols` collection
pass, and adding one is a separate concern. Recorded in ADR-0041 §9.3, along
with three narrower residues in §9.4.

## Verification

- `make test`: Files=3655, Tests=37119, **Result: PASS**
- 81 whitelisted roast files under S02-names/S02-names-vars/S04-declarations/
  S04-phasers/S06-currying/S06-operator-overloading/S10-packages/S11-modules:
  **PASS**
- 155 whitelisted roast files whose source mentions `constant`/`BEGIN`/`CHECK`
  (54733 subtests): **PASS**
- `cargo fmt --check`, `cargo clippy -- -D warnings`: clean
- Every expectation in the new `t/` pins was verified against real `raku` first.
