### PR TITLE
docs: triage the doc-diff sweep's highest-signal file into six tickets

### DIFF
--- a/docs/doc-diff-backlog.md
+++ b/docs/doc-diff-backlog.md
@@ -813,6 +813,42 @@ Found in the 2026-08-22 batch-6 re-run of `Metamodel::DefiniteHOW`/`Junction`/`f
   type-only-invocant repro (`method (List:D:) {...}`) were one ticket, now FIXED; see
   [news/2026-08/method-literal-invocant-declaration-syntax-broken.md](../news/2026-08/method-literal-invocant-declaration-syntax-broken.md).
 
+Found in the 2026-09-06 full re-sweep, triaging its highest-signal file
+(`Language/operators.rakudoc`, 4 mismatch + 2 crash). **All six blocks reproduce
+against raku v2026.07**, and each was narrowed past the doc example to a
+one-line repro before filing — in two cases the doc example was actively
+misleading about the cause:
+
+- `Language/operators.rakudoc:1795` — baggy union `(+)` adds weights as `f64`,
+  so a `Rat` weight comes back as `4.140000000000001`. Ordinary `Rat + Int` is
+  exact, so this is the operator, not the tower.
+  → [todo/tickets/baggy-union-weight-loses-rat-precision.md](../todo/tickets/baggy-union-weight-loses-rat-precision.md)
+- `Language/operators.rakudoc:1977` — `1 but R(42)` names the mixin `Int+{R[Int]}`
+  instead of `Int+{R}`: the single-attribute initialization form is being recorded
+  as a role *parameterization*. Behaviour is correct; only `.^name` is wrong.
+  → [todo/tickets/role-mixin-name-carries-a-spurious-type-parameter.md](../todo/tickets/role-mixin-name-carries-a-spurious-type-parameter.md)
+- `Language/operators.rakudoc:3157` — a **chained** `Z` whose leftmost operand is
+  a comma list fails to parse ("Two terms in a row"). The doc example's `<+ ->`
+  is a red herring: `1, 2 Z <a b c> Z <x y>` fails identically, while
+  `1 Z <a b> Z <+ ->` (single left operand) parses.
+  → [todo/tickets/zip-chain-with-a-comma-list-left-operand-fails-to-parse.md](../todo/tickets/zip-chain-with-a-comma-list-left-operand-fails-to-parse.md)
+- `Language/operators.rakudoc:602` — `my @n = [\~] 1..*` hangs, though
+  `([\~] 1..*)[^5]` and `my @n = 1..*` / `.map` / `lazy gather` all work: the
+  triangle reduce's `Seq` is not carrying whatever marks the others lazy, so the
+  list assignment reifies it.
+  → [todo/tickets/array-assignment-eagerly-reifies-a-triangle-reduce.md](../todo/tickets/array-assignment-eagerly-reifies-a-triangle-reduce.md)
+- `Language/operators.rakudoc:2376` — a `Set`'s own `.WHICH` ignores its
+  elements' user-defined `.WHICH`, so two structurally identical Sets differ
+  under `eqv`/`===`. The elements themselves compare equal, and object-hash keys
+  already use `value_which_key`, so the machinery exists and the Set identity
+  path is not using it.
+  → [todo/tickets/set-which-ignores-a-user-defined-element-which.md](../todo/tickets/set-which-ignores-a-user-defined-element-which.md)
+- `Language/operators.rakudoc:2507` — `$*TOLERANCE` is `(Any)` rather than
+  `1e-15`, so the doc's `≅` example compares `1 ≅ 1`. `≅` itself answers
+  correctly on the other rows tested, so this may be just the missing dynamic
+  variable plus wiring it into the operator.
+  → [todo/tickets/tolerance-dynamic-variable-is-undefined.md](../todo/tickets/tolerance-dynamic-variable-is-undefined.md)
+
 ### Deferred / deep (tracked elsewhere — do not re-open as a shallow slice)
 These root causes account for a large share of the survey's `mism`/`crash` and are
 intentionally deferred; see PLAN.md §8.5 and the ADRs:

--- a/todo/tickets/array-assignment-eagerly-reifies-a-triangle-reduce.md
+++ b/todo/tickets/array-assignment-eagerly-reifies-a-triangle-reduce.md
@@ -1,0 +1,44 @@
+# `my @n = [\~] 1..*` hangs — array assignment reifies a triangle reduce eagerly
+
+Found by the 2026-09-06 doc-diff sweep (`raku-doc/doc/Language/operators.rakudoc:602`),
+re-verified against raku v2026.07 the same day.
+
+## Repro
+
+```raku
+my @n = [\~] 1..*;
+say @n[^5];        # raku: (1 12 123 1234 12345)   mutsu: hangs (exit 124)
+```
+
+## Narrowed — it is the assignment, and only for the triangle reduce
+
+Both halves work in isolation. Every other lazy source survives the same
+assignment, and the same triangle reduce survives every other consumer:
+
+| Program | mutsu |
+|---|---|
+| `say ([\~] 1..*)[^5]` | fine — subscripted directly |
+| `say ([\+] 1..*)[^5]` | fine |
+| `my @n = 1..*; say @n[^5]` | fine |
+| `my @n = (1..*).map(*+1); say @n[^3]` | fine |
+| `my @n = lazy gather { take $_ for 1..* }; say @n[^3]` | fine |
+| `my @n = [\~] 1..*; say @n[^5]` | **hangs** |
+
+So `@`-assignment does preserve laziness in general, and the triangle reduce is
+lazy when consumed directly — but the `Seq` the triangle reduce hands to the
+assignment is not carrying whatever marks the others as lazy, so the assignment
+tries to reify it to completion.
+
+## Where to look
+
+The triangle-reduce (`[\op]`) producer and what kind of value it returns
+(`src/vm/vm_misc_ops.rs` reduction handling), compared with what `1..*`,
+`.map` over an infinite range, and `lazy gather` return. The list-assign path
+(`vm_var_assign_*`) decides eagerness from that.
+
+## Neighbourhood to check when fixing
+
+`[\+]`, `[\*]` and a user-defined operator; `my @n := [\~] 1..*` (bind rather
+than assign); assignment into `my $n =` and into a `Seq`-typed variable;
+`.head(5)` / `.[^5]` / `for` over the assigned array; and whether
+`[\~] (1..*).map(...)` behaves like the bare range.

--- a/todo/tickets/baggy-union-weight-loses-rat-precision.md
+++ b/todo/tickets/baggy-union-weight-loses-rat-precision.md
@@ -1,0 +1,41 @@
+# Baggy union adds weights as `Num`, so a `Rat` weight loses precision
+
+Found by the 2026-09-06 doc-diff sweep (`raku-doc/doc/Language/operators.rakudoc:1795`),
+re-verified against raku v2026.07 the same day.
+
+## Repro
+
+```raku
+say <a b c> (+) (a => 2.5, b => 3.14).Mix;
+# raku:  Mix(a(3.5) b(4.14) c)
+# mutsu: Mix(a(3.5) b(4.140000000000001) c)
+```
+
+## Narrowed
+
+The `Rat` survives everywhere except the union's own addition:
+
+| Program | raku | mutsu |
+|---|---|---|
+| `say (3.14 + 1).raku` | `4.14` | `4.14` |
+| `say (2.5 + 3.14).raku` | `5.64` | `5.64` |
+| `say (a => 3.14).Mix.raku` | `("a"=>3.14).Mix` | same |
+| `say <b> (+) (b => 3.14).Mix` | `Mix(b(4.14))` | `Mix(b(4.140000000000001))` |
+
+So the `Mix` stores `3.14` as a `Rat` and ordinary `Rat + Int` is exact; it is
+`(+)` (`infix:<(+)>`, baggy addition) that coerces the two weights to `f64`
+before adding. `a(3.5)` happens to be exact in binary, which is why only the
+`b` entry shows it.
+
+## Where to look
+
+`src/vm/vm_set_ops.rs` and the Bag/Mix weight arithmetic in `src/builtins/`.
+The fix is to add weights with the same numeric-tower promotion ordinary `+`
+uses (`Int`+`Rat` stays `Rat`, only a real `Num` operand makes the result
+`Num`), rather than going through `f64`.
+
+## Neighbourhood to check when fixing
+
+`(-)`, `(.)`, `(^)` and the `⊎`/`∩`/`∖` spellings; `Bag`/`BagHash`/`MixHash`
+receivers; a `FatRat` weight; and `.total`/`.roll` weight sums, which may share
+the same coercion.

--- a/todo/tickets/role-mixin-name-carries-a-spurious-type-parameter.md
+++ b/todo/tickets/role-mixin-name-carries-a-spurious-type-parameter.md
@@ -1,0 +1,46 @@
+# `but R(42)` names the mixin `R[Int]` — the argument is an attribute, not a type parameter
+
+Found by the 2026-09-06 doc-diff sweep (`raku-doc/doc/Language/operators.rakudoc:1977`),
+re-verified against raku v2026.07 the same day.
+
+## Repro
+
+```raku
+role Answerable { has $.answer }
+my $u = 'Life' but Answerable(42);
+say $u.^name;      # raku: Str+{Answerable}   mutsu: Str+{Answerable[Int]}
+say $u.answer;     # both: 42
+```
+
+Minimal:
+
+```raku
+role R { has $.x }
+say (1 but R(2)).^name;   # raku: Int+{R}   mutsu: Int+{R[Int]}
+```
+
+## Diagnosis
+
+The *behaviour* is right — the attribute is initialized and `.answer` reads
+back `42` — so this is purely a naming defect: `R(42)` in `but` position
+initializes the role's single attribute (`Language/operators.rakudoc`'s "role
+with a single attribute" form), and mutsu is recording it as if it were a role
+**parameterization** (`R[Int]`), stamping the argument's *type* into the
+composed name.
+
+Since `.^name` is what `X::` messages, `.raku`, `.gist` and introspection all
+report, this leaks into any program that prints a mixin's type.
+
+## Where to look
+
+The `but`/`does` mixin composition path (`src/vm/vm_trait_mod_does_ops.rs`) and
+wherever the composed name is built. A genuinely parameterized role
+(`role R[::T] { }`; `1 but R[Int]`) must keep its `[Int]`, so the fix is to
+distinguish the two spellings rather than to drop the suffix unconditionally.
+
+## Neighbourhood to check when fixing
+
+`does R(42)` as well as `but`; a role with two attributes (`R(1, 2)`); a role
+that is both parameterized and attribute-carrying; `.^roles`/`.^mro` output;
+and `X::Role::Initialization` (raku throws it when the role has no attribute to
+initialize — check mutsu's behaviour there too).

--- a/todo/tickets/set-which-ignores-a-user-defined-element-which.md
+++ b/todo/tickets/set-which-ignores-a-user-defined-element-which.md
@@ -1,0 +1,51 @@
+# A `Set`'s own `.WHICH` ignores its elements' user-defined `.WHICH`
+
+Found by the 2026-09-06 doc-diff sweep (`raku-doc/doc/Language/operators.rakudoc:2376`),
+re-verified against raku v2026.07 the same day.
+
+## Repro
+
+```raku
+my class A {
+    has $.a;
+    method WHICH { ValueObjAt.new: "A|$!a.WHICH()" }
+}
+say Set(A.new(a => 5)) eqv Set(A.new(a => 5));
+# raku: True   mutsu: False
+```
+
+## Narrowed — the elements agree, the Sets do not
+
+```raku
+my $s = Set(A.new(a=>5));
+my $t = Set(A.new(a=>5));
+say $s.keys».WHICH;      # both: (A|5)
+say $t.keys».WHICH;      # both: (A|5)
+say $s.WHICH eq $t.WHICH; # raku: True   mutsu: False
+say $s === $t;            # raku: True   mutsu: False
+say $s eqv $t;            # raku: True   mutsu: False
+```
+
+The user `WHICH` is honoured for the *element* (`A.new(a=>5).WHICH` is `A|5` in
+both, and the two instances compare equal by `WHICH`) and the `Set` correctly
+holds one key. What differs is the **`Set`'s own `.WHICH`**: mutsu builds it
+from something other than the elements' `.WHICH` strings — object identity,
+presumably — so two structurally identical Sets get different value identities.
+
+`===` and `eqv` both read `.WHICH`, so all three rows above are one defect.
+
+## Where to look
+
+Set/Bag/Mix `.WHICH` construction (`src/builtins/methods_0arg/`, the QuantHash
+identity path) and how set keys are encoded. Note that mutsu already has a
+`.WHICH`-encoded key path for **object hashes** (`hash_uses_typed_keys` /
+`value_which_key`, used by `my %h{Any}`), so the machinery to ask an element for
+its `.WHICH` exists — the Set identity path is not using it.
+
+## Neighbourhood to check when fixing
+
+`Bag`/`Mix`/`SetHash`/`BagHash`/`MixHash` receivers; `.WHICH` on a `List`,
+`Array`, `Hash` and `Pair` holding such elements; a user `WHICH` that is *not*
+a `ValueObjAt` (raku requires `ValueObjAt` for value semantics — check mutsu
+does not accept a plain `Str`); and `%h{$obj}` object-hash keys, which should
+already be correct and must stay so.

--- a/todo/tickets/tolerance-dynamic-variable-is-undefined.md
+++ b/todo/tickets/tolerance-dynamic-variable-is-undefined.md
@@ -1,0 +1,44 @@
+# `$*TOLERANCE` is undefined, so `≅` uses the wrong tolerance
+
+Found by the 2026-09-06 doc-diff sweep (`raku-doc/doc/Language/operators.rakudoc:2507`),
+re-verified against raku v2026.07 the same day.
+
+## Repro
+
+```raku
+my $x = 1;
+say ($x + $*TOLERANCE) ≅ $x;   # raku: False   mutsu: True
+say ($x - $*TOLERANCE) ≅ $x;   # both: True
+```
+
+## Narrowed — the variable itself is missing
+
+```raku
+say $*TOLERANCE;   # raku: 1e-15   mutsu: (Any)
+```
+
+So the first line is really `(1 + Any) ≅ 1`, i.e. `1 ≅ 1`, which is trivially
+`True`. The asymmetry raku shows is genuine and is the point of the doc example:
+`1 + 1e-15` is a different `Num` from `1` while `1 - 1e-15` rounds back to `1`.
+
+`≅` itself is not obviously broken — `1.000001 ≅ 1` and `100 ≅ 100.00001` both
+answer `False` in mutsu as in raku — so the fix may be just to define the
+dynamic variable with raku's default (`1e-15`) and make `infix:<≅>` /
+`infix:<=~=>` read it.
+
+## Where to look
+
+Wherever the built-in dynamic variables are seeded (`$*IN`, `$*OUT`, `$*ERR`,
+`$*PID` …) and the `≅` implementation in `src/builtins/`. Per
+`raku-doc/doc/Language/operators.rakudoc`, the comparison is
+`abs(a - b) <= $*TOLERANCE * max(abs(a), abs(b))` for non-zero operands, with an
+absolute comparison when either side is zero — check mutsu's formula against
+that at the same time, since a hard-coded tolerance may currently be standing in.
+
+## Neighbourhood to check when fixing
+
+A user-set `$*TOLERANCE` in an inner scope (it is a dynamic variable, so
+`{ my $*TOLERANCE = 0.1; say 1 ≅ 1.05 }` must see the override); the `=~=` ASCII
+spelling; `Complex` and `Rat` operands; comparisons involving `0`, `Inf` and
+`NaN`; and `is-approx` in `Test`, which raku documents in terms of the same
+tolerance.

--- a/todo/tickets/zip-chain-with-a-comma-list-left-operand-fails-to-parse.md
+++ b/todo/tickets/zip-chain-with-a-comma-list-left-operand-fails-to-parse.md
@@ -1,0 +1,44 @@
+# A chained `Z` whose left operand is a comma list fails to parse
+
+Found by the 2026-09-06 doc-diff sweep (`raku-doc/doc/Language/operators.rakudoc:3157`),
+re-verified against raku v2026.07 the same day.
+
+## Repro
+
+```raku
+say (1, 2 Z <a b c> Z <x y>).raku;
+# raku:  ((1, "a", "x"), (2, "b", "y")).Seq
+# mutsu: Two terms in a row
+```
+
+## Narrowed — the doc example's `<+ ->` is a red herring
+
+The doc block that surfaced this uses `Z <+ ->`, which looks like the culprit
+and is not:
+
+| Program | mutsu |
+|---|---|
+| `say <+ ->.raku` | `("+", "-")` — fine |
+| `say (<a b> Z <+ ->).raku` | fine |
+| `say (1, 2 Z <a b c>).raku` | fine — one `Z`, comma-list left operand |
+| `say (1 Z <a b> Z <+ ->).raku` | fine — chained `Z`, **single** left operand |
+| `say (1, 2 Z <a b c> Z <x y>).raku` | **Two terms in a row** |
+| `say (1, 2 Z <a b c> Z <+ ->).raku` | **Two terms in a row** |
+
+So the trigger is exactly: a **chain of two or more `Z`** whose leftmost
+operand is a **comma list**. `Z` is `list infix` (same precedence level as `X`
+and `Zop`), so `1, 2 Z <a b c> Z <x y>` parses in raku as one n-ary zip of
+three lists with `1, 2` as the first — mutsu appears to close the list after
+the first `Z` and then find a second `Z` with nothing to its left.
+
+## Where to look
+
+The list-infix chain handling in the parser (`src/parser/`), specifically how a
+comma list on the left of a list infix is closed off before the next operator of
+the same precedence is read.
+
+## Neighbourhood to check when fixing
+
+The other list infixes at that level: `X`, `Xop`, `Zop` (`1, 2 Z+ <3 4> Z+ ...`),
+and `xx`. Also the reverse shape (a comma list on the *right* of the second
+operator), and a three-`Z` chain.


### PR DESCRIPTION
The 2026-09-06 re-sweep (#7381) ranked `Language/operators.rakudoc` first (4 mismatch + 2 crash). This triages it: **all six blocks reproduce against raku v2026.07**, and each is narrowed past the doc example to a one-line repro.

Two of the doc examples actively pointed at the wrong cause, which is why the narrowing is in the tickets rather than the doc snippet:

- The `Z` failure is **not** about `<+ ->`. That word-quote is fine alone, and `<a b> Z <+ ->` parses. The trigger is a *chained* `Z` whose leftmost operand is a comma list: `1, 2 Z <a b c> Z <x y>` fails identically, while `1 Z <a b> Z <+ ->` parses.
- The `[\\~] 1..*` hang is **not** the triangle reduce being eager (`([\\~] 1..*)[^5]` works) nor `@`-assignment being eager (`my @n = 1..*`, `.map` over an infinite range, and `lazy gather` all survive it). It is the reduce's `Seq` not carrying laziness into the list assign.

The other four: baggy `(+)` adds weights as `f64` so a `Rat` weight loses precision; `1 but R(42)` names the mixin `R[Int]`, recording an attribute initialization as a role parameterization; a `Set`'s own `.WHICH` ignores its elements' user-defined `.WHICH`; and `$*TOLERANCE` is `(Any)` rather than `1e-15`, so the `≅` example silently compares `1 ≅ 1`.

Each ticket carries its narrowing table, where to look, and a neighbourhood list to check while fixing. Docs/todo only, so the four heavy CI jobs skip by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)