### PR TITLE
perf(vm): nqp:: ops and say's Str gist skip the general call machinery

### DIFF
--- a/news/2026-09/nqp-ops-and-str-gist-skip-the-call-machinery.md
+++ b/news/2026-09/nqp-ops-and-str-gist-skip-the-call-machinery.md
@@ -1,0 +1,54 @@
+# `nqp::` ops and `say`'s Str gist stop paying for the general call machinery
+
+Sixth perf slice for `todo/deep/vendor-real-test-module.md`. Callgrind on the
+per-assertion protocol (300 `ok 1, "x"` in a loop under `MUTSU_REAL_TEST=1`,
+one-assertion baseline subtracted, release build) put two things at the top of
+what a `Test.rakumod` assertion does that is not the assertion:
+
+- **An `nqp::` op paid ~4k instructions of call dispatch for a ~1k op.**
+  `exec_call_func_op` already had an `nqp::` arm, but it sat at the *end* of the
+  general chain: the increment-operator gate, the NativeCall table, the
+  empty-proto veto, the `&`-param shadow set, the direct-mapped and
+  name-keyed light-call caches, the OTF cache, `decode_arg_sources`, and
+  `normalize_call_args_for_target`'s registry probes (`fn_keys_for_base`,
+  `has_proto_cached`) all ran first and all missed, because `nqp::` is a
+  reserved namespace no routine can be declared in. `proclaim` runs five of
+  these per assertion (`nqp::time` x2, `nqp::join`/`nqp::split` x2, one
+  `nqp::iseq_i`), so that was ~20k per assertion of dispatch that could never
+  change the answer. The callee symbol now carries a memoized `flags::NQP_OP`
+  bit (the same per-symbol flag byte the return merge uses), and the op's
+  `CallFunc` takes `exec_nqp_call_op` first: spread `|` positions, unwrap
+  `VarRef` captures (what `normalize_call_args_for_target` always chose for an
+  unregistered name), strip the callsite-line marker, FETCH `Proxy` arguments,
+  dispatch. The JIT's `call_func` shim reaches the same entry.
+- **`say $str` rendered its gist through the slow-path method dispatch.**
+  `render_gist_value` called `call_method_with_values(value, "gist")` for every
+  value, which for a plain `Str` was a ~7k-instruction walk of the
+  qualified/mixin/proxy/format/collection probes before the native `Str` row
+  answered "the string itself". `$output.say: $tap` is how every TAP line the
+  vendored module prints reaches stdout. A `Str` now gists as itself directly,
+  gated on the same memoized `native_lever_a_user_override` check the native
+  method fast paths use, so an `augment class Str { method gist {...} }` still
+  dispatches.
+
+Nothing is special-cased for `Test`: both paths are what any program that
+calls `nqp::` ops or `say`s a string was paying.
+
+## Measured
+
+Callgrind, per assertion, baseline subtracted (the profile's
+`exec_call_func_op'2` row is the five `nqp::` calls;
+`try_native_io_handle_output` is the `$output.say`):
+
+| | before | after |
+| --- | --- | --- |
+| per assertion | 335,929 Ir | 313,662 Ir |
+| `exec_call_func_op'2` (5 `nqp::` calls) | 28.1k | 16.0k |
+| `try_native_io_handle_output` | 9.8k | 3.2k |
+
+**-6.6% per assertion.**
+
+A measurement note for whoever runs this protocol next: the first run after
+a rebuild re-parses `Test.rakumod` (the module precompilation cache is keyed
+to the binary), so warm the cache with an uninstrumented run before the
+300-assertion side, or the ~1G of parser work lands on it.

--- a/src/runtime/io_env.rs
+++ b/src/runtime/io_env.rs
@@ -406,6 +406,18 @@ impl Interpreter {
         } else {
             value
         };
+        // A plain `Str` gists as itself. Answered here unless the program has
+        // augmented `Str` (or an ancestor) with its own `gist` -- the same
+        // memoized gate the native method fast paths use -- because the
+        // general dispatch below is a ~7k-instruction walk of every
+        // qualified/mixin/proxy/format/collection probe before it reaches the
+        // native `Str` row, and `say $str` is what every TAP line the vendored
+        // `Test.rakumod` prints comes down to (`$output.say: $tap`).
+        if let ValueView::Str(s) = value.view()
+            && !self.native_lever_a_user_override(value, "gist")
+        {
+            return Ok(s.to_string());
+        }
         // The pure native `.gist` fast path cannot reproduce the base method's
         // virtual `.Str` call on a role Mixin. Enter mixin dispatch directly so
         // a role-provided `gist`, or its inherited-gist/provided-Str fallback,

--- a/src/symbol.rs
+++ b/src/symbol.rs
@@ -160,6 +160,11 @@ pub(crate) mod flags {
     pub(crate) const INDEX_RW_CALL_TEMP: u8 = 1 << 1;
     /// A `__mutsu_type::<name>` typed-lexical metadata key.
     pub(crate) const TYPE_META: u8 = 1 << 2;
+    /// An `nqp::<op>` routine name: a compiler-known primitive in a reserved
+    /// namespace no user routine can be declared in, so a call op carrying
+    /// this name dispatches straight to the op table
+    /// (`Interpreter::exec_nqp_call_op`).
+    pub(crate) const NQP_OP: u8 = 1 << 3;
     /// Set once the byte has been computed (so a symbol with no flags is not
     /// recomputed on every lookup).
     pub(crate) const COMPUTED: u8 = 1 << 7;
@@ -168,6 +173,9 @@ pub(crate) mod flags {
 /// The `__mutsu_type::` prefix `flags::TYPE_META` marks. Kept next to the flag
 /// so the two cannot drift.
 pub(crate) const TYPE_META_PREFIX: &str = "__mutsu_type::";
+
+/// The `nqp::` prefix `flags::NQP_OP` marks.
+pub(crate) const NQP_OP_PREFIX: &str = "nqp::";
 
 fn compute_flags(s: &str) -> u8 {
     let mut f = flags::COMPUTED;
@@ -179,6 +187,9 @@ fn compute_flags(s: &str) -> u8 {
     }
     if s.starts_with(TYPE_META_PREFIX) {
         f |= flags::TYPE_META;
+    }
+    if s.starts_with(NQP_OP_PREFIX) {
+        f |= flags::NQP_OP;
     }
     f
 }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -146,6 +146,7 @@ mod vm_call_method_mut_ops;
 mod vm_call_method_ops;
 mod vm_call_named;
 mod vm_call_named_inner;
+mod vm_call_nqp;
 mod vm_call_resolve;
 pub(crate) mod vm_call_state_guard;
 mod vm_catch_dispatch;

--- a/src/vm/vm_call_func_ops.rs
+++ b/src/vm/vm_call_func_ops.rs
@@ -359,6 +359,13 @@ impl Interpreter {
         compiled_fns: &CompiledFns,
     ) -> Result<(), RuntimeError> {
         crate::vm::vm_stats::record_function_dispatch();
+        // An `nqp::` op is a compiler-known primitive in a reserved namespace:
+        // nothing below can answer it differently than the op table, so it
+        // goes there directly (see `exec_nqp_call_op`). One memoized flag
+        // byte on the callee symbol decides.
+        if code.const_sym(name_idx).flags() & crate::symbol::flags::NQP_OP != 0 {
+            return self.exec_nqp_call_op(code, name_idx, arity, arg_sources_idx);
+        }
         // `++`/`--` reach here as a call only because a user declared a `multi`
         // for the operator; the native implementation is one candidate of that
         // multi (rakudo's `Int:D`/`Bool`/`Num:D`/... core candidates), so rank

--- a/src/vm/vm_call_nqp.rs
+++ b/src/vm/vm_call_nqp.rs
@@ -1,0 +1,64 @@
+use super::*;
+
+impl Interpreter {
+    /// `OpCode::CallFunc` whose callee is an `nqp::` op.
+    ///
+    /// `nqp::` is a RESERVED namespace: no user routine can be declared there,
+    /// so none of the machinery `exec_call_func_op` runs for an ordinary call
+    /// — the increment/NativeCall/empty-proto gates, the light-call and OTF
+    /// cache probes, `normalize_call_args_for_target`'s registry probes,
+    /// `decode_arg_sources` — can ever change what the op table answers. The
+    /// op table already sat at the end of that chain (it was reached only after
+    /// every cache had missed); this entry, keyed on the callee symbol's
+    /// memoized `flags::NQP_OP` bit, takes it first. The vendored `Test.rakumod`
+    /// runs five `nqp::` ops per assertion (`nqp::time` twice, `nqp::join` /
+    /// `nqp::split` twice each, `nqp::iseq_i`), and each paid ~4k instructions
+    /// of call-dispatch overhead for a ~1k op
+    /// (`todo/deep/vendor-real-test-module.md`).
+    ///
+    /// The arguments are prepared exactly as the general path prepared them
+    /// before it reached the op table, so the ops see the same values:
+    ///
+    /// * `|EXPR` positions spread (`spread_call_args_by_syntax`);
+    /// * a `VarRef` capture unwraps to its value — the general path did this
+    ///   through `normalize_call_args_for_target`, whose registry probes all
+    ///   miss for an unregistered name, so it always chose the plain arguments
+    ///   (`nqp::eqaddr(Int, Int)` depends on it);
+    /// * the synthetic callsite-line marker is stripped and recorded;
+    /// * `Proxy` arguments are FETCHed (`nqp::` is not in
+    ///   `callee_takes_arg_containers`, and lvalue-assignment context never
+    ///   targets an nqp op).
+    ///
+    /// The rw-source descriptor is NOT decoded: an `nqp::` op binds no `is rw`
+    /// parameter, so it never contributes a writeback source, and the
+    /// companion slot map is repopulated (cleared first) by the next call that
+    /// does decode it.
+    pub(super) fn exec_nqp_call_op(
+        &mut self,
+        code: &CompiledCode,
+        name_idx: u32,
+        arity: u32,
+        arg_sources_idx: Option<u32>,
+    ) -> Result<(), RuntimeError> {
+        let arity = arity as usize;
+        if self.stack.len() < arity {
+            return Err(RuntimeError::new("Interpreter stack underflow in CallFunc"));
+        }
+        let start = self.stack.len() - arity;
+        let raw_args: Vec<Value> = self.stack.drain(start..).collect();
+        let (args, _) = Self::spread_call_args_by_syntax(code, raw_args, arg_sources_idx, None);
+        let args: Vec<Value> = args.into_iter().map(Self::unwrap_var_ref_value).collect();
+        // Unconditional, exactly as the general path: a `None` here clears a
+        // marker line a preceding call left pending.
+        let (args, callsite_line) = self.sanitize_call_args_owned(args);
+        loan_env!(self, set_pending_callsite_line(callsite_line));
+        let args = self.auto_fetch_proxy_args(args)?;
+        let name = Self::const_str(code, name_idx);
+        let op = name
+            .strip_prefix(crate::symbol::NQP_OP_PREFIX)
+            .expect("exec_nqp_call_op reached with a non-nqp:: callee");
+        let result = self.dispatch_nqp_op(op, &args)?;
+        self.stack.push(result);
+        Ok(())
+    }
+}


### PR DESCRIPTION
Sixth perf slice for `todo/deep/vendor-real-test-module.md` (callgrind-driven; the box has no `perf`).

## What

- **`nqp::` ops reach their op table first.** `exec_call_func_op` had an `nqp::` arm, but at the *end* of the general chain: the increment-operator gate, the NativeCall table, the empty-proto veto, the `&`-param shadow set, the direct-mapped + name-keyed light-call caches, the OTF cache, `decode_arg_sources`, and `normalize_call_args_for_target`'s registry probes all ran and all missed first (`nqp::` is a reserved namespace no routine can be declared in). ~4k instructions of dispatch for a ~1k op, five ops per `Test.rakumod` assertion. The callee symbol now carries a memoized `flags::NQP_OP` bit and the call takes `exec_nqp_call_op` (new, `src/vm/vm_call_nqp.rs`), which prepares the arguments exactly as the general path did before reaching the op table: spread `|` positions, unwrap `VarRef` captures, strip/record the callsite-line marker, FETCH `Proxy` args. The JIT's `call_func` shim reaches the same entry.
- **`say $str` no longer dispatches `.gist` through the slow path.** `render_gist_value` called `call_method_with_values(value, "gist")` for every value; for a plain `Str` that was ~7k instructions of qualified/mixin/proxy/format/collection probes before the native `Str` row answered "the string itself". A `Str` gists directly, gated on the same memoized `native_lever_a_user_override` check the native method fast paths use, so an `augment class Str { method gist {...} }` still dispatches.

Nothing is special-cased for `Test`.

## Measured

Callgrind, 300 `ok 1, "x"` in a loop under `MUTSU_REAL_TEST=1`, one-assertion baseline subtracted, release build:

| | before | after |
| --- | --- | --- |
| per assertion | 335,929 Ir | 313,662 Ir |
| `exec_call_func_op'2` (the five `nqp::` calls) | 28.1k | 16.0k |
| `try_native_io_handle_output` (`$output.say`) | 9.8k | 3.2k |

**-6.6% per assertion.**

## Verified

- `prove t/` on the debug binary: 3777 files, all pass.
- Whitelisted `roast/S24-testing/*.t` under both the native and the vendored `Test` provider (release): all pass.
- `cargo clippy --all-targets -- -D warnings`, `cargo fmt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J314VsqdhJ15T1rUJLvmyH

---
_Generated by [Claude Code](https://claude.ai/code/session_01J314VsqdhJ15T1rUJLvmyH)_