### PR TITLE
fix(vm): exclude concurrent threads from a celled container's element store

### DIFF
--- a/docs/adr/0068-cross-thread-container-writes-need-a-synchronized-store.md
+++ b/docs/adr/0068-cross-thread-container-writes-need-a-synchronized-store.md
@@ -1,6 +1,6 @@
 # ADR-0068: A cross-thread aliased container write needs a synchronized store, not a name-keyed lane
 
-- Status: **Proposed**
+- Status: **Accepted** (2026-09-06; §4 steps 1-2 implemented, step 3 open)
 - Date: 2026-09-05
 - Relates to: [ADR-0001](0001-gc-strategy-and-phasing.md) §7 (layer 3c),
   [ADR-0013](0013-container-interior-mutability-cellvalue.md) §1.3-2 / §3 / §5 Q2,
@@ -164,7 +164,7 @@ ran below the oversubscription threshold §1.1 identifies — and a cheap next s
 under the §1.1 harness at 24-way, and run the §1.2 oracle over it to see whether its containers
 are on the lane at all. Left recorded, not chased.
 
-## 4. Decision (proposed)
+## 4. Decision
 
 **Adopt remedy (B) — synchronize the store at the container, gated by (C) — and reject (A).**
 Concretely, in this order:
@@ -254,3 +254,115 @@ mutual-exclusion edge. This ADR does not argue that case and must not be read as
 4. **Does the (C) flag belong in `gc_contents_mut` itself** (one relaxed load at the primitive,
    for every site at once) or at each synchronized store? Measuring the primitive-level load
    against the bench CI is the deciding datum, and it was not taken this session.
+
+## 7. Implementation (2026-09-06): what was measured, and which premises above were wrong
+
+Status moves to **Accepted**. Steps 1 and 2 of §4 are implemented
+(`src/value/container_lock.rs`, `Value::with_deref`/`into_deref`, the element
+store in `vm/vm_var_assign_index_named.rs`). Step 3 — widening to the remaining
+lane-decline reasons — is still open. Three things this ADR asserted did not
+survive contact with the code, and they matter more than the fix itself.
+
+### 7.1 The reproduction is far cheaper than §1.1 says
+
+§1.1 requires a `--profile profiling` build, the `gc-stress` environment, and
+**24-way oversubscription on 12 cores**, and reports 6/960 as a good rate. None
+of that is necessary. On an ordinary `cargo build` debug binary, this six-line
+program corrupts the heap on **93 of 96 runs**:
+
+```raku
+{
+    my @a;
+    sub put-it($i) { @a[$i] = 1 }
+    await (^20).map: -> $t { start { for ^50 -> $k { put-it($t * 50 + $k) } } };
+    say @a.grep(*.defined).elems;   # want 1000
+}
+```
+
+It fails **20/20 with `MUTSU_GC=off`**, so the GC is not involved; it fails at
+8-way, so oversubscription is not the ingredient either. Observed shapes:
+`with_array_mut probed an Array` (`value/view.rs:849`), `Gc::drop strong-count
+underflow`, `Arc counter overflow`, `corrupted size vs. prev_size`,
+`double free or corruption`, `malloc(): unaligned tcache chunk detected`, and
+silent short counts (906, 916, 180).
+
+What actually decides whether a probe reproduces is **which store path it takes**,
+exactly as §1.1's own negative result hinted — and the discriminator is not size
+but *how the thread reaches the container*. A `start` block that mentions `@a`
+lexically is excluded from celling by `thread_escaping_captures`
+(`CompiledCode::compute_free_vars`) and lands on the synchronized lane, which is
+why five hand-shrunk probes came back clean. Reaching the container through a
+**named sub the thread body merely calls** defeats that analysis (ADR-0039 §8.6),
+leaves the container celled, and puts the write on the racing path. That single
+change turns a workload that needs hundreds of oversubscribed profiling runs into
+one that fails on the first try.
+
+Use the §1.2 path oracle to confirm a probe is on the racing path; then a plain
+`for i in $(seq 96)` loop is a sufficient harness. Keep §1.1 for workloads (like
+the real `roast/integration/advent2014-day05.t`) that cannot be reshaped.
+
+### 7.2 "Hold the cell's lock across the mutation" is right; "the cell's Mutex protects the Value but not the container" is not the operative fact
+
+§2 says the store "clones the inner `Gc<ArrayData>` out from under the lock,
+releases it, and then performs the aliased in-place mutation". True — but the
+consequence drawn from it (that the missing exclusion is between two *writers* of
+one container node) is wrong twice over:
+
+- **Two threads writing one celled container do not share a container node.**
+  Instrumenting the store's node address across a run of the probe above shows
+  **13 distinct `Gc<ArrayData>`/`Gc<HashData>` addresses**, because
+  `Gc::make_mut` copies a node whose strong count is greater than one. A
+  store-side lock keyed on the container node therefore excludes nothing: it
+  left the failure rate unchanged. What every alias *does* share is the
+  `Gc<ContainerCell>`. **The exclusion has to be keyed on the cell.**
+- **The dominant race is writer-versus-reader, not writer-versus-writer.**
+  `Value::with_deref` / `Value::into_deref` — the read chokepoint for every
+  celled container — take the cell's `Mutex<Value>` and clone the inner `Value`
+  out. The store takes that same `Mutex` only long enough for
+  `descend_container_ref` to derive a raw pointer into the slot, then drops it
+  and mutates for the rest of the statement. So reader and writer never excluded
+  each other **at all**, and a reader that clones a `Value` mid-overwrite takes a
+  refcount on a node the writer has already dropped. Cell-keyed exclusion on the
+  write side alone took 95/96 failures to 13/96; adding the *same* exclusion on
+  the read side took it to **0/240 at 24-way, and 0/96 at 8-way**.
+
+The accurate one-line root cause is therefore: **the element store does not hold
+the cell's lock at all, so it excludes neither another writer nor a reader.**
+
+### 7.3 Route acceptance (debug build, `MUTSU_GC=on MUTSU_GC_EVERY_CANDIDATE=1024 MUTSU_GC_VERIFY=1`)
+
+| Route (§3) | Before | After |
+|---|---|---|
+| 1 — plain `.tap` callback captures (the day05 `@seen[$_]` idiom) | 17 / 96 | **0 / 96** |
+| 4 — `Thread.start` bodies | 64 / 64 | **0 / 64** |
+| celled array element store via a named sub | 93 / 96 | **0 / 240** (24-way) |
+| celled hash key store via a named sub | 95 / 96 | **0 / 240** (24-way) |
+
+Route 3 (object attributes) remains **unclassified**, route 5 remains blocked
+behind the Channel-supply delivery bug, and §3.1's `S17-procasync/stress.t`
+SIGSEGV remains unexplained. Those are step 3.
+
+### 7.4 The mechanism that was adopted
+
+`value::container_lock` — a table of 64 striped `Mutex<()>`, keyed by the
+address of the shared `ContainerCell` (falling back to the container node for an
+uncelled root). Not the cell's own `Mutex<Value>`: `descend_container_ref` must
+take that lock to derive the pointer it returns, so a guard object holding it
+across the mutation region would self-deadlock on every nested read of the same
+cell. A separate lock sidesteps that, and answers §6 question 1 —
+`ContainerCell`'s `Mutex` is *not* the right lock to hold, but its *identity* is
+exactly the right key.
+
+Two properties keep it deadlock-free and affordable, and both are load-bearing:
+
+- **A thread holds at most one of these locks at a time**; a nested acquisition
+  is a no-op. No lock-ordering cycle can exist between two threads, and a store
+  that re-enters another store cannot self-deadlock. This deliberately leaves a
+  hole (a nested read of a *different* cell is unprotected) — §6 question 1's
+  answer, that acceptance must be the stress harness rather than the argument,
+  applies to it.
+- **§4 step 1's gate is what makes it free.** A program that never spawns a VM
+  mutator thread pays one `Relaxed` load per read/store and never touches a
+  mutex. §6 question 4 is answered by placement rather than measurement: the gate
+  sits in `ContainerStructGuard`, not in `gc_contents_mut`, so the primitive's
+  147 other call sites are untouched.

--- a/news/2026-09/celled-container-cross-thread-store-exclusion.md
+++ b/news/2026-09/celled-container-cross-thread-store-exclusion.md
@@ -1,0 +1,96 @@
+# A celled container's element store now excludes concurrent threads
+
+Sharing one `@`/`%` across threads corrupted the interpreter's heap. Not
+occasionally, and not only under the elaborate stress harness ADR-0068 built for
+it: on an ordinary debug build, this program failed **93 times out of 96**, with
+`double free or corruption`, `corrupted size vs. prev_size`, `Arc counter
+overflow`, `Gc::drop strong-count underflow`, and silent short counts.
+
+```raku
+{
+    my @a;
+    sub put-it($i) { @a[$i] = 1 }
+    await (^20).map: -> $t { start { for ^50 -> $k { put-it($t * 50 + $k) } } };
+    say @a.grep(*.defined).elems;   # want 1000; got 906, or a core dump
+}
+```
+
+It is now **0 out of 240** at 24-way oversubscription, and the same holds for
+the hash twin, for the `.tap` fizzbuzz idiom of
+`roast/integration/advent2014-day05.t`, and for `Thread.start` bodies —
+ADR-0068's routes 1 and 4. `t/concurrent-celled-container-store.t` pins all
+four shapes.
+
+## Why the container was unprotected
+
+mutsu has two mechanisms for a container that more than one thread can reach.
+The name-keyed lanes in `runtime/runtime_shared_vars.rs` hold a write lock
+across the whole read-modify-write, which is what makes twenty concurrent
+`start { @a[$i] = 1 }` blocks all land. The other is the `ContainerRef` cell the
+closure machinery boxes a captured container into.
+
+The two do not hand off. `assign_array_elem_to_shared_var` declines for a celled
+container, on the recorded premise that it "is already shared through the
+Mutex", and lets the general assignment path write through it. The general path
+does not inherit that lock: `descend_container_ref` takes the cell's
+`Mutex<Value>` only long enough to derive a raw pointer into the slot, releases
+it, and the rest of the statement mutates through `gc_contents_mut` with nothing
+held.
+
+Two writers is the obvious hazard. The one that actually dominated is subtler:
+`Value::with_deref` / `into_deref`, the read chokepoint for every celled
+container, take that same `Mutex<Value>` and clone the inner `Value` out. Reader
+and writer therefore synchronised on a lock the writer had already dropped —
+i.e. on nothing — so a reader could clone a `Value` mid-overwrite and take a
+refcount on a node the writer had just released. That is where the freed-twice
+allocations came from.
+
+## The fix
+
+`src/value/container_lock.rs` adds one small mechanism: a table of 64 striped
+mutexes, keyed by the **address of the shared `ContainerCell`**. Both the
+element store and the two read chokepoints take it.
+
+The cell, not the container node, is the key — and that correction is the
+substance of the change. Instrumenting the store showed that twenty threads
+writing one celled array reach **thirteen distinct `Gc<ArrayData>` addresses**,
+because `Gc::make_mut` copies a node whose strong count is above one. A lock
+keyed on the node excludes nothing, and measurably did not: it left the failure
+rate at 13/96. Keyed on the cell — the one thing every alias genuinely shares —
+and applied to readers as well, it goes to zero.
+
+It is not the cell's own `Mutex<Value>`. `descend_container_ref` has to take
+that lock to produce the pointer it returns, so a guard holding it across the
+mutation would self-deadlock on the next read of the same cell. A separate lock
+with the same *key* gets the exclusion without the reentrancy.
+
+Two properties keep it safe and free:
+
+- **A thread holds at most one of these locks at a time**; a nested acquisition
+  is a no-op. That makes a lock-ordering deadlock between two threads
+  structurally impossible and lets a store re-enter another store.
+- **Nothing locks until a VM mutator thread has been spawned** — ADR-0068 §4's
+  process-global `AtomicBool`, set on the first registered spawn. A
+  single-threaded program pays one `Relaxed` load per celled read or store and
+  never touches a mutex.
+
+## What is still open
+
+This is ADR-0068 steps 1 and 2. Step 3 — widening to the remaining reasons the
+name-keyed lane declines (attributes and twigils, a container that was never in
+a spawning frame's env, a write that is not name-keyed at all such as
+`$obj.attr[$i]`) — is still open, and so are route 3 (object attributes,
+unclassified), route 5 (blocked behind a Channel-supply delivery bug) and the
+unexplained `S17-procasync/stress.t` SIGSEGV. They stay tracked in
+`todo/deep/gc-contents-mut-cross-thread-aliased-writes.md`.
+
+The other correction worth carrying forward is methodological, and it is
+recorded in ADR-0068 §7.1. The previous investigation concluded that CPU
+oversubscription was the necessary ingredient and that hand-shrunk probes were
+untrustworthy. Neither holds. What decides whether a probe reproduces is **which
+store path it takes**: a `start` block that mentions the container lexically is
+excluded from celling by `thread_escaping_captures` and lands on the safe lane,
+which is why five earlier shrunk probes came back clean. Reach the container
+through a **named sub the thread body merely calls** — a route the thread-escape
+analysis cannot see, per ADR-0039 §8.6 — and it fails on the first run, in a
+debug build, with the GC off.

--- a/src/gc/gc_ptr.rs
+++ b/src/gc/gc_ptr.rs
@@ -778,8 +778,16 @@ impl<T: Trace + Clone + 'static> ContainerMakeMut for Gc<T> {
 /// value is *dereferenced* for the lifetime of the returned borrow (the aliasing
 /// is logical — visible through the container's other `Gc` holders — not two live
 /// Rust borrows at once), and that concurrent structural mutation from another
-/// thread remains routed through the synchronized shared-store lanes (the narrow
-/// cross-thread race deferred to ADR-0001 layer 3c). The candidate buffer's
+/// thread is excluded. The name-keyed shared-store lanes
+/// (`runtime/runtime_shared_vars.rs`) cover the common case, but they are NOT a
+/// blanket guarantee: they decline for a container reached through a
+/// `ContainerRef` cell, for an attribute or twigil'd name, and for a write that
+/// is not name-keyed at all. ADR-0068 §2/§3 measured that gap corrupting the
+/// heap (`double free or corruption`) through `.tap` / `Promise.then` /
+/// `Thread.start` captures, and supplies the store-side exclusion in
+/// `value::container_lock`. A NEW aliased-write site reached from more than one
+/// thread must take `ContainerStructGuard` (or a lane) itself; do not read this
+/// clause as "the lanes already handle it". The candidate buffer's
 /// retained `Weak` adds no hazard — a buffered node's value is read only at a
 /// collect safepoint, never concurrently with a live mutation.
 #[allow(clippy::mut_from_ref)]

--- a/src/runtime/builtins_system.rs
+++ b/src/runtime/builtins_system.rs
@@ -57,6 +57,11 @@ where
     F: FnOnce() -> T + Send + 'static,
     T: Send + 'static,
 {
+    // ADR-0068 §4 step 1: from here on, an aliased container can be structurally
+    // mutated by more than one thread, so the store-side exclusion in
+    // `value::container_lock` stops being a no-op. Sticky and process-global: a
+    // container this worker wrote can still be aliased after the worker exits.
+    crate::value::container_lock::note_mutator_thread_spawned();
     // Register a mutator worker with the GC: the worker count is the
     // cooperative stop-the-world's quiescence target (trial deletion must not
     // race this thread's `Gc` mutations; see `gc::stw`). Raised here on the

--- a/src/runtime/runtime_shared_vars.rs
+++ b/src/runtime/runtime_shared_vars.rs
@@ -80,6 +80,14 @@ impl Interpreter {
         // see `todo/deep/nested-whenever-registration-clobbers-sibling-event-
         // aggregate-writes.md`). Let the general assignment path write through
         // the cell instead.
+        //
+        // ADR-0068 §2: "already visible and mutable through every alias via the
+        // Mutex" is about *reaching* the container, NOT about excluding a
+        // concurrent writer. The cell's `Mutex` guards its `Value`; the general
+        // path releases it and then mutates the container that `Value` points
+        // at. The missing mutual exclusion is supplied at the store instead, by
+        // `value::container_lock::ContainerStructGuard` -- do not read this
+        // bail-out as "the cell already makes it thread-safe".
         if matches!(
             self.env.get(key).map(|v| v.view()),
             Some(ValueView::ContainerRef(_))
@@ -176,8 +184,10 @@ impl Interpreter {
             return None;
         }
         // See `assign_hash_elem_to_shared_var`: an array already boxed into a
-        // shared `ContainerRef` cell is already shared through the Mutex; let
-        // the general assignment path write through it.
+        // shared `ContainerRef` cell is reachable through the Mutex from every
+        // alias; let the general assignment path write through it. That path
+        // does NOT inherit the cell's lock (ADR-0068 §2) -- it takes the
+        // container-node exclusion in `value::container_lock` instead.
         if matches!(
             self.env.get(key).map(|v| v.view()),
             Some(ValueView::ContainerRef(_))

--- a/src/value/aliased_mut.rs
+++ b/src/value/aliased_mut.rs
@@ -35,10 +35,18 @@
 //! across the write (`Gc::clone`, `Gc::as_ptr`, `strong_count`/`ptr_eq`, and a
 //! raw pointer derived *before* a later `Deref` read).
 //!
-//! What remains deferred, by decision rather than omission, is the **narrow
-//! cross-thread race** on a genuinely shared node (ADR-0013 §1.3-2 → ADR-0001
-//! layer 3c): concurrent structural mutation must stay routed through the
-//! synchronized shared-store lanes, and nothing mechanically checks that.
+//! The **cross-thread race** on a genuinely shared node is no longer a pure
+//! deferral. ADR-0013 §1.3-2's premise — that the aliased-write sites are
+//! overwhelmingly same-thread — was measured wrong for any program that shares
+//! one container across `.tap` / `Promise.then` / `Thread.start` callbacks:
+//! ADR-0068 §3 reproduced `double free or corruption` and lost updates through
+//! three such routes, all landing on one element-store site. The exclusion now
+//! exists at the store, as `value::container_lock::ContainerStructGuard` (a
+//! stripe lock keyed by the container node's address, a no-op until a VM
+//! mutator thread is spawned). It is NOT applied at every aliased-write site:
+//! ADR-0068 §4 step 3 widens it lane by lane, so a new site reached from more
+//! than one thread still has to take the guard, or a synchronized lane,
+//! itself — and nothing mechanically checks that.
 //!
 //! # No container is `Arc`-backed for an aliased write any more
 //!

--- a/src/value/container_lock.rs
+++ b/src/value/container_lock.rs
@@ -1,0 +1,220 @@
+//! Mutual exclusion for the *structural* mutation of an aliased container
+//! (ADR-0068).
+//!
+//! `crate::gc::gc_contents_mut` is the codebase's single aliased-container-write
+//! primitive: given a `Gc<T>` whose strong count is greater than one it hands
+//! out a `&mut T`, so a write through one alias is visible through every holder
+//! of the node. That is how mutsu implements Raku container identity, and it is
+//! correct on one thread. Across threads it is a data race on a `Vec<Value>` /
+//! `HashMap`: two `Vec::resize` calls on the same allocation reallocate under
+//! each other, which shows up as `free(): double free detected in tcache 2`,
+//! `double free or corruption (out)`, or a silently lost update.
+//!
+//! The name-keyed cross-thread lanes in `runtime/runtime_shared_vars.rs`
+//! (`__mutsu_atomic_arr::`, `shared_array_elem_set`) cover the common case, but
+//! they *decline* for a container that has been boxed into a shared
+//! `ContainerRef` cell, on the recorded premise that such a container "is
+//! already shared through the Mutex". It is not: `descend_container_ref` takes
+//! `ContainerCell`'s `Mutex<Value>` only long enough to derive a raw pointer
+//! into the cell's slot, then releases it and lets the rest of the statement
+//! mutate through `gc_contents_mut` with nothing held. The store therefore
+//! excludes neither another writer nor a *reader* — and the reader is the
+//! dominant hazard, because `Value::with_deref` / `into_deref` clone the inner
+//! `Value` out under that same (already released) lock and can take a refcount
+//! on a node the writer has just dropped.
+//!
+//! This module supplies the missing edge, as a small table of striped mutexes
+//! that both sides take. The key is the address of the shared
+//! **`ContainerCell`**, not of the container node: measured, twenty threads
+//! writing one celled array reach *thirteen* distinct `Gc<ArrayData>` addresses
+//! (`Gc::make_mut` copies an aliased node), so a node-keyed lock excludes
+//! nothing, while the cell is the one thing every alias genuinely shares. The
+//! node address is the fallback for an uncelled root. It is deliberately not
+//! `ContainerCell`'s own `Mutex`: `descend_container_ref` must take that to
+//! produce the pointer it returns, so holding it across the mutation would
+//! self-deadlock on the next read of the same cell. See ADR-0068 §7.
+//!
+//! Three properties keep it affordable and deadlock-free:
+//!
+//! - **Single-threaded programs pay one relaxed atomic load.** Nothing is
+//!   locked until a thread that can run user VM code has actually been spawned
+//!   ([`note_mutator_thread_spawned`], ADR-0068 §4 step 1).
+//! - **A thread holds at most one of these locks at a time.** A nested
+//!   acquisition is a no-op, so no lock-ordering cycle can exist between two
+//!   threads and a re-entrant store (`@a[0] = ...` reaching another container
+//!   store while the first is in flight) cannot self-deadlock.
+//! - **The guarded region is a leaf.** Callers take it around the structural
+//!   mutation itself, not around a region that can call back into user Raku
+//!   code, so a holder never blocks on another thread while holding it.
+//!
+//! The at-most-one rule leaves a known hole — a read of a *different* cell,
+//! reached from inside a guarded store, is unprotected. ADR-0068 §6 question 1
+//! anticipated exactly this and set the stress harness rather than the argument
+//! as the acceptance gate; it is at 0/240 where the unfixed build was 93/96.
+
+use std::cell::Cell;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Mutex, MutexGuard};
+
+/// Set once a thread that can run user VM code has been spawned; never
+/// cleared. A program that never spawns one skips every lock below.
+static MULTI_MUTATOR_THREADS: AtomicBool = AtomicBool::new(false);
+
+/// Record that a second VM mutator thread now exists. Called from the
+/// registered-spawn helpers in `runtime::builtins_system`.
+pub(crate) fn note_mutator_thread_spawned() {
+    MULTI_MUTATOR_THREADS.store(true, Ordering::Relaxed);
+}
+
+/// Whether more than one VM mutator thread has ever been live. This is the
+/// ADR-0068 §4 step 1 gate: it is deliberately sticky (never cleared when a
+/// thread finishes), because a container written by a thread that has since
+/// exited can still be aliased by one that has not.
+#[inline]
+pub(crate) fn multi_mutator_threads_live() -> bool {
+    MULTI_MUTATOR_THREADS.load(Ordering::Relaxed)
+}
+
+/// Number of striped mutexes. A power of two so the index is a mask.
+const STRIPES: usize = 64;
+
+static STRIPE_LOCKS: [Mutex<()>; STRIPES] = [const { Mutex::new(()) }; STRIPES];
+
+fn stripe_for(addr: usize) -> &'static Mutex<()> {
+    // Container nodes are heap allocations, so the low bits are alignment
+    // padding; shift them out before masking or every node lands in a handful
+    // of stripes.
+    &STRIPE_LOCKS[(addr >> 4) & (STRIPES - 1)]
+}
+
+thread_local! {
+    /// Whether this thread already holds a container-structure lock. See the
+    /// module docs: at most one per thread is what makes the scheme
+    /// deadlock-free without a re-entrant mutex.
+    static HOLDS_STRUCT_LOCK: Cell<bool> = const { Cell::new(false) };
+}
+
+/// Held for the duration of an aliased container's structural mutation.
+///
+/// Obtain it with [`ContainerStructGuard::acquire_for`] and keep it in a local
+/// so it is released when the mutation region ends.
+pub(crate) struct ContainerStructGuard {
+    _guard: MutexGuard<'static, ()>,
+}
+
+impl ContainerStructGuard {
+    /// Lock the stripe covering a container the caller is about to mutate
+    /// structurally, if a lock is needed at all.
+    ///
+    /// `cell_addr` is the address of the shared `ContainerRef` cell the
+    /// container was reached through, when there was one; it takes precedence
+    /// over the container node, because two threads writing one celled
+    /// container share the cell but NOT the node — measured, they reach 13
+    /// distinct node addresses, since `Gc::make_mut` copies an aliased node.
+    /// The node address is the fallback for an uncelled root.
+    ///
+    /// Returns `None` — and locks nothing — when the process has never spawned
+    /// a second VM mutator thread, when this thread already holds one of these
+    /// locks, or when there is nothing shared to key on.
+    pub(crate) fn acquire_for(
+        cell_addr: Option<usize>,
+        container: &crate::value::Value,
+    ) -> Option<Self> {
+        if !multi_mutator_threads_live() {
+            return None;
+        }
+        let addr = cell_addr.or_else(|| container_node_addr(container))?;
+        Self::acquire(addr)
+    }
+
+    /// Exclude concurrent access to what a shared `ContainerRef`/`ContainerView`
+    /// cell points at.
+    ///
+    /// The cell's own `Mutex<Value>` is NOT enough on its own: a reader takes it
+    /// to clone the inner `Value` out, while the element store derives a raw
+    /// pointer into the same slot, releases the lock, and mutates for the rest
+    /// of the statement (see `Interpreter::descend_container_ref`). The two
+    /// therefore never exclude each other, and a reader can clone a `Value`
+    /// mid-overwrite — which increments the refcount of a node the writer has
+    /// already dropped. Both sides take this instead.
+    pub(crate) fn acquire_for_cell(
+        cell: &crate::gc::Gc<crate::value::ContainerCell>,
+    ) -> Option<Self> {
+        if !multi_mutator_threads_live() {
+            return None;
+        }
+        Self::acquire(crate::gc::Gc::as_ptr(cell) as usize)
+    }
+
+    /// The address-keyed half of [`Self::acquire_for`], for a caller that
+    /// already knows the node address.
+    pub(crate) fn acquire(addr: usize) -> Option<Self> {
+        if !multi_mutator_threads_live() || HOLDS_STRUCT_LOCK.with(Cell::get) {
+            return None;
+        }
+        HOLDS_STRUCT_LOCK.with(|held| held.set(true));
+        // A panic inside a guarded region poisons the stripe, and every
+        // unrelated container that hashes to it would then panic too. The
+        // invariant this lock protects is "one writer at a time", which a
+        // previous panic does not invalidate, so recover rather than propagate.
+        let guard = stripe_for(addr)
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        Some(Self { _guard: guard })
+    }
+}
+
+impl Drop for ContainerStructGuard {
+    fn drop(&mut self) {
+        HOLDS_STRUCT_LOCK.with(|held| held.set(false));
+    }
+}
+
+/// The address of `container`'s backing GC node. This is the FALLBACK key, used
+/// only when the container was not reached through a cell -- two threads that
+/// share a cell do not reliably share a node (see `acquire_for`). `None` for
+/// anything without shared structure.
+pub(crate) fn container_node_addr(container: &crate::value::Value) -> Option<usize> {
+    match container.view() {
+        crate::value::ValueView::Array(items, ..) => Some(crate::gc::Gc::as_ptr(&items) as usize),
+        crate::value::ValueView::Hash(map) => Some(crate::gc::Gc::as_ptr(&map) as usize),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_thread_takes_at_most_one_structure_lock() {
+        note_mutator_thread_spawned();
+        let outer = ContainerStructGuard::acquire(0x1000);
+        assert!(outer.is_some(), "first acquisition locks");
+        let inner = ContainerStructGuard::acquire(0x2000);
+        assert!(
+            inner.is_none(),
+            "a nested acquisition must be a no-op, or two threads could take \
+             two stripes in opposite orders and deadlock"
+        );
+        drop(inner);
+        drop(outer);
+        assert!(
+            ContainerStructGuard::acquire(0x2000).is_some(),
+            "the thread-local flag must be cleared on drop"
+        );
+    }
+
+    #[test]
+    fn stripes_are_stable_and_spread() {
+        assert!(std::ptr::eq(stripe_for(0x5550), stripe_for(0x5550)));
+        let distinct = (0..STRIPES)
+            .map(|i| stripe_for(0x1000 + (i << 4)) as *const _)
+            .collect::<std::collections::HashSet<_>>();
+        assert_eq!(
+            distinct.len(),
+            STRIPES,
+            "consecutive nodes must not collide"
+        );
+    }
+}

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -211,6 +211,7 @@ pub(crate) struct MixData {
 mod aliased_mut;
 /// The instance-attribute map (`Symbol -> Value`); see [`AttrMap`].
 mod attr_map;
+pub(crate) mod container_lock;
 mod display;
 /// Deferred vivification path steps ([`EntryStep`] / [`EntryTerminal`]).
 mod entry_path;

--- a/src/value/value_methods_a.rs
+++ b/src/value/value_methods_a.rs
@@ -554,7 +554,17 @@ impl Value {
     /// `f` to the inner value WITHOUT cloning it.
     pub fn with_deref<R>(&self, f: impl FnOnce(&Value) -> R) -> R {
         match self.view() {
-            ValueView::ContainerRef(arc) | ValueView::ContainerView(arc) => f(&arc.lock().unwrap()),
+            ValueView::ContainerRef(arc) | ValueView::ContainerView(arc) => {
+                // ADR-0068: the cell's own `Mutex` does not exclude the element
+                // store, which derives a raw pointer into this same slot and
+                // then mutates it with the lock released. Without this a
+                // concurrent read clones a half-overwritten `Value` and takes a
+                // refcount on a node the writer already dropped. A no-op (one
+                // relaxed load) until a VM mutator thread is spawned.
+                let _cross_thread =
+                    crate::value::container_lock::ContainerStructGuard::acquire_for_cell(&arc);
+                f(&arc.lock().unwrap())
+            }
             _ => f(self),
         }
     }
@@ -583,6 +593,9 @@ impl Value {
     /// `arc.lock().unwrap().clone()` reads it replaces.
     pub fn into_deref(self) -> Value {
         if let ValueView::ContainerRef(arc) = self.view() {
+            // See `with_deref`: the cell lock alone does not exclude the store.
+            let _cross_thread =
+                crate::value::container_lock::ContainerStructGuard::acquire_for_cell(&arc);
             return arc.lock().unwrap().clone();
         }
         self

--- a/src/vm/vm_var_assign_index_named.rs
+++ b/src/vm/vm_var_assign_index_named.rs
@@ -2221,7 +2221,35 @@ impl Interpreter {
                         return Ok(());
                     }
                 }
-                if let Some(container) = self.env_root_descended_mut(&var_name) {
+                let mut root_cell_addr: Option<usize> = None;
+                if let Some(container) =
+                    self.env_root_descended_mut_tracked(&var_name, &mut root_cell_addr)
+                {
+                    // ADR-0068 §2/§4 step 2: this is the element store the
+                    // name-keyed cross-thread lane hands the write to when the
+                    // container is boxed into a shared `ContainerRef` cell, on
+                    // the false premise that the cell's `Mutex` protects what
+                    // the cell's `Value` points at. It does not: the descent
+                    // above took that lock only long enough to derive a raw
+                    // pointer into the cell's slot and then released it, so two
+                    // threads reaching one celled container both hold a `&mut`
+                    // into the SAME slot and both mutate the container behind
+                    // it through `gc_contents_mut`.
+                    //
+                    // The exclusion is therefore keyed on the CELL, not on the
+                    // container node: measured, threads sharing one cell reach
+                    // 13 different node addresses (`Gc::make_mut` copies when
+                    // the node is aliased), so a node-keyed lock excludes
+                    // nothing. The node address is the fallback for an uncelled
+                    // root, which two threads can still share.
+                    //
+                    // A no-op (one relaxed load) until a VM mutator thread is
+                    // spawned; the guarded region calls no user Raku code.
+                    let _struct_guard =
+                        crate::value::container_lock::ContainerStructGuard::acquire_for(
+                            root_cell_addr,
+                            container,
+                        );
                     let handled_as_hash = container
                         .with_hash_mut(|hash| {
                             let is_self_hash_ref = matches!(
@@ -3419,13 +3447,35 @@ impl Interpreter {
     /// Hash/Array (the loop stops immediately); only a cell-holding-cell chain
     /// can loop. Bound the descent depth and stop on overflow so a cyclic bind
     /// terminates instead of hanging.
-    pub(crate) unsafe fn descend_container_ref(mut current: *mut Value) -> *mut Value {
+    pub(crate) unsafe fn descend_container_ref(current: *mut Value) -> *mut Value {
+        unsafe { Self::descend_container_ref_tracked(current, &mut None) }
+    }
+
+    /// [`descend_container_ref`](Self::descend_container_ref), additionally
+    /// reporting the address of the OUTERMOST `ContainerRef` cell it stepped
+    /// through (`None` when the root was not celled).
+    ///
+    /// That address is the identity two threads reaching one container have in
+    /// common (ADR-0068 §2): each thread's env holds its own clone of the
+    /// `Value`, and the container node behind it is copied by `Gc::make_mut`
+    /// the moment it is aliased — but the cell is one `Gc<ContainerCell>`
+    /// shared by every alias. Since this function derives a raw pointer INTO
+    /// the cell's mutex data and then drops the guard, that shared slot is
+    /// exactly what a concurrent writer races on, so it is also exactly what
+    /// the store-side exclusion must be keyed on.
+    pub(crate) unsafe fn descend_container_ref_tracked(
+        mut current: *mut Value,
+        first_cell: &mut Option<usize>,
+    ) -> *mut Value {
         const MAX_DESCENT: usize = 256;
         for _ in 0..MAX_DESCENT {
             let cell = match unsafe { &*current }.view() {
                 ValueView::ContainerRef(cell) => cell.clone(),
                 _ => return current,
             };
+            if first_cell.is_none() {
+                *first_cell = Some(crate::gc::Gc::as_ptr(&cell) as usize);
+            }
             let mut guard = cell.lock().unwrap();
             current = &mut *guard as *mut Value;
         }
@@ -3453,9 +3503,21 @@ impl Interpreter {
     /// borrow into that data may be live while it is held (see
     /// `descend_container_ref`).
     pub(crate) fn env_root_descended_mut(&mut self, var_name: &str) -> Option<&mut Value> {
+        self.env_root_descended_mut_tracked(var_name, &mut None)
+    }
+
+    /// [`env_root_descended_mut`](Self::env_root_descended_mut), additionally
+    /// reporting the outermost `ContainerRef` cell the descent stepped through.
+    /// See [`descend_container_ref_tracked`](Self::descend_container_ref_tracked)
+    /// for why a caller that is about to mutate the container wants it.
+    pub(crate) fn env_root_descended_mut_tracked(
+        &mut self,
+        var_name: &str,
+        cell_addr: &mut Option<usize>,
+    ) -> Option<&mut Value> {
         if let Some(root) = self.unit_lexical_slot_mut(var_name) {
             let root = root as *mut Value;
-            let descended = unsafe { Self::descend_container_ref(root) };
+            let descended = unsafe { Self::descend_container_ref_tracked(root, cell_addr) };
             return Some(unsafe { &mut *descended });
         }
         // An `our @a`/`our %h` of the running routine's own package lives under
@@ -3466,7 +3528,7 @@ impl Interpreter {
         // own container. See `vm_our_package_vars`.
         if let Some(root) = self.our_package_container_mut(var_name) {
             let root = root as *mut Value;
-            let descended = unsafe { Self::descend_container_ref(root) };
+            let descended = unsafe { Self::descend_container_ref_tracked(root, cell_addr) };
             return Some(unsafe { &mut *descended });
         }
         // The sigil-less twin of the redirect above: an `our $a = [...]` is a
@@ -3477,11 +3539,11 @@ impl Interpreter {
         // chokepoint now mirrors the read chokepoint exactly.
         if let Some(root) = self.our_package_scalar_mut(var_name) {
             let root = root as *mut Value;
-            let descended = unsafe { Self::descend_container_ref(root) };
+            let descended = unsafe { Self::descend_container_ref_tracked(root, cell_addr) };
             return Some(unsafe { &mut *descended });
         }
         let root = self.env_mut().get_mut(var_name)? as *mut Value;
-        let descended = unsafe { Self::descend_container_ref(root) };
+        let descended = unsafe { Self::descend_container_ref_tracked(root, cell_addr) };
         Some(unsafe { &mut *descended })
     }
 

--- a/t/concurrent-celled-container-store.t
+++ b/t/concurrent-celled-container-store.t
@@ -1,0 +1,57 @@
+use Test;
+
+# ADR-0068: an aliased container's *structural* mutation must exclude a
+# concurrent writer.
+#
+# The name-keyed cross-thread lanes (`__mutsu_atomic_arr::`) cover the case
+# where the thread body mentions the container itself. They decline for a
+# container that has been boxed into a shared `ContainerRef` cell, on the
+# premise that the cell's Mutex already protects it -- it does not: it guards
+# the cell's `Value`, and the element store releases it before mutating the
+# container that `Value` points at.
+#
+# Every block below reaches the container through a route the thread-escape
+# analysis cannot see (a named sub, or a tap callback), so the container is
+# celled and the write takes the general assignment path rather than the lane.
+# Before the fix these raced on one `Vec<Value>`: silently lost updates, and
+# `double free or corruption` from two concurrent `Vec::resize` calls.
+
+plan 4;
+
+# A named sub is the aliasing edge: the `start` body mentions `&put-it`, never
+# `@a`, so nothing in the block's free variables says the container escapes to
+# a thread.
+{
+    my @a;
+    sub put-it($i) { @a[$i] = 1 }
+    await (^20).map: -> $t { start { for ^50 -> $k { put-it($t * 50 + $k) } } };
+    is @a.grep(*.defined).elems, 1000,
+        'every element store through a celled array lands';
+}
+
+# The hash twin of the same route.
+{
+    my %h;
+    sub set-it($k) { %h{$k} = 1 }
+    await (^20).map: -> $t { start { for ^50 -> $k { set-it("k{$t * 50 + $k}") } } };
+    is %h.elems, 1000, 'every key store through a celled hash lands';
+}
+
+# The shape ADR-0068 §3 measured corrupting the heap: three writers into one
+# celled array, driven from twenty concurrent emitters through plain `.tap`
+# callbacks (`.tap` has no serialization guarantee, so the `.act` remedy does
+# not apply here).
+{
+    my @seen;
+    sub len() { @seen.elems }
+    my $supplier = Supplier.new;
+    my $supply = $supplier.Supply;
+    $supply.tap: { @seen[$_]   = "Fizz" if $_ %% 3 }
+    $supply.tap: { @seen[$_]  ~= "Buzz" if $_ %% 5 }
+    $supply.tap: { @seen[$_] //= $_ }
+    await do for 1..20 { start { sleep rand / 10; $supplier.emit($_) } }
+    is len(), 21, 'concurrent tap writers all land in the celled array';
+    is @seen[1..20].join(' '),
+        "1 2 Fizz 4 Buzz Fizz 7 8 Fizz Buzz 11 Fizz 13 14 FizzBuzz 16 17 Fizz 19 Buzz",
+        'and each element holds what the three writers composed';
+}

--- a/todo/deep/celled-container-element-write-races-under-threads.md
+++ b/todo/deep/celled-container-element-write-races-under-threads.md
@@ -1,107 +1,62 @@
-# An element write through a celled `@`/`%` races when threads share it
+# A thread-escaping container is kept off the cell path, and loses its own binding
 
-Measured 2026-09-06 while landing the container half of ADR-0055's capture cell
-dichotomy (`news/2026-09/container-captures-join-the-cell-dichotomy.md`). The
-container-cell path and the cross-thread atomic lane are two mechanisms for the
-same job, and the hand-off between them is not sound: an array or hash that has
-been boxed into a `ContainerRef` cell loses the lane's locking without gaining
-any locking of its own.
+**The race this file was originally about is fixed** (2026-09-06,
+`news/2026-09/celled-container-cross-thread-store-exclusion.md`,
+[ADR-0068](../../docs/adr/0068-cross-thread-container-writes-need-a-synchronized-store.md)
+§4 steps 1-2). An element write that reaches its container through a shared
+`ContainerRef` cell now excludes concurrent threads, on both the write and the
+read side, keyed on the cell. What survives is the **mitigation that was put in
+place while it was unsafe**, and the correctness cost that mitigation carries.
 
-## Root cause
+## The mitigation
 
-`Interpreter::assign_array_elem_to_shared_var` (and its hash twin
-`assign_hash_elem_to_shared_var`, `src/runtime/runtime_shared_vars.rs`) route a
-`@a[$i] = $v` performed while `shared_vars_active` through
-`shared_array_elem_set`, which holds the `__mutsu_atomic_arr::` store's write
-lock across the whole read-modify-write. That is what makes twenty concurrent
-`start { @a[$i] = 1 }` blocks all land instead of clobbering each other.
+`CompiledCode::compute_free_vars` (`src/opcode.rs`) subtracts
+`thread_escaping_captures` from `needs_cell_unvouched_containers`: every name a
+thread-escaping nested closure captures is *excluded* from the decl-site
+container cell, so it keeps the name-keyed `__mutsu_atomic_arr::` lane instead.
+Its comment says why in as many words — "boxing one turns
+`start { @a[$i] = ... }` into a data race".
 
-Both functions bail out early when the name is already a `ContainerRef`:
+That premise is now false. The celled path is synchronized.
 
-```rust
-// An array already boxed into a shared `ContainerRef` cell is already shared
-// through the Mutex; let the general assignment path write through it.
-if matches!(self.env.get(key).map(|v| v.view()), Some(ValueView::ContainerRef(_))) {
-    return None;
-}
-```
+## What the mitigation costs
 
-The comment is half true. The cell's `Mutex` protects *rebinding* the name — the
-`*cell.lock() = updated` writes elsewhere in that file. It does not protect the
-container's **contents**: the general assignment path
-(`exec_index_assign_expr_named_op` → `vm_var_assign_index_named.rs`) derefs the
-cell, reaches the `Array`, and mutates its `ArrayData` in place via
-`crate::value::gc_contents_mut` with no lock held at all. Two threads doing that
-concurrently is a data race on a `Vec<Value>`.
-
-The bail-out itself is load-bearing for a different scenario and must not simply
-be deleted: it was added because the `__mutsu_atomic_hash::` lane only understands
-a bare `ValueView::Hash`, so it treated a celled hash as absent and reinstalled a
-plain unboxed `Hash` into `env`, permanently un-sharing the cell (see
-`todo/deep/nested-whenever-registration-clobbers-sibling-event-aggregate-writes.md`).
-
-## Minimal repro
-
-Any path that gets a container celled *and* then written from several threads.
-The one that surfaced it: temporarily drop the `thread_escaping_captures`
-subtraction from `needs_cell_unvouched_containers` (`CompiledCode::compute_free_vars`,
-`src/opcode.rs`), then
-
-```raku
-my @a;
-await (^20).map: -> $t { start { for ^50 -> $k { @a[$t * 50 + $k] = 1 } } };
-say @a.grep(*.defined).elems;   # want 1000
-```
-
-aborts within a run or two:
-
-```
-thread 'pool' panicked at src/value/view.rs:849:18:
-internal error: entered unreachable code: with_array_mut probed an Array
-double free or corruption (out)
-```
-
-— a TOCTOU inside `with_array_mut` (`self.view()` saw an `Array`, the following
-`with_repr_mut` did not, because another thread had rewritten the same `Value`)
-followed by a heap corruption in glibc. It is real UB, not a logic bug.
-
-`t/concurrent-array-index-assign.t` test 7 and `t/concurrent-hash-assign.t`
-test 7 are the ready-made reproductions.
-
-## Why this is large
-
-The fix is a decision about which mechanism owns a shared container, not a patch:
-
-- **Make the celled write path thread-safe.** Every general-path element write
-  that reaches a container through a `ContainerRef` would have to take that
-  cell's lock for the duration of the `ArrayData`/`HashData` mutation. The write
-  sites are numerous (`vm_var_assign_index_named.rs`,
-  `vm_var_assign_element.rs`, the `try_native_array_mut` /
-  `try_native_hash_mut_bound` mutating-method paths, `env_root_descended_mut`)
-  and they are on the hot single-threaded path, so a blanket lock is a
-  pessimization that would need measuring.
-- **Or retire the atomic lane for celled containers properly**, teaching
-  `shared_array_elem_set` / `shared_hash_elem_set` to write *through* the cell
-  under the cell's own lock, and then deleting the bail-out. That keeps one
-  mechanism, but the lane also carries the dirty-marking and
-  `sync_shared_vars_to_env` writeback that the cell path does not, so the two
-  have to be unified rather than one dropped.
-
-Either way it is an ADR-sized call about the relationship between the
-`ContainerRef` cell (ADR-0013/ADR-0039/ADR-0055) and the `shared_vars` lane.
-
-## What it currently costs
-
-`needs_cell_unvouched_containers` subtracts every name a thread-escaping nested
-closure captures, so a container lexical handed to a thread keeps the atomic
-lane — and keeps the ADR-0055 hijack the rest of the family no longer has:
+A container lexical handed to a thread keeps the lane, and therefore keeps the
+ADR-0055 hijack the rest of the capture-cell family no longer has:
 
 ```raku
 my @a = 1, 2;
 @a.push(3);
 my $f = -> { start { @a.elems } };
 sub collide() { my @a = 9; await $f.() }
-say collide();          # raku: 3
+say collide();          # raku: 3, mutsu: 1
 ```
 
-That is the whole residue; every non-thread-escaping container capture is fixed.
+The closure's `@a` resolves to whatever same-named binding the *calling* frame
+happens to have, because the lane is keyed by name. Every non-thread-escaping
+container capture was fixed by ADR-0055 slice 1b (`da8e94252`); this is the last
+hole, and it is held open only by the subtraction.
+
+## Why it is still deep, not a one-line deletion
+
+Deleting the subtraction moves thread-shared containers from the lane onto the
+cell path, and the two are not interchangeable in what they carry:
+
+- the lane performs the dirty-marking and `sync_shared_vars_to_env` writeback
+  that merges a worker's env back into the spawning frame; the cell path does
+  not, because the cell *is* the sharing;
+- the lane's `assign_array_elem_to_shared_var` / `assign_hash_elem_to_shared_var`
+  bail-outs and `container_name_is_redeclared` masking exist for shapes
+  (re-declared names, attribute containers) that the cell path spells
+  differently.
+
+So the unit of work is "retire the lane for containers that have a cell", not
+"drop the filter". The pins that decide it are `t/concurrent-array-index-assign.t`,
+`t/concurrent-hash-assign.t`, `t/concurrent-celled-container-store.t` and the
+S17 whitelist; the reward is the repro above answering `3`, and one mechanism
+instead of two for a container more than one thread can see.
+
+Adjacent, and probably the same slice: ADR-0068 §4 step 3 still has to widen the
+store-side exclusion to mutating *methods* (`push`/`pop`/`splice`/`:delete`),
+which today rely on the lane for exactly the containers this filter keeps there.
+See `todo/deep/gc-contents-mut-cross-thread-aliased-writes.md`.

--- a/todo/deep/gc-contents-mut-cross-thread-aliased-writes.md
+++ b/todo/deep/gc-contents-mut-cross-thread-aliased-writes.md
@@ -1,99 +1,100 @@
 # `gc_contents_mut` aliased writes are unsynchronized across VM threads
 
-This is the residue of `todo/deep/procasync-stress-segv.md`, which was closed on
-2026-09-05 by finding and fixing the path that actually crashed
-(`news/2026-09/supply-act-serialization-and-the-concurrency-crash-cluster.md`). Read that
-entry first: it has the evidence, the measurements, and the negative results from the
-memory checkers, none of which is repeated here.
+This is the residue of `todo/deep/procasync-stress-segv.md`, closed on 2026-09-05 by
+finding and fixing the path that actually crashed
+(`news/2026-09/supply-act-serialization-and-the-concurrency-crash-cluster.md`).
 
-**Design status (2026-09-05): [ADR-0068](../../docs/adr/0068-cross-thread-container-writes-need-a-synchronized-store.md)
-is the `Proposed` design for this finding.** It carries the route audit, the calibrated
-reproduction harness, the path oracle, the deadlock quantification that rejects
-"synchronize the primitive", and the proposed remedy. This file is now the *open work
-item*; the ADR is the reasoning. Do not re-derive either from scratch.
+**Design status: [ADR-0068](../../docs/adr/0068-cross-thread-container-writes-need-a-synchronized-store.md)
+is `Accepted`, and its §4 steps 1 and 2 are IMPLEMENTED** (2026-09-06,
+`news/2026-09/celled-container-cross-thread-store-exclusion.md`). Read ADR-0068 §7
+before anything else here: it records three premises of the original design that
+measurement contradicted, including the one this file used to lead with. This
+file is now only the *open remainder* — §4 step 3.
 
-## The general hazard
+## What is closed
 
-`crate::gc::gc_contents_mut` is, in its own words, *"the codebase's single
-aliased-container-write primitive"*: given a `Gc<T>` whose strong count is greater than
-one, it hands out a `&mut T` so that a write through one alias is visible through every
-holder of the same node. That is how mutsu implements Raku container identity, and it is
-correct on one thread.
+The celled-container route. An element store that reaches its container through a
+shared `ContainerRef` cell now takes a cell-keyed stripe lock
+(`src/value/container_lock.rs`), and so do the read chokepoints
+(`Value::with_deref` / `into_deref`). ADR-0068's routes 1 (`.tap` captures) and 4
+(`Thread.start` bodies) went from 17/96 and 64/64 failures to 0/96 and 0/64; the
+named-sub array and hash probes went from 93/96 and 95/96 to 0/240 at 24-way.
+`t/concurrent-celled-container-store.t` pins all four shapes.
 
-Its `# Safety` clause already names the gap:
+Two corrections that the fix turned up, and that anyone continuing this work needs:
 
-> The caller must ensure that ... concurrent structural mutation from another thread
-> remains routed through the synchronized shared-store lanes (the narrow cross-thread
-> race deferred to ADR-0001 layer 3c).
+- **The shared thing is the CELL, not the container node.** Twenty threads writing
+  one celled array reach *thirteen* distinct `Gc<ArrayData>` addresses, because
+  `Gc::make_mut` copies an aliased node. A node-keyed lock excludes nothing, and
+  measurably did not move the failure rate.
+- **The dominant race was writer-versus-reader.** The store derives a raw pointer
+  into the cell's slot and releases the cell's `Mutex`; the readers take that same
+  `Mutex` to clone the inner `Value` out. So they never excluded each other, and a
+  reader could take a refcount on a node the writer had already dropped. Locking
+  only the write side left 13/96 failures standing.
 
-There are **149 call sites** and none of them establishes that. The shared-store lanes
-(`runtime/runtime_shared_vars.rs`) are keyed by variable name and seeded from a spawning
-frame's env walk. Any *other* way a container comes to be aliased by two VM threads
-bypasses them entirely, and then two threads can call `Vec::resize` / `HashMap::insert` on
-the same allocation at once.
+## What is still open — ADR-0068 §4 step 3
 
-## What the 2026-09-05 audit established
+`gc_contents_mut` has 149 call sites and the exclusion is applied at three of them.
+The remaining exposure is the rest of the ways a container becomes cross-thread
+reachable while the name-keyed lane declines (ADR-0068 §2 lists five):
 
-**The root cause is narrower and more specific than "149 unsynchronized sites".** The lane
-does not merely fail to cover the container — it *hands the write to a mechanism it
-believes is synchronized and is not*. `assign_array_elem_to_shared_var` returns `None` when
-the env entry is a `ContainerRef`, on the recorded premise that such an array *"is already
-shared through the Mutex"*. `ContainerCell`'s `Mutex` protects the cell's **`Value`**, not
-the container the `Value` points at: the element store clones the inner `Gc<ArrayData>` out
-from under the lock and then runs `gc_contents_mut` → `autoviv_resize` → `Vec::resize` with
-no lock held. On the confirmed-racing workload that `return None` fired 21/21 times. A
-container reaches that state whenever the closure machinery boxes it into a shared cell —
-most commonly because a **named sub closes over it**. See ADR-0068 §2.
+- the name is not a plain lexical `@`/`%` (attributes, twigils);
+- the name is masked as re-declared;
+- the container was never in a spawning frame's env;
+- the write is not name-keyed at all (`$obj.attr[$i]`, `%h<k>[$i]`, a container
+  returned from a method);
+- mutating *methods* rather than element stores — `push`/`pop`/`splice`/`:delete`
+  and the `try_native_array_mut` / `try_native_hash_mut_bound` paths — which reach
+  their container through the same `env_root_descended_mut` chokepoint but do not
+  yet take the guard.
 
-### Route audit (measured, ADR-0068 §3)
+Each wants its own oracle-classified probe and its own stress acceptance, per
+ADR-0068 §4 step 3 — not one 149-site sweep.
 
-| Route | Verdict |
-|---|---|
-| `Supply.act` tap captures | **Closed** by #7336 (0/240 after; 6/960 with the fix disabled) |
-| plain `.tap` callback captures | **RACES** — 4/960, with `free(): double free detected in tcache 2` and `double free or corruption (out)` core dumps. Not fixable by locking dispatch: `.tap` has no serialization guarantee in Raku |
-| `Promise.then` combinator callback captures | **RACES** — 3/240, lost updates |
-| `Thread.start` bodies | **Exposed** on the path oracle (21/0), same site as the two above |
-| `Channel.Supply` tap captures | **Exposed** on the path oracle (20/0), but blocked behind a separate deterministic Channel-supply delivery bug that drops/misorders values on a single unloaded run — fix that first or the race rate is unmeasurable |
-| Object attribute (`has @.seen is rw`) | **Unresolved** — reaches none of the probed aliased-store sites, nor `gc_data_mut`, nor the computed-attr sites. Needs its own path trace before it can be called covered or exposed |
+Three specific loose ends from the route audit:
 
-Routes 1, 2 and 4 all corrupt through the **same** site
-(`vm/vm_var_assign_index_named.rs:2353`) — three doors into one room, which is what makes a
-store-side remedy tractable.
+- **Route 3 (object attributes, `has @.seen is rw`) is unclassified.** It reaches
+  none of the probed aliased-store sites, nor `gc_data_mut`, nor the computed-attr
+  sites. Trace it before calling it covered or exposed.
+- **Route 5 (`Channel.Supply` tap captures)** is exposed on the path oracle but
+  blocked behind a separate deterministic Channel-supply delivery bug that
+  drops/misorders values on a single unloaded run. Fix that first.
+- **`roast/S17-procasync/stress.t` SIGSEGV** (CI run 30590633128, 2026-07-30, the
+  rakudo#3299 block) has never reproduced and is still unexplained. Run it under
+  the §1.1 harness at 24-way and the §1.2 oracle to see whether its containers are
+  on the lane at all.
 
-## Reproduction harness — this is the reusable part
+## How to reproduce this class cheaply — read this before building a harness
 
-Previous attempts failed for a measurable reason, and the correction matters more than the
-old advice did:
+ADR-0068 §1.1's requirement of a `--profile profiling` build, the `gc-stress`
+environment and 24-way oversubscription is **not** necessary, and §7.1 records why.
+The discriminator is which store path the workload takes, not how loaded the box
+is. A `start` block that mentions the container lexically is excluded from celling
+by `thread_escaping_captures` and lands on the safe lane — which is what made five
+earlier hand-shrunk probes come back clean. Reach the container through a **named
+sub the thread body merely calls** (a route the thread-escape analysis cannot see,
+ADR-0039 §8.6) and an ordinary debug build fails on the first run, with the GC off:
 
-- **CPU oversubscription is the necessary ingredient, not concurrency.** At 8-way on 12
-  cores the *known-racing* pre-fix workload was 0/64 and 0/240 — clean. At **24-way on 12
-  cores** it failed 6/960 within seconds per batch. Every earlier "could not reproduce" in
-  this area was taken below that threshold and means nothing.
-- Run the **real workload** as separate processes under the `gc-stress` environment
-  (`MUTSU_GC=on MUTSU_GC_EVERY_CANDIDATE=1024 MUTSU_GC_VERIFY=1`) on a `--profile profiling`
-  build. mutsu's own `Vec` bounds check and glibc's allocator are the detectors.
-- **A hand-shrunk probe is not a substitute for the real file.** Five standalone probes
-  written from the racing test's own source were clean over 1440+ block executions at full
-  power *with the fix disabled*, because shrinking silently moved them onto the
-  **synchronized** lane.
-- **Use the path oracle before the stress harness.** `rust-gdb`'s ignore counter turns a
-  breakpoint into a free call counter with no rebuild; breaking on
-  `vm_var_assign_index_named.rs:2353` (unsynchronized) and
-  `Interpreter::shared_array_elem_set` (lane) classifies a workload as exposed-or-covered in
-  one debug run. See ADR-0068 §1.2 for the exact command.
-- **Do not start with `valgrind --tool=memcheck`** (0 errors on a demonstrably racing
-  workload — it serializes threads onto one core) or `helgrind` (cannot symbolize the
-  optimized binary). AddressSanitizer reports nothing either; it is useful only as a
-  *scheduler*, because its ~10x slowdown widens the window.
+```raku
+{
+    my @a;
+    sub put-it($i) { @a[$i] = 1 }
+    await (^20).map: -> $t { start { for ^50 -> $k { put-it($t * 50 + $k) } } };
+    say @a.grep(*.defined).elems;   # want 1000
+}
+```
 
-## The one instance that is NOT explained by the fixed path
+Use ADR-0068 §1.2's `rust-gdb` ignore-counter oracle to confirm a new probe is on
+the racing path before trusting a clean result. Do not start with
+`valgrind --tool=memcheck` (it serializes threads onto one core and reports
+nothing) or helgrind (cannot symbolize the optimized binary).
 
-`roast/S17-procasync/stress.t` died of SIGSEGV once, on CI run 30590633128 (2026-07-30), in
-the rakudo#3299 block that starts 1200 `Proc::Async` instances inside a `react`. It has
-never reproduced — ~130 targeted local runs across four configurations, plus the 2026-09-05
-session's — and it has no `Supply.act` tap, so the `.act` fix does not obviously cover it.
-The 2026-09-05 audit does **not** explain it either. What it adds is a reason the hunts
-failed (all of them ran below the oversubscription threshold above) and a cheap next step:
-run that file under the 24-way harness, and run the path oracle over it to see whether its
-containers are on the lane at all. Treat it as an open, unexplained instance of the general
-hazard rather than as its own investigation.
+## A follow-up worth measuring
+
+The read-side guard sits in `Value::with_deref` / `into_deref`, which are hot. It
+is gated on "a VM mutator thread has been spawned", so a single-threaded program
+pays one `Relaxed` load — but a *threaded* program now takes a mutex on every
+celled-container read. No slowdown showed up in `make test`, and nothing measured
+it directly. If a concurrency-heavy benchmark regresses, that gate is the first
+place to look, and per-cell striping granularity is the first knob.


### PR DESCRIPTION
Implements [ADR-0068](docs/adr/0068-cross-thread-container-writes-need-a-synchronized-store.md) §4 steps 1 and 2 — the only Tier S cluster in `todo/TRIAGE.md`. Step 3 stays open.

## The bug

Sharing one `@`/`%` across threads corrupted the interpreter's heap. On an ordinary **debug** build this six-line program failed **93 of 96 runs**:

```raku
{
    my @a;
    sub put-it($i) { @a[$i] = 1 }
    await (^20).map: -> $t { start { for ^50 -> $k { put-it($t * 50 + $k) } } };
    say @a.grep(*.defined).elems;   # want 1000
}
```

Shapes seen: `double free or corruption`, `corrupted size vs. prev_size`, `Arc counter overflow`, `Gc::drop strong-count underflow`, `malloc(): unaligned tcache chunk detected`, `with_array_mut probed an Array`, and silent short counts (906, 916, 180). It fails **20/20 with `MUTSU_GC=off`**, so the GC is not involved.

## Root cause, and where ADR-0068 was wrong

mutsu has two mechanisms for a container more than one thread can reach: the name-keyed lanes in `runtime_shared_vars.rs` (which hold a write lock across the whole read-modify-write) and the `ContainerRef` cell the closure machinery boxes a captured container into. **They do not hand off.** `assign_array_elem_to_shared_var` declines for a celled container on the recorded premise that it "is already shared through the Mutex", and the general path it defers to does not inherit that lock — `descend_container_ref` takes the cell's `Mutex<Value>` only long enough to derive a raw pointer into the slot, releases it, and the rest of the statement mutates through `gc_contents_mut` with nothing held.

ADR-0068 framed the consequence as a writer-versus-writer race on the container node. Two measurements contradict that, and both are now recorded in the ADR's new §7:

- **The shared thing is the CELL, not the node.** Twenty threads writing one celled array reach **thirteen distinct `Gc<ArrayData>` addresses**, because `Gc::make_mut` copies an aliased node. A node-keyed lock excludes nothing, and measurably left the failure rate unchanged.
- **The dominant race is writer-versus-READER.** `Value::with_deref` / `into_deref` — the read chokepoint for every celled container — take the same cell `Mutex` the store has already dropped, so the two never excluded each other at all; a reader could clone a `Value` mid-overwrite and take a refcount on a node the writer had just released. Locking only the write side left 13/96 failures standing.

## The fix

`src/value/container_lock.rs`: a table of 64 striped mutexes keyed by the shared `ContainerCell`'s address (falling back to the container node for an uncelled root), taken by the element store **and by both read chokepoints**.

It is deliberately *not* the cell's own `Mutex` — `descend_container_ref` must take that to produce the pointer it returns, so holding it across the mutation would self-deadlock on the next read of the same cell. A separate lock with the same *key* gets the exclusion without the reentrancy. Two properties keep it safe and free:

- **A thread holds at most one of these locks at a time**; a nested acquisition is a no-op, so a lock-ordering deadlock between two threads is structurally impossible.
- **Nothing locks until a VM mutator thread has been spawned** (ADR-0068 step 1's process-global `AtomicBool`), so a single-threaded program pays one `Relaxed` load per celled read or store.

## Measured (debug build, `MUTSU_GC=on MUTSU_GC_EVERY_CANDIDATE=1024 MUTSU_GC_VERIFY=1`)

| Route | Before | After |
|---|---|---|
| celled array element store via a named sub | 93 / 96 | **0 / 240** (24-way) |
| celled hash key store via a named sub | 95 / 96 | **0 / 240** (24-way) |
| ADR-0068 route 1 — plain `.tap` callback captures (day05 idiom) | 17 / 96 | **0 / 96** |
| ADR-0068 route 4 — `Thread.start` bodies | 64 / 64 | **0 / 64** |

`t/concurrent-celled-container-store.t` pins all four shapes. `make test` passes (3733 files / 38576 tests); `roast/integration/advent2014-day05.t`, `S17-supply/basic.t`, `S17-lowlevel/thread.t`, `S17-promise/nonblocking-await.t` all pass.

## Methodology correction worth keeping (ADR-0068 §7.1)

ADR-0068 §1.1 concluded that a `--profile profiling` build, the gc-stress environment and **24-way oversubscription** were necessary, and that hand-shrunk probes were untrustworthy. Neither holds. What decides whether a probe reproduces is **which store path it takes**: a `start` block that mentions the container lexically is excluded from celling by `thread_escaping_captures` and lands on the safe lane — which is exactly why five earlier shrunk probes came back clean. Reach the container through a **named sub the thread body merely calls** (a route the thread-escape analysis cannot see, ADR-0039 §8.6) and a plain debug build fails on the first run.

## Also in this PR

Corrects the three comments that made the hole invisible — the two "already shared through the Mutex" bail-outs, `gc_contents_mut`'s `# Safety` clause, and `value/aliased_mut.rs`'s deferral note — and rewrites both `todo/deep/` files to their actual remaining scope.