### PR TITLE
fix: a `with` pointy container param binds the list, and can-ok sees accessors

### DIFF
--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -387,13 +387,31 @@ impl Compiler {
         // A `$=...` Pod document variable is bound, not a Scalar container, so
         // `my @a = $=pod` copies the blocks rather than nesting the document
         // in one element (see `scalar_var_is_item_container`).
+        // A desugaring temp (`__with_tmp_N`, `__destructure_tmp__`, …) is not a
+        // `$`-scalar container the source wrote — it is the slot a control
+        // construct parked its once-evaluated value in. Itemizing it makes the
+        // construct's own `@`/`%` binding see one element instead of the list:
+        // `with (1,2,3) -> @m { @m.elems }` answered 1 against raku's 3, and
+        // `with $str ~~ m:g/…/ -> @m` answered 1 against 2, which is what left
+        // `Template::Nest::Fast` at 0/10. The lvalue spelling (`with $r -> @m`)
+        // was already right because it routes through `given`'s alias bind, not
+        // through this assignment path.
         if name.starts_with('@')
             && let Expr::Var(var_name) = unwrapped
             && !var_name.starts_with('=')
+            && !Self::is_desugar_temp_name(var_name)
         {
             let name_idx = self.code.add_constant(Value::str(var_name.clone()));
             self.code.emit(OpCode::ItemizeVar(name_idx));
         }
+    }
+
+    /// Whether `name` is one of mutsu's internal desugaring temps rather than a
+    /// variable the source wrote. The same rule
+    /// `rakuast::convert::is_desugar_marker` uses, and for the same reason: an
+    /// internal name has none of the container semantics a user variable has.
+    fn is_desugar_temp_name(name: &str) -> bool {
+        name.starts_with("__")
     }
 
     fn compile_condition_expr(&mut self, cond: &Expr) {

--- a/src/runtime/accessors_stack.rs
+++ b/src/runtime/accessors_stack.rs
@@ -287,9 +287,18 @@ impl Interpreter {
         if self.e2_native_method_exists(value, method_sym.as_str()) {
             return true;
         }
-        // For instances, check class methods
+        // For instances, check class methods -- and the auto-generated public
+        // accessor of a `has $.x`, which in Raku is an ordinary method of its
+        // declaring class and so is exactly as `can`-able as a written one.
+        // `class_has_method` only walks the method tables, so `can-ok $obj,
+        // 'attr'` answered False for every accessor while `$obj.can('attr')`
+        // (which goes through `resolve_user_method_or_accessor`) answered True
+        // -- the two disagreed about the same question. That is what left
+        // `Template::Nest::Fast` failing its `can-ok` sweep on six of seven
+        // names.
         if let ValueView::Instance { class_name, .. } = value.view()
-            && self.class_has_method(&class_name.resolve(), method)
+            && (self.class_has_method(&class_name.resolve(), method)
+                || self.has_public_accessor(&class_name.resolve(), method))
         {
             return true;
         }
@@ -297,7 +306,8 @@ impl Interpreter {
         // ...`), resolve methods against the named class's MRO too — a type
         // object can do any of its class's methods, not just the universal set.
         if let ValueView::Package(class_name) = value.view()
-            && self.class_has_method(&class_name.resolve(), method)
+            && (self.class_has_method(&class_name.resolve(), method)
+                || self.has_public_accessor(&class_name.resolve(), method))
         {
             return true;
         }

--- a/t/can-ok-sees-attribute-accessors.t
+++ b/t/can-ok-sees-attribute-accessors.t
@@ -1,0 +1,41 @@
+use Test;
+
+# In Raku the auto-generated accessor for `has $.x` is an ordinary method of its
+# declaring class, so it is exactly as `can`-able as a written one. mutsu's
+# `can-ok` walked only the method tables, so it answered False for every
+# accessor -- while `$obj.can('attr')`, which resolves through
+# `resolve_user_method_or_accessor`, answered True. The two disagreed about the
+# same question.
+
+plan 12;
+
+class C {
+    has $.a;
+    has Str $.b-c;
+    has @.d;
+    has %.e;
+    has $!private;
+    method m() { }
+    method n-o() { }
+}
+
+my $c = C.new;
+
+can-ok $c, 'm', 'a written method';
+can-ok $c, 'n-o', 'a written method with a hyphen';
+can-ok $c, 'a', 'a `$` accessor';
+can-ok $c, 'b-c', 'a typed `$` accessor with a hyphen';
+can-ok $c, 'd', 'an `@` accessor';
+can-ok $c, 'e', 'a `%` accessor';
+can-ok $c, 'new', 'the default constructor';
+
+# The type object can do them too.
+can-ok C, 'a', 'a `$` accessor on the type object';
+can-ok C, 'm', 'a written method on the type object';
+
+# `.can` and `can-ok` must agree -- that they did not is what this pins.
+ok $c.can('a').so, '.can agrees for an accessor';
+ok $c.can('m').so, '.can agrees for a method';
+
+# A private attribute generates no accessor, so neither should see one.
+nok $c.can('private').so, 'a private attribute has no accessor';

--- a/t/with-pointy-container-param.t
+++ b/t/with-pointy-container-param.t
@@ -1,0 +1,51 @@
+use Test;
+
+# `with EXPR -> @m { }` desugars to a temp holding the once-evaluated condition
+# plus `my @m = <temp>`. The compiler's "assigning a `$` scalar variable to an
+# `@` target itemizes it" rule then fired on that temp, so the block's `@m` saw
+# ONE element -- the whole list -- instead of the list. A desugaring temp is not
+# a Scalar container the source wrote, so it must not itemize.
+#
+# The lvalue spelling (`with $r -> @m`) was already right: it routes through
+# `given`'s alias bind rather than through the assignment path.
+
+plan 8;
+
+{
+    my $r = ("a<!--x-->b<!--yy-->c" ~~ m:g/('<!--') \s* (\w+) \s* ('-->')/);
+    is $r.elems, 2, 'the :g match itself has two results';
+
+    with ("a<!--x-->b<!--yy-->c" ~~ m:g/('<!--') \s* (\w+) \s* ('-->')/) -> @m {
+        is @m.elems, 2, 'an expression topic binds the list, not a wrapper';
+    }
+
+    with $r -> @m {
+        is @m.elems, 2, '... and so does an lvalue topic (already worked)';
+    }
+}
+
+with (1, 2, 3) -> @m {
+    is @m.elems, 3, 'a literal list topic binds all three elements';
+}
+
+with (1, 2, 3) -> $m {
+    is $m.elems, 3, '... and a `$` parameter still sees the whole list';
+}
+
+with %(:a(1), :b(2)) -> %h {
+    is %h.elems, 2, 'a `%` parameter binds the hash, not a wrapper';
+}
+
+# Controls: the itemizing rule this fix narrows must keep applying to a real
+# `$`-scalar container.
+{
+    my $x = (1, 2, 3);
+    my @a = $x;
+    is @a.elems, 1, '`my @a = $x` still itemizes the scalar container';
+}
+
+{
+    my @src = 1, 2, 3;
+    my @b = @src;
+    is @b.elems, 3, '... while `my @b = @src` still copies the elements';
+}


### PR DESCRIPTION
Two general bugs, both found by reducing `Template::Nest::Fast` — the row `todo/deep/template-engines-blocked-on-mutsu.md` calls its **cheapest remaining lever**. The dist goes **0/10 → 2/10**; what is left there is a separate, deeper rendering bug (output comes out as `<!D<p>Simple Variable in Simple Component…`).

## 1. `with EXPR -> @m` bound a one-element wrapper

```raku
with (1,2,3) -> @m { say @m.elems }                          # was 1, raku 3
with ("a<!--x-->b<!--yy-->c" ~~ m:g/…/) -> @m { say @m.elems }  # was 1, raku 2
```

The desugar parks the once-evaluated condition in a temp and emits `my @m = <temp>`, which hits the compiler's *"assigning a `$` scalar variable to an `@` target itemizes it"* rule. That rule is right for a Scalar container the source wrote; **a desugaring temp is not one** — it is the slot a control construct parked its value in. The itemize is now skipped for an internal `__`-prefixed name, the same rule `rakuast::convert::is_desugar_marker` already uses.

**The discriminator that located it:** the lvalue spelling `with $r -> @m` was already correct, because it routes through `given`'s alias bind rather than through the assignment path.

| probe | before | rakudo / after |
|---|---|---|
| `with (1,2,3) -> @m` | 1 | 3 |
| `with ($s ~~ m:g/…/) -> @m` | 1 | 2 |
| `with $r -> @m` (lvalue) | 2 | 2 |
| `with (1,2,3) -> $m` | 3 | 3 |
| `with %(:a(1),:b(2)) -> %h` | 1 | 2 |
| **control** `my @a = $x` (real scalar container) | 1 | 1 |
| **control** `my @b = @src` | 3 | 3 |

## 2. `can-ok` did not see attribute accessors

```raku
class C { has $.a; method m() { } }
can-ok C.new, 'm';   # passed
can-ok C.new, 'a';   # FAILED, while C.new.can('a') answered True
```

Two paths disagreeing about the same question. `value_can_method` walked only the method tables (`class_has_method`), while `.can` resolves through `resolve_user_method_or_accessor`. In Raku the auto-generated accessor for `has $.x` is an ordinary method of its declaring class, so it is exactly as `can`-able as a written one. `value_can_method` now also consults `has_public_accessor`, for instances and type objects alike. A private attribute generates no accessor and is still not `can`-able.

This is what left `Template::Nest::Fast`'s `00-basic.rakutest` failing six of its seven `can-ok` names.

## Tests

- `t/with-pointy-container-param.t` — 8 rows
- `t/can-ok-sees-attribute-accessors.t` — 12 rows

Both green under **rakudo** as well as mutsu.

| gate | result |
|---|---|
| `make test` | **PASS** — 3793 files / 39918 tests |
| targeted roast (`S02-types/*`, `S12-introspection/*`, `S04-statements/with.t`) | **PASS** — 75 files / 8516 tests |
| `cargo fmt` / `clippy --all-targets -D warnings` | clean |

🤖 Generated with [Claude Code](https://claude.com/claude-code)