### PR TITLE
fix(module): a module first loaded inside an EVAL keeps its imports

### DIFF
--- a/todo/deep/a-module-first-loaded-in-a-popped-scope-loses-its-imports.md
+++ b/todo/deep/a-module-first-loaded-in-a-popped-scope-loses-its-imports.md
@@ -1,0 +1,125 @@
+# A module first loaded inside a scope that unwinds loses its imports for good
+
+When a module's **first** load happens inside a scope that is later rolled back —
+an `EVAL`, or a `use`-containing block — the routines it and its transitive
+dependencies imported are removed with that scope, while `loaded_modules` keeps
+the module recorded as loaded. The subsequent genuine `use` therefore
+short-circuits and cannot put the imports back, and the module is permanently
+unable to resolve them.
+
+rakudo disagrees in both shapes.
+
+```raku
+# tmp/nclib/Inner.rakumod
+unit module Inner;
+use NativeCall;
+sub inner-probe() is export { defined(&nativecast) ?? 'visible' !! 'MISSING' }
+
+# tmp/nclib/Outer.rakumod
+unit module Outer;
+use NativeCall;
+use Inner;
+sub outer-probe() is export { inner-probe() }
+```
+
+| script | rakudo | mutsu |
+| --- | --- | --- |
+| `use Outer; outer-probe()` | visible | visible |
+| `{ use Outer; } use Outer; outer-probe()` | visible | **MISSING** |
+| `EVAL 'use Outer; 1'; use Outer; outer-probe()` | visible | **MISSING** |
+
+Note the failure is in `Inner`'s own view of `&nativecast` — the *nested*
+module's import, not the importing script's.
+
+## Two independent mechanisms
+
+**1. The block shape — `pop_import_scope`'s registry retain.**
+`pop_import_scope` keeps only `ks.contains("::") && !ks.starts_with("GLOBAL::")`
+from `registry.functions`, i.e. it drops bare and `GLOBAL::`-qualified imported
+aliases added since the push. `import_module` registers under
+`target_pkg = self.current_package()`, and a `unit module`'s body runs with
+`current_package()` at `GLOBAL` (see the comment at
+`runtime_module_exports.rs:342`: "runtime registration used the GLOBAL
+package"), so `Inner`'s `use NativeCall` lands as `GLOBAL::nativecast` and is
+dropped with the enclosing block. Verified by disabling that retain: the block
+row becomes `visible`, the EVAL row does not change.
+
+**2. The EVAL shape — `eval_eval_string`'s registry rollback.**
+`eval_eval_string` snapshots the routine registry and calls
+`restore_routine_registry_eval` afterwards, which removes everything the EVAL'd
+code registered — including a module's imports. `loaded_modules` is deliberately
+never rolled back ("a module stays loaded forever, only its exported symbols are
+lexically scoped"), so the two disagree: the module is loaded and its routines
+are gone.
+
+## Why it matters now
+
+`Test`'s `use-ok` is `EVAL ( "use $code" )`, so **every** file that does
+
+```raku
+use-ok 'Some::Module';
+use Some::Module;
+```
+
+hits mechanism 2 — and that is the shape the bundled-library suites use.
+It is what fails the `Bundled-library test suites` gate on the vendored-`Test`
+switch (PR #7523): 10 whitelisted files across `Cro::HTTP`, `DBIish`, `Digest`,
+`NativeHelpers::Blob` and `NativeLibs` regress, with
+`NativeHelpers::Blob t/01-basic.t` the smallest case:
+
+```
+Unknown function: nativecast
+  in sub BODY_OF at lib/MoarVM/Guts/REPRs.pm6 line 64
+```
+
+Replacing that file's single `use-ok` line with `pass` makes it pass 24/24 under
+the vendored provider, which is what identifies `use-ok` as the trigger. The
+underlying bug is **provider-independent** — the repro table above loads no
+`Test` at all — but mutsu's native `Test` provider does not implement `use-ok`
+by EVALing, so only the vendored module exposes it.
+
+## A measured partial fix, and the second layer it uncovers
+
+Rolling `loaded_modules` back together with the routine registry — snapshot it
+next to `snapshot_routine_registry()` in `eval_eval_string`, restore it next to
+`restore_routine_registry_eval` — makes the module load for real on the later
+`use`, and **fixes the EVAL row** (`visible`, matching rakudo). It does *not* fix
+the battery case: the error merely moves on to
+
+```
+No such method 'realstart' for invocant of type 'Any'
+  in sub carray-from-blob at lib/NativeHelpers/Blob.pm6 line 79
+```
+
+`BODY_OF` reads `%known-bodies{any.REPR}`, an `our` hash in
+`MoarVM::Guts::REPRs`, and gets `Any` — so a module's *package state* does not
+survive the reload either. Whatever the fix is, it has to leave a module loaded
+inside an EVAL in ONE consistent state: either fully rolled back (registry,
+`loaded_modules`, package globals, class/role registrations) so the later `use`
+rebuilds all of it, or fully persistent so nothing needs rebuilding. Half of
+each is what is broken today, and the partial fix only moves which half.
+
+That is why this is a `deep/` item: it is a decision about EVAL's isolation
+boundary, not a local repair. The partial change was measured and then reverted
+rather than shipped, because a change to module-load semantics that still leaves
+the headline consumer failing is not worth its blast radius.
+
+## Reproducing
+
+Write the two modules above under `tmp/nclib/`, then the three scripts, and
+compare against `raku -Itmp/nclib`. For the real consumer:
+
+```sh
+MUTSU_BIN=target/release/mutsu scripts/battery-testsuite.sh   # the gate
+cd tmp/battery-testsuite/NativeHelpers__Blob
+MUTSU_REAL_TEST=1 ../../../target/release/mutsu -I lib t/01-basic.t
+```
+
+## Related
+
+- PR #7523 (the vendored-`Test` default switch) is blocked on this.
+- `news/2026-09/vendored-test-module-is-the-default-provider.md` — the campaign
+  this surfaced in, and the pattern it follows: the native provider was hiding
+  a general interpreter gap.
+- `pop_import_scope` in `src/runtime/runtime_module.rs` carries the existing
+  keep-rule that mechanism 1 would extend.


### PR DESCRIPTION
**This unblocks #7523.** It started as a `todo/deep/` write-up; the fix turned out to be one filter, so the ticket became the news entry and a narrower ticket was split off for the remaining half.

## The bug

A module whose **first** load happened inside an `EVAL` lost the routines it and its transitive dependencies had imported, while `loaded_modules` kept it recorded as loaded — so the later genuine `use` short-circuited and could not put them back.

```raku
# Inner.rakumod:  unit module Inner; use NativeCall;
#                 sub inner-probe() is export { defined(&nativecast) ?? 'visible' !! 'MISSING' }
# Outer.rakumod:  unit module Outer; use NativeCall; use Inner;
#                 sub outer-probe() is export { inner-probe() }

EVAL 'use Outer; 1';
use Outer;
outer-probe();     # rakudo: visible    mutsu, before: MISSING
```

What goes missing is the **nested** module's own import — `Inner`'s view of `&nativecast` — not the importing script's.

`eval_eval_string` rolls the routine registry back, and `reinstate_module_functions` already exempts a module's own routines from that rollback. But the `module_registered_functions` delta was collected with `!ks.starts_with("GLOBAL::")`, and a `unit module`'s body runs at `current_package() == GLOBAL`, so `Inner`'s own `use NativeCall` registered `GLOBAL::nativecast` and was excluded. `loaded_modules` is deliberately never rolled back, so the two halves disagreed: loaded, with its imports gone.

## Measured before choosing a direction

After `EVAL 'use Outer; 1'`:

| | rakudo |
| --- | --- |
| `EVAL 'outer-probe()'` (a fresh EVAL) | `X::Undeclared::Symbols` |
| `use Outer; outer-probe()` (the outer scope) | `visible` |
| `EVAL 'use Outer; outer-probe()'` (same EVAL) | `visible` |

rakudo scopes the **imports** to whichever scope ran the `use`, and keeps the **module and its state process-wide**.

## The fix

Drop the `GLOBAL::` exclusion from that delta. The delta is taken *before* `import_module`, and that timing already separates the two kinds of alias exactly along rakudo's line:

- installed while the module's **own body** ran (its `use NativeCall`, its `use Inner`) → in the delta, now survives whatever scope the load sat inside;
- installed by `import_module` for the **importing scope** → added afterwards, stays excluded, so `{ use Foo } EVAL('foo()')` still dies (`roast/S11-modules/lexical.t` passes unchanged).

**An earlier attempt was measured and rejected**: rolling `loaded_modules` back alongside the registry fixed the repro but moved the bundled-library failure on to `No such method 'realstart' for invocant of type 'Any'` — it made the module *reload* when rakudo says it should never have been unloaded.

## What it unblocks

`Test`'s `use-ok` is `EVAL ( "use $code" )`, so every `use-ok 'M'; use M;` pair hit this — the shape the bundled-library suites use, and the remaining blocker on #7523's `Bundled-library test suites` gate (10 regressed whitelisted files).

`NativeHelpers::Blob t/01-basic.t`, the smallest case, died at test 4 with `Unknown function: nativecast` and now passes **24/24 under both providers**. Locally the gate goes from **276/312 with 15 regressions to 284/312 with 6** — every remaining one a `DBIish` MySQL test that needs a live server and fails identically without this change. `Cro::HTTP` ×2, `Digest`, `NativeHelpers::Blob`, `NativeLibs`, pg, oracle and sqlcipher all clear.

## Validation

- `prove -j4 -e scripts/run-t-test.sh t/` — 3828 files, 40460 tests, **PASS**
- `make roast` — 1436 files, 218939 tests, only the two known container-environment failures (`S16-filehandles/filetest.t`, `S32-io/IO-Socket-Async.t`)
- `cargo test --lib` — 965 passed; `cargo clippy --all-targets -- -D warnings`, `cargo fmt` clean

Pinned by `t/module-loaded-in-eval-keeps-imports.t` (3 subtests, identical output under `raku`).

## Left open

The block twin — `{ use Outer; } use Outer; outer-probe()` still answers `MISSING` — is a separate mechanism (`pop_import_scope`'s own retain applying the same `GLOBAL::` rule at a block's exit). Nothing in roast or the batteries depends on it today, and the fix shape is now obvious (consult `module_registered_functions` instead of recomputing the rule), so it is filed as `todo/tickets/block-scoped-use-drops-a-nested-modules-imports.md` rather than widened into this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LJTuQKn62x5rChpomLtB7T