### PR TITLE
fix(vm): a rebuilt QuantHash keeps its container identity (ADR-0039 slice 2)

### DIFF
--- a/docs/adr/0039-container-lexicals-resolve-lexically.md
+++ b/docs/adr/0039-container-lexicals-resolve-lexically.md
@@ -13,10 +13,15 @@
   `news/2026-08/our-scalar-bare-name-resolves-to-the-package-cell.md`.
   Slice 2 (§4.2) is still next and still the end state. Its read side was
   re-implemented and re-measured on 2026-09-06 and **withdrawn a second time**;
-  §10 records the full re-measurement (which found §4.1's exclusion list already
+  §10 records that re-measurement (which found §4.1's exclusion list already
   free of divergences), the four defects the flip exposed, the one fix that
-  shipped on its own, and the enumerated reason the flip is blocked — the
-  *write/capture* lane, not §9's store lane.
+  shipped on its own, and the reason it was blocked then — the *write/capture*
+  lane, not §9's store lane. §11 measured that blocker closed. **Attempt 3
+  (2026-09-07) got much further and was withdrawn a third time**: it reached a
+  green `prove t/` AND a green full `make roast` with the flip on, and was
+  stopped by the bundled-library battery gate. §12 records what it measured, the
+  seven repairs it needed, and the one blocker left; the work item carries the
+  re-derivable detail.
 - Date: 2026-08-20
 - Related: ADR-0013 (container interior mutability — `gc_contents_mut`),
   ADR-0024 (mainline lexicals for named subs — the scalar half of this bug),
@@ -1012,3 +1017,74 @@ before being planned around — the same rule that caught this blocker. The work
 item now lives at
 `todo/deep/adr0039-slice2-container-reads-compile-to-a-slot.md`, with those
 defects carried forward and flagged as pre-`da8e94252` measurements.
+
+
+## 12. Attempt 3 (2026-09-07): seven repairs, `t/` and roast green, blocked by the battery gate
+
+The read flip was implemented a third time, restricted to **plain user lexicals**
+(`is_plain_user_lexical` on the sigiled name). It reached a fully green
+`prove t/` (3783 files) and a fully green local `make roast` (1436 files, 218962
+tests), and was withdrawn by the bundled-library battery gate — a required CI
+check that neither of those covers. Only the part that is independently
+observable shipped:
+`store_container_preserving_identity`'s Set/Bag/Mix arms (repair 5 below), pinned
+in `t/container-rebuild-preserves-identity.t`. The rest, with enough detail to be
+re-derived rather than re-measured, is in
+`todo/deep/adr0039-slice2-container-reads-compile-to-a-slot.md`.
+
+What belongs in the ADR:
+
+**Re-measuring §10 was decisive, and most of it had moved.** §11's blocker was
+gone as predicted and §10.2's defect 3 had shipped. Defects 1 and 2 still
+reproduced. Defect 4 reproduced with a *different* root cause. Both of §10.3's
+roast rows still reproduced and **both recorded diagnoses were wrong**:
+`S32-list/classify.t` is not "a bug in fix 3's own probe" but
+`store_container_preserving_identity` having no QuantHash arm, and
+`S03-metaops/hyper.t` does **not** need §10.5 point 3's baked `HyperMethodCall`
+target slot — writing the rebuilt array through the existing node fixes it and
+removes the slot search entirely. Against that, the naive flip's fallout had
+GROWN from §10.2's 8 `t/` files to **26**, in two families §10 never enumerated.
+
+**The `is_plain_user_lexical` restriction is not a safety margin, it is a
+requirement.** The by-name read's tail is load-bearing for non-plain names: its
+`None` arm supplies the empty container that makes `%_` read as `{}` on the fast
+method-dispatch path, and its cascade is the only route by which `%!attr`/`%.attr`
+reach `self`'s attribute cell and `@*dyn` / `%?RESOURCES` / `::`-qualified names
+resolve at all. Those shapes are not lexical bindings of the frame; slice 2 is
+about the ones that are. Any future widening must supply their behaviour first.
+
+**§8.4 point 2 is narrower than it predicted, and it is about the CELL.** That
+point expected the flip to cut the cross-thread store off from the reader. What
+was measured instead: `GetLocal`'s `@`/`%` arms consult the `__mutsu_atomic_*`
+lanes and the bare-name store *before* the slot, and when the slot holds the
+shared `ContainerRef` cell that `env` still names, that ordering is backwards —
+`get_env_with_main_alias` has always preferred the cell (its first act is
+`unit_scope_lexical`, before its `_inner`'s lane probe). Gating on "the slot's
+cell is still what `env` names" closed all 9 cross-thread `t/` files, and both
+neighbouring conditions were measured wrong: "any cell in the slot" breaks
+`roast/S32-io/IO-Socket-Async.t` 37, "the unit-lexical cell" excludes the case the
+gate exists for. §8.4 point 2's `pending_caller_var_writeback`-shaped drain was
+**not** needed.
+
+**The remaining blocker is the `@` half of that same cell story, in `gather`.**
+`shared_hash_elem_set` writes its merged hash through the binding's cell
+unconditionally; `shared_array_mutate` does so only on its non-`is_thread_clone`
+branch. A container appended to from inside a `gather`-driven frame therefore
+ends up in the atomic lane with the owner's cell left empty — invisible while the
+owner re-resolves the NAME (the lane wins that cascade), wrong the moment it
+reads its slot. The reduction that found this is worth reusing: a temporary
+compiler env-var restricting the flip to a name list, plus delta debugging over
+the names a run touches, reduced a 3000-line vendored library to one variable.
+
+**Container identity is the repair for three of the seven defects, and it
+generalises.** `store_container_preserving_identity` (§10.4) turned out to be the
+right primitive well beyond its original three call sites. The rule that keeps
+falling out is §2/§3's: a runtime helper that REBUILDS a variable's container must
+copy the result into the existing backing node, never drop a fresh node into
+`env`; and every by-name slot search such a helper uses to "also update the slot"
+(`locals_set_by_name`, `find_local_slot`) is both unnecessary and wrong under a
+shadow.
+
+**Process note for attempt 4.** `t/` and `make roast` are not sufficient evidence
+for this change — both were green. `scripts/battery-testsuite.sh` is, and it runs
+locally in about ten minutes.

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -729,6 +729,27 @@ impl Interpreter {
                     {
                         Some(Self::hash_inplace_reassign(old_gc, new_gc))
                     }
+                    // ADR-0039 slice 2: the QuantHash kinds, for the same reason
+                    // and by the same rule. `classify(..., :into(my %b :=
+                    // BagHash.new))` rebuilds the bag and used to drop the fresh
+                    // node into `env`, which only a by-name read could see; the
+                    // binding's own slot kept the empty original
+                    // (`roast/S32-list/classify.t` 25-27).
+                    (ValueView::Set(old_gc, _), ValueView::Set(new_gc, m)) => {
+                        Self::quanthash_inplace_reassign(old_gc, new_gc, |gc| {
+                            Value::set_parts(gc, *m)
+                        })
+                    }
+                    (ValueView::Bag(old_gc, _), ValueView::Bag(new_gc, m)) => {
+                        Self::quanthash_inplace_reassign(old_gc, new_gc, |gc| {
+                            Value::bag_parts(gc, *m)
+                        })
+                    }
+                    (ValueView::Mix(old_gc, _), ValueView::Mix(new_gc, m)) => {
+                        Self::quanthash_inplace_reassign(old_gc, new_gc, |gc| {
+                            Value::mix_parts(gc, *m)
+                        })
+                    }
                     _ => None,
                 }
             }
@@ -745,6 +766,28 @@ impl Interpreter {
                 self.env_mut().insert(var_name.to_string(), new_val);
             }
         }
+    }
+
+    /// Copy a rebuilt QuantHash's data into the original backing node, so every
+    /// holder of that node (a local slot, a by-value capture, a `:=` alias) sees
+    /// the rebuild. `None` when the two are already the same node, which leaves
+    /// the caller's env entry untouched. ADR-0039 slice 2.
+    fn quanthash_inplace_reassign<T: crate::gc::Trace + Clone + 'static>(
+        old_gc: &crate::gc::Gc<T>,
+        new_gc: &crate::gc::Gc<T>,
+        rebuild: impl FnOnce(crate::gc::Gc<T>) -> Value,
+    ) -> Option<Value> {
+        if crate::gc::Gc::ptr_eq(old_gc, new_gc) {
+            return None;
+        }
+        let data = (**new_gc).clone();
+        // SAFETY: single audited aliased in-place container write
+        // (`value::aliased_mut`); `data` is a fresh clone and no borrow into
+        // `old_gc`'s contents is live across the write.
+        unsafe {
+            *crate::value::gc_contents_mut(old_gc) = data;
+        }
+        Some(rebuild(old_gc.clone()))
     }
 
     /// Container identity (§3, splice.t): copy `new_gc`'s array contents into the

--- a/t/container-rebuild-preserves-identity.t
+++ b/t/container-rebuild-preserves-identity.t
@@ -9,7 +9,7 @@ use Test;
 #
 # Every assertion is byte-identical under `raku`.
 
-plan 10;
+plan 14;
 
 # --- the listop `map` rw element writeback ----------------------------------
 
@@ -57,4 +57,21 @@ plan 10;
     @src.classify({ .chars }, into => %into);
     is %into.keys.sort.join(","), '1,2,3', 'classify :into fills the target';
     is $alias.keys.sort.join(","), '1,2,3', 'and the := alias observes it';
+}
+
+# --- The QuantHash kinds rebuild too ---------------------------------------
+# `classify(..., :into(my %b := BagHash.new))` builds a fresh Bag node; without
+# a Set/Bag/Mix arm in `store_container_preserving_identity` it replaced the env
+# entry and every other holder of the original node kept an empty bag
+# (`roast/S32-list/classify.t` 25-27 once `%b` resolves through its slot).
+
+{
+    sub even-odd($i) { $i %% 2 ?? 'even' !! 'odd' }
+    my %b := BagHash.new;
+    my $alias := %b;
+    classify(&even-odd, (1, 2, 3, 4), :into(%b));
+    is %b<even>, 2, 'classify :into a BagHash counts the evens';
+    is $alias<even>, 2, 'and the := alias observes it';
+    is %b<odd>, 2, 'and the odds';
+    is $alias<odd>, 2, 'through the alias too';
 }

--- a/todo/deep/adr0039-slice2-container-reads-compile-to-a-slot.md
+++ b/todo/deep/adr0039-slice2-container-reads-compile-to-a-slot.md
@@ -1,92 +1,177 @@
-# ADR-0039 slice 2: `@`/`%` reads should compile to a slot, and the blocker is gone
+# ADR-0039 slice 2: `@`/`%` reads should compile to a slot — attempt 3 measured, seven defects found, one blocker left
 
 **Design: [ADR-0039](../../docs/adr/0039-container-lexicals-resolve-lexically.md)
-§4.2 first bullet; the measurements are §9, §10 and §11.**
+§4.2 first bullet; the measurements are §9, §10, §11 and now §12.**
 
 A container read (`Expr::ArrayVar` / `Expr::HashVar`) still compiles to a by-name
-`env` lookup where a scalar read compiles to `GetLocal(slot)`. Slice 2 flips it.
-The flip has been implemented and measured twice and withdrawn twice — but the
-reason it was withdrawn the second time **no longer reproduces**, which is why
-this is now its own file instead of a paragraph inside a symptom report that has
-been closed.
+`GetArrayVar` / `GetHashVar` where a scalar read compiles to `GetLocal(slot)`.
+Container lexical scoping is therefore *dynamic*, not lexical — and the by-name
+read is what **hides store-lane bugs**: two paths that end up naming different
+containers under one name look fine as long as every read re-resolves the name.
+
+Attempt 3 (2026-09-07) implemented the flip, fixed seven store-side defects it
+exposed, reached a fully green `prove t/` (3783 files) **and a fully green local
+`make roast`** (1436 files, 218962 tests) — and was then withdrawn by the
+**bundled-library battery gate**, which is a required CI check that neither `t/`
+nor roast covers. Everything below is measured on `fad0ac3ad`; treat it as the
+starting state for attempt 4, not as an estimate.
 
 ## Why it is worth doing
 
-The by-name read is what *hides* store-lane bugs: two paths that end up naming
-different containers under one name look fine as long as every read re-resolves
-the name. Slice 1 (`unit_lexicals`) already made the declaration side lexical;
-until the read side follows, a whole class of "the slot and `env` disagree"
-defects stays invisible rather than fixed, and every write site has to keep
-paying the by-name lookup.
+Slice 1 (`unit_lexicals`) made the declaration side lexical; until the read side
+follows, a whole class of "the slot and `env` disagree" defects stays invisible
+rather than fixed, and every write site keeps paying the by-name lookup.
+Attempt 3 is direct evidence: turning the read into a slot read surfaced
+**26 `t/` files + 3 roast files + 2 battery files** of genuine, pre-existing
+divergence from `raku`, every one of which the by-name read had been papering
+over. Six of the seven repairs are real bug fixes that simply had no observable
+symptom before.
 
-## The blocker ADR-0039 §10.3 named is measured closed
+## What attempt 3 measured (supersedes §10's numbers)
 
-§10.3 withdrew the flip because `make roast` then failed two whitelisted files —
-`roast/S15-nfg/concat-stable.t` and `roast/integration/advent2014-day05.t` —
-which were one root cause: *a container mutated from a nested frame propagated to
-its owner by NAME only*, so a replacing write left the owner's slot stale.
+| what §10/§11 recorded | re-measured 2026-09-07 |
+| --- | --- |
+| §11: the write/capture blocker (nested-frame container mutation reaches its owner by NAME only) | **gone**, as §11 predicted; `t/nested-frame-container-mutation-reaches-owner.t` passes under the flip |
+| §10.2 defect 1 — expression-position container declaration allocates no slot | still reproduces (`t/block-local-my-scope` 21/23, `t/feed-operators` 17/18, `t/push-inline-array-decl` 3/5) |
+| §10.2 defect 2 — `try_fast_hash_element_assign` resolves its target by name | still reproduces (`t/var-decl-constraint-clear` 7) |
+| §10.2 defect 3 — whole-container rebuilds replace the node | **gone** — shipped on its own as `store_container_preserving_identity` (§10.4) |
+| §10.2 defect 4 — a QuantHash re-tag rebuilds its data node | still reproduces, **different root cause** (see fix 7) |
+| §10.3 roast row `S32-list/classify.t` 25-27 | still reproduces; the recorded diagnosis ("a bug in fix 3's own probe") is **wrong** — see fix 5 |
+| §10.3 roast row `S03-metaops/hyper.t` 18-19, 92-93 | still reproduces; §10.5 point 3's remedy (a baked `HyperMethodCall` target slot) is **not** needed — see fix 6 |
+| — | NEW: `@_`/`%_` and twigil'd names — 11 `t/` files |
+| — | NEW: the cross-thread lane — 9 `t/` files |
+| — | NEW: `roast/S32-io/IO-Socket-Async.t` 37 |
+| — | NEW (the blocker): `Cro::HTTP/router-auth.rakutest`, `zef/distribution-depends-parsing.rakutest` |
 
-That root cause was closed by `da8e94252` (ADR-0055 slice 1b, "an escaping
-container capture the frame cannot vouch for gets a cell"), which puts the
-container in a shared `ContainerRef` cell at its declaration so a closure holds
-the *binding* rather than the *name*. Verified 2026-09-06 by building at
-`da8e94252^`: six probe shapes (in-place growth with a live shadow, whole-container
-replace, shrinking `.shift`, hash key add, hash replace, `.=` rebuild) all diverge
-before it and all match `raku` after. Pinned as
-`t/nested-frame-container-mutation-reaches-owner.t`. Closed out in
-`news/2026-09/nested-frame-container-mutation-reaches-its-owner.md`.
+All 26 `t/` files were verified green on the same build with the flip reverted,
+so every one was genuine flip fallout rather than pre-existing noise.
 
-## What to expect when you re-attempt it
+## The seven repairs (six still unlanded; re-derive them, do not re-measure)
 
-**Re-measure first.** Everything below was measured on `2a9e06f91`, i.e. *before*
-`da8e94252`. Some of it may have gone the same way the blocker did; the project's
-standing rule about stale `todo/` diagnoses applies to this file too, and it is
-the third pass on this flip.
+1. **Gate the flip on `is_plain_user_lexical(sigiled)`.** The by-name read's tail
+   is load-bearing for non-plain names: its `None` arm yields an empty container,
+   which is how `%_` reads as `{}` on the fast method-dispatch path that
+   deliberately leaves it unbound (`t/method-implicit-named-slurpy.t`), and its
+   cascade is how `%!attr`/`%.attr` reach `self`'s attribute cell and how
+   `@*dyn`, `%?RESOURCES` and `::`-qualified names resolve at all. Reading `%_`
+   through a slot raised `Variable '%_' is not declared`. This one restriction
+   closed 11 of the 26 files, and any future widening has to supply those
+   behaviours first.
+2. **`GetLocal` must not prefer the name-keyed store over a live cell.** Its
+   `@`/`%` arms consult `__mutsu_atomic_arr::`/`__mutsu_atomic_hash::` and the
+   bare-name shared store *before* reading the slot. The condition that worked
+   is **"the slot's cell is still what this frame's `env` names"**, and both
+   neighbours of it were measured wrong: "the slot holds any cell" breaks
+   `roast/S32-io/IO-Socket-Async.t` 37 (a `supply`/tap body's shared block
+   lexical is cell-boxed too, but the lane does *not* write through that cell,
+   so a tap callback's `@got.append` lands in the lane and in `env` while the
+   cell stays empty), and "the slot holds the *unit-lexical* cell" excludes the
+   `my %h; await (^3).map: -> $i { start { %h{$i} = $i } }` case the gate exists
+   for. Closed all 9 cross-thread files.
+3. **An expression-position container declaration must take the slot the read
+   resolves to** (`compile_expr_stmt`'s `Stmt::VarDecl` arm,
+   `compiler/expr_block.rs`). `local_map` is monotonic in the default build, so a
+   popped sibling block's `@a` slot stays reachable and
+   `{ my @a = 5,7,9 } (my @a).push: $_ for ^3` stored into `env` alone.
+   `declare_local` resolves get-or-create by name in the default build, so it
+   reuses the very slot the read resolves to.
+4. **`try_fast_hash_element_assign` must use its compiler-baked `target_slot`**
+   (thread it in from `exec_index_assign_expr_named_op`, resolve with
+   `resolve_local_slot`). `find_local_slot` is a `position` search, so with a
+   same-named shadow (`code.locals == ["%h", "%h"]`) it nil'd and re-seeded the
+   OUTER binding.
+5. **`store_container_preserving_identity` needs Set/Bag/Mix arms.**
+   `classify(..., :into(my %b := BagHash.new))` rebuilds the bag, which fell
+   through to a plain `env.insert` of the fresh node. **This one is
+   independently observable and has landed** (see
+   `t/container-rebuild-preserves-identity.t`'s QuantHash rows).
+6. **`write_back_hyper_target_var` must write THROUGH the container node.** Its
+   fallback did `set_env_with_main_alias` + `locals_set_by_name`, and the latter
+   is a `position` search, so under a same-named shadow (`my @r;` at file scope
+   plus a block's own `my @r = (1,2,3)`) it wrote the OUTER slot: `@r»++`
+   answered `1 2 3`. Mutating the existing node reaches every holder and needs no
+   slot search — which is why §10.5 point 3's baked `HyperMethodCall` slot is
+   unnecessary.
+7. **The `is BagHash`/`SetHash`/`MixHash` trait handler must re-sync its slot
+   after registering the name-keyed constraint.** That registration re-tags
+   `env`'s value via `register_var_container_type_metadata` →
+   `tag_container_metadata` → `Gc::make_mut`, which COPIES a shared node — and
+   the node was just stored into this frame's slot. Read `env` back and re-store
+   it into the slot afterwards. Two neighbouring repairs were measured **wrong**:
+   making `register_var_container_type_metadata` itself store
+   identity-preservingly breaks `t/typed-bind-recursion.t` (a call frame's
+   flattened env carries the caller's same-named entry, so a recursive
+   `my @ret := Array[T].new` retags the CALLER's container — restricting it to
+   the frame's own overlay does not help), and moving the registration to run
+   *before* the trait's own stores breaks `t/quanthash-hyper-funcop.t`,
+   `t/pairs-element-container.t` and `t/quanthash-declared-init-identity.t`.
 
-The flip itself: `Expr::ArrayVar` / `Expr::HashVar` emit `GetLocal(slot)` when
-`local_map` holds the sigiled name. Fallout on `prove t/` was 8 files / 14
-assertions, from four store-side defects (ADR-0039 §10.2 has the detail):
+## The blocker: a `gather` body's container append reaches the lane, not the owner's cell
 
-1. An expression-position container declaration allocates no slot —
-   `compile_expr_stmt`'s `Stmt::VarDecl` arm (`compiler/expr_block.rs`) takes a
-   `decl_slot` only when the declaration shadows an outer binding, and
-   `local_map` retains a popped sibling block's slot for a first declaration.
-2. The element-assign fast path is never handed its baked `target_slot`, so it
-   nil'd and re-seeded the wrong binding. Fix: thread `target_slot` in and use
-   `resolve_local_slot`.
-3. Whole-container rebuilds replaced the node — **already fixed and shipped** as
-   `Interpreter::store_container_preserving_identity` (§10.4).
-4. A QuantHash re-tag rebuilds its data node: `register_var_container_type_metadata`
-   (`runtime/runtime_container.rs`) tags the env value and re-inserts it, so
-   `my %h is MixHash` left the declaring slot on the untagged original.
+With all seven applied, `prove t/` and a full local `make roast` are green, and
+the **battery gate** fails on two files:
 
-`make roast` then failed four files. Two were the blocker above (now closed). The
-other two are ordinary and were diagnosed:
+- `Cro::HTTP/router-auth.rakutest` (24 assertions)
+- `zef/distribution-depends-parsing.rakutest` (1 assertion, test 21)
 
-- `S32-list/classify.t` 25-27 — a bug in fix 3's own probe (it promoted a parent-tier
-  env entry into the frame overlay); corrected by probing read-only.
-- `S03-metaops/hyper.t` 18-19, 92-93 — `@r»++` with an outer same-named `my @r`:
-  `write_back_hyper_target_var` resolves by `find_local_slot` / `locals_set_by_name`
-  (`position` → the OUTER slot). Same class as defect 2; needs a baked slot on
-  `HyperMethodCall`.
+The zef one was bisected to a **single container name**, `@prereq-candidates` in
+`Zef::Client!find-prereq-candidates`, using a temporary compiler harness worth
+rebuilding: an env var that restricts the flip to a comma-separated name list
+(`MUTSU_SLOT_READ_FILTER`) plus one that dumps every name the flip would apply to
+(`MUTSU_SLOT_READ_DUMP`), then a delta-debugging script over the ~92 names. That
+turns "a 3000-line vendored library misbehaves" into "one name" in a few minutes;
+**do this first next time**, before trying to reduce the source by hand.
+
+What the traces then showed, in the frame that fails:
+
+- the owner's slot and its `env` entry hold the **same** `ContainerRef` cell,
+  and that cell's array is **empty**;
+- `get_env_with_main_alias(name)` nevertheless answers a **1-element** array,
+  because `get_env_with_main_alias_inner`'s `__mutsu_atomic_arr::` probe wins
+  over `env`;
+- so the append (`@prereq-candidates.append(@candidates)`, performed from inside
+  a nested `gather for ... { ... }` block) landed in the **atomic lane** and
+  never reached the cell the owner's slot holds.
+
+The `%` twin does not have this problem: `shared_hash_elem_set` writes the merged
+hash through `unit_lexical_container_cell` / the env cell **unconditionally**,
+while `shared_array_mutate` does so only on its non-`is_thread_clone` branch. A
+first attempt at the obvious repair — capture the binding cell before
+`shared_array_mutate`'s thread-clone `env.remove` and write through it
+unconditionally — did **not** fix it, so the appending frame's `env` apparently
+does not hold the cell either; the next step is to trace which env tier the
+`gather` body runs against.
+
+Note the shape: this is §8.4 point 2's territory ("once `Expr::ArrayVar` emits
+`GetLocal(slot)`, the store-writeback path can no longer reach the reader"), but
+narrower than that point predicted — the lane still works, it is the *cell* that
+goes stale, and only for `@` (not `%`) and only when the mutation happens in a
+`gather`-driven frame.
+
+**Beware the Heisenbug.** Adding a `note "..." ~ @prereq-candidates.elems` *inside*
+the appending closure makes the whole file pass: the extra read changes the
+closure's free-variable set and therefore its capture strategy. Instrument only
+outside closures, or instrument the VM instead.
 
 ## What NOT to do
 
-Do not reach for decl-site cell-boxing of every `@`/`%` as the repair for a
-store-lane gap. `docs/captured-outer-cell-sharing.md` §7.1d records that broader
-`@`/`%` decl-site boxing regressed ~12 files through decont leaks, which is why
-`register_container_ref_capture_if_free` (`compiler/expr_call.rs`) is restricted
-to plain `$` names. ADR-0055 slice 1b's cell is narrow on purpose — it applies
-only to an *escaping capture the frame cannot vouch for* — and widening it is a
-different decision, not a slice-2 detail.
+- Do not reach for decl-site cell-boxing of every `@`/`%`.
+  `docs/captured-outer-cell-sharing.md` §7.1d records that it regressed ~12 files
+  through decont leaks, which is why `register_container_ref_capture_if_free` is
+  restricted to plain `$` names.
+- Do not lift the `is <Type>`-trait exclusion from
+  `CompiledCode::needs_cell_unvouched_containers`. It was measured as a working
+  fix for the `%h is MixHash` capture, but repair 7 subsumes it at a fraction of
+  the blast radius.
+- Do not trust `t/` + roast alone for this change. Both were fully green with the
+  flip on; the battery gate (`scripts/battery-testsuite.sh`, `MUTSU_BIN=…`) is the
+  only local gate that caught the blocker. Run it — it takes ~10 minutes.
 
 ## Acceptance
 
-- `prove t/` green with the flip on, including `t/closure-topic-readonly.t` and
-  `t/push-inline-array-decl.t`.
-- **A full local `make roast`** (not delegated to CI): the flip changes a
-  universal property of container reads, which is the shape ADR-0040 slice 2's
-  17 counter-current fixes came from, 9 of them found only by roast.
+- `prove t/` green with the flip on (attempt 3 reached this).
+- A full local `make roast` green (attempt 3 reached this).
+- **`MUTSU_BIN=target/release/mutsu scripts/battery-testsuite.sh` green** — the
+  gate attempt 3 did not reach.
 - `t/nested-frame-container-mutation-reaches-owner.t` and
-  `t/container-lexical-declarator-matrix.t` keep passing — they are the two pins
-  that say the write/capture lane is still sound underneath the flip.
+  `t/container-lexical-declarator-matrix.t` keep passing.


### PR DESCRIPTION
ADR-0039 slice 2's read flip (`@`/`%` reads compile to `GetLocal(slot)`) was implemented and measured for a third time. It got much further than §9 or §10 — a green `prove t/` and a green **full local `make roast`** with the flip on — and was withdrawn again by the **bundled-library battery gate**, which neither of those suites covers. What ships here is the one repair that is independently observable; everything else is recorded in enough detail to be re-derived rather than re-measured.

## What ships

`store_container_preserving_identity` (ADR-0039 §10.4) copies a rebuilt container's contents into the existing backing node instead of dropping a fresh node into `env`, so every other holder — a `:=` alias, a by-value capture, the declaring frame's slot — observes the rebuild. It only knew Array and Hash, so `classify(..., :into(my %b := BagHash.new))` rebuilt the Bag and fell through to a plain `env.insert`:

```raku
my %b := BagHash.new;
my $alias := %b;
classify(&even-odd, (1, 2, 3, 4), :into(%b));
say $alias<even>;   # raku: 2    mutsu (before): 0
```

Set/Bag/Mix arms added, sharing one `quanthash_inplace_reassign` helper whose aliased in-place write is the same audited shape as the two arms beside it. This also **corrects ADR-0039 §10.3's recorded diagnosis** of `roast/S32-list/classify.t` 25-27, which blamed "a bug in fix 3's own probe".

Pin: `t/container-rebuild-preserves-identity.t` grows four assertions (14 total, byte-identical under `raku`).

## The re-measurement (why the flip is withdrawn again)

Everything §10 recorded was measured on `2a9e06f91`, before `da8e94252`. Re-measured on `fad0ac3ad` with the flip applied:

| what §10/§11 recorded | re-measured 2026-09-07 |
| --- | --- |
| §11: the write/capture blocker | **gone**, as §11 predicted |
| §10.2 defect 1 — expression-position container decl allocates no slot | still reproduces (3 `t/` files) |
| §10.2 defect 2 — `try_fast_hash_element_assign` resolves by name | still reproduces (1 `t/` file) |
| §10.2 defect 3 — whole-container rebuilds replace the node | **gone** (shipped as §10.4) |
| §10.2 defect 4 — a QuantHash re-tag rebuilds its data node | still reproduces, **different root cause** |
| §10.3 roast row `S32-list/classify.t` 25-27 | still reproduces; **the diagnosis was wrong** — it is the missing QuantHash arm shipped here |
| §10.3 roast row `S03-metaops/hyper.t` 18-19, 92-93 | still reproduces; **§10.5 point 3's remedy is not needed** — writing the rebuilt array through the node fixes it and removes the slot search |
| — | NEW: `@_`/`%_` and twigil'd names — 11 `t/` files |
| — | NEW: the cross-thread lane — 9 `t/` files |
| — | NEW: `roast/S32-io/IO-Socket-Async.t` 37 |
| — | NEW (the blocker): `Cro::HTTP/router-auth.rakutest`, `zef/distribution-depends-parsing.rakutest` |

The naive flip's fallout was **26 `t/` files**, not §10.2's 8; all 26 were verified green on the same build with the flip reverted. Seven repairs took `t/` and roast fully green. The battery gate then failed on two files.

The zef failure was reduced to a **single container name** with a temporary compiler harness (an env var restricting the flip to a name list, plus delta debugging over the ~92 names a run touches) — worth rebuilding next time, it turns "a 3000-line vendored library misbehaves" into "one variable" in minutes. The mechanism: `shared_hash_elem_set` writes its merged hash through the binding's `ContainerRef` cell unconditionally, while `shared_array_mutate` does so only off the `is_thread_clone` branch, so a container appended to from a `gather`-driven frame lands in the atomic lane with the owner's cell left empty — invisible while the owner re-resolves the NAME (the lane wins that cascade), wrong the moment it reads its slot.

## Notes worth reading in the diff

- The `is_plain_user_lexical` restriction on the flip is a **requirement, not a margin**: the by-name read's `None` arm is what makes `%_` read as `{}` on the fast method-dispatch path, and its cascade is the only route to `%!attr`/`%.attr`, `@*dyn`, `%?RESOURCES` and `::`-qualified names.
- Three conditions had **both** their looser and their tighter neighbour measured wrong (the `GetLocal` cell gate, the QuantHash trait re-sync, the identity-preserving re-tag); all six variants and their failing tests are recorded so attempt 4 does not rediscover them.
- `t/` + `make roast` are **not sufficient evidence** for this change — both were green. `scripts/battery-testsuite.sh` is, and runs locally in ~10 minutes.

## Verification

- `make test` (incl. `cargo test`): **PASS**; `prove t/` 3782 files, 39753 tests.
- Full local `make roast`: 1436 files, 218962 tests, **PASS**.
- `MUTSU_BIN=target/release/mutsu scripts/battery-testsuite.sh`: **GATE PASSED**, 289/312 (287 with the flip).
- `cargo fmt` + `cargo clippy --all-targets -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
