### PR TITLE
feat(vm): an lvalue method call's invocant can be an rw attribute accessor

### DIFF
--- a/docs/adr/0067-a-routine-hands-back-the-container-it-was-given.md
+++ b/docs/adr/0067-a-routine-hands-back-the-container-it-was-given.md
@@ -1,12 +1,12 @@
 # ADR-0067: A routine hands back the container it was *given* — raw arguments, raw invocants, and the subscript step through an object
 
 - Status: Proposed (Slices 1, 2, 3a, 4 and 5 implemented 2026-09-05, Slice 3b
-  2026-09-06; Slice 3 was re-scoped into 3a/3b on 2026-09-05 after measurement,
-  and 3a's E6 row split off again into the rw-attribute-accessor producer;
-  Slice 4 absorbed two of Slice 5's three acceptance rows, again after
-  measurement; Slice 3b shipped the *named-receiver* half of the arrival
-  direction and split its subscript-receiver rows (I3/K3) off into a producer
-  slice of their own; the E6 producer and that subscript producer remain open)
+  and the E6 rw-attribute-accessor producer 2026-09-06; Slice 3 was re-scoped
+  into 3a/3b on 2026-09-05 after measurement, and 3a's E6 row split off again
+  into that producer; Slice 4 absorbed two of Slice 5's three acceptance rows,
+  again after measurement; Slice 3b shipped the *named-receiver* half of the
+  arrival direction and split its subscript-receiver rows (I3/K3) off into a
+  producer slice of their own, which is the only slice still open)
 - Date: 2026-09-05
 - Related: [ADR-0059](0059-is-rw-routines-return-a-container.md) (an `is rw`
   routine returns a container), [ADR-0036](0036-element-container-pairs-from-subscripts-and-pairs.md)
@@ -640,6 +640,16 @@ slice. The mutation discriminator, not `.VAR`, is what settled this: `$c.v`
 produces a container for a `:=` bind but not in argument position
 (`sub g($y is rw) {...}; g($c.v)` dies with "expects a writable container").
 
+> **Correction (2026-09-06, from the E6 producer's own re-measurement).** That
+> last parenthesis attributes **mutsu's** diagnostic to raku. raku answers `9`
+> for `sub g($y is rw) { $y = 9 }; g($c.v)`; it is mutsu that dies with
+> "expects a writable container". The conclusion the row was cited for — that
+> E6 is a producer question and `.VAR` is not the discriminator — is unaffected,
+> but argument position is a *third* consumer that is still broken, and its
+> `is raw` twin (`sub f(\x) is raw { x }; f($c.v) = 9`) is **silently wrong**
+> (`42` where raku says `9`), not merely a copy as the non-goals section says.
+> Recorded as `todo/tickets/attribute-accessor-container-lost-in-argument-position.md`.
+
 **Also still refusing after 3a, all loudly (not silently wrong), all out of
 scope:** `@a.snitch = (7,8)` and `%h.snitch = (b=>2)` (aggregate invocants —
 route 4's scalar restriction declines them), `$a.list = 5` (list assignment, see
@@ -823,6 +833,137 @@ before replacing it, and five regression rows — the two non-raw invocant
 controls, an ordinary method whose value semantics must survive the
 program-wide pre-filter being on, and a read-only raw-invocant method that
 must stay a plain rvalue call.
+
+#### The E6 producer — IMPLEMENTED 2026-09-06
+
+The slice 3a paragraph above split this row off with a prescription: emit
+`MarkAccessorRefContext` before an lvalue invocant, pair it with the
+decontainerize chokepoint, re-measure every `$obj.acc.m = v` shape. Every row of
+the Correction-3 and slice-3a tables plus a fresh 29-row `$obj.acc.m = v` survey
+was re-measured against raku v2026.07 and a debug `mutsu` built from `main` at
+`30d6754f5` before any code was written. The prescription held; two things
+around it did not.
+
+**What shipped.**
+
+- **The emission** (`Compiler::lvalue_invocant_wants_accessor_ref`,
+  `src/compiler/expr_call.rs`), in the generic `CallFunc` argument loop: when a
+  `__mutsu_assign_method_lvalue` call's argument 0 is an argument-less,
+  unmodified, unquoted `Expr::MethodCall`, insert the marker before that call's
+  trailing `CallMethod`/`CallMethodMut`. The insertion helper is slice 4's
+  existing `mark_trailing_method_call_as_accessor_ref`, refactored to take the
+  marker so both spellings share one site.
+- **The op is `MarkLvalueInvocantRefContext`, not `MarkAccessorRefContext`** —
+  a *runtime-gated* twin. See the cost note below for why. It sets the same
+  `accessor_ref_pending` flag, deliberately: the consumer
+  (`try_fast_accessor_read`'s `want_ref` branch) must stay one code path, or the
+  container a `:=` bind gets and the container an lvalue invocant gets could
+  drift apart.
+- **No new consumer.** Slice 3a's `try_raw_invocant_container_lvalue` already
+  writes through a `ContainerRef` invocant, and its gate
+  (`box_raw_lvalue_invocant`) already returns early when `args[0]` is one, so
+  the container is neither double-boxed nor re-derived. This is part 4 of the
+  ADR working exactly as claimed: three producers now, one consumer.
+
+**The narrowness is in the consumer, not the emission — which is what makes an
+unconditional compile-side change safe.** Rawness is not statically known, so
+the marker is emitted for every `$obj.acc.m = v`. But
+`try_fast_accessor_read` hands back a container only for a zero-argument read of
+a **public `is rw` scalar** attribute accessor (`rw_accessor_type_constraint`
+is `Some` only for those, and `Array`/`Hash`/`Mixin` values are excluded), and
+ignores the flag entirely otherwise. Verified with `--dump-bytecode`:
+`benchmarks/method-call.raku`, `benchmarks/bench-class.raku` and a
+`$p.x = $i` loop compile **byte-identically** with and without the change.
+
+**Slice 3a's "single chokepoint" claim was not actually true, and E6 is what
+exposed it.** 3a records that the target is decontainerized "at a single
+chokepoint right after the branch declines", which "keeps the boxing invisible
+to the other ~40 branches". One `Instance`-matching branch sat *above* it: the
+IO::Path `.SPEC`/`.CWD` read-only guard. With a container invocant
+(`class C { has IO::Path $.p is rw }; $c.p.SPEC = 5`) it stopped matching and the
+diagnostic degraded from `Cannot modify an immutable IO::Spec::Unix
+((IO::Spec::Unix))` to a bare `No matching candidates for method: SPEC`. The
+guard now sits **below** the chokepoint, where the ADR's own rule always said it
+belonged; neither branch above it cares (the type-object half requires a
+`Package`, the raw-invocant half requires a raw-invocant declaration, and
+`.SPEC` is neither).
+
+**A cost that was measured, and designed out rather than paid — in three
+steps, each of which the previous step's measurement forced.** All numbers are
+same-binary env-switch A/B on a release build (comparing two binaries is not
+reliable), min-of-N with the two arms **interleaved** so load drift hits both.
+
+1. **The plain `MarkAccessorRefContext` cost ~14%** on a tight `$o.i.w = $n`
+   loop (`class I { has $.w is rw }; class O { has $.i is rw }`). The extra
+   opcode is not the cost: the `want_ref` branch runs
+   `rw_accessor_type_constraint` (a `collect_class_attributes` plus an MRO walk)
+   and `promote_attr_to_container` on every iteration, to mint a container the
+   chokepoint then throws away because `.w` is not raw.
+2. **A name-blind gate was not enough, and cost a heap allocation.** Gating on
+   "could *any* callee be raw" (`Registry::any_raw_invocant_method` plus the
+   native table) fixed the 6.d case but left 6.e paying the full price, because
+   the native `snitch` row exists there for every method name. Worse, asking the
+   native table called `current_language_version()`, which **clones a `String`**
+   — a heap allocation per iteration, measured at ~29%. That is now
+   `current_language_version_starts_with`, a non-allocating prefix check on the
+   same thread-local.
+3. **The gate carries the outer method's name**, which the compiler does know in
+   every spelling but the dynamic one. The runtime test is then
+   character-for-character slice 3a's own filter
+   (`native_method_returns_raw_invocant(name) || any_raw_invocant_method`),
+   evaluated one op earlier, and `$o.i.w = $n` declines even under 6.e —
+   confirmed under `rust-gdb` by breaking on the flag-setting line and observing
+   it never fire.
+
+**Final numbers** (min of 15 interleaved pairs, on a box under sibling load):
+`$o.i.w = $n` under 6.e **+1.9%**, the same loop under 6.d **-4.4%**. The noise
+floor is calibrated by the control: `$p.x = $i` compiles **byte-identically** in
+both arms (`--dump-bytecode` diff, as do `benchmarks/method-call.raku` and
+`benchmarks/bench-class.raku`) and still measured **+6.3%**, so both figures are
+inside the noise. `method-call.raku` and `bench-class.raku` measured 0.0%.
+
+**What went green.** E6 itself (`$c.v.snitch = 9` -> `42` then `9`), its typed,
+`Str`-valued, unset, inherited, role-composed and `self`-rooted twins, the
+depth-2 accessor chain (`$o.i.w.snitch = 9`), and the *user*-declared
+raw-invocant callees over the same producer — all three rw-capable spellings
+(`is raw`, `is rw`, `return-rw`) reached through `augment class Any`.
+
+**Still refusing after the E6 producer, all loudly, all measured:** the three
+contract controls (a non-rw attribute accessor, a raw-invocant routine that is
+not rw-capable, and an rw-capable routine whose invocant is not raw) plus a
+raw-invocant body that returns a value rather than a location; `.self` over a
+container invocant (an ADR non-goal); a computed invocant
+(`method thing { 42 }`); `$c.a[0].snitch = 9` (an lvalue invocant that is an
+*element* of an attribute-held array, whose compiled tail is `Index`, not a
+method call, so no marker is inserted); and everything slice 3a already listed.
+
+**Two rows the ADR's tables did not contain, both recorded rather than fixed:**
+
+- An `is rw` **method** (not an attribute accessor) as the lvalue invocant —
+  `class C { has $.v is rw; method acc is rw { $!v } }; $c.acc.snitch = 9` — is
+  out of reach, because `try_fast_accessor_read` bails as soon as the name
+  resolves to a `UserMethod` rather than an `Accessor`. The `:=` spelling of the
+  same read is broken too (`my $x := $c.acc` dies), so this is a missing
+  producer, not a missing consumer:
+  `todo/tickets/rw-method-result-is-not-a-container-for-bind-or-invocant.md`.
+- Argument position is a third consumer that still loses the container, and its
+  `is raw` twin is **silently wrong**:
+  `todo/tickets/attribute-accessor-container-lost-in-argument-position.md`. This
+  is also where slice 3a's discriminator row was misattributed — see the
+  correction note above.
+
+**Pinned by** `t/lvalue-invocant-attribute-accessor-container.t` (25 tests) and
+`t/lvalue-invocant-user-raw-method.t` (8 tests), both byte-identical under
+`mutsu` and `raku`. `.snitch` is given an explicit snitcher throughout so the
+observation lands in a variable rather than on stderr, which keeps the
+comparison over stdout alone. Between them they cover every green row above, the
+six controls, the runtime method-name spelling (the one shape whose marker
+carries no name, so its gate must pass), and the shapes that had to stay
+untouched: the plain `$c.v = 9`
+store, the `:=` bind producer, an rvalue accessor read still copying, a nested
+non-rw attribute store (and the object still rendering as itself, since the
+producer promotes attribute slots to shared cells), array- and hash-valued
+attribute element stores, and an argument-carrying rw accessor invocant.
 
 ### Slice 4 — the chain walk steps through an object
 

--- a/news/2026-09/lvalue-invocant-attribute-accessor-container.md
+++ b/news/2026-09/lvalue-invocant-attribute-accessor-container.md
@@ -1,0 +1,82 @@
+# An lvalue method call's invocant can now be an rw attribute accessor
+
+ADR-0067's E6 row is closed. `class C { has $.v is rw }; my $c = C.new(v => 42);
+$c.v.snitch = 9` now writes `9` into `$c.v`, matching raku; before this it died
+with `X::Assignment::RO: cannot assign through .snitch on non-instance`.
+
+## What was actually missing
+
+Nothing about the write. ADR-0067's slice 3a already made a raw invocant arrive
+as a container and taught `assign_method_lvalue_with_values` to write through it,
+and ADR-0059's `assign_lvalue_container` has always been the one consumer. What
+E6 lacked was a **producer**: an invocant that is itself a method call was
+compiled as an ordinary rvalue read, so the attribute's Scalar never reached the
+call. mutsu already had the producer for exactly that container — the
+`MarkAccessorRefContext` marker that makes `my $x := $c.v; $x = 9` write through
+today — it was simply never emitted before an lvalue invocant.
+
+So the change is one insertion in the compiler: when a
+`__mutsu_assign_method_lvalue` call's argument 0 is an argument-less method
+call, mark that call as wanting a container. Three producers now feed the single
+consumer ADR-0059 built, which is the shape the ADR predicted for its "one rule,
+four mechanical parts".
+
+## Why an unconditional emission is safe
+
+Rawness is not statically known — `$a.snitch`'s callee depends on `$a`'s runtime
+type, and for the dynamic spellings on a runtime method-name string — so the
+marker goes out for *every* `$obj.acc.m = v`. The narrowness lives in the
+consumer instead: `try_fast_accessor_read` hands back a container only for a
+zero-argument read of a public `is rw` **scalar** attribute accessor, and
+ignores the flag entirely otherwise. `--dump-bytecode` confirms that
+`benchmarks/method-call.raku`, `benchmarks/bench-class.raku` and a `$p.x = $i`
+loop compile byte-identically with and without the change.
+
+## Two things measurement changed
+
+**Slice 3a's "single chokepoint" was not single.** 3a decontainerizes the target
+at one point right after the raw-invocant branch declines, so that the ~40
+`Instance`/`Array`/`Hash` branches below it keep seeing plain values. One such
+branch sat *above* it — the IO::Path `.SPEC`/`.CWD` read-only guard — and with a
+container invocant (`class C { has IO::Path $.p is rw }; $c.p.SPEC = 5`) its
+diagnostic degraded to a bare `No matching candidates for method: SPEC`. It now
+sits below the chokepoint, where the rule always said it belonged.
+
+**The marker had to become a runtime-gated op, and it took three measurements
+to get the gate right.** Emitting the plain `MarkAccessorRefContext` cost ~14%
+on a tight `$o.i.w = $n` loop, because the container-producing branch runs an
+MRO walk and promotes the attribute slot on every iteration to mint a container
+the chokepoint then discards (`.w` is not raw). Gating on "could *any* callee be
+raw" fixed 6.d but not 6.e, where the native `snitch` row exists for every
+method name — and asking that question called `current_language_version()`,
+which clones a `String`, so it cost ~29% in heap allocation alone (there is now
+a non-allocating `current_language_version_starts_with`). The shipped
+`MarkLvalueInvocantRefContext` therefore carries the *outer* method's name,
+which the compiler knows in every spelling but the dynamic one, making the
+runtime test character-for-character slice 3a's own filter one op earlier.
+
+Final same-binary env-switch A/B on a release build, min of 15 interleaved
+pairs: `$o.i.w = $n` is +1.9% under 6.e and −4.4% under 6.d. Both are inside the
+noise floor, which the control calibrates directly — `$p.x = $i` compiles
+byte-identically in both arms and still measured +6.3%. `method-call.raku` and
+`bench-class.raku` measured 0.0%.
+
+## What still refuses, and what it turned up
+
+Every control still dies loudly and with an unchanged message: a non-rw
+attribute accessor, a raw-invocant routine that is not rw-capable, an rw-capable
+routine whose invocant is not raw, a raw-invocant body that returns a value
+rather than a location, `.self` (an ADR non-goal), and a computed invocant.
+
+Two divergences the ADR's tables did not contain were measured and recorded as
+tickets rather than folded in: an `is rw` **method** (as opposed to an attribute
+accessor) still produces no container for a `:=` bind or an lvalue invocant, and
+argument position still loses the container — where the `is raw` twin
+(`sub f(\x) is raw { x }; f($c.v) = 9`) is *silently* wrong rather than a
+refusal. The second of those also corrects a row in ADR-0067 itself, which cited
+`sub g($y is rw) {...}; g($c.v)` as raku dying with "expects a writable
+container": that is mutsu's diagnostic, not raku's — raku answers `9`.
+
+Pinned by `t/lvalue-invocant-attribute-accessor-container.t` (25 tests) and
+`t/lvalue-invocant-user-raw-method.t` (8 tests), both byte-identical under
+`mutsu` and `raku`.

--- a/src/compiler/expr_call.rs
+++ b/src/compiler/expr_call.rs
@@ -55,6 +55,68 @@ impl Compiler {
         }
     }
 
+    /// ADR-0067, the E6 producer: does this `__mutsu_assign_method_lvalue` call
+    /// have an INVOCANT that must arrive as the attribute's container rather
+    /// than as a copy of its value?
+    ///
+    /// `class C { has $.v is rw }; $c.v.snitch = 9` writes `9` into `$c.v` in
+    /// raku, because `.snitch` binds its invocant raw and `$c.v` names the
+    /// attribute's Scalar. mutsu's producer for that container already exists —
+    /// `MarkAccessorRefContext`, which is what makes `my $x := $c.v; $x = 9`
+    /// write through — it was simply never emitted before an lvalue invocant.
+    ///
+    /// Unlike slice 3a's runtime gate, this cannot ask whether the *callee*
+    /// binds its invocant raw: `$a.snitch`'s callee depends on `$a`'s runtime
+    /// type and, for the dynamic spellings, on a runtime method-name string. So
+    /// the emission is decided by the *invocant's* shape alone. Two things keep
+    /// it narrow anyway. The marker's only consumer, `try_fast_accessor_read`,
+    /// hands back a container just for a zero-argument read of a **public
+    /// `is rw` scalar** attribute accessor and ignores the flag entirely
+    /// otherwise — so every other invocant shape behaves exactly as before, and
+    /// a program with no such accessor at all compiles to bytecode that differs
+    /// only by this one marker. And the op emitted is the *gated*
+    /// `MarkLvalueInvocantRefContext`, which carries the OUTER method's name
+    /// (below) so the VM can decline the flag outright when no callee of that
+    /// name could be raw — see that opcode's doc comment.
+    ///
+    /// A `ContainerRef` invocant is then absorbed by the chokepoint slice 3a
+    /// installed in `assign_method_lvalue_with_values`, which decontainerizes
+    /// as soon as the raw-invocant branch declines — so the ~40 `Instance` /
+    /// `Array` / `Hash` branches below it keep seeing exactly what they saw.
+    ///
+    /// Restricted to an argument-less, unmodified, unquoted method call because
+    /// that is precisely what `try_fast_accessor_read` accepts; marking any
+    /// other spelling would be inert, and saying so here keeps the compile-side
+    /// intent readable rather than leaning on a distant runtime bail-out.
+    ///
+    /// Answers `None` when no marker is wanted. `Some(name)` carries the OUTER
+    /// method's name for the VM's gate — `Some(None)` when that name is only
+    /// computed at run time (`$c.v."$name"() = 9`), which the gate must let
+    /// through.
+    fn lvalue_invocant_wants_accessor_ref(name: Symbol, args: &[Expr]) -> Option<Option<String>> {
+        if name.resolve() != "__mutsu_assign_method_lvalue" || args.len() < 4 {
+            return None;
+        }
+        if !matches!(
+            &args[0],
+            Expr::MethodCall {
+                args: invocant_args,
+                modifier: None,
+                quoted: false,
+                ..
+            } if invocant_args.is_empty()
+        ) {
+            return None;
+        }
+        Some(match &args[1] {
+            Expr::Literal(lit) => match lit.view() {
+                crate::value::ValueView::Str(s) => Some(s.to_string()),
+                _ => None,
+            },
+            _ => None,
+        })
+    }
+
     pub(super) fn emit_wrap_var_ref(&mut self, name: &str) {
         let name_idx = self.code.add_constant(Value::str(name.to_string()));
         let slot = self.local_map.get(name).copied().unwrap_or(u32::MAX);
@@ -1696,6 +1758,11 @@ impl Compiler {
                     && Self::is_bare_block_arg(&args[0])
                     && args[1..].iter().all(Self::for_iterable_yields_bare_items);
                 let wb_base = self.index_rw_writeback_base();
+                // ADR-0067, the E6 producer: an lvalue method call whose
+                // INVOCANT is itself a bare attribute-accessor read
+                // (`$c.v.snitch = 9`) must hand the callee the attribute's
+                // container, not a copy of its value.
+                let accessor_ref_invocant = Self::lvalue_invocant_wants_accessor_ref(*name, args);
                 for (i, arg) in args.iter().enumerate() {
                     // `start` keeps marking EVERY argument escaping, exactly as
                     // before; other calls mark only a closure literal.
@@ -1731,6 +1798,13 @@ impl Compiler {
                             s.compile_call_arg_with_escape(arg, escaping_args)
                         });
                         self.pending_immutable_topic_block = false;
+                        if i == 0
+                            && let Some(outer_method) = accessor_ref_invocant.as_ref()
+                        {
+                            self.mark_trailing_method_call_as_lvalue_invocant_ref(
+                                outer_method.as_deref(),
+                            );
+                        }
                     }
                 }
                 let name_idx = self.code.add_constant(Value::str(name.resolve()));

--- a/src/compiler/helpers_call_args.rs
+++ b/src/compiler/helpers_call_args.rs
@@ -575,6 +575,26 @@ impl Compiler {
     /// index now lands on the marker and falls through to the same call.
     /// No-op when the compiled tail is not a method call.
     pub(super) fn mark_trailing_method_call_as_accessor_ref(&mut self) {
+        self.insert_accessor_ref_marker(OpCode::MarkAccessorRefContext);
+    }
+
+    /// The same insertion, with the runtime-gated marker
+    /// (`MarkLvalueInvocantRefContext`) ADR-0067's E6 producer emits before an
+    /// lvalue method call's *invocant*. `method_name` is the OUTER method's
+    /// name — the one whose invocant this is — when it is a compile-time
+    /// literal, and `None` for the dynamic spelling. See that opcode's doc
+    /// comment: the compiler cannot know whether that callee binds its invocant
+    /// raw, so the marker is emitted for every `$obj.acc.m = v` and the VM
+    /// declines it unless a raw-invocant callee is possible for that name.
+    pub(super) fn mark_trailing_method_call_as_lvalue_invocant_ref(
+        &mut self,
+        method_name: Option<&str>,
+    ) {
+        let idx = method_name.map(|n| self.code.add_constant(Value::str(n.to_string())));
+        self.insert_accessor_ref_marker(OpCode::MarkLvalueInvocantRefContext(idx));
+    }
+
+    fn insert_accessor_ref_marker(&mut self, marker: OpCode) {
         let mut i = self.code.ops.len();
         while i > 0 {
             match &self.code.ops[i - 1] {
@@ -583,7 +603,7 @@ impl Compiler {
                     // Keep the ip -> line table (`op_lines`) aligned with `ops`:
                     // the marker inherits the call's line.
                     let line = self.code.op_lines[i - 1];
-                    self.code.ops.insert(i - 1, OpCode::MarkAccessorRefContext);
+                    self.code.ops.insert(i - 1, marker);
                     self.code.op_lines.insert(i - 1, line);
                     return;
                 }

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -956,6 +956,41 @@ pub(crate) enum OpCode {
     /// identity. Consumed (and unconditionally cleared) at CallMethod entry, so
     /// it cannot leak past the one dispatch it was emitted for.
     MarkAccessorRefContext,
+    /// ADR-0067, the E6 producer: [`Self::MarkAccessorRefContext`] emitted
+    /// before the *invocant* of an lvalue method call (`$c.v.snitch = 9`), and
+    /// honoured only when the program could actually have a raw-invocant
+    /// callee.
+    ///
+    /// The compiler cannot decide that: rawness depends on the invocant's
+    /// runtime type and, for the dynamic spellings, on a runtime method-name
+    /// string, so the marker is emitted for every `$obj.acc.m = v`. But the
+    /// container it asks for is *only* consumed when the callee binds parameter
+    /// zero raw, and slice 3a already maintains exactly that question as its VM
+    /// gate's pre-filter — a set-only registration flag
+    /// (`Registry::any_raw_invocant_method`, read through slice 3b's lock-free
+    /// mirror `any_raw_invocant_method_possible`) or/ed with the native
+    /// raw-invocant table, keyed by the method's name. This op asks the same
+    /// pair before setting the flag (see the operand below), so an lvalue
+    /// invocant whose callee cannot be raw pays one predicate instead of an
+    /// attribute-slot promotion plus an MRO walk per iteration. Measured: on a
+    /// tight `$o.i.w = $n` loop the ungated marker cost ~14%; gated it is
+    /// within noise of not emitting it at all.
+    ///
+    /// Sharing `MarkAccessorRefContext`'s flag rather than adding a second one
+    /// is deliberate — the *consumer* (`try_fast_accessor_read`'s `want_ref`
+    /// branch) must stay one code path, or the container the `:=` bind gets and
+    /// the container the lvalue invocant gets could drift apart.
+    ///
+    /// The operand is the constant-pool index of the *outer* method's name — the
+    /// one whose invocant this is — or `None` for the dynamic spelling
+    /// (`$o.v."$name"() = v`), where the name is only a runtime string. With the
+    /// name in hand the gate is character-for-character slice 3a's own filter
+    /// (`any_raw_invocant_method || native_method_returns_raw_invocant(name)`),
+    /// evaluated one op earlier; without it the gate must pass, which is the
+    /// conservative direction. This is what keeps `$o.i.w = $n` free even under
+    /// 6.e, where the native `snitch` row exists and a name-blind gate would let
+    /// every lvalue invocant through.
+    MarkLvalueInvocantRefContext(Option<u32>),
     /// Slice 2a/2b (`docs/scalar-array-sharing.md`): signal that the next
     /// SetLocal/AssignExpr assigns to a `$` scalar via plain `=` and that the
     /// named source variable's container should be shared by reference. The

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -92,6 +92,12 @@ pub(crate) fn current_language_version() -> String {
     stmt::simple::current_language_version()
 }
 
+/// `current_language_version().starts_with(prefix)` without the `String` clone —
+/// for VM hot paths. See the implementation's doc comment.
+pub(crate) fn current_language_version_starts_with(prefix: &str) -> bool {
+    stmt::simple::current_language_version_starts_with(prefix)
+}
+
 pub(crate) fn set_current_language_version(version: &str) {
     stmt::simple::set_current_language_version(version);
 }

--- a/src/parser/stmt/simple.rs
+++ b/src/parser/stmt/simple.rs
@@ -45,7 +45,9 @@ pub use lib_paths::{
 
 // `pub(crate)` re-exports.
 pub(crate) use compile_consts::is_imported_function;
-pub(crate) use registry::{current_language_version, set_current_language_version};
+pub(crate) use registry::{
+    current_language_version, current_language_version_starts_with, set_current_language_version,
+};
 pub(crate) use registry::{declare_keyword_names, register_declare_keyword};
 pub(crate) use slang_modes::{
     apply_slang_rule_override, consume_slang_ident_trailing_punct, set_slang_modes, slang_modes,

--- a/src/parser/stmt/simple/registry.rs
+++ b/src/parser/stmt/simple/registry.rs
@@ -286,3 +286,14 @@ pub(in crate::parser) fn restore_declare_keywords(saved: HashMap<String, String>
 pub(crate) fn current_language_version() -> String {
     CURRENT_LANGUAGE_VERSION.with(|v| v.borrow().clone())
 }
+
+/// `current_language_version().starts_with(prefix)` without the `String` clone.
+///
+/// The allocating form is fine at parse time, where it is asked once per
+/// construct, but a *VM* hot path cannot pay a heap allocation to ask which
+/// language version is in force — `OpCode::MarkLvalueInvocantRefContext` runs on
+/// every `$obj.acc.m = v` (ADR-0067's E6 producer), where the clone cost ~29% on
+/// a tight loop.
+pub(crate) fn current_language_version_starts_with(prefix: &str) -> bool {
+    CURRENT_LANGUAGE_VERSION.with(|v| v.borrow().starts_with(prefix))
+}

--- a/src/runtime/methods_mut_method_lvalue.rs
+++ b/src/runtime/methods_mut_method_lvalue.rs
@@ -168,20 +168,6 @@ impl Interpreter {
                 ));
             }
         }
-        // IO::Path read-only accessors (`.SPEC`, `.CWD`) are not `rw`: assigning
-        // to them raises X::Assignment::RO referencing the current value, matching
-        // Raku (`'.'.IO.SPEC = ...` / `'.'.IO.CWD = ...`).
-        if method_args.is_empty()
-            && matches!(method, "SPEC" | "CWD")
-            && matches!(target.view(), ValueView::Instance { class_name, .. } if class_name == "IO::Path")
-        {
-            let cur = self
-                .call_method_with_values(target.clone(), method, vec![])
-                .unwrap_or(Value::NIL);
-            let typename = crate::value::what_type_name(&cur);
-            let repr = cur.to_string_value();
-            return Err(RuntimeError::assignment_ro_typename(&typename, &repr));
-        }
         // Lvalue return (ADR-0059) for a TYPE-OBJECT invocant
         // (`Crane::In.in(container, @path) = $v`, a class-method lvalue): run
         // the method and write through the container it returns. Every
@@ -215,6 +201,28 @@ impl Interpreter {
         } else {
             target
         };
+        // IO::Path read-only accessors (`.SPEC`, `.CWD`) are not `rw`: assigning
+        // to them raises X::Assignment::RO referencing the current value, matching
+        // Raku (`'.'.IO.SPEC = ...` / `'.'.IO.CWD = ...`).
+        //
+        // Deliberately BELOW the chokepoint: this is an `Instance` match, and the
+        // ADR-0067 E6 producer can hand an lvalue call a `ContainerRef`-wrapped
+        // invocant (`class C { has IO::Path $.p is rw }; $c.p.SPEC = 5`), which
+        // would slip past the match and degrade the diagnostic into a bare
+        // "No matching candidates for method: SPEC". Neither branch above cares:
+        // the type-object half requires a `Package`, and the raw-invocant half
+        // requires a raw-invocant declaration, which `.SPEC` is not.
+        if method_args.is_empty()
+            && matches!(method, "SPEC" | "CWD")
+            && matches!(target.view(), ValueView::Instance { class_name, .. } if class_name == "IO::Path")
+        {
+            let cur = self
+                .call_method_with_values(target.clone(), method, vec![])
+                .unwrap_or(Value::NIL);
+            let typename = crate::value::what_type_name(&cur);
+            let repr = cur.to_string_value();
+            return Err(RuntimeError::assignment_ro_typename(&typename, &repr));
+        }
         // An `is repr('CStruct')` handle keeps no Raku attributes: its fields
         // live in the C struct its `address` points at, so an assignment has to
         // write native memory (`$bind.buffer = $addr`). Without this the write

--- a/src/runtime/raw_invocant.rs
+++ b/src/runtime/raw_invocant.rs
@@ -80,7 +80,7 @@ pub(crate) fn native_method_returns_raw_invocant(method: &str) -> bool {
         // `method snitch(\snitchee: &snitcher = &note)` — 6.e only, so the
         // method simply is not there below that version (rakudo reports
         // `No such method`), and neither is the lvalue shape.
-        "snitch" => crate::parser::current_language_version().starts_with("6.e"),
+        "snitch" => crate::parser::current_language_version_starts_with("6.e"),
         _ => false,
     }
 }

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -2291,6 +2291,29 @@ impl Interpreter {
                 self.accessor_ref_pending = true;
                 *ip += 1;
             }
+            OpCode::MarkLvalueInvocantRefContext(method_name_idx) => {
+                // ADR-0067's E6 producer: only a raw-invocant callee can consume
+                // the container this asks for, so ask slice 3a's filter first.
+                // See the opcode's doc comment.
+                let raw_callee_possible = match method_name_idx {
+                    Some(idx) => crate::runtime::raw_invocant::native_method_returns_raw_invocant(
+                        Self::const_str(code, *idx),
+                    ),
+                    // A dynamic method name is only knowable at run time; pass.
+                    None => true,
+                };
+                // The user half reads slice 3b's lock-free mirror of
+                // `Registry::any_raw_invocant_method` rather than the flag
+                // itself: both are raised by the same writer, and this op runs
+                // per `$obj.acc.m = v`, where a registry read-lock acquisition
+                // is not worth paying for a question that is almost always no.
+                if raw_callee_possible
+                    || crate::runtime::raw_invocant::any_raw_invocant_method_possible()
+                {
+                    self.accessor_ref_pending = true;
+                }
+                *ip += 1;
+            }
             OpCode::MarkArrayShareSource(name_idx) => {
                 self.array_share_context.set(true);
                 self.array_share_source

--- a/src/vm/vm_jit_support.rs
+++ b/src/vm/vm_jit_support.rs
@@ -107,6 +107,7 @@ pub(super) fn step_supported(op: &OpCode) -> bool {
             | OpCode::TagContainerRef(..)
             | OpCode::TagContainerRefReversed(..)
             | OpCode::MarkAccessorRefContext
+            | OpCode::MarkLvalueInvocantRefContext(..)
             // List / hash construction, indexing and coercion
             | OpCode::MakeArray(_)
             | OpCode::MakeRealArray(_)

--- a/t/lvalue-invocant-attribute-accessor-container.t
+++ b/t/lvalue-invocant-attribute-accessor-container.t
@@ -1,0 +1,196 @@
+use v6.e.PREVIEW;
+use Test;
+
+# ADR-0067, the E6 producer: an lvalue method call whose INVOCANT is a bare
+# `is rw` attribute-accessor read hands the callee the attribute's container,
+# so a raw-invocant callee writes through it.
+#
+#     class C { has $.v is rw }; my $c = C.new(v => 42);
+#     $c.v.snitch = 9;                  # raku: $c.v is now 9
+#
+# Everything here is byte-identical under `raku` and `mutsu`. `.snitch` is given
+# an explicit snitcher throughout so the observation lands in a variable instead
+# of on stderr, which keeps the comparison over stdout alone. A bare `-> $ { }`
+# is used rather than `{}`, which is an empty Hash literal.
+
+plan 25;
+
+# --- E6 itself -------------------------------------------------------------
+
+class E6Basic { has $.v is rw }
+{
+    my $c = E6Basic.new(v => 42);
+    my @seen;
+    $c.v.snitch(-> $x { @seen.push($x) }) = 9;
+    is $c.v, 9, 'E6: a write through a raw invocant reaches the attribute';
+    is-deeply @seen, [42], 'E6: the raw-invocant method still observed the old value';
+}
+
+class E6Str { has $.v is rw }
+{
+    my $c = E6Str.new(v => 'hi');
+    $c.v.snitch(-> $ { }) = 'yo';
+    is $c.v, 'yo', 'E6: a Str-valued attribute';
+}
+
+class E6Unset { has $.v is rw }
+{
+    # An unset attribute has no value to copy, but still names a location.
+    my $c = E6Unset.new;
+    $c.v.snitch(-> $ { }) = 9;
+    is $c.v, 9, 'E6: an unset attribute';
+}
+
+class E6Base { has $.v is rw }
+class E6Derived is E6Base { }
+{
+    my $d = E6Derived.new(v => 42);
+    $d.v.snitch(-> $ { }) = 9;
+    is $d.v, 9, 'E6: an inherited attribute';
+}
+
+role E6Role { has $.v is rw }
+class E6Composed does E6Role { }
+{
+    my $c = E6Composed.new(v => 42);
+    $c.v.snitch(-> $ { }) = 9;
+    is $c.v, 9, 'E6: a role-composed attribute';
+}
+
+class E6Self {
+    has $.v is rw;
+    method go { self.v.snitch(-> $ { }) = 9 }
+}
+{
+    my $c = E6Self.new(v => 42);
+    $c.go;
+    is $c.v, 9, 'E6: through `self` inside a method';
+}
+
+class E6Two { has $.v is rw }
+{
+    # The container is per-object: writing one must not touch the other.
+    my $c = E6Two.new(v => 1);
+    my $d = E6Two.new(v => 2);
+    $c.v.snitch(-> $ { }) = 9;
+    is $c.v, 9, 'E6: the written object changed';
+    is $d.v, 2, 'E6: a sibling object did not';
+}
+
+class E6Typed { has Int $.v is rw }
+{
+    # The typed attribute's constraint travels with the container.
+    my $c = E6Typed.new(v => 42);
+    $c.v.snitch(-> $ { }) = 9;
+    is $c.v, 9, 'E6: a typed attribute writes through';
+    dies-ok { $c.v = 'x' }, 'E6: and still type-checks afterwards';
+}
+
+class E6Inner { has $.w is rw }
+class E6Outer { has $.i is rw }
+{
+    # Depth 2: `$o.i` is an ordinary read, `.w` is the marked invocant.
+    my $o = E6Outer.new(i => E6Inner.new(w => 1));
+    $o.i.w.snitch(-> $ { }) = 9;
+    is $o.i.w, 9, 'E6: a depth-2 accessor chain';
+}
+
+class E6Dynamic { has $.v is rw }
+{
+    # The method name is only known at run time, so the marker carries no name
+    # and its gate must let the dispatch through.
+    my $c = E6Dynamic.new(v => 42);
+    my $m = 'snitch';
+    $c.v."$m"() = 9;
+    is $c.v, 9, 'E6: a runtime method name';
+}
+
+# --- shapes that must keep working exactly as they did ---------------------
+
+class NPlain { has $.v is rw }
+{
+    my $c = NPlain.new(v => 42);
+    $c.v = 9;
+    is $c.v, 9, 'plain rw attribute assignment is untouched';
+}
+
+class NBind { has $.v is rw }
+{
+    my $c = NBind.new(v => 42);
+    my $x := $c.v;
+    $x = 9;
+    is $c.v, 9, 'the `:=` bind producer is untouched';
+}
+
+class NCopy { has $.v is rw }
+{
+    # An rvalue read still copies -- the container must not escape into `$r`.
+    my $c = NCopy.new(v => 42);
+    my $r = $c.v;
+    $r = 100;
+    is $c.v, 42, 'an rvalue accessor read is still a copy';
+}
+
+class NNestedInner { has $.w is rw }
+class NNestedOuter { has $.i is rw }
+{
+    my $o = NNestedOuter.new(i => NNestedInner.new(w => 1));
+    $o.i.w = 9;
+    is $o.i.w, 9, 'a nested non-raw attribute store still writes the attribute';
+    is $o.i.raku, 'NNestedInner.new(w => 9)', 'and the object still renders as itself';
+}
+
+class NArray { has $.a is rw }
+{
+    my $c = NArray.new(a => [1, 2]);
+    $c.a[0] = 9;
+    is-deeply $c.a, [9, 2], 'an array-valued attribute element store is untouched';
+}
+
+class NHash { has $.h is rw }
+{
+    my $c = NHash.new(h => {a => 1});
+    $c.h<a> = 9;
+    is $c.h<a>, 9, 'a hash-valued attribute element store is untouched';
+}
+
+class NArgAccessor {
+    has %.d is rw;
+    method get($k) is rw { %!d{$k} }
+}
+{
+    my $c = NArgAccessor.new(d => {foo => 1});
+    $c.get('foo').snitch(-> $ { }) = 9;
+    is $c.d<foo>, 9, 'an argument-carrying rw accessor invocant is untouched';
+}
+
+# --- shapes that must keep REFUSING ---------------------------------------
+
+class RNonRw { has $.v }
+{
+    # Not `is rw`: raku refuses (`Cannot modify an immutable Int`). The marker
+    # is emitted, but a non-rw accessor hands back no container, so the
+    # assignment stays a refusal rather than becoming silently wrong.
+    my $c = RNonRw.new(v => 42);
+    dies-ok { $c.v.snitch(-> $ { }) = 9 }, 'a non-rw attribute accessor still refuses';
+    is $c.v, 42, 'and the attribute is unchanged';
+}
+
+class RSelf { has $.v is rw }
+{
+    # `.self` is deliberately outside the raw-invocant family (ADR-0067
+    # non-goals): raku refuses `$a.self = 5`, and so must the E6 spelling even
+    # though the invocant now arrives as a container.
+    my $c = RSelf.new(v => 42);
+    dies-ok { $c.v.self = 9 }, '`.self` over a container invocant still refuses';
+}
+
+class RComputed { method thing { 42 } }
+{
+    # No accessor at all behind the invocant: a computed value is not a
+    # location, and must stay a loud refusal.
+    my $c = RComputed.new;
+    dies-ok { $c.thing.snitch(-> $ { }) = 9 }, 'a computed invocant still refuses';
+}
+
+done-testing;

--- a/t/lvalue-invocant-user-raw-method.t
+++ b/t/lvalue-invocant-user-raw-method.t
@@ -1,0 +1,80 @@
+use v6.e.PREVIEW;
+use MONKEY-TYPING;
+use Test;
+
+# ADR-0067, the E6 producer, user-declared half: the container an `is rw`
+# attribute accessor hands an lvalue invocant is consumed by a *user* method
+# that binds parameter zero raw, not only by the native `.snitch`.
+#
+# This file also exercises the user side of the runtime gate on
+# `OpCode::MarkLvalueInvocantRefContext` (`Registry::any_raw_invocant_method`),
+# which the sibling file `t/lvalue-invocant-attribute-accessor-container.t`
+# cannot: that one declares no raw invocant at all.
+#
+# Byte-identical under `raku` and `mutsu`.
+
+plan 8;
+
+augment class Any {
+    # Raw invocant AND rw-capable -- the contract's two halves, all three
+    # rw-capable spellings.
+    method mutsuE6Raw(\S:) is raw { S }
+    method mutsuE6Rw(\S:) is rw { S }
+    method mutsuE6ReturnRw(\S:) { return-rw S }
+    # Raw invocant, but the body returns a value rather than a location.
+    method mutsuE6RawValue(\S:) is raw { 42 }
+    # Raw invocant, NOT rw-capable -- raku: "Cannot modify an immutable Int".
+    method mutsuE6NotRw(\S:) { S }
+    # rw-capable, but the invocant is NOT raw -- raku: "Cannot assign to a
+    # readonly variable or a value".
+    method mutsuE6NotRawInv(Any:D $s:) is raw { $s }
+}
+
+class Holder { has $.v is rw }
+
+{
+    my $c = Holder.new(v => 42);
+    $c.v.mutsuE6Raw = 9;
+    is $c.v, 9, '`is raw` with a raw invocant writes through the attribute';
+}
+
+{
+    my $c = Holder.new(v => 42);
+    $c.v.mutsuE6Rw = 9;
+    is $c.v, 9, '`is rw` with a raw invocant writes through the attribute';
+}
+
+{
+    my $c = Holder.new(v => 42);
+    $c.v.mutsuE6ReturnRw = 9;
+    is $c.v, 9, '`return-rw` with a raw invocant writes through the attribute';
+}
+
+{
+    # An ordinary rvalue call must still hand back a plain value.
+    my $c = Holder.new(v => 42);
+    my $r = $c.v.mutsuE6Raw;
+    $r = 100;
+    is $c.v, 42, 'an rvalue call through the same method is still a copy';
+}
+
+{
+    my $c = Holder.new(v => 42);
+    dies-ok { $c.v.mutsuE6RawValue = 9 },
+        'a raw-invocant body returning a value still refuses';
+    is $c.v, 42, 'and the attribute is unchanged';
+}
+
+{
+    my $c = Holder.new(v => 42);
+    dies-ok { $c.v.mutsuE6NotRw = 9 },
+        'a raw invocant that is not rw-capable still refuses';
+}
+
+{
+    my $c = Holder.new(v => 42);
+    dies-ok { $c.v.mutsuE6NotRawInv = 9 },
+        'an rw-capable method whose invocant is not raw still refuses';
+}
+
+done-testing;

--- a/todo/tickets/attribute-accessor-container-lost-in-argument-position.md
+++ b/todo/tickets/attribute-accessor-container-lost-in-argument-position.md
@@ -1,0 +1,56 @@
+# An `is rw` attribute accessor names a container for `:=` and for an lvalue invocant, but not in argument position
+
+Measured 2026-09-06 against raku v2026.07 and a debug `mutsu` built from `main`
+at `30d6754f5` (plus ADR-0067's E6 producer, which does not touch argument
+position).
+
+`class C { has $.v is rw }` gives `$c.v` a real Scalar in raku. mutsu now agrees
+for two of the three consumers:
+
+| Consumer | raku | mutsu |
+|---|---|---|
+| `my $x := $c.v; $x = 9` | `9` | `9` |
+| `$c.v.snitch = 9` (ADR-0067 E6) | `9` | `9` |
+| `sub g($y is rw) { $y = 9 }; g($c.v)` | `9` | **dies**: `Parameter '$y' expects a writable container (variable) as an argument, but got '42' (Int) as a value without a container.` |
+| `sub f(\x) is raw { x }; f($c.v) = 9` | `9` | **`42` — silent, exit 0** |
+
+The last row is the bad one: it is not a refusal, it reports success and drops
+the write.
+
+## Why this is a separate producer
+
+ADR-0067's E6 producer emits `MarkAccessorRefContext` before the *invocant* of
+an `__mutsu_assign_method_lvalue` call, so the container is produced only for
+that one call shape. An ordinary argument goes through
+`compile_call_arg_with_escape` (`src/compiler/helpers_call_args.rs`), whose
+`is_bind_target` arm already marks a `:=` bind RHS the same way — but a plain
+positional argument is not a bind target, so no marker is emitted and the
+accessor read returns a value copy.
+
+The narrow fix is presumably the argument twin of the E6 producer: mark an
+argument-position accessor read when the callee's parameter is `is rw` / raw.
+But unlike the invocant case, the callee's signature is not knowable at compile
+time for an indirect call, and unlike the invocant case there is no
+decontainerize chokepoint downstream to absorb a `ContainerRef` that nobody
+consumes — so this needs its own measurement of where such a container would
+flow before any code is written.
+
+## ADR correction this row carries
+
+ADR-0067's slice-3a subsection cites this exact program as evidence, saying raku
+"dies with 'expects a writable container'". That is **mutsu's** diagnostic, not
+raku's; raku answers `9`. The conclusion the row supported (E6 is a producer
+question, and `.VAR` is not the discriminator) is unaffected, but the row itself
+was misattributed. The ADR's non-goals section likewise describes the
+`f($c.v) = 9` twin as "still copies", which understates it: it is a silent wrong
+answer, not a conservative copy.
+
+## Repro
+
+```raku
+class C { has $.v is rw }
+sub f(\x) is raw { x }
+my $c = C.new(v => 42);
+f($c.v) = 9;
+say $c.v;          # raku: 9    mutsu: 42
+```

--- a/todo/tickets/rw-method-result-is-not-a-container-for-bind-or-invocant.md
+++ b/todo/tickets/rw-method-result-is-not-a-container-for-bind-or-invocant.md
@@ -1,0 +1,52 @@
+# An `is rw` *method* returns a container when assigned to, but not when bound or used as an lvalue invocant
+
+Measured 2026-09-06 against raku v2026.07 and a debug `mutsu` built from `main`
+at `30d6754f5` (plus ADR-0067's E6 producer, which does not reach this shape).
+
+```raku
+class C { has $.v is rw; method acc is rw { $!v } }
+my $c = C.new(v => 42);
+```
+
+| Consumer | raku | mutsu |
+|---|---|---|
+| `$c.acc = 9` | `9` | `9` |
+| `my $x := $c.acc; $x = 9` | `9` | **dies**: `Cannot assign to an immutable value` |
+| `sub g($y is rw) { $y = 9 }; g($c.acc)` | `9` | **dies**: `Parameter '$y' expects a writable container ...` |
+| `$c.acc.snitch = 9` (the E6 shape) | `42` then `9` | **dies**: `X::Assignment::RO: cannot assign through .snitch on non-instance` |
+| `self!p.snitch = 9` for `method !p is rw { $!v }` | `42` then `9` | the same refusal |
+
+## Why the E6 producer does not cover it
+
+ADR-0067's E6 producer emits `MarkAccessorRefContext` before an lvalue call's
+invocant, and that marker is consumed by `try_fast_accessor_read`
+(`src/vm/vm_call_method_ops.rs`), which by construction only serves a **public
+attribute accessor** — it bails as soon as
+`resolve_user_method_or_accessor` answers `UserMethod` rather than `Accessor`.
+A user-written `is rw` method is exactly the `UserMethod` case.
+
+The `$c.acc = 9` row works through a completely different route (the lvalue
+assignment path calls the method and writes through the container its rw tail
+returns, ADR-0059). So the machinery exists; what is missing is a producer that
+runs the rw method **for a plain read** and hands its container back when the
+read is in a container-wanting context (`:=`, an `is rw` argument, an lvalue
+invocant).
+
+The `:=` row is the cheapest entry point and the one to measure first: it is the
+same context `MarkAccessorRefContext` already flags, so the question is only
+whether the flagged dispatch can be routed to a container-mode method call
+instead of `try_fast_accessor_read`'s accessor-only fast path. Note that doing so
+means *calling* the method in a context where mutsu currently does not, so a
+non-rw method must keep going through the plain read — gate on
+`Interpreter::method_is_rw_capable` (ADR-0067 slice 2's oracle), not on the shape
+of what comes back.
+
+## Repro
+
+```raku
+class C { has $.v is rw; method acc is rw { $!v } }
+my $c = C.new(v => 42);
+my $x := $c.acc;
+$x = 9;
+say $c.v;          # raku: 9    mutsu: dies "Cannot assign to an immutable value"
+```


### PR DESCRIPTION
Closes ADR-0067's **E6 row** — the last open item besides Slice 3b's subscript-receiver producer.

```raku
use v6.e.PREVIEW;
class C { has $.v is rw }
my $c = C.new(v => 42);
$c.v.snitch = 9;      # raku: 42 then 9.  mutsu before: X::Assignment::RO
say $c.v;             # raku: 9
```

## Root cause: a missing producer, not a missing write

Slice 3a already made a raw invocant arrive as a container and taught `assign_method_lvalue_with_values` to write through it; ADR-0059's `assign_lvalue_container` has always been the one consumer. But an invocant that is *itself* a method call was compiled as an ordinary rvalue read, so the attribute's Scalar never reached the call. mutsu already had the producer for exactly that container — the `MarkAccessorRefContext` marker that makes `my $x := $c.v; $x = 9` write through — it was simply never emitted before an lvalue invocant.

So the change is one insertion in the compiler: when a `__mutsu_assign_method_lvalue` call's argument 0 is an argument-less method call, mark that call as wanting a container. Three producers now feed the single consumer ADR-0059 built.

## Why an unconditional emission is safe

Rawness is not statically known, so the marker goes out for every `$obj.acc.m = v`. The narrowness lives in the consumer: `try_fast_accessor_read` hands back a container only for a zero-argument read of a public `is rw` **scalar** attribute accessor and ignores the flag otherwise. `--dump-bytecode` confirms `benchmarks/method-call.raku`, `benchmarks/bench-class.raku` and a `$p.x = $i` loop compile **byte-identically** with and without the change.

## Two things measurement forced

**Slice 3a's "single chokepoint" was not single.** It decontainerizes the target right after the raw-invocant branch declines, so the ~40 `Instance`/`Array`/`Hash` branches below keep seeing plain values. One such branch sat *above* it — the IO::Path `.SPEC`/`.CWD` read-only guard — and with a container invocant (`class C { has IO::Path $.p is rw }; $c.p.SPEC = 5`) its diagnostic degraded to a bare `No matching candidates for method: SPEC`. It now sits below the chokepoint.

**The marker had to become a runtime-gated op**, in three measured steps:

1. The plain `MarkAccessorRefContext` cost **~14%** on a tight `$o.i.w = $n` loop — not the opcode, but the `want_ref` branch running an MRO walk plus an attribute-slot promotion every iteration to mint a container the chokepoint then discards.
2. A name-blind gate ("could *any* callee be raw") fixed 6.d but not 6.e, where the native `snitch` row exists for every method name — and asking that question called `current_language_version()`, which clones a `String`: **~29%** in heap allocation alone. There is now a non-allocating `current_language_version_starts_with`.
3. The shipped `MarkLvalueInvocantRefContext` carries the **outer method's name**, which the compiler knows in every spelling but the dynamic one. Its runtime test is then character-for-character slice 3a's own filter one op earlier, read through slice 3b's lock-free registry mirror. Confirmed under `rust-gdb`: the flag-setting line never fires for `$o.i.w = $n`, even under 6.e.

### Perf (same-binary env-switch A/B, release, min of 15 **interleaved** pairs)

| Program | delta |
|---|---|
| `$o.i.w = $n` under 6.e (gate passes on name only) | **+1.9%** |
| `$o.i.w = $n` under 6.d | **−4.4%** |
| `$p.x = $i` — **byte-identical bytecode**, i.e. pure noise | **+6.3%** |
| `benchmarks/method-call.raku` — byte-identical | 0.0% |
| `benchmarks/bench-class.raku` — byte-identical | 0.0% |

The byte-identical control calibrates the noise floor at ±6% on this box, so both real figures are inside it.

## Nothing traded a loud refusal for a silent wrong answer

Every control still dies loudly, with an unchanged message: a non-rw attribute accessor, a raw-invocant routine that is not rw-capable, an rw-capable routine whose invocant is not raw, a raw-invocant body that returns a value rather than a location, `.self` (an ADR non-goal), and a computed invocant. A 29-row `$obj.acc.m = v` survey was diffed against a baseline binary built from `main`: 8 rows went from divergent to matching, zero regressed.

## Two divergences recorded, not folded in

- `todo/tickets/rw-method-result-is-not-a-container-for-bind-or-invocant.md` — an `is rw` *method* (not an attribute accessor) produces no container for a `:=` bind or an lvalue invocant. Out of reach here because `try_fast_accessor_read` serves accessors only.
- `todo/tickets/attribute-accessor-container-lost-in-argument-position.md` — argument position still loses the container, and its `is raw` twin is **silently** wrong. This also corrects a row in ADR-0067 itself, which cited `sub g($y is rw) {...}; g($c.v)` as raku dying with "expects a writable container" — that is *mutsu's* diagnostic; raku answers `9`.

## Verification

- `make test`: **Files=3700, Tests=37845, Result: PASS**
- Targeted roast sweep (S12/S14-roles/S06-traits/S06-operator-overloading/S03-binding/S09/S32-array/S32-hash, 202 whitelisted files): **12467 tests, PASS**
- Battery gate (`scripts/battery-testsuite.sh`, release): **GATE PASSED, 289/312**
- Slice 3b's own pins re-run after rebasing onto it: byte-identical under `mutsu` and `raku`
- New pins `t/lvalue-invocant-attribute-accessor-container.t` (25 tests) and `t/lvalue-invocant-user-raw-method.t` (8 tests), both byte-identical under `mutsu` and `raku`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
