### PR TITLE
feat(seq): .map produces a deferred Seq (ADR-0058 step 2)

### DIFF
--- a/docs/adr/0058-map-grep-produce-a-deferred-seq.md
+++ b/docs/adr/0058-map-grep-produce-a-deferred-seq.md
@@ -1,6 +1,6 @@
 # ADR-0058: `.map`/`.grep` produce a deferred `Seq` — the callback runs at first consumption, not at the call
 
-- **Status**: Proposed
+- **Status**: Accepted (step 2 shipped 2026-09-07; steps 3-4 open)
 - **Date**: 2026-08-22
 - **Deciders**: tokuhirom, Claude
 - **Related**: [ADR-0034](0034-seq-reification-is-in-place-and-distinct-from-consumption.md)
@@ -268,7 +268,7 @@ callback `Value` already carries its own closure environment.
 | --- | --- | --- |
 | **0** | **Measure the read-path exposure** by flipping `dispatch_map_method`/`builtin_map` to always call `create_lazy_map_list` behind a temporary env gate, and running `t/` and the roast whitelist with it on. This is option 3's exposure without option 3's cost, and it produces the list of consumers that read a deferred sequence without forcing it. | Discard the gate afterwards; it is a measurement, not a slice. |
 | **1** | **Done (2026-08-22).** `t/map-callback-runs-at-consumption.t` — 23 rows, raku-verified 23/23, mutsu 12 passing and 11 `todo`. Un-`todo`ing the nine ADR-0058 rows is this ADR's completion signal; the other two `todo`s belong to §1.4's separate bug. | Same shape as ADR-0034 phase 1. |
-| **2** | Add `SeqSource::MapGrep` + the `pull_seq_source` arm + `Value::seq_deferred` construction in `dispatch_map_method` only (not `builtin_map`, not `grep`). Fix the consumers step 0 found. | `map` method form alone is enough to un-`todo` most of phase 1. |
+| **2** | **Done (2026-09-07).** `SeqSource::MapGrep` + the `pull_seq_source` arm + `Value::seq_deferred` construction in `dispatch_map_method` only (not `builtin_map`, not `grep`), plus the read-path consumers S8 lists. | All nine ADR-0058 rows of phase 1's oracle are un-`todo`d; the two remaining `todo`s are S1.4's separate bug. |
 | **3** | Extend to `builtin_map` (the `map &f, @xs` function form) and to both `grep` entry points. `grep`'s `:k`/`:kv`/`:p` adverbs need positional indices over the whole result and can stay eager, exactly as they already opt out of `make_lazy_pipe`. | |
 | **4** | Retire the `body_contains_return` / `is_stub_routine_body` deferral predicate and `create_lazy_map_list` — both become dead once every map defers. | The maintainability payout. |
 
@@ -353,3 +353,124 @@ make roast      # mandatory: this makes mutsu STRICTER in every ticket cell
   keeps growing one observable-eagerness bug at a time, and `map` keeps being
   the one core operation whose laziness mutsu decides by grepping the callback's
   AST.
+
+---
+
+## 8. Outcome of step 2 (2026-09-07)
+
+### 8.1 What step 0 actually measured
+
+The §4 step-0 probe was run as specified — `dispatch_map_method`/`builtin_map`
+flipped to always call `create_lazy_map_list` behind a throwaway
+`MUTSU_ADR0058_STEP0` env gate — against a current `main` build:
+
+| Suite | Files failing under the gate |
+| --- | --- |
+| `prove -j4 t/` (3735 files) | **59** |
+| roast whitelist, release binary (1436 files) | **55** |
+
+**The proxy over-reported, and its excess was systematic, not random.** Roughly
+half the `t/` hits were the `concurrent-*`/`thread-*`/`cas-*`/`shared-*` family,
+which fail under option 1 for a reason option 3 does not have: §3.2's
+per-`map` `let mut env = self.env.clone()` **snapshots** the captured lexicals,
+so a shared cell mutated by a `start` block inside the callback is lost. The
+real `SeqSource::MapGrep` implementation reuses the callback `Value`'s own
+closure environment and none of those files ever failed. Under the real
+mechanism the first full `t/` run showed **44** failures, converging to 0.
+
+So step 0's value was **not** the count: it was confirming that the exposure is
+a *bounded, enumerable list of element readers* rather than an open-ended one,
+and that the failures cluster into a handful of funnels. Recommendation for a
+future slice: run the exposure probe with the mechanism you intend to ship
+(behind an env gate), not with a proxy — the proxy's own defects dominate the
+signal, and the extra cost is zero because the mechanism has to be written
+anyway.
+
+### 8.2 The read-path consumers step 2 had to fix
+
+`Interpreter::reify_map_grep_seq` / `_args` / `sink_map_grep_seq`
+(`vm/vm_helpers_lazy.rs`) are the guard; they are tag-probed (`is_seq_value()`
+before `view()`, because `view()` on a lazy `Match` materializes it — ADR-0016
+P5) and no-op for every other `SeqSource`, whose streaming semantics must **not**
+be forced at an argument boundary. Call sites, by funnel:
+
+- **Argument boundaries** (a native/builtin reads elements as plain Rust
+  values): `Interpreter::call_function` (gated on `is_builtin_function`),
+  `try_native_function`, `try_native_method` (arguments only — the receiver is
+  ADR-0034's job), `exec_call_method_mut` args, `call_compiled_closure`
+  (a slurpy/`@_` parameter *flattens* a Seq), `call_sub_value`, `builtin_await`.
+- **Rendering / coercion**: `exec_say_op`/`note`/`put`/`print`,
+  `exec_str_coerce_op`, `exec_num_coerce_op`, `coerce_stringy_operand`.
+- **Operators**: `eval_binary_with_junctions` (the shared binary funnel),
+  `exec_meta_op` + `zip_iter_from_value` (`Z`/`X`), `exec_reduction_op`
+  (`[+] @xs.map(...)`), `set_contains` (`(elem)`), `vm_smart_match`.
+- **Assignment**: `SetGlobal` and `AssignExpr`/`AssignExprLocal` for an `@`/`%`
+  target (the `my @a = SEQ` reify already existed only on `SetLocal`), and
+  `IndexAssignExprNamed` **for a slice index only** — a single-element store
+  itemizes the Seq into that element's Scalar container and stays unforced
+  (measured: `my %h; %h<f> = (1..3).map({die}); say "alive"` prints "alive" in
+  raku, while `@n[0,1] = (1,2).map({...})` is eager,
+  `roast/S32-list/seq.t` #18). For the same reason `SinkPopAssign` no longer
+  sinks a `MapGrep` body at all.
+- **Composition / hyper**: the `__mutsu_compose_left/right` relay, the
+  `hyper_race_wrap` re-wrap for a >=1000-element `HyperSeq.map`, and the
+  per-element result push in `exec_hyper_method_call_op`.
+- **`Test` handlers that discard a block's value**: rakudo's `dies-ok`,
+  `lives-ok` and `throws-like` write `$code();` as a *statement*, so the block's
+  Seq is **sunk** and the callback's exception escapes. mutsu calls the block
+  natively and dropped the value, so those three now call `sink_map_grep_seq`
+  explicitly.
+- **The program's own tail statement** (`runtime/run.rs`), next to the existing
+  `LazyList` drain — `(1,2,3).map({ die "oh noes" })` as a whole program must
+  die (`roast/integration/weird-errors.t` #18).
+- **`flatmap`**, which is implemented as `.map(...)` plus a pure flatten.
+- **`ApplyVarTrait`**: `my %r is SetHash = %h.map: {...}` binds the Seq into the
+  slot *before* the trait runs (the declaration emits `MarkBindContext;
+  SetLocal`, which skips `exec_set_local_op_inner`'s `@`/`%` reify), and the
+  QuantHash coercion reads the elements purely.
+
+### 8.3 Premises that did not survive contact with the code
+
+- **§4's step-0 recipe is a proxy, and a lossy one** — see §8.1.
+- **`SeqBody::take` does not store what it pulls.** §3.4 assumed the existing
+  reify/consume machinery would cover the new source "for free". It does for
+  `reify`, but `take` on a genuinely deferred source hands the elements to the
+  caller and leaves `gens` empty — and two consumers (`.iterator`'s arm in
+  `reify_or_consume_seq_target_inner`, and `exec_hyper_method_call_op`) call
+  `take` and then read the *same body* back through `Deref`. That was a latent
+  ADR-0034 bug, invisible while only `IO::Handle.lines` produced deferred
+  bodies; `SeqBody::store_taken_elements` fixes it without reviving the source.
+  It is what made `method iterator() { self.pairs.iterator }` in a
+  `does Iterable` role iterate nothing.
+- **`use fatal` is lexical, so it cannot be read at pull time.**
+  `eval_map_over_items` consults `self.fatal_mode`; deferring the loop moved
+  that read from the `.map` call site to the *consumer's* dynamic context, which
+  retroactively made a soft Failure fatal (`t/try-fatal-does-not-retroactively-flag-closure-seq.t`)
+  and stopped a genuinely fatal one from throwing
+  (`t/whatever-code-fixes.t`). `SeqSource::MapGrep` therefore carries a `fatal`
+  field captured at the `.map` call and restored around the pull.
+- **A deferred body needs the same caller writeback a `LazyList` force does.**
+  The pull is the effective call site for the callbacks it runs, so it must call
+  `reconcile_caller_after_lazy_force` exactly as `force_lazy_list_vm` does, or a
+  captured-outer lexical the callback mutated (`LAST $ran = True`, `$count++`)
+  never reaches the consuming frame's local slot.
+- **`has_deferred_source()` must NOT include `MapGrep`.** Every call site of that
+  predicate reads it as "single-use, steal it" — most visibly
+  `reify_or_consume_seq_target_inner`'s `"list"` arm, whose entire compromise is
+  that a `.map`/`.grep` result stays re-readable through `@$s`
+  (`t/seq-array-context-reiterate.t`). `MapGrep` is deferred in *when the
+  callback runs*, not in whether the result is re-readable.
+- **A Seq read out of an `@`/`%` element arrives wrapped.** ADR-0040 itemizes it
+  into a `Value::Scalar` box, so `reify_or_consume_seq_target_inner`'s
+  `ValueView::Seq` match missed it entirely and `%h<k>.elems` answered 0. That
+  function now looks through a `Scalar`/`ContainerRef` wrapper.
+
+### 8.4 Known remaining holes (deliberately not closed here)
+
+The infallible set operators (`exec_set_diff_op`, `exec_set_sym_diff_op`,
+`exec_set_subset_op`/`superset`/`strict_*`) read their operands through pure
+code and cannot propagate a callback's exception without a signature change;
+they still read an unpulled `MapGrep` body's empty seed. `set_contains`
+(`(elem)`/`(cont)`) is fixed but has to swallow a throwing callback for the same
+reason. No test in `t/` or the roast whitelist exercises the remaining ones;
+step 3 (which makes `grep` deferred too) should revisit them.

--- a/news/2026-09/map-produces-a-deferred-seq.md
+++ b/news/2026-09/map-produces-a-deferred-seq.md
@@ -1,0 +1,58 @@
+# `.map` produces a deferred `Seq`: the callback runs at first consumption
+
+[ADR-0058](../../docs/adr/0058-map-grep-produce-a-deferred-seq.md) step 2 shipped.
+`.map` (the method form, `dispatch_map_method`) no longer runs its callback at
+the call: it hands back a `Seq` whose `SeqSource::MapGrep { items, func, fatal }`
+body runs the callback the first time something consumes the sequence, through
+ADR-0034's existing `reify`/`take`/`sink` split. That is rakudo's timing, and it
+closes the whole "residual try-cell" divergence family in one move:
+
+```raku
+try { (1..3).map({die "boom"}) }; say "alive ", $!.defined
+# before: alive True     after (and raku): dies, uncaught
+my $s = (1..3).map({ say "side $_"; $_ }); say "before"; say $s.List;
+# before: side 1/2/3 then "before"     after (and raku): "before" first
+```
+
+Nine of the eleven `todo` rows in `t/map-callback-runs-at-consumption.t` — the
+ADR's completion oracle, raku-verified 23/23 — are now un-`todo`d. The two that
+remain belong to a separate, narrower bug (a force-time `fail` under an
+enclosing `try` returning a `Failure` instead of throwing), still tracked in
+`todo/deep/residual-try-cell-eager-seq-reification-divergences.md`.
+
+The interesting half of the work was the read path. ADR-0034 §2.1 deliberately
+made a `SeqBody` read through `Deref` return the *empty seed* for a body nobody
+has pulled, so a read can never re-enter the VM — safe while deferred bodies
+were a rare `IO::Handle.lines` corner, and load-bearing the moment every `.map`
+became one. `Interpreter::reify_map_grep_seq`/`_args`/`sink_map_grep_seq` are
+the new guard (tag-probed before `view()`, and a no-op for every other
+`SeqSource`, whose streaming semantics must not be forced at an argument
+boundary); ADR-0058 §8.2 lists every call site by funnel — argument boundaries,
+rendering and coercion, operators, `@`/`%` assignment, composition and hyper,
+the `Test` handlers that discard a block's value, and the program's own tail
+statement.
+
+Three of the ADR's own premises did not survive contact with the code, and each
+turned out to be a real bug rather than a detail (ADR-0058 §8.3): `SeqBody::take`
+never stored what it pulled, so `.iterator` and the hyper dispatch read the same
+body back through `Deref` and got nothing — a latent ADR-0034 bug that made
+`method iterator() { self.pairs.iterator }` in a `does Iterable` role iterate
+zero elements; `use fatal` is lexical, so deferring the loop moved that read
+from the `.map` call site to the consumer's dynamic context and both created and
+suppressed exceptions (the source now captures `fatal` at the call); and the
+pull is the effective call site for the callbacks it runs, so it has to drain
+`reconcile_caller_after_lazy_force` exactly as `force_lazy_list_vm` does, or a
+`LAST $ran = True` in the callback never reaches the consuming frame's slot.
+
+Step 0's own recipe is worth recording as a lesson: the ADR prescribed measuring
+the read-path exposure with a *proxy* (routing every map through
+`create_lazy_map_list` behind a throwaway env gate). It over-reported — 59 `t/`
+files and 55 roast files versus 44 under the real mechanism — and its excess was
+systematic, not random: half the extra hits were the concurrency family failing
+on option 1's per-`map` `Env` clone, a defect `SeqSource::MapGrep` does not have.
+Run an exposure probe with the mechanism you intend to ship, behind a gate; it
+costs nothing extra, because the mechanism has to be written anyway.
+
+`grep` and the `map &f, @xs` function form stay eager for now (ADR-0058 step 3),
+and the `body_contains_return`/`is_stub_routine_body` deferral predicate stays
+until step 4.

--- a/src/runtime/builtins.rs
+++ b/src/runtime/builtins.rs
@@ -563,6 +563,15 @@ impl Interpreter {
     ) -> Result<Value, RuntimeError> {
         let (mut args, callsite_line) = self.sanitize_call_args_owned(args);
         self.test_pending_callsite_line = callsite_line;
+        // ADR-0058: a builtin reads its arguments as plain Rust values, so a
+        // still-deferred `.map` Seq (`SeqSource::MapGrep`) has to be pulled
+        // first or `say`/`join`/`await`/... would read its empty seed. Only
+        // the builtin funnel does this -- a USER routine must keep receiving
+        // an unforced Seq, which is why the pass is gated on the name being a
+        // real builtin rather than applied to every call.
+        if Self::is_builtin_function(name) {
+            self.reify_map_grep_seq_args(&args)?;
+        }
         crate::trace::trace_log!("call", "call_function: {} ({} args)", name, args.len());
         // The `nqp::` namespace is reserved: no user routine can ever be
         // declared in it, so an `nqp::` name needs none of the builtin match

--- a/src/runtime/builtins_system_async.rs
+++ b/src/runtime/builtins_system_async.rs
@@ -299,6 +299,9 @@ impl Interpreter {
                 "Must specify a Promise or list of Promises to await",
             ));
         }
+        // ADR-0058: `await (^10).map({ start { … } })` hands us a Seq whose
+        // callback has not run yet — the Promises only exist once it does.
+        self.reify_map_grep_seq_args(args)?;
         let mut await_targets: Vec<Value> = Vec::new();
         for arg in args {
             self.await_collect_targets(arg.clone(), &mut await_targets)?;

--- a/src/runtime/methods_call_dispatch.rs
+++ b/src/runtime/methods_call_dispatch.rs
@@ -164,6 +164,14 @@ impl Interpreter {
         if method == "WHICH" && args.is_empty() {
             self.warm_which_identity(&target);
         }
+        // ADR-0058: a slurpy parameter FLATTENS a `Seq` argument, and the
+        // binder reads its elements through pure code -- so a still-deferred
+        // `.map`/`.grep` argument has to run its callback before binding
+        // (zef's `self!depends2specs($deps)`, where `$deps` is a
+        // `.grep(...).map(...)` chain and the callee takes `*@depends`).
+        // The RECEIVER is handled separately, by
+        // `reify_or_consume_seq_target`.
+        self.reify_map_grep_seq_args(&args)?;
         // A user `IO::Handle` subclass that overrides `WRITE`/`READ`/`EOF` gets
         // the high-level text methods for free by routing them through those
         // overrides (`try_user_io_handle_method`). That hook was wired into the

--- a/src/runtime/methods_dispatch_match2.rs
+++ b/src/runtime/methods_dispatch_match2.rs
@@ -219,7 +219,11 @@ impl Interpreter {
             "map" => Some(self.dispatch_map_method(target, args)),
             "flatmap" => {
                 // flatmap is equivalent to .map(...).flat
-                Some(self.dispatch_map_method(target, args).map(|mapped| {
+                Some(self.dispatch_map_method(target, args).and_then(|mapped| {
+                    // ADR-0058: `.map` now hands back a Seq whose callback has
+                    // not run; the flattening below reads its elements through
+                    // pure code, so pull it here.
+                    self.reify_map_grep_seq(&mapped)?;
                     let items = Self::value_to_list(&mapped);
                     let mut flat_items = Vec::new();
                     for item in items {
@@ -233,7 +237,7 @@ impl Interpreter {
                             _ => flat_items.push(item.clone()),
                         }
                     }
-                    Value::seq(flat_items)
+                    Ok(Value::seq(flat_items))
                 }))
             }
             "duckmap" => {
@@ -583,29 +587,29 @@ impl Interpreter {
                 }
             }
         };
-        // In Raku, `.map` returns a lazy Seq. mutsu evaluates map eagerly for
-        // performance, which is observationally equivalent except when the
-        // callback contains a `return`: that `return` targets the lexically
-        // enclosing routine, and if the Seq is forced after that routine has
-        // exited it must surface as `X::ControlFlow::Return` with
-        // out-of-dynamic-scope set. To get that right without making every map
-        // lazy (which perturbs list shape/context in many call sites), only
-        // defer evaluation when the callback body actually contains a `return`.
-        // A stub body (`...`) must likewise stay unevaluated until the Seq is
-        // forced: `map -> $x, $y { ... }, @list` lives in Raku as long as the
-        // result is never iterated.
+        // A `return`/stub callback keeps the older `LazyList` deferral for now
+        // (ADR-0058 step 4 retires it once `builtin_map`/`grep` defer too):
+        // that `return` targets the lexically enclosing routine, and if the
+        // Seq is forced after that routine has exited it must surface as
+        // `X::ControlFlow::Return` with out-of-dynamic-scope set, which the
+        // `LazyList` path already gets right.
         if let Some(ValueView::Sub(sub_data)) = args.first().map(Value::view)
             && (Self::body_contains_return(&sub_data.body)
                 || Self::is_stub_routine_body(&sub_data.body))
         {
             return Ok(self.create_lazy_map_list(items, &sub_data));
         }
-        let result = self.eval_map_over_items(args.first().cloned(), items)?;
-        // .map() returns a Seq per Raku spec
-        Ok(match result.view() {
-            ValueView::Array(items, _) => Value::seq(items.to_vec()),
-            _ => result.clone(),
-        })
+        // ADR-0058 step 2: `.map` returns a Seq whose callback has NOT run
+        // yet. The callback runs when something consumes the Seq, through
+        // ADR-0034's `reify`/`take`/`sink` split (`SeqSource::MapGrep`'s arm
+        // in `pull_seq_source`), which is rakudo's timing: a `die` in the
+        // callback escapes a `try` that merely encloses the `.map` call, and
+        // a plain side effect happens at first consumption rather than here.
+        Ok(Value::seq_deferred(crate::value::SeqSource::MapGrep {
+            items: std::sync::Arc::new(items),
+            func: args.first().cloned(),
+            fatal: self.fatal_mode,
+        }))
     }
 
     /// Create a `LazyList` that lazily maps `callback` over `items`.

--- a/src/runtime/resolution_call_sub.rs
+++ b/src/runtime/resolution_call_sub.rs
@@ -267,6 +267,15 @@ impl Interpreter {
         args: Vec<Value>,
         merge_all: bool,
     ) -> Result<Value, RuntimeError> {
+        // ADR-0058: a slurpy parameter FLATTENS a `Seq` argument
+        // (`{ [+] @_ } o *.map(* * 2)` sums the mapped elements, not the Seq),
+        // and the binder reads those elements through pure code. Pull a
+        // still-deferred `.map`/`.grep` argument here rather than teaching
+        // every binding shape about it. A `MapGrep` source is always finite
+        // (its items were materialized at the `.map` call), so this cannot
+        // hang; it costs raku's argument-position laziness, which mutsu never
+        // had for `.map` anyway.
+        self.reify_map_grep_seq_args(&args)?;
         let func = Self::unwrap_callable_mixin(func);
         // Upgrade WeakSub to Sub transparently
         let func = match func.view() {
@@ -527,6 +536,11 @@ impl Interpreter {
                 data.env.get("__mutsu_compose_right").cloned(),
             ) {
                 let right_result = self.call_sub_value(right, call_args, false)?;
+                // ADR-0058: `composed_result_to_args` spreads a `Seq` result
+                // into the left callable's arguments by reading its elements
+                // through pure code, so a still-deferred `.map`/`.grep` result
+                // (`{ [+] @_ } o *.map(* * 2)`) has to run its callback first.
+                self.reify_map_grep_seq(&right_result)?;
                 let (left_params, left_param_defs) = self.callable_signature(&left);
                 let left_variadic = left_param_defs.iter().any(|pd| pd.slurpy && !pd.named);
                 let left_expects_single = match left.view() {

--- a/src/runtime/resolution_map_grep.rs
+++ b/src/runtime/resolution_map_grep.rs
@@ -320,7 +320,7 @@ impl Interpreter {
         (code, fns)
     }
 
-    pub(super) fn eval_map_over_items(
+    pub(crate) fn eval_map_over_items(
         &mut self,
         func: Option<Value>,
         list_items: Vec<Value>,

--- a/src/runtime/run.rs
+++ b/src/runtime/run.rs
@@ -669,6 +669,15 @@ impl Interpreter {
                 let _ = self.finish();
                 return Err(e);
             }
+            // ADR-0058: the same rule for a `.map`/`.grep` Seq whose callback
+            // has not run yet — `(1,2,3).map({ die "oh noes" })` as a whole
+            // program must die (`roast/integration/weird-errors.t`).
+            if let Some(v) = last_value.clone()
+                && let Err(e) = self.sink_map_grep_seq(&v)
+            {
+                let _ = self.finish();
+                return Err(e);
+            }
         }
         // Only store last_value if _ was actually set during this execution
         // (not inherited from a previous REPL line)

--- a/src/runtime/test_functions/eval_exception.rs
+++ b/src/runtime/test_functions/eval_exception.rs
@@ -76,7 +76,17 @@ impl Interpreter {
                 {
                     return result;
                 }
-                result.is_ok()
+                // ADR-0058: rakudo's `lives-ok` sinks the block's result (see
+                // the twin comment in `test_fn_dies_ok`), so a `.map` whose
+                // callback throws makes it fail rather than silently pass.
+                match &result {
+                    Ok(val) => match self.sink_map_grep_seq(val) {
+                        Err(e) if Self::is_live_nonlocal_control(&e) => return Err(e),
+                        Err(_) => false,
+                        Ok(()) => true,
+                    },
+                    Err(_) => false,
+                }
             }
             _ => true,
         };
@@ -120,8 +130,22 @@ impl Interpreter {
                 match &result {
                     Err(_) => true,
                     Ok(val) => {
-                        // A Failure value in sink context should throw
-                        Self::is_failure_value(val)
+                        // ADR-0058: rakudo's `dies-ok` writes `$code();` as a
+                        // STATEMENT, so the block's result is SUNK -- and a
+                        // `.map` whose callback throws only runs at that sink.
+                        // mutsu calls the block natively and discards the
+                        // value, so sink it explicitly here or
+                        // `dies-ok { (1,2,3).map({ $^a + $^b }) }` would report
+                        // "lived".
+                        if let Err(e) = self.sink_map_grep_seq(val) {
+                            if Self::is_live_nonlocal_control(&e) {
+                                return Err(e);
+                            }
+                            true
+                        } else {
+                            // A Failure value in sink context should throw
+                            Self::is_failure_value(val)
+                        }
                     }
                 }
             }

--- a/src/runtime/test_functions/throws_like.rs
+++ b/src/runtime/test_functions/throws_like.rs
@@ -27,7 +27,18 @@ impl Interpreter {
                 let saved_last_value = self.last_value.take();
                 let r = self.eval_test_block_value(&data.body, Some(data.id));
                 self.last_value = saved_last_value;
-                r
+                // ADR-0058: `throws-like` runs its block in SINK context (see
+                // the `last_value` force below for the `gather` twin), so a
+                // deferred `.map`/`.grep` the block returned must run its
+                // callback here — that is where the exception under test comes
+                // from (`throws-like { use fatal; "a".map: *.Int }`).
+                match r {
+                    Ok(val) => match self.sink_map_grep_seq(&val) {
+                        Ok(()) => Ok(val),
+                        Err(e) => Err(e),
+                    },
+                    err => err,
+                }
             }
             ValueView::Str(code) => {
                 let mut nested = Interpreter::new();
@@ -275,6 +286,12 @@ impl Interpreter {
                                     && ll.coroutine.is_some()
                                     && let Err(e) = nested.force_lazy_list_vm(&ll)
                                 {
+                                    Err(e)
+                                // ADR-0058: same sink contract for a deferred
+                                // `.map`/`.grep` Seq — its callback only runs
+                                // when the value is sunk, which is exactly what
+                                // `throws-like` is simulating here.
+                                } else if let Err(e) = nested.sink_map_grep_seq(&last_val) {
                                     Err(e)
                                 } else {
                                     Self::sink_failure_to_error(last_val)

--- a/src/value/seq_body.rs
+++ b/src/value/seq_body.rs
@@ -36,6 +36,22 @@ pub(crate) enum SeqSource {
         words: bool,
         kv: bool,
     },
+    /// `.map`/`.grep` over an already-materialized source (docs/adr/0058):
+    /// run `func` over `items` on first touch. This is rakudo's `Seq` from
+    /// `map`/`grep` — the callback runs at first consumption, not at the
+    /// `.map` call, so a `die`/`fail` inside it escapes a `try` that only
+    /// lexically encloses the `.map`.
+    MapGrep {
+        items: Arc<Vec<Value>>,
+        func: Option<Value>,
+        /// `use fatal` as it stood at the `.map` CALL, not at the pull.
+        /// `use fatal` is lexical, so a callback written outside a `use fatal`
+        /// scope must not become fatal merely because the Seq is consumed
+        /// inside one (`my &c = { "a".map: *.Int }; try { c() }` keeps the
+        /// Failure soft in rakudo — pinned by
+        /// `t/try-fatal-does-not-retroactively-flag-closure-seq.t`).
+        fatal: bool,
+    },
     /// The source was handed away by a consuming method (`.iterator`,
     /// `.list`, ...). A later attempt to reify or take again throws
     /// `X::Seq::Consumed`.
@@ -387,6 +403,31 @@ impl SeqBody {
         Ok((items, SeqTaken::Taken))
     }
 
+    /// Store elements a [`SeqBody::take`] just pulled back into this body's
+    /// generation graveyard WITHOUT reviving its (now `Taken`) source.
+    ///
+    /// `take` deliberately hands the pulled elements to the caller instead of
+    /// storing them — a consuming touch steals the single read. But
+    /// `.iterator` is the one consumer that must keep operating on the SAME
+    /// `Arc<SeqBody>` afterwards (`reify_or_consume_seq_target_inner`'s
+    /// `.iterator` arm explains why: `dispatch_iterator_method` looks up
+    /// `squish_iterator_meta` by this body's address), and it reads the
+    /// elements back through `Deref`. Without this the elements a genuinely
+    /// deferred source produced were pulled and then dropped, and the iterator
+    /// was built over the still-empty seed — invisible while only
+    /// `IO::Handle.lines` produced deferred bodies, and exposed the moment
+    /// ADR-0058 made every `.map` deferred (`self.pairs.iterator` in a
+    /// `does Iterable` role iterated nothing).
+    pub(crate) fn store_taken_elements(&self, items: Vec<Value>) {
+        if self.live_generation().len() == items.len() {
+            return;
+        }
+        // SAFETY: same reasoning as `pull_and_store` — no reference into
+        // `gens` is held across this push, and earlier generations are never
+        // rewritten, only superseded.
+        unsafe { (*self.core.gens.get()).push(Box::new(items)) };
+    }
+
     /// A `for`-loop's own single-use gate (`vm_for_loop_dispatch.rs`):
     /// unlike every other consumer, `for` does NOT go through `take` at all
     /// (it is not a `seq_method_consumes` entry — reading a bare `for $s {}`
@@ -437,7 +478,10 @@ impl SeqBody {
                 _ => std::mem::replace(&mut state.source, SeqSource::Taken),
             }
         };
-        if matches!(source, SeqSource::Iterator(_) | SeqSource::IoLines { .. }) {
+        if matches!(
+            source,
+            SeqSource::Iterator(_) | SeqSource::IoLines { .. } | SeqSource::MapGrep { .. }
+        ) {
             pull(&source)?;
         }
         Ok(())
@@ -481,10 +525,31 @@ impl SeqBody {
     /// Whether this body still has a source to pull from (an unreified
     /// `Seq.new($iterator)` or `IO::Handle.lines`) rather than being already
     /// reified or already taken.
+    ///
+    /// **`SeqSource::MapGrep` is deliberately NOT included** (docs/adr/0058
+    /// §step 2): every call site of this predicate treats "deferred" as
+    /// "single-use, steal it" — most visibly `reify_or_consume_seq_target`'s
+    /// `"list"` arm, whose whole compromise is that a `.map`/`.grep` result
+    /// must stay re-readable through `@$s` (`t/seq-array-context-reiterate.t`)
+    /// while an `IO::Handle.lines` Seq consumes. A `MapGrep` body is deferred
+    /// in *when the callback runs*, not in whether the result is re-readable,
+    /// so it keeps the eager map's behaviour at those sites. Use
+    /// [`SeqBody::needs_touch`] for "does this need reifying at all".
     pub(crate) fn has_deferred_source(&self) -> bool {
         matches!(
             self.core.state.lock().unwrap().source,
             SeqSource::Iterator(_) | SeqSource::IoLines { .. }
+        )
+    }
+
+    /// Whether this body is a not-yet-run `.map`/`.grep` (docs/adr/0058).
+    /// Read by the handful of pure-value read paths that cannot re-enter the
+    /// VM to pull (`Value::truthy`, `.gist`), which must not mistake an
+    /// un-pulled body's empty seed for a genuinely empty sequence.
+    pub(crate) fn is_map_grep_source(&self) -> bool {
+        matches!(
+            self.core.state.lock().unwrap().source,
+            SeqSource::MapGrep { .. }
         )
     }
 
@@ -656,6 +721,14 @@ impl SeqBody {
         match &state.source {
             SeqSource::Iterator(v) => v.gc_trace(visit),
             SeqSource::IoLines { handle, .. } => handle.gc_trace(visit),
+            SeqSource::MapGrep { items, func, .. } => {
+                for v in items.iter() {
+                    v.gc_trace(visit);
+                }
+                if let Some(f) = func {
+                    f.gc_trace(visit);
+                }
+            }
             SeqSource::Reified | SeqSource::Taken => {}
         }
     }

--- a/src/value/types_truthy.rs
+++ b/src/value/types_truthy.rs
@@ -131,7 +131,14 @@ impl Value {
                 // reports `true` without peeking. Every other Seq (reified,
                 // or a not-yet-touched `Iterator` source reading its still-
                 // empty seed) uses the element count.
-                items.is_io_lines_source() || !items.is_empty()
+                // ADR-0058: a not-yet-run `.map`/`.grep` (`SeqSource::MapGrep`)
+                // reads its still-empty seed here, exactly like the IoLines
+                // case above — report `true` rather than "empty". The pure
+                // approximation is sound for `.map` (one result per source
+                // element, so a non-empty source cannot map to nothing unless
+                // the callback slips) and the VM forces the body at every
+                // boolean chokepoint it can reach with an `&mut Interpreter`.
+                items.is_io_lines_source() || items.is_map_grep_source() || !items.is_empty()
             }
             ValueView::LazyList(_) => true,
             ValueView::Promise(p) => p.is_resolved(),

--- a/src/vm/vm_call_method_mut_ops.rs
+++ b/src/vm/vm_call_method_mut_ops.rs
@@ -684,6 +684,10 @@ impl Interpreter {
         // variable, a second alias, a value passed to a sub one call frame
         // away) observes it for free.
         let target = self.reify_or_consume_seq_target(target, method.as_str())?;
+        // ADR-0058: a mutating method reads its ARGUMENTS' elements through
+        // pure code (`@a.splice(1, 1, (7,8).map({...}))` flattens the Seq into
+        // the array), so a still-deferred `.map` argument has to run first.
+        self.reify_map_grep_seq_args(&args)?;
         // Mutating methods reached through `.VAR` must retain the underlying
         // cell so the established container writeback paths can update it.
         let target = if !matches!(method.as_str(), "WHAT" | "^name" | "VAR")

--- a/src/vm/vm_call_method_ops.rs
+++ b/src/vm/vm_call_method_ops.rs
@@ -2226,6 +2226,11 @@ impl Interpreter {
                 if let Some(is_hyper) = hyper_race_wrap
                     && let Some(result) = self.stack.pop()
                 {
+                    // ADR-0058: a large HyperSeq/RaceSeq `.map`/`.grep` falls
+                    // through to the ordinary array dispatch, which now returns
+                    // a Seq whose callback has not run; `value_to_list` below
+                    // reads it through pure code.
+                    self.reify_map_grep_seq(&result)?;
                     let result_items = crate::runtime::value_to_list(&result);
                     let wrapped = if is_hyper {
                         Value::hyper_seq(result_items)

--- a/src/vm/vm_closure_dispatch.rs
+++ b/src/vm/vm_closure_dispatch.rs
@@ -112,6 +112,12 @@ impl Interpreter {
         args: Vec<Value>,
         compiled_fns: &CompiledFns,
     ) -> Result<Value, RuntimeError> {
+        // ADR-0058: a slurpy/`@_` parameter FLATTENS a `Seq` argument
+        // (`{ [+] @_ } o *.map(* * 2)` sums the mapped elements), and the
+        // binder reads them through pure code -- so pull a still-deferred
+        // `.map`/`.grep` argument before binding. A `MapGrep` source is always
+        // finite, so this cannot hang.
+        self.reify_map_grep_seq_args(&args)?;
         // RAII (`PragmaGuard`, `todo/deep/panic-unwind-leaks-side-channel-call-state.md`):
         // restores pragma state on drop -- including on a Rust panic unwind
         // through `call_compiled_closure_with_topic` below -- rather than a

--- a/src/vm/vm_coerce_concat_ops.rs
+++ b/src/vm/vm_coerce_concat_ops.rs
@@ -221,6 +221,9 @@ impl Interpreter {
     /// `concat_values` / `to_str_context` handle those, including built-in
     /// `.gist`/`.Str`). Shared by infix `~` and the string-comparison ops.
     pub(crate) fn coerce_stringy_operand(&mut self, v: Value) -> Result<Value, RuntimeError> {
+        // ADR-0058: a string context renders a Seq's elements, so a
+        // still-deferred `.map` must run its callback first.
+        self.reify_map_grep_seq(&v)?;
         // A string context is a READ, so a `Proxy` operand FETCHes: `"x" ~ $p`
         // is `x5`, not `xProxy`. Every other value context already FETCHed
         // (arithmetic via `eval_binary_with_junctions`, `say`/`print`/`note`,

--- a/src/vm/vm_data_io_ops.rs
+++ b/src/vm/vm_data_io_ops.rs
@@ -209,6 +209,9 @@ impl Interpreter {
         let n = n as usize;
         let start = self.stack.len() - n;
         let values: Vec<Value> = Self::flatten_slip_args(self.stack.drain(start..).collect());
+        // ADR-0058: rendering reads elements through pure code, so a
+        // still-deferred `.map` Seq must run its callback first.
+        self.reify_map_grep_seq_args(&values)?;
         // Slice F: a user `.gist`/`.Str` closure run below can mutate a
         // captured-outer caller lexical (`say $x but role { method gist {$seen=1} }`).
         // `say` is a dedicated op (no `code` param), so capture the caller frame's
@@ -243,6 +246,9 @@ impl Interpreter {
         } else {
             let start = self.stack.len() - n;
             let values: Vec<Value> = Self::flatten_slip_args(self.stack.drain(start..).collect());
+            // ADR-0058: rendering reads elements through pure code, so a
+            // still-deferred `.map` Seq must run its callback first.
+            self.reify_map_grep_seq_args(&values)?;
             // Slice F: see exec_say_op — reconcile after a user `.gist` closure.
             let caller_code = self.current_code;
             let mut parts = Vec::new();
@@ -266,6 +272,9 @@ impl Interpreter {
         let n = n as usize;
         let start = self.stack.len() - n;
         let values: Vec<Value> = Self::flatten_slip_args(self.stack.drain(start..).collect());
+        // ADR-0058: rendering reads elements through pure code, so a
+        // still-deferred `.map` Seq must run its callback first.
+        self.reify_map_grep_seq_args(&values)?;
         // A lone Junction argument autothreads: each eigenstate is put on its
         // own line (`put 1|2` => "1\n2\n").
         if values.len() == 1 && matches!(values[0].view(), ValueView::Junction { .. }) {
@@ -304,6 +313,9 @@ impl Interpreter {
         let n = n as usize;
         let start = self.stack.len() - n;
         let values: Vec<Value> = Self::flatten_slip_args(self.stack.drain(start..).collect());
+        // ADR-0058: rendering reads elements through pure code, so a
+        // still-deferred `.map` Seq must run its callback first.
+        self.reify_map_grep_seq_args(&values)?;
         // Slice F: see exec_put_op — reconcile after a user `.Str` closure.
         let caller_code = self.current_code;
         let mut content = String::new();

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -875,6 +875,18 @@ impl Interpreter {
                     Some(s) => s,
                     None => unreachable!("SetGlobal name must be a string constant"),
                 };
+                // ADR-0058: assigning a Seq to an `@`/`%` target reifies it
+                // (raku list semantics) -- the same rule `exec_set_local_op_inner`
+                // applies. An anonymous `my @ = EXPR` inside a nested block
+                // compiles to SetGlobal, not SetLocal, so without this a
+                // deferred `.map` initializer stored an empty array.
+                if !is_bind_ctx
+                    && !is_rebind
+                    && (name_str.starts_with('@') || name_str.starts_with('%'))
+                    && let Some(top) = self.stack.last().cloned()
+                {
+                    self.reify_map_grep_seq(&top)?;
+                }
                 // Fast path for the anonymous state scalar (`$` and `$.` desugaring).
                 // `__ANON_STATE__` is a synthetic internal name that can never be a
                 // private attribute, package/class, sigilless-bound alias, or strict-
@@ -3140,7 +3152,18 @@ impl Interpreter {
                         ValueView::LazyList(list) => {
                             self.force_lazy_list_vm(&list)?;
                         }
-                        ValueView::Seq(body) if body.needs_touch() => {
+                        // ADR-0058: a `.map`/`.grep` Seq assigned into a
+                        // container is itemized by that store, so the
+                        // statement's sink must NOT force it — measured
+                        // against raku: `my %h; %h<f> = (1..3).map({die});
+                        // say "alive"` prints "alive" and only `%h<f>.elems`
+                        // afterwards throws. A local `$x = SEQ` gets the same
+                        // exemption through `SeqBody::mark_itemized`; an
+                        // ELEMENT store has no equivalent hook, so recognise
+                        // the source kind here instead.
+                        ValueView::Seq(body)
+                            if body.needs_touch() && !body.is_map_grep_source() =>
+                        {
                             let body = std::sync::Arc::clone(&body);
                             self.sink_seq_body(&body)?;
                         }

--- a/src/vm/vm_helpers_junction.rs
+++ b/src/vm/vm_helpers_junction.rs
@@ -7,6 +7,11 @@ impl Interpreter {
         right: Value,
         f: fn(&mut Interpreter, Value, Value) -> Result<Value, RuntimeError>,
     ) -> Result<Value, RuntimeError> {
+        // ADR-0058: every binary operator below reads its operands' elements
+        // through pure code (set ops, comparison, `~`, ...), so a
+        // still-deferred `.map` operand has to run its callback first.
+        self.reify_map_grep_seq(&left)?;
+        self.reify_map_grep_seq(&right)?;
         // Auto-FETCH Proxy containers in binary operations
         let left = loan_env!(self, auto_fetch_proxy(&left))?;
         let right = loan_env!(self, auto_fetch_proxy(&right))?;

--- a/src/vm/vm_helpers_lazy.rs
+++ b/src/vm/vm_helpers_lazy.rs
@@ -287,9 +287,21 @@ impl Interpreter {
     }
 
     /// [`Self::reify_map_grep_seq`] over a whole argument list.
+    ///
+    /// Looks through a `Pair`, because a NAMED argument's value is an argument
+    /// too: zef's `Any.new(:specs($spec.values[0].map: {...}))` binds the
+    /// mapped Seq to an `@.specs` attribute, and the binder reads its elements
+    /// through pure code.
     pub(crate) fn reify_map_grep_seq_args(&mut self, args: &[Value]) -> Result<(), RuntimeError> {
         for arg in args {
             self.reify_map_grep_seq(arg)?;
+            match arg.view() {
+                ValueView::Pair(_, v) | ValueView::ValuePair(_, v) => {
+                    let v = v.clone();
+                    self.reify_map_grep_seq(&v)?;
+                }
+                _ => {}
+            }
         }
         Ok(())
     }

--- a/src/vm/vm_helpers_lazy.rs
+++ b/src/vm/vm_helpers_lazy.rs
@@ -23,6 +23,31 @@ impl Interpreter {
             SeqSource::IoLines { handle, words, kv } => {
                 self.pull_io_lines_to_vec(handle.clone(), *words, *kv)
             }
+            // docs/adr/0058: a `.map`/`.grep` whose callback has not run yet.
+            // This IS `dispatch_map_method`'s old eager tail, just moved to
+            // first consumption — so a `die`/`fail` it raises surfaces at the
+            // consuming statement, outside a `try` that merely enclosed the
+            // `.map` call.
+            SeqSource::MapGrep { items, func, fatal } => {
+                // Same contract as `force_lazy_list_vm`: this force IS the
+                // effective call site for the callbacks it runs, so a
+                // captured-outer lexical the callback mutated (`LAST $ran =
+                // True`, `$count++`) has to be drained back into the consuming
+                // frame's local slots — the reify is not a call op, so nothing
+                // else would.
+                let caller_code = self.current_code;
+                // `use fatal` is lexical to the `.map` call site, not to
+                // whoever consumes the Seq — see `SeqSource::MapGrep::fatal`.
+                let saved_fatal = std::mem::replace(&mut self.fatal_mode, *fatal);
+                let result = self.eval_map_over_items(func.clone(), items.as_ref().clone());
+                self.fatal_mode = saved_fatal;
+                self.reconcile_caller_after_lazy_force(caller_code);
+                let result = result?;
+                Ok(match result.view() {
+                    ValueView::Array(items, _) => items.to_vec(),
+                    _ => crate::runtime::utils::value_to_list(&result),
+                })
+            }
         }
     }
 
@@ -209,6 +234,66 @@ impl Interpreter {
         body.sink(|source| self.pull_seq_source(source))
     }
 
+    /// Reify a not-yet-run `.map`/`.grep` Seq (`SeqSource::MapGrep`,
+    /// docs/adr/0058) before a **pure-value reader** touches it.
+    ///
+    /// ADR-0034 §2.1 deliberately made a `SeqBody` read through `Deref` return
+    /// the *empty seed* for a body nobody has pulled, so a read can never
+    /// re-enter the VM. That is safe while deferred bodies are rare
+    /// (`IO::Handle.lines`, `Seq.new($iterator)`), but ADR-0058 makes every
+    /// `.map` deferred, so the many `ValueView::Seq(items)` readers that cannot
+    /// pull would silently see an empty sequence. This is the one-line guard
+    /// those call sites use: it is a no-op for every other value (including
+    /// every other `SeqSource`, whose streaming semantics must NOT be forced at
+    /// an argument boundary), and a `MapGrep` source is always finite — its
+    /// `items` were materialized at the `.map` call — so forcing it can never
+    /// hang.
+    ///
+    /// Reification is non-consuming and idempotent: the body keeps its
+    /// identity and stays readable afterwards.
+    pub(crate) fn reify_map_grep_seq(&mut self, value: &Value) -> Result<(), RuntimeError> {
+        // Tag-probed before `view()`: this guard sits on hot operand/argument
+        // paths, and `view()` on a lazy `Match` materializes every capture
+        // (ADR-0016 P5).
+        if !value.is_seq_value() {
+            return Ok(());
+        }
+        if let ValueView::Seq(body) = value.view()
+            && body.is_map_grep_source()
+        {
+            let body = Arc::clone(&body);
+            self.reify_seq_body(&body)?;
+        }
+        Ok(())
+    }
+
+    /// rakudo's sink of a *discarded* value, for the handful of native
+    /// handlers that call a user block and throw its result away
+    /// (`dies-ok`/`lives-ok`, whose `Test.rakumod` originals write `$code();`
+    /// as a STATEMENT, so rakudo sinks the block's Seq and the callback's
+    /// exception escapes). A no-op for every value that is not a not-yet-run
+    /// `.map`/`.grep` Seq (docs/adr/0058).
+    pub(crate) fn sink_map_grep_seq(&mut self, value: &Value) -> Result<(), RuntimeError> {
+        if !value.is_seq_value() {
+            return Ok(());
+        }
+        if let ValueView::Seq(body) = value.view()
+            && body.is_map_grep_source()
+        {
+            let body = Arc::clone(&body);
+            self.sink_seq_body(&body)?;
+        }
+        Ok(())
+    }
+
+    /// [`Self::reify_map_grep_seq`] over a whole argument list.
+    pub(crate) fn reify_map_grep_seq_args(&mut self, args: &[Value]) -> Result<(), RuntimeError> {
+        for arg in args {
+            self.reify_map_grep_seq(arg)?;
+        }
+        Ok(())
+    }
+
     /// Pre-dispatch guard (ADR-0034 §2.3): if `target` is a `Seq` whose body
     /// needs touching before `method` can run — a deferred source
     /// (`Seq.new($iterator)`, `IO::Handle.lines` — formerly the separate
@@ -265,6 +350,40 @@ impl Interpreter {
         handle_iterator: bool,
     ) -> Result<Value, RuntimeError> {
         let ValueView::Seq(body) = target.view() else {
+            // A Seq read out of a container (`%h<k>`, `@a[0]`, a `$`-bound
+            // element) arrives wrapped in its Scalar cell, so the match above
+            // misses it and the method would read the body's empty seed. Reify
+            // THROUGH the cell: reification is in place on the shared
+            // `Arc<SeqBody>`, so the container keeps holding the same value and
+            // only the (previously unpulled) elements change. A genuinely
+            // CONSUMING method still has to see the stolen elements, so hand it
+            // the unwrapped replacement — matching what the direct-Seq path
+            // returns (docs/adr/0058).
+            let unwrapped = match target.view() {
+                // ADR-0040: a Seq stored into an `@`/`%` element is itemized
+                // into a `Scalar` box by `itemize_for_element_store`, so
+                // `%h<k>.elems` arrives here wrapped.
+                ValueView::Scalar(inner) if matches!(inner.view(), ValueView::Seq(_)) => {
+                    Some(inner.clone())
+                }
+                _ if target.is_container_ref()
+                    && matches!(target.deref_container().view(), ValueView::Seq(_)) =>
+                {
+                    Some(target.deref_container())
+                }
+                _ => None,
+            };
+            if let Some(inner) = unwrapped {
+                let inner_body = match inner.view() {
+                    ValueView::Seq(b) => Arc::as_ptr(&b) as usize,
+                    _ => 0,
+                };
+                let replaced =
+                    self.reify_or_consume_seq_target_inner(inner, method, handle_iterator)?;
+                let same_body = matches!(replaced.view(),
+                    ValueView::Seq(b) if Arc::as_ptr(&b) as usize == inner_body);
+                return Ok(if same_body { target } else { replaced });
+            }
             return Ok(target);
         };
         if !body.needs_touch() || crate::value::seq_method_never_touches(method) {
@@ -422,7 +541,12 @@ impl Interpreter {
             // the SAME body (identity preserved either way) to build the
             // instance, so its `squish_iterator_meta`/`Deref`-based fallback
             // both see the correct, final data.
-            self.take_seq_body(&body)?;
+            let (items, _) = self.take_seq_body(&body)?;
+            // A genuinely deferred source (`SeqSource::MapGrep`,
+            // `IoLines`, `Iterator`) hands its elements to the caller rather
+            // than storing them, but `dispatch_iterator_method` reads THIS
+            // body back through `Deref` — see `SeqBody::store_taken_elements`.
+            body.store_taken_elements(items);
             return self.dispatch_iterator_method(target);
         }
         if crate::value::seq_method_consumes(method) {

--- a/src/vm/vm_hyper_method_ops.rs
+++ b/src/vm/vm_hyper_method_ops.rs
@@ -527,7 +527,12 @@ impl Interpreter {
         // source first if needed.
         if let ValueView::Seq(body) = target.view() {
             let body = std::sync::Arc::clone(&body);
-            self.take_seq_body(&body)?;
+            let (items, _) = self.take_seq_body(&body)?;
+            // ADR-0058: `hyper_source_items` below reads THIS body back
+            // through `Deref`, but `take` hands a genuinely deferred source's
+            // elements to the caller instead of storing them — see
+            // `SeqBody::store_taken_elements`.
+            body.store_taken_elements(items);
         }
         // A not-yet-forced lazy list (`gather { take 1 }`, a finite `.map` pipe)
         // carries an EMPTY cache, and `hyper_source_items` below is a static
@@ -956,6 +961,12 @@ impl Interpreter {
                         // `((2 3) (4 [5 6]))`, not a flattened `(2 3 4 [5 6])`
                         // (roast S03-metaops/hyper.t "`.Slip` is nodal"). Only a
                         // leaf application slips.
+                        // ADR-0058: a per-element `.map`/`.grep` hands back a
+                        // Seq whose callback has not run; the result vector is
+                        // read by pure code (`.gist`, the writeback below), so
+                        // pull it here (`[[2,3],[4,[5,6]]]».map(* + 1)`,
+                        // `roast/S03-metaops/hyper.t` ".map is nodal").
+                        self.reify_map_grep_seq(&val)?;
                         if is_list_native_method {
                             results.push(val);
                         } else {

--- a/src/vm/vm_meta_ops.rs
+++ b/src/vm/vm_meta_ops.rs
@@ -3,6 +3,9 @@ use super::*;
 
 impl Interpreter {
     fn zip_iter_from_value(&mut self, val: &Value, needed: usize) -> Result<ZipIter, RuntimeError> {
+        // ADR-0058: `ZipIter::from_value` reads the elements through pure
+        // code, so a still-deferred `.map` operand has to run first.
+        self.reify_map_grep_seq(val)?;
         if let ValueView::LazyList(list) = val.view() {
             // A cache-only lazy value is already finite.  Pull-backed values
             // (map/grep pipes and sequences) need VM execution to populate the
@@ -50,6 +53,11 @@ impl Interpreter {
     ) -> Result<(), RuntimeError> {
         let right = self.stack.pop().unwrap_or(Value::NIL);
         let left = self.stack.pop().unwrap_or(Value::NIL);
+        // ADR-0058: the meta-ops below read their operands' elements through
+        // pure helpers (`ZipIter::from_value`, `value_to_list`), so a
+        // still-deferred `.map` operand has to run its callback first.
+        self.reify_map_grep_seq(&left)?;
+        self.reify_map_grep_seq(&right)?;
         let meta = Self::const_str(code, meta_idx).to_string();
         let op = Self::const_str(code, op_idx).to_string();
         let result = match meta.as_str() {

--- a/src/vm/vm_misc_assign.rs
+++ b/src/vm/vm_misc_assign.rs
@@ -120,6 +120,15 @@ impl Interpreter {
         };
         self.check_readonly_for_modify(&name)?;
         self.check_dot_twigil_accessor_writable(&name)?;
+        // ADR-0058: assigning a Seq to an `@`/`%` target reifies it (raku list
+        // semantics) — the same rule `exec_set_local_op_inner` /
+        // `exec_assign_expr_local_op_inner` apply. This is the by-name
+        // reassignment form (an `@a = SEQ` inside a loop body).
+        if (name.starts_with('@') || name.starts_with('%'))
+            && let Some(top) = self.stack.last().cloned()
+        {
+            self.reify_map_grep_seq(&top)?;
+        }
         // A whole-container reassignment breaks every `:=`-bound element, so drop
         // the read-only-element markers (`%h<i> := 137; %h = (...)` makes `%h<i>`
         // writable again). Covers the tied-STORE path below too.

--- a/src/vm/vm_misc_coerce.rs
+++ b/src/vm/vm_misc_coerce.rs
@@ -3,6 +3,9 @@ use super::*;
 impl Interpreter {
     pub(super) fn exec_num_coerce_op(&mut self) -> Result<(), RuntimeError> {
         let val = self.stack.pop().unwrap();
+        // ADR-0058: numifying a Seq counts its elements, so a still-deferred
+        // `.map` has to run its callback first.
+        self.reify_map_grep_seq(&val)?;
         // Auto-FETCH Proxy containers
         let val = loan_env!(self, auto_fetch_proxy(&val))?;
         // Junction auto-threading for prefix:<+>
@@ -133,6 +136,9 @@ impl Interpreter {
 
     pub(super) fn exec_str_coerce_op(&mut self) -> Result<(), RuntimeError> {
         let val = self.stack.pop().unwrap();
+        // ADR-0058: stringifying a Seq renders its elements, so a
+        // still-deferred `.map` has to run its callback first.
+        self.reify_map_grep_seq(&val)?;
         // Auto-FETCH Proxy containers
         let val = loan_env!(self, auto_fetch_proxy(&val))?;
         // A `ContainerRef` is transparent to string coercion: `~$x` renders

--- a/src/vm/vm_misc_reduction_exec.rs
+++ b/src/vm/vm_misc_reduction_exec.rs
@@ -65,6 +65,9 @@ impl Interpreter {
             return self.exec_scan_shortcircuit_reduction(sc_op, negate, scan, thunks);
         }
         let list_value = self.stack.pop().unwrap_or(Value::NIL);
+        // ADR-0058: `[+] (2..N).map({...})` folds over the mapped elements, so
+        // a still-deferred `.map` operand has to run its callback first.
+        self.reify_map_grep_seq(&list_value)?;
         let input_is_lazy = crate::builtins::methods_0arg::is_value_lazy(&list_value);
         // For scan (triangle reduce) on infinite/lazy inputs, handle lazily
         // to avoid materializing the entire infinite range.

--- a/src/vm/vm_native_dispatch.rs
+++ b/src/vm/vm_native_dispatch.rs
@@ -24,6 +24,13 @@ impl Interpreter {
         method_sym: crate::symbol::Symbol,
         args: &[Value],
     ) -> Option<Result<Value, RuntimeError>> {
+        // ADR-0058: a native method reads its ARGUMENTS' elements through pure
+        // Rust (the receiver is already handled by
+        // `reify_or_consume_seq_target`), so a still-deferred `.map` argument —
+        // `600.polymod((1..3).map(* * 3))` — must run its callback first.
+        if let Err(e) = self.reify_map_grep_seq_args(args) {
+            return Some(Err(e));
+        }
         let result = self.try_native_method_raw(target, method_sym, args);
         if let Some(Err(e)) = &result
             && e.is_warn()
@@ -650,6 +657,13 @@ impl Interpreter {
             {
                 return Some(result);
             }
+        }
+        // ADR-0058: `crate::builtins::native_function` is pure Rust that reads
+        // its arguments' elements directly, so a still-deferred `.map` Seq has
+        // to be pulled first (otherwise `join`/`say`/... read its empty seed).
+        // No-op for every other value and every other `SeqSource`.
+        if let Err(e) = self.reify_map_grep_seq_args(args) {
+            return Some(Err(e));
         }
         if args
             .iter()

--- a/src/vm/vm_set_ops.rs
+++ b/src/vm/vm_set_ops.rs
@@ -135,6 +135,12 @@ impl Interpreter {
     }
 
     fn set_contains(&mut self, container: &Value, needle: &Value) -> bool {
+        // ADR-0058: `"x" (elem) @xs.map({...})` tests membership in the MAPPED
+        // elements, which `as_list_items` below reads through pure code.
+        // Membership is a Bool, so a callback that throws here is reported as
+        // "not a member" rather than propagated -- the same shape every other
+        // pure predicate in this file uses.
+        let _ = self.reify_map_grep_seq(container);
         // ADR-0040 slices 1-2: the container is the RECEIVER of this membership
         // test, so its own element-itemization is not part of the question --
         // `my @e = 2, 1..2` makes `@e[1]` a `Scalar(Range)`, and

--- a/src/vm/vm_smart_match.rs
+++ b/src/vm/vm_smart_match.rs
@@ -675,6 +675,13 @@ impl Interpreter {
     }
 
     pub(super) fn vm_smart_match(&mut self, left: &Value, right: &Value) -> bool {
+        // ADR-0058: list matching reads a Seq's elements through pure code, so
+        // a still-deferred `.map`/`.grep` operand has to run its callback
+        // first. Smartmatch answers a Bool, so a callback that throws here is
+        // reported as "no match" — the same shape every other pure predicate
+        // reachable from this infallible signature uses.
+        let _ = self.reify_map_grep_seq(left);
+        let _ = self.reify_map_grep_seq(right);
         // Force finite lazy operands first so list matching sees their
         // elements (see reify_finite_lazy_for_match).
         if let Some(forced) = self.reify_finite_lazy_for_match(left) {

--- a/src/vm/vm_var_assign_index_named.rs
+++ b/src/vm/vm_var_assign_index_named.rs
@@ -343,6 +343,20 @@ impl Interpreter {
         let declared_shape_key = format!("__mutsu_shaped_array_dims::{var_name}");
         let has_declared_shape = self.env().contains_key(&declared_shape_key);
         let idx = self.stack.pop().unwrap_or(Value::NIL);
+        // ADR-0058: a SLICE assignment (`@n[0,1] = (1,2).map({...})`) is a
+        // LIST assignment -- it distributes the Seq's elements across the
+        // targeted slots, so it is eager (`roast/S32-list/seq.t` #18, "Array
+        // slice assigned from Seq is eager"). A SINGLE-element assignment is
+        // not: it itemizes the Seq into that element's Scalar container and
+        // leaves it unforced (measured against raku: `my %h; %h<f> =
+        // (1..3).map({die}); say "alive"` prints "alive").
+        let idx_is_slice = matches!(
+            idx.view(),
+            ValueView::Array(..) | ValueView::Seq(_) | ValueView::Slip(_) | ValueView::Whatever
+        ) || idx.is_range();
+        if idx_is_slice && let Some(top) = self.stack.last().cloned() {
+            self.reify_map_grep_seq(&top)?;
+        }
         // A user-defined Associative/Positional object in a scalar
         // (`my $q = URI::Query.new(...); $q<baz> = v` / `$q[0] = v`) dispatches
         // the raku subscript protocol (ASSIGN-KEY/ASSIGN-POS) — without this

--- a/src/vm/vm_var_assign_local.rs
+++ b/src/vm/vm_var_assign_local.rs
@@ -9,6 +9,15 @@ impl Interpreter {
         idx: u32,
     ) -> Result<(), RuntimeError> {
         let idx = idx as usize;
+        // ADR-0058: assigning a Seq to an `@`/`%` target reifies it (raku list
+        // semantics) — the same rule `exec_set_local_op_inner` applies to the
+        // `my @a = SEQ` declaration form. This is the plain reassignment form
+        // (`(@p = (^5).map: {...}).tail`).
+        if (code.locals[idx].starts_with('@') || code.locals[idx].starts_with('%'))
+            && let Some(top) = self.stack.last().cloned()
+        {
+            self.reify_map_grep_seq(&top)?;
+        }
         // A whole `%`/`@` reassignment breaks every `:=`-bound element — drop the
         // read-only-element markers so a later `%h<k> = v` is writable again.
         if crate::env::elem_index_meta_possible() {

--- a/src/vm/vm_var_trait_ops.rs
+++ b/src/vm/vm_var_trait_ops.rs
@@ -243,6 +243,14 @@ impl Interpreter {
                 // If so, construct the QuantHash from those values instead of creating
                 // an empty one. This handles `my %h is Bag = <a b b c>`.
                 let current_val = self.read_local_slot_or_name(code, eff_slot, &name_str);
+                // ADR-0058: `my %r is SetHash = %h.map: {...}` binds the Seq
+                // into the slot BEFORE this trait runs (the declaration emits
+                // `MarkBindContext; SetLocal`, so `exec_set_local_op_inner`'s
+                // `@`/`%` reify is skipped), and the coercion below reads the
+                // elements through pure code. Run the callback first.
+                if let Some(v) = current_val.as_ref() {
+                    self.reify_map_grep_seq(v)?;
+                }
                 let has_init_values = match current_val.as_ref().map(Value::view) {
                     Some(ValueView::Hash(h)) => !h.is_empty(),
                     Some(ValueView::Array(a, _)) => !a.is_empty(),

--- a/t/map-callback-runs-at-consumption.t
+++ b/t/map-callback-runs-at-consumption.t
@@ -12,10 +12,13 @@ use Test;
 # sink forces the Seq is uncaught. `t/try-sink-semantics.t` pins the
 # sink-placement half of this; the laziness half is docs/adr/0058.
 #
-# Part 2's rows are `todo` because mutsu evaluates a `.map` over a finite
-# source eagerly, at the `.map` call, so the callback has already thrown by the
-# time the `try` block's tail value exists. Un-`todo` them when ADR-0058 lands
-# --- they are that ADR's completion oracle.
+# Part 2's rows were `todo` until ADR-0058 step 2 landed: mutsu used to
+# evaluate a `.map` over a finite source eagerly, at the `.map` call, so the
+# callback had already thrown by the time the `try` block's tail value existed.
+# `.map` now hands back a `Seq` whose `SeqSource::MapGrep` body runs the
+# callback at first consumption, so these rows pass. The two remaining `todo`s
+# are Part 1's, and belong to the separate `fail`-under-an-enclosing-`try` bug
+# recorded in ADR-0058 S1.4.
 
 plan 23;
 
@@ -79,13 +82,11 @@ sub run-snippet($code) {
 
 {
     my ($rc, $out) = run-snippet('try { (1..3).map({die "boom"}) }; say "alive ", $!.defined');
-    todo 'ADR-0058: a finite-source .map runs its callback eagerly', 2;
     isnt $rc, 0, 'P4: a dying map callback escapes a statement-position try';
     unlike $out, /'alive'/, 'P4: ... and the next statement never runs';
 }
 {
     my ($rc, $out) = run-snippet('sub f { (1..3).map({die "boom"}) }; try { f() }; say "alive"');
-    todo 'ADR-0058: a finite-source .map runs its callback eagerly', 2;
     isnt $rc, 0, 'P5: same, through one level of call indirection';
     unlike $out, /'alive'/, 'P5: ... and the next statement never runs';
 }
@@ -93,25 +94,21 @@ sub run-snippet($code) {
     my ($rc, $out) = run-snippet(
         'sub f { (1..3).map({die "boom"}) }; sub ee { try { f() } }; say ee().^name; say "alive"');
     is $rc, 0, 'P18: the program survives a dying map Seq used as the try value';
-    todo 'ADR-0058: a finite-source .map runs its callback eagerly';
     like $out, /^^ 'Seq'/, 'P18: ... and the unforced Seq is still a Seq';
 }
 {
     my ($rc, $out) = run-snippet(
         'try { (1..3).map({die "boom"}) }; CATCH { default { say "unit-caught" } }; say "alive"');
     is $rc, 0, 'Q9: the program survives an escape caught by the enclosing CATCH';
-    todo 'ADR-0058: a finite-source .map runs its callback eagerly';
     like $out, /'unit-caught'/, 'Q9: ... and the enclosing block CATCH reports it';
 }
 {
     my ($rc, $out) = run-snippet('sub f { (1..3).map({ fail "x" }) }; try { f() }; say "alive"');
-    todo 'ADR-0058: a finite-source .map runs its callback eagerly', 2;
     isnt $rc, 0, 'Q14: a failing map callback escapes the try too';
     unlike $out, /'alive'/, 'Q14: ... and the next statement never runs';
 }
 {
     my ($rc, $out) = run-snippet(
         'my $s = (1..3).map({ say "side $_"; $_ }); say "before"; say $s.List');
-    todo 'ADR-0058: a finite-source .map runs its callback eagerly';
     like $out, /^ 'before'/, 'the map callback runs after the statement following the .map';
 }

--- a/todo/deep/residual-try-cell-eager-seq-reification-divergences.md
+++ b/todo/deep/residual-try-cell-eager-seq-reification-divergences.md
@@ -1,55 +1,49 @@
-# Residual try-cell divergences: `.map` runs its callback eagerly
+# Residual try-cell divergences: a force-time `fail` under an enclosing `try`
 
-**Re-diagnosed 2026-08-22.** All twelve cells below were re-measured against a
-current `main` build and all twelve still reproduce — none was fixed by an
-intervening change. The design for the main root cause now lives in
-[ADR-0058](../../docs/adr/0058-map-grep-produce-a-deferred-seq.md) (`Proposed`),
-and the whole cell matrix is pinned as a rakudo-verified oracle in
-`t/map-callback-runs-at-consumption.t` (23 rows; raku passes 23/23, mutsu 12,
-with the 11 divergent rows marked `todo`). This file stays open only to track
-that the work is not done.
+**Scope narrowed 2026-09-07.** [ADR-0058](../../docs/adr/0058-map-grep-produce-a-deferred-seq.md)
+step 2 shipped: `.map` (method form) now returns a `Seq` whose
+`SeqSource::MapGrep` body runs the callback at first consumption, so the nine
+rows this ticket owned — P4, P5, P12, P13, P18, Q9, Q11, Q14 and the
+side-effect-ordering row — now match rakudo and are un-`todo`d in
+`t/map-callback-runs-at-consumption.t`. ADR-0058 S8 records what step 0
+measured and which of the ADR's premises did not survive contact with the code.
 
-## The root cause is NOT what this ticket originally said
+## What is left
 
-The original text (and [ADR-0034](../../docs/adr/0034-seq-reification-is-in-place-and-distinct-from-consumption.md)
-§6 quoting it) blamed "mutsu forces a `map`-produced `LazyList` at the
-assignment/call boundary" and pointed at `force_lazy_list_vm`'s callers. That
-does not fit the cells: `(1..3)` is **finite**, so `is_lazy_pipe_source`
-(`src/runtime/methods_collection.rs`) is false and **no `LazyList` is ever
-built**. `dispatch_map_method` (`src/runtime/methods_dispatch_match2.rs`)
-materializes the source and calls `eval_map_over_items` immediately, inside the
-`try`. There is no deferred value whose force could be moved — the callback has
-already run by the time the `try` block's tail value exists.
-
-mutsu's `try`/sink *placement* is also not at fault and must not be touched:
-`compile_try_region` leaves the tail value on the stack and lets the enclosing
-statement's `SinkPop` force it outside the trap, which is rakudo's own rule
-(`news/2026-08/try-statement-sink-semantics-pinned.md`).
-
-**The real cause is that `.map`/`.grep` are eager over a finite source in mutsu
-and lazy in rakudo.** This is observable with no `try` and no exception at all:
+**Two rows, and they are a different bug from the one this file was opened for.**
+Q5/Q6/R6/R7 use a `...` **stub** callback, which mutsu already deferred before
+ADR-0058 (`create_lazy_map_list`, gated on `is_stub_routine_body`), so
+eagerness was never their problem. Measured against a current build, mutsu
+matches raku exactly for the stub map as soon as the enclosing `try` is removed:
 
 ```raku
-my $s = (1..3).map({ say "side $_"; $_ }); say "before"; say $s.List;
-# raku:  before / side 1 / side 2 / side 3 / (1 2 3)
-# mutsu: side 1 / side 2 / side 3 / before / (1 2 3)
+sub ee { map -> $x, $y { ... }, 1..6; say "reached-tail"; "done" }
+say ee(); say "alive";       # both: "Stub code executed", exit 1
+say ee().^name; say "alive"; # both: Failure / alive, exit 0
 ```
 
-`.grep` behaves the same way and does not even have the `return`/stub deferral
-`.map` has.
+Add the `try` back and the divergence appears:
 
-## What is left to do
+```raku
+sub ee { try { map -> $x, $y { ... }, 1..6 }; say "reached-tail"; $! }
+say ee().^name; say "alive"
+# raku:  throws, "reached-tail" never printed, exit 1
+# mutsu: Failure / reached-tail / alive, exit 0
+```
 
-- **Nine of the eleven divergent rows** (P4, P5, P12, P13, P18, Q9, Q11, Q14 and
-  the side-effect-ordering row) are ADR-0058's target. Implementing that ADR
-  un-`todo`s them; it also makes mutsu **stricter**, so a full `make roast` is
-  mandatory, not `make test` alone.
-- **The other two rows** (Q5/Q6/R6/R7's exit status) are a **separate, narrower
-  bug**, recorded in ADR-0058 §1.4: the stub-map path already defers correctly
-  and already matches raku once the enclosing `try` is removed. What diverges is
-  how a `fail` raised *during the force* resolves when a `try` sits lexically
-  between it and the routine — mutsu returns it from the routine as a `Failure`,
-  rakudo throws it. Nobody has looked into that yet.
+So the force lands in the right place (the enclosing statement's `SinkPop`,
+outside the trap — `t/try-sink-semantics.t` pins that half and must keep
+passing). What differs is **how a `fail` raised during that force resolves when
+a `try` sits lexically between it and the routine**: mutsu lets it return from
+the routine as a `Failure`, rakudo throws it. Nobody has looked into that yet.
 
-`t/try-sink-semantics.t` pins the sink-placement half and must keep passing
-through both fixes.
+The two rows are pinned as the only remaining `todo`s in
+`t/map-callback-runs-at-consumption.t` (rows 1 and 3, "a force-time `fail` under
+an enclosing `try` returns a Failure instead of throwing"). Un-`todo`ing them is
+this ticket's completion signal.
+
+## Not part of this ticket
+
+ADR-0058 steps 3 (extend the deferral to `builtin_map` and both `grep` entry
+points) and 4 (retire the `body_contains_return`/`is_stub_routine_body`
+deferral predicate and `create_lazy_map_list`) are tracked in the ADR, not here.


### PR DESCRIPTION
Implements [ADR-0058](../blob/main/docs/adr/0058-map-grep-produce-a-deferred-seq.md) **step 0** (measure) and **step 2** (the slice). Steps 3 and 4 stay open.

## The bug

`.map` was eager, so a callback that dies inside a `try` was caught by that `try` where rakudo lets it escape:

```raku
try { (1..3).map({die "boom"}) }; say "alive ", $!.defined
# raku:  dies, uncaught ("boom")
# mutsu: alive True
```

The ADR's re-diagnosis was re-measured on a fresh build before starting and is still accurate: the ticket's original root cause ("mutsu forces a map-produced `LazyList` at the assignment boundary") does **not** fit these cells — `(1..3)` is finite, `is_lazy_pipe_source` is false, and no `LazyList` is ever built. `try`/sink placement is also not at fault. The real cause is that `.map`/`.grep` are eager in mutsu and lazy in rakudo.

## The change

`dispatch_map_method` returns `Value::seq_deferred(SeqSource::MapGrep { items, func, fatal })`; `Interpreter::pull_seq_source` gains the arm that runs the callback, driven by ADR-0034's existing `reify`/`take`/`sink` split. No new `Value` variant, no new forcing rules, no `Env` clone.

**Completion signal:** nine of the eleven `todo` rows in `t/map-callback-runs-at-consumption.t` (the ADR's oracle, raku-verified 23/23) are un-`todo`d. The two that remain are Part 1's and belong to the separate force-time-`fail` bug (ADR-0058 §1.4).

## Step 0 — what the exposure probe actually measured

Run as the ADR specified (`dispatch_map_method`/`builtin_map` flipped to always call `create_lazy_map_list` behind a throwaway `MUTSU_ADR0058_STEP0` env gate, discarded afterwards):

| Suite | Failing under the step-0 gate | Failing under the real mechanism |
| --- | --- | --- |
| `prove -j4 t/` (3735 files) | 59 | 44 → 0 |
| roast whitelist, release (1436 files) | 55 | 0 |

**The proxy over-reported, systematically.** About half the extra `t/` hits were the `concurrent-*`/`thread-*`/`cas-*`/`shared-*` family, which fail under option 1 for a reason option 3 does not have: `create_lazy_map_list` does `let mut env = self.env.clone()`, **snapshotting** the captured lexicals, so a shared cell mutated by a `start` block inside the callback is lost. `SeqSource::MapGrep` reuses the callback `Value`'s own closure env and none of those files ever failed.

Step 0's real value was confirming the exposure is a *bounded, enumerable* list of element readers clustering into a handful of funnels. Recommendation recorded in the ADR: run the probe with the mechanism you intend to ship, behind a gate — the proxy's own defects dominate the signal, and it costs nothing extra.

## Read-path consumers fixed (ADR-0058 §8.2 has the full list)

`reify_map_grep_seq`/`_args`/`sink_map_grep_seq` are the guard — tag-probed before `view()` (a `view()` on a lazy `Match` materializes it, ADR-0016 P5), and a no-op for every other `SeqSource`, whose streaming semantics must not be forced at an argument boundary. By funnel: argument boundaries (builtins, native functions/methods, closures, `call_sub_value`, `await`); rendering and coercion (`say`/`note`/`put`/`print`, `~`, `Str`/`Num` coerce); operators (the shared binary funnel, `Z`/`X`, `[op]` reduction, `(elem)`, smartmatch); `@`/`%` assignment (`SetGlobal`, `AssignExpr`, `AssignExprLocal`, and slice `IndexAssignExprNamed`); composition and hyper; the `Test` handlers that discard a block's value; the program's own tail statement; `flatmap`; and `ApplyVarTrait`.

## Premises that did not survive contact with the code

Three, and each turned out to be a real bug rather than a detail (ADR-0058 §8.3):

- **`SeqBody::take` never stored what it pulled.** `take` on a genuinely deferred source hands the elements to the caller and leaves `gens` empty, but two consumers (`.iterator`'s arm, and `exec_hyper_method_call_op`) call `take` and then read the *same body* back through `Deref`. A latent ADR-0034 bug, invisible while only `IO::Handle.lines` produced deferred bodies — it made `method iterator() { self.pairs.iterator }` in a `does Iterable` role iterate zero elements. Fixed with `SeqBody::store_taken_elements`.
- **`use fatal` is lexical, so it cannot be read at pull time.** Deferring the loop moved `eval_map_over_items`'s `self.fatal_mode` read to the consumer's dynamic context, which both retroactively fatalized a soft Failure and suppressed a genuinely fatal one. The source now carries the `fatal` captured at the `.map` call.
- **A deferred body needs the same caller writeback a `LazyList` force does** (`reconcile_caller_after_lazy_force`), or a `LAST $ran = True` in the callback never reaches the consuming frame's slot.

Plus two measured semantics, both checked against `raku`: an **element** store itemizes the Seq and stays unforced (`my %h; %h<f> = (1..3).map({die}); say "alive"` prints "alive"), while a **slice** store is a list assignment and is eager (`roast/S32-list/seq.t` #18).

## Verification

- `prove -e target/debug/mutsu t/map-callback-runs-at-consumption.t` — 23/23, only the two §1.4 `todo`s left
- `raku t/map-callback-runs-at-consumption.t` — 23/23 (reference)
- `make test` — 933 cargo tests + 3735 TAP files, PASS
- **`make roast` locally, release, run alone** — 1436 files / 218962 tests, PASS. This was mandatory: the change makes mutsu *stricter* in every ticket cell, so it can newly abort files that used to pass. The first full roast run surfaced 8 real regressions (hyper/race, set ops, smartmatch, composition, slice assign, the program tail sink), all fixed here.
- `cargo fmt` + `cargo clippy --all-targets -- -D warnings` clean

## Known remaining holes (deliberately not closed)

The infallible set operators (`exec_set_diff_op`, `set_sym_diff`, `subset`/`superset`/`strict_*`) read their operands purely and cannot propagate a callback's exception without a signature change; nothing in `t/` or the roast whitelist exercises them today. Step 3, which makes `grep` deferred too, should revisit them. Recorded in ADR-0058 §8.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
