### PR TITLE
feat(rakuast): EVAL a WhateverCode tree (ADR-0033 Phase 3)

### DIFF
--- a/docs/adr/0033-whatever-priming-leaf-and-derived-scope.md
+++ b/docs/adr/0033-whatever-priming-leaf-and-derived-scope.md
@@ -7,8 +7,8 @@
   `todo/tickets/chained-compare-ast-node.md` **shipped 2026-08-26** (see `news/2026-08/
   chained-compare-ast-node.md`): `TokenKind::ChainAnd` is retired now that a real AST node
   exists, and `.AST` renders a chain as rakudo's left-nested `ApplyInfix` instead of the
-  expanded `&&`/`DoBlock` shape. Phase 3 (RakuAST write / `EVAL`) not started; it has no
-  roast or correctness payoff of its own and was deliberately left until after Phase 4.
+  expanded `&&`/`DoBlock` shape. **Phase 3 shipped 2026-09-05 (see "Phase 3 outcome"
+  below)**, so every phase of this ADR is now complete.
 - **Scope**: Owns the `WhateverCode` item of
   [`todo/deep/rakuast-remaining.md`](../../todo/deep/rakuast-remaining.md) — both its
   read-direction half ("`* + 1` has no `.AST`") and its lowering half ("`EVAL` of a
@@ -643,6 +643,62 @@ unit tests plus every integration binary) green; `cargo clippy -- -D warnings` c
 whitelisted `roast/S02-*`, `roast/S03-*` and `roast/S04-*` sweep (345 files) green, with
 `roast/S02-types/{whatever,hyperwhatever}.t`, `roast/S03-operators/composition.t`,
 `short-circuit.t` and `ternary.t` checked individually first.
+
+## Phase 3 outcome (2026-09-05)
+
+`EVAL` of a `WhateverCode` tree works. `RakuAST::WhateverCode::Argument` lowers to
+`Expr::WhateverArg`, and — the part that made this more than a missing match arm — the
+priming *scope* is now planted for a lowered tree by the same authority that plants it
+for a parsed one.
+
+### The asymmetry section 6 predicted, and what closing it actually took
+
+Section 6 called it exactly: the converter *refused* a WhateverCode while the lowerer
+emitted a bare leaf and never re-ran the currying transform, so a round trip would have
+come back uncurried. What section 6 did not say is *how* to re-derive the scope, and
+that turned out to be the whole of the work.
+
+The parser plants its scopes at ~29 grammar positions. Those positions carry context
+`should_wrap_whatevercode` alone does not have, so neither of the two obvious
+reimplementations works:
+
+- **Bottom-up** (wrap each qualifying subexpression as `lower_expr` returns it) gives
+  *minimal* scopes. `*.abs + 1` becomes `WhateverCurry(WhateverCurry(*.abs) + 1)` — an
+  inner closure added to `1` — where the parser produces one scope over the whole sum.
+- **Top-down over `should_wrap_whatevercode` alone** gives maximal scopes correctly
+  almost everywhere, because `contains_whatever` is deliberately *not* transparent
+  through a call argument, a method-call argument, or a thunk barrier. That is what makes
+  `@a.first(* > 1)` plant one scope around the argument and none around the method call,
+  with no special case needed.
+
+So the implementation is the second, run as a mode of the walk that already exists.
+`whatever_curry::mark`'s post-parse walk reaches every expression slot top-down and
+already calls `plant_here` before recursing; in the new mode `plant_here` also
+materialises a scope around the node itself, so the *first* node that primes gets the
+marker. `rakuast::lower` turns the mode on for its single `mark_program` call; the parser
+path never sets it and is unchanged by construction.
+
+Two adjustments were needed, both found by differential testing rather than by reading:
+
+- **A marker's body must not be re-planted.** `mark_expr` recurses into a
+  `WhateverCurry`'s body, which is still an expression that primes, so it was wrapped
+  again — and again. `plant_here` split into a scope half and a barrier half, and the
+  marker-body recursion now runs only the barrier half.
+- **An invocation is never itself a scope.** `should_wrap_whatevercode` answers `true`
+  for a `CallOn` with a compound target only because the parser never asks it — it wraps
+  the *target* at a dedicated site instead. Wrapping the whole `CallOn` made
+  `(* + 1)(4)` evaluate to the closure instead of calling it. `plant_all_scopes` skips
+  `CallOn`, and the recursion plants the target.
+
+### Validation
+
+The oracle for this phase is mutsu against itself: for a snippet `S`, running `S`
+directly must produce exactly what `EVAL(Q{S}.AST)` produces. That comparison found both
+adjustments above and now agrees across the priming corpus — the canonical `.map(* + 1)`
+/ `.grep(* > 3)` / `@a[* - 1]` forms, maximal-scope compounds, immediate invocation,
+multi-`*` arity, the Phase 4 barrier cases, and the value-position `*` forms that must
+NOT curry. `t/rakuast-eval-whatever-code.t` (18 assertions) pins that corpus and passes
+verbatim under both mutsu and raku.
 
 ## Phase 2 detailed design (added 2026-08-20)
 

--- a/news/2026-09/rakuast-whatever-code-eval.md
+++ b/news/2026-09/rakuast-whatever-code-eval.md
@@ -1,0 +1,62 @@
+# EVAL of a WhateverCode tree (ADR-0033 Phase 3)
+
+`EVAL(Q{(1..5).map(* + 1)}.AST)` works. This was the last open phase of
+[ADR-0033](../../docs/adr/0033-whatever-priming-leaf-and-derived-scope.md), and
+it closes the `WhateverCode` item of `todo/deep/rakuast-remaining.md`: Phase 2
+gave `* + 1` a `.AST`, but the write direction refused the tree it produced, so
+the highest-frequency construct in real Raku code — `.map(* + 1)`,
+`.grep(* > 3)`, `@a[* - 1]` — could be read and never lowered.
+
+## Why it was not just a missing match arm
+
+`RakuAST::WhateverCode::Argument` → `Expr::WhateverArg` is one line. The work
+was the priming *scope*.
+
+mutsu's parser plants a `WhateverCurry` marker at ~29 grammar positions; a tree
+lowered from RakuAST has no parser behind it and therefore no scopes at all.
+Re-deriving them is not a matter of applying the parser's predicate wherever it
+says yes:
+
+- **Bottom-up** — wrapping each qualifying subexpression as `lower_expr` returns
+  it — gives *minimal* scopes. `*.abs + 1` becomes
+  `WhateverCurry(WhateverCurry(*.abs) + 1)`, an inner closure added to `1`,
+  where the parser produces one scope over the whole sum.
+- **Top-down** gives maximal scopes correctly almost everywhere, because
+  `contains_whatever` is deliberately *not* transparent through a call argument,
+  a method-call argument, or a thunk barrier. That is what makes
+  `@a.first(* > 1)` plant one scope around the argument and none around the
+  method call, with no special case needed.
+
+So the implementation is the second, run as a mode of the walk that already
+exists. `whatever_curry::mark`'s post-parse walk reaches every expression slot
+top-down and already calls `plant_here` before recursing; in the new mode
+`plant_here` also materialises a scope around the node itself, so the *first*
+node that primes gets the marker. `rakuast::lower` turns the mode on for its
+single `mark_program` call. The parser path never sets it and is unchanged by
+construction — which is the whole reason the mode exists rather than a change to
+the default rule.
+
+## Two adjustments, both found by differential testing
+
+- **A marker's body must not be re-planted.** `mark_expr` recurses into a
+  `WhateverCurry`'s body, which is still an expression that primes, so it was
+  wrapped again — and again, until the stack overflowed. `plant_here` split into
+  a scope half and a barrier half, and the marker-body recursion now runs only
+  the barrier half.
+- **An invocation is never itself a scope.** `should_wrap_whatevercode` answers
+  `true` for a `CallOn` with a compound target only because the parser never
+  asks it — the parser wraps the *target* at a dedicated site instead. Wrapping
+  the whole `CallOn` made `(* + 1)(4)` evaluate to the closure instead of
+  calling it.
+
+## The oracle
+
+mutsu against itself: for a snippet `S`, running `S` directly must produce
+exactly what `EVAL(Q{S}.AST)` produces. That comparison found both adjustments
+above, and it now agrees across the priming corpus.
+
+`t/rakuast-eval-whatever-code.t` (18 assertions) pins that corpus — the
+canonical `.map` / `.grep` / subscript forms, maximal-scope compounds, immediate
+invocation, multi-`*` arity, the Phase 4 thunk-barrier cases, and the
+value-position `*` forms that must NOT curry. It is a dual-oracle test: it
+passes verbatim under both mutsu and raku.

--- a/src/rakuast/lower.rs
+++ b/src/rakuast/lower.rs
@@ -21,6 +21,21 @@ fn unsupported(node: &RakuAstNode) -> RuntimeError {
 /// (e.g. `EVAL(RakuAST::IntLiteral.new(42))`) becomes a single expression
 /// statement.
 pub fn lower(node: &RakuAstNode) -> Result<Vec<Stmt>, RuntimeError> {
+    let mut stmts = lower_stmts(node)?;
+    // ADR-0033 Phase 3. A lowered tree carries `Expr::WhateverArg` leaves but no
+    // priming *scopes*: those are planted by the parser at its own grammar
+    // positions, and there is no parser here. Run the same scope authority the
+    // parser's output goes through, in the mode that plants every scope rather
+    // than only the thunk-barrier ones, so a `WhateverCode::Argument` tree —
+    // hand-built or read back from `.AST` — becomes the same closure the
+    // equivalent source does.
+    crate::whatever_curry::with_all_scopes(|| {
+        crate::whatever_curry::mark::mark_program(&mut stmts)
+    });
+    Ok(stmts)
+}
+
+fn lower_stmts(node: &RakuAstNode) -> Result<Vec<Stmt>, RuntimeError> {
     match node.class {
         RakuAstClass::StatementList => {
             let mut stmts = Vec::with_capacity(node.fields.len());
@@ -220,7 +235,7 @@ fn lower_sub(node: &RakuAstNode) -> Result<Stmt, RuntimeError> {
     let (params, param_defs) = signature_positional_params(node)?;
     let (return_type, custom_traits) = routine_return_type(node)?;
     // A Sub's `body` is the Blockoid directly (not a Block wrapping one).
-    let body = lower(named_child_or_positional(named_child(node, "body")?)?)?;
+    let body = lower_stmts(named_child_or_positional(named_child(node, "body")?)?)?;
     Ok(Stmt::SubDecl {
         name: crate::symbol::Symbol::intern(&name),
         name_expr: None,
@@ -281,7 +296,7 @@ fn lower_role(node: &RakuAstNode) -> Result<Stmt, RuntimeError> {
     if role_body.class != RakuAstClass::RoleBody {
         return Err(unsupported(node));
     }
-    let body = lower(named_child_or_positional(named_child(role_body, "body")?)?)?;
+    let body = lower_stmts(named_child_or_positional(named_child(role_body, "body")?)?)?;
     Ok(Stmt::RoleDecl {
         name: crate::symbol::Symbol::intern(&name),
         type_params: Vec::new(),
@@ -303,7 +318,7 @@ fn lower_method(node: &RakuAstNode) -> Result<Stmt, RuntimeError> {
     let name = call_name_str(node)?;
     let (params, param_defs) = signature_positional_params(node)?;
     let (return_type, custom_traits) = routine_return_type(node)?;
-    let body = lower(named_child_or_positional(named_child(node, "body")?)?)?;
+    let body = lower_stmts(named_child_or_positional(named_child(node, "body")?)?)?;
     Ok(Stmt::MethodDecl {
         name: crate::symbol::Symbol::intern(&name),
         name_expr: None,
@@ -598,7 +613,7 @@ fn lower_cstyle_loop(node: &RakuAstNode) -> Result<Stmt, RuntimeError> {
 /// statement list.
 fn lower_block(block: &RakuAstNode) -> Result<Vec<Stmt>, RuntimeError> {
     let blockoid = named_child(block, "body")?;
-    lower(named_child_or_positional(blockoid)?)
+    lower_stmts(named_child_or_positional(blockoid)?)
 }
 
 /// Whether an `ApplyInfix`'s `infix` child is an `Assignment` node (`$x = …`).
@@ -877,7 +892,7 @@ fn lower_expr(node: &RakuAstNode) -> Result<Expr, RuntimeError> {
                 return Err(unsupported(node));
             }
             // A Sub's `body` is the Blockoid directly (not a Block wrapping one).
-            let body = lower(named_child_or_positional(named_child(node, "body")?)?)?;
+            let body = lower_stmts(named_child_or_positional(named_child(node, "body")?)?)?;
             if params.is_empty() && return_type.is_none() {
                 return Ok(Expr::AnonSub {
                     body,
@@ -967,8 +982,12 @@ fn lower_expr(node: &RakuAstNode) -> Result<Expr, RuntimeError> {
                 expr: Box::new(lower_expr(child_node(&only.value)?)?),
             })
         }
-        // The `*` whatever term.
+        // The `*` whatever term — the *value* leaf (`1..*`, `@a[*]`).
         RakuAstClass::TermWhatever => Ok(Expr::Whatever),
+        // The `*` priming-argument leaf (`* + 1`, `* > 3`). ADR-0033 splits the
+        // two leaf roles; the enclosing priming *scope* is planted afterwards by
+        // `whatever_curry`, not here — see `lower`'s entry point.
+        RakuAstClass::WhateverCodeArgument => Ok(Expr::WhateverArg),
         // `do { … }` -> a do-block expression over the lowered block body.
         RakuAstClass::StatementPrefixDo => {
             let block = named_child_or_positional(node)?;

--- a/src/whatever_curry/mark/expr.rs
+++ b/src/whatever_curry/mark/expr.rs
@@ -30,6 +30,19 @@ pub(super) fn mark_expr(expr: &mut Expr) {
     // the recursion below then classifies the leaves inside the new marker
     // exactly as it would have classified them in place.
     crate::whatever_curry::plant_here(expr);
+    mark_expr_after_plant(expr);
+}
+
+/// The body of an `Expr::WhateverCurry` marker. It is already *inside* a scope,
+/// so the every-expression planting of ADR-0033 Phase 3 must not run on it —
+/// re-wrapping the same expression would recurse forever. Barrier splitting
+/// still applies: an operand of a `&&` under the marker is its own scope.
+fn mark_curry_body(expr: &mut Expr) {
+    crate::whatever_curry::plant_barriers_here(expr);
+    mark_expr_after_plant(expr);
+}
+
+fn mark_expr_after_plant(expr: &mut Expr) {
     match expr {
         Expr::Whatever => *expr = Expr::WhateverArg,
         // Already classified (re-running mark_expr should never happen in
@@ -37,7 +50,7 @@ pub(super) fn mark_expr(expr: &mut Expr) {
         Expr::WhateverArg | Expr::HyperWhatever => {}
         // A marker's un-curried body is exactly the "argument" role: recurse
         // straight through, no wrapper of its own.
-        Expr::WhateverCurry(inner) => mark_expr(inner),
+        Expr::WhateverCurry(inner) => mark_curry_body(inner),
         Expr::Grouped(inner) => mark_expr(inner),
         // Comma-list positions: `1, *, 2`, `[*]`, `\(*, 1)`.
         Expr::ArrayLiteral(items) | Expr::BracketArray(items, _) | Expr::CaptureLiteral(items) => {

--- a/src/whatever_curry/mod.rs
+++ b/src/whatever_curry/mod.rs
@@ -30,4 +30,4 @@ mod plant;
 mod replace;
 
 pub(crate) use build::{build_closure, make_wc_param};
-pub(crate) use plant::{is_thunk_barrier, plant_here};
+pub(crate) use plant::{is_thunk_barrier, plant_barriers_here, plant_here, with_all_scopes};

--- a/src/whatever_curry/plant.rs
+++ b/src/whatever_curry/plant.rs
@@ -106,6 +106,63 @@ fn materialise_scope(slot: &mut Expr) {
     }
 }
 
+thread_local! {
+    /// Whether the walk currently running is planting *every* priming scope
+    /// (ADR-0033 Phase 3) rather than only the barrier ones.
+    ///
+    /// The parser plants its own scopes at ~29 grammar positions and then runs
+    /// [`super::mark`] purely to classify leaves and split barriers, so for a
+    /// parsed program this stays `false` and nothing about that path changes.
+    /// A tree lowered from RakuAST has no parser behind it and therefore no
+    /// scopes at all, so `rakuast::lower` runs the same walk with this set —
+    /// see [`plant_all_scopes`].
+    static PLANT_ALL_SCOPES: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
+
+/// Run `body` with every-expression scope planting enabled, restoring the
+/// previous setting afterwards (including on an unwind).
+pub(crate) fn with_all_scopes<R>(body: impl FnOnce() -> R) -> R {
+    struct Restore(bool);
+    impl Drop for Restore {
+        fn drop(&mut self) {
+            PLANT_ALL_SCOPES.with(|f| f.set(self.0));
+        }
+    }
+    let _restore = Restore(PLANT_ALL_SCOPES.with(|f| f.replace(true)));
+    body()
+}
+
+/// The Phase 3 half of the scope authority: materialise a scope around **this**
+/// expression when it primes at all.
+///
+/// [`super::mark`]'s walk reaches every expression slot top-down and calls this
+/// before recursing, so the *first* (outermost) node that primes gets the
+/// marker — which is what makes the scope maximal, exactly as the parser's own
+/// planting sites make it. Wrapping bottom-up instead would give `*.abs + 1`
+/// two nested markers (an inner closure added to `1`) rather than one.
+///
+/// It is deliberately not universal: `should_wrap_whatevercode` is the parser's
+/// own predicate, and `contains_whatever` under it stops at a call/method
+/// argument, a barrier, and the other non-currying positions. That is why
+/// `@a.first(* > 1)` plants one scope around the *argument* and none around the
+/// method call.
+fn plant_all_scopes(expr: &mut Expr) {
+    if !PLANT_ALL_SCOPES.with(|f| f.get()) {
+        return;
+    }
+    // An invocation is never itself a scope: `(* + 1)(4)` curries the *target*
+    // and then calls it, so the scope belongs on the target and the recursion
+    // below plants it there. `should_wrap_whatevercode` says `true` here only
+    // because the parser never asks it about an invocation — it wraps the
+    // target at its own dedicated grammar site instead — and wrapping the whole
+    // `CallOn` would make the program evaluate to the closure rather than call
+    // it.
+    if matches!(expr, Expr::CallOn { .. }) {
+        return;
+    }
+    materialise_scope(expr);
+}
+
 /// The scope authority, applied to one expression node.
 ///
 /// Invoked from [`super::mark`]'s post-parse walk (which already visits every
@@ -113,6 +170,15 @@ fn materialise_scope(slot: &mut Expr) {
 /// into the node's children, so the recursion sees — and classifies the leaves
 /// of — whatever markers this planted.
 pub(crate) fn plant_here(expr: &mut Expr) {
+    plant_all_scopes(expr);
+    plant_barriers_here(expr);
+}
+
+/// The barrier half alone, for a node that is already known to sit *directly*
+/// inside a scope marker: its enclosing scope exists, so planting another one
+/// around it would wrap the same expression forever, but each barrier operand
+/// under it is still a scope of its own.
+pub(crate) fn plant_barriers_here(expr: &mut Expr) {
     if !is_thunk_barrier(expr) {
         return;
     }

--- a/t/rakuast-eval-whatever-code.t
+++ b/t/rakuast-eval-whatever-code.t
@@ -1,0 +1,57 @@
+use v6;
+use MONKEY-SEE-NO-EVAL;
+use experimental :rakuast;
+use Test;
+
+# ADR-0033 Phase 3: `EVAL` of a WhateverCode tree.
+#
+# Phase 2 gave `* + 1` a `.AST` (`RakuAST::WhateverCode::Argument` for the
+# priming leaf), but the write direction refused it, so the highest-frequency
+# construct in real Raku code — `.map(* + 1)`, `.grep(* > 3)`, `@a[* - 1]` —
+# could be read and never lowered.
+#
+# The asymmetry the ADR called out is what made this more than a missing match
+# arm: the priming *scope* is planted by the parser at its own grammar
+# positions, and a lowered tree has no parser behind it. `whatever_curry` now
+# owns that decision for both producers — the same top-down walk, run in a mode
+# that plants every scope rather than only the thunk-barrier ones — so a lowered
+# tree becomes the same closure the equivalent source does.
+#
+# Passes under BOTH mutsu and raku.
+
+plan 18;
+
+# --- the canonical priming forms --------------------------------------------
+is EVAL(Q{(1..5).map(* + 1).join(",")}.AST), '2,3,4,5,6', '.map(* + 1)';
+is EVAL(Q{(1..10).grep(* > 3).join(",")}.AST), '4,5,6,7,8,9,10', '.grep(* > 3)';
+is EVAL(Q{my @a = 1, 2, 3; @a[* - 1]}.AST), 3, '@a[* - 1]';
+is EVAL(Q{(1..5).first(* > 2)}.AST), 3, '.first(* > 2)';
+is EVAL(Q{(1..5).grep(* %% 2).join(",")}.AST), '2,4', '.grep(* %% 2)';
+
+# --- the scope is maximal, not minimal --------------------------------------
+# `*.abs + 1` is ONE closure over `abs($_) + 1`; wrapping bottom-up would give
+# two nested ones (a closure added to 1).
+is EVAL(Q{(*.abs + 1)(-4)}.AST), 5, 'a compound target is one maximal scope';
+is EVAL(Q{(*.Str.chars)(123)}.AST), 3, 'a method chain is one scope';
+
+# --- an invocation is not itself a scope ------------------------------------
+is EVAL(Q{(* + 1)(4)}.AST), 5, 'an immediately-invoked WhateverCode is called';
+is EVAL(Q{(* * 2)(21)}.AST), 42, 'an immediately-invoked product is called';
+is EVAL(Q{(*[0])([1, 2, 3])}.AST), 1, 'an immediately-invoked subscript is called';
+
+# --- multiple `*` primes to multiple parameters -----------------------------
+is EVAL(Q{(* + *)(3, 4)}.AST), 7, 'two `*` prime to two parameters';
+is EVAL(Q{my @a = 3, 1, 2; @a.sort(* <=> *).join(",")}.AST), '1,2,3',
+    'a two-parameter comparator lowers';
+
+# --- thunk barriers stay their own scopes (ADR-0033 Phase 4) ----------------
+is EVAL(Q{(1..10).grep(* > 3 && * < 8).join(",")}.AST), '1,2,3,4,5,6,7',
+    'a `&&` of two primings stays two arity-1 closures';
+is EVAL(Q{(* > 3 && * < 8).arity}.AST), 1, 'the barrier keeps the arity at 1';
+is EVAL(Q{(1..6).grep(* > 2 || * < 0).join(",")}.AST), '3,4,5,6',
+    'a `||` of two primings behaves the same';
+is EVAL(Q{((* + 1 ?? * + 2 !! * + 3))(1)}.AST), 3, 'a ternary primes per branch';
+
+# --- a `*` in a value position is still a value -----------------------------
+is EVAL(Q{(1 .. *)[3]}.AST), 4, 'a range endpoint `*` stays the Whatever value';
+is EVAL(Q{(1, 2, *).elems}.AST), 3, 'a comma operand `*` stays the Whatever value';

--- a/todo/deep/rakuast-remaining.md
+++ b/todo/deep/rakuast-remaining.md
@@ -203,10 +203,6 @@ an explicit design:
 - `constant`
 - associative subscripts
 - `CATCH` blocks
-- WhateverCode such as `* + 1` — **Phases 1, 2 and 4 shipped: `Q[* + 1].AST` works, and
-  priming now stops at thunk barriers. Only Phase 3 (RakuAST write / `EVAL`) is left, and
-  it has no roast or correctness payoff of its own — see
-  [ADR-0033](../../docs/adr/0033-whatever-priming-leaf-and-derived-scope.md)**
 - code-block interpolation
 - regexes
 
@@ -214,7 +210,7 @@ Pick these deliberately by user impact rather than treating them as another
 cadence of mechanical slices. Lower through the existing internal AST and
 compiler; do not add a second execution engine.
 
-### Phases 1, 2 and 4 shipped; only Phase 3 remains: WhateverCode (ADR-0033)
+### WhateverCode (ADR-0033) — all four phases shipped
 
 `* + 1` was picked first because it is the highest-frequency construct on the list
 (`.map(* + 1)`, `.grep(* > 3)`, `@a[* - 1]`) and because investigating it surfaced a
@@ -264,10 +260,18 @@ RakuAST rendering fidelity) shipped 2026-08-26 and retired `ChainAnd` in the pro
 See the ADR's "Phase 4 outcome" section for the full account of the original prerequisite,
 including the `xor` / `^^` re-measurement and a latent de-duplication bug it flushed out.
 
-**Phase 3 (RakuAST write / `EVAL` of a hand-constructed `WhateverCode::Argument` tree) is
-the only part of ADR-0033 still open.** It remains designed only at the ADR's outline
-level and has no roast/correctness payoff of its own (RakuAST has zero roast dependents,
-ADR-0011 ANALYSIS §7-9), so it is a low-priority pick relative to the rest of this file.
+Phase 3 — the RakuAST write direction — shipped 2026-09-05, completing the ADR.
+`RakuAST::WhateverCode::Argument` lowers to `Expr::WhateverArg`, and the priming *scope*
+a lowered tree has no parser to plant is now derived by the same authority: the
+`whatever_curry::mark` walk runs in a mode that materialises a scope at the first
+(outermost) expression that primes, which is what makes the scope maximal. Two
+corrections came out of differential testing rather than reading — a marker's own body
+must not be re-planted (it recursed until the stack overflowed), and an invocation is
+never itself a scope (`(* + 1)(4)` evaluated to the closure instead of calling it). The
+oracle is mutsu against itself: running `S` must equal `EVAL(Q{S}.AST)`. Pinned by
+`t/rakuast-eval-whatever-code.t`; see
+[the news entry](../../news/2026-09/rakuast-whatever-code-eval.md) and the ADR's
+"Phase 3 outcome" section.
 
 The remaining items on both lists above are still undesigned.
 


### PR DESCRIPTION
Completes ADR-0033 — Phase 3 was its last open phase — and closes the
`WhateverCode` item of `todo/deep/rakuast-remaining.md`.

## Problem

Phase 2 gave `* + 1` a `.AST`, but the write direction refused the tree it had
just produced, so the highest-frequency construct in real Raku code —
`.map(* + 1)`, `.grep(* > 3)`, `@a[* - 1]` — could be read and never lowered:

```
$ mutsu -e 'use MONKEY-SEE-NO-EVAL; EVAL(Q{(1..5).map(* + 1)}.AST)'
RakuAST: EVAL does not yet support lowering `RakuAST::WhateverCode::Argument`
```

## Why it was not just a missing match arm

`RakuAST::WhateverCode::Argument` → `Expr::WhateverArg` is one line. The work was
the priming **scope**.

mutsu's parser plants a `WhateverCurry` marker at ~29 grammar positions; a
lowered tree has no parser behind it and therefore no scopes at all. Re-deriving
them is not a matter of applying the parser's predicate wherever it says yes:

- **Bottom-up** — wrapping each qualifying subexpression as `lower_expr` returns
  it — gives *minimal* scopes. `*.abs + 1` becomes
  `WhateverCurry(WhateverCurry(*.abs) + 1)`, an inner closure added to `1`, where
  the parser produces one scope over the whole sum.
- **Top-down** gives maximal scopes correctly almost everywhere, because
  `contains_whatever` is deliberately *not* transparent through a call argument,
  a method-call argument, or a thunk barrier. That is what makes
  `@a.first(* > 1)` plant one scope around the argument and none around the
  method call, with no special case needed.

So the implementation is the second, run as a **mode of the walk that already
exists**. `whatever_curry::mark`'s post-parse walk reaches every expression slot
top-down and already calls `plant_here` before recursing; in the new mode
`plant_here` also materialises a scope around the node itself, so the first
(outermost) node that primes gets the marker. `rakuast::lower` turns the mode on
for its single `mark_program` call. **The parser path never sets it and is
unchanged by construction** — which is the whole reason this is a mode rather
than a change to the default rule.

## Two corrections, both found by differential testing rather than reading

- **A marker's body must not be re-planted.** `mark_expr` recurses into a
  `WhateverCurry`'s body, which is still an expression that primes, so it was
  wrapped again — and again, until the stack overflowed. `plant_here` split into
  a scope half and a barrier half; the marker-body recursion runs only the
  barrier half.
- **An invocation is never itself a scope.** `should_wrap_whatevercode` answers
  `true` for a `CallOn` with a compound target only because the parser never asks
  it — the parser wraps the *target* at a dedicated site instead. Wrapping the
  whole `CallOn` made `(* + 1)(4)` evaluate to the closure instead of calling it.

## The oracle

mutsu against itself: for a snippet `S`, running `S` directly must produce
exactly what `EVAL(Q{S}.AST)` produces. That comparison found both corrections
above and now agrees across the priming corpus.

`t/rakuast-eval-whatever-code.t` (18 assertions) pins that corpus — the canonical
`.map` / `.grep` / subscript forms, maximal-scope compounds, immediate
invocation, multi-`*` arity, the Phase 4 thunk-barrier cases, and the
value-position `*` forms that must NOT curry. Like the rest of the suite it is a
dual-oracle test that passes verbatim under both mutsu and raku.

`roast/S02-types/whatever.t` (131 tests) and the whole `t/whatever*.t` family
still pass, which is the check that matters most here: the planting walk is
shared with the parser, so a leak into that path would show up as ordinary
programs changing behaviour.

ADR-0033 and the campaign file are updated to record the phase as shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TtL4NKUC5rVfjD6mFDpqh9

---
_Generated by [Claude Code](https://claude.ai/code/session_01TtL4NKUC5rVfjD6mFDpqh9)_