### PR TITLE
fix(compiler): the immutable-topic receiver oracle learns the shapes raku refuses

### DIFF
--- a/news/2026-09/immutable-topic-receiver-oracle-widened.md
+++ b/news/2026-09/immutable-topic-receiver-oracle-widened.md
@@ -1,0 +1,99 @@
+# The immutable-topic receiver oracle learns the shapes raku actually refuses
+
+`todo/deep/immutable-lvalues-that-mutsu-still-lets-you-assign-to.md` section A
+collected the receivers where mutsu silently accepted `$_ = ...` on a topic
+rakudo refuses. The file's own conclusion was that section A "cannot be closed
+by a local runtime test" and had to wait for either section B or a grown
+compile-time receiver oracle. Re-measuring the whole survey on 2026-09-07
+showed most of section A is the *second* route, and that route is a lot smaller
+than the file assumed: four of its six rows, plus every row of two families the
+survey had not enumerated, are decided by `Compiler::for_iterable_yields_bare_items`
+alone.
+
+## The rule, measured
+
+raku binds a `for` loop's implicit topic — and a `.map`/`.grep`/`.first`
+callback's `$_` — to the source ELEMENT. `$_ = ...` is legal exactly when that
+element has a `Scalar` behind it. Measured against rakudo, that makes the
+verdict a property of the receiver's syntax in three families the oracle did not
+know:
+
+| receiver | rakudo | mutsu before |
+|---|---|---|
+| `for %h { $_ = 5 }`, `%h.map({ $_ = 5 })`, `%h.grep(...)` | throws | silently dropped |
+| `for @a.List`, `@a.List.map`, `@a.pairs`, `@a.antipairs`, `%h.kv`, `%h.List` | throws | silently dropped |
+| `for (@a,)`, `for @a, @b`, `for $x, @a`, `for $x, 2`, `for ($x + 1,)`, `for (1..2), (3..4)` | throws | silently dropped, or wrote one item and continued |
+| `(1, 2).first({ $_ = 5 })` | throws | answered `1` |
+
+and — the half that keeps the change honest — leaves these writable, because
+each one hands out the source's own containers:
+
+`for @a`, `for (@a)`, `for @a.list`, `for @a.values`, `for @a.Seq`,
+`for %h.values`, `for ($x, $y)`, `($x, $y).map({ $_ = 5 })`, `for ($x,)`,
+`@a.first({ $_ = 5 })`, `@a.values.first({ $_ = 5 })`.
+
+A **list literal is element-wise**: `($x, $y)` is a `List` of the two `Scalar`s
+and writes through, while any item with no `Scalar` behind it — a bare value, an
+`@`/`%` variable, a `Range`, an arithmetic result — makes the topic immutable.
+That is why the oracle's `ArrayLiteral` arm flipped from "every item is a
+literal" to "**any** item is provably bare": the mark is one per loop rather
+than per item, and raku throws at the bare item either way.
+
+## The marking had to be split shallow/deep
+
+`for %h { $_ = 5 }` throws in raku but `for %h { .value = 5 }` writes the hash,
+and so do `for %h -> $p { $p.value = 7 }` and `for %h.pairs { .value = 9 }`. The
+survey predicted this correctly: the `for` loop had fused its topic mark with
+the `__mutsu_deep_readonly::_` env flag that also refuses a method lvalue, so
+extending the oracle to `%h` would have converted a write raku performs into a
+throw.
+
+The two are now computed independently in `vm_for_loop_body.rs`. The deep flag
+belongs only to an *immutable QuantHash* source (`Set`/`Bag`/`Mix`), where
+nothing reachable through the topic may be written; a provably-bare source is
+shallowly readonly, because the topic has no container of its own even though
+the item object it names may be perfectly mutable.
+
+## `.first` was one missing call, not a missing mechanism
+
+`.first`'s matcher already reaches `vm_call_on_value`, which consults
+`CompiledCode::immutable_topic`, but the batched scan
+(`try_first_match_batched`, the ~25x-cheaper setup-once path that actually
+serves `.first({ ... })`) bound the topic with a direct `env` insert and never
+called `set_loop_topic_readonly` the way the sibling grep loop does. Adding
+`"first"` to `method_binds_immutable_topic` and the two-line mark to that scan —
+under the same `ReadonlyFrameGuard` the grep loop opens, so the mark is
+journalled rather than leaked — closes the row. `@a.first({ $_ = 5 })` is
+unaffected: `@a` is not a provably-bare receiver, and that scan already binds
+the element containers for it.
+
+## A free second consumer: ADR-0045's rw bind
+
+`ForLoopSpec::source_items_are_bare` also gates ADR-0045 slice 5 — an
+`is rw` / `<->` parameter over a source that can only yield bare values has no
+container to alias, and raku fails the *bind*, before the body runs. Widening
+the oracle therefore closed that half too, with no separate change:
+`for %h <-> $p`, `for %h -> $p is rw`, `for @a.List <-> $v`,
+`for @a.pairs <-> $p`, `for @a.antipairs <-> $p`, `for %h.kv <-> $v`,
+`for %h.List <-> $v` and `for (@a,) <-> $v` all now raise the same
+`Parameter '$v' expects a writable container` rakudo raises, with the same
+rendered value; `for $x, $y <-> $v { $v = 9 }` still binds and writes back.
+
+The one residual approximation is *which* item is reported when a list literal
+mixes shapes: `for $x, 2 <-> $v` names item 1 where rakudo names item 2, because
+the verdict is one mark per loop rather than per item. Both die.
+
+## Pinned
+
+`t/immutable-topic-receiver-oracle.t`, 51 rows, green under `raku` as well as
+mutsu — 18 of them controls that must NOT start throwing or start failing a
+bind.
+
+## Residue
+
+`todo/deep/immutable-lvalues-that-mutsu-still-lets-you-assign-to.md` keeps the
+rows a syntactic oracle cannot decide (a `@` variable `:=`-bound to a `List`, a
+`$` variable holding a `Seq`), section B's surviving producer, and sections
+C2/D/E/F. Two new rows were found while measuring: a `$^x` placeholder parameter
+misses the readonly marking `-> $v` gets, and `%h.map({ .value = 9 })` throws
+where `%h.pairs.map({ .value = 9 })` writes through.

--- a/src/compiler/expr_method.rs
+++ b/src/compiler/expr_method.rs
@@ -551,8 +551,8 @@ impl Compiler {
         self.compile_expr_method_on_index(&final_target, name, args, modifier, quoted);
     }
 
-    /// Does a `.map`/`.grep` written directly against `target` bind its
-    /// callback's implicit `$_` to an item with no container of its own?
+    /// Does a `.map`/`.grep`/`.first` written directly against `target` bind
+    /// its callback's implicit `$_` to an item with no container of its own?
     ///
     /// Reuses the `for`-loop oracle
     /// ([`Compiler::for_iterable_yields_bare_items`]): `(1, 2).map({ $_ = 5 })`
@@ -561,7 +561,12 @@ impl Compiler {
     /// `@a.map({ $_ = 5 })` and every shape mutsu cannot prove bare keep
     /// today's writable topic. See [`crate::opcode::CompiledCode::immutable_topic`].
     pub(super) fn method_binds_immutable_topic(target: &Expr, mname: &str) -> bool {
-        matches!(mname, "map" | "grep") && Self::for_iterable_yields_bare_items(target)
+        // `.first` scans with the same topic binding `.grep` does — its matcher
+        // block reaches `vm_call_on_value`, which already consults
+        // `CompiledCode::immutable_topic` — so `(1, 2).first({ $_ = 5 })` is the
+        // same rejection. `@a.first({ $_ = 5 })` keeps writing through, because
+        // `@a` is not a provably-bare receiver.
+        matches!(mname, "map" | "grep" | "first") && Self::for_iterable_yields_bare_items(target)
     }
 
     /// A directly-written bare block argument (`{ ... }`), the only shape whose

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -3351,9 +3351,17 @@ impl Compiler {
                 v.view(),
                 crate::value::ValueView::Array(..) | crate::value::ValueView::Hash(..)
             ),
-            // A list built entirely out of literals (`for 1, 2`, `for <a b>`).
+            // A LIST literal. raku builds a `List` whose elements are exactly
+            // the item expressions' containers, so an item that denotes a
+            // `Scalar` (`for $x, $y { $_ = 9 }`) keeps the topic writable while
+            // any item that is a bare value, an `Array` or a `Hash` has no
+            // `Scalar` behind it and makes `$_ = ...` an error at THAT item
+            // (`for $x, 2 { }`, `for @a, @b { }`, `for (@a,) { }`, `for 1, 2
+            // { }`). The mark is one per loop, not per item, so a literal with
+            // a mix answers `true`: raku throws on the bare item either way,
+            // and the only difference is how far the loop got first.
             Expr::ArrayLiteral(items) => {
-                !items.is_empty() && items.iter().all(|i| matches!(i, Expr::Literal(_)))
+                !items.is_empty() && items.iter().any(Self::list_literal_item_is_bare)
             }
             // A `Range` yields immutable endpoints-derived values and never
             // element containers, whatever its endpoints are -- `for $a..$b
@@ -3365,15 +3373,68 @@ impl Compiler {
                     | crate::token_kind::TokenKind::CaretDotDot
                     | crate::token_kind::TokenKind::CaretDotDotCaret
             ),
-            // `.keys` on a container yields freshly built keys, never the
-            // container's element cells. Restricted to `@`/`%` variables so a
-            // user-defined `keys` method returning containers is not affected.
+            // Iterating a `%` variable mints a fresh `Pair` per entry; the
+            // topic is that `Pair` itself, with no `Scalar` behind it, so raku
+            // rejects `for %h { $_ = 5 }` and `%h.map({ $_ = 9 })`. The Pair
+            // OBJECT stays mutable — `for %h { .value = 5 }` writes the hash —
+            // which is why this marking must stay SHALLOW (see
+            // `ForLoopSpec::source_items_are_bare`'s use site).
+            Expr::HashVar(_) => true,
+            // Coercers and views that build fresh items rather than handing out
+            // the container's element cells. Restricted to `@`/`%` variables so
+            // a user-defined method of the same name is not affected.
+            //
+            // `.List` copies into an immutable `List`; `.keys`/`.pairs`/
+            // `.antipairs`/`.kv` mint fresh keys and `Pair`s. Deliberately NOT
+            // here: `.list` and `.values`, which raku iterates through the
+            // source's own containers (`for @a.list { $_ = 5 }` and
+            // `for %h.values { $_ = 5 }` both write through).
             Expr::MethodCall {
                 target, name, args, ..
-            } if args.is_empty() && *name == "keys" => {
+            } if args.is_empty()
+                && (*name == "keys"
+                    || *name == "List"
+                    || *name == "pairs"
+                    || *name == "antipairs"
+                    || *name == "kv") =>
+            {
                 matches!(target.as_ref(), Expr::ArrayVar(_) | Expr::HashVar(_))
             }
             _ => false,
+        }
+    }
+
+    /// Whether one ITEM of a list literal is provably not a `Scalar` container
+    /// — see the `Expr::ArrayLiteral` arm of
+    /// [`Compiler::for_iterable_yields_bare_items`]. Conservative: an
+    /// unrecognised shape answers `false`, which only leaves today's writable
+    /// topic in place instead of inventing a throw raku does not have.
+    fn list_literal_item_is_bare(item: &Expr) -> bool {
+        match item {
+            Expr::Grouped(inner) => Self::list_literal_item_is_bare(inner),
+            // `(@a,)` / `(%h,)`: the item IS the Array/Hash, which is a
+            // container but not a `Scalar`, so `$_ = 5` is still refused.
+            Expr::ArrayVar(_) | Expr::HashVar(_) => true,
+            // A `Range` item yields the Range object itself here, and an
+            // arithmetic/string operator mints a fresh value whatever its
+            // operands are (`for $x + 1, $y { }`), so unlike
+            // `expr_yields_container_less_value` — which must stay conservative
+            // about what an operand denotes — the operands need no inspection.
+            Expr::Binary { op, .. } => matches!(
+                op,
+                crate::token_kind::TokenKind::DotDot
+                    | crate::token_kind::TokenKind::DotDotCaret
+                    | crate::token_kind::TokenKind::CaretDotDot
+                    | crate::token_kind::TokenKind::CaretDotDotCaret
+                    | crate::token_kind::TokenKind::Plus
+                    | crate::token_kind::TokenKind::Minus
+                    | crate::token_kind::TokenKind::Star
+                    | crate::token_kind::TokenKind::Slash
+                    | crate::token_kind::TokenKind::Percent
+                    | crate::token_kind::TokenKind::StarStar
+                    | crate::token_kind::TokenKind::Tilde
+            ),
+            other => Self::expr_yields_container_less_value(other),
         }
     }
 

--- a/src/runtime/resolution_map_grep.rs
+++ b/src/runtime/resolution_map_grep.rs
@@ -956,6 +956,18 @@ impl Interpreter {
 
         let keeps_outer_topic = block_keeps_outer_topic(&data);
         let outer_topic = self.env.get("_").cloned();
+        // Same compile-time verdict the map/grep loops use: the matcher was
+        // written directly against a source that provably yields bare items
+        // (`(1, 2).first({ $_ = 5 })`), so its implicit topic has no container
+        // to assign into -- see `CompiledCode::immutable_topic` and
+        // `set_loop_topic_readonly`. `@a.first({ $_ = 5 })` is unaffected: `@a`
+        // is not a provably-bare receiver, and this scan already binds the
+        // element CONTAINERS for it.
+        let immutable_topic = !keeps_outer_topic
+            && data
+                .compiled_code
+                .as_ref()
+                .is_some_and(|cc| cc.immutable_topic);
 
         let mut found: Option<(usize, Value)> = None;
         let loop_result: Result<(), RuntimeError> = self.with_nested_registers(|vm| {
@@ -985,6 +997,14 @@ impl Interpreter {
                     }
                     bind_loop_topic(vm.env_mut(), &call_item, keeps_outer_topic, &outer_topic);
                     let saved_when_matched = vm.when_matched();
+                    // This loop binds params directly into `env` instead of
+                    // going through the call machinery, so `readonly_frames` is
+                    // never incremented here; without an open readonly scope the
+                    // topic mark would skip the undo journal and leak
+                    // permanently (see the sibling comment in the grep loop).
+                    let _readonly_guard =
+                        crate::vm::vm_call_state_guard::ReadonlyFrameGuard::new(vm);
+                    set_loop_topic_readonly(vm, immutable_topic);
                     match vm.run_reuse(&code, &compiled_fns) {
                         Ok(()) => {
                             let pred = vm

--- a/src/vm/vm_for_loop_body.rs
+++ b/src/vm/vm_for_loop_body.rs
@@ -528,24 +528,32 @@ impl Interpreter {
         // `for 1, 2 { for @b { $_ = 1 } }` wrongly threw "Cannot assign to an
         // immutable value". Saved and restored on every exit path below.
         let saved_topic_readonly = binds_implicit_topic.then(|| self.readonly_kind("_"));
-        let topic_readonly = !spec.is_rw && binds_implicit_topic && {
-            spec.source_items_are_bare
-                || match &container_binding {
-                    None => false,
-                    Some(name) => {
-                        if let Some(val) = self.get_env_with_main_alias(name) {
-                            matches!(
-                                val.view(),
-                                ValueView::Mix(_, false)
-                                    | ValueView::Set(_, false)
-                                    | ValueView::Bag(_, false)
-                            )
-                        } else {
-                            false
-                        }
+        // An IMMUTABLE QuantHash source is readonly all the way down: nothing
+        // reachable through the topic may be written.
+        let topic_deep_readonly = !spec.is_rw
+            && binds_implicit_topic
+            && match &container_binding {
+                None => false,
+                Some(name) => {
+                    if let Some(val) = self.get_env_with_main_alias(name) {
+                        matches!(
+                            val.view(),
+                            ValueView::Mix(_, false)
+                                | ValueView::Set(_, false)
+                                | ValueView::Bag(_, false)
+                        )
+                    } else {
+                        false
                     }
                 }
-        };
+            };
+        // A provably-bare source is only SHALLOWLY readonly: the topic has no
+        // container of its own, so `$_ = ...` is refused, but the item OBJECT
+        // may still be mutable. `for %h { .value = 5 }` and `for %h.pairs {
+        // .value = 5 }` write the hash in raku even though `for %h { $_ = 5 }`
+        // throws, so the deep flag must NOT follow `source_items_are_bare`.
+        let topic_readonly = topic_deep_readonly
+            || (!spec.is_rw && binds_implicit_topic && spec.source_items_are_bare);
         let total_items = chunked_items.len();
         // `is copy` loop param (is_rw set, do_writeback suppressed): the param
         // owns a DISTINCT container per iteration. Mutations write through the
@@ -792,8 +800,12 @@ impl Interpreter {
                 // to an immutable value" (not the readonly-*variable* wording
                 // a named `-> $v` alias gets).
                 self.mark_readonly_with("_", crate::ast::ReadonlyKind::Immutable);
-                self.env_mut()
-                    .insert("__mutsu_deep_readonly::_".to_string(), Value::TRUE);
+                if topic_deep_readonly {
+                    self.env_mut()
+                        .insert("__mutsu_deep_readonly::_".to_string(), Value::TRUE);
+                } else {
+                    self.env_mut().remove("__mutsu_deep_readonly::_");
+                }
             } else if binds_implicit_topic {
                 // See `saved_topic_readonly`: this loop's topic is writable, so
                 // an enclosing construct's mark must not carry into the body --

--- a/t/immutable-topic-receiver-oracle.t
+++ b/t/immutable-topic-receiver-oracle.t
@@ -1,0 +1,250 @@
+use Test;
+
+# The compile-time "this receiver yields bare items" oracle
+# (`Compiler::for_iterable_yields_bare_items`) decides whether a `for` loop's
+# implicit topic, or a `.map`/`.grep`/`.first` callback's `$_`, is assignable.
+# raku binds the topic to the source ELEMENT, so `$_ = ...` is legal exactly
+# when that element has a `Scalar` behind it.
+#
+# Every row below was verified against rakudo; the file is designed to pass
+# under `raku` too, so a wrong expectation here fails against the oracle.
+
+plan 51;
+
+# --- a `%` variable mints a fresh Pair per entry: the topic is that Pair,
+#     which is not in a Scalar, so `$_ = ...` is refused ------------------
+{
+    my %h = a => 1, b => 2;
+    dies-ok { for %h { $_ = 5 } }, 'for %h { $_ = ... } dies';
+    is %h<a>, 1, 'for %h { $_ = ... } left the hash alone';
+}
+{
+    my %h = a => 1, b => 2;
+    dies-ok { %h.map({ $_ = 5 }).eager }, '%h.map({ $_ = ... }) dies';
+}
+{
+    my %h = a => 1, b => 2;
+    dies-ok { %h.grep({ $_ = 5 }).eager }, '%h.grep({ $_ = ... }) dies';
+}
+
+# --- but the Pair OBJECT stays mutable: the marking is SHALLOW ----------
+{
+    my %h = a => 1, b => 2;
+    for %h { .value = 5 }
+    is-deeply %h, {a => 5, b => 5}, 'for %h { .value = ... } still writes through';
+}
+{
+    my %h = a => 1, b => 2;
+    for %h -> $p { $p.value = 7 }
+    is-deeply %h, {a => 7, b => 7}, 'for %h -> $p { $p.value = ... } still writes through';
+}
+{
+    my %h = a => 1;
+    for %h.pairs { .value = 9 }
+    is-deeply %h, {a => 9}, 'for %h.pairs { .value = ... } still writes through';
+}
+{
+    my %h = a => 1, b => 2;
+    my $n = 0;
+    for %h { $n += .value }
+    is $n, 3, 'for %h reads .value normally';
+}
+
+# --- coercers/views that mint fresh items -------------------------------
+{
+    my @a = 1, 2;
+    dies-ok { for @a.List { $_ = 5 } }, 'for @a.List { $_ = ... } dies';
+    is-deeply @a, [1, 2], '.List left the array alone';
+}
+{
+    my @a = 1, 2;
+    dies-ok { @a.List.map({ $_ = 5 }).eager }, '@a.List.map({ $_ = ... }) dies';
+}
+{
+    my @a = 1, 2;
+    dies-ok { @a.List.grep({ $_ = 5 }).eager }, '@a.List.grep({ $_ = ... }) dies';
+}
+{
+    my @a = 1, 2;
+    dies-ok { for @a.pairs { $_ = 5 } }, 'for @a.pairs { $_ = ... } dies';
+}
+{
+    my @a = 1, 2;
+    dies-ok { for @a.antipairs { $_ = 5 } }, 'for @a.antipairs { $_ = ... } dies';
+}
+{
+    my %h = a => 1;
+    dies-ok { for %h.kv { $_ = 5 } }, 'for %h.kv { $_ = ... } dies';
+    is %h<a>, 1, '%h.kv left the hash alone';
+}
+{
+    my %h = a => 1;
+    dies-ok { for %h.List { $_ = 5 } }, 'for %h.List { $_ = ... } dies';
+}
+
+# --- .pairs still hands out writable values ----------------------------
+{
+    my @a = 1, 2;
+    for @a.pairs { .value = 5 }
+    is-deeply @a, [5, 5], 'for @a.pairs { .value = ... } still writes through';
+}
+
+# --- a LIST literal is element-wise: an item with no Scalar behind it
+#     makes the topic immutable ------------------------------------------
+{
+    my @a = 1, 2;
+    dies-ok { for (@a,) { $_ = 5 } }, 'for (@a,) { $_ = ... } dies';
+    is-deeply @a, [1, 2], '(@a,) left the array alone';
+}
+{
+    my @a = 1, 2;
+    my @b = 3, 4;
+    dies-ok { for @a, @b { $_ = 5 } }, 'for @a, @b { $_ = ... } dies';
+}
+{
+    my $x = 1;
+    my @a = 2, 3;
+    dies-ok { for $x, @a { $_ = 9 } }, 'for $x, @a { $_ = ... } dies';
+}
+{
+    my $x = 1;
+    dies-ok { for $x, 2 { $_ = 5 } }, 'for $x, 2 { $_ = ... } dies';
+}
+{
+    my $x = 1;
+    dies-ok { for ($x + 1,) { $_ = 5 } }, 'for ($x + 1,) { $_ = ... } dies';
+}
+{
+    dies-ok { for (1..2), (3..4) { $_ = 5 } }, 'for (1..2), (3..4) { $_ = ... } dies';
+}
+{
+    my @a = 1, 2;
+    dies-ok { (@a,).map({ $_ = 5 }).eager }, '(@a,).map({ $_ = ... }) dies';
+}
+{
+    my %h = a => 1;
+    dies-ok { for (%h,) { $_ = 5 } }, 'for (%h,) { $_ = ... } dies';
+}
+
+# --- CONTROL: a list literal made only of Scalar-denoting items keeps a
+#     writable topic ------------------------------------------------------
+{
+    my $x = 1;
+    my $y = 2;
+    for ($x, $y) { $_ = 5 }
+    is "$x $y", "5 5", 'for ($x, $y) { $_ = ... } still writes through';
+}
+{
+    my $x = 1;
+    my $y = 2;
+    ($x, $y).map({ $_ = 5 }).eager;
+    is "$x $y", "5 5", '($x, $y).map({ $_ = ... }) still writes through';
+}
+{
+    my $x = 1;
+    for ($x,) { $_ = 5 }
+    is $x, 5, 'for ($x,) { $_ = ... } still writes through';
+}
+
+# --- CONTROL: `.list` and `.values` iterate the source's own containers -
+{
+    my @a = 1, 2;
+    for @a.list { $_ = 5 }
+    is-deeply @a, [5, 5], 'for @a.list { $_ = ... } still writes through';
+}
+{
+    my @a = 1, 2;
+    for @a.values { $_ = 5 }
+    is-deeply @a, [5, 5], 'for @a.values { $_ = ... } still writes through';
+}
+{
+    my %h = a => 1;
+    for %h.values { $_ = 5 }
+    is-deeply %h, {a => 5}, 'for %h.values { $_ = ... } still writes through';
+}
+{
+    my @a = 1, 2;
+    for @a { $_ = 5 }
+    is-deeply @a, [5, 5], 'for @a { $_ = ... } still writes through';
+}
+{
+    my @a = 1, 2;
+    for @a.Seq { $_ = 5 }
+    is-deeply @a, [5, 5], 'for @a.Seq { $_ = ... } still writes through';
+}
+
+# --- `.first` joins `.map`/`.grep` in consulting the same oracle --------
+{
+    dies-ok { (1, 2).first({ $_ = 5 }) }, '(1, 2).first({ $_ = ... }) dies';
+}
+{
+    my @a = 1, 2;
+    dies-ok { @a.List.first({ $_ = 5 }) }, '@a.List.first({ $_ = ... }) dies';
+}
+# CONTROL: `.first` over a real array still scans the element containers.
+{
+    my @a = 1, 2;
+    is @a.first({ $_ = 5 }), 5, '@a.first({ $_ = ... }) answers the written value';
+    is-deeply @a, [5, 2], '@a.first({ $_ = ... }) still writes through';
+}
+{
+    my @a = 1, 2;
+    @a.values.first({ $_ = 5 });
+    is-deeply @a, [5, 2], '@a.values.first({ $_ = ... }) still writes through';
+}
+{
+    my @a = 3, 4, 5;
+    is @a.first({ $_ > 3 }), 4, '.first with an ordinary matcher is unaffected';
+}
+{
+    my @a = 3, 4, 5;
+    is @a.first(* > 3), 4, '.first with a Whatever matcher is unaffected';
+}
+
+# --- the same oracle gates ADR-0045's `is rw` / `<->` BIND: a source that can
+#     only yield bare values has no container to alias, and raku fails the bind
+#     before the body runs ---------------------------------------------------
+{
+    my %h = a => 1;
+    dies-ok { for %h <-> $p { } }, 'for %h <-> $p fails the bind';
+}
+{
+    my @a = 1, 2;
+    dies-ok { for @a.List <-> $v { } }, 'for @a.List <-> $v fails the bind';
+}
+{
+    my @a = 1, 2;
+    dies-ok { for @a.pairs <-> $p { } }, 'for @a.pairs <-> $p fails the bind';
+}
+{
+    my @a = 1, 2;
+    dies-ok { for (@a,) <-> $v { } }, 'for (@a,) <-> $v fails the bind';
+}
+{
+    my %h = a => 1;
+    dies-ok { for %h.kv <-> $v { } }, 'for %h.kv <-> $v fails the bind';
+}
+{
+    my %h = a => 1;
+    dies-ok { for %h -> $p is rw { } }, 'for %h -> $p is rw fails the bind';
+}
+# CONTROL: an all-Scalar list literal still binds and writes back.
+{
+    my $x = 1;
+    my $y = 2;
+    for $x, $y <-> $v { $v = 9 }
+    is "$x $y", "9 9", 'for $x, $y <-> $v still binds and writes back';
+}
+# CONTROL: a read-only named param over the same sources still binds.
+{
+    my %h = a => 1;
+    my @k;
+    for %h -> $p { @k.push: $p.key }
+    is-deeply @k, ["a"], 'for %h -> $p (read-only) still binds';
+}
+{
+    my @a = 1, 2;
+    my $n;
+    for (@a,) -> $v { $n = $v.elems }
+    is $n, 2, 'for (@a,) -> $v (read-only) still binds';
+}

--- a/todo/deep/immutable-lvalues-that-mutsu-still-lets-you-assign-to.md
+++ b/todo/deep/immutable-lvalues-that-mutsu-still-lets-you-assign-to.md
@@ -4,10 +4,12 @@ Found by the exception-taxonomy survey in
 `news/2026-08/readonly-assign-exception-taxonomy.md`. That work fixed *which*
 exception a rejected assignment throws; this ticket collects the cases where
 mutsu does not reject the assignment at all, which the same survey surfaced.
-Every row below was re-measured against `raku` v2026.06 on **2026-09-05**, on
-top of the closure-topic fix (`news/2026-09/closure-and-map-grep-topic-readonly.md`).
+Every surviving row below was re-measured against `raku` on **2026-09-07** on a
+fresh build of `main` at `2c7fc1dde`; every one of them still reproduced, and
+the ones this file no longer lists were closed on that same day. C2, D, E and F
+were re-verified unchanged then (D's shape had drifted — see its row).
 
-## Status (2026-09-05)
+## Status (last updated 2026-09-07)
 
 Closed since the survey opened:
 
@@ -35,8 +37,15 @@ Section B was re-measured on **2026-09-07** and three of its four producers
 were closed the same day
 (`news/2026-09/slice-first-and-block-topic-element-containers.md`); only
 producer 1 (`.list` feeding `map`) survives. Section C was re-measured on
-2026-09-06 (all seven rows diverged) and then closed; sections A, B(1), D, E and
-F are what is left.
+2026-09-06 (all seven rows diverged) and then closed.
+
+**Section A was re-measured and mostly closed on 2026-09-07**
+(`news/2026-09/immutable-topic-receiver-oracle-widened.md`, pinned by
+`t/immutable-topic-receiver-oracle.t`): the compile-time receiver oracle grew,
+which is the second of the two routes the "how the surviving rows differ"
+section below names. What is left of A is the two receivers a *syntactic* oracle
+genuinely cannot decide, plus two rows found while measuring. Sections A(rest),
+B(1), C2, D, E and F are what remain.
 
 **Read the "how the surviving rows differ" section below before designing
 anything**: two successive stated blockers for the closure-topic rows (first
@@ -51,29 +60,48 @@ accepts.
 
 ```
 my @a := (1,2,3); @a.map({$_=5}).eager      raku: X::AdHoc   mutsu: (5 5 5)
+my @a := (1,2,3); @a.grep({$_=5}).eager     raku: X::AdHoc   mutsu: (5 5 5)
+my @a := (1,2,3); for @a { $_ = 5 }         raku: X::AdHoc   mutsu: silently OK
 my $s = (1,2,3).Seq; $s.map({$_=5}).eager   raku: X::AdHoc   mutsu: (5 5 5)
-(1,2).first({$_=5})                         raku: X::AdHoc   mutsu: 1
-my %h = a=>1; %h.map({$_=9}).eager          raku: X::AdHoc   mutsu: (9)
-my @a = 1,2; (@a,).map({$_=5}).eager        raku: X::AdHoc   mutsu: (5)
-for %h { $_ = 5 }                           raku: X::AdHoc   mutsu: silently OK
+my $s = (1,2,3).Seq; $s.grep({$_=5}).eager  raku: X::AdHoc   mutsu: (5 5 5)
 ```
 
-The shipped fix keys off `Compiler::for_iterable_yields_bare_items` applied to
-the *receiver expression*, which deliberately answers `false` for a variable and
-for any derived receiver. These rows are exactly the receivers it cannot prove:
-an `@`-variable `:=`-bound to a `List`, a `$`-variable holding a `Seq`, a
-`%`-variable (whose iteration mints fresh `Pair`s), and a one-element list
-literal built from an array variable. `.first` additionally never reaches the
-marking at all — only the two map loops and the grep loop consult
-`CompiledCode::immutable_topic`.
+`Compiler::for_iterable_yields_bare_items` is a verdict on the receiver's
+*syntax*, and these two receivers are plain variables: an `@`-variable
+`:=`-bound to a `List`, and a `$`-variable holding a `Seq`. Nothing in the
+expression says so. Closing them needs either a compile-time notion of "this
+variable is `:=`-bound to an immutable Positional" / "this variable holds a
+`Seq`" (the compiler already tracks something adjacent in `scalar_bind_*`), or
+section B closed first so `is_container_ref()` becomes a sound runtime oracle.
 
-`for %h` is the same row from the `for` side. Extending
-`for_iterable_yields_bare_items` to `Expr::HashVar` looks like the one-line fix
-for both, but the `for` loop pairs its topic mark with the
-`__mutsu_deep_readonly::_` env flag, which would then also reject
-`for %h { .value = 5 }` — a write rakudo performs. Whatever closes this row has
-to separate "the topic itself is immutable" from "everything reachable through
-it is".
+Four rows that used to sit here — `(1,2).first({$_=5})`, `%h.map({$_=9})`,
+`(@a,).map({$_=5})` and `for %h { $_ = 5 }` — were closed on 2026-09-07 by
+widening that same oracle (a `%` variable, `.List`/`.pairs`/`.antipairs`/`.kv`
+on an `@`/`%` variable, and a list literal with any provably-bare item), by
+adding `"first"` to `method_binds_immutable_topic`, and by splitting the `for`
+loop's shallow topic mark from its `__mutsu_deep_readonly::_` flag — which is
+exactly the separation this section predicted was required, and it was.
+
+#### Two more rows in this family, both located but not fixed
+
+```
+my $v=1; my $b={$^x=9}; $b($v); $v
+    # raku: X::Assignment "Cannot assign to a readonly variable or a value"
+    # mutsu: silently assigns the placeholder local, $v stays 1
+my $c = class { has $.n = 1 }.new; my $b={$_=9}; $b($c.n); $c.n
+    # raku: X::AdHoc "Cannot assign to an immutable value"
+    # mutsu: silently succeeds, $c.n stays 1
+```
+
+The first is located (2026-09-07): a `$`-sigiled **pointy** parameter is marked
+readonly at the call site via `CompiledCode::pointy_alias_param`, set in
+`Compiler::compile_expr_lambda`. A **placeholder** block (`{ $^x = 9 }`) is
+compiled by `compile_expr_anon_sub` instead, which emits `MakeAnonSub` and never
+sets that flag, so `sub f($x) { $x = 5 }` and `-> $x { $x = 5 }` both die
+correctly while `{ $^x = 5 }` does not. Read the long comment above
+`pointy_alias_param` before moving the marking: injecting a `MarkReadonly`
+prologue into the body instead leaks the mark permanently through the fast
+native map/grep/first loops, and that reached CI once already.
 
 ### B. Element and argument shapes where mutsu drops the write instead
 
@@ -176,15 +204,6 @@ my $x=[1,2,3]; $x.map({$_=5}).eager; $x         raku [5 5 5]   mutsu [1 2 3]
    `Text::CSV` shape needs, which has to be understood before the positional
    half can land.
 
-   Two exclusions a future producer must inherit, both found by the local suite:
-   a HOLE that reads as the container's `is default(...)` value is not promoted
-   (`@a[3]:delete` then `@a[2,3,4]` must read the default, not the marker), and
-   the list-destructuring staging temp is excluded from the shared gate
-   entirely — see
-   `todo/deep/containerref-holding-a-hash-is-indistinguishable-from-itemization.md`
-   for why the alternative (decontainerizing in the hash initializer) is blocked
-   by a representation ambiguity.
-
 3. ~~**A block called with an argument does not alias `$_` to it.**~~ **CLOSED
    2026-09-07**, in two halves. A plain scalar argument goes through
    `Interpreter::pending_call_topic_source`, the exact sibling of
@@ -219,19 +238,29 @@ container" — is closed with it, and so is the headline of
 position over). That ticket's two asides remain open, plus one new row it
 records.
 
-#### Two more rows found while measuring producer 3 (2026-09-07)
+#### A hash-sourced `map`/`grep` Pair does not share the hash's value container
 
-Both belong with section A, not here — they are silent successes where rakudo
-refuses, and neither is fixed:
+Found 2026-09-07 while measuring section A, and it is the OPPOSITE direction —
+mutsu throws where rakudo writes:
 
 ```
-my $v=1; my $b={$^x=9}; $b($v); $v
-    # raku: X::Assignment "Cannot assign to a readonly variable or a value"
-    # mutsu: silently assigns the placeholder local, $v stays 1
-my $c = class { has $.n = 1 }.new; my $b={$_=9}; $b($c.n); $c.n
-    # raku: X::AdHoc "Cannot assign to an immutable value"
-    # mutsu: silently succeeds, $c.n stays 1
+my %h = a=>1; %h.map({ .value = 9 }).eager; %h    raku {a => 9}  mutsu: throws
+my %h = a=>1; %h.grep({ .value = 9 }).eager; %h   raku {a => 9}  mutsu: throws
+my %h = a=>1; %h.pairs.map({ .value = 9 }); %h    raku {a => 9}  mutsu {a => 9}
+my %h = a=>1; for %h { .value = 9 }; %h           raku {a => 9}  mutsu {a => 9}
 ```
+
+("throws" = `X::Assignment::RO`, "Cannot modify an immutable Int (1)".)
+
+The producer is `runtime/utils/list.rs`'s `value_to_list`, which a direct
+`%h.map`/`%h.grep` receiver goes through: its `ValueView::Hash` arm builds each
+item with `items.typed_pair(k, v.clone())`, and `typed_pair` **decontainerizes**
+the element cell deliberately, so that a pair's value matches a `%h<k>` read and
+a `.values` element (`t/bind-hash-value-pairs.t`). `%h.pairs` and the `for %h`
+loop use a different producer and keep the cell. Making the map/grep-over-a-hash
+path use the `.pairs` producer is the shape of the fix, but `value_to_list` is
+a very widely shared funnel — measure who else depends on the decontainerizing
+arm before changing it.
 
 ### How the surviving rows differ from what was fixed (measured, do not skip)
 
@@ -256,6 +285,17 @@ second route is now most of the way there for a *slice* and for `.first`; it is
 still false for a plain `@a[0]` read and for `@a`'s own elements outside a
 producer, so the runtime rule is not yet sound.
 Closing B first is the architecturally cleaner order.
+
+**Update 2026-09-07:** the *first* route — growing the receiver oracle — turned
+out to cover far more of section A than this paragraph assumed, and to need no
+runtime test at all. The exact rule, measured against rakudo, is that a list
+literal is **element-wise** (`($x, $y)` is a `List` of two `Scalar`s and writes
+through; any item with no `Scalar` behind it makes the topic immutable), and
+that a `%` variable and the `.List`/`.pairs`/`.antipairs`/`.kv` views mint fresh
+items while `.list`/`.values`/`.Seq` hand out the source's own containers. Those
+are all syntactic, so they are decidable where a `:=`-bound `@a` is not. See
+`news/2026-09/immutable-topic-receiver-oracle-widened.md`; only the two
+variable-receiver rows above still need route two.
 
 ### C. A `$` bind of a MUTABLE container is still assignable — **CLOSED 2026-09-06**
 
@@ -306,9 +346,11 @@ it would clobber the value); the same distinction is missing one level down.
 ### D. A `gather` sequence's element store
 
 ```
-my $s = (gather { take 1; take 2 }); $s[0] = 5
-    # raku: X::Assignment::RO, "Cannot modify an immutable Int (1)"
-    # mutsu: silently succeeds
+my $s = (gather { take 1; take 2 }); $s[0] = 5; say $s
+    # raku:  X::Assignment::RO, "Cannot modify an immutable Int (1)"
+    # mutsu: silently succeeds, and TRUNCATES -- prints `[5]`, not `[5 2]`
+    #        (re-measured 2026-09-07; the truncation is new information, the
+    #        store apparently reifies only as far as the assigned index)
 ```
 
 The `.Seq` twin was fixed by teaching `try_seq_element_cell_assign` to refuse a


### PR DESCRIPTION
Works `todo/deep/immutable-lvalues-that-mutsu-still-lets-you-assign-to.md`.

## Re-measurement first (2026-09-07, fresh build of `main` at `2c7fc1dde`)

Every surviving row of the survey was re-run against `raku` before any design.
**All of them still reproduced** — nothing had been silently fixed by the
changes that landed on `main` today, and the two rows the file flagged as
"measured wrong before" stayed measured-wrong-before.

| row | shape | status | note |
|---|---|---|---|
| A1 | `my @a := (1,2,3); @a.map({$_=5})` | **reproduces** | needs a non-syntactic receiver oracle; left open |
| A2 | `my $s = (1,2,3).Seq; $s.map({$_=5})` | **reproduces** | same; left open |
| A3 | `(1,2).first({$_=5})` | **reproduces** | **FIXED** here |
| A4 | `%h.map({$_=9})` | **reproduces** | **FIXED** here |
| A5 | `(@a,).map({$_=5})` | **reproduces** | **FIXED** here |
| A6 | `for %h { $_ = 5 }` | **reproduces** | **FIXED** here |
| A7 | `my $b={$^x=9}; $b($v)` | **reproduces** | root cause located, left open (see below) |
| A8 | `my $b={$_=9}; $b($c.n)` | **reproduces** | left open |
| B1 | `@a.list.map({$_=7})` loses the write | **reproduces** | ADR-0058 deferral; another agent is on it, untouched here |
| B2 | positional slice hands out bare values | **reproduces** | PARKED on `Text::CSV`; untouched |
| C2 | `@a[1][0] = 9` autovivifies over a defined `Int` | **reproduces** | unchanged by ADR-0067's landed slices; left open |
| D | `my $s = gather {...}; $s[0] = 5` | **reproduces, CHANGED SHAPE** | mutsu now also TRUNCATES — prints `[5]`, not `[5 2]`. New information, recorded in the ticket |
| E | `my $s = (1,2,3).Seq; $s<a> = 5` | **reproduces** | left open |
| F | `(my $x = $a, 6)[0] = 10` | **reproduces** | left open |

Measuring around those rows found two families the survey had never enumerated,
and one row in the opposite direction:

| new row | rakudo | mutsu before | status |
|---|---|---|---|
| `for @a.List`, `@a.List.map`, `@a.List.grep`, `@a.pairs`, `@a.antipairs`, `%h.kv`, `%h.List` with `$_ = 5` | throws | silently dropped | **FIXED** |
| `for @a, @b`, `for $x, @a`, `for $x, 2`, `for ($x + 1,)`, `for (1..2), (3..4)`, `for (%h,)` | throws | silently dropped / wrote one item and continued | **FIXED** |
| `%h.map({ .value = 9 })` | writes the hash | **throws** | still open; producer located (see the ticket) |

## What was fixed, and why generally

raku binds a `for` loop's implicit topic — and a `.map`/`.grep`/`.first`
callback's `$_` — to the source ELEMENT. `$_ = ...` is legal exactly when that
element has a `Scalar` behind it. mutsu decides this from the receiver's syntax
(`Compiler::for_iterable_yields_bare_items`); the oracle was missing three
families:

- **a `%` variable.** Iterating a Hash mints a fresh `Pair` per entry, which is
  not in a `Scalar`.
- **the coercers/views that build fresh items** rather than handing out the
  container's element cells: `.List`, `.pairs`, `.antipairs`, `.kv` on an
  `@`/`%` variable. `.list`, `.values` and `.Seq` are deliberately NOT in the
  set — raku iterates those through the source's own containers and they must
  keep writing through, which the pin file asserts.
- **a list literal, which is element-wise.** `($x, $y)` is a `List` of the two
  `Scalar`s and writes through; any item with no `Scalar` behind it makes the
  topic immutable. The `ArrayLiteral` arm therefore flips from "every item is a
  literal" to "**any** item is provably bare" — the mark is one per loop rather
  than per item, and raku throws at the bare item either way.

Two mechanism fixes go with it.

**The `for` loop's shallow topic mark was fused with its deep-readonly flag.**
`for %h { $_ = 5 }` throws in raku but `for %h { .value = 5 }` writes the hash;
extending the oracle to `%h` without splitting them would have converted a write
rakudo performs into a throw — exactly what the ticket predicted would be
required, and it was. The deep flag now belongs only to an immutable QuantHash
source (`Set`/`Bag`/`Mix`); a provably-bare source is only shallowly readonly.

**`.first` never consulted the marking.** Its matcher reaches
`vm_call_on_value`, which already reads `CompiledCode::immutable_topic`, but the
batched scan (`try_first_match_batched` — the setup-once path that actually
serves `.first({ ... })`) bound the topic with a direct `env` insert and never
called `set_loop_topic_readonly` the way the sibling grep loop does. It does now,
under the same `ReadonlyFrameGuard` the grep loop opens so the mark is journalled
rather than leaked permanently.

### A free second consumer

`ForLoopSpec::source_items_are_bare` also gates ADR-0045 slice 5's `is rw` /
`<->` **bind** failure, so the widened oracle closed that half with no separate
change: `for %h <-> $p`, `for %h -> $p is rw`, `for @a.List <-> $v`,
`for @a.pairs <-> $p`, `for @a.antipairs <-> $p`, `for %h.kv <-> $v`,
`for %h.List <-> $v` and `for (@a,) <-> $v` all now raise the same
`Parameter '$v' expects a writable container` rakudo raises, with the same
rendered value.

## What was deliberately NOT done

- **The `.map` deferral was not touched.** Section B producer 1 sits on the
  ADR-0058 `SeqSource::MapGrep` path that another agent is currently
  reimplementing (`todo/deep/array-map-on-a-real-array-is-still-eager.md`).
- **The runtime rule the ticket warns about was not adopted.** Marking the topic
  read-only when `!item.is_container_ref()` still converts section B's rows into
  spurious throws; this change is entirely compile-time and syntactic.

## Gates

- `make test`: **PASS**, 3791 files / 39897 tests, no failures.
- Full local `make roast` (this is an assignment-legality change — a universal
  property of values, so CLAUDE.md's measured process exception applies).
- `cargo fmt`, `cargo clippy --all-targets -- -D warnings`: clean.
- `t/immutable-topic-receiver-oracle.t`: 51 rows, **green under `raku` as well as
  mutsu**. 18 of them are controls that must not start throwing or start failing
  a bind.

## Residue

`todo/deep/immutable-lvalues-that-mutsu-still-lets-you-assign-to.md` is trimmed
to what is left, with two newly located root causes recorded:

- a `$^x` placeholder parameter misses the readonly marking a `-> $v` pointy
  parameter gets — `compile_expr_anon_sub` emits `MakeAnonSub` and never sets
  `CompiledCode::pointy_alias_param`, which `compile_expr_lambda` does;
- `%h.map({ .value = 9 })` throws where `%h.pairs.map({ .value = 9 })` writes,
  because a direct hash receiver goes through `value_to_list`, whose
  `ValueView::Hash` arm builds each item with `typed_pair`, which
  **decontainerizes** the element cell deliberately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
