### PR TITLE
feat(runtime): grep produces a deferred Seq too (ADR-0058 step 3b)

### DIFF
--- a/docs/adr/0058-map-grep-produce-a-deferred-seq.md
+++ b/docs/adr/0058-map-grep-produce-a-deferred-seq.md
@@ -271,7 +271,7 @@ callback `Value` already carries its own closure environment.
 | **2** | **Done (2026-09-07).** `SeqSource::MapGrep` + the `pull_seq_source` arm + `Value::seq_deferred` construction in `dispatch_map_method`, plus the read-path consumers S8 lists. Shipped covering only SOME receivers; the `@`-array hole it left is closed by step 3c below. | All nine ADR-0058 rows of phase 1's oracle are un-`todo`d. |
 | **3a** | **Done (2026-09-07).** `builtin_map` (the `map &f, @xs` listop form) returns the same `Value::seq_deferred(SeqSource::MapGrep { .. })` as step 2. Attempted and reverted earlier the same day behind a step-2 hole (S9.1); that hole is closed (`news/2026-09/deferred-map-callback-frame.md`). The mandatory full `make roast` then found three more consumers, all fixed generally -- see S9.3. | `t/listop-map-defers.t`, and `t/nested-deferred-map-seq-is-pulled.t`'s listop row un-`todo`d. |
 | **3c** | **Done (2026-09-07).** The three EAGER `.map` loops keyed on an `@`-sigil receiver -- `call_method_mut_with_values`'s rw gate, `try_native_array_map`, and `builtin_map`'s `source_var` branch -- defer through the same `SeqSource::MapGrep`, which gains `rw_source` so the pull can publish the rw write-back in place. `is_stub_routine_body` drops out of both deferral predicates, and a `Control::Fail` raised under a captured `fatal` throws at the pull. Closes S9.4; the oracle is 37 rows with no `todo`s. | `news/2026-09/real-array-map-defers.md`. The mandatory full `make roast` + `make test` + battery run found EIGHT more general defects -- see S9.4. |
-| **3b** | Extend to both `grep` entry points. Measured 2026-09-07: grep is still fully eager and diverges from rakudo. `grep`'s `:k`/`:kv`/`:p` adverbs need positional indices over the whole result and can stay eager, exactly as they already opt out of `make_lazy_pipe`. **Its own slice, for a measured reason -- see S9.2.** | |
+| **3b** | **Done (2026-09-07).** Every `grep` entry point defers with the default `:v` adverb: the concrete-array arm, the range arm, the generic arm and the listop. `:k`/`:kv`/`:p` keep the eager path (they need positional indices over the whole result), the same exemption they already take from `make_lazy_pipe`. §9.5 records what the gates found. | `SeqSource::MapGrep`'s two `Option<Value>` fields collapsed into one `MapGrepMode` enum so the four shapes are mutually exclusive by construction. |
 | **4** | Retire the `body_contains_return` deferral predicate and `create_lazy_map_list` — both become dead once every map defers. (`is_stub_routine_body` already dropped out of both predicates in step 3c: a `...` stub needs only "do not fire until iterated", which `MapGrep` gives, and unlike the `LazyList` route `MapGrep` carries the `fatal` a stub-as-`fail` needs.) | The maintainability payout. |
 
 ### Verification
@@ -616,6 +616,37 @@ EAGERNESS (it read the source after `.^name`, which does not consume); re-measur
 under `raku` it answers `[1, 2, 3]`, and the row now says so. The oracle is 37
 raku-verified rows with no `todo`s, its new Part 3 being the spelling audit.
 `news/2026-09/real-array-map-defers.md`.
+
+### 9.5 What step 3b found: deferring the SIBLING is what surfaces a read-path hole
+
+Step 3b's own diff is small. Its gates turned up **six** defects, and **five of
+them were already live on `main`** — holes in step 3c's `.map` deferral that
+`grep` had been masking simply by still being eager. Every one is the same
+shape: a consumer that reads a `Seq`'s elements through pure code, which cannot
+pull, and so sees ADR-0034's empty seed.
+
+| consumer | symptom | broken for `.map` too? |
+|---|---|---|
+| `+@a` single-argument-rule slurpy binder | `sub f(+@a) { @a }; f((1,2,3).map({$_}))` answered `()` | yes |
+| boolean context | an EMPTY result read as TRUE, so every `!...grep(...)` guard inverted | yes |
+| `[$p?, *@r]` destructuring binder | a recursive quicksort unpacked the empty seed at every level | yes |
+| `constant @x = …` (`OpCode::CoerceToList`) | the constant was FROZEN as the empty seed | yes |
+| slice index (`@f[SEQ]`) | the slice addressed no slots | yes |
+| itemized array through the promoting arm | `grep({…}, $(1,2,3))` greps its ELEMENTS | 3b's own |
+
+The boolean one is worth naming twice: `Value::truthy`'s `is_map_grep_source`
+arm carried a comment promising that "the VM forces the body at every boolean
+chokepoint it can reach with an `&mut Interpreter`". It did not — `eval_truthy`
+had no such force. The comment documented an invariant nobody had implemented.
+
+**The transferable lesson.** §5 already says a deferral step makes mutsu
+stricter in every consumer and mandates a full `make roast`. What 3b adds is
+that a *green* gate on the step that deferred is not evidence the consumers are
+covered: as long as a sibling operation is still eager, it keeps producing
+reified Seqs that hide the same holes. Deferring the sibling is the detector.
+Step 4 should expect the same, and the **bundled-library battery gate** is where
+two of these six surfaced (`Text::CSV` 78_fragment/90_csv) with `make test` and
+a full `make roast` both green.
 
 ### 9.3 What the mandatory roast run found when step 3 landed (2026-09-07)
 

--- a/news/2026-09/grep-defers.md
+++ b/news/2026-09/grep-defers.md
@@ -1,0 +1,93 @@
+# `grep` produces a deferred Seq too (ADR-0058 step 3b)
+
+`.map` has answered a not-yet-run `Seq` since ADR-0058 steps 2/3a/3c. `.grep`
+still ran its callback at the call, in all four spellings, so the two halves of
+the same operation disagreed about when the callback runs.
+
+```raku
+my @a = 1,2,3;
+my $s1 = @a.grep({ print "A"; $_ > 1 });        print "|";
+my $s2 = @a.List.grep({ print "B"; $_ > 1 });   print "|";
+my $s3 = (1,2,3).grep({ print "C"; $_ > 1 });   print "|";
+my $s4 = grep({ print "D"; $_ > 1 }, @a);       print "|";
+print "\n";
+$s1.List; $s2.List; $s3.List; $s4.List;
+```
+
+| | at the calls | at the pulls |
+|---|---|---|
+| rakudo | `\|\|\|\|` | — |
+| before | `AAA\|BBB\|CCC\|DDD\|` | — |
+| after | `\|\|\|\|` | `AAABBBCCCDDD` |
+
+All four of ADR-0058 §9.2's recorded rows now match rakudo, including the two
+that were not about timing at all:
+
+| §9.2 row | before | after = rakudo |
+|---|---|---|
+| `(1..3).grep` side-effect order | `RRRT` | `TRRR` |
+| the listop spelling of the same | `RRRT` | `TRRR` |
+| `grep({ $_ = 5 }, @a).eager` | `[1, 2, 3]` | `[5, 5, 5]` |
+| `for @a.grep(…) { $_++ }` | `[1, 3, 4]` | unchanged |
+
+## Two things the implementation turned up
+
+**`builtin_grep` had no `source_var` branch at all.** The third row above was
+broken *before* deferral and would have stayed broken after it: the listop grep
+never wrote back through `$_`, because unlike `builtin_map` it never looked at
+`pending_call_arg_sources`. A single concrete-array source now takes the same
+promoting arm the method form does.
+
+**`SeqSource::MapGrep`'s two `Option<Value>` fields were not mutually
+exclusive.** `rw_source` (added by step 3c) and the `grep_source` this step
+wanted describe four shapes that cannot co-occur — a body cannot be both an rw
+map and a promoting grep — so they collapsed into one `MapGrepMode` enum
+(`Map` / `MapRw(Value)` / `Grep` / `GrepArray(Value)`). The pull's dispatch is
+now a total match rather than a tuple of `Option`s.
+
+Deferring the promoting arm at all is only sound because the promotion is
+published by mutating the source `ArrayData` **in place** rather than by
+re-binding its name in the current frame — the pull happens wherever the Seq is
+consumed, long after that frame is gone
+(`news/2026-09/grep-promotion-is-published-in-place.md`).
+
+## What the gates found: deferring the sibling is the detector
+
+The diff is small; the gates turned up **six** defects, and **five were already
+live on `main`** — holes in `.map`'s deferral that `grep` had been masking by
+still being eager. Every one is the same shape: a consumer that reads a `Seq`'s
+elements through pure code, which cannot pull, and so sees ADR-0034's empty
+seed.
+
+| consumer | symptom | broken for `.map` too? |
+|---|---|---|
+| `+@a` slurpy binder | `sub f(+@a) { @a }; f((1,2,3).map({$_}))` answered `()` | yes |
+| boolean context | an EMPTY result read as TRUE, inverting every `!…grep(…)` | yes |
+| `[$p?, *@r]` destructuring | a recursive quicksort unpacked the empty seed at every level | yes |
+| `constant @x = …` | the constant was frozen as the empty seed | yes |
+| slice index `@f[SEQ]` | the slice addressed no slots | yes |
+| itemized array through the promoting arm | `grep({…}, $(1,2,3))` grepped its elements | this step's own |
+
+The boolean one is worth naming twice. `Value::truthy`'s `is_map_grep_source`
+arm carried a comment promising that *"the VM forces the body at every boolean
+chokepoint it can reach with an `&mut Interpreter`"*. It did not — `eval_truthy`
+had no such force. The comment documented an invariant nobody had implemented,
+and it read as reassurance for two weeks.
+
+**The transferable lesson**, recorded as ADR-0058 §9.5: a green gate on the step
+that deferred is not evidence its consumers are covered. As long as a sibling
+operation is still eager it keeps handing out reified Seqs, which hide exactly
+the same holes. Step 4 should expect the same.
+
+Two of the six surfaced **only** in the bundled-library battery gate
+(`Text::CSV` 78_fragment / 90_csv) with `make test` and a full `make roast` both
+green — the fourth time in one day that gate caught what the other two missed.
+
+## Gates
+
+`make test` PASS (3799 files / 40048 tests) · full local `make roast` PASS
+(1436 files / 218962 tests) · `scripts/battery-testsuite.sh` **GATE PASSED**
+(289/312). Pinned by `t/grep-defers.t` (11 rows, green under rakudo too).
+
+Step 4 — retiring `create_lazy_map_list` and the `body_contains_return`
+predicate — is what is left of ADR-0058.

--- a/src/runtime/builtins_collection_mapgrep.rs
+++ b/src/runtime/builtins_collection_mapgrep.rs
@@ -101,7 +101,7 @@ impl Interpreter {
                 items: std::sync::Arc::new(list_items),
                 func,
                 fatal: self.fatal_mode,
-                rw_source: Some(args[1].clone()),
+                mode: crate::value::MapGrepMode::MapRw(args[1].clone()),
             }))
         } else {
             // Same deferral as dispatch_map_method: a callback containing
@@ -123,7 +123,7 @@ impl Interpreter {
                 items: std::sync::Arc::new(list_items),
                 func,
                 fatal: self.fatal_mode,
-                rw_source: None,
+                mode: crate::value::MapGrepMode::Map,
             }))
         }
     }
@@ -278,11 +278,36 @@ impl Interpreter {
             // The sub form returns a Seq like the method form (raku: `grep
             // *.so, @a` is a Seq, and a `--> Seq` return constraint on a sub
             // that ends in a grep call must pass).
-            let result = self.eval_grep_over_items(func, list_items)?;
-            Ok(match result.view() {
-                ValueView::Array(items, ..) => Value::seq(items.to_vec()),
-                _ => result,
-            })
+            // ADR-0058 step 3b: the listop `grep &f, @xs` defers exactly as the
+            // method form does -- the callback runs when something consumes the
+            // Seq. The adverbed forms above keep the eager path; they need
+            // positional indices over the whole result.
+            // A single concrete-array source takes the same promoting arm the
+            // method form does, so `grep({ $_ = 5 }, @a)` writes back through
+            // `$_` into `@a` (rakudo: `[5 5 5]`). `builtin_grep` had no
+            // `source_var` branch at all, which is why that row of ADR-0058
+            // §9.2's table was wrong before deferral and would have stayed
+            // wrong after it.
+            // ... but ONLY for a source whose elements this call actually
+            // greps over. An itemized array (`$(1,2,3)` / `$[1,2,3]`) is a
+            // single item under the single-argument rule, so it must keep the
+            // plain arm and grep the one already-built `list_items` entry --
+            // routing it through the promoting arm greps its ELEMENTS instead
+            // (`t/map-grep-itemized-arg.t`).
+            let mode = match args.get(1).map(Value::view) {
+                Some(ValueView::Array(_, kind))
+                    if args.len() == 2 && !kind.is_itemized() && single_arg_rule =>
+                {
+                    crate::value::MapGrepMode::GrepArray(args[1].clone())
+                }
+                _ => crate::value::MapGrepMode::Grep,
+            };
+            Ok(Value::seq_deferred(crate::value::SeqSource::MapGrep {
+                items: std::sync::Arc::new(list_items),
+                func,
+                fatal: self.fatal_mode,
+                mode,
+            }))
         }
     }
 

--- a/src/runtime/methods_collection_ops/grep.rs
+++ b/src/runtime/methods_collection_ops/grep.rs
@@ -304,105 +304,20 @@ impl Interpreter {
                 Ok(Value::make_instance(Symbol::intern("Supply"), attrs))
             }
             ValueView::Array(items, _arr_kind) => {
-                let (filtered, mutated_items, matched_indices) =
-                    self.eval_grep_over_items_with_mutated(args.first().cloned(), items.to_vec())?;
-                // Which source positions matched, so those slots can be shared
-                // with the result as first-class element containers. The grep
-                // loop reports them; they used to be re-derived here by scanning
-                // the source for a value `===` to each result element, which
-                // could not find a `Proxy` slot (the result holds the FETCHed
-                // value, the slot holds the Proxy). The miss then truncated the
-                // result below, because it is rebuilt from the located slots.
-                //
-                // `None` is a chunked grep (`grep -> $a, $b {...}`): no
-                // one-to-one element/slot mapping, so nothing is aliased.
-                let indices = matched_indices.unwrap_or_default();
-                // Promote each matched source slot to a shared `ContainerRef`
-                // cell and reference the SAME cells from the grep result. A
-                // writeback loop (`for @a.grep(...) { $_++ }` / `@a.grep(...)>>++`)
-                // then mutates THROUGH the cell into @a's slot via the ordinary
-                // element-cell write path — no GrepView side channel needed. A
-                // later `=` assignment (`my @g = @a.grep(...)`) decontainerizes the
-                // cells, so the named copy owns its values and never writes back.
-                let mut promoted = mutated_items;
-                let mut shared_cells: Vec<Value> = Vec::with_capacity(indices.len());
-                for &i in &indices {
-                    // A `:delete`d (or never-assigned) slot has no element
-                    // container to alias, and promoting it would *create* one:
-                    // `ArrayData::hole_at` recognises a hole by the gap marker
-                    // value (`Package("Any")`/the declared type) sitting in the
-                    // slot AND its absence from `initialized`, so wrapping that
-                    // marker in a `ContainerRef` makes the slot read as a live
-                    // element while `initialized` still calls it empty. The two
-                    // then disagree, and a later trailing-slot `:delete` stops
-                    // truncating the array (`@a[2]:delete; @a.grep({True});
-                    // @a[3]:delete` left 3 elements instead of 2). Hand the
-                    // grep result the raw marker instead — Raku yields `Any`
-                    // there, not an alias into a slot that does not exist.
-                    if items.hole_at(i) {
-                        shared_cells.push(promoted[i].clone());
-                        continue;
-                    }
-                    let cell = match promoted[i].view() {
-                        ValueView::ContainerRef(_) => promoted[i].clone(),
-                        _ => Value::container_ref(crate::gc::Gc::new(
-                            crate::value::ContainerCell::new(promoted[i].clone()),
-                        )),
-                    };
-                    promoted[i] = cell.clone();
-                    shared_cells.push(cell);
+                // ADR-0058 step 3b: with the default `:v` adverb the callback
+                // runs when the Seq is CONSUMED, not here. The adverbed forms
+                // (`:k`/`:kv`/`:p`) need positional indices over the whole
+                // result, so they keep the eager path -- the same exemption
+                // they already take from `make_lazy_pipe`.
+                if matches!(grep_adverb, GrepAdverb::V) {
+                    return Ok(Value::seq_deferred(crate::value::SeqSource::MapGrep {
+                        items: std::sync::Arc::new(Vec::new()),
+                        func: args.first().cloned(),
+                        fatal: self.fatal_mode,
+                        mode: crate::value::MapGrepMode::GrepArray(target.clone()),
+                    }));
                 }
-                // Publish the promotion by mutating the source `ArrayData` IN
-                // PLACE rather than building a replacement and re-binding every
-                // name that pointed at the old one. Both are visible to every
-                // alias, but the old route reached them through
-                // `overwrite_array_bindings_by_identity`, which walks the
-                // CURRENT frame's `env` — so it only ever found the aliases
-                // that happened to be lexically visible right here, and needed
-                // a `pending_rw_writeback_sources` drain to keep the caller's
-                // local slot from going stale behind it. Writing through the
-                // `Gc` (ADR-0013 §7 made this sound at the primitive) reaches
-                // every alias by construction, needs no drain, and does not
-                // depend on which frame is running — which is what ADR-0058
-                // step 3b needs, since a deferred grep promotes at PULL time,
-                // in a frame where the source's names are long gone.
-                {
-                    let data = unsafe { crate::value::gc_contents_mut(&items) };
-                    let slots = data.items_mut();
-                    for (i, v) in promoted.into_iter().enumerate() {
-                        if i < slots.len() {
-                            slots[i] = v;
-                        }
-                    }
-                }
-                // Build the result array from the shared cells (default `:v`
-                // adverb). The `:k`/`:kv`/`:p` adverbs rebuild a fresh array in
-                // `transform_result` from `indices`, which drops the aliasing (a
-                // keys/pairs copy owns its values).
-                //
-                // The cells replace the result's items wholesale, so there must
-                // be exactly one per matched element or the result would be
-                // silently truncated -- which is what the old identity scan did
-                // whenever it failed to locate a slot.
-                let filtered = if !indices.is_empty()
-                    && let ValueView::Array(filtered_items, fkind) = filtered.view()
-                {
-                    debug_assert_eq!(
-                        shared_cells.len(),
-                        filtered_items.len(),
-                        "grep aliasing must cover every matched element"
-                    );
-                    if shared_cells.len() != filtered_items.len() {
-                        Value::array_with_kind(filtered_items.clone(), fkind)
-                    } else {
-                        let mut data = (**filtered_items).clone();
-                        *data.items_mut() = shared_cells;
-                        Value::array_with_kind(crate::gc::Gc::new(data), fkind)
-                    }
-                } else {
-                    filtered
-                };
-                grep_adverb.transform_result(filtered, &indices)
+                self.grep_over_array_promoting(items.clone(), args.first().cloned(), &grep_adverb)
             }
             ValueView::Range(..)
             | ValueView::RangeExcl(..)
@@ -417,6 +332,17 @@ impl Interpreter {
                     &target,
                     crate::runtime::utils::MAX_RANGE_EXPAND as usize,
                 );
+                // ADR-0058 step 3b: a range receiver has no source slots to
+                // promote, so it defers as a plain `Grep`. The adverbed forms
+                // stay eager -- they need indices over the whole result.
+                if matches!(grep_adverb, GrepAdverb::V) {
+                    return Ok(Value::seq_deferred(crate::value::SeqSource::MapGrep {
+                        items: std::sync::Arc::new(items),
+                        func: args.first().cloned(),
+                        fatal: self.fatal_mode,
+                        mode: crate::value::MapGrepMode::Grep,
+                    }));
+                }
                 self.eval_grep_with_adverb(args.first().cloned(), items, &grep_adverb)
             }
             ValueView::GenericRange { .. } => {
@@ -547,5 +473,124 @@ impl Interpreter {
             None => compute_grep_indices(&original_items, &filtered),
         };
         adverb.transform_result(filtered, &indices)
+    }
+
+    /// The `.grep` over a concrete array: run the callback, promote every
+    /// MATCHED source slot to a shared element cell (so a writeback loop
+    /// mutates through into the source), and build the result out of the same
+    /// cells.
+    ///
+    /// Split out of `dispatch_grep`'s `ValueView::Array` arm for ADR-0058 step
+    /// 3b: with the default `:v` adverb the arm is now DEFERRED, so this body
+    /// runs at the pull instead of at the `.grep` call. That is only sound
+    /// because the promotion is published by mutating the source `ArrayData` in
+    /// place rather than by re-binding its name in the current frame -- the
+    /// pull happens wherever the Seq is consumed, long after that frame is gone
+    /// (`news/2026-09/grep-promotion-is-published-in-place.md`).
+    pub(crate) fn grep_over_array_promoting(
+        &mut self,
+        items: crate::gc::Gc<crate::value::ArrayData>,
+        func: Option<Value>,
+        grep_adverb: &GrepAdverb,
+    ) -> Result<Value, RuntimeError> {
+        let (filtered, mutated_items, matched_indices) =
+            self.eval_grep_over_items_with_mutated(func, items.to_vec())?;
+        // Which source positions matched, so those slots can be shared
+        // with the result as first-class element containers. The grep
+        // loop reports them; they used to be re-derived here by scanning
+        // the source for a value `===` to each result element, which
+        // could not find a `Proxy` slot (the result holds the FETCHed
+        // value, the slot holds the Proxy). The miss then truncated the
+        // result below, because it is rebuilt from the located slots.
+        //
+        // `None` is a chunked grep (`grep -> $a, $b {...}`): no
+        // one-to-one element/slot mapping, so nothing is aliased.
+        let indices = matched_indices.unwrap_or_default();
+        // Promote each matched source slot to a shared `ContainerRef`
+        // cell and reference the SAME cells from the grep result. A
+        // writeback loop (`for @a.grep(...) { $_++ }` / `@a.grep(...)>>++`)
+        // then mutates THROUGH the cell into @a's slot via the ordinary
+        // element-cell write path — no GrepView side channel needed. A
+        // later `=` assignment (`my @g = @a.grep(...)`) decontainerizes the
+        // cells, so the named copy owns its values and never writes back.
+        let mut promoted = mutated_items;
+        let mut shared_cells: Vec<Value> = Vec::with_capacity(indices.len());
+        for &i in &indices {
+            // A `:delete`d (or never-assigned) slot has no element
+            // container to alias, and promoting it would *create* one:
+            // `ArrayData::hole_at` recognises a hole by the gap marker
+            // value (`Package("Any")`/the declared type) sitting in the
+            // slot AND its absence from `initialized`, so wrapping that
+            // marker in a `ContainerRef` makes the slot read as a live
+            // element while `initialized` still calls it empty. The two
+            // then disagree, and a later trailing-slot `:delete` stops
+            // truncating the array (`@a[2]:delete; @a.grep({True});
+            // @a[3]:delete` left 3 elements instead of 2). Hand the
+            // grep result the raw marker instead — Raku yields `Any`
+            // there, not an alias into a slot that does not exist.
+            if items.hole_at(i) {
+                shared_cells.push(promoted[i].clone());
+                continue;
+            }
+            let cell = match promoted[i].view() {
+                ValueView::ContainerRef(_) => promoted[i].clone(),
+                _ => Value::container_ref(crate::gc::Gc::new(crate::value::ContainerCell::new(
+                    promoted[i].clone(),
+                ))),
+            };
+            promoted[i] = cell.clone();
+            shared_cells.push(cell);
+        }
+        // Publish the promotion by mutating the source `ArrayData` IN
+        // PLACE rather than building a replacement and re-binding every
+        // name that pointed at the old one. Both are visible to every
+        // alias, but the old route reached them through
+        // `overwrite_array_bindings_by_identity`, which walks the
+        // CURRENT frame's `env` — so it only ever found the aliases
+        // that happened to be lexically visible right here, and needed
+        // a `pending_rw_writeback_sources` drain to keep the caller's
+        // local slot from going stale behind it. Writing through the
+        // `Gc` (ADR-0013 §7 made this sound at the primitive) reaches
+        // every alias by construction, needs no drain, and does not
+        // depend on which frame is running — which is what ADR-0058
+        // step 3b needs, since a deferred grep promotes at PULL time,
+        // in a frame where the source's names are long gone.
+        {
+            let data = unsafe { crate::value::gc_contents_mut(&items) };
+            let slots = data.items_mut();
+            for (i, v) in promoted.into_iter().enumerate() {
+                if i < slots.len() {
+                    slots[i] = v;
+                }
+            }
+        }
+        // Build the result array from the shared cells (default `:v`
+        // adverb). The `:k`/`:kv`/`:p` adverbs rebuild a fresh array in
+        // `transform_result` from `indices`, which drops the aliasing (a
+        // keys/pairs copy owns its values).
+        //
+        // The cells replace the result's items wholesale, so there must
+        // be exactly one per matched element or the result would be
+        // silently truncated -- which is what the old identity scan did
+        // whenever it failed to locate a slot.
+        let filtered = if !indices.is_empty()
+            && let ValueView::Array(filtered_items, fkind) = filtered.view()
+        {
+            debug_assert_eq!(
+                shared_cells.len(),
+                filtered_items.len(),
+                "grep aliasing must cover every matched element"
+            );
+            if shared_cells.len() != filtered_items.len() {
+                Value::array_with_kind(filtered_items.clone(), fkind)
+            } else {
+                let mut data = (**filtered_items).clone();
+                *data.items_mut() = shared_cells;
+                Value::array_with_kind(crate::gc::Gc::new(data), fkind)
+            }
+        } else {
+            filtered
+        };
+        grep_adverb.transform_result(filtered, &indices)
     }
 }

--- a/src/runtime/methods_collection_ops/mod.rs
+++ b/src/runtime/methods_collection_ops/mod.rs
@@ -39,7 +39,7 @@ pub(crate) fn compute_grep_indices(original_items: &[Value], filtered: &Value) -
 }
 
 /// Adverb mode for grep: controls what is returned.
-enum GrepAdverb {
+pub(crate) enum GrepAdverb {
     /// :v (default) — return matching values
     V,
     /// :k — return indices of matching elements

--- a/src/runtime/methods_dispatch_match2.rs
+++ b/src/runtime/methods_dispatch_match2.rs
@@ -632,7 +632,7 @@ impl Interpreter {
             items: std::sync::Arc::new(items),
             func: args.first().cloned(),
             fatal: self.fatal_mode,
-            rw_source: None,
+            mode: crate::value::MapGrepMode::Map,
         }))
     }
 

--- a/src/runtime/methods_mut_dispatch.rs
+++ b/src/runtime/methods_mut_dispatch.rs
@@ -2128,7 +2128,7 @@ impl Interpreter {
                 items: std::sync::Arc::new(items),
                 func: args.first().cloned(),
                 fatal: self.fatal_mode,
-                rw_source: Some(target.clone()),
+                mode: crate::value::MapGrepMode::MapRw(target.clone()),
             }));
         }
 

--- a/src/runtime/resolution_map_grep.rs
+++ b/src/runtime/resolution_map_grep.rs
@@ -834,7 +834,7 @@ impl Interpreter {
     /// list elements, implementing Raku's rw binding semantics for map.
     /// Uses the same VM fast path as `eval_map_over_items` but checks for
     /// `__mutsu_rw_map_topic__` after each iteration to capture mutations.
-    pub(super) fn eval_grep_over_items(
+    pub(crate) fn eval_grep_over_items(
         &mut self,
         func: Option<Value>,
         list_items: Vec<Value>,

--- a/src/runtime/types/binding_signature.rs
+++ b/src/runtime/types/binding_signature.rs
@@ -926,6 +926,13 @@ impl Interpreter {
                 }
                 let items = if remaining_positional.len() == 1 {
                     let single = unwrap_varref_value(remaining_positional[0].clone());
+                    // ADR-0058: a lone `.map`/`.grep` argument is a Seq whose
+                    // callback has not run, and the `Seq` arm below reads its
+                    // elements through pure code, which cannot pull -- so
+                    // `sub f(+@a) { @a }; f((1,2,3).map({$_}))` collected the
+                    // empty seed and answered `()`. Tag-probed, so this is one
+                    // relaxed check for every other argument shape.
+                    self.reify_map_grep_seq(&single)?;
                     match single.view() {
                         ValueView::Array(arr, kind) if !kind.is_itemized() => arr.to_vec(),
                         ValueView::Slip(arr) => arr.to_vec(),

--- a/src/runtime/types/signature.rs
+++ b/src/runtime/types/signature.rs
@@ -770,6 +770,13 @@ pub(in crate::runtime) fn bind_sub_signature_from_value(
     sub_params: &[ParamDef],
     value: &Value,
 ) -> Result<(), RuntimeError> {
+    // ADR-0058: a destructured argument can be a not-yet-run `.map`/`.grep`
+    // Seq (`fsort([$p?, *@r])` called as `fsort(@r.grep({...}))`, the recursive
+    // quicksort in `roast/S06-signature/unpack-array.t`), and
+    // `positional_values_from_unpack_target` reads its elements through pure
+    // code, which cannot pull -- so every recursion level unpacked the empty
+    // seed. Tag-probed, so every other argument shape pays one relaxed check.
+    interpreter.reify_map_grep_seq(value)?;
     let value = &interpreter.coerce_via_user_capture(value);
     let positional =
         drop_pairs_captured_as_named(value, positional_values_from_unpack_target(value));

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -269,7 +269,8 @@ pub use guards::{ArcRef, GcRef, RefGuard, WeakGcRef};
 pub(in crate::value) use nanbox::NanBox;
 use native_backing::NativeBacking;
 pub(crate) use seq_body::{
-    SeqBody, SeqSource, SeqTaken, SeqView, seq_method_consumes, seq_method_never_touches,
+    MapGrepMode, SeqBody, SeqSource, SeqTaken, SeqView, seq_method_consumes,
+    seq_method_never_touches,
 };
 
 /// A `'static` Nil for call sites that keep a `&Value` beyond one expression:

--- a/src/value/seq_body.rs
+++ b/src/value/seq_body.rs
@@ -22,6 +22,30 @@ use super::sync_cell::SyncUnsafeCell;
 use super::{RuntimeError, Value};
 use std::sync::{Arc, Mutex};
 
+/// Which deferred `.map`/`.grep` shape a [`SeqSource::MapGrep`] body carries.
+#[derive(Clone)]
+pub(crate) enum MapGrepMode {
+    /// `.map` over already-materialized items.
+    Map,
+    /// `@a.map({ $_++ })`: Raku rw-binds `$_` to the source element, so the
+    /// callback's writes have to reach the container. The pull runs
+    /// `eval_map_over_items_rw` and publishes the write-back by mutating this
+    /// container's `ArrayData` IN PLACE, which is frame-independent — the pull
+    /// happens wherever the Seq is consumed, long after the frame whose `env`
+    /// held the source's name is gone.
+    MapRw(Value),
+    /// `.grep` over already-materialized items (the listop form, and every
+    /// receiver that is not a concrete array).
+    Grep,
+    /// `@a.grep({...})` on a concrete array: the pull promotes every MATCHED
+    /// source slot to a shared element cell and builds the result out of the
+    /// same cells, so a writeback loop (`for @a.grep(...) { $_++ }`) mutates
+    /// through into the source. Machinery `.map` has no equivalent of; sound
+    /// at pull time for the same reason `MapRw` is
+    /// (`news/2026-09/grep-promotion-is-published-in-place.md`).
+    GrepArray(Value),
+}
+
 /// What a `Seq` still has to do to produce its elements.
 #[derive(Clone)]
 pub(crate) enum SeqSource {
@@ -51,17 +75,12 @@ pub(crate) enum SeqSource {
         /// Failure soft in rakudo — pinned by
         /// `t/try-fatal-does-not-retroactively-flag-closure-seq.t`).
         fatal: bool,
-        /// The `@`-sigil source container a `.map` was called on, when the
-        /// callback may rw-write its elements back (`@a.map({ $_++ })` —
-        /// Raku rw-binds `$_` to each source element). `None` for every other
-        /// `.map`/`.grep`. The pull runs `eval_map_over_items_rw` instead of
-        /// `eval_map_over_items` and publishes any write-back by mutating
-        /// this container's `ArrayData` IN PLACE, which is frame-independent
-        /// — the pull happens wherever the Seq is consumed, long after the
-        /// frame whose `env` held the source's name is gone (the same
-        /// reasoning that moved `grep`'s element promotion in place, ADR-0058
-        /// §9.2).
-        rw_source: Option<Value>,
+        /// Which of the four `.map`/`.grep` shapes this body defers, and the
+        /// source container the two container-aware ones write through. One
+        /// field rather than two `Option<Value>`s so the shapes stay mutually
+        /// exclusive by construction — a body cannot be both an rw map and a
+        /// promoting grep.
+        mode: MapGrepMode,
     },
     /// The source was handed away by a consuming method (`.iterator`,
     /// `.list`, ...). A later attempt to reify or take again throws
@@ -782,10 +801,7 @@ impl SeqBody {
             SeqSource::Iterator(v) => v.gc_trace(visit),
             SeqSource::IoLines { handle, .. } => handle.gc_trace(visit),
             SeqSource::MapGrep {
-                items,
-                func,
-                rw_source,
-                ..
+                items, func, mode, ..
             } => {
                 for v in items.iter() {
                     v.gc_trace(visit);
@@ -793,8 +809,9 @@ impl SeqBody {
                 if let Some(f) = func {
                     f.gc_trace(visit);
                 }
-                if let Some(src) = rw_source {
-                    src.gc_trace(visit);
+                match mode {
+                    MapGrepMode::MapRw(src) | MapGrepMode::GrepArray(src) => src.gc_trace(visit),
+                    MapGrepMode::Map | MapGrepMode::Grep => {}
                 }
             }
             SeqSource::Reified | SeqSource::Taken => {}

--- a/src/vm/vm_dispatch_helpers.rs
+++ b/src/vm/vm_dispatch_helpers.rs
@@ -473,6 +473,15 @@ impl Interpreter {
     /// For Package (type objects) and Instance values, checks if the class defines
     /// a custom Bool method and calls it. Falls back to Value::truthy() otherwise.
     pub(super) fn eval_truthy(&mut self, val: &Value) -> bool {
+        // ADR-0058: `Value::truthy` cannot pull, so it reports a not-yet-run
+        // `.map`/`.grep` Seq as TRUE rather than reading its still-empty seed
+        // (see the `is_map_grep_source` arm there). This IS the boolean
+        // chokepoint that arm defers to -- it has an `&mut Interpreter` -- so
+        // force the body here and let the element count decide. Without it an
+        // EMPTY result read as true: `@a.grep(* == 9) ?? 't' !! 'f'` answered
+        // `t` where rakudo answers `f`, and every `!...grep(...)` guard
+        // inverted. Tag-probed, so every other value pays one relaxed check.
+        let _ = self.reify_map_grep_seq(val);
         match val.view() {
             ValueView::Package(name) => {
                 let class_name = name.resolve().to_string();

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -2991,6 +2991,14 @@ impl Interpreter {
             OpCode::CoerceToList => {
                 self.sync_source_line(code, *ip);
                 let val = self.stack.pop().unwrap_or(Value::NIL);
+                // ADR-0058: `constant @x = (^5).grep(* > 2)` reaches here with a
+                // not-yet-run Seq, and the `Seq` arm below reads its elements
+                // through pure code -- so the constant was FROZEN as the empty
+                // seed and every later `@x[0]` / `@x.List` answered nothing
+                // (`roast/S04-declarations/constant.t` "constant @x caches
+                // Seq"). This op is the coercion that makes the constant's
+                // value, so it is where the body has to be run.
+                self.reify_map_grep_seq(&val)?;
                 let list_val = match val.view() {
                     // Explicit Arrays ([1,2,3]) are preserved as-is.
                     ValueView::Array(_, kind) if kind.is_real_array() => val,

--- a/src/vm/vm_helpers_lazy.rs
+++ b/src/vm/vm_helpers_lazy.rs
@@ -32,7 +32,7 @@ impl Interpreter {
                 items,
                 func,
                 fatal,
-                rw_source,
+                mode,
             } => {
                 // Same contract as `force_lazy_list_vm`: this force IS the
                 // effective call site for the callbacks it runs, so a
@@ -66,14 +66,32 @@ impl Interpreter {
                     }
                     _ => None,
                 });
-                let result = match rw_source {
+                let result = match mode {
+                    // ADR-0058 step 3b: `@a.grep({...})` promotes every matched
+                    // source slot to a shared element cell and builds its result
+                    // out of the same cells, so a writeback loop mutates through
+                    // into `@a`. That whole arm runs here now instead of at the
+                    // `.grep` call. See `MapGrepMode::GrepArray`.
+                    crate::value::MapGrepMode::GrepArray(source) => match source.view() {
+                        ValueView::Array(source_items, _) => self.grep_over_array_promoting(
+                            source_items.clone(),
+                            func.clone(),
+                            &crate::runtime::methods_collection_ops::GrepAdverb::V,
+                        ),
+                        _ => self.eval_grep_over_items(func.clone(), items.as_ref().clone()),
+                    },
+                    crate::value::MapGrepMode::Grep => {
+                        self.eval_grep_over_items(func.clone(), items.as_ref().clone())
+                    }
                     // `@a.map({ $_++ })`: Raku rw-binds `$_` to the source
                     // element, so the callback's writes have to reach `@a`.
-                    // See `SeqSource::MapGrep::rw_source`.
-                    Some(source) => {
+                    // See `MapGrepMode::MapRw`.
+                    crate::value::MapGrepMode::MapRw(source) => {
                         self.pull_rw_map(func.clone(), items.as_ref().clone(), source.clone())
                     }
-                    None => self.eval_map_over_items(func.clone(), items.as_ref().clone()),
+                    crate::value::MapGrepMode::Map => {
+                        self.eval_map_over_items(func.clone(), items.as_ref().clone())
+                    }
                 };
                 self.fatal_mode = saved_fatal;
                 self.reconcile_caller_after_lazy_force(caller_code);

--- a/src/vm/vm_var_index_ops.rs
+++ b/src/vm/vm_var_index_ops.rs
@@ -442,6 +442,12 @@ impl Interpreter {
         // never leaks onto a later, unrelated subscript.
         let core_subscript_call = std::mem::take(&mut self.skip_postcircumfix_overload);
         let mut index = self.stack.pop().unwrap();
+        // ADR-0058: a slice index can be a not-yet-run `.map`/`.grep` Seq
+        // (`@f[(^$n).grep({...})]`, Text::CSV's fragment selector), and every
+        // reader below takes its elements through pure code -- so the slice
+        // addressed NO slots and answered `()`. Tag-probed, so every other
+        // subscript shape pays one relaxed check.
+        self.reify_map_grep_seq(&index)?;
         // An *itemized* list/Range used as a subscript (`@a[$(7,8,9)]`,
         // `@a[my $ = ^2]`) is a SINGLE subscript, not a slice: itemization makes
         // it one item. (A bare `@a[7,8,9]` / `@a[^2]` is still a slice.)

--- a/t/grep-defers.t
+++ b/t/grep-defers.t
@@ -1,0 +1,59 @@
+use Test;
+
+# ADR-0058 step 3b: `.grep` produces a deferred `Seq`, exactly as `.map` does
+# since steps 2/3a/3c. All four spellings ran their callback at the CALL before
+# this; rakudo runs none of them until the Seq is consumed.
+#
+# `grep` needs something `map` has no equivalent of: on a concrete array it
+# promotes every MATCHED source slot to a shared element cell and builds the
+# result out of the same cells, so `for @a.grep(...) { $_++ }` mutates through
+# into `@a`. Deferring moves that promotion to the pull, in a frame where the
+# source's name is gone -- which only works because the promotion is published
+# by mutating the source `ArrayData` in place.
+
+plan 11;
+
+{
+    my @a = 1, 2, 3;
+    my $log = '';
+    my $s1 = @a.grep({ $log ~= 'A'; $_ > 1 });
+    my $s2 = @a.List.grep({ $log ~= 'B'; $_ > 1 });
+    my $s3 = (1, 2, 3).grep({ $log ~= 'C'; $_ > 1 });
+    my $s4 = grep({ $log ~= 'D'; $_ > 1 }, @a);
+    is $log, '', 'no callback has run at any of the four `.grep` calls';
+
+    is $s1.List, (2, 3), 'an `@` receiver filters at the pull';
+    is $s2.List, (2, 3), '... a `.List` receiver too';
+    is $s3.List, (2, 3), '... a literal list too';
+    is $s4.List, (2, 3), '... and the listop spelling too';
+    is $log, 'AAABBBCCCDDD', 'every callback ran at its pull, in order';
+}
+
+is (1, 2, 3).grep({ $_ > 1 }).^name, 'Seq', '.grep answers a Seq';
+
+# The write-back the promotion exists for, at both spellings.
+{
+    my @a = 1, 2, 3;
+    for @a.grep({ $_ > 1 }) { $_++ }
+    is @a.raku, '[1, 3, 4]', 'a writeback loop mutates through into the source';
+}
+
+{
+    my @a = 1, 2, 3;
+    grep({ $_ = 5 }, @a).eager;
+    is @a.raku, '[5, 5, 5]', '... and the listop spelling writes back through `$_` too';
+}
+
+{
+    my @a = 1, 2, 3;
+    my @copy = @a.grep({ $_ > 1 });
+    @copy[0] = 99;
+    is @a.raku, '[1, 2, 3]', 'an `=` copy of the result decontainerizes';
+}
+
+# The adverbed forms need positional indices over the whole result, so they
+# keep the eager path -- the same exemption they already take elsewhere.
+{
+    my @a = 1, 2, 3;
+    is @a.grep({ $_ > 1 }, :k).List, (1, 2), ':k still answers the matched indices';
+}


### PR DESCRIPTION
`.map` has answered a not-yet-run `Seq` since ADR-0058 steps 2/3a/3c. `.grep` still ran its callback at the call, in **all four spellings**, so the two halves of the same operation disagreed about when the callback runs.

| | at the `.grep` calls | at the pulls |
|---|---|---|
| rakudo | `\|\|\|\|` | — |
| before | `AAA\|BBB\|CCC\|DDD\|` | — |
| after | `\|\|\|\|` | `AAABBBCCCDDD` |

Every entry point defers with the default `:v` adverb — the concrete-array arm, the range arm, the generic arm and the listop. `:k`/`:kv`/`:p` keep the eager path (they need positional indices over the whole result), the same exemption they already take from `make_lazy_pipe`.

All four of **§9.2's recorded rows** now match rakudo:

| §9.2 row | before | after = rakudo |
|---|---|---|
| `(1..3).grep` side-effect order | `RRRT` | `TRRR` |
| the listop spelling of the same | `RRRT` | `TRRR` |
| `grep({ $_ = 5 }, @a).eager` | `[1, 2, 3]` | `[5, 5, 5]` |
| `for @a.grep(…) { $_++ }` | `[1, 3, 4]` | unchanged |

## Two things the implementation turned up

**`builtin_grep` had no `source_var` branch at all.** The third row was broken *before* deferral and would have stayed broken after it — unlike `builtin_map` it never consulted `pending_call_arg_sources`, so the listop never wrote back through `$_`.

**`SeqSource::MapGrep`'s two `Option<Value>` fields were not mutually exclusive.** `rw_source` (step 3c) and the `grep_source` this step wanted describe four shapes that cannot co-occur, so they collapse into one `MapGrepMode` enum (`Map` / `MapRw` / `Grep` / `GrepArray`); the pull's dispatch is a total match rather than a tuple of `Option`s.

Deferring the promoting arm is only sound because grep's element promotion is published by **mutating the source `ArrayData` in place** rather than re-binding its name in the current frame (#7481) — the pull happens wherever the Seq is consumed, long after that frame is gone.

## What the gates found — deferring the sibling is the detector

The diff is small. The gates turned up **six** defects, and **five were already live on `main`**: holes in `.map`'s deferral that `grep` had been masking simply by still being eager. Every one is the same shape — a consumer that reads a `Seq`'s elements through pure code, which cannot pull, and so sees ADR-0034's empty seed.

| consumer | symptom | broken for `.map` too? |
|---|---|---|
| `+@a` slurpy binder | `sub f(+@a) { @a }; f((1,2,3).map({$_}))` answered `()` | **yes** |
| boolean context | an EMPTY result read as TRUE, inverting every `!…grep(…)` guard | **yes** |
| `[$p?, *@r]` destructuring | a recursive quicksort unpacked the empty seed at every level | **yes** |
| `constant @x = …` | the constant was frozen as the empty seed | **yes** |
| slice index `@f[SEQ]` | the slice addressed no slots | **yes** |
| itemized array through the promoting arm | `grep({…}, $(1,2,3))` grepped its elements | this step's own |

The boolean one is worth naming twice: `Value::truthy`'s `is_map_grep_source` arm carried a comment promising that *"the VM forces the body at every boolean chokepoint it can reach with an `&mut Interpreter`"*. It did not — `eval_truthy` had no such force. **The comment documented an invariant nobody had implemented.**

Recorded as **ADR-0058 §9.5**: a green gate on the step that deferred is not evidence its consumers are covered, because a still-eager sibling keeps handing out reified Seqs that hide the same holes. Step 4 should expect the same.

Two of the six surfaced **only** in the bundled-library battery gate (`Text::CSV` 78_fragment / 90_csv) with `make test` and a full `make roast` both green — the fourth time in one day that gate caught what the other two missed.

## Gates

| gate | result |
|---|---|
| `make test` | **PASS** — 3799 files / 40048 tests |
| full local `make roast` | **PASS** — 1436 files / 218962 tests |
| `scripts/battery-testsuite.sh` (run alone, release) | **GATE PASSED** — 289/312 |
| `cargo fmt` / `clippy --all-targets -D warnings` | clean |

Pin: `t/grep-defers.t` (11 rows, green under **rakudo** as well as mutsu).

Step 4 — retiring `create_lazy_map_list` and the `body_contains_return` predicate — is what is left of ADR-0058.

🤖 Generated with [Claude Code](https://claude.com/claude-code)