### PR TITLE
perf(vm): free-variable reads stop building substring searchers

### DIFF
--- a/news/2026-09/free-variable-reads-drop-the-substring-searchers.md
+++ b/news/2026-09/free-variable-reads-drop-the-substring-searchers.md
@@ -1,0 +1,43 @@
+# Free-variable reads stop building substring searchers
+
+Eighth perf slice for `todo/deep/vendor-real-test-module.md`. After the two
+previous slices the callgrind profile of a vendored-`Test` assertion showed
+`<&str as Pattern>::is_contained_in` at ~13.7k instructions per assertion,
+~6k of it under `package_scope_lexical` alone. A routine body's free-variable
+read (`$num_of_tests_run`, `$indents`, `$output`, ... -- a `Test.rakumod`
+assertion makes about ten) resolves through the package-lexical, unit-lexical
+and `our`-mirror stores in turn, and each of those asked
+`str::contains("::")` / `contains("::&")` of the variable name and the running
+package. `str::contains(&str)` builds a two-way searcher per call; on names
+this short the setup is the whole cost.
+
+Two changes, both general:
+
+- **`package_scope_lexical` gates on an empty store first.** It answers a
+  bare `package P { my $x; ... }` block's lexical from inside `P`'s subs;
+  most programs never run such a block, so `package_lexicals` is empty and
+  nothing below the gate can resolve. The package probe and both name scans
+  now run only when the store has something to find.
+- **The fixed ASCII markers are byte scans.** `runtime::utils::str_scan`
+  provides `has_double_colon`, `has_routine_scope_marker` (`::&`) and
+  `has_anon_marker` (`__ANON`) as plain `windows().any()` scans, and the
+  resolvers on the read/write hot paths use them (`vm_env_helpers`,
+  `vm_our_package_vars`, `vm_var_get_ops`, `exec_set_local_op`, the
+  container-identity store, the routine-package entry). A unit test pins
+  them against `str::contains` on the shapes the resolvers see.
+
+## Measured
+
+Callgrind, 300 `ok 1, "x"` in a loop under `MUTSU_REAL_TEST=1`, one-assertion
+baseline subtracted, release build:
+
+| | before | after |
+| --- | --- | --- |
+| per assertion | 285,180 Ir | 276,814 Ir |
+| `<&str as Pattern>::is_contained_in` | 13.7k | 0 |
+| `unit_lexical_slot` | 12.4k | 7.5k |
+| `get_env_with_main_alias` | 11.6k | 8.2k |
+
+**-2.9% per assertion**; -17.6% since the session opened at 335,929
+(`news/2026-09/nqp-ops-and-str-gist-skip-the-call-machinery.md`,
+`news/2026-09/env-pure-method-dispatch-skips-the-scoped-env-flatten.md`).

--- a/src/runtime/utils.rs
+++ b/src/runtime/utils.rs
@@ -573,6 +573,7 @@ mod rat;
 mod set_coerce;
 mod set_ops;
 mod shaped;
+mod str_scan;
 mod type_constraints;
 mod type_misc;
 
@@ -587,6 +588,7 @@ pub(crate) use rat::*;
 pub(crate) use set_coerce::*;
 pub(crate) use set_ops::*;
 pub(crate) use shaped::*;
+pub(crate) use str_scan::*;
 pub(crate) use type_constraints::*;
 pub(crate) use type_misc::*;
 

--- a/src/runtime/utils/str_scan.rs
+++ b/src/runtime/utils/str_scan.rs
@@ -1,0 +1,69 @@
+//! Byte scans for the fixed ASCII markers the name-resolution hot paths test
+//! for (`::`, `::&`, `__ANON`).
+//!
+//! `str::contains(&str)` builds a two-way searcher per call; on the short
+//! variable/package names these paths test that setup dominates the scan,
+//! and a free-variable read in a routine body asked it several times per
+//! read (the package-lexical, unit-lexical and `our`-mirror resolvers each
+//! probe `name` for `::` and the running package for `::&`). Callgrind on the
+//! vendored `Test.rakumod`'s assertion loop put `is_contained_in` at ~14k
+//! instructions per assertion, ~6k of it from `package_scope_lexical` alone
+//! (`todo/deep/vendor-real-test-module.md`). A linear byte scan for a
+//! two-to-six byte needle is a handful of instructions per haystack byte and
+//! needs no setup.
+
+/// `hay` contains the ASCII `needle` (non-empty).
+#[inline]
+pub(crate) fn has_ascii(hay: impl AsRef<str>, needle: &[u8]) -> bool {
+    let h = hay.as_ref().as_bytes();
+    if h.len() < needle.len() {
+        return false;
+    }
+    h.windows(needle.len()).any(|w| w == needle)
+}
+
+/// `name` is package-qualified: it contains `::`.
+#[inline]
+pub(crate) fn has_double_colon(name: impl AsRef<str>) -> bool {
+    has_ascii(name, b"::")
+}
+
+/// `pkg` is a mangled routine-body scope name (`Pkg::&sub/arity`).
+#[inline]
+pub(crate) fn has_routine_scope_marker(pkg: impl AsRef<str>) -> bool {
+    has_ascii(pkg, b"::&")
+}
+
+/// `name` is a compiler-synthesised anonymous container slot
+/// (`%__ANON_HASH__` / `@__ANON_ARRAY__`).
+#[inline]
+pub(crate) fn has_anon_marker(name: impl AsRef<str>) -> bool {
+    has_ascii(name, b"__ANON")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scans_agree_with_str_contains() {
+        for s in [
+            "",
+            ":",
+            "::",
+            "a::b",
+            "P::&f/2",
+            "%__ANON_HASH__",
+            "@__ANON_ARRAY__",
+            "__ANO",
+            "x",
+            "Test",
+            "num_of_tests_run",
+            "IO::Handle+{M::R}",
+        ] {
+            assert_eq!(has_double_colon(s), s.contains("::"), "{s:?}");
+            assert_eq!(has_routine_scope_marker(s), s.contains("::&"), "{s:?}");
+            assert_eq!(has_anon_marker(s), s.contains("__ANON"), "{s:?}");
+        }
+    }
+}

--- a/src/vm/vm_call_eligibility.rs
+++ b/src/vm/vm_call_eligibility.rs
@@ -25,7 +25,7 @@ impl Interpreter {
 
     #[inline(never)]
     fn enter_routine_package_outlined(&mut self, cf: &CompiledFunction) -> Option<String> {
-        if cf.package.contains("::&") {
+        if crate::runtime::utils::has_routine_scope_marker(&cf.package) {
             return None;
         }
         let saved = self.current_package();

--- a/src/vm/vm_call_named_inner.rs
+++ b/src/vm/vm_call_named_inner.rs
@@ -158,7 +158,9 @@ impl Interpreter {
         // call read/wrote package vars under `GLOBAL` and silently lost them.
         // Skip a mangled state-scope package (`Pkg::&sub/arity`, used for nested
         // subs) and fall back to the passed name in that case.
-        let def_package: &str = if !cf.package.is_empty() && !cf.package.contains("::&") {
+        let def_package: &str = if !cf.package.is_empty()
+            && !crate::runtime::utils::has_routine_scope_marker(&cf.package)
+        {
             cf.package.as_str()
         } else {
             fn_package

--- a/src/vm/vm_closure_dispatch.rs
+++ b/src/vm/vm_closure_dispatch.rs
@@ -945,7 +945,9 @@ impl Interpreter {
             // in place, so `group-of { … my class Foo {} … }` named the class
             // `Test::Util::Foo` and every message quoting it diverged from raku
             // (roast/integration/error-reporting.t).
-            if !pkg.is_empty() && !pkg.contains("::&") && data.package != self.current_package_sym()
+            if !pkg.is_empty()
+                && !crate::runtime::utils::has_routine_scope_marker(pkg)
+                && data.package != self.current_package_sym()
             {
                 Some(self.enter_package_guarded(pkg.to_string()))
             } else {

--- a/src/vm/vm_env_helpers.rs
+++ b/src/vm/vm_env_helpers.rs
@@ -222,7 +222,11 @@ impl Interpreter {
     /// mirroring the `GetGlobal` bare-name read fallback so reads and writes
     /// resolve to the same canonical store.
     pub(super) fn package_qualified_candidate(name: &str, cur: &str) -> Option<String> {
-        if name.contains("::") || cur.is_empty() || cur == "GLOBAL" || cur.contains("::&") {
+        if crate::runtime::utils::has_double_colon(name)
+            || cur.is_empty()
+            || cur == "GLOBAL"
+            || crate::runtime::utils::has_routine_scope_marker(cur)
+        {
             return None;
         }
         let bare_first = name.trim_start_matches(['$', '@', '%', '&']);
@@ -252,7 +256,7 @@ impl Interpreter {
     /// nested `use` made invisible under their bare name. Walks up the package
     /// chain like `resolve_type_in_current_package`.
     pub(super) fn resolve_enum_member_in_current_package(&self, name: &str) -> Option<Value> {
-        if name.is_empty() || name.contains("::") {
+        if name.is_empty() || crate::runtime::utils::has_double_colon(name) {
             return None;
         }
         let probe_chain = |root: &str| -> Option<Value> {
@@ -319,13 +323,14 @@ impl Interpreter {
     /// always wins. Never falls through to the bare (GLOBAL) name — the
     /// lexical alias for `our` is block-scoped.
     pub(super) fn package_chain_var_fallback(&self, name: &str) -> Option<Value> {
-        if name.contains("::") {
+        if crate::runtime::utils::has_double_colon(name) {
             return None;
         }
         // `&'static str` off the atomic symbol mirror: `current_package()` takes
         // the `RwLock` and clones the `String` on every free-variable read.
         let cur: &str = self.current_package_sym().as_str();
-        if cur.is_empty() || cur == "GLOBAL" || cur.contains("::&") {
+        if cur.is_empty() || cur == "GLOBAL" || crate::runtime::utils::has_routine_scope_marker(cur)
+        {
             return None;
         }
         let bare_first = name.trim_start_matches(['$', '@', '%', '&']);
@@ -375,10 +380,18 @@ impl Interpreter {
     /// block (running under GLOBAL) never resolves here. A name shadowed by the
     /// sub's own `my`/param is a local slot (GetLocal), so it never reaches here.
     pub(super) fn package_scope_lexical(&self, name: &str) -> Option<Value> {
+        // Most programs never run a bare `package P { my $x; ... }` block, so
+        // the store is empty and nothing below can resolve: answer before the
+        // package probe and the two name scans, which every free-variable read
+        // in a routine body otherwise paid.
+        if self.package_lexicals.is_empty() {
+            return None;
+        }
         // `&'static str` off the atomic symbol mirror: `current_package()` takes
         // the `RwLock` and clones the `String` on every free-variable read.
         let cur: &str = self.current_package_sym().as_str();
-        if cur.is_empty() || cur == "GLOBAL" || cur.contains("::&") {
+        if cur.is_empty() || cur == "GLOBAL" || crate::runtime::utils::has_routine_scope_marker(cur)
+        {
             return None;
         }
         // `package_lexicals` is keyed by the package's own env name for the
@@ -393,7 +406,7 @@ impl Interpreter {
         //     auto-qualifies free vars. Resolve ONLY when the qualifier is the
         //     current package, so `$Other::x` from outside never reaches another
         //     package's `my` lexical (Raku: `my` lexicals are not package-public).
-        let key: std::borrow::Cow<str> = if name.contains("::") {
+        let key: std::borrow::Cow<str> = if crate::runtime::utils::has_double_colon(name) {
             let (sigil, rest) = match name.as_bytes().first() {
                 Some(b @ (b'$' | b'@' | b'%' | b'&')) => (Some(*b as char), &name[1..]),
                 _ => (None, name),
@@ -502,10 +515,10 @@ impl Interpreter {
         &self,
         name: &str,
     ) -> Option<crate::gc::Gc<crate::value::ContainerCell>> {
-        if name.contains("__ANON") {
+        if crate::runtime::utils::has_anon_marker(name) {
             return None;
         }
-        if !name.contains("::")
+        if !crate::runtime::utils::has_double_colon(name)
             && let Some(ValueView::ContainerRef(arc)) = self
                 .unit_lexicals
                 .get(crate::runtime::MAINLINE_UNIT_KEY)
@@ -579,7 +592,7 @@ impl Interpreter {
         }
         // Probed once: `str::contains` builds a searcher per call, and this
         // resolver asked it three times per free-variable read.
-        let qualified = name.contains("::");
+        let qualified = crate::runtime::utils::has_double_colon(name);
         // ADR-0024: a mainline named sub's free-variable read consults its own
         // captured cells first. Tried before the package-chain candidates
         // below, which all explicitly exclude `GLOBAL` — the running routine's
@@ -618,7 +631,10 @@ impl Interpreter {
             Some(cur),
         ];
         for candidate in candidates.into_iter().flatten() {
-            if candidate.is_empty() || candidate == "GLOBAL" || candidate.contains("::&") {
+            if candidate.is_empty()
+                || candidate == "GLOBAL"
+                || crate::runtime::utils::has_routine_scope_marker(candidate)
+            {
                 continue;
             }
             if let Some(found) = Self::lookup_in_package_chain(&self.unit_lexicals, candidate, name)
@@ -650,7 +666,7 @@ impl Interpreter {
         // later immutable accessor calls in the same function does not
         // borrow-check under NLL even though the borrow is never actually
         // live past the `return`.
-        let qualified = name.contains("::");
+        let qualified = crate::runtime::utils::has_double_colon(name);
         let mainline_active = !qualified && self.mainline_lexical_frame_active();
         if mainline_active
             && self
@@ -699,7 +715,10 @@ impl Interpreter {
         .flatten()
         .collect();
         for candidate in candidates {
-            if candidate.is_empty() || candidate == "GLOBAL" || candidate.contains("::&") {
+            if candidate.is_empty()
+                || candidate == "GLOBAL"
+                || crate::runtime::utils::has_routine_scope_marker(&candidate)
+            {
                 continue;
             }
             if Self::lookup_in_package_chain(&self.unit_lexicals, &candidate, name).is_some() {
@@ -997,7 +1016,7 @@ impl Interpreter {
     fn main_qualified_name(name: &str) -> Option<String> {
         for sigil in ["$", "@", "%", "&"] {
             if let Some(rest) = name.strip_prefix(sigil)
-                && !rest.contains("::")
+                && !crate::runtime::utils::has_double_colon(rest)
             {
                 return Some(format!("{sigil}Main::{rest}"));
             }
@@ -1855,7 +1874,7 @@ impl Interpreter {
             && !name.starts_with('!')
             && !name.starts_with('^')
             && name != "_"
-            && !name.contains("::")
+            && !crate::runtime::utils::has_double_colon(name)
             && !name.starts_with("__mutsu_")
     }
 

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -355,7 +355,7 @@ impl Interpreter {
                         // variables accessed via package-qualified names (e.g., $Pkg::var).
                         // Bare variable names should NOT fall back to our_vars — the
                         // lexical alias for `our` variables is block-scoped.
-                        if name.contains("::") {
+                        if crate::runtime::utils::has_double_colon(name) {
                             self.get_our_var(name)
                                 .cloned()
                                 .or_else(|| self.our_var_pseudo_unqualified(name))
@@ -412,7 +412,7 @@ impl Interpreter {
                         // This handles class body statements that access outer
                         // lexical variables which are stored in env under their
                         // unqualified names (not as `A::x`).
-                        if !name.contains("::") {
+                        if !crate::runtime::utils::has_double_colon(name) {
                             return None;
                         }
                         // Only apply when the qualifier matches the current package
@@ -966,7 +966,9 @@ impl Interpreter {
                     let sig_len = sigil.map(|_| 1).unwrap_or(0);
                     let qualifier = &name[sig_len..pos];
                     let bare_after = &name[pos + 2..];
-                    if !qualifier.is_empty() && !bare_after.is_empty() && !bare_after.contains("::")
+                    if !qualifier.is_empty()
+                        && !bare_after.is_empty()
+                        && !crate::runtime::utils::has_double_colon(bare_after)
                     {
                         let cur = self.current_package();
                         let bare = match sigil {
@@ -1051,7 +1053,7 @@ impl Interpreter {
                     && !self.vardecl_context.get()
                     && !is_attr_twigil
                     && !is_internal_temp
-                    && !name.contains("::")
+                    && !crate::runtime::utils::has_double_colon(&name)
                     && !self.env().contains_key(&name)
                     && !self.has_unit_scope_lexical(&name)
                     && !code.param_bind_names.iter().any(|n| n == &name)
@@ -1176,7 +1178,7 @@ impl Interpreter {
                     && !name.starts_with('@')
                     && !name.starts_with('%')
                     && !name.starts_with('&')
-                    && !name.contains("::")
+                    && !crate::runtime::utils::has_double_colon(&name)
                 {
                     // A bareword that has never been (re)bound to something
                     // else still resolves to the type object it names (an
@@ -1804,7 +1806,7 @@ impl Interpreter {
                     // fresh container (`@kh.VAR.name` reports "@kh" through any
                     // later pass-by-binding chain). Safe to stamp: the detach
                     // above guarantees an unshared node.
-                    if !name.contains("__ANON") {
+                    if !crate::runtime::utils::has_anon_marker(&name) {
                         val.stamp_descriptor_name(&name);
                     }
                 }
@@ -1813,7 +1815,7 @@ impl Interpreter {
                     && !raw_mode
                     && !sg_is_vardecl
                     && bind_source.is_none()
-                    && !name.contains("__ANON")
+                    && !crate::runtime::utils::has_anon_marker(&name)
                     && (name.starts_with('@') || name.starts_with('%'))
                 {
                     match (self.env().get(&name).map(Value::view), val.view()) {

--- a/src/vm/vm_our_package_vars.rs
+++ b/src/vm/vm_our_package_vars.rs
@@ -78,7 +78,9 @@ impl Interpreter {
     fn our_package_var_key(&self, name: &str) -> Option<String> {
         // An explicitly-written `@Other::x` is already the package variable it
         // names; anonymous containers are never package variables.
-        if name.contains("::") || name.contains("__ANON") {
+        if crate::runtime::utils::has_double_colon(name)
+            || crate::runtime::utils::has_anon_marker(name)
+        {
             return None;
         }
         if self.running_frame_declares_local(name) {
@@ -97,7 +99,10 @@ impl Interpreter {
         for candidate in candidates.into_iter().flatten() {
             let mut pkg = candidate;
             loop {
-                if pkg.is_empty() || pkg == "GLOBAL" || pkg.contains("::&") {
+                if pkg.is_empty()
+                    || pkg == "GLOBAL"
+                    || crate::runtime::utils::has_routine_scope_marker(pkg)
+                {
                     break;
                 }
                 // `package_qualified_candidate` applies the same twigil /

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -818,7 +818,7 @@ impl Interpreter {
         arc: &crate::gc::Gc<crate::value::ContainerCell>,
         val: &Value,
     ) {
-        let is_anon_container = name.contains("__ANON");
+        let is_anon_container = crate::runtime::utils::has_anon_marker(name);
         let mut inner = arc.lock().unwrap();
         let replacement = match (inner.view(), val.view()) {
             (ValueView::Hash(old_gc), ValueView::Hash(new_gc))

--- a/src/vm/vm_var_assign_set_local.rs
+++ b/src/vm/vm_var_assign_set_local.rs
@@ -367,7 +367,7 @@ impl Interpreter {
             && code.locals.get(idx as usize).is_some_and(|n| {
                 (n.starts_with('@') || n.starts_with('%'))
                     && !n[1..].starts_with(['!', '.'])
-                    && !n.contains("__ANON")
+                    && !crate::runtime::utils::has_anon_marker(n)
             });
         let r = self.exec_set_local_op_inner(code, idx);
         // The store that ends a declaration's in-flight window: from here the
@@ -935,7 +935,7 @@ impl Interpreter {
         // In-place reassignment there would alias two unrelated anonymous
         // containers (e.g. `(my % = ...), (my % = ...)` in a list), so exclude
         // anon names and let them take the fresh-container (replace) path.
-        let is_anon_container = name.contains("__ANON");
+        let is_anon_container = crate::runtime::utils::has_anon_marker(name);
         let inplace_old_array: Option<crate::gc::Gc<crate::value::ArrayData>> =
             if name.starts_with('@') && !is_bind && !is_rebind && !is_vardecl && !is_anon_container
             {

--- a/src/vm/vm_var_get_ops.rs
+++ b/src/vm/vm_var_get_ops.rs
@@ -215,7 +215,7 @@ impl Interpreter {
             {
                 // Check for poisoned enum aliases
                 if matches!(v.view(), ValueView::Enum { .. })
-                    && !name.contains("::")
+                    && !crate::runtime::utils::has_double_colon(name)
                     && let Some(pkg_name) = self.is_poisoned_enum_alias(name)
                 {
                     let pkg_name = pkg_name.to_string();
@@ -243,7 +243,7 @@ impl Interpreter {
                 v.clone()
             } else if self.has_type(name) || Self::is_builtin_type(name) {
                 Value::package(Symbol::intern(&self.type_object_name_for_bareword(name)))
-            } else if name.contains("::")
+            } else if crate::runtime::utils::has_double_colon(name)
                 && !name.starts_with('$')
                 && !name.starts_with('@')
                 && !name.starts_with('%')
@@ -276,7 +276,7 @@ impl Interpreter {
             // prefix through the alias and then looks up the enum variant, e.g.
             // `my constant G = F::B; G::c === F::B::c`.
             enum_val
-        } else if name.contains("::")
+        } else if crate::runtime::utils::has_double_colon(name)
             && let Some(def) = loan_env!(self, resolve_function_with_types(name, &[]))
         {
             if let Some(cf) = self.find_compiled_function(compiled_fns, name, &[]) {
@@ -374,7 +374,7 @@ impl Interpreter {
         } else if name.starts_with("Metamodel::") {
             // Meta-object protocol type objects
             Value::package(Symbol::intern(name))
-        } else if name.contains("::") {
+        } else if crate::runtime::utils::has_double_colon(name) {
             // Check if this is an access to a non-existent enum variant
             if let Some((pkg, sym)) = name.rsplit_once("::")
                 && self.has_enum_type(pkg)


### PR DESCRIPTION
Eighth perf slice for `todo/deep/vendor-real-test-module.md` (callgrind-driven), following #7472 and #7476.

## What

After the previous two slices the per-assertion profile of the vendored `Test.rakumod` showed `<&str as Pattern>::is_contained_in` at ~13.7k instructions per assertion, ~6k of it under `package_scope_lexical` alone. A routine body's free-variable read (`$num_of_tests_run`, `$indents`, `$output`, ... — about ten per assertion) resolves through the package-lexical, unit-lexical and `our`-mirror stores, and each asked `str::contains("::")` / `contains("::&")` of the variable name and the running package. `str::contains(&str)` builds a two-way searcher per call; on names this short the setup is the whole cost.

- **`package_scope_lexical` gates on an empty store first.** It answers a bare `package P { my $x; ... }` block's lexical from inside `P`'s subs; most programs never run such a block, so `package_lexicals` is empty and nothing below the gate can resolve.
- **The fixed ASCII markers are byte scans.** `runtime::utils::str_scan` provides `has_double_colon`, `has_routine_scope_marker` (`::&`) and `has_anon_marker` (`__ANON`) as plain `windows().any()` scans; the resolvers on the read/write hot paths use them (`vm_env_helpers`, `vm_our_package_vars`, `vm_var_get_ops`, `exec_set_local_op`, the container-identity store, the routine-package entry). A unit test pins them against `str::contains` on the shapes the resolvers see.

## Measured

Callgrind, 300 `ok 1, "x"` in a loop under `MUTSU_REAL_TEST=1`, one-assertion baseline subtracted, release build:

| | before | after |
| --- | --- | --- |
| per assertion | 285,180 Ir | 276,814 Ir |
| `<&str as Pattern>::is_contained_in` | 13.7k | 0 |
| `unit_lexical_slot` | 12.4k | 7.5k |
| `get_env_with_main_alias` | 11.6k | 8.2k |

**-2.9% per assertion**; -17.6% cumulative since the session opened at 335,929.

## Verified

- `prove t/` on the debug binary: 3782 files, all pass.
- `cargo test --lib str_scan`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J314VsqdhJ15T1rUJLvmyH

---
_Generated by [Claude Code](https://claude.ai/code/session_01J314VsqdhJ15T1rUJLvmyH)_