### PR TITLE
fix(rakuast): stop leaking an injected argument and a TokenKind variant name

### DIFF
--- a/news/2026-09/rakuast-internal-arg-and-range-op-leaks.md
+++ b/news/2026-09/rakuast-internal-arg-and-range-op-leaks.md
@@ -1,0 +1,59 @@
+# RakuAST stops leaking two mutsu internals
+
+Two `.AST` leaks, both silent wrongness rather than coverage gaps, both found by
+the gist-comparison sweep against rakudo 2026.07.
+
+## An injected named argument rendered as a real one
+
+mutsu's parser attaches a `__mutsu_test_callsite_line => N` named argument to
+every listop call, so a failing `Test` assertion can report the caller's line. It
+is instrumentation, not something the source wrote, and the converter rendered it
+as an ordinary argument — on calls as plain as `f()`:
+
+```
+$ mutsu -e 'say Q{sub f { }; f()}.AST'
+    expression => RakuAST::Call::Name.new(
+      name => RakuAST::Name.from-identifier("f"),
+      args => RakuAST::ArgList.new(
+        RakuAST::ApplyInfix.new(
+          left  => RakuAST::QuotedString.new(
+            segments   => (
+              RakuAST::StrLiteral.new("__mutsu_test_callsite_line"),
+```
+
+`arg_list` now skips a named argument whose key is one of mutsu's internal
+markers, using the same `is_desugar_marker` predicate that already refuses
+internal *routine* and *variable* names — this was simply the third place such a
+name could reach the output.
+
+Fixing it exposed a third leak: raku omits the `args` field entirely for an
+argument-less call, so filtering left an empty `ArgList` where there should be no
+field at all. `call_name` now omits it, the way `control_call` already did for a
+bare `return`/`last`/`next`.
+
+## A Rust variant name rendered as an operator
+
+`token_kind_to_op_name` ends in a `{:?}` fallback, so any `TokenKind` without an
+explicit row renders its **Rust variant name**. The exclusive range operators had
+no rows:
+
+```
+$ mutsu -e 'say Q{my @a = 1..^3}.AST'
+          infix => RakuAST::Infix.new("DotDotCaret")     # rakudo: "..^"
+```
+
+`..^`, `^..`, `^..^` and `...^` now have rows, and the fallback carries a comment
+saying what it does, so the next missing operator is a known cost rather than a
+surprise.
+
+## Coverage
+
+`t/rakuast-internal-arg-and-range-ops.t` (10 assertions) pins that no `__mutsu`
+name appears in a rendered call, that an argument-less call omits `args` while a
+call with arguments keeps it, that a listop keeps its *real* argument, each
+exclusive range operator rendering as itself, and that no `TokenKind` variant
+name leaks into a range gist. It is a dual-oracle test: it passes verbatim under
+both mutsu and rakudo 2026.07.
+
+After this, a 28-program sweep across the common syntax renders byte-identically
+to rakudo.

--- a/src/compiler/helpers_ops.rs
+++ b/src/compiler/helpers_ops.rs
@@ -81,6 +81,17 @@ pub(crate) fn token_kind_to_op_name(op: &TokenKind) -> String {
         TokenKind::SetStrictSuperset => "(>)".to_string(),
         TokenKind::PlusPlus => "++".to_string(),
         TokenKind::MinusMinus => "--".to_string(),
+        // The exclusive range family. Without these rows they fell to the
+        // `{:?}` fallback below, so `.AST` rendered `Infix.new("DotDotCaret")`
+        // — a Rust variant name, not an operator anyone wrote.
+        TokenKind::DotDotCaret => "..^".to_string(),
+        TokenKind::CaretDotDot => "^..".to_string(),
+        TokenKind::CaretDotDotCaret => "^..^".to_string(),
+        TokenKind::DotDotDotCaret => "...^".to_string(),
+        // A `TokenKind` with no spelling here renders its Rust variant name.
+        // That is fine for runtime dispatch (the lookup simply misses), but it
+        // is how an internal name leaks into `.AST` — see the range rows above.
+        // Add a row rather than relying on this.
         _ => format!("{:?}", op),
     }
 }

--- a/src/rakuast/convert.rs
+++ b/src/rakuast/convert.rs
@@ -2410,13 +2410,16 @@ fn call_name(
     } else {
         RakuAstClass::CallName
     };
-    Ok(RakuAstNode {
-        class,
-        fields: vec![
-            node_field(Some("name"), name_node),
-            node_field(Some("args"), arg_list),
-        ],
-    })
+    let mut fields = vec![node_field(Some("name"), name_node)];
+    // raku omits `args` entirely for an argument-less call, the same way
+    // `control_call` below already does for a bare `return`/`last`/`next`. This
+    // matters more than it looks: mutsu injects a `__mutsu_test_callsite_line`
+    // named argument into listop calls, so filtering that out in `arg_list` can
+    // leave an *empty* list where the source had no arguments at all.
+    if !arg_list.fields.is_empty() {
+        fields.push(node_field(Some("args"), arg_list));
+    }
+    Ok(RakuAstNode { class, fields })
 }
 
 /// A control-flow listop (`return`/`last`/`next`) — a `Call::Name` in
@@ -2509,10 +2512,42 @@ fn comma_list_node(items: &[Expr]) -> Result<RakuAstNode, RuntimeError> {
 fn arg_list(args: &[Expr]) -> Result<RakuAstNode, RuntimeError> {
     let mut fields = Vec::with_capacity(args.len());
     for a in args {
+        // mutsu's parser attaches a `__mutsu_test_callsite_line => N` named
+        // argument to every listop call so a failing `Test` assertion can report
+        // the caller's line. It is instrumentation, not something the source
+        // wrote, and raku's tree has no such argument — rendering it produced a
+        // node that cannot exist upstream, on calls as ordinary as `f()`.
+        if is_injected_named_arg(a) {
+            continue;
+        }
         fields.push(node_field(None, convert_expr(a)?));
     }
     Ok(RakuAstNode {
         class: RakuAstClass::ArgList,
         fields,
     })
+}
+
+/// Whether a call argument is one of mutsu's own injected named arguments
+/// (`__`-prefixed key), rather than one the source wrote.
+fn is_injected_named_arg(arg: &Expr) -> bool {
+    let pair = match arg {
+        Expr::PositionalPair(inner) => inner.as_ref(),
+        other => other,
+    };
+    let Expr::Binary {
+        left,
+        op: crate::token_kind::TokenKind::FatArrow,
+        ..
+    } = pair
+    else {
+        return false;
+    };
+    match left.as_ref() {
+        Expr::Literal(v) | Expr::LiteralSrc(v, _) => match v.view() {
+            ValueView::Str(s) => is_desugar_marker(&s),
+            _ => false,
+        },
+        _ => false,
+    }
 }

--- a/t/rakuast-internal-arg-and-range-ops.t
+++ b/t/rakuast-internal-arg-and-range-ops.t
@@ -1,0 +1,51 @@
+use v6;
+use experimental :rakuast;
+use Test;
+
+# Two `.AST` leaks of mutsu internals, both silent wrongness rather than
+# coverage gaps, both measured against rakudo 2026.07.
+#
+#   1. mutsu's parser attaches a `__mutsu_test_callsite_line => N` named
+#      argument to every listop call so a failing `Test` assertion can report the
+#      caller's line. It is instrumentation, not something the source wrote, and
+#      it was rendered as a real argument — on calls as ordinary as `f()`.
+#
+#   2. `token_kind_to_op_name` had no rows for the exclusive range operators, so
+#      they fell to its `{:?}` fallback and `1..^3` rendered
+#      `Infix.new("DotDotCaret")` — a Rust variant name, not an operator anyone
+#      wrote.
+#
+# Fixing (1) exposed a third: raku omits `args` entirely for an argument-less
+# call, so filtering the injected argument out left an empty `ArgList` where
+# there should be no field at all.
+#
+# Passes under BOTH mutsu and raku.
+
+plan 10;
+
+# --- no injected argument leaks into a call ---------------------------------
+my $call = Q{sub f { }; f()}.AST.gist;
+nok $call.contains('__mutsu'), 'no mutsu-internal argument is rendered';
+nok $call.contains('args'), 'an argument-less call omits its args field';
+
+my $say = Q{say 42}.AST.gist;
+nok $say.contains('__mutsu'), 'a listop call renders no internal argument';
+ok $say.contains('RakuAST::IntLiteral.new(42)'), 'a listop keeps its real argument';
+
+my $one = Q{sub f($x) { }; f(1)}.AST.gist;
+ok $one.contains('args => RakuAST::ArgList.new('), 'a call with arguments keeps its args field';
+
+# --- the exclusive range operators render their real spelling ---------------
+for '..^', '^..', '^..^' -> $op {
+    my $src = "my \@a = 1 $op 3";
+    ok $src.AST.gist.contains("RakuAST::Infix.new(\"$op\")"),
+        "`$op` renders as itself";
+}
+
+# --- the inclusive range is unchanged ----------------------------------------
+ok Q{my @a = 1..3}.AST.gist.contains('RakuAST::Infix.new("..")'),
+    '`..` still renders as itself';
+
+# --- no Rust variant name leaks anywhere in a range gist ---------------------
+nok Q{my @a = 1..^3}.AST.gist.contains('DotDot'),
+    'no TokenKind variant name leaks into the rendered operator';

--- a/todo/deep/rakuast-remaining.md
+++ b/todo/deep/rakuast-remaining.md
@@ -77,6 +77,13 @@ the parser/internal AST, not guessing during RakuAST conversion.
 
 **Closed 2026-09-05**:
 
+- *Two internal leaks.* An injected `__mutsu_test_callsite_line` named argument
+  rendered as a real argument on every listop call (and filtering it out exposed
+  raku's omission of an empty `args` field), and the exclusive range operators
+  had no row in `token_kind_to_op_name`, so `1..^3` rendered
+  `Infix.new("DotDotCaret")` — a Rust variant name. Pinned by
+  `t/rakuast-internal-arg-and-range-ops.t`; see
+  [the news entry](../../news/2026-09/rakuast-internal-arg-and-range-op-leaks.md).
 - *`until` / `repeat … until`.* Both were rendered *wrongly* (as a `While` over a
   negated condition) rather than refused; `Stmt::While`/`Stmt::Loop` already kept
   an `is_until` flag the converter did not read. Found by a gist-comparison sweep


### PR DESCRIPTION
Two more `.AST` leaks of mutsu internals — silent wrongness rather than coverage
gaps — found by the same gist-comparison sweep against rakudo 2026.07 that caught
`until`.

## 1. An injected named argument rendered as a real one

mutsu's parser attaches a `__mutsu_test_callsite_line => N` named argument to
every listop call, so a failing `Test` assertion can report the caller's line. It
is instrumentation, not something the source wrote, and the converter rendered it
as an ordinary argument — on calls as plain as `f()`:

```
$ mutsu -e 'say Q{sub f { }; f()}.AST'
    expression => RakuAST::Call::Name.new(
      name => RakuAST::Name.from-identifier("f"),
      args => RakuAST::ArgList.new(
        RakuAST::ApplyInfix.new(
          left  => RakuAST::QuotedString.new(
            segments   => (
              RakuAST::StrLiteral.new("__mutsu_test_callsite_line"),
```

`arg_list` now skips a named argument whose key is one of mutsu's internal
markers, reusing the `is_desugar_marker` predicate that already refuses internal
*routine* and *variable* names. This was simply the third place such a name could
reach the output.

Fixing it exposed a third leak: raku omits the `args` field entirely for an
argument-less call, so filtering the injected argument left an empty `ArgList`
where there should be no field at all. `call_name` now omits it, the way
`control_call` already did for a bare `return`/`last`/`next`.

## 2. A Rust variant name rendered as an operator

`token_kind_to_op_name` ends in a `{:?}` fallback, so any `TokenKind` without an
explicit row renders its **Rust variant name**. The exclusive range operators had
none:

```
$ mutsu -e 'say Q{my @a = 1..^3}.AST'
          infix => RakuAST::Infix.new("DotDotCaret")     # rakudo: "..^"
```

`..^`, `^..`, `^..^` and `...^` now have rows, and the fallback carries a comment
saying what it does, so the next missing operator is a known cost rather than a
surprise.

## Tests

`t/rakuast-internal-arg-and-range-ops.t` (10 assertions) pins that no `__mutsu`
name appears in a rendered call, that an argument-less call omits `args` while a
call with arguments keeps it, that a listop keeps its *real* argument, each
exclusive range operator rendering as itself, and that no `TokenKind` variant
name leaks into a range gist. It passes verbatim under mutsu **and** rakudo
2026.07.

After this, a 28-program sweep across the common syntax (literals, all the
control-flow forms, calls, subscripts, declarations, phasers, class traits,
`multi`, `constant`, interpolation, `where` constraints, reductions) renders
**byte-identically** to rakudo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TtL4NKUC5rVfjD6mFDpqh9

---
_Generated by [Claude Code](https://claude.ai/code/session_01TtL4NKUC5rVfjD6mFDpqh9)_