### PR TITLE
chore: provision rustc and raku automatically in ephemeral containers

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# SessionStart hook: bring a freshly provisioned container up to the toolchain
+# this repository needs, before the agent runs its first command.
+#
+# Two things are routinely missing or stale in the ephemeral containers that
+# Claude Code on the web / the Claude app provision:
+#
+#   1. rustc — the base image ships whatever stable it was built with, which is
+#      regularly older than the version this repo compiles under. The failure
+#      mode is a confusing E0658 pointing at a line in src/ (see
+#      .claude/skills/rustc-too-old/SKILL.md).
+#   2. raku — the Rakudo oracle used to check expected behaviour is absent
+#      entirely, and Ubuntu's packaged one is far too old to be useful.
+#
+# Both are mechanical to fix, so fix them here rather than paying for the
+# rediscovery every session.
+#
+# Local checkouts are left alone: a developer machine is pinned by .mise.toml
+# and owns its own toolchain. Set MUTSU_SETUP_FORCE=1 to run it anyway.
+set -euo pipefail
+
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ] && [ "${MUTSU_SETUP_FORCE:-}" != "1" ]; then
+  exit 0
+fi
+
+REPO="${CLAUDE_PROJECT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+cd "$REPO"
+
+say() { printf 'session-start: %s\n' "$*"; }
+warn() { printf 'session-start: WARNING: %s\n' "$*" >&2; }
+
+# ------------------------------------------------------------------- rustc --
+# Three places declare a Rust version and they can drift apart, so take the
+# highest: the CI toolchain pin (authoritative — CI demonstrably builds with
+# it), the MSRV in Cargo.toml (cargo refuses outright below it), and the
+# .mise.toml pin developers use locally.
+wanted_rust() {
+  {
+    sed -n 's|.*dtolnay/rust-toolchain@[0-9a-f]\{6,\} *# *\([0-9][0-9.]*\).*|\1|p' \
+      .github/workflows/ci.yml
+    sed -n 's/^rust-version *= *"\([0-9][0-9.]*\)".*/\1/p' Cargo.toml
+    sed -n 's/^rust *= *"\([0-9][0-9.]*\)".*/\1/p' .mise.toml
+  } 2>/dev/null | sort -V | tail -n1
+}
+
+setup_rust() {
+  local want have
+  want="$(wanted_rust || true)"
+  if [ -z "$want" ]; then
+    warn "could not determine the Rust version this repo wants; leaving the toolchain alone"
+    return 0
+  fi
+  have="$(rustc --version 2>/dev/null | awk '{print $2}')"
+  say "rustc: have ${have:-none}, repo wants $want"
+
+  # sort -V puts the smaller first; if `want` is already the smaller of the
+  # two, the installed compiler is new enough.
+  if [ -n "$have" ] && [ "$(printf '%s\n%s\n' "$want" "$have" | sort -V | head -n1)" = "$want" ]; then
+    say "rustc is new enough"
+    return 0
+  fi
+
+  if ! command -v rustup >/dev/null 2>&1; then
+    warn "rustc $want is needed but rustup is not installed; see https://rustup.rs"
+    return 0
+  fi
+
+  # clippy and rustfmt are not in --profile minimal, and both the pre-commit
+  # hooks and CI run them, so install them up front.
+  say "installing rustc $want via rustup (a few minutes on a cold container)"
+  if rustup toolchain install "$want" --profile minimal -c clippy -c rustfmt \
+     && rustup default "$want"; then
+    say "rustc is now $(rustc --version | awk '{print $2}')"
+  else
+    warn "rustup could not install $want; the build may fail with E0658 (see .claude/skills/rustc-too-old/SKILL.md)"
+  fi
+}
+
+# -------------------------------------------------------------------- raku --
+# The Rakudo oracle. install-raku.sh is a no-op when a working `raku` is
+# already on PATH, so this is safe to re-run.
+setup_raku() {
+  export PATH="$HOME/.local/bin:$PATH"
+  if command -v raku >/dev/null 2>&1; then
+    say "raku already present: $(command -v raku)"
+    return 0
+  fi
+  say "installing the Rakudo oracle (prebuilt archive, no compilation)"
+  if ! .agents/skills/install-raku/install-raku.sh; then
+    warn "could not install raku; work that needs the oracle will have to do without it"
+    return 0
+  fi
+  say "raku installed: $(raku --version 2>/dev/null | head -n1)"
+}
+
+setup_rust
+setup_raku
+
+# Warm the crate cache so the first build is compile-only. Cheap next to the
+# build itself, and the container image is snapshotted after this hook.
+cargo fetch --locked >/dev/null 2>&1 || cargo fetch >/dev/null 2>&1 || \
+  warn "cargo fetch failed; the first build will download crates itself"
+
+# Persist PATH for the session: ~/.local/bin holds the raku symlinks,
+# ~/.cargo/bin the rustup shims.
+if [ -n "${CLAUDE_ENV_FILE:-}" ]; then
+  printf 'export PATH="%s/.local/bin:%s/.cargo/bin:$PATH"\n' "$HOME" "$HOME" >> "$CLAUDE_ENV_FILE"
+fi
+
+say "environment ready"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh",
+            "timeout": 900
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,10 @@ tmp-lock-test-*.txt
 
 target-local/
 .claude/worktrees/
+# The bare `hooks` rule above (a stray-git-dir artifact from tests) would
+# otherwise swallow the SessionStart provisioning hook, which is tracked.
+!.claude/hooks/
+!.claude/hooks/*
 .codex
 .codex/
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -415,6 +415,24 @@ Agent worktrees under `.claude/worktrees/` and cargo caches under `target/` are 
 
 This development environment runs inside a dedicated mutsu LXC container. The container may be destroyed at any time — always commit important changes and push PRs promptly.
 
+### Ephemeral containers self-provision via a SessionStart hook
+
+Sessions started from the Claude app / Claude Code on the web get a **fresh container** whose base
+image usually ships a rustc older than this repo compiles under and no `raku` at all. Both are fixed
+automatically by `.claude/hooks/session-start.sh`, registered as a `SessionStart` hook in
+`.claude/settings.json`: it installs the highest Rust version declared by the repo (the `ci.yml`
+toolchain pin, `Cargo.toml`'s `rust-version`, `.mise.toml`) via rustup, runs
+`.agents/skills/install-raku/install-raku.sh` when `raku` is missing, and warms the crate cache with
+`cargo fetch`. It is idempotent (~0.3s when everything is already in place) and does nothing on a
+local checkout unless `MUTSU_SETUP_FORCE=1` is set — a developer machine is pinned by `.mise.toml`
+and owns its own toolchain.
+
+So **do not hand-install rustc or rakudo at the start of a remote session** — it has already
+happened. If a build still fails with `E0658`, the hook did not run (check for its
+`session-start: environment ready` line) and `.claude/skills/rustc-too-old/SKILL.md` applies.
+Whenever a version pin moves, the hook follows it with no edit; only the *sources* of the pins are
+hardcoded, so add a new one there if the repo ever grows a `rust-toolchain.toml`.
+
 ## Test::Util function workout
 
 When the user says **"Test::Util workout"** (or similar), follow **`.agents/skills/test-util-workout/SKILL.md`**: pick one function from `roast/packages/Test-Helpers/lib/Test/Util.rakumod`, write `t/<function-name>.t`, fix the interpreter (in `src/runtime/test_functions.rs`, never as a core builtin) until it passes, and land it as a PR.

--- a/news/2026-09/session-start-hook-provisions-ephemeral-containers.md
+++ b/news/2026-09/session-start-hook-provisions-ephemeral-containers.md
@@ -1,0 +1,48 @@
+# Ephemeral containers now provision their own rustc and raku
+
+Sessions launched from the Claude app (Claude Code on the web) run in a container that is created
+fresh from a base image, and that image is not this repository's environment. Two things were
+missing every single time:
+
+- **rustc was behind the code.** The image shipped 1.94.1 while the repo builds with 1.96.x, so the
+  first `cargo build` died with `E0658` pointing at a line in `src/` — a failure that looks like a
+  code error and invites "fixing" the source to suit an old compiler. `.claude/skills/rustc-too-old/`
+  exists precisely because that misdiagnosis kept happening.
+- **`raku` was absent.** Any work that has to *measure* Rakudo's behaviour (RakuAST node shapes above
+  all) is blocked without the oracle, and Ubuntu's packaged rakudo is far too old to serve as one.
+
+Both fixes were already written down — the `rustc-too-old` and `install-raku` skills — but a skill is
+only read when an agent already suspects the problem, which is after it has wasted the session on the
+symptom. The knowledge was in the wrong shape: this is provisioning, not diagnosis.
+
+`.claude/hooks/session-start.sh`, registered as a `SessionStart` hook in `.claude/settings.json`, now
+runs the provisioning before the agent's first command:
+
+1. **Rust.** Three places in the repo declare a Rust version and they drift apart — the `ci.yml`
+   `dtolnay/rust-toolchain` pin comment (authoritative: CI demonstrably builds with it),
+   `Cargo.toml`'s `rust-version` MSRV, and `.mise.toml`'s local pin. The hook reads all three and
+   takes the highest via `sort -V`, so it tracks whichever one moves without ever needing an edit
+   itself. When the installed compiler is older it runs `rustup toolchain install <ver> --profile
+   minimal -c clippy -c rustfmt` (both components are needed by the pre-commit hooks and CI, and
+   `minimal` omits them) and makes it the default.
+2. **Raku.** Delegates to the existing `.agents/skills/install-raku/install-raku.sh`, which picks the
+   newest `moar`/`archive` prebuilt for the platform out of the rakudo.org index, verifies its
+   SHA256, and symlinks `bin/*` into `~/.local/bin`.
+3. **Crate cache.** `cargo fetch`, so the first build is compile-only. The container image is
+   snapshotted after the hook, so the download is paid once per image rather than once per session.
+
+`~/.local/bin` and `~/.cargo/bin` are appended to `PATH` through `$CLAUDE_ENV_FILE` so the session
+inherits them.
+
+The hook is **synchronous** on purpose: async startup would let the agent begin work — and quite
+possibly start a build against the stale compiler — while the toolchain was still installing, which
+is exactly the race the hook exists to remove. Its `timeout` is set to 900s in `settings.json`
+because a cold rustup + rakudo download takes minutes, well past the 60s hook default. It is
+idempotent and costs ~0.3s once the container is warm.
+
+It also does nothing on a local checkout (it exits unless `CLAUDE_CODE_REMOTE=true`, overridable with
+`MUTSU_SETUP_FORCE=1`): a developer machine is pinned by `.mise.toml` and owns its own toolchain, and
+silently repointing someone's `rustup default` from a repo file would be a rude surprise.
+
+Verified in a live remote container: 1.94.1 → 1.96.1, Rakudo v2026.07 installed from scratch, a
+second run reporting "rustc is new enough / raku already present" in 0.26s.


### PR DESCRIPTION
Sessions started from the Claude app run in a container built from a base
image that is not this repo's environment: rustc is regularly older than the
version the code compiles under (1.94.1 vs the 1.96.x this repo pins), and
`raku` -- the oracle every behavioural question needs -- is absent entirely.
Both cost the first minutes of every such session, and the rustc case
actively misleads: it surfaces as E0658 pointing at a line in src/, which
invites "fixing" the source to suit an old compiler.

The fixes were already written down as skills (rustc-too-old, install-raku),
but a skill is only read once an agent suspects the problem, which is after
it has already paid for the symptom. This is provisioning, not diagnosis, so
move it to a SessionStart hook that runs before the first command.

.claude/hooks/session-start.sh:
  - Rust: reads the three places that declare a version (the ci.yml
    dtolnay/rust-toolchain pin comment, Cargo.toml's rust-version, the
    .mise.toml pin), takes the highest with sort -V, and installs it via
    rustup with clippy and rustfmt (--profile minimal omits both, and the
    pre-commit hooks and CI need them). Tracking the declarations rather
    than hardcoding a version means a pin bump needs no edit here.
  - Raku: delegates to .agents/skills/install-raku/install-raku.sh, which is
    already a no-op when a working raku is on PATH.
  - cargo fetch, so the first build is compile-only.
  - Exports ~/.local/bin and ~/.cargo/bin via $CLAUDE_ENV_FILE.

Synchronous on purpose: an async hook would let the agent start a build
against the stale compiler while the toolchain was still installing, which
is the race the hook exists to remove. The 900s timeout in settings.json
covers a cold rustup plus rakudo download, well past the 60s hook default.
It is idempotent (0.26s warm) and exits immediately on a local checkout,
where .mise.toml pins the toolchain and the developer owns it;
MUTSU_SETUP_FORCE=1 overrides that for testing.

.gitignore needed a negation: the bare `hooks` rule (a stray-git-dir
artifact from tests) was swallowing .claude/hooks/.

Verified live in a remote container: 1.94.1 -> 1.96.1, Rakudo v2026.07
installed from scratch, then cargo build, cargo clippy -D warnings,
cargo fmt --check and prove t/accessor-fast-path.t all green.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016dbuRGnKn64DApuB7M3cmY