### PR TITLE
perf(vm): let an imported module sub reach the cached dispatch

### DIFF
--- a/news/2026-09/imported-module-sub-reaches-the-cached-dispatch.md
+++ b/news/2026-09/imported-module-sub-reaches-the-cached-dispatch.md
@@ -1,0 +1,85 @@
+# An imported module sub no longer re-resolves itself on every call
+
+Calling a sub imported from a module cost **14.7 us**; calling an identical sub
+declared in the calling file cost **0.75 us**. Same signature, same body, same
+call site shape — a 20x penalty for nothing but where the sub was declared.
+
+## Three registry walks per call
+
+`exec_call_func_op` keeps a name-keyed `otf_call_cache` so a repeat call to a
+sub that is not in the caller's `compiled_fns` table can dispatch straight to
+its compiled body. `compile_and_call_function_def` populates that cache — but
+only when it had to compile the body itself:
+
+```rust
+let (cf, compiled_from_plan) = match &def.compiled {
+    Some(compiled) => (Arc::clone(compiled), true),
+    None => (self.otf_compile_function_def(def), false),
+};
+if !compiled_from_plan && !self.has_multi_candidates_cached(&name) { /* cache it */ }
+```
+
+A sub imported from a module always arrives with `def.compiled` already set —
+its module was compiled when it was loaded — so `compiled_from_plan` was always
+true and the entry was never written. Every single call then re-ran the whole
+resolution chain from scratch:
+
+1. `find_compiled_function` — two `Vec<String>` type-signature allocations, a
+   cache-key clone, a full `resolve_function_with_types`, then four `format!`ed
+   key probes that all miss, because the sub is not in the caller's table at all;
+2. `user_function_matches_call` — a second full resolve;
+3. `resolve_function_with_types` — a third.
+
+Measured on 20 000 calls: **60 000 `function-full-resolve`s for 20 000 calls**,
+against **1** for the same sub declared locally.
+
+## The fix
+
+Cache the plan-compiled body on exactly the same terms as the OTF-compiled one.
+The guards that make the OTF entry sound are not specific to who compiled the
+body: the entry is keyed by the *callsite* package, invalidated by
+`fn_resolve_gen`, and never written for a multi name (whose winner depends on
+argument types). A cache hit now also runs the body against the routine's own
+nested-sub table (`cf.compiled_fns`) rather than the caller's, which is what the
+uncached path next to it already did (ADR-0019 C6e-3c) and what a body compiled
+inside another module needs to resolve its own nested `RegisterSub` keys.
+
+| call | before | after |
+| --- | --- | --- |
+| imported `sub plainmod($c, $d)` | 294 ms / 20 000 | **18 ms** |
+| imported `sub modsub(Bool(Mu) $c, $d is copy, $p = '')` | 643 ms / 20 000 | **373 ms** |
+| local `sub localsub($c, $d)` (control) | 15 ms / 20 000 | 15 ms |
+
+The simple imported sub is now at parity with a local one. The heavy-signature
+one still pays for its own signature — a coercion type, an `is copy`, and a
+default keep it off both light call paths and on the full binder — but no longer
+pays for its provenance on top.
+
+## Where it showed up
+
+`todo/deep/vendor-real-test-module.md`: under the vendored upstream `Test`,
+every assertion calls `proclaim`, which is imported and has exactly that heavy
+signature. It was doing three full registry walks per assertion — 280 110 of
+`roast/S03-buf/write-int.t`'s 565 212 resolutions. That file's real-`Test` run
+drops from 48.2 s to 45.4 s and `proclaim`'s resolve count from 3-per-call to 3
+in total; the *rest* of that file's cost is elsewhere (see the ticket), so this
+is a 6% slice of it and a 16x win on the general shape.
+
+## The guard the change needed
+
+`t/sub-rw-writeback-attr-source-no-leak.t` was written against a shape that
+"does not currently reproduce" through a plain sub call, and said so explicitly:
+
+> If a future change to the sub-call fast paths starts populating `rw_bindings`
+> for this shape, `apply_rw_bindings_to_env` would need the same
+> attribute-twigil guard `vm_method_dispatch.rs`'s `rw_writeback` loop already
+> has — this test would catch the regression either way.
+
+It did, on the first full `make test` after the change. `f(:%!plugin-config)`
+encodes the *attribute's* twigil form as the writeback's source name; inserted
+verbatim into the caller's env it becomes a pseudo-key an unrelated later method
+call's `reconcile_attrs` scan can adopt as its own attribute override, silently
+overwriting a different instance's same-named attribute.
+`apply_rw_bindings_to_env` now skips an attribute-shaped source, exactly as the
+method-call twin does — the shared `ContainerRef` cell the writeback exists for
+already carries content mutations without the insert.

--- a/src/runtime/types/mod.rs
+++ b/src/runtime/types/mod.rs
@@ -506,6 +506,25 @@ impl Interpreter {
                 }
                 continue;
             }
+            // A named `:$scalar` param bound from an `@`/`%` SOURCE THAT IS
+            // ITSELF AN ATTRIBUTE EXPRESSION (`f(:%!plugin-config)`) encodes
+            // that attribute's twigil form as `source_name` -- the CALLEE's
+            // (well, the calling method's) own attribute key, not a lexical
+            // belonging to the caller. Writing it into the caller's env plants
+            // a pseudo-key that an unrelated later method call's
+            // `reconcile_attrs` candidate scan can mistake for a `:=` binding
+            // and adopt as its own attribute override, silently overwriting a
+            // different instance's same-named attribute. The shared
+            // `ContainerRef` cell this writeback exists for already keeps
+            // content mutations visible without the insert. This is the sub-call
+            // twin of the guard `vm_method_dispatch.rs`'s `rw_writeback` loop
+            // already applies (`is_attr_twigil_shaped`); it became reachable
+            // when module/plan-compiled subs started taking the cached dispatch,
+            // which is exactly the regression
+            // `t/sub-rw-writeback-attr-source-no-leak.t` was written to catch.
+            if crate::value::attr_twigil_base(source_name).is_some() {
+                continue;
+            }
             if let Some(updated) = self.env.get(param_name).cloned() {
                 // When the caller's variable already holds a shared `ContainerRef`
                 // cell (e.g. an inner `$a := $arg` re-bound the rw param into the

--- a/src/vm/vm_call_dispatch.rs
+++ b/src/vm/vm_call_dispatch.rs
@@ -363,9 +363,9 @@ impl Interpreter {
         let name = def.name.resolve();
         let pkg = def.package.resolve();
 
-        let (cf, compiled_from_plan) = match &def.compiled {
-            Some(compiled) => (Arc::clone(compiled), true),
-            None => (self.otf_compile_function_def(def), false),
+        let cf = match &def.compiled {
+            Some(compiled) => Arc::clone(compiled),
+            None => self.otf_compile_function_def(def),
         };
 
         // Cache by name for fast lookup in exec_call_func_op — but never for a
@@ -373,7 +373,23 @@ impl Interpreter {
         // candidate under the bare name would make a later call with different
         // argument types wrongly reuse it. Multi candidates are still cached by
         // body fingerprint in `otf_compile_cache` above (safe, per-candidate).
-        if !compiled_from_plan && !self.has_multi_candidates_cached(&name) {
+        //
+        // A *plan-compiled* def (`def.compiled` already set — the shape every
+        // sub imported from a module takes) is cached on exactly the same
+        // terms. Excluding it meant an imported module sub could never reach a
+        // cached dispatch at all: every call re-ran the whole resolution chain
+        // (`find_compiled_function` → `user_function_matches_call` →
+        // `resolve_function_with_types`, three full registry walks per call, plus
+        // the key `format!` probes that all miss because the sub is not in the
+        // caller's `compiled_fns`). Measured at 14.7 us per call against 0.75 us
+        // for an identical sub declared in the calling file, and it is the
+        // dominant per-assertion cost of the vendored upstream `Test` module
+        // (`todo/deep/vendor-real-test-module.md`), whose `proclaim` alone paid
+        // three of those walks on every assertion. The entry is guarded exactly
+        // as the OTF one is — callsite package, `fn_resolve_gen`, and the multi
+        // exclusion above — and a hit runs the body under the routine's own
+        // nested-sub table, as this function does below.
+        if !self.has_multi_candidates_cached(&name) {
             let name_sym = Symbol::intern(&name);
             // Keyed to the *callsite* package, not `def.package`: the cache
             // answers "what does this bare name mean here", and a module's

--- a/src/vm/vm_call_func_ops.rs
+++ b/src/vm/vm_call_func_ops.rs
@@ -744,6 +744,15 @@ impl Interpreter {
                             .any(|v| matches!(v.view(), ValueView::Junction { .. }));
                         let mainline_capture_blocked =
                             self.light_call_blocked_by_mainline_capture(name_str);
+                        // Run the body against the routine's OWN nested-sub
+                        // table when it carries one, exactly as the uncached
+                        // `compile_and_call_function_def` does (ADR-0019
+                        // C6e-3c): the caller's table cannot resolve a nested
+                        // `RegisterSub` key of a routine compiled elsewhere,
+                        // which a plan-compiled module sub reaching this cache
+                        // routinely is.
+                        let body_fns = cf.compiled_fns.clone();
+                        let compiled_fns = body_fns.as_deref().unwrap_or(compiled_fns);
                         let result = if !share_into_scalar
                             && !named_share
                             && !has_junction

--- a/todo/deep/vendor-real-test-module.md
+++ b/todo/deep/vendor-real-test-module.md
@@ -95,31 +95,64 @@ fail under both (pre-existing):    4
 
 ```
 pass under both:                   3665
-regressed under the real Test:     4 -> 3 after the fix above
+regressed under the real Test:     4 -> 1 after the fixes below
 passes only under the real Test:   0
 fail under both (pre-existing):    23
 ```
 
 All four were verified to reproduce identically on `origin/main`, so none was
 introduced by the perf work of 2026-09-05. `t/list-str-calls-element-str.t` is
-the one the Seq fix closed. The remaining three, each still open:
+the one the Seq fix closed. **Two of the remaining three were closed on
+2026-09-06**, and both turned out to be general interpreter bugs that had
+nothing to do with `Test` — the module only latched the condition that exposed
+them (`news/2026-09/routine-match-scope-survives-an-eval-in-the-program.md`):
 
-- `t/closure-capture-cell-dichotomy.t` #7 — "call-arg-sourced capture wins over
-  a slot-resident same-named caller lexical".
-- `t/match-vars-are-routine-scoped.t` #8 — "a sub that resets captures does not
-  delete the caller `$<first>`".
-- `t/undeclared-routine-suggests-unit-own-subs.t` #1,#2 — the CHECK-time
-  "Did you mean 'greeting'?" suggestion is absent when the `throws-like` that
-  EVALs the snippet comes from the real module rather than the native handler.
-  The exception type and the die itself are right; only the suggestion list is
-  empty.
+- `t/match-vars-are-routine-scoped.t` #8 — **fixed**. The zero-argument compiled
+  fast call installed its scoped env overlay only while
+  `reflective_name_access_possible()` was false. That flag is process-global and
+  monotonic, so ONE `EVAL` anywhere in a program removed the boundary from every
+  zero-local routine in it, and such a routine's `reset_capture_env_vars` — which
+  REMOVES inherited `$<name>` keys — then deleted the CALLER's named captures.
+  Every file that loads the real `Test` latches the flag (`throws-like` EVALs a
+  string), which is why it was real-provider-only. Reproduced with a bare
+  `EVAL '1'` and no Test module at all; pinned by
+  `t/match-vars-scoped-under-eval.t`.
+- `t/undeclared-routine-suggests-unit-own-subs.t` #1,#2 — **fixed**. Not a
+  provider difference in the check: the EVAL-time undeclared-routine check drew
+  its suggestion candidates from the registry alone, so `EVAL 'sub greeting {};
+  greetng()'` lost the suggestion under BOTH providers. The native `throws-like`
+  simply does not go through EVAL, so only the real module's EVALing
+  implementation exposed it. The EVAL path now passes the EVAL'd unit's own
+  routine declarations, as the mainline CHECK-time walker already did.
+- `t/closure-capture-cell-dichotomy.t` #7 — **still open, and now identified**:
+  it is the *known-open* env-resident half of ADR-0055 section 1.2(b), which the
+  file's own comment already records as open and blocked on
+  `todo/deep/unvouched-capture-cells-leak-state-across-cro-client-requests.md`.
+  The reflective flag is again the bridge: with it latched, `SetLocal`'s
+  `skip_env_write` is disabled, so the *slot*-resident variant the test pins
+  becomes the env-resident variant that was already failing. Repro without any
+  Test module:
+
+  ```raku
+  my $z = EVAL "1";                 # latches the flag
+  sub noop($v) { 1 }
+  my $b = "OUTER";
+  noop($b);                         # the vouch refusal
+  my $f = { $b };
+  sub collide-slot() { my $b = "CALLER"; $f.() }
+  say collide-slot();               # 'CALLER', rakudo says 'OUTER'
+  ```
+
+  So this row is NOT a separate real-`Test` blocker: closing ADR-0055 §1.2(b)
+  closes it. Do not chase it from the `Test` side.
 
 ### Performance: one file left, and the attribution has moved again
 
 `S03-buf/read-write-bits.t` is **no longer** a timeout — it now completes in
 ~16 s here (so ~8 s on the reference machine). Only `write-int.t` remains, at
-~49 s here (~25 s on the reference machine, against a 30 s budget), versus 4.4 s
-under the native provider. It runs ~93 000 assertions, which is why it is the
+~45 s here after the 2026-09-06 dispatch fix, 48 s before it (so ~23 s on the
+reference machine, against a 30 s budget), versus 4.4 s under the native
+provider. It runs ~93 000 assertions, which is why it is the
 last one standing: at ~0.31 ms per assertion that is ~29 s of pure assertion
 overhead.
 
@@ -129,10 +162,43 @@ release, 6.22 G -> ~2.5 G retired instructions — by removing the registry walk
 `nqp::` ops and lone-`multi` resolution were paying. **Do not restart from the
 `&`-sigil framing in `todo/perf/interpreter-call-path-in-hot-loops.md`; that
 section is stale, and so is the `nqp::`/`has_multi_candidates` diagnosis, which
-is now fixed.** The measured next targets are:
+is now fixed.**
+
+**Correction (2026-09-06): target 1 below was mis-attributed, and it has been
+partly overtaken.** `proclaim`'s 280 110 by-name resolutions were NOT the
+defaulted-parameter light-call gate — `proclaim` never reached that gate, because
+it is imported and so is absent from the caller's `compiled_fns` entirely. It
+was excluded from the `otf_call_cache` instead (that cache skipped every
+*plan-compiled* def, which is every module sub), so each call re-ran three full
+registry walks. Fixed:
+`news/2026-09/imported-module-sub-reaches-the-cached-dispatch.md` — a simple
+imported sub went 14.7 us -> 0.9 us per call, at parity with a local one, and
+`proclaim` now resolves 3 times in total rather than 3 times per assertion.
+`write-int.t` went 48.2 s -> 45.4 s here, so **the resolutions were only ~6% of
+that file**: the per-assertion cost is dominated by something else. Two
+measurements say where to look next:
+
+- **The cost is linear in env size.** Adding N unused `our` variables to the
+  mainline of a 2000-assertion file adds ~0.98 ns per entry per assertion:
+  0 pads 0.609 s, 300 pads 1.213 s, 600 pads 1.841 s, 900 pads 2.363 s (release,
+  this machine). `MUTSU_VM_STATS` reports **3 `env_deep_copies` and 2
+  `clone_env`s per assertion**, and `clone_env` is `Env::flattened()` — an
+  O(env) rebuild whenever the live env is a scoped overlay, which it is on the
+  named-call path. `call_compiled_function_named_inner` takes two of them
+  eagerly: `push_caller_env()` and the flat env handed to the `Sub` value built
+  for `callframe().code` introspection. Neither is used by an assertion that
+  never introspects its frame. Making them lazy (or storing the scoped env and
+  flattening at the point of use) is the measured next lever.
+- **`ok`/`is` are multis, so they still resolve once per call** (2001 resolves
+  for 2000 `ok`s). The `otf_call_cache` deliberately excludes multi names; the
+  sound multi-resolution cache misses because the arguments arrive as
+  varref-captured containers, which `multi_arg_type_keys` declines to key on.
+
+The remaining targets, unchanged in substance:
 
 1. **A defaulted parameter disqualifies the callee from the cached light-call
-   path.** `is_positional_light_call_eligible` (`vm/vm_call_eligibility.rs`)
+   path.** (Real, but see the correction above: it is not what `proclaim` was
+   paying, so do not expect the `Test` numbers to move much.) `is_positional_light_call_eligible` (`vm/vm_call_eligibility.rs`)
    requires `pd.default.is_none() && !pd.optional_marker`, so every call to a
    routine with a trailing default re-resolves by name. Measured:
    `sub f($a) {...}` called 1000x costs **1** `function-full-resolve` in total;

--- a/todo/perf/named-call-flattens-the-env-twice-per-call.md
+++ b/todo/perf/named-call-flattens-the-env-twice-per-call.md
@@ -1,0 +1,86 @@
+# The named call path flattens the whole env twice on every call
+
+`call_compiled_function_named_inner` — the general (non-light) call path, which
+every routine with a heavy signature takes — rebuilds a flat copy of the entire
+lexical env **twice per call**, before it has run a single opcode of the body.
+The cost is linear in how many names are in scope, so it grows with the program
+rather than with the call.
+
+## The measurement
+
+2000 `ok 1, "x"` assertions under the vendored upstream `Test`
+(`MUTSU_REAL_TEST=1`, release), with N unused `our` variables added to the
+mainline purely to grow the env:
+
+| padding vars | wall clock |
+| --- | --- |
+| 0 | 0.609 s |
+| 300 | 1.213 s |
+| 600 | 1.841 s |
+| 900 | 2.363 s |
+
+Slope: **~0.98 ns per env entry per assertion**, i.e. roughly a full copy of the
+env two to three times per call. `MUTSU_VM_STATS` agrees: 2 `clone_env` and 3
+`env_deep_copies` per assertion.
+
+Nothing in `ok 1, "x"` reads those variables. The whole slope is bookkeeping.
+
+## Where the two flattens are
+
+```rust
+loan_env!(self, push_caller_env());                  // (1)
+let sub_val = Value::make_sub(
+    ..., self.clone_env(),                           // (2)
+);
+...
+{ let parent = self.env().clone();                   // the cheap one
+  self.set_env(crate::env::Env::scoped_child(parent)); }
+```
+
+`clone_env()` is `Env::flattened()`. On a flat env that is an `Arc` bump, but on
+the hot path the live env is a **scoped overlay** (every enclosing frame
+installed one), and flattening a scoped env walks the parent chain and rebuilds
+the map. So:
+
+1. `push_caller_env()` snapshots the caller's env so a callee's `CALLER::<$x>`
+   can read it. Almost no call is ever the target of a `CALLER::` lookup.
+2. The `Sub` value pushed on the block stack carries a flat env so
+   `callframe().code` can expose a full lexical view. Almost no call has its
+   frame introspected.
+
+Both are eager snapshots taken for a consumer that usually never runs. Note
+the third `clone_env` at the same site (`make_sub`) is the *reason* the env's
+`Arc` is then shared, which is what turns the callee's first by-name write into
+an `Arc::make_mut` deep copy — so (2) costs twice.
+
+## What a fix has to preserve
+
+The scoped-env safety invariant (`docs/vm-dual-store.md` Slice 6) is that
+anything capturing or cloning the env across a boundary flattens it first, so no
+full-view *iteration* consumer is starved of parent lexicals. Reads are fine
+unflattened: a scoped env's `get` walks its parent chain. So the shape of a fix
+is to store the scoped env (an `Arc` bump) and flatten at the point of use —
+`get_caller_var` / `callframe` / `.WHO`-style iteration — rather than at every
+call. The consumers are the risk: a single missed iteration site reads one tier
+and silently reports a truncated lexical view.
+
+An intermediate step that needs no consumer audit: make the `Sub` value's env
+lazy (built on first introspection from a retained scoped env), which removes
+one flatten and, with it, the sharing that forces the callee's first write to
+deep-copy.
+
+## Why it matters
+
+This is the measured remainder of `todo/deep/vendor-real-test-module.md`'s last
+timeout: after the 2026-09-06 dispatch-cache fix removed the three per-call
+registry walks, `roast/S03-buf/write-int.t` still runs 45 s against a 30 s
+budget, and the resolutions were only ~6% of it. Every heavy-signature call in
+any program pays this, not just `Test` — but `Test` is where it is measurable,
+because an assertion is nothing *but* a call.
+
+## Measurement protocol
+
+Iterate on `MUTSU_VM_STATS`'s `clone_env` / `env_deep_copies` counters (they are
+deterministic and optimization-independent, so the debug build is enough), then
+confirm wall clock on release with the padding table above — it is the cleanest
+signal that the per-call cost stopped scaling with env size.


### PR DESCRIPTION
Calling a sub imported from a module cost **14.7 us**; an identical sub declared
in the calling file cost **0.75 us**. Same signature, same body, same call site
— a 20x penalty for nothing but where the sub was declared.

## Three registry walks per call

`compile_and_call_function_def` populated the name-keyed `otf_call_cache` only
when it had compiled the body itself:

```rust
let (cf, compiled_from_plan) = match &def.compiled {
    Some(compiled) => (Arc::clone(compiled), true),
    None => (self.otf_compile_function_def(def), false),
};
if !compiled_from_plan && !self.has_multi_candidates_cached(&name) { /* cache it */ }
```

A module sub always arrives with `def.compiled` already set (its module was
compiled when it was loaded), so the entry was never written and every call
re-ran the whole chain: `find_compiled_function` (two type-signature
`Vec<String>` builds, a full resolve, four `format!`ed key probes that all miss
because the sub is not in the caller's table at all) → `user_function_matches_call`
→ `resolve_function_with_types`. **60 000 `function-full-resolve`s for 20 000
calls**, against **1** for the local twin.

## The change

Cache the plan-compiled body on exactly the same terms as the OTF one. The
guards that make the OTF entry sound — callsite-package key, `fn_resolve_gen`
invalidation, never written for a multi name — do not depend on who compiled the
body. A hit now also runs the body against the routine's own nested-sub table
(`cf.compiled_fns`), which is what the uncached path beside it already did
(ADR-0019 C6e-3c) and what a body compiled inside another module needs to
resolve its own nested `RegisterSub` keys.

| call, 20 000 iterations (release) | before | after |
| --- | --- | --- |
| imported `sub plainmod($c, $d)` | 294 ms | **18 ms** |
| imported `sub modsub(Bool(Mu) $c, $d is copy, $p = '')` | 643 ms | **373 ms** |
| local `sub localsub($c, $d)` (control) | 15 ms | 15 ms |

The simple imported sub reaches parity with a local one; the heavy-signature one
still pays for its own signature (a coercion type, an `is copy` and a default
keep it off both light paths) but no longer for its provenance.

Under the vendored upstream `Test`, `roast/S03-buf/write-int.t` goes 48.2 s →
45.4 s and `proclaim` from three full registry walks *per assertion* to three in
total.

## The guard this needed

`t/sub-rw-writeback-attr-source-no-leak.t` was written against a shape that did
not then reproduce through a plain sub call, and said so:

> If a future change to the sub-call fast paths starts populating `rw_bindings`
> for this shape, `apply_rw_bindings_to_env` would need the same
> attribute-twigil guard `vm_method_dispatch.rs`'s `rw_writeback` loop already
> has — this test would catch the regression either way.

It did, on the first full `make test`. `f(:%!plugin-config)` encodes the
*attribute's* twigil form as the writeback's source name; inserted verbatim into
the caller's env it becomes a pseudo-key an unrelated later method call's
`reconcile_attrs` scan can adopt as its own attribute override, silently
overwriting a different instance's same-named attribute.
`apply_rw_bindings_to_env` now skips an attribute-shaped source, mirroring the
method-call twin — the shared `ContainerRef` cell the writeback exists for
already carries content mutations without the insert.

## Docs

- `news/2026-09/imported-module-sub-reaches-the-cached-dispatch.md`.
- New `todo/perf/named-call-flattens-the-env-twice-per-call.md`: the measured
  *remainder* of the real-`Test` timeout. Per-call cost is linear in env size
  (~0.98 ns per entry per assertion; 0/300/600/900 padding vars →
  0.609/1.213/1.841/2.363 s for 2000 assertions), because the named call path
  takes two eager `Env::flattened()` snapshots — `push_caller_env()` and the
  `Sub` value's env for `callframe().code` — for consumers that almost never run.
- `todo/deep/vendor-real-test-module.md` corrected: its "a defaulted parameter
  forfeits the light-call path" attribution was wrong for `proclaim`, which
  never reached that gate.

## Tests

`make test` clean apart from `t/io-path-smartmatch-permissions.t`, which fails
for a root-user container regardless of this change (same as the pre-change
baseline on this box).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UUpduPmW6HWAcpLk2RjT2V

---
_Generated by [Claude Code](https://claude.ai/code/session_01UUpduPmW6HWAcpLk2RjT2V)_