### PR TITLE
fix(binder): a deferred map/grep Seq flattens into a `*@` slurpy too

### DIFF
--- a/src/runtime/types/binding_signature.rs
+++ b/src/runtime/types/binding_signature.rs
@@ -1223,6 +1223,20 @@ impl Interpreter {
                         positional_idx = args.len();
                         continue;
                     }
+                    // ADR-0058: a `.map`/`.grep`/`gather` argument is a Seq whose
+                    // callback has not run, and the flatten below reads its
+                    // elements through pure code, which cannot pull -- so
+                    // `sub f(*@a) { @a }; f((1,2,3).grep({$_}))` collected
+                    // ADR-0034's empty seed and answered `()`. This is the `*@`
+                    // twin of the `+@` reification above; step 3b added the `+@`
+                    // one and left this arm to the still-eager `.grep`, which is
+                    // why deferring `grep` regressed it. Tag-probed, so every
+                    // other argument shape pays one relaxed check. A genuinely
+                    // lazy source never reaches here -- the `single_lazy_value`
+                    // branch above binds it lazily and `continue`s.
+                    for arg in &args[positional_idx..] {
+                        self.reify_map_grep_seq(arg)?;
+                    }
                     while positional_idx < args.len() {
                         let raw_arg = args[positional_idx].clone();
                         // The source name comes from the varref capture the caller

--- a/t/lazy-seq-into-user-slurpy.t
+++ b/t/lazy-seq-into-user-slurpy.t
@@ -1,0 +1,50 @@
+use Test;
+
+# A lazy `Seq` passed to a USER-defined slurpy must be flattened into it, the
+# same way an eager one is. ADR-0058 made `.map` (steps 2/3a/3c) and `.grep`
+# (step 3b) answer a not-yet-run `Seq`; the `*@a` binder reads its elements
+# through pure code, which cannot pull, so it collected ADR-0034's empty seed
+# and the caller's arguments silently vanished.
+#
+# Step 3b added the reification to the `+@a` arm and left `*@a` to the
+# still-eager `.grep` — so deferring `grep` turned `*@a` from 3 elements to 0.
+# The discriminator is LAZINESS, not slurpiness: every eager shape below was
+# always correct, and a non-slurpy `@a` receives the Seq intact.
+
+plan 12;
+
+# --- the deferred map/grep Seqs (the bug) ---
+
+sub count(*@a) { @a.elems }
+sub items(*@a) { @a }
+
+is count((1..3).grep(* > 0)), 3, '.grep into *@a flattens (regression from ADR-0058 step 3b)';
+is items((1..3).map(* + 0)).raku, '[1, 2, 3]', '.map into *@a flattens';
+is count((1..3).grep(* > 1)), 2, '.grep into *@a keeps the FILTERED count, not the source count';
+is count(((1..3).map(* + 0))), 3, 'a parenthesized .map argument flattens too';
+
+# --- eager controls: these were never broken and must stay correct ---
+
+is count((1, 2, 3)), 3, 'control: a literal list still flattens';
+is count((1, 2, 3).Seq), 3, 'control: an EAGER Seq still flattens';
+is count((1, 2, 3).List), 3, 'control: a List still flattens';
+is count(1 .. 3), 3, 'control: a Range still flattens';
+is count(1, 2, 3), 3, 'control: three separate arguments still collect';
+
+# A genuinely lazy source must NOT be reified into the slurpy — it stays lazy
+# and reify-on-index, or an infinite source would hang here.
+sub head3(*@a) { @a[0 .. 2].join(',') }
+is head3(1 .. Inf), '1,2,3', 'control: an infinite lazy source stays lazy in *@a';
+
+# A non-slurpy positional receives the Seq itself, not its elements.
+sub whole(@a) { @a.elems }
+is whole((1..3).map(* + 0)), 3, 'control: a non-slurpy @a receives the Seq intact';
+
+# --- still open: a `gather` / sequence-operator Seq binds as ONE element ---
+#
+# A different mechanism from the map/grep hole above: the slurpy is not empty,
+# it holds the Seq itself (`@a[0].^name` is `Seq`, `@a[0].elems` is 4), so
+# `flatten_into_slurpy` is declining to flatten it rather than reading an empty
+# seed. Tracked in todo/tickets/lazy-seq-argument-vanishes-into-a-user-slurpy.md.
+todo 'a gather Seq is bound as one element instead of being flattened', 1;
+is count(gather { take $_ for 1 .. 4 }), 4, 'gather into *@a flattens';

--- a/todo/tickets/lazy-seq-argument-vanishes-into-a-user-slurpy.md
+++ b/todo/tickets/lazy-seq-argument-vanishes-into-a-user-slurpy.md
@@ -1,4 +1,13 @@
-# A lazy Seq passed to a user `*@a` slurpy arrives empty or as one element
+# A `gather`/sequence-operator Seq is bound as one element to a user `*@a` slurpy
+
+> **Status 2026-09-08: the `.map` and `.grep` halves are FIXED** (the `*@a`
+> binder now reifies a deferred map/grep Seq, the `*@` twin of the `+@`
+> reification ADR-0058 step 3b added). Pin: `t/lazy-seq-into-user-slurpy.t`.
+> What survives is the `gather` / sequence-operator half below, which has a
+> **different mechanism** — the slurpy is not empty, it holds the Seq itself.
+> The title and body below are kept for the history; read this box first.
+
+## Original report — a lazy Seq passed to a user `*@a` slurpy arrives empty or as one element
 
 Passing a lazy `Seq` — from `.map`, `.grep`, the sequence operator, or `gather`
 — to a **user-defined** slurpy parameter silently loses the elements. No error,
@@ -62,9 +71,38 @@ deferred source differently from an eager one — note the eager `.Seq` control
 passes. Start by diffing what `#7481` (correct) and `#7501` (broken) changed
 about when a grep Seq is forced.
 
+## What is actually left (measured 2026-09-08, after the fix)
+
+```
+sub f(*@a) { say @a.elems }; f(gather { take $_ for 1..4 });   # mutsu 1   raku 4
+sub f(*@a) { say @a.elems }; f((1, *+1 ... 4));                # mutsu 1   raku 4
+```
+
+**Different mechanism from the map/grep hole.** The slurpy is not empty — it
+holds the Seq as a single element:
+
+```
+sub f(*@a) { say @a[0].^name; say @a[0].elems }; f(gather { take $_ for 1..4 });
+# mutsu:  Seq / 4
+```
+
+So `flatten_into_slurpy` is *declining to flatten* a `gather`/sequence-operator
+Seq, rather than reading an empty seed through pure code. Both report
+`.is-lazy` `False` and `.^name` `Seq`, matching raku, so the value itself looks
+right; only the flatten decision differs. Note a second, separable oddity found
+while measuring it: `@a.raku` renders `[]` for that one-element array even
+though `@a[0]` is a 4-element `Seq` — see
+[code-object-renders-as-nothing-inside-a-list](code-object-renders-as-nothing-inside-a-list.md)
+for a sibling rendering collapse.
+
+Careful: a genuinely lazy source must NOT be reified here — `f(1..Inf)` binds
+lazily through the `single_lazy_value` branch and would otherwise hang. That
+branch is why the map/grep fix is safe, and any flatten change has to preserve
+it (pinned as a control in `t/lazy-seq-into-user-slurpy.t`).
+
 ## Acceptance
 
-- All four repro rows match raku.
+- All four repro rows match raku (**two now do**).
 - Every control above still passes.
 - A `t/` pin covering `.map`, `.grep`, `gather` and the sequence operator into
   both a user `*@a` slurpy and a user `@a` positional, since the two paths


### PR DESCRIPTION
`sub f(*@a) { @a.elems }; f((1..3).grep(* > 0))` bound **zero** elements where rakudo binds three — the caller's arguments silently vanished, with nothing reporting it.

## This is a regression on `main`, bisected

Built four commits and ran that one program:

| commit | PR | result |
|---|---|---|
| `f62654e3d` | before the step-3 work | **3** ✅ |
| `2c7fc1dde` | #7481 `adr0058-step3b-grep` | **3** ✅ |
| `200923834` | #7496 `real-array-map-defers` | **3** ✅ |
| **`182178e6b`** | **#7501 `adr0058-step3b-grep-defer`** | **0** ❌ |
| `dccfd1737` | `main` | **0** ❌ |

Step 3b added `reify_map_grep_seq` to the `+@` single-argument-rule slurpy arm and left the `*@` arm alone. That was invisible while `.grep` was still eager: `*@` had been reading a deferred Seq's elements through pure code, which cannot pull, and collecting ADR-0034's empty seed — the still-eager `.grep` was the only thing keeping any test green. Deferring `grep` removed the cover.

This is precisely the failure mode **ADR-0058 §9.5** already records: *a green gate on the step that deferred is not evidence its consumers are covered, because a still-eager sibling keeps handing out reified Seqs that hide the same holes.* The same paragraph lists six such consumers found that way; `*@` is a seventh that was missed.

## The fix

The `*@` twin of step 3b's `+@` reification, placed **after** the `single_lazy_value` branch so a genuinely lazy source (`f(1..Inf)`) still binds lazily and cannot hang. Tag-probed, so every other argument shape pays one relaxed check.

It also closes the **`.map` face, which was not a regression** — `f((1..3).map(*+0))` answered `[]` at `f62654e3d` too. It had been broken since `.map` began deferring and was simply never measured.

## What remains open, and why it is not in this PR

`gather` and the sequence operator still bind as **one element**, and that is a different mechanism — the slurpy is not empty, it holds the Seq itself:

```
sub f(*@a) { say @a[0].^name; say @a[0].elems }; f(gather { take $_ for 1..4 });
# mutsu:  Seq / 4
```

So `flatten_into_slurpy` is *declining to flatten* rather than reading an empty seed. Recorded with measurements in the ticket and pinned as a `todo` row rather than guessed at here.

## Verification

- Pin `t/lazy-seq-into-user-slurpy.t` — 12 rows, green under mutsu **and** under rakudo. Controls: an eager `Seq`/`List`/`Range`/literal still flattens; an infinite lazy source stays lazy (would hang if the fix were placed wrong); a non-slurpy `@a` still receives the Seq intact.
- `make test` **PASS** — 3812 files / 40213 tests.
- Targeted roast **PASS** — 52 whitelisted `S06-signature` / `S06-currying` / `S02-lists` / `S04-declarations` files, 1648 tests. Full roast delegated to CI.

Found by the 2026-09-07b doc-diff re-sweep (`Language/traps.rakudoc:858`), filed in #7510.

🤖 Generated with [Claude Code](https://claude.com/claude-code)