### PR TITLE
fix: five general bugs found by reducing Template6 (0/12 -> 10/12)

### DIFF
--- a/docs/batteries/templates.md
+++ b/docs/batteries/templates.md
@@ -48,26 +48,40 @@ plain checkout of the dist with `-I lib`.
 
 | Candidate | Version | Released | License | Runtime deps | Dependents¹ | raku | **mutsu** |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| **`Template::Mustache`** | 1.2.6 | 2026-01-12 | Artistic-2.0 | **0** | **11** | 11/13² | **13/13** ⬆ |
-| `Template6` | 0.16.0 | 2026-02-04³ | Artistic-2.0 | **0** | 7 | **12/12** | **0/12** |
-| `Template::Jinja2` | 0.2.0 | 2026-04-29 | Artistic-2.0 | 1 (`JSON::Fast`, native) | 2 | 22/23 | **0/23** |
-| `Template::Mojo` | 0.2.2 | 2023-07-31 | MIT | **0** | 3 | **5/5** | **0/5** |
+| **`Template::Mustache`** | 1.2.6 | 2026-01-12 | Artistic-2.0 | **0** | **11** | 11/13² | **13/13** |
+| `Template6` | 0.16.0 | 2026-02-04³ | Artistic-2.0 | **0** | 7 | **12/12** | **10/12** ⬆ |
+| `Template::Jinja2` | 0.2.0 | 2026-04-29 | Artistic-2.0 | 1 (`JSON::Fast`, native) | 2 | 22/23 | **3/23** ⬆ |
+| `Template::Mojo` | 0.2.2 | 2023-07-31 | MIT | **0** | 3 | **5/5** | **4/5** |
 | `Template::Nest::Fast` | 0.3.0 | 2024-11-18 | ISC | **0** | 0 | **10/10** | **0/10** |
-| `SP6` | 0.2.1 | 2021-09-04 | Apache-2.0 | **0** | 0 | 10/11 | 6/11 |
+| `SP6` | 0.2.1 | 2021-09-04 | Apache-2.0 | **0** | 0 | 10/11 | **10/11** |
 | `Template::Classic` | 0.0.3 | 2020-04-11 | BSD-3-Clause | **0** | 1 | **1/1** | 0/1 |
-| `Template::HAML` | 0.9.5 | 2026-06-27 | Artistic-2.0 | **0** | 2 | 82/83 | 14/83⁴ |
+| `Template::HAML` | 0.9.5 | 2026-06-27 | Artistic-2.0 | **0** | 2 | 82/83 | 39/83⁴ |
 | `Template::Protone` | 0.1.4 | 2021-01-20 | Artistic-2.0 | **0** | 0 | *ships no tests* | *ships no tests* |
 | `ERK` | 1.1.4 | 2025-11-14 | Artistic-2.0 | **0** | 1 | *ships no tests* | *ships no tests* |
 
-⬆ `Template::Mustache` went **1/13 → 11/13** on 2026-07-25 when the single
+The mutsu column was **re-measured in full on 2026-09-06** (debug build). Do not
+quote a row without re-running the survey: on that re-run four of the eight rows
+had moved since the last measurement, all from unrelated work.
+
+⬆ `Template6` went **0/12 → 10/12** on 2026-09-06. Its long-standing
+"unreduced, `Use of Nil in string context`" state turned out to hide **four**
+independent general interpreter bugs, none of them the warning: a `split(/…/, :v)`
+separator `Match` carried no named captures, `.subst(…, :nth(2..*))` aborted the
+process with a Rust `capacity overflow`, an attribute default's closure was
+stamped with the *constructing* class (so it could not see its own file's subs),
+and an assignment to `$_` inside a nested block was discarded on block exit. Pins:
+`t/split-regex-separator-captures.t`, `t/subst-nth-range.t`,
+`t/attr-default-closure-package.t`, `t/topic-assign-in-nested-block.t`. Write-up:
+`news/2026-09/template6-zero-to-ten-of-twelve.md`.
+
+`Template::Mustache` itself went **1/13 → 11/13** on 2026-07-25 when the single
 interpreter bug behind it was fixed: a hyper method call (`@objs>>.made`) did not
 flatten a `Slip` returned by the method, so the parse tree came out with each
 hunk's `Slip` nested — and `.flat` then decomposed the `Hash` inside it into
-Pairs. The whole official mustache spec suite (`91-specs`, 10/10) passes now.
-Pin: `t/hyper-method-slip-result.t`. The last two files followed the same day
-(**11/13 → 13/13**) from three more general fixes: a subscript assignment through
-a `$`-sigil attribute (`$!h<k> = 1`) reaching the instance, a `for` block no
-longer leaking its topic into the enclosing `$_`, and text-mode file reads
+Pairs. Pin: `t/hyper-method-slip-result.t`. The last two files followed the same
+day (**11/13 → 13/13**) from three more general fixes: a subscript assignment
+through a `$`-sigil attribute (`$!h<k> = 1`) reaching the instance, a `for` block
+no longer leaking its topic into the enclosing `$_`, and text-mode file reads
 decoding CRLF to LF. Pins: `t/attr-subscript-assignment.t`,
 `t/for-topic-restore.t`, `t/io-crlf-translation.t`.
 
@@ -87,40 +101,50 @@ the real figure — measure release.) See
 
 ### First observed failure under mutsu
 
-Enough to start root-causing; none of these are module rot, since raku runs them.
+As of the 2026-09-06 re-measurement. None of these are module rot — raku runs
+them all.
 
 | Candidate | Symptom |
 | --- | --- |
-| `Template::Mustache` | `Use of Nil in string context` from the `TOP` grammar action (`lib/Template/Mustache.rakumod:136`), reached via `parse-template` |
-| `Template6` | same warning, from `Parser.compile` — a `q:to/RAKU/` heredoc whose `\qq[$safe-delimiter]` / `\qq[$segment]` come out empty |
-| `Template::Jinja2` | Two bugs, both reduced 2026-08-19. `01-lexer` fails on its own because a literal `{` inside `<-[{]>` makes mutsu's assertion scanner miss the class's closing `>`, swallowing the `+` and every atom after it; the other 22 files die at `Renderer.rakumod` load time on `Cannot call private method without permission`, because a qualified `$obj!Renderer::meth` inside `module Template::Jinja2::Renderer` compares the short owner name against the fully-qualified caller |
-| `Template::Mojo` | `No such method 'characters' for invocant of type 'Match'` — the grammar's `token characters` is not being resolved as a subrule (`.characters` is not a raku method either, so mutsu is falling back to method dispatch where it should be a named capture) |
-| `Template::Nest::Fast` | `Use of Nil in string context` |
-| `Template::Classic` | `X::Method::NotFound: Unknown method value dispatch (fallback dispatch)` |
-| `SP6` | 5 files fail; `Use of uninitialized value element of type Any in string context` |
+| `Template::Mustache` | none; 13/13 |
+| `Template6` | 10/12. `02-for`: an `@` argument's mutation is lost on the *second* call through a slurpy relay (`todo/tickets/array-arg-mutation-lost-on-the-second-call-through-a-slurpy-relay.md`). `05-includes`: `[% INCLUDE "x" name = "World" %]` renders `name` instead of `World` (`todo/tickets/template6-include-local-data-not-reaching-the-included-stash.md`) |
+| `Template::Jinja2` | loads now (3/23); the rest are ordinary per-feature failures. Its last load blocker — `Renderer.rakumod:114`'s `when If {` read as a call — was fixed 2026-09-06 |
+| `Template::Mojo` | `00-basic` only; `todo/tickets/template-mojo-residual-failures.md` |
+| `Template::Nest::Fast` | `with $f ~~ m:g/…/ -> @m` binds `@m` to a one-element list *containing* the match list, so `$m[0].from` is Nil. `with ("a<!--x-->b<!--yy-->c" ~~ m:g/('<!--') \s* (\w+) \s* ('-->')/) -> @m { say @m.elems }` gives 2 under raku, 1 under mutsu |
+| `Template::Classic` | `Unterminated <%` from its own grammar — the `$<part> = <rule>` capture-assignment form inside a `||` chain does not match |
+| `SP6` | at parity with raku (both 10/11, same file) |
 
-Note the warning text is a *warning* in both implementations and is not itself
-fatal (verified) — it is simply the first non-TAP line the harness captured, so
-treat it as a pointer, not the diagnosis.
+The old "`Use of Nil in string context`" entries are gone: that line was a
+*warning* in both implementations and never the diagnosis, exactly as
+`todo/deep/template-engines-blocked-on-mutsu.md` warned. Every row that was
+reduced turned out to be something else entirely.
 
-Confirmed and separately filed so far:
+Confirmed and separately filed so far (all three of the older entries here are
+now **fixed**; they are kept because each was a general bug found through this
+survey):
 
-- `todo/tickets/q-heredoc-interpolates-qq-escape.md` — `Q:to/…/` wrongly honours
-  `\qq[…]`; raku leaves it literal. Found while reducing the `Template6` failure.
-  (Fixed 2026-07-26; it was **not** the `Template6` blocker.)
-- `todo/tickets/regex-brace-paren-inside-char-class-swallows-rest-of-pattern.md`
-  — a literal `{` / `(` written inside a `<[...]>` char class makes
-  `scan_angle_assertion_body()` miss the assertion's closing `>`, so the
-  quantifier and every following atom are silently dropped. Reduced from
-  `Template::Jinja2`'s `01-lexer` (0/15 → 15/15 with the brace escaped by hand),
-  but it is a general grammar-slang bug: `<-[{]>+` ("text up to the next opening
-  delimiter") is idiomatic in template and config grammars.
-- `todo/tickets/qualified-private-method-call-uses-short-owner-name.md` — a
-  qualified private call `$obj!Renderer::meth` written inside
-  `module Template::Jinja2::Renderer` is rejected because the statically-checked
-  owner name is compared as written against the fully-qualified caller class.
-  This is what makes `Template::Jinja2` unloadable; it is **distinct** from the
-  private-method-in-closure bug fixed in #5466.
+- ~~`todo/tickets/q-heredoc-interpolates-qq-escape.md`~~ — `Q:to/…/` wrongly
+  honoured `\qq[…]`; raku leaves it literal. Fixed 2026-07-26; it was **not**
+  the `Template6` blocker.
+- ~~`todo/tickets/regex-brace-paren-inside-char-class-swallows-rest-of-pattern.md`~~
+  — a literal `{` / `(` inside a `<[...]>` char class made
+  `scan_angle_assertion_body()` miss the assertion's closing `>`. Fixed;
+  `news/2026-08/regex-char-class-literal-brace-paren.md`. Took
+  `Template::Jinja2`'s `01-lexer` from 0/15 to 15/15.
+- ~~`todo/tickets/qualified-private-method-call-uses-short-owner-name.md`~~ — a
+  qualified private call `$obj!Renderer::meth` inside
+  `module Template::Jinja2::Renderer` compared the owner name as written against
+  the fully-qualified caller class. Fixed;
+  `news/2026-08/private-method-qualified-short-owner-in-module.md`. It was
+  **not** the last Jinja2 load blocker — an imported-`is export`ed-type parse
+  bug was stacked behind it, fixed 2026-09-06 (pin
+  `t/when-imported-exported-type.t`).
+- Open, from the 2026-09-06 re-measurement:
+  `todo/tickets/array-arg-mutation-lost-on-the-second-call-through-a-slurpy-relay.md`,
+  `todo/tickets/template6-include-local-data-not-reaching-the-included-stash.md`,
+  `todo/tickets/trailing-comma-in-attribute-default-drops-the-declaration.md`,
+  `todo/tickets/template-mojo-residual-failures.md`,
+  `todo/tickets/grammar-heavy-module-load-slower-than-raku.md`.
 - `todo/deep/template-engines-blocked-on-mutsu.md` — this matrix as a work item.
 
 ## How the field was surveyed
@@ -165,13 +189,12 @@ version and its own suite run under both `raku` and `target/debug/mutsu`
   `Template::Classic` embed Raku code. For "a small web blog", logic-free plus
   the host program's own code is the safer default, and it is what most of the
   ecosystem picked.
-- **`Template::Jinja2` deserves a second look after its blockers are fixed** — it
-  is the newest of the field (2026-04-29), 22/23 under raku, and as of the
-  2026-08-19 reduction both of its mutsu blockers are **one-function interpreter
-  bugs** (a char-class scanning bug and a private-method permission check), one
-  of which kills 22 files at once. So it stays the cheapest of the field to
-  unblock. Its ecosystem standing is weak (2 dependents, both by the same
-  author).
+- **`Template::Jinja2` deserves a second look once it loads** — it is the newest
+  of the field (2026-04-29) and 22/23 under raku. Both blockers named in the
+  2026-08-19 reduction are fixed and `01-lexer` passes, but a third one (a
+  `when TYPENAME {` parse bug) still kills the remaining 22 files at load, so it
+  is still the cheapest of the field to unblock by file count. Its ecosystem
+  standing is weak (2 dependents, both by the same author).
 - **`Template::Protone` and `ERK` were never in contention**: they ship no tests
   at all, so there is nothing to gate at release time — a structural problem for
   a battery whose whole verification story is `scripts/battery-testsuite.sh`.
@@ -179,9 +202,10 @@ version and its own suite run under both `raku` and `target/debug/mutsu`
 The deciding move was that Mustache's failure turned out to be **one interpreter
 bug**, not a pile of them, so fixing it both unblocked the strongest candidate
 and improved mutsu generally. The other engines' blockers stay on the work list
-(`todo/deep/template-engines-blocked-on-mutsu.md`); `Template6` in particular is
-worth fixing so the slot has a real second option rather than a single viable
-choice.
+(`todo/deep/template-engines-blocked-on-mutsu.md`). `Template6` was fixed for
+exactly that reason — so the slot has a real second option rather than a single
+viable choice — and now runs 10 of its 12 files
+(`news/2026-09/template6-zero-to-ten-of-twelve.md`).
 
 ## Provenance and update procedure
 

--- a/news/2026-09/template6-zero-to-ten-of-twelve.md
+++ b/news/2026-09/template6-zero-to-ten-of-twelve.md
@@ -1,0 +1,138 @@
+# `Template6` goes 0/12 → 10/12 on four general interpreter fixes (and Jinja2 finally loads)
+
+The template-engine survey (`todo/deep/template-engines-blocked-on-mutsu.md`)
+was re-measured on 2026-09-06 — every row in it had gone stale — and
+`Template6` 0.16.0, the runner-up for the template battery slot, was reduced
+from its long-standing "unreduced, `Use of Nil in string context`" state. That
+warning was, as the deep file's own lesson predicted, a pointer and not the
+diagnosis: reducing `Parser.compile` by deletion turned up **four separate,
+entirely general interpreter bugs**, none of them about the warning. Fixing them
+takes the dist from **0 of 12** upstream test files to **10 of 12**. A fifth bug,
+found while re-measuring the *other* rows of the same survey, ships alongside
+them: it is what finally makes `Template::Jinja2` loadable (0/23 → 3/23).
+
+The survey itself was the other half of the work. Four of its eight rows had
+moved since the last measurement without anyone noticing, so
+`todo/deep/template-engines-blocked-on-mutsu.md` and
+`docs/batteries/templates.md` now carry fresh counts and a measurement log.
+
+## 1. A `split(/regex/, :v)` separator Match had no named captures
+
+`Template6::Parser.compile` splits a template with
+
+```raku
+$template.split(/ $<prefix-linebreak>=(\n?) '[%' $<comment-signature>=('#'?)
+                  \s* $<tokens>=(.*?) \s* '%]' /, :v)
+```
+
+and then reads `~$segment<tokens>` off each separator `Match`. Every one of
+those came back `Nil`: the separator Match was built by
+`make_match_object_with_captures` with a hard-coded empty named map, and only
+text-flattened positional captures (whose `.from`/`.to` were fabricated `0..len`
+spans over the separator text rather than offsets into the split subject). The
+list-of-splitters form (`.split([/a/, ','], :v)`) dropped even the positional
+ones.
+
+Both runtime split paths now obtain the engine's real `RegexCaptures`
+(`regex_match_with_captures_from`, the same entry point `.match` uses) and build
+the separator Match with `make_match_object_full_visible` — the identical
+construction `~~ /…/` performs. `SplitMatch` carries the finished Match instead
+of a `Vec<String>` of capture texts, and `separator_value` is now just "the
+engine's Match, or the matched text for a string splitter". Pin:
+`t/split-regex-separator-captures.t`.
+
+## 2. `.subst(..., :nth(2..*))` aborted the process with a Rust panic
+
+`Parser.compile` ends with
+`$script.subst(/ 'my %localdata;' /, '', :nd(2..*)).EVAL`. `subst_nth_indices`
+expanded a Range adverb eagerly, so an infinite upper bound became
+`(2..=i64::MAX).collect()` and the process died with `capacity overflow` from
+`raw_vec`. Range arguments now join `:nth(*)` / `:nth(*-1)` on the *deferred*
+path, resolved against the actual match count by `resolve_nth_value_indices` —
+which already clamps correctly, and which gained the two Range flavours it was
+missing (`1^..3`, `1^..^4`, previously "Cannot convert '2 3' to integer for
+:nth"). The literal-string `.subst` branch also learned to consult the deferred
+list at all; it used to ignore it and substitute nothing. Pin:
+`t/subst-nth-range.t`.
+
+## 3. An attribute default's closure was stamped with the CONSTRUCTING class
+
+`has %!directive-handlers = … default => (-> @, **@values { parse-set(…) }, …)`
+could not call `parse-set`, a file-scoped sub in the same
+`unit class Template6::Parser` — but only when `Template6::Context::BUILD`
+constructed the parser, never when the script constructed it directly, which is
+what made it look like a scoping mystery.
+
+An attribute default is lowered to bytecode when the class is declared but
+*executed* inside whatever frame calls `.new`. `lexical_closure_package()`
+walked the routine stack first and found the constructing caller's method, so it
+stamped the caller's class onto every closure the default built; the closure
+then ran under the wrong package and `bare_name_packages()` never contained the
+declaring one. `eval_attr_default_expr` already sets `constructing_class` — the
+one and only producer of that field, and an exact "we are inside an attribute
+default of class X" signal — so `lexical_closure_package()` now consults it
+first. Pin: `t/attr-default-closure-package.t` (plus two fixture modules under
+`t/lib/`, since the bug only appears across a module boundary).
+
+## 4. Assigning to `$_` inside a nested block was discarded on block exit
+
+`Context.get-template-block` caches a compiled template with
+
+```raku
+given $template {
+    if $_ !~~ Callable { $_ = $.parser.compile($_) }
+    %.blocks{$d}{$d.^name} = $_;
+}
+```
+
+and mutsu cached the raw template *text*, so the second `process` of the same
+template died with `No such method 'CALL-ME' for invocant of type 'Str'`.
+
+`OpCode::BlockScope`'s env restore skipped `_` unconditionally, on the grounds
+that "the lexical topic is block-scoped". That is true of a block that *binds*
+its own topic (a `for`/`given`/`when` body, a pointy `-> $_`) and false of a
+plain nested block, whose `$_` simply IS the enclosing topic. The write still
+reached the topic's source variable through its container, so `$template` and
+`$_` disagreed from the next statement onwards — which is why the symptom was so
+strange. The skip is now conditional on the block actually containing a
+topic-binding opcode. The same fix repairs `sub f($_ is rw)`, where a write
+inside a nested block reached neither the sub's own later reads nor the caller.
+Pin: `t/topic-assign-in-nested-block.t`; `t/for-topic-restore.t` still passes.
+
+## 5. A `use`d module's `is export`ed types never reached the parse-time type index
+
+Found while re-measuring the rest of the survey, and shipped in the same change
+because it is the same kind of bug. `when SomeType { … }` needs the parser to
+know `SomeType` is a type — an undeclared bareword there really does gobble the
+block in Raku, and mutsu diagnoses that. The parse-time type index is built by
+scanning each `use`d module's source, but a trait on a declarator
+(`class Cond is export { }`) makes the parser wrap the declaration in a bare
+`Stmt::Block`, and `collect_module_type_names_under` never walked into one. So
+**every `is export`ed class, role, grammar and enum in a `use`d module was
+invisible** to the importer's parser, and `when Cond { }` failed to compile with
+"Function 'Cond' needs parens to avoid gobbling block". Imported enum *values*
+had the same hole.
+
+Bare blocks are now walked (with the same package prefix, since a bare block
+introduces no package level), and imported type names are registered in the
+outermost scope like imported enum values and constants already were, so they
+stay visible for the rest of the importing file. This is what kept
+`Template::Jinja2` from loading at all: its `Renderer.rakumod` dispatches on the
+AST node types it imports, `when If { … } when For { … }`. With it fixed the
+dist loads and runs 3 of its 23 files (up from 1). Pin:
+`t/when-imported-exported-type.t` plus `t/lib/ExportedTypeIndex.rakumod`.
+
+## Where `Template6` stands
+
+10 of 12 files pass. The two that remain are filed separately, both reduced:
+
+- `todo/tickets/array-arg-mutation-lost-on-the-second-call-through-a-slurpy-relay.md`
+  — an `@`-parameter mutation reaches the caller on the first call through a
+  slurpy relay and is silently lost on every later one (18-line repro, not the
+  JIT). This is `t/02-for.rakutest`.
+- `todo/tickets/template6-include-local-data-not-reaching-the-included-stash.md`
+  — `[% INCLUDE "x" name = "World" %]` renders `name` instead of `World`. This
+  is `t/05-includes.rakutest`.
+
+A third finding, unrelated to `Template6` but hit while writing the pins, is
+`todo/tickets/trailing-comma-in-attribute-default-drops-the-declaration.md`.

--- a/src/builtins/split.rs
+++ b/src/builtins/split.rs
@@ -123,8 +123,11 @@ pub(crate) struct SplitMatch {
     pub is_regex: bool,
     /// The original string being split (needed for Match object construction).
     pub orig: String,
-    /// Positional captures from regex match (for :v Match objects).
-    pub positional_captures: Vec<String>,
+    /// The fully-built separator `Match` for a regex splitter, carrying the
+    /// span-bearing positional AND named captures the engine recorded. Only the
+    /// runtime split paths hold the engine's `RegexCaptures`, so only they set
+    /// it; a string splitter leaves it `None` and reports `matched` instead.
+    pub match_obj: Option<Value>,
 }
 
 /// Split a string by a string splitter. Returns list of (segment, Option<match>).
@@ -169,7 +172,7 @@ fn split_by_string(
                     splitter_index: 0,
                     is_regex: false,
                     orig: String::new(),
-                    positional_captures: Vec::new(),
+                    match_obj: None,
                 }),
             ));
             seg_start = match_pos;
@@ -215,7 +218,7 @@ fn split_by_string(
                         splitter_index: 0,
                         is_regex: false,
                         orig: String::new(),
-                        positional_captures: Vec::new(),
+                        match_obj: None,
                     }),
                 ));
                 pos = match_pos + sep_len;
@@ -296,7 +299,7 @@ fn split_by_strings(
                         splitter_index: splitter_idx,
                         is_regex: false,
                         orig: String::new(),
-                        positional_captures: Vec::new(),
+                        match_obj: None,
                     }),
                 ));
                 pos = match_pos + match_len;
@@ -311,31 +314,12 @@ fn split_by_strings(
     }
 }
 
-/// Create a separator value: Match object for regex splits, string for string splits.
+/// Create a separator value: the engine-built Match object for regex splits,
+/// the matched text for string splits.
 fn separator_value(m: &SplitMatch) -> Value {
-    if m.is_regex {
-        use std::collections::HashMap;
-        // A separator Match's subject: the whole split subject when known,
-        // else the separator text itself (spans are then 0-based over it).
-        let target = if m.orig.is_empty() {
-            crate::runtime::MatchTarget::new(&m.matched)
-        } else {
-            crate::runtime::MatchTarget::new(&m.orig)
-        };
-        let (from, to) = if m.orig.is_empty() {
-            (0, m.matched.chars().count() as i64)
-        } else {
-            (m.from as i64, m.to as i64)
-        };
-        Value::make_match_object_with_captures(
-            from,
-            to,
-            &m.positional_captures,
-            &HashMap::new(),
-            target,
-        )
-    } else {
-        Value::str(m.matched.clone())
+    match &m.match_obj {
+        Some(obj) => obj.clone(),
+        None => Value::str(m.matched.clone()),
     }
 }
 

--- a/src/parser/stmt/simple.rs
+++ b/src/parser/stmt/simple.rs
@@ -74,8 +74,8 @@ pub(in crate::parser) use module_exports::{
 };
 pub(in crate::parser) use pragma_preseed::{
     current_attributes_pragma, is_imported_value_term, is_user_declared_enum_value,
-    is_user_declared_sub, is_user_declared_type, push_package_path, register_imported_value_term,
-    register_user_enum_value, register_user_type, register_user_type_verbatim, reset_package_path,
+    is_user_declared_sub, is_user_declared_type, push_package_path, register_imported_type,
+    register_imported_value_term, register_user_enum_value, register_user_type, reset_package_path,
     set_attributes_pragma, set_eval_imported_function_preseed, set_eval_operator_assoc_preseed,
     set_eval_operator_preseed, set_eval_user_sub_preseed, set_eval_user_type_preseed,
     set_eval_user_value_term_preseed,

--- a/src/parser/stmt/simple/module_exports.rs
+++ b/src/parser/stmt/simple/module_exports.rs
@@ -197,7 +197,7 @@ fn apply_scan_types(scan: &ModuleScanResult) {
     for name in &scan.type_names {
         // The names are already fully composed; a `use` that appears inside
         // a package block must not compose them a second time.
-        register_user_type_verbatim(name);
+        register_imported_type(name);
     }
     // An enum's *values* travel with it. Without this a bare
     // `MYSQL_TYPE_BLOB` in the importing file is an unknown identifier, and
@@ -703,7 +703,11 @@ fn collect_module_enum_values(stmts: &[Stmt], out: &mut Vec<String>) {
             }
             Stmt::ClassDecl { body, .. }
             | Stmt::RoleDecl { body, .. }
-            | Stmt::Package { body, .. } => collect_module_enum_values(body, out),
+            | Stmt::Package { body, .. }
+            // A traited declarator (`enum E is export < a b >`) is wrapped in a
+            // bare block by the parser; walk into it like any other body.
+            | Stmt::Block(body)
+            | Stmt::SyntheticBlock(body) => collect_module_enum_values(body, out),
             _ => {}
         }
     }
@@ -772,6 +776,17 @@ fn collect_module_type_names_under(stmts: &[Stmt], prefix: &str, out: &mut Vec<S
                 if *is_unit {
                     prefix = composed;
                 }
+            }
+            // A trait on a declarator (`class Foo is export { }`) makes the
+            // parser wrap the declaration in a bare `Stmt::Block`. A bare block
+            // introduces no package level, so it is walked with the SAME
+            // prefix — without this, EVERY `is export`ed class in a `use`d
+            // module was invisible to the importer's parse-time type index,
+            // and `when SomeImportedType { … }` was diagnosed as an undeclared
+            // bareword gobbling its block. (A `unit` declarator is never
+            // wrapped this way, so no prefix has to be carried back out.)
+            Stmt::Block(body) | Stmt::SyntheticBlock(body) => {
+                collect_module_type_names_under(body, &prefix, out);
             }
             _ => {}
         }

--- a/src/parser/stmt/simple/pragma_preseed.rs
+++ b/src/parser/stmt/simple/pragma_preseed.rs
@@ -126,6 +126,32 @@ pub(crate) fn register_user_type_verbatim(name: &str) {
     });
 }
 
+/// Register a type name harvested from a `use`d module.
+///
+/// Registered in **both** the current and the outermost scope, for the same
+/// reason as an imported enum value or `constant`
+/// ([`register_user_enum_value`], [`register_imported_value_term`]): an
+/// imported type must stay visible for the rest of the importing file, not
+/// only until whatever scope happened to be innermost when the `use` was
+/// parsed is popped. Registering it innermost-only meant `when SomeImportedType
+/// { … }` was diagnosed as an undeclared bareword gobbling its block — the
+/// parse error that kept `Template::Jinja2` from loading.
+pub(crate) fn register_imported_type(name: &str) {
+    SCOPES.with(|s| {
+        let mut scopes = s.borrow_mut();
+        scopes
+            .first_mut()
+            .expect("scope stack should never be empty")
+            .user_types
+            .insert(name.to_string());
+        scopes
+            .last_mut()
+            .expect("scope stack should never be empty")
+            .user_types
+            .insert(name.to_string());
+    });
+}
+
 /// Register a user-declared type name (class, role, grammar, enum).
 pub(crate) fn register_user_type(name: &str) {
     register_user_type_verbatim(name);

--- a/src/runtime/accessors_state.rs
+++ b/src/runtime/accessors_state.rs
@@ -569,6 +569,19 @@ impl Interpreter {
     /// the class for some method shapes (class-scoped subs, package lexicals, a
     /// `::`-qualified owner), so fall back to the running method's class.
     pub(crate) fn lexical_closure_package(&self) -> String {
+        // An attribute default (`has $.x = -> { helper() }`) is lowered at class
+        // declaration time but RUN inside the constructing caller's frame, so
+        // the routine walk below would see the caller's method and stamp the
+        // caller's class onto the closure — the closure then ran under the wrong
+        // package and could not see its own class's file-scoped subs (only when
+        // `.new` was called from another module, which is what made it look like
+        // a scoping mystery). `constructing_class` is set by exactly one place,
+        // `eval_attr_default_expr`, and means precisely "we are evaluating an
+        // attribute default of this class", so it is the authoritative answer
+        // here.
+        if let Some(class) = &self.constructing_class {
+            return class.clone();
+        }
         // A closure created inside a METHOD body lexically belongs to that
         // method's class, even when `current_package` still holds the CALLER's
         // package (method dispatch pushes `method_class_stack` but does not

--- a/src/runtime/builtins_string.rs
+++ b/src/runtime/builtins_string.rs
@@ -317,6 +317,19 @@ impl Interpreter {
         }
     }
 
+    /// Build the `Match` object a `:v`/`:kv`/`:p` split reports for one regex
+    /// separator. It is the same construction `~~ /…/` and `.match` use, so a
+    /// separator Match carries the engine's span-bearing positional AND named
+    /// captures (`$<name>` on a split separator used to come back `Nil`) and
+    /// their `.from`/`.to` are real offsets into the split subject.
+    fn split_separator_match(&mut self, mut caps: RegexCaptures, text: &str) -> Value {
+        let from = caps.from as i64;
+        let to = caps.to as i64;
+        let mtarget = caps.target_or_new(text);
+        self.reduce_regex_captures_made(&mut caps, Some(&mtarget));
+        Value::make_match_object_full_visible(from, to, &caps.positional, &caps.named, mtarget)
+    }
+
     /// Split by a single regex pattern.
     fn split_by_regex(
         &mut self,
@@ -354,11 +367,11 @@ impl Interpreter {
             }
 
             // Try to match regex starting from search_from, using full text for context
-            if let Some((from, to, pcaps)) =
-                self.regex_find_first_from_with_captures(pattern, text, search_from)
-            {
+            if let Some(caps) = self.regex_match_with_captures_from(pattern, text, search_from) {
+                let (from, to) = (caps.from, caps.to);
                 let segment: String = chars[pos..from].iter().collect();
                 let matched: String = chars[from..to].iter().collect();
+                let match_obj = self.split_separator_match(caps, text);
                 result.push((
                     segment,
                     Some(SplitMatch {
@@ -368,7 +381,7 @@ impl Interpreter {
                         splitter_index: 0,
                         is_regex: true,
                         orig: text.to_string(),
-                        positional_captures: pcaps,
+                        match_obj: Some(match_obj),
                     }),
                 ));
                 splits_done += 1;
@@ -426,20 +439,24 @@ impl Interpreter {
                 return Ok(result);
             }
 
-            // (abs_from, abs_to, idx, matched, is_regex) — positions in full text
-            let mut best: Option<(usize, usize, usize, String, bool)> = None;
+            // (abs_from, abs_to, idx, matched, captures) — positions in full text.
+            // `captures` is `Some` exactly when the winning splitter was a regex.
+            let mut best: Option<(usize, usize, usize, String, Option<RegexCaptures>)> = None;
 
             for (idx, splitter) in splitters.iter().enumerate() {
                 match splitter.view() {
                     ValueView::Regex(_) | ValueView::RegexWithAdverbs(_) => {
                         let found = match splitter.view() {
-                            ValueView::Regex(p) => self.regex_find_first_from(&p, text, pos),
+                            ValueView::Regex(p) => {
+                                self.regex_match_with_captures_from(&p, text, pos)
+                            }
                             ValueView::RegexWithAdverbs(a) => {
-                                self.regex_find_first_from(&a.pattern, text, pos)
+                                self.regex_match_with_captures_from(&a.pattern, text, pos)
                             }
                             _ => unreachable!(),
                         };
-                        if let Some((from, to)) = found {
+                        if let Some(caps) = found {
+                            let (from, to) = (caps.from, caps.to);
                             let matched: String = chars[from..to].iter().collect();
                             let is_better = match &best {
                                 None => true,
@@ -448,7 +465,7 @@ impl Interpreter {
                                 }
                             };
                             if is_better {
-                                best = Some((from, to, idx, matched, true));
+                                best = Some((from, to, idx, matched, Some(caps)));
                             }
                         }
                     }
@@ -471,7 +488,7 @@ impl Interpreter {
                                             start + sep_chars.len(),
                                             idx,
                                             sep.clone(),
-                                            false,
+                                            None,
                                         ));
                                     }
                                     break;
@@ -483,8 +500,10 @@ impl Interpreter {
             }
 
             match best {
-                Some((from, to, idx, matched, is_regex)) => {
+                Some((from, to, idx, matched, caps)) => {
                     let segment: String = chars[pos..from].iter().collect();
+                    let is_regex = caps.is_some();
+                    let match_obj = caps.map(|c| self.split_separator_match(c, text));
                     result.push((
                         segment,
                         Some(SplitMatch {
@@ -494,7 +513,7 @@ impl Interpreter {
                             splitter_index: idx,
                             is_regex,
                             orig: text.to_string(),
-                            positional_captures: Vec::new(),
+                            match_obj,
                         }),
                     ));
                     pos = to;
@@ -559,7 +578,7 @@ fn split_by_string_static(
                     splitter_index: 0,
                     is_regex: false,
                     orig: String::new(),
-                    positional_captures: Vec::new(),
+                    match_obj: None,
                 }),
             ));
             seg_start = match_pos;
@@ -605,7 +624,7 @@ fn split_by_string_static(
                         splitter_index: 0,
                         is_regex: false,
                         orig: String::new(),
-                        positional_captures: Vec::new(),
+                        match_obj: None,
                     }),
                 ));
                 pos = match_pos + sep_len;
@@ -689,7 +708,7 @@ fn split_by_strings_static(
                         splitter_index: splitter_idx,
                         is_regex: false,
                         orig: String::new(),
-                        positional_captures: Vec::new(),
+                        match_obj: None,
                     }),
                 ));
                 pos = match_pos + match_len;

--- a/src/runtime/methods_match_dispatch.rs
+++ b/src/runtime/methods_match_dispatch.rs
@@ -424,6 +424,25 @@ impl Interpreter {
                     }
                 }
             }
+            // `1^..3` / `1^..^4`: the excluded start is simply the next index.
+            ValueView::RangeExclStart(start, end) => {
+                Self::validate_nth_value(start + 1)?;
+                let effective_end = (end as usize).min(total_matches) as i64;
+                for i in (start + 1)..=effective_end {
+                    if i > 0 {
+                        indices.push(i as usize);
+                    }
+                }
+            }
+            ValueView::RangeExclBoth(start, end) => {
+                Self::validate_nth_value(start + 1)?;
+                let effective_end = (end as usize).min(total_matches + 1) as i64;
+                for i in (start + 1)..effective_end {
+                    if i > 0 && (i as usize) <= total_matches {
+                        indices.push(i as usize);
+                    }
+                }
+            }
             ValueView::GenericRange {
                 start,
                 end,

--- a/src/runtime/methods_string.rs
+++ b/src/runtime/methods_string.rs
@@ -73,6 +73,8 @@ impl Interpreter {
         )
     }
 
+    /// Only reached for values [`Self::is_deferred_nth_value`] rejected, so
+    /// every Range that gets here has a bounded, small upper end.
     fn subst_nth_indices(value: &Value) -> Vec<i64> {
         match value.view() {
             ValueView::Int(n) => vec![n],
@@ -83,6 +85,45 @@ impl Interpreter {
             ValueView::RangeExclBoth(lo, hi) => ((lo + 1)..hi).collect(),
             _ => vec![value.to_f64() as i64],
         }
+    }
+
+    /// The largest `:nth` Range endpoint still expanded eagerly by
+    /// [`Self::subst_nth_indices`]. A substitution can never have more matches
+    /// than the subject has characters, so anything past this is only ever
+    /// clamped away — and expanding it costs 8 bytes per index.
+    const NTH_EAGER_RANGE_LIMIT: i64 = 100_000;
+
+    /// Whether a `:nth` argument can only be turned into concrete indices once
+    /// the match count is known. `Whatever`/`WhateverCode` obviously can; so can
+    /// an unbounded Range: `:nth(2..*)` has an infinite upper end, and expanding
+    /// it eagerly asked for an `i64::MAX`-element `Vec` (a `capacity overflow`
+    /// abort). These go through `resolve_nth_value_indices`, which clamps every
+    /// Range flavour to the number of matches — the same resolution
+    /// `.match(:nth(...))` already uses. A small bounded Range stays on the
+    /// eager path, where its literal length also decides `result_is_list`.
+    fn is_deferred_nth_value(value: &Value) -> bool {
+        if matches!(value.view(), ValueView::Whatever) || Self::is_whatever_code_value(value) {
+            return true;
+        }
+        Self::deferred_nth_range_end(value).is_some()
+    }
+
+    /// The upper endpoint of a `:nth` Range too large to expand eagerly, or
+    /// `None` when the value is not such a Range. Also the "this spec selects a
+    /// whole span of matches, not one" signal `result_is_list` needs.
+    fn deferred_nth_range_end(value: &Value) -> Option<i64> {
+        let hi = match value.view() {
+            ValueView::Range(_, hi)
+            | ValueView::RangeExcl(_, hi)
+            | ValueView::RangeExclStart(_, hi)
+            | ValueView::RangeExclBoth(_, hi) => hi,
+            // A `GenericRange` was never expanded by `subst_nth_indices` at all
+            // (it fell through to the numify-the-whole-value arm); the deferred
+            // resolver understands it, including an `Inf`/`*` end.
+            ValueView::GenericRange { .. } => return Some(i64::MAX),
+            _ => return None,
+        };
+        (hi > Self::NTH_EAGER_RANGE_LIMIT).then_some(hi)
     }
 
     /// Build the `$/` value after a multi-match substitution. With a List-result
@@ -202,8 +243,8 @@ impl Interpreter {
         let mut positional: Vec<Value> = Vec::new();
         let mut global = false;
         let mut nth: Option<Vec<i64>> = None;
-        // `:nth(*)` / `:nth(*-1)` can only be resolved once the match count is
-        // known, so keep the raw Whatever/WhateverCode for deferred resolution.
+        // `:nth(*)` / `:nth(*-1)` / `:nth(2..*)` can only be resolved once the
+        // match count is known, so keep the raw value for deferred resolution.
         let mut nth_deferred: Vec<Value> = Vec::new();
         let mut x_count: Option<Value> = None;
         let mut pos_start: Option<usize> = None;
@@ -218,9 +259,7 @@ impl Interpreter {
                     // select 1-based match indices. The argument may be an Int, a
                     // list of Ints, or a Range (`:nth(1..3)`).
                     "nth" | "st" | "nd" | "rd" | "th" => {
-                        if matches!(value.view(), ValueView::Whatever)
-                            || Self::is_whatever_code_value(value)
-                        {
+                        if Self::is_deferred_nth_value(value) {
                             // Resolved later against the match count.
                             nth_deferred.push(value.clone());
                             nth.get_or_insert_with(Vec::new);
@@ -355,8 +394,14 @@ impl Interpreter {
                 // for `:g`/`:x`/multi-`:nth`, but a single Match for a single-index
                 // `:nth` (even when combined with `:g`, e.g. `s:2nd:g/./Z/`).
                 let nth_len = nth.as_ref().map(|v| v.len());
-                let single_nth = nth_len == Some(1);
-                let nth_is_multi = nth_len.is_some_and(|n| n > 1);
+                // A deferred Range (`:nth(2..*)`) selects a span of matches, so
+                // it is "multi" even though its indices are not known yet; a
+                // deferred `Whatever` selects exactly one and is not.
+                let deferred_nth_is_range = nth_deferred
+                    .iter()
+                    .any(|v| Self::deferred_nth_range_end(v).is_some());
+                let single_nth = nth_len == Some(1) && !deferred_nth_is_range;
+                let nth_is_multi = nth_len.is_some_and(|n| n > 1) || deferred_nth_is_range;
                 let result_is_list =
                     !single_nth && (pat_global || x_count.is_some() || nth_is_multi);
                 let empty_match_var = |me: &mut Self| {
@@ -549,6 +594,20 @@ impl Interpreter {
                     }
                     if !global && nth.is_none() && x_count.is_none() {
                         keep.truncate(1);
+                    }
+                    // Resolve any deferred `:nth(*)` / `:nth(*-1)` / `:nth(2..*)`
+                    // now that the match count is known — the literal-pattern
+                    // branch used to ignore them entirely, silently substituting
+                    // nothing.
+                    if !nth_deferred.is_empty() {
+                        let total = keep.len();
+                        let mut extra: Vec<i64> = Vec::new();
+                        for spec in &nth_deferred {
+                            let resolved = self.resolve_nth_value_indices(spec, total)?;
+                            extra.extend(resolved.into_iter().map(|i| i as i64));
+                        }
+                        extra.sort_unstable();
+                        nth.get_or_insert_with(Vec::new).extend(extra);
                     }
                     if let Some(ref nth_list) = nth {
                         Self::validate_subst_nth_list(nth_list)?;

--- a/src/runtime/regex/regex_match_find.rs
+++ b/src/runtime/regex/regex_match_find.rs
@@ -307,56 +307,9 @@ impl Interpreter {
         out
     }
 
-    /// Find first regex match in text, starting search from `min_pos` (char index).
-    /// Returns (from, to) as char indices in the full text.
-    /// Unlike `regex_find_first`, this preserves full-text context for zero-width assertions.
-    pub(crate) fn regex_find_first_from(
-        &mut self,
-        pattern: &str,
-        text: &str,
-        min_pos: usize,
-    ) -> Option<(usize, usize)> {
-        let parsed = self.parse_regex(pattern)?;
-        let pkg = self.current_package();
-        let orig_chars: Vec<char> = text.chars().collect();
-        if parsed.anchor_start && min_pos > 0 {
-            return None;
-        }
-        if parsed.ignore_mark {
-            let (stripped_chars, pos_map) = strip_marks_text(&orig_chars);
-            let stripped_parsed = strip_marks_pattern(&parsed);
-            let orig_len = orig_chars.len();
-            let stripped_min = pos_map
-                .iter()
-                .position(|&p| p >= min_pos)
-                .unwrap_or(stripped_chars.len());
-            let search_start = if stripped_parsed.anchor_start {
-                0
-            } else {
-                stripped_min
-            };
-            for start in search_start..=stripped_chars.len() {
-                if let Some(end) =
-                    self.regex_match_end_from_in_pkg(&stripped_parsed, &stripped_chars, start, &pkg)
-                {
-                    return Some((
-                        map_pos(start, &pos_map, orig_len),
-                        map_pos(end, &pos_map, orig_len),
-                    ));
-                }
-            }
-            return None;
-        }
-        let search_start = if parsed.anchor_start { 0 } else { min_pos };
-        for start in search_start..=orig_chars.len() {
-            if let Some(end) = self.regex_match_end_from_in_pkg(&parsed, &orig_chars, start, &pkg) {
-                return Some((start, end));
-            }
-        }
-        None
-    }
-
-    /// Like `regex_find_first_from` but also returns positional captures.
+    /// Find the first match from `min_pos`, returning its positional captures.
+    /// Unlike `regex_find_first`, this preserves full-text context for zero-width
+    /// assertions.
     pub(crate) fn regex_find_first_from_with_captures(
         &mut self,
         pattern: &str,

--- a/src/vm/vm_misc_scope.rs
+++ b/src/vm/vm_misc_scope.rs
@@ -455,6 +455,36 @@ impl Interpreter {
                 _ => None,
             })
             .collect();
+        // Does this block bind a topic of its own anywhere in its range? Only
+        // then is `$_` block-scoped and must not be written back on exit (see
+        // the restore loop below). Kept deliberately broad — every opcode that
+        // can leave `$_` pointing at something this block chose counts, and a
+        // `$_ := …` rebinding (`MarkRebindContext` + a store to `_`) is such a
+        // binding too, even though a plain `$_ = …` assignment is not.
+        let block_ops = &code.ops[pre_start..end];
+        let binds_own_topic = block_ops.iter().any(|op| {
+            matches!(
+                op,
+                OpCode::SetTopic
+                    | OpCode::SaveTopic
+                    | OpCode::RestoreTopic
+                    | OpCode::EnterPointyTopic
+                    | OpCode::ExitPointyTopic
+                    | OpCode::ForLoop(_)
+                    | OpCode::Given { .. }
+                    | OpCode::DoGivenExpr { .. }
+                    | OpCode::When { .. }
+            )
+        }) || (block_ops
+            .iter()
+            .any(|op| matches!(op, OpCode::MarkRebindContext))
+            && block_ops.iter().any(|op| match op {
+                OpCode::SetGlobal(idx) => code
+                    .constants
+                    .get(*idx as usize)
+                    .is_some_and(|c| matches!(c.view(), ValueView::Str(s) if s.as_str() == "_")),
+                _ => false,
+            }));
         let routine_snapshot = self.snapshot_routine_registry();
         let saved_env = self.env().clone();
         // Under shadow slots (default) the block exit uses a targeted Nil-reset of
@@ -656,10 +686,17 @@ impl Interpreter {
                 continue;
             }
             if saved_env.contains_key_sym(k) {
-                // Lexical topic is block-scoped; don't write inner `$_` back
-                // to the outer scope on block exit. Also preserve the alias
-                // metadata for `$_` so that `:=` bindings survive block exit.
-                if k == "_" || k == "__mutsu_sigilless_alias::_" {
+                // A block that BINDS its own topic (a `for`/`given`/`when`
+                // body, a pointy `-> $_`) must not write that binding back to
+                // the enclosing scope on exit. A plain nested block binds
+                // nothing: inside `given $x { if COND { $_ = 'new' } ; say $_ }`
+                // the `if` body's `$_` IS the enclosing topic, so an assignment
+                // through it has to survive the block — skipping it wholesale
+                // made the write invisible to the very next statement (while
+                // still reaching `$x` through the topic's container, which is
+                // what made the symptom so confusing). The same rule applies to
+                // the `:=` alias metadata.
+                if (k == "_" || k == "__mutsu_sigilless_alias::_") && binds_own_topic {
                     continue;
                 }
                 // Variables declared with `my` inside this block should not

--- a/t/attr-default-closure-package.t
+++ b/t/attr-default-closure-package.t
@@ -1,0 +1,37 @@
+use lib 't/lib';
+use Test;
+use AttrDefaultClosureScope;
+use AttrDefaultClosureUser;
+
+# An attribute default (`has $.x = -> { helper() }`) is lowered to bytecode when
+# the class is declared but EXECUTED inside whatever frame calls `.new`. mutsu
+# stamped the *constructing* frame's class onto any closure the default built,
+# so the closure later ran under the wrong package and could not see its own
+# class's file-scoped subs — but only when `.new` was called from inside another
+# module's method, which is what made it look like a scoping mystery rather than
+# a bug. Reduced from `Template6`, whose `%!directive-handlers` closures could
+# not call `parse-set` once `Template6::Context::BUILD` was the constructor.
+
+plan 10;
+
+# Constructed from the mainline: this always worked.
+my $direct = AttrDefaultClosureScope.new;
+is $direct.via-attr(1), 'helper(1)', 'mainline: scalar attribute-default closure';
+is $direct.via-table('wrapped', 2), 'helper(2)', 'mainline: hash-valued default closure';
+is $direct.via-table('direct', 3), 'helper(3)', 'mainline: `&sub` term in a default';
+is $direct.via-nested(4), 'helper(4)', 'mainline: closure returned by a default closure';
+
+# Constructed from inside another module's method: this is what regressed.
+my $via = AttrDefaultClosureUser.new;
+is $via.attr(1), 'helper(1)',
+   'cross-module: scalar attribute-default closure sees its own class scope';
+is $via.table('wrapped', 2), 'helper(2)',
+   'cross-module: hash-valued default closure sees its own class scope';
+is $via.table('direct', 3), 'helper(3)',
+   'cross-module: `&sub` term in a default still resolves';
+is $via.nested(4), 'helper(4)',
+   'cross-module: a closure returned by a default closure keeps the scope';
+is $via.local(5), 'helper(5)',
+   'cross-module: a closure built in a method body is unaffected';
+is $via.direct(6), 'helper(6)',
+   'cross-module: a plain call from a method body is unaffected';

--- a/t/lib/AttrDefaultClosureScope.rakumod
+++ b/t/lib/AttrDefaultClosureScope.rakumod
@@ -1,0 +1,17 @@
+unit class AttrDefaultClosureScope;
+
+# The closures below are *lowered* when this class is declared but *run* inside
+# whatever frame calls `.new`. They must still resolve this file's lexical subs.
+has $.lazy = -> $x { helper($x) };
+has %.table =
+    direct  => &helper,
+    wrapped => (-> $x { helper($x) }),
+    nested  => (-> $x { -> $y { helper($y) } });
+
+sub helper($x) { "helper($x)" }
+
+method via-attr($x) { $!lazy($x) }
+method via-table($k, $x) { %!table{$k}($x) }
+method via-nested($x) { %!table<nested>($x)($x) }
+method via-local($x) { my $c = -> $y { helper($y) }; $c($x) }
+method direct-call($x) { helper($x) }

--- a/t/lib/AttrDefaultClosureUser.rakumod
+++ b/t/lib/AttrDefaultClosureUser.rakumod
@@ -1,0 +1,14 @@
+unit class AttrDefaultClosureUser;
+use AttrDefaultClosureScope;
+
+has $.inner;
+
+# Constructing from inside ANOTHER module's method is what used to stamp this
+# class's name onto the other class's attribute-default closures.
+submethod BUILD() { $!inner = AttrDefaultClosureScope.new }
+
+method attr($x) { $!inner.via-attr($x) }
+method table($k, $x) { $!inner.via-table($k, $x) }
+method nested($x) { $!inner.via-nested($x) }
+method local($x) { $!inner.via-local($x) }
+method direct($x) { $!inner.direct-call($x) }

--- a/t/lib/ExportedTypeIndex.rakumod
+++ b/t/lib/ExportedTypeIndex.rakumod
@@ -1,0 +1,9 @@
+unit module ExportedTypeIndex;
+
+role Node is export { }
+class Cond does Node is export { has $.x is rw = 1; }
+class Loop does Node is export { }
+enum ExpColour is export <Red Green Blue>;
+constant EXP_MARK is export = 'mark';
+
+class Plain { }

--- a/t/split-regex-separator-captures.t
+++ b/t/split-regex-separator-captures.t
@@ -1,0 +1,55 @@
+use Test;
+
+# A `.split(/regex/, :v)` separator Match is a real Match: it carries the
+# engine's NAMED captures as well as its positional ones, and every capture
+# reports a real span into the split subject. Named captures used to come back
+# `Nil` (the separator Match was built with an empty named map), which made
+# `Template6`'s `Parser.compile` — `.split(/ $<prefix-linebreak>=(\n?) '[%'
+# $<tokens>=(.*?) '%]' /, :v)` — see `~$segment<tokens>` as Nil for every
+# directive it parsed.
+
+plan 20;
+
+my $s = "aXbYc";
+
+# --- :v named captures ---------------------------------------------------
+my @v = $s.split(/ $<up>=(<[XY]>) /, :v);
+is @v.elems, 5, ':v interleaves separators';
+is @v[0], 'a', 'first segment';
+is @v[2], 'b', 'middle segment';
+is @v[4], 'c', 'last segment';
+ok @v[1] ~~ Match, 'separator is a Match';
+is ~@v[1]<up>, 'X', 'named capture on first separator';
+is ~@v[3]<up>, 'Y', 'named capture on second separator';
+
+# Spans are real offsets into the split subject, not 0-based over the
+# separator text.
+is @v[1]<up>.from, 1, 'named capture .from is a subject offset';
+is @v[1]<up>.to, 2, 'named capture .to is a subject offset';
+is @v[3]<up>.from, 3, 'second separator named capture .from';
+
+# --- positional captures still work --------------------------------------
+my @p = $s.split(/ (<[XY]>) /, :v);
+is ~@p[1][0], 'X', 'positional capture on separator';
+is @p[1][0].from, 1, 'positional capture .from is a subject offset';
+
+# --- named and positional captures side by side --------------------------
+my @b = "a12b".split(/ $<pair>=(\d) (\d) /, :v);
+is ~@b[1]<pair>, '1', 'named capture alongside a positional one';
+is ~@b[1][0], '2', 'the positional capture keeps its own slot';
+is @b[1].list.elems, 1, 'a named capture does not occupy a positional slot';
+
+# --- :kv and :p carry the same Match -------------------------------------
+my @kv = $s.split(/ $<up>=(<[XY]>) /, :kv);
+is ~@kv[2]<up>, 'X', ':kv separator keeps named captures';
+my @pr = $s.split(/ $<up>=(<[XY]>) /, :p);
+is ~@pr[1].value<up>, 'X', ':p separator keeps named captures';
+
+# --- multi-line subject, several directives ------------------------------
+my @m = "x[%a%]y[%bb%]z".split(/ '[%' $<tok>=(<-[\%]>+) '%]' /, :v);
+is @m.map({ $_ ~~ Match ?? ~$_<tok> !! $_ }).join('|'), 'x|a|y|bb|z',
+   'every separator in a multi-hit split keeps its named capture';
+
+# --- the whole separator Match still reports itself correctly -------------
+is ~@v[1], 'X', 'separator Match stringifies to the matched text';
+is @v[1].from, 1, 'separator Match .from';

--- a/t/subst-nth-range.t
+++ b/t/subst-nth-range.t
@@ -1,0 +1,39 @@
+use Test;
+
+# `.subst(..., :nth(2..*))` selects "every match from the 2nd on". mutsu used to
+# expand the Range eagerly into a Vec of indices, so an infinite upper bound
+# asked for an `i64::MAX`-element allocation and the process aborted with a Rust
+# `capacity overflow` panic. Range arguments now defer to the same resolution
+# `.match(:nth(...))` uses, which clamps every Range flavour to the number of
+# matches actually found. Reduced from `Template6`'s `Parser.compile`, which
+# ends in `$script.subst(/ 'my %localdata;' /, '', :nd(2..*))`.
+
+plan 16;
+
+my $s = "x x x x x";
+
+is $s.subst(/x/, 'Y', :nth(2..*)),  "x Y Y Y Y", ':nth with an infinite Range';
+is $s.subst(/x/, 'Y', :nd(2..*)),   "x Y Y Y Y", ':nd ordinal alias with an infinite Range';
+is $s.subst(/x/, 'Y', :st(1..*)),   "Y Y Y Y Y", ':st ordinal alias with an infinite Range';
+is $s.subst(/x/, 'Y', :nth(2..3)),  "x Y Y x x", ':nth with a bounded Range';
+is $s.subst(/x/, 'Y', :nth(2..^4)), "x Y Y x x", ':nth with an end-exclusive Range';
+is $s.subst(/x/, 'Y', :nth(1^..3)), "x Y Y x x", ':nth with a start-exclusive Range';
+is $s.subst(/x/, 'Y', :nth(1^..^4)),"x Y Y x x", ':nth with a both-exclusive Range';
+
+# A Range that runs past the end of the match list is clamped, not an error.
+is $s.subst(/x/, 'Y', :nth(4..99)), "x x x Y Y", ':nth Range past the last match is clamped';
+is $s.subst(/x/, 'Y', :nth(9..*)),  "x x x x x", ':nth Range starting past the last match matches nothing';
+
+# The non-Range forms are unaffected.
+is $s.subst(/x/, 'Y', :nth(*)),     "x x x x Y", ':nth(*) still means the last match';
+is $s.subst(/x/, 'Y', :nth(*-1)),   "x x x Y x", ':nth(*-1) still counts back from the end';
+is $s.subst(/x/, 'Y', :nth(2)),     "x Y x x x", ':nth with a plain Int';
+is $s.subst(/x/, 'Y', :nth(1, 3)),  "Y x Y x x", ':nth with a list of Ints';
+
+# Ranges work over a longer subject and with a Callable replacement too.
+my $t = "a1b2c3d4";
+is $t.subst(/\d/, '#', :nth(2..*)), "a1b#c#d#", 'Range :nth over a longer subject';
+is $t.subst(/(\d)/, { $0 * 2 }, :nth(2..*)), "a1b4c6d8", 'Range :nth with a Callable replacement';
+
+# A Range :nth on a string pattern goes through the same path.
+is "ababab".subst('a', 'Z', :nth(2..*)), "abZbZb", 'Range :nth with a string pattern';

--- a/t/topic-assign-in-nested-block.t
+++ b/t/topic-assign-in-nested-block.t
@@ -1,0 +1,99 @@
+use Test;
+
+# A plain nested block does NOT bind a topic of its own: inside
+# `given $x { if COND { $_ = 'new' }; say $_ }` the `if` body's `$_` IS the
+# enclosing topic, so an assignment through it must survive the block. mutsu's
+# block-scope restore used to drop every `$_` write on exit, so the very next
+# statement read the pre-block value — while the write still reached `$x`
+# through the topic's container, which made the two disagree. Reduced from
+# `Template6`'s `Context.get-template-block`, whose
+# `given $template { if $_ !~~ Callable { $_ = $.parser.compile($_) }; %blocks{...} = $_ }`
+# cached the raw template text instead of the compiled closure.
+
+plan 15;
+
+{
+    my $x = 'old';
+    given $x {
+        if True { $_ = 'new' }
+        is $_, 'new', 'given: $_ assigned in a nested if is visible afterwards';
+    }
+    is $x, 'new', 'given: the topic source variable is updated too';
+}
+
+{
+    my $x = 'old';
+    given $x {
+        { $_ = 'new' }
+        is $_, 'new', 'given: $_ assigned in a bare nested block is visible afterwards';
+    }
+}
+
+{
+    my $x = 'old';
+    with $x {
+        if True { $_ = 'new' }
+        is $_, 'new', 'with: $_ assigned in a nested if is visible afterwards';
+    }
+    is $x, 'new', 'with: the topic source variable is updated too';
+}
+
+{
+    my $x = 'old';
+    for $x {
+        if True { $_ = 'new' }
+        is $_, 'new', 'for: $_ assigned in a nested if is visible afterwards';
+    }
+    is $x, 'new', 'for: the topic source variable is updated too';
+}
+
+# An `is rw` `$_` parameter is the same shape.
+sub bump($_ is rw) {
+    if True { $_ = 'new' }
+    $_
+}
+{
+    my $x = 'old';
+    is bump($x), 'new', 'rw $_ parameter: the nested write is visible in the sub';
+    is $x, 'new', 'rw $_ parameter: the caller sees the write';
+}
+
+# A block that DOES bind its own topic still keeps it to itself.
+{
+    my $x = 'outer';
+    given $x {
+        for 'inner1', 'inner2' { }
+        is $_, 'outer', 'an inner for does not leak its topic to the enclosing given';
+    }
+    is $x, 'outer', 'and does not touch the topic source variable';
+}
+
+{
+    my $x = 'outer';
+    given $x {
+        given 'inner' { }
+        is $_, 'outer', 'an inner given restores the enclosing topic';
+    }
+}
+
+{
+    for ('outer',) {
+        if True {
+            for 'inner' { }
+        }
+        is $_, 'outer', 'a for nested two blocks deep still restores the topic';
+    }
+}
+
+# The mainline topic is not disturbed by a block that never touches it.
+$_ = 'mainline';
+{ my $unused = 1 }
+is $_, 'mainline', 'a block that never assigns $_ leaves the topic alone';
+
+{
+    my $x = 'old';
+    given $x {
+        if False { $_ = 'never' }
+        is $_, 'old', 'an untaken branch does not change the topic';
+    }
+}

--- a/t/when-imported-exported-type.t
+++ b/t/when-imported-exported-type.t
@@ -1,0 +1,48 @@
+use lib 't/lib';
+use Test;
+use ExportedTypeIndex;
+
+# `when SomeType { … }` needs the parser to know that `SomeType` is a type; an
+# undeclared bareword there really does gobble the block in Raku, and mutsu
+# diagnoses that. The parse-time type index is built by scanning each `use`d
+# module — but a trait on a declarator (`class Cond is export { }`) makes the
+# parser wrap it in a bare `Stmt::Block`, and the scan's collector never walked
+# into one. So EVERY `is export`ed class in a `use`d module was invisible, and
+# `when Cond { }` died at compile time with
+# "Function 'Cond' needs parens to avoid gobbling block". Reduced from
+# `Template::Jinja2`, whose `Renderer.rakumod` dispatches on its AST node types
+# exactly this way and could not be loaded at all.
+
+plan 9;
+
+sub classify($node) {
+    given $node {
+        when Cond { 'cond' }
+        when Loop { 'loop' }
+        default   { 'other' }
+    }
+}
+
+is classify(Cond.new), 'cond', 'when on an imported exported class matches';
+is classify(Loop.new), 'loop', 'the second such when matches too';
+is classify(42), 'other', 'a non-match still falls through to default';
+
+# The same name works everywhere else a type is expected, and inside a nested
+# package block (which is how the module itself is written).
+module Consumer {
+    our sub check($n) {
+        given $n {
+            when Cond { 'nested-cond' }
+            default   { 'nested-other' }
+        }
+    }
+}
+is Consumer::check(Cond.new), 'nested-cond', 'when works inside a module block';
+is Consumer::check(1), 'nested-other', 'and still falls through there';
+
+# An exported role, enum and constant come through the same scan.
+ok Cond.new ~~ Node, 'an exported role is composed';
+is classify(Cond.new), 'cond', 'the type index survives later statements';
+my $c = ExpColour::Green;
+is $c.key, 'Green', 'an exported enum value is still usable';
+is EXP_MARK, 'mark', 'an exported constant is still usable';

--- a/todo/deep/template-engines-blocked-on-mutsu.md
+++ b/todo/deep/template-engines-blocked-on-mutsu.md
@@ -1,21 +1,33 @@
 # Every Raku template engine is blocked on mutsu bugs
 
-Measured 2026-07-25 while surveying candidates for the template battery slot
-(the full table, criteria and rejections live in
+First measured 2026-07-25 while surveying candidates for the template battery
+slot (the full table, criteria and rejections live in
 [docs/batteries/templates.md](../../docs/batteries/templates.md)). The finding is
 not "which engine is best" — it is that **the whole field is healthy under raku
 and broken under mutsu**, so the battery decision is blocked on interpreter work.
 
+**Re-measured in full on 2026-09-06** — every row below is a fresh count from
+that run (debug build; a row counts whole upstream test files that pass), not a
+carried-over figure. Several rows had gone badly stale.
+
 | Candidate | raku | mutsu | First failure under mutsu |
 | --- | --- | --- | --- |
-| `Template::Mustache` 1.2.6 | 11/13 | ~~1/13~~ → **11/13** | **FIXED** — hyper `».method` did not flatten a `Slip` result; pin `t/hyper-method-slip-result.t`. Two files remain: `06-logging` (2/3), `92-specs-file` (1/10) |
-| `Template6` 0.16.0 | 12/12 | **0/12** | `Use of Nil in string context` from `Parser.compile`: a `q:to/RAKU/` heredoc whose `\qq[$safe-delimiter]` / `\qq[$segment]` come out empty |
-| `Template::Jinja2` 0.2.0 | 22/23 | **0/23 files** | **REDUCED 2026-08-19 — two interpreter bugs, both filed as tickets.** (1) `todo/tickets/regex-brace-paren-inside-char-class-swallows-rest-of-pattern.md` — a literal `{` inside `<-[{]>` makes the assertion scanner miss its closing `>`, so the `+` and every following atom is swallowed; the lexer chunks plain text one character per token. Escaping that single brace by hand takes `01-lexer` from **0/15 to 15/15**. (2) `todo/tickets/qualified-private-method-call-uses-short-owner-name.md` — `$renderer!Renderer::…` inside `module Template::Jinja2::Renderer` is rejected because the owner is compared as written (`Renderer`) against the fully-qualified caller (`Template::Jinja2::Renderer::Renderer`); this kills the other 22 files at load |
-| `Template::Mojo` 0.2.2 | 5/5 | ~~0/5~~ → **4 of 5 files run** | **FIXED 2026-07-26** (#5468, `news/2026-07/regex-assertion-quoted-angle-brackets.md`): a quoted `<`/`>` inside a regex lookaround broke the parse — not a named-capture bug. Now 00-basic 15/17, 01-template 3/3, 02-complex 1/1, 04-native-named 1/1; residue in `todo/tickets/template-mojo-residual-failures.md` |
-| `Template::Nest::Fast` 0.3.0 | 10/10 | **0/10** | `Use of Nil in string context` |
-| `Template::HAML` 0.9.5 | 82/83 | 14/83 | many; also **2–3× slower to load than raku** (release) → `todo/tickets/grammar-heavy-module-load-slower-than-raku.md` |
-| `SP6` 0.2.1 | 10/11 | 6/11 | `Use of uninitialized value element of type Any in string context` |
-| `Template::Classic` 0.0.3 | 1/1 | 0/1 | `X::Method::NotFound: Unknown method value dispatch (fallback dispatch)` |
+| `Template::Mustache` 1.2.6 | 11/13 ¹ | **13/13** | none — the bundled battery |
+| `Template6` 0.16.0 | 12/12 | ~~0/12~~ → **10/12** | **REDUCED AND LARGELY FIXED 2026-09-06** (`news/2026-09/template6-zero-to-ten-of-twelve.md`). The `Use of Nil in string context` headline was, as this file predicted, a pointer and not the diagnosis: reducing `Parser.compile` by deletion found four unrelated general bugs — a split-`:v` separator `Match` carried no named captures; `.subst(…, :nth(2..*))` aborted the process with a Rust `capacity overflow`; an attribute default's closure was stamped with the *constructing* class and lost its own file's subs; and an assignment to `$_` inside a nested block was discarded on block exit. Two files remain, both filed: `todo/tickets/array-arg-mutation-lost-on-the-second-call-through-a-slurpy-relay.md` (`02-for`) and `todo/tickets/template6-include-local-data-not-reaching-the-included-stash.md` (`05-includes`) |
+| `Template::Jinja2` 0.2.0 | 22/23 | ~~0/23~~ → **3/23** | The two 2026-08-19 blockers are genuinely fixed, and so is the *third* one found on 2026-09-06: `lib/Template/Jinja2/Renderer.rakumod:114`'s `when If {` was parsed as a call (`Function 'If' needs parens to avoid gobbling block`) because a `use`d module's `is export`ed classes never reached the parser's type index — a trait on a declarator wraps it in a bare `Stmt::Block` the module scan did not walk into. The dist now loads; the remaining 20 files are ordinary per-feature failures |
+| `Template::Mojo` 0.2.2 | 5/5 | **4/5** | `00-basic` only; residue in `todo/tickets/template-mojo-residual-failures.md` |
+| `Template::Nest::Fast` 0.3.0 | 10/10 | **0/10** | `with $f ~~ m:g/…/ -> @m` binds `@m` to a one-element list *containing* the match list instead of to the list itself, so `$m[0].from` is Nil and `!index-template` warns and then dies. Reduced: `with ("a<!--x-->b<!--yy-->c" ~~ m:g/('<!--') \s* (\w+) \s* ('-->')/) -> @m { say @m.elems }` — raku 2, mutsu 1 |
+| `Template::HAML` 0.9.5 | 82/83 | **39/83** ² | many; also **2–3× slower to load than raku** (release) → `todo/tickets/grammar-heavy-module-load-slower-than-raku.md` |
+| `SP6` 0.2.1 | 10/11 | **10/11** | at parity — its one failure is `00-meta`, the same file raku fails |
+| `Template::Classic` 0.0.3 | 1/1 | **0/1** | `Unterminated <%` thrown by its own grammar: `my grammar Grammar { token TOP { ^ [ $<part> = <text> || $<part> = <code> || <!before $> { die … } ] … } }`. The `$<part> = <rule>` capture-assignment form inside a `||` chain does not match. (The older "`Unknown method value dispatch`" note is stale.) |
+
+¹ raku's two `91/92-specs` failures are a harness gap — they need `JSON::Fast`
+from the ecosystem, which the baseline install does not have; mutsu provides it
+natively, which is the only reason mutsu scores higher on that row.
+² Up from 14/83 at the 2026-07-25 measurement, entirely from unrelated fixes
+landed since. This row is slow to re-count (83 files under a debug build) and was
+taken on the build immediately before the 2026-09-06 fixes, so it may now be
+higher.
 
 Reproduce with `tmp/tmpl-survey.sh` (fetches each dist from the REA archive at a
 pinned version and runs its own suite; swap `MUTSU_BIN=raku` for the baseline).
@@ -48,12 +60,19 @@ needs its own reduction before it can be scheduled. What *is* known:
   message is a symptom; reduce the real module by deleting constructs until a
   two-line repro falls out, rather than theorising from the message.**
 - `Template::Jinja2` was the cheapest lever by file count. Its 2026-07-26
-  "load blocker FIXED (#5466)" note was **too optimistic**: #5466 did fix the
-  `sub (*@args) { self!cycle(|@args) }` closure form, but the dist still dies at
-  `use Template::Jinja2::Renderer` on a *different* private-method path (the
-  qualified `$renderer!Renderer::…` form). Re-measured 2026-08-19 on the current
-  build: **0/23 files**. Both remaining causes are now reduced to one-function
-  bugs — see the two tickets in the row above.
+  "load blocker FIXED (#5466)" note was too optimistic, and so was the
+  2026-08-19 one: both blockers named there are now genuinely fixed
+  (`news/2026-08/regex-char-class-literal-brace-paren.md`,
+  `news/2026-08/private-method-qualified-short-owner-in-module.md`) and
+  `01-lexer` passes — but a *third* load blocker was hiding behind them
+  (imported `is export`ed types missing from the parse-time type index), fixed
+  2026-09-06. That is three times running that a "the last Jinja2 blocker" note
+  turned out to be one of several stacked at the same call site: **do not
+  declare a load blocker the last one until the dist actually loads.**
+- `Template6` was reduced on 2026-09-06 by deleting constructs out of
+  `Parser.compile` until each divergence fell out. Four bugs, none of them the
+  warning in the headline. The method worked exactly as this file prescribed
+  it — write it down again for the next row.
 
 ## Already reduced and split out
 
@@ -66,42 +85,33 @@ needs its own reduction before it can be scheduled. What *is* known:
 
 ## Order of work
 
-1. ~~`Template::Mustache`~~ — **done 2026-07-25**, and it is the chosen engine for
-   the slot. One general fix (hyper Slip flattening) took it 1/13 → 11/13. The
-   last two files are tracked with the battery itself, not here.
-2. `Template::Jinja2` — **reduced 2026-08-19, ready to implement.** Both
-   remaining blockers are one-function interpreter bugs with pins specified:
-   `todo/tickets/regex-brace-paren-inside-char-class-swallows-rest-of-pattern.md`
-   (fixes `01-lexer` outright, and is a general grammar-slang bug that any
-   template/config grammar will hit) and
-   `todo/tickets/qualified-private-method-call-uses-short-owner-name.md` (which
-   makes the dist loadable at all). Do them in that order — the char-class one is
-   independently valuable and has the smaller diff.
-3. `Template6` — the runner-up candidate; worth fixing so the survey has a real
-   second option rather than a single viable choice. Still **unreduced**:
-   re-checked 2026-08-19, `t/01-simple.rakutest` emits `Use of Nil in string
-   context` from `Parser.compile` at `lib/Template6/Parser.rakumod` lines
-   227/230/231 and yields empty output. Per the lesson above, that warning is a
-   pointer, not the diagnosis — reduce `Parser.compile` by deletion rather than
-   theorising about the heredoc. Confirmed **not** the char-class bug: Template6
-   uses no `{`/`(` inside a `<[...]>` class.
-4. The rest (`Mojo`, `Nest::Fast`, `HAML`, `SP6`, `Classic`) as ordinary
-   compatibility work; each is also a data point that mutsu's grammar/list
-   semantics still diverge in ways ordinary modules hit.
+1. ~~`Template::Mustache`~~ — **done 2026-07-25**; it is the chosen engine for the
+   slot and passes 13/13. Tracked with the battery itself, not here.
+2. ~~`Template::Jinja2`'s load blockers~~ — **all three done** (the 2026-08-19
+   pair, plus the imported-`is export`-type parse bug found and fixed
+   2026-09-06). The dist loads and runs 3/23; what is left is ordinary
+   per-feature compatibility work, no longer a single lever.
+3. ~~`Template6`~~ — **10/12 as of 2026-09-06**; the two residual files are filed
+   as tickets and are ordinary compatibility work now, not a survey blocker.
+4. `Template::Nest::Fast` — 0/10 behind a single reduced bug (`with EXPR -> @m`
+   wrapping the list); likely the cheapest whole row left.
+5. The rest (`Mojo`, `HAML`, `Classic`) as ordinary compatibility work; each is
+   also a data point that mutsu's grammar/list semantics still diverge in ways
+   ordinary modules hit.
 
 Re-run `tmp/tmpl-survey.sh` and update
 [docs/batteries/templates.md](../../docs/batteries/templates.md) after each fix;
 the table is the decision input and goes stale the moment one lands.
 
-## Re-verified 2026-09-01 (TRIAGE regeneration)
+## Measurement log
 
-Both `Template::Jinja2` blockers named in "Order of work" item 2 are **fixed
-and closed**: the char-class one is
-`news/2026-08/regex-char-class-literal-brace-paren.md` and the private-method
-one is `news/2026-08/private-method-qualified-short-owner-in-module.md`
-(`'ab{cd' ~~ / <-[{]>+ /` gives `｢ab｣` and `self!Renderer::p` inside `module
-Foo::Renderer` resolves, in both implementations). The Jinja2 row's
-"0/23 files" is therefore unmeasured since then — **re-run the survey before
-picking the next engine**; Jinja2 may already be past its known blockers, and
-`Template6` (item 3) is still unreduced. The dist tarballs were not fetched
-for this re-verification (network), so none of the other rows moved.
+- **2026-09-01 (TRIAGE regeneration, no tarballs fetched):** confirmed from the
+  news archive that both `Template::Jinja2` blockers were closed, and flagged
+  the whole table as unmeasured since.
+- **2026-09-06 (full re-run, all eight dists fetched):** the table above. The
+  Jinja2 row had indeed moved (0/23 → 1/23, and onto a new blocker, itself
+  fixed the same day to reach 3/23), `SP6` had
+  silently reached parity (6/11 → 10/11), `Template::HAML` had nearly tripled
+  (14/83 → 39/83) and `Template::Classic`'s recorded symptom was stale — all
+  from unrelated work, none of it noticed because nobody re-ran the survey. The
+  standing instruction to re-measure before quoting a row is not ceremony.

--- a/todo/tickets/array-arg-mutation-lost-on-the-second-call-through-a-slurpy-relay.md
+++ b/todo/tickets/array-arg-mutation-lost-on-the-second-call-through-a-slurpy-relay.md
@@ -1,0 +1,62 @@
+# An array argument's mutation is lost on the SECOND call through a slurpy relay
+
+Found 2026-09-06 while taking `Template6` 0.16.0 from 0/12 to 10/12 test files
+(see `news/2026-09/template6-split-captures-and-topic-writeback.md`). This is
+one of the two remaining blockers for that dist: `t/02-for.rakutest`.
+
+A closure stored in a hash mutates its `@stack` parameter. The mutation reaches
+the caller's array the *first* time the relay sub is used, and is silently lost
+on every call after that.
+
+```raku
+my %handlers =
+    push => -> @stack, $a { @stack.unshift('for'); 'pushed' },
+    pop  => -> @stack { "popped({@stack.shift // 'EMPTY'})" };
+
+sub act(@stack, *@stmts) {
+    my $name = @stmts.shift;
+    %handlers{$name}(@stack, |@stmts)
+}
+
+sub run() {
+    my @s;
+    my $a = act(@s, 'push', 'x');
+    my $b = act(@s, 'pop');
+    "$a/$b"
+}
+
+say run;   # raku: pushed/popped(for)   mutsu: pushed/popped(for)
+say run;   # raku: pushed/popped(for)   mutsu: pushed/popped(EMPTY)
+```
+
+The first `run` is correct in both. On the second `run`, mutsu's `push` handler
+still reports `'pushed'` but the `unshift` never reaches `@s`, so `pop` finds an
+empty array. Neither the class wrapper nor the `subset`-typed array in the
+original is needed — the shape above is the whole thing. It smells like a
+compiled-closure / call-cache path that is taken only once the callee is warm
+and that binds the array parameter by value instead of by container.
+
+In the dist this shows up as `Template6::Parser`'s `%!directive-handlers`:
+`for` does `@control-stack.unshift('for')` and the matching `end` does
+`my ControlState $closed-directive = @control-stack.shift`, so the second
+`Parser.compile` in a process dies with
+
+```
+Type check failed in assignment to $closed-directive; expected ControlState but got Failure
+```
+
+Dist-level repro (with `Template6` 0.16.0 unpacked and `-I lib`):
+
+```raku
+use Template6::Parser;
+my $p = Template6::Parser.new;
+say $p.compile("a[% for li in ul %]x[% end %]b").defined;   # True
+say $p.compile("a[% for li in ul %]x[% end %]b").defined;   # dies under mutsu
+```
+
+Likely area: the compiled-closure call path (`src/vm/vm_closure_dispatch.rs`,
+`call_compiled_closure_in_unit`) and its argument binding for `@`-sigil
+parameters, plus whatever per-`CompiledCode` warm-up switches behaviour between
+the first and later calls. It is **not** the JIT: `MUTSU_JIT=off` reproduces
+identically, so the state that changes between the two `run` calls lives in the
+interpreter's own compiled-function/closure caching.

--- a/todo/tickets/template6-include-local-data-not-reaching-the-included-stash.md
+++ b/todo/tickets/template6-include-local-data-not-reaching-the-included-stash.md
@@ -1,0 +1,44 @@
+# `Template6` INCLUDE with inline data renders the variable name instead of its value
+
+Found 2026-09-06 while taking `Template6` 0.16.0 from 0/12 to 10/12 test files
+(`news/2026-09/template6-split-captures-and-topic-writeback.md`). This is the
+second of the two remaining blockers for that dist: `t/05-includes.rakutest`
+subtest 2, "INCLUDE statement with local template data".
+
+With `Template6` 0.16.0 unpacked and `-I lib`:
+
+```
+t/templates/include2.tt:  [% INCLUDE "included" name = "World" %]
+t/templates/included.tt:  <h1>Hello [% name %]</h1>
+```
+
+```raku
+use Template6;
+my $t6 = Template6.new;
+$t6.add-path: 't/templates';
+print $t6.process('include2');
+```
+
+raku renders `<h1>Hello World</h1>`; mutsu renders `<h1>Hello name</h1>` — the
+included template gets the *name* of the local variable where its value should
+be. Every other subtest in the file passes, so plain `INSERT`/`INCLUDE` without
+inline data is fine; it is specifically the `name = "World"` local-data form.
+
+Not yet reduced to a language-level repro. What has been ruled out:
+
+- `Template6::Parser`'s `resolve-value` is correct under mutsu — `'"World"'`,
+  `"'World'"`, `'42'` and `'name'` all resolve to the same strings raku
+  produces (`given`/`when` over a regex with a `(...)` capture and `$0`
+  interpolation all behave).
+
+So the divergence is downstream, in how the generated
+`%localdata<name> = 'World';` line reaches
+`$context.process($tfile, :localise, |%localdata)` and then
+`Context.localise` → `Stash.make-clone`. Likely candidates to check next: the
+`|%localdata` flatten into a `*%params` slurpy, `Stash.make-clone(|%params)`,
+and `Parser.compile`'s
+`$script.subst(/ 'my %localdata;' /, '', :nd(2..*))` — that `:nd(2..*)` was
+itself broken until this session (it panicked the process), so the generated
+script's `%localdata` scoping is worth dumping first (uncomment the
+`note "<DEBUG:template>..."` line in `Parser.compile` and diff the generated
+script against raku's).

--- a/todo/tickets/trailing-comma-in-attribute-default-drops-the-declaration.md
+++ b/todo/tickets/trailing-comma-in-attribute-default-drops-the-declaration.md
@@ -1,0 +1,44 @@
+# A trailing comma in an attribute default silently drops the initializer (and sometimes the accessor)
+
+Found 2026-09-06 while writing a regression pin for the attribute-default
+closure-package fix (`news/2026-09/attr-default-closure-declaring-package.md`).
+
+A trailing comma is legal in every Raku list literal, including the one that
+initializes an attribute. mutsu parses the declaration but throws the value
+away, and for a `%`-sigil attribute it loses the generated accessor as well:
+
+```raku
+class C { has @.a = 1, 2,; has $.b = 3; method m { @!a } }
+say C.new.m.raku;   # raku: [1, 2]     mutsu: []
+say C.new.b;        # 3 in both — an adjacent attribute is unaffected
+```
+
+```raku
+class C { has %.t = a => 1, b => 2,; }
+say C.new.t.raku;   # raku: {:a(1), :b(2)}
+                    # mutsu: No such method 't' for invocant of type 'C'
+```
+
+Removing the trailing comma makes both correct, so the value and the accessor
+are both a function of how the initializer expression is scanned:
+
+```raku
+class C { has %.t = a => 1, b => 2; }
+say C.new.t.raku;   # {:a(1), :b(2)} in both
+```
+
+The same trailing comma is fine outside a class body (`my @x = 1, 2,;` gives
+`[1, 2]` in mutsu), so this is specific to the attribute-declaration parse, not
+to list literals in general. The `%`-sigil case losing the accessor suggests the
+attribute declaration itself fails to register (the `has` statement is being
+mis-terminated at the comma), rather than only its default expression being
+mis-evaluated.
+
+Affected area: the `has` declaration parser in `src/parser/` and the
+`CompiledAttrDecl` default lowering it feeds (`src/opcode.rs`
+`CompiledAttrDecl { default: Option<DeclTraitArg>, … }`, evaluated by
+`Interpreter::eval_attr_default_expr` in `src/runtime/attr_build_defaults.rs`).
+
+Minimal repro: the two snippets above. A pin belongs next to
+`t/attr-default-closure-package.t`, whose fixture module had to drop a trailing
+comma to work around this.


### PR DESCRIPTION
Re-measured the template-engine survey in full (all eight dists fetched fresh from the REA archive) and reduced `Template6` 0.16.0, the runner-up for the template battery slot. Its long-standing "unreduced, `Use of Nil in string context`" state hid **five unrelated general interpreter bugs**, none of them the warning — exactly the trap `todo/deep/template-engines-blocked-on-mutsu.md` warns about. Reducing by deletion rather than theorising from the message is what found them.

**`Template6`: 0/12 → 10/12 upstream test files. `Template::Jinja2`: 0/23 → 3/23 (it now loads at all).**

## The five bugs

1. **A `split(/regex/, :v)` separator `Match` carried no named captures.** It was built with a hard-coded empty named map and text-flattened positional captures whose `.from`/`.to` were fabricated `0..len` spans over the separator text; the list-of-splitters form dropped the positional ones too. Both runtime split paths now take the engine's real `RegexCaptures` (`regex_match_with_captures_from` — the entry point `.match` uses) and build the Match with `make_match_object_full_visible`, the identical construction `~~ /…/` performs. Pin: `t/split-regex-separator-captures.t`.

2. **`.subst(…, :nth(2..*))` aborted the process with a Rust `capacity overflow`** — the Range was expanded eagerly, so an infinite upper end became `(2..=i64::MAX).collect()`. Unbounded Ranges now join `:nth(*)` on the deferred path, resolved against the real match count; `resolve_nth_value_indices` gained the two Range flavours it was missing (`1^..3`, `1^..^4`), and the literal-string `.subst` branch learned to consult the deferred list at all. Pin: `t/subst-nth-range.t`.

3. **An attribute default's closure was stamped with the *constructing* class.** A default is lowered at class-declaration time but executed in whatever frame calls `.new`, so `lexical_closure_package()` picked up the caller's method class and the closure could not see its own file's subs — but only across a module boundary, which is what made it look like a scoping mystery. It now consults `constructing_class`, whose sole producer is `eval_attr_default_expr`. Pin: `t/attr-default-closure-package.t`.

4. **Assigning to `$_` inside a nested block was discarded on block exit.** `BlockScope`'s env restore skipped `_` unconditionally; that is right for a block that *binds* its own topic (a `for`/`given`/`when` body, a pointy `-> $_`, a `$_ :=` rebinding) and wrong for a plain nested block, whose `$_` **is** the enclosing topic. The write still reached the topic's source variable through its container, so the two disagreed from the next statement onwards. Also repairs `sub f($_ is rw)`. Pin: `t/topic-assign-in-nested-block.t`; `t/for-topic-restore.t` and `t/topic-bind-conditions.t` still pass.

5. **A `use`d module's `is export`ed types never reached the parse-time type index.** A trait on a declarator wraps it in a bare `Stmt::Block` that the module scan's collector never walked into, so *every* exported class/role/grammar/enum in a `use`d module was invisible and `when Cond { }` failed to compile with "Function 'Cond' needs parens to avoid gobbling block". Bare blocks are now walked, and imported type names land in the outermost scope like imported enum values and constants already did. Pin: `t/when-imported-exported-type.t`.

## Survey

Four of the eight rows had moved since the last measurement without anyone noticing (`SP6` had silently reached parity, `Template::HAML` nearly tripled, `Template::Classic`'s recorded symptom was stale, and Jinja2 had moved onto a new blocker). `todo/deep/template-engines-blocked-on-mutsu.md` and `docs/batteries/templates.md` now carry fresh counts, per-row first failures and a measurement log.

Three residual findings are filed rather than forced into this PR:
`todo/tickets/array-arg-mutation-lost-on-the-second-call-through-a-slurpy-relay.md` (18-line repro, not the JIT), `todo/tickets/template6-include-local-data-not-reaching-the-included-stash.md`, `todo/tickets/trailing-comma-in-attribute-default-drops-the-declaration.md`.

## Verification

- `make test` PASS (3703 files, 37882 tests)
- targeted roast sweep of every whitelisted file under `S04-`, `S05-`, `S11-`, `S12-attributes`, `S12-class`, `S12-construction`, `S03-binding`, `S32-str`, `S02-magicals` (318 files): clean
- `scripts/battery-testsuite.sh`: GATE PASSED, 289/312
- every new `t/*.t` produces byte-identical output under `mutsu` and `raku`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
