### PR TITLE
refactor(runtime): retire the second map deferral mechanism (ADR-0058 step 4)

### DIFF
--- a/docs/adr/0058-map-grep-produce-a-deferred-seq.md
+++ b/docs/adr/0058-map-grep-produce-a-deferred-seq.md
@@ -1,6 +1,6 @@
 # ADR-0058: `.map`/`.grep` produce a deferred `Seq` — the callback runs at first consumption, not at the call
 
-- **Status**: Accepted (steps 2, 3a and 3c shipped 2026-09-07; steps 3b and 4 open)
+- **Status**: Accepted — **fully implemented** (steps 0-4 all shipped 2026-09-07)
 - **Date**: 2026-08-22
 - **Deciders**: tokuhirom, Claude
 - **Related**: [ADR-0034](0034-seq-reification-is-in-place-and-distinct-from-consumption.md)
@@ -140,6 +140,26 @@ rather than a patch — see §5.
 
 ---
 
+## 1b. Status (2026-09-07): every step is shipped
+
+Steps 0-4 are all done. `.map` and `.grep` both answer a deferred `Seq` in every
+spelling, one mechanism (`SeqSource::MapGrep` + `MapGrepMode`) implements it,
+and the older `LazyList` deferral is deleted. §9.5 records the process lesson
+that came out of it, and is the part worth carrying to the next deferral-shaped
+change.
+
+One divergence measured while retiring step 4 is NOT caused by it and stays
+open, unrecorded elsewhere: a `return` inside a `.map` callback that is forced
+*within* the declaring routine returns from that routine in mutsu and does not
+in rakudo --
+
+```raku
+sub h() { my $r = (1,2,3).map({ return 9 }).List; "unreached" }
+say h();      # rakudo: unreached      mutsu: 9
+```
+
+It is unaffected by the carve-out's presence or absence (measured both ways).
+
 ## 2. Decision
 
 **`.map` and `.grep` return a `Seq` whose body is not yet reified. The callback
@@ -272,7 +292,7 @@ callback `Value` already carries its own closure environment.
 | **3a** | **Done (2026-09-07).** `builtin_map` (the `map &f, @xs` listop form) returns the same `Value::seq_deferred(SeqSource::MapGrep { .. })` as step 2. Attempted and reverted earlier the same day behind a step-2 hole (S9.1); that hole is closed (`news/2026-09/deferred-map-callback-frame.md`). The mandatory full `make roast` then found three more consumers, all fixed generally -- see S9.3. | `t/listop-map-defers.t`, and `t/nested-deferred-map-seq-is-pulled.t`'s listop row un-`todo`d. |
 | **3c** | **Done (2026-09-07).** The three EAGER `.map` loops keyed on an `@`-sigil receiver -- `call_method_mut_with_values`'s rw gate, `try_native_array_map`, and `builtin_map`'s `source_var` branch -- defer through the same `SeqSource::MapGrep`, which gains `rw_source` so the pull can publish the rw write-back in place. `is_stub_routine_body` drops out of both deferral predicates, and a `Control::Fail` raised under a captured `fatal` throws at the pull. Closes S9.4; the oracle is 37 rows with no `todo`s. | `news/2026-09/real-array-map-defers.md`. The mandatory full `make roast` + `make test` + battery run found EIGHT more general defects -- see S9.4. |
 | **3b** | **Done (2026-09-07).** Every `grep` entry point defers with the default `:v` adverb: the concrete-array arm, the range arm, the generic arm and the listop. `:k`/`:kv`/`:p` keep the eager path (they need positional indices over the whole result), the same exemption they already take from `make_lazy_pipe`. §9.5 records what the gates found. | `SeqSource::MapGrep`'s two `Option<Value>` fields collapsed into one `MapGrepMode` enum so the four shapes are mutually exclusive by construction. |
-| **4** | Retire the `body_contains_return` deferral predicate and `create_lazy_map_list` — both become dead once every map defers. (`is_stub_routine_body` already dropped out of both predicates in step 3c: a `...` stub needs only "do not fire until iterated", which `MapGrep` gives, and unlike the `LazyList` route `MapGrep` carries the `fatal` a stub-as-`fail` needs.) | The maintainability payout. |
+| **4** | **Done (2026-09-07).** `create_lazy_map_list` and the `body_contains_return` predicate are deleted (102 lines). The carve-out's stated reason -- that an out-of-dynamic-scope `return` "the `LazyList` path already gets right" -- was measured obsolete: removing it changed nothing, because `SeqSource::MapGrep` surfaces `X::ControlFlow::Return` identically. | The maintainability payout. One deferral mechanism remains. |
 
 ### Verification
 

--- a/news/2026-09/adr0058-complete-one-deferral-mechanism.md
+++ b/news/2026-09/adr0058-complete-one-deferral-mechanism.md
@@ -1,0 +1,64 @@
+# ADR-0058 is complete: one deferral mechanism, not two
+
+Step 4 retires `create_lazy_map_list` and the `body_contains_return` predicate —
+102 lines deleted — and with them the second of the two mechanisms mutsu used to
+defer a `.map`/`.grep` callback. `SeqSource::MapGrep` is now the only one.
+
+## The carve-out was already obsolete
+
+Both `dispatch_map_method` and `builtin_map` kept a callback whose body contains
+`return` on the older `LazyList` route, with this reason on the record:
+
+> that `return` targets the lexically enclosing routine, and if the Seq is
+> forced after that routine has exited it must surface as
+> `X::ControlFlow::Return` with out-of-dynamic-scope set, which the `LazyList`
+> path already gets right.
+
+Measured against rakudo before and after removing it, the three shapes that
+exercise the claim are unchanged:
+
+| probe | rakudo | before | after |
+|---|---|---|---|
+| `sub f() { my $s = (1,2,3).map({ return 9 }); "made" }` | `made` | `made` | `made` |
+| forcing the Seq after the declaring routine returned | throws `X::ControlFlow::Return` | same | same |
+| `sub h() { my $r = (1,2,3).map({ return 9 }).List; "unreached" }` | `unreached` | `9` | `9` |
+
+So `SeqSource::MapGrep` surfaces the out-of-dynamic-scope return identically,
+and the reason to keep a whole second mechanism had lapsed at some point without
+anyone re-measuring it. That is the same shape as two other findings from this
+ADR's own steps — `Value::truthy`'s comment promising a boolean-chokepoint force
+that did not exist (§9.5), and `env_root_descended_mut_tracked`'s doc comment
+telling callers about to mutate to use it while the chained-subscript store
+called the untracked sibling. **A comment stating an invariant is not evidence
+the invariant holds.**
+
+## One divergence measured, and deliberately left open
+
+Row 3 above is a real difference and it is *not* caused by step 4 — it answers
+`9` with the carve-out present and absent alike. A `return` inside a `.map`
+callback forced **within** the declaring routine returns from that routine in
+mutsu; rakudo runs on. Recorded in ADR-0058 §1b rather than fixed here, because
+it is a `return`-targeting question, not a deferral one.
+
+## Gates
+
+`make test` PASS (3799 files / 40048 tests) · full local `make roast` PASS
+(1436 files / 218962 tests) · `scripts/battery-testsuite.sh` **GATE PASSED**
+(289/312) · `cargo fmt` / `clippy --all-targets -D warnings` clean.
+
+## ADR-0058, start to finish
+
+Every step shipped on 2026-09-07:
+
+| step | what |
+|---|---|
+| 2 | `SeqSource::MapGrep` + the `pull_seq_source` arm, `dispatch_map_method` only |
+| 3a | the listop `map &f, @xs` form |
+| 3c | `@a.map` on a real array — three eager implementations, all keyed on the `@` receiver |
+| 3b | every `grep` entry point |
+| 4 | retire `create_lazy_map_list` |
+
+The process lesson is §9.5's, and it is the part worth carrying forward: a green
+gate on the step that deferred is not evidence its consumers are covered,
+because a still-eager sibling keeps handing out reified Seqs that hide the same
+read-path holes. Deferring `grep` is what surfaced five of them in `.map`.

--- a/src/runtime/builtins_collection_mapgrep.rs
+++ b/src/runtime/builtins_collection_mapgrep.rs
@@ -108,11 +108,6 @@ impl Interpreter {
             // `return` must not run until the Seq is forced. A `...` stub
             // goes through `SeqSource::MapGrep` like everything else — see
             // the comment there.
-            if let Some(ValueView::Sub(sub_data)) = func.as_ref().map(Value::view)
-                && Self::body_contains_return(&sub_data.body)
-            {
-                return Ok(self.create_lazy_map_list(list_items, &sub_data));
-            }
             // ADR-0058 step 3: the listop `map &f, @xs` form defers exactly as
             // the method form does — the callback runs when something consumes
             // the Seq, not here. Without this the listop answered a `List`

--- a/src/runtime/methods_dispatch_match2.rs
+++ b/src/runtime/methods_dispatch_match2.rs
@@ -617,11 +617,6 @@ impl Interpreter {
         // needs the `use fatal` captured at the `.map` call, which the
         // `LazyList` route has no field for. That was the last thing keeping
         // `t/map-callback-runs-at-consumption.t`'s two Part-1 rows `todo`.
-        if let Some(ValueView::Sub(sub_data)) = args.first().map(Value::view)
-            && Self::body_contains_return(&sub_data.body)
-        {
-            return Ok(self.create_lazy_map_list(items, &sub_data));
-        }
         // ADR-0058 step 2: `.map` returns a Seq whose callback has NOT run
         // yet. The callback runs when something consumes the Seq, through
         // ADR-0034's `reify`/`take`/`sink` split (`SeqSource::MapGrep`'s arm
@@ -635,57 +630,6 @@ impl Interpreter {
             mode: crate::value::MapGrepMode::Map,
         }))
     }
-
-    /// Create a `LazyList` that lazily maps `callback` over `items`.
-    ///
-    /// Instead of eagerly evaluating the map, stores the items and callback
-    /// in a `LazyList`. When the list is forced, `eval_map_over_items` runs
-    /// the callback for each item. This ensures that `return` inside the
-    /// callback correctly detects when the lexically enclosing routine has
-    /// already exited (out-of-dynamic-scope).
-    pub(super) fn create_lazy_map_list(
-        &self,
-        items: Vec<Value>,
-        callback: &crate::gc::Gc<crate::value::SubData>,
-    ) -> Value {
-        let mut env = self.env.clone();
-        env.insert(
-            "__mutsu_lazy_map_items".to_string(),
-            Value::array_with_kind(
-                crate::gc::Gc::new(crate::value::ArrayData::new(items)),
-                crate::value::ArrayKind::List,
-            ),
-        );
-        env.insert(
-            "__mutsu_lazy_map_func".to_string(),
-            Value::sub_value(callback.clone()),
-        );
-        // Mark as gather-based so the VM auto-forces it for chained methods.
-        env.insert("__mutsu_lazylist_from_gather".to_string(), Value::TRUE);
-
-        let list = crate::value::LazyList {
-            body: Vec::new(),
-            env,
-            cache: std::sync::Mutex::new(None),
-            generation_state: std::sync::Mutex::new(None),
-            compiled_code: None,
-            compiled_fns: None,
-            elems_count: None,
-            scan_spec: None,
-            sequence_spec: None,
-            coroutine: None,
-            lazy_pipe: None,
-            closure_seq: None,
-            walk_pending: None,
-            cat_pull: None,
-            array_context: false,
-            list_context: false,
-            cached_no_sink: false,
-            itemized: false,
-        };
-        Value::lazy_list(crate::gc::Gc::new(list))
-    }
-
     /// Dispatch "min" and "max" methods.
     fn dispatch_min_max_method(
         &mut self,

--- a/src/runtime/registration.rs
+++ b/src/runtime/registration.rs
@@ -1112,57 +1112,6 @@ impl Interpreter {
         )));
         err
     }
-
-    /// Returns true if the statement list contains a `return` statement
-    /// (including a bare `return` with no value), descending into nested
-    /// control-flow blocks but not into nested routine declarations.
-    ///
-    /// Used to decide whether a `.map` callback must be evaluated lazily: a
-    /// `return` inside a map block targets the lexically enclosing routine, so
-    /// the callback must be deferred until the Seq is forced to get the correct
-    /// out-of-dynamic-scope semantics. Plain map blocks (the overwhelming
-    /// majority) keep eager evaluation.
-    pub(crate) fn body_contains_return(stmts: &[Stmt]) -> bool {
-        for stmt in stmts {
-            match stmt {
-                Stmt::Return(_) => return true,
-                Stmt::If {
-                    then_branch,
-                    else_branch,
-                    ..
-                } => {
-                    if Self::body_contains_return(then_branch)
-                        || Self::body_contains_return(else_branch)
-                    {
-                        return true;
-                    }
-                }
-                Stmt::While { body, .. }
-                | Stmt::React { body }
-                | Stmt::SyntheticBlock(body)
-                | Stmt::Block(body)
-                | Stmt::Subtest { body, .. }
-                | Stmt::For { body, .. } => {
-                    if Self::body_contains_return(body) {
-                        return true;
-                    }
-                }
-                Stmt::Loop { init, body, .. } => {
-                    if let Some(init) = init
-                        && Self::body_contains_return(std::slice::from_ref(init.as_ref()))
-                    {
-                        return true;
-                    }
-                    if Self::body_contains_return(body) {
-                        return true;
-                    }
-                }
-                _ => {}
-            }
-        }
-        false
-    }
-
     pub(super) fn body_contains_non_nil_return(stmts: &[Stmt]) -> bool {
         for stmt in stmts {
             match stmt {


### PR DESCRIPTION
Completes **ADR-0058**. `create_lazy_map_list` and the `body_contains_return` predicate are deleted — 102 lines — and with them the second of the two mechanisms mutsu used to defer a `.map`/`.grep` callback. `SeqSource::MapGrep` is now the only one.

## The carve-out was already obsolete

Both `dispatch_map_method` and `builtin_map` kept a callback whose body contains `return` on the older `LazyList` route, with this reason on the record:

> that `return` targets the lexically enclosing routine, and if the Seq is forced after that routine has exited it must surface as `X::ControlFlow::Return` with out-of-dynamic-scope set, which the `LazyList` path already gets right.

Measured against rakudo with the carve-out **present and absent**, the three shapes that exercise the claim are unchanged:

| probe | rakudo | before | after |
|---|---|---|---|
| `sub f() { my $s = (1,2,3).map({ return 9 }); "made" }` | `made` | `made` | `made` |
| forcing the Seq after the declaring routine returned | throws `X::ControlFlow::Return` | same | same |
| `sub h() { my $r = (1,2,3).map({ return 9 }).List; "unreached" }` | `unreached` | `9` | `9` |

`SeqSource::MapGrep` surfaces the out-of-dynamic-scope return identically, so the reason to keep a whole second mechanism had lapsed at some point without anyone re-measuring it.

That is the **third instance in this ADR's own steps** of a comment stating an invariant that no longer held, or never had:

- `Value::truthy` promised that "the VM forces the body at every boolean chokepoint it can reach with an `&mut Interpreter`" — `eval_truthy` had no such force (§9.5);
- `env_root_descended_mut_tracked`'s doc told callers about to mutate the container to use it, while the chained-subscript store called the untracked sibling (#7495);
- this one.

## One divergence measured, deliberately left open

Row 3 is a real difference and is **not** caused by step 4 — it answers `9` with the carve-out present and absent alike. A `return` inside a `.map` callback forced *within* the declaring routine returns from that routine in mutsu; rakudo runs on. Recorded in **ADR-0058 §1b** rather than fixed here, because it is a `return`-targeting question, not a deferral one.

## Gates

| gate | result |
|---|---|
| `make test` | **PASS** — 3799 files / 40048 tests |
| full local `make roast` | **PASS** — 1436 files / 218962 tests |
| `scripts/battery-testsuite.sh` (run alone, release) | **GATE PASSED** — 289/312 |
| `cargo fmt` / `clippy --all-targets -D warnings` | clean |

## ADR-0058, start to finish

Every step shipped on 2026-09-07: step 2 (`SeqSource::MapGrep`, method `.map` only) → 3a (listop `map`) → 3c (`@a.map` on a real array — three eager implementations) → 3b (every `grep` entry point) → 4 (this).

The process lesson is §9.5's: a green gate on the step that deferred is not evidence its consumers are covered, because a still-eager sibling keeps handing out reified Seqs that hide the same read-path holes. Deferring `grep` is what surfaced five of them in `.map`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)