### PR TITLE
fix(vm): a chained subscript store takes the cross-thread exclusion too

### DIFF
--- a/src/vm/vm_var_assign_index_named.rs
+++ b/src/vm/vm_var_assign_index_named.rs
@@ -3248,9 +3248,25 @@ impl Interpreter {
         {
             self.locals[slot] = Value::NIL;
         }
+        // ADR-0068 §4 step 3: a CHAINED subscript store (`%h<k>[$i] = v`,
+        // `@a[$i]<k> = v`) mutates the inner container through
+        // `gc_contents_mut` exactly as the single-subscript store below does,
+        // but it was on none of the three guarded funnels — measured with the
+        // §1.2 breakpoint oracle, `%h<k>[$i] = 1` from 20 threads hit zero of
+        // them and SIGSEGV'd on 24 of 24 runs where rakudo answers 1000. Take
+        // the same cell-keyed exclusion the named single-subscript store takes;
+        // `env_root_descended_mut_tracked` reports the outermost cell the
+        // descent stepped through, which is what makes the key shared between
+        // threads (a node-keyed lock excludes nothing — `Gc::make_mut` copies
+        // an aliased node, see ADR-0068 §7).
+        let mut nested_cell_addr: Option<usize> = None;
         if let Some(handled) = self
-            .env_root_descended_mut(&var_name)
+            .env_root_descended_mut_tracked(&var_name, &mut nested_cell_addr)
             .and_then(|container| {
+                let _struct_guard = crate::value::container_lock::ContainerStructGuard::acquire_for(
+                    nested_cell_addr,
+                    container,
+                );
                 container.with_array_mut(|outer_arr, _kind| -> Result<bool, RuntimeError> {
                     let Ok(inner_i) = inner_key.parse::<usize>() else {
                         return Ok(false);
@@ -3347,8 +3363,14 @@ impl Interpreter {
         if let Some(slot) = self.find_local_slot(code, &var_name) {
             self.locals[slot] = Value::NIL;
         }
-        self.env_root_descended_mut(&var_name)
+        // Same ADR-0068 §4 step 3 exclusion as the array-outer arm above.
+        let mut nested_cell_addr: Option<usize> = None;
+        self.env_root_descended_mut_tracked(&var_name, &mut nested_cell_addr)
             .and_then(|container| {
+                let _struct_guard = crate::value::container_lock::ContainerStructGuard::acquire_for(
+                    nested_cell_addr,
+                    container,
+                );
                 container.with_hash_mut(|outer_hash| -> Result<(), RuntimeError> {
                     // Container identity (§3): write in place via the raw
                     // pointer both when exclusively owned (`Arc::make_mut`

--- a/t/concurrent-nested-subscript-store.t
+++ b/t/concurrent-nested-subscript-store.t
@@ -1,0 +1,35 @@
+use Test;
+
+# ADR-0068 §4 step 3: a CHAINED subscript store (`%h<k>[$i] = v`) mutates the
+# inner container through `gc_contents_mut` exactly as a single-subscript store
+# does, but it was on none of the three guarded funnels. Measured with the §1.2
+# breakpoint oracle, this shape hit zero of them, and 20 threads writing 1000
+# elements SIGSEGV'd on 24 of 24 runs where rakudo answers 1000.
+#
+# The container is reached through a named sub the thread body merely calls --
+# a route the closure-capture analysis cannot see (ADR-0039 §8.6), which is what
+# keeps it off the celled lane and on the raw store.
+
+plan 3;
+
+{
+    my %h = k => [];
+    sub put-hash-array($i) { %h<k>[$i] = 1 }
+    await (^20).map: -> $t { start { for ^50 -> $k { put-hash-array($t * 50 + $k) } } };
+    is %h<k>.grep(*.defined).elems, 1000, 'a `%h<k>[$i]` store from 20 threads keeps every write';
+}
+
+{
+    my @a = [[], []];
+    sub put-array-array($i) { @a[0][$i] = 1 }
+    await (^20).map: -> $t { start { for ^50 -> $k { put-array-array($t * 50 + $k) } } };
+    is @a[0].grep(*.defined).elems, 1000, '... and so does `@a[0][$i]`';
+}
+
+# The single-subscript route this one was modelled on must stay fixed.
+{
+    my @b;
+    sub put-plain($i) { @b[$i] = 1 }
+    await (^20).map: -> $t { start { for ^50 -> $k { put-plain($t * 50 + $k) } } };
+    is @b.grep(*.defined).elems, 1000, 'the single-subscript named store is still exclusive';
+}

--- a/todo/deep/gc-contents-mut-cross-thread-aliased-writes.md
+++ b/todo/deep/gc-contents-mut-cross-thread-aliased-writes.md
@@ -69,6 +69,34 @@ Three specific loose ends from the route audit:
   it arriving as an ordinary VALUE dispatch (`exec_call_method_op` ->
   `call_method_with_values`), and excluding a small allowlist of mutator method
   names there takes it to 0/240 at 24-way.
+- ~~**The chained-subscript store (`%h<k>[$i] = v`)**~~ **CLASSIFIED AND FIXED
+  (2026-09-07).** It is `OpCode::IndexAssignExprNested`, and the §1.2 breakpoint
+  oracle showed it hitting **zero** of the three guarded funnels: it mutates the
+  inner container through `gc_contents_mut` exactly as the single-subscript
+  store does, but took none of their exclusions. 20 threads writing 1000
+  elements **SIGSEGV'd on 24 of 24 runs** (rakudo: 1000). It now takes the same
+  cell-keyed guard the named single-subscript store takes, via
+  `env_root_descended_mut_tracked` — which already existed for exactly this
+  purpose and whose doc comment already said a caller about to mutate wants it.
+  0/24 after, both the hash-outer and array-outer arms. Pin:
+  `t/concurrent-nested-subscript-store.t`.
+
+- **An element store through a container returned by a USER method is still
+  open, and it is NOT a locking gap.** `class Holder { has @.items; method
+  bag() { @!items } }` with `$h.bag[$i] = 1` from 20 threads lands
+  **418 / 543 / 304 of 1000** writes (rakudo: 1000) — silent data loss, no
+  crash. The breakpoint oracle shows it DOES reach the attribute-lvalue funnel
+  (`builtin_index_assign_method_lvalue`), once per write, and keying that
+  funnel's guard on the shared invocant instead of the returned container was
+  implemented and measured: still 24/24 wrong. The reason is that the guard is
+  acquired *after* `current = self.call_method_with_values(...)` — the accessor
+  call, which is where each thread takes its own copy of the array
+  (`Gc::make_mut` on an aliased node), runs unguarded. So the exclusion has to
+  cover the accessor dispatch, which is what that funnel's own comment
+  deliberately kept outside the region ("the accessor dispatches inside the
+  region cannot deadlock against themselves"). Resolving that tension is the
+  next unit of work here, and it needs a decision, not a patch.
+
 - **Route 5 (`Channel.Supply` tap captures)** is exposed on the path oracle but
   blocked behind a separate deterministic Channel-supply delivery bug that
   drops/misorders values on a single unloaded run. Fix that first.


### PR DESCRIPTION
ADR-0068 §4 step 3 — the remaining **Tier S** row (`todo/deep/gc-contents-mut-cross-thread-aliased-writes.md`). Four routes probed and oracle-classified; one fixed, one newly classified and left open with its measurement.

## Route classification (20 threads × 50 writes, 24 runs each, rakudo answers 1000 for all four)

| probe | before | after | funnel reached |
|---|---|---|---|
| named single-subscript store (the file's own baseline) | 0/24 | 0/24 | guarded |
| container **never in a spawning frame's env** (created inside a sub the mainline never mentions) | 0/24 | 0/24 | guarded — this route was already closed |
| **chained subscript `%h<k>[$i] = v`** | **24/24, SIGSEGV** | **0/24** | **none of the three** |
| element store through a container returned by a **user method** | 24/24, silent loss | 24/24 | attribute-lvalue funnel, once per write |

Serially all four are correct in both implementations, so the failures are races, not semantic gaps.

## What is fixed

`OpCode::IndexAssignExprNested` mutates the inner container through `gc_contents_mut` exactly as the single-subscript store does, but took none of the guarded funnels' exclusions. The §1.2 breakpoint oracle is unambiguous — with breakpoints on all three funnels, this shape hits **zero** of them, which is that oracle's definition of an exposed workload.

```raku
my %h = k => [];
sub put-it($i) { %h<k>[$i] = 1 }
await (^20).map: -> $t { start { for ^50 -> $k { put-it($t*50 + $k) } } };
say %h<k>.grep(*.defined).elems;      # rakudo 1000; mutsu dumped core, 24/24
```

The container is reached through **a named sub the thread body merely calls** — the route the closure-capture analysis cannot see (ADR-0039 §8.6) — which is what keeps it off the celled lane.

Both arms (hash-outer and array-outer) now take the same cell-keyed guard the named single-subscript store takes, via `env_root_descended_mut_tracked`. That helper **already existed for exactly this purpose**; its doc comment already said *"a caller that is about to mutate the container wants it"*, and this op was calling the untracked sibling.

## What is classified and left open — and why it is not a locking gap

```raku
class Holder { has @.items; method bag() { @!items } }
my $h = Holder.new;
sub put-it($i) { $h.bag[$i] = 1 }
```

lands **418 / 543 / 304 of 1000** writes (rakudo: 1000) — silent data loss, no crash. The oracle shows it *does* reach `builtin_index_assign_method_lvalue`, once per write, so the guard is acquired every time. Keying that guard on the shared **invocant** instead of the returned container was implemented and measured: still 24/24 wrong, so it was reverted rather than shipped as a lock that buys nothing.

The reason is that the guard is acquired **after** `current = self.call_method_with_values(...)` — the accessor call, which is where each thread takes its own copy of the array (`Gc::make_mut` on an aliased node, ADR-0068 §7). Covering the accessor dispatch is a design decision that funnel's own comment deliberately declined (*"the accessor dispatches inside the region cannot deadlock against themselves"*), so it wants an ADR paragraph, not a patch. Recorded in the ticket with the full measurement.

## Tests

- `t/concurrent-nested-subscript-store.t` — 3 rows, green under **rakudo** and 5/5 consecutive under mutsu.

| gate | result |
|---|---|
| `make test` | **PASS** — 3795 files / 39976 tests |
| targeted roast (`S09-subscript/*`, `S17-supply/*`, `S02-types/hash.t`) | **PASS** — 61 files / 1081 tests |
| `cargo fmt` / `clippy --all-targets -D warnings` | clean |

🤖 Generated with [Claude Code](https://claude.com/claude-code)