### PR TITLE
feat: a raw invocant parameter binds the caller's container (ADR-0067 slice 3b)

### DIFF
--- a/docs/adr/0067-a-routine-hands-back-the-container-it-was-given.md
+++ b/docs/adr/0067-a-routine-hands-back-the-container-it-was-given.md
@@ -1,10 +1,12 @@
 # ADR-0067: A routine hands back the container it was *given* — raw arguments, raw invocants, and the subscript step through an object
 
-- Status: Proposed (Slices 1, 2, 3a, 4 and 5 implemented 2026-09-05; Slice 3 was
-  re-scoped into 3a/3b on the same day after measurement, and 3a's E6 row split
-  off again into the rw-attribute-accessor producer; Slice 4 absorbed two of
-  Slice 5's three acceptance rows, again after measurement; Slices 3b and the E6
-  producer open)
+- Status: Proposed (Slices 1, 2, 3a, 4 and 5 implemented 2026-09-05, Slice 3b
+  2026-09-06; Slice 3 was re-scoped into 3a/3b on 2026-09-05 after measurement,
+  and 3a's E6 row split off again into the rw-attribute-accessor producer;
+  Slice 4 absorbed two of Slice 5's three acceptance rows, again after
+  measurement; Slice 3b shipped the *named-receiver* half of the arrival
+  direction and split its subscript-receiver rows (I3/K3) off into a producer
+  slice of their own; the E6 producer and that subscript producer remain open)
 - Date: 2026-09-05
 - Related: [ADR-0059](0059-is-rw-routines-return-a-container.md) (an `is rw`
   routine returns a container), [ADR-0036](0036-element-container-pairs-from-subscripts-and-pairs.md)
@@ -644,6 +646,183 @@ route 4's scalar restriction declines them), `$a.list = 5` (list assignment, see
 above), `$a.snitch.snitch = 5` (a chained lvalue invocant),
 `@n[0][1].mutsuRawInv = 8` (a depth-2 subscript invocant, which is slice 4's
 walker), and `42.snitch = 5` (raku also dies, with a different message).
+
+#### Slice 3b — IMPLEMENTED 2026-09-06
+
+Every row of the I/E/F/G families above was re-measured against raku v2026.07
+and a debug `mutsu` built from `main` at `30d6754f5` before any code was
+written, along with a new L/M/N/O/Q/R/S family built to find the *edges* of the
+contract. Two of this ADR's own claims about 3b did not survive that.
+
+**Correction A — `is raw` on the routine is not part of the arrival contract,
+and E1/E2 are not regression controls for this half.** The slice 3 text says
+"E1/E2 stay regression controls for both: raku needs the invocant raw **and**
+the routine `is raw`/`is rw`, and dropping either must keep refusing". Measured,
+that conjunction is the *outbound* (lvalue-return) contract only:
+
+| # | Program | raku |
+|---|---|---|
+| L1 | `class C { method m(\S:) { S = 7 } }; my $c = C.new; $c.m; say $c` | `7` |
+| L2 | the same with `method m($s is raw:)` | `7` |
+| L3 | the same with `method m($s is rw:)` | `7` |
+| L4 | the same with `method m($s:)` | dies, `Cannot assign to a readonly variable or a value` |
+| L5 | the same with `method m(C $s:)` | dies, `Cannot assign to an immutable value` |
+
+No `is raw` on the routine anywhere in L1-L3. `is raw`/`is rw` on the *routine*
+answers "is this call an lvalue"; rawness of the *invocant parameter* answers
+"does the body's write reach the caller". They are independent, and 3b needs
+only the second. So the shipped oracle is
+`Interpreter::method_binds_raw_invocant` — the same resolve as slice 3a's
+`method_returns_raw_invocant` with the `method_is_rw_capable` conjunct dropped.
+Both read the one `method_def_has_raw_invocant` predicate, so the two halves
+cannot disagree about what "raw invocant" means. E1/E2 remain slice 3a's
+controls and are re-verified unchanged; L4/L5 are 3b's own controls.
+
+**Correction B — the recorded call chain was the wrong one, and the transport
+the ADR predicted is not the transport that shipped.** The ADR's `rust-gdb`
+trace has `call_compiled_method_fast <- call_compiled_method <-
+dispatch_compiled_method <- try_dispatch_compiled_method_direct_as`, and
+concludes 3b "is a signature change across that whole chain". Re-traced on I1
+and L2, the chain above `call_compiled_method` is **two** different chains and
+neither is the recorded one at its top:
+
+```
+$c.m, Instance receiver:
+  exec_call_method_mut_op_impl (vm_call_method_mut_ops.rs)   target_name = "c"
+    -> try_compiled_method_mut_or_interpret_sym              target_name = "c"
+      -> call_compiled_method            (:581,  slow binder, `$s is raw:`)
+        -> call_compiled_method_fast     (:1512, fast binder, `\S:`)
+
+$a.mut, `augment class Int` receiver:
+  exec_call_method_mut_op_impl                               target_name = "a"
+    -> try_compiled_method_mut_or_interpret_sym
+      -> vm_call_method_mut_with_values -> call_method_mut_with_values
+        -> call_method_with_values -> call_method_with_values_inner
+          -> try_dispatch_compiled_method_direct_as -> dispatch_compiled_method
+            -> call_compiled_method -> call_compiled_method_fast
+```
+
+The second chain runs through `call_method_with_values`, which takes
+`target: Value` and no source channel and is called from ~everywhere, so the
+signature change the ADR imagined would have been far wider than "that whole
+chain". What both chains *do* share is their single origin, the `CallMethodMut`
+opcode, which is the only place that has the receiver's source name at all.
+So the shipped transport is a **one-slot channel armed at that opcode and
+consumed at the binder**, not a parameter: `pending_raw_invocant`
+(`src/vm/vm_raw_invocant_arrival.rs`), armed immediately before the dispatch,
+disarmed immediately after, and consumed only by a binder that both agrees on
+the method name and is looking at a `ParamDef` that really is a raw invocant.
+That last re-check is what makes a nested dispatch in the window (a `where`
+clause, a multi tie-break) unable to mis-bind it — and it is also the
+authority when multi-dispatch lands on a different candidate than the gate
+resolved.
+
+The ADR *was* right that both binders must learn the container, and right about
+which is which: `binds_caller_container()` is true for `$s is raw:` / `$s is rw:`
+(the traits arm), which routes those to the slow binder, while a sigil-less
+`\S:` is excluded by that predicate's own `!pd.is_invocant` and lands on the
+fast one. The shipped pin exercises both spellings for exactly this reason.
+
+**What shipped.**
+
+- **`Interpreter::method_binds_raw_invocant`** (`src/runtime/raw_invocant.rs`),
+  the arrival oracle described above. No native fallback row: no native method
+  mutates its invocant through parameter zero (`.snitch`, slice 3a's one row,
+  only hands it back).
+- **The arrival channel and its arm/disarm pair**
+  (`src/vm/vm_raw_invocant_arrival.rs`), wired into `CallMethodMut`'s two
+  user-method dispatch sites through one helper so the pair can never be split,
+  and into `CallMethodDynamicMut` for the runtime method-name spelling.
+- **No new producer.** The container comes from slice 3a's
+  `capture_lvalue_invocant_cell`, reused verbatim — which is the point: its
+  route order (an existing frame cell, then an existing env container, then a
+  direct slot box, then a minted cell) is the thing slice 3a had to learn the
+  hard way, and reusing it is what makes `for @a <-> $e { $e.m }` and
+  `for @a -> $e is rw { $e.m }` bind the element's *already promoted* cell
+  instead of a second, disconnected one. Both are pinned.
+- **The binder change is two lines in each binder**: bind parameter zero to the
+  channel's cell when it holds one, and leave `base` alone. `base` stays the
+  plain value, so `self`, the attribute seeding, the dispatch frame and the
+  ~40 downstream `target.view()` branches see exactly what they see today —
+  the 3a hazard ("boxing every invocant would hand a `ContainerRef` to branches
+  that match `Instance`/`Array`/`Hash` directly") does not arise here at all,
+  because only the *parameter* is boxed, never the invocant value.
+- **Write-through needs no new consumer either.** A local slot holding a
+  `ContainerRef` already stores through the cell (`vm_var_assign_set_local.rs`,
+  `vm_var_assign_local.rs`) and `GetLocal` already derefs one, so `S = 7` inside
+  the body reaches the caller with no writeback machinery. Slice 3b adds no
+  writeback path, no `pending_rw_writeback_sources` entry, and no new opcode.
+
+**The cost, measured.** The gate runs on **every** `$var.method(...)`, an
+order of magnitude more traffic than slice 3a's `$obj.attr = v`. Slice 3a's
+pre-filter is `self.registry().any_raw_invocant_method`, which is an `RwLock`
+read acquisition — affordable there, not here. So the flag is mirrored into a
+process-global, set-only `AtomicBool` raised by the *same* writer
+(`Registry::note_raw_invocant_methods`), the pattern `env.rs`'s
+`CLOSURE_META_KEY_SEEN` already uses, and a `debug_assert` in
+`debug_verify_owner_method_names_index` fails the debug `t/` suite if a future
+writer of the registry field ever bypasses that one writer. With the mirror,
+the whole gate for a program that declares no raw-invocant method is one relaxed
+atomic load and an `is_empty()`.
+
+Same-binary env-switch A/B on a release build (`MUTSU_SKIP_RAW_INVOCANT_ARRIVAL`
+short-circuits the gate), 4M iterations of `$p.bump` on a `has $.x is rw` class,
+`taskset -c 2`, min of 11: **15.15s with the gate against 15.49s with it
+skipped**, and 16.88s against 17.14s on a second interleaved round taken under
+heavier machine load. The gate is *faster* in both rounds, which is the honest
+reading of "below the noise floor": the sign is meaningless, and the
+between-round drift (15.2s -> 16.9s on the same binary at the same switch
+position) is an order of magnitude larger than the difference being measured.
+Compare slice 3a, whose un-filtered gate showed a clean, repeatable **+13%** on
+the same kind of A/B — a real cost is visible in this harness when there is one.
+
+**What still refuses or is still wrong, all measured, all deliberately out of
+scope.**
+
+- **I3/K3 — a *subscript* receiver (`@a[0].mut`, `%h<a>.mut`) is unchanged.**
+  This is the row the ADR named as 3b acceptance, and it is not reachable from
+  this mechanism: `--dump-bytecode` shows `@a[0].mut` compiling to
+  `GetArrayVar; LoadConst; Index; CallMethod` — a plain `CallMethod`, which
+  carries **no** `target_name_idx`, and whose receiver arrives as a value the
+  `Index` op has already read out of the array. There is no name to box and no
+  location on the stack. What it needs is a *producer* — the subscript handing
+  over the element's own cell, which `array_slot_ref` can already mint — and
+  emitting that is an **unconditional compile-side change** to a very common
+  shape (every `<subscript>.method(...)` in every program), so it must be
+  paired with a decontainerize-at-the-chokepoint guard in `CallMethod` and
+  re-measured, exactly as the E6 producer must. That is its own slice, recorded
+  as `todo/tickets/subscript-receiver-raw-invocant-producer.md`. These rows are
+  *unchanged*, not newly wrong: mutsu silently dropped the write before this
+  slice and still does.
+- **N1 — an attribute-accessor receiver (`$d.v.mut`) is unchanged**, for the
+  same reason and by the same missing producer as 3a's E6 row
+  (`MarkAccessorRefContext`). It belongs to that slice, not this one.
+- **O1 — an aggregate receiver (`@a.mut` with `S = [7,8]`) is unchanged.**
+  `capture_lvalue_invocant_cell` declines every route for an `@`/`%` name by
+  design (route 4's scalar restriction), because a cell over an aggregate would
+  disagree with its identity-shared storage. raku answers `[7 8]`; mutsu
+  silently answers `[1 2]`, as before.
+- **L4/L5/J5 — a non-raw invocant assigned to inside the body.** raku dies;
+  mutsu silently drops the write, unchanged. This is a readonly-parameter
+  enforcement gap, not an arrival gap: the gate correctly declines these, and
+  the *observable* half of the contract (the caller's variable is not modified)
+  already matches, which is what the pin asserts.
+- **M1/M2 — an rvalue invocant (`42.mut`, `($a + 1).mut`).** raku dies with
+  `Cannot modify an immutable Int`; mutsu silently succeeds doing nothing.
+  Unchanged: there is no location, so the gate declines and nothing is boxed.
+
+**Pinned by** `t/raw-invocant-arrives-as-container.t` (26 tests, byte-identical
+output under `mutsu` and `raku`): the three raw-invocant spellings over both
+binders, the routine-rw-capability independence (Correction A's B1/B2 rows),
+`augment class Int`/`Str` receivers with a repeated mutation that proves the
+container survives, each frame shape a receiver name can have (a `<->` and an
+`is rw` loop parameter, a captured-outer scalar written from a closure, an
+`is rw` sub parameter, a `:=`-bound alias), `multi` candidate selection, role
+composition, the runtime method-name spelling, a body that reads its invocant
+before replacing it, and five regression rows — the two non-raw invocant
+controls, an ordinary method whose value semantics must survive the
+program-wide pre-filter being on, and a read-only raw-invocant method that
+must stay a plain rvalue call.
 
 ### Slice 4 — the chain walk steps through an object
 

--- a/news/2026-09/raw-invocant-parameter-binds-the-callers-container.md
+++ b/news/2026-09/raw-invocant-parameter-binds-the-callers-container.md
@@ -1,0 +1,98 @@
+# A raw invocant parameter binds the caller's container
+
+`class C { method m(\S:) { S = 7 } }; my $c = C.new; $c.m` leaves `$c` holding
+`7` in raku, because a raw invocant parameter binds the caller's Scalar
+container rather than a copy of its contents. mutsu left `$c` untouched. This is
+ADR-0067 slice 3b, the inbound mirror of slice 3a: 3a made an lvalue *call* hand
+a container back, this makes the invocant *arrive* as one.
+
+Now identical to raku for a named receiver, whichever raw spelling is used and
+whichever of the two compiled-method binders runs:
+
+```raku
+class A { method m(\S:)        { S = 7 } }; my $c = A.new; $c.m; say $c;  # 7
+class B { method m($s is raw:) { $s = 7 } }; my $c = B.new; $c.m; say $c; # 7
+class C { method m($s is rw:)  { $s = 7 } }; my $c = C.new; $c.m; say $c; # 7
+
+use v6.e.PREVIEW; use MONKEY-TYPING;
+augment class Int { method inc(\S:) { S = S + 1 } }
+my $a = 42; $a.inc; $a.inc; say $a;                                      # 44
+my @a = 1, 2; for @a <-> $e { $e.inc }; say @a;                          # [2 3]
+```
+
+## What the ADR got wrong, and measurement caught
+
+**`is raw` on the *routine* is not part of this contract.** The ADR carried
+slice 3a's rule forward and said raku needs the invocant raw *and* the routine
+rw-capable, with `E1`/`E2` as regression controls for both halves. Re-measured
+against raku v2026.07, that conjunction is the *outbound* contract only: `is
+raw`/`is rw` on a routine answers "is this call an lvalue", while rawness of the
+invocant *parameter* answers "does the body's write reach the caller". All three
+programs above mutate with no routine trait anywhere, and a plain `$s:` or
+`C $s:` invocant is refused whether or not the routine is `is raw`. So the
+shipped oracle, `Interpreter::method_binds_raw_invocant`, is slice 3a's resolve
+with the rw-capability conjunct dropped — both read the one
+`method_def_has_raw_invocant` predicate, so the two halves cannot drift apart
+about what "raw invocant" means.
+
+**The recorded call chain was one of two, and neither was named at its top.**
+The ADR's `rust-gdb` trace concluded 3b "is a signature change across that whole
+chain". Re-tracing under `rust-gdb` found two disjoint chains — an `Instance`
+receiver reaches `call_compiled_method` directly, while an `augment`ed native
+receiver detours through `call_method_mut_with_values` →
+`call_method_with_values` → `try_dispatch_compiled_method_direct_as` — and the
+second runs through `call_method_with_values`, which is called from ~everywhere
+and carries no source channel. What both chains share is their single origin,
+the `CallMethodMut` opcode, which is also the only place that knows the
+receiver's source name. So the transport is a one-slot channel armed at that
+opcode and consumed at the binder, not a parameter: it is disarmed immediately
+after the dispatch, and a binder only consumes it when it agrees on the method
+name *and* is looking at a `ParamDef` that really is a raw invocant — which also
+makes the actually-bound candidate the authority when multi-dispatch lands
+somewhere the gate did not.
+
+## Reuse, not new machinery
+
+The container itself comes from slice 3a's `capture_lvalue_invocant_cell`,
+reused verbatim. That is the point: its route order — an existing frame cell,
+then an existing env container, then a direct slot box, and only then a freshly
+minted one — is the rule slice 3a learned the hard way, and reusing it is what
+makes `for @a <-> $e { $e.m }` bind the element's *already promoted* cell rather
+than shadowing it with a disconnected second one. Write-through needs no new
+consumer either: a local slot holding a `ContainerRef` already stores through
+the cell and `GetLocal` already derefs one, so the slice adds no writeback path
+and no new opcode. Only the *parameter* is boxed — the invocant value `base`
+stays plain, so `self`, attribute seeding and every downstream branch that
+matches `Instance`/`Array`/`Hash` see exactly what they saw before.
+
+## Cost
+
+The gate runs on every `$var.method(...)`, an order of magnitude more traffic
+than slice 3a's `$obj.attr = v`, so slice 3a's `self.registry()` pre-filter (an
+`RwLock` read acquisition) was not affordable. The flag is mirrored into a
+process-global, set-only `AtomicBool` raised by the same single writer, with a
+`debug_assert` that fails the debug `t/` suite if a future writer of the registry
+field bypasses it. A program that declares no raw-invocant method pays one
+relaxed atomic load per method call. Same-binary env-switch A/B on a release
+build over 4M `$p.bump` calls: 15.15s with the gate against 15.49s with it
+skipped, and 16.88s against 17.14s on a second round. The gate measures
+*faster* both times, which is how "below the noise floor" looks — the sign is
+meaningless and the between-round drift dwarfs the difference. For comparison,
+slice 3a's un-filtered gate showed a clean, repeatable +13% on the same kind of
+A/B, so this harness does surface a real cost when there is one.
+
+## Still out of scope, and why
+
+A *subscript* receiver (`@a[0].mut`, `%h<a>.mut`) is unchanged. It compiles to a
+plain `CallMethod`, which carries no receiver name, and the `Index` op has
+already read the element's value off the array — so there is neither a name to
+box nor a location on the stack. What it needs is a producer (the subscript
+handing over the element's own cell), and emitting one is an unconditional
+compile-side change to a very common shape that has to be paired with a
+decontainerize chokepoint and re-measured, including under the JIT. That is
+`todo/tickets/subscript-receiver-raw-invocant-producer.md`. The
+attribute-accessor receiver (`$d.v.mut`) is the same missing-producer problem
+and belongs to slice 3a's E6 row. Both are unchanged rather than newly wrong.
+
+Pinned by `t/raw-invocant-arrives-as-container.t` (26 tests, byte-identical
+output under `mutsu` and `raku`).

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1709,6 +1709,13 @@ pub struct Interpreter {
     /// `X::Attribute::NoPackage`.
     pub(crate) defining_class: Option<String>,
     pending_call_arg_sources: Option<Vec<Option<String>>>,
+    /// ADR-0067 slice 3b: the caller's container for the invocant of the method
+    /// call currently being dispatched, staged by
+    /// `Interpreter::arm_raw_invocant_arrival` and consumed by whichever of the
+    /// two compiled-method binders runs. Always `None` outside the window
+    /// between one method-call opcode's arm and its matching disarm.
+    pub(crate) pending_raw_invocant:
+        Option<Box<crate::vm::vm_raw_invocant_arrival::PendingRawInvocant>>,
     /// Every positional argument of the value-call currently being dispatched
     /// (`$b(7)` / `&b(7)` — `OpCode::CallOnValue`/`CallOnCodeVar`'s `bare_args`)
     /// is a syntactically container-less expression, so a bare block's implicit

--- a/src/runtime/raw_invocant.rs
+++ b/src/runtime/raw_invocant.rs
@@ -25,6 +25,33 @@
 //! `assign_method_lvalue_with_values`, silently skipping all of them.
 
 use super::*;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+/// Lock-free mirror of [`Registry::any_raw_invocant_method`], raised at the
+/// same instant by the same writer ([`Registry::note_raw_invocant_methods`]).
+///
+/// Slice 3a's gate runs on `$obj.attr = v` and can afford
+/// `self.registry().any_raw_invocant_method`; slice 3b's runs on **every**
+/// `$var.method(...)`, where an `RwLock` read acquisition per call is not
+/// affordable. Same soundness argument as `env.rs`'s `CLOSURE_META_KEY_SEEN`:
+/// monotone, set-only, and an over-set only makes the (correct) resolve run.
+/// Process-global rather than per-interpreter for the same reason that flag is
+/// — a second interpreter in the same process merely inherits a conservative
+/// `true`.
+static ANY_RAW_INVOCANT_METHOD: AtomicBool = AtomicBool::new(false);
+
+/// Raise the mirror. Called only from `Registry::note_raw_invocant_methods`, so
+/// the two flags cannot drift apart.
+pub(crate) fn note_any_raw_invocant_method() {
+    ANY_RAW_INVOCANT_METHOD.store(true, Ordering::Relaxed);
+}
+
+/// Whether any registered method anywhere declares a raw invocant. The cheap
+/// pre-gate of the slice 3b arrival path.
+#[inline]
+pub(crate) fn any_raw_invocant_method_possible() -> bool {
+    ANY_RAW_INVOCANT_METHOD.load(Ordering::Relaxed)
+}
 
 /// Native methods that Rakudo declares `is raw` on their invocant *and* which
 /// hand that invocant straight back, so `$a.NAME = v` writes through `$a`.
@@ -64,7 +91,7 @@ pub(crate) fn native_method_returns_raw_invocant(method: &str) -> bool {
 /// Three spellings, all verified against raku v2026.07: the sigilless `\SELF:`
 /// (which the parser records as `sigilless`), `$s is raw:`, and `$s is rw:`. A
 /// plain `Any:D $s:` is *not* raw, which is the E2 regression control.
-fn param_is_raw_invocant(pd: &crate::ast::ParamDef) -> bool {
+pub(crate) fn param_is_raw_invocant(pd: &crate::ast::ParamDef) -> bool {
     pd.is_invocant
         && (pd.sigilless
             || pd
@@ -109,6 +136,44 @@ impl Interpreter {
             return Self::method_is_rw_capable(&def) && method_def_has_raw_invocant(&def);
         }
         native_method_returns_raw_invocant(method)
+    }
+
+    /// The ADR-0067 slice 3b **arrival** oracle: does `target.method(args)`
+    /// resolve to a routine that binds its invocant raw, so mutation *through*
+    /// the invocant inside the body must reach the caller's variable?
+    ///
+    /// This is deliberately a weaker question than
+    /// [`Self::method_returns_raw_invocant`], and the difference was measured
+    /// against raku v2026.07 rather than inherited from the ADR text, which
+    /// asserted that both halves of the contract apply to slice 3b too:
+    ///
+    /// ```raku
+    /// class C { method m(\S:)          { S = 7 } }; C.new.m   # raku: 7
+    /// class C { method m($s is raw:)   { $s = 7 } }; C.new.m  # raku: 7
+    /// class C { method m($s:)          { $s = 7 } }; C.new.m  # raku: dies
+    /// ```
+    ///
+    /// No `is raw` on the *routine* anywhere — that trait governs the outbound
+    /// direction (whether the call is an lvalue), which is slice 3a's question.
+    /// Inbound, only the invocant *parameter*'s own rawness matters, so this
+    /// oracle drops the `method_is_rw_capable` conjunct and keeps the
+    /// [`method_def_has_raw_invocant`] one. Both oracles read that same
+    /// predicate, so the two halves cannot disagree about what "raw invocant"
+    /// means.
+    ///
+    /// There is deliberately no native fallback row: no native method mutates
+    /// its invocant through parameter zero (`.snitch`, the one row of
+    /// [`native_method_returns_raw_invocant`], only hands it back).
+    pub(crate) fn method_binds_raw_invocant(
+        &mut self,
+        target: &Value,
+        method: &str,
+        method_args: &[Value],
+    ) -> bool {
+        let class_name = Self::raw_invocant_class_name(target);
+        self.resolve_method(&class_name, method, method_args)
+            .as_ref()
+            .is_some_and(method_def_has_raw_invocant)
     }
 
     /// The class name a method is resolved against for an lvalue invocant.

--- a/src/runtime/registry_method_table.rs
+++ b/src/runtime/registry_method_table.rs
@@ -71,6 +71,18 @@ impl Registry {
     pub(super) fn debug_verify_owner_method_names_index(&self) {
         use std::sync::OnceLock;
         static ENABLED: OnceLock<bool> = OnceLock::new();
+        // The slice 3b mirror must never lag the registry flag: the arrival gate
+        // reads only the mirror, so a `true` here with a `false` there would
+        // silently turn the feature off. Checked unconditionally (one relaxed
+        // atomic load) rather than behind MUTSU_CHECK_METHOD_INDEX, because it
+        // is the invariant that a future writer of `any_raw_invocant_method`
+        // could plausibly break.
+        debug_assert!(
+            !self.any_raw_invocant_method
+                || crate::runtime::raw_invocant::any_raw_invocant_method_possible(),
+            "Registry::any_raw_invocant_method is set but its lock-free mirror is not -- \
+             a writer bypassed note_raw_invocant_methods"
+        );
         if !*ENABLED.get_or_init(|| std::env::var_os("MUTSU_CHECK_METHOD_INDEX").is_some()) {
             return;
         }
@@ -122,6 +134,10 @@ impl Registry {
                 .any(crate::runtime::raw_invocant::method_def_has_raw_invocant)
         {
             self.any_raw_invocant_method = true;
+            // Slice 3b's gate runs on every method call and cannot take the
+            // registry read lock, so it reads a lock-free mirror raised here —
+            // the one writer of both, so they cannot disagree.
+            crate::runtime::raw_invocant::note_any_raw_invocant_method();
         }
     }
 

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -2449,6 +2449,7 @@ impl Interpreter {
             build_attr_writes: std::cell::RefCell::new(Vec::new()),
             defining_class: None,
             pending_call_arg_sources: None,
+            pending_raw_invocant: None,
             pending_call_topic_bare: false,
             require_propagates_missing_module: false,
             pending_call_arg_source_slots: std::collections::HashMap::new(),

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -586,6 +586,7 @@ impl Interpreter {
             build_attr_writes: std::cell::RefCell::new(Vec::new()),
             defining_class: None,
             pending_call_arg_sources: None,
+            pending_raw_invocant: None,
             pending_call_topic_bare: false,
             require_propagates_missing_module: false,
             pending_call_arg_source_slots: std::collections::HashMap::new(),

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -223,6 +223,7 @@ mod vm_native_subst;
 mod vm_native_test;
 mod vm_our_package_vars;
 mod vm_range_int_bounds;
+pub(crate) mod vm_raw_invocant_arrival;
 mod vm_raw_invocant_lvalue;
 mod vm_react_loop;
 mod vm_react_subscriptions;

--- a/src/vm/vm_call_method_mut_ops.rs
+++ b/src/vm/vm_call_method_mut_ops.rs
@@ -464,7 +464,14 @@ impl Interpreter {
         } else {
             // TODO: compile to bytecode — generic mut method fork (ledger §1).
             crate::vm::vm_stats::record_dispatch_entry_outcome("callmethoddynamicmut", "user");
-            self.vm_call_method_mut_with_values(&target_name, target, &method, args)
+            // ADR-0067 slice 3b: the runtime method-name spelling reaches the
+            // same binders, and rawness is only knowable here anyway, so the
+            // arrival channel is armed the same way the statically named
+            // dispatch arms it.
+            let armed = self.arm_raw_invocant_arrival(code, &target_name, &target, &method, &args);
+            let r = self.vm_call_method_mut_with_values(&target_name, target, &method, args);
+            self.disarm_raw_invocant_arrival(armed);
+            r
         };
         match saved_self {
             Some(s) => self.set_env_with_main_alias("self", s),
@@ -2814,9 +2821,11 @@ impl Interpreter {
                             args.len(),
                             false,
                         );
-                        self.try_compiled_method_mut_or_interpret_sym(
+                        self.dispatch_compiled_method_mut_with_raw_invocant(
+                            code,
                             &target_name,
                             target,
+                            &method,
                             method_sym,
                             args,
                         )
@@ -2830,9 +2839,11 @@ impl Interpreter {
                     // resolver's Native candidate against, unlike the genuine
                     // native/user completions above.
                     crate::vm::vm_stats::record_dispatch_entry_outcome("callmethodmut", "user");
-                    self.try_compiled_method_mut_or_interpret_sym(
+                    self.dispatch_compiled_method_mut_with_raw_invocant(
+                        code,
                         &target_name,
                         target,
+                        &method,
                         method_sym,
                         args,
                     )

--- a/src/vm/vm_method_dispatch.rs
+++ b/src/vm/vm_method_dispatch.rs
@@ -578,7 +578,15 @@ impl Interpreter {
                         }
                     }
                 }
-                self.env_mut().insert(param_name.clone(), base.clone());
+                // ADR-0067 slice 3b: a raw invocant parameter binds the
+                // caller's container, not a copy of its contents, so
+                // `method m($s is raw:) { $s = 7 }` writes the caller's
+                // variable. `base` itself stays the plain value — it is what
+                // `self`, the attribute seeding and the dispatch frame use.
+                let invocant_value = self
+                    .take_raw_invocant_arrival(method_name, method_def.param_defs.get(idx))
+                    .unwrap_or_else(|| base.clone());
+                self.env_mut().insert(param_name.clone(), invocant_value);
                 continue;
             }
             bind_params.push(param_name.clone());
@@ -1509,7 +1517,15 @@ impl Interpreter {
                 .map(|pd| pd.is_invocant || pd.traits.iter().any(|t| t == "invocant"))
                 .unwrap_or(false);
             if is_invocant {
-                param_values.push((param_name, base.clone()));
+                // ADR-0067 slice 3b — see the twin in `call_compiled_method`.
+                // Which of the two binders runs is decided by the fast-path
+                // eligibility gate above (`has_rw_params`), and the sigil-less
+                // `\S:` spelling lands here while `$s is raw:` lands there, so
+                // both have to learn the container.
+                let invocant_value = self
+                    .take_raw_invocant_arrival(method_name, pd)
+                    .unwrap_or_else(|| base.clone());
+                param_values.push((param_name, invocant_value));
                 continue;
             }
             if let Some(pd) = pd.filter(|pd| pd.named) {

--- a/src/vm/vm_raw_invocant_arrival.rs
+++ b/src/vm/vm_raw_invocant_arrival.rs
@@ -1,0 +1,156 @@
+//! The VM half of ADR-0067 slice 3b: the invocant *arrives* as a container.
+//!
+//! `class C { method m(\S:) { S = 7 } }; my $c = C.new; $c.m` leaves `$c`
+//! holding `7` in raku, because a raw invocant parameter binds the caller's
+//! Scalar container rather than a copy of its contents. Slice 3a made an
+//! lvalue *call* hand a container back; this is the mirror image, and it shares
+//! no code with it: `$c.m` is an ordinary `CallMethodMut`, whose invocant
+//! travels from the opcode to the parameter binder as a bare `Value`.
+//!
+//! The producer is the same one slice 3a uses
+//! (`capture_lvalue_invocant_cell`), which is the whole point of reusing it:
+//! its route order — an existing frame cell, then an existing env container,
+//! then a direct slot box, and only then a freshly minted cell — is what keeps
+//! a loop parameter's already-promoted element cell from being shadowed by a
+//! second, disconnected one.
+//!
+//! Transport is a single-slot channel rather than a signature change across
+//! `dispatch_compiled_method` / `call_method_with_values`: the invocant reaches
+//! the two binders through two disjoint chains (an `Instance` receiver goes
+//! straight to `call_compiled_method`, while an `augment`ed native receiver
+//! detours through `call_method_mut_with_values` -> `call_method_with_values`
+//! -> `try_dispatch_compiled_method_direct_as`), and only the *first* of those
+//! carries a receiver name at all. The channel is armed immediately before the
+//! dispatch, disarmed immediately after it, and is only consumed by a binder
+//! that both agrees on the method name and is looking at a parameter that
+//! really is a raw invocant — so a nested dispatch that happens in between
+//! (a `where` clause, a multi tie-break) cannot mis-bind it.
+
+use super::*;
+
+/// The container staged for the invocant parameter of the method call the VM is
+/// about to dispatch, and the method name that may consume it.
+pub(crate) struct PendingRawInvocant {
+    pub(crate) method: String,
+    pub(crate) cell: Value,
+}
+
+impl Interpreter {
+    /// Arm the arrival channel for `target.method(args)` when the callee binds
+    /// its invocant raw. Returns whether anything was armed, which the caller
+    /// passes back to [`Self::disarm_raw_invocant_arrival`].
+    ///
+    /// The first test is the registry's set-only pre-filter, against a
+    /// *borrowed* method name and before any allocation: this runs on every
+    /// `$var.method(...)` in the program, and slice 3a measured that the
+    /// argument marshalling a full oracle call needs — not the MRO walk — is
+    /// where such a gate's cost actually lives. A program that declares no
+    /// raw-invocant method anywhere pays one bool load.
+    #[inline]
+    pub(super) fn arm_raw_invocant_arrival(
+        &mut self,
+        code: &CompiledCode,
+        target_name: &str,
+        target: &Value,
+        method: &str,
+        args: &[Value],
+    ) -> bool {
+        if !crate::runtime::raw_invocant::any_raw_invocant_method_possible()
+            || target_name.is_empty()
+        {
+            return false;
+        }
+        self.arm_raw_invocant_arrival_slow(code, target_name, target, method, args)
+    }
+
+    /// The part of [`Self::arm_raw_invocant_arrival`] past the pre-gate, kept
+    /// out of line so the gate itself is a bool load at the call site.
+    fn arm_raw_invocant_arrival_slow(
+        &mut self,
+        code: &CompiledCode,
+        target_name: &str,
+        target: &Value,
+        method: &str,
+        args: &[Value],
+    ) -> bool {
+        if !self.method_binds_raw_invocant(target, method, args) {
+            return false;
+        }
+        let cell = if target.is_container_ref() {
+            // Already a location: whatever produced it (a `:=`-bound alias, a
+            // shared state cell) owns the identity, so hand out that cell
+            // rather than asking for another one — the same
+            // "reuse before minting" rule the producer below encodes.
+            target.clone()
+        } else {
+            // No storage location to hand out (an aggregate variable, an rvalue
+            // receiver) leaves the channel disarmed, so the call behaves exactly
+            // as it does today instead of binding a disconnected cell whose
+            // writes would be silently dropped.
+            let Some(cell) =
+                self.capture_lvalue_invocant_cell(code, target_name, target.clone(), None)
+            else {
+                return false;
+            };
+            cell
+        };
+        self.pending_raw_invocant = Some(Box::new(PendingRawInvocant {
+            method: method.to_string(),
+            cell,
+        }));
+        true
+    }
+
+    /// `try_compiled_method_mut_or_interpret_sym` with the ADR-0067 slice 3b
+    /// arrival channel armed around it. Both of `CallMethodMut`'s user-method
+    /// dispatch sites go through here so the arm/disarm pair can never be
+    /// split; the receiver name the opcode carries is the location the callee
+    /// may write through.
+    pub(super) fn dispatch_compiled_method_mut_with_raw_invocant(
+        &mut self,
+        code: &CompiledCode,
+        target_name: &str,
+        target: Value,
+        method: &str,
+        method_sym: crate::symbol::Symbol,
+        args: Vec<Value>,
+    ) -> Result<Value, RuntimeError> {
+        let armed = self.arm_raw_invocant_arrival(code, target_name, &target, method, &args);
+        let result =
+            self.try_compiled_method_mut_or_interpret_sym(target_name, target, method_sym, args);
+        self.disarm_raw_invocant_arrival(armed);
+        result
+    }
+
+    /// Disarm the channel after the dispatch returns. Unconditional on the
+    /// `armed` path so a callee that never reached a compiled binder (a native
+    /// fallback, an error) cannot leave the cell visible to the next call.
+    #[inline]
+    pub(super) fn disarm_raw_invocant_arrival(&mut self, armed: bool) {
+        if armed {
+            self.pending_raw_invocant = None;
+        }
+    }
+
+    /// The container to bind parameter zero to, for a binder that has reached
+    /// the invocant parameter of `method_name`.
+    ///
+    /// `pd` is re-checked here rather than trusted from the arming side because
+    /// multi-dispatch may land on a different candidate than the one the gate
+    /// resolved: the parameter actually being bound is the authority on whether
+    /// it is raw.
+    pub(crate) fn take_raw_invocant_arrival(
+        &mut self,
+        method_name: &str,
+        pd: Option<&crate::ast::ParamDef>,
+    ) -> Option<Value> {
+        let pending = self.pending_raw_invocant.as_ref()?;
+        if pending.method != method_name {
+            return None;
+        }
+        if !pd.is_some_and(crate::runtime::raw_invocant::param_is_raw_invocant) {
+            return None;
+        }
+        self.pending_raw_invocant.take().map(|p| p.cell)
+    }
+}

--- a/src/vm/vm_raw_invocant_lvalue.rs
+++ b/src/vm/vm_raw_invocant_lvalue.rs
@@ -161,7 +161,11 @@ impl Interpreter {
     /// `capture_var_cell_inner`'s own `is_reference` guard: boxing an
     /// `Array`/`Hash`/`Instance` env entry would produce a cell that disagrees
     /// with the aggregate's own identity-shared storage.
-    fn capture_lvalue_invocant_cell(
+    ///
+    /// Slice 3b (`vm_raw_invocant_arrival.rs`) reuses this same routine for the
+    /// *arrival* direction, so the "reuse an existing location before minting
+    /// one" ordering above is enforced once for both halves.
+    pub(super) fn capture_lvalue_invocant_cell(
         &mut self,
         code: &CompiledCode,
         name: &str,

--- a/t/raw-invocant-arrives-as-container.t
+++ b/t/raw-invocant-arrives-as-container.t
@@ -1,0 +1,171 @@
+use v6.e.PREVIEW;
+use MONKEY-TYPING;
+use Test;
+
+# ADR-0067 slice 3b: a raw invocant parameter binds the CALLER's container, so
+# mutation through it inside the body reaches the caller's variable.
+#
+# The contract measured against raku v2026.07 is that only the invocant
+# PARAMETER's rawness matters here -- `is raw`/`is rw` on the routine governs the
+# outbound (lvalue-return) direction, which is slice 3a's question. So all three
+# raw spellings mutate whether or not the routine is rw-capable, and a plain
+# `$s:` / `C:D $s:` invocant must not.
+#
+# Both compiled-method binders are exercised on purpose: a sigil-less `\S:`
+# invocant keeps the method on the fast binder (`call_compiled_method_fast`),
+# while `$s is raw:` / `$s is rw:` set `binds_caller_container` and route to the
+# slow binder (`call_compiled_method`).
+
+plan 26;
+
+# --- the three raw-invocant spellings, instance receiver -------------------
+{
+    class A1 { method m(\S:) { S = 7 } }
+    my $c = A1.new;
+    $c.m;
+    is $c, 7, 'sigil-less raw invocant reaches the caller (fast binder)';
+}
+{
+    class A2 { method m($s is raw:) { $s = 7 } }
+    my $c = A2.new;
+    $c.m;
+    is $c, 7, '`$s is raw:` invocant reaches the caller (slow binder)';
+}
+{
+    class A3 { method m($s is rw:) { $s = 7 } }
+    my $c = A3.new;
+    $c.m;
+    is $c, 7, '`$s is rw:` invocant reaches the caller (slow binder)';
+}
+
+# --- rw-capability of the ROUTINE is irrelevant to the arrival direction ----
+{
+    class B1 { method m(\S:) is raw { S = 8 } }
+    my $c = B1.new;
+    $c.m;
+    is $c, 8, 'an `is raw` routine with a raw invocant still mutates';
+}
+{
+    class B2 { method m(\S:) is rw { S = 9 } }
+    my $c = B2.new;
+    $c.m;
+    is $c, 9, 'an `is rw` routine with a raw invocant still mutates';
+}
+
+# --- an augmented native type: the invocant is an ordinary Int -------------
+{
+    augment class Int { method mutsuArrInc(\S:) { S = S + 1 } }
+    my $a = 42;
+    $a.mutsuArrInc;
+    is $a, 43, 'augment class Int: a raw invocant writes the scalar';
+    $a.mutsuArrInc;
+    is $a, 44, 'the write is repeatable (the container survives)';
+}
+{
+    augment class Str { method mutsuArrSet(\S:) { S = 'x' } }
+    my $s = 'a';
+    $s.mutsuArrSet;
+    is $s, 'x', 'augment class Str: a raw invocant writes the scalar';
+}
+
+# --- the frame shapes a receiver name can have -----------------------------
+{
+    my @a = 1, 2;
+    for @a <-> $e { $e.mutsuArrInc }
+    is @a.gist, '[2 3]', 'a `<->` loop parameter aliases the element it names';
+}
+{
+    my @a = 5, 6;
+    for @a -> $e is rw { $e.mutsuArrInc }
+    is @a.gist, '[6 7]', 'an `is rw` loop parameter aliases the element it names';
+}
+{
+    my $a = 1;
+    my $f = { $a.mutsuArrInc };
+    $f();
+    is $a, 2, 'a captured-outer scalar written from inside a closure';
+}
+{
+    sub g($x is rw) { $x.mutsuArrInc }
+    my $a = 10;
+    g($a);
+    is $a, 11, 'an `is rw` sub parameter passes its container on';
+}
+{
+    my $a = 3;
+    my $b := $a;
+    $b.mutsuArrInc;
+    is $a, 4, 'a `:=`-bound alias shares the container it was bound to';
+}
+
+# --- candidate selection: multi, role, dynamic name ------------------------
+{
+    class C1 { multi method m(\S: Int $n) { S = $n }; multi method m(\S: Str $t) { S = $t } }
+    my $c = C1.new;
+    $c.m(9);
+    is $c, 9, 'a multi candidate selected by a real argument';
+    my $d = C1.new;
+    $d.m('t');
+    is $d, 't', 'the other multi candidate';
+}
+{
+    role R1 { method m(\S:) { S = 'r' } }
+    class C2 does R1 {}
+    my $c = C2.new;
+    $c.m;
+    is $c, 'r', 'a raw invocant on a composed role method';
+}
+{
+    class C3 { method m(\S:) { S = 'd' } }
+    my $c = C3.new;
+    my $name = 'm';
+    $c."$name"();
+    is $c, 'd', 'the runtime method-name spelling';
+}
+
+# --- the body may read the invocant before writing it ----------------------
+{
+    class D1 { method m(\S:) { my $was = S.^name; S = $was } }
+    my $c = D1.new;
+    $c.m;
+    is $c, 'D1', 'the body observes the invocant before replacing it';
+}
+
+# --- regression controls ---------------------------------------------------
+{
+    # A non-raw invocant must not reach the caller. raku refuses the assignment
+    # outright; mutsu does not (yet) -- what both agree on, and what this pins,
+    # is that the caller's variable is NOT modified.
+    class E1 { method m($s:) { $s = 7 } }
+    my $c = E1.new;
+    try { $c.m };
+    ok $c ~~ E1, 'a plain `$s:` invocant does not reach the caller';
+}
+{
+    class E2 { method m(E2:D $s:) is raw { $s = 7 } }
+    my $c = E2.new;
+    try { $c.m };
+    ok $c ~~ E2, 'a typed non-raw invocant does not reach the caller, even `is raw`';
+}
+{
+    # An ordinary method must keep value semantics for its invocant even though
+    # the program above declares raw-invocant methods (the registry pre-filter
+    # is program-wide, so this is the row that catches a gate that over-fires).
+    class F1 { has $.v is rw; method bump { $!v = $!v + 1; $!v } }
+    my $c = F1.new(v => 1);
+    is $c.bump, 2, 'an ordinary method is unaffected';
+    is $c.v, 2, 'and its attribute write still lands';
+}
+{
+    # A raw-invocant method that only READS is still a plain rvalue call.
+    class G1 { method m(\S:) { S } }
+    my $c = G1.new;
+    my $r = $c.m;
+    ok $r === $c, 'a read-only raw-invocant method returns the invocant';
+    ok $c ~~ G1, 'and leaves the caller alone';
+}
+{
+    my $a = 100;
+    is $a.mutsuArrInc, 101, 'the mutating call returns the assigned value';
+    is $a, 101, 'and the caller sees it';
+}

--- a/todo/tickets/subscript-receiver-raw-invocant-producer.md
+++ b/todo/tickets/subscript-receiver-raw-invocant-producer.md
@@ -1,0 +1,74 @@
+# A subscript receiver does not hand its element's container to a raw invocant
+
+`@a[0].mut` and `%h<a>.mut`, where `mut` declares a raw invocant, must mutate
+the element in raku. mutsu silently does nothing.
+
+```raku
+use v6.e.PREVIEW; use MONKEY-TYPING;
+augment class Int { method mut(\S:) { S = 7 } }
+my @a = 1, 2;  @a[0].mut;  say @a;   # raku: [7 2]   mutsu: [1 2]
+my %h = a => 1; %h<a>.mut; say %h;   # raku: {a => 7} mutsu: {a => 1}
+```
+
+These are rows I3 and K3 of
+[ADR-0067](../../docs/adr/0067-a-routine-hands-back-the-container-it-was-given.md).
+Slice 3b made the *arrival* direction work — a raw invocant parameter now binds
+the caller's container — but only for a receiver the call site can name.
+
+## Root cause: `CallMethod` has no receiver location, and `Index` already read
+## the value out
+
+`--dump-bytecode` on `@a[0].mut`:
+
+```
+GetArrayVar(4); LoadConst(0); Index { is_positional: true }
+CallMethod { name_idx: 3, arity: 0, modifier_idx: None, quoted: false, arg_sources_idx: None }
+```
+
+Two things follow. `CallMethod` carries no `target_name_idx` (only
+`CallMethodMut` does), so slice 3b's arrival gate — which boxes the *named*
+receiver's location with `capture_lvalue_invocant_cell` — has nothing to box.
+And the `Index` op has already read the element's value onto the stack, so by
+the time the method call runs there is no location left on it either.
+
+The missing piece is a **producer**: the subscript must hand over the element's
+own `Scalar` container rather than its value. The primitive exists —
+`Value::array_slot_ref(i, true)` promotes an element to a shared cell in place
+and idempotently (`vm_element_producers.rs` uses it for `.pairs`/`.values`/
+`.Seq`), and the hash side has `HashEntryRef`.
+
+## Why this is not a one-line change
+
+Rawness is not statically known: `@a[0].mut`'s callee depends on the element's
+runtime type and, for the dynamic spelling, on a runtime method-name string. So
+whatever produces the container has to be emitted **unconditionally** for every
+`<subscript>.method(...)` in every program — one of the most common shapes there
+is — and then made invisible again at the consumer:
+
+- Whatever `CallMethod` receives has to be decontainerized at a single
+  chokepoint unless the resolved callee binds its invocant raw, or a
+  `ContainerRef` leaks into every native and user method that matches
+  `Instance`/`Array`/`Hash` on its invocant. This is the same hazard slice 3a
+  had to solve at its own site (see the ADR's "One guard the boxing required").
+- The gate cannot be the compiler's, so the runtime cost lands on a hot path
+  and must be A/B measured the way slice 3a's and 3b's were. Slice 3b's
+  process-global `any_raw_invocant_method_possible()` mirror is the right
+  pre-gate to reuse.
+- The JIT compiles `Index` and shims `CallMethod`, so whatever shape is chosen
+  must behave identically under `MUTSU_JIT=on` — a producer that only fires in
+  the interpreter would make the feature switch off once a loop goes hot, which
+  is worse than not having it.
+
+## Sibling
+
+The attribute-accessor receiver (`$d.v.mut`, ADR-0067 row N1 / E6) is the same
+missing-producer problem with a different producer (`MarkAccessorRefContext`),
+and is tracked with slice 3a's E6 row. If both are done, they should probably
+share the decontainerize chokepoint rather than each adding their own.
+
+## Repro / pin
+
+`t/raw-invocant-arrives-as-container.t` covers the shapes that do work. The two
+programs at the top of this file are the repro; both are *silently* wrong today
+(exit 0, no diagnostic), which is what they were before slice 3b too — this
+ticket is a missing capability, not a regression.


### PR DESCRIPTION
ADR-0067 slice 3b — the **arrival** half of "a routine hands back the container it was *given*".

```raku
class C { method m(\S:) { S = 7 } }
my $c = C.new; $c.m; say $c;   # raku: 7   mutsu before: C.new   mutsu now: 7
```

A raw invocant parameter binds the caller's Scalar container rather than a copy of its contents. Slice 3a made an lvalue *call* hand a container back; this is the mirror image. The invocant travelled from the method-call opcode to the parameter binder as a bare `Value`, so parameter zero was always bound to `base.clone()` no matter how it was declared.

## What the ADR got wrong (measured before writing any code)

Every I/E/F/G row was re-measured against raku v2026.07 and a debug `mutsu` from `main`, plus a new L/M/N/O/Q/R/S family built to find the edges. Two of the ADR's own claims about 3b did not survive.

**1. `is raw` on the *routine* is not part of this contract.** The ADR carried slice 3a's rule forward and made `E1`/`E2` regression controls for both halves. That conjunction is the *outbound* contract only:

| Program | raku |
|---|---|
| `class C { method m(\S:) { S = 7 } }; C.new.m` | `7` |
| `method m($s is raw:) { $s = 7 }` | `7` |
| `method m($s is rw:) { $s = 7 }` | `7` |
| `method m($s:) { $s = 7 }` | dies |
| `method m(C $s:) { $s = 7 }` | dies |

No routine trait anywhere in the three that mutate. `is raw`/`is rw` on a routine answers "is this call an lvalue"; rawness of the invocant *parameter* answers "does the body's write reach the caller". So the shipped oracle `method_binds_raw_invocant` is slice 3a's resolve with the rw-capability conjunct dropped — both still read the one `method_def_has_raw_invocant` predicate, so they cannot disagree about what "raw invocant" means. `E1`/`E2` stay slice 3a's controls; the new `L4`/`L5` rows are 3b's.

**2. The recorded call chain was one of two, and the predicted transport was not viable.** Re-traced under `rust-gdb`:

```
$c.m (Instance receiver):
  exec_call_method_mut_op_impl        target_name = "c"
    -> try_compiled_method_mut_or_interpret_sym
      -> call_compiled_method       (slow binder, `$s is raw:`)
        -> call_compiled_method_fast (fast binder, `\S:`)

$a.mut (`augment class Int` receiver):
  exec_call_method_mut_op_impl        target_name = "a"
    -> try_compiled_method_mut_or_interpret_sym
      -> vm_call_method_mut_with_values -> call_method_mut_with_values
        -> call_method_with_values -> call_method_with_values_inner
          -> try_dispatch_compiled_method_direct_as -> dispatch_compiled_method
            -> call_compiled_method -> call_compiled_method_fast
```

The second runs through `call_method_with_values`, which is called from ~everywhere and carries no source channel — so "a signature change across that whole chain" was far wider than the ADR thought. What both chains share is their single origin, the `CallMethodMut` opcode, which is also the only place that knows the receiver's source name. Transport is therefore a **one-slot channel** armed there and consumed at the binder, disarmed immediately after the dispatch, and consumed only by a binder that agrees on the method name *and* is looking at a `ParamDef` that really is a raw invocant — which also makes the actually-bound candidate the authority when multi-dispatch lands somewhere the gate did not.

The ADR *was* right that both binders must learn it, and which is which: `binds_caller_container()` sends `$s is raw:`/`$s is rw:` to the slow binder while its own `!pd.is_invocant` sends sigil-less `\S:` to the fast one. The pin exercises both spellings for exactly that reason.

## No new producer, no new consumer

The container comes from slice 3a's `capture_lvalue_invocant_cell`, reused verbatim — the point being its route order (existing frame cell → existing env container → direct slot box → minted cell), which is what makes `for @a <-> $e { $e.m }` and `for @a -> $e is rw { $e.m }` bind the element's *already promoted* cell instead of shadowing it. Both pinned.

Write-through is the existing one too: a local slot holding a `ContainerRef` already stores through the cell and `GetLocal` already derefs one. No writeback path, no new opcode. Only the *parameter* is boxed — `base` stays the plain value, so `self`, attribute seeding and every downstream `Instance`/`Array`/`Hash` branch see exactly what they saw before, and slice 3a's "boxing every invocant would silently skip ~40 branches" hazard does not arise.

## Cost

The gate runs on **every** `$var.method(...)`, an order of magnitude more traffic than slice 3a's `$obj.attr = v`, so slice 3a's `self.registry().any_raw_invocant_method` pre-filter — an `RwLock` read acquisition — was not affordable. The flag is mirrored into a process-global, set-only `AtomicBool` raised by the *same single writer* (`Registry::note_raw_invocant_methods`), the pattern `env.rs`'s `CLOSURE_META_KEY_SEEN` already uses, with a `debug_assert` in `debug_verify_owner_method_names_index` that fails the debug `t/` suite if a future writer bypasses it. A program declaring no raw-invocant method pays one relaxed atomic load per method call.

Same-binary env-switch A/B on a release build (a temporary `MUTSU_SKIP_RAW_INVOCANT_ARRIVAL` short-circuit, removed before commit), 4M `$p.bump` calls on a `has $.x is rw` class, `taskset -c 2`, min of 11:

| | gate ON | gate SKIP |
|---|---|---|
| round 1 | **15.15s** | 15.49s |
| round 2 | **16.88s** | 17.14s |

The gate is *faster* both times, which is how "below the noise floor" looks — the sign is meaningless and the between-round drift dwarfs the difference. Slice 3a's un-filtered gate showed a clean, repeatable +13% on this same harness, so it does surface a real cost when there is one.

## Still refusing / still wrong, all measured, all unchanged rather than newly wrong

- **`@a[0].m` / `%h<a>.m` (ADR rows I3/K3)** — the rows the ADR named as 3b acceptance, and **not reachable from this mechanism**. `--dump-bytecode` shows `GetArrayVar; LoadConst; Index; CallMethod`: a plain `CallMethod` carries no `target_name_idx`, and `Index` has already read the element's value off the array, so there is neither a name to box nor a location on the stack. What it needs is a *producer*, and emitting one is an unconditional compile-side change to a very common shape that must be paired with a decontainerize chokepoint and re-measured (including under the JIT, which compiles `Index` and shims `CallMethod`). Split out as `todo/tickets/subscript-receiver-raw-invocant-producer.md`. Silently wrong before this PR, silently wrong after — not a regression.
- **`$d.v.m`** — same missing-producer problem, belongs to slice 3a's E6 row (`MarkAccessorRefContext`), which another agent is working on. Untouched here.
- **`@a.m` (aggregate receiver)** — `capture_lvalue_invocant_cell` declines every route for an `@`/`%` name by design, because a cell over an aggregate would disagree with its identity-shared storage.
- **`method m($s:) { $s = 7 }` / `42.m`** — raku dies; mutsu silently drops the write. A readonly-parameter enforcement gap, not an arrival gap: the gate correctly declines, and the *observable* half (the caller's variable is not modified) already matches, which is what the pin asserts.

## Verification

- `t/raw-invocant-arrives-as-container.t` — **26 tests, byte-identical output under `mutsu` and `raku`**: three raw spellings over both compiled binders, routine-rw-capability independence, `augment class Int`/`Str` with a repeated mutation proving the container survives, every frame shape a receiver name can have (`<->` and `is rw` loop parameters, a captured-outer scalar written from a closure, an `is rw` sub parameter, a `:=`-bound alias), `multi` candidate selection, role composition, the runtime method-name spelling, a body that reads before writing, and five regression rows including an ordinary method that must keep value semantics with the program-wide pre-filter on.
- `make test` — **PASS**, 3699 files / 37838 tests.
- Targeted roast sweep of the areas this touches — all whitelisted `S12-*`, `S06-*`, `S03-*` plus every whitelisted file mentioning `is raw`/`is rw`: **365 files, 32483 tests, PASS**.
- Battery gate (`scripts/battery-testsuite.sh` on the release binary): **GATE PASSED**, 289/312.
- `cargo fmt`, `cargo clippy -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
