### PR TITLE
fix(hyper): `»=»` distributes over its target's shape

### DIFF
--- a/news/2026-09/hyper-assignment-distributes-over-its-target-shape.md
+++ b/news/2026-09/hyper-assignment-distributes-over-its-target-shape.md
@@ -1,0 +1,73 @@
+# A hyper assignment distributes over its target's shape
+
+`news/2026-09/slice-assign-pads-short-rhs.md` made a plain slice assignment zip
+its RHS against the slots and pad the tail. It kept the hyper spelling working
+by marking it: `»=»` desugared to the same `IndexAssign` node as `=`, so a
+`Stmt::MarkHyperSliceAssign` flag told the store to cycle the RHS instead of
+padding it. That preserved the four slice rows it was measured against, but the
+cycle-in-the-store was only ever an approximation of the hyper rule, and it was
+already wrong wherever a slice store is not what the metaoperator lands on:
+
+```raku
+my @a = 1, 2, 3; @a »=» 7;       # raku [7, 7, 7]   was [7]
+my @a = 1, 2, 3; @a[0..2] »=» 7; # raku [7, 7, 7]   was [7, Nil, Nil]
+my @a = 1, 2, 3; @a[*] »=» 7;    # raku [7, 7, 7]   was [7, Any, Any]
+```
+
+The whole-container spelling stored a **one**-element array, because the parser
+lowered `»=»` to a plain `target = value` and threw the dwim arrows away; nothing
+distributed anything. The Range and Whatever subscripts reached a store the
+marker did not cover.
+
+## The fix
+
+`»=»` is an assignment hyper-op like `»+=»`, so it now compiles as one. Its base
+op is `=`, which yields its right operand at the leaf; the existing hyper
+machinery supplies the distribution and the dwim-length rules, and the
+compiler's assignment-hyper-op write-back stores the result. `is_assign_op` and
+the base-op split in `compile_expr_hyper_op` grew the `=` case (the base op of
+`»+=»` is `+`; the base op of `»=»` is `=` itself), and the base-op slice is now
+computed only for an assignment hyper-op — every such op ends in the ASCII `=`,
+where an arbitrary one may end in a multi-byte char and `&op[..op.len() - 1]`
+panicked on `»×»`.
+
+A literal list of lvalues (`(($a, ($b, $c)), $d) »=« ((4, (5, 6)), 7)`) keeps
+its own recursive lowering, which handles nesting the hyper machinery does not.
+
+Because the distribution now happens in the hyper op, the list a slice store
+receives is already exactly as long as the slice, and there is nothing left to
+cycle. `Stmt::MarkHyperSliceAssign`, `OpCode::MarkHyperSliceAssign`, the
+`hyper_slice_assign` one-shot `Cell` and `slice_rhs_value`'s `cycle` parameter
+are therefore retired: one mechanism decides the rule, at the point that knows
+it. All four of the marker's own hyper rows still pass, unchanged.
+
+## Two more gaps closed with it
+
+A hyper assignment has to know the slice's **arity**, and an associative slice of
+an undefined scalar collapsed to a single `Any`: `my $h; $h<a b c>` answered
+`Any` where raku answers `(Any, Any, Any)`. Its positional twin `$h[0,1,2]` was
+already correct, so the associative arm of the `Package("Any")` subscript now has
+the same shape.
+
+Separately, a slice assignment's own **value** is the list it actually stored —
+the RHS zipped against the slots, so both padded and truncated — not the raw RHS.
+`(%h<a b c> = 1, 2)` is `(1, 2, Any)` and `(@a[0,1] = 1, 2, 3)` is `(1, 2)`. The
+positional arm builds that list as it assigns; the associative arm, which exits
+through the shared tail rather than returning early, hands it up in
+`slice_assigned_rvalue`.
+
+## Tests
+
+`t/slice-assign-pads-short-rhs.t` grows from 20 to 30 assertions: the whole-array
+and whole-hash hyper spellings, the Range and Whatever subscripts, the
+undefined-scalar slice arity and a hyper assignment through it, and four rvalue
+rows. Every one was run against `raku v2026.07` first.
+`roast/S03-metaops/hyper.t`, `roast/S13-overloading/metaoperators.t` (which uses
+`$a<a b c> »=» 42`), `t/hyper-assign-nested-destructuring.t`,
+`t/index-assign-shadow-slot.t` and `t/unicode-ops-hyper.t` all stay green.
+
+Two neighbourhood findings are filed rather than fixed here:
+`todo/tickets/hyper-assign-to-a-list-of-lvalues-cannot-broadcast.md` (a scalar
+RHS into `($x, $y) »=» 5` dies, because that lowering indexes the RHS
+positionally) and
+`todo/tickets/one-element-slice-assignment-rvalue-is-not-a-list.md`.

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1027,13 +1027,6 @@ pub(crate) enum Stmt {
     MarkBind,
     /// Flag that the next slice assignment is a HYPER one (`%h<a b c> »=» 7`).
     ///
-    /// A plain slice assignment ZIPS: a slot past the end of the RHS gets the
-    /// container's undefined value (`%h<a b> = 1` leaves `b` as `Any`). A hyper
-    /// one CYCLES the RHS instead (`%h<a b c> »=» (1, 2)` is `a => 1, b => 2,
-    /// c => 1`), which is the whole point of the metaoperator. The two are the
-    /// same `IndexAssign` node by the time the VM sees them, so the hyper
-    /// desugaring (`lower_hyper_assignment`) emits this marker ahead of it.
-    MarkHyperSliceAssign,
     /// Mark a sigilless variable as readonly via `__mutsu_sigilless_readonly::NAME` env key.
     MarkSigillessReadonly(String),
     /// Register a sigilless variable name in the compiler's `sigilless_locals`

--- a/src/compiler/expr_ops.rs
+++ b/src/compiler/expr_ops.rs
@@ -223,20 +223,33 @@ impl Compiler {
         let left = left.peel_parens();
         // Detect assignment hyper-ops (e.g. >>+=>>, >>~=>>)
         // These need to compute with the base op and then assign back.
-        let is_assign_op = op.ends_with('=')
-            && op.len() > 1
-            && !matches!(
-                op,
-                "==" | "!=" | "<=" | ">=" | "===" | "!==" | "<=>" | "=~=" | "=:="
-            );
+        // `»=»` is one of them: its base op IS `=`, which yields its right
+        // operand, so the distributed list is what gets stored back.
+        let is_assign_op = op == "="
+            || (op.ends_with('=')
+                && op.len() > 1
+                && !matches!(
+                    op,
+                    "==" | "!=" | "<=" | ">=" | "===" | "!==" | "<=>" | "=~=" | "=:="
+                ));
+        // The base op of `»+=»` is `+`; the base op of `»=»` is `=` itself.
+        // Only computed for an assignment hyper-op: slicing off a trailing byte
+        // is safe there (every such op ends in the ASCII `=`), but not for an
+        // arbitrary op, which may end in a multi-byte char (`»×»`).
+        let base_op: &str = if !is_assign_op {
+            op
+        } else if op == "=" {
+            "="
+        } else {
+            &op[..op.len() - 1]
+        };
         // Hyper meta-assignment over a literal list of lvalues, e.g.
         // `($a, $b, $c) »~=» <pie tart>`: compute the element-wise result with
         // the base op, then distribute it back to each lvalue via the regular
         // list-assignment machinery so each scalar is mutated.
         if is_assign_op && matches!(left, Expr::ArrayLiteral(_)) {
-            let base_op = op[..op.len() - 1].to_string();
             let value_expr = Expr::HyperOp {
-                op: base_op,
+                op: base_op.to_string(),
                 left: Box::new(left.clone()),
                 right: Box::new(right.clone()),
                 dwim_left,
@@ -250,7 +263,6 @@ impl Compiler {
             return;
         }
         if is_assign_op {
-            let base_op = &op[..op.len() - 1];
             self.compile_expr(left);
             self.compile_expr(right);
             let op_idx = self.code.add_constant(Value::str(base_op.to_string()));

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -1323,9 +1323,6 @@ impl Compiler {
             Stmt::MarkBind => {
                 // Handled by SyntheticBlock detection; no-op when compiled standalone.
             }
-            Stmt::MarkHyperSliceAssign => {
-                self.code.emit(OpCode::MarkHyperSliceAssign);
-            }
             Stmt::MarkSigilless(name) => {
                 // Track a sigilless local so BareWord compilation reads it from its
                 // slot (GetLocal), not via GetBareWord/env. Unlike

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -990,9 +990,6 @@ pub(crate) enum OpCode {
     AttrContainerRef(u32),
     /// Signal that the next SetLocal is a `:=` bind (preserve container type for `@` vars).
     MarkBindContext,
-    /// Signal that the next slice assignment CYCLES its RHS rather than padding
-    /// a short one -- see `Stmt::MarkHyperSliceAssign`.
-    MarkHyperSliceAssign,
     /// Signal that the next SetLocal binds a `$` scalar to a Positional value via
     /// `:=`, so it must be recorded as decontainerized (so `@a = $bound` flattens).
     MarkScalarBindContext,

--- a/src/parser/expr/precedence_meta_ops/hyper_concat.rs
+++ b/src/parser/expr/precedence_meta_ops/hyper_concat.rs
@@ -148,7 +148,27 @@ fn lower_hyper_assign_target(target: Expr, source: Expr) -> Expr {
     }
 }
 
-fn lower_hyper_assignment(target: Expr, value: Expr) -> Expr {
+fn lower_hyper_assignment(target: Expr, value: Expr, dwim_left: bool, dwim_right: bool) -> Expr {
+    // A literal list of lvalues destructures positionally, nested sublists
+    // included (`(($a, ($b, $c)), $d) »=« ((4, (5, 6)), 7)`), so it keeps the
+    // element-wise lowering below.
+    //
+    // Every other target is an ordinary hyper op: `=` distributes its RIGHT
+    // operand across the LEFT's shape, and the compiler's assignment-hyper-op
+    // write-back stores the resulting list — the same route `»+=»` takes.
+    // Lowering to a plain `target = value` instead made `@a »=» 7` store a
+    // ONE-element array, and left a slice target to be filled by the store
+    // path broadcasting its short RHS, which is not the same rule (a plain
+    // `@a[0,1,2] = 7` must pad, not broadcast).
+    if !matches!(target.peel_parens(), Expr::ArrayLiteral(_)) {
+        return Expr::HyperOp {
+            op: "=".to_string(),
+            left: Box::new(target),
+            right: Box::new(value),
+            dwim_left,
+            dwim_right,
+        };
+    }
     let temp_name = format!(
         "__mutsu_hyper_assign_{}",
         TMP_INDEX_COUNTER.fetch_add(1, Ordering::Relaxed)
@@ -167,11 +187,6 @@ fn lower_hyper_assignment(target: Expr, value: Expr) -> Expr {
                 custom_traits: Vec::new(),
                 where_constraint: None,
             },
-            // A hyper assignment CYCLES its RHS across the targets, where a
-            // plain slice assignment pads a short one -- see
-            // `Stmt::MarkHyperSliceAssign`. The two are the same `IndexAssign`
-            // node by the time the VM sees them, so say which this is.
-            crate::ast::Stmt::MarkHyperSliceAssign,
             crate::ast::Stmt::Expr(lower_hyper_assign_target(target, Expr::Var(temp_name))),
         ],
         label: None,
@@ -286,7 +301,7 @@ fn parse_hyper_rhs(input: &str, parent_prec: i32) -> PResult<'_, Expr> {
                 enrich_expected_error(err, "expected expression after hyper operator", r.len())
             })?;
             left = if op == "=" {
-                lower_hyper_assignment(left, right)
+                lower_hyper_assignment(left, right, dwim_left, dwim_right)
             } else {
                 Expr::HyperOp {
                     op,
@@ -342,7 +357,7 @@ pub(crate) fn concat_expr(input: &str) -> PResult<'_, Expr> {
                 enrich_expected_error(err, "expected expression after hyper operator", r.len())
             })?;
             left = if op == "=" {
-                lower_hyper_assignment(left, right)
+                lower_hyper_assignment(left, right, dwim_left, dwim_right)
             } else {
                 Expr::HyperOp {
                     op,

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -3090,11 +3090,6 @@ pub struct Interpreter {
     /// `Arc<RwLock<String>>`/`Arc<AtomicU32>` backing works) — see that
     /// module's doc comment for the full history.
     pub(crate) bind_context: Box<Cell<bool>>,
-    /// One-shot: the next slice assignment CYCLES its RHS instead of padding a
-    /// short one, because it came from the hyper metaoperator
-    /// (`%h<a b c> »=» 7`). Set by `OpCode::MarkHyperSliceAssign` and consumed
-    /// by the slice arm of `IndexAssignExprNamed`.
-    pub(crate) hyper_slice_assign: Box<Cell<bool>>,
     pub(crate) scalar_bind_context: Box<Cell<bool>>,
     /// Set by `MarkParamRawBindContext` just before the SetLocal/SetGlobal of
     /// an assignment whose target is a sigilless binding (`-> \v` loop-param

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -3149,7 +3149,6 @@ impl Interpreter {
             #[cfg(feature = "jit")]
             jit_error: None,
             bind_context: Box::new(std::cell::Cell::new(false)),
-            hyper_slice_assign: Box::new(std::cell::Cell::new(false)),
             scalar_bind_context: Box::new(std::cell::Cell::new(false)),
             param_raw_bind_context: Box::new(std::cell::Cell::new(false)),
             bound_decont_active: Box::new(std::cell::Cell::new(false)),

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -890,7 +890,6 @@ impl Interpreter {
             #[cfg(feature = "jit")]
             jit_error: None,
             bind_context: Box::new(std::cell::Cell::new(false)),
-            hyper_slice_assign: Box::new(std::cell::Cell::new(false)),
             scalar_bind_context: Box::new(std::cell::Cell::new(false)),
             param_raw_bind_context: Box::new(std::cell::Cell::new(false)),
             bound_decont_active: Box::new(std::cell::Cell::new(false)),

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -2338,10 +2338,6 @@ impl Interpreter {
                 self.bind_context.set(true);
                 *ip += 1;
             }
-            OpCode::MarkHyperSliceAssign => {
-                self.hyper_slice_assign.set(true);
-                *ip += 1;
-            }
             OpCode::MarkParamRawBindContext => {
                 self.param_raw_bind_context.set(true);
                 *ip += 1;

--- a/src/vm/vm_hyper_ops.rs
+++ b/src/vm/vm_hyper_ops.rs
@@ -493,6 +493,13 @@ impl Interpreter {
             };
         }
         // Base case: both operands are scalars.
+        // A hyper assignment's leaf op yields its right operand: `@a »=» 7`
+        // distributes 7 across @a's shape, and the old left value is simply
+        // replaced. The distribution and the dwim rules are the ordinary hyper
+        // ones, handled above; only the leaf is special.
+        if op == "=" {
+            return Ok(right.clone());
+        }
         if op == "~~" {
             return Ok(Value::truth(self.vm_smart_match(left, right)));
         }

--- a/src/vm/vm_var_assign_coerce.rs
+++ b/src/vm/vm_var_assign_coerce.rs
@@ -599,15 +599,13 @@ impl Interpreter {
 
     /// The value slot `i` of a slice assignment receives.
     ///
-    /// A plain slice assignment ZIPS, so a slot past the end of the RHS gets
-    /// `pad` ([`Self::slice_pad_value`]). A HYPER one CYCLES the RHS instead --
-    /// `%h<a b c> »=» (1, 2)` is `a => 1, b => 2, c => 1`, which is the whole
-    /// point of the metaoperator (`Stmt::MarkHyperSliceAssign` is what tells
-    /// the two apart, since they are the same `IndexAssign` node here).
-    pub(crate) fn slice_rhs_value(vals: &[Value], i: usize, cycle: bool, pad: &Value) -> Value {
-        if cycle && !vals.is_empty() {
-            return vals[i % vals.len()].clone();
-        }
+    /// A slice assignment ZIPS, so a slot past the end of the RHS gets `pad`
+    /// ([`Self::slice_pad_value`]). The HYPER spelling cycles instead --
+    /// `%h<a b c> »=» (1, 2)` is `a => 1, b => 2, c => 1` -- but that is now
+    /// decided where it belongs, in the hyper op itself: `»=»` lowers to an
+    /// ordinary `Expr::HyperOp` whose dwim rules produce an exact-length list,
+    /// so by the time a slice store sees it there is nothing left to cycle.
+    pub(crate) fn slice_rhs_value(vals: &[Value], i: usize, pad: &Value) -> Value {
         vals.get(i).cloned().unwrap_or_else(|| pad.clone())
     }
 

--- a/src/vm/vm_var_assign_index_named.rs
+++ b/src/vm/vm_var_assign_index_named.rs
@@ -307,6 +307,11 @@ impl Interpreter {
         // the assigned value (`$sh<k> = 2` is `Bool::True`); set in the Set store
         // arm and applied at the final result push.
         let mut setty_bool_result: Option<Value> = None;
+        // A hash slice assignment's rvalue is the list of values it actually
+        // stored (the RHS zipped against the keys, so truncated AND padded), not
+        // the raw RHS. Set by the hash-slice arm, which exits through the shared
+        // tail rather than returning early like its positional twin.
+        let mut slice_assigned_rvalue: Option<Value> = None;
         // §1.4 shadow-slot: the compiler-baked slot is valid only for the
         // target's own name (`original_var_name`). If a sigilless alias redirects
         // to a DIFFERENT variable, the baked slot no longer applies — fall back to
@@ -1471,14 +1476,11 @@ impl Interpreter {
             // made, so an `ItemList` that reaches here unnormalized by some
             // other route is still handled.)
             ValueView::Array(keys, kind) if is_positional || !kind.is_itemized() => {
-                let mut vals = self.assignment_rhs_values(&val)?;
+                let vals = self.assignment_rhs_values(&val)?;
                 // The value the slots past the end of the RHS get -- see
                 // `slice_pad_value`. Computed once here, before the `&mut
                 // self.env` borrows below.
                 let pad = self.slice_pad_value(&var_name);
-                // One-shot, consumed here whether or not this turns out to be a
-                // slice, so it cannot leak onto the next assignment.
-                let cycle_rhs = self.hyper_slice_assign.replace(false);
                 // Per-element type check for slice assignment to a typed array,
                 // e.g. `my Array @x; @x[0,2] = 2, 3` must reject each Int element.
                 if var_name.starts_with('@')
@@ -1528,6 +1530,12 @@ impl Interpreter {
                         has_declared_shape || crate::runtime::utils::is_shaped_array(container);
                     let mut initialized_marks: Vec<String> = Vec::new();
                     let mut nested_result: Option<Value> = None;
+                    // The values a flat slice assignment actually stored, in slot
+                    // order -- the RHS zipped against the slots, so it is both
+                    // truncated (a long RHS drops its tail) and padded (a short
+                    // one contributes the element's undefined value). That list,
+                    // not the raw RHS, is the assignment's rvalue in raku.
+                    let mut assigned_values: Vec<Value> = Vec::new();
                     if is_shaped {
                         if bind_mode && is_bound_index {
                             return Err(RuntimeError::assignment_ro(None));
@@ -1537,7 +1545,8 @@ impl Interpreter {
                             // 1D shaped array with multiple indices: slice
                             // assignment, padded like the flat one below.
                             for (i, key) in keys.iter().enumerate() {
-                                let v = Self::slice_rhs_value(&vals, i, cycle_rhs, &pad);
+                                let v = Self::slice_rhs_value(&vals, i, &pad);
+                                assigned_values.push(v.clone());
                                 Self::assign_array_multidim(
                                     container,
                                     std::slice::from_ref(key),
@@ -1606,7 +1615,8 @@ impl Interpreter {
                         // typed target pads with its element type
                         // (`my Int @a` with `Int`, `my int @a` with `0`).
                         for (i, key) in keys.iter().enumerate() {
-                            let v = Self::slice_rhs_value(&vals, i, cycle_rhs, &pad);
+                            let v = Self::slice_rhs_value(&vals, i, &pad);
+                            assigned_values.push(v.clone());
                             Self::assign_array_multidim(container, std::slice::from_ref(key), v)?;
                             initialized_marks.push(Self::encode_bound_index(key));
                         }
@@ -1625,6 +1635,8 @@ impl Interpreter {
                         nested
                     } else if idx_is_single_element {
                         Self::itemize_value(val)
+                    } else if !assigned_values.is_empty() {
+                        Value::array(assigned_values)
                     } else {
                         val
                     };
@@ -1641,9 +1653,6 @@ impl Interpreter {
                     }
                     self.stack.push(result);
                     return Ok(());
-                }
-                if vals.is_empty() {
-                    vals.push(Value::NIL);
                 }
                 // A mutable QuantHash (SetHash/BagHash/MixHash) slice assignment
                 // applies membership/count/weight semantics per key
@@ -1828,6 +1837,7 @@ impl Interpreter {
                     String,
                     crate::gc::Gc<crate::value::ContainerCell>,
                 )> = Vec::new();
+                let mut assigned_values: Vec<Value> = Vec::new();
                 if let Some(entry) = self.env_mut().get_mut(&var_name) {
                     let _ = entry.with_hash_mut(|hash| {
                         let h = crate::value::gc_data_mut(hash);
@@ -1848,8 +1858,9 @@ impl Interpreter {
                                 // slice, so `%h<a b> = 1` filled both keys and
                                 // `%j{1,2,3} = "z","y"` repeated `"z"`; the
                                 // hyper spelling keeps the cycle.
-                                Self::slice_rhs_value(&vals, i, cycle_rhs, &pad)
+                                Self::slice_rhs_value(&vals, i, &pad)
                             };
+                            assigned_values.push(v.clone());
                             if bind_mode
                                 && let Some(Some((source_install, cell))) = slice_bind_cells.get(i)
                             {
@@ -1880,6 +1891,9 @@ impl Interpreter {
                     let cell_val = Value::container_ref(cell);
                     self.set_env_with_main_alias(&source_name, cell_val.clone());
                     self.update_local_if_exists(code, &source_name, &cell_val);
+                }
+                if !assigned_values.is_empty() {
+                    slice_assigned_rvalue = Some(Value::array(assigned_values));
                 }
             }
             _ => {
@@ -2851,6 +2865,8 @@ impl Interpreter {
         // keeps a string-range hash subscript from being mis-itemized.
         let result = if let Some(bool_result) = setty_bool_result {
             bool_result
+        } else if let Some(assigned) = slice_assigned_rvalue {
+            assigned
         } else if idx_is_single_element && !var_name.starts_with('%') {
             Self::itemize_value(val)
         } else {

--- a/src/vm/vm_var_index_ops.rs
+++ b/src/vm/vm_var_index_ops.rs
@@ -2377,8 +2377,22 @@ impl Interpreter {
             // object returns Any per Raku spec (S09/autovivification): reading a
             // missing key does not autovivify and the result must be indistinct
             // from Any so that `%h<missing><b> === Any` holds.
-            (ValueView::Package(name), _) if !is_positional && name.resolve() == "Any" => {
-                Value::package(Symbol::intern("Any"))
+            (ValueView::Package(name), idx) if !is_positional && name.resolve() == "Any" => {
+                // A SLICE of keys answers a matching-length list of Any, exactly
+                // like the positional arm below: `my $h; $h<a b c>` is
+                // `(Any, Any, Any)` in raku, and collapsing it to a single `Any`
+                // lost the slice's arity — which a hyper assignment
+                // (`$h<a b c> »=» 42`) needs to know how many slots it is
+                // distributing over.
+                match idx {
+                    ValueView::Array(items, kind) if !kind.is_itemized() => Value::array(
+                        items
+                            .iter()
+                            .map(|_| Value::package(Symbol::intern("Any")))
+                            .collect(),
+                    ),
+                    _ => Value::package(Symbol::intern("Any")),
+                }
             }
             // Postcircumfix POSITIONAL index (`[idx]`) on the bare Any type object —
             // a runtime Any value (e.g. from a missing hash key: `my %h; %h<k>[0]`)

--- a/src/whatever_curry/mark/stmt.rs
+++ b/src/whatever_curry/mark/stmt.rs
@@ -170,7 +170,6 @@ pub(super) fn mark_stmt(stmt: &mut Stmt) {
         Stmt::MarkReadonly(..)
         | Stmt::MarkBoundContainer(_)
         | Stmt::MarkBind
-        | Stmt::MarkHyperSliceAssign
         | Stmt::MarkSigillessReadonly(_)
         | Stmt::MarkSigilless(_)
         | Stmt::ProtoToken { .. }

--- a/t/slice-assign-pads-short-rhs.t
+++ b/t/slice-assign-pads-short-rhs.t
@@ -1,6 +1,6 @@
 use Test;
 
-plan 20;
+plan 30;
 
 # A slice assignment is a LIST assignment: raku zips the RHS against the
 # targeted slots, and a slot past the end of the RHS gets the container's
@@ -77,9 +77,9 @@ plan 20;
     is %s.raku, '{:a(1), :b(2), :c(Any)}', 'a Seq RHS pads its short tail';
 }
 
-# The HYPER spelling is the opposite rule and keeps it: it CYCLES the RHS
-# across the targets, which is the whole point of the metaoperator. Spelled
-# with the Unicode delimiters because rakudo does not parse the ASCII
+# The HYPER spelling is the opposite rule and keeps it: it distributes its RHS
+# across the target's shape, which is the whole point of the metaoperator.
+# Spelled with the Unicode delimiters because rakudo does not parse the ASCII
 # `>>=>>` form in this position.
 {
     my %h; %h<a b c> »=» 7;
@@ -96,4 +96,61 @@ plan 20;
 {
     my %j; my @k = <a b c>; %j{@k} »=» 9;
     is %j.raku, '{:a(9), :b(9), :c(9)}', 'and with a runtime key list';
+}
+
+# The rest of the hyper rule, which a slice store cannot express at all: `»=»`
+# distributes across the target's SHAPE, so it applies to a whole container and
+# to a computed index list just as much as to a literal slice. It used to lower
+# to a plain `target = value`, which stored a ONE-element array for the whole-
+# container spelling and left the literal slice to be filled by the store
+# broadcasting a short RHS.
+{
+    my @a = 1, 2, 3; @a »=» 7;
+    is @a.raku, '[7, 7, 7]', 'a hyper assignment over a whole array keeps its length';
+}
+{
+    my %h = a => 1, b => 2; %h »=» 7;
+    is %h.raku, '{:a(7), :b(7)}', 'and over a whole hash keeps its keys';
+}
+{
+    my @a = 1, 2, 3; @a[0..2] »=» 7;
+    is @a.raku, '[7, 7, 7]', 'a Range subscript distributes too';
+}
+{
+    my @a = 1, 2, 3; @a[*] »=» 7;
+    is @a.raku, '[7, 7, 7]', 'and a Whatever subscript';
+}
+
+# A hyper assignment has to know the slice's ARITY, which an undefined scalar's
+# associative slice read used to collapse to a single `Any`. Its positional twin
+# (`$h[0,1,2]`) was already right.
+{
+    my $h;
+    is $h<a b c>.raku, '(Any, Any, Any)',
+        'an associative slice of an undefined scalar has the slice arity';
+}
+{
+    my $h; $h<a b c> »=» 42;
+    is ($h<a>, $h<b>, $h<c>).raku, '(42, 42, 42)',
+        'so a hyper assignment through one fills every key';
+}
+
+# A slice assignment's own VALUE is the list it actually stored -- the RHS
+# zipped against the slots, so both padded and truncated -- not the raw RHS.
+{
+    my %h;
+    is (%h<a b c> = 1, 2).raku, '(1, 2, Any)', 'a hash slice rvalue is padded';
+}
+{
+    my %h;
+    is (%h<a b> = 1, 2, 3).raku, '(1, 2)', 'a hash slice rvalue is truncated';
+}
+{
+    my @a;
+    is (@a[0, 1, 2] = 5,).raku, '(5, Any, Any)', 'an array slice rvalue is padded';
+}
+{
+    my Int @a;
+    is (@a[0, 1, 2] = 5,).raku, '(5, Int, Int)',
+        'and a typed one pads its rvalue with the element type';
 }

--- a/todo/tickets/array-subclass-assignment-in-expression-position.md
+++ b/todo/tickets/array-subclass-assignment-in-expression-position.md
@@ -1,42 +1,120 @@
-# An array assignment in VALUE position does not decompose an `is Array` subclass
+# An `is Array` subclass crossing an assignment: the two paths disagree in both directions
 
 Split out of `news/2026-09/array-subclass-iterator-override.md` (2026-09-07),
-which fixed the statement-position spelling. Everything below is what is left.
+which fixed the statement-position spelling. Re-measured and re-scoped
+2026-09-07 after an attempt that produced a working half and a blocked half —
+see "What an attempt established" below, which is the part worth reading before
+touching this again.
 
 ## Repro
 
 ```raku
 class SA is Array { }
+
+# (1) a `@`-bound instance: list assignment must DISTRIBUTE its elements
 my @a := SA.new(3,2,1,4);
+my @c = @a;              say @c.raku;   # raku [3, 2, 1, 4]   mutsu [3, 2, 1, 4]   OK
+say (my @b = @a).raku;                  # raku [3, 2, 1, 4]   mutsu [[3, 2, 1, 4]]
+my @d; say (@d = @a).raku;              # raku [3, 2, 1, 4]   mutsu [[3, 2, 1, 4]]
 
-my @c = @a;              # statement position
-say @c.raku;             # raku: [3, 2, 1, 4]     mutsu: [3, 2, 1, 4]   -- correct
-
-say (my @b = @a).raku;   # value position
-                         # raku: [3, 2, 1, 4]     mutsu: [[3, 2, 1, 4]]
+# (2) a `$`-held instance: list assignment must store it as ONE element
+my $e = SA.new(3,2,1,4);
+my @h; @h = $e;          say @h.raku;   # raku [[3, 2, 1, 4],]   mutsu [3, 2, 1, 4]
+say (my @f = $e).raku;                  # raku [[3, 2, 1, 4],]   mutsu [[3, 2, 1, 4]]   OK
 ```
 
-The same assignment, written where its result is consumed, still stores the
-instance as a single element. With an `iterator` override on the class the
-value-position form is wrong in the same way (`[[1, 2, 3, 4]]` where rakudo
-says `[1, 2, 3, 4]`), so this is one gap, not two.
+So this is **not** "value position is missing the rule". The two directions are
+wrong in opposite ways, and each is right in exactly the position where the
+other is wrong. An `iterator` override behaves the same way in direction (1)
+(`class SB is Array { method iterator() {…} }`, value position gives
+`[[7, 8, 9]]` where rakudo gives `[7, 8, 9]`).
 
-## Where to look
+## What an attempt established (2026-09-07)
 
-The statement-position fix landed in `Interpreter::set_local_*`
-(`src/vm/vm_var_assign_set_local.rs`), on the `else if` chain that already
-handled a `does Iterable` instance through `try_iterable_instance_items`: an
-`is Array`/`is List` subclass instance now distributes its
-`__mutsu_array_storage` elements there. The parenthesised form evidently
-compiles to a different assignment path that never reaches that chain — find
-it and give it the same rule (ideally by routing both through one helper, so
-the next such divergence cannot happen).
+**Direction (1) is a solved, mechanical fix, and it is small.** There are
+exactly **three** `@`-store routes, and only one of them carries the rule:
+
+| route | opcode | where | has the rule |
+|---|---|---|---|
+| statement `my @c = @a` | `SetLocalDecl` | `src/vm/vm_var_assign_set_local.rs` | yes |
+| expression `(my @b = @a)` | `SetGlobal` | `src/vm/vm_exec_dispatch.rs`, the `name.starts_with('@')` arm | no |
+| expression `(@d = @a)` | `AssignExprLocal` | `src/vm/vm_var_assign_local.rs`, the `name.starts_with('@')` arm | no |
+
+(`--dump-bytecode` shows the split directly; the expression-position declaration
+compiles through `SetGlobal` because `decl_slot` is `None` there.) Lifting the
+`try_iterable_instance_items` / `__mutsu_array_storage` chain out of
+`set_local` into one helper — `positional_assign_instance_items`, next to
+`try_iterable_instance_items` in `src/vm/vm_for_loop_dispatch.rs` — and calling
+it from all three fixes every row of direction (1), including the `iterator`
+override. That was built and measured.
+
+**Direction (2) is the blocker, and it is a representation question, not a
+routing one.** The reason no store route can tell the two directions apart is
+that mutsu does not itemize an `is Array` subclass instance when it is stored in
+a `$`:
+
+```
+my $e = SA.new(3,2,1,4);  say $e.raku;   # raku $[3, 2, 1, 4]   mutsu [3, 2, 1, 4]
+```
+
+An ordinary `my $x = [1,2,3]` *is* itemized (mutsu's `@y = $x` correctly gives
+one element), so the missing itemization is what leaves the instance
+indistinguishable from the `@`-bound one at every `@`-store site. Fixing
+direction (1) alone therefore **regresses** the two direction-(2) rows that were
+accidentally right, which is why the attempt was withdrawn whole rather than
+half-landed.
+
+The obvious itemization — a `Scalar` wrapper in
+`Interpreter::itemize_scalar_store_value`, which is exactly what the `Range` arm
+right below it does, since an instance has no itemized representation of its own
+— was tried and **measured to break the receiver**:
+
+```
+class SA is Array {}; my $c = SA.new(1,2);
+$c.elems      # 1   (raku 2)      -- the wrapper's own element count
+$c.join("-")  # SA()  (raku 1-2)
+for $c { … }  # $_ gists as SA()  (raku "1 2")
+```
+
+Adding the unwrap to `call_method_with_values_inner` was not enough: the hot
+method-call paths reach `delegates_to_array_storage` from **three** places
+(`src/vm/vm_call_method_ops.rs`, `src/vm/vm_call_method_mut_ops.rs`,
+`src/runtime/methods_call_dispatch.rs`), each testing `target.view()` for
+`ValueView::Instance` directly, and `for`-loop iteration and stringification
+test it again. A `Scalar`-wrapped instance is invisible to all of them.
+
+## The decision this needs
+
+How is "this container-subclass instance is held in a `$`" represented, such
+that every existing `ValueView::Instance` test still sees an instance?
+
+Three candidates, none free:
+
+1. **`Scalar` wrapper + make the wrapper transparent** at every method-call
+   receiver, `for`-loop source, and stringifier. Semantically the cleanest (it
+   is what `Range` does, and what the ADR-0064 container-transparency rule
+   already says), and the largest diff. Ordering matters: `.VAR`, `.raku` and
+   `.perl` must keep seeing the wrapper, or `$e.raku` loses its `$`.
+2. **Itemize the backing `__mutsu_array_storage`** to an itemized `ArrayKind`.
+   Contained, but `value_to_list` on an itemized array yields one element, so
+   every delegation through the storage (`.elems`, `.join`, …) breaks the same
+   way — measured to be the same dead end as (1) without its upside.
+3. **A marker attribute** on the instance, consulted only by
+   `positional_assign_instance_items`. Smallest possible diff and nothing else
+   changes — but it stores a *container* property inside the *object*, and
+   instance attributes are deep-copied on assignment, so `my @z := $e` would
+   inherit an itemization that is not its own. A band-aid; would need a
+   `// TODO:` and probably does not survive review.
+
+(1) looks right and is plausibly ADR-sized. Do not start direction (1)'s routing
+fix without settling this first — on its own it trades three wrong rows for two.
 
 ## Check when fixing
 
 `say (my @b = @a).raku` and `say (@b = @a).raku` for an already-declared `@b`;
-the same two with an `iterator` override (which must follow the override, as
-the statement form does); `my $c = SA.new(...)` in value position, which must
-STAY one element (`[[3, 2, 1, 4],]` in rakudo — an itemized scalar is not
-decomposed); and `t/array-subclass-iterator-override.t`, which pins the
-statement-position behaviour.
+the same two with an `iterator` override (which must follow the override, as the
+statement form does); `my $c = SA.new(...)` in **both** positions, which must
+give one element in both; `$c.elems` / `$c.join` / `for $c` / `$c.raku` /
+`$c.push`, which is where the itemization representation shows; and
+`t/array-subclass-iterator-override.t`, which pins the statement-position
+behaviour and does **not** currently pin the `@e = $c` row — add it.

--- a/todo/tickets/hyper-assign-to-a-list-of-lvalues-cannot-broadcast.md
+++ b/todo/tickets/hyper-assign-to-a-list-of-lvalues-cannot-broadcast.md
@@ -1,0 +1,61 @@
+# A hyper assignment into a flat list of lvalues dies on a scalar RHS
+
+Found 2026-09-07 in the neighbourhood of
+`news/2026-09/short-rhs-slice-assign-broadcasts-instead-of-padding.md`, which
+made `»=»` a real distributing hyper op for every *other* target shape.
+Pre-existing and independent of that change (verified against the same tree
+with the change stashed), so it was left out of scope there.
+
+## Repro
+
+```
+$ ./target/debug/mutsu -e 'my ($x, $y); ($x, $y) »=» 5; say ($x, $y).raku'
+Index out of range. Is: 1, should be in 0..0
+  in block <unit> at -e line 1
+
+$ raku -e 'my ($x, $y); ($x, $y) »=» 5; say ($x, $y).raku'
+(5, 5)
+```
+
+A **list** RHS works on both (`($x, $y) »=» (5, 6)` gives `(5, 6)`), so it is the
+scalar RHS specifically. This is the same broadcast raku applies to every other
+hyper target — `@a »=» 7` and `%h »=» 7` both fill every slot — so the list of
+lvalues is the one shape that cannot take it.
+
+## Root cause
+
+`lower_hyper_assign_target` (`src/parser/expr/precedence_meta_ops/hyper_concat.rs`)
+lowers a literal list of lvalues by *positional index into the RHS*: element `i`
+of the target is assigned `Expr::Index { target: source, index: i }`. With a
+scalar source that is `5[1]`, which is out of range rather than a broadcast.
+
+The lowering is recursive and handles nested sublists
+(`(($a, ($b, $c)), $d) »=« ((4, (5, 6)), 7)`, pinned by
+`t/hyper-assign-nested-destructuring.t`), which is why it is a separate path
+from the ordinary `Expr::HyperOp` route that every other target now takes.
+
+## Fix sketch
+
+Two shapes are available and they trade off differently:
+
+1. **Pre-distribute before destructuring.** Build the RHS as
+   `HyperOp { op: "=", left: <the target read>, right: value, dwim_left, dwim_right }`
+   and destructure *that* — the hyper machinery already gets the length and the
+   dwim arrows right, and the target read `($a, $b)` supplies the arity. The
+   risk is the RHS-evaluated-once guarantee: `t/hyper-assign-nested-destructuring.t`'s
+   third subtest asserts a `do { … }` RHS runs exactly once, and the current
+   lowering buys that with the `__mutsu_hyper_assign_N` temp. Keep the temp.
+2. **Index with a dwim.** Replace the raw `source[i]` with an index that cycles
+   a shorter source, which is what the hyper dwim rule says anyway. Smaller, but
+   it re-implements the dwim rule in the parser instead of reusing it.
+
+Prefer (1) if the once-only evaluation survives; it removes a second
+implementation of the distribution rule rather than adding one.
+
+## Check when fixing
+
+`($x, $y) »=» 5` and `($x, $y) «=« 5` (the arrows decide which side adapts);
+`($x, $y) »=» (5, 6)`; a nested target with a scalar RHS
+(`(($a, $b), $c) »=» 9`); a non-dwim mismatch, which must still raise
+`X::HyperOp::NonDWIM`; and all three subtests of
+`t/hyper-assign-nested-destructuring.t`, especially the evaluate-once one.

--- a/todo/tickets/one-element-slice-assignment-rvalue-is-not-a-list.md
+++ b/todo/tickets/one-element-slice-assignment-rvalue-is-not-a-list.md
@@ -1,0 +1,73 @@
+# A one-element slice assignment's rvalue is the bare element, not a one-element list
+
+Found 2026-09-07 while making a slice assignment's rvalue the list it actually
+stored (`news/2026-09/short-rhs-slice-assign-broadcasts-instead-of-padding.md`).
+Pre-existing and independent of that change — verified against the same tree with
+the change stashed — so it was deliberately left alone there.
+
+## Repro
+
+```
+$ ./target/debug/mutsu -e 'my @d; say (@d[0,] = 5).raku; say (@d[0,] = 5).^name'
+5
+Int
+
+$ raku -e 'my @d; say (@d[0,] = 5).raku; say (@d[0,] = 5).^name'
+(5,)
+List
+```
+
+`.elems` agrees (1 on both), so only the *shape* of the rvalue is wrong: raku
+keeps the one-element **list** a slice always produces, mutsu collapses it to the
+element.
+
+The controls hold and are what make this narrow: a genuine single-index
+assignment yields the bare value on both (`(@d[0] = 5)` is `5`, `(%h<a> = 5)` is
+`5`). A one-element *slice* (`@d[0,]`, with the trailing comma) is a different
+construct — it names a list of one slot — and that is the only shape that
+diverges.
+
+## Where to look
+
+`src/vm/vm_var_assign_index_named.rs`, the `idx_is_single_element` arm of the
+`ValueView::Array(keys, kind)` slice branch:
+
+```rust
+let result = if let Some(nested) = nested_result {
+    nested
+} else if idx_is_single_element {
+    Self::itemize_value(val)          // <-- collapses the slice to its element
+} else if !assigned_values.is_empty() {
+    Value::array(assigned_values)
+} else {
+    val
+};
+```
+
+`idx_is_single_element` is doing double duty. It exists so an *itemized* hash
+index (`my $s = $(1,2); %c{$s}`) is one key rather than a slice — see the long
+comment on the `!kind.is_itemized()` guard just above the arm — and that job is
+load-bearing. Reusing the same flag to decide the *rvalue shape* is what makes a
+one-element positional slice render as a scalar.
+
+The shared tail at the end of the same function has a second copy of the rule
+(`idx_is_single_element && !var_name.starts_with('%')`), so both need the same
+answer.
+
+## Fix sketch
+
+Separate "this subscript names one key" (the itemized-index question, which
+`idx_is_single_element` must keep answering) from "this assignment's rvalue is a
+scalar" (true for `@a[0] = …`, false for `@a[0,] = …`). The distinguishing
+information — whether the subscript was written as a list — is present at the
+opcode's index value, since `@d[0,]` arrives as a one-element non-itemized
+`Array` while `@d[0]` arrives as a bare `Int`; the arm just does not consult it.
+
+## Check when fixing
+
+`(@d[0] = 5)` and `(%h<a> = 5)`, which must stay bare; `(@d[0,] = 5)` and
+`(%h<a>, = 5)`; the itemized-key control from the guard's own comment
+(`my $s = $(1,2); my %c; %c{$s} = "x"; %c.keys`), which must still be one key;
+`roast/S09-subscript/slice.t` and `roast/S32-hash/adverbs.t`; and
+`t/slice-assign-short-rhs-padding.t`, whose rvalue rows pin the multi-element
+side of this arm.


### PR DESCRIPTION
Rebased onto `main` again. The parallel ticket pipeline has now landed all three Tier S rows this branch started from — #7512 (slice padding), #7520 (capture cell) and #7524 (decimal literal) — so those commits are dropped as fully subsumed. **What is left is one commit that none of them covered**, plus the retirement of a mechanism #7512 introduced.

## `»=»` distributes over its target's shape

#7512 kept the hyper spelling working by marking it: `»=»` desugars to the same `IndexAssign` node as `=`, so a `Stmt::MarkHyperSliceAssign` flag told the store to cycle the RHS instead of padding it. That preserved the four slice rows it was measured against, but cycling-in-the-store is only an approximation of the hyper rule, and it was already wrong wherever the metaoperator does not land on a slice store:

```raku
my @a = 1, 2, 3; @a »=» 7;       # raku [7, 7, 7]   is [7]
my @a = 1, 2, 3; @a[0..2] »=» 7; # raku [7, 7, 7]   is [7, Nil, Nil]
my @a = 1, 2, 3; @a[*] »=» 7;    # raku [7, 7, 7]   is [7, Any, Any]
```

The whole-container spelling stores a **one**-element array, because the parser lowers `»=»` to a plain `target = value` and throws the dwim arrows away; nothing distributes anything.

`»=»` is an assignment hyper-op like `»+=»`, so it now compiles as one. Its base op is `=`, which yields its right operand at the leaf; the existing hyper machinery supplies the distribution and the dwim-length rules, and the compiler's assignment-hyper-op write-back stores the result. The base-op slice is now computed only for an assignment hyper-op — every such op ends in the ASCII `=`, where an arbitrary one may end in a multi-byte char and `&op[..op.len() - 1]` panicked on `»×»`. A literal list of lvalues keeps its own recursive lowering, which handles nesting the hyper machinery does not.

Because the distribution now happens in the hyper op, the list a slice store receives is already exactly as long as the slice and there is nothing left to cycle. **`Stmt::MarkHyperSliceAssign`, `OpCode::MarkHyperSliceAssign`, the `hyper_slice_assign` one-shot `Cell` and `slice_rhs_value`'s `cycle` parameter are retired with it** — one mechanism decides the rule, at the point that knows it. All four of #7512's own hyper rows still pass unchanged.

## Two gaps that close with it

- A hyper assignment has to know the slice's **arity**, and an associative slice of an undefined scalar collapses to a single `Any`: `my $h; $h<a b c>` answers `Any` where raku answers `(Any, Any, Any)`. Its positional twin `$h[0,1,2]` is already correct, so the associative arm now has the same shape.
- A slice assignment's own **value** is the list it actually stored — the RHS zipped against the slots, so both padded and truncated — not the raw RHS: `(%h<a b c> = 1, 2)` is `(1, 2, Any)` and `(@a[0,1] = 1, 2, 3)` is `(1, 2)`.

## Testing

- `t/slice-assign-pads-short-rhs.t` grows from 20 to 30 assertions (the new rows added to #7512's file rather than a second near-duplicate file). Every one was run against `raku v2026.07` first.
- Full local `prove t/` (3823 files) green.
- `roast/S03-metaops/hyper.t`, `roast/S13-overloading/metaoperators.t` (which uses `$a<a b c> »=» 42`), `t/hyper-assign-nested-destructuring.t`, `t/index-assign-shadow-slot.t`, `t/unicode-ops-hyper.t` and `t/typed-container-capture-cell.t` all stay green.
- An earlier revision of this branch (same hyper change, plus the two now-dropped commits) passed a full local `make roast` with no regressions.

## `todo/` bookkeeping

- `array-subclass-assignment-in-expression-position` is **rewritten, not fixed**. The value-position half was implemented and measured working — the three `@`-store routes are `SetLocalDecl` / `SetGlobal` / `AssignExprLocal` and only the first carries the rule — but landing it alone *regresses* the `$`-held direction, which is right today only by accident. The ticket now states the blocking representation question (how to mark "this container-subclass instance is held in a `$`" so that every existing `ValueView::Instance` test still sees an instance) and records that the obvious `Scalar` wrapper was measured to break `.elems`, `.join` and `for`.
- Two new tickets from the same neighbourhood: `hyper-assign-to-a-list-of-lvalues-cannot-broadcast` (`($x, $y) »=» 5` dies with "Index out of range") and `one-element-slice-assignment-rvalue-is-not-a-list`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AgkMvUW9c2d1tBXUzy3Wbx