### PR TITLE
fix(dispatch): builtin methods declare the named arguments they accept

### DIFF
--- a/docs/adr/0070-native-methods-declare-the-named-arguments-they-accept.md
+++ b/docs/adr/0070-native-methods-declare-the-named-arguments-they-accept.md
@@ -1,0 +1,227 @@
+# ADR-0070: A builtin method declares the named arguments it accepts, and the arity cascade drops the rest
+
+- Status: **Proposed** (slice 1 implemented 2026-09-07)
+- Date: 2026-09-07
+- Related: [ADR-0021](0021-argument-namedness-is-a-call-site-property.md)
+  (argument named-ness is a call-site property),
+  [ADR-0019](0019-compiled-declarations-and-unified-method-dispatch.md)
+  (unified method dispatch entries, native method rows),
+  `news/2026-08/native-methods-honour-the-implicit-slurpy-named.md` (the loud
+  half of this bug), `todo/deep/native-method-accepted-named-declarations.md`
+
+## Context
+
+Every Raku *method* carries an implicit `*%_`, so a named argument the method
+does not declare is silently swallowed and cannot change the answer. mutsu's
+builtin methods are not dispatched by signature — they are dispatched by
+**arity**, by `native_method_0arg` / `_1arg` / `_2arg` and by three by-name
+handlers (`dispatch_method_by_name_1/2/3`), none of which has any notion of a
+named argument. A call-site `Pair` therefore occupies a positional slot.
+
+That has two symptoms, and only the first is fixed.
+
+**1. The lookup misses (loud).** `4.log(:base(2))` counted the `Pair` as a
+positional, looked up a 1-ary `log`, found none and died with
+`X::Method::NotFound`. Fixed 2026-08-25 by an implicit-`*%_` retry in
+`call_method_with_values`: offer the full argument list first, and only when the
+whole chain answers "no such method" retry with the nameds removed. That is
+provably non-regressive — a call that succeeds today never takes the retry — and
+it closed 24 measured divergences.
+
+**2. The wrong arm hits (silent).** When a positional slot happens to *accept*
+the `Pair`, it is numified or consumed as data and the call succeeds with the
+wrong answer. There is no error to retry on. A 2026-09-07 re-measurement swept
+2 600 (receiver, method, argument-shape) probes derived from
+`src/builtins/native_method_row_table.rs`, comparing `R.M(A)` against
+`R.M(A, :qqzz9)` in mutsu and then checking every divergence against `raku`:
+**754 probes were not named-blind in mutsu**, spanning about 30 methods. A
+sample, with the `todo/deep/` file's original six rows marked `*`:
+
+| call | raku | mutsu (before) |
+|---|---|---|
+| `"abc".chop(:zzz)` * | `"ab"` | `"abc"` (Pair numified to a 0 char count) |
+| `10.polymod(3, :zzz)` * | `(1, 3)` | `(1, 3, Inf)` (Pair became a modulus) |
+| `3.fmt("%d", :zzz)` * | `"3"` | dies "Too many positionals … got 3" |
+| `255.fmt(:zzz)` | `"255"` | `"zzz\tTrue"` (Pair became the format) |
+| `(1,2,3).rotor(2, :zzz)` * | `((1, 2),)` | `((1, 2), ())` |
+| `(1,2,3).classify({$_}, :zzz)` * | 3 keys | 4 keys |
+| `(1,2,3).categorize({$_}, :zzz)` | 3 keys | 4 keys |
+| `(1,2,3).first(:zzz)` * | `X::Adverb` Failure | `Any` |
+| `(1,2,3).minmax(:zzz)` | `1..3` | `Nil` |
+| `"%s".sprintf("x", :zzz)` | `"x"` | dies (surplus sprintf argument) |
+| `(1,2,3).AT-POS(1, :zzz)` | `2` | `Failure` "Index out of range" |
+| `(1,2,3).EXISTS-POS(1, :zzz)` | `True` | `False` |
+| `Buf.new(1,2,3).subbuf(1, :zzz)` | `Buf.new(2,3)` | `Buf.new()` |
+| `255.base(16, :zzz)` | `"FF"` | (agreed) |
+| `3.expmod(2, 5, :zzz)` | `4` | (agreed on this shape, not on others) |
+
+Two rows of the recorded table had already **drifted** before this work started,
+which is why the re-measurement came first: `3.fmt("%d", :zzz)` no longer died
+with `X::AdHoc` about a surplus sprintf argument but with a positional-arity
+error, and the sweep found roughly five times as many affected methods as the
+six the file listed.
+
+The measurement also corrected the file's framing in one important way. It said
+`chop` / `polymod` / `fmt` "have no named parsing at all to extend", implying
+they are structurally different from `rotor` / `classify`. They are not: what
+distinguishes them is only *which* names they accept (none, versus `:partial`
+and `:as`/`:into`). And `classify`'s "a named-flavour `Pair` can legitimately
+arrive as data" caveat turns out not to apply to the *argument list* at all —
+`callable_item`'s comment is about `Pair`s that arrive as **elements of the
+list being classified** (from a `Hash`/`Bag` invocant iterating to pairs), which
+never pass through the argument vector. A `Pair` genuinely passed positionally
+(`rotor(2 => -1)`) carries the *positional* flavour, which ADR-0021 already
+keeps distinct.
+
+## Decision
+
+**A builtin method declares the set of named arguments it accepts, and the
+builtin dispatch layer drops every named argument outside that set before it
+chooses an arity.**
+
+The declaration is `native_method_accepted_nameds(method) -> Option<&'static
+[&'static str]>` in `src/builtins/accepted_nameds.rs`, and it is deliberately
+**partial**:
+
+- `Some(names)` — surveyed. An undeclared named is dropped before dispatch.
+- `None` — not surveyed. Nothing is dropped; behaviour is byte-for-byte today's.
+
+It is consulted at the three places the builtin layer is entered, and **only**
+there, so a user-defined method, a constructor and every `%_`-carrying handler
+downstream still see the call's own arguments:
+
+1. `vm/vm_native_dispatch.rs::try_native_method_raw`, immediately before the
+   `args.len()` cascade and after the existing `native_*_with_options`
+   interceptors;
+2. `runtime/methods_call_dispatch.rs`, before the interpreter-side twin of that
+   cascade;
+3. `runtime/methods_call_dispatch.rs`, before `dispatch_method_by_name_1/2/3`.
+
+The filtered list is a local; if the builtin layer declines, the original `args`
+flow on unchanged.
+
+`grep` and `first` are handled by a *second*, different mechanism and are
+deliberately absent from the table: Rakudo does not let their implicit slurpy
+swallow an unknown adverb, it **validates** and answers `X::Adverb` (`grep`
+throws, `first` `fail`s). mutsu already did that for `grep`; this ADR extends it
+to `first`, in both the method and the sub form.
+
+### Which polarity, and why
+
+Two polarities were available, and the choice is the whole decision:
+
+- **Listed = filtered** (chosen). An omission from the table leaves an already
+  wrong answer wrong. It can never invent a new one.
+- **Unlisted = filtered** ("the cascade is named-blind by construction"). An
+  omission silently deletes a *real* adverb.
+
+The `todo/deep/` file flagged the completeness of the table as the risk of this
+design, and it is right — but the risk is a function of the polarity, not of the
+table. With "listed = filtered", the failure mode of an *incomplete* table is
+"one more known bug stays open", and the failure mode of a *wrong* row (a method
+declared that really does read an adverb) is loud: that adverb stops working,
+which `make test` and roast see immediately. That asymmetry is what makes the
+table safe to grow one row at a time.
+
+### The table is generated, not guessed
+
+`scripts/native-method-adverb-survey.raku` reports, for each method name, the
+named parameters every candidate declares across every owner type. That is the
+authoritative accepted-name set, because Rakudo's implicit `*%_` means a name
+outside it *cannot* change the answer. It also flags the `*%_` slurpy explicitly,
+so a routine that validates its own `%_` (`grep`, `first`) is visibly not
+answerable by signature alone and gets the validation treatment instead.
+
+`t/native-method-accepted-nameds.t` pins both halves of every declaration — an
+undeclared named is invisible, and every declared adverb still reaches the
+implementation. **The whole file passes unmodified under `raku` as well as under
+mutsu**, so it is a conformance test rather than a snapshot of mutsu's own
+behaviour.
+
+## Alternatives considered
+
+### Option 2 — extend the interceptor pattern until no cascade arm reads an argument `Pair`
+
+The `todo/deep/` file's second candidate: lift every adverb-aware native out in
+front of the arity cascade (as `native_contains_with_options`,
+`native_prefix_suffix_with_options` and `native_substr_eq_with_options` already
+are), then make the cascade named-blind by construction. The invariant would be
+structural rather than a list to keep in sync, which is genuinely more
+attractive.
+
+Rejected on the measurement, for two reasons.
+
+**It does not reach the affected population.** The `arity_bits` column of
+`native_method_row_table.rs` says which methods the pure cascade actually
+serves. Of the methods this bug touches, only about half are cascade-served
+(`chop`, `fmt`, `base`, `expmod`, `AT-POS`, `EXISTS-POS`, `join`, `tail`,
+`combinations`, `subbuf`, `int-bounds`, `indent`, `samecase`, `uniprops`); the
+rest — `polymod`, `rotor`, `classify`, `categorize`, `first`, `minmax`, `skip`,
+`sprintf` — carry `N` (slow path) and are served by `dispatch_method_by_name_*`,
+where "no arm reads an argument `Pair`" is not a property one can establish
+without rewriting those handlers. Making the *cascade* named-blind would close
+half the finding and leave the louder half (`polymod`, `classify`, `rotor`)
+open.
+
+**The structural invariant it buys is weaker than it looks.** The cascade is
+already almost named-blind — a grep of `methods_0arg/` and `methods_narg/` finds
+only five arg-side named reads (`Str(:superscript/:subscript)`,
+`lines(:chomp/:count)`, `batch(:elems/:batch)`, `comb`, `split`, plus
+`flatten(:hammer)`); nearly every `ValueView::Pair` match in that tree is on the
+*receiver* (`.key`, `.value`, `.antipair`, `.raku` of a `Pair`). So option 2's
+end state is a five-entry exemption list guarding a filter — which is option 1
+with a different name and a much larger diff.
+
+The interceptor pattern is not being retired: it stays where it belongs, for
+natives that need `&mut self` or a shape the arity cascade cannot express. It is
+just not the mechanism for "this method reads no adverbs at all".
+
+### Strip named arguments unconditionally before dispatch
+
+Already rejected by the 2026-08 work, for the reason recorded there: a native
+that genuinely reads an adverb reads it out of that same argument list, so a
+blanket strip silently drops real adverbs (`.split(:skip-empty)`,
+`.substr-eq(:i)`, `.comb(:match)`, `.subst(:g)`). That is exactly the
+"unlisted = filtered" polarity above.
+
+### Reverse the retry (positionals first, full list as fallback)
+
+Also already rejected: `"a,b,,c".split(",", :skip-empty)` would hit the
+positional-only `split(",")` arm and lose `:skip-empty` before the fallback ever
+ran.
+
+## Consequences
+
+- 332 of the 754 non-named-blind probes become named-blind, including every row
+  of the original finding. No probe that was named-blind before stops being so;
+  the only new divergences in the sweep are `first`'s intended `X::Adverb` and
+  pre-existing QuantHash iteration-order noise.
+- The remaining 422 probes are undeclared methods (`None`) plus receiver shapes
+  where the plain call already diverges from raku for unrelated reasons (e.g.
+  `4.roots(2)` answers `Num`s where raku answers `Complex`). They are residue,
+  not regressions, and are tracked in the narrowed
+  `todo/deep/native-method-accepted-named-declarations.md`.
+- `base` is declared with `:no-trailing-zeroes`, which mutsu does not yet
+  implement. Declaring it is still correct — it keeps the adverb reaching the
+  implementation, so implementing it later needs no change here.
+- Cost on the hot path is one tag-level `is_string_pair_value` scan of the
+  argument slice (no `view()`, so a lazy `Match` argument is not materialized),
+  and no allocation unless something is actually dropped.
+- Dropping an argument shifts the indices a handler uses to read the call site's
+  `arg_sources` metadata. Only `classify`/`categorize` do that (to recover the
+  variable name behind `:into`), and only when an *undeclared* named precedes
+  `:into` in the same call; the mis-indexed source cannot start with `into=`, so
+  the lookup falls through to the existing `find_var_by_identity` fallback rather
+  than resolving the wrong variable.
+
+## Implementation status
+
+- **Slice 1 (implemented 2026-09-07).** `accepted_nameds.rs` with 29 surveyed
+  methods, the three call sites, `first`'s `X::Adverb` validation in both forms,
+  `scripts/native-method-adverb-survey.raku`, and
+  `t/native-method-accepted-nameds.t` (66 assertions, green under raku and
+  mutsu).
+- **Slice 2 (open).** Survey and declare the remaining residue — `add` /
+  `remove` / `grab` on the mutable QuantHashes, and the methods whose adverb set
+  Rakudo answers only through `%_` validation. Recorded in the narrowed
+  `todo/deep/` file.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -95,3 +95,4 @@ The role of an ADR is to preserve the *context of the judgment* — something th
 | [0067](0067-a-routine-hands-back-the-container-it-was-given.md) | A routine hands back the container it was *given* — raw arguments, raw invocants, and the subscript step through an object | Accepted (all slices implemented 2026-09-05/06) |
 | [0068](0068-cross-thread-container-writes-need-a-synchronized-store.md) | A cross-thread aliased container write needs a synchronized store, not a name-keyed lane | Proposed |
 | [0069](0069-a-definiteness-constrained-type-object-is-a-named-type-object.md) | A definiteness-constrained type object is a named type object, not a new value kind | Accepted (implemented) |
+| [0070](0070-native-methods-declare-the-named-arguments-they-accept.md) | A builtin method declares the named arguments it accepts, and the arity cascade drops the rest | Proposed (slice 1 implemented) |

--- a/news/2026-09/builtin-methods-declare-their-accepted-nameds.md
+++ b/news/2026-09/builtin-methods-declare-their-accepted-nameds.md
@@ -1,0 +1,103 @@
+# Builtin methods declare the named arguments they accept
+
+`"abc".chop(:zzz)` answered `"abc"`. `10.polymod(3, :zzz)` answered
+`(1, 3, Inf)`. `(1,2,3).classify({$_}, :zzz)` produced four buckets. In every
+case the call *succeeded*, with the wrong answer and no error to notice.
+
+This was the silent half of "a named argument may occupy a positional slot".
+The loud half — where an unknown named made the arity-keyed builtin lookup miss
+entirely, and `4.log(:base(2))` died with `X::Method::NotFound` — was fixed in
+August by an implicit-`*%_` retry in `call_method_with_values`
+([news](../2026-08/native-methods-honour-the-implicit-slurpy-named.md)). The
+retry cannot help when the *wrong arm hits*: mutsu's builtin methods are
+dispatched by arity rather than by signature, so a call-site `Pair` is counted
+as a positional and then numified (a 0 character count for `chop`), read as
+data (a second modulus for `polymod`, a second cycle spec for `rotor`, an extra
+list element for `classify`) or rejected as surplus (`sprintf`).
+
+## The measurement came first, and it moved
+
+`todo/deep/native-method-accepted-named-declarations.md` recorded six affected
+calls. Two of them had already drifted — `3.fmt("%d", :zzz)` no longer died with
+an `X::AdHoc` about a surplus sprintf argument but with a positional-arity error
+— so the first step was a fresh, wider sweep: 2 600 (receiver, method,
+argument-shape) probes generated from `src/builtins/native_method_row_table.rs`,
+each run as `R.M(A)` against `R.M(A, :qqzz9)`, with every divergence then checked
+against `raku`. **754 probes were not named-blind**, across about 30 methods —
+five times the recorded population. `fmt` on three owner types, `sprintf`,
+`base`, `expmod`, `minmax`, `AT-POS`, `EXISTS-POS`, `subbuf`, `categorize`,
+`join`, `tail`, `skip`, `combinations`, `indent`, `samecase`, `uniprops` and
+`int-bounds` were all affected and none had been recorded.
+
+The sweep also corrected the finding's framing. It said `chop`/`polymod`/`fmt`
+"have no named parsing at all to extend", implying they differ structurally from
+`rotor`/`classify`. They do not — only in *which* names they accept (none,
+versus `:partial` and `:as`/`:into`). And the `classify` caveat about a
+named-flavour `Pair` legitimately arriving as data turned out not to apply to
+the argument list at all: `callable_item`'s comment is about `Pair`s that arrive
+as **elements of the list being classified** (a `Hash`/`Bag` invocant iterating
+to pairs), which never pass through the argument vector.
+
+## The mechanism
+
+[ADR-0070](../../docs/adr/0070-native-methods-declare-the-named-arguments-they-accept.md).
+`native_method_accepted_nameds(method) -> Option<&'static [&'static str]>` in
+`src/builtins/accepted_nameds.rs` states which names each surveyed method reads,
+and the builtin dispatch layer drops everything outside that set before it
+chooses an arity. It is consulted at exactly the three places that layer is
+entered — `try_native_method_raw`'s arity cascade, its interpreter-side twin in
+`methods_call_dispatch.rs`, and `dispatch_method_by_name_1/2/3` — and the
+filtered list is a local, so a user method, a constructor and every
+`%_`-carrying handler downstream still see the call's own arguments.
+
+The table is **partial on purpose**, and the polarity is the whole decision. An
+unsurveyed method is `None` and behaves exactly as before, so an omission leaves
+a known-wrong answer wrong rather than inventing a new one; a *wrong* row (a
+method declared that really does read an adverb) makes that adverb stop working,
+which is loud. The other polarity — "the cascade is named-blind unless the
+method is listed" — has the failure modes the other way round, and would delete
+real adverbs on an omission.
+
+The ADR also records why the file's second candidate design (extend the
+`native_*_with_options` interceptor pattern until no cascade arm reads an
+argument `Pair`) was rejected on the measurement: the `arity_bits` column shows
+only about half the affected methods are served by the pure cascade at all —
+`polymod`, `rotor`, `classify`, `categorize`, `first`, `minmax`, `skip` and
+`sprintf` are slow-path — so it would close half the finding, and the cascade is
+already so close to named-blind (five arg-side named reads in the whole tree)
+that its "structural invariant" reduces to a five-entry exemption list guarding
+the same filter.
+
+`grep` and `first` are deliberately not in the table: Rakudo does not let their
+implicit slurpy swallow an unknown adverb, it **validates** and answers
+`X::Adverb` (`grep` throws, `first` `fail`s). mutsu already did that for `grep`;
+`first` now does too, in both the method and the sub form, so
+`(1,2,3).first(:zzz)` is a Failure carrying `X::Adverb` with `.what`,
+`.source` and `.unexpected` rather than a silent `Nil`.
+
+## The guard
+
+The sets are not hand-guessed. `scripts/native-method-adverb-survey.raku` asks
+Rakudo for the named parameters every candidate of a method declares across
+every owner type — authoritative, because Rakudo's implicit `*%_` means a name
+outside that set *cannot* change the answer. It flags the `*%_` slurpy
+explicitly, so a routine that validates its own `%_` is visibly not answerable
+by signature alone and is left out.
+
+`t/native-method-accepted-nameds.t` pins both halves of every declaration — an
+undeclared named is invisible, and every declared adverb still reaches the
+implementation (`rotor(:partial)`, `classify(:as)`/`(:into)`, `minmax(:by)`,
+`first(:k)`/`(:kv)`/`(:end)`), plus the positional `Pair` cycle spec
+`rotor(2 => -1)` that ADR-0021's flavour distinction protects. **The file passes
+unmodified under `raku` as well as under mutsu**, so it is a conformance test,
+not a snapshot of mutsu's own behaviour.
+
+## Result
+
+332 of the 754 non-named-blind probes became named-blind, including every row of
+the original finding. No probe that was named-blind before stopped being so; the
+only new divergences in the re-run sweep are `first`'s intended `X::Adverb` and
+pre-existing QuantHash iteration-order noise. The remainder is undeclared
+methods plus receiver shapes whose *plain* call already diverges for unrelated
+reasons (`4.roots(2)` answers `Num`s where raku answers `Complex`), and stays
+recorded in the narrowed `todo/deep/` file.

--- a/scripts/native-method-adverb-survey.raku
+++ b/scripts/native-method-adverb-survey.raku
@@ -1,0 +1,67 @@
+#!/usr/bin/env raku
+
+# Regenerates the evidence behind `native_method_accepted_nameds`
+# (`src/builtins/accepted_nameds.rs`): for each method name, the set of named
+# parameters Rakudo declares for it, across every owner type that has one.
+#
+# Run with a real `raku` (see .agents/skills/install-raku/):
+#
+#     raku scripts/native-method-adverb-survey.raku
+#     raku scripts/native-method-adverb-survey.raku chop polymod rotor
+#
+# The output is the authoritative accepted-named set for a method: a Raku method
+# carries an implicit `*%_`, so a named argument that is not in this set cannot
+# change the method's answer, and mutsu's builtin dispatch may therefore drop it
+# before choosing an arity. `*%_` / `*%a` slurpies are reported as `**SLURPY**`
+# and are NOT accepted names -- but note that a routine which validates its own
+# `%_` (`grep`, `first`) accepts names that no signature mentions, so a method
+# whose only entry is `**SLURPY**` still needs its adverbs confirmed by hand
+# against `raku-doc/doc/Type/`.
+
+my @OWNERS = <Mu Any Cool Str Int Num Rat Complex List Array Seq Hash Map Range
+              Pair Set Bag Mix SetHash BagHash MixHash Blob Buf Match Date
+              DateTime IO::Path Junction Supply Channel>;
+
+my @DEFAULT-METHODS = <
+    chop chomp polymod expmod base fmt sprintf AT-POS EXISTS-POS AT-KEY
+    EXISTS-KEY subbuf subbuf-rw int-bounds join tail skip head combinations
+    permutations indent samecase samemark unimatch uniprops roots minmax rotor
+    classify categorize first grep map split comb lines batch Str contains
+    starts-with ends-with substr-eq subst trans match min max unique squish
+    sort reduce produce keys values kv pairs list Array
+>;
+
+sub named-params($m) {
+    my %seen;
+    for $m.candidates -> $c {
+        for $c.signature.params -> $p {
+            next unless $p.named;
+            if $p.slurpy {
+                %seen{'**SLURPY**'} = True;
+            } else {
+                %seen{$_} = True for $p.named_names;
+            }
+        }
+    }
+    %seen.keys.sort
+}
+
+my @methods = @*ARGS ?? @*ARGS !! @DEFAULT-METHODS;
+
+for @methods -> $name {
+    my %union;
+    my @owners-with;
+    for @OWNERS -> $owner {
+        my $type = ::($owner);
+        next if $type ~~ Failure;
+        my $m = $type.^lookup($name);
+        next without $m;
+        my @n = named-params($m);
+        next unless @n;
+        @owners-with.push: $owner;
+        %union{$_} = True for @n;
+    }
+    my @accepted = %union.keys.grep({ $_ ne '**SLURPY**' }).sort;
+    my $slurpy = %union<**SLURPY**> ?? ' (+*%_)' !! '';
+    printf "%-14s %s%s\n", $name, (@accepted ?? @accepted.join(' ') !! '--'), $slurpy;
+}

--- a/src/builtins/accepted_nameds.rs
+++ b/src/builtins/accepted_nameds.rs
@@ -1,0 +1,131 @@
+//! Which named arguments a builtin method accepts.
+//!
+//! Every Raku *method* carries an implicit `*%_`, so a named argument the
+//! method does not declare is swallowed and cannot change the answer. mutsu's
+//! builtin methods are dispatched by *arity* rather than by signature, so a
+//! named argument occupies a positional slot in that count. `4.log(:base(2))`
+//! used to miss the lookup entirely -- that half is fixed, by the implicit-`*%_`
+//! retry in `Interpreter::call_method_with_values` (see
+//! `news/2026-08/native-methods-honour-the-implicit-slurpy-named.md`).
+//!
+//! This module closes the other half: the case where the wrong arm *hits*.
+//! `"abc".chop(:zzz)` numified the `Pair` to a 0 character count and answered
+//! `"abc"`; `10.polymod(3, :zzz)` read it as a second modulus and answered
+//! `(1, 3, Inf)`. There is no error to retry on, so the argument list has to be
+//! corrected *before* dispatch -- which needs the one thing the arity cascade
+//! does not have: a statement of which names each method actually reads.
+//!
+//! [`native_method_accepted_nameds`] is that statement, and it is deliberately
+//! *partial*:
+//!
+//! - `Some(names)` -- declared. A call-site named argument whose key is not in
+//!   `names` is dropped before the builtin layer chooses an arity.
+//! - `None` -- undeclared. Nothing is dropped; behaviour is exactly what it was.
+//!
+//! The default being `None` is what makes the table safe to grow one row at a
+//! time: an omission leaves a known-wrong answer wrong, it never invents a new
+//! one. The opposite mistake -- declaring a method that really does read an
+//! adverb -- makes that adverb stop working, which is loud, and is pinned per
+//! declared adverb by `t/native-method-accepted-nameds.t`.
+//!
+//! The sets are not hand-guessed. They come from Rakudo, via
+//! `scripts/native-method-adverb-survey.raku`, which reports the named
+//! parameters every candidate of a method declares across every owner type.
+//! A routine that validates its own `%_` instead of declaring parameters
+//! (`grep`, `first`) accepts names no signature mentions; those are handled by
+//! their own validation (they answer `X::Adverb`, as Rakudo does) and are
+//! deliberately absent from this table.
+
+use crate::value::{Value, ValueView};
+
+/// The named arguments the builtin implementation of `method` accepts, or
+/// `None` if the method has not been surveyed (in which case nothing is
+/// dropped). See the module docs for why `None` is the safe default.
+pub(crate) fn native_method_accepted_nameds(method: &str) -> Option<&'static [&'static str]> {
+    // Every row below is `raku`-derived; see
+    // `scripts/native-method-adverb-survey.raku`.
+    Some(match method {
+        // Surveyed as accepting no named argument at all.
+        "AT-KEY" | "AT-POS" | "EXISTS-KEY" | "EXISTS-POS" | "chomp" | "chop" | "combinations"
+        | "expmod" | "fmt" | "indent" | "int-bounds" | "join" | "permutations" | "polymod"
+        | "roots" | "samecase" | "samemark" | "skip" | "sprintf" | "subbuf" | "subbuf-rw"
+        | "tail" | "unimatch" | "uniprops" => &[],
+        "base" => &["no-trailing-zeroes"],
+        "minmax" => &["by"],
+        "rotor" => &["partial"],
+        "classify" | "categorize" => &["as", "into"],
+        _ => return None,
+    })
+}
+
+/// Drop the call-site named arguments `method` does not accept.
+///
+/// Returns `None` when there is nothing to do -- no nameds, an undeclared
+/// method, or every named accepted -- so the overwhelmingly common case costs
+/// one tag-level scan and no allocation.
+///
+/// Named-ness is a call-site property (ADR-0021): only the `Pair` flavour is a
+/// named argument, so a *positional* `Pair` (`%h.push((a => 1))`, a `Pair` held
+/// in a variable, a `rotor` cycle spec such as `2 => -1`) is never dropped.
+pub(crate) fn strip_undeclared_nameds(method: &str, args: &[Value]) -> Option<Vec<Value>> {
+    // Tag probe first: `view()` on a lazy Match argument would materialize it.
+    if !args.iter().any(|a| a.is_string_pair_value()) {
+        return None;
+    }
+    let accepted = native_method_accepted_nameds(method)?;
+    let kept: Vec<Value> = args
+        .iter()
+        .filter(|a| {
+            if !a.is_string_pair_value() {
+                return true;
+            }
+            match a.view() {
+                ValueView::Pair(key, _) => accepted.contains(&key.as_str()),
+                _ => true,
+            }
+        })
+        .cloned()
+        .collect();
+    if kept.len() == args.len() {
+        None
+    } else {
+        Some(kept)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn an_undeclared_method_keeps_every_argument() {
+        let args = vec![Value::pair("zzz".to_string(), Value::TRUE)];
+        assert!(strip_undeclared_nameds("no-such-builtin-method", &args).is_none());
+    }
+
+    #[test]
+    fn a_declared_method_drops_only_the_undeclared_named() {
+        let args = vec![
+            Value::int(2),
+            Value::pair("partial".to_string(), Value::TRUE),
+            Value::pair("zzz".to_string(), Value::TRUE),
+        ];
+        let kept = strip_undeclared_nameds("rotor", &args).expect("zzz must go");
+        assert_eq!(kept.len(), 2);
+        assert!(kept[1].is_string_pair_value());
+    }
+
+    #[test]
+    fn a_positional_pair_is_not_a_named_argument() {
+        // `2 => -1` is a rotor cycle spec, not an adverb: the positional Pair
+        // flavour must survive even on a declared method.
+        let args = vec![Value::value_pair(Value::int(2), Value::int(-1))];
+        assert!(strip_undeclared_nameds("rotor", &args).is_none());
+    }
+
+    #[test]
+    fn nothing_to_strip_allocates_nothing() {
+        let args = vec![Value::int(1), Value::int(2)];
+        assert!(strip_undeclared_nameds("chop", &args).is_none());
+    }
+}

--- a/src/builtins/mod.rs
+++ b/src/builtins/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod accepted_nameds;
 pub(crate) mod arith;
 pub(crate) mod backtrace_methods;
 pub(crate) mod buf_bits;
@@ -93,6 +94,7 @@ pub(crate) fn chomp_one(s: &str) -> String {
     }
 }
 
+pub(crate) use accepted_nameds::strip_undeclared_nameds;
 pub(crate) use arith::{
     arith_add, arith_div, arith_mod, arith_mul, arith_negate, arith_pow, arith_sub,
 };

--- a/src/runtime/builtins_collection_mapgrep.rs
+++ b/src/runtime/builtins_collection_mapgrep.rs
@@ -398,6 +398,18 @@ impl Interpreter {
                 ValueView::Pair(key, value) if key == "p" => {
                     has_p = value.truthy();
                 }
+                // `first` validates its adverbs instead of letting an unknown
+                // one be swallowed, in the sub form too: rakudo answers
+                // `first(* > 1, (1,2,3), :zzz)` with an `X::Adverb` Failure.
+                // The method-form twin of this arm is in
+                // `methods_collection_ops/first_polymod_tree.rs`.
+                ValueView::Pair(key, _) => {
+                    return Ok(RuntimeError::unexpected_adverb_failure(
+                        &[key.to_string()],
+                        "first",
+                        "List",
+                    ));
+                }
                 _ => positional.push(arg.clone()),
             }
         }

--- a/src/runtime/methods_call_dispatch.rs
+++ b/src/runtime/methods_call_dispatch.rs
@@ -3266,10 +3266,20 @@ impl Interpreter {
             args.len(),
         );
         let method_sym = crate::symbol::Symbol::intern(method);
+        // Named-blind arity cascade -- the interpreter-side twin of the guard in
+        // `vm_native_dispatch::try_native_method_raw`. The arity cascade selects
+        // its arm by argument *count*, so a named argument the method does not
+        // accept must not be in the list; `builtins::accepted_nameds` states
+        // which names each surveyed method reads. The stripped list is used ONLY
+        // for this cascade: if it declines, the original `args` (nameds intact)
+        // go on to the by-name dispatchers, the constructors and the user
+        // method, none of which may lose a named.
+        let cascade_stripped = crate::builtins::strip_undeclared_nameds(method, &args);
+        let cascade_args: &[Value] = cascade_stripped.as_deref().unwrap_or(&args);
         let native_result = if bypass_native_fastpath {
             None
         } else {
-            match args.as_slice() {
+            match cascade_args {
                 [] => crate::builtins::native_method_0arg(&target, method_sym),
                 [a] => crate::builtins::native_method_1arg(&target, method_sym, a),
                 [a, b] => crate::builtins::native_method_2arg(&target, method_sym, a, b),
@@ -3281,7 +3291,7 @@ impl Interpreter {
                 "methods_call_dispatch::call_method_with_values",
                 &target,
                 method_sym.as_str(),
-                args.len(),
+                cascade_args.len(),
             );
         }
         if !bypass_native_fastpath {
@@ -4220,10 +4230,20 @@ impl Interpreter {
                 _ => false,
             };
 
+        // Named-blind by-name dispatch, the slow-path twin of the arity-cascade
+        // guard above. These three handlers read `args[0]`/`args[1]` positionally
+        // just as the cascade does (`10.polymod(3, :zzz)` read the Pair as a
+        // second modulus; `(1,2,3).rotor(2, :zzz)` as a second cycle spec), so a
+        // named argument the method does not accept is dropped here too. The
+        // filtered list reaches ONLY these three: `dispatch_new_and_constructors`
+        // and everything after it below still sees the call's own `args`.
+        let by_name_stripped = crate::builtins::strip_undeclared_nameds(method, &args);
+        let by_name_args: &[Value] = by_name_stripped.as_deref().unwrap_or(&args);
+
         // Primary method dispatch by name (group 1: string, IO, coercion, misc)
         if !shadows_builtin
             && let Some(result) =
-                self.dispatch_method_by_name_1(target.clone(), method, args.clone())
+                self.dispatch_method_by_name_1(target.clone(), method, by_name_args.to_vec())
         {
             return result;
         }
@@ -4231,7 +4251,7 @@ impl Interpreter {
         // Primary method dispatch by name (group 2: collection/iteration)
         if !shadows_builtin
             && let Some(result) =
-                self.dispatch_method_by_name_2(target.clone(), method, args.clone())
+                self.dispatch_method_by_name_2(target.clone(), method, by_name_args.to_vec())
         {
             return result;
         }
@@ -4239,7 +4259,7 @@ impl Interpreter {
         // Primary method dispatch by name (group 3: Supply, network, temporal, misc)
         if !shadows_builtin
             && let Some(result) =
-                self.dispatch_method_by_name_3(target.clone(), method, args.clone())
+                self.dispatch_method_by_name_3(target.clone(), method, by_name_args.to_vec())
         {
             return result;
         }

--- a/src/runtime/methods_collection_ops/first_polymod_tree.rs
+++ b/src/runtime/methods_collection_ops/first_polymod_tree.rs
@@ -35,6 +35,20 @@ impl Interpreter {
                 ValueView::Pair(key, value) if key == "p" => {
                     has_p = value.truthy();
                 }
+                // Rakudo's `first` reads its adverbs out of `%_` and *validates*
+                // them rather than letting the implicit slurpy swallow an
+                // unknown one, so an undeclared named is an `X::Adverb` -- a
+                // soft `fail`, unlike `grep`'s throw. Without this the Pair fell
+                // into the positional vector and became the matcher
+                // (`(1,2,3).first(:zzz)` answered `Nil`) or was silently ignored
+                // (`(1,2,3).first(* > 1, :zzz)` answered `2`).
+                ValueView::Pair(key, _) => {
+                    return Ok(RuntimeError::unexpected_adverb_failure(
+                        &[key.to_string()],
+                        "first",
+                        crate::runtime::utils::value_type_name(&target),
+                    ));
+                }
                 _ => positional.push(arg.clone()),
             }
         }

--- a/src/value/error_typed.rs
+++ b/src/value/error_typed.rs
@@ -368,6 +368,28 @@ impl RuntimeError {
         Self::typed("X::Adverb", attrs)
     }
 
+    /// The soft `Failure` form of [`Self::unexpected_adverb`].
+    ///
+    /// `grep` *throws* its `X::Adverb` while `first` `fail`s with the same
+    /// exception, so `(1,2,3).first(:zzz)` yields a Failure that only blows up
+    /// when it is used. Same exception object either way -- a `CATCH` and a
+    /// `throws-like X::Adverb` see no difference; a sunk result does.
+    pub(crate) fn unexpected_adverb_failure(
+        unexpected: &[String],
+        what: &str,
+        source: &str,
+    ) -> Value {
+        let err = Self::unexpected_adverb(unexpected, what, source);
+        let exception = err
+            .exception
+            .map(|e| *e)
+            .unwrap_or_else(|| Value::str(err.message.to_string()));
+        let mut failure_attrs = HashMap::new();
+        failure_attrs.insert("exception".to_string(), exception);
+        failure_attrs.insert("handled".to_string(), Value::FALSE);
+        Value::make_instance(crate::symbol::Symbol::intern("Failure"), failure_attrs)
+    }
+
     /// X::Immutable - Cannot modify an immutable value
     pub(crate) fn immutable(typename: &str, method: &str) -> Self {
         let msg = format!("Cannot call '{}' on an immutable '{}'", method, typename);

--- a/src/vm/vm_native_dispatch.rs
+++ b/src/vm/vm_native_dispatch.rs
@@ -489,6 +489,17 @@ impl Interpreter {
         if Self::is_range_int_bounds_rw(target, &method_name, args) {
             return Some(self.range_int_bounds_rw(target));
         }
+        // A named argument the method does not accept must not be counted as a
+        // positional: the cascade below picks its arm by `args.len()` and then
+        // indexes `args[0]`/`args[1]`, so an undeclared `Pair` would be numified
+        // or consumed as data (`"abc".chop(:zzz)` -> a 0 character count). Every
+        // native that genuinely reads an adverb is either lifted out as an
+        // interceptor above (`contains` / `starts-with` / `ends-with` /
+        // `substr-eq`) or declared in `builtins::accepted_nameds`; for anything
+        // it declares, the cascade is named-blind. See that module for why the
+        // declaration is partial and why `None` is the safe default.
+        let stripped = crate::builtins::strip_undeclared_nameds(method_name.as_str(), args);
+        let args: &[Value] = stripped.as_deref().unwrap_or(args);
         let mut result = if args.len() == 2 {
             crate::builtins::native_method_2arg(target, method_sym, &args[0], &args[1])
         } else if args.len() == 1 {

--- a/t/native-method-accepted-nameds.t
+++ b/t/native-method-accepted-nameds.t
@@ -1,0 +1,141 @@
+use Test;
+
+# A Raku *method* carries an implicit `*%_`, so a named argument the method does
+# not declare is swallowed and cannot change the answer. mutsu's builtin methods
+# are dispatched by arity, so an undeclared named used to occupy a positional
+# slot and be numified or consumed as data. `src/builtins/accepted_nameds.rs`
+# states which names each surveyed method accepts; this file pins both halves of
+# that declaration:
+#
+#   * an UNDECLARED named is invisible -- `M(..., :zzz)` eqv `M(...)`;
+#   * every DECLARED adverb still reaches the implementation.
+#
+# Every expectation below was measured against Rakudo (see the PR that added
+# this file, and `scripts/native-method-adverb-survey.raku` for the accepted-name
+# survey the Rust table is generated from). Rows that already agreed before the
+# fix are pinned too, so a future change cannot quietly break them.
+
+# --- Str / Cool ------------------------------------------------------------
+
+is "abc".chop(:zzz), "ab", 'chop ignores an undeclared named';
+is "abc".chop(2, :zzz), "a", 'chop(N) ignores an undeclared named';
+is "abc\n".chomp(:zzz), "abc", 'chomp ignores an undeclared named';
+is "abc".samecase("AB", :zzz), "ABC", 'samecase ignores an undeclared named';
+is "abc".samemark("a\x[301]", :zzz), "a\x[301]b\x[301]c\x[301]",
+    'samemark ignores an undeclared named';
+is-deeply "abc".uniprops(:zzz).List, ("Ll", "Ll", "Ll"), 'uniprops ignores an undeclared named';
+is "abcdef".indent(2, :zzz), "  abcdef", 'indent ignores an undeclared named';
+is "%s".sprintf("x", :zzz), "x", 'sprintf ignores an undeclared named';
+
+# --- numeric ---------------------------------------------------------------
+
+is-deeply 10.polymod(3, :zzz).List, (1, 3), 'polymod ignores an undeclared named';
+is-deeply 10.polymod(3, 2, :zzz).List, (1, 1, 1), 'polymod(a, b) ignores an undeclared named';
+is 3.expmod(2, 5, :zzz), 4, 'expmod ignores an undeclared named';
+is 255.base(16, :zzz), "FF", 'base ignores an undeclared named';
+is 3.fmt("%d", :zzz), "3", 'Int.fmt(format) ignores an undeclared named';
+is 255.fmt(:zzz), "255", 'Int.fmt ignores an undeclared named';
+is (1,2,3).fmt(:zzz), "1 2 3", 'List.fmt ignores an undeclared named';
+is (1,2,3).fmt("%02d", :zzz), "01 02 03", 'List.fmt(format) ignores an undeclared named';
+
+# --- positional/associative protocol ---------------------------------------
+
+is (1,2,3).AT-POS(1, :zzz), 2, 'AT-POS ignores an undeclared named';
+is (1,2,3).EXISTS-POS(1, :zzz), True, 'EXISTS-POS ignores an undeclared named';
+is {a => 1}.AT-KEY("a", :zzz), 1, 'AT-KEY ignores an undeclared named';
+is {a => 1}.EXISTS-KEY("a", :zzz), True, 'EXISTS-KEY ignores an undeclared named';
+
+# --- list shaping ----------------------------------------------------------
+
+is (1,2,3).join("-", :zzz), "1-2-3", 'join ignores an undeclared named';
+is-deeply (1,2,3).tail(2, :zzz).List, (2, 3), 'tail ignores an undeclared named';
+is-deeply (1,2,3).skip(1, :zzz).List, (2, 3), 'skip ignores an undeclared named';
+is (1,2,3).combinations(2, :zzz).elems, 3, 'combinations ignores an undeclared named';
+is (1,2).permutations(:zzz).elems, 2, 'permutations ignores an undeclared named';
+is-deeply (1,2,3).minmax(:zzz), (1..3), 'minmax ignores an undeclared named';
+is (1..5).int-bounds(:zzz).join(","), "1,5", 'int-bounds ignores an undeclared named';
+
+# `:by` is a DECLARED adverb of minmax and must still work.
+is-deeply (1,2,3).minmax(:by(* * -1)), (3..1), 'minmax keeps its declared :by';
+
+# --- Blob ------------------------------------------------------------------
+
+is Buf.new(1,2,3).subbuf(1, :zzz).elems, 2, 'subbuf ignores an undeclared named';
+
+# --- rotor: one declared adverb (:partial) ---------------------------------
+
+is (1,2,3).rotor(2, :zzz).elems, 1, 'rotor ignores an undeclared named';
+is (1,2,3).rotor(2, :partial).elems, 2, 'rotor keeps its declared :partial';
+# A `Pair` in a POSITIONAL slot is a rotor cycle spec, not an adverb, and must
+# survive (named-ness is a call-site property, ADR-0021).
+is-deeply (1,2,3,4).rotor(2 => -1).List.map(*.List).List, ((1,2), (2,3), (3,4)),
+    'rotor keeps a positional Pair cycle spec';
+
+# --- classify / categorize: two declared adverbs (:as, :into) --------------
+
+is (1,2,3).classify({$_}, :zzz).keys.elems, 3, 'classify ignores an undeclared named';
+is (1,2,3).categorize({$_}, :zzz).keys.elems, 3, 'categorize ignores an undeclared named';
+is-deeply (1,2,3).classify({$_}, :as({$_ * 2})).values.map(*[0]).sort.List, (2, 4, 6),
+    'classify keeps its declared :as';
+is-deeply (1,2,3).categorize({$_}, :as({$_ * 2})).values.map(*[0]).sort.List, (2, 4, 6),
+    'categorize keeps its declared :as';
+my %into;
+(1,2,3).classify({$_}, :into(%into));
+is %into.keys.elems, 3, 'classify keeps its declared :into';
+
+# --- first / grep validate their adverbs instead of swallowing them --------
+
+# Rakudo `fail`s an X::Adverb for an unknown adverb on `first` (and throws one
+# on `grep`), rather than letting the implicit slurpy eat it.
+{
+    my $f = (1,2,3).first(:zzz);
+    isa-ok $f, Failure, 'first(:unknown) is a Failure';
+    is $f.exception.^name, 'X::Adverb', 'first(:unknown) fails with X::Adverb';
+    is $f.exception.what, 'first', 'X::Adverb .what is the routine';
+    is-deeply $f.exception.unexpected.List, ("zzz",), 'X::Adverb .unexpected lists the name';
+    $f.so;  # mark handled; an unhandled Failure warns from DESTROY
+}
+{
+    my $f = (1,2,3).first(* > 1, :zzz);
+    isa-ok $f, Failure, 'first(matcher, :unknown) is a Failure too';
+    $f.so;
+}
+{
+    my $f = first(* > 1, (1,2,3), :zzz);
+    isa-ok $f, Failure, 'the first SUB validates its adverbs as well';
+    $f.so;
+}
+is (1,2,3).first(* > 1, :k), 1, 'first keeps its declared :k';
+is (1,2,3).first(* > 1, :end), 3, 'first keeps its declared :end';
+is-deeply (1,2,3).first(* > 1, :kv).List, (1, 2), 'first keeps its declared :kv';
+is (1,2,3).first(* > 1), 2, 'first with no adverb is unaffected';
+throws-like { (1,2,3).grep(* > 1, :zzz) }, X::Adverb, 'grep throws X::Adverb (unchanged)';
+is-deeply (1,2,3).grep(* > 1, :k).List, (1, 2), 'grep keeps its declared :k';
+
+# --- undeclared methods keep working exactly as before ---------------------
+#
+# These were already named-blind before the table existed; the table must not
+# have changed them, and their own adverbs must still be honoured.
+
+is-deeply "a,b,,c".split(",", :zzz).List, ("a", "b", "", "c"), 'split still ignores :zzz';
+is-deeply "a,b,,c".split(",", :skip-empty).List, ("a", "b", "c"), 'split keeps :skip-empty';
+is-deeply "abc".comb(:zzz).List, ("a", "b", "c"), 'comb still ignores :zzz';
+is "a\nb".lines(:count), 2, 'lines keeps :count';
+is-deeply "a\nb".lines(:zzz).List, ("a", "b"), 'lines still ignores :zzz';
+is (1,2,3).batch(:elems(2)).elems, 2, 'batch keeps :elems';
+is 42.Str(:superscript), "⁴²", 'Str keeps :superscript';
+is 42.Str(:zzz), "42", 'Str still ignores :zzz';
+is "abcdef".contains("B", :i), True, 'contains keeps :i';
+is "abcdef".contains("b", :zzz), True, 'contains still ignores :zzz';
+is "abcdef".starts-with("A", :i), True, 'starts-with keeps :i';
+is "abcdef".substr-eq("B", 1, :i), True, 'substr-eq keeps :i';
+is (1,2,3).min(:by(* <=> *)), 1, 'min keeps :by';
+is "abcdef".subst("b", "X", :zzz), "aXcdef", 'subst still ignores :zzz';
+
+# The implicit-`*%_` retry that fixed the LOUD half of this bug must keep
+# working (news/2026-08/native-methods-honour-the-implicit-slurpy-named.md).
+is 4.log(:base(2)), 4.log, 'log(:base) still falls back to the 0-ary log';
+is "abc".uc(:foo), "ABC", 'uc(:foo) still swallows the named';
+is (1,2,3).map({ $_ * 2 }).join("-", :foo), "2-4-6", 'a Seq body is consumed exactly once';
+
+done-testing;

--- a/todo/deep/native-method-accepted-named-declarations.md
+++ b/todo/deep/native-method-accepted-named-declarations.md
@@ -1,105 +1,79 @@
-# Native methods need a declared set of accepted named arguments
+# Native methods still without a declared set of accepted named arguments
 
-Follow-on from
-[news/2026-08/native-methods-honour-the-implicit-slurpy-named.md](../../news/2026-08/native-methods-honour-the-implicit-slurpy-named.md),
-which fixed the *loud* half of "a named argument may occupy a positional slot".
-This file records the *silent* half, which the same investigation measured but
-could not close soundly.
+**Narrowed 2026-09-07.** The mechanism this file asked for now exists:
+[ADR-0070](../../docs/adr/0070-native-methods-declare-the-named-arguments-they-accept.md),
+`src/builtins/accepted_nameds.rs`, `scripts/native-method-adverb-survey.raku`
+and `t/native-method-accepted-nameds.t`. Every row of the original measured
+table is fixed. What is left is the residue of the same survey, which needs no
+new design — only more rows.
 
-## What is already fixed
+## What shipped
 
-`call_method_with_values` now implements Raku's implicit `*%_` for native
-methods: it offers the full argument list first, and only when the whole
-dispatch chain answers `X::Method::NotFound` does it retry with the named
-arguments removed. That is provably non-regressive — a call that succeeds today
-never takes the retry path — and it fixed every case where an unknown named made
-the arity-keyed native lookup *miss* (`4.log(:base(2))`, `"abc".uc(:foo)`, and
-22 more measured against `raku`).
+`native_method_accepted_nameds(method) -> Option<&'static [&'static str]>` is
+consulted at the three places the builtin dispatch layer is entered
+(`try_native_method_raw`'s arity cascade, its interpreter-side twin, and
+`dispatch_method_by_name_1/2/3`). A named argument outside a *declared*
+method's set is dropped before an arity is chosen; a method the table does not
+mention is untouched. 29 methods are declared, from a Rakudo signature survey.
+`first` gained the `X::Adverb` validation Rakudo does instead (mirroring the
+`grep` handler), in both the method and the sub form.
 
-Re-confirmed 2026-08-26 while closing
-`todo/tickets/str-comb-named-arg-only-dispatch-missing.md`: `.comb(:match)` —
-which that ticket suspected would need the per-method declaration described
-below — is entirely on the *loud* side and is already fixed by the retry. It
-needs no accepted-named table. The scope of this ticket is unchanged: only the
-silent-wrong-arm cases listed next.
+A 2 600-probe sweep over `native_method_row_table.rs` went from 754
+not-named-blind probes to 422, with no probe losing named-blindness.
 
-## What is still wrong
+## What is left
 
-The retry cannot help when the wrong arm *hits*. If a native arm accepts the
-named `Pair` in a positional slot and numifies or consumes it, the call succeeds
-with the wrong answer and there is no error to retry on. Measured 2026-08-25
-against `raku` (mutsu on the left of the arrow is the current, post-fix
-behaviour):
+### 1. Methods still undeclared, with a measured wrong answer
 
-| Call | raku | mutsu |
-|---|---|---|
-| `"abc".chop(:zzz)` | `"ab"` | `"abc"` (the pair numified to a 0 char count) |
-| `10.polymod(3, :zzz)` | `(1, 3)` | `(1, 3, Inf)` (the pair became a second modulus) |
-| `3.fmt("%d", :zzz)` | `"3"` | dies `X::AdHoc` (surplus sprintf argument) |
-| `(1,2,3).rotor(2, :zzz)` | `((1, 2),)` | `((1, 2), ())` (the pair became a second cycle spec) |
-| `(1,2,3).classify({$_}, :zzz)` | 3 keys | 4 keys — the pair was classified as an element |
-| `(1,2,3).first(:zzz)` | dies `X::Adverb` | `Any` |
+- **`add` / `remove` on the mutable QuantHashes.** `BagHash.new(1,2,2).add(1,
+  :zzz)` dies with "Too many positionals passed; expected 2 arguments but got 3"
+  where raku answers `Nil`. Rakudo's survey says these accept no named at all,
+  so the row itself is trivial — but the failure does *not* come from either
+  arity cascade or from `dispatch_method_by_name_*`, so adding the row alone
+  does not fix it. Find the handler that raises that arity error (it looks like
+  a class-registered native method with a declared signature) and route it
+  through the same declaration. `grab` is in the same family.
+- **`base(:no-trailing-zeroes)`** is declared, and correctly so, but not
+  implemented: `0.5.base(10, 5, :no-trailing-zeroes)` answers `"0.50000"` where
+  raku answers `"0.5"`. Purely a missing feature now; the adverb reaches the
+  implementation.
 
-`chop` / `polymod` / `fmt` have no named parsing at all to extend. `rotor` and
-`classify` do, but a named-flavour `Pair` can legitimately arrive there as
-*data* — `builtins_collection_classify.rs` says so explicitly in
-`callable_item`'s comment ("a list element that is a named-marker `Pair` is data
-here, not a call-site named argument") — so blanket-dropping named pairs in
-those two would trade one wrong answer for another. `first` is different again:
-Rakudo *validates* its adverbs and throws `X::Adverb` for an unknown one, rather
-than swallowing it.
+### 2. Methods whose accepted set Rakudo answers only through `%_`
 
-## Why it is large
+`scripts/native-method-adverb-survey.raku` reports `**SLURPY**` and nothing else
+for a routine that reads its adverbs out of `%_` rather than declaring
+parameters — `grep`, `first`, `subst`, `trans`, `reduce`, `produce`, `keys`,
+`values`, `kv`, `pairs`, `list`, `Array`. For those the survey is a *lower
+bound*, so they are deliberately absent from the table. Each needs its accepted
+set confirmed by hand against `raku-doc/doc/Type/` before it can be declared.
+(Measured 2026-09-07: none of them currently answers a `:zzz` probe wrongly, so
+this is hardening, not a live bug.)
 
-The sound fix is the declaration the ticket that started this predicted: each
-native method needs to state **which named arguments it accepts**, so unknown
-ones can be dropped before any positional-slot interpretation while declared
-adverbs keep flowing through. Today that knowledge is scattered and implicit:
+### 3. Unrelated divergences the sweep surfaced
 
-- adverb parsing lives in per-method Rust helpers (`SplitOpts::from_args`,
-  `split_string_match_args`, `extract_extrema_adverbs`, `native_comb_method`,
-  `dispatch_rotor`, the `subst`/`trans`/`match`/`grep`/`first` handlers, the IO
-  and temporal constructors, …), each with its own hand-written match on key
-  strings;
-- the arity cascade (`native_method_0arg`/`_1arg`/`_2arg`) has no notion of
-  named arguments at all — it just indexes `args[0]`, `args[1]`;
-- a handful of adverb-aware natives are already lifted out in front of the
-  cascade as interceptors (`native_contains_with_options`,
-  `native_prefix_suffix_with_options`, `native_substr_eq_with_options` in
-  `src/vm/vm_native_dispatch.rs`), which is the shape the end state wants.
+Not named-argument bugs — the *plain* call already differs from raku — but worth
+their own tickets if anyone picks them up:
 
-Two plausible designs, both needing an ADR before code:
+- `4.roots(2)` answers `(2e0, -2e0)` where raku answers the two complex roots
+  `(<2+0i>, <-2+2.4e-16i>)`.
+- `(1,2,3).rotor("b")` answers `().Seq` where raku dies "cannot unbox to a
+  native integer"; `(1,2,3).AT-POS("b")` answers `Nil` where raku dies.
+- `(1,2,3).splice(1, 1)` reports `X::Immutable` where raku reports
+  "Cannot resolve caller".
 
-1. **Per-method accepted-named table.** A `native_method_accepted_nameds(method)
-   -> &'static [&'static str]` consulted at the dispatch entry; unknown nameds
-   are dropped, declared ones stay in place. Cheap to implement, but the table's
-   *completeness* is load-bearing: a method missing from it silently loses a real
-   adverb. It must be generated from, or checked against, the helpers above —
-   never hand-maintained on its own.
-2. **Every adverb-aware native becomes an interceptor.** Extend the
-   `native_*_with_options` pattern until no arm inside the arity cascade reads an
-   argument `Pair`, then make the cascade named-blind by construction. More work,
-   but the invariant is then structural rather than a list someone has to keep
-   in sync.
-
-Either way the entry point is one place —
-`Interpreter::call_method_with_values` in
-`src/runtime/methods_call_dispatch.rs`, which every dispatch chain funnels
-through exactly once (verified with `rust-gdb`), and which already owns the
-implicit-`*%_` retry.
-
-## Repro
+## Repro for the residue
 
 ```
-raku -e 'say "abc".chop(:zzz); say 10.polymod(3, :zzz); say 3.fmt("%d", :zzz)'
-# ab / (1 3) / 3
-./target/debug/mutsu -e 'say "abc".chop(:zzz); say 10.polymod(3, :zzz); say 3.fmt("%d", :zzz)'
-# abc / (1 3 Inf) / dies
+raku -e 'say BagHash.new(1,2,2).add(1, :zzz).raku; say 0.5.base(10, 5, :no-trailing-zeroes)'
+# Nil / 0.5
+./target/debug/mutsu -e 'say BagHash.new(1,2,2).add(1, :zzz).raku; say 0.5.base(10, 5, :no-trailing-zeroes)'
+# dies / 0.50000
 ```
 
 ## Affected files
 
-- `src/runtime/methods_call_dispatch.rs` (`call_method_with_values`)
-- `src/builtins/methods_0arg/`, `src/builtins/methods_narg/` (the arity cascade)
-- `src/vm/vm_native_dispatch.rs` (the existing interceptor pattern)
-- the per-method adverb helpers listed above
+- `src/builtins/accepted_nameds.rs` (the table — add rows here)
+- `scripts/native-method-adverb-survey.raku` (regenerates the evidence)
+- `t/native-method-accepted-nameds.t` (pins every declared row, and passes
+  under `raku` unmodified)
+- whichever handler raises the `add`/`remove` arity error (not yet located)


### PR DESCRIPTION
Closes the silent half of "a named argument may occupy a positional slot"
(`todo/deep/native-method-accepted-named-declarations.md`, now narrowed to its
residue). Design: **[ADR-0070](docs/adr/0070-native-methods-declare-the-named-arguments-they-accept.md)** (Proposed).

## The bug

A Raku *method* carries an implicit `*%_`, so a named argument the method does
not declare is swallowed and cannot change the answer. mutsu's builtin methods
are dispatched by **arity**, not by signature, so a call-site `Pair` occupies a
positional slot and is numified, consumed as data, or rejected as surplus. The
call *succeeds*, with the wrong answer and nothing to retry on. (The loud
half — where the lookup missed entirely and `4.log(:base(2))` died with
`X::Method::NotFound` — was fixed in August by the implicit-`*%_` retry.)

## Re-measured first, and it had drifted

The recorded finding listed six calls. Two had already changed behaviour, so
the first step was a fresh sweep: **2 600 probes** generated from
`src/builtins/native_method_row_table.rs`, each run as `R.M(A)` against
`R.M(A, :qqzz9)` in mutsu, with every divergence then checked against `raku`.
**754 probes were not named-blind**, across about 30 methods — five times the
recorded population.

| call | raku | mutsu before | mutsu after |
|---|---|---|---|
| `"abc".chop(:zzz)` | `"ab"` | `"abc"` | `"ab"` |
| `10.polymod(3, :zzz)` | `(1, 3)` | `(1, 3, Inf)` | `(1, 3)` |
| `3.fmt("%d", :zzz)` | `"3"` | dies (positional arity) | `"3"` |
| `255.fmt(:zzz)` | `"255"` | `"zzz\tTrue"` | `"255"` |
| `(1,2,3).fmt(:zzz)` | `"1 2 3"` | `"zzz\tTrue …"` | `"1 2 3"` |
| `"%s".sprintf("x", :zzz)` | `"x"` | dies (surplus arg) | `"x"` |
| `(1,2,3).rotor(2, :zzz)` | `((1, 2),)` | `((1, 2), ())` | `((1, 2),)` |
| `(1,2,3).classify({$_}, :zzz)` | 3 keys | 4 keys | 3 keys |
| `(1,2,3).categorize({$_}, :zzz)` | 3 keys | 4 keys | 3 keys |
| `(1,2,3).minmax(:zzz)` | `1..3` | `Nil` | `1..3` |
| `(1,2,3).AT-POS(1, :zzz)` | `2` | `Failure` "Index out of range" | `2` |
| `(1,2,3).EXISTS-POS(1, :zzz)` | `True` | `False` | `True` |
| `Buf.new(1,2,3).subbuf(1, :zzz)` | `Buf.new(2,3)` | `Buf.new()` | `Buf.new(2,3)` |
| `(1,2,3).first(:zzz)` | `X::Adverb` Failure | `Any` | `X::Adverb` Failure |
| `(1,2,3).first(* > 1, :zzz)` | `X::Adverb` Failure | `2` | `X::Adverb` Failure |
| `255.base(16, :zzz)` | `"FF"` | `"FF"` | `"FF"` |
| `"a,b,,c".split(",", :skip-empty)` | `("a","b","c")` | same | same |
| `"abcdef".contains("B", :i)` | `True` | `True` | `True` |

`(1,2,3).first(:zzz)` measured as a **Failure**, not a throw — rakudo `fail`s
`first`'s `X::Adverb` while it throws `grep`'s.

The sweep also corrected the finding's framing. It said `chop`/`polymod`/`fmt`
"have no named parsing at all to extend", implying they differ structurally
from `rotor`/`classify` — they do not, only in *which* names they accept. And
`classify`'s "a named-flavour `Pair` can legitimately arrive as data" caveat
does not apply to the argument list at all: `callable_item`'s comment is about
`Pair`s arriving as **elements of the list being classified**, which never pass
through the argument vector.

## The fix

`native_method_accepted_nameds(method) -> Option<&'static [&'static str]>`
(`src/builtins/accepted_nameds.rs`) states which names each surveyed method
reads. The builtin dispatch layer drops everything outside that set before it
chooses an arity, at the three places that layer is entered and **only** there —
`try_native_method_raw`'s arity cascade, its interpreter-side twin, and
`dispatch_method_by_name_1/2/3`. The filtered list is a local, so a user
method, a constructor and every `%_`-carrying handler downstream still see the
call's own arguments.

The table is **partial on purpose**, and the polarity is the whole decision:

- *listed = filtered* (chosen) — an omission leaves a known-wrong answer wrong;
- *unlisted = filtered* — an omission silently deletes a real adverb.

ADR-0070 records why the alternative design the todo file proposed (extend the
`native_*_with_options` interceptor pattern until no cascade arm reads an
argument `Pair`) was rejected **on the measurement**: the `arity_bits` column
shows only about half the affected methods are cascade-served at all —
`polymod`, `rotor`, `classify`, `categorize`, `first`, `minmax`, `skip` and
`sprintf` are slow-path — and the cascade is already so close to named-blind
(five arg-side named reads in the whole tree) that its "structural invariant"
reduces to a five-entry exemption list guarding the same filter.

`grep`/`first` are deliberately absent from the table: rakudo *validates* their
adverbs rather than swallowing an unknown one. `first` now does too, in both
the method and the sub form.

## The guard

Not a hand-maintained list. `scripts/native-method-adverb-survey.raku` asks
rakudo for the named parameters every candidate of a method declares across
every owner type — authoritative, because the implicit `*%_` means a name
outside that set *cannot* change the answer — and flags the `*%_` slurpy so a
routine that validates its own `%_` is visibly not answerable by signature
alone.

`t/native-method-accepted-nameds.t` (66 assertions) pins both halves of every
declaration: an undeclared named is invisible, and every declared adverb still
reaches the implementation (`rotor(:partial)`, `classify(:as)`/`(:into)`,
`minmax(:by)`, `first(:k)`/`(:kv)`/`(:end)`), plus the positional `Pair` cycle
spec `rotor(2 => -1)` that ADR-0021's flavour distinction protects. **The file
passes unmodified under `raku` as well as under mutsu**, so it is a conformance
test, not a snapshot of mutsu's own behaviour.

## Result

332 of the 754 non-named-blind probes became named-blind, including every row
of the original finding. No probe that was named-blind before stopped being so;
the only new divergences in the re-run sweep are `first`'s intended `X::Adverb`
and pre-existing QuantHash iteration-order noise.

- `make test`: PASS (3746 files, 38945 tests).
- 315 whitelisted roast files across `S32-str`/`-list`/`-array`/`-hash`/`-num`,
  `S02-types`, `S29-*` and `S03-operators`: 60 782 tests, 0 failures.

Residue (undeclared methods, `add`/`remove`/`grab` on the mutable QuantHashes,
and methods whose adverb set rakudo answers only through `%_`) stays recorded
in the narrowed `todo/deep/native-method-accepted-named-declarations.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
