### PR TITLE
fix(vm): ADR-0068 step 3 — the three funnels of a cross-thread container write

### DIFF
--- a/docs/adr/0068-cross-thread-container-writes-need-a-synchronized-store.md
+++ b/docs/adr/0068-cross-thread-container-writes-need-a-synchronized-store.md
@@ -1,6 +1,6 @@
 # ADR-0068: A cross-thread aliased container write needs a synchronized store, not a name-keyed lane
 
-- Status: **Accepted** (2026-09-06; §4 steps 1-2 implemented, step 3 open)
+- Status: **Accepted** (2026-09-06; §4 steps 1-2 implemented, step 3 started — see §8)
 - Date: 2026-09-05
 - Relates to: [ADR-0001](0001-gc-strategy-and-phasing.md) §7 (layer 3c),
   [ADR-0013](0013-container-interior-mutability-cellvalue.md) §1.3-2 / §3 / §5 Q2,
@@ -366,3 +366,46 @@ Two properties keep it deadlock-free and affordable, and both are load-bearing:
   mutex. §6 question 4 is answered by placement rather than measurement: the gate
   sits in `ContainerStructGuard`, not in `gc_contents_mut`, so the primitive's
   147 other call sites are untouched.
+
+## 8. Step 3, first slice (2026-09-06): route 3 is classified, and it was the worst one
+
+§3 left route 3 (an object attribute written from two threads) **Unresolved** —
+"the probe reached none of the aliased-store sites this session probed, nor
+`gc_data_mut`, nor the computed-attr sites". Re-probed with the §1.1 harness now
+that the harness is cheap (§7.1):
+
+| route | before | after |
+|---|---|---|
+| `$obj.attr[$i] = v` from 20 threads | **96 / 96** | **0 / 240** (24-way) |
+| `$obj.attr{$k} = v` from 20 threads | 0 / 96 | 0 / 240 (24-way) |
+| `$obj.attr.push($v)` from 20 threads | **95 / 96** | **95 / 96 — still racing** |
+
+So route 3 is not merely exposed: at 96/96 it is the highest rate any route in
+this ADR has shown, with `corrupted size vs. prev_size`,
+`double free or corruption (top)` and a NaN-box tag panic, and with the
+name-keyed lane never consulted — which is exactly right, because an
+attribute-rooted store is not name-keyed at all. §3's "Unresolved" was a probe
+that missed, not an absence.
+
+The reason the earlier probe found nothing is worth recording: it looked for the
+*aliased-store* sites, and this route does not use them. `$obj.attr[$i] = v`
+lowers to `__mutsu_index_assign_method_lvalue`, whose whole body writes through
+the container the accessor just handed back — so the exclusion goes on **that
+container**, once, and covers every write in the function regardless of which
+internal helper performs it. That is the same "find the funnel, not the sites"
+shape §2 used for the celled route.
+
+### Still open in step 3
+
+- **A mutating METHOD on an attribute container** (`$obj.attr.push`) races at
+  95/96. It does not go through `__mutsu_index_assign_method_lvalue`, and four
+  breakpoint probes (`call_method_mut_with_values`, `try_native_array_mut`,
+  `proxy_subclass_array_mutate`, `gc_data_mut`'s aliased branch) all came back
+  cold, so its write site is not yet located. Locating it is the next
+  measurement, and the §1.2 oracle is the tool.
+- The other lane-decline reasons from §2 (twigil'd names, a container never in a
+  spawning frame's env) are unprobed.
+- Route 5 is still blocked behind the Channel-supply delivery bug, and §3.1's
+  `S17-procasync/stress.t` SIGSEGV is still unexplained.
+
+Pinned by `t/concurrent-attribute-element-store.t` (3 rows, green under raku).

--- a/docs/adr/0068-cross-thread-container-writes-need-a-synchronized-store.md
+++ b/docs/adr/0068-cross-thread-container-writes-need-a-synchronized-store.md
@@ -378,7 +378,7 @@ that the harness is cheap (§7.1):
 |---|---|---|
 | `$obj.attr[$i] = v` from 20 threads | **96 / 96** | **0 / 240** (24-way) |
 | `$obj.attr{$k} = v` from 20 threads | 0 / 96 | 0 / 240 (24-way) |
-| `$obj.attr.push($v)` from 20 threads | **95 / 96** | **95 / 96 — still racing** |
+| `$obj.attr.push($v)` from 20 threads | **95 / 96** | **0 / 240** (24-way) |
 
 So route 3 is not merely exposed: at 96/96 it is the highest rate any route in
 this ADR has shown, with `corrupted size vs. prev_size`,
@@ -395,17 +395,29 @@ container**, once, and covers every write in the function regardless of which
 internal helper performs it. That is the same "find the funnel, not the sites"
 shape §2 used for the celled route.
 
+### A mutating METHOD is a third funnel
+
+`$obj.attr.push($v)` raced at 95/96 and goes through neither store funnel. Four
+breakpoint probes (`call_method_mut_with_values`, `try_native_array_mut`,
+`proxy_subclass_array_mutate`, `gc_data_mut`'s aliased branch) all came back
+cold; the §1.2 oracle then showed it arriving as an ordinary *value* dispatch —
+`exec_call_method_op` → `call_method_with_values`, once each. That is its funnel,
+and excluding a small allowlist of mutator method names there
+(`push`/`append`/`prepend`/`unshift`/`pop`/`shift`/`splice` plus the
+`STORE`/`ASSIGN-*`/`DELETE-*` protocol names) takes it to **0/240 at 24-way**.
+
+So step 3's shape is now clear, and it is not the "149-site sweep" §4 warned
+against: there are **three funnels**, not 149 sites — the named element store
+(§2), the attribute-rooted element store (above), and the mutating method. Each
+was found the same way, by asking the §1.2 oracle which path the failing
+workload actually took rather than by reading the write sites.
+
 ### Still open in step 3
 
-- **A mutating METHOD on an attribute container** (`$obj.attr.push`) races at
-  95/96. It does not go through `__mutsu_index_assign_method_lvalue`, and four
-  breakpoint probes (`call_method_mut_with_values`, `try_native_array_mut`,
-  `proxy_subclass_array_mutate`, `gc_data_mut`'s aliased branch) all came back
-  cold, so its write site is not yet located. Locating it is the next
-  measurement, and the §1.2 oracle is the tool.
 - The other lane-decline reasons from §2 (twigil'd names, a container never in a
-  spawning frame's env) are unprobed.
+  spawning frame's env) are unprobed. Given the three funnels above, the
+  expectation is that they arrive at one of them; probe before assuming.
 - Route 5 is still blocked behind the Channel-supply delivery bug, and §3.1's
   `S17-procasync/stress.t` SIGSEGV is still unexplained.
 
-Pinned by `t/concurrent-attribute-element-store.t` (3 rows, green under raku).
+Pinned by `t/concurrent-attribute-element-store.t` (4 rows, green under raku).

--- a/src/runtime/builtins_multidim_assign.rs
+++ b/src/runtime/builtins_multidim_assign.rs
@@ -84,10 +84,29 @@ impl Interpreter {
         // for the element modify; the shared-Arc propagation below
         // (`overwrite_array_bindings_by_identity`, now cell-aware) reaches every
         // alias through the cell's inner Arc.
+        // ADR-0068 §4 step 3: an attribute-rooted element store
+        // (`$obj.attr[$i] = v`) is one of the routes the name-keyed cross-thread
+        // lane cannot cover -- it is not name-keyed at all -- and §3 left it
+        // "Unresolved" for want of a trace. Measured with the §1.1 harness:
+        // 96/96 runs corrupt the heap (`corrupted size vs. prev_size`,
+        // `double free or corruption (top)`, a NaN-box tag panic), with the lane
+        // never consulted. Every write below goes through the container the
+        // accessor just handed back, so excluding on that container covers them
+        // all at once. A no-op (one relaxed load) until a VM mutator thread is
+        // spawned; a thread holds at most one of these locks, so the accessor
+        // dispatches inside the region cannot deadlock against themselves.
+        let attr_cell_addr = match current.view() {
+            ValueView::ContainerRef(cell) => Some(crate::gc::Gc::as_ptr(&cell) as usize),
+            _ => None,
+        };
         let current = match current.view() {
             ValueView::ContainerRef(cell) => cell.lock().unwrap().clone(),
             _ => current,
         };
+        let _struct_guard = crate::value::container_lock::ContainerStructGuard::acquire_for(
+            attr_cell_addr,
+            &current,
+        );
 
         // Package-level `is rw` accessors with arguments (for example
         // `Crane::At.at($root, @path)`) return the selected container itself.

--- a/src/runtime/methods_call_dispatch.rs
+++ b/src/runtime/methods_call_dispatch.rs
@@ -137,6 +137,29 @@ impl Interpreter {
     ///
     /// Named-ness is a call-site property (ADR-0021): only the `Pair` flavour is a
     /// named argument, so a positional `Pair` (`%h.push((a => 1))`) is untouched.
+    /// Whether `method` structurally mutates its container receiver, i.e.
+    /// whether two threads running it on one container race on the backing
+    /// `Vec`/`HashMap`. Deliberately a small allowlist of the mutators, not a
+    /// blanket guard: every other method is a read and pays only the relaxed
+    /// load in the caller's gate.
+    fn method_mutates_container(method: &str) -> bool {
+        matches!(
+            method,
+            "push"
+                | "append"
+                | "prepend"
+                | "unshift"
+                | "pop"
+                | "shift"
+                | "splice"
+                | "STORE"
+                | "ASSIGN-POS"
+                | "ASSIGN-KEY"
+                | "DELETE-POS"
+                | "DELETE-KEY"
+        )
+    }
+
     pub(crate) fn call_method_with_values(
         &mut self,
         target: Value,
@@ -187,6 +210,23 @@ impl Interpreter {
         if let Some(result) = self.try_user_io_handle_method(&target, method, &args) {
             return result;
         }
+        // ADR-0068 §4 step 3: a MUTATING METHOD on a container that two threads
+        // can reach -- `$obj.attr.push($v)` is the measured shape, 95/96 runs
+        // corrupt -- structurally mutates the backing node with nothing held.
+        // The element-store routes are excluded at their own funnels; this is
+        // the funnel for the method form, which arrives here as an ordinary
+        // value dispatch (verified by breakpoint: `exec_call_method_op` ->
+        // `call_method_with_values`, reaching none of the store paths).
+        // Keyed on the receiver's own node, which is what two threads holding
+        // the same attribute container share. A no-op (one relaxed load) until
+        // a VM mutator thread is spawned.
+        let _mutating_guard = if crate::value::container_lock::multi_mutator_threads_live()
+            && Self::method_mutates_container(method)
+        {
+            crate::value::container_lock::ContainerStructGuard::acquire_for(None, &target)
+        } else {
+            None
+        };
         if !args.iter().any(|a| a.is_string_pair_value()) {
             return self.call_method_with_values_inner(target, method, args, true);
         }

--- a/t/concurrent-attribute-element-store.t
+++ b/t/concurrent-attribute-element-store.t
@@ -18,7 +18,7 @@ use Test;
 # container all land, but it does not corrupt its own heap either, and every
 # row below is measured green under raku.
 
-plan 3;
+plan 4;
 
 # The array attribute: 1000 distinct indices from 20 threads.
 {
@@ -49,4 +49,16 @@ plan 3;
     await (^12).map: -> $t { start { for ^40 -> $k { deep($t * 40 + $k) } } };
     is $n.rows.grep(*.defined).elems, 480,
         'the same holds when the thread body only calls a routine that writes';
+}
+
+# A mutating METHOD on the same attribute container. This arrives as an
+# ordinary value dispatch (`exec_call_method_op` -> `call_method_with_values`,
+# verified by breakpoint) and reaches none of the store funnels, so it needs its
+# own exclusion.
+{
+    class Pushy { has @.log is rw; }
+    my $p = Pushy.new(log => []);
+    sub add($v) { $p.log.push($v) }
+    await (^20).map: -> $t { start { for ^50 -> $k { add($t * 50 + $k) } } };
+    is $p.log.elems, 1000, 'every push onto an attribute container lands';
 }

--- a/t/concurrent-attribute-element-store.t
+++ b/t/concurrent-attribute-element-store.t
@@ -1,0 +1,52 @@
+use Test;
+
+# ADR-0068 §3 route 3 -- an object attribute written from several threads --
+# was recorded as "Unresolved: the probe reached none of the aliased-store
+# sites this session probed". Measured 2026-09-06 with the §1.1 harness it is
+# not merely exposed, it is the worst route yet found: 96 of 96 runs corrupted
+# the heap (`corrupted size vs. prev_size`, `double free or corruption (top)`,
+# a NaN-box tag panic), with the name-keyed lane never consulted -- which is
+# expected, since an attribute-rooted store is not name-keyed at all.
+#
+# The route reaches its container through `builtin_index_assign_method_lvalue`
+# (`$obj.attr[$i] = v` lowers to `__mutsu_index_assign_method_lvalue`), and
+# every write in that function goes through the container the accessor hands
+# back -- so one exclusion on that container covers them all.
+#
+# Like the other cross-thread pins, these assert mutsu's stronger guarantee:
+# rakudo does not promise that concurrent unsynchronised writes to one
+# container all land, but it does not corrupt its own heap either, and every
+# row below is measured green under raku.
+
+plan 3;
+
+# The array attribute: 1000 distinct indices from 20 threads.
+{
+    class Holder { has @.seen is rw; }
+    my $h = Holder.new(seen => []);
+    sub note-array($v) { $h.seen[$v] = 1 }
+    await (^20).map: -> $t { start { for ^50 -> $k { note-array($t * 50 + $k) } } };
+    is $h.seen.grep(*.defined).elems, 1000,
+        'every element store through an array attribute lands';
+}
+
+# The hash attribute takes the same path.
+{
+    class HHolder { has %.seen is rw; }
+    my $h = HHolder.new(seen => {});
+    sub note-hash($v) { $h.seen{"k$v"} = 1 }
+    await (^20).map: -> $t { start { for ^50 -> $k { note-hash($t * 50 + $k) } } };
+    is $h.seen.elems, 1000, 'every key store through a hash attribute lands';
+}
+
+# Reached through a named sub the thread body merely calls, which is the shape
+# the thread-escape analysis cannot see (ADR-0039 §8.6) -- the same shape that
+# made the celled-container route reproduce on the first run.
+{
+    class Nested { has @.rows is rw; }
+    my $n = Nested.new(rows => []);
+    sub deep($i) { $n.rows[$i] = $i }
+    await (^12).map: -> $t { start { for ^40 -> $k { deep($t * 40 + $k) } } };
+    is $n.rows.grep(*.defined).elems, 480,
+        'the same holds when the thread body only calls a routine that writes';
+}

--- a/todo/deep/gc-contents-mut-cross-thread-aliased-writes.md
+++ b/todo/deep/gc-contents-mut-cross-thread-aliased-writes.md
@@ -44,13 +44,13 @@ reachable while the name-keyed lane declines (ADR-0068 §2 lists five):
 - the container was never in a spawning frame's env;
 - the write is not name-keyed at all (`$obj.attr[$i]`, `%h<k>[$i]`, a container
   returned from a method);
-- mutating *methods* rather than element stores — `push`/`pop`/`splice`/`:delete`
-  and the `try_native_array_mut` / `try_native_hash_mut_bound` paths — which reach
-  their container through the same `env_root_descended_mut` chokepoint but do not
-  yet take the guard.
+- ~~mutating *methods* rather than element stores~~ — **done**, see above.
 
 Each wants its own oracle-classified probe and its own stress acceptance, per
-ADR-0068 §4 step 3 — not one 149-site sweep.
+ADR-0068 §4 step 3 — not one 149-site sweep. The evidence so far is that this
+class has **three funnels**, not 149 sites: the named element store, the
+attribute-rooted element store, and the mutating method. Expect a new route to
+arrive at one of them; probe before assuming it needs a fourth.
 
 Three specific loose ends from the route audit:
 
@@ -63,11 +63,12 @@ Three specific loose ends from the route audit:
   container the accessor hands back, so the exclusion goes on that container.
   Element stores (array and hash) are now 0/240 at 24-way.
 
-  **A mutating METHOD on an attribute container still races at 95/96**
-  (`$obj.attr.push($v)`). It does not go through that builtin, and four
-  breakpoint probes (`call_method_mut_with_values`, `try_native_array_mut`,
-  `proxy_subclass_array_mutate`, `gc_data_mut`'s aliased branch) came back cold,
-  so its write site is not located yet. That is the next measurement.
+  **A mutating METHOD on an attribute container was a third funnel**, also
+  fixed: `$obj.attr.push($v)` raced at 95/96 and goes through neither store
+  funnel. Four breakpoint probes came back cold; the ADR-0068 §1.2 oracle showed
+  it arriving as an ordinary VALUE dispatch (`exec_call_method_op` ->
+  `call_method_with_values`), and excluding a small allowlist of mutator method
+  names there takes it to 0/240 at 24-way.
 - **Route 5 (`Channel.Supply` tap captures)** is exposed on the path oracle but
   blocked behind a separate deterministic Channel-supply delivery bug that
   drops/misorders values on a single unloaded run. Fix that first.

--- a/todo/deep/gc-contents-mut-cross-thread-aliased-writes.md
+++ b/todo/deep/gc-contents-mut-cross-thread-aliased-writes.md
@@ -54,9 +54,20 @@ ADR-0068 §4 step 3 — not one 149-site sweep.
 
 Three specific loose ends from the route audit:
 
-- **Route 3 (object attributes, `has @.seen is rw`) is unclassified.** It reaches
-  none of the probed aliased-store sites, nor `gc_data_mut`, nor the computed-attr
-  sites. Trace it before calling it covered or exposed.
+- ~~**Route 3 (object attributes) is unclassified.**~~ **CLASSIFIED AND HALF
+  FIXED (2026-09-06, ADR-0068 §8).** It was the worst route in the ADR: an
+  element store through an array attribute corrupted the heap on **96 of 96**
+  runs. The earlier probe missed because it looked for the *aliased-store* sites
+  and this route uses none of them — `$obj.attr[$i] = v` lowers to
+  `__mutsu_index_assign_method_lvalue`, whose whole body writes through the
+  container the accessor hands back, so the exclusion goes on that container.
+  Element stores (array and hash) are now 0/240 at 24-way.
+
+  **A mutating METHOD on an attribute container still races at 95/96**
+  (`$obj.attr.push($v)`). It does not go through that builtin, and four
+  breakpoint probes (`call_method_mut_with_values`, `try_native_array_mut`,
+  `proxy_subclass_array_mutate`, `gc_data_mut`'s aliased branch) came back cold,
+  so its write site is not located yet. That is the next measurement.
 - **Route 5 (`Channel.Supply` tap captures)** is exposed on the path oracle but
   blocked behind a separate deterministic Channel-supply delivery bug that
   drops/misorders values on a single unloaded run. Fix that first.


### PR DESCRIPTION
ADR-0068 step 3 — the Tier S cluster in `todo/TRIAGE.md`. Two racing routes closed, and the shape of the remaining work settled.

## Route 3 was not "unclassified". It was the worst route in the ADR.

ADR-0068 §3 left route 3 — an object attribute written from two threads — **Unresolved**: "the probe reached none of the aliased-store sites this session probed, nor `gc_data_mut`, nor the computed-attr sites". Re-probed with the §1.1 harness:

```raku
class Holder { has @.seen is rw; }
my $h = Holder.new(seen => []);
sub note-it($v) { $h.seen[$v] = 1 }
await (^20).map: -> $t { start { for ^50 -> $k { note-it($t * 50 + $k) } } };
say $h.seen.grep(*.defined).elems;   # want 1000
```

**96 of 96 runs corrupted the heap**, with the name-keyed lane never consulted — which is exactly right, because an attribute-rooted store is not name-keyed at all.

## Measured

| route | before | after |
|---|---|---|
| `$obj.attr[$i] = v` from 20 threads | **96 / 96** | **0 / 240** (24-way) |
| `$obj.attr{$k} = v` from 20 threads | 0 / 96 | 0 / 240 (24-way) |
| `$obj.attr.push($v)` from 20 threads | **95 / 96** | **0 / 240** (24-way) |
| plain `@a.push` from 20 threads (control) | 0 / 96 | 0 / 120 |

## The finding: three funnels, not 149 sites

§4 framed step 3 as a route-by-route widening against `gc_contents_mut`'s 149 call sites. It is not. This class has **three funnels**, and all three were found the same way — by asking the §1.2 oracle *which path the failing workload actually took*, never by reading the write sites:

1. the **named element store** (§2, already excluded);
2. the **attribute-rooted element store** — `$obj.attr[$i] = v` lowers to `__mutsu_index_assign_method_lvalue`, and every write in that builtin goes through the container the accessor just handed back, so one exclusion on *that container* covers them all;
3. the **mutating method** — `$obj.attr.push($v)` goes through neither store funnel. Four breakpoint probes came back cold (`call_method_mut_with_values`, `try_native_array_mut`, `proxy_subclass_array_mutate`, `gc_data_mut`'s aliased branch); the oracle showed it arriving as an ordinary *value* dispatch, `exec_call_method_op` → `call_method_with_values`. Excluding a small allowlist of mutator method names there closes it. The allowlist is deliberate — every other method is a read and pays only the relaxed load in the caller's gate.

The ADR and the ticket now record this, so the next route gets probed against those three before anyone assumes a fourth.

## Coverage

`t/concurrent-attribute-element-store.t` — 4 rows, all green under `raku` v2026.07, including the one reached through a **named sub the thread body merely calls** (the route the thread-escape analysis cannot see, ADR-0039 §8.6 — the shape that made the celled route reproduce on the first try).

`make test` passes (3753 files / 39049 tests). All four concurrency pins, `roast/integration/advent2014-day05.t`, `S17-supply/basic.t`, `S17-lowlevel/thread.t` and `S12-attributes/instance.t` pass.

## Still open in step 3

The other lane-decline reasons from §2 (twigil'd names, a container never in a spawning frame's env) are unprobed — the expectation is now that they arrive at one of the three funnels. Route 5 remains blocked behind the Channel-supply delivery bug, and §3.1's `S17-procasync/stress.t` SIGSEGV remains unexplained.