### PR TITLE
docs(todo): the module-private-sub fix is blocked on one measured gap

### DIFF
--- a/todo/deep/module-toplevel-private-sub-leak-cleanup.md
+++ b/todo/deep/module-toplevel-private-sub-leak-cleanup.md
@@ -2,11 +2,9 @@
 
 `require`-ing or `use`-ing a module whose own package-less top-level `sub`
 declaration is NOT `is export`ed still leaves that sub permanently callable,
-bare, from the loading scope after the load finishes -- which raku does not
-do (a package-less top-level `sub name {...}` is lexically scoped to its own
+bare, from the loading scope after the load finishes — which raku does not do
+(a package-less top-level `sub name {...}` is lexically scoped to its own
 compilation unit).
-
-Minimal repro (no deps):
 
 ```
 # HelperMod.rakumod: sub helper() { say "mod helper" }
@@ -14,96 +12,138 @@ $ mutsu -e 'require HelperMod; helper();'
 mod helper                      # raku: compile-time "Undeclared routine: helper"
 ```
 
-`raku -e '...'` for the same source dies at compile time with `Undeclared
-routine: helper`; mutsu prints `mod helper` and exits 0.
+## Attempted and blocked (2026-09-07) — read this before starting again
 
-## Root cause
+A full implementation exists and is **recoverable**: branch
+`fix/module-private-toplevel-sub-compunit-scope`, PR **#7436** (closed, not
+merged — `gh pr diff 7436` for the whole change, +556/-137). It is worth reading
+rather than re-deriving; the design below is sound and only its last mile is
+open.
 
-mutsu always registers a package-less top-level routine under the literal
-`GLOBAL::<name>` function-registry key (see
-`Interpreter::hide_toplevel_global_routines`'s doc comment in
-`src/runtime/builtins_system_require.rs` for the full picture) -- the same
-key any OTHER package-less top-level declaration, including the loading
-scope's own, would use. Nothing currently distinguishes "this routine was
-exported and should reach the importer" from "this routine was merely
-declared, non-exported, and should stay private to its own compunit" at the
-level of what remains reachable after a load finishes.
+### What it built
 
-## Why this is filed separately, not fixed inline
+`runtime/unit_private_routines.rs`: seclusion is a **move, not a delete**. The
+entry leaves the flat `GLOBAL::name` registry and enters
+`Interpreter::unit_private_routines`, keyed by the declaring compunit;
+`unit_private_routine` hands it back only to code compiled in that unit (or in
+an `EVAL` nested inside it) — the same lexical-by-compilation-unit scoping
+`user_declared_infix_ops` already uses, riding the `current_unit` symbol the VM
+maintains.
 
-`fix/require-mod-main-redeclaration` (PR landing alongside this ticket) fixed
-the sibling, acute bug: a same-named package-less top-level routine in the
-requiring script AND the required module raised a false `X::Redeclaration`
-(or silently overwrote the caller's own binding when it didn't). That fix
-added `Interpreter::hide_toplevel_global_routines` /
-`restore_toplevel_global_routines`, which temporarily hide the loading
-scope's own package-less top-level routines while the loaded compunit's body
-runs, then restore them -- this alone is sufficient to stop the collision and
-protect the caller's own bindings, and does not need to know anything about
-export status.
+The delete that every earlier attempt tried cannot work, and the branch says why
+precisely: mutsu resolves a bare routine name through the flat registry, so the
+module's **own** bodies — its exported subs, its classes' methods, its
+`sub EXPORT` — reach their private helpers by the very key a sweep would delete.
+(`import_module`'s existing non-exported sweep is gated on "shadows a core
+builtin" for exactly that reason.)
 
-Fixing (or leaking) a module's own NON-exported top-level routine was
-initially attempted as a bonus generalization of the old `MAIN`-only
-`remove_leaked_main_routines` sweep (delete any newly-registered,
-non-`is export`ed top-level routine after a successful load). That
-generalization repeatedly collided with other ambient/ephemeral top-level
-mechanisms already in the codebase, each discovered only by a full `make
-test` regression after the previous fix:
+Which routines are candidates is made **exact** rather than guessed:
+`hide_toplevel_global_routines` already empties the package-less single-routine
+namespace before the loaded body runs, so whatever occupies it afterwards was
+registered by that body. Seclusion additionally skips `sub EXPORT`, multi
+candidate slots, package-qualified entries, exported names (union of
+`exported_subs` / `unit_module_exported_subs` / `module_owned_exports`),
+`PRELUDE_SUB_TRAIT` routines (NativeCall's ambient `nativecast`/`nativesizeof`),
+`MAIN`, and — added after roast caught it — `our sub name {...}`, which in a
+package-less compunit really *is* a `GLOBAL` stash entry that the loading scope
+legitimately reaches by bare name (discriminated by the pre-existing
+`my_scoped_package_items` marker).
 
-- **`sub EXPORT` itself** (`Interpreter::apply_module_export`) always
-  registers as `GLOBAL::EXPORT`, is never itself `is export`ed, and is
-  read+deleted by `apply_module_export` strictly *after* the module's own
-  `run_block` returns -- a naive sweep deleted it before that call, and
-  `apply_module_export`'s own `EXPORT` invocation commonly reads the
-  module's OTHER private top-level subs too (`sub EXPORT($lang) { ... &greet-fr
-  ... }`, `t/sub-export.t` "EXPORT selects among existing module subs by
-  argument") -- sweeping those before the call also broke it.
-- **NativeCall's prelude helpers** (`nativesizeof`, `nativecast`, `cglobal`,
-  ...) are deliberately spliced as package-less `GLOBAL::` routines into
-  every compunit that uses NativeCall (`PRELUDE_SUB_TRAIT` in
-  `src/runtime/mod.rs`) and are never `is export`ed themselves -- a naive
-  sweep deleted the first module's copy once a LATER, unrelated module
-  finished loading (`t/add-method-qualified-and-invocant.t`,
-  `t/bare-array-type-match.t`).
-- **Multi candidates** are additive across compunits by design (several
-  modules legitimately contribute candidates to the same shared name, e.g. a
-  custom `multi trait_mod:<is>(...) is export` alongside `Test.rakumod`'s
-  own) and export bookkeeping (`exported_subs`) is a per-name *set*, not a
-  per-candidate record, so a before/after diff of it cannot tell "this name
-  was already exported by an earlier module" from "this module's own new
-  candidate happens to share that name" (`roast/integration/advent2011-day14.t`'s
-  `Advent::MetaBoundaryAspect` fixture).
+Two independent pre-existing bugs it fixed on the way, both worth salvaging
+separately if this stays parked:
 
-Each fix widened the exemption list without any confidence the list was now
-exhaustive. Rather than keep discovering ambient mechanisms case-by-case
-under `make test`, the generalization was reverted: `remove_leaked_main_routines`
-stays scoped to `MAIN` only (the one name whose leak has a distinct, narrow
-safety concern -- an un-exported leaked `MAIN` candidate must never remain
-reachable at the dispatchable auto-dispatch key), and this repro is left
-unfixed. See `news/2026-08/require-toplevel-routine-scoped-to-compunit.md`
-for the full writeup of what shipped and what did not.
+- the name-keyed call caches (`pos_light_call_cache`, `light_call_cache`,
+  `otf_call_cache`, `func_multi_resolve_cache`, `fn_resolve_cache`) are keyed by
+  `(name, package)` and cannot represent a winner that depends on which unit is
+  asking;
+- `call_compiled_function_positional_light_at`'s return-type-check failure path
+  returned **without restoring `current_unit`** — a leak that also mis-scoped
+  user-declared operators.
 
-## What a real fix needs
+### What blocks it
 
-An exhaustive audit of every mechanism that installs a package-less
-`GLOBAL::<name>` function-registry entry outside of an ordinary user
-`sub`/`multi sub` declaration, so a leak-sweep can positively identify "this
-is one of the known persistent/ambient kinds, never touch it" rather than
-guessing from a `newly-registered && not is-export` heuristic that keeps
-being wrong. Candidates to grep for: `PRELUDE_SUB_TRAIT`, `EXPORT`-shaped
-runtime hooks (`EXPORTHOW`, `sub EXPORT`), anything the compiler/registration
-path treats as "GLOBAL regardless of package" by convention rather than by
-explicit `unit module`/`package` declaration. Once that list is closed, the
-same `remove_leaked_toplevel_routines` shape this ticket's PR tried (diff of
-`exported_subs` before/after a specific load, scoped to package-less single
-routines, explicitly excluding known-ambient names) should work.
+The bundled-battery gate regressed 12 whitelisted files: ten `Cro::HTTP`
+(`http-auth-basic`, `http-auth-basic-with-session`, `http-auth-webtoken-bearer`,
+`http-auth-webtoken-cookie`, `http-log-file`, `http-middleware`,
+`http-router-plugin`, `http-session-inmemory`, `http-session-persistent`,
+`router-auth`), `IO::Socket::Async::SSL bad-incoming`, and
+`zef distribution-depends-parsing`. Reproduced locally, identically.
 
-## Impact
+The Cro symptom is `Unknown function: wrap-response-logging`, raised from
+`Cro::HTTP::Middleware`'s
 
-Narrow in practice: the leaked routine is only reachable if the caller
-happens to call it bare by the exact same name the module used internally,
-and roast's own suite did not surface this as a failure (no whitelisted file
-regressed from leaving it unfixed). It is nonetheless a genuine
-lexical-scoping divergence from raku, and the same root mechanism as the
-already-recorded (fixed, but only for the module-vs-module direction)
-cross-module-private-sub-redeclaration finding.
+```raku
+supply whenever wrap-response-logging($!middleware, $pipeline, {...}) -> $response { ... }
+```
+
+where `wrap-response-logging` is a package-less private top-level sub of that
+very module.
+
+Reduced to a self-contained probe (`t/lib`-style module plus a script):
+
+```raku
+# Mod.rakumod (package-less)
+sub helper($x) { "helped-$x" }
+sub tap-from-sub(Supply $in) is export { my @g; $in.tap(-> $v { @g.push(helper($v)) }); @g }
+```
+
+```
+sub + .tap callback          -> Unknown function: helper     (raku: works)
+method + .tap callback       -> Unknown function: helper     (raku: works)
+supply/whenever body         -> QUIT: Unknown function: helper
+plain block called directly  -> works
+`start { helper(...) }`      -> works
+`.map({ helper(...) })`      -> works
+role method calling it       -> works
+loading scope calling it     -> correctly refused
+```
+
+**So the blocker is one specific gap: a block handed to a NATIVE callback taker
+does not enter its declaring compilation unit when it is finally invoked.**
+`.tap` is such a taker, and every `supply`/`whenever` body is one. The closure
+creation sites are innocent — `MakeAnonSub` and `MakeAnonSubParams` both already
+stamp `source_file: self.executing_source_file()` — and
+`call_compiled_closure_with_topic` already enters
+`unit_of_source(data.source_file)`. The tap callback simply is not invoked
+through that path: the supply machinery calls it through the generic code-object
+entry (`call_sub_value` / `SupplierEmitAction::Call`), which never touches
+`current_unit`.
+
+### What closing it needs
+
+Making the generic code-object invocation enter the callee's unit. That is a
+real change, not a patch: `call_sub_value` is ~1000 lines with many early
+returns (so it needs a save/restore wrapper, not an inline assignment), it is
+the hottest generic call entry in the interpreter, and `current_unit` is *also*
+what `user_declared_infix_ops` resolves against — so setting it there changes
+operator scoping for every closure call in the program, which has to be measured
+(full `make test`, full `make roast`, and the battery gate) rather than assumed.
+
+Possible narrower shapes to weigh first:
+
+- stamp the declaring unit on the code object itself (a `decl_unit: Option<Symbol>`
+  on `SubData`, set from `executing_source_file()` at the two creation arms) and
+  read it wherever a code object is invoked, instead of threading `current_unit`
+  through the generic entry. 23 `SubData {` construction sites, but one central
+  `Value::new_code_object` helper covers most of them.
+- enter the unit only in the supply/tap emit path, which is where the measured
+  regressions live — narrower, but leaves the same hole for every other native
+  callback taker, so it would need a survey of those first.
+
+**Do not restart from the sweep-and-delete design.** It is disproved, and the
+branch above documents why.
+
+## Gates any retry must pass
+
+`make test`, full `make roast`, and — the one that caught this —
+`scripts/battery-testsuite.sh`, run **alone** (two battery gates in a shared
+workdir produce a false REGRESSION). The 12 files above are the acceptance set.
+The pin for the feature itself is `t/module-private-sub-does-not-leak.t` with
+`t/lib/PrivateSubMod.rakumod` (10 assertions, each verified against Rakudo), on
+the closed branch.
+
+## Related, filed separately
+
+`todo/tickets/qualified-call-falls-back-to-bare-global-routine.md` —
+`Pkg::name(...)` falls back to a bare `GLOBAL::name` even when `Pkg` does not
+exist. Found while working this; independent of it.

--- a/todo/tickets/qualified-call-falls-back-to-bare-global-routine.md
+++ b/todo/tickets/qualified-call-falls-back-to-bare-global-routine.md
@@ -1,0 +1,44 @@
+# A package-qualified call falls back to a bare `GLOBAL::` routine of the same short name
+
+`Pkg::name(...)` resolves to `GLOBAL::name` when `Pkg` declares no such
+routine -- even when `Pkg` does not exist at all. Rakudo raises
+`Could not find symbol '&name' in 'GLOBAL::Pkg'`.
+
+Minimal repro (no modules involved):
+
+```
+$ mutsu -e 'sub zzz($n) { $n + 1 }; say NoSuchPkg::zzz(1);'
+2
+$ raku  -e 'sub zzz($n) { $n + 1 }; say NoSuchPkg::zzz(1);'
+Could not find symbol '&zzz' in 'GLOBAL::NoSuchPkg'
+```
+
+## Where it comes from
+
+`Interpreter::resolve_function_with_types`' qualified branch
+(`src/runtime/dispatch_resolve.rs`) ends by falling through to the bare-name
+machinery once every `Pkg::name`-shaped probe misses. `fn_keys_for_base`
+reduces `Pkg::name` to the base name `name`, so the candidate gather that
+follows is keyed on the short name and can hand back a routine that lives in a
+completely different package. The `qualified_name_hidden_here` gate above it
+only hides `my`-scoped package items; it does not assert that the resolved
+candidate actually belongs to the named package.
+
+## Why it matters
+
+It is a silent wrong-routine dispatch, not just a missing error: a typo'd or
+stale package qualifier calls the caller's own same-named routine and returns a
+plausible answer. It also makes an otherwise good assertion untestable --
+`t/module-private-sub-does-not-leak.t` wanted to pin "a compunit-private
+routine is not reachable as `Mod::name`" and could not, because the script's own
+`sub secret-helper` answered the qualified call.
+
+## Shape of the fix
+
+After the qualified probes fail, verify that whatever the fallback resolved
+actually has `def.package` equal to (or an ancestor-visible alias of) the
+requested package, and otherwise raise the `X::NoSuchSymbol`-shaped error the
+stash path already produces (`Could not find symbol '&name' in 'GLOBAL::Pkg'`).
+Expect fallout in tests that lean on the sloppy fallback -- the qualified path
+is also how a `unit module`'s own `our sub` is reached in several shapes -- so
+this needs a full `make test` + `make roast` pass, not a spot check.


### PR DESCRIPTION
An implementation of `todo/deep/module-toplevel-private-sub-leak-cleanup.md` exists on `fix/module-private-toplevel-sub-compunit-scope` (#7436) and regressed **12 whitelisted bundled-battery files** — ten `Cro::HTTP`, plus `IO::Socket::Async::SSL bad-incoming` and `zef distribution-depends-parsing`. Reproduced locally, identically. This rewrites the ticket around what that measured, so the next attempt starts from the blocker rather than from the design.

## The design is sound and worth reading

Seclusion is a **move** out of the flat `GLOBAL::name` registry into a table keyed by the declaring compunit, not a delete — a delete cannot work, because the module's *own* bodies (its exported subs, its classes' methods, its `sub EXPORT`) reach their private helpers by the very key a sweep would remove. The candidate set is made *exact* by the pre-existing `hide_toplevel_global_routines` rather than guessed. `gh pr diff 7436` has the whole thing (+556/−137).

## The blocker, reduced to a probe

**A block handed to a NATIVE callback taker does not enter its declaring compilation unit when it is finally invoked.** `.tap` is such a taker, and every `supply`/`whenever` body is one — which is exactly Cro's

```raku
supply whenever wrap-response-logging($!middleware, $pipeline, {...}) -> $response { ... }
```

failing with `Unknown function: wrap-response-logging`, a package-less private top-level sub of that same module.

With a package-less module declaring `sub helper($x)`:

| shape | result |
|---|---|
| sub + `.tap` callback | **Unknown function: helper** (raku: works) |
| method + `.tap` callback | **Unknown function: helper** (raku: works) |
| `supply`/`whenever` body | **QUIT: Unknown function: helper** |
| plain block called directly | works |
| `start { helper(...) }` | works |
| `.map({ helper(...) })` | works |
| role method calling it | works |
| loading scope calling it | correctly refused |

The closure creation sites are innocent — `MakeAnonSub` and `MakeAnonSubParams` both already stamp `source_file: self.executing_source_file()` — and `call_compiled_closure_with_topic` already enters `unit_of_source(data.source_file)`. The tap callback is simply not invoked through that path: the supply machinery goes through the generic code-object entry, which never touches `current_unit`.

## What closing it needs

Entering the callee's unit at the generic code-object invocation. That is a real change, not a patch: `call_sub_value` is ~1000 lines with many early returns (so it needs a save/restore wrapper), it is the hottest generic call entry, and `current_unit` is *also* what `user_declared_infix_ops` resolves against — so setting it there changes operator scoping for every closure call and has to be measured, not assumed. The ticket records two narrower shapes to weigh first.

## Also preserved

- the two independent pre-existing bugs the branch fixed on the way (the `(name, package)`-keyed call caches that cannot represent a unit-dependent winner; `call_compiled_function_positional_light_at` returning without restoring `current_unit`), so they can be salvaged separately;
- the 12-file battery acceptance set, and the reminder that `scripts/battery-testsuite.sh` must run **alone**;
- **`todo/tickets/qualified-call-falls-back-to-bare-global-routine.md`, salvaged onto `main`** — it only existed on the closed branch. Re-verified: `mutsu -e 'sub zzz($n) {$n+1}; say NoSuchPkg::zzz(1)'` answers `2` where raku raises `Could not find symbol '&zzz' in 'GLOBAL::NoSuchPkg'`.

Documentation only — the five build jobs skip by design (`scripts/ci-docs-only.sh`).