### PR TITLE
feat(rakuast): render method return types in .AST

### DIFF
--- a/news/2026-09/rakuast-method-return-types.md
+++ b/news/2026-09/rakuast-method-return-types.md
@@ -1,0 +1,54 @@
+# RakuAST method return types
+
+`method m(--> Int)`, `method m() returns Int`, and `method m() of Int` now
+render their return type in `.AST`, closing the read-direction gap
+`todo/deep/rakuast-remaining.md` recorded for methods. Before this change any
+method carrying a return type was a `.AST` coverage boundary
+(`RakuAST: `.AST` does not yet support this construct: method with traits /
+private / multi / submethod`), even though the identical `sub` forms had been
+closed since 2026-08-22.
+
+## Root cause
+
+The blocker was not in the converter but in the parser. `sub`'s trait parser
+records *which spelling* a return type used as an internal pseudo-trait —
+`__return_via_trait` for `returns X`, `__return_via_of` for `of X` — because
+raku models the three spellings with three different nodes
+(`Signature.returns`, `Trait::Returns`, `Trait::Of`) and the converter must
+never guess between them.
+
+`src/parser/stmt/sub_param/method_decl.rs` filtered *every* `__`-prefixed entry
+out of `MethodDecl.custom_traits`, so by the time a method declaration reached
+`src/rakuast/convert.rs` the `-->` and `returns` spellings were
+indistinguishable. Since `RakuAST::Method` and `RakuAST::Sub` are both
+`RakuAST::Routine`s and carry the same `signature` / `traits` shape, once the
+marker survives, the existing `return_type_spelling` / `routine_node` machinery
+renders methods with no new node logic at all.
+
+## Change
+
+- `method_decl.rs` keeps `__`-prefixed parser markers in
+  `MethodDecl.custom_traits` (user-facing traits like `default` and
+  `DEPRECATED` are still extracted into their own fields as before).
+- `src/runtime/registration_class_body_method.rs` skips `__`-prefixed entries
+  when applying user `trait_mod:<is>` candidates, so an internal marker never
+  reaches user code. The gate that decides whether trait application runs at
+  all now also ignores markers, keeping a plain
+  `method m(--> Int)` on exactly the path it was on before.
+- `src/rakuast/convert.rs`'s `MethodDecl` arm reads the spelling with the same
+  `return_type_spelling` helper the `SubDecl` arm uses and passes the return
+  type to `routine_node`. A method with a `__return_via_*` marker but no return
+  type is refused rather than rendered wrong.
+
+## Coverage
+
+`t/rakuast-method-return-type.t` (16 assertions) pins all three spellings, the
+parameterised forms, the in-class-body form, that a plain `method m() { 1 }`
+still omits its signature entirely, and that `Signature.returns` /
+`Trait::Returns.type` are reachable through the accessors. Like the rest of the
+`t/rakuast*.t` suite it is a dual-oracle test: it passes verbatim under both
+mutsu and the system `raku`.
+
+The write direction is untouched: `RakuAST::Method` has no `EVAL` lowering at
+all yet (neither does `RakuAST::Class`), so method lowering remains its own
+future slice rather than a gap this change opens.

--- a/src/parser/stmt/sub_param/method_decl.rs
+++ b/src/parser/stmt/sub_param/method_decl.rs
@@ -174,14 +174,17 @@ fn method_decl_body_with_my(
                 }
             }),
             handles: traits.handles.clone(),
+            // `__`-prefixed entries are internal parser markers, not user
+            // traits: `__return_via_trait` / `__return_via_of` record which
+            // spelling a return type used (`returns` vs `of`), which RakuAST
+            // models with different nodes. They are kept here so the
+            // distinction survives to the converter; every consumer of
+            // `MethodDecl.custom_traits` that applies user traits skips them.
             custom_traits: traits
                 .custom_traits
                 .iter()
                 .filter(|(t, _)| {
-                    t != "default"
-                        && t != "DEPRECATED"
-                        && !t.starts_with("DEPRECATED:")
-                        && !t.starts_with("__")
+                    t != "default" && t != "DEPRECATED" && !t.starts_with("DEPRECATED:")
                 })
                 .cloned()
                 .collect(),

--- a/src/rakuast/convert.rs
+++ b/src/rakuast/convert.rs
@@ -407,8 +407,13 @@ fn convert_stmt(stmt: &Stmt) -> Result<Option<RakuAstNode>, RuntimeError> {
             custom_traits,
             ..
         } => {
-            // Plain `method NAME (params) { body }`. Private/submethod/multi/our/
-            // my forms, traits, delegation, and return types carry extra shape.
+            // Plain `method NAME (params) { body }`, with return types in all
+            // three spellings (`-->` via `Signature.returns`, `returns`/`of`
+            // via `Trait::Returns`/`Trait::Of`) — a `RakuAST::Method` is a
+            // `RakuAST::Routine` just like `RakuAST::Sub`, so it carries the
+            // same `signature` / `traits` shape. Private/submethod/multi/our/
+            // my forms, user traits, and delegation carry extra shape.
+            let spelling = return_type_spelling(custom_traits)?;
             if name_expr.is_some()
                 || *multi
                 || *is_rw
@@ -417,22 +422,28 @@ fn convert_stmt(stmt: &Stmt) -> Result<Option<RakuAstNode>, RuntimeError> {
                 || *is_my
                 || *is_submethod
                 || *our_variable_form
-                || return_type.is_some()
                 || *is_default_candidate
                 || deprecated_message.is_some()
                 || !handles.is_empty()
-                || !custom_traits.is_empty()
+                || custom_traits
+                    .iter()
+                    .any(|(t, _)| !is_return_spelling_marker(t))
             {
                 return Err(unsupported(
                     "method with traits / private / multi / submethod",
                 ));
+            }
+            if return_type.is_none() && spelling != ReturnSpelling::Arrow {
+                // A `__return_via_*` marker without a return type would be a
+                // parser inconsistency; refuse rather than render a wrong node.
+                return Err(unsupported("method with a return trait but no return type"));
             }
             Ok(Some(statement_expression(routine_node(
                 RakuAstClass::Method,
                 &name.resolve(),
                 param_defs,
                 body,
-                None,
+                return_type.as_deref().map(|t| (t, spelling)),
             )?)))
         }
         Stmt::ClassDecl {

--- a/src/runtime/registration_class_body_method.rs
+++ b/src/runtime/registration_class_body_method.rs
@@ -9,6 +9,14 @@ use super::*;
 use crate::ast::HandleSpec;
 use crate::symbol::Symbol;
 
+/// Whether a `custom_traits` entry is an internal parser marker rather than a
+/// user trait. The parser records the return-type spelling (`returns` vs `of`)
+/// as a `__`-prefixed pseudo-trait so the RakuAST converter can tell the two
+/// apart; nothing in trait application should ever see it.
+fn is_parser_marker(trait_name: &str) -> bool {
+    trait_name.starts_with("__")
+}
+
 impl Interpreter {
     /// The `method` arm of the class-body walk: validate the declaration,
     /// build its `MethodDef`, install it in the method table, and register
@@ -282,12 +290,19 @@ impl Interpreter {
                 &crate::opcode::decl_traits_from_ast(&decl.custom_traits),
             )?;
         }
-        // Apply custom trait_mod:<is> for each non-builtin trait on methods
-        if !decl.custom_traits.is_empty() {
+        // Apply custom trait_mod:<is> for each non-builtin trait on methods.
+        // `__`-prefixed entries are internal parser markers (the
+        // `__return_via_trait` / `__return_via_of` return-type spelling the
+        // RakuAST converter reads), never user traits, so they never reach a
+        // user `trait_mod:<is>` candidate.
+        if decl.custom_traits.iter().any(|(t, _)| !is_parser_marker(t)) {
             let has_trait_mod =
                 self.has_proto("trait_mod:<is>") || self.has_multi_candidates("trait_mod:<is>");
             if has_trait_mod {
                 for (trait_name, trait_arg) in &decl.custom_traits {
+                    if is_parser_marker(trait_name) {
+                        continue;
+                    }
                     let mut trait_env = self.env.clone();
                     // Add method lookup markers so .wrap stores in
                     // method_wrap_chains (keyed by class+method).

--- a/t/rakuast-method-return-type.t
+++ b/t/rakuast-method-return-type.t
@@ -1,0 +1,72 @@
+use v6;
+use MONKEY-SEE-NO-EVAL;
+use experimental :rakuast;
+use Test;
+
+# RakuAST method return types (ADR-0011), read direction.
+#
+# `RakuAST::Method` is a `RakuAST::Routine` just like `RakuAST::Sub`, so it
+# carries the same return-type shape and the same three spellings:
+#   * `method m(--> Int)`        -> Signature.returns => Type::Simple
+#   * `method m() returns Int`   -> traits => (Trait::Returns(Type::Simple),)
+#   * `method m() of Int`        -> traits => (Trait::Of(Type::Simple),)
+#
+# The parser records which spelling was used as a `__return_via_*` marker in
+# `MethodDecl.custom_traits`; before this slice that marker was filtered out at
+# parse time, so the three forms were indistinguishable and every method with a
+# return type was a `.AST` coverage boundary.
+#
+# Passes under BOTH mutsu and raku.
+
+plan 16;
+
+# --- read side: the `-->` arrow lands in the signature ----------------------
+my $arrow = Q[method m(--> Int) { 1 }].AST.gist;
+ok $arrow.contains('RakuAST::Method.new('),
+    'a method with a `-->` return type renders as a RakuAST::Method';
+ok $arrow.contains('returns    => RakuAST::Type::Simple.new('),
+    'a `-->` return type renders as Signature.returns';
+ok $arrow.contains('parameters => $( )'),
+    'a parameter-less method signature renders its empty parameter list as $( )';
+nok $arrow.contains('RakuAST::Trait::'),
+    'a `-->` return type emits no trait';
+
+my $arrow_p = Q[method m($x --> Int) { 1 }].AST.gist;
+ok $arrow_p.contains('RakuAST::ParameterTarget::Var.new(')
+    && $arrow_p.contains('returns    => RakuAST::Type::Simple.new('),
+    'a method signature can carry both parameters and a `-->` return type';
+
+# --- read side: the `returns` / `of` traits ---------------------------------
+my $ret = Q[method m() returns Int { 1 }].AST.gist;
+ok $ret.contains('RakuAST::Trait::Returns.new('),
+    '`returns Int` on a method renders as a Trait::Returns';
+nok $ret.contains('returns    =>'),
+    '`returns Int` on a method does not also fill Signature.returns';
+
+ok Q[method m() of Int { 1 }].AST.gist.contains('RakuAST::Trait::Of.new('),
+    '`of Int` on a method renders as a Trait::Of';
+
+ok Q[method m($x) returns Int { 1 }].AST.gist.contains('RakuAST::Trait::Returns.new('),
+    'a parameterised method can carry a `returns` trait';
+
+# --- a plain method still omits the signature -------------------------------
+nok Q[method m() { 1 }].AST.gist.contains('signature'),
+    'a method with neither parameters nor a return type omits the signature';
+
+# --- the same shape inside a class body -------------------------------------
+my $in_class = Q[class C { method m(--> Int) { 1 } }].AST.gist;
+ok $in_class.contains('RakuAST::Method.new('),
+    'a method declared in a class body renders as a RakuAST::Method';
+ok $in_class.contains('returns    => RakuAST::Type::Simple.new('),
+    'a class method carries its `-->` return type in the signature';
+
+# --- introspection ----------------------------------------------------------
+my $sig = Q[method m(--> Int) { 1 }].AST.statements[0].expression.signature;
+ok $sig ~~ RakuAST::Signature, 'the method exposes its Signature';
+is $sig.returns.name.gist, 'RakuAST::Name.from-identifier("Int")',
+    'Signature.returns is reachable through the method accessors';
+
+my $trait = Q[method m() returns Int { 1 }].AST.statements[0].expression.traits[0];
+is $trait.^name, 'RakuAST::Trait::Returns', 'the method exposes its return trait';
+is $trait.type.name.gist, 'RakuAST::Name.from-identifier("Int")',
+    'Trait::Returns.type is reachable through the method accessors';

--- a/todo/deep/rakuast-remaining.md
+++ b/todo/deep/rakuast-remaining.md
@@ -75,6 +75,18 @@ the parser/internal AST, not guessing during RakuAST conversion.
   `MetaInfix::Hyper(FunctionInfix(Var::Lexical))` with the measured DWIM fields,
   and lowers back through the existing `Expr::HyperFuncOp` execution path.
 
+**Closed 2026-09-05** (read direction, pinned by
+`t/rakuast-method-return-type.t`; see
+[the news entry](../../news/2026-09/rakuast-method-return-types.md)):
+
+- *Signature return types on methods.* `method m(--> Int)`,
+  `method m() returns Int`, and `method m() of Int` render the same three node
+  shapes a `sub` does. The parser now keeps its `__return_via_*` spelling
+  markers in `MethodDecl.custom_traits` (method trait application skips
+  `__`-prefixed entries), so the converter reads the spelling instead of
+  guessing. The write direction is unaffected: `RakuAST::Method` has no `EVAL`
+  lowering yet at all, which is its own slice.
+
 Still open:
 
 - `.=` and Whatever compound autoprime. `$x .= Str` desugars to a plain `=` over
@@ -85,12 +97,6 @@ Still open:
   `EVAL` reuses the existing execution expansion. The `* += 1` Whatever
   autoprime path remains a separate boundary because it still builds its
   closure before conversion; ADR-0033 §2.5 tracks that case.
-- Signature return types **on methods**. `method m(--> Int)` is still deferred:
-  `src/parser/stmt/sub_param/method_decl.rs` filters every `__`-prefixed marker
-  out of `MethodDecl.custom_traits`, so `-->` and `returns` are indistinguishable
-  there. Fixing it means either plumbing the spelling through a dedicated
-  `MethodDecl` field or keeping the marker and teaching the method trait-application
-  loop (`registration_class_body_method.rs`) to skip `__`-prefixed names.
 - The remaining hyper forms: hyper *prefix* (`-<<@a`, desugared to a
   `__mutsu_hyper_prefix` call), hyper *postcircumfix* (`@a>>[1]`, desugared to a
   hyper `AT-POS` method call), and `@a<<.abs` (which mutsu's parser currently


### PR DESCRIPTION
Closes the "signature return types **on methods**" read-direction gap from
`todo/deep/rakuast-remaining.md`.

## Problem

`method m(--> Int)`, `method m() returns Int`, and `method m() of Int` were all
a `.AST` coverage boundary:

```
$ mutsu -e 'say Q[method m(--> Int) { 1 }].AST'
RakuAST: `.AST` does not yet support this construct: method with traits / private / multi / submethod
```

…even though the identical `sub` spellings have been closed since 2026-08-22.

## Root cause

The blocker was in the parser, not the converter. `sub`'s trait parser records
*which spelling* a return type used as an internal pseudo-trait —
`__return_via_trait` for `returns X`, `__return_via_of` for `of X` — because
raku models the three spellings with three different nodes
(`Signature.returns`, `Trait::Returns`, `Trait::Of`) and the converter must
never guess between them.

`src/parser/stmt/sub_param/method_decl.rs` filtered *every* `__`-prefixed entry
out of `MethodDecl.custom_traits`, so by conversion time `-->` and `returns`
were indistinguishable there.

`RakuAST::Method` and `RakuAST::Sub` are both `RakuAST::Routine`s and carry the
same `signature` / `traits` shape, so once the marker survives, the existing
`return_type_spelling` / `routine_node` machinery renders methods with **no new
node logic at all**.

## Change

- `method_decl.rs` keeps `__`-prefixed parser markers in
  `MethodDecl.custom_traits` (the user-facing `default` / `DEPRECATED` traits
  are still extracted into their own fields exactly as before).
- `src/runtime/registration_class_body_method.rs` skips `__`-prefixed entries
  when applying user `trait_mod:<is>` candidates, and the gate that decides
  whether trait application runs at all ignores them too — so a plain
  `method m(--> Int)` stays on precisely the path it was on before.
- `src/rakuast/convert.rs`'s `MethodDecl` arm reads the spelling with the same
  helper the `SubDecl` arm uses and passes the return type to `routine_node`. A
  method carrying a `__return_via_*` marker but no return type is refused
  rather than rendered wrong.

## Result

```
$ mutsu -e 'say Q[method m(--> Int) { 1 }].AST'
RakuAST::StatementList.new(
  RakuAST::Statement::Expression.new(
    expression => RakuAST::Method.new(
      name      => RakuAST::Name.from-identifier("m"),
      signature => RakuAST::Signature.new(
        parameters => $( ),
        returns    => RakuAST::Type::Simple.new(
          RakuAST::Name.from-identifier("Int")
        )
      ),
      ...
```

`returns Int` renders `traits => (RakuAST::Trait::Returns.new(...),)` and
`of Int` renders `RakuAST::Trait::Of`, matching the `sub` forms.

## Tests

`t/rakuast-method-return-type.t` (16 assertions) pins all three spellings, the
parameterised forms, the in-class-body form, that a plain `method m() { 1 }`
still omits its signature entirely, and that `Signature.returns` /
`Trait::Returns.type` are reachable through the accessors. Like the rest of the
`t/rakuast*.t` suite it is a dual-oracle test that passes verbatim under both
mutsu and raku.

Runtime behaviour is unchanged — `method m(--> Int)` still enforces its return
type (`X::TypeCheck::Return`), and user traits on methods still reach
`trait_mod:<is>`.

The write direction is untouched: `RakuAST::Method` has no `EVAL` lowering yet
at all (neither does `RakuAST::Class`), so method lowering remains its own
future slice rather than a gap this change opens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TtL4NKUC5rVfjD6mFDpqh9

---
_Generated by [Claude Code](https://claude.ai/code/session_01TtL4NKUC5rVfjD6mFDpqh9)_