### PR TITLE
perf(binder): a literal parameter default binds directly instead of being evaluated per call

### DIFF
--- a/news/2026-09/literal-param-defaults-bind-directly.md
+++ b/news/2026-09/literal-param-defaults-bind-directly.md
@@ -1,0 +1,45 @@
+# A literal parameter default binds directly instead of being evaluated per call
+
+`Interpreter::eval_param_default` evaluated every omitted parameter's default
+through `eval_block_value`: save and restore the topic, shadow the parameter
+with its own type object, compile the default's AST as a one-statement block,
+run it, restore. That is the right protocol for `$c = $a * 2` or
+`&foo = &foo`, whose value depends on the scope the binder has built so far.
+It was also paid for `$desc = ''` and `$n = 1`, whose value depends on nothing.
+
+The general binder now binds an immutable scalar literal default (`Int`,
+`Num`, `Str`, `Bool`, `Rat`) directly, before any of that machinery runs. It
+is the same shape the positional light path already fills from its
+registration-time table (`CompiledFunction::const_fill_for_param`,
+`news/2026-09/defaulted-params-reach-the-positional-light-path.md`); this
+closes the gap for the routines that path cannot admit at all -- an `is copy`
+parameter, a coercion type, a `multi` -- which is every assertion routine in
+the vendored upstream `Test.rakumod`. A container literal (`$acc = []`) is
+still evaluated per call on purpose, because that evaluation is what hands
+each call its own fresh container.
+
+## Measured
+
+`proclaim($cond, $desc is copy, $unescaped-prefix = '')` is called once per
+assertion under `MUTSU_REAL_TEST=1`, and every call omits the third
+parameter. On the callgrind protocol from
+`todo/deep/vendor-real-test-module.md` (300 `ok 1, "x"` under the real
+module, one-assertion baseline subtracted):
+
+| | per assertion |
+| --- | --- |
+| before | 492,188 Ir |
+| after | 454,016 Ir |
+
+-7.8%, all of it the `eval_param_default` row (38,214 Ir inclusive) going to
+zero. Wall clock on the same box: the 20,000-assertion `ok` loop 1.33 s ->
+1.0 s, `roast/S03-buf/write-int.t` under the real module 13.8 s -> 11.6 s.
+
+## Pin
+
+`MUTSU_VM_STATS=1` now prints a `param-defaults:` line with an `evaluated=`
+count (defaults that went through `eval_block_value`) and a `constant=` count
+(literals bound directly). `tests/param_default_literal_binds_directly.rs`
+pins `evaluated=0` for a literal default on an `is copy` routine, one
+evaluation per call for a default that reads an earlier parameter, and a
+fresh container per call for `$acc = []`.

--- a/src/opcode_param_fills.rs
+++ b/src/opcode_param_fills.rs
@@ -100,7 +100,7 @@ impl CompiledFunction {
     /// (`$x = []`) is excluded on purpose — the general binder re-evaluates the
     /// expression per call and so hands every call a *fresh* container, which a
     /// shared constant would not.
-    fn is_immutable_scalar_literal(v: &Value) -> bool {
+    pub(crate) fn is_immutable_scalar_literal(v: &Value) -> bool {
         matches!(
             v.view(),
             ValueView::Int(_)

--- a/src/runtime/types/binding_helpers.rs
+++ b/src/runtime/types/binding_helpers.rs
@@ -36,6 +36,22 @@ impl Interpreter {
         pd: &ParamDef,
         default_expr: &Expr,
     ) -> Result<Value, RuntimeError> {
+        // An immutable scalar literal (`$desc = ''`, `$n = 1`) is its own
+        // value: nothing in the scoping below can change what it evaluates
+        // to, so bind it directly instead of paying a re-entrant
+        // `eval_block_value` -- topic save/restore, parameter shadow, a fresh
+        // compile of the one-statement block -- on every call that omits the
+        // parameter. The same shape the light call path fills from its
+        // registration-time table (`CompiledFunction::const_fill_for_param`);
+        // a container literal is deliberately NOT short-circuited, because the
+        // evaluation below hands every call a fresh container.
+        if let Expr::Literal(v) = default_expr
+            && crate::opcode::CompiledFunction::is_immutable_scalar_literal(v)
+        {
+            crate::vm::vm_stats::record_param_default(false);
+            return Ok(v.clone());
+        }
+        crate::vm::vm_stats::record_param_default(true);
         let saved_topic = self.env.get("_").cloned();
         let saved_dollar_topic = self.env.get("$_").cloned();
         // Shadow the parameter with its undefined type object (or Nil) so a

--- a/src/vm/vm_stats.rs
+++ b/src/vm/vm_stats.rs
@@ -102,6 +102,15 @@ static ENV_DEEP_COPY: AtomicU64 = AtomicU64::new(0);
 static ENV_FLUSH: AtomicU64 = AtomicU64::new(0);
 static ENV_SLOTS_FLUSHED: AtomicU64 = AtomicU64::new(0);
 
+// Parameter defaults. `PARAM_DEFAULT_EVALS` counts every default expression
+// the general binder had to EVALUATE (a re-entrant `eval_block_value` of the
+// default's AST, with the parameter shadowed by its own type object);
+// `PARAM_DEFAULT_CONSTS` the omitted parameters whose default was an
+// immutable scalar literal and so bound the literal itself. A routine whose
+// only default is `$desc = ''` should never appear in the first counter.
+static PARAM_DEFAULT_EVALS: AtomicU64 = AtomicU64::new(0);
+static PARAM_DEFAULT_CONSTS: AtomicU64 = AtomicU64::new(0);
+
 // Constant-pool interning (ADR-0006 §2.4). `CONST_POOL_ADDS` counts every
 // `CompiledCode::add_constant` call, `CONST_POOL_DEDUP_HITS` the ones that
 // reused an existing slot instead of pushing a copy. Compile-time counters:
@@ -923,6 +932,20 @@ pub(crate) fn record_env_deep_copy() {
     }
 }
 
+/// Record one parameter default the general binder bound: `evaluated` when
+/// the default's AST had to be run through `eval_block_value`, false when it
+/// was an immutable scalar literal bound directly.
+#[inline]
+pub(crate) fn record_param_default(evaluated: bool) {
+    if enabled() {
+        if evaluated {
+            PARAM_DEFAULT_EVALS.fetch_add(1, Ordering::Relaxed);
+        } else {
+            PARAM_DEFAULT_CONSTS.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+}
+
 /// Record a write-through mirror of a local slot into env (`flush_local_to_env`).
 /// Each call mirrors one name-observable slot, so `slots` is 1 per call.
 #[inline]
@@ -1029,6 +1052,11 @@ pub(crate) fn dump() {
     let slots = ENV_SLOTS_FLUSHED.load(Ordering::Relaxed);
     eprintln!(
         "[mutsu vm-stats] dual-store: clone_env={clone_env} (O(1) Arc bumps) env_deep_copies={deep_copy} (O(env) make_mut) env_flushes={env_flush} slots_flushed={slots}"
+    );
+    let default_evals = PARAM_DEFAULT_EVALS.load(Ordering::Relaxed);
+    let default_consts = PARAM_DEFAULT_CONSTS.load(Ordering::Relaxed);
+    eprintln!(
+        "[mutsu vm-stats] param-defaults: evaluated={default_evals} (eval_block_value of the default AST) constant={default_consts} (immutable literal bound directly)"
     );
     let const_adds = CONST_POOL_ADDS.load(Ordering::Relaxed);
     let const_hits = CONST_POOL_DEDUP_HITS.load(Ordering::Relaxed);

--- a/tests/param_default_literal_binds_directly.rs
+++ b/tests/param_default_literal_binds_directly.rs
@@ -1,0 +1,81 @@
+//! Pins the "literal parameter default binds directly" rule in
+//! `Interpreter::eval_param_default`: an omitted parameter whose default is an
+//! immutable scalar literal (`$desc = ''`, `$n = 1`) must bind the literal
+//! itself, not re-enter `eval_block_value` on every call. The vendored
+//! `Test.rakumod`'s `proclaim($cond, $desc, $unescaped-prefix = '')` paid that
+//! evaluation once per assertion -- about 8% of an `ok` under the real
+//! module -- for a value that can never be anything but `''`.
+//!
+//! A regression here shows up as the `evaluated=` count climbing back to one
+//! per call in the `param-defaults` vm-stats line.
+
+use std::process::Command;
+
+fn run_with_stats(src: &str) -> (String, String, bool) {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_mutsu"));
+    cmd.arg("-e").arg(src);
+    cmd.env("MUTSU_VM_STATS", "1");
+    let out = cmd.output().expect("failed to spawn mutsu");
+    (
+        String::from_utf8_lossy(&out.stdout).into_owned(),
+        String::from_utf8_lossy(&out.stderr).into_owned(),
+        out.status.success(),
+    )
+}
+
+/// `(evaluated, constant)` from the `param-defaults` vm-stats line.
+fn param_default_counts(stderr: &str) -> (u64, u64) {
+    let line = stderr
+        .lines()
+        .find(|l| l.contains("] param-defaults:"))
+        .unwrap_or_else(|| panic!("no param-defaults vm-stats line in stderr: {stderr}"));
+    let field = |key: &str| -> u64 {
+        line.split_whitespace()
+            .find_map(|w| w.strip_prefix(key))
+            .and_then(|v| v.parse().ok())
+            .unwrap_or_else(|| panic!("missing {key} in: {line}"))
+    };
+    (field("evaluated="), field("constant="))
+}
+
+#[test]
+fn literal_default_is_bound_without_evaluating_it() {
+    // `is copy` keeps `f` off the positional light path (which fills constant
+    // defaults from its own table), so every call below goes through the
+    // general binder and its `eval_param_default`.
+    let src = "sub f($a, $s is copy, $d = '', $n = 1) { $s ~ $d ~ $n }; \
+               my $r; for ^50 { $r = f(1, 'x') }; say $r";
+    let (out, err, ok) = run_with_stats(src);
+    assert!(ok, "run failed: {err}");
+    assert_eq!(out, "x1\n");
+    let (evaluated, constant) = param_default_counts(&err);
+    assert_eq!(evaluated, 0, "a literal default was evaluated: {err}");
+    assert_eq!(
+        constant, 100,
+        "two literal defaults per call over 50 calls: {err}"
+    );
+}
+
+#[test]
+fn non_literal_default_is_still_evaluated_per_call() {
+    // A default that reads an earlier parameter is an expression; it must be
+    // evaluated each call, with the earlier parameter in scope.
+    let src = "sub g($a, $b is copy, $c = $a * 2) { $c }; \
+               my @r; for 1..3 { @r.push(g($_, 0)) }; say @r";
+    let (out, err, ok) = run_with_stats(src);
+    assert!(ok, "run failed: {err}");
+    assert_eq!(out, "[2 4 6]\n");
+    let (evaluated, _) = param_default_counts(&err);
+    assert_eq!(evaluated, 3, "one evaluation per call: {err}");
+}
+
+#[test]
+fn container_literal_default_stays_fresh_per_call() {
+    // `[]` is a container literal: each call must get its OWN array, so the
+    // shortcut must not apply (a shared constant would accumulate pushes).
+    let src = "sub h($a, $b is copy, $acc = []) { $acc.push($a); $acc.elems }; \
+               say (h(1, 0), h(2, 0), h(3, 0))";
+    let (out, err, ok) = run_with_stats(src);
+    assert!(ok, "run failed: {err}");
+    assert_eq!(out, "(1 1 1)\n");
+}


### PR DESCRIPTION
## Summary

First slice of the perf work `todo/deep/vendor-real-test-module.md` calls for (making the vendored upstream `Test.rakumod` cheap enough to become the default provider).

`eval_param_default` ran every omitted parameter's default through `eval_block_value` -- topic save/restore, shadow the parameter with its type object, compile and run the default's AST as a one-statement block -- even when the default was `''` or `1`, whose value depends on nothing. `proclaim($cond, $desc is copy, $unescaped-prefix = '')` in the vendored `Test` paid that once per assertion: 38k of the 492k instructions an `ok` costs under `MUTSU_REAL_TEST=1`.

An immutable scalar literal default (`Int`/`Num`/`Str`/`Bool`/`Rat`) now binds the literal itself before any of that machinery runs. Same shape the positional light path already fills from its registration-time table (`CompiledFunction::const_fill_for_param`), extended to the routines that path cannot admit (an `is copy` parameter, a coercion type, a `multi`). A container literal (`$acc = []`) is still evaluated per call on purpose -- that evaluation is what hands each call its own fresh container.

## Measured

Callgrind, 300 `ok 1, "x"` under the real module, one-assertion baseline subtracted:

| | per assertion |
| --- | --- |
| before | 492,188 Ir |
| after | 454,016 Ir |

-7.8%, all of it the `eval_param_default` row going to zero. Wall clock on the same box: the 20k-assertion `ok` loop 1.33 s -> 1.0 s; `roast/S03-buf/write-int.t` under the real module 13.8 s -> 11.6 s.

## Pin

`MUTSU_VM_STATS=1` prints a new `param-defaults:` line (`evaluated=` / `constant=`); `tests/param_default_literal_binds_directly.rs` pins `evaluated=0` for a literal default on an `is copy` routine, one evaluation per call for a default that reads an earlier parameter, and a fresh container per call for `$acc = []`.

## Verified locally

- `cargo test --test param_default_literal_binds_directly`
- 358 default/signature/binder-related `t/*.t` files and `roast/S06-signature/{defaults,optional}.t`, `roast/S06-multi/type-based.t` on the debug build
- `t/vendored-real-test-module.t` and `roast/S24-testing/fails-like.t` under `MUTSU_REAL_TEST=1`
- `cargo fmt`, `cargo clippy --all-targets -- -D warnings`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VVJRdzUGzQpeRcLdum7Ptu

---
_Generated by [Claude Code](https://claude.ai/code/session_01VVJRdzUGzQpeRcLdum7Ptu)_