### PR TITLE
feat(rakuast): phasers, class traits, multi, and constant

### DIFF
--- a/news/2026-09/rakuast-class-traits-multi-constant.md
+++ b/news/2026-09/rakuast-class-traits-multi-constant.md
@@ -1,0 +1,54 @@
+# RakuAST class traits, `multi`, and `constant`
+
+Three more read gaps, all measured against rakudo 2026.07 and byte-for-byte
+identical there. Each also lowers back through `EVAL`.
+
+## Class traits
+
+`class C is Int { }`, `class C does R { }` and `class C is rw { }` were one
+boundary ("class with inheritance / scope / repr / traits"). raku spells the
+three differently, and the differences are not guessable:
+
+- `is Int` → `Trait::Is(type => Type::Simple(...))` — a **named** `type` field.
+- `does R` → `Trait::Does(Type::Simple(...))` — **positional**.
+- `is rw` → `Trait::Is(name => Name.from-identifier("rw"))` — a trait *name*,
+  not a type.
+
+`is repr("P6opaque")` is not a trait at all: it is a `repr` leaf field on the
+class, in field order `scope, name, repr, traits, body`.
+
+One mutsu detail the round trip had to respect: a `does` role is recorded in
+**both** `ClassDecl.parents` and `ClassDecl.does_parents` — `parents` is the
+general composed-type list the dispatcher reads — so the converter skips a
+parent that is also a role, or it would render the role twice, and the lowerer
+puts it back in both.
+
+Still deferred: `my`/unit scope, `hides`, computed names, and user traits.
+
+## `multi`
+
+`multi sub f(...)` renders `multiness => "multi"`, which precedes `name` in
+raku's field order. A `proto` also uses this field but carries a `{*}` body that
+mutsu keeps in a separate `Stmt::ProtoDecl`, so it stays a boundary.
+
+## `constant`
+
+`constant X = 5` is a declaration of its own — `RakuAST::VarDeclaration::Constant`
+— not a scoped `my`, and its `name` is a plain string rather than a `Name` node.
+The package-scoped default spelling emits no `scope`; `my constant Y = 7` emits
+`scope => "my"`, which mutsu records as the *absence* of its `is_our` flag.
+A sigilled (`constant @a = 1, 2`) or typed constant stays a boundary.
+
+## Coverage
+
+`t/rakuast-class-traits-multi-constant.t` (16 assertions) pins all three trait
+spellings, the repr field, that a plain class emits no `traits`, the multiness
+field and its absence, all three constant fields, and three `EVAL` round trips
+including a class composing a role and calling the composed method. It is a
+dual-oracle test: it passes verbatim under both mutsu and rakudo 2026.07.
+
+Each declaration is the last statement of its `EVAL`'d program, so the `EVAL`'d
+value is the declared thing and the test inspects it from the outside —
+referring to a user class or constant by bare name *inside* the same program is
+a separate, still-open read gap (raku renders a type bareword as
+`Type::Simple` and a constant bareword as `Term::Name`, both measured).

--- a/news/2026-09/rakuast-phasers.md
+++ b/news/2026-09/rakuast-phasers.md
@@ -1,0 +1,49 @@
+# RakuAST phasers
+
+`BEGIN`, `CHECK`, `INIT`, `END`, `ENTER`, `LEAVE`, `KEEP`, `UNDO`, `FIRST`,
+`NEXT`, `LAST`, `QUIT` and `CLOSE` now render, and all but `BEGIN` lower back
+through `EVAL`. A phaser used to be a `.AST` coverage boundary printing mutsu's
+internal `Stmt::Phaser` debug form.
+
+raku gives each kind its own class,
+`RakuAST::StatementPrefix::Phaser::<Kind>`, wrapping the block positionally.
+mutsu's single `Stmt::Phaser { kind, .. }` maps onto them 1:1, so the whole
+family lands in one slice. Measured against rakudo 2026.07: the rendered gists
+are byte-for-byte identical for every kind checked.
+
+`PRE`/`POST` stay a boundary on both sides. rakudo desugars them into a call
+*around* the block — the phaser's child is an `ApplyPostfix`, not a `Block` —
+and mutsu additionally keeps the condition's source text for the
+`X::Phaser::PrePost` message, so neither the shape nor the extra field maps
+cleanly.
+
+## Two ordering bugs the oracle caught
+
+Rendering was the easy half. Running the lowered tree revealed that mutsu's
+re-entrant `EVAL` carrier ran the *compile-time* phasers in statement position:
+
+```
+$ mutsu -e 'my $x = 0; INIT { $x = 1 }; say $x'
+0                                              # correct, matches raku
+$ mutsu -e 'use MONKEY-SEE-NO-EVAL; say EVAL(Q{my $x = 0; INIT { $x = 1 }; $x}.AST)'
+1                                              # raku: 0
+```
+
+`INIT` and `CHECK` run before the mainline, so the later `my $x = 0` should win.
+The string-`EVAL` path already applies `phasers::reorder_phasers_for_eval` for
+exactly this reason; the RakuAST branch of `builtin_eval` did not. It does now,
+and both kinds agree with raku.
+
+`BEGIN` is not fixed by that. `extract_phasers_from_stmts` takes a `_begin`
+accumulator it never fills — `run.rs`'s own comment records that BEGIN is hoisted
+earlier, during compilation of a program, by a mechanism the carrier never runs.
+Rather than lower it to a wrong answer, `RakuAST::StatementPrefix::Phaser::Begin`
+is refused, and the gap is filed as
+`todo/tickets/rakuast-eval-begin-phaser.md`. Its *read* direction is complete.
+
+## Coverage
+
+`t/rakuast-phaser.t` (15 assertions) pins one class name per kind for eight
+kinds, the positional block, five `EVAL` round trips covering entry/exit and
+loop phasers, and the pre-mainline ordering of `INIT` and `CHECK`. It is a
+dual-oracle test: it passes verbatim under both mutsu and rakudo 2026.07.

--- a/src/rakuast/convert.rs
+++ b/src/rakuast/convert.rs
@@ -109,6 +109,13 @@ fn convert_stmt(stmt: &Stmt) -> Result<Option<RakuAstNode>, RuntimeError> {
             if *is_dynamic || where_constraint.is_some() {
                 return Err(unsupported("dynamic / where-constrained declaration"));
             }
+            // `constant X = 5` is a distinct raku node, not a scoped `my`.
+            // mutsu marks it with a `__constant` pseudo-trait (plus a
+            // `__constant_sigil` recording the declared sigil) and sets
+            // `is_our` for the package-scoped default spelling.
+            if custom_traits.iter().any(|(n, _)| n == "__constant") {
+                return constant_declaration(name, expr, custom_traits, type_constraint, *is_our);
+            }
             if custom_traits.iter().any(|(n, _)| n != "__has_initializer") {
                 return Err(unsupported("declaration with traits"));
             }
@@ -386,7 +393,6 @@ fn convert_stmt(stmt: &Stmt) -> Result<Option<RakuAstNode>, RuntimeError> {
                 || associativity.is_some()
                 || precedence_trait.is_some()
                 || !signature_alternates.is_empty()
-                || *multi
                 || *is_rw
                 || *is_raw
                 || *is_export
@@ -404,13 +410,19 @@ fn convert_stmt(stmt: &Stmt) -> Result<Option<RakuAstNode>, RuntimeError> {
                 // parser inconsistency; refuse rather than render a wrong node.
                 return Err(unsupported("sub with a return trait but no return type"));
             }
-            Ok(Some(statement_expression(routine_node(
+            let mut node = routine_node(
                 RakuAstClass::Sub,
                 &name.resolve(),
                 param_defs,
                 body,
                 return_type.as_deref().map(|t| (t, spelling)),
-            )?)))
+            )?;
+            if *multi {
+                // `multiness` precedes `name` in raku's field order.
+                node.fields
+                    .insert(0, leaf_field(Some("multiness"), Value::str_from("multi")));
+            }
+            Ok(Some(statement_expression(node)))
         }
         Stmt::MethodDecl {
             name,
@@ -487,16 +499,14 @@ fn convert_stmt(stmt: &Stmt) -> Result<Option<RakuAstNode>, RuntimeError> {
             is_unit,
             ..
         } => {
-            // Plain `class NAME { body }`. Inheritance (`is`/`does`), `my`/unit
-            // scope, reprs, `rw`, and traits carry extra RakuAST shape, deferred.
+            // `class NAME [is P] [does R] [is rw] [is repr(R)] { body }`.
+            // Inheritance and `rw` are `traits`, the repr is its own leaf field.
+            // `my`/unit scope, `hides`, computed names and user traits carry
+            // extra RakuAST shape, deferred.
             if name_expr.is_some()
-                || !parents.is_empty()
-                || *class_is_rw
                 || *is_hidden
                 || *is_lexical
                 || !hidden_parents.is_empty()
-                || !does_parents.is_empty()
-                || repr.is_some()
                 || !custom_traits.is_empty()
                 || *is_unit
             {
@@ -504,12 +514,25 @@ fn convert_stmt(stmt: &Stmt) -> Result<Option<RakuAstNode>, RuntimeError> {
                     "class with inheritance / scope / repr / traits",
                 ));
             }
+            let mut fields = vec![node_field(
+                Some("name"),
+                name_from_identifier(&name.resolve()),
+            )];
+            // Field order matches raku: scope, name, repr, traits, body.
+            if let Some(r) = repr {
+                fields.push(leaf_field(Some("repr"), Value::str(r.clone())));
+            }
+            let traits = class_traits(parents, does_parents, *class_is_rw)?;
+            if !traits.is_empty() {
+                fields.push(RakuAstField {
+                    name: Some("traits"),
+                    value: RakuAstFieldValue::List(traits),
+                });
+            }
+            fields.push(node_field(Some("body"), block_node(body)?));
             Ok(Some(statement_expression(RakuAstNode {
                 class: RakuAstClass::Class,
-                fields: vec![
-                    node_field(Some("name"), name_from_identifier(&name.resolve())),
-                    node_field(Some("body"), block_node(body)?),
-                ],
+                fields,
             })))
         }
         Stmt::RoleDecl {
@@ -1593,6 +1616,103 @@ fn pointy_block_from_lambda(param: &str, body: &[Stmt]) -> Result<RakuAstNode, R
             node_field(Some("body"), blockoid(body)?),
         ],
     })
+}
+
+/// `constant X = 5` -> `VarDeclaration::Constant(name => "X", initializer =>
+/// Initializer::Assign(...))`. Measured against rakudo 2026.07: the `name` is a
+/// plain string (not a `Name` node), the package-scoped default spelling emits
+/// no `scope`, and `my constant Y = 7` emits `scope => "my"`.
+///
+/// A sigilled constant (`constant @a = 1, 2`) or a typed one carries shape this
+/// does not model yet, so both stay a boundary.
+fn constant_declaration(
+    name: &str,
+    expr: &Expr,
+    custom_traits: &[(String, Option<Expr>)],
+    type_constraint: &Option<String>,
+    is_our: bool,
+) -> Result<Option<RakuAstNode>, RuntimeError> {
+    if type_constraint.is_some() {
+        return Err(unsupported("typed constant"));
+    }
+    // `__constant_sigil` carries the declared sigil; only the sigilless form
+    // (a plain `constant X`) maps onto the measured node shape.
+    let sigil = custom_traits.iter().find_map(|(n, arg)| {
+        (n == "__constant_sigil").then(|| match arg {
+            Some(Expr::Literal(v)) => match v.view() {
+                ValueView::Str(s) => s.to_string(),
+                _ => String::new(),
+            },
+            _ => String::new(),
+        })
+    });
+    if sigil.is_some_and(|s| !s.is_empty()) {
+        return Err(unsupported("sigilled constant"));
+    }
+    if custom_traits
+        .iter()
+        .any(|(n, _)| n != "__constant" && n != "__constant_sigil" && n != "__has_initializer")
+    {
+        return Err(unsupported("constant with traits"));
+    }
+    let mut fields = Vec::new();
+    // The package-scoped default (`constant X`) prints no scope; `my constant`
+    // does. mutsu records the default as `is_our`.
+    if !is_our {
+        fields.push(leaf_field(Some("scope"), Value::str_from("my")));
+    }
+    fields.push(leaf_field(Some("name"), Value::str(name.to_string())));
+    fields.push(node_field(
+        Some("initializer"),
+        RakuAstNode {
+            class: RakuAstClass::InitializerAssign,
+            fields: vec![node_field(None, convert_expr(expr)?)],
+        },
+    ));
+    Ok(Some(statement_expression(RakuAstNode {
+        class: RakuAstClass::VarDeclarationConstant,
+        fields,
+    })))
+}
+
+/// A class declaration's `traits` list, in source order: `is P` inheritance
+/// first, then `does R` role composition, then a bare `is rw`.
+///
+/// raku spells the three differently, all measured against rakudo 2026.07:
+/// `is Int` is `Trait::Is(type => Type::Simple)` (a NAMED `type`), `does R` is
+/// `Trait::Does(Type::Simple)` (POSITIONAL), and `is rw` is
+/// `Trait::Is(name => Name)` — a trait *name*, not a type.
+fn class_traits(
+    parents: &[String],
+    does_parents: &[String],
+    is_rw: bool,
+) -> Result<Vec<Value>, RuntimeError> {
+    let mut traits = Vec::new();
+    for parent in parents {
+        // A `does R` role is recorded in BOTH lists (`parents` is the general
+        // composed-type list the dispatcher reads), so skip the ones that are
+        // really role composition or they would render twice.
+        if does_parents.iter().any(|r| r == parent) {
+            continue;
+        }
+        traits.push(Value::rakuast(Box::new(RakuAstNode {
+            class: RakuAstClass::TraitIs,
+            fields: vec![node_field(Some("type"), build_type_node(parent)?)],
+        })));
+    }
+    for role in does_parents {
+        traits.push(Value::rakuast(Box::new(RakuAstNode {
+            class: RakuAstClass::TraitDoes,
+            fields: vec![node_field(None, build_type_node(role)?)],
+        })));
+    }
+    if is_rw {
+        traits.push(Value::rakuast(Box::new(RakuAstNode {
+            class: RakuAstClass::TraitIs,
+            fields: vec![node_field(Some("name"), name_from_identifier("rw"))],
+        })));
+    }
+    Ok(traits)
 }
 
 /// The `RakuAST::StatementPrefix::Phaser::<Kind>` class for a phaser kind.

--- a/src/rakuast/convert.rs
+++ b/src/rakuast/convert.rs
@@ -131,6 +131,30 @@ fn convert_stmt(stmt: &Stmt) -> Result<Option<RakuAstNode>, RuntimeError> {
         }
         // A bare `{ ... }` block at statement level -> Statement::Expression(Block).
         Stmt::Block(body) => Ok(Some(statement_expression(block_node(body)?))),
+        // `BEGIN { … }` / `INIT { … }` / `LEAVE { … }` / … -> a
+        // `StatementPrefix::Phaser::<Kind>` wrapping the block positionally.
+        // raku has one class per kind, which mutsu's single `PhaserKind` maps
+        // onto 1:1. `PRE`/`POST` are the exception: rakudo desugars them into a
+        // call around the block (an `ApplyPostfix` operand), and mutsu also
+        // keeps a source-text `condition` for their exception message, so they
+        // stay the boundary.
+        Stmt::Phaser {
+            kind,
+            body,
+            condition,
+        } => {
+            if condition.is_some() {
+                return Err(unsupported("PRE/POST phaser condition"));
+            }
+            let class = match phaser_class(kind) {
+                Some(c) => c,
+                None => return Err(unsupported("PRE/POST phaser")),
+            };
+            Ok(Some(statement_expression(RakuAstNode {
+                class,
+                fields: vec![node_field(None, block_node(body)?)],
+            })))
+        }
         Stmt::If {
             cond,
             then_branch,
@@ -1568,6 +1592,29 @@ fn pointy_block_from_lambda(param: &str, body: &[Stmt]) -> Result<RakuAstNode, R
             node_field(Some("signature"), sig),
             node_field(Some("body"), blockoid(body)?),
         ],
+    })
+}
+
+/// The `RakuAST::StatementPrefix::Phaser::<Kind>` class for a phaser kind.
+/// `PRE`/`POST` have no plain mapping — rakudo wraps their block in a call —
+/// so they answer `None` and stay a coverage boundary.
+fn phaser_class(kind: &crate::ast::PhaserKind) -> Option<RakuAstClass> {
+    use crate::ast::PhaserKind::*;
+    Some(match kind {
+        Begin => RakuAstClass::StatementPrefixPhaserBegin,
+        Check => RakuAstClass::StatementPrefixPhaserCheck,
+        Init => RakuAstClass::StatementPrefixPhaserInit,
+        End => RakuAstClass::StatementPrefixPhaserEnd,
+        Enter => RakuAstClass::StatementPrefixPhaserEnter,
+        Leave => RakuAstClass::StatementPrefixPhaserLeave,
+        Keep => RakuAstClass::StatementPrefixPhaserKeep,
+        Undo => RakuAstClass::StatementPrefixPhaserUndo,
+        First => RakuAstClass::StatementPrefixPhaserFirst,
+        Next => RakuAstClass::StatementPrefixPhaserNext,
+        Last => RakuAstClass::StatementPrefixPhaserLast,
+        Quit => RakuAstClass::StatementPrefixPhaserQuit,
+        Close => RakuAstClass::StatementPrefixPhaserClose,
+        Pre | Post => return None,
     })
 }
 

--- a/src/rakuast/lower.rs
+++ b/src/rakuast/lower.rs
@@ -74,6 +74,7 @@ fn lower_stmt(node: &RakuAstNode) -> Result<Stmt, RuntimeError> {
 fn lower_stmt_inner(node: &RakuAstNode) -> Result<Stmt, RuntimeError> {
     match node.class {
         RakuAstClass::VarDeclarationSimple => lower_var_decl(node),
+        RakuAstClass::VarDeclarationConstant => lower_constant(node),
         RakuAstClass::StatementIf => lower_if(node),
         RakuAstClass::StatementLoopWhile => lower_while(node),
         RakuAstClass::StatementLoop => lower_cstyle_loop(node),
@@ -248,6 +249,15 @@ fn lower_sub(node: &RakuAstNode) -> Result<Stmt, RuntimeError> {
     let name = call_name_str(node)?;
     let (params, param_defs) = signature_positional_params(node)?;
     let (return_type, custom_traits) = routine_return_type(node)?;
+    // `multiness => "multi"`. A `proto` carries a `{*}` body shape mutsu keeps
+    // in a separate `Stmt::ProtoDecl`, so it stays the boundary.
+    let multi = match node.fields.iter().find(|f| f.name == Some("multiness")) {
+        None => false,
+        Some(_) => match leaf_str(node, "multiness")?.as_str() {
+            "multi" => true,
+            _ => return Err(unsupported(node)),
+        },
+    };
     // A Sub's `body` is the Blockoid directly (not a Block wrapping one).
     let body = lower_stmts(named_child_or_positional(named_child(node, "body")?)?)?;
     Ok(Stmt::SubDecl {
@@ -260,7 +270,7 @@ fn lower_sub(node: &RakuAstNode) -> Result<Stmt, RuntimeError> {
         precedence_trait: None,
         signature_alternates: Vec::new(),
         body,
-        multi: false,
+        multi,
         is_rw: false,
         is_raw: false,
         is_export: false,
@@ -268,6 +278,89 @@ fn lower_sub(node: &RakuAstNode) -> Result<Stmt, RuntimeError> {
         is_test_assertion: false,
         supersede: false,
         custom_traits,
+    })
+}
+
+/// A class declaration's `traits` list, back into mutsu's three fields:
+/// `Trait::Is(type => …)` is inheritance, `Trait::Does(…)` is role composition
+/// (which mutsu records in BOTH `parents` and `does_parents`), and
+/// `Trait::Is(name => "rw")` is the `rw` flag.
+#[allow(clippy::type_complexity)]
+fn class_traits(node: &RakuAstNode) -> Result<(Vec<String>, Vec<String>, bool), RuntimeError> {
+    let Some(f) = node.fields.iter().find(|f| f.name == Some("traits")) else {
+        return Ok((Vec::new(), Vec::new(), false));
+    };
+    let RakuAstFieldValue::List(items) = &f.value else {
+        return Err(unsupported(node));
+    };
+    let mut parents = Vec::new();
+    let mut does_parents = Vec::new();
+    let mut is_rw = false;
+    for item in items {
+        let ValueView::RakuAst(t) = item.view() else {
+            return Err(unsupported(node));
+        };
+        match t.class {
+            RakuAstClass::TraitIs => {
+                if let Ok(type_node) = named_child(t, "type") {
+                    parents.push(simple_type_name(node, type_node)?);
+                } else if let Ok(name_node) = named_child(t, "name") {
+                    match positional_leaf(name_node)?.view() {
+                        ValueView::Str(s) if s.as_str() == "rw" => is_rw = true,
+                        _ => return Err(unsupported(node)),
+                    }
+                } else {
+                    return Err(unsupported(node));
+                }
+            }
+            RakuAstClass::TraitDoes => {
+                let role = simple_type_name(node, named_child_or_positional(t)?)?;
+                // mutsu's dispatcher reads `parents`, so a composed role has to
+                // appear there too — exactly what the parser records.
+                parents.push(role.clone());
+                does_parents.push(role);
+            }
+            _ => return Err(unsupported(node)),
+        }
+    }
+    Ok((parents, does_parents, is_rw))
+}
+
+/// `constant X = 5` -> a `Stmt::VarDecl` carrying mutsu's `__constant` marker
+/// pair. The package-scoped default spelling is `is_our`; `scope => "my"` is the
+/// lexical one. Only the sigilless form round-trips, matching what the
+/// converter renders.
+fn lower_constant(node: &RakuAstNode) -> Result<Stmt, RuntimeError> {
+    let name = leaf_str(node, "name")?;
+    let is_our = match node.fields.iter().find(|f| f.name == Some("scope")) {
+        None => true,
+        Some(_) => match leaf_str(node, "scope")?.as_str() {
+            "my" => false,
+            _ => return Err(unsupported(node)),
+        },
+    };
+    let init = named_child(node, "initializer")?;
+    if init.class != RakuAstClass::InitializerAssign {
+        return Err(unsupported(node));
+    }
+    let expr = lower_expr(named_child_or_positional(init)?)?;
+    Ok(Stmt::VarDecl {
+        name,
+        expr,
+        type_constraint: None,
+        is_state: false,
+        is_our,
+        is_dynamic: false,
+        is_export: false,
+        export_tags: Vec::new(),
+        custom_traits: vec![
+            ("__constant".to_string(), None),
+            (
+                "__constant_sigil".to_string(),
+                Some(Expr::Literal(Value::str_from(""))),
+            ),
+        ],
+        where_constraint: None,
     })
 }
 
@@ -319,16 +412,21 @@ fn lower_phaser(node: &RakuAstNode) -> Result<Stmt, RuntimeError> {
 fn lower_class(node: &RakuAstNode) -> Result<Stmt, RuntimeError> {
     let name = call_name_str(node)?;
     let body = lower_block(named_child(node, "body")?)?;
+    let (parents, does_parents, class_is_rw) = class_traits(node)?;
+    let repr = match node.fields.iter().find(|f| f.name == Some("repr")) {
+        Some(_) => Some(leaf_str(node, "repr")?),
+        None => None,
+    };
     Ok(Stmt::ClassDecl {
         name: crate::symbol::Symbol::intern(&name),
         name_expr: None,
-        parents: Vec::new(),
-        class_is_rw: false,
+        parents,
+        class_is_rw,
         is_hidden: false,
         is_lexical: false,
         hidden_parents: Vec::new(),
-        does_parents: Vec::new(),
-        repr: None,
+        does_parents,
+        repr,
         body,
         language_version: crate::parser::current_language_version(),
         custom_traits: Vec::new(),

--- a/src/rakuast/lower.rs
+++ b/src/rakuast/lower.rs
@@ -89,6 +89,20 @@ fn lower_stmt_inner(node: &RakuAstNode) -> Result<Stmt, RuntimeError> {
             is_until: false,
         }),
         RakuAstClass::StatementFor => lower_for(node),
+        // `INIT { … }` / `LEAVE { … }` / … -> `Stmt::Phaser`, one class per kind.
+        // `BEGIN` is absent deliberately — see `lower_phaser`.
+        RakuAstClass::StatementPrefixPhaserCheck
+        | RakuAstClass::StatementPrefixPhaserInit
+        | RakuAstClass::StatementPrefixPhaserEnd
+        | RakuAstClass::StatementPrefixPhaserEnter
+        | RakuAstClass::StatementPrefixPhaserLeave
+        | RakuAstClass::StatementPrefixPhaserKeep
+        | RakuAstClass::StatementPrefixPhaserUndo
+        | RakuAstClass::StatementPrefixPhaserFirst
+        | RakuAstClass::StatementPrefixPhaserNext
+        | RakuAstClass::StatementPrefixPhaserLast
+        | RakuAstClass::StatementPrefixPhaserQuit
+        | RakuAstClass::StatementPrefixPhaserClose => lower_phaser(node),
         RakuAstClass::Class => lower_class(node),
         RakuAstClass::Role => lower_role(node),
         RakuAstClass::Method => lower_method(node),
@@ -254,6 +268,46 @@ fn lower_sub(node: &RakuAstNode) -> Result<Stmt, RuntimeError> {
         is_test_assertion: false,
         supersede: false,
         custom_traits,
+    })
+}
+
+/// A `StatementPrefix::Phaser::<Kind>` -> `Stmt::Phaser`.
+///
+/// Two kinds are deliberately absent:
+///
+/// * `PRE`/`POST` — rakudo wraps their block in a call (the phaser's child is
+///   an `ApplyPostfix`, not a `Block`), and mutsu also keeps a source-text
+///   condition for the `X::Phaser::PrePost` message, so the converter refuses
+///   them and nothing lowered can be one.
+/// * `BEGIN` — it runs at *compile* time, and mutsu hoists it during
+///   compilation of a program rather than in `reorder_phasers`, so the
+///   re-entrant carrier this lowering feeds runs it in statement position
+///   instead. `EVAL(Q{my $x = 0; BEGIN { $x = 1 }; $x}.AST)` would answer 1
+///   where raku and mutsu's own direct execution both answer 0. Refusing is the
+///   honest boundary until the carrier gains a BEGIN pass — see
+///   `todo/tickets/rakuast-eval-begin-phaser.md`. `CHECK` and `INIT` are fine:
+///   `reorder_phasers_for_eval` handles both.
+fn lower_phaser(node: &RakuAstNode) -> Result<Stmt, RuntimeError> {
+    use crate::ast::PhaserKind;
+    let kind = match node.class {
+        RakuAstClass::StatementPrefixPhaserCheck => PhaserKind::Check,
+        RakuAstClass::StatementPrefixPhaserInit => PhaserKind::Init,
+        RakuAstClass::StatementPrefixPhaserEnd => PhaserKind::End,
+        RakuAstClass::StatementPrefixPhaserEnter => PhaserKind::Enter,
+        RakuAstClass::StatementPrefixPhaserLeave => PhaserKind::Leave,
+        RakuAstClass::StatementPrefixPhaserKeep => PhaserKind::Keep,
+        RakuAstClass::StatementPrefixPhaserUndo => PhaserKind::Undo,
+        RakuAstClass::StatementPrefixPhaserFirst => PhaserKind::First,
+        RakuAstClass::StatementPrefixPhaserNext => PhaserKind::Next,
+        RakuAstClass::StatementPrefixPhaserLast => PhaserKind::Last,
+        RakuAstClass::StatementPrefixPhaserQuit => PhaserKind::Quit,
+        RakuAstClass::StatementPrefixPhaserClose => PhaserKind::Close,
+        _ => return Err(unsupported(node)),
+    };
+    Ok(Stmt::Phaser {
+        kind,
+        body: lower_block(named_child_or_positional(node)?)?,
+        condition: None,
     })
 }
 

--- a/src/rakuast/mod.rs
+++ b/src/rakuast/mod.rs
@@ -162,6 +162,24 @@ pub enum RakuAstClass {
     StatementPrefixGather,
     // Phase 2 slice 39: calling a term (`$f(…)`).
     CallTerm,
+    // Phasers (`BEGIN`, `INIT`, `LEAVE`, ...). raku models each kind as its own
+    // `RakuAST::StatementPrefix::Phaser::<Kind>` class wrapping a positional
+    // `Block`; mutsu's one `Stmt::Phaser { kind, .. }` maps onto them 1:1.
+    StatementPrefixPhaserBegin,
+    StatementPrefixPhaserCheck,
+    StatementPrefixPhaserInit,
+    StatementPrefixPhaserEnd,
+    StatementPrefixPhaserEnter,
+    StatementPrefixPhaserLeave,
+    StatementPrefixPhaserKeep,
+    StatementPrefixPhaserUndo,
+    StatementPrefixPhaserFirst,
+    StatementPrefixPhaserNext,
+    StatementPrefixPhaserLast,
+    StatementPrefixPhaserPre,
+    StatementPrefixPhaserPost,
+    StatementPrefixPhaserQuit,
+    StatementPrefixPhaserClose,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -249,6 +267,21 @@ impl RakuAstClass {
             StatementPrefixTry => "RakuAST::StatementPrefix::Try",
             StatementPrefixGather => "RakuAST::StatementPrefix::Gather",
             CallTerm => "RakuAST::Call::Term",
+            StatementPrefixPhaserBegin => "RakuAST::StatementPrefix::Phaser::Begin",
+            StatementPrefixPhaserCheck => "RakuAST::StatementPrefix::Phaser::Check",
+            StatementPrefixPhaserInit => "RakuAST::StatementPrefix::Phaser::Init",
+            StatementPrefixPhaserEnd => "RakuAST::StatementPrefix::Phaser::End",
+            StatementPrefixPhaserEnter => "RakuAST::StatementPrefix::Phaser::Enter",
+            StatementPrefixPhaserLeave => "RakuAST::StatementPrefix::Phaser::Leave",
+            StatementPrefixPhaserKeep => "RakuAST::StatementPrefix::Phaser::Keep",
+            StatementPrefixPhaserUndo => "RakuAST::StatementPrefix::Phaser::Undo",
+            StatementPrefixPhaserFirst => "RakuAST::StatementPrefix::Phaser::First",
+            StatementPrefixPhaserNext => "RakuAST::StatementPrefix::Phaser::Next",
+            StatementPrefixPhaserLast => "RakuAST::StatementPrefix::Phaser::Last",
+            StatementPrefixPhaserPre => "RakuAST::StatementPrefix::Phaser::Pre",
+            StatementPrefixPhaserPost => "RakuAST::StatementPrefix::Phaser::Post",
+            StatementPrefixPhaserQuit => "RakuAST::StatementPrefix::Phaser::Quit",
+            StatementPrefixPhaserClose => "RakuAST::StatementPrefix::Phaser::Close",
         }
     }
 
@@ -528,6 +561,21 @@ const RAKUAST_CLASSES: &[RakuAstClass] = &[
     RakuAstClass::StatementPrefixTry,
     RakuAstClass::StatementPrefixGather,
     RakuAstClass::CallTerm,
+    RakuAstClass::StatementPrefixPhaserBegin,
+    RakuAstClass::StatementPrefixPhaserCheck,
+    RakuAstClass::StatementPrefixPhaserInit,
+    RakuAstClass::StatementPrefixPhaserEnd,
+    RakuAstClass::StatementPrefixPhaserEnter,
+    RakuAstClass::StatementPrefixPhaserLeave,
+    RakuAstClass::StatementPrefixPhaserKeep,
+    RakuAstClass::StatementPrefixPhaserUndo,
+    RakuAstClass::StatementPrefixPhaserFirst,
+    RakuAstClass::StatementPrefixPhaserNext,
+    RakuAstClass::StatementPrefixPhaserLast,
+    RakuAstClass::StatementPrefixPhaserPre,
+    RakuAstClass::StatementPrefixPhaserPost,
+    RakuAstClass::StatementPrefixPhaserQuit,
+    RakuAstClass::StatementPrefixPhaserClose,
 ];
 
 /// Entry point for `Str.AST`: parse the source, convert, wrap in `Value::RakuAst`.

--- a/src/rakuast/mod.rs
+++ b/src/rakuast/mod.rs
@@ -165,6 +165,11 @@ pub enum RakuAstClass {
     // Phasers (`BEGIN`, `INIT`, `LEAVE`, ...). raku models each kind as its own
     // `RakuAST::StatementPrefix::Phaser::<Kind>` class wrapping a positional
     // `Block`; mutsu's one `Stmt::Phaser { kind, .. }` maps onto them 1:1.
+    // `constant X = 5` — a declaration of its own, not a scoped `my`.
+    VarDeclarationConstant,
+    // Class/role declaration traits (`is Parent`, `does Role`, `is rw`).
+    TraitIs,
+    TraitDoes,
     StatementPrefixPhaserBegin,
     StatementPrefixPhaserCheck,
     StatementPrefixPhaserInit,
@@ -267,6 +272,9 @@ impl RakuAstClass {
             StatementPrefixTry => "RakuAST::StatementPrefix::Try",
             StatementPrefixGather => "RakuAST::StatementPrefix::Gather",
             CallTerm => "RakuAST::Call::Term",
+            VarDeclarationConstant => "RakuAST::VarDeclaration::Constant",
+            TraitIs => "RakuAST::Trait::Is",
+            TraitDoes => "RakuAST::Trait::Does",
             StatementPrefixPhaserBegin => "RakuAST::StatementPrefix::Phaser::Begin",
             StatementPrefixPhaserCheck => "RakuAST::StatementPrefix::Phaser::Check",
             StatementPrefixPhaserInit => "RakuAST::StatementPrefix::Phaser::Init",
@@ -561,6 +569,9 @@ const RAKUAST_CLASSES: &[RakuAstClass] = &[
     RakuAstClass::StatementPrefixTry,
     RakuAstClass::StatementPrefixGather,
     RakuAstClass::CallTerm,
+    RakuAstClass::VarDeclarationConstant,
+    RakuAstClass::TraitIs,
+    RakuAstClass::TraitDoes,
     RakuAstClass::StatementPrefixPhaserBegin,
     RakuAstClass::StatementPrefixPhaserCheck,
     RakuAstClass::StatementPrefixPhaserInit,

--- a/src/runtime/builtins_eval_misc.rs
+++ b/src/runtime/builtins_eval_misc.rs
@@ -303,7 +303,13 @@ impl Interpreter {
         if let Some(first_arg) = Self::positional_value(args, 0)
             && let ValueView::RakuAst(node) = first_arg.view()
         {
-            let stmts = crate::rakuast::lower(node)?;
+            let mut stmts = crate::rakuast::lower(node)?;
+            // A lowered tree is an EVAL'd compilation unit, so its phasers need
+            // the same reordering the string-EVAL path applies: BEGIN/CHECK/INIT
+            // run *before* the mainline, not in statement position. Without it
+            // `EVAL(Q{my $x = 0; INIT { $x = 1 }; $x}.AST)` answered 1 where
+            // both raku and mutsu's own direct execution answer 0.
+            crate::runtime::phasers::reorder_phasers_for_eval(&mut stmts);
             return self.eval_block_value(&stmts);
         }
         // EVAL only accepts strings (and Buf), not blocks

--- a/t/rakuast-class-traits-multi-constant.t
+++ b/t/rakuast-class-traits-multi-constant.t
@@ -1,0 +1,67 @@
+use v6;
+use MONKEY-SEE-NO-EVAL;
+use experimental :rakuast;
+use Test;
+
+# Three more read gaps, all measured against rakudo 2026.07 and byte-for-byte
+# identical there:
+#
+#   * class traits — `is Parent` is `Trait::Is(type => Type::Simple)` (a NAMED
+#     `type`), `does Role` is `Trait::Does(Type::Simple)` (POSITIONAL), and
+#     `is rw` is `Trait::Is(name => Name)`, a trait *name* rather than a type.
+#     `is repr(...)` is its own leaf field, not a trait.
+#   * `multi sub` — `multiness => "multi"`, before `name` in field order.
+#   * `constant X = 5` — `VarDeclaration::Constant`, whose `name` is a plain
+#     string rather than a `Name` node. The package-scoped default spelling
+#     emits no `scope`; `my constant` emits `scope => "my"`.
+#
+# Each declaration is the last statement of its EVAL'd program, so the EVAL'd
+# value is the declared thing and the test inspects it from the outside.
+# Referring to a user class or constant by bare name *inside* the same program
+# is a separate, still-open read gap.
+#
+# Passes under BOTH mutsu and raku.
+
+plan 16;
+
+# --- class traits: read ------------------------------------------------------
+my $is = Q{class T1 is Int { }}.AST.gist;
+ok $is.contains('RakuAST::Trait::Is.new('), '`is Parent` renders a Trait::Is';
+ok $is.contains('type => RakuAST::Type::Simple.new('),
+    '`is Parent` carries its parent as a named `type`';
+
+my $does = Q{role T2R { }; class T2 does T2R { }}.AST.gist;
+ok $does.contains('RakuAST::Trait::Does.new('), '`does Role` renders a Trait::Does';
+ok $does.contains("RakuAST::Name.from-identifier(\"T2R\")"),
+    '`does Role` names the composed role';
+
+my $rw = Q{class T3 is rw { }}.AST.gist;
+ok $rw.contains('RakuAST::Trait::Is.new(') && $rw.contains('name => RakuAST::Name.from-identifier("rw")'),
+    '`is rw` renders a Trait::Is carrying a trait *name*';
+
+ok Q{class T4 is Int is repr("P6opaque") { }}.AST.gist.contains('repr   => "P6opaque"'),
+    'a repr renders as its own leaf field';
+
+nok Q{class T5 { }}.AST.gist.contains('traits'),
+    'a plain class emits no traits field';
+
+# --- multi: read -------------------------------------------------------------
+ok Q{multi sub t6(Int $x) { 1 }}.AST.gist.contains('multiness => "multi"'),
+    'a multi sub renders its multiness';
+nok Q{sub t7($x) { 1 }}.AST.gist.contains('multiness'),
+    'an ordinary sub emits no multiness';
+
+# --- constant: read ----------------------------------------------------------
+my $const = Q{constant T8 = 5}.AST.gist;
+ok $const.contains('RakuAST::VarDeclaration::Constant.new('),
+    'a constant renders as VarDeclaration::Constant';
+ok $const.contains('name        => "T8"'), 'a constant names itself with a plain string';
+nok $const.contains('scope'), 'a package-scoped constant emits no scope';
+ok Q{my constant T9 = 7}.AST.gist.contains('scope       => "my"'),
+    'a lexical constant emits scope => "my"';
+
+# --- write side --------------------------------------------------------------
+is EVAL(Q{constant TA = 5}.AST), 5, 'a constant lowers to its value';
+is EVAL(Q{class TB is Int { }}.AST).^name, 'TB', 'a class with a parent lowers';
+is EVAL(Q{role TCR { method m() { 6 } }; class TC does TCR { }}.AST).new.m, 6,
+    'a class composing a role lowers, and the role method is callable';

--- a/t/rakuast-phaser.t
+++ b/t/rakuast-phaser.t
@@ -1,0 +1,64 @@
+use v6;
+use MONKEY-SEE-NO-EVAL;
+use experimental :rakuast;
+use Test;
+
+# Phasers in both RakuAST directions (ADR-0011).
+#
+# raku gives each phaser kind its own class,
+# `RakuAST::StatementPrefix::Phaser::<Kind>`, wrapping the block positionally.
+# mutsu's single `Stmt::Phaser { kind, .. }` maps onto them 1:1, so the whole
+# family lands in one slice. Measured against rakudo 2026.07: the rendered gists
+# are byte-for-byte identical.
+#
+# `PRE`/`POST` are the exception on the read side and stay a boundary: rakudo
+# desugars them into a call *around* the block (the phaser's child is an
+# `ApplyPostfix`, not a `Block`), and mutsu additionally keeps the condition's
+# source text for the `X::Phaser::PrePost` message.
+#
+# `BEGIN` reads fine but does not *lower*: it runs at compile time, and mutsu
+# hoists it during compilation of a program rather than in `reorder_phasers`, so
+# the re-entrant carrier this lowering feeds would run it in statement position
+# and answer 1 for the `INIT` test below's shape where raku answers 0. It is
+# refused rather than lowered wrong — see
+# todo/tickets/rakuast-eval-begin-phaser.md.
+#
+# Passes under BOTH mutsu and raku.
+
+plan 15;
+
+sub phaser-class($src) {
+    $src.AST.statements[0].expression.^name
+}
+
+# --- read side: one class per kind ------------------------------------------
+is phaser-class(Q{BEGIN { 1 }}), 'RakuAST::StatementPrefix::Phaser::Begin', 'BEGIN';
+is phaser-class(Q{CHECK { 1 }}), 'RakuAST::StatementPrefix::Phaser::Check', 'CHECK';
+is phaser-class(Q{INIT { 1 }}),  'RakuAST::StatementPrefix::Phaser::Init',  'INIT';
+is phaser-class(Q{END { 1 }}),   'RakuAST::StatementPrefix::Phaser::End',   'END';
+is phaser-class(Q{ENTER { 1 }}), 'RakuAST::StatementPrefix::Phaser::Enter', 'ENTER';
+is phaser-class(Q{LEAVE { 1 }}), 'RakuAST::StatementPrefix::Phaser::Leave', 'LEAVE';
+is phaser-class(Q{KEEP { 1 }}),  'RakuAST::StatementPrefix::Phaser::Keep',  'KEEP';
+is phaser-class(Q{UNDO { 1 }}),  'RakuAST::StatementPrefix::Phaser::Undo',  'UNDO';
+
+# --- the block is a positional child ----------------------------------------
+ok Q{INIT { 1 }}.AST.gist.contains('RakuAST::StatementPrefix::Phaser::Init.new(')
+    && Q{INIT { 1 }}.AST.gist.contains('RakuAST::Block.new('),
+    'a phaser wraps its block positionally';
+
+# --- write side: the phaser still fires at its phase -------------------------
+is EVAL(Q{my $x = 0; sub f { ENTER { $x = 2 }; 0 }; f(); $x}.AST), 2,
+    'a lowered ENTER runs on entry';
+is EVAL(Q{my $x = 0; sub f { LEAVE { $x = 3 }; 0 }; f(); $x}.AST), 3,
+    'a lowered LEAVE runs on exit';
+is EVAL(Q{my $n = 0; for 1..3 { FIRST { $n = $n + 10 }; $n = $n + 1 }; $n}.AST), 13,
+    'a lowered FIRST runs once, before the first iteration';
+is EVAL(Q{my $n = 0; for 1..3 { NEXT { $n = $n + 10 }; $n = $n + 1 }; $n}.AST), 33,
+    'a lowered NEXT runs after each iteration';
+
+# --- the compile-time phasers keep their pre-mainline ordering --------------
+# `CHECK`/`INIT` run before the mainline, so the later `my $x = 0` wins.
+is EVAL(Q{my $x = 0; INIT { $x = 1 }; $x}.AST), 0,
+    'a lowered INIT runs before the mainline, not in statement position';
+is EVAL(Q{my $x = 0; CHECK { $x = 1 }; $x}.AST), 0,
+    'a lowered CHECK runs before the mainline too';

--- a/todo/deep/rakuast-remaining.md
+++ b/todo/deep/rakuast-remaining.md
@@ -77,6 +77,16 @@ the parser/internal AST, not guessing during RakuAST conversion.
 
 **Closed 2026-09-05**:
 
+- *Phasers.* `BEGIN` / `CHECK` / `INIT` / `END` / `ENTER` / `LEAVE` / `KEEP` /
+  `UNDO` / `FIRST` / `NEXT` / `LAST` / `QUIT` / `CLOSE` render as
+  `RakuAST::StatementPrefix::Phaser::<Kind>` (byte-identical to rakudo 2026.07)
+  and all but `BEGIN` lower back. `PRE`/`POST` stay a boundary on both sides
+  (rakudo wraps their block in a call, and mutsu keeps a source-text condition).
+  Fixing the write direction also made the `EVAL` carrier apply
+  `reorder_phasers_for_eval`, so `INIT`/`CHECK` run before the mainline as they
+  must; `BEGIN` needs a compile-time hoist the carrier lacks and is refused —
+  `todo/tickets/rakuast-eval-begin-phaser.md`. Pinned by `t/rakuast-phaser.t`;
+  see [the news entry](../../news/2026-09/rakuast-phasers.md).
 - *Where-constrained parameters (read direction).* `sub f($x where * > 0)`
   renders its `where` field — the shape `RakuAST::Parameter.new(:where)` already
   built and `EVAL` already lowered and enforced. Fixing it also made the

--- a/todo/deep/rakuast-remaining.md
+++ b/todo/deep/rakuast-remaining.md
@@ -77,6 +77,11 @@ the parser/internal AST, not guessing during RakuAST conversion.
 
 **Closed 2026-09-05**:
 
+- *Class traits, `multi`, and `constant`.* `class C is P`, `class C does R`,
+  `class C is rw`, `is repr(...)`, `multi sub`, and `constant X = 5` all render
+  (byte-identical to rakudo 2026.07) and lower back. Pinned by
+  `t/rakuast-class-traits-multi-constant.t`; see
+  [the news entry](../../news/2026-09/rakuast-class-traits-multi-constant.md).
 - *Phasers.* `BEGIN` / `CHECK` / `INIT` / `END` / `ENTER` / `LEAVE` / `KEEP` /
   `UNDO` / `FIRST` / `NEXT` / `LAST` / `QUIT` / `CLOSE` render as
   `RakuAST::StatementPrefix::Phaser::<Kind>` (byte-identical to rakudo 2026.07)
@@ -161,17 +166,25 @@ Still open:
   an `if` on `.defined`, so there is no statement to map to
   `Statement::With` / `Statement::Without`. It is an explicit boundary (the temp
   var's internal name is refused), not a wrong rendering.
-- A reference to a user-declared type by bare name. `class C { }; C.new` reads
-  `C` as `Expr::BareWord`, and only *builtin* type names
-  (`is_known_type_constraint`) convert to `Type::Simple`, so any program that
-  declares a class and then uses it is a `.AST` boundary. This is what keeps
-  `t/rakuast-eval-class.t` calling into the `EVAL`'d type object from the
-  outside instead of using the class inside the lowered program. Closing it
-  needs the converter to know which names the same compilation unit declared,
-  which the read side does not currently track.
+- A reference to a user-declared type or constant by bare name.
+  `class C { }; C.new` reads `C` as `Expr::BareWord`, and only *builtin* type
+  names (`is_known_type_constraint`) convert to `Type::Simple`, so any program
+  that declares a class or a constant and then uses it is a `.AST` boundary.
+  This is what keeps `t/rakuast-eval-class.t` and
+  `t/rakuast-class-traits-multi-constant.t` calling into the `EVAL`'d value from
+  the outside instead of using the name inside the lowered program. **Measured
+  2026-09-05 against rakudo 2026.07:** a type bareword renders
+  `RakuAST::Type::Simple(Name)` (identical to a builtin type) and a constant
+  bareword renders `RakuAST::Term::Name(Name)`; an undeclared bareword is a
+  compile error in raku. So the shapes are known — what is missing is for the
+  converter to know which names the same compilation unit declared, which the
+  read side does not currently track. This is now the single highest-leverage
+  remaining read gap, because it is what blocks testing every other
+  declaration slice from *inside* the lowered program.
 - Grammar declarations. `grammar G { }` is a `Stmt::ClassDecl` with
-  `parents = ["Grammar"]`, so it hits the class-inheritance boundary instead of
-  producing `RakuAST::Grammar` + `TokenDeclaration` + the regex node tree.
+  `parents = ["Grammar"]`; class inheritance itself is closed now, so what
+  remains is producing `RakuAST::Grammar` + `TokenDeclaration` + the regex node
+  tree rather than a `Class` with a `Grammar` parent.
 - Associative `%h{...}` versus `%h<...>` subscripts. Both are
   `Expr::Index { is_positional: false }` with a `Literal(Str)` index, so the read
   side cannot choose raku's `Postcircumfix::LiteralHashIndex` (a word-quoted

--- a/todo/tickets/rakuast-eval-begin-phaser.md
+++ b/todo/tickets/rakuast-eval-begin-phaser.md
@@ -1,0 +1,53 @@
+# `EVAL` of a RakuAST tree runs a `BEGIN` phaser at the wrong time
+
+`BEGIN` runs at *compile* time, so a later mainline declaration overwrites
+whatever it did:
+
+```
+$ mutsu -e 'my $x = 0; BEGIN { $x = 1 }; say $x'
+0                                                    # correct, matches raku
+$ mutsu -e 'use MONKEY-SEE-NO-EVAL; say EVAL(Q{my $x = 0; BEGIN { $x = 1 }; $x}.AST)'
+1                                                    # raku: 0
+```
+
+Measured against rakudo 2026.07: raku answers `0` for both spellings, and so
+does mutsu's own direct execution. Only the RakuAST `EVAL` carrier disagrees.
+
+## Root cause
+
+`builtin_eval`'s RakuAST branch lowers the tree and runs it through
+`eval_block_value`. Since 2026-09-05 it also applies
+`phasers::reorder_phasers_for_eval`, which fixes `CHECK` and `INIT` — those are
+lifted out of statement position by `extract_phasers_from_stmts`. `BEGIN` is
+*not*: that function takes a `_begin` accumulator it never fills, and
+`run.rs`'s comment ("the hoisted BEGINs are gone before that pass") records
+that BEGIN is hoisted earlier, during compilation of a program, by a mechanism
+the re-entrant carrier never runs.
+
+So a lowered `Stmt::Phaser { kind: Begin, .. }` executes in statement position,
+i.e. *after* the `my $x = 0` that should have clobbered it.
+
+## Current state
+
+`src/rakuast/lower.rs` refuses `RakuAST::StatementPrefix::Phaser::Begin` rather
+than lowering it to a wrong answer. The *read* direction is complete — `BEGIN`
+renders as `RakuAST::StatementPrefix::Phaser::Begin`, byte-for-byte identical to
+rakudo — so this is a write-direction-only gap, pinned as a boundary by
+`t/rakuast-phaser.t`.
+
+## Why it is not a small fix
+
+The right fix is for the carrier path to run the same compile-time BEGIN
+handling the ordinary pipeline does, which means locating that mechanism (it is
+not in `phasers.rs`, which only reorders CHECK/INIT) and making it reusable from
+`eval_block_value`. That is the same "the carrier is not the real pipeline"
+shape as the other `eval_block_value` debts CLAUDE.md lists, so it likely wants
+solving once for every carrier rather than for RakuAST alone.
+
+## Minimal repro
+
+```
+mutsu -e 'use MONKEY-SEE-NO-EVAL; say EVAL(Q{my $x = 0; BEGIN { $x = 1 }; $x}.AST)'
+# expected 0 (raku, and mutsu's own direct execution), got a boundary error
+# today; before the boundary was added, got 1.
+```


### PR DESCRIPTION
Four read gaps closed, all **measured against rakudo 2026.07** and byte-for-byte
identical there. Each lowers back through `EVAL` too, except where noted.

## 1. Phasers

A phaser was a `.AST` boundary printing mutsu's internal `Stmt::Phaser` debug
form. raku gives each kind its own class,
`RakuAST::StatementPrefix::Phaser::<Kind>`, wrapping the block positionally, and
mutsu's single `Stmt::Phaser { kind, .. }` maps onto them 1:1 — so `BEGIN`,
`CHECK`, `INIT`, `END`, `ENTER`, `LEAVE`, `KEEP`, `UNDO`, `FIRST`, `NEXT`,
`LAST`, `QUIT` and `CLOSE` all land in one slice.

`PRE`/`POST` stay a boundary on both sides: rakudo desugars them into a call
*around* the block (the child is an `ApplyPostfix`, not a `Block`), and mutsu
additionally keeps the condition's source text for `X::Phaser::PrePost`.

### The ordering bug the oracle caught

Rendering was the easy half. Running the lowered tree showed the re-entrant
`EVAL` carrier running the *compile-time* phasers in statement position:

```
$ mutsu -e 'my $x = 0; INIT { $x = 1 }; say $x'
0                                     # correct, matches raku
$ mutsu -e 'use MONKEY-SEE-NO-EVAL; say EVAL(Q{my $x = 0; INIT { $x = 1 }; $x}.AST)'
1                                     # raku: 0
```

`INIT`/`CHECK` run before the mainline, so the later `my $x = 0` wins. The
string-`EVAL` path already applies `phasers::reorder_phasers_for_eval` for
exactly this reason; the RakuAST branch of `builtin_eval` did not. It does now,
and both kinds agree with raku.

`BEGIN` is not fixed by that — `extract_phasers_from_stmts` takes a `_begin`
accumulator it never fills, and `run.rs`'s own comment records that BEGIN is
hoisted during compilation of a program by a mechanism the carrier never runs.
Rather than lower it to a wrong answer it is **refused**, and the gap is filed as
`todo/tickets/rakuast-eval-begin-phaser.md`. Its read direction is complete.

## 2. Class traits

`class C is Int { }`, `class C does R { }` and `class C is rw { }` were one
boundary. raku spells the three differently, and the differences are not
guessable:

- `is Int` → `Trait::Is(type => Type::Simple(...))` — a **named** `type`.
- `does R` → `Trait::Does(Type::Simple(...))` — **positional**.
- `is rw` → `Trait::Is(name => Name.from-identifier("rw"))` — a trait *name*.

`is repr("P6opaque")` is not a trait at all but a `repr` leaf field, in field
order `scope, name, repr, traits, body`.

One mutsu detail the round trip had to respect: a `does` role is recorded in
**both** `ClassDecl.parents` and `ClassDecl.does_parents` (`parents` is the
general composed-type list the dispatcher reads), so the converter skips a
parent that is also a role — otherwise the role renders twice — and the lowerer
puts it back in both. Still deferred: `my`/unit scope, `hides`, computed names,
user traits.

## 3. `multi`

`multi sub f(...)` renders `multiness => "multi"`, before `name` in raku's field
order. A `proto` uses the same field but carries a `{*}` body mutsu keeps in a
separate `Stmt::ProtoDecl`, so it stays a boundary.

## 4. `constant`

`constant X = 5` is a declaration of its own — `RakuAST::VarDeclaration::Constant`
— not a scoped `my`, and its `name` is a plain string rather than a `Name` node.
The package-scoped default emits no `scope`; `my constant Y = 7` emits
`scope => "my"`, which mutsu records as the *absence* of its `is_our` flag. A
sigilled or typed constant stays a boundary.

## Tests

- `t/rakuast-phaser.t` (15 assertions) — one class name per kind for eight kinds,
  the positional block, five `EVAL` round trips covering entry/exit and loop
  phasers, and the pre-mainline ordering of `INIT` and `CHECK`.
- `t/rakuast-class-traits-multi-constant.t` (16 assertions) — all three trait
  spellings, the repr field, that a plain class emits no `traits`, the multiness
  field and its absence, all three constant fields, and three `EVAL` round trips
  including a class composing a role and calling the composed method.

Both pass verbatim under mutsu **and** rakudo 2026.07.

## Note on the next gap

The campaign file's user-bareword entry now carries measured shapes: a
user-declared *type* bareword renders `RakuAST::Type::Simple(Name)` (identical to
a builtin type) and a *constant* bareword renders `RakuAST::Term::Name(Name)`.
That gap is what forces both new tests to inspect the `EVAL`'d value from the
outside rather than using the declared name inside the lowered program, so it is
now the highest-leverage remaining read gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TtL4NKUC5rVfjD6mFDpqh9

---
_Generated by [Claude Code](https://claude.ai/code/session_01TtL4NKUC5rVfjD6mFDpqh9)_