### PR TITLE
perf(vm): build a named routine's callframe().code object on demand

### DIFF
--- a/news/2026-09/callframe-code-object-is-built-on-demand.md
+++ b/news/2026-09/callframe-code-object-is-built-on-demand.md
@@ -1,0 +1,53 @@
+# A named routine's `callframe().code` object is built on demand
+
+Ninth perf slice for `todo/deep/vendor-real-test-module.md`. Every named
+routine call pushed its own `Sub` value on entry so that `callframe().code`,
+`&?ROUTINE` and the backtrace could hand it out:
+
+```rust
+Value::make_sub(pkg, name, cf.params.clone(), cf.param_defs.clone(), vec![],
+                false, self.clone_env())
+```
+
+That is a `Gc` allocation, two `Vec` deep clones, and -- because `clone_env`
+flattens -- a whole-lexical-scope map clone whenever the caller's env was a
+scoped overlay, which it is for every call made from inside another routine.
+Then the object is dropped on return. Almost no call ever reads it. On the
+vendored `Test.rakumod`'s assertion loop the two frames (`ok`, `proclaim`)
+cost ~16k instructions per assertion in `Env::flattened` and
+`drop_in_place<Gc<SubData>>` alone, and
+`todo/perf/method-dispatch-flattens-the-env-on-every-call.md` had already named
+"a lazy `callframe().code` env" as one of the three per-call full-view
+consumers standing between the interpreter and a cheaper scoped-env story.
+
+`block_stack` and `CallFrameEntry::code` now hold a `CodeFrame`:
+`Ready(Value)` for a closure/block body or an interpreter-carrier routine
+(unchanged), or `Lazy(Arc<LazyRoutineCode>)` for a named compiled routine.
+The lazy frame records the ingredients -- package, name, params, param_defs,
+and the caller's env as an `Arc` bump (later caller writes copy-on-write away
+from it, so it is the same snapshot the eager flatten took) -- and
+`Interpreter::code_frame_value` builds the `Sub` on first read exactly as the
+entry path used to (full lexical view via `Env::flattened`, routine mixins
+re-applied), caching it in the frame so repeated reads within one frame see one
+object. The readers (`callframe(N).code`, `&?ROUTINE`, `&?BLOCK`, the
+backtrace's routine search, `CallFrame.code` attributes) go through that
+accessor; the backtrace search compares the frame's `(package, name)` without
+materializing. The cycle collector roots a lazy frame's captured env values
+and its built object.
+
+## Measured
+
+Callgrind, 300 `ok 1, "x"` in a loop under `MUTSU_REAL_TEST=1`, one-assertion
+baseline subtracted, release build:
+
+| | before | after |
+| --- | --- | --- |
+| per assertion | 276,814 Ir | 261,339 Ir |
+| `Env::flattened` | 8.2k | 0 |
+| `drop_in_place<Gc<SubData>>` | 7.9k | 0 |
+| `proclaim`'s frame (`call_compiled_function_named_inner'2`) | 166.4k | 144.1k |
+
+**-5.6% per assertion**; -22.2% since the session opened at 335,929
+(`news/2026-09/nqp-ops-and-str-gist-skip-the-call-machinery.md`,
+`news/2026-09/env-pure-method-dispatch-skips-the-scoped-env-flatten.md`,
+`news/2026-09/free-variable-reads-drop-the-substring-searchers.md`).

--- a/src/runtime/accessors_resolve.rs
+++ b/src/runtime/accessors_resolve.rs
@@ -358,7 +358,7 @@ impl Interpreter {
                 // Anonymous subs are pushed with "<anon>" as the sentinel name.
                 // Return the block_stack Sub directly so callers can invoke it.
                 if frame.name.is_empty() || frame.name == "<anon>" {
-                    if let Some(val) = self.block_stack.last().cloned()
+                    if let Some(val) = self.block_stack_top()
                         && matches!(val.view(), ValueView::Sub(_))
                     {
                         return val;

--- a/src/runtime/accessors_stack.rs
+++ b/src/runtime/accessors_stack.rs
@@ -242,12 +242,23 @@ impl Interpreter {
         self.routine_stack.truncate(len);
     }
 
-    pub(crate) fn block_stack_top(&self) -> Option<&Value> {
-        self.block_stack.last()
+    /// The innermost frame's code object, built on demand for a lazy routine
+    /// frame (see `CodeFrame`).
+    pub(crate) fn block_stack_top(&self) -> Option<Value> {
+        self.block_stack
+            .last()
+            .map(|frame| self.code_frame_value(frame))
     }
 
     pub(crate) fn push_block(&mut self, val: Value) {
-        self.block_stack.push(val);
+        self.block_stack.push(CodeFrame::Ready(val));
+    }
+
+    /// Push a named routine's frame without building its `Sub`; a reader
+    /// materializes it (`Interpreter::code_frame_value`).
+    pub(crate) fn push_lazy_block(&mut self, code: LazyRoutineCode) {
+        self.block_stack
+            .push(CodeFrame::Lazy(std::sync::Arc::new(code)));
     }
 
     pub(crate) fn pop_block(&mut self) {

--- a/src/runtime/builtins_eval_misc.rs
+++ b/src/runtime/builtins_eval_misc.rs
@@ -214,22 +214,16 @@ impl Interpreter {
             .block_stack
             .iter()
             .rev()
-            .find(|v| {
-                let sd = match v.view() {
-                    ValueView::Sub(sd) => Some(sd),
-                    ValueView::Mixin(inner, _) => match inner.as_ref().view() {
-                        ValueView::Sub(sd) => Some(sd),
-                        _ => None,
-                    },
-                    _ => None,
+            .find(|code_frame| {
+                let Some((package, name)) = code_frame.routine_identity() else {
+                    return false;
                 };
-                let Some(sd) = sd else { return false };
-                sd.name == frame.name
-                    && (sd.package == frame.package
-                        || (frame.package == "GLOBAL" && sd.package.is_empty())
-                        || (sd.package == "GLOBAL" && frame.package.is_empty()))
+                name == frame.name
+                    && (package == frame.package
+                        || (frame.package == "GLOBAL" && package.is_empty())
+                        || (package == "GLOBAL" && frame.package.is_empty()))
             })
-            .cloned()
+            .map(|code_frame| self.code_frame_value(code_frame))
             .or_else(|| self.env.get(&format!("&{}", frame.name)).cloned())
             .or_else(|| self.env.get_sym(frame.name).cloned())
             .unwrap_or(Value::NIL);

--- a/src/runtime/builtins_operators_fallback.rs
+++ b/src/runtime/builtins_operators_fallback.rs
@@ -627,7 +627,8 @@ impl Interpreter {
                 &def.package.resolve(),
                 &def.name.resolve(),
             );
-            self.block_stack.push(sub_val);
+            self.block_stack
+                .push(crate::runtime::CodeFrame::Ready(sub_val));
             let pushed_assertion = self.push_test_assertion_context(def.is_test_assertion);
             let invocation_id = self.take_invocation_id();
             self.routine_stack.push(RoutineFrame {

--- a/src/runtime/code_frame.rs
+++ b/src/runtime/code_frame.rs
@@ -1,0 +1,144 @@
+use super::*;
+
+/// The code object a call frame exposes through `callframe().code`,
+/// `&?ROUTINE` / `&?BLOCK` and the backtrace, held on `block_stack` and in
+/// `CallFrameEntry::code`.
+///
+/// A *named* routine call used to build its `Sub` eagerly on entry:
+/// `Value::make_sub(.., params.clone(), param_defs.clone(), .., clone_env())`
+/// -- a `Gc` allocation, two `Vec` deep clones and, because `clone_env`
+/// flattens, a whole-lexical-scope map clone whenever the caller's env was a
+/// scoped overlay (every call made from inside another routine). Almost no
+/// call ever reads the object: the vendored `Test.rakumod`'s assertion loop
+/// paid ~16k instructions per assertion building and dropping two of them
+/// (`todo/deep/vendor-real-test-module.md`). The frame now records what the
+/// object would be built FROM and materializes on first read, caching the
+/// result so repeated reads within the frame see one object.
+#[derive(Clone)]
+pub(crate) enum CodeFrame {
+    /// An already-built code object (a closure/block body, or a routine the
+    /// interpreter carrier dispatched).
+    Ready(Value),
+    /// A named routine's frame, built on demand.
+    Lazy(std::sync::Arc<LazyRoutineCode>),
+}
+
+/// The ingredients of a named routine's `Sub` value, captured at call entry.
+pub(crate) struct LazyRoutineCode {
+    pub(crate) package: Symbol,
+    pub(crate) name: Symbol,
+    pub(crate) params: Vec<String>,
+    pub(crate) param_defs: Vec<ParamDef>,
+    /// The caller's env as it was at call entry. An `Arc` bump of the live
+    /// env: later writes to that env copy-on-write away from this handle, so
+    /// it is the same snapshot the eager `clone_env()` took, minus the
+    /// flatten -- which happens in `materialize` if anyone asks.
+    pub(crate) env: Env,
+    materialized: std::sync::OnceLock<Value>,
+}
+
+impl LazyRoutineCode {
+    pub(crate) fn new(
+        package: Symbol,
+        name: Symbol,
+        params: Vec<String>,
+        param_defs: Vec<ParamDef>,
+        env: Env,
+    ) -> Self {
+        Self {
+            package,
+            name,
+            params,
+            param_defs,
+            env,
+            materialized: std::sync::OnceLock::new(),
+        }
+    }
+
+    /// The cached code object, if a read has already built it.
+    pub(crate) fn built(&self) -> Option<&Value> {
+        self.materialized.get()
+    }
+}
+
+impl CodeFrame {
+    /// The routine's `(package, name)` without materializing: `Nil` for a
+    /// `Ready` frame that is not a `Sub` (or a `Mixin` over one).
+    pub(crate) fn routine_identity(&self) -> Option<(Symbol, Symbol)> {
+        match self {
+            CodeFrame::Lazy(l) => Some((l.package, l.name)),
+            CodeFrame::Ready(v) => {
+                let sd = match v.view() {
+                    ValueView::Sub(sd) => Some(sd),
+                    ValueView::Mixin(inner, _) => match inner.as_ref().view() {
+                        ValueView::Sub(sd) => Some(sd),
+                        _ => None,
+                    },
+                    _ => None,
+                };
+                sd.map(|sd| (sd.package, sd.name))
+            }
+        }
+    }
+
+    /// True when materializing yields a `Sub` (or a `Mixin` over one).
+    pub(crate) fn is_sub(&self) -> bool {
+        match self {
+            CodeFrame::Lazy(_) => true,
+            CodeFrame::Ready(v) => match v.view() {
+                ValueView::Sub(_) => true,
+                ValueView::Mixin(inner, _) => matches!(inner.as_ref().view(), ValueView::Sub(_)),
+                _ => false,
+            },
+        }
+    }
+
+    /// Visit the `Value`s this frame roots for the cycle collector: the
+    /// object itself when built, and the captured env's own (overlay) values
+    /// for a lazy frame -- the parent tiers are rooted by the frames that own
+    /// them.
+    pub(crate) fn visit_roots(&self, visitor: &mut dyn crate::gc::RootVisitor) {
+        match self {
+            CodeFrame::Ready(v) => visitor.visit_value(v),
+            CodeFrame::Lazy(l) => {
+                if let Some(v) = l.built() {
+                    visitor.visit_value(v);
+                }
+                l.env.visit_values(visitor);
+            }
+        }
+    }
+}
+
+impl Interpreter {
+    /// The code object for `frame`, building a lazy routine frame's `Sub` on
+    /// first use exactly as the eager entry path used to: the routine's
+    /// params/param_defs, an empty AST body, the caller env flattened to its
+    /// full lexical view (a `callframe().code` must expose the whole scope,
+    /// not a scoped overlay), and any role ever composed onto the routine
+    /// re-applied.
+    pub(crate) fn code_frame_value(&self, frame: &CodeFrame) -> Value {
+        match frame {
+            CodeFrame::Ready(v) => v.clone(),
+            CodeFrame::Lazy(l) => l
+                .materialized
+                .get_or_init(|| {
+                    let sub_val = Value::make_sub(
+                        l.package,
+                        l.name,
+                        l.params.clone(),
+                        l.param_defs.clone(),
+                        vec![],
+                        false,
+                        l.env.flattened(),
+                    );
+                    self.materialize_routine_mixins_shared(
+                        sub_val,
+                        l.package.as_str(),
+                        l.name.as_str(),
+                    )
+                })
+                .clone(),
+        }
+    }
+}

--- a/src/runtime/gc_roots.rs
+++ b/src/runtime/gc_roots.rs
@@ -198,7 +198,9 @@ impl Interpreter {
         for vec in &self.gather_items {
             visit_slice(visitor, vec);
         }
-        visit_slice(visitor, &self.block_stack);
+        for frame in &self.block_stack {
+            frame.visit_roots(visitor);
+        }
         visit_map_values(visitor, &self.predictive_seq_iters);
         visit_opt(visitor, &self.current_distribution);
         visit_map_values(visitor, &self.package_distributions);

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -442,6 +442,8 @@ mod calls;
 mod class;
 mod class_dispatch;
 mod class_introspection;
+mod code_frame;
+pub(crate) use code_frame::{CodeFrame, LazyRoutineCode};
 mod ctor_phase_plan;
 mod nqp_ops;
 mod nqp_ops_builtin;
@@ -1385,7 +1387,7 @@ pub(crate) struct IoHandleState {
 pub(crate) struct CallFrameEntry {
     pub file: String,
     pub line: i64,
-    pub code: Option<Value>,
+    pub code: Option<CodeFrame>,
     pub env: Env,
 }
 
@@ -1830,7 +1832,7 @@ pub struct Interpreter {
     /// warn/control signals appropriately.
     pub(crate) control_handler_depth: u32,
     test_assertion_line_stack: Vec<i64>,
-    block_stack: Vec<Value>,
+    block_stack: Vec<CodeFrame>,
     doc_comments: HashMap<String, DocComment>,
     /// Ordered list of doc comments for $=pod
     doc_comment_list: Vec<DocComment>,

--- a/src/runtime/resolution_call_sub.rs
+++ b/src/runtime/resolution_call_sub.rs
@@ -794,7 +794,8 @@ impl Interpreter {
                 def_file: None,
                 invocation_id,
             });
-            self.block_stack.push(block_sub);
+            self.block_stack
+                .push(crate::runtime::CodeFrame::Ready(block_sub));
             let return_spec = data
                 .env
                 .get("__mutsu_return_type")

--- a/src/runtime/runtime_caller_env.rs
+++ b/src/runtime/runtime_caller_env.rs
@@ -12,7 +12,9 @@ impl Interpreter {
         // file is the file the currently-executing routine was defined in.
         let file = self.executing_source_file().unwrap_or_default();
         let line = self.cur_source_line;
-        let code = code.or_else(|| self.block_stack.last().cloned());
+        let code = code
+            .map(CodeFrame::Ready)
+            .or_else(|| self.block_stack.last().cloned());
         self.callframe_stack.push(CallFrameEntry {
             file,
             line,

--- a/src/runtime/system_introspect.rs
+++ b/src/runtime/system_introspect.rs
@@ -57,7 +57,11 @@ impl Interpreter {
             return None;
         }
         let entry = &self.callframe_stack[stack_len - depth];
-        let code = entry.code.clone().unwrap_or(Value::NIL);
+        let code = entry
+            .code
+            .as_ref()
+            .map(|frame| self.code_frame_value(frame))
+            .unwrap_or(Value::NIL);
         let my_hash = self.build_lexical_hash(&entry.env, Some(depth));
         let mut attrs = HashMap::new();
         attrs.insert("line".to_string(), Value::int(entry.line));
@@ -144,20 +148,16 @@ impl Interpreter {
     fn current_routine_sub_value(&self) -> Value {
         // Try to find the current routine as a Sub value from the block stack
         // (looking through a `Mixin` wrapper the same way as above).
-        for v in self.block_stack.iter().rev() {
-            let inner_is_sub = match v.view() {
-                ValueView::Mixin(inner, _) => matches!(inner.as_ref().view(), ValueView::Sub(_)),
-                other => matches!(other, ValueView::Sub(_)),
-            };
-            if inner_is_sub {
-                return v.clone();
+        for frame in self.block_stack.iter().rev() {
+            if frame.is_sub() {
+                return self.code_frame_value(frame);
             }
         }
         // Fallback: look at the most recent callframe stack entry for the code
         if let Some(entry) = self.callframe_stack.last()
             && let Some(ref code) = entry.code
         {
-            return code.clone();
+            return self.code_frame_value(code);
         }
         Value::NIL
     }

--- a/src/vm/vm_call_named_inner.rs
+++ b/src/vm/vm_call_named_inner.rs
@@ -63,25 +63,20 @@ impl Interpreter {
 
         loan_env!(self, push_caller_env());
 
-        // Push Sub value to block_stack for callframe().code
-        let sub_val = Value::make_sub(
+        // The frame's code object for callframe().code / &?ROUTINE, recorded
+        // lazily: the `Sub` (and the flatten of the caller env its full
+        // lexical view needs) is built only when something reads it, which
+        // almost no call does. The env handle is an `Arc` bump of the caller's
+        // env as it is right now; later caller writes copy-on-write away from
+        // it, so a read sees exactly the snapshot the eager `clone_env()` took.
+        // See `crate::runtime::CodeFrame`.
+        self.push_lazy_block(crate::runtime::LazyRoutineCode::new(
             fn_package_sym,
             fn_name_sym,
             cf.params.clone(),
             cf.param_defs.clone(),
-            vec![],
-            false,
-            // Flatten: this Sub is pushed for callframe().code introspection and
-            // must expose the full lexical view, not a scoped overlay.
-            self.clone_env(),
-        );
-        // Re-apply any role ever composed onto this routine (`.^mixin(Role)`,
-        // or a trait handler's `$r does Role`) — this Sub is a fresh rebuild
-        // from the registry, not the same object the composition ran on, so
-        // it does not carry the role by itself. See
-        // `Interpreter::materialize_routine_mixins`.
-        let sub_val = self.materialize_routine_mixins(sub_val, fn_package, fn_name);
-        self.push_block(sub_val);
+            self.env().clone(),
+        ));
 
         // Scoped-overlay (docs/vm-dual-store.md Slice 6): install an empty
         // born-owned overlay over the caller now that sub_val / push_caller_env

--- a/src/vm/vm_misc_codevar.rs
+++ b/src/vm/vm_misc_codevar.rs
@@ -78,7 +78,7 @@ impl Interpreter {
         // self-reference needed by `.leave` and other identity-sensitive APIs.
         if val.is_nil()
             && name == "?BLOCK"
-            && let Some(block) = self.block_stack_top().cloned()
+            && let Some(block) = self.block_stack_top()
         {
             val = block;
         }

--- a/src/vm/vm_misc_reduction_scan.rs
+++ b/src/vm/vm_misc_reduction_scan.rs
@@ -210,7 +210,7 @@ impl Interpreter {
             // Anonymous subs are pushed with "<anon>" as the sentinel name.
             // Return the block_stack Sub directly so callers can invoke it.
             if frame.name.is_empty() || frame.name == "<anon>" {
-                if let Some(val) = self.block_stack_top().cloned()
+                if let Some(val) = self.block_stack_top()
                     && matches!(val.view(), ValueView::Sub(_))
                 {
                     self.stack.push(val);
@@ -227,7 +227,7 @@ impl Interpreter {
     }
 
     pub(super) fn exec_block_magic_op(&mut self) -> Result<(), RuntimeError> {
-        if let Some(val) = self.block_stack_top().cloned() {
+        if let Some(val) = self.block_stack_top() {
             if matches!(val.view(), ValueView::Sub(_)) {
                 self.stack.push(val);
             } else {


### PR DESCRIPTION
Ninth perf slice for `todo/deep/vendor-real-test-module.md` (callgrind-driven), following #7472, #7476, #7477.

## What

Every named routine call pushed its own `Sub` value on entry so that `callframe().code`, `&?ROUTINE` and the backtrace could hand it out:

```rust
Value::make_sub(pkg, name, cf.params.clone(), cf.param_defs.clone(), vec[], false, self.clone_env())
```

A `Gc` allocation, two `Vec` deep clones, and — because `clone_env` flattens — a whole-lexical-scope map clone whenever the caller's env was a scoped overlay (every call made from inside another routine), then dropped on return. Almost no call ever reads it. `todo/perf/method-dispatch-flattens-the-env-on-every-call.md` had already named "a lazy `callframe().code` env" as one of the three per-call full-view consumers.

`block_stack` and `CallFrameEntry::code` now hold a `CodeFrame` (`src/runtime/code_frame.rs`):

- `Ready(Value)` — a closure/block body or an interpreter-carrier routine, unchanged;
- `Lazy(Arc<LazyRoutineCode>)` — a named compiled routine: package, name, params, param_defs, and the caller env as an `Arc` bump (later caller writes copy-on-write away from it, so it is the same snapshot the eager flatten took).

`Interpreter::code_frame_value` builds the `Sub` on first read exactly as the entry path used to (full lexical view via `Env::flattened`, routine mixins re-applied via `materialize_routine_mixins_shared`) and caches it in the frame, so repeated reads within one frame see one object. Every reader goes through it (`callframe(N).code`, `&?ROUTINE`, `&?BLOCK`, `CallFrame.code` attributes); the backtrace's routine search compares `(package, name)` without materializing. The cycle collector roots a lazy frame's env values and its built object.

## Measured

Callgrind, 300 `ok 1, "x"` in a loop under `MUTSU_REAL_TEST=1`, one-assertion baseline subtracted, release build:

| | before | after |
| --- | --- | --- |
| per assertion | 276,814 Ir | 261,339 Ir |
| `Env::flattened` | 8.2k | 0 |
| `drop_in_place<Gc<SubData>>` | 7.9k | 0 |
| `proclaim`'s frame | 166.4k | 144.1k |

**-5.6% per assertion**; -22.2% cumulative since the session opened at 335,929.

## Verified

- `prove t/` on the debug binary: 3782 files, all pass.
- 40 whitelisted roast files that read call frames / `&?ROUTINE` / backtraces / wrap chains (release, via `scripts/run-roast-test.sh`): all pass.
- 150 callframe/closure/gather `t/` files plus the assertion loop under `MUTSU_GC=on MUTSU_GC_EVERY_CANDIDATE=64 MUTSU_GC_VERIFY=1`: all pass.
- `cargo clippy --all-targets -- -D warnings`, `cargo fmt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J314VsqdhJ15T1rUJLvmyH

---
_Generated by [Claude Code](https://claude.ai/code/session_01J314VsqdhJ15T1rUJLvmyH)_