### PR TITLE
chore: raise the declared MSRV to reality, add a rustc-toolchain skill, let .claude/ skip the heavy jobs

### DIFF
--- a/.claude/skills/rustc-too-old/SKILL.md
+++ b/.claude/skills/rustc-too-old/SKILL.md
@@ -17,7 +17,24 @@ version first; it costs one command.
 
 ## 1. Recognize it
 
-The tell is an error about the *language*, not about your program's meaning:
+There are two shapes, and which one you get depends on whether the declared
+MSRV is currently accurate.
+
+**The good one** — cargo refuses before compiling anything, because
+`Cargo.toml`'s `rust-version` is higher than the installed toolchain:
+
+```
+error: rustc 1.94.1 is not supported by the following package:
+  mutsu@0.23.0 requires rustc 1.96.0
+```
+
+That is unambiguous: go to step 2. Note that cargo checks *every* package in
+the workspace, so this fires even for `cargo check -p mutsu-lsp`, which does
+not build the interpreter at all.
+
+**The confusing one** — the declaration has drifted behind what the source
+actually uses, so cargo's gate passes and the compiler then rejects the
+*language*, not your program's meaning:
 
 ```
 error[E0658]: `if let` guards are experimental
@@ -29,6 +46,9 @@ error[E0658]: `if let` guards are experimental
 `E0658` is the canonical one, but the family also includes "is unstable", "use
 of unstable library feature", and "requires nightly". A `= note: see issue
 NNNNN` line pointing at a rust-lang tracking issue is a strong signal.
+
+Seeing this second shape means the MSRV declaration is stale — worth fixing
+once you are unblocked, so the next person gets the first shape instead.
 
 **Read the whole error, not the tail of the log.** A long build's last few lines
 are just `error: could not compile ... due to 1 previous error`, which says
@@ -62,13 +82,14 @@ The pinned action SHA carries a version comment:
 That comment is the version CI builds with, so it is by definition a version the
 code compiles under.
 
-`Cargo.toml`'s `rust-version` is **not** that answer, and trusting it will send
-you in circles. It is a declared MSRV that cargo checks against the running
-toolchain — it does not track which features the source has since started using.
-At the time of writing it says `1.94.0` while the code needs `1.96.0`, so an
-installed 1.94.1 satisfies cargo's gate and then fails to compile. If you notice
-that gap, it is a real (if harmless) inconsistency worth mentioning to the user;
-it is not something to "fix" by editing either number to make an error go away.
+`Cargo.toml`'s `rust-version` is a useful first signal but not the
+authoritative one. It is a hand-maintained MSRV declaration that cargo checks
+against the running toolchain; it does not track which features the source has
+since started using. It read `1.94.0` for a while after the code already needed
+`1.96.0`, which is exactly how an installed 1.94.1 came to satisfy cargo's gate
+and *then* fail to compile. Both manifests (root and `crates/mutsu-lsp/`) now
+say `1.96.0`, so the two agree — but if they ever disagree again, the CI pin
+wins, and the drift is worth reporting rather than papering over.
 
 Note also that the repo has no `rust-toolchain.toml`, which is why the container
 toolchain is whatever it is rather than being pinned per-checkout.
@@ -105,5 +126,8 @@ small box.
 - **Do not switch to nightly** to get the feature. CI builds on pinned stable;
   a nightly-only local build hides real errors until the PR is open. (The one
   legitimate nightly here is the miri job, which pins its own dated nightly.)
-- **Do not edit `Cargo.toml`'s `rust-version`** to silence anything. It gates
-  nothing you are hitting.
+- **Do not edit `Cargo.toml`'s `rust-version` to make an error go away.**
+  Raising it when it has genuinely drifted behind the code is a real fix — it
+  converts a future E0658 into cargo's legible refusal — but lowering it, or
+  raising it in the hope that a compile error disappears, only misstates what
+  the crate supports. It gates the toolchain, not the features.

--- a/.claude/skills/rustc-too-old/SKILL.md
+++ b/.claude/skills/rustc-too-old/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: rustc-too-old
+description: Diagnose and fix a rustc/toolchain that is older than the code needs, in a container where `cargo build` fails on a language feature rather than on the code. Use this whenever a build dies with E0658, "are experimental", "unstable", "requires nightly", "add `#![feature(...)]`", "consider using an edition", or an unexplained "could not compile `mutsu` (lib)" — and also whenever the session is on a fresh or ephemeral machine and you are about to build for the first time, or the user asks how to upgrade rustc, which Rust version this repo wants, or why a build works in CI but not here. Reach for it before you consider rewriting the code to suit the compiler.
+---
+
+# The compiler is behind the code, not the other way round
+
+A remote or newly-provisioned container often ships whatever rustc the base
+image happened to have. This repo tracks a recent stable and uses features that
+land in it, so the first `cargo build` on such a machine can fail on syntax the
+code has used for months. Nothing is wrong with the code — the toolchain is the
+thing to move.
+
+The failure mode worth naming: this looks like a code error. It cites a file and
+a line in `src/`, so the reflex is to "fix" that line. Don't. Check the compiler
+version first; it costs one command.
+
+## 1. Recognize it
+
+The tell is an error about the *language*, not about your program's meaning:
+
+```
+error[E0658]: `if let` guards are experimental
+   --> src/vm/vm_data_ops.rs:134:19
+    = note: see issue #51114 <https://github.com/rust-lang/rust/issues/51114> for more information
+    = help: you can write `if matches!(<expr>, <pattern>)` instead of `if let <pattern> = <expr>`
+```
+
+`E0658` is the canonical one, but the family also includes "is unstable", "use
+of unstable library feature", and "requires nightly". A `= note: see issue
+NNNNN` line pointing at a rust-lang tracking issue is a strong signal.
+
+**Read the whole error, not the tail of the log.** A long build's last few lines
+are just `error: could not compile ... due to 1 previous error`, which says
+nothing. If you backgrounded the build or piped it through `tail`, re-read with
+the error in view:
+
+```bash
+cargo build 2>&1 | grep -B2 -A 12 '^error' | head -60
+```
+
+Then confirm the suspicion:
+
+```bash
+rustc --version
+```
+
+## 2. Find the version the repo actually wants
+
+**The authoritative source is the CI toolchain pin, not `Cargo.toml`.**
+
+```bash
+grep -n "rust-toolchain@" .github/workflows/ci.yml
+```
+
+The pinned action SHA carries a version comment:
+
+```
+- uses: dtolnay/rust-toolchain@01ba1edad32c6f80dbcce879d3e0fa5a00b2a84e # 1.96.0
+```
+
+That comment is the version CI builds with, so it is by definition a version the
+code compiles under.
+
+`Cargo.toml`'s `rust-version` is **not** that answer, and trusting it will send
+you in circles. It is a declared MSRV that cargo checks against the running
+toolchain — it does not track which features the source has since started using.
+At the time of writing it says `1.94.0` while the code needs `1.96.0`, so an
+installed 1.94.1 satisfies cargo's gate and then fails to compile. If you notice
+that gap, it is a real (if harmless) inconsistency worth mentioning to the user;
+it is not something to "fix" by editing either number to make an error go away.
+
+Note also that the repo has no `rust-toolchain.toml`, which is why the container
+toolchain is whatever it is rather than being pinned per-checkout.
+
+## 3. Install it and switch
+
+```bash
+rustup toolchain install 1.96.0 --profile minimal -c clippy -c rustfmt
+rustup default 1.96.0
+rustc --version   # confirm
+```
+
+Install `clippy` and `rustfmt` explicitly: `--profile minimal` omits them, and
+this repo's pre-commit hooks and CI both run `cargo clippy -- -D warnings` and
+`cargo fmt`. Discovering they are missing three commits later is a waste.
+
+If `rustup` itself is absent (a distro-packaged rustc, no toolchain manager),
+install rustup first from https://rustup.rs and then run the above.
+
+## 4. Budget for the rebuild
+
+Changing the default toolchain invalidates every previously built artifact, so
+the next build is a full one — dependencies included. On a modest container
+expect a few minutes for `cargo build` and closer to ten for
+`cargo build --release`. Start it in the background and do something else rather
+than watching it, but do not start unrelated CPU-heavy work alongside it on a
+small box.
+
+## What not to do
+
+- **Do not rewrite the source to suit an old compiler.** Turning an `if let`
+  guard into `matches!` because the local rustc is behind makes the diff about
+  the container, not about the task, and CI would have accepted the original.
+- **Do not switch to nightly** to get the feature. CI builds on pinned stable;
+  a nightly-only local build hides real errors until the PR is open. (The one
+  legitimate nightly here is the miri job, which pins its own dated nightly.)
+- **Do not edit `Cargo.toml`'s `rust-version`** to silence anything. It gates
+  nothing you are hitting.

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -28,6 +28,7 @@ on:
       - 'TODO_roast/**'
       - 'old-design-docs/**'
       - 'raku-doc/**'
+      - '.claude/**'
       - '*.md'
       - 'LICENSE'
   workflow_dispatch:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ default-members = ["."]
 name = "mutsu"
 version = "0.23.0"
 edition = "2024"
-rust-version = "1.94.0"
+rust-version = "1.96.0"
 license = "Artistic-2.0"
 
 [lib]

--- a/crates/mutsu-lsp/Cargo.toml
+++ b/crates/mutsu-lsp/Cargo.toml
@@ -5,7 +5,7 @@ name = "mutsu-lsp"
 # tying the two together is a decision for whenever it ships.
 version = "0.1.0"
 edition = "2024"
-rust-version = "1.94.0"
+rust-version = "1.96.0"
 license = "Artistic-2.0"
 description = "Language server for mutsu, targeting AI agents (ADR-0065)"
 

--- a/scripts/ci-docs-only.sh
+++ b/scripts/ci-docs-only.sh
@@ -41,9 +41,19 @@ set -u
 # to files the build reads, and the blast radius of guessing wrong there is a
 # silently-untested merge. Top-level *.md (PLAN, README, CLAUDE, ANALYSIS,
 # PERFORMANCE, BATTERIES, AGENTS) is safe and covers the common case.
+#
+# `.claude/**` is agent configuration and agent-facing documentation (skills,
+# settings). Nothing in the build reads it -- not cargo, not `prove`, not the
+# roast runner -- so a change there cannot move a single test result, and
+# adding a skill used to cost a full ~25 min suite for one markdown file. It is
+# on the allowlist as a whole directory rather than just `.claude/skills/**`
+# because the same argument covers everything CI ignores; if something under it
+# ever does become an input to a job, that job's workflow file changes too, and
+# `.github/**` forces the full suite.
 is_doc_path() {
   case "$1" in
     docs/*|news/*|todo/*|TODO_roast/*|old-design-docs/*|raku-doc/*) return 0 ;;
+    .claude/*) return 0 ;;
     LICENSE) return 0 ;;
     */*) return 1 ;;          # any other nested path: not documentation
     *.md) return 0 ;;         # top-level markdown only
@@ -160,6 +170,10 @@ self_test() {
   check true  'roast ledger'            TODO_roast/BLOCKERS.md
   check true  'vendored docs'           raku-doc/doc/Type/Str.rakudoc
   check true  'non-md under docs/'      docs/probes/pool-spawn.raku
+  check true  'agent skill'             .claude/skills/rustc-too-old/SKILL.md
+  check true  'agent settings'          .claude/settings.json
+  check true  'skill + news entry'      .claude/skills/x/SKILL.md news/2026-09/y.md
+  check false 'skill + src'             .claude/skills/x/SKILL.md src/vm/vm.rs
   check false 'src change'              src/vm/vm.rs
   check false 'docs + src'              docs/adr/0016-x.md src/vm/vm.rs
   check false 'workflow change'         .github/workflows/ci.yml


### PR DESCRIPTION
A fresh remote container ships whatever rustc its base image happened to have,
and this repo tracks a recent stable, so the first `cargo build` there died on
syntax the code has used for months:

```
error[E0658]: `if let` guards are experimental
   --> src/vm/vm_data_ops.rs:134:19
```

That error cites a file and a line in `src/`, so the reflex is to "fix" that
line — which produces a diff about the container rather than about the task, on
code CI already accepts. Three changes so the next person does not spend that
time.

## 1. `rust-version` now matches what the code needs

The root manifest declared `1.94.0` while the source had long since started
using `if let` guards, which land in 1.96. An installed 1.94.1 therefore
satisfied cargo's gate and *then* failed to compile. Both manifests now say
`1.96.0` — the version CI pins — so cargo refuses up front instead, with a
diagnostic that points at the toolchain rather than at the code:

```
error: rustc 1.94.1 is not supported by the following package:
  mutsu@0.23.0 requires rustc 1.96.0
```

`crates/mutsu-lsp` is bumped too. It does not depend on the interpreter crate,
so its own `1.94.0` claim was defensible in isolation — but cargo checks
`rust-version` for **every package in the workspace**, so once the root requires
1.96 the whole workspace does. Verified: `cargo +1.94.1 check -p mutsu-lsp`
refuses, naming both packages. Leaving the two split would advertise support
that cannot be exercised.

## 2. `.claude/**` joins the docs-only allowlist

Adding one markdown skill file was costing a full ~25 min suite. Nothing in the
build reads that directory — not cargo, not `prove`, not the roast runner — so a
change there cannot move a test result.

It is allowlisted as a whole directory rather than just `.claude/skills/**`
because the same argument covers everything CI ignores; if something under it
ever does become a job input, that job's workflow file changes with it and
`.github/**` already forces the full suite. `bench.yml`'s `paths-ignore` is kept
in sync per CLAUDE.md, and the classifier's `--self-test` grows four cases —
including the mixed `skill + src` diff that must still classify `false`:

```
ok - agent skill
ok - agent settings
ok - skill + news entry
ok - skill + src
```

## 3. The skill itself

`.claude/skills/rustc-too-old/SKILL.md`. Its job is to get the next agent to
check `rustc --version` before it touches the source. It records:

- **Two symptom shapes.** Cargo's legible refusal is now the expected one; E0658
  is what you get only once the declaration has drifted behind the source again
  — and seeing it is itself the signal to fix the declaration.
- **The authoritative version is the CI toolchain pin's version comment**
  (`dtolnay/rust-toolchain@<sha> # 1.96.0`), not `rust-version`. The latter is
  hand-maintained and does not track which features the source has started
  using — which is exactly how this drift happened.
- **A backgrounded or `tail`-ed build hides the diagnostic.** The last lines are
  just `could not compile ... due to 1 previous error`, which says nothing.
- Installing `clippy`/`rustfmt` alongside (the pre-commit hooks and CI need
  both, and `--profile minimal` omits them), budgeting for the full rebuild that
  switching the default toolchain forces, and why nightly is not the answer —
  CI builds on pinned stable, and the only legitimate nightly is miri's own
  dated pin.

Every command in it was run in this session.

## Testing

- `scripts/ci-docs-only.sh --self-test`: all cases pass.
- `cargo build` on 1.96.0: clean.
- `cargo +1.94.1 check -p mutsu-lsp`: refuses with the message quoted above,
  which is the behaviour change this PR is buying.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UUpduPmW6HWAcpLk2RjT2V