### PR TITLE
fix(parser): `qq[[@a[0]]]` parses — the close scan steps over an interpolation atom

### DIFF
--- a/news/2026-09/qq-doubled-delimiter-interpolation-subscript.md
+++ b/news/2026-09/qq-doubled-delimiter-interpolation-subscript.md
@@ -1,61 +1,61 @@
-# `qq[[@a[0]]]` fails to parse: the close scan runs before interpolation
+# `qq[[@a[0]]]` parses: the close scan steps over an interpolation atom
 
-An interpolated variable whose subscript ends exactly at a doubled quote
-delimiter's closing run is mis-scanned:
+An interpolated variable whose subscript ended exactly where a doubled
+delimiter's closing run begins was mis-scanned into a parse failure:
 
 ```
 $ raku  -e 'my @a = 1,2; say qq[[@a[0]]]'
 1
-$ mutsu -e 'my @a = 1,2; say qq[[@a[0]]]'
+$ mutsu -e 'my @a = 1,2; say qq[[@a[0]]]'      # before
 ===SORRY!=== Error while compiling -e
 ```
 
-Measured 2026-09-05 on `main` at `2a9e06f91`.
+## The phase split
 
-## Why
+mutsu parses a quote in two phases: `parse_q_quoted_content` first finds the
+closing delimiter with a purely textual scan — `read_multi_bracketed` for a
+repeated delimiter — and only then hands the extracted content to
+`interpolate_string_content`. In `qq[[@a[0]]]` the text after the `[[` opener is
+`@a[0]]]`, whose first `]]` sits immediately after the `0`. The scan stopped
+there, yielding the content `@a[0` (an unterminated subscript) and leaving a
+stray `]` behind.
 
-mutsu parses a quote in two phases: `parse_q_quoted_content`
-(`src/parser/primary/string/q_string.rs`) first finds the closing delimiter with a
-purely textual scan — `read_multi_bracketed`
-(`src/parser/primary/string/helpers.rs`) for a repeated delimiter — and only then
-hands the extracted content to `interpolate_string_content`. In `qq[[@a[0]]]` the
-text after the `[[` opener is `@a[0]]]`, whose first `]]` sits immediately after
-the `0`. The scan stops there, yielding the content `@a[0` (an unterminated
-subscript) and leaving a stray `]` behind, so the parse fails.
-
-Rakudo has no such phase split: its quote grammar parses the interpolation atom
+Rakudo has no such split: its quote grammar parses the interpolation atom
 `@a[0]` as a unit — subscript included — and only then looks for the close. That
-is also why rakudo's behaviour here is *not* single-bracket nesting: `qq[[a[b]]]`
-is a syntax error in rakudo (no sigil, so nothing to consume the `[b]`), while
-`qq[[$x[0]]]` and `qq[[{ 1+1 }]]` both work. Any fix has to reproduce that
-distinction — counting single brackets would make `qq[[a[b]]]` wrongly succeed.
+is also why rakudo's behaviour here is *not* single-bracket nesting:
+`qq[[a[b]]]` is a syntax error in rakudo (no sigil, so nothing consumes the
+`[b]`), while `qq[[$x[0]]]` and `qq[[{ 1+1 }]]` both work. Counting bare
+brackets would have made `qq[[a[b]]]` wrongly succeed.
+
+## Measuring the atom instead of re-deriving it
+
+The scan now steps over a whole interpolation atom when the quote interpolates
+and the delimiter is repeated. The obvious way to write that skipper — sigil,
+name, then a hand-rolled chain of balanced postfixes — is exactly what the
+ticket warned against: it has to agree with what `interpolate_string_content`
+later consumes, or the two disagree and the string silently changes.
+
+So it does not re-derive the rule. `interpolation_atom_end` calls
+`try_interpolate_var` — the very function that will later consume the atom —
+with a throwaway output buffer and reads back how much input it took. Agreement
+is then true by construction, including the parts that are easy to get subtly
+wrong: `@a[0]` scans to the FIRST `]` (not a balanced one), `%h<k>` to the first
+`>`, `%h{…}` balanced, and no postfix may be preceded by whitespace.
+
+The extra parse is paid only for a *repeated* delimiter in an *interpolating*
+quote, which is where the phase split is observable at all. Both entry points
+thread the flag: the direct `qq[[…]]` form and the adverb-driven one
+(`q:qq[[…]]`, via `read_delimited_content`), which had the same bug.
 
 ## Scope
 
-Narrow. The bug needs all three of: a repeated delimiter, interpolation, and a
-subscript (or other bracketed postfix) whose closing bracket abuts the
-delimiter's closing run. Every neighbour is already correct and pinned by
-`t/quote-doubled-delimiter.t`:
+The architecturally right answer is still to stop scanning for the close ahead
+of parsing the content — to let the quote parser find the close as rakudo's
+grammar does — but that is a larger change to the quote slang. This fix removes
+the observable divergence without introducing a second, divergeable copy of the
+interpolation rules.
 
-```
-qq[@a[0]]        # ok -- single delimiter, incidental bracket nesting covers it
-qq[[x@a[0]y]]    # ok -- the subscript does not abut the close
-qq{{@a[0]}}      # ok -- `}` is not the subscript's bracket
-qq[[%h<a>]]      # ok
-```
-
-## Where to look
-
-`read_multi_bracketed` would need to skip an interpolation atom (sigil, name,
-then a chain of balanced `[...]` / `{...}` / `<...>` / `(...)` postfixes) when
-scanning an *interpolating* quote, which means passing an `is_qq` flag down from
-`parse_q_quoted_content`. That skipper must agree with what
-`interpolate_string_content` later consumes, or the two disagree and the string
-silently changes — which is why this is a ticket and not a one-liner. The
-architecturally right answer is to stop scanning for the close ahead of parsing
-the content at all, and let the quote parser find the close as rakudo's grammar
-does; that is a larger change to the quote slang.
-
-## Repro
-
-The four lines under "Scope", plus the headline. No fixtures.
+Pinned by `t/quote-doubled-delimiter-interpolation.t`, whose 19 assertions were
+measured against rakudo 2026.07 and pass identically under both. The existing
+`t/quote-doubled-delimiter.t` (25 assertions, including the two syntax errors
+that must stay errors) is unchanged and still passes.

--- a/src/parser/primary/string.rs
+++ b/src/parser/primary/string.rs
@@ -43,7 +43,7 @@ pub(in crate::parser) use qx::qx_string;
 
 pub(crate) use helpers::{
     count_repeated_bracket, process_q_escapes, quote_delimiters, read_delimited_content,
-    read_multi_bracketed, unicode_bracket_close,
+    read_delimited_content_interpolating, read_multi_bracketed, unicode_bracket_close,
 };
 pub(crate) use heredoc::parse_to_heredoc_with_flags;
 pub(crate) use interp_content::parse_single_quote_qq;

--- a/src/parser/primary/string/helpers.rs
+++ b/src/parser/primary/string/helpers.rs
@@ -214,11 +214,32 @@ pub(crate) fn read_bracketed(
 /// Nested occurrences of `open_str` and `close_str` are tracked for proper balancing.
 /// When `allow_escape` is true, `\x` consumes both chars so escaped delimiters
 /// do not affect nesting.
+/// Read the content of a delimiter repeated `n` times (`q[[ … ]]`,
+/// `qq{{ … }}`). For an *interpolating* quote (`is_qq`) the scan steps over a
+/// whole interpolation atom rather than over its individual characters.
+///
+/// mutsu finds a quote's closing delimiter with a purely textual scan and only
+/// then hands the extracted text to `interpolate_string_content`. With a
+/// repeated delimiter that split gets `qq[[@a[0]]]` wrong: the text after the
+/// `[[` opener is `@a[0]]]`, whose first `]]` sits immediately after the `0`, so
+/// the scan stops there and yields the unterminated `@a[0`.
+///
+/// Rakudo has no such split — its quote grammar parses `@a[0]` as one atom,
+/// subscript included, and only then looks for the close. Note this is NOT
+/// single-bracket nesting: `qq[[a[b]]]` is a syntax error in rakudo too (no
+/// sigil, so nothing consumes the `[b]`), which counting bare brackets would
+/// wrongly accept.
+///
+/// The atom is measured by calling `try_interpolate_var` — the very function
+/// that will later consume it — so the two cannot disagree about where the
+/// interpolation ends. It is only consulted for a repeated delimiter, which is
+/// where the phase split is observable.
 pub(crate) fn read_multi_bracketed<'a>(
     input: &'a str,
     open_str: &str,
     close_str: &str,
     allow_escape: bool,
+    is_qq: bool,
 ) -> PResult<'a, &'a str> {
     if !input.starts_with(open_str) {
         return Err(PError::expected(&format!("'{}'", open_str)));
@@ -234,6 +255,13 @@ pub(crate) fn read_multi_bracketed<'a>(
             // Skip escape sequence (backslash + next char)
             let next_ch = rest[1..].chars().next().unwrap();
             rest = &rest[1 + next_ch.len_utf8()..];
+            continue;
+        }
+        if is_qq
+            && rest.starts_with(['$', '@', '%', '&'])
+            && let Some(after) = interpolation_atom_end(rest)
+        {
+            rest = after;
             continue;
         }
         if rest.starts_with(open_str) {
@@ -255,6 +283,22 @@ pub(crate) fn read_multi_bracketed<'a>(
     }
 }
 
+/// The input remaining after the interpolation atom at the start of `input`, or
+/// `None` when there is no interpolation there (a bare `$` or `@`, a sigil
+/// followed by punctuation, ...).
+///
+/// Delegates to the real interpolator so the answer is by construction the same
+/// span `interpolate_string_content` will later consume — including its
+/// subscript rules (`@a[0]` scans to the FIRST `]`, `%h<k>` to the first `>`,
+/// `%h{...}` balanced) and its refusal to cross whitespace before a postfix.
+fn interpolation_atom_end(input: &str) -> Option<&str> {
+    let mut parts = Vec::new();
+    let mut current = String::new();
+    let after = super::interp_var::try_interpolate_var(input, &mut parts, &mut current)?;
+    // A zero-width match would spin the scan loop forever.
+    (after.len() < input.len()).then_some(after)
+}
+
 /// Count how many times the given bracket char is repeated at the start of `input`.
 pub(crate) fn count_repeated_bracket(input: &str, ch: char) -> usize {
     let mut count = 0;
@@ -272,6 +316,16 @@ pub(crate) fn count_repeated_bracket(input: &str, ch: char) -> usize {
 pub(crate) fn read_delimited_content<'a>(
     input: &'a str,
     escape_backslash: bool,
+) -> PResult<'a, &'a str> {
+    read_delimited_content_interpolating(input, escape_backslash, false)
+}
+
+/// As [`read_delimited_content`], but tells the repeated-delimiter scan whether
+/// the quote interpolates — see [`read_multi_bracketed`].
+pub(crate) fn read_delimited_content_interpolating<'a>(
+    input: &'a str,
+    escape_backslash: bool,
+    is_qq: bool,
 ) -> PResult<'a, &'a str> {
     let rest = input.trim_start();
     let delim_char = rest
@@ -293,7 +347,7 @@ pub(crate) fn read_delimited_content<'a>(
         if repeat_count > 1 {
             let open_str: String = std::iter::repeat_n(delim_char, repeat_count).collect();
             let close_str: String = std::iter::repeat_n(close_char, repeat_count).collect();
-            return read_multi_bracketed(rest, &open_str, &close_str, escape_backslash);
+            return read_multi_bracketed(rest, &open_str, &close_str, escape_backslash, is_qq);
         }
         return read_bracketed(rest, delim_char, close_char, escape_backslash);
     }

--- a/src/parser/primary/string/q_string.rs
+++ b/src/parser/primary/string/q_string.rs
@@ -88,7 +88,8 @@ pub(crate) fn big_q_string(input: &str) -> PResult<'_, Expr> {
 
     // Read delimited content
     let escape = flags.q_mode || flags.qq_mode || flags.backslash;
-    let (after, content) = read_delimited_content(rest, escape)?;
+    let (after, content) =
+        read_delimited_content_interpolating(rest, escape, flags.has_interpolation())?;
 
     // Process content with flags
     if flags.quotewords {
@@ -273,7 +274,8 @@ pub(crate) fn q_string(input: &str) -> PResult<'_, Expr> {
 
     // Read delimited content
     let escape = flags.q_mode || flags.qq_mode || flags.backslash;
-    let (rest, content) = read_delimited_content(after_q, escape)?;
+    let (rest, content) =
+        read_delimited_content_interpolating(after_q, escape, flags.has_interpolation())?;
 
     // For q-mode with symmetric delimiters, pre-process \<delim> → <delim>
     let delim_char = after_q.trim_start().chars().next().unwrap_or('/');
@@ -398,7 +400,7 @@ pub(crate) fn parse_q_quoted_content(
             // Multi-bracket delimiter (e.g. q{{ ... }}, q[[ ... ]])
             let open_str: String = std::iter::repeat_n(first, repeat_count).collect();
             let close_str: String = std::iter::repeat_n(close_ch, repeat_count).collect();
-            let (rest, content) = read_multi_bracketed(input, &open_str, &close_str, true)?;
+            let (rest, content) = read_multi_bracketed(input, &open_str, &close_str, true, is_qq)?;
             return Ok((
                 rest,
                 make_q_content_expr(content, is_qq, q_closure_interp, first, close_ch),

--- a/t/quote-doubled-delimiter-interpolation.t
+++ b/t/quote-doubled-delimiter-interpolation.t
@@ -1,0 +1,50 @@
+use Test;
+
+# An interpolation whose *subscript* ends exactly where a repeated delimiter's
+# closing run begins: `qq[[@a[0]]]`.
+#
+# mutsu used to find a quote's close with a purely textual scan and only then
+# hand the extracted text to the interpolator. With a repeated delimiter that
+# split got this wrong: the text after `[[` is `@a[0]]]`, whose first `]]` sits
+# immediately after the `0`, so the scan stopped there and yielded the
+# unterminated `@a[0`. The close scan now steps over a whole interpolation atom,
+# measured by the very function that will later consume it.
+#
+# This is NOT single-bracket nesting -- `qq[[a[b]]]` stays a syntax error in
+# rakudo and here, because with no sigil nothing consumes the `[b]`. That case
+# and the neighbouring correct ones are pinned by `t/quote-doubled-delimiter.t`;
+# this file pins the interpolating half. Measured against rakudo 2026.07.
+
+plan 19;
+
+my @a = 1, 2, 3;
+my %h = a => 5, b => 6;
+my $x = 'X';
+my $s = 'abc';
+
+# --- the headline: a subscript abutting the closing run ----------------------
+is qq[[@a[0]]], '1', 'an indexed array abutting the `]]` close';
+is qq[[@a[1]@a[2]]], '23', 'two of them, the second abutting the close';
+is qq[[%h<a>]], '5', 'an angle hash subscript abutting the close';
+is qq[[%h<a>%h<b>]], '56', 'two of those';
+is qq[[%h{'b'}]], '6', 'a braced hash subscript';
+is qq[[@a[*-1]]], '3', 'a Whatever-relative index';
+is qq<<@a[0]>>, '1', 'the same shape with a doubled angle delimiter';
+is qq[[@a[0,1]]], '1 2', 'a slice subscript abutting the close';
+is qq[[%h<<a>>]], '5', 'a doubled-angle hash subscript abutting the close';
+is qq{{@a[0]}}, '1', '`{{ }}`, where `}` is not the subscript bracket';
+
+# --- the neighbours that already worked, so they cannot regress --------------
+is qq[@a[0]], '1', 'a single delimiter, via incidental bracket nesting';
+is qq[[x@a[0]y]], 'x1y', 'a subscript that does not abut the close';
+is qq[[$x]], 'X', 'a plain scalar';
+is qq[[{ 1 + 1 }]], '2', 'a closure interpolation';
+is qq[[@a[0] and @a[1]]], '1 and 2', 'a subscript followed by literal text';
+is qq[[$s.uc()]], 'ABC', 'a method call on an interpolated scalar';
+
+# --- the scan must not start consuming un-sigiled brackets -------------------
+throws-like { EVAL 'qq[[a[b]]]' }, Exception,
+    'a bareword bracket still does not balance a doubled delimiter';
+throws-like { EVAL 'qq[[a]]]' }, Exception,
+    'a trailing stray bracket is still a syntax error';
+is qq[[a] [b]], 'a] [b', 'an unbalanced bracket with no sigil is plain content';


### PR DESCRIPTION
Closes `todo/tickets/qq-doubled-delimiter-interpolation-subscript.md`.

## The divergence

An interpolated variable whose subscript ended exactly where a doubled delimiter's closing run begins was mis-scanned into a parse failure:

```
$ raku  -e 'my @a = 1,2; say qq[[@a[0]]]'
1
$ mutsu -e 'my @a = 1,2; say qq[[@a[0]]]'      # before
===SORRY!=== Error while compiling -e
```

## The phase split

mutsu parses a quote in two phases: `parse_q_quoted_content` first finds the closing delimiter with a purely textual scan — `read_multi_bracketed` for a repeated delimiter — and only then hands the extracted content to `interpolate_string_content`. The text after the `[[` opener is `@a[0]]]`, whose first `]]` sits immediately after the `0`. The scan stopped there, yielding the content `@a[0` (an unterminated subscript) and leaving a stray `]` behind.

Rakudo has no such split: its quote grammar parses the interpolation atom `@a[0]` as a unit — subscript included — and only then looks for the close. That is also why rakudo's behaviour here is **not** single-bracket nesting: `qq[[a[b]]]` is a syntax error in rakudo (no sigil, so nothing consumes the `[b]`), while `qq[[$x[0]]]` and `qq[[{ 1+1 }]]` both work. Counting bare brackets would have made `qq[[a[b]]]` wrongly succeed.

## Measuring the atom instead of re-deriving it

The scan now steps over a whole interpolation atom when the quote interpolates and the delimiter is repeated. The obvious way to write that skipper — sigil, name, then a hand-rolled chain of balanced postfixes — is exactly what the ticket warned against: it has to agree with what `interpolate_string_content` later consumes, or the two disagree and the string silently changes.

So it does not re-derive the rule. `interpolation_atom_end` calls `try_interpolate_var` — the very function that will later consume the atom — with a throwaway output buffer and reads back how much input it took. Agreement is then true by construction, including the parts that are easy to get subtly wrong: `@a[0]` scans to the **first** `]` (not a balanced one), `%h<k>` to the first `>`, `%h{…}` balanced, and no postfix may be preceded by whitespace.

The extra parse is paid only for a *repeated* delimiter in an *interpolating* quote, which is where the phase split is observable at all. Both entry points thread the flag: the direct `qq[[…]]` form and the adverb-driven one (`q:qq[[…]]`, via `read_delimited_content`), which had the same bug.

## Scope

The architecturally right answer is still to stop scanning for the close ahead of parsing the content — to let the quote parser find the close as rakudo's grammar does — but that is a larger change to the quote slang. This fix removes the observable divergence without introducing a second, divergeable copy of the interpolation rules.

This PR also rewrites `news/2026-09/qq-doubled-delimiter-interpolation-subscript.md`: its file move (the ticket text verbatim, no code) was accidentally staged into #7352, so `main` briefly carried a news entry describing an open bug. It now describes the fix.

## Testing

- New `t/quote-doubled-delimiter-interpolation.t`: 19 assertions measured against rakudo 2026.07, passing identically under `raku` and `mutsu` — including the two shapes that must **stay** syntax errors.
- The existing `t/quote-doubled-delimiter.t` (25 assertions) is unchanged and still passes.
- `cargo clippy -- -D warnings` and `cargo fmt --check` clean on the CI-pinned 1.96.0 toolchain.
- `make test`: 3694 files / 37753 tests. The sole failure is `t/io-path-smartmatch-permissions.t`, which asserts `/sys` is not writable — this container runs as root, and `raku` answers `True` there too. Unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BDufqN1HVJqmkLhV9y4t4s

---
_Generated by [Claude Code](https://claude.ai/code/session_01BDufqN1HVJqmkLhV9y4t4s)_