### PR TITLE
docs: narrow the chained-Z ticket — the bracket spelling is silently wrong

### DIFF
--- a/todo/tickets/zip-chain-with-a-comma-list-left-operand-fails-to-parse.md
+++ b/todo/tickets/zip-chain-with-a-comma-list-left-operand-fails-to-parse.md
@@ -31,14 +31,74 @@ and `Zop`), so `1, 2 Z <a b c> Z <x y>` parses in raku as one n-ary zip of
 three lists with `1, 2` as the first — mutsu appears to close the list after
 the first `Z` and then find a second `Z` with nothing to its left.
 
+## Narrowed further, 2026-09-06 (a second session, same day)
+
+**The bracket spelling is worse than the paren one: it parses and answers
+wrongly.** That is a silent wrong answer, not a refusal, and it was not in the
+first pass:
+
+```raku
+say [1, 2 Z <a b> Z <c d>].raku;
+# raku:  [(1, "a", "c"), (2, "b", "d")]
+# mutsu: [(1, "c"), (((2, "a"),).Seq, "d")]
+```
+
+`my @r = 1, 2 Z <a b> Z <c d>` produces the same wrong value. So the family is
+one defect with two faces: where the bracket/assign spellings mis-associate, the
+paren spelling leaves the tail unconsumed and the statement layer reports
+`Confused. Two terms in a row`.
+
+Reading the wrong value tells you the shape: mutsu builds
+`[1, ((2 Z <a b>) Z <c d>)]` — the comma list keeps `1` as its own item and the
+**whole** `Z` chain becomes the last item — and then lifts only one level, so
+`1` lands beside the *inner* zip's result instead of beside `2`.
+
+### The chain-aware lift already exists and is not being reached
+
+`lift_meta_ops_in_paren_list` (`src/parser/primary/container/meta_ops.rs`) is
+already written for exactly this: it walks the left-nested same-op chain in a
+`while` loop, collects each `right` as a column, and folds the preceding comma
+items into the first column. It is called from `finalize_paren_list`.
+
+So the fix is probably **not** to write a new lift — it is to find why that one
+does not see this shape. For the paren spelling the list never finishes
+(`finalize_paren_list` is never reached); for the bracket/assign spellings the
+one-level lift in `src/parser/stmt/args.rs:48` runs instead, which does
+`items.push(*left)` on the *outermost* MetaOp and therefore cannot handle a
+chain.
+
+### What already works, and bounds the fix
+
+| Program | mutsu |
+|---|---|
+| `1, 2 X <a b> X <c d>` | correct (8 elements, same as raku) |
+| `1, 2 Z+ <3 4> Z+ <5 6>` | correct value `(9, 12)` |
+| `(1, 2) Z <a b> Z <c d>` | correct — parenthesised left operand |
+| `1 Z <a b> Z <c d>` | correct — single left operand |
+| `1, 2 Z <a b>` | correct — single `Z` |
+| `1, 2 Z <a b>, 3` | correct |
+| `1, 2 Z <a b> X <c d>` | correctly refused as non-associative |
+
+`X` chaining correctly through the same comma-list shape is the strongest hint
+that this is reachable without new machinery: whatever path `X` takes, `Z` is
+not taking it.
+
+One unrelated nit noticed while measuring: `(1, 2 Z+ <3 4> Z+ <5 6>).raku` is
+`(9, 12).Seq` in raku and `(9, 12)` in mutsu — the value is right, the type is
+not. Not part of this ticket.
+
 ## Where to look
 
-The list-infix chain handling in the parser (`src/parser/`), specifically how a
-comma list on the left of a list infix is closed off before the next operator of
-the same precedence is read.
+`src/parser/primary/container/paren.rs` (the comma loop that reads each item
+with `expression_no_sequence` and never completes for this shape),
+`src/parser/primary/container/meta_ops.rs` (`lift_meta_ops_in_paren_list`, the
+chain-aware lift that should be doing this work), and
+`src/parser/stmt/args.rs:48` (the one-level lift the bracket/assign spellings
+use instead).
 
 ## Neighbourhood to check when fixing
 
-The other list infixes at that level: `X`, `Xop`, `Zop` (`1, 2 Z+ <3 4> Z+ ...`),
-and `xx`. Also the reverse shape (a comma list on the *right* of the second
-operator), and a three-`Z` chain.
+The other list infixes at that level: `X`, `Xop`, `Zop`, and `xx`. Also the
+reverse shape (a comma list on the *right* of the second operator), a three-`Z`
+chain, the `[...]`/`my @a = ...`/`my $x = (...)` spellings above (each takes a
+different path today), and `.Seq`-ness of the result.


### PR DESCRIPTION
Follow-up investigation on the `zip-chain-with-a-comma-list-left-operand` ticket filed earlier today (#7382). Three things it did not know:

**The bracket and assign spellings do not refuse — they answer wrongly.**

```raku
say [1, 2 Z <a b> Z <c d>].raku;
# raku:  [(1, "a", "c"), (2, "b", "d")]
# mutsu: [(1, "c"), (((2, "a"),).Seq, "d")]
```

`my @r = 1, 2 Z <a b> Z <c d>` does the same. So this is a **silent wrong answer** whose paren-shaped face is the parse failure the ticket was filed for — strictly worse than first recorded.

**The wrong value names the shape.** mutsu builds `[1, ((2 Z <a b>) Z <c d>)]` — the comma list keeps `1` as its own item while the whole chain becomes the last item — then lifts one level, landing `1` beside the inner zip's *result* instead of beside `2`.

**The chain-aware lift already exists and is not being reached.** `lift_meta_ops_in_paren_list` walks the left-nested same-op chain in a `while` loop and folds preceding comma items into the first column — exactly this job. The paren spelling never finishes its list so `finalize_paren_list` never calls it; the bracket/assign spellings take the one-level lift in `src/parser/stmt/args.rs:48` instead, which pushes the *outermost* MetaOp's left operand and cannot handle a chain. That `X` chains correctly through the identical comma-list shape points the same way: this is a routing question, not missing machinery.

The ticket now carries a bounding table (which spellings work, which are wrong, which refuse), the three files to look at, and a wider neighbourhood list.

Not fixed here on purpose: the paren item loop's failure needs a parser change whose blast radius deserves its own slice rather than being rushed at the end of a session.

Docs/todo only, so the four heavy CI jobs skip by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)