### PR TITLE
docs: add an install-raku skill for the Rakudo prebuilt oracle

### DIFF
--- a/.agents/skills/cut-release/SKILL.md
+++ b/.agents/skills/cut-release/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: cut-release
+description: Cut a mutsu release — choose the version by semver judgment, fire the tag-release workflow, and verify that the tag build publishes all four tarballs, the npm package, and the GitHub Release. Use when asked to release, cut a version, tag a release, bump the version, or publish mutsu.
+metadata:
+  short-description: Release mutsu via the tag-release workflow
+---
+
+# Cutting a release
+
+Releases are cut by **one manual trigger** — the `tag-release.yml` workflow. tagpr was removed
+(2026-07-25): there is no release PR, no `CHANGELOG.md`, and no `minor`/`major` version-bump
+label to apply on ordinary PRs.
+
+## 1. Pick the version by hand
+
+There is no label-driven *version* automation. Use semver judgment over what actually merged
+since the last tag:
+
+```bash
+git fetch origin main --tags
+git log --oneline "$(git describe --tags --abbrev=0)"..origin/main
+```
+
+- **patch** — fixes, roast progress, docs
+- **minor** — a new user-visible feature
+- **major** — a breaking change
+
+## 2. Trigger the workflow
+
+```bash
+gh workflow run tag-release.yml -f version=0.18.0
+```
+
+(or Actions tab → "Tag release" → Run workflow). **No `v` prefix** — the workflow validates the
+input against `^[0-9]+\.[0-9]+\.[0-9]+$` and fails otherwise.
+
+## 3. What the trigger sets in motion
+
+`tag-release.yml` (one job) bumps `version` in `Cargo.toml`, syncs the `mutsu` `Cargo.lock`
+entry with `cargo update -p mutsu`, commits `Release vX.Y.Z` straight to `main`, and pushes the
+`vX.Y.Z` tag. It does both through a **GitHub App token**, for two independent reasons: the App
+is a configured bypass actor on the `main` ruleset (so the push is not rejected by
+`required_status_checks`), and a tag pushed with the default `GITHUB_TOKEN` would **not** start
+dependent workflows.
+
+The tag push fires `release.yml`:
+
+| Job | What it does |
+| --- | --- |
+| `build` | Builds `mutsu` + `mzef` for all four targets (Linux x64/arm64, macOS x64/arm64) and packages `bin/` + `share/mutsu/zef` tarballs. **All four are required** — none is `continue-on-error` any more. |
+| `batteries` | Release gate: every bundled library's upstream test suite must still pass at its recorded baseline against the shipped library + this mutsu (`scripts/battery-testsuite.sh`). |
+| `npm` | Builds the browser/WASM package and publishes `@tokuhirom/mutsu` via OIDC trusted publishing (`id-token: write`). npm records provenance automatically — **do not add a long-lived npm token.** |
+| `release` | Downloads the artifacts, writes `mutsu-vX.Y.Z-SHA256SUMS.txt`, and creates the GitHub Release with `generate_release_notes: true`. |
+
+`mutsu --version` reports `env!("CARGO_PKG_VERSION")`, so the `Cargo.toml` version the workflow
+writes is the shipped version; the workflow keeps them coherent for you.
+
+## 4. Verify the release actually landed
+
+Do not stop at "the workflow was dispatched".
+
+```bash
+gh run list --workflow=tag-release.yml -L 1          # bump + tag pushed?
+gh run list --workflow=release.yml -L 1              # tag build started?
+gh run watch "$(gh run list --workflow=release.yml -L 1 --json databaseId -q '.[0].databaseId')"
+gh release view "v0.18.0" --json assets -q '.assets[].name'   # 4 tarballs + SHA256SUMS
+npm view @tokuhirom/mutsu version                    # npm publish landed?
+```
+
+The GitHub Release should carry four `mutsu-vX.Y.Z-*.tar.gz` assets plus
+`mutsu-vX.Y.Z-SHA256SUMS.txt`.
+
+If `release.yml` fails, note that **the version-bump commit and the tag are already on `main`** —
+nothing rolls back. Decide with the user whether to fix forward with a new patch version or to
+delete and re-push the tag; do not silently do either.
+
+## Release notes
+
+Notes are auto-generated from the PRs merged since the previous tag and **grouped into sections**
+(🚀 Features / 🐛 Bug Fixes / ⚡ Performance / 📝 Documentation / 📦 Dependencies / 🔧 Maintenance
+/ Other) by `.github/release.yml`. GitHub sorts each PR by label, and `.github/workflows/label-pr.yml`
+applies the category label (`feat`/`fix`/`perf`/`docs`/`maintenance`, or `dependencies` for
+`*(deps):`) from the PR's conventional-commit title prefix. Dependabot labels its own PRs
+`dependencies`.
+
+**So keep the `type:` / `type(scope):` PR title convention** — it is the only thing driving both
+the label and the release-note section. A PR titled without a prefix falls through to
+"Other Changes".
+
+## One-time infra prerequisites (already done; do not undo)
+
+- The release GitHub App must remain a **bypass actor on the `main` branch ruleset**, or
+  `tag-release.yml`'s push to `main` is rejected by `required_status_checks`.
+- **npm bootstrap:** npm only allows trusted publishers to be configured for an *existing*
+  package. The first `@tokuhirom/mutsu` version was published interactively with 2FA
+  (`npm publish --access public <tarball>`), then its GitHub Actions trusted publisher was
+  configured as user `tokuhirom`, repository `mutsu`, workflow `release.yml`, allowed action
+  `npm publish`. Every later tag publishes without a token.
+- macOS arm64 was `continue-on-error` until the vendored-libffi bump (ADR-0012) fixed its Mach-O
+  CFI build. That `optional` flag is gone, so a macOS regression now fails the release loudly —
+  **do not "fix" macOS by weakening the Linux path.**

--- a/.agents/skills/install-raku/SKILL.md
+++ b/.agents/skills/install-raku/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: install-raku
+description: Install an upstream Rakudo prebuilt binary so that `raku` is available as mutsu's reference oracle. Use when `raku: command not found` in a fresh or ephemeral container blocks comparing mutsu against Rakudo, measuring `.AST` shapes, or running a roast test under raku.
+metadata:
+  short-description: Make `raku` available from a rakudo.org prebuilt
+---
+
+# Install a Rakudo prebuilt binary
+
+mutsu development depends on a working `raku` as an oracle: `raku -e '<code>'` decides
+expected behaviour when the spec is unclear, `raku <roast-test>` shows the expected output
+before mutsu is compared against it, and every RakuAST slice starts by measuring the Rakudo
+`.AST` shape (`docs/rakuast/README.md`). A fresh remote or ephemeral container has no rakudo,
+and Ubuntu's `apt` package is 2022.12 — far too old for RakuAST. Do not work without the
+oracle; install the prebuilt instead.
+
+## Install
+
+```bash
+.agents/skills/install-raku/install-raku.sh
+```
+
+It takes a few seconds and needs no compiler: the rakudo.org archive is a self-contained,
+relocatable tree. The script is idempotent — if a working `raku` is already on `PATH` it
+reports the version and exits 0, so it is safe to run at the start of any session.
+
+What it does:
+
+1. Fetches the JSON release index from `https://rakudo.org/dl/rakudo`.
+2. Selects the newest entry with `type: archive`, `backend: moar`, and this machine's
+   `platform`/`arch`, ordered by `(ver, build_rev)`.
+3. Downloads the tarball and verifies its SHA256 against the published `.checksums.txt`.
+4. Unpacks it to `~/.local/rakudo/<release>/` and symlinks `bin/*` into `~/.local/bin/`.
+5. Runs `raku -e 'say $*RAKU.compiler.version'` to prove the install works, and warns if the
+   bindir is not on `PATH`.
+
+**Do not select on the index's `latest` flag.** It marks the newest *source* release, which is
+routinely published before that release's binary builds exist — on 2026-09-05 `latest: 1` was
+2026.08 (src only) while the newest linux prebuilt was 2026.07. Ordering by `(ver, build_rev)`
+over the filtered archive entries is the correct selection.
+
+## Options
+
+| Flag | Effect |
+| --- | --- |
+| `--prefix DIR` | Unpack location (default `~/.local/rakudo`, or `$RAKUDO_PREFIX`) |
+| `--bindir DIR` | Symlink location (default `~/.local/bin`, or `$RAKUDO_BINDIR`) |
+| `--version VER` | Pin a release, e.g. `--version 2026.07` |
+| `--force` | Reinstall even when `raku` is already on `PATH` |
+| `--no-verify` | Skip the SHA256 check |
+| `--print-url` | Print the selected tarball URL and exit (useful for a dry run) |
+
+## Platform limits
+
+Prebuilts exist for `linux/x86_64`, `macos/x86_64`, `macos/arm64` and `win/x86_64` only.
+There is **no `linux/arm64` prebuilt**; the script fails there with a clear message. On such a
+host either build from source with [rakubrew](https://rakubrew.org/) (slow, needs a toolchain)
+or run the oracle inside the official `rakudo/rakudo` container image.
+
+## Confirm the oracle works
+
+```bash
+raku --version
+raku -e 'say (1..5).map(* ** 2)'          # behaviour oracle
+raku -e 'say Q|say 42|.AST'               # RakuAST shape oracle
+raku roast/S02-literals/numeric.t | head  # expected roast output
+```
+
+`--target=ast` dumps QAST, not RakuAST — use `Q|...|.AST` for the node shapes that RakuAST
+slices are measured against.
+
+## Scope
+
+- The archive ships `raku`, `rakudo`, `nqp`, `moar` and the `perl6` aliases. It does **not**
+  ship `zef`; mutsu vendors its own copy under `vendor/zef/`, so nothing here needs it.
+- This installs a reference implementation for comparison only. It is not part of mutsu's
+  build or test pipeline, and nothing under `~/.local/rakudo` belongs in the repository.

--- a/.agents/skills/install-raku/install-raku.sh
+++ b/.agents/skills/install-raku/install-raku.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+# Install an upstream Rakudo prebuilt binary so that `raku` is available as an
+# oracle for mutsu development. No compilation: the archive from rakudo.org is a
+# self-contained, relocatable tree.
+#
+# Usage: install-raku.sh [--prefix DIR] [--bindir DIR] [--version VER]
+#                        [--force] [--no-verify] [--print-url] [--help]
+set -euo pipefail
+
+INDEX_URL="https://rakudo.org/dl/rakudo"
+PREFIX="${RAKUDO_PREFIX:-$HOME/.local/rakudo}"
+BINDIR="${RAKUDO_BINDIR:-$HOME/.local/bin}"
+WANT_VERSION=""
+FORCE=0
+VERIFY=1
+PRINT_URL_ONLY=0
+
+die() { printf 'install-raku: %s\n' "$*" >&2; exit 1; }
+info() { printf 'install-raku: %s\n' "$*" >&2; }
+
+usage() {
+  # Reprint the leading comment block (everything after the shebang).
+  awk 'NR > 1 { if (!/^#/) exit; sub(/^# ?/, ""); print }' "$0"
+  cat <<'EOF'
+
+Options:
+  --prefix DIR    where the rakudo tree is unpacked (default ~/.local/rakudo,
+                  or $RAKUDO_PREFIX)
+  --bindir DIR    where `raku`/`rakudo` symlinks are created (default
+                  ~/.local/bin, or $RAKUDO_BINDIR)
+  --version VER   install this release (e.g. 2026.07) instead of the newest
+  --force         reinstall even if a working `raku` is already on PATH
+  --no-verify     skip the SHA256 checksum check
+  --print-url     print the selected tarball URL and exit
+EOF
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --prefix) PREFIX="${2:?--prefix needs a directory}"; shift 2 ;;
+    --bindir) BINDIR="${2:?--bindir needs a directory}"; shift 2 ;;
+    --version) WANT_VERSION="${2:?--version needs a release}"; shift 2 ;;
+    --force) FORCE=1; shift ;;
+    --no-verify) VERIFY=0; shift ;;
+    --print-url) PRINT_URL_ONLY=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) die "unknown option: $1 (try --help)" ;;
+  esac
+done
+
+# ---------------------------------------------------------------- preflight --
+if [ "$FORCE" -eq 0 ] && [ "$PRINT_URL_ONLY" -eq 0 ] && command -v raku >/dev/null 2>&1; then
+  info "raku is already on PATH: $(command -v raku)"
+  raku --version >&2 || die "the existing raku is broken; rerun with --force"
+  exit 0
+fi
+
+command -v curl >/dev/null 2>&1 || die "curl is required"
+command -v tar  >/dev/null 2>&1 || die "tar is required"
+
+case "$(uname -s)" in
+  Linux)  OS=linux ;;
+  Darwin) OS=macos ;;
+  *) die "unsupported OS: $(uname -s). Prebuilts exist for linux, macos and win only." ;;
+esac
+case "$(uname -m)" in
+  x86_64|amd64)  ARCH=x86_64 ;;
+  arm64|aarch64) ARCH=arm64 ;;
+  *) die "unsupported CPU: $(uname -m)" ;;
+esac
+
+if [ "$OS" = linux ] && [ "$ARCH" = arm64 ]; then
+  die "rakudo.org publishes no linux/arm64 prebuilt. Build from source with
+  rakubrew (https://rakubrew.org/), or run the oracle in the official
+  rakudo/rakudo container image instead."
+fi
+
+# ------------------------------------------------------- pick the newest URL --
+# The index is a JSON array of release entries. Choose the newest one that is a
+# moar-backend *archive* for this OS/arch, sorting by (ver, build_rev). The
+# `latest` flag is not usable here: it marks the newest source release, which is
+# often published before the binary builds for a given platform exist.
+select_url() {
+  local index="$1"
+  if command -v python3 >/dev/null 2>&1; then
+    OS="$OS" ARCH="$ARCH" WANT_VERSION="$WANT_VERSION" python3 - "$index" <<'PY'
+import json, os, sys
+os_, arch = os.environ["OS"], os.environ["ARCH"]
+want = os.environ.get("WANT_VERSION") or None
+with open(sys.argv[1]) as fh:
+    entries = json.load(fh)
+cands = [
+    e for e in entries
+    if e.get("name") == "rakudo" and e.get("type") == "archive"
+    and e.get("backend") == "moar" and e.get("platform") == os_
+    and e.get("arch") == arch and (want is None or e.get("ver") == want)
+]
+if not cands:
+    sys.exit(1)
+best = max(cands, key=lambda e: (e.get("ver", ""), e.get("build_rev", 0)))
+print(best["url"])
+PY
+  elif command -v jq >/dev/null 2>&1; then
+    jq -r --arg os "$OS" --arg arch "$ARCH" --arg want "$WANT_VERSION" '
+      [ .[] | select(.name == "rakudo" and .type == "archive" and .backend == "moar"
+                     and .platform == $os and .arch == $arch)
+            | select($want == "" or .ver == $want) ]
+      | sort_by(.ver, (.build_rev // 0)) | last | .url // empty
+    ' "$index"
+  else
+    die "either python3 or jq is required to read the rakudo release index"
+  fi
+}
+
+TMPDIR_INSTALL="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_INSTALL"' EXIT
+
+info "fetching release index from $INDEX_URL"
+curl -fsSL -o "$TMPDIR_INSTALL/index.json" "$INDEX_URL" \
+  || die "could not fetch $INDEX_URL"
+
+URL="$(select_url "$TMPDIR_INSTALL/index.json" || true)"
+[ -n "$URL" ] || die "no ${OS}/${ARCH} moar prebuilt${WANT_VERSION:+ for $WANT_VERSION} in the index"
+
+if [ "$PRINT_URL_ONLY" -eq 1 ]; then
+  printf '%s\n' "$URL"
+  exit 0
+fi
+
+TARBALL="${URL##*/}"
+# rakudo-moar-2026.07-01-linux-x86_64-gcc.tar.gz -> rakudo-moar-2026.07-01-linux-x86_64-gcc
+RELEASE="${TARBALL%.tar.gz}"
+
+# ------------------------------------------------------ download and verify --
+info "downloading $TARBALL"
+curl -fSL --progress-bar -o "$TMPDIR_INSTALL/$TARBALL" "$URL" \
+  || die "download failed: $URL"
+
+if [ "$VERIFY" -eq 1 ]; then
+  if command -v sha256sum >/dev/null 2>&1; then
+    GOT="$(sha256sum "$TMPDIR_INSTALL/$TARBALL" | cut -d' ' -f1)"
+  elif command -v shasum >/dev/null 2>&1; then
+    GOT="$(shasum -a 256 "$TMPDIR_INSTALL/$TARBALL" | cut -d' ' -f1)"
+  else
+    GOT=""
+    info "no sha256sum/shasum available; skipping checksum verification"
+  fi
+  if [ -n "$GOT" ]; then
+    # The .checksums.txt is a clear-signed file with one "SHA256 (file) = hex" line.
+    if curl -fsSL -o "$TMPDIR_INSTALL/checksums.txt" "$URL.checksums.txt"; then
+      WANT_SUM="$(grep -o "SHA256 ($TARBALL) = [0-9a-f]*" "$TMPDIR_INSTALL/checksums.txt" \
+                  | head -n1 | awk '{print $NF}')"
+      [ -n "$WANT_SUM" ] || die "no SHA256 line for $TARBALL in the checksum file"
+      [ "$WANT_SUM" = "$GOT" ] \
+        || die "checksum mismatch for $TARBALL: expected $WANT_SUM, got $GOT"
+      info "sha256 verified"
+    else
+      die "could not fetch $URL.checksums.txt (rerun with --no-verify to skip)"
+    fi
+  fi
+fi
+
+# ------------------------------------------------------------------ install --
+DEST="$PREFIX/$RELEASE"
+mkdir -p "$DEST"
+info "unpacking into $DEST"
+tar -xzf "$TMPDIR_INSTALL/$TARBALL" -C "$DEST" --strip-components=1
+
+[ -x "$DEST/bin/raku" ] || die "the archive contains no bin/raku (layout changed?)"
+
+mkdir -p "$BINDIR"
+for exe in "$DEST"/bin/*; do
+  [ -f "$exe" ] && [ -x "$exe" ] || continue
+  ln -sf "$exe" "$BINDIR/$(basename "$exe")"
+done
+info "symlinked $(basename "$DEST")/bin/* into $BINDIR"
+
+# ------------------------------------------------------------------- verify --
+"$DEST/bin/raku" -e 'say "raku ok: ", $*RAKU.compiler.version' \
+  || die "the installed raku does not run"
+
+if ! command -v raku >/dev/null 2>&1; then
+  cat >&2 <<EOF
+
+install-raku: $BINDIR is not on PATH. Add it, e.g.:
+  export PATH="$BINDIR:\$PATH"
+EOF
+fi

--- a/.agents/skills/reclaim-disk/SKILL.md
+++ b/.agents/skills/reclaim-disk/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: reclaim-disk
+description: Reclaim disk on a mutsu development box by removing stale agent worktrees and cargo build caches, and optionally set up mold + sccache for faster shared builds. Use when disk is filling up, a build fails with "no space left on device", or worktrees from parallel agents have accumulated.
+metadata:
+  short-description: Free disk from worktrees and cargo caches
+---
+
+# Reclaiming disk
+
+Two things dominate disk use on a mutsu box: agent worktrees under `.claude/worktrees/`, and
+cargo build caches under `target/`. Both are disposable — deleting them costs at most a
+one-time rebuild.
+
+## Worktree cleanup
+
+`isolation: "worktree"` agents leave stale trees under `.claude/worktrees/` that can consume
+hundreds of GB. **Clean them up at least once per hour** during long sessions, and between
+batches of the parallel-agent pipeline.
+
+First check which agents are still running (`ListAgents`) and exclude their worktrees. Then:
+
+```bash
+cd .claude/worktrees/
+for d in agent-*; do
+  git -C <repo-root> worktree remove --force ".claude/worktrees/$d" 2>/dev/null
+done
+git worktree prune
+```
+
+Verify with `du -sh .claude/worktrees/`.
+
+## Build cache cleanup
+
+`target/` grows without bound and is usually the top consumer — a single checkout can reach
+100 GB+, and several checkouts on one machine easily pass 300 GB. **The dominant offender is
+`target/debug/incremental/`**: every branch switch and profile change spawns a new incremental
+session, and cargo does not GC old ones aggressively, so it balloons to tens of GB per checkout.
+
+Neither pass below touches source or the built binaries in `target/*/deps` — only regenerable
+caches. **First check nothing is building (`pgrep -a cargo rustc`)**, then:
+
+```bash
+# 1. Time-based sweep: remove artifacts not touched in 14 days (cargo-sweep).
+#    cargo install cargo-sweep   # once
+cargo sweep --time 14                 # add --dry-run first to preview
+
+# 2. Nuke incremental caches (the big win). Regenerated on next build.
+rm -rf target/*/incremental
+```
+
+Run both in *each* checkout on a multi-checkout machine. One such cleanup took the root FS from
+84% to 58% (~230 GB freed), ~199 GB of it from `target/debug/incremental`. Consider doing this
+monthly, or set `CARGO_INCREMENTAL=0` for checkouts you build in only occasionally so they never
+accumulate incremental sessions.
+
+## Optional: faster, shared local builds (mold + sccache)
+
+Not required, but recommended when you keep several checkouts on one machine — their build
+caches are otherwise unshared. Configure once in `~/.cargo/config.toml`:
+
+```toml
+[build]
+rustc-wrapper = "sccache"   # shares compiled dependencies across all checkouts
+
+[target.x86_64-unknown-linux-gnu]
+rustflags = ["-C", "link-arg=-fuse-ld=mold"]   # much faster linking
+```
+
+Requires `mold` (apt) and `sccache` (`cargo install sccache`; bump its cache with a
+`~/.config/sccache/config` `[cache.disk] size` line). sccache passes the *incremental* dev build
+of the local crate straight through — so edit→build stays incremental-fast — while caching the
+non-incremental dependency and release builds, which is exactly what is shared across checkouts.
+CI links with mold and caches dependencies via `Swatinem/rust-cache`; the release profile is
+`debug = false` (build `--profile profiling` when you need `perf` symbols).

--- a/.agents/skills/roast-triage/SKILL.md
+++ b/.agents/skills/roast-triage/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: roast-triage
+description: Choose which roast work to do next and investigate one failing roast test — PLAN.md/BLOCKERS.md-driven task selection, the raku-vs-mutsu comparison order, and the roast-history.sh diagnostic categories. Use when picking the next roast target or debugging a specific failing roast/*.t file.
+metadata:
+  short-description: Pick and investigate roast work
+---
+
+# Roast triage
+
+Two separate questions, in this order: *which* roast work to do, and *why* one specific file
+fails.
+
+## Choosing what to work on
+
+**Primary: PLAN.md → BLOCKERS.md → then individual tests.** The project is in its final
+stretch; work is driven by strategic priorities, not random test selection.
+
+1. **PLAN.md priorities first.** Check the current quarter's section for high-impact tasks
+   (exception types, performance, module compatibility, ...). They are chosen because they
+   unblock many tests or advance project goals.
+2. **`TODO_roast/BLOCKERS.md` for roast work.** It is the single ledger of all non-whitelisted
+   roast tests, tracked per file and by root cause, with a raku-baseline column, and it groups
+   failing tests by the missing feature. Implement the features that unblock the most tests
+   (e.g. "Exception Types" blocks 22 tests, "Threading" blocks 31).
+3. **Then individual tests**, for features already in progress.
+
+**Do NOT cherry-pick easy tests to game the pass count.** The goal is implementing missing
+features with broad impact — and do not skip a task because it looks hard (see "Working on
+complex features" in `CLAUDE.md`: a test needing several unrelated features gets them all, in
+one PR if that is what it takes).
+
+When you defer a test, record *why* in its `TODO_roast/BLOCKERS.md` row (or the "Investigation
+notes" section for longer findings). When a test reaches the whitelist, remove its row — the
+details move to `news/`.
+
+### Diagnostic tools (status tracking, not task selection)
+
+`./scripts/roast-history.sh` generates per-file category lists under `tmp/`:
+
+| File | Meaning |
+| --- | --- |
+| `tmp/roast-panic.txt` | Rust panics — highest priority to fix |
+| `tmp/roast-timeout.txt` | timeouts |
+| `tmp/roast-error.txt` | no valid TAP plan |
+| `tmp/roast-fail.txt` | some subtests failing |
+| `tmp/roast-pass.txt` | fully passing |
+
+Re-run it after a change to find newly passing tests.
+
+## Investigating one failing test
+
+Before writing any code, always investigate in this order:
+
+1. **Run it with `raku`** to see the expected output: `raku <roast-test-path>`.
+   (No `raku` on this machine? Use the `install-raku` skill — do not work without the oracle.)
+2. **Dump the AST with `raku`** if needed: `raku --target=ast -e '<relevant code>'`.
+3. **Dump the AST with mutsu**: `timeout 30 target/debug/mutsu --dump-ast <roast-test-path>`.
+4. **Run it with mutsu**: `timeout 30 target/debug/mutsu <roast-test-path>`.
+5. Compare the outputs to identify what mutsu is doing wrong, then fix the interpreter.
+
+Run a single roast test with fudge preprocessing enabled — **`MUTSU_FUDGE=1` is required**, or
+`#?rakudo skip/todo` directives are ignored and the counts come out wrong:
+
+```bash
+cargo build && MUTSU_FUDGE=1 prove -e 'target/debug/mutsu' roast/<path>.t
+```
+
+Never set `MUTSU_FUDGE` when running ordinary (non-roast) scripts — a stray `#?rakudo skip`
+comment would drop the next statement.
+
+## Rules that constrain any fix
+
+- `roast/` is **read-only** — a vendored upstream copy pinned in `vendor.lock`, updated only via
+  `scripts/update-vendor.sh`. Roast is the authoritative spec: if passing a roast test requires
+  changing a local `t/` test, change the `t/` test.
+- **Never add special-case logic, hardcoded results, or test-specific hacks** to pass a test.
+  Every fix must be a genuine, general-purpose improvement.
+- Do not add a test to `roast-whitelist.txt` unless `prove -e 'target/debug/mutsu' <file>` exits
+  cleanly, and keep the file sorted (`LC_ALL=C sort -c roast-whitelist.txt`) — CI fails if it is
+  not.
+- **Never remove a previously passing test from the whitelist** because of a regression; fix the
+  regression. When `make roast` shows failures in whitelisted tests, investigate each one — do
+  not dismiss them as "pre-existing" (check "Known flaky tests" in `CLAUDE.md` first, and follow
+  its triage protocol before trusting any "flaky" label).

--- a/.agents/skills/test-util-workout/SKILL.md
+++ b/.agents/skills/test-util-workout/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: test-util-workout
+description: Pick one Test::Util function from roast's Test-Helpers package, write a t/ test for it, and fix the interpreter until it passes, ending in a merged PR. Use when asked for a "Test::Util workout" or to work through the Test::Util helper functions.
+metadata:
+  short-description: Land one Test::Util helper end-to-end
+---
+
+# Test::Util function workout
+
+`Test::Util` is **not** part of the Raku core. Its functions (`is_run`, `doesn't-hang`,
+`make-temp-dir`, `make-temp-file`, ...) are defined in
+`roast/packages/Test-Helpers/lib/Test/Util.rakumod`, and a roast test only sees them after it
+`use`s the module. Never implement one as a core builtin — always read that source first to
+learn the expected behaviour.
+
+## Workflow
+
+1. Read `roast/packages/Test-Helpers/lib/Test/Util.rakumod` for the list of exported functions.
+2. Check `t/` for the existing coverage (`test-util-*.t`, `is-run.t`, ...) to see which
+   functions already have tests.
+3. Pick **one** unimplemented or undertested function. Once chosen, do **not** switch to a
+   different one mid-task.
+4. Write `t/<function-name>.t` exercising it with several cases: basic usage, edge cases, and
+   combined checks.
+5. Run it: `timeout 30 target/debug/mutsu t/<function-name>.t`.
+6. Fix the interpreter until it passes. When the spec is unclear, check with `raku -e '<code>'`
+   (the `install-raku` skill gets `raku` if the container has none) and consult `raku-doc/`.
+7. Run `make test` and `make roast` to check for regressions, then read the results out of
+   `tmp/make-test.log` / `tmp/make-roast.log` rather than re-running.
+8. Branch off `main`, commit, push, and open a PR per the repository's PR workflow in
+   `CLAUDE.md`.
+9. Enable auto-merge: `gh pr merge --auto --merge <pr-number>` — `--squash` is rejected by this
+   repository.
+
+## Rules
+
+- The implementation lives in `src/runtime/test_functions.rs`, **not** as a builtin in
+  `builtins/`.
+- If making the function work needs a new language feature (e.g. `exit_code` support),
+  implement the feature properly. No stubs, hardcoded outputs, or early returns.
+- Always read the `.rakumod` source before implementing — the helper's real behaviour, not an
+  assumed one, is what the roast tests depend on.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,13 @@ For a request to implement a file in `todo/tickets/`, use the
 `mutsu-ticket-flow` skill. It defines the required lifecycle through a verified
 merge and selection of the next ticket.
 
+Self-contained procedures live under `.agents/skills/<name>/SKILL.md` rather
+than in this file; read the matching one before starting such a task. Currently:
+`cut-release` (releasing), `install-raku` (installing the Rakudo oracle when
+`raku` is missing), `roast-triage` (choosing and investigating roast work),
+`test-util-workout`, `reclaim-disk` (stale worktrees and cargo caches),
+`mutsu-ticket-flow`, and `rakuast-implementation`.
+
 ## Architecture
 
 The execution pipeline is Parser -> Compiler -> VM. Implement language features

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,22 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 This repo is a Rust implementation of a minimal Raku (Perl 6) compatible interpreter called **mutsu**.
 
+## Skills (`.agents/skills/`)
+
+This file holds the rules that apply to *every* session. Self-contained **procedures** live as
+skills instead, so they are read only when the task calls for them. Read the relevant `SKILL.md`
+before starting one of these tasks:
+
+| Skill | Read it when |
+| --- | --- |
+| [`cut-release`](.agents/skills/cut-release/SKILL.md) | Releasing: picking the version, firing `tag-release.yml`, verifying tarballs/npm/Release |
+| [`install-raku`](.agents/skills/install-raku/SKILL.md) | `raku` is missing and the Rakudo oracle needs installing |
+| [`roast-triage`](.agents/skills/roast-triage/SKILL.md) | Choosing the next roast target, or investigating one failing `roast/*.t` |
+| [`test-util-workout`](.agents/skills/test-util-workout/SKILL.md) | A "Test::Util workout" request |
+| [`reclaim-disk`](.agents/skills/reclaim-disk/SKILL.md) | Disk is filling up: stale agent worktrees, `target/` caches |
+| [`mutsu-ticket-flow`](.agents/skills/mutsu-ticket-flow/SKILL.md) | Working `todo/tickets/` items end-to-end through merge |
+| [`rakuast-implementation`](.agents/skills/rakuast-implementation/SKILL.md) | A RakuAST compatibility slice (`src/rakuast/`, `t/rakuast*.t`) |
+
 ## Build & run
 
 - Build: `cargo build`
@@ -135,19 +151,9 @@ Executes compiled bytecode. `vm.rs` holds the (unified `Interpreter`) struct, `r
 
 ## Cutting a release
 
-Releases are cut by **one manual trigger** — the `tag-release.yml` workflow (`.github/workflows/tag-release.yml`). tagpr was removed (2026-07-25); there is no release PR, no `CHANGELOG.md`, and no `minor`/`major` version-bump label to apply on ordinary PRs. To release:
+Releases are cut by **one manual trigger** — `gh workflow run tag-release.yml -f version=X.Y.Z` (no `v` prefix). tagpr was removed (2026-07-25): there is no release PR, no `CHANGELOG.md`, and no version-bump label on ordinary PRs. **Keep the `type:` / `type(scope):` PR title convention** — it drives the auto-applied category label and hence the release-note section.
 
-```
-gh workflow run tag-release.yml -f version=0.18.0
-```
-
-(or the Actions tab → "Tag release" → Run workflow → enter the version, no `v` prefix). That one run: bumps `Cargo.toml` + the `mutsu` `Cargo.lock` entry to the given version, commits it straight to `main` (via a GitHub App token that is a bypass actor on the `main` ruleset), and pushes the `vX.Y.Z` tag. The tag push fires `release.yml`, which builds all four target tarballs (Linux x64/arm64, macOS x64/arm64), runs the batteries gate, publishes the browser/WASM package to npm through OIDC trusted publishing, and publishes the GitHub Release with **auto-generated notes** (`generate_release_notes: true`, from the merged PRs since the previous tag). npm automatically records provenance for the OIDC publish; do not add a long-lived npm token.
-
-- **Pick the version by hand** using semver judgment over what merged since the last tag: patch for fixes/roast/docs, minor for a new user-visible feature, major for a breaking change. There is no label-driven *version* automation anymore.
-- The release notes are **grouped into sections** (Features / Bug Fixes / Performance / Documentation / Dependencies / Maintenance / Other) by `.github/release.yml`. PRs are sorted by label, and `.github/workflows/label-pr.yml` auto-applies the category label (`feat`/`fix`/`perf`/`docs`/`maintenance`, or `dependencies` for `*(deps):`) from each PR's conventional-commit title prefix — so **keep the `type:` / `type(scope):` title convention**; it is what drives both the label and the release-note section. Dependabot labels its own PRs `dependencies`.
-- `mutsu --version` reports `env!("CARGO_PKG_VERSION")`, so the `Cargo.toml` version the workflow writes is the shipped version — keep them coherent (the workflow does this for you).
-- **Prerequisite (infra, one-time):** the release GitHub App must remain a bypass actor on the `main` branch ruleset, or the workflow's push to `main` is rejected by `required_status_checks`.
-- **npm bootstrap (one-time):** npm only allows trusted publishers to be configured for an existing package. Publish the first `@tokuhirom/mutsu` version interactively with 2FA (`npm publish --access public <tarball>`), then configure its GitHub Actions trusted publisher as user `tokuhirom`, repository `mutsu`, workflow `release.yml`, allowed action `npm publish`. Every later tag publishes without a token.
+Full procedure — version choice, what the two workflows do, how to verify the tarballs/npm/Release actually landed, and the one-time infra prerequisites — is in **`.agents/skills/cut-release/SKILL.md`**. Read it before releasing.
 
 ## mzef package manager and distribution
 
@@ -280,22 +286,7 @@ Per-type method documentation — consult when implementing methods on specific 
 
 ## Roast test prioritization
 
-**Primary: PLAN.md → BLOCKERS.md → then individual tests.**
-
-The project is in its final stretch. Work should be driven by strategic priorities, not random test selection:
-
-1. **PLAN.md priorities first.** Check the current quarter's section for high-impact tasks (e.g., exception types, performance, module compatibility). These are chosen because they unblock many tests or advance project goals.
-2. **BLOCKERS.md for roast work.** When working on roast, consult `TODO_roast/BLOCKERS.md` which groups failing tests by the missing feature. Implement features that unblock the most tests (e.g., "Exception Types" blocks 22 tests, "Threading" blocks 31).
-3. **Roast diagnostic tools** (for status tracking, not task selection):
-   - Run `./scripts/roast-history.sh` to generate per-file category lists under `tmp/`:
-     - `tmp/roast-panic.txt` — Rust panics (highest priority to fix)
-     - `tmp/roast-timeout.txt` — timeouts
-     - `tmp/roast-error.txt` — no valid TAP plan
-     - `tmp/roast-fail.txt` — some subtests failing
-     - `tmp/roast-pass.txt` — fully passing
-   - After making changes, run `roast-history.sh` to check for newly passing tests.
-
-- Do NOT cherry-pick easy tests to game the pass count. The goal is implementing missing features that have broad impact. (See "Working on complex features" — don't skip a task because it looks hard.)
+**Primary: PLAN.md → BLOCKERS.md → then individual tests.** Work is driven by strategic priorities, not random test selection, and **not** by cherry-picking easy tests to game the pass count. The task-selection procedure, the `scripts/roast-history.sh` diagnostic categories, and the order in which to investigate one failing test are in **`.agents/skills/roast-triage/SKILL.md`**.
 
 ## Trust the main branch
 
@@ -380,6 +371,9 @@ Running the entire roast suite locally is wasteful and slow — **let CI run the
 - Run individual roast tests with `MUTSU_FUDGE=1 prove -e 'target/debug/mutsu' roast/<path>.t` (the `MUTSU_FUDGE=1` is required — see the build/run section above), or the exact files you touched / suspect regressed.
 - CI does not invoke `make test`; its `test` job runs the steps individually and runs the **TAP suite (`prove t/`) on the `debug` binary** (`MUTSU_BIN=target/debug/mutsu`), reserving the **release build** (`cargo build --release`, `MUTSU_BIN=target/release/mutsu`) for **`make roast`**. Local `make test` matches this — it runs `t/` on debug too (see `docs/adr/0014-make-test-runs-tap-on-debug-binary.md`); only roast uses release. Debug builds are much slower at runtime, so a local *roast* timeout on a heavy test does not necessarily indicate a real failure — confirm with a release build (`target/release/mutsu`) before assuming a regression, and otherwise trust CI's verdict.
 - Push the branch and rely on CI for the comprehensive roast result rather than running the whole suite locally.
+- To pick roast work, or to investigate why one file fails, read `.agents/skills/roast-triage/SKILL.md`.
+
+## Build profiles and benchmark numbers
 
 ### Use the DEBUG build to iterate on `MUTSU_VM_STATS` counters — release is for wall-clock only
 
@@ -413,81 +407,9 @@ timeout 30 target/debug/mutsu -e '<code>'
 timeout 30 target/debug/mutsu --dump-ast <file>
 ```
 
-## Investigating a failing roast test
+## Disk cleanup (worktrees and build caches)
 
-Before writing any code, always investigate the test in this order:
-
-1. **Run with `raku`** to see the expected output: `raku <roast-test-path>`
-2. **Dump AST with `raku`** (if needed): `raku --target=ast -e '<relevant code>'`
-3. **Dump AST with `mutsu`**: `timeout 30 target/debug/mutsu --dump-ast <roast-test-path>`
-4. **Run with `mutsu`**: `timeout 30 target/debug/mutsu <roast-test-path>`
-5. Compare outputs to identify what mutsu is doing wrong, then fix the interpreter.
-
-## Worktree cleanup
-
-When using `isolation: "worktree"` agents, stale worktrees accumulate under `.claude/worktrees/` and can consume hundreds of GB. **Clean up worktrees at least once per hour** during long sessions:
-
-```bash
-# Remove all agent worktrees except currently active ones
-cd .claude/worktrees/
-for d in agent-*; do
-  git -C <repo-root> worktree remove --force ".claude/worktrees/$d" 2>/dev/null
-done
-git worktree prune
-```
-
-Before cleanup, check which agents are still running and exclude their worktrees. After cleanup, verify disk usage with `du -sh .claude/worktrees/`.
-
-## Build cache cleanup (reclaiming disk)
-
-`target/` grows without bound and is usually the top disk consumer — a single
-checkout can reach 100 GB+, and with several checkouts on one machine it easily
-passes 300 GB. **The dominant offender is `target/debug/incremental/`**: every
-branch switch and profile change spawns a new incremental session and cargo does
-not GC old ones aggressively, so it balloons to tens of GB per checkout. These
-caches are disposable — deleting them only costs a one-time non-incremental
-rebuild (cheap when dependencies are already cached).
-
-Reclaim disk in two passes (safe: neither touches source or built binaries in
-`target/*/deps`, only regenerable caches). **First check nothing is building
-(`pgrep -a cargo rustc`)**, then:
-
-```bash
-# 1. Time-based sweep: remove artifacts not touched in 14 days (cargo-sweep).
-#    cargo install cargo-sweep   # once
-cargo sweep --time 14                 # add --dry-run first to preview
-
-# 2. Nuke incremental caches (the big win). Regenerated on next build.
-rm -rf target/*/incremental
-```
-
-On a machine with multiple checkouts, run both in each. In one cleanup this took
-the root FS from 84% to 58% (~230 GB freed), ~199 GB of it from
-`target/debug/incremental`. Consider doing this monthly, or set
-`CARGO_INCREMENTAL=0` for checkouts you only build in occasionally so they never
-accumulate incremental sessions.
-
-### Optional: faster, shared local builds (mold + sccache)
-
-Not required, but recommended when you keep several checkouts on one machine
-(their build caches are otherwise unshared). Configure once in
-`~/.cargo/config.toml`:
-
-```toml
-[build]
-rustc-wrapper = "sccache"   # shares compiled dependencies across all checkouts
-
-[target.x86_64-unknown-linux-gnu]
-rustflags = ["-C", "link-arg=-fuse-ld=mold"]   # much faster linking
-```
-
-Requires `mold` (apt) and `sccache` (`cargo install sccache`; bump its cache
-with a `~/.config/sccache/config` `[cache.disk] size` line). sccache passes the
-*incremental* dev build of the local crate straight through (so edit->build
-stays incremental-fast) while caching the non-incremental dependency and release
-builds — which is exactly what is shared across checkouts. CI links with mold and
-caches dependencies via `Swatinem/rust-cache`; the release profile is
-`debug = false` (build `--profile profiling` when you need `perf` symbols).
+Agent worktrees under `.claude/worktrees/` and cargo caches under `target/` are the two disk hogs; both are disposable. **Clean up worktrees at least once per hour** during long sessions and between agent batches. The commands — worktree removal, `cargo sweep`, nuking `target/*/incremental` (the dominant offender), and the optional mold + sccache setup — are in **`.agents/skills/reclaim-disk/SKILL.md`**.
 
 ## LXC container environment
 
@@ -495,22 +417,7 @@ This development environment runs inside a dedicated mutsu LXC container. The co
 
 ## Test::Util function workout
 
-When the user says **"Test::Util workout"** (or similar), execute this workflow:
-
-1. Check `roast/packages/Test-Helpers/lib/Test/Util.rakumod` for the list of exported functions.
-2. Check `t/` for existing `test-util-*.t` and `is-run.t` etc. to see which functions already have tests.
-3. Pick **one** unimplemented or undertested function. Once chosen, do NOT switch to a different one.
-4. Write a test file `t/<function-name>.t` exercising the function with multiple cases (basic usage, edge cases, combined checks).
-5. Run the test with `timeout 30 target/debug/mutsu t/<function-name>.t` to see what fails.
-6. Fix the interpreter to make the test pass. When the spec is unclear, check behavior with `raku -e '<code>'` and consult `raku-doc/`.
-7. Run `make test` and `make roast` to ensure no regressions.
-8. Create a feature branch, commit, push, and open a PR (follow PR workflow above).
-9. Enable auto-merge: `gh pr merge --auto --merge <pr-number>` (see the PR workflow above — `--squash` is rejected by this repository).
-
-Key rules:
-- The function implementation lives in `src/runtime/test_functions.rs` (not as a builtin).
-- If fixing the function requires adding a new language feature (e.g., `exit_code` support), implement it properly — no stubs or hacks.
-- Test::Util functions are defined in `roast/packages/Test-Helpers/lib/Test/Util.rakumod`. Always read the source to understand the expected behavior before implementing.
+When the user says **"Test::Util workout"** (or similar), follow **`.agents/skills/test-util-workout/SKILL.md`**: pick one function from `roast/packages/Test-Helpers/lib/Test/Util.rakumod`, write `t/<function-name>.t`, fix the interpreter (in `src/runtime/test_functions.rs`, never as a core builtin) until it passes, and land it as a PR.
 
 ## Debugging guidelines
 
@@ -605,7 +512,7 @@ Each slang has its own grammar rules (e.g., `+` means repetition in Regex slang 
 ## Agent workflow
 
 - **Sub-agents are allowed (policy updated 2026-06-15).** Use them where they help — read-only fan-out searches (Explore), independent non-conflicting implementation slices, or sweeping across many files where you only need the conclusion. Be deliberate, not reflexive: Rust builds are expensive and each parallel worktree agent multiplies `cargo build`/`clippy`/`make test` cost and accumulates large `target/` worktrees, so reach for a sub-agent when the task genuinely fans out, not for trivial single-file work you can do inline. Read-only Explore/research agents are cheap; worktree-isolated build agents are not.
-- **Keep at most 3 concurrent agents that build** (user decision, 2026-08-22, tightening the previous cap of 4). This caps agents actually *doing work*, not agents idling on a CI run: an agent whose PR is open and waiting on GitHub Actions uses no local CPU, so it is fine to launch a fresh agent past the nominal cap while others are purely CI-pending (user-confirmed 2026-08-20). **Even so, never exceed 10 agents in total (working + CI-idle combined)** (user-confirmed 2026-08-20) — check `ListAgents` before launching a new one when the count is already high. Read-only Explore/research agents do not count against the build cap. Clean up worktrees per the "Worktree cleanup" section.
+- **Keep at most 3 concurrent agents that build** (user decision, 2026-08-22, tightening the previous cap of 4). This caps agents actually *doing work*, not agents idling on a CI run: an agent whose PR is open and waiting on GitHub Actions uses no local CPU, so it is fine to launch a fresh agent past the nominal cap while others are purely CI-pending (user-confirmed 2026-08-20). **Even so, never exceed 10 agents in total (working + CI-idle combined)** (user-confirmed 2026-08-20) — check `ListAgents` before launching a new one when the count is already high. Read-only Explore/research agents do not count against the build cap. Clean up worktrees per the "Disk cleanup" section.
   - **Why 3 and not more:** on this 12-core box, five worktree agents drove the load average to 70 with 17 concurrent `rustc` processes, and builds stopped completing. That does not merely slow the batch down — it makes agents *unable to verify their own work*: the `residual-try-cell-eager-seq-reification-divergences` agent had to revert a measured prototype and downgrade to a `Proposed` ADR because its from-scratch `cargo build` never finished under load. Over-parallelising costs correctness, not just wall-clock. When in doubt, check `uptime` and `pgrep -c -x rustc` before launching (a two-digit `rustc` count on 12 cores is already oversubscribed).
 - **Task selection order:**
   1. PLAN.md current quarter priorities

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -174,15 +174,16 @@ gh workflow run tag-release.yml -f version=0.18.0
 
 - `raku` is available on this system. Use `raku -e '<code>'` to check expected behavior when the spec is unclear.
 - **If `raku` is missing** (a fresh remote/ephemeral container often has no
-  rakudo, and Ubuntu's `apt` package is 2022.12 — far too old for RakuAST),
-  install an upstream prebuilt instead of doing without an oracle. `curl -sS
-  https://rakudo.org/dl/rakudo` returns a JSON index; pick the newest entry with
-  `backend: moar`, `type: archive`, `platform: linux` and your arch, untar it,
-  and symlink its `bin/raku` onto `PATH`. It is a self-contained tree, needs no
-  build, and takes about a minute. Without it, any work that has to *measure*
-  rakudo's behavior (RakuAST node shapes above all) is blocked — see
-  `docs/rakuast/README.md`, whose whole slice checklist starts with "measure the
-  Rakudo `.AST` shape".
+  rakudo, and Ubuntu's `apt` package is 2022.12 — far too old for RakuAST), run
+  `.agents/skills/install-raku/install-raku.sh` (the `install-raku` skill)
+  instead of doing without an oracle. It picks the newest `backend: moar`,
+  `type: archive` prebuilt for this platform out of the `https://rakudo.org/dl/rakudo`
+  JSON index, verifies its SHA256, unpacks it to `~/.local/rakudo/` and symlinks
+  `bin/*` into `~/.local/bin/`. It is a self-contained tree, needs no build, and
+  takes a few seconds; rerunning it when `raku` already works is a no-op.
+  Without it, any work that has to *measure* rakudo's behavior (RakuAST node
+  shapes above all) is blocked — see `docs/rakuast/README.md`, whose whole slice
+  checklist starts with "measure the Rakudo `.AST` shape".
 - When investigating a roast test, always run it with `raku` first to see the expected output before comparing with mutsu.
 - Design docs: `./old-design-docs/`
 - Raku language documentation: `./raku-doc/` — consult these docs when the language spec or behavior is unclear. See the section below for a detailed guide to the most useful files.

--- a/news/2026-09/claude-md-procedures-to-skills.md
+++ b/news/2026-09/claude-md-procedures-to-skills.md
@@ -1,0 +1,49 @@
+# CLAUDE.md: move task-triggered procedures out into skills
+
+CLAUDE.md had grown to 627 lines / 70 KB, and a large share of that was
+step-by-step procedure that only matters when a specific task is requested —
+how to cut a release, how to run a "Test::Util workout", how to clear stale
+agent worktrees and cargo caches, how to pick and investigate roast work. Every
+session paid for all of it up front, and the file's actual job — the standing
+rules that apply to *every* session — was buried among them.
+
+Those four clusters are now skills under `.agents/skills/`, joining the existing
+`mutsu-ticket-flow` and `rakuast-implementation` and the new `install-raku`:
+
+- **`cut-release`** — version choice by semver judgment over what merged since
+  the last tag, the `gh workflow run tag-release.yml -f version=X.Y.Z` trigger,
+  a job-by-job account of what `tag-release.yml` and `release.yml` actually do
+  (including *why* the GitHub App token matters twice: bypass actor on the `main`
+  ruleset, and a tag pushed with the default `GITHUB_TOKEN` would not start
+  dependent workflows), explicit verification commands for the four tarballs,
+  the npm publish and the GitHub Release, the label-driven release-note grouping,
+  and the one-time infra prerequisites.
+- **`roast-triage`** — the PLAN.md → BLOCKERS.md task-selection order, the
+  `scripts/roast-history.sh` diagnostic categories, and the raku-first
+  investigation order for a single failing file.
+- **`test-util-workout`** — the one-function-at-a-time workflow, with the
+  reminder that `Test::Util` is a roast test-helper module and never a core
+  builtin.
+- **`reclaim-disk`** — worktree removal, `cargo sweep`, nuking
+  `target/*/incremental` (the dominant offender), and the optional mold + sccache
+  setup.
+
+Each skill is written to stand alone, because a subagent starts with no context:
+where a skill needs a rule that also lives in CLAUDE.md (never special-case a
+roast test, keep the whitelist sorted, `--squash` is rejected by this
+repository), it restates it rather than pointing back.
+
+CLAUDE.md keeps a short section for each cluster holding only the always-on
+rule — the release trigger and the `type:` title convention, "clean worktrees at
+least once per hour", "task selection is PLAN.md → BLOCKERS.md driven" — plus a
+pointer to the skill. The section *headings* were deliberately preserved, since
+`docs/maintenance.md`, `docs/batteries/testsuite-gate.md`, ADR-0014 and
+`todo/perf/yaml-parse-throughput.md` all cite them by name. Two subsections that
+had been filed under "Delegate the full roast run to CI" but are really about
+build profiles (`MUTSU_VM_STATS` counters on debug; benchmark numbers coming
+from the bench CI) were promoted to their own section. A new table at the top of
+CLAUDE.md indexes all seven skills with the trigger for each, and AGENTS.md
+gained the same pointer for Codex.
+
+Net: CLAUDE.md 627 → 534 lines, with no content dropped — every removed line
+landed in a skill.

--- a/news/2026-09/install-raku-skill.md
+++ b/news/2026-09/install-raku-skill.md
@@ -1,0 +1,40 @@
+# `install-raku` skill: get the Rakudo oracle back in one command
+
+Almost every mutsu workflow leans on a working `raku` as the reference oracle —
+`raku -e '<code>'` decides expected behaviour when the spec is unclear, `raku
+<roast-test>` shows the expected output before mutsu is compared against it, and
+every RakuAST slice starts by measuring the Rakudo `.AST` shape. A fresh remote
+or ephemeral container has no rakudo at all, and Ubuntu's `apt` package is
+2022.12, far too old for RakuAST. Until now CLAUDE.md carried a prose recipe for
+recovering from that (fetch the rakudo.org JSON index, pick an entry, untar,
+symlink), which had to be re-derived by hand in every new container.
+
+That recipe is now a skill: `.agents/skills/install-raku/`, with an executable
+`install-raku.sh`. It fetches `https://rakudo.org/dl/rakudo`, selects the newest
+`type: archive` / `backend: moar` entry for the host platform and arch,
+downloads the tarball, verifies its SHA256 against the published
+`.checksums.txt`, unpacks it to `~/.local/rakudo/<release>/`, symlinks `bin/*`
+into `~/.local/bin/`, and proves the result by running
+`raku -e 'say $*RAKU.compiler.version'`. On this container the whole run takes
+about five seconds. It is idempotent: when a working `raku` is already on `PATH`
+it prints the version and exits 0, so it is safe to run unconditionally at the
+start of a session. `--prefix`, `--bindir`, `--version`, `--force`,
+`--no-verify` and `--print-url` cover the remaining cases; release selection
+works through either `python3` or `jq`, whichever the host has.
+
+Two details are worth recording because both are easy to get wrong by hand.
+First, **the index's `latest` flag must not be used to select the download**: it
+marks the newest *source* release, which is routinely published before that
+release's binary builds exist. On 2026-09-05 `latest: 1` was 2026.08 (src only)
+while the newest linux prebuilt was 2026.07, so a `latest`-driven selection
+finds nothing installable. Ordering by `(ver, build_rev)` across the filtered
+archive entries is the correct rule. Second, **rakudo.org publishes no
+`linux/arm64` prebuilt** — only `linux/x86_64`, `macos/x86_64`, `macos/arm64`
+and `win/x86_64`. The script detects that case and fails with a message pointing
+at rakubrew or the official container image, rather than downloading a tarball
+for the wrong architecture.
+
+The prebuilt tree ships `raku`, `rakudo`, `nqp`, `moar` and the `perl6` aliases,
+but not `zef`; mutsu vendors its own copy under `vendor/zef/`, so nothing here
+depends on that. CLAUDE.md's "Reference implementation" section now points at
+the skill instead of restating the manual steps.


### PR DESCRIPTION
mutsu development depends on a working `raku` as the reference oracle:
behaviour checks with `raku -e`, expected roast output, and the `.AST`
measurement every RakuAST slice starts from. A fresh remote/ephemeral
container ships no rakudo, and Ubuntu's apt package (2022.12) is far too
old for RakuAST, so that recovery step was being re-derived by hand from
a prose recipe in CLAUDE.md.

Turn the recipe into `.agents/skills/install-raku/` with an executable
`install-raku.sh`: it reads the rakudo.org JSON index, selects the newest
`type: archive` / `backend: moar` build for the host platform and arch,
verifies the tarball's SHA256 against the published `.checksums.txt`,
unpacks it under `~/.local/rakudo/` and symlinks `bin/*` into
`~/.local/bin/`, then proves the install by running the compiler version.
It is idempotent (a working `raku` on PATH short-circuits to exit 0) and
supports `--prefix`, `--bindir`, `--version`, `--force`, `--no-verify`
and `--print-url`. Release selection works through python3 or jq.

Two selection rules the manual recipe got wrong are encoded here:

- The index's `latest` flag marks the newest *source* release, which is
  published before the binary builds exist (on 2026-09-05 `latest: 1` was
  2026.08, src only, while the newest linux prebuilt was 2026.07). The
  script orders the filtered archive entries by `(ver, build_rev)`.
- rakudo.org publishes no linux/arm64 prebuilt, so that case fails with a
  message pointing at rakubrew or the container image instead of pulling
  a tarball for the wrong architecture.

Verified end to end on this container: full install in ~5s, checksum
verified, `raku -e` / `Q|...|.AST` both working, rerun a no-op, custom
--prefix/--bindir and both the python3 and jq selection paths exercised.

Point CLAUDE.md's "Reference implementation" section at the skill, and
record the result in news/.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FdH9zTqe6mng8j87xqc6d5