### PR TITLE
fix(seq): pulling a deferred map pulls the deferred maps it produced

### DIFF
--- a/docs/adr/0058-map-grep-produce-a-deferred-seq.md
+++ b/docs/adr/0058-map-grep-produce-a-deferred-seq.md
@@ -269,7 +269,8 @@ callback `Value` already carries its own closure environment.
 | **0** | **Measure the read-path exposure** by flipping `dispatch_map_method`/`builtin_map` to always call `create_lazy_map_list` behind a temporary env gate, and running `t/` and the roast whitelist with it on. This is option 3's exposure without option 3's cost, and it produces the list of consumers that read a deferred sequence without forcing it. | Discard the gate afterwards; it is a measurement, not a slice. |
 | **1** | **Done (2026-08-22).** `t/map-callback-runs-at-consumption.t` — 23 rows, raku-verified 23/23, mutsu 12 passing and 11 `todo`. Un-`todo`ing the nine ADR-0058 rows is this ADR's completion signal; the other two `todo`s belong to §1.4's separate bug. | Same shape as ADR-0034 phase 1. |
 | **2** | **Done (2026-09-07).** `SeqSource::MapGrep` + the `pull_seq_source` arm + `Value::seq_deferred` construction in `dispatch_map_method` only (not `builtin_map`, not `grep`), plus the read-path consumers S8 lists. | All nine ADR-0058 rows of phase 1's oracle are un-`todo`d; the two remaining `todo`s are S1.4's separate bug. |
-| **3** | Extend to `builtin_map` (the `map &f, @xs` function form) and to both `grep` entry points. `grep`'s `:k`/`:kv`/`:p` adverbs need positional indices over the whole result and can stay eager, exactly as they already opt out of `make_lazy_pipe`. | |
+| **3a** | **Attempted and REVERTED (2026-09-07).** `builtin_map` (the `map &f, @xs` listop form) returning the same `Value::seq_deferred(SeqSource::MapGrep { .. })` as step 2 is a five-line diff and was green on `make test`, but the full roast run aborted a whitelisted file. **Blocked on a step-2 hole**, see S9.1 and `todo/deep/deferred-map-callback-runs-in-the-consuming-frames-env.md`. | |
+| **3b** | Extend to both `grep` entry points. Measured 2026-09-07: grep is still fully eager and diverges from rakudo. `grep`'s `:k`/`:kv`/`:p` adverbs need positional indices over the whole result and can stay eager, exactly as they already opt out of `make_lazy_pipe`. **Its own slice, for a measured reason -- see S9.2.** | |
 | **4** | Retire the `body_contains_return` / `is_stub_routine_body` deferral predicate and `create_lazy_map_list` — both become dead once every map defers. | The maintainability payout. |
 
 ### Verification
@@ -474,3 +475,85 @@ they still read an unpulled `MapGrep` body's empty seed. `set_contains`
 (`(elem)`/`(cont)`) is fixed but has to swallow a throwing callback for the same
 reason. No test in `t/` or the roast whitelist exercises the remaining ones;
 step 3 (which makes `grep` deferred too) should revisit them.
+
+## 9. Step 3 attempt (2026-09-07): what it found, and why it is parked
+
+### 9.1 The listop diff is trivial; the blocker is a step-2 hole
+
+`builtin_map`'s non-rw tail called `eval_map_over_items` directly, so the
+`map &f, @xs` form ran its callback at the call and answered a **`List`**:
+
+```raku
+my $s = map { $_ * 2 }, 1..3;
+say $s.^name;        # rakudo: Seq       mutsu: List
+```
+
+Returning the deferred Seq there instead fixed the type, the side-effect timing
+(`sub ee { my $s = map -> $x { say "RAN"; $x }, 1..3; say "T"; $s }` printed
+`RAN RAN RAN T` and now printed rakudo's `T RAN RAN RAN`), `for map { ... }, 1..3`,
+assignment to an `@` variable, `.elems` and the empty-source case, with the
+`source_var` rw-writeback branch left eager. `make test` was green (3757 files /
+39156 tests).
+
+The **full `make roast`** this ADR's §5 makes mandatory then aborted
+`roast/integration/99problems-21-to-30.t` with a stack overflow. Reduced:
+
+```raku
+sub g(@sizes) {
+    return "STOP" if @sizes == 0;
+    [1].map(-> $e { g(@sizes[1..*]).map(-> $x { $x }) })
+}
+say g((2,1)).raku;
+```
+
+rakudo terminates at depth 3 with `@sizes` empty; mutsu recurses forever
+reading `@sizes` as depth 1's `(2, 1)`. **This reproduces on `main` with the
+METHOD form**, so it is not step 3's bug -- step 3 only routes more programs
+onto it. A deferred `MapGrep` carries `items`, `func` and `fatal` but **no
+frame**, so `eval_map_over_items` runs the callback under whatever env is
+active at the pull; the pre-ADR-0058 `create_lazy_map_list` snapshots
+`self.env` at the `.map` call and gets the same program right.
+
+Step 3 is therefore parked behind that hole, which is recorded with its options
+(whole-env snapshot vs. capturing only `free_var_syms` vs. making the closure
+capture of a routine parameter work at deferral time) in
+`todo/deep/deferred-map-callback-runs-in-the-consuming-frames-env.md`. It also
+blocks step 4, which retires `create_lazy_map_list` -- the only deferral that
+currently gets the frame right.
+
+### 9.2 grep is eager too, and is its own slice regardless
+
+Measured on the same build:
+
+| probe | rakudo | mutsu |
+|---|---|---|
+| `my $s = (1..3).grep({ say "RAN"; $_ > 1 }); say "T"` | `T RAN RAN RAN` | `RAN RAN RAN T` |
+| the listop spelling of the same | `T RAN RAN RAN` | `RAN RAN RAN T` |
+| `sub ee { try { (1..3).grep({ die "boom" }) }; say "reached-tail"; 42 }` | throws, tail unreached | `reached-tail`, `42`, alive |
+| `my @a=1,2,3; grep({$_=5}, @a).eager; say @a` | `[5 5 5]` | `[1 2 3]` |
+
+Beyond the shared blocker, grep needs something `map` has no equivalent of:
+`dispatch_grep`'s `ValueView::Array` arm **promotes each matched source slot to
+a shared `ContainerRef` cell**, writes the promoted array back with
+`overwrite_array_bindings_by_identity`, and builds the result out of the same
+cells, so `for @a.grep(...) { $_++ }` mutates through into `@a`. Deferring grep
+moves that promotion and its identity-keyed writeback to pull time, in a
+different frame. That is also why
+`todo/deep/immutable-lvalues-that-mutsu-still-lets-you-assign-to.md` §B finds
+`@a.list.grep({$_=5})` writing through while `@a.list.map({$_=5})` does not --
+3b and that ticket's producer 1 are one decision.
+
+`SeqSource::MapGrep`'s pull arm also runs `eval_map_over_items` unconditionally,
+so 3b needs a grep mode on the variant (or a sibling variant) before any of the
+above.
+
+### 9.3 What DID land from the attempt
+
+Pulling a deferred `MapGrep` left the deferred `MapGrep`s it *produced*
+unpulled, so the pure readers §8 exists for saw ADR-0034's empty seed one level
+down: `[1].map({ [2].map({ "STOP" }) })` rendered `(().Seq,).Seq` for `.raku`,
+`(())` for `.gist`, nothing for `.Str`, and nothing for `.flat.join`, where
+rakudo gives the nested values. The pull arm now pulls the `MapGrep`s its own
+pull produced, recursively. Pinned by `t/nested-deferred-map-seq-is-pulled.t`
+(8 rows, raku-verified);
+`news/2026-09/nested-deferred-map-seq-is-pulled.md`.

--- a/news/2026-09/nested-deferred-map-seq-is-pulled.md
+++ b/news/2026-09/nested-deferred-map-seq-is-pulled.md
@@ -1,0 +1,70 @@
+# Pulling a deferred map now pulls the deferred maps it produced
+
+[ADR-0058](../../docs/adr/0058-map-grep-produce-a-deferred-seq.md) made `.map`
+return a `Seq` whose `SeqSource::MapGrep` body runs the callback at first
+consumption, and §8.2 lists the pure-value readers that had to learn to force
+one first (`reify_map_grep_seq`). One case was missed: a callback that itself
+returns a deferred Seq.
+
+```raku
+say [1].map(-> $e { [2].map(-> $x { "STOP" }) }).raku;
+```
+
+Pulling the outer body ran the outer callback, which produced an **unpulled**
+inner `MapGrep` body — and the same pure readers then saw ADR-0034's empty seed
+one level down:
+
+| read | rakudo | mutsu (before) |
+|---|---|---|
+| `.raku` | `(("STOP",).Seq,).Seq` | `(().Seq,).Seq` |
+| `.gist` / `say` | `((STOP))` | `(())` |
+| `.Str` | `STOP` | (empty) |
+| `.flat.join` | `STOP` | (empty) |
+
+The fix is at the single chokepoint rather than at each reader: the `MapGrep`
+arm of `pull_seq_source` (`src/vm/vm_helpers_lazy.rs`) now reifies any deferred
+Seq among the elements its own pull just produced, recursively. Depth is bounded
+by how deeply the callbacks nest, and every level is finite for the same reason
+the top level is — a `MapGrep`'s `items` were materialized at the `.map` call.
+
+Laziness is unchanged: the outer callback still runs at first consumption
+(`t/map-callback-runs-at-consumption.t` and `t/try-sink-semantics.t` are
+untouched and green). Only the elements a pull has *already* produced are
+descended into.
+
+## Found while attempting ADR-0058 step 3, which is now parked
+
+Step 3 (make the listop `map &f, @xs` form defer like the method form) is a
+five-line diff and was green on `make test`, but the mandatory full `make roast`
+aborted `roast/integration/99problems-21-to-30.t` with a stack overflow. That
+turned out to be a **step 2 hole that step 3 only routes more programs onto**,
+and it reproduces on `main` today with the method form:
+
+```raku
+sub g(@sizes) {
+    return "STOP" if @sizes == 0;
+    [1].map(-> $e { g(@sizes[1..*]).map(-> $x { $x }) })
+}
+say g((2,1)).raku;
+```
+
+rakudo terminates at depth 3 with `@sizes` empty; mutsu recurses forever,
+reading `@sizes` as depth 1's `(2, 1)`. A deferred `MapGrep` carries `items`,
+`func` and `fatal` but **no frame**, so the callback runs under whatever env is
+active at the pull — while the pre-ADR-0058 `create_lazy_map_list`, which
+snapshots `self.env` at the `.map` call, gets the same program right. The two
+deferral mechanisms step 4 wants to collapse therefore disagree about which
+lexical frame a deferred callback belongs to.
+
+Recorded with its options and its measurements in
+`todo/deep/deferred-map-callback-runs-in-the-consuming-frames-env.md` and
+ADR-0058 §9.1; grep's separate blocker (its matched-slot `ContainerRef`
+promotion and identity-keyed writeback) is measured in §9.2.
+
+## Gates
+
+`t/nested-deferred-map-seq-is-pulled.t` (8 rows, verified green under `raku`
+too; the listop row is `todo`-marked until step 3 lands).
+`t/map-callback-runs-at-consumption.t` and `t/try-sink-semantics.t` unchanged
+and green. `make test` PASS. Full local `make roast` PASS, as ADR-0058 §5
+requires for any change in this family.

--- a/src/vm/vm_helpers_lazy.rs
+++ b/src/vm/vm_helpers_lazy.rs
@@ -43,10 +43,29 @@ impl Interpreter {
                 self.fatal_mode = saved_fatal;
                 self.reconcile_caller_after_lazy_force(caller_code);
                 let result = result?;
-                Ok(match result.view() {
+                let items = match result.view() {
                     ValueView::Array(items, _) => items.to_vec(),
                     _ => crate::runtime::utils::value_to_list(&result),
-                })
+                };
+                // A callback that itself returns a deferred Seq
+                // (`[1].map({ [2].map({ ... }) })`, and the recursive
+                // `map`-over-`map` shape `roast/integration/99problems-21-to-30.t`
+                // builds) leaves nested unpulled `MapGrep` bodies sitting in
+                // the elements this pull just produced -- and the same pure
+                // readers `reify_map_grep_seq` exists for then see the empty
+                // seed one level down: `.raku` rendered `(().Seq,).Seq` where
+                // rakudo says `(("STOP",).Seq,).Seq`, and `say`/`.Str`/`.gist`/
+                // `.flat` came out empty. Pulling a `MapGrep` therefore pulls
+                // the `MapGrep`s it produced. Depth is bounded by how deeply
+                // the callbacks nest, and every level is finite for the same
+                // reason the top level is (its `items` were materialized at
+                // the `.map` call).
+                for item in &items {
+                    if item.is_seq_value() {
+                        self.reify_map_grep_seq(item)?;
+                    }
+                }
+                Ok(items)
             }
         }
     }

--- a/t/nested-deferred-map-seq-is-pulled.t
+++ b/t/nested-deferred-map-seq-is-pulled.t
@@ -1,0 +1,33 @@
+use Test;
+
+# ADR-0058 made `.map` return a `Seq` whose callback runs at first consumption.
+# When that callback itself returns a `.map` Seq, pulling the outer one left
+# the INNER bodies unpulled, sitting in the elements the pull had just
+# produced -- and the pure-value readers `reify_map_grep_seq` exists for then
+# saw ADR-0034's empty seed one level down. Pulling a deferred map now pulls
+# the deferred maps it produced.
+#
+# Every expectation was verified by running this file under real `raku`.
+
+plan 8;
+
+sub nested { [1].map(-> $e { [2].map(-> $x { "STOP" }) }) }
+
+is nested().raku, '(("STOP",).Seq,).Seq', '.raku renders the inner Seq';
+is nested().gist, '((STOP))', '.gist renders it';
+is nested().Str, 'STOP', '.Str renders it';
+is nested().flat.join('|'), 'STOP', '.flat reaches the inner elements';
+is nested().elems, 1, 'the outer Seq still has one element';
+is nested()[0].elems, 1, '... whose own Seq has one element';
+
+# The listop spelling of the same nesting. It does not reach this path at all
+# yet: `builtin_map` is still eager (ADR-0058 step 3 is blocked -- see
+# `todo/deep/deferred-map-callback-runs-in-the-consuming-frames-env.md`), so it
+# answers a plain nested List instead of a Seq of Seqs.
+todo 'the listop `map` is still eager (ADR-0058 step 3)';
+is (map { map { "STOP" }, [2] }, [1]).raku, '(("STOP",).Seq,).Seq',
+    'the listop spelling agrees';
+
+# Three levels deep.
+is [1].map(-> $a { [2].map(-> $b { [3].map(-> $c { "END" }) }) }).gist,
+    '(((END)))', 'the descent is recursive, not one level';

--- a/todo/deep/deferred-map-callback-runs-in-the-consuming-frames-env.md
+++ b/todo/deep/deferred-map-callback-runs-in-the-consuming-frames-env.md
@@ -1,0 +1,106 @@
+# A deferred `.map` callback reads its routine's parameters from the CONSUMING frame
+
+Found 2026-09-07 while implementing [ADR-0058](../../docs/adr/0058-map-grep-produce-a-deferred-seq.md)
+step 3 (extend the deferral to the listop `map` form). Step 3 was implemented,
+measured green on `make test`, and then **reverted**, because it made
+`roast/integration/99problems-21-to-30.t` — a whitelisted file — abort with a
+stack overflow. The abort is not caused by step 3: it is a **step 2 hole that
+step 3 merely routes more code onto**, and it reproduces on `main` today with
+the *method* form.
+
+## The bug
+
+```raku
+my $d = 0;
+sub g(@sizes) {
+    $d++; die "DEEP" if $d > 8;
+    note "d=$d sizes=" ~ @sizes.raku;
+    return "STOP" if @sizes == 0;
+    [1].map(-> $e {
+        g(@sizes[1..*]).map(-> $x { $x })
+    })
+}
+say g((2,1)).raku;
+```
+
+```
+raku:   d=1 sizes=(2, 1)   d=2 sizes=(1,)   d=3 sizes=()     then (($(("STOP",).Seq),).Seq,).Seq
+mutsu:  d=1 sizes=(2, 1)   d=2 sizes=(1,)   d=3 sizes=(1,)   d=4 (1,) ... runaway
+```
+
+`g`'s recursion terminates on `@sizes == 0`. In mutsu the recursion never gets
+there: at depth 3 the callback reads `@sizes` as `(2, 1)` — **depth 1's**
+binding — so `@sizes[1..*]` is perpetually `(1,)`.
+
+The parameter is bound correctly at each call (the `note` at `g`'s entry prints
+the right value every time). What is wrong is the frame the *callback* reads it
+from when the Seq is finally pulled: by then `g` has returned, and
+`eval_map_over_items` runs the callback under whatever env is active at the
+pull — which, in a recursive nest, is an OUTER invocation of the same routine.
+
+## Why the older deferral does not have it
+
+Replacing the callback with one that contains a `return` routes the same
+program through the pre-ADR-0058 deferral (`create_lazy_map_list`, gated on
+`body_contains_return` / `is_stub_routine_body`) instead, and the recursion
+**terminates correctly at depth 2**. The difference is one line:
+
+```rust
+// runtime/methods_dispatch_match2.rs, create_lazy_map_list
+let mut env = self.env.clone();          // <- the env at the `.map` CALL
+...
+let list = crate::value::LazyList { body: Vec::new(), env, .. };
+```
+
+`SeqSource::MapGrep { items, func, fatal }` carries no equivalent. So the two
+deferral mechanisms that ADR-0058 step 4 wants to collapse into one disagree
+about the most basic property of a deferred callback: which lexical frame it
+belongs to.
+
+## Why it is deep, and what a fix has to weigh
+
+The obvious fix — give `SeqSource::MapGrep` an env snapshot and restore it
+around `eval_map_over_items` in the pull arm (`vm/vm_helpers_lazy.rs`) — is
+exactly what `create_lazy_map_list` does, and it is *already* paid for on the
+`return`/stub path. But that path is rare; ADR-0058 made **every** `.map`
+deferred, so an `Env` clone would move onto the hot path, and `env_deep_copies`
+is a tracked `MUTSU_VM_STATS` counter for a reason. Measure it before adopting
+it (the counter is optimization-independent, so iterate on the debug build —
+see CLAUDE.md's build-profiles section).
+
+Cheaper shapes worth measuring first:
+
+- capture only the callback's own free variables rather than the whole env —
+  `CompiledCode::free_var_syms` already names them, and `SubData` already
+  carries a closure env that is evidently *not* getting `@sizes` (a parameter
+  living in a local slot, resolved through the frame at call time);
+- or make the closure capture of a routine PARAMETER work at deferral time, so
+  no env snapshot is needed at all. That is the same family as ADR-0055's
+  unvouched-capture cell and #7432's `unit_scope_lexical_bind`, and it is the
+  architecturally cleaner answer if it is affordable.
+
+## What this blocks
+
+- **ADR-0058 step 3** (the listop `map` form, and then grep). The step-3a diff
+  is small and was measured green on `make test` (3757 files / 39156 tests)
+  before the roast run found this; see ADR-0058 §9.
+- **ADR-0058 step 4**, which retires `create_lazy_map_list` — impossible while
+  it is the only deferral that gets the frame right.
+
+## Not the same thing as the nested-render hole
+
+A second, unrelated bug found in the same session — pulling a deferred `MapGrep`
+left the deferred `MapGrep`s it *produced* unpulled, so `.raku` / `.gist` /
+`.Str` / `.flat` read the empty seed one level down — is fixed and pinned by
+`t/nested-deferred-map-seq-is-pulled.t`
+(`news/2026-09/nested-deferred-map-seq-is-pulled.md`). That fix is in this
+file's way only in that its listop row is `todo`-marked until step 3 lands.
+
+## Affected files
+
+- `src/value/seq_body.rs` — `SeqSource::MapGrep`, which would gain the frame
+- `src/vm/vm_helpers_lazy.rs` — the `MapGrep` pull arm, which would restore it
+- `src/runtime/methods_dispatch_match2.rs` — `create_lazy_map_list`, the
+  mechanism that already does it, and `dispatch_map_method`, which does not
+- `src/runtime/builtins_collection_mapgrep.rs` — `builtin_map`, the step-3a site
+- `roast/integration/99problems-21-to-30.t` — the whitelisted witness

--- a/todo/deep/residual-try-cell-eager-seq-reification-divergences.md
+++ b/todo/deep/residual-try-cell-eager-seq-reification-divergences.md
@@ -42,8 +42,42 @@ The two rows are pinned as the only remaining `todo`s in
 an enclosing `try` returns a Failure instead of throwing"). Un-`todo`ing them is
 this ticket's completion signal.
 
+## Measured 2026-09-07: the discriminator is `try` specifically, and only the exit status differs
+
+Re-run on a fresh build. **Only ONE assertion of the two `todo` rows actually
+fails**: the exit status. `unlike $out, /'reached-tail'/` already passes in
+mutsu -- the statement after the `try` does not run there either. So the
+divergence is narrower than "returns a Failure instead of throwing": both
+implementations abandon the rest of `ee`; rakudo lets the exception reach the
+top and exits 1, mutsu returns a `Failure` from `ee` and the caller's
+`.^name` (which does not force it) leaves the program alive at exit 0.
+
+The discriminator is `try` **specifically**, not "a block between the `fail` and
+the routine". Measured, with `sub ee { BLOCK; say "T"; 99 }` and a stub-map
+inside:
+
+| the block between | rakudo |
+|---|---|
+| `try { ... }` | **throws**, `T` unreached |
+| `{ ... }` (bare block) | `fail` returns a Failure from `ee`, alive |
+| `do { ... }` | same as the bare block |
+| no block at all | same as the bare block |
+
+and when the Seq is forced INSIDE the `try` (`try { my @z = map ... }`, or
+`try { eager map ... }`) rakudo and mutsu already agree: the `try` catches it,
+`$!` is `X::StubCode`, execution continues. So this is not about where the force
+lands -- `t/try-sink-semantics.t` pins that correctly -- it is about what a
+`fail` raised at a statement sink does when a `try` sits lexically between it
+and the routine. Nobody has explained rakudo's rule here yet, and a fix keyed on
+"the sink of a `try` statement's value" would be an ad-hoc special case; the
+rule has to be understood first.
+
 ## Not part of this ticket
 
-ADR-0058 steps 3 (extend the deferral to `builtin_map` and both `grep` entry
-points) and 4 (retire the `body_contains_return`/`is_stub_routine_body`
-deferral predicate and `create_lazy_map_list`) are tracked in the ADR, not here.
+ADR-0058 step 3 (the listop `map` form, then grep) was attempted on 2026-09-07
+and parked behind a step-2 hole -- see ADR-0058 §9 and
+`todo/deep/deferred-map-callback-runs-in-the-consuming-frames-env.md`. It would
+not move these two rows either way: they use a pure `...` stub body, which the
+older `create_lazy_map_list` deferral already handles. Step 4 (retire the
+`body_contains_return`/`is_stub_routine_body` predicate and
+`create_lazy_map_list`) is tracked in the ADR, not here.


### PR DESCRIPTION
## Root cause

[ADR-0058](docs/adr/0058-map-grep-produce-a-deferred-seq.md) made `.map` return a `Seq` whose `SeqSource::MapGrep` body runs the callback at first consumption, and §8.2 lists the pure-value readers that had to learn to force one first (`reify_map_grep_seq`). One case was missed: **a callback that itself returns a deferred Seq**.

```raku
say [1].map(-> $e { [2].map(-> $x { "STOP" }) }).raku;
```

Pulling the outer body ran the outer callback, which produced an *unpulled* inner `MapGrep` body — and the same pure readers then saw ADR-0034's empty seed one level down:

| read | rakudo | mutsu (before) |
|---|---|---|
| `.raku` | `(("STOP",).Seq,).Seq` | `(().Seq,).Seq` |
| `.gist` / `say` | `((STOP))` | `(())` |
| `.Str` | `STOP` | (empty) |
| `.flat.join` | `STOP` | (empty) |

The fix is at the single chokepoint rather than at each reader: the `MapGrep` arm of `pull_seq_source` now reifies any deferred Seq among the elements its own pull just produced, recursively. Depth is bounded by how deeply the callbacks nest, and every level is finite for the same reason the top level is — a `MapGrep`'s `items` were materialized at the `.map` call. **Laziness is unchanged**: only elements a pull has *already* produced are descended into.

## Found while attempting ADR-0058 step 3, which is now parked

Step 3 (make the listop `map &f, @xs` form defer like the method form) is a five-line diff and was green on `make test`, but the mandatory full `make roast` aborted the whitelisted `roast/integration/99problems-21-to-30.t` with a stack overflow. That turned out to be **a step 2 hole that step 3 only routes more programs onto**, and it reproduces on `main` today with the *method* form:

```raku
sub g(@sizes) {
    return "STOP" if @sizes == 0;
    [1].map(-> $e { g(@sizes[1..*]).map(-> $x { $x }) })
}
say g((2,1)).raku;
```

rakudo terminates at depth 3 with `@sizes` empty; mutsu recurses forever, reading `@sizes` as depth 1's `(2, 1)`. A deferred `MapGrep` carries `items`, `func` and `fatal` but **no frame**, so the callback runs under whatever env is active at the pull — while the pre-ADR-0058 `create_lazy_map_list`, which snapshots `self.env` at the `.map` call, gets the same program right. The two deferral mechanisms step 4 wants to collapse therefore disagree about which lexical frame a deferred callback belongs to.

Step 3 is reverted here and recorded with its options (whole-env snapshot vs. capturing only `free_var_syms` vs. making the closure capture of a routine parameter work at deferral time) in `todo/deep/deferred-map-callback-runs-in-the-consuming-frames-env.md` and ADR-0058 §9.1. grep's *separate* blocker — `dispatch_grep`'s matched-slot `ContainerRef` promotion and `overwrite_array_bindings_by_identity` writeback, which deferral would move to pull time in a different frame — is measured in §9.2, along with the four grep rows that still diverge from rakudo.

## Gates

- new pin `t/nested-deferred-map-seq-is-pulled.t` — 8 rows, verified green under `raku` too; its listop row is `todo`-marked until step 3 lands
- `t/map-callback-runs-at-consumption.t` and `t/try-sink-semantics.t` unchanged and green
- `make test` PASS (3759 files, 39217 tests)
- **full local `make roast` PASS** (1436 files, 218962 tests), as ADR-0058 §5 requires for any change in this family