### PR TITLE
perf(dispatch): count allocations per scope, and stop allocating the method-entry env keys

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -380,6 +380,28 @@ Running the entire roast suite locally is wasteful and slow — **let CI run the
 
 The `MUTSU_VM_STATS=1` dual-store counters (`locals_pulls`, `env_flushes`, `env_deep_copies`, `clone_env`, ...) are **deterministic and independent of the optimization level** — they count VM events, not time. So when tuning a perf/decoupling change against those counters, **iterate with the debug build** (`cargo build`, ~30-70s) and read the counters off `target/debug/mutsu`; the numbers are identical to release. Reserve `cargo build --release` for the **final wall-clock measurement** only. Do NOT default to release just because the task is perf-related — that wastes build time per iteration for byte-identical counter output. (Release is `debug = false` by default; for `perf`/flamegraph profiling that needs symbols, build `cargo build --profile profiling` — a release-optimized binary that keeps debuginfo.)
 
+### Counting allocations: `alloc_scope!` + the `alloc-stats` feature
+
+When the question is "how many allocations does *this region* cost" (not "where does wall-clock
+go"), use the deterministic counter rather than a profiler — `perf --call-graph` has never worked in
+this container (stale `/root/.debug` build-id store for `dwarf`, garbage stacks for `fp`):
+
+```
+cargo build --release --features alloc-stats
+MUTSU_ALLOC_STATS=1 ./target/release/mutsu benchmarks/bench-ctor.raku
+```
+
+`alloc_scope!("label")` (in `src/alloc_stats.rs`) opens an accounting region for the rest of its
+block; `alloc_scope_named!`/`alloc_scope_end!` close one early so a function can be split into
+sequential phases. The stderr report gives per-scope allocations and bytes, both inclusive and
+exclusive of nested scopes. Counts are exact and load-independent, so — like the `MUTSU_VM_STATS`
+counters — they are the right thing to iterate a change against. **Wall-clock from an `alloc-stats`
+build is meaningless**; time with an ordinary release build. With the feature off (every normal
+build, and CI) the macro expands to nothing and the counting allocator is not installed, so call
+sites are free to leave in place. `callgrind` also works here (`valgrind` + `callgrind_annotate` are
+installed) and `callgrind_annotate --tree=caller` gives the caller attribution `perf` could not —
+run it on a reduced-iteration copy of the benchmark, it is ~50x slower than native.
+
 ### Benchmark numbers in documents come from the bench CI, not local runs
 
 Numbers recorded in PERFORMANCE.md / PLAN.md / news must come from the **bench CI history** (`bench-history.tsv` on the `bench-data` branch, appended on every main push: median of 7 runs plus a same-runner raku ratio that normalizes runner speed), citing the main commit hash the row belongs to. Read it with `git show origin/bench-data:bench-history.tsv`. The `<bench>+jit` rows are the JIT-on series — the default configuration since J5 (2026-07-13); the plain rows pin `MUTSU_JIT=off` as the interpreter baseline. Local `perf stat` A/B measurements are fine for PR descriptions and in-flight development decisions, but they drift with thermals and binary layout (±5% is common), so they are NOT the source of truth for documents.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,11 @@ wasm = ["wasm-bindgen", "console_error_panic_hook"]
 # NativeCall (C FFI) support — gated under `native`; wasm builds cannot do FFI.
 libloading = ["dep:libloading"]
 libffi = ["dep:libffi"]
+# Deterministic per-scope allocation counting (`src/alloc_stats.rs`). A
+# measurement-only build: it installs a counting `#[global_allocator]` and makes
+# `alloc_scope!` expand to a real guard. Never enable it for a timing run or a
+# shipped binary. See todo/perf/adr0019-g3-diffuse-bless-allocation-cost.md.
+alloc-stats = []
 # Cranelift method JIT (ADR-0004, layer 4). Compiled in by default but inert
 # unless MUTSU_JIT=on at runtime. Disable for targets Cranelift can't build on.
 jit = [

--- a/news/2026-09/alloc-scope-accounting-and-method-entry-symbol-keys.md
+++ b/news/2026-09/alloc-scope-accounting-and-method-entry-symbol-keys.md
@@ -1,0 +1,95 @@
+# Per-scope allocation accounting, and the method-entry env keys it found
+
+ADR-0019 G3 (`todo/perf/adr0019-g3-diffuse-bless-allocation-cost.md`) had been stuck on a
+measurement problem, not a coding one. `bench-ctor`'s regression is *diffuse*: a flat `perf` profile
+shows ~7% in `malloc`/`free` and ~6.5% in NaN-box GC/refcount ops with no single hot function, and
+the obvious follow-up question — *which caller is doing all that allocating?* — could not be
+answered, because call-graph attribution was unusable in the dev container (`--call-graph dwarf`
+died on a stale `/root/.debug` build-id store, `--call-graph fp` produced garbage stacks through the
+optimized build). The ticket's own next-steps list proposed building a counting allocator instead.
+This is that tool, plus the first two fixes it found.
+
+## `alloc_scope!` — exact, deterministic allocation counts per region
+
+`src/alloc_stats.rs` adds a measurement-only cargo feature, `alloc-stats`. With it on, a counting
+`#[global_allocator]` wraps `System` and `alloc_scope!("label")` opens an accounting region for the
+rest of its block (`alloc_scope_named!` / `alloc_scope_end!` close one early, so a function can be
+split into sequential phases without being re-indented into nested blocks). The report goes to
+stderr at the end of the run:
+
+```
+cargo build --release --features alloc-stats
+MUTSU_ALLOC_STATS=1 ./target/release/mutsu benchmarks/bench-ctor.raku
+```
+
+Each scope reports its entry count and its allocations/bytes both inclusive of nested scopes and
+exclusive of them, so a nested set of scopes reads like a profiler's self-time column. Counts are
+exact and do not depend on machine load, thermals, or binary layout — the same property that makes
+the `MUTSU_VM_STATS` counters, rather than local wall-clock, the right thing to iterate against.
+
+With the feature off — every ordinary build, and everything CI compiles — `alloc_scope!` expands to
+nothing and the custom allocator is not installed, so there is no cost to leave the call sites in.
+They are left in place along the construction path (`bless`, its attribute-default / named-arg /
+BUILD / TWEAK phases, `run_construction_phase_steps`, and the compiled method-call entry split into
+prologue / param-bind / env-setup / locals / body / epilogue), where they now serve as executable
+documentation of that path's cost structure.
+
+## What it found
+
+Constructing one `bench-ctor` object (a 20-attribute class, `method new(*%_)` delegating to
+`self.bless`, `TWEAK` at two MRO levels) cost 1,646,587 allocations over 5000 iterations. The
+breakdown was not where the ticket had assumed:
+
+- `bless` itself is cheap. Its own body, the attribute-default seeding loop, and building the
+  instance came to ~21 allocations per construction combined — the `AttrMap::with_capacity`
+  pre-sizing from the previous session's slice had already done its job.
+- **64% of every allocation in the whole program was made inside `call_compiled_method`**, exclusive
+  of everything it calls. Per method call that is ~70 allocations, of which ~29 are pure call-frame
+  setup — paid identically by `submethod TWEAK(:$!spec) { }`, whose body is empty.
+
+So the target was never `bless`. It was the per-method-call frame.
+
+## Fix 1: the fixed per-call env keys are pre-interned symbols
+
+Both compiled method-call paths opened a frame by writing a fixed set of env keys — `self`,
+`__ANON_STATE__`, `?CLASS`, `?ROLE`, `_`, `!`, `__mutsu_callable_id`, `%_` — through
+`Env::insert(String, Value)`, which allocates a `String` only to hand it to `Symbol::intern` and
+drop it again. Bound parameters went the same way, with a `String` allocated per parameter per call.
+
+`symbol::wk` already existed for exactly this problem: its `rebound_return` entry carries the note
+that re-interning a name on a hot path "showed up as 5.3% of `bench-fib`", because the thread-local
+intern cache is a string-keyed hash lookup. The method-entry key family had simply never been given
+the same treatment. It has now — the fixed keys are `wk` symbols written with `insert_sym`, and
+parameters intern their borrowed `&str` directly instead of allocating a copy of it first.
+
+`insert_sym` deliberately does not run `env::note_env_key`, the latch that records whether any
+`^placeholder` or `__mutsu_bound::`-family metadata key may exist. None of the fixed keys is one of
+those, so skipping it is sound; a *parameter* name can be `^`-prefixed, so the parameter helper
+calls `note_env_key` itself. A unit test pins each well-known symbol against its string spelling,
+since a typo there would compile fine and silently write the wrong env key.
+
+Measured: `mfast:env-setup` fell from 9.0 to 2.7 allocations per method call, and the whole program
+from 1,646,587 to 1,536,588 allocations (-6.7%).
+
+## Fix 2: the `BUILDALL`/`POPULATE` probe moves into the per-class plan
+
+Every `bless` ended by asking whether the class declares a user `BUILDALL` or `POPULATE`, and asked
+it by walking the MRO twice through `Registry::user_method_overloads` — interning both the class
+name and the method name at every level, ~16 interns per construction, to reach the answer `None`
+that essentially every class gives. That is pure class shape, so it now sits in `NativeCtorPlan` as
+`user_buildall`, next to the `has_build` / `has_tweak` / `has_custom_bless` probes that were moved
+there for the same reason. It allocated nothing, so the allocation count is unchanged; what it
+removes is instruction count on a path `callgrind` showed spending 6.5% of the program in
+`Symbol::intern`'s thread-local lookup.
+
+## Result
+
+Order-swapped min-of-9 A/B against the pre-change binary, `MUTSU_JIT=off`: `bench-ctor` -3.5%,
+`bench-class` -4.6%. Both benchmarks improve in both orders. The change helps every method call in
+every program, not just construction — `bench-class`, which has no `bless`-heavy shape at all, is
+the larger of the two wins.
+
+The ticket stays open: the tool has now localized the *next* target precisely (the implicit `*%_`
+slurpy hash, built on every method call whether or not the body can observe it — 10.3 allocations
+per call, ~10% of `bench-ctor`'s total), which is a compiler-analysis slice rather than a dispatch
+one and is written up there as its own next step.

--- a/src/alloc_stats.rs
+++ b/src/alloc_stats.rs
@@ -1,0 +1,276 @@
+//! Deterministic per-scope allocation accounting (`alloc-stats` feature).
+//!
+//! Why this exists: the ADR-0019 G3 investigation
+//! (`todo/perf/adr0019-g3-diffuse-bless-allocation-cost.md`) stalled because
+//! `bench-ctor`'s cost is *diffuse* — a flat `perf` profile shows ~7% in
+//! `malloc`/`free` and ~6.5% in NaN-box GC/refcount ops with no single hot
+//! function, and call-graph attribution was unusable in the dev container
+//! (`--call-graph dwarf` died on a stale `/root/.debug` build-id store,
+//! `--call-graph fp` produced garbage stacks through the optimized build). So
+//! "which caller is doing all the allocating?" could not be answered with a
+//! profiler at all.
+//!
+//! This module answers it without one. A counting `#[global_allocator]` plus a
+//! scope stack turns the question into an exact, deterministic *count*:
+//! `alloc_scope!("bless")` around a region reports how many allocations (and
+//! bytes) happened inside it, both inclusive of nested scopes and exclusive of
+//! them. Counts do not depend on machine load, thermals, or binary layout, so
+//! a change either reduces the number of allocations per `bless` or it does
+//! not — the same property that makes the `MUTSU_VM_STATS` counters useful for
+//! the dual-store work (see the "Build profiles and benchmark numbers" section
+//! of CLAUDE.md).
+//!
+//! # Usage
+//!
+//! ```text
+//! cargo build --release --features alloc-stats
+//! MUTSU_ALLOC_STATS=1 ./target/release/mutsu benchmarks/bench-ctor.raku
+//! ```
+//!
+//! The report goes to stderr at the end of the run, via `dump_vm_stats()`.
+//!
+//! # Cost when the feature is off (the default)
+//!
+//! Zero. [`alloc_scope!`] expands to nothing and the custom allocator is not
+//! installed, so a default `cargo build` is byte-identical to one from before
+//! this module existed. The feature is a measurement tool, never shipped on.
+//!
+//! # Cost when the feature is on
+//!
+//! Every allocation does one const-initialized thread-local `Cell` bump. The
+//! numbers are still exact — but wall-clock from an `alloc-stats` build is
+//! meaningless; measure time with a normal release build.
+
+/// Open an allocation-accounting scope for the rest of the enclosing block.
+///
+/// Expands to nothing unless the `alloc-stats` feature is on, so call sites can
+/// be left in place permanently. The label must be a string literal.
+///
+/// ```ignore
+/// fn dispatch_bless(&mut self, ..) -> Result<Value, RuntimeError> {
+///     crate::alloc_scope!("bless");
+///     ..
+/// }
+/// ```
+#[macro_export]
+macro_rules! alloc_scope {
+    ($label:literal) => {
+        #[cfg(feature = "alloc-stats")]
+        let _mutsu_alloc_scope = $crate::alloc_stats::Scope::new($label);
+    };
+}
+
+/// Like [`alloc_scope!`], but binds the guard to a named variable so the region
+/// can be closed early with [`alloc_scope_end!`] instead of running to the end
+/// of the block. Use it to split one function into sequential phases without
+/// re-indenting it into nested blocks.
+#[macro_export]
+macro_rules! alloc_scope_named {
+    ($ident:ident, $label:literal) => {
+        #[cfg(feature = "alloc-stats")]
+        let $ident = $crate::alloc_stats::Scope::new($label);
+    };
+}
+
+/// Close a scope opened by [`alloc_scope_named!`].
+#[macro_export]
+macro_rules! alloc_scope_end {
+    ($ident:ident) => {
+        #[cfg(feature = "alloc-stats")]
+        drop($ident);
+    };
+}
+
+#[cfg(feature = "alloc-stats")]
+pub use imp::{CountingAllocator, Scope, dump};
+
+/// No-op stand-in used when the `alloc-stats` feature is off.
+#[cfg(not(feature = "alloc-stats"))]
+pub fn dump() {}
+
+#[cfg(feature = "alloc-stats")]
+mod imp {
+    use std::alloc::{GlobalAlloc, Layout, System};
+    use std::cell::Cell;
+    use std::collections::HashMap;
+    use std::sync::{Mutex, OnceLock};
+
+    thread_local! {
+        /// Allocations made by this thread so far.
+        static ALLOCS: Cell<u64> = const { Cell::new(0) };
+        /// Bytes requested by this thread so far (allocations only; frees are
+        /// not subtracted — this is turnover, not peak RSS).
+        static BYTES: Cell<u64> = const { Cell::new(0) };
+        /// Inclusive totals accumulated by the direct children of the scope
+        /// currently on top of this thread's scope stack, so a scope can
+        /// report exclusive counts by subtracting them.
+        static CHILD_ALLOCS: Cell<u64> = const { Cell::new(0) };
+        static CHILD_BYTES: Cell<u64> = const { Cell::new(0) };
+        /// Set while a [`Scope`] is folding its result into the global report.
+        /// That bookkeeping allocates (the report's `HashMap`), and counting
+        /// those allocations would both pollute the numbers and, worse, mean
+        /// the allocator re-enters the map it is already borrowing.
+        static SUSPENDED: Cell<bool> = const { Cell::new(false) };
+    }
+
+    /// One scope's accumulated counts across every thread and every entry.
+    #[derive(Default, Clone, Copy)]
+    struct Stats {
+        entries: u64,
+        incl_allocs: u64,
+        incl_bytes: u64,
+        excl_allocs: u64,
+        excl_bytes: u64,
+    }
+
+    fn report() -> &'static Mutex<HashMap<&'static str, Stats>> {
+        static REPORT: OnceLock<Mutex<HashMap<&'static str, Stats>>> = OnceLock::new();
+        REPORT.get_or_init(|| Mutex::new(HashMap::new()))
+    }
+
+    #[inline]
+    fn record(size: usize) {
+        // A thread whose TLS is being torn down would panic on `.with`; during
+        // shutdown we simply stop counting.
+        let _ = SUSPENDED.try_with(|s| {
+            if s.get() {
+                return;
+            }
+            let _ = ALLOCS.try_with(|a| a.set(a.get().wrapping_add(1)));
+            let _ = BYTES.try_with(|b| b.set(b.get().wrapping_add(size as u64)));
+        });
+    }
+
+    /// `System`, plus a counter bump on every allocating call.
+    ///
+    /// `dealloc` is deliberately not counted: the question this tool answers is
+    /// "how many allocations does constructing one object cost", and a scope's
+    /// frees are not necessarily made inside it (a value built during `bless`
+    /// is dropped long after). `realloc` counts as one allocation of the new
+    /// size, which is what it costs.
+    pub struct CountingAllocator;
+
+    unsafe impl GlobalAlloc for CountingAllocator {
+        #[inline]
+        unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+            record(layout.size());
+            unsafe { System.alloc(layout) }
+        }
+
+        #[inline]
+        unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+            unsafe { System.dealloc(ptr, layout) }
+        }
+
+        #[inline]
+        unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+            record(layout.size());
+            unsafe { System.alloc_zeroed(layout) }
+        }
+
+        #[inline]
+        unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+            record(new_size);
+            unsafe { System.realloc(ptr, layout, new_size) }
+        }
+    }
+
+    /// A live allocation-accounting region; see [`crate::alloc_scope!`].
+    ///
+    /// Nesting is handled by the same save/restore trick a profiler uses for
+    /// self time: on entry the scope takes over the thread's child accumulator,
+    /// on exit it reports `inclusive - children` as its exclusive cost and adds
+    /// its own inclusive total to the parent's accumulator.
+    pub struct Scope {
+        label: &'static str,
+        start_allocs: u64,
+        start_bytes: u64,
+        parent_child_allocs: u64,
+        parent_child_bytes: u64,
+    }
+
+    impl Scope {
+        pub fn new(label: &'static str) -> Self {
+            Scope {
+                label,
+                start_allocs: ALLOCS.with(|a| a.get()),
+                start_bytes: BYTES.with(|b| b.get()),
+                parent_child_allocs: CHILD_ALLOCS.with(|a| a.replace(0)),
+                parent_child_bytes: CHILD_BYTES.with(|b| b.replace(0)),
+            }
+        }
+    }
+
+    impl Drop for Scope {
+        fn drop(&mut self) {
+            let incl_allocs = ALLOCS.with(|a| a.get()).wrapping_sub(self.start_allocs);
+            let incl_bytes = BYTES.with(|b| b.get()).wrapping_sub(self.start_bytes);
+            let child_allocs = CHILD_ALLOCS.with(|a| a.replace(self.parent_child_allocs));
+            let child_bytes = CHILD_BYTES.with(|b| b.replace(self.parent_child_bytes));
+            CHILD_ALLOCS.with(|a| a.set(a.get().wrapping_add(incl_allocs)));
+            CHILD_BYTES.with(|b| b.set(b.get().wrapping_add(incl_bytes)));
+
+            // Fold into the shared report with counting suspended: the map's
+            // own growth is not part of the program's allocation behavior.
+            let was = SUSPENDED.with(|s| s.replace(true));
+            if let Ok(mut map) = report().lock() {
+                let e = map.entry(self.label).or_default();
+                e.entries += 1;
+                e.incl_allocs += incl_allocs;
+                e.incl_bytes += incl_bytes;
+                e.excl_allocs += incl_allocs.saturating_sub(child_allocs);
+                e.excl_bytes += incl_bytes.saturating_sub(child_bytes);
+            }
+            SUSPENDED.with(|s| s.set(was));
+        }
+    }
+
+    /// Print the per-scope allocation report to stderr.
+    ///
+    /// No-op unless `MUTSU_ALLOC_STATS` is set, so an `alloc-stats` build still
+    /// behaves like a normal one for anything that reads stderr (the `t/` TAP
+    /// suite, `is_run`-style tests) unless measurement was asked for.
+    pub fn dump() {
+        if std::env::var_os("MUTSU_ALLOC_STATS").is_none() {
+            return;
+        }
+        let Ok(map) = report().lock() else { return };
+        let mut rows: Vec<(&&str, &Stats)> = map.iter().collect();
+        rows.sort_by_key(|(_, s)| std::cmp::Reverse(s.excl_allocs));
+        eprintln!(
+            "alloc-stats: {:<36} {:>10} {:>12} {:>12} {:>12} {:>12} {:>10}",
+            "scope",
+            "entries",
+            "incl-allocs",
+            "excl-allocs",
+            "incl-bytes",
+            "excl-bytes",
+            "per-entry"
+        );
+        for (label, s) in rows {
+            let per_entry = if s.entries == 0 {
+                0.0
+            } else {
+                s.incl_allocs as f64 / s.entries as f64
+            };
+            eprintln!(
+                "alloc-stats: {:<36} {:>10} {:>12} {:>12} {:>12} {:>12} {:>10.1}",
+                label,
+                s.entries,
+                s.incl_allocs,
+                s.excl_allocs,
+                s.incl_bytes,
+                s.excl_bytes,
+                per_entry
+            );
+        }
+        // The process-wide total is the main thread's raw counter; it bounds
+        // every scope's inclusive number and shows how much of the run the
+        // instrumented scopes actually cover.
+        eprintln!(
+            "alloc-stats: process total (main thread): {} allocations, {} bytes",
+            ALLOCS.with(|a| a.get()),
+            BYTES.with(|b| b.get())
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod alloc_stats;
 pub mod analysis;
 pub mod anon_names;
 mod ast;
@@ -38,7 +39,16 @@ pub use value::{RuntimeError, RuntimeErrorCode, Value};
 /// progress on decoupling the bytecode VM from the tree-walking interpreter.
 pub fn dump_vm_stats() {
     vm::vm_stats::dump();
+    alloc_stats::dump();
 }
+
+/// Count every allocation the process makes, so `alloc_scope!` regions can
+/// report exact per-scope allocation counts. Only compiled in under the
+/// measurement-only `alloc-stats` feature; a default build uses the system
+/// allocator unwrapped. See `src/alloc_stats.rs`.
+#[cfg(feature = "alloc-stats")]
+#[global_allocator]
+static ALLOC: alloc_stats::CountingAllocator = alloc_stats::CountingAllocator;
 
 /// Register the calling thread as the interpreter's main mutator thread for
 /// the GC's cooperative stop-the-world accounting (`gc::stw`). The CLI entry

--- a/src/runtime/class_dispatch.rs
+++ b/src/runtime/class_dispatch.rs
@@ -552,6 +552,7 @@ impl Interpreter {
         args: Vec<Value>,
         invocant: Option<Value>,
     ) -> Result<(Value, Option<AttrMap>), RuntimeError> {
+        crate::alloc_scope!("resolved-method-celled");
         // Writeback-safety gate (§B, #3658 step 4 — free_var_writes filter REMOVED).
         // Any resolved candidate that has compiled bytecode and is not a delegation
         // forwarder now runs compiled, regardless of what free vars it writes:
@@ -607,10 +608,13 @@ impl Interpreter {
                 )
                 .map(|(v, updated)| (v, Some(updated)));
         }
+        crate::alloc_scope_named!(_sc_cc, "resolved-method-celled:prep");
         let cc = method_def.compiled_code.clone().unwrap();
         let empty_fns = crate::opcode::CompiledFns::default();
         let fns_ref = method_def.compiled_fns.as_deref().unwrap_or(&empty_fns);
         let saved_pending = std::mem::take(&mut self.pending_rw_writeback_sources);
+        crate::alloc_scope_end!(_sc_cc);
+        crate::alloc_scope_named!(_sc_call, "resolved-method-celled:call");
         let call_result = self.call_compiled_method(
             receiver_class_name,
             owner_class,
@@ -622,6 +626,7 @@ impl Interpreter {
             invocant,
             fns_ref,
         );
+        crate::alloc_scope_end!(_sc_call);
         // MERGE the saved sibling writes (e.g. a sibling BUILD's captured-outer
         // write queued for the outer `.new` caller to drain, #3620) with the
         // body's OWN captured-outer writes that `call_compiled_method` recorded

--- a/src/runtime/ctor_phase_plan.rs
+++ b/src/runtime/ctor_phase_plan.rs
@@ -181,15 +181,18 @@ impl Interpreter {
         role_fail: PhaseFail,
         class_fail: PhaseFail,
     ) -> Result<Result<(), Value>, RuntimeError> {
+        crate::alloc_scope!("phase-steps");
         let Some(cell) = Self::self_instance_attrs(inv) else {
             return Ok(Ok(()));
         };
         let plan = self.native_ctor_plan(class_name);
+        crate::alloc_scope_named!(_sc_steps, "phase-steps:clone-steps");
         let steps = if method_name == "BUILD" {
             plan.build_steps.clone()
         } else {
             plan.tweak_steps.clone()
         };
+        crate::alloc_scope_end!(_sc_steps);
         if steps.is_empty() {
             return Ok(Ok(()));
         }
@@ -200,6 +203,7 @@ impl Interpreter {
         let mut probe_owned: Option<AttrMap> = None;
         let cn = class_name.resolve();
         for step in steps.iter() {
+            crate::alloc_scope!("phase-steps:step");
             if live_has_alias {
                 probe_owned = Some(cell.to_map());
             }

--- a/src/runtime/methods_dispatch_new.rs
+++ b/src/runtime/methods_dispatch_new.rs
@@ -314,6 +314,7 @@ impl Interpreter {
 
     /// Handle the "bless" method: creates a new instance with attributes from named args.
     fn dispatch_bless(&mut self, target: &Value, args: Vec<Value>) -> Result<Value, RuntimeError> {
+        crate::alloc_scope!("bless");
         // self.bless(:attr1($val1), :attr2($val2), ...)
         // Creates a new instance of the invocant's class with attributes from named args
         let class_name = match target.view() {
@@ -351,6 +352,7 @@ impl Interpreter {
         // (shape-only data, invalidated with the dispatch caches) instead of
         // being re-collected on every bless.
         let plan = self.native_ctor_plan(class_name);
+        crate::alloc_scope_named!(_sc_defaults, "bless:attr-defaults");
         let cn_resolved = class_name.as_str();
         let mut attributes = AttrMap::with_capacity(plan.class_attrs.len());
         let mut deferred_defaults: Vec<super::attr_build_defaults::DeferredAttrDefault> =
@@ -453,6 +455,8 @@ impl Interpreter {
             }
             attributes.insert(attr_sym, val);
         }
+        crate::alloc_scope_end!(_sc_defaults);
+        crate::alloc_scope_named!(_sc_named, "bless:named-args");
         // Override with named args from bless call. A key that names a declared
         // attribute reuses its pre-interned Symbol (the common case — `|%_`
         // passthrough in a user `new`); anything else interns as before.
@@ -486,6 +490,8 @@ impl Interpreter {
                 deferred_defaults.retain(|d| d.name.as_str() != &**key);
             }
         }
+        crate::alloc_scope_end!(_sc_named);
+        crate::alloc_scope_named!(_sc_container, "bless:container-subclass");
         // Array-subclass construction: an `is Array` subclass reaches the base
         // `Array.new(1, 2, 3)` semantics through `nextwith(|@values)` in its own
         // `new`, which lands here as `bless` with positional (non-Pair) args.
@@ -559,17 +565,21 @@ impl Interpreter {
         }
         // Embed `is default(...)` element defaults into `@`/`%` containers.
         self.apply_container_attribute_defaults(cn_resolved, &mut attributes);
+        crate::alloc_scope_end!(_sc_container);
         // Build the instance BEFORE the BUILD/TWEAK phases and thread its shared
         // attribute cell through them (raku semantics: `self` inside BUILD/TWEAK
         // IS the constructed object — same identity, mutations through a stored
         // `self` alias stay visible). This also drops the former per-phase-step
         // AttrMap clones + phantom intermediate instances (each of which was
         // queued for DESTROY).
+        crate::alloc_scope_named!(_sc_mk, "bless:make-instance");
         let inv = Value::make_instance(class_name, attributes);
+        crate::alloc_scope_end!(_sc_mk);
         // Run BUILD/TWEAK submethods in MRO order (base-first). The whole BUILD
         // walk (per-MRO-class registry probes + role-submethod ordering) is
         // skipped when the plan says no class or composed role declares one.
         if plan.has_build {
+            crate::alloc_scope!("bless:build-phase");
             self.push_build_write_frame(&inv);
             let build_result = self.run_bless_build_phase(class_name, &inv, &args);
             let build_writes = self.pop_build_write_frame();
@@ -591,6 +601,7 @@ impl Interpreter {
         // parameter binds -- the args are also pre-folded into `attributes` above
         // for the common no-explicit-BUILD case.
         if plan.has_tweak {
+            crate::alloc_scope!("bless:tweak-phase");
             match self.run_tweak_phase(class_name, &inv, &args)? {
                 Ok(()) => {}
                 // `fail` inside TWEAK: return the Failure instead of the instance.
@@ -616,18 +627,17 @@ impl Interpreter {
         instance: &Value,
         args: &[Value],
     ) -> Result<(), RuntimeError> {
-        let has_user = |zelf: &mut Self, m: &str| {
-            zelf.class_mro(class_key).iter().any(|c| {
-                zelf.registry()
-                    .user_method_overloads(c.as_str(), m)
-                    .is_some()
-            })
-        };
-        let method = if has_user(self, "BUILDALL") {
-            "BUILDALL"
-        } else if has_user(self, "POPULATE") {
-            "POPULATE"
-        } else {
+        // The MRO x {BUILDALL, POPULATE} probe this used to run per
+        // construction is pure class shape, so it is precomputed once per class
+        // in the `NativeCtorPlan` (`user_buildall`) next to `has_build` /
+        // `has_tweak`. Answering `None` — the overwhelmingly common case — is
+        // now a cached-plan field read instead of an MRO walk of registry
+        // lookups that interned both the class and the method name at every
+        // level.
+        let Some(method) = self
+            .native_ctor_plan(crate::symbol::Symbol::intern(class_key))
+            .user_buildall
+        else {
             return Ok(());
         };
         self.call_method_with_values(instance.clone(), method, args.to_vec())?;

--- a/src/runtime/methods_object.rs
+++ b/src/runtime/methods_object.rs
@@ -288,6 +288,7 @@ impl Interpreter {
             has_custom_bless,
             has_container_defaults,
             attrs_fully_known,
+            user_buildall,
         ) = if registered {
             let class_attrs = std::sync::Arc::new(self.collect_class_attributes(cn_resolved));
             let type_constraints =
@@ -328,6 +329,21 @@ impl Interpreter {
                 });
             }
             let has_custom_bless = self.has_user_method(cn_resolved, "bless");
+            // Same MRO probe `run_user_buildall_hook` ran per construction.
+            let user_buildall = {
+                let registry = self.registry();
+                let declares = |m: &str| {
+                    mro.iter()
+                        .any(|cls| registry.user_method_overloads(cls, m).is_some())
+                };
+                if declares("BUILDALL") {
+                    Some("BUILDALL")
+                } else if declares("POPULATE") {
+                    Some("POPULATE")
+                } else {
+                    None
+                }
+            };
             // See `NativeCtorPlan::attrs_fully_known`. Roles are flattened into
             // `ClassDef::attributes` at composition time, so only the MRO's
             // classes need to be registered for the attribute set to be complete.
@@ -371,6 +387,7 @@ impl Interpreter {
                 has_custom_bless,
                 has_container_defaults,
                 attrs_fully_known,
+                user_buildall,
             )
         } else {
             (
@@ -382,6 +399,7 @@ impl Interpreter {
                 false,
                 false,
                 false,
+                None,
             )
         };
         let attr_syms = std::sync::Arc::new(
@@ -436,6 +454,7 @@ impl Interpreter {
             build_steps,
             tweak_steps,
             probe_skeleton,
+            user_buildall,
         });
         // Don't freeze a plan for a class that is not (yet) registered: e.g. a
         // role punned to a class on first use would otherwise keep a stale

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1108,6 +1108,13 @@ pub(crate) struct NativeCtorPlan {
     /// `run_construction_phase_steps`), so the per-construction whole-cell
     /// `to_map()` value clone is skipped.
     pub(crate) probe_skeleton: Arc<crate::value::AttrMap>,
+    /// Which user-defined whole-object build hook this class's MRO declares —
+    /// `Some("BUILDALL")`, `Some("POPULATE")`, or `None` (the overwhelmingly
+    /// common case). `run_user_buildall_hook` probed this per construction with
+    /// an MRO walk x 2 method names of `user_method_overloads` lookups, each
+    /// interning both names; the answer is pure class shape, so it belongs in
+    /// the plan next to `has_build`/`has_tweak`/`has_custom_bless`.
+    pub(crate) user_buildall: Option<&'static str>,
 }
 
 /// One pre-derived step of a construction phase (BUILD or TWEAK) — see

--- a/src/symbol.rs
+++ b/src/symbol.rs
@@ -167,6 +167,38 @@ pub(crate) mod wk {
         /// must never be re-interned there -- the thread-local intern cache is
         /// a string-keyed hash lookup, which showed up as 5.3% of `bench-fib`.
         rebound_return => "&return";
+        /// The invocant, `self`. One of the fixed env keys every compiled
+        /// method call writes on entry (see the family below).
+        self_ => "self";
+        /// `$.foo` desugaring's alias for the invocant, written next to `self`.
+        anon_state => "__ANON_STATE__";
+        /// `::?CLASS`, written on every compiled method entry.
+        class_decl => "?CLASS";
+        /// `::?ROLE`: written when the method came from a role, removed
+        /// otherwise — so a method call touches this key either way.
+        role_decl => "?ROLE";
+        /// The per-routine `$!`, reset to Nil on entry.
+        error_var => "!";
+        /// The invocation id a non-local return from an inner block targets.
+        callable_id => "__mutsu_callable_id";
+        /// The implicit `*%_` named slurpy every method carries.
+        named_slurpy => "%_";
+    }
+
+    /// Whether `key` is one of the fixed per-call env keys the well-known
+    /// method-entry family above covers. Only used by debug assertions and
+    /// tests that check the string-keyed and symbol-keyed spellings agree.
+    #[cfg(test)]
+    pub(crate) fn method_entry_keys() -> [(Symbol, &'static str); 7] {
+        [
+            (self_(), "self"),
+            (anon_state(), "__ANON_STATE__"),
+            (class_decl(), "?CLASS"),
+            (role_decl(), "?ROLE"),
+            (error_var(), "!"),
+            (callable_id(), "__mutsu_callable_id"),
+            (named_slurpy(), "%_"),
+        ]
     }
 }
 
@@ -535,5 +567,22 @@ mod tests {
         let before = capture_shaped_symbols().0.len();
         let _ = Symbol::intern("31337");
         assert_eq!(capture_shaped_symbols().0.len(), before);
+    }
+
+    #[test]
+    fn method_entry_well_known_symbols_match_their_strings() {
+        // The compiled method-call paths write these env keys symbol-keyed
+        // (`insert_sym`) instead of allocating a `String` per call. A typo in
+        // one of the literals would not fail to compile -- it would silently
+        // write a DIFFERENT env key, so `self` / `?CLASS` / `%_` would read as
+        // undefined inside every method body. Pin each against the string
+        // spelling the interpreter's other (string-keyed) readers use.
+        for (sym, text) in wk::method_entry_keys() {
+            assert_eq!(sym, Symbol::intern(text), "well-known symbol {text:?}");
+            assert!(
+                sym.with_str(|s| s == text),
+                "well-known symbol {text:?} resolves to a different string"
+            );
+        }
     }
 }

--- a/src/vm/vm_method_dispatch.rs
+++ b/src/vm/vm_method_dispatch.rs
@@ -19,6 +19,7 @@ impl Interpreter {
         invocant: Option<Value>,
         compiled_fns: &CompiledFns,
     ) -> Result<(Value, Option<AttrMap>), RuntimeError> {
+        crate::alloc_scope!("call-compiled-method");
         // Slice F: the rw-writeback source list is drained by the CallMethod /
         // CallMethodMut op right after this dispatch returns, so it must hold
         // only this call's sources. Clear any leftover from a sibling whose call
@@ -413,28 +414,36 @@ impl Interpreter {
             self.set_current_package(owner_class.to_string());
         }
 
-        // Set self and __ANON_STATE__ (used by `$.foo` desugaring inside methods)
-        self.env_mut().insert("self".to_string(), base.clone());
+        // Set self and __ANON_STATE__ (used by `$.foo` desugaring inside methods).
+        // Symbol-keyed: these fixed per-call keys are pre-interned well-known
+        // symbols (`symbol::wk`), so a method entry no longer allocates a
+        // `String` per key just to hand it to `Symbol::intern`. None of them is
+        // a `note_env_key`-tracked metadata name (a `^` placeholder or one of
+        // the `__mutsu_bound::`-style families), so skipping that latch — which
+        // `insert_sym` does not run — is sound here.
         self.env_mut()
-            .insert("__ANON_STATE__".to_string(), base.clone());
+            .insert_sym(crate::symbol::wk::self_(), base.clone());
+        self.env_mut()
+            .insert_sym(crate::symbol::wk::anon_state(), base.clone());
 
         // In Raku, methods do NOT set $_ to the invocant by default.
         // $_ in a method body is Any unless the invocant is explicitly named $_
         // (e.g. `method foo ($_: ) { ... }`). The invocant binding loop below
         // will set $_ back to self if the invocant param is named "_".
-        self.env_mut().insert(
-            "_".to_string(),
-            Value::package(crate::symbol::Symbol::intern("Any")),
+        self.env_mut().insert_sym(
+            crate::symbol::wk::topic(),
+            Value::package(crate::symbol::wk::any()),
         );
 
         // Raku: $! is scoped per routine — fresh Nil on entry
-        self.env_mut().insert("!".to_string(), Value::NIL);
+        self.env_mut()
+            .insert_sym(crate::symbol::wk::error_var(), Value::NIL);
 
         // Assign a unique callable ID for this method invocation so that
         // non-local returns from blocks defined inside this method can target it.
         let method_callable_id = crate::value::next_instance_id();
-        self.env_mut().insert(
-            "__mutsu_callable_id".to_string(),
+        self.env_mut().insert_sym(
+            crate::symbol::wk::callable_id(),
             Value::int(method_callable_id as i64),
         );
 
@@ -1404,6 +1413,22 @@ impl Interpreter {
     /// profiles); the returned map is `Some` only when the `:=` reconcile
     /// adjusted it beyond the cell contents.
     #[allow(clippy::too_many_arguments)]
+    /// Insert the fast path's bound parameters into `env`.
+    ///
+    /// Symbol-keyed so a call does not allocate a `String` per parameter just
+    /// to hand it to `Symbol::intern` (the name is already a `&str` borrowed
+    /// from the method def). A parameter name IS name-derived, so unlike the
+    /// fixed well-known keys around it this must still run
+    /// [`crate::env::note_env_key`] — a placeholder parameter (`$^a`) is stored
+    /// under a `^`-prefixed key, and dropping that latch would leave
+    /// `placeholder_var_possible()` reading false while such a key is live.
+    fn insert_fast_param_values(env: &mut crate::env::Env, param_values: &[(&str, Value)]) {
+        for (param_name, param_val) in param_values {
+            crate::env::note_env_key(param_name);
+            env.insert_sym(crate::symbol::Symbol::intern(param_name), param_val.clone());
+        }
+    }
+
     #[allow(clippy::too_many_arguments)]
     pub(super) fn call_compiled_method_fast(
         &mut self,
@@ -1417,6 +1442,8 @@ impl Interpreter {
         compiled_fns: &CompiledFns,
         can_skip_merge: bool,
     ) -> Result<(Value, Option<AttrMap>), RuntimeError> {
+        crate::alloc_scope!("mfast");
+        crate::alloc_scope_named!(_sc_pro, "mfast:prologue");
         let attrs_cell = match base.view() {
             ValueView::Instance { attributes, .. } => Some(attributes.clone()),
             _ => None,
@@ -1519,6 +1546,8 @@ impl Interpreter {
         // arguments the way the slow binder does; named params match Pair args
         // by key (rightmost wins), and attributive named params write through
         // the invocant's live attribute cell exactly like `bind_param_value`.
+        crate::alloc_scope_end!(_sc_pro);
+        crate::alloc_scope_named!(_sc_bind, "mfast:param-bind");
         let mut param_values: Vec<(&str, Value)> = Vec::new();
         let mut arg_idx = 0;
         for (idx, param_name) in method_def.params.iter().enumerate() {
@@ -1630,6 +1659,8 @@ impl Interpreter {
             }
         }
 
+        crate::alloc_scope_end!(_sc_bind);
+        crate::alloc_scope_named!(_sc_env, "mfast:env-setup");
         // Build class value for ?CLASS
         let class_val = Value::package(crate::symbol::Symbol::intern(owner_class));
         let method_callable_id = crate::value::next_instance_id();
@@ -1647,50 +1678,48 @@ impl Interpreter {
         self.inject_class_body_statics(owner_class);
         if skip_env_setup {
             let env = self.env_mut();
-            env.insert("self".to_string(), base.clone());
-            env.insert("__ANON_STATE__".to_string(), base.clone());
-            env.insert("?CLASS".to_string(), class_val.clone());
-            env.insert("_".to_string(), any_val.clone());
+            env.insert_sym(crate::symbol::wk::self_(), base.clone());
+            env.insert_sym(crate::symbol::wk::anon_state(), base.clone());
+            env.insert_sym(crate::symbol::wk::class_decl(), class_val.clone());
+            env.insert_sym(crate::symbol::wk::topic(), any_val.clone());
             if let Some(ref role_name) = role_context {
-                env.insert(
-                    "?ROLE".to_string(),
+                env.insert_sym(
+                    crate::symbol::wk::role_decl(),
                     Value::package(crate::symbol::Symbol::intern(role_name)),
                 );
             } else {
-                env.remove("?ROLE");
+                env.remove_sym(crate::symbol::wk::role_decl());
             }
-            for (param_name, param_val) in &param_values {
-                env.insert(param_name.to_string(), param_val.clone());
-            }
+            Self::insert_fast_param_values(env, &param_values);
         } else {
             let env = self.env_mut();
-            env.insert("self".to_string(), base.clone());
-            env.insert("__ANON_STATE__".to_string(), base.clone());
-            env.insert("?CLASS".to_string(), class_val.clone());
-            env.insert("_".to_string(), any_val.clone());
-            env.insert("!".to_string(), Value::NIL);
-            env.insert(
-                "__mutsu_callable_id".to_string(),
+            env.insert_sym(crate::symbol::wk::self_(), base.clone());
+            env.insert_sym(crate::symbol::wk::anon_state(), base.clone());
+            env.insert_sym(crate::symbol::wk::class_decl(), class_val.clone());
+            env.insert_sym(crate::symbol::wk::topic(), any_val.clone());
+            env.insert_sym(crate::symbol::wk::error_var(), Value::NIL);
+            env.insert_sym(
+                crate::symbol::wk::callable_id(),
                 Value::int(method_callable_id as i64),
             );
             if let Some(ref role_name) = role_context {
-                env.insert(
-                    "?ROLE".to_string(),
+                env.insert_sym(
+                    crate::symbol::wk::role_decl(),
                     Value::package(crate::symbol::Symbol::intern(role_name)),
                 );
             } else {
-                env.remove("?ROLE");
+                env.remove_sym(crate::symbol::wk::role_decl());
             }
             // Array/hash attribute env copies are no longer materialized here:
             // reads are cell-direct (Stage 2b) and the mutating ops refresh
             // env/locals from the live cell pre-op (`array_hash_attr_env_snapshot`),
             // so a closure capturing this env resolves `@!a`/`%!h` through the
             // captured `self` instead of a stale env snapshot.
-            for (param_name, param_val) in &param_values {
-                env.insert(param_name.to_string(), param_val.clone());
-            }
+            Self::insert_fast_param_values(env, &param_values);
         }
 
+        crate::alloc_scope_end!(_sc_env);
+        crate::alloc_scope_named!(_sc_loc, "mfast:slurpy-captures-locals");
         // Bind the method's implicit `*%_` slurpy (a Hash of the leftover named
         // args, empty when none). The compiler adds a `*%_` param to every method;
         // the slow `bind_function_args_values` path fills it, but this fast path
@@ -1715,7 +1744,8 @@ impl Interpreter {
         // lookup -- it strips the sigil and searches "_" -- can't resolve, falling
         // back to the topic `$_`).
         if let Some(slurpy) = &implicit_named_slurpy {
-            self.env_mut().insert("%_".to_string(), slurpy.clone());
+            self.env_mut()
+                .insert_sym(crate::symbol::wk::named_slurpy(), slurpy.clone());
         }
 
         // A method can carry its defining lexical environment either from an
@@ -1846,6 +1876,8 @@ impl Interpreter {
             }
         }
 
+        crate::alloc_scope_end!(_sc_loc);
+        crate::alloc_scope_named!(_sc_body, "mfast:body");
         self.push_method_routine_with_location(
             Symbol::intern(owner_class),
             Symbol::intern(&method_def.lexical_package),
@@ -1972,6 +2004,8 @@ impl Interpreter {
             loan_env!(self, set_state_var(scoped_key, val));
         }
         self.state_scope_id.set(saved_state_scope);
+        crate::alloc_scope_end!(_sc_body);
+        crate::alloc_scope!("mfast:epilogue");
 
         if !can_skip_merge {
             // Non-can_skip_merge: AssignExpr may have written attribute values to

--- a/todo/perf/adr0019-g3-diffuse-bless-allocation-cost.md
+++ b/todo/perf/adr0019-g3-diffuse-bless-allocation-cost.md
@@ -160,3 +160,76 @@ round 2 swapped: new 1.13s / base 1.21s). `t/*constant*.t` (18 files) and the fu
 
 Landed as a second commit on the same PR as the `AttrMap` pre-sizing fix (both are G3-investigation
 findings from this session; see the PR for the combined test plan).
+
+## 2026-09-06: the tooling blocker is gone — `alloc_scope!` answers the attribution question
+
+The "Next steps for a dedicated perf session" list above offered two routes past the dead
+`perf --call-graph`: fix the debug store, or "build a debug/instrumented binary with a counting
+`#[global_allocator]` wrapper ... deterministic, environment-independent, and answers 'how many
+allocations does constructing a 20-attr object cost' without needing symbolized call graphs at
+all". The second route was taken and landed (see
+`news/2026-09/alloc-scope-accounting-and-method-entry-symbol-keys.md`).
+
+`src/alloc_stats.rs` + the `alloc-stats` cargo feature give exact, load-independent per-region
+allocation counts:
+
+```
+cargo build --release --features alloc-stats
+MUTSU_ALLOC_STATS=1 ./target/release/mutsu benchmarks/bench-ctor.raku
+```
+
+`alloc_scope!("label")` (and `alloc_scope_named!`/`alloc_scope_end!` for sequential phases) reports
+allocations and bytes both inclusive and exclusive of nested scopes. With the feature off it expands
+to nothing, so the call sites now marking up the construction and method-dispatch paths cost an
+ordinary build nothing. **Use this, not `perf`, for any further work on this ticket** — the
+`/root/.debug` build-id problem was never solved and does not need to be.
+
+`callgrind` also turned out to work in this container (`valgrind` and `callgrind_annotate` are both
+installed), and `callgrind_annotate --tree=caller` gives the caller attribution `perf` could not.
+Run it on a reduced-iteration copy of the benchmark; it is ~50x slower than native.
+
+### What the attribution actually says
+
+Per 5000 `bench-ctor` constructions, 1,646,587 allocations. **The premise this ticket was written
+under is wrong: `bless` is not where the cost is.**
+
+| region | allocations / construction |
+| --- | --- |
+| `bless` body + attribute-default seeding + instance build | ~21 |
+| `bless`'s TWEAK phase (2 MRO levels) | ~111 |
+| **`call_compiled_method`, exclusive of everything it calls** | **~70 per method call, 64% of the entire program** |
+
+Of that ~70, roughly 29 are call-*frame* overhead — paid identically by `submethod TWEAK(:$!spec) { }`,
+which has an empty body. The `AttrMap::with_capacity` pre-sizing from the 2026-08-17 session had
+already flattened the map-growth cost it targeted; what remained was never in `bless` at all.
+
+Two fixes landed from this (details in the news entry): the fixed per-method-call env keys are now
+pre-interned `symbol::wk` symbols written with `insert_sym` instead of a `String` allocated per key
+per call (`mfast:env-setup` 9.0 -> 2.7 allocations/call; whole program -6.7%), and the
+`BUILDALL`/`POPULATE` MRO probe moved into `NativeCtorPlan::user_buildall` (no allocations, but it
+removes ~16 `Symbol::intern` thread-local lookups per construction on a path `callgrind` showed
+spending 6.5% of the program in that function).
+
+Order-swapped min-of-9 A/B, `MUTSU_JIT=off`: `bench-ctor` -3.5%, `bench-class` -4.6%.
+
+### Next step (specified, not speculative): the implicit `*%_` slurpy
+
+The largest single remaining item the tool identifies is `mfast:slurpy-captures-locals` at **10.3
+allocations per method call (~10% of `bench-ctor`'s total)**, and essentially all of it is
+`implicit_method_named_slurpy` (`src/runtime/types/binding_helpers.rs`). Every compiled method call
+materializes the implicit `*%_` — a `HashMap` grown incrementally, a `String` per leftover named
+key, and a `Value` hash — **whether or not the body can ever observe `%_`**. `submethod TWEAK(:$!spec) { }`
+builds a 7-key hash and throws it away.
+
+The fix is a compile-time gate, in the shape of the existing `uses_dispatcher` flag (added for
+precisely this reason: "so a plain method call that never defers pays no per-call String/Vec
+clone"). Compute, once per `CompiledCode`, whether the body *or any nested closure body* mentions
+`%_` — over-approximating is fine and safe, since a false positive only keeps today's behavior — and
+skip both the `%_` env insert and the hash construction when it definitely does not. The escape
+hatches to over-approximate on are `EVAL` and dynamic-name lookup (`::('%_')`), which can reach a
+lexical without naming it in the constant pool.
+
+This is a compiler-analysis slice rather than a dispatch one, which is why it was not folded into
+the PR above. Remaining smaller items, in order: `bless:named-args` (11 allocations per bless, the
+sigil-coercion clone loop), `mfast:epilogue` (5.1/call), and the `format!("{}\0{}")` qualified
+private-attribute key built per private-attribute local per call in the fast path's locals-init loop.


### PR DESCRIPTION
ADR-0019 G3 (`todo/perf/adr0019-g3-diffuse-bless-allocation-cost.md`) was blocked on **measurement**, not on coding. `bench-ctor`'s cost is diffuse — a flat `perf` profile shows ~7% in `malloc`/`free` and ~6.5% in NaN-box GC/refcount ops with no single hot function — and the follow-up question *"which caller is doing all that allocating?"* was unanswerable, because call-graph attribution does not work in this container (`--call-graph dwarf` dies on a stale `/root/.debug` build-id store, `--call-graph fp` yields garbage stacks through the optimized build).

The ticket's own next-steps list proposed building a counting allocator instead. This is that tool, plus the first two fixes it found.

## The tool: `alloc_scope!` + the `alloc-stats` feature

`src/alloc_stats.rs` adds a measurement-only cargo feature. With it on, a counting `#[global_allocator]` wraps `System` and `alloc_scope!("label")` opens an accounting region for the rest of its block (`alloc_scope_named!` / `alloc_scope_end!` close one early, so a function splits into sequential phases without being re-indented into nested blocks):

```
cargo build --release --features alloc-stats
MUTSU_ALLOC_STATS=1 ./target/release/mutsu benchmarks/bench-ctor.raku
```

Each scope reports its entry count and its allocations/bytes both **inclusive** of nested scopes and **exclusive** of them, so a nested set reads like a profiler's self-time column. Counts are exact and load-independent — the same property that makes the `MUTSU_VM_STATS` counters, not local wall-clock, the right thing to iterate a change against.

With the feature off — every ordinary build, and everything CI compiles — the macro expands to nothing and the allocator is not installed, so the call sites now marking up the construction and method-dispatch paths cost nothing and stand as executable documentation of that path's cost structure. (`callgrind` also turns out to work here; `callgrind_annotate --tree=caller` gives the caller attribution `perf` could not. Both are written up in CLAUDE.md.)

## What it found

**The ticket's premise was wrong: `bless` is not where the cost is.** Per 5000 `bench-ctor` constructions (1,646,587 allocations total):

| region | allocations / construction |
| --- | --- |
| `bless` body + attribute-default seeding + instance build | ~21 |
| `bless`'s TWEAK phase (2 MRO levels) | ~111 |
| **`call_compiled_method`, exclusive of everything it calls** | **~70 per method call — 64% of the entire program** |

Of that ~70, ~29 are pure call-*frame* setup, paid identically by `submethod TWEAK(:$!spec) { }`, whose body is empty. The `AttrMap::with_capacity` pre-sizing from the previous session had already flattened the map-growth cost it targeted; what remained was never in `bless`.

## Fix 1 — the fixed per-call env keys become pre-interned symbols

Both compiled method-call paths opened a frame by writing a fixed set of env keys — `self`, `__ANON_STATE__`, `?CLASS`, `?ROLE`, `_`, `!`, `__mutsu_callable_id`, `%_` — through `Env::insert(String, Value)`, which allocates a `String` only to hand it to `Symbol::intern` and drop it again. Bound parameters went the same way, one `String` per parameter per call.

`symbol::wk` already existed for exactly this problem — its `rebound_return` entry carries the note that re-interning a name on a hot path "showed up as 5.3% of `bench-fib`", because the thread-local intern cache is a string-keyed hash lookup. The method-entry key family had simply never been given the same treatment. Now the fixed keys are `wk` symbols written with `insert_sym`, and parameters intern their borrowed `&str` directly instead of allocating a copy first.

`insert_sym` deliberately does not run `env::note_env_key` (the latch recording whether any `^placeholder` / `__mutsu_bound::`-family metadata key may exist). None of the fixed keys is one of those, so skipping it is sound; a *parameter* name can be `^`-prefixed, so the parameter helper calls `note_env_key` itself. A unit test pins each well-known symbol against its string spelling — a typo there would compile fine and silently write the wrong env key.

## Fix 2 — the `BUILDALL`/`POPULATE` probe moves into the per-class plan

Every `bless` ended by asking whether the class declares a user `BUILDALL` or `POPULATE`, and asked by walking the MRO twice through `Registry::user_method_overloads`, interning both the class and method name at every level (~16 interns per construction) to reach the `None` that essentially every class gives. That is pure class shape, so it now sits in `NativeCtorPlan::user_buildall` beside the `has_build` / `has_tweak` / `has_custom_bless` probes moved there for the same reason. It allocated nothing; what it removes is instruction count on a path `callgrind` showed spending 6.5% of the program inside `Symbol::intern`'s thread-local lookup.

## Results

- `mfast:env-setup`: **9.0 → 2.7** allocations per method call
- whole program: **1,646,587 → 1,536,588** allocations (**−6.7%**)
- Order-swapped min-of-9 wall-clock A/B vs. the pre-change binary, `MUTSU_JIT=off`: **`bench-ctor` −3.5%, `bench-class` −4.6%** — both improving in both orders. The change helps *every* method call, not just construction, which is why `bench-class` (no bless-heavy shape at all) is the larger win.

Local numbers are for the in-flight decision only; the documented trend comes from the bench CI (`bench-history.tsv`) as usual.

## Not in this PR (and why)

The tool localizes the next target precisely: the implicit `*%_` slurpy hash, materialized on **every** method call whether or not the body can observe it — **10.3 allocations/call, ~10% of `bench-ctor`'s total**. The fix is a compile-time "does this body or any nested closure mention `%_`" gate, in the shape of the existing `uses_dispatcher` flag. That is a compiler-analysis slice rather than a dispatch one, so it is specified in the ticket rather than folded in here. The ticket stays open.

## Test plan

- `make test`: 3724 files, 38376 tests. Four failures, all environmental and none caused by this change:
  - `t/io-path-smartmatch-permissions.t` — fails **identically on the pre-change baseline binary** (this container runs as root, so the effective-write-access check is true even for a read-only file).
  - `t/io-path-methods.t`, `t/io-socket-async-bin.t`, `t/io-socket-async-listen.t` — all pass serially with the new binary; they failed only under parallel `prove` (the port-collision / parallel-load family CLAUDE.md documents).
- `cargo clippy --all-targets -- -D warnings` clean in **both** the default and `--features alloc-stats` configurations.
- New unit test `method_entry_well_known_symbols_match_their_strings` guards the well-known symbol spellings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KitbyPcD9nMPmUZeq8vh7m

---
_Generated by [Claude Code](https://claude.ai/code/session_01KitbyPcD9nMPmUZeq8vh7m)_