### PR TITLE
fix(dispatch): propagate where-clause exceptions, check a defaulted param's where, seed a typed element's ++

### DIFF
--- a/src/runtime/dispatch_candidates.rs
+++ b/src/runtime/dispatch_candidates.rs
@@ -7,6 +7,19 @@ use crate::value::ValueView;
 /// model).  Any real ancestor scores below this.
 pub(super) const UNRELATED_DISTANCE: usize = 500;
 
+/// The narrowness key a multi candidate is ranked by (see
+/// `Interpreter::candidate_rank_key`): specificity rank, type-hierarchy
+/// distance, whether it declares any named parameter, optional-positional
+/// count, required-named count, declaration order.
+type CandidateRankKey = (
+    (usize, usize, usize, usize, usize, usize),
+    usize,
+    usize,
+    usize,
+    usize,
+    u64,
+);
+
 /// The type a coercion parameter accepts, i.e. the type it is as *wide* as.
 /// `Str()` is short for `Str(Any)`, so it accepts anything.
 fn coercion_accepted_constraint(constraint: &str) -> Option<&str> {
@@ -63,6 +76,34 @@ impl Interpreter {
         err
     }
 
+    /// The narrowness key a multi candidate is ranked by, in
+    /// `candidate_rank_cmp` order: specificity rank, type-hierarchy distance,
+    /// whether it declares any named parameter, optional-positional count,
+    /// required-named count, declaration order.
+    fn candidate_rank_key(&mut self, def: &Arc<FunctionDef>, args: &[Value]) -> CandidateRankKey {
+        let rank = self.candidate_specificity_rank_for_args(def, args);
+        let dist = self.candidate_type_distance(args, def);
+        let has_named = usize::from(Self::candidate_declares_named(def));
+        let opt = Self::candidate_optional_positional_count(def);
+        let req_named = Self::candidate_required_named_count(def);
+        (rank, dist, has_named, opt, req_named, def.decl_order)
+    }
+
+    /// Order two [`Self::candidate_rank_key`]s narrowest-first: higher rank
+    /// first, then lower distance, then a candidate that declares nameds over
+    /// one that declares none, then fewer optional positionals (a required
+    /// param is narrower than an optional one), then higher required named,
+    /// and finally — for candidates tied on all of that — the one declared
+    /// first, which is what Rakudo runs.
+    fn candidate_rank_cmp(a: CandidateRankKey, b: CandidateRankKey) -> std::cmp::Ordering {
+        b.0.cmp(&a.0)
+            .then(a.1.cmp(&b.1))
+            .then(b.2.cmp(&a.2))
+            .then(a.3.cmp(&b.3))
+            .then(b.4.cmp(&a.4))
+            .then(a.5.cmp(&b.5))
+    }
+
     pub(super) fn choose_best_matching_candidate(
         &mut self,
         name: &str,
@@ -71,6 +112,17 @@ impl Interpreter {
     ) -> Option<Arc<FunctionDef>> {
         let mut matches = Vec::new();
         let mut seen = std::collections::HashSet::new();
+        // The first candidate whose `where` constraint THREW, together with
+        // the exception. Raku walks the candidates narrowest-first and stops at
+        // the first that binds, so such an exception escapes only when that
+        // candidate is one raku would actually have reached — i.e. when it is
+        // not out-ranked by a candidate that did match. Deciding that needs the
+        // winner, so the exception is parked here until the ranking below.
+        let mut threw: Option<(Arc<FunctionDef>, RuntimeError)> = None;
+        // A `where` exception recorded OUTSIDE this dispatch (by a method match
+        // earlier in the same instruction, say) must not be mistaken for one of
+        // these candidates': park it and put it back below.
+        let outer_where_exception = self.pending_where_exception.take();
         for (_, def) in candidates {
             // For auto-param subs ($^a, $^b) with empty param_defs but
             // non-empty params, check arity against params.len() since
@@ -89,6 +141,14 @@ impl Interpreter {
             } else {
                 self.args_match_param_types(args, &def.param_defs)
             };
+            if let Some(e) = self.take_where_exception() {
+                if threw.is_none() {
+                    threw = Some((def.clone(), e));
+                }
+                // A candidate whose `where` died did not match; whether the
+                // exception escapes is settled after the winner is known.
+                continue;
+            }
             if type_ok {
                 let fingerprint = def.body_fingerprint();
                 if !seen.insert(fingerprint) {
@@ -97,6 +157,45 @@ impl Interpreter {
                 matches.push(def);
             }
         }
+        if let Some((thrower, e)) = threw {
+            // No candidate matched at all, or the thrower sorts at least as
+            // narrow as (or was declared before) the best match: raku would
+            // have reached the `where` and died there, so re-raise.
+            let reached = match matches.first() {
+                None => true,
+                Some(best) => {
+                    // Compare narrowness with the `where`-constraint component
+                    // ZEROED on both sides. Rakudo orders candidates by their
+                    // NOMINAL types first and only lets a `where` break a tie
+                    // between equally-nominal candidates, so a nominally
+                    // narrower candidate that matched (`multi bar(| (A $x))`)
+                    // is reached before a `where`-only one
+                    // (`multi bar(| where { ... })`) and that `where` never
+                    // runs. mutsu's own ranking weighs `where` above the
+                    // nominal shape, which is fine for picking a winner among
+                    // candidates that all matched but would wrongly claim the
+                    // thrower came first here.
+                    let mut a = self.candidate_rank_key(&thrower, args);
+                    let mut b = self.candidate_rank_key(best, args);
+                    a.0.1 = 0;
+                    b.0.1 = 0;
+                    Self::candidate_rank_cmp(a, b) != std::cmp::Ordering::Greater
+                }
+            };
+            if reached {
+                // Signal it the way an ambiguous dispatch is signalled: `None`
+                // plus a pending dispatch error, which every caller of the
+                // resolver already re-raises. A plain `pending_where_exception`
+                // stash would not survive the fallback path's deliberate
+                // re-resolve (it clears the pending error and resolves again),
+                // and the leftover would then be attributed to whichever
+                // candidate the second scan looked at first.
+                self.set_pending_dispatch_error(e);
+                self.pending_where_exception = outer_where_exception;
+                return None;
+            }
+        }
+        self.pending_where_exception = outer_where_exception;
         if matches.len() <= 1 {
             return matches.into_iter().next();
         }
@@ -112,30 +211,9 @@ impl Interpreter {
             let mut ranked: Vec<(usize, _)> = matches
                 .iter()
                 .enumerate()
-                .map(|(i, def)| {
-                    let rank = self.candidate_specificity_rank_for_args(def, args);
-                    let dist = self.candidate_type_distance(args, def);
-                    let has_named = usize::from(Self::candidate_declares_named(def));
-                    let opt = Self::candidate_optional_positional_count(def);
-                    let req_named = Self::candidate_required_named_count(def);
-                    (i, (rank, dist, has_named, opt, req_named, def.decl_order))
-                })
+                .map(|(i, def)| (i, self.candidate_rank_key(def, args)))
                 .collect();
-            ranked.sort_by(|a, b| {
-                // Higher rank first, then lower distance, then a candidate that
-                // declares nameds over one that declares none, then fewer
-                // optional positionals (a required param is narrower than an
-                // optional one), then higher required named, and finally — for
-                // candidates that are tied on all of that — the one declared
-                // first, which is what Rakudo runs.
-                b.1.0
-                    .cmp(&a.1.0)
-                    .then(a.1.1.cmp(&b.1.1))
-                    .then(b.1.2.cmp(&a.1.2))
-                    .then(a.1.3.cmp(&b.1.3))
-                    .then(b.1.4.cmp(&a.1.4))
-                    .then(a.1.5.cmp(&b.1.5))
-            });
+            ranked.sort_by(|a, b| Self::candidate_rank_cmp(a.1, b.1));
             let sorted_matches: Vec<Arc<FunctionDef>> =
                 ranked.iter().map(|(i, _)| matches[*i].clone()).collect();
             matches = sorted_matches;

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1757,6 +1757,17 @@ pub struct Interpreter {
     /// `X::Attribute::NoPackage`.
     pub(crate) defining_class: Option<String>,
     pending_call_arg_sources: Option<Vec<Option<String>>>,
+    /// An exception thrown while *evaluating a `where` constraint* during
+    /// candidate matching. Raku propagates such an exception out of the whole
+    /// dispatch (the `where` block is ordinary code); mutsu's matchers are
+    /// `bool`-returning predicates, so they cannot return it directly. They
+    /// stash it here instead and the dispatch funnels
+    /// (`resolve_function_with_types`, `choose_best_matching_candidate`) stop
+    /// scanning; `Interpreter::exec_one` is the backstop that turns a stash no
+    /// funnel drained into the error it always was, so it can never be silently
+    /// dropped. Only genuine exceptions are recorded -- a control-flow signal
+    /// (`return`/`next`/...) is not an exception and still reads as "no match".
+    pub(crate) pending_where_exception: Option<Box<RuntimeError>>,
     /// ADR-0067 slice 3b: the caller's container for the invocant of the method
     /// call currently being dispatched, staged by
     /// `Interpreter::arm_raw_invocant_arrival` and consumed by whichever of the

--- a/src/runtime/resolution_method.rs
+++ b/src/runtime/resolution_method.rs
@@ -57,6 +57,17 @@ impl Interpreter {
                 }
             }
         }
+        // Candidate matching runs user code (a `where` constraint, and the
+        // default expression a `where` is checked against) before the method
+        // call installs its own environment, so `self` -- and hence `$.attr` --
+        // has to be reachable from here too. Without it a signature like
+        // `multi method message(Str:D $c where { $_ eq 'INTM' } = $.classifier)`
+        // could not be told apart from its sibling and the first candidate
+        // declared always won. The whole block runs inside the
+        // `saved_env`/restore window, so this binding is scoped to the match.
+        if let Some(inv) = invocant {
+            self.env.insert("self".to_string(), inv.clone());
+        }
         for pd in &def.param_defs {
             if !(pd.is_invocant || pd.traits.iter().any(|t| t == "invocant")) {
                 continue;

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -2864,6 +2864,7 @@ impl Interpreter {
             build_attr_writes: std::cell::RefCell::new(Vec::new()),
             defining_class: None,
             pending_call_arg_sources: None,
+            pending_where_exception: None,
             pending_raw_invocant: None,
             pending_call_topic_bare: false,
             pending_call_topic_source: None,

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -594,6 +594,7 @@ impl Interpreter {
             build_attr_writes: std::cell::RefCell::new(Vec::new()),
             defining_class: None,
             pending_call_arg_sources: None,
+            pending_where_exception: None,
             pending_raw_invocant: None,
             pending_call_topic_bare: false,
             pending_call_topic_source: None,

--- a/src/runtime/types/args_matching.rs
+++ b/src/runtime/types/args_matching.rs
@@ -2,6 +2,43 @@ use super::*;
 use crate::value::ValueView;
 
 impl Interpreter {
+    /// Record an exception thrown while evaluating a `where` constraint during
+    /// candidate matching, and report the constraint as unmatched. Raku
+    /// propagates such an exception out of the whole dispatch instead of
+    /// treating the candidate as a non-match, so the recorded error is
+    /// re-raised by the dispatch funnels (and, as a backstop, by `exec_one`).
+    /// A control-flow signal (`return`/`next`/`last`/...) is not an exception
+    /// and keeps the old "does not match" reading.
+    pub(crate) fn note_where_exception(&mut self, e: RuntimeError) -> bool {
+        if e.control.is_none() && self.pending_where_exception.is_none() {
+            self.pending_where_exception = Some(Box::new(e));
+        }
+        false
+    }
+
+    /// Truthiness of a `where` constraint body's result, recording an
+    /// exception rather than swallowing it.
+    pub(crate) fn where_truthy(&mut self, r: Result<Value, RuntimeError>) -> bool {
+        match r {
+            Ok(v) => v.truthy(),
+            Err(e) => self.note_where_exception(e),
+        }
+    }
+
+    /// As [`Self::where_truthy`], for a non-block `where` constraint, whose
+    /// value is smart-matched against the candidate argument.
+    pub(crate) fn where_smartmatch(&mut self, arg: &Value, r: Result<Value, RuntimeError>) -> bool {
+        match r {
+            Ok(v) => self.smart_match(arg, &v),
+            Err(e) => self.note_where_exception(e),
+        }
+    }
+
+    /// Drain a `where`-constraint exception recorded during candidate matching.
+    pub(crate) fn take_where_exception(&mut self) -> Option<RuntimeError> {
+        self.pending_where_exception.take().map(|e| *e)
+    }
+
     /// Verify that every `is rw` positional parameter in a subsignature is
     /// matched by a writable variable argument.  `args` is the full positional
     /// argument list of the enclosing call and `start` is the index of the
@@ -493,10 +530,26 @@ impl Interpreter {
                         return false;
                     }
                 }
+                // An unsupplied parameter that HAS a default is checked
+                // against the *default value* -- raku evaluates the default and
+                // then applies the `where`, which is how a multi can select a
+                // candidate purely on its defaulted parameter
+                // (`multi method message(Str:D $c where { $_ eq 'INTM' } = $.classifier)`).
+                // Skipping the check made every such candidate match, so the
+                // first one declared always won.
+                let where_default =
+                    if !arg_was_supplied && let Some(default_expr) = pd.default.as_ref() {
+                        self.eval_block_value(&[Stmt::Expr(default_expr.clone())])
+                            .ok()
+                    } else {
+                        None
+                    };
                 if let Some(where_expr) = &pd.where_constraint
-                    && (arg_was_supplied || !(pd.default.is_some() || pd.optional_marker))
+                    && (arg_was_supplied
+                        || where_default.is_some()
+                        || !(pd.default.is_some() || pd.optional_marker))
                 {
-                    let Some(arg) = arg_for_checks.as_ref() else {
+                    let Some(arg) = where_default.as_ref().or(arg_for_checks.as_ref()) else {
                         return false;
                     };
                     let saved = self.env.clone();
@@ -526,24 +579,25 @@ impl Interpreter {
                                 self.env.insert(key.clone(), arg.clone());
                                 self.mark_readonly(key);
                             }
-                            let r = self
-                                .eval_block_value(body)
-                                .map(|v| v.truthy())
-                                .unwrap_or(false);
+                            let r = {
+                                let ev = self.eval_block_value(body);
+                                self.where_truthy(ev)
+                            };
                             for key in &ph_keys {
                                 self.unmark_readonly(key);
                             }
                             r
                         }
-                        Expr::MethodCall { target, .. } if matches!(target.as_ref(), Expr::Var(name) if name == "_") => {
-                            self.eval_block_value(&[Stmt::Expr(where_expr.as_ref().clone())])
-                                .map(|v| v.truthy())
-                                .unwrap_or(false)
+                        Expr::MethodCall { target, .. } if matches!(target.as_ref(), Expr::Var(name) if name == "_") =>
+                        {
+                            let ev =
+                                self.eval_block_value(&[Stmt::Expr(where_expr.as_ref().clone())]);
+                            self.where_truthy(ev)
                         }
-                        expr => self
-                            .eval_block_value(&[Stmt::Expr(expr.clone())])
-                            .map(|v| self.smart_match(arg, &v))
-                            .unwrap_or(false),
+                        expr => {
+                            let ev = self.eval_block_value(&[Stmt::Expr(expr.clone())]);
+                            self.where_smartmatch(arg, ev)
+                        }
                     };
                     // Keep the where clause's dynamic-variable side effects
                     // across the bindings rollback (A01-limits/misc.t).
@@ -727,19 +781,20 @@ impl Interpreter {
                         self.env.insert(pd.name.clone(), val.clone());
                     }
                     let ok = match where_expr.as_ref() {
-                        Expr::AnonSub { body, .. } => self
-                            .eval_block_value(body)
-                            .map(|v| v.truthy())
-                            .unwrap_or(false),
-                        Expr::MethodCall { target, .. } if matches!(target.as_ref(), Expr::Var(name) if name == "_") => {
-                            self.eval_block_value(&[Stmt::Expr(where_expr.as_ref().clone())])
-                                .map(|v| v.truthy())
-                                .unwrap_or(false)
+                        Expr::AnonSub { body, .. } => {
+                            let ev = self.eval_block_value(body);
+                            self.where_truthy(ev)
                         }
-                        expr => self
-                            .eval_block_value(&[Stmt::Expr(expr.clone())])
-                            .map(|v| self.smart_match(&val, &v))
-                            .unwrap_or(false),
+                        Expr::MethodCall { target, .. } if matches!(target.as_ref(), Expr::Var(name) if name == "_") =>
+                        {
+                            let ev =
+                                self.eval_block_value(&[Stmt::Expr(where_expr.as_ref().clone())]);
+                            self.where_truthy(ev)
+                        }
+                        expr => {
+                            let ev = self.eval_block_value(&[Stmt::Expr(expr.clone())]);
+                            self.where_smartmatch(&val, ev)
+                        }
                     };
                     // Keep the where clause's dynamic-variable side effects
                     // across the bindings rollback (A01-limits/misc.t).

--- a/src/runtime/types/signature.rs
+++ b/src/runtime/types/signature.rs
@@ -422,25 +422,24 @@ fn where_constraint_matches(
                 interpreter.env.insert(key.clone(), candidate.clone());
                 interpreter.mark_readonly(key);
             }
-            let r = interpreter
-                .eval_block_value(body)
-                .map(|v| v.truthy())
-                .unwrap_or(false);
+            let r = {
+                let ev = interpreter.eval_block_value(body);
+                interpreter.where_truthy(ev)
+            };
             for key in &ph_keys {
                 interpreter.unmark_readonly(key);
             }
             r
         }
-        Expr::MethodCall { target, .. } if matches!(target.as_ref(), Expr::Var(name) if name == "_") => {
-            interpreter
-                .eval_block_value(&[Stmt::Expr(where_expr.clone())])
-                .map(|v| v.truthy())
-                .unwrap_or(false)
+        Expr::MethodCall { target, .. } if matches!(target.as_ref(), Expr::Var(name) if name == "_") =>
+        {
+            let ev = interpreter.eval_block_value(&[Stmt::Expr(where_expr.clone())]);
+            interpreter.where_truthy(ev)
         }
-        expr => interpreter
-            .eval_block_value(&[Stmt::Expr(expr.clone())])
-            .map(|v| interpreter.smart_match(candidate, &v))
-            .unwrap_or(false),
+        expr => {
+            let ev = interpreter.eval_block_value(&[Stmt::Expr(expr.clone())]);
+            interpreter.where_smartmatch(candidate, ev)
+        }
     };
     interpreter.env = saved;
     ok

--- a/src/vm/vm_call_func_ops.rs
+++ b/src/vm/vm_call_func_ops.rs
@@ -1509,6 +1509,13 @@ impl Interpreter {
                 None
             };
             self.set_pending_call_arg_sources(None);
+            // A `where` constraint that threw while candidate matching ran is
+            // an exception of the *call*, not a "candidate does not match":
+            // raku propagates it out of the dispatch, so no candidate body may
+            // run. Raise it here, before the winner is invoked.
+            if let Some(e) = self.take_where_exception() {
+                return Err(e);
+            }
             if let Some(cf) = compiled {
                 // Try positional light call path first (ultra-fast, no env clone).
                 // Skip for multi functions since the cache doesn't differentiate by arg types.

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -134,6 +134,17 @@ impl Interpreter {
         compiled_fns: &CompiledFns,
     ) -> Result<(), RuntimeError> {
         let mut result = self.exec_one_dispatch(code, ip, compiled_fns);
+        // Backstop for a `where`-constraint exception recorded during candidate
+        // matching (`pending_where_exception`). The dispatch funnels raise it
+        // before invoking a winner; this catches any matching path that has no
+        // funnel of its own, so the exception can never be silently dropped.
+        // It happened *before* whatever this instruction went on to do, so it
+        // wins over a later error too.
+        if self.pending_where_exception.is_some()
+            && let Some(e) = self.take_where_exception()
+        {
+            result = Err(e);
+        }
         // Only genuine runtime errors get a backtrace here: control-flow
         // signals (return/next/warn/fail/...) and parse errors (which carry
         // their own line/column and render as ===SORRY!===) are excluded.

--- a/src/vm/vm_value_helpers.rs
+++ b/src/vm/vm_value_helpers.rs
@@ -190,6 +190,26 @@ impl Interpreter {
         value
     }
 
+    /// The value an undefined `++`/`--` target starts from, given the declared
+    /// type of the container it lives in. Raku's `postfix:<++>` is `.=succ` on
+    /// the *current* value, and for an uninitialized slot that value is the
+    /// declared type's own zero — `Bool` increments to `True`, not to `Int` 1.
+    /// A definiteness/coercion smiley (`Bool:D`) names the same base type, so
+    /// it is stripped before the lookup.
+    pub(crate) fn incdec_seed_for_constraint(constraint: &str) -> Value {
+        let base = match constraint.find(':') {
+            Some(i) if matches!(&constraint[i..], ":D" | ":U" | ":_") => &constraint[..i],
+            _ => constraint,
+        };
+        match base {
+            "Num" | "num" => Value::num(0.0),
+            "Rat" => crate::value::make_rat(0, 1),
+            "Complex" => Value::complex(0.0, 0.0),
+            "Bool" => Value::FALSE,
+            _ => Value::int(0),
+        }
+    }
+
     /// Like normalize_incdec_source, but also checks the variable's type
     /// constraint when the value is Nil. This ensures that e.g. `my Num $v; ++$v`
     /// starts from Num(0.0) rather than Int(0).
@@ -200,13 +220,7 @@ impl Interpreter {
     ) -> Value {
         if value.is_nil() {
             if let Some(tc) = loan_env!(self, var_type_constraint(var_name)) {
-                match tc.as_str() {
-                    "Num" | "num" => Value::num(0.0),
-                    "Rat" => crate::value::make_rat(0, 1),
-                    "Complex" => Value::complex(0.0, 0.0),
-                    "Bool" => Value::FALSE,
-                    _ => Value::int(0),
-                }
+                Self::incdec_seed_for_constraint(&tc)
             } else {
                 Value::int(0)
             }

--- a/src/vm/vm_var_assign_post_incdec.rs
+++ b/src/vm/vm_var_assign_post_incdec.rs
@@ -483,9 +483,46 @@ impl Interpreter {
             declared_constraint_incdec.as_deref(),
             Some("SetHash" | "BagHash" | "MixHash")
         );
+        // An object hash (`my %h{Array:D}`, `has Bool:D %!seen{Array:D}`) is
+        // `.WHICH`-keyed exactly like a QuantHash: an element `++` has to select
+        // the same slot an `=` store does, and has to record the key *object* in
+        // `original_keys` so `.keys`/`.kv`/`.raku` report the object rather than
+        // its stringification. Keying it by the display string made `%h{$@p}++`
+        // and `%h{$@p} = 1` land in two different buckets and made every
+        // `.keys` read hand back a `Str`.
+        // The predicate is deliberately the SAME one the element-assign path
+        // uses (`vm_var_assign_index_named.rs`'s `is_object_hash`): the
+        // declared key constraint of this NAME. Deriving it from the
+        // container's own `key_type` instead would make `++` key by `.WHICH`
+        // in contexts where `=` still keys by the display string (a hash
+        // destructured into an anonymous `%a is raw` parameter, say), and the
+        // two would land in different buckets.
+        let object_hash_key_type: Option<String> = if name.starts_with('%') {
+            loan_env!(self, var_hash_key_constraint(&name))
+        } else {
+            None
+        };
+        // Declared *element* type of the container being subscripted, used to
+        // seed an absent element for `++`/`--` (see below). The value carried by
+        // the container wins over the name-keyed declaration so it also works
+        // for an attribute or a parameter.
+        let element_constraint_incdec: Option<String> = container
+            .as_ref()
+            .and_then(|c| self.container_type_metadata(c))
+            .map(|info| info.value_type)
+            .filter(|t| !t.is_empty() && t != "Any" && t != "Mu")
+            .or_else(|| {
+                if name.starts_with('@') || name.starts_with('%') {
+                    declared_constraint_incdec.clone()
+                } else {
+                    None
+                }
+            });
         let (key, quanthash_elem) = if quanthash_target {
             let (k, e) = crate::runtime::utils::quanthash_elem_entry(&idx_val);
             (k, Some(e))
+        } else if object_hash_key_type.is_some() {
+            (self.which_key(&idx_val), None)
         } else {
             (idx_val.to_string_value(), None)
         };
@@ -757,7 +794,16 @@ impl Interpreter {
                     .or_else(|| self.var_default(&name).cloned());
                 match def {
                     Some(d) if !d.is_nil() => d,
-                    _ => Value::int(0),
+                    // No `is default`: an absent element starts from its
+                    // container's declared *element* type's zero, the same way
+                    // `normalize_incdec_source_with_type` seeds a scalar. A
+                    // `Bool`-valued hash/array increments to `True`, so seeding
+                    // it with `Int` 0 both produced the wrong value and failed
+                    // the element type check (`my Bool:D %h; %h<a>++`).
+                    _ => match element_constraint_incdec.as_deref() {
+                        Some(c) => Self::incdec_seed_for_constraint(c),
+                        None => Value::int(0),
+                    },
                 }
             } else {
                 current.clone()
@@ -850,19 +896,22 @@ impl Interpreter {
                 // Container identity (§3): no sigil carve-out — a shared hash
                 // mutates through the backing node for every holder.
                 let use_inplace = crate::gc::Gc::strong_count_of(h) > 1;
-                if use_inplace {
+                let data: &mut crate::value::HashData = if use_inplace {
                     // SAFETY: aliased in-place mutation of a shared hash
                     // (strong_count > 1, the shared-cell case); mirrors the
                     // array arm's `gc_contents_mut` usage.
-                    let h = unsafe { crate::value::gc_contents_mut(h) };
-                    Value::hash_insert_through(&mut h.map, key.clone(), new_val.clone());
+                    unsafe { crate::value::gc_contents_mut(h) }
                 } else {
-                    Value::hash_insert_through(
-                        &mut crate::gc::Gc::make_mut(h).map,
-                        key.clone(),
-                        new_val.clone(),
-                    );
+                    crate::gc::Gc::make_mut(h)
+                };
+                // Object hash: remember the key object under its `.WHICH` store
+                // key so `.keys`/`.kv`/`.raku` recover it (`typed_key`).
+                if object_hash_key_type.is_some() {
+                    data.original_keys
+                        .get_or_insert_with(std::collections::HashMap::new)
+                        .insert(key.clone(), idx_val.clone());
                 }
+                Value::hash_insert_through(&mut data.map, key.clone(), new_val.clone());
                 true
             }) {
                 done

--- a/t/incdec-element-typed-seed-and-object-hash-key.t
+++ b/t/incdec-element-typed-seed-and-object-hash-key.t
@@ -1,0 +1,72 @@
+use v6;
+use Test;
+
+# `++`/`--` on a container ELEMENT must
+#   (1) seed an absent element from the container's declared element type
+#       (Raku's `postfix:<++>` is `.=succ` on the current value, and a Bool
+#       increments to True, not to Int 1), and
+#   (2) key an object hash (`my %h{KeyType}`) by the key's `.WHICH`, recording
+#       the key object so `.keys`/`.kv` report the object -- exactly as an `=`
+#       store and an element read already do.
+
+plan 19;
+
+# --- (1) element seed comes from the declared element type -------------------
+
+my Bool:D %b;
+%b<a>++;
+is %b<a>, True, 'Bool-valued hash element ++ yields True';
+isa-ok %b<a>, Bool, 'Bool-valued hash element ++ stays a Bool';
+%b<a>++;
+is %b<a>, True, 'incrementing a True Bool element stays True';
+
+my Bool @ba;
+@ba[0]++;
+is @ba[0], True, 'Bool-valued array element ++ yields True';
+
+my Num %n;
+%n<q>++;
+is %n<q>, 1e0, 'Num-valued hash element ++ yields 1e0';
+isa-ok %n<q>, Num, 'Num-valued hash element ++ stays a Num';
+
+my Int %i;
+%i<z>++;
+is %i<z>, 1, 'Int-valued hash element ++ still yields 1';
+
+my %plain;
+%plain<x>++;
+%plain<x>++;
+is %plain<x>, 2, 'untyped hash element ++ is unchanged';
+
+# --- (2) object-hash element ++ keys by .WHICH -------------------------------
+
+my %s{Str};
+%s<a>++;
+%s<a>++;
+is %s<a>, 2, 'Str-keyed object hash accumulates across ++';
+is %s.elems, 1, 'Str-keyed object hash ++ uses one bucket';
+is-deeply %s.keys.list, ("a",), 'Str-keyed object hash reports its key';
+
+my %oi{Int};
+%oi{5}++;
+%oi{5}++;
+is %oi{5}, 2, 'Int-keyed object hash accumulates across ++';
+is-deeply %oi.keys.list, (5,), 'Int-keyed object hash reports the Int key object';
+
+my %d{Date};
+my $day = Date.new(2026, 9, 7);
+%d{$day}++;
+is %d{$day}, 1, 'Date-keyed object hash element ++ is readable back';
+is-deeply %d.keys.list, ($day,), 'Date-keyed object hash reports the Date key object';
+
+# An object hash whose values are Bool combines both halves: the key object has
+# to survive AND the element has to seed from `Bool`.
+my Bool:D %seen{Array:D};
+my Str:D @path = <alpha beta>;
+%seen{$@path}++;
+is %seen.elems, 1, 'Array-keyed Bool object hash got one entry';
+ok %seen.keys.first ~~ Positional, 'Array-keyed object hash key stays a Positional';
+is %seen.keys.first.join('|'), 'alpha|beta', 'the recorded key object is the path array';
+is %seen.values.first, True, 'Bool-valued object hash element ++ yields True';
+
+done-testing;

--- a/t/where-clause-exception-and-defaulted-param-dispatch.t
+++ b/t/where-clause-exception-and-defaulted-param-dispatch.t
@@ -1,0 +1,63 @@
+use v6;
+use Test;
+
+# Two properties of a `where` constraint during multi dispatch:
+#
+#  (1) A `where` block is ordinary code. An exception it throws propagates out
+#      of the whole dispatch -- it is NOT "this candidate does not match", so a
+#      later candidate must not silently take over.
+#  (2) An unsupplied parameter that has a DEFAULT is checked against that
+#      default's value, so a multi can select a candidate purely on its
+#      defaulted parameter (including a default that reads `$.attr`).
+
+plan 14;
+
+# --- (1) an exception from a `where` propagates ------------------------------
+
+sub check($x) { die "boom" if $x eq 'bad'; True }
+multi sub f(@s where { check(@s[0]) }) { 'matched' }
+multi sub f(@s)                        { 'fallback' }
+
+is f(['good']), 'matched', 'a where that returns True still selects its candidate';
+throws-like { f(['bad']) }, X::AdHoc, message => /boom/,
+    'an exception thrown by a where clause propagates out of the dispatch';
+
+my class X::WhereBoom is Exception {
+    method message { 'where-boom' }
+}
+multi sub g($x where { $x == 2 ?? die(X::WhereBoom.new) !! True }) { 'first' }
+multi sub g($x)                                                    { 'second' }
+is g(1), 'first', 'the non-throwing case still dispatches normally';
+is g(3), 'first', 'and keeps dispatching normally afterwards';
+throws-like { g(2) }, X::WhereBoom,
+    'a typed exception from a where keeps its type';
+
+# A `where` that merely returns False is still just "no match".
+multi sub h($x where { $x > 10 }) { 'big' }
+multi sub h($x)                   { 'small' }
+is h(20), 'big', 'a true where matches';
+is h(2), 'small', 'a false where falls through to the next candidate';
+
+# --- (2) a defaulted parameter's `where` selects the candidate ---------------
+
+my $tag = 'B';
+multi sub d(Str:D $x where { $_ eq 'A' } = $tag) { 'sub-A' }
+multi sub d(Str:D $x where { $_ eq 'B' } = $tag) { 'sub-B' }
+is d(), 'sub-B', 'an unsupplied defaulted param is matched against its default';
+is d('A'), 'sub-A', 'an explicitly supplied argument still wins';
+
+class Tagged {
+    has Str:D $.tag is required;
+    multi method m(Str:D $t where { $_ eq 'A' } = $.tag) { 'method-A' }
+    multi method m(Str:D $t where { $_ eq 'B' } = $.tag) { 'method-B' }
+}
+is Tagged.new(:tag<A>).m, 'method-A', 'a default reading $.attr selects the A candidate';
+is Tagged.new(:tag<B>).m, 'method-B', 'a default reading $.attr selects the B candidate';
+is Tagged.new(:tag<A>).m('B'), 'method-B', 'an explicit argument overrides the attribute default';
+
+multi sub n($x where { $_ > 10 } = 42) { 'big' }
+multi sub n($x where { $_ <= 10 } = 42) { 'small' }
+is n(), 'big', 'a numeric defaulted where picks the matching candidate';
+is n(3), 'small', 'and a supplied argument is matched on its own';
+
+done-testing;

--- a/todo/deep/config-toml-battery-core-blockers.md
+++ b/todo/deep/config-toml-battery-core-blockers.md
@@ -1,92 +1,116 @@
 # `Config::TOML` battery is blocked on core interpreter campaigns
 
-## Current measurement (2026-09-06)
+## Current measurement (2026-09-07)
 
 Both upstream suites re-fetched from GitHub (`raku-community-modules/Crane`,
 `raku-community-modules/Config-TOML`) and run from their own directories
 against a **debug** build; `Config::TOML` with `Crane/lib` on `MUTSULIB`.
 
-| Suite | raku | mutsu (2026-08-31) | mutsu (2026-09-06, before this round) | mutsu (2026-09-06, after) |
-| --- | --- | --- | --- | --- |
-| `Config::TOML` v0.1.3 | 19/19 files | 0/19 | **10/19** | **10/19** |
-| `Crane` v0.1.2 | 15/15 files | 3/15 | **3/15** | **3/15** |
+| Suite | raku | mutsu (2026-08-31) | mutsu (2026-09-06) | mutsu (2026-09-07, before) | mutsu (2026-09-07, after) |
+| --- | --- | --- | --- | --- | --- |
+| `Config::TOML` v0.1.3 | 19/19 files | 0/19 | 10/19 | 10/19 | **11/19** |
+| `Crane` v0.1.2 | 15/15 files | 3/15 | 3/15 | 3/15 | **4/15** |
 
-**The ticket's `Config::TOML 0/19` was badly stale: it is 10/19 today**, and two
-of the four listed blockers are gone. `Crane` is still 3/15 at the file level
-(`at`, `exists`, `test`) but its assertion-level failures moved a lot this
-round — `t/add.rakutest`'s "Original container is unchanged" cluster went 5 → 1.
+The 2026-09-06 numbers reproduced exactly, so that pass's re-measurement was
+sound. This pass fixed four general interpreter bugs (below) and moved both
+counts: `Config::TOML`'s `exceptions/01-parser.rakutest` went from 12 failing
+assertions to a clean 17/17, and `Crane`'s `get.rakutest` now passes.
 
-`Config::TOML` passing: `api/01`, `grammar/01-04`, `grammar-actions/03`,
-`special-cases/01`, `04`, `05`, `06`.
-`Config::TOML` failing: `dumper/01`, `exceptions/01-02`,
-`grammar-actions/01`, `02`, `04`, `special-cases/02`, `03`, `07`.
+`Config::TOML` passing: `api/01`, `exceptions/01`, `grammar/01-04`,
+`grammar-actions/03`, `special-cases/01`, `04`, `05`, `06`.
+`Config::TOML` failing: `dumper/01`, `exceptions/02`, `grammar-actions/01`,
+`02`, `04`, `special-cases/02`, `03`, `07`.
+`Crane` passing: `at`, `exists`, `get`, `test`.
 
-## Blocker status, re-checked 2026-09-06
+## Fixed 2026-09-07 (general interpreter bugs, all pinned)
 
-1. **Crane's array-path semantics.** Partly stale, partly still open.
-   - *Copy isolation* ("Original container is unchanged"): **mostly a
-     misdiagnosis.** The failures were not container aliasing at all. Two
-     general interpreter bugs produced them and are now fixed:
-     - A **sigilless parameter (`\c`) re-read the caller's variable out of
-       `env` by name** instead of using the argument the VM evaluated. When the
-       live value sat in the caller's local slot and `env` still held the
-       declaration-time one — what a cross-compunit method call leaves behind —
-       the parameter bound the variable's *type object*, and the exit writeback
-       stamped that back onto the caller. Repro needs no module machinery:
-       a `unit class C;` with `method m(\c) { 99 }`, called as
-       `my Positional $t = <foo bar>; C.m($t)`, left `$t` as `(Positional)`.
-       Pin: `t/sigilless-param-reads-argument-not-env.t`.
-     - `.isa` answered **False for every role type object** (`class_mro` on a
-       role name yields just that name), so Crane's `ok($t.isa(Any))` on an
-       undefined `Associative`/`Positional`-typed scalar failed. raku answers
-       from the role's pun's chain — exactly `Any` and `Mu`. A class whose only
-       declared parents are composed roles (`class K does A`) had the twin bug.
-       Pin: `t/isa-role-type-object-and-role-only-parent.t`.
-   - *`Crane::List`* (and every other `unit class Crane::X;` file): the `::`
-     segments of a **compound declared name** were treated as enclosing lexical
-     scopes, so `List.new(...)` inside `class Crane::List` constructed a
-     `Crane::List` ("Default constructor for 'Crane::List' only takes named
-     arguments") instead of a core `List`. Fixed by recording, at declaration
-     time, whether a registry key's segments came from a compound name or from
-     real nesting (`unit module NL; class Searcher`) and skipping the former in
-     the type-name walk. Pin: `t/compound-declared-name-is-not-a-scope.t`.
-     NOTE: bare *routine* lookup deliberately still crosses those segments —
-     mutsu also uses them to model a module compunit's file-scope lexicals
-     (`HTTP::HPACK`'s own `sub decode-int`, reached from
-     `HTTP::HPACK::Decoder`'s methods), and cutting that walk breaks bundled
-     modules. So `class Quux::User { method m { greet() } }` still prefers
-     `Quux::greet` over the file's own `greet`, where raku picks the file's.
-     That residual divergence is unfixed.
-   - *Positional-index classification* (`X::Crane::PositionalIndexInvalid`
-     raised by `Crane::Utils`' enum-value multis): **stale — this works.** The
-     whole `is-valid-positional-index` / `gen-classifier` chain, including
-     `WhateverCode` (`*-0`) steps, matches raku exactly on a standalone repro.
-     What still fails in `t/in.rakutest` is the *descent* around it, not the
-     classifier.
-   - *Still open:* the out-of-range / sparse-Positional exception family. Crane
-     wraps `splice` in a `CATCH { when X::OutOfRange { ... } }` and re-throws
-     `X::Crane::AddPathOutOfRange`; mutsu's `splice` does raise `X::OutOfRange`
-     with the right message on its own, so the gap is somewhere in the descent
-     or the `CATCH` mapping. Not bisected. This is now the dominant Crane
-     cluster: `add` 6× "code dies" + 5× wrong exception type, and the same
-     shape in `copy`, `move`, `remove`, `replace`, `set`, `patch`.
+1. **A container element's `++`/`--` seeded from `Int` 0 regardless of the
+   declared element type.** `my Bool:D %h; %h<a>++` died with
+   `Type check failed for an element of %h; expected Bool:D but got Int (1)`;
+   raku answers `True` (`postfix:<++>` is `.=succ`, and an uninitialized
+   `Bool` slot succs to `True`). The scalar path already seeded from the
+   declared type (`normalize_incdec_source_with_type`); the element path did
+   not. Now both share `incdec_seed_for_constraint`, which also strips a
+   `:D`/`:U`/`:_` smiley before the lookup.
+2. **An object hash's element `++`/`--` keyed by the display string.**
+   `my %h{Int}; %h{5}++; say %h{5}` read back the type object, because the
+   store used `idx.Str` while every read (and every `=` store) uses `.WHICH`;
+   and `.keys` handed back a `Str` because nothing recorded the key object in
+   `original_keys`. `exec_inc_dec_index_op` now detects the object hash the
+   same way the assign path does and takes the `.WHICH`/`original_keys` route.
+3. **An exception thrown by a `where` constraint was swallowed and read as
+   "this candidate does not match".** Raku propagates it out of the whole
+   dispatch. This is the mechanism the *whole* of `Crane` is built on -- its
+   `at`/`in`/`add`/`set` descent is a chain of
+   `multi sub at(Positional:D $c, @steps where { ... is-valid-positional-index(@steps[0]) ... })`
+   candidates whose `where` *dies* to classify a bad index. mutsu fell through
+   to the next candidate and reported the wrong exception type everywhere.
+   The matchers are `bool`-returning predicates, so the exception is stashed in
+   `Interpreter::pending_where_exception` and re-raised by the dispatch funnel
+   before any candidate body runs, with `exec_one` as the backstop that
+   guarantees it can never be dropped. A control-flow signal
+   (`return`/`next`/...) is not an exception and still reads as "no match".
+   The exception escapes only when raku would have *reached* that candidate:
+   mutsu evaluates every candidate's matcher to rank them, while rakudo walks
+   them narrowest-first and stops at the first that binds, so
+   `choose_best_matching_candidate` discards the stash when a nominally
+   narrower candidate matched. (Comparing NOMINAL narrowness -- mutsu's own
+   ranking weighs a `where` above the parameter shape, which is right for
+   picking a winner but would wrongly claim the thrower came first;
+   `roast/S06-multi/proto.t`'s `multi bar(| (A $x))` vs
+   `multi bar(| where { $_[0] == 42 })` pins exactly that.)
+4. **An unsupplied parameter with a DEFAULT skipped its `where` entirely**, so
+   every such candidate matched and the first one declared always won.
+   Raku evaluates the default and applies the `where` to it, which is how
+   `X::Crane::PositionalIndexInvalid`'s
+   `multi method message(Str:D $c where { $_ eq 'INTM' } = $.classifier)` pair
+   picks its message. Fixing it also required binding `self` during method
+   candidate matching -- a default (or a `where`) that reads `$.attr` had no
+   invocant in scope.
+
+Pins: `t/incdec-element-typed-seed-and-object-hash-key.t`,
+`t/where-clause-exception-and-defaulted-param-dispatch.t`.
+
+## Blocker status, re-checked 2026-09-07
+
+1. **Crane's array-path semantics.**
+   - *Positional-index classification* (`X::Crane::PositionalIndexInvalid`):
+     **closed** by fixes 3 + 4 above. `Crane.get(%data, :path<legumes foo>)`
+     now raises the right type *and* the right message.
+   - *Copy isolation* ("Original container is unchanged"): still 1 failure in
+     `add.rakutest` and the dominant cluster in `transform.rakutest`. The
+     2026-09-06 diagnosis (two general bugs, since fixed) accounted for most of
+     it; what is left is a genuine `is rw` / `return-rw` descent that mutates
+     the caller's container when Crane asked for a copy.
+   - *The `X::OutOfRange` / `CATCH` re-throw descent* was **not** a single
+     cluster and was **not** what the 2026-09-06 note guessed. Bisected this
+     pass: `splice` itself is correct (`@a.splice(*-2, 0, 'x')` on an empty
+     array raises `X::OutOfRange` with raku's exact message). Two separate
+     residues remain: (a) `$list.splice(...)` on an immutable `List` raises
+     `X::Immutable` where raku raises `X::Multi::NoMatch`, which Crane's
+     `CATCH` maps to `X::Crane::Add::RO` only in raku's spelling; (b) a
+     `splice` reached through Crane's `*-0` path inserts at index 0 instead of
+     at the end (`add.rakutest`'s two "Is expected value" failures show the
+     spliced `0..11` landing first, not last).
+   - *`Crane::List` / `Crane::Flatten`*: still the object-hash ticket, see 5.
 2. ~~`t/patch.rakutest` fails to parse.~~ Fixed 2026-08-31.
-3. ~~The 8-hex `\UXXXXXXXX` string escape.~~ **Fixed** — `grammar/04` and
-   `grammar-actions/04`'s grammar half both pass now; `grammar-actions/04`
-   still fails for an unrelated reason.
-4. ~~`t/grammar/03-inline-tables.rakutest` times out.~~ **Fixed** — it passes,
-   and so does `grammar-actions/03`.
-
-New this round, filed separately:
-
-5. `todo/tickets/object-hash-key-lost-when-pair-value-is-a-container.md` — the
-   whole remaining blocker for `Crane`'s `flatten` and `list` files.
-   `my Any:D %t{List:D} = (%h<path> => %h<value>,)` dies with a bogus
-   `expected List:D but got Str ("1 2")` because the Pair's *value* is a
-   write-through `ContainerRef` and the object hash then loses the key object.
-   Also records two smaller measured divergences (`=>` does not decontainerize
-   its key; an itemized list used as a hash subscript is flattened into a
-   slice).
+3. ~~The 8-hex `\UXXXXXXXX` string escape.~~ Fixed 2026-09-06.
+4. ~~`t/grammar/03-inline-tables.rakutest` times out.~~ Fixed 2026-09-06.
+5. `todo/tickets/object-hash-key-lost-when-pair-value-is-a-container.md` --
+   still the whole remaining blocker for `Crane`'s `flatten` and `list` files.
+6. **New this pass, unfixed:** `.WHICH` of an `Array` is mutsu's Gc pointer in
+   some paths and the content string (`Array|a b`) in others, so
+   `my %h{Array:D}; %h{$k} = 1` and a later `%h{$k}` read agree with each other
+   but neither agrees with a pointer-keyed write. Fix 2 above deliberately
+   keys `++` the way the read and `=` paths already key, so nothing regressed,
+   but an object hash keyed by a *mutable* container is still not identity-keyed
+   the way Rakudo keys it. Not worth a campaign for these two dists (neither
+   looks an `Array` key up by hash; `Config::TOML` compares with `eqv`).
+7. **New this pass, unfixed (`Config::TOML` residue):** `grammar-actions/01`
+   is 3 byte-for-byte string-equivalence failures plus an `Int` coercion
+   reporting `''` instead of `(Int)`; `grammar-actions/02` is one Rat/FatRat
+   precision digit (`9224617.445991228313` vs `9224617.445991227`);
+   `dumper/01` + `exceptions/02` are the TOML *dumper*, untouched this pass.
 
 ## What this ticket is
 
@@ -98,7 +122,7 @@ recorded in `BATTERIES.md` §7 as **Selected, not yet bundled**.
 
 This ticket is the **follow-up mechanical step** — vendoring + wiring it up as
 an actual battery — once its blockers clear. **Do not start the vendoring steps
-yet**: `Crane` at 3/15 is still too thin for a per-file whitelist to be worth
+yet**: `Crane` at 4/15 is still too thin for a per-file whitelist to be worth
 it, and `Config::TOML` builds every result through `Crane.set`/`Crane.exists`.
 
 ## Steps (once unblocked)
@@ -153,5 +177,7 @@ git clone --depth 50 https://github.com/raku-community-modules/Config-TOML.git
 ```
 
 Run every failing file under `raku` on the same checkout before calling
-anything a mutsu bug — three of this ticket's four listed blockers turned out
-to be already fixed or misdiagnosed when that was actually done.
+anything a mutsu bug — three of this ticket's four originally listed blockers
+turned out to be already fixed or misdiagnosed when that was actually done, and
+the 2026-09-07 pass found the "not bisected" `X::OutOfRange` cluster was two
+unrelated residues rather than one.


### PR DESCRIPTION
Re-measured `todo/deep/config-toml-battery-core-blockers.md` from scratch, file
by file, against `raku` on freshly-fetched upstream checkouts, then fixed the
four **general** interpreter bugs the measurement exposed. No vendoring steps
were started (the ticket says not to yet).

## Re-measurement

| Suite | raku | mutsu 2026-08-31 | mutsu 2026-09-06 | before this PR | after this PR |
| --- | --- | --- | --- | --- | --- |
| `Config::TOML` v0.1.3 | 19/19 files | 0/19 | 10/19 | 10/19 | **11/19** |
| `Crane` v0.1.2 | 15/15 files | 3/15 | 3/15 | 3/15 | **4/15** |

The 2026-09-06 numbers reproduced exactly, so that pass's re-measurement was
sound. `Config::TOML`'s `exceptions/01-parser.rakutest` went from 12 failing
assertions to a clean 17/17; `Crane`'s `get.rakutest` now passes.

Blocker-by-blocker, against the ticket's own list:

| Ticket blocker | Status now |
| --- | --- |
| Positional-index classification (`X::Crane::PositionalIndexInvalid`) | **closed** — right exception type *and* right message |
| The "not bisected" `X::OutOfRange` / `CATCH` re-throw descent | **bisected**: not one cluster. `splice` itself is correct; two unrelated residues remain (below) |
| Copy isolation ("Original container is unchanged") | still open — a genuine `is rw`/`return-rw` descent, 1 failure in `add`, the dominant cluster in `transform` |
| `Crane::List` / `Crane::Flatten` | unchanged — still the separate object-hash ticket |
| 8-hex `\UXXXXXXXX`, `patch.rakutest` parse, inline-tables timeout | still fixed (stale entries confirmed stale) |

The `X::OutOfRange` bisection: `@a.splice(*-2, 0, 'x')` on an empty array
already raises `X::OutOfRange` with rakudo's exact message. What is left is
(a) `$list.splice(...)` on an immutable `List` raising `X::Immutable` where
raku raises `X::Multi::NoMatch` (Crane's `CATCH` only maps raku's spelling to
`X::Crane::Add::RO`), and (b) a `splice` through Crane's `*-0` path inserting
at index 0 instead of at the end.

## Root causes fixed (each reduced and verified against `raku` first)

### 1. An element `++`/`--` always seeded from `Int` 0

```raku
my Bool:D %h; %h<a>++;   # raku: True;  mutsu: "Type check failed ... expected Bool:D but got Int (1)"
my Num %n;    %n<q>++;   # raku: 1e0;   mutsu: 1
```

Raku's `postfix:<++>` is `.=succ` on the current value, so an uninitialized
`Bool` slot succs to `True`. The scalar path already seeded from the declared
type (`normalize_incdec_source_with_type`); the element path hardcoded
`Value::int(0)`. Both now share `incdec_seed_for_constraint`, which strips a
`:D`/`:U`/`:_` smiley before the lookup.

### 2. An object hash's element `++`/`--` keyed by the display string

```raku
my %h{Int}; %h{5}++; %h{5}++; say %h{5};   # raku: 2;   mutsu: (Any)
my %d{Date}; %d{Date.new(2026,9,7)}++;     # unreadable back, and .keys handed back a Str
```

Every read and every `=` store keys an object hash by `.WHICH`; the increment
path stored under `idx.Str` and recorded nothing in `original_keys`, so the
bump landed where no read could find it. The increment path now detects the
object hash with the *same* predicate the element-assign path uses (the
declared key constraint of the name — deriving it from the container's own
`key_type` instead makes `++` `.WHICH`-key a hash destructured into an
anonymous `%a is raw` parameter, which `=` still display-keys; that is what
`roast/S02-names/is_default.t` caught).

### 3. An exception thrown by a `where` constraint was swallowed

```raku
sub check($x) { die "boom" if $x eq 'bad'; True }
multi sub f(@s where { check(@s[0]) }) { 'matched' }
multi sub f(@s)                        { 'fallback' }
say f(['bad']);        # raku: dies "boom";  mutsu: 'fallback'
```

A `where` block is ordinary code and raku propagates its exception out of the
whole dispatch, rather than reading it as "this candidate does not match".
This is the mechanism the whole of `Crane` is built on — its
`at`/`get`/`in`/`add`/`set` descent is a chain of candidates whose `where`
*dies* to classify a bad index — so mutsu reported the wrong exception type
everywhere in that dist.

The matchers are `bool`-returning predicates, so the exception is recorded in
`Interpreter::pending_where_exception` and re-raised rather than dropped:
`exec_one` is the backstop, and function dispatch signals it the way an
ambiguous dispatch already is (`None` + `pending_dispatch_error`, which every
resolver caller re-raises — a plain stash does not survive the fallback path's
deliberate re-resolve). A control-flow signal (`return`/`next`/…) is not an
exception and still reads as "no match".

The exception escapes only when raku would have **reached** that candidate.
mutsu evaluates every candidate's matcher in order to rank them, while rakudo
walks them narrowest-first and stops at the first that binds, so the record is
discarded when a *nominally* narrower candidate matched.
`roast/S06-multi/proto.t`'s `multi bar(| (A $x))` vs
`multi bar(| where { $_[0] == 42 })` pins exactly that (mutsu's own ranking
weighs a `where` above the parameter shape, which is right for picking a winner
but would wrongly claim the thrower came first).

### 4. An unsupplied parameter with a DEFAULT skipped its `where`

```raku
class C {
    has Str:D $.tag is required;
    multi method m(Str:D $t where { $_ eq 'A' } = $.tag) { 'is-A' }
    multi method m(Str:D $t where { $_ eq 'B' } = $.tag) { 'is-B' }
}
say C.new(:tag<B>).m;   # raku: is-B;  mutsu: is-A
```

Raku evaluates the default and applies the `where` to its value — which is how
`X::Crane::PositionalIndexInvalid`'s
`multi method message(Str:D $c where { $_ eq 'INTM' } = $.classifier)` pair
picks its message. mutsu skipped the check whenever the argument was absent and
a default existed, so every such candidate matched and the first declared
always won. Making it work also required binding `self` during method candidate
matching — a default (or a `where`) reading `$.attr` had no invocant in scope.

## Pins

- `t/incdec-element-typed-seed-and-object-hash-key.t` (19 assertions)
- `t/where-clause-exception-and-defaulted-param-dispatch.t` (14 assertions)

Both were run under `raku` as well as mutsu — a pin rakudo fails is pinning the
wrong answer.

## Gates

- `make test`: PASS (3799 files, 40047 tests) — includes `cargo test`.
- Full local `make roast`: PASS. Run in full rather than as a targeted sweep
  because the change alters a universal property of dispatch; it caught two
  regressions (`S02-names/is_default.t`, `S06-multi/proto.t`), both root-caused
  and fixed here, then re-run clean.
- `scripts/battery-testsuite.sh` (run alone): PASS, 289/312.
- `cargo fmt`, `cargo clippy --all-targets -- -D warnings`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
