### PR TITLE
perf(dispatch): stop merging back the env entries a method never changed

### DIFF
--- a/news/2026-09/method-env-merge-skips-unchanged-inherited-entries.md
+++ b/news/2026-09/method-env-merge-skips-unchanged-inherited-entries.md
@@ -1,0 +1,90 @@
+# A method's env merge stops re-writing 26 entries it never changed
+
+Third slice off `todo/perf/adr0019-g3-diffuse-bless-allocation-cost.md`, and the second one
+found by pointing `alloc_scope!` at a region rather than guessing what was in it. The
+ticket's own next-item list turned out to be wrong about one item and right about another;
+this entry records both.
+
+## The item that was misdiagnosed
+
+The ticket named `bless:named-args` (11 allocations per `bless` on `benchmarks/bench-ctor.raku`)
+and proposed a cause: an O(attrs x args) linear scan over `plan.class_attrs` that wanted an
+index. Splitting that loop into sub-scopes attributed **all 11 allocations to the `%`-sigil
+attribute coercions and exactly zero to anything else** — not the scan, not the
+`attributes.insert`, not the `deferred_defaults.retain`. Indexing the scan would have
+bought nothing.
+
+The real cause is that `HashData::map` is a `HashMap<String, Value>`, so copying a hash
+allocates one `String` per key. Confirmed by scaling: constructing an object with one `%`
+attribute 1000 times costs 58,512 allocations with a 1-key hash and 67,508 with a 10-key
+one — exactly one allocation per extra key per copy. That is a structural property of
+mutsu's hash representation, not a `bless` problem, and the fix (an `Arc<str>` or interned
+key type) touches every site naming `HashMap<String, Value>`. Filed as
+`todo/deep/hash-copy-allocates-a-string-per-key.md` with the measurements and the
+"measure before building it" caveat, rather than forced into an undersized fix here.
+
+## The item that was real: `mfast:epilogue`
+
+The compiled method-call epilogue cost 4.9 allocations and 815 bytes per call. Sub-scoping
+it put 3.5 of those in the env-restore branch, and 4.0 per merging call inside
+`merge_method_env` itself.
+
+A temporary probe printing the merged key set answered why. `submethod TWEAK(:$!spec) { }`
+— an empty body — merged **26 entries** back into its caller on every single call:
+
+```
+*CWD  *TMPDIR  @*ARGS  ?FILE  $*OUT  $*ERR  *IN  *PROGRAM-NAME  $*CWD  $*TMPDIR
+Dist  *SCHEDULER  *HOME  %*ENV  *OUT  *REPO  $*IN  *PROGRAM  *ARGFILES  Spec
+$*HOME  *ERR  Any  d  $*ARGFILES  =pod
+```
+
+None of them is a write. They are there for the reason a comment a few lines below already
+gave: a nested method call flattens the scoped overlay, copying every parent
+lexical/global into the callee's overlay, so the merge sees them as callee-overlay entries
+and — because the caller has the same key — keeps them. Each one was then re-inserted into
+the caller env, paying for the `writes` Vec and for the caller overlay's `cow_mut` clone.
+
+The `changed_caller_locals` scan right below already computed the answer for a subset of
+these: `cheaply_unchanged(old, v)`, an O(1) conservative identity test that only returns
+true when it can *prove* the values are the same. If it proves them the same, re-inserting
+is a no-op. So the collect now drops such an entry outright:
+
+```rust
+if saved.get_sym(*k).is_some_and(|old| cheaply_unchanged(old, v)) {
+    return None;
+}
+```
+
+This cannot change `changed_caller_locals`, which pushes a key only when `saved.get_sym` is
+absent or `cheaply_unchanged` is false — exactly the entries the new test keeps. Nor can it
+change what the caller observes: a container the callee mutated in place keeps its `Gc`
+identity, so the caller already points at the mutated container and the merge was a no-op
+for it before too.
+
+## Measurements
+
+Allocations (`--features alloc-stats`, exact and load-independent), `bench-ctor`:
+
+| | before | after |
+| --- | --- | --- |
+| `mfast:epilogue` per method call | 4.9 allocations / 815 bytes | 2.2 / 205 |
+| whole program | 1,444,372 allocations / 111.4 MB | 1,404,374 / 102.2 MB (-2.8% / -8.2%) |
+
+Order-swapped wall-clock A/B, `MUTSU_JIT=off`, min-of-13 then min-of-11, both binaries
+built from the same tree:
+
+| benchmark | round 1 (new first / base first) | round 2 (new first / base first) |
+| --- | --- | --- |
+| `bench-ctor` | -3.6% / -2.8% | -3.5% / -5.9% |
+| `bench-class` | -2.0% / -4.1% | — |
+| `method-call` | -8.3% / -8.1% | -2.4% / +6.3% |
+| `bench-fib` | — | -9.0% / -14.5% |
+| `poly-call` | — | -0.3% / -0.4% |
+| `bench-yaml-parse` | — | +0.6% / -9.8% |
+
+`bench-ctor` and `bench-fib` are consistent in every order; `method-call`'s second round
+flips sign, so treat it as no worse than flat. Nothing regresses consistently.
+
+`t/method-env-merge-unchanged-globals.t` pins the semantics the skip must not break: a
+method that genuinely writes a caller lexical, a dynamic, and a global still propagates it,
+and one that only reads them does not disturb the caller.

--- a/src/vm/vm_method_dispatch.rs
+++ b/src/vm/vm_method_dispatch.rs
@@ -2365,6 +2365,26 @@ fn merge_method_env(
             }) {
                 return None;
             }
+            // An entry the callee overlay merely *inherited* would merge back a
+            // value the caller already holds. A nested method call flattens the
+            // scoped overlay, copying every parent lexical/global into the
+            // callee's (the same reason the `changed_caller_locals` scan below
+            // exists), so `submethod TWEAK(:$!spec) { }` -- an empty body --
+            // collected 26 of these on every call: `%*ENV`, `@*ARGS`, `$*OUT`,
+            // `$*CWD`, the type names in scope, `=pod`, and the caller's own
+            // lexicals. Re-inserting a value `cheaply_unchanged` proves identical
+            // is a no-op, so drop it here instead: it keeps the `writes` Vec
+            // empty and spares the caller env's `cow_mut` overlay clone.
+            //
+            // This cannot change `changed_caller_locals`: that scan pushes a key
+            // only when `saved.get_sym(k)` is absent or `cheaply_unchanged` is
+            // false, i.e. exactly the entries this test keeps.
+            if saved
+                .get_sym(*k)
+                .is_some_and(|old| cheaply_unchanged(old, v))
+            {
+                return None;
+            }
             let keep = saved.contains_key_sym(*k)
                 || (k.starts_with("&") && !k.starts_with("&?"))
                 || k.starts_with("__mutsu_method_value::")

--- a/t/method-env-merge-unchanged-globals.t
+++ b/t/method-env-merge-unchanged-globals.t
@@ -1,0 +1,59 @@
+use Test;
+
+# A method's exit merges its env writes back into the caller. A nested call
+# flattens the scoped overlay, so the callee's overlay also carries every
+# parent lexical/global it never touched; those are dropped from the merge when
+# `cheaply_unchanged` proves them identical. These pin what the merge must still
+# propagate, so the skip can never grow into a dropped write.
+
+plan 10;
+
+our $pkg-var = 'pkg-before';
+my $outer = 'outer-before';
+my @outer-list = 1, 2;
+my %outer-map = a => 1;
+
+class W {
+    has $.n is rw;
+    method touch-outer() { $outer = 'outer-after' }
+    method touch-pkg() { $pkg-var = 'pkg-after' }
+    method touch-dynamic() { $*dyn = 'dyn-after' }
+    method push-list() { @outer-list.push(3) }
+    method store-map() { %outer-map<b> = 2 }
+    method read-only() { return $outer.chars }
+    method sets-attr() { $!n = 42 }
+}
+
+my $w = W.new(n => 0);
+
+is $w.read-only(), 12, 'a method that only reads a caller lexical returns the right value';
+is $outer, 'outer-before', '...and leaves it alone';
+
+$w.touch-outer();
+is $outer, 'outer-after', 'a method writing a caller lexical still propagates';
+
+$w.touch-pkg();
+is $pkg-var, 'pkg-after', 'a method writing an `our` package variable still propagates';
+
+{
+    my $*dyn = 'dyn-before';
+    $w.touch-dynamic();
+    is $*dyn, 'dyn-after', 'a method writing a dynamic still propagates';
+}
+
+$w.push-list();
+is @outer-list.join(','), '1,2,3', 'an in-place push on a caller array is visible';
+
+$w.store-map();
+is %outer-map<b>, 2, 'an in-place store into a caller hash is visible';
+
+$w.sets-attr();
+is $w.n, 42, 'an attribute write inside a method survives the merge';
+
+# The construction path: TWEAK at two MRO levels, whose frames carry the whole
+# global overlay and write only attributes.
+class Base { has $.a; submethod TWEAK(:$!a) { } }
+class Kid is Base { has $.b; submethod TWEAK(:$!b) { } }
+my $k = Kid.new(a => 'x', b => 'y');
+is $k.a ~ $k.b, 'xy', 'TWEAK at two MRO levels binds both attributes';
+is $outer, 'outer-after', 'constructing through TWEAK does not disturb a caller lexical';

--- a/todo/deep/hash-copy-allocates-a-string-per-key.md
+++ b/todo/deep/hash-copy-allocates-a-string-per-key.md
@@ -1,0 +1,81 @@
+# Copying a Hash allocates one `String` per key
+
+Every value-copy of a mutsu `Hash` costs one heap allocation per key, because
+`HashData::map` is a `HashMap<String, Value>` and `HashMap::clone` deep-clones each
+`String` key. Raku assignment semantics make hash copies routine — `%a = %b`, binding a
+`%` parameter, storing into a `%` attribute — so this is a broad, structural cost, not a
+local one.
+
+## How it was found
+
+`todo/perf/adr0019-g3-diffuse-bless-allocation-cost.md` listed `bless:named-args` (11
+allocations per `bless` on `benchmarks/bench-ctor.raku`) as its next item, and guessed the
+cause: "each supplied named argument does a linear `plan.class_attrs.iter().position(...)`
+scan and then a `coerce_provided_attr_value_by_sigil` clone. The scan is O(attrs x args) on
+a 20-attribute class; an index on the plan would make it O(args)."
+
+That guess was wrong, and `alloc_scope!` says so exactly. Splitting the loop into
+sub-scopes attributes **all 11 allocations to the `%`-sigil coercions and none to anything
+else**:
+
+```
+bless:named-args:coerce-hash     10000  55000 allocs  4730000 bytes   5.5 / entry
+bless:named-args:coerce-scalar   25000      0                         0.0
+bless:named-args:insert          35000      0                         0.0
+bless:named-args:retain          35000      0                         0.0
+```
+
+The linear scan, the `attributes.insert`, and the `deferred_defaults.retain` allocate
+nothing at all. Indexing the scan would have bought zero.
+
+`bench-ctor` supplies two `%` attributes per construction: `provides` (1 key) and
+`:meta(%_)` (6 keys). `coerce_provided_attr_value_by_sigil` sends both through
+`Value::detached_container_copy`, which is `Gc::new((**arc).clone())` on the `HashData`.
+That is 1 table + 1 Gc box + one `String` per key:
+
+- 1-key hash: 1 + 1 + 1 = 3
+- 6-key hash: 1 + 1 + 6 = 8
+- total 11 — exactly the measured figure.
+
+Confirmed independently by scaling: a 1000-iteration loop constructing an object with one
+`%` attribute costs 58,512 allocations when the hash has 1 key and 67,508 when it has 10 —
+**+8,996 for 9 extra keys x 1000 constructions, i.e. exactly one allocation per key per
+copy.**
+
+## Why it is deep, not a ticket
+
+The fix is to make the key type cheap to clone: `Arc<str>`, `Box<str>` plus interning, or
+the existing `Symbol`. Any of those touches `HashData::map` and therefore every
+construction, iteration, subscript and coercion site that names `HashMap<String, Value>` —
+a very large surface, with knock-on questions of its own:
+
+- **Which type.** `Symbol` is the cheapest to clone and already exists, but hash keys are
+  arbitrary runtime strings, so interning every one of them grows the global symbol table
+  without bound (a hash built from user input would leak). `Arc<str>` clones in O(1)
+  without that risk and is the likelier answer.
+- **Object hashes.** `original_keys: Option<HashMap<String, Value>>` is keyed by `.WHICH`
+  strings and has the same shape and the same problem.
+- **Borrowing.** Lookups today take `&str` freely via `HashMap<String, _>`'s `Borrow`
+  impl. `Arc<str>` keeps that (`Borrow<str>` holds), but any code that constructs a key by
+  `to_string()` and inserts needs auditing to avoid re-introducing the allocation at the
+  insert site.
+
+## What it would be worth
+
+On `bench-ctor` it is 11 of ~1.40M allocations per 5000 constructions (a rounding error
+there — the two hashes are small). The real prize is anywhere hashes are large or copied in
+a loop: `%_` slurpy materialization, hash-valued parameter binds, `%h = %g`, and the
+JSON/YAML/META6 workloads whose whole shape is "build a big hash, copy it".
+
+**Measure before committing to it.** A cheap first estimate: instrument
+`HashData::clone`/`detached_container_copy` with an `alloc_scope!` and run
+`benchmarks/bench-hash.raku`, `bench-yaml-parse.raku` and the zef `Ecosystems` populate
+path. If hash copying is not a material share there, this stays filed and unbuilt.
+
+## Also worth noting
+
+`benchmarks/bench-ctor.raku`'s `method new(*%_) { self.bless(|%_, :meta(%_)) }` pays the
+per-key cost at least twice per construction: once when `implicit_method_named_slurpy`
+builds `%_`, and again when `:meta(%_)` copies it into the attribute. That is the
+benchmark's own code shape (it mirrors `Zef::Distribution`), not a bug — but it is why this
+one benchmark shows the cost at all.

--- a/todo/perf/adr0019-g3-diffuse-bless-allocation-cost.md
+++ b/todo/perf/adr0019-g3-diffuse-bless-allocation-cost.md
@@ -248,21 +248,37 @@ The `alloc_scope!` report on `benchmarks/bench-ctor.raku` after that fix reads:
 | `mfast:body` (exclusive) | 40.7 per method call |
 | `bless:named-args` | 11.0 per bless |
 | `bless:attr-defaults` | 5.0 per bless |
-| `mfast:epilogue` | 4.9 per method call |
+| `mfast:epilogue` | 4.9 per method call (now 2.2) |
 | `mfast:slurpy-captures-locals` | 4.0 per method call |
 | `mfast:env-setup` | 2.7 per method call |
 | `mfast:param-bind` | 2.3 per method call |
 | `mfast:prologue` | 1.7 per method call |
 
-- **`bless:named-args`, 11 allocations per bless** (`dispatch_bless`'s override loop in
-  `runtime/methods_dispatch_new.rs`). Each supplied named argument does a linear
-  `plan.class_attrs.iter().position(...)` scan and then a `coerce_provided_attr_value_by_sigil`
-  clone. The scan is O(attrs x args) on a 20-attribute class; an index on the plan would make it
-  O(args), and the clone is worth checking for a no-op sigil case that can skip it.
-- **`mfast:epilogue`, 4.9 per method call.**
+- ~~**`bless:named-args`, 11 allocations per bless**~~ — **misdiagnosed, closed out.** The guess
+  recorded here was an O(attrs x args) linear scan over `plan.class_attrs` wanting an index.
+  Sub-scoping the loop attributes all 11 allocations to the `%`-sigil attribute coercions and
+  **zero** to the scan, the `attributes.insert` or the `deferred_defaults.retain`; indexing would
+  have bought nothing. The real cause is that `HashData::map` is a `HashMap<String, Value>`, so a
+  hash copy allocates one `String` per key (verified by scaling: +1 allocation per extra key per
+  copy). That is structural, not a `bless` problem — filed as
+  `todo/deep/hash-copy-allocates-a-string-per-key.md`.
+- ~~**`mfast:epilogue`, 4.9 per method call**~~ — **fixed** (2026-09-06,
+  `news/2026-09/method-env-merge-skips-unchanged-inherited-entries.md`). A probe on the merged key
+  set showed `submethod TWEAK(:$!spec) { }` merging 26 entries back into its caller on every call —
+  `%*ENV`, `@*ARGS`, `$*OUT`, `$*CWD`, type names, `=pod`, the caller's own lexicals — none of them
+  a write; a nested call flattens the scoped overlay, so the callee's overlay carries every parent
+  global. `merge_method_env` now drops an entry `cheaply_unchanged` proves identical to what the
+  caller already holds, which keeps the `writes` Vec empty and spares the caller env's `cow_mut`
+  overlay clone. `mfast:epilogue` 4.9 -> 2.2 allocations per call (815 -> 205 bytes); whole program
+  -2.8% allocations, -8.2% bytes.
 - **The residual 4.0 in `mfast:slurpy-captures-locals`**, which is now the locals-init loop alone:
   the `vec![Value::NIL; cc.locals.len()]` plus a `format!("{}\0{}", owner_class, attr_name)`
   built per private-attribute local per call. The format could reuse one scratch `String` across
-  the loop.
+  the loop. Note the lesson above before assuming this is where the cost is: **sub-scope the region
+  with `alloc_scope!` first**, both remaining guesses in this list were checked that way and one was
+  wrong.
+- **`mfast:body`, 40.7 per method call exclusive** — now by far the largest region, and entirely
+  unexamined. It is the bytecode execution itself, so it needs sub-scoping by opcode family before
+  anything can be said about it.
 - Re-run the 7/31-vs-HEAD A/B from the top of this ticket, or read the bench-CI trend, to see how
   much of the original drift these have now closed.


### PR DESCRIPTION
Third slice off `todo/perf/adr0019-g3-diffuse-bless-allocation-cost.md` (ADR-0019 G3), and the second one found by pointing `alloc_scope!` at a region instead of guessing what was in it. The ticket's next-item list turned out to be wrong about one item and right about another; this PR handles both.

## The item that was real: `mfast:epilogue`

The compiled method-call epilogue cost 4.9 allocations and 815 bytes per call. Sub-scoping it put 3.5 of those in the env-restore branch, and 4.0 per merging call inside `merge_method_env` itself.

A temporary probe on the merged key set said why. `submethod TWEAK(:$!spec) { }` — an empty body — merged **26 entries** back into its caller on every single call:

```
*CWD  *TMPDIR  @*ARGS  ?FILE  $*OUT  $*ERR  *IN  *PROGRAM-NAME  $*CWD  $*TMPDIR
Dist  *SCHEDULER  *HOME  %*ENV  *OUT  *REPO  $*IN  *PROGRAM  *ARGFILES  Spec
$*HOME  *ERR  Any  d  $*ARGFILES  =pod
```

None of them is a write. They are there for the reason a comment a few lines below already gave: a nested method call flattens the scoped overlay, copying every parent lexical/global into the callee's, so the merge sees them as callee-overlay entries and keeps them because the caller has the same key. Each was then re-inserted into the caller env, paying for the `writes` Vec and for the caller overlay's `cow_mut` clone.

The `changed_caller_locals` scan right below already computed the answer for a subset of these: `cheaply_unchanged`, an O(1) conservative identity test that returns true only when it can *prove* the two values are the same. If it proves them the same, re-inserting is a no-op, so the collect drops such an entry outright:

```rust
if saved.get_sym(*k).is_some_and(|old| cheaply_unchanged(old, v)) {
    return None;
}
```

**Why this is safe.** It cannot change `changed_caller_locals`, which pushes a key only when `saved.get_sym` is absent or `cheaply_unchanged` is false — exactly the entries the new test keeps, so the `env_dirty` signal and the Slice F write-through are bit-for-bit unchanged. Nor can it change what the caller observes: a container the callee mutated in place keeps its `Gc` identity, so the caller already points at the mutated container and the merge was a no-op for it before too.

## The item that was misdiagnosed: `bless:named-args`

The ticket named this (11 allocations per `bless`) and proposed a cause: an O(attrs x args) linear scan over `plan.class_attrs` wanting an index. Sub-scoping the loop attributes **all 11 allocations to the `%`-sigil coercions and exactly zero to the scan, the `attributes.insert`, or the `deferred_defaults.retain`**:

```
bless:named-args:coerce-hash     10000  55000 allocs   5.5 / entry
bless:named-args:coerce-scalar   25000      0          0.0
bless:named-args:insert          35000      0          0.0
bless:named-args:retain          35000      0          0.0
```

Indexing the scan would have bought nothing. The real cause is that `HashData::map` is a `HashMap<String, Value>`, so a hash copy allocates one `String` per key — confirmed by scaling (1-key vs 10-key hash: exactly +1 allocation per extra key per copy). That is structural, touching every site naming `HashMap<String, Value>`, so it is filed as `todo/deep/hash-copy-allocates-a-string-per-key.md` with the measurements and a "measure before building it" caveat, rather than forced into an undersized fix here.

## Measurements

Allocations (`--features alloc-stats`, exact and load-independent), `benchmarks/bench-ctor.raku`:

| | before | after |
| --- | --- | --- |
| `mfast:epilogue` per method call | 4.9 allocations / 815 bytes | 2.2 / 205 |
| whole program | 1,444,372 allocations / 111.4 MB | 1,404,374 / 102.2 MB (**-2.8% / -8.2%**) |

Order-swapped wall-clock A/B, `MUTSU_JIT=off`, min-of-13 then min-of-11, both binaries built from the same tree:

| benchmark | round 1 (new first / base first) | round 2 (new first / base first) |
| --- | --- | --- |
| `bench-ctor` | -3.6% / -2.8% | -3.5% / -5.9% |
| `bench-class` | -2.0% / -4.1% | — |
| `method-call` | -8.3% / -8.1% | -2.4% / +6.3% |
| `bench-fib` | — | -9.0% / -14.5% |
| `poly-call` | — | -0.3% / -0.4% |
| `bench-yaml-parse` | — | +0.6% / -9.8% |

`bench-ctor` and `bench-fib` are consistent in every order; `method-call`'s second round flips sign, so treat it as no worse than flat. Nothing regresses consistently.

(Per the project convention, numbers that end up in documents come from the bench CI trend; these local A/Bs are the in-flight development evidence.)

## Test plan

- `t/method-env-merge-unchanged-globals.t` (new, 10 tests) pins what the skip must never drop: a method writing a caller lexical, an `our` package variable or a dynamic still propagates; an in-place push/store on a caller container is still visible; a method that only *reads* a caller lexical leaves it alone; TWEAK at two MRO levels still binds its attributes without disturbing the caller. Passes under rakudo as well as mutsu.
- `make test`: 3732 files / 38571 tests. The only failure is `t/io-path-smartmatch-permissions.t` (`'/sys'.IO ~~ :w` must be `False`); this dev container runs as uid 0, so root genuinely can write it. Environment artifact — CI runs non-root.
- **754 whitelisted roast files** across S02 / S04 / S06 / S10-S14 / S32 on a release build: 749 clean. The five that were not were each re-run against a baseline binary built from `main` **without** this change and behave identically there:
  - `S32-str/{gb2312,gb18030,shiftjis}-encode-decode.t` — need `t/spec/S32-str/text-samples/…` fixtures that only exist under `make roast`'s harness, not under a bare `prove -e` on `roast/`.
  - `6.c/S32-io/file-tests.t` — the same root-uid permission-bits artifact (`-w-` is readable as root).
  - `S32-io/IO-Socket-Async.t` — stalls at 17 of 40 subtests with `Failed: 0` in this container's network sandbox; byte-identical on the baseline binary through `scripts/run-roast-test.sh`.
- `cargo fmt` and `cargo clippy --all-targets -- -D warnings` clean.

## Follow-ups

The ticket stays open. Remaining, with the lesson recorded in it (sub-scope with `alloc_scope!` before assuming where the cost is — both guesses in that list were checked and one was wrong):

- the residual 4.0 in `mfast:slurpy-captures-locals`, now the locals-init loop alone;
- `mfast:body` at 40.7 allocations per call exclusive — by far the largest region now, and entirely unexamined.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BSyRU5UPUU2HmzLZhi2sNA

---
_Generated by [Claude Code](https://claude.ai/code/session_01BSyRU5UPUU2HmzLZhi2sNA)_