### PR TITLE
docs(todo): regenerate TRIAGE after two days that replaced it entirely

### DIFF
--- a/todo/TRIAGE.md
+++ b/todo/TRIAGE.md
@@ -1,4 +1,4 @@
-# TRIAGE — prioritized snapshot of todo/ (2026-09-04, second pass)
+# TRIAGE — prioritized snapshot of todo/ (2026-09-06)
 
 A ranked index of every open finding under `todo/tickets/`, `todo/deep/` and
 `todo/perf/`, so a session can pick the next unit of work without re-reading
@@ -10,56 +10,67 @@ conflicts `todo/` exists to avoid. A stale row is fine; the per-ticket files
 stay the source of truth. Regenerate the whole file when it has drifted too
 far (re-survey every ticket, re-score, rewrite).
 
-## What changed since the morning regen (7dce1ff5b, the same day)
+## What changed since the 2026-09-04 regen (`cfba3c0d7`)
 
-Surveyed at `54946f2aa`: **71 files** — 44 `deep/`, 15 `tickets/`, 12 `perf/`.
+Surveyed at `884366c95`: **75 files** — 39 `deep/`, 20 `tickets/`, 16 `perf/`
+(was 71: 44/15/12).
 
-One working day (PRs #7274-#7294) turned over the entire top of the previous
-snapshot:
+Two working days replaced the snapshot almost completely.
 
-- **All four Tier S rows moved.** Three are closed — the
-  `&postcircumfix:<[ ]>` stack-overflow crash (#7285, and it was *not* the sub
-  hoisting ADR-0041 blamed), `proxy-assigned-into-an-array-is-not-fetched`
-  (#7290, now ADR-0040 §9), and `multidim-assign-to-an-expression-target`
-  (#7286). The fourth, `procasync-stress-segv`, had its **§8.2 diagnostics
-  slice landed** (#7291): the reason three CI crashes left no report was that
-  the handler *overflowed `std`'s 8 KiB alternate signal stack* on worker
-  threads, found with `strace -f -e trace=sigaltstack`, not with a debugger.
-- **Eleven new tickets were filed** and four closed, so `tickets/` went 8 → 15
-  and is now the queue that matters. They are not scattered: **eight of the
-  eleven fall into two coherent clusters** (Proxy containers, and the
-  routine registry not being lexically scoped) — see "Recommended next
-  campaigns".
-- **The perf call-path campaign delivered.** `bench-fib` went from ~1.25-1.32x
-  raku on the morning of 2026-09-03 to **0.84x at `54946f2aa`** (JIT row 0.41x)
-  across ~10 PRs. No `todo/perf/` file was edited, so every row in that section
-  below is now describing a *pre-sweep* world; re-measure before starting one.
-- **ADR-0040 grew a §9** that answers the `Proxy`-at-the-store question with
-  the same boundary as itemization, and **ADR-0041 grew a §6** recording that
-  two of its own premises were wrong. Both are worth reading before touching
-  their areas.
+- **Every row of the previous top is closed.** All four Tier S rows and *all
+  fifteen* `todo/tickets/` entries merged (#7296-#7380), plus nine `deep/`
+  files. Twenty-four closures in two days. Do not look for the old rows here;
+  they are in `news/2026-09/`.
+- **`tickets/` refilled from a different source.** The new tickets are not a
+  random scatter: most came from the **2026-09-06 full doc-diff re-sweep**
+  (`docs/doc-diff-backlog.md` — high-signal 296 → **108**, `mismatch` 184 → 74,
+  `crash` 112 → 34), triaged file-by-file into tickets. That backlog is now the
+  main feeder of `todo/tickets/`, and its two highest-signal files
+  (`Language/operators`, `Language/structures`) have been drained; the next
+  untriaged files are `Type/Any`, `Language/experimental`, `Language/objects`.
+- **`ADR-0068` was filed and is the only Tier S owner.** The residue of the
+  closed `procasync-stress-segv` became
+  [ADR-0068](../docs/adr/0068-cross-thread-container-writes-need-a-synchronized-store.md)
+  (`Proposed`), which owns *both* remaining Tier S rows, carries a **calibrated
+  reproduction harness**, and rejects the obvious remedy on the record. It is
+  the highest-value un-owned campaign in the repo.
+- **The perf picture inverted.** `bench-fib` went 0.84x raku (2026-09-04) to
+  **0.37x** at `87e910a62` (JIT row 0.20x); `hash-access` 0.18x,
+  `string-concat` 0.10x. The rows still above 0.5x are `method-call` (0.92x),
+  `time-parts` (1.12x) and `debug-guard` (0.76x). Four *new* perf files were
+  filed inside that campaign and are its live continuation.
+- **The `Test`-provider retirement is one perf slice from done.** The vendored
+  `Test` moved `roast/S03-buf/write-int.t` from 48.0s to **29.5s** against a
+  hard 30s gate (rakudo 3.49s, native provider 5.04s). Its file states
+  completion criterion 2 is **not** met and names its own next targets.
 
 ### What was re-verified for this regen
 
-All **eleven new tickets** were run today against `raku` v2026.06 on a fresh
-`target/debug/mutsu` at `54946f2aa`; every one reproduces as written. So did a
-re-run of every Tier S/B1 row and the `immutable-lvalues` probe harness. Three
-rows *moved* and are called out inline:
+Every one of the 75 files was read and, where it had a runnable repro, run
+against `raku` v2026.07 on a fresh `target/debug/mutsu` at `884366c95`. Of the
+20 tickets, **19 reproduce as written**. Three `deep/` rows moved and are
+called out inline. Four claims were re-run by hand rather than taken from the
+survey:
 
-- `promoted-element-cell-does-not-know-its-container-name` — a *direct* store
-  (`my Int @a = 1,2; @a[0] = "x"`) now names `@a` correctly; the ticket is about
-  the **promotion** sites (`:=` bind, `%h<a>`, `:p`), and all four of those
-  still print the bare sigil. Ticket stands, repro unchanged.
-- `chained-and-array-element-sigilless-bind-wrongly-readonly` — its **shape 2 is
-  fixed** (`my Int @arr = 1,2,3; my \x := @arr[0]; x = 1000` writes through).
-  Only shape 1, the two-hop bind chain, survives, and its message changed
-  (`Cannot modify an immutable Int (5)`, not `immutable value (x)`), so the
-  file's `mark_readonly` hypothesis is stale.
+- `deep/module-file-scope-array-and-hash-still-share-the-caller` — its ADR-0039
+  §6 acceptance repro is now **byte-identical to raku** (`inner=[3]` /
+  `[1 2 9]`). `da8e94252` (the ADR-0055 unvouched-capture cell) appears to have
+  closed it. Moved to Icebox pending a re-check of its two named roast rows.
+- `deep/call-compiled-closure-lacks-merge-all-...` — its `CALLER`/`OUTER` repro
+  also matches raku now. Only structural residue remains.
+- `deep/dollar-dot-attr-compound-assign-spurious-ro-error` — **the file's own
+  2026-09-01 tail is wrong**: `$.x *= 2` throws `X::Assignment::RO` again (raku
+  silently no-ops), while `$.x = 9` still mutates (raku throws). Two
+  divergences in opposite directions.
+- The `.WHICH` ticket pair — `===` and `set()` membership already agree with
+  raku, so only the `.WHICH` *method string* is wrong. That makes the cluster
+  cheap and low-risk, which is why it is recommended below.
 
 **Standing caveat.** A tier is a routing hint. This is one run on one box;
 CLAUDE.md's rule still applies — re-verify a ticket's repro on your own build
 before acting on it, and read the *tail* of a ticket file, where successive
-"Re-verified" sections accumulate.
+"Re-verified" sections accumulate (and, as the `$.x` row above shows, can
+themselves rot).
 
 ## How the ranking works
 
@@ -85,41 +96,57 @@ before acting on it, and read the *tail* of a ticket file, where successive
 
 ## Tier S — Soundness (crashes, silent data loss)
 
-| Ticket | Breadth | Effort | Verified 2026-09-04 (2nd pass) |
+| Ticket | Breadth | Effort | Verified 2026-09-06 |
 |---|---|---|---|
-| [rw-param-does-not-bind-a-proxy-container](tickets/rw-param-does-not-bind-a-proxy-container.md) | every `is rw`/`is raw` parameter and method parameter given a `Proxy` | M-L | **Confirmed**: `sub f($x is rw) { $x = 42 }; f($p)` leaves the backing lexical at `5`; raku `42`. The write is silently dropped — `auto_fetch_proxy_args` FETCHes *before* signature binding, so there is no container left to bind. The gate is keyed on the **callee's name** (a hardcoded `skip_proxy_fetch` list) when it is a property of the **parameter**. |
-| [element-bind-fetches-the-proxy-it-should-install](tickets/element-bind-fetches-the-proxy-it-should-install.md) | every `@a[0] := $proxy` | M | **Confirmed**: prints `5` where raku prints `9` — the element stops tracking. Same mechanism seen from the `:=` side: `__mutsu_bind_index_value` is an ordinary `CallFunc` and is the one sibling helper missing from that same name list. ADR-0040 §9 explicitly rules that a `:=` bind installs the Proxy itself, so this is a stated-rule violation, not an open question. |
-| [method-rooted-subscript-chain-autoviv-is-dropped](tickets/method-rooted-subscript-chain-autoviv-is-dropped.md) | every lvalue subscript chain rooted at a method call that must autovivify | L | **Confirmed both spellings**: `$o.a[0]<x> = 5` and `$o.a[0]{1;2} = 5` both leave `[]` where raku gives `[{:x(5)},]` / `[{"1" => ${"2" => 5}},]`. Exit 0, nothing reported. It only survives when the element already exists. The fix is **not** to grow `__mutsu_index_assign_method_lvalue_nested` (a `runtime/methods.rs`-era slow path CLAUDE.md forbids extending) — an attribute accessor has to yield a real container reference in lvalue context. |
-| [same-named-loop-params-in-one-unit-interfere](tickets/same-named-loop-params-in-one-unit-interfere.md) | any unit with two `for` loops that happen to reuse a parameter name | L | **Confirmed**: an `is rw` loop in one block silently changes what a later, unrelated, non-rw loop's closures capture (`[30 30]` vs raku `[10 30]`). Action at a distance across blocks, with nothing detecting it. Cause: four closure-capture sets (`captured_mutated_locals`, `needs_cell_locals`, `for_loop_param_syms`, `free_var_writes`) are keyed by **name** over the whole `CompiledCode`. **First experiment is cheap**: turn on `MUTSU_SHADOW_SLOTS` and see whether the repro passes — if it does, this is a datapoint for that campaign, not its own work. |
-| ~~procasync-stress-segv~~ -> [gc-contents-mut-cross-thread-aliased-writes](deep/gc-contents-mut-cross-thread-aliased-writes.md) | `roast/S17-procasync/stress.t`, `integration/advent2014-day05.t` | — | **ROOT-CAUSED AND CLOSED 2026-09-05** (`news/2026-09/supply-act-serialization-and-the-concurrency-crash-cluster.md`): `Supply.act` never enforced its "executed by only one thread at a time" guarantee, so concurrent `start` emitters ran act callbacks at once and their writes to one captured, `Gc`-aliased array raced through `gc_contents_mut` — whose `# Safety` clause forbids exactly that. `autoviv_resize` is a `Vec::resize`, so two workers reallocated one `Vec`: the corrupted-chunk abort in `__libc_free`. Reproduced at 1/64 native and 2/36 under ASan, 0/80 after serializing act dispatch. **The residual general hazard** (149 unsynchronized `gc_contents_mut` sites, plus the still-unexplained `stress.t` instance) moved to the linked deep file; it needs a `Proposed` ADR, not a crash hunt. |
+| [celled-container-element-write-races-under-threads](deep/celled-container-element-write-races-under-threads.md) | any container shared across a `start`/`.tap`/`.then` boundary | XL | **Confirmed, and it is real UB.** The visible half: `my @a = 1,2; @a.push(3); my $f = -> { start { @a.elems } }; sub collide() { my @a = 9; await $f.() }` answers `1`, raku `3`. The invisible half is heap corruption — `assign_array_elem_to_shared_var` bows out to "the general path" for a container already boxed in a `ContainerRef` cell, believing that cell is synchronized; it is not, and the write goes through an unlocked `gc_contents_mut`. Owned by **ADR-0068**. |
+| [gc-contents-mut-cross-thread-aliased-writes](deep/gc-contents-mut-cross-thread-aliased-writes.md) | 149 `gc_contents_mut` call sites; measured on `.tap`, `Promise.then`, `Thread.start` | XL | **Record, not a repro** — the route audit and the harness behind the row above. Failure shapes observed: `free(): double free detected in tcache 2`, `double free or corruption (out)` with a core dump, SIGILL, and silent lost updates. One `roast/S17-procasync/stress.t` SIGSEGV remains explicitly unexplained. Read this before writing any code against ADR-0068. |
+| [baggy-addition-panics-on-a-bigint-bag-weight](tickets/baggy-addition-panics-on-a-bigint-bag-weight.md) | every baggy operator — `(+) (-) (&) (^) (.)` — with a weight past `i64::MAX` | L | **Confirmed**: `say (a => 10**30).Bag (+) (a => 1).Bag` panics at `src/vm/vm_set_arith_ops.rs:60` (`attempt to add with overflow`); raku answers `Bag(a(1000000000000000000000000000001))`. **In release it does not panic — it wraps**, so this is a crash in debug and silent numeric corruption in the shipped build. Root cause: weights are coerced into an `i64`-keyed map *before* the operator body runs, so precision is already gone. Sits in the neighbourhood the 2026-09-06 Mix numeric-tower fix (`771504161`) just corrected — reuse that rule. |
 
 ---
 
-## `todo/tickets/` — all 15
+## `todo/tickets/` — all 20
 
-Eleven of these fifteen were filed after the morning regen. Four are ranked in
-**Tier S** above; the rest are below.
+Nineteen of the twenty reproduce exactly as written. Three are ranked above
+(one Tier S) or in the Icebox; the rest are here.
 
-### Startable today (8)
+### Broad correctness (5)
 
-| Ticket | Tier | Note (verified 2026-09-04, 2nd pass) |
+| Ticket | Tier | Note (verified 2026-09-06) |
 |---|---|---|
-| [package-body-proto-multi-not-lexical-to-the-package](tickets/package-body-proto-multi-not-lexical-to-the-package.md) | B1, **M-L** | **Confirmed, and it is two failures.** A class-body `proto`+`multi` family is unreachable from the class's own methods (`Unknown function: foo`; raku `in-class`); add a mainline `foo` and the method silently calls *that* one. A module-body one instead answers `Ambiguous call to foo(Int); these signatures all match: (Int $x), (Int $x)` — the two candidate sets are being **merged** across the package boundary. The single-`sub` baseline is correct in both, which localises it precisely: `resolve_function_with_types` / the multi-candidate gather, not registration. |
-| [imported-constant-class-alias-does-not-resolve](tickets/imported-constant-class-alias-does-not-resolve.md) | B1/B2, **M** | **Confirmed both spellings** against the fixture: `Rounded.new(1).^name` and `my @a is Rounded` both answer `Array` where raku answers `RoundedMod::Array::Rounded`. Two resolution paths (`exec_apply_var_trait_op` matches the trait name literally; the bareword path handles a same-file `my constant` but not a cross-module `is export` one). The `Array::Rounded` idiom is common; this is what is left of that dist's blockers now that the postcircumfix half is fixed. |
-| [do-block-does-not-scope-routine-declarations](tickets/do-block-does-not-scope-routine-declarations.md) | B1 (narrow breadth), **M** | **Confirmed**: a `sub` declared in a value-position `do { }` leaks out and permanently replaces the outer one (`inner`/`inner`; raku `inner`/`outer`). The statement-form bare block is already correct, and `Compiler::stmts_declare_routines` + the for-loop path are the precedent to copy. Costs a compile-time flag on `OpCode::DoBlockExpr` (mind `opcode_size_guard`) and wants a full roast + batteries run, since correcting it *removes* names that currently leak. |
-| [for-loop-sigilless-param-writeback-skips-the-type-check](tickets/for-loop-sigilless-param-writeback-skips-the-type-check.md) | N-B, **M (as a slice: L)** | **Confirmed**: `my SmallInt $a; for $a -> \x { x = 1000 }` silently sets `1000`; raku throws. The `:=` spelling now type-checks, so this is specific to the loop's `store_loop_source_var` writeback, which bypasses the container chokepoint entirely. The file argues for fix (2) — make the loop parameter a real alias and delete the scalar-source writeback — as an ADR-0045 slice, and explicitly asks you not to ship (1) silently. Named consumer: `Native::Overflow`'s `t/01-basic.rakutest`. |
-| [list-element-proxy-not-rendered-through-fetch](tickets/list-element-proxy-not-rendered-through-fetch.md) | N (rendering), **M** | **Confirmed**: `say (1, $proxy, 3)` prints `(1 Proxy 3)`; raku `(1 9 3)`. This one is *correct* to keep the Proxy in the List — ADR-0040 §9 rules that a List's elements are not containers — so it is purely a render gap. The `say` half is nearly a one-liner (`resolve_proxies_in_value` exists); every other renderer (`.gist`, `.raku`, interpolation, `~`) goes through pure `Value` methods with no `&mut Interpreter`, which is the real question and belongs as an ADR-0040 amendment. |
-| [promoted-element-cell-does-not-know-its-container-name](tickets/promoted-element-cell-does-not-know-its-container-name.md) | N (message quality), **S-M / L** | **Re-confirmed at all four promotion sites** (`:=` bind, `%h<a>`, `:p`, and the cross-routine `@z`-not-`@b` rule): all print `element of @` / `element of %`. The anonymous-container row correctly agrees with raku. Option 2 (retag at the naming opcodes) is a cheap interim; option 1 (an owner field beside `value_type`) is the honest fix and is the *name* half of ADR-0042's descriptor. Nothing measured depends on the wording. |
-| [list-literal-does-not-capture-element-containers](tickets/list-literal-does-not-capture-element-containers.md) | N-B, **M** | **Confirmed**: `my (\p,\q) := (@a[0],@a[1]); p = 9` dies with `Cannot modify an immutable Int (1)`; raku writes `[9 2]`. `compile_call_arg` tags a source container only from a source *name*, and `Expr::Index` has none. Changes what every parenthesised list holds, so it wants its own measurement pass. Paired with `deep/immutable-list-element-bind-is-writable`. |
-| [analysis-parse-mints-process-unique-registry-names](tickets/analysis-parse-mints-process-unique-registry-names.md) | N (resource leak), **M** | **Its prerequisite is now met** — ADR-0065 S1-S5a shipped and `src/analysis/{mod,symbols}.rs` expose the entry points (`check()`, `symbols()`) the fix hangs off. Each anonymous declaration leaks one interned registry name **per parse** (1.00/parse, ~0.5 KiB/parse, linear over 8000 re-parses); add a unit-local counter mode on those entry points, inherited by nested sub-parses and off for every existing caller. **Do not "fix" it by resetting the global counters** — the file explains why that breaks cross-unit uniqueness. Re-measure first (`MUTSU_S0_ITERATIONS=8000 cargo test --test long_lived_parse`); the numbers in the file are from a debug build. |
+| [smartmatch-against-the-topic-returns-bool-not-match](tickets/smartmatch-against-the-topic-returns-bool-not-match.md) | B1, **M** | **Confirmed**: `for (/a/,) { say ("ab" ~~ $_).raku }` gives `Bool::True`; raku a full `Match`. `exec_smart_match_expr_op` sets `$_` to the LHS *before* running the RHS bytecode range, so an RHS that reads `$_` sees the wrong thing — proved by elimination (`my $r2 = $_` first makes it work). `EXPR ~~ $_` inside `for`/`given` is a very common idiom. The fix needs a design split between `~~`-as-topicalizer and a plain-expression RHS, not a patch. |
+| [array-subclass-iterator-override-ignored](tickets/array-subclass-iterator-override-ignored.md) | B1, **M** | **Confirmed**: `class SortedArray is Array {...}; .say for @thing` prints the whole array as one item; raku iterates four. A user `iterator`/`list` override on an `is Array` subclass is not consulted, and `for` decides iterability from its own shape analysis. Adjacent to the `array-subclass-delegation-is-one-decision` work that landed this week — read that news entry first. |
+| [array-assignment-eagerly-reifies-a-triangle-reduce](tickets/array-assignment-eagerly-reifies-a-triangle-reduce.md) | B1, **M** | **Confirmed as a hang**: `my @n = [\~] 1..*; say @n[^5]` never terminates (exit 124); raku `(1 12 123 1234 12345)`. The laziness marker is not carried from the `[\op]` producer through `@`-assignment. Sibling of `deep/residual-try-cell-...` (ADR-0058) but a *different* producer — do not assume that ADR covers it. |
+| [native-int-candidate-loses-to-int-for-a-literal](tickets/native-int-candidate-loses-to-int-for-a-literal.md) | B1, **M** | **Confirmed**: with `multi d(int $x)` and `multi d(Int $x)`, `d(5)` picks `boxed`; raku `native`. A literal arrives with no declared-type source, so `candidate_type_distance` ranks `Int` closer. Independent of the multi-resolve-cache-key work that landed 2026-09-06 (that fixed *caching* of a resolution, not the ranking). |
+| [typed-container-capture-still-loses-to-a-same-named-caller-array](tickets/typed-container-capture-still-loses-to-a-same-named-caller-array.md) | B1, **L** | **Confirmed**: a closure over `my Int @a` reads `1` where raku reads `3` once a callee declares its own `@a`. The **last hole** in the otherwise-complete capture-cell dichotomy (ADR-0055 slice 1b, `da8e94252`) — plain containers were fixed, typed ones were not. The file records two *measured* regressions (BagHash/SetHash roast) from the naive widening, so read it before trying the obvious fix. |
 
-### Narrow, permissive, or low priority (3)
+### Battery-blocking (1)
 
 | Ticket | Tier | Note |
 |---|---|---|
-| [associative-multidim-lvalue-edge-divergences](tickets/associative-multidim-lvalue-edge-divergences.md) | N, **S-M** | Three independent rows, all **confirmed**. (1) `%h{1;2} //= 7` writes where raku no-ops, and the named-root and chain-root spellings do not even agree with each other. (2) `%h{*} = 5` yields `{"*" => 5}` — a **silent write to a stringified `Whatever`** where raku throws; that row alone is Tier-S-shaped but only reachable via a `Whatever` in an associative assignment. (3) `:delete` on a multi-dim subscript is accepted where raku refuses to resolve the caller — and its behaviour has *changed since the file was written* (it now deletes the inner key, leaving `{"1" => ${}}`, rather than no-opping), so re-read row 3 before fixing it. |
-| [our-proto-redeclaration-across-scopes-is-accepted](tickets/our-proto-redeclaration-across-scopes-is-accepted.md) | N (permissive), **S** | **Confirmed**: nested `our proto sub foo` shadows instead of being refused (`i`/`o`; raku `===SORRY!=== Redeclaration of routine 'foo'`). Direct fallout of the lexical-shadowing exemption added the same day — the exemption should not apply to an `our`-scoped declaration (`__our_scoped` marks it). Re-check all of `t/multi-proto-lexical-scope.t` after, since the `our` and `my` paths share the check. |
-| [procasync-output-chunks-do-not-hold-back-final-grapheme](tickets/procasync-output-chunks-do-not-hold-back-final-grapheme.md) | N, **M** | Carried. raku emits `["ab","cde","f"]`, mutsu `["abc","def"]`; on malformed UTF-8 the content differs too. Generalise the existing `held_cr` hold-back in `feed_utf8_incremental`; confirm rakudo's discard-on-error rule first. |
+| [object-hash-key-lost-when-pair-value-is-a-container](tickets/object-hash-key-lost-when-pair-value-is-a-container.md) | B2, **L** | **Confirmed**: a `Pair` whose value came from a hash read loses its key's container on assignment into `my Any:D %t{List:D}` — `Type check failed ... expected List:D but got Str ("1 2")`; raku builds the hash. Blocks 2 of Crane's 15 upstream files, i.e. it is part of the same `Config::TOML` + `Crane` battery slot as `deep/config-toml-battery-core-blockers`. |
+
+### Narrow correctness, diagnostics, permissiveness (11)
+
+| Ticket | Tier | Note |
+|---|---|---|
+| [subscript-argument-container-producer](tickets/subscript-argument-container-producer.md) | N, **L** | **Confirmed**: `g(@a[0])` writes through for a named sub, but `S.new.take(@a[0])` dies `expects a writable container ... but got '9' (Int) as a value`. It refuses loudly rather than losing the write, hence N. The producer for an `Expr::Index` argument is wired into `CallFunc` only, not `CallMethod`/`CallOnValue`/`CallOnCodeVar`. ADR-0067 residue; pairs with the row below. |
+| [immutable-list-element-write-is-silently-dropped](tickets/immutable-list-element-write-is-silently-dropped.md) | N, **L** | **Confirmed**: `$l[0].mut` on `my $l = (1,2)` with a `\S:` raw invocant silently succeeds and changes nothing; raku dies `Cannot modify an immutable Int (1)`. The write is correctly dropped — only the *diagnostic* is missing, because the binder does not consult readonly-ness for a raw invocant. Receiver-side twin of the row above. |
+| [list-and-array-which-should-be-object-identity](tickets/list-and-array-which-should-be-object-identity.md) | N, **M** | **Confirmed**: `(1,2).WHICH eq (1,2).WHICH` is `True`; raku `False` (same for `[1,2]` and `{a=>1}`). **Verified separately that `===` and `set()` membership already answer correctly** — only the `.WHICH` method arm in `builtins/methods_0arg/dispatch_core_coerce.rs` computes its own string instead of delegating to `value_which_key`. |
+| [pair-which-is-object-identity-not-content](tickets/pair-which-is-object-identity-not-content.md) | N, **S** | **Confirmed**: `(a=>1).WHICH` is `Pair|3` (a per-object counter) so two equal Pairs compare unequal; raku hashes the content. Same `.WHICH` arm, opposite polarity. One fix closes both rows. |
+| [itemized-list-element-var-reports-inner-type](tickets/itemized-list-element-var-reports-inner-type.md) | N, **S** | **Confirmed**: `(1,2,3,$(4,5))[3].VAR.^name` is `List`; raku `Scalar`. ADR-0064's descriptor synthesis declines for a *genuinely* itemized element and reports the inner type. Smallest open row in the file. |
+| [tolerance-dynamic-variable-is-undefined](tickets/tolerance-dynamic-variable-is-undefined.md) | N, **S** | **Confirmed**: `$*TOLERANCE` is `Nil`; raku `1e-15`, which makes every `≅`/`=~=` comparison answer on the wrong basis. Seed it beside the other `$*`-dynamics. |
+| [state-and-our-typed-declaration-hoist](tickets/state-and-our-typed-declaration-hoist.md) | N, **S** | **Confirmed, two independent rows.** `state Int $x` is not in effect before its declaration statement (raku type-checks, mutsu does not); and `our Int $x` compiles and dies at *runtime*, where raku refuses at compile time (`Cannot put a type constraint on an 'our'-scoped variable`). The residue of the typed-declaration-hoist fix that landed as `d61e6c534`. |
+| [set-operator-reduction-one-arg-rule-does-not-coerce](tickets/set-operator-reduction-one-arg-rule-does-not-coerce.md) | N, **M** | **Confirmed**: `[(|)] (a => 2).Bag` returns the bare operand `:a(2)`; raku applies the implied unary coercion and answers `("a"=>2).Bag`. The one-argument shortcut skips the coercion; `reduction_identity_opt` already knows the right per-operator zero. |
+| [mro-includes-composed-roles](tickets/mro-includes-composed-roles.md) | N, **L** | **Confirmed**: `K.^mro` lists `K,R2,Any,Mu`; raku `K,Any,Mu`. Introspection output is conflated with dispatch order. **L, not S, deliberately** — MRO widening has caused an unrelated dispatch-table regression here before (`trap-mro-widening-...`), so separate the two consumers rather than editing one list. |
+| [role-mixin-name-carries-a-spurious-type-parameter](tickets/role-mixin-name-carries-a-spurious-type-parameter.md) | N, **M** | **Confirmed**: `(1 but R(2)).^name` is `Int+{R[Int]}`; raku `Int+{R}`. Naming only — the attribute initialization itself reads back correctly. |
+| [zip-chain-with-a-comma-list-left-operand-fails-to-parse](tickets/zip-chain-with-a-comma-list-left-operand-fails-to-parse.md) | N, **M** | **Confirmed, two faces.** The paren spelling refuses to parse (`Confused. Two terms in a row`); the bracket spelling **silently mis-associates** — `[1, 2 Z <a b> Z <c d>]` gives `[(1,"c"), (((2,"a"),).Seq,"d")]` against raku's `[(1,"a","c"), (2,"b","d")]`. The silent-wrong-answer face is S-shaped but only reachable through this rare parse; `lift_meta_ops_in_paren_list` is never reached and `args.rs`'s one-level lift is used instead. |
+
+### Icebox tickets (2)
+
+| Ticket | Why here |
+|---|---|
+| [miri-leak-check-flakes-on-a-gc-test-fixture](tickets/miri-leak-check-flakes-on-a-gc-test-fixture.md) | CI-only, non-deterministic, and the file already records a **measured disproof of the obvious fix** — the leak did not reproduce in four local runs of the exact CI command. Not reachable through `./target/debug/mutsu` at all. Do not spend a session guessing at it; it needs a `cargo miri` run under the CI's own ordering. |
+| [rustdoc-doc-link-warnings](tickets/rustdoc-doc-link-warnings.md) | Pure lint debt with no functional repro and no CI gate. **Its headline number is already stale**: `cargo doc --no-deps --document-private-items` now reports ~248 warnings against the file's recorded 210, so the per-category breakdown is out of date too (the taxonomy is probably still right). Fix the count when you fix the warnings, or add the gate first. |
 
 ---
 
@@ -129,71 +156,100 @@ Eleven of these fifteen were filed after the morning regen. Four are ranked in
 campaign ran last, and `ls -tr` mtimes are corrupted by worktrees). Work it by
 ADR cluster: most deep findings wait on a *slice of an ADR that already
 exists*, and one landed slice closes several rows. Every `Status` line below
-was read on 2026-09-04 (2nd pass).
+was read on 2026-09-06.
 
 | ADR | Status | Rows it would close |
 |---|---|---|
-| [ADR-0040](../docs/adr/0040-array-hash-elements-are-itemized-at-the-store.md) elements itemized at the store | Complete, and **grew a §9 today**: `Proxy` is FETCHed at the *same* boundary as itemization, with two deliberate exclusions (a `:=` bind installs the Proxy; a `List`'s elements are not containers). Pinned by `t/proxy-store-boundary.t`, 28 dual-oracled rows. | It is the **owner of the whole Proxy cluster**: two Tier S rows and one Tier N render row are §9's residue, and §9 already states the rule each of them violates. |
-| [ADR-0041](../docs/adr/0041-sub-hoisting-vs-compile-time-name-visibility.md) sub hoisting vs name visibility | Still `Proposed`, but **§6 now records that two of its premises were wrong**: the crash was a missing `postcircumfix:<` entry in `resolve_code_var`'s operator fast path, not hoisting; and Option B (emit each `RegisterDecl` at its textual position) is **rejected as specified** — the real discriminator is compile time vs run time. | Its own residue (§6.4): a `&name` inside `constant`/`BEGIN` still sees what only the hoist pass made visible. §6.4 explicitly says this, the proto/multi shadowing gap, and ADR-0039 "should be resourced as one campaign, not three patches". |
-| [ADR-0039](../docs/adr/0039-container-lexicals-resolve-lexically.md) container lexicals resolve lexically | Slice 1 landed 2026-08-20; §8.2 and the `our` case closed separately; **slice 2 open** | `module-file-scope-array-and-hash-still-share-the-caller`; and it is the third leg of the registry-scope campaign above. |
-| [ADR-0024](../docs/adr/0024-mainline-lexicals-for-named-subs.md) mainline lexicals for named subs | (no slice plan) | `mainline-lexical-sigilless-binding-leaks-into-a-later-redeclaration` — a name-keyed mainline-lexical entry outlives its block. Fourth leg of the same campaign; ADR-0032 D2's "slot-addressed, never name-addressed" is the constraint it violates. |
-| [ADR-0045](../docs/adr/0045-for-loop-parameters-bind-the-element-container.md) for-param binds the element container | Accepted, fully implemented; **its last two named residues were closed today** (the multi-parameter read-only capture, and the Proxy landmine that forced `t/for-loop-element-alias.t` to rename its parameters — they are `$x`/`$y` again) | `tickets/for-loop-sigilless-param-writeback-skips-the-type-check` is the *right* home for a new slice: make the scalar-source loop parameter a real alias and delete the writeback. |
-| [ADR-0036](../docs/adr/0036-element-container-pairs-from-subscripts-and-pairs.md) element-container Pairs | Implemented; every slice landed, and its last open ticket closed today | Nothing. |
-| [ADR-0059](../docs/adr/0059-is-rw-routines-return-a-container.md) `is rw` routines return a container | Slices 1-2 implemented; **slice 3 open**, with no failing repro attached | Nothing today. |
-| [ADR-0048](../docs/adr/0048-placeholder-scope-is-a-block-invocation-contract.md) placeholder scope | Accepted; P1-P4 landed, P5's scope half landed, its value half deferred | `role-body-placeholder-mu-supply` (P5's value half — corpus hits: zero) |
-| [ADR-0055](../docs/adr/0055-closure-free-vars-resolve-to-their-own-binding.md) closure free vars bind their own | Slices 1 + **1b** landed (1b 2026-09-06: the vouch's complement gets a cell). **§1.2(b) is closed for plain scalars on every invocation path**; slices 2-5 not started, and §7.6 records the three things the ADR got wrong (there are THREE closure-env merges, not two) | `call-compiled-closure-lacks-merge-all-...` (structural gaps only now); `tickets/parameter-capture-handed-to-a-call-has-neither-defence`, `tickets/container-lexical-capture-loses-to-same-named-caller-array` (the two measured residues) |
-| [ADR-0065](../docs/adr/0065-language-server-targets-ai-agents.md) LSP targets AI agents | **Accepted; S0-S5a shipped** (S1 entry point, S2 unknown-routine reporting, S3 parse-error recovery, S4 symbols + go-to-definition, S5a hover) | `lsp-references-needs-a-side-table-not-ast-spans` (amends D6/S5b); **`tickets/analysis-parse-mints-...` is now unblocked** |
-| [ADR-0042](../docs/adr/0042-type-constraints-belong-to-the-container-not-to-a-name.md) container-carried type constraints | **Implemented; all three slices shipped** (2026-09-06) — the global `var_type_constraints` map and its hash-key twin are deleted, and §12 records what §5.3 got wrong about the `for`-loop workaround. The 47-row matrix is pinned in `t/typed-constraint-store-matrix.t` | `tickets/promoted-element-cell-...` is the *name* half of the same descriptor and is now unblocked |
-| [ADR-0052](../docs/adr/0052-a-when-clause-produces-its-value-on-the-stack.md) `when` value on the stack | **Accepted; all four slices shipped** (2026-09-05) — §7 supersedes §2.4's "observe the smartmatch" premise and corrects §1.2's compiler count (eight, not three) | none open |
-| [ADR-0053](../docs/adr/0053-do-whenever-produces-a-tap-on-the-stack.md) `do whenever` produces a Tap | `Proposed`, **and its header is still behind the code**: `.WHAT` already answers `Tap`; only the subscription-identity half is open | `whenever-expression-position-needs-real-design` |
-| [ADR-0058](../docs/adr/0058-map-grep-produce-a-deferred-seq.md) map/grep produce a deferred Seq | `Proposed` | `residual-try-cell-eager-seq-reification-divergences` |
-| [ADR-0047](../docs/adr/0047-type-identity-is-a-declaration-site-not-a-registry-name.md) type identity | P1-P2 landed; **P3-P4 open** | `subtest-compiled-dispatch-async-middleware-regression` (P4 is a prerequisite for re-landing #6499, not a fix for the regression) |
+| [ADR-0068](../docs/adr/0068-cross-thread-container-writes-need-a-synchronized-store.md) cross-thread container writes | **`Proposed` (2026-09-05)** — decision written: (C) a global "more than one mutator thread is live" `AtomicBool` gate, then (B) the smallest provable slice, then widen lane by lane. Remedy (A), "lock the primitive", is **rejected on the record** (45 of the 149 sites can re-enter user code while holding it). | **Both Tier S rows.** This is the only ADR that owns a Tier S finding, and it is not started. |
+| [ADR-0067](../docs/adr/0067-a-routine-hands-back-the-container-it-was-given.md) a routine hands back its container | **Accepted; every slice implemented** (1, 2, 3a, 3b, 4, 5 across 2026-09-05/06) | Its *residue* is two tickets: `subscript-argument-container-producer` (argument side) and `immutable-list-element-write-is-silently-dropped` (receiver side). Both are the same missing wiring on the non-`CallFunc` call paths. |
+| [ADR-0055](../docs/adr/0055-closure-free-vars-resolve-to-their-own-binding.md) closure free vars bind their own | Slices 1 + 1b landed (1b 2026-09-06); slices 2-5 open. §7.6 records that the ADR was wrong about there being two closure-env merges — there are three. | `tickets/typed-container-capture-...` (the last measured hole); `deep/call-compiled-closure-...` (structural only now — its headline repro passes). Slice 1b also appears to have closed ADR-0039's acceptance case, see below. |
+| [ADR-0058](../docs/adr/0058-map-grep-produce-a-deferred-seq.md) map/grep produce a deferred Seq | `Proposed`. Slice 1 (un-`todo` the test) done; **slice 2 — wire `SeqSource::MapGrep` into `dispatch_map_method`/`builtin_map`/`grep` — is the concrete next step.** | `residual-try-cell-eager-seq-reification-divergences` (9 of its 11 rows). Implementing it makes mutsu *stricter*, so a full local `make roast` is mandatory. |
+| [ADR-0047](../docs/adr/0047-type-identity-is-a-declaration-site-not-a-registry-name.md) type identity | Partially adopted — P1/P2 landed; **P3 and P4 not started** | `subtest-compiled-dispatch-async-middleware-regression` (P4 is the prerequisite for re-landing #6499, *not* itself the fix for the regression). |
+| [ADR-0053](../docs/adr/0053-do-whenever-produces-a-tap-on-the-stack.md) `do whenever` produces a Tap | `Proposed`, "implementation not started" — **the header is behind the code**: `.WHAT` already answers `Tap`. | `whenever-expression-position-needs-real-design`, whose symptom has *moved again*: the pre-`close` emission is now dropped too. Reconcile the header before designing. |
+| [ADR-0048](../docs/adr/0048-placeholder-scope-is-a-block-invocation-contract.md) placeholder scope | Accepted; P1-P4 landed, P5's scope half landed, its value half deferred | `role-body-placeholder-mu-supply` — and the file argues against doing it: corpus hits are **zero** and rakudo's own behaviour there is an artifact (`$^c.defined` throws in real raku). |
+| [ADR-0039](../docs/adr/0039-container-lexicals-resolve-lexically.md) container lexicals resolve lexically | Slice 1 landed 2026-08-20; §8.2 closed 2026-08-22; slice 2 nominally open | `module-file-scope-array-and-hash-still-share-the-caller` — but **its §6 acceptance repro now matches raku exactly** (verified by hand for this regen). Re-check the two roast rows it names (`S15-nfg/concat-stable.t`, `integration/advent2014-day05.t`) and close it rather than resourcing slice 2 blind. |
+| [ADR-0065](../docs/adr/0065-language-server-targets-ai-agents.md) LSP targets AI agents | Accepted; header says "S0 and S1 shipped" while its own phasing table marks **S5a done** — the header is behind the table | `lsp-references-needs-a-side-table-not-ast-spans` (amends D6/S5b; blocked on a *measurement*, not a design). |
+| [ADR-0029](../docs/adr/0029-exception-class-role-membership.md) exception class role membership | Slices 1-3 + R1-R4 landed; **R5 blocked on `vendor-real-test-module`** | `exception-class-hierarchy-is-mostly-unregistered` — whose title is now badly stale: all 373 rakudo `X::` subtypes match. It is closed-pending-an-unrelated-dependency. |
+| [ADR-0059](../docs/adr/0059-is-rw-routines-return-a-container.md) `is rw` routines return a container | Slices 1-2 implemented; slice 3 open, no failing repro attached | Nothing today. |
+| [ADR-0051](../docs/adr/0051-type-ancestry-has-one-oracle-and-an-unresolved-method-throws.md) / [ADR-0021](../docs/adr/0021-argument-namedness-is-a-call-site-property.md) / [ADR-0025](../docs/adr/0025-captured-scalar-cells-value-kind-blind.md) | P2+P5 / P5 / slice 3 open respectively | Nothing in `todo/` names them. Open slices without a failing repro — do not resource them ahead of a Tier S row. |
+| [ADR-0050](../docs/adr/0050-block-routine-ness-is-a-definition-site-property.md) / [ADR-0043](../docs/adr/0043-scheduled-delivery-hop-belongs-to-the-tapped-supply.md) | Both `Proposed`, implementation not started (ADR-0043's Decision 1 is probe-verified and ready) | Nothing in `todo/` — designs waiting for a consumer. |
 
 ### Recommended next campaigns
 
-1. **The Proxy container boundary (two Tier S rows + one Tier N).**
-   `rw-param-does-not-bind-a-proxy-container` and
-   `element-bind-fetches-the-proxy-it-should-install` are **the same defect from
-   two sides**: whether an argument is FETCHed is decided by a hardcoded list of
-   *callee names* when it is a property of the *parameter or bind target*.
-   Both files say so, and both say "prefer fixing the decision once over
-   lengthening the list a fourth time". ADR-0040 §9 already states the rule they
-   break, so this is a slice with a written spec, not a design problem.
-   `list-element-proxy-not-rendered-through-fetch` is the render-side third and
-   can ride along or be split.
-2. **The routine registry is not lexically scoped (ADR-0041 §6.4's own
-   recommendation).** Four findings are one mechanism:
-   `package-body-proto-multi-not-lexical-to-the-package` (candidate sets merged
-   across a package boundary), `do-block-does-not-scope-routine-declarations`
-   (no snapshot/restore on `DoBlockExpr`),
-   `our-proto-redeclaration-across-scopes-is-accepted` (the shadow exemption
-   ignores `our`), and ADR-0041 §6.4's BEGIN-time visibility residue — with
-   ADR-0039 slice 2 and `mainline-lexical-sigilless-binding-leaks` as the
-   container-side analogue. §6.4 says explicitly: **resource these as one
-   campaign, not three patches.** This is the highest-value un-owned ADR work.
-3. **`same-named-loop-params-in-one-unit-interfere`, starting with the cheap
-   experiment.** Turn on `MUTSU_SHADOW_SLOTS` and re-run the two-block repro. If
-   it passes, this Tier S row is a datapoint for the shadow-slot campaign
-   (`docs/lexical-scope-slot-campaign.md` §1.3/§1.4) and not separate work —
-   which would be the strongest argument yet for finishing that campaign.
+1. **ADR-0068 slice (B) — the only Tier S cluster, and the design is already
+   written.** Two `deep/` rows are one mechanism: the shared-vars lane hands a
+   write to a `ContainerRef` cell it *believes* is synchronized and is not, and
+   the write goes out through an unlocked `gc_contents_mut`. The ADR has
+   already done the expensive parts — it rejects "lock the primitive" with a
+   149-site re-entrancy census, and it ships a **calibrated harness** (see the
+   methods note below). Start at step 1 (the `AtomicBool` gate), then the
+   single-lock repair of the false premise in §2; do not start with a 149-site
+   sweep. This is real UB in a shipped configuration and outranks everything
+   else in this file.
+2. **Finish the `Test`-provider retirement (a PLAN §1 goal item, not perf
+   polish).** `deep/vendor-real-test-module` is at 29.5s against a 30s gate,
+   and it names its own remaining work: `perf/defaulted-param-forfeits-the-light-call-path`
+   (a routine with one defaulted trailing parameter re-resolves **by name on
+   every call** — 1001 full resolves per 1000 calls, and 280k of the 565k
+   by-name resolves in `write-int.t`), `perf/listop-call-bypasses-every-compiled-call-cache`
+   (`ok`/`is`-shaped listop calls reach *none* of `CallFunc`'s three caches) and
+   `perf/method-dispatch-flattens-the-env-on-every-call` (17% of what is left).
+   All three are ordinary implementation work with measured targets — no ADR —
+   and retiring a rung-3 native provider is a BATTERIES.md goal. **This is the
+   highest-value non-Tier-S work in the repo.**
+3. **The ADR-0067 producer residue (two tickets, one mechanism).**
+   `subscript-argument-container-producer` and
+   `immutable-list-element-write-is-silently-dropped` are the argument side and
+   the receiver side of the same gap: the container plumbing a named-sub call
+   gets was never extended to `CallMethod`/`CallOnValue`/`CallOnCodeVar`.
+   ADR-0067 is Accepted with every slice landed, so this is completing a stated
+   rule, not opening a question.
+4. **The `.WHICH` identity pair — the cheapest coherent win in the file.**
+   `list-and-array-which-should-be-object-identity` and
+   `pair-which-is-object-identity-not-content` are one arm of
+   `dispatch_core_coerce.rs` computing its own string instead of delegating to
+   `value_which_key`. Verified for this regen that `===` and `set()` membership
+   **already answer correctly**, so the internal oracle is right and only the
+   method disagrees with it — which bounds the blast radius to introspection.
+   S+M effort, two rows, one fix.
+5. **`perf/locals-frame-is-a-pooled-vec-not-a-register-window` — write the ADR,
+   do not start the code.** It is the largest single remaining cluster after the
+   September sweep (~5.7% of `bench-fib` spent managing a one-element `Vec`),
+   but `self.locals` is touched at 484 sites across 60 files, `mem::take` is
+   load-bearing in three call paths, and the JIT emits native code against the
+   current layout's offset. A `Proposed` ADR is the deliverable.
 
 **One measured process exception, kept from previous regens:** when a change
 alters a *universal property of values* ("what is in every container"), run the
 full local `make roast` before pushing (ADR-0040 slice 2 needed 17
-counter-current fixes, 9 found only by roast). The Proxy campaign above is
-exactly that shape. Ordinary parser/operator/dispatch fixes still delegate to CI.
+counter-current fixes, 9 found only by roast). Campaign 3 above is that shape.
+Ordinary parser/operator/dispatch fixes still delegate to CI.
 
-**Two methods worth copying.**
+**Methods worth copying.** Five, all earned this cycle:
 
-- **The instrumented sweep.** Three consecutive ADR closures each ended by
-  instrumenting the single function the mechanism stores through, running all of
-  `t/` plus the roast whitelist under it, and diffing every row against raku.
-  All three found live defects their own divergence matrices could not see.
-- **`strace` for anything signal- or syscall-shaped.** The three-recurrence
-  `procasync` diagnostics gap was closed in four lines of
-  `strace -f -e trace=sigaltstack` output after a debugger had only established
-  that the handler ran. A debugger answers "did we get here"; `strace` answers
-  "what did the kernel then do to us".
+- **ADR-0068's stress harness — CPU *oversubscription* is the ingredient, not
+  concurrency.** At 8-way on 12 cores a racing workload was 0/64 and 0/240 —
+  clean. At **24-way on 12 cores** the same binary failed 6/960 within seconds.
+  Every earlier "clean" measurement in this area was taken below the threshold
+  and means nothing. Negative results kept on the record: `memcheck` finds
+  nothing (it serializes threads onto one core), and helgrind was a dead end.
+- **The two-breakpoint gdb oracle.** Break on the unsynchronized site and on
+  the synchronized lane; `already hit N times` on the first with nothing on the
+  second means the workload is *exposed*. Deterministic, one debug run, and it
+  settled every route in minutes where the stress harness needs hundreds of
+  runs to say the same thing probabilistically.
+- **Compare against rakudo on the same workload, not mutsu against mutsu.**
+  Three rounds of the YAML campaign profiled mutsu internally and missed a
+  40x-over-firing grammar action; instrumenting *both* implementations' action
+  call counts found it immediately.
+- **`add_constant` must stay flat on a steady-state loop.** Growth with
+  iteration count means something is being *compiled* per call. Do not conclude
+  "flat profile, no dominant cost" before checking it — that mistake cost the
+  bench-ctor campaign three rounds.
+- **Do NOT keep bisecting a ~5% perf regression.** A second bisect named a
+  commit whose code samples *zero cycles* in the benchmark: pure binary-layout
+  noise. Discharge any bisect result by checking whether the named code is even
+  sampled, and prefer retired instructions to cycles.
 
 ---
 
@@ -203,35 +259,27 @@ exactly that shape. Ordinary parser/operator/dispatch fixes still delegate to CI
 
 | Ticket | Effort | Why here |
 |---|---|---|
-| [free-var-read-in-callee-resolves-through-dynamic-caller-chain](deep/free-var-read-in-callee-resolves-through-dynamic-caller-chain.md) | XL | **Reconfirmed today** (`f sees 1` / `alias 200`; raku `f sees 5`). A callee's env is `Env::scoped_child(caller_env)`, so a free variable walks the *dynamic* chain and a routine loses its own lexical. Silent wrong read in ordinary code, still the highest-leverage finding with no ADR (ADR-0055 §7.5 puts it out of scope). Its cheaper half — why `f`'s own `my $var = 5` is not visible in `f`'s env tier — is worth isolating first. **The repro needs the file form**; the `:=` bind in `g` is load-bearing. |
-| [immutable-list-element-bind-is-writable](deep/immutable-list-element-bind-is-writable.md) | L | **Reconfirmed**: `my @t := (5,6); my $x := @t[0]; $x = 10` prints `(10 6)` — mutsu *mutates an immutable List*; raku refuses. The guard exists but is **narrowed to `my \a :=` binds only** because three consumers lean on the promotion (a chunked multi-parameter loop — `S32-str/val.t` loses 1201 subtests — QuantHash `.kv`, `Pair.kv` in a closure). Closing it means fixing those three, then dropping the flag; prototypes for two are in the file. |
-| [mainline-lexical-sigilless-binding-leaks-into-a-later-redeclaration](deep/mainline-lexical-sigilless-binding-leaks-into-a-later-redeclaration.md) | L | A named sub closing over `my \x` puts a **name-keyed** mainline-lexical entry that outlives its block, so an unrelated later `my \x := 5` finds the stale `ContainerRef` and a write that must die silently succeeds. Fourth leg of campaign 2 above. |
-| [dollar-dot-attr-compound-assign-spurious-ro-error](deep/dollar-dot-attr-compound-assign-spurious-ro-error.md) | L | **Reconfirmed**: `$.x = 9` inside a method *mutates* a non-`rw` attribute (prints `9`); raku throws `Cannot modify an immutable Int (1)`. Both halves are silent over-mutation. Needs the "accessor read is an itemized copy" ADR; explicitly **not** ADR-0040. |
-| [call-compiled-closure-lacks-merge-all-and-dual-persistence-store](deep/call-compiled-closure-lacks-merge-all-and-dual-persistence-store.md) | XL | **Headline defect FIXED 2026-09-06** (ADR-0055 slice 1b): the `CALLER`/`OUTER` repro is pinned green on five invocation paths. What remains is structural — no `merge_all` equivalent in `call_compiled_closure`, and the two disjoint per-instance state stores; both are ADR-0055 slices 3-5, which *retire* the parameter rather than add a knob. |
-| [residual-try-cell-eager-seq-reification-divergences](deep/residual-try-cell-eager-seq-reification-divergences.md) | L | `.map`/`.grep` run their callback eagerly. ADR-0058's target; implementing it makes mutsu stricter, so a full local `make roast` is mandatory. |
-| [module-file-scope-array-and-hash-still-share-the-caller](deep/module-file-scope-array-and-hash-still-share-the-caller.md) | L | Module shape fixed (ADR-0039 slice 1); by-name container resolution in inner blocks/closures still corrupts. Slice 2, and the container-side leg of campaign 2. |
-| [supply-channel-has-no-fanout-to-multiple-taps](deep/supply-channel-has-no-fanout-to-multiple-taps.md) | L | Second `whenever` on `$proc.stdout` gets nothing (single `mpsc` receiver). Live-vs-on-demand replay semantics must be respected; unify with the `Supplier` registry. |
-| [whenever-expression-position-needs-real-design](deep/whenever-expression-position-needs-real-design.md) | M | Symptom already moved: both legal shapes answer `Tap`; `Tap.close` retroactively drops the value emitted before it. Reconcile ADR-0053's header with what landed, then do the identity slice. |
-| [grammar-action-ordering-vs-inline-code-blocks](deep/grammar-action-ordering-vs-inline-code-blocks.md) | L | A `make`-bearing embedded block runs at reduce time, out of order. Needs a write channel into the live capture accumulator plus backtrack undo; lands under full roast + battery coverage or not at all. |
-| [regex-quantifier-eager-candidate-enumeration-overruns-code-blocks](deep/regex-quantifier-eager-candidate-enumeration-overruns-code-blocks.md) | L | Embedded blocks fire per *computed* candidate (5 vs 2, 17 vs 3). Quantifier-matching architecture change; ADR-0009's "never execute user code while measuring" is the prior art. |
-| [native-method-accepted-named-declarations](deep/native-method-accepted-named-declarations.md) | L | **Reconfirmed**: `"abc".chop(:zzz)` → `abc` (raku `ab`); an unknown named silently lands in a positional slot on six measured methods. Two designs, ADR first. |
-| [user-prefix-op-candidate-beats-builtin-typed-candidate](deep/user-prefix-op-candidate-beats-builtin-typed-candidate.md) | L | **Reconfirmed with the file's own repro** (`multi prefix:<++>($a) is default {...}; ++$foo` → mutsu `0`, raku `2`). Note a plain `sub prefix:<++>` *does* win in raku too — use the file's `multi` repro, not a simplified one. Native operators are not dispatch candidates at all. |
-| [definiteness-constrained-type-object-identity-lost](deep/definiteness-constrained-type-object-identity-lost.md) | L | **Reconfirmed**: `Any:D.^name` → `Any` (raku `Any:D`). Needs a `DefiniteHOW`-equivalent representation ADR. |
-| [resume-does-not-return-to-die-call-site-in-nested-sub](deep/resume-does-not-return-to-die-call-site-in-nested-sub.md) | L/XL | `.resume` after a `die` in a nested sub prints nothing at all (raku: `after-inner` / `after-call`). Continuation-shaped; tied to how Rust frames unwind. |
-| [custom-io-handle-write-read-not-dispatched](deep/custom-io-handle-write-read-not-dispatched.md) | L | `$*OUT = $store` writes to the real fd and the store stays empty; raku captures. Subclass `WRITE`/`READ`/`EOF` ignored by print/say/read. |
-| [is-typename-custom-container-store-protocol-unimplemented](deep/is-typename-custom-container-store-protocol-unimplemented.md) | L | `my @v is DNA = 1,2` never calls `STORE`. Scope it first (grep the corpus for `method STORE`). |
-| [export-default-package-not-symbolically-navigable](deep/export-default-package-not-symbolically-navigable.md) | M-L | `::("Test::EXPORT::DEFAULT::&ok")` yields a `Failure` (raku `(Sub)`). Decide how deep to model export tags. |
-| [unify-statement-expression-control-construct-compilation](deep/unify-statement-expression-control-construct-compilation.md) | XL | Architectural debt, still growing. Keeps producing paired half-bugs — `when-nonmatch` and `do-block-does-not-scope-routine-declarations` are both instances. |
+| [free-var-read-in-callee-resolves-through-dynamic-caller-chain](deep/free-var-read-in-callee-resolves-through-dynamic-caller-chain.md) | XL | **Re-verified by hand for this regen** (`f sees 1` / `alias 200`; raku `f sees 5`). A callee's env is `Env::scoped_child(caller_env)`, so a free variable walks the *dynamic* chain and a routine loses its own lexical. Still the highest-leverage finding with **no ADR** — ADR-0055 §7.5 explicitly disclaims it. Its cheaper half (why `f`'s own `my $var = 5` is not visible in `f`'s env tier) is worth isolating first. The repro needs the file form; the `:=` bind in `g` is load-bearing. |
+| [dollar-dot-attr-compound-assign-spurious-ro-error](deep/dollar-dot-attr-compound-assign-spurious-ro-error.md) | L | **Re-verified, and the file's own tail is stale — rewrite it before dispatching.** Today: `$.x = 9` inside a method *mutates* a non-`rw` attribute (raku throws `X::Assignment::RO`), while `$.x *= 2` *throws* `X::Assignment::RO` (raku silently no-ops). Two divergences in opposite directions, which is the signal that the accessor's lvalue-ness is decided in two places. Needs the "accessor read is an itemized copy" ADR; explicitly **not** ADR-0040. |
+| [immutable-lvalues-that-mutsu-still-lets-you-assign-to](deep/immutable-lvalues-that-mutsu-still-lets-you-assign-to.md) | L | **Partially drained and still worth mining**: the element-store/bind and closure-topic families closed this cycle (both news-linked), and **7 rows survive** — e.g. `my @a = 1,2,3; my $x := @a; $x = 5` mutates `@a` where raku dies. The file records two "obvious fixes" that were tried and *measured* to regress other rows. Mine it for rows; do not dispatch it whole. |
+| [custom-io-handle-write-read-not-dispatched](deep/custom-io-handle-write-read-not-dispatched.md) | XL | **Confirmed both halves**: `$*OUT = $store` writes to the real fd and the store stays empty; a custom `.READ` handle dies `Expected IO::Handle`. Native print/read never check for a user `WRITE`/`READ`/`EOF` override. Cross-cutting (`io_env.rs`, `io_handle.rs`, `handle_open.rs`). |
+| [definiteness-constrained-type-object-identity-lost](deep/definiteness-constrained-type-object-identity-lost.md) | L | **Confirmed and wider than the title**: `Any:D.^name` → `Any` (raku `Any:D`), `Any:U` likewise, `~~` answers `True` for everything, and `.^base_type` does not exist. `grep -rn DefiniteHOW src/` still finds nothing. Needs its own small representation ADR — none exists. |
+| [user-prefix-op-candidate-beats-builtin-typed-candidate](deep/user-prefix-op-candidate-beats-builtin-typed-candidate.md) | XL | **Confirmed with the file's own repro** (`multi prefix:<++>($a) is default {...}; ++$foo` → `0`, raku `2`). Note a plain `sub prefix:<++>` *does* win in raku too, so use the `multi` spelling. The parse-time rewrite bypasses the native op entirely and native operators are not dispatch candidates at all. |
+| [residual-try-cell-eager-seq-reification-divergences](deep/residual-try-cell-eager-seq-reification-divergences.md) | L | **Confirmed**, and the file's own self-correction still holds: the cause is not `try`/sink placement — `.map`/`.grep` are simply eager over a finite source. ADR-0058 slice 2 is the fix for 9 of 11 rows; the `fail`+`try` exit-status rows are a separate, uninvestigated bug. |
+| [regex-quantifier-eager-candidate-enumeration-overruns-code-blocks](deep/regex-quantifier-eager-candidate-enumeration-overruns-code-blocks.md) | XL | **Confirmed**: `"aaac" ~~ / :my $c = 0; ( \w* { ++$c } ) c /` gives `5`; raku `2`. An embedded block fires once per *eagerly enumerated* candidate length instead of once per real backtrack. Engine-architecture change; ADR-0009's "never execute user code while measuring" is the prior art. |
+| [supply-channel-has-no-fanout-to-multiple-taps](deep/supply-channel-has-no-fanout-to-multiple-taps.md) | XL | **Confirmed**: a second `whenever` on `$proc.stdout` gets nothing — one `mpsc` receiver per Supply id, taken exclusively by whoever asks first. A naive buffer-and-replay fan-out would violate raku's live-vs-on-demand distinction, so this needs a design pass, not a patch. |
+| [resume-does-not-return-to-die-call-site-in-nested-sub](deep/resume-does-not-return-to-die-call-site-in-nested-sub.md) | XL | **Confirmed**: `.resume` after a `die` in a nested sub prints nothing after the handler; raku continues at the call site. `try_resume_safe_control_inline` is built for CONTROL exceptions (`warn`), not arbitrary `die`. Continuation-shaped; tied to how Rust frames unwind. |
 
 ### B2 — batteries / dist-blocking
 
 | Ticket | Blocks | Effort |
 |---|---|---|
-| [vendor-real-test-module](deep/vendor-real-test-module.md) | making the vendored upstream `Test` the default (retiring the native provider) | XL as a campaign. Its remaining blocker is perf, **and the perf ticket's diagnosis is wrong** — see the perf section. The call-path sweep that landed today (~33% off `bench-fib`) has not been re-measured against this workload; **do that first**, it is the single cheapest thing in this row. |
-| [config-toml-battery-core-blockers](deep/config-toml-battery-core-blockers.md) | `Config::TOML` + `Crane` battery slot | L (cluster): three independent core campaigns (Crane's array-path semantics, `\UXXXXXXXX` grammar candidate selection, inline-table timeout). **Do not start the vendoring steps.** |
-| [template-engines-blocked-on-mutsu](deep/template-engines-blocked-on-mutsu.md) | the template battery runner-ups | L (cluster) — **re-survey first**: both `Template::Jinja2` blockers are closed in `news/`, so its "0/23" row is unmeasured. `Template6` is still unreduced. |
-| [p5tie-stash-bind-key-protocol](deep/p5tie-stash-bind-key-protocol.md) | `P5tie`, `annotations` (~0.5% of sampled dists) | L — `Stash.BIND-KEY` / `CALLER::.BIND-KEY` both missing. Rung-2 machinery only. |
-| [subtest-compiled-dispatch-async-middleware-regression](deep/subtest-compiled-dispatch-async-middleware-regression.md) | re-landing #6499's `subtest` perf win | M-L — root cause unknown; bisect from the dispatch end with `rust-gdb` frame diffs, not from Cro. |
+| [vendor-real-test-module](deep/vendor-real-test-module.md) | making the vendored upstream `Test` the default (retiring a rung-3 native provider — a PLAN §1 goal) | L — **not XL any more.** `write-int.t` 48.0s → **29.5s** after the multi-resolve-cache fix, against a hard 30s gate (rakudo 3.49s; the native provider 5.04s on the same 93,370 assertions). The file states completion criterion 2 is **not** met and names the three perf rows that close it. All correctness regressions it tracked are closed (`t/` sweep: 0). See campaign 2. |
+| [config-toml-battery-core-blockers](deep/config-toml-battery-core-blockers.md) | `Config::TOML` (10/19) + `Crane` (3/15) battery slot | L (cluster). A self-re-measuring record — it flags its own previous numbers as stale each pass. The dominant remaining Crane cluster (`X::OutOfRange`/`CATCH` re-throw descent) is honestly marked "not bisected". `tickets/object-hash-key-lost-when-pair-value-is-a-container` is part of the same slot. **Do not start the vendoring steps.** |
+| [template-engines-blocked-on-mutsu](deep/template-engines-blocked-on-mutsu.md) | the template battery runner-ups | XL (cluster) — **re-measured 2026-09-06, trust these numbers**: `Template::Mustache` 13/13 and `Template6` 12/12 are now **done**; `Template::Jinja2` 3/23, `Template::HAML` 39/83, `Template::Mojo` 4/5, `SP6` 10/11, `Template::Nest::Fast` 0/10. The cheapest remaining lever is `Template::Nest::Fast`'s single `with EXPR -> @m` list-wrapping bug. |
+| [subtest-compiled-dispatch-async-middleware-regression](deep/subtest-compiled-dispatch-async-middleware-regression.md) | re-landing #6499's `subtest` perf win | L — root cause still unknown; #6499 is still reverted (`subtest_call_block` still routes through `call_sub_value`). Class registration, LEAVE phasers and async transforms are all ruled out by measurement, which narrows it to early/conditional-response middleware meeting compiled-closure frame construction. Bisect from the dispatch end with `rust-gdb` frame diffs, not from Cro. |
+| [rakuast-remaining](deep/rakuast-remaining.md) | RakuAST parity | XL — an actively-worked ledger with entries through today. Its own headline count is understated (`t/rakuast*.t` is **113 files**, not the 93 recorded), and **ADR-0011's header is behind it** by five weeks. Zero roast dependents; pick by user impact, not cadence, and read the RakuAST implementation skill first. |
+| [unify-statement-expression-control-construct-compilation](deep/unify-statement-expression-control-construct-compilation.md) | nothing directly — architectural debt | XL, and **measurably getting worse**: `helpers_do_expr.rs` is now **669 lines** (476 → 609 → 669), and `ForLoopSpec` is still constructed in two places. It keeps producing paired half-bugs; `do-block-does-not-scope-routine-declarations` (closed this cycle) was the most recent. |
 
 ---
 
@@ -239,46 +287,54 @@ exactly that shape. Ordinary parser/operator/dispatch fixes still delegate to CI
 
 | Ticket | Category | Effort / note |
 |---|---|---|
-| [end-phasers-install-at-compile-time](deep/end-phasers-install-at-compile-time.md) | correctness-narrow | M-L — mutsu prints `loop`/`main`; raku also runs the END in a never-taken `if False` block and in an uncalled sub. Same-line ordering tie-break included. |
-| [chained-index-assign-autoviv-loses-hole-tracking](deep/chained-index-assign-autoviv-loses-hole-tracking.md) | correctness-narrow | S-M — **reconfirmed**: `@a[0][1] = 5; @a[0][0]:exists` is `True` (raku `False`). The `;` form is fixed; find the chained autoviv site. |
-| [chained-and-array-element-sigilless-bind-wrongly-readonly](deep/chained-and-array-element-sigilless-bind-wrongly-readonly.md) | spurious die on valid code | M — **half fixed, rewrite before dispatching.** Shape 2 (`my \x := @arr[0]; x = 1000`) now writes through. Only shape 1 survives, the two-hop bind chain (`my \y := $a; my \x := y; x = 42` → `Cannot modify an immutable Int (5)`; raku `a=42`), and its message changed, so the file's `mark_readonly` hypothesis is stale. **Note it is a duplicate**: the same two-hop row is also recorded in `tickets/for-loop-sigilless-param-writeback-skips-the-type-check`'s "Also still open" section. Break with gdb before fixing. |
-| [module-toplevel-private-sub-leak-cleanup](deep/module-toplevel-private-sub-leak-cleanup.md) | accepts code raku rejects | M — **reconfirmed**: a non-exported module `sub helper` stays callable bare after `require` (raku: compile-time `Undeclared routine`). Needs an exhaustive audit of ambient `GLOBAL::` installers first (a generalisation was tried and reverted). Adjacent to campaign 2, but a *different* mechanism (the `GLOBAL::` key), so do not fold it in blindly. |
-| [role-body-placeholder-mu-supply](deep/role-body-placeholder-mu-supply.md) | rejects code raku accepts | M-L, **low priority by its own assessment** — ADR-0048 P5's value half. raku accepts `role R { $^c }` but supplies an uninitialized `VMNull` whose `.defined` *throws*, i.e. the semantics being matched are garbage. Corpus scan of `roast/`, `modules/`, `vendor/`, `lib/`: **zero** hits. |
-| [native-method-cannot-return-an-lvalue-container](deep/native-method-cannot-return-an-lvalue-container.md) | missing feature | L — the `.VAR = 5` row is *wrong* (raku dies too); `.snitch = 666` is the only acceptance case. Needs the container-propagation design campaign. |
-| [typed-shaped-array-rows-lose-element-value-type](deep/typed-shaped-array-rows-lose-element-value-type.md) | self-consistency (**no raku oracle** — raku says "Partially dimensioned views of shaped arrays not yet implemented") | S-M — thread `value_type` through `make_shaped_array_seeded`'s rows. |
-| [slurpy-hash-named-arg-raku-boolean-shorthand-missing](deep/slurpy-hash-named-arg-raku-boolean-shorthand-missing.md) | rendering | **Reconfirmed**: `{:a(Bool::True)}` vs raku `{:a}`. Small and self-contained. |
-| [direct-metamodel-classhow-new-type-immutable-error](deep/direct-metamodel-classhow-new-type-immutable-error.md) | missing feature | M/L — **narrow the file before starting**: the `.^add_method`-on-`new_type` half appears to work now. What is confirmed still broken is `does Metamodel::Naming` / `Metamodel::Stashing` (`X::InvalidType`), a much larger slice of the MOP. |
-| [begin-time-adverb-value-interpolation](deep/begin-time-adverb-value-interpolation.md) | correctness-narrow | L, **low priority** by its own assessment — no roast coverage; would add a whole-AST name-rewriting pass. |
+| [chained-index-assign-autoviv-loses-hole-tracking](deep/chained-index-assign-autoviv-loses-hole-tracking.md) | correctness-narrow | **S** — **confirmed**: `@a[0][1] = 5; @a[0][0]:exists` is `True` (raku `False`). The `;` form is already fixed; the file names the exact `IndexAssign` vs `MultiDimIndexAssign` divergence but deliberately leaves the site for the implementer. Smallest open `deep/` row. |
+| [end-phasers-install-at-compile-time](deep/end-phasers-install-at-compile-time.md) | correctness-narrow | M — **confirmed**: raku also runs an `END` inside a never-taken `if False` block and in an uncalled sub; mutsu registers only at `PhaserEnd` execution. The source-order half already shipped; this is the residue. |
+| [grammar-dynvar-code-block-still-defers](deep/grammar-dynvar-code-block-still-defers.md) | correctness-narrow | M — **confirmed**: a `$*`-mentioning inline block still runs at reduce time, so `inline` prints before `dyn`. The narrow residue of the `make`-bearing-block fix that landed this cycle. |
+| [ordered-alternation-eager-candidate-enumeration](deep/ordered-alternation-eager-candidate-enumeration.md) | correctness-narrow | XL — **confirmed**: a non-ratcheted `regex` subrule enumerates the whole candidate set, so both `||` branches' code blocks fire (`["one","two"]`; raku `["one"]`). Filed 2026-09-05 as the follow-on the continuation-driven ordered-alternation fix left open; same family as the quantifier row in B1. |
+| [module-toplevel-private-sub-leak-cleanup](deep/module-toplevel-private-sub-leak-cleanup.md) | accepts code raku rejects | L — **confirmed**: a non-exported module `sub helper` stays callable bare after `require`; raku fails at compile time. Needs an exhaustive audit of ambient `GLOBAL::` installers first — a generalisation was tried and reverted. |
+| [native-method-accepted-named-declarations](deep/native-method-accepted-named-declarations.md) | accepts code raku rejects | L — **confirmed, with one arm moved**: `"abc".chop(:zzz)` → `abc` and `10.polymod(3,:zzz)` → `(1 3 Inf)` still silently wrong; `3.fmt("%d",:zzz)` now dies with a *positional-arity* error instead of the recorded `X::AdHoc`. Cosmetic drift — note it if you touch the file. Two designs; ADR first. |
+| [export-default-package-not-symbolically-navigable](deep/export-default-package-not-symbolically-navigable.md) | missing feature | L — **confirmed**: `::("Test::EXPORT::DEFAULT::&ok")` fails; raku answers `&ok`. Exported symbols are copied by name and `Module::EXPORT::DEFAULT` is never materialized as a real stash. Calls for a module-system design decision that no ADR covers. |
+| [is-typename-custom-container-store-protocol-unimplemented](deep/is-typename-custom-container-store-protocol-unimplemented.md) | missing feature | XL — **confirmed**: `my @v is DNA = 1,2` never calls `STORE` and the logger never fires. The file rightly asks you to scope it first (grep the corpus for `method STORE`) before committing. |
+| [direct-metamodel-classhow-new-type-immutable-error](deep/direct-metamodel-classhow-new-type-immutable-error.md) | missing feature | M — **narrowed, as the file already says**: the immutable-binding error and `.^add_method` are fixed; what survives is that *calling* a method on a `new_type`-minted Package is a silent no-op (`A.x()` prints nothing; raku `42`). `Metamodel::Naming`/`Stashing` composition is a separate, larger row. |
+| [whenever-expression-position-needs-real-design](deep/whenever-expression-position-needs-real-design.md) | correctness-narrow | M — **moved again**: `.WHAT` answers `Tap`, but the value emitted *before* `.close` is now dropped as well, not just the one after. Reconcile ADR-0053's header with what actually landed before designing the identity slice. |
+| [slurpy-hash-named-arg-raku-boolean-shorthand-missing](deep/slurpy-hash-named-arg-raku-boolean-shorthand-missing.md) | rendering | L — **confirmed**: `foo :a1:b2` renders `{:a1(Bool::True), :b2(Bool::True)}`; raku `{:a1, :b2}`. Moved from `tickets/` to `deep/` deliberately: its own recommendation is "do not fix this in isolation" — it wants per-element `Hash` containers (the associative half of element itemization). |
+| [typed-shaped-array-rows-lose-element-value-type](deep/typed-shaped-array-rows-lose-element-value-type.md) | self-consistency (**no raku oracle**) | M — **confirmed**, including that raku has no oracle: it dies "Partially dimensioned views of shaped arrays not yet implemented" on the first statement. mutsu's own 1D `:exists` is right and its 2D row `:exists` is not. Thread `value_type` through `make_shaped_array_seeded`'s rows. |
+| [begin-time-adverb-value-interpolation](deep/begin-time-adverb-value-interpolation.md) | correctness-narrow | L, **low priority by its own assessment** — confirmed (`$a:foo«$c»` → `Nil`; raku `answer`), but there is no roast coverage and the fix wants a whole-AST name-normalization pass across ~104 scattered `local_map` lookups. |
 
 ---
 
 ## Perf — batch into one profiling session; implementation agent runs SOLO
 
-**Every file in this section now predates the sweep that landed on 2026-09-03/04.**
-Ten PRs (#7259, #7262, #7274-#7280) took `bench-fib` from ~1.25-1.32x raku on
-the morning of 2026-09-03 to **0.84x at `54946f2aa`** (JIT row 0.41x), and none
-of these files was updated. **Re-measure before starting any row below** — for
-several of them the profile they describe no longer exists.
+The September call-path campaign **landed and inverted the picture**:
+`bench-fib` 0.84x → **0.37x** raku (JIT 0.20x), `hash-access` 0.18x,
+`string-concat` 0.10x at `87e910a62`. Four files below were filed *inside* that
+campaign and are its live continuation; the rest predate it in whole or part.
+Numbers marked *debug* have never been confirmed on release.
 
 | Ticket | Status |
 |---|---|
-| [late-august-call-path-slowdown-remainder](perf/late-august-call-path-slowdown-remainder.md) | **The live campaign's ledger, now behind its own campaign.** Re-read it against the bench history before continuing. Its "Do NOT keep bisecting" section is still the most important paragraph in `todo/perf/`: layout noise is ~5%, so any commit a bisect names must be discharged by checking whether its code is even *sampled*. Use the differential profile. |
-| [locals-frame-is-a-pooled-vec-not-a-register-window](perf/locals-frame-is-a-pooled-vec-not-a-register-window.md) | **The named next target** — but its ~5.7% figure was measured *before* the sweep; re-profile first. The fix is the standard register window (one `locals_stack` with a per-frame base). **ADR-class, not a slice**: `self.locals` is touched at 484 sites across 60 files, `mem::take` is load-bearing in three call paths, `VmCallFrame::saved_locals` owns a whole `Vec`, and the JIT emits code against `Interpreter::locals`' offset. Write a `Proposed` ADR before any code. |
-| [interpreter-call-path-in-hot-loops](perf/interpreter-call-path-in-hot-loops.md) | **Symptom real, root-cause section STALE — do not start from its "Where to start".** The `&`-sigil signature gate it blames was measured closed on 2026-09-04 (byte-identical opcode profiles for `sub f(&c)` vs `sub f($c)`). The morning's replacement pointer — 2000 real-`Test` assertions doing 50 060 full by-name resolves, 83.3% of function-call opcodes falling back to the interpreter path — is also **pre-sweep**. Step one is a fresh measurement of `ok`-per-assertion cost under real `Test`; that number decides whether `vendor-real-test-module` is still perf-blocked at all. |
-| [hash-workload-cost-is-spread-across-gc-alloc-and-key-hashing](perf/hash-workload-cost-is-spread-across-gc-alloc-and-key-hashing.md) | A profile *record*, deliberately not a fix: GC ≈14%, allocation ≈12%, NaN-box decode ≈13%, key hashing+comparison ≈10%. Three leads, most tractable first: `Interpreter::current_package()` (an `RwLock` read + `String` clone, 2.2%, 228 call sites, with a `current_package_sym()` already beside it); the user-key `HashMap`'s SipHash (**do not just swap the hasher** — iteration order and collision-DoS both need deciding); and whether a hash element store needs a cycle-collected cell at all (ADR discussion). |
-| [bench-ctor-construction-parity](perf/bench-ctor-construction-parity.md) | Round 5 found the "flat profile" conclusion of rounds 2-4 was wrong — a per-call `.map` compile. Lesson: **`MUTSU_VM_STATS` `add_constant` must stay flat on a steady-state loop**; growth = a runtime compile. Three unmeasured leads inside `dispatch_bless` remain. |
-| [closure-literal-creation-cost](perf/closure-literal-creation-cost.md) | Parts A/C done (−20%/creation, body shared). Part B (O(kept-env) capture) is ADR territory — narrowing the kept set trusts an incomplete static analysis, the `roles-6e.t` flake shape. Cost the "share the system-name portion through the parent chain" alternative first. |
-| [interpreter-new-is-expensive-and-retains-memory](perf/interpreter-new-is-expensive-and-retains-memory.md) | ~9 ms and **~7.2 KiB retained** per `Interpreter::new()`, linear over 4000 constructions. **Debug-build numbers** — re-measure in release before designing. Chase the *retention* first, not the wall clock. Now slightly more relevant: the LSP (ADR-0065 S1-S5a) is a long-lived process that parses repeatedly. |
-| [digest-ripemd-start-per-block-overhead](perf/digest-ripemd-start-per-block-overhead.md) | Title is historical (the `start` lever is closed). `t/ripemd.t` ~148-156s vs a hard 120s gate; profile is flat; needs a fresh dominant item, not a guess. |
-| [yaml-parse-throughput](perf/yaml-parse-throughput.md) | ~5x raku on real files after nine rounds; open items: candidate enumeration, `invoke_grammar_actions` materializations. Carries the three most valuable methodology notes in `todo/` (CPU-spinner check before any A/B; deep-recursion `perf` children percentages are misattributions; compute from the tag probe you already have). |
-| [adr0019-g3-diffuse-bless-allocation-cost](perf/adr0019-g3-diffuse-bless-allocation-cost.md) | Blocked on a working call-graph profiler (`addr2line` stale build-id entries under `/root/.debug`). Pair with the bench-ctor row. |
-| [bigint-repeated-addition-performance-gap](perf/bigint-repeated-addition-performance-gap.md) | ~14x raku — **on a debug build**; re-measure on release before ranking. |
-| [closure-sequence-evolution-performance-gap](perf/closure-sequence-evolution-performance-gap.md) | ~84x raku — **debug numbers**; the combined case (48s) far exceeds the sum of its parts (~7.5s), which is the actionable signal. |
+| [defaulted-param-forfeits-the-light-call-path](perf/defaulted-param-forfeits-the-light-call-path.md) | **NEXT — and the cheapest of the four.** A routine with one defaulted trailing parameter re-resolves **by name on every call**: 1001 `function-full-resolve` over 1000 calls, and 280k of `write-int.t`'s 565k by-name resolves. Two-tier binder fix (exact-arity-with-defaults, then constant-default filling); no ADR. Counters are optimization-independent, so iterate on debug. |
+| [listop-call-bypasses-every-compiled-call-cache](perf/listop-call-bypasses-every-compiled-call-cache.md) | **NEXT.** `ok`/`is`-shaped listop calls (`ExecCallPairs`) reach *none* of `CallFunc`'s three caches. gdb-verified structurally; no timing yet. Add an `ExecCallPairs` `record_dispatch_entry_outcome` counter **before** optimizing, then measure `write-int.t`. Wiring an existing mechanism into a second opcode; no ADR. |
+| [method-dispatch-flattens-the-env-on-every-call](perf/method-dispatch-flattens-the-env-on-every-call.md) | **NEXT.** Every full method dispatch that misses the accessor fast path runs `flatten_scoped_env()`, making method cost linear in names-in-scope *and* destroying the O(writes) return-merge — 17% of what remains in the 20k-assertion `ok` loop. Two suspects already eliminated by measurement. Cheaper sub-fix if the full move looks risky: short-circuit `Env::flattened()` to `parent.flattened()` on an empty overlay. Risk shape is a wrong answer, not a crash — read `docs/vm-dual-store.md`. |
+| [interpreter-call-path-in-hot-loops](perf/interpreter-call-path-in-hot-loops.md) | **Do NOT start from its "Where to start" — the file says so itself.** The `&`-sigil gate it blamed for a year is measured closed (byte-identical opcode profiles). The live finding is new: under `MUTSU_REAL_TEST=1`, **83.3% of function-call opcodes fall back to the interpreter**, dominated by `nqp::`-prefixed calls that never reach a cached dispatch despite being fixed known names. That is the question. Methodology: "raku will delete your benchmark" — an unread accumulator is optimized away and manufactures a 140-370x fake deficit. |
+| [late-august-call-path-slowdown-remainder](perf/late-august-call-path-slowdown-remainder.md) | **ACTIVE — the campaign's central ledger**, items closed inline as they land. Its ADR-0066 item is resolved (Accepted + implemented 2026-09-03). Open item #3: `mutsu_jit_1` got ~50% slower since August with nothing in the interpreter explaining it — dump the generated code for both builds. Its "Do NOT keep bisecting" paragraph is still the most important one in `todo/perf/`. |
+| [locals-frame-is-a-pooled-vec-not-a-register-window](perf/locals-frame-is-a-pooled-vec-not-a-register-window.md) | **BLOCKED on an ADR, and it is the largest single remaining cluster** (~5.7% of `bench-fib` managing a one-element `Vec`). 484 `self.locals` sites across 60 files, `mem::take` load-bearing in three call paths, `VmCallFrame::saved_locals` owning a whole `Vec`, and the JIT emitting against the current offset. Write the `Proposed` ADR (representation, migration order, JIT layout) before any code. |
+| [hash-access-diffuse-regression-2026-09](perf/hash-access-diffuse-regression-2026-09.md) | **ACTIVE.** Ratio crept 0.17 → 0.19 over 2026-08-27..09-06 with no single culprit; three fixes landed (`hash-access` 266.2M → 253.3M instructions, −4.8%) and the rest is still there. Next: symbol-key the remaining ~155k `Symbol::intern` calls. Methodology: **read the ratio column, not `mutsu_median_s`** — a 26% "step" was runner noise that moved raku's baseline identically. |
+| [hash-workload-cost-is-spread-across-gc-alloc-and-key-hashing](perf/hash-workload-cost-is-spread-across-gc-alloc-and-key-hashing.md) | **RECORD**, deliberately not a fix: GC ≈14%, allocation ≈12%, NaN-box decode ≈13%, key hashing+comparison ≈10%. Most tractable lead is `Interpreter::current_package()` (an `RwLock` read + `String` clone, 2.2%, 228 sites, with `current_package_sym()` already beside it) — get a caller breakdown first, most sites are cold. Leads 2 and 3 (SipHash→FxHash; whether a plain-scalar hash element needs a cycle-collected cell) both **need an ADR**, not a drive-by. |
+| [adr0019-g3-diffuse-bless-allocation-cost](perf/adr0019-g3-diffuse-bless-allocation-cost.md) | **ACTIVE, and its tooling blocker is gone** — `alloc_scope!` + `--features alloc-stats` replaced the `perf --call-graph` dead end. Next: `bless`'s O(attrs×args) named-argument scan (11 allocations per `bless`) and a reusable scratch `String` in locals-init. Supersedes most of the bench-ctor row below. |
+| [bench-ctor-construction-parity](perf/bench-ctor-construction-parity.md) | Round 5 disproved rounds 2-4's "flat profile" conclusion by finding a per-call `.map` **compile** (−12.9%). Still-open lead: custom-`new`→`bless` plumbing (~11.6µs vs raku's ~1.4µs). Largely superseded in substance by the row above; keep it for its methodology note. |
+| [yaml-parse-throughput](perf/yaml-parse-throughput.md) | **Round 10 (2026-09-06) closed the gap**: `bench-yaml-parse` 1.14s → 0.138s, now **2.5x faster than rakudo**; a 120-row document is 0.96s vs raku's 0.44s. Remainder is genuinely flat (allocator ~20%, memcpy 6.7%, SipHash on capture maps 8.1%). Carries the "compare against rakudo, not against yourself" lesson. |
+| [closure-literal-creation-cost](perf/closure-literal-creation-cost.md) | Parts A and C done (−20%/creation, body shared). **Part B needs an ADR**: narrowing `capture_closure_env`'s kept set trusts an incomplete static analysis — the `roles-6e.t` flake shape CLAUDE.md warns about. Cost the "share the system-name portion through the parent chain" alternative first. Methodology: `bench-startup.raku` is too short to A/B, consecutive runs of one binary differ ~2x. |
+| [digest-ripemd-start-per-block-overhead](perf/digest-ripemd-start-per-block-overhead.md) | **Re-measure before anything.** 156.6s against a 120s gate, but its round-6 fix (generation-checked dispatch memos) is the same shape as the campaign's multi-resolution cache, which has since landed generally. The recorded number almost certainly moved. Profile is otherwise flat. |
+| [interpreter-new-is-expensive-and-retains-memory](perf/interpreter-new-is-expensive-and-retains-memory.md) | ~9.17ms and **~7.2 KiB retained** per `Interpreter::new()`, linear over 4000 constructions. **Debug numbers.** Nothing is currently blocked (the LSP's S2 avoided needing an `Interpreter`), but the retention is unexplained and nothing read "obviously retains" — chase the *retention*, not the wall clock. |
+| [bigint-repeated-addition-performance-gap](perf/bigint-repeated-addition-performance-gap.md) | ~14x raku — **debug, and never profiled**. Its root cause is an untested hypothesis. Step one is the release profile of `builtins/arith.rs` bignum `+` that the file admits never happened. Orthogonal to the call-path campaign. |
+| [closure-sequence-evolution-performance-gap](perf/closure-sequence-evolution-performance-gap.md) | ~84x raku — **debug**, pure hypothesis. The actionable signal is that the combined case (48s) far exceeds the sum of its parts (~7.5s). Profile `max :by` and `subst`'s regex-assertion closure crossing on release. |
 
 Numbers that end up in a document must come from the **bench CI**
 (`bench-history.tsv` on `bench-data`), never from a profiling session's own
-local runs. The `0.84`/`0.41` figures above are read from that file at
-`54946f2aa`; everything else quoted here is session-local routing evidence.
+local runs. The `0.37`/`0.20`/`0.18`/`0.10` figures above are read from that
+file at `87e910a62`; everything else quoted here is session-local routing
+evidence.
 
 ---
 
@@ -286,46 +342,52 @@ local runs. The `0.84`/`0.41` figures above are read from that file at
 
 | Ticket | Blocked on / why |
 |---|---|
-| [lsp-references-needs-a-side-table-not-ast-spans](deep/lsp-references-needs-a-side-table-not-ast-spans.md) | **Measurement before design.** ADR-0065 D6 assumed spans on AST variants; the parser already knows every byte offset, so a thread-local occurrence table gated on an analysis flag is cheaper and touches neither `Expr`'s size nor the bincode cache. The blocker is **backtracking** — a `Var` parsed in a failed alternative would be a phantom reference. Step one is to build the table behind the flag, run it over `modules/`/`vendor/`/`t/`, and measure the phantom rate; that number decides the design. Also needs an explicit ADR decision that `references` is name-based, not declaration-based. |
-| [immutable-lvalues-that-mutsu-still-lets-you-assign-to](deep/immutable-lvalues-that-mutsu-still-lets-you-assign-to.md) | **A survey, not a unit of work.** Probe harness re-run today: **6 of 7 rows still succeed silently** and `(1..3)[0] = 9` still throws the right class with the wrong rendering (`immutable value (1 2 3)` vs `immutable Range (1..3)`). No row has moved across four ADR closures, which is itself the finding: these rows are not element-container work. Mine it for rows, do not dispatch it whole. |
-| [exception-class-hierarchy-is-mostly-unregistered](deep/exception-class-hierarchy-is-mostly-unregistered.md) | Done except R5 (re-run the real-`Test` sweep), which waits on `vendor-real-test-module`. All 373 rakudo `X::` subtypes match. |
-| [rakuast-remaining](deep/rakuast-remaining.md) | ADR-0033 Phase 3 + an undesigned read-gap list. Zero roast dependents; pick by user impact, not cadence. A RakuAST implementation workflow was added 2026-09-03 — read it first. |
-| [nativecall-cannot-be-vendored](deep/nativecall-cannot-be-vendored.md) | Measurement record with reopen conditions; blocker 3 (parser) is gone, 1/2/4 stand. Keeps `NativeCall` a justified rung-3 provider. |
-| [adr0019-e2-e4-resolver-core](deep/adr0019-e2-e4-resolver-core.md) | E3/E4 closed; E2 is a non-gating counter cleanup. |
+| [module-file-scope-array-and-hash-still-share-the-caller](deep/module-file-scope-array-and-hash-still-share-the-caller.md) | **Probably closeable.** Its ADR-0039 §6 acceptance repro was re-run by hand for this regen and is byte-identical to raku; `da8e94252` (ADR-0055's unvouched-capture cell) appears to have fixed the by-name propagation it names as its blocker. Next step is *verification*, not implementation: re-check `S15-nfg/concat-stable.t` and `integration/advent2014-day05.t`, then move it to `news/` with a pinned regression test. |
+| [call-compiled-closure-lacks-merge-all-and-dual-persistence-store](deep/call-compiled-closure-lacks-merge-all-and-dual-persistence-store.md) | Headline defect fixed (ADR-0055 slice 1b) and re-verified here. What remains is structural — no `merge_all` equivalent in `call_compiled_closure`, and two disjoint per-instance state stores — with no measured wrong answer. Both are ADR-0055 slices 3-5, which *retire* the parameter rather than add a knob. |
+| [exception-class-hierarchy-is-mostly-unregistered](deep/exception-class-hierarchy-is-mostly-unregistered.md) | Title is badly stale: all **373** rakudo `X::` subtypes now match, and the file regenerates its own numbers from a checked-in script. Only R5 (the real-`Test` sweep) is left and it is blocked entirely on `vendor-real-test-module` (ADR-0029 slice 4). Closed-pending-a-dependency. |
+| [lsp-references-needs-a-side-table-not-ast-spans](deep/lsp-references-needs-a-side-table-not-ast-spans.md) | **Measurement before design.** ADR-0065 D6 assumed spans on AST variants; the parser already knows every byte offset, so a thread-local occurrence table gated on an analysis flag is cheaper and touches neither `Expr`'s size nor the bincode cache. The blocker is **backtracking** — a `Var` parsed in a failed alternative is a phantom reference. Build the table behind the flag, run it over `modules/`/`vendor/`/`t/`, measure the phantom rate; that number decides the design. Also needs an explicit ADR decision that `references` is name-based. |
+| [role-body-placeholder-mu-supply](deep/role-body-placeholder-mu-supply.md) | **Its own assessment is "don't"**: corpus hits across `roast/`, `modules/`, `vendor/`, `lib/` are **zero**, and the semantics being matched are garbage (rakudo supplies an uninitialized value whose `.defined` throws). ADR-0048 P5's value half; do it only if the deferred-body plumbing is opened for another reason. |
+| [adr0019-e2-e4-resolver-core](deep/adr0019-e2-e4-resolver-core.md) | E3/E4 closed; E2 is a non-gating counter cleanup. ADR-0019's four completion gates are all closed. |
+| [nativecall-cannot-be-vendored](deep/nativecall-cannot-be-vendored.md) | Measurement record with reopen conditions. Blocker 3 (parser) is gone — re-verified: `is repr<Uninstantiable>` / `is ctype<long>` now parse and run identically to raku. Blockers 1/2/4 (QAST surface, MoarVM dispatch programs, 61 missing `nqp::` ops) stand, so `NativeCall` remains a justified rung-3 provider. |
+| [p5tie-stash-bind-key-protocol](deep/p5tie-stash-bind-key-protocol.md) | A corpus-measured deferral, not a bug: `Stash.BIND-KEY`/`CALLER::.BIND-KEY` are unimplemented and cover ~0.5% of sampled dists (`P5tie`, `annotations`). Rung-2 machinery only; ADR-0013 §7's `ContainerRef` is the proposed surface. |
 
 ---
 
 ## Housekeeping notes
 
-- **Closed since the morning regen** (PR that merged the closure): #7285
-  `user-postcircumfix-index-not-dispatched-for-instances` (Tier S crash; the
-  surviving half was rewritten and moved to `tickets/imported-constant-class-alias-does-not-resolve`),
-  #7286 `multidim-assign-to-an-expression-target-is-dropped` (Tier S), #7290
-  `proxy-assigned-into-an-array-is-not-fetched` (Tier S, now ADR-0040 §9), #7292
-  `multi-param-read-only-closure-capture-snapshots-the-element`, #7293
-  `undefined-typed-scalar-loses-its-constraint-when-aliased`, #7294
-  `producer-seq-index-read-decontainerizes-the-element-cell`. #7291 closed
-  `procasync-stress-segv`'s §8.2 diagnostics slice without closing the file.
-- **`todo/` files whose own root-cause section is wrong or half-stale** —
-  this project's most common failure mode, so treat it as the default
-  assumption: `deep/chained-and-array-element-sigilless-bind-wrongly-readonly`
-  (shape 2 fixed, message changed), `perf/interpreter-call-path-in-hot-loops`
-  (the gate it blames is closed *and* its replacement pointer predates the
-  sweep), `tickets/associative-multidim-lvalue-edge-divergences` row 3
-  (`:delete` now deletes rather than no-ops), and every `perf/` file's numbers.
-  ADR-0041 §6 is the model for how to record this: keep the ADR, add a section
-  saying which premises were measured false and why.
-- **One known duplicate**: the two-hop sigilless bind chain
-  (`my \y := $a; my \x := y; x = 5`) is recorded both in
-  `deep/chained-and-array-element-sigilless-bind-wrongly-readonly` shape 1 and
-  in `tickets/for-loop-sigilless-param-writeback-skips-the-type-check`'s "Also
-  still open" section. Whoever fixes it should close both.
-- **One stale cross-reference**: `tickets/same-named-loop-params-in-one-unit-interfere`
-  points at `tickets/closure-for-loop-param-hijacked-by-same-named-captured-outer.md`,
-  which was closed by `04d72e09f`
-  (`news/2026-09/proxy-at-pos-store-and-shadowed-capture-fixed.md`).
-- **Two ADR headers are behind their code**: ADR-0053 says "implementation not
-  started" while `.WHAT` already answers `Tap`; ADR-0041 is still `Proposed`
-  even though its §6 now records a landed fix and a rejected option.
+- **Closed since the 2026-09-04 regen** — 24 files, all four Tier S rows and
+  every `tickets/` entry: #7296 (`rw-param-does-not-bind-a-proxy-container` +
+  `element-bind-fetches-the-proxy-it-should-install`), #7298, #7299, #7300,
+  #7302 (`method-rooted-subscript-chain-autoviv-is-dropped`), #7303, #7305,
+  #7309, #7310, #7314, #7316, #7317, #7320, #7323, #7324, #7325, #7334, #7336
+  (`procasync-stress-segv`), #7355 (`same-named-loop-params-in-one-unit-interfere`),
+  #7364, #7367, #7380. Details are in `news/2026-09/`.
+- **`todo/` files whose own root-cause or status section is wrong** — this
+  project's most common failure mode, so treat it as the default assumption.
+  This cycle: `deep/dollar-dot-attr-compound-assign-spurious-ro-error` (its
+  2026-09-01 tail is contradicted by today's run, in both directions),
+  `deep/module-file-scope-...` (headline repro now passes),
+  `deep/call-compiled-closure-...` (headline repro now passes),
+  `deep/exception-class-hierarchy-...` (title vs body),
+  `deep/native-method-accepted-named-declarations` (`fmt`'s failure class
+  moved), `deep/whenever-expression-position-...` (symptom moved again),
+  `tickets/rustdoc-doc-link-warnings` (210 → ~248), and
+  `perf/interpreter-call-path-in-hot-loops` (says so itself, in bold).
+  ADR-0041 §6 remains the model for recording this: keep the document, add a
+  section naming which premises were measured false and why.
+- **Three ADR headers are behind their code**: ADR-0053 says "implementation
+  not started" while `.WHAT` already answers `Tap`; ADR-0011 points at
+  `rakuast-remaining` as its live inventory but its own timestamp predates five
+  weeks of landed slices; ADR-0065's header says "S0 and S1 shipped" while its
+  own phasing table marks S5a done.
+- **`docs/doc-diff-backlog.md` is now the main feeder of `todo/tickets/`.** Its
+  2026-09-06 full re-sweep took high-signal findings 296 → **108** while
+  `match` rose 2195 → 2376 (the blocks are being answered, not disappearing).
+  Its two highest-signal files are drained into tickets; the next untriaged are
+  `Type/Any`, `Language/experimental`, `Language/objects`, `Language/traps`.
+  When you close a ticket that came from there, update its **Ticketed** row too
+  — a finding tracked in only one of the two places is the one that gets lost.
+- **No duplicate rows this cycle** — the previous regen's one known duplicate
+  (the two-hop sigilless bind chain) closed with both of its homes.
 - Verification for this regen was run ad hoc from `tmp/` (gitignored); each
   ticket's own repro block regenerates it.


### PR DESCRIPTION
Regenerates `todo/TRIAGE.md`. The previous snapshot (2026-09-04, `cfba3c0d7`) is fully stale: **all four of its Tier S rows and all fifteen of its `todo/tickets/` entries merged** (#7296-#7380), along with nine `deep/` files — twenty-four closures in two days. `todo/` now holds **75 files** (39 `deep/`, 20 `tickets/`, 16 `perf/`) against the previous 71.

## Method

Every one of the 75 files was read and, where it had a runnable repro, re-run against `raku` v2026.07 on a fresh debug build at `884366c95`. **Nineteen of the twenty tickets reproduce as written.** Four claims were re-run by hand rather than taken from the survey, and three of those moved:

- `deep/module-file-scope-array-and-hash-still-share-the-caller` — its ADR-0039 §6 acceptance repro is now **byte-identical to raku**. `da8e94252` (the ADR-0055 unvouched-capture cell) appears to have closed it; moved to Icebox as *verification* work, not implementation work.
- `deep/call-compiled-closure-lacks-merge-all-...` — its `CALLER`/`OUTER` repro also passes now; only structural residue remains.
- `deep/dollar-dot-attr-compound-assign-spurious-ro-error` — **the file's own 2026-09-01 tail is wrong.** `$.x *= 2` throws `X::Assignment::RO` again where raku silently no-ops, while `$.x = 9` still mutates where raku throws. Two divergences in opposite directions.
- The two `.WHICH` tickets — `===` and `set()` membership already agree with raku, so only the `.WHICH` *method string* is wrong. That bounds the blast radius, and is why the pair is recommended as the cheapest coherent win.

## What the new ranking says

- **Tier S is one cluster plus one panic.** Both cross-thread rows are owned by **ADR-0068** (`Proposed`), which already carries a calibrated stress harness (CPU *oversubscription* at 24-way, not concurrency, is the necessary ingredient) and rejects "lock the primitive" on the record with a 149-site re-entrancy census. It is the only ADR owning a Tier S finding, and it is not started. The third row is a debug-build overflow panic in the baggy operators that **silently wraps in release**.
- **The `Test`-provider retirement is one perf slice from done** — `write-int.t` went 48.0s → **29.5s** against a hard 30s gate, and its file names the three perf rows that close it. A PLAN §1 goal item, not polish.
- **The perf picture inverted** (`bench-fib` 0.84x → **0.37x** raku, JIT 0.20x, at `87e910a62`), so every perf row was re-dated against that campaign and the four files filed *inside* it are marked as its live continuation.
- `todo/tickets/` refilled from `docs/doc-diff-backlog.md`'s 2026-09-06 full re-sweep (high-signal 296 → 108), now its main feeder.

Also records **three ADR headers that are behind their code** (0053, 0011, 0065) and the eight files whose own root-cause or status section is contradicted by a current run.

Verified that all 75 files are referenced exactly once and every relative link resolves.

Docs-only, so the five build jobs are skipped by design (`scripts/ci-docs-only.sh`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)