### PR TITLE
perf(call): stop re-resolving symbols and re-walking type checks on the named call path

### DIFF
--- a/news/2026-09/named-call-path-symbol-and-type-check-churn.md
+++ b/news/2026-09/named-call-path-symbol-and-type-check-churn.md
@@ -1,0 +1,53 @@
+# The named call path stops re-resolving symbols and re-walking type checks per call
+
+Second perf slice for `todo/deep/vendor-real-test-module.md`. After the
+literal-default fix (`news/2026-09/literal-param-defaults-bind-directly.md`)
+the callgrind profile of an `ok 1, "x"` under the vendored `Test.rakumod`
+was dominated by symbol traffic on `call_compiled_function_named_inner` and
+by `type_matches_value` walks that answered a question the caller could
+have answered by a tag compare. Five independent fixes, all on that path:
+
+- **The return merge compared every key against four strings.** The
+  scoped-overlay merge loop asked `*k == "_" || *k == "@_" || *k == "%_"`
+  and `*k == "__mutsu_callable_id"` of every key in the callee env, and a
+  `Symbol == &str` compare resolves the symbol through the thread-local
+  string cache first. On a callee env that a method dispatch in the body
+  has flattened to the whole lexical scope (~106 keys for a `Test`
+  assertion) that was ~400 thread-local accesses per call. The four are now
+  integer compares against pre-interned `wk` symbols (`@_` and `<anon>`
+  joined the well-known table).
+- **The frame seeded its locals through `env.get(&String)`**, interning each
+  local's name on every call. It reads through the chunk's pre-interned
+  `locals_sym` twin instead.
+- **`fn_package` / `fn_name` were interned three and two times per call**
+  (the `callframe().code` Sub, the routine frame, the state scope). Once
+  each now; the `$!` reset and the fresh-topic seed use `wk` symbols too.
+- **`type_matches_value` sent an `int` constraint through the full
+  checker.** The tag fast-accept only knew the boxed names, so
+  `my int $num_of_tests_run = $num_of_tests_run + 1` -- the vendored
+  module counts its tests in `my int` lexicals -- paid the gauntlet twice
+  per assertion. `int`/`num`/`str` are accepted alongside `Int`/`Num`/`Str`,
+  exactly as the general checker's alias rule already answered them.
+- **The native method fast path probed `Real` and `Numeric` before asking
+  whether the class had an interpreter-side handler.** `IO::Handle.say`
+  reached `None` either way, but only after two full `type_matches_value`
+  walks on an instance that cannot be numeric. The `is_native_method`
+  decision moved ahead of the numeric-bridge probes; every branch involved
+  declines the native path, so the outcome is unchanged.
+- **`function_key_base_name` built a two-way searcher per key** (`rfind("::")`)
+  on the per-dispatch candidate walk. A byte scan now; pinned by a unit
+  test against the shapes the registry produces.
+
+## Measured
+
+Callgrind, 300 `ok 1, "x"` under `MUTSU_REAL_TEST=1`, one-assertion
+baseline subtracted:
+
+| | per assertion |
+| --- | --- |
+| before (after the literal-default fix) | 454,016 Ir |
+| after | 397,305 Ir |
+
+-12.5% on this slice, -19.3% since the session started at 492,188.
+`roast/S03-buf/write-int.t` under the real module: 11.6 s -> 10.3 s on the
+same box (13.8 s at the start of the session).

--- a/src/runtime/dispatch_resolve.rs
+++ b/src/runtime/dispatch_resolve.rs
@@ -21,10 +21,18 @@ fn function_key_base_name(key: &str) -> &str {
         }
     }
     let head = &key[..end];
-    match head.rfind("::") {
-        Some(p) => &head[p + 2..],
-        None => head,
+    // A hand-rolled reverse scan for `::`: `str::rfind` builds a two-way
+    // searcher per call, which is most of what this function cost on the
+    // per-dispatch candidate walk that calls it once per registry key.
+    let hb = head.as_bytes();
+    let mut j = hb.len();
+    while j >= 2 {
+        if hb[j - 1] == b':' && hb[j - 2] == b':' {
+            return &head[j..];
+        }
+        j -= 1;
     }
+    head
 }
 
 impl Interpreter {
@@ -714,5 +722,28 @@ impl Interpreter {
         }
 
         all_matches
+    }
+}
+
+#[cfg(test)]
+mod base_name_tests {
+    use super::function_key_base_name;
+
+    /// The hand-rolled `::` scan must agree with the `rfind` it replaced on
+    /// every key shape the registry produces: bare, package-qualified, with
+    /// and without the `/arity` suffix, and degenerate short keys.
+    #[test]
+    fn base_name_strips_package_and_arity() {
+        assert_eq!(function_key_base_name("foo"), "foo");
+        assert_eq!(function_key_base_name("GLOBAL::foo"), "foo");
+        assert_eq!(function_key_base_name("A::B::foo"), "foo");
+        assert_eq!(function_key_base_name("A::B::foo/2"), "foo");
+        assert_eq!(function_key_base_name("foo/10"), "foo");
+        assert_eq!(function_key_base_name("A::B::infix:<+>/2"), "infix:<+>");
+        assert_eq!(function_key_base_name("::foo"), "foo");
+        assert_eq!(function_key_base_name(":"), ":");
+        assert_eq!(function_key_base_name("::"), "");
+        assert_eq!(function_key_base_name(""), "");
+        assert_eq!(function_key_base_name("a"), "a");
     }
 }

--- a/src/runtime/types/type_matching.rs
+++ b/src/runtime/types/type_matching.rs
@@ -431,10 +431,15 @@ impl Interpreter {
             matches!(constraint, "Match" | "Any" | "Mu")
                 || constraint == value.match_dispatch_class()
         } else {
+            // The lowercase native aliases are accepted alongside the boxed
+            // names exactly as the general checker below does for them (an
+            // `int` constraint admits any Int; see `type_matches`): the
+            // vendored `Test.rakumod` counts its tests in `my int` lexicals,
+            // so every assertion paid the full gauntlet for `int` twice.
             match value.view() {
-                ValueView::Int(_) => constraint == "Int",
-                ValueView::Num(_) => constraint == "Num",
-                ValueView::Str(_) => constraint == "Str",
+                ValueView::Int(_) => constraint == "Int" || constraint == "int",
+                ValueView::Num(_) => constraint == "Num" || constraint == "num",
+                ValueView::Str(_) => constraint == "Str" || constraint == "str",
                 ValueView::Bool(_) => constraint == "Bool",
                 ValueView::Instance { class_name, .. } => class_name.as_str() == constraint,
                 // `LazyList` can present as `Array`, `List`, or `Seq` depending

--- a/src/symbol.rs
+++ b/src/symbol.rs
@@ -233,6 +233,11 @@ pub(crate) mod wk {
         callable_id => "__mutsu_callable_id";
         /// The implicit `*%_` named slurpy every method carries.
         named_slurpy => "%_";
+        /// The legacy `@_` positional slurpy every call binds.
+        positional_slurpy => "@_";
+        /// The routine-frame name a nameless compiled routine is pushed under
+        /// (so `&?ROUTINE` works inside an anonymous sub).
+        anon_routine => "<anon>";
     }
 
     /// Whether `key` is one of the fixed per-call env keys the well-known

--- a/src/vm/vm_call_named_inner.rs
+++ b/src/vm/vm_call_named_inner.rs
@@ -33,6 +33,12 @@ impl Interpreter {
         if callsite_line.is_some() {
             loan_env!(self, set_pending_callsite_line(callsite_line));
         }
+        // Interned once per call: the package and routine name are pushed on
+        // three frames below (the `callframe().code` Sub, the routine frame,
+        // the state scope), and each `Symbol::intern` is a thread-local
+        // string-keyed hash lookup.
+        let fn_package_sym = Symbol::intern(fn_package);
+        let fn_name_sym = Symbol::intern(fn_name);
         // Record deprecation for cached compiled functions
         self.record_cf_deprecation(cf);
         // An END phaser registered inside this call closes over this frame's
@@ -59,8 +65,8 @@ impl Interpreter {
 
         // Push Sub value to block_stack for callframe().code
         let sub_val = Value::make_sub(
-            Symbol::intern(fn_package),
-            Symbol::intern(fn_name),
+            fn_package_sym,
+            fn_name_sym,
             cf.params.clone(),
             cf.param_defs.clone(),
             vec![],
@@ -90,12 +96,12 @@ impl Interpreter {
         // Always push a routine frame so that &?ROUTINE works inside anonymous
         // subs too. Use "<anon>" as a sentinel name when fn_name is empty.
         let routine_push_name = if fn_name.is_empty() {
-            Symbol::intern("<anon>")
+            crate::symbol::wk::anon_routine()
         } else {
-            Symbol::intern(fn_name)
+            fn_name_sym
         };
         self.push_routine_with_location(
-            Symbol::intern(fn_package),
+            fn_package_sym,
             routine_push_name,
             self.current_source_line(),
             self.current_source_file_sym(),
@@ -117,8 +123,8 @@ impl Interpreter {
             // the missing/None case correctly. This avoids triggering
             // Arc::make_mut deep clone on the CoW env for simple functions.
             if resolved_callable_id != 0 {
-                self.env_mut().insert(
-                    "__mutsu_callable_id".to_string(),
+                self.env_mut().insert_sym(
+                    crate::symbol::wk::callable_id(),
                     Value::int(resolved_callable_id),
                 );
             }
@@ -246,24 +252,39 @@ impl Interpreter {
         // Only insert if $! isn't already Nil, to avoid triggering
         // Arc::make_mut deep clone on the CoW env.
         if !fn_name.is_empty() {
-            let needs_reset = self.env().get("!").is_some_and(|v| !v.is_nil());
+            let needs_reset = self
+                .env()
+                .get_sym(crate::symbol::wk::error_var())
+                .is_some_and(|v| !v.is_nil());
             if needs_reset {
-                self.env_mut().insert("!".to_string(), Value::NIL);
+                self.env_mut()
+                    .insert_sym(crate::symbol::wk::error_var(), Value::NIL);
             }
         }
 
         // Raku: routines get their own $_ initialized to (Any).
         if cf.code.is_routine && !cf.param_defs.iter().any(|pd| pd.name == "_") {
-            self.env_mut().insert(
-                "_".to_string(),
-                Value::package(crate::symbol::Symbol::intern("Any")),
+            self.env_mut().insert_sym(
+                crate::symbol::wk::topic(),
+                Value::package(crate::symbol::wk::any()),
             );
         }
 
         self.locals = vec![Value::NIL; cf.code.locals.len()];
-        for (i, local_name) in cf.code.locals.iter().enumerate() {
-            if let Some(val) = self.env().get(local_name) {
-                self.locals[i] = val.clone();
+        // `locals_sym` is the pre-interned twin of `locals` (empty only for a
+        // hand-built chunk that never ran `compute_locals_sym`); reading the
+        // seed values through it saves one string intern per local per call.
+        if cf.code.locals_sym.len() == cf.code.locals.len() {
+            for (i, local_sym) in cf.code.locals_sym.iter().enumerate() {
+                if let Some(val) = self.env().get_sym(*local_sym) {
+                    self.locals[i] = val.clone();
+                }
+            }
+        } else {
+            for (i, local_name) in cf.code.locals.iter().enumerate() {
+                if let Some(val) = self.env().get(local_name) {
+                    self.locals[i] = val.clone();
+                }
             }
         }
         // A named sub's `state` scope is its REGISTRATION clone id (refreshed
@@ -672,14 +693,22 @@ impl Interpreter {
             // caller's error variable. Blocks are excluded: a bare block shares
             // its enclosing routine's `$!` and a `CATCH` writes it there.
             let bang_is_callee_private = cf.code.is_routine;
+            // Integer compares against the pre-interned keys: a `Symbol ==
+            // &str` compare resolves the symbol through the thread-local
+            // string cache first, and this loop asked that question four
+            // times per key of a (flattened, whole-scope) callee env.
+            let topic_sym = crate::symbol::wk::topic();
+            let positional_slurpy_sym = crate::symbol::wk::positional_slurpy();
+            let named_slurpy_sym = crate::symbol::wk::named_slurpy();
+            let callable_id_sym = crate::symbol::wk::callable_id();
             for (k, v) in self.env().iter() {
-                if *k == "_" || *k == "@_" || *k == "%_" {
+                if *k == topic_sym || *k == positional_slurpy_sym || *k == named_slurpy_sym {
                     continue;
                 }
                 // __mutsu_callable_id must not leak from callee back to
                 // caller; it identifies the current routine scope for
                 // non-local return targeting.
-                if *k == "__mutsu_callable_id" {
+                if *k == callable_id_sym {
                     continue;
                 }
                 // One memoized byte answers both string predicates this loop

--- a/src/vm/vm_native_dispatch.rs
+++ b/src/vm/vm_native_dispatch.rs
@@ -319,6 +319,15 @@ impl Interpreter {
                 if cn == "Supplier" && method_sym == "Supply" && args.is_empty() {
                     return None;
                 }
+                // Native method on instance class: an interpreter-side handler
+                // (`IO::Handle.say`, ...) serves it, so decline the pure native
+                // path. Decided BEFORE the numeric-bridge probes below, which
+                // reach the same `None` for such a class only after two full
+                // `type_matches_value` walks (`Real`, then `Numeric`) -- the
+                // cost every `$output.say` in the vendored `Test` was paying.
+                if self.is_native_method(&cn, &method_name) {
+                    return None;
+                }
                 // Numeric bridge — Real/Numeric instances route through the
                 // interpreter's Numeric bridge for arithmetic and coercion.
                 // Exception: pure-render methods (gist/Str/raku/...) don't need
@@ -351,10 +360,6 @@ impl Interpreter {
                     "throw" | "rethrow" | "gist" | "Str" | "Stringy"
                 ) && self.exception_render_needs_interpreter(target, &cn)
                 {
-                    return None;
-                }
-                // Native method on instance class
-                if self.is_native_method(&cn, &method_name) {
                     return None;
                 }
                 // A Cool-only builtin (`.uc`, `.flip`, `.subst`, ...) is not


### PR DESCRIPTION
## Summary

Second perf slice for `todo/deep/vendor-real-test-module.md` (branched on top of #7457; the diff collapses to this commit once that merges). After the literal-default fix, the callgrind profile of an `ok 1, "x"` under the vendored `Test.rakumod` was dominated by symbol traffic in `call_compiled_function_named_inner` and by `type_matches_value` walks a tag compare could have answered. Six independent fixes, all on that path:

- **The return merge compared every key against four strings.** `*k == "_" || *k == "@_" || *k == "%_"` and `*k == "__mutsu_callable_id"` on every key of the callee env; a `Symbol == &str` compare resolves the symbol through the thread-local string cache first, so on a callee env a method dispatch had flattened to the whole scope (~106 keys) that was ~400 thread-local accesses per call. Integer compares against pre-interned `wk` symbols now (`@_` and `<anon>` join the well-known table).
- **The frame seeded its locals through `env.get(&String)`**, interning each name per call; it reads through the chunk's pre-interned `locals_sym` twin.
- **`fn_package` / `fn_name` were interned three and two times per call**; once each. The `$!` reset and fresh-topic seed use `wk` symbols too.
- **`type_matches_value`'s tag fast-accept only knew the boxed names**, so `my int $num_of_tests_run = $num_of_tests_run + 1` (the vendored module counts tests in `my int` lexicals) paid the full checker twice per assertion. `int`/`num`/`str` are accepted alongside `Int`/`Num`/`Str`, exactly as the general checker's alias rule already answered them.
- **The native method fast path probed `Real` and `Numeric` before asking whether the class had an interpreter-side handler.** `IO::Handle.say` reached `None` either way, but only after two full `type_matches_value` walks. The `is_native_method` decision moved ahead of the numeric-bridge probes; every branch involved declines the native path, so the outcome is unchanged.
- **`function_key_base_name` built a two-way searcher per key** (`rfind("::")`) on the per-dispatch candidate walk. A byte scan now, pinned by a unit test against the key shapes the registry produces.

## Measured

Callgrind, 300 `ok 1, "x"` under `MUTSU_REAL_TEST=1`, one-assertion baseline subtracted:

| | per assertion |
| --- | --- |
| before (after #7457) | 454,016 Ir |
| after | 397,305 Ir |

-12.5% on this slice, -19.3% since the session started at 492,188. `roast/S03-buf/write-int.t` under the real module: 11.6 s -> 10.3 s on the same box (13.8 s at the start of the session).

## Verified locally

- 1348 call/method/multi/dispatch/type-related `t/*.t` files on the debug build
- `t/vendored-real-test-module.t`, `roast/S24-testing/fails-like.t`, `roast/S06-signature/defaults.t`, `roast/S12-methods/instance.t`, `roast/S06-multi/type-based.t` under `MUTSU_REAL_TEST=1`
- `cargo test --lib base_name_tests`
- `cargo fmt`, `cargo clippy --all-targets -- -D warnings`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VVJRdzUGzQpeRcLdum7Ptu

---
_Generated by [Claude Code](https://claude.ai/code/session_01VVJRdzUGzQpeRcLdum7Ptu)_