### PR TITLE
fix(mop): `.^add_method` installs a routine-backed code object

### DIFF
--- a/news/2026-09/add-method-installs-a-routine-backed-code-object.md
+++ b/news/2026-09/add-method-installs-a-routine-backed-code-object.md
@@ -1,0 +1,70 @@
+# `.^add_method` installs a routine-backed code object, instead of an empty method
+
+```raku
+class C { }
+C.^add_method('m', my method m5() { 5 });
+C.^compose;
+say C.m();      # raku: 5   mutsu was: Nil
+```
+
+`.^add_method` silently installed a method with an **empty body** whenever the
+code object it was handed was a *named, separately-declared routine*. The method
+was genuinely registered — `.^can` found it, `.^lookup` returned a defined
+`Method`, `.^methods` counted it, and its `.name` and `.signature` read back
+plausibly — and the call just answered `Nil`, with no error anywhere.
+
+Every *anonymous* shape worked: `method () {...}`, `my method () {...}`,
+`anon method n() {...}`, a pointy block. That split is what made the bug hard to
+see from the outside, and it is also why the batteries never hit it.
+
+## What the ticket said, and what was actually true
+
+`todo/deep/direct-metamodel-classhow-new-type-immutable-error.md` had been
+narrowed to "a method-dispatch gap on a `new_type`-minted `Package`". It has
+nothing to do with `new_type`: an ordinary `class C { }` shows it identically.
+What decides the outcome is the shape of the code object, not the shape of the
+type it is being added to.
+
+The code object was never at fault either — calling the very same
+`my $m = my method m() { 42 }` through `$m()` returned `42`.
+
+## Root cause
+
+`add_method` builds its `MethodDef` from the Sub's AST `body` plus its
+`compiled_code`. A Sub built from a **declared routine** — `&foo`, a
+`.candidates` entry, a `my sub` / `my method` read back through `GetCodeVar` —
+carries its bytecode in `SubData::compiled_routine` instead. The two fields are
+kept deliberately apart, because they are invoked under different calling
+conventions, and ADR-0019 C6c stopped the sub declaration plan shipping an
+executable AST at all. `MethodDef` has no `compiled_routine` field, so the def
+came out with an empty body and no code.
+
+It is visible straight from `--dump-bytecode`: a named `my method a() { 42 }` in
+expression position compiles to `RegisterDecl(0); GetCodeVar("a")` plus a
+separate `sub GLOBAL::a` chunk, while the anonymous form compiles to a single
+`MakeAnonSubParams` that carries the body with it.
+
+The fix takes the routine's own `CompiledCode` when the Sub is routine-backed and
+carries no closure body. The method ABI drives parameter binding from the
+`MethodDef`'s own `params`/`param_defs`, which `add_method` already fills in from
+the Sub, so the routine's bytecode runs correctly under it — verified across the
+shapes that actually exercise the convention: reading `self`'s attributes,
+positional parameters, a named parameter and its default, a `:D` invocant
+constraint, and an explicit `return` in the body.
+
+`t/add-method-named-routine.t` pins 16 rows against `raku` v2026.07, including
+the four anonymous shapes that already worked and the registration
+introspection that was always right.
+
+## Two things measured alongside, deliberately left open
+
+Both are recorded in the ticket, which stays open for them:
+
+- **The installed method reports the name it was added under**, where raku
+  reports the routine's own name: `A.^lookup('m').name` is `m` in mutsu and `m9`
+  in raku. Kept as a `todo` row in the pin.
+- **A plain `sub` used as a method does not receive the invocant as its first
+  positional.** `B.^add_method('p', &plain)` with `sub plain($x)` answers `42`
+  for `B.p(21)`; raku rejects the call, because the invocant occupies the first
+  slot. It answered `Nil` before this change, so it was wrong either way — but
+  now it is wrong *loudly enough to be worth fixing separately*.

--- a/src/runtime/methods_classhow_dispatch.rs
+++ b/src/runtime/methods_classhow_dispatch.rs
@@ -1008,6 +1008,23 @@ impl Interpreter {
                     }
                     None => (sub_data.body.clone(), sub_data.compiled_code.clone()),
                 };
+                // A Sub built from a DECLARED routine (`my method m() {...}`,
+                // `my sub a() {...}`, `&foo` -- anything read back through
+                // `GetCodeVar`) carries its bytecode in `compiled_routine`, not
+                // in `compiled_code`: ADR-0019 C6c stopped the declaration plan
+                // shipping an executable AST, and `SubData` keeps the two apart
+                // because they are invoked under different calling conventions.
+                // Without this, `add_method` registered a `MethodDef` with an
+                // empty body and no code, so the method was findable by
+                // `.^can`/`.^lookup` and answered `Nil` when called -- silently.
+                // Only the anonymous shapes (`method () {...}`, a pointy block)
+                // ever worked. See `t/add-method-named-routine.t`.
+                let method_compiled = match (&method_compiled, sub_data.compiled_routine.as_ref()) {
+                    (None, Some(routine)) if method_body.is_empty() => {
+                        Some(std::sync::Arc::new(routine.code.clone()))
+                    }
+                    _ => method_compiled,
+                };
                 // The name list has to lose the invocant too, not just
                 // `param_defs`: dispatch binds arguments positionally against
                 // `params`, so leaving `self` in it shifted every argument by one

--- a/t/add-method-named-routine.t
+++ b/t/add-method-named-routine.t
@@ -1,10 +1,10 @@
 use Test;
 
 # `.^add_method(name, $code)` must install a callable method whatever shape the
-# code object arrives in. In mutsu it silently installs an EMPTY one whenever
-# `$code` is a NAMED, separately-declared routine: the method is registered
-# (`.^can`, `.^lookup`, `.^methods`, its `.name` and `.signature` are all
-# right), and calling it returns `Nil` with no error.
+# code object arrives in. mutsu used to silently install an EMPTY one whenever
+# `$code` was a NAMED, separately-declared routine: the method was registered
+# (`.^can`, `.^lookup`, `.^methods`, its `.name` and `.signature` were all
+# right) and calling it returned `Nil` with no error.
 #
 # `todo/deep/direct-metamodel-classhow-new-type-immutable-error.md` recorded
 # this as "a method-dispatch gap on a `new_type`-minted Package". Measured
@@ -12,14 +12,14 @@ use Test;
 # ordinary `class C { }` shows it identically, and what actually decides the
 # outcome is whether the code object is anonymous or a named declaration.
 #
-# The value itself is fine -- calling the same `my method m() { 42 }` directly
-# through its variable returns 42. `add_method` builds its `MethodDef` from the
-# Sub's AST `body` plus `compiled_code`, and a Sub built from a DECLARED routine
-# carries its bytecode in `compiled_routine` instead (ADR-0019 C6c stopped the
-# declaration plan shipping an executable AST), which `MethodDef` has no field
-# for.
+# The value itself was always fine -- calling the same `my method m() { 42 }`
+# directly through its variable returned 42. `add_method` builds its `MethodDef`
+# from the Sub's AST `body` plus `compiled_code`, and a Sub built from a DECLARED
+# routine carries its bytecode in `compiled_routine` instead (ADR-0019 C6c
+# stopped the declaration plan shipping an executable AST); `MethodDef` has no
+# field for it, so it now takes the routine's own `CompiledCode`.
 
-plan 10;
+plan 16;
 
 # What already works: every anonymous shape.
 {
@@ -61,14 +61,12 @@ plan 10;
     class A5 { }
     A5.^add_method('m', my method m5() { 5 });
     A5.^compose;
-    todo 'a named `my method` installs an empty body';
     is A5.m(), 5, 'a named `my method` installs and runs';
 }
 {
     class A6 { }
     A6.^add_method('m', my method m6(A6:) { 6 });
     A6.^compose;
-    todo 'same mechanism; the type invocant is not what breaks it';
     is A6.m(), 6, 'a named `my method` with a type invocant installs and runs';
 }
 {
@@ -77,7 +75,6 @@ plan 10;
     constant A7 := Metamodel::ClassHOW.new_type(name => 'A7');
     A7.^add_method('m', my method m7(A7:) { 7 });
     A7.^compose;
-    todo 'same mechanism, reached through a hand-minted type';
     is A7.m(), 7, 'the MOP example from Language/mop.rakudoc runs';
 }
 
@@ -89,4 +86,37 @@ plan 10;
     A9.^compose;
     todo 'mutsu reports the added name, raku the routine name';
     is A9.^lookup('m').name, 'm9', 'lookup reports the routine name';
+}
+
+# Shapes that exercise the routine calling convention through the method ABI.
+{
+    class B1 { has $.n = 7 }
+    B1.^add_method('get', my method g1() { self.n });
+    B1.^compose;
+    is B1.new.get(), 7, 'a routine-backed method reads the invocant\'s attributes';
+}
+{
+    class B2 { }
+    B2.^add_method('add', my method g2($a, $b) { $a + $b });
+    B2.^compose;
+    is B2.add(3, 4), 7, 'positional parameters bind';
+}
+{
+    class B3 { }
+    B3.^add_method('nam', my method g3(:$k = 9) { $k });
+    B3.^compose;
+    is B3.nam(:k(5)), 5, 'a named parameter binds';
+    is B3.nam(), 9, 'and its default applies';
+}
+{
+    class B5 { has $.v = 3 }
+    B5.^add_method('d', my method g5(B5:D:) { self.v });
+    B5.^compose;
+    is B5.new.d(), 3, 'a :D invocant constraint binds';
+}
+{
+    class B7 { }
+    B7.^add_method('r', my method g7() { return 11; 99 });
+    B7.^compose;
+    is B7.r(), 11, 'an explicit `return` inside the routine body works';
 }

--- a/todo/deep/direct-metamodel-classhow-new-type-immutable-error.md
+++ b/todo/deep/direct-metamodel-classhow-new-type-immutable-error.md
@@ -36,6 +36,28 @@ And the code object itself is fine: calling the very same
 `my $m = my method m() { 42 }` through `$m()` returns `42`. So `add_method`
 drops the body; the producer does not.
 
+## FIXED 2026-09-06
+
+`news/2026-09/add-method-installs-a-routine-backed-code-object.md`. `add_method`
+now takes the routine's own `CompiledCode` when the Sub is routine-backed and
+carries no closure body, and `t/add-method-named-routine.t` covers 16 rows
+against raku including the parameter, named-argument, `:D`-invocant and explicit
+-`return` shapes that exercise the routine calling convention through the method
+ABI.
+
+Two things measured alongside it are NOT fixed and stay open:
+
+- **The installed method reports the name it was ADDED under**, where raku
+  reports the routine's own name (`A9.^lookup('m').name` is `m` in mutsu, `m9`
+  in raku). Pinned as a `todo` row in that file.
+- **A plain `sub` used as a method does not receive the invocant as its first
+  positional.** `B.^add_method('p', &plain)` with `sub plain($x)` answers 42 for
+  `B.p(21)` in mutsu; raku rejects the call ("Too many positionals passed;
+  expected 1 argument but got 2") because the invocant occupies the first slot.
+  Before this fix the same call answered `Nil`, so it was wrong either way.
+
+The rest of this file below is the historical record.
+
 ## Root cause
 
 `add_method` (`src/runtime/methods_classhow_dispatch.rs`, the `"add_method"` arm)


### PR DESCRIPTION
Fixes the surviving half of `todo/deep/direct-metamodel-classhow-new-type-immutable-error.md`, whose oracle landed in #7415 as 10 rows with 4 `todo`. This un-`todo`s three of them.

## The bug

```raku
class C { }
C.^add_method('m', my method m5() { 5 });
C.^compose;
say C.m();      # raku: 5   mutsu: Nil
```

`.^add_method` silently installed a method with an **empty body** whenever the code object was a *named, separately-declared routine*. The method was genuinely registered — `.^can` found it, `.^lookup` returned a defined `Method`, `.^methods` counted it, and its `.name` and `.signature` read back plausibly — and the call just answered `Nil`, with no error anywhere.

Every **anonymous** shape worked (`method () {...}`, `my method () {...}`, `anon method n() {...}`, a pointy block), which is why the batteries never hit it and why the ticket had mis-attributed it to `new_type`.

## Root cause

`add_method` builds its `MethodDef` from the Sub's AST `body` plus its `compiled_code`. A Sub built from a **declared routine** — `&foo`, a `.candidates` entry, a `my sub` / `my method` read back through `GetCodeVar` — carries its bytecode in `SubData::compiled_routine` instead. The two are kept deliberately apart because they are invoked under different calling conventions, and ADR-0019 C6c stopped the sub declaration plan shipping an executable AST at all. `MethodDef` has no field for it, so the def came out with an empty body and no code.

Straight from `--dump-bytecode`: the named form compiles to `RegisterDecl(0); GetCodeVar("a")` plus a separate `sub GLOBAL::a` chunk, while the anonymous form compiles to a single `MakeAnonSubParams` that carries the body with it.

The fix takes the routine's own `CompiledCode` when the Sub is routine-backed and carries no closure body. The method ABI drives parameter binding from the `MethodDef`'s own `params`/`param_defs`, which `add_method` already fills in from the Sub, so the routine's bytecode runs correctly under it.

## Verified across the shapes that exercise the calling convention

`t/add-method-named-routine.t` grows 10 → 16 rows, all measured against `raku` v2026.07: reading `self`'s attributes, positional parameters, a named parameter and its default, a `:D` invocant constraint, and an explicit `return` in the body — plus the `Language/mop.rakudoc` example the ticket was originally filed from, and the four anonymous shapes that already worked.

`make test` passes (3746 files / 38896 tests). Every whitelisted `roast/S12-*` and `roast/S14-roles` file passes locally (`S12-meta/exporthow.t` fails, but it is not whitelisted and fails on `main` too); full roast delegated to CI.

## Deliberately left open

Two divergences measured alongside, both recorded in the ticket, which stays open for them:

- the installed method reports the name it was **added under** (`m`) where raku reports the routine's own name (`m9`) — still a `todo` row in the pin;
- a plain `sub` used as a method does not receive the invocant as its first positional. `B.^add_method('p', &plain)` with `sub plain($x)` answers `42` for `B.p(21)`; raku rejects the call because the invocant occupies the first slot. It answered `Nil` before this change, so it was wrong either way — but it is now wrong loudly enough to be worth its own fix.