### PR TITLE
fix(vm): Template::Nest::Fast 2/10 -> 10/10 (three general bugs)

### DIFF
--- a/docs/batteries/templates.md
+++ b/docs/batteries/templates.md
@@ -52,7 +52,7 @@ plain checkout of the dist with `-I lib`.
 | `Template6` | 0.16.0 | 2026-02-04³ | Artistic-2.0 | **0** | 7 | **12/12** | **12/12** ⬆ |
 | `Template::Jinja2` | 0.2.0 | 2026-04-29 | Artistic-2.0 | 1 (`JSON::Fast`, native) | 2 | 22/23 | **3/23** ⬆ |
 | `Template::Mojo` | 0.2.2 | 2023-07-31 | MIT | **0** | 3 | **5/5** | **4/5** |
-| `Template::Nest::Fast` | 0.3.0 | 2024-11-18 | ISC | **0** | 0 | **10/10** | **0/10** |
+| `Template::Nest::Fast` | 0.3.0 | 2024-11-18 | ISC | **0** | 0 | **10/10** | **10/10** ⬆ |
 | `SP6` | 0.2.1 | 2021-09-04 | Apache-2.0 | **0** | 0 | 10/11 | **10/11** |
 | `Template::Classic` | 0.0.3 | 2020-04-11 | BSD-3-Clause | **0** | 1 | **1/1** | 0/1 |
 | `Template::HAML` | 0.9.5 | 2026-06-27 | Artistic-2.0 | **0** | 2 | 82/83 | 39/83⁴ |
@@ -78,6 +78,20 @@ followed the same rule once more: its `[% INCLUDE "x" name = "World" %]` rendere
 `name` instead of `World` because the *no-capture* regex matcher ignored frugal
 quantifiers, so the directive tokenizer's `.comb(/ \" .*? \" | \S+ /)` returned one
 token spanning the whole statement (`news/2026-09/frugal-quantifier-in-the-no-capture-matcher.md`).
+
+⬆ `Template::Nest::Fast` went **0/10 → 2/10 → 10/10** on 2026-09-07, and made
+the same point a third time: the row's recorded first failure (`with $f ~~ m:g/…/
+-> @m` binding a one-element wrapper) was genuine but bought only two files. The
+other eight came from three general bugs in three subsystems the row never
+mentioned — an lvalue method's own arguments keeping the `Scalar` element
+containers of their argument carrier (so `$s.substr-rw($from, $len) = v` ignored
+the length and replaced the whole tail), a `%`/`@`-sigil `for` parameter being
+exempt from the loop's parameter save/restore (so recursing into the same loop
+resumed the outer iteration with the inner frame's element), and
+`IO::Path.modified` truncating to whole seconds (so a "is the file newer than my
+index?" check never fired). Pins: `t/substr-rw-computed-args.t`,
+`t/for-container-param-recursion.t`, `t/io-path-timestamp-subsecond.t`.
+Write-up: `news/2026-09/template-nest-fast-zero-to-ten-of-ten.md`.
 
 `Template::Mustache` itself went **1/13 → 11/13** on 2026-07-25 when the single
 interpreter bug behind it was fixed: a hyper method call (`@objs>>.made`) did not
@@ -115,7 +129,7 @@ them all.
 | `Template6` | none; 12/12. The last file (`05-includes`) was fixed 2026-09-06: the no-capture regex matcher matched frugal quantifiers greedily, so `.comb(/ \" .*? \" | \S+ /)` collapsed a whole `[% INCLUDE ... %]` statement into one token (`news/2026-09/frugal-quantifier-in-the-no-capture-matcher.md`) |
 | `Template::Jinja2` | loads now (3/23); the rest are ordinary per-feature failures. Its last load blocker — `Renderer.rakumod:114`'s `when If {` read as a call — was fixed 2026-09-06 |
 | `Template::Mojo` | `00-basic` only; `todo/tickets/template-mojo-residual-failures.md` |
-| `Template::Nest::Fast` | `with $f ~~ m:g/…/ -> @m` binds `@m` to a one-element list *containing* the match list, so `$m[0].from` is Nil. `with ("a<!--x-->b<!--yy-->c" ~~ m:g/('<!--') \s* (\w+) \s* ('-->')/) -> @m { say @m.elems }` gives 2 under raku, 1 under mutsu |
+| `Template::Nest::Fast` | none; 10/10 as of 2026-09-07. The recorded `with EXPR -> @m` symptom was real but only worth 2/10; the rest came from three unrelated general bugs (`news/2026-09/template-nest-fast-zero-to-ten-of-ten.md`) |
 | `Template::Classic` | `Unterminated <%` from its own grammar — the `$<part> = <rule>` capture-assignment form inside a `||` chain does not match |
 | `SP6` | at parity with raku (both 10/11, same file) |
 

--- a/news/2026-09/template-nest-fast-zero-to-ten-of-ten.md
+++ b/news/2026-09/template-nest-fast-zero-to-ten-of-ten.md
@@ -1,0 +1,123 @@
+# Template::Nest::Fast goes 0/10 → 10/10, and none of the five bugs were in the template engine
+
+`Template::Nest::Fast` 0.3.0 was the last "cheap whole row" in
+`todo/deep/template-engines-blocked-on-mutsu.md`: healthy under raku (10/10),
+0/10 under mutsu. It is now **10/10**, from five general interpreter fixes. As
+with `Template6` before it, every one of them was found by reducing a divergence
+to a two-line snippet, and not one of them was in the code the ticket pointed at.
+
+## The two fixes that got it off zero (2/10)
+
+Landed a few hours earlier, in a separate change:
+
+- `with EXPR -> @m { }` bound `@m` to a **one-element wrapper** containing the
+  list instead of to the list itself, because the desugaring temp tripped the
+  compiler's `my @a = $x` itemize rule. `!index-template`'s
+  `with $f ~~ m:g/…/ -> @m` therefore saw one match, and `$m[0].from` was `Nil`.
+- `can-ok` did not see auto-generated attribute accessors while `$obj.can('x')`
+  did — two paths answering the same question differently.
+
+## Splicing: an lvalue method's own arguments kept their element containers
+
+`render` splices with `$rendered.substr-rw(%v<start-pos>, %v<length>) = $append`.
+Under mutsu the *length* was ignored whenever it was not an integer literal, so
+each splice replaced the whole tail of the template:
+
+```raku
+my $l = 3;
+my $s = "hello";
+$s.substr-rw(1, $l) = "Z";
+say $s;             # raku: hZo    mutsu (before): hZ
+```
+
+Root cause: `$o.meth(args) = v` lowers to `__mutsu_assign_method_lvalue`, whose
+whole argument list is exempt from the call-site auto-FETCH because the
+**invocant** is a container by contract (ADR-0040 §9). The assigned *value* was
+re-fetched explicitly; the method's own arguments were not. They arrive inside
+an `ArrayLiteral` carrier, and ADR-0040 makes an `Array` element a `Scalar`
+container at the store — so a **variable** argument arrived as a `ContainerRef`
+while a **literal** one arrived bare. Every consumer then had to decide for
+itself: `substr_resolve_position` happened to stringify-and-parse its way out of
+it (which is why the *start* position worked by accident), while
+`resolve_substr_rw_range`'s length arm and `substr_extract_range` both fell to
+their "no length given" / "not a Range" defaults.
+
+The fix reads through the container once, in
+`builtin_assign_method_lvalue`, where the carrier is unpacked — the method's own
+arguments are ordinary rvalues, exactly like the assigned value.
+
+A neighbouring divergence fell out of the same reduction and is fixed with it: a
+`$`-held Range is itemized, so `my $r = 1..3; $s.substr($r)` handed `substr` a
+`Scalar`-wrapped Range and it silently took the whole rest of the string.
+`substr_extract_range` and `substr_resolve_position` now descalarize first.
+
+Pin: `t/substr-rw-computed-args.t`.
+
+## A `%`/`@` loop parameter was exempt from the loop's save/restore
+
+With the splice fixed, the output was still wrong — but now *correctly spliced
+at the wrong offsets*: the parent template got the nested component's `start-pos`
+and `length`. Instrumenting the dist showed `render`'s `for @(%t-indexed<vars>)
+-> %v` loop resuming its **outer** iteration with the **inner** recursive
+frame's `%v`:
+
+```raku
+class Recurse {
+    method walk(@vars, $depth --> Str) {
+        my Str $acc = '';
+        for @vars -> %v {
+            my Str $inner = $depth == 0 ?? self.walk([%(n => 'I1')], 1) !! 'x';
+            $acc ~= "[{%v<n>}:$inner]";
+        }
+        return $acc;
+    }
+}
+say Recurse.new.walk([%(n => 'O1'), %(n => 'O2')], 0);
+# raku:           [O1:[I1:x]][O2:[I1:x]]
+# mutsu (before): [I1:[I1:x]][I1:[I1:x]]
+```
+
+The VM saves and restores a single named `for` parameter's prior binding so a
+nested loop over the same name cannot leak out — but it explicitly skipped `@`
+and `%` sigils, "which bind a shared mutable container the body may legitimately
+reassign". That reasoning does not hold: a pointy parameter's scope ends with the
+loop either way, and restoring the **name** does not undo a mutation of the
+container the name pointed at (same Gc node before and after). What the exemption
+actually cost was recursion — the same `for` re-entered from a nested frame left
+the inner frame's last element bound on return.
+
+`@`/`%` parameters are saved and restored now, in all three places that had to
+agree so the deferred-restore push/pop stay balanced: `vm_for_loop_body.rs`,
+`vm_for_loop_intrange.rs`, and the two compiler sites that emit
+`OpCode::RestoreForParam`. Aliasing is unchanged — `for @aoa -> @row {
+@row.push(9) }` still writes through to the source element.
+
+Pin: `t/for-container-param-recursion.t`.
+
+## `IO::Path.modified` was truncated to whole seconds
+
+The last file, `09-advanced-indexing`, exercises the dist's re-index check:
+`%t-indexed<path>.modified > %t-indexed<modified>`. It never fired, because
+mutsu's `.created`/`.modified`/`.accessed`/`.changed` built their `Instant` from
+`Duration::as_secs()` — so two writes inside the same second compared equal.
+
+```raku
+my $p = "x".IO; $p.spurt('one'); my $a = $p.modified;
+sleep 0.05;     $p.spurt('two'); my $b = $p.modified;
+say $b > $a;    # raku: True     mutsu (before): False
+```
+
+raku reports these to nanosecond resolution. They now keep the sub-second part
+(`as_secs_f64`, and `ctime` + `ctime_nsec` for `.changed` on unix).
+
+Pin: `t/io-path-timestamp-subsecond.t`.
+
+## Why this keeps happening
+
+Three for three, on the three template dists reduced so far, the recorded
+"first failure" was a pointer and not a diagnosis, and the actual causes were in
+subsystems the ticket never mentioned — the regex tokenizer for `Template6`, the
+lvalue-argument boundary and the for-loop parameter lifetime here. The method in
+`todo/deep/template-engines-blocked-on-mutsu.md` — reduce by deletion until a
+two-line repro falls out, and check every reduction against raku — is what found
+all of them. Reading the first error line found none.

--- a/src/compiler/helpers_do_expr.rs
+++ b/src/compiler/helpers_do_expr.rs
@@ -504,10 +504,7 @@ impl Compiler {
         // Balance the ForLoop opcode's deferred param-restore push (see the
         // Stmt::For compile path). Required even though this collected form has
         // no post phasers, so the push/pop stay balanced.
-        if param
-            .as_ref()
-            .is_some_and(|p| !p.starts_with('@') && !p.starts_with('%'))
-        {
+        if param.is_some() {
             self.code.emit(OpCode::RestoreForParam);
         }
     }

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -3094,12 +3094,9 @@ impl Compiler {
                 // Restore the single named loop param after the post (LAST)
                 // phasers ran. The ForLoop opcode deferred this restore (pushing
                 // its saved binding) so the phasers could still see the param at
-                // its final value. Emit only when a single non-@/% named param
-                // exists, mirroring the VM's save condition so push/pop balance.
-                if param
-                    .as_ref()
-                    .is_some_and(|p| !p.starts_with('@') && !p.starts_with('%'))
-                {
+                // its final value. Emit whenever a single named param exists,
+                // mirroring the VM's save condition so push/pop balance.
+                if param.is_some() {
                     self.code.emit(OpCode::RestoreForParam);
                 }
                 self.self_is_signature_param = saved_self_is_signature_param;

--- a/src/runtime/builtins_multidim_assign.rs
+++ b/src/runtime/builtins_multidim_assign.rs
@@ -648,6 +648,16 @@ impl Interpreter {
         }
         let target = args[0].clone();
         let method = args[1].to_string_value();
+        // NOTE: these keep their containers. The method's own arguments reach us
+        // inside an `ArrayLiteral` carrier and ADR-0040 makes an `Array` element
+        // a `Scalar` container at the store, so a *variable* argument arrives as
+        // a `ContainerRef` while a literal one arrives bare — and that asymmetry
+        // is load-bearing for a user routine with a raw/rw parameter
+        // (`class C { method m(\x) is rw { x } }; C.new.m($a) = 5` must reach
+        // `$a`, ADR-0067 slice 2/3a). A *native* lvalue method whose arguments
+        // are plain offsets instead reads through the container itself; see
+        // `assign_substr_rw`, where taking a `ContainerRef` at face value made a
+        // variable length fall to the "no length given" default.
         let method_args = match args[2].view() {
             ValueView::Array(items, ..) => items.to_vec(),
             ValueView::Nil => Vec::new(),

--- a/src/runtime/handle_open.rs
+++ b/src/runtime/handle_open.rs
@@ -429,10 +429,18 @@ impl Interpreter {
         self.with_handle_mut(handle_value, |state| Ok(state.encoding_setting(encoding)))
     }
 
-    pub(super) fn system_time_to_int(time: SystemTime) -> i64 {
+    /// POSIX seconds since the epoch, **keeping the sub-second part**.
+    ///
+    /// The file-timestamp accessors (`.created`/`.modified`/`.accessed`) build a
+    /// Raku `Instant` out of this, and raku reports those to nanosecond
+    /// resolution. Truncating to whole seconds made two writes inside the same
+    /// second compare equal, so a cache keyed on "is the file on disk newer than
+    /// the copy I indexed?" never invalidated (`Template::Nest::Fast`'s
+    /// `:advanced-indexing` re-index check).
+    pub(super) fn system_time_to_secs(time: SystemTime) -> f64 {
         match time.duration_since(UNIX_EPOCH) {
-            Ok(duration) => duration.as_secs() as i64,
-            Err(_) => 0,
+            Ok(duration) => duration.as_secs_f64(),
+            Err(_) => 0.0,
         }
     }
 

--- a/src/runtime/methods_mut_substr_buf.rs
+++ b/src/runtime/methods_mut_substr_buf.rs
@@ -14,6 +14,19 @@ impl Interpreter {
         let chars: Vec<char> = s.chars().collect();
         let str_len = chars.len();
 
+        // `substr-rw`'s own arguments are plain offsets, not containers. The
+        // lvalue lowering deliberately hands the whole argument list through
+        // WITHOUT the call-site auto-FETCH (a user `method m(\x) is rw` needs
+        // its argument's container — ADR-0067), and the arguments travel inside
+        // an array carrier whose elements are `Scalar` containers per ADR-0040.
+        // So a variable offset arrives as a `ContainerRef` while a literal one
+        // arrives bare: `resolve_substr_rw_range`'s length arm then saw neither
+        // an `Int` nor a `Whatever` and fell to its "no length given" default,
+        // replacing the whole tail of the string
+        // (`$s.substr-rw(1, $len) = "Z"`). Read through the container here,
+        // where we know these are offsets.
+        let method_args: Vec<Value> = method_args.iter().map(Value::deref_container).collect();
+
         // Resolve start and end using the same logic as dispatch_substr
         let (start, end) = self.resolve_substr_rw_range(&method_args, str_len)?;
 
@@ -115,6 +128,10 @@ impl Interpreter {
         } else {
             Vec::new()
         };
+
+        // See `assign_substr_rw`: `subbuf-rw`'s from/length are plain offsets,
+        // and a variable one arrives wrapped in its element container.
+        let method_args: Vec<Value> = method_args.iter().map(Value::deref_container).collect();
 
         // Splice `new_bytes` over the `[from, from+len)` window. Shared by the
         // in-place and the rebuild path below, so the two cannot drift.

--- a/src/runtime/methods_string_substr.rs
+++ b/src/runtime/methods_string_substr.rs
@@ -311,6 +311,8 @@ impl Interpreter {
         pos: &Value,
         total_len: usize,
     ) -> Result<i64, RuntimeError> {
+        // See `substr_extract_range`: an itemized argument keeps its `Scalar`.
+        let pos = pos.descalarize();
         match pos.view() {
             ValueView::Int(i) => Ok(i),
             ValueView::Num(f) => Ok(f as i64),
@@ -352,6 +354,11 @@ impl Interpreter {
         val: &Value,
         total_len: usize,
     ) -> Result<Option<(usize, usize)>, RuntimeError> {
+        // A `$`-held Range is itemized (`my $r = 1..3`), so the argument arrives
+        // wrapped in a `Scalar`. Read through it before asking "is this a
+        // Range?" — otherwise `$s.substr($r)` silently fell to the "not a Range"
+        // default and took the whole rest of the string.
+        let val = val.descalarize();
         match val.view() {
             ValueView::Range(a, b) => {
                 let end = b.saturating_add(1).max(0) as usize;

--- a/src/runtime/native_io/io_path_stat.rs
+++ b/src/runtime/native_io/io_path_stat.rs
@@ -335,21 +335,15 @@ impl Interpreter {
             // Raku, and fail with `X::IO::DoesNotExist` (a Failure) on a missing
             // path — not a plain Int / generic error (roast S32-io/file-tests.t).
             "created" => match fs::metadata(path_buf).and_then(|meta| meta.created()) {
-                Ok(t) => Ok(Value::make_instant_from_posix(
-                    Self::system_time_to_int(t) as f64
-                )),
+                Ok(t) => Ok(Value::make_instant_from_posix(Self::system_time_to_secs(t))),
                 Err(_) => Ok(io_path_missing_failure(p, "created")),
             },
             "modified" => match fs::metadata(path_buf).and_then(|meta| meta.modified()) {
-                Ok(t) => Ok(Value::make_instant_from_posix(
-                    Self::system_time_to_int(t) as f64
-                )),
+                Ok(t) => Ok(Value::make_instant_from_posix(Self::system_time_to_secs(t))),
                 Err(_) => Ok(io_path_missing_failure(p, "modified")),
             },
             "accessed" => match fs::metadata(path_buf).and_then(|meta| meta.accessed()) {
-                Ok(t) => Ok(Value::make_instant_from_posix(
-                    Self::system_time_to_int(t) as f64
-                )),
+                Ok(t) => Ok(Value::make_instant_from_posix(Self::system_time_to_secs(t))),
                 Err(_) => Ok(io_path_missing_failure(p, "accessed")),
             },
             "changed" => {
@@ -357,7 +351,9 @@ impl Interpreter {
                 {
                     use std::os::unix::fs::MetadataExt;
                     match fs::metadata(path_buf) {
-                        Ok(meta) => Ok(Value::make_instant_from_posix(meta.ctime() as f64)),
+                        Ok(meta) => Ok(Value::make_instant_from_posix(
+                            meta.ctime() as f64 + meta.ctime_nsec() as f64 / 1e9,
+                        )),
                         Err(_) => Ok(io_path_missing_failure(p, "changed")),
                     }
                 }
@@ -365,9 +361,7 @@ impl Interpreter {
                 {
                     // On non-Unix platforms, fall back to modified time.
                     match fs::metadata(path_buf).and_then(|meta| meta.modified()) {
-                        Ok(t) => Ok(Value::make_instant_from_posix(
-                            Self::system_time_to_int(t) as f64
-                        )),
+                        Ok(t) => Ok(Value::make_instant_from_posix(Self::system_time_to_secs(t))),
                         Err(_) => Ok(io_path_missing_failure(p, "changed")),
                     }
                 }

--- a/src/vm/vm_for_loop_body.rs
+++ b/src/vm/vm_for_loop_body.rs
@@ -427,13 +427,21 @@ impl Interpreter {
             .collect();
         // Save the single named loop param (`for ... -> $x`) too, so a loop in a
         // called sub that reuses the same variable name does not clobber an outer
-        // loop's binding of that name (the env keys these by bare name). Skip
-        // `@`/`%` sigils, which bind a shared mutable container the body may
-        // legitimately reassign, and skip the rw case (handled via writeback).
-        let saved_param: Option<(String, Option<Value>, Option<u32>)> = param_name
-            .as_ref()
-            .filter(|n| !n.starts_with('@') && !n.starts_with('%'))
-            .map(|name| {
+        // loop's binding of that name (the env keys these by bare name).
+        //
+        // `@`/`%` parameters are saved too. They used to be skipped on the theory
+        // that they "bind a shared mutable container the body may legitimately
+        // reassign" — but a pointy parameter's scope ends with the loop either
+        // way, and restoring the NAME does not undo a mutation of the container
+        // the name pointed at (that is the same Gc node before and after). What
+        // the exemption actually cost was the recursion case: a method whose body
+        // is `for @vars -> %v { ... self.render(...) ... }` re-enters the same
+        // loop in the nested frame, and with no save/restore the inner frame's
+        // last `%v` stayed bound when control returned, so the OUTER iteration
+        // finished with the inner element (`Template::Nest::Fast`'s render spliced
+        // the nested component's offsets into the parent template).
+        let saved_param: Option<(String, Option<Value>, Option<u32>)> =
+            param_name.as_ref().map(|name| {
                 (
                     name.clone(),
                     self.env().get(name).cloned(),

--- a/src/vm/vm_for_loop_intrange.rs
+++ b/src/vm/vm_for_loop_intrange.rs
@@ -49,12 +49,10 @@ impl Interpreter {
         // frozen captured value via the don't-overwrite merge) instead of its own
         // per-iteration binding. Mirrors `exec_for_loop_body`'s `saved_param`:
         // restored after the loop's LAST/post phasers via the `RestoreForParam`
-        // opcode (the compiler emits it for any single non-@/% named param), so
-        // the push below must balance that pop on normal completion.
-        let saved_param: Option<(String, Option<Value>, Option<u32>)> = param_name
-            .as_ref()
-            .filter(|n| !n.starts_with('@') && !n.starts_with('%'))
-            .map(|name| {
+        // opcode (the compiler emits it for any single named param), so the push
+        // below must balance that pop on normal completion.
+        let saved_param: Option<(String, Option<Value>, Option<u32>)> =
+            param_name.as_ref().map(|name| {
                 (
                     name.clone(),
                     self.env().get(name).cloned(),

--- a/t/for-container-param-recursion.t
+++ b/t/for-container-param-recursion.t
@@ -1,0 +1,60 @@
+use Test;
+
+plan 5;
+
+# A `for ... -> %v` / `-> @v` pointy parameter is a per-iteration binding whose
+# scope ends with the loop, exactly like `-> $v`. It used to be exempt from the
+# loop's save/restore of the parameter name, so re-entering the SAME loop from
+# a nested call left the inner frame's last element bound: the outer iteration
+# resumed with the inner element. (Template::Nest::Fast's recursive `render`
+# then spliced a nested component's offsets into the parent template.)
+
+class Recurse {
+    method walk(@vars, $depth --> Str) {
+        my Str $acc = '';
+        for @vars -> %v {
+            my Str $inner = $depth == 0 ?? self.walk([%(n => 'I1')], 1) !! 'x';
+            $acc ~= "[{%v<n>}:$inner]";
+        }
+        return $acc;
+    }
+}
+is Recurse.new.walk([%(n => 'O1'), %(n => 'O2')], 0),
+   '[O1:[I1:x]][O2:[I1:x]]',
+   'a %-sigil loop parameter survives recursion into the same loop';
+
+class RecurseArray {
+    method walk(@vars, $depth --> Str) {
+        my Str $acc = '';
+        for @vars -> @v {
+            my Str $inner = $depth == 0 ?? self.walk([['I1'],], 1) !! 'x';
+            $acc ~= "[{@v[0]}:$inner]";
+        }
+        return $acc;
+    }
+}
+is RecurseArray.new.walk([['O1'], ['O2']], 0),
+   '[O1:[I1:x]][O2:[I1:x]]',
+   'an @-sigil loop parameter survives recursion into the same loop';
+
+sub walk-sub(@vars, $depth --> Str) {
+    my Str $acc = '';
+    for @vars -> %v {
+        my Str $inner = $depth == 0 ?? walk-sub([%(n => 'I1')], 1) !! 'x';
+        $acc ~= "[{%v<n>}:$inner]";
+    }
+    return $acc;
+}
+is walk-sub([%(n => 'O1'), %(n => 'O2')], 0),
+   '[O1:[I1:x]][O2:[I1:x]]',
+   'the same holds for a recursive sub';
+
+# The container binding itself is still shared, not copied: mutating through
+# the parameter must reach the source element.
+my @aoa = [1, 2], [3, 4];
+for @aoa -> @row { @row.push(9) }
+is @aoa.raku, '[[1, 2, 9], [3, 4, 9]]', 'an @-sigil loop parameter still aliases its element';
+
+my @aoh = %(n => 1), %(n => 2);
+for @aoh -> %row { %row<m> = 5 }
+is @aoh.map(*<m>).join(','), '5,5', 'a %-sigil loop parameter still aliases its element';

--- a/t/io-path-timestamp-subsecond.t
+++ b/t/io-path-timestamp-subsecond.t
@@ -1,0 +1,30 @@
+use Test;
+
+plan 4;
+
+# `.created` / `.modified` / `.accessed` / `.changed` are `Instant`s, and raku
+# reports them to sub-second resolution. Truncating to whole seconds made two
+# writes inside the same second compare equal, so any "is the file on disk newer
+# than my cached copy?" check never fired (Template::Nest::Fast's
+# `:advanced-indexing` re-index).
+
+my $dir  = $*TMPDIR.add("mutsu-mtime-{$*PID}-{(^100000).pick}");
+$dir.mkdir;
+my $file = $dir.add('stamp.txt');
+
+$file.spurt('one');
+my $first = $file.modified;
+
+sleep 0.05;
+
+$file.spurt('two-and-a-bit-longer');
+my $second = $file.modified;
+
+isa-ok $first, Instant, '.modified returns an Instant';
+ok $second > $first, 'a rewrite inside the same second is strictly newer';
+ok $first.Rat - $first.Rat.Int != 0 || $second.Rat - $second.Rat.Int != 0,
+   'at least one timestamp carries a sub-second part';
+ok $file.changed >= $first, '.changed is at least as new as the first write';
+
+$file.unlink;
+$dir.rmdir;

--- a/t/substr-rw-computed-args.t
+++ b/t/substr-rw-computed-args.t
@@ -1,0 +1,61 @@
+use Test;
+
+plan 12;
+
+# `$s.substr-rw($from, $len) = $v` — the method's own arguments are ordinary
+# rvalues. They reach the lvalue-assignment builtin inside an array carrier
+# whose elements are `Scalar` containers, so a *variable* argument used to
+# arrive as a container while a literal one arrived bare; the length arm then
+# fell to its "no length given" default and replaced the whole tail.
+
+my $p = 1;
+my $l = 3;
+
+my $a = "hello";
+$a.substr-rw(1, 3) = "Z";
+is $a, "hZo", "literal from, literal length";
+
+my $b = "hello";
+$b.substr-rw($p, 3) = "Z";
+is $b, "hZo", "variable from, literal length";
+
+my $c = "hello";
+$c.substr-rw(1, $l) = "Z";
+is $c, "hZo", "literal from, variable length";
+
+my $d = "hello";
+$d.substr-rw($p, $l) = "Z";
+is $d, "hZo", "variable from, variable length";
+
+my Int $li = 3;
+my $e = "hello";
+$e.substr-rw(1, $li) = "Z";
+is $e, "hZo", "Int-typed variable length";
+
+my $f = "hello";
+$f.substr-rw($p, $l) = "";
+is $f, "ho", "empty replacement still honours the length";
+
+my %h = (pos => 1, len => 3);
+my $g = "hello";
+$g.substr-rw(%h<pos>, %h<len>) = "ZZ";
+is $g, "hZZo", "hash-element from and length";
+
+my @idx = 1, 3;
+my $i = "hello";
+$i.substr-rw(@idx[0], @idx[1]) = "ZZ";
+is $i, "hZZo", "array-element from and length";
+
+# A `$`-held Range is itemized, so it arrives wrapped in a Scalar. Both the
+# rvalue `substr` and the `substr-rw` lvalue must still see a Range.
+my $rng = 1..3;
+is "abcdef".substr($rng), "bcd", "substr with a Range held in a scalar";
+is "abcdef".substr(1..3), "bcd", "substr with a literal Range";
+
+my $j = "abcdef";
+$j.substr-rw($rng) = "XY";
+is $j, "aXYef", "substr-rw with a Range held in a scalar";
+
+my $k = "abcdef";
+$k.substr-rw(1..3) = "XY";
+is $k, "aXYef", "substr-rw with a literal Range";

--- a/todo/deep/template-engines-blocked-on-mutsu.md
+++ b/todo/deep/template-engines-blocked-on-mutsu.md
@@ -16,7 +16,7 @@ carried-over figure. Several rows had gone badly stale.
 | `Template6` 0.16.0 | 12/12 | ~~0/12~~ → ~~10/12~~ → ~~11/12~~ → **12/12** | **DONE 2026-09-06** (`news/2026-09/template6-zero-to-ten-of-twelve.md`). The `Use of Nil in string context` headline was, as this file predicted, a pointer and not the diagnosis: reducing `Parser.compile` by deletion found four unrelated general bugs — a split-`:v` separator `Match` carried no named captures; `.subst(…, :nth(2..*))` aborted the process with a Rust `capacity overflow`; an attribute default's closure was stamped with the *constructing* class and lost its own file's subs; and an assignment to `$_` inside a nested block was discarded on block exit. `02-for` was then fixed on 2026-09-06 too: a one-parameter pointy block lost its parameter's sigil, so `-> @stack { @stack.shift }` bound the caller's array BY VALUE (`news/2026-09/one-parameter-pointy-block-loses-its-sigil.md`). The last file, `05-includes`, followed on 2026-09-06 as well and it too was one general bug rather than the template machinery the ticket suspected: the *no-capture* regex matcher (`regex_match_end_from_in_pkg`, the engine behind `.comb(/rx/)`, `.split`, `.subst(:g)` and the lookaround assertions) ignored `RegexToken::frugal` outright, so `Parser!action`'s `.comb(/ \" .*? \" | \' .*? \' | \S+ /)` matched from the first quote to the LAST one and returned the whole `[% INCLUDE "included" name = "World" %]` statement as a single token (`news/2026-09/frugal-quantifier-in-the-no-capture-matcher.md`). The dist is complete |
 | `Template::Jinja2` 0.2.0 | 22/23 | ~~0/23~~ → **3/23** | The two 2026-08-19 blockers are genuinely fixed, and so is the *third* one found on 2026-09-06: `lib/Template/Jinja2/Renderer.rakumod:114`'s `when If {` was parsed as a call (`Function 'If' needs parens to avoid gobbling block`) because a `use`d module's `is export`ed classes never reached the parser's type index — a trait on a declarator wraps it in a bare `Stmt::Block` the module scan did not walk into. The dist now loads; the remaining 20 files are ordinary per-feature failures |
 | `Template::Mojo` 0.2.2 | 5/5 | **4/5** | `00-basic` only; residue in `todo/tickets/template-mojo-residual-failures.md` |
-| `Template::Nest::Fast` 0.3.0 | 10/10 | **0/10** | `with $f ~~ m:g/…/ -> @m` binds `@m` to a one-element list *containing* the match list instead of to the list itself, so `$m[0].from` is Nil and `!index-template` warns and then dies. Reduced: `with ("a<!--x-->b<!--yy-->c" ~~ m:g/('<!--') \s* (\w+) \s* ('-->')/) -> @m { say @m.elems }` — raku 2, mutsu 1 |
+| `Template::Nest::Fast` 0.3.0 | 10/10 | ~~0/10~~ → ~~2/10~~ → **10/10** | **DONE 2026-09-07** (`news/2026-09/template-nest-fast-zero-to-ten-of-ten.md`). Five general bugs, none of them in the template machinery. Off zero: `with EXPR -> @m` bound `@m` to a one-element wrapper, and `can-ok` did not see auto-generated attribute accessors. Then, in order: an lvalue method's **own arguments** kept the `Scalar` element containers of their array carrier, so `$s.substr-rw($from, $len) = v` saw neither an `Int` length nor a `Range` and replaced the whole tail (`my $l = 3; my $s = "hello"; $s.substr-rw(1, $l) = "Z"` — raku `hZo`, mutsu `hZ`); a `%`/`@`-sigil `for` parameter was exempt from the loop's save/restore, so recursing into the same loop left the inner frame's element bound and `render` spliced the nested component's offsets into the parent; and `IO::Path.modified` truncated to whole seconds, so the `:advanced-indexing` re-index check never fired. Pins: `t/substr-rw-computed-args.t`, `t/for-container-param-recursion.t`, `t/io-path-timestamp-subsecond.t` |
 | `Template::HAML` 0.9.5 | 82/83 | **39/83** ² | many; also **2–3× slower to load than raku** (release) → `todo/tickets/grammar-heavy-module-load-slower-than-raku.md` |
 | `SP6` 0.2.1 | 10/11 | **10/11** | at parity — its one failure is `00-meta`, the same file raku fails |
 | `Template::Classic` 0.0.3 | 1/1 | **0/1** | `Unterminated <%` thrown by its own grammar: `my grammar Grammar { token TOP { ^ [ $<part> = <text> || $<part> = <code> || <!before $> { die … } ] … } }`. The `$<part> = <rule>` capture-assignment form inside a `||` chain does not match. (The older "`Unknown method value dispatch`" note is stale.) |
@@ -99,8 +99,12 @@ needs its own reduction before it can be scheduled. What *is* known:
 3. ~~`Template6`~~ — **12/12 as of 2026-09-06**; the dist is closed. Five
    general interpreter bugs came out of reducing it, every one of them found by
    deleting constructs rather than by reading the first error line.
-4. `Template::Nest::Fast` — 0/10 behind a single reduced bug (`with EXPR -> @m`
-   wrapping the list); likely the cheapest whole row left.
+4. ~~`Template::Nest::Fast`~~ — **10/10 as of 2026-09-07**; the dist is closed.
+   The ticket's "single reduced bug" guess was wrong in the usual direction: the
+   `with EXPR -> @m` wrapping was real but only worth 2/10, and the remaining
+   eight files came from three further general bugs in three unrelated
+   subsystems (the lvalue-argument container boundary, the `for`-parameter
+   lifetime, and `IO::Path` timestamp resolution).
 5. The rest (`Mojo`, `HAML`, `Classic`) as ordinary compatibility work; each is
    also a data point that mutsu's grammar/list semantics still diverge in ways
    ordinary modules hit.
@@ -114,6 +118,13 @@ the table is the decision input and goes stale the moment one lands.
 - **2026-09-01 (TRIAGE regeneration, no tarballs fetched):** confirmed from the
   news archive that both `Template::Jinja2` blockers were closed, and flagged
   the whole table as unmeasured since.
+- **2026-09-07 (`Template::Nest::Fast` only):** 2/10 → **10/10**. Three general
+  fixes on top of the two that took it off zero the same day; every one found by
+  reducing a divergence to a snippet, none of them where the recorded symptom
+  pointed. Notably the second one was only visible *after* the first: with the
+  splice length fixed, the output was still wrong but now spliced correctly at
+  the wrong offsets, which is what exposed the loop-parameter leak. Reducing one
+  layer at a time is what this file prescribes and it paid again.
 - **2026-09-06 (full re-run, all eight dists fetched):** the table above. The
   Jinja2 row had indeed moved (0/23 → 1/23, and onto a new blocker, itself
   fixed the same day to reach 3/23), `SP6` had


### PR DESCRIPTION
`Template::Nest::Fast` 0.3.0 — one row of `todo/deep/template-engines-blocked-on-mutsu.md` — is **10/10 under raku** and was **2/10 under mutsu** after #7493 landed the `with EXPR -> @m` / `can-ok` pair. It is now **10/10**.

The remaining eight files came from **three unrelated general interpreter bugs**, none of them in the template machinery, and each found by reducing a divergence to a snippet rather than by reading the first error line.

| | before | after |
| --- | --- | --- |
| `Template::Nest::Fast` (10 files) | 2/10 | **10/10** |

---

## 1. A native lvalue method's own arguments kept their element containers

```raku
my $l = 3;
my $s = "hello";
$s.substr-rw(1, $l) = "Z";
say $s;             # raku: hZo    mutsu (before): hZ
```

A **literal** length worked; a **variable** one did not.

`$o.meth(args) = v` lowers to `__mutsu_assign_method_lvalue`, whose whole argument list is exempt from the call-site auto-FETCH — the **invocant** is a container by contract (ADR-0040 §9), and a user routine with a raw/rw parameter needs its argument's container too (ADR-0067 slice 2/3a: `class C { method m(\x) is rw { x } }; C.new.m($a) = 5` must reach `$a`). Those arguments travel inside an `ArrayLiteral` carrier, and ADR-0040 makes an `Array` element a `Scalar` container at the store — so a variable argument arrives as a `ContainerRef` while a literal one arrives bare, and each consumer decided for itself what to do about it. `substr_resolve_position` happened to stringify-and-parse its way out (which is why the *start* offset worked by accident), while `resolve_substr_rw_range`'s length arm and `substr_extract_range` both fell to their "no length given" / "not a Range" defaults.

`render`'s `$rendered.substr-rw(%v<start-pos>, %v<length>) = $append` therefore replaced the whole tail of the template on every splice.

`substr-rw` / `subbuf-rw` are native lvalue methods whose arguments are plain offsets, so they read through the container where that is known. The generic carrier unpack is deliberately left alone — the asymmetry there is load-bearing for the rw-parameter case (a blanket deref regressed `t/method-rw-capability-oracle.t` and `t/sigilless-raw-param-container-return.t`, which is how the boundary got pinned down).

Found by the same reduction and fixed with it: a `$`-held Range is itemized, so

```raku
my $r = 1..3;
say "abcdef".substr($r);   # raku: bcd    mutsu (before): abcdef
```

handed `substr` a `Scalar`-wrapped Range and it silently took the rest of the string. `substr_extract_range` / `substr_resolve_position` descalarize first now.

Pin: `t/substr-rw-computed-args.t`

## 2. A `%`/`@`-sigil `for` parameter was exempt from the loop's parameter save/restore

With the splice fixed the output was still wrong — but now *correctly spliced at the wrong offsets*: the parent template got the nested component's `start-pos` and `length`.

```raku
class Recurse {
    method walk(@vars, $depth --> Str) {
        my Str $acc = '';
        for @vars -> %v {
            my Str $inner = $depth == 0 ?? self.walk([%(n => 'I1')], 1) !! 'x';
            $acc ~= "[{%v<n>}:$inner]";
        }
        return $acc;
    }
}
say Recurse.new.walk([%(n => 'O1'), %(n => 'O2')], 0);
# raku:           [O1:[I1:x]][O2:[I1:x]]
# mutsu (before): [I1:[I1:x]][I1:[I1:x]]
```

The VM saves and restores a single named `for` parameter's prior binding so a nested loop over the same name cannot leak out, but skipped `@`/`%` sigils, "which bind a shared mutable container the body may legitimately reassign". That reasoning does not hold: a pointy parameter's scope ends with the loop either way, and restoring the **name** does not undo a mutation of the container the name pointed at (same Gc node before and after). What the exemption cost was **recursion** — re-entering the same loop from a nested frame left the inner frame's last element bound on return.

`@`/`%` parameters are saved and restored now, in all three sites that must agree so the deferred-restore push/pop stay balanced: `vm_for_loop_body.rs`, `vm_for_loop_intrange.rs`, and the two compiler sites that emit `OpCode::RestoreForParam`. Element aliasing is unchanged — `for @aoa -> @row { @row.push(9) }` still writes through, and the pin asserts it.

Pin: `t/for-container-param-recursion.t`

## 3. `IO::Path` timestamps were truncated to whole seconds

```raku
my $p = "x".IO; $p.spurt('one'); my $a = $p.modified;
sleep 0.05;     $p.spurt('two'); my $b = $p.modified;
say $b > $a;    # raku: True     mutsu (before): False
```

`.created`/`.modified`/`.accessed`/`.changed` built their `Instant` from `Duration::as_secs()`, so two writes inside the same second compared equal and any "is the file on disk newer than my cached copy?" check never fired — here, the dist's `:advanced-indexing` re-index. raku reports these to nanosecond resolution; they keep the sub-second part now (`as_secs_f64`, and `ctime` + `ctime_nsec` for `.changed` on unix).

Pin: `t/io-path-timestamp-subsecond.t`

---

## Gates

- `make test` — **PASS**, 3796 files / 39942 tests.
- Targeted roast sweeps, 451 whitelisted files / ~55k tests, over `S32-str`, `S32-io`, `S16-io`, `S04-statements`, `S04-blocks-and-statements`, `S04-statement-modifiers`, `S04-declarations`, `S04-phasers`, `S07-iterators`, `S07-slip`, `S32-list`, `S03-binding`, `S03-operators`, `S32-container`, `S32-scalar`, `S02-lists`, `S05-match`, `S06-parameters`, `S06-signature`, `S09-subscript`, `S12-methods`, `S29-context`, `S32-array`, `S32-hash` — clean. Two reports, both investigated and neither a regression: `S04-declarations/state.t` hit the 30s runner budget under `-j4` in a **debug** build (82s alone, passes; `make roast` uses release), and three `S32-str` encoding files need `scripts/run-roast-test.sh`'s cwd for their sample data (all pass under it).
- `scripts/battery-testsuite.sh` (release, run alone) — **GATE PASSED**, 289/312.
- `cargo fmt` clean, `cargo clippy --all-targets -- -D warnings` clean.

## Docs

`todo/deep/template-engines-blocked-on-mutsu.md`'s table, order-of-work list and measurement log are updated, as is `docs/batteries/templates.md`. Write-up: `news/2026-09/template-nest-fast-zero-to-ten-of-ten.md`.

Three template dists reduced so far, three times the recorded "first failure" was a pointer and not a diagnosis. The `Template::Nest::Fast` row's own guess — "0/10 behind a single reduced bug" — was worth two files out of ten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
