### PR TITLE
test(react): pin whenever-Tap close ordering, and reconcile ADR-0053's header

### DIFF
--- a/docs/adr/0053-do-whenever-produces-a-tap-on-the-stack.md
+++ b/docs/adr/0053-do-whenever-produces-a-tap-on-the-stack.md
@@ -1,6 +1,6 @@
 # ADR-0053: `do whenever` produces a `Tap` on the stack — retiring the source-variable name bridge
 
-- Status: Proposed (design complete; implementation not started)
+- Status: Proposed (design complete; **partially implemented** — see §8)
 - Date: 2026-08-20
 - Origin: `todo/deep/whenever-expression-position-needs-real-design.md`
   (re-verified against `main` @ `16a7def3e`, 2026-08-20). The investigation
@@ -332,3 +332,35 @@ closure clone (plus one per `LAST`/`QUIT` phaser) that the same function
 already performs. The drive loop gains one set lookup per subscription per
 poll round; it already performs per-round per-subscription source polling.
 No steady-state emit-path cost is added.
+
+## 8. Status reconciliation (2026-09-06)
+
+The header said "implementation not started" for two and a half weeks after it
+stopped being true. Measured on `main`:
+
+- **`.WHAT` already answers `Tap`** for both legal shapes,
+  `my $tap = do whenever $s.Supply -> $x {…}` and `do { whenever $s {…} }`. The
+  `Str "whenever"` / `Supply` / `Any` answers this ADR was written against are
+  gone, and so is the source-variable name bridge's visible symptom.
+- **The subscription identity half is not done**, and it is worse than the
+  originating ticket recorded. `Tap.close` does not merely drop the value
+  emitted immediately before it: it discards **every event the react loop has
+  not yet processed**. With two emits followed by a close — no ordering
+  ambiguity at all — raku delivers both and mutsu delivers neither.
+
+The site is `Interpreter::drain_waker_events`
+(`src/vm/vm_react_subscriptions.rs`): it calls `waker.drain()`, which hands back
+the whole FIFO batch, and *then* consults `is_whenever_closed` per event. The
+close is a bit in a process-global set with no position in the event order, so
+that check cannot distinguish an event queued before the close from one queued
+after, and drops both.
+
+Closing this needs an ordering between the close and the queued emits — either
+enqueue the close as an event on the same waker queue (closest to raku, but
+`close_whenever` is a free function with no waker in scope), or stamp events with
+an emit counter and give the close an epoch (less invasive, but adds a counter to
+the hot emit path). The global bit stays as the steady-state "this subscription is
+retired" check; only the in-batch test changes.
+
+Pinned by `t/whenever-tap-close-ordering.t` — four rows, all green under raku, the
+two close rows `todo` under mutsu.

--- a/t/whenever-tap-close-ordering.t
+++ b/t/whenever-tap-close-ordering.t
@@ -1,0 +1,71 @@
+use Test;
+
+# Closing a `whenever`'s Tap must stop FUTURE deliveries only. Values already
+# emitted before the `.close` are still delivered, because the emit and the
+# close are ordered against each other.
+#
+# mutsu drops them: `close_whenever` sets a global flag, and
+# `Interpreter::drain_waker_events` (`vm/vm_react_subscriptions.rs`) checks that
+# flag AFTER `waker.drain()` has already handed it the queued batch -- so every
+# event the react loop had not got to yet is discarded, however long before the
+# close it was emitted.
+#
+# Measured 2026-09-06 against raku v2026.07. ADR-0053 owns the design.
+
+plan 4;
+
+# The tap is a real Tap object in both -- ADR-0053's header still says
+# "implementation not started", which is stale for this row.
+{
+    my $s = Supplier.new;
+    my $what;
+    react {
+        my $t = do whenever $s.Supply -> $x { };
+        $what = $t.WHAT.^name;
+        whenever Promise.in(0.1) { done }
+    }
+    is $what, 'Tap', 'a `do whenever` in expression position yields a Tap';
+}
+
+# No close: every emit is delivered. This is the control.
+{
+    my $s = Supplier.new;
+    my @got;
+    react {
+        my $t = do whenever $s.Supply -> $x { @got.push($x) };
+        $s.emit(1);
+        $s.emit(2);
+        whenever Promise.in(0.1) { done }
+    }
+    is @got, [1, 2], 'without a close, every emitted value arrives';
+}
+
+# Close AFTER both emits: both must still arrive.
+{
+    my $s = Supplier.new;
+    my @got;
+    react {
+        my $t = do whenever $s.Supply -> $x { @got.push($x) };
+        $s.emit(1);
+        $s.emit(2);
+        $t.close;
+        whenever Promise.in(0.1) { done }
+    }
+    todo 'the close discards the already-queued batch';
+    is @got, [1, 2], 'closing after two emits still delivers both';
+}
+
+# Close between: the first arrives, the second does not.
+{
+    my $s = Supplier.new;
+    my @got;
+    react {
+        my $t = do whenever $s.Supply -> $x { @got.push($x) };
+        $s.emit(1);
+        $t.close;
+        $s.emit(2);
+        whenever Promise.in(0.1) { done }
+    }
+    todo 'ditto -- the value emitted before the close is dropped too';
+    is @got, [1], 'closing between two emits delivers only the first';
+}

--- a/todo/deep/whenever-expression-position-needs-real-design.md
+++ b/todo/deep/whenever-expression-position-needs-real-design.md
@@ -184,14 +184,69 @@ react {
 # prints "Supply", not "Tap" -- even the narrow do{}-wrapped case is broken
 ```
 
-## Re-verified 2026-09-01 (TRIAGE regeneration): the symptom moved
+## Re-verified 2026-09-01: the symptom moved
 
 Both legal shapes (`my $tap = do whenever ...` and `do { whenever ... }`) now
-answer `Tap` for `.WHAT` and deliver `got 1` — the `Str "whenever"` /
-`Supply` / `Any` symptoms above are gone. What is still wrong is the
-**subscription identity** half: after `$s.emit(1); $tap.close; $s.emit(2)`,
-raku prints `got 1` then `done`, but mutsu prints only `done` — closing the
-Tap retroactively drops the value emitted *before* the close. ADR-0053's
-header still says "implementation not started", which is stale relative to
-the `.WHAT` result; whoever picks this up should first reconcile the ADR with
-whatever landed, then implement the identity slice.
+answer `Tap` for `.WHAT` — the `Str "whenever"` / `Supply` / `Any` symptoms above
+are gone. ADR-0053's header still says "implementation not started", which is
+stale relative to that.
+
+## Re-measured 2026-09-06: it is worse than "the value before the close", and the site is located
+
+`t/whenever-tap-close-ordering.t` pins the four rows below; all four are green
+under `raku` v2026.07, two are `todo` under mutsu.
+
+| shape | raku | mutsu |
+|---|---|---|
+| `.WHAT` of a `do whenever` | `Tap` | `Tap` |
+| two emits, **no** close | both delivered | both delivered |
+| two emits, **then** close | **both delivered** | **neither** |
+| emit, close, emit | first delivered | **neither** |
+
+So `.close` does not merely drop the one value emitted before it — it discards
+**every value the react loop has not got to yet**, however long before the close
+it was emitted. Row 3 has no ordering ambiguity at all: both emits precede the
+close and both are lost.
+
+### The site
+
+`Interpreter::drain_waker_events` (`src/vm/vm_react_subscriptions.rs`) does:
+
+```rust
+let events = waker.drain();          // the whole queued batch, FIFO
+for (key, event) in events {
+    if react_subs[key].whenever_id.is_some_and(is_whenever_closed) {
+        react_subs[key].done = true;
+        continue;                    // <-- discards an ALREADY-QUEUED event
+    }
+    ...
+```
+
+`Tap.close` (`native_tap`, `runtime/native_methods/scheduler.rs`) calls
+`close_whenever(id)`, which sets a bit in a process-global set
+(`native_methods/state.rs`). The bit has no position in the event order, so a
+check performed after the batch has been drained cannot tell an event that was
+queued *before* the close from one queued after it — and drops both.
+
+### What a fix has to supply
+
+An ordering between the close and the queued emits. The waker's
+`VecDeque<(usize, SinkEvent)>` is already FIFO, so the two shapes that fit are:
+
+- **make the close an event.** Enqueue a close marker on the same waker queue
+  instead of only setting the global bit; the drain then delivers what precedes
+  it and stops at it. Closest to raku's semantics and needs no sequence numbers,
+  but `close_whenever` is a free function with no waker in scope, so the Tap
+  would have to carry (or reach) its subscription's waker.
+- **give the close an epoch.** Record the global emit counter at close time and
+  stamp each queued event with the counter at enqueue time; drop only events
+  stamped later. Less invasive to the call graph, but adds a counter to the hot
+  emit path.
+
+Either way the global `closed_whenever_map` bit stays as the *steady-state*
+check (the three other consumers in `vm_react_subscriptions.rs` are about
+retiring a finished subscription, not about a single event) — what changes is
+only the in-batch check quoted above.
+
+ADR-0053 owns the design. Reconcile its header with the `.WHAT` row before
+implementing.


### PR DESCRIPTION
Works `todo/deep/whenever-expression-position-needs-real-design.md`, which `todo/TRIAGE.md` flags as "symptom moved again; reconcile ADR-0053's header before designing". **Tests and documentation only.**

## ADR-0053's header was stale

It said "implementation not started" for two and a half weeks after that stopped being true. Measured on `main`: `.WHAT` already answers `Tap` for both legal shapes (`my $tap = do whenever $s.Supply -> $x {…}` and `do { whenever $s {…} }`), and the source-variable name bridge's visible symptom is gone.

## The surviving half is worse than recorded

The ticket said `.close` "retroactively drops the value emitted *before* the close". It drops **every event the react loop has not yet processed**:

| shape | raku | mutsu |
|---|---|---|
| `.WHAT` of a `do whenever` | `Tap` | `Tap` |
| two emits, **no** close | both delivered | both delivered |
| two emits, **then** close | **both delivered** | **neither** |
| emit, close, emit | first delivered | **neither** |

Row 3 has no ordering ambiguity at all — both emits precede the close, and both are lost.

## Located

`Interpreter::drain_waker_events` (`src/vm/vm_react_subscriptions.rs`) calls `waker.drain()`, which hands back the whole FIFO batch, and *then* consults `is_whenever_closed` per event:

```rust
let events = waker.drain();          // the whole queued batch, FIFO
for (key, event) in events {
    if react_subs[key].whenever_id.is_some_and(is_whenever_closed) {
        react_subs[key].done = true;
        continue;                    // <-- discards an ALREADY-QUEUED event
    }
```

`Tap.close` sets a bit in a process-global set (`native_methods/state.rs`). The bit has no position in the event order, so a check performed after the batch is drained cannot distinguish an event queued before the close from one queued after — and drops both.

## What a fix needs, and what it must not touch

An ordering between the close and the queued emits. The waker's `VecDeque<(usize, SinkEvent)>` is already FIFO, so two shapes fit:

- **make the close an event** — enqueue a close marker on the same waker queue, so the drain delivers what precedes it and stops at it. Closest to raku, but `close_whenever` is a free function with no waker in scope.
- **give the close an epoch** — stamp events with the emit counter at enqueue and drop only later ones. Less invasive to the call graph, but adds a counter to the hot emit path.

Either way the global bit stays as the steady-state "this subscription is retired" check: three of the four `is_whenever_closed` consumers are about retiring a finished subscription, not about a single event. Only the in-batch test changes.

`t/whenever-tap-close-ordering.t` — four rows, all green under `raku` v2026.07, the two close rows `todo`. It also pins the `.WHAT` row that already works, so the half that landed cannot regress unnoticed again.