### PR TITLE
fix(container): rebuilt containers must write through their own node

### DIFF
--- a/docs/adr/0039-container-lexicals-resolve-lexically.md
+++ b/docs/adr/0039-container-lexicals-resolve-lexically.md
@@ -11,10 +11,12 @@
   as well as a resolution preference, because a scalar write replaces a value —
   followed on 2026-08-25 through the same module's `our` cell; see
   `news/2026-08/our-scalar-bare-name-resolves-to-the-package-cell.md`.
-  Slice 2 (§4.2 — containers resolve by
-  slot/upvalue, not by name, retiring the by-name path at the compiler) is
-  still next and still the end state; it now carries no known open
-  correctness bug of its own.
+  Slice 2 (§4.2) is still next and still the end state. Its read side was
+  re-implemented and re-measured on 2026-09-06 and **withdrawn a second time**;
+  §10 records the full re-measurement (which found §4.1's exclusion list already
+  free of divergences), the four defects the flip exposed, the one fix that
+  shipped on its own, and the enumerated reason the flip is blocked — the
+  *write/capture* lane, not §9's store lane.
 - Date: 2026-08-20
 - Related: ADR-0013 (container interior mutability — `gc_contents_mut`),
   ADR-0024 (mainline lexicals for named subs — the scalar half of this bug),
@@ -799,3 +801,166 @@ different containers, which a by-name read papered over:
   `target_slot`), then flip the read. The read flip is the cheap last step and
   its acceptance is already written (§6's rows (a) and (b), plus the 12
   assertions above as the regression set).
+
+## 10. Slice 2 re-measured and re-withdrawn (2026-09-06); §4.1's exclusion list is already empty
+
+§9 measured §4.2's first bullet (container reads emit `GetLocal(slot)`), found 7
+`t/` files / 12 assertions of fallout, withdrew it, and concluded the blocker was
+§1.3 of `docs/lexical-scope-slot-campaign.md` — the *store* lane. That diagnosis
+was **half right**. Re-doing it end-to-end shows the store lane is a short,
+concrete list that can be fixed; what actually blocks the flip is a different
+lane the ADR had not enumerated.
+
+### 10.1 The re-measurement (do this before planning any more slice-2 work)
+
+Before writing code, §1.1/§1.2's repros, §6's two acceptance rows, §8.2's two
+cross-thread rows, and **one row per §4.1 exclusion-list entry** (`our`, `state`,
+`is export`, `$*dynamic`, `::`-qualified, type-constrained, anonymous container)
+in BOTH the module file-scope shape and the mainline named-sub shadow shape were
+run under `raku` v2026.07 and `target/debug/mutsu` on `2a9e06f91`.
+
+| row | shape | status |
+|---|---|---|
+| §1.1 | module file-scope `my @`/`my %` | agrees |
+| §1.2 | mainline named sub × shadowing block, `@`/`%` | agrees |
+| §1.2 3rd | `our @`/`our %`, module and mainline | agrees |
+| excl. `state` | module `state @`, mainline `state @` × shadow | agrees |
+| excl. `is export` | `our @exp is export` | agrees |
+| excl. `$*dynamic` | module routine mutating `@*dyn` under a nested re-declaration | agrees |
+| excl. `::`-qualified | `@Q::arr` mutated by a sub, with a same-named block `my @arr` | agrees |
+| excl. type-constrained | module `my Int @`/`my Int %`, mainline `my Int @` × shadow | agrees |
+| excl. anonymous | module `my $anon = [...]` vs consumer `my $anon` | **diverges** (scalar lane) |
+| §8.2 (a)/(b) | cross-thread container escape | agrees (closed by §8.6) |
+| §6 row (a) | closure's `@a.push` landing on an inner block's shadow | **diverges** |
+| §6 row (b) | closure-local `my @c` emptying the mainline `@c` | **diverges** |
+
+**§4.3's "slice 1's exclusion list is the list of things slice 2 must subsume"
+is stale: as measured, that list contains no divergences at all.** Those names
+were excluded from slice 1's *store*, and the bugs they used to carry were closed
+separately — the `our` container resolution fix (2026-08-23), its scalar twin
+(2026-08-25), and §8.6's lane lifetime (2026-08-22). Read the list as "shapes
+slice 1 deliberately did not put in `unit_lexicals`", not as open bugs. Anyone
+planning slice 2 should stop treating it as a work item.
+
+The one exclusion row that does diverge is a **scalar** lane bug: a module's
+`my $anon = [...]` colliding with a consumer's `my $anon` (the binding is
+`$`-sigiled; only its value is an Array). It reproduces identically without any
+slice-2 change and is context-sensitive rather than reducible to two lines —
+tracked in `todo/tickets/module-scalar-held-array-collides-with-caller-my.md`.
+
+### 10.2 The read flip, measured again
+
+The flip (`Expr::ArrayVar`/`Expr::HashVar` emit `GetLocal(slot)` when `local_map`
+holds the sigiled name) was implemented and measured on `2a9e06f91`. Fallout on
+`prove t/` was **8 files / 14 assertions** — §9's 7 files plus
+`t/closure-topic-readonly.t` 12 and `t/push-inline-array-decl.t` 3. Four distinct
+defects account for all of them, and each is a store site that leaves the slot and
+`env` naming different containers, which the by-name read had been hiding:
+
+1. **An expression-position container declaration allocates no slot.**
+   `compile_expr_stmt`'s `Stmt::VarDecl` arm (`compiler/expr_block.rs`) takes a
+   `decl_slot` only when the declaration shadows an outer binding; otherwise it
+   emits `MarkVarDeclContext; SetGlobal(name)`. `local_map` retains a *popped
+   sibling block's* slot for a first declaration, so `{ my @a = 5,7,9 } (my
+   @a).push: $_ for ^3` read that stale slot. Fix: any container declaration
+   whose name already has a reachable slot takes one. (6 of the 14.)
+2. **`try_fast_hash_element_assign` resolves its target by name.**
+   `vm/vm_var_assign_element.rs` used `find_local_slot` (`position`), which with
+   a same-named shadow (`code.locals == ["%h", "%h"]`) answers the OUTER entry:
+   the fast path nil'd and re-seeded the wrong binding while the inner
+   declaration's slot never saw the write. §9 attributed this to
+   `exec_index_assign_expr_named_op_inner` ignoring its baked `target_slot`; the
+   real culprit is this fast path, which is never handed the baked slot at all.
+   Fix: thread `target_slot` in and use `resolve_local_slot`. (1 of the 14.)
+3. **Whole-container rebuilds replace the node.** The `.map` rw element
+   writeback (both the `map` builtin and the `.map` method) and
+   `classify`/`categorize`'s `:into` target rebuilt the container and inserted
+   the fresh node into `env` under the bare name. (3 of the 14.)
+4. **A QuantHash re-tag rebuilds its data node.**
+   `register_var_container_type_metadata` (`runtime/runtime_container.rs`) tags
+   the env value and re-inserts it; a `Set`/`Bag`/`Mix` embeds its metadata in the
+   data node, so tagging builds a NEW node. `my %h is MixHash` therefore left the
+   declaring slot on the untagged original, and a later `%h<k> = w` from a nested
+   frame mutated a container the slot never saw. (5 of the 14.)
+
+With all four fixed, `prove t/` is fully green under the flip (3709 files, 38033
+tests), and §6's acceptance row (b) answers raku's `[1 7]`.
+
+### 10.3 Why it was withdrawn anyway: `make roast` names the real blocker
+
+The full whitelist (release, 1436 files) then failed **4 files**, and they are not
+more of the same:
+
+| file | shape | lane |
+|---|---|---|
+| `S32-list/classify.t` 25-27 | `:into(my %b := BagHash.new)` | fix 3's probe promoted a parent-tier env entry into the frame overlay — a genuine bug in the fix, corrected by probing read-only |
+| `S03-metaops/hyper.t` 18-19, 92-93 | `@r»++` with an outer same-named `my @r` | `write_back_hyper_target_var` resolves by `find_local_slot`/`locals_set_by_name` (`position` → the OUTER slot). Same class as fix 2; needs a baked slot on `HyperMethodCall` |
+| `S15-nfg/concat-stable.t` 4-7, 11-14, 18-21 | `my @n = @o.shift xx $_` — the `xx` LHS is an anon-sub thunk that mutates `@o` | **write/capture lane** |
+| `integration/advent2014-day05.t` 6 | `$supply.act: { @seen[$_] //= $_ }` | **write/capture lane** |
+
+The last two are the blocker, and they are one root cause: **a container mutated
+from a nested frame (an anon-sub thunk, a `.act`/`start` handler) propagates to
+its owner by NAME only.** The frame doing the mutation has no slot for the name,
+so the write lands in `env` and, when the write path *replaces* rather than
+mutates the node, the owner's slot goes stale. Today's by-name read hides this
+completely.
+
+The obvious repair — cell-box the container at its declaration so both halves
+alias one cell — is the route
+`docs/captured-outer-cell-sharing.md` §7.1d already records as tried and
+rejected: broader `@`/`%` decl-site boxing regressed ~12 files through decont
+leaks, which is why `register_container_ref_capture_if_free`
+(`compiler/expr_call.rs`) is restricted to plain `$` names to this day. Every
+"scalars only (containers share via Arc already)" comment in
+`vm/vm_env_helpers.rs`'s boxing helpers rests on the same premise — true for
+in-place mutation (§2), false the moment a path replaces the container.
+
+So **the read flip is gated on the write/capture lane, i.e. §4.2's SECOND
+bullet, not on §9's store lane.** They cannot be landed in the order §4.2 lists
+them, and they cannot be landed independently either.
+
+### 10.4 What shipped from this investigation
+
+Only the part that is correct and pinnable **without** the flip:
+
+- `Interpreter::store_container_preserving_identity` (`vm/vm_var_assign_ops.rs`)
+  and its three call sites (the `map` builtin's rw writeback, the `.map` method's
+  rw writeback, `classify`/`categorize`'s `:into`). It copies a rebuilt
+  container's contents into the existing backing node instead of replacing the
+  env entry. Two user-visible bugs fixed: `my $b := @a; map { $_ = 5 }, @a`
+  left `$b` at `[1 2 3]`, and `my $f := %into; @src.categorize(..., :into(%into))`
+  left `$f` empty. Pin: `t/container-rebuild-preserves-identity.t` (10
+  assertions, byte-identical under `raku`).
+
+Held back deliberately, because with by-name reads they are **not observable**
+and therefore cannot be pinned (measured: the same probes pass identically with
+and without them):
+
+- the expression-position declaration slot (fix 1) — worse, it *changes*
+  behaviour for the wrong reason without the flip, since the store then lands in
+  a slot nothing reads;
+- `try_fast_hash_element_assign`'s baked target slot (fix 2);
+- `Value::retag_quanthash_in_place` + `register_var_container_type_metadata`
+  (fix 4).
+
+They are described precisely enough in §10.2 to be re-derived; do not re-measure
+them from scratch.
+
+### 10.5 The order slice 2 should now take
+
+§9 said "store sites first, read flip last". Correct the middle:
+
+1. **The write/capture lane first** — make a container mutated from a nested
+   frame reach its owner's binding, without decl-site boxing (§7.1d). §6
+   acceptance row (a) is its acceptance test; `S15-nfg/concat-stable.t`'s `xx`
+   thunk and `integration/advent2014-day05.t`'s `.act` handler are two more, and
+   both are already in the whitelist so a regression is loud. This is adjacent to
+   ADR-0055's closure free-variable work and should be resourced with it.
+2. **Then the four store fixes of §10.2** together with the read flip, as one
+   change — none of them is separately pinnable.
+3. `HyperMethodCall` needs a baked target slot in that same change (the hyper.t
+   rows above), joining the S1-S17 slot-bake series in
+   `docs/lexical-scope-slot-campaign.md`.
+4. §4.2's third bullet (`is_plain_lexical_name`'s `@%&` exclusion) stays
+   independent and still open.
+

--- a/src/runtime/builtins_collection_classify.rs
+++ b/src/runtime/builtins_collection_classify.rs
@@ -440,7 +440,11 @@ impl Interpreter {
                     if has_proxy {
                         let _ = self.assign_proxy_lvalue(into_target_raw.unwrap(), new_value)?;
                     } else if let Some(ref vname) = into_varname {
-                        self.env_mut().insert(vname.clone(), new_value);
+                        // ADR-0039 slice 2: `:into(%h)` mutates the CALLER's
+                        // hash, so the rebuilt buckets must be written through
+                        // its own node -- a bare-name env replacement leaves
+                        // the caller's local slot on the original container.
+                        self.store_container_preserving_identity(vname, new_value);
                     }
                 }
             }

--- a/src/runtime/builtins_collection_mapgrep.rs
+++ b/src/runtime/builtins_collection_mapgrep.rs
@@ -95,7 +95,12 @@ impl Interpreter {
             // container's per-slot metadata (`initialized` holes, element type)
             // — see the same gate in `methods_mut_dispatch.rs`.
             if wrote_back {
-                self.env.insert(var_name, Value::real_array(list_items));
+                // ADR-0039 slice 2: write the mutated elements THROUGH the
+                // source container's own node instead of dropping a fresh
+                // array into `env` under the bare name -- the owning frame's
+                // local slot (which `@a` now reads through) points at the
+                // original node, so a replacement would be invisible to it.
+                self.store_container_preserving_identity(&var_name, Value::real_array(list_items));
             }
             Ok(result)
         } else {

--- a/src/runtime/methods_mut_dispatch.rs
+++ b/src/runtime/methods_mut_dispatch.rs
@@ -2094,14 +2094,21 @@ impl Interpreter {
                 if let Some(info) = self.container_type_metadata(&target) {
                     rebuilt = self.tag_container_metadata(rebuilt, info);
                 }
-                self.env.insert(key, rebuilt);
+                // ADR-0039 slice 2: preserve the source container's identity
+                // (see `store_container_preserving_identity`) -- the caller's
+                // local slot holds the original node and a bare-name env
+                // replacement never reaches it.
+                self.store_container_preserving_identity(&key, rebuilt);
             } else if let ValueView::Array(src, kind) = target.view() {
                 // Keep the source container's metadata (element type, default,
                 // `initialized` holes) across the rebuild.
                 let rebuilt = Value::array_data_like(&src, items);
-                self.env.insert(key, Value::array_with_kind(rebuilt, kind));
+                self.store_container_preserving_identity(
+                    &key,
+                    Value::array_with_kind(rebuilt, kind),
+                );
             } else {
-                self.env.insert(key, Value::real_array(items));
+                self.store_container_preserving_identity(&key, Value::real_array(items));
             }
             return Ok(result);
         }

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -690,6 +690,63 @@ impl Interpreter {
         });
     }
 
+    /// Store a REBUILT container back under `var_name` while preserving the
+    /// binding's container identity.
+    ///
+    /// ADR-0039 slice 2: a runtime helper that rebuilds a whole container from
+    /// scratch (the `.map` rw element writeback, `classify`/`categorize`'s
+    /// `:into` target, ...) used to drop the fresh node into `env` under the
+    /// bare name. That is only observable through a by-name read -- the owning
+    /// frame's local slot still points at the ORIGINAL node -- so once `@`/`%`
+    /// reads resolve through their slot the rebuild is silently lost. Copying
+    /// the rebuilt contents into the existing backing node instead makes the
+    /// update visible to every holder of that container (the slot, a by-value
+    /// capture, a `:=` alias), which is what Raku container identity means
+    /// (ADR-0039 §2/§3: in-place mutation needs no write handle, only the
+    /// right node).
+    ///
+    /// Falls back to a plain env insert when the name currently holds no
+    /// container of the same kind (autovivification, a type change, a `Bag`
+    /// replacing a `Hash`), which is a genuine rebinding rather than a
+    /// mutation.
+    pub(crate) fn store_container_preserving_identity(&mut self, var_name: &str, new_val: Value) {
+        // Probe READ-ONLY: `env_root_descended_mut` would promote a parent-tier
+        // entry into this frame's overlay, which is a real change in env shape
+        // for a `:=`-bound target (`:into(my %b := BagHash.new)`).
+        let current = self.env().get(var_name).map(|v| v.clone().into_deref());
+        let rebuilt = match &current {
+            Some(cur) => {
+                let old_view = cur.view();
+                let new_view = new_val.view();
+                match (&old_view, &new_view) {
+                    (ValueView::Array(old_gc, _), ValueView::Array(new_gc, kind))
+                        if !crate::gc::Gc::ptr_eq(old_gc, new_gc) =>
+                    {
+                        Some(Self::array_inplace_reassign(old_gc, new_gc, *kind))
+                    }
+                    (ValueView::Hash(old_gc), ValueView::Hash(new_gc))
+                        if !crate::gc::Gc::ptr_eq(old_gc, new_gc) =>
+                    {
+                        Some(Self::hash_inplace_reassign(old_gc, new_gc))
+                    }
+                    _ => None,
+                }
+            }
+            None => None,
+        };
+        drop(current);
+        match rebuilt {
+            Some(updated) => {
+                if let Some(container) = self.env_root_descended_mut(var_name) {
+                    *container = updated;
+                }
+            }
+            None => {
+                self.env_mut().insert(var_name.to_string(), new_val);
+            }
+        }
+    }
+
     /// Container identity (§3, splice.t): copy `new_gc`'s array contents into the
     /// original backing `old_gc` in place — preserving the pointer identity every
     /// by-value holder of `old_gc` shares (an `@a` captured into a list `(0, @a)` /

--- a/t/container-lexical-declarator-matrix.t
+++ b/t/container-lexical-declarator-matrix.t
@@ -1,0 +1,168 @@
+use lib $?FILE.IO.parent.add('lib').Str;
+use Test;
+use ContainerSlotLexical;
+
+# ADR-0039 §10.1: the re-measured container-lexical matrix.
+#
+# ADR-0039 §4.3 claimed slice 1's exclusion list (`our`, `state`, `is export`,
+# `$*dynamic`, `::`-qualified, type-constrained, anonymous container) was "the
+# list of things slice 2 must subsume". Measured on 2026-09-06, every one of
+# those rows already agrees with `raku` — they were excluded from slice 1's
+# *store*, not from correctness. This file pins that so the claim cannot rot
+# back into a to-do item, and so a future slice-2 attempt has its acceptance
+# corpus ready.
+#
+# One row per declarator, in BOTH shapes that make the collision likely: a
+# module's own file-scope container seen from its own routines while the
+# consumer holds a same-named one, and a mainline named sub's container across
+# a shadowing inner block. Every assertion is byte-identical under `raku`.
+#
+# Everything that needs a MAINLINE binding is written at file scope on purpose:
+# a `my` inside a block is a different (block) binding, and the shapes under
+# test are specifically about a mainline lexical seen from a named sub.
+
+plan 41;
+
+# --- module file scope: the module's own containers are not the caller's -----
+
+my @items = <x y z>;
+my %hs = (mine => 1);
+my-push("c");
+my-hset("m");
+is my-peek(), 'a,b,c', 'module my @ sees its own binding';
+is my-hpeek(), 'k,m', 'module my % sees its own binding';
+is @items.join(","), 'x,y,z', "consumer's my @ is untouched";
+is %hs.keys.sort.join(","), 'mine', "consumer's my % is untouched";
+
+my @ours = <x y z>;
+my %ourh = (mine => 1);
+our-push("c");
+our-hset("m");
+is our-peek(), 'a,b,c', 'module our @ sees the package binding';
+is our-hpeek(), 'k,m', 'module our % sees the package binding';
+is @ours.join(","), 'x,y,z', "consumer's same-named my @ is untouched";
+is %ourh.keys.sort.join(","), 'mine', "consumer's same-named my % is untouched";
+is @ContainerSlotLexical::ours.join(","), 'a,b,c',
+    'the package-qualified mirror agrees';
+
+my @st = <x y z>;
+state-push("c");
+is state-peek(), 'a,b,c', 'module state @ sees its own binding';
+is @st.join(","), 'x,y,z', "consumer's same-named my @ is untouched (state)";
+
+my @ti = <x y z>;
+typed-push(9);
+is typed-peek(), '1,2,9', 'module type-constrained @ sees its own binding';
+is @ti.join(","), 'x,y,z', "consumer's same-named untyped @ is untouched";
+
+# (The module's anonymous scalar-held container -- `my $anon = [...]` -- is
+# deliberately NOT pinned here: it collides with a consumer's same-named `my
+# $anon` through the SCALAR unit-lexical lane, a pre-existing divergence
+# unrelated to container resolution. See
+# todo/tickets/module-scalar-held-array-collides-with-caller-my.md.)
+
+my @*csldyn = <a b>;
+sub dyn-wrapper() {
+    my @*csldyn = <p q>;
+    dyn-push("c");
+    dyn-peek();
+}
+is dyn-wrapper(), 'p,q,c', 'a dynamic container resolves dynamically, not lexically';
+is @*csldyn.join(","), 'a,b', 'the outer dynamic binding is untouched';
+
+# --- mainline: a named sub keeps its own binding across a shadowing block ----
+
+my @names = <a b>;
+my %hn = (k => 'v');
+sub add-name($v) { @names.push($v) }
+sub read-names() { @names.join(",") }
+sub hset($k) { %hn{$k} = 1 }
+sub hread() { %hn.keys.sort.join(",") }
+add-name("c");
+is read-names(), 'a,b,c', 'mainline named sub mutates the mainline @';
+{
+    my @names = <x y z>;
+    my %hn = (mine => 1);
+    add-name("d");
+    hset("m");
+    is @names.join(","), 'x,y,z', 'the shadowing block @ is untouched by the sub';
+    is read-names(), 'a,b,c,d', 'the sub still sees the mainline @';
+    is %hn.keys.sort.join(","), 'mine', 'the shadowing block % is untouched';
+    is hread(), 'k,m', 'the sub still sees the mainline %';
+}
+is read-names(), 'a,b,c,d', 'the mainline @ kept both pushes';
+is hread(), 'k,m', 'the mainline % kept its key';
+
+our @oc = <a b>;
+our %od = (k => 'v');
+sub oadd($v) { @oc.push($v) }
+sub ohset($k) { %od{$k} = 1 }
+sub opeek() { @oc.join(",") }
+sub ohpeek() { %od.keys.sort.join(",") }
+oadd("c");
+is opeek(), 'a,b,c', 'a mainline our @ is mutated by its named sub';
+{
+    my @oc = <x y z>;
+    my %od = (mine => 1);
+    oadd("d");
+    ohset("m");
+    is @oc.join(","), 'x,y,z', 'the shadowing block my @ is untouched (our)';
+    is opeek(), 'a,b,c,d', 'the our @ still sees its own binding';
+    is %od.keys.sort.join(","), 'mine', 'the shadowing block my % is untouched (our)';
+    is ohpeek(), 'k,m', 'the our % still sees its own binding';
+}
+
+module Q { our @arr = <a b>; our %hsh = (k => 'v'); }
+sub qadd($v) { @Q::arr.push($v) }
+sub qhset($k) { %Q::hsh{$k} = 1 }
+qadd("c");
+qhset("m");
+is @Q::arr.join(","), 'a,b,c', 'a ::-qualified @ resolves to the package';
+is %Q::hsh.keys.sort.join(","), 'k,m', 'a ::-qualified % resolves to the package';
+{
+    my @arr = <x y z>;
+    my %hsh = (mine => 1);
+    qadd("d");
+    qhset("n");
+    is @arr.join(","), 'x,y,z', 'a same-named block my @ does not capture the qualified write';
+    is @Q::arr.join(","), 'a,b,c,d', 'the qualified @ kept both pushes';
+    is %hsh.keys.sort.join(","), 'mine', 'a same-named block my % is untouched';
+    is %Q::hsh.keys.sort.join(","), 'k,m,n', 'the qualified % kept both keys';
+}
+
+my Int @tc = 1, 2;
+my Int %td = (k => 5);
+sub tadd($v) { @tc.push($v) }
+sub tset($k) { %td{$k} = 1 }
+tadd(3);
+is @tc.join(","), '1,2,3', 'a type-constrained mainline @ is mutated by its sub';
+{
+    my @tc = <x y z>;
+    my %td = (mine => 1);
+    tadd(4);
+    tset("m");
+    is @tc.join(","), 'x,y,z', 'the untyped shadow @ is untouched';
+    is %td.keys.sort.join(","), 'mine', 'the untyped shadow % is untouched';
+}
+is @tc.join(","), '1,2,3,4', 'the typed @ kept both pushes';
+is %td.keys.sort.join(","), 'k,m', 'the typed % kept its key';
+
+# --- §8.2's cross-thread rows, closed by §8.6: a routine-local container must
+#     not escape into an unrelated caller once any `start` has run ------------
+
+sub work($tag) {
+    my @esc = ($tag,);
+    await start { 1 };
+    @esc.push("$tag-2");
+}
+my @esc = <x y z>;
+work('A');
+is-deeply @esc, ["x", "y", "z"], 'a callee-local container does not escape into the caller';
+@esc.push('MINE');
+work('B');
+is-deeply @esc, ["x", "y", "z", "MINE"], 'and stays intact across a second call';
+
+sub takes(@list is copy) { await start { 1 }; @list.push('R') }
+my @list = <x y z>;
+takes(<p q>);
+is-deeply @list, ["x", "y", "z"], 'a non-slurpy @ parameter does not escape the call';

--- a/t/container-rebuild-preserves-identity.t
+++ b/t/container-rebuild-preserves-identity.t
@@ -1,0 +1,60 @@
+use Test;
+
+# A runtime helper that rebuilds a whole container from scratch must write the
+# rebuilt contents THROUGH the existing backing node, not drop a fresh node into
+# `env` under the variable's bare name. A replacement is invisible to every
+# other holder of that container -- a `:=`-bound alias, a by-value capture, and
+# (once `@`/`%` reads are slot-addressed, ADR-0039 slice 2) the declaring
+# frame's own local slot.
+#
+# Every assertion is byte-identical under `raku`.
+
+plan 10;
+
+# --- the listop `map` rw element writeback ----------------------------------
+
+{
+    my @a = 1, 2, 3;
+    my $alias := @a;
+    map { $_ = 5 }, @a;
+    is-deeply @a, [5, 5, 5], 'listop map rw writeback updates the source';
+    is-deeply $alias, [5, 5, 5], 'and the := alias observes it';
+}
+
+{
+    my @a = 1, 2, 3;
+    my @holder = (0, @a);
+    map { $_ = 7 }, @a;
+    is-deeply @a, [7, 7, 7], 'listop map rw writeback updates the source (capture)';
+    is-deeply @holder[1], [7, 7, 7], 'and a by-value capture of the container observes it';
+}
+
+# --- the `.map` method rw element writeback ---------------------------------
+
+{
+    my @b = 1, 2, 3;
+    my $alias := @b;
+    @b.map({ $_ = 8 }).eager;
+    is-deeply @b, [8, 8, 8], '.map rw writeback updates the source';
+    is-deeply $alias, [8, 8, 8], 'and the := alias observes it';
+}
+
+# --- `classify` / `categorize` writing into a caller's hash -----------------
+
+{
+    my %into;
+    my $alias := %into;
+    my @src = (1, 2, 3, 4);
+    @src.categorize({ $_ %% 2 }, into => %into);
+    is %into.keys.sort.join(","), 'False,True', 'categorize :into fills the target';
+    is $alias.keys.sort.join(","), 'False,True', 'and the := alias observes it';
+}
+
+{
+    my %into;
+    my $alias := %into;
+    my @src = <a bb ccc>;
+    @src.classify({ .chars }, into => %into);
+    is %into.keys.sort.join(","), '1,2,3', 'classify :into fills the target';
+    is $alias.keys.sort.join(","), '1,2,3', 'and the := alias observes it';
+}

--- a/t/lib/ContainerSlotLexical.rakumod
+++ b/t/lib/ContainerSlotLexical.rakumod
@@ -1,0 +1,36 @@
+unit module ContainerSlotLexical;
+
+# A compunit's own file-scope containers, in every declarator ADR-0039 §4.1
+# listed as an exclusion. Each pair of routines lets the consumer prove the
+# module's binding is the one its own routines see, while the consumer's
+# same-named container stays untouched.
+
+my @items = <a b>;
+my %hs = (k => 'v');
+our @ours = <a b>;
+our %ourh = (k => 'v');
+state @st = <a b>;
+my Int @ti = 1, 2;
+my $anon = [<a b>];
+
+sub my-push($v) is export { @items.push($v) }
+sub my-peek() is export { @items.join(",") }
+sub my-hset($k) is export { %hs{$k} = 1 }
+sub my-hpeek() is export { %hs.keys.sort.join(",") }
+
+sub our-push($v) is export { @ours.push($v) }
+sub our-peek() is export { @ours.join(",") }
+sub our-hset($k) is export { %ourh{$k} = 1 }
+sub our-hpeek() is export { %ourh.keys.sort.join(",") }
+
+sub state-push($v) is export { @st.push($v) }
+sub state-peek() is export { @st.join(",") }
+
+sub typed-push(Int $v) is export { @ti.push($v) }
+sub typed-peek() is export { @ti.join(",") }
+
+sub anon-push($v) is export { $anon.push($v) }
+sub anon-peek() is export { $anon.join(",") }
+
+sub dyn-push($v) is export { @*csldyn.push($v) }
+sub dyn-peek() is export { @*csldyn.join(",") }

--- a/todo/deep/module-file-scope-array-and-hash-still-share-the-caller.md
+++ b/todo/deep/module-file-scope-array-and-hash-still-share-the-caller.md
@@ -1,186 +1,94 @@
 # A module's file-scope `my @a` / `my %h` is still the caller's variable
 
-**Design: [ADR-0039](../../docs/adr/0039-container-lexicals-resolve-lexically.md).
-Slice 1 (§4.1) LANDED 2026-08-20** — the module shape, the module-free mainline
-shadow shape, and the sub-local-consumer shape from this file's repros are all
-fixed and pinned (`t/module-file-scope-lexical.t`,
-`t/named-sub-lexical-scope-container.t`). **This file stays open** because
-slice 2 (§4.2 — containers resolve by slot/upvalue at the compiler, not by
-name, retiring `unit_lexicals`'s container special-casing entirely) is the
-ADR's stated architectural end state, not merely a follow-up; the exclusion
-list slice 1 carries (`our`, `state`, `is export`, `$*dynamic`, `::`-qualified,
-type-constrained, anonymous-container names) is explicitly "the list of things
-slice 2 must subsume" (ADR-0039 §4.3). `our @arr` colliding (§1.2's third
-instance) was ALSO still broken after slice 1; it is **FIXED as of 2026-08-23**
-by a resolution-only change (see "Remaining open scope" item 1). Move this file
-to `news/2026-08/` only once slice 2 lands and closes the remaining by-name
-container resolution path.
+**Design: [ADR-0039](../../docs/adr/0039-container-lexicals-resolve-lexically.md).**
 
-`news/2026-08/module-file-scope-lexical-is-not-the-callers.md` fixed this for
-**scalars**: a `unit` compunit's file-scope `my $x` now lives in a shared cell in
-`Interpreter::unit_lexicals`, keyed by the unit package. `@`/`%` were
-deliberately left out of that store until slice 1 landed:
+- **Slice 1 (§4.1) LANDED 2026-08-20.** The module shape, the module-free
+  mainline shadow shape, and the sub-local-consumer shape from this file's
+  original repros are fixed and pinned (`t/module-file-scope-lexical.t`,
+  `t/named-sub-lexical-scope-container.t`).
+- **Slice 2 (§4.2) re-measured and re-withdrawn 2026-09-06.** See ADR-0039 §10
+  for the enumeration. The short version is below, because it changes what
+  "remaining scope" means for this file.
 
-```raku
-# UFL.rakumod
-unit module UFL;
-my @items = <a b>;
-sub peek-items() is export { @items.join(",") }
-sub push-item($v) is export { @items.push($v) }
-```
-```raku
-use UFL;
-my @items = <x y z>;
-push-item("c");
-say peek-items();        # raku: a,b,c    mutsu (slice 1): a,b,c  (was: x,y,z,c)
-say @items.join(",");    # raku: x,y,z    mutsu (slice 1): x,y,z  (was: x,y,z,c)
-```
+## The 2026-09-06 re-measurement — read this before planning more work
 
-Verified fixed on the slice-1 branch, 2026-08-20 — see ADR-0039 §6.1 for the
-implementation notes (which write chokepoints needed fixing beyond the two
-skips) and the full acceptance-criteria verification.
+Every row of ADR-0039's matrices, plus **one row per entry of slice 1's
+exclusion list** (`our`, `state`, `is export`, `$*dynamic`, `::`-qualified,
+type-constrained, anonymous container) in both the module file-scope shape and
+the mainline named-sub shadow shape, was run under `raku` v2026.07 and debug
+`mutsu` on `2a9e06f91`. Full table: ADR-0039 §10.1.
 
-## Two corrections the 2026-08-20 investigation made (read before touching this)
+> **The exclusion list is not a list of divergences.** Every one of those rows
+> already agreed with `raku`. ADR-0039 §4.3's "slice 1's exclusion list is the
+> list of things slice 2 must subsume" is stale — those names were excluded from
+> slice 1's *store*, and the divergences they used to carry were closed
+> separately (the `our` container resolution fix 2026-08-23, its scalar twin
+> 2026-08-25, and §8.6's lane lifetime 2026-08-22).
 
-Both of the previous version's load-bearing claims were wrong. The full
-argument is in ADR-0039 §1.2 and §2; the summary:
+That matrix is now pinned as `t/container-lexical-declarator-matrix.t`
+(41 assertions, fixture `t/lib/ContainerSlotLexical.rakumod`, byte-identical
+under `raku`) so the claim cannot rot back into a to-do item.
 
-1. **It is not a module bug.** The identical divergence reproduces with no
-   module involved, at plain mainline scope, when an ordinary inner block
-   declares a same-named `my @a` while a named sub mutates the outer one. The
-   byte-identical *scalar* program is correct, because ADR-0024 fixed it. So
-   this ticket is exactly the `@`/`%` follow-up that ADR-0024 ("Known
-   limitations") and ADR-0025 (slice 3) both named and deferred — module
-   loading is merely the shape that makes the collision most likely. `our @a`
-   in a module collides too, for the same reason.
+One exclusion row does still diverge, and it is a **scalar** lane bug: a
+module's `my $anon = [...]` colliding with a consumer's `my $anon` (the binding
+is `$`-sigiled; only its value is an Array). Split out to
+`todo/tickets/module-scalar-held-array-collides-with-caller-my.md`.
 
-2. **The "~120+ call sites" sizing rested on an obsolete premise.** The
-   previous version argued that container mutation goes through `Gc::make_mut`
-   (copy-on-write), so a sound fix would need a new
-   write-through-the-canonical-slot primitive at every site. mutsu does not do
-   that: `Value::with_array_inplace` (`src/value/view.rs:769-789`) writes
-   through the **shared** node via ADR-0013's `gc_contents_mut`, and its doc
-   comment states outright that `Gc::make_mut` is *wrong* here (Raku `=` copy
-   semantics are enforced at copy time by `detach_shared_container` instead).
-   Verified empirically: two distinct `env` keys holding one container observe
-   each other's `push` / element-assign / key-set. **In-place mutation needs no
-   write handle — it only needs to read the right container.** The previous
-   version's dismissal of ADR-0013 as "orthogonal" was the mis-attribution, not
-   the citation it replaced.
+## What this file's remaining scope actually is
 
-What survives is the *routing* diagnosis, which ADR-0039 §4.1 scopes: the
-residual hazard is the small set of sites that, on an `env` miss, **build a
-fresh container and insert it** under the bare name — `push_to_shared_var`'s
-tail (`src/runtime/runtime_thread.rs:929-957`) being the sharpest — plus
-whole-container reassignment, which must preserve container identity through
-the cell.
+Slice 2's read side (`@`/`%` reads compile to `GetLocal(slot)`) was implemented
+and measured a second time. `prove t/` goes fully green under it once four
+store-side defects are fixed (ADR-0039 §10.2 lists them precisely), and §6's
+acceptance row (b) is fixed by it. But `make roast` then fails two whitelisted
+files that are a different lane entirely:
 
-## What slice 1 changed, and what slice 2 still owns
+- `roast/S15-nfg/concat-stable.t` — `my @n = @o.shift xx $_`, where the `xx`
+  LHS is an anon-sub thunk that mutates `@o`;
+- `roast/integration/advent2014-day05.t` — `$supply.act: { @seen[$_] //= $_ }`.
 
-- `collect_unit_lexical_names` (`src/runtime/run_modules.rs`) and ADR-0024's
-  mainline capture (`src/vm/vm_register_sub_ops.rs`) no longer skip `@`/`%` —
-  see ADR-0039 §4.1/§6.1 for the full list of write-side chokepoints
-  (`env_root_descended_mut`, `push_to_shared_var`, `exec_delete_index_named_op`)
-  that had to learn to consult `unit_lexicals` first.
-- **`compute_upvalues`** (`src/opcode.rs:6124-6130`, still excludes
-  `@`/`%`/`&`) and **`is_plain_lexical_name`**'s `@%&` exclusion
-  (`compiler/mod.rs:1712-1721`) are UNCHANGED by slice 1 — a container
-  free variable still resolves by NAME at the compiler, not by slot/upvalue.
-  This is exactly slice 1's scope boundary: it makes a compunit's OWN
-  file-scope containers safe by giving them a name-keyed cell store that
-  wins over `env`, but does not make container scoping lexical in general
-  (an ordinary inner block's `@a` is still name-resolved). Closing that
-  asymmetry — deleting `unit_lexicals`'s container special-casing along with
-  it — is slice 2 (ADR-0039 §4.2), not this file's concern any more once
-  slice 2 lands.
-- `box_captured_lexicals` (`src/vm/vm_register_ops.rs:927`) is the scalar-only
-  box-on-capture mechanism (lever C slice 2, unrelated numbering to this
-  ADR's slice 2) — still scalar-only, not touched by ADR-0039 slice 1.
+Both are one root cause, and it is the same as ADR-0039 §6 acceptance row (a):
 
-## Stale: the `roast/integration/99problems-41-to-50.t` instance
+> **A container mutated from a nested frame propagates to its owner by NAME
+> only.** The mutating frame has no slot for the name, so the write lands in
+> `env`; when the write path *replaces* the container rather than mutating it in
+> place, the owner's slot goes stale. Today's by-name read hides this entirely,
+> which is why the read flip cannot land without it.
 
-The previous version recorded that file aborting at 1 of 9 under
-`MUTSU_REAL_TEST=1` because `Test.rakumod`'s `my @vars` collided with the
-test's own. It now runs 9/9 clean under `MUTSU_REAL_TEST=1`, although the
-collision setup is unchanged — see ADR-0039 §7. It is no longer a usable
-measure; ADR-0039 §6's divergence matrix replaces it.
+The obvious repair — cell-box the container at its declaration — is already
+recorded as tried and rejected: `docs/captured-outer-cell-sharing.md` §7.1d
+(broader `@`/`%` decl-site boxing regressed ~12 files through decont leaks), and
+that is why `register_container_ref_capture_if_free` (`compiler/expr_call.rs`)
+is restricted to plain `$` names. Every "scalars only (containers share via Arc
+already)" comment in `vm/vm_env_helpers.rs`'s boxing helpers rests on a premise
+that is true for in-place mutation (ADR-0039 §2) and false the moment a path
+replaces the container.
 
-## Repros
-
-`tmp/ufl/` (regenerate from ADR-0039 §1.1/§1.2, or from ADR-0039 §6.1's fixed
-examples): `matrix.raku` (15-assertion `@`/`%` operation matrix through a
-module — now pinned as `t/module-file-scope-lexical.t`'s container half),
-`namedsub-mainline.raku` (the module-free mainline shadow shape — now pinned
-as `t/named-sub-lexical-scope-container.t`), `repro-sub.raku` (consumer
-declares the shadow inside a sub — now fixed too), `ourtest.raku` (`our @a` —
-fixed 2026-08-23, now pinned as `t/our-container-bare-name-resolution.t`; only
-its trailing `our $s` scalar line still diverges, tracked separately),
-`alias.raku` (the write-through control, unaffected by this ADR either way).
-
-## Remaining open scope (why this file is not fully closed)
-
-1. ~~**`our @arr` colliding**~~ — **FIXED 2026-08-23**, see
-   `news/2026-08/our-container-bare-name-prefers-package-mirror.md`. The
-   resolution fix landed as `src/vm/vm_our_package_vars.rs`: a bare `@`/`%`
-   name is resolved to the package-qualified `our` mirror of the package the
-   running routine belongs to, wired into the read chokepoint
-   (`get_env_with_main_alias`), the container-mutation chokepoint
-   (`env_root_descended_mut`), and `:delete`'s own by-name dance
-   (`exec_delete_index_named_op`). A name the running frame declares as its
-   own local is never redirected, so lexical shadowing inside the module
-   still wins. Pinned by `t/our-container-bare-name-resolution.t` (28
-   assertions) with fixture `t/lib/UnitOurContainer.rakumod`. No store change
-   was needed, exactly as ADR-0039 §4.1 predicted.
-
-   The **scalar** twin (`our $x` written from a module routine landing on the
-   caller's `my $x`) is a different mechanism — a scalar has no shared node,
-   so it needs `SetGlobal`'s bare env store suppressed rather than resolution
-   redirected — and is tracked separately in
-   `todo/tickets/our-scalar-write-leaks-to-the-callers-lexical.md`.
-2. **Slice 2** (ADR-0039 §4.2): container free variables in ordinary inner
-   blocks, closures, and any non-compunit-file-scope declaration still
-   resolve by name at the compiler (`Expr::ArrayVar`/`Expr::HashVar` emit
-   `GetArrayVar`/`GetHashVar` unconditionally, never `GetLocal(slot)`). Slice
-   1 is a name-keyed cell store that shadows `env` for exactly the compunit
-   file-scope case; slice 2 is the architectural fix that makes container
-   scoping lexical everywhere, the way scalar scoping already is, and lets
-   the container special cases slice 1 introduced be deleted rather than
-   extended further.
-
-## Re-verified 2026-09-01 (TRIAGE regeneration): two slice-2 acceptance rows
-
-The module shape and the mainline named-sub shadow shape agree with raku
-(slice 1 holds). Two non-file-scope shapes still resolve the container by
-name, and are usable as slice 2's acceptance rows (raku answers first):
+So this file is now **one ticket: make a container mutated from a nested frame
+reach its owner's binding**, without decl-site boxing. It is ADR-0039 §4.2's
+SECOND bullet, adjacent to ADR-0055's closure free-variable work, and it gates
+the read flip rather than following it. Acceptance:
 
 ```raku
-# (a) a sub-local @a captured by an inner anonymous sub, shadowed by an inner block's @a
-sub f { my @a = 1, 2; my $push = sub { @a.push(9) }; { my @a = 3; $push(); say "inner=", @a }; @a }
-say f();      # raku: inner=[3] / [1 2 9]    mutsu: inner=[3 9] / [1 2]  -- the push lands on the shadow
-
-# (b) a closure declaring @c that shadows a mainline @c and calls a named sub
-my @c = 1; sub g { @c.push(7) }
-my $h = { my @c; g(); @c }; $h();
-say @c;       # raku [1 7]     mutsu []     -- the mainline @c is emptied
+# ADR-0039 §6 row (a)
+sub f {
+    my @a = 1, 2;
+    my $push = sub { @a.push(9) };
+    { my @a = 3; $push(); say "inner=", @a }   # raku: inner=[3]   mutsu: inner=[3 9]
+    @a
+}
+say f();                                       # raku: [1 2 9]     mutsu: [1 2]
 ```
 
-(Both measured 2026-09-01 on `target/debug/mutsu` vs raku v2026.06.)
+plus the two roast files above (both already whitelisted, so a regression is
+loud).
 
-## Slice 2's read side measured, and withdrawn (2026-09-04) — see ADR-0039 §9
+## What shipped 2026-09-06
 
-Both acceptance rows above still reproduce. §4.2's first bullet (container reads
-emit `GetLocal(slot)`) was implemented and measured: **7 `t/` files, 12
-assertions**, and row (b) is fixed by it alone. Every one of the 12 is a *store*
-site that leaves the slot and `env` naming different containers — an
-expression-position declaration that allocates no slot (and a monotonic
-`local_map` that still holds a popped sibling's slot), or a genuine same-named
-shadow producing two `code.locals` entries with one name for an env-centric
-`IndexAssignExprNamed` to resolve between.
-
-So the first bullet is not independently landable, and the blocker is §1.3 of
-`docs/lexical-scope-slot-campaign.md`, not anything internal to this ADR. ADR-0039
-§9 records the enumeration, the withdrawn diff's shape, and the inverted order
-slice 2 should now take (store sites first, read flip last). Resource slice 2
-with §1.3, alongside
-`todo/tickets/same-named-loop-params-in-one-unit-interfere.md`, which reached the
-same conclusion from the scalar side.
+Only the part correct and pinnable without the read flip:
+`Interpreter::store_container_preserving_identity` and its three call sites (the
+`map` builtin's rw writeback, the `.map` method's rw writeback,
+`classify`/`categorize`'s `:into`), which write a rebuilt container's contents
+through the existing backing node. Two real bugs fixed —
+`my $b := @a; map { $_ = 5 }, @a` left `$b` at `[1 2 3]`, and
+`my $f := %into; @src.categorize(..., :into(%into))` left `$f` empty. Pin:
+`t/container-rebuild-preserves-identity.t`.

--- a/todo/tickets/module-scalar-held-array-collides-with-caller-my.md
+++ b/todo/tickets/module-scalar-held-array-collides-with-caller-my.md
@@ -1,0 +1,68 @@
+# A module's file-scope `my $x = [...]` still collides with the caller's `my $x`
+
+Found while building the ADR-0039 slice-2 acceptance matrix
+(`t/container-lexical-slot-resolution.t`, 2026-09-06). It is a **scalar** lane
+divergence, not a container one, and it reproduces identically with and without
+slice 2 — so it is out of ADR-0039's scope and tracked separately here.
+
+## Repro
+
+`t/lib/ContainerSlotLexical.rakumod` declares, at file scope:
+
+```raku
+unit module ContainerSlotLexical;
+my $anon = [<a b>];
+sub anon-push($v) is export { $anon.push($v) }
+sub anon-peek()   is export { $anon.join(",") }
+```
+
+and a consumer:
+
+```raku
+use ContainerSlotLexical;
+my $anon = [<x y z>];
+anon-push("c");
+say anon-peek();        # raku: a,b,c   mutsu: a,b
+say $anon.join(",");    # raku: x,y,z   mutsu: x,y,z,c
+```
+
+The module's push lands on the **consumer's** array: the module routine
+resolved `$anon` to the loading scope's binding.
+
+## Why it is not "just the ADR-0039 bug again"
+
+The sigil is `$`. The value is an Array, but the *binding* is a scalar, so it
+takes the scalar unit-lexical lane (ADR-0024), not the `@`/`%` container lane
+ADR-0039 slice 1 gave a cell store and slice 2 slot-addressed. The container
+shapes (`my @items`, `my %hs`, `our @a`, `state @a`, `my Int @a`) are all
+correct today — see `t/container-lexical-slot-resolution.t`.
+
+## The part that makes it hard to reduce
+
+The divergence is **context-sensitive**, which is the real finding here. The
+two-line repro above passes on its own; it only fails once the consumer file
+also declares several *other* mainline lexicals and named subs before it (the
+shape it was found in is `t/container-lexical-slot-resolution.t` with the
+module's `@items`/`@ours`/`@st`/`@ti` consumers, `sub dyn-wrapper`, and the
+`add-name`/`read-names` family declared afterwards). So the trigger is not the
+`$anon` declaration itself but *which* names the mainline capture
+(`exec_register_sub_op` → `unit_lexicals[MAINLINE_UNIT_KEY]`) ends up holding
+by the time the module routine runs.
+
+`unit_lexical_container_cell` (`src/vm/vm_env_helpers.rs`) probes
+`unit_lexicals[MAINLINE_UNIT_KEY]` **before** `unit_lexical_slot(name)`, i.e.
+the *loading script's* mainline lexicals win over the running routine's own
+compunit. That precedence is the first thing to check; `unit_lexical_slot`'s
+own ordering is the second.
+
+## Suggested first steps
+
+1. Bisect the consumer prefix mechanically (delete one preceding declaration at
+   a time from `t/container-lexical-slot-resolution.t` until the `$anon` rows
+   pass) to name the exact trigger, rather than guessing.
+2. Then decide whether the fix is a precedence change in
+   `unit_lexical_container_cell` / `unit_lexical_slot` or a capture-set fix in
+   `exec_register_sub_op`.
+3. When fixed, restore the two rows that were removed from
+   `t/container-lexical-slot-resolution.t` (they are marked with a comment
+   pointing at this file) and bump its plan from 52 to 54.


### PR DESCRIPTION
## What

A runtime helper that rebuilds a whole container from scratch dropped the fresh node into `env` under the variable's bare name. That is only ever observable through a **by-name** read: every other holder of the container — a `:=`-bound alias, a by-value capture into a list, and (once ADR-0039 slice 2 makes `@`/`%` reads slot-addressed) the declaring frame's own local slot — still points at the ORIGINAL node and never sees the rebuild.

Container mutation in mutsu is write-through-the-shared-node by design (`Value::with_array_inplace` / `gc_data_mut`, ADR-0039 §2), and the whole boxing layer's *"scalars only — containers share via Arc already"* premise depends on it. A path that **replaces** the container instead of mutating it silently breaks that premise for every alias.

Three such paths are fixed through one new chokepoint, `Interpreter::store_container_preserving_identity`, which copies the rebuilt contents into the existing backing node (reusing `array_inplace_reassign` / `hash_inplace_reassign`) and falls back to a plain env insert only for a genuine rebinding (a different container kind):

- the `map` builtin's rw element writeback
- the `.map` method's rw element writeback (including its shaped-array arm)
- `classify`/`categorize`'s `:into` target

Two user-visible bugs fixed:

```raku
my @a = 1, 2, 3; my $b := @a; map { $_ = 5 }, @a;
say $b;    # raku [5 5 5]   mutsu (before) [1 2 3]

my %h; my $f := %h; @src.categorize({ $_ %% 2 }, :into(%h));
say $f;    # raku {False => …, True => …}   mutsu (before) {}
```

The container probe is deliberately **read-only**: `env_root_descended_mut` would promote a parent-tier entry into the current frame's overlay, which changes env shape for a `:=`-bound target (`:into(my %b := BagHash.new)`, `roast/S32-list/classify.t`).

## Why the ADR churn is in the same PR

This came out of an ADR-0039 slice-2 attempt. Two findings are worth the diff on their own and are recorded as ADR-0039 §10:

1. **§4.1's exclusion list contains no divergences.** `our`, `state`, `is export`, `$*dynamic`, `::`-qualified, type-constrained and anonymous containers were each measured against `raku` v2026.07 in *both* the module file-scope shape and the mainline named-sub shadow shape — all agree. §4.3's "slice 1's exclusion list is the list of things slice 2 must subsume" is stale; those names were excluded from slice 1's *store*, and the bugs they used to carry were closed separately (the `our` container fix 2026-08-23, its scalar twin 2026-08-25, §8.6's lane lifetime 2026-08-22). Pinned as `t/container-lexical-declarator-matrix.t` so it cannot rot back into a to-do item.

2. **The slice-2 read flip is gated on the WRITE lane, not §9's store lane.** The flip (`Expr::ArrayVar`/`Expr::HashVar` → `GetLocal(slot)`) was implemented and measured again: `prove t/` goes fully green under it once four store-side defects are fixed (all four enumerated precisely in §10.2), and §6 acceptance row (b) is fixed by it. But `make roast` then fails two whitelisted files — `S15-nfg/concat-stable.t` (an `xx` thunk mutating `@o`) and `integration/advent2014-day05.t` (`$supply.act: { @seen[$_] //= $_ }`) — whose single root cause is that **a container mutated from a nested frame propagates to its owner by name only**. The obvious repair (decl-site cell boxing) is already recorded as tried and rejected in `docs/captured-outer-cell-sharing.md` §7.1d. So the flip is withdrawn again, and §10.5 records the corrected order: write/capture lane first, then the four store fixes and the read flip as one change.

The unshipped store-side fixes are described precisely enough in §10.2 to be re-derived; they are held back because with by-name reads they are **not observable** and therefore cannot be pinned.

Also: `todo/deep/module-file-scope-array-and-hash-still-share-the-caller.md` rewritten down to its single remaining ticket, and a new `todo/tickets/module-scalar-held-array-collides-with-caller-my.md` for the one exclusion-list row that does still diverge (a `$`-sigiled binding holding an Array — the scalar lane, unrelated to this slice).

## Verification

- `make test` — 3711 files / 38084 tests PASS
- `cargo build --release && make roast` — 1436 files / 218962 tests PASS
- `scripts/battery-testsuite.sh` — `GATE PASSED: 289/312`
- Both new pins byte-identical under `raku` v2026.07 and `mutsu`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
