### PR TITLE
fix(regex): produce conjunction candidates on demand (ADR-0073)

### DIFF
--- a/news/2026-09/regex-conjunction-candidates-are-demand-driven.md
+++ b/news/2026-09/regex-conjunction-candidates-are-demand-driven.md
@@ -1,0 +1,60 @@
+# The conjunction arm is demand-driven too
+
+[ADR-0073](../../docs/adr/0073-regex-atom-candidates-are-produced-on-demand.md)
+slices 1 and 3 made the group, alternation and separated-quantifier boundaries
+continuation-driven: an atom that recurses into a sub-pattern now produces
+candidate *k+1* only once candidate *k* has been rejected by the real
+continuation, so an embedded `{ ... }` block runs once per candidate the engine
+*enters* rather than once per candidate it *computes*. `Conjunction` was left on
+the eager producer and recorded as remaining work.
+
+It is the same defect and the same fix:
+
+```raku
+my $n = 0;
+"aaa" ~~ / ( \w* { $n++ } & \w* ) /;
+say $n;        # rakudo: 1     mutsu (before): 4
+```
+
+`&` / `&&` require every branch to match the **same** substring, so the atom's
+candidates are the first branch's ends that every other branch also reaches. The
+eager arm collected the first branch's whole end set before probing any of them,
+running the blocks inside it once per computed end.
+
+`drive_conjunction_candidates` walks the first branch through a
+`MatchSink::Cont` instead. The other branches keep the eager probe on purpose:
+`regex_match_branch_ending_at` asks a yes/no question about **one** end, so
+there is no candidate set to stream, and raku evaluates them for the end under
+test too. An end that a sibling branch cannot reach is not a candidate at all,
+so a `:ratchet` has nothing to commit to there and the walk continues — the
+ratchet only fires once a candidate has actually been delivered.
+
+## What was verified, not assumed
+
+Every conjunction shape was run under real `raku` and mutsu side by side, and
+all agree:
+
+| shape | result |
+|---|---|
+| `( \w* & \w* )` on `aaa` | `aaa` |
+| `(\w+ & <[a..c]>+)` on `abc` | `abc` |
+| `(\d+ & \w+)` on `abc` | no match |
+| `(\w+) & (\w+)` on `abc` | `abc`, captures from both sides |
+| `( \w+ & \w\w )` on `abcd` | `ab` — the shared end is the shorter branch |
+| `^ [ \w+ & 'abc' ] $` on `abc` | `abc` |
+| `( \w* {B} & \w* ) b` on `aaab` | matches `aaab`, **`B` runs twice** |
+
+The last row is the one that matters for the fix's soundness: the continuation
+rejects the first (longest) end, the walk comes back for the second, and the
+block runs exactly once per end actually entered — rakudo's count, not one and
+not four.
+
+## Gates
+
+`t/regex-lazy-candidate-enumeration.t` grew rows A16b–A16i and its A16
+`todo` marker is gone; the file passes 72/72 under **both** mutsu and `raku`.
+`make test` PASS (3764 files, 39314 tests); full local `make roast` PASS.
+
+ADR-0073's Slice 2 (the `<subrule>` boundary, rows E1/E2/E3/E6) is untouched and
+remains the last collect-then-pick barrier —
+`todo/deep/ordered-alternation-eager-candidate-enumeration.md`.

--- a/src/runtime/regex/regex_match_atom.rs
+++ b/src/runtime/regex/regex_match_atom.rs
@@ -101,7 +101,7 @@ impl Interpreter {
     /// `target_end`. Returns the branch's own captures (relative to an empty
     /// baseline) on success. Used by conjunction (`&` / `&&`) matching, where
     /// every branch must cover the same substring.
-    fn regex_match_branch_ending_at(
+    pub(super) fn regex_match_branch_ending_at(
         &mut self,
         branch: &RegexPattern,
         chars: &[char],

--- a/src/runtime/regex/regex_match_lazy.rs
+++ b/src/runtime/regex/regex_match_lazy.rs
@@ -20,7 +20,7 @@
 //! is what confines the change to the atoms that can contain code.
 
 use super::super::*;
-use super::regex_helpers::{LTM_DECLARATIVE_MODE, alternation_capture_slots};
+use super::regex_helpers::{LTM_DECLARATIVE_MODE, alternation_capture_slots, merge_regex_captures};
 use super::regex_match_core::MatchSink;
 use super::regex_trail::CapStore;
 use std::cell::Cell;
@@ -93,6 +93,11 @@ impl Interpreter {
                         ratchet,
                         on,
                         GroupShape::Isolated,
+                    );
+                }
+                RegexAtom::Conjunction(branches) => {
+                    return self.drive_conjunction_candidates(
+                        branches, chars, pos, store, pkg, ratchet, on,
                     );
                 }
                 RegexAtom::Alternation(alternatives) => {
@@ -199,6 +204,71 @@ impl Interpreter {
             };
             self.regex_walk_ends_in_pkg(
                 pattern,
+                chars,
+                pos,
+                pkg,
+                false,
+                false,
+                &mut MatchSink::Cont(&mut cont),
+            );
+        }
+        unwind
+    }
+
+    /// Drive a `&`/`&&` conjunction: every branch has to match the SAME
+    /// substring, so the atom's candidates are the FIRST branch's ends that
+    /// every other branch also reaches. The eager producer collected the first
+    /// branch's whole end set before probing any of them, which ran the code
+    /// blocks inside it once per computed end (`( \w* {B} & \w* )` on `"aaa"`
+    /// fired `B` four times against raku's one). Driving the first branch
+    /// through a `MatchSink::Cont` instead means end *k+1* is computed only
+    /// once end *k* has been rejected -- either by a sibling branch that cannot
+    /// reach it, or by the real continuation.
+    ///
+    /// The other branches keep the eager probe: `regex_match_branch_ending_at`
+    /// asks a yes/no question about ONE end, so there is no candidate set to
+    /// stream, and raku evaluates them for the end under test too.
+    #[allow(clippy::too_many_arguments)]
+    fn drive_conjunction_candidates(
+        &mut self,
+        branches: &[RegexPattern],
+        chars: &[char],
+        pos: usize,
+        store: &mut CapStore,
+        pkg: &str,
+        ratchet: bool,
+        on: &mut AtomCandidateCont<'_>,
+    ) -> bool {
+        // An empty conjunction matches zero-width, as the eager producer does.
+        let Some((first, rest)) = branches.split_first() else {
+            return on(self, store, pos, RegexCaptures::default());
+        };
+        let mut unwind = false;
+        {
+            let unwind = &mut unwind;
+            let mut cont =
+                |interp: &mut Interpreter, end: usize, first_caps: RegexCaptures| -> bool {
+                    // Raku keeps the captures from EVERY side of `&`, in written
+                    // order -- same merge the eager arm performs.
+                    let mut merged = merge_regex_captures(RegexCaptures::default(), first_caps);
+                    for branch in rest {
+                        match interp.regex_match_branch_ending_at(branch, chars, pos, end, pkg) {
+                            Some(bcaps) => merged = merge_regex_captures(merged, bcaps),
+                            // This end is not a candidate at all, so a ratchet has
+                            // nothing to commit to yet: keep walking.
+                            None => return false,
+                        }
+                    }
+                    if on(interp, store, end, merged) {
+                        *unwind = true;
+                        return true;
+                    }
+                    // Ratchet (`:`) commits to the highest-priority candidate and
+                    // forbids backtracking into the atom.
+                    ratchet
+                };
+            self.regex_walk_ends_in_pkg(
+                first,
                 chars,
                 pos,
                 pkg,

--- a/t/regex-lazy-candidate-enumeration.t
+++ b/t/regex-lazy-candidate-enumeration.t
@@ -8,7 +8,7 @@ use Test;
 # rows that already agreed before the change are just as important as the rows
 # that did not: they are what a laziness change is most likely to break.
 
-plan 64;
+plan 72;
 
 my $c;
 
@@ -62,7 +62,6 @@ todo 'residue: the find scan re-runs the pattern at a position';
 is $c, 1, 'A15 subst runs the block once';
 
 $c = 0; "aaa" ~~ / ( \w* { $c++ } & \w* ) /;
-todo 'ADR-0073: the conjunction arm is still collect-then-pick';
 is $c, 1, 'A16 conjunction runs the block once';
 
 # A17: a `die` in a block on a candidate raku never enters must not abort the
@@ -257,3 +256,25 @@ is ~("a,b,c" ~~ / [ \w+ ] ** 2 % ',' /), 'a,b', 'G2  ** 2 % , chain';
 is ~("a,b,c" ~~ / [ \w+ ] +% ',' /), 'a,b,c', 'G3  +% , chain';
 is (("a,b,c" ~~ / ( \w+ ) ** 1..3 % ',' /)[0].map(~*).join('|')), 'a|b|c',
     'G4  ** 1..3 % , folds each iteration into $0';
+
+# --- A16b: the conjunction's other shapes, all verified against raku ---------
+# The first branch is now walked lazily and the OTHER branches keep the eager
+# yes/no probe (`regex_match_branch_ending_at` asks about one end, so there is
+# no candidate set to stream). These pin that the merge, the priority order and
+# the backtracking into a shorter first-branch match are unchanged.
+
+is ("aaa" ~~ / ( \w* & \w* ) /).Str, 'aaa', 'A16b conjunction of two greedy branches';
+is ("abc" ~~ / (\w+ & <[a..c]>+) /).Str, 'abc', 'A16c a character-class branch';
+nok ("abc" ~~ / (\d+ & \w+) /), 'A16d a branch that cannot match fails the whole conjunction';
+is ("abc" ~~ / (\w+) & (\w+) /).Str, 'abc', 'A16e captures from both sides are kept';
+is ("abcd" ~~ / ( \w+ & \w\w ) /).Str, 'ab', 'A16f the shared end is the shorter branch';
+is ("abc" ~~ /^ [ \w+ & 'abc' ] $/).Str, 'abc', 'A16g anchored conjunction';
+
+{
+    # The continuation rejects the first (longest) end, so the walk comes back
+    # for the second -- and the block runs exactly twice, as raku does.
+    my $n = 0;
+    is ("aaab" ~~ / ( \w* { $n++ } & \w* ) b /).Str, 'aaab',
+        'A16h backtracking into the conjunction still matches';
+    is $n, 2, 'A16i ... and runs the block once per end actually entered';
+}

--- a/todo/deep/ordered-alternation-eager-candidate-enumeration.md
+++ b/todo/deep/ordered-alternation-eager-candidate-enumeration.md
@@ -69,10 +69,13 @@ left-recursive grammar carrying a code block before it is asserted.
 
 ## Also still eager (measured, different mechanisms)
 
-- **Conjunction** (`( \w* {B} & \w* )` on `"aaa"`: raku 1, mutsu 4). The
-  `Conjunction` arm tries the first branch's candidate ends and requires every
-  other branch to end exactly there, so it wants the first branch's set. It is a
-  small, self-contained addition to `for_each_atom_candidate` — the first
-  branch can be driven lazily and the other branches probed per candidate.
+- ~~**Conjunction**~~ **DONE 2026-09-07**
+  (`news/2026-09/regex-conjunction-candidates-are-demand-driven.md`). The first
+  branch is now driven through a `MatchSink::Cont` and the other branches keep
+  the eager yes/no probe (`regex_match_branch_ending_at` asks about ONE end, so
+  there is no candidate set to stream, and raku evaluates them for the end under
+  test too). `( \w* {B} & \w* )` on `"aaa"` went 4 -> 1, matching raku; the
+  backtracking shape `( \w* {B} & \w* ) b` on `"aaab"` stays at raku's 2.
+  Pinned by rows A16-A16i of `t/regex-lazy-candidate-enumeration.t`.
 - The `:g` / `subst` scan and the counted-separator chain bug have their own
   ticket files (see the news entry's Residue section).


### PR DESCRIPTION
## Root cause

[ADR-0073](docs/adr/0073-regex-atom-candidates-are-produced-on-demand.md) slices 1 and 3 made the group, alternation and separated-quantifier boundaries continuation-driven, so an embedded `{ ... }` block runs once per candidate the engine **enters** rather than once per candidate it **computes**. `Conjunction` was left on the eager producer and recorded as remaining work. It is the same defect:

```raku
my $n = 0;
"aaa" ~~ / ( \w* { $n++ } & \w* ) /;
say $n;        # rakudo: 1   mutsu (before): 4
```

`&` / `&&` require every branch to match the **same** substring, so the atom's candidates are the first branch's ends that every other branch also reaches. The eager arm collected the first branch's whole end set before probing any of them.

## The fix

`drive_conjunction_candidates` walks the first branch through a `MatchSink::Cont`. The other branches keep the eager probe **on purpose**: `regex_match_branch_ending_at` asks a yes/no question about *one* end, so there is no candidate set to stream, and raku evaluates them for the end under test too.

An end a sibling branch cannot reach is not a candidate at all, so a `:ratchet` has nothing to commit to there and the walk continues; the ratchet fires only once a candidate has actually been delivered.

## Verified, not assumed

Every conjunction shape run under real `raku` and mutsu side by side — all agree:

| shape | result |
|---|---|
| `( \w* & \w* )` on `aaa` | `aaa` |
| `(\w+ & <[a..c]>+)` on `abc` | `abc` |
| `(\d+ & \w+)` on `abc` | no match |
| `(\w+) & (\w+)` on `abc` | `abc`, captures from both sides |
| `( \w+ & \w\w )` on `abcd` | `ab` — the shared end is the shorter branch |
| `^ [ \w+ & 'abc' ] $` on `abc` | `abc` |
| **`( \w* {B} & \w* ) b` on `aaab`** | matches `aaab`, **`B` runs twice** |

The last row is what decides the fix's soundness: the continuation rejects the first (longest) end, the walk comes back for the second, and the block runs exactly once per end actually entered — rakudo's count, not one and not four.

## Gates

- `t/regex-lazy-candidate-enumeration.t` grew rows A16b–A16i and its A16 `todo` marker is gone; the file passes **72/72 under both mutsu and `raku`**
- `make test` PASS (3764 files, 39314 tests)
- **full local `make roast` PASS** (1436 files, 218962 tests)

ADR-0073's Slice 2 (the `<subrule>` boundary, rows E1/E2/E3/E6) is untouched and remains the last collect-then-pick barrier — `todo/deep/ordered-alternation-eager-candidate-enumeration.md`.