### PR TITLE
feat(rakuast): lower classes, roles, methods and attributes through EVAL

### DIFF
--- a/news/2026-09/rakuast-class-role-method-lowering.md
+++ b/news/2026-09/rakuast-class-role-method-lowering.md
@@ -1,0 +1,55 @@
+# RakuAST class, role, method and attribute lowering
+
+`EVAL` now accepts `RakuAST::Class`, `RakuAST::Role`, `RakuAST::Method`, and
+the attribute form of `RakuAST::VarDeclaration::Simple`. Before this change the
+read direction rendered all four (Phase 2 slice 13, pinned by
+`t/rakuast-class.t` and `t/rakuast-role.t`) while the write direction refused
+the whole tree — `EVAL does not yet support lowering RakuAST::Class` — so the
+declaration cluster was readable but not round-trippable.
+
+## Change
+
+`src/rakuast/lower.rs` gained four arms, each lowering into the existing
+internal AST so the ordinary compiler and VM run the result. There is no second
+execution path.
+
+- `RakuAST::Class` -> `Stmt::ClassDecl`. Its `body` is a `Block` whose
+  statements are the class body, lowered by the same statement dispatch, so
+  methods and attributes come along for free.
+- `RakuAST::Role` -> `Stmt::RoleDecl`. A role's body is a `RoleBody` wrapping
+  the `Blockoid`, matching what the converter renders; a `Block` there is
+  refused.
+- `RakuAST::Method` -> `Stmt::MethodDecl`, the `Method` counterpart of
+  `lower_sub`. It reads its return type through the same
+  `signature.returns` / `Trait::Returns` / `Trait::Of` helper, so all three
+  spellings the converter renders lower back, and the lowered return type is
+  still enforced at run time.
+- A `VarDeclaration::Simple` with `scope => "has"` -> `Stmt::HasDecl`, reading
+  the twigil (`.` public / `!` private), the sigil, and an optional type. A
+  typed attribute's implicit `BareWord(<TypeName>)` default — which the parser
+  plants and the converter deliberately skips — is re-planted so the two
+  directions stay symmetric.
+
+Every richer form (inheritance, scope, reprs, traits, parameterised roles,
+private/multi/submethods, attribute traits and `will build` defaults) is
+already refused on the *read* side, so nothing that reaches these lowerers can
+carry shape they would drop.
+
+## A rendering bug fixed on the way
+
+`method m() is raw { }` rendered as a plain `RakuAST::Method`, silently dropping
+the trait. `is_raw` was added to `Stmt::MethodDecl` after the converter arm was
+written, and the arm's "no traits" guard was never extended to it. It is now
+refused (a coverage boundary) instead of rendered wrong, which is the rule the
+rest of that arm already followed.
+
+## Coverage
+
+`t/rakuast-eval-class.t` (15 assertions) exercises an empty class, a class with
+a method, a method with parameters, public/private/typed attributes and their
+accessors, all three return-type spellings, run-time enforcement of a lowered
+return type, and the role forms. Each program ends with its declaration, so the
+`EVAL`'d value is the type object and the test calls into it from the outside —
+referring to a user class by bare name *inside* the same program is a separate,
+still-open read-direction gap (a user type name renders as a bareword). It is a
+dual-oracle test: it passes verbatim under both mutsu and raku.

--- a/src/rakuast/convert.rs
+++ b/src/rakuast/convert.rs
@@ -395,6 +395,7 @@ fn convert_stmt(stmt: &Stmt) -> Result<Option<RakuAstNode>, RuntimeError> {
             body,
             multi,
             is_rw,
+            is_raw,
             is_private,
             is_our,
             is_my,
@@ -417,6 +418,7 @@ fn convert_stmt(stmt: &Stmt) -> Result<Option<RakuAstNode>, RuntimeError> {
             if name_expr.is_some()
                 || *multi
                 || *is_rw
+                || *is_raw
                 || *is_private
                 || *is_our
                 || *is_my

--- a/src/rakuast/lower.rs
+++ b/src/rakuast/lower.rs
@@ -74,6 +74,9 @@ fn lower_stmt_inner(node: &RakuAstNode) -> Result<Stmt, RuntimeError> {
             is_until: false,
         }),
         RakuAstClass::StatementFor => lower_for(node),
+        RakuAstClass::Class => lower_class(node),
+        RakuAstClass::Role => lower_role(node),
+        RakuAstClass::Method => lower_method(node),
         // A named `sub f { … }` is a declaration; a nameless one (`sub ($x) { … }`,
         // `sub { … }`) is a closure *value*, so it lowers through the expression
         // path instead.
@@ -236,6 +239,92 @@ fn lower_sub(node: &RakuAstNode) -> Result<Stmt, RuntimeError> {
         is_test_assertion: false,
         supersede: false,
         custom_traits,
+    })
+}
+
+/// `class NAME { … }` -> `Stmt::ClassDecl`. The body is a `Block` whose
+/// statements are the class body (methods, attributes, …), lowered by the same
+/// statement dispatch. Only the plain form round-trips: the converter refuses
+/// to *read* a class with inheritance, scope, a repr, or traits, so nothing
+/// lowered here can carry them either.
+fn lower_class(node: &RakuAstNode) -> Result<Stmt, RuntimeError> {
+    let name = call_name_str(node)?;
+    let body = lower_block(named_child(node, "body")?)?;
+    Ok(Stmt::ClassDecl {
+        name: crate::symbol::Symbol::intern(&name),
+        name_expr: None,
+        parents: Vec::new(),
+        class_is_rw: false,
+        is_hidden: false,
+        is_lexical: false,
+        hidden_parents: Vec::new(),
+        does_parents: Vec::new(),
+        repr: None,
+        body,
+        language_version: crate::parser::current_language_version(),
+        custom_traits: Vec::new(),
+        is_unit: false,
+        // A hand-built or lowered declaration has no parse-time site, which is
+        // exactly what `decl_id: 0` means.
+        decl_id: 0,
+        parent_args: Vec::new(),
+    })
+}
+
+/// `role NAME { … }` -> `Stmt::RoleDecl`. A role's body is a `RoleBody` (not a
+/// plain `Block`) wrapping the `Blockoid`, matching what the converter renders.
+/// Parameterised roles, export, `is rw`, and traits are refused on the read
+/// side, so nothing lowered here carries them.
+fn lower_role(node: &RakuAstNode) -> Result<Stmt, RuntimeError> {
+    let name = call_name_str(node)?;
+    let role_body = named_child(node, "body")?;
+    if role_body.class != RakuAstClass::RoleBody {
+        return Err(unsupported(node));
+    }
+    let body = lower(named_child_or_positional(named_child(role_body, "body")?)?)?;
+    Ok(Stmt::RoleDecl {
+        name: crate::symbol::Symbol::intern(&name),
+        type_params: Vec::new(),
+        type_param_defs: Vec::new(),
+        is_export: false,
+        export_tags: Vec::new(),
+        body,
+        is_rw: false,
+        language_version: crate::parser::current_language_version(),
+        custom_traits: Vec::new(),
+    })
+}
+
+/// `method NAME (…) { … }` -> `Stmt::MethodDecl`, the `Method` counterpart of
+/// [`lower_sub`]. The return type comes back through the same
+/// `signature.returns` / `Trait::Returns` / `Trait::Of` reading `lower_sub`
+/// uses, so all three spellings the converter renders lower back.
+fn lower_method(node: &RakuAstNode) -> Result<Stmt, RuntimeError> {
+    let name = call_name_str(node)?;
+    let (params, param_defs) = signature_positional_params(node)?;
+    let (return_type, custom_traits) = routine_return_type(node)?;
+    let body = lower(named_child_or_positional(named_child(node, "body")?)?)?;
+    Ok(Stmt::MethodDecl {
+        name: crate::symbol::Symbol::intern(&name),
+        name_expr: None,
+        params,
+        param_defs,
+        body,
+        multi: false,
+        is_rw: false,
+        is_raw: false,
+        is_private: false,
+        is_our: false,
+        is_my: false,
+        is_submethod: false,
+        our_variable_form: false,
+        return_type,
+        is_default_candidate: false,
+        deprecated_message: None,
+        handles: Vec::new(),
+        custom_traits,
+        is_export: false,
+        export_tags: Vec::new(),
     })
 }
 
@@ -604,6 +693,11 @@ fn arg_exprs(node: &RakuAstNode) -> Result<Vec<Expr>, RuntimeError> {
 /// attribute forms (which carry `scope`/`type`/`twigil`/`traits` fields) are the
 /// coverage boundary.
 fn lower_var_decl(node: &RakuAstNode) -> Result<Stmt, RuntimeError> {
+    // `scope => "has"` is an attribute declaration, not a variable one; it is
+    // the only scope that lowers (the converter renders no other).
+    if matches!(leaf_str(node, "scope").as_deref(), Ok("has")) {
+        return lower_attribute(node);
+    }
     if node.fields.iter().any(|f| {
         matches!(
             f.name,
@@ -648,6 +742,65 @@ fn lower_var_decl(node: &RakuAstNode) -> Result<Stmt, RuntimeError> {
         export_tags: Vec::new(),
         custom_traits,
         where_constraint: None,
+    })
+}
+
+/// `has [Type] $.x` -> `Stmt::HasDecl`. The converter renders an attribute as a
+/// `VarDeclaration::Simple` with `scope => "has"` and a `twigil` (`.` public /
+/// `!` private); everything richer (traits, smileys, `required`, `where`,
+/// aliases, `my`/`our` attributes) is refused on the read side, so nothing that
+/// reaches here can carry it. An explicit `= EXPR` default is a
+/// `Trait::WillBuild` in raku, which the converter also refuses, so an
+/// `initializer` here would be a shape it never produced.
+fn lower_attribute(node: &RakuAstNode) -> Result<Stmt, RuntimeError> {
+    if node
+        .fields
+        .iter()
+        .any(|f| matches!(f.name, Some("traits") | Some("initializer")))
+    {
+        return Err(unsupported(node));
+    }
+    let sigil = leaf_str(node, "sigil")?;
+    let mut chars = sigil.chars();
+    let (Some(sigil_char), None) = (chars.next(), chars.next()) else {
+        return Err(unsupported(node));
+    };
+    let is_public = match leaf_str(node, "twigil")?.as_str() {
+        "." => true,
+        "!" => false,
+        _ => return Err(unsupported(node)),
+    };
+    let desigil = match positional_leaf(named_child(node, "desigilname")?)?.view() {
+        ValueView::Str(s) => s.to_string(),
+        _ => return Err(unsupported(node)),
+    };
+    let type_constraint = match node.fields.iter().find(|f| f.name == Some("type")) {
+        Some(f) => Some(simple_type_name(node, child_node(&f.value)?)?),
+        None => None,
+    };
+    Ok(Stmt::HasDecl {
+        name: crate::symbol::Symbol::intern(&desigil),
+        is_public,
+        // A typed attribute carries an implicit `BareWord(<TypeName>)` default
+        // in the internal AST; the parser plants it, and the converter skips it
+        // on the way out, so re-plant it here to keep the two sides symmetric.
+        default: type_constraint.as_ref().map(|t| Expr::BareWord(t.clone())),
+        handles: Vec::new(),
+        is_rw: false,
+        is_readonly: false,
+        type_constraint,
+        type_smiley: None,
+        is_required: None,
+        sigil: sigil_char,
+        where_constraint: None,
+        is_alias: false,
+        is_our: false,
+        is_my: false,
+        is_default: None,
+        is_type: None,
+        deprecated_message: None,
+        is_built: None,
+        unknown_traits: Vec::new(),
     })
 }
 

--- a/t/rakuast-eval-class.t
+++ b/t/rakuast-eval-class.t
@@ -1,0 +1,70 @@
+use v6;
+use MONKEY-SEE-NO-EVAL;
+use experimental :rakuast;
+use Test;
+
+# RakuAST class / role / method / attribute lowering (ADR-0011, the write
+# direction).
+#
+# `RakuAST::Class`, `RakuAST::Role`, `RakuAST::Method`, and the
+# `VarDeclaration::Simple` with `scope => "has"` that an attribute renders as
+# have been readable since Phase 2 slice 13, but none of them lowered: `EVAL`
+# refused the whole tree. They now lower to `Stmt::ClassDecl` /
+# `Stmt::RoleDecl` / `Stmt::MethodDecl` / `Stmt::HasDecl` and run through the
+# ordinary compiler and VM.
+#
+# A class declaration is the last statement of each EVAL'd program, so the
+# EVAL'd value is the type object and the test calls into it from the outside.
+# (Referring to the class *inside* the same program by bare name is a separate,
+# still-open read-direction gap: a user type name renders as a bareword.)
+#
+# Each test uses a distinct class name because `.AST` registers the symbol and
+# raku rejects redeclaration.
+#
+# Passes under BOTH mutsu and raku.
+
+plan 15;
+
+# --- an empty class ---------------------------------------------------------
+is EVAL(Q[class E1 { }].AST).^name, 'E1',
+    'an empty class lowers to a type object with its name';
+
+# --- a class with a method --------------------------------------------------
+my $c2 = EVAL(Q[class E2 { method m() { 42 } }].AST);
+is $c2.^name, 'E2', 'a class with a method keeps its name';
+is $c2.m, 42, 'the lowered method runs';
+
+# --- a method with parameters -----------------------------------------------
+is EVAL(Q[class E3 { method add($a, $b) { $a + $b } }].AST).add(3, 4), 7,
+    'a lowered method takes its parameters';
+
+# --- a public attribute -----------------------------------------------------
+my $c4 = EVAL(Q[class E4 { has $.x; method double() { $!x * 2 } }].AST);
+is $c4.new(x => 21).double, 42, 'a lowered public attribute is set by .new';
+is $c4.new(x => 5).x, 5, 'a lowered public attribute has its accessor';
+
+# --- a private attribute ----------------------------------------------------
+my $c5 = EVAL(Q[class E5 { has $!n; method m() { 7 } }].AST);
+is $c5.m, 7, 'a class with a private attribute lowers';
+nok $c5.^can('n'), 'a private attribute gets no public accessor';
+
+# --- a typed attribute ------------------------------------------------------
+is EVAL(Q[class E6 { has Int $.n; method plus1() { $!n + 1 } }].AST).new(n => 4).plus1, 5,
+    'a lowered typed attribute keeps its type constraint';
+
+# --- return types in all three spellings ------------------------------------
+is EVAL(Q[class E7 { method m(--> Int) { 9 } }].AST).m, 9,
+    'a `-->` return type lowers on a method';
+is EVAL(Q[class E8 { method m() returns Int { 10 } }].AST).m, 10,
+    'a `returns` trait lowers on a method';
+
+# --- the lowered return type is still enforced ------------------------------
+throws-like { EVAL(Q[class E9 { method m(--> Int) { "nope" } }].AST).m }, Exception,
+    'the lowered method return type is checked at run time';
+
+# --- a role lowers the same way (its body is a RoleBody, not a Block) -------
+my $r1 = EVAL(Q[role E10 { method m() { 5 } }].AST);
+is $r1.^name, 'E10', 'a role lowers to a role type object with its name';
+is $r1.m, 5, 'the lowered role method runs on the punned role';
+
+is EVAL(Q[role E11 { }].AST).^name, 'E11', 'an empty role lowers';

--- a/todo/deep/rakuast-remaining.md
+++ b/todo/deep/rakuast-remaining.md
@@ -77,6 +77,13 @@ the parser/internal AST, not guessing during RakuAST conversion.
 
 **Closed 2026-09-05**:
 
+- *Class / role / method / attribute lowering.* `EVAL` accepts
+  `RakuAST::Class`, `RakuAST::Role`, `RakuAST::Method`, and the attribute form
+  of `VarDeclaration::Simple` (`scope => "has"`), lowering them to
+  `Stmt::ClassDecl` / `RoleDecl` / `MethodDecl` / `HasDecl`. The declaration
+  cluster had been readable since Phase 2 slice 13 but not round-trippable.
+  Pinned by `t/rakuast-eval-class.t`; see
+  [the news entry](../../news/2026-09/rakuast-class-role-method-lowering.md).
 - *Anonymous subs with explicit signatures.* `sub ($x) { }` renders as a
   nameless `RakuAST::Sub` (its parameters carrying the implicit
   `Type::Setting(Any)` a pointy block's do not) and lowers back through `EVAL`;
@@ -113,6 +120,14 @@ Still open:
 - `with` / `without`. Desugared at parse time into a `__with_tmp_N` temp var plus
   an `if` on `.defined`, so there is no statement to map to
   `Statement::With` / `Statement::Without`.
+- A reference to a user-declared type by bare name. `class C { }; C.new` reads
+  `C` as `Expr::BareWord`, and only *builtin* type names
+  (`is_known_type_constraint`) convert to `Type::Simple`, so any program that
+  declares a class and then uses it is a `.AST` boundary. This is what keeps
+  `t/rakuast-eval-class.t` calling into the `EVAL`'d type object from the
+  outside instead of using the class inside the lowered program. Closing it
+  needs the converter to know which names the same compilation unit declared,
+  which the read side does not currently track.
 - Grammar declarations. `grammar G { }` is a `Stmt::ClassDecl` with
   `parents = ["Grammar"]`, so it hits the class-inheritance boundary instead of
   producing `RakuAST::Grammar` + `TokenDeclaration` + the regex node tree.


### PR DESCRIPTION
Closes the declaration cluster's write direction: `RakuAST::Class`,
`RakuAST::Role`, `RakuAST::Method`, and the attribute form of
`RakuAST::VarDeclaration::Simple` were readable but not round-trippable.

## Problem

All four have been readable since Phase 2 slice 13 (pinned by
`t/rakuast-class.t` / `t/rakuast-role.t`), but none of them lowered:

```
$ mutsu -e 'use MONKEY-SEE-NO-EVAL; EVAL(Q[class C { method m() { 42 } }].AST)'
RakuAST: EVAL does not yet support lowering `RakuAST::Class`
```

## Change

`src/rakuast/lower.rs` gains four arms, each lowering into the existing internal
AST so the ordinary compiler and VM run the result — no second execution path:

- **`RakuAST::Class` → `Stmt::ClassDecl`.** Its `body` is a `Block` whose
  statements are the class body, lowered by the same statement dispatch, so
  methods and attributes come along for free.
- **`RakuAST::Role` → `Stmt::RoleDecl`.** A role's body is a `RoleBody` wrapping
  the `Blockoid`, matching what the converter renders; a `Block` there is
  refused.
- **`RakuAST::Method` → `Stmt::MethodDecl`**, the `Method` counterpart of
  `lower_sub`. It reads its return type through the same `signature.returns` /
  `Trait::Returns` / `Trait::Of` helper, so all three spellings the converter
  renders lower back — and the lowered return type is still enforced at run
  time.
- **A `VarDeclaration::Simple` with `scope => "has"` → `Stmt::HasDecl`**, reading
  the twigil (`.` public / `!` private), the sigil, and an optional type. A
  typed attribute's implicit `BareWord(<TypeName>)` default — which the parser
  plants and the converter deliberately skips — is re-planted so the two
  directions stay symmetric.

Every richer form (inheritance, scope, reprs, traits, parameterised roles,
private/multi/submethods, attribute traits and `will build` defaults) is already
refused on the **read** side, so nothing that reaches these lowerers can carry
shape they would drop.

## A rendering bug fixed on the way

`method m() is raw { }` rendered as a plain `RakuAST::Method`, silently dropping
the trait. `is_raw` was added to `Stmt::MethodDecl` after that converter arm was
written and its "no traits" guard was never extended to it. It is now refused (a
coverage boundary) instead of rendered wrong, which is the rule the rest of the
arm already followed.

## Tests

`t/rakuast-eval-class.t` (15 assertions) exercises an empty class, a class with
a method, a method with parameters, public/private/typed attributes and their
accessors, all three return-type spellings, run-time enforcement of a lowered
return type, and the role forms (including punning).

Each program ends with its declaration, so the `EVAL`'d value is the type object
and the test calls into it from the outside. Referring to a user class by bare
name *inside* the same program is a separate, still-open read-direction gap — a
user type name renders as a bareword, since only builtin type names convert to
`Type::Simple`. That gap is now recorded in the campaign file.

Like the rest of the `t/rakuast*.t` suite this is a dual-oracle test that passes
verbatim under both mutsu and raku.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TtL4NKUC5rVfjD6mFDpqh9

---
_Generated by [Claude Code](https://claude.ai/code/session_01TtL4NKUC5rVfjD6mFDpqh9)_