### PR TITLE
fix: three general bugs behind the Crane/Config::TOML battery gate

### DIFF
--- a/docs/batteries/toml.md
+++ b/docs/batteries/toml.md
@@ -36,6 +36,19 @@ elsewhere is `✗ Crane error: associative key does not exist`, plus a hard pars
 error in `t/patch.rakutest` and a 90s timeout in
 `Config::TOML`'s `t/grammar/03-inline-tables.rakutest`.
 
+**Re-measured 2026-09-06** (fresh clone of both dists, each suite run from its
+own directory against a debug build): **`Config::TOML` 10/19, `Crane` 3/15**.
+The `0/19` above is stale — the `\UXXXXXXXX` escape (item 2's residue) and the
+`grammar/03-inline-tables` timeout (item 4) are both fixed, and half the
+`Config::TOML` suite passes now. `Crane` is unchanged at the file level but its
+assertion-level failures moved: the "Original container is unchanged" cluster in
+`t/add.rakutest` went 5 → 1 once two general bugs were fixed (a sigilless
+parameter re-read the caller's variable out of a stale `env` instead of using
+the argument; `.isa` answered False for every role type object). The current
+blocker list, with what is stale and what is still open, is in
+`todo/deep/config-toml-battery-core-blockers.md` — read that, not the
+2026-08-22 work list below.
+
 ```raku
 use Config::TOML;
 my %config = from-toml('example.toml'.IO.slurp);   # not yet runnable on mutsu

--- a/src/runtime/accessors_stack.rs
+++ b/src/runtime/accessors_stack.rs
@@ -484,6 +484,17 @@ impl Interpreter {
     /// The common case — mainline code under `GLOBAL` — returns a single
     /// element, so callers pay one small `Vec` for what used to be two
     /// hard-coded `format!`s.
+    ///
+    /// NOTE: for a *compound declared name* (`class HTTP::HPACK::Decoder { ...
+    /// }` written at file scope), the `::` segments are not real lexical scopes
+    /// in raku — but this walk must still cross them, because they are also how
+    /// mutsu models a module compunit's *file-scope* lexicals: `HTTP::HPACK`'s
+    /// own `sub decode-int` is registered under `HTTP::HPACK` and reached from
+    /// `HTTP::HPACK::Decoder`'s methods only by stripping a segment. Cutting the
+    /// walk there breaks every bundled module written in that (very common)
+    /// shape. The compound-name distinction is enforced for *type* names, where
+    /// a precise registration-time record exists — see
+    /// `Registry::compound_declared_types`.
     pub(crate) fn bare_name_packages(&self) -> Vec<String> {
         let cur = self.current_package();
         let lexical = self

--- a/src/runtime/methods_instance_ops.rs
+++ b/src/runtime/methods_instance_ops.rs
@@ -2272,6 +2272,18 @@ impl Interpreter {
                         base = parent_base;
                     }
                 }
+                // A role type object has no class MRO of its own — `class_mro`
+                // on a role name yields just that name, so every probe answered
+                // False. raku answers `.isa` for it from the chain the role's
+                // *pun* would have, which is exactly `Any` then `Mu`:
+                // `Associative.isa(Any)`, `Positional.isa(Mu)` and
+                // `role R {}; R.isa(Any)` are all True, while `.isa` of any
+                // other type — including a role the role itself `does`
+                // (`role B does A {}; B.isa(A)`) — is False. `.does` remains
+                // the operator that answers role composition.
+                if self.is_role_type_name(&pkg_name) {
+                    return Ok(Value::truth(target_name == "Any" || target_name == "Mu"));
+                }
                 Ok(Value::truth(
                     self.class_mro(&pkg_name)
                         .contains(&crate::symbol::Symbol::intern(&target_name)),

--- a/src/runtime/registration_class_decl.rs
+++ b/src/runtime/registration_class_decl.rs
@@ -186,6 +186,7 @@ impl Interpreter {
         } else {
             self.registry_mut().lexical_classes.remove(name);
         }
+        self.note_compound_declared_type(name);
 
         let (self_named_does_roles, deferred_custom_traits) =
             self.validate_class_parents(name, parents, does_parents, hidden_parents)?;

--- a/src/runtime/registry.rs
+++ b/src/runtime/registry.rs
@@ -214,6 +214,23 @@ pub(crate) struct Registry {
     /// error for an unrelated `EVAL q[class Foo {}]` (verified against real
     /// `raku`, which allows it — see `t/eval-class-redeclaration-cross-boundary.t`).
     pub(crate) lexical_classes: HashSet<String>,
+    /// Registry keys whose `::` segments come from a **compound declared name**
+    /// (`class Foo::List { ... }` written at file scope) rather than from real
+    /// lexical nesting (`unit module NL; class Searcher { ... }`).
+    ///
+    /// Both register under a `::`-joined key, so the key alone cannot tell them
+    /// apart — but raku scopes them very differently. The compound form puts
+    /// only a `Foo` package *stub* in the file's scope; `Foo`'s contents are not
+    /// visible unqualified, so a bare `List` inside `Foo::List`'s body is CORE's
+    /// `List`. The nested form really is inside `NL`, so a bare `Hash` inside
+    /// `NL::Hash` is `NL::Hash`.
+    ///
+    /// Populated at declaration time, when the enclosing package is still known
+    /// (it is not recoverable from the key afterwards), and consulted by the
+    /// outward package walk in `resolve_type_in_current_package`, which would
+    /// otherwise re-derive `Foo` as a scope and let the class resolve *itself*
+    /// under its own short name.
+    pub(crate) compound_declared_types: HashSet<String>,
     /// Forward-declared class stubs (`class Foo { ... }` declared later).
     pub(crate) class_stubs: HashSet<String>,
     /// Forward-declared package stubs.
@@ -788,10 +805,26 @@ impl Registry {
         // `ClassDef` for "Array" with no `is` clause of its own) instead keeps
         // its real builtin parent (`List`, not `Any`) so the rest of its
         // catalog ancestor chain (`Cool`/`Any`/`Mu`) is still reachable below.
-        let parents = if explicit_parents.is_empty() && self.classes.contains_key(class_name) {
+        //
+        // "No explicit parents" means no *class* parent: a class whose only
+        // `parents` entries are composed roles (`class K does A {}`) still
+        // inherits from Any in raku. Without this, its linearization stopped at
+        // the role and `K.isa(Any)` / `K.isa(Mu)` were False even though
+        // `K.^mro` (computed elsewhere) listed both.
+        let has_class_parent = explicit_parents.iter().any(|p| {
+            let base = p.split_once('[').map(|(b, _)| b).unwrap_or(p);
+            !self.roles.contains_key(base)
+        });
+        let parents = if !has_class_parent && self.classes.contains_key(class_name) {
             match crate::builtins::builtin_type_catalog::builtin_type_info(class_name) {
-                Some(info) if info.mro.len() > 1 => vec![info.mro[1].to_string()],
-                _ => vec!["Any".to_string()],
+                Some(info) if info.mro.len() > 1 && explicit_parents.is_empty() => {
+                    vec![info.mro[1].to_string()]
+                }
+                _ => {
+                    let mut with_any = explicit_parents;
+                    with_any.push("Any".to_string());
+                    with_any
+                }
             }
         } else {
             explicit_parents

--- a/src/runtime/runtime_class_query.rs
+++ b/src/runtime/runtime_class_query.rs
@@ -57,6 +57,11 @@ impl Interpreter {
                 return None;
             }
             let key = format!("{}::{}", pkg.split("::&").next().unwrap_or(&pkg), name);
+            // `pkg` re-derived from a compound declared name is not a scope —
+            // see `Registry::compound_declared_types`.
+            if self.registry().compound_declared_types.contains(&key) {
+                return None;
+            }
             (self.has_class(&key) || self.has_role(&key)).then_some(key)
         })
     }

--- a/src/runtime/types/binding_signature.rs
+++ b/src/runtime/types/binding_signature.rs
@@ -2070,6 +2070,16 @@ impl Interpreter {
                             // callee's freshly-blanked `_` and bound the Any type object
                             // — a plain `$x` param, which does not re-read, got the real
                             // value (`method m (K:D: Int \ch)` called as `$k.m($_)`).
+                            //
+                            // The re-read is for the *alias* only: `value` keeps
+                            // whatever the VM evaluated at the callsite. Replacing
+                            // it with the env entry made the parameter observe a
+                            // STALE copy of the caller's variable whenever the
+                            // live value lived in the caller's local slot and env
+                            // still held the declaration-time one — `my Positional
+                            // $a = <foo bar>; Mod::C.m($a)` bound the `Positional`
+                            // type object to `\c`. The two named exceptions below
+                            // were the same bug reached from other directions.
                             let is_compile_time_pseudo = source_name.starts_with('?');
                             let is_routine_reset_magic =
                                 matches!(source_name.as_str(), "_" | "!" | "@_" | "%_");
@@ -2078,9 +2088,7 @@ impl Interpreter {
                             if is_compile_time_pseudo || is_routine_reset_magic {
                                 self.env.remove(&alias_key);
                                 self.env.insert(readonly_key, Value::TRUE);
-                            } else if let Some(source_val) = self.env.get(&resolved_source).cloned()
-                            {
-                                value = source_val;
+                            } else if self.env.get(&resolved_source).is_some() {
                                 self.env.insert(alias_key, Value::str(resolved_source));
                                 self.env.insert(readonly_key, Value::FALSE);
                                 self.sigilless_alias_seen = true;

--- a/src/runtime/types/type_registry.rs
+++ b/src/runtime/types/type_registry.rs
@@ -61,6 +61,34 @@ impl Interpreter {
     pub(crate) fn is_role_type_name(&self, name: &str) -> bool {
         self.has_role(name) || is_builtin_role_name(name)
     }
+
+    /// Record whether `name` was declared with a **compound name** at a package
+    /// that is not its own parent prefix (`class Foo::List { ... }` at file
+    /// scope), as opposed to a simple name inside its enclosing package
+    /// (`unit module NL; class Searcher { ... }`). See
+    /// [`crate::runtime::Registry::compound_declared_types`]; the enclosing
+    /// package is only knowable here, at declaration time.
+    pub(crate) fn note_compound_declared_type(&mut self, name: &str) {
+        let Some((parent, _)) = name.rsplit_once("::") else {
+            return;
+        };
+        let enclosing = self.current_package();
+        if parent == enclosing {
+            self.registry_mut().compound_declared_types.remove(name);
+        } else {
+            self.registry_mut()
+                .compound_declared_types
+                .insert(name.to_string());
+        }
+    }
+
+    /// True when `qualified` is only reachable through `pkg` because `pkg` was
+    /// re-derived by splitting a compound declared name — i.e. `pkg` is not a
+    /// real lexical scope for it. See
+    /// [`crate::runtime::Registry::compound_declared_types`].
+    fn compound_name_segment_is_not_a_scope(&self, qualified: &str) -> bool {
+        self.registry().compound_declared_types.contains(qualified)
+    }
 }
 
 impl Interpreter {
@@ -628,7 +656,15 @@ impl Interpreter {
             // `resolve_lexical_type_key` tries the bare form FIRST (so a
             // `decl_id == 0` / non-lexical declaration is unaffected) and only
             // then scans for the mangled variant.
-            if let Some(key) = self.resolve_lexical_type_key(&qualified) {
+            // The `::` segments of a COMPOUND DECLARED NAME are not lexical
+            // scopes: inside a top-level `class Foo::Hash { ... }`, stripping
+            // to `Foo` and probing `Foo::Hash` made the class resolve its own
+            // short name `Hash`, shadowing CORE's `Hash` for its whole body
+            // (and `Crane::List`'s `List.new` for the whole `Crane` dist).
+            // Real nesting (`unit module NL; class Hash`) still resolves.
+            if !self.compound_name_segment_is_not_a_scope(&qualified)
+                && let Some(key) = self.resolve_lexical_type_key(&qualified)
+            {
                 return Some(key);
             }
             match pkg.rsplit_once("::") {

--- a/t/compound-declared-name-is-not-a-scope.t
+++ b/t/compound-declared-name-is-not-a-scope.t
@@ -1,0 +1,64 @@
+use v6;
+use lib 't/lib';
+use Test;
+use CompoundNameScope;
+
+plan 7;
+
+# The `::` segments of a COMPOUND DECLARED NAME are not lexical scopes.
+# `class Foo::List { ... }` at file scope puts only a `Foo` package stub in the
+# file's scope in raku; `Foo`'s contents are NOT visible unqualified inside the
+# body. mutsu derived the enclosing-package chain by splitting the registered
+# name, so `Foo` looked like a real scope and the class found ITSELF under its
+# own short name -- `List.new(1, 2, 3)` inside `class Foo::List` constructed a
+# `Foo::List` instead of a core List. That is the `Crane::List` / `Crane::Set`
+# shape every `unit class Crane::X;` file is written in.
+#
+# Only TYPE names are pinned here. Bare *routine* lookup still crosses those
+# segments on purpose: mutsu also uses them to model a module compunit's
+# file-scope lexicals (`HTTP::HPACK`'s own `sub decode-int`, reached from
+# `HTTP::HPACK::Decoder`'s methods), so cutting the walk there breaks bundled
+# modules. See `bare_name_packages`.
+
+class Foo::List {
+    method core-list-name() { List.^name }
+    method make-a-list() { List.new(1, 2, 3) }
+}
+
+is Foo::List.core-list-name, 'List',
+    'a bare core type name inside `class Foo::List` is the CORE List';
+is-deeply Foo::List.make-a-list, (1, 2, 3),
+    'and `List.new` inside it builds a core List';
+
+class Baz::Hash {
+    method core-hash-name() { Hash.^name }
+}
+is Baz::Hash.core-hash-name, 'Hash',
+    'same for a compound-named class whose tail is `Hash`';
+
+grammar Qux::Match {
+    method core-match-name() { Match.^name }
+}
+is Qux::Match.core-match-name, 'Match',
+    'same for a compound-named grammar';
+
+class Corge::Set {
+    method core-set-name() { Set.^name }
+    method make-a-set() { Set.new(1, 2) }
+}
+is Corge::Set.core-set-name, 'Set',
+    'same when the tail shadows a core role-backed type';
+
+# Real lexical nesting must keep working: a class declared INSIDE a module is
+# registered module-qualified too, and there the outward walk is correct.
+is CompoundNameScope::Searcher.call-helper, 'module helper',
+    'a class lexically inside a module still sees the module\'s routines';
+
+module Deep {
+    our sub deep-helper() { 'deep helper' }
+    class Inner {
+        method call() { deep-helper() }
+    }
+}
+is Deep::Inner.call, 'deep helper',
+    'and so does a class inside an in-file module block';

--- a/t/isa-role-type-object-and-role-only-parent.t
+++ b/t/isa-role-type-object-and-role-only-parent.t
@@ -1,0 +1,47 @@
+use v6;
+use Test;
+
+plan 14;
+
+# `.isa` answers *class* inheritance. Two shapes of it were wrong in mutsu, both
+# reachable from ordinary "is this container still undefined?" code:
+#
+#  1. A ROLE TYPE OBJECT has no class MRO of its own, so `class_mro` on the role
+#     name yielded just the name and every probe answered False. raku answers
+#     from the chain the role's pun would have -- exactly `Any`, then `Mu`.
+#     `my Associative $t; $t.isa(Any)` (Crane's "original container is
+#     unchanged" assertion) therefore reported False.
+#
+#  2. A class whose only declared parents are COMPOSED ROLES (`class K does A`)
+#     linearized to `(K, A)` and stopped there, so `K.isa(Any)` was False even
+#     though `K.^mro` listed `Any` and `Mu`.
+
+role A { }
+role B does A { }
+class K does A { }
+class Plain { }
+class Sub is Plain { }
+
+# 1. role type objects
+ok Associative.isa(Any), 'a built-in role type object isa Any';
+ok Associative.isa(Mu), 'a built-in role type object isa Mu';
+nok Associative.isa(Cool), 'but not an unrelated class';
+nok Associative.isa(Str), 'nor Str';
+ok Positional.isa(Any), 'Positional isa Any too';
+ok A.isa(Any), 'a user role type object isa Any';
+ok B.isa(Mu), 'including one that composes another role';
+
+# An undefined scalar typed with a role holds that role's type object.
+my Associative $t;
+ok $t.isa(Any), 'an undefined Associative-typed scalar isa Any';
+my Positional $q;
+ok $q.isa(Any), 'an undefined Positional-typed scalar isa Any';
+
+# 2. classes whose only parents are roles
+ok K.isa(Any), 'a class whose only parent is a role still isa Any';
+ok K.isa(Mu), 'and isa Mu';
+ok K.new.isa(Any), 'and so does its instance';
+
+# Ordinary class inheritance is untouched.
+ok Sub.isa(Plain), 'a subclass isa its parent';
+ok Sub.isa(Any), 'and isa Any';

--- a/t/lib/CompoundNameScope.rakumod
+++ b/t/lib/CompoundNameScope.rakumod
@@ -1,0 +1,9 @@
+unit module CompoundNameScope;
+
+our sub helper() is export { 'module helper' }
+
+# `NL::Searcher`-shaped nesting: the class IS lexically inside the module, so a
+# bare routine name in its body must find the module's routine.
+class Searcher is export {
+    method call-helper() { helper() }
+}

--- a/t/lib/SigillessParamAcrossModule.rakumod
+++ b/t/lib/SigillessParamAcrossModule.rakumod
@@ -1,0 +1,9 @@
+unit class SigillessParamAcrossModule;
+
+# A method whose parameter is sigilless (`\c`) must observe the value the
+# caller actually passed, not a re-read of the caller's variable by name.
+method peek(\c) { c }
+method peek-and-write(\c) { my $r = c; $r = 'local'; c }
+method two(\c, $d) { (c, $d) }
+
+sub peek-sub(\c) is export { c }

--- a/t/sigilless-param-reads-argument-not-env.t
+++ b/t/sigilless-param-reads-argument-not-env.t
@@ -1,0 +1,67 @@
+use v6;
+use lib 't/lib';
+use Test;
+use SigillessParamAcrossModule;
+
+plan 14;
+
+# A sigilless parameter (`\c`) is implicitly raw: it aliases the caller's
+# container. mutsu recorded that alias by *name* and then re-read the caller's
+# variable out of `env` to produce the bound value. When the live value lived
+# in the caller's local slot and `env` still held the declaration-time one --
+# which is what a cross-compunit method call leaves behind -- the parameter
+# bound the variable's TYPE OBJECT instead of its value:
+#
+#   my Positional $t = <foo bar>;
+#   Mod::C.m($t);     # `\c` inside `m` saw `(Positional)`, and the exit
+#                     # writeback then stamped that back onto `$t`
+#
+# The alias is what the re-read is for; the VALUE must come from the argument
+# the VM evaluated at the callsite. Explicit `is raw` / `is rw` parameters
+# never re-read, which is why only the sigilless spelling was affected.
+
+my $C = SigillessParamAcrossModule;
+
+{
+    my Positional $t = <foo bar>;
+    is-deeply $C.peek($t), $($t), 'sigilless param sees a Positional-typed scalar';
+    is-deeply $t, $(<foo bar>), 'and the caller variable is unchanged';
+}
+
+{
+    my Associative $h = {:a(1)};
+    is-deeply $C.peek($h), $({:a(1)}), 'sigilless param sees an Associative-typed scalar';
+    is-deeply $h, $({:a(1)}), 'and the caller variable is unchanged';
+}
+
+{
+    my Int $n = 7;
+    is $C.peek($n), 7, 'sigilless param sees an Int-typed scalar';
+    is $n, 7, 'and the caller variable is unchanged';
+}
+
+{
+    my $u = <a b>;
+    is-deeply $C.peek($u), $(<a b>), 'sigilless param sees an untyped scalar';
+    is-deeply $u, $(<a b>), 'and the caller variable is unchanged';
+}
+
+{
+    my @a = <x y>;
+    is-deeply $C.peek(@a), <x y>.Array, 'sigilless param sees an array variable';
+    is-deeply @a, <x y>.Array, 'and the caller array is unchanged';
+}
+
+{
+    my Int $n = 3;
+    is-deeply $C.two($n, 9), (3, 9), 'sigilless param alongside an ordinary one';
+    is $n, 3, 'and the caller variable is unchanged';
+}
+
+# An exported sub with the same signature shape never had the bug; pin it so a
+# future change keeps the two spellings in agreement.
+{
+    my Positional $t = <foo bar>;
+    is-deeply peek-sub($t), $($t), 'sigilless param of a module sub sees the argument';
+    is-deeply $t, $(<foo bar>), 'and the caller variable is unchanged';
+}

--- a/todo/deep/config-toml-battery-core-blockers.md
+++ b/todo/deep/config-toml-battery-core-blockers.md
@@ -1,104 +1,105 @@
 # `Config::TOML` battery is blocked on core interpreter campaigns
 
-## Deep-triage note (2026-09-02)
+## Current measurement (2026-09-06)
 
-Moved from `todo/tickets/` after re-checking the current status of ADR-0059
-and the TOML/Crane measurements. The mechanical vendoring work is still
-blocked by three independent core investigations: Crane's array-path semantics
-(copy isolation, positional-invalid classification, and `WhateverCode` path
-steps), `\\UXXXXXXXX` grammar candidate selection, and the inline-table
-timeout. ADR-0059's container-return work and its typed deferred-vivification
-follow-up are already landed; they do not establish the remaining Crane
-semantics. These are cross-cutting Parser -> Compiler -> VM/runtime campaigns,
-not a bounded battery packaging PR. Re-open a focused ticket for vendoring
-only after fresh upstream suite measurements show a workable Config::TOML and
-Crane gate. A focused re-run of Crane v0.1.2's `t/copy.rakutest` on
-2026-09-02 still failed 5 of 6 top-level subtests, including copy isolation,
-positional-index classification, and positional out-of-range handling.
+Both upstream suites re-fetched from GitHub (`raku-community-modules/Crane`,
+`raku-community-modules/Config-TOML`) and run from their own directories
+against a **debug** build; `Config::TOML` with `Crane/lib` on `MUTSULIB`.
 
-## Former ticket scope
+| Suite | raku | mutsu (2026-08-31) | mutsu (2026-09-06, before this round) | mutsu (2026-09-06, after) |
+| --- | --- | --- | --- | --- |
+| `Config::TOML` v0.1.3 | 19/19 files | 0/19 | **10/19** | **10/19** |
+| `Crane` v0.1.2 | 15/15 files | 3/15 | **3/15** | **3/15** |
 
-## What this is
+**The ticket's `Config::TOML 0/19` was badly stale: it is 10/19 today**, and two
+of the four listed blockers are gone. `Crane` is still 3/15 at the file level
+(`at`, `exists`, `test`) but its assertion-level failures moved a lot this
+round — `t/add.rakutest`'s "Original container is unchanged" cluster went 5 → 1.
+
+`Config::TOML` passing: `api/01`, `grammar/01-04`, `grammar-actions/03`,
+`special-cases/01`, `04`, `05`, `06`.
+`Config::TOML` failing: `dumper/01`, `exceptions/01-02`,
+`grammar-actions/01`, `02`, `04`, `special-cases/02`, `03`, `07`.
+
+## Blocker status, re-checked 2026-09-06
+
+1. **Crane's array-path semantics.** Partly stale, partly still open.
+   - *Copy isolation* ("Original container is unchanged"): **mostly a
+     misdiagnosis.** The failures were not container aliasing at all. Two
+     general interpreter bugs produced them and are now fixed:
+     - A **sigilless parameter (`\c`) re-read the caller's variable out of
+       `env` by name** instead of using the argument the VM evaluated. When the
+       live value sat in the caller's local slot and `env` still held the
+       declaration-time one — what a cross-compunit method call leaves behind —
+       the parameter bound the variable's *type object*, and the exit writeback
+       stamped that back onto the caller. Repro needs no module machinery:
+       a `unit class C;` with `method m(\c) { 99 }`, called as
+       `my Positional $t = <foo bar>; C.m($t)`, left `$t` as `(Positional)`.
+       Pin: `t/sigilless-param-reads-argument-not-env.t`.
+     - `.isa` answered **False for every role type object** (`class_mro` on a
+       role name yields just that name), so Crane's `ok($t.isa(Any))` on an
+       undefined `Associative`/`Positional`-typed scalar failed. raku answers
+       from the role's pun's chain — exactly `Any` and `Mu`. A class whose only
+       declared parents are composed roles (`class K does A`) had the twin bug.
+       Pin: `t/isa-role-type-object-and-role-only-parent.t`.
+   - *`Crane::List`* (and every other `unit class Crane::X;` file): the `::`
+     segments of a **compound declared name** were treated as enclosing lexical
+     scopes, so `List.new(...)` inside `class Crane::List` constructed a
+     `Crane::List` ("Default constructor for 'Crane::List' only takes named
+     arguments") instead of a core `List`. Fixed by recording, at declaration
+     time, whether a registry key's segments came from a compound name or from
+     real nesting (`unit module NL; class Searcher`) and skipping the former in
+     the type-name walk. Pin: `t/compound-declared-name-is-not-a-scope.t`.
+     NOTE: bare *routine* lookup deliberately still crosses those segments —
+     mutsu also uses them to model a module compunit's file-scope lexicals
+     (`HTTP::HPACK`'s own `sub decode-int`, reached from
+     `HTTP::HPACK::Decoder`'s methods), and cutting that walk breaks bundled
+     modules. So `class Quux::User { method m { greet() } }` still prefers
+     `Quux::greet` over the file's own `greet`, where raku picks the file's.
+     That residual divergence is unfixed.
+   - *Positional-index classification* (`X::Crane::PositionalIndexInvalid`
+     raised by `Crane::Utils`' enum-value multis): **stale — this works.** The
+     whole `is-valid-positional-index` / `gen-classifier` chain, including
+     `WhateverCode` (`*-0`) steps, matches raku exactly on a standalone repro.
+     What still fails in `t/in.rakutest` is the *descent* around it, not the
+     classifier.
+   - *Still open:* the out-of-range / sparse-Positional exception family. Crane
+     wraps `splice` in a `CATCH { when X::OutOfRange { ... } }` and re-throws
+     `X::Crane::AddPathOutOfRange`; mutsu's `splice` does raise `X::OutOfRange`
+     with the right message on its own, so the gap is somewhere in the descent
+     or the `CATCH` mapping. Not bisected. This is now the dominant Crane
+     cluster: `add` 6× "code dies" + 5× wrong exception type, and the same
+     shape in `copy`, `move`, `remove`, `replace`, `set`, `patch`.
+2. ~~`t/patch.rakutest` fails to parse.~~ Fixed 2026-08-31.
+3. ~~The 8-hex `\UXXXXXXXX` string escape.~~ **Fixed** — `grammar/04` and
+   `grammar-actions/04`'s grammar half both pass now; `grammar-actions/04`
+   still fails for an unrelated reason.
+4. ~~`t/grammar/03-inline-tables.rakutest` times out.~~ **Fixed** — it passes,
+   and so does `grammar-actions/03`.
+
+New this round, filed separately:
+
+5. `todo/tickets/object-hash-key-lost-when-pair-value-is-a-container.md` — the
+   whole remaining blocker for `Crane`'s `flatten` and `list` files.
+   `my Any:D %t{List:D} = (%h<path> => %h<value>,)` dies with a bogus
+   `expected List:D but got Str ("1 2")` because the Pair's *value* is a
+   write-through `ContainerRef` and the object hash then loses the key object.
+   Also records two smaller measured divergences (`=>` does not decontainerize
+   its key; an itemized list used as a hash subscript is flattened into a
+   slice).
+
+## What this ticket is
 
 `Config::TOML` v0.1.3 + its dependency `Crane` v0.1.2 (both
 `auth<zef:raku-community-modules>`, Unlicense) won the TOML-parser
 battery-slot survey — see `docs/batteries/toml.md` for the full field, the
 metrics, and why it beat `TOML` (zef:tony-o) and `TOML::Thumb`. It is
-recorded in `BATTERIES.md` §7 as **Selected, not yet bundled**: the decision
-is made, but the module does not run on mutsu yet, so there is nothing to
-vendor or gate today.
+recorded in `BATTERIES.md` §7 as **Selected, not yet bundled**.
 
-This ticket is the **follow-up mechanical step** — vendoring + wiring it up
-as an actual battery — once its blockers clear. It is intentionally separate
-from the blockers themselves so none of those interpreter fixes is scoped to
-also cover packaging/docs/CI work.
-
-## Current measurement (2026-08-31)
-
-Re-run of the `Crane` v0.1.2 suite against a debug build: still **3/15**
-(`at`, `exists`, `test` — the ticket's earlier list named `flatten` instead of
-`exists`, so the passing set has shifted without the count moving). The gate is
-still closed; do not start the vendoring steps.
-
-What did change: blocker 2 below (`t/patch.rakutest` fails to *parse*) is
-**fixed**. It bisected to the hash-literal colonpair argument reader, which
-demanded at least one expression between the parens and so rejected both
-`{ :path() }` (an empty argument list) and `{ :path('a',) }` (a trailing
-comma) — the two shapes every `Crane` patch element is written in. Both are
-general parser bugs unrelated to `Crane`; fixed with
-`t/hash-literal-colonpair-arglist-edges.t` as the pin. `t/patch.rakutest` now
-compiles and runs, and fails on blocker 1 (the array-path descent) like the
-rest of the suite.
-
-## Previous measurement (2026-08-26)
-
-Re-measured from a fresh REA fetch of both dists, running each upstream suite
-from its own directory (`Config::TOML` with `Crane` on `MUTSULIB`) against a
-release build:
-
-| Suite | raku | mutsu |
-| --- | --- | --- |
-| `Config::TOML` v0.1.3 | 19/19 files | **0/19** |
-| `Crane` v0.1.2 | 15/15 files | **3/15** |
-
-Unchanged from the 2026-08-22 numbers: none of the fixes that landed since then
-(grammar dynamic-variable rule parameters, `FAILGOAL`, `<?ww>`, NativeCall typed
-pointers, the `:ver<0.4.0+>` selector, quote-vs-declared-term, the
-group-backreference fix that came out of this same re-measurement) touch what
-`Crane` needs. This tracker is **not** ready to start.
-
-`Crane` passing: `at`, `flatten`, `test`. The dominant failure across the rest
-is `✗ Crane error: associative key does not exist`, plus a hard parse error in
-`t/patch.rakutest` (`Confused. expected statement`). Because `Config::TOML`
-builds every result through `Crane.set`/`Crane.exists`, a `Crane` descent that
-answers from an empty container makes its own duplicate-key guard fire on every
-document — which is why the file-level count is a flat zero rather than a
-partial pass.
-
-## Blocked on
-
-`docs/batteries/toml.md`'s **remaining work list** carries the detail. Largest
-first:
-
-1. `Crane`'s array-path descent: `.add`/`.copy` must deep-clone ("Original
-   container is unchanged"), `X::Crane::PositionalIndexInvalid` is not raised by
-   `Crane::Utils`' classifier multis, and WhateverCode (`*-0`) indices do not
-   survive the descent. (The `is rw` lvalue return and the typed deferred
-   vivification token both landed 2026-08-22 — ADR-0059 and
-   `news/2026-08/deferred-vivification-path-steps-are-typed.md` — so those two
-   are no longer the gate.)
-2. ~~`t/patch.rakutest` fails to *parse* under mutsu; not yet bisected.~~
-   **Fixed 2026-08-31** — see the measurement note above. The file parses and
-   runs now; it fails on blocker 1.
-3. The 8-hex `\UXXXXXXXX` string escape still reports
-   "bad string escape sequence 「U」", blocking `grammar/04` and
-   `grammar-actions/04`.
-4. `t/grammar/03-inline-tables.rakutest` times out (90s) rather than failing.
-
-**Do not start this ticket before those are fixed and both suites have been
-re-run to confirm they now pass** — or at least pass enough files to be worth a
-per-file whitelist, the way `CBOR::Simple`/`Log::Timeline`/`Log::Async` ship
-with partial coverage. At 0/19 there is nothing a whitelist could gate.
+This ticket is the **follow-up mechanical step** — vendoring + wiring it up as
+an actual battery — once its blockers clear. **Do not start the vendoring steps
+yet**: `Crane` at 3/15 is still too thin for a per-file whitelist to be worth
+it, and `Config::TOML` builds every result through `Crane.set`/`Crane.exists`.
 
 ## Steps (once unblocked)
 
@@ -109,11 +110,8 @@ finished record and PR:
 
 1. **Re-run the survey** to get current pass counts: fetch both dists fresh
    (`docs/batteries/toml.md`'s provenance table has the exact upstream URLs
-   and pinned versions/commits) and run their suites under `raku` and a
-   release `target/release/mutsu` build. Confirm which of the 19
-   `Config::TOML` files (plus `Crane`'s own ~15 `.rakutest` files under
-   `t/`) actually pass now — the parser fix may not clear 100% on the first
-   try.
+   and pinned versions) and run their suites under `raku` and a release
+   `target/release/mutsu` build.
 2. **Vendor** `lib/` + `META6.json` + `UNLICENSE` + `README.md` for both
    modules into `modules/Config-TOML/` and `modules/Crane/` (new
    directories, following the `modules/<Dist-Name>/` naming already used by
@@ -122,9 +120,7 @@ finished record and PR:
 3. **Register the default module search path** entry the same way every
    other bundled module is wired (check `add_default_site_repo()` / the
    `modules/` tree registration mentioned in
-   [BATTERIES.md §3](../../BATTERIES.md#3-vendoring-and-resolution) — no new
-   mechanism needed, this is just adding two more directories to an
-   existing list/manifest).
+   [BATTERIES.md §3](../../BATTERIES.md#3-vendoring-and-resolution)).
 4. **`batteries.lock`**: add entries for `Config::TOML` (commit pinned to
    v0.1.3) and `Crane` (commit pinned to v0.1.2), then run
    `scripts/battery-testsuite.sh --update` and review the
@@ -133,9 +129,9 @@ finished record and PR:
 5. **Smoke test**: `mutsu -e 'use Config::TOML; say from-toml(q[[a]]{Xb}=1)'`
    (or equivalent) round-trips.
 6. **Update `docs/batteries/toml.md`**: flip the status line from "Selected,
-   not yet bundled" to "Working" (or "Sufficient for X" / a partial-pass
-   note if the whitelist isn't 19/19), fill in the actual commit hashes in
-   the provenance table, add the vendor-recipe `rsync` commands.
+   not yet bundled" to "Working" (or a partial-pass note if the whitelist
+   isn't 19/19), fill in the actual commit hashes in the provenance table,
+   add the vendor-recipe `rsync` commands.
 7. **Update `BATTERIES.md` §7**'s TOML row: change `Kind` from
    `**Selected, not yet bundled**` to `Adopted`, and rewrite the `Status`
    cell to match whatever `docs/batteries/toml.md` now says.
@@ -143,11 +139,19 @@ finished record and PR:
    [BATTERIES.md §5](../../BATTERIES.md#publish-the-bundle-on-the-pages-site)
    — only once it is actually "Working", not before.
 9. Regenerate the manifest if one exists for the bundle
-   (`python3 scripts/gen-batteries-manifest.py`, same as the
-   `Template::Mustache` recipe).
+   (`python3 scripts/gen-batteries-manifest.py`).
 
-## Why this is a `tickets/` item, not `deep/`
+## How to re-measure
 
-No design decision is needed — the candidate, its license, and the vendoring
-recipe are all already fully decided and documented in `docs/batteries/toml.md`.
-This is pure mechanical follow-through once its blocking bugs are fixed.
+```
+mkdir -p tmp/toml-survey && cd tmp/toml-survey
+git clone --depth 50 https://github.com/raku-community-modules/Crane.git
+git clone --depth 50 https://github.com/raku-community-modules/Config-TOML.git
+# Crane:        (cd Crane && mutsu -I lib t/<file>.rakutest)
+# Config::TOML: (cd Config-TOML && MUTSULIB=../Crane/lib mutsu -I lib t/<dir>/<file>.rakutest)
+# raku baseline: same, with `raku -Ilib [-I../Crane/lib]`
+```
+
+Run every failing file under `raku` on the same checkout before calling
+anything a mutsu bug — three of this ticket's four listed blockers turned out
+to be already fixed or misdiagnosed when that was actually done.

--- a/todo/tickets/object-hash-key-lost-when-pair-value-is-a-container.md
+++ b/todo/tickets/object-hash-key-lost-when-pair-value-is-a-container.md
@@ -1,0 +1,80 @@
+# An object hash loses its typed key when the Pair's *value* came from a container read
+
+Measured 2026-09-06 while re-triaging
+`todo/deep/config-toml-battery-core-blockers.md`. This is the whole remaining
+blocker for `Crane`'s `t/flatten.rakutest` and `t/list.rakutest`, and it needs
+no module to reproduce.
+
+## Minimal repro
+
+```raku
+my %h = :path($(1, 2)), :value(9);
+my $p = (%h<path> => %h<value>);      # NB: the VALUE also comes from a hash read
+my Any:D %t{List:D} = ($p,);
+say %t.raku;
+```
+
+- raku: `(my Any:D %{List:D} = (1, 2) => 9)`
+- mutsu: `Type check failed for an element of %t; expected List:D but got Str ("1 2")`
+
+The **value** side is the trigger, not the key:
+
+```raku
+my $p = (%h<path> => 9);              # literal value -> works
+my $p = ($(1, 2) => %h<value>);       # literal key, hash-read value -> FAILS
+```
+
+`key => $var` deliberately captures the RHS as a write-through `ContainerRef`
+(`pop_pair_operands_capturing`, `src/vm/vm_mixin_does_ops.rs`), which is correct
+for `$pair.value = X`. Somewhere between there and
+`coerce_typed_container_assignment` (`src/vm/vm_var_assign_typed.rs:270`), the
+Pair list is converted to a `Hash` whose `original_keys` map does **not** record
+the non-`Str` key object when the value is that `ContainerRef`. The object-hash
+key check then falls back to `try_reconstruct_typed_key(str_key, "List:D")`,
+which hands it `Str("1 2")` and the assignment dies.
+
+The candidate conversion site is `pair_list_to_hash`-style code in
+`src/runtime/utils/coerce_containers.rs` (the `ValuePair(k, v)` arms around
+lines 137 and 180, which do register `original_keys`) — but the failing path
+evidently reaches `coerce_typed_container_assignment` with the hash *already*
+built somewhere else, so the first job is to find which conversion actually runs
+(a `rust-gdb` breakpoint on `set_hash_original_keys` will name it in one run).
+
+## Secondary divergence found alongside it
+
+mutsu keeps a Pair key **itemized**; raku decontainerizes it:
+
+```raku
+my $s = $(1, 2);
+say ($s => "x").raku;        # raku: (1, 2) => "x"   mutsu: $(1, 2) => "x"
+say ($s => "x").key.VAR.^name;  # raku: List (mutsu also reports List via .VAR)
+```
+
+Rakudo's `infix:<< => >>` binds the key as a plain `Mu $key`, so the Scalar
+wrapper is gone; the *value* keeps its container in both (raku reports
+`Scalar` for `("k" => $s).value.VAR`). Fixing the key side would make
+`%t.raku` print `(1, 2) => 9` like raku and may or may not be the same bug as
+above — measure before assuming it is.
+
+## Also measured, not fixed
+
+An **itemized** value used as a hash subscript must be ONE key, not a slice:
+
+```raku
+my $s = $(1, 2);
+my Any:D %c{List:D};
+%c{$s} = 'x';
+# raku:  (my Any:D %{List:D} = (1, 2) => "x")
+# mutsu: Type check failed for an element of %c; expected List:D but got Int (2)
+```
+
+mutsu flattens `$s` into a two-element slice subscript. (raku dies on the
+*non*-itemized `%c{(1, 2)}` for exactly that reason, so the itemization is what
+distinguishes the two, and mutsu ignores it here.)
+
+## Why it matters
+
+`Crane::Flatten` is one line — `my Any:D %tree{List:D} = Crane::List.list($container, :@path).map({ .<path> => .<value> })` —
+and it is the exact shape above: a list of Pairs whose key and value both come
+out of a hash read. `Config::TOML` does not use `Crane.flatten`, so this blocks
+2 of `Crane`'s 15 upstream files, not the TOML half.


### PR DESCRIPTION
Re-triage of `todo/deep/config-toml-battery-core-blockers.md`, starting from a
fresh measurement of both upstream suites on current `main` as the ticket asked.

## The measurement first

| Suite | raku | ticket said (2026-08-31) | actual, today |
| --- | --- | --- | --- |
| `Config::TOML` v0.1.3 | 19/19 files | 0/19 | **10/19** |
| `Crane` v0.1.2 | 15/15 files | 3/15 | **3/15** |

Two of the ticket's four blockers were already fixed by other work (the 8-hex
`\UXXXXXXXX` string escape, and the `grammar/03-inline-tables` 90s timeout), and
a third — "`X::Crane::PositionalIndexInvalid` is not raised by `Crane::Utils`'
classifier multis" — turns out to work exactly like raku, `WhateverCode` steps
included, on a standalone repro. The ticket is rewritten with today's numbers
and a per-blocker verdict so the next agent does not re-derive them.

## Three general bugs, none needing a module to reproduce

**1. A sigilless parameter re-read the caller's variable out of a stale `env`.**

```raku
# Mod.rakumod:   unit class C;   method m(\c) { 99 }
my Positional $t = <foo bar>;
C.m($t);
say $t;    # raku: ($("foo", "bar"))    mutsu: (Positional)
```

`\c` is implicitly raw, so the binder records a write-through alias by name —
and, while doing so, replaced the bound value with `env`'s copy of that name.
When the live value sat in the caller's *local slot* and `env` still held the
declaration-time one (which is what a cross-compunit method call leaves behind),
the parameter bound the variable's **type object**, and the exit writeback then
stamped that back onto the caller. Every scalar was affected whatever its
declared type; `is raw`, `is rw` and plain `$` parameters were fine, because
only the sigilless spelling re-reads. The alias registration stays; only the
value assignment is dropped. The two special cases already carved out of that
branch (`?CLASS`, `$_`/`$!`/`@_`/`%_`) were this same bug reached from other
directions.

**2. A compound declared name's `::` segments were treated as lexical scopes for
type lookup.**

```raku
class Foo::List { method m() { List.new(1, 2, 3) } }
Foo::List.m;   # mutsu: Default constructor for 'Foo::List' only takes named arguments
```

The class found *itself* under its own short name, shadowing CORE's `List` for
its whole body — which is exactly what every `unit class Crane::X;` file does.
Whether a registry key's segments came from a compound name (`class Foo::List`
at file scope) or from real nesting (`unit module NL; class Searcher`) is not
recoverable from the key, so it is now recorded at declaration time, when the
enclosing package is still known.

Bare **routine** lookup deliberately still crosses those segments: mutsu also
uses them to model a module compunit's file-scope lexicals (`HTTP::HPACK`'s own
`sub decode-int`, reached from `HTTP::HPACK::Decoder`'s methods). Cutting that
walk breaks bundled modules — `t/http-hpack-battery.t` caught it when this
change was first written to cover both halves, so the routine half was reverted
and the residual divergence is recorded in the ticket.

**3. `.isa` answered False for every role type object.**

`class_mro` on a role name yields just that name, so `my Associative $t;
$t.isa(Any)` — Crane's "original container is unchanged" assertion — was False.
raku answers from the chain the role's pun would have: exactly `Any` and `Mu`,
and False for everything else including a role the role itself `does`. Its twin,
found alongside: a class whose only declared parents are composed roles
(`class K does A`) linearized to `(K, A)` and stopped there, so `K.isa(Any)` was
False even though `K.^mro` listed `Any` and `Mu`.

## Effect

No file-level movement in either suite, but Crane's assertion-level failures
moved: `t/add.rakutest`'s "Original container is unchanged" cluster went 5 → 1,
and `t/flatten.rakutest`/`t/list.rakutest` now fail past the `Crane::List` alias
on a single remaining bug, filed as
`todo/tickets/object-hash-key-lost-when-pair-value-is-a-container.md`
(`my Any:D %t{List:D} = (%h<path> => %h<value>,)` loses the typed key because
the Pair's *value* is a write-through `ContainerRef`). That ticket also records
two smaller measured divergences found in the neighbourhood: `=>` does not
decontainerize its key, and an itemized list used as a hash subscript is
flattened into a slice.

No vendoring/packaging work — the gate is still not workable, and the ticket
says so.

## Gates

- `make test`: **PASS** (932 cargo tests + 3723 `t/` files).
- Targeted roast, picked by consumer (`S06-signature`, `S09-*`, `S10-packages`,
  `S02-names-vars`, `S12-*`, `S14-*`, `S32-array`, `S32-hash`): 229 files /
  13169 tests, **PASS**.
- `scripts/battery-testsuite.sh`: **289/312, GATE PASSED** — unchanged baseline.

All three pins were verified against `raku` before being written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
