### PR TITLE
docs: triage the sweep's second-highest-signal file into three tickets

### DIFF
--- a/docs/doc-diff-backlog.md
+++ b/docs/doc-diff-backlog.md
@@ -849,6 +849,33 @@ misleading about the cause:
   variable plus wiring it into the operator.
   → [todo/tickets/tolerance-dynamic-variable-is-undefined.md](../todo/tickets/tolerance-dynamic-variable-is-undefined.md)
 
+Found in the 2026-09-06 full re-sweep, second triage round, on its
+next-highest-signal file (`Language/structures.rakudoc`, 4 mismatch + 1 crash).
+All three reproduce against raku v2026.07 and each was narrowed to a repro
+smaller than the doc block:
+
+- `Language/structures.rakudoc:220` — a smartmatch whose right operand is the
+  **topic** returns `Bool` instead of the `Match`. Every other spelling (literal
+  regex, regex in a named variable, sub parameter, `WhateverCode`, inside a
+  `.map` block) answers correctly, so neither `.map`, nor the block, nor
+  regex-in-a-variable is the cause: `for (/a/,) { say ("ab" ~~ $_).raku }` is the
+  one-line repro.
+  → [todo/tickets/smartmatch-against-the-topic-returns-bool-not-match.md](../todo/tickets/smartmatch-against-the-topic-returns-bool-not-match.md)
+- `Language/structures.rakudoc:123` — an `is Array` subclass's `iterator`
+  override is ignored *and* the object iterates as a single item (`.say for
+  @thing` prints `[3 2 1 4]` on one line). The second half is the more visible
+  one: `for` never decomposed the instance at all.
+  → [todo/tickets/array-subclass-iterator-override-ignored.md](../todo/tickets/array-subclass-iterator-override-ignored.md)
+- `Language/structures.rakudoc:26` — `.VAR` on an itemized list element reports
+  the inner type (`List`) rather than `Scalar`, the mirror image of the
+  standing "`.VAR` reports `Scalar` whether or not a container arrived" warning
+  in ADR-0067's source finding.
+  → [todo/tickets/itemized-list-element-var-reports-inner-type.md](../todo/tickets/itemized-list-element-var-reports-inner-type.md)
+
+The file's other two rows are `raku-drift-from-doc` (a `.WHICH` address in the
+expected output) plus a `$Logger::get` example that raku itself answers oddly;
+neither is a mutsu defect.
+
 ### Deferred / deep (tracked elsewhere — do not re-open as a shallow slice)
 These root causes account for a large share of the survey's `mism`/`crash` and are
 intentionally deferred; see PLAN.md §8.5 and the ADRs:

--- a/todo/tickets/array-subclass-iterator-override-ignored.md
+++ b/todo/tickets/array-subclass-iterator-override-ignored.md
@@ -1,0 +1,58 @@
+# An `is Array` subclass's `iterator` override is ignored, and the object iterates as one item
+
+Found by the 2026-09-06 doc-diff sweep (`raku-doc/doc/Language/structures.rakudoc:123`),
+re-verified against raku v2026.07 the same day.
+
+## Repro
+
+```raku
+class SortedArray is Array {
+    method iterator() { self.sort.iterator }
+}
+my @thing := SortedArray.new([3,2,1,4]);
+.say for @thing;
+# raku:  1 2 3 4  (four lines)
+# mutsu: [3 2 1 4]  (one line)
+```
+
+Two things are wrong and they may be one cause or two:
+
+1. the user's `iterator` override is not consulted, and
+2. the object is iterated as a **single item** rather than as its four
+   elements — mutsu prints the whole array on one line, so `for` never
+   decomposed it at all.
+
+The second is the more visible half: even without an `iterator` override, `for`
+over an `is Array` subclass instance should yield its elements.
+
+## Why it is not obviously small
+
+`delegates_to_array_storage` (`src/vm/vm_call_method_ops.rs`) already routes an
+`is Array`/`is List` subclass instance's non-user methods to its backing
+`__mutsu_array_storage`, with `is_type_identity_method` as the documented
+exception list. `iterator` is not in that exception list, so a *plain* `.iterator`
+call on such an instance probably already reaches the storage — which would
+answer the storage's iterator and ignore the override, matching what we see.
+But `for` may not go through method dispatch for its iterable at all: it has its
+own iterable-shape analysis, and that is the likelier reason the instance is
+treated as one item.
+
+So the fix has to decide, for an `is Array` subclass:
+
+- does `for` ask the object for an `iterator` (raku: yes, via the `Iterable`
+  protocol), and
+- when a user method of that name exists, does it win over the storage
+  delegation (raku: yes — a user method always wins).
+
+Both answers look like "yes", but the second one interacts with
+`delegates_to_array_storage`'s default-delegate design, which is deliberately
+the opposite of the Associative side's curated allowlist. Read that function's
+doc comment before changing it.
+
+## Neighbourhood to check when fixing
+
+`is List` as well as `is Array`; an `is Hash` subclass overriding `iterator`;
+overriding `AT-POS`/`elems`/`list`/`List`/`Seq` instead; `for`, `map`, `grep`,
+`.eager`, `|@thing` flattening, `@thing[0]` and `@thing.elems` over the same
+object; and `my @a := SortedArray.new(...)` vs `my $a = SortedArray.new(...)`
+(the repro uses `:=`).

--- a/todo/tickets/itemized-list-element-var-reports-inner-type.md
+++ b/todo/tickets/itemized-list-element-var-reports-inner-type.md
@@ -1,0 +1,48 @@
+# `.VAR` on an itemized list element reports the inner type, not `Scalar`
+
+Found by the 2026-09-06 doc-diff sweep (`raku-doc/doc/Language/structures.rakudoc:26`),
+re-verified against raku v2026.07 the same day.
+
+## Repro
+
+```raku
+(1, 2, 3, $(4, 5))[3].VAR.^name.say;
+# raku:  Scalar
+# mutsu: List
+```
+
+The `$(...)` itemization is exactly what puts a `Scalar` container around the
+inner list, and `.VAR` is the one introspection that is supposed to report it —
+that is the point of the doc example, which is illustrating "itemization is what
+makes a list one element".
+
+## Relationship to ADR-0064
+
+ADR-0064 made `.VAR` synthesise a container descriptor from the contained value
+rather than requiring a real container to exist. That is what lets
+`$obj.attr.VAR.^name` answer `Scalar` without every attribute being boxed. This
+row looks like the same synthesis declining for an element that *is* genuinely
+itemized: the value is `Scalar(List)`, and `.VAR` is answering for the inner
+`List` instead of for the `Scalar` wrapper.
+
+`ADR-0067`'s `native-method-cannot-return-an-lvalue-container` file carries a
+standing warning worth repeating here: **do not use `.VAR` to test whether a
+container arrived** — `S.VAR.WHAT` reports `Scalar` whether or not one did.
+This ticket is the mirror image (it reports the inner type where a wrapper
+really is present), so a fix must not be validated by `.VAR` alone; check the
+itemization survives `.raku`, `.elems` and `.WHAT` too.
+
+## Where to look
+
+The `.VAR` dispatch (`methods_mut_dispatch.rs`'s VAR arm and
+`src/vm/vm_call_method_ops.rs`'s `method == "VAR"` early return) and how it
+treats a `ValueView::Scalar` wrapper around an aggregate.
+
+## Neighbourhood to check when fixing
+
+`$[1,2]` (itemized Array) as well as `$(1,2)`; `.VAR.^name` on a plain
+(non-itemized) list element, which must stay the element's own type;
+`@a[0].VAR.^name` where `@a`'s element was itemized by a reference push
+(ADR-0040 slice 1 already gives that shape a `Scalar(ContainerRef(cell))`);
+`%h<k>.VAR.^name`; and `.VAR.WHAT` / `.VAR.^name` right after each other, which
+ADR-0064 handles as a documented pair.

--- a/todo/tickets/smartmatch-against-the-topic-returns-bool-not-match.md
+++ b/todo/tickets/smartmatch-against-the-topic-returns-bool-not-match.md
@@ -1,0 +1,64 @@
+# `$str ~~ $_` returns `Bool` instead of the `Match`
+
+Found by the 2026-09-06 doc-diff sweep (`raku-doc/doc/Language/structures.rakudoc:220`)
+and narrowed the same day against raku v2026.07.
+
+## Repro
+
+```raku
+for (/a/,) { say ("ab" ~~ $_).raku }
+# raku:  Match.new(:orig("ab"), :from(0), :pos(1))
+# mutsu: Bool::True
+```
+
+The doc block it came from is the same defect one layer up:
+
+```raku
+my @regex-check = ( /<alnum>/, /<alpha>/, /<punct>/ );
+say @regex-check.map: "33af" ~~ *;
+# raku:  (｢3｣ alnum => ｢3｣  ｢a｣ alpha => ｢a｣  Nil)
+# mutsu: (True True True)
+```
+
+## Narrowed — it is the topic, not the regex, the block or `.map`
+
+Every other spelling of "smartmatch a string against a regex held in a variable"
+answers with the `Match`:
+
+| Program | raku | mutsu |
+|---|---|---|
+| `say ("ab" ~~ /a/).raku` | `Match` | `Match` |
+| `my $r = /a/; say ("ab" ~~ $r).raku` | `Match` | `Match` |
+| `sub f($x) { "ab" ~~ $x }; say f(/a/).raku` | `Match` | `Match` |
+| `say ("ab" ~~ *)(/a/).raku` | `Match` | `Match` |
+| `say (1,).map({ "ab" ~~ /a/ }).raku` | `Match` | `Match` |
+| `my $r = /a/; say (1,).map({ "ab" ~~ $r }).raku` | `Match` | `Match` |
+| `say (1,).map({ my $m = "ab" ~~ /a/; $m }).raku` | `Match` | `Match` |
+| **`for (/a/,) { say ("ab" ~~ $_).raku }`** | `Match` | **`Bool::True`** |
+| **`say (/a/,).map({ "ab" ~~ $_ }).raku`** | `Match` | **`Bool::True`** |
+
+So `.map`, the block, the `WhateverCode` spelling and regex-in-a-variable are
+all fine. The one condition that changes the answer is the right-hand side being
+the **topic** `$_`.
+
+Raku's rule is that `$x ~~ $y` returns whatever `$y.ACCEPTS($x)` returns — a
+`Regex` returns its `Match`. Something on the `$_` path is instead asking for a
+boolean.
+
+## Where to look
+
+The smartmatch implementation (`src/vm/vm_smart_match.rs`,
+`src/vm/vm_smartmatch_ops.rs`) and, specifically, whatever distinguishes a
+topic-valued right operand — a compile-time special case for `~~ $_`, or a
+runtime path that reads the topic and coerces it. Confirm with a `rust-gdb`
+breakpoint on the arm that produces the `Bool` rather than guessing which of the
+two it is.
+
+## Neighbourhood to check when fixing
+
+`$_ ~~ $_`; the topic holding a `Junction`, a type object, a `Callable`, a
+`Range`, a `Set` or a plain `Str` (each has its own `ACCEPTS` return value, and
+only some of them are `Bool` in raku); `!~~` against the topic; `when $_ { }`;
+`given`/`for` topics vs a `-> $_` block parameter; and `$/` being set correctly
+after the match in every one of those (a `Match`-returning smartmatch must also
+populate `$/`).


### PR DESCRIPTION
`Language/structures.rakudoc` was the second row of the 2026-09-06 re-sweep (4 mismatch + 1 crash). All three reproduce against raku v2026.07, and each is narrowed to a repro smaller than the doc block.

That narrowing mattered most for the first one. The doc block reaches it through `@regex-check.map: "33af" ~~ *`, so `.map` and `WhateverCode` both look implicated — **neither is**:

| Program | mutsu |
|---|---|
| `("ab" ~~ /a/).raku` | correct `Match` |
| `my $r = /a/; ("ab" ~~ $r).raku` | correct |
| `sub f($x) { "ab" ~~ $x }; f(/a/).raku` | correct |
| `("ab" ~~ *)(/a/).raku` | correct |
| `(1,).map({ "ab" ~~ /a/ }).raku` | correct |
| `for (/a/,) { ("ab" ~~ $_).raku }` | **`Bool::True`** |
| `(/a/,).map({ "ab" ~~ $_ }).raku` | **`Bool::True`** |

The one condition that changes the answer is `$_` on the right-hand side.

The other two: an `is Array` subclass's `iterator` override is ignored **and** the object iterates as a single item (`.say for @thing` prints `[3 2 1 4]` on one line, so `for` never decomposed it); and `.VAR` on an itemized list element reports the inner type rather than `Scalar` — the mirror image of the standing "`.VAR` reports Scalar whether or not a container arrived" warning, so a fix there must not be validated by `.VAR` alone.

The file's remaining two rows are raku-drift (a `.WHICH` address baked into the expected output) and a `$Logger::get` example raku itself answers oddly; neither is a mutsu defect.

Docs/todo only, so the four heavy CI jobs skip by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)