### PR TITLE
perf(runtime): binder stops re-deriving the implicit Any check and probing absent meta keys

### DIFF
--- a/news/2026-09/binder-stops-re-deriving-the-implicit-any-check.md
+++ b/news/2026-09/binder-stops-re-deriving-the-implicit-any-check.md
@@ -1,0 +1,56 @@
+# The binder stops re-deriving the implicit `Any` check and probing for absent meta keys
+
+Tenth perf slice for `todo/deep/vendor-real-test-module.md`. With the call
+machinery, the method-dispatch flatten, the substring searchers and the
+`callframe().code` object out of the way, `bind_function_args_values` was the
+largest single row of a vendored-`Test` assertion at ~39k instructions for its
+two calls (`ok(Mu $cond, $desc = '')` and
+`proclaim(Bool(Mu) $cond, $desc is copy, $unescaped-prefix = '')`). Four
+things it did per parameter turned out to be answerable up front:
+
+- **The implicit `Any` check walked the whole type gauntlet.** An untyped `$`
+  parameter is implicitly `Any` (to reject a Junction, which is a `Mu` but not
+  an `Any`), so the binder asks `type_matches_value("Any", value)` for every
+  such argument. `type_matches_value` fast-accepts an exact tag match and `Mu`,
+  but `Any` had to fall through the MRO dispatch, the role-key resolution and
+  the parametric/coercion parsers (~3.3k instructions) to reach the answer a
+  concrete `Int`/`Str`/`Num`/`Bool`/`Rat` value has by construction. Those
+  native scalar tags now accept `Any` directly, gated on the subset registry
+  like the existing fast accepts; a type object, an instance of a class that
+  `is Mu`, a junction or a container keeps the full checker.
+- **`has_type_capture_binding` built and interned a marker key per probe.**
+  `resolved_type_capture_name` asks it for every typed constraint and again
+  for the constraint's base (`Bool(Mu)`, `Mu`), each a `format!` +
+  interning env lookup. A process-global monotonic latch set by
+  `bind_type_capture` -- the only writer of the marker -- answers `false`
+  until a `::T` capture has ever been bound (the same pattern as
+  `ENV_TYPE_CONSTRAINT_SEEN`, and process-global for the same adoption
+  reasons).
+- **An `is copy` parameter removed two sigilless meta keys that cannot
+  exist.** Both `__mutsu_sigilless_alias::` and `__mutsu_sigilless_readonly::`
+  are written only by sigilless-parameter bindings; every such arm now latches
+  `sigilless_alias_seen`, and the `is copy` cleanup skips its two `format!` +
+  interning removes until the latch is set.
+- **`set_env_plain_lexical` formatted the `^name` placeholder twin per
+  store.** Once a program declares one placeholder parameter anywhere, every
+  by-name local store probed `env` for `^<name>` with a fresh `format!` +
+  intern. The key is memoized per name symbol (`placeholder_key_sym`, the
+  `type_meta_key_sym` pattern) and probed by symbol.
+
+## Measured
+
+Callgrind, 300 `ok 1, "x"` in a loop under `MUTSU_REAL_TEST=1`, one-assertion
+baseline subtracted, release build:
+
+| | before | after |
+| --- | --- | --- |
+| per assertion | 261,339 Ir | 250,138 Ir |
+| `bind_function_args_values_inner` | 39.4k | 28.9k |
+| `type_matches_value` | 7.0k | 0.9k |
+| `resolved_type_capture_name` | 4.7k | 1.1k |
+
+**-4.3% per assertion**; -25.5% since the session opened at 335,929
+(`news/2026-09/nqp-ops-and-str-gist-skip-the-call-machinery.md`,
+`news/2026-09/env-pure-method-dispatch-skips-the-scoped-env-flatten.md`,
+`news/2026-09/free-variable-reads-drop-the-substring-searchers.md`,
+`news/2026-09/callframe-code-object-is-built-on-demand.md`).

--- a/src/runtime/runtime_var_meta.rs
+++ b/src/runtime/runtime_var_meta.rs
@@ -83,6 +83,24 @@ impl Interpreter {
         sym
     }
 
+    /// The env key for `name`'s placeholder-parameter twin, `^<name>`, as a
+    /// pre-interned `Symbol`, memoized per name symbol exactly like
+    /// [`Self::type_meta_key_sym`] (the mapping never changes).
+    pub(crate) fn placeholder_key_sym(name_sym: Symbol) -> Symbol {
+        thread_local! {
+            static PLACEHOLDER_KEYS: std::cell::RefCell<rustc_hash::FxHashMap<Symbol, Symbol>> =
+                std::cell::RefCell::new(rustc_hash::FxHashMap::default());
+        }
+        if let Some(sym) = PLACEHOLDER_KEYS.with(|c| c.borrow().get(&name_sym).copied()) {
+            return sym;
+        }
+        let sym = name_sym.with_str(|name| Symbol::intern(&format!("^{name}")));
+        PLACEHOLDER_KEYS.with(|c| {
+            c.borrow_mut().insert(name_sym, sym);
+        });
+        sym
+    }
+
     pub(crate) fn normalize_var_meta_name(name: &str) -> &str {
         name.trim_start_matches(['$', '@', '%', '&'])
     }

--- a/src/runtime/types/binding_signature.rs
+++ b/src/runtime/types/binding_signature.rs
@@ -904,6 +904,7 @@ impl Interpreter {
                     positional_idx = args.len();
                     if !pd.name.is_empty() {
                         if pd.sigilless {
+                            self.sigilless_alias_seen = true;
                             self.env
                                 .insert(sigilless_readonly_key(&pd.name), Value::TRUE);
                             self.env.remove(&sigilless_alias_key(&pd.name));
@@ -996,6 +997,7 @@ impl Interpreter {
                     // Sigilless single-argument rule slurpy (`+foo`): bind a
                     // read-only List under the bare name, with no `@` sigil.
                     if !pd.name.is_empty() {
+                        self.sigilless_alias_seen = true;
                         self.env
                             .insert(sigilless_readonly_key(&pd.name), Value::TRUE);
                         self.env.remove(&sigilless_alias_key(&pd.name));
@@ -1982,10 +1984,19 @@ impl Interpreter {
                         // alias chain (or reject the store outright), which can
                         // reach an immutable literal through an intermediate plain
                         // scalar parameter.
-                        self.env
-                            .remove(&crate::runtime::sigilless_alias_key(&pd.name));
-                        self.env
-                            .remove(&crate::runtime::sigilless_readonly_key(&pd.name));
+                        //
+                        // Both keys are only ever written by a sigilless
+                        // parameter binding, every one of which latches
+                        // `sigilless_alias_seen`; until one has run there is
+                        // nothing to remove, and the two `format!`s plus their
+                        // interning removes were a fixed cost on every `is copy`
+                        // parameter of every call.
+                        if self.sigilless_alias_seen {
+                            self.env
+                                .remove(&crate::runtime::sigilless_alias_key(&pd.name));
+                            self.env
+                                .remove(&crate::runtime::sigilless_readonly_key(&pd.name));
+                        }
                         value = value.detach_shared_container();
                         // The copy is a fresh container: its descriptor name is
                         // "element" in rakudo, not the source variable's name the
@@ -2013,6 +2024,11 @@ impl Interpreter {
                         }
                     }
                     if pd.sigilless {
+                        // Every arm below writes at least one of the two
+                        // sigilless meta keys; the latch is what lets an
+                        // `is copy` binding skip removing them when none can
+                        // exist (see there).
+                        self.sigilless_alias_seen = true;
                         let alias_key = sigilless_alias_key(&pd.name);
                         let readonly_key = sigilless_readonly_key(&pd.name);
                         if matches!(

--- a/src/runtime/types/mod.rs
+++ b/src/runtime/types/mod.rs
@@ -693,8 +693,15 @@ impl Interpreter {
     fn type_capture_marker_key(name: &str) -> String {
         format!("__type_capture__{}", name)
     }
+}
 
+/// Whether any `::T` type capture has ever been bound (`bind_type_capture`),
+/// process-wide and monotonic. Gates `has_type_capture_binding`.
+static TYPE_CAPTURE_SEEN: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+
+impl Interpreter {
     pub(crate) fn bind_type_capture(&mut self, name: &str, value: &Value) {
+        TYPE_CAPTURE_SEEN.store(true, std::sync::atomic::Ordering::Relaxed);
         let captured = Self::captured_type_object(value);
         self.env.insert(name.to_string(), captured.clone());
         if self.current_package() != "GLOBAL"
@@ -709,6 +716,16 @@ impl Interpreter {
     }
 
     pub(crate) fn has_type_capture_binding(&self, name: &str) -> bool {
+        // No `::T` capture has ever been bound anywhere in the process, so no
+        // marker key can exist: skip the `format!` + interning env probe that
+        // every typed parameter binding otherwise paid, twice
+        // (`resolved_type_capture_name` asks for the constraint and for its
+        // base). Monotonic and process-global for the same reason
+        // `ENV_TYPE_CONSTRAINT_SEEN` is: a worker interpreter binds captures
+        // into the same env family the parent later reads.
+        if !TYPE_CAPTURE_SEEN.load(std::sync::atomic::Ordering::Relaxed) {
+            return false;
+        }
         matches!(
             self.env
                 .get(&Self::type_capture_marker_key(name))

--- a/src/runtime/types/type_matching.rs
+++ b/src/runtime/types/type_matching.rs
@@ -464,6 +464,30 @@ impl Interpreter {
         if constraint == "Mu" && !self.registry().subsets.contains_key("Mu") {
             return true;
         }
+        // `Any` is the next root down, and a concrete native scalar is an
+        // `Any` by construction (`Int`/`Num`/`Str`/`Bool`/`Rat` all derive
+        // from `Cool`). This is the implicit constraint the binder checks on
+        // every untyped `$` parameter -- to reject a Junction, which is a Mu
+        // but not an Any -- so without the fast accept every such argument
+        // walked the whole gauntlet below (the MRO dispatch, the role-key
+        // resolution, the parametric/coercion parsers) to reach the answer
+        // `Any` has for it. Gated on the subset registry like the tag accept
+        // above; a type object, an instance of a class that `is Mu`, a
+        // junction, a container, or anything else keeps the full checker.
+        if constraint == "Any"
+            && matches!(
+                value.view(),
+                ValueView::Int(_)
+                    | ValueView::Num(_)
+                    | ValueView::Str(_)
+                    | ValueView::Bool(_)
+                    | ValueView::BigInt(_)
+                    | ValueView::Rat(..)
+            )
+            && !self.registry().subsets.contains_key("Any")
+        {
+            return true;
+        }
         if let ValueView::Scalar(inner) = value.view() {
             return self.type_matches_value(constraint, inner);
         }

--- a/src/vm/vm_env_helpers.rs
+++ b/src/vm/vm_env_helpers.rs
@@ -1258,10 +1258,18 @@ impl Interpreter {
             set.insert(name.to_string());
         }
         if crate::env::placeholder_var_possible() {
-            let placeholder = format!("^{name}");
-            if self.env().contains_key(&placeholder) {
-                loan_env!(self, set_shared_var(&placeholder, value.clone()));
-                self.env_mut().insert(placeholder, value);
+            // The `^name` key as a symbol: memoized per name symbol when the
+            // caller has one (every compiled `SetLocal` does), so a program
+            // that declares one placeholder parameter anywhere does not pay a
+            // `format!` + intern on every local store in the rest of it.
+            let placeholder_sym = match sym {
+                Some(sym) => Self::placeholder_key_sym(sym),
+                None => Symbol::intern(&format!("^{name}")),
+            };
+            if self.env().contains_key_sym(placeholder_sym) {
+                let placeholder: &str = placeholder_sym.as_str();
+                loan_env!(self, set_shared_var(placeholder, value.clone()));
+                self.env_mut().insert_sym(placeholder_sym, value);
                 return;
             }
         }


### PR DESCRIPTION
Tenth perf slice for `todo/deep/vendor-real-test-module.md` (callgrind-driven), following #7472, #7476, #7477, #7480.

## What

With the call machinery, the method-dispatch flatten, the substring searchers and the `callframe().code` object out of the way, `bind_function_args_values` was the largest single row of a vendored-`Test` assertion at ~39k instructions for its two calls (`ok(Mu $cond, $desc = '')` and `proclaim(Bool(Mu) $cond, $desc is copy, ...)`). Four things it did per parameter are answerable up front:

- **The implicit `Any` check walked the whole type gauntlet.** An untyped `$` parameter is implicitly `Any`, so the binder asks `type_matches_value("Any", value)` for every such argument; `Any` fell through MRO dispatch, role-key resolution and the parametric/coercion parsers (~3.3k Ir) to reach the answer a concrete `Int`/`Str`/`Num`/`Bool`/`Rat` value has by construction. Those native scalar tags now accept `Any` directly, gated on the subset registry like the existing fast accepts; type objects, instances, junctions and containers keep the full checker.
- **`has_type_capture_binding` built and interned a marker key per probe.** A process-global monotonic latch set by `bind_type_capture` (the only writer of the marker) answers `false` until a `::T` capture has ever been bound — the `ENV_TYPE_CONSTRAINT_SEEN` pattern.
- **An `is copy` parameter removed two sigilless meta keys that cannot exist.** Every sigilless-parameter binding arm now latches `sigilless_alias_seen`, and the `is copy` cleanup skips its two `format!` + interning removes until the latch is set.
- **`set_env_plain_lexical` formatted the `^name` placeholder twin per store.** The key is memoized per name symbol (`placeholder_key_sym`, the `type_meta_key_sym` pattern) and probed by symbol.

## Measured

Callgrind, 300 `ok 1, "x"` in a loop under `MUTSU_REAL_TEST=1`, one-assertion baseline subtracted, release build:

| | before | after |
| --- | --- | --- |
| per assertion | 261,339 Ir | 250,138 Ir |
| `bind_function_args_values_inner` | 39.4k | 28.9k |
| `type_matches_value` | 7.0k | 0.9k |
| `resolved_type_capture_name` | 4.7k | 1.1k |

**-4.3% per assertion**; -25.5% cumulative since the session opened at 335,929.

## Verified

- `prove t/` on the debug binary: 3782 files, all pass.
- `cargo clippy --all-targets -- -D warnings`, `cargo fmt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J314VsqdhJ15T1rUJLvmyH

---
_Generated by [Claude Code](https://claude.ai/code/session_01J314VsqdhJ15T1rUJLvmyH)_