### PR TITLE
perf(dispatch): build a method's implicit `*%_` only when its body can see it

### DIFF
--- a/news/2026-09/implicit-named-slurpy-gated-at-compile-time.md
+++ b/news/2026-09/implicit-named-slurpy-gated-at-compile-time.md
@@ -1,0 +1,67 @@
+# A method builds its implicit `*%_` only when its body can observe it
+
+`todo/perf/adr0019-g3-diffuse-bless-allocation-cost.md` had, for the first time, a *specified*
+next step rather than a speculative one. The `alloc_scope!` accounting landed in the previous
+session named the largest single remaining item on `bench-ctor`'s construction path:
+`mfast:slurpy-captures-locals`, at 10.3 allocations per compiled method call — about 10% of the
+whole program — and essentially all of it in `implicit_method_named_slurpy`.
+
+## What was happening
+
+Every Raku method carries an implicit `*%_`: a Hash of the named arguments no explicit named
+parameter consumed. It exists so a body can write `self.bless(|%_)` without declaring anything,
+and so `%_` reads as an empty Hash rather than `Any` (which would splat a stray positional).
+
+The compiled method fast path materialized it on *every* call: a `HashMap` grown incrementally, a
+`String` per leftover named key, and a `Value` hash — whether or not the body could ever look at
+it. `bench-ctor`'s `submethod TWEAK(:$!spec) { }` has an empty body and built a 7-key hash on each
+of its 5000 calls, purely to drop it.
+
+## The gate
+
+`CompiledCode` now carries `may_observe_named_slurpy`, computed while the body is compiled, in the
+shape of the existing `uses_dispatcher` flag (which exists for exactly this reason: so a method
+that never defers pays no per-call `SamewithContext` clone). The fast path builds `%_` only when it
+is set.
+
+The flag is deliberately an over-approximation — a false positive merely keeps the old behaviour,
+so the analysis only has to be *complete*, not tight:
+
+- **Any string constant that spells `%_`.** Every way a body reaches the slurpy — a read, a `|%_`
+  flatten, an index, a store, an explicitly declared `*%_` used in the body — compiles to an opcode
+  whose name operand is the variable-name string `%_` in the constant pool, so one substring test
+  in `add_constant` catches the lot. A source literal that merely contains `%_` trips it too.
+- **A nested closure whose own flag is set.** A closure in a method body resolves `%_` through the
+  method's env, so `add_closure_code` folds the child's flag into the parent's.
+- **The dynamic escape hatches**, checked in `emit()`: `EVAL`/`EVALFILE`, symbolic deref
+  (`::('%_')`), the `CALLER::` pseudo-package ops, and any inner routine/subset declaration — whose
+  body lives in `decl_plans`, not in the constants `add_constant` scans.
+
+Rakudo, checked as the oracle, actually rejects both `EVAL '%_...'` ("Cannot use placeholder
+parameter %_ outside of a sub or block") and `%_` in a nested `sub`'s body ("Placeholder variable
+'%_' cannot override existing signature"), so two of those hatches guard against paths that are not
+reachable in correct Raku at all. They cost nothing and stay.
+
+## Measurements
+
+Allocation counts (`--features alloc-stats`, exact and load-independent), `benchmarks/bench-ctor.raku`:
+
+| scope | before | after |
+| --- | --- | --- |
+| `mfast:slurpy-captures-locals` per method call | 10.3 | 4.0 |
+| whole program | 1,541,606 | 1,444,372 (-6.3%) |
+
+Order-swapped min-of-11 and min-of-13 wall-clock A/B, `MUTSU_JIT=off`, both binaries built from the
+same tree:
+
+| benchmark | round 1 (new first / base first) | round 2 (new first / base first) |
+| --- | --- | --- |
+| `bench-ctor` | -1.2% / -6.0% | -6.0% / -5.2% |
+| `bench-class` | -2.0% / -6.7% | -7.1% / -5.9% |
+
+Faster in every order in both rounds. `method-call`, `poly-call`, `bench-grammar-parse` and
+`bench-yaml-parse` were checked for a regression and showed none — their deltas flip sign with
+measurement order, which is what noise looks like on a sub-150ms benchmark.
+
+`t/implicit-named-slurpy-gate.t` pins the semantics each branch of the gate has to preserve, and
+passes under rakudo as well as mutsu.

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -4683,6 +4683,21 @@ pub(crate) struct CompiledCode {
     /// `todo/tickets/callsame-to-native-mu-methods-nil.md` for why an
     /// unconditional push was rejected on hot-path cost grounds.
     pub(crate) uses_dispatcher: bool,
+    /// True if this code can possibly observe the implicit `*%_` named slurpy
+    /// every method signature carries. Computed conservatively while compiling:
+    /// set by any string constant that spells `%_` (every `%_` read, index,
+    /// flatten or store names it in the constant pool), by any nested closure
+    /// body whose own flag is set, by an inner routine/subset declaration
+    /// (whose body is not in this code's constant pool), and by the dynamic
+    /// escape hatches that can reach a lexical without naming it -- `EVAL`,
+    /// symbolic deref (`::('%_')`) and the `CALLER::` ops.
+    ///
+    /// The method fast paths materialize `%_` -- a `HashMap`, a `String` per
+    /// leftover named key and a `Value` hash -- on *every* call; a body that
+    /// cannot observe it (e.g. `submethod TWEAK(:$!spec) { }`) built a hash
+    /// only to throw it away. Over-approximating is always safe: a false
+    /// positive just keeps the old behaviour.
+    pub(crate) may_observe_named_slurpy: bool,
     /// True if this code is the body of a `supply { … }` block — the lambda
     /// `Supply.on-demand` is handed, recognised by its generated emitter
     /// parameter (`__mutsu_supply_emitter_N`, see `supply_method_call`).
@@ -5124,6 +5139,7 @@ impl CompiledCode {
             has_once: false,
             uses_callframe: false,
             uses_dispatcher: false,
+            may_observe_named_slurpy: false,
             source_line: None,
             is_pointy_block: false,
             pointy_alias_param: false,
@@ -7185,6 +7201,9 @@ impl CompiledCode {
     /// whether the closure was created in an escaping position (see
     /// `closure_escapes`); the two Vecs are kept index-aligned in lockstep.
     pub(crate) fn add_closure_code(&mut self, code: CompiledCode, escapes: bool) -> u32 {
+        // A closure nested in a method body resolves `%_` through the method's
+        // env, so its mention counts as this code's.
+        self.may_observe_named_slurpy |= code.may_observe_named_slurpy;
         let idx = self.closure_compiled_codes.len() as u32;
         self.closure_compiled_codes.push(Arc::new(code));
         self.closure_escapes.push(escapes);
@@ -7227,6 +7246,32 @@ impl CompiledCode {
                 }
                 _ => {}
             }
+        }
+        if !self.may_observe_named_slurpy {
+            // The escape hatches that reach a lexical without naming it in this
+            // code's constant pool: `EVAL`ed source, symbolic deref
+            // (`::('%_')`), the `CALLER::` pseudo-package ops, and an inner
+            // routine/subset declaration whose body lives in `decl_plans`
+            // rather than in the constants scanned by `add_constant`.
+            self.may_observe_named_slurpy = match &op {
+                OpCode::CallFunc { name_idx, .. }
+                | OpCode::CallFuncNamed { name_idx, .. }
+                | OpCode::GetBareWord(name_idx) => self
+                    .constants
+                    .get(*name_idx as usize)
+                    .is_some_and(|v| match v.view() {
+                        ValueView::Str(s) => matches!(s.as_str(), "EVAL" | "EVALFILE"),
+                        _ => false,
+                    }),
+                OpCode::SymbolicDeref { .. }
+                | OpCode::GetCallerVar { .. }
+                | OpCode::SetCallerVar { .. }
+                | OpCode::BindCallerVar { .. }
+                | OpCode::GetCallerOuterVar { .. }
+                | OpCode::RegisterDecl(..)
+                | OpCode::RegisterSubset(..) => true,
+                _ => false,
+            };
         }
         if !self.uses_dispatcher
             && let OpCode::CallFunc { name_idx, .. }
@@ -7653,6 +7698,18 @@ impl CompiledCode {
     /// Values with an observable identity (containers, Instances, Regex, ...)
     /// get no key and always take a fresh slot.
     pub(crate) fn add_constant(&mut self, value: Value) -> u32 {
+        // Every `%_` reference -- a read, an index, a `|%_` flatten, a store --
+        // reaches the constant pool as a variable-name string spelling `%_`
+        // (possibly package-qualified), so one substring test over the strings
+        // this code interns is a complete, conservative detector. A source
+        // literal that merely *contains* `%_` trips it too; that is a harmless
+        // false positive.
+        if !self.may_observe_named_slurpy
+            && let ValueView::Str(s) = value.view()
+            && s.contains("%_")
+        {
+            self.may_observe_named_slurpy = true;
+        }
         let Some(key) = ConstKey::of(&value) else {
             let idx = self.constants.len() as u32;
             self.constants.push(value);

--- a/src/vm/vm_method_dispatch.rs
+++ b/src/vm/vm_method_dispatch.rs
@@ -1726,10 +1726,16 @@ impl Interpreter {
         // binds positionals by index and skips slurpy params, leaving `%_` as
         // `Any` -- so `|%_` would splat a stray positional. Compute it here and let
         // the locals-init loop fill the `%_` slot.
-        let implicit_named_slurpy: Option<Value> = if method_def
-            .param_defs
-            .iter()
-            .any(|pd| pd.slurpy && pd.name == "%_")
+        // ...but only when the body can actually observe `%_`. `cc` records
+        // that conservatively at compile time (`may_observe_named_slurpy`);
+        // a body that never spells `%_` -- `submethod TWEAK(:$!spec) { }`,
+        // the overwhelming majority of methods -- built a hash of the leftover
+        // named args on every call and immediately threw it away.
+        let implicit_named_slurpy: Option<Value> = if cc.may_observe_named_slurpy
+            && method_def
+                .param_defs
+                .iter()
+                .any(|pd| pd.slurpy && pd.name == "%_")
         {
             Some(Self::implicit_method_named_slurpy(
                 &method_def.param_defs,

--- a/t/implicit-named-slurpy-gate.t
+++ b/t/implicit-named-slurpy-gate.t
@@ -1,0 +1,52 @@
+use Test;
+
+# Every method carries an implicit `*%_` holding the named arguments no explicit
+# named parameter consumed. The compiled fast path only *materializes* it when
+# the method body can observe it (`CompiledCode::may_observe_named_slurpy`),
+# which is decided conservatively at compile time -- so cover each way a body
+# reaches `%_`: directly, through an explicit `*%_` forwarded with `|%_`, from a
+# nested closure, and across a `nextsame` deferral.
+
+plan 9;
+
+class A {
+    has $.x;
+    method plain($v) { return $v + 1 }
+    method direct(:$a) { return %_.keys.sort.join(",") }
+    method forwards(*%_) { return self.bless(|%_) }
+    method in-closure() { my $c = { %_<k> // "none" }; return $c() }
+    method empty-slurpy() { return %_.elems }
+    method evals() { return EVAL '40 + 2' }
+}
+
+my $a = A.new(x => 1);
+
+is $a.plain(1), 2, 'a method that never names %_ still binds its parameters';
+is $a.direct(:a(1), :b(2), :c(3)), 'b,c',
+    '%_ holds exactly the named args no explicit parameter consumed';
+is A.forwards(x => 9).x, 9, 'an explicit *%_ forwards through |%_ to bless';
+is $a.in-closure(k => 'hi'), 'hi', 'a nested closure sees the method %_';
+is $a.empty-slurpy(), 0, '%_ is an empty Hash when no named args are left over';
+is $a.direct(), '', '%_ is empty, not Any, when the call passes no named args';
+is $a.evals(), 42, 'an EVAL in a method body still runs';
+
+# A deferral re-dispatches the original arguments, so the next candidate must
+# see its own `%_` even though the first candidate never named it.
+class Base {
+    method who() { return "base:" ~ %_.keys.sort.join(",") }
+}
+class Derived is Base {
+    method who() { nextsame }
+}
+is Derived.new.who(:p(1), :q(2)), 'base:p,q',
+    'a deferral hands the next candidate its own %_';
+
+# `bless` through a user `new` that never names `%_` must still initialise
+# attributes from the named arguments it forwards positionally.
+class Point {
+    has $.x;
+    has $.y;
+    submethod TWEAK(:$!x, :$!y) { }
+}
+is Point.new(x => 3, y => 4).x + Point.new(x => 3, y => 4).y, 7,
+    'attributive named parameters bind without materialising %_';

--- a/todo/perf/adr0019-g3-diffuse-bless-allocation-cost.md
+++ b/todo/perf/adr0019-g3-diffuse-bless-allocation-cost.md
@@ -212,7 +212,7 @@ spending 6.5% of the program in that function).
 
 Order-swapped min-of-9 A/B, `MUTSU_JIT=off`: `bench-ctor` -3.5%, `bench-class` -4.6%.
 
-### Next step (specified, not speculative): the implicit `*%_` slurpy
+### 2026-09-06 (same day, later): the implicit `*%_` slurpy is gated -- DONE
 
 The largest single remaining item the tool identifies is `mfast:slurpy-captures-locals` at **10.3
 allocations per method call (~10% of `bench-ctor`'s total)**, and essentially all of it is
@@ -230,6 +230,39 @@ hatches to over-approximate on are `EVAL` and dynamic-name lookup (`::('%_')`), 
 lexical without naming it in the constant pool.
 
 This is a compiler-analysis slice rather than a dispatch one, which is why it was not folded into
-the PR above. Remaining smaller items, in order: `bless:named-args` (11 allocations per bless, the
-sigil-coercion clone loop), `mfast:epilogue` (5.1/call), and the `format!("{}\0{}")` qualified
-private-attribute key built per private-attribute local per call in the fast path's locals-init loop.
+the PR above.
+
+The gate landed as described (`news/2026-09/implicit-named-slurpy-gated-at-compile-time.md`):
+`CompiledCode::may_observe_named_slurpy`, set by any `%_`-spelling string constant, by a nested
+closure whose own flag is set, and by the dynamic escape hatches (`EVAL`, symbolic deref,
+`CALLER::` ops, inner routine/subset declarations). `mfast:slurpy-captures-locals` fell from 10.3
+to 4.0 allocations per method call and the whole program from 1,541,606 to 1,444,372 allocations
+(-6.3%); order-swapped wall-clock A/B put `bench-ctor` and `bench-class` each ~5-7% faster.
+
+### Next steps (still specified, in order)
+
+The `alloc_scope!` report on `benchmarks/bench-ctor.raku` after that fix reads:
+
+| scope | allocations / entry |
+| --- | --- |
+| `mfast:body` (exclusive) | 40.7 per method call |
+| `bless:named-args` | 11.0 per bless |
+| `bless:attr-defaults` | 5.0 per bless |
+| `mfast:epilogue` | 4.9 per method call |
+| `mfast:slurpy-captures-locals` | 4.0 per method call |
+| `mfast:env-setup` | 2.7 per method call |
+| `mfast:param-bind` | 2.3 per method call |
+| `mfast:prologue` | 1.7 per method call |
+
+- **`bless:named-args`, 11 allocations per bless** (`dispatch_bless`'s override loop in
+  `runtime/methods_dispatch_new.rs`). Each supplied named argument does a linear
+  `plan.class_attrs.iter().position(...)` scan and then a `coerce_provided_attr_value_by_sigil`
+  clone. The scan is O(attrs x args) on a 20-attribute class; an index on the plan would make it
+  O(args), and the clone is worth checking for a no-op sigil case that can skip it.
+- **`mfast:epilogue`, 4.9 per method call.**
+- **The residual 4.0 in `mfast:slurpy-captures-locals`**, which is now the locals-init loop alone:
+  the `vec![Value::NIL; cc.locals.len()]` plus a `format!("{}\0{}", owner_class, attr_name)`
+  built per private-attribute local per call. The format could reuse one scratch `String` across
+  the loop.
+- Re-run the 7/31-vs-HEAD A/B from the top of this ticket, or read the bench-CI trend, to see how
+  much of the original drift these have now closed.


### PR DESCRIPTION
Continues `todo/perf/adr0019-g3-diffuse-bless-allocation-cost.md` (ADR-0019 G3), taking the next step that ticket specified.

## The problem

Every Raku method carries an implicit `*%_` — a Hash of the named arguments no explicit named parameter consumed — so a body can write `self.bless(|%_)` without declaring anything, and so `%_` reads as an empty Hash rather than `Any` (which would splat a stray positional).

The compiled method fast path materialized it on **every** call: a `HashMap` grown incrementally, a `String` per leftover named key, and a `Value` hash, whether or not the body could ever look at it. The `alloc_scope!` accounting added in the previous slice named this the largest single remaining item on `bench-ctor`'s construction path — `mfast:slurpy-captures-locals`, **10.3 allocations per method call, about 10% of the whole program** — because `submethod TWEAK(:$!spec) { }` has an empty body and built a 7-key hash on each of its 5000 calls purely to drop it.

## The change

`CompiledCode` now carries `may_observe_named_slurpy`, computed while the body is compiled, in the shape of the existing `uses_dispatcher` flag (which exists for exactly this reason: so a method that never defers pays no per-call `SamewithContext` clone). The fast path builds `%_` only when it is set.

The analysis over-approximates on purpose — a false positive just keeps today's behaviour, so it only has to be *complete*, not tight. It is set by:

- **any string constant spelling `%_`** — every way a body reaches the slurpy (a read, a `|%_` flatten, an index, a store, an explicitly declared `*%_` used in the body) compiles to an opcode whose name operand is that variable-name string in the constant pool, so one substring test in `add_constant` catches the lot;
- **any nested closure whose own flag is set** — a closure in a method body resolves `%_` through the method's env, so `add_closure_code` folds the child's flag into the parent's;
- **the dynamic escape hatches**, checked in `emit()`: `EVAL`/`EVALFILE`, symbolic deref (`::('%_')`), the `CALLER::` pseudo-package ops, and any inner routine/subset declaration — whose body lives in `decl_plans`, not in the constants `add_constant` scans.

Rakudo, checked as the oracle, actually rejects both `EVAL '%_...'` ("Cannot use placeholder parameter %_ outside of a sub or block") and `%_` in a nested `sub`'s body ("Placeholder variable '%_' cannot override existing signature"), so two of those hatches guard paths that are not reachable in correct Raku at all. They cost nothing and stay.

## Measurements

Allocation counts (`--features alloc-stats`, exact and load-independent), `benchmarks/bench-ctor.raku`:

| scope | before | after |
| --- | --- | --- |
| `mfast:slurpy-captures-locals` per method call | 10.3 | 4.0 |
| whole program | 1,541,606 | 1,444,372 (**-6.3%**) |

Order-swapped min-of-11 and min-of-13 wall-clock A/B, `MUTSU_JIT=off`, both binaries built from the same tree:

| benchmark | round 1 (new first / base first) | round 2 (new first / base first) |
| --- | --- | --- |
| `bench-ctor` | -1.2% / -6.0% | -6.0% / -5.2% |
| `bench-class` | -2.0% / -6.7% | -7.1% / -5.9% |

Faster in every order in both rounds. `method-call`, `poly-call`, `bench-grammar-parse` and `bench-yaml-parse` were checked for a regression and showed none — their deltas flip sign with measurement order, which is what noise looks like on a sub-150ms benchmark.

(Per the project convention, the numbers that end up in documents come from the bench CI trend; these local A/Bs are the in-flight development evidence.)

## Test plan

- `t/implicit-named-slurpy-gate.t` (new, 9 tests) pins the semantics each branch of the gate has to preserve — a body that never names `%_`, a direct `%_` read, an explicit `*%_` forwarded through `|%_` to `bless`, a nested closure reading `%_`, an empty `%_`, an `EVAL` in a method body, a `nextsame` deferral handing the next candidate its own `%_`, and attributive named parameters binding without materialising `%_`. It passes under rakudo as well as mutsu.
- `make test`: 3728 files / 38455 tests. The only failure is `t/io-path-smartmatch-permissions.t`, which asserts `'/sys'.IO ~~ :w` is `False`; this dev container runs as uid 0, so root genuinely can write it. Environment artifact, unrelated to this diff — CI runs non-root.
- 226 whitelisted roast files across S06 / S12 / S13 / S14 (5511 tests): all pass.
- `cargo fmt` and `cargo clippy --all-targets -- -D warnings` clean.

## Follow-ups

The ticket stays open, updated with the post-fix `alloc_scope!` table and the next items in order: `bless:named-args` (11 allocations per bless, an O(attrs x args) linear scan that wants an index on the plan), `mfast:epilogue` (4.9/call), and the residual `format!("{}\0{}")` qualified private-attribute key in the locals-init loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BSyRU5UPUU2HmzLZhi2sNA

---
_Generated by [Claude Code](https://claude.ai/code/session_01BSyRU5UPUU2HmzLZhi2sNA)_