### PR TITLE
fix(vm): `$.attr = v` assigns through the accessor, and consults `is rw`

### DIFF
--- a/news/2026-09/dot-twigil-accessor-assignment-consults-rw.md
+++ b/news/2026-09/dot-twigil-accessor-assignment-consults-rw.md
@@ -1,0 +1,69 @@
+# `$.attr = v` now consults the accessor, instead of writing past it
+
+Inside a method, `$.attr = v` is not a write to the attribute slot. Raku
+evaluates `self.attr` and assigns to whatever that hands back, so for a non-`rw`
+attribute it hands back a bare value and the assignment dies:
+
+```raku
+class F { has $.x = 5; method m { $.x = 9 } }
+F.new.m;   # raku: X::Assignment::RO: Cannot modify an immutable Int (5)
+```
+
+mutsu wrote `9` into the attribute and carried on. `is rw` was never consulted at
+all, in either statement or expression position — a public accessor's read-only
+contract was simply not enforced from inside the class.
+
+## Why it slipped through
+
+`Compiler::compile_expr_assign`'s `$.attr` arm (`src/compiler/expr_data.rs`) does
+call the accessor — but only to check that it *exists*. It emits `CallMethod`,
+immediately `Pop`s the result, and then performs an ordinary **named** assignment
+to the variable `.attr`, which lands on the attribute. The accessor's return
+value, and with it its mutability, was thrown away one instruction after it was
+computed.
+
+The check now lives at the store instead of in the compiler
+(`Interpreter::check_dot_twigil_accessor_writable`, `src/vm/vm_misc_assign.rs`),
+because rw-ness is a property of the *invocant's class*, which only the runtime
+knows. It reports raku's own wording — `Cannot modify an immutable Int (5)`, the
+accessor's return type and value — rather than mutsu's older
+`method 'x' is not rw`.
+
+## Scoped to the `$` sigil, deliberately
+
+Measured against raku v2026.07: for a non-`rw` `has @.a` and `has %.h`,
+
+```raku
+@.a = 7, 8;      # succeeds
+@.a[0] = 99;     # succeeds
+@.a.push(3);     # succeeds
+%.h<k> = 99;     # succeeds
+```
+
+all work without `is rw`, because those accessors hand back the container itself
+and assigning *into* a container is a `STORE`, not a modification of an immutable
+value. Only the scalar accessor refuses. `t/dot-twigil-accessor-readonly.t` pins
+both halves, plus the `is rw` and `$!` forms that must stay unaffected.
+
+Blast radius turned out to be zero: of the 138 `t/` files whose grep matched
+`$.name =`, every one was either a `has $.x = default` declaration, an `is rw`
+attribute, or a write from a `sub` with no invocant.
+
+## What is left
+
+The **compound** form is still divergent, now in the safe direction. raku treats
+`$.x *= 2` on a non-`rw` accessor as a silent no-op — the `$` sigil itemizes the
+accessor's bare return into a throwaway `Scalar`, the multiplication lands there,
+and the attribute is untouched — while mutsu refuses. Before this change mutsu was
+*inconsistent* about it: the bare-statement form threw, and the
+expression/parenthesized forms silently over-mutated the attribute, because the
+two spellings take entirely different lowerings (`MethodCall` on `__ANON_STATE__`
+versus `AssignExpr { name: ".x" }`). Now all four spellings refuse, which is
+coherent and never loses a write.
+
+Closing the remaining gap needs the `$.`-versus-`self.` origin to survive both
+lowerings, which is a parser and compiler change rather than a runtime one. The
+map — including why the obvious `do { my $t = self.x; $t OP= v; $t }` desugaring
+would break every `is rw` compound assign — is in
+`todo/deep/dollar-dot-attr-compound-assign-spurious-ro-error.md`, retitled to
+match what is actually left.

--- a/src/runtime/class_introspection.rs
+++ b/src/runtime/class_introspection.rs
@@ -576,7 +576,7 @@ impl Interpreter {
         matches!(name, "pos" | "orig" | "target" | "from" | "to")
     }
 
-    pub(super) fn collect_class_attributes(&mut self, class_name: &str) -> Vec<ClassAttributeDef> {
+    pub(crate) fn collect_class_attributes(&mut self, class_name: &str) -> Vec<ClassAttributeDef> {
         let mro = self.class_mro(class_name);
         let mut attrs: Vec<ClassAttributeDef> = Vec::new();
         for cn in mro.iter().rev() {

--- a/src/vm/vm_misc_assign.rs
+++ b/src/vm/vm_misc_assign.rs
@@ -52,6 +52,63 @@ impl Interpreter {
         Ok(val)
     }
 
+    /// `$.attr = v` inside a method assigns through the attribute's *public
+    /// accessor*, not to the attribute slot: raku evaluates `self.attr` and then
+    /// assigns to what it hands back. A non-`rw` scalar accessor hands back a
+    /// bare value, so the assignment dies with
+    /// `X::Assignment::RO: Cannot modify an immutable Int (5)`.
+    ///
+    /// mutsu compiles `$.attr = v` as an ordinary *named* assignment to the
+    /// variable `.attr` (`Compiler::compile_expr_assign` only calls the accessor
+    /// to check that it exists, then discards the result), which wrote the
+    /// attribute directly and never consulted `is rw` at all. This is that
+    /// missing check, placed at the store rather than in the compiler because
+    /// rw-ness is a property of the *invocant's class*, which only the runtime
+    /// knows.
+    ///
+    /// Deliberately scoped to the `$` sigil. Measured against raku v2026.07: for
+    /// a non-`rw` `has @.a` / `has %.h`, `@.a = 7,8`, `@.a[0] = 99` and
+    /// `%.h<k> = 99` all SUCCEED, because those accessors hand back the container
+    /// itself and assigning into a container is a `STORE`, not a modification of
+    /// an immutable value. Only the scalar case refuses.
+    fn check_dot_twigil_accessor_writable(&mut self, name: &str) -> Result<(), RuntimeError> {
+        let Some(attr) = name.strip_prefix('.') else {
+            return Ok(());
+        };
+        if attr.is_empty() || attr.starts_with(['@', '%', '&']) {
+            return Ok(());
+        }
+        let Some(self_val) = self.get_env_with_main_alias("self") else {
+            return Ok(());
+        };
+        let self_val = self_val.deref_container();
+        let ValueView::Instance { class_name, .. } = self_val.view() else {
+            return Ok(());
+        };
+        let class_name = class_name.resolve();
+        let is_readonly_public_scalar = self
+            .collect_class_attributes(&class_name)
+            .iter()
+            .find(|a| a.name == attr)
+            .is_some_and(|a| a.is_public && !a.is_rw && a.sigil == '$');
+        if !is_readonly_public_scalar {
+            return Ok(());
+        }
+        let current = match self_val.view() {
+            ValueView::Instance { attributes, .. } => {
+                [attr.to_string(), format!("${attr}"), format!("!{attr}")]
+                    .iter()
+                    .find_map(|k| attributes.as_map().get(k.as_str()).cloned())
+                    .unwrap_or(Value::NIL)
+            }
+            _ => Value::NIL,
+        };
+        Err(RuntimeError::assignment_ro_typename(
+            &crate::value::what_type_name(&current),
+            &current.to_string_value(),
+        ))
+    }
+
     pub(super) fn exec_assign_expr_op_inner(
         &mut self,
         code: &CompiledCode,
@@ -62,6 +119,7 @@ impl Interpreter {
             _ => unreachable!("AssignExpr name must be a string constant"),
         };
         self.check_readonly_for_modify(&name)?;
+        self.check_dot_twigil_accessor_writable(&name)?;
         // A whole-container reassignment breaks every `:=`-bound element, so drop
         // the read-only-element markers (`%h<i> := 137; %h = (...)` makes `%h<i>`
         // writable again). Covers the tied-STORE path below too.

--- a/t/dot-twigil-accessor-readonly.t
+++ b/t/dot-twigil-accessor-readonly.t
@@ -1,0 +1,67 @@
+use Test;
+
+# `$.attr = v` inside a method assigns through the attribute's PUBLIC ACCESSOR,
+# not to the attribute slot: raku evaluates `self.attr` and assigns to what it
+# hands back. A non-`rw` scalar accessor hands back a bare value, so the
+# assignment dies. mutsu used to compile `$.attr = v` as an ordinary named
+# assignment to the variable `.attr` -- the accessor was called only to check
+# that it exists, and its result discarded -- so the write landed on the
+# attribute and `is rw` was never consulted at all.
+#
+# Scoped to the `$` sigil on purpose. Measured against raku v2026.07: for a
+# non-`rw` `has @.a` / `has %.h`, `@.a = 7,8`, `@.a[0] = 99` and `%.h<k> = 99`
+# all SUCCEED, because those accessors hand back the container itself and
+# assigning into a container is a STORE, not a modification of an immutable
+# value.
+
+plan 12;
+
+class RO {
+    has $.x = 5;
+    has @.a = (1, 2);
+    has %.h = (k => 1);
+    method simple      { $.x = 9 }
+    method simple-expr { my $r = ($.x = 9); $r }
+    method peek        { $!x }
+    method arr-assign  { @.a = 7, 8; @!a }
+    method arr-elem    { @.a[0] = 99; @!a }
+    method arr-push    { @.a.push(3); @!a }
+    method hash-elem   { %.h<k> = 99; %!h<k> }
+}
+
+class RW {
+    has $.y is rw = 5;
+    method simple   { $.y = 9; $!y }
+    method compound { $.y *= 2; $!y }
+    method selfform { self.y = 7; $!y }
+}
+
+my $ro = RO.new;
+throws-like { $ro.simple }, X::Assignment::RO,
+    '$.x = v on a non-rw scalar accessor throws';
+is $ro.peek, 5, 'and the attribute is untouched';
+
+throws-like { RO.new.simple-expr }, X::Assignment::RO,
+    'the same in expression position';
+
+# raku spells this "Cannot modify an immutable Int (5)" -- the accessor's
+# return type and value, not the accessor's name.
+my $msg = '';
+{ RO.new.simple; CATCH { default { $msg = .Str } } }
+like $msg, /'Cannot modify an immutable Int (5)'/,
+    'the message names the immutable value, as raku does';
+
+# A container accessor is NOT read-only in this sense, even without `is rw`.
+is RO.new.arr-assign, [7, 8], '@.a = ... succeeds without is rw';
+is RO.new.arr-elem, [99, 2], '@.a[0] = ... succeeds without is rw';
+is RO.new.arr-push, [1, 2, 3], '@.a.push succeeds without is rw';
+is RO.new.hash-elem, 99, '%.h<k> = ... succeeds without is rw';
+
+# `is rw` is unaffected in every form.
+is RW.new.simple, 9, '$.y = v mutates an is-rw attribute';
+is RW.new.compound, 10, '$.y *= 2 mutates an is-rw attribute';
+is RW.new.selfform, 7, 'self.y = v mutates an is-rw attribute';
+
+# A private twigil write is always allowed.
+class Priv { has $.z = 5; method bump { $!z = 9; $!z } }
+is Priv.new.bump, 9, '$!z = v is unaffected';

--- a/todo/deep/dollar-dot-attr-compound-assign-spurious-ro-error.md
+++ b/todo/deep/dollar-dot-attr-compound-assign-spurious-ro-error.md
@@ -1,139 +1,153 @@
-# `$.attr` inside a method is an *itemized* accessor read — mutsu has both halves of the RO rule backwards
+# A `$.attr` compound assign should be a silent no-op, not a refusal
 
-> **Moved from `todo/tickets/` to `todo/deep/` on 2026-08-26.** Per `todo/README.md`,
-> `tickets/` is for small, self-contained slices that need no design work. This one asks for
-> a semantic change to what *every* public accessor returns (a container rather than a value),
-> which moves `$obj.attr.VAR`, `=:=`-on-clones and `is rw` write-back all at once — and the
-> ticket's own "The right fix" section asks for an ADR before starting. That is the definition
-> of a `deep/` item, and filing it under `tickets/` was causing it to be picked up by the
-> oldest-first ticket pipeline and deferred again on each pass (it has now been deferred twice
-> for exactly this reason).
+> **Moved from `todo/tickets/` to `todo/deep/` on 2026-08-26**, because the fix it
+> asked for was a semantic change to what *every* public accessor returns. That is
+> **no longer** the shape of the work — see "What actually has to change" below.
 
-Discovered via the doc-diff harness on `raku-doc/doc/Language/traps.rakudoc`
-(around line 212). The doc's own `# OUTPUT:` comment is stale (it says the trap
-*should* throw "Cannot assign to an immutable value"); current `raku` does not
-throw for the compound-assign form.
+**Every previous diagnosis in this file, and TRIAGE's correction of it, was wrong
+about the mutsu column.** The 2026-09-01 tail said `$.x *= 2` mutates; the
+2026-09-06 TRIAGE said it throws. Both are right, for *different statement
+positions*, and neither noticed the other. The full table below was measured on
+`main` at `710b21d9c` (2026-09-06) against `raku` v2026.07, and every row was run
+both bare and inside `try`/`CATCH`.
 
-Re-measured against `raku` v2026.06 on 2026-08-26, and the root cause is now
-**established**, not guessed. The original guess in this ticket ("raku treats a
-compound-assign through a read-only accessor as a silent no-op") was the symptom,
-not the mechanism.
+## Status 2026-09-06: the silent half is fixed, the loud half remains
 
-## The mechanism
+The **simple** assignment now behaves like raku:
+`$.x = 9` on a non-`rw` scalar accessor throws
+`X::Assignment::RO: Cannot modify an immutable Int (5)` and leaves the attribute
+alone, in statement and expression position alike
+(`news/2026-09/dot-twigil-accessor-assignment-consults-rw.md`,
+`t/dot-twigil-accessor-readonly.t`). Silent over-mutation is gone.
 
-`$.x` inside a method is `self.x` **itemized** — the `$` sigil puts the accessor
-result in item context, which for a bare value means *a fresh anonymous `Scalar`
-container*. `self.x` is not itemized. That single difference explains every
-observation:
+What is left is narrower and is **not** silent data loss: a `$.x OP= v` compound
+assign on a non-`rw` scalar accessor now **refuses** in every position, where raku
+silently discards the write and yields the computed value. That is internally
+consistent and safe, but it is still a divergence, and the rest of this file is
+the map for closing it. The original title's "spurious RO error" is now the
+*only* remaining symptom, which is why the file has been retitled.
 
-```raku
-class F { has $.x = 5; has @.a = 1,2;
-  method probe { say $.x.VAR.^name; say self.x.VAR.^name } }
-F.new.probe;             # Scalar   /   Int
-say F.new.x.VAR.^name;   # Int      (from outside, no itemization)
-```
+## The measured table
 
-- A **non-`rw`** accessor returns a bare value, so `$.x` itemizes it into a
-  *throwaway* `Scalar`. `$.x *= 2` therefore assigns successfully — into the
-  throwaway — and the attribute is unchanged. `($.x *= 2)` evaluates to `10`
-  while the next `$.x` still reads `5`. No exception.
-- An **`is rw`** accessor returns the attribute's real `Scalar` container, so
-  itemization is the identity and `$.x *= 2` genuinely mutates it (`10`).
-- A **simple** assignment `$.x = 9` is compiled as an lvalue, *without* the
-  itemize wrapper (the wrapper would defeat the assignment), so it hits the raw
-  accessor return: `X::Assignment::RO: Cannot modify an immutable Int (5)` for a
-  non-`rw` attribute.
-- `self.x *= 2` also throws, because `self.x` was never itemized.
+For a **non-`rw` scalar** `has $.x = 5`, inside a method of that class:
 
-So Rakudo's pair for a non-`rw` `has $.x`, inside a method, is:
+| form | raku | mutsu before | mutsu now |
+|---|---|---|---|
+| `my $r = ($.x *= 2)` | `r=10`, attr stays `5` | `r=10`, attr became `10` | **throws** |
+| `my $r = $.x *= 2` | `r=10`, attr stays `5` | `r=10`, attr became `10` | **throws** |
+| `($.x *= 2);` as a statement | attr stays `5` | attr became `10` | **throws** |
+| `$.x *= 2;` as a bare statement | attr stays `5` | throws `method 'x' is not rw` | throws (same) |
+| `$.x = 9;` | throws `Cannot modify an immutable Int (5)` | attr became `9` | **throws, same message** |
+| `my $r = ($.x = 9)` | throws | `r=9`, attr became `9` | **throws, same message** |
+| `self.x *= 2` | throws | throws (`method 'x' is not rw`) | unchanged |
+| `self.x = 9` | throws | throws (`method 'x' is not rw`) | unchanged |
+| `$!x *= 2` | mutates | mutates | unchanged |
 
-| form | raku |
-| --- | --- |
-| `$.x = 9`   | throws `X::Assignment::RO: Cannot modify an immutable Int (5)` |
-| `$.x *= 2`  | **silent no-op**, expression value `10` |
-| `self.x *= 2` | throws |
-| `$!x *= 2`  | mutates (`10`) |
+Everything else already agrees and must not be disturbed. Measured on the same
+run: `$.x.VAR.^name` / `self.x.VAR.^name` / `F.new.x.VAR.^name` are
+`Scalar` / `Int` / `Int` in both; `has $.y is rw` mutates for every form in both;
+and for a **non-`rw` `@.a` / `%.h`**, `@.a.push(3)`, `@.a = 7,8`, `@.a[0] = 99`,
+`%.h<k> = 99` all succeed in raku *and* in mutsu. **Only the `$`-sigil accessor
+throws in raku**, because `@.a`'s accessor hands back the Array container and
+assigning into a container is `STORE`, not a modification of an immutable value.
 
-## What mutsu does — both halves reversed
+## The mechanism, traced through `--dump-ast`
 
-| form | mutsu |
-| --- | --- |
-| `$.x = 9`   | **succeeds** and mutates the attribute |
-| `$.x *= 2`  | **throws** `X::Assignment::RO: method 'x' is not rw` |
+`$.x` reaches the store through **two different lowerings**, which is why the
+divergence looks self-contradictory:
 
-`$.x op= v` lowers to
-`__mutsu_assign_method_lvalue(self, "x", [], <computed>, "<self-var>", true)`
-(`src/parser/stmt/assign/compound_expr.rs` →
-`Interpreter::assign_method_lvalue_with_values`,
-`src/runtime/methods_mut_method_lvalue.rs`), which rejects a public non-`rw`
-accessor with "method '…' is not rw". The simple-assign form reaches the same
-helper but takes the `found_public_rw` arm, which mutsu grants too generously.
+1. **Expression position** (`my $r = ($.x *= 2)`, `($.x *= 2);`) keeps
+   `CompoundAssign { target: Var(".x"), expanded: AssignExpr { name: ".x", … } }`.
+   `AssignExpr { name: ".x" }` is compiled by `Compiler::compile_expr_assign`
+   (`src/compiler/expr_data.rs:44-59`), whose `$.attr` arm merely **validates that
+   the accessor exists** — `CallMethod(x)` followed by `Pop` — and then performs an
+   ordinary *named* assignment to the variable `.x`, which writes the attribute
+   directly. No rw-ness is ever consulted. That is the whole reason `$.x = 9` and
+   the expression-position compound both over-mutate.
+2. **Bare statement position** (`$.x *= 2;`) is rewritten by the parser into
+   `MethodCall { target: Var("__ANON_STATE__"), name: "x" }` and lowered to
+   `__mutsu_assign_method_lvalue(self, "x", [], <computed>, "__ANON_STATE__", true)`
+   (`src/parser/stmt/assign/compound_expr.rs:308-338` → `assign/lvalue.rs`). That
+   reaches `assign_method_lvalue_with_values`
+   (`src/runtime/methods_mut_method_lvalue.rs:1076-1092`), which rejects a
+   non-`rw` public **scalar** accessor with "method '…' is not rw". Correct to
+   refuse a `self.x` write; wrong for `$.x`, which raku itemizes.
 
-## Why this was not fixed with the surrounding batch (2026-08-26)
+So `$.` and `self.` are indistinguishable by the time the statement path reaches
+the runtime — the `__ANON_STATE__` collapse in
+`src/parser/stmt/assign/assign_stmt.rs:62-65` is deliberate and drops exactly the
+distinction the fix needs.
 
-Fixing *only* the compound-assign half — turning the throw into a silent
-discard — would leave mutsu with an actively incoherent pair: plain assignment
-mutates the attribute while compound assignment silently does not. That trades a
-loud error for silent data loss and is worse than the current state.
+## Why raku behaves the way it does
 
-Fixing *both* halves means making `$.x = v` on a non-`rw` attribute start
-throwing, which is a real compatibility change for existing mutsu code and
-tests. It is also the same underlying gap as the one recorded at the end of
-`news/2026-08/clone-array-hash-attribute-containers-not-shared.md`: mutsu's
-accessors return attribute **values** where Rakudo returns their **containers**.
+`$.x` inside a method is `self.x` **itemized**: the `$` sigil puts the accessor
+result in item context, which for a bare value is a *fresh anonymous `Scalar`*.
+`self.x` is not itemized.
 
-## Re-confirmed 2026-08-26 (second pass)
+- non-`rw`: the accessor returns a bare value, so `$.x` itemizes it into a
+  throwaway `Scalar`. `$.x *= 2` assigns into the throwaway — expression value
+  `10`, attribute unchanged, **no exception**.
+- `is rw`: the accessor returns the attribute's real `Scalar`, itemization is the
+  identity, and `$.x *= 2` genuinely mutates.
+- A **simple** assignment is compiled as an lvalue *without* the itemize wrapper
+  (it would defeat the assignment), so it hits the raw accessor return and throws.
 
-Re-measured again as part of the itemization/readonly batch: `$.x = 9` still
-mutates and `$.x *= 2` still throws `X::Assignment::RO: method 'x' is not rw`.
-Deferred a second time for the reason recorded above — step 1 below (accessors
-returning containers) is a real semantic change to every attribute read, it
-changes `$obj.attr.VAR`, `=:=`-on-clones and `is rw` writeback at once, and the
-ticket itself asks for an ADR first. It is **not** blocked on ADR-0040 (element
-itemization); it is its own decision about what a public accessor returns.
+## What actually has to change
 
-## The right fix
+Earlier passes concluded that step 1 had to be "make an `is rw` accessor return
+its `Scalar` container", and deferred three times on that ground. **That is not
+required.** Every `is rw` form already behaves correctly in mutsu, and so does
+every `@.`/`%.` form. The work is confined to the `$`-sigil non-`rw` case and to
+teaching the two lowerings apart:
 
-Make the accessor return the container, then let itemization do the rest — i.e.
-implement the model above literally rather than special-casing the compound
-form:
+1. ~~**`AssignExpr { name: ".attr" }` must consult rw-ness.**~~ **DONE.** The
+   check went in at the store (`Interpreter::check_dot_twigil_accessor_writable`,
+   `src/vm/vm_misc_assign.rs`) rather than in the compiler, because rw-ness is a
+   property of the *invocant's class* and only the runtime knows it. It is scoped
+   to the `$` sigil: measured, raku accepts `@.a = 7,8` and `%.h<k> = 99` on
+   non-`rw` container attributes.
+2. **A `$.`-twigil compound assign must become a silent no-op for a non-`rw`
+   scalar accessor**, yielding the computed value. This is all that is left, and
+   both lowerings need it:
+   - expression position: intercept `Expr::CompoundAssign { target: Var(".x"), .. }`
+     in `Compiler::compile_expr` (`src/compiler/expr.rs:785`, which today just
+     compiles `expanded`) before change 1 turns it into a throw;
+   - statement position: carry the `$.`-origin through
+     `method_lvalue_roundtrip_assign_expr` as a new argument of
+     `__mutsu_assign_method_lvalue` (arg 5 is `target_var`, arg 6 is
+     `preserve_hash_entries`; add arg 7), read it in
+     `builtin_assign_method_lvalue` (`src/runtime/builtins_multidim_assign.rs:621`)
+     and thread it into `assign_method_lvalue_with_values`, where the non-`rw`
+     public scalar rejection returns `Ok(value)` instead of an error.
+3. ~~**Align the message.**~~ **DONE for the `$.` form** — it now reports
+   `X::Assignment::RO: Cannot modify an immutable Int (5)`. `self.x = 9` and
+   `self.x *= 2` still say `method 'x' is not rw`; raku uses the immutable-value
+   wording there too. Cheap to align at
+   `src/runtime/methods_mut_method_lvalue.rs:1076-1092`, but do it in the same
+   change as item 2 so the two do not disagree about which message a `$.` write
+   gets.
 
-1. An `is rw` public accessor returns the attribute's `Scalar` container
-   (`ContainerRef` cell), not its value. This alone makes `$.x *= 2` work for
-   `is rw` for the right reason, and fixes `$obj.rw-attr.VAR.^name` and the
-   `=:=`-on-two-clones divergence noted in the clone news entry.
-2. A non-`rw` public accessor keeps returning a bare value.
-3. `$.x` as a *term* itemizes the accessor result (`Value::item()`): identity for
-   (1), a fresh throwaway `Scalar` for (2). `$.x op= v` then no-ops on a
-   read-only attribute with no special case anywhere.
-4. `$.x` as a *simple-assign lvalue* does not itemize, so it reaches the raw
-   accessor return and throws for (2).
+Why item 2 could not simply be lowered as `do { my $t = self.x; $t OP= v; $t }`,
+which would be raku's model literally: mutsu's `is rw` accessor hands back a
+*value*, not the attribute's `Scalar` container, so a throwaway temporary would
+break every `is rw` compound assign — all of which pass today. Making the accessor
+return its container is the change earlier passes of this file proposed; it is
+still the principled route, but item 2 does not require it, and nothing else in the
+measured table does either.
 
-Step 1 is the load-bearing, high-blast-radius piece; steps 3-4 are compiler
-lowering. Worth an ADR before starting.
+## Blast radius (measured when item 1 landed)
 
-## Affected files (starting point)
+Zero, in the end. Of the 138 `t/` files whose crude grep matched `$.name =`, all
+but two were `has $.x = default` declarations or `is rw` attributes. Of those two,
+`t/iterable-iterator-protocol.t:62` writes an `is rw` attribute and
+`t/imperative-does-parameterized-role.t:9` writes from a `sub` (no invocant, so
+the guard does not fire). `make test` passed unchanged.
 
-- `src/runtime/methods_mut_method_lvalue.rs` — `assign_method_lvalue_with_values`
-  (both the "not rw" rejection and the `found_public_rw` arm)
-- `src/runtime/methods_mut_dispatch.rs` — the fast public-accessor arms
-- `src/parser/stmt/assign/compound_expr.rs` — the `op=`-through-a-method lowering
-- `src/compiler/expr.rs` / `src/compiler/expr_method.rs` — where a `$.`-twigil
-  term would gain its itemization
+## Affected files
 
-## Re-verified 2026-09-01 (TRIAGE regeneration): the mutsu column moved
-
-The title's "spurious RO error" no longer happens. For a non-`rw` `has $.x =
-5` inside a method, current `main` gives:
-
-| form | raku | mutsu (2026-09-01) |
-| --- | --- | --- |
-| `$.x = 9` | throws `X::Assignment::RO` | **succeeds and mutates** (unchanged) |
-| `$.x *= 2` | silent no-op, expression value `10`, attr stays `5` | **mutates: attr becomes `10`** (was: threw "method 'x' is not rw") |
-| `self.x *= 2` | throws | throws `X::Assignment::RO: method 'x' is not rw` |
-| `$!x *= 2` | mutates | mutates |
-
-The `.VAR.^name` probes (`Scalar` / `Int` / `Int`) already match raku. Both
-halves still diverge, now as silent over-mutation rather than a throw —
-probably moved by `ffab0eb0c` ("attribute and collection container
-identity"). The "accessor read returns an itemized copy" ADR ask is unchanged.
+- `src/compiler/expr_data.rs` — `compile_expr_assign`'s `$.attr` arm (change 1)
+- `src/compiler/expr.rs:785` — the `CompoundAssign` arm (change 2, expression half)
+- `src/parser/stmt/assign/lvalue.rs`, `compound_expr.rs`, `assign_stmt.rs` —
+  carrying the `$.`-origin (change 2, statement half)
+- `src/runtime/builtins_multidim_assign.rs:621` — `builtin_assign_method_lvalue`
+- `src/runtime/methods_mut_method_lvalue.rs:1076-1092` — the rejection site


### PR DESCRIPTION
Works `todo/deep/dollar-dot-attr-compound-assign-spurious-ro-error.md` (Tier B1 in `todo/TRIAGE.md`).

## The bug

Inside a method, `$.attr = v` is not a write to the attribute slot. Raku evaluates `self.attr` and assigns to whatever that hands back, so a non-`rw` attribute hands back a bare value and the assignment dies:

```raku
class F { has $.x = 5; method m { $.x = 9 } }
F.new.m;   # raku: X::Assignment::RO: Cannot modify an immutable Int (5)
```

mutsu wrote `9` into the attribute and carried on, in statement and expression position alike. `is rw` was never consulted at all — a public accessor's read-only contract was unenforceable from inside its own class.

## Root cause

`Compiler::compile_expr_assign`'s `$.attr` arm (`src/compiler/expr_data.rs:44-59`) *does* call the accessor — but only to check that it **exists**. It emits `CallMethod`, `Pop`s the result one instruction later, and then performs an ordinary **named** assignment to the variable `.attr`, which lands on the attribute. The accessor's return value, and with it its mutability, was discarded.

The check goes in at the store (`Interpreter::check_dot_twigil_accessor_writable`, `src/vm/vm_misc_assign.rs`) rather than in the compiler, because rw-ness is a property of the *invocant's class* and only the runtime knows it. It reports raku's own wording — `Cannot modify an immutable Int (5)`, the accessor's return type and value — instead of mutsu's older `method 'x' is not rw`.

## Scoped to the `$` sigil, deliberately

Measured against raku v2026.07: for a non-`rw` `has @.a` / `has %.h`, `@.a = 7,8`, `@.a[0] = 99`, `@.a.push(3)` and `%.h<k> = 99` **all succeed**, because those accessors hand back the container itself and assigning *into* a container is a `STORE`, not a modification of an immutable value. Only the scalar accessor refuses. `t/dot-twigil-accessor-readonly.t` pins both halves plus the `is rw` and `$!` forms that must stay unaffected (12 assertions, all verified against `raku` first).

## Blast radius: measured as zero

Of the 138 `t/` files whose grep matched `$.name =`, every one is a `has $.x = default` declaration, an `is rw` attribute, or a write from a `sub` with no invocant. `make test` passes unchanged (3734 files / 38604 tests).

## The three prior diagnoses of this ticket were all wrong

Worth recording, because this file has now been deferred three times on a wrong map:

- the 2026-09-01 tail said `$.x *= 2` **mutates**;
- the 2026-09-06 TRIAGE said it **throws**;
- both are right, about **different statement positions**, and neither noticed the other.

`$.x` reaches the store through two lowerings. Expression and parenthesized positions keep `CompoundAssign { target: Var(".x"), expanded: AssignExpr { name: ".x" } }` and go through the compiler arm above (silent over-mutation). The bare-statement position is rewritten by the parser into `MethodCall { target: Var("__ANON_STATE__") }` and lowered to `__mutsu_assign_method_lvalue`, which rejects with "method 'x' is not rw". The ticket now carries the full nine-row table, measured bare and inside `try`/`CATCH`.

Earlier passes also concluded the fix required "make an `is rw` accessor return its `Scalar` container" — a change to what every accessor returns. **It does not.** Every `is rw` form and every `@.`/`%.` form already behaves correctly; the divergence is confined to the `$`-sigil non-`rw` case.

## What is left

The **compound** form is still divergent, now in the safe direction: raku silently no-ops `$.x *= 2` (the `$` sigil itemizes the bare accessor return into a throwaway `Scalar`), mutsu refuses. Before this change mutsu was *inconsistent* about it — bare statement threw, expression/paren silently over-mutated. Now all four spellings refuse, which is coherent and never loses a write. Closing the rest needs the `$.`-versus-`self.` origin to survive both lowerings, which is a parser change; the retitled ticket carries the map, including why the obvious `do { my $t = self.x; $t OP= v; $t }` desugaring would break every `is rw` compound assign.