### PR TITLE
fix(runtime): store through the container a user accessor hands back

### DIFF
--- a/docs/adr/0068-cross-thread-container-writes-need-a-synchronized-store.md
+++ b/docs/adr/0068-cross-thread-container-writes-need-a-synchronized-store.md
@@ -1,6 +1,6 @@
 # ADR-0068: A cross-thread aliased container write needs a synchronized store, not a name-keyed lane
 
-- Status: **Accepted** (2026-09-06; §4 steps 1-2 implemented, step 3 started — see §8)
+- Status: **Accepted** (2026-09-06; §4 steps 1-2 implemented, step 3 in progress — see §8, §10)
 - Date: 2026-09-05
 - Relates to: [ADR-0001](0001-gc-strategy-and-phasing.md) §7 (layer 3c),
   [ADR-0013](0013-container-interior-mutability-cellvalue.md) §1.3-2 / §3 / §5 Q2,
@@ -445,3 +445,97 @@ the cell *is* the sharing, so a worker's `@b.push(30)` is visible in the
 declaring frame with no writeback step. See
 `news/2026-09/thread-escaping-container-cell-exclusion-retired.md`; pinned by
 `t/thread-escaping-container-capture-is-lexical.t`.
+
+## 10. Step 3, second slice (2026-09-08): the accessor-returned container, and why it was never a lock
+
+`todo/deep/gc-contents-mut-cross-thread-aliased-writes.md` left one route open
+and flagged it as needing "a decision, not a patch": a container handed back by
+a **user-written** accessor.
+
+```raku
+class Holder { has @.items; method bag() { @!items } }
+```
+
+`$h.bag[$i] = 1` from 20 threads landed **418 / 543 / 304 of 1000** writes
+(rakudo: 1000) — silent loss, no crash. The earlier attempt keyed that funnel's
+guard on the shared invocant and still measured 24/24 wrong, and concluded that
+the exclusion would have to cover the accessor dispatch. Both halves of that
+conclusion turned out to be right, but only after a **deterministic bug** was
+removed from underneath them.
+
+### 10.1 The accessor assignment was rebinding the attribute, not storing through it
+
+`method items { @!items }` hands back the attribute's own `Array`; in raku it
+*is* that object, so `$obj.items = LIST` and `$obj.items[$i] = v` store **into**
+that container. mutsu instead rebuilt the whole attribute map around a fresh
+node (`assign_method_lvalue_with_values`'s `rw_attr_target` branch →
+`Value::write_back_sharing`). That is observable with one thread:
+
+```raku
+my @alias := $h.bag;  $h.bag = (1,2,3);
+say @alias;    # raku: [1 2 3]    mutsu: []
+```
+
+The generated accessor for the same attribute never had the bug, which is
+exactly why `has @.seen` measured 0/240 in §8 while `method seen { @!seen }` lost
+half its writes.
+
+The concurrency consequence is the interesting one, and it is why no amount of
+locking had moved the number: **the container's address moved on every write**,
+so a guard keyed on it locked a different stripe each time (measured: four
+distinct `Gc<ArrayData>` addresses in six writes from two threads). On top of
+that, `write_back_sharing` commits a *copy of the whole attribute map* into the
+shared cell, so a slow thread could clobber concurrent writes to unrelated
+attributes as well.
+
+`ArrayData::adopt_state_from` / `HashData::adopt_state_from` do the store in
+place, preserving the node (and hence `.WHICH`) and dropping the map commit.
+Pin: `t/attribute-accessor-container-identity.t`.
+
+### 10.2 The guard is keyed on the invocant's attribute cell, and taken before the accessor runs
+
+§8 put the attribute funnel's guard on the container the accessor handed back,
+and deliberately left the accessor dispatch outside the region. With §10.1's
+node churn removed the container is stable again — but it is still the wrong
+key, because the *read* that races is the accessor's own read of the live
+container's elements, and that read happens before any guard exists.
+
+The `Gc<InstanceAttrs>` of the invocant is the right key: measured, it is
+identical on every write from every thread reaching the same object, and no
+store moves it. `builtin_index_assign_method_lvalue` now acquires the guard on
+it **before** the accessor dispatch, so the whole read-modify-write — accessor
+call, element modify, store-back — is one critical section. A non-instance
+invocant keeps the previous container/cell key.
+
+This is the decision the ticket asked for. Its cost is that user code (the
+accessor body) now runs inside the region. The at-most-one-lock rule makes that
+safe against the obvious re-entrancy — an accessor that itself stores into a
+container takes no second lock, so it cannot self-deadlock — and what remains
+uncovered is an accessor that *blocks on another thread* while this one holds
+the stripe. No such accessor exists in the suite, and the alternative is leaving
+a live container's element read racing with a `Vec` reallocation, which is a
+use-after-free.
+
+### 10.3 Acceptance (debug build, `MUTSU_GC=on MUTSU_GC_EVERY_CANDIDATE=1024 MUTSU_GC_VERIFY=1`, 24-way)
+
+| Route | Before | After |
+|---|---|---|
+| `$h.bag[$i] = 1`, user accessor, array | 304-543 of 1000 writes landed | **0 / 96 failures** |
+| `$h.bag{$k} = 1`, user accessor, hash | — | **0 / 96** |
+| `$h.bag.push($v)`, user accessor | — | **0 / 96** |
+| `$obj.attr[$i] = v` written INLINE in the thread body (no routine in between) | lost updates on 4 of 5 runs | **0 / 96** |
+| §8's named-sub attribute store (regression check) | 0 / 240 | **0 / 96** |
+
+The inline row is a route §8 never probed: with no routine closing over the
+invocant the container never becomes celled, so neither the celled guard nor the
+name-keyed lane applied to it. It is covered by the same change.
+Pins: three new rows in `t/concurrent-attribute-element-store.t`.
+
+### 10.4 Still open
+
+Route 5 (`Channel.Supply` tap captures) is still blocked behind the
+Channel-supply delivery bug, and §3.1's `S17-procasync/stress.t` SIGSEGV is
+still unexplained. The remaining §2 lane-decline reasons (twigil'd names, a
+container never in a spawning frame's env) stay unprobed; the expectation
+recorded in §8 — that a new route arrives at one of the known funnels — held for
+this one.

--- a/news/2026-09/accessor-returned-container-identity-and-its-cross-thread-store.md
+++ b/news/2026-09/accessor-returned-container-identity-and-its-cross-thread-store.md
@@ -1,0 +1,98 @@
+# A user-written attribute accessor hands back the container, not a copy of it
+
+`todo/deep/gc-contents-mut-cross-thread-aliased-writes.md` (ADR-0068 §4 step 3)
+had one route left open, and had flagged it as needing "a decision, not a
+patch": an element store through a container returned by a **user-written**
+accessor.
+
+```raku
+class Holder { has @.items; method bag() { @!items } }
+```
+
+Twenty threads writing 1000 distinct indices through `$h.bag[$i] = 1` landed
+**418 / 543 / 304** of them (rakudo: 1000) — silent loss, no crash. An earlier
+attempt keyed the funnel's guard on the shared invocant and still measured 24/24
+wrong, and concluded the exclusion would have to cover the accessor dispatch
+itself, which the funnel's own comment had deliberately kept outside its region.
+
+Both halves of that conclusion were right. Neither could work until a
+**deterministic bug underneath them** was removed.
+
+## The accessor assignment was rebinding the attribute
+
+`method items { @!items }` hands back the attribute's own `Array` — in raku it
+*is* that object — so `$obj.items = LIST` and `$obj.items[$i] = v` store **into**
+that container. mutsu rebuilt the whole attribute map around a fresh node
+instead (`assign_method_lvalue_with_values`'s `rw_attr_target` branch →
+`Value::write_back_sharing`). One thread is enough to see it:
+
+```raku
+my @alias := $h.bag;  $h.bag = (1, 2, 3);
+say @alias;    # raku: [1 2 3]     mutsu: []
+```
+
+The *generated* accessor for the same attribute never had this bug, which is
+exactly why ADR-0068 §8 measured `has @.seen` at 0/240 while
+`method seen { @!seen }` lost half its writes: it was never really the same
+route.
+
+The concurrency consequence is what made the route look unfixable. Because the
+attribute was rebound on every write, **the container's address moved on every
+write** — four distinct `Gc<ArrayData>` addresses in six writes from two threads
+— so the ADR-0068 store guard, which keys on the container node when the
+container is not celled, locked a different stripe each time and excluded
+nothing. On top of that, `write_back_sharing` commits a *copy of the whole
+attribute map* into the shared cell, so a slow thread could clobber concurrent
+writes to unrelated attributes as well.
+
+`ArrayData::adopt_state_from` / `HashData::adopt_state_from` now perform the
+store in place, keeping the node (and hence `.WHICH`) and dropping the map
+commit entirely.
+
+## The guard moved to the invocant, and now precedes the accessor
+
+With the node churn gone the container is stable again, but it is still the
+wrong key: the read that races is the accessor's own read of the live
+container's elements, and that read happens before any guard exists. Removing
+the churn without moving the guard turned the lost updates into a NaN-box tag
+panic and `double free or corruption` — honest exposure, not a fix.
+
+The invocant's `Gc<InstanceAttrs>` is the right key. Measured, it is identical
+on every write from every thread that reaches the same object, and no store
+moves it. `builtin_index_assign_method_lvalue` now takes the guard on it
+**before** the accessor dispatch, so the accessor call, the element modify and
+the store-back are one critical section. A non-instance invocant (a `Pair`
+value, a package path accessor) keeps the previous container/cell key.
+
+The cost of that decision is that user code — the accessor body — runs inside
+the region. `container_lock`'s at-most-one-lock-per-thread rule makes it safe
+against the obvious re-entrancy: an accessor that itself stores into a container
+takes no second lock, so it cannot self-deadlock. What stays uncovered is an
+accessor that *blocks on another thread* while this one holds the stripe; no
+such accessor exists in the suite, and the alternative is leaving a live
+container's element read racing with a `Vec` reallocation.
+
+## Measured
+
+Debug build, `MUTSU_GC=on MUTSU_GC_EVERY_CANDIDATE=1024 MUTSU_GC_VERIFY=1`,
+96 processes at 24-way on 12 cores:
+
+| Route | Before | After |
+|---|---|---|
+| `$h.bag[$i] = 1`, user accessor, array | 304-543 of 1000 writes landed | 0 / 96 failures |
+| `$h.bag{$k} = 1`, user accessor, hash | — | 0 / 96 |
+| `$h.bag.push($v)`, user accessor | — | 0 / 96 |
+| `$obj.attr[$i] = v` written INLINE in the thread body | lost updates on 4 of 5 runs | 0 / 96 |
+| ADR-0068 §8's named-sub attribute store (regression check) | 0 / 240 | 0 / 96 |
+
+The inline row is a route §8 never probed: with no routine closing over the
+invocant the container never becomes celled, so neither the celled guard nor the
+name-keyed lane applied to it. The same change covers it.
+
+Pins: `t/attribute-accessor-container-identity.t` (8 deterministic rows, green
+under raku) and three new rows in `t/concurrent-attribute-element-store.t`.
+Recorded as ADR-0068 §10.
+
+Still open in step 3: route 5 (`Channel.Supply` tap captures) behind the
+Channel-supply delivery bug, and ADR-0068 §3.1's unexplained
+`S17-procasync/stress.t` SIGSEGV.

--- a/src/runtime/builtins_multidim_assign.rs
+++ b/src/runtime/builtins_multidim_assign.rs
@@ -50,6 +50,37 @@ impl Interpreter {
         let value = args[3 + offset].clone();
         let var_name = args[4 + offset].to_string_value();
 
+        // ADR-0068 §4 step 3: an attribute-rooted element store on an INSTANCE
+        // is guarded from HERE -- before the accessor runs -- keyed on the
+        // invocant's attribute cell.
+        //
+        // The container the accessor hands back is the wrong key: it moves.
+        // Measured across two threads writing one array attribute, the
+        // attribute's `Gc<ArrayData>` took four distinct addresses in six
+        // writes, so a guard keyed on it locked a different stripe almost every
+        // time and excluded nothing, while the accessor call -- which reads the
+        // live container's elements -- sat outside the region entirely. The
+        // invocant's `Gc<InstanceAttrs>` is the one address every thread
+        // reaching the same object agrees on and that no store moves: the same
+        // measurement shows it identical on all six writes from both threads.
+        //
+        // Extending the region over the accessor dispatch is the decision
+        // `todo/deep/gc-contents-mut-cross-thread-aliased-writes.md` asked for.
+        // It is safe against the obvious re-entrancy: a thread holds at most one
+        // container-structure lock (`container_lock`'s at-most-one rule), so an
+        // accessor that itself stores into a container takes no second lock and
+        // cannot self-deadlock. What it does NOT cover is an accessor that
+        // blocks on *another* thread while this one holds the stripe; no such
+        // accessor exists in the suite, and the alternative -- leaving the read
+        // of the live container unguarded -- is a use-after-free.
+        let invocant_guard = match target.view() {
+            ValueView::Instance { attributes, .. } => {
+                let attrs_addr = crate::gc::Gc::as_ptr(&attributes) as usize;
+                crate::value::container_lock::ContainerStructGuard::acquire(attrs_addr)
+            }
+            _ => None,
+        };
+
         // Path accessors conventionally receive `(root, @steps)`. Resolve that
         // shape from the supplied root so the selected container stays anchored
         // there even when the accessor's `return-rw` temporary is unwound.
@@ -84,17 +115,10 @@ impl Interpreter {
         // for the element modify; the shared-Arc propagation below
         // (`overwrite_array_bindings_by_identity`, now cell-aware) reaches every
         // alias through the cell's inner Arc.
-        // ADR-0068 §4 step 3: an attribute-rooted element store
-        // (`$obj.attr[$i] = v`) is one of the routes the name-keyed cross-thread
-        // lane cannot cover -- it is not name-keyed at all -- and §3 left it
-        // "Unresolved" for want of a trace. Measured with the §1.1 harness:
-        // 96/96 runs corrupt the heap (`corrupted size vs. prev_size`,
-        // `double free or corruption (top)`, a NaN-box tag panic), with the lane
-        // never consulted. Every write below goes through the container the
-        // accessor just handed back, so excluding on that container covers them
-        // all at once. A no-op (one relaxed load) until a VM mutator thread is
-        // spawned; a thread holds at most one of these locks, so the accessor
-        // dispatches inside the region cannot deadlock against themselves.
+        // For a non-instance invocant (a Pair value, a package path accessor)
+        // there is no attribute cell to key on, so the container the accessor
+        // handed back is still the best available key. `acquire_for` is a no-op
+        // when `invocant_guard` above already locked this thread's one stripe.
         let attr_cell_addr = match current.view() {
             ValueView::ContainerRef(cell) => Some(crate::gc::Gc::as_ptr(&cell) as usize),
             _ => None,
@@ -103,10 +127,12 @@ impl Interpreter {
             ValueView::ContainerRef(cell) => cell.lock().unwrap().clone(),
             _ => current,
         };
-        let _struct_guard = crate::value::container_lock::ContainerStructGuard::acquire_for(
-            attr_cell_addr,
-            &current,
-        );
+        let _struct_guard = invocant_guard.or_else(|| {
+            crate::value::container_lock::ContainerStructGuard::acquire_for(
+                attr_cell_addr,
+                &current,
+            )
+        });
 
         // Package-level `is rw` accessors with arguments (for example
         // `Crane::At.at($root, @path)`) return the selected container itself.

--- a/src/runtime/methods_mut_method_lvalue.rs
+++ b/src/runtime/methods_mut_method_lvalue.rs
@@ -1427,6 +1427,17 @@ impl Interpreter {
                 attr_sigil,
                 assigned_value,
             );
+            // The accessor named a container the attribute already holds, so
+            // this is a store INTO that container, not a rebinding of the
+            // attribute (see `store_into_attr_container`). Doing it in place
+            // keeps the container's identity -- and keeps a concurrent writer
+            // from committing a stale copy of the whole attribute map over
+            // another thread's write.
+            if let Some(existing) = updated.get(&attr_name).cloned()
+                && Self::store_into_attr_container(&existing, &assigned_value)
+            {
+                return Ok(assigned_value);
+            }
             updated.insert(attr_name, assigned_value.clone());
             if let Some(var_name) = target_var {
                 self.env.insert_through(

--- a/src/runtime/methods_mut_rw_attr.rs
+++ b/src/runtime/methods_mut_rw_attr.rs
@@ -208,6 +208,55 @@ impl Interpreter {
         None
     }
 
+    /// Store `new_value` into the container the attribute `existing` already
+    /// holds, keeping that container's identity. Returns `false` when the two
+    /// are not the same kind of container, in which case the caller falls back
+    /// to rebinding the attribute.
+    ///
+    /// `method items { @!items }` hands back the attribute's own Array -- in
+    /// raku it *is* that object -- so `$obj.items = LIST` and
+    /// `$obj.items[$i] = v` store INTO that container; they do not rebind the
+    /// attribute to a fresh one. mutsu rebuilt the whole attribute map around a
+    /// new node instead, which was wrong twice over:
+    ///
+    /// - every alias went stale: `my @a := $obj.items; $obj.items = (1,2,3)`
+    ///   left `@a` empty where raku shows `[1 2 3]`;
+    /// - the container node moved on every write, so the ADR-0068 element-store
+    ///   guard -- which keys on the container node when the container is not
+    ///   celled -- locked a different stripe each time and excluded nothing.
+    ///   Twenty threads writing 1000 distinct indices through such an accessor
+    ///   landed 304-543 of them (rakudo: 1000), and the whole-map commit in
+    ///   `write_back_sharing` clobbered concurrent writes to *other* attributes
+    ///   as well. Storing in place removes both the stale map copy and the
+    ///   moving key.
+    ///
+    /// The auto-generated accessor for the same attribute already behaved this
+    /// way, which is why `has @.seen` was measured clean at 0/240 while
+    /// `method seen { @!seen }` lost half its writes.
+    pub(crate) fn store_into_attr_container(existing: &Value, new_value: &Value) -> bool {
+        match (existing.view(), new_value.view()) {
+            (ValueView::Array(dst, _), ValueView::Array(src, _)) => {
+                if crate::gc::Gc::ptr_eq(&dst, &src) {
+                    return true;
+                }
+                let _guard =
+                    crate::value::container_lock::ContainerStructGuard::acquire_for(None, existing);
+                unsafe { crate::value::gc_contents_mut(&dst) }.adopt_state_from(&src);
+                true
+            }
+            (ValueView::Hash(dst), ValueView::Hash(src)) => {
+                if crate::gc::Gc::ptr_eq(&dst, &src) {
+                    return true;
+                }
+                let _guard =
+                    crate::value::container_lock::ContainerStructGuard::acquire_for(None, existing);
+                unsafe { crate::value::gc_contents_mut(&dst) }.adopt_state_from(&src);
+                true
+            }
+            _ => false,
+        }
+    }
+
     /// Assign `value` into element `index_value` of the array/hash attribute
     /// `attr_name` on the instance, then write the updated instance back through
     /// `target_var`. Backs `$obj.rw-method(idx) = value` where the method

--- a/src/value/value_collections.rs
+++ b/src/value/value_collections.rs
@@ -67,6 +67,14 @@ impl HashData {
         self.has_type_meta() || self.original_keys.is_some()
     }
 
+    /// Adopt `src`'s entire state while keeping this node's `.WHICH` identity.
+    /// The hash twin of [`ArrayData::adopt_state_from`].
+    pub(crate) fn adopt_state_from(&mut self, src: &HashData) {
+        let identity = std::mem::take(&mut self.which_id);
+        *self = src.clone();
+        self.which_id = identity;
+    }
+
     /// Whether container *type* metadata (element/key/declared type) is attached.
     /// This is the authoritative replacement for the `hash_type_metadata` side
     /// table: a freshly-built hash literal has `false` here, so it can never
@@ -178,6 +186,19 @@ impl ArrayData {
     /// Whether container *type* metadata (element/key/declared type) is attached.
     pub fn has_type_meta(&self) -> bool {
         self.value_type.is_some() || self.key_type.is_some() || self.declared_type.is_some()
+    }
+
+    /// Adopt `src`'s entire state while keeping this node's `.WHICH` identity.
+    ///
+    /// This is the "same container, new contents" half of a Raku list
+    /// assignment (`@!items = LIST`): the array object survives, so every alias
+    /// of it observes the store. `which_id` is the one field deliberately not
+    /// taken from `src` -- it *is* the identity being preserved, and cloning an
+    /// `ArrayData` mints a fresh one.
+    pub(crate) fn adopt_state_from(&mut self, src: &ArrayData) {
+        let identity = std::mem::take(&mut self.which_id);
+        *self = src.clone();
+        self.which_id = identity;
     }
 
     /// Borrow the element vector through the representation chokepoint.

--- a/t/attribute-accessor-container-identity.t
+++ b/t/attribute-accessor-container-identity.t
@@ -1,0 +1,73 @@
+use Test;
+
+# `method items { @!items }` hands back the attribute's own Array -- in raku it
+# IS that object -- so assigning through the accessor stores INTO that
+# container; it does not rebind the attribute to a fresh one. mutsu rebuilt the
+# whole attribute map around a new node, so every alias of the container went
+# stale, and the container's address moved on every write.
+#
+# The second consequence was the cross-thread one (ADR-0068 §4 step 3): with the
+# node moving, the element-store guard keyed on it locked a different stripe per
+# write and excluded nothing, and `write_back_sharing`'s whole-map commit
+# clobbered concurrent writes to other attributes as well. The concurrency rows
+# live in `t/concurrent-attribute-element-store.t`; these are the deterministic,
+# single-threaded halves.
+
+plan 8;
+
+# The bug as first measured: an alias taken before the assignment.
+{
+    class H { has @.seen; method bag() { @!seen } }
+    my $h = H.new(seen => []);
+    my @alias := $h.bag;
+    $h.bag = (1, 2, 3);
+    is-deeply @alias.List, (1, 2, 3), 'a whole-container store through a user accessor is seen by an alias';
+    is-deeply $h.seen.List, (1, 2, 3), 'and by the attribute itself';
+}
+
+# The auto-generated accessor always behaved this way; pin that the user-written
+# one now matches it.
+{
+    class H2 { has @.seen; }
+    my $g = H2.new(seen => []);
+    my @alias := $g.seen;
+    $g.seen = (4, 5, 6);
+    is-deeply @alias.List, (4, 5, 6), 'the generated accessor stores through the container too';
+}
+
+# The container object survives the store, so `===` holds across it.
+{
+    class H3 { has @.seen; method bag() { @!seen } }
+    my $h = H3.new(seen => []);
+    my $before = $h.bag;
+    $h.bag = (7, 8);
+    ok $before === $h.bag, 'the accessor keeps handing back the same container';
+}
+
+# An element store through the accessor lands in the same container.
+{
+    class H4 { has @.seen; method bag() { @!seen } }
+    my $h = H4.new(seen => []);
+    my @alias := $h.bag;
+    $h.bag[2] = 'x';
+    is @alias[2], 'x', 'an element store through a user accessor reaches the alias';
+}
+
+# The hash twin.
+{
+    class H5 { has %.seen; method bag() { %!seen } }
+    my $h = H5.new(seen => {});
+    my %alias := $h.bag;
+    $h.bag = (a => 1, b => 2);
+    is %alias<b>, 2, 'a whole-container store through a user hash accessor is seen by an alias';
+    $h.bag<c> = 3;
+    is %alias<c>, 3, 'and so is a key store';
+}
+
+# Storing the container into itself must not empty it.
+{
+    class H6 { has @.seen; method bag() { @!seen } }
+    my $h = H6.new(seen => [1, 2, 3]);
+    $h.bag = $h.bag;
+    is-deeply $h.seen.List, (1, 2, 3), 'assigning the container to itself is a no-op';
+}

--- a/t/concurrent-attribute-element-store.t
+++ b/t/concurrent-attribute-element-store.t
@@ -18,7 +18,7 @@ use Test;
 # container all land, but it does not corrupt its own heap either, and every
 # row below is measured green under raku.
 
-plan 4;
+plan 7;
 
 # The array attribute: 1000 distinct indices from 20 threads.
 {
@@ -61,4 +61,47 @@ plan 4;
     sub add($v) { $p.log.push($v) }
     await (^20).map: -> $t { start { for ^50 -> $k { add($t * 50 + $k) } } };
     is $p.log.elems, 1000, 'every push onto an attribute container lands';
+}
+
+# ADR-0068 §4 step 3, the last route the ticket left open: the container is
+# handed back by a USER-WRITTEN accessor (`method bag() { @!items }`) rather
+# than a generated one. It was measured landing 304-543 of 1000 writes.
+#
+# Two things were wrong, and only the first is a locking question. The accessor
+# assignment rebound the attribute to a fresh container instead of storing into
+# the one it already held (pinned deterministically in
+# `t/attribute-accessor-container-identity.t`), so the container's address moved
+# on every write and the store guard, keyed on it, locked a different stripe
+# each time. And the guard was taken only *after* the accessor ran, leaving the
+# read of the live container outside the region. The guard is now keyed on the
+# invocant's attribute cell -- the one address every thread agrees on -- and
+# acquired before the accessor dispatch.
+{
+    class Bagged { has @.items; method bag() { @!items } }
+    my $b = Bagged.new;
+    sub put-it($i) { $b.bag[$i] = 1 }
+    await (^20).map: -> $t { start { for ^50 -> $k { put-it($t * 50 + $k) } } };
+    is $b.items.grep(*.defined).elems, 1000,
+        'every element store through a user-written array accessor lands';
+}
+
+{
+    class HBagged { has %.items; method bag() { %!items } }
+    my $b = HBagged.new;
+    sub put-key($i) { $b.bag{"k$i"} = 1 }
+    await (^20).map: -> $t { start { for ^50 -> $k { put-key($t * 50 + $k) } } };
+    is $b.items.elems, 1000,
+        'every key store through a user-written hash accessor lands';
+}
+
+# The same shape written straight into the thread body, with no named sub in
+# between. This is the variant that stayed exposed after the first attribute
+# slice: with no routine to close over the invocant it never became celled, so
+# the celled read/write guard never applied to it either.
+{
+    class Inline { has @.rows is rw; }
+    my $n = Inline.new(rows => []);
+    await (^12).map: -> $t { start { for ^40 -> $k { $n.rows[$t * 40 + $k] = 1 } } };
+    is $n.rows.grep(*.defined).elems, 480,
+        'an inline attribute element store lands with no routine in between';
 }

--- a/todo/deep/gc-contents-mut-cross-thread-aliased-writes.md
+++ b/todo/deep/gc-contents-mut-cross-thread-aliased-writes.md
@@ -42,8 +42,8 @@ reachable while the name-keyed lane declines (ADR-0068 §2 lists five):
 - the name is not a plain lexical `@`/`%` (attributes, twigils);
 - the name is masked as re-declared;
 - the container was never in a spawning frame's env;
-- the write is not name-keyed at all (`$obj.attr[$i]`, `%h<k>[$i]`, a container
-  returned from a method);
+- the write is not name-keyed at all (~~`$obj.attr[$i]`, `%h<k>[$i]`, a
+  container returned from a method~~ — all three done, see below);
 - ~~mutating *methods* rather than element stores~~ — **done**, see above.
 
 Each wants its own oracle-classified probe and its own stress acceptance, per
@@ -81,21 +81,28 @@ Three specific loose ends from the route audit:
   0/24 after, both the hash-outer and array-outer arms. Pin:
   `t/concurrent-nested-subscript-store.t`.
 
-- **An element store through a container returned by a USER method is still
-  open, and it is NOT a locking gap.** `class Holder { has @.items; method
-  bag() { @!items } }` with `$h.bag[$i] = 1` from 20 threads lands
-  **418 / 543 / 304 of 1000** writes (rakudo: 1000) — silent data loss, no
-  crash. The breakpoint oracle shows it DOES reach the attribute-lvalue funnel
-  (`builtin_index_assign_method_lvalue`), once per write, and keying that
-  funnel's guard on the shared invocant instead of the returned container was
-  implemented and measured: still 24/24 wrong. The reason is that the guard is
-  acquired *after* `current = self.call_method_with_values(...)` — the accessor
-  call, which is where each thread takes its own copy of the array
-  (`Gc::make_mut` on an aliased node), runs unguarded. So the exclusion has to
-  cover the accessor dispatch, which is what that funnel's own comment
-  deliberately kept outside the region ("the accessor dispatches inside the
-  region cannot deadlock against themselves"). Resolving that tension is the
-  next unit of work here, and it needs a decision, not a patch.
+- ~~**An element store through a container returned by a USER method**~~
+  **CLASSIFIED AND FIXED (2026-09-08, ADR-0068 §10).** It was not a locking
+  gap, and the "each thread takes its own copy of the array" reading was wrong
+  in an instructive way: the accessor hands back the attribute's live container
+  just fine, but the *assignment* rebound the attribute to a fresh one
+  (`assign_method_lvalue_with_values`'s `rw_attr_target` branch →
+  `write_back_sharing`) instead of storing into it. That is a deterministic,
+  single-threaded identity bug — `my @a := $h.bag; $h.bag = (1,2,3)` left `@a`
+  empty where raku shows `[1 2 3]` — and it is why the container's address
+  moved on every write, so no guard keyed on it could exclude anything.
+  `ArrayData::adopt_state_from`/`HashData::adopt_state_from` store in place.
+
+  With the churn gone the guard could finally be keyed on something stable: the
+  invocant's `Gc<InstanceAttrs>`, measured identical on every write from every
+  thread, acquired **before** the accessor dispatch so the accessor's read of
+  the live container is inside the region. That is the decision this file asked
+  for; its cost (user code runs inside the region) is bounded by
+  `container_lock`'s at-most-one-lock rule. 0/96 at 24-way, and it also fixed a
+  route §8 never probed: the same store written INLINE in the thread body, with
+  no routine in between, which was losing updates on 4 of 5 runs. Pins:
+  `t/attribute-accessor-container-identity.t` and three new rows in
+  `t/concurrent-attribute-element-store.t`.
 
 - **Route 5 (`Channel.Supply` tap captures)** is exposed on the path oracle but
   blocked behind a separate deterministic Channel-supply delivery bug that


### PR DESCRIPTION
Closes ADR-0068 §4 step 3's last open route (`todo/deep/gc-contents-mut-cross-thread-aliased-writes.md`), which the ticket had flagged as needing "a decision, not a patch". The decision turned out to rest on a **deterministic, single-threaded bug** hiding underneath it.

## The identity bug

`method items { @!items }` hands back the attribute's own `Array` — in raku it *is* that object — so `$obj.items = LIST` and `$obj.items[$i] = v` store **into** that container. mutsu rebuilt the whole attribute map around a fresh node instead (`assign_method_lvalue_with_values`'s `rw_attr_target` branch → `Value::write_back_sharing`). One thread is enough to see it:

```raku
class H { has @.seen; method bag() { @!seen } }
my $h = H.new(seen => []);
my @alias := $h.bag;
$h.bag = (1, 2, 3);
say @alias;    # raku: [1 2 3]     mutsu: []
```

The *generated* accessor for the same attribute never had this bug — which is why ADR-0068 §8 measured `has @.seen` at 0/240 while `method seen { @!seen }` lost half its writes. They were never really the same route.

`ArrayData::adopt_state_from` / `HashData::adopt_state_from` now perform the store in place, keeping the node (and hence `.WHICH`) and dropping the whole-attribute-map commit entirely.

## Why that was blocking the concurrency fix

`$h.bag[$i] = 1` from 20 threads landed **418 / 543 / 304 of 1000** writes (rakudo: 1000). Because the attribute was rebound on every write, **the container's address moved on every write** — measured, four distinct `Gc<ArrayData>` addresses in six writes from two threads — so the ADR-0068 store guard, which keys on the container node when the container is not celled, locked a different stripe each time and excluded nothing. `write_back_sharing` additionally commits a *copy of the whole attribute map*, so a slow thread could clobber concurrent writes to unrelated attributes.

With the churn gone the guard is keyed on the invocant's `Gc<InstanceAttrs>` — measured identical on every write from every thread reaching the same object, and moved by no store — and acquired **before** the accessor dispatch, so the accessor's read of the live container's elements is inside the region. (Removing the churn without moving the guard turned the lost updates into a NaN-box tag panic and `double free or corruption`: honest exposure, not a fix.)

Extending the region over user code is the tension the ticket asked to resolve. It is bounded by `container_lock`'s at-most-one-lock-per-thread rule: an accessor that itself stores into a container takes no second lock and cannot self-deadlock. What stays uncovered is an accessor that *blocks on another thread* while this one holds the stripe; no such accessor exists in the suite, and the alternative is a live container's element read racing with a `Vec` reallocation.

## Measured

Debug build, `MUTSU_GC=on MUTSU_GC_EVERY_CANDIDATE=1024 MUTSU_GC_VERIFY=1`, 96 processes at 24-way on 12 cores:

| Route | Before | After |
|---|---|---|
| `$h.bag[$i] = 1`, user accessor, array | 304–543 of 1000 writes landed | 0 / 96 failures |
| `$h.bag{$k} = 1`, user accessor, hash | — | 0 / 96 |
| `$h.bag.push($v)`, user accessor | — | 0 / 96 |
| `$obj.attr[$i] = v` written INLINE in the thread body | lost updates on 4 of 5 runs | 0 / 96 |
| ADR-0068 §8's named-sub attribute store (regression check) | 0 / 240 | 0 / 96 |

The inline row is a route §8 never probed: with no routine closing over the invocant the container never becomes celled, so neither the celled guard nor the name-keyed lane applied to it. The same change covers it.

## Tests

- New `t/attribute-accessor-container-identity.t` — 8 deterministic rows, verified green under `raku`.
- Three new rows in `t/concurrent-attribute-element-store.t` (plan 4 → 7).
- `make test`: 3824 files, 40392 tests, PASS. `cargo clippy --all-targets -D warnings` clean.
- Local roast S12 + S17 slice (196 whitelisted files, release build): PASS.

Docs: ADR-0068 §10, `news/2026-09/accessor-returned-container-identity-and-its-cross-thread-store.md`, and the ticket's open-item list updated. Still open in step 3: route 5 (`Channel.Supply` tap captures) behind the Channel-supply delivery bug, and ADR-0068 §3.1's unexplained `S17-procasync/stress.t` SIGSEGV.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Cm35NZLjAcEMJVC1uaARu

---
_Generated by [Claude Code](https://claude.ai/code/session_018Cm35NZLjAcEMJVC1uaARu)_