### PR TITLE
fix(vm): a `$` bound to a non-Scalar container refuses whole-value assignment

### DIFF
--- a/news/2026-09/scalar-bind-to-a-non-scalar-container-refuses-assignment.md
+++ b/news/2026-09/scalar-bind-to-a-non-scalar-container-refuses-assignment.md
@@ -1,0 +1,65 @@
+# A `$` bound to a non-Scalar container refuses whole-value assignment
+
+Raku's rule for `$x = v` is sharper than "the thing `$x` is bound to is
+immutable": `$x` must be bound to a **Scalar** container, and no other container
+qualifies. A real `Array`, a `Hash`, a `Map` and a `Pair` all refuse the
+whole-value assignment, though every one of them is mutable through its own
+interface.
+
+mutsu accepted all of them. For the most common spelling it did worse than
+accept:
+
+```raku
+my @a = 1, 2, 3;
+my $x := @a;
+$x = 5;      # raku: X::AdHoc, "Cannot assign to an immutable value"
+say @a;      # raku never gets here; mutsu printed 5 -- @a was gone
+```
+
+All seven rows of section C of
+`todo/deep/immutable-lvalues-that-mutsu-still-lets-you-assign-to.md` now throw
+`X::AdHoc: Cannot assign to an immutable value`, matching raku's class *and* its
+wording, and `t/scalar-bind-to-non-scalar-container.t` pins them alongside the
+aliasing they must not disturb.
+
+## The fix
+
+`bind_source_is_non_scalar_container`, beside the existing
+`bind_source_has_no_container` in `vm/vm_var_assign_set_local.rs`. The two say
+different things and are gated differently, which is why they are separate
+predicates rather than one widened allowlist: the older one is about
+*immutability* and applies to any `:=`, while this one is about *which kind of
+container the name owns*.
+
+Three things decided the shape:
+
+- **Two rows never reached the immutability test at all.** `my $x := @a` and
+  `my $x := %h` carry a NAMED source, and a named bind is excluded from the
+  marking outright because it denotes another variable. They needed their own
+  arm, keyed on the source name's sigil, exactly as the survey predicted.
+- **The marking has to be restricted to a declaration.** A parameter bind reaches
+  the same store, and an `is raw` / `\x` parameter bound to an array must stay
+  assignable. Without the `is_vardecl` gate this would have refused writes raku
+  performs — the survey's standing warning that "the conservative direction is to
+  mark less" applies here too.
+- **`my $x := (a => 1)` arrives as `ValueView::ValuePair`, not
+  `ValueView::Pair`.** Matching only the latter left that one row still passing,
+  which is the kind of thing a per-row test catches and a per-family one does not.
+
+Only the whole-value `=` is refused. The aliasing these binds exist for is
+untouched, and the test pins that half explicitly: `$x.push(9)` still grows `@a`,
+`$x<b> = 2` still adds the key to `%h`, `$x[0]` still reads through, and a `$`
+bound to another `$` is still assignable and still writes through.
+
+## What is left in the survey
+
+Sections A, B, D, E and F. B is the one to read first: those rows are the
+*opposite* failure — rakudo performs the write and mutsu silently loses it — so
+they must not be "fixed" by teaching the marking to reject more. The survey's own
+"how the surviving rows differ" section records two rules that look obviously
+right for section A and were measured to break five shapes rakudo accepts; it is
+still the thing to read before designing anything there.
+
+One near-miss stays open in this family: `my $x := $(1,2,3); $x = 5` throws
+`X::AdHoc` in both, but rakudo words it "Cannot assign to a readonly variable or
+a value" where mutsu says "Cannot assign to an immutable value".

--- a/src/vm/vm_var_assign_set_local.rs
+++ b/src/vm/vm_var_assign_set_local.rs
@@ -53,6 +53,35 @@ impl Interpreter {
         }
     }
 
+    /// True when a `$`-sigil `:=` bind SOURCE is a container that is not a
+    /// **Scalar** container, so a later whole-value `$x = v` through the bound
+    /// name is rakudo's X::AdHoc "Cannot assign to an immutable value".
+    ///
+    /// rakudo's rule is sharper than "immutable": `$x = v` needs `$x` bound to a
+    /// Scalar, and no other container qualifies — a real `Array`, a `Hash`, a
+    /// `Map` and a `Pair` all refuse it, though each is mutable through its own
+    /// interface. `my $x := @a; $x = 5` is a hard error there and used to
+    /// overwrite `@a` here.
+    ///
+    /// Separate from [`bind_source_has_no_container`] because the two say
+    /// different things and are gated differently. That one is about
+    /// immutability and applies to any `:=`; this one is about *which kind of
+    /// container the name owns*, and its caller restricts it to a DECLARATION —
+    /// a parameter bind reaches the same store, and an `is raw` / `\x`
+    /// parameter bound to an array must stay assignable.
+    ///
+    /// The aliasing these binds exist for is untouched: only the whole-value
+    /// `=` is refused, so `$x.push(9)`, `$x<k> = 2` and `$x[0]` keep working.
+    fn bind_source_is_non_scalar_container(v: &Value) -> bool {
+        matches!(
+            v.view(),
+            ValueView::Array(..)
+                | ValueView::Hash(_)
+                | ValueView::Pair(..)
+                | ValueView::ValuePair(..)
+        )
+    }
+
     /// If `name` is a raw `\target` bound to a multi-dim slice lvalue (marked at
     /// bind time by `is_multidim_slice_cells`) whose current value `holder` is a
     /// non-empty list of `ContainerRef` cells, distribute `rhs` element-wise
@@ -598,6 +627,24 @@ impl Interpreter {
         let bind_marks_immutable = scalar_bind
             && (bind_source.is_none() || synthetic_index_source)
             && Self::bind_source_has_no_container(&raw_popped);
+        // The other half of rakudo's rule: `$x = v` needs `$x` bound to a
+        // SCALAR container, and a `Hash`/`Map`/`Pair`/real `Array` is not one
+        // even though each is mutable through its own interface
+        // (`todo/deep/immutable-lvalues-that-mutsu-still-lets-you-assign-to.md`
+        // section C). Two source shapes reach it: an unnamed container value
+        // (`my $x := [1,2,3]`, `{a=>1}`, `Map.new(...)`, `(a => 1)`), and a
+        // NAMED `@`/`%` source (`my $x := @a`), which the immutability test
+        // above excludes outright because a named bind denotes another
+        // variable. Restricted to a DECLARATION: a parameter bind reaches this
+        // same store, and an `is raw` / `\x` parameter bound to an array must
+        // stay assignable.
+        let bind_marks_non_scalar_container = is_vardecl
+            && scalar_bind
+            && (((bind_source.is_none() || synthetic_index_source)
+                && Self::bind_source_is_non_scalar_container(&raw_popped))
+                || bind_source
+                    .as_deref()
+                    .is_some_and(|n| n.starts_with(['@', '%'])));
         // The same "a `:=` bind to a VALUE, not to another name" test as
         // `bind_marks_immutable`, minus the immutability allowlist: `my $o :=
         // C.new` binds `$o` straight to the object, so `$o` owns no Scalar
@@ -785,7 +832,7 @@ impl Interpreter {
         // bare name. A `$` name bound straight to a literal has no container of
         // its own, so rakudo's assignment error is X::AdHoc "Cannot assign to
         // an immutable value".
-        if bind_marks_immutable {
+        if bind_marks_immutable || bind_marks_non_scalar_container {
             let bare = code.locals[idx]
                 .trim_start_matches(['$', '@', '%', '&'])
                 .to_string();

--- a/t/scalar-bind-to-non-scalar-container.t
+++ b/t/scalar-bind-to-non-scalar-container.t
@@ -1,0 +1,70 @@
+use Test;
+
+# rakudo's rule for `$x = v` is sharper than "the bound thing is immutable":
+# `$x` must be bound to a **Scalar** container, and no other container
+# qualifies. A real `Array`, a `Hash`, a `Map` and a `Pair` all refuse the
+# whole-value assignment, though every one of them is mutable through its own
+# interface.
+#
+# mutsu accepted all of them, and for `my $x := @a` it did not merely accept the
+# assignment -- it overwrote `@a` with the scalar.
+#
+# Only the whole-value `=` is refused. The aliasing these binds exist for
+# (`$x.push`, `$x<k> = v`, `$x[0]`) is what they are for and must keep working;
+# the last block below is the guard for that.
+
+plan 13;
+
+sub throws-ro(&c, $why) {
+    my $threw = False;
+    { c(); CATCH { when X::AdHoc { $threw = .Str eq 'Cannot assign to an immutable value' } } }
+    ok $threw, $why;
+}
+
+throws-ro { my @a = 1, 2, 3; my $x := @a; $x = 5 },
+    'a $ bound to a named @ refuses whole-value assignment';
+throws-ro { my %h = a => 1; my $x := %h; $x = 5 },
+    'a $ bound to a named % refuses whole-value assignment';
+throws-ro { my @a := (1, 2, 3); my $x := @a; $x = 5 },
+    'a $ bound to a name that is itself bound to a List refuses it';
+throws-ro { my $x := [1, 2, 3]; $x = 5 },
+    'a $ bound to an Array literal refuses it';
+throws-ro { my $x := {a => 1}; $x = 5 },
+    'a $ bound to a Hash literal refuses it';
+throws-ro { my $x := Map.new((a => 1)); $x = 5 },
+    'a $ bound to a Map refuses it';
+throws-ro { my $x := (a => 1); $x = 5 },
+    'a $ bound to a parenthesized Pair refuses it';
+throws-ro { my $x := a => 1; $x = 5 },
+    'a $ bound to a bare Pair refuses it';
+
+# The `@a` row is the one that lost data rather than merely permitting a write.
+{
+    my @a = 1, 2, 3;
+    my $x := @a;
+    { $x = 5; CATCH { default { } } }
+    is @a, [1, 2, 3], 'the refused assignment leaves the aliased array intact';
+}
+
+# What must keep working: these binds exist for aliasing.
+{
+    my @a = 1, 2, 3;
+    my $x := @a;
+    $x.push(9);
+    is @a, [1, 2, 3, 9], 'a mutating method through the alias still writes through';
+    is $x[0], 1, 'an element read through the alias still works';
+}
+{
+    my %h = a => 1;
+    my $x := %h;
+    $x<b> = 2;
+    is %h.keys.sort, ('a', 'b'), 'an element store through the alias still works';
+}
+
+# A `$` bound to an ordinary scalar keeps its own Scalar container.
+{
+    my $src = 1;
+    my $x := $src;
+    $x = 5;
+    is $src, 5, 'a $ bound to another $ is still assignable, and writes through';
+}

--- a/todo/deep/immutable-lvalues-that-mutsu-still-lets-you-assign-to.md
+++ b/todo/deep/immutable-lvalues-that-mutsu-still-lets-you-assign-to.md
@@ -11,6 +11,9 @@ top of the closure-topic fix (`news/2026-09/closure-and-map-grep-topic-readonly.
 
 Closed since the survey opened:
 
+- **section C in full (2026-09-06)** — a `$` bound to a non-Scalar container now
+  refuses whole-value assignment:
+  `news/2026-09/scalar-bind-to-a-non-scalar-container-refuses-assignment.md`;
 - the element-store and `:=`-bind halves —
   `news/2026-09/immutable-element-store-and-bind.md`;
 - the closure/map/grep topic family (`(1,2).map({$_=5})`,
@@ -29,7 +32,8 @@ one is a method-call-path gap rather than a store-path gap, and it belongs to
 ADR-0067's L4/L5/M1/M2 readonly-enforcement rows.
 
 Section B below was re-measured on **2026-09-06**: all seven rows still diverge
-exactly as recorded.
+exactly as recorded. Section C was re-measured the same day (all seven rows
+diverged) and then closed; sections A, B, D, E and F are what is left.
 
 **Read the "how the surviving rows differ" section below before designing
 anything**: two successive stated blockers for the closure-topic rows (first
@@ -109,34 +113,34 @@ tracks partially in `scalar_bind_*`), or section B is closed first — once an
 element really is a cell, `is_container_ref()` becomes a sound oracle for both.
 Closing B first is the architecturally cleaner order.
 
-### C. A `$` bind of a MUTABLE container is still assignable
+### C. A `$` bind of a MUTABLE container is still assignable — **CLOSED 2026-09-06**
+
+`news/2026-09/scalar-bind-to-a-non-scalar-container-refuses-assignment.md`,
+pinned by `t/scalar-bind-to-non-scalar-container.t`.
 
 rakudo's rule is sharper than "immutable": `$x = v` needs `$x` bound to a
 **Scalar** container, and no other container qualifies — a real `Array`, a
 `Hash`, a `Map` and a `Pair` all refuse it, though each is mutable through its
-own interface.
+own interface. All seven rows now throw `X::AdHoc: Cannot assign to an immutable
+value`, matching raku's class and wording, and the `my $x := @a` row no longer
+silently overwrites `@a`.
 
-```
-my @a = 1,2,3; my $x := @a;        $x = 5     # raku: X::AdHoc; mutsu: OK, @a becomes 5
-my $x := [1,2,3];                  $x = 5     # raku: X::AdHoc; mutsu: OK
-my @a := (1,2,3); my $x := @a;     $x = 5     # raku: X::AdHoc; mutsu: OK
-my $x := {a=>1};                   $x = 5     # raku: X::AdHoc; mutsu: OK
-my $x := Map.new((a=>1));          $x = 5     # raku: X::AdHoc; mutsu: OK
-my $x := (a => 1);                 $x = 5     # raku: X::AdHoc; mutsu: OK
-```
+The fix is `bind_source_is_non_scalar_container` beside the existing
+`bind_source_has_no_container` (`vm/vm_var_assign_set_local.rs`). Two things the
+file predicted correctly and one it did not:
 
-Deliberately left out of the 2026-09-05 element-store fix, which extended
-`bind_source_has_no_container`'s allowlist only to immutable Positionals. Two of
-these rows (`my $x := @a`, `my $x := %h`) do not even reach that decision — a
-bind whose RHS is a simple variable carries a NAMED source and is excluded from
-the marking outright — so closing this family means deciding what a named
-`@`/`%` source should imply for a `$` target, not just widening a match arm. The
-`$x.push(...)` aliasing those binds exist for must keep working; only the
-whole-value `=` is refused.
+- the two named-source rows (`my $x := @a`, `my $x := %h`) really do not reach
+  the immutability test, and needed their own arm keyed on the source name's
+  sigil;
+- the marking has to be restricted to a **declaration**. A parameter bind reaches
+  the same store, and an `is raw` / `\x` parameter bound to an array must stay
+  assignable;
+- `my $x := (a => 1)` arrives as `ValueView::ValuePair`, not `ValueView::Pair`,
+  so matching only the latter left that row passing.
 
-One near-miss in the same family: `my $x := $(1,2,3); $x = 5` throws `X::AdHoc`
-in both, but rakudo words it "Cannot assign to a readonly variable or a value"
-where mutsu says "Cannot assign to an immutable value".
+One near-miss remains: `my $x := $(1,2,3); $x = 5` throws `X::AdHoc` in both, but
+rakudo words it "Cannot assign to a readonly variable or a value" where mutsu
+says "Cannot assign to an immutable value".
 
 ### D. A `gather` sequence's element store
 


### PR DESCRIPTION
Closes **section C** of `todo/deep/immutable-lvalues-that-mutsu-still-lets-you-assign-to.md` (Tier B1 in `todo/TRIAGE.md`, which says to *mine that file for rows rather than dispatch it whole* — this is one such row).

## The bug

Raku's rule for `$x = v` is sharper than "the thing `$x` is bound to is immutable": `$x` must be bound to a **Scalar** container, and no other container qualifies. A real `Array`, a `Hash`, a `Map` and a `Pair` all refuse the whole-value assignment, though every one of them is mutable through its own interface.

mutsu accepted all of them. For the most common spelling it did worse than accept:

```raku
my @a = 1, 2, 3;
my $x := @a;
$x = 5;      # raku: X::AdHoc, "Cannot assign to an immutable value"
say @a;      # raku never gets here; mutsu printed 5 — @a was gone
```

All seven rows now throw `X::AdHoc: Cannot assign to an immutable value`, matching raku's class **and** its wording. Re-measured against `raku` v2026.07 before and after.

## The fix

`bind_source_is_non_scalar_container`, beside the existing `bind_source_has_no_container` in `vm/vm_var_assign_set_local.rs`. They stay two predicates rather than one widened allowlist because they say different things and are gated differently: the older one is about *immutability* and applies to any `:=`; this one is about *which kind of container the name owns* and applies only to a declaration.

Three things decided the shape, two of which the survey predicted and one it did not:

- **Two rows never reached the immutability test.** `my $x := @a` and `my $x := %h` carry a NAMED source, and a named bind is excluded from the marking outright because it denotes another variable. They needed their own arm, keyed on the source name's sigil.
- **The marking has to be restricted to a declaration.** A parameter bind reaches the same store, and an `is raw` / `\x` parameter bound to an array must stay assignable. Without the `is_vardecl` gate this would refuse writes raku performs — the survey's standing warning that "the conservative direction is to mark less" applies here too.
- **`my $x := (a => 1)` arrives as `ValueView::ValuePair`, not `ValueView::Pair`.** Matching only the latter left that one row still passing — the kind of thing a per-row test catches and a per-family one does not.

## Only the whole-value `=` is refused

The aliasing these binds exist for is exactly why they exist, and `t/scalar-bind-to-non-scalar-container.t` (13 assertions, every expectation run against `raku` first) pins that half explicitly: `$x.push(9)` still grows `@a`, `$x<b> = 2` still adds the key to `%h`, `$x[0]` still reads through, a `$` bound to another `$` is still assignable and still writes through, and the refused assignment leaves the aliased array intact.

`make test` passes (3736 files / 38662 tests). Full roast delegated to CI.

## What is left in that survey

Sections A, B, D, E and F. B is the one to read first: those rows are the *opposite* failure — rakudo performs the write and mutsu silently loses it — so they must not be "fixed" by teaching the marking to reject more. One near-miss stays open here too: `my $x := $(1,2,3); $x = 5` throws `X::AdHoc` in both, but rakudo words it "Cannot assign to a readonly variable or a value".