### PR TITLE
fix(rakuast): stop rendering internal markers, and finish ApplyPostfix lowering

### DIFF
--- a/news/2026-09/rakuast-desugar-marker-boundary.md
+++ b/news/2026-09/rakuast-desugar-marker-boundary.md
@@ -1,0 +1,49 @@
+# RakuAST no longer renders mutsu's internal desugaring markers
+
+`.AST` emitted nodes that cannot exist in a real RakuAST tree. mutsu desugars a
+handful of constructs in the parser into calls to internal routines, or into
+temporaries with internal names, and the converter rendered those names
+verbatim:
+
+```
+$ mutsu -e 'my @a; say Q[-<<@a].AST'
+...
+    expression => RakuAST::Call::Name.new(
+      name => RakuAST::Name.from-identifier("__mutsu_hyper_prefix"),
+```
+
+raku keeps every one of these constructs as a dedicated node
+(`-<<@a` is a hyper *prefix*, not a call) and has no such name anywhere, so the
+rendered tree was not merely incomplete — it was wrong, and it would not survive
+comparison with the reference implementation.
+
+## Change
+
+`src/rakuast/convert.rs` refuses a routine or variable name that is one of
+mutsu's internal markers (`__mutsu_*`, `__with_tmp_N`, `@__destructure_tmp__`,
+…) and reports it as a coverage boundary:
+
+```
+RakuAST: `.AST` does not yet support this construct: desugared construct (internal name `__mutsu_hyper_prefix`)
+```
+
+This is the rule the rest of the converter already follows, and the one
+`docs/rakuast/README.md` states outright: *if the parser/internal AST has
+already erased a distinction, do not guess it inside RakuAST conversion.* An
+erased distinction is a boundary, never a guess. Nothing here asserts what the
+right node would be — that needs measuring against raku first, and the
+underlying constructs (hyper prefix, `with`/`without`, list assignment, …) stay
+on the read-direction gap list in `todo/deep/rakuast-remaining.md`.
+
+Only names that mutsu itself plants are affected. Ordinary calls, hyper method
+calls, and variable declarations render exactly as before, and the whole
+`t/rakuast*.t` suite passes unchanged — no previously-correct rendering was
+lost, because these names never had a correct rendering.
+
+## Coverage
+
+`t/rakuast-desugar-boundary.t` (6 assertions) pins three constructs as
+boundaries (hyper prefix, zip assignment, `with`) and three neighbouring
+constructs as still rendering. It is deliberately mutsu-only: it asserts
+mutsu's boundary behaviour, which has no raku counterpart, so unlike the rest
+of the `t/rakuast*.t` suite it is not a dual-oracle file.

--- a/news/2026-09/rakuast-postfix-lowering.md
+++ b/news/2026-09/rakuast-postfix-lowering.md
@@ -1,0 +1,48 @@
+# RakuAST postfix lowering, and a silent no-op increment
+
+`EVAL` of a RakuAST tree handled only three of the postfix forms the read
+direction renders — `Call::Method` (with no dispatch modifier), `Call::Term`,
+and `Postcircumfix::ArrayIndex`. Everything else in the cluster read fine and
+then failed with `EVAL does not yet support lowering RakuAST::ApplyPostfix`.
+
+## Change
+
+`src/rakuast/lower.rs`'s `ApplyPostfix` arm now covers:
+
+- `Postfix(operator => "++" / "--")` -> `Expr::PostfixOp`. Unlike `Infix` and
+  `Prefix`, a `Postfix` carries its operator in a *named* `operator` field, so
+  it needs its own reader.
+- `MetaPostfix::Hyper(Call::Method)` -> `Expr::HyperMethodCall`, the node the
+  converter already renders `@a>>.abs` from.
+- `Call::Method`'s `dispatch` field -> the `.?` / `.+` / `.*` modifier. It was
+  being dropped: `EVAL(Q[my $x = -5; $x.?no-such].AST)` threw
+  `No such method` where the source form returns `Nil`.
+- `Call::QuotedMethod` -> a method call with a quoted name. Only a
+  single-`StrLiteral`-segment name lowers; an interpolated one is a different
+  internal node.
+
+## The bug underneath
+
+Adding the postfix operators surfaced a real defect in a shared table.
+`op_name_to_token_kind` had no row for `++` or `--`, so both fell through to its
+`Ident` catch-all. A *prefix* increment already lowered — `++$x` renders as
+`ApplyPrefix(Prefix("++"))` and reached `Expr::Unary` — but with
+`op: Ident("++")`, which the compiler does not treat as an increment. It
+compiled to something that quietly produced `Any`:
+
+```
+$ mutsu -e 'use MONKEY-SEE-NO-EVAL; EVAL(Q[my $x = 1; ++$x; say $x].AST)'
+1     # before
+2     # after
+```
+
+No error, no boundary message — the increment simply did not happen. The table
+is used only by the RakuAST lowerer, so the two added rows change nothing else.
+
+## Coverage
+
+`t/rakuast-eval-postfix.t` (12 assertions) pins postfix and prefix `++`/`--`
+including their differing result values, an increment on an array element, a
+C-style loop whose step is `$i++`, hyper method calls, `.?` on both a present
+and a missing method, and a quoted method name. It is a dual-oracle test: it
+passes verbatim under both mutsu and raku.

--- a/src/compiler/helpers_ops.rs
+++ b/src/compiler/helpers_ops.rs
@@ -119,6 +119,13 @@ pub(crate) fn op_name_to_token_kind(name: &str) -> Option<TokenKind> {
         "~~" => TokenKind::SmartMatch,
         "!~~" => TokenKind::BangTilde,
         "=>" => TokenKind::FatArrow,
+        // Increment / decrement, which appear as a `Prefix` (`++$x`) and as the
+        // only two `Postfix` operators (`$x++`). Without these two rows they
+        // fell through to the `Ident` catch-all below, and an
+        // `Expr::Unary { op: Ident("++") }` is not an increment to the compiler:
+        // `EVAL(Q[my $x = 1; ++$x; say $x].AST)` silently printed 1.
+        "++" => TokenKind::PlusPlus,
+        "--" => TokenKind::MinusMinus,
         // Any remaining operator name is a named infix (`x`, `xx`, `eq`, `ne`,
         // `lt`/`gt`/`le`/`ge`, `cmp`, `leg`, `div`, `mod`, ...), which mutsu
         // represents with a generic `Ident` token (the inverse of

--- a/src/rakuast/convert.rs
+++ b/src/rakuast/convert.rs
@@ -873,9 +873,17 @@ fn convert_expr(expr: &Expr) -> Result<RakuAstNode, RuntimeError> {
     match expr {
         Expr::Literal(v) | Expr::LiteralSrc(v, _) => convert_literal(v),
         Expr::Call { name, args } | Expr::UserRoutineCall { name, args } => {
+            if is_desugar_marker(name.as_str()) {
+                return Err(desugared(name.as_str()));
+            }
             Ok(call_name(name.as_str(), args, false)?)
         }
-        Expr::Var(name) => Ok(var_lexical("$", name)),
+        Expr::Var(name) => {
+            if is_desugar_marker(name) {
+                return Err(desugared(name));
+            }
+            Ok(var_lexical("$", name))
+        }
         // Calling a term `$f(1, 2)` -> ApplyPostfix(operand, Call::Term(args)).
         Expr::CallOn { target, args } => {
             let call_term = RakuAstNode {
@@ -990,8 +998,18 @@ fn convert_expr(expr: &Expr) -> Result<RakuAstNode, RuntimeError> {
         Expr::CompoundAssign {
             target, op, rhs, ..
         } => compound_assignment_infix(target, op, rhs),
-        Expr::ArrayVar(name) => Ok(var_lexical("@", name)),
-        Expr::HashVar(name) => Ok(var_lexical("%", name)),
+        Expr::ArrayVar(name) => {
+            if is_desugar_marker(name) {
+                return Err(desugared(name));
+            }
+            Ok(var_lexical("@", name))
+        }
+        Expr::HashVar(name) => {
+            if is_desugar_marker(name) {
+                return Err(desugared(name));
+            }
+            Ok(var_lexical("%", name))
+        }
         Expr::CodeVar(name) => Ok(var_lexical("&", name)),
         // `todo/tickets/chained-compare-ast-node.md`: rakudo has no AST-level
         // `&&` for a chained comparison — `Q[1 < 2 < 3].AST` is a left-nested
@@ -1867,6 +1885,24 @@ fn call_quoted_method(name: &str, args: &[Expr]) -> Result<RakuAstNode, RuntimeE
         class: RakuAstClass::CallQuotedMethod,
         fields,
     })
+}
+
+/// Whether a routine or variable name is one of mutsu's internal desugaring
+/// markers (`__mutsu_hyper_prefix`, `__with_tmp_0`, `__destructure_tmp__`, …)
+/// rather than something the source wrote. raku keeps these constructs as
+/// dedicated nodes and never has such a name, so rendering one would emit a
+/// node that cannot exist in a real RakuAST tree. Refusing is the same rule the
+/// rest of the converter follows: an erased distinction is a boundary, never a
+/// guess. The underlying constructs are tracked as read-direction gaps in
+/// `todo/deep/rakuast-remaining.md`.
+fn is_desugar_marker(name: &str) -> bool {
+    name.starts_with("__") || name.starts_with("@__") || name.starts_with("%__")
+}
+
+/// The coverage-boundary error for a construct that reached conversion already
+/// desugared into an internal marker.
+fn desugared(name: &str) -> RuntimeError {
+    unsupported(&format!("desugared construct (internal name `{name}`)"))
 }
 
 /// `$x` / `@a` / `%h` / `&f` usage -> `Var::Lexical("<sigil><name>")`.

--- a/src/rakuast/lower.rs
+++ b/src/rakuast/lower.rs
@@ -1100,9 +1100,10 @@ fn lower_expr(node: &RakuAstNode) -> Result<Expr, RuntimeError> {
             }
             Ok(Expr::ArrayLiteral(items))
         }
-        // A postfix method call (`$x.abs`) or a positional subscript (`@a[1]`).
-        // Hyper-calls and associative subscripts carry a different postfix and are
-        // deferred.
+        // A postfix method call (`$x.abs`, `$x.?abs`, `$x."abs"()`), a hyper
+        // method call (`@a>>.abs`), a postfix operator (`$x++`), or a positional
+        // subscript (`@a[1]`). Associative subscripts carry a different postfix
+        // and are deferred.
         RakuAstClass::ApplyPostfix => {
             let operand = lower_expr(named_child(node, "operand")?)?;
             let postfix = named_child(node, "postfix")?;
@@ -1111,8 +1112,45 @@ fn lower_expr(node: &RakuAstNode) -> Result<Expr, RuntimeError> {
                     target: Box::new(operand),
                     name: crate::symbol::Symbol::intern(&call_name_str(postfix)?),
                     args: arg_exprs(postfix)?,
-                    modifier: None,
+                    modifier: dispatch_modifier(postfix)?,
                     quoted: false,
+                }),
+                // `$x."name"()` -> Call::QuotedMethod, whose `name` is a
+                // QuotedString rather than a Name. Only a single-literal-segment
+                // name round-trips; an interpolated one is a different internal
+                // node (`MethodCallDynamic`).
+                RakuAstClass::CallQuotedMethod => Ok(Expr::MethodCall {
+                    target: Box::new(operand),
+                    name: crate::symbol::Symbol::intern(&quoted_method_name(postfix)?),
+                    args: arg_exprs(postfix)?,
+                    modifier: None,
+                    quoted: true,
+                }),
+                // `@a>>.abs` -> MetaPostfix::Hyper wrapping the ordinary
+                // method-call postfix.
+                RakuAstClass::MetaPostfixHyper => {
+                    let inner = named_child_or_positional(postfix)?;
+                    let (name, quoted) = match inner.class {
+                        RakuAstClass::CallMethod => (call_name_str(inner)?, false),
+                        RakuAstClass::CallQuotedMethod => (quoted_method_name(inner)?, true),
+                        _ => return Err(unsupported(node)),
+                    };
+                    Ok(Expr::HyperMethodCall {
+                        target: Box::new(operand),
+                        name: crate::symbol::Symbol::intern(&name),
+                        args: arg_exprs(inner)?,
+                        modifier: if quoted {
+                            None
+                        } else {
+                            dispatch_modifier(inner)?
+                        },
+                        quoted,
+                    })
+                }
+                // `$x++` / `$x--` -> Postfix(operator => "++").
+                RakuAstClass::Postfix => Ok(Expr::PostfixOp {
+                    op: postfix_token(postfix)?,
+                    expr: Box::new(operand),
                 }),
                 // `$f(EXPR)` -> Call::Term(args) -> a call on the operand term.
                 RakuAstClass::CallTerm => Ok(Expr::CallOn {
@@ -1136,6 +1174,68 @@ fn lower_expr(node: &RakuAstNode) -> Result<Expr, RuntimeError> {
         }
         _ => Err(unsupported(node)),
     }
+}
+
+/// The `.?` / `.+` / `.*` dispatch modifier of a `Call::Method`, as the single
+/// character mutsu's `MethodCall.modifier` keeps. The field is absent for a
+/// plain `.method`.
+fn dispatch_modifier(node: &RakuAstNode) -> Result<Option<char>, RuntimeError> {
+    let Some(f) = node.fields.iter().find(|f| f.name == Some("dispatch")) else {
+        return Ok(None);
+    };
+    let RakuAstFieldValue::Node(v) = &f.value else {
+        return Err(unsupported(node));
+    };
+    let ValueView::Str(s) = v.view() else {
+        return Err(unsupported(node));
+    };
+    // The rendered form is `.?` / `.+` / `.*`; mutsu keeps only the modifier.
+    match s.strip_prefix('.').and_then(|rest| {
+        let mut chars = rest.chars();
+        match (chars.next(), chars.next()) {
+            (Some(c), None) => Some(c),
+            _ => None,
+        }
+    }) {
+        Some(c) => Ok(Some(c)),
+        None => Err(unsupported(node)),
+    }
+}
+
+/// The name of a `Call::QuotedMethod`, whose `name` child is a `QuotedString`
+/// rather than a `Name`. Only a single `StrLiteral` segment lowers; an
+/// interpolated method name is a different internal node.
+fn quoted_method_name(node: &RakuAstNode) -> Result<String, RuntimeError> {
+    let quoted = named_child(node, "name")?;
+    if quoted.class != RakuAstClass::QuotedString {
+        return Err(unsupported(node));
+    }
+    let Some(f) = quoted.fields.iter().find(|f| f.name == Some("segments")) else {
+        return Err(unsupported(node));
+    };
+    let RakuAstFieldValue::List(items) = &f.value else {
+        return Err(unsupported(node));
+    };
+    let [only] = items.as_slice() else {
+        return Err(unsupported(node));
+    };
+    let ValueView::RakuAst(seg) = only.view() else {
+        return Err(unsupported(node));
+    };
+    if seg.class != RakuAstClass::StrLiteral {
+        return Err(unsupported(node));
+    }
+    match positional_leaf(seg)?.view() {
+        ValueView::Str(s) => Ok(s.to_string()),
+        _ => Err(unsupported(node)),
+    }
+}
+
+/// The `TokenKind` for a `Postfix` operator node. Unlike `Infix`/`Prefix`, a
+/// `Postfix` carries its operator in a NAMED `operator` field.
+fn postfix_token(node: &RakuAstNode) -> Result<crate::token_kind::TokenKind, RuntimeError> {
+    let name = leaf_str(node, "operator")?;
+    crate::compiler::helpers_ops::op_name_to_token_kind(&name).ok_or_else(|| unsupported(node))
 }
 
 /// The `TokenKind` for an `Infix`/`Prefix` operator node (its positional operator

--- a/t/rakuast-desugar-boundary.t
+++ b/t/rakuast-desugar-boundary.t
@@ -1,0 +1,43 @@
+use v6;
+use experimental :rakuast;
+use Test;
+
+# mutsu desugars a few constructs in the parser into calls to internal routines
+# (`__mutsu_hyper_prefix`, `__mutsu_zip_assign`, …) or into temporaries with
+# internal names (`__with_tmp_0`, `@__destructure_tmp__`). raku keeps every one
+# of them as a dedicated RakuAST node and has no such name anywhere, so
+# rendering one emitted a node that cannot exist in a real RakuAST tree — a
+# `RakuAST::Call::Name.new(name => RakuAST::Name.from-identifier(
+# "__mutsu_hyper_prefix"))` for `-<<@a`, for instance.
+#
+# Those are now explicit `.AST` coverage boundaries, which is the rule the rest
+# of the converter follows: an erased distinction is a boundary, never a guess.
+# The underlying constructs are tracked as read-direction gaps in
+# todo/deep/rakuast-remaining.md.
+#
+# This file is mutsu-only: it asserts on mutsu's boundary behaviour, which has
+# no raku counterpart (raku renders these constructs properly). It deliberately
+# does NOT assert what the right node would be — that needs measuring against
+# raku first.
+
+plan 6;
+
+# --- a desugared construct throws rather than rendering a fake node ---------
+throws-like { Q[-<<@a].AST }, Exception,
+    'hyper prefix does not render an internal __mutsu_hyper_prefix call';
+
+throws-like { Q[my @a; @a Z= @a].AST }, Exception,
+    'zip assignment does not render an internal __mutsu_zip_assign call';
+
+throws-like { Q[with 1 { say $_ }].AST }, Exception,
+    '`with` does not render its __with_tmp_N temporary';
+
+# --- constructs that are NOT desugared still render -------------------------
+ok Q[say 42].AST.gist.contains('RakuAST::Call::Name::WithoutParentheses.new('),
+    'an ordinary named call still renders';
+
+ok Q[my @a; @a>>.abs].AST.gist.contains('RakuAST::MetaPostfix::Hyper.new('),
+    'a hyper method call still renders';
+
+ok Q[my $x = 1].AST.gist.contains('RakuAST::VarDeclaration::Simple.new('),
+    'an ordinary variable declaration still renders';

--- a/t/rakuast-eval-postfix.t
+++ b/t/rakuast-eval-postfix.t
@@ -1,0 +1,57 @@
+use v6;
+use MONKEY-SEE-NO-EVAL;
+use experimental :rakuast;
+use Test;
+
+# RakuAST `ApplyPostfix` lowering (ADR-0011, the write direction).
+#
+# The read direction has rendered all of these for a while; `EVAL` handled only
+# `Call::Method` (with no dispatch modifier), `Call::Term`, and
+# `Postcircumfix::ArrayIndex`. The rest of the postfix cluster now lowers too:
+#
+#   * `Postfix(operator => "++"/"--")`  -> Expr::PostfixOp
+#   * `MetaPostfix::Hyper(Call::Method)` -> Expr::HyperMethodCall
+#   * `Call::Method`'s `dispatch` field  -> the `.?` / `.+` / `.*` modifier
+#   * `Call::QuotedMethod`               -> a quoted method name
+#
+# Fixing this surfaced a real lowering bug of its own: the operator-name table
+# had no row for `++`/`--`, so a *prefix* `++$x` — which already lowered —
+# became `Expr::Unary { op: Ident("++") }`, which the compiler does not treat as
+# an increment. `EVAL(Q[my $x = 1; ++$x; say $x].AST)` silently printed 1.
+#
+# Passes under BOTH mutsu and raku.
+
+plan 12;
+
+# --- postfix increment / decrement ------------------------------------------
+is EVAL(Q[my $x = 1; $x++; $x].AST), 2, 'a postfix ++ lowers and mutates';
+is EVAL(Q[my $x = 5; $x--; $x].AST), 4, 'a postfix -- lowers and mutates';
+is EVAL(Q[my $x = 1; my $y = $x++; $y].AST), 1,
+    'a postfix ++ evaluates to the value before the increment';
+
+# --- prefix increment / decrement (the operator-name table bug) -------------
+is EVAL(Q[my $x = 1; ++$x; $x].AST), 2, 'a prefix ++ lowers and mutates';
+is EVAL(Q[my $x = 5; --$x; $x].AST), 4, 'a prefix -- lowers and mutates';
+is EVAL(Q[my $x = 1; my $y = ++$x; $y].AST), 2,
+    'a prefix ++ evaluates to the value after the increment';
+
+# --- an increment on an element ---------------------------------------------
+is EVAL(Q[my @a = (1, 2); @a[0]++; @a[0]].AST), 2,
+    'a postfix ++ on an array element lowers';
+
+# --- a C-style loop stepping with ++ ----------------------------------------
+is EVAL(Q[my $s = 0; loop (my $i = 0; $i < 3; $i++) { $s = $s + $i }; $s].AST), 3,
+    'a C-style loop whose step is a postfix ++ lowers';
+
+# --- hyper method calls -----------------------------------------------------
+is EVAL(Q[my @a = (-1, -2); (@a>>.abs).join(",")].AST), '1,2',
+    'a hyper method call lowers';
+
+# --- the .? dispatch modifier -----------------------------------------------
+is EVAL(Q[my $x = -5; $x.?abs].AST), 5,
+    'a `.?` call on an existing method lowers and dispatches';
+ok EVAL(Q[my $x = -5; $x.?no-such-method-here].AST) === Nil,
+    'a `.?` call on a missing method lowers and returns Nil';
+
+# --- a quoted method name ---------------------------------------------------
+is EVAL(Q[my $x = -5; $x."abs"()].AST), 5, 'a quoted method name lowers';

--- a/todo/deep/rakuast-remaining.md
+++ b/todo/deep/rakuast-remaining.md
@@ -116,10 +116,15 @@ Still open:
 - The remaining hyper forms: hyper *prefix* (`-<<@a`, desugared to a
   `__mutsu_hyper_prefix` call), hyper *postcircumfix* (`@a>>[1]`, desugared to a
   hyper `AT-POS` method call), and `@a<<.abs` (which mutsu's parser currently
-  reads as a quote-words subscript).
+  reads as a quote-words subscript). Since 2026-09-05 the desugared *call* forms
+  are an explicit `.AST` boundary rather than a node naming a mutsu internal —
+  see [the news entry](../../news/2026-09/rakuast-desugar-marker-boundary.md).
+  The `@a>>[1]` case still renders a hyper `AT-POS` `Call::Method`, which is a
+  wrong node rather than an internal name, so it needs its own measured slice.
 - `with` / `without`. Desugared at parse time into a `__with_tmp_N` temp var plus
   an `if` on `.defined`, so there is no statement to map to
-  `Statement::With` / `Statement::Without`.
+  `Statement::With` / `Statement::Without`. It is an explicit boundary (the temp
+  var's internal name is refused), not a wrong rendering.
 - A reference to a user-declared type by bare name. `class C { }; C.new` reads
   `C` as `Expr::BareWord`, and only *builtin* type names
   (`is_known_type_constraint`) convert to `Type::Simple`, so any program that

--- a/todo/deep/rakuast-remaining.md
+++ b/todo/deep/rakuast-remaining.md
@@ -77,6 +77,13 @@ the parser/internal AST, not guessing during RakuAST conversion.
 
 **Closed 2026-09-05**:
 
+- *Postfix lowering.* `EVAL` lowers the rest of the `ApplyPostfix` cluster:
+  `Postfix` (`$x++`/`$x--`), `MetaPostfix::Hyper` (`@a>>.abs`), a
+  `Call::Method`'s `.?`/`.+`/`.*` dispatch modifier, and `Call::QuotedMethod`.
+  It also fixed a silent no-op: `op_name_to_token_kind` had no `++`/`--` row, so
+  the already-lowering *prefix* `++$x` became `Unary { op: Ident("++") }` and did
+  not increment. Pinned by `t/rakuast-eval-postfix.t`; see
+  [the news entry](../../news/2026-09/rakuast-postfix-lowering.md).
 - *Class / role / method / attribute lowering.* `EVAL` accepts
   `RakuAST::Class`, `RakuAST::Role`, `RakuAST::Method`, and the attribute form
   of `VarDeclaration::Simple` (`scope => "has"`), lowering them to


### PR DESCRIPTION
Two RakuAST fidelity fixes, one per direction. Both are correctness fixes
rather than new coverage: each removes a case where mutsu produced something
*wrong* rather than saying it could not.

## 1. Read: stop rendering mutsu's internal desugaring markers

mutsu desugars a handful of constructs in the parser into calls to internal
routines, or into temporaries with internal names, and the converter rendered
those names verbatim:

```
$ mutsu -e 'my @a; say Q[-<<@a].AST'
...
    expression => RakuAST::Call::Name.new(
      name => RakuAST::Name.from-identifier("__mutsu_hyper_prefix"),
```

raku keeps every one of these constructs as a dedicated node (`-<<@a` is a
hyper *prefix*, not a call) and has no such name anywhere, so the rendered tree
was not merely incomplete — it was wrong, and would not survive comparison with
the reference implementation.

`src/rakuast/convert.rs` now refuses a routine or variable name that is one of
mutsu's internal markers (`__mutsu_*`, `__with_tmp_N`, `@__destructure_tmp__`,
…) and reports it as a coverage boundary. This is the rule the rest of the
converter already follows, and the one `docs/rakuast/README.md` states outright:
*if the parser/internal AST has already erased a distinction, do not guess it
inside RakuAST conversion.* Nothing here asserts what the right node would be —
that needs measuring against raku first, and the underlying constructs (hyper
prefix, `with`/`without`, list assignment, …) stay on the read-direction gap
list.

Only names mutsu itself plants are affected. The whole `t/rakuast*.t` suite
passes unchanged: no previously-correct rendering was lost, because these names
never had a correct rendering.

## 2. Write: the rest of the `ApplyPostfix` cluster

`EVAL` handled only three of the postfix forms the read direction renders —
`Call::Method` (with no dispatch modifier), `Call::Term`, and
`Postcircumfix::ArrayIndex`. The rest read fine and then failed with
`EVAL does not yet support lowering RakuAST::ApplyPostfix`. Now covered:

- `Postfix(operator => "++" / "--")` → `Expr::PostfixOp`. Unlike `Infix` and
  `Prefix`, a `Postfix` carries its operator in a *named* `operator` field, so
  it needs its own reader.
- `MetaPostfix::Hyper(Call::Method)` → `Expr::HyperMethodCall`.
- `Call::Method`'s `dispatch` field → the `.?` / `.+` / `.*` modifier. It was
  being dropped, so `EVAL(Q[my $x = -5; $x.?no-such].AST)` threw
  `No such method` where the source form returns `Nil`.
- `Call::QuotedMethod` → a method call with a quoted name.

### The bug underneath

Adding the postfix operators surfaced a real defect in a shared table.
`op_name_to_token_kind` had no row for `++` or `--`, so both fell through to its
`Ident` catch-all. A *prefix* increment already lowered — `++$x` renders as
`ApplyPrefix(Prefix("++"))` and reached `Expr::Unary` — but with
`op: Ident("++")`, which the compiler does not treat as an increment. It
compiled to something that quietly produced `Any`:

```
$ mutsu -e 'use MONKEY-SEE-NO-EVAL; EVAL(Q[my $x = 1; ++$x; say $x].AST)'
1     # before
2     # after
```

No error, no boundary message — the increment simply did not happen. The table
is used only by the RakuAST lowerer, so the two added rows change nothing else.

## Tests

- `t/rakuast-eval-postfix.t` (12 assertions) pins postfix and prefix `++`/`--`
  including their differing result values, an increment on an array element, a
  C-style loop whose step is `$i++`, hyper method calls, `.?` on both a present
  and a missing method, and a quoted method name. Dual-oracle: it passes
  verbatim under both mutsu and raku.
- `t/rakuast-desugar-boundary.t` (6 assertions) pins three constructs as
  boundaries and three neighbouring constructs as still rendering. It is
  deliberately **mutsu-only** — it asserts mutsu's boundary behaviour, which has
  no raku counterpart — so unlike the rest of the suite it is not a dual-oracle
  file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TtL4NKUC5rVfjD6mFDpqh9

---
_Generated by [Claude Code](https://claude.ai/code/session_01TtL4NKUC5rVfjD6mFDpqh9)_