### PR TITLE
feat(rakuast): reduction/arity-0 lowering, and consistent type-object introspection

### DIFF
--- a/news/2026-09/rakuast-reduce-and-arity-0-pointy-lowering.md
+++ b/news/2026-09/rakuast-reduce-and-arity-0-pointy-lowering.md
@@ -1,0 +1,36 @@
+# RakuAST reduction and arity-0 pointy-block lowering
+
+Two more write-direction gaps closed. Both constructs have been readable for a
+while and simply had no lowering, so `EVAL` refused a tree the converter had
+just produced.
+
+- **`RakuAST::Term::Reduce`** — `[+] @a` and the triangle form `[\+] @a`.
+  mutsu's `Expr::Reduction` keeps the triangle marker inside the operator string
+  itself (a leading backslash), which is how the converter reads it back out
+  into the `triangle` field, so the lowerer puts it back the same way.
+- **A zero-parameter `RakuAST::PointyBlock`** — `-> { … }`. The
+  single-parameter form lowered to `Expr::Lambda` and the multi-parameter form
+  to `Expr::AnonSubParams`; the arity-0 form was left as an explicit boundary
+  even though the parser builds exactly the same `AnonSubParams` node with an
+  empty parameter list. It now takes the same path, so the lowered closure keeps
+  arity 0 — unlike a bare block, `-> { … }` rejects arguments.
+
+## Coverage
+
+`t/rakuast-eval-reduce-pointy.t` (10 assertions) pins `[+]`, `[*]`, `[~]`, a
+reduction over a literal list, the triangle form's running results, an arity-0
+pointy block's call and `.arity`, and the neighbouring single-parameter,
+two-parameter and bare-block forms. It is a dual-oracle test: it passes verbatim
+under both mutsu and raku.
+
+## A parser bug found while writing it
+
+`Q[[+] 1, 2, 3]` does not mean what it says: a bracketing quote whose content
+*starts* with the same opening bracket loses that bracket and its match, so
+`Q[[1]]` yields `1` rather than `[1]` and `Q[[1] 2]` fails to compile. Anything
+before the nested bracket is handled correctly (`Q[x[1]]` is fine), so it is a
+leading-nested-delimiter bug in the bracketing-quote scanner, not a nesting bug
+in general. It matters here because `Q[...]` is the idiomatic way to hand a
+program to `.AST`, and a *silently different* program is worse than an error in
+a dual-oracle test. The affected assertions use `Q{...}`, and the bug is filed
+as `todo/tickets/q-bracket-leading-nested-delimiter.md`.

--- a/news/2026-09/rakuast-type-object-lookup-and-methods.md
+++ b/news/2026-09/rakuast-type-object-lookup-and-methods.md
@@ -1,0 +1,45 @@
+# RakuAST type-object `.^methods` and `.^lookup`
+
+Four metaobject operations on a RakuAST model class disagreed with each other.
+`.^methods(:local)`, `.^can` and `.^method_table` all answered from the model
+metadata and found `RakuAST::IntLiteral`'s `value` accessor; `.^methods` (the
+default, no adverb) returned `()` and `.^lookup("value")` returned `(Mu)`.
+
+RakuAST model classes are native type objects with no entry in mutsu's class
+registry, so each metaobject operation has to consult that metadata explicitly
+or fall through to an empty registry answer. Two of them never did.
+
+## Change
+
+`src/rakuast/mod.rs` gained `inherited_method_names`, the MRO-walking companion
+to `local_method_names`: it unions the model methods of a class and its model
+ancestors, dropping the `Any`/`Mu` tail. Today the abstract RakuAST classes
+(`Node`, `Expression`, `Term`, `Statement`) declare no model methods of their
+own, so the result equals the local set — but it is the rule
+`Type/Metamodel/MethodContainer.rakudoc` specifies, and it stays correct as that
+metadata grows.
+
+Three call sites now use it:
+
+- `.^methods` with no adverb returns the inherited set. `:local` keeps the
+  narrower `local_method_names` answer, and `:all` seeds the model names and
+  then falls through to the ordinary built-in list, so the Any/Mu tail is added
+  on top rather than replacing the model methods.
+- `.^lookup($name)` returns the `Method` object when the name is in that set and
+  `(Mu)` otherwise, matching the documented "first matching Method along the
+  MRO, else `(Mu)`".
+- `.^can` moves from the class's own names to the inherited set, so an
+  inherited model method is found, exactly as `.^can` on an ordinary class
+  spans its MRO.
+
+## Coverage
+
+`t/rakuast-type-lookup.t` (11 assertions) pins all three adverb cases of
+`.^methods`, `.^lookup` on a present and a missing method (including that it
+returns a `Method`), `.^can` agreeing with both, and the three staying in
+lockstep on a second class.
+
+It is deliberately mutsu-only rather than dual-oracle: the method *names* are
+mutsu's own model API — `local_method_names` documents them as describing
+mutsu's implemented model rather than Rakudo's compiler-internal `IMPL-*`
+surface — so a raku run would legitimately report a different set.

--- a/src/rakuast/lower.rs
+++ b/src/rakuast/lower.rs
@@ -896,13 +896,14 @@ fn lower_expr(node: &RakuAstNode) -> Result<Expr, RuntimeError> {
             })
         }
         // A pointy block in expression position (`-> $x { … }`) is a closure. A
-        // single parameter lowers to `Expr::Lambda`; several to `AnonSubParams`. A
-        // zero-parameter block stays the boundary.
+        // single parameter lowers to `Expr::Lambda`; zero or several to
+        // `AnonSubParams` — which is exactly what the parser builds for
+        // `-> { … }`, an arity-0 closure that (unlike a bare block) rejects
+        // arguments.
         RakuAstClass::PointyBlock => {
             let (params, param_defs) = signature_positional_params(node)?;
             let body = lower_block(node)?;
             match params.len() {
-                0 => Err(unsupported(node)),
                 1 => Ok(Expr::Lambda {
                     param: params.into_iter().next().unwrap(),
                     body,
@@ -938,6 +939,33 @@ fn lower_expr(node: &RakuAstNode) -> Result<Expr, RuntimeError> {
                 other => vec![other],
             };
             Ok(Expr::BracketArray(items, false))
+        }
+        // `[+] @a` / `[\\+] @a` -> a reduction over a single argument. mutsu's
+        // `Expr::Reduction` keeps the triangle form in the operator string
+        // itself (a leading backslash), which is how the converter reads it
+        // back out into the `triangle` field.
+        RakuAstClass::TermReduce => {
+            let infix = named_child(node, "infix")?;
+            if infix.class != RakuAstClass::Infix {
+                return Err(unsupported(node));
+            }
+            let infix_value = positional_leaf(infix)?;
+            let op = match infix_value.view() {
+                ValueView::Str(s) => s.to_string(),
+                _ => return Err(unsupported(node)),
+            };
+            let triangle = bool_field(node, "triangle")?;
+            let args = named_child(node, "args")?;
+            // A reduction takes exactly one argument expression (a list, an
+            // array variable, ...); the converter never builds more.
+            let [only] = args.fields.as_slice() else {
+                return Err(unsupported(node));
+            };
+            let op = op.to_string();
+            Ok(Expr::Reduction {
+                op: if triangle { format!("\\{op}") } else { op },
+                expr: Box::new(lower_expr(child_node(&only.value)?)?),
+            })
         }
         // The `*` whatever term.
         RakuAstClass::TermWhatever => Ok(Expr::Whatever),

--- a/src/rakuast/mod.rs
+++ b/src/rakuast/mod.rs
@@ -1062,6 +1062,29 @@ pub fn local_method_names(class_name: &str) -> Option<Vec<&'static str>> {
     Some(names)
 }
 
+/// The public methods a RakuAST model class exposes *including* the ones it
+/// inherits, for `.^methods` (whose default, per
+/// `Type/Metamodel/MethodContainer.rakudoc`, is "methods of the class and its
+/// parents, stopping at Cool/Any/Mu" — `:local` is the narrower set
+/// [`local_method_names`] returns). Walks the model MRO and drops the `Any` /
+/// `Mu` tail, so the result grows automatically as the abstract RakuAST classes
+/// gain model methods of their own.
+pub fn inherited_method_names(class_name: &str) -> Option<Vec<&'static str>> {
+    let mro = type_object_mro(class_name)?;
+    let mut names = Vec::new();
+    for cls in &mro {
+        if cls == "Any" || cls == "Mu" {
+            break;
+        }
+        if let Some(local) = local_method_names(cls) {
+            names.extend(local);
+        }
+    }
+    names.sort_unstable();
+    names.dedup();
+    Some(names)
+}
+
 /// Model fields declared directly by a RakuAST class, for `.^attributes(:local)`.
 ///
 /// As with [`local_method_names`], these are mutsu's public model fields rather

--- a/src/runtime/methods_classhow_builtin_methods.rs
+++ b/src/runtime/methods_classhow_builtin_methods.rs
@@ -34,11 +34,25 @@ impl Interpreter {
 
         // RakuAST model classes are native type objects rather than entries in
         // the user-class registry.  Expose the constructors/accessors that the
-        // model layer really implements so `.^methods(:local)` is useful (and
-        // does not fall through to an empty built-in method list).
+        // model layer really implements so `.^methods` is useful (and does not
+        // fall through to an empty built-in method list).
+        //
+        // `Type/Metamodel/MethodContainer.rakudoc`: the default is the methods
+        // of the class *and its parents*, stopping at Cool/Any/Mu; `:local` is
+        // only what the class itself declares; `:all` adds the Any/Mu tail on
+        // top of both. The model MRO supplies the first two, and `:all` falls
+        // through to the ordinary built-in list below after seeding the model
+        // names — otherwise `RakuAST::IntLiteral.^methods` was empty even
+        // though `.^methods(:local)` and `.^can("value")` both found `value`.
         if local && let Some(names) = crate::rakuast::local_method_names(&class_name) {
             self.push_native_method_objects(&names, &class_name, &mut result);
             return Ok(Value::array(result));
+        }
+        if let Some(names) = crate::rakuast::inherited_method_names(&class_name) {
+            self.push_native_method_objects(&names, &class_name, &mut result);
+            if !all {
+                return Ok(Value::array(result));
+            }
         }
 
         // Extract mixin role names from the invocant for runtime role method collection

--- a/src/runtime/methods_classhow_lookup.rs
+++ b/src/runtime/methods_classhow_lookup.rs
@@ -37,6 +37,20 @@ impl Interpreter {
                 (Symbol::intern(&type_name), type_name)
             }
         };
+        // RakuAST model classes are native type objects with no registry entry,
+        // so the MRO walk below finds nothing for them. Answer from the same
+        // model metadata `.^methods` and `.^can` use, keeping the three in
+        // lockstep — `RakuAST::IntLiteral.^lookup("value")` returned `(Mu)`
+        // while `.^can("value")` found it.
+        if let Some(names) = crate::rakuast::inherited_method_names(&class_name_str) {
+            return names.contains(&method_name).then(|| {
+                Value::routine_parts(
+                    Symbol::intern(&class_name_str),
+                    Symbol::intern(method_name),
+                    false,
+                )
+            });
+        }
         // Check user-defined class methods first, walking the receiver's full
         // MRO rather than only its own class — `B.^lookup('foo')` must find a
         // `foo` declared only on an ancestor `A` (`class B is A {}`), exactly

--- a/src/runtime/methods_classhow_method_obj.rs
+++ b/src/runtime/methods_classhow_method_obj.rs
@@ -640,9 +640,11 @@ impl Interpreter {
             _ => self.mop_receiver_owner(target),
         };
         // RakuAST model classes are native type objects rather than ordinary
-        // ClassDef entries. Keep `.^can` in lockstep with `.^methods(:local)`
-        // and `.^method_table` by consulting their shared model metadata.
-        if let Some(names) = crate::rakuast::local_method_names(&class_name) {
+        // ClassDef entries. Keep `.^can` in lockstep with `.^methods` and
+        // `.^method_table` by consulting their shared model metadata. Like an
+        // ordinary `.^can` this spans the whole MRO, not just the receiver's
+        // own class, so an inherited model method is found too.
+        if let Some(names) = crate::rakuast::inherited_method_names(&class_name) {
             return if names.contains(&method_name) {
                 vec![Value::routine_parts(
                     Symbol::intern(&class_name),

--- a/t/rakuast-eval-reduce-pointy.t
+++ b/t/rakuast-eval-reduce-pointy.t
@@ -1,0 +1,48 @@
+use v6;
+use MONKEY-SEE-NO-EVAL;
+use experimental :rakuast;
+use Test;
+
+# Two more write-direction gaps closed (ADR-0011): both constructs have been
+# readable for a while and simply had no lowering.
+#
+#   * `RakuAST::Term::Reduce`  — `[+] @a` and the triangle form `[\+] @a`.
+#     mutsu's `Expr::Reduction` keeps the triangle marker in the operator string
+#     itself (a leading backslash), which is how the converter reads it back out
+#     into the `triangle` field, so the lowerer puts it back the same way.
+#   * a zero-parameter `RakuAST::PointyBlock` — `-> { … }`. The single-parameter
+#     form lowers to `Expr::Lambda` and the multi-parameter form to
+#     `Expr::AnonSubParams`; the arity-0 form was left as a boundary even though
+#     the parser builds exactly the same `AnonSubParams` node with an empty
+#     parameter list.
+#
+# Passes under BOTH mutsu and raku.
+
+plan 10;
+
+# --- reductions -------------------------------------------------------------
+is EVAL(Q{my @a = 1, 2, 3; [+] @a}.AST), 6, 'a `[+]` reduction lowers';
+is EVAL(Q{my @a = 2, 3, 4; [*] @a}.AST), 24, 'a `[*]` reduction lowers';
+is EVAL(Q{my @a = 1, 2; [~] @a}.AST), '12', 'a `[~]` reduction lowers';
+# (`Q{...}` rather than `Q[...]`: mutsu currently mis-lexes a bracketing quote
+# whose content starts with the same bracket — see
+# todo/tickets/q-bracket-leading-nested-delimiter.md.)
+is EVAL(Q{[+] 1, 2, 3}.AST), 6, 'a reduction over a literal list lowers';
+
+# --- the triangle form ------------------------------------------------------
+is EVAL(Q{my @a = 1, 2, 3; ([\+] @a).join(",")}.AST), '1,3,6',
+    'a triangle reduction lowers and keeps its running results';
+
+# --- zero-parameter pointy blocks -------------------------------------------
+is EVAL(Q[my $f = -> { 42 }; $f()].AST), 42,
+    'a zero-parameter pointy block lowers and can be called';
+is EVAL(Q[my $f = -> { 42 }; $f.arity].AST), 0,
+    'a lowered zero-parameter pointy block has arity 0';
+
+# --- the neighbouring forms still lower -------------------------------------
+is EVAL(Q[my $f = -> $x { $x * 2 }; $f(4)].AST), 8,
+    'a single-parameter pointy block still lowers';
+is EVAL(Q[my $f = -> $a, $b { $a + $b }; $f(1, 2)].AST), 3,
+    'a two-parameter pointy block still lowers';
+is EVAL(Q[my $f = { 42 }; $f()].AST), 42,
+    'a bare block still lowers';

--- a/t/rakuast-type-lookup.t
+++ b/t/rakuast-type-lookup.t
@@ -1,0 +1,55 @@
+use v6;
+use experimental :rakuast;
+use Test;
+
+# RakuAST type-object introspection: `.^methods` (no adverb), `.^lookup`, and
+# `.^can` now answer from the same model metadata, over the model MRO.
+#
+# RakuAST model classes are native type objects with no entry in mutsu's class
+# registry, so each metaobject operation has to consult that metadata
+# explicitly. `.^methods(:local)`, `.^can` and `.^method_table` did;
+# `.^methods` (the default) and `.^lookup` did not, and answered `()` and
+# `(Mu)` for a method the other three could see.
+#
+# `Type/Metamodel/MethodContainer.rakudoc` fixes the three adverb cases:
+#   * default  -- the class and its parents, stopping at Cool/Any/Mu
+#   * :local   -- only what the class declares itself
+#   * :all     -- everything, including the Any/Mu tail
+# and `.^lookup` returns the Method object found along the MRO, or `(Mu)`.
+#
+# This file is mutsu-only: the method *names* are mutsu's own model API
+# (`local_method_names` documents them as such), not Rakudo's compiler-internal
+# `IMPL-*` surface, so a raku run would legitimately report a different set.
+
+plan 11;
+
+# --- .^methods (default) sees the class's own model methods ------------------
+my @m = RakuAST::IntLiteral.^methods.map(*.name).sort;
+is @m, <new value>, '.^methods lists the model constructor and accessor';
+
+# --- .^methods(:local) agrees for a leaf class ------------------------------
+is RakuAST::IntLiteral.^methods(:local).map(*.name).sort, @m,
+    '.^methods(:local) agrees with the default for a leaf model class';
+
+# --- :all adds the Any/Mu tail on top ---------------------------------------
+my @all = RakuAST::IntLiteral.^methods(:all).map(*.name);
+ok @all.elems > @m.elems, '.^methods(:all) is a superset of the default';
+ok @all.grep('value'), '.^methods(:all) still contains the model accessor';
+
+# --- .^lookup finds the same methods ----------------------------------------
+is RakuAST::IntLiteral.^lookup('value').name, 'value',
+    '.^lookup finds a model accessor';
+is RakuAST::IntLiteral.^lookup('value').^name, 'Method',
+    '.^lookup returns a Method object';
+is RakuAST::IntLiteral.^lookup('no-such-method').gist, '(Mu)',
+    '.^lookup returns (Mu) for a missing method';
+
+# --- .^can agrees ------------------------------------------------------------
+ok RakuAST::IntLiteral.^can('value'), '.^can finds a model accessor';
+nok RakuAST::IntLiteral.^can('no-such-method'), '.^can rejects a missing method';
+
+# --- the three stay in lockstep on another class -----------------------------
+ok RakuAST::Sub.^methods.map(*.name).grep('body'),
+    '.^methods sees a Sub model accessor';
+is RakuAST::Sub.^lookup('body').name, 'body',
+    '.^lookup sees the same Sub model accessor';

--- a/todo/deep/rakuast-remaining.md
+++ b/todo/deep/rakuast-remaining.md
@@ -77,6 +77,13 @@ the parser/internal AST, not guessing during RakuAST conversion.
 
 **Closed 2026-09-05**:
 
+- *Reduction and arity-0 pointy-block lowering.* `EVAL` lowers
+  `RakuAST::Term::Reduce` (`[+] @a` and the triangle `[\+] @a`, whose marker
+  mutsu keeps inside the operator string) and a zero-parameter
+  `RakuAST::PointyBlock` (`-> { … }`, the same `AnonSubParams` node the parser
+  builds, so the lowered closure keeps arity 0). Pinned by
+  `t/rakuast-eval-reduce-pointy.t`; see
+  [the news entry](../../news/2026-09/rakuast-reduce-and-arity-0-pointy-lowering.md).
 - *Postfix lowering.* `EVAL` lowers the rest of the `ApplyPostfix` cluster:
   `Postfix` (`$x++`/`$x--`), `MetaPostfix::Hyper` (`@a>>.abs`), a
   `Call::Method`'s `.?`/`.+`/`.*` dispatch modifier, and `Call::QuotedMethod`.

--- a/todo/deep/rakuast-remaining.md
+++ b/todo/deep/rakuast-remaining.md
@@ -165,6 +165,13 @@ The RakuAST type registry supports the common hierarchy, method, attribute, and
 `.^can` operations. Audit and implement the remaining metaobject operations from
 the same model metadata. Do not expose Rakudo compiler-private `IMPL-*` details.
 
+**Closed 2026-09-05:** `.^methods` (with no adverb) and `.^lookup` answered `()`
+and `(Mu)` for a method `.^methods(:local)`, `.^can` and `.^method_table` could
+all see. All four now read the model metadata through one MRO-walking helper,
+with the three `.^methods` adverb cases following
+`Type/Metamodel/MethodContainer.rakudoc`. Pinned by `t/rakuast-type-lookup.t`;
+see [the news entry](../../news/2026-09/rakuast-type-object-lookup-and-methods.md).
+
 ## Construction
 
 Advanced parameter construction remains:

--- a/todo/tickets/q-bracket-leading-nested-delimiter.md
+++ b/todo/tickets/q-bracket-leading-nested-delimiter.md
@@ -1,0 +1,49 @@
+# `Q[[...]]` drops the leading nested bracket
+
+A bracketing quote whose content *starts* with the same opening bracket loses
+that bracket and its match:
+
+```
+$ mutsu -e 'say Q[[1]]'
+1                       # raku: [1]
+$ mutsu -e 'say Q[[1] 2]'
+===SORRY!=== Error while compiling -e
+```
+
+The same content with anything before the nested bracket is fine, so nesting
+itself works — only a *leading* nested delimiter is mishandled:
+
+```
+$ mutsu -e 'say Q[x[1]]'
+x[1]                    # correct
+```
+
+`q[[1]]` and `Q<<1>>` show it too, so it is the bracketing-quote delimiter
+scanner rather than anything specific to `Q`.
+
+## Why it matters
+
+Beyond the obvious string bug, this is a papercut in RakuAST work, where
+`Q[...]` is the idiomatic way to hand a program to `.AST`. `Q[[+] 1, 2, 3].AST`
+silently parses a *different program* than the one written — it was first hit
+while testing reduction lowering, where the workaround was to switch the test to
+`Q{[+] 1, 2, 3}`. A silently-wrong parse is worse than an error here, because a
+dual-oracle test written that way compares two different programs.
+
+## Where to look
+
+The bracketing-quote scanner that finds the closing delimiter and counts nested
+pairs — `src/parser/` quote handling. A plausible shape for the bug is that the
+scanner consumes the opening delimiter, then treats the immediately-following
+identical character as the *closing* one (or as a second opening delimiter for
+the outer quote) instead of starting the nesting count at the first content
+character.
+
+## Minimal repro
+
+```
+say Q[[1]];      # expected: [1]      got: 1
+say Q[[1] 2];    # expected: [1] 2    got: a compile error
+say q[[1]];      # expected: [1]      got: 1
+say Q[x[1]];     # expected: x[1]     got: x[1]  (correct)
+```


### PR DESCRIPTION
Two more RakuAST slices.

## 1. Lower reductions and arity-0 pointy blocks

Both constructs have been readable for a while and simply had no lowering, so
`EVAL` refused a tree the converter had just produced.

- **`RakuAST::Term::Reduce` → `Expr::Reduction`** — `[+] @a` and the triangle
  form `[\+] @a`. mutsu keeps the triangle marker inside the operator string
  itself (a leading backslash), which is how the converter reads it back out
  into the `triangle` field, so the lowerer puts it back the same way.
- **A zero-parameter `RakuAST::PointyBlock` → `Expr::AnonSubParams`** with an
  empty parameter list. The single-parameter form lowered to `Expr::Lambda` and
  the multi-parameter form to `AnonSubParams`; the arity-0 form was left as an
  explicit boundary even though the parser builds exactly that node. It now
  takes the same path, so the lowered closure keeps arity 0 — unlike a bare
  block, `-> { … }` rejects arguments.

## 2. `.^methods` and `.^lookup` on a RakuAST type object

Four metaobject operations on a RakuAST model class disagreed with each other.
`.^methods(:local)`, `.^can` and `.^method_table` all answered from the model
metadata and found `RakuAST::IntLiteral`'s `value` accessor; `.^methods` (the
default, no adverb) returned `()` and `.^lookup("value")` returned `(Mu)`.

RakuAST model classes are native type objects with no entry in mutsu's class
registry, so each metaobject operation has to consult that metadata explicitly
or fall through to an empty registry answer. Two of them never did.

`src/rakuast/mod.rs` gained `inherited_method_names`, the MRO-walking companion
to `local_method_names`. Today the abstract RakuAST classes declare no model
methods of their own, so its result equals the local set — but it is the rule
`Type/Metamodel/MethodContainer.rakudoc` specifies, and it stays correct as that
metadata grows.

- `.^methods` with no adverb returns the inherited set. `:local` keeps the
  narrower answer, and `:all` seeds the model names and then falls through to
  the ordinary built-in list, so the Any/Mu tail is added on top rather than
  replacing the model methods.
- `.^lookup($name)` returns the `Method` object when the name is in that set and
  `(Mu)` otherwise, matching the documented "first matching Method along the
  MRO, else `(Mu)`".
- `.^can` moves from the class's own names to the inherited set, so an inherited
  model method is found, exactly as `.^can` on an ordinary class spans its MRO.

## A parser bug found on the way (filed, not fixed)

`Q[[+] 1, 2, 3]` does not mean what it says. A bracketing quote whose content
*starts* with the same opening bracket loses that bracket and its match, so
`Q[[1]]` yields `1` rather than `[1]` and `Q[[1] 2]` fails to compile. Anything
before the nested bracket is handled correctly (`Q[x[1]]` is fine), so it is a
leading-nested-delimiter bug in the bracketing-quote scanner, not a nesting bug
in general.

It matters for this campaign because `Q[...]` is the idiomatic way to hand a
program to `.AST`, and a *silently different* program is worse than an error in
a dual-oracle test. The affected assertions use `Q{...}`, and the bug is filed
as `todo/tickets/q-bracket-leading-nested-delimiter.md`.

## Tests

- `t/rakuast-eval-reduce-pointy.t` (10 assertions) — `[+]`, `[*]`, `[~]`, a
  reduction over a literal list, the triangle form's running results, an arity-0
  pointy block's call and `.arity`, and the neighbouring single-parameter,
  two-parameter and bare-block forms. Dual-oracle: passes verbatim under both
  mutsu and raku.
- `t/rakuast-type-lookup.t` (11 assertions) — all three `.^methods` adverb
  cases, `.^lookup` on a present and a missing method (including that it returns
  a `Method`), `.^can` agreeing with both, and the three staying in lockstep on
  a second class. Deliberately **mutsu-only** rather than dual-oracle: the method
  *names* are mutsu's own model API (`local_method_names` documents them as
  such, not Rakudo's compiler-internal `IMPL-*` surface), so a raku run would
  legitimately report a different set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TtL4NKUC5rVfjD6mFDpqh9

---
_Generated by [Claude Code](https://claude.ai/code/session_01TtL4NKUC5rVfjD6mFDpqh9)_