### PR TITLE
fix: a Seq operand of eq must use its elements' own Str

### DIFF
--- a/news/2026-09/seq-operand-coercion-skipped-element-stringifiers.md
+++ b/news/2026-09/seq-operand-coercion-skipped-element-stringifiers.md
@@ -1,0 +1,50 @@
+# A `Seq` operand of `eq` skipped its elements' own `Str`
+
+`@objs eq "a b"` was `True` and `@objs.Seq eq "a b"` was `False`, for the same
+elements — objects of a class that defines its own `method Str`. So was
+`@objs.Seq eq @objs`, and so was every comparison whose two sides differed only
+in being an Array on one side and a Seq on the other.
+
+## Cause
+
+`coerce_stringy_operand` (`vm/vm_coerce_concat_ops.rs`) is the string-context
+coercion every `~` and `eq`/`ne`/`lt`/… operand goes through. It does two
+things that a list of objects needs, in this order:
+
+1. a `Seq` still holding a deferred source is reified, so string context sees
+   its elements rather than the opaque `(...)` placeholder;
+2. an `Instance` element that defines its own `Str` is replaced by the string
+   that method returns, because the pure renderer downstream cannot dispatch a
+   user method.
+
+Step 1 `return`ed. A `Seq` therefore never reached step 2, while an Array —
+which never takes step 1 — always did. The two sides of the comparison were
+rendered by different stringifiers: one by the element's `Str`, the other by
+the `ClassName()` fallback.
+
+The fix is to let the reified value fall through to step 2 instead of returning
+it.
+
+## Where it showed up
+
+`roast/integration/advent2009-day20.t` under the vendored upstream
+`Test.rakumod` (`MUTSU_REAL_TEST=1`), where
+
+```raku
+is @b, (@people.sort: { +.karma }), 'Sort explicitly numerically';
+```
+
+failed with `expected:` and `got:` diagnostics that printed *identically* —
+because `is` in rakudo's Test is `$got eq $expected`, and the diagnostic that
+follows is a separate `.raku()` render that does not go through the coercion.
+`@b` is an Array, the right-hand side a Seq, and `Person` defines
+`method Str { "$.name ($.karma)" }`.
+
+It was equally wrong under mutsu's native provider — `@objs.Seq eq "..."` is a
+plain Raku expression — but the native `is` compares by a different route, so
+nothing in the suite caught it. The new assertions in
+`t/list-str-calls-element-str.t` go through `eq` directly for that reason.
+
+This was one of two real-provider regressions in the 2026-09-06 roast sweep for
+`todo/deep/vendor-real-test-module.md`; it also closed
+`t/list-str-calls-element-str.t`'s real-provider failure in the `t/` sweep.

--- a/src/vm/vm_coerce_concat_ops.rs
+++ b/src/vm/vm_coerce_concat_ops.rs
@@ -266,12 +266,24 @@ impl Interpreter {
         // operand in grammar-action code, where an unconditional `view()` would
         // materialize a lazy Match (see
         // `tests/lazy_match_no_eager_materialization.rs`).
-        if v.is_seq_value()
+        //
+        // The reified value FALLS THROUGH to the element-stringifier resolution
+        // below rather than being returned here: a `Seq` of objects that define
+        // their own `.Str` needs both steps, and returning early gave the pure
+        // stringifier a Seq of `Instance`s it cannot call `.Str` on. That made
+        // `@objs.Seq eq "p1 p2"` False where the identical `@objs eq "p1 p2"`
+        // (an Array, which never took this early return) was True — and, in the
+        // vendored `Test.rakumod`, made `is @sorted, @people.sort(...)` fail on
+        // two values whose diagnostics printed identically
+        // (roast/integration/advent2009-day20.t).
+        let v = if v.is_seq_value()
             && let ValueView::Seq(body) = v.view()
             && body.needs_touch()
         {
-            return self.reify_or_consume_seq_target(v, "Str");
-        }
+            self.reify_or_consume_seq_target(v, "Str")?
+        } else {
+            v
+        };
         // A role-mixed value is NOT an `Instance` view, so it used to fall
         // straight through to the `_` arm below and lose its composed
         // `Stringy`/`Str` (see `mixin_user_stringifier`).

--- a/t/list-str-calls-element-str.t
+++ b/t/list-str-calls-element-str.t
@@ -7,7 +7,7 @@ use Test;
 # the elements first and hands the result to the same renderer, so the
 # list-shape rules (space separation, nested flattening) stay in one place.
 
-plan 16;
+plan 19;
 
 class C { has $.t; method Str { $!t } }
 class D { has $.t; method Stringy { "S:" ~ $!t } }
@@ -55,6 +55,20 @@ class D { has $.t; method Stringy { "S:" ~ $!t } }
     is @a, @a.Seq, 'a Seq stringifies its elements like an Array';
     is ~@a.Seq, 'a b', 'and prefix ~ on that Seq agrees';
     is @a, @a.map({ $_ }), 'a mapped Seq agrees too';
+}
+
+# ... and infix `eq` must agree with all of the above. A Seq that still holds a
+# deferred source reaches string context through the operand coercion, which
+# reified it and RETURNED, skipping the element-`Str` resolution the Array side
+# had already had -- so the two sides of an otherwise identical comparison were
+# rendered by different stringifiers. These assertions fail through `eq`
+# directly, so they catch it under mutsu's native Test provider too, not only
+# under the vendored `Test.rakumod` whose `is` is the `eq` in question.
+{
+    my @a = (C.new(t => "a"), C.new(t => "b"));
+    ok @a.Seq eq 'a b', 'infix eq on a Seq of objects uses the element Str';
+    ok @a.Seq eq @a, 'a Seq compares eq to the same Array';
+    ok @a.map({ $_ }) eq @a, 'a mapped Seq does too';
 }
 
 # A list with no such element takes the untouched fast path.

--- a/todo/deep/vendor-real-test-module.md
+++ b/todo/deep/vendor-real-test-module.md
@@ -57,32 +57,102 @@ For an `exit 124` roast row, re-run the individual file with a larger timeout
 before classifying it as a correctness bug. The vendored provider executes
 assertions as Raku code and is therefore slower than the Rust-native provider.
 
-## Current residue (2026-08-30)
+## Current residue (2026-09-06)
 
-The latest release sweep reported 1427 files passing under both providers,
-eight initial real-provider regressions, and one pre-existing failure.
-`S24-testing/fails-like.t` was the only correctness regression and has since
-been fixed. Re-measure before quoting this count; the list below is the useful
-handoff state.
+Both sweeps were re-run on this date, on a machine roughly **2x slower** than
+the one the 2026-08-29/30 numbers came from (calibration: `S04-declarations/state.t`
+under the real module took 15.1 s there and 28.5 s here). Read every wall-clock
+figure below with that in mind, and re-calibrate before comparing across
+sessions.
 
-### Performance blockers
+### Roast sweep (release, whitelist)
 
-These are timeouts under real `Test`, not known semantic divergences:
+```
+pass under both:                   1430
+regressed under the real Test:     2 -> 1 after the fix below
+passes only under the real Test:   0
+fail under both (pre-existing):    4
+```
 
-- `S03-buf/{read-write-bits,write-int}.t`
+- `roast/integration/advent2009-day20.t` — **fixed**. `is @b, (@people.sort: {...})`
+  compared an Array against a Seq whose elements define their own `.Str`, and
+  the two sides were rendered by different stringifiers: the operand coercion
+  reified a deferred `Seq` and returned early, skipping the element-`Str`
+  resolution the Array side had already had. So `@objs.Seq eq "..."` was False
+  where the identical `@objs eq "..."` was True. This was a general `eq`/`~`
+  bug, not a Test one; the vendored module merely exposed it because its `is`
+  IS that `eq`. Pinned by `t/list-str-calls-element-str.t` (assertions that go
+  through `eq` directly, so they fail under the native provider too).
+- `roast/S03-buf/write-int.t` — `exit 124`, the one remaining timeout. See
+  below.
+- The four fail-under-both rows (`6.c/S32-io/file-tests.t`,
+  `S10-packages/precompilation.t`, `S16-filehandles/filetest.t`,
+  `S32-io/IO-Socket-Async.t`) are provider-independent and were not
+  investigated here; three of them are filesystem tests that a root-user
+  container answers differently.
 
-The earlier `6.d/S32-str/sprintf-{b,d,x}.t` rows and
-`S04-declarations/state.t` are no longer timeout blockers: the 2026-08-29
-release measurement recorded them within the per-file budget. Commit
-`a7373e323` (`perf: cache positional callable parameter calls`) also removed
-the full name-resolution cost of a positional `&` parameter that is merely
-bound. Its regression coverage is `t/amp-param-positional-light.t`.
+### `t/` sweep (debug, all 3692 files)
 
-The remaining blocker is invoking that Callable value: `c()` still compiles to
-`CallOnCodeVar` and follows the generic closure-call path. Real `Test` uses
-this shape in `dies-ok` and nested `subtest` loops. Follow
-`todo/perf/interpreter-call-path-in-hot-loops.md`; do not weaken roast timeouts
-or special-case `Test` to hide it.
+```
+pass under both:                   3665
+regressed under the real Test:     4 -> 3 after the fix above
+passes only under the real Test:   0
+fail under both (pre-existing):    23
+```
+
+All four were verified to reproduce identically on `origin/main`, so none was
+introduced by the perf work of 2026-09-05. `t/list-str-calls-element-str.t` is
+the one the Seq fix closed. The remaining three, each still open:
+
+- `t/closure-capture-cell-dichotomy.t` #7 — "call-arg-sourced capture wins over
+  a slot-resident same-named caller lexical".
+- `t/match-vars-are-routine-scoped.t` #8 — "a sub that resets captures does not
+  delete the caller `$<first>`".
+- `t/undeclared-routine-suggests-unit-own-subs.t` #1,#2 — the CHECK-time
+  "Did you mean 'greeting'?" suggestion is absent when the `throws-like` that
+  EVALs the snippet comes from the real module rather than the native handler.
+  The exception type and the die itself are right; only the suggestion list is
+  empty.
+
+### Performance: one file left, and the attribution has moved again
+
+`S03-buf/read-write-bits.t` is **no longer** a timeout — it now completes in
+~16 s here (so ~8 s on the reference machine). Only `write-int.t` remains, at
+~49 s here (~25 s on the reference machine, against a 30 s budget), versus 4.4 s
+under the native provider. It runs ~93 000 assertions, which is why it is the
+last one standing: at ~0.31 ms per assertion that is ~29 s of pure assertion
+overhead.
+
+The 2026-09-05 work (`news/2026-09/nqp-and-name-dispatch-fast-paths.md`) halved
+the per-assertion cost — 2000 `ok 1, "x"` assertions went 1.310 s -> 0.650 s
+release, 6.22 G -> ~2.5 G retired instructions — by removing the registry walks
+`nqp::` ops and lone-`multi` resolution were paying. **Do not restart from the
+`&`-sigil framing in `todo/perf/interpreter-call-path-in-hot-loops.md`; that
+section is stale, and so is the `nqp::`/`has_multi_candidates` diagnosis, which
+is now fixed.** The measured next targets are:
+
+1. **A defaulted parameter disqualifies the callee from the cached light-call
+   path.** `is_positional_light_call_eligible` (`vm/vm_call_eligibility.rs`)
+   requires `pd.default.is_none() && !pd.optional_marker`, so every call to a
+   routine with a trailing default re-resolves by name. Measured:
+   `sub f($a) {...}` called 1000x costs **1** `function-full-resolve` in total;
+   `sub f($a, $b = 1, $c = 2) {...}` costs **1001**, one per call. Every
+   assertion routine in `Test.rakumod` has that shape
+   (`proclaim($cond, $desc, $unescaped-prefix = '')`,
+   `ok(Mu $cond, $desc = '')`). This is the exact analogue of the `&`-sigil
+   gate that `a7373e323` lifted.
+2. **`cached_fn_package` is a stub that always returns `None`**
+   (`vm/vm_call_resolve.rs`), so the non-light call path runs a full
+   `resolve_function_with_types` purely to learn the callee's defining package
+   — and that resolve also drives the deprecation check, so removing it needs
+   the deprecation info cached alongside the package.
+3. `.WHAT` always falls back to the interpreter carrier
+   (`vm_call_method_compiled_mut.rs` routes the MOP pseudo-methods there):
+   measured 5.3 us/call against 1.2 us for `.defined`. Small next to the two
+   above (~0.5 s of `write-int.t`'s 49 s) but broad — `.WHAT` is everywhere in
+   Raku code, and real `Test`'s `is` calls it twice per assertion.
+
+Do not weaken roast timeouts or special-case `Test` to hide the remaining file.
 
 ### Native-provider-only whitelist rows
 


### PR DESCRIPTION
`@objs eq "a b"` was `True` and `@objs.Seq eq "a b"` was `False` for the same
elements — objects of a class defining its own `method Str`. So was
`@objs.Seq eq @objs`, and every comparison whose two sides differed only in
being an Array on one side and a Seq on the other.

## Cause

`coerce_stringy_operand` (`vm/vm_coerce_concat_ops.rs`) is the string-context
coercion every `~` and `eq`/`ne`/`lt`/… operand goes through, and it does two
things a list of objects needs, in this order:

1. reify a `Seq` that still holds a deferred source, so string context sees its
   elements rather than the opaque `(...)` placeholder;
2. replace each `Instance` element with what its own `Str` returns — the pure
   renderer downstream cannot dispatch a user method.

Step 1 `return`ed, so a Seq never reached step 2, while an Array — which never
takes step 1 — always did. The two sides of the comparison were rendered by
different stringifiers: one by the element's `Str`, the other by the
`ClassName()` fallback. The reified value now falls through instead of being
returned.

## How it was found

`roast/integration/advent2009-day20.t` under the vendored upstream
`Test.rakumod` (`MUTSU_REAL_TEST=1`), where

```raku
is @b, (@people.sort: { +.karma }), 'Sort explicitly numerically';
```

failed with `expected:` and `got:` diagnostics that printed **identically** —
rakudo's `is` *is* this `eq`, and the diagnostic after it is a separate
`.raku()` render that does not go through the coercion. `@b` is an Array, the
right-hand side a Seq, and `Person` defines `method Str { "$.name ($.karma)" }`.

It was equally wrong under mutsu's native provider (`@objs.Seq eq "..."` is
plain Raku), but that provider's `is` compares by another route, so nothing in
the suite caught it. The new assertions in `t/list-str-calls-element-str.t` go
through `eq` directly for exactly that reason.

## Provider sweeps re-measured

This also updates `todo/deep/vendor-real-test-module.md` from fresh runs of both
`MUTSU_REAL_TEST=1` sweeps (neither is part of CI). They were run on a machine
roughly 2× slower than the one the previous numbers came from, which the ticket
now records so future comparisons calibrate.

| sweep | pass both | fail both | real-provider regressions |
| --- | --- | --- | --- |
| roast (whitelist, release) | 1430 | 4 | 2 → **1** after this fix |
| `t/` (debug, 3692 files) | 3665 | 23 | 4 → **3** after this fix |

All four `t/` regressions were verified to reproduce on `origin/main`, so none
came from the 2026-09-05 perf work; the three survivors are described in the
ticket. The one remaining roast regression is `S03-buf/write-int.t`, a timeout
rather than a semantic divergence — and `read-write-bits.t`, its former
partner, now fits comfortably.

The ticket's stale performance attribution is replaced with what is now
measured:

1. **A defaulted parameter disqualifies a routine from the cached light-call
   path** (`is_positional_light_call_eligible` requires
   `pd.default.is_none() && !pd.optional_marker`). `sub f($a) {…}` called 1000×
   costs **1** `function-full-resolve` in total; `sub f($a, $b = 1, $c = 2) {…}`
   costs **1001**, one per call — and every assertion routine in
   `Test.rakumod` has that shape.
2. `cached_fn_package` is a stub that always returns `None`, so the non-light
   call path runs a full resolve purely to learn the callee's defining package.
3. `.WHAT` always falls back to the interpreter carrier: 5.3 µs/call against
   1.2 µs for `.defined`.

## Testing

- `make test`: `Files=3695, Tests=37770` — one failure,
  `t/io-path-smartmatch-permissions.t`, which asserts `'/sys'.IO ~~ :w` is
  `False`. This session runs as root, where rakudo answers `True` too, so it is
  an environment artifact.
- `roast/integration/advent2009-day20.t` now passes under **both** providers.
- `t/list-str-calls-element-str.t` grew three assertions (16 → 19).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UUpduPmW6HWAcpLk2RjT2V

---
_Generated by [Claude Code](https://claude.ai/code/session_01UUpduPmW6HWAcpLk2RjT2V)_