### PR TITLE
fix(runtime): publish grep's element promotion in place, not by re-binding names

### DIFF
--- a/docs/adr/0058-map-grep-produce-a-deferred-seq.md
+++ b/docs/adr/0058-map-grep-produce-a-deferred-seq.md
@@ -582,10 +582,17 @@ dropping the promotion for any source not lexically visible right there.
 Publishing the promotion by mutating the source `Gc<ArrayData>` in place
 (ADR-0013 §7 made this sound at the primitive) is frame-independent, reaches
 every alias by construction, and drops the `pending_rw_writeback_sources` drain
-the re-binding needed. It also cost the drop of exactly two decont leaks
-(`Backtrace`'s frame readers), which is the measured blast radius: `make test`
-and a full `make roast` are otherwise unchanged. 3b's remaining work is the
-grep mode on the variant plus deferring the two entry points.
+the re-binding needed. Making the publication universal cost two follow-on
+fixes, both for pre-existing bugs the old frame-dependent route had merely
+hidden: two decont leaks in `Backtrace`'s frame readers, and -- caught by the
+bundled-library battery gate on `URI mutate.rakutest` -- a closure's frame-exit
+"rejoin an rw-argument writeback to the captured cell" step that fired for any
+name on the *process-wide* retain-on-miss pending list, so a stale `_` entry let
+one closure store the calling frame's ambient topic through the element cell a
+`.map`/`.grep` block had captured. That is now gated on
+`cc.capture_free_var_set()`. With both, `make test` and a full `make roast` are
+unchanged. 3b's remaining work is the grep mode on the variant plus deferring
+the two entry points.
 
 ### 9.3 What DID land from the attempt
 

--- a/docs/adr/0058-map-grep-produce-a-deferred-seq.md
+++ b/docs/adr/0058-map-grep-produce-a-deferred-seq.md
@@ -572,6 +572,21 @@ different frame. That is also why
 so 3b needs a grep mode on the variant (or a sibling variant) before any of the
 above.
 
+**Prerequisite landed 2026-09-07** (`news/2026-09/grep-promotion-is-published-in-place.md`).
+The concrete blocker was sharper than "the promotion moves to pull time": the
+promotion was published by building a REPLACEMENT `ArrayData` and re-binding it
+with `overwrite_array_bindings_by_identity`, which walks the **current frame's
+`env`**. A deferred grep promotes in a frame where the source's names are gone,
+so that route cannot work at pull time at all -- and it was already silently
+dropping the promotion for any source not lexically visible right there.
+Publishing the promotion by mutating the source `Gc<ArrayData>` in place
+(ADR-0013 §7 made this sound at the primitive) is frame-independent, reaches
+every alias by construction, and drops the `pending_rw_writeback_sources` drain
+the re-binding needed. It also cost the drop of exactly two decont leaks
+(`Backtrace`'s frame readers), which is the measured blast radius: `make test`
+and a full `make roast` are otherwise unchanged. 3b's remaining work is the
+grep mode on the variant plus deferring the two entry points.
+
 ### 9.3 What DID land from the attempt
 
 Pulling a deferred `MapGrep` left the deferred `MapGrep`s it *produced*

--- a/news/2026-09/grep-promotion-is-published-in-place.md
+++ b/news/2026-09/grep-promotion-is-published-in-place.md
@@ -62,6 +62,65 @@ too), which asserts both halves: a backtrace survives a `.grep` over itself, and
 the writeback the promotion exists for still works while an `=` copy of the
 result still decontainerizes.
 
+## The second thing it surfaced: a stale writeback clobbering a captured topic
+
+The bundled-library battery gate then caught `URI mutate.rakutest`, and it turned
+out to be a **pre-existing, general bug the universal publication merely made
+visible**. Minimal repro (rakudo prints the array unchanged; mutsu blanked out an
+element):
+
+```raku
+my @src = 1, 2, 3;
+sub bump(\x) { x = x + 0 }
+for @src { bump($_) }              # parks `_` on the pending-writeback list
+
+class Q {
+    has Pair @!qf;
+    method setup(@p) { @!qf = @p }
+    method !value-for($k) {
+        my $l = @!qf.grep({ .key eq $k }).map({
+            my $v = .value;
+            Proxy.new(FETCH => method () { $v },
+                      STORE => method ($n) { die "read-only" });
+        }).List;
+        $l[0]
+    }
+    method AT-KEY($k) { self!value-for($k) }
+}
+```
+
+`call_compiled_closure_in_unit` ends every closure call by rejoining an
+rw-argument writeback to the cell the closure captured under that source name —
+the mechanism behind `my $i = 0; sub inc($o is rw) { $o++ }; my $t = { inc($i) };
+$t(); $t();` answering 2. Its trigger was the *process-wide* pending lists, with
+no check that the closure has anything to do with the name.
+
+`pending_caller_var_writeback` is retain-on-miss: an entry stays until some
+frame's `code` owns a local slot for it, so a name no frame can ever own — the
+implicit topic `_`, `$/`, `@_`, a package or enum constant — is retained for the
+rest of the run. (`_` gets there from a sigilless parameter aliasing `$_`:
+`exec_set_local_op_inner` records the alias chain's root as a writeback source,
+and the drain then migrates it to the retain-on-miss list.) Every later closure
+call therefore re-ran the rejoin for `_`, storing the CALLING frame's ambient
+`$_` through whatever cell the closure's captured env held under that name.
+
+A `.map`/`.grep` block's `$_` is the source element's own container, so a closure
+created inside the block captures `_` bound to that element cell. `URI::Query`
+builds exactly such a closure — the `Proxy` reader in `!value-for` — and calling
+it from a method frame, whose ambient `$_` is undefined, wrote `Any` straight
+into `@!query-form`'s element. The next `ASSIGN-KEY` then died with "No such
+method 'key' for invocant of type 'Any'". Before this PR the promotion never
+reached the attribute array, so the fabricated write landed in a transient grep
+result and nobody saw it.
+
+The fix gates that loop on `cc.capture_free_var_set()`: only a lexical this body
+actually *reads* can be the source of a writeback into its own capture.
+`data.env` cannot make that call — it is the whole captured enclosing env, not
+the set of names the body uses — while `free_var_syms` is exactly that set, and
+is already the gate the per-instance persistence loop right below uses. Pinned by
+`t/closure-captured-topic-writeback.t` (green under rakudo; 2 of its 4 rows fail
+without the gate).
+
 ## What is left of ADR-0058 step 3b
 
 The grep mode on `SeqSource::MapGrep` (its pull arm runs `eval_map_over_items`

--- a/news/2026-09/grep-promotion-is-published-in-place.md
+++ b/news/2026-09/grep-promotion-is-published-in-place.md
@@ -1,0 +1,70 @@
+# `grep`'s element promotion is published in place, not by re-binding names
+
+`@a.grep(...)` promotes each matched source slot to a shared `ContainerRef`
+cell and hands the same cells to the result, so `for @a.grep(...) { $_++ }`
+mutates through into `@a`. The promotion was *published* by building a
+replacement `ArrayData` and calling `overwrite_array_bindings_by_identity` —
+which walks the **current frame's `env`** looking for names that point at the
+old one.
+
+That route has two problems, and only the second is why it was touched.
+
+- It only ever reached the aliases that happened to be lexically visible at the
+  `.grep` call. A source array reachable some other way silently kept the
+  unpromoted slots, and the replacement was discarded. It also needed a
+  `pending_rw_writeback_sources` drain to stop the caller's local slot going
+  stale behind the by-name write.
+- It is **frame-dependent**, which is what blocks ADR-0058 step 3b. A deferred
+  `grep` promotes at *pull* time, in a frame where the source's names are long
+  gone, so the env walk finds nothing and the writeback disappears. §9.2
+  recorded this as "deferring grep moves the promotion and its identity-keyed
+  writeback to pull time, in a different frame"; the sharper statement is that
+  the publication mechanism itself cannot survive the move.
+
+The promotion is now published by mutating the source `Gc<ArrayData>` in place.
+ADR-0013 §7's `GcBox`/`UnsafeCell` interior-mutability refinement made this
+sound at the primitive, and CLAUDE.md records that it unblocks exactly this kind
+of work. Writing through the `Gc` reaches every alias by construction, needs no
+drain, and does not care which frame is running.
+
+## What that surfaced, which is the point
+
+Making the publication universal means a source that was previously skipped now
+really does end up holding element cells — so every reader of that array has to
+look *through* them. Two `Backtrace` readers did not:
+
+```raku
+my sub bar { die }();
+CATCH { default {
+    my $bt = .backtrace;
+    say $bt.summary.chars;      # 151
+    $bt.grep({ !.is-hidden });
+    say $bt.summary.chars;      # 0
+} }
+```
+
+`concise`/`summary`/`full` matched `ValueView::Instance` on each frame directly,
+and `backtrace_methods`'s `frame_field` / `is_routine` / `is_setting` did the
+same. A promoted frame matched none of them, so `.summary` came back empty and
+`.nice` / `next-interesting-index` lost their filtering. The three accessors are
+fixed at their one chokepoint — `frames_of` dereferences as it builds the list —
+so a future reader inherits the fix instead of repeating the bug.
+
+This is the decont-leak class ADR-0039's history warns about (a previous attempt
+at decl-site cell-boxing regressed ~12 files through it). The measured blast
+radius here is **two files**: `t/backtrace-frame.t` and
+`t/backtrace-introspection.t`, 9 subtests between them. `make test` (3784 files
+/ 39776 tests) and a full local `make roast` (1436 files / 218962 tests) are
+otherwise unchanged.
+
+Pinned by `t/grep-promotion-does-not-hide-frames.t` (6 rows, green under rakudo
+too), which asserts both halves: a backtrace survives a `.grep` over itself, and
+the writeback the promotion exists for still works while an `=` copy of the
+result still decontainerizes.
+
+## What is left of ADR-0058 step 3b
+
+The grep mode on `SeqSource::MapGrep` (its pull arm runs `eval_map_over_items`
+unconditionally) and the two entry points. The listop `grep({ $_ = 5 }, @a)`
+form separately does not write back at all — `builtin_grep` has no `source_var`
+path — which is a pre-existing bug measured here and unrelated to deferral.

--- a/src/builtins/backtrace_methods.rs
+++ b/src/builtins/backtrace_methods.rs
@@ -78,12 +78,23 @@ pub(crate) fn frame_is_routine(attributes: &Gc<InstanceAttrs>) -> bool {
 }
 
 /// The `frames` list of a `Backtrace` instance.
+///
+/// Elements are dereferenced here, at the one chokepoint every frame reader
+/// goes through, rather than in each of them: a `.grep` over a backtrace
+/// promotes the matched source slots to shared element cells (so a writeback
+/// loop can mutate through them) and publishes that promotion on the frames
+/// array itself, after which every `match frame.view() { ValueView::Instance
+/// .. }` reader silently saw nothing. `.summary` came back empty and
+/// `.nice` / `next-interesting-index` lost their filters.
 pub(crate) fn frames_of(attributes: &Gc<InstanceAttrs>) -> Vec<Value> {
     attributes
         .as_map()
         .get("frames")
         .map(crate::runtime::utils::value_to_list)
         .unwrap_or_default()
+        .into_iter()
+        .map(|frame| frame.with_deref(|v| v.clone()))
+        .collect()
 }
 
 fn frame_field(frame: &Value, key: &str) -> String {

--- a/src/builtins/methods_0arg/mod.rs
+++ b/src/builtins/methods_0arg/mod.rs
@@ -1640,6 +1640,11 @@ fn dispatch_core(target: &Value, method: &str) -> Option<Result<Value, RuntimeEr
                     let frames = crate::builtins::backtrace_methods::frames_of(&attributes);
                     let mut out = String::new();
                     for frame in &frames {
+                        // See the `concise`/`summary` arm: a frame can arrive
+                        // inside an element container once a `.grep` over this
+                        // backtrace has promoted its slots, and matching
+                        // `ValueView::Instance` without dereferencing skips it.
+                        let frame = frame.with_deref(|v| v.clone());
                         if let ValueView::Instance { attributes: fa, .. } = frame.view() {
                             out.push_str(&backtrace_frame_str(&fa));
                         }
@@ -1682,6 +1687,14 @@ fn dispatch_core(target: &Value, method: &str) -> Option<Result<Value, RuntimeEr
                     let want_summary = method == "summary";
                     let mut out = String::new();
                     for frame in &frames {
+                        // A frame can arrive inside an element container: a
+                        // `.grep` over this backtrace promotes each matched
+                        // source slot to a shared cell so a writeback loop can
+                        // mutate through it, and that promotion is published on
+                        // the frames array itself. Matching `ValueView::Instance`
+                        // without dereferencing silently skipped every promoted
+                        // frame, so `.summary` after a `.grep` came back empty.
+                        let frame = frame.with_deref(|v| v.clone());
                         if let ValueView::Instance { attributes: fa, .. } = frame.view() {
                             let is_routine = backtrace_frame_is_routine(&fa);
                             // concise: only non-hidden, non-setting routines.

--- a/src/runtime/methods_collection_ops/grep.rs
+++ b/src/runtime/methods_collection_ops/grep.rs
@@ -303,7 +303,7 @@ impl Interpreter {
                 );
                 Ok(Value::make_instance(Symbol::intern("Supply"), attrs))
             }
-            ValueView::Array(items, arr_kind) => {
+            ValueView::Array(items, _arr_kind) => {
                 let (filtered, mutated_items, matched_indices) =
                     self.eval_grep_over_items_with_mutated(args.first().cloned(), items.to_vec())?;
                 // Which source positions matched, so those slots can be shared
@@ -352,11 +352,29 @@ impl Interpreter {
                     promoted[i] = cell.clone();
                     shared_cells.push(cell);
                 }
-                let updated_source = crate::value::Value::array_data_like(&items, promoted);
-                self.overwrite_array_bindings_by_identity(
-                    &items,
-                    Value::array_with_kind(updated_source, arr_kind),
-                );
+                // Publish the promotion by mutating the source `ArrayData` IN
+                // PLACE rather than building a replacement and re-binding every
+                // name that pointed at the old one. Both are visible to every
+                // alias, but the old route reached them through
+                // `overwrite_array_bindings_by_identity`, which walks the
+                // CURRENT frame's `env` — so it only ever found the aliases
+                // that happened to be lexically visible right here, and needed
+                // a `pending_rw_writeback_sources` drain to keep the caller's
+                // local slot from going stale behind it. Writing through the
+                // `Gc` (ADR-0013 §7 made this sound at the primitive) reaches
+                // every alias by construction, needs no drain, and does not
+                // depend on which frame is running — which is what ADR-0058
+                // step 3b needs, since a deferred grep promotes at PULL time,
+                // in a frame where the source's names are long gone.
+                {
+                    let data = unsafe { crate::value::gc_contents_mut(&items) };
+                    let slots = data.items_mut();
+                    for (i, v) in promoted.into_iter().enumerate() {
+                        if i < slots.len() {
+                            slots[i] = v;
+                        }
+                    }
+                }
                 // Build the result array from the shared cells (default `:v`
                 // adverb). The `:k`/`:kv`/`:p` adverbs rebuild a fresh array in
                 // `transform_result` from `indices`, which drops the aliasing (a

--- a/src/vm/vm_closure_dispatch.rs
+++ b/src/vm/vm_closure_dispatch.rs
@@ -1258,6 +1258,29 @@ impl Interpreter {
             if source.with_str(crate::env::is_dynamic_var_name) {
                 continue;
             }
+            // Only a lexical this body actually CAPTURED can be the source of
+            // such a writeback. Both pending lists are process-wide and
+            // retain-on-miss: `pending_caller_var_writeback` keeps a name until
+            // some frame's `code` owns a local slot for it, and a name that no
+            // frame can ever own (the implicit topic `_`, `$/`, `@_`, a package
+            // or enum constant) is therefore retained for the rest of the run.
+            // Without this gate every later closure call re-ran the rejoin for
+            // those stale names, storing the CALLING frame's ambient value
+            // through whatever cell the closure's captured env happened to hold
+            // under that name -- a write the closure never performed.
+            //
+            // The topic is how that bites: a `.map`/`.grep` block's `$_` is the
+            // source element's own container, so a closure created inside the
+            // block (`Proxy.new(FETCH => method () { $v })` in URI::Query)
+            // captures `_` bound to that element cell. Calling it later, from a
+            // frame whose ambient `$_` is undefined, wrote `Any` straight into
+            // the source array element. `data.env` alone cannot tell the two
+            // apart: it is the whole captured enclosing env, not the set of
+            // names this body reads. `free_var_syms` is exactly that set -- the
+            // same gate the per-instance persistence loop below already uses.
+            if !cc.capture_free_var_set().contains(&source) {
+                continue;
+            }
             let Some(updated) = self.env().get_sym(source).cloned() else {
                 continue;
             };

--- a/t/closure-captured-topic-writeback.t
+++ b/t/closure-captured-topic-writeback.t
@@ -1,0 +1,54 @@
+use Test;
+
+# A closure created inside a `.map`/`.grep` block captures the block's `$_`,
+# which is the SOURCE ELEMENT's own container. Calling that closure later must
+# not write the calling frame's ambient topic through that captured container.
+#
+# The frame-exit "rejoin an rw-argument writeback to the captured cell" step in
+# `call_compiled_closure_in_unit` used to run for every name sitting on the
+# process-wide pending-writeback lists. `pending_caller_var_writeback` is
+# retain-on-miss: a name no frame owns a local slot for -- the implicit topic
+# `_` above all -- stays on it for the rest of the run. So every later closure
+# call re-ran the rejoin for `_` and stored the calling frame's ambient `$_`
+# (undefined inside a method) straight into the source array element.
+#
+# This is what broke `URI::Query`: `!value-for` builds `Proxy` readers inside
+# `@!query-form.grep(...).map(...)`, and reading one key blanked out a
+# query-form element, so the next `ASSIGN-KEY` died with
+# "No such method 'key' for invocant of type 'Any'".
+
+plan 4;
+
+# Park the topic on the retain-on-miss pending list: a sigilless parameter
+# aliases `$_`, and assigning through it records `_` as a writeback source that
+# no frame's local slots can ever claim.
+my @src = 1, 2, 3;
+sub bump(\x) { x = x + 0 }
+for @src { bump($_) }
+
+class Q {
+    has Pair @!qf;
+    method setup(@p) { @!qf = @p }
+    method keys-str()   { @!qf.map({ .defined ?? .key   !! '(undef)' }).join(',') }
+    method values-str() { @!qf.map({ .defined ?? .value !! '(undef)' }).join(',') }
+    method !value-for($key) {
+        my $l = @!qf.grep({ .key eq $key }).map({
+            my $v = .value;
+            Proxy.new(
+                FETCH => method () { $v },
+                STORE => method ($n) { die "read-only" },
+            );
+        }).List;
+        $l[0]
+    }
+    method AT-KEY($k) { self!value-for($k) }
+}
+
+my $q = Q.new;
+$q.setup([ 'foo' => 'cod', 'foo' => 'trout' ]);
+is $q.keys-str, 'foo,foo', 'the attribute array starts with both pairs';
+
+is $q<foo>, 'cod', 'reading a key answers through the Proxy';
+
+is $q.keys-str, 'foo,foo', 'the source element survives the read';
+is $q.values-str, 'cod,trout', '... with its value intact';

--- a/t/grep-promotion-does-not-hide-frames.t
+++ b/t/grep-promotion-does-not-hide-frames.t
@@ -1,0 +1,42 @@
+use Test;
+
+# `.grep` over an Array promotes each matched source slot to a shared element
+# cell, so a writeback loop mutates through into the source. That promotion is
+# published on the source `ArrayData` itself, which means a later reader of the
+# same array sees element containers where it used to see bare values. Every
+# reader has to look through them.
+#
+# `Backtrace` is the case that found this: its frame readers matched
+# `ValueView::Instance` directly, so after `$bt.grep(...)` the whole backtrace
+# read as empty -- `.summary` came back '' and `.nice` lost its filtering.
+
+plan 6;
+
+{
+    my sub bar { die }();
+    CATCH {
+        default {
+            my $bt = .backtrace;
+            my $before = $bt.summary;
+            ok $before.chars > 0, '.summary is non-empty to begin with';
+            $bt.grep({ !.is-hidden && .is-routine });
+            is $bt.summary, $before, '.summary survives a `.grep` over the same backtrace';
+            is $bt.full.chars > 0, True, '... and so does .full';
+            is $bt.list.elems > 0, True, '... and so does .list';
+        }
+    }
+}
+
+# The writeback the promotion exists for must keep working.
+{
+    my @a = 1, 2, 3;
+    for @a.grep({ $_ > 1 }) { $_++ }
+    is @a.raku, '[1, 3, 4]', 'a writeback loop still mutates through the grep result';
+}
+
+{
+    my @b = 1, 2, 3;
+    my @c = @b.grep({ $_ > 1 });
+    @c[0] = 99;
+    is @b.raku, '[1, 2, 3]', '... while an `=` copy of the result decontainerizes';
+}


### PR DESCRIPTION
The prerequisite ADR-0058 step 3b (deferring `grep`) was blocked on. §9.2 recorded the blocker as "deferring grep moves the promotion and its identity-keyed writeback to pull time, in a different frame"; the sharper statement, measured here, is that the **publication mechanism itself cannot survive the move**.

## What was wrong

`@a.grep(...)` promotes each matched source slot to a shared `ContainerRef` cell and hands the same cells to the result, so `for @a.grep(...) { $_++ }` mutates through into `@a`. The promotion was *published* by building a replacement `ArrayData` and calling `overwrite_array_bindings_by_identity` — which walks the **current frame's `env`** for names pointing at the old one.

- It reached only the aliases lexically visible at the `.grep` call. A source array reachable some other way silently kept its unpromoted slots and the replacement was discarded. It also needed a `pending_rw_writeback_sources` drain so the caller's local slot did not go stale behind the by-name write.
- It is **frame-dependent**. A deferred `grep` promotes at *pull* time, where the source's names are long gone, so the env walk finds nothing and the writeback disappears.

## The change

Publish the promotion by mutating the source `Gc<ArrayData>` **in place** — sound at the primitive since ADR-0013 §7's `GcBox`/`UnsafeCell` refinement, which CLAUDE.md records as unblocking exactly this kind of work. It reaches every alias by construction, needs no drain, and does not care which frame is running.

## What that surfaced — the point of the change

Universal publication means a source that used to be skipped now really does hold element cells, so every reader of that array has to look *through* them. Two `Backtrace` readers did not:

```raku
my sub bar { die }();
CATCH { default {
    my $bt = .backtrace;
    say $bt.summary.chars;      # 151
    $bt.grep({ !.is-hidden });
    say $bt.summary.chars;      # 0   <- every frame skipped
} }
```

`concise`/`summary`/`full` matched `ValueView::Instance` on each frame directly, and `backtrace_methods`'s `frame_field` / `is_routine` / `is_setting` did the same, so `.summary` came back empty and `.nice` / `next-interesting-index` lost their filtering. Fixed at the **one chokepoint** every frame reader goes through (`frames_of` dereferences as it builds the list), so a future reader inherits the fix rather than repeating the bug.

This is the decont-leak class ADR-0039's history warns about — a previous decl-site cell-boxing attempt regressed ~12 files through it. **Measured blast radius here: two files, 9 subtests.**

| gate | result |
|---|---|
| `make test` | **PASS** — 3784 files / 39776 tests |
| full local `make roast` | **PASS** — 1436 files / 218962 tests |
| `t/grep-promotion-does-not-hide-frames.t` (new, 6 rows) | green under mutsu **and** rakudo |

The pin asserts both halves: a backtrace survives a `.grep` over itself, and the writeback the promotion exists for still works while an `=` copy of the result still decontainerizes.

## Follow-up

ADR-0058 step 3b still needs the grep mode on `SeqSource::MapGrep` (its pull arm runs `eval_map_over_items` unconditionally) and the two entry points. Separately measured and recorded here: the listop `grep({ $_ = 5 }, @a)` form does not write back at all — `builtin_grep` has no `source_var` path — a pre-existing bug unrelated to deferral.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## The battery regression this surfaced, and its fix

The bundled-library battery gate then failed on `URI mutate.rakutest`
(`REGRESSION: whitelisted 'URI mutate.rakutest' did not pass this run`), with
every other CI job green. Reading `$u.query<foo>` blanked out an element of
`URI::Query`'s `@!query-form`, so the next `ASSIGN-KEY` died with `No such
method 'key' for invocant of type 'Any'`.

That is **a pre-existing, general bug that publishing the promotion in place
merely made visible.** Root-caused with a `rust-gdb` hardware watchpoint on the
promoted `ContainerCell`'s value word, which named the writer in one step:
`Value::store_through_cell`, from the frame-exit rejoin loop in
`call_compiled_closure_in_unit`, under `proxy_fetch`.

### What that loop is for, and what was wrong

It rejoins an rw-argument writeback to the cell the closure captured under that
source name -- the mechanism behind

```raku
my $i = 0;
sub inc($o is rw) { $o++ }
my $t = { inc($i) };
$t(); $t();          # 2, not 1   (t/closure-rw-param-writeback.t)
```

Its trigger, though, was the **process-wide** pending-writeback lists, with no
check that the closure has anything to do with the name.
`pending_caller_var_writeback` is retain-on-miss: an entry stays until some
frame's `code` owns a local slot for it, so a name no frame can ever own -- the
implicit topic `_`, `$/`, `@_`, a package or enum constant -- is retained for
the rest of the run. (`_` reaches it from a sigilless parameter aliasing `$_`:
`exec_set_local_op_inner` records the alias chain's root as a writeback source,
and `apply_pending_rw_writeback_slow` migrates the unclaimed name onward.) So
every later closure call re-ran the rejoin for the stale name and stored the
**calling** frame's ambient value through whatever cell the closure's captured
env held under it -- a write the closure never performed.

The topic is how that bites. A `.map`/`.grep` block's `$_` is the source
element's own container, so a closure created inside the block captures `_`
bound to that element cell. `URI::Query`'s `!value-for` builds exactly such a
closure (a `Proxy` reader), and calling it from a method frame -- whose ambient
`$_` is undefined -- wrote `Any` straight into the source element. Before this
PR the promotion never reached the attribute array, so the fabricated write
landed in a discarded grep result and nobody saw it.

### The fix

Gate the rejoin on `cc.capture_free_var_set()`: only a lexical this body
actually *reads* can be the source of a writeback into its own capture.
`data.env` cannot make that call (it is the whole captured enclosing env, not
the set of names the body uses); `free_var_syms` is exactly that set, and is
already the gate the per-instance persistence loop directly below uses. No
special case for `given`, `first`, `grep`, or the topic.

Standalone repro, independent of URI (rakudo prints the array unchanged):

```raku
my @src = 1, 2, 3;
sub bump(\x) { x = x + 0 }
for @src { bump($_) }              # parks `_` on the pending list

class Q {
    has Pair @!qf;
    method setup(@p) { @!qf = @p }
    method !value-for($k) {
        my $l = @!qf.grep({ .key eq $k }).map({
            my $v = .value;
            Proxy.new(FETCH => method () { $v },
                      STORE => method ($n) { die "read-only" });
        }).List;
        $l[0]
    }
    method AT-KEY($k) { self!value-for($k) }
}
```

| gate (with the fix) | result |
|---|---|
| `make test` | **PASS** -- 3787 files / 39799 tests, plus 954 `cargo test` units |
| `scripts/battery-testsuite.sh` (run alone) | **GATE PASSED** -- 289/312, no `REGRESSION:` line |
| full local `make roast` | **PASS** -- 1436 files / 218962 tests (unchanged) |
| `t/closure-captured-topic-writeback.t` (new, 4 rows) | green under mutsu **and** rakudo; 2 rows fail without the gate |

