### PR TITLE
fix(rakuast): render `until` as `until`, not as a negated `while`

### DIFF
--- a/news/2026-09/rakuast-until-loop.md
+++ b/news/2026-09/rakuast-until-loop.md
@@ -1,0 +1,42 @@
+# RakuAST renders `until` as `until`
+
+`until X { }` and `repeat { } until X` were *wrongly rendered* rather than
+refused: mutsu stores an `until` as `while !X`, and `.AST` rendered exactly
+that — a `Statement::Loop::While` over an `ApplyPrefix("!")`. raku has
+`Statement::Loop::Until` and `Statement::Loop::RepeatUntil` classes and renders
+the **undecorated** condition.
+
+The information was there all along. `Stmt::While` and `Stmt::Loop` both keep an
+`is_until` flag alongside the negated condition — the converter simply did not
+read it, and its comment ("mutsu desugars `until X` to `while !X`") recorded the
+desugaring as if it were lossy. The converter now picks the class from the flag
+and strips the `!` the parser added; the lowerer re-plants it. A flagged loop
+whose condition is *not* a negation is refused rather than rendered, since that
+would mean the flag and the negation had drifted apart.
+
+Measured against rakudo 2026.07: the gists are byte-for-byte identical for
+`until`, `repeat ... until`, and both `while` forms.
+
+## How it was found
+
+A gist-comparison sweep: render a corpus of small programs under both mutsu and
+rakudo and diff, reporting only cases where **both** render — a mutsu boundary
+is honest, a mutsu *disagreement* is a bug. `until` was one of four hits.
+
+The other three need the parser to stop erasing a distinction, and are filed with
+their measured rakudo shapes:
+
+- `todo/tickets/rakuast-fat-arrow-key-spelling-swapped.md` — `a => 1` and
+  `"a" => 1` render as each other's node. `PositionalPair`, which the converter
+  keys on, means "parenthesized pair", not "quoted key".
+- `todo/tickets/rakuast-unless-and-parens.md` — `unless` renders as a negated
+  `if` (`Stmt::If` has no `is_unless` flag, unlike `Stmt::While::is_until`), and
+  `(1, 2)` loses its `Circumfix::Parentheses` wrapper.
+
+## Coverage
+
+`t/rakuast-until-loop.t` (11 assertions) pins both `until` classes, the
+undecorated condition, that neither renders as a `While`, that both `while` forms
+are unchanged, and four `EVAL` round trips including an `until` whose condition
+is already true. It is a dual-oracle test: it passes verbatim under both mutsu
+and rakudo 2026.07.

--- a/src/rakuast/convert.rs
+++ b/src/rakuast/convert.rs
@@ -304,14 +304,32 @@ fn convert_stmt(stmt: &Stmt) -> Result<Option<RakuAstNode>, RuntimeError> {
             }))
         }
         Stmt::While {
-            cond, body, label, ..
+            cond,
+            body,
+            label,
+            is_until,
+            ..
         } => {
-            // mutsu desugars `until X` to `while !X` (same as unless/if above).
+            // mutsu stores `until X` as `while !X` PLUS an `is_until` flag, so
+            // the source keyword is recoverable: raku has a `Loop::Until` class
+            // and renders the *undecorated* condition, so the `!` the parser
+            // added is stripped back off.
             let mut fields = label_fields(label);
-            fields.push(node_field(Some("condition"), convert_expr(cond)?));
+            fields.push(node_field(
+                Some("condition"),
+                convert_expr(if *is_until {
+                    strip_negation(cond)?
+                } else {
+                    cond
+                })?,
+            ));
             fields.push(node_field(Some("body"), block_node(body)?));
             Ok(Some(RakuAstNode {
-                class: RakuAstClass::StatementLoopWhile,
+                class: if *is_until {
+                    RakuAstClass::StatementLoopUntil
+                } else {
+                    RakuAstClass::StatementLoopWhile
+                },
                 fields,
             }))
         }
@@ -322,20 +340,33 @@ fn convert_stmt(stmt: &Stmt) -> Result<Option<RakuAstNode>, RuntimeError> {
             body,
             repeat,
             label,
+            is_until,
             ..
         } => {
             if *repeat {
-                // `repeat { } while X`. mutsu desugars `repeat { } until X` to a
-                // negated `while` condition (same collapse as while/until), so
-                // this always renders as `Loop::RepeatWhile`.
+                // `repeat { } while X` / `repeat { } until X`. As with the plain
+                // `while`, mutsu negates the condition and keeps an `is_until`
+                // flag, so both the class and the undecorated condition are
+                // recoverable.
                 let cond = cond
                     .as_ref()
                     .ok_or_else(|| unsupported("repeat loop without condition"))?;
                 let mut fields = label_fields(label);
                 fields.push(node_field(Some("body"), block_node(body)?));
-                fields.push(node_field(Some("condition"), convert_expr(cond)?));
+                fields.push(node_field(
+                    Some("condition"),
+                    convert_expr(if *is_until {
+                        strip_negation(cond)?
+                    } else {
+                        cond
+                    })?,
+                ));
                 return Ok(Some(RakuAstNode {
-                    class: RakuAstClass::StatementLoopRepeatWhile,
+                    class: if *is_until {
+                        RakuAstClass::StatementLoopRepeatUntil
+                    } else {
+                        RakuAstClass::StatementLoopRepeatWhile
+                    },
                     fields,
                 }));
             }
@@ -1784,6 +1815,21 @@ fn constant_declaration(
         class: RakuAstClass::VarDeclarationConstant,
         fields,
     })))
+}
+
+/// Strip the `!` the parser adds when it stores `until X` as `while !X`.
+///
+/// The flag and the negation are planted together, so an `is_until` loop whose
+/// condition is *not* a `!` would mean the two had drifted apart; refuse rather
+/// than render a condition that is not the one in the source.
+fn strip_negation(cond: &Expr) -> Result<&Expr, RuntimeError> {
+    match cond {
+        Expr::Unary {
+            op: crate::token_kind::TokenKind::Bang,
+            expr,
+        } => Ok(expr),
+        _ => Err(unsupported("`until` loop without the parser's negation")),
+    }
 }
 
 /// A class declaration's `traits` list, in source order: `is P` inheritance

--- a/src/rakuast/lower.rs
+++ b/src/rakuast/lower.rs
@@ -76,19 +76,26 @@ fn lower_stmt_inner(node: &RakuAstNode) -> Result<Stmt, RuntimeError> {
         RakuAstClass::VarDeclarationSimple => lower_var_decl(node),
         RakuAstClass::VarDeclarationConstant => lower_constant(node),
         RakuAstClass::StatementIf => lower_if(node),
-        RakuAstClass::StatementLoopWhile => lower_while(node),
+        RakuAstClass::StatementLoopWhile | RakuAstClass::StatementLoopUntil => lower_while(node),
         RakuAstClass::StatementLoop => lower_cstyle_loop(node),
         // `repeat { … } while/until C` runs the body once before testing the
         // condition (`until` desugars to `while !C`, handled by the prefix `!`).
-        RakuAstClass::StatementLoopRepeatWhile => Ok(Stmt::Loop {
-            init: None,
-            cond: Some(lower_expr(named_child(node, "condition")?)?),
-            step: None,
-            body: lower_block(named_child(node, "body")?)?,
-            repeat: true,
-            label: None,
-            is_until: false,
-        }),
+        // `repeat { … } while/until C`. mutsu stores an `until` as a negated
+        // condition plus the flag, which is what the converter reads back, so
+        // the lowerer has to re-plant both.
+        RakuAstClass::StatementLoopRepeatWhile | RakuAstClass::StatementLoopRepeatUntil => {
+            let is_until = node.class == RakuAstClass::StatementLoopRepeatUntil;
+            let cond = lower_expr(named_child(node, "condition")?)?;
+            Ok(Stmt::Loop {
+                init: None,
+                cond: Some(negate_if(cond, is_until)),
+                step: None,
+                body: lower_block(named_child(node, "body")?)?,
+                repeat: true,
+                label: None,
+                is_until,
+            })
+        }
         RakuAstClass::StatementFor => lower_for(node),
         // `INIT { … }` / `LEAVE { … }` / … -> `Stmt::Phaser`, one class per kind.
         // `BEGIN` is absent deliberately — see `lower_phaser`.
@@ -723,15 +730,30 @@ fn pointy_single_param(pointy: &RakuAstNode) -> Result<Option<String>, RuntimeEr
 
 /// Lower `while COND { … }` to `Stmt::While`.
 fn lower_while(node: &RakuAstNode) -> Result<Stmt, RuntimeError> {
+    let is_until = node.class == RakuAstClass::StatementLoopUntil;
     let cond = lower_expr(named_child(node, "condition")?)?;
     let body = lower_block(named_child(node, "body")?)?;
     Ok(Stmt::While {
-        cond,
+        cond: negate_if(cond, is_until),
         body,
         label: None,
         is_statement_modifier: false,
-        is_until: false,
+        is_until,
     })
+}
+
+/// mutsu stores an `until` loop as a `while` over a negated condition *plus* an
+/// `is_until` flag; raku keeps the condition undecorated and puts the keyword in
+/// the class name. Re-plant the negation the parser would have added.
+fn negate_if(cond: Expr, is_until: bool) -> Expr {
+    if is_until {
+        Expr::Unary {
+            op: crate::token_kind::TokenKind::Bang,
+            expr: Box::new(cond),
+        }
+    } else {
+        cond
+    }
 }
 
 /// Lower a C-style `loop (SETUP; COND; STEP) { … }` to `Stmt::Loop`. Each of the

--- a/src/rakuast/mod.rs
+++ b/src/rakuast/mod.rs
@@ -172,6 +172,9 @@ pub enum RakuAstClass {
     TermName,
     // `.^name` — a metamethod call, distinct from `.?`/`.+`/`.*` dispatch.
     CallMetaMethod,
+    // `until` / `repeat … until` — raku's own classes, not a negated `while`.
+    StatementLoopUntil,
+    StatementLoopRepeatUntil,
     // Class/role declaration traits (`is Parent`, `does Role`, `is rw`).
     TraitIs,
     TraitDoes,
@@ -280,6 +283,8 @@ impl RakuAstClass {
             VarDeclarationConstant => "RakuAST::VarDeclaration::Constant",
             TermName => "RakuAST::Term::Name",
             CallMetaMethod => "RakuAST::Call::MetaMethod",
+            StatementLoopUntil => "RakuAST::Statement::Loop::Until",
+            StatementLoopRepeatUntil => "RakuAST::Statement::Loop::RepeatUntil",
             TraitIs => "RakuAST::Trait::Is",
             TraitDoes => "RakuAST::Trait::Does",
             StatementPrefixPhaserBegin => "RakuAST::StatementPrefix::Phaser::Begin",
@@ -579,6 +584,8 @@ const RAKUAST_CLASSES: &[RakuAstClass] = &[
     RakuAstClass::VarDeclarationConstant,
     RakuAstClass::TermName,
     RakuAstClass::CallMetaMethod,
+    RakuAstClass::StatementLoopUntil,
+    RakuAstClass::StatementLoopRepeatUntil,
     RakuAstClass::TraitIs,
     RakuAstClass::TraitDoes,
     RakuAstClass::StatementPrefixPhaserBegin,

--- a/t/rakuast-until-loop.t
+++ b/t/rakuast-until-loop.t
@@ -1,0 +1,50 @@
+use v6;
+use MONKEY-SEE-NO-EVAL;
+use experimental :rakuast;
+use Test;
+
+# `until` and `repeat ... until`, both directions (ADR-0011).
+#
+# These were *wrongly rendered* rather than refused: mutsu stores `until X` as
+# `while !X` and rendered exactly that — `Statement::Loop::While` over an
+# `ApplyPrefix("!")`. raku has `Statement::Loop::Until` / `Loop::RepeatUntil`
+# classes and renders the *undecorated* condition.
+#
+# mutsu keeps an `is_until` flag alongside the negated condition, so the source
+# keyword was recoverable all along; the converter strips the `!` the parser
+# added and the lowerer re-plants it. Measured against rakudo 2026.07: the gists
+# are byte-for-byte identical.
+#
+# Passes under BOTH mutsu and raku.
+
+plan 11;
+
+# --- read side ---------------------------------------------------------------
+my $until = Q{until 1 { last }}.AST.gist;
+ok $until.contains('RakuAST::Statement::Loop::Until.new('),
+    '`until` renders as Loop::Until';
+nok $until.contains('RakuAST::Prefix.new("!")'),
+    "`until` renders its condition without the parser's negation";
+nok $until.contains('Loop::While'), '`until` is not a While';
+
+my $ru = Q{repeat { last } until 1}.AST.gist;
+ok $ru.contains('RakuAST::Statement::Loop::RepeatUntil.new('),
+    '`repeat ... until` renders as Loop::RepeatUntil';
+nok $ru.contains('RakuAST::Prefix.new("!")'),
+    '`repeat ... until` renders its condition undecorated';
+
+# --- the `while` forms are unchanged -----------------------------------------
+ok Q{while 1 { last }}.AST.gist.contains('RakuAST::Statement::Loop::While.new('),
+    '`while` still renders as Loop::While';
+ok Q{repeat { last } while 0}.AST.gist.contains('RakuAST::Statement::Loop::RepeatWhile.new('),
+    '`repeat ... while` still renders as Loop::RepeatWhile';
+
+# --- write side --------------------------------------------------------------
+is EVAL(Q{my $i = 0; until $i >= 3 { $i = $i + 1 }; $i}.AST), 3,
+    'an `until` loop lowers and runs to its condition';
+is EVAL(Q{my $i = 5; until $i > 0 { $i = 0 }; $i}.AST), 5,
+    'an `until` whose condition is already true never runs its body';
+is EVAL(Q{my $i = 0; repeat { $i = $i + 1 } until $i >= 3; $i}.AST), 3,
+    'a `repeat ... until` lowers';
+is EVAL(Q{my $i = 0; while $i < 3 { $i = $i + 1 }; $i}.AST), 3,
+    'a `while` loop still lowers';

--- a/todo/deep/rakuast-remaining.md
+++ b/todo/deep/rakuast-remaining.md
@@ -77,6 +77,14 @@ the parser/internal AST, not guessing during RakuAST conversion.
 
 **Closed 2026-09-05**:
 
+- *`until` / `repeat … until`.* Both were rendered *wrongly* (as a `While` over a
+  negated condition) rather than refused; `Stmt::While`/`Stmt::Loop` already kept
+  an `is_until` flag the converter did not read. Found by a gist-comparison sweep
+  against rakudo; the three other hits from that sweep need parser changes and
+  are filed as `todo/tickets/rakuast-fat-arrow-key-spelling-swapped.md` and
+  `todo/tickets/rakuast-unless-and-parens.md`, both with measured shapes. Pinned
+  by `t/rakuast-until-loop.t`; see
+  [the news entry](../../news/2026-09/rakuast-until-loop.md).
 - *Interpolated code blocks.* `"a{ $x }b"` renders its `{ ... }` segment as a
   plain `Block` (mutsu's `DoStmt` wrapper has no RakuAST counterpart) and lowers
   back to that wrapper — without which the segment became a closure and the

--- a/todo/tickets/rakuast-fat-arrow-key-spelling-swapped.md
+++ b/todo/tickets/rakuast-fat-arrow-key-spelling-swapped.md
@@ -1,0 +1,56 @@
+# RakuAST renders the two fat-arrow key spellings the wrong way round
+
+Measured against rakudo 2026.07, mutsu has `a => 1` and `"a" => 1` **swapped**:
+
+| source | rakudo | mutsu |
+|---|---|---|
+| `a => 1` (bareword key) | `FatArrow(key => "a", value => ...)` | `ApplyInfix(left => QuotedString, infix => "=>", ...)` |
+| `"a" => 1` (quoted key) | `ApplyInfix(left => QuotedString, infix => "=>", ...)` | `FatArrow(key => "a", value => ...)` |
+| `$k => 1` (computed key) | `ApplyInfix(left => Var::Lexical, infix => "=>", ...)` | boundary (`non-literal pair key`) |
+
+Both wrong cases render *something*, so this is silent wrongness rather than a
+coverage boundary — and `a => 1` is one of the most common constructs in Raku.
+
+## Root cause
+
+`src/rakuast/convert.rs` keys the choice off `Expr::PositionalPair`: that variant
+renders `FatArrow` and a plain `Expr::Binary { op: FatArrow }` falls through to
+the generic infix arm. But `PositionalPair` does not mean "quoted key" — its own
+doc says it marks *a pair expression that was parenthesized*. It happens to also
+appear for `my $p = "a" => 1`, which is what makes the current mapping look
+right in that one case.
+
+Measured internal ASTs:
+
+```
+a => 1            Binary { left: Literal(Str("a")), op: FatArrow, ... }
+"a" => 1          PositionalPair(Binary { left: Literal(Str("a")), ... })
+(a => 1)          PositionalPair(...)     <- bareword key, still PositionalPair
+("a" => 1)        PositionalPair(...)
+```
+
+So the bareword and quoted spellings both arrive as `Literal(Str("a"))` on the
+left, and `PositionalPair` cannot separate them: `(a => 1)` is a bareword key
+that would render as an `ApplyInfix` under any rule keyed on that variant, where
+rakudo renders a `FatArrow` inside a `Circumfix::Parentheses`.
+
+## What it needs
+
+The parser has to record which spelling produced the key — the same shape of fix
+as the `is_sub` flag on `Expr::AnonSubParams` (news/2026-09/
+rakuast-anonymous-sub-signature.md) and for the same reason: a distinction raku
+models with different nodes that mutsu erases before conversion. A flag on the
+`FatArrow` binary (or a dedicated pair node) would do it; `Expr::Binary` is
+generic, so it probably wants its own node rather than a field every binary pays
+for.
+
+Until then the honest interim state would be to refuse both spellings rather
+than render them swapped — that is a judgement call for whoever picks this up,
+since refusing removes coverage that some existing tests may assert.
+
+## Minimal repro
+
+```
+mutsu -e 'say Q{my $p = a => 1}.AST'      # renders ApplyInfix; rakudo: FatArrow
+mutsu -e 'say Q{my $p = "a" => 1}.AST'    # renders FatArrow;   rakudo: ApplyInfix
+```

--- a/todo/tickets/rakuast-unless-and-parens.md
+++ b/todo/tickets/rakuast-unless-and-parens.md
@@ -1,0 +1,58 @@
+# RakuAST renders `unless` as a negated `if`, and drops parentheses
+
+Two read-direction divergences measured against rakudo 2026.07. Both render
+*something* rather than refusing, so both are silent wrongness.
+
+## 1. `unless`
+
+```
+$ mutsu -e 'say Q{unless 1 { 2 }}.AST'
+  RakuAST::Statement::If.new(
+    condition => RakuAST::ApplyPrefix.new(
+      prefix  => RakuAST::Prefix.new("!"),
+...
+# rakudo:
+  RakuAST::Statement::Unless.new(
+    condition => RakuAST::IntLiteral.new(1),
+    body      => ...
+```
+
+mutsu desugars `unless X` to `if !X` and `Stmt::If` keeps no flag saying which
+keyword the source used, so `unless 1 { }` and `if !1 { }` are indistinguishable
+by the time the converter sees them. (`until` had the same shape but *did* keep
+an `is_until` flag, which is why it could be fixed — see
+`news/2026-09/rakuast-until-loop.md`.)
+
+The fix is an `is_unless` flag on `Stmt::If`, mirroring `Stmt::While::is_until`.
+`Stmt::If {` appears at ~101 sites, so it is a mechanical but wide change; the
+flag has no execution meaning, exactly like `is_until`.
+
+Note rakudo's node is `Statement::Unless` with a `body` field (not `then`), and
+an `unless` cannot carry `elsif`/`else`, so the node is simpler than `If`.
+
+## 2. Parentheses
+
+```
+$ mutsu -e 'say Q{my $x = (1, 2)}.AST'
+    ... RakuAST::ApplyListInfix.new(infix => ",", operands => (...))
+# rakudo:
+    ... RakuAST::Circumfix::Parentheses.new(
+          RakuAST::SemiList.new(
+            RakuAST::Statement::Expression.new(
+              expression => RakuAST::ApplyListInfix.new(...)
+```
+
+rakudo keeps the parentheses as a `Circumfix::Parentheses` wrapping a `SemiList`;
+`(1)` gets the same wrapper around a bare `IntLiteral`. mutsu renders the wrapper
+for `Expr::Grouped` but the parser does not produce `Grouped` in an initializer
+position, so the parens are simply gone.
+
+Worth checking whether the parser can keep `Grouped` there, or whether the
+initializer path unwraps it deliberately for a reason the converter should
+respect.
+
+## Why they are grouped here
+
+Both are "the parser erased a distinction raku keeps", both are in very common
+syntax, and both are cheap *once* the upstream representation carries the
+information. Neither needs new measurement: the rakudo shapes above are recorded.


### PR DESCRIPTION
A **silent wrongness**, not a coverage gap: `until X { }` and
`repeat { } until X` were rendered as something rakudo disagrees with, rather
than refused.

## Problem

```
$ mutsu -e 'say Q{until 1 { last }}.AST'
  RakuAST::Statement::Loop::While.new(
    condition => RakuAST::ApplyPrefix.new(
      prefix  => RakuAST::Prefix.new("!"),
      operand => RakuAST::IntLiteral.new(1)
...
# rakudo 2026.07:
  RakuAST::Statement::Loop::Until.new(
    condition => RakuAST::IntLiteral.new(1),
```

mutsu stores an `until` as `while !X`, and `.AST` rendered exactly that. raku has
`Statement::Loop::Until` and `Statement::Loop::RepeatUntil` classes and renders
the **undecorated** condition.

## The information was there all along

`Stmt::While` and `Stmt::Loop` both keep an `is_until` flag alongside the negated
condition. The converter simply did not read it, and its comment — "mutsu
desugars `until X` to `while !X`" — recorded the desugaring as if it were lossy.

The converter now picks the class from the flag and strips the `!` the parser
added; the lowerer re-plants it. A flagged loop whose condition is *not* a
negation is refused rather than rendered, since that would mean the flag and the
negation had drifted apart.

Measured against rakudo 2026.07: byte-for-byte identical for `until`,
`repeat ... until`, and both `while` forms.

## How it was found, and what else the sweep caught

A gist-comparison sweep — render a corpus of small programs under both
implementations and diff, reporting only cases where **both** render, since a
mutsu boundary is honest but a mutsu *disagreement* is a bug.

The three other hits need the parser to stop erasing a distinction, so they are
filed rather than fixed, each with its measured rakudo shape:

- **`todo/tickets/rakuast-fat-arrow-key-spelling-swapped.md`** — `a => 1` and
  `"a" => 1` render as *each other's node*. The converter keys on
  `Expr::PositionalPair`, which means "parenthesized pair", not "quoted key", so
  `(a => 1)` would be wrong under any rule based on it. `a => 1` is one of the
  most common constructs in Raku, so this is the more valuable of the two.
- **`todo/tickets/rakuast-unless-and-parens.md`** — `unless` renders as a negated
  `if` (`Stmt::If` has no `is_unless` flag, unlike `Stmt::While::is_until` —
  which is exactly why `until` was fixable here and `unless` is not), and
  `(1, 2)` loses its `Circumfix::Parentheses` wrapper.

## Tests

`t/rakuast-until-loop.t` (11 assertions) pins both `until` classes, the
undecorated condition, that neither renders as a `While`, that both `while` forms
are unchanged, and four `EVAL` round trips including an `until` whose condition
is already true so its body never runs. It passes verbatim under mutsu **and**
rakudo 2026.07.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TtL4NKUC5rVfjD6mFDpqh9

---
_Generated by [Claude Code](https://claude.ai/code/session_01TtL4NKUC5rVfjD6mFDpqh9)_