### PR TITLE
fix(vm): a routine's capture reset must not escape into its caller under EVAL

### DIFF
--- a/news/2026-09/routine-match-scope-survives-an-eval-in-the-program.md
+++ b/news/2026-09/routine-match-scope-survives-an-eval-in-the-program.md
@@ -1,0 +1,43 @@
+# A routine's match reset no longer deletes its caller's named captures
+
+`$/` and its capture views (`$0`, `$<name>`) are implicitly `my`-declared per
+routine, so a sub that matches internally must not disturb its caller's match.
+mutsu enforced that with the scoped env overlay the zero-argument compiled fast
+call installs: the callee's `reset_capture_env_vars` REMOVES inherited
+`$<name>` keys, and inside an overlay that removal is a callee-local tombstone
+that is dropped on return instead of reaching the caller.
+
+That overlay was gated on `!opcode::reflective_name_access_possible()`, a
+**process-global, monotonic** flag latched at compile time by any `EVAL`,
+`CALLER::`, symbolic deref or pseudo-stash op anywhere in the program. One
+`EVAL` therefore turned the boundary off for *every* zero-local routine in the
+program, and such a routine's capture reset then ran directly against the
+caller's env — deleting the caller's `$<first>` outright:
+
+```raku
+my $unused = EVAL '1';                      # latches the flag
+sub inner-match() { "zz" ~~ /(z)/; 1 }
+"abc" ~~ /$<first>=(b)(c)/;
+inner-match();
+say ~$<first>;                              # was '', rakudo says 'b'
+```
+
+Without the `EVAL` line the same program was correct, which is what kept this
+hidden: the failure needs a reflective op somewhere else entirely. It surfaced
+through the vendored upstream `Test` module (`todo/deep/vendor-real-test-module.md`),
+whose `throws-like`/`eval-dies-ok` EVAL a string — so *every* file that loads
+it latched the flag and lost the boundary, and
+`t/match-vars-are-routine-scoped.t` failed under `MUTSU_REAL_TEST=1` while
+passing under the native provider.
+
+The gate is gone: the overlay is installed whenever the body needs a boundary
+(it has locals, or it is a routine that writes env), regardless of the flag.
+The invariant the gate stood in for — that no full-view iteration consumer is
+starved of parent lexicals — is enforced structurally instead, by flattening a
+scoped env in everything that captures or clones it across a boundary
+(`docs/vm-dual-store.md` Slice 6). The positional-light path has always
+installed the same overlay without consulting the flag, so the two zero-arg and
+positional call paths now agree.
+
+Pinned by `t/match-vars-scoped-under-eval.t`, which reproduces the bug with a
+bare `EVAL '1'` and no Test module at all.

--- a/src/runtime/system_eval_names.rs
+++ b/src/runtime/system_eval_names.rs
@@ -582,9 +582,16 @@ impl Interpreter {
         &self,
         stmts: &[Stmt],
     ) -> Result<(), RuntimeError> {
+        // The unit's own `sub`/`method`/`proto` declarations, kept apart from
+        // the rest of `declared`: every declared name suppresses the check
+        // (the safe direction), but only a *routine* may be offered as the
+        // routine the caller meant -- a `my $greeting` must never answer
+        // "Did you mean 'greeting'?", which rakudo never does.
+        let mut declared_routines: HashSet<String> = HashSet::new();
         let mut declared: HashSet<String> = HashSet::new();
         for s in stmts {
             Self::collect_declared_routine_names(s, &mut declared);
+            Self::collect_routine_decl_names(s, &mut declared_routines);
             Self::collect_declared_vars(s, &mut declared);
         }
         let extra: Vec<String> = declared
@@ -612,7 +619,14 @@ impl Interpreter {
             {
                 continue;
             }
-            let suggestions = self.suggest_routine_names(&name);
+            // Rakudo's suggestion candidates include the compilation unit's own
+            // routines, not just the registered/core ones -- and an EVAL'd
+            // snippet is a compilation unit like any other, so
+            // `EVAL 'sub greeting {}; greetng()'` must answer "Did you mean
+            // 'greeting'?" exactly as the mainline check does
+            // (`check_undeclared_routines_mainline`). The unit's subs are not in
+            // the registry at this point, so pass the ones just collected.
+            let suggestions = self.suggest_routine_names_including(&name, &declared_routines);
             return Err(Self::undeclared_routine_error(&name, 1, suggestions));
         }
         Ok(())
@@ -659,6 +673,31 @@ impl Interpreter {
             }
         }
         Ok(())
+    }
+
+    /// The *routine* subset of [`Self::collect_declared_routine_names`]: only
+    /// `sub` / `method` / `proto` declarations, without the class, role, subset
+    /// and enum names that one also collects (those suppress the undeclared
+    /// check, but naming one is not "the routine you meant"). Mirrors the
+    /// CHECK-time walker's `Scan::declared_routines`
+    /// (`runtime/undeclared_routines.rs`), which draws the same distinction.
+    fn collect_routine_decl_names(stmt: &Stmt, out: &mut HashSet<String>) {
+        match stmt {
+            Stmt::SubDecl { name, .. }
+            | Stmt::MethodDecl { name, .. }
+            | Stmt::ProtoDecl { name, .. } => {
+                out.insert(name.resolve());
+            }
+            Stmt::ClassDecl { body, .. }
+            | Stmt::AugmentClass { body, .. }
+            | Stmt::RoleDecl { body, .. }
+            | Stmt::SyntheticBlock(body) => {
+                for s in body {
+                    Self::collect_routine_decl_names(s, out);
+                }
+            }
+            _ => {}
+        }
     }
 
     fn collect_declared_routine_names(stmt: &Stmt, out: &mut HashSet<String>) {

--- a/src/vm/vm_call_fast.rs
+++ b/src/vm/vm_call_fast.rs
@@ -66,17 +66,27 @@ impl Interpreter {
         // *overlay only* (the callee's actual writes) back, and discard
         // callee-local writes for free. Gated to bodies that never capture or
         // iterate the env for a full lexical view: no inner subs (no
-        // closure/thread/block creation) and no reflective by-name access
-        // (EVAL / CALLER:: / symbolic deref / pseudo-stash).
+        // closure/thread/block creation).
         // A routine with no compiled locals may still write implicit match
         // state by name. It needs the same boundary: in particular,
         // `reset_capture_env_vars` removes inherited `$<name>` keys, which
         // must become callee-local tombstones instead of deleting the caller's
         // binding directly. Ordinary no-write helpers retain the allocation-free
         // in-place path.
-        let use_scoped = (has_locals || (cf.code.is_routine && cf.code.has_env_writes))
-            && !cf.has_inner_subs
-            && !crate::opcode::reflective_name_access_possible();
+        //
+        // The pilot slice additionally required `!reflective_name_access_possible()`
+        // (docs/vm-dual-store.md Slice 6), but that flag is program-global and
+        // monotonic: one `EVAL` anywhere in the program — as in every file that
+        // loads the vendored upstream `Test` — turned the boundary off for EVERY
+        // zero-local routine in that program, and a routine that then reset its
+        // captures deleted its CALLER's `$<name>` (`t/match-vars-are-routine-scoped.t`).
+        // The safety invariant the gate stood in for is enforced structurally
+        // instead: every consumer that captures or iterates the env for a full
+        // lexical view flattens a scoped env first, which is why the
+        // positional-light path has always installed this overlay without
+        // consulting the flag.
+        let use_scoped =
+            (has_locals || (cf.code.is_routine && cf.code.has_env_writes)) && !cf.has_inner_subs;
         let caller_env: Option<Env> = if use_scoped {
             // Chain a child over the whole caller env (itself possibly scoped):
             // no flatten, so nested fast calls don't pay the O(env) merge.

--- a/t/match-vars-scoped-under-eval.t
+++ b/t/match-vars-scoped-under-eval.t
@@ -1,0 +1,30 @@
+use Test;
+
+# `$/` and its capture views are routine-scoped even when the program contains
+# an `EVAL` (`t/match-vars-are-routine-scoped.t` pins the scoping itself).
+#
+# `EVAL` anywhere in a program latches the process-global
+# `REFLECTIVE_NAME_ACCESS_SEEN` flag, and the zero-argument compiled fast call
+# used to read that flag to decide whether to install its scoped env overlay.
+# With the flag latched it installed none -- and a zero-local routine that
+# matched internally then ran `reset_capture_env_vars` directly against the
+# CALLER's env, whose `$<name>` keys it REMOVES (they must become callee-local
+# tombstones). So `inner-match()` deleted the caller's `$<first>` in any program
+# containing an EVAL, which is every file that loads the vendored upstream
+# `Test` module. The overlay is now installed regardless of the flag.
+
+plan 4;
+
+my $unused = EVAL '1';
+
+sub inner-match() { "zz" ~~ /(z)/; 1 }
+
+"abc" ~~ /(b)(c)/;
+inner-match();
+
+"abc" ~~ /$<first>=(b)(c)/;
+is ~$<first>, 'b', 'baseline $<first> with an EVAL in the program';
+inner-match();
+is ~$<first>, 'b', 'a zero-local sub does not delete the caller $<first>';
+is ~$/, 'bc', '... nor clobber the caller $/';
+is ~$0, 'c', '... nor the caller $0 (the sole positional of that match)';

--- a/t/undeclared-routine-suggests-unit-own-subs.t
+++ b/t/undeclared-routine-suggests-unit-own-subs.t
@@ -19,7 +19,7 @@ use Test;
 # subset only, or a `my $greeting` would be offered as the routine you meant,
 # which rakudo never does.
 
-plan 4;
+plan 7;
 
 throws-like 'sub greeting() { 1 }; greetng()', X::Undeclared::Symbols,
     "a typo'd call suggests the unit's own sub",
@@ -42,3 +42,26 @@ try {
 }
 nok $message.contains('Did you mean'),
     'a same-named variable is not offered as the routine you meant';
+
+# The same must hold when the snippet is compiled through EVAL rather than as
+# the mainline: EVAL'd code is a compilation unit like any other, and its own
+# `sub` declarations are suggestion candidates. (`throws-like` reaches this
+# path only with the vendored upstream Test module, whose implementation EVALs
+# the string; these assertions exercise it under either provider.)
+sub eval-message($code) {
+    my $message = '';
+    try {
+        EVAL $code;
+        CATCH { default { $message = .message } }
+    }
+    $message;
+}
+
+ok eval-message('sub greeting() { 1 }; greetng()').contains("Did you mean 'greeting'"),
+    "an EVAL'd typo suggests the EVAL'd unit's own sub";
+
+ok eval-message('multi sub handle(Int) { 1 }; handel(1)').contains("Did you mean 'handle'"),
+    "an EVAL'd multi candidate is a suggestion candidate too";
+
+nok eval-message('my $greeting = 1; greetng()').contains('Did you mean'),
+    "an EVAL'd same-named variable is not offered as the routine you meant";


### PR DESCRIPTION
Two independent scoping defects that the vendored upstream `Test` module
exposed (`todo/deep/vendor-real-test-module.md`), both general interpreter
bugs rather than Test ones. Each was a real-provider-only regression in that
ticket's sweep; both now pass under either provider.

## 1. A routine's capture reset escaped into its caller (`vm/vm_call_fast.rs`)

`$/` and its capture views are routine-scoped, which mutsu enforces with the
scoped env overlay the zero-argument compiled fast call installs: a callee's
`reset_capture_env_vars` REMOVES inherited `$<name>` keys, and inside an
overlay that removal is a callee-local tombstone dropped on return.

The overlay was gated on `!opcode::reflective_name_access_possible()` — a
**process-global, monotonic** flag latched by any `EVAL` / `CALLER::` /
symbolic-deref op anywhere in the program. One `EVAL` therefore removed the
boundary from every zero-local routine in the program, and such a routine then
deleted its caller's named captures outright:

```raku
my $unused = EVAL '1';                      # latches the flag
sub inner-match() { "zz" ~~ /(z)/; 1 }
"abc" ~~ /$<first>=(b)(c)/;
inner-match();
say ~$<first>;                              # was '', rakudo says 'b'
```

Every file that loads the vendored `Test` latches that flag (its
`throws-like`/`eval-dies-ok` EVAL a string), which is why
`t/match-vars-are-routine-scoped.t` #8 failed only under `MUTSU_REAL_TEST=1`.

The gate is dropped. The invariant it stood in for — no full-view iteration
consumer is starved of parent lexicals — is enforced structurally instead, by
flattening a scoped env in everything that captures or clones it across a
boundary (`docs/vm-dual-store.md` Slice 6); the positional-light path has
always installed the same overlay without consulting the flag.

## 2. EVAL'd code got no "Did you mean ...?" suggestion (`runtime/system_eval_names.rs`)

`EVAL 'sub greeting {}; greetng()'` named the typo with no way to see what was
meant, because the EVAL-time check drew candidates from the registry alone.
It now passes the EVAL'd unit's own routine declarations, exactly as the
mainline CHECK-time walker does — and only the *routine* subset, so a
`my $greeting` is never offered as the routine you meant. Verified against
rakudo, which answers `Did you mean 'greeting'?` here.

## Tests

- New: `t/match-vars-scoped-under-eval.t` (reproduces #1 with a bare
  `EVAL '1'` and no Test module at all; passes under rakudo unchanged).
- Extended: `t/undeclared-routine-suggests-unit-own-subs.t` with three
  EVAL-path assertions, so #2 is pinned under either Test provider.
- `make test`: clean apart from `t/io-path-smartmatch-permissions.t`, which
  fails for a root-user container regardless of this change.
- All 293 whitelisted roast files that use `EVAL` pass on a release build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UUpduPmW6HWAcpLk2RjT2V

---
_Generated by [Claude Code](https://claude.ai/code/session_01UUpduPmW6HWAcpLk2RjT2V)_