### PR TITLE
perf(dispatch): memoize a multi's dispatch-frame candidate list; flatten an env chain in one pass

### DIFF
--- a/news/2026-09/multi-dispatch-frame-memo-and-single-pass-flatten.md
+++ b/news/2026-09/multi-dispatch-frame-memo-and-single-pass-flatten.md
@@ -1,0 +1,44 @@
+# A multi's dispatch frame reuses its candidate list, and a chain flatten clones the scope once
+
+Fifth perf slice for `todo/deep/vendor-real-test-module.md`. Two fixes on
+the largest rows left in the per-assertion profile under the vendored
+`Test.rakumod`:
+
+- **Every call of a `multi` re-gathered its full candidate list.**
+  `push_multi_dispatch_frame` -- which every `multi` call runs so that
+  `callsame`/`nextsame` have somewhere to defer to -- called
+  `resolve_all_multi_candidates_indexed` per call: build the package list,
+  format one `Pkg::name/` prefix per package, resolve the proto owner,
+  filter the base-name key index, dedupe by body fingerprint, sort by
+  specificity. `ok` and `is` are multis, so that ran once per assertion,
+  rebuilding a list that had not changed since the previous call.
+  `resolve_all_multi_candidates_cached` memoizes the shared list per
+  `(name, current package, frame lexical package)` -- the inputs the gather
+  reads besides the registry -- and drops the memo when `fn_resolve_gen`
+  (every function registration or removal) or the registry's `proto_gen`
+  moves. The existing gather-equivalence unit test pins that a registration
+  after a hit refreshes the answer.
+- **`Env::flattened` on a two-tier chain cloned the whole scope twice.**
+  It recursed through `parent.flattened()` and then cloned *that* result to
+  layer its own overlay on top, so a method call two routine frames deep
+  (`ok` -> `proclaim` -> `$output.say`) materialized the mainline scope
+  once per tier. It now walks to the flat root, clones that map once, and
+  layers every tier's tombstones and overlay on it root-ward first -- the
+  single pass `filtered_flat` already used.
+
+## Measured
+
+Callgrind, 300 `ok 1, "x"` under `MUTSU_REAL_TEST=1`, one-assertion
+baseline subtracted:
+
+| | per assertion |
+| --- | --- |
+| before (after the call-return slice) | 352,748 Ir |
+| after | 333,577 Ir |
+
+-5.4% on this slice, -32.2% since the session started at 492,188. The
+`push_multi_dispatch_frame` row (9,535 Ir per assertion) is gone from the
+profile; `Env::flattened` went 24,619 -> 15,944 and the scope-map clone
+inside it 16,868 -> 12,143. `roast/S03-buf/write-int.t` under the real
+module: 9.9 s (median of three) on the same box, 13.8 s at the start of
+the session.

--- a/src/env.rs
+++ b/src/env.rs
@@ -632,21 +632,32 @@ impl Env {
             Some(parent) if self.inner.is_empty() && self.tombstones.is_none() => {
                 parent.flattened()
             }
-            Some(parent) => {
-                // Recursively collapse the parent chain to a flat overlay first
-                // (the base tier stays shared, never materialized), then layer
-                // this frame's tombstones and overlay on top.
-                let parent_flat = parent.flattened();
-                let mut merged: SymMap = (*parent_flat.inner).clone();
-                // Apply tombstones: a key removed in this scope must not survive
-                // into the flattened (flat) env.
-                if let Some(tomb) = &self.tombstones {
-                    for k in tomb {
-                        merged.remove(k);
-                    }
+            Some(_) => {
+                // Collapse the whole chain in ONE pass: clone the flat root
+                // tier's map once, then layer every tier's tombstones and
+                // overlay on top of it, root-ward first. Recursing through
+                // `parent.flattened()` instead materialized a full copy of the
+                // map at EVERY tier of the chain -- a method call two routine
+                // frames deep paid two whole-scope clones for one flatten. The
+                // base tier stays shared, never materialized, as before.
+                let mut tiers: Vec<&Env> = Vec::new();
+                let mut cur: &Env = self;
+                while let Some(parent) = &cur.parent {
+                    tiers.push(cur);
+                    cur = parent;
                 }
-                for (k, v) in self.inner.iter() {
-                    merged.insert(*k, v.clone());
+                let mut merged: SymMap = (*cur.inner).clone();
+                for tier in tiers.into_iter().rev() {
+                    // An overlay that never received a write (and holds no
+                    // tombstone) is invisible to lookups.
+                    if let Some(tomb) = &tier.tombstones {
+                        for k in tomb {
+                            merged.remove(k);
+                        }
+                    }
+                    for (k, v) in tier.inner.iter() {
+                        merged.insert(*k, v.clone());
+                    }
                 }
                 Self {
                     inner: Arc::new(merged),

--- a/src/runtime/accessors_state.rs
+++ b/src/runtime/accessors_state.rs
@@ -1237,7 +1237,9 @@ impl Interpreter {
         // Collect ALL multi candidates regardless of arg matching. This is
         // needed because callwith() can re-dispatch with different args, so
         // candidates that don't match the original args may match the new ones.
-        let all_candidates = self.resolve_all_multi_candidates_indexed(name);
+        // Memoized per (name, package context, registry generation): the list
+        // is identical from one call of the same multi to the next.
+        let all_candidates = self.resolve_all_multi_candidates_cached(name);
         // A name with no multi candidates at all is a plain sub: it establishes
         // no dispatcher, so `nextsame` from its body correctly dies with
         // X::NoDispatcher (`roast/S06-multi/redispatch.t` test 10).
@@ -1283,11 +1285,12 @@ impl Interpreter {
             self.set_pending_dispatch_error(err);
         }
         let remaining: Vec<std::sync::Arc<super::FunctionDef>> = all_candidates
-            .into_iter()
+            .iter()
             .filter(|c| {
                 let fp = c.body_fingerprint();
                 Some(fp) != current_fp
             })
+            .cloned()
             .collect();
         // Capture the FIRST (winning) candidate's scalar rw params so a
         // nextsame+rw redispatch can chain the rw value through it (§D).

--- a/src/runtime/dispatch_proto_candidates.rs
+++ b/src/runtime/dispatch_proto_candidates.rs
@@ -43,6 +43,35 @@ impl Interpreter {
         self.multi_candidates_over(name, Some(&keys))
     }
 
+    /// [`Self::resolve_all_multi_candidates_indexed`] behind the per-generation
+    /// memo (`multi_dispatch_candidates_memo`): the same list, shared, for a repeat call
+    /// of the same name from the same package context under an unchanged
+    /// registry.
+    pub(crate) fn resolve_all_multi_candidates_cached(
+        &mut self,
+        name: &str,
+    ) -> crate::runtime::MultiCandidateList {
+        let generation = (self.fn_resolve_gen, self.registry().proto_generation());
+        if self.multi_dispatch_candidates_memo_gen != generation {
+            self.multi_dispatch_candidates_memo.clear();
+            self.multi_dispatch_candidates_memo_gen = generation;
+        }
+        let key = (
+            Symbol::intern(name),
+            self.current_package_sym(),
+            self.routine_stack()
+                .last()
+                .and_then(|frame| frame.lexical_package),
+        );
+        if let Some(cached) = self.multi_dispatch_candidates_memo.get(&key) {
+            return cached.clone();
+        }
+        let candidates = Arc::new(self.resolve_all_multi_candidates_indexed(name));
+        self.multi_dispatch_candidates_memo
+            .insert(key, candidates.clone());
+        candidates
+    }
+
     /// Shared body of the two candidate gathers above: `keys`, when given, is the
     /// candidate key set to filter; `None` means walk the whole functions map.
     fn multi_candidates_over(&self, name: &str, keys: Option<&[Symbol]>) -> Vec<Arc<FunctionDef>> {
@@ -170,5 +199,15 @@ mod indexed_gather_equivalence_tests {
                 .len(),
             2
         );
+
+        // The memoized gather answers the same list, and a later registration
+        // (which moves `fn_resolve_gen`) refreshes it rather than serving the
+        // stale one.
+        assert_eq!(i.resolve_all_multi_candidates_cached("f").len(), 3);
+        assert_eq!(i.resolve_all_multi_candidates_cached("f").len(), 3);
+        i.run("multi sub f(Num $x, Num $y, Num $z) { 4 }")
+            .expect("a fourth candidate registers");
+        assert_eq!(i.resolve_all_multi_candidates_cached("f").len(), 4);
+        assert_eq!(i.resolve_all_multi_candidates_indexed("f").len(), 4);
     }
 }

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -10,6 +10,13 @@ pub(crate) type PackageKeyed<V> = rustc_hash::FxHashMap<String, rustc_hash::FxHa
 /// The compunit / package-block lexical stores (`unit_lexicals`,
 /// `package_lexicals`): see [`PackageKeyed`].
 pub(crate) type PackageLexicals = PackageKeyed<Value>;
+/// The full, specificity-sorted candidate list a multi dispatch frame carries
+/// (`push_multi_dispatch_frame`), shared between the frames that reuse it.
+pub(crate) type MultiCandidateList = std::sync::Arc<Vec<std::sync::Arc<FunctionDef>>>;
+/// `(name, current package, frame lexical package) -> candidate list`: see
+/// `Interpreter::multi_dispatch_candidates_memo`.
+pub(crate) type MultiDispatchCandidatesMemo =
+    rustc_hash::FxHashMap<(Symbol, Symbol, Option<Symbol>), MultiCandidateList>;
 use std::env;
 use std::fs;
 use std::io::{Read, Seek, SeekFrom, Write};
@@ -3217,6 +3224,18 @@ pub struct Interpreter {
     /// its generation bump fails CI rather than silently mis-dispatching).
     pub(crate) fn_keys_by_base: rustc_hash::FxHashMap<Symbol, std::sync::Arc<[Symbol]>>,
     pub(crate) fn_keys_by_base_gen: u64,
+    /// Memo of `resolve_all_multi_candidates_indexed` -- the FULL candidate
+    /// list a multi dispatch frame carries for `callsame`/`nextsame` -- keyed by
+    /// `(name, current package, frame lexical package)`, the three inputs the
+    /// gather reads besides the registry (`bare_name_packages`, the proto
+    /// owner). Dropped wholesale when either registry generation it depends on
+    /// moves: `fn_resolve_gen` (every function registration/removal) or the
+    /// registry's `proto_gen`. Without it every call of a `multi` re-ran the
+    /// gather -- package list, prefix strings, key filter, specificity sort --
+    /// to rebuild a list that had not changed since the previous call.
+    pub(crate) multi_dispatch_candidates_memo: MultiDispatchCandidatesMemo,
+    /// `(fn_resolve_gen, proto_gen)` the memo above was filled under.
+    pub(crate) multi_dispatch_candidates_memo_gen: (u64, u64),
     /// Keyed by `(callee name, callsite package)` for the same reason as
     /// [`Self::pos_light_call_cache`] below.
     pub(crate) light_call_cache: rustc_hash::FxHashMap<(Symbol, Symbol), (Symbol, u64)>,

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -3112,6 +3112,8 @@ impl Interpreter {
             multi_fn_cache_gen: 0,
             fn_keys_by_base: Default::default(),
             fn_keys_by_base_gen: 0,
+            multi_dispatch_candidates_memo: Default::default(),
+            multi_dispatch_candidates_memo_gen: (0, 0),
             light_call_cache: Default::default(),
             light_call_cache_gen: 0,
             pos_light_call_cache: Default::default(),

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -925,6 +925,8 @@ impl Interpreter {
             multi_fn_cache_gen: 0,
             fn_keys_by_base: Default::default(),
             fn_keys_by_base_gen: 0,
+            multi_dispatch_candidates_memo: Default::default(),
+            multi_dispatch_candidates_memo_gen: (0, 0),
             light_call_cache: Default::default(),
             light_call_cache_gen: 0,
             pos_light_call_cache: Default::default(),


### PR DESCRIPTION
## Summary

Fifth perf slice for `todo/deep/vendor-real-test-module.md` (branched on top of #7463; the diff collapses to this commit once that merges). Two fixes on the largest rows left in the per-assertion profile under the vendored `Test.rakumod`:

- **Every call of a `multi` re-gathered its full candidate list.** `push_multi_dispatch_frame` -- which every `multi` call runs so that `callsame`/`nextsame` have somewhere to defer to -- called `resolve_all_multi_candidates_indexed` per call: build the package list, format one `Pkg::name/` prefix per package, resolve the proto owner, filter the base-name key index, dedupe by body fingerprint, sort by specificity. `ok` and `is` are multis, so that ran once per assertion, rebuilding a list that had not changed since the previous call. `resolve_all_multi_candidates_cached` memoizes the shared list per `(name, current package, frame lexical package)` -- the inputs the gather reads besides the registry -- and drops the memo when `fn_resolve_gen` (every function registration or removal) or the registry's `proto_gen` moves. The existing gather-equivalence unit test now also pins that a registration after a hit refreshes the answer.
- **`Env::flattened` on a two-tier chain cloned the whole scope twice.** It recursed through `parent.flattened()` and then cloned *that* result to layer its own overlay on top, so a method call two routine frames deep (`ok` -> `proclaim` -> `$output.say`) materialized the mainline scope once per tier. It now walks to the flat root, clones that map once, and layers every tier's tombstones and overlay on it root-ward first -- the single pass `filtered_flat` already used.

## Measured

Callgrind, 300 `ok 1, "x"` under `MUTSU_REAL_TEST=1`, one-assertion baseline subtracted:

| | per assertion |
| --- | --- |
| before (after #7463) | 352,748 Ir |
| after | 333,577 Ir |

-5.4% on this slice, -32.2% since the session started at 492,188. The `push_multi_dispatch_frame` row (9,535 Ir per assertion) is gone from the profile; `Env::flattened` went 24,619 -> 15,944 and the scope-map clone inside it 16,868 -> 12,143. `roast/S03-buf/write-int.t` under the real module: 9.9 s (median of three) on the same box, 13.8 s at the start of the session.

## Verified locally

- 581 multi/dispatch/nextsame/proto/env/closure/method-related `t/*.t` files on the debug build
- `roast/S06-multi/redispatch.t`, `roast/S06-multi/proto.t`, `roast/S06-multi/type-based.t`, `roast/S12-methods/defer-next.t`, `roast/S12-methods/defer-call.t`, `roast/S24-testing/fails-like.t` under both providers
- `t/vendored-real-test-module.t` under `MUTSU_REAL_TEST=1`
- `cargo test --lib indexed_gather_equivalence_tests`
- `cargo fmt`, `cargo clippy --all-targets -- -D warnings`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VVJRdzUGzQpeRcLdum7Ptu

---
_Generated by [Claude Code](https://claude.ai/code/session_01VVJRdzUGzQpeRcLdum7Ptu)_