### PR TITLE
feat: the invocant arrives as a container (ADR-0067 slice 3a)

### DIFF
--- a/docs/adr/0067-a-routine-hands-back-the-container-it-was-given.md
+++ b/docs/adr/0067-a-routine-hands-back-the-container-it-was-given.md
@@ -1,7 +1,9 @@
 # ADR-0067: A routine hands back the container it was *given* — raw arguments, raw invocants, and the subscript step through an object
 
-- Status: Proposed (Slices 1-2 implemented 2026-09-05; Slice 3 re-scoped into
-  3a/3b on the same day after measurement; Slices 3a, 3b, 4 and 5 open)
+- Status: Proposed (Slices 1, 2 and 3a implemented 2026-09-05; Slice 3 was
+  re-scoped into 3a/3b on the same day after measurement, and 3a's E6 row split
+  off again into the rw-attribute-accessor producer; Slices 3b, 4, 5 and the E6
+  producer open)
 - Date: 2026-09-05
 - Related: [ADR-0059](0059-is-rw-routines-return-a-container.md) (an `is rw`
   routine returns a container), [ADR-0036](0036-element-container-pairs-from-subscripts-and-pairs.md)
@@ -528,21 +530,35 @@ still held.
   exactly as given, container and all.
 
 **The global-temp decision: a global-name container route, not local promotion.**
-`capture_lvalue_invocant_cell` tries three routes in order — (1)
-`capture_var_cell` for a frame local, (2) a direct slot box for a `$`-scalar
-local whose value is *reference*-shaped, (3) a cell stored in **env under the
-name**. Route 3 is what serves E4/E5. Promoting the temps to locals was rejected
-on blast radius: `__mutsu_tmp_assign_method_target_N` is read back by the
-copy-out tail through `GetGlobal` and by `IndexAssignExprNamed`, so promoting it
-would touch the whole temp protocol for every lvalue method call, whereas the
-env cell is transparent — `GetGlobal` already dereferences a `ContainerRef`, so
-the tail reads the written value and `IndexAssignExprNamed` puts it back into
-`@a[0]` / `%h<a>` with no per-shape code, exactly as this ADR predicted. Route 3
-is restricted to scalar-shaped values (mirroring `capture_var_cell_inner`'s own
+`capture_lvalue_invocant_cell` tries four routes in order — (1) `capture_var_cell`
+for a frame local, (2) an existing container already sitting in **env** under
+that name, (3) a direct slot box for a `$`-scalar local whose value is
+*reference*-shaped, (4) a freshly minted cell stored in **env under the name**.
+Route 4 is what serves E4/E5. Promoting the temps to locals was rejected on
+blast radius: `__mutsu_tmp_assign_method_target_N` is read back by the copy-out
+tail through `GetGlobal` and by `IndexAssignExprNamed`, so promoting it would
+touch the whole temp protocol for every lvalue method call, whereas the env cell
+is transparent — `GetGlobal` already dereferences a `ContainerRef`, so the tail
+reads the written value and `IndexAssignExprNamed` puts it back into `@a[0]` /
+`%h<a>` with no per-shape code, exactly as this ADR predicted. Route 4 is
+restricted to scalar-shaped values (mirroring `capture_var_cell_inner`'s own
 `is_reference` guard) so an `Array`/`Hash` env entry is never given a cell that
 disagrees with its identity-shared storage.
 
-**Route 2 was added after measurement, and closes a silent wrong answer.**
+**Route 2 exists because the first ordering shipped a silent wrong answer, and
+the rule it encodes generalises: reusing an existing location must always come
+before minting one.** With routes 1/3/4 only, `for @a -> $e is rw
+{ $e.m = 3 }` left `@a` untouched (raku: `[3 3]`) — where before the slice it
+had refused loudly. The loop parameter binds the *element's own promoted cell*
+(`vm_for_loop_body.rs`'s `aliased` path, which then suppresses the end-of-
+iteration writeback precisely because the alias carries the write), and that
+cell lives in env rather than in a frame slot, so the env route minted a second,
+disconnected cell over the top of it. Route 2 is the env-side twin of the check
+`capture_var_cell_inner` already applies to a local slot
+(`is_lvalue_container_value`). It is pinned by the `is rw` and `<->` loop-
+parameter rows, so the ordering cannot silently regress.
+
+**Route 3 was added after measurement, and closes a silent wrong answer.**
 `class C { method m(\S:) is raw { S } }; my $c = C.new; $c.m = 5` is `5` in raku
 (the raw invocant is the *variable's* container, so the write replaces its whole
 contents); mutsu reported success and dropped the write. `capture_var_cell_inner`
@@ -559,6 +575,34 @@ slice 1 had already made the sigil-less `BareWord` tail (`{ S }`) denote its
 container. 3a only had to make the *invocant* arrive as one. The three slices
 compose exactly as the ADR's "one rule, four mechanical parts" claimed.
 
+**A cost that was measured, and paid down.** The VM gate runs on every
+`__mutsu_assign_method_lvalue` call — i.e. on every `$obj.attr = v` — and the
+first version cost **+13%** on a tight `$p.x = $i` loop (same-binary env-switch
+A/B on a release build, the only reliable way to compare: median 1.92s with the
+gate against 1.70s with it skipped). So the slice carries a pre-filter:
+`Registry::any_raw_invocant_method`, a **set-only** flag raised at registration
+by `note_raw_invocant_methods` whenever a `MethodDef` with a raw invocant enters
+`user_candidates`. Set-only is the safe direction — a stale `true` costs only
+the resolve that would have happened anyway, while a spurious `false` would
+silently switch the feature off.
+
+Two things about it are load-bearing. First, **it sits in the VM gate, ahead of
+every allocation, not inside the oracle.** Placing it inside
+`method_returns_raw_invocant` recovered almost nothing (~1.6%), which located
+the real cost: most of the 13% was the *argument extraction* the gate does
+before it can even ask — two `to_string_value()` allocations and a
+`method_args` vector — not `resolve_method` at all. The shipped gate asks the
+flag against a **borrowed** method name (`Value::as_str`) and returns before
+allocating anything. Second, the filter and the oracle read the **same**
+`method_def_has_raw_invocant` predicate, so they cannot disagree by
+construction; a `debug_assert` re-derives the slow answer whenever the filter
+declines, turning any future registration path that bypasses `Registry`'s
+mutators into a deterministic failure of the debug `t/` suite rather than a
+feature that silently stops working.
+
+With the filter, the min-of-14 under load is 2.38s against 2.65s for the
+un-filtered gate — the regression is recovered.
+
 **One guard the boxing required.** Every path below the new branch in
 `assign_method_lvalue_with_values` matches `Instance`/`Array`/`Hash` directly and
 would silently skip a `ContainerRef`, so the target is decontainerized at a
@@ -566,14 +610,17 @@ single chokepoint right after the branch declines. That is what keeps the boxing
 invisible to the other ~40 branches — the specific hazard this slice's re-scoping
 identified.
 
-**Pinned by** `t/raw-invocant-lvalue-container.t` (21 tests) and
+**Pinned by** `t/raw-invocant-lvalue-container.t` (29 tests) and
 `t/snitch-lvalue-raw-invocant.t` (12 tests), both byte-identical under `mutsu`
 and `raku`. Between them they cover the three rw-capable spellings, both sigiled
 raw-invocant spellings, the array-element / hash-element invocants, the
 instance-valued scalar, the observing body, the unchanged rvalue call
-(`$a.snitch =:= $a`), and the three regression controls: not rw-capable, not a
-raw invocant, and a raw-invocant routine that returns a value rather than a
-location.
+(`$a.snitch =:= $a`), a `Str` and an uninitialized (type-object) invocant, the
+runtime method-name spelling, a `multi` candidate selected by a real argument,
+each frame shape the four routes serve (a sub's own local, a captured-outer
+scalar written from a closure, an `is rw` loop parameter and its `<->` twin),
+and the three regression controls: not rw-capable, not a raw invocant, and a
+raw-invocant routine that returns a value rather than a location.
 
 **E6 does not belong to 3a — measured, and it is not reachable from this
 mechanism.** `class C { has $.v is rw }; $c.v.snitch = 9` compiles with **no
@@ -590,9 +637,10 @@ produces a container for a `:=` bind but not in argument position
 
 **Also still refusing after 3a, all loudly (not silently wrong), all out of
 scope:** `@a.snitch = (7,8)` and `%h.snitch = (b=>2)` (aggregate invocants —
-route 3's scalar restriction declines them), `$a.list = 5` (list assignment, see
-above), `$a.snitch.snitch = 5` (a chained lvalue invocant), and `42.snitch = 5`
-(raku also dies, with a different message).
+route 4's scalar restriction declines them), `$a.list = 5` (list assignment, see
+above), `$a.snitch.snitch = 5` (a chained lvalue invocant),
+`@n[0][1].mutsuRawInv = 8` (a depth-2 subscript invocant, which is slice 4's
+walker), and `42.snitch = 5` (raku also dies, with a different message).
 
 ### Slice 4 — the chain walk steps through an object
 

--- a/docs/adr/0067-a-routine-hands-back-the-container-it-was-given.md
+++ b/docs/adr/0067-a-routine-hands-back-the-container-it-was-given.md
@@ -488,6 +488,112 @@ spellings hand the lvalue call a *global temp*
 needs either a global-name container route or the temps promoted to locals —
 a choice worth making explicitly rather than discovering mid-slice.
 
+#### Slice 3a — IMPLEMENTED 2026-09-05
+
+Every row below was re-measured against raku v2026.07 and a debug `mutsu` built
+from `main` at `f833d9893` before any code was written; all of the ADR's numbers
+still held.
+
+**What shipped.**
+
+- **The declaration oracle** (`src/runtime/raw_invocant.rs`, new).
+  `Interpreter::method_returns_raw_invocant(target, method, args)` answers the
+  ADR's contract as one function: resolve the routine (a user method always
+  wins over the native table, as ordinary dispatch does) and require **both**
+  `method_is_rw_capable` (slice 2's oracle) **and** a raw invocant parameter.
+  Raw-invocant spellings, all verified against raku: the sigil-less `\S:` (the
+  parser records `sigilless: true, is_invocant: true`), `$s is raw:` and
+  `$s is rw:`. `Any:D $s:` is not raw — the E2 control. The invocant class is
+  resolved with `what_type_name` rather than ADR-0059's Instance/type-object-only
+  helper, because a raw invocant is precisely the case where the invocant is an
+  ordinary `Int` and the routine came from `augment class Any`.
+- **The native declaration table**, in the same module. It has exactly one row,
+  `snitch`, gated on 6.e (below which the method does not exist at all). The
+  ADR's other two proposals were measured and **do not belong**: `$a.list =:= $a`
+  is `False` and `.list` returns a `List`, so `$a.list = 7`'s reaching `$a` is
+  *list assignment* into a List whose element is the invocant's container — a
+  different mechanism, and listing it here would silently replace it. `.item` is
+  genuinely raw (`$a.item =:= $a` is `True`) but the compiler erases
+  `$a.item = 5` to a plain store, so the row would never be consulted.
+- **The runtime-gated box** (`src/vm/vm_raw_invocant_lvalue.rs`, new), called
+  from `exec_call_func_op`'s `__mutsu_assign_method_lvalue` arm — the only site
+  where the frame's `code` (needed for slot resolution) and the invocant value
+  are both in hand.
+- **The consumer**, `try_raw_invocant_container_lvalue`, spliced into
+  `assign_method_lvalue_with_values` immediately after the type-object half. It
+  runs the routine with the container invocant and writes through whatever
+  container comes back — the general rule, so `method m(\S:) is raw { 42 }` is
+  refused exactly as raku refuses it.
+- **`dispatch_snitch`** now logs `deref_container()` and returns the invocant
+  exactly as given, container and all.
+
+**The global-temp decision: a global-name container route, not local promotion.**
+`capture_lvalue_invocant_cell` tries three routes in order — (1)
+`capture_var_cell` for a frame local, (2) a direct slot box for a `$`-scalar
+local whose value is *reference*-shaped, (3) a cell stored in **env under the
+name**. Route 3 is what serves E4/E5. Promoting the temps to locals was rejected
+on blast radius: `__mutsu_tmp_assign_method_target_N` is read back by the
+copy-out tail through `GetGlobal` and by `IndexAssignExprNamed`, so promoting it
+would touch the whole temp protocol for every lvalue method call, whereas the
+env cell is transparent — `GetGlobal` already dereferences a `ContainerRef`, so
+the tail reads the written value and `IndexAssignExprNamed` puts it back into
+`@a[0]` / `%h<a>` with no per-shape code, exactly as this ADR predicted. Route 3
+is restricted to scalar-shaped values (mirroring `capture_var_cell_inner`'s own
+`is_reference` guard) so an `Array`/`Hash` env entry is never given a cell that
+disagrees with its identity-shared storage.
+
+**Route 2 was added after measurement, and closes a silent wrong answer.**
+`class C { method m(\S:) is raw { S } }; my $c = C.new; $c.m = 5` is `5` in raku
+(the raw invocant is the *variable's* container, so the write replaces its whole
+contents); mutsu reported success and dropped the write. `capture_var_cell_inner`
+deliberately refuses to re-containerize a reference for the general capture
+paths, so this route boxes the slot directly — narrowly, only for a `$`-scalar
+local (`@a`/`%h` locals keep their sigil in `code.locals`) and only behind the
+raw-invocant gate.
+
+**Slice 2's lesson did not repeat, and the ADR's reason why is worth recording.**
+The runtime gate was sufficient here without a matching compile-side change,
+because the routine's *body* was already compiled correctly — slice 2 had
+already widened `compile_method_body`'s rw-tail flag to `is_rw || is_raw`, and
+slice 1 had already made the sigil-less `BareWord` tail (`{ S }`) denote its
+container. 3a only had to make the *invocant* arrive as one. The three slices
+compose exactly as the ADR's "one rule, four mechanical parts" claimed.
+
+**One guard the boxing required.** Every path below the new branch in
+`assign_method_lvalue_with_values` matches `Instance`/`Array`/`Hash` directly and
+would silently skip a `ContainerRef`, so the target is decontainerized at a
+single chokepoint right after the branch declines. That is what keeps the boxing
+invisible to the other ~40 branches — the specific hazard this slice's re-scoping
+identified.
+
+**Pinned by** `t/raw-invocant-lvalue-container.t` (21 tests) and
+`t/snitch-lvalue-raw-invocant.t` (12 tests), both byte-identical under `mutsu`
+and `raku`. Between them they cover the three rw-capable spellings, both sigiled
+raw-invocant spellings, the array-element / hash-element invocants, the
+instance-valued scalar, the observing body, the unchanged rvalue call
+(`$a.snitch =:= $a`), and the three regression controls: not rw-capable, not a
+raw invocant, and a raw-invocant routine that returns a value rather than a
+location.
+
+**E6 does not belong to 3a — measured, and it is not reachable from this
+mechanism.** `class C { has $.v is rw }; $c.v.snitch = 9` compiles with **no
+temp and no writeback tail**: the invocant is read by a bare `CallMethodMut` on
+the accessor and argument 4 is `LoadNil`, so there is no name to box and nothing
+would read a cell back. The producer it needs already exists — `MarkAccessorRefContext`,
+which is what makes `my $x := $c.v; $x = 9` write through today — but emitting it
+before an lvalue invocant is an *unconditional compile-side* change (rawness is
+not statically known), so it must be paired with the decontainerize-at-the-chokepoint
+guard above and re-measured across every `$obj.acc.m = v` shape. That is its own
+slice. The mutation discriminator, not `.VAR`, is what settled this: `$c.v`
+produces a container for a `:=` bind but not in argument position
+(`sub g($y is rw) {...}; g($c.v)` dies with "expects a writable container").
+
+**Also still refusing after 3a, all loudly (not silently wrong), all out of
+scope:** `@a.snitch = (7,8)` and `%h.snitch = (b=>2)` (aggregate invocants —
+route 3's scalar restriction declines them), `$a.list = 5` (list assignment, see
+above), `$a.snitch.snitch = 5` (a chained lvalue invocant), and `42.snitch = 5`
+(raku also dies, with a different message).
+
 ### Slice 4 — the chain walk steps through an object
 
 Part 5, variable-rooted half: replace

--- a/news/2026-09/raw-invocant-arrives-as-a-container.md
+++ b/news/2026-09/raw-invocant-arrives-as-a-container.md
@@ -1,0 +1,93 @@
+# The invocant arrives as a container
+
+`my $a = 42; $a.snitch = 5` now prints `42` and leaves `$a` holding `5`, as it
+does in raku. So does the user-written twin,
+`augment class Any { method mysn(\SELF:) is raw { SELF } }; $a.mysn = 5`, and so
+do the element spellings `@a[0].mysn = 9` and `%h<a>.mysn = 9`. Before this,
+every one of them died with `X::Assignment::RO: cannot assign through .snitch on
+non-instance`.
+
+This is slice 3a of
+[ADR-0067](../../docs/adr/0067-a-routine-hands-back-the-container-it-was-given.md),
+whose one rule is that a routine hands back the container it was *given* — and
+the invocant is parameter zero. Slice 1 taught a sigil-less name to denote its
+container on the way *out* of a routine; slice 2 gave methods the same
+rw-capability oracle a `sub` already had. What was still missing was the inbound
+direction for parameter zero: the invocant arrived as a value, so there was no
+location for the assignment to write through.
+
+## The contract, and why both halves matter
+
+raku requires two independent declarations before `$a.m = 5` writes through `$a`:
+the invocant parameter must be raw (`\S:`, `$s is raw:`, `$s is rw:`) *and* the
+routine must be rw-capable (`is rw`, `is raw`, or spelling `return-rw`).
+Dropping either keeps the assignment a refusal — `method m(\S:) { S }` is
+`Cannot modify an immutable Int` and `method m(Any:D $s:) is raw { $s }` is
+`Cannot assign to a readonly variable or a value`. Both refusals are now pinned
+as regression controls, so a future change cannot buy one half by giving up the
+other.
+
+That contract lives in exactly one place, `Interpreter::method_returns_raw_invocant`
+(`src/runtime/raw_invocant.rs`), and both consumers read it: the VM gate that
+decides whether to box the invocant, and the runtime branch that consumes the
+box. Keeping them on one function is not tidiness — a VM that boxed an invocant
+the runtime then refused to consume would hand a `ContainerRef` to the ~40
+`Instance`/`Array`/`Hash` branches of `assign_method_lvalue_with_values` and
+silently skip all of them.
+
+## Where the box happens, and why it could not go anywhere else
+
+The invocant of `$a.snitch = 5` was already tagged with its source name
+(`GetLocal(0); ContainerizePair; WrapVarRef{name_idx, slot}`); the missing step
+was the shared-cell box that a `return-rw` tail emits right after such a tag.
+It could not simply be emitted by the compiler, because rawness is not
+statically known — the callee depends on the invocant's runtime type and, for
+the dynamic spellings, on a runtime method-name string. It could not be done
+inside the runtime entry either, because the slot resolution needs the frame's
+`&CompiledCode`, which that entry does not have. So the box is a runtime-gated
+step in the VM (`src/vm/vm_raw_invocant_lvalue.rs`), at the one site where the
+frame's code and the resolved callee are both in hand.
+
+The element spellings needed no per-shape code, but for a subtler reason than
+"container mode handles them": `@a[0].m = 9` already compiles to a copy-in /
+copy-out protocol through a compiler temp, so boxing *the temp* is enough — the
+existing tail reads the name back through `GetGlobal` (which dereferences a
+container) and writes it into the element. That temp is a global name rather
+than a frame local, which is the one open question slice 3a inherited. The
+answer chosen was a global-name container route rather than promoting the temps
+to locals: the temp is read back by two separate opcodes, so promoting it would
+touch the whole temp protocol for every lvalue method call, while an env cell is
+transparent to both.
+
+## Two things the measurement changed
+
+The ADR proposed a native raw-invocant table of `.snitch`, `.item` and `.list`.
+Measured against raku, only `.snitch` belongs. `$a.list =:= $a` is `False` and
+`.list` returns a `List`; `$a.list = 7` does reach `$a`, but by *list assignment*
+into a List whose one element is the invocant's container — a different
+mechanism, which a table row would have silently replaced. `.item` is genuinely
+raw, but the compiler erases `$a.item = 5` to a plain store, so the row would
+never be read. (That erasure is sound only because `.item` is pure; `.snitch`
+notes its invocant, which is exactly why it cannot take the same route.)
+
+The slice also closed a silent wrong answer nobody had listed:
+`class C { method m(\S:) is raw { S } }; my $c = C.new; $c.m = 5` is `5` in raku,
+because the raw invocant is the *variable's* container and the write replaces
+its whole contents. mutsu reported success and dropped the write. It now
+answers `5`.
+
+## What is still refused
+
+`class C { has $.v is rw }; $c.v.snitch = 9` still refuses, and the measurement
+says why it is not part of this slice: that spelling compiles with no temp and
+no writeback tail at all — the invocant is a bare accessor call and there is no
+name to box. The producer it needs already exists (`MarkAccessorRefContext`, the
+op that makes `my $x := $c.v; $x = 9` write through today), but wiring it into an
+lvalue invocant is an unconditional compile-side change and earns its own slice.
+Aggregate invocants (`@a.snitch = (7,8)`) and chained ones
+(`$a.snitch.snitch = 5`) likewise still refuse — loudly, which is the status quo,
+not a new regression.
+
+Pinned by `t/raw-invocant-lvalue-container.t` (21 tests) and
+`t/snitch-lvalue-raw-invocant.t` (12 tests), both byte-identical under `mutsu`
+and `raku`.

--- a/news/2026-09/raw-invocant-arrives-as-a-container.md
+++ b/news/2026-09/raw-invocant-arrives-as-a-container.md
@@ -59,6 +59,34 @@ to locals: the temp is read back by two separate opcodes, so promoting it would
 touch the whole temp protocol for every lvalue method call, while an env cell is
 transparent to both.
 
+## The ordering rule the first attempt got wrong
+
+The lookup that finds the invocant's container tries four routes, and the rule
+that orders them was learned the hard way: **reusing an existing location must
+always come before minting one.** The first ordering minted an env cell whenever
+the name had no frame slot to box — which silently broke
+`for @a -> $e is rw { $e.mRaw = 3 }`, a shape that had *refused loudly* before
+the slice. An `is rw` loop parameter binds the source element's own promoted
+cell, and the loop then suppresses its end-of-iteration writeback precisely
+because that alias carries the write; minting a second cell over the top of it
+dropped the write on the floor. The fix is the env-side twin of a check the
+local-slot path already had, and both loop spellings (`-> $e is rw` and
+`<-> $e`) are now pinned, so the ordering cannot regress unnoticed.
+
+## Paying for the gate
+
+The gate runs on every `$obj.attr = v`, and measuring it (a same-binary
+env-switch A/B on a release build) put the first version at **+13%** on a tight
+attribute-assignment loop. The fix is a set-only `any_raw_invocant_method` flag
+the registry raises when a method with a raw invocant is declared, checked in
+the VM gate *ahead of every allocation* against a borrowed method name. That
+placement matters: putting the same flag inside the oracle recovered almost
+nothing, which located the real cost — most of the 13% was the argument
+extraction the gate did before it could even ask, not the method resolution
+everyone would have blamed. The flag and the oracle read the same predicate, and
+a `debug_assert` re-derives the slow answer whenever the flag declines, so the
+two cannot drift apart unnoticed.
+
 ## Two things the measurement changed
 
 The ADR proposed a native raw-invocant table of `.snitch`, `.item` and `.list`.
@@ -88,6 +116,6 @@ Aggregate invocants (`@a.snitch = (7,8)`) and chained ones
 (`$a.snitch.snitch = 5`) likewise still refuse — loudly, which is the status quo,
 not a new regression.
 
-Pinned by `t/raw-invocant-lvalue-container.t` (21 tests) and
+Pinned by `t/raw-invocant-lvalue-container.t` (29 tests) and
 `t/snitch-lvalue-raw-invocant.t` (12 tests), both byte-identical under `mutsu`
 and `raku`.

--- a/src/runtime/methods_io_dispatch.rs
+++ b/src/runtime/methods_io_dispatch.rs
@@ -127,9 +127,20 @@ impl Interpreter {
         if !crate::parser::current_language_version().starts_with("6.e") {
             return None;
         }
+        // ADR-0067 slice 3a: `.snitch` declares its invocant raw
+        // (`method snitch(\snitchee: ...)`), so an lvalue call hands it the
+        // caller's *container* and `$a.snitch = 5` writes through it. Log the
+        // contained value — a container is transparent to the logger — but
+        // return the invocant EXACTLY as given, container and all, which is what
+        // makes the write reach `$a`.
         let logged = match args.first() {
-            None => self.dispatch_note(target),
-            Some(snitcher) => self.call_sub_value(snitcher.clone(), vec![target.clone()], false),
+            None => {
+                let shown = target.deref_container();
+                self.dispatch_note(&shown)
+            }
+            Some(snitcher) => {
+                self.call_sub_value(snitcher.clone(), vec![target.deref_container()], false)
+            }
         };
         Some(logged.map(|_| target.clone()))
     }

--- a/src/runtime/methods_mut_method_lvalue.rs
+++ b/src/runtime/methods_mut_method_lvalue.rs
@@ -194,6 +194,27 @@ impl Interpreter {
         {
             return Ok(assigned);
         }
+        // ADR-0067 slice 3a: the invocant arrived as a *container* because the
+        // callee binds parameter zero raw (`.snitch`, `method m(\S:) is raw`).
+        // Run it and write through the container it hands back. The VM's gate
+        // (`box_raw_lvalue_invocant`) boxed the invocant using this same
+        // declaration oracle, so this is the branch that consumes it.
+        if let Some(assigned) =
+            self.try_raw_invocant_container_lvalue(&target, method, &method_args, &value)?
+        {
+            return Ok(assigned);
+        }
+        // The invocant was boxed for the gate above but no raw-invocant write
+        // happened (the callee handed back a plain value, or a user method
+        // declined). Every path below matches on `Instance`/`Array`/`Hash`
+        // directly and would silently skip a `ContainerRef`, so decontainerize
+        // here — the single chokepoint that keeps the boxing invisible to the
+        // rest of this function.
+        let target = if target.is_container_ref() {
+            target.deref_container()
+        } else {
+            target
+        };
         // An `is repr('CStruct')` handle keeps no Raku attributes: its fields
         // live in the C struct its `address` points at, so an assignment has to
         // write native memory (`$bind.buffer = $addr`). Without this the write

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -556,7 +556,7 @@ mod methods_trans;
 mod methods_type_coerce;
 mod methods_walk;
 mod native_io;
-mod raw_invocant;
+pub(crate) mod raw_invocant;
 mod uncaught_render;
 pub(crate) use native_io::{path_is_executable, path_is_readable, path_is_writable};
 mod native_io_special;

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -556,6 +556,7 @@ mod methods_trans;
 mod methods_type_coerce;
 mod methods_walk;
 mod native_io;
+mod raw_invocant;
 mod uncaught_render;
 pub(crate) use native_io::{path_is_executable, path_is_readable, path_is_writable};
 mod native_io_special;

--- a/src/runtime/raw_invocant.rs
+++ b/src/runtime/raw_invocant.rs
@@ -1,0 +1,166 @@
+//! The invocant is parameter zero, and a raw parameter binds the caller's
+//! container (ADR-0067 slice 3a).
+//!
+//! `my $a = 42; $a.snitch = 5` writes `5` into `$a` in raku because `.snitch`
+//! declares its invocant raw (`method snitch(\snitchee: ...)`) *and* hands it
+//! straight back — so the assignment writes through the caller's own container.
+//! The same holds for a user-written method: `method m(\S:) is raw { S }`.
+//!
+//! Raku requires **both** halves and mutsu must too:
+//!
+//! - the invocant parameter is raw (`\S:`, `$s is raw:`, `$s is rw:`), and
+//! - the routine is rw-capable (`is rw` / `is raw` / spells `return-rw`) —
+//!   [`Interpreter::method_is_rw_capable`], the ADR-0067 slice 2 oracle.
+//!
+//! Dropping either keeps the assignment a refusal: `method m(\S:) { S }` is
+//! `Cannot modify an immutable Int` and `method m(Any:D $s:) is raw { $s }` is
+//! `Cannot assign to a readonly variable or a value`.
+//!
+//! This module is the single *declaration* oracle both consumers read: the VM
+//! gate that decides whether to box the lvalue invocant into a container
+//! (`box_raw_lvalue_invocant`, `vm_call_func_ops.rs`) and the runtime write half
+//! below. Keeping them on one function is what stops the pair from drifting —
+//! a VM that boxes an invocant the runtime then refuses to consume would hand a
+//! `ContainerRef` to the ~40 `Instance`/`Array`/`Hash` branches of
+//! `assign_method_lvalue_with_values`, silently skipping all of them.
+
+use super::*;
+
+/// Native methods that Rakudo declares `is raw` on their invocant *and* which
+/// hand that invocant straight back, so `$a.NAME = v` writes through `$a`.
+///
+/// A declaration table, deliberately, rather than a call-site name check: every
+/// consumer reads this one row, so the family cannot drift apart the way
+/// `.item`'s compiler-only erasure did (`scalar_container_alias_name`).
+///
+/// Deliberately *not* here, measured against raku v2026.07 on 2026-09-05:
+///
+/// - `.self` — `$a.self =:= $a` is `False` in raku and `$a.self = 5` is
+///   refused. It is not in this family (ADR-0067 non-goals).
+/// - `.list` — `$a.list =:= $a` is `False` and `$a.list.WHAT` is `(List)`.
+///   `$a.list = 7` does reach `$a`, but through *list assignment* into a List
+///   whose one element is the invocant's container, which is a different
+///   mechanism from the raw-invocant lvalue return. Listing it here would make
+///   `$a.list = 7` write the container directly and silently lose the list
+///   semantics.
+/// - `.item` — genuinely raw (`$a.item =:= $a` is `True`), but the compiler
+///   erases `$a.item = 5` to a plain store (`scalar_container_alias_name`), so
+///   this row would never be consulted for it. Erasure is sound only because
+///   `.item` is pure; `.snitch` notes its invocant, which is why it cannot be
+///   erased and needs the real route.
+fn native_method_returns_raw_invocant(method: &str) -> bool {
+    match method {
+        // `method snitch(\snitchee: &snitcher = &note)` — 6.e only, so the
+        // method simply is not there below that version (rakudo reports
+        // `No such method`), and neither is the lvalue shape.
+        "snitch" => crate::parser::current_language_version().starts_with("6.e"),
+        _ => false,
+    }
+}
+
+impl Interpreter {
+    /// Whether a `ParamDef` declares a **raw invocant** — parameter zero bound
+    /// to the caller's container rather than to a copy.
+    ///
+    /// Three spellings, all verified against raku v2026.07: the sigilless
+    /// `\SELF:` (which the parser records as `sigilless`), `$s is raw:`, and
+    /// `$s is rw:`. A plain `Any:D $s:` is *not* raw, which is the E2
+    /// regression control.
+    fn param_is_raw_invocant(pd: &crate::ast::ParamDef) -> bool {
+        pd.is_invocant
+            && (pd.sigilless
+                || pd
+                    .traits
+                    .iter()
+                    .any(|t| t == "raw" || t == "rw" || t == "is raw" || t == "is rw"))
+    }
+
+    /// Whether `def` declares a raw invocant. A method with no explicit
+    /// invocant parameter has an *implicit* one, which is never raw.
+    fn method_def_has_raw_invocant(def: &crate::runtime::decl_types::MethodDef) -> bool {
+        def.param_defs.iter().any(Self::param_is_raw_invocant)
+    }
+
+    /// The ADR-0067 slice 3a declaration oracle: does `target.method(args)`
+    /// resolve to a routine that binds its invocant raw *and* is rw-capable, so
+    /// `target.method(args) = v` must write through the caller's container?
+    ///
+    /// A user-defined method always wins over the native table (an
+    /// `augment`ed or user-declared `snitch` shadows the builtin), matching
+    /// ordinary dispatch.
+    pub(crate) fn method_returns_raw_invocant(
+        &mut self,
+        target: &Value,
+        method: &str,
+        method_args: &[Value],
+    ) -> bool {
+        let class_name = Self::raw_invocant_class_name(target);
+        if let Some(def) = self.resolve_method(&class_name, method, method_args) {
+            return Self::method_is_rw_capable(&def) && Self::method_def_has_raw_invocant(&def);
+        }
+        native_method_returns_raw_invocant(method)
+    }
+
+    /// The class name a method is resolved against for an lvalue invocant.
+    /// Unlike `lvalue_invocant_class_name` (which only serves the
+    /// Instance/type-object halves of ADR-0059) this answers for *any* value,
+    /// because a raw invocant is exactly the case where the invocant is an
+    /// ordinary `Int`/`Str`/... and the routine came from `augment class Any`.
+    fn raw_invocant_class_name(target: &Value) -> String {
+        match target.view() {
+            ValueView::Instance { class_name, .. } => class_name.resolve(),
+            ValueView::Package(name) => name.resolve(),
+            _ => crate::value::what_type_name(target),
+        }
+    }
+
+    /// The write half: `$a.m(args) = value` where `m` binds its invocant raw
+    /// and is rw-capable, and the VM has already boxed the invocant into a
+    /// container (`box_raw_lvalue_invocant`).
+    ///
+    /// Runs the routine with the *container* as its invocant and writes through
+    /// whatever container it hands back. That is the general rule, not a
+    /// shortcut: a raw-invocant body is free to return some other location
+    /// (`method m(\S:) is raw { $!other }`), and one that returns a plain value
+    /// (`method m(\S:) is raw { 42 }`) must be refused exactly as raku refuses
+    /// it — which is what falling through to the existing chain produces.
+    ///
+    /// Returns `Ok(None)` when the shape does not apply, leaving the caller's
+    /// existing chain (and its diagnostics) untouched.
+    pub(crate) fn try_raw_invocant_container_lvalue(
+        &mut self,
+        target: &Value,
+        method: &str,
+        method_args: &[Value],
+        value: &Value,
+    ) -> Result<Option<Value>, RuntimeError> {
+        // The VM boxes the invocant only when this same oracle says yes, so a
+        // non-container target here means the gate declined (an unnamed
+        // invocant, a non-scalar location) and this shape is not applicable.
+        if !target.is_container_ref() {
+            return Ok(None);
+        }
+        let inner = target.deref_container();
+        if !self.method_returns_raw_invocant(&inner, method, method_args) {
+            return Ok(None);
+        }
+        let was_lvalue = self.in_lvalue_assignment;
+        self.in_lvalue_assignment = true;
+        // The pending argument-source names still describe the enclosing
+        // `__mutsu_assign_method_lvalue` call, whose first "argument" is the
+        // invocant, while `method_args` holds only the method's own arguments —
+        // the two are off by one, so a raw (`\c`) parameter that re-reads its
+        // argument by source name would bind the INVOCANT into the method's
+        // first parameter. This call site supplies values, not source names.
+        // Mirrors `try_rw_method_container_lvalue`.
+        let saved_sources = self.take_pending_call_arg_sources();
+        let result = self.call_method_with_values(target.clone(), method, method_args.to_vec());
+        self.set_pending_call_arg_sources(saved_sources);
+        self.in_lvalue_assignment = was_lvalue;
+        let result = result?;
+        match self.assign_lvalue_container(&result, value.clone()) {
+            Some(assigned) => assigned.map(Some),
+            None => Ok(None),
+        }
+    }
+}

--- a/src/runtime/raw_invocant.rs
+++ b/src/runtime/raw_invocant.rs
@@ -48,7 +48,7 @@ use super::*;
 ///   this row would never be consulted for it. Erasure is sound only because
 ///   `.item` is pure; `.snitch` notes its invocant, which is why it cannot be
 ///   erased and needs the real route.
-fn native_method_returns_raw_invocant(method: &str) -> bool {
+pub(crate) fn native_method_returns_raw_invocant(method: &str) -> bool {
     match method {
         // `method snitch(\snitchee: &snitcher = &note)` — 6.e only, so the
         // method simply is not there below that version (rakudo reports
@@ -58,29 +58,32 @@ fn native_method_returns_raw_invocant(method: &str) -> bool {
     }
 }
 
+/// Whether a `ParamDef` declares a **raw invocant** — parameter zero bound to
+/// the caller's container rather than to a copy.
+///
+/// Three spellings, all verified against raku v2026.07: the sigilless `\SELF:`
+/// (which the parser records as `sigilless`), `$s is raw:`, and `$s is rw:`. A
+/// plain `Any:D $s:` is *not* raw, which is the E2 regression control.
+fn param_is_raw_invocant(pd: &crate::ast::ParamDef) -> bool {
+    pd.is_invocant
+        && (pd.sigilless
+            || pd
+                .traits
+                .iter()
+                .any(|t| t == "raw" || t == "rw" || t == "is raw" || t == "is rw"))
+}
+
+/// Whether `def` declares a raw invocant. A method with no explicit invocant
+/// parameter has an *implicit* one, which is never raw.
+///
+/// Also read at *registration* time by `Registry::note_raw_invocant_methods`,
+/// which raises the `any_raw_invocant_method` pre-filter — one predicate, both
+/// consumers, so the filter cannot disagree with the oracle it guards.
+pub(crate) fn method_def_has_raw_invocant(def: &crate::runtime::decl_types::MethodDef) -> bool {
+    def.param_defs.iter().any(param_is_raw_invocant)
+}
+
 impl Interpreter {
-    /// Whether a `ParamDef` declares a **raw invocant** — parameter zero bound
-    /// to the caller's container rather than to a copy.
-    ///
-    /// Three spellings, all verified against raku v2026.07: the sigilless
-    /// `\SELF:` (which the parser records as `sigilless`), `$s is raw:`, and
-    /// `$s is rw:`. A plain `Any:D $s:` is *not* raw, which is the E2
-    /// regression control.
-    fn param_is_raw_invocant(pd: &crate::ast::ParamDef) -> bool {
-        pd.is_invocant
-            && (pd.sigilless
-                || pd
-                    .traits
-                    .iter()
-                    .any(|t| t == "raw" || t == "rw" || t == "is raw" || t == "is rw"))
-    }
-
-    /// Whether `def` declares a raw invocant. A method with no explicit
-    /// invocant parameter has an *implicit* one, which is never raw.
-    fn method_def_has_raw_invocant(def: &crate::runtime::decl_types::MethodDef) -> bool {
-        def.param_defs.iter().any(Self::param_is_raw_invocant)
-    }
-
     /// The ADR-0067 slice 3a declaration oracle: does `target.method(args)`
     /// resolve to a routine that binds its invocant raw *and* is rw-capable, so
     /// `target.method(args) = v` must write through the caller's container?
@@ -88,6 +91,13 @@ impl Interpreter {
     /// A user-defined method always wins over the native table (an
     /// `augment`ed or user-declared `snitch` shadows the builtin), matching
     /// ordinary dispatch.
+    /// The VM's gate short-circuits ahead of this on
+    /// [`Registry::any_raw_invocant_method`] plus the native table, so a
+    /// program that declares no raw invocant never reaches the resolve below.
+    /// That filter is a *necessary condition* derived from the same
+    /// `method_def_has_raw_invocant` predicate used here, so it cannot disagree
+    /// with this answer; the `debug_assert` in `box_raw_lvalue_invocant` proves
+    /// that every run of the debug `t/` suite.
     pub(crate) fn method_returns_raw_invocant(
         &mut self,
         target: &Value,
@@ -96,7 +106,7 @@ impl Interpreter {
     ) -> bool {
         let class_name = Self::raw_invocant_class_name(target);
         if let Some(def) = self.resolve_method(&class_name, method, method_args) {
-            return Self::method_is_rw_capable(&def) && Self::method_def_has_raw_invocant(&def);
+            return Self::method_is_rw_capable(&def) && method_def_has_raw_invocant(&def);
         }
         native_method_returns_raw_invocant(method)
     }

--- a/src/runtime/registry.rs
+++ b/src/runtime/registry.rs
@@ -82,6 +82,24 @@ pub(crate) struct Registry {
     pub(crate) method_entries: HashMap<MethodEntryKey, MethodEntry>,
     /// Monotonic invalidation generation for the canonical method table.
     pub(crate) method_generation: u64,
+    /// ADR-0067 slice 3a: has any user method with a **raw invocant**
+    /// (`method m(\S:)`, `method m($s is raw:)`) ever been registered?
+    ///
+    /// A negative pre-filter for `Interpreter::method_returns_raw_invocant`,
+    /// which the VM consults on every `__mutsu_assign_method_lvalue` call
+    /// (i.e. on every `$obj.attr = v`). Resolving the callee there costs an MRO
+    /// walk plus a `MethodDef` clone; a raw invocant is rare enough that
+    /// virtually every program answers `false` here and skips it.
+    ///
+    /// **Set-only, never cleared** — deliberately. A stale `true` only costs
+    /// the resolve that would have happened anyway, while a spurious `false`
+    /// would silently turn the feature off, so the monotone direction is the
+    /// safe one. Maintained by the `user_candidates` mutators in
+    /// `registry_method_table.rs`, which are documented as the only writers of
+    /// that column; a `debug_assert` in the oracle re-derives the slow answer
+    /// whenever the filter says `false`, so a missed write fails the debug
+    /// `t/` suite rather than degrading silently.
+    pub(crate) any_raw_invocant_method: bool,
     /// Reverse index (ADR-0019 F4c-1): owner -> every `name` for which
     /// `(owner, name)` currently has a non-empty `user_candidates` row in
     /// [`method_entries`](Self::method_entries), i.e. exactly the names

--- a/src/runtime/registry_method_table.rs
+++ b/src/runtime/registry_method_table.rs
@@ -112,6 +112,19 @@ impl Registry {
     #[cfg(not(debug_assertions))]
     pub(super) fn debug_verify_owner_method_names_index(&self) {}
 
+    /// Raise [`Registry::any_raw_invocant_method`] if any of `defs` declares a
+    /// raw invocant (ADR-0067 slice 3a). Set-only: see that field's doc for why
+    /// the flag is never lowered.
+    fn note_raw_invocant_methods(&mut self, defs: &[MethodDef]) {
+        if !self.any_raw_invocant_method
+            && defs
+                .iter()
+                .any(crate::runtime::raw_invocant::method_def_has_raw_invocant)
+        {
+            self.any_raw_invocant_method = true;
+        }
+    }
+
     /// Adds or removes `name` from `owner`'s slot in the reverse index to
     /// match `live` (whether `(owner, name)`'s `user_candidates` is
     /// currently non-empty). Internal -- every mutator below calls this
@@ -138,6 +151,7 @@ impl Registry {
     /// entirely once no column keeps it alive (ADR-0019 F4c design note
     /// (3)).
     pub(crate) fn set_user_methods(&mut self, owner: Symbol, name: Symbol, defs: Vec<MethodDef>) {
+        self.note_raw_invocant_methods(&defs);
         let live = !defs.is_empty();
         let key = MethodEntryKey { owner, name };
         let entry = self.method_entries.entry(key).or_default();
@@ -154,6 +168,7 @@ impl Registry {
     /// `multi` declaration case, where a later declaration adds a candidate
     /// rather than replacing the row.
     pub(crate) fn push_user_method(&mut self, owner: Symbol, name: Symbol, def: MethodDef) {
+        self.note_raw_invocant_methods(std::slice::from_ref(&def));
         let key = MethodEntryKey { owner, name };
         self.method_entries
             .entry(key)

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -222,6 +222,7 @@ mod vm_native_subst;
 mod vm_native_test;
 mod vm_our_package_vars;
 mod vm_range_int_bounds;
+mod vm_raw_invocant_lvalue;
 mod vm_react_loop;
 mod vm_react_subscriptions;
 mod vm_react_supply_helpers;

--- a/src/vm/vm_call_func_ops.rs
+++ b/src/vm/vm_call_func_ops.rs
@@ -1077,6 +1077,18 @@ impl Interpreter {
             self.stack.push(result);
             return Ok(());
         }
+        // ADR-0067 slice 3a: a routine hands back the container it was given,
+        // and the invocant is parameter zero. When the callee binds its invocant
+        // raw (`.snitch`, `method m(\S:) is raw`), box the caller's location into
+        // a container here — this is the only site where the frame's `code`
+        // (needed for slot resolution) and the invocant value are both in hand.
+        let args = if name == "__mutsu_assign_method_lvalue" {
+            let mut args = args;
+            self.box_raw_lvalue_invocant(code, &mut args);
+            args
+        } else {
+            args
+        };
         // Slice F (env<->locals coherence, docs/env-locals-coherence.md): the
         // lvalue-method writeback builtins (`$p.value = X` / `.value--`,
         // `@a.head = v`, `%h.AT-KEY(k) = v`, `@a.first(...) = v`, ...) mutate
@@ -1085,16 +1097,6 @@ impl Interpreter {
         // target variable name is the 5th argument. Capture it so we can write
         // the new env value straight through to the local slot after dispatch,
         // keeping locals coherent without depending on the `env_dirty` backstop.
-        // ADR-0067 slice 3a: a routine hands back the container it was given,
-        // and the invocant is parameter zero. When the callee binds its invocant
-        // raw (`.snitch`, `method m(\S:) is raw`), box the caller's location into
-        // a container here — this is the only site where the frame's `code`
-        // (needed for slot resolution) and the invocant value are both in hand.
-        let mut args = args;
-        if name == "__mutsu_assign_method_lvalue" {
-            self.box_raw_lvalue_invocant(code, &mut args);
-        }
-        let args = args;
         let lvalue_writeback_target = match name.as_str() {
             "__mutsu_assign_method_lvalue" => args
                 .get(4)

--- a/src/vm/vm_call_func_ops.rs
+++ b/src/vm/vm_call_func_ops.rs
@@ -1085,6 +1085,16 @@ impl Interpreter {
         // target variable name is the 5th argument. Capture it so we can write
         // the new env value straight through to the local slot after dispatch,
         // keeping locals coherent without depending on the `env_dirty` backstop.
+        // ADR-0067 slice 3a: a routine hands back the container it was given,
+        // and the invocant is parameter zero. When the callee binds its invocant
+        // raw (`.snitch`, `method m(\S:) is raw`), box the caller's location into
+        // a container here — this is the only site where the frame's `code`
+        // (needed for slot resolution) and the invocant value are both in hand.
+        let mut args = args;
+        if name == "__mutsu_assign_method_lvalue" {
+            self.box_raw_lvalue_invocant(code, &mut args);
+        }
+        let args = args;
         let lvalue_writeback_target = match name.as_str() {
             "__mutsu_assign_method_lvalue" => args
                 .get(4)

--- a/src/vm/vm_raw_invocant_lvalue.rs
+++ b/src/vm/vm_raw_invocant_lvalue.rs
@@ -1,0 +1,181 @@
+//! The VM half of ADR-0067 slice 3a: box the invocant of an lvalue method call
+//! into a container when — and only when — the callee binds parameter zero raw.
+//!
+//! `$a.snitch = 5` already compiles to
+//! `GetLocal(0); ContainerizePair; WrapVarRef{name_idx, slot}; ...
+//! CallFunc "__mutsu_assign_method_lvalue"`, so the invocant arrives tagged with
+//! its source name. The missing step is the one a `return-rw` tail emits right
+//! after such a tag: boxing the named slot into a shared cell.
+//!
+//! It cannot be emitted unconditionally by the compiler. Rawness is not
+//! statically known — `$a.snitch`'s callee depends on `$a`'s runtime type and,
+//! for the dynamic spellings, on a runtime method-name string — and boxing every
+//! lvalue invocant would hand a `ContainerRef` to the ~40 `target.view()`
+//! branches of `assign_method_lvalue_with_values` that match `Instance` /
+//! `Array` / `Hash` directly. Nor can it be done inside that runtime function:
+//! `capture_var_cell_inner` needs the frame's `&CompiledCode` to resolve a slot,
+//! which the runtime entry does not have.
+//!
+//! So the box happens here, in the VM, where the frame's `code` and the invocant
+//! value are both in hand, gated on the same declaration oracle the runtime
+//! consumer reads (`Interpreter::method_returns_raw_invocant`).
+
+use super::*;
+
+impl Interpreter {
+    /// Replace `args[0]` (the invocant of a `__mutsu_assign_method_lvalue` call)
+    /// with the caller's container, when the callee binds its invocant raw.
+    ///
+    /// A no-op for every other callee, so the ordinary lvalue paths keep seeing
+    /// exactly the value they see today.
+    pub(super) fn box_raw_lvalue_invocant(&mut self, code: &CompiledCode, args: &mut [Value]) {
+        // target, method name, method args, value -- the writeback-target name
+        // is argument 4 and is what makes the element/attribute spellings work.
+        if args.len() < 4 {
+            return;
+        }
+        let target = args[0].clone();
+        if target.is_container_ref() {
+            return;
+        }
+        // The invocant's source name. `$a.m = v` tags it with `WrapVarRef`; the
+        // element spellings (`@a[0].m = v`) instead stash the invocant in a
+        // compiler temp whose name the parser passes as argument 4, and whose
+        // value the copy-out tail reads back (`GetGlobal(tmp); ...;
+        // IndexAssignExprNamed`). Either way the name is the location to box.
+        let (source_name, inner, slot_hint) = match target.as_varref() {
+            Some((name, value, _)) => (
+                name.resolve().to_string(),
+                value.clone(),
+                target.varref_slot(),
+            ),
+            None => (String::new(), target.clone(), None),
+        };
+        let name = if source_name.is_empty() {
+            match args.get(4).map(Value::to_string_value) {
+                Some(n) if !n.is_empty() => n,
+                _ => return,
+            }
+        } else {
+            source_name
+        };
+        let method = args[1].to_string_value();
+        let method_args: Vec<Value> = match args[2].view() {
+            ValueView::Array(items, ..) => items.to_vec(),
+            ValueView::Nil => Vec::new(),
+            _ => vec![args[2].clone()],
+        };
+        if !self.method_returns_raw_invocant(&inner, &method, &method_args) {
+            return;
+        }
+        if let Some(cell) = self.capture_lvalue_invocant_cell(code, &name, inner, slot_hint) {
+            args[0] = cell;
+        }
+    }
+
+    /// The container for the named lvalue invocant, or `None` when there is no
+    /// storage location to hand out (in which case the assignment keeps its
+    /// existing loud refusal rather than silently writing a disconnected cell).
+    ///
+    /// Three routes, in order:
+    ///
+    /// 1. **A local of this frame** — `capture_var_cell` boxes the slot into a
+    ///    shared cell and mirrors it into env, which is the same cell a
+    ///    `return-rw` tail or a `\($a)` capture would produce. This is `$a.m = v`.
+    /// 2. **A `$`-scalar local that route 1 declined** because its value is
+    ///    reference-shaped (an `Instance`). See the comment on the branch.
+    /// 3. **A name that only lives in env** — the compiler temp the element
+    ///    spellings route through (`__mutsu_tmp_assign_method_target_N`), and a
+    ///    captured-outer scalar. `capture_var_cell_inner` returns such a value
+    ///    unchanged (it has no slot to box), so box it into a cell stored in env
+    ///    under that name. The copy-out tail reads the name back through
+    ///    `GetGlobal`, which dereferences the cell, so the write reaches
+    ///    `@a[0]` / `%h<a>`.
+    ///
+    /// Route 3 is deliberately restricted to *scalar-shaped* values, mirroring
+    /// `capture_var_cell_inner`'s own `is_reference` guard: boxing an
+    /// `Array`/`Hash`/`Instance` env entry would produce a cell that disagrees
+    /// with the aggregate's own identity-shared storage.
+    fn capture_lvalue_invocant_cell(
+        &mut self,
+        code: &CompiledCode,
+        name: &str,
+        inner: Value,
+        slot_hint: Option<u32>,
+    ) -> Option<Value> {
+        let boxed = self.capture_var_cell(code, name, inner.clone(), slot_hint);
+        if boxed.is_container_ref() || matches!(boxed.view(), ValueView::HashEntryRef { .. }) {
+            return Some(boxed);
+        }
+        // A `$`-scalar local holding a *reference* (an `Instance`): the general
+        // capture paths deliberately refuse to re-containerize one, but a raw
+        // invocant is the caller's Scalar container and raku replaces its whole
+        // contents — `class C { method m(\S:) is raw { S } }; my $c = C.new;
+        // $c.m = 5` leaves `$c` holding `5`. Scalar names only: `@a`/`%h`
+        // locals keep their sigil in `code.locals`, and their own identity-
+        // shared storage is not this cell's to replace.
+        if Self::is_scalar_local_name(name)
+            && let Some(idx) = Self::frame_local_slot(code, name, slot_hint)
+        {
+            let cell = self.locals[idx].clone().into_container_ref();
+            self.locals[idx] = cell.clone();
+            let sym = code.locals_sym.get(idx).copied();
+            self.set_env_with_main_alias_sym(name, sym, cell.clone());
+            return Some(cell);
+        }
+        if !Self::raw_invocant_boxable_in_env(&inner) {
+            return None;
+        }
+        self.env().get(name)?;
+        let cell = inner.into_container_ref();
+        self.set_env_with_main_alias_sym(name, None, cell.clone());
+        Some(cell)
+    }
+
+    /// Whether `name` (as it appears in `code.locals`) is a plain `$`-scalar
+    /// lexical. Array, hash and code locals keep their sigil there, and a
+    /// twigil / dynamic / attribute / compiler-synthesized name is not a plain
+    /// lexical slot to re-containerize. Mirrors
+    /// `Compiler::is_plain_lexical_name`, which gates the compile-side
+    /// container-capture edge for the same reason.
+    fn is_scalar_local_name(name: &str) -> bool {
+        !name.is_empty()
+            && !name.starts_with(['$', '@', '%', '&', '.', '!', '^', '*'])
+            && name != "_"
+            && !name.contains("::")
+            && !name.starts_with("__mutsu_")
+            && !name.starts_with("__ANON")
+    }
+
+    /// The frame slot `name` occupies, preferring the compile-time-resolved
+    /// hint (shadow slots give several `code.locals` entries the same name, so
+    /// a by-name search would pick the wrong one).
+    fn frame_local_slot(code: &CompiledCode, name: &str, slot_hint: Option<u32>) -> Option<usize> {
+        match slot_hint {
+            Some(hint)
+                if hint != u32::MAX
+                    && code.locals.get(hint as usize).map(String::as_str) == Some(name) =>
+            {
+                Some(hint as usize)
+            }
+            Some(hint) if hint == u32::MAX => None,
+            _ => code.locals.iter().rposition(|n| n == name),
+        }
+    }
+
+    /// Whether an env-only name may be boxed into a fresh scalar container cell.
+    /// Reference-shaped values carry their own shared storage and type objects
+    /// are not locations, so neither is boxed — matching the guard
+    /// `capture_var_cell_inner` applies to a frame local.
+    fn raw_invocant_boxable_in_env(value: &Value) -> bool {
+        !matches!(
+            value.view(),
+            ValueView::Array(..)
+                | ValueView::Hash(..)
+                | ValueView::Sub(..)
+                | ValueView::Instance { .. }
+                | ValueView::Proxy { .. }
+                | ValueView::Package(_)
+        )
+    }
+}

--- a/src/vm/vm_raw_invocant_lvalue.rs
+++ b/src/vm/vm_raw_invocant_lvalue.rs
@@ -34,6 +34,26 @@ impl Interpreter {
         if args.len() < 4 {
             return;
         }
+        // The cheapest possible gate, first: this runs on EVERY `$obj.attr = v`,
+        // and everything below it allocates (two `to_string_value()`s, a
+        // `method_args` vector, an MRO walk plus a `MethodDef` clone). A raw
+        // invocant is rare, so ask the registry's set-only flag and the native
+        // table — both against a *borrowed* method name — before paying for any
+        // of it. Measured: doing the extraction unconditionally costs ~13% on a
+        // tight `$p.x = $i` loop.
+        match args[1].as_str() {
+            Some(name)
+                if self.registry().any_raw_invocant_method
+                    || crate::runtime::raw_invocant::native_method_returns_raw_invocant(name) => {}
+            // A non-`Str` method name cannot happen from the compiler, but a
+            // dynamic spelling could in principle; fall back to the full oracle
+            // rather than silently declining.
+            None => {}
+            _ => {
+                self.debug_verify_raw_invocant_filter(args);
+                return;
+            }
+        }
         let target = args[0].clone();
         if target.is_container_ref() {
             return;
@@ -60,11 +80,7 @@ impl Interpreter {
             source_name
         };
         let method = args[1].to_string_value();
-        let method_args: Vec<Value> = match args[2].view() {
-            ValueView::Array(items, ..) => items.to_vec(),
-            ValueView::Nil => Vec::new(),
-            _ => vec![args[2].clone()],
-        };
+        let method_args = Self::lvalue_method_args(&args[2]);
         if !self.method_returns_raw_invocant(&inner, &method, &method_args) {
             return;
         }
@@ -73,26 +89,75 @@ impl Interpreter {
         }
     }
 
+    /// Debug-only: re-derive the slow answer whenever the cheap pre-filter
+    /// declined, and blow up if they disagree.
+    ///
+    /// The filter is a necessary condition maintained at *registration* time
+    /// (`Registry::note_raw_invocant_methods`), so it can only go wrong if some
+    /// path writes `method_entries`' `user_candidates` column without going
+    /// through the documented mutators. This turns that into a deterministic
+    /// failure of the debug `t/` suite instead of a feature that silently stops
+    /// working.
+    #[cfg(debug_assertions)]
+    fn debug_verify_raw_invocant_filter(&mut self, args: &[Value]) {
+        let method = args[1].to_string_value();
+        let method_args: Vec<Value> = Self::lvalue_method_args(&args[2]);
+        // Derive the invocant exactly as the live path does, or the resolve
+        // would run against `VarRef` instead of the value it wraps.
+        let inner = match args[0].as_varref() {
+            Some((_, value, _)) => value.clone(),
+            None => args[0].clone(),
+        };
+        assert!(
+            !self.method_returns_raw_invocant(&inner, &method, &method_args),
+            "the any_raw_invocant_method pre-filter declined, but the oracle says \
+             .{method} takes a raw invocant -- a registration path wrote \
+             user_candidates without going through Registry's mutators"
+        );
+    }
+
+    #[cfg(not(debug_assertions))]
+    fn debug_verify_raw_invocant_filter(&mut self, _args: &[Value]) {}
+
+    /// The method's own argument list, as `__mutsu_assign_method_lvalue`
+    /// packs it into argument 2.
+    fn lvalue_method_args(packed: &Value) -> Vec<Value> {
+        match packed.view() {
+            ValueView::Array(items, ..) => items.to_vec(),
+            ValueView::Nil => Vec::new(),
+            _ => vec![packed.clone()],
+        }
+    }
+
     /// The container for the named lvalue invocant, or `None` when there is no
     /// storage location to hand out (in which case the assignment keeps its
     /// existing loud refusal rather than silently writing a disconnected cell).
     ///
-    /// Three routes, in order:
+    /// Four routes, in order. **Reusing an existing container always comes
+    /// before minting one** — a name that already denotes a location must hand
+    /// out *that* location, or the write lands in a disconnected cell and is
+    /// silently lost. (Measured: `for @a -> $e is rw { $e.m = 3 }` binds `$e` to
+    /// the element's own promoted cell, and minting a fresh one dropped the
+    /// write.)
     ///
     /// 1. **A local of this frame** — `capture_var_cell` boxes the slot into a
     ///    shared cell and mirrors it into env, which is the same cell a
-    ///    `return-rw` tail or a `\($a)` capture would produce. This is `$a.m = v`.
-    /// 2. **A `$`-scalar local that route 1 declined** because its value is
+    ///    `return-rw` tail or a `\($a)` capture would produce. It already
+    ///    returns an existing cell untouched when the slot holds one. This is
+    ///    `$a.m = v`.
+    /// 2. **A name whose env entry is already a container** — an `is rw` /
+    ///    `<->` loop parameter aliasing the source element, a `:=`-bound name,
+    ///    a captured-outer scalar that was boxed elsewhere. Hand out that cell.
+    /// 3. **A `$`-scalar local that route 1 declined** because its value is
     ///    reference-shaped (an `Instance`). See the comment on the branch.
-    /// 3. **A name that only lives in env** — the compiler temp the element
-    ///    spellings route through (`__mutsu_tmp_assign_method_target_N`), and a
-    ///    captured-outer scalar. `capture_var_cell_inner` returns such a value
-    ///    unchanged (it has no slot to box), so box it into a cell stored in env
-    ///    under that name. The copy-out tail reads the name back through
-    ///    `GetGlobal`, which dereferences the cell, so the write reaches
-    ///    `@a[0]` / `%h<a>`.
+    /// 4. **A name that only lives in env** — the compiler temp the element
+    ///    spellings route through (`__mutsu_tmp_assign_method_target_N`).
+    ///    `capture_var_cell_inner` returns such a value unchanged (it has no
+    ///    slot to box), so box it into a cell stored in env under that name.
+    ///    The copy-out tail reads the name back through `GetGlobal`, which
+    ///    dereferences the cell, so the write reaches `@a[0]` / `%h<a>`.
     ///
-    /// Route 3 is deliberately restricted to *scalar-shaped* values, mirroring
+    /// Route 4 is deliberately restricted to *scalar-shaped* values, mirroring
     /// `capture_var_cell_inner`'s own `is_reference` guard: boxing an
     /// `Array`/`Hash`/`Instance` env entry would produce a cell that disagrees
     /// with the aggregate's own identity-shared storage.
@@ -104,8 +169,12 @@ impl Interpreter {
         slot_hint: Option<u32>,
     ) -> Option<Value> {
         let boxed = self.capture_var_cell(code, name, inner.clone(), slot_hint);
-        if boxed.is_container_ref() || matches!(boxed.view(), ValueView::HashEntryRef { .. }) {
+        if Self::is_lvalue_location(&boxed) {
             return Some(boxed);
+        }
+        let existing = self.env().get(name).cloned();
+        if let Some(existing) = existing.as_ref().filter(|v| Self::is_lvalue_location(v)) {
+            return Some(existing.clone());
         }
         // A `$`-scalar local holding a *reference* (an `Instance`): the general
         // capture paths deliberately refuse to re-containerize one, but a raw
@@ -123,13 +192,20 @@ impl Interpreter {
             self.set_env_with_main_alias_sym(name, sym, cell.clone());
             return Some(cell);
         }
+        existing?;
         if !Self::raw_invocant_boxable_in_env(&inner) {
             return None;
         }
-        self.env().get(name)?;
         let cell = inner.into_container_ref();
         self.set_env_with_main_alias_sym(name, None, cell.clone());
         Some(cell)
+    }
+
+    /// Whether a value already IS a storage location, so it must be handed out
+    /// rather than boxed into a fresh cell. Mirrors
+    /// `capture_var_cell_inner`'s `is_lvalue_container_value`.
+    fn is_lvalue_location(value: &Value) -> bool {
+        value.is_container_ref() || matches!(value.view(), ValueView::HashEntryRef { .. })
     }
 
     /// Whether `name` (as it appears in `code.locals`) is a plain `$`-scalar

--- a/t/raw-invocant-lvalue-container.t
+++ b/t/raw-invocant-lvalue-container.t
@@ -11,7 +11,7 @@ use Test;
 # Dropping either half must keep refusing, which is what the regression
 # controls below pin. Verified byte-identical under `mutsu` and `raku`.
 
-plan 21;
+plan 29;
 
 my @mutsu-raw-seen;
 
@@ -30,6 +30,8 @@ augment class Any {
     method mutsuRawButConst(\S:) is raw { 99 }
     # a raw-invocant routine that also READS its invocant before handing it back.
     method mutsuPeek(\S:) is raw { @mutsu-raw-seen.push(S); S }
+    # a raw-invocant candidate selected by multi dispatch on a real argument.
+    multi method mutsuMulti(\S: Int $i) is raw { S }
 }
 
 # --- the three rw-capable spellings, over a scalar --------------------------
@@ -138,6 +140,58 @@ augment class Any {
     my $e = MutsuRawE.new(v => 1);
     $e.v = 7;
     is $e.v, 7, 'an ordinary is rw attribute accessor still assigns normally';
+}
+
+# --- the location the name denotes, in every frame shape --------------------
+#
+# A name that ALREADY denotes a location must hand out that location, never a
+# freshly minted one. The `is rw` loop parameter below is the row that proves
+# it: it aliases the source element's own container, and minting a new cell
+# instead silently dropped the write.
+
+{
+    sub mutsu-raw-in-a-sub() { my $x = 1; $x.mutsuRawInv = 5; $x }
+    is mutsu-raw-in-a-sub(), 5, 'a plain local of a sub frame';
+}
+{
+    my $outer = 1;
+    my $closure = { $outer.mutsuRawInv = 7 };
+    $closure();
+    is $outer, 7, 'a captured-outer scalar written from inside a closure';
+}
+{
+    my @a = 1, 2;
+    for @a -> $e is rw { $e.mutsuRawInv = 3 }
+    is-deeply @a, [3, 3], 'an is rw loop parameter aliases the source element';
+}
+{
+    my @a = 1, 2;
+    for @a <-> $e { $e.mutsuRawInv = 4 }
+    is-deeply @a, [4, 4], 'and so does the <-> spelling';
+}
+{
+    my $n = 'mutsuRawInv';
+    my $a = 1;
+    $a."$n"() = 9;
+    is $a, 9, 'a runtime method name resolves the same declaration';
+}
+{
+    my $a = 1;
+    $a.mutsuMulti(2) = 4;
+    is $a, 4, 'a multi candidate selected by a real argument';
+}
+
+# --- invocant types other than Int ------------------------------------------
+
+{
+    my $s = "str";
+    $s.mutsuRawInv = "x";
+    is $s, "x", 'a Str invocant';
+}
+{
+    my $u;
+    $u.mutsuRawInv = 5;
+    is $u, 5, 'an uninitialized scalar (a type object) is still a location';
 }
 
 done-testing;

--- a/t/raw-invocant-lvalue-container.t
+++ b/t/raw-invocant-lvalue-container.t
@@ -1,0 +1,143 @@
+use MONKEY-TYPING;
+use Test;
+
+# ADR-0067 slice 3a: a routine hands back the container it was *given*, and the
+# invocant is parameter zero. `$a.m = 5` writes through `$a`'s own container
+# when — and only when — the callee declares BOTH halves:
+#
+#   * the invocant parameter is raw (`\S:`, `$s is raw:`, `$s is rw:`), and
+#   * the routine is rw-capable (`is rw` / `is raw` / spells `return-rw`).
+#
+# Dropping either half must keep refusing, which is what the regression
+# controls below pin. Verified byte-identical under `mutsu` and `raku`.
+
+plan 21;
+
+my @mutsu-raw-seen;
+
+augment class Any {
+    # rw-capable AND raw invocant, in all three rw-capable spellings.
+    method mutsuRawInv(\S:) is raw { S }
+    method mutsuRwInv(\S:) is rw { S }
+    method mutsuRetRwInv(\S:) { return-rw S }
+    # a raw invocant spelled with a sigil rather than sigil-less.
+    method mutsuSigilRaw($s is raw:) is raw { $s }
+    method mutsuSigilRw($s is rw:) is raw { $s }
+    # regression controls.
+    method mutsuNotRwCapable(\S:) { S }
+    method mutsuNotRawInvocant(Any:D $s:) is raw { $s }
+    # a raw invocant that hands back something that is not a location.
+    method mutsuRawButConst(\S:) is raw { 99 }
+    # a raw-invocant routine that also READS its invocant before handing it back.
+    method mutsuPeek(\S:) is raw { @mutsu-raw-seen.push(S); S }
+}
+
+# --- the three rw-capable spellings, over a scalar --------------------------
+
+{
+    my $a = 42;
+    $a.mutsuRawInv = 5;
+    is $a, 5, 'is raw + raw invocant writes through the scalar';
+}
+{
+    my $a = 42;
+    $a.mutsuRwInv = 5;
+    is $a, 5, 'is rw + raw invocant writes through the scalar';
+}
+{
+    my $a = 42;
+    $a.mutsuRetRwInv = 5;
+    is $a, 5, 'return-rw + raw invocant writes through the scalar';
+}
+
+# --- the sigiled raw-invocant spellings -------------------------------------
+
+{
+    my $a = 42;
+    $a.mutsuSigilRaw = 5;
+    is $a, 5, '$s is raw: invocant writes through the scalar';
+}
+{
+    my $a = 42;
+    $a.mutsuSigilRw = 5;
+    is $a, 5, '$s is rw: invocant writes through the scalar';
+}
+
+# --- both halves are required -----------------------------------------------
+
+{
+    my $a = 42;
+    dies-ok { $a.mutsuNotRwCapable = 5 },
+        'a raw invocant without is raw/is rw/return-rw still refuses';
+    is $a, 42, 'and the refused assignment left the variable alone';
+}
+{
+    my $a = 42;
+    dies-ok { $a.mutsuNotRawInvocant = 5 },
+        'is raw without a raw invocant still refuses';
+    is $a, 42, 'and the refused assignment left the variable alone (2)';
+}
+{
+    my $a = 42;
+    dies-ok { $a.mutsuRawButConst = 5 },
+        'a raw-invocant routine that returns a value, not a location, refuses';
+    is $a, 42, 'and the refused assignment left the variable alone (3)';
+}
+
+# --- the element invocant spellings -----------------------------------------
+#
+# `@a[0].m = 9` compiles to a copy-in/copy-out protocol through a compiler
+# temp, so boxing the TEMP is what makes the write reach the element.
+
+{
+    my @a = 1, 2;
+    @a[0].mutsuRawInv = 9;
+    is-deeply @a, [9, 2], 'an array-element invocant writes back into the element';
+}
+{
+    my %h = a => 1, b => 2;
+    %h<a>.mutsuRawInv = 9;
+    is %h<a>, 9, 'a hash-element invocant writes back into the entry';
+    is %h<b>, 2, 'and leaves its neighbour alone';
+}
+
+# --- an instance-valued scalar ----------------------------------------------
+#
+# The raw invocant is the VARIABLE's container, so the assignment replaces its
+# whole contents rather than touching an attribute.
+
+{
+    class MutsuRawC { method m(\S:) is raw { S } }
+    my $c = MutsuRawC.new;
+    $c.m = 5;
+    is $c, 5, 'an instance invocant: the write replaces the whole variable';
+}
+
+# --- the routine still receives the invocant as a readable value ------------
+
+{
+    my $d = 41;
+    $d.mutsuPeek = 8;
+    is @mutsu-raw-seen[0], 41, 'the routine observed the pre-assignment invocant';
+    is $d, 8, 'and the assignment still landed';
+}
+
+# --- an ordinary (non-lvalue) call is unaffected ----------------------------
+
+{
+    my $a = 42;
+    is $a.mutsuRawInv, 42, 'an rvalue call still just returns the invocant';
+    is $a, 42, 'and does not disturb the variable';
+    ok $a.mutsuRawInv =:= $a, 'the raw invocant is the same container';
+}
+
+# --- a non-raw-invocant method on a class is untouched ----------------------
+
+{
+    class MutsuRawE { has $.v is rw }
+    my $e = MutsuRawE.new(v => 1);
+    $e.v = 7;
+    is $e.v, 7, 'an ordinary is rw attribute accessor still assigns normally';
+}
+
+done-testing;

--- a/t/snitch-lvalue-raw-invocant.t
+++ b/t/snitch-lvalue-raw-invocant.t
@@ -1,0 +1,64 @@
+use v6.e.PREVIEW;
+use Test;
+
+# ADR-0067 slice 3a, native half. `.snitch` is declared
+# `method snitch(\snitchee: &snitcher = &note)` — its invocant is RAW — and it
+# hands that invocant straight back, so `$a.snitch = 5` notes the old value and
+# then writes `5` through `$a`'s own container.
+#
+# This is the reason `.snitch` cannot take `.item`'s route: `.item` is erased at
+# compile time to a plain store, which is sound only because `.item` is pure.
+# `.snitch` has a side effect, so erasing the call would drop it.
+#
+# Verified byte-identical under `mutsu` and `raku`.
+
+plan 12;
+
+# --- the scalar invocant ----------------------------------------------------
+
+{
+    my $noted;
+    my $a = 42;
+    $a.snitch({ $noted = $_ }) = 5;
+    is $noted, 42, '.snitch logged the invocant before the assignment';
+    is $a, 5, 'and the assignment wrote through the raw invocant';
+}
+
+{
+    my $a = 42;
+    $a.snitch = 5;
+    is $a, 5, 'the default (note) snitcher assigns through too';
+}
+
+# --- the element invocant spellings -----------------------------------------
+
+{
+    my @noted;
+    my @a = 1, 2;
+    @a[0].snitch({ @noted.push($_) }) = 9;
+    is @noted[0], 1, 'an array element is snitched by value';
+    is-deeply @a, [9, 2], 'and the write reaches the element';
+}
+
+{
+    my @noted;
+    my %h = a => 1, b => 2;
+    %h<a>.snitch({ @noted.push($_) }) = 9;
+    is @noted[0], 1, 'a hash entry is snitched by value';
+    is %h<a>, 9, 'and the write reaches the entry';
+    is %h<b>, 2, 'leaving its neighbour alone';
+}
+
+# --- the rvalue call is unchanged -------------------------------------------
+
+{
+    my $a = 42;
+    my $seen;
+    my $back = $a.snitch({ $seen = $_ });
+    is $seen, 42, 'an rvalue .snitch still logs the invocant';
+    is $back, 42, 'and still returns it';
+    is $a, 42, 'without disturbing the variable';
+    ok $a.snitch(-> $ { }) =:= $a, '.snitch hands back the very container';
+}
+
+done-testing;


### PR DESCRIPTION
ADR-0067 slice 3a: **a routine hands back the container it was *given*, and the invocant is parameter zero.**

`my $a = 42; $a.snitch = 5` died with `X::Assignment::RO: cannot assign through .snitch on non-instance`; raku prints `42` and leaves `$a` holding `5`. So did the user-written twin and the element spellings.

## Acceptance rows (all re-measured against raku v2026.07 before any code)

| # | Program | raku | before | after |
|---|---|---|---|---|
| A3 | `my $a = 42; $a.snitch = 5; say $a` | `42` / `5` | `X::Assignment::RO` | `42` / `5` |
| A6 | `augment class Any { method mysn(\SELF:) is raw { SELF } }; $a.mysn = 5` | `5` | the same error | `5` |
| E4 | `my @a = 1,2; @a[0].mysn = 9; say @a` | `[9 2]` | the same error | `[9 2]` |
| E5 | `my %h = a=>1; %h<a>.mysn = 9` | `{a => 9}` | the same error | `{a => 9}` |
| E1 | the same **without** `is raw` | `Cannot modify an immutable Int` | refuses | still refuses |
| E2 | `method mysn2(Any:D $s:) is raw { $s }` (non-raw invocant) | `Cannot assign to a readonly variable` | refuses | still refuses |
| — | `class C { method m(\S:) is raw { S } }; my $c = C.new; $c.m = 5` | `5` | **`C.new` — silent** | `5` |
| — | `for @a -> $e is rw { $e.mysn = 3 }` | `[3 3]` | refuses loudly | `[3 3]` |

## Root cause

ADR-0059 built production and consumption of "an `is rw` routine returns a container"; slices 1-2 fixed the outbound side for a sigil-less name and unified the method rw-capability oracle. Inbound transport for **parameter zero** was still missing — the invocant arrived as a plain value, so there was no location for `assign_lvalue_container` to write through, and every such assignment fell out of `assign_method_lvalue_with_values` at its `Instance`-only gate.

## What shipped

raku requires **both** declarations before the write happens: the invocant parameter raw (`\S:`, `$s is raw:`, `$s is rw:`) **and** the routine rw-capable (`is rw` / `is raw` / `return-rw`). That contract lives in one function, `Interpreter::method_returns_raw_invocant` (`src/runtime/raw_invocant.rs`), read by both consumers:

- **The VM gate** (`src/vm/vm_raw_invocant_lvalue.rs`), from `exec_call_func_op`'s `__mutsu_assign_method_lvalue` arm — the only site where the frame's `&CompiledCode` (needed for slot resolution) and the resolved callee are both in hand. It cannot be a compile-time decision: rawness depends on the invocant's runtime type and on a runtime method-name string.
- **The runtime consumer** `try_raw_invocant_container_lvalue`, after ADR-0059's type-object half. It runs the routine with the container invocant and writes through whatever container comes back, so `method m(\S:) is raw { 42 }` is refused exactly as raku refuses it.

A boxed invocant would otherwise be silently skipped by the ~40 `Instance`/`Array`/`Hash` branches below, so the target is decontainerized at a **single chokepoint** right after the new branch declines.

## The global-temp decision

A **global-name container route**, not local promotion. `__mutsu_tmp_assign_method_target_N` is read back by two separate opcodes (`GetGlobal` in the copy-out tail and `IndexAssignExprNamed`), so promoting the temps to locals would touch the whole temp protocol for every lvalue method call. An env cell is transparent instead: `GetGlobal` already dereferences a `ContainerRef`, so the existing tail writes the result into `@a[0]` / `%h<a>` with **no per-shape code**.

## The ordering rule, learned the hard way

Four routes find the invocant's container, and **reusing an existing location always comes before minting one.** The first ordering minted an env cell whenever the name had no frame slot, which silently broke `for @a -> $e is rw { $e.mysn = 3 }` — a shape that had *refused loudly* before the slice, so it traded a loud refusal for a silent wrong answer. An `is rw` loop parameter binds the source element's own promoted cell and the loop then suppresses its writeback precisely because that alias carries the write; minting a second cell over the top dropped it. Both loop spellings are now pinned.

## Perf: measured, and paid down

The gate runs on every `$obj.attr = v`. A same-binary env-switch A/B on a release build put the first version at **+13%** on a tight `$p.x = $i` loop (1.92s vs 1.70s). The fix is `Registry::any_raw_invocant_method`, a **set-only** flag raised at registration; set-only is the safe direction, since a stale `true` costs only a resolve while a spurious `false` would silently switch the feature off.

Two things about it are load-bearing:

- It sits **in the VM gate, ahead of every allocation**, not inside the oracle. Putting it inside `method_returns_raw_invocant` recovered ~1.6%, which located the real cost: most of the 13% was the *argument extraction* — two `to_string_value()` allocations plus a `method_args` vector — not `resolve_method` at all. The shipped gate asks against a **borrowed** method name and returns before allocating.
- The filter and the oracle read the **same** `method_def_has_raw_invocant` predicate, so they cannot disagree by construction, and a `debug_assert` re-derives the slow answer whenever the filter declines — a future registration path bypassing `Registry`'s mutators becomes a deterministic debug-`t/` failure rather than a feature that silently stops working.

With the filter, min-of-14 under load is 2.38s against 2.65s un-filtered.

## Two things measurement changed about the ADR

- The native raw-invocant table has **one** row, not three. `$a.list =:= $a` is `False` and `.list` returns a `List` — its assignability is *list assignment* into a List whose element is the invocant's container, a different mechanism a table row would have silently replaced. `.item` is genuinely raw but is erased at compile time, so its row would never be read.
- The instance-invocant row above was a pre-existing silent wrong answer nobody had listed.

## Still refusing, recorded in the ADR

`$c.v.snitch = 9` (E6) compiles with **no temp and no writeback tail** — the invocant is a bare accessor call and argument 4 is `LoadNil`, so there is no name to box. The producer it needs exists (`MarkAccessorRefContext`, which makes `my $x := $c.v; $x = 9` write through today) but wiring it into an lvalue invocant is an unconditional compile-side change and earns its own slice. The mutation discriminator settled this, not `.VAR`: `$c.v` produces a container for a `:=` bind but not in argument position. Aggregate (`@a.snitch = (7,8)`), chained (`$a.snitch.snitch = 5`) and depth-2-subscript (`@n[0][1].mysn = 8`, slice 4's walker) invocants also still refuse — loudly, the status quo.

## Testing

- `t/raw-invocant-lvalue-container.t` (29 tests) and `t/snitch-lvalue-raw-invocant.t` (12 tests), both **byte-identical under `mutsu` and `raku`**, covering the three rw-capable spellings, both sigiled raw-invocant spellings, array/hash-element invocants, the instance-valued scalar, each frame shape the four routes serve (sub local, captured-outer written from a closure, `-> $e is rw`, `<-> $e`), a runtime method name, a `multi` candidate, `Str`/uninitialized invocants, and all three regression controls.
- `make test`: 3665 files / 37330 tests, PASS.
- Targeted roast sweeps, `MUTSU_FUDGE=1`: S12-attributes/class/methods/construction/introspection, S14-roles, S06-traits, S06-operator-overloading, S03-binding (125 files) and S02-names-vars, S03-operators, S04-declarations, S09-typed-arrays, S32-array, S32-hash, S02-types (198 files) — all PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
