### PR TITLE
fix(grammar): aliased captures fired their action 2^depth times (and 8.3x on bench-yaml-parse)

### DIFF
--- a/news/2026-09/grammar-alias-action-exponential-firing.md
+++ b/news/2026-09/grammar-alias-action-exponential-firing.md
@@ -1,0 +1,55 @@
+# An aliased capture's grammar action fired 2^depth times
+
+`<x=rule>` — a non-suppressing capture alias — files the match under **both**
+the alias name and the rule's own name, which is what Rakudo does (`$<x>` and
+`$<rule>` both answer, and they are the *same* cursor: `$<x> === $<rule>` is
+`True`). mutsu stored two **independent** copies of the capture node, the
+second a deep clone of the whole matched subtree, and the grammar action walk
+then dispatched each slot on its own. So every aliased capture ran its
+subtree's actions twice — and because the duplication happens at every level,
+nested aliases multiplied it: a leaf action fired `2^depth` times.
+
+The minimal repro (now pinned by `t/grammar-alias-action-fires-once.t`,
+verified against rakudo 2026.07):
+
+```raku
+grammar E3 {
+    token TOP { <x=l1> }; token l1 { <y=l2> };
+    token l2 { <z=l3> };  token l3 { 'x' }
+}
+```
+
+raku fires each of `l1`/`l2`/`l3` once. mutsu fired them 2/4/**8** times.
+
+This is a correctness bug first — an action method with side effects ran up to
+`2^depth` times — and a large performance one second. `benchmarks/bench-yaml-parse.raku`
+exercises it hard: YAMLish's quoted-scalar rules alias `<str=single-bare> |
+<str=single-quotes> | <str=space>` and sit eight alias levels deep, so the
+`space` action fired **256 times per matched space character** and the parse
+ran 40115 action methods where rakudo runs 997.
+
+## The fix
+
+Both slots now push the **same** `Arc<CapNode>` — no subtree clone, and the
+two names really are one cursor (mutsu now answers `True` for `$<x> === $<rule>`
+too). The action walk dispatches at most once per capture node per parent
+(`Value::match_node_identity` compares the stored node behind two lazy
+`Match`es) and hands the second slot the same updated Match, so the `.made`
+the single dispatch produced still reaches both names.
+
+## Effect
+
+On `benchmarks/bench-yaml-parse.raku` (release, idle box, median of 7 runs):
+1.14s → 0.34s. Counted rather than timed, the same run's `MUTSU_VM_STATS`:
+
+| counter | before | after |
+| --- | ---: | ---: |
+| opcodes executed | 75595 | 2877 |
+| `dual-store: env_deep_copies` | 41360 | 580 |
+| `regex-captures: match_materializations` | 1743 | 69 |
+| grammar action methods run | 40115 | 191 |
+
+Found by comparing per-action fire counts against rakudo on an instrumented
+copy of YAMLish, after a callgrind profile showed `invoke_leaf_action_lazy`
+running 76800 times on a document with ~150 leaf captures. See
+`todo/perf/yaml-parse-throughput.md` round 10.

--- a/news/2026-09/registry-accessor-column-index.md
+++ b/news/2026-09/registry-accessor-column-index.md
@@ -1,0 +1,31 @@
+# sync_accessor_entries no longer scans the whole method table
+
+`Registry::sync_accessor_entries` re-derives one class's auto-generated
+attribute accessors into the canonical `method_entries` table. To clear the
+previous derivation it scanned **every row of the table** looking for rows
+owned by that class with an `accessor` column — an O(total methods) sweep per
+call, documented at the time as "deliberately not index-accelerated" because
+accessor-only rows are not covered by `owner_method_names` (that index is
+scoped to the user-method column).
+
+Measurement caught up with the note. `Interpreter::new` calls it once per
+built-in class, so interpreter construction was quadratic in the built-in
+method table, and a callgrind profile of `benchmarks/bench-yaml-parse.raku`
+attributed **12.7%** of the whole run to the `Vec::from_iter` behind that one
+scan (92955 calls — the benchmark's regex paths were building ~200 scratch
+interpreters per parse).
+
+`Registry::owner_accessor_names` is the accessor-column twin of the existing
+reverse index, so the stale set is now read directly and the call is
+O(the owner's attributes). `sync_accessor_entries` is the only writer of the
+`accessor` column, and no other mutator can drop such a row behind its back —
+`entry_is_live` keeps a row alive while its `accessor` is set — so the index
+is exact. `replace_method_entries_from` copies it alongside the table it
+derives from, and the `MUTSU_CHECK_METHOD_INDEX` debug verifier checks both
+directions of it the way it already did for the method half.
+
+Found while profiling `todo/perf/yaml-parse-throughput.md` (round 10); the
+same round then removed most of the calls themselves by not building the
+built-in registry for scratch interpreters at all
+(`news/2026-09/scratch-interpreter-skips-builtin-registry.md`), which is why
+the residual cost of this site is now ~2.5% of that benchmark rather than 12.7%.

--- a/news/2026-09/scratch-interpreter-skips-builtin-registry.md
+++ b/news/2026-09/scratch-interpreter-skips-builtin-registry.md
@@ -1,0 +1,52 @@
+# Regex scratch interpreters no longer build the built-in registry
+
+Every regex/grammar sub-evaluation — a subrule called with arguments, an
+embedded `{ ... }` block, a `<?{ ... }>` assertion, a `.^lookup`-style token
+method — builds a scratch `Interpreter` so the evaluation cannot mutate the
+caller's environment. `Interpreter::new` built the entire built-in declaration
+registry for each one: ~450 `ClassDef`s, the `X::` exception hierarchy, the
+composed-role seeds, and a freshly seeded method table.
+
+That work was pure waste. Every one of the ten scratch construction sites
+immediately replaces the scratch's registry with the caller's
+(`copy_decl_registry_into` / `copy_full_registry_into`) before the scratch runs
+anything. `benchmarks/bench-yaml-parse.raku` builds **207** scratch
+interpreters per parse, and a callgrind profile attributed **~48% of the whole
+run** to those constructions (`Interpreter::new` reached from
+`eval_regex_expr_value`, `resolve_token_patterns_with_args_in_pkg`,
+`regex_match_atom_in_pkg_inner`, ...).
+
+## The fix
+
+`copy_decl_registry_into` used to clone four maps (`functions`,
+`proto_functions`, `token_defs`, `enum_types`) into the registry the scratch
+had built for itself, leaving it on its own built-in `classes`/`method_entries`.
+It now shares the parent's copy-on-write `Arc<Registry>` — what
+`copy_full_registry_into` already did for the actions path. That is O(1)
+instead of four map clones plus a registry write, and it is a strict superset
+of the data: the parent's registry carries every built-in the scratch used to
+build for itself, plus the user declarations it previously could not see.
+
+With no caller reading the scratch's self-built registry, `Interpreter::new`
+skips building it under the existing `BUILDING_SCRATCH` flag (which already
+skipped the `%*ENV` sweep, IO handles and `$*REPO` setup for the same reason).
+The construction moved verbatim into `Interpreter::build_builtin_registry`,
+called only for a real interpreter.
+
+## Effect
+
+Release build, idle box, median of 7 runs:
+
+| workload | before | after | raku (same box) |
+| --- | ---: | ---: | ---: |
+| `benchmarks/bench-yaml-parse.raku` | 0.344s | **0.138s** | 0.340s |
+| a 120-row YAML document | 2.97s | **0.96s** | 0.44s |
+
+The `t/` suite's total CPU time drops ~11% (352s → 312s), since every
+grammar-using test pays this. `registry-cow: clones` stays 0 on the benchmark,
+so the shared registry is not trading construction for copy-on-write clones.
+
+(The `before` column is already after the same session's aliased-capture action
+fix — see `news/2026-09/grammar-alias-action-exponential-firing.md`. Against
+this ticket's session-start baseline of 1.14s, `bench-yaml-parse` is 8.3x
+faster and now runs 2.5x faster than rakudo on the same box.)

--- a/src/runtime/methods_grammar.rs
+++ b/src/runtime/methods_grammar.rs
@@ -1246,6 +1246,35 @@ impl Interpreter {
     }
 
     /// Walk the match tree bottom-up and invoke action methods on the actions object.
+    /// [`Self::invoke_grammar_actions`], but at most once per capture node
+    /// within one parent's child walk.
+    ///
+    /// `seen` memoizes `(node identity, updated Match)` for the siblings
+    /// dispatched so far. The one shape that repeats a node among siblings is
+    /// a non-suppressing alias (`<x=rule>` files the same node under `x` and
+    /// `rule`), where raku hands out one cursor — so the second slot must
+    /// receive the SAME updated Match (carrying the `.made` the single
+    /// dispatch produced), not a second dispatch of its own.
+    fn invoke_grammar_actions_once(
+        &mut self,
+        seen: &mut Vec<(usize, Value)>,
+        match_obj: Value,
+        actions: &mut Value,
+        rule_name: &str,
+    ) -> Result<Value, RuntimeError> {
+        let identity = match_obj.match_node_identity();
+        if let Some(id) = identity
+            && let Some((_, updated)) = seen.iter().find(|(seen_id, _)| *seen_id == id)
+        {
+            return Ok(updated.clone());
+        }
+        let updated = self.invoke_grammar_actions(match_obj, actions, rule_name)?;
+        if let Some(id) = identity {
+            seen.push((id, updated.clone()));
+        }
+        Ok(updated)
+    }
+
     pub(crate) fn invoke_grammar_actions(
         &mut self,
         match_obj: Value,
@@ -1343,22 +1372,39 @@ impl Interpreter {
             // `match_from` is the non-materializing seam read — a lazy child
             // is not forced just to be sorted.
             children.sort_by_key(|(_, v)| v.match_from().unwrap_or(0));
+            // A non-suppressing alias (`<x=rule>`) files ONE capture node under
+            // both `x` and `rule`, so the same cursor appears twice among these
+            // siblings. Rakudo dispatches an action per reduced cursor, not per
+            // capture slot; dispatching per slot fired the whole subtree's
+            // actions twice per alias level, compounding to 2^depth (256x on
+            // `benchmarks/bench-yaml-parse.raku`). Dispatch once per node and
+            // give both slots the same updated child — which is also what
+            // `$<x> === $<rule>` means.
+            let mut seen: Vec<(usize, Value)> = Vec::new();
             for (child_name, child_match) in children {
                 // Probe Match first (non-materializing); only non-Match values
                 // (arrays of per-iteration Matches) go through `view()`.
                 if child_match.is_match_instance() {
                     let dispatch_name =
                         Self::get_action_name(&child_match).unwrap_or_else(|| child_name.clone());
-                    let updated_child =
-                        self.invoke_grammar_actions(child_match, actions, &dispatch_name)?;
+                    let updated_child = self.invoke_grammar_actions_once(
+                        &mut seen,
+                        child_match,
+                        actions,
+                        &dispatch_name,
+                    )?;
                     updated_named.insert(child_name, updated_child);
                 } else if let ValueView::Array(items, meta) = child_match.view() {
                     let mut updated_items = Vec::with_capacity(items.len());
                     for item in items.as_ref() {
                         let dispatch_name =
                             Self::get_action_name(item).unwrap_or_else(|| child_name.clone());
-                        let updated_item =
-                            self.invoke_grammar_actions(item.clone(), actions, &dispatch_name)?;
+                        let updated_item = self.invoke_grammar_actions_once(
+                            &mut seen,
+                            item.clone(),
+                            actions,
+                            &dispatch_name,
+                        )?;
                         updated_items.push(updated_item);
                     }
                     updated_named.insert(
@@ -1371,8 +1417,12 @@ impl Interpreter {
                 } else {
                     let dispatch_name =
                         Self::get_action_name(&child_match).unwrap_or_else(|| child_name.clone());
-                    let updated_child =
-                        self.invoke_grammar_actions(child_match, actions, &dispatch_name)?;
+                    let updated_child = self.invoke_grammar_actions_once(
+                        &mut seen,
+                        child_match,
+                        actions,
+                        &dispatch_name,
+                    )?;
                     updated_named.insert(child_name, updated_child);
                 }
             }

--- a/src/runtime/regex/regex_eval.rs
+++ b/src/runtime/regex/regex_eval.rs
@@ -49,40 +49,21 @@ impl Interpreter {
         Some(stmts)
     }
 
-    /// Copy the declaration registry (functions / proto_functions / token_defs)
-    /// from `self` into a freshly-built sub-interpreter used for regex/grammar
-    /// evaluation. `self` and `target` have distinct registry `Arc`s, so this is
-    /// a snapshot copy (matches the prior per-field clone in the struct literal).
+    /// Install `self`'s declaration registry into a freshly-built
+    /// sub-interpreter used for regex/grammar evaluation.
+    ///
+    /// This used to copy four fields (`functions` / `proto_functions` /
+    /// `token_defs` / `enum_types`) into the registry the sub-interpreter built
+    /// for itself, leaving it on its own built-in `classes`/`method_entries`.
+    /// Sharing the parent's whole registry instead (the copy-on-write
+    /// `Arc<Registry>`, see [`Self::copy_full_registry_into`]) is both a strict
+    /// superset of that data — the parent's registry carries every built-in the
+    /// sub-interpreter used to build for itself, plus the user declarations it
+    /// could not see before — and O(1) instead of four map clones plus a
+    /// registry write. It is also what lets `Interpreter::new` skip building the
+    /// built-in registry for a scratch interpreter altogether.
     pub(crate) fn copy_decl_registry_into(&self, target: &mut Interpreter) {
-        // During a `Grammar.parse(:actions(...))`, a sub-interpreter spawned for
-        // subrule/proto-regex matching may evaluate a `<?{ $<x>.made ... }>`
-        // assertion, which has to dispatch the action class's methods (in
-        // `Registry::classes`). Copy the *full* registry in that case so those
-        // methods are reachable; otherwise keep the lean three-field copy that the
-        // common (action-less) regex/closure eval path relies on.
-        if self.current_grammar_actions.is_some() {
-            self.copy_full_registry_into(target);
-        } else {
-            let (functions, proto_functions, token_defs, enum_types) = {
-                let src = self.registry();
-                (
-                    src.functions.clone(),
-                    src.proto_functions.clone(),
-                    src.token_defs.clone(),
-                    src.enum_types.clone(),
-                )
-            };
-            let mut dst = target.registry_mut();
-            dst.functions = functions;
-            dst.proto_functions = proto_functions;
-            dst.token_defs = token_defs;
-            // Inherit the parent's enum types (built-in Order/Signal/... plus any
-            // user-declared enums). The scratch interpreter is built via
-            // `new_regex_scratch`, which skips seeding the built-in enums into its
-            // own registry, so copy them from the parent here — this also makes a
-            // regex closure see user-defined enums it previously could not.
-            dst.enum_types = enum_types;
-        }
+        self.copy_full_registry_into(target);
         // Propagate the in-progress `Grammar.parse(:actions(...))` object so the
         // assertion's sub-interpreter can still run the action method mid-parse.
         // None outside a parse, so this is a no-op there.

--- a/src/runtime/regex/regex_match_atom.rs
+++ b/src/runtime/regex/regex_match_atom.rs
@@ -1010,19 +1010,16 @@ impl Interpreter {
                 // `<name=&subrule>`) installs the capture under BOTH the alias name
                 // AND the subrule's own name, matching Rakudo (e.g. `<x=num>` yields
                 // `$<x>` and `$<num>`; repeated `<num>`/`<offset=count>` aggregate
-                // into a list under the rule name). Snapshot the subcap/text before
-                // the alias push consumes them so we can also store under the original.
+                // into a list under the rule name). Both slots share ONE node
+                // (see the `shared_under_original` push below).
                 let also_under_original = spec.capture_name.is_some()
                     && !spec.alias_replaces_original
                     && capture_name != spec.lookup_name;
-                let original_subcap = also_under_original.then(|| subcap.clone());
                 // For an aliased capture (`<x=rule>`), record the original rule
                 // name for grammar action dispatch BEFORE the node is wrapped in
                 // an Arc and shared (`record_reduced_subrule` clones the handle):
                 // writing it afterwards through `Arc::make_mut` deep-copied the
                 // whole descendant subtree for every aliased subrule capture.
-                // The alias copy carries it; the original-name copy (cloned just
-                // above) keeps `action_name: None`, same as before.
                 let is_alias = spec.capture_name.is_some() && capture_name != spec.lookup_name;
                 let mut subcap = subcap;
                 if is_alias {
@@ -1033,6 +1030,16 @@ impl Interpreter {
                 // overall can still run its action, the way Rakudo (which
                 // dispatches at reduce time) does — see `REDUCED_SUBRULES`.
                 super::regex_helpers::record_reduced_subrule(&spec.lookup_name, &subcap);
+                // Both slots reference the SAME node, the way Rakudo stores the
+                // same cursor under both names (`$<x> === $<num>` is `True`).
+                // Cloning the node here instead — as this did until the
+                // exponential-action fix — deep-copied the whole matched
+                // subtree per aliased capture AND made the grammar action walk
+                // dispatch that subtree twice, once per slot; nested aliases
+                // then multiplied, firing a leaf's action 2^depth times (256x
+                // on `benchmarks/bench-yaml-parse.raku`).
+                let shared_under_original =
+                    also_under_original.then(|| std::sync::Arc::clone(&subcap));
                 new_caps
                     .named
                     .entry(Symbol::intern(capture_name))
@@ -1044,13 +1051,13 @@ impl Interpreter {
                         .capture_alias_map
                         .insert(capture_name.to_string(), spec.lookup_name.clone());
                 }
-                if let Some(orig_subcap) = original_subcap {
+                if let Some(orig_subcap) = shared_under_original {
                     new_caps
                         .named
                         .entry(Symbol::intern(&spec.lookup_name))
                         .or_default()
                         .nodes
-                        .push(std::sync::Arc::new(orig_subcap.into_cap_node()));
+                        .push(orig_subcap);
                 }
             } else if !inner_caps.named.is_empty() {
                 // Silent subrule (`<.foo>`) that contains nested captures. The

--- a/src/runtime/registry.rs
+++ b/src/runtime/registry.rs
@@ -123,6 +123,23 @@ pub(crate) struct Registry {
     /// block should go through [`owner_method_names`](Self::owner_method_names)
     /// rather than touching the field directly.
     pub(crate) owner_method_names: HashMap<Symbol, Vec<Symbol>>,
+    /// Reverse index for the OTHER half of the same table: owner -> every
+    /// `name` whose `(owner, name)` row currently carries an `accessor`
+    /// column. Maintained solely by
+    /// [`sync_accessor_entries`](Self::sync_accessor_entries), the only writer
+    /// of that column; no other mutator can drop such a row behind its back,
+    /// since `entry_is_live` keeps a row alive while its `accessor` is set.
+    ///
+    /// Exists to give `sync_accessor_entries` its stale set without scanning
+    /// every row in the table. `Interpreter::new` re-derives accessors for
+    /// each of the ~450 built-in classes, so the scan made construction
+    /// O(classes x rows) — 12.7% of `benchmarks/bench-yaml-parse.raku`, whose
+    /// regex paths build ~200 scratch interpreters per parse.
+    ///
+    /// `pub(crate)` for the same struct-update-syntax reason as
+    /// [`owner_method_names`](Self::owner_method_names); read and written only
+    /// through `registry_method_table.rs`.
+    pub(crate) owner_accessor_names: HashMap<Symbol, Vec<Symbol>>,
     /// Method-candidate wrap chains: `(owner class, method name, candidate
     /// index)` -> stack of `(handle_id, wrapper_sub)`, outermost (currently
     /// active) last. Populated by `.wrap()` on a Sub/Method obtained via
@@ -509,6 +526,10 @@ impl Registry {
         // `throws-like`/`fails-like`) would run the parent's `method_entries`
         // against its own `Interpreter::new()`'s empty `owner_method_names`.
         self.owner_method_names = source.owner_method_names.clone();
+        // Same reasoning for the accessor half of the table: a nested
+        // interpreter must not run the copied `method_entries` against its own
+        // (differently populated) accessor index.
+        self.owner_accessor_names = source.owner_accessor_names.clone();
         self.bump_method_generation();
     }
 

--- a/src/runtime/registry_method_table.rs
+++ b/src/runtime/registry_method_table.rs
@@ -119,6 +119,37 @@ impl Registry {
                 "MUTSU_CHECK_METHOD_INDEX: method_entries[{key:?}] has live user_candidates but is missing from owner_method_names"
             );
         }
+        // The same invariant for the accessor half: `sync_accessor_entries`
+        // derives its stale set from `owner_accessor_names`, so an accessor row
+        // missing from the index would never be cleared on re-derivation.
+        for (owner, names) in &self.owner_accessor_names {
+            for name in names {
+                let live = self
+                    .method_entries
+                    .get(&MethodEntryKey {
+                        owner: *owner,
+                        name: *name,
+                    })
+                    .is_some_and(|entry| entry.accessor.is_some());
+                assert!(
+                    live,
+                    "MUTSU_CHECK_METHOD_INDEX: owner_accessor_names[{owner:?}] lists {name:?} but its row has no accessor"
+                );
+            }
+        }
+        for (key, entry) in &self.method_entries {
+            if entry.accessor.is_none() {
+                continue;
+            }
+            let indexed = self
+                .owner_accessor_names
+                .get(&key.owner)
+                .is_some_and(|names| names.contains(&key.name));
+            assert!(
+                indexed,
+                "MUTSU_CHECK_METHOD_INDEX: method_entries[{key:?}] has an accessor but is missing from owner_accessor_names"
+            );
+        }
     }
 
     #[cfg(not(debug_assertions))]
@@ -322,21 +353,21 @@ impl Registry {
     /// Re-derives `owner`'s `accessor` column from `ClassDef::attributes` --
     /// the "surviving half" of the old `sync_user_method_entries` (ADR-0019
     /// F4c design note (3)): type-structure metadata stays on `ClassDef` by
-    /// design, so this keeps its pre-existing O(total table) shape
-    /// (deliberately not index-accelerated -- accessor-only rows are not
-    /// covered by `owner_method_names`, which is scoped to the user-method
-    /// column only) rather than getting the O(names) treatment the method
-    /// half got. A later same-name attribute overrides an earlier one:
+    /// design. A later same-name attribute overrides an earlier one:
     /// iterating `ClassDef::attributes` in declaration order and letting
     /// each write clobber the last gives "most recent wins".
+    ///
+    /// The stale set comes from
+    /// [`owner_accessor_names`](Registry::owner_accessor_names), this
+    /// function's own reverse index, so the call is O(`owner`'s attributes)
+    /// rather than O(total table). It used to scan every row: `Interpreter::
+    /// new` runs it once per built-in class, which made interpreter
+    /// construction quadratic in the built-in table and cost 12.7% of
+    /// `benchmarks/bench-yaml-parse.raku` (whose regex paths build ~200
+    /// scratch interpreters per parse).
     pub(crate) fn sync_accessor_entries(&mut self, owner: Symbol) {
-        let stale: Vec<MethodEntryKey> = self
-            .method_entries
-            .iter()
-            .filter(|(key, entry)| key.owner == owner && entry.accessor.is_some())
-            .map(|(key, _)| *key)
-            .collect();
-        for key in stale {
+        for name in self.owner_accessor_names.remove(&owner).unwrap_or_default() {
+            let key = MethodEntryKey { owner, name };
             if let Some(entry) = self.method_entries.get_mut(&key) {
                 entry.accessor = None;
                 if !entry_is_live(entry) {
@@ -346,14 +377,19 @@ impl Registry {
         }
         if let Some(class_def) = self.classes.get(Symbol::resolve(&owner).as_str()) {
             let attributes = class_def.attributes.clone();
+            let mut names: Vec<Symbol> = Vec::with_capacity(attributes.len());
             for attr in &attributes {
+                let name = Symbol::intern(&attr.name);
                 self.method_entries
-                    .entry(MethodEntryKey {
-                        owner,
-                        name: Symbol::intern(&attr.name),
-                    })
+                    .entry(MethodEntryKey { owner, name })
                     .or_default()
                     .accessor = Some(attr.is_public);
+                if !names.contains(&name) {
+                    names.push(name);
+                }
+            }
+            if !names.is_empty() {
+                self.owner_accessor_names.insert(owner, names);
             }
         }
         self.bump_method_generation();

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -57,27 +57,19 @@ impl Interpreter {
         regex_parse::PENDING_REGEX_ERROR.with(|e| e.borrow_mut().take())
     }
 
-    pub fn new() -> Self {
-        let mut env = HashMap::new();
-        env.insert("*PID".to_string(), Value::int(current_process_id()));
-        env.insert("*TZ".to_string(), Value::int(local_timezone_offset_secs()));
-        env.insert("@*ARGS".to_string(), Value::real_array(Vec::new()));
-        env.insert("*INIT-INSTANT".to_string(), Value::make_instant_now());
-        // Populate %*ENV with all OS environment variables so that
-        // %*ENV.keys, %*ENV.elems, and copying %*ENV work correctly. A scratch
-        // interpreter inherits the caller's env (which already carries %*ENV), so
-        // skip the OS-env sweep there.
-        if !Self::is_building_scratch() {
-            let env_hash = os_env_hash();
-            env.insert(
-                "%*ENV".to_string(),
-                Value::hash_with_data(Value::hash_arc(env_hash)),
-            );
-        }
-        env.insert(
-            "*SCHEDULER".to_string(),
-            Value::make_instance(Symbol::intern("ThreadPoolScheduler"), HashMap::new()),
-        );
+    /// Build the built-in declaration registry: every built-in `ClassDef`,
+    /// the exception-class hierarchy, the composed-role seeds and the seeded
+    /// method table.
+    ///
+    /// Extracted from [`Self::new`] so a regex/grammar scratch interpreter can
+    /// SKIP it (see `BUILDING_SCRATCH`): a scratch interpreter has its whole
+    /// registry replaced by the caller's (`copy_decl_registry_into`) before it
+    /// runs anything, so building ~450 class definitions and seeding their
+    /// method entries first was pure waste — and a grammar parse builds one
+    /// scratch interpreter per subrule-with-arguments call and per embedded
+    /// code block (207 of them on `benchmarks/bench-yaml-parse.raku`, where a
+    /// callgrind profile attributed ~48% of the whole run to this work).
+    fn build_builtin_registry() -> Registry {
         let mut classes = rustc_hash::FxHashMap::default();
         classes.insert(
             "Mu".to_string(),
@@ -2420,6 +2412,397 @@ impl Interpreter {
         register_x("X::Worry::P5::BackReference", "X::Worry::P5", &[]);
         register_x("X::Worry::P5::LeadingZero", "X::Worry::P5", &[]);
         register_x("X::Worry::P5::Reference", "X::Worry::P5", &[]);
+        // Built-in class definitions (PR-A slice 3: `classes` now lives in the
+        // shared Registry instead of an Interpreter field).
+        // Field-by-field init rather than `Registry { .. }` struct
+        // update: `proto_subs`/`proto_gen` are private (their
+        // mutations must flow through the gen-bumping accessors).
+        let mut registry = Registry::default();
+        registry.classes = classes;
+        registry.seed_builtin_method_entries();
+        // Built-in class -> composed-role seeds (PR-A slice 2: class metadata
+        // now lives in the shared Registry instead of an Interpreter field).
+        let ccr = &mut registry.class_composed_roles;
+        ccr.insert(
+            "CompUnit::Repository::FileSystem".to_string(),
+            vec!["CompUnit::Repository".to_string()],
+        );
+        // Built-in type role composition
+        ccr.insert(
+            "Int".to_string(),
+            vec!["Real".to_string(), "Numeric".to_string()],
+        );
+        ccr.insert(
+            "Num".to_string(),
+            vec!["Real".to_string(), "Numeric".to_string()],
+        );
+        ccr.insert(
+            "Rat".to_string(),
+            vec![
+                "Rational[Int,Int]".to_string(),
+                "Real".to_string(),
+                "Numeric".to_string(),
+            ],
+        );
+        ccr.insert(
+            "FatRat".to_string(),
+            vec![
+                "Rational[Int,Int]".to_string(),
+                "Real".to_string(),
+                "Numeric".to_string(),
+            ],
+        );
+        ccr.insert("Complex".to_string(), vec!["Numeric".to_string()]);
+        ccr.insert("Str".to_string(), vec!["Stringy".to_string()]);
+        // Built-in role definitions (PR-A slice 4: roles now live in the
+        // shared Registry instead of an Interpreter field).
+        registry.roles = {
+            let mut roles = rustc_hash::FxHashMap::default();
+            roles.insert(
+                "Encoding".to_string(),
+                RoleDef {
+                    attributes: Vec::new(),
+                    methods: HashMap::new(),
+                    is_stub_role: false,
+                    is_hidden: false,
+                    is_rw: false,
+                    captured_env: None,
+                    wildcard_handles: Vec::new(),
+                    role_id: 0,
+                    attribute_conflicts: Vec::new(),
+                    own_attribute_names: std::collections::HashSet::new(),
+                    deferred_body: Vec::new(),
+                    deferred_custom_traits: Vec::new(),
+                },
+            );
+            roles.insert(
+                "Iterator".to_string(),
+                RoleDef {
+                    attributes: Vec::new(),
+                    methods: HashMap::new(),
+                    is_stub_role: false,
+                    is_hidden: false,
+                    is_rw: false,
+                    captured_env: None,
+                    wildcard_handles: Vec::new(),
+                    role_id: 0,
+                    attribute_conflicts: Vec::new(),
+                    own_attribute_names: std::collections::HashSet::new(),
+                    deferred_body: Vec::new(),
+                    deferred_custom_traits: Vec::new(),
+                },
+            );
+            roles.insert(
+                "PredictiveIterator".to_string(),
+                RoleDef {
+                    attributes: Vec::new(),
+                    methods: HashMap::new(),
+                    is_stub_role: false,
+                    is_hidden: false,
+                    is_rw: false,
+                    captured_env: None,
+                    wildcard_handles: Vec::new(),
+                    role_id: 0,
+                    attribute_conflicts: Vec::new(),
+                    own_attribute_names: std::collections::HashSet::new(),
+                    deferred_body: Vec::new(),
+                    deferred_custom_traits: Vec::new(),
+                },
+            );
+            roles.insert(
+                "Iterable".to_string(),
+                RoleDef {
+                    attributes: Vec::new(),
+                    methods: HashMap::new(),
+                    is_stub_role: false,
+                    is_hidden: false,
+                    is_rw: false,
+                    captured_env: None,
+                    wildcard_handles: Vec::new(),
+                    role_id: 0,
+                    attribute_conflicts: Vec::new(),
+                    own_attribute_names: std::collections::HashSet::new(),
+                    deferred_body: Vec::new(),
+                    deferred_custom_traits: Vec::new(),
+                },
+            );
+            roles.insert(
+                "X::Control".to_string(),
+                RoleDef {
+                    attributes: Vec::new(),
+                    methods: HashMap::new(),
+                    is_stub_role: false,
+                    is_hidden: false,
+                    is_rw: false,
+                    captured_env: None,
+                    wildcard_handles: Vec::new(),
+                    role_id: 0,
+                    attribute_conflicts: Vec::new(),
+                    own_attribute_names: std::collections::HashSet::new(),
+                    deferred_body: Vec::new(),
+                    deferred_custom_traits: Vec::new(),
+                },
+            );
+            // ADR-0029: role-shaped `X::` exception "namespaces".
+            // Measured against real rakudo (2026-08-17), 59% of the
+            // `X::` classes mutsu raises or tests against compose one
+            // or more of these marker roles rather than inheriting
+            // from a same-named class -- `X::Comp`, `X::Syntax`,
+            // `X::IO`, and `X::OS` are the heavily-used ones (135/69/
+            // 22/22 classes respectively), the rest are 1-7 each. All
+            // are empty-bodied here, as they are in rakudo too: mutsu's
+            // exception machinery supplies the behaviour, these exist
+            // purely so `.^roles`, `.^does`, and `~~` agree with
+            // rakudo about which classes compose them. Registering
+            // them as roles (not classes) also satisfies
+            // `type_matching.rs`'s `resolve_role_key` gate for
+            // type-object `~~` (e.g. `X::Comp::FailGoal ~~ X::Comp`).
+            // `X::Nominalizable` / `X::Role::Attribute` (Slice 3) were
+            // not in the ADR's original 14 -- its corpus was a 303-name
+            // roast/t sample; Slice 3's broader capture (roast/t plus
+            // every `X::...` string literal in mutsu's own source)
+            // surfaced these two additional roles the same way.
+            for role_name in [
+                "X::Comp",
+                "X::Syntax",
+                "X::IO",
+                "X::OS",
+                "X::Trait",
+                "X::Proc::Async",
+                "X::BadType",
+                "X::Temporal",
+                "X::MOP",
+                "X::Encoding",
+                "X::Pod",
+                "X::Wrapper",
+                "X::RoleApplier",
+                "X::RoleApplier::Method",
+                "X::Nominalizable",
+                "X::Role::Attribute",
+                // Not a marker role like the rest: rakudo mixes
+                // `X::Promise::Broken` into the *cause* exception that
+                // `Promise.result` rethrows, producing the anonymous
+                // mixin type `X::AdHoc+{X::Promise::Broken}`. It is
+                // registered here so `eval_does_values` can compose it
+                // and `~~ X::Promise::Broken` answers correctly.
+                "X::Promise::Broken",
+                // Also not a marker role: rakudo's
+                // `X::AdHoc.from-slurpy(...)` mixes this into the
+                // `Capture` it stores as `.payload`, so the payload's
+                // `.^name` is `Capture+{X::AdHoc::SlurpySentry}` and
+                // `.Str` knows to concatenate rather than render the
+                // capture. Registered here so the composition can
+                // happen at all.
+                "X::AdHoc::SlurpySentry",
+            ] {
+                roles.insert(
+                    role_name.to_string(),
+                    RoleDef {
+                        attributes: Vec::new(),
+                        methods: HashMap::new(),
+                        is_stub_role: false,
+                        is_hidden: false,
+                        is_rw: false,
+                        captured_env: None,
+                        wildcard_handles: Vec::new(),
+                        role_id: 0,
+                        attribute_conflicts: Vec::new(),
+                        own_attribute_names: std::collections::HashSet::new(),
+                        deferred_body: Vec::new(),
+                        deferred_custom_traits: Vec::new(),
+                    },
+                );
+            }
+            // CompUnit::Repository role with required stub methods
+            {
+                let stub_body = vec![Stmt::Expr(Expr::Call {
+                    name: Symbol::intern("__mutsu_stub_die"),
+                    args: vec![],
+                })];
+                let stub_method = |body: Vec<Stmt>| MethodDef {
+                    lexical_package: "GLOBAL".to_string(),
+                    params: Vec::new(),
+                    param_defs: Vec::new(),
+                    body: std::sync::Arc::new(body),
+                    is_rw: false,
+                    is_raw: false,
+                    is_private: false,
+                    is_multi: false,
+                    is_my: false,
+                    role_origin: None,
+                    original_role: None,
+                    return_type: None,
+                    compiled_code: None,
+                    compiled_fns: None,
+                    delegation: None,
+                    is_default: false,
+                    deprecated_message: None,
+                    is_submethod: false,
+                    captured_env: None,
+                    source_file: None,
+                    role_param_bindings: None,
+                };
+                let mut methods = HashMap::new();
+                // Rakudo's CompUnit::Repository role requires exactly
+                // `id`, `need`, and `loaded` (a class doing the role must
+                // implement those three). `load` is NOT a required method.
+                for name in ["id", "need", "loaded"] {
+                    methods.insert(name.to_string(), vec![stub_method(stub_body.clone())]);
+                }
+                roles.insert(
+                    "CompUnit::Repository".to_string(),
+                    RoleDef {
+                        attributes: Vec::new(),
+                        methods,
+                        is_stub_role: false,
+                        is_hidden: false,
+                        is_rw: false,
+                        captured_env: None,
+                        wildcard_handles: Vec::new(),
+                        role_id: 0,
+                        attribute_conflicts: Vec::new(),
+                        own_attribute_names: std::collections::HashSet::new(),
+                        deferred_body: Vec::new(),
+                        deferred_custom_traits: Vec::new(),
+                    },
+                );
+            }
+            // `Distribution` built-in interface role. Real Rakudo defines
+            // it with required stub methods `meta` and `content`; user
+            // distribution classes (e.g. `Zef::Distribution does
+            // Distribution`) supply the implementations. Registering the
+            // role lets such classes compose and lets `~~ Distribution`
+            // recognize them.
+            {
+                let stub_body = vec![Stmt::Expr(Expr::Call {
+                    name: Symbol::intern("__mutsu_stub_die"),
+                    args: vec![],
+                })];
+                let stub_method = |body: Vec<Stmt>| MethodDef {
+                    lexical_package: "GLOBAL".to_string(),
+                    params: Vec::new(),
+                    param_defs: Vec::new(),
+                    body: std::sync::Arc::new(body),
+                    is_rw: false,
+                    is_raw: false,
+                    is_private: false,
+                    is_multi: false,
+                    is_my: false,
+                    role_origin: None,
+                    original_role: None,
+                    return_type: None,
+                    compiled_code: None,
+                    compiled_fns: None,
+                    delegation: None,
+                    is_default: false,
+                    deprecated_message: None,
+                    is_submethod: false,
+                    captured_env: None,
+                    source_file: None,
+                    role_param_bindings: None,
+                };
+                let mut methods = HashMap::new();
+                for name in ["meta", "content"] {
+                    methods.insert(name.to_string(), vec![stub_method(stub_body.clone())]);
+                }
+                roles.insert(
+                    "Distribution".to_string(),
+                    RoleDef {
+                        attributes: Vec::new(),
+                        methods,
+                        is_stub_role: false,
+                        is_hidden: false,
+                        is_rw: false,
+                        captured_env: None,
+                        wildcard_handles: Vec::new(),
+                        role_id: 0,
+                        attribute_conflicts: Vec::new(),
+                        own_attribute_names: std::collections::HashSet::new(),
+                        deferred_body: Vec::new(),
+                        deferred_custom_traits: Vec::new(),
+                    },
+                );
+            }
+            roles
+        };
+        // ADR-0029: role-to-role composition among the 16 `X::` marker
+        // roles above, re-verified against real rakudo (2026-08-19,
+        // see todo/deep/exception-class-hierarchy-is-mostly-unregistered.md
+        // R1) -- exactly three edges exist; the other thirteen compose
+        // nothing. (Slice 3 grew the marker-role list from the ADR's
+        // original 14 to 16 without re-running this measurement, which
+        // is how `X::Role::Attribute does X::RoleApplier` was missed.)
+        registry
+            .role_parents
+            .insert("X::Syntax".to_string(), vec!["X::Comp".to_string()]);
+        registry
+            .role_parents
+            .insert("X::IO".to_string(), vec!["X::OS".to_string()]);
+        registry.role_parents.insert(
+            "X::Role::Attribute".to_string(),
+            vec!["X::RoleApplier".to_string()],
+        );
+        // ADR-0029: write `register_x`'s collected `does` lists into the
+        // composed-role registries that `.^roles`, `~~`, qualified
+        // `self.Role::meth` dispatch, and method-candidate collection
+        // already read (`class_composed_roles` /
+        // `class_direct_composed_roles` / `class_does_only_roles`).
+        // `class_composed_roles` is documented as the FLATTENED set, so
+        // walk `role_parents` here to pull in roles reached
+        // transitively through a composed role's own `does` (a class
+        // doing `X::Syntax` also does `X::Comp`).
+        for (class_name, does) in &register_x_does {
+            let mut flattened: Vec<String> = does.clone();
+            let mut seen: HashSet<String> = flattened.iter().cloned().collect();
+            let mut i = 0;
+            while i < flattened.len() {
+                if let Some(parents) = registry.role_parents.get(&flattened[i]).cloned() {
+                    for p in parents {
+                        if seen.insert(p.clone()) {
+                            flattened.push(p);
+                        }
+                    }
+                }
+                i += 1;
+            }
+            registry
+                .class_composed_roles
+                .insert(class_name.clone(), flattened);
+            registry
+                .class_direct_composed_roles
+                .insert(class_name.clone(), does.clone());
+            registry
+                .class_does_only_roles
+                .insert(class_name.clone(), does.clone());
+        }
+        let class_names: Vec<String> = registry.classes.keys().cloned().collect();
+        for class_name in class_names {
+            registry.sync_accessor_entries(crate::symbol::Symbol::intern(&class_name));
+        }
+        registry
+    }
+
+    pub fn new() -> Self {
+        let mut env = HashMap::new();
+        env.insert("*PID".to_string(), Value::int(current_process_id()));
+        env.insert("*TZ".to_string(), Value::int(local_timezone_offset_secs()));
+        env.insert("@*ARGS".to_string(), Value::real_array(Vec::new()));
+        env.insert("*INIT-INSTANT".to_string(), Value::make_instant_now());
+        // Populate %*ENV with all OS environment variables so that
+        // %*ENV.keys, %*ENV.elems, and copying %*ENV work correctly. A scratch
+        // interpreter inherits the caller's env (which already carries %*ENV), so
+        // skip the OS-env sweep there.
+        if !Self::is_building_scratch() {
+            let env_hash = os_env_hash();
+            env.insert(
+                "%*ENV".to_string(),
+                Value::hash_with_data(Value::hash_arc(env_hash)),
+            );
+        }
+        env.insert(
+            "*SCHEDULER".to_string(),
+            Value::make_instance(Symbol::intern("ThreadPoolScheduler"), HashMap::new()),
+        );
 
         let mut interpreter = Self {
             user_declared_classes: std::collections::HashSet::new(),
@@ -2482,376 +2865,11 @@ impl Interpreter {
             gather_items: Vec::new(),
             gather_take_limits: Vec::new(),
             block_scope_depth: 0,
-            registry: {
-                // Built-in class definitions (PR-A slice 3: `classes` now lives in the
-                // shared Registry instead of an Interpreter field).
-                // Field-by-field init rather than `Registry { .. }` struct
-                // update: `proto_subs`/`proto_gen` are private (their
-                // mutations must flow through the gen-bumping accessors).
-                let mut registry = Registry::default();
-                registry.classes = classes;
-                registry.seed_builtin_method_entries();
-                // Built-in class -> composed-role seeds (PR-A slice 2: class metadata
-                // now lives in the shared Registry instead of an Interpreter field).
-                let ccr = &mut registry.class_composed_roles;
-                ccr.insert(
-                    "CompUnit::Repository::FileSystem".to_string(),
-                    vec!["CompUnit::Repository".to_string()],
-                );
-                // Built-in type role composition
-                ccr.insert(
-                    "Int".to_string(),
-                    vec!["Real".to_string(), "Numeric".to_string()],
-                );
-                ccr.insert(
-                    "Num".to_string(),
-                    vec!["Real".to_string(), "Numeric".to_string()],
-                );
-                ccr.insert(
-                    "Rat".to_string(),
-                    vec![
-                        "Rational[Int,Int]".to_string(),
-                        "Real".to_string(),
-                        "Numeric".to_string(),
-                    ],
-                );
-                ccr.insert(
-                    "FatRat".to_string(),
-                    vec![
-                        "Rational[Int,Int]".to_string(),
-                        "Real".to_string(),
-                        "Numeric".to_string(),
-                    ],
-                );
-                ccr.insert("Complex".to_string(), vec!["Numeric".to_string()]);
-                ccr.insert("Str".to_string(), vec!["Stringy".to_string()]);
-                // Built-in role definitions (PR-A slice 4: roles now live in the
-                // shared Registry instead of an Interpreter field).
-                registry.roles = {
-                    let mut roles = rustc_hash::FxHashMap::default();
-                    roles.insert(
-                        "Encoding".to_string(),
-                        RoleDef {
-                            attributes: Vec::new(),
-                            methods: HashMap::new(),
-                            is_stub_role: false,
-                            is_hidden: false,
-                            is_rw: false,
-                            captured_env: None,
-                            wildcard_handles: Vec::new(),
-                            role_id: 0,
-                            attribute_conflicts: Vec::new(),
-                            own_attribute_names: std::collections::HashSet::new(),
-                            deferred_body: Vec::new(),
-                            deferred_custom_traits: Vec::new(),
-                        },
-                    );
-                    roles.insert(
-                        "Iterator".to_string(),
-                        RoleDef {
-                            attributes: Vec::new(),
-                            methods: HashMap::new(),
-                            is_stub_role: false,
-                            is_hidden: false,
-                            is_rw: false,
-                            captured_env: None,
-                            wildcard_handles: Vec::new(),
-                            role_id: 0,
-                            attribute_conflicts: Vec::new(),
-                            own_attribute_names: std::collections::HashSet::new(),
-                            deferred_body: Vec::new(),
-                            deferred_custom_traits: Vec::new(),
-                        },
-                    );
-                    roles.insert(
-                        "PredictiveIterator".to_string(),
-                        RoleDef {
-                            attributes: Vec::new(),
-                            methods: HashMap::new(),
-                            is_stub_role: false,
-                            is_hidden: false,
-                            is_rw: false,
-                            captured_env: None,
-                            wildcard_handles: Vec::new(),
-                            role_id: 0,
-                            attribute_conflicts: Vec::new(),
-                            own_attribute_names: std::collections::HashSet::new(),
-                            deferred_body: Vec::new(),
-                            deferred_custom_traits: Vec::new(),
-                        },
-                    );
-                    roles.insert(
-                        "Iterable".to_string(),
-                        RoleDef {
-                            attributes: Vec::new(),
-                            methods: HashMap::new(),
-                            is_stub_role: false,
-                            is_hidden: false,
-                            is_rw: false,
-                            captured_env: None,
-                            wildcard_handles: Vec::new(),
-                            role_id: 0,
-                            attribute_conflicts: Vec::new(),
-                            own_attribute_names: std::collections::HashSet::new(),
-                            deferred_body: Vec::new(),
-                            deferred_custom_traits: Vec::new(),
-                        },
-                    );
-                    roles.insert(
-                        "X::Control".to_string(),
-                        RoleDef {
-                            attributes: Vec::new(),
-                            methods: HashMap::new(),
-                            is_stub_role: false,
-                            is_hidden: false,
-                            is_rw: false,
-                            captured_env: None,
-                            wildcard_handles: Vec::new(),
-                            role_id: 0,
-                            attribute_conflicts: Vec::new(),
-                            own_attribute_names: std::collections::HashSet::new(),
-                            deferred_body: Vec::new(),
-                            deferred_custom_traits: Vec::new(),
-                        },
-                    );
-                    // ADR-0029: role-shaped `X::` exception "namespaces".
-                    // Measured against real rakudo (2026-08-17), 59% of the
-                    // `X::` classes mutsu raises or tests against compose one
-                    // or more of these marker roles rather than inheriting
-                    // from a same-named class -- `X::Comp`, `X::Syntax`,
-                    // `X::IO`, and `X::OS` are the heavily-used ones (135/69/
-                    // 22/22 classes respectively), the rest are 1-7 each. All
-                    // are empty-bodied here, as they are in rakudo too: mutsu's
-                    // exception machinery supplies the behaviour, these exist
-                    // purely so `.^roles`, `.^does`, and `~~` agree with
-                    // rakudo about which classes compose them. Registering
-                    // them as roles (not classes) also satisfies
-                    // `type_matching.rs`'s `resolve_role_key` gate for
-                    // type-object `~~` (e.g. `X::Comp::FailGoal ~~ X::Comp`).
-                    // `X::Nominalizable` / `X::Role::Attribute` (Slice 3) were
-                    // not in the ADR's original 14 -- its corpus was a 303-name
-                    // roast/t sample; Slice 3's broader capture (roast/t plus
-                    // every `X::...` string literal in mutsu's own source)
-                    // surfaced these two additional roles the same way.
-                    for role_name in [
-                        "X::Comp",
-                        "X::Syntax",
-                        "X::IO",
-                        "X::OS",
-                        "X::Trait",
-                        "X::Proc::Async",
-                        "X::BadType",
-                        "X::Temporal",
-                        "X::MOP",
-                        "X::Encoding",
-                        "X::Pod",
-                        "X::Wrapper",
-                        "X::RoleApplier",
-                        "X::RoleApplier::Method",
-                        "X::Nominalizable",
-                        "X::Role::Attribute",
-                        // Not a marker role like the rest: rakudo mixes
-                        // `X::Promise::Broken` into the *cause* exception that
-                        // `Promise.result` rethrows, producing the anonymous
-                        // mixin type `X::AdHoc+{X::Promise::Broken}`. It is
-                        // registered here so `eval_does_values` can compose it
-                        // and `~~ X::Promise::Broken` answers correctly.
-                        "X::Promise::Broken",
-                        // Also not a marker role: rakudo's
-                        // `X::AdHoc.from-slurpy(...)` mixes this into the
-                        // `Capture` it stores as `.payload`, so the payload's
-                        // `.^name` is `Capture+{X::AdHoc::SlurpySentry}` and
-                        // `.Str` knows to concatenate rather than render the
-                        // capture. Registered here so the composition can
-                        // happen at all.
-                        "X::AdHoc::SlurpySentry",
-                    ] {
-                        roles.insert(
-                            role_name.to_string(),
-                            RoleDef {
-                                attributes: Vec::new(),
-                                methods: HashMap::new(),
-                                is_stub_role: false,
-                                is_hidden: false,
-                                is_rw: false,
-                                captured_env: None,
-                                wildcard_handles: Vec::new(),
-                                role_id: 0,
-                                attribute_conflicts: Vec::new(),
-                                own_attribute_names: std::collections::HashSet::new(),
-                                deferred_body: Vec::new(),
-                                deferred_custom_traits: Vec::new(),
-                            },
-                        );
-                    }
-                    // CompUnit::Repository role with required stub methods
-                    {
-                        let stub_body = vec![Stmt::Expr(Expr::Call {
-                            name: Symbol::intern("__mutsu_stub_die"),
-                            args: vec![],
-                        })];
-                        let stub_method = |body: Vec<Stmt>| MethodDef {
-                            lexical_package: "GLOBAL".to_string(),
-                            params: Vec::new(),
-                            param_defs: Vec::new(),
-                            body: std::sync::Arc::new(body),
-                            is_rw: false,
-                            is_raw: false,
-                            is_private: false,
-                            is_multi: false,
-                            is_my: false,
-                            role_origin: None,
-                            original_role: None,
-                            return_type: None,
-                            compiled_code: None,
-                            compiled_fns: None,
-                            delegation: None,
-                            is_default: false,
-                            deprecated_message: None,
-                            is_submethod: false,
-                            captured_env: None,
-                            source_file: None,
-                            role_param_bindings: None,
-                        };
-                        let mut methods = HashMap::new();
-                        // Rakudo's CompUnit::Repository role requires exactly
-                        // `id`, `need`, and `loaded` (a class doing the role must
-                        // implement those three). `load` is NOT a required method.
-                        for name in ["id", "need", "loaded"] {
-                            methods.insert(name.to_string(), vec![stub_method(stub_body.clone())]);
-                        }
-                        roles.insert(
-                            "CompUnit::Repository".to_string(),
-                            RoleDef {
-                                attributes: Vec::new(),
-                                methods,
-                                is_stub_role: false,
-                                is_hidden: false,
-                                is_rw: false,
-                                captured_env: None,
-                                wildcard_handles: Vec::new(),
-                                role_id: 0,
-                                attribute_conflicts: Vec::new(),
-                                own_attribute_names: std::collections::HashSet::new(),
-                                deferred_body: Vec::new(),
-                                deferred_custom_traits: Vec::new(),
-                            },
-                        );
-                    }
-                    // `Distribution` built-in interface role. Real Rakudo defines
-                    // it with required stub methods `meta` and `content`; user
-                    // distribution classes (e.g. `Zef::Distribution does
-                    // Distribution`) supply the implementations. Registering the
-                    // role lets such classes compose and lets `~~ Distribution`
-                    // recognize them.
-                    {
-                        let stub_body = vec![Stmt::Expr(Expr::Call {
-                            name: Symbol::intern("__mutsu_stub_die"),
-                            args: vec![],
-                        })];
-                        let stub_method = |body: Vec<Stmt>| MethodDef {
-                            lexical_package: "GLOBAL".to_string(),
-                            params: Vec::new(),
-                            param_defs: Vec::new(),
-                            body: std::sync::Arc::new(body),
-                            is_rw: false,
-                            is_raw: false,
-                            is_private: false,
-                            is_multi: false,
-                            is_my: false,
-                            role_origin: None,
-                            original_role: None,
-                            return_type: None,
-                            compiled_code: None,
-                            compiled_fns: None,
-                            delegation: None,
-                            is_default: false,
-                            deprecated_message: None,
-                            is_submethod: false,
-                            captured_env: None,
-                            source_file: None,
-                            role_param_bindings: None,
-                        };
-                        let mut methods = HashMap::new();
-                        for name in ["meta", "content"] {
-                            methods.insert(name.to_string(), vec![stub_method(stub_body.clone())]);
-                        }
-                        roles.insert(
-                            "Distribution".to_string(),
-                            RoleDef {
-                                attributes: Vec::new(),
-                                methods,
-                                is_stub_role: false,
-                                is_hidden: false,
-                                is_rw: false,
-                                captured_env: None,
-                                wildcard_handles: Vec::new(),
-                                role_id: 0,
-                                attribute_conflicts: Vec::new(),
-                                own_attribute_names: std::collections::HashSet::new(),
-                                deferred_body: Vec::new(),
-                                deferred_custom_traits: Vec::new(),
-                            },
-                        );
-                    }
-                    roles
-                };
-                // ADR-0029: role-to-role composition among the 16 `X::` marker
-                // roles above, re-verified against real rakudo (2026-08-19,
-                // see todo/deep/exception-class-hierarchy-is-mostly-unregistered.md
-                // R1) -- exactly three edges exist; the other thirteen compose
-                // nothing. (Slice 3 grew the marker-role list from the ADR's
-                // original 14 to 16 without re-running this measurement, which
-                // is how `X::Role::Attribute does X::RoleApplier` was missed.)
-                registry
-                    .role_parents
-                    .insert("X::Syntax".to_string(), vec!["X::Comp".to_string()]);
-                registry
-                    .role_parents
-                    .insert("X::IO".to_string(), vec!["X::OS".to_string()]);
-                registry.role_parents.insert(
-                    "X::Role::Attribute".to_string(),
-                    vec!["X::RoleApplier".to_string()],
-                );
-                // ADR-0029: write `register_x`'s collected `does` lists into the
-                // composed-role registries that `.^roles`, `~~`, qualified
-                // `self.Role::meth` dispatch, and method-candidate collection
-                // already read (`class_composed_roles` /
-                // `class_direct_composed_roles` / `class_does_only_roles`).
-                // `class_composed_roles` is documented as the FLATTENED set, so
-                // walk `role_parents` here to pull in roles reached
-                // transitively through a composed role's own `does` (a class
-                // doing `X::Syntax` also does `X::Comp`).
-                for (class_name, does) in &register_x_does {
-                    let mut flattened: Vec<String> = does.clone();
-                    let mut seen: HashSet<String> = flattened.iter().cloned().collect();
-                    let mut i = 0;
-                    while i < flattened.len() {
-                        if let Some(parents) = registry.role_parents.get(&flattened[i]).cloned() {
-                            for p in parents {
-                                if seen.insert(p.clone()) {
-                                    flattened.push(p);
-                                }
-                            }
-                        }
-                        i += 1;
-                    }
-                    registry
-                        .class_composed_roles
-                        .insert(class_name.clone(), flattened);
-                    registry
-                        .class_direct_composed_roles
-                        .insert(class_name.clone(), does.clone());
-                    registry
-                        .class_does_only_roles
-                        .insert(class_name.clone(), does.clone());
-                }
-                let class_names: Vec<String> = registry.classes.keys().cloned().collect();
-                for class_name in class_names {
-                    registry.sync_accessor_entries(crate::symbol::Symbol::intern(&class_name));
-                }
-                Arc::new(RwLock::new(Arc::new(registry)))
-            },
+            registry: Arc::new(RwLock::new(Arc::new(if Self::is_building_scratch() {
+                Registry::default()
+            } else {
+                Self::build_builtin_registry()
+            }))),
             registry_write_gen: std::sync::atomic::AtomicU64::new(0),
             proto_dispatch_stack: Vec::new(),
             pending_dispatch_error: None,

--- a/src/value/match_view.rs
+++ b/src/value/match_view.rs
@@ -128,6 +128,21 @@ impl Value {
         }
     }
 
+    /// Identity of the capture node behind a still-lazy `Match`: two Match
+    /// values that present the SAME stored node compare equal here.
+    ///
+    /// A non-suppressing alias (`<x=rule>`) files one node under both names,
+    /// so `$<x>` and `$<rule>` are the same cursor (raku: `$<x> === $<rule>`).
+    /// The grammar action walk uses this to dispatch such a node's action once
+    /// per parent instead of once per slot — firing it per slot multiplied
+    /// exponentially through nested aliases. `None` once the Match has been
+    /// rebuilt into an eager `Instance` (no shared node to compare).
+    pub(crate) fn match_node_identity(&self) -> Option<usize> {
+        self.0
+            .as_match_node()
+            .map(|node| Arc::as_ptr(&node.cap) as usize)
+    }
+
     /// A Match equal to `self` with the given attributes replaced — the
     /// rebuild pattern every post-hoc attribute write (`.made`/`ast`,
     /// `actions`, `capture_alias_map`, `orig`, `named`, `list`) uses.

--- a/t/grammar-alias-action-fires-once.t
+++ b/t/grammar-alias-action-fires-once.t
@@ -1,0 +1,54 @@
+use Test;
+
+# A non-suppressing alias `<x=rule>` files ONE capture under both `x` and
+# `rule` (raku: `$<x> === $<rule>`), so its action method must fire exactly
+# once. mutsu used to store two independent copies of the node and dispatch
+# each of them, which fired the whole matched subtree's actions twice per
+# alias level -- compounding to 2^depth for nested aliases (a leaf action ran
+# 256 times on `benchmarks/bench-yaml-parse.raku`, whose YAMLish grammar
+# aliases `<str=space>` and friends eight levels deep).
+
+plan 8;
+
+my %fired;
+
+grammar Flat {
+    token TOP { <x=leaf> }
+    token leaf { 'x' }
+}
+grammar Nested {
+    token TOP { <a=one> }
+    token one { <b=two> }
+    token two { <c=leaf> }
+    token leaf { 'x' }
+}
+grammar Alternation {
+    token TOP { [ <c=a> | <c=b> ]* }
+    token a { 'x' }
+    token b { 'y' }
+}
+
+class Actions {
+    method leaf($/) { %fired<leaf>++; make 'LEAF' }
+    method one($/)  { %fired<one>++ }
+    method two($/)  { %fired<two>++ }
+    method a($/)    { %fired<a>++ }
+    method b($/)    { %fired<b>++ }
+}
+
+%fired = ();
+my $flat = Flat.parse('x', :actions(Actions));
+is %fired<leaf>, 1, 'aliased capture fires its action once';
+is $flat<x>.made, 'LEAF', 'the alias name carries .made';
+is $flat<leaf>.made, 'LEAF', 'the rule name carries the same .made';
+ok $flat<x> === $flat<leaf>, 'both names are the same Match object';
+
+%fired = ();
+Nested.parse('x', :actions(Actions));
+is %fired<leaf>, 1, 'nested aliases do not multiply the leaf action';
+is-deeply (%fired<one>, %fired<two>), (1, 1), 'each intermediate alias fires once';
+
+%fired = ();
+Alternation.parse('xyx', :actions(Actions));
+is %fired<a>, 2, 'aliased alternative fires once per match (a)';
+is %fired<b>, 1, 'aliased alternative fires once per match (b)';

--- a/todo/perf/yaml-parse-throughput.md
+++ b/todo/perf/yaml-parse-throughput.md
@@ -1,4 +1,75 @@
-# Parsing YAML with the bundled `YAMLish` is still ~5-35x slower than raku
+# Parsing YAML with the bundled `YAMLish`: now at/near raku, deeper documents still ~2x
+
+**Update (2026-09-06, round 10): the dominant cost was never the regex engine
+-- it was an exponential grammar-action bug plus 207 wasted interpreter
+constructions per parse. `benchmarks/bench-yaml-parse.raku` goes 1.14s ->
+0.138s (8.3x), which is 2.5x FASTER than rakudo on the same box; a 120-row
+document lands at 0.96s against rakudo's 0.44s (2.2x, measured after (a);
+its pre-round-10 time was not measured).** Three landed changes,
+each found by measurement rather than by reading code:
+
+**(a) An aliased capture's action fired 2^depth times (a correctness bug).**
+The round-7/8/9 sessions were chasing `Value::view()` materialization sites
+while the actual multiplier sat in the action walk. Counting how often each
+YAMLish action method runs -- on an instrumented copy of the module, under
+mutsu and under rakudo 2026.07 -- showed mutsu running **40115** action
+methods to rakudo's **997**, with `space` firing **256 times per matched
+space character** (2^8). Root cause: a non-suppressing alias `<x=rule>` files
+the capture under both names, and mutsu stored two INDEPENDENT nodes (the
+second a deep clone of the whole matched subtree), so the action walk
+dispatched each slot; nested aliases compounded. Both slots now share one
+`Arc<CapNode>` -- which is also what `$<x> === $<rule>` means, and mutsu now
+answers `True` there like raku -- and the walk dispatches at most once per
+capture node per parent. Pinned by `t/grammar-alias-action-fires-once.t`
+(verified against rakudo). Effect: 1.14s -> 0.34s; opcodes executed 75595 ->
+2877, `env_deep_copies` 41360 -> 580, `match_materializations` 1743 -> 69.
+Details: `news/2026-09/grammar-alias-action-exponential-firing.md`.
+
+**(b) Regex scratch interpreters built the whole built-in registry.** With
+(a) landed, a fresh callgrind profile put ~48% of the run in
+`Interpreter::new`, called **207 times per parse** from the regex paths
+(`eval_regex_expr_value` 102x, `resolve_token_patterns_with_args_in_pkg`
+56x, `regex_match_atom_in_pkg_inner` 36x, ...). Every one of those scratch
+interpreters had its registry replaced by the caller immediately afterwards,
+so building ~450 `ClassDef`s and seeding their method entries was pure waste.
+`copy_decl_registry_into` now shares the parent's copy-on-write
+`Arc<Registry>` (O(1), a strict superset of the four maps it used to clone),
+and `Interpreter::new` skips the built-in registry under the existing
+`BUILDING_SCRATCH` flag. Effect: 0.34s -> 0.138s, and the whole `t/` suite's
+CPU time drops ~11%. Details:
+`news/2026-09/scratch-interpreter-skips-builtin-registry.md`.
+
+**(c) `sync_accessor_entries` scanned the entire method table per call.**
+12.7% of the pre-(b) profile, because `Interpreter::new` calls it once per
+built-in class. Now index-accelerated via `Registry::owner_accessor_names`.
+Mostly subsumed by (b) for THIS benchmark (the calls themselves went away),
+but it is the general fix for any class-declaring program. Details:
+`news/2026-09/registry-accessor-column-index.md`.
+
+**Method note for future rounds -- this is the lesson of rounds 7-9 vs round
+10.** Three rounds of `MUTSU_VM_STATS` counter-diffing and gdb hit-count
+sweeps localized real inefficiencies but never found the multiplier, because
+every counter they compared was mutsu-against-mutsu. What found it in one
+step was comparing mutsu against **rakudo on the same workload**: instrument
+the module's own action methods with a counter hash, run both, and diff. A
+40x gap in "how many times does this user-visible callback run" is invisible
+to any internal counter and obvious in that comparison. Also: `valgrind
+--tool=callgrind` + `callgrind_annotate --tree=both` gives a deterministic,
+contention-proof caller-attributed profile, which is exactly what this
+ticket's own "measurement caveat" section says local wall-clock and `perf`
+sampling on this box could not.
+
+**What is left (in the round-10 profile of a 120-row document, 6.7 Bn Ir):**
+no single dominant site any more -- allocator traffic
+(`malloc`/`free`/`_int_malloc`) ~20%, `memcpy` 6.7%, `LocalKey::with` 5.7%
+(mostly `Symbol::intern`, ~1.3M calls), SipHash `Hasher::write` + `hash_one`
+8.1% (std `HashMap`s on regex-capture paths that could be `FxHashMap`), and
+the regex matcher's own `regex_match_ends_from_caps_in_pkg_impl` /
+`regex_match_atom_all_with_capture_in_pkg_inner` ~4.4%. The remaining ~2x
+against rakudo on larger documents is that flat allocation/hashing tail, not
+one call site. Items 3 (candidate enumeration) and 4 (per-leaf Match
+construction) below are the shape of that tail.
+
 
 **Update (2026-08-15, round 9): the three round-7-identified-but-unfixed unguarded
 `Value::view()` sites are now fixed** — `OpCode::GetGlobal` (`vm_exec_dispatch.rs`),


### PR DESCRIPTION
Round 10 of `todo/perf/yaml-parse-throughput.md`. The dominant cost was never the regex
engine: it was an exponential grammar-action bug plus 207 wasted interpreter constructions
per parse.

`benchmarks/bench-yaml-parse.raku` (release, idle box, median of 7 runs):

| | time |
| --- | ---: |
| before (this branch's merge base) | 1.14s |
| after | **0.138s** |
| rakudo 2026.07, same box | 0.340s |

8.3x faster, and now 2.5x faster than rakudo on that benchmark. A 120-row YAML document
lands at 0.96s against rakudo's 0.44s. The `t/` suite's own total CPU time drops ~11%,
since every grammar-using test paid the second bug.

## 1. An aliased capture's action fired 2^depth times (a correctness bug)

A non-suppressing alias `<x=rule>` files the capture under **both** the alias name and the
rule's own name, matching Rakudo — where they are the *same* cursor (`$<x> === $<rule>` is
`True`). mutsu stored two **independent** copies of the node, the second a deep clone of the
whole matched subtree, and the grammar action walk dispatched each slot on its own. The
duplication happens at every level, so nested aliases multiplied it:

```raku
grammar E3 {
    token TOP { <x=l1> }; token l1 { <y=l2> };
    token l2 { <z=l3> };  token l3 { 'x' }
}
```

raku fires each of `l1`/`l2`/`l3` once; mutsu fired them 2/4/**8** times. An action method
with side effects therefore ran up to `2^depth` times.

YAMLish exercises this hard (`<str=single-bare> | <str=single-quotes> | <str=space>`, eight
alias levels deep): the `space` action fired **256 times per matched space character**, and
the parse ran **40115** action methods where rakudo runs **997**.

Both slots now push the same `Arc<CapNode>` — no subtree clone, and mutsu answers `True` for
`$<x> === $<rule>` too — and the action walk dispatches at most once per capture node per
parent, handing the second slot the same updated Match so the `.made` from that single
dispatch still reaches both names. Pinned by `t/grammar-alias-action-fires-once.t`, which was
verified to pass under rakudo 2026.07 first.

Counted rather than timed, on the benchmark: opcodes executed 75595 -> 2877,
`dual-store: env_deep_copies` 41360 -> 580, `match_materializations` 1743 -> 69.

## 2. Regex scratch interpreters built the whole built-in registry

With (1) landed, a callgrind profile put ~48% of the run in `Interpreter::new`, called **207
times per parse** from the regex paths (`eval_regex_expr_value` 102x,
`resolve_token_patterns_with_args_in_pkg` 56x, `regex_match_atom_in_pkg_inner` 36x, ...).
Each of those scratch interpreters built ~450 `ClassDef`s, the `X::` hierarchy and a seeded
method table — then had its registry replaced by the caller before it ran anything.

`copy_decl_registry_into` now shares the parent's copy-on-write `Arc<Registry>` (what
`copy_full_registry_into` already did for the actions path): O(1) instead of four map clones
plus a registry write, and a strict superset of the data it used to copy. With no caller
reading the scratch's self-built registry, `Interpreter::new` skips building it under the
existing `BUILDING_SCRATCH` flag; the construction moves verbatim into
`Interpreter::build_builtin_registry`. `registry-cow: clones` stays 0 on the benchmark, so
this is not trading construction for copy-on-write clones.

## 3. `sync_accessor_entries` scanned the entire method table per call

12.7% of the pre-(2) profile, because `Interpreter::new` calls it once per built-in class,
making construction quadratic in the built-in table. Added `Registry::owner_accessor_names`,
the accessor-column twin of the existing `owner_method_names` reverse index —
`sync_accessor_entries` is the only writer of that column and `entry_is_live` keeps accessor
rows alive, so the index is exact. `replace_method_entries_from` copies it, and the
`MUTSU_CHECK_METHOD_INDEX` verifier checks both directions of it.

## Verification

- `prove -e target/debug/mutsu t/`: 3720 files, 38269 tests. The only failure is
  `t/io-path-smartmatch-permissions.t`, which fails in this container because it runs as
  **root** (every file is writable to uid 0) — unrelated to the change.
- `make roast` (full whitelist): 1436 files, 218939 tests. Failures are the same
  root-permission family (`6.c/S32-io/file-tests.t`, `S16-filehandles/filetest.t` — "File
  with r-- is not writable") plus one `S32-io/IO-Socket-Async.t` timeout.
- `cargo fmt`, `cargo clippy -- -D warnings` clean; class/attribute/role/grammar tests also
  run with `MUTSU_CHECK_METHOD_INDEX=1` to exercise the new index verifier.
- The wall-clock numbers above are local (idle box, median of 7); `bench-history.tsv` on
  `bench-data` is the authoritative series and will confirm them after merge.

## Method note

Rounds 7-9 spent three sessions diffing mutsu's own counters against mutsu and never found
this multiplier. What found it in one step was comparing against **rakudo on the same
workload**: instrument the module's own action methods with a counter hash, run both, diff. A
40x gap in how often a user-visible callback runs is invisible to any internal counter.
`valgrind --tool=callgrind` + `callgrind_annotate --tree=both` also gave the deterministic,
caller-attributed profile this ticket's own "measurement caveat" section says local
wall-clock and `perf` sampling on this box could not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YH8RUdVVCqRpsQ8m9qiVTc

---
_Generated by [Claude Code](https://claude.ai/code/session_01YH8RUdVVCqRpsQ8m9qiVTc)_