### PR TITLE
feat(rakuast): declared names, .^name as a metamethod, and interpolated code blocks

### DIFF
--- a/news/2026-09/rakuast-declared-name-and-metamethod.md
+++ b/news/2026-09/rakuast-declared-name-and-metamethod.md
@@ -1,0 +1,44 @@
+# RakuAST resolves a declared name, and `.^name` is a metamethod
+
+Two read gaps, both measured against rakudo 2026.07 and byte-for-byte identical
+there, both lowering back through `EVAL`.
+
+## A bareword the same unit declared
+
+`class C { }; C.new` was a `.AST` boundary. raku resolves such a name at parse
+time — a declared *type* renders as `RakuAST::Type::Simple`, exactly like a
+builtin type, and a declared *constant* renders as `RakuAST::Term::Name` — but
+mutsu's parser leaves both as `Expr::BareWord`, and only builtin type names
+(`is_known_type_constraint`) converted. So *any* program that declared a class,
+role, enum, subset or constant and then used it could not be rendered at all.
+
+That is what forced every declaration slice so far — `t/rakuast-eval-class.t`,
+`t/rakuast-class-traits-multi-constant.t` — to end its program with the
+declaration and inspect the `EVAL`'d value from the *outside*. Those programs can
+now use the name where it was declared.
+
+The converter collects the unit's declared names before converting (a walk over
+the statement list, descending into blocks, packages and routine bodies) and
+keeps them in a scoped thread-local for the duration, restoring the previous set
+on the way out so a nested conversion cannot leak into the outer one. A bareword
+that names nothing the unit declared is still the boundary it was.
+
+## `.^name`
+
+`.^name` rendered as an ordinary `Call::Method` carrying a `dispatch => ".^"`
+field, alongside `.?` / `.+` / `.*`. raku gives it a class of its own,
+`RakuAST::Call::MetaMethod`, whose `name` is a plain string rather than a `Name`
+node. `.?` / `.+` / `.*` really are dispatch modifiers and are unchanged.
+
+mutsu keeps `^` in the same `modifier` slot as the dispatch modifiers
+internally, so this is purely a rendering split; the lowerer puts it back.
+
+## Coverage
+
+`t/rakuast-declared-name.t` (14 assertions) pins a declared class and role
+rendering as `Type::Simple`, a declared constant as `Term::Name` (and *not* as a
+type), the metamethod shape and the absence of a `dispatch` field on it, `.?`
+still carrying one, and six `EVAL` round trips that use the declared name inside
+the lowered program — a constant in an expression, a class called and
+constructed by name, and a class composing a role. It is a dual-oracle test: it
+passes verbatim under both mutsu and rakudo 2026.07.

--- a/news/2026-09/rakuast-interpolated-code-block.md
+++ b/news/2026-09/rakuast-interpolated-code-block.md
@@ -1,0 +1,31 @@
+# RakuAST interpolated code blocks
+
+`"a{ $x }b"` now renders and lowers. It was a `.AST` boundary, and it is on the
+campaign file's own lowering list ("code-block interpolation").
+
+raku renders a `{ ... }` segment of an interpolated string as a plain
+`RakuAST::Block`, alongside the `StrLiteral` runs. mutsu wraps the block in a
+`DoStmt` — that is how its parser makes a block an expression — which has no
+RakuAST counterpart, so the segment converter refused the whole string.
+Unwrapping it in `interp_segment` is the entire read-side change; measured
+against rakudo 2026.07, the rendered gists are byte-for-byte identical.
+
+## The write direction needed the mirror
+
+A `Block` *segment* is evaluated, not a closure value. Lowering it through the
+ordinary expression path built a closure and interpolated its stringification,
+so `"a{ $x }b"` came out as `ab` — silently losing the interpolated value rather
+than erroring. The lowerer now spells a `Block` segment `DoStmt(Block)`, the
+same shape the parser produces.
+
+That divergence was found by running the same snippet twice — directly, and
+through `EVAL(Q{...}.AST)` — against both mutsu and rakudo 2026.07. The read
+direction alone looked complete.
+
+## Coverage
+
+`t/rakuast-interp-code-block.t` (10 assertions) pins the `Block` segment and the
+absence of any `DoStmt` wrapper in the gist, the literal runs around it, that a
+plain `$x` segment is still a `Var` and not a `Block`, and four `EVAL` round
+trips including a string that is only a code block and a method call inside one.
+It is a dual-oracle test: it passes verbatim under both mutsu and rakudo 2026.07.

--- a/src/rakuast/convert.rs
+++ b/src/rakuast/convert.rs
@@ -34,6 +34,11 @@ fn leaf_field(name: Option<&'static str>, value: Value) -> RakuAstField {
 
 /// Top-level: a parsed program becomes a `RakuAST::StatementList`.
 pub(super) fn statement_list(stmts: &[Stmt]) -> Result<RakuAstNode, RuntimeError> {
+    let _scope = DeclaredNames::collect(stmts);
+    statement_list_inner(stmts)
+}
+
+fn statement_list_inner(stmts: &[Stmt]) -> Result<RakuAstNode, RuntimeError> {
     let mut fields = Vec::new();
     for stmt in stmts {
         if let Some(node) = convert_stmt(stmt)? {
@@ -44,6 +49,92 @@ pub(super) fn statement_list(stmts: &[Stmt]) -> Result<RakuAstNode, RuntimeError
         class: RakuAstClass::StatementList,
         fields,
     })
+}
+
+/// What a bareword naming something the same compilation unit declared means.
+///
+/// raku resolves such a name at parse time, so `class C { }; C.new` renders `C`
+/// as a `Type::Simple` — exactly like a builtin type — and
+/// `constant X = 5; X` renders `X` as a `Term::Name`. Both measured against
+/// rakudo 2026.07. mutsu's parser leaves both as `Expr::BareWord`, so the
+/// converter has to re-derive which is which from the unit's own declarations.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum DeclaredKind {
+    /// A `class` / `role` / `grammar` / `enum` name.
+    Type,
+    /// A `constant` name.
+    Constant,
+}
+
+thread_local! {
+    /// The names the compilation unit currently being converted declares.
+    /// Empty outside a conversion, so a nested/re-entrant conversion that never
+    /// ran `statement_list` simply sees no declarations and keeps the old
+    /// bareword boundary.
+    static DECLARED_NAMES: std::cell::RefCell<std::collections::HashMap<String, DeclaredKind>> =
+        std::cell::RefCell::new(std::collections::HashMap::new());
+}
+
+/// RAII guard installing the unit's declared names for the duration of a
+/// conversion, restoring whatever was there before (so a nested conversion
+/// cannot leak its names into the outer one).
+struct DeclaredNames(std::collections::HashMap<String, DeclaredKind>);
+
+impl DeclaredNames {
+    fn collect(stmts: &[Stmt]) -> Self {
+        let mut names = std::collections::HashMap::new();
+        collect_declared_names(stmts, &mut names);
+        Self(DECLARED_NAMES.with(|d| std::mem::replace(&mut *d.borrow_mut(), names)))
+    }
+}
+
+impl Drop for DeclaredNames {
+    fn drop(&mut self) {
+        DECLARED_NAMES.with(|d| {
+            *d.borrow_mut() = std::mem::take(&mut self.0);
+        });
+    }
+}
+
+fn declared_kind(name: &str) -> Option<DeclaredKind> {
+    DECLARED_NAMES.with(|d| d.borrow().get(name).copied())
+}
+
+/// Walk a statement list for the names it declares. Nested blocks count: raku
+/// resolves a name declared anywhere the reference can see it, and a bareword
+/// that reaches conversion at all was already accepted by the parser.
+fn collect_declared_names(
+    stmts: &[Stmt],
+    out: &mut std::collections::HashMap<String, DeclaredKind>,
+) {
+    for stmt in stmts {
+        match stmt {
+            Stmt::ClassDecl { name, body, .. } => {
+                out.insert(name.resolve(), DeclaredKind::Type);
+                collect_declared_names(body, out);
+            }
+            Stmt::RoleDecl { name, body, .. } => {
+                out.insert(name.resolve(), DeclaredKind::Type);
+                collect_declared_names(body, out);
+            }
+            Stmt::EnumDecl { name, .. } | Stmt::SubsetDecl { name, .. } => {
+                out.insert(name.resolve(), DeclaredKind::Type);
+            }
+            Stmt::VarDecl {
+                name,
+                custom_traits,
+                ..
+            } if custom_traits.iter().any(|(n, _)| n == "__constant") => {
+                out.insert(name.clone(), DeclaredKind::Constant);
+            }
+            Stmt::Block(body)
+            | Stmt::SyntheticBlock(body)
+            | Stmt::Package { body, .. }
+            | Stmt::SubDecl { body, .. }
+            | Stmt::MethodDecl { body, .. } => collect_declared_names(body, out),
+            _ => {}
+        }
+    }
 }
 
 /// Convert one statement. Returns `Ok(None)` for non-semantic bookkeeping
@@ -1016,9 +1107,20 @@ fn convert_expr(expr: &Expr) -> Result<RakuAstNode, RuntimeError> {
             }
             _ => Err(unsupported("non-fat-arrow positional pair")),
         },
-        // A bare type name used as a term (`Int`, `Str`) -> `Type::Simple`. Only
-        // known builtin types convert; a non-type bareword stays the boundary.
+        // A bare type name used as a term (`Int`, `Str`) -> `Type::Simple`.
         Expr::BareWord(name) if is_known_type_constraint(name) => Ok(simple_type_node(name)),
+        // A name the same compilation unit declared. raku resolves it at parse
+        // time: a type name renders exactly like a builtin one, a constant
+        // renders as a `Term::Name`. Any other bareword stays the boundary.
+        Expr::BareWord(name) if declared_kind(name).is_some() => {
+            match declared_kind(name).expect("just checked") {
+                DeclaredKind::Type => Ok(simple_type_node(name)),
+                DeclaredKind::Constant => Ok(RakuAstNode {
+                    class: RakuAstClass::TermName,
+                    fields: vec![node_field(None, name_from_identifier(name))],
+                }),
+            }
+        }
         // `(EXPR)` -> `Circumfix::Parentheses(SemiList(Statement::Expression(...)))`.
         Expr::Grouped(inner) => {
             let semilist = RakuAstNode {
@@ -2013,10 +2115,22 @@ fn method_call_postfix(
         if modifier.is_some() {
             return Err(unsupported("quoted method name with a modifier"));
         }
-        call_quoted_method(name, args)
-    } else {
-        call_method(name, args, modifier)
+        return call_quoted_method(name, args);
     }
+    // `.^name` is a *metamethod* call, not an ordinary call with a dispatch
+    // modifier: raku gives it its own `Call::MetaMethod` class whose `name` is a
+    // plain string. Only `.?` / `.+` / `.*` are dispatch modifiers.
+    if modifier == Some('^') {
+        let mut fields = vec![leaf_field(Some("name"), Value::str(name.to_string()))];
+        if !args.is_empty() {
+            fields.push(node_field(Some("args"), arg_list(args)?));
+        }
+        return Ok(RakuAstNode {
+            class: RakuAstClass::CallMetaMethod,
+            fields,
+        });
+    }
+    call_method(name, args, modifier)
 }
 
 /// `.method` / `.method(args)` -> `Call::Method(name => Name, [args => ArgList])`.

--- a/src/rakuast/convert.rs
+++ b/src/rakuast/convert.rs
@@ -1518,6 +1518,15 @@ fn interp_segment(expr: &Expr) -> Result<RakuAstNode, RuntimeError> {
                 fields: vec![leaf_field(None, v.clone())],
             })
         }
+        // An interpolated code block (`"a{ $x }b"`) is a segment like any other,
+        // and raku renders it as a plain `Block`. mutsu wraps the block in a
+        // `DoStmt` (that is how the parser makes it an expression), which has no
+        // RakuAST counterpart, so unwrap it here rather than rendering the
+        // wrapper. Measured against rakudo 2026.07.
+        Expr::DoStmt(inner) => match inner.as_ref() {
+            Stmt::Block(body) => block_node(body),
+            _ => convert_expr(expr),
+        },
         other => convert_expr(other),
     }
 }

--- a/src/rakuast/lower.rs
+++ b/src/rakuast/lower.rs
@@ -1017,6 +1017,15 @@ fn lower_expr(node: &RakuAstNode) -> Result<Expr, RuntimeError> {
                 let ValueView::RakuAst(seg) = s.view() else {
                     return Err(unsupported(node));
                 };
+                // An interpolated code block (`"a{ $x }b"`) is a `Block`
+                // segment, but as a *segment* it is evaluated, not a closure
+                // value. mutsu spells that `DoStmt(Block)`; lowering it through
+                // the ordinary expression path would build a closure and
+                // interpolate its stringification instead of its result.
+                if seg.class == RakuAstClass::Block {
+                    parts.push(Expr::DoStmt(Box::new(Stmt::Block(lower_block(seg)?))));
+                    continue;
+                }
                 parts.push(lower_expr(seg)?);
             }
             Ok(Expr::StringInterpolation(parts))

--- a/src/rakuast/lower.rs
+++ b/src/rakuast/lower.rs
@@ -1107,6 +1107,16 @@ fn lower_expr(node: &RakuAstNode) -> Result<Expr, RuntimeError> {
             };
             Ok(Expr::BracketArray(items, false))
         }
+        // A bareword naming a `constant` the same unit declared. Its value is
+        // whatever the declaration bound, so it lowers to the same bareword the
+        // parser produces.
+        RakuAstClass::TermName => {
+            let name = match positional_leaf(named_child_or_positional(node)?)?.view() {
+                ValueView::Str(s) => s.to_string(),
+                _ => return Err(unsupported(node)),
+            };
+            Ok(Expr::BareWord(name))
+        }
         // `[+] @a` / `[\\+] @a` -> a reduction over a single argument. mutsu's
         // `Expr::Reduction` keeps the triangle form in the operator string
         // itself (a leading backslash), which is how the converter reads it
@@ -1347,6 +1357,16 @@ fn lower_expr(node: &RakuAstNode) -> Result<Expr, RuntimeError> {
                     args: arg_exprs(postfix)?,
                     modifier: None,
                     quoted: true,
+                }),
+                // `.^name` -> a metamethod call. Its `name` is a plain string,
+                // not a `Name` node, and mutsu keeps the `^` in the same
+                // `modifier` slot the dispatch modifiers use.
+                RakuAstClass::CallMetaMethod => Ok(Expr::MethodCall {
+                    target: Box::new(operand),
+                    name: crate::symbol::Symbol::intern(&leaf_str(postfix, "name")?),
+                    args: arg_exprs(postfix)?,
+                    modifier: Some('^'),
+                    quoted: false,
                 }),
                 // `@a>>.abs` -> MetaPostfix::Hyper wrapping the ordinary
                 // method-call postfix.

--- a/src/rakuast/mod.rs
+++ b/src/rakuast/mod.rs
@@ -167,6 +167,11 @@ pub enum RakuAstClass {
     // `Block`; mutsu's one `Stmt::Phaser { kind, .. }` maps onto them 1:1.
     // `constant X = 5` — a declaration of its own, not a scoped `my`.
     VarDeclarationConstant,
+    // A bareword naming something the unit declared that is not a type — a
+    // `constant`, in practice.
+    TermName,
+    // `.^name` — a metamethod call, distinct from `.?`/`.+`/`.*` dispatch.
+    CallMetaMethod,
     // Class/role declaration traits (`is Parent`, `does Role`, `is rw`).
     TraitIs,
     TraitDoes,
@@ -273,6 +278,8 @@ impl RakuAstClass {
             StatementPrefixGather => "RakuAST::StatementPrefix::Gather",
             CallTerm => "RakuAST::Call::Term",
             VarDeclarationConstant => "RakuAST::VarDeclaration::Constant",
+            TermName => "RakuAST::Term::Name",
+            CallMetaMethod => "RakuAST::Call::MetaMethod",
             TraitIs => "RakuAST::Trait::Is",
             TraitDoes => "RakuAST::Trait::Does",
             StatementPrefixPhaserBegin => "RakuAST::StatementPrefix::Phaser::Begin",
@@ -570,6 +577,8 @@ const RAKUAST_CLASSES: &[RakuAstClass] = &[
     RakuAstClass::StatementPrefixGather,
     RakuAstClass::CallTerm,
     RakuAstClass::VarDeclarationConstant,
+    RakuAstClass::TermName,
+    RakuAstClass::CallMetaMethod,
     RakuAstClass::TraitIs,
     RakuAstClass::TraitDoes,
     RakuAstClass::StatementPrefixPhaserBegin,

--- a/t/rakuast-declared-name.t
+++ b/t/rakuast-declared-name.t
@@ -1,0 +1,64 @@
+use v6;
+use MONKEY-SEE-NO-EVAL;
+use experimental :rakuast;
+use Test;
+
+# A bareword naming something the same compilation unit declared (ADR-0011).
+#
+# raku resolves such a name at parse time, so `class C { }; C.new` renders `C`
+# as a `Type::Simple` — exactly like a builtin type — and `constant X = 5; X`
+# renders `X` as a `Term::Name`. Both measured against rakudo 2026.07.
+#
+# mutsu's parser leaves both as `Expr::BareWord`, and only *builtin* type names
+# converted, so any program that declared a class or a constant and then used it
+# was a `.AST` boundary. That is what forced every declaration test so far to
+# inspect the EVAL'd value from the outside instead of using the name inside the
+# lowered program — the tests below do use it.
+#
+# Also fixed here: `.^name` is a *metamethod* call (`Call::MetaMethod`, whose
+# `name` is a plain string), not an ordinary call carrying a `.^` dispatch
+# modifier. Only `.?` / `.+` / `.*` are dispatch modifiers.
+#
+# Each test uses distinct names because `.AST` registers the symbol and raku
+# rejects redeclaration.
+#
+# Passes under BOTH mutsu and raku.
+
+plan 14;
+
+# --- read: a declared type renders like a builtin one ------------------------
+my $cls = Q{class D1 { }; D1.new}.AST.gist;
+ok $cls.contains('RakuAST::Type::Simple.new(') && $cls.contains('RakuAST::Name.from-identifier("D1")'),
+    'a declared class used as a term renders as Type::Simple';
+
+ok Q{role D2 { }; D2.^name}.AST.gist.contains('RakuAST::Type::Simple.new('),
+    'a declared role used as a term renders as Type::Simple';
+
+# --- read: a declared constant renders as Term::Name -------------------------
+my $const = Q{constant D3 = 5; D3}.AST.gist;
+ok $const.contains('RakuAST::Term::Name.new('),
+    'a declared constant used as a term renders as Term::Name';
+nok $const.contains('RakuAST::Type::Simple.new(
+    RakuAST::Name.from-identifier("D3")'),
+    'a declared constant is not rendered as a type';
+
+# --- read: `.^name` is a metamethod call -------------------------------------
+my $meta = Q{my $x = 1; $x.^name}.AST.gist;
+ok $meta.contains('RakuAST::Call::MetaMethod.new('), '`.^name` renders a Call::MetaMethod';
+ok $meta.contains('name => "name"'), 'a metamethod name is a plain string';
+nok $meta.contains('dispatch'), '`.^` is not a dispatch modifier';
+
+# --- read: `.?` is still an ordinary call with a dispatch modifier ------------
+my $maybe = Q{my $x = 1; $x.?abs}.AST.gist;
+ok $maybe.contains('RakuAST::Call::Method.new(') && $maybe.contains('dispatch => ".?"'),
+    '`.?` is still a dispatch modifier on an ordinary Call::Method';
+
+# --- write: the declared name is usable inside the lowered program -----------
+is EVAL(Q{constant D4 = 5; D4}.AST), 5, 'a constant is readable by name';
+is EVAL(Q{constant D5 = 5; D5 + 1}.AST), 6, 'a constant works in an expression';
+is EVAL(Q{my constant D6 = "ab"; D6.chars}.AST), 2, 'a lexical constant is readable by name';
+is EVAL(Q{class D7 { method m() { 7 } }; D7.m}.AST), 7, 'a declared class is callable by name';
+is EVAL(Q{class D8 { has $.v; method d() { $!v * 2 } }; D8.new(v => 21).d}.AST), 42,
+    'a declared class can be constructed and used by name';
+is EVAL(Q{role D9R { method m() { 5 } }; class D9 does D9R { }; D9.new.m}.AST), 5,
+    'a class composing a role is usable by name';

--- a/t/rakuast-interp-code-block.t
+++ b/t/rakuast-interp-code-block.t
@@ -1,0 +1,40 @@
+use v6;
+use MONKEY-SEE-NO-EVAL;
+use experimental :rakuast;
+use Test;
+
+# Interpolated code blocks (`"a{ $x }b"`), both directions (ADR-0011).
+#
+# raku renders a `{ ... }` segment of an interpolated string as a plain
+# `RakuAST::Block` alongside the `StrLiteral` runs. mutsu wraps the block in a
+# `DoStmt` — that is how its parser makes a block an expression — which has no
+# RakuAST counterpart, so `.AST` refused the whole string.
+#
+# The write direction needed the mirror of that: a `Block` *segment* is
+# evaluated, not a closure value, so lowering it through the ordinary expression
+# path built a closure and interpolated its stringification (`"a{ $x }b"` came
+# out as `ab`).
+#
+# Measured against rakudo 2026.07: the rendered gists are byte-for-byte
+# identical. Passes under BOTH mutsu and raku.
+
+plan 10;
+
+# --- read side ---------------------------------------------------------------
+my $g = Q{my $x = 1; "a{ $x }b"}.AST.gist;
+ok $g.contains('RakuAST::QuotedString.new('), 'an interpolated string is a QuotedString';
+ok $g.contains('RakuAST::Block.new('), 'a code-block segment renders as a plain Block';
+nok $g.contains('StatementPrefix::Do'), 'the DoStmt wrapper is not rendered';
+ok $g.contains('RakuAST::StrLiteral.new("a")') && $g.contains('RakuAST::StrLiteral.new("b")'),
+    'the literal runs around the block are kept';
+
+# --- a plain variable interpolation is unchanged -----------------------------
+my $v = Q{my $x = 1; "a$x b"}.AST.gist;
+ok $v.contains('RakuAST::Var::Lexical.new('), 'a `$x` segment still renders as a Var';
+nok $v.contains('RakuAST::Block.new('), 'a `$x` segment is not a Block';
+
+# --- write side --------------------------------------------------------------
+is EVAL(Q{my $x = 1; "a{ $x }b"}.AST), 'a1b', 'a code block interpolates its value';
+is EVAL(Q{my $x = 2; "v{ $x + 1 }"}.AST), 'v3', 'the block is evaluated, not stringified';
+is EVAL(Q{"{ 1 + 1 }"}.AST), '2', 'a string that is only a code block';
+is EVAL(Q{my @a = 1, 2; "e{ @a.elems }"}.AST), 'e2', 'a method call inside a block';

--- a/todo/deep/rakuast-remaining.md
+++ b/todo/deep/rakuast-remaining.md
@@ -77,6 +77,13 @@ the parser/internal AST, not guessing during RakuAST conversion.
 
 **Closed 2026-09-05**:
 
+- *A bareword naming something the unit declared, and `.^name`.* A declared
+  type renders as `Type::Simple` and a declared constant as `Term::Name`, so a
+  program can finally use a class or constant it declares — which is what forced
+  the earlier declaration slices to inspect the `EVAL`'d value from outside.
+  `.^name` also moved from a `Call::Method` with a `.^` dispatch field to raku's
+  own `Call::MetaMethod`. Pinned by `t/rakuast-declared-name.t`; see
+  [the news entry](../../news/2026-09/rakuast-declared-name-and-metamethod.md).
 - *Class traits, `multi`, and `constant`.* `class C is P`, `class C does R`,
   `class C is rw`, `is repr(...)`, `multi sub`, and `constant X = 5` all render
   (byte-identical to rakudo 2026.07) and lower back. Pinned by
@@ -166,21 +173,6 @@ Still open:
   an `if` on `.defined`, so there is no statement to map to
   `Statement::With` / `Statement::Without`. It is an explicit boundary (the temp
   var's internal name is refused), not a wrong rendering.
-- A reference to a user-declared type or constant by bare name.
-  `class C { }; C.new` reads `C` as `Expr::BareWord`, and only *builtin* type
-  names (`is_known_type_constraint`) convert to `Type::Simple`, so any program
-  that declares a class or a constant and then uses it is a `.AST` boundary.
-  This is what keeps `t/rakuast-eval-class.t` and
-  `t/rakuast-class-traits-multi-constant.t` calling into the `EVAL`'d value from
-  the outside instead of using the name inside the lowered program. **Measured
-  2026-09-05 against rakudo 2026.07:** a type bareword renders
-  `RakuAST::Type::Simple(Name)` (identical to a builtin type) and a constant
-  bareword renders `RakuAST::Term::Name(Name)`; an undeclared bareword is a
-  compile error in raku. So the shapes are known — what is missing is for the
-  converter to know which names the same compilation unit declared, which the
-  read side does not currently track. This is now the single highest-leverage
-  remaining read gap, because it is what blocks testing every other
-  declaration slice from *inside* the lowered program.
 - Grammar declarations. `grammar G { }` is a `Stmt::ClassDecl` with
   `parents = ["Grammar"]`; class inheritance itself is closed now, so what
   remains is producing `RakuAST::Grammar` + `TokenDeclaration` + the regex node

--- a/todo/deep/rakuast-remaining.md
+++ b/todo/deep/rakuast-remaining.md
@@ -77,6 +77,12 @@ the parser/internal AST, not guessing during RakuAST conversion.
 
 **Closed 2026-09-05**:
 
+- *Interpolated code blocks.* `"a{ $x }b"` renders its `{ ... }` segment as a
+  plain `Block` (mutsu's `DoStmt` wrapper has no RakuAST counterpart) and lowers
+  back to that wrapper — without which the segment became a closure and the
+  interpolated value was silently lost. Pinned by
+  `t/rakuast-interp-code-block.t`; see
+  [the news entry](../../news/2026-09/rakuast-interpolated-code-block.md).
 - *A bareword naming something the unit declared, and `.^name`.* A declared
   type renders as `Type::Simple` and a declared constant as `Term::Name`, so a
   program can finally use a class or constant it declares — which is what forced
@@ -154,8 +160,14 @@ the parser/internal AST, not guessing during RakuAST conversion.
 Still open:
 
 - `.=` and Whatever compound autoprime. `$x .= Str` desugars to a plain `=` over
-  a method call (raku: `ApplyDottyInfix` + `DottyInfix::CallAssign`) and still
-  needs the parser to retain its dotty-infix form. Core compound assignment is
+  a method call and still needs the parser to retain its dotty-infix form.
+  **Measured 2026-09-05 against rakudo 2026.07:** `ApplyDottyInfix(left =>
+  Var::Lexical, infix => DottyInfix::CallAssign.new, right => Call::Method(...))`.
+  The blocker is confirmed by construction: `$x .= Str` and `$x = $x.Str` parse
+  to *byte-identical* internal ASTs (`Stmt::Assign` over a `MethodCall` on the
+  same variable), so the converter cannot tell them apart. `AssignOp` is the
+  natural place for a marker, but it is matched at ~294 sites, so this is a
+  parser/AST slice rather than a converter one. Core compound assignment is
   now closed: `+=`, `-=`, `*=`, `~=`, `//=`, `||=`, `&&=`, indexed lvalues, and
   `AT-POS` lvalues preserve `MetaInfix::Assign(Infix(...))` for `.AST`, while
   `EVAL` reuses the existing execution expansion. The `* += 1` Whatever
@@ -172,7 +184,10 @@ Still open:
 - `with` / `without`. Desugared at parse time into a `__with_tmp_N` temp var plus
   an `if` on `.defined`, so there is no statement to map to
   `Statement::With` / `Statement::Without`. It is an explicit boundary (the temp
-  var's internal name is refused), not a wrong rendering.
+  var's internal name is refused), not a wrong rendering. **Measured 2026-09-05
+  against rakudo 2026.07:** `Statement::With(condition => <expr>, then =>
+  Block(implicit-topic => True, required-topic => 1, body => Blockoid(...)))` —
+  note the two topic fields on the block, which no other block form carries.
 - Grammar declarations. `grammar G { }` is a `Stmt::ClassDecl` with
   `parents = ["Grammar"]`; class inheritance itself is closed now, so what
   remains is producing `RakuAST::Grammar` + `TokenDeclaration` + the regex node
@@ -229,11 +244,13 @@ an explicit design:
 
 - placeholder blocks such as `{ $^a }`
 - `with` / `without`
-- list assignment
+- list assignment. **Measured 2026-09-05 against rakudo 2026.07:**
+  `my ($a, $b) = 1, 2` is a `VarDeclaration::Signature(signature => Signature(...),
+  initializer => ...)`, i.e. raku models the declaration as a *signature bind*,
+  not as the temp-var destructuring mutsu desugars it into.
 - `constant`
 - associative subscripts
 - `CATCH` blocks
-- code-block interpolation
 - regexes
 
 Pick these deliberately by user impact rather than treating them as another


### PR DESCRIPTION
Three read gaps, all **measured against rakudo 2026.07** and byte-for-byte
identical there, all lowering back through `EVAL`.

## 1. A bareword the same unit declared

`class C { }; C.new` was a `.AST` boundary. raku resolves such a name at parse
time — a declared **type** renders as `RakuAST::Type::Simple`, exactly like a
builtin type, and a declared **constant** renders as `RakuAST::Term::Name` — but
mutsu's parser leaves both as `Expr::BareWord`, and only builtin type names
(`is_known_type_constraint`) converted. So *any* program that declared a class,
role, enum, subset or constant and then used it could not be rendered at all.

That is what forced every declaration slice so far (`t/rakuast-eval-class.t`,
`t/rakuast-class-traits-multi-constant.t`) to end its program with the
declaration and inspect the `EVAL`'d value from the *outside*. Those programs can
now use the name where it was declared, and six assertions in the new test do
exactly that.

The converter collects the unit's declared names before converting (a walk over
the statement list, descending into blocks, packages and routine bodies) and
holds them in a scoped thread-local, restoring the previous set on the way out so
a nested conversion cannot leak into the outer one. A bareword naming nothing the
unit declared is still the boundary it was.

## 2. `.^name` is a metamethod call

It rendered as an ordinary `Call::Method` carrying `dispatch => ".^"`, alongside
`.?` / `.+` / `.*`. raku gives it a class of its own,
`RakuAST::Call::MetaMethod`, whose `name` is a plain string rather than a `Name`
node. `.?` / `.+` / `.*` really are dispatch modifiers and are unchanged. mutsu
keeps `^` in the same `modifier` slot internally, so this is purely a rendering
split and the lowerer puts it back.

## 3. Interpolated code blocks

`"a{ $x }b"` was a boundary, and is on the campaign file's own lowering list.
raku renders the `{ ... }` segment as a plain `RakuAST::Block` alongside the
`StrLiteral` runs; mutsu wraps the block in a `DoStmt` (that is how its parser
makes a block an expression), which has no RakuAST counterpart.

**The write direction needed the mirror, and only differential testing found
it.** A `Block` *segment* is evaluated, not a closure value, so lowering it
through the ordinary expression path built a closure and interpolated its
stringification — `"a{ $x }b"` came out as `ab`, silently losing the value rather
than erroring. The read direction alone looked complete.

## Tests

- `t/rakuast-declared-name.t` (14 assertions) — a declared class and role as
  `Type::Simple`, a declared constant as `Term::Name` (and *not* as a type), the
  metamethod shape and the absence of a `dispatch` field on it, `.?` still
  carrying one, and six `EVAL` round trips that use the declared name inside the
  lowered program.
- `t/rakuast-interp-code-block.t` (10 assertions) — the `Block` segment, the
  absence of any `DoStmt` wrapper in the gist, the literal runs around it, that a
  plain `$x` segment is still a `Var`, and four `EVAL` round trips.

Both pass verbatim under mutsu **and** rakudo 2026.07.

## Measurements recorded for the next slices

Three gaps this session could not close now carry their measured rakudo shapes in
the campaign file, so the next slice does not re-measure:

- **`.=`** → `ApplyDottyInfix(left, infix => DottyInfix::CallAssign.new, right =>
  Call::Method(...))`. The blocker is now confirmed by construction: `$x .= Str`
  and `$x = $x.Str` parse to *byte-identical* internal ASTs, so the converter
  cannot tell them apart and the marker has to come from the parser. `AssignOp`
  is the natural place but is matched at ~294 sites.
- **`with`** → `Statement::With(condition, then => Block(implicit-topic => True,
  required-topic => 1, ...))` — two topic fields no other block form carries.
- **`my ($a, $b) = 1, 2`** → `VarDeclaration::Signature(signature => Signature,
  initializer => ...)`, i.e. a *signature bind*, not the temp-var destructuring
  mutsu desugars it into.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TtL4NKUC5rVfjD6mFDpqh9

---
_Generated by [Claude Code](https://claude.ai/code/session_01TtL4NKUC5rVfjD6mFDpqh9)_