### PR TITLE
docs: root-cause the topic-smartmatch ticket filed hours earlier

### DIFF
--- a/todo/tickets/smartmatch-against-the-topic-returns-bool-not-match.md
+++ b/todo/tickets/smartmatch-against-the-topic-returns-bool-not-match.md
@@ -45,14 +45,58 @@ Raku's rule is that `$x ~~ $y` returns whatever `$y.ACCEPTS($x)` returns — a
 `Regex` returns its `Match`. Something on the `$_` path is instead asking for a
 boolean.
 
+## Root cause — found 2026-09-06, and it is not a special case for `$_`
+
+**The RHS is evaluated with `$_` already overwritten by the LHS**, so
+`"ab" ~~ $_` really evaluates `"ab" ~~ "ab"` — a string-vs-string smartmatch,
+which is correctly `True`. Nothing is coercing a `Match` to a `Bool`; the match
+that would produce the `Match` never happens.
+
+`exec_smart_match_expr_op` (`src/vm/vm_smartmatch_ops.rs`) does this before
+running the RHS instruction range:
+
+```rust
+if topic_cell.is_none() {
+    self.env_mut().insert("_".to_string(), left.clone());
+}
+...
+let rhs_run = self.run_range(code, rhs_start, rhs_end, compiled_fns);
+```
+
+The two bytecode streams are otherwise identical — the working spelling's RHS is
+`GetLocal(0)` and the broken one's is `GetGlobal("_")`, and both run under the
+same `SmartMatchExpr` with the same flags. Confirmed by elimination: reading the
+topic into a name *first* (`my $r2 = $_; "ab" ~~ $r2`) answers `Match`, and
+`$_.WHAT.^name` outside the match is `Regex`, so the topic holds the right value
+right up to the moment the RHS runs.
+
+## Why the overwrite is there, and why the fix needs a decision
+
+It is deliberate and load-bearing: `$x ~~ s///` must topicalize `$x` so the
+substitution has something to write through, and the surrounding code has a
+careful `topic_cell` / `topic_ro_override` dance for the aliasing cases
+(`t/smartmatch-subst-topic.t`, ADR-0045). Raku's own rule is the other way
+round for a *value* RHS — `$x ~~ EXPR` evaluates `EXPR` and then calls
+`EXPR.ACCEPTS($x)`, with the topicalization happening inside `ACCEPTS`, not
+around the evaluation.
+
+So the fix is to separate the two: an RHS that must run *as* the match
+(`s///`, `tr///`, a regex literal, a block) needs the topic installed first; an
+RHS that is merely an expression to be evaluated must see the enclosing topic.
+The opcode already carries `rhs_is_match_regex` / `rhs_pure_regex` flags, so the
+compiler may already know enough to make that distinction — check what they mean
+before adding a third flag.
+
+Both spellings in the table above compile to `rhs_pure_regex: false`, so those
+existing flags do **not** currently separate these two cases.
+
 ## Where to look
 
-The smartmatch implementation (`src/vm/vm_smart_match.rs`,
-`src/vm/vm_smartmatch_ops.rs`) and, specifically, whatever distinguishes a
-topic-valued right operand — a compile-time special case for `~~ $_`, or a
-runtime path that reads the topic and coerces it. Confirm with a `rust-gdb`
-breakpoint on the arm that produces the `Bool` rather than guessing which of the
-two it is.
+`src/vm/vm_smartmatch_ops.rs` (`exec_smart_match_expr_op`, the `env_mut().insert("_")`
+above and the `saved_topic` restore after it), the compiler's `SmartMatchExpr`
+emission and what `rhs_is_match_regex` / `rhs_pure_regex` are set from, and
+`t/smartmatch-subst-topic.t` — the pin that the overwrite exists to satisfy and
+that any fix must keep green.
 
 ## Neighbourhood to check when fixing
 


### PR DESCRIPTION
Follow-up on the `smartmatch-against-the-topic-returns-bool-not-match` ticket filed in #7391 today. The root cause is found, and it is **not** a special case for `$_`.

**The RHS is evaluated with `$_` already overwritten by the LHS.** So `"ab" ~~ $_` really evaluates `"ab" ~~ "ab"` — a string-vs-string smartmatch, which is correctly `True`. Nothing is coercing a `Match` to a `Bool`; the match that would produce one never happens.

`exec_smart_match_expr_op` does this before running the RHS instruction range:

```rust
if topic_cell.is_none() {
    self.env_mut().insert("_".to_string(), left.clone());
}
...
let rhs_run = self.run_range(code, rhs_start, rhs_end, compiled_fns);
```

Evidence: the two bytecode streams are otherwise identical — the working spelling's RHS is `GetLocal(0)`, the broken one's is `GetGlobal("_")`, under the same `SmartMatchExpr` with the same flags — and reading the topic into a name first (`my $r2 = $_; "ab" ~~ $r2`) answers `Match`, while `$_.WHAT.^name` outside the match is `Regex`. The topic holds the right value right up to the moment the RHS runs.

**Why it is not fixed here.** The overwrite is deliberate and load-bearing: `$x ~~ s///` must topicalize `$x` so the substitution has a container to write through, and there is a careful `topic_cell` / `topic_ro_override` dance around it (ADR-0045, `t/smartmatch-subst-topic.t`). Raku's rule for a *value* RHS is the other way round — evaluate `EXPR`, then call `EXPR.ACCEPTS($x)`, with topicalization inside `ACCEPTS`. Separating "an RHS that runs *as* the match" from "an RHS that is merely evaluated" is a semantics decision across every smartmatch in the language, not an end-of-session edit.

The ticket records that the existing `rhs_is_match_regex` / `rhs_pure_regex` flags do **not** currently distinguish the two cases (both spellings compile to `rhs_pure_regex: false`), so whoever takes it should check what those flags mean before adding a third.

Docs/todo only, so the four heavy CI jobs skip by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)