### PR TITLE
feat: a sigilless parameter's container survives the return (ADR-0067 slice 1)

### DIFF
--- a/docs/adr/0067-a-routine-hands-back-the-container-it-was-given.md
+++ b/docs/adr/0067-a-routine-hands-back-the-container-it-was-given.md
@@ -1,0 +1,410 @@
+# ADR-0067: A routine hands back the container it was *given* — raw arguments, raw invocants, and the subscript step through an object
+
+- Status: Proposed (Slice 1 implemented 2026-09-05; Slices 2-5 open)
+- Date: 2026-09-05
+- Related: [ADR-0059](0059-is-rw-routines-return-a-container.md) (an `is rw`
+  routine returns a container), [ADR-0036](0036-element-container-pairs-from-subscripts-and-pairs.md)
+  (element-container Pairs), [ADR-0013](0013-container-interior-mutability-cellvalue.md)
+  §7 (interior-mutability prerequisite — solved),
+  [ADR-0001](0001-gc-strategy-and-phasing.md) §7 (Track B is no longer
+  GC-coupled), [ADR-0064](0064-var-descriptor-carries-the-contained-value.md)
+  (`.VAR` descriptors)
+- Addresses: `todo/deep/native-method-cannot-return-an-lvalue-container.md`,
+  `todo/tickets/lvalue-chain-through-at-key-at-pos-object-root.md`
+
+## Context
+
+Two open findings say explicitly that they are the same problem and must be
+designed together:
+
+```raku
+# (a) a method hands back its invocant's container
+use v6.e.PREVIEW;
+my $a = 42; $a.snitch = 666; say $a;   # raku: 42 then 666
+
+# (b) an lvalue subscript chain that steps through an object with AT-KEY
+class Q { has %.d is rw; method AT-KEY($k) is rw { %!d{$k} } }
+class U { has Q $.query = Q.new(d => {foo => [1,2]}) }
+my $u = U.new; $u.query<foo>[0] = 99; say $u.query.d;   # raku: {foo => [99 2]}
+```
+
+ADR-0059 established that **an `is rw` routine returns a container**, and built
+two of the three halves that needs:
+
+- **Production** — `compile_return_rw_arg` compiles a `return-rw` operand, and
+  the bare tail of an `is rw`/`is raw` body, in container mode.
+- **Consumption** — `assign_lvalue_container`
+  (`src/runtime/lvalue_container_return.rs:33`) writes a value through a
+  returned `Proxy` / `ContainerRef` / `HashEntryRef`.
+
+What it did not build is the third half: **transport in the inbound direction**.
+A routine can only hand back a location it was *given*, and mutsu's argument and
+invocant paths hand it values.
+
+This ADR closes that half, and shows that (a) and (b) are the same statement
+applied at two different producers.
+
+## Measured — what is actually broken (and what the findings got wrong)
+
+Everything below was measured on 2026-09-05 against `raku` v2026.07 and a debug
+`mutsu` built from `main` at `37dd63f33`. **Three of the two findings' central
+claims are wrong**; they are corrected here rather than carried forward.
+
+### Correction 1 — `.VAR` is not an acceptance case, and `.snitch` needs no parentheses
+
+The deep file's headline repro claims `my $a = 42; $a.VAR = 5` prints `5` in
+raku. It does not — raku dies with `Cannot assign to a readonly variable or a
+value`. `$a.VAR` returns a **readonly `Scalar` object**, which is a different
+feature from the raw-invocant return. (The file's own 2026-09-01 note already
+caught this; the ticket text above it was never corrected, and the task that
+produced this ADR was briefed with the wrong expectation.) The acceptance case
+is `.snitch`, and it does *not* need the parenthesised spelling — plain
+`$a.snitch = 5` works in raku too.
+
+### Correction 2 — this is not a native-method problem
+
+The deep file's root cause is "a *native* method has nowhere to put the answer".
+That framing is wrong: the identical failure reproduces for a **user-written**
+method, so nothing about it is native-specific.
+
+| # | Program | raku | mutsu (before) |
+|---|---|---|---|
+| A3 | `my $a = 42; $a.snitch = 5; say $a` | `42` / `5` | `X::Assignment::RO: cannot assign through .snitch on non-instance` |
+| A6 | `augment class Any { method mysn(\SELF:) is raw { SELF } }; $a.mysn = 5` | `5` | *the same error* |
+| E1 | same, but **without** `is raw` on the method | `Cannot modify an immutable Int (42)` | the same error |
+| E2 | `method mysn2(Any:D $s:) is raw { $s }` (non-raw invocant) | `Cannot assign to a readonly variable or a value` | the same error |
+
+A6 vs E1/E2 pins the contract precisely: **both** the invocant parameter must be
+raw (`\SELF:`) **and** the routine must be `is raw`/`is rw`. Neither alone.
+
+### Correction 3 — the ticket's "at least loud and honest" claim covers one spelling out of four
+
+The ticket says the (b) failure is now a loud refusal. That is true only for the
+depth->=2 *method-rooted* spelling. Every neighbouring spelling is **silently
+wrong**, and one is worse than silent:
+
+| # | Program (with `class Q { has %.d; method AT-KEY($k) is rw { %!d{$k} } }`) | raku | mutsu (before) |
+|---|---|---|---|
+| B1 | `$u.query<foo>[0] = 99` (method-rooted, depth 2) | `{foo => [99 2]}` | loud refusal (the ticket's case) |
+| C3/H1 | `my $q = Q.new(...); $q<foo>[0] = 99` (**variable**-rooted, depth 2) | `{foo => [99 2]}` | `{foo => [1 2]}` — **silent**, exit 0 |
+| B4 | `$u.query<foo> = 99` (method-rooted, depth 1) | `{foo => 99}` | `{foo => 1}` — **silent** |
+| B6 | `my $t := $u.query; $t<foo>[0] = 99` | `{foo => [99 2]}` | `{foo => [1 2]}` — **silent** |
+| H2 | `$q.AT-KEY("foo")[0] = 99` (explicit spelling) | `{foo => [99 2]}` | `{foo => [1 2]}` — **silent** |
+| H5/B8 | `$q<foo><bar>[0] = 99` (depth 3) | `{foo => {bar => [99 2]}}` | `No such method 'd' for invocant of type 'Hash'` — the **instance is replaced by a Hash** |
+| C4 | `$q<foo> = 99` (var-rooted, depth 1) | `{foo => 99}` | `{foo => 99}` — correct |
+| H3 | `my $e := $q<foo>; $e[0] = 99` | `{foo => [99 2]}` | `{foo => [99 2]}` — **correct** |
+| H4 | `$q<foo>.push(99)` | `{foo => [1 2 99]}` | correct |
+
+H3 is the load-bearing row: the `:=`-bind spelling of *exactly the same
+subscript* already produces the right container. So (b) is not a missing
+capability — it is a **producer that is not consulted**.
+
+### The two real root causes
+
+**(R1) The return side loses the container for a sigilless name.** Bytecode,
+not inference:
+
+```
+sub f($x is rw) is rw { $x }     ->  GetLocal(0); WrapVarRef{name_idx:0,slot:0}; CaptureVarCell
+sub f(\x)       is rw { x }      ->  GetLocal(0)
+sub f(\x)       { return-rw x }  ->  GetLocal(0); CallFunc "return-rw"
+```
+
+Both routines store the parameter in the same slot under the same local name
+`"x"`. The only difference is the **tail's AST node**: `$x` parses to
+`Expr::Var("x")`, a sigilless `\x` parses to `Expr::BareWord("x")`, and
+`scalar_container_alias_name` (`src/compiler/expr_call.rs:41`) matches only
+`Expr::Var`. So `return_rw_container_name` never fires and no cell is captured.
+This is the entire cause of the `sub f(\x) is raw { x }; f($a) = 5` family.
+
+**(R2) The invocant never arrives as a container at all.** Positional raw
+parameters *do* (`sub f(\x) { x = 7 }` writes the caller's `$a`; so does
+`f(@a[0])`), but the invocant does not:
+
+| # | Program | raku | mutsu |
+|---|---|---|---|
+| F3 | `sub f(\x) { x = 7 }; my $a = 42; f($a); say $a` | `7` | `7` |
+| G3 | `sub f(\x) { x = 9 }; my @a = 1,2; f(@a[0]); say @a` | `[9 2]` | `[9 2]` |
+| I1 | `augment class Any { method mut(\S:) { S = 7 } }; my $a = 42; $a.mut; say $a` | `7` | **`42`** |
+| I3 | the same over `@a[0].mut` | `[7 2]` | **`[1 2]`** |
+
+**Methodological note, because it nearly produced a wrong ADR.** The obvious
+probe — `method vv(\S:) { say S.VAR.WHAT }` — reports `(Scalar)` in mutsu, which
+looks like the container arrived. It is a **false positive**: ADR-0064 makes
+`.VAR` synthesise a descriptor from the contained value, so it answers `Scalar`
+whether or not a real cell exists. Only the *mutation* discriminator (I1/I3)
+separates the two. Do not use `.VAR` as a container oracle here.
+
+### What `.item` is, and why it is not the design
+
+`$a.item = 5` already works in mutsu, and `scalar_container_alias_name`'s doc
+comment presents it as "a native raw-invocant method handing the container
+back". The bytecode says otherwise:
+
+```
+my $a = 42; $a.item = 5   ->  LoadConst(5); AssignExprLocal(0); TagContainerRef(0, Some(0))
+my $a = 42; $a.snitch = 5 ->  ... CallFunc "__mutsu_assign_method_lvalue" (arity 5)
+```
+
+`.item` is **erased at compile time** — the call disappears and the assignment
+becomes a plain store to `$a`. That is sound for `.item` only because `.item` is
+pure. It cannot be generalised: `.snitch` **notes its invocant** (raku prints
+`42` before `666`), and erasing the call would drop the side effect. So the
+cheap route — "add `snitch` to the erasure list" — is not merely a band-aid, it
+is *incorrect*. This ADR takes the real route instead.
+
+### Where the object-rooted chain loses the write (R3, a consequence of R2)
+
+`exec_index_assign_expr_nested_op` (`src/vm/vm_var_assign_index_named.rs:2963`)
+*does* have an Instance branch. Under `rust-gdb`, breaking at :2984, :3014 and
+:3033 on the H1 repro shows it entered, called `AT-KEY`, and then fell straight
+through to the generic Hash/Array walk:
+
+```
+Breakpoint 1 (:2984  "if let Some(at) = at")      hit
+Breakpoint 2 (:3014  "let idx_u = ...")           hit
+Breakpoint 3 (:3033  "let inner_key = ...")       hit   <- generic walk, root is the Q Instance
+```
+
+The branch calls the accessor as an **rvalue** and discards its container on the
+next line:
+
+```rust
+let inner = self
+    .call_method_with_values(target, at, vec![inner_idx.clone()])?
+    .deref_container();                       // <- the container is thrown away here
+```
+
+It then writes only if the element happens to be a `Proxy`, or the inner value
+is itself an Instance with `ASSIGN-POS`/`ASSIGN-KEY`. For the ordinary case it
+falls out and the generic walk runs against a root that is not a container — the
+write is dropped (and at depth 3 the root is replaced by a fresh Hash, which is
+where H5's nonsense error comes from).
+
+## Decision
+
+**A raw parameter binds the caller's container, and the invocant is parameter
+zero. A routine declared `is rw`/`is raw` (or spelling `return-rw`) hands that
+container back, and every lvalue consumer writes through it — including the
+subscript-chain walker, which takes its step through an object by calling
+`AT-KEY`/`AT-POS` in that same lvalue mode.**
+
+One rule, four mechanical parts. Three of the four already exist and are simply
+not connected; none of this is new machinery.
+
+### 1. Rw-capability is one declaration oracle
+
+`Interpreter::routine_is_rw_capable` (`src/runtime/builtins_lvalue.rs:251`)
+already states the rule — `is rw || is raw || body spells return-rw` — and the
+**sub** lvalue path uses it. The **method** path does not: it tests
+`method_def.is_rw` alone (`methods_mut_method_lvalue.rs:1363`), and `MethodDef`
+has no `is_raw` field at all because `Stmt::MethodDecl` never carried one
+(`src/ast.rs:1348`; `SubDecl` carries both, `src/ast.rs:1026`). Measured
+consequence:
+
+| # | Program | raku | mutsu |
+|---|---|---|---|
+| K1 | `class C { method m(\x) is rw { x } }; C.new.m($a) = 5` | `5` | `5` (after Slice 1) |
+| K2 | the same with `is raw` | `5` | `X::Assignment::RO: method 'm' is not rw` |
+| K4 | `method m(\x) { return-rw x }` | `5` | the same error |
+
+So: plumb `is_raw` onto `MethodDecl`/`MethodDef` and route the method gate
+through `routine_is_rw_capable`. One oracle, two callers — not two rules.
+
+For **native** methods, invocant-rawness is likewise a declaration, and it needs
+a place to live: a single table of native methods that are `is raw` on their
+invocant, transcribed from Rakudo's signatures (`.snitch`, `.item`, and the
+container-carrying `.list`). This is deliberately a *declaration table*, not a
+call-site name check — the difference is that every consumer (the compiler's
+argument mode, the runtime dispatch, the lvalue gate) reads the same row, so the
+family cannot drift apart the way `.item`'s compiler-only erasure did.
+
+### 2. Inbound transport — the invocant is compiled in container mode
+
+The container-mode argument compile already exists
+(`compile_rw_chain_index_arg`, `compile_return_rw_arg`) and is already applied
+to the arguments of a call nested inside a `return-rw` operand. Apply the same
+mode to the **invocant** of a call to a raw-invocant routine.
+
+The call site is already 90% there. `$a.snitch = 5` compiles to
+
+```
+GetLocal(0); ContainerizePair; WrapVarRef{name_idx:0, slot:0}; ... CallFunc "__mutsu_assign_method_lvalue"
+```
+
+— the invocant is *already* tagged with `WrapVarRef`, carrying its source name.
+The missing op is the one the `return-rw` tail emits right after it:
+`OpCode::CaptureVarCell`, which boxes the named slot into the shared cell. With
+the invocant compiled in container mode, the element and attribute spellings
+raku supports come for free, because container mode is what already handles
+them:
+
+| # | Program | raku |
+|---|---|---|
+| E4 | `my @a = 1,2; @a[0].snitch = 9; say @a` | `[9 2]` |
+| E5 | `my %h = a=>1; %h<a>.snitch = 9; say %h` | `{a => 9}` |
+| E6 | `class C { has $.v is rw }; $c.v.snitch = 9` | `9` |
+
+That is the whole reason to do this in the shared container-mode compile rather
+than at the `$a`-shaped call site: there is no per-shape code.
+
+### 3. Outbound transport — a sigilless name denotes its container
+
+`Expr::BareWord` is how the parser spells a sigilless lexical, *and* how it
+spells a type name, an enum value and a bare call. It denotes a container
+exactly when it resolves to a local slot of the frame being compiled — which is
+what `local_map` records. So the rw-tail site consults `local_map` rather than
+guessing from the spelling.
+
+This is scoped to `return_rw_container_name` and deliberately **not** folded
+into `scalar_container_alias_name`, whose other three callers (List-literal
+elements `src/compiler/expr.rs:330`, fat-arrow Pair values
+`src/compiler/expr_binary.rs:707`) legitimately see barewords that are type
+names in ordinary code — `my @a = (Int, Str)` must not box `Int`.
+
+### 4. Consumption — unchanged, and that is the point
+
+`assign_lvalue_container` already writes through `Proxy` / `ContainerRef` /
+`HashEntryRef`. Nothing in this ADR adds a consumer; parts 1-3 exist so that the
+one consumer ADR-0059 built is actually reached.
+
+### 5. (b) is part 2 applied to one more producer
+
+The chain walk's step through an object becomes: *call `AT-KEY`/`AT-POS` in
+lvalue mode and descend into the container it returns*, replacing
+`call_method_with_values(...).deref_container()`. Because the accessor is `is
+rw`, `routine_is_rw_capable` says yes, container mode produces a `ContainerRef`
+(or a `HashEntryRef` for a missing key), and the walk already knows how to
+descend into a `ContainerRef` — `descend_container_ref`
+(`vm_var_assign_index_named.rs:3401`) and `env_root_descended_mut` (:3434) do
+exactly that. H3 proves the produced container is the right one.
+
+The same substitution serves the *method-rooted* spelling: the compiler temp
+`bind_method_rooted_chain_root` installs (`src/compiler/expr_closure.rs:606`) is
+filled by a plain `self.compile_expr(cur)` — an rvalue read. Compiling that root
+in container mode makes the temp hold the accessor's container, and
+`lvalue_root_temp_not_a_container`'s loud refusal (:3470) then fires only for
+roots that genuinely are not locations.
+
+**Explicitly rejected:** reintroducing an accessor-keyed slow path. The deleted
+`__mutsu_index_assign_method_lvalue_nested` is what silently dropped the writes
+this ticket's neighbours were about
+(`news/2026-09/method-rooted-lvalue-subscript-chain-writes-through.md`), and its
+copy-on-write model is the specific thing that made autovivified levels
+evaporate. The routing above adds no new walker at all.
+
+## Which dispatch paths must preserve a container invocant
+
+Enumerated, not hand-waved. A container invocant must survive from the call site
+to the routine body on each of these, and each currently derefs or is simply not
+reached:
+
+| Path | Site | Status |
+|---|---|---|
+| `OpCode::CallMethod` | `src/opcode.rs:1262` | ordinary rvalue call — must stay value-passing except for a raw-invocant callee |
+| `OpCode::CallMethodMut` | `src/opcode.rs:1285` | lexical receiver; already retains a `ContainerView` cell for non-`WHAT`/`VAR` methods (`vm_call_method_mut_ops.rs:682`) — the nearest thing to a working precedent |
+| `OpCode::CallMethodDynamic` / `…DynamicMut` | `src/opcode.rs:1298`/`:1308` | computed method name; rawness is only knowable at runtime, so the *runtime* gate (part 1's oracle) has to decide |
+| `OpCode::HyperMethodCall` / `…Dynamic` | `src/opcode.rs:2041`/`:2056` | `>>.` — raku does not give a hyper call an lvalue result; must keep decontainerizing, and this is a deliberate non-goal |
+| `__mutsu_assign_method_lvalue` -> `assign_method_lvalue_with_values` | `methods_mut_method_lvalue.rs:146` | the lvalue entry; already receives a `WrapVarRef`-tagged invocant, missing `CaptureVarCell` |
+| `try_rw_method_container_lvalue` | `lvalue_container_return.rs:125` | type-object invocant half; unaffected (a type object has no container) |
+| `call_method_with_values` | `methods_call_dispatch.rs:140` | takes `target: Value`, so it can already carry a `ContainerRef`; the derefs are downstream |
+| `native_method_0arg` / `_1arg` / `_2arg` | `builtins/methods_0arg/mod.rs:304`, `methods_narg/dispatch_1arg.rs:25`, `dispatch_2arg.rs:17` | take `target: &Value` — a native method can already *receive* a container; the raw-invocant table decides which ones must return it unchanged |
+
+## Slices
+
+Each slice is independently verifiable and independently shippable.
+
+### Slice 1 — a sigilless name denotes its container (IMPLEMENTED 2026-09-05)
+
+Part 3 above. `return_rw_container_name` becomes a method so it can consult
+`self.local_map`, and gains a `BareWord` arm gated on
+`is_plain_lexical_name(name) && self.local_map.contains_key(name)`.
+
+**Acceptance** (all verified identical under raku v2026.07):
+
+```raku
+sub f(\x) is raw { x }; my $a = 42; f($a) = 5;              # 5
+sub f(\x) is rw  { x }; my $a = 42; f($a) = 5;              # 5
+sub f(\x) { return-rw x }; my $a = 42; f($a) = 5;           # 5
+sub f(\x) is raw { x }; say f($a).VAR.^name;                # Scalar
+class C { method m(\x) is rw { x } }; C.new.m($a) = 5;      # 5
+sub f(\x) is raw { x }; my @a = 1,2; f(@a[0]) = 9;          # [9 2]
+```
+
+Pinned by `t/sigilless-raw-param-container-return.t` (21 tests, byte-identical
+output under `mutsu` and `raku`), which includes the three non-regression rows
+that constrain the gate: `my @a = (Int, Str)`, `my $p = (a => Int)`, and
+`sub f() is raw { my \w = 5; w }`.
+
+### Slice 2 — one rw-capability oracle for methods
+
+Part 1's user half: add `is_raw` to `Stmt::MethodDecl` and `MethodDef` (~18
+construction sites), parse the trait, and replace
+`methods_mut_method_lvalue.rs:1363`'s `!method_def.is_rw` with
+`routine_is_rw_capable`. Mechanical and wide; no design left in it.
+
+**Acceptance:** K2 and K4 above.
+
+### Slice 3 — the invocant arrives as a container
+
+Parts 1 (native table) and 2. Emit `CaptureVarCell` for the invocant of a call
+to a raw-invocant routine at the lvalue call site, teach the runtime dispatch
+not to deref it, and have the raw-invocant natives return it unchanged.
+
+**Acceptance:** A3/A6 (`$a.snitch = 5` -> `42` then `5`; the `augment` twin),
+I1/I3 (mutation *through* a raw invocant reaches the caller), and E4/E5/E6 (the
+element and attribute invocant spellings). E1/E2 must keep refusing.
+
+### Slice 4 — the chain walk steps through an object
+
+Part 5, variable-rooted half: replace
+`vm_var_assign_index_named.rs:2985`'s rvalue `AT-KEY`/`AT-POS` call with the
+lvalue-mode call, and descend into the returned container.
+
+**Acceptance:** C3/H1, C4 (must stay correct), H2, H5 (depth 3 — must stop
+replacing the instance with a Hash), and C2 (the `AT-POS` twin). H3/H4 are
+regression rows.
+
+### Slice 5 — the method-rooted chain root
+
+Part 5, method-rooted half: compile
+`bind_method_rooted_chain_root`'s root expression in container mode.
+
+**Acceptance:** B1 (the ticket's headline), B4 (depth 1), B6 (the `:=`-bound
+alias spelling), with
+`t/method-rooted-lvalue-subscript-chain.t` as the regression gate.
+
+## Alternatives considered
+
+- **Add `snitch` to `.item`'s compile-time erasure.** Rejected on correctness,
+  not taste: `.item` is erased, and `.snitch` has a side effect that erasure
+  would drop (raku prints the invocant before the assignment lands). Measured
+  above.
+- **Special-case `.VAR`.** Not applicable — `.VAR` is not in this family at all;
+  raku refuses `$a.VAR = 5`. Correction 1.
+- **Fix (b) with an accessor-keyed slow path.** Rejected — that is the deleted
+  `__mutsu_index_assign_method_lvalue_nested`, and its copy-on-write rebuild is
+  precisely what dropped the writes. Explicitly forbidden by the ticket.
+- **Make the *whole* invocant path container-carrying, unconditionally.**
+  Rejected: it would leak a `ContainerRef` into every method body and past every
+  consumer that only decontainerizes at the scalar chokepoints — the same
+  failure mode `return_rw_container_name`'s narrowness exists to avoid. Rawness
+  is a declared property; only declared-raw invocants get the container.
+- **Wait for a "universal container-reference propagation" campaign** (the deep
+  file's 2026-08-31 triage). Rejected as over-scoped: the measurements above
+  show mutsu already propagates containers through positional raw parameters
+  (F3/G3), through `:=`-bound subscripts (H3), and out of `return-rw` tails.
+  Three named gaps remain, each with its own repro. There is no universal
+  campaign left to run — there are four slices.
+
+## Non-goals
+
+- `$a.VAR = 5` stays a refusal (it is one in raku).
+- Hyper method calls (`>>.`) keep decontainerizing.
+- `.self` is *not* in the raw-invocant family in raku (`$a.self =:= $a` is
+  `False`, and `$a.self = 5` is refused) while mutsu answers `True`. That is a
+  separate divergence, recorded here so it is not swept into the table by
+  mistake.
+- `sub f(\x) is raw { x }; my $c = C.new(v=>1); f($c.v) = 9` (a raw *argument*
+  over an attribute accessor) still copies. It is the argument twin of Slice 3
+  and is expected to fall out of it; if it does not, it earns its own ticket.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -92,3 +92,4 @@ The role of an ADR is to preserve the *context of the judgment* — something th
 | [0064](0064-var-descriptor-carries-the-contained-value.md) | A `.VAR` container descriptor carries the value its container holds | Accepted (implemented) |
 | [0065](0065-language-server-targets-ai-agents.md) | The language server targets AI agents, and is scoped to the protocol surface an agent actually consumes | Proposed (design only; no implementation) |
 | [0066](0066-call-dispatch-inline-cache.md) | Call dispatch resolves through a per-callsite inline cache, not a name-keyed hash map | Proposed (design only; no implementation) |
+| [0067](0067-a-routine-hands-back-the-container-it-was-given.md) | A routine hands back the container it was *given* — raw arguments, raw invocants, and the subscript step through an object | Proposed (Slice 1 implemented 2026-09-05; Slices 2-5 open) |

--- a/news/2026-09/sigilless-raw-param-returns-its-container.md
+++ b/news/2026-09/sigilless-raw-param-returns-its-container.md
@@ -1,0 +1,70 @@
+# A sigilless parameter's container survives the return
+
+`sub f(\x) is raw { x }; my $a = 42; f($a) = 5` died with `Cannot modify an
+immutable Int (42)`. So did the `is rw` spelling, and the explicit `return-rw x`
+spelling, and the method form `class C { method m(\x) is rw { x } }`. raku
+writes `5` through to `$a` in every one of them.
+
+## What was wrong
+
+ADR-0059 made an `is rw`/`is raw` routine compile its tail in *container mode*,
+so the routine hands its caller a storage location rather than a value. The tail
+compile recognises the location by asking `scalar_container_alias_name` for the
+lexical name an expression denotes the container of — and that function matches
+`Expr::Var` only.
+
+A **sigilless** lexical (`\x`) is spelled `Expr::BareWord` by the parser. Same
+local slot, same local name (`"x"`), different AST node — so the tail was never
+recognised and no cell was captured. The bytecode is the whole story:
+
+```
+sub f($x is rw) is rw { $x }    ->  GetLocal(0); WrapVarRef{name_idx:0,slot:0}; CaptureVarCell
+sub f(\x)       is rw { x }     ->  GetLocal(0)
+sub f(\x) { return-rw x }       ->  GetLocal(0); CallFunc "return-rw"
+```
+
+## The fix
+
+`return_rw_container_name` became a method so it can consult `self.local_map`,
+and gained a `BareWord` arm. The gate matters: `Expr::BareWord` is also how a
+type name, an enum value and a bare call are spelled, so a bareword denotes a
+container only when it actually resolves to a local slot of the frame being
+compiled — which is precisely what `local_map` records. Guessing from the
+spelling would have boxed `Int` in `my @a = (Int, Str)`.
+
+The arm is deliberately scoped to the `return-rw` / rw-tail site and **not**
+folded into `scalar_container_alias_name` itself, whose other callers (List
+literal elements, fat-arrow Pair values) see type-name barewords in ordinary
+code.
+
+## Measured
+
+Verified against raku v2026.07, before and after:
+
+| | raku | before | after |
+|---|---|---|---|
+| `sub f(\x) is raw { x }; f($a) = 5` | `5` | dies | `5` |
+| `sub f(\x) is rw { x }; f($a) = 5` | `5` | dies | `5` |
+| `sub f(\x) { return-rw x }; f($a) = 5` | `5` | dies | `5` |
+| `f($a).VAR.^name` | `Scalar` | `Int` | `Scalar` |
+| `my $b := f($a); $b = 7; say $a` | `7` | dies | `7` |
+| `my @a = 1,2; f(@a[0]) = 9` | `[9 2]` | dies | `[9 2]` |
+| `class C { method m(\x) is rw { x } }; C.new.m($a) = 5` | `5` | dies | `5` |
+
+Pinned by `t/sigilless-raw-param-container-return.t` — 21 tests, byte-identical
+output under `mutsu` and `raku`, including the non-regression rows that
+constrain the gate (`my @a = (Int, Str)`, `my $p = (a => Int)`, `my \y = 5`,
+`my \z := $v`, and a routine returning an inline sigilless declaration), and the
+row that keeps a *non*-rw-capable routine refusing.
+
+## Where this sits
+
+This is Slice 1 of
+[ADR-0067](../../docs/adr/0067-a-routine-hands-back-the-container-it-was-given.md),
+which is the design that unifies two open findings — a method handing back its
+invocant's container (`.snitch = ...`) and an lvalue subscript chain stepping
+through an object's `AT-KEY`/`AT-POS`. ADR-0067 corrects three claims those
+findings made: `.VAR` is not an acceptance case (raku refuses it too), the
+invocant problem is not native-specific (a user `augment` method fails
+identically), and the chain failure is silent in four of its six broken
+spellings rather than loud in all of them.

--- a/src/compiler/helpers_call_args.rs
+++ b/src/compiler/helpers_call_args.rs
@@ -62,7 +62,7 @@ impl Compiler {
                 self.code.patch_jump(jump_end);
             }
             _ => {
-                let cell_name = Self::return_rw_container_name(arg);
+                let cell_name = self.return_rw_container_name(arg);
                 self.compile_expr(arg);
                 if let Some(name) = cell_name {
                     self.emit_wrap_var_ref(&name);
@@ -79,16 +79,39 @@ impl Compiler {
     /// and an inline `my $x = ...` declaration, whose slot is live by the time
     /// the operand's value reaches the stack.
     ///
+    /// A **sigilless** lexical (`sub f(\x) is raw { x }`, `my \y := ...`) names
+    /// the same kind of storage location a `$`-sigiled one does, but the parser
+    /// gives it `Expr::BareWord` rather than `Expr::Var` — a bareword is also
+    /// how a type name, an enum value and a listop-less call are spelled, so it
+    /// is only a container reference when it actually resolves to a local slot
+    /// of the frame being compiled. That is exactly what `local_map` records, so
+    /// consult it rather than guessing from the spelling.
+    ///
+    /// Scoped to the `return-rw` / rw-tail site (`return_rw_container_name`) and
+    /// deliberately NOT folded into `scalar_container_alias_name`, whose other
+    /// callers (List literal elements, fat-arrow Pair values) see barewords that
+    /// are type names in ordinary code.
+    fn sigilless_local_container_name(&self, arg: &Expr) -> Option<String> {
+        let Expr::BareWord(name) = arg else {
+            return None;
+        };
+        (Self::is_plain_lexical_name(name) && self.local_map.contains_key(name))
+            .then(|| name.clone())
+    }
+
     /// Deliberately narrow. `@`/`%`/`&`-sigiled names, twigils, attributes and
     /// package-qualified names are excluded: their containers are reached by
     /// their own machinery, and boxing them into a scalar cell here would leak a
     /// `ContainerRef` past the consumers that only decontainerize at the scalar
     /// chokepoints.
-    fn return_rw_container_name(arg: &Expr) -> Option<String> {
+    fn return_rw_container_name(&self, arg: &Expr) -> Option<String> {
         if let Some(name) = Self::scalar_container_alias_name(arg)
             && Self::is_plain_lexical_name(name)
         {
             return Some(name.to_string());
+        }
+        if let Some(name) = self.sigilless_local_container_name(arg) {
+            return Some(name);
         }
         if let Expr::DoStmt(stmt) = arg
             && let Stmt::VarDecl { name, .. } = stmt.as_ref()

--- a/t/sigilless-raw-param-container-return.t
+++ b/t/sigilless-raw-param-container-return.t
@@ -1,0 +1,125 @@
+use Test;
+
+# ADR-0067 Slice 1: a SIGILLESS lexical (`\x`) names a storage location exactly
+# as a `$`-sigiled one does, so an `is rw` / `is raw` routine whose tail is a
+# bare sigilless name hands its caller that name's container.
+#
+# The parser spells a sigilless name `Expr::BareWord`, not `Expr::Var`, so the
+# container-mode tail compile never recognised it and the routine returned a
+# decontainerized value. Every expectation below was verified against
+# raku v2026.07.
+
+plan 21;
+
+# --- A. a sigilless parameter's container survives the return ---------------
+{
+    sub f(\x) is raw { x }
+    my $a = 42;
+    f($a) = 5;
+    is $a, 5, '`is raw` routine with a sigilless-name tail assigns through';
+}
+{
+    sub f(\x) is rw { x }
+    my $a = 42;
+    f($a) = 5;
+    is $a, 5, '`is rw` routine with a sigilless-name tail assigns through';
+}
+{
+    sub f(\x) { return-rw x }
+    my $a = 42;
+    f($a) = 5;
+    is $a, 5, 'an explicit `return-rw` of a sigilless name assigns through';
+}
+
+# --- B. the returned thing really is a container ----------------------------
+{
+    sub f(\x) is raw { x }
+    my $a = 42;
+    is f($a).VAR.^name, 'Scalar', 'the call result reports a Scalar container';
+    my $b := f($a);
+    $b = 7;
+    is $a, 7, 'binding the result and writing through reaches the source';
+    $a = 11;
+    is $b, 11, 'the binding sees a later write to the source (one shared cell)';
+}
+
+# --- C. an ordinary read still decontainerizes ------------------------------
+{
+    sub f(\x) is raw { x }
+    my $a = 42;
+    my $c = f($a);
+    $c = 7;
+    is $a, 42, 'a plain `my $c = f($a)` copies the value, it does not alias';
+}
+
+# --- D. the container comes from whatever produced the argument -------------
+{
+    sub f(\x) is raw { x }
+    my @a = 1, 2;
+    f(@a[0]) = 9;
+    is-deeply @a, [9, 2], 'a sigilless parameter over an array element';
+}
+{
+    sub f(\x) is raw { x }
+    my %h = a => 1;
+    f(%h<a>) = 9;
+    is %h<a>, 9, 'a sigilless parameter over a hash element';
+}
+
+# --- E. several parameters, and a computed tail -----------------------------
+{
+    sub f(\x, \y) is raw { y }
+    my $a = 1;
+    my $b = 2;
+    f($a, $b) = 9;
+    is $a, 1, 'the parameter that was NOT returned is untouched';
+    is $b, 9, 'the returned parameter is written through';
+}
+{
+    sub f(\x, \y, $c) is raw { $c ?? x !! y }
+    my $a = 1;
+    my $b = 2;
+    f($a, $b, True) = 9;
+    is $a, 9, 'a ternary tail assigns through the taken branch';
+    is $b, 2, 'and leaves the other branch alone';
+}
+
+# --- F. the method form -----------------------------------------------------
+{
+    class C { method m(\x) is rw { x } }
+    my $a = 42;
+    C.new.m($a) = 5;
+    is $a, 5, 'an `is rw` METHOD with a sigilless-name tail assigns through';
+}
+
+# --- G. a routine that is not rw-capable still refuses ----------------------
+{
+    sub f(\x) { x }
+    my $a = 42;
+    dies-ok { f($a) = 5 }, 'a plain sub with a sigilless tail is not assignable';
+    is $a, 42, 'and the source is unchanged';
+}
+
+# --- H. a bareword that is NOT a lexical must not be boxed ------------------
+# `Expr::BareWord` is also how a type name and an enum value are spelled; only a
+# bareword that resolves to a local slot denotes a container.
+{
+    my @a = (Int, Str);
+    is @a.map(*.^name).join(','), 'Int,Str', 'a list of type names is unaffected';
+    my $p = (a => Int);
+    is $p.value.^name, 'Int', 'a fat-arrow pair with a type-name value is unaffected';
+}
+{
+    my \y = 5;
+    is y, 5, 'an ordinary sigilless declaration still reads as its value';
+}
+{
+    my $v = 1;
+    my \z := $v;
+    z = 9;
+    is $v, 9, 'a sigilless binding to a scalar still aliases it';
+}
+{
+    sub f() is raw { my \w = 5; w }
+    is f(), 5, 'a routine returning an inline sigilless declaration reads back';
+}

--- a/todo/deep/native-method-cannot-return-an-lvalue-container.md
+++ b/todo/deep/native-method-cannot-return-an-lvalue-container.md
@@ -1,4 +1,10 @@
-# A native method cannot return its invocant's container, so `$x.VAR = ...` / `.snitch = ...` fail
+# A method cannot hand back its invocant's container, so `.snitch = ...` fails
+
+**Designed: [ADR-0067](../../docs/adr/0067-a-routine-hands-back-the-container-it-was-given.md)**
+(2026-09-05). Slice 1 of that ADR has landed; this file now tracks Slices 2-3,
+which own this repro. The ticket
+`todo/tickets/lvalue-chain-through-at-key-at-pos-object-root.md` is the same
+design's Slices 4-5 — read the ADR, not the two files, for the mechanism.
 
 Split off from `news/2026-08/snitch-method-unimplemented.md`, where the five
 other documented `snitch` examples were fixed and this one was not.
@@ -6,76 +12,76 @@ other documented `snitch` examples were fixed and this one was not.
 ## Repro
 
 ```raku
-my $a = 42;
-$a.VAR = 5;
-say $a;
-```
-
-- raku: `5`
-- mutsu: `X::Assignment::RO: cannot assign through .VAR on non-instance`
-
-The same shape, from `raku-doc/doc/Type/Any.rakudoc:1550`:
-
-```raku
 use v6.e.PREVIEW;
-(my $a = 42).snitch = 666; say $a;   # raku: 42 then 666; mutsu: the same error
+my $a = 42; $a.snitch = 5; say $a;   # raku: 42 then 5; mutsu: X::Assignment::RO
 ```
 
-## Root cause
+The parenthesised spelling in the original ticket
+(`(my $a = 42).snitch = 666`) is not required — plain `$a.snitch = 5` behaves
+the same in raku.
 
-mutsu's assign-through-a-method path
-(`src/runtime/methods_mut_method_lvalue.rs`) is **attribute-backed**: it locates
-a public attribute (or a role mixin entry) on an `Instance` receiver and writes
-into it. A user-declared `method p() is rw { return-rw $!v }` therefore works,
-because it resolves to an attribute in the end.
+## Root cause (corrected 2026-09-05 — the original diagnosis was wrong twice)
 
-A *native* method has nowhere to put the answer. `.VAR`, `.snitch` and friends
-are `is rw` in rakudo because they return the invocant's **container**, and in
-mutsu the receiver reaching the lvalue path is already the decontainerized value
-(`Int 42`), which is why the error is literally "on non-instance". There is no
-way for a native method to hand back a `ContainerRef` that the assignment could
-write through.
+The original text said (1) `my $a = 42; $a.VAR = 5` should print `5`, and
+(2) the defect is that *a native method* has nowhere to put the answer. Both are
+wrong, and ADR-0067 records the measurements:
 
-## Why it is not a small fix
+1. **`.VAR` is not an acceptance case.** raku also refuses `$a.VAR = 5`
+   (`Cannot assign to a readonly variable or a value`) — `.VAR` returns a
+   readonly `Scalar` object. (The 2026-09-01 note below caught this; the body
+   above it was never corrected, and an agent was later briefed with the wrong
+   expectation because of that.) Only `.snitch` is the acceptance case.
+2. **It is not a native-method problem.** A user-written
+   `augment class Any { method mysn(\SELF:) is raw { SELF } }; $a.mysn = 5`
+   fails identically. The contract raku enforces is that the invocant parameter
+   is raw (`\SELF:`) *and* the routine is `is raw`/`is rw`; dropping either
+   makes raku refuse too.
 
-Making this work means keeping `ContainerRef` alive across method dispatch —
-the receiver must arrive as a container, the native method must be able to
-return it, and the assignment path must recognise a returned container as an
-lvalue. That is exactly the "make `ContainerRef` deref universal" work
-(ADR-0001 §2.1 / Track B, now unblocked by
-[ADR-0013](../../docs/adr/0013-container-interior-mutability-cellvalue.md) §7),
-not a per-method patch. Adding a special case for `.snitch` alone would be a
-band-aid over a general gap.
+The real cause is that **the invocant never arrives as a container**. A
+*positional* raw parameter does — `sub f(\x) { x = 7 }; my $a = 42; f($a)`
+leaves `$a` at `7`, and so does `f(@a[0])` over an array element — but the
+invocant does not: `method mut(\S:) { S = 7 }` called as `$a.mut` leaves `$a` at
+`42` (raku: `7`).
 
-## Deep-triage update (2026-08-31)
+**Do not use `.VAR` to test this.** `S.VAR.WHAT` reports `(Scalar)` inside the
+method whether or not a container arrived, because ADR-0064 synthesises the
+descriptor from the contained value. Only mutating through the invocant and
+checking the caller distinguishes the two; a first pass at this investigation
+was misled by exactly that false positive.
 
-Moved from `todo/tickets/` after rechecking the current ADR outcomes.
-ADR-0001 §7 says its former Track-B/GC coupling is historical: first-class
-element cells now need an independently justified design. ADR-0013 §7 solved
-the interior-mutability safety prerequisite, but it does not define how a
-receiver `ContainerRef` survives every method-dispatch and lvalue-assignment
-path. This item therefore needs a bounded design campaign for universal
-container-reference propagation (including native-method returns) before an
-implementation slice can be selected. The existing `.VAR` and `.snitch`
-repros remain the acceptance cases; do not special-case either method.
+A second, adjacent gap in the same family: the method lvalue gate
+(`methods_mut_method_lvalue.rs:1363`) tests `method_def.is_rw` alone, while the
+sub path uses the shared `routine_is_rw_capable` oracle (`is rw || is raw ||
+return-rw`). `MethodDef` has no `is_raw` field at all, so
+`method m(\x) is raw { x }` and `method m(\x) { return-rw x }` are both refused
+with "method 'm' is not rw" even though the sub spellings now work.
 
-## Affected files (starting point)
+## What already works (so the remaining scope is small)
+
+- Production and consumption are both built (ADR-0059): `assign_lvalue_container`
+  writes through a returned `Proxy`/`ContainerRef`/`HashEntryRef`.
+- Since ADR-0067 Slice 1, a **sigilless name tail** returns its container, so
+  `sub f(\x) is raw { x }; f($a) = 5` and `class C { method m(\x) is rw { x } }`
+  both work. Pinned by `t/sigilless-raw-param-container-return.t`.
+- The lvalue call site already tags the invocant with `WrapVarRef` (carrying its
+  source name); the missing op is the `CaptureVarCell` the `return-rw` tail
+  emits right after it.
+
+## Affected files
 
 - `src/runtime/methods_mut_method_lvalue.rs` — the "cannot assign through .{} on
-  non-instance" site
-- `src/vm/vm_call_method_compiled.rs` — the compiled twin of that check
-- `src/runtime/methods_io_dispatch.rs` — `dispatch_snitch`, which would return
-  the container once one is reachable
+  non-instance" site (:1023) and the `is_rw`-only gate (:1363)
+- `src/ast.rs:1348` (`MethodDecl`) and `src/runtime/decl_types.rs:94`
+  (`MethodDef`) — neither carries `is_raw`
+- `src/runtime/methods_io_dispatch.rs` — `dispatch_snitch`
+- `src/builtins/methods_0arg/mod.rs:304` — takes `target: &Value`, so a native
+  method can already *receive* a container
 
-## Re-verified 2026-09-01 (TRIAGE regeneration)
+## Not the fix
 
-**The `.VAR` row's raku expectation above is wrong.** `raku -e 'my $a = 42;
-$a.VAR = 5; say $a'` does NOT print `5` — it dies with `Cannot assign to a
-readonly variable or a value`. Both implementations refuse; only the wording
-differs (`X::Assignment::RO: cannot assign through .VAR on non-instance` in
-mutsu). So `$a.VAR = 5` is not a divergence and must not be used as an
-acceptance case.
-
-The `.snitch` row is the real one and still reproduces: `use v6.e.PREVIEW;
-(my $a = 42).snitch = 666; say $a` prints `42` / `666` in raku and dies with
-the same RO error in mutsu. Keep `.snitch` as the acceptance case.
+Adding `snitch` to the compile-time erasure that already handles `.item` is
+**incorrect**, not merely a band-aid: `$a.item = 5` compiles to a plain store to
+`$a` with the call erased, which is sound only because `.item` is pure.
+`.snitch` notes its invocant (raku prints `42` before the assignment lands), and
+erasure would drop that. See ADR-0067's "What `.item` is, and why it is not the
+design".

--- a/todo/tickets/lvalue-chain-through-at-key-at-pos-object-root.md
+++ b/todo/tickets/lvalue-chain-through-at-key-at-pos-object-root.md
@@ -1,57 +1,68 @@
 # An lvalue subscript chain rooted at a subscriptable OBJECT is not routed through AT-KEY/AT-POS
 
-When the root of an lvalue subscript chain is an accessor that returns an
-**object** implementing `AT-KEY`/`AT-POS` — rather than a plain Array/Hash —
-the write does not reach it:
+**Designed: [ADR-0067](../../docs/adr/0067-a-routine-hands-back-the-container-it-was-given.md)**
+(2026-09-05), Slices 4 (variable-rooted) and 5 (method-rooted). The companion
+finding `todo/deep/native-method-cannot-return-an-lvalue-container.md` is Slices
+2-3 of the same design. Read the ADR for the mechanism; this file records the
+repro set.
 
-```raku
-class Q { has %.d is rw; method AT-KEY($k) is rw { %!d{$k} } }
-class U { has Q $.query = Q.new(d => {foo => [1,2]}) }
-my $u = U.new;
-$u.query<foo>[0] = 99;
-say $u.query.d;
-# raku:  {foo => [99 2]}
-# mutsu: Cannot subscript-assign through %!query: it returned Q, not an Array
-#        or Hash container
+When an lvalue subscript chain steps through an **object** implementing
+`AT-KEY`/`AT-POS` — rather than a plain Array/Hash — the write does not reach
+it.
+
+## Repro set (re-measured 2026-09-05 against raku v2026.07 and `main` @ 37dd63f33)
+
+All rows use `class Q { has %.d; method AT-KEY($k) is rw { %!d{$k} } }`.
+
+| Spelling | raku | mutsu |
+|---|---|---|
+| `$u.query<foo>[0] = 99` (method-rooted, depth 2 — the original headline) | `{foo => [99 2]}` | loud refusal: `Cannot subscript-assign through %!query: it returned Q, ...` |
+| `my $q = Q.new(...); $q<foo>[0] = 99` (**variable**-rooted, depth 2) | `{foo => [99 2]}` | `{foo => [1 2]}` — **silent, exit 0** |
+| `$u.query<foo> = 99` (method-rooted, depth 1) | `{foo => 99}` | `{foo => 1}` — **silent** |
+| `my $t := $u.query; $t<foo>[0] = 99` | `{foo => [99 2]}` | `{foo => [1 2]}` — **silent** |
+| `$q.AT-KEY("foo")[0] = 99` (explicit spelling) | `{foo => [99 2]}` | `{foo => [1 2]}` — **silent** |
+| `$q<foo><bar>[0] = 99` (depth 3) | `{foo => {bar => [99 2]}}` | `No such method 'd' for invocant of type 'Hash'` — **the instance is replaced by a Hash** |
+| `$q<foo> = 99` (var-rooted, depth 1) | `{foo => 99}` | correct |
+| `my $e := $q<foo>; $e[0] = 99` | `{foo => [99 2]}` | **correct** |
+| `$q<foo>.push(99)` | `{foo => [1 2 99]}` | correct |
+
+**Correction to the previous text.** This file said the failure is "at least
+loud and honest" now. That is true for exactly one of the six broken spellings;
+the other four are silent, and the depth-3 one corrupts the object. The
+variable-rooted silent row is the better acceptance case.
+
+## Root cause (gdb-confirmed 2026-09-05)
+
+`exec_index_assign_expr_nested_op` (`src/vm/vm_var_assign_index_named.rs:2963`)
+*does* have an Instance branch, and it *is* entered. Breaking at :2984, :3014
+and :3033 on the variable-rooted repro shows all three hit: the branch calls
+`AT-KEY`, discards its container on the very next line —
+
+```rust
+let inner = self.call_method_with_values(target, at, vec![inner_idx.clone()])?
+    .deref_container();
 ```
 
-Measured 2026-09-04 against `raku` v2026.06.
+— writes only if the element is a `Proxy` or the inner value is an Instance with
+`ASSIGN-*`, and otherwise falls through to the generic Hash/Array walk (:3033)
+against a root that is not a container. That walk drops the write, and at depth
+3 autovivifies a Hash over the instance.
 
-## History
+The accessor is called as an **rvalue**. The `:=`-bound row above proves the
+container-mode read of the same subscript already produces the right thing, so
+the fix is to call it in lvalue mode and descend into what comes back — the walk
+already descends `ContainerRef` (`descend_container_ref`, :3401).
 
-This shape has never worked. Before
-`news/2026-09/method-rooted-lvalue-subscript-chain-writes-through.md` it was
-handled by `__mutsu_index_assign_method_lvalue_nested`, whose `Instance` branch
-looked for a `Proxy` element behind `AT-POS`/`AT-KEY` and, finding none, fell
-through to a typed-attribute check that then fired on the *outer* object — so
-the same code answered a nonsensical `Type check failed for an element of
-@query ...; expected Q but got Hash`. The `:=`-bound spelling
-(`my $t := $u.query; $t<foo>[0] = 99`) dropped the write silently.
+The method-rooted half has the same shape one level up: the compiler temp
+`bind_method_rooted_chain_root` installs
+(`src/compiler/expr_closure.rs:606,639`) is filled by a plain
+`self.compile_expr(cur)`, an rvalue read.
 
-Now that the chain is routed through the variable-rooted walk, the failure is
-at least loud and honest: the walk refuses a root that is not a container.
+## Not the fix
 
-## What a fix needs
-
-The chain walk (`exec_index_assign_expr_nested_op` /
-`exec_index_assign_deep_nested_op` in `src/vm/vm_var_assign_index_named.rs`)
-descends only into `Array`/`Hash`/`ContainerRef` roots. For an `Instance` root
-it would have to call the user's `AT-KEY`/`AT-POS` — in **lvalue** mode, so the
-returned element is a container it can store through (an `is rw` method, or a
-`Proxy`). That is the same "a method must be able to return an lvalue
-container" problem as `todo/deep/native-method-cannot-return-an-lvalue-container.md`,
-and it should be designed with it rather than special-cased here.
-
-Do NOT fix this by reintroducing an accessor-keyed slow path: the deleted one
-is exactly what dropped the writes this ticket's neighbours were about.
-
-## Re-verified 2026-09-05
-
-Still reproduces on `main` at `e4994a3`, with the same loud error
-("Cannot subscript-assign through %!query: it returned Q, not an Array or Hash
-container"). The dependency named above has also not moved: the
-2026-08-31 deep-triage note on
-`todo/deep/native-method-cannot-return-an-lvalue-container.md` says a bounded
-design campaign for universal container-reference propagation has to happen
-before an implementation slice can be selected, and no such campaign has
-started. So this ticket is still blocked on that design, not on effort.
+Do NOT reintroduce an accessor-keyed slow path. The deleted
+`__mutsu_index_assign_method_lvalue_nested` is exactly what dropped the writes
+this ticket's neighbours were about
+(`news/2026-09/method-rooted-lvalue-subscript-chain-writes-through.md`); its
+copy-on-write rebuild is what made autovivified levels evaporate. ADR-0067's
+routing adds no new walker.

--- a/todo/tickets/self-method-does-not-decontainerize.md
+++ b/todo/tickets/self-method-does-not-decontainerize.md
@@ -1,0 +1,43 @@
+# `.self` does not decontainerize, so `$a.self =:= $a` answers True
+
+Measured 2026-09-05 against raku v2026.07 and `main` @ `37dd63f33`, while
+surveying the raw-invocant method family for
+[ADR-0067](../../docs/adr/0067-a-routine-hands-back-the-container-it-was-given.md).
+
+## Repro
+
+```raku
+my $a = 42;        say ($a.self =:= $a);   # raku: False   mutsu: True
+class C {}; my $c = C.new;
+                   say ($c.self =:= $c);   # raku: False   mutsu: True
+my @a = 1, 2;      say (@a.self =:= @a);   # raku: True    mutsu: True    (agrees)
+my $a = 42;        say ($a.item =:= $a);   # raku: True    mutsu: True    (agrees)
+```
+
+## Why it matters
+
+`.self` looks like it belongs to the raw-invocant family (`.item`, `.snitch`)
+and it does not. In Rakudo `.item` hands the invocant's **container** back
+(`$a.item =:= $a` is `True`, and `$a.item = 5` writes `$a`), whereas `.self`
+hands back the **value** — `$a.self = 5` is refused, and the identity test is
+`False` for anything held in a scalar container.
+
+mutsu returns the invocant unchanged for `.self`, container and all, so it
+reports `True` where raku reports `False`. The `@`/`%` rows agree because those
+sigils pass the container itself either way.
+
+ADR-0067 lists this as an explicit non-goal so the family survey does not sweep
+`.self` in by mistake; it is recorded here so the divergence itself is not lost.
+
+## Scope
+
+Small and self-contained: make `.self` decontainerize its invocant. The risk to
+check before shipping is the `@`/`%` rows above, which must keep answering
+`True`, and any internal caller that uses `.self` as an identity-preserving
+no-op.
+
+## Not a duplicate of
+
+- `todo/deep/native-method-cannot-return-an-lvalue-container.md` — that is the
+  opposite direction (a method that *should* hand back a container and does
+  not). This one hands back a container it should not.


### PR DESCRIPTION
Records **[ADR-0067](https://github.com/tokuhirom/mutsu/blob/design/method-lvalue-container/docs/adr/0067-a-routine-hands-back-the-container-it-was-given.md)** — the design that unifies two open findings that both say they are the same problem — and ships its Slice 1.

## The design

ADR-0059 established that *an `is rw` routine returns a container* and built two of the three halves that needs: **production** (compile a `return-rw` / rw tail in container mode) and **consumption** (`assign_lvalue_container` writes through a returned `Proxy`/`ContainerRef`/`HashEntryRef`). What it did not build is **inbound transport**: a routine can only hand back a location it was *given*, and mutsu's argument and invocant paths hand it values.

ADR-0067's rule: **a raw parameter binds the caller's container, and the invocant is parameter zero.** Both findings fall out of that one statement — the `.snitch` case is the invocant producer, and the `AT-KEY`/`AT-POS` chain case is the same lvalue-mode call used as a subscript step.

## What the measurements corrected

Everything was re-measured against `raku` v2026.07 and `main` @ `37dd63f33`. **Three central claims of the two findings are wrong**, and the ADR corrects rather than carries them:

1. **`.VAR` is not an acceptance case.** raku also refuses `my $a = 42; $a.VAR = 5` (`Cannot assign to a readonly variable or a value`) — `.VAR` returns a readonly `Scalar` object. Only `.snitch` is the case, and it needs no parentheses.
2. **It is not a native-method problem.** A user-written `augment class Any { method mysn(\SELF:) is raw { SELF } }; $a.mysn = 5` fails identically. raku's contract is that the invocant is raw (`\SELF:`) *and* the routine is `is raw`/`is rw` — dropping either makes raku refuse too.
3. **The chain failure is loud in one of six broken spellings.** Four are silent (including the variable-rooted one, which is the better acceptance case), and the depth-3 one replaces the instance with a Hash.

Two more findings that shaped the design:

- **`.item` is not a precedent.** `$a.item = 5` compiles to a plain store to `$a` with the call *erased* — sound only because `.item` is pure. `.snitch` notes its invocant (raku prints `42` before `666`), so adding it to the erasure list is not a band-aid but incorrect.
- **`.VAR` is a false-positive container oracle.** `method vv(\S:) { say S.VAR.WHAT }` reports `(Scalar)` in mutsu whether or not a container arrived (ADR-0064 synthesises the descriptor). Only the *mutation* discriminator separates them — and it shows positional raw params do get the container while the invocant does not. That nearly produced a wrong ADR.

`rust-gdb` breakpoints at `vm_var_assign_index_named.rs:2984/:3014/:3033` confirm the chain walk enters its Instance branch, calls `AT-KEY` as an **rvalue**, discards the container on the next line with `.deref_container()`, and falls through to the generic walk against a non-container root. Since `my $e := $q<foo>; $e[0] = 99` already works, that half is a producer that is not consulted — not a missing walker.

## Slice 1 (shipped here)

`sub f(\x) is raw { x }; my $a = 42; f($a) = 5` died with `Cannot modify an immutable Int (42)`. The bytecode is the whole story:

```
sub f($x is rw) is rw { $x }   ->  GetLocal(0); WrapVarRef; CaptureVarCell
sub f(\x)       is rw { x }    ->  GetLocal(0)
```

Same slot, same local name `"x"` — the only difference is the tail's AST node. `$x` parses to `Expr::Var`, a sigilless `\x` parses to `Expr::BareWord`, and `scalar_container_alias_name` matches only `Expr::Var`.

`return_rw_container_name` becomes a method so it can consult `self.local_map`, and gains a `BareWord` arm gated on the name actually resolving to a local slot. That gate is load-bearing — `Expr::BareWord` is also how a type name and an enum value are spelled, so guessing from the spelling would box `Int` in `my @a = (Int, Str)`. The arm is scoped to the rw-tail site and **not** folded into `scalar_container_alias_name`, whose other callers (List literal elements, fat-arrow Pair values) legitimately see type-name barewords.

| | raku | before | after |
|---|---|---|---|
| `sub f(\x) is raw { x }; f($a) = 5` | `5` | dies | `5` |
| `sub f(\x) is rw { x }; f($a) = 5` | `5` | dies | `5` |
| `sub f(\x) { return-rw x }; f($a) = 5` | `5` | dies | `5` |
| `f($a).VAR.^name` | `Scalar` | `Int` | `Scalar` |
| `my $b := f($a); $b = 7; say $a` | `7` | dies | `7` |
| `my @a = 1,2; f(@a[0]) = 9` | `[9 2]` | dies | `[9 2]` |
| `class C { method m(\x) is rw { x } }; C.new.m($a) = 5` | `5` | dies | `5` |

## Remaining slices (open, each with its own acceptance repro in the ADR)

2. One rw-capability oracle for methods — `MethodDef` has no `is_raw` field, so `method m(\x) is raw { x }` is refused while the sub spelling now works.
3. The invocant arrives as a container — delivers `.snitch`, plus the element/attribute invocant spellings.
4. The chain walk steps through an object in lvalue mode — delivers the variable-rooted `AT-KEY` case.
5. The method-rooted chain root compiles in container mode — delivers the ticket's headline.

## Also filed

`todo/tickets/self-method-does-not-decontainerize.md` — `.self` returns its invocant container-and-all, so `$a.self =:= $a` answers `True` where raku answers `False`.

## Gates

- `t/sigilless-raw-param-container-return.t` — 21 tests, byte-identical output under `mutsu` and `raku`, including the non-regression rows that constrain the gate (`my @a = (Int, Str)`, `my $p = (a => Int)`, `my \y = 5`, `my \z := $v`, and a non-rw-capable routine that must keep refusing).
- Targeted roast, all pass: `S12-methods/lvalue.t`, `S06-traits/misc.t`, `S06-traits/slurpy-is-rw.t`, `S14-traits/routines.t`, `S12-attributes/mutators.t`, `S06-other/pairs-as-lvalues.t`, `S03-binding/nested.t`, `S06-signature/slurpy-params.t` (207 tests).
- `cargo fmt` and `cargo clippy -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
