### PR TITLE
docs: record the second face of the Mix f64-weight storage limit

### DIFF
--- a/news/2026-09/mix-weight-arithmetic-under-the-numeric-tower.md
+++ b/news/2026-09/mix-weight-arithmetic-under-the-numeric-tower.md
@@ -94,6 +94,26 @@ that needs `MixData` to hold `Value` weights, which reaches roughly 474
 one. The tower fix is exact for every weight the storage can represent, which is
 every decimal literal.
 
+**The same storage limit has a second face, found while verifying this change
+against raku on 2026-09-06: a weight whose value is integral loses its
+`Rat`-ness.** The decoding is `Int` first, so any `Rat` that happens to be a
+whole number decodes as an `Int`:
+
+```raku
+say (a => 6.0).Mix<a>.^name;                        # raku: Rat   mutsu: Int
+my $m = (a => 2.5).Mix (+) (a => 3.5).Mix;
+say $m<a>.^name;                                    # raku: Rat   mutsu: Int
+say (a => 2.5, b => 3.5).Mix.total.^name;           # raku: Rat   mutsu: Int
+```
+
+The *values* are right in every row (`6`), and the numeric tower itself is right
+— `(2.5 + 3.5).^name` is `Rat` in both. It is only the round trip through the
+`f64` that forgets which side of the tower the weight came from, exactly as the
+`1/3` row above does; this face was simply not visible until the arithmetic
+started producing exact sums. Both close together when `MixData` holds `Value`
+weights, and neither is worth a partial fix that would make the decoding depend
+on which operation produced the double.
+
 ## Pin
 
 `t/mix-weight-numeric-tower.t` — 40 tests covering `(+)`/`(-)`/`(.)`/`(^)` and


### PR DESCRIPTION
Found while independently verifying #7394 against raku (11 of 12 rows matched; this is the twelfth).

A `Mix` weight whose value is integral loses its `Rat`-ness, because the canonical decoding tries `Int` first:

```raku
say (a => 6.0).Mix<a>.^name;                 # raku: Rat   mutsu: Int
my $m = (a => 2.5).Mix (+) (a => 3.5).Mix;
say $m<a>.^name;                             # raku: Rat   mutsu: Int
say (a => 2.5, b => 3.5).Mix.total.^name;    # raku: Rat   mutsu: Int
```

The **values** are right in every row (`6`), and the numeric tower itself is right — `(2.5 + 3.5).^name` is `Rat` in both. It is only the round trip through the `f64` that forgets which side of the tower the weight came from.

That is the same root as the `(a => 1/3).Mix` row #7394 already documents, but the opposite symptom: that one is a `Rat` that cannot be decoded, this one is a `Rat` that decodes *too well*. It only became visible once the arithmetic started producing exact sums, which is why #7394 could not have seen it.

Recorded next to that row rather than filed as its own ticket: both close together when `MixData` holds `Value` weights (~474 `ValueView::Mix` sites, a campaign of its own), and a partial fix would make the decoding depend on which operation produced the double.

Docs-only, so the four heavy CI jobs skip by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)