### PR TITLE
docs: ADR-0068 — audit the cross-thread aliased container-write hazard

### DIFF
--- a/docs/adr/0068-cross-thread-container-writes-need-a-synchronized-store.md
+++ b/docs/adr/0068-cross-thread-container-writes-need-a-synchronized-store.md
@@ -1,0 +1,256 @@
+# ADR-0068: A cross-thread aliased container write needs a synchronized store, not a name-keyed lane
+
+- Status: **Proposed**
+- Date: 2026-09-05
+- Relates to: [ADR-0001](0001-gc-strategy-and-phasing.md) §7 (layer 3c),
+  [ADR-0013](0013-container-interior-mutability-cellvalue.md) §1.3-2 / §3 / §5 Q2,
+  [ADR-0010](0010-cross-thread-lexical-sharing-scope.md),
+  [ADR-0039](0039-container-lexicals-resolve-lexically.md) §8.6
+- Supersedes nothing. Fires the revisit condition that ADR-0013 §5 Q2 set for itself.
+
+## 1. Context
+
+`crate::gc::gc_contents_mut` (`src/gc/gc_ptr.rs:786`) is the codebase's single
+aliased-container-write primitive: given a `Gc<T>` whose strong count is greater than one it
+hands out a `&mut T`, so a write through one alias is visible through every holder of the
+node. That is how mutsu implements Raku container identity, and it is correct on one thread.
+Its own `# Safety` clause names the gap:
+
+> ... concurrent structural mutation from another thread remains routed through the
+> synchronized shared-store lanes (the narrow cross-thread race deferred to ADR-0001 layer 3c).
+
+There are **149 call sites** and none of them establishes that. The lanes
+(`runtime/runtime_shared_vars.rs` — `assign_array_elem_to_shared_var`, `shared_array_elem_set`,
+`push_to_existing_shared_var`, `__mutsu_atomic_arr::`) are keyed by **variable name** and seeded
+from a spawning frame's env walk (`clone_for_thread_excluding`). A container that becomes
+aliased by two VM threads any other way is written through `Vec::resize` / `HashMap::insert`
+concurrently, which is a double free or a use-after-free.
+
+ADR-0013 §5 Q2 resolved to defer this, with an explicit revisit condition:
+
+> **Cross-thread race: defer to layer 3c.** ... Revisit only if gc-stress/S17 surfaces an actual race.
+
+**That condition has now fired twice.** `news/2026-09/supply-act-serialization-and-the-concurrency-crash-cluster.md`
+root-caused a months-old CI crash cluster (glibc corrupted-chunk abort in `__libc_free`,
+SIGSEGV, both with `Failed: 0`) to exactly this hazard reached through a `Supply.act` tap's
+captured `my @seen`; and the route audit in §3 below reproduces the same corruption through
+routes that the `.act` fix cannot cover. ADR-0013 §1.3-2's premise — *"the `gc_contents_mut`
+sites are overwhelmingly same-thread aliased writes, not live cross-thread races"* — is
+measurably wrong for any program that shares one container across taps or `.then` callbacks.
+
+### 1.1 A calibrated reproduction harness (this is the reusable part)
+
+The previous investigation spent six sessions failing to reproduce, and its recorded next
+steps (memcheck, then helgrind) were both dead ends. The harness that works is:
+
+- the **real workload**, run many times as **separate processes**, under the `gc-stress` job's
+  environment (`MUTSU_GC=on MUTSU_GC_EVERY_CANDIDATE=1024 MUTSU_GC_VERIFY=1`), on a
+  `--profile profiling` build;
+- **CPU oversubscription is the necessary ingredient, not concurrency.** At 8-way on 12 cores
+  the pre-fix `roast/integration/advent2014-day05.t` was 0/64 and 0/240 — clean. At **24-way on
+  12 cores** the same binary and file failed 6/960 within seconds per batch. Every earlier
+  "clean" measurement in this area was taken below the oversubscription threshold and means
+  nothing.
+- **mutsu's own `Vec` bounds check and glibc's allocator are the detectors.** Observed failure
+  shapes in this session: `free(): double free detected in tcache 2`,
+  `double free or corruption (out)` with a core dump, `double free or corruption (fasttop)`,
+  SIGILL, and silent lost updates.
+
+Negative results worth keeping (they narrow the next attempt):
+
+- `valgrind --tool=memcheck` — 0 errors on a demonstrably racing workload (prior session). It
+  serializes threads onto one core, which suppresses exactly the interleaving this class needs.
+  **Do not start here.**
+- `valgrind --tool=helgrind` — could not symbolize the optimized binary or unwind a frame; its
+  1000 contexts were unusable (prior session).
+- **AddressSanitizer** reports nothing, but its ~10x slowdown widens the window; it is a
+  *scheduler*, not a detector, for this bug.
+- **A hand-written minimal probe is not a substitute for the real file.** Five standalone
+  probes written from the racing test's own source — same three writers, same
+  `sleep rand`, same 20 emitters, at file scope and in a loop — were clean over 1440+ block
+  executions at full power *with the fix disabled*, because they took the **synchronized lane**
+  instead of the racing path (see §2). Shrinking the repro silently changed which store path ran.
+
+### 1.2 The path oracle — how to tell exposure from coverage in one command
+
+Rather than guessing, ask the binary which store path a workload takes. `rust-gdb`'s ignore
+counter turns a breakpoint into a free call counter, with no rebuild:
+
+```bash
+MUTSU_FUDGE=1 rust-gdb -batch \
+  -ex 'break src/vm/vm_var_assign_index_named.rs:2353' \
+  -ex 'break mutsu::runtime::Interpreter::shared_array_elem_set' \
+  -ex 'ignore 1 1000000' -ex 'ignore 2 1000000' \
+  -ex 'run' -ex 'info breakpoints' \
+  --args ./target/debug/mutsu <file>
+```
+
+Breakpoint 1 is the unsynchronized aliased element store (the site the crash backtrace named);
+breakpoint 2 is the synchronized lane. `already hit N times` on 1 with nothing on 2 means the
+workload is **exposed**. This oracle is deterministic, costs one debug run, and settled every
+route in §3 in minutes — where the stress harness needs hundreds of runs to say the same thing
+probabilistically.
+
+## 2. The actual root cause is narrower and more specific than "149 unsynchronized sites"
+
+The lane is not merely *incomplete*; it **hands the write to a mechanism it believes is
+synchronized and is not.** `assign_array_elem_to_shared_var` bows out here
+(`runtime/runtime_shared_vars.rs:181-186`):
+
+```rust
+// See `assign_hash_elem_to_shared_var`: an array already boxed into a
+// shared `ContainerRef` cell is already shared through the Mutex; let
+// the general assignment path write through it.
+if matches!(self.env.get(key).map(|v| v.view()), Some(ValueView::ContainerRef(_))) {
+    return None;
+}
+```
+
+`ContainerCell` (`src/value/mod.rs:429`) is `{ value: Mutex<Value>, constraint: Mutex<...>, ... }`.
+**That `Mutex` protects the cell's `Value`, not the container the `Value` points at.** The
+element store clones the inner `Gc<ArrayData>` out from under the lock, releases it, and then
+performs the aliased in-place mutation — `Gc::strong_count(items) > 1` ⇒
+`gc_contents_mut(items)` ⇒ `autoviv_resize` ⇒ `Vec::resize`
+(`vm/vm_var_assign_index_named.rs:2349-2357`) — with no lock held at all. The comment's
+"already shared through the Mutex" is a **false premise in the code**, and it is the single
+condition that fired on the confirmed-racing workload (verified with the §1.2 oracle: the
+`return None` at line 185 fired 21/21 times).
+
+A container reaches that state whenever the closure machinery boxes it into a shared cell —
+most commonly because a **named sub closes over it** (ADR-0024's unit-lexical cells). In
+`roast/integration/advent2014-day05.t` that is literally the first line of the file's first
+block, `sub print($a) { @seen.push: $a }`, and it is why the racing shape could not be shrunk:
+removing that sub moved the workload back onto the synchronized lane.
+
+So the exposure surface is not "any of 149 sites" — it is **the set of ways a container becomes
+cross-thread reachable while the name lane declines**, and the lane declines for five known
+reasons: the name is not a plain lexical `@`/`%` (attributes, twigils); the name is masked as
+re-declared; **the env entry is a `ContainerRef` cell** (this ADR's finding); the container was
+never in a spawning frame's env; or the write is not name-keyed at all (`$obj.attr[$i]`,
+`%h<k>[$i]`, a container returned from a method).
+
+## 3. Route audit (measured this session)
+
+Every route was probed in the day05 idiom — three writers (`=`, `~=`, `//=`) into one
+container, 20 concurrent producers with `sleep rand` — and classified with the §1.2 oracle,
+then confirmed with the §1.1 stress harness at 24-way on 12 cores.
+
+| # | Route | Oracle: unsynchronized / lane | Stress result | Verdict |
+|---|---|---|---|---|
+| 0 | `Supply.act` tap captures (**fixed** by #7336) | — | 0 / 240 after the fix; 6 / 960 with the fix disabled, incl. `double free or corruption (fasttop)` + SIGILL | **Closed** — and this is the harness calibration |
+| 1 | **plain `.tap` callback captures** | 20 / 0 | **4 / 960**, incl. `free(): double free detected in tcache 2` and `double free or corruption (out)` with core dumps | **RACES.** Not fixable by locking dispatch — `.tap` has no serialization guarantee in Raku |
+| 2 | **`Promise.then` combinator callback captures** | 21 / 0 | **3 / 240**, lost updates | **RACES** |
+| 3 | Object attribute (`has @.seen is rw`) written from two threads | 0 / 0 — reaches **neither** probed aliased-store site, nor `gc_data_mut`, nor the computed-attr sites | 1 clean run | **Unresolved** — the write takes some other path; needs its own trace before it can be called covered or exposed |
+| 4 | `Thread.start` bodies (spawn via block-less `clone_for_thread`) | 21 / 0 | run incomplete at wind-down | **Exposed** on the oracle; same site as routes 1/2 |
+| 5 | `Channel.Supply` tap captures | 20 / 0 | fails on a *single* run | **Exposed** on the oracle, but the single-run failure is a separate, deterministic Channel-supply delivery bug (values dropped/misordered), which must be fixed first before this route's race is measurable |
+
+Route 1 is the important one: it is the same shape as the fixed `.act` route, it races at the
+same rate (0.42% vs 0.63% per run — statistically indistinguishable), it produces genuine
+allocator corruption, and **the `.act` remedy cannot be applied to it**, because Raku
+deliberately gives `.tap` no serialization guarantee. Serializing `.tap` dispatch would be a
+private-dialect divergence, not a fix.
+
+Routes 1, 2 and 4 all corrupt through the **same** site (`vm_var_assign_index_named.rs:2353`),
+which is what makes a store-side remedy tractable: they are three doors into one room.
+
+### 3.1 The unexplained `S17-procasync/stress.t` SIGSEGV
+
+CI run 30590633128 (2026-07-30) killed the interpreter in the rakudo#3299 block (1200
+`Proc::Async` instances inside a `react`). It has never reproduced (~130 targeted runs across
+four configurations, plus this session's). It has no `Supply.act`, and `react`/`whenever`
+already had a serialize group, so the `.act` fix does not obviously cover it. **This audit does
+not explain it.** What it does supply is a reason the earlier hunts failed — every one of them
+ran below the oversubscription threshold §1.1 identifies — and a cheap next step: run that file
+under the §1.1 harness at 24-way, and run the §1.2 oracle over it to see whether its containers
+are on the lane at all. Left recorded, not chased.
+
+## 4. Decision (proposed)
+
+**Adopt remedy (B) — synchronize the store at the container, gated by (C) — and reject (A).**
+Concretely, in this order:
+
+1. **(C) A process-global "more than one VM mutator thread is live" flag** (`AtomicBool`,
+   `Relaxed` load), set on the first spawn and never cleared. Every synchronization added below
+   is a no-op behind it, so a single-threaded program pays one relaxed load per aliased write.
+   This is a prerequisite, not an optimization: it is what makes (B) affordable.
+2. **(B) Repair the false premise in §2 first, as the smallest provable slice.** A container
+   reached through a `ContainerRef` cell must have its structural mutation performed **while
+   holding that cell's own lock**, or the lane must stop deferring to it. This is one lock,
+   already owned by the aliasing edge, taken at a site that the code already documents as
+   synchronized. Acceptance: routes 1, 2 and 4 go to 0 failures under the §1.1 harness at
+   24-way, and their §1.2 oracle shows the write no longer racing.
+3. **Then widen from there** to the remaining four lane-decline reasons in §2, each with its own
+   oracle-classified probe and stress acceptance, rather than as one 149-site sweep.
+
+### Why not (A), "synchronize the primitive"
+
+`gc_contents_mut` returns a `&mut T` that **outlives the call**, so a guard cannot live inside
+it; the lock would have to be taken by each of the 149 callers around its own mutation region.
+That is not merely a large mechanical diff — it carries a deadlock-analysis obligation at every
+site that can call user code while holding the lock. Quantifying that obligation, over the 149
+sites:
+
+| Bucket | Files | Character |
+|---|---|---|
+| VM store/assign paths | `vm/vm_var_assign_index_named.rs` (13), `vm_var_assign_ops.rs` (8), `vm_exec_dispatch.rs` (8), `vm_var_assign_post_incdec.rs` (4), `vm_var_assign_computed_attr.rs` (4), `vm_var_assign_coerce.rs` (3), `vm_var_index_tracking.rs` (2), `vm_var_elem_mutate.rs` (2) | **Can call user code while holding it** — `Proxy` STORE, `where` constraints, `AT-POS`/`ASSIGN-POS` overloads, tied accessors |
+| Method dispatch | `runtime/methods_mut_dispatch.rs` (5), `vm_call_method_mut_ops.rs` (3), `vm_hyper_method_ops.rs` (4), `vm_call_method_ops.rs` (1), `runtime/methods_call_dispatch.rs` (2), `methods_classhow_dispatch.rs` (2) | **Can call user code** — the mutation region *is* a dispatch |
+| Collection builtins | `runtime/builtins_collection_deepmap.rs` (4), `builtins_multidim_assign.rs` (2), `builtins.rs` (1), `utils/shaped.rs` (2) | `deepmap`/`deepmap`-alikes take a **user callback** |
+| Value-layer mechanics | `value/value_methods_a.rs` (8), `value_methods_b.rs` (14), `entry_path.rs` (7), `native_backing.rs` (4), `aliased_mut.rs` (4), `native_cache_shapes.rs` (2), `view.rs`, `value_gc.rs`, `value_buf.rs`, `sync_cell.rs`, `mod.rs` | Mostly leaf; the safe part of the diff |
+| NativeCall / NQP | `runtime/nativecall.rs` (2), `cstruct_layout.rs` (2), `nqp_ops.rs` (1), `methods_mixin_what_cache.rs` (1) | Can re-enter through an **outbound callback** (ADR-0063) |
+
+**Roughly 45 of the 149 sites sit in buckets that can re-enter user code**, and mutsu's
+identity-write pattern is deliberately re-entrant and aliased (`@a[$i] = @a[$j]`, a `Proxy`
+whose STORE touches the same container). A non-reentrant lock there deadlocks; a reentrant one
+does not actually exclude the second writer. This is the same objection ADR-0013 §3 raised
+against option 2a (per-container `RwLock`) and it has not weakened. (A) is rejected on the
+record.
+
+### Why (B) and not "widen the lanes"
+
+The finding's remedy 2 — register any container that *becomes cross-thread reachable* — is the
+attractive framing, but "becomes cross-thread reachable" is a **whole-heap reachability
+question mutsu has no answer to today**: it would need either a write barrier on every store of
+a container into anything a worker can see, or a mark phase over each spawn's transitive
+capture set. ADR-0039 §8.6 already documents why the cheap approximation fails — a routine the
+block merely *calls* can reach a container no analysis over the block's own free variables can
+see, which is why lane entries are published for everything and then retired as *transient*
+rather than withheld. Widening that to full reachability is a GC-scale change, and it lands in
+the territory ADR-0001 keeps rejecting.
+
+(B) sidesteps the question: it does not ask *which* containers are shared, it makes the *write*
+safe wherever the aliasing edge already carries a lock. §2 shows the first and largest such edge
+already exists and is merely unused.
+
+### What is explicitly NOT proposed
+
+Level 2 — a full VM redesign for a MoarVM-style precise moving/tracing GC — remains rejected per
+ADR-0001 §4.1 / CLAUDE.md. Nothing measured here is a *refcount ceiling*; it is a missing
+mutual-exclusion edge. This ADR does not argue that case and must not be read as opening it.
+
+## 5. Consequences
+
+- ADR-0013 §5 Q2's deferral is **spent**: gc-stress/S17-class workloads have surfaced an actual
+  race, with allocator corruption, on routes the `.act` fix cannot reach. The `# Safety` clause
+  on `gc_contents_mut` and the header of `value/aliased_mut.rs` should stop describing the
+  cross-thread race as "already lane-governed" and instead point at §2 and §3 of this ADR.
+- The comment at `runtime_shared_vars.rs:181-186` ("already shared through the Mutex") is
+  **wrong as written** and should be corrected even before a fix lands, because it is the reason
+  the hole was invisible.
+- The §1.1 harness and the §1.2 oracle become the standing acceptance gate for this class. A
+  future "we could not reproduce it" is only meaningful if it was measured at oversubscription
+  *and* the oracle confirms the workload is on the racing path.
+
+## 6. Open questions
+
+1. **Is the `ContainerCell` lock the right lock to hold across a structural mutation?** It is a
+   `Mutex<Value>` whose guard is currently taken only to read/replace the `Value`. Holding it
+   across the mutation excludes other writers through *the same cell*, but not a holder that
+   obtained the `Gc<ArrayData>` by another route. Slice (B)-2's acceptance must therefore be the
+   stress harness, not the argument.
+2. **Route 3 (object attributes) is unclassified.** The probe reached none of the aliased-store
+   sites this session probed. Trace it before assuming either coverage or exposure.
+3. **Route 5 is blocked by a separate Channel-supply delivery bug** (values dropped/misordered
+   on a single, unloaded run). Fix that first; until then this route's race rate is unmeasurable.
+4. **Does the (C) flag belong in `gc_contents_mut` itself** (one relaxed load at the primitive,
+   for every site at once) or at each synchronized store? Measuring the primitive-level load
+   against the bench CI is the deciding datum, and it was not taken this session.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -93,3 +93,4 @@ The role of an ADR is to preserve the *context of the judgment* — something th
 | [0065](0065-language-server-targets-ai-agents.md) | The language server targets AI agents, and is scoped to the protocol surface an agent actually consumes | Proposed (design only; no implementation) |
 | [0066](0066-call-dispatch-inline-cache.md) | Call dispatch resolves through a per-callsite inline cache, not a name-keyed hash map | Proposed (design only; no implementation) |
 | [0067](0067-a-routine-hands-back-the-container-it-was-given.md) | A routine hands back the container it was *given* — raw arguments, raw invocants, and the subscript step through an object | Proposed (Slice 1 implemented 2026-09-05; Slices 2-5 open) |
+| [0068](0068-cross-thread-container-writes-need-a-synchronized-store.md) | A cross-thread aliased container write needs a synchronized store, not a name-keyed lane | Proposed |

--- a/news/2026-09/cross-thread-container-write-route-audit.md
+++ b/news/2026-09/cross-thread-container-write-route-audit.md
@@ -1,0 +1,99 @@
+# The cross-thread container-write hazard, audited: three live routes and a calibrated repro
+
+`todo/deep/gc-contents-mut-cross-thread-aliased-writes.md` was the residue left behind when
+`Supply.act` was made to serialize (`news/2026-09/supply-act-serialization-and-the-concurrency-crash-cluster.md`):
+one crashing route was closed, but the general hazard — 149 `gc_contents_mut` call sites, none of
+which establishes the primitive's own cross-thread safety contract — was neither enumerated nor
+designed. This session enumerated it, measured it, and wrote the design as
+[ADR-0068](../../docs/adr/0068-cross-thread-container-writes-need-a-synchronized-store.md)
+(`Proposed`).
+
+## A reproduction harness that actually reproduces
+
+The single most reusable result is a correction to how this class is hunted. Six earlier sessions
+and roughly 130 targeted runs had failed to reproduce the crash, and the standing advice was to
+reach for a memory checker. Both parts were wrong.
+
+**CPU oversubscription is the necessary ingredient, not concurrency.** Running the *known-racing*
+pre-fix workload eight ways on twelve cores gave 0 failures in 64 runs and 0 in 240 — clean, and
+exactly the shape of every historical "could not reproduce". Running the same binary and the same
+file **24 ways on twelve cores** produced 6 failures in 960 runs, within seconds per batch, with
+`double free or corruption (fasttop)`, a SIGILL, and lost updates. Every earlier clean measurement
+in this area was taken below the threshold and carries no information.
+
+The harness is otherwise plain: the *real* workload, run as separate processes under the
+`gc-stress` job's environment on a `--profile profiling` build, with mutsu's own `Vec` bounds check
+and glibc's allocator as the detectors. `valgrind --tool=memcheck` remains useless here (it
+serializes threads onto one core and suppresses the interleaving); helgrind cannot symbolize the
+optimized binary; AddressSanitizer reports nothing and is useful only because its ~10x slowdown
+widens the window.
+
+A second correction: **a hand-shrunk probe is not a substitute for the real file.** Five standalone
+probes written from the racing test's own source — same three writers, same `sleep rand`, same
+twenty emitters — were clean over 1440+ block executions at full power *with the fix deliberately
+disabled*. Shrinking had silently moved them onto the *synchronized* store path. That is what made
+the earlier hunts feel like noise.
+
+## A path oracle, so exposure is a fact and not a guess
+
+Rather than infer coverage from a probabilistic stress result, ask the binary which store path a
+workload takes. `rust-gdb`'s ignore counter turns a breakpoint into a free call counter with no
+rebuild: break on the unsynchronized aliased element store
+(`vm/vm_var_assign_index_named.rs:2353`) and on the synchronized lane
+(`Interpreter::shared_array_elem_set`), set both ignore counts high, run, and read
+`already hit N times`. One debug run classifies a workload as exposed or covered. This settled
+every route in minutes where the stress harness needs hundreds of runs to say the same thing.
+
+## The root cause is a false premise in the code, not 149 anonymous sites
+
+`assign_array_elem_to_shared_var` declines the synchronized lane when the variable's env entry is a
+`ContainerRef`, on the recorded premise that such an array *"is already shared through the Mutex"*.
+It is not. `ContainerCell`'s `Mutex` protects the cell's `Value` — the pointer — not the container
+the `Value` points at. The element store clones the inner `Gc<ArrayData>` out from under that lock,
+releases it, and then performs `gc_contents_mut` → `autoviv_resize` → `Vec::resize` with no lock
+held at all. On the confirmed-racing workload that `return None` fired 21 times out of 21.
+
+A container reaches that state whenever the closure machinery boxes it into a shared cell — most
+commonly because a **named sub closes over it**. In `roast/integration/advent2014-day05.t` that is
+literally the first line of the file, `sub print($a) { @seen.push: $a }`, and it is why the racing
+shape resisted shrinking: deleting that sub moved the workload back onto the safe lane.
+
+## Route audit
+
+- **plain `.tap` callback captures — RACES.** 4 failures in 960 runs, including
+  `free(): double free detected in tcache 2` and `double free or corruption (out)` with core dumps,
+  at a rate statistically indistinguishable from the `.act` route that was just fixed. This one
+  cannot be fixed the way `.act` was: Raku deliberately gives `.tap` no serialization guarantee, so
+  locking the dispatch would be a private-dialect divergence.
+- **`Promise.then` combinator callback captures — RACES.** 3 failures in 240 runs, lost updates.
+- **`Thread.start` bodies — exposed** on the path oracle, through the same site.
+- **`Channel.Supply` tap captures — exposed** on the path oracle, but blocked behind a separate,
+  deterministic Channel-supply delivery bug that drops or misorders values even on a single
+  unloaded run.
+- **Object attributes (`has @.seen is rw`) — unresolved.** The write reaches none of the probed
+  aliased-store sites, nor `gc_data_mut`, nor the computed-attribute sites; it needs its own trace
+  before it can be called either covered or exposed.
+
+Three of those routes corrupt through the *same* site, which is what makes a store-side remedy
+tractable rather than a 149-site sweep.
+
+## What the ADR decides
+
+It rejects "synchronize the primitive" on the record, with the count that makes the objection
+concrete: `gc_contents_mut` returns a `&mut T` that outlives the call, so the lock must be taken by
+each caller around its own mutation region — and roughly 45 of the 149 sites sit in buckets that
+can re-enter user code (`Proxy` STORE, `where` constraints, `AT-POS`/`ASSIGN-POS` overloads,
+`deepmap` callbacks, NativeCall outbound callbacks). A non-reentrant lock there deadlocks; a
+reentrant one does not exclude the second writer. It also declines "widen the lanes to every
+cross-thread-reachable container", because that is a whole-heap reachability question mutsu has no
+answer to and ADR-0039 §8.6 already documents why the cheap approximation fails.
+
+What it proposes instead is to repair the false premise above as the smallest provable slice —
+perform the structural mutation while holding the cell's own lock, or stop deferring to it — gated
+behind a process-global "more than one VM mutator thread is live" flag so single-threaded programs
+pay one relaxed atomic load. ADR-0013 §5 Q2 had deferred this cross-thread race with an explicit
+revisit condition, *"revisit only if gc-stress/S17 surfaces an actual race"*. That condition has now
+fired, with allocator corruption, on routes the `.act` fix cannot reach.
+
+No code landed. The deliverable is the design plus the audit, and in particular the harness and the
+oracle, so the next attempt does not spend its first several sessions failing to reproduce.

--- a/todo/deep/gc-contents-mut-cross-thread-aliased-writes.md
+++ b/todo/deep/gc-contents-mut-cross-thread-aliased-writes.md
@@ -6,6 +6,12 @@ This is the residue of `todo/deep/procasync-stress-segv.md`, which was closed on
 entry first: it has the evidence, the measurements, and the negative results from the
 memory checkers, none of which is repeated here.
 
+**Design status (2026-09-05): [ADR-0068](../../docs/adr/0068-cross-thread-container-writes-need-a-synchronized-store.md)
+is the `Proposed` design for this finding.** It carries the route audit, the calibrated
+reproduction harness, the path oracle, the deadlock quantification that rejects
+"synchronize the primitive", and the proposed remedy. This file is now the *open work
+item*; the ADR is the reasoning. Do not re-derive either from scratch.
+
 ## The general hazard
 
 `crate::gc::gc_contents_mut` is, in its own words, *"the codebase's single
@@ -21,71 +27,73 @@ Its `# Safety` clause already names the gap:
 > race deferred to ADR-0001 layer 3c).
 
 There are **149 call sites** and none of them establishes that. The shared-store lanes
-(`runtime/runtime_shared_vars.rs` — `assign_array_elem_to_shared_var`,
-`shared_array_elem_set`, `push_to_existing_shared_var`, `__mutsu_atomic_arr::`) are seeded
-from a `start` block's own captured environment. Any *other* way a container comes to be
-aliased by two VM threads bypasses them entirely, and then two threads can call
-`Vec::resize` / `HashMap::insert` on the same allocation at once. The damage is a
-double free or a use-after-free, which surfaces as a glibc corrupted-chunk abort inside
-`__libc_free` or as a bare SIGSEGV — both observed on CI, both with `Failed: 0`.
+(`runtime/runtime_shared_vars.rs`) are keyed by variable name and seeded from a spawning
+frame's env walk. Any *other* way a container comes to be aliased by two VM threads
+bypasses them entirely, and then two threads can call `Vec::resize` / `HashMap::insert` on
+the same allocation at once.
 
-The demonstrated route was a `Supply.act` tap closure's captured `my @seen`, aliased by
-every pool worker that emitted into the supplier. That one is closed: `.act` now takes the
-supply serialize group, so its callbacks cannot run concurrently. Other routes are not
-enumerated. Candidates worth auditing, roughly in order of how easily user code reaches
-them:
+## What the 2026-09-05 audit established
 
-- a `.tap` (not `.act`) callback's captured containers — `.tap` has no serialization
-  guarantee in Raku either, so this cannot be fixed by locking the dispatch; it needs the
-  store to be synchronized, or the capture to be routed through a shared lane
-- a `Channel` / `Promise` combinator callback's captured containers
-- an object attribute (`Instance` `AttrMap`) reachable from two threads, where the
-  element-store path takes the same `strong_count > 1` in-place branch
-- `Thread.start` bodies, which do not go through `clone_for_thread_for_block`'s seeding
+**The root cause is narrower and more specific than "149 unsynchronized sites".** The lane
+does not merely fail to cover the container — it *hands the write to a mechanism it
+believes is synchronized and is not*. `assign_array_elem_to_shared_var` returns `None` when
+the env entry is a `ContainerRef`, on the recorded premise that such an array *"is already
+shared through the Mutex"*. `ContainerCell`'s `Mutex` protects the cell's **`Value`**, not
+the container the `Value` points at: the element store clones the inner `Gc<ArrayData>` out
+from under the lock and then runs `gc_contents_mut` → `autoviv_resize` → `Vec::resize` with
+no lock held. On the confirmed-racing workload that `return None` fired 21/21 times. A
+container reaches that state whenever the closure machinery boxes it into a shared cell —
+most commonly because a **named sub closes over it**. See ADR-0068 §2.
 
-## Why it is deep, not a ticket
+### Route audit (measured, ADR-0068 §3)
 
-Every candidate remedy is an architectural call:
+| Route | Verdict |
+|---|---|
+| `Supply.act` tap captures | **Closed** by #7336 (0/240 after; 6/960 with the fix disabled) |
+| plain `.tap` callback captures | **RACES** — 4/960, with `free(): double free detected in tcache 2` and `double free or corruption (out)` core dumps. Not fixable by locking dispatch: `.tap` has no serialization guarantee in Raku |
+| `Promise.then` combinator callback captures | **RACES** — 3/240, lost updates |
+| `Thread.start` bodies | **Exposed** on the path oracle (21/0), same site as the two above |
+| `Channel.Supply` tap captures | **Exposed** on the path oracle (20/0), but blocked behind a separate deterministic Channel-supply delivery bug that drops/misorders values on a single unloaded run — fix that first or the race rate is unmeasurable |
+| Object attribute (`has @.seen is rw`) | **Unresolved** — reaches none of the probed aliased-store sites, nor `gc_data_mut`, nor the computed-attr sites. Needs its own path trace before it can be called covered or exposed |
 
-1. **Synchronize the primitive.** `gc_contents_mut` returns a `&mut T` that outlives the
-   call, so a guard cannot live inside it; the lock would have to be taken by each of the
-   149 callers around its own mutation region. Mechanical, but a large diff and a
-   deadlock-analysis obligation at every site that can call user code while holding it.
-2. **Widen the shared-store lanes** so any container that becomes cross-thread reachable
-   is registered, not just a `start` block's captures. This is the "right" fix in the
-   sense that it reuses the existing serialization, but "becomes cross-thread reachable"
-   is a reachability question mutsu has no answer to today.
-3. **Make the lock free when it is free.** Both of the above can gate on a
-   process-global "more than one VM mutator thread is live" flag, so single-threaded
-   programs pay one relaxed atomic load. That is what makes either affordable, and it
-   should be measured against the bench CI before being assumed cheap.
+Routes 1, 2 and 4 all corrupt through the **same** site
+(`vm/vm_var_assign_index_named.rs:2353`) — three doors into one room, which is what makes a
+store-side remedy tractable.
 
-This is ADR-0001 layer 3c territory and should get a `Proposed` ADR before any code.
+## Reproduction harness — this is the reusable part
+
+Previous attempts failed for a measurable reason, and the correction matters more than the
+old advice did:
+
+- **CPU oversubscription is the necessary ingredient, not concurrency.** At 8-way on 12
+  cores the *known-racing* pre-fix workload was 0/64 and 0/240 — clean. At **24-way on 12
+  cores** it failed 6/960 within seconds per batch. Every earlier "could not reproduce" in
+  this area was taken below that threshold and means nothing.
+- Run the **real workload** as separate processes under the `gc-stress` environment
+  (`MUTSU_GC=on MUTSU_GC_EVERY_CANDIDATE=1024 MUTSU_GC_VERIFY=1`) on a `--profile profiling`
+  build. mutsu's own `Vec` bounds check and glibc's allocator are the detectors.
+- **A hand-shrunk probe is not a substitute for the real file.** Five standalone probes
+  written from the racing test's own source were clean over 1440+ block executions at full
+  power *with the fix disabled*, because shrinking silently moved them onto the
+  **synchronized** lane.
+- **Use the path oracle before the stress harness.** `rust-gdb`'s ignore counter turns a
+  breakpoint into a free call counter with no rebuild; breaking on
+  `vm_var_assign_index_named.rs:2353` (unsynchronized) and
+  `Interpreter::shared_array_elem_set` (lane) classifies a workload as exposed-or-covered in
+  one debug run. See ADR-0068 §1.2 for the exact command.
+- **Do not start with `valgrind --tool=memcheck`** (0 errors on a demonstrably racing
+  workload — it serializes threads onto one core) or `helgrind` (cannot symbolize the
+  optimized binary). AddressSanitizer reports nothing either; it is useful only as a
+  *scheduler*, because its ~10x slowdown widens the window.
 
 ## The one instance that is NOT explained by the fixed path
 
-`roast/S17-procasync/stress.t` was the original ticket's subject: it died of SIGSEGV once,
-on CI run 30590633128 (2026-07-30), in the rakudo#3299 block that starts 1200
-`Proc::Async` instances inside a `react`. It has never reproduced since — roughly 130
-targeted local runs across four configurations, plus this session's runs, are all clean —
-and it has no `Supply.act` tap, so the `.act` fix does not obviously cover it. It uses
-`react`/`whenever`, which already had a serialize group, so if it is the same class the
-aliasing must come from somewhere else. Treat it as an open, unexplained instance of the
-general hazard above rather than as its own investigation: it is not reproducible, and
-chasing it directly has already consumed several sessions with nothing to show.
-
-## Reproduction harness
-
-`news/2026-09/supply-act-serialization-and-the-concurrency-crash-cluster.md` records what
-worked and what did not. The short version for whoever picks this up:
-
-- **Do not start with `valgrind --tool=memcheck`.** It serializes threads onto one core
-  and therefore suppresses the interleaving this class needs; it reported 0 errors on a
-  workload that was demonstrably racing.
-- **`helgrind` could not symbolize the binary** (`??? (in .../mutsu)`) or unwind an
-  optimized frame, so its 1000 contexts were unusable. If a race detector is wanted,
-  invest in ThreadSanitizer (`-Zsanitizer=thread`) rather than helgrind.
-- **What worked** was running the real workload many times concurrently under the
-  `gc-stress` environment and letting mutsu's own `Vec` bounds check fire. An
-  AddressSanitizer build helps not by reporting anything but by slowing execution ~10x,
-  which widens the window: the same file failed 2/36 under ASan versus 1/64 native.
+`roast/S17-procasync/stress.t` died of SIGSEGV once, on CI run 30590633128 (2026-07-30), in
+the rakudo#3299 block that starts 1200 `Proc::Async` instances inside a `react`. It has
+never reproduced — ~130 targeted local runs across four configurations, plus the 2026-09-05
+session's — and it has no `Supply.act` tap, so the `.act` fix does not obviously cover it.
+The 2026-09-05 audit does **not** explain it either. What it adds is a reason the hunts
+failed (all of them ran below the oversubscription threshold above) and a cheap next step:
+run that file under the 24-way harness, and run the path oracle over it to see whether its
+containers are on the lane at all. Treat it as an open, unexplained instance of the general
+hazard rather than as its own investigation.


### PR DESCRIPTION
`todo/deep/gc-contents-mut-cross-thread-aliased-writes.md` was the residue of the `Supply.act` crash cluster (#7336): one crashing route closed, the general hazard neither enumerated nor designed. This enumerates it, measures it, and records the design as [ADR-0068](docs/adr/0068-cross-thread-container-writes-need-a-synchronized-store.md) (`Proposed`). **Documentation only; no code lands.**

## The root cause is narrower and more specific than "149 unsynchronized sites"

The name-keyed lane does not merely fail to cover a container — it *hands the write to a mechanism it believes is synchronized and is not*. `assign_array_elem_to_shared_var` declines when the env entry is a `ContainerRef`, on the recorded premise that such an array *"is already shared through the Mutex"*. `ContainerCell`'s `Mutex` protects the cell's `Value` — the pointer — not the container the `Value` points at. The element store clones the inner `Gc<ArrayData>` out from under the lock, releases it, and then runs `gc_contents_mut` → `autoviv_resize` → `Vec::resize` with no lock held. On the confirmed-racing workload that `return None` fired 21/21 times.

A container reaches that state whenever the closure machinery boxes it into a shared cell — most commonly because a **named sub closes over it**.

## Route audit (measured)

| Route | Verdict |
|---|---|
| `Supply.act` tap captures | **Closed** by #7336 (0/240 after; 6/960 with the fix disabled) |
| plain `.tap` callback captures | **RACES** — 4/960, with `free(): double free detected in tcache 2` and `double free or corruption (out)` core dumps. Not fixable the way `.act` was: Raku gives `.tap` no serialization guarantee |
| `Promise.then` combinator captures | **RACES** — 3/240, lost updates |
| `Thread.start` bodies | **Exposed** on the path oracle, same site |
| `Channel.Supply` tap captures | **Exposed** on the oracle, blocked behind a separate deterministic delivery bug |
| Object attribute (`has @.seen is rw`) | **Unresolved** — reaches none of the probed aliased-store sites |

Three of those corrupt through the **same** site, which is what makes a store-side remedy tractable rather than a 149-site sweep.

## Harness correction — the most reusable part

**CPU oversubscription is the necessary ingredient, not concurrency.** The *known-racing* pre-fix workload was 0/64 and 0/240 at 8-way on 12 cores, and 6/960 at **24-way on 12 cores**. Every earlier "could not reproduce" in this area was taken below that threshold and carries no information.

**A hand-shrunk probe is not a substitute for the real file:** five standalone probes written from the racing test's own source were clean over 1440+ block executions at full power *with the fix deliberately disabled*, because shrinking silently moved them onto the synchronized lane.

The ADR also records a **path oracle** — `rust-gdb`'s ignore counter as a free call counter — that classifies a workload as exposed or covered in one debug run, and re-confirms the negatives on memcheck (0 errors; it serializes threads onto one core), helgrind (cannot symbolize an optimized binary) and ASan (reports nothing; useful only as a scheduler).

## What the ADR decides

It rejects **"synchronize the primitive"** on the record: `gc_contents_mut` hands back a `&mut T` that outlives the call, so the lock must be taken by each of the 149 callers, and roughly **45** of them sit in buckets that can re-enter user code (`Proxy` STORE, `where` constraints, `AT-POS`/`ASSIGN-POS` overloads, `deepmap` callbacks, NativeCall outbound callbacks) — a non-reentrant lock deadlocks, a reentrant one does not exclude the second writer. It declines **"widen the lanes"** as a whole-heap reachability question mutsu has no answer to (ADR-0039 §8.6 already documents why the cheap approximation fails). It proposes repairing the false premise above as the smallest provable slice, gated on a process-global "more than one VM mutator thread is live" flag.

This fires the revisit condition [ADR-0013](docs/adr/0013-container-interior-mutability-cellvalue.md) §5 Q2 set for itself — *"revisit only if gc-stress/S17 surfaces an actual race"* — now with allocator corruption, on routes the `.act` fix cannot reach. Level-2 (a MoarVM-style precise moving/tracing GC) is explicitly **not** proposed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
