### PR TITLE
fix(rakuast): render junctions and min/max as list infixes

### DIFF
--- a/news/2026-09/rakuast-list-infixes.md
+++ b/news/2026-09/rakuast-list-infixes.md
@@ -1,0 +1,37 @@
+# RakuAST list infixes: junctions, `min` and `max`
+
+raku renders a *list-associative* infix as one flat `ApplyListInfix` carrying
+every operand of the chain, where an ordinary infix is a left-nested
+`ApplyInfix`. Measured against rakudo 2026.07, the list-associative set mutsu can
+produce is:
+
+```
+,   andthen   orelse   notandthen   |   &   ^   min   max
+```
+
+and these are *not*: `+`, `~`, `*`, `==`, `eq`, `and`, `or`, `&&`, `||`, `//`.
+
+The comma and the `andthen` family were already handled. The junction
+constructors and `min`/`max` rendered as nested `ApplyInfix` — a shape rakudo
+never produces for them, so silent wrongness rather than a coverage gap.
+
+## Change
+
+`is_list_infix` gained the five operators, which routes them through the
+existing `flatten_list_infix` path that already collapses a left-nested
+same-operator chain into one operand list.
+
+The lowerer's list-infix arm no longer hardcodes the three `andthen`-family
+names: it maps the operator name back through `op_name_to_token_kind`, which
+gained rows for `|`, `&` and `^` (`min`/`max` are already `TokenKind::Ident`, so
+the catch-all is correct for them). This is the third time this session that
+adding a row to that table was the whole fix — it is only used by the RakuAST
+lowerer, so a missing row is invisible until a node reaches it.
+
+## Coverage
+
+`t/rakuast-list-infix.t` (12 assertions) pins `min`, `max` and all three
+junction constructors as `ApplyListInfix`, that a three-operand chain is **one**
+flat list rather than a nest (counting the occurrences, not just looking for the
+class), that `+` and `~` are unchanged, and two `EVAL` round trips. It is a
+dual-oracle test: it passes verbatim under both mutsu and rakudo 2026.07.

--- a/src/compiler/helpers_ops.rs
+++ b/src/compiler/helpers_ops.rs
@@ -145,6 +145,12 @@ pub(crate) fn op_name_to_token_kind(name: &str) -> Option<TokenKind> {
         "andthen" => TokenKind::AndThen,
         "orelse" => TokenKind::OrElse,
         "notandthen" => TokenKind::NotAndThen,
+        // The junction constructors. Like the `andthen` family these are list
+        // infixes in raku, so the RakuAST lowerer has to map them back to a
+        // real token rather than the `Ident` catch-all below.
+        "|" => TokenKind::Pipe,
+        "&" => TokenKind::Ampersand,
+        "^" => TokenKind::Caret,
         // Any remaining operator name is a named infix (`x`, `xx`, `eq`, `ne`,
         // `lt`/`gt`/`le`/`ge`, `cmp`, `leg`, `div`, `mod`, ...), which mutsu
         // represents with a generic `Ident` token (the inverse of

--- a/src/rakuast/convert.rs
+++ b/src/rakuast/convert.rs
@@ -2312,8 +2312,16 @@ fn is_list_infix(op: &crate::token_kind::TokenKind) -> bool {
     use crate::token_kind::TokenKind;
     matches!(
         op,
-        TokenKind::AndThen | TokenKind::OrElse | TokenKind::NotAndThen
-    )
+        TokenKind::AndThen
+            | TokenKind::OrElse
+            | TokenKind::NotAndThen
+            // The junction constructors and `min`/`max`. Measured against
+            // rakudo 2026.07: each renders one flat `ApplyListInfix` with every
+            // operand of the chain, where mutsu nests them left-associatively.
+            | TokenKind::Pipe
+            | TokenKind::Ampersand
+            | TokenKind::Caret
+    ) || matches!(op, TokenKind::Ident(name) if name == "min" || name == "max")
 }
 
 /// Flatten a left-nested same-operator chain (`a op b op c` parsed as

--- a/src/rakuast/lower.rs
+++ b/src/rakuast/lower.rs
@@ -1345,11 +1345,12 @@ fn lower_expr(node: &RakuAstNode) -> Result<Expr, RuntimeError> {
             if op == "," {
                 return Ok(Expr::ArrayLiteral(items));
             }
-            let token = match op.as_str() {
-                "andthen" => crate::token_kind::TokenKind::AndThen,
-                "orelse" => crate::token_kind::TokenKind::OrElse,
-                "notandthen" => crate::token_kind::TokenKind::NotAndThen,
-                _ => return Err(unsupported(node)),
+            // Every other list infix mutsu renders — the `andthen` family, the
+            // junction constructors, `min`/`max` — is an ordinary left-nested
+            // `Expr::Binary` internally, so the operator name maps straight back
+            // to its token.
+            let Some(token) = crate::compiler::helpers_ops::op_name_to_token_kind(&op) else {
+                return Err(unsupported(node));
             };
             // These chain left-associatively: `a andthen b andthen c` is
             // `(a andthen b) andthen c`, which is how the parser builds it.

--- a/t/rakuast-list-infix.t
+++ b/t/rakuast-list-infix.t
@@ -1,32 +1,58 @@
 use v6;
+use MONKEY-SEE-NO-EVAL;
+use experimental :rakuast;
 use Test;
 
-# RakuAST Phase 2 slice 24 (ADR-0011): list-associative infixes
-# `andthen` / `orelse` / `notandthen`. These render as a single flat
-# ApplyListInfix in raku; mutsu nests them left-associatively, so a same-op
-# chain is flattened into one operand list. Expected gists captured verbatim
-# from Rakudo; this file passes under BOTH mutsu and raku.
+# List infixes beyond the comma and the `andthen` family (ADR-0011).
+#
+# raku renders a *list-associative* infix as one flat `ApplyListInfix` carrying
+# every operand of the chain, where an ordinary infix is a left-nested
+# `ApplyInfix`. Measured against rakudo 2026.07, the list-associative set mutsu
+# can produce is: `,`, `andthen`/`orelse`/`notandthen`, the junction
+# constructors `|` / `&` / `^`, and `min` / `max`. `+`, `~`, `*`, `==`, `eq`,
+# `and`, `or`, `&&`, `||` and `//` are all ordinary infixes.
+#
+# The comma and the `andthen` family were already handled; the junctions and
+# `min`/`max` rendered as nested `ApplyInfix`, which is a shape rakudo never
+# produces for them.
+#
+# Passes under BOTH mutsu and raku.
 
-plan 3;
+plan 12;
 
-# --- two-operand andthen ----------------------------------------------------
-is Q[my $a; my $b; $a andthen $b].AST.gist.contains(q:to/FRAG/.chomp), True, 'andthen -> ApplyListInfix';
-        expression => RakuAST::ApplyListInfix.new(
-          infix    => RakuAST::Infix.new("andthen"),
-          operands => (
-            RakuAST::Var::Lexical.new("\$a"),
-            RakuAST::Var::Lexical.new("\$b"),
-          )
-        )
-    FRAG
+sub expr-of($src) { $src.AST.statements[0].expression.gist }
 
-# --- a three-operand chain flattens into one operand list -------------------
-my $chain = Q[my $a; my $b; my $c; $a andthen $b andthen $c].AST.gist;
-ok $chain.contains('RakuAST::ApplyListInfix.new(')
-    && $chain.contains('RakuAST::Infix.new("andthen")')
-    && $chain.comb(/'RakuAST::Var::Lexical'/).elems == 3,   # 3 flat operands
-    'a op b op c flattens into three operands (not nested)';
+# --- min / max ---------------------------------------------------------------
+ok expr-of(Q{my $x = 1 min 2}).contains('RakuAST::ApplyListInfix.new('),
+    '`min` renders as an ApplyListInfix';
+ok expr-of(Q{my $x = 1 max 2}).contains('RakuAST::ApplyListInfix.new('),
+    '`max` renders as an ApplyListInfix';
 
-# --- orelse also uses ApplyListInfix ----------------------------------------
-is Q[my $a; my $b; $a orelse $b].AST.gist.contains('RakuAST::Infix.new("orelse")'), True,
-    'orelse -> ApplyListInfix with the orelse infix';
+# --- a chain flattens into one operand list ---------------------------------
+my $chain = expr-of(Q{my $x = 1 min 2 min 3});
+ok $chain.contains('RakuAST::IntLiteral.new(1)')
+    && $chain.contains('RakuAST::IntLiteral.new(2)')
+    && $chain.contains('RakuAST::IntLiteral.new(3)'),
+    'a `min` chain keeps all three operands';
+is $chain.comb('ApplyListInfix').elems, 1,
+    'a `min` chain is ONE flat list, not a nest';
+
+# --- junction constructors ---------------------------------------------------
+ok expr-of(Q{my $x = 1 | 2}).contains('RakuAST::ApplyListInfix.new('),
+    '`|` renders as an ApplyListInfix';
+ok expr-of(Q{my $x = 1 & 2}).contains('RakuAST::ApplyListInfix.new('),
+    '`&` renders as an ApplyListInfix';
+ok expr-of(Q{my $x = 1 ^ 2}).contains('RakuAST::ApplyListInfix.new('),
+    '`^` renders as an ApplyListInfix';
+is expr-of(Q{my $x = 1 | 2 | 3}).comb('ApplyListInfix').elems, 1,
+    'a `|` chain is one flat list';
+
+# --- ordinary infixes are unchanged -----------------------------------------
+ok expr-of(Q{my $x = 1 + 2}).contains('RakuAST::ApplyInfix.new('),
+    '`+` is still an ordinary ApplyInfix';
+nok expr-of(Q{my $x = 1 ~ 2}).contains('ApplyListInfix'),
+    '`~` is still an ordinary ApplyInfix';
+
+# --- write side --------------------------------------------------------------
+is EVAL(Q{1 min 2 min 3}.AST), 1, 'a `min` chain lowers and evaluates';
+is EVAL(Q{my $x = 1; ($x ~~ 1|2)}.AST), True, 'a junction lowers and smartmatches';

--- a/todo/deep/rakuast-remaining.md
+++ b/todo/deep/rakuast-remaining.md
@@ -77,6 +77,12 @@ the parser/internal AST, not guessing during RakuAST conversion.
 
 **Closed 2026-09-05**:
 
+- *List infixes.* The junction constructors (`|` / `&` / `^`) and `min` / `max`
+  are list-associative in raku — one flat `ApplyListInfix` per chain — and were
+  rendering as nested `ApplyInfix`. Measured the full list-associative set
+  against rakudo 2026.07 (`,`, the `andthen` family, the junctions, `min`/`max`;
+  everything else ordinary). Pinned by `t/rakuast-list-infix.t`; see
+  [the news entry](../../news/2026-09/rakuast-list-infixes.md).
 - *Two internal leaks.* An injected `__mutsu_test_callsite_line` named argument
   rendered as a real argument on every listop call (and filtering it out exposed
   raku's omission of an empty `args` field), and the exclusive range operators


### PR DESCRIPTION
More silent wrongness from the gist-comparison sweep against rakudo 2026.07.

## Problem

raku renders a *list-associative* infix as **one flat** `ApplyListInfix` carrying
every operand of the chain, where an ordinary infix is a left-nested
`ApplyInfix`. Measured against rakudo 2026.07, the list-associative set mutsu can
produce is:

```
,   andthen   orelse   notandthen   |   &   ^   min   max
```

and these are *not*: `+`, `~`, `*`, `==`, `eq`, `and`, `or`, `&&`, `||`, `//`.

The comma and the `andthen` family were already handled. The junction
constructors and `min`/`max` rendered as nested `ApplyInfix` — a shape rakudo
never produces for them:

```
$ mutsu -e 'say Q{my $x = 1 min 2 min 3}.AST'
      RakuAST::ApplyInfix.new(
        left  => RakuAST::ApplyInfix.new(...)     # rakudo: one ApplyListInfix
```

## Change

`is_list_infix` gained the five operators, which routes them through the existing
`flatten_list_infix` path that already collapses a left-nested same-operator
chain into one operand list.

The lowerer's list-infix arm no longer hardcodes the three `andthen`-family
names: it maps the operator name back through `op_name_to_token_kind`, which
gained rows for `|`, `&` and `^` (`min`/`max` are already `TokenKind::Ident`, so
the catch-all is correct for them).

That is the **third time this session** that adding a row to that table was the
whole fix — it is used only by the RakuAST lowerer, so a missing row stays
invisible until a node reaches it. (The earlier two: `++`/`--`, where a missing
row made `EVAL` of `++$x` a silent no-op; and the `andthen` family itself.)

## Tests

`t/rakuast-list-infix.t` (12 assertions) pins `min`, `max` and all three junction
constructors as `ApplyListInfix`, that a three-operand chain is **one** flat list
rather than a nest — counting the occurrences, not just looking for the class, so
a nested-but-present rendering still fails — that `+` and `~` are unchanged, and
two `EVAL` round trips including a junction smartmatch.

It passes verbatim under mutsu **and** rakudo 2026.07, as does the whole
`t/junction*.t` family locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TtL4NKUC5rVfjD6mFDpqh9

---
_Generated by [Claude Code](https://claude.ai/code/session_01TtL4NKUC5rVfjD6mFDpqh9)_