### PR TITLE
feat(runtime): the listop map defers too (ADR-0058 step 3)

### DIFF
--- a/docs/adr/0058-map-grep-produce-a-deferred-seq.md
+++ b/docs/adr/0058-map-grep-produce-a-deferred-seq.md
@@ -269,7 +269,7 @@ callback `Value` already carries its own closure environment.
 | **0** | **Measure the read-path exposure** by flipping `dispatch_map_method`/`builtin_map` to always call `create_lazy_map_list` behind a temporary env gate, and running `t/` and the roast whitelist with it on. This is option 3's exposure without option 3's cost, and it produces the list of consumers that read a deferred sequence without forcing it. | Discard the gate afterwards; it is a measurement, not a slice. |
 | **1** | **Done (2026-08-22).** `t/map-callback-runs-at-consumption.t` — 23 rows, raku-verified 23/23, mutsu 12 passing and 11 `todo`. Un-`todo`ing the nine ADR-0058 rows is this ADR's completion signal; the other two `todo`s belong to §1.4's separate bug. | Same shape as ADR-0034 phase 1. |
 | **2** | **Done (2026-09-07).** `SeqSource::MapGrep` + the `pull_seq_source` arm + `Value::seq_deferred` construction in `dispatch_map_method` only (not `builtin_map`, not `grep`), plus the read-path consumers S8 lists. | All nine ADR-0058 rows of phase 1's oracle are un-`todo`d; the two remaining `todo`s are S1.4's separate bug. |
-| **3a** | **Attempted and REVERTED (2026-09-07).** `builtin_map` (the `map &f, @xs` listop form) returning the same `Value::seq_deferred(SeqSource::MapGrep { .. })` as step 2 is a five-line diff and was green on `make test`, but the full roast run aborted a whitelisted file. **Blocked on a step-2 hole**, see S9.1 and `todo/deep/deferred-map-callback-runs-in-the-consuming-frames-env.md`. | |
+| **3a** | **Done (2026-09-07).** `builtin_map` (the `map &f, @xs` listop form) returns the same `Value::seq_deferred(SeqSource::MapGrep { .. })` as step 2. Attempted and reverted earlier the same day behind a step-2 hole (S9.1); that hole is closed (`news/2026-09/deferred-map-callback-frame.md`). The mandatory full `make roast` then found three more consumers, all fixed generally -- see S9.3. | `t/listop-map-defers.t`, and `t/nested-deferred-map-seq-is-pulled.t`'s listop row un-`todo`d. |
 | **3b** | Extend to both `grep` entry points. Measured 2026-09-07: grep is still fully eager and diverges from rakudo. `grep`'s `:k`/`:kv`/`:p` adverbs need positional indices over the whole result and can stay eager, exactly as they already opt out of `make_lazy_pipe`. **Its own slice, for a measured reason -- see S9.2.** | |
 | **4** | Retire the `body_contains_return` / `is_stub_routine_body` deferral predicate and `create_lazy_map_list` — both become dead once every map defers. | The maintainability payout. |
 
@@ -529,6 +529,22 @@ captured value for one of the block's own `free_var_syms` win, which is the same
 lexical-resolution rule the cell encodes, and costs a set lookup per captured
 key rather than an `Env` clone. So step 3 and step 4 are unblocked, and §5's
 mandatory full `make roast` is what still gates them.
+
+### 9.3 What the mandatory roast run found when step 3 landed (2026-09-07)
+
+`make test` was green (3779 files / 39681 tests) with step 3 in place, and the
+full `make roast` still failed three files. All three were **general** defects
+that eager `map` had been hiding, not step-3 special cases:
+
+| file | defect | fix |
+|---|---|---|
+| `integration/99problems-21-to-30.t` | The capture merge in `eval_map_over_items` now *overwrites* a same-named key, but `touched_keys` -- the save/restore set around the map loop -- still listed only the keys the merge *introduced*. A nested deferred map therefore left its own capture behind for the enclosing map's NEXT iteration, and a recursive producer read the inner call's `@sizes` from iteration 2 on. | Every key the merge overwrites is saved and restored. |
+| `S32-list/categorize.t` | `categorize`'s mapper result is read through `as_items`, a pure-value reader that cannot pull, so a mapper whose body is a `map` categorized nothing. The `LazyList` force beside it was the same guard for the older deferral. | `reify_map_grep_seq` on the mapper result. |
+| `S06-other/main.t` | rakudo's `RUN-MAIN` **sinks** `MAIN`'s return value; mutsu dropped it. Invisible while `map` was eager. | `sink_map_grep_seq` on `MAIN`'s result (both the fall-off-the-end and the explicit-`return` paths). |
+
+This is the §5 risk paying for itself twice: the run before step 3 caught the
+frame hole, and the run with step 3 caught three consumers. Keep the full local
+`make roast` for step 3b and step 4.
 
 ### 9.2 grep is eager too, and is its own slice regardless
 

--- a/news/2026-09/listop-map-defers.md
+++ b/news/2026-09/listop-map-defers.md
@@ -1,0 +1,77 @@
+# The listop `map` defers too (ADR-0058 step 3)
+
+`map &f, @xs` — the listop spelling — ran its callback at the call and answered
+a `List`. `@xs.map(&f)` has answered a not-yet-run `Seq` since ADR-0058 step 2,
+so the two spellings of the same operation disagreed about when the callback
+runs, what type comes back, and whether an enclosing `try` can catch a `die`
+raised inside it.
+
+```raku
+say (map { $_ * 2 }, 1..3).^name;                       # was List, now Seq
+sub ee { my $s = map -> $x { print "RAN"; $x }, 1..3; print "T"; $s }
+ee().List;                                              # was RANRANRANT, now TRANRANRAN
+sub dying { my $s = try { map { die "boom" }, 1..2 }; "tail" }
+```
+
+Step 3 is a five-line diff — `builtin_map`'s non-rw tail returns
+`Value::seq_deferred(SeqSource::MapGrep { .. })` instead of calling
+`eval_map_over_items`. It was attempted and reverted on 2026-09-06 because the
+full roast run aborted a whitelisted file with a stack overflow; that blocker
+(a deferred callback reading its free variables from the consuming frame) was
+closed first — `news/2026-09/deferred-map-callback-frame.md`.
+
+## The interesting part: what the mandatory roast run found
+
+ADR-0058 §5 makes a full local `make roast` mandatory for these steps, because
+each one makes mutsu *stricter* in every consumer of a mapped sequence.
+`make test` was green with step 3 in place — 3779 files, 39681 tests — and the
+roast run still failed three files. None of the three was a step-3 special
+case; all three were general defects that eager `map` had been hiding.
+
+**1. A nested deferred map clobbered the enclosing one's capture.**
+`eval_map_over_items` merges the callback's captured env into the running frame
+and restores it afterwards, but the save set (`touched_keys`) listed only the
+keys the merge *introduced*. Since the merge began overwriting a same-named key
+(the free-variable rule that closed the previous bug), an overwritten key was
+never restored — so an inner map left its own capture behind for the outer
+map's **next** iteration:
+
+```raku
+sub inner(@sizes) {
+    return $["END"] if @sizes == 0;
+    map -> $e { map -> $g { "$e/$g" }, inner(@sizes[1..*]) }, ['a', 'b']
+}
+say inner((1,2)).map({ .List.raku }).join(' ; ');
+```
+
+| | |
+|---|---|
+| rakudo | `("a/a/END", "a/b/END") ; ("b/a/END", "b/b/END")` |
+| before | `("a/a/END", "a/b/END") ; ("b/END",)` |
+
+Iteration 1 was right and iteration 2 read `@sizes` as the recursive call's
+`(2,)`. Every key the merge overwrites is saved and restored now.
+
+**2. `categorize`'s mapper result was never forced.** Its keys are read through
+`as_items`, a pure-value reader that cannot pull a deferred body (ADR-0034
+§2.1), so `categorize({ map { … }, .comb }, …)` categorized *nothing* — an
+empty hash. The one-line guard for exactly this, `reify_map_grep_seq`, was
+already in the codebase, and the older deferral's `LazyList` force sits on the
+adjacent line.
+
+**3. `MAIN`'s return value was not sunk.** rakudo's `RUN-MAIN` sinks it, which
+is why `sub MAIN() { map { print "ha" }, ^3 }` prints `hahaha`. mutsu dropped
+the value, which was invisible while `map` was eager and printed nothing once
+it was not. Both the fall-off-the-end and the explicit-`return` paths sink now.
+
+## Result
+
+`make test` PASS (3779 files / 39681 tests) and the full `make roast` PASS
+(1436 files / 218962 tests). Pinned by `t/listop-map-defers.t` (10 rows) and
+two new rows in `t/deferred-map-callback-frame.t`, all verified green under
+rakudo as well; `t/nested-deferred-map-seq-is-pulled.t`'s listop row is
+un-`todo`d.
+
+ADR-0058 step 3b (`grep`, which needs the rw-cell promotion `map` has no
+equivalent of) and step 4 (retiring `create_lazy_map_list`) remain open, and
+§5's full `make roast` still gates them.

--- a/src/runtime/builtins_collection_classify.rs
+++ b/src/runtime/builtins_collection_classify.rs
@@ -324,6 +324,13 @@ impl Interpreter {
             } else {
                 mapped
             };
+            // ADR-0058: a mapper whose body is a `map`/`grep` hands back a
+            // not-yet-run Seq, and `mapper_categories`/`mapper_path` read its
+            // elements through pure code (`as_items`), which cannot pull. Without
+            // this the whole categorization came out empty
+            // (`roast/S32-list/categorize.t`'s multi-level row). The sibling
+            // `LazyList` force above is the same guard for the older deferral.
+            self.reify_map_grep_seq(&mapped)?;
 
             let mapped_item = if let Some(as_fn) = &as_mapper {
                 self.call_sub_value(as_fn.clone(), vec![callable_item(item)], true)?

--- a/src/runtime/builtins_collection_mapgrep.rs
+++ b/src/runtime/builtins_collection_mapgrep.rs
@@ -112,7 +112,17 @@ impl Interpreter {
             {
                 return Ok(self.create_lazy_map_list(list_items, &sub_data));
             }
-            self.eval_map_over_items(func, list_items)
+            // ADR-0058 step 3: the listop `map &f, @xs` form defers exactly as
+            // the method form does — the callback runs when something consumes
+            // the Seq, not here. Without this the listop answered a `List`
+            // where rakudo answers a `Seq`, ran its side effects at the call
+            // instead of at first consumption, and let a `die` inside the
+            // callback be caught by a `try` that merely enclosed the `map`.
+            Ok(Value::seq_deferred(crate::value::SeqSource::MapGrep {
+                items: std::sync::Arc::new(list_items),
+                func,
+                fatal: self.fatal_mode,
+            }))
         }
     }
 

--- a/src/runtime/main_args.rs
+++ b/src/runtime/main_args.rs
@@ -533,9 +533,22 @@ impl Interpreter {
             .insert("*USAGE".to_string(), Value::str(usage_text));
         self.mark_readonly("$*USAGE");
         self.mark_readonly("*USAGE");
+        // rakudo's `RUN-MAIN` SINKS whatever `MAIN` returns
+        // (`roast/S06-other/main.t`'s "MAIN return value is sunk"), so a `MAIN`
+        // whose tail is a `map` still runs its callback. Since ADR-0058 that
+        // tail is a not-yet-run Seq rather than an already-evaluated List, and
+        // dropping it here dropped the side effects with it.
         match self.call_routine_def(candidate, args) {
-            Ok(_) => Ok(()),
-            Err(e) if e.return_value.is_some() => Ok(()),
+            Ok(v) => {
+                self.sink_map_grep_seq(&v)?;
+                Ok(())
+            }
+            Err(e) if e.return_value.is_some() => {
+                if let Some(v) = e.return_value.clone() {
+                    self.sink_map_grep_seq(&v)?;
+                }
+                Ok(())
+            }
             Err(e) if e.message.is_empty() => Ok(()),
             Err(e) => Err(e),
         }

--- a/src/runtime/resolution_map_grep.rs
+++ b/src/runtime/resolution_map_grep.rs
@@ -498,8 +498,26 @@ impl Interpreter {
             // Captured lexical vars (in data.env) must keep mutations done inside
             // the mapper block (e.g. `{ $a++ }`).
             let mut touched_keys: Vec<String> = Vec::with_capacity(data.params.len() + 1);
-            for k in data.env.keys() {
-                if !self.env.contains_key_sym(*k) {
+            // Every key the capture merge below OVERWRITES has to be saved here
+            // too, not only the ones it introduces: a nested map that overwrote
+            // a name the enclosing map had already installed would otherwise
+            // leave its own value behind for the enclosing map's NEXT iteration
+            // (`sub inner(@sizes) { map -> $e { map -> $g {...},
+            // inner(@sizes[1..*]) }, ['a','b'] }` read `@sizes` as the inner
+            // call's on iteration 2). `self` is handled explicitly below.
+            let free_vars = data
+                .compiled_code
+                .as_ref()
+                .map(|cc| cc.capture_free_var_set());
+            let capture_wins = |k: &crate::symbol::Symbol, v: &Value| {
+                let is_dynamic =
+                    k.with_str(|s| s.trim_start_matches(['$', '@', '%', '&']).starts_with('*'));
+                !is_dynamic
+                    && (matches!(v.view(), ValueView::ContainerRef(_))
+                        || free_vars.is_some_and(|free| free.contains(k)))
+            };
+            for (k, v) in &data.env {
+                if !self.env.contains_key_sym(*k) || capture_wins(k, v) {
                     touched_keys.push(k.resolve());
                 }
             }
@@ -560,17 +578,11 @@ impl Interpreter {
             //    base case (`todo/deep/deferred-map-callback-...`, which
             //    aborted `roast/integration/99problems-21-to-30.t` with a
             //    stack overflow when ADR-0058 step 3 landed).
-            let free_vars = data
-                .compiled_code
-                .as_ref()
-                .map(|cc| cc.capture_free_var_set());
             for (k, v) in &data.env {
-                let is_dynamic =
-                    k.with_str(|s| s.trim_start_matches(['$', '@', '%', '&']).starts_with('*'));
-                let capture_wins = !is_dynamic
-                    && (matches!(v.view(), ValueView::ContainerRef(_))
-                        || free_vars.is_some_and(|free| free.contains(k)));
-                if capture_wins || k.with_str(|s| s == "self") || !self.env.contains_key_sym(*k) {
+                if capture_wins(k, v)
+                    || k.with_str(|s| s == "self")
+                    || !self.env.contains_key_sym(*k)
+                {
                     self.env.insert_sym(*k, v.clone());
                 }
             }

--- a/t/deferred-map-callback-frame.t
+++ b/t/deferred-map-callback-frame.t
@@ -7,7 +7,7 @@ use Test;
 # frame. Only `$`-scalars got this right (they are boxed into a shared cell);
 # an `@`/`%` container free variable lost to the consumer's.
 
-plan 9;
+plan 11;
 
 {
     my @sizes = 1, 2, 3;
@@ -71,4 +71,34 @@ plan 9;
     my $s = (1,).map({ $a });
     $a = 5;
     is $s.List, (5,), 'a lexical mutated after the `.map` call is seen at the pull';
+}
+
+# A NESTED deferred map must not leave its own capture behind for the enclosing
+# map's next iteration. The capture merge overwrites a same-named key now, so
+# every key it overwrites has to be saved and restored around the loop -- not
+# only the keys it introduces. Without that, `inner`'s second outer iteration
+# read `@sizes` as the recursive call's `(2,)`.
+{
+    sub inner(@sizes) {
+        return $["END"] if @sizes == 0;
+        map -> $e {
+            map -> $g { "$e/$g" }, inner(@sizes[1..*])
+        }, ['a', 'b']
+    }
+    is inner((1, 2)).map({ .List.raku }).join(' ; '),
+        '("a/a/END", "a/b/END") ; ("b/a/END", "b/b/END")',
+        'a nested deferred map does not clobber the enclosing one\'s capture';
+}
+
+# The same shape one level deeper, with the recursion feeding the inner source.
+{
+    sub deep(@sizes) {
+        return $['X'] if @sizes == 0;
+        map -> $e {
+            map -> $g { "$e$g" }, deep(@sizes[1..*])
+        }, ['p', 'q']
+    }
+    is deep((1, 2, 3)).map({ .List.map({ .List.raku }).join(',') }).join(' ; '),
+        '("pppX pqX",),("pqpX qqX",) ; ("qppX pqX",),("qqpX qqX",)',
+        '... at three levels of recursion too';
 }

--- a/t/listop-map-defers.t
+++ b/t/listop-map-defers.t
@@ -1,0 +1,48 @@
+use Test;
+
+# ADR-0058 step 3: the listop `map &f, @xs` form defers exactly as the method
+# form does. Until it did, the listop answered a `List` where rakudo answers a
+# `Seq`, ran its side effects at the call instead of at first consumption, and
+# let a `die` inside the callback be caught by a `try` that merely enclosed the
+# `map` call.
+
+plan 10;
+
+is (map { $_ * 2 }, 1..3).^name, 'Seq', 'the listop map answers a Seq';
+
+{
+    my $log = '';
+    sub produce { my $s = map -> $x { $log ~= "RAN"; $x }, 1..3; $log ~= "T"; $s }
+    my $seq = produce();
+    is $log, 'T', 'the callback has not run when the listop map returns';
+    is $seq.List.elems, 3, '... the pull produces every element';
+    is $log, 'TRANRANRAN', '... and the callback ran at the pull, not at the call';
+}
+
+{
+    # A `die` inside the callback escapes a `try` that only lexically encloses
+    # the `map`, because the callback runs later, at the consuming statement.
+    sub produce-dying { my $s = try { map { die "boom" }, 1..2 }; "reached-tail|" ~ $s.defined }
+    is produce-dying(), 'reached-tail|True', 'the enclosing try does not catch a not-yet-run callback';
+}
+
+is (map { $_ + 1 }, 1..3).List.raku, '(2, 3, 4)', 'the elements are the mapped ones';
+is (map { $_ }, ()).List.raku, '()', 'an empty source produces an empty Seq';
+
+{
+    my @out;
+    for map { $_ * 5 }, 1..3 { @out.push: $_ }
+    is @out.raku, '[5, 10, 15]', 'a `for` over the deferred listop map iterates it';
+}
+
+# Pure-value readers cannot pull a deferred Seq, so a consumer that reads the
+# callback's result through `as_items` needs the ADR-0058 reify guard.
+# `categorize`'s mapper is one: without it the whole categorization came out
+# empty (`roast/S32-list/categorize.t`'s multi-level row).
+is categorize({ map { $_ + 10 }, .comb }, 12, 34).raku,
+    '(my Mu %{Mu} = 11 => $[12], 12 => $[12], 13 => $[34], 14 => $[34])',
+    'a `categorize` mapper whose body is a listop map is forced';
+
+is classify({ (map { $_ }, .comb).head }, 12, 34).raku,
+    '(my Mu %{Mu} = "1" => $[12], "3" => $[34])',
+    '... and so is a `classify` mapper';

--- a/t/nested-deferred-map-seq-is-pulled.t
+++ b/t/nested-deferred-map-seq-is-pulled.t
@@ -20,11 +20,7 @@ is nested().flat.join('|'), 'STOP', '.flat reaches the inner elements';
 is nested().elems, 1, 'the outer Seq still has one element';
 is nested()[0].elems, 1, '... whose own Seq has one element';
 
-# The listop spelling of the same nesting. It does not reach this path at all
-# yet: `builtin_map` is still eager (ADR-0058 step 3 is blocked -- see
-# `todo/deep/deferred-map-callback-runs-in-the-consuming-frames-env.md`), so it
-# answers a plain nested List instead of a Seq of Seqs.
-todo 'the listop `map` is still eager (ADR-0058 step 3)';
+# The listop spelling of the same nesting, deferred since ADR-0058 step 3.
 is (map { map { "STOP" }, [2] }, [1]).raku, '(("STOP",).Seq,).Seq',
     'the listop spelling agrees';
 


### PR DESCRIPTION
Re-lands ADR-0058 step 3, which was attempted and reverted on 2026-09-06 behind a step-2 hole. That hole is closed (#7467), so this is the five-line diff plus what the mandatory roast run then found.

## What changes

`map &f, @xs` ran its callback at the call and answered a `List`, while `@xs.map(&f)` has answered a not-yet-run `Seq` since step 2. The two spellings of the same operation disagreed about when the callback runs, what type comes back, and whether an enclosing `try` catches a `die` raised inside it. `builtin_map`'s non-rw tail now returns the same `Value::seq_deferred(SeqSource::MapGrep { .. })`.

| probe | before | rakudo / after |
|---|---|---|
| `(map { $_ * 2 }, 1..3).^name` | `List` | `Seq` |
| `sub ee { my $s = map -> $x { print "RAN"; $x }, 1..3; print "T"; $s }`, then pull | `RANRANRANT` | `TRANRANRAN` |
| `try { map { die "boom" }, 1..2 }`, consumed after the `try` | caught | escapes |

## The interesting part — what the mandatory `make roast` found

ADR-0058 §5 makes a full local `make roast` mandatory for these steps, because each one makes mutsu *stricter* in every consumer of a mapped sequence. `make test` was green with step 3 in place — 3779 files / 39681 tests — and roast still failed three files. **None was a step-3 special case; all three were general defects that eager `map` had been hiding.**

### 1. A nested deferred map clobbered the enclosing one's capture

`eval_map_over_items` saves and restores the keys its capture merge touches, but the save set (`touched_keys`) listed only the keys the merge *introduced*. Since the merge began overwriting a same-named key (#7467's free-variable rule), an overwritten key was never restored — so an inner map left its own capture behind for the outer map's **next** iteration.

```raku
sub inner(@sizes) {
    return $["END"] if @sizes == 0;
    map -> $e { map -> $g { "$e/$g" }, inner(@sizes[1..*]) }, ['a', 'b']
}
say inner((1,2)).map({ .List.raku }).join(' ; ');
```

| | |
|---|---|
| rakudo | `("a/a/END", "a/b/END") ; ("b/a/END", "b/b/END")` |
| before | `("a/a/END", "a/b/END") ; ("b/END",)` |

Iteration 1 was right; iteration 2 read `@sizes` as the recursive call's `(2,)`. Every key the merge overwrites is saved and restored now. Caught by `roast/integration/99problems-21-to-30.t`.

### 2. `categorize`'s mapper result was never forced

Its keys are read through `as_items`, a pure-value reader that cannot pull a deferred body (ADR-0034 §2.1), so `categorize({ map { … }, .comb }, …)` categorized **nothing** — an empty hash. Fixed with the existing one-line `reify_map_grep_seq` guard, which sits beside the `LazyList` force that is the same guard for the older deferral. Caught by `roast/S32-list/categorize.t`.

### 3. `MAIN`'s return value was not sunk

rakudo's `RUN-MAIN` sinks it, which is why `sub MAIN() { map { print "ha" }, ^3 }` prints `hahaha`. mutsu dropped the value — invisible while `map` was eager, and silent once it was not. Both the fall-off-the-end and the explicit-`return` paths sink now. Caught by `roast/S06-other/main.t`.

## Tests

- `t/listop-map-defers.t` — 10 rows (new), green under **rakudo** as well.
- `t/deferred-map-callback-frame.t` — 2 new rows for the nested/recursive clobber, also rakudo-green.
- `t/nested-deferred-map-seq-is-pulled.t` — its listop row is un-`todo`d.
- `make test`: **PASS**, 3779 files / 39681 tests.
- Full local `make roast`: **PASS**, 1436 files / 218962 tests.

## Follow-up

Step 3b (`grep` — it needs the rw-cell promotion `map` has no equivalent of, see ADR-0058 §9.2) and step 4 (retiring `create_lazy_map_list`) remain open. §5's full `make roast` still gates both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)