### PR TITLE
fix: reject assignment to a bare block's immutable implicit topic

### DIFF
--- a/news/2026-09/closure-and-map-grep-topic-readonly.md
+++ b/news/2026-09/closure-and-map-grep-topic-readonly.md
@@ -1,0 +1,99 @@
+# A bare block's implicit topic is read-only when it aliases an immutable item
+
+`(1, 2).map({ $_ = 5 })`, `(1, 2).grep({ $_ = 5 })` and `my $s = { $_ = 5 };
+$s(7)` — the three closure-topic rows of
+`todo/deep/immutable-lvalues-that-mutsu-still-lets-you-assign-to.md` — all
+succeeded silently in mutsu where rakudo throws `X::AdHoc`, "Cannot assign to an
+immutable value". They now answer exactly what rakudo answers, and so do six
+neighbours found on the way (`(1..3).map`, `%h.keys.map`, the listop
+`map { $_ = 5 }, 1, 2` and its `grep` twin, `{ $_ = 5 }(3 + 4)`, and the
+`&`-sigiled `my &s = { $_ = 5 }; s(7)`).
+
+## The blocker the ticket recorded did not exist, and neither did its successor
+
+The ticket said these rows were blocked on "separating the direct value call and
+native map rw-writeback callers of `call_compiled_closure_with_topic`, which
+currently share it". A gdb-instrumented sweep disproved that: `capture_rw_topic
+== true` is produced by exactly one call site in the tree (`vm_native_map.rs`,
+gated on `writeback_name.is_some()`), so it already means precisely "this topic
+is an element of a named real `Array` that will be written back" — the
+separation was already there. The two `.map`/`.grep`-over-a-literal rows never
+reach that function at all; they land in `eval_map_over_items` /
+`eval_grep_over_items_with_mutated` and bind the topic at `bind_loop_topic`.
+
+The obvious replacement — decide per item at runtime, `!item.is_container_ref()`,
+the test `vm_for_loop_lazy.rs` already applies on the lazy `for` path — was
+measured and rejected. A real `Array`'s elements are stored **bare** in mutsu, so
+that test additionally rejects five shapes rakudo accepts: `@a.list.map({ $_ = 7
+})`, `@a[0..1].map(...)`, `@a.Seq.map(...)`, `my $x = [1,2,3]; $x.map(...)` and a
+`.sort` key extractor. Turning a silent no-op into a spurious throw is a worse
+answer, not a better one, so the runtime rule was dropped.
+
+## What shipped instead: the receiver's syntax, decided at compile time
+
+The oracle is `Compiler::for_iterable_yields_bare_items` — the same conservative
+predicate that fixed the `for`-loop topic rows in August (`for 1, 2 { $_ = 5 }`
+and `(1, 2).map({ $_ = 5 })` are the same rejection in rakudo, for the same
+reason). When a `.map`/`.grep` (method or listop form) is written directly
+against a source it proves bare, the bare-block argument is compiled with a new
+`CompiledCode::immutable_topic` flag, and the three loops mark `$_` read-only per
+iteration. Because the predicate answers `false` for every variable and every
+derived receiver, no shape that works today starts throwing.
+
+The direct value call (`$s(7)`) is the same idea at the argument end: a new
+`Compiler::expr_yields_container_less_value` recognises an argument expression
+that provably mints a fresh value (a literal, or an operator result built only
+out of such), `OpCode::CallOnValue`/`CallOnCodeVar` carry that verdict as a
+`bare_args` flag, and `call_compiled_closure_with_topic` marks the implicit topic
+when it holds. `{ $_ = 9 }($v)` and `{ $_ = 9 }(@a[0])` — which rakudo lets write
+through — are excluded by construction, since a variable and a subscript are both
+outside the predicate.
+
+Both marks are made at the **call/loop site**, never as an injected body prologue:
+a prologue statement runs wherever the bytecode does, including the
+`push_call_frame`-bypassing native loops, where a mark with no readonly frame open
+skips the undo journal and leaks permanently (the trap the `-> $v { $v = 1 }` fix
+already hit). The grep loop, which had no per-iteration `ReadonlyFrameGuard` while
+both map loops did, gained one.
+
+## Five pre-existing divergences fell out of making the marking symmetric
+
+`readonly_vars` is keyed by the bare name `_`, so a construct that marked its own
+topic immutable left that mark in force inside *any* nested topic binding. That
+was already wrong before this change, and it is why `for 1, 2 { ... }` bodies were
+oddly restricted:
+
+```
+for 1, 2 { my @b = 7,8; for @b { $_ = 1 } }     # threw; rakudo: fine
+sub f() { $_ = 5 }; for 1, 2 { f() }            # threw; rakudo: fine
+my @a = 1,2,3; for 1, 2 { @a.map({ $_ = 5 }) }  # threw; rakudo: [5 5 5]
+my @a = 1,2,3; for 1, 2 { @a.grep({ $_ = 5 }) } # threw; rakudo: [5 5 5]
+```
+
+Every construct that binds a topic now sets its writability in **both**
+directions rather than only marking: the eager `for` loop clears the mark when
+its own topic is writable (and restores the caller's marking on all three exit
+paths), the map/grep loops do the same per iteration inside their readonly
+frames, `call_compiled_closure_with_topic` clears it for a writable implicit
+topic and for a routine's fresh `$_`, and `call_compiled_function_fast` — which
+deliberately opens no readonly frame — saves the topic's kind and puts it back on
+the way out, matching the `unmark_readonly_topic` every other call path already
+did.
+
+## Pins
+
+`t/closure-topic-readonly.t` (31 assertions) pins both halves in one file, so a
+future change cannot fix one by breaking the other: the rejected shapes, the
+write-through shapes that must keep working (`@a.map({ $_ *= 10 })`,
+`@a.map({ $_ = 5 })`, `@a.grep({ $_ = 5 })`, `%h.values.map({ $_ = 9 })`,
+`@a.values.map({ $_ = 7 })`, the listop `map { $_ = 5 }, @a`, and a block called
+with a variable or an element), the read-only uses of the topic, and the five
+nesting cases above. Every expectation was measured against rakudo first; the
+whole file passes under `raku` as well as under mutsu.
+
+What is still open — the `@`-bound-List and `Seq`-variable receivers, `.first`
+over a literal, `for %h`, the element shapes where mutsu drops the write instead
+of performing it, and the error *class* rakudo uses for a compound assignment —
+is recorded in
+`todo/deep/immutable-lvalues-that-mutsu-still-lets-you-assign-to.md` with the
+measurements that separate them from what landed here.

--- a/src/compiler/expr_block.rs
+++ b/src/compiler/expr_block.rs
@@ -969,6 +969,12 @@ impl Compiler {
             }
             return;
         }
+        // A bare block invoked with only syntactically container-less arguments
+        // binds its implicit `$_` to a value with no container behind it, which
+        // raku refuses to assign to (`{ $_ = 5 }(7)`). Decided here, from the
+        // call site's own syntax, because the block is compiled elsewhere and
+        // the same block is writable when called with an lvalue.
+        let bare_args = !args.is_empty() && args.iter().all(Self::expr_yields_container_less_value);
         if let Expr::CodeVar(name) = target {
             let arg_sources_idx = self.add_arg_sources_constant(args);
             for arg in args {
@@ -991,6 +997,7 @@ impl Compiler {
                 name_idx,
                 arity: args.len() as u32,
                 arg_sources_idx,
+                bare_args,
             });
         } else {
             self.compile_expr(target);
@@ -1008,6 +1015,7 @@ impl Compiler {
             self.code.emit(OpCode::CallOnValue {
                 arity: args.len() as u32,
                 arg_sources_idx,
+                bare_args,
             });
         }
     }

--- a/src/compiler/expr_call.rs
+++ b/src/compiler/expr_call.rs
@@ -1686,6 +1686,14 @@ impl Compiler {
                 // and the synthetic callsite-line marker must remain an
                 // in-band pair for `peek_callsite_line`.
                 let mut named_entries: Vec<crate::opcode::NamedArgEntry> = Vec::new();
+                // The listop form of the same rule the method form gets in
+                // `expr_method.rs`: `map { $_ = 5 }, 1, 2` binds the callback's
+                // implicit topic to a bare item, which raku refuses to assign
+                // to. See `CompiledCode::immutable_topic`.
+                let immutable_topic_cb = args.len() >= 2
+                    && matches!(name.resolve().as_str(), "map" | "grep")
+                    && Self::is_bare_block_arg(&args[0])
+                    && args[1..].iter().all(Self::for_iterable_yields_bare_items);
                 let wb_base = self.index_rw_writeback_base();
                 for (i, arg) in args.iter().enumerate() {
                     // `start` keeps marking EVERY argument escaping, exactly as
@@ -1717,9 +1725,11 @@ impl Compiler {
                             })
                         });
                     } else {
+                        self.pending_immutable_topic_block = immutable_topic_cb && i == 0;
                         self.with_thread_escape(thread_escaping, |s| {
                             s.compile_call_arg_with_escape(arg, escaping_args)
                         });
+                        self.pending_immutable_topic_block = false;
                     }
                 }
                 let name_idx = self.code.add_constant(Value::str(name.resolve()));

--- a/src/compiler/expr_closure.rs
+++ b/src/compiler/expr_closure.rs
@@ -73,15 +73,20 @@ impl Compiler {
     /// `is_block` = true for bare blocks `{ }`, false for `sub { }`.
     /// Bare blocks are NOT routine boundaries for `return`.
     pub(super) fn compile_expr_anon_sub(&mut self, body: &[Stmt], is_rw: bool, is_block: bool) {
+        // One-shot, consumed here so only THIS block (not one nested inside it)
+        // picks up the enclosing `.map`/`.grep`-over-a-literal verdict the
+        // caller set -- see `CompiledCode::immutable_topic`.
+        let immutable_topic = std::mem::take(&mut self.pending_immutable_topic_block);
         if is_rw {
             // A bare `is rw` block (a `<->`-style loop body) keeps its tail
             // as a value; only an anonymous `sub ... is rw` hands out its
             // tail's container (ADR-0059 Slice 2).
-            let compiled = if is_block {
+            let mut compiled = if is_block {
                 self.compile_closure_body(&[], &[], body)
             } else {
                 self.compile_routine_closure_body(&[], &[], body, true)
             };
+            compiled.immutable_topic = immutable_topic;
             let esc = self.escaping_position;
             let cc_idx = self.add_closure_code_baked(compiled, esc);
             let idx = self.code.add_stmt(Stmt::SubDecl {
@@ -122,11 +127,15 @@ impl Compiler {
                 return;
             }
             let placeholders = crate::ast::collect_placeholders_shallow(body);
-            let compiled = if is_block {
+            let mut compiled = if is_block {
                 self.compile_closure_body(&placeholders, &[], body)
             } else {
                 self.compile_routine_closure_body(&placeholders, &[], body, false)
             };
+            // Only a bare, parameterless block topicalizes the element; a
+            // placeholder block (`{ $^a }`) binds its own parameter and keeps
+            // the enclosing `$_`.
+            compiled.immutable_topic = immutable_topic && placeholders.is_empty();
             let esc = self.escaping_position;
             let cc_idx = self.add_closure_code_baked(compiled, esc);
             let idx = self.code.add_stmt(Stmt::Block(body.to_vec()));

--- a/src/compiler/expr_method.rs
+++ b/src/compiler/expr_method.rs
@@ -290,6 +290,7 @@ impl Compiler {
             && !quoted
             && args.len() == 2
             && matches!(&args[1], Expr::Var(n) if !n.contains("::"));
+        let immutable_topic_cb = Self::method_binds_immutable_topic(target, &mname);
         for (i, arg) in args.iter().enumerate() {
             // Only the closure literal itself is escaping (see
             // `is_closure_literal_arg`); the legacy `then`/`tap`/`act`/`start`
@@ -297,9 +298,11 @@ impl Compiler {
             let arg_esc = esc
                 && (Self::is_closure_literal_arg(Self::unwrap_named_arg_value(arg))
                     || matches!(mname.as_str(), "then" | "tap" | "act" | "start"));
+            self.pending_immutable_topic_block = immutable_topic_cb && Self::is_bare_block_arg(arg);
             self.with_thread_escape(thread_esc, |s| {
                 s.compile_method_arg_with_escape(arg, arg_esc)
             });
+            self.pending_immutable_topic_block = false;
             if pair_value_capture
                 && i == 1
                 && let Expr::Var(n) = arg
@@ -523,6 +526,25 @@ impl Compiler {
         self.compile_expr_method_on_index(&final_target, name, args, modifier, quoted);
     }
 
+    /// Does a `.map`/`.grep` written directly against `target` bind its
+    /// callback's implicit `$_` to an item with no container of its own?
+    ///
+    /// Reuses the `for`-loop oracle
+    /// ([`Compiler::for_iterable_yields_bare_items`]): `(1, 2).map({ $_ = 5 })`
+    /// and `for 1, 2 { $_ = 5 }` are the same rejection in raku, for the same
+    /// reason. Conservative — a variable/derived receiver answers `false`, so
+    /// `@a.map({ $_ = 5 })` and every shape mutsu cannot prove bare keep
+    /// today's writable topic. See [`crate::opcode::CompiledCode::immutable_topic`].
+    pub(super) fn method_binds_immutable_topic(target: &Expr, mname: &str) -> bool {
+        matches!(mname, "map" | "grep") && Self::for_iterable_yields_bare_items(target)
+    }
+
+    /// A directly-written bare block argument (`{ ... }`), the only shape whose
+    /// implicit topic this call site can speak for.
+    pub(super) fn is_bare_block_arg(arg: &Expr) -> bool {
+        matches!(arg, Expr::AnonSub { is_block: true, .. })
+    }
+
     /// Compile method call on non-variable target (no writeback needed).
     pub(super) fn compile_expr_method_generic(
         &mut self,
@@ -692,14 +714,17 @@ impl Compiler {
         let esc = Self::method_escapes_closure_args(&mname);
         // `Thread.start` / `Promise.start` hand the block to a thread.
         let thread_esc = mname == "start";
+        let immutable_topic_cb = Self::method_binds_immutable_topic(target, &mname);
         for arg in args {
             // See the sibling loop in `compile_expr_method_call`.
             let arg_esc = esc
                 && (Self::is_closure_literal_arg(Self::unwrap_named_arg_value(arg))
                     || matches!(mname.as_str(), "then" | "tap" | "act" | "start"));
+            self.pending_immutable_topic_block = immutable_topic_cb && Self::is_bare_block_arg(arg);
             self.with_thread_escape(thread_esc, |s| {
                 s.compile_method_arg_with_escape(arg, arg_esc)
             });
+            self.pending_immutable_topic_block = false;
         }
         let name_idx = self.code.add_constant(Value::str(name.resolve()));
         let modifier_idx = modifier.map(|m| self.code.add_constant(Value::str(m.to_string())));

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -1386,6 +1386,13 @@ pub(crate) struct Compiler {
     /// sub-expressions, so a Pair nested in the value (`f(a => (b => 1))`)
     /// does not inherit it — only the outermost, genuinely-named pair does.
     mint_named_pair: bool,
+    /// One-shot: the block argument about to be compiled is the callback of a
+    /// `.map`/`.grep` (method or listop form) whose source provably yields bare
+    /// items, so its implicit `$_` aliases an immutable value. Set only around
+    /// compiling that one argument; `compile_expr_anon_sub` reads and clears it
+    /// at entry, so a block nested inside the callback does not inherit it.
+    /// See [`crate::opcode::CompiledCode::immutable_topic`].
+    pending_immutable_topic_block: bool,
     /// Variables declared as `constant` (no Scalar container).
     constant_vars: std::collections::HashSet<String>,
     /// Scalar variables `:=`-bound to a non-itemized value (no Scalar
@@ -1638,6 +1645,7 @@ impl Compiler {
             rw_tail: false,
             bind_target_direct: false,
             mint_named_pair: false,
+            pending_immutable_topic_block: false,
             constant_vars: std::collections::HashSet::new(),
             noncontainer_bound_vars: std::collections::HashSet::new(),
             constant_vars_in_scope: std::collections::HashSet::new(),
@@ -3242,6 +3250,49 @@ impl Compiler {
                 target, name, args, ..
             } if args.is_empty() && *name == "keys" => {
                 matches!(target.as_ref(), Expr::ArrayVar(_) | Expr::HashVar(_))
+            }
+            _ => false,
+        }
+    }
+
+    /// Whether `expr` provably evaluates to a value that has no container of
+    /// its own — a literal, or an operator result built only out of such.
+    ///
+    /// Used to decide whether a bare block invoked as `$b(EXPR)` binds its
+    /// implicit `$_` to something assignable: raku rejects `{ $_ = 5 }(7)`
+    /// ("Cannot assign to an immutable value") but accepts `{ $_ = 9 }($v)`
+    /// and `{ $_ = 9 }(@a[0])`, which alias the caller's container. Deliberately
+    /// conservative — anything that could denote an lvalue (a variable, a
+    /// subscript, an attribute, a call result) answers `false`, so a missed
+    /// shape only leaves today's behaviour in place instead of inventing a
+    /// throw raku does not have.
+    pub(crate) fn expr_yields_container_less_value(expr: &Expr) -> bool {
+        use crate::token_kind::TokenKind;
+        match expr {
+            Expr::Grouped(inner) => Self::expr_yields_container_less_value(inner),
+            // A container-valued literal is excluded: `[1,2]`/`{a=>1}` are
+            // containers whose elements stay assignable.
+            Expr::Literal(v) => !matches!(
+                v.view(),
+                crate::value::ValueView::Array(..) | crate::value::ValueView::Hash(..)
+            ),
+            Expr::Unary { op, expr } => {
+                matches!(op, TokenKind::Minus | TokenKind::Plus | TokenKind::Bang)
+                    && Self::expr_yields_container_less_value(expr)
+            }
+            // An arithmetic/string operator always mints a fresh value.
+            Expr::Binary { left, op, right } => {
+                matches!(
+                    op,
+                    TokenKind::Plus
+                        | TokenKind::Minus
+                        | TokenKind::Star
+                        | TokenKind::Slash
+                        | TokenKind::Percent
+                        | TokenKind::StarStar
+                        | TokenKind::Tilde
+                ) && Self::expr_yields_container_less_value(left)
+                    && Self::expr_yields_container_less_value(right)
             }
             _ => false,
         }

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -1475,11 +1475,22 @@ pub(crate) enum OpCode {
     CallOnValue {
         arity: u32,
         arg_sources_idx: Option<u32>,
+        /// Every positional argument at this call site is a syntactically
+        /// container-less expression (a literal, or an operator result built
+        /// only out of such) — see
+        /// [`crate::compiler::Compiler::expr_yields_container_less_value`].
+        /// A bare block invoked this way binds its implicit `$_` to a value
+        /// with no container, so `{ $_ = 5 }(7)` is `X::AdHoc` "Cannot assign
+        /// to an immutable value" in raku while `{ $_ = 5 }($v)` writes
+        /// through. Consumed via `Interpreter::pending_call_topic_bare`.
+        bare_args: bool,
     },
     CallOnCodeVar {
         name_idx: u32,
         arity: u32,
         arg_sources_idx: Option<u32>,
+        /// See [`OpCode::CallOnValue`]'s `bare_args`.
+        bare_args: bool,
     },
     /// Third field: true when this is a bare block `{ }`, false for `sub { }`.
     MakeAnonSub(u32, Option<u32>, bool),
@@ -4087,6 +4098,25 @@ pub(crate) struct CompiledCode {
     /// `push_call_frame`-bypassing "fast native loop" paths, which would leak
     /// the mark permanently).
     pub(crate) pointy_alias_param: bool,
+    /// Whether this block was written directly as the callback of a
+    /// `.map`/`.grep` (method or listop form) whose SOURCE provably yields bare
+    /// items — a list of literals, a `Range`, `%h.keys` (the same
+    /// [`crate::compiler::Compiler::for_iterable_yields_bare_items`] oracle the
+    /// `for`-loop topic marking uses). raku binds the callback's implicit `$_`
+    /// to the source element, so with no container behind that element
+    /// `$_ = ...` is `X::AdHoc` "Cannot assign to an immutable value"
+    /// (`(1, 2).map({ $_ = 5 })`) — while `@a.map({ $_ = 5 })` writes through.
+    ///
+    /// Decided at COMPILE time from the receiver's syntax rather than at
+    /// runtime from the element's shape: a real `Array`'s elements are stored
+    /// bare in mutsu, so a runtime "is this item a container" test would
+    /// additionally reject `@a.list.map({ $_ = 5 })`, `@a[0..1].map(...)` and
+    /// `@a.Seq.map(...)`, all of which raku accepts (measured 2026-09-05).
+    ///
+    /// Consumed at the loop/call site (`resolution_map_grep*.rs`,
+    /// `call_compiled_closure_with_topic`), never as a body prologue — see
+    /// `pointy_alias_param` above for why a prologue leaks the mark.
+    pub(crate) immutable_topic: bool,
     /// Whether this code contains opcodes that write to env (SetGlobal,
     /// AssignExpr, PostIncrement, etc.). Used by call_compiled_method to
     /// skip the expensive env merge when the method body is read-only.
@@ -4884,6 +4914,7 @@ impl CompiledCode {
             source_line: None,
             is_pointy_block: false,
             pointy_alias_param: false,
+            immutable_topic: false,
             has_env_writes: false,
             may_capture_outer_vars: false,
             needs_env_sync: Vec::new(),

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1707,6 +1707,14 @@ pub struct Interpreter {
     /// `X::Attribute::NoPackage`.
     pub(crate) defining_class: Option<String>,
     pending_call_arg_sources: Option<Vec<Option<String>>>,
+    /// Every positional argument of the value-call currently being dispatched
+    /// (`$b(7)` / `&b(7)` — `OpCode::CallOnValue`/`CallOnCodeVar`'s `bare_args`)
+    /// is a syntactically container-less expression, so a bare block's implicit
+    /// `$_` aliases a value with no container and raku refuses `$_ = ...`
+    /// inside it. Read (and cleared) by `call_compiled_closure_with_topic`
+    /// BEFORE it pushes its call frame; `push_call_frame` clears it too, so the
+    /// flag can never leak past one call boundary into an unrelated block.
+    pub(crate) pending_call_topic_bare: bool,
     /// Set while `require` resolves a module: a missing `Test::`-namespace
     /// module must surface as a catchable X::CompUnit::UnsatisfiedDependency
     /// instead of the silent no-op `use Test::Util` relies on.

--- a/src/runtime/resolution_map_grep.rs
+++ b/src/runtime/resolution_map_grep.rs
@@ -90,6 +90,35 @@ pub(crate) fn bind_loop_topic(
     }
 }
 
+/// Set the topic's read-only marking for one iteration of a map/grep loop.
+///
+/// raku binds a callback's implicit `$_` to the source ELEMENT, so `$_ = ...`
+/// is legal exactly when that element has a container behind it:
+/// `(1, 2).map({ $_ = 5 })` throws X::AdHoc "Cannot assign to an immutable
+/// value" while `@a.map({ $_ = 5 })` writes through. `immutable_topic` is the
+/// COMPILE-TIME verdict for this callback (`CompiledCode::immutable_topic`,
+/// decided from the receiver's syntax by
+/// `Compiler::for_iterable_yields_bare_items`) rather than a runtime test on
+/// the element: a real `Array`'s elements are stored bare in mutsu, so
+/// "is this item a container" would also reject `@a.list.map({ $_ = 5 })`,
+/// `@a[0..1].map(...)` and `@a.Seq.map(...)`, which raku accepts.
+///
+/// The marking is set in BOTH directions: `readonly_vars` is keyed by bare
+/// name, so a writable topic must also CLEAR a mark an enclosing construct
+/// (an outer `for 1, 2`, an outer map over a literal) left on `$_`.
+///
+/// Callers must already hold a `ReadonlyFrameGuard`: these loops run the body
+/// through `run_reuse` without `push_call_frame`, so without an open readonly
+/// scope the mark would skip the undo journal and leak permanently (see the
+/// guard's own comment at each call site).
+pub(crate) fn set_loop_topic_readonly(vm: &mut Interpreter, immutable_topic: bool) {
+    if immutable_topic {
+        vm.mark_readonly_with("_", crate::ast::ReadonlyKind::Immutable);
+    } else {
+        vm.unmark_readonly("_");
+    }
+}
+
 /// Convert a `CallArg` to an `Expr` for expression-level call compilation,
 /// preserving named (`k => v`) and slip (`|v`) args. Mirrors the compiler's
 /// `call_args_to_expr_args`.
@@ -507,6 +536,15 @@ impl Interpreter {
 
             let is_whatever_code = block_keeps_outer_topic(&data);
             let outer_topic = self.env.get("_").cloned();
+            // The compiler saw this callback written directly against a source
+            // that provably yields bare items (`(1, 2).map({ $_ = 5 })`), so
+            // its implicit topic has no container to assign into -- see
+            // `CompiledCode::immutable_topic` and `set_loop_topic_readonly`.
+            let immutable_topic = !is_whatever_code
+                && data
+                    .compiled_code
+                    .as_ref()
+                    .is_some_and(|cc| cc.immutable_topic);
 
             // CP-3 collapse: run the map loop with fresh execution registers
             // (replaces the `mem::take(self)` + `VM::new` sub-VM, reusing one
@@ -603,6 +641,7 @@ impl Interpreter {
                     // `resolution_map_grep_rw.rs`).
                     let _readonly_guard =
                         crate::vm::vm_call_state_guard::ReadonlyFrameGuard::new(vm);
+                    set_loop_topic_readonly(vm, immutable_topic);
                     match vm.run_reuse(&code, &compiled_fns) {
                         Ok(()) => {
                             let val = vm

--- a/src/runtime/resolution_map_grep_rw.rs
+++ b/src/runtime/resolution_map_grep_rw.rs
@@ -231,6 +231,12 @@ impl Interpreter {
             // NOT an alias for the element either, so it must not write back.
             let keeps_outer_topic = super::resolution_map_grep::block_keeps_outer_topic(&data);
             let outer_topic = self.env.get("_").cloned();
+            // See `CompiledCode::immutable_topic` / `set_loop_topic_readonly`.
+            let immutable_topic = !keeps_outer_topic
+                && data
+                    .compiled_code
+                    .as_ref()
+                    .is_some_and(|cc| cc.immutable_topic);
 
             // CP-3 collapse: run the rw map loop with fresh execution registers
             // (replaces the `mem::take(self)` + `VM::new` sub-VM). The closure
@@ -342,6 +348,7 @@ impl Interpreter {
                     // same isolation `call_compiled_closure_with_topic` does.
                     let _readonly_guard =
                         crate::vm::vm_call_state_guard::ReadonlyFrameGuard::new(vm);
+                    super::resolution_map_grep::set_loop_topic_readonly(vm, immutable_topic);
                     match vm.run_reuse(&code, &compiled_fns) {
                         Ok(()) => {
                             let val = vm
@@ -540,6 +547,12 @@ impl Interpreter {
 
             let keeps_outer_topic = super::resolution_map_grep::block_keeps_outer_topic(&data);
             let outer_topic = self.env.get("_").cloned();
+            // See `CompiledCode::immutable_topic` / `set_loop_topic_readonly`.
+            let immutable_topic = !keeps_outer_topic
+                && data
+                    .compiled_code
+                    .as_ref()
+                    .is_some_and(|cc| cc.immutable_topic);
 
             // CP-3 collapse: run the grep loop with fresh execution registers
             // (replaces the `mem::take(self)` + `VM::new` sub-VM). The closure
@@ -619,6 +632,15 @@ impl Interpreter {
                             (arity == 1 && !keeps_outer_topic).then_some(topic_source_key.clone()),
                         );
                         let saved_when_matched = vm.when_matched();
+                        // Same per-iteration readonly scope the two map loops
+                        // open: this loop also binds the block's params by a
+                        // direct `env.insert` and runs the body through
+                        // `run_reuse`, without `push_call_frame`, so a mark made
+                        // inside it would otherwise skip the undo journal and
+                        // leak permanently (see `mark_readonly_sym_with`).
+                        let _readonly_guard =
+                            crate::vm::vm_call_state_guard::ReadonlyFrameGuard::new(vm);
+                        super::resolution_map_grep::set_loop_topic_readonly(vm, immutable_topic);
                         match vm.run_reuse(&code, &compiled_fns) {
                             Ok(()) => {
                                 let pred = vm

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -2449,6 +2449,7 @@ impl Interpreter {
             build_attr_writes: std::cell::RefCell::new(Vec::new()),
             defining_class: None,
             pending_call_arg_sources: None,
+            pending_call_topic_bare: false,
             require_propagates_missing_module: false,
             pending_call_arg_source_slots: std::collections::HashMap::new(),
             pending_rw_writeback_slots: std::collections::HashMap::new(),

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -586,6 +586,7 @@ impl Interpreter {
             build_attr_writes: std::cell::RefCell::new(Vec::new()),
             defining_class: None,
             pending_call_arg_sources: None,
+            pending_call_topic_bare: false,
             require_propagates_missing_module: false,
             pending_call_arg_source_slots: std::collections::HashMap::new(),
             pending_rw_writeback_slots: std::collections::HashMap::new(),

--- a/src/vm/vm_call_fast.rs
+++ b/src/vm/vm_call_fast.rs
@@ -126,6 +126,19 @@ impl Interpreter {
         } else {
             None
         };
+        // ...and that fresh `$_` is WRITABLE, whatever the caller's topic was:
+        // `readonly_vars` is keyed by bare name, so a caller that marked its own
+        // topic immutable (`for 1, 2 { f() }`, `(1, 2).map({ f() })`) would
+        // otherwise leave the mark in force inside the routine and reject its
+        // `$_ = ...`. The other call paths get this from
+        // `unmark_readonly_topic` under a journaled readonly frame; this fast
+        // path deliberately opens no frame, so save the kind and put it back on
+        // the way out (every error arm above `break`s to that same tail).
+        let saved_topic_readonly = cf.code.is_routine.then(|| {
+            let kind = self.readonly_kind("_");
+            self.unmark_readonly_topic();
+            kind
+        });
 
         // Reuse a pooled locals vec to avoid per-call allocation
         let num_locals = cf.code.locals.len();
@@ -359,6 +372,11 @@ impl Interpreter {
                     self.env_mut().remove_sym(crate::symbol::wk::topic());
                 }
             }
+        }
+        // The readonly marking is not env-scoped, so it is restored on both the
+        // scoped and the clone path.
+        if let Some(kind) = saved_topic_readonly {
+            self.restore_topic_readonly(kind);
         }
 
         // Slice F (env<->locals coherence): record the captured-outer variables

--- a/src/vm/vm_call_func_ops.rs
+++ b/src/vm/vm_call_func_ops.rs
@@ -1172,6 +1172,7 @@ impl Interpreter {
         code: &CompiledCode,
         arity: u32,
         arg_sources_idx: Option<u32>,
+        bare_args: bool,
         compiled_fns: &CompiledFns,
     ) -> Result<(), RuntimeError> {
         crate::vm::vm_stats::record_function_dispatch();
@@ -1215,7 +1216,9 @@ impl Interpreter {
             false
         };
         self.set_pending_call_arg_sources(arg_sources);
+        self.pending_call_topic_bare = bare_args;
         let result = self.vm_call_on_value(target, args, Some(compiled_fns));
+        self.pending_call_topic_bare = false;
         self.set_pending_call_arg_sources(None);
         let result = result?;
         let result = loan_env!(self, maybe_fetch_rw_proxy(result, sub_is_rw))?;
@@ -1230,6 +1233,7 @@ impl Interpreter {
         name_idx: u32,
         arity: u32,
         arg_sources_idx: Option<u32>,
+        bare_args: bool,
         compiled_fns: &CompiledFns,
     ) -> Result<(), RuntimeError> {
         crate::vm::vm_stats::record_function_dispatch();
@@ -1293,7 +1297,9 @@ impl Interpreter {
                 false
             };
             self.set_pending_call_arg_sources(arg_sources.clone());
+            self.pending_call_topic_bare = bare_args;
             let result = self.vm_call_on_value(target, args, Some(compiled_fns));
+            self.pending_call_topic_bare = false;
             self.set_pending_call_arg_sources(None);
             let result = result?;
             loan_env!(self, maybe_fetch_rw_proxy(result, sub_is_rw))?

--- a/src/vm/vm_closure_dispatch.rs
+++ b/src/vm/vm_closure_dispatch.rs
@@ -214,6 +214,11 @@ impl Interpreter {
         // One-shot: consumed here so a nested call inside the body does not
         // inherit the carrier's raw-binding-error request.
         let suppress_bind_enhance = std::mem::take(&mut self.suppress_binding_error_enhance);
+        // One-shot, and read BEFORE `push_call_frame` (which clears it): the
+        // call site said every positional argument is a container-less
+        // expression, so this block's implicit `$_` has nothing behind it to
+        // assign to. See `Interpreter::pending_call_topic_bare`.
+        let topic_arg_is_bare = std::mem::take(&mut self.pending_call_topic_bare);
         let (mut args, callsite_line) = self.sanitize_call_args_owned(args);
         if callsite_line.is_some() {
             loan_env!(self, set_pending_callsite_line(callsite_line));
@@ -661,6 +666,36 @@ impl Interpreter {
             {
                 self.env_mut()
                     .insert_sym(crate::symbol::Symbol::intern("_"), first.clone());
+                // raku binds a bare block's implicit `$_` to the argument
+                // itself: `{ $_ = 5 }(7)` is X::AdHoc "Cannot assign to an
+                // immutable value", while `{ $_ = 9 }($v)` / `(@a[0])` write
+                // through the caller's container. `topic_arg_is_bare` is the
+                // call site's own syntactic verdict (see
+                // `Compiler::expr_yields_container_less_value`) and
+                // `cc.immutable_topic` the `.map`/`.grep`-over-a-literal one;
+                // both are conservative, so an unrecognised shape keeps the
+                // topic writable rather than inventing a throw.
+                //
+                // `explicit_topic`/`capture_rw_topic` mean the native `.map`
+                // loop supplied this topic from a real container it will write
+                // back to (`@a.map({ $_ *= 10 })`), which must stay writable —
+                // and `explicit_topic` overwrites the bind above further down,
+                // so it must be excluded here, not merely below.
+                //
+                // Set in BOTH directions: `readonly_vars` is keyed by bare
+                // name, so a writable topic must also CLEAR a mark an
+                // enclosing construct left on `$_` -- `for 1, 2 { @a.map({ $_
+                // = 5 }) }` (whose native rw-map topic IS a writable element)
+                // wrongly threw. `push_call_frame` above journals either way.
+                if (topic_arg_is_bare || cc.immutable_topic)
+                    && !capture_rw_topic
+                    && explicit_topic.is_none()
+                    && !first.is_container_ref()
+                {
+                    self.mark_readonly_with("_", crate::ast::ReadonlyKind::Immutable);
+                } else {
+                    self.unmark_readonly_topic();
+                }
             }
         } else if data.params.is_empty() && args.is_empty() && data.name.is_empty() {
             // A block lexically captures $_ from its creation scope (the env-merge
@@ -705,6 +740,16 @@ impl Interpreter {
                 crate::symbol::Symbol::intern("_"),
                 Value::package(crate::symbol::Symbol::intern("Any")),
             );
+            // ...and that fresh `$_` is WRITABLE, whatever the caller's topic
+            // was. `readonly_vars` is keyed by bare name, so a construct that
+            // marked its own topic immutable (a `for 1, 2` alias, a
+            // `.map`/`.grep` over a literal) would otherwise have that mark
+            // still in force inside an unrelated routine called from the body:
+            // `for 1, 2 { f() }` with `sub f() { $_ = 5 }` wrongly threw
+            // "Cannot assign to an immutable value". `push_call_frame` above
+            // journals the unmark, so the caller's marking is restored on
+            // return.
+            self.unmark_readonly_topic();
         }
 
         // Raku: $! is scoped per routine — fresh Nil on entry. Gated on

--- a/src/vm/vm_env_helpers.rs
+++ b/src/vm/vm_env_helpers.rs
@@ -64,6 +64,11 @@ impl Interpreter {
             saved_active_loop_param_names: std::mem::take(&mut self.active_loop_param_names),
             saved_active_loop_rw_param_names: std::mem::take(&mut self.active_loop_rw_param_names),
         };
+        // A call-site "the topic argument is a bare literal" flag
+        // (`OpCode::CallOnValue`'s `bare_args`) belongs to exactly one call.
+        // `call_compiled_closure_with_topic` reads it before pushing its frame;
+        // clearing it here stops it reaching any deeper block call.
+        self.pending_call_topic_bare = false;
         self.call_frames.push(frame);
     }
 

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -3674,6 +3674,7 @@ impl Interpreter {
             OpCode::CallOnValue {
                 arity,
                 arg_sources_idx,
+                bare_args,
             } => {
                 self.sync_source_line(code, *ip);
                 // `use fatal`: see the comment on the `CallFunc` arm above. The
@@ -3685,7 +3686,13 @@ impl Interpreter {
                 // `my $w = &warn; $w.("x")` raises a resumable `warn` signal from
                 // inside the dispatched callable, exactly like a direct `warn`
                 // (which the `ExecCall` arm below already handles).
-                match self.exec_call_on_value_op(code, *arity, *arg_sources_idx, compiled_fns) {
+                match self.exec_call_on_value_op(
+                    code,
+                    *arity,
+                    *arg_sources_idx,
+                    *bare_args,
+                    compiled_fns,
+                ) {
                     Ok(()) => {}
                     Err(e) => {
                         if !e.is_resume() && self.resume_ip.is_none() {
@@ -3700,6 +3707,7 @@ impl Interpreter {
                 name_idx,
                 arity,
                 arg_sources_idx,
+                bare_args,
             } => {
                 self.sync_source_line(code, *ip);
                 // `use fatal`: see the comment on the `CallFunc` arm above.
@@ -3712,6 +3720,7 @@ impl Interpreter {
                     *name_idx,
                     *arity,
                     *arg_sources_idx,
+                    *bare_args,
                     compiled_fns,
                 ) {
                     Ok(()) => {}

--- a/src/vm/vm_for_loop_body.rs
+++ b/src/vm/vm_for_loop_body.rs
@@ -509,25 +509,34 @@ impl Interpreter {
         // `ForLoopSpec::source_items_are_bare`) gets the same treatment: the
         // topic aliases the item itself, with no container behind it, so raku
         // rejects `$_ = ...` and reports the item's own type from `.VAR`.
-        let topic_readonly =
-            !spec.is_rw && param_name.is_none() && spec.multi_param_names.is_empty() && {
-                spec.source_items_are_bare
-                    || match &container_binding {
-                        None => false,
-                        Some(name) => {
-                            if let Some(val) = self.get_env_with_main_alias(name) {
-                                matches!(
-                                    val.view(),
-                                    ValueView::Mix(_, false)
-                                        | ValueView::Set(_, false)
-                                        | ValueView::Bag(_, false)
-                                )
-                            } else {
-                                false
-                            }
+        // Whether this loop binds the implicit topic at all (as opposed to a
+        // named/multi parameter, which leaves `$_` alone).
+        let binds_implicit_topic = param_name.is_none() && spec.multi_param_names.is_empty();
+        // `readonly_vars` is keyed by bare name, so an enclosing construct that
+        // marked ITS topic immutable (an outer `for 1, 2`, a `.map` over a
+        // literal) is still in force here. A loop whose own topic IS writable
+        // must therefore clear that mark, not merely refrain from setting one:
+        // `for 1, 2 { for @b { $_ = 1 } }` wrongly threw "Cannot assign to an
+        // immutable value". Saved and restored on every exit path below.
+        let saved_topic_readonly = binds_implicit_topic.then(|| self.readonly_kind("_"));
+        let topic_readonly = !spec.is_rw && binds_implicit_topic && {
+            spec.source_items_are_bare
+                || match &container_binding {
+                    None => false,
+                    Some(name) => {
+                        if let Some(val) = self.get_env_with_main_alias(name) {
+                            matches!(
+                                val.view(),
+                                ValueView::Mix(_, false)
+                                    | ValueView::Set(_, false)
+                                    | ValueView::Bag(_, false)
+                            )
+                        } else {
+                            false
                         }
                     }
-            };
+                }
+        };
         let total_items = chunked_items.len();
         // `is copy` loop param (is_rw set, do_writeback suppressed): the param
         // owns a DISTINCT container per iteration. Mutations write through the
@@ -776,6 +785,13 @@ impl Interpreter {
                 self.mark_readonly_with("_", crate::ast::ReadonlyKind::Immutable);
                 self.env_mut()
                     .insert("__mutsu_deep_readonly::_".to_string(), Value::TRUE);
+            } else if binds_implicit_topic {
+                // See `saved_topic_readonly`: this loop's topic is writable, so
+                // an enclosing construct's mark must not carry into the body --
+                // including its deep flag, which would otherwise refuse a
+                // `.value = ...` through THIS loop's own (mutable) topic.
+                self.unmark_readonly("_");
+                self.env_mut().remove("__mutsu_deep_readonly::_");
             }
             // Mark named params readonly when not in rw mode.
             // Skip @-sigil and %-sigil params: they bind to a mutable
@@ -1160,8 +1176,8 @@ impl Interpreter {
                                 resume_body_ip,
                                 inner: nested.map(Box::new),
                             });
-                        if topic_readonly {
-                            self.unmark_readonly("_");
+                        if let Some(saved) = saved_topic_readonly {
+                            self.restore_topic_readonly(saved);
                             self.env_mut().remove("__mutsu_deep_readonly::_");
                         }
                         if !spec.is_rw
@@ -1177,9 +1193,9 @@ impl Interpreter {
                         return Err(e);
                     }
                     Err(e) => {
-                        // Unmark readonly before propagating error
-                        if topic_readonly {
-                            self.unmark_readonly("_");
+                        // Restore the topic marking before propagating error
+                        if let Some(saved) = saved_topic_readonly {
+                            self.restore_topic_readonly(saved);
                             self.env_mut().remove("__mutsu_deep_readonly::_");
                         }
                         if !spec.is_rw
@@ -1223,9 +1239,9 @@ impl Interpreter {
                 break;
             }
         }
-        // Unmark readonly topic after loop completion
-        if topic_readonly {
-            self.unmark_readonly("_");
+        // Restore the topic marking after loop completion
+        if let Some(saved) = saved_topic_readonly {
+            self.restore_topic_readonly(saved);
             self.env_mut().remove("__mutsu_deep_readonly::_");
         }
         // Unmark readonly params after loop completion

--- a/t/closure-topic-readonly.t
+++ b/t/closure-topic-readonly.t
@@ -1,0 +1,162 @@
+use Test;
+
+# The implicit topic of a bare block is read-only exactly when the item it is
+# bound to has no container of its own. Both halves are pinned here so a future
+# change has to keep them honest at once: over-marking invents a throw rakudo
+# does not have, under-marking silently drops a write rakudo rejects.
+# Every expectation below was measured against rakudo 2026.06.
+plan 31;
+
+# --- must throw: the topic aliases an immutable item -------------------------
+
+throws-like { (1, 2).map({ $_ = 5 }).eager }, X::AdHoc,
+    message => 'Cannot assign to an immutable value',
+    '.map over a list literal binds an immutable topic';
+
+throws-like { (1, 2).grep({ $_ = 5 }).eager }, X::AdHoc,
+    message => 'Cannot assign to an immutable value',
+    '.grep over a list literal binds an immutable topic';
+
+throws-like { (1 .. 3).map({ $_ = 5 }).eager }, X::AdHoc,
+    message => 'Cannot assign to an immutable value',
+    '.map over a Range binds an immutable topic';
+
+throws-like { my %h = a => 1; %h.keys.map({ $_ = "z" }).eager }, X::AdHoc,
+    message => 'Cannot assign to an immutable value',
+    '.map over %h.keys binds an immutable topic';
+
+throws-like { my $s = { $_ = 5 }; $s(7) }, X::AdHoc,
+    message => 'Cannot assign to an immutable value',
+    'a bare block called with a literal binds an immutable topic';
+
+throws-like { my $s = { $_ = 5 }; $s(3 + 4) }, X::AdHoc,
+    message => 'Cannot assign to an immutable value',
+    'a bare block called with an arithmetic result binds an immutable topic';
+
+throws-like { my &s = { $_ = 5 }; s(7) }, X::AdHoc,
+    message => 'Cannot assign to an immutable value',
+    'a &-sigiled block called with a literal binds an immutable topic';
+
+# A compound assignment to the same topic is rejected too. rakudo reports these
+# as X::Assignment::RO ("Cannot modify an immutable Str (a)") rather than the
+# X::AdHoc a plain `=` gets; mutsu's compound-assign paths still answer with
+# their own wording, so only the rejection itself is pinned here (see the
+# "Messages that are close but not exact" section of
+# todo/deep/immutable-lvalues-that-mutsu-still-lets-you-assign-to.md).
+dies-ok { ("a", "b").map({ $_ ~= "!" }).eager },
+    'a compound assignment to a literal-list topic is rejected too';
+dies-ok { ("a", "b").map({ $_ .= uc }).eager },
+    'a .= mutation of a literal-list topic is rejected too';
+
+throws-like { (map { $_ = 5 }, 1, 2).eager }, X::AdHoc,
+    message => 'Cannot assign to an immutable value',
+    'the listop map over literals binds an immutable topic';
+
+throws-like { (grep { $_ = 5 }, 1, 2).eager }, X::AdHoc,
+    message => 'Cannot assign to an immutable value',
+    'the listop grep over literals binds an immutable topic';
+
+# --- must stay writable: the topic aliases a real element --------------------
+
+{
+    my @a = 1, 2, 3;
+    map { $_ = 5 }, @a;
+    is-deeply @a, [5, 5, 5], 'the listop map over a named array still writes back';
+}
+
+
+{
+    my @a = 1, 2, 3;
+    @a.map({ $_ *= 10 }).eager;
+    is-deeply @a, [10, 20, 30], '@a.map({ $_ *= 10 }) still writes back';
+}
+
+{
+    my @a = 1, 2, 3;
+    @a.map({ $_ = 5 }).eager;
+    is-deeply @a, [5, 5, 5], '@a.map({ $_ = 5 }) still writes back';
+}
+
+{
+    my @a = 1, 2, 3;
+    @a.grep({ $_ = 5 });
+    is-deeply @a, [5, 5, 5], '@a.grep({ $_ = 5 }) still writes back';
+}
+
+{
+    my %h = a => 1;
+    %h.values.map({ $_ = 9 }).eager;
+    is %h<a>, 9, '%h.values.map({ $_ = 9 }) still writes back';
+}
+
+{
+    my @a = 1, 2, 3;
+    @a.values.map({ $_ = 7 }).eager;
+    is-deeply @a, [7, 7, 7], '@a.values.map({ $_ = 7 }) still writes back';
+}
+
+{
+    my $v = 1;
+    my $b = { $_ = 9 };
+    lives-ok { $b($v) }, 'a bare block called with a variable keeps a writable topic';
+}
+
+{
+    my @a = 1, 2, 3;
+    my $b = { $_ = 9 };
+    lives-ok { $b(@a[0]) }, 'a bare block called with an element keeps a writable topic';
+}
+
+is (1, 2).map({ $_ * 2 }).eager, (2, 4), 'reading the topic over a literal is unaffected';
+is (1, 2).grep({ $_ > 1 }).eager, (2,), 'reading the grep topic over a literal is unaffected';
+is (1, 2).map(-> $v { $v + 1 }).eager, (2, 3),
+    'a pointy block over a literal binds its own parameter, not the topic';
+is (1, 2).map({ $^a + 1 }).eager, (2, 3),
+    'a placeholder block over a literal keeps its own parameter';
+
+# --- the mark must not leak into a nested topic binding ----------------------
+
+sub topic-writer() { $_ = 5; "written" }
+
+{
+    my @b = 7, 8;
+    (1, 2).map({ for @b { $_ = 1 } }).eager;
+    is-deeply @b, [1, 1], 'an inner for over a real array stays writable inside a literal map';
+}
+
+is (1, 2).map({ topic-writer() }).eager, ("written", "written"),
+    'a routine called from a literal-map block gets its own writable $_';
+
+is (1, 2).grep({ topic-writer() }).elems, 2,
+    'a routine called from a literal-grep block gets its own writable $_';
+
+{
+    my @a = 1, 2, 3;
+    for 1, 2 { @a.map({ $_ = 5 }).eager }
+    is-deeply @a, [5, 5, 5], 'an rw .map inside a for over a literal stays writable';
+}
+
+{
+    my @a = 1, 2, 3;
+    for 1, 2 { @a.grep({ $_ = 5 }) }
+    is-deeply @a, [5, 5, 5], 'an rw .grep inside a for over a literal stays writable';
+}
+
+{
+    my @b = 7, 8;
+    for 1, 2 { for @b { $_ = 1 } }
+    is-deeply @b, [1, 1], 'an inner for over a real array stays writable inside a literal for';
+}
+
+{
+    lives-ok { for 1, 2 { topic-writer() } },
+        'a routine called from a for over a literal gets its own writable $_';
+}
+
+# ...and the outer mark comes back afterwards.
+throws-like {
+    my @a = 1, 2, 3;
+    for 1, 2 { @a.map({ $_ = 5 }).eager; $_ = 9 }
+}, X::AdHoc,
+    message => 'Cannot assign to an immutable value',
+    'the for-literal topic is immutable again after a nested writable binding';

--- a/todo/deep/immutable-lvalues-that-mutsu-still-lets-you-assign-to.md
+++ b/todo/deep/immutable-lvalues-that-mutsu-still-lets-you-assign-to.md
@@ -4,80 +4,106 @@ Found by the exception-taxonomy survey in
 `news/2026-08/readonly-assign-exception-taxonomy.md`. That work fixed *which*
 exception a rejected assignment throws; this ticket collects the cases where
 mutsu does not reject the assignment at all, which the same survey surfaced.
-Every row was probed against `raku` v2026.06.
+Every row below was re-measured against `raku` v2026.06 on **2026-09-05**, on
+top of the closure-topic fix (`news/2026-09/closure-and-map-grep-topic-readonly.md`).
 
-## Status (2026-09-05): only the closure-topic rows are left
+## Status (2026-09-05)
 
-The element-store and `:=`-bind halves of this survey are **closed** — see
-`news/2026-09/immutable-element-store-and-bind.md`. `(1,2,3)[0] = 9`,
-`(1..3)[0] = 9`, `my $s = (1,2,3).Seq; $s[0] = 5`, `my $x := (1,2,3); $x = 5`
-and `my $x := (5,6)[0]; $x = 10` all answer exactly what rakudo answers now,
-messages included, pinned by `t/immutable-element-store-and-bind.t`. The
-prerequisite that note recorded (ADR-0036's element-container semantics) was
-not the blocker: the fix was a source-derived writability verdict for the
-`$`-sigil declaration bind plus an element-keyed refusal on the `Seq` store.
+Closed since the survey opened:
 
-What remains here is the **closure-topic family only**, which is a genuinely
-different mechanism (see the "Why `-> $v { $v = 1 }` was fixable" section
-below), plus three neighbours found while closing the rest:
+- the element-store and `:=`-bind halves —
+  `news/2026-09/immutable-element-store-and-bind.md`;
+- the closure/map/grep topic family (`(1,2).map({$_=5})`,
+  `(1,2).grep({$_=5})`, `{ $_ = 5 }(7)`, plus `(1..3).map`, `%h.keys.map`, the
+  listop `map { $_ = 5 }, 1, 2` and its `grep` twin, `{ $_ = 5 }(3+4)` and
+  `my &s = { $_ = 5 }; s(7)`) —
+  `news/2026-09/closure-and-map-grep-topic-readonly.md`, pinned by
+  `t/closure-topic-readonly.t`.
 
-```raku
-p "map literal topic",{ (1,2).map({ $_ = 5 }).eager };   # raku: X::AdHoc
-p "grep topic",       { (1,2).grep({ $_ = 5 }).eager };  # raku: X::AdHoc
-p "block arg topic",  { my $s = { $_ = 5 }; $s(7) };     # raku: X::AdHoc
-```
+**Read the "how the surviving rows differ" section below before designing
+anything**: two successive stated blockers for the closure-topic rows (first
+"separate the two `call_compiled_closure_with_topic` callers", then ADR-0036 /
+ADR-0040) were both measured to be wrong, and the runtime rule that looks
+obviously right for the rows below was measured to *break* five shapes rakudo
+accepts.
 
-### Neighbour 1: a `gather` sequence's element store
+## The surviving rows
 
-```
-my $s = (gather { take 1; take 2 }); $s[0] = 5
-    # raku: X::Assignment::RO, "Cannot modify an immutable Int (1)"
-    # mutsu: silently succeeds
-```
-
-The `.Seq` twin of this row was fixed by teaching
-`try_seq_element_cell_assign` to refuse a materialized non-container element.
-A `gather` result is a `ValueView::LazyList` in mutsu, not a `Seq`, and it
-shares that representation with the lazy `@`-array whose element assignment is
-*legitimate* (`my @a = 1,2,4...Inf; @a[2] = 99` is real raku, and
-`restore_lazy_array_slot` exists to support it). So the refusal cannot simply
-be extended to `LazyList`: it needs the `array_context` / `list_context`
-distinction to be the oracle, which is a separate piece of work.
-
-### Neighbour 2: an associative subscript of a `Seq`
+### A. `.map`/`.grep`/`.first` over a receiver mutsu cannot prove bare
 
 ```
-my $s = (1,2,3).Seq; $s<a> = 5
-    # raku: X::AdHoc, "Type Seq does not support associative indexing."
-    # mutsu: silently succeeds
+my @a := (1,2,3); @a.map({$_=5}).eager      raku: X::AdHoc   mutsu: (5 5 5)
+my $s = (1,2,3).Seq; $s.map({$_=5}).eager   raku: X::AdHoc   mutsu: (5 5 5)
+(1,2).first({$_=5})                         raku: X::AdHoc   mutsu: 1
+my %h = a=>1; %h.map({$_=9}).eager          raku: X::AdHoc   mutsu: (9)
+my @a = 1,2; (@a,).map({$_=5}).eager        raku: X::AdHoc   mutsu: (5)
+for %h { $_ = 5 }                           raku: X::AdHoc   mutsu: silently OK
 ```
 
-rakudo refuses the *subscript*, not the store, so this is not an immutability
-row at all — it belongs with whatever enforces the Positional/Associative
-protocol per type.
+The shipped fix keys off `Compiler::for_iterable_yields_bare_items` applied to
+the *receiver expression*, which deliberately answers `false` for a variable and
+for any derived receiver. These rows are exactly the receivers it cannot prove:
+an `@`-variable `:=`-bound to a `List`, a `$`-variable holding a `Seq`, a
+`%`-variable (whose iteration mints fresh `Pair`s), and a one-element list
+literal built from an array variable. `.first` additionally never reaches the
+marking at all — only the two map loops and the grep loop consult
+`CompiledCode::immutable_topic`.
 
-### Neighbour 3: an inline declaration inside a list literal
+`for %h` is the same row from the `for` side. Extending
+`for_iterable_yields_bare_items` to `Expr::HashVar` looks like the one-line fix
+for both, but the `for` loop pairs its topic mark with the
+`__mutsu_deep_readonly::_` env flag, which would then also reject
+`for %h { .value = 5 }` — a write rakudo performs. Whatever closes this row has
+to separate "the topic itself is immutable" from "everything reachable through
+it is".
+
+### B. Element and argument shapes where mutsu drops the write instead
+
+Not immutability rows at all — rakudo performs these writes and mutsu silently
+loses them, which is the *opposite* failure and must not be "fixed" by teaching
+the marking to reject them:
 
 ```
-my $a = 1; (my $x = $a, 6)[0] = 10
-    # raku:  x=10 a=1  (an inline declaration in a list literal denotes the
-    #        freshly-declared variable's container, so the store writes it)
-    # mutsu: X::Assignment::RO, "Cannot modify an immutable List ((1 6))"
-    #        (before the 2026-09-05 List-literal store fix the write was
-    #        silently dropped instead; both answers diverge)
+my @a=1,2,3; @a.list.map({$_=7}).eager; @a      raku [7 7 7]   mutsu [1 2 3]
+my @a=1,2,3; @a[0..1].map({$_=5}).eager; @a     raku [5 5 3]   mutsu [1 2 3]
+my $x=[1,2,3]; $x.map({$_=5}).eager; $x         raku [5 5 5]   mutsu [1 2 3]
+my @a=1,2,3; @a.first({$_=5}); @a               raku [5 2 3]   mutsu [1 2 3]
+my $v=1; my $b={$_=9}; $b($v); $v               raku 9         mutsu 1
+my @a=1,2,3; my $b={$_=9}; $b(@a[0]); @a        raku [9 2 3]   mutsu [1 2 3]
+my @a=1,2,3; for @a[0..1] { $_ = 5 }; @a        raku [5 5 3]   mutsu [1 2 3]
 ```
 
-Extending `scalar_container_alias_name` to cover `Expr::DoStmt(VarDecl)` was
-tried and did not reach it, so the inline declaration does not arrive in that
-shape at this position; finding what it *does* arrive as is the next step.
+These are the real ADR-0036/ADR-0040 surface: the element handed to the topic is
+a bare value, not a cell, so the write has nowhere to land. Note that mutsu
+*does* hand out cells for `@a.values` and `%h.values` (those rows write through
+correctly today), so the gap is per-producer, not universal.
 
-### Neighbour 4: a `$` bind of a MUTABLE container is still assignable
+### How the surviving rows differ from what was fixed (measured, do not skip)
 
-Measured 2026-09-05 while closing the immutable-container rows. rakudo's rule
-is sharper than "immutable": `$x = v` needs `$x` bound to a **Scalar**
-container, and *no* other container qualifies — a real `Array`, a `Hash`, a
-`Map` and a `Pair` all refuse it too, even though each is perfectly mutable
-through its own interface.
+The tempting rule for section A is the runtime one the lazy `for` path already
+uses (`vm_for_loop_lazy.rs`): mark the topic read-only when
+`!item.is_container_ref()`. It was implemented and measured on 2026-09-05, and it
+converts **every row in section B** from a silently-dropped write into a spurious
+throw, because a real `Array`'s elements are stored bare. A source-*kind* rule
+(`ArrayKind::List`/`ItemList` ⇒ immutable) fails the same way: `@a.list` and
+`@a[0..1]` both produce a `List` whose elements rakudo still writes through, and
+`@a.list.grep({$_=5})` currently writes back correctly via
+`overwrite_array_bindings_by_identity`, so a kind-based refusal would regress a
+row that works.
+
+So section A cannot be closed by a local runtime test. Either the receiver
+oracle grows (a compile-time notion of "this variable is `:=`-bound to an
+immutable Positional" / "this variable holds a `Seq`", which the compiler already
+tracks partially in `scalar_bind_*`), or section B is closed first — once an
+element really is a cell, `is_container_ref()` becomes a sound oracle for both.
+Closing B first is the architecturally cleaner order.
+
+### C. A `$` bind of a MUTABLE container is still assignable
+
+rakudo's rule is sharper than "immutable": `$x = v` needs `$x` bound to a
+**Scalar** container, and no other container qualifies — a real `Array`, a
+`Hash`, a `Map` and a `Pair` all refuse it, though each is mutable through its
+own interface.
 
 ```
 my @a = 1,2,3; my $x := @a;        $x = 5     # raku: X::AdHoc; mutsu: OK, @a becomes 5
@@ -88,327 +114,100 @@ my $x := Map.new((a=>1));          $x = 5     # raku: X::AdHoc; mutsu: OK
 my $x := (a => 1);                 $x = 5     # raku: X::AdHoc; mutsu: OK
 ```
 
-Deliberately left out of the 2026-09-05 fix, which extended
-`bind_source_has_no_container`'s allowlist only to immutable Positionals. Two
-of these rows (`my $x := @a`, `my $x := %h`) do not even reach that decision —
-a bind whose RHS is a simple variable carries a NAMED source and is excluded
-from the marking outright — so closing this family means deciding what a named
-`@`/`%` source should imply for a `$` target, not just widening a match arm.
-The `$x.push(...)` aliasing those binds exist for must keep working; only the
+Deliberately left out of the 2026-09-05 element-store fix, which extended
+`bind_source_has_no_container`'s allowlist only to immutable Positionals. Two of
+these rows (`my $x := @a`, `my $x := %h`) do not even reach that decision — a
+bind whose RHS is a simple variable carries a NAMED source and is excluded from
+the marking outright — so closing this family means deciding what a named
+`@`/`%` source should imply for a `$` target, not just widening a match arm. The
+`$x.push(...)` aliasing those binds exist for must keep working; only the
 whole-value `=` is refused.
 
-One near-miss in the same family: `my $x := $(1,2,3); $x = 5` throws
-`X::AdHoc` in both, but rakudo words it "Cannot assign to a readonly variable
-or a value" where mutsu says "Cannot assign to an immutable value".
+One near-miss in the same family: `my $x := $(1,2,3); $x = 5` throws `X::AdHoc`
+in both, but rakudo words it "Cannot assign to a readonly variable or a value"
+where mutsu says "Cannot assign to an immutable value".
 
-## Status update (2026-08-27)
-
-Seven more rows are now **fixed** (`news/2026-08/closure-call-and-bareword-term-readonly-gaps.md`):
-a `$`-sigiled single-param pointy block (`-> $v { $v = 1 }`); assigning to the
-bare `Nil` term, a builtin type object (`Int = 5`), or an enum value (`enum Fo
-<A B>; A = 3`); a sub-signature destructure leaf, both sigilless (`\a`) and
-`$`-sigiled (`$x`); `push`/`append`/`unshift`/`prepend`/`pop`/`shift` on an
-`@`-var bound to an immutable List (`my @a := (1,2,3); @a.push(4)`); and
-postfix/prefix `++`/`--` on a sigilless bind (`my \G = 5; G++`).
-
-The probe harness (see the 2026-09-05 status section above for what still
-diverges):
-
-```raku
-sub p($l, &c) { my $r = try { c() }; say $l, " => ", ($! ?? $!.^name ~ " | " ~ $!.Str !! "OK") }
-
-p "map literal topic",{ (1,2).map({ $_ = 5 }).eager };          # raku: X::AdHoc
-p "grep topic",       { (1,2).grep({ $_ = 5 }).eager };         # raku: X::AdHoc
-p "block arg topic",  { my $s = { $_ = 5 }; $s(7) };            # raku: X::AdHoc
-```
-
-(The four topic rows fixed 2026-08-26 -- `for 1,2`, `for (1,2)`, `for <a b>`,
-`for %h.keys` -- the seven fixed 2026-08-27 above, and the five element-store /
-`:=`-bind rows fixed 2026-09-05 are no longer listed.)
-
-## Why `-> $v { $v = 1 }` was fixable but `{ $_ = 5 }` (block-argument topic) is not
-
-Both looked like the same gap ("named routines mark their params, the
-closure-call path does not"), but they turned out to need genuinely different
-mechanisms, and only one is safe to ship:
-
-- **A `$`-sigiled pointy-block parameter is *always* readonly**, regardless of
-  what it is called with (row 1 of the readonly-assign-exception-taxonomy: a
-  readonly binding with a container, `X::AdHoc` "Cannot assign to a readonly
-  variable or a value") — the same rule a `for`-loop's named alias already
-  gets. This does not depend on whether the argument came from a container, so
-  it is safe to mark unconditionally.
-- **A bare `{ $_ = 5 }` block's IMPLICIT topic is writable exactly when the
-  argument is a container** (row 2 vs. row 3 of the same taxonomy). `$s(7)`
-  passes a literal `7` — never a container — so it should always be readonly.
-  But the exact same VM code path (`call_compiled_closure_with_topic`'s
-  "implicit `$_` for bare blocks" branch, `vm_closure_dispatch.rs`) is also
-  what `@a.map({ $_ *= 10 })` uses when the native `.map` loop's rw-writeback
-  detection (`vm_native_map.rs`'s `mutates_topic`/`writeback_name`) hands it a
-  *named array's real element* with `capture_rw_topic: true` — and THAT case
-  legitimately mutates the source array (verified: `my @a = 1,2,3;
-  @a.map({ $_ *= 10 }); say @a;` prints `[10 20 30]` in both raku and mutsu,
-  and this is load-bearing existing behaviour, not a bug). Marking the
-  implicit topic readonly at that shared call site would break
-  `@a.map({ $_ = ... })`'s rw writeback outright — it is the exact same
-  ADR-0040 "does mutsu know the source item is a container" gap the `for`-loop
-  topic rows are blocked on, just reached from `.map`/direct-call instead of
-  `for`. **Left unfixed; do not attempt without ADR-0040's store-side element
-  itemization**, and do not reuse `call_compiled_closure_with_topic`'s
-  implicit-topic branch for this without first separating the "direct value
-  call" and "native map rw-writeback" callers, which currently share it.
-- The two `.map`/`.grep`-literal-topic rows are the same blocker by the same
-  mechanism (both go through the identical "implicit topic from a positional
-  arg, `capture_rw_topic` may or may not be set" code, since `(1,2).map({ $_ =
-  5 })` over non-Pair literal elements takes the exact same `explicit_topic:
-  None` path as `@a.map({ $_ *= 10 })` over a real array — the two are
-  indistinguishable at that call site without per-item container information).
-
-## A live trap this ticket's fix ran into: bytecode-injected readonly marks leak through "fast native loop" call paths
-
-The first implementation of the `-> $v { $v = 1 }` fix injected a
-`Stmt::MarkReadonly` prologue statement into the pointy block's *compiled
-body*, mirroring how `Stmt::MarkSigillessReadonly` already does this for `my
-\x = 5`. That reached CI green locally but broke `t/digest-battery.t`,
-`t/map-native-rw-param.t`, and `t/topic-alias-does-not-cross-frames.t`:
-`resolution_map_grep.rs`/`resolution_map_grep_rw.rs` (the native `.map`/`.grep`
-loops, plus a `.first` matcher) bind a block's params by a direct `env.insert`
-and run its body via `run_reuse` *without* `push_call_frame`/
-`enter_readonly_frame` (a deliberate perf shortcut around the general call
-machinery). A prologue statement runs unconditionally wherever the bytecode
-executes, so it marked `readonly_vars` with `readonly_frames == 0` — which
-skips the undo journal entirely (`mark_readonly_sym_with`'s `if
-self.readonly_frames.get() == 0 { return; }`) and leaked the mark
-PERMANENTLY into the next unrelated same-named lexical anywhere later in the
-program (SHA3's `map -> $x {...}` leaking "x" into a later `for ... -> ($x,
-$y)` reusing the name; digest's rw-map "x" leaking across an outer `for`
-iteration).
-
-**Fix actually shipped:** mark the parameter at the CALL SITE
-(`call_compiled_closure_with_topic` in `vm_closure_dispatch.rs`, gated on a
-new `CompiledCode::pointy_alias_param` flag set only for this one shape) right
-after `bind_function_args_values` succeeds, not via a body prologue.
-`push_call_frame` already ran earlier in that same function, so the mark is
-correctly scoped and rolled back on every exit. This also means the mark is
-simply never applied when a native fast loop bypasses that function entirely
-— which is exactly the "leave the topic rows alone" boundary this ticket
-already draws, achieved as a side effect rather than a special case.
-
-The two leaky loops (`eval_map_over_items` and `eval_map_over_items_rw`) were
-also hardened directly with a `ReadonlyFrameGuard` around each iteration's
-`run_reuse` call, so a *future* body side effect of the same shape doesn't
-reintroduce this class of leak.
-
-## A second live trap: the bareword-term check can't just test the CURRENT value
-
-The `Nil`/type-object/enum fix (added to the `SetGlobal` opcode handler)
-rejects an assignment when the target's CURRENT env value looks like a type
-object, `Nil`, or an enum member. That is unsound on its own: a bareword
-carries no sigil in its *storage key* either way (`Nil = 5` and `$_ = 5` both
-compile to `Stmt::Assign { name: "_"|"Nil", ... }` — the sigil is stripped
-before this point, same information loss `constant $PI` vs. `constant PI` hit
-in the exception-taxonomy work), so a check keyed only on "does the current
-value look like an enum" cannot tell the true case (`enum Fo <A B>; A = 3`)
-apart from a plain variable that merely happens to currently hold a COPY of
-that same enum value — e.g. `$_ = $state` where `$state` holds `A` from an
-earlier loop iteration reached `t/topic-alias-does-not-cross-frames.t` and
-broke it (mutsu called `.=` on the container-less topic and reported "Cannot
-modify an immutable State (A)").
-
-The reason only `$_` triggers this SPECIFIC ambiguity in practice: a simple
-`my`/`our`-declared variable (`my $state = ...`) compiles to a local SLOT
-(`SetLocal`, never reaching this `SetGlobal`-only check at all), so it can't
-collide with a bareword this way. `$_` is dynamically resolved via env by
-design on every frame, never slot-allocated — and a bareword `_` alone is
-never a valid Raku term regardless (rejected at `exec_get_bare_word_op`'s very
-first check). So excluding `name == "_"` from this check is a principled fix
-for that specific case, not a narrow patch papering over the real gap —
-verified against `my $state`/`our $state` holding-then-reassigning an enum
-value, neither of which reaches this code path at all. (This claim held for
-the ENUM check; the type-object check needed a further refinement — see the
-third trap below, which found that NOT EVERY variable avoids `SetGlobal` the
-way a simple `my $x` does.)
-
-## A third live trap: a lowercase bareword's storage key ALSO collides with a variable, on its first-ever write
-
-The type-object check's `unbound_type_slot` test originally treated "never
-referenced at all" (`env.get(name)` is `None`) the same as a pre-seeded `Nil`
-slot — necessary for `Int = 5` to be caught, since a builtin type's bareword
-is never actually written into env by anything else. That broke
-`roast/S32-str/comb.t`: `for @tests -> ($str, $expected, |args) {...}` binds
-its sub-signature destructure leaves by a direct `SetGlobal`, NOT a local
-slot (destructure leaves aren't slot-allocated the way a simple `my $str` is —
-contradicting the "an ordinary variable always compiles to SetLocal" claim
-above, which is true for a simple declaration but not for every binding
-shape). `$str`'s very first write hit the exact same "never referenced" check
-and was misidentified as assigning to the lowercase native type `str`.
-
-**Fix:** restrict the `None`-counts-as-unbound inference to TitleCase names
-(`name.starts_with` an uppercase char). `str`/`int`/`num`/`array`/`bool`/...
-are realistic, common variable names whose sigil-stripped key collides with a
-type synonym; `str = 5` as a bare statement referencing the TYPE object is not
-idiomatic Raku at all. So the lost coverage (a lowercase native-type
-bareword's very first, never-yet-referenced assignment) is a deliberate,
-accepted trade-off — `Int`/`Nil`/a user class (TitleCase by convention) still
-work, and a genuinely ambiguous case would need the sigil-vs-bareword
-distinction preserved at compile time (the same class of fix the
-exception-taxonomy work made for `constant $PI` vs. `constant PI` via the
-parser-recorded `__constant_sigil` trait) to close soundly.
-
-**This same ambiguity turned out to have a THIRD current-value shape, not just
-`None`/`Nil`: `Package(Any)`.** That one reached CI as `roast/S02-types/set.t`
-and `sethash.t` going red with an unrelated-looking symptom — `lives-ok`/
-`dies-ok` false negatives (`my $str; lives-ok { $str = 1 }, "x"` reported "not
-ok" even though the assignment succeeded and nothing threw). Root cause:
-`SetVarDynamic`'s closure-capture-by-reference support pre-seeds ANY not-yet-
-assigned closure-captured variable's env slot with the placeholder
-`Package(Any)`, regardless of the variable's own name (the same mechanism
-`exec_get_bare_word_op`'s read-side fallback already special-cases). The
-`Package(_)` branch of the original fix was left completely unconditional —
-no TitleCase gate at all — so a captured, not-yet-initialized `$str` hit this
-placeholder on its first (`lives-ok`-internal) write and was misidentified as
-assigning to the type `str`; `lives-ok` correctly caught the resulting
-spurious `X::Assignment::RO`, which is why the symptom looked like a `Test`
-bug rather than an assignment bug. Fixed the same way: `Package(Any)` (for any
-name other than the literal bareword `Any`) now requires the same TitleCase
-gate as `None`/a real `Nil`; only a genuine `Package(SomeRealType)` (set
-exclusively by actual class/type registration) is trusted unconditionally.
-`t/immutable-lvalue-assignment-gaps.t` pins all three shapes as separate
-regression controls (a `for`-loop destructure leaf, a `lives-ok`-captured
-uninitialized variable, and the direct `Int`/`Nil`/`Foo` cases) so a future
-change to this check has to keep all three honest at once.
-
-## Still blocked: the topic rows (`for`-loop per-item container-ness)
-
-`for %h`, `for @a[0..1]`, `for @a.map(…)` remain blocked on ADR-0040's
-store-side element itemization, unrelated to the mechanism above:
+### D. A `gather` sequence's element store
 
 ```
-for @a         Scalar      for 1,2        Int
-for @a.values  Scalar      for (1,2)      Int
-for $a, $b     Scalar      for <a b>      Str
-for @a[0..1]   Scalar      for %h.keys    Str
-for @a.map({}) Scalar      for %h         Pair
+my $s = (gather { take 1; take 2 }); $s[0] = 5
+    # raku: X::Assignment::RO, "Cannot modify an immutable Int (1)"
+    # mutsu: silently succeeds
 ```
 
-mutsu cannot evaluate that at runtime because real `Array`/`Hash` elements are
-stored **bare** — see `todo/deep/element-itemization-lost-in-scalar-binding.md`
-and ADR-0040. `vm_for_loop_lazy.rs` already applies the correct runtime test
-(`item.is_container_ref()`), which is why `for gather { … }` is rejected
-correctly; applying the same test on the eager path would additionally mark
-`for @a[0..1]` and `for @a.map(…)` read-only, inventing throws raku does not
-have. **These rows are therefore blocked on ADR-0040's store-side element
-itemization, not on the topic-marking code.**
+The `.Seq` twin was fixed by teaching `try_seq_element_cell_assign` to refuse a
+materialized non-container element. A `gather` result is a `ValueView::LazyList`
+in mutsu, not a `Seq`, and it shares that representation with the lazy `@`-array
+whose element assignment is *legitimate* (`my @a = 1,2,4...Inf; @a[2] = 99` is
+real raku, and `restore_lazy_array_slot` exists to support it). So the refusal
+cannot simply be extended to `LazyList`: it needs the `array_context` /
+`list_context` distinction to be the oracle, which is separate work.
 
-## FIXED 2026-09-05: `my $x := (1,2,3); $x = 5` and the element stores
+### E. An associative subscript of a `Seq`
 
-Both sections that stood here — "Still blocked: `my $x := (1,2,3); $x = 5`" and
-"Still blocked: element assignment (`(1,2,3)[0] = 9`, `Range`, `Seq`)" — are
-closed. See `news/2026-09/immutable-element-store-and-bind.md`. The predicted
-prerequisite ("the container/no-container distinction has to be a property of
-the *value*") turned out not to be needed: an immutable Positional is a
-container, just not a **Scalar** container, and rakudo's scalar assignment needs
-one — so the existing `bind_marks_immutable` allowlist could simply grow the
-immutable Positional kinds, and the `Seq` store reused the element-keyed rule
-the `List` store already applied.
+```
+my $s = (1,2,3).Seq; $s<a> = 5
+    # raku: X::AdHoc, "Type Seq does not support associative indexing."
+    # mutsu: silently succeeds
+```
 
-## Status update (2026-08-27): ADR-0040 slices 1-2 landed and did NOT unblock these rows
+rakudo refuses the *subscript*, not the store, so this is not an immutability row
+at all — it belongs with whatever enforces the Positional/Associative protocol
+per type.
 
-The 2026-08-26 note above says the `for` topic rows are "blocked on ADR-0040's store-side
-element itemization". ADR-0040 slices 1 and 2 have both landed (mutation sites and
-construction sites — a real `Array`/`Hash` element that holds an aggregate is now itemized),
-and every row was re-measured against it. **None moved.** `(1,2,3)[0] = 9`,
-`(1..3)[0] = 9`, the `Seq` element, `map`/`grep` topics and `for %h` all still succeed
-silently in mutsu, and `for @a[0..1] { $_ = 5 }` still fails to write through.
+### F. An inline declaration inside a list literal
 
-The re-measurement corrects the blocker attribution, which is the useful outcome:
-**itemization is not container-ness.** ADR-0040 makes an element render as one item
-(`ArrayKind::ItemArray` / a `Scalar` wrapper); it does not make the element a *cell*, and
-`item.is_container_ref()` — the runtime test the note proposes reusing on the eager `for`
-path — is still False for an ordinary itemized element. Worse, itemization is orthogonal to
-what these rows need: a plain `Int` element of a real `Array` is writable and is *not*
-itemized (§2's negatives), while a `List` literal's `List` element is not writable and, in a
-`for` over a real array, *is*. So the flag cannot be used as the writability oracle even in
-principle.
+```
+my $a = 1; (my $x = $a, 6)[0] = 10
+    # raku:  x=10 a=1  (an inline declaration in a list literal denotes the
+    #        freshly-declared variable's container, so the store writes it)
+    # mutsu: X::Assignment::RO, "Cannot modify an immutable List ((1 6))"
+```
 
-The property these rows actually need is ADR-0036's surface — promoting the element that is
-handed out to a real `ContainerRef` cell — plus, for `map`/`grep`/pointy-block topics, the
-missing readonly marking on the closure-call binding path (which ADR-0040 never touched and
-which is independent of both). Re-point the blocker at
-[ADR-0036](../../docs/adr/0036-element-container-pairs-from-subscripts-and-pairs.md) rather
-than at ADR-0040.
+Extending `scalar_container_alias_name` to cover `Expr::DoStmt(VarDecl)` was
+tried and did not reach it, so the inline declaration does not arrive in that
+shape at this position; finding what it *does* arrive as is the next step.
 
 ## Messages that are close but not exact
 
 These already throw the right class; only the rendered value differs:
 
-- `my constant @A = 1,2,3; @A = 5` — raku names the *element*
-  ("Cannot modify an immutable Int (1)", because a list assignment writes into
-  the immutable List's elements); mutsu names the container
-  ("Cannot modify an immutable List ((1 2 3))" since 2026-09-05, when the
-  rendering was corrected to rakudo's type-plus-gist shape; the *choice* of
-  container-over-element is the part that still differs). Same for
-  `my @a is List`.
+- a **compound** assignment to an immutable topic. rakudo answers
+  `X::Assignment::RO` naming the element ("Cannot modify an immutable Str (a)")
+  for `$_ .= uc` and `$_ ~= "!"`, and `X::AdHoc` for `$_ += 1`. mutsu answers
+  `X::AdHoc` for `.=` and `X::Multi::NoMatch` "Cannot resolve caller
+  postfix:<++>(_)" for `+=`/`~=` — the latter because the recompiled map/grep
+  block body routes `+= 1` through the increment check, which hardcodes
+  `postfix:<++>` as the operator name. All three now correctly *die*
+  (`t/closure-topic-readonly.t` pins that much); only the class/wording differs.
+- `my constant @A = 1,2,3; @A = 5` — raku names the *element* ("Cannot modify an
+  immutable Int (1)", because a list assignment writes into the immutable List's
+  elements); mutsu names the container ("Cannot modify an immutable List
+  ((1 2 3))"). Same for `my @a is List`.
 - `my constant %C = (a=>1); %C = (b=>2)` — raku "Cannot modify an immutable Pair
   (a => 1)"; mutsu renders the pair with a tab instead of `=>`.
 - `my %m := mix <a b>; %m = (c=>1)` — raku "immutable Mix (Mix(a b))", mutsu
   "immutable Mix (a b)".
 - `sub g() {...}; g() = 5` — raku "Cannot modify an immutable Int (42)", mutsu
-  "sub 'g' is not rw"; `$obj.x = 5` on a non-`rw` attribute — raku
-  "Cannot modify an immutable Int (1)", mutsu "method 'x' is not rw".
-- `my @a := (1,2,3); @a.splice(0,1)` — raku does not even define a `splice`
-  candidate on a plain `List` (`X::Multi::NoMatch`, "Routine does not have any
+  "sub 'g' is not rw"; `$obj.x = 5` on a non-`rw` attribute — raku "Cannot modify
+  an immutable Int (1)", mutsu "method 'x' is not rw".
+- `my @a := (1,2,3); @a.splice(0,1)` — raku does not define a `splice` candidate
+  on a plain `List` (`X::Multi::NoMatch`, "Routine does not have any
   candidates"); mutsu reports `X::Immutable` "Cannot call 'splice' on an
-  immutable 'List'" (the same message the other five list mutators correctly
-  use, since `splice` shares their dispatch check). Pre-existing, not
-  introduced by the 2026-08-27 push/append/unshift/prepend/pop/shift fix above
-  (which only extended that same check from `$`-bound to `@`-bound targets).
+  immutable 'List'" (the same message the other five list mutators use, since
+  `splice` shares their dispatch check).
 
-## Re-verified 2026-09-01 (TRIAGE regeneration)
+## Corrected blocker attributions (do not re-derive these)
 
-Six of the seven remaining harness rows still answer `OK` (list elem, Seq
-elem, map literal topic, grep topic, block arg topic, bind list assign; plus
-`for %h { $_ = 5 }`). One row moved: `(1..3)[0] = 9` now throws
-`X::Assignment::RO` in mutsu — the right class, but rendered as `Cannot modify
-an immutable value (1 2 3)` where raku says `... immutable Range (1..3)`, so it
-belongs in the "close but not exact" section rather than the live harness.
-Blocker attribution (ADR-0036, not ADR-0040) unchanged.
-
-(Superseded 2026-09-05: every row named here except the three closure-topic
-ones now matches rakudo, rendering included — see the status section at the
-top.)
-
-## Status update (2026-09-01): ADR-0036 slice 4 landed and did NOT move these rows either
-
-Slice 4 (the `env`-scan compensator deletion, plus element type constraints on
-deferred `:=`-bound slots — `news/2026-09/pair-value-lvalue-drops-the-env-scan.md`)
-completed ADR-0036's implementation. The harness above was re-run against it:
-**all seven rows answer exactly as they did on 2026-09-01 before the slice.**
-
-So the ADR-0036 attribution needs the same correction ADR-0040's did. ADR-0036
-is about what a *pair producer* hands out; every row here is about what the
-*subscript store path* and the *closure-call topic binding* accept, and neither
-of those is a pair producer. Concretely:
-
-- `(1,2,3)[0] = 9` / the `Seq` element never build a Pair at all — they need the
-  element **store** to know its container is immutable. (This bullet also
-  claimed `array_slot_ref` "already declines `ArrayKind::List`/`ItemList`". It
-  does not, and never did — re-measured 2026-09-05: it promotes every scalar
-  leaf regardless of kind, and the declining lives in
-  `exec_index_autovivify_lazy_op_decl_bind`'s `decl_bind` arm. Both rows are
-  fixed now; the correction is recorded so the claim is not reused.)
-- the four topic rows are the closure-call readonly marking this ticket's own
-  "Why `-> $v { $v = 1 }` was fixable" section describes, unchanged.
-- `my $x := (1,2,3); $x = 5` is the bind-side whitelist in
-  `vm_var_assign_set_local.rs`, also untouched by any ADR-0036 slice.
-
-**Do not block this survey on ADR-0036 any longer** — it is finished and these
-rows are still open. The remaining work is two independent, and individually
-small, surfaces: an immutable-container check on the element store, and
-separating the direct-call and native-map callers of
-`call_compiled_closure_with_topic`.
-
-That call was right, and the first of the two landed on 2026-09-05
-(`news/2026-09/immutable-element-store-and-bind.md`). **The only remaining
-surface for this survey is the second one**: separating the direct-call and
-native-map callers of `call_compiled_closure_with_topic`.
+- **ADR-0040 (store-side element itemization) is not the blocker.** Slices 1 and
+  2 landed and moved no row. Itemization is not container-ness: it makes an
+  element *render* as one item, not become a cell, and `is_container_ref()` stays
+  false for an ordinary itemized element.
+- **ADR-0036 (element containers from subscripts/pairs) is not the blocker
+  either.** Slice 4 completed it and moved no row. ADR-0036 is about what a
+  *pair producer* hands out; these rows are about what the *subscript store path*
+  and the *topic binding* accept.
+- **"Separate the two `call_compiled_closure_with_topic` callers" was not a
+  blocker.** Measured 2026-09-05: `capture_rw_topic == true` has exactly one
+  producer in the tree, so the separation already existed, and the two
+  `.map`/`.grep` rows never reached that function at all.


### PR DESCRIPTION
Closes the closure-topic rows of `todo/deep/immutable-lvalues-that-mutsu-still-lets-you-assign-to.md`.

`(1, 2).map({ $_ = 5 })`, `(1, 2).grep({ $_ = 5 })` and `my $s = { $_ = 5 }; $s(7)` succeeded silently where rakudo throws `X::AdHoc`, "Cannot assign to an immutable value". They now match, and so do six neighbours: `(1..3).map`, `%h.keys.map`, the listop `map { $_ = 5 }, 1, 2` and its `grep` twin, `{ $_ = 5 }(3 + 4)`, and `my &s = { $_ = 5 }; s(7)`.

## Two dead ends, both measured

The ticket blamed a shared `call_compiled_closure_with_topic` between the direct value call and the native rw-map. Measured with gdb: only one call site in the tree produces `capture_rw_topic == true`, so that separation already existed — and the two map/grep rows never reach that function at all, landing in `eval_map_over_items` / `eval_grep_over_items_with_mutated`.

The obvious replacement — decide per item with `!item.is_container_ref()`, as `vm_for_loop_lazy.rs` does — was implemented and measured, then dropped: a real `Array`'s elements are stored **bare** in mutsu, so it also rejects `@a.list.map({ $_ = 7 })`, `@a[0..1].map(...)`, `@a.Seq.map(...)`, `my $x = [1,2,3]; $x.map(...)` and a `.sort` key extractor — all of which rakudo accepts. A source-*kind* rule fails the same way (`@a.list` is a `List` whose elements rakudo still writes through).

## What ships

The receiver's **syntax**, decided at compile time by the existing `Compiler::for_iterable_yields_bare_items` — the same oracle that fixed the `for`-loop topic rows, since `for 1, 2 { $_ = 5 }` and `(1, 2).map({ $_ = 5 })` are one rejection in rakudo for one reason. A bare block written directly against a provably-bare source carries a new `CompiledCode::immutable_topic`; the three loops mark `$_` per iteration.

The direct value call is the same idea at the argument end: a new `Compiler::expr_yields_container_less_value` recognises an argument that provably mints a fresh value, `OpCode::CallOnValue`/`CallOnCodeVar` carry it as `bare_args`, and the closure dispatch marks the implicit topic. Both predicates answer `false` for anything that could denote an lvalue (`$b($v)`, `$b(@a[0])` stay writable), so **no shape that works today starts throwing**.

Both marks are made at the call/loop site, never as a body prologue — that leaks past the `push_call_frame`-bypassing native loops. The grep loop, alone among the three, had no per-iteration `ReadonlyFrameGuard`; it gained one.

## Five pre-existing divergences fell out of making the marking symmetric

`readonly_vars` is keyed by the bare name `_`, so a construct that marked its own topic left the mark in force inside every nested topic binding. All four of these threw before this PR and are fine in rakudo:

```raku
for 1, 2 { my @b = 7,8; for @b { $_ = 1 } }
sub f() { $_ = 5 }; for 1, 2 { f() }
my @a = 1,2,3; for 1, 2 { @a.map({ $_ = 5 }) }
my @a = 1,2,3; for 1, 2 { @a.grep({ $_ = 5 }) }
```

Every construct that binds a topic now sets writability in **both** directions: the eager `for` loop clears an inherited mark (restoring the caller's on all three exit paths), the map/grep loops do so per iteration inside their readonly frames, the closure dispatch clears it for a writable topic and for a routine's fresh `$_`, and `call_compiled_function_fast` — which deliberately opens no readonly frame — saves the kind and restores it on the way out, matching the `unmark_readonly_topic` every other call path already did.

## Testing

- `t/closure-topic-readonly.t` — 31 assertions pinning **both** halves in one file (rejected shapes, the write-through shapes that must keep working, the read-only uses, and the five nesting cases). Green under `raku` as well as under mutsu; every expectation was measured against rakudo first.
- `make test`: PASS (3661 files, 37246 tests).
- Targeted roast sweep: all 70 whitelisted files containing a `$_` assignment — PASS. Plus `S32-list/map.t`, `S32-list/grep.t`, `S02-types/whatever.t`, `S03-operators/flip-flop.t` and the five `t/map-*`/`t/grep-*`/`t/topic-*` pins.

The ticket is rewritten to hold only what is still open (the receivers mutsu cannot prove bare, the element shapes where it drops the write instead, the `$`-bind-of-a-mutable-container family, `gather`/`Seq` stores, and the compound-assign error class), with the measurements that separate them from what landed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)