### PR TITLE
docs: the t/ real-Test regression class is empty; file the two new roast rows

### DIFF
--- a/todo/deep/vendor-real-test-module.md
+++ b/todo/deep/vendor-real-test-module.md
@@ -57,7 +57,48 @@ For an `exit 124` roast row, re-run the individual file with a larger timeout
 before classifying it as a correctness bug. The vendored provider executes
 assertions as Raku code and is therefore slower than the Rust-native provider.
 
-## Current residue (2026-09-06)
+## Current residue (2026-09-06, second sweep)
+
+Both sweeps were re-run at the end of 2026-09-06, after that day's fixes. The
+`t/` regression class is **empty** for the first time; the roast side has the
+known timeout plus two rows a same-day refactor introduced.
+
+### `t/` sweep (debug, all 3711 files)
+
+```
+pass under both:                   3688
+regressed under the real Test:     0
+passes only under the real Test:   0
+fail under both (pre-existing):    23
+```
+
+All four rows of the morning's sweep are closed: `t/list-str-calls-element-str.t`
+by the Seq fix, `t/match-vars-are-routine-scoped.t` and
+`t/undeclared-routine-suggests-unit-own-subs.t` by
+`news/2026-09/routine-match-scope-survives-an-eval-in-the-program.md`, and
+`t/closure-capture-cell-dichotomy.t` by PR #7367 (the ADR-0055 unvouched-capture
+fix), exactly as the analysis below predicted — it was never a `Test` blocker.
+
+### Roast sweep (release, whitelist)
+
+```
+pass under both:                   1429
+regressed under the real Test:     3
+passes only under the real Test:   0
+fail under both (pre-existing):    4
+```
+
+- `roast/S03-buf/write-int.t` — `exit 124`, the known timeout. See the
+  performance section below.
+- `roast/S04-declarations/my-6e.t` #61 and `roast/6.c/S04-declarations/my-6c.t`
+  #62, both "also a type error" — **new, and not a `Test` problem**. Bisected to
+  `e49b300` / PR #7364 (ADR-0042 slice 3, retiring the name-keyed
+  type-constraint side table): an EVAL'd `$x = "abc"` stops seeing the type of a
+  `my Int $x` declared later in the same block. Filed as
+  `todo/tickets/eval-assign-loses-a-later-block-declarations-type.md`. CI cannot
+  see it because the dual-provider sweep is not part of CI.
+
+## Earlier residue (2026-09-06, first sweep)
 
 Both sweeps were re-run on this date, on a machine roughly **2x slower** than
 the one the 2026-08-29/30 numbers came from (calibration: `S04-declarations/state.t`

--- a/todo/tickets/eval-assign-loses-a-later-block-declarations-type.md
+++ b/todo/tickets/eval-assign-loses-a-later-block-declarations-type.md
@@ -1,0 +1,81 @@
+# An EVAL'd by-name assignment stops seeing a later `my Int $x`'s type
+
+Raku's "declarations are in effect at block start" rule means an assignment that
+runs *before* the textual declaration still sees its type constraint:
+
+```raku
+{
+    try { EVAL '$x = "abc"' };   # X::TypeCheck::Assignment: expected Int, got Str
+    my Int $x;
+}
+```
+
+That still works in isolation. Inside `roast/S04-declarations/my-6e.t` (and its
+`6.c` twin `roast/6.c/S04-declarations/my-6c.t`) it no longer does when the file
+runs under the **vendored upstream `Test`** module (`MUTSU_REAL_TEST=1`): the
+EVAL'd assignment succeeds silently and the assertion
+
+```raku
+dies-ok { EVAL '$x = "abc"'; my Int $x; }, 'also a type error';
+```
+
+fails. Instrumenting the same spot to report what was thrown:
+
+```
+native provider:  X::TypeCheck::Assignment: Type check failed in assignment to
+                  $x; expected Int but got Str ("abc")
+real Test:        NO-DIE
+```
+
+## Bisected
+
+Introduced by **`e49b300` / PR #7364, "retire the global name-keyed
+type-constraint side table (ADR-0042 slice 3)"**. Verified by building both
+sides on a debug build and running the file under `MUTSU_REAL_TEST=1`:
+
+| commit | `my-6e.t` under the real `Test` |
+| --- | --- |
+| `bbdebb1` (the merge before it) | passes |
+| `e49b300` (ADR-0042 slice 3) | `not ok 61 - also a type error` |
+
+The native provider passes on both, which is why CI did not catch it: the
+dual-provider sweep (`scripts/roast-test-module-sweep.sh`) is not part of CI.
+See `todo/deep/vendor-real-test-module.md`.
+
+## Why the provider matters at all
+
+The construct is provider-independent in isolation — the bare block above is
+correct on current `main` — so the failure needs the file's accumulated state.
+The plausible reading is that the retired side table was what carried a
+*name*-keyed constraint for a declaration whose container does not exist yet
+(nothing has executed the `my Int $x`), and that after the retirement the
+constraint is only reachable through a container/descriptor that some earlier
+statement in the file happens to have materialized. The two providers run
+different sequences of EVALs before reaching line 229, so only one of them
+leaves that state behind. That is a hypothesis, not a diagnosis: it has not
+been confirmed against the slice-3 diff.
+
+## Reproducing
+
+```sh
+cargo build
+MUTSU_REAL_TEST=1 MUTSU_FUDGE=1 ./target/debug/mutsu roast/S04-declarations/my-6e.t
+# not ok 61 - also a type error
+```
+
+For a copy you can edit (roast is read-only), take the file's first 229 lines,
+drop its `plan`, close the block and add `done-testing`, then run it with
+`-I roast/packages/Test-Helpers/lib`; the failure survives that truncation, so
+bisecting the preceding statements is tractable from there. It does NOT survive
+extracting only the enclosing block, so the trigger is cumulative.
+
+## Why this is a ticket and not a fix
+
+The right fix depends on what ADR-0042 slice 3 intends to replace the name-keyed
+lookup with for a declaration that has not executed yet — a question for the
+slice's own design rather than something to patch around at the EVAL assignment
+site. Both affected files are on the roast whitelist and pass under the default
+(native) provider, so nothing is currently red; this blocks completion criterion
+1 of `todo/deep/vendor-real-test-module.md` (no real-provider correctness
+regressions), which is otherwise now met for `t/` — that sweep reports **0**
+regressions as of 2026-09-06.


### PR DESCRIPTION
Documentation only. Re-ran both dual-provider sweeps
(`todo/deep/vendor-real-test-module.md`'s required measurement, which is not
part of CI) after the day's fixes.

## `t/` sweep: zero regressions, for the first time

```
pass under both:                   3688
regressed under the real Test:     0
passes only under the real Test:   0
fail under both (pre-existing):    23
```

All four rows of the morning's sweep are closed:

- `t/list-str-calls-element-str.t` — the Seq operand-coercion fix (earlier);
- `t/match-vars-are-routine-scoped.t`, `t/undeclared-routine-suggests-unit-own-subs.t`
  — #7363;
- `t/closure-capture-cell-dichotomy.t` — **#7367** (the ADR-0055 unvouched-capture
  fix). The ticket had already recorded that this row was the known-open
  env-resident half of ADR-0055 §1.2(b) and not a `Test` blocker; closing that
  ADR closed it, exactly as predicted.

## Roast sweep: the timeout, plus two rows a same-day refactor introduced

```
pass under both:                   1429
regressed under the real Test:     3
passes only under the real Test:   0
fail under both (pre-existing):    4
```

`roast/S03-buf/write-int.t` is the known `exit 124` timeout. The other two —
`roast/S04-declarations/my-6e.t` #61 and `roast/6.c/S04-declarations/my-6c.t`
#62, both `also a type error` — are **new and not `Test`'s**.

Bisected on a debug build to `e49b300` / **PR #7364** (ADR-0042 slice 3,
retiring the name-keyed type-constraint side table):

| commit | `my-6e.t` under the real `Test` |
| --- | --- |
| `bbdebb1` (the merge before it) | passes |
| `e49b300` (ADR-0042 slice 3) | `not ok 61` |

An EVAL'd `$x = "abc"` stops seeing the type of a `my Int $x` declared later in
the same block, so the assignment silently succeeds where it must throw.
Instrumented at that spot:

```
native provider:  X::TypeCheck::Assignment: Type check failed in assignment to
                  $x; expected Int but got Str ("abc")
real Test:        NO-DIE
```

The native provider passes on both commits, which is why CI missed it. Both
files remain green on the whitelist under the default provider, so nothing is
red today.

Filed as `todo/tickets/eval-assign-loses-a-later-block-declarations-type.md`
with the bisect, the instrumented before/after, and a truncation recipe for
narrowing it further — the real fix belongs to slice 3's own design (what
replaces the name-keyed lookup for a declaration that has not executed yet),
not to a patch at the EVAL assignment site.

Docs-only, so the four heavy CI jobs skip by design (`scripts/ci-docs-only.sh`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UUpduPmW6HWAcpLk2RjT2V

---
_Generated by [Claude Code](https://claude.ai/code/session_01UUpduPmW6HWAcpLk2RjT2V)_