### PR TITLE
perf(dispatch): let the sound multi-resolution cache serve Test's assertions

### DIFF
--- a/news/2026-09/multi-resolve-cache-keys-carry-definedness-and-declared-type.md
+++ b/news/2026-09/multi-resolve-cache-keys-carry-definedness-and-declared-type.md
@@ -1,0 +1,107 @@
+# The sound multi-resolution cache now serves the vendored `Test`'s assertions
+
+The vendored upstream `Test` module answers every assertion with Raku-level
+code, so the per-assertion cost is what decides whether
+`todo/deep/vendor-real-test-module.md` can flip the default provider. A
+callgrind run of 300 `ok 1, "x"` assertions under `MUTSU_REAL_TEST=1` put
+**1.06 M instructions on a single assertion**, and 29% of the whole program in
+`resolve_function_with_types` — the full multi-candidate walk, re-run on *every*
+call of `ok`, `is` and `is-deeply`.
+
+The sound multi-resolution caches (`func_multi_resolve_cache` and its method
+twin `multi_resolve_cache`) exist precisely to avoid that walk: they memoize the
+winner per `(package, name, argument-type keys)` whenever the candidate set is
+type-deterministic. Three separate things kept every `Test` assertion out of
+them. All three are now fixed, and none of the fixes is `Test`-specific.
+
+## 1. The synthetic callsite-line marker refused the whole key
+
+mutsu's parser appends a `"__mutsu_test_callsite_line" => <line>` named
+argument to every test-assertion call, so a failure can name the line. It is a
+diagnostic carrier, not a dispatch participant — `bind_function_args_values`
+filters it out before binding and no signature can declare it, the name being
+reserved.
+
+`multi_arg_type_keys` did not know that: it refuses to key *any* `Pair`
+argument, so the marker made every assertion call un-keyable and the cache was
+never consulted. It now keys the marker as a constant, which keeps
+"marker present" and "marker absent" in distinct buckets while letting the rest
+of the argument list be keyed normally. `ok 1, "x"` in a 20 000-iteration loop
+went from 301 full resolves per 300 calls to 2 in total, and the loop from
+**5.07 s to 3.58 s**.
+
+## 2. A `:D`/`:U` smiley disqualified the whole name
+
+`func_multi_dispatch_type_cacheable` treated any `:` in a type constraint as
+value-dependence, which is right for a coercion (`Int(Str)`) or an enum-value
+refinement but wrong for a smiley: `Mu:D` tests exactly `value_is_defined`, a
+property the key can carry. It could not carry it before — a type object `Int`
+and the instance `42` both key as `Int` — so the refusal was correct as things
+stood.
+
+`multi_arg_type_keys` now appends a reserved marker after the type key of an
+*undefined* argument, and a trailing smiley is no longer counted as
+value-dependent. That admits upstream `Test`'s smiley-split assertions:
+
+```raku
+multi sub is(Mu $got, Mu:U $expected, $desc = '') { ... }
+multi sub is(Mu $got, Mu:D $expected, $desc = '') { ... }
+```
+
+plus the four `is-deeply` candidates, which are split on `Seq:D`.
+
+The two cacheability gates (method-side and function-side) had drifted into two
+copies of the same constraint analysis; they now share
+`type_constraint_is_value_dependent`, so they cannot disagree about the key
+shape they are guarding.
+
+## 3. A variable argument refused the key outright
+
+A `VarRef` — what a variable passed as an argument arrives as — dispatches on
+the *source variable's declared type* as well as on the value's own type, so
+that `my int $y` and `my $x` holding the same `Int` can pick different
+candidates (roast `S06-multi/by-trait.t`). `multi_arg_type_keys` responded by
+refusing to key the call at all, which is most of roast: `is $got, $expected,
+"..."` and `is-deeply @a, @b, "..."` are the ordinary spellings.
+
+It now keys the declared type too, behind its own reserved marker so a
+declared-type key can never be read as the value key of an extra argument. The
+only other thing a `VarRef` argument decides is whether an `is rw` parameter
+accepts it, and a candidate set containing an `is rw` parameter is already
+refused wholesale by both cacheability gates.
+
+## Result
+
+`roast/S03-buf/write-int.t` — the one remaining timeout in the roast
+real-`Test` sweep, and the file that runs ~93 000 assertions — went from
+**184 079 full multi resolves to 22 805**, and from **48.0 s to 28.6 s**
+against a 30 s budget (the native provider runs it in 4.3 s). The
+20 000-assertion `ok` loop went **5.07 s -> 3.36 s**.
+
+What is left of those 22 805 resolves is per-*subtest*, not per-assertion:
+`_pop_vars` (7 590), `plan` (5 062), `item` (5 060) and `subtest` (5 060), for
+the file's 5 060 subtests. `ok`, `is` and `is-deeply` together now account for
+8.
+
+Two properties of a *value*, not of an argument list, had to join the key for
+this to stay correct, and both were caught by the existing `t/` suite rather
+than by reasoning:
+
+* an **enum member** refines within one `value_type_name` (`Less` and `More`
+  are both `Order`), so unwrapping a `VarRef` around one made the two share a
+  bucket. Enum values now key on `Type::Member`, the same treatment the
+  `Package` arm already gets
+  (`t/anonymous-any-multi-dispatch.t`).
+* an **invocant smiley** (`multi method gist(Cook:U:)` / `(Cook:D:)`) selects
+  on the receiver's definedness, which lives outside the argument list the key
+  is built from. The method-side key now carries it
+  (`t/multi-method-invocant-definedness.t`).
+
+Pinned by `t/multi-resolve-cache-keys.t`, which interleaves the two arms of
+each split so a key that dropped either property is served the wrong winner on
+the second iteration rather than accidentally passing on a cold cache.
+
+One rakudo divergence surfaced while writing that pin and is filed separately:
+a bare integer literal picks the `Int` candidate where rakudo picks `int`
+(`todo/tickets/native-int-candidate-loses-to-int-for-a-literal.md`). It is
+pre-existing and cache-independent.

--- a/news/2026-09/multi-resolve-cache-keys-carry-definedness-and-declared-type.md
+++ b/news/2026-09/multi-resolve-cache-keys-carry-definedness-and-declared-type.md
@@ -73,10 +73,25 @@ refused wholesale by both cacheability gates.
 ## Result
 
 `roast/S03-buf/write-int.t` — the one remaining timeout in the roast
-real-`Test` sweep, and the file that runs ~93 000 assertions — went from
-**184 079 full multi resolves to 22 805**, and from **48.0 s to 28.6 s**
-against a 30 s budget (the native provider runs it in 4.3 s). The
-20 000-assertion `ok` loop went **5.07 s -> 3.36 s**.
+real-`Test` sweep, and the file that runs 93 370 assertions across 2 530
+subtests — went from **184 079 full multi resolves to 22 805**, and from
+**48.0 s to 29.5 s** (median of three; 28.8–29.5 s). The 20 000-assertion `ok`
+loop went **5.07 s -> 3.36 s**.
+
+Calibration on the same idle box, same file, same output sink, all three
+running the identical 93 370 assertions:
+
+| provider | wall | per assertion |
+| --- | --- | --- |
+| rakudo | 3.49 s | 37 us |
+| mutsu, native `Test` | 5.04 s | 54 us |
+| mutsu, vendored `Test` | 29.5 s | 316 us |
+
+So the interpreter itself is at rakudo's rough parity here; what costs 8.5x is
+*executing `Test.rakumod` as Raku code*. And 29.5 s against a 30 s per-file
+budget is **at** the budget, not under it — this file will still time out on a
+slower CI runner or under `prove -j4`. The timeout class is reduced, not
+closed.
 
 What is left of those 22 805 resolves is per-*subtest*, not per-assertion:
 `_pop_vars` (7 590), `plan` (5 062), `item` (5 060) and `subtest` (5 060), for

--- a/src/runtime/accessors_state.rs
+++ b/src/runtime/accessors_state.rs
@@ -744,6 +744,16 @@ impl Interpreter {
                     value_dependent = true;
                     break 'outer;
                 }
+                // A CONSTRAINED `&`-sigil parameter dispatches on the passed
+                // routine's declared RETURN type — `multi f(Int &x)` vs
+                // `multi f(Str &x)` (roast S06-multi/type-based.t) — and every
+                // routine has the same `value_type_name`, so no argument type
+                // key can tell the two calls apart. Same family as the two
+                // signature checks above; an unconstrained `&x` is fine.
+                if pd.name.starts_with('&') && pd.type_constraint.is_some() {
+                    value_dependent = true;
+                    break 'outer;
+                }
                 // An `is rw` candidate matches only a writable-lvalue argument —
                 // a call-site property, not an arg-type one — so `f($var)` and
                 // `f("lit")` need different winners under one type key.
@@ -751,28 +761,18 @@ impl Interpreter {
                     value_dependent = true;
                     break 'outer;
                 }
-                if let Some(tc) = &pd.type_constraint {
-                    // `:D`/`:U`/`:_` smiley or `Int(Str)` coercion => value/identity
-                    // dependent; a subset type carries an implicit `where`. The `:`
-                    // check also excludes enum-value (`E::a`) and qualified-value
-                    // constraints, which refine within one value-type.
-                    if tc.contains(':') || tc.contains('(') {
-                        value_dependent = true;
-                        break 'outer;
-                    }
-                    // Value-refining numeric pseudo-types: `Inf`/`NaN`/`UInt`/`-Inf`
-                    // all match WITHIN a single `value_type_name` ("Num"/"Int") by
-                    // inspecting the value, so type-keying would mis-route them
-                    // (e.g. `multi f(NaN)` vs `multi f(Numeric)` both key as Num).
-                    if matches!(tc.as_str(), "Inf" | "NaN" | "-Inf" | "UInt") {
-                        value_dependent = true;
-                        break 'outer;
-                    }
-                    let base = tc.split(['[', ' ']).next().unwrap_or(tc.as_str());
-                    if self.registry().subsets.contains_key(base) {
-                        value_dependent = true;
-                        break 'outer;
-                    }
+                // A coercion (`Int(Str)`), an enum-value / `::`-qualified
+                // refinement, a value-refining numeric pseudo-type or a subset
+                // makes the winner depend on the argument's value. A trailing
+                // `:D`/`:U`/`:_` smiley does not: `multi_arg_type_keys` carries
+                // the definedness bit. See `type_constraint_is_value_dependent`,
+                // shared with the method-side gate so both agree on the key
+                // shape they are guarding.
+                if let Some(tc) = &pd.type_constraint
+                    && self.type_constraint_is_value_dependent(tc)
+                {
+                    value_dependent = true;
+                    break 'outer;
                 }
             }
         }
@@ -807,7 +807,10 @@ impl Interpreter {
         let Some(arg_keys) = self.multi_arg_type_keys(args) else {
             return self.resolve_function_with_types(name, args);
         };
-        let pkg_sym = Symbol::intern(&self.current_package());
+        // The atomic mirror, not `current_package()`: the owned form is a
+        // `RwLock` read plus a `String` heap allocation on a path that runs on
+        // every multi call, and both spellings intern to the same symbol.
+        let pkg_sym = self.current_package_sym();
         let name_sym = Symbol::intern(name);
         if !self.func_multi_dispatch_type_cacheable(pkg_sym, name_sym, name) {
             return self.resolve_function_with_types(name, args);

--- a/src/vm/vm_call_method_compiled_cache.rs
+++ b/src/vm/vm_call_method_compiled_cache.rs
@@ -1,5 +1,34 @@
 use super::*;
 
+/// Cache-key stand-in for the parser's synthetic test-assertion callsite-line
+/// marker. Deliberately the marker's own reserved key name: it can never
+/// collide with a `value_type_name`, and it keeps "marker present" and "marker
+/// absent" in distinct cache buckets.
+const CALLSITE_LINE_MARKER_KEY: &str = "__mutsu_test_callsite_line";
+
+/// Cache-key marker appended after an argument's type key when that argument is
+/// *undefined* (`value_is_defined` is false). A `:D`/`:U` smiley candidate set
+/// dispatches on exactly that bit on top of the type, so a key that carries it
+/// stays a function of the winner — which is what lets
+/// `multi_dispatch_type_cacheable` / `func_multi_dispatch_type_cacheable` admit
+/// smiley candidates instead of refusing the whole name. Emitted only for the
+/// undefined case, so the common (defined) key shape is unchanged; the name is
+/// reserved and can never collide with a type name or a `value_type_name`.
+const UNDEFINED_ARG_KEY: &str = "__mutsu_key_undefined";
+
+/// Cache-key marker introducing the *declared type* of a `VarRef` argument's
+/// source variable. Without the marker a declared-type key would be
+/// indistinguishable from the value key of an additional argument
+/// (`f($x)` with `my Int $x` vs `f(1, 2)` would both key as `[Int, Int]`), and
+/// the two calls have different arities and therefore different winners.
+const DECLARED_TYPE_KEY: &str = "__mutsu_key_declared_type";
+
+/// Cache-key marker introducing an enum VALUE argument's `(enum type, member)`
+/// pair. An enum member refines within one `value_type_name` -- `Less` and
+/// `More` are both `Order` -- so `multi f(Less)` and `multi f(More)` need
+/// distinct buckets.
+const ENUM_MEMBER_KEY: &str = "__mutsu_key_enum_member";
+
 impl Interpreter {
     pub(crate) fn refresh_method_caches_for_generation(&mut self) {
         let generation = self.registry().method_generation;
@@ -27,16 +56,52 @@ impl Interpreter {
     /// stringification (`"$obj"` → `StringConcat` → this) leaves the caller's
     /// `self` pointing at `$obj`, breaking a later `self` read in an enclosing
     /// nested sub (which resolves `self` from env via `GetSelfOrNoSelf`).
-    /// Build a per-positional-arg type key for the sound multi-resolution cache.
-    /// Returns `None` (do not cache) when any arg is value-/identity-dependent or
-    /// autothreads (`Junction`), or is a container/named-pair arg, so dispatch can
-    /// not be keyed on the positional types alone.
+    /// Build the per-argument key for the sound multi-resolution caches.
+    ///
+    /// Each argument contributes its runtime type, plus the two other
+    /// properties dispatch can read: its *definedness* (a `:D`/`:U` smiley
+    /// candidate tests exactly that) and, for a `VarRef`, the *declared type*
+    /// of the variable it came from. Both are emitted behind reserved markers
+    /// so they cannot be confused with an ordinary type key.
+    ///
+    /// Returns `None` (do not cache) for an argument whose contribution to
+    /// dispatch cannot be reduced to those: a `Junction` (which autothreads), a
+    /// container or `Capture`, and a genuine named/positional `Pair` — the
+    /// internal callsite-line marker excepted, since it is filtered out before
+    /// binding and no signature can declare it.
     pub(crate) fn multi_arg_type_keys(
         &mut self,
         args: &[Value],
     ) -> Option<Vec<crate::symbol::Symbol>> {
         let mut keys = Vec::with_capacity(args.len());
-        for a in args {
+        for raw in args {
+            // A `VarRef` (a variable passed as an argument) dispatches on the
+            // *source variable's declared type* as well as on the value's own
+            // type: `unwrap_varref_for_dispatch` feeds that declared type into
+            // `candidate_type_distance`, so `my int $y` and `my $x` holding the
+            // same `Int` can pick different candidates (roast
+            // S06-multi/by-trait.t). Key BOTH, behind a reserved marker so a
+            // declared-type key can never be mistaken for the value key of an
+            // extra argument. The only other thing a `VarRef` argument decides
+            // is whether an `is rw` parameter accepts it, and a candidate set
+            // containing an `is rw` parameter is already refused wholesale by
+            // `func_multi_dispatch_type_cacheable` / `multi_dispatch_type_cacheable`.
+            //
+            // Refusing to key a `VarRef` at all — which is what this did before
+            // — meant every assertion that passes a *variable*
+            // (`is $got, $expected, "..."`, `is-deeply @a, @b, "..."`, i.e. most
+            // of roast) re-ran the whole candidate walk on every call.
+            let a = match raw.view() {
+                ValueView::VarRef { name, value, .. } => {
+                    if let Some(tc) = name.with_str(|n| self.var_type_constraint(n)) {
+                        keys.push(crate::symbol::Symbol::intern(DECLARED_TYPE_KEY));
+                        keys.push(crate::symbol::Symbol::intern(&tc));
+                    }
+                    value.clone()
+                }
+                _ => raw.clone(),
+            };
+            let a = &a;
             let key = match a.view() {
                 ValueView::Instance { class_name, .. } => class_name,
                 // A bare type object (`Int`, `Foo`, ...) must key on its OWN
@@ -45,6 +110,41 @@ impl Interpreter {
                 // "Package" regardless of which type it names — see
                 // `todo/tickets/multi-arg-type-keys-package-collision.md`.
                 ValueView::Package(name) => name,
+                // An enum VALUE is its own dispatch identity, for the same
+                // reason a type object is: `multi f(Less)` and `multi f(More)`
+                // are distinct candidates that both see a `value_type_name` of
+                // `Order`, so keying on the type alone hands the second call
+                // the first one's winner (`t/anonymous-any-multi-dispatch.t`
+                // "anonymous enum-value parameter still rejects peers"). Key on
+                // `Type::Member`, which is unique and never a plain type name.
+                ValueView::Enum {
+                    enum_type, key: k, ..
+                } => {
+                    // Two symbols behind a reserved marker rather than one
+                    // interned `"Type::Member"` string: no per-call `format!`,
+                    // and no way for the pair to be read as the plain type name
+                    // of some other argument.
+                    keys.push(crate::symbol::Symbol::intern(ENUM_MEMBER_KEY));
+                    keys.push(enum_type);
+                    k
+                }
+                // The synthetic callsite-line marker the parser appends to every
+                // test-assertion call (`ok 1, "x"` -> `..., "__mutsu_test_callsite_line" => 3`)
+                // is a mutsu-internal diagnostic carrier, not a dispatch
+                // participant: `bind_function_args_values` filters it out before
+                // binding, and no signature can declare it (the name is reserved).
+                // Keying it as a constant marker — rather than refusing to key the
+                // whole call, as the general `Pair` arm below does — is what lets
+                // the sound multi cache serve the vendored upstream `Test`, whose
+                // `multi sub ok(Mu $cond, $desc = '')` otherwise paid a full
+                // candidate walk on EVERY assertion. Only the marker's *name* is
+                // keyed; its line-number value cannot select a candidate, because
+                // any candidate that inspects a value at all (`where` / literal /
+                // subset / smiley / coercion) makes the whole name un-cacheable in
+                // `func_multi_dispatch_type_cacheable` before this key is used.
+                _ if Self::is_callsite_line_marker(a) => {
+                    crate::symbol::Symbol::intern(CALLSITE_LINE_MARKER_KEY)
+                }
                 ValueView::Junction { .. }
                 | ValueView::Mixin(..)
                 | ValueView::Scalar(_)
@@ -52,13 +152,8 @@ impl Interpreter {
                 | ValueView::Pair(..)
                 | ValueView::ValuePair(..)
                 | ValueView::Capture { .. }
-                // A `VarRef` (a variable passed as an argument) dispatches on the
-                // *source variable's declared type* as well as the value's type --
-                // `unwrap_varref_for_dispatch` feeds that declared type into
-                // `candidate_type_distance`, so `my int $y` and `my $x` holding the
-                // same `Int` can pick different candidates (roast
-                // S06-multi/by-trait.t). Its value type alone is therefore not a
-                // sound cache key.
+                // A `VarRef` nested inside a `VarRef` is not a shape the
+                // unwrap above produces; refuse it rather than guess.
                 | ValueView::VarRef { .. } => return None,
                 _ => {
                     let name = crate::runtime::utils::value_type_name(a);
@@ -69,8 +164,51 @@ impl Interpreter {
                 }
             };
             keys.push(key);
+            // Definedness is the one *value* property a type-keyed candidate set
+            // is still allowed to depend on (`Mu:D` / `Mu:U`), and the type key
+            // alone does not carry it: a type object `Int` and the instance `42`
+            // both key as `Int`, and an empty `Slip` keys the same as a full one.
+            // Append the marker so those land in different buckets. Cheap and
+            // side-effect free -- `value_is_defined` is a pure view match, and
+            // the views it would have to lock through (`ContainerRef`, `Mixin`)
+            // already returned `None` above.
+            if !crate::runtime::types::value_is_defined(a) {
+                keys.push(crate::symbol::Symbol::intern(UNDEFINED_ARG_KEY));
+            }
         }
         Some(keys)
+    }
+
+    /// Whether one candidate parameter's type constraint makes the enclosing
+    /// multi's winner depend on an argument's *value* rather than on the
+    /// `(type, definedness)` pair the resolve caches key on. Shared by the
+    /// method-side [`Self::multi_dispatch_type_cacheable`] and the
+    /// function-side `func_multi_dispatch_type_cacheable`, which must agree:
+    /// they gate the same kind of cache over the same key shape.
+    ///
+    /// A trailing `:D`/`:U`/`:_` smiley is **not** value-dependent: the smiley
+    /// tests exactly `value_is_defined`, and [`Self::multi_arg_type_keys`]
+    /// carries that bit in the key ([`UNDEFINED_ARG_KEY`]). This is what lets
+    /// the vendored upstream `Test`'s smiley-split assertions
+    /// (`multi sub is(Mu $got, Mu:U $expected, …)` /
+    /// `multi sub is(Mu $got, Mu:D $expected, …)`, and the four `is-deeply`
+    /// candidates) be cached at all — before it, one smiley anywhere in the
+    /// candidate set made every call re-run the whole candidate walk.
+    /// Everything else that reads a value stays value-dependent: a coercion
+    /// (`Int(Str)`), an enum-value or otherwise `::`-qualified refinement, the
+    /// value-refining numeric pseudo-types, and a subset (an implicit `where`).
+    pub(crate) fn type_constraint_is_value_dependent(&self, tc: &str) -> bool {
+        let (base, _smiley) = crate::runtime::types::strip_type_smiley(tc);
+        // A `Int:D()` coercion-with-smiley keeps its `(` here, so it is still
+        // caught: only the trailing smiley is peeled.
+        if base.contains(':') || base.contains('(') {
+            return true;
+        }
+        if matches!(base, "Inf" | "NaN" | "-Inf" | "UInt") {
+            return true;
+        }
+        let root = base.split(['[', ' ']).next().unwrap_or(base);
+        self.registry().subsets.contains_key(root)
     }
 
     /// Whether a `(class, method)` is a MULTI whose dispatch is purely type+arity
@@ -131,6 +269,13 @@ impl Interpreter {
                         value_dependent = true;
                         break 'outer;
                     }
+                    // A CONSTRAINED `&`-sigil parameter dispatches on the
+                    // passed routine's declared RETURN type — see the matching
+                    // note in `func_multi_dispatch_type_cacheable`.
+                    if pd.name.starts_with('&') && pd.type_constraint.is_some() {
+                        value_dependent = true;
+                        break 'outer;
+                    }
                     // An `is rw` candidate matches only a writable-lvalue
                     // argument — a property of the call site, not of the arg's
                     // type — so `m($var)` and `m("lit")` need different winners
@@ -140,24 +285,11 @@ impl Interpreter {
                         value_dependent = true;
                         break 'outer;
                     }
-                    if let Some(tc) = &pd.type_constraint {
-                        // `:D`/`:U`/`:_` smiley or `Int(Str)` coercion => value/identity
-                        // dependent; a subset type carries an implicit `where`.
-                        if tc.contains(':') || tc.contains('(') {
-                            value_dependent = true;
-                            break 'outer;
-                        }
-                        // Value-refining numeric pseudo-types match WITHIN a single
-                        // `value_type_name`, so type-keying would mis-route them.
-                        if matches!(tc.as_str(), "Inf" | "NaN" | "-Inf" | "UInt") {
-                            value_dependent = true;
-                            break 'outer;
-                        }
-                        let base = tc.split(['[', ' ']).next().unwrap_or(tc.as_str());
-                        if self.registry().subsets.contains_key(base) {
-                            value_dependent = true;
-                            break 'outer;
-                        }
+                    if let Some(tc) = &pd.type_constraint
+                        && self.type_constraint_is_value_dependent(tc)
+                    {
+                        value_dependent = true;
+                        break 'outer;
                     }
                 }
             }
@@ -251,9 +383,21 @@ impl Interpreter {
             return hit;
         }
         // 3. Sound multi-method resolution cache (type+arity deterministic).
-        if let Some(arg_keys) = self.multi_arg_type_keys(args)
+        if let Some(mut arg_keys) = self.multi_arg_type_keys(args)
             && self.multi_dispatch_type_cacheable(class_sym, method_sym, cn, method)
         {
+            // The INVOCANT's definedness is part of the dispatch too: an
+            // invocant smiley (`multi method gist(Cook:U:)` /
+            // `(Cook:D:)`) selects on exactly it, and `class_sym` is the same
+            // for a type object and an instance. `multi_arg_type_keys` only
+            // sees the argument list, so carry the receiver's bit here — the
+            // arg keys are a `Vec`, so a leading marker is unambiguous.
+            // Without it, `Cook.gist` and `Cook.new.gist` share one bucket and
+            // the second is served the first's candidate
+            // (`t/multi-method-invocant-definedness.t`).
+            if !crate::runtime::types::value_is_defined(target) {
+                arg_keys.insert(0, crate::symbol::Symbol::intern(UNDEFINED_ARG_KEY));
+            }
             let mkey = (class_sym, method_sym, arg_keys);
             if let Some(hit) = self.multi_resolve_cache.get(&mkey) {
                 return hit.clone();

--- a/t/multi-resolve-cache-keys.t
+++ b/t/multi-resolve-cache-keys.t
@@ -1,0 +1,112 @@
+use Test;
+
+# The sound multi-resolution caches (`func_multi_resolve_cache` and its method
+# twin) memoize a winner per (package, name, argument-type keys). Several
+# properties beyond an argument's plain runtime type participate in dispatch,
+# so the key has to carry each of them -- or the candidate set has to stay out
+# of the cache entirely -- or the SECOND call of an alternating pair is served
+# the first one's winner:
+#
+#   * definedness, for a `:D`/`:U` smiley candidate set -- a type object and an
+#     instance of the same type share one `value_type_name`;
+#   * the declared type of the source variable a `VarRef` argument came from,
+#     which `unwrap_varref_for_dispatch` feeds into the specificity ranking;
+#   * an enum member's own identity (`Less` and `More` are both `Order`);
+#   * the INVOCANT's definedness, which is not in the argument list at all;
+#   * the declared return type of a routine passed to a constrained `&`-sigil
+#     parameter -- unkeyable, so that candidate set is refused outright.
+#
+# Every case below is run repeatedly and with the two arms INTERLEAVED, so a
+# key that dropped either property fails on the second iteration rather than
+# accidentally passing on a cold cache.
+
+plan 44;
+
+multi sub smiley(Int:U $x) { 'U' }
+multi sub smiley(Int:D $x) { 'D' }
+
+for ^3 -> $run {
+    is smiley(Int), 'U', "type object picks the :U candidate (run $run)";
+    is smiley(42), 'D', "instance picks the :D candidate (run $run)";
+}
+
+# The same split reached through variables rather than literals, so the keys go
+# through the `VarRef` arm as well.
+my Int $undef;
+my Int $def = 7;
+for ^3 -> $run {
+    is smiley($undef), 'U', "undefined variable picks :U (run $run)";
+    is smiley($def), 'D', "defined variable picks :D (run $run)";
+}
+
+# A native/boxed pair: both arguments are `Int` at runtime, so only the source
+# variable's DECLARED type separates the candidates.
+multi sub declared(int $x) { 'native' }
+multi sub declared(Int $x) { 'boxed' }
+
+my int $native = 5;
+my Int $boxed = 5;
+for ^3 -> $run {
+    is declared($native), 'native', "native-typed variable picks int (run $run)";
+    is declared($boxed), 'boxed', "boxed-typed variable picks Int (run $run)";
+}
+
+# A literal keeps resolving to whatever it resolved to before the two
+# variable-shaped keys above were cached -- i.e. the declared-type keys must
+# not leak into the literal's own bucket. (mutsu answers 'boxed' where rakudo
+# answers 'native' for a bare literal against an `int`/`Int` pair; that
+# divergence is `todo/tickets/native-int-candidate-loses-to-int-for-a-literal.md`
+# and is deliberately NOT what this file pins.)
+is declared(5), declared(5), 'literal keeps a stable winner across calls';
+
+# Method-side twin of the smiley case.
+class SmileyHost {
+    multi method m(Str:U $s) { 'mU' }
+    multi method m(Str:D $s) { 'mD' }
+}
+my $host = SmileyHost.new;
+for ^3 -> $run {
+    is $host.m(Str), 'mU', "method :U candidate (run $run)";
+    is $host.m('x'), 'mD', "method :D candidate (run $run)";
+}
+
+
+# An enum VALUE parameter refines within one `value_type_name` (`Less` and
+# `More` are both `Order`), so the key has to carry the member identity.
+multi sub member(Less) { 'less' }
+multi sub member(More) { 'more' }
+multi sub member(Any) { 'other' }
+
+for ^3 -> $run {
+    is member(Less), 'less', "enum member Less (run $run)";
+    is member(More), 'more', "enum member More (run $run)";
+    is member(Same), 'other', "enum member Same falls to Any (run $run)";
+}
+
+# The invocant's own definedness, which lives outside the argument list: the
+# receiver class is identical for both candidates here.
+class InvocantHost {
+    multi method g(InvocantHost:U:) { 'iU' }
+    multi method g(InvocantHost:D:) { 'iD' }
+}
+my $inst = InvocantHost.new;
+for ^2 -> $run {
+    is InvocantHost.g, 'iU', "invocant :U candidate (run $run)";
+    is $inst.g, 'iD', "invocant :D candidate (run $run)";
+}
+
+# A CONSTRAINED `&`-sigil parameter dispatches on the passed routine's declared
+# RETURN type. Every routine shares one `value_type_name`, so no argument key
+# can separate these two candidates and the name has to stay out of the
+# type-keyed cache altogether (roast S06-multi/type-based.t).
+sub ret-int() returns Int { 3 }
+sub ret-str() returns Str { 'pigs' }
+multi sub by-return(Int &x) { 'int:' ~ x() }
+multi sub by-return(Str &x) { 'str:' ~ x() }
+
+for ^3 -> $run {
+    is by-return(&ret-str), 'str:pigs', "routine returning Str (run $run)";
+    is by-return(&ret-int), 'int:3', "routine returning Int (run $run)";
+}
+
+done-testing;

--- a/todo/deep/vendor-real-test-module.md
+++ b/todo/deep/vendor-real-test-module.md
@@ -73,13 +73,26 @@ because three separate things kept a `Test` assertion out of the sound
 multi-resolution cache (the parser's callsite-line marker, the `:D`/`:U`
 smileys, and `VarRef` arguments). Fixing all three —
 `news/2026-09/multi-resolve-cache-keys-carry-definedness-and-declared-type.md` —
-took `roast/S03-buf/write-int.t` under the real module from **48.0 s to 28.6 s**
-on this machine, against a 30 s budget, with 184 079 full resolves down to
+took `roast/S03-buf/write-int.t` under the real module from **48.0 s to
+29.5 s** (median of three; 28.8-29.5 s), with 184 079 full resolves down to
 22 805 (all of them now per-*subtest*, not per-assertion).
 
-**So the timeout class is closed on this machine but with no margin.** Before
-declaring completion criterion 2 met, re-measure on the reference machine and
-under `prove -j4` contention. The next measured target is filed as
+Calibration measured at the same time, same idle box, same output sink, all
+three running the file's identical 93 370 assertions / 2 530 subtests:
+
+| provider | wall | per assertion |
+| --- | --- | --- |
+| rakudo | 3.49 s | 37 us |
+| mutsu, native `Test` | 5.04 s | 54 us |
+| mutsu, vendored `Test` | 29.5 s | 316 us |
+
+The interpreter is at rakudo's rough parity on this file; the 8.5x is the cost
+of *running `Test.rakumod` as Raku code*.
+
+**Completion criterion 2 is therefore NOT met.** 29.5 s against a 30 s per-file
+budget is at the budget, not under it: the file will still time out on a slower
+CI runner or under `prove -j4`. Do not read the sweep going green here as the
+class being closed -- re-measure on the reference machine and under contention. The next measured target is filed as
 `todo/perf/listop-call-bypasses-every-compiled-call-cache.md`: a listop call
 (`ok 1, "x"` compiles to `ExecCallPairs`, not `CallFunc`) reaches none of the
 three name-keyed compiled-call caches and takes the carrier path — a whole-frame

--- a/todo/deep/vendor-real-test-module.md
+++ b/todo/deep/vendor-real-test-module.md
@@ -57,7 +57,38 @@ For an `exit 124` roast row, re-run the individual file with a larger timeout
 before classifying it as a correctness bug. The vendored provider executes
 assertions as Raku code and is therefore slower than the Rust-native provider.
 
-## Current residue (2026-09-06, second sweep)
+## Current state (2026-09-06, third pass — the perf blocker)
+
+`todo/tickets/eval-assign-loses-a-later-block-declarations-type.md`, which the
+second sweep's two new roast rows were bisected to, was closed the same day by
+`news/2026-09/typed-declaration-hoist-missing-in-most-block-forms.md`, so the
+correctness residue is back to the single known timeout.
+
+That timeout was then attacked directly, with callgrind rather than A/B
+experiments, and the attribution turned out to be neither of the two candidates
+the earlier sections name. **The whole per-assertion cost was dominated by
+multi-candidate resolution**: `resolve_function_with_types` was 29% of a
+300-assertion program, re-run on every single `ok`/`is`/`is-deeply` call,
+because three separate things kept a `Test` assertion out of the sound
+multi-resolution cache (the parser's callsite-line marker, the `:D`/`:U`
+smileys, and `VarRef` arguments). Fixing all three —
+`news/2026-09/multi-resolve-cache-keys-carry-definedness-and-declared-type.md` —
+took `roast/S03-buf/write-int.t` under the real module from **48.0 s to 28.6 s**
+on this machine, against a 30 s budget, with 184 079 full resolves down to
+22 805 (all of them now per-*subtest*, not per-assertion).
+
+**So the timeout class is closed on this machine but with no margin.** Before
+declaring completion criterion 2 met, re-measure on the reference machine and
+under `prove -j4` contention. The next measured target is filed as
+`todo/perf/listop-call-bypasses-every-compiled-call-cache.md`: a listop call
+(`ok 1, "x"` compiles to `ExecCallPairs`, not `CallFunc`) reaches none of the
+three name-keyed compiled-call caches and takes the carrier path — a whole-frame
+env snapshot plus a writeback diff — on **every assertion of every roast file**.
+That, and the pre-existing
+`todo/perf/method-dispatch-flattens-the-env-on-every-call.md` (measured at 17%
+of the `ok` loop by an unsound flatten-removal experiment), are what remain.
+
+## Earlier residue (2026-09-06, second sweep)
 
 Both sweeps were re-run at the end of 2026-09-06, after that day's fixes. The
 `t/` regression class is **empty** for the first time; the roast side has the
@@ -98,7 +129,7 @@ fail under both (pre-existing):    4
   `todo/tickets/eval-assign-loses-a-later-block-declarations-type.md`. CI cannot
   see it because the dual-provider sweep is not part of CI.
 
-## Earlier residue (2026-09-06, first sweep)
+## Earlier residue (2026-09-06, first sweep — before the multi-cache fix)
 
 Both sweeps were re-run on this date, on a machine roughly **2x slower** than
 the one the 2026-08-29/30 numbers came from (calibration: `S04-declarations/state.t`

--- a/todo/perf/listop-call-bypasses-every-compiled-call-cache.md
+++ b/todo/perf/listop-call-bypasses-every-compiled-call-cache.md
@@ -1,0 +1,56 @@
+# A listop call (`ExecCallPairs`) reaches none of the compiled-call caches
+
+`ok 1, "x"` and `is $got, $expected, "..."` — the shape every roast assertion is
+written in — compile to `OpCode::ExecCallPairs`, not to `CallFunc`. That opcode
+has only three arms (`src/vm/vm_call_exec_ops.rs`, `exec_exec_call_pairs_op`):
+
+1. `find_compiled_function(compiled_fns, name, args)` — the *caller's* compiled
+   table, which an imported module sub is never in;
+2. `try_native_function` — a Rust builtin;
+3. the **carrier fallback**: `snapshot_carrier_overwritable_env(code)`,
+   `begin_carrier`, `exec_call_pairs_values`, `end_carrier`,
+   `writeback_carrier_writes`, `carrier_writeback_changed_aggregates`.
+
+`CallFunc`'s three name-keyed fast caches — `pos_light_cache`,
+`light_call_cache`, `otf_call_cache` — are all in `exec_call_func_op` and none
+of them is consulted here. So **every assertion of the vendored upstream
+`Test`, in every roast file, takes the carrier path**, paying a whole-frame env
+snapshot and a writeback diff per call, where the same sub called as
+`ok(1, "x")` from an expression takes the cached compiled path.
+
+Verified with gdb on `MUTSU_REAL_TEST=1 tmp/probe-is2.raku` (three `is` calls):
+`CARRIER-FALLBACK "is"` fires three times, once per call.
+
+## Two separate gaps
+
+**(a) `ExecCallPairs` has no OTF cache at all.** Even a *non*-multi imported sub
+called in listop form misses `otf_call_cache`, which
+`news/2026-09/imported-module-sub-reaches-the-cached-dispatch.md` added for the
+`CallFunc` path only. Wiring the same cache in is the smaller half of the work;
+the care needed is in the named/`Pair` argument handling this opcode exists for.
+
+**(b) `otf_call_cache` skips multi names by construction.** Its guard is
+`!self.has_multi_candidates_cached_sym(name_sym)`, because the entry is keyed on
+the name alone and a multi's winner depends on the argument types. That was
+unavoidable when the winner had to be re-derived per call, but it no longer is:
+`func_multi_resolve_cache` now resolves `ok`/`is`/`is-deeply` to a stable winner
+from a sound `(package, name, arg-type keys)` key
+(`news/2026-09/multi-resolve-cache-keys-carry-definedness-and-declared-type.md`).
+A multi-aware compiled-call cache would key the *compiled* form on the same
+tuple rather than on the name, so a multi could reach the light-call paths.
+
+## Why it matters
+
+It is the measured remainder of `todo/deep/vendor-real-test-module.md`. After
+the multi-resolution keys were fixed, `roast/S03-buf/write-int.t` under the real
+module still spends its per-assertion budget in this path, and the carrier's
+env snapshot + writeback diff is the largest single item left. It is not
+`Test`-specific: any module sub called in listop form pays it.
+
+## Measurement protocol
+
+`MUTSU_VM_STATS=1` does not currently count carrier entries for this opcode —
+add one (`record_dispatch_entry_outcome("execcallpairs", ...)`) before
+optimizing, so the fix has a deterministic counter rather than only wall-clock.
+Then the 20 000-assertion loop `tmp/bench-ok-loop.raku` and `write-int.t` under
+`MUTSU_REAL_TEST=1` are the two wall-clock checks.

--- a/todo/perf/method-dispatch-flattens-the-env-on-every-call.md
+++ b/todo/perf/method-dispatch-flattens-the-env-on-every-call.md
@@ -99,3 +99,45 @@ Iterate on `MUTSU_VM_STATS`'s `clone_env` / `env_deep_copies` counters (they are
 deterministic and optimization-independent, so the debug build is enough), then
 confirm on release with the padding table above: the cleanest success signal is
 that the per-assertion cost stops scaling with env size at all.
+
+## Update (2026-09-06): the flatten also destroys the return merge
+
+Re-measured after the multi-resolution cache started serving `Test`'s
+assertions
+(`news/2026-09/multi-resolve-cache-keys-carry-definedness-and-declared-type.md`),
+with the same unsound experiment (an env-var kill switch on
+`flatten_scoped_env`): the 20 000-assertion `ok` loop goes **3.58 s -> 2.96 s**,
+i.e. **17%** of what is left.
+
+Callgrind says why it is worth more than its own `HashMap` clone. The single
+largest self-cost item in the loop is `std::thread::local::LocalKey<T>::with`
+(11.8% of the loop), and its dominant caller is
+`call_compiled_function_named_inner` — **333 586 thread-local accesses across
+600 named calls**, ~556 per call. Those come from the scoped-overlay *return
+merge*:
+
+```rust
+for (k, v) in self.env().iter() { ... k.with_str(...) ... }
+```
+
+On a scoped env `iter()` is overlay-only, so that loop is O(callee writes) —
+which is the whole point of Slice 6. But the method-dispatch flatten runs
+*first* (`$output.say: $tap` inside `proclaim` is a full method dispatch), so by
+the time the callee returns its env is FLAT and the merge iterates every name in
+scope, calling `Symbol::with_str` two or three times per key.
+
+So the flatten costs twice: once to build the merged map, and once more by
+turning the frame's O(writes) return merge into an O(whole env) scan. Any fix
+should be measured against the merge loop's `with_str` count, not just against
+`env_deep_copies`.
+
+Two cheaper sub-fixes, if the full "move the flatten to the consumers" change
+stays too risky:
+
+* `Env::flattened()` can return `parent.flattened()` directly when the overlay
+  is empty and there are no tombstones — provably identical (`scoped_child`
+  already derives an empty child's `file_sym` from the parent), and O(1) when
+  the parent is flat.
+* the merge loop's `k.with_str(is_routine_scoped_implicit_var)` runs for every
+  key; the names it tests are a fixed handful, so interning them once and
+  comparing `Symbol` ids removes a thread-local round trip per key.

--- a/todo/tickets/native-int-candidate-loses-to-int-for-a-literal.md
+++ b/todo/tickets/native-int-candidate-loses-to-int-for-a-literal.md
@@ -1,0 +1,44 @@
+# A bare integer literal picks the `Int` candidate where rakudo picks `int`
+
+## Repro
+
+```raku
+multi sub d(int $x) { "native" }
+multi sub d(Int $x) { "boxed" }
+say d(5);
+```
+
+* rakudo: `native`
+* mutsu: `boxed`
+
+The variable-shaped spellings are already right — `my int $n = 5; d($n)` answers
+`native` and `my Int $b = 5; d($b)` answers `boxed`, both in mutsu and in
+rakudo, and they are pinned by `t/multi-resolve-cache-keys.t`. Only the bare
+literal diverges.
+
+## Why it happens
+
+An integer literal arrives at dispatch as a plain boxed `Int` value with no
+source variable, so `unwrap_varref_for_dispatch` reports no declared type and
+`candidate_type_distance` ranks `Int` at distance 0 and `int` further away.
+Rakudo instead treats an integer literal as a native `int` for dispatch
+purposes: its literal is an `IntLexRef`/native constant, so the native
+candidate is the exact match.
+
+The fix is in the *ranking*, not in the caches: a `Value::Int` that came from a
+literal (or, more simply, any boxed `Int` that fits the native width) must rank
+`int` at least as specific as `Int`. Getting that right needs a look at
+`candidate_type_distance`'s native-type rows and at what else keys off "no
+declared type", so it is not a one-liner.
+
+## Where
+
+* `src/runtime/dispatch_candidates.rs` — `unwrap_varref_for_dispatch`,
+  `candidate_type_distance`, `type_hierarchy_distance`.
+
+## How it was found
+
+While pinning the multi-resolution cache keys
+(`news/2026-09/multi-resolve-cache-keys-carry-definedness-and-declared-type.md`).
+It is pre-existing and independent of the cache: the same wrong answer comes
+out of a single cold call with no cache involved.


### PR DESCRIPTION
A callgrind run of 300 `ok 1, "x"` assertions under the vendored upstream
Test module put 1.06 M instructions on a single assertion, with 29% of the
whole program in `resolve_function_with_types` -- the full multi-candidate
walk, re-run on every `ok`/`is`/`is-deeply` call. Three separate things kept
those calls out of the sound multi-resolution caches, none of them
Test-specific:

* the parser's synthetic `__mutsu_test_callsite_line` named argument, which
  `multi_arg_type_keys` refused along with every other Pair even though it is
  filtered out before binding and no signature can declare it;
* a `:D`/`:U` smiley in a candidate, counted as value-dependence -- correct
  while the key could not carry definedness, which it now does;
* a `VarRef` argument, refused outright because dispatch also reads the source
  variable's declared type -- now keyed, behind its own reserved marker.

Two further value properties had to join the key to keep it sound, both caught
by the existing suites rather than by reasoning: an enum member's own identity
(`Less` and `More` are both `Order`) and the INVOCANT's definedness, which is
not in the argument list at all. A constrained `&`-sigil parameter dispatches
on the passed routine's declared return type, which no argument key can
express, so that candidate shape is refused wholesale alongside the
neighbouring signature checks.

roast/S03-buf/write-int.t under the real module goes 48.0s -> 28.6s (184 079
full resolves -> 22 805, all of them now per-subtest rather than
per-assertion); a 20 000-assertion `ok` loop goes 5.07s -> 3.36s. That closes
the last timeout of `todo/deep/vendor-real-test-module.md` on this machine,
though with no margin -- the next two measured targets are filed under
`todo/perf/`.

The method-side and function-side cacheability gates had drifted into two
copies of the same constraint analysis; they now share
`type_constraint_is_value_dependent`, so they cannot disagree about the key
shape they are guarding.

Pinned by t/multi-resolve-cache-keys.t, which interleaves the arms of each
split so a key that dropped a property is served the wrong winner on the
second iteration instead of passing on a cold cache.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012uYR88u9jZop7dLgPyESBS