### PR TITLE
perf(vm): compiled-function table shares its bodies so a call holds its routine by Arc

### DIFF
--- a/news/2026-09/compiled-function-table-shares-its-bodies.md
+++ b/news/2026-09/compiled-function-table-shares-its-bodies.md
@@ -1,0 +1,42 @@
+# The compiled-function table shares its bodies
+
+Twelfth perf slice for `todo/deep/vendor-real-test-module.md`. The on-demand
+`callframe().code` object (`news/2026-09/callframe-code-object-is-built-on-demand.md`)
+stopped building a `Sub` per named call, but the lazy frame it pushes instead
+still captured what the `Sub` would be built from -- `cf.params.clone()` and
+`cf.param_defs.clone()`, a `Vec<String>` and a `Vec<ParamDef>` deep-copied on
+every entry and dropped on every return. It had to: `CompiledFns` owned its
+`CompiledFunction`s by value, so a running call held only a borrow of its own
+routine and nothing it could keep past the table's lifetime.
+
+`CompiledFnMap` is now `FxHashMap<Symbol, Arc<CompiledFunction>>`. The table
+API is unchanged for writers (`insert` wraps; `retain` hands out `&`), the
+resolvers (`find_compiled_function`, the ADR-0066 direct-mapped call cache) hand
+out `&Arc<CompiledFunction>`, and the named/light call paths take the `Arc` so
+`LazyRoutineCode` holds one refcount bump of the routine instead of copies of
+its signature. The cache slot still stores an address into the table -- now of
+the `Arc` value slot -- under exactly the same `fns_id` validity argument.
+
+Two other deep copies fell out along the way: an imported module's routines
+were installed in both the importer's table and the per-import table by
+cloning every body (`insert_shared` now shares them), and the `&?ROUTINE`
+materialisation of a plan-compiled multi rebuilt its `Arc<CompiledFunction>`
+from a clone (`Arc::clone` now). The registration side
+(`register_compiled_sub_decl` / `register_proto_decl`) still receives
+`&CompiledFunction` and clones into `FunctionDef::compiled`; that is a
+declaration-time cost, not a per-call one, and is left as is.
+
+## Measured
+
+Callgrind, 300 `ok 1, "x"` in a loop under `MUTSU_REAL_TEST=1`, one-assertion
+baseline subtracted, release build:
+
+| | before | after |
+| --- | --- | --- |
+| per assertion | 244,707 Ir | 237,744 Ir |
+| `<Vec<T,A> as Clone>::clone` | 5.0k | 1.4k |
+| `<ParamDef as Clone>::clone` | 2.3k | 0 |
+| `drop_in_place<ParamDef>` | 1.5k | 0 |
+| `call_compiled_function_named_inner` (outer frame) | 224.9k | 218.0k |
+
+**-2.8% per assertion**; -29.2% since the session opened at 335,929.

--- a/src/compiler/helpers_sub_body.rs
+++ b/src/compiler/helpers_sub_body.rs
@@ -51,8 +51,8 @@ impl Compiler {
                 remap.insert(key, imported_key);
             }
             self.compiled_functions
-                .insert(imported_key, function.clone());
-            imported.insert(imported_key, function);
+                .insert_shared(imported_key, std::sync::Arc::clone(&function));
+            imported.insert_shared(imported_key, function);
         }
         if !remap.is_empty() {
             code.remap_sub_decl_compiled_routine_keys(&remap);

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -4931,7 +4931,8 @@ pub(crate) struct CallIcSlot {
     /// 0 = empty; otherwise the `pos_light_ic_epoch` this entry was filled at.
     pub(crate) epoch: u64,
     pub(crate) fns_id: u64,
-    /// `*const CompiledFunction` into the table identified by `fns_id`.
+    /// `*const Arc<CompiledFunction>` -- the address of the value slot in the
+    /// table identified by `fns_id`.
     pub(crate) target: usize,
     /// `Symbol::id()` of the callee name this entry resolved.
     pub(crate) name: u32,
@@ -8262,7 +8263,11 @@ impl CompiledCode {
 /// allocation). The slow resolution path probes candidate keys via
 /// `Symbol::lookup` (no interning of names that turn out not to exist), so a
 /// missed probe never grows the global symbol table.
-pub(crate) type CompiledFnMap = rustc_hash::FxHashMap<crate::symbol::Symbol, CompiledFunction>;
+/// Values are `Arc`-shared so a running call can hold its own routine's
+/// definition (the on-demand `callframe().code` object, `CodeFrame::Lazy`)
+/// without deep-cloning the signature vectors on every entry, and so a table
+/// clone is a refcount bump per entry rather than a copy of every body.
+pub(crate) type CompiledFnMap = rustc_hash::FxHashMap<crate::symbol::Symbol, Arc<CompiledFunction>>;
 
 /// The table itself, wrapped so that it carries a **version token** (`id`).
 ///
@@ -8304,18 +8309,30 @@ impl CompiledFns {
 
     pub(crate) fn insert(&mut self, key: crate::symbol::Symbol, value: CompiledFunction) {
         self.id = Self::next_id();
+        self.map.insert(key, Arc::new(value));
+    }
+
+    /// Insert a body another table already owns, sharing it instead of
+    /// copying it (an imported module's routines are installed in both the
+    /// importer's table and the per-import table).
+    pub(crate) fn insert_shared(
+        &mut self,
+        key: crate::symbol::Symbol,
+        value: Arc<CompiledFunction>,
+    ) {
+        self.id = Self::next_id();
         self.map.insert(key, value);
     }
 
     pub(crate) fn retain(
         &mut self,
-        f: impl FnMut(&crate::symbol::Symbol, &mut CompiledFunction) -> bool,
+        mut f: impl FnMut(&crate::symbol::Symbol, &CompiledFunction) -> bool,
     ) {
         self.id = Self::next_id();
-        self.map.retain(f);
+        self.map.retain(|key, value| f(key, value));
     }
 
-    pub(crate) fn into_values(self) -> impl Iterator<Item = CompiledFunction> {
+    pub(crate) fn into_values(self) -> impl Iterator<Item = Arc<CompiledFunction>> {
         self.map.into_values()
     }
 }
@@ -8348,7 +8365,10 @@ impl FromIterator<(crate::symbol::Symbol, CompiledFunction)> for CompiledFns {
     fn from_iter<T: IntoIterator<Item = (crate::symbol::Symbol, CompiledFunction)>>(
         iter: T,
     ) -> Self {
-        let map: CompiledFnMap = iter.into_iter().collect();
+        let map: CompiledFnMap = iter
+            .into_iter()
+            .map(|(key, value)| (key, Arc::new(value)))
+            .collect();
         let id = if map.is_empty() { 0 } else { Self::next_id() };
         Self { map, id }
     }
@@ -8360,12 +8380,13 @@ impl Extend<(crate::symbol::Symbol, CompiledFunction)> for CompiledFns {
         iter: T,
     ) {
         self.id = Self::next_id();
-        self.map.extend(iter);
+        self.map
+            .extend(iter.into_iter().map(|(key, value)| (key, Arc::new(value))));
     }
 }
 
 impl IntoIterator for CompiledFns {
-    type Item = (crate::symbol::Symbol, CompiledFunction);
+    type Item = (crate::symbol::Symbol, Arc<CompiledFunction>);
     type IntoIter = <CompiledFnMap as IntoIterator>::IntoIter;
     fn into_iter(self) -> Self::IntoIter {
         self.map.into_iter()
@@ -8373,7 +8394,7 @@ impl IntoIterator for CompiledFns {
 }
 
 impl<'a> IntoIterator for &'a CompiledFns {
-    type Item = (&'a crate::symbol::Symbol, &'a CompiledFunction);
+    type Item = (&'a crate::symbol::Symbol, &'a Arc<CompiledFunction>);
     type IntoIter = <&'a CompiledFnMap as IntoIterator>::IntoIter;
     fn into_iter(self) -> Self::IntoIter {
         self.map.iter()

--- a/src/runtime/code_frame.rs
+++ b/src/runtime/code_frame.rs
@@ -27,8 +27,11 @@ pub(crate) enum CodeFrame {
 pub(crate) struct LazyRoutineCode {
     pub(crate) package: Symbol,
     pub(crate) name: Symbol,
-    pub(crate) params: Vec<String>,
-    pub(crate) param_defs: Vec<ParamDef>,
+    /// The routine being run: a refcount bump of the table's (or the OTF
+    /// cache's) own `Arc`, so entry copies no signature vector. The
+    /// `params` / `param_defs` the built `Sub` carries are read off it only
+    /// if something materializes the frame.
+    pub(crate) cf: std::sync::Arc<crate::opcode::CompiledFunction>,
     /// The caller's env as it was at call entry. An `Arc` bump of the live
     /// env: later writes to that env copy-on-write away from this handle, so
     /// it is the same snapshot the eager `clone_env()` took, minus the
@@ -41,15 +44,13 @@ impl LazyRoutineCode {
     pub(crate) fn new(
         package: Symbol,
         name: Symbol,
-        params: Vec<String>,
-        param_defs: Vec<ParamDef>,
+        cf: std::sync::Arc<crate::opcode::CompiledFunction>,
         env: Env,
     ) -> Self {
         Self {
             package,
             name,
-            params,
-            param_defs,
+            cf,
             env,
             materialized: std::sync::OnceLock::new(),
         }
@@ -126,8 +127,8 @@ impl Interpreter {
                     let sub_val = Value::make_sub(
                         l.package,
                         l.name,
-                        l.params.clone(),
-                        l.param_defs.clone(),
+                        l.cf.params.clone(),
+                        l.cf.param_defs.clone(),
                         vec![],
                         false,
                         l.env.flattened(),

--- a/src/runtime/run_modules.rs
+++ b/src/runtime/run_modules.rs
@@ -1123,7 +1123,7 @@ impl Interpreter {
         for cf in compiled_fns.into_values() {
             self.imported_compiled_fns
                 .entry(cf.fingerprint)
-                .or_insert_with(|| std::sync::Arc::new(cf));
+                .or_insert_with(|| cf);
         }
     }
 

--- a/src/vm/vm_call_func_ops.rs
+++ b/src/vm/vm_call_func_ops.rs
@@ -35,7 +35,7 @@ impl Interpreter {
         name_sym: Symbol,
         pkg_sym: Symbol,
         fns_id: u64,
-    ) -> Option<*const CompiledFunction> {
+    ) -> Option<*const Arc<CompiledFunction>> {
         // Masked index: in bounds by construction, so no bounds check survives.
         let slot = &self.call_ic[crate::opcode::CallIcSlot::way(name_sym)];
         if slot.epoch == self.pos_light_ic_epoch
@@ -43,7 +43,7 @@ impl Interpreter {
             && slot.name == name_sym.id()
             && slot.pkg == pkg_sym.id()
         {
-            Some(slot.target as *const CompiledFunction)
+            Some(slot.target as *const Arc<CompiledFunction>)
         } else {
             None
         }
@@ -55,7 +55,10 @@ impl Interpreter {
     /// `ptr` must have been taken from `fns` while `fns.id()` had the value the
     /// caller compared against, and `fns` must not have been mutated since.
     #[inline]
-    unsafe fn ic_target(_fns: &CompiledFns, ptr: *const CompiledFunction) -> &CompiledFunction {
+    unsafe fn ic_target(
+        _fns: &CompiledFns,
+        ptr: *const Arc<CompiledFunction>,
+    ) -> &Arc<CompiledFunction> {
         unsafe { &*ptr }
     }
 
@@ -66,7 +69,7 @@ impl Interpreter {
         name_sym: Symbol,
         pkg_sym: Symbol,
         fns_id: u64,
-        target: &CompiledFunction,
+        target: &Arc<CompiledFunction>,
     ) {
         // A table that has never been mutated has no identity to vouch for the
         // address (id 0 is shared by every empty scratch table), so it cannot
@@ -77,7 +80,7 @@ impl Interpreter {
         self.call_ic[crate::opcode::CallIcSlot::way(name_sym)] = crate::opcode::CallIcSlot {
             epoch: self.pos_light_ic_epoch,
             fns_id,
-            target: target as *const CompiledFunction as usize,
+            target: target as *const Arc<CompiledFunction> as usize,
             name: name_sym.id(),
             pkg: pkg_sym.id(),
         };
@@ -534,7 +537,7 @@ impl Interpreter {
                 // chunk-side index table measured no better than the probes.
                 let fns_id = compiled_fns.id();
                 let cur_pkg_sym = self.current_package_sym();
-                let mut cached: Option<&CompiledFunction> = self
+                let mut cached: Option<&Arc<CompiledFunction>> = self
                     .call_ic_hit(name_sym, cur_pkg_sym, fns_id)
                     // SAFETY: `call_ic_hit` yields the address only when the
                     // slot's `fns_id` equals this table's — which proves both
@@ -567,7 +570,7 @@ impl Interpreter {
                         self.call_ic_fill(name_sym, cur_pkg_sym, fns_id, cf);
                     }
                 }
-                if let Some(cf) = cached.or(otf_hold.as_deref()) {
+                if let Some(cf) = cached.or(otf_hold.as_ref()) {
                     let arity_usize = arity as usize;
                     if self.stack.len() >= arity_usize {
                         // One fused pass over the args (J4d): junction detection
@@ -2485,7 +2488,7 @@ impl Interpreter {
     /// shared cell accumulates (matching how a same-unit compiled `sub` is called).
     pub(super) fn call_shared_state_body(
         &mut self,
-        shared: &CompiledFunction,
+        shared: &Arc<CompiledFunction>,
         args: Vec<Value>,
         compiled_fns: &CompiledFns,
         pkg: &str,

--- a/src/vm/vm_call_light_typed.rs
+++ b/src/vm/vm_call_light_typed.rs
@@ -7,7 +7,7 @@ impl Interpreter {
     /// without touching the env HashMap, maximizing performance for hot loops.
     pub(super) fn call_compiled_function_light(
         &mut self,
-        cf: &CompiledFunction,
+        cf: &Arc<CompiledFunction>,
         args: &[Value],
         compiled_fns: &CompiledFns,
         func_name: &str,
@@ -31,7 +31,7 @@ impl Interpreter {
     /// all-in-band ordering.
     pub(super) fn call_compiled_function_light_spec(
         &mut self,
-        cf: &CompiledFunction,
+        cf: &Arc<CompiledFunction>,
         args: &[Value],
         compiled_fns: &CompiledFns,
         func_name: &str,

--- a/src/vm/vm_call_named.rs
+++ b/src/vm/vm_call_named.rs
@@ -3,7 +3,7 @@ use super::*;
 impl Interpreter {
     pub(crate) fn call_compiled_function_named(
         &mut self,
-        cf: &CompiledFunction,
+        cf: &Arc<CompiledFunction>,
         args: Vec<Value>,
         compiled_fns: &CompiledFns,
         fn_package: &str,

--- a/src/vm/vm_call_named_inner.rs
+++ b/src/vm/vm_call_named_inner.rs
@@ -3,7 +3,7 @@ use super::*;
 impl Interpreter {
     pub(super) fn call_compiled_function_named_inner(
         &mut self,
-        cf: &CompiledFunction,
+        cf: &Arc<CompiledFunction>,
         args: Vec<Value>,
         compiled_fns: &CompiledFns,
         fn_package: &str,
@@ -73,8 +73,7 @@ impl Interpreter {
         self.push_lazy_block(crate::runtime::LazyRoutineCode::new(
             fn_package_sym,
             fn_name_sym,
-            cf.params.clone(),
-            cf.param_defs.clone(),
+            Arc::clone(cf),
             self.env().clone(),
         ));
 
@@ -502,7 +501,7 @@ impl Interpreter {
                         Vec::new(),
                         plan.is_rw,
                         self.clone_env(),
-                        Some(std::sync::Arc::new(compiled.clone())),
+                        Some(std::sync::Arc::clone(compiled)),
                     ),
                     // Neither the registry lookup above nor the plan's own
                     // compiled routine resolved: build a body-less Sub (the

--- a/src/vm/vm_call_resolve.rs
+++ b/src/vm/vm_call_resolve.rs
@@ -6,7 +6,7 @@ impl Interpreter {
         compiled_fns: &'a CompiledFns,
         name: &str,
         args: &[Value],
-    ) -> Option<&'a CompiledFunction> {
+    ) -> Option<&'a Arc<CompiledFunction>> {
         // Pseudo-package names need interpreter's special resolution
         if self.is_interpreter_handled_function(name) {
             return None;
@@ -27,7 +27,7 @@ impl Interpreter {
         compiled_fns: &'a CompiledFns,
         name: &str,
         args: &[Value],
-    ) -> Option<&'a CompiledFunction> {
+    ) -> Option<&'a Arc<CompiledFunction>> {
         let arity = args.len();
         let name_sym = Symbol::intern(name);
         // Build a type signature for cache key to handle multi dispatch correctly

--- a/src/vm/vm_register_sub_ops.rs
+++ b/src/vm/vm_register_sub_ops.rs
@@ -309,7 +309,9 @@ impl Interpreter {
                 if compiled_routine_keys.len() != 1 + signature_alternates.len() {
                     return None;
                 }
-                compiled_fns.get(&compiled_routine_keys[slot])
+                compiled_fns
+                    .get(&compiled_routine_keys[slot])
+                    .map(|cf| &**cf)
             };
             let primary_compiled = plan_compiled(0);
             let body: &[Stmt] = &[];
@@ -1204,7 +1206,7 @@ impl Interpreter {
                 return_type.as_ref(),
                 body,
                 *is_our,
-                compiled,
+                compiled.map(|cf| &**cf),
                 is_lexical_hoist,
             )?;
         }
@@ -1215,7 +1217,7 @@ impl Interpreter {
                 param_defs,
                 return_type.as_ref(),
                 body,
-                compiled,
+                compiled.map(|cf| &**cf),
             )?;
             // Record the export so consumers/MAIN-dispatch see the whole multi
             // family. A `proto … is export` exports its candidates too (raku),


### PR DESCRIPTION
Twelfth perf slice for `todo/deep/vendor-real-test-module.md` (callgrind-driven), following #7472, #7476, #7477, #7480, #7483, #7486.

## What

The on-demand `callframe().code` object (#7480) stopped building a `Sub` per named call, but the lazy frame it pushes instead still captured what the `Sub` would be built from: `cf.params.clone()` and `cf.param_defs.clone()`, a `Vec<String>` and a `Vec<ParamDef>` deep-copied on every entry and dropped on every return. It had to: `CompiledFns` owned its `CompiledFunction`s by value, so a running call held only a borrow of its own routine.

`CompiledFnMap` is now `FxHashMap<Symbol, Arc<CompiledFunction>>`:

- the table API is unchanged for writers (`insert` wraps, `retain` hands out `&`; `insert_shared` added for a body another table already owns);
- `find_compiled_function` and the ADR-0066 direct-mapped call cache hand out `&Arc<CompiledFunction>` — the cache slot still stores an address into the table, now of the `Arc` value slot, under exactly the same `fns_id` validity argument;
- `call_compiled_function_named[_inner]`, `call_compiled_function_light[_spec]` and `call_shared_state_body` take the `Arc`, so `LazyRoutineCode` holds one refcount bump of the routine instead of copies of its signature (materialization reads `params`/`param_defs` off it).

Two other deep copies fell out: an imported module's routines were installed in both the importer's table and the per-import table by cloning every body (`insert_shared` now shares them), and the `&?ROUTINE` materialization of a plan-compiled multi rebuilt its `Arc<CompiledFunction>` from a clone (`Arc::clone` now). The registration side (`register_compiled_sub_decl` / `register_proto_decl`) still receives `&CompiledFunction` and clones into `FunctionDef::compiled`; that is a declaration-time cost and is left as is.

## Measured

Callgrind, 300 `ok 1, "x"` in a loop under `MUTSU_REAL_TEST=1`, one-assertion baseline subtracted, release build:

| | before | after |
| --- | --- | --- |
| per assertion | 244,707 Ir | 237,744 Ir |
| `<Vec<T,A> as Clone>::clone` | 5.0k | 1.4k |
| `<ParamDef as Clone>::clone` | 2.3k | 0 |
| `drop_in_place<ParamDef>` | 1.5k | 0 |
| `call_compiled_function_named_inner` (outer frame) | 224.9k | 218.0k |

**-2.8% per assertion**; -29.2% cumulative since the session opened at 335,929.

## Verified

- `prove t/` on the debug binary: 3782 files, all pass.
- `cargo clippy --all-targets -- -D warnings`, `cargo fmt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J314VsqdhJ15T1rUJLvmyH

---
_Generated by [Claude Code](https://claude.ai/code/session_01J314VsqdhJ15T1rUJLvmyH)_