### PR TITLE
perf: answer the per-match capture reset from a registry, not an env scan

### DIFF
--- a/news/2026-09/bench-string-capture-reset-regression.md
+++ b/news/2026-09/bench-string-capture-reset-regression.md
@@ -1,0 +1,74 @@
+# `bench-string` regression: the per-match capture reset scanned the whole visible env
+
+The bench CI's `bench-string` row stepped from a raku ratio of ~0.30 to ~0.42
+between 2026-08-31 and 2026-09-01 and stayed there — a 45% slowdown, and by far
+the largest mover in that window (the next worst was `hash-access` at 1.12x).
+Both the interpreter series and the `+jit` series moved by the same amount, so
+the cost was in the interpreter, not in the JIT.
+
+## What happened
+
+`fix: keep named captures scoped to routines` (13191415) fixed a real bug:
+`reset_capture_env_vars` shadows the previous match's capture variables before
+a new match installs its own, but it only looked at `Env::keys()` — this
+frame's own overlay — so a capture inherited from a *caller* frame survived
+into the callee. The fix switched it to `Env::visible_keys_where`, which walks
+the entire visible chain (every overlay tier plus the process-wide global base)
+and is correct.
+
+It is also enormously expensive on a hot path. `visible_keys_where` resolves
+every key it walks into an owned `String`, collects them into a
+`HashSet<String>`, and the caller then re-interns each survivor back into a
+`Symbol`. That is O(visible env) work with an allocation per key, run twice per
+match. Callgrind put it at **40% of `bench-string`**: 5000 matches x ~75,600
+instructions each, and roughly 380 of the benchmark's ~1.9M `malloc`/`free`
+pairs per match.
+
+## The fix
+
+The scan asks the wrong question. The names it looks for — all-digit (`$0`,
+`$1`) and angle-wrapped (`$<name>`) — are a tiny, fixed vocabulary, while the
+env it scans is large and mostly irrelevant.
+
+So the answer now comes from a registry instead of a scan. `Symbol::intern`
+classifies each *newly interned* name by capture shape and records it in an
+append-only, process-wide list. A name has to be interned before it can be an
+env key, so that list is a guaranteed superset of the capture keys any env can
+hold: `reset_capture_env_vars` iterates it and probes `Env::contains_key_sym`,
+which is O(capture names in the program) with no per-key allocation. Recording
+happens while the symbol table's write lock is still held, so a thread cannot
+observe a name as interned before it is registered.
+
+The classification runs once per distinct string ever interned — the intern
+caches short-circuit every repeat — so the hot path pays nothing for it.
+
+`visible_keys_where` itself is unchanged and still used by the two cold callers
+that need a genuine full-env view (`EVAL`'s redeclaration check and the
+pseudo-stash walk).
+
+## Result
+
+Instructions retired for `benchmarks/bench-string.raku` (`MUTSU_JIT=off`,
+callgrind):
+
+| build | Ir | vs pre-regression |
+| --- | --- | --- |
+| a0932728 (pre-regression, 2026-08-31) | 578,335,273 | — |
+| main before this change | 945,506,769 | +63% |
+| main with this change | 568,702,466 | -1.7% |
+
+`reset_capture_env_vars` drops from 378.2M Ir (40.0%) to 1.85M Ir (0.33%), a
+204x reduction, and the regression is fully recovered — slightly past the
+pre-regression baseline. Wall clock on the dev box goes 0.106s -> 0.065s.
+`word-count`, which also matches regexes in a loop, improves 4%.
+
+`hash-access` / `bench-hash` remain ~12% above their 2026-08-31 baseline. That
+is a separate, diffuse regression (every frame in the profile grew
+proportionally, with no single hotspot) and is recorded in
+`todo/perf/hash-access-diffuse-regression-2026-09.md`.
+
+## Pins
+
+`t/match-vars-are-routine-scoped.t` and `t/capture-var-topic-slot.t` — the two
+tests that pin the scoping behaviour the original fix introduced — still pass,
+as does the rest of the `t/` suite.

--- a/src/runtime/seq_helpers/regex_captures.rs
+++ b/src/runtime/seq_helpers/regex_captures.rs
@@ -16,23 +16,23 @@ impl Interpreter {
         // exposes this frame's overlay only), but they must still be shadowed
         // here. Removing an inherited named capture records an overlay
         // tombstone, so it cannot reach the caller when this frame is dropped.
-        let numeric_keys: Vec<Symbol> = self
-            .env
-            .visible_keys_where(|s| !s.is_empty() && s.chars().all(|ch| ch.is_ascii_digit()))
-            .into_iter()
-            .map(|key| Symbol::intern(&key))
-            .collect();
+        //
+        // Which keys those are is answered from the symbol table's
+        // capture-shape registry rather than by scanning the visible env: the
+        // registry is a superset of the capture keys any env can hold (a key
+        // must be interned before it can be a key), so probing each of its
+        // entries is O(capture names) -- a handful -- instead of O(env) with a
+        // `String` allocation per key, which was 40% of `bench-string`.
+        let (numeric_keys, angle_keys) = crate::symbol::capture_shaped_symbols();
         for key in numeric_keys {
-            self.env.insert_sym(key, Value::NIL);
+            if self.env.contains_key_sym(key) {
+                self.env.insert_sym(key, Value::NIL);
+            }
         }
-        let angle_keys: Vec<Symbol> = self
-            .env
-            .visible_keys_where(|s| s.len() > 2 && s.starts_with('<') && s.ends_with('>'))
-            .into_iter()
-            .map(|key| Symbol::intern(&key))
-            .collect();
         for key in angle_keys {
-            self.env.remove_sym(key);
+            if self.env.contains_key_sym(key) {
+                self.env.remove_sym(key);
+            }
         }
     }
 

--- a/src/symbol.rs
+++ b/src/symbol.rs
@@ -49,6 +49,65 @@ struct SymbolTable {
 
 static GLOBAL_TABLE: OnceLock<RwLock<SymbolTable>> = OnceLock::new();
 
+/// The two capture-variable name shapes the regex engine parks in the env.
+///
+/// `$0`, `$1`, ... are stored under all-digit keys and `$<name>` under
+/// `<name>` (angle-wrapped), sigil-less like every other env key.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CaptureShape {
+    /// An all-digit name: a positional capture (`$0`).
+    Numeric,
+    /// An angle-wrapped name (`<foo>`): a named capture (`$<foo>`).
+    Angle,
+}
+
+/// Classify a name by capture shape. Cheap enough to run once per *newly
+/// interned* string; never on a repeat intern (the caches short-circuit those).
+#[inline]
+fn capture_shape_of(s: &str) -> Option<CaptureShape> {
+    let bytes = s.as_bytes();
+    match bytes.first() {
+        Some(b'0'..=b'9') if bytes.iter().all(|b| b.is_ascii_digit()) => {
+            Some(CaptureShape::Numeric)
+        }
+        Some(b'<') if bytes.len() > 2 && bytes[bytes.len() - 1] == b'>' => {
+            Some(CaptureShape::Angle)
+        }
+        _ => None,
+    }
+}
+
+/// Every capture-shaped symbol the process has ever interned, split by shape.
+///
+/// `reset_capture_env_vars` has to shadow *stale* capture variables before a
+/// new match installs its own, and they may be inherited from a caller frame
+/// rather than declared in the callee's own overlay. Scanning the whole visible
+/// env for them is O(env) per match with a `String` allocation per key — it was
+/// measured at 40% of `bench-string` (5000 matches x ~75k instructions).
+///
+/// The env cannot hold a key that was never interned, so this registry is a
+/// superset of the capture keys any env can contain: iterating it and probing
+/// `contains_key_sym` is O(capture names), which is a handful in any real
+/// program, and costs no allocation per key. The table is append-only, so an
+/// entry recorded here stays valid for the life of the process.
+static CAPTURE_SHAPED: OnceLock<RwLock<(Vec<Symbol>, Vec<Symbol>)>> = OnceLock::new();
+
+fn capture_shaped() -> &'static RwLock<(Vec<Symbol>, Vec<Symbol>)> {
+    CAPTURE_SHAPED.get_or_init(|| RwLock::new((Vec::new(), Vec::new())))
+}
+
+/// Snapshot of the capture-shaped symbols interned so far, as
+/// `(numeric, angle)`.
+///
+/// Returns owned vectors rather than lending the guard out on purpose: the
+/// caller mutates the env while iterating, and any interning on that path takes
+/// the symbol-table write lock. Cloning two short vectors keeps the lock scope
+/// to this function and the lock order trivially acyclic.
+pub(crate) fn capture_shaped_symbols() -> (Vec<Symbol>, Vec<Symbol>) {
+    let guard = capture_shaped().read().unwrap();
+    guard.clone()
+}
+
 fn global_table() -> &'static RwLock<SymbolTable> {
     GLOBAL_TABLE.get_or_init(|| {
         RwLock::new(SymbolTable {
@@ -187,6 +246,25 @@ impl Symbol {
         let leaked: &'static str = Box::leak(s.to_owned().into_boxed_str());
         table.id_to_str.push(leaked);
         table.str_to_id.insert(leaked, sym);
+        // Record the capture shape once, here, where a name becomes a symbol
+        // for the first time. Doing it at the intern choke point rather than at
+        // the (many) sites that insert a capture into the env is what makes the
+        // registry a guaranteed superset: no key can reach an env without
+        // passing through here first.
+        if let Some(shape) = capture_shape_of(leaked) {
+            // Push while the symbol-table write lock is STILL held, so no other
+            // thread can observe the name as interned before it is registered:
+            // a racing thread that saw the table entry first would use the
+            // symbol as an env key that `reset_capture_env_vars` then missed.
+            // Lock order is one-way (table write -> registry write; the reader
+            // takes the registry lock alone and releases it before touching an
+            // env), so there is no cycle to deadlock on.
+            let mut shaped = capture_shaped().write().unwrap();
+            match shape {
+                CaptureShape::Numeric => shaped.0.push(sym),
+                CaptureShape::Angle => shaped.1.push(sym),
+            }
+        }
         sym
     }
 
@@ -395,5 +473,67 @@ mod tests {
         let sym = Symbol::intern("hashkey_test");
         map.insert(sym, 42);
         assert_eq!(map.get(&sym), Some(&42));
+    }
+
+    #[test]
+    fn capture_shape_matches_the_old_env_scan_predicates() {
+        // These two must stay exactly equivalent to the predicates
+        // `reset_capture_env_vars` used to hand `Env::visible_keys_where`,
+        // since the registry replaced that scan.
+        let numeric = |s: &str| !s.is_empty() && s.chars().all(|ch| ch.is_ascii_digit());
+        let angle = |s: &str| s.len() > 2 && s.starts_with('<') && s.ends_with('>');
+        for s in [
+            "",
+            "0",
+            "1",
+            "42",
+            "007",
+            "a",
+            "0a",
+            "a0",
+            "<>",
+            "<a>",
+            "<ab>",
+            "<",
+            ">",
+            "<a",
+            "a>",
+            "_",
+            "$/",
+            "<0>",
+            "1<2>",
+            "\u{3042}",
+            "<\u{3042}>",
+            "x<y>",
+        ] {
+            let shape = capture_shape_of(s);
+            assert_eq!(
+                matches!(shape, Some(CaptureShape::Numeric)),
+                numeric(s),
+                "numeric shape disagrees for {s:?}"
+            );
+            assert_eq!(
+                matches!(shape, Some(CaptureShape::Angle)),
+                angle(s),
+                "angle shape disagrees for {s:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn interning_a_capture_shaped_name_registers_it() {
+        // The registry is a superset of the capture keys an env can hold, and
+        // that only holds if `intern` records every capture-shaped name.
+        let num = Symbol::intern("31337");
+        let named = Symbol::intern("<capture_shape_registry_probe>");
+        let plain = Symbol::intern("capture_shape_registry_plain");
+        let (numeric, angle) = capture_shaped_symbols();
+        assert!(numeric.contains(&num), "all-digit name was not registered");
+        assert!(angle.contains(&named), "angle name was not registered");
+        assert!(!numeric.contains(&plain) && !angle.contains(&plain));
+        // Re-interning must not duplicate the entry.
+        let before = capture_shaped_symbols().0.len();
+        let _ = Symbol::intern("31337");
+        assert_eq!(capture_shaped_symbols().0.len(), before);
     }
 }

--- a/todo/perf/hash-access-diffuse-regression-2026-09.md
+++ b/todo/perf/hash-access-diffuse-regression-2026-09.md
@@ -1,0 +1,57 @@
+# `hash-access` / `bench-hash` are ~12% slower than their 2026-08-31 baseline
+
+The bench CI shows `hash-access` and `bench-hash` (both series, JIT on and off)
+sitting at a raku ratio of 0.19 from 2026-09-01 onward, against 0.17 through
+late August. That is a real ~12% regression, and unlike the `bench-string`
+regression fixed alongside this note it does **not** have a single hotspot.
+
+## Measurement
+
+Callgrind, `MUTSU_JIT=off`, `benchmarks/hash-access.raku`:
+
+| build | Ir |
+| --- | --- |
+| a0932728 (2026-08-31) | 237,598,221 |
+| beb00070 (2026-09-06) | 265,876,144 |
+
+That is 1.119x, matching the bench CI ratio almost exactly, so it reproduces
+deterministically and is not runner noise. `bench-hash` moves the same way
+(287.5M -> 313.3M, 1.09x).
+
+The profile shape, however, is unchanged. Every frame grew by roughly the same
+proportion:
+
+| frame | pre | post |
+| --- | --- | --- |
+| `exec_for_loop_int_range` | 118.9M (50.1%) | 134.9M (50.7%) |
+| `exec_for_loop_body` | 86.4M (36.4%) | 96.6M (36.3%) |
+| `exec_index_assign_expr_named_op` | 73.0M (30.7%) | 83.4M (31.4%) |
+| `exec_index_assign_expr_named_op_seeded_inner` | 49.9M (21.0%) | 59.7M (22.4%) |
+| `__rust_dealloc` | 24.1M (10.2%) | 27.0M (10.2%) |
+
+`exec_index_assign_expr_named_op_seeded_inner` grew the most in relative terms
+(+19.5%), which is where to start, but nothing here is a smoking gun the way
+`reset_capture_env_vars` was for `bench-string`.
+
+## Why this is a perf ticket and not a quick fix
+
+A diffuse +12% across the whole hash store/read path most likely means either a
+small cost was added to something every iteration touches (an extra check in
+the named-index assign path, a Value/container shape change that costs one more
+indirection), or several unrelated small costs landed in the same week. Either
+way it needs a bisect over the 2026-08-31..2026-09-01 range with callgrind Ir
+as the signal — cheap and deterministic, but a few release builds' worth of
+wall clock, which is why it is not folded into the `bench-string` fix.
+
+## Reproduce
+
+```
+cargo build --release
+MUTSU_JIT=off valgrind --tool=callgrind --callgrind-out-file=/dev/null \
+    --cache-sim=no --branch-sim=no ./target/release/mutsu benchmarks/hash-access.raku
+```
+
+Ir is stable to within a few thousand instructions across runs, so a bisect can
+compare single runs rather than medians. Per `todo/README.md` this is a
+`todo/perf/` item: mutsu is correct here, just slower, and the next step is
+profiling.


### PR DESCRIPTION
## The regression

`bench-string` stepped from a raku ratio of ~0.30 to ~0.42 between 2026-08-31 and 2026-09-01 and stayed there — a 45% slowdown, and by far the largest mover in that window (the next worst was `hash-access` at 1.12x). Both the interpreter series and the `+jit` series moved by the same amount, so the cost was in the interpreter, not the JIT.

Daily medians of the `bench-string` raku ratio from `bench-history.tsv`:

```
2026-08-29  0.30      2026-09-01  0.41
2026-08-30  0.29      2026-09-02  0.41
2026-08-31  0.30      2026-09-05  0.42
```

## Root cause

`13191415` ("fix: keep named captures scoped to routines"). Its fix was correct — `reset_capture_env_vars` had been looking only at this frame's own overlay via `Env::keys()`, so a capture inherited from a *caller* frame survived into the callee — but the replacement, `Env::visible_keys_where`, walks every overlay tier plus the process-wide global base, resolves each key it walks into an owned `String`, collects a `HashSet<String>`, and the caller then re-interns each survivor back into a `Symbol`.

That is O(visible env) with an allocation per key, run **twice per match**. Callgrind put it at **40% of `bench-string`**: 5000 matches × ~75,600 instructions each, and roughly 380 of the benchmark's ~1.9M `malloc`/`free` pairs per match.

## The fix

The scan asks the wrong question. The names it looks for — all-digit (`$0`, `$1`) and angle-wrapped (`$<name>`) — are a tiny fixed vocabulary, while the env it walks is large and almost entirely irrelevant.

So the answer now comes from a registry instead of a scan. `Symbol::intern` classifies each *newly interned* name by capture shape and records it in an append-only, process-wide list. A name has to be interned before it can be an env key, so that list is a guaranteed superset of the capture keys any env can hold: `reset_capture_env_vars` iterates it and probes `Env::contains_key_sym`, which is O(capture names in the program) with no per-key allocation.

The registry push happens while the symbol table's write lock is still held, so no thread can observe a name as interned before it is registered. Lock order is one-way (table write → registry write; the reader takes the registry lock alone and releases it before touching an env), so there is no cycle to deadlock on.

Classification runs once per distinct string ever interned — the intern caches short-circuit every repeat — so the hot path pays nothing for it. `visible_keys_where` itself is unchanged and still serves its two cold callers that need a genuine full-env view (`EVAL`'s redeclaration check and the pseudo-stash walk).

## Result

Instructions retired for `benchmarks/bench-string.raku` (`MUTSU_JIT=off`, callgrind):

| build | Ir | vs pre-regression |
| --- | --- | --- |
| `a0932728` (pre-regression, 2026-08-31) | 578,335,273 | — |
| `main` before this change | 945,506,769 | +63% |
| `main` with this change | 568,702,466 | **-1.7%** |

`reset_capture_env_vars` drops from 378.2M Ir (40.0%) to 1.85M Ir (0.33%), a 204x reduction. The regression is fully recovered, slightly past the pre-regression baseline. Wall clock on the dev box goes 0.106s → 0.065s. `word-count`, which also matches regexes in a loop, improves 4%; no other benchmark moved by more than 1.5% either way.

These are local callgrind numbers, which are deterministic and so fine for an A/B here; the bench CI history remains the source of truth for the documented series.

## Tests

- `make test`: 3711 files / 38067 tests. Two failures, neither from this change:
  - `t/io-path-smartmatch-permissions.t` — environmental. The dev container runs as root, so `/sys` really is writable; it fails identically on the pre-regression binary.
  - `t/proc-async.t` test 7 (`.kill terminates process`) — load-sensitive under `-j4`; passes 3/3 standalone and passed in an earlier full run.
- `t/match-vars-are-routine-scoped.t` and `t/capture-var-topic-slot.t`, the two tests that pin the scoping behaviour `13191415` introduced, still pass.
- New Rust unit tests pin that `capture_shape_of` agrees exactly with the two predicates the old env scan used, and that interning registers a capture-shaped name exactly once.
- `cargo clippy -- -D warnings` and `cargo fmt` clean.

## Also recorded

`hash-access` / `bench-hash` remain ~12% above their 2026-08-31 baseline. That is a separate, diffuse regression — every frame in the profile grew proportionally, with no single hotspot — so it is filed as `todo/perf/hash-access-diffuse-regression-2026-09.md` with the measurements and a repro rather than folded in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YH8RUdVVCqRpsQ8m9qiVTc

---
_Generated by [Claude Code](https://claude.ai/code/session_01YH8RUdVVCqRpsQ8m9qiVTc)_