### PR TITLE
fix(io): a custom IO::Handle's WRITE/READ routing reaches every dispatch entry

### DIFF
--- a/news/2026-09/custom-io-handle-routing-reaches-every-dispatch-entry.md
+++ b/news/2026-09/custom-io-handle-routing-reaches-every-dispatch-entry.md
@@ -1,0 +1,78 @@
+# A custom `IO::Handle`'s WRITE/READ routing now reaches every dispatch entry
+
+`Type/IO/Handle.rakudoc`'s "Creating Custom Handles" (6.d) documents that a class
+`is IO::Handle` implementing `.WRITE` / `.READ` / `.EOF` gets the high-level text
+methods for free. Both of the doc's worked examples failed:
+
+```raku
+my $store = IO::Store.new;
+my $out = $*OUT;
+$*OUT = $store;
+.say for <one two three>;
+$*OUT = $out;
+say $store.lines;      # raku: [one\n two\n three\n]
+                       # mutsu: printed to the real stdout, captured nothing
+```
+
+and the second example died outright with `Expected IO::Handle`.
+
+## The routing already existed
+
+`todo/deep/custom-io-handle-write-read-not-dispatched.md` called the feature
+"completely unimplemented" and scoped a fix across `native_io/io_handle.rs`,
+`handle_open.rs` and the say/print VM ops. None of that was needed.
+`try_user_io_handle_method` (`vm/vm_call_method_compiled_io.rs`) already
+implemented the whole routing — it was simply **wired into two of the
+interpreter's four method-dispatch entry points**:
+
+- the documented `$*OUT = $store` idiom reaches the handle through an *internal*
+  `.print` dispatch from `write_to_named_handle`, i.e. `call_method_with_values`,
+  which had no hook — so the call errored, and `write_to_named_handle`'s own
+  fallback swallowed the error and printed to the real stdout;
+- the read-side methods (`.read`, `.eof`, `.getc`, `.get`, `.lines`, …) are
+  mut-path methods and arrive at `call_method_mut_with_values`, which had no hook
+  either — so they reached the native `IO::Handle` arm and died for want of a
+  real file descriptor.
+
+`$store.print("x")` written directly in Raku worked the whole time, which is what
+kept the two paths' disagreement invisible.
+
+A third defect sat inside the routing itself: the write dispatch's `match method`
+ended in `_ => return None`, so a handle overriding **both** `WRITE` and `READ`
+bailed out of the function before reaching its own read block. Every read method
+on such a handle was unreachable by construction — and overriding both is exactly
+what the doc's second example does.
+
+## The fix
+
+Three small changes: the hook added to the two missing dispatch entries, and the
+write match's catch-all changed to fall through to the read block instead of
+returning.
+
+`t/custom-io-handle-write-read.t` pins six rows against raku v2026.07: the
+documented `$*OUT` redirect for `say` / `print` / `.say`, direct
+`print`/`say`/`put` reaching `WRITE`, and `.read` / `.eof` / `.getc` reaching
+`READ`/`EOF` — including that `.read` advances.
+
+## What is left
+
+Recorded in the (retained, narrowed) ticket:
+
+- **A `READ` that over-returns is not buffered.** Raku keeps what `READ` hands
+  back beyond the requested count and serves the next read from it, which is why
+  the doc's second example — whose `READ` ignores its count and returns the whole
+  buffer — prints `one` then `two` there. mutsu returns whatever `READ` gave. A
+  well-behaved `READ` that honours its count works correctly today.
+- **A separate bug found while testing, not about custom handles at all**:
+  declaring *any* class with a `print` method makes an *unrelated* class's
+  `$*OUT = $handle` redirect fall through to the real stdout. Bisected — the same
+  block passes alone and fails as soon as such a class exists anywhere in the
+  file, because `write_to_named_handle` then takes its real-fd branch for the
+  custom handle. That is the shape of a name-keyed "a user overrode this native
+  method" check that is not scoped to the receiver's class.
+
+The methodological note worth keeping: the ticket's estimate was "a systemic
+change across three subsystems". The actual defect was a hook wired into half the
+dispatch entry points and one early `return` — found by asking *which* dispatch
+path the failing call took (`rust-gdb` backtrace at the error site) rather than by
+reading the feature's implementation.

--- a/src/runtime/methods_call_dispatch.rs
+++ b/src/runtime/methods_call_dispatch.rs
@@ -164,6 +164,21 @@ impl Interpreter {
         if method == "WHICH" && args.is_empty() {
             self.warm_which_identity(&target);
         }
+        // A user `IO::Handle` subclass that overrides `WRITE`/`READ`/`EOF` gets
+        // the high-level text methods for free by routing them through those
+        // overrides (`try_user_io_handle_method`). That hook was wired into the
+        // two OPCODE dispatch paths only, so an INTERNAL dispatch reached the
+        // native `IO::Handle` arm instead and failed for want of a real file
+        // descriptor. The visible symptom was the documented `$*OUT = $store`
+        // idiom (`Type/IO/Handle.rakudoc`, "Creating Custom Handles") printing
+        // to the real stdout and capturing nothing:
+        // `write_to_named_handle` calls `.print` on the handle through here,
+        // that call errored, and the error was swallowed by its own fallback to
+        // `emit_output`. `$store.print(...)` written directly in Raku worked all
+        // along, which is what made the two paths' disagreement invisible.
+        if let Some(result) = self.try_user_io_handle_method(&target, method, &args) {
+            return result;
+        }
         if !args.iter().any(|a| a.is_string_pair_value()) {
             return self.call_method_with_values_inner(target, method, args, true);
         }

--- a/src/runtime/methods_mut_dispatch.rs
+++ b/src/runtime/methods_mut_dispatch.rs
@@ -15,6 +15,17 @@ impl Interpreter {
         method: &str,
         args: Vec<Value>,
     ) -> Result<Value, RuntimeError> {
+        // A user `IO::Handle` subclass overriding `WRITE`/`READ`/`EOF` routes
+        // its high-level text methods through those overrides. The read-side
+        // methods (`.read`, `.eof`, `.getc`, `.get`, ...) are mut-path methods
+        // and arrive HERE, not at the two dispatch entries that already carried
+        // the hook -- so they fell through to the native `IO::Handle` arm and
+        // died with "Expected IO::Handle" for want of a real file descriptor,
+        // while `.print` on the same object worked. See
+        // `try_user_io_handle_method`.
+        if let Some(result) = self.try_user_io_handle_method(&target, method, &args) {
+            return result;
+        }
         // Augmented native-type dispatch (mut-path twin of the non-mut guard in
         // `call_method_with_values`): see `native_lever_a_user_override`'s doc
         // comment. A native-typed receiver never carries an attribute cell, so

--- a/src/vm/vm_call_method_compiled_io.rs
+++ b/src/vm/vm_call_method_compiled_io.rs
@@ -193,105 +193,114 @@ impl Interpreter {
             };
         }
 
-        if has_write {
-            // `nl-out` for the newline-appending methods; default "\n".
-            let nl_out = match target.view() {
-                ValueView::Instance { attributes, .. } => attributes
-                    .as_map()
-                    .get("nl-out")
-                    .map(|v| v.to_string_value())
-                    .unwrap_or_else(|| "\n".to_string()),
-                _ => "\n".to_string(),
-            };
-            // Raw-byte methods first: their argument is (or may be) a Blob.
-            match method {
-                "write" => {
-                    let mut out = Vec::new();
-                    for arg in args {
-                        if Self::is_buf_value(arg) {
-                            out.extend(self.supply_chunk_to_bytes(arg, "utf-8"));
-                        } else {
-                            out.extend(loan_env!(self, render_str_value(arg)).into_bytes());
-                        }
-                    }
-                    return Some(self.call_user_io_write(target, out).map(|_| Value::TRUE));
-                }
-                "spurt" => {
-                    let cv = args
-                        .first()
-                        .cloned()
-                        .unwrap_or_else(|| Value::str(String::new()));
-                    let bytes = if Self::is_buf_value(&cv) {
-                        Self::extract_buf_bytes(&cv)
-                    } else {
-                        cv.to_string_value().into_bytes()
-                    };
-                    return Some(self.call_user_io_write(target, bytes).map(|_| Value::TRUE));
-                }
-                _ => {}
-            }
-            // Text methods: build the string content then append `nl-out`.
-            let (content, newline) = match method {
-                "print" => {
-                    let mut c = String::new();
-                    for arg in args {
-                        c.push_str(&loan_env!(self, render_str_value(arg)));
-                    }
-                    (c, false)
-                }
-                "put" => {
-                    let mut c = String::new();
-                    for arg in args {
-                        c.push_str(&loan_env!(self, render_str_value(arg)));
-                    }
-                    (c, true)
-                }
-                "say" => {
-                    let mut c = String::new();
-                    for arg in args {
-                        match loan_env!(self, render_gist_value(arg)) {
-                            Ok(g) => c.push_str(&g),
-                            Err(e) => return Some(Err(e)),
-                        }
-                    }
-                    (c, true)
-                }
-                "printf" => {
-                    // printf requires a format argument; a bare `$handle.printf`
-                    // matches no candidate (roast .../multi-no-match.t).
-                    if args.is_empty() {
-                        return Some(Err(
-                            crate::runtime::methods_signature_errors::make_multi_no_match_error(
-                                "printf",
-                            ),
-                        ));
-                    }
-                    let fmt = args
-                        .first()
+        // A handle that overrides BOTH `WRITE` and `READ` must still reach the
+        // read block below: this used to `return None` from the write match's
+        // catch-all, so `.read`/`.eof`/`.getc` on such a handle fell through to
+        // the native `IO::Handle` arm and died with "Expected IO::Handle" --
+        // which is exactly the shape `Type/IO/Handle.rakudoc`'s second worked
+        // example uses. `break 'write` falls through instead.
+        #[allow(clippy::never_loop)]
+        'write: {
+            if has_write {
+                // `nl-out` for the newline-appending methods; default "\n".
+                let nl_out = match target.view() {
+                    ValueView::Instance { attributes, .. } => attributes
+                        .as_map()
+                        .get("nl-out")
                         .map(|v| v.to_string_value())
-                        .unwrap_or_default();
-                    let rest = &args[1..];
-                    if let Err(e) =
-                        crate::runtime::sprintf::validate_sprintf_directives(&fmt, rest.len())
-                    {
-                        return Some(Err(e));
+                        .unwrap_or_else(|| "\n".to_string()),
+                    _ => "\n".to_string(),
+                };
+                // Raw-byte methods first: their argument is (or may be) a Blob.
+                match method {
+                    "write" => {
+                        let mut out = Vec::new();
+                        for arg in args {
+                            if Self::is_buf_value(arg) {
+                                out.extend(self.supply_chunk_to_bytes(arg, "utf-8"));
+                            } else {
+                                out.extend(loan_env!(self, render_str_value(arg)).into_bytes());
+                            }
+                        }
+                        return Some(self.call_user_io_write(target, out).map(|_| Value::TRUE));
                     }
-                    (
-                        crate::runtime::sprintf::format_sprintf_args(&fmt, rest),
-                        false,
-                    )
+                    "spurt" => {
+                        let cv = args
+                            .first()
+                            .cloned()
+                            .unwrap_or_else(|| Value::str(String::new()));
+                        let bytes = if Self::is_buf_value(&cv) {
+                            Self::extract_buf_bytes(&cv)
+                        } else {
+                            cv.to_string_value().into_bytes()
+                        };
+                        return Some(self.call_user_io_write(target, bytes).map(|_| Value::TRUE));
+                    }
+                    _ => {}
                 }
-                "print-nl" => (String::new(), true),
-                _ => return None,
-            };
-            let mut text = content;
-            if newline {
-                text.push_str(&nl_out);
+                // Text methods: build the string content then append `nl-out`.
+                let (content, newline) = match method {
+                    "print" => {
+                        let mut c = String::new();
+                        for arg in args {
+                            c.push_str(&loan_env!(self, render_str_value(arg)));
+                        }
+                        (c, false)
+                    }
+                    "put" => {
+                        let mut c = String::new();
+                        for arg in args {
+                            c.push_str(&loan_env!(self, render_str_value(arg)));
+                        }
+                        (c, true)
+                    }
+                    "say" => {
+                        let mut c = String::new();
+                        for arg in args {
+                            match loan_env!(self, render_gist_value(arg)) {
+                                Ok(g) => c.push_str(&g),
+                                Err(e) => return Some(Err(e)),
+                            }
+                        }
+                        (c, true)
+                    }
+                    "printf" => {
+                        // printf requires a format argument; a bare `$handle.printf`
+                        // matches no candidate (roast .../multi-no-match.t).
+                        if args.is_empty() {
+                            return Some(Err(
+                                crate::runtime::methods_signature_errors::make_multi_no_match_error(
+                                    "printf",
+                                ),
+                            ));
+                        }
+                        let fmt = args
+                            .first()
+                            .map(|v| v.to_string_value())
+                            .unwrap_or_default();
+                        let rest = &args[1..];
+                        if let Err(e) =
+                            crate::runtime::sprintf::validate_sprintf_directives(&fmt, rest.len())
+                        {
+                            return Some(Err(e));
+                        }
+                        (
+                            crate::runtime::sprintf::format_sprintf_args(&fmt, rest),
+                            false,
+                        )
+                    }
+                    "print-nl" => (String::new(), true),
+                    _ => break 'write,
+                };
+                let mut text = content;
+                if newline {
+                    text.push_str(&nl_out);
+                }
+                return Some(
+                    self.call_user_io_write(target, text.into_bytes())
+                        .map(|_| Value::TRUE),
+                );
             }
-            return Some(
-                self.call_user_io_write(target, text.into_bytes())
-                    .map(|_| Value::TRUE),
-            );
         }
 
         if has_read {

--- a/t/custom-io-handle-write-read.t
+++ b/t/custom-io-handle-write-read.t
@@ -1,0 +1,85 @@
+use Test;
+
+# `Type/IO/Handle.rakudoc`'s "Creating Custom Handles" (6.d): a class
+# `is IO::Handle` that implements `.WRITE` / `.READ` / `.EOF` gets the
+# high-level text methods for free, because the base class routes them through
+# those overrides.
+#
+# mutsu has that routing (`try_user_io_handle_method`), but it was wired into
+# two of the interpreter's method-dispatch entry points only. The documented
+# `$*OUT = $store` idiom goes through a third (an INTERNAL `.print` dispatch
+# from `write_to_named_handle`), and the read-side methods go through a fourth
+# (the mut path), so both fell through to the native `IO::Handle` arm and failed
+# for want of a real file descriptor -- the redirect printed to the real stdout
+# and captured nothing, and `.read` died "Expected IO::Handle".
+#
+# All expectations measured against raku v2026.07.
+
+plan 6;
+
+class Store is IO::Handle {
+    has @.lines = [];
+    submethod TWEAK { self.encoding: 'utf8' }
+    method WRITE(IO::Handle:D: Blob:D \data --> Bool:D) { @!lines.push: data.decode; True }
+}
+
+# The documented redirect idiom.
+{
+    my $store = Store.new;
+    my $old = $*OUT;
+    $*OUT = $store;
+    say "one";
+    print "two\n";
+    "three".say;
+    $*OUT = $old;
+    is $store.lines, ["one\n", "two\n", "three\n"],
+        'a $*OUT redirect to a custom handle routes say/print through WRITE';
+}
+
+
+# Direct calls, which always worked, pinned so the routing cannot regress.
+{
+    my $store = Store.new;
+    $store.print("a");
+    $store.say("b");
+    $store.put("c");
+    is $store.lines, ["a", "b\n", "c\n"], 'print/say/put on a custom handle reach WRITE';
+}
+
+# The read side. A handle overriding BOTH WRITE and READ must still reach the
+# read methods -- the write dispatch's catch-all used to bail out first.
+class RW is IO::Handle {
+    has $.data is rw = "";
+    has $.pos is rw = 0;
+    submethod TWEAK { self.encoding: 'utf8' }
+    method WRITE(IO::Handle:D: Blob:D \data --> Bool:D) { $!data ~= data.decode; True }
+    method READ(IO::Handle:D: Int:D \bytes --> Blob:D) {
+        my $s = $!data.substr($!pos, bytes);
+        $!pos += $s.chars;
+        $s.encode('utf8')
+    }
+    method EOF { $!pos >= $!data.chars }
+}
+
+{
+    my $h = RW.new;
+    $h.print("onetwo");
+    is $h.read(3).decode, 'one', '.read reaches READ';
+    is $h.read(3).decode, 'two', 'and advances';
+    ok $h.eof, '.eof reaches EOF';
+}
+
+{
+    my $h = RW.new;
+    $h.print("xy");
+    is $h.getc, 'x', '.getc reaches READ';
+}
+
+# NOT about the routing above, and left in a file of its own for that reason:
+# declaring ANY class with a `print` method makes an unrelated class's
+# `$*OUT = $handle` redirect fall through to the real stdout. Measured
+# 2026-09-06: the block below passes on its own and fails if a
+# `class Cap { method print(*@a) {...} }` is declared anywhere in the same file,
+# which is the shape of a name-keyed "a user overrode this native method" check
+# that is not scoped to the receiver's class. See
+# `todo/deep/custom-io-handle-write-read-not-dispatched.md`.

--- a/todo/deep/custom-io-handle-write-read-not-dispatched.md
+++ b/todo/deep/custom-io-handle-write-read-not-dispatched.md
@@ -1,3 +1,20 @@
+> **Largely fixed 2026-09-06** —
+> `news/2026-09/custom-io-handle-routing-reaches-every-dispatch-entry.md`,
+> pinned by `t/custom-io-handle-write-read.t` (6 rows against raku v2026.07).
+> Both worked examples from `Type/IO/Handle.rakudoc` now route through the user's
+> `WRITE`/`READ`/`EOF`. The remaining scope is narrower than this file's, and it
+> is recorded at the bottom under "What is left".
+>
+> The routing this file says is "completely unimplemented" was in fact already
+> implemented (`try_user_io_handle_method`, `vm/vm_call_method_compiled_io.rs`)
+> and merely **wired into two of the interpreter's four method-dispatch entry
+> points**. The `$*OUT = $store` idiom goes through a third (an internal
+> `.print` dispatch from `write_to_named_handle`) and the read-side methods
+> through a fourth (the mut path), so both fell through to the native
+> `IO::Handle` arm. A third defect sat inside the routing itself: the write
+> dispatch's catch-all arm returned early, so a handle overriding BOTH `WRITE`
+> and `READ` could never reach its own read methods.
+
 # Custom `IO::Handle` subclasses overriding WRITE/READ/EOF are not honored by print/say/read
 
 Found by the doc-diff harness (`docs/doc-diff-backlog.md`, `Type/IO/Handle.rakudoc:959`
@@ -102,3 +119,39 @@ anything). That is a systemic change across `src/runtime/native_io/io_handle.rs`
   backing handle.
 - `src/runtime/handle_open.rs` — `IoHandleState`/`IoHandleTarget` may need a new target
   variant for "backed by user WRITE/READ methods, not a real fd".
+
+## What is left (measured 2026-09-06)
+
+Two things, both narrower than the original report and neither about the routing:
+
+1. **A `READ` that over-returns is not buffered.** Raku's `IO::Handle.read($n)`
+   keeps what `READ` hands back beyond `$n` and serves the next read from it —
+   which is why `Type/IO/Handle.rakudoc`'s second example, whose `READ` ignores
+   its byte count and returns the whole buffer every time, prints `one` then
+   `two` under raku. mutsu returns whatever `READ` gave, so it prints the whole
+   buffer twice. A well-behaved `READ` that honours its count and advances a
+   position works correctly today (pinned). Closing this means giving the user
+   handle a read buffer; `read_user_io_char` currently assumes `READ(1)` returns
+   exactly one byte, so it wants the same buffer.
+
+2. **A separate, pre-existing bug found while testing this, which is NOT about
+   custom handles at all**: declaring *any* class with a `print` method makes an
+   *unrelated* class's `$*OUT = $handle` redirect fall through to the real
+   stdout.
+
+   ```raku
+   class Store is IO::Handle { has @.lines = []; submethod TWEAK { self.encoding: 'utf8' }
+       method WRITE(IO::Handle:D: Blob:D \d --> Bool:D) { @!lines.push: d.decode; True } }
+   class Cap { has $.buf is rw = ""; method print(*@a) { $!buf ~= @a.join; True } }   # <-- just declaring this
+   my $store = Store.new; my $old = $*OUT;
+   $*OUT = $store; say "one"; $*OUT = $old;
+   say $store.lines;    # ["one\n"] without the Cap declaration, [] with it
+   ```
+
+   Bisected: the block passes on its own and fails as soon as a class with a
+   `print` method exists anywhere in the file. `write_to_named_handle` then takes
+   its `handle_id_from_value(...).is_some()` branch (the real-fd path) for the
+   custom handle, so the user routing is never consulted. That is the shape of a
+   name-keyed "a user overrode this native method" check that is not scoped to
+   the receiver's class — `native_lever_a_user_override` is the obvious
+   candidate. It deserves its own ticket once someone confirms the site.


### PR DESCRIPTION
Largely closes `todo/deep/custom-io-handle-write-read-not-dispatched.md` (Tier B1 in `todo/TRIAGE.md`).

## The bug

`Type/IO/Handle.rakudoc`'s "Creating Custom Handles" (6.d) documents that a class `is IO::Handle` implementing `.WRITE` / `.READ` / `.EOF` gets the high-level text methods for free. **Both** of the doc's worked examples failed:

```raku
my $store = IO::Store.new;
my $out = $*OUT;
$*OUT = $store;
.say for <one two three>;
$*OUT = $out;
say $store.lines;      # raku: [one\n two\n three\n]
                       # mutsu: printed to the real stdout, captured nothing
```

and the second died outright with `Expected IO::Handle`.

## The routing already existed

The ticket called the feature "completely unimplemented" and scoped a fix across `native_io/io_handle.rs`, `handle_open.rs` and the say/print VM ops. **None of that was needed.** `try_user_io_handle_method` (`vm/vm_call_method_compiled_io.rs`) already implemented the whole routing — it was wired into **two of the interpreter's four** method-dispatch entry points:

- the documented `$*OUT = $store` idiom reaches the handle through an *internal* `.print` dispatch from `write_to_named_handle`, i.e. `call_method_with_values`, which had no hook — so the call errored, and `write_to_named_handle`'s own fallback swallowed the error and printed to the real stdout;
- the read-side methods (`.read`, `.eof`, `.getc`, `.get`, `.lines`, …) are mut-path methods and arrive at `call_method_mut_with_values`, which had no hook either — so they reached the native `IO::Handle` arm and died for want of a real file descriptor.

`$store.print("x")` written directly in Raku worked the whole time, which is what kept the two paths' disagreement invisible. Found by asking *which* dispatch path the failing call took (a `rust-gdb` backtrace at the error site) rather than by reading the feature's implementation.

A third defect sat **inside** the routing: the write dispatch's `match method` ended in `_ => return None`, so a handle overriding **both** `WRITE` and `READ` bailed out of the function before reaching its own read block. Every read method on such a handle was unreachable by construction — and overriding both is exactly what the doc's second example does.

## Coverage

`t/custom-io-handle-write-read.t` — six rows against `raku` v2026.07: the documented `$*OUT` redirect for `say` / `print` / `.say`, direct `print`/`say`/`put` reaching `WRITE`, and `.read` / `.eof` / `.getc` reaching `READ`/`EOF`, including that `.read` advances.

`make test` passes (3748 files / 38913 tests). Every whitelisted `roast/S32-io` and `roast/S16-io` file passes locally; full roast delegated to CI.

## What stays open (ticket retained, narrowed)

- **A `READ` that over-returns is not buffered.** Raku keeps what `READ` hands back beyond the requested count and serves the next read from it — which is why the doc's second example, whose `READ` ignores its count, prints `one` then `two` there. mutsu returns whatever `READ` gave. A well-behaved `READ` that honours its count works correctly today (pinned).
- **A separate bug found while testing, not about custom handles at all**: declaring *any* class with a `print` method makes an *unrelated* class's `$*OUT = $handle` redirect fall through to the real stdout. Bisected — the block passes alone and fails as soon as such a class exists anywhere in the file, because `write_to_named_handle` then takes its real-fd branch for the custom handle. That is the shape of a name-keyed "a user overrode this native method" check that is not scoped to the receiver's class; it deserves its own ticket once the site is confirmed.