### PR TITLE
perf: take three speculative probes off the hash-benchmark hot path

### DIFF
--- a/news/2026-09/hash-benchmark-hot-path-probes.md
+++ b/news/2026-09/hash-benchmark-hot-path-probes.md
@@ -1,0 +1,77 @@
+# Three speculative probes taken off the hash-benchmark hot path
+
+`hash-access` and `bench-hash` had been drifting upward at roughly 2%/day since
+late August. The investigation is written up in
+`todo/perf/hash-access-diffuse-regression-2026-09.md`; the short version is that
+there is no single culprit commit, just a steady accumulation of small checks on
+paths those benchmarks execute 10,000 times. Three of them were pure waste and
+are now gone.
+
+## `list_str_needs_interpreter` rejects by tag before it clones
+
+`c6d8041b7` (2026-09-02) put `Interpreter::list_str_needs_interpreter` on the
+`~`/`eq` operand coercion, so a list whose elements define their own `.Str`
+renders correctly through interpolation. Correct, but it lands on **every**
+interpolated value and every `~` operand, and its first act is
+`value.deref_container()` — an owned clone — followed by `descalarize()` and a
+`view()`, only to answer `false` for anything that is not a list.
+
+The surrounding code in `exec_string_concat_op` is written to exactly the
+opposite discipline: its `Proxy` and `Seq` checks are deliberately tag probes,
+with comments saying so ("this coercion runs on every `~`/`eq` operand, so the
+common non-`Proxy` case must not even clone the value"). This call had simply
+missed that rule.
+
+It now follows it. A new `may_hide_a_stringifiable_list` tag probe answers from
+the nanbox kind word alone — true for the list kinds plus the three wrappers the
+scan looks through (`ContainerRef`/`ContainerView` for `with_deref`,
+`HashEntryRef` for `deref_container`'s read-through, `Scalar` for
+`descalarize`), false for everything else. A `false` is exactly the `_ => false`
+arm of the match it replaces, so an `Int` or `Str` operand now costs one tag
+compare instead of a clone, two derefs and three views.
+
+## The `__mutsu_bound_index::` probes use the flag that exists for them
+
+`ELEM_INDEX_META_SEEN` is a monotonic process-global flag whose doc comment
+names this exact case: "Their probes run on *every* element write (`@a[i] = x`)
+... each would otherwise cost a `format!` plus a `Symbol::intern`ing env
+lookup." The key only appears once a program `:=`-binds an element, which almost
+no program does.
+
+Three probes in `vm_var_assign_element.rs` — in the hash fast path, the array
+fast path, and the general element-assign path — built the key and looked it up
+unconditionally anyway, while a fourth probe ten lines below one of them
+consulted the flag correctly. All three are now gated.
+
+## The `for` topic is written by symbol, not by string
+
+`restore_loop_topic` and `set_loop_topic` run once per loop item and wrote the
+topic through the `String`-keyed `Env::insert`/`remove`, allocating the key
+`"_"` and re-interning it every iteration — and the thread-local intern cache is
+a string-keyed hash lookup, which is why `Symbol::intern` reached ~8% of
+`hash-access`. `wk::topic()` exists for precisely this and resolves once per
+process. The same change applies to the topic's readonly marking
+(`mark_readonly_sym_with` / `unmark_readonly_sym`).
+
+Neither key latches an env metadata flag — `note_env_key` only fires for
+`__mutsu_*` prefixes — so the symbol-keyed form is equivalent.
+
+## Result
+
+Instructions retired (`MUTSU_JIT=off`, callgrind), against `d4a63aebb`:
+
+| benchmark | before | after | |
+| --- | --- | --- | --- |
+| `hash-access` | 266,157,741 | 253,289,943 | **-4.8%** |
+| `bench-hash` | 313,258,959 | 300,195,256 | **-4.2%** |
+| `bench-class` | 1,530,950,359 | 1,512,043,185 | -1.2% |
+| `bench-string` | 568,702,466 | 565,281,004 | -0.6% |
+| `word-count` | 1,036,691,782 | 1,034,415,597 | -0.2% |
+
+The first two recover roughly the last two days of the creep. The broader wins
+are the concat fast reject, which every string interpolation in every program
+pays for, and the topic write, which every `for` loop does per item.
+
+The remaining creep, the still-substantial `Symbol::intern` traffic, and the
+separate SipHash-vs-FxHash question for user-facing hashes are all recorded in
+the `todo/perf/` ticket.

--- a/src/runtime/list_element_stringify.rs
+++ b/src/runtime/list_element_stringify.rs
@@ -27,6 +27,15 @@ impl crate::Interpreter {
     /// renders correctly from the pure `to_string_value`, so the native fast
     /// path keeps it.
     pub(crate) fn list_str_needs_interpreter(value: &Value) -> bool {
+        // Tag-probed: this runs on every `~`/`eq` operand and every
+        // interpolated value (`exec_string_concat_op`), so the overwhelmingly
+        // common non-list operand -- an `Int`, a `Str` -- must reject before
+        // the `deref_container` clone below. The probe answers `false` only for
+        // kinds that can neither be a list nor wrap one, so a rejection here is
+        // exactly the `_ => false` arm of the match.
+        if !value.may_hide_a_stringifiable_list() {
+            return false;
+        }
         // The list may arrive itemized (`$[...]`, e.g. bound to a `Mu $got`
         // parameter) or behind a `ContainerRef` cell; stringification looks
         // through both.

--- a/src/value/nanbox/peek.rs
+++ b/src/value/nanbox/peek.rs
@@ -381,6 +381,40 @@ impl NanBox {
         )
     }
 
+    /// Whether this word could possibly be, or be hiding, a list that
+    /// `Interpreter::list_str_needs_interpreter` would have to scan — the list
+    /// kinds themselves plus the three wrappers that scan looks through
+    /// (`with_deref`'s `ContainerRef`/`ContainerView`, `deref_container`'s
+    /// `HashEntryRef` read-through, and `descalarize`'s `Scalar`).
+    ///
+    /// It must stay a tag probe. The scan runs on every `~`/`eq` operand and
+    /// every interpolated value, and its first step clones through
+    /// `deref_container`; a plain `Int` or `Str` operand has to reject here,
+    /// before paying for that clone. The rest of that operand coercion
+    /// (`exec_string_concat_op`) is written to the same rule.
+    #[inline]
+    pub(in crate::value) fn may_hide_a_stringifiable_list(&self) -> bool {
+        matches!(
+            classify(self.0.get()),
+            Classified::Kind(
+                Kind::ArrayList
+                    | Kind::ArrayArray
+                    | Kind::ArrayItemList
+                    | Kind::ArrayItemArray
+                    | Kind::ArrayShaped
+                    | Kind::ArrayLazy
+                    | Kind::Slip
+                    | Kind::Seq
+                    | Kind::HyperSeq
+                    | Kind::RaceSeq
+                    | Kind::ContainerRef
+                    | Kind::ContainerView
+                    | Kind::HashEntryRef
+                    | Kind::Scalar
+            )
+        )
+    }
+
     /// The `MatchNode` pointee if this is a lazy `Match`. The non-forcing
     /// probe behind the seam accessors' fast paths.
     #[inline]

--- a/src/value/view.rs
+++ b/src/value/view.rs
@@ -719,6 +719,16 @@ impl Value {
         self.0.is_seq()
     }
 
+    /// Whether this could be, or could be hiding, a list that
+    /// `Interpreter::list_str_needs_interpreter` would have to scan. A pure tag
+    /// probe (see [`Self::is_junction_value`]); a `false` here is a definitive
+    /// "not a list", so the caller can skip that scan's `deref_container`
+    /// clone entirely.
+    #[inline]
+    pub(crate) fn may_hide_a_stringifiable_list(&self) -> bool {
+        self.0.may_hide_a_stringifiable_list()
+    }
+
     /// Whether this is a `LazyList`. A pure tag probe (see
     /// [`Self::is_junction_value`]).
     #[inline]

--- a/src/vm/vm_for_loop_body.rs
+++ b/src/vm/vm_for_loop_body.rs
@@ -14,12 +14,18 @@ impl Interpreter {
         saved: Option<Value>,
         saved_local: Option<(usize, Value)>,
     ) {
+        // Symbol-keyed: this runs on every `for` body execution, and the
+        // `String`-keyed `insert`/`remove` would allocate the key and re-intern
+        // `"_"` each time (the thread-local intern cache is a string-keyed hash
+        // lookup). `wk::topic()` resolves once per process. Neither key latches
+        // an env metadata flag (`note_env_key` only fires for `__mutsu_*`), so
+        // the symbol form is equivalent here.
         match saved {
             Some(v) => {
-                self.env_mut().insert("_".to_string(), v);
+                self.env_mut().insert_sym(crate::symbol::wk::topic(), v);
             }
             None => {
-                self.env_mut().remove("_");
+                self.env_mut().remove_sym(crate::symbol::wk::topic());
             }
         }
         if let Some((slot, v)) = saved_local {
@@ -43,8 +49,8 @@ impl Interpreter {
     /// `vm_for_loop_lazy.rs`).
     pub(super) fn restore_topic_readonly(&mut self, saved: Option<crate::ast::ReadonlyKind>) {
         match saved {
-            Some(kind) => self.mark_readonly_with("_", kind),
-            None => self.unmark_readonly("_"),
+            Some(kind) => self.mark_readonly_sym_with(crate::symbol::wk::topic(), kind),
+            None => self.unmark_readonly_sym(crate::symbol::wk::topic()),
         }
     }
 
@@ -54,7 +60,9 @@ impl Interpreter {
         if let Some(slot) = topic_local {
             self.locals[slot] = val.clone();
         }
-        self.env_mut().insert("_".to_string(), val);
+        // Symbol-keyed for the same reason as `restore_loop_topic`: this is the
+        // per-item topic bind, the hottest `"_"` write in the VM.
+        self.env_mut().insert_sym(crate::symbol::wk::topic(), val);
     }
 
     /// The `'$name'`-quoted form a loop parameter's bare env-key name

--- a/src/vm/vm_var_assign_element.rs
+++ b/src/vm/vm_var_assign_element.rs
@@ -74,7 +74,13 @@ impl Interpreter {
                 return None;
             }
         }
-        {
+        // Gated on the process-global flag, like the `elem_index_meta_possible`
+        // probe further down: this runs on EVERY hash element write, and the
+        // `format!` plus the `Symbol::intern`ing `contains_key` it guards are
+        // exactly the cost `ELEM_INDEX_META_SEEN` was introduced to avoid. The
+        // key can only exist once the program `:=`-binds an element, which
+        // latches the flag through `Env::insert`.
+        if crate::env::elem_index_meta_possible() {
             let bound_key = format!("__mutsu_bound_index::{}", var_name);
             if self.env().contains_key(&bound_key) {
                 return None;
@@ -162,9 +168,15 @@ impl Interpreter {
         }
         {
             let shaped_key = format!("__mutsu_shaped_array_dims::{}", var_name);
-            let bound_key = format!("__mutsu_bound_index::{}", var_name);
-            if self.env().contains_key(&shaped_key) || self.env().contains_key(&bound_key) {
+            if self.env().contains_key(&shaped_key) {
                 return None;
+            }
+            // See the hash twin above for why the bound-index probe is gated.
+            if crate::env::elem_index_meta_possible() {
+                let bound_key = format!("__mutsu_bound_index::{}", var_name);
+                if self.env().contains_key(&bound_key) {
+                    return None;
+                }
             }
         }
         let var_name = var_name.to_string();
@@ -284,8 +296,9 @@ impl Interpreter {
             }
         }
         // Reject if any bound indices exist for this variable
-        // (e.g. `%h<a> := $foo` makes element writes propagate to $foo)
-        {
+        // (e.g. `%h<a> := $foo` makes element writes propagate to $foo).
+        // Gated like the twin above: no bound element, no probe.
+        if crate::env::elem_index_meta_possible() {
             let bound_key = format!("__mutsu_bound_index::{}", var_name);
             if self.env().contains_key(&bound_key) {
                 return None;

--- a/todo/perf/hash-access-diffuse-regression-2026-09.md
+++ b/todo/perf/hash-access-diffuse-regression-2026-09.md
@@ -1,47 +1,96 @@
-# `hash-access` / `bench-hash` are ~12% slower than their 2026-08-31 baseline
+# `hash-access` / `bench-hash` drift upward ~2%/day, with no single culprit commit
 
 The bench CI shows `hash-access` and `bench-hash` (both series, JIT on and off)
-sitting at a raku ratio of 0.19 from 2026-09-01 onward, against 0.17 through
-late August. That is a real ~12% regression, and unlike the `bench-string`
-regression fixed alongside this note it does **not** have a single hotspot.
+at a raku ratio of 0.19 from 2026-09-01 onward, against 0.17 through late
+August. This note records what a callgrind bisect actually found, so the next
+person does not repeat it.
 
-## Measurement
+## The 2026-08-27 "step" is runner noise, not a regression
 
-Callgrind, `MUTSU_JIT=off`, `benchmarks/hash-access.raku`:
+`mutsu_median_s` for `hash-access` shows a sharp jump on 2026-08-27 at 13:26Z,
+from 0.0277 (`7c60c853f`) to 0.0350 (`94a218779`) — +26%, which looks exactly
+like a bad commit landing. It is not. The **raku** baseline in the same rows
+stepped identically (0.1824 -> 0.2153), and the two commits are one docs change
+and one `:=` bind fix. Building both and counting instructions confirms it:
 
-| build | Ir |
+| commit | Ir (`MUTSU_JIT=off`, callgrind) |
 | --- | --- |
-| a0932728 (2026-08-31) | 237,598,221 |
-| beb00070 (2026-09-06) | 265,876,144 |
+| `7c60c853f` | 219,375,414 |
+| `94a218779` | 219,319,562 |
 
-That is 1.119x, matching the bench CI ratio almost exactly, so it reproduces
-deterministically and is not runner noise. `bench-hash` moves the same way
-(287.5M -> 313.3M, 1.09x).
+Identical to within 0.03%. The runner simply got slower that afternoon and
+stayed slower. **Read the ratio column, not `mutsu_median_s`** — that is what it
+is for. This mistake cost two release builds; do not repeat it.
 
-The profile shape, however, is unchanged. Every frame grew by roughly the same
-proportion:
+## The real regression is a slow, diffuse creep
 
-| frame | pre | post |
+Instructions retired for `benchmarks/hash-access.raku`, one release build per
+point:
+
+| commit | date | Ir | step |
+| --- | --- | --- | --- |
+| `7c60c853f` | 2026-08-27 | 219,375,414 | — |
+| `f76addaee` | 2026-08-29 | 229,047,499 | +4.4% |
+| `a0932728` | 2026-08-31 | 237,598,221 | +3.7% |
+| `8fff1596d` | 2026-09-02 | 246,480,320 | +3.7% |
+| `d4a63aebb` | 2026-09-06 | 266,157,741 | +7.9% |
+
+That is roughly +2%/day, sustained, with no step large enough to bisect to. It
+is death by a thousand cuts: each correctness fix adds a small check to a path
+the hash benchmarks run 10,000 times, and none of them is individually wrong.
+
+A per-function self-cost diff (2026-08-29 vs 2026-09-06) shows the same shape —
+no single frame dominates the delta:
+
+| function | Aug 29 | Sep 06 | delta |
+| --- | --- | --- | --- |
+| `nanbox::payload_op` | 6.37M | 9.82M | +3.45M |
+| `LocalKey::with` | 13.46M | 16.68M | +3.22M |
+| `nanbox::peek::view_kind` | 3.74M | 6.47M | +2.73M |
+| `exec_index_assign_expr_named_op*` | 4.25M | 6.55M | +2.30M |
+| `Value::deref_container` | 0.37M | 2.33M | +1.96M |
+| malloc/free family | 33.30M | 37.36M | +4.06M |
+| `list_str_needs_interpreter` (new) | 0 | 1.89M | +1.89M |
+
+## What has been fixed
+
+Three of these were addressable and are done (see
+`news/2026-09/hash-benchmark-hot-path-probes.md`): a tag-probe fast reject in
+`list_str_needs_interpreter`, gating the `__mutsu_bound_index::` probes on the
+`ELEM_INDEX_META_SEEN` flag that already exists for them, and symbol-keying the
+per-item `for` topic writes. Together: `hash-access` 266.2M -> 253.3M (-4.8%),
+`bench-hash` 313.3M -> 300.2M (-4.2%).
+
+That recovers roughly the last two days of the creep. The rest of it is still
+there.
+
+## What is left, and where to look next
+
+`Symbol::intern` is still called **~155,000 times** for a benchmark with 20,000
+loop iterations — ~8% of the run, almost all of it re-interning *constant*
+names on hot paths. Remaining callers, by intern count:
+
+| callers | interns | note |
 | --- | --- | --- |
-| `exec_for_loop_int_range` | 118.9M (50.1%) | 134.9M (50.7%) |
-| `exec_for_loop_body` | 86.4M (36.4%) | 96.6M (36.3%) |
-| `exec_index_assign_expr_named_op` | 73.0M (30.7%) | 83.4M (31.4%) |
-| `exec_index_assign_expr_named_op_seeded_inner` | 49.9M (21.0%) | 59.7M (22.4%) |
-| `__rust_dealloc` | 24.1M (10.2%) | 27.0M (10.2%) |
+| `get_env_with_main_alias_inner` | 30,007 | the `&str`-keyed by-name read chokepoint |
+| `exec_index_assign_expr_named_op*` | ~10,000 | still interns `var_name` several times per store |
+| `reify_lazy_array_slot` | 10,000 | |
+| `is_readonly` | 10,000 | `is_readonly_sym` exists; the caller has the name, not a symbol |
 
-`exec_index_assign_expr_named_op_seeded_inner` grew the most in relative terms
-(+19.5%), which is where to start, but nothing here is a smoking gun the way
-`reset_capture_env_vars` was for `bench-string`.
+The pattern to apply is the one `wk::` already documents: resolve a fixed name
+once per process, or intern the variable name once per operation and thread the
+`Symbol` through instead of re-interning it at each helper. The hash fast path
+(`try_fast_hash_element_assign`) interns `var_name` for `env().get`,
+`var_default`, `is_readonly` and the shared-store commit separately; interning
+once and passing the symbol would cut four to one. That needs `_sym` variants of
+`var_default` and friends, which is why it was not folded into the fix above.
 
-## Why this is a perf ticket and not a quick fix
-
-A diffuse +12% across the whole hash store/read path most likely means either a
-small cost was added to something every iteration touches (an extra check in
-the named-index assign path, a Value/container shape change that costs one more
-indirection), or several unrelated small costs landed in the same week. Either
-way it needs a bisect over the 2026-08-31..2026-09-01 range with callgrind Ir
-as the signal — cheap and deterministic, but a few release builds' worth of
-wall clock, which is why it is not folded into the `bench-string` fix.
+Separately, `hash_one` + `sip::Hasher::write` is **15.8M Ir (6%)** on
+`hash-access`: user-facing `HashData` still uses std's SipHash while the env
+moved to `FxHashMap` long ago. Switching would be a large, easy win — but it
+trades away HashDoS resistance on *user-controlled* keys, which is a real
+decision for a language runtime and needs an explicit call (an ADR), not a
+drive-by change. It is also pre-existing, not part of this regression.
 
 ## Reproduce
 
@@ -51,7 +100,6 @@ MUTSU_JIT=off valgrind --tool=callgrind --callgrind-out-file=/dev/null \
     --cache-sim=no --branch-sim=no ./target/release/mutsu benchmarks/hash-access.raku
 ```
 
-Ir is stable to within a few thousand instructions across runs, so a bisect can
-compare single runs rather than medians. Per `todo/README.md` this is a
-`todo/perf/` item: mutsu is correct here, just slower, and the next step is
-profiling.
+Ir is stable to within a few thousand instructions across runs and is unaffected
+by runner speed, so single runs can be compared directly — which is exactly why
+it, and not wall clock, is the right instrument for this ticket.


### PR DESCRIPTION
Follow-up to #7372, which fixed the `bench-string` regression. `hash-access` / `bench-hash` were the other movers in that window, and this is what a callgrind bisect found.

## The 2026-08-27 "step" is runner noise

`mutsu_median_s` for `hash-access` jumps on 2026-08-27 at 13:26Z from 0.0277 (`7c60c853f`) to 0.0350 (`94a218779`) — +26%, which looks exactly like a bad commit landing. It isn't. The **raku** baseline in the same rows stepped identically (0.1824 → 0.2153), and building both sides confirms it:

| commit | Ir |
| --- | --- |
| `7c60c853f` | 219,375,414 |
| `94a218779` | 219,319,562 |

Identical to within 0.03%. The runner got slower that afternoon and stayed slower. Read the ratio column, not `mutsu_median_s` — that's what it's for.

## The real regression is a diffuse creep

| commit | date | Ir | step |
| --- | --- | --- | --- |
| `7c60c853f` | 2026-08-27 | 219,375,414 | — |
| `f76addaee` | 2026-08-29 | 229,047,499 | +4.4% |
| `a0932728` | 2026-08-31 | 237,598,221 | +3.7% |
| `8fff1596d` | 2026-09-02 | 246,480,320 | +3.7% |
| `d4a63aebb` | 2026-09-06 | 266,157,741 | +7.9% |

~2%/day, sustained, with no step big enough to bisect to. A per-function self-cost diff shows the same shape — no frame dominates the delta. Three of the contributors were pure waste and are fixed here.

## 1. `list_str_needs_interpreter` rejects by tag before it clones

`c6d8041b7` (Sep 2) put it on the `~`/`eq` operand coercion so a list whose elements define their own `.Str` interpolates correctly. Correct — but it runs on **every** interpolated value, and its first act is `deref_container()` (an owned clone), then `descalarize()`, then a `view()`, only to answer `false` for anything that isn't a list.

The surrounding `exec_string_concat_op` is written to the opposite discipline; its `Proxy` and `Seq` checks are deliberately tag probes, with comments saying so ("this coercion runs on every `~`/`eq` operand, so the common non-`Proxy` case must not even clone the value"). This call had simply missed that rule.

A new `may_hide_a_stringifiable_list` tag probe answers from the nanbox kind word alone — true for the list kinds plus the three wrappers the scan looks through (`ContainerRef`/`ContainerView` for `with_deref`, `HashEntryRef` for `deref_container`'s read-through, `Scalar` for `descalarize`), false for everything else. A `false` is exactly the `_ => false` arm it short-circuits.

## 2. The `__mutsu_bound_index::` probes use the flag that exists for them

`ELEM_INDEX_META_SEEN`'s own doc names this case: *"Their probes run on every element write (`@a[i] = x`) ... each would otherwise cost a `format!` plus a `Symbol::intern`ing env lookup."* Three probes in `vm_var_assign_element.rs` built the key and looked it up unconditionally anyway — while a fourth probe ten lines below one of them consulted the flag correctly. All three are now gated.

## 3. The `for` topic is written by symbol, not by string

`restore_loop_topic` and `set_loop_topic` run once per loop item and went through the `String`-keyed `Env::insert`/`remove`, allocating `"_"` and re-interning it every iteration — and the thread-local intern cache is a string-keyed hash lookup, which is why `Symbol::intern` reached ~8% of `hash-access`. `wk::topic()` exists for exactly this. Neither key latches an env metadata flag (`note_env_key` only fires for `__mutsu_*`), so the symbol-keyed form is equivalent.

## Result

Ir (`MUTSU_JIT=off`, callgrind) against `d4a63aebb`:

| benchmark | before | after | |
| --- | --- | --- | --- |
| `hash-access` | 266,157,741 | 253,289,943 | **-4.8%** |
| `bench-hash` | 313,258,959 | 300,195,256 | **-4.2%** |
| `bench-class` | 1,530,950,359 | 1,512,043,185 | -1.2% |
| `bench-string` | 568,702,466 | 565,281,004 | -0.6% |
| `word-count` | 1,036,691,782 | 1,034,415,597 | -0.2% |

Nothing regressed. The first two recover roughly the last two days of the creep; the broader wins are the concat fast reject (every string interpolation in every program pays for it) and the topic write (every `for` loop, per item).

Local callgrind numbers, which are deterministic and immune to runner speed — the right instrument here, and the reason the Aug-27 red herring was catchable at all. The bench CI history stays the source of truth for the documented series.

## Tests

- `make test`: 3714 files / 38168 tests, 20 cargo test blocks all `ok`, 0 `FAILED`. The one TAP failure is `t/io-path-smartmatch-permissions.t`, environmental — the dev container runs as root so `/sys` really is writable, and it fails identically on pre-regression binaries.
- `cargo clippy -- -D warnings` and `cargo fmt` clean.

## Left open

`todo/perf/hash-access-diffuse-regression-2026-09.md` is rewritten with the evidence above and what to attack next:

- `Symbol::intern` is *still* called ~155,000 times for 20,000 loop iterations, almost all re-interning constant names. The biggest remaining callers are listed with counts; the hash fast path alone interns `var_name` four separate times per store and could intern once and thread the `Symbol` through (needs `_sym` variants of `var_default` and friends, which is why it isn't folded in here).
- `hash_one` + `sip::Hasher::write` is 15.8M Ir (6%) on `hash-access`: user-facing `HashData` still uses std's SipHash while the env moved to `FxHashMap` long ago. Switching is a large, easy win but trades away HashDoS resistance on *user-controlled* keys — a real decision for a language runtime that wants an ADR, not a drive-by change. It's also pre-existing, not part of this regression.

Unrelated observation while running the suite: `src/vm/vm_var_assign_index_named.rs:2362` panics with "attempt to add with overflow" in debug builds 26 times across `t/`. Identical count before and after this change, so pre-existing and evidently tolerated, but flagging it since release builds would silently wrap instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YH8RUdVVCqRpsQ8m9qiVTc

---
_Generated by [Claude Code](https://claude.ai/code/session_01YH8RUdVVCqRpsQ8m9qiVTc)_