### PR TITLE
perf(vm): answer env-pure CallMethodMut shapes before the scoped-env flatten

### DIFF
--- a/news/2026-09/env-pure-method-dispatch-skips-the-scoped-env-flatten.md
+++ b/news/2026-09/env-pure-method-dispatch-skips-the-scoped-env-flatten.md
@@ -1,0 +1,61 @@
+# Two env-pure method dispatch shapes stop flattening the caller's scoped env
+
+Seventh perf slice for `todo/deep/vendor-real-test-module.md`. The
+`CallMethodMut` opcode collapses a scoped overlay env to a flat one before any
+dispatch past the pure-read accessor fast path, because full dispatch may
+capture the env into a closure or run an interpreter fallback that iterates it.
+A vendored-`Test` assertion makes exactly two method calls, `$desc.Str` and
+`$output.say: $tap`, and both paid that guard: the flatten itself is a
+whole-scope map clone, and once `proclaim`'s env is flat its return merge and
+env drop become scope-sized instead of overlay-sized.
+`todo/perf/method-dispatch-flattens-the-env-on-every-call.md` records why the
+wholesale answer -- deleting the guard and moving the flatten to the consumers
+that iterate -- measured neutral-to-negative; this slice does not touch the
+guard. It answers two dispatch shapes *before* it, the way the accessor read
+already is:
+
+- **A pure native method on an immutable scalar receiver** (`Str`, `Int`,
+  `Num`, `Bool`). `try_native_method` is Rust over the value, and an immutable
+  receiver has no writeback, so none of the by-name or by-identity env scans
+  the container mutators perform can be reached. Every decision the general
+  path made for such a receiver is made identically: the same `quoted` /
+  modifier exclusions, the same junction-argument autothreading deferral, the
+  same `native_lever_a_user_override` gate (an augmented `Str.uc` still
+  dispatches), and the methods that own a dedicated branch on the general path
+  (`subst-mutate`, the `hyper`/`race` configuration form, the xxx-KEY /
+  `BIND-POS` / `add`/`remove` mutator arms, the `push`-family
+  autovivification, the undeclared-type `.new` check) are left to it.
+- **Text output to a native `IO::Handle`** (`print`/`put`/`say`/`printf`/
+  `print-nl` on an exact `IO::Handle` instance with no augmented override).
+  `try_native_io_handle_output` writes handle-table state and renders its
+  arguments; it neither captures nor iterates the caller's env. A user
+  subclass has a different class name and keeps the full path, so its `WRITE`
+  override still routes through `try_user_io_handle_method`.
+
+The hoisted shapes also skip the receiver-typed branches between the guard and
+the general native probe (junction threading, `WHO`, `Lock.protect`, the
+shared-array mutators, the `skip_native` computation, `Match.make`, the
+HyperSeq arms, the xxx-KEY match), which is why the win exceeds what the
+flatten alone cost. `src/vm/vm_call_method_mut_prenative.rs` holds the entry;
+the general path is unchanged for everything it declines.
+
+## Measured
+
+Callgrind, 300 `ok 1, "x"` in a loop under `MUTSU_REAL_TEST=1`, one-assertion
+baseline subtracted, release build:
+
+| | before | after |
+| --- | --- | --- |
+| per assertion | 313,662 Ir | 285,180 Ir |
+| `exec_call_method_mut_op_impl` (both calls) | 29.6k | 14.6k |
+| `flatten_scoped_env` | 8.8k | 0 |
+| `proclaim`'s frame (`call_compiled_function_named_inner'2`) | 194.8k | 166.4k |
+
+**-9.1% per assertion**, against a -7.5% upper bound measured by disabling the
+guard outright (an unsound kill-switch run, purely to size the prize): the
+guard's flatten, the scope-sized return merge, and the scope-sized env drop
+all go, plus the intermediate branches.
+
+Since the session opened at 335,929 Ir per assertion this and the previous
+slice (`news/2026-09/nqp-ops-and-str-gist-skip-the-call-machinery.md`)
+total **-15.1%**.

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -143,6 +143,7 @@ mod vm_call_method_compiled_interpret;
 mod vm_call_method_compiled_io;
 mod vm_call_method_compiled_mut;
 mod vm_call_method_mut_ops;
+mod vm_call_method_mut_prenative;
 mod vm_call_method_ops;
 mod vm_call_named;
 mod vm_call_named_inner;

--- a/src/vm/vm_call_method_mut_ops.rs
+++ b/src/vm/vm_call_method_mut_ops.rs
@@ -992,6 +992,16 @@ impl Interpreter {
                 return Ok(());
             }
         }
+        // Two more dispatch shapes that touch no env -- a pure native method on
+        // an immutable scalar receiver, and text output to a native
+        // `IO::Handle` -- are answered here, before the flatten below, for the
+        // same reason the accessor read is. See `try_env_pure_mut_dispatch`.
+        if let Some(result) =
+            self.try_env_pure_mut_dispatch(&target, &method, method_sym, &args, modifier, quoted)
+        {
+            self.stack.push(result?);
+            return Ok(());
+        }
         // Beyond the pure-read accessor fast path above, full method dispatch may
         // capture/iterate the env; collapse a transient scoped overlay env to a
         // flat env so the full lexical view is seen. Placed after the accessor

--- a/src/vm/vm_call_method_mut_prenative.rs
+++ b/src/vm/vm_call_method_mut_prenative.rs
@@ -1,0 +1,124 @@
+use super::*;
+
+impl Interpreter {
+    /// Method names `exec_call_method_mut_op_impl` gives a dedicated branch
+    /// between its scoped-env flatten and its general native probe that can
+    /// apply to a plain scalar receiver: the undeclared-type `.new` check on a
+    /// `Str`, `subst-mutate`, the `hyper`/`race` configuration form, the
+    /// xxx-KEY / BIND-POS / `add`/`remove` mutators (their `Nil`/type-object
+    /// arms), the `push`-family autovivification, and the Lock/Match/WHO
+    /// arms (receiver-typed, listed for completeness). A call to any of them
+    /// keeps the full dispatch path so that branch still sees it.
+    fn mut_dispatch_branches_before_native_probe(method: &str) -> bool {
+        matches!(
+            method,
+            "new"
+                | "WHO"
+                | "protect"
+                | "protect-or-queue-on-recursion"
+                | "with-lock-hidden-from-recursion-check"
+                | "make"
+                | "subst-mutate"
+                | "hyper"
+                | "race"
+                | "AT-KEY"
+                | "ASSIGN-KEY"
+                | "DELETE-KEY"
+                | "BIND-KEY"
+                | "BIND-POS"
+                | "add"
+                | "remove"
+                | "push"
+                | "unshift"
+                | "append"
+                | "prepend"
+        )
+    }
+
+    /// `CallMethodMut` dispatches that provably never look at the lexical
+    /// environment, answered BEFORE the opcode's `flatten_scoped_env` guard.
+    ///
+    /// The guard exists because full method dispatch may capture the env into
+    /// a closure or run an interpreter fallback that iterates it, and a scoped
+    /// overlay env would hand such a consumer a truncated view. Two dispatch
+    /// shapes cannot reach any such consumer, and they are exactly the two a
+    /// vendored `Test.rakumod` assertion makes (`$desc.Str`, `$output.say`):
+    ///
+    /// 1. **A pure native method on an immutable scalar receiver** (`Str`,
+    ///    `Int`, `Num`, `Bool`). `try_native_method` is Rust over the value;
+    ///    an immutable receiver has no writeback, so none of the by-name or
+    ///    by-identity env scans the container mutators perform can be
+    ///    reached. Everything the general path would have decided for such a
+    ///    receiver is decided identically here: the same `quoted`/modifier
+    ///    exclusions, the same junction-argument autothreading deferral, the
+    ///    same `native_lever_a_user_override` gate (an augmented `Str.uc`
+    ///    still wins), and the methods that own a dedicated branch on the
+    ///    general path are left to it (`mut_dispatch_branches_before_native_probe`).
+    /// 2. **Text output to a native `IO::Handle`** (`print`/`put`/`say`/
+    ///    `printf`/`print-nl` on an exact `IO::Handle` instance, no augmented
+    ///    override). `try_native_io_handle_output` writes handle-table state
+    ///    and renders its arguments; it neither captures nor iterates the
+    ///    caller's env. A user subclass has a different class name and keeps
+    ///    the full path (its `WRITE` override is what `try_user_io_handle_method`
+    ///    routes to).
+    ///
+    /// Why this matters: the guard's flatten on a scoped env is a whole-scope
+    /// map clone, and it also turns the enclosing routine's return merge and
+    /// env drop from overlay-sized into scope-sized. Measured on the vendored
+    /// `Test` assertion loop the guard and its consequences were ~7.5% of the
+    /// per-assertion budget, with these two calls the only dispatches that
+    /// paid it (`todo/deep/vendor-real-test-module.md`, and the record of the
+    /// wholesale relocation that did NOT pay in
+    /// `todo/perf/method-dispatch-flattens-the-env-on-every-call.md`).
+    ///
+    /// Returns `None` to continue with the general path unchanged.
+    #[allow(clippy::too_many_arguments)]
+    pub(super) fn try_env_pure_mut_dispatch(
+        &mut self,
+        target: &Value,
+        method: &str,
+        method_sym: crate::symbol::Symbol,
+        args: &[Value],
+        modifier: Option<&str>,
+        quoted: bool,
+    ) -> Option<Result<Value, RuntimeError>> {
+        if modifier.is_some() || quoted {
+            return None;
+        }
+        if matches!(
+            target.view(),
+            ValueView::Str(_) | ValueView::Int(_) | ValueView::Num(_) | ValueView::Bool(_)
+        ) {
+            if Self::mut_dispatch_branches_before_native_probe(method)
+                || args
+                    .iter()
+                    .any(|a| matches!(a.view(), ValueView::Junction { .. }))
+                || self.native_lever_a_user_override(target, method)
+            {
+                return None;
+            }
+            let native_result = self.try_native_method(target, method_sym, args)?;
+            // Same bookkeeping as the general path's native completion: a
+            // value-returning native on an immutable receiver is env-pure.
+            self.method_dispatch_pure = true;
+            crate::vm::vm_stats::record_dispatch_entry_outcome("callmethodmut", "native");
+            self.shadow_check_native_row_candidate(target, method, method_sym, args.len(), true);
+            return Some(native_result);
+        }
+        if let ValueView::Instance { class_name, .. } = target.view()
+            && class_name == "IO::Handle"
+            && matches!(method, "print" | "put" | "say" | "printf" | "print-nl")
+            && !self.has_user_method("IO::Handle", method)
+        {
+            let result = self.try_native_io_handle_output(target, method, args)?;
+            // Same bookkeeping as the general path's user-dispatch completion
+            // this used to reach: the rendering may run user `gist` code, so
+            // the dispatch is not assumed env-pure.
+            self.method_dispatch_pure = false;
+            crate::vm::vm_stats::record_dispatch_entry_outcome("callmethodmut", "user");
+            self.shadow_check_native_row_candidate(target, method, method_sym, args.len(), false);
+            return Some(result);
+        }
+        None
+    }
+}


### PR DESCRIPTION
Seventh perf slice for `todo/deep/vendor-real-test-module.md` (callgrind-driven), following #7472.

## What

`CallMethodMut` runs `flatten_scoped_env()` before any dispatch past the pure-read accessor fast path, because full dispatch may capture the env into a closure or run an interpreter fallback that iterates it. A vendored-`Test` assertion makes exactly two method calls, `$desc.Str` and `$output.say: $tap`, and both paid that guard: the flatten is a whole-scope map clone, and once `proclaim`'s env is flat its return merge and env drop are scope-sized instead of overlay-sized.

`todo/perf/method-dispatch-flattens-the-env-on-every-call.md` records why deleting the guard and relocating the flatten to the consumers measured neutral-to-negative. This PR does not touch the guard. It answers two dispatch shapes *before* it, the way the accessor read already is (`src/vm/vm_call_method_mut_prenative.rs`, `try_env_pure_mut_dispatch`):

1. **A pure native method on an immutable scalar receiver** (`Str`/`Int`/`Num`/`Bool`). `try_native_method` is Rust over the value and an immutable receiver has no writeback, so none of the by-name / by-identity env scans the container mutators perform can be reached. The same exclusions the general path applies are applied here: `quoted`/modifier forms, junction-argument autothreading, the `native_lever_a_user_override` gate (an augmented `Str.uc` still dispatches), and the methods that own a dedicated branch on the general path (`subst-mutate`, `hyper`/`race` config, xxx-KEY / `BIND-POS` / `add`/`remove` arms, `push`-family autoviv, the undeclared-type `.new` check) are left to it.
2. **Text output to a native `IO::Handle`** (`print`/`put`/`say`/`printf`/`print-nl` on an exact `IO::Handle` instance, no augmented override). `try_native_io_handle_output` writes handle-table state and renders its arguments; a user subclass has a different class name and keeps the full path (its `WRITE` override still routes through `try_user_io_handle_method`).

The general path is unchanged for everything the entry declines.

## Measured

Callgrind, 300 `ok 1, "x"` in a loop under `MUTSU_REAL_TEST=1`, one-assertion baseline subtracted, release build:

| | before | after |
| --- | --- | --- |
| per assertion | 313,662 Ir | 285,180 Ir |
| `exec_call_method_mut_op_impl` (both calls) | 29.6k | 14.6k |
| `flatten_scoped_env` | 8.8k | 0 |
| `proclaim`'s frame | 194.8k | 166.4k |

**-9.1% per assertion**, against a -7.5% upper bound from an unsound kill-switch run that disabled the guard outright (the hoisted shapes also skip the receiver-typed branches between the guard and the general native probe). Cumulative since the session opened at 335,929: **-15.1%**.

## Verified

- `prove t/` on the debug binary: 3777 files, all pass.
- Whitelisted `roast/S24-testing/*.t` under both providers, plus 82 `S32-str` / `S02-types` / `S32-io` whitelisted files (release): all pass (the three `*-encode-decode.t` files need the `scripts/run-roast-test.sh` path setup and pass through it).
- `cargo clippy --all-targets -- -D warnings`, `cargo fmt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J314VsqdhJ15T1rUJLvmyH

---
_Generated by [Claude Code](https://claude.ai/code/session_01J314VsqdhJ15T1rUJLvmyH)_