### PR TITLE
test(mop): pin `.^add_method`, and re-scope its ticket away from new_type

### DIFF
--- a/t/add-method-named-routine.t
+++ b/t/add-method-named-routine.t
@@ -1,0 +1,92 @@
+use Test;
+
+# `.^add_method(name, $code)` must install a callable method whatever shape the
+# code object arrives in. In mutsu it silently installs an EMPTY one whenever
+# `$code` is a NAMED, separately-declared routine: the method is registered
+# (`.^can`, `.^lookup`, `.^methods`, its `.name` and `.signature` are all
+# right), and calling it returns `Nil` with no error.
+#
+# `todo/deep/direct-metamodel-classhow-new-type-immutable-error.md` recorded
+# this as "a method-dispatch gap on a `new_type`-minted Package". Measured
+# 2026-09-06 against raku v2026.07, it has nothing to do with `new_type`: an
+# ordinary `class C { }` shows it identically, and what actually decides the
+# outcome is whether the code object is anonymous or a named declaration.
+#
+# The value itself is fine -- calling the same `my method m() { 42 }` directly
+# through its variable returns 42. `add_method` builds its `MethodDef` from the
+# Sub's AST `body` plus `compiled_code`, and a Sub built from a DECLARED routine
+# carries its bytecode in `compiled_routine` instead (ADR-0019 C6c stopped the
+# declaration plan shipping an executable AST), which `MethodDef` has no field
+# for.
+
+plan 10;
+
+# What already works: every anonymous shape.
+{
+    class A1 { }
+    A1.^add_method('m', method () { 1 });
+    A1.^compose;
+    is A1.m(), 1, 'an anonymous `method` installs and runs';
+}
+{
+    class A2 { }
+    A2.^add_method('m', my method () { 2 });
+    A2.^compose;
+    is A2.m(), 2, 'an anonymous `my method` installs and runs';
+}
+{
+    class A3 { }
+    A3.^add_method('m', anon method m3() { 3 });
+    A3.^compose;
+    is A3.m(), 3, 'an `anon method` with a name installs and runs';
+}
+{
+    class A4 { }
+    A4.^add_method('m', -> $s { 4 });
+    A4.^compose;
+    is A4.m(), 4, 'a pointy block installs and runs';
+}
+
+# Registration is right even for the shapes that do not run.
+{
+    class A8 { }
+    A8.^add_method('m', my method m8() { 8 });
+    A8.^compose;
+    is A8.^can('m').elems, 1, 'a named `my method` IS registered';
+    ok A8.^lookup('m').defined, 'and IS findable by lookup';
+}
+
+# What does not run.
+{
+    class A5 { }
+    A5.^add_method('m', my method m5() { 5 });
+    A5.^compose;
+    todo 'a named `my method` installs an empty body';
+    is A5.m(), 5, 'a named `my method` installs and runs';
+}
+{
+    class A6 { }
+    A6.^add_method('m', my method m6(A6:) { 6 });
+    A6.^compose;
+    todo 'same mechanism; the type invocant is not what breaks it';
+    is A6.m(), 6, 'a named `my method` with a type invocant installs and runs';
+}
+{
+    # The doc's own MOP example (`Language/mop.rakudoc`), which is what the
+    # ticket was filed from. It is the row above, not a `new_type` problem.
+    constant A7 := Metamodel::ClassHOW.new_type(name => 'A7');
+    A7.^add_method('m', my method m7(A7:) { 7 });
+    A7.^compose;
+    todo 'same mechanism, reached through a hand-minted type';
+    is A7.m(), 7, 'the MOP example from Language/mop.rakudoc runs';
+}
+
+# A smaller, separate divergence measured alongside: the installed method keeps
+# the name it was ADDED under, where raku keeps the routine's own name.
+{
+    class A9 { }
+    A9.^add_method('m', my method m9() { 9 });
+    A9.^compose;
+    todo 'mutsu reports the added name, raku the routine name';
+    is A9.^lookup('m').name, 'm9', 'lookup reports the routine name';
+}

--- a/todo/deep/direct-metamodel-classhow-new-type-immutable-error.md
+++ b/todo/deep/direct-metamodel-classhow-new-type-immutable-error.md
@@ -1,8 +1,78 @@
-# `constant NAME := Metamodel::ClassHOW.new_type(name => 'NAME')` immediately errors as "immutable"
+# `.^add_method` installs an EMPTY method when given a named, separately-declared routine
 
 Found by the doc-diff harness (`docs/doc-diff-backlog.md`, `Language/mop.rakudoc:34` —
 the doc's own worked example showing what a `class A { ... }` declaration desugars to
 at the metaobject-protocol level).
+
+> **Re-measured 2026-09-06 and re-scoped.** Two earlier framings of this file are
+> now closed or wrong: the "immutable type object" error was fixed 2026-08-26 (see
+> the UPDATE below), and the survivor was recorded as "a method-dispatch gap on a
+> `new_type`-minted Package". It is not about `new_type` at all — an ordinary
+> `class C { }` shows it identically. The oracle is checked in as
+> `t/add-method-named-routine.t` (10 rows, all 10 green under `raku`, 6 green
+> under mutsu and 4 `todo`). Run that file rather than re-deriving the matrix.
+
+## What is actually wrong (measured 2026-09-06, raku v2026.07)
+
+`.^add_method(name, $code)` installs a method whose **body is empty** whenever
+`$code` is a NAMED, separately-declared routine. It works for every anonymous
+shape:
+
+| code object passed to `.^add_method` | raku | mutsu |
+|---|---|---|
+| `method () { 1 }` | 1 | 1 |
+| `my method () { 2 }` | 2 | 2 |
+| `anon method m3() { 3 }` | 3 | 3 |
+| `-> $s { 4 }` | 4 | 4 |
+| **`my method m5() { 5 }`** | 5 | **Nil** |
+| **`my method m6(A6:) { 6 }`** | 6 | **Nil** |
+| **`my sub a() { … }` / `&topsub`** | (raku rejects the arity) | **Nil** |
+
+The failure is silent. The method is genuinely registered — `.^can` finds it,
+`.^lookup` returns a defined Method, `.^methods` counts it, and its `.name` and
+`.signature` read back plausibly — the call just returns `Nil`.
+
+And the code object itself is fine: calling the very same
+`my $m = my method m() { 42 }` through `$m()` returns `42`. So `add_method`
+drops the body; the producer does not.
+
+## Root cause
+
+`add_method` (`src/runtime/methods_classhow_dispatch.rs`, the `"add_method"` arm)
+builds its `MethodDef` from the Sub's AST `body` plus `sub_data.compiled_code`.
+A Sub built from a **declared routine** — `&foo`, a `.candidates` entry, a
+`my sub`/`my method` read back through `GetCodeVar` — carries its bytecode in
+`SubData::compiled_routine` instead, and `SubData`'s own doc says why: ADR-0019
+C6c stopped the sub declaration plan shipping an executable AST, and
+`compiled_routine` is kept deliberately SEPARATE from `compiled_code` because
+the two are invoked under different calling conventions
+(`CompiledFunction::param_local_slots` / `named_call_plan` versus
+`call_compiled_closure`'s upvalue alignment).
+
+`MethodDef` has no `compiled_routine` field. So the def gets an empty body and
+no code, and dispatch answers `Nil`.
+
+This is visible in the bytecode: a named `my method a() { 42 }` in expression
+position compiles to `RegisterDecl(0); GetCodeVar("a")` and a separate
+`sub GLOBAL::a` chunk, where the anonymous form compiles to a single
+`MakeAnonSubParams` that carries the body with it.
+
+## What the fix has to decide
+
+Either `MethodDef` gains a `compiled_routine` and the method-dispatch entry
+learns to invoke routine bytecode under the method calling convention (the
+invocant has to be bound as the routine's first positional), or `add_method`
+converts a routine-backed Sub into a closure-backed one at registration time.
+The first keeps one representation per code object; the second keeps dispatch
+unchanged. Worth an ADR only if the first is chosen, since it widens what a
+`MethodDef` can hold.
+
+Whatever lands must keep the four anonymous rows working — they are the shapes
+the batteries actually use — and should also fix the smaller divergence measured
+beside them: mutsu's installed method reports the name it was ADDED under
+(`m`), where raku reports the routine's own name (`m9`).
+
+## Original report (the "immutable" error, fixed 2026-08-26)
 
 ## Repro
 


### PR DESCRIPTION
Re-scopes `todo/deep/direct-metamodel-classhow-new-type-immutable-error.md`. **Tests and documentation only — no interpreter change.**

## The ticket's surviving diagnosis was wrong

It had been narrowed to "a method-dispatch gap on a `new_type`-minted `Package`". Measured against `raku` v2026.07, it has **nothing to do with `new_type`** — an ordinary `class C { }` shows it identically.

What actually decides the outcome is the **shape of the code object**:

| passed to `.^add_method` | raku | mutsu |
|---|---|---|
| `method () { 1 }` | 1 | 1 |
| `my method () { 2 }` | 2 | 2 |
| `anon method m3() { 3 }` | 3 | 3 |
| `-> $s { 4 }` | 4 | 4 |
| **`my method m5() { 5 }`** | 5 | **Nil** |
| **`my method m6(A6:) { 6 }`** | 6 | **Nil** |
| **`my sub a() {...}` / `&topsub`** | (raku rejects the arity) | **Nil** |

Every *anonymous* shape works; a **named, separately-declared routine** installs a method whose body is empty.

The failure is silent, which is what makes it nasty: the method is genuinely registered — `.^can` finds it, `.^lookup` returns a defined `Method`, `.^methods` counts it, and its `.name` and `.signature` read back plausibly — and the call just answers `Nil`. The code object itself is fine: calling the very same `my $m = my method m() { 42 }` through `$m()` returns `42`, so `add_method` drops the body rather than the producer handing it a bad one.

## Root cause

`add_method` builds its `MethodDef` from the Sub's AST `body` plus `compiled_code`. A Sub built from a **declared routine** carries its bytecode in `SubData::compiled_routine` instead — kept deliberately separate, because the two are invoked under different calling conventions (`CompiledFunction::param_local_slots` / `named_call_plan` versus `call_compiled_closure`'s upvalue alignment), and ADR-0019 C6c stopped the sub declaration plan shipping an executable AST at all. `MethodDef` has no field for it, so the def gets an empty body and no code.

Visible straight from `--dump-bytecode`: the named form compiles to `RegisterDecl(0); GetCodeVar("a")` plus a separate `sub GLOBAL::a` chunk, while the anonymous form compiles to a single `MakeAnonSubParams` that carries the body with it.

## The deliverable

`t/add-method-named-routine.t` — 10 rows, all 10 green under `raku`, 6 green under mutsu with 4 `todo`. It pins the four anonymous shapes that already work (the ones the batteries actually use) so they cannot regress while the rest is fixed, and it records a smaller divergence measured beside them: mutsu's installed method reports the name it was **added under** (`m`), where raku reports the routine's own name (`m9`).

The ticket is retitled, given the measured table and the root cause, and states the decision the fix has to make — give `MethodDef` a `compiled_routine` and teach method dispatch to bind an invocant into routine bytecode, or convert a routine-backed Sub into a closure-backed one at registration time.