### PR TITLE
perf(vm): stop the scoped-overlay return merge paying for a flattened env

### DIFF
--- a/news/2026-09/scoped-overlay-return-merge-stops-paying-for-a-flattened-env.md
+++ b/news/2026-09/scoped-overlay-return-merge-stops-paying-for-a-flattened-env.md
@@ -1,0 +1,68 @@
+# The scoped-overlay return merge stops paying for a flattened env
+
+`call_compiled_function_named_inner` ends every named call with the
+scoped-overlay return merge: walk the callee env and copy back the names the
+caller also has. On a *scoped* env that walk is O(callee writes), which is the
+whole point of `docs/vm-dual-store.md` Slice 6. But any full method dispatch
+inside the callee body collapses the overlay
+(`todo/perf/method-dispatch-flattens-the-env-on-every-call.md`), and a
+flattened env holds the caller's entire lexical scope — so the merge silently
+becomes O(whole program scope), on every call whose body touches a method.
+
+The vendored upstream `Test` makes two method calls per assertion
+(`$output.say: $tap`, `$desc.Str`), so every assertion paid it twice. Callgrind
+put `std::thread::local::LocalKey<T>::with` at **11.8%** of the assertion loop,
+with this merge as its dominant caller: **~556 thread-local round trips per
+named call**, from resolving each key's symbol to a `&str` two or three times
+and re-scanning the bytes.
+
+Three fixes, none of which changes when the flatten happens:
+
+**A memoized flag byte per symbol.** The merge asks three pure, string-derived
+questions about every key — is it a routine-scoped implicit (`$!`, `$/`, `$0`,
+`$<name>`), is it a per-call-site index-rw temp, is it a `__mutsu_type::`
+metadata key. Symbol ids are append-only and a symbol's string never changes,
+so the answers are computable once and cached forever. `Symbol::flags()` now
+serves all three from a single lookup (`symbol::flags`), replacing three
+`as_str()` round trips plus several `memcmp`s per key. `is_callee_local_sym`
+takes the same gate before its `strip_prefix`.
+
+**Skip the merge of a key the callee never rebound.** The merge re-inserted
+every caller-visible key it walked — a hash write, a refcount bump and a drop
+each — even though on a flattened env the overwhelming majority are the
+caller's own untouched bindings that the flatten copied in. `Value::same_binding`
+(O(1): the same immediate, or the same heap allocation) now short-circuits
+those. An in-place container mutation leaves those bits unchanged too, and
+correctly so: the caller shares the allocation and already sees it.
+
+**`Env::flattened()` short-circuits an empty overlay.** A scoped tier that never
+received a write and holds no tombstone is invisible to lookups, so the
+parent's flattening *is* this env's — including `file_sym`, which
+`scoped_child` copies from the parent for exactly that reason. Returning
+`parent.flattened()` is an `Arc` bump instead of a whole-map clone when the
+parent is already flat, with the copy deferred to the first write via
+`cow_mut`. Same "an empty tier is not a tier" rule `scoped_child` already
+applies when it chains over an empty parent instead of stacking on it.
+
+## Measured
+
+Instructions per assertion, callgrind, 300 `ok 1, "x"` under
+`MUTSU_REAL_TEST=1` minus a one-assertion baseline (deterministic, so the
+noisy wall clock of this box does not enter):
+
+| | Ir / assertion |
+| --- | --- |
+| before today | 1.06 M |
+| after the multi-resolution cache keys | 658 k |
+| after this change | **535 k** |
+
+Wall clock: the 20 000-assertion `ok` loop 3.36 s -> 3.03 s;
+`roast/S03-buf/write-int.t` under the real module 29.5 s -> **27.4 s** (median
+of eight; 26.5-28.1 s with one 30.4 s outlier). Against a 30 s per-file budget
+that is still not a comfortable margin — see
+`todo/deep/vendor-real-test-module.md`.
+
+The flatten itself is untouched and still costs: an unsound experiment that
+removes it entirely was worth a further ~17% before this change. What is gone
+is the *compounding* — the flatten no longer also turns an O(callee writes)
+merge into an O(whole scope) one at three string scans per key.

--- a/src/env.rs
+++ b/src/env.rs
@@ -620,6 +620,18 @@ impl Env {
     pub(crate) fn flattened(&self) -> Self {
         match &self.parent {
             None => self.clone(),
+            // An overlay that never received a write (and holds no tombstone)
+            // is invisible to lookups, so the parent's own flattening IS this
+            // env's -- including `file_sym`, which `scoped_child` copies from
+            // the parent for exactly this reason. Short-circuiting is not just
+            // cheaper than the merge below, it is *free* when the parent is
+            // already flat: an `Arc` bump instead of a whole-map clone, with
+            // the copy deferred to the first write via `cow_mut`. This is the
+            // same "empty tier is not a tier" rule `scoped_child` applies when
+            // it chains over an empty parent instead of stacking on it.
+            Some(parent) if self.inner.is_empty() && self.tombstones.is_none() => {
+                parent.flattened()
+            }
             Some(parent) => {
                 // Recursively collapse the parent chain to a flat overlay first
                 // (the base tier stays shared, never materialized), then layer

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -8900,8 +8900,15 @@ impl CompiledFunction {
         // is frame state: merging it back into the caller env would re-create
         // the cross-frame constraint leak through the env store (see
         // `news/2026-09/type-constraint-global-side-table-retired.md`).
+        //
+        // Gated on the memoized flag rather than resolving the symbol to a
+        // `&str` and `strip_prefix`-ing it: this runs for every key of the
+        // return merge, and almost none of them are metadata keys.
+        if sym.flags() & crate::symbol::flags::TYPE_META == 0 {
+            return false;
+        }
         sym.with_str(|s| {
-            s.strip_prefix("__mutsu_type::")
+            s.strip_prefix(crate::symbol::TYPE_META_PREFIX)
                 .is_some_and(|base| self.is_callee_local_sym_direct(Symbol::intern(base)))
         })
     }

--- a/src/symbol.rs
+++ b/src/symbol.rs
@@ -131,6 +131,56 @@ thread_local! {
     /// class-name borrow, `==` compare, `starts_with`, `Display`) off the
     /// globally-shared `RwLock`.
     static RESOLVE_CACHE: RefCell<Vec<Option<&'static str>>> = const { RefCell::new(Vec::new()) };
+
+    /// Per-thread memo of [`SymFlags`], the pure string predicates the hot
+    /// merge/dispatch paths ask about a name. Same validity argument as
+    /// `RESOLVE_CACHE`: ids are append-only and a symbol's string never
+    /// changes, so a computed answer is good for the life of the process.
+    static FLAG_CACHE: RefCell<Vec<u8>> = const { RefCell::new(Vec::new()) };
+}
+
+/// Pure, string-derived properties of a symbol, computed once per symbol.
+///
+/// The scoped-overlay return merge (`call_compiled_function_named_inner`) asks
+/// three of these about *every* env key it walks, and did so by resolving the
+/// symbol to a `&str` and re-scanning the bytes each time — three
+/// thread-local + `RefCell` round trips plus several `memcmp`s per key, per
+/// call. A callgrind run of the vendored `Test`'s assertion loop put
+/// `LocalKey::with` at 11.8% of the whole program with that merge as its
+/// dominant caller (~556 accesses per named call). One memoized byte answers
+/// all of them with a single lookup.
+pub(crate) mod flags {
+    /// `$!` / `$/` and the capture views that belong to `$/` (`0`, `1`, ...,
+    /// `<name>`) — the names scoped per *routine*, which a return merge must
+    /// never copy back into the caller. Mirrors
+    /// `crate::runtime::utils::is_routine_scoped_implicit_var`.
+    pub(crate) const ROUTINE_SCOPED_IMPLICIT: u8 = 1 << 0;
+    /// A per-call-site index-rw / call-result temporary. Mirrors
+    /// `crate::runtime::utils::is_index_rw_call_temp`.
+    pub(crate) const INDEX_RW_CALL_TEMP: u8 = 1 << 1;
+    /// A `__mutsu_type::<name>` typed-lexical metadata key.
+    pub(crate) const TYPE_META: u8 = 1 << 2;
+    /// Set once the byte has been computed (so a symbol with no flags is not
+    /// recomputed on every lookup).
+    pub(crate) const COMPUTED: u8 = 1 << 7;
+}
+
+/// The `__mutsu_type::` prefix `flags::TYPE_META` marks. Kept next to the flag
+/// so the two cannot drift.
+pub(crate) const TYPE_META_PREFIX: &str = "__mutsu_type::";
+
+fn compute_flags(s: &str) -> u8 {
+    let mut f = flags::COMPUTED;
+    if crate::runtime::utils::is_routine_scoped_implicit_var(s) {
+        f |= flags::ROUTINE_SCOPED_IMPLICIT;
+    }
+    if crate::runtime::utils::is_index_rw_call_temp(s) {
+        f |= flags::INDEX_RW_CALL_TEMP;
+    }
+    if s.starts_with(TYPE_META_PREFIX) {
+        f |= flags::TYPE_META;
+    }
+    f
 }
 
 /// Pre-interned symbols for names the VM resolves on hot paths.
@@ -318,6 +368,32 @@ impl Symbol {
             cache[idx] = Some(s);
             s
         })
+    }
+
+    /// This symbol's memoized [`flags`] byte — see that module for what the
+    /// bits mean and why the merge path needs them fused into one lookup.
+    ///
+    /// Computed on first ask and cached per thread. Test the result with the
+    /// `flags::*` constants, e.g.
+    /// `sym.flags() & flags::ROUTINE_SCOPED_IMPLICIT != 0`.
+    pub(crate) fn flags(self) -> u8 {
+        let idx = self.0 as usize;
+        if let Some(f) = FLAG_CACHE.with(|c| c.borrow().get(idx).copied())
+            && f & flags::COMPUTED != 0
+        {
+            return f;
+        }
+        // `as_str` takes the resolve cache's borrow, so compute the value
+        // before taking the flag cache's — never hold both.
+        let f = compute_flags(self.as_str());
+        FLAG_CACHE.with(|c| {
+            let mut cache = c.borrow_mut();
+            if cache.len() <= idx {
+                cache.resize(idx + 1, 0);
+            }
+            cache[idx] = f;
+        });
+        f
     }
 
     /// Resolve the symbol back to its string representation.

--- a/src/vm/vm_call_named_inner.rs
+++ b/src/vm/vm_call_named_inner.rs
@@ -682,9 +682,40 @@ impl Interpreter {
                 if *k == "__mutsu_callable_id" {
                     continue;
                 }
+                // One memoized byte answers both string predicates this loop
+                // asks of every key. It used to resolve the symbol to a `&str`
+                // and re-scan it two or three times per key -- and a *flattened*
+                // callee env (any full method dispatch in the body collapses
+                // the overlay) makes "every key" the whole lexical scope, which
+                // is why this showed up as the single hottest thing in the
+                // vendored `Test`'s assertion loop. See `symbol::flags`.
+                let kflags = k.flags();
                 if bang_is_callee_private
-                    && k.with_str(crate::runtime::utils::is_routine_scoped_implicit_var)
+                    && kflags & crate::symbol::flags::ROUTINE_SCOPED_IMPLICIT != 0
                 {
+                    continue;
+                }
+                // Per-call-site index-rw temps are frame-internal; merging a
+                // callee's same-named entries corrupts the caller's pending
+                // post-call writeback compare.
+                if kflags & crate::symbol::flags::INDEX_RW_CALL_TEMP != 0 {
+                    continue;
+                }
+                // Only a key the caller already has can be merged back, and
+                // only if the callee actually REBOUND it: a key whose value is
+                // the same binding (same immediate, or the same heap
+                // allocation) is what the caller already holds, so re-inserting
+                // it is a hash write, a refcount bump and a drop for nothing.
+                // On a flattened callee env — which any full method dispatch in
+                // the body produces — that is the overwhelming majority of the
+                // keys walked here, because the flatten copied the caller's
+                // whole lexical scope in. An in-place container mutation leaves
+                // these bits unchanged too, and correctly so: the caller shares
+                // the allocation and already sees it.
+                let unchanged = restored_env
+                    .get_sym(*k)
+                    .is_some_and(|old| old.same_binding(v));
+                if unchanged {
                     continue;
                 }
                 if restored_env.contains_key_sym(*k)
@@ -694,13 +725,11 @@ impl Interpreter {
                     // the binding overwrote a same-named caller symbol for the
                     // rest of the program.
                     && !cf.code.my_declared_enum_sym.contains(k)
-                    && !k.with_str(|s| {
-                        rw_sources.contains(s)
-                            // Per-call-site index-rw temps are frame-internal;
-                            // merging a callee's same-named entries corrupts the
-                            // caller's pending post-call writeback compare.
-                            || crate::runtime::utils::is_index_rw_call_temp(s)
-                    })
+                    // The rw-source names are a per-call `HashSet<String>`, so
+                    // only resolve the key to a `&str` when there is one to
+                    // compare against -- the overwhelmingly common case is a
+                    // call with no `is rw` parameter at all.
+                    && (rw_sources.is_empty() || !k.with_str(|s| rw_sources.contains(s)))
                 {
                     restored_env.insert_sym(*k, v.clone());
                 }

--- a/todo/deep/vendor-real-test-module.md
+++ b/todo/deep/vendor-real-test-module.md
@@ -74,8 +74,13 @@ multi-resolution cache (the parser's callsite-line marker, the `:D`/`:U`
 smileys, and `VarRef` arguments). Fixing all three —
 `news/2026-09/multi-resolve-cache-keys-carry-definedness-and-declared-type.md` —
 took `roast/S03-buf/write-int.t` under the real module from **48.0 s to
-29.5 s** (median of three; 28.8-29.5 s), with 184 079 full resolves down to
-22 805 (all of them now per-*subtest*, not per-assertion).
+29.5 s**, with 184 079 full resolves down to 22 805 (all of them now
+per-*subtest*, not per-assertion). A second pass on the scoped-overlay return
+merge
+(`news/2026-09/scoped-overlay-return-merge-stops-paying-for-a-flattened-env.md`)
+took it further, to **27.4 s** (median of eight; 26.5-28.1 s with one 30.4 s
+outlier). In deterministic terms — callgrind, per assertion, baseline
+subtracted — the two together are **1.06 M -> 535 k instructions**.
 
 Calibration measured at the same time, same idle box, same output sink, all
 three running the file's identical 93 370 assertions / 2 530 subtests:
@@ -84,15 +89,16 @@ three running the file's identical 93 370 assertions / 2 530 subtests:
 | --- | --- | --- |
 | rakudo | 3.49 s | 37 us |
 | mutsu, native `Test` | 5.04 s | 54 us |
-| mutsu, vendored `Test` | 29.5 s | 316 us |
+| mutsu, vendored `Test` | 27.4 s | 293 us |
 
-The interpreter is at rakudo's rough parity on this file; the 8.5x is the cost
-of *running `Test.rakumod` as Raku code*.
+The interpreter is at rakudo's rough parity on this file; the remaining ~8x is
+the cost of *running `Test.rakumod` as Raku code*.
 
-**Completion criterion 2 is therefore NOT met.** 29.5 s against a 30 s per-file
-budget is at the budget, not under it: the file will still time out on a slower
-CI runner or under `prove -j4`. Do not read the sweep going green here as the
-class being closed -- re-measure on the reference machine and under contention. The next measured target is filed as
+**Completion criterion 2 is therefore still NOT met.** 27.4 s against a 30 s
+per-file budget is a ~9% margin on an idle box, and single samples reached
+30.4 s: the file can still time out on a slower CI runner or under `prove -j4`.
+Do not read the sweep going green here as the class being closed -- re-measure
+on the reference machine and under contention. The next measured target is filed as
 `todo/perf/listop-call-bypasses-every-compiled-call-cache.md`: a listop call
 (`ok 1, "x"` compiles to `ExecCallPairs`, not `CallFunc`) reaches none of the
 three name-keyed compiled-call caches and takes the carrier path — a whole-frame

--- a/todo/perf/method-dispatch-flattens-the-env-on-every-call.md
+++ b/todo/perf/method-dispatch-flattens-the-env-on-every-call.md
@@ -131,13 +131,35 @@ turning the frame's O(writes) return merge into an O(whole env) scan. Any fix
 should be measured against the merge loop's `with_str` count, not just against
 `env_deep_copies`.
 
-Two cheaper sub-fixes, if the full "move the flatten to the consumers" change
-stays too risky:
+### Both cheap sub-fixes are DONE; the flatten itself is what is left
 
-* `Env::flattened()` can return `parent.flattened()` directly when the overlay
-  is empty and there are no tombstones — provably identical (`scoped_child`
-  already derives an empty child's `file_sym` from the parent), and O(1) when
-  the parent is flat.
-* the merge loop's `k.with_str(is_routine_scoped_implicit_var)` runs for every
-  key; the names it tests are a fixed handful, so interning them once and
-  comparing `Symbol` ids removes a thread-local round trip per key.
+`news/2026-09/scoped-overlay-return-merge-stops-paying-for-a-flattened-env.md`
+landed the two cheaper halves plus one more:
+
+* `Env::flattened()` now short-circuits an empty overlay to
+  `parent.flattened()`;
+* the merge loop's three per-key string predicates are one memoized
+  `Symbol::flags()` byte;
+* a key the callee never rebound (`Value::same_binding`) is no longer
+  re-inserted.
+
+Together: 658 k -> 535 k instructions per assertion. So **the merge is no
+longer the expensive half of the compounding** - what remains is the flatten's
+own whole-map clone and the fact that it happens at all.
+
+Re-measure before resuming: the "17% of the `ok` loop" figure above was taken
+BEFORE these three, so the flatten's remaining share is smaller than that now.
+Redo the `MUTSU_NO_FLATTEN` kill-switch experiment on the current tree first,
+and only then decide whether the "move the flatten to the consumers" refactor
+is worth its blast radius.
+
+The audit that refactor needs is smaller than the doc's "~80 env-iteration
+consumers" suggests: `remove` is already tombstone-aware and `get_mut` already
+COW-promotes a parent key into the overlay, so the genuinely overlay-only
+operations are `iter`/`keys`/`values`/`len`/`values_mut`, and a grep finds
+**13** direct `self.env().iter()/keys()/values()` sites in the VM. The biggest
+of them - the return merge in `vm_call_named_inner.rs` - *wants* overlay-only
+and is correct either way, so it is not a blocker. The hazard is an env cloned
+into a local (`let e = self.env().clone(); e.iter()`), which keeps the parent
+chain and iterates overlay-only; those have to be found by reading, not by
+grepping for `env().iter()`.

--- a/todo/perf/method-dispatch-flattens-the-env-on-every-call.md
+++ b/todo/perf/method-dispatch-flattens-the-env-on-every-call.md
@@ -1,5 +1,11 @@
 # Every full method dispatch rebuilds the whole lexical env
 
+> **Read "Update (2026-09-06b)" at the bottom before starting.** The obvious
+> fix -- removing the guard and moving it to the consumers that actually
+> iterate -- was implemented in full on 2026-09-06, validated clean over both
+> suites, and **measured neutral-to-negative**. Do not redo it without a
+> different plan.
+
 `exec_call_method_mut_op_impl` calls `flatten_scoped_env()` before dispatching
 any method that misses the pure-read accessor fast path. On a scoped env — which
 is what every enclosing call frame installs — `Env::flattened()` walks the parent
@@ -63,7 +69,9 @@ individually:
   with an empty env changed the 2000-assertion time by nothing (1.630 s -> 1.625 s
   for three runs). It IS an `Env::flattened()` per named call, but for a caller
   whose env is flat that is an `Arc` bump, and the workload's named calls are
-  mostly of that shape.
+  mostly of that shape. **(This finding is the key to the failed attempt below:
+  that `clone_env` is only cheap *because* the method-dispatch guard already
+  flattened it. Remove the guard and it becomes a real per-call flatten.)**
 - `push_caller_env()` — this is a plain `Env` clone (`Arc` bumps), not a flatten.
 
 So the fix belongs on the method path, not the sub path.
@@ -100,66 +108,129 @@ deterministic and optimization-independent, so the debug build is enough), then
 confirm on release with the padding table above: the cleanest success signal is
 that the per-assertion cost stops scaling with env size at all.
 
-## Update (2026-09-06): the flatten also destroys the return merge
+## Update (2026-09-06a): the flatten also destroys the return merge
 
-Re-measured after the multi-resolution cache started serving `Test`'s
-assertions
-(`news/2026-09/multi-resolve-cache-keys-carry-definedness-and-declared-type.md`),
-with the same unsound experiment (an env-var kill switch on
-`flatten_scoped_env`): the 20 000-assertion `ok` loop goes **3.58 s -> 2.96 s**,
-i.e. **17%** of what is left.
-
-Callgrind says why it is worth more than its own `HashMap` clone. The single
-largest self-cost item in the loop is `std::thread::local::LocalKey<T>::with`
-(11.8% of the loop), and its dominant caller is
-`call_compiled_function_named_inner` — **333 586 thread-local accesses across
-600 named calls**, ~556 per call. Those come from the scoped-overlay *return
-merge*:
+The scoped-overlay *return merge* in `call_compiled_function_named_inner` is
+O(callee writes) on a scoped env and O(whole scope) on a flat one:
 
 ```rust
 for (k, v) in self.env().iter() { ... k.with_str(...) ... }
 ```
 
-On a scoped env `iter()` is overlay-only, so that loop is O(callee writes) —
-which is the whole point of Slice 6. But the method-dispatch flatten runs
-*first* (`$output.say: $tap` inside `proclaim` is a full method dispatch), so by
-the time the callee returns its env is FLAT and the merge iterates every name in
-scope, calling `Symbol::with_str` two or three times per key.
+A full method dispatch in the callee body flattens the env, so by the time the
+callee returns the merge walks every name in scope. Callgrind put
+`std::thread::local::LocalKey<T>::with` at 11.8% of the assertion loop with this
+merge as its dominant caller (~556 thread-local accesses per named call).
 
-So the flatten costs twice: once to build the merged map, and once more by
-turning the frame's O(writes) return merge into an O(whole env) scan. Any fix
-should be measured against the merge loop's `with_str` count, not just against
-`env_deep_copies`.
-
-### Both cheap sub-fixes are DONE; the flatten itself is what is left
-
+**That half is fixed** --
 `news/2026-09/scoped-overlay-return-merge-stops-paying-for-a-flattened-env.md`
-landed the two cheaper halves plus one more:
+made the merge's per-key work a single memoized `Symbol::flags()` byte, skipped
+keys the callee never rebound (`Value::same_binding`), and short-circuited
+`Env::flattened()` for an empty overlay: 658 k -> 535 k instructions per
+assertion. The compounding is gone; the flatten's own cost is not.
 
-* `Env::flattened()` now short-circuits an empty overlay to
-  `parent.flattened()`;
-* the merge loop's three per-key string predicates are one memoized
-  `Symbol::flags()` byte;
-* a key the callee never rebound (`Value::same_binding`) is no longer
-  re-inserted.
+## Update (2026-09-06b): the relocation fix was implemented, measured, REVERTED
 
-Together: 658 k -> 535 k instructions per assertion. So **the merge is no
-longer the expensive half of the compounding** - what remains is the flatten's
-own whole-map clone and the fact that it happens at all.
+### What was built
 
-Re-measure before resuming: the "17% of the `ok` loop" figure above was taken
-BEFORE these three, so the flatten's remaining share is smaller than that now.
-Redo the `MUTSU_NO_FLATTEN` kill-switch experiment on the current tree first,
-and only then decide whether the "move the flatten to the consumers" refactor
-is worth its blast radius.
+The full "move the flatten to the consumers that iterate" change, end to end:
 
-The audit that refactor needs is smaller than the doc's "~80 env-iteration
-consumers" suggests: `remove` is already tombstone-aware and `get_mut` already
-COW-promotes a parent key into the overlay, so the genuinely overlay-only
-operations are `iter`/`keys`/`values`/`len`/`values_mut`, and a grep finds
-**13** direct `self.env().iter()/keys()/values()` sites in the VM. The biggest
-of them - the return merge in `vm_call_named_inner.rs` - *wants* overlay-only
-and is correct either way, so it is not a blocker. The hazard is an env cloned
-into a local (`let e = self.env().clone(); e.iter()`), which keeps the parent
-chain and iterates overlay-only; those have to be found by reading, not by
-grepping for `env().iter()`.
+1. `Env::lexical_view()` -- the whole visible lexical view as a flat env
+   (`self.flattened()`; an `Arc` bump when already flat).
+2. `#[track_caller] debug_assert!(!self.is_scoped())` on `Env::iter` / `keys` /
+   `values` / `values_mut` / `len`, turning "a consumer sees a truncated scope"
+   from a silent wrong answer into a debug panic that names the *caller*.
+3. The three return merges (`vm_call_named_inner`, `vm_call_fast`,
+   `vm_closure_dispatch`) switched to `overlay_iter()` -- semantically
+   identical, since `iter()` on a scoped env already IS the overlay.
+4. All four `flatten_scoped_env()` call sites deleted, and the helper with them.
+5. Every site the assertion caught migrated to `lexical_view()`.
+
+### The site inventory (the reusable part)
+
+Renaming the accessors to force compile errors found **133** call sites -- far
+too many to hand-classify. The `#[track_caller]` assertion plus a sweep script
+narrowed that to the sites *actually* reached with a scoped env: **44**,
+converging over five rounds (35, 13, 9, 9, 1) across `t/` (3723 files) and the
+roast whitelist (1436 files) on the debug binary.
+
+Nearly all wanted the full view: pseudo-stashes (`MY::`/`OUTER::`/`LEXICAL::`),
+identity searches (`find_var_by_identity`, `find_instance_in_env`), the
+`__mutsu_sigilless_alias::` scan, operator-name collection, class-body and
+module-exit lexical snapshots, the END-phaser capture overlay. Only three wanted
+overlay-only (the return merges), plus the GC's `SubData`/`LazyList` traces,
+where overlay-only is positively *required*: a scoped env's parent tier is an
+`Arc<Env>` this node does not own, so tracing a flattened view would be exactly
+the edge over-claim `gc_overlay_uniquely_owned` exists to prevent.
+
+If this is retried, rebuild the sweep: run each test file, `awk` the
+`panicked at src/...` line together with the message line that follows it, and
+keep only the ones mentioning a scoped env -- a test that panics for an
+unrelated reason (`t/hyper-race-panic-boundary.t` deliberately overflows an
+index) must not show up as a target. Note that a snippet run in a SUBPROCESS
+(`is_run` / `run-snippet`) hides its panic from the sweep: two sites
+(`run.rs`'s END-phaser overlay, `accessors_stash.rs`'s
+`package_namespace_exists`) surfaced only as ordinary `make test` failures.
+
+### Correctness
+
+Clean. `make test` and the roast whitelist both passed with only the known
+environmental failures, and the debug-assert sweep was silent over both suites.
+
+### Performance: it does not pay
+
+Deterministic instruction counts (callgrind, 300 `ok 1, "x"` under
+`MUTSU_REAL_TEST=1`, one-assertion baseline subtracted) plus wall clock on an
+idle box. `pad-N` is a 2000-iteration `ok` loop with N unused `our` variables:
+
+| build | loop Ir | pad-0 | pad-900 | 20 k `ok` loop |
+| --- | --- | --- | --- | --- |
+| as committed (flatten present) | **158.8 M** | 0.326 s | 1.207 s | 2.945 s |
+| flatten removed, sites migrated | 163.8 M | 0.355 s | 1.047 s | 3.164 s |
+| unsound kill-switch (flatten never runs) | 144.4 M | -- | -- | -- |
+
+The size-scaling improves only from 3.7x to 2.9x, the base case gets ~9%
+*worse*, and the instruction count is 3% worse overall -- against a kill-switch
+that promised 10%.
+
+### Why it does not pay
+
+**The flatten relocates rather than disappears.** Every removal exposed another
+consumer that genuinely needs a full view *per call*:
+
+1. `Value::make_sub(..., self.clone_env())` for `callframe().code` -- cheap only
+   because the guard had already flattened (see "What was ruled out" above).
+   Capturing the scoped env unflattened is sound (a scoped env is already an
+   immutable snapshot: later caller writes un-share it via `cow_mut`) and
+   recovered part of it.
+2. `exec_block_local_scope_op`'s `env_had_before` key-set snapshot -- O(env) on
+   every block-scope opcode, twice per assertion, and now a flatten too.
+   Replacing it with an O(1) `Env` snapshot + `contains_key_sym` recovered a
+   little more.
+3. The `__mutsu_sigilless_alias::` reverse-alias scan on every named `SetLocal`.
+   Gating it on a new monotonic `sigilless_alias_possible()` latch recovered a
+   little more.
+
+Even with all three the total stayed above the committed baseline. And **tried
+on their own against the committed tree, (2) and (3) also measured neutral**
+(259.3 M vs 258.2 M): with the guard in place the env at those sites is already
+flat, so the O(env) walk they remove is the cheap kind. They are not
+independently shippable wins -- do not resurrect them in isolation.
+
+### What a real fix would have to be
+
+Not a relocation. Either:
+
+* **a representation change** that makes a full lexical view structurally free
+  -- a persistent/HAMT overlay map, where `flattened()` is O(overlay) with
+  sharing instead of O(scope) with a copy. That costs a slower `get`, which is
+  far hotter, so it needs its own measurement before anything else; or
+* **removing the per-call need for a full view** -- the three consumers above
+  are each avoidable in principle (a lazy `callframe().code` env, a block-scope
+  declaration list that never consults the env, an alias table that is not
+  env-resident). That is three separate, individually-measurable tickets, and
+  only after all of them is deleting the guard worth re-testing.
+
+Either way, re-run the `MUTSU_NO_FLATTEN` kill-switch experiment first: the
+prize was 17% when this ticket was filed, 10% after the return-merge fix, and it
+keeps shrinking as the per-call full-view consumers go away.


### PR DESCRIPTION
Follow-up to #7393, continuing `todo/deep/vendor-real-test-module.md`'s
per-assertion cost. Two commits: one perf change, and one negative result that
closes off the obvious next step.

## 1. `perf(vm)`: the return merge stops paying for a flattened env

`call_compiled_function_named_inner`'s scoped-overlay return merge is O(callee
writes) on a scoped env — the point of `docs/vm-dual-store.md` Slice 6 — but any
full method dispatch in the callee body collapses the overlay
(`flatten_scoped_env`), and a flattened env holds the caller's whole lexical
scope, so the merge silently becomes O(whole scope). The vendored upstream
`Test` makes two method calls per assertion, so every assertion paid it twice:
callgrind put `LocalKey::with` at 11.8% of the assertion loop with this merge as
its dominant caller, ~556 thread-local round trips per named call.

Three fixes, none of which changes *when* the flatten happens:

* **`Symbol::flags()`** memoizes the pure string-derived predicates the merge
  asks of every key (routine-scoped implicit, index-rw temp, `__mutsu_type::`
  metadata) into one byte. Symbol ids are append-only and a symbol's string
  never changes, so the answer is good for the life of the process. Replaces
  three `as_str()` round trips plus several `memcmp`s per key;
  `is_callee_local_sym` takes the same gate before its `strip_prefix`.
* **A key the callee never rebound is no longer re-inserted.**
  `Value::same_binding` is O(1), and on a flattened env the overwhelming
  majority of keys walked are the caller's own untouched bindings that the
  flatten copied in. An in-place container mutation leaves those bits unchanged
  too, and correctly so: the caller shares the allocation and already sees it.
* **`Env::flattened()` short-circuits an empty overlay** to
  `parent.flattened()`. A tier with no writes and no tombstone is invisible to
  lookups, so the parent's flattening *is* this env's — `file_sym` included,
  which `scoped_child` copies from the parent for exactly that reason. An `Arc`
  bump instead of a whole-map clone when the parent is flat.

Measured — instructions per assertion (callgrind, 300 `ok 1, "x"` under
`MUTSU_REAL_TEST=1`, one-assertion baseline subtracted; deterministic, unlike
this box's wall clock): **658 k -> 535 k**. Wall clock: the 20 000-assertion
`ok` loop 3.36 s -> 3.03 s; `roast/S03-buf/write-int.t` under the real module
29.5 s -> **27.4 s** (median of eight).

Against a 30 s per-file budget that is still not a comfortable margin, and
`todo/deep/vendor-real-test-module.md` says so: completion criterion 2 of the
vendoring ticket remains **unmet**.

## 2. `docs(perf)`: the method-dispatch flatten does not relocate away

The flatten itself is untouched above, so the obvious next step was the one
`todo/perf/method-dispatch-flattens-the-env-on-every-call.md` asks for: delete
the guard and move it to the consumers that actually iterate. That was
implemented end to end — `Env::lexical_view()`, a `#[track_caller]`
`debug_assert!` on `Env::iter`/`keys`/`values`/`values_mut`/`len` turning a
truncated scoped-env view from a silent wrong answer into a panic naming the
caller, the three return merges moved to `overlay_iter()`, all four
`flatten_scoped_env()` call sites deleted, and every site the assertion caught
migrated.

It was **correct and slower**, so it is not in this PR. `make test` and the
roast whitelist were both clean and the assert sweep silent over both, but:

| build | loop Ir | pad-0 | pad-900 | 20 k `ok` loop |
| --- | --- | --- | --- | --- |
| as committed (flatten present) | **158.8 M** | 0.326 s | 1.207 s | 2.945 s |
| flatten removed, sites migrated | 163.8 M | 0.355 s | 1.047 s | 3.164 s |
| unsound kill-switch (flatten never runs) | 144.4 M | — | — | — |

The flatten *relocates* rather than disappears: `clone_env()` for
`callframe().code`, the block-scope `env_had_before` key snapshot, and the
`__mutsu_sigilless_alias::` reverse-alias scan each genuinely need a full
lexical view once per call, and each was cheap only *because* the guard had
already flattened. Fixing all three still did not reach the baseline, and tried
on their own against the committed tree the latter two measure neutral
(259.3 M vs 258.2 M), so they are not independently shippable either.

The ticket now records what was built, the 44-site inventory the assertion found
(out of 133 raw call sites) and how to rebuild the sweep, the numbers, and what
a real fix would have to be instead — a representation change, or removing the
per-call need for a full view one consumer at a time.

## Testing

* `make test` on this branch, rebased onto current `main`: 3759 files / 39226
  tests, only `t/io-path-smartmatch-permissions.t` failing — the known
  root-container artefact (`'/sys'.IO ~~ :w` is True for root).
* `make roast` before the rebase: only the three known provider-independent
  rows (`6.c/S32-io/file-tests.t`, `S16-filehandles/filetest.t`,
  `S32-io/IO-Socket-Async.t`), identical to the set before these changes. The
  post-rebase roast run was interrupted by a container restart, so CI's is the
  authoritative one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012uYR88u9jZop7dLgPyESBS


---
_Generated by [Claude Code](https://claude.ai/code/session_012uYR88u9jZop7dLgPyESBS)_