### PR TITLE
perf(runtime): native integer wrapping stays in machine arithmetic

### DIFF
--- a/news/2026-09/native-int-wrapping-stays-in-machine-arithmetic.md
+++ b/news/2026-09/native-int-wrapping-stays-in-machine-arithmetic.md
@@ -1,0 +1,45 @@
+# Native integer wrapping stays in machine arithmetic
+
+Eleventh perf slice for `todo/deep/vendor-real-test-module.md`. The callgrind
+profile of a vendored-`Test` assertion carried ~7k instructions of
+`num_bigint` division -- `Rem`, `div_rem`, `div_rem_ref` -- under
+`wrap_native_int`, the helper that gives a store into a native integer
+variable its C-style modular wrap. It computed `((v % m) + m) % m` on heap
+integers regardless of the value's size: three `BigInt` divisions and several
+allocations, and its callers first boxed the `Int` they held into a `BigInt`
+to call it (and `is_in_native_range` allocated the type's two `BigInt` bounds
+per check). `Test.rakumod` counts its tests in `my int` lexicals, so
+`$num_of_tests_run = $num_of_tests_run + 1` paid all of that once per
+assertion; so does every `my int`/`uint8`/... store and every native-typed
+parameter binding in any program.
+
+Every native integer type is at most 64 bits wide, so both its modulus and
+its bounds fit an `i128`, and so does every value an `Int` (`i64`) store ever
+sees. `native_types` gains `wrap_native_int_i128`, `wrap_native_int_value` and
+`native_int_bounds_i128`; `wrap_native_int` and `is_in_native_range` take the
+machine path whenever the `BigInt` fits an `i128` (a `BigInt` that does not is
+out of every native range and keeps the old path), and the three `Value`-level
+callers (`maybe_wrap_native_int` on the read-modify-write store,
+`wrap_native_int_by_constraint` on assignment, `wrap_native_int_for_binding`
+on parameter binding) answer their `Int` arm without ever building a `BigInt`.
+A unit test checks the machine paths against the `BigInt` definitions across
+every width and both signednesses, including the `u64::MAX` / `i64::MIN`
+edges.
+
+Behaviour is unchanged (the smoke comparison against rakudo shows the same
+pre-existing difference as before: mutsu wraps a native-typed *parameter*'s
+argument where rakudo binds the unwrapped Int; that is not touched here).
+
+## Measured
+
+Callgrind, 300 `ok 1, "x"` in a loop under `MUTSU_REAL_TEST=1`, one-assertion
+baseline subtracted, release build:
+
+| | before | after |
+| --- | --- | --- |
+| per assertion | 250,138 Ir | 244,707 Ir |
+| `num_bigint` division rows | ~7.4k | 0 |
+| `exec_atomic_compound_var_op` (the `my int` RMW) | 8.0k | 4.6k |
+| `store_named_scalar_rmw_result` | 6.5k | 3.2k |
+
+**-2.2% per assertion**; -27.2% since the session opened at 335,929.

--- a/src/runtime/native_types.rs
+++ b/src/runtime/native_types.rs
@@ -153,6 +153,53 @@ pub(crate) fn is_signed_native(type_name: &str) -> bool {
     )
 }
 
+/// [`native_int_bounds`] without the two `BigInt` allocations: the bounds of
+/// every native integer type fit an `i128`.
+pub(crate) fn native_int_bounds_i128(type_name: &str) -> Option<(i128, i128)> {
+    let bits = native_type_bits(type_name)?;
+    Some(if is_signed_native(type_name) {
+        (-(1i128 << (bits - 1)), (1i128 << (bits - 1)) - 1)
+    } else {
+        (0, (1i128 << bits) - 1)
+    })
+}
+
+/// [`wrap_native_int`] for a value that fits an `i128` -- which every value a
+/// native store or a native-typed parameter ever sees does (`Int` is an
+/// `i64`, and a `BigInt` that fits is converted by the caller). Every native
+/// type is at most 64 bits wide, so the modulus `2^bits` fits an `i128` too
+/// and the wrap is two machine operations. `None` for a name that is not a
+/// native integer type.
+///
+/// The `BigInt` version below computed `((v % m) + m) % m` on heap integers:
+/// three divisions and several allocations per store into a `my int` lexical,
+/// which the vendored `Test.rakumod` does once per assertion
+/// (`$num_of_tests_run = $num_of_tests_run + 1`) and which showed up as ~7k
+/// instructions of `num_bigint` division per assertion
+/// (`todo/deep/vendor-real-test-module.md`).
+pub(crate) fn wrap_native_int_i128(type_name: &str, value: i128) -> Option<i128> {
+    let bits = native_type_bits(type_name)?;
+    let modulus = 1i128 << bits;
+    let wrapped = value.rem_euclid(modulus);
+    Some(if is_signed_native(type_name) && wrapped >= modulus >> 1 {
+        wrapped - modulus
+    } else {
+        wrapped
+    })
+}
+
+/// [`wrap_native_int_i128`] for an `Int` value, producing the wrapped `Value`
+/// (an `Int` when the result fits an `i64`, which it always does for a signed
+/// type; a `uint64` result above `i64::MAX` boxes). `None` for a name that is
+/// not a native integer type.
+pub(crate) fn wrap_native_int_value(type_name: &str, value: i64) -> Option<crate::value::Value> {
+    let wrapped = wrap_native_int_i128(type_name, value as i128)?;
+    Some(match i64::try_from(wrapped) {
+        Ok(n) => crate::value::Value::int(n),
+        Err(_) => crate::value::Value::bigint(NumBigInt::from(wrapped)),
+    })
+}
+
 /// Wrap a BigInt value to fit within the native type's range.
 /// This performs modular wrapping (like C integer overflow).
 pub(crate) fn wrap_native_int(type_name: &str, value: &NumBigInt) -> NumBigInt {
@@ -160,6 +207,12 @@ pub(crate) fn wrap_native_int(type_name: &str, value: &NumBigInt) -> NumBigInt {
         Some(b) => b,
         None => return value.clone(),
     };
+    // Machine arithmetic whenever the value fits (see `wrap_native_int_i128`).
+    if let Some(v) = num_traits::ToPrimitive::to_i128(value)
+        && let Some(wrapped) = wrap_native_int_i128(type_name, v)
+    {
+        return NumBigInt::from(wrapped);
+    }
     let signed = is_signed_native(type_name);
 
     // Total range = 2^bits
@@ -182,6 +235,14 @@ pub(crate) fn wrap_native_int(type_name: &str, value: &NumBigInt) -> NumBigInt {
 
 /// Check if a value (as BigInt) is within range for the native type.
 pub(crate) fn is_in_native_range(type_name: &str, value: &NumBigInt) -> bool {
+    // Machine compare whenever the value fits an `i128` (see
+    // `native_int_bounds_i128`); a wider value is out of every native range.
+    if let Some((min, max)) = native_int_bounds_i128(type_name) {
+        return match num_traits::ToPrimitive::to_i128(value) {
+            Some(v) => v >= min && v <= max,
+            None => false,
+        };
+    }
     if let Some((min, max)) = native_int_bounds(type_name) {
         value >= &min && value <= &max
     } else {
@@ -230,6 +291,80 @@ mod tests {
         // -129 should wrap to 127
         let val = NumBigInt::from(-129);
         assert_eq!(wrap_native_int("int8", &val), NumBigInt::from(127));
+    }
+
+    /// The machine-arithmetic fast paths agree with the `BigInt` definitions
+    /// they short-circuit, across every width and both signednesses.
+    #[test]
+    fn i128_fast_paths_agree_with_bigint_paths() {
+        use num_traits::ToPrimitive;
+        let bigint_wrap = |type_name: &str, value: &NumBigInt| -> NumBigInt {
+            let bits = native_type_bits(type_name).unwrap();
+            let modulus = NumBigInt::from(1u64) << bits;
+            let wrapped = ((value % &modulus) + &modulus) % &modulus;
+            if is_signed_native(type_name) && wrapped >= (&modulus >> 1) {
+                wrapped - modulus
+            } else {
+                wrapped
+            }
+        };
+        let samples: [i128; 14] = [
+            0,
+            1,
+            -1,
+            127,
+            128,
+            -128,
+            -129,
+            255,
+            256,
+            65_536,
+            i64::MAX as i128,
+            i64::MIN as i128,
+            u64::MAX as i128,
+            u64::MAX as i128 + 1,
+        ];
+        for type_name in [
+            "int8", "uint8", "int16", "uint16", "int32", "uint32", "int", "uint",
+        ] {
+            let (lo, hi) = native_int_bounds(type_name).unwrap();
+            assert_eq!(
+                native_int_bounds_i128(type_name).unwrap(),
+                (lo.to_i128().unwrap(), hi.to_i128().unwrap()),
+                "{type_name} bounds"
+            );
+            for v in samples {
+                let big = NumBigInt::from(v);
+                assert_eq!(
+                    NumBigInt::from(wrap_native_int_i128(type_name, v).unwrap()),
+                    bigint_wrap(type_name, &big),
+                    "{type_name} wrap {v}"
+                );
+                assert_eq!(
+                    wrap_native_int(type_name, &big),
+                    bigint_wrap(type_name, &big),
+                    "{type_name} wrap (BigInt entry) {v}"
+                );
+                assert_eq!(
+                    is_in_native_range(type_name, &big),
+                    big >= lo && big <= hi,
+                    "{type_name} range {v}"
+                );
+            }
+        }
+        assert_eq!(wrap_native_int_i128("Str", 5), None);
+        assert_eq!(
+            wrap_native_int_value("uint8", 300).unwrap(),
+            crate::value::Value::int(44)
+        );
+        assert_eq!(
+            wrap_native_int_value("int8", -129).unwrap(),
+            crate::value::Value::int(127)
+        );
+        assert_eq!(
+            wrap_native_int_value("uint64", -1).unwrap(),
+            crate::value::Value::bigint(NumBigInt::from(u64::MAX))
+        );
     }
 
     #[test]

--- a/src/runtime/types/signature.rs
+++ b/src/runtime/types/signature.rs
@@ -84,7 +84,12 @@ pub(in crate::runtime) fn wrap_native_int_for_binding(
         )));
     }
     let big_val = match val.view() {
-        ValueView::Int(n) => NumBigInt::from(n),
+        // The common case, machine arithmetic and no allocation. An `Int` is
+        // always in range for the full-width types (the overflow errors below
+        // are about `BigInt`s), and the narrower ones wrap.
+        ValueView::Int(n) => {
+            return Ok(native_types::wrap_native_int_value(base, n).unwrap_or(val));
+        }
         ValueView::BigInt(n) => (**n).clone(),
         _ => return Ok(val),
     };

--- a/src/vm/vm_value_helpers.rs
+++ b/src/vm/vm_value_helpers.rs
@@ -560,7 +560,6 @@ impl Interpreter {
     /// Used by increment/decrement to implement overflow/underflow wrapping.
     pub(super) fn maybe_wrap_native_int(&mut self, var_name: &str, value: Value) -> Value {
         use crate::runtime::native_types;
-        use num_bigint::BigInt as NumBigInt;
         use num_traits::ToPrimitive;
 
         let constraint = match loan_env!(self, var_type_constraint(var_name)) {
@@ -572,7 +571,10 @@ impl Interpreter {
         }
 
         let big_val = match value.view() {
-            ValueView::Int(n) => NumBigInt::from(n),
+            // The common case, machine arithmetic and no allocation.
+            ValueView::Int(n) => {
+                return native_types::wrap_native_int_value(&constraint, n).unwrap_or(value);
+            }
             ValueView::BigInt(n) => (**n).clone(),
             _ => return value,
         };

--- a/src/vm/vm_var_assign_local.rs
+++ b/src/vm/vm_var_assign_local.rs
@@ -744,7 +744,6 @@ impl Interpreter {
         val: Value,
     ) -> Result<Value, RuntimeError> {
         use crate::runtime::native_types;
-        use num_bigint::BigInt as NumBigInt;
         use num_traits::ToPrimitive;
 
         let (base, _) = crate::runtime::types::strip_type_smiley(constraint);
@@ -800,17 +799,16 @@ impl Interpreter {
             if let ValueView::Int(n) = val.view()
                 && n < 0
             {
-                let big_val = NumBigInt::from(n);
-                let wrapped = native_types::wrap_native_int(base, &big_val);
-                return Ok(wrapped
-                    .to_i64()
-                    .map(Value::int)
-                    .unwrap_or_else(|| Value::bigint(wrapped)));
+                return Ok(native_types::wrap_native_int_value(base, n).unwrap_or(val));
             }
             return Ok(val);
         }
         let big_val = match val.view() {
-            ValueView::Int(n) => NumBigInt::from(n),
+            // The common case, machine arithmetic and no allocation: in range
+            // is the identity, out of range wraps.
+            ValueView::Int(n) => {
+                return Ok(native_types::wrap_native_int_value(base, n).unwrap_or(val));
+            }
             ValueView::BigInt(n) => (**n).clone(),
             _ => return Ok(val),
         };


### PR DESCRIPTION
Eleventh perf slice for `todo/deep/vendor-real-test-module.md` (callgrind-driven), following #7472, #7476, #7477, #7480, #7483.

## What

The profile of a vendored-`Test` assertion carried ~7k instructions of `num_bigint` division (`Rem`, `div_rem`, `div_rem_ref`) under `wrap_native_int`, the helper that gives a store into a native integer variable its C-style modular wrap. It computed `((v % m) + m) % m` on heap integers regardless of the value's size — three `BigInt` divisions and several allocations — and its callers first boxed the `Int` they held into a `BigInt` to call it (`is_in_native_range` allocated the type's two `BigInt` bounds per check). `Test.rakumod` counts its tests in `my int` lexicals, so `$num_of_tests_run = $num_of_tests_run + 1` paid all of that once per assertion; so does every `my int`/`uint8`/... store and every native-typed parameter binding in any program.

Every native integer type is at most 64 bits wide, so its modulus and bounds fit an `i128`, and so does every value an `Int` (`i64`) store ever sees. `native_types` gains `wrap_native_int_i128`, `wrap_native_int_value` and `native_int_bounds_i128`; `wrap_native_int` / `is_in_native_range` take the machine path whenever the `BigInt` fits an `i128` (one that does not is out of every native range and keeps the old path), and the three `Value`-level callers (`maybe_wrap_native_int` on the RMW store, `wrap_native_int_by_constraint` on assignment, `wrap_native_int_for_binding` on parameter binding) answer their `Int` arm without building a `BigInt`. A unit test checks the machine paths against the `BigInt` definitions across every width and both signednesses, including the `u64::MAX` / `i64::MIN` edges.

Behaviour is unchanged (the smoke comparison against rakudo shows the same pre-existing difference as before: mutsu wraps a native-typed *parameter*'s argument where rakudo binds the unwrapped Int; not touched here).

## Measured

Callgrind, 300 `ok 1, "x"` in a loop under `MUTSU_REAL_TEST=1`, one-assertion baseline subtracted, release build:

| | before | after |
| --- | --- | --- |
| per assertion | 250,138 Ir | 244,707 Ir |
| `num_bigint` division rows | ~7.4k | 0 |
| `exec_atomic_compound_var_op` (the `my int` RMW) | 8.0k | 4.6k |
| `store_named_scalar_rmw_result` | 6.5k | 3.2k |

**-2.2% per assertion**; -27.2% cumulative since the session opened at 335,929.

## Verified

- `prove t/` on the debug binary: 3782 files, all pass.
- `cargo test` unit test `i128_fast_paths_agree_with_bigint_paths`.
- `cargo clippy --all-targets -- -D warnings`, `cargo fmt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J314VsqdhJ15T1rUJLvmyH

---
_Generated by [Claude Code](https://claude.ai/code/session_01J314VsqdhJ15T1rUJLvmyH)_