### PR TITLE
fix(builtins): honour the accepted-named declaration at every builtin-layer entry

### DIFF
--- a/docs/adr/0070-native-methods-declare-the-named-arguments-they-accept.md
+++ b/docs/adr/0070-native-methods-declare-the-named-arguments-they-accept.md
@@ -221,7 +221,36 @@ ran.
   `scripts/native-method-adverb-survey.raku`, and
   `t/native-method-accepted-nameds.t` (66 assertions, green under raku and
   mutsu).
-- **Slice 2 (open).** Survey and declare the remaining residue — `add` /
-  `remove` / `grab` on the mutable QuantHashes, and the methods whose adverb set
-  Rakudo answers only through `%_` validation. Recorded in the narrowed
-  `todo/deep/` file.
+- **Slice 2 (implemented 2026-09-07).** 35 more `&[]` rows plus six with a
+  non-empty accepted set, `native_base_with_options` (the `base`
+  `:no-trailing-zeroes` adverb this ADR listed as declared-but-unimplemented),
+  and `scripts/native-method-adverb-sweep.raku` — the sweep this ADR describes,
+  now a committed script that runs under any interpreter. See
+  `news/2026-09/native-method-accepted-nameds-slice-2.md`.
+
+  Slice 2 corrected two of this ADR's own claims, both by measurement:
+
+  1. **"the adverb reaches the implementation" for `base` is false.**
+     `.base($radix, $digits, :no-trailing-zeroes)` is a three-argument call that
+     matches no arity arm, so the implicit-`*%_` retry dropped the adverb before
+     the 2-ary arm saw it. It needed an interceptor, not just a row.
+  2. **The builtin layer has seven entries, not three.** The Decision section
+     lists the arity cascade, its interpreter twin and
+     `dispatch_method_by_name_1/2/3`. Six further sites dispatch a builtin
+     *before* the cascade and had to be routed through the same declaration:
+     `vm_baghash_mutators::apply_baghash_mutator`, the `tail` interceptor, the
+     by-value array/hash mutator blocks, `exec_call_method_mut_op_impl` +
+     `call_method_mut_with_values`, `call_native_instance_method` +
+     `try_io_path_lexical`, and the compose-a-method-over-a-callable last
+     resort. The compiler's `ArrayPush` fast path also had to decline a named
+     call site. Each is restricted to a receiver that cannot be a user class,
+     so the "a user method still sees its own nameds" invariant holds.
+
+  It also refuted the tempting shortcut that a method whose only named slurpy is
+  the implicit `%_` accepts nothing: `Str.trans` declares only `*%_` and reads
+  `:d`/`:s`/`:c` out of it. The survey now reports each slurpy **by name**
+  (`(+*%_)` vs `(+*%options)`), which makes the *declared*-slurpy readers
+  visible, but a `--` row still has to be confirmed behaviourally.
+
+- **Slice 3 (open).** `subst` / `trans`, `new`, and the plain-call divergences
+  the sweep surfaces. Recorded in the narrowed `todo/deep/` file.

--- a/news/2026-09/native-method-accepted-nameds-slice-2.md
+++ b/news/2026-09/native-method-accepted-nameds-slice-2.md
@@ -1,0 +1,115 @@
+# Every builtin-layer entry now honours the accepted-named declaration
+
+[ADR-0070](../../docs/adr/0070-native-methods-declare-the-named-arguments-they-accept.md)
+gave builtin methods a declaration of the named arguments they accept, and had
+the *arity cascade* drop the rest. Slice 2 finishes the job: it declares the
+residue of the same Rakudo survey, implements the one adverb the table listed
+but mutsu did not honour (`base(:no-trailing-zeroes)`), and — the part that
+turned out to be the real work — routes the **six other places the builtin
+layer is entered** through the same declaration.
+
+## The metric
+
+`scripts/native-method-adverb-sweep.raku` is new, and is the measurement the
+ADR described but never shipped as a script. It derives 1 422 (receiver, method,
+argument-shape) probes from `src/builtins/native_method_row_table.rs` and, for
+each, compares `R.M(A)` against `R.M(A, :qqzz9)`. `:qqzz9` is a name no Raku
+routine declares, so under a conforming implementation the two must agree. It
+runs under any interpreter, so `raku` supplies its own baseline:
+
+| | not named-blind, of 1 422 probes |
+|---|---|
+| mutsu, before | **78** |
+| mutsu, after | **18** |
+| `raku` (the baseline: calls Rakudo itself rejects) | 23 |
+
+Of the 18, only 9 are mutsu-specific, down from 72.
+
+## What was actually wrong
+
+### `elems` on an instance recursed until the stack overflowed
+
+The sweep could not even run: `Blob.new(1,2,3).elems(:qqzz9)` **crashed the
+process**. `builtin_elems` is defined as `$x.elems`, and
+`dispatch_elems_method` delegates back to `call_function("elems", ...)` — a
+cycle that terminates only when the inner call is served by the arity cascade.
+`native_fastpath_receiver_state_guard` deliberately diverts *every* `Instance`
+receiver's `.elems` away from that cascade (so a `Supply` reaches its own arm),
+so for any other instance the two bounced forever.
+
+That is not a named-argument bug at all: `elems(Date.new(2026,1,1))`,
+`elems(Blob.new(1,2,3))` and `elems(C.new)` for a plain user class all
+stack-overflowed on `main`. An instance now answers from the native 0-arg layer
+directly, which is where the bounce was trying to arrive.
+
+### The declaration reached one entry, and the builtin layer has seven
+
+The ADR wired the declaration into the arity cascade, its interpreter twin and
+`dispatch_method_by_name_1/2/3`. Everything else that dispatches a builtin
+*before* the cascade kept counting an adverb as a positional. Each of these is
+now routed through `strip_undeclared_nameds`, restricted so a user class's own
+named parameter is never at risk:
+
+- `vm_baghash_mutators::apply_baghash_mutator` — `BagHash.new(1,2,2).add(1, :zzz)`
+  died "Too many positionals passed; expected 2 arguments but got 3"; raku adds
+  the element and answers `Nil`.
+- the `tail` interceptor in `call_method_with_values_inner` — `(1,2,3).tail(:zzz)`
+  died "Cannot use 'zzz\tTrue' as a tail count".
+- the two by-value array/hash mutator blocks — `[1,2,3].pop(:zzz)` died,
+  `%h.push(:zzz)` inserted a `zzz` key.
+- `exec_call_method_mut_op_impl` and `call_method_mut_with_values`, the mutable
+  opcode and its dispatch entry — `@a.push(:zzz)` left `[1, 2, 3, :zzz]`.
+- `call_native_instance_method` and `try_io_path_lexical`, the native-instance
+  entries — `"/tmp".IO.sibling(:zzz)` built `IO::Path.new("/zzz\tTrue")`.
+- the "compose a method over a callable" last resort — `{ $_ }.arity(:zzz)`
+  answered a `<composed-method:arity>` **Sub**, because the real `.arity` arm is
+  guarded on `args.is_empty()` and had already declined.
+
+The compiler's `@a.push(x)` → `ArrayPush` fast path also bails out on a named
+call site now: that opcode stores whatever single value it is handed and has no
+notion of named-ness.
+
+A *positional* `Pair` is still data everywhere (`@a.push((k => 9))`,
+`rotor(2 => -1)`, a `Pair` held in a variable) — named-ness is a call-site
+property, ADR-0021.
+
+### `base(:no-trailing-zeroes)` was declared but not implemented
+
+The ADR recorded that "the adverb reaches the implementation". Re-measured: it
+does not. `.base($radix, $digits, :no-trailing-zeroes)` is a three-argument
+call that matches no arity arm, so the implicit-`*%_` retry dropped the adverb
+before the 2-ary `base` ever saw it. `native_base_with_options` is a new
+interceptor in front of the cascade, consulted from both the VM and the
+interpreter entry.
+
+The semantics were established against `raku` over 21 cases, and the adverb is
+narrower than it looks: it is declared on **`Rational.base` only**.
+`255.base(16, 4, :no-trailing-zeroes)` is still `"FF.0000"` and
+`2.5e0.base(10, 5, :no-trailing-zeroes)` still `"2.50000"`; `0.5` gives `"0.5"`,
+and `1.0` gives `"1"` — when every fractional digit goes, so does the radix
+point.
+
+## The survey's blind spot, measured
+
+The `todo/deep/` file asked for the `%_`-slurpy family (`grep`, `first`,
+`subst`, `trans`, `reduce`, `produce`, `keys`, `values`, `kv`, `pairs`, `list`,
+`Array`) to have its accepted set "confirmed by hand". That turned out to matter
+for exactly the reason it warned about. A refinement of the survey — reporting
+the *name* of each named slurpy rather than just its presence — separates the
+implicit `*%_` every method carries from a slurpy the routine declares and
+reads (`subst`'s `*%options`, `first`'s `*%a`). But it is still only a lower
+bound: `Str.trans` declares nothing but `*%_` and nevertheless reads `:d`,
+`:s` and `:c` out of it. So `trans` and `subst` stay undeclared, while the rest
+of the family — behaviourally verified against Rakudo, which ignores `:qqzz9` on
+every one of them — is declared.
+
+35 method names were added to the table, plus six with a non-empty accepted set
+(`Str`'s `:subscript`/`:superscript`, `raku`'s `:arglist`, `map`'s six plus
+hyper's `:batch`/`:degree`, `classify-list`/`categorize-list`'s `:as`,
+`unique`'s `:as`/`:with`/`:expires`, `Numeric`'s `:fail-or-nil`).
+
+## Pins
+
+`t/native-method-accepted-nameds.t` grows from 66 to 123 assertions, and — as
+before — the **whole file passes unmodified under real `raku`**, so it is a
+conformance test rather than a snapshot of mutsu's behaviour.

--- a/scripts/native-method-adverb-survey.raku
+++ b/scripts/native-method-adverb-survey.raku
@@ -12,11 +12,21 @@
 # The output is the authoritative accepted-named set for a method: a Raku method
 # carries an implicit `*%_`, so a named argument that is not in this set cannot
 # change the method's answer, and mutsu's builtin dispatch may therefore drop it
-# before choosing an arity. `*%_` / `*%a` slurpies are reported as `**SLURPY**`
-# and are NOT accepted names -- but note that a routine which validates its own
-# `%_` (`grep`, `first`) accepts names that no signature mentions, so a method
-# whose only entry is `**SLURPY**` still needs its adverbs confirmed by hand
-# against `raku-doc/doc/Type/`.
+# before choosing an arity.
+#
+# A named SLURPY is reported separately, by name, because the name is what tells
+# the two cases apart:
+#
+#   * `(+*%_)` -- only the implicit slurpy every method carries. The explicit
+#     named set is then very likely complete.
+#   * `(+*%options)`, `(+*%a)`, ... -- the routine DECLARED a named slurpy, which
+#     means it reads its adverbs out of it (`subst`'s `:g`/`:x`/`:nth`,
+#     `first`'s validation). The explicit set is a LOWER BOUND; do not declare
+#     such a method without establishing its real set by hand.
+#
+# The distinction is necessary but NOT sufficient: `Str.trans` declares nothing
+# but the implicit `*%_` and still reads `:d`/`:s`/`:c` out of it. Confirm any
+# `--` row behaviourally (and against `raku-doc/doc/Type/`) before declaring it.
 
 my @OWNERS = <Mu Any Cool Str Int Num Rat Complex List Array Seq Hash Map Range
               Pair Set Bag Mix SetHash BagHash MixHash Blob Buf Match Date
@@ -29,6 +39,10 @@ my @DEFAULT-METHODS = <
     classify categorize first grep map split comb lines batch Str contains
     starts-with ends-with substr-eq subst trans match min max unique squish
     sort reduce produce keys values kv pairs list Array
+    add remove grab tail tree Rat FatRat Int Bool Numeric atan2 abs gist raku
+    WHICH arity count signature of lazy link sibling yyyy-mm-dd mm-dd-yyyy
+    dd-mm-yyyy push pop shift unshift append prepend splice
+    classify-list categorize-list
 >;
 
 sub named-params($m) {
@@ -37,7 +51,7 @@ sub named-params($m) {
         for $c.signature.params -> $p {
             next unless $p.named;
             if $p.slurpy {
-                %seen{'**SLURPY**'} = True;
+                %seen{'**SLURPY:' ~ ($p.name // '(anon)') ~ '**'} = True;
             } else {
                 %seen{$_} = True for $p.named_names;
             }
@@ -54,14 +68,17 @@ for @methods -> $name {
     for @OWNERS -> $owner {
         my $type = ::($owner);
         next if $type ~~ Failure;
-        my $m = $type.^lookup($name);
-        next without $m;
-        my @n = named-params($m);
+        # `^lookup` can answer an NQPRoutine, which has no `.defined`.
+        my $m = try $type.^lookup($name);
+        next unless (try so $m) // False;
+        my @n = try named-params($m) // ();
         next unless @n;
         @owners-with.push: $owner;
         %union{$_} = True for @n;
     }
-    my @accepted = %union.keys.grep({ $_ ne '**SLURPY**' }).sort;
-    my $slurpy = %union<**SLURPY**> ?? ' (+*%_)' !! '';
+    my @accepted = %union.keys.grep({ !.starts-with('**SLURPY:') }).sort;
+    my @slurpies = %union.keys.grep({ .starts-with('**SLURPY:') })
+                              .map({ .substr(9, *-2) }).sort;
+    my $slurpy = @slurpies ?? " (+*{@slurpies.join(' +*')})" !! '';
     printf "%-14s %s%s\n", $name, (@accepted ?? @accepted.join(' ') !! '--'), $slurpy;
 }

--- a/scripts/native-method-adverb-sweep.raku
+++ b/scripts/native-method-adverb-sweep.raku
@@ -1,0 +1,154 @@
+#!/usr/bin/env raku
+
+# The measurement behind ADR-0070: how many builtin-method calls are NOT
+# named-blind?
+#
+# Every Raku *method* carries an implicit `*%_`, so an adverb the method does
+# not declare cannot change its answer. This script probes that property
+# directly: for every (owner, method, argument-shape) triple derived from
+# `src/builtins/native_method_row_table.rs` it evaluates
+#
+#     RECEIVER.method(ARGS)          and          RECEIVER.method(ARGS, :qqzz9)
+#
+# and reports every probe whose two answers differ. `:qqzz9` is a name no Raku
+# routine declares, so under a conforming implementation the two must agree --
+# either both give the same value or both die the same way.
+#
+# The script is implementation-agnostic: run it under the interpreter you want
+# to measure.
+#
+#     raku                    scripts/native-method-adverb-sweep.raku   # oracle
+#     ./target/release/mutsu  scripts/native-method-adverb-sweep.raku   # mutsu
+#
+# Pass `-v` (as the first argument) to list every diverging probe rather than
+# only the count. The count is the campaign's progress metric; the residue is
+# tracked in `todo/deep/native-method-accepted-named-declarations.md`.
+#
+# Note that a *non-zero* count is not automatically a named-argument bug: a
+# receiver whose plain call already returns something unstable (`.WHERE`) or
+# random is excluded below, but a method whose plain answer diverges from raku
+# for an unrelated reason can still show up here. Compare the two runs.
+
+use MONKEY-SEE-NO-EVAL;
+
+my $verbose = so @*ARGS.grep('-v');
+# `-t` echoes each probe to stderr before it runs, so an interpreter that dies
+# mid-sweep (a stack overflow, a hang) names the probe that killed it.
+my $trace   = so @*ARGS.grep('-t');
+
+# A representative receiver per owner named in the row table. Owners with no
+# cheap, side-effect-free, deterministic sample (IO::Handle, Supply, the
+# RakuAST:: nodes, Backtrace, CallFrame, ...) are deliberately absent: the sweep
+# is a comparable metric, not an exhaustive census.
+my %RECEIVER =
+    'Any'        => 'Any',
+    'Mu'         => 'Mu',
+    'Nil'        => 'Nil',
+    'Bool'       => 'True',
+    'Int'        => '42',
+    'Num'        => '4.25e0',
+    'Rat'        => '0.5',
+    'Complex'    => '(1+2i)',
+    'Cool'       => '42',
+    'Str'        => '"abc"',
+    'List'       => '(1, 2, 3)',
+    'Array'      => '[1, 2, 3]',
+    'Seq'        => '(1, 2, 3).Seq',
+    'Hash'       => '{ a => 1 }',
+    'Map'        => 'Map.new(("a", 1))',
+    'Pair'       => '(a => 1)',
+    'Range'      => '(1 .. 5)',
+    'Set'        => 'Set.new(1)',
+    'SetHash'    => 'SetHash.new(1)',
+    'Bag'        => 'Bag.new(1, 1)',
+    'BagHash'    => 'BagHash.new(1, 1)',
+    'Mix'        => '(a => 1.5).Mix',
+    'MixHash'    => '(a => 1.5).MixHash',
+    'Blob'       => 'Blob.new(1, 2, 3)',
+    'Buf'        => 'Buf.new(1, 2, 3)',
+    'Match'      => '("abc" ~~ /b/)',
+    'Junction'   => 'any(1, 2)',
+    'Date'       => 'Date.new(2026, 1, 1)',
+    'DateTime'   => 'DateTime.new(2026, 1, 1, 0, 0, 0)',
+    'Duration'   => 'Duration.new(1)',
+    'Instant'    => 'Instant.from-posix(1)',
+    'IO::Path'   => '"/tmp".IO',
+    'Capture'    => '\\(1, 2)',
+    'Signature'  => ':(Int $x)',
+    'Code'       => '{ $_ }',
+    'Block'      => '{ $_ }',
+    'Version'    => 'v1.2.3',
+    'Uni'        => '"abc".NFC',
+    'X::AdHoc'   => 'X::AdHoc.new(payload => "x")',
+    ;
+
+# Methods whose plain answer is random, time-dependent, address-dependent or
+# has an external side effect. They cannot be compared to themselves, so they
+# say nothing about named-blindness.
+my $SKIP = set <
+    pick roll grab grabpairs WHERE
+    print say note put printf print-nl
+    exit sleep run shell EVAL EVALFILE
+    spurt slurp open unlink mkdir rmdir rename copy move symlink
+    lines words getc get readchars read write close watch
+    now rand
+    line file callframe
+    Supply Channel Promise start
+>;
+
+sub rows() {
+    my $path = 'src/builtins/native_method_row_table.rs';
+    my @out;
+    for $path.IO.lines -> $line {
+        next unless $line ~~ / ^ \s* '(' '"' (<-["]>+) '"' ',' \s* '"' (<-["]>+) '"' ',' \s* (\d+) ',' /;
+        @out.push: ($0.Str, $1.Str, $2.Int);
+    }
+    @out
+}
+
+sub arg-shapes($bits) {
+    my @shapes;
+    @shapes.push: ''            if $bits +& 0b0001;
+    @shapes.push: '1', '"a"'    if $bits +& 0b0010;
+    @shapes.push: '1, 2'        if $bits +& 0b0100;
+    @shapes.push: '', '1'       if $bits +& 0b1000;
+    @shapes.unique
+}
+
+sub answer($code) {
+    my $v = try EVAL($code);
+    my $raw = $! ?? "DIED: {$!.Str.lines.head // ''}" !! (try $v.raku) // "UNRAKUABLE";
+    # An arity/dispatch error quotes the call back at you, so the probe name
+    # itself appears in the message ("Cannot resolve caller Str(Str:D: Str:D,
+    # :qqzz9)"). That is the same failure, not a divergence -- erase the probe
+    # name before comparing.
+    # `Block|3046962412944` / `ObjAt.new("List|4755263302896")`: an object
+    # identity, freshly allocated per EVAL, is not an answer.
+    $raw.subst(/ ','? \s* ':qqzz9' /, '', :g)
+        .subst(/ \s+ ')' /, ')', :g)
+        .subst(/ '|' '0x'? <[0..9a..fA..F]>+ /, '|<id>', :g)
+}
+
+my $total = 0;
+my $diverging = 0;
+my @report;
+
+for rows() -> ($owner, $method, $bits) {
+    my $recv = %RECEIVER{$owner} // next;
+    next if $method (elem) $SKIP;
+    for arg-shapes($bits) -> $shape {
+        my $plain = "$recv.$method\($shape\)";
+        my $withz = $shape ?? "$recv.$method\($shape, :qqzz9)" !! "$recv.$method\(:qqzz9)";
+        $total++;
+        note $plain if $trace;
+        my $a = answer($plain);
+        my $b = answer($withz);
+        next if $a eq $b;
+        $diverging++;
+        @report.push: "  $plain\n      plain: $a\n      :qqzz9: $b";
+    }
+}
+
+say @report.join("\n") if $verbose;
+say "probes: $total";
+say "not named-blind: $diverging";

--- a/src/builtins/accepted_nameds.rs
+++ b/src/builtins/accepted_nameds.rs
@@ -50,10 +50,31 @@ pub(crate) fn native_method_accepted_nameds(method: &str) -> Option<&'static [&'
         | "expmod" | "fmt" | "indent" | "int-bounds" | "join" | "permutations" | "polymod"
         | "roots" | "samecase" | "samemark" | "skip" | "sprintf" | "subbuf" | "subbuf-rw"
         | "tail" | "unimatch" | "uniprops" => &[],
+        // Slice 2 of the same survey. `add`/`remove`/`grab` are the mutable
+        // QuantHash mutators (`BagHash.add(1, :zzz)` counted the adverb as a
+        // second positional and died with an arity error); the rest are the
+        // "answers its adverb set only through `%_`" family the survey could
+        // previously only report as a lower bound, each confirmed by hand
+        // against `raku-doc/doc/Type/` and by probing Rakudo.
+        "Array" | "Bool" | "FatRat" | "Int" | "Rat" | "WHICH" | "abs" | "add" | "append"
+        | "arity" | "atan2" | "count" | "dd-mm-yyyy" | "gist" | "grab" | "keys" | "kv" | "lazy"
+        | "link" | "list" | "mm-dd-yyyy" | "of" | "pairs" | "pop" | "prepend" | "produce"
+        | "push" | "reduce" | "remove" | "shift" | "sibling" | "signature" | "splice" | "tree"
+        | "unshift" | "values" | "yyyy-mm-dd" => &[],
         "base" => &["no-trailing-zeroes"],
         "minmax" => &["by"],
         "rotor" => &["partial"],
         "classify" | "categorize" => &["as", "into"],
+        "classify-list" | "categorize-list" => &["as"],
+        "raku" => &["arglist"],
+        "Numeric" => &["fail-or-nil"],
+        "Str" => &["subscript", "superscript"],
+        "unique" => &["as", "expires", "with"],
+        // `Any.map` declares these six; `HyperSeq`/`RaceSeq` read `:batch` and
+        // `:degree` out of their own `*%options` slurpy.
+        "map" => &[
+            "batch", "deep", "degree", "duck", "flat", "item", "label", "node",
+        ],
         _ => return None,
     })
 }

--- a/src/builtins/methods_narg.rs
+++ b/src/builtins/methods_narg.rs
@@ -16,6 +16,7 @@ mod indent;
 mod numeric;
 mod str_match;
 
+pub(crate) use base::native_base_with_options;
 pub(crate) use buf::{read_f32_endian, read_f64_endian, read_int_value};
 pub(crate) use dispatch_1arg::native_method_1arg;
 pub(crate) use dispatch_2arg::native_method_2arg;

--- a/src/builtins/methods_narg/base.rs
+++ b/src/builtins/methods_narg/base.rs
@@ -164,6 +164,83 @@ pub(crate) fn rat_to_base(n: i64, d: i64, radix: u32, digits_mode: BaseDigits) -
     result
 }
 
+/// `.base($radix, $digits?, :no-trailing-zeroes)`.
+///
+/// The adverb is Rakudo's, and it is declared on **`Rational.base` only**:
+/// `255.base(16, 4, :no-trailing-zeroes)` is still `"FF.0000"` and
+/// `2.5e0.base(10, 5, :no-trailing-zeroes)` still `"2.50000"`, while
+/// `0.5.base(10, 5, :no-trailing-zeroes)` is `"0.5"` and
+/// `1.0.base(10, 5, :no-trailing-zeroes)` is `"1"` -- when every fractional
+/// digit goes, so does the radix point (all measured against `raku`).
+///
+/// This is an interceptor, in front of the arity cascade, for the reason the
+/// other `native_*_with_options` helpers are: the cascade picks its arm by
+/// argument count, so the three-argument call never reaches a 2-ary `base`.
+/// Returns `None` when the adverb is absent, so the ordinary forms keep their
+/// existing arms.
+pub(crate) fn native_base_with_options(
+    target: &Value,
+    args: &[Value],
+) -> Option<Result<Value, RuntimeError>> {
+    let mut no_trailing_zeroes = None;
+    let mut positional: Vec<&Value> = Vec::with_capacity(args.len());
+    for arg in args {
+        if arg.is_string_pair_value()
+            && let ValueView::Pair(key, value) = arg.view()
+            && key.as_str() == "no-trailing-zeroes"
+        {
+            no_trailing_zeroes = Some(value.truthy());
+            continue;
+        }
+        positional.push(arg);
+    }
+    let strip = no_trailing_zeroes?;
+    let radix = parse_radix_checked(positional.first().copied()?)?;
+    let radix = match radix {
+        Ok(r) => r,
+        Err(e) => return Some(Err(e)),
+    };
+    let digits_mode = match positional.get(1).copied().map(Value::view) {
+        None => BaseDigits::Auto,
+        Some(ValueView::Int(d)) if d >= 0 => BaseDigits::Fixed(d as u32),
+        Some(ValueView::Whatever) => BaseDigits::Whatever,
+        Some(_) => return None,
+    };
+    if positional.len() > 2 {
+        return None;
+    }
+    // Only a Rational honours the adverb; everything else keeps the plain
+    // answer, which is what the ordinary arms already produce.
+    let (n, d, rational) = match target.view() {
+        ValueView::Rat(n, d) | ValueView::FatRat(n, d) => (n, d, true),
+        ValueView::Int(i) => (i, 1, false),
+        ValueView::Num(f) => {
+            let (n, d) = f64_to_rat(f);
+            (n, d, false)
+        }
+        _ => return None,
+    };
+    let rendered = rat_to_base(n, d, radix, digits_mode);
+    if !(strip && rational) {
+        return Some(Ok(Value::str(rendered)));
+    }
+    Some(Ok(Value::str(strip_trailing_base_zeroes(&rendered))))
+}
+
+/// Drop the trailing zero digits of a base-rendered fraction, and the radix
+/// point with them when nothing is left after it.
+fn strip_trailing_base_zeroes(rendered: &str) -> String {
+    let Some(point) = rendered.find('.') else {
+        return rendered.to_string();
+    };
+    let trimmed = rendered[point + 1..].trim_end_matches('0');
+    if trimmed.is_empty() {
+        rendered[..point].to_string()
+    } else {
+        format!("{}.{}", &rendered[..point], trimmed)
+    }
+}
+
 fn int_to_base(mut n: u64, radix: u32) -> String {
     if n == 0 {
         return "0".to_string();

--- a/src/builtins/mod.rs
+++ b/src/builtins/mod.rs
@@ -104,7 +104,7 @@ pub(crate) use functions::native_function;
 pub(crate) use functions::{deitemize_flat_operand, flat_val};
 pub(crate) use methods_0arg::native_method_0arg;
 pub(crate) use methods_narg::{
-    native_contains_with_options, native_method_1arg, native_method_2arg,
+    native_base_with_options, native_contains_with_options, native_method_1arg, native_method_2arg,
     native_prefix_suffix_with_options, native_substr_eq_with_options, read_f32_endian,
     read_f64_endian, read_int_value,
 };

--- a/src/compiler/expr_method.rs
+++ b/src/compiler/expr_method.rs
@@ -230,6 +230,12 @@ impl Compiler {
             && args.len() == 1
             && modifier.is_none()
             && !quoted
+            // ADR-0070: `Array.push` accepts no named argument, so
+            // `@a.push(:zzz)` is a no-op in raku. This opcode stores whatever
+            // single value it is handed, with no notion of named-ness, so a
+            // named call site has to take the general dispatch path (which
+            // consults `builtins::accepted_nameds` and drops the adverb).
+            && !Self::is_named_arg_expr(&args[0])
             && matches!(target, Expr::ArrayVar(_))
             && self.code.locals.contains(&target_name)
         {

--- a/src/runtime/methods_call_dispatch.rs
+++ b/src/runtime/methods_call_dispatch.rs
@@ -1595,6 +1595,11 @@ impl Interpreter {
             "push" | "pop" | "shift" | "unshift" | "append" | "prepend" | "splice"
         ) && matches!(target.view(), ValueView::Array(_, kind) if kind.is_real_array())
         {
+            // ADR-0070: this block runs in front of the arity cascade and reads
+            // `args` positionally, so an adverb none of these methods accepts
+            // would be spliced in as an element or counted as a positional
+            // (`[1,2,3].pop(:zzz)` died with an arity error; raku pops).
+            let args = crate::builtins::strip_undeclared_nameds(method, &args).unwrap_or(args);
             // Check element type constraints from container metadata (e.g., typed attribute arrays)
             if matches!(method, "push" | "append" | "unshift" | "prepend") {
                 self.check_array_value_element_types(&target, &args)?;
@@ -1641,6 +1646,11 @@ impl Interpreter {
         // In Raku, %h.push: (k => v) inserts the pair; if the key exists,
         // it creates an itemized array of both values.
         if matches!(method, "push" | "append") && matches!(target.view(), ValueView::Hash(_)) {
+            // ADR-0070, as in the Array block above: `%h.push(:zzz)` inserted a
+            // `zzz` key where raku's `Hash.push(+new)` swallows the adverb into
+            // `%_` and leaves the hash alone. A *positional* `Pair`
+            // (`%h.push((k => 1))`) carries the other flavour and survives.
+            let args = crate::builtins::strip_undeclared_nameds(method, &args).unwrap_or(args);
             // Type check values being pushed against container type metadata
             if let Some(info) = self.container_type_metadata(&target) {
                 let constraint = &info.value_type.clone();
@@ -3337,6 +3347,16 @@ impl Interpreter {
         // for this cascade: if it declines, the original `args` (nameds intact)
         // go on to the by-name dispatchers, the constructors and the user
         // method, none of which may lose a named.
+        // The interpreter-side twin of `try_native_method_raw`'s `base`
+        // interceptor: `.base($radix, $digits, :no-trailing-zeroes)` is a
+        // three-argument call no arity arm matches, so the adverb has to be read
+        // before the cascade or the implicit-`*%_` retry silently drops it.
+        if method == "base"
+            && !bypass_native_fastpath
+            && let Some(result) = crate::builtins::native_base_with_options(&target, &args)
+        {
+            return result;
+        }
         let cascade_stripped = crate::builtins::strip_undeclared_nameds(method, &args);
         let cascade_args: &[Value] = cascade_stripped.as_deref().unwrap_or(&args);
         let native_result = if bypass_native_fastpath {
@@ -3381,7 +3401,11 @@ impl Interpreter {
             && !bypass_native_fastpath
             && !matches!(target.view(), ValueView::Instance { class_name, .. } if class_name == "Supply")
         {
-            return self.dispatch_tail(target, &args);
+            // `dispatch_tail` reads `args[0]` as the tail COUNT, so it needs the
+            // same named-blindness the arity cascade below gets: `tail` is
+            // declared as accepting no adverb, and `(1,2,3).tail(:zzz)` used to
+            // die "Cannot use 'zzz\tTrue' as a tail count" where raku answers 3.
+            return self.dispatch_tail(target, cascade_args);
         }
         // `.head(&callable)` / `.head(*)` — WhateverCode/Whatever argument. The
         // native fast path only handles plain numeric counts; resolve the

--- a/src/runtime/methods_dispatch_match2.rs
+++ b/src/runtime/methods_dispatch_match2.rs
@@ -476,6 +476,23 @@ impl Interpreter {
         if !args.is_empty() {
             return None;
         }
+        // The same cycle, on the receiver side. `call_function("elems", ..)`
+        // reaches `builtin_elems`, which is DEFINED as `$x.elems`, so the
+        // delegation below only terminates when that inner call is served by
+        // the arity cascade -- and `native_fastpath_receiver_state_guard`
+        // deliberately diverts EVERY `Instance` receiver's `.elems` away from
+        // that cascade (so a `Supply` reaches the arm above). For any other
+        // instance the bounce therefore came straight back here and recursed
+        // until the stack overflowed: `elems(Date.new(2026,1,1))`,
+        // `elems(C.new)` for a plain user class, and -- via the implicit-`*%_`
+        // retry that re-enters this chain with the adverb removed --
+        // `Blob.new(1,2,3).elems(:adverb)`. Answer an instance from the native
+        // 0-arg layer directly, which is where the bounce was trying to arrive
+        // (a buf-backed class reports its length, a `Stash` its symbol count,
+        // anything else raku's `Any.elems` of 1).
+        if matches!(target.view(), ValueView::Instance { .. }) {
+            return crate::builtins::native_method_0arg(&target, Symbol::intern("elems"));
+        }
         Some(self.call_function("elems", vec![target]))
     }
 

--- a/src/runtime/methods_instance_ops.rs
+++ b/src/runtime/methods_instance_ops.rs
@@ -2454,6 +2454,18 @@ impl Interpreter {
                 // Method calls on callables compose by applying the method to the
                 // callable's return value, e.g. `(*-*).abs`.
                 if matches!(target.view(), ValueView::Sub(_) | ValueView::WeakSub(_)) {
+                    // ADR-0070: composing is the LAST resort, so an adverb the
+                    // method does not accept must not be what pushes the call
+                    // into it. `{ $_ }.arity(:zzz)` answered a
+                    // `<composed-method:arity>` Sub (the `args.is_empty()` guard
+                    // on the real `.arity` arm had already declined) where raku
+                    // answers 0. Drop the undeclared nameds and re-dispatch;
+                    // `strip_undeclared_nameds` answers `Some` only when it
+                    // actually removed something, so the retry cannot loop.
+                    if let Some(stripped) = crate::builtins::strip_undeclared_nameds(method, &args)
+                    {
+                        return self.call_method_with_values(target, method, stripped);
+                    }
                     use crate::ast::{Expr, Stmt};
                     use std::sync::atomic::{AtomicU64, Ordering};
 

--- a/src/runtime/methods_mut_dispatch.rs
+++ b/src/runtime/methods_mut_dispatch.rs
@@ -38,6 +38,21 @@ impl Interpreter {
         {
             return self.call_method_with_values(target, method, args);
         }
+        // ADR-0070 at the mutable dispatch entry -- the fourth place the builtin
+        // layer is entered. The native array/hash mutator arms below run in
+        // FRONT of the arity cascade and read `args` positionally, so a named
+        // argument none of them accepts was appended as an ELEMENT
+        // (`@a.push(:zzz)` stored the `Pair` where raku ignores it and leaves
+        // the array alone) or counted as a positional (`@a.pop(:zzz)` died
+        // "Too many positionals passed" where raku pops). Restricted to a
+        // native container receiver: an `Instance`/`Package` may be a user class
+        // whose own `push` genuinely declares a named parameter, and a `Mixin`
+        // may carry a role method, so neither is touched here.
+        let args = if matches!(target.view(), ValueView::Array(..) | ValueView::Hash(_)) {
+            crate::builtins::strip_undeclared_nameds(method, &args).unwrap_or(args)
+        } else {
+            args
+        };
         // Track B/Track C: an aggregate that lives in a shared `ContainerRef`
         // cell (a `state @a`/`state %h` under an active thread context — see
         // `exec_state_var_init_op`). Dispatch on the cell's CONTENT, then fold

--- a/src/runtime/native_io/io_path_lexical.rs
+++ b/src/runtime/native_io/io_path_lexical.rs
@@ -40,6 +40,12 @@ impl Interpreter {
         method: &str,
         args: &[Value],
     ) -> Option<Result<Value, RuntimeError>> {
+        // ADR-0070: this is the single `IO::Path` native funnel, reached from
+        // three dispatch entries, and the arms below read `args` positionally.
+        // `"/tmp".IO.sibling(:zzz)` built `IO::Path.new("/zzz\tTrue")` where
+        // raku's implicit `*%_` swallows the adverb.
+        let stripped = crate::builtins::strip_undeclared_nameds(method, args);
+        let args: &[Value] = stripped.as_deref().unwrap_or(args);
         let io_path_class = Symbol::intern(class_name);
         let p = attributes
             .get("path")

--- a/src/runtime/native_methods/mod.rs
+++ b/src/runtime/native_methods/mod.rs
@@ -352,6 +352,17 @@ impl Interpreter {
         method: &str,
         args: Vec<Value>,
     ) -> Result<Value, RuntimeError> {
+        // ADR-0070 at the native-INSTANCE dispatch entry. The per-class handlers
+        // below read `args` positionally just as the arity cascade does, so an
+        // adverb the method does not declare was consumed as data:
+        // `"/tmp".IO.sibling(:zzz)` built `IO::Path.new("/zzz\tTrue")` where raku
+        // swallows the adverb into `%_`. Reached only when the receiver's class
+        // has a NATIVE method of this name and no user method shadowing it (the
+        // `is_native_method && !has_user_method` gate in
+        // `dispatch_instance_and_fallback`), so a user class's own named
+        // parameter is never at risk here.
+        let stripped = crate::builtins::strip_undeclared_nameds(method, &args);
+        let args = stripped.unwrap_or(args);
         let dispatch_class = if matches!(
             class_name,
             "IO::Path"

--- a/src/vm/vm_baghash_mutators.rs
+++ b/src/vm/vm_baghash_mutators.rs
@@ -50,6 +50,14 @@ pub(crate) fn apply_baghash_mutator(
     method: &str,
     args: &[Value],
 ) -> Result<Value, RuntimeError> {
+    // This helper is a pre-dispatch interceptor: it runs *before* the builtin
+    // arity cascade, so ADR-0070's declaration has to be honoured here too or
+    // the arity check below counts an adverb as a positional. Rakudo's
+    // `method add(BagHash:D: \to-add, *%_)` accepts no named at all, so
+    // `BagHash.new(1,2,2).add(1, :zzz)` is `Nil` there, where mutsu died with
+    // "Too many positionals passed; expected 2 arguments but got 3".
+    let stripped = crate::builtins::strip_undeclared_nameds(method, args);
+    let args: &[Value] = stripped.as_deref().unwrap_or(args);
     if args.len() != 1 {
         let word = if args.is_empty() { "few" } else { "many" };
         return Err(RuntimeError::new(format!(

--- a/src/vm/vm_call_method_mut_ops.rs
+++ b/src/vm/vm_call_method_mut_ops.rs
@@ -684,6 +684,19 @@ impl Interpreter {
         // variable, a second alias, a value passed to a sub one call frame
         // away) observes it for free.
         let target = self.reify_or_consume_seq_target(target, method.as_str())?;
+        // ADR-0070 at the mutable OPCODE entry. The push/append/unshift/prepend
+        // branches below (and the `call_method_mut_with_values` arms they lead
+        // to) read `args` positionally, so an adverb none of them declares was
+        // stored as an ELEMENT: `@a.push(:zzz)` left `[1, 2, 3, :zzz]` where
+        // raku's implicit `*%_` swallows it and the array is untouched.
+        // Restricted to a native container receiver -- an `Instance`/`Package`
+        // may be a user class whose own `push` declares a named parameter, and a
+        // `Mixin` may carry a role method, so neither is touched here.
+        let args = if matches!(target.view(), ValueView::Array(..) | ValueView::Hash(_)) {
+            crate::builtins::strip_undeclared_nameds(&method, &args).unwrap_or(args)
+        } else {
+            args
+        };
         // ADR-0058: a mutating method reads its ARGUMENTS' elements through
         // pure code (`@a.splice(1, 1, (7,8).map({...}))` flattens the Seq into
         // the array), so a still-deferred `.map` argument has to run first.

--- a/src/vm/vm_native_dispatch.rs
+++ b/src/vm/vm_native_dispatch.rs
@@ -489,6 +489,15 @@ impl Interpreter {
         {
             return Some(result);
         }
+        // `.base($radix, $digits, :no-trailing-zeroes)` — the one adverb `base`
+        // declares. It has to be read in front of the cascade: a three-argument
+        // call matches no arity arm, and the implicit-`*%_` retry then drops the
+        // adverb before the 2-ary arm sees it.
+        if method_name == "base"
+            && let Some(result) = crate::builtins::native_base_with_options(target, args)
+        {
+            return Some(result);
+        }
         // `Range.int-bounds($from is rw, $to is rw --> Bool)`: writes the bounds
         // into the caller's containers, so it needs `&mut self` and the call
         // site's arg-source names (see `vm/vm_range_int_bounds.rs`). The

--- a/t/native-method-accepted-nameds.t
+++ b/t/native-method-accepted-nameds.t
@@ -138,4 +138,123 @@ is 4.log(:base(2)), 4.log, 'log(:base) still falls back to the 0-ary log';
 is "abc".uc(:foo), "ABC", 'uc(:foo) still swallows the named';
 is (1,2,3).map({ $_ * 2 }).join("-", :foo), "2-4-6", 'a Seq body is consumed exactly once';
 
+# ===========================================================================
+# Slice 2: the residue of the same survey.
+# ===========================================================================
+
+# --- the mutable QuantHash mutators ----------------------------------------
+#
+# Rakudo's `method add(BagHash:D: \to-add, *%_)` accepts no named, so the
+# adverb is swallowed and the element is still added. mutsu counted it as a
+# second positional and died "Too many positionals passed; expected 2
+# arguments but got 3".
+
+{
+    my $b = BagHash.new(1, 2, 2);
+    my $r = $b.add(1, :zzz);
+    nok $r.defined, 'BagHash.add returns Nil';
+    is $b{1}, 2, 'add(x, :undeclared) still adds x';
+    is $b{2}, 2, 'add(x, :undeclared) leaves the other keys alone';
+}
+{
+    my $b = BagHash.new(1, 2, 2);
+    $b.remove(2, :zzz);
+    is $b{2}, 1, 'remove(x, :undeclared) still removes one x';
+}
+is BagHash.new(1, 1, 1).grab(2, :zzz).elems, 2, 'grab(n, :undeclared) still grabs n';
+
+# --- base(:no-trailing-zeroes) ---------------------------------------------
+#
+# The adverb is declared on `Rational.base` ONLY: an Int or Num invocant keeps
+# every trailing zero. When the whole fraction goes, so does the radix point.
+
+is 0.5.base(10, 5, :no-trailing-zeroes), "0.5", 'base drops trailing zeroes';
+is 1.0.base(10, 5, :no-trailing-zeroes), "1", 'base drops the radix point with them';
+is 0.125.base(2, 8, :no-trailing-zeroes), "0.001", 'base :no-trailing-zeroes in base 2';
+is (-0.5).base(10, 5, :no-trailing-zeroes), "-0.5", 'base :no-trailing-zeroes keeps the sign';
+is 0.5.base(10, 5), "0.50000", 'base without the adverb pads as before';
+is 0.5.base(10, 5, :no-trailing-zeroes(False)), "0.50000", 'base :no-trailing-zeroes(False)';
+is 255.base(16, 4, :no-trailing-zeroes), "FF.0000", 'base :no-trailing-zeroes is Rational-only';
+
+# --- the array/hash mutators -----------------------------------------------
+#
+# `Array.push`/`append`/`unshift`/`prepend` and `Hash.push`/`append` accept no
+# named, so an adverb is swallowed and the container is untouched; `pop`/
+# `shift`/`splice` take no named either and must not count one as a positional.
+
+{ my @a = 1, 2, 3; @a.push(:zzz);    is-deeply @a.List, (1, 2, 3), 'Array.push ignores an undeclared named'; }
+{ my @a = 1, 2, 3; @a.append(:zzz);  is-deeply @a.List, (1, 2, 3), 'Array.append ignores an undeclared named'; }
+{ my @a = 1, 2, 3; @a.unshift(:zzz); is-deeply @a.List, (1, 2, 3), 'Array.unshift ignores an undeclared named'; }
+{ my @a = 1, 2, 3; @a.prepend(:zzz); is-deeply @a.List, (1, 2, 3), 'Array.prepend ignores an undeclared named'; }
+{ my @a = 1, 2, 3; is @a.pop(:zzz), 3,   'Array.pop ignores an undeclared named'; }
+{ my @a = 1, 2, 3; is @a.shift(:zzz), 1, 'Array.shift ignores an undeclared named'; }
+{
+    my @a = 1, 2, 3;
+    is-deeply @a.splice(1, :zzz).List, (2, 3), 'Array.splice ignores an undeclared named';
+    is-deeply @a.List, (1,), 'Array.splice(:undeclared) still spliced';
+}
+{ my %h = a => 1; %h.push(:zzz);   is-deeply %h.keys.List, ("a",), 'Hash.push ignores an undeclared named'; }
+{ my %h = a => 1; %h.append(:zzz); is-deeply %h.keys.List, ("a",), 'Hash.append ignores an undeclared named'; }
+is [1, 2, 3].pop(:zzz), 3, 'a by-value Array receiver takes the same path';
+
+# A POSITIONAL Pair is data, not an adverb, and must survive (ADR-0021).
+{ my @a = 1, 2; @a.push((k => 9)); is @a[2].key, "k", 'Array.push keeps a positional Pair'; }
+{ my @a = 1, 2; my $p = (m => 8); @a.push($p); is @a[2].key, "m", 'a Pair in a variable is positional'; }
+
+# --- the rest of the surveyed residue --------------------------------------
+
+is-deeply (1,2,3).tree(:zzz).List, (1, 2, 3), 'tree ignores an undeclared named';
+is 0.5.Rat(:zzz), 0.5, 'Rat ignores an undeclared named';
+is (1/3).FatRat(:zzz), (1/3).FatRat, 'FatRat ignores an undeclared named';
+is 1.atan2(:zzz), 1.atan2, 'atan2 ignores an undeclared named';
+is Duration.new(-1).abs(:zzz), 1, 'abs ignores an undeclared named';
+is "42".Numeric(:zzz), 42, 'Numeric ignores an undeclared named';
+is "42".Int(:zzz), 42, 'Int ignores an undeclared named';
+is 42.Bool(:zzz), True, 'Bool ignores an undeclared named';
+is 42.gist(:zzz), "42", 'gist ignores an undeclared named';
+is 42.WHICH(:zzz), 42.WHICH, 'WHICH ignores an undeclared named';
+is-deeply (1,2,3).keys(:zzz).List, (0, 1, 2), 'keys ignores an undeclared named';
+is-deeply (1,2,3).values(:zzz).List, (1, 2, 3), 'values ignores an undeclared named';
+is-deeply {a => 1}.kv(:zzz).List, ("a", 1), 'kv ignores an undeclared named';
+is-deeply (1,2).pairs(:zzz).List.map(*.key).List, (0, 1), 'pairs ignores an undeclared named';
+is-deeply (1,2).list(:zzz).List, (1, 2), 'list ignores an undeclared named';
+is-deeply (1,2).Array(:zzz).List, (1, 2), 'Array ignores an undeclared named';
+is (1,2,3).reduce(&[+], :zzz), 6, 'reduce ignores an undeclared named';
+is-deeply (1,2,3).produce(&[+], :zzz).List, (1, 3, 6), 'produce ignores an undeclared named';
+is-deeply (1,1,2).unique(:zzz).List, (1, 2), 'unique ignores an undeclared named';
+is-deeply (1,2,3).map({ $_ * 2 }, :zzz).List, (2, 4, 6), 'map ignores an undeclared named';
+is Date.new(2026, 1, 1).yyyy-mm-dd(:zzz), "2026-01-01", 'yyyy-mm-dd ignores an undeclared named';
+is "/tmp/x".IO.sibling("y", :zzz).Str, "/tmp/y", 'IO::Path.sibling ignores an undeclared named';
+is {a => 1}.classify-list({ $_ }, 1, 2, :zzz).keys.elems, 3,
+    'classify-list ignores an undeclared named';
+
+# Declared adverbs of those same methods must still reach the implementation.
+is-deeply (1, 2, 2.0).unique(as => *.Str).List, (1, 2), 'unique keeps its declared :as';
+is-deeply (1, 2, 2.0).unique(with => &[==]).List, (1, 2), 'unique keeps its declared :with';
+is (1,2).raku(:arglist), "(1, 2)", 'raku keeps its declared :arglist';
+
+# --- Code/Block introspection ----------------------------------------------
+#
+# These have no `%_`-carrying candidate to fall back on, so an undeclared named
+# used to push the call into the "compose a method over a callable" fallback
+# (`(*-*).abs`) and answer a `<composed-method:arity>` Sub.
+
+{
+    my $b = { $_ };
+    is $b.arity(:zzz), $b.arity, 'Code.arity ignores an undeclared named';
+    is $b.count(:zzz), $b.count, 'Code.count ignores an undeclared named';
+    is $b.signature(:zzz).raku, $b.signature.raku, 'Code.signature ignores an undeclared named';
+}
+
+# --- `elems` on an instance is not infinitely recursive --------------------
+#
+# `elems($x)` is defined as `$x.elems`, and the method dispatcher delegated
+# back to it for every `Instance` receiver, so the two bounced until the stack
+# overflowed. (`.elems(:adverb)` reached the same loop through the
+# implicit-`*%_` retry.)
+
+is elems(Date.new(2026, 1, 1)), 1, 'elems() on a plain instance terminates';
+is elems(Blob.new(1, 2, 3)), 3, 'elems() on a Blob answers its length';
+is Blob.new(1, 2, 3).elems(:zzz), 3, 'Blob.elems ignores an undeclared named';
+
 done-testing;

--- a/todo/deep/native-method-accepted-named-declarations.md
+++ b/todo/deep/native-method-accepted-named-declarations.md
@@ -1,79 +1,85 @@
 # Native methods still without a declared set of accepted named arguments
 
-**Narrowed 2026-09-07.** The mechanism this file asked for now exists:
-[ADR-0070](../../docs/adr/0070-native-methods-declare-the-named-arguments-they-accept.md),
-`src/builtins/accepted_nameds.rs`, `scripts/native-method-adverb-survey.raku`
-and `t/native-method-accepted-nameds.t`. Every row of the original measured
-table is fixed. What is left is the residue of the same survey, which needs no
-new design — only more rows.
+**Narrowed again 2026-09-07 (slice 2).** The mechanism is
+[ADR-0070](../../docs/adr/0070-native-methods-declare-the-named-arguments-they-accept.md);
+slice 1 built it and slice 2 drained the measured residue. See
+`news/2026-09/native-method-accepted-nameds-slice-2.md`. What is left is a
+short, *measured* list, none of which is a straightforward "add a row".
 
-## What shipped
+## The measurement
 
-`native_method_accepted_nameds(method) -> Option<&'static [&'static str]>` is
-consulted at the three places the builtin dispatch layer is entered
-(`try_native_method_raw`'s arity cascade, its interpreter-side twin, and
-`dispatch_method_by_name_1/2/3`). A named argument outside a *declared*
-method's set is dropped before an arity is chosen; a method the table does not
-mention is untouched. 29 methods are declared, from a Rakudo signature survey.
-`first` gained the `X::Adverb` validation Rakudo does instead (mirroring the
-`grep` handler), in both the method and the sub form.
+`scripts/native-method-adverb-sweep.raku` is the progress metric: 1 422
+(receiver, method, argument-shape) probes derived from
+`src/builtins/native_method_row_table.rs`, each comparing `R.M(A)` against
+`R.M(A, :qqzz9)`. Run it under the interpreter you want to measure.
 
-A 2 600-probe sweep over `native_method_row_table.rs` went from 754
-not-named-blind probes to 422, with no probe losing named-blindness.
+| | not named-blind, of 1 422 |
+|---|---|
+| mutsu before slice 2 | 78 |
+| mutsu after slice 2 | **18** |
+| `raku` baseline (calls Rakudo itself rejects) | 23 |
+
+`comm`-ing the two `-v` listings is the useful view: only **9** of mutsu's 18
+are mutsu-specific.
 
 ## What is left
 
-### 1. Methods still undeclared, with a measured wrong answer
+### 1. `subst` and `trans` — a real `%_`-read set, not a signature
 
-- **`add` / `remove` on the mutable QuantHashes.** `BagHash.new(1,2,2).add(1,
-  :zzz)` dies with "Too many positionals passed; expected 2 arguments but got 3"
-  where raku answers `Nil`. Rakudo's survey says these accept no named at all,
-  so the row itself is trivial — but the failure does *not* come from either
-  arity cascade or from `dispatch_method_by_name_*`, so adding the row alone
-  does not fix it. Find the handler that raises that arity error (it looks like
-  a class-registered native method with a declared signature) and route it
-  through the same declaration. `grab` is in the same family.
-- **`base(:no-trailing-zeroes)`** is declared, and correctly so, but not
-  implemented: `0.5.base(10, 5, :no-trailing-zeroes)` answers `"0.50000"` where
-  raku answers `"0.5"`. Purely a missing feature now; the adverb reaches the
-  implementation.
+Both read adverbs out of a slurpy, so the Rakudo *signature* survey is only a
+lower bound for them and they are deliberately undeclared:
 
-### 2. Methods whose accepted set Rakudo answers only through `%_`
+- `subst` declares `*%options` (the survey now names the slurpy, so this case is
+  visible rather than silent).
+- `trans` declares nothing but the implicit `*%_` **and still reads `:d`, `:s`
+  and `:c` out of it** — measured, and the reason "the only slurpy is `%_`"
+  cannot be used as a rule.
 
-`scripts/native-method-adverb-survey.raku` reports `**SLURPY**` and nothing else
-for a routine that reads its adverbs out of `%_` rather than declaring
-parameters — `grep`, `first`, `subst`, `trans`, `reduce`, `produce`, `keys`,
-`values`, `kv`, `pairs`, `list`, `Array`. For those the survey is a *lower
-bound*, so they are deliberately absent from the table. Each needs its accepted
-set confirmed by hand against `raku-doc/doc/Type/` before it can be declared.
-(Measured 2026-09-07: none of them currently answers a `:zzz` probe wrongly, so
-this is hardening, not a live bug.)
+Declaring either needs its full adverb set established by hand (roughly
+`match`'s set for `subst`: `:g/:global`, `:x`, `:nth`/`:st`/`:nd`/`:rd`/`:th`,
+`:i`, `:m`, `:s`, `:ov`, `:ex`, `:c`, `:p`, plus `:samecase`/`:samespace`/
+`:samemark` and `:squash`/`:complement`/`:delete` for `trans`). Neither
+currently answers a `:qqzz9` probe wrongly, so this is hardening, not a live
+bug — but it is the one place where getting the row wrong would break a real,
+widely used adverb, so it wants its own slice.
 
-### 3. Unrelated divergences the sweep surfaced
+### 2. Constructors (`new`) are deliberately undeclared
 
-Not named-argument bugs — the *plain* call already differs from raku — but worth
-their own tickets if anyone picks them up:
+`Blob.new(1,2,3).new(:qqzz9)` answers `Blob.new(0)` where raku answers
+`Blob.new()`. A row for `new` would be wrong in general: a constructor takes
+arbitrary nameds (`Foo.new(:a(1))`), and the declaration is consulted at
+entries that a native `new` shares with those. Fixing this needs the `new`
+handlers themselves to distinguish an attribute-initialising named from a
+positional, not a table row.
 
-- `4.roots(2)` answers `(2e0, -2e0)` where raku answers the two complex roots
-  `(<2+0i>, <-2+2.4e-16i>)`.
+### 3. Plain-call divergences the sweep surfaces (not named-argument bugs)
+
+These show up in the sweep only because mutsu's *plain* answer already differs
+from raku, so the `:qqzz9` arm cannot agree with it either:
+
+- `(1,2,3).grep()` / `Any.grep()` / `Any.first(1)` — raku dies "Cannot resolve
+  caller grep(List:D: )"; mutsu answers the receiver (and then reports
+  `X::Adverb` for the adverb arm, which is right for a resolvable call).
+- `Any.values(:qqzz9)` answers `().Seq` where the plain call answers `$()`.
+- `"/tmp".IO.link()` — raku dies "Too few positionals passed"; mutsu has no
+  arity check on the native `IO::Path` arms. The same gap makes
+  `"/tmp".IO.sibling()` answer `"/".IO` instead of dying.
+- `{ $_ }.returns(:qqzz9)` — raku rejects the adverb on `Code.returns`
+  (no `%_` at all); mutsu answers `Mu`. In the "too lax" direction, and the same
+  is true of `of`, `WHAT`, `HOW`, `DEFINITE` and `clone`, which raku also
+  rejects. mutsu implements none of those rejections.
+- `4.roots(2)` answers `(2e0, -2e0)` where raku answers the two complex roots.
 - `(1,2,3).rotor("b")` answers `().Seq` where raku dies "cannot unbox to a
   native integer"; `(1,2,3).AT-POS("b")` answers `Nil` where raku dies.
 - `(1,2,3).splice(1, 1)` reports `X::Immutable` where raku reports
   "Cannot resolve caller".
 
-## Repro for the residue
-
-```
-raku -e 'say BagHash.new(1,2,2).add(1, :zzz).raku; say 0.5.base(10, 5, :no-trailing-zeroes)'
-# Nil / 0.5
-./target/debug/mutsu -e 'say BagHash.new(1,2,2).add(1, :zzz).raku; say 0.5.base(10, 5, :no-trailing-zeroes)'
-# dies / 0.50000
-```
-
 ## Affected files
 
-- `src/builtins/accepted_nameds.rs` (the table — add rows here)
-- `scripts/native-method-adverb-survey.raku` (regenerates the evidence)
-- `t/native-method-accepted-nameds.t` (pins every declared row, and passes
-  under `raku` unmodified)
-- whichever handler raises the `add`/`remove` arity error (not yet located)
+- `src/builtins/accepted_nameds.rs` (the table)
+- `scripts/native-method-adverb-survey.raku` (accepted-name evidence; now
+  reports each named slurpy BY NAME, which is what separates the implicit `*%_`
+  from a declared, read `*%options`)
+- `scripts/native-method-adverb-sweep.raku` (the progress metric)
+- `t/native-method-accepted-nameds.t` (123 assertions; passes under `raku`
+  unmodified)


### PR DESCRIPTION
ADR-0070 slice 2 — the residue of `todo/deep/native-method-accepted-named-declarations.md`.

Slice 1 gave builtin methods a declaration of the named arguments they accept and had the arity cascade drop the rest. This drains the measured residue and, in doing so, corrects two of the ADR's own claims.

## The metric

`scripts/native-method-adverb-sweep.raku` is new — the sweep the ADR described but never shipped as a script. It derives 1 422 (receiver, method, argument-shape) probes from `native_method_row_table.rs` and compares `R.M(A)` with `R.M(A, :qqzz9)`. It runs under any interpreter, so `raku` supplies its own baseline.

| | not named-blind, of 1 422 |
|---|---|
| mutsu, before | **78** |
| mutsu, after | **18** |
| `raku` (calls Rakudo itself rejects) | 23 |

Only 9 of the 18 are mutsu-specific, down from 72.

## Root causes

**1. `elems` on an instance recursed until the stack overflowed.** The sweep could not even run. `builtin_elems` is defined as `$x.elems`, and `dispatch_elems_method` delegates back to `call_function("elems", ...)` — a cycle that terminates only when the inner call is served by the arity cascade. `native_fastpath_receiver_state_guard` deliberately diverts *every* `Instance` receiver's `.elems` away from that cascade (so a `Supply` reaches its own arm), so for any other instance the two bounced forever. Not a named-argument bug at all: `elems(Date.new(2026,1,1))`, `elems(Blob.new(1,2,3))` and `elems(C.new)` for a plain user class all crashed the process on `main`.

**2. The builtin layer has seven entries, not three.** The ADR wired the declaration into the arity cascade, its interpreter twin and `dispatch_method_by_name_1/2/3`. Six further sites dispatch a builtin *before* the cascade:

| site | symptom | raku |
|---|---|---|
| `apply_baghash_mutator` | `BagHash.new(1,2,2).add(1, :zzz)` dies "Too many positionals passed" | `Nil`, element added |
| the `tail` interceptor | `(1,2,3).tail(:zzz)` dies "Cannot use 'zzz\tTrue' as a tail count" | `3` |
| by-value array/hash mutators | `[1,2,3].pop(:zzz)` dies; `%h.push(:zzz)` inserts a `zzz` key | `3`; hash untouched |
| `exec_call_method_mut_op_impl` + `call_method_mut_with_values` | `@a.push(:zzz)` leaves `[1, 2, 3, :zzz]` | `[1, 2, 3]` |
| `call_native_instance_method` + `try_io_path_lexical` | `"/tmp".IO.sibling(:zzz)` builds `IO::Path.new("/zzz\tTrue")` | adverb swallowed |
| compose-a-method-over-a-callable | `{ $_ }.arity(:zzz)` answers a `<composed-method:arity>` **Sub** | `0` |

Each strip is restricted to a receiver that cannot be a user class, so a user method's own named parameter is never at risk (pinned). The compiler's `@a.push(x)` → `ArrayPush` fast path also declines a named call site now — that opcode stores whatever single value it is handed and has no notion of named-ness.

A *positional* `Pair` is still data everywhere (`@a.push((k => 9))`, `rotor(2 => -1)`, a `Pair` in a variable) — named-ness is a call-site property, ADR-0021.

**3. `base(:no-trailing-zeroes)` was declared but not reaching the implementation**, contrary to the ADR's note. The three-argument call matches no arity arm, so the implicit-`*%_` retry dropped the adverb before the 2-ary `base` saw it. `native_base_with_options` is a new interceptor in front of the cascade. The semantics were established over 21 cases against `raku`, and are narrower than they look: the adverb is declared on **`Rational.base` only** (`255.base(16, 4, :no-trailing-zeroes)` is still `"FF.0000"`), and when every fractional digit goes so does the radix point (`1.0` → `"1"`).

## The survey's blind spot, measured

The ticket asked for the `%_`-slurpy family to be confirmed by hand, and that turned out to matter. The survey now reports each named slurpy **by name**, separating the implicit `*%_` from a slurpy the routine declares and reads (`subst`'s `*%options`, `first`'s `*%a`). But that is still only a lower bound: `Str.trans` declares nothing but `*%_` and nevertheless reads `:d`, `:s` and `:c` out of it. So `trans` and `subst` stay undeclared and keep their own ticket; the rest of the family, behaviourally verified against Rakudo, is declared.

38 method names gained an empty accepted set, plus six with a non-empty one (`Str`'s `:subscript`/`:superscript`, `raku`'s `:arglist`, `map`'s six plus hyper's `:batch`/`:degree`, `classify-list`/`categorize-list`'s `:as`, `unique`'s `:as`/`:with`/`:expires`, `Numeric`'s `:fail-or-nil`).

## Gates

- `t/native-method-accepted-nameds.t`: 66 → 123 assertions, and — as before — **the whole file passes unmodified under real `raku`**, so it is a conformance test, not a snapshot.
- Local `make test`: PASS (3 759 files, 39 283 tests).
- Local `make roast`: PASS (1 436 files, 218 962 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
