### PR TITLE
test(io): give t/io-path-methods.t a per-PID temp directory

### DIFF
--- a/news/2026-09/io-path-methods-test-no-longer-races-with-itself.md
+++ b/news/2026-09/io-path-methods-test-no-longer-races-with-itself.md
@@ -1,0 +1,26 @@
+# `t/io-path-methods.t` no longer races with itself
+
+The file built its symlink tree at a **fixed** path:
+
+```raku
+my $base = "tmp/io-path-methods-regression".IO;
+```
+
+so two processes running it at once raced on the same `mkdir`/`symlink` and
+whichever lost saw a half-built tree — "planned 8, ran 6", the two `resolve`
+rows. Measured: six concurrent `prove` runs of the old file failed 3 of 6; the
+fixed file passes 6 of 6 and leaves nothing behind. Standalone it always passed,
+which is what made the failure look like noise.
+
+It was the lone outlier. Every other `t/` file that builds a tree under `tmp/`
+— `t/native-io-path-{comb,content-read,fs-mutate,fs-stat,open,two-path}.t`,
+`t/compunit-need-protocol.t` — already names it per-`$*PID`; this one now does
+too. That is the directory twin of the hardcoded-port collision CLAUDE.md
+records for `t/io-socket-recv-limit.t` ("never hardcode a port in a new test"),
+and a unique name also means a leftover from an interrupted run can never be
+mistaken for this run's tree — so the stale-cleanup prologue the file carried
+is gone.
+
+The teardown moved into a `LEAVE` block, so a failure anywhere in the file
+cannot leave the tree behind either. (`dies-ok` already swallowed its own
+exception, but nothing else did.)

--- a/t/io-path-methods.t
+++ b/t/io-path-methods.t
@@ -13,19 +13,16 @@ is $parts<volume>, "", "parts volume matches";
 is $parts<dirname>, "foo", "parts dirname matches";
 is $parts<basename>, "bar.txt", "parts basename matches";
 
-my $base = "tmp/io-path-methods-regression".IO;
+# Per-PID, like every other `t/` file that builds a tree under `tmp/`
+# (`t/native-io-path-*.t`, `t/compunit-need-protocol.t`). This one used a FIXED
+# name, so two processes running it at once raced on the same `mkdir`/`symlink`
+# and whichever lost saw a half-built tree ("planned 8, ran 6") -- the directory
+# twin of the hardcoded-port collision CLAUDE.md records for
+# `t/io-socket-recv-limit.t`. A unique name also means a leftover from an
+# interrupted run can never be mistaken for this run's tree.
+my $base = "tmp/io-path-methods-regression-$*PID".IO;
 my $real = $base.add("real");
 my $link = $base.add("link");
-
-if try { $link.l } || $link.e {
-    $link.unlink;
-}
-if $real.e {
-    $real.rmdir;
-}
-if $base.e {
-    $base.rmdir;
-}
 
 mkdir $base;
 mkdir $real;
@@ -36,6 +33,10 @@ is $link.add("../x").resolve.Str, $base.add("x").absolute,
 dies-ok { $base.add("missing/../x").resolve(:completely) },
     "resolve(:completely) dies when a non-final component is missing";
 
-$link.unlink;
-$real.rmdir;
-$base.rmdir;
+# Torn down unconditionally: `dies-ok` above swallows its exception, but a
+# failure anywhere else must not leave the tree behind for the next run.
+LEAVE {
+    $link.unlink if try { $link.l } || $link.e;
+    $real.rmdir if $real.e;
+    $base.rmdir if $base.e;
+}


### PR DESCRIPTION
Closes `todo/tickets/io-path-methods-test-uses-a-fixed-temp-directory.md` (filed by #7461, still in flight — see the note at the bottom).

## The defect

```raku
my $base = "tmp/io-path-methods-regression".IO;
```

A **fixed** path. Two processes running this file at once raced on the same `mkdir`/`symlink`, and whichever lost saw a half-built tree — "planned 8, ran 6", the two `resolve` rows. Standalone it always passed, which is what made the failure look like noise when it turned up in a `prove` run.

Measured on this box:

| | result |
|---|---|
| six concurrent `prove` runs of the old file | **3 of 6 FAIL** |
| six concurrent `prove` runs of the fixed file | 6 of 6 PASS, nothing left behind |

## Fix

It was the lone outlier: every other `t/` file that builds a tree under `tmp/` — `t/native-io-path-{comb,content-read,fs-mutate,fs-stat,open,two-path}.t` and `t/compunit-need-protocol.t` — already names it per-`$*PID`. This one now does too. That is the directory twin of the hardcoded-port collision CLAUDE.md records for `t/io-socket-recv-limit.t` ("never hardcode a port in a new test").

A unique name also means a leftover from an interrupted run can never be mistaken for *this* run's tree, so the stale-cleanup prologue the file carried is gone. The teardown moves into a `LEAVE` block, so a failure anywhere in the file cannot leave the tree behind either (`dies-ok` already swallowed its own exception; nothing else did).

The file still passes under `raku` unchanged.

## Note on the ticket file

The ticket this closes is *added* by #7461 (the regex PR that noticed the collision), which has not merged yet. Removing it here would conflict with that PR, so it is left in place and will be removed in a follow-up once #7461 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016px8Bgoyt7diCQY2mTuz67

---
_Generated by [Claude Code](https://claude.ai/code/session_016px8Bgoyt7diCQY2mTuz67)_