### PR TITLE
fix(regex): stream a subrule call's candidates, decided by a rule call graph

### DIFF
--- a/docs/adr/0073-regex-atom-candidates-are-demand-driven.md
+++ b/docs/adr/0073-regex-atom-candidates-are-demand-driven.md
@@ -1,8 +1,11 @@
 # ADR-0073: Regex atom candidates are produced on demand, driven by the continuation
 
-- Status: Proposed (Slices 1 and 3 implemented 2026-09-07; Slice 2's ratcheted
-  half implemented 2026-09-07; Slice 2's non-ratcheted half — a `regex` caller
-  that really can backtrack into the subrule — open, tracked in
+- Status: Accepted (Slices 1 and 3 implemented 2026-09-07; Slice 2 implemented
+  in two halves, the ratcheted one 2026-09-07 and the streamed one 2026-09-08.
+  What the streamed path still declines — a call with arguments, a proto, several
+  resolved candidates, `<::(EXPR)>`, a custom-HOW grammar, `:m`, a program
+  declaring any dynamic rule parameter, and a rule that really is part of a call
+  cycle — stays on the eager arm and is tracked in
   `todo/deep/ordered-alternation-eager-candidate-enumeration.md`)
 - Date: 2026-09-07
 - Supersedes: nothing
@@ -266,7 +269,7 @@ it can be adopted incrementally.
 | A14, A15 (`:g` / `subst`) | not addressed by either — the scan is the mechanism | not addressed |
 | A16 (conjunction) | fixed | needs a `Conjunction` arm; not in Slice 1 |
 | E3 | fixed only if the subrule boundary is also replayed | fixed by Slice 2's ratcheted half |
-| E1, E2, E6 | fixed only if the subrule boundary is also replayed | needs Slice 2's non-ratcheted half |
+| E1, E2, E6 | fixed only if the subrule boundary is also replayed | fixed by Slice 2's streamed half |
 | F1, F2 | fixed | fixed by Slice 3 |
 | F6 | not a count bug at all — a pre-existing wrong *match* | unchanged, filed separately |
 | C1, D1-D3 (controls) | at risk (suppression can mute a needed block) | unchanged by construction |
@@ -305,14 +308,45 @@ it can be adopted incrementally.
   cycle" needs a rule-call-graph analysis and is residue. The seed loop keeps a
   runtime fallback (redo the iteration with the full set) for the case a `{ … }`
   block re-enters the rule by hand.
-- **Slice 2 (non-ratcheted half) — OPEN.** A `regex` caller really can backtrack
-  into the subrule, so truncation is wrong there and the arm has to *stream*
-  through a `MatchSink::Cont` — which means threading the continuation through
-  the seed loop, the proto rank-then-match dispatch (ADR-0046) and the three
-  `Vec`-returning escape hatches (`try_regex_subrule_as_method`,
-  `try_custom_how_subrule_dispatch`, `<::(EXPR)>`). The separable case is "no
-  arguments, no proto, one resolved candidate, this key not LR-active", and it
-  is the one E1/E2/E6 need.
+- **Slice 2 (streamed half) — IMPLEMENTED 2026-09-08.**
+  `drive_named_subrule_candidates` (`regex_match_lazy.rs`) walks the subrule's
+  body through a `MatchSink::Cont`, wrapping each end into the atom's capture
+  delta as it is produced, so end *k+1* is computed only once the real
+  continuation has rejected end *k*. It takes the separable case named above —
+  no arguments, no proto, exactly one resolved candidate, no custom-HOW
+  dispatch, no `:m`, no dynamic (`$*`) rule parameters anywhere in the program,
+  and this key not LR-active — and everything else falls back to the eager arm
+  unchanged. Fixes E1, E2 and E6.
+
+  What made the case decidable is `src/runtime/regex/regex_call_graph.rs`, which
+  replaces Slice 2's syntactic guard with the question the seed loop actually
+  asks: *can this rule reach a call to its own name?* Edges come from the same
+  resolution the matcher uses, `<.ws>` is an edge to `ws`, a name that resolves
+  to no rule is a builtin assertion (no edge) unless the grammar has a method of
+  that name, and anything unresolvable answers "may re-enter". So `true` means
+  proven safe and `false` only means not proven. With re-entry ruled out the
+  growing-seed loop is a formality — one iteration, seed unconsulted, first
+  result final — and the walk can be streamed. A ratchet on the calling token
+  simply stops the stream after the first end, which is what the ratcheted half
+  needed `first_only` for, so **non-leaf rules under a ratcheted caller are now
+  streamed too** and the leaf-only over-approximation is lifted for them.
+
+  The analysis is memoized per `TOKEN_DEFS_GEN` in three layers (streamable
+  verdict, direct edges, and the raw-text staticness that decides whether a
+  node's edges are generation-stable at all), because re-deciding it per call
+  cost more than the laziness saved — measured at +22% instructions on
+  `bench-yaml-parse` before the memoization and +1.6% after. A rule body whose
+  text splices a value in is answered "not knowable" *and cached as such*: a
+  `Regex`-valued scalar is interpolated as pattern SOURCE
+  (`interpolate_bound_regex_scalars`), so such a body really can gain a call
+  edge between two attempts. A sigil that appears only inside a `{ … }` code
+  block does not, because that pass treats code blocks as opaque — which is what
+  keeps the overwhelmingly common `token part { \w+ { $n++ } }` shape eligible.
+
+  The activation is still registered while streaming, so a `{ … }` block that
+  re-enters the key by hand reads the empty seed and fails instead of recursing
+  forever; if the seed turns out to have been consulted and nothing has
+  committed yet, the call is handed back to the eager growing-seed path.
 
 Two rows are deliberately **out of this ADR's scope** and have their own ticket
 files, because their mechanism is not candidate production: the `:g` / `subst`

--- a/news/2026-09/subrule-calls-stream-their-candidates.md
+++ b/news/2026-09/subrule-calls-stream-their-candidates.md
@@ -1,0 +1,149 @@
+# A `<subrule>` call streams its candidates, decided by a rule call graph
+
+ADR-0073's Slice 2 — the `<subrule>` boundary, the last collect-then-pick
+barrier in the regex engine — is closed for its **non-ratcheted** half, and the
+ratcheted half's leaf-only restriction is lifted at the same time. Both fall out
+of one new thing: an analysis that answers *can this rule reach a call to
+itself?* over the grammar's rule call graph.
+
+## What was still wrong
+
+An embedded `{ … }` block inside a subrule called from a `regex` caller ran once
+per candidate the engine *computed* rather than once per candidate raku's cursor
+*enters*:
+
+```raku
+my $n = 0;
+grammar G { regex TOP { <part> 'c' }; regex part { \w* { $n++ } } }
+G.parse('aaac');
+say $n;                 # raku: 2     mutsu before: 5
+```
+
+The match itself was right; every block mutsu ran is one raku *would* run if the
+continuation had failed. It bites a block with a side effect that must not
+happen on a path never taken — a `die`, a push, a counter. The nastiest shape was
+an ordered alternation inside such a subrule, where the losing branch's block
+fired even though the winning branch had already carried the whole parse:
+
+```raku
+my @seen;
+grammar G {
+    regex TOP  { <part> 'cd' }
+    regex part { 'a' [ 'b' { @seen.push('one') } || 'bc' { @seen.push('two') } ] }
+}
+G.parse('abcd');
+say @seen;              # raku: [one]     mutsu before: [one two]
+```
+
+## Why the `Named` arm resisted the earlier slices
+
+Slice 1 turned `Group` / `CaptureGroup` / `CaptureIsolatedGroup` / `Conjunction`
+/ `Alternation` into continuation-driven producers, and Slice 2's ratcheted half
+walked a subrule's body with `first_only` when the calling `token` could not
+backtrack into it anyway. Neither could touch the general `<subrule>` case,
+because the `Named` arm carries the **left-recursion growing-seed loop**
+(`LR_ACTIVE` / `LR_MEMO` / `LR_SEED_READ`). That loop decides whether a rule is
+left-recursive *at this position* by evaluating its candidates and then asking
+whether the seed was consulted — it cannot know before evaluating, and it cannot
+un-run the blocks a cut-short walk already ran. The ratcheted half sidestepped it
+with a syntactic precondition, `pattern_is_rule_call_free`: a body that cannot
+invoke a named rule at all cannot re-enter its own key. Sound, but it admits
+**leaf rules only**, so a grammar's interior rules kept paying for their whole
+end set even under a ratcheted caller.
+
+## The call graph answers the real question
+
+`src/runtime/regex/regex_call_graph.rs` replaces the syntactic guess with the
+question the seed loop actually cares about. A rule's left-recursion key is
+re-entered only by a *call* to a rule of the same name, so walking the call graph
+from `(package, name)` and asking whether `name` shows up again in the reachable
+set decides it exactly:
+
+- edges come from the same resolution the matcher uses
+  (`parsed_subrule_candidates`), so a candidate's body resolves its unqualified
+  references against the package that *defined* it;
+- `<.ws>` is an edge to `ws`; a name that resolves to no rule is a builtin
+  assertion or character class (no edge) unless the grammar has a *method* of
+  that name, which is arbitrary user code;
+- anything unresolvable — a rule call with arguments, `<::(EXPR)>`, `<{ … }>`,
+  `<~~>`, a body whose pattern will not resolve — answers "may re-enter".
+
+So the verdict is a sound under-approximation of safety: `true` means proven
+safe, `false` means only *not proven*, and the caller falls back to today's eager
+path.
+
+## Memoize it, or it costs more than it saves
+
+Re-deciding this per call was measured at **+22% instructions** on
+`bench-yaml-parse` (`callgrind`, 804M vs 657M Ir), almost all of it `malloc` and
+`free`: every subrule call re-resolved its own rule and then walked the grammar's
+whole call cone. Three memo layers keyed on `TOKEN_DEFS_GEN` bring that to
+**+1.6%** (and to parity on `bench-grammar-parse` / `-deep`):
+
+- `STREAMABLE` — `package -> subrule atom text -> may this be streamed?`, a
+  two-level map so the hot probe borrows `&str` instead of building a
+  `(String, String)` key. It is asked *before* the atom's name is parsed, so an
+  ineligible call costs two hash lookups and nothing else.
+- `DIRECT_CALLS` — one node's edges.
+- the raw-text staticness that decides whether a node's edges are
+  generation-stable at all.
+
+That last one is the subtle part. A body carrying an interpolation is re-parsed
+on every attempt, and a `Regex`-valued scalar is spliced in as pattern *source*
+(`interpolate_bound_regex_scalars`), so such a body genuinely can gain a call
+edge between two attempts — its edges are answered "not knowable", and **that
+verdict is itself cached**, which is what keeps the analysis off the hot path. A
+sigil that appears only inside a `{ … }` code block does not count, because that
+interpolation pass treats code blocks as opaque; without that distinction the
+overwhelmingly common `token part { \w+ { $n++ } }` shape — the very shape this
+work exists for — would have been ineligible.
+
+With re-entry ruled out, the growing-seed loop is a formality — one iteration,
+seed unconsulted, first result final — and the call can be **streamed**.
+`drive_named_subrule_candidates` (`regex_match_lazy.rs`) walks the subrule body
+through a `MatchSink::Cont`, wrapping each end into the atom's capture delta as
+it is produced, so end *k+1* is computed only after the real continuation has
+rejected end *k*. It takes only the shape where none of the `Named` arm's other
+machinery is in play: an argument-less call, exactly one non-proto candidate, no
+custom-HOW dispatch, no `:m`, no dynamic (`$*`) rule parameters anywhere in the
+program, and a key that is not already LR-active. A ratchet on the calling token
+simply stops the stream after the first end, which is what the ratcheted half
+used `first_only` for — so non-leaf rules under a ratcheted caller are now
+streamed too.
+
+The one construct the call graph deliberately treats as harmless is an embedded
+`{ … }` block: it is user code and could re-enter the rule by hand. The
+activation is still registered (so such a re-entry reads the empty seed and fails
+instead of recursing forever), and if the seed turns out to have been consulted
+while nothing has committed yet, the call is handed back to the eager
+growing-seed path.
+
+## Measured
+
+`B` is an embedded block incrementing a counter; the cells are how many times it
+ran. Every row was run against `raku` (2026-09-07) and a fresh `cargo build`.
+
+| shape | raku | before | after |
+| --- | --- | --- | --- |
+| `regex TOP { <part> 'c' }` / `regex part { \w* {B} }` on `aaac` | 2 | 5 | 2 |
+| `regex TOP { <a> 'c' }` / `regex a { <b> }` / `regex b { \w* {B} }` | 2 | 5 | 2 |
+| `regex part { 'a' [ 'b' {one} \|\| 'bc' {two} ] }` under `regex TOP { <part> 'cd' }` | `one` | `one,two` | `one` |
+| `token TOP { <part> 'c' }` / `regex part { <inner> }` / `regex inner { \w* {B} }` | 1 | 5 | 1 |
+
+The controls that already agreed did not move: a `token` subrule under a `regex`
+caller, `token`/`token`, a `$*`-declaring caller, a `make`-bearing block, a
+quantified subrule under either kind of caller, a `rule` caller's `<.ws>`, and
+the left-recursive `token expr { <term> | <expr> '+' <term> }` growing-seed rows
+— the last of which is exactly what the call graph refuses, keeping it on the
+full walk. All of them are pinned in `t/regex-lazy-candidate-enumeration.t`,
+which also gains a mutual-recursion row (`a` reaches `a` through `b`) and a
+backtracking-through-two-subrule-levels row.
+
+## Residue
+
+The eager `Named` arm still owns every call the streamed path declines: one with
+arguments, a proto's rank-then-match dispatch, several resolved candidates,
+`<::(EXPR)>` indirection, a custom-HOW grammar, `:m`, a program that declares any
+dynamic rule parameter, and — by construction — a rule that really is part of a
+call cycle. See
+`todo/deep/ordered-alternation-eager-candidate-enumeration.md`.

--- a/src/runtime/regex/mod.rs
+++ b/src/runtime/regex/mod.rs
@@ -1,3 +1,4 @@
+mod regex_call_graph;
 mod regex_casefold;
 pub(crate) mod regex_dynparams;
 mod regex_eval;
@@ -13,6 +14,7 @@ mod regex_match_core;
 mod regex_match_delta;
 mod regex_match_find;
 mod regex_match_lazy;
+mod regex_match_lazy_subrule;
 mod regex_match_nocap;
 mod regex_match_public;
 mod regex_match_sep;

--- a/src/runtime/regex/regex_call_graph.rs
+++ b/src/runtime/regex/regex_call_graph.rs
@@ -1,0 +1,390 @@
+//! ADR-0073 Slice 2: "can this rule reach itself?", answered over the rule
+//! call graph.
+//!
+//! The `<subrule>` arm of the atom producer (`regex_match_atom.rs`) carries the
+//! left-recursion growing-seed loop, which discovers that a rule is
+//! left-recursive at a position by *evaluating* its candidates and then
+//! checking whether the seed was consulted. That is what forces the arm to
+//! collect a subrule's whole end set before the caller descends into any of
+//! them — and, because an embedded `{ ... }` block runs inline for real
+//! (ADR-0009), makes the block fire once per end *computed* rather than once
+//! per end *entered*.
+//!
+//! Slice 2's first half sidestepped the loop with a purely syntactic
+//! precondition ([`super::regex_subrule_lazy::pattern_is_rule_call_free`]): a
+//! body that cannot invoke a named rule at all cannot re-enter its own key.
+//! That admits leaf rules only, so a grammar's interior rules kept paying for
+//! the full end set.
+//!
+//! This module answers the real question instead. A rule's key is re-entered
+//! only by a *call* to a rule of the same name, so walking the call graph from
+//! `(pkg, name)` and asking whether `name` appears again in the reachable set
+//! decides it exactly. Anything the walk cannot resolve — a rule call with
+//! arguments, `<::(EXPR)>` indirection, `<{ ... }>`, `<~~>`, a name that
+//! resolves to a grammar *method* rather than to a rule, a body whose pattern
+//! is not static enough to resolve at all — is answered "may re-enter", so the
+//! verdict is a sound under-approximation of safety: `true` means proven safe,
+//! `false` means only "not proven".
+//!
+//! The one construct deliberately treated as harmless is an embedded
+//! `{ ... }` / `<?{ ... }>` block. It is arbitrary user code and could in
+//! principle re-enter the same rule at the same position by hand; the callers
+//! keep a runtime escape for that (`regex_match_atom.rs`'s `first_only`
+//! retry, and the streamed subrule's seed-consulted fallback in
+//! `regex_match_lazy.rs`), exactly as the first half of Slice 2 does.
+
+use std::cell::RefCell;
+use std::collections::{HashMap, HashSet, VecDeque};
+
+use super::super::*;
+use crate::runtime::regex_types::{RegexAtom, RegexPattern};
+
+/// A `(package, rule name)` node of the call graph.
+type RuleNode = (String, String);
+
+/// Ceiling on the reachable set. A grammar with more rules than this in one
+/// call cone is answered "not proven" rather than walked further — the
+/// analysis exists to save work, not to spend it.
+const MAX_REACHABLE_RULES: usize = 512;
+
+thread_local! {
+    /// `(name, pkg) -> the rules its candidates call directly`, or `None` when
+    /// some construct in one of them cannot be resolved. Same generation key.
+    #[allow(clippy::type_complexity)]
+    static DIRECT_CALLS: RefCell<(u64, HashMap<RuleNode, Option<std::sync::Arc<Vec<RuleNode>>>>)> =
+        RefCell::new((0, HashMap::new()));
+
+    /// `pkg -> subrule atom text -> may this call be streamed?`. This is the
+    /// hot lookup: it is consulted before the call is resolved (and before its
+    /// name is even parsed), so a rule that is not streamable costs two
+    /// borrowed hash lookups rather than a resolution plus a graph walk. The
+    /// two-level shape is what keeps it allocation-free — a `(String, String)`
+    /// key would have to be built to probe it. Same generation key.
+    #[allow(clippy::type_complexity)]
+    static STREAMABLE: RefCell<(u64, HashMap<String, HashMap<String, bool>>)> =
+        RefCell::new((0, HashMap::new()));
+}
+
+fn token_defs_gen() -> u64 {
+    crate::runtime::regex_parse::TOKEN_DEFS_GEN.load(std::sync::atomic::Ordering::Relaxed)
+}
+
+impl Interpreter {
+    /// The reachability walk itself: is a call to `name` reachable from
+    /// `(pkg, name)`?
+    fn cannot_reenter(&mut self, name: &str, pkg: &str) -> bool {
+        let start: RuleNode = (pkg.to_string(), name.to_string());
+        let mut seen: HashSet<RuleNode> = HashSet::from([start.clone()]);
+        let mut queue: VecDeque<RuleNode> = VecDeque::from([start]);
+        while let Some((cur_pkg, cur_name)) = queue.pop_front() {
+            let Some(calls) = self.direct_rule_calls(&cur_name, &cur_pkg) else {
+                return false;
+            };
+            for callee in calls.iter() {
+                // Reaching the starting NAME again closes the loop the
+                // growing-seed algorithm exists for.
+                if callee.1 == name {
+                    return false;
+                }
+                if seen.len() >= MAX_REACHABLE_RULES {
+                    return false;
+                }
+                if seen.insert(callee.clone()) {
+                    queue.push_back(callee.clone());
+                }
+            }
+        }
+        true
+    }
+
+    /// The rules every candidate of `<name>` in `pkg` calls directly, or `None`
+    /// when the answer is not knowable for the whole token generation — either
+    /// because a candidate contains a construct whose dispatch target is not
+    /// static, or because the body is re-parsed per call and so could gain an
+    /// edge between two attempts. Both are cached: a "not knowable" verdict is
+    /// as stable as a known edge set, and re-deciding it per call is what made
+    /// this analysis cost more than it saved.
+    fn direct_rule_calls(
+        &mut self,
+        name: &str,
+        pkg: &str,
+    ) -> Option<std::sync::Arc<Vec<RuleNode>>> {
+        let generation = token_defs_gen();
+        let key = (pkg.to_string(), name.to_string());
+        if let Some(hit) = DIRECT_CALLS.with(|c| {
+            let c = c.borrow();
+            (c.0 == generation)
+                .then(|| c.1.get(&key).cloned())
+                .flatten()
+        }) {
+            return hit;
+        }
+        // The memoized resolver only answers for candidates whose pattern text
+        // is static ANYWHERE, which a `{ $n++ }` block alone is enough to spoil.
+        // When it declines, fall back to the same per-call resolution the
+        // matcher itself uses — but only when the sole reason the body is
+        // non-static lives inside a code block, because parse-time interpolation
+        // treats those as opaque (`interpolate_bound_regex_scalars`). A body
+        // that really does splice a value in is answered `None`.
+        let computed = match self.resolve_parsed_token_candidates_in_pkg(name, pkg) {
+            Some(candidates) => {
+                let raw_empty = candidates.is_empty();
+                self.rule_calls_of(name, pkg, &candidates, raw_empty)
+            }
+            None if self.rule_body_edges_are_generation_stable(name, pkg) => {
+                let spec = Self::parse_named_regex_lookup_spec(name);
+                let (candidates, raw_empty) = self.parsed_subrule_candidates(&spec, pkg, &[]);
+                self.rule_calls_of(name, pkg, &candidates, raw_empty)
+            }
+            None => None,
+        };
+        DIRECT_CALLS.with(|c| {
+            let mut c = c.borrow_mut();
+            if c.0 != generation {
+                c.0 = generation;
+                c.1.clear();
+            }
+            c.1.insert(key, computed.clone());
+        });
+        computed
+    }
+
+    /// The direct call edges of one already-resolved candidate list.
+    fn rule_calls_of(
+        &mut self,
+        name: &str,
+        pkg: &str,
+        candidates: &[super::regex_token_resolve::ParsedTokenCandidate],
+        raw_empty: bool,
+    ) -> Option<std::sync::Arc<Vec<RuleNode>>> {
+        if raw_empty || candidates.is_empty() {
+            // No token/regex/rule answers to this name here. It is either a
+            // builtin assertion or character class (`<alpha>`, `<ws>` with no
+            // grammar override, `<sym>`), which cannot dispatch to a user rule,
+            // or a plain grammar METHOD — arbitrary user code, so unknowable.
+            return self
+                .registry()
+                .user_method_overloads(pkg, name)
+                .is_none()
+                .then(|| std::sync::Arc::new(Vec::new()));
+        }
+        let mut out: Vec<RuleNode> = Vec::new();
+        for (parsed, sub_pkg, _) in candidates.iter() {
+            // A candidate's own body resolves its unqualified subrule
+            // references against the package that DEFINED it, not against the
+            // caller's — the same rule `subrule_candidate_ends` matches under.
+            if !collect_pattern_calls(parsed, sub_pkg, &mut out) {
+                return None;
+            }
+        }
+        out.sort();
+        out.dedup();
+        Some(std::sync::Arc::new(out))
+    }
+}
+
+impl Interpreter {
+    /// Whether the streamed `<subrule>` path in `regex_match_lazy.rs` may take
+    /// this call at all: the memoized front door, consulted BEFORE the call is
+    /// resolved so an ineligible one costs a hash lookup instead of a
+    /// resolution plus a call-graph walk.
+    ///
+    /// `atom_text` is the subrule atom exactly as written,
+    /// so `<foo>` and `<&foo>` get their own entries rather than sharing one.
+    pub(super) fn subrule_call_is_streamable(&mut self, atom_text: &str, pkg: &str) -> bool {
+        let generation = token_defs_gen();
+        if let Some(hit) = STREAMABLE.with(|c| {
+            let c = c.borrow();
+            (c.0 == generation)
+                .then(|| c.1.get(pkg).and_then(|m| m.get(atom_text)).copied())
+                .flatten()
+        }) {
+            return hit;
+        }
+        let verdict = self.compute_streamable(atom_text, pkg);
+        STREAMABLE.with(|c| {
+            let mut c = c.borrow_mut();
+            if c.0 != generation {
+                c.0 = generation;
+                c.1.clear();
+            }
+            c.1.entry(pkg.to_string())
+                .or_default()
+                .insert(atom_text.to_string(), verdict);
+        });
+        verdict
+    }
+
+    fn compute_streamable(&mut self, atom_text: &str, pkg: &str) -> bool {
+        let spec = Self::parse_named_regex_lookup_spec(atom_text);
+        // A rule call with arguments, and `<::(EXPR)>` symbolic indirection,
+        // both resolve per call; neither is a shape this path handles.
+        if !spec.arg_exprs.is_empty() || spec.lookup_name == "::" {
+            return false;
+        }
+        let (candidates, raw_empty) = self.parsed_subrule_candidates(&spec, pkg, &[]);
+        // Exactly one plain candidate. A proto keeps its rank-then-match
+        // dispatch (ADR-0046), several candidates need the cross-candidate dedup
+        // the eager arm performs, and `:m` remaps positions across the whole
+        // result set. All three are properties of the rule's DEFINITIONS, so the
+        // verdict holds for the whole token generation even when the body's
+        // parse does not.
+        let shape_ok = !raw_empty
+            && matches!(&candidates[..], [(parsed, _, sym)] if sym.is_none() && !parsed.ignore_mark);
+        shape_ok && self.cannot_reenter(&spec.lookup_name, pkg)
+    }
+
+    /// `true` when every definition answering to `<name>` in `pkg` compiles to
+    /// the same rule-call edges on every match attempt.
+    ///
+    /// A body is re-parsed per call when its text carries an interpolation, and
+    /// a `$`-valued `Regex` is spliced in as pattern SOURCE
+    /// (`interpolate_bound_regex_scalars`), so such a body really can gain or
+    /// lose a call edge between two attempts. But that interpolation pass treats
+    /// an embedded `{ ... }` code block as opaque, so a sigil that only appears
+    /// inside one — `token part { \w+ { $n++ } }`, the overwhelmingly common
+    /// case — does not make the parse value-dependent at all.
+    fn rule_body_edges_are_generation_stable(&mut self, name: &str, pkg: &str) -> bool {
+        self.resolve_token_patterns_static_in_pkg(name, pkg)
+            .iter()
+            .all(|(pattern, _, _)| pattern_text_is_static_outside_code_blocks(pattern))
+    }
+}
+
+/// [`Interpreter::rule_body_edges_are_generation_stable`]'s scan: blank out
+/// every balanced `{ ... }` code block and ask the ordinary staticness question
+/// about what is left. An unbalanced block is answered `false` rather than
+/// guessed at.
+fn pattern_text_is_static_outside_code_blocks(pattern: &str) -> bool {
+    let chars: Vec<char> = pattern.chars().collect();
+    let mut blanked = String::with_capacity(pattern.len());
+    let mut i = 0usize;
+    while i < chars.len() {
+        let c = chars[i];
+        if c == '\\' {
+            blanked.push(c);
+            i += 1;
+            if i < chars.len() {
+                blanked.push(chars[i]);
+                i += 1;
+            }
+            continue;
+        }
+        if c == '{' {
+            let mut depth = 1usize;
+            let mut j = i + 1;
+            while j < chars.len() && depth > 0 {
+                match chars[j] {
+                    '\\' => j += 1,
+                    '{' => depth += 1,
+                    '}' => depth -= 1,
+                    _ => {}
+                }
+                j += 1;
+            }
+            if depth > 0 {
+                return false;
+            }
+            // Keep the braces so a `**{...}` quantifier still reads as one.
+            blanked.push('{');
+            blanked.push('}');
+            i = j;
+            continue;
+        }
+        blanked.push(c);
+        i += 1;
+    }
+    crate::runtime::regex_parse::regex_pattern_is_static(&blanked)
+}
+
+/// Append every rule `pattern` (matched in `pkg`) can dispatch to. Returns
+/// `false` when it contains a construct whose target is not statically known,
+/// in which case `out` is meaningless.
+fn collect_pattern_calls(pattern: &RegexPattern, pkg: &str, out: &mut Vec<RuleNode>) -> bool {
+    pattern.tokens.iter().all(|token| {
+        collect_atom_calls(&token.atom, pkg, out)
+            && token
+                .separator
+                .as_ref()
+                .is_none_or(|sep| collect_pattern_calls(&sep.pattern, pkg, out))
+    })
+}
+
+fn collect_atom_calls(atom: &RegexAtom, pkg: &str, out: &mut Vec<RuleNode>) -> bool {
+    match atom {
+        // Matches text or asserts on its own; reaches no dispatcher.
+        RegexAtom::Literal(_)
+        | RegexAtom::Any
+        | RegexAtom::CharClass(_)
+        | RegexAtom::Newline
+        | RegexAtom::NotNewline
+        | RegexAtom::ZeroWidth
+        // User code. See the module header: treated as harmless here, with a
+        // runtime escape at both call sites.
+        | RegexAtom::CodeAssertion { .. }
+        | RegexAtom::UnicodeProp { .. }
+        | RegexAtom::UnicodePropAssert { .. }
+        | RegexAtom::CaptureStartMarker
+        | RegexAtom::CaptureEndMarker
+        | RegexAtom::VarDecl { .. }
+        | RegexAtom::CompositeClass { .. }
+        | RegexAtom::LeftWordBoundary
+        | RegexAtom::RightWordBoundary
+        | RegexAtom::WordBoundary { .. }
+        | RegexAtom::WithinWord { .. }
+        | RegexAtom::StartOfLine
+        | RegexAtom::EndOfLine
+        | RegexAtom::EndOfString
+        | RegexAtom::Backref(_)
+        | RegexAtom::NamedBackref(_)
+        // Interpolates a variable's STRING value as a literal, not as a rule.
+        | RegexAtom::VarInterp(_)
+        | RegexAtom::SameAssertion { .. }
+        | RegexAtom::AtPosition(_)
+        | RegexAtom::TildeMarker => true,
+        RegexAtom::Group(p) | RegexAtom::CaptureGroup(p) | RegexAtom::CaptureIsolatedGroup(p) => {
+            collect_pattern_calls(p, pkg, out)
+        }
+        RegexAtom::Alternation(alts)
+        | RegexAtom::SequentialAlternation(alts)
+        | RegexAtom::Conjunction(alts) => alts
+            .iter()
+            .all(|alt| collect_pattern_calls(alt, pkg, out)),
+        RegexAtom::Lookaround { pattern, .. } => collect_pattern_calls(pattern, pkg, out),
+        RegexAtom::GoalMatch { goal, inner, .. } => {
+            collect_pattern_calls(goal, pkg, out) && collect_pattern_calls(inner, pkg, out)
+        }
+        RegexAtom::WsRule => {
+            // `<.ws>` dispatches to whatever `ws` the grammar resolves to.
+            out.push((pkg.to_string(), "ws".to_string()));
+            true
+        }
+        RegexAtom::Named(name) => {
+            let spec = Interpreter::parse_named_regex_lookup_spec(name);
+            // `<::(EXPR)>` names its target at runtime, and a rule call with
+            // arguments resolves per argument list — neither is a static edge.
+            if spec.lookup_name == "::" || !spec.arg_exprs.is_empty() {
+                return false;
+            }
+            // Anything that is not a plain (possibly qualified) rule name is a
+            // form this walk does not model — `<$rx>` interpolates a regex whose
+            // own calls are not visible here, and a character-class spec that
+            // reached this variant is not a dispatch at all. Both answer
+            // "unknown" rather than being recorded as an edge to a rule that
+            // does not exist.
+            if spec.lookup_name.is_empty()
+                || !spec
+                    .lookup_name
+                    .chars()
+                    .all(|c| c.is_alphanumeric() || matches!(c, '_' | '-' | ':'))
+            {
+                return false;
+            }
+            out.push((pkg.to_string(), spec.lookup_name));
+            true
+        }
+        // `<{ ... }>` matches whatever regex the code returns; `<~~>` re-enters
+        // the enclosing rule by construction.
+        RegexAtom::ClosureInterpolation { .. } | RegexAtom::RecurseSelf(_) => false,
+    }
+}

--- a/src/runtime/regex/regex_match_atom.rs
+++ b/src/runtime/regex/regex_match_atom.rs
@@ -36,6 +36,43 @@ thread_local! {
 /// with its PLURAL ends (highest-priority-first).
 type RankedAlternationBranch = ((usize, usize), Vec<(usize, RegexCaptures)>);
 
+/// The left-recursion key a `<subrule>` call at `pos` is evaluated under:
+/// `(written rule name, chars remaining)`. It carries no package, so two
+/// grammars that define the same rule name share it — see
+/// `regex_call_graph::subrule_cannot_reenter_itself`.
+pub(super) type LrKey = (String, usize);
+
+/// `true` when this key is already being evaluated further up the stack, i.e.
+/// entering it again would be a left-recursive re-entry.
+pub(super) fn lr_key_is_active(key: &LrKey) -> bool {
+    LR_ACTIVE.with(|a| a.borrow().contains_key(key))
+}
+
+/// Mark `key` as under evaluation with an empty seed, returning the enclosing
+/// activation's "seed was consulted" flag for [`lr_end_activation`] to restore.
+pub(super) fn lr_begin_activation(key: &LrKey) -> bool {
+    LR_MEMO.with(|m| m.borrow_mut().insert(key.clone(), Vec::new()));
+    LR_ACTIVE.with(|a| a.borrow_mut().insert(key.clone(), ()));
+    LR_SEED_READ.with(|s| s.borrow_mut().remove(key))
+}
+
+/// Undo [`lr_begin_activation`], reporting whether anything re-entered `key`
+/// and read its seed while it was active.
+pub(super) fn lr_end_activation(key: &LrKey, outer_seed_read: bool) -> bool {
+    LR_ACTIVE.with(|a| a.borrow_mut().remove(key));
+    LR_MEMO.with(|m| m.borrow_mut().remove(key));
+    LR_SEED_READ.with(|s| {
+        let mut s = s.borrow_mut();
+        let consulted = s.contains(key);
+        if outer_seed_read {
+            s.insert(key.clone());
+        } else {
+            s.remove(key);
+        }
+        consulted
+    })
+}
+
 impl Interpreter {
     /// An alternation alternative that is a lone plain `{ … }` code block
     /// (`|| { die "no match" }`). Such a branch matches zero-width and exists

--- a/src/runtime/regex/regex_match_lazy.rs
+++ b/src/runtime/regex/regex_match_lazy.rs
@@ -28,7 +28,7 @@ use std::cell::Cell;
 
 /// What the walk does with one atom candidate: merge its delta, descend, and
 /// report whether the whole walk should stop.
-pub(super) type AtomCandidateCont<'f> =
+pub(in crate::runtime::regex) type AtomCandidateCont<'f> =
     dyn FnMut(&mut Interpreter, &mut CapStore, usize, RegexCaptures) -> bool + 'f;
 
 impl Interpreter {
@@ -112,6 +112,13 @@ impl Interpreter {
                         ratchet,
                         on,
                     );
+                }
+                RegexAtom::Named(name) => {
+                    if let Some(stop) = self
+                        .drive_named_subrule_candidates(name, chars, pos, store, pkg, ratchet, on)
+                    {
+                        return stop;
+                    }
                 }
                 _ => {}
             }

--- a/src/runtime/regex/regex_match_lazy_subrule.rs
+++ b/src/runtime/regex/regex_match_lazy_subrule.rs
@@ -1,0 +1,148 @@
+//! ADR-0073 Slice 2 (streamed half): a `<subrule>` call's candidates are
+//! produced on demand.
+//!
+//! The eager `Named` arm (`regex_match_atom.rs`) collects a subrule's whole end
+//! set before the caller descends into any of it, because it carries the
+//! left-recursion growing-seed loop, the proto rank-then-match dispatch
+//! (ADR-0046) and three `Vec`-returning escape hatches. This module takes the
+//! one shape where none of that is in play and drives the subrule's body
+//! through a `MatchSink::Cont` instead, so an embedded `{ ... }` block inside it
+//! runs once per end the cursor ENTERS rather than once per end the engine
+//! COMPUTES.
+//!
+//! The precondition that makes it sound is `regex_call_graph`'s reachability
+//! analysis: with a call to this rule's own name proven unreachable, the
+//! growing-seed loop is a formality and there is nothing for the stream to get
+//! wrong.
+
+use super::super::*;
+use super::regex_match_core::MatchSink;
+use super::regex_match_lazy::AtomCandidateCont;
+use super::regex_trail::CapStore;
+
+impl Interpreter {
+    /// Drive a `<subrule>` call's walk, wrapping each of its ends into this
+    /// atom's capture delta as it is produced (ADR-0073 Slice 2's second half).
+    ///
+    /// `Some(stop)` when the call was streamed; `None` when it is not eligible
+    /// and the caller must fall back to the eager producer.
+    ///
+    /// The eager `Named` arm (`regex_match_atom.rs`) cannot stream because it
+    /// carries the left-recursion growing-seed loop, the proto rank-then-match
+    /// dispatch and three `Vec`-returning escape hatches. This path takes only
+    /// the shape where none of them is in play — an argument-less call with
+    /// exactly one non-proto candidate, no custom-HOW dispatch, no `:m`, no
+    /// dynamic (`$*`) rule parameters anywhere in the program, and a key that
+    /// is not already active — and, crucially, only when the call graph proves
+    /// the rule cannot reach a call to its own name
+    /// (`regex_call_graph::subrule_call_is_streamable`). With re-entry
+    /// impossible, the growing-seed loop is a formality: it runs one iteration,
+    /// finds the seed unconsulted, and returns the first result.
+    ///
+    /// The activation is still registered, because an embedded `{ ... }` block
+    /// is user code the call graph does not model: if it re-enters this key by
+    /// hand, it reads the empty seed and fails instead of recursing forever.
+    /// When that happens and nothing has committed to a candidate yet, the call
+    /// falls back to the eager growing-seed path — the block runs again, which
+    /// is the same over-firing this slice removes elsewhere, but the match is
+    /// the one the seed loop would have produced.
+    #[allow(clippy::too_many_arguments)]
+    pub(super) fn drive_named_subrule_candidates(
+        &mut self,
+        name: &str,
+        chars: &[char],
+        pos: usize,
+        store: &mut CapStore,
+        pkg: &str,
+        ratchet: bool,
+        on: &mut AtomCandidateCont<'_>,
+    ) -> Option<bool> {
+        // A `$*`-twigil rule parameter has to be installed around the call and
+        // torn down after it; streaming would keep it installed across the
+        // continuation, which is a different dynamic scope. The flag is global
+        // and almost always false, so this costs nothing in practice.
+        if crate::runtime::regex::regex_dynparams::ANY_DYNAMIC_TOKEN_PARAM
+            .load(std::sync::atomic::Ordering::Relaxed)
+        {
+            return None;
+        }
+        if !self.registry().grammar_custom_how.is_empty() {
+            return None;
+        }
+        // Memoized per (package, atom text), and asked FIRST: the rule resolves
+        // to exactly one plain argument-less candidate AND the call graph proves
+        // it cannot reach a call to its own name. A call that fails this costs
+        // two borrowed hash lookups — no name parse, no resolution the eager arm
+        // would then repeat.
+        if !self.subrule_call_is_streamable(name, pkg) {
+            return None;
+        }
+        let spec = Self::parse_named_regex_lookup_spec(name);
+        let lr_key = (spec.lookup_name.clone(), chars.len() - pos);
+        if super::regex_match_atom::lr_key_is_active(&lr_key) {
+            return None;
+        }
+        // Same resolution the eager arm performs (memoized for a static body,
+        // per-call otherwise). The shape was settled above, but a body that is
+        // re-parsed per call is re-checked rather than assumed.
+        let (candidates, _) = self.parsed_subrule_candidates(&spec, pkg, &[]);
+        let [(parsed, sub_pkg, sym_key)] = &candidates[..] else {
+            return None;
+        };
+        if sym_key.is_some() || parsed.ignore_mark {
+            return None;
+        }
+        let parsed = std::sync::Arc::clone(parsed);
+        let sub_pkg = sub_pkg.clone();
+
+        let outer_seed_read = super::regex_match_atom::lr_begin_activation(&lr_key);
+        // Ends are deduplicated the way the eager arm does it: the first (=
+        // highest-priority) path to reach an end wins, later ones are dropped.
+        let mut seen_ends: Vec<usize> = Vec::new();
+        let mut unwind = false;
+        {
+            let unwind = &mut unwind;
+            let mut cont = |interp: &mut Interpreter, end: usize, inner: RegexCaptures| -> bool {
+                if seen_ends.contains(&end) {
+                    return false;
+                }
+                seen_ends.push(end);
+                let wrapped = Interpreter::build_named_candidates_from_inner(
+                    vec![(end, inner)],
+                    pos,
+                    &spec,
+                    None,
+                );
+                let Some((end, delta)) = wrapped.into_iter().next() else {
+                    return false;
+                };
+                if on(interp, store, end, delta) {
+                    *unwind = true;
+                    return true;
+                }
+                // Ratchet (`:`, and every `token`/`rule` body) commits to the
+                // subrule's highest-priority end and forbids backtracking into
+                // it, so there is no second candidate to compute.
+                ratchet
+            };
+            self.regex_walk_ends_in_pkg(
+                &parsed,
+                chars,
+                pos,
+                &sub_pkg,
+                false,
+                false,
+                &mut MatchSink::Cont(&mut cont),
+            );
+        }
+        let seed_consulted = super::regex_match_atom::lr_end_activation(&lr_key, outer_seed_read);
+        if seed_consulted && !unwind {
+            // A `{ ... }` block re-entered this key after all, so the single
+            // pass above is not the growing-seed loop's answer. Nothing has
+            // committed (the continuation rejected every streamed end), so hand
+            // the call back to the eager arm.
+            return None;
+        }
+        Some(unwind)
+    }
+}

--- a/src/runtime/regex/regex_subrule_lazy.rs
+++ b/src/runtime/regex/regex_subrule_lazy.rs
@@ -34,9 +34,15 @@
 //! that hazard out: a body that cannot invoke a named rule at all cannot
 //! re-enter *itself*, so its seed can never be consulted and the growing loop
 //! is guaranteed to stop after one iteration whether or not the walk was cut
-//! short. It is an over-approximation — a non-leaf rule that is provably not
-//! part of a call cycle is eligible in principle — and tightening it needs a
-//! rule-call-graph cycle analysis, which is deliberately out of this slice.
+//! short. It is an over-approximation — it admits leaf rules only.
+//!
+//! The rule-call-graph analysis that answers the real question lives in
+//! [`super::regex_call_graph`] and gates the *streamed* subrule path
+//! (`regex_match_lazy::drive_named_subrule_candidates`), which handles a
+//! single-candidate, argument-less call under either kind of caller. This
+//! predicate is what the eager arm still falls back on for everything that path
+//! declines — a proto, several candidates, a call with arguments — where the
+//! ratchet is the only thing making truncation legal.
 //!
 //! The predicate lists the safe atom kinds explicitly and answers `false` for
 //! anything else, so a newly added `RegexAtom` variant is excluded until

--- a/src/runtime/regex/regex_token_resolve.rs
+++ b/src/runtime/regex/regex_token_resolve.rs
@@ -91,7 +91,7 @@ impl Interpreter {
     /// (pkg, name). Returns `None` when any candidate's pattern is non-static
     /// (its parse depends on runtime variable interpolation) or fails to
     /// parse — callers fall back to the uncached per-call path.
-    fn resolve_parsed_token_candidates_in_pkg(
+    pub(super) fn resolve_parsed_token_candidates_in_pkg(
         &mut self,
         name: &str,
         pkg: &str,

--- a/t/regex-lazy-candidate-enumeration.t
+++ b/t/regex-lazy-candidate-enumeration.t
@@ -8,7 +8,7 @@ use Test;
 # rows that already agreed before the change are just as important as the rows
 # that did not: they are what a laziness change is most likely to break.
 
-plan 87;
+plan 94;
 
 my $c;
 
@@ -174,13 +174,11 @@ is $c, 1, 'D3  no continuation, first branch wins';
 my $e = 0;
 grammar E1G { regex TOP { <part> 'c' }; regex part { \w* { $e++ } } }
 $e = 0; E1G.parse('aaac');
-todo 'ADR-0073 Slice 2: the <subrule> boundary is still collect-then-pick';
 is $e, 2, 'E1  regex subrule under a regex caller';
 
 my $e2 = 0;
 grammar E2G { regex TOP { <a> 'c' }; regex a { <b> }; regex b { \w* { $e2++ } } }
 $e2 = 0; E2G.parse('aaac');
-todo 'ADR-0073 Slice 2: the <subrule> boundary is still collect-then-pick';
 is $e2, 2, 'E2  nested regex subrules';
 
 my $e3 = 0;
@@ -257,7 +255,6 @@ grammar E6G {
     regex part { 'a' [ 'b' { @e6.push('one') } || 'bc' { @e6.push('two') } ] }
 }
 @e6 = (); E6G.parse('abcd');
-todo 'ADR-0073 Slice 2: the <subrule> boundary is still collect-then-pick';
 is @e6.join(','), 'one', 'E6  ordered alternation inside a non-ratcheted subrule';
 
 my $e7 = 0;
@@ -269,6 +266,47 @@ my $e8 = 0;
 grammar E8G { token TOP { <part> 'c' }; token part { (\w*) { $e8++; make ~$0 } } }
 $e8 = 0; E8G.parse('aaac');
 is $e8, 1, 'E8  a make-bearing block runs once';
+
+# E9: a NON-LEAF rule under a ratcheted caller. The first half of Slice 2 kept
+# such a rule on the full walk (its syntactic guard admitted leaf bodies only);
+# the call-graph analysis proves `part` cannot reach a call to `part`, so it is
+# streamed like any other.
+my $e9 = 0;
+grammar E9G {
+    token TOP   { <part> 'c' }
+    regex part  { <inner> }
+    regex inner { \w* { $e9++ } }
+}
+E9G.parse('aaac');
+is $e9, 1, 'E9  a non-leaf subrule under a ratcheted caller runs its block once';
+
+# E10: mutual recursion. `a` can reach `a` (through `b`), so the call graph
+# refuses it and the growing-seed loop keeps the full end set. No raku oracle --
+# Rakudo hangs on this grammar -- so this pins mutsu's own capability, exactly
+# as E3d/E3e do.
+grammar E10G {
+    regex TOP { <a> 'c' }
+    regex a   { <b> | 'zz' }
+    regex b   { <a> | \w* }
+}
+is ~(E10G.parse('aaac') // ''), 'aaac', 'E10 mutual recursion still parses';
+
+# E11/E12/E13 were measured against raku and agreed before this change; they are
+# the shapes a streamed `<subrule>` is most likely to break.
+my $e11 = 0;
+grammar E11G { rule TOP { <part> 'c' }; token part { \w+ { $e11++ } } }
+is ~(E11G.parse('aaa c') // ''), 'aaa c', 'E11 a `rule` caller (with <.ws>) still parses';
+is $e11, 1, 'E11a and runs the subrule block once';
+
+my $e12 = 0;
+grammar E12G { regex TOP { <part>+ 'c' }; regex part { \w { $e12++ } } }
+E12G.parse('aaac');
+is $e12, 4, 'E12 a quantified subrule under a NON-ratcheted caller';
+
+my $e13 = 0;
+grammar E13G { regex TOP { <a> 'c' }; regex a { <b> 'a' }; regex b { \w* { $e13++ } } }
+is ~(E13G.parse('aaac') // ''), 'aaac', 'E13 backtracking through two subrule levels';
+is $e13, 3, 'E13a and the innermost block runs once per end entered';
 
 # --- Family F: separated quantifiers ---------------------------------------
 

--- a/todo/deep/ordered-alternation-eager-candidate-enumeration.md
+++ b/todo/deep/ordered-alternation-eager-candidate-enumeration.md
@@ -1,92 +1,70 @@
-# The non-ratcheted `<subrule>` boundary is the last collect-then-pick barrier in the regex engine
+# The `<subrule>` calls the streamed path declines are the last collect-then-pick barrier
 
-**Narrowed 2026-09-07** by ADR-0073 Slice 1+3
-(`news/2026-09/regex-atom-candidates-are-demand-driven.md`) and again the same
-day by Slice 2's ratcheted half
-(`news/2026-09/ratcheted-subrule-calls-are-first-only.md`). The group,
-alternation, conjunction and separated-quantifier boundaries are
-continuation-driven; a `<subrule>` called from a **ratcheted** caller
-(`token` / `rule`) now walks its body with `first_only`. What is left is the
-**non-ratcheted (`regex`) caller**, which genuinely can backtrack into the
-subrule and therefore needs a streamed candidate set rather than a truncated
-one. This is the residue of ADR-0073's **Slice 2**.
+**Narrowed 2026-09-08** by ADR-0073's streamed half
+(`news/2026-09/subrule-calls-stream-their-candidates.md`), which closed the
+headline rows this file was opened for: E1, E2 and E6 all match `raku` now, and
+non-leaf rules under a ratcheted caller no longer compute an end set their caller
+cannot use. Earlier narrowings: Slice 1+3
+(`news/2026-09/regex-atom-candidates-are-demand-driven.md`) and Slice 2's
+ratcheted half (`news/2026-09/ratcheted-subrule-calls-are-first-only.md`).
 
-## What is left (re-measured 2026-09-07 against `raku` and a current build)
+## What is left
 
-An embedded `{ ... }` block inside a subrule called from a **non-ratcheted
-(`regex`) caller** still runs once per candidate the engine *computes* rather
-than once per candidate raku's cursor *enters*.
+`drive_named_subrule_candidates` (`src/runtime/regex/regex_match_lazy.rs`) takes
+one shape and one only: an argument-less call resolving to exactly one non-proto
+candidate, with no custom-HOW dispatch, no `:m`, no dynamic (`$*`) rule
+parameters declared anywhere in the program, a key that is not already LR-active,
+and a rule the call graph (`regex_call_graph.rs`) proves cannot reach a call to
+its own name. Everything else still goes to the eager `Named` arm in
+`regex_match_atom.rs`, which computes a subrule's whole end set before the caller
+descends into any of it — so an embedded `{ … }` block inside such a subrule
+still runs once per end *computed* rather than once per end *entered*.
 
-| # | shape | subject | raku | mutsu |
-| --- | --- | --- | --- | --- |
-| E1 | `regex TOP { <part> 'c' }` / `regex part { \w* {B} }` | `aaac` | 2 | 5 |
-| E2 | `regex TOP { <a> 'c' }` / `regex a { <b> }` / `regex b { \w* {B} }` | `aaac` | 2 | 5 |
-| E6 | `regex part { 'a' [ 'b' {one} \|\| 'bc' {two} ] }` under `regex TOP { <part> 'cd' }` | `abcd` | `one` | `one,two` |
+The declined shapes, roughly in descending order of how often they come up:
 
-Controls that already agree and must not move: `regex TOP` calling a `token`
-subrule (E4), `token`/`token` (E5), a `$*`-declaring caller (E7), a
-`make`-bearing block (E8), a quantified subrule under a ratcheted caller (E3g),
-and — new with the ratcheted half — the left-recursive `token expr { <term> |
-<expr> '+' <term> }` growing-seed rows (E3d/E3e). All of them are pinned in
-`t/regex-lazy-candidate-enumeration.t`; the three rows above are still `todo`.
+1. **A rule that really is part of a call cycle.** Left recursion is the reason
+   the growing-seed loop exists, and the loop needs the whole candidate set to
+   decide whether the seed grew. Streaming here means threading the continuation
+   *through* the seed loop, so that a candidate is produced, offered, and only
+   then followed by the next iteration's — with no way to un-run what the
+   rejected ones already did. This is the genuinely hard residue.
+2. **A proto/`multi` subrule.** ADR-0046's rank-then-match dispatch is already
+   demand-driven at the *candidate* level, but it wants the winning candidate's
+   whole end set. Streaming it means driving the ranked candidates and their
+   ends from one continuation.
+3. **Several resolved candidates without a proto.** The eager arm deduplicates
+   ends *across* candidates (first occurrence per end wins); a streamed form has
+   to interleave the candidates' walks to preserve that priority order.
+4. **A call with arguments** (`<expr($p-1)>`). The arguments are part of the
+   left-recursion key and are evaluated per call, so the memoized call-graph
+   verdict does not apply; the analysis answers "may re-enter" for any
+   argument-bearing edge, which also makes every *caller* of such a rule
+   ineligible.
+5. **A body that splices a value into its own pattern text.** A `Regex`-valued
+   scalar is interpolated as pattern SOURCE, so the rule's call edges are not a
+   property of the token generation and the analysis refuses to cache — it
+   answers "not knowable" instead. (A sigil inside a `{ … }` code block does not
+   count; parse-time interpolation treats code blocks as opaque.) Tightening this
+   means tracking *which* interpolations can introduce a rule call.
+6. `<::(EXPR)>` symbolic indirection, `<{ … }>` closure interpolation, `<~~>`,
+   a name that resolves to a grammar **method**, a custom-HOW grammar, `:m`, and
+   a program that declares any dynamic (`$*`) rule parameter — each of which
+   returns from a different place in the arm, or changes the dynamic scope the
+   continuation would run under.
 
-E6 is the row the original 2026-09-05 filing was written around: the match
-itself is correct, and every block mutsu runs is one raku *would* run if the
-continuation had failed. It only bites a block with a side effect that must not
-happen — a `die`, a push, a counter.
+## Why the residue is not obviously worth clearing
 
-## Why the `Named` arm resisted Slice 1, and what the ratcheted half did instead
+Every item above is *correct* today; what it costs is extra `{ … }` block runs
+on paths raku never enters, which only bites a block with a side effect that must
+not happen — a `die`, a push, a counter — plus the wasted enumeration. Before
+opening any of these, measure how often the declined shapes actually occur: the
+streamable verdict is memoized per (package, subrule atom text) in
+`regex_call_graph.rs`'s `STREAMABLE`, so a counter there would say directly which
+of the six is worth the work.
 
-`for_each_atom_candidate` (`src/runtime/regex/regex_match_lazy.rs`) drives
-`Group` / `CaptureGroup` / `CaptureIsolatedGroup` / `Conjunction` /
-`Alternation` through a `MatchSink::Cont` and falls back to the eager producer
-for everything else. `RegexAtom::Named` is still on the fallback: its arm in
-`regex_match_atom.rs` is not a simple sub-pattern walk. It carries
-
-- the **left-recursion growing-seed loop** (`LR_ACTIVE` / `LR_MEMO` /
-  `LR_SEED_READ`), which decides whether the rule is left-recursive at this
-  position by evaluating the candidates and then checking whether the seed was
-  consulted. It cannot know before evaluating, so a lazy path that skipped the
-  bookkeeping would let a genuinely left-recursive rule recurse forever, and one
-  that discovers re-entry mid-walk cannot un-run the blocks it already ran;
-- the **proto rank-then-match dispatch** (ADR-0046), which ranks candidates by
-  measurement and then commits to the first that matches — already
-  demand-driven at the candidate level, but it wants the matched candidate's
-  whole end set;
-- `try_regex_subrule_as_method`, `try_custom_how_subrule_dispatch`, and the
-  `<::(EXPR)>` symbolic indirection, each of which returns a `Vec` from a
-  different place.
-
-The **ratcheted** half sidestepped all of that: when the calling token cannot
-backtrack into the atom, only the subrule's highest-priority end can ever be
-used, so the arm walks each candidate body with `first_only` instead of
-collecting its whole end set. No streaming, no interface change — the arm still
-returns a `Vec`, it is just a `Vec` of length ≤ 1. The one hazard is the seed
-loop above (a `first_only` walk can return before entering the branch that
-re-enters the rule), and it is closed by a *sound* structural precondition:
-`regex_subrule_lazy::pattern_is_rule_call_free` — a body that cannot invoke a
-named rule cannot re-enter its own key. That is an over-approximation: it admits
-leaf rules only.
-
-## The two pieces of residue
-
-1. **The non-ratcheted caller (E1/E2/E6).** A `regex` caller really can
-   backtrack into the subrule, so truncation is wrong and the arm has to
-   *stream*: `regex_match_atom_all_with_capture_opts` would have to grow a
-   `MatchSink::Cont` form so candidate *k+1* of the subrule is computed only
-   after *k* has been rejected. That means threading the continuation through
-   the seed loop, the proto dispatch and the three `Vec`-returning escape
-   hatches — the work Slice 1 deliberately deferred. The separable sub-case
-   remains "no arguments, no proto, exactly one resolved candidate, this
-   `(name, position)` key not currently LR-active".
-
-2. **Non-leaf rules under a ratcheted caller.** `pattern_is_rule_call_free`
-   excludes any body containing `<name>`, `<.ws>`, `<{ … }>` or `<~~>`, so a
-   grammar's interior rules keep computing their full end set even though their
-   ratcheted caller will use only the first. Lifting this needs a rule-call-graph
-   cycle analysis ("can this rule reach itself?") rather than the current
-   syntactic "does this rule call anything at all?", and that analysis has to
-   cope with inheritance, protos and `<::(EXPR)>` indirection.
+Note also that the analysis is deliberately a *sound under-approximation*: it
+answers "may re-enter" for anything it cannot resolve. Widening it is the cheap
+half of items 4-6; the streaming machinery is the expensive half of items 1-3.
 
 ## Also still eager (measured, different mechanisms)
 


### PR DESCRIPTION
Closes the non-ratcheted half of ADR-0073's Slice 2 — the `<subrule>` boundary,
the last collect-then-pick barrier in the regex engine — and lifts the ratcheted
half's leaf-only restriction at the same time. Works
`todo/deep/ordered-alternation-eager-candidate-enumeration.md`.

## The bug

An embedded `{ … }` block inside a subrule called from a `regex` caller ran once
per candidate the engine **computed** rather than once per candidate raku's
cursor **enters**:

```raku
my $n = 0;
grammar G { regex TOP { <part> 'c' }; regex part { \w* { $n++ } } }
G.parse('aaac');
say $n;                 # raku: 2     mutsu before: 5
```

The match itself was right; every block mutsu ran is one raku *would* run if the
continuation had failed. It bites a block with a side effect that must not happen
on a path never taken. The nastiest shape was an ordered alternation inside such
a subrule, where the losing branch's block fired even though the winning branch
had already carried the whole parse (`one,two` against raku's `one`).

## Why the earlier slices could not touch it

The `Named` arm carries the left-recursion growing-seed loop (`LR_ACTIVE` /
`LR_MEMO` / `LR_SEED_READ`), which decides whether a rule is left-recursive *at
this position* by evaluating its candidates and then asking whether the seed was
consulted — it cannot know before evaluating, and cannot un-run the blocks a
cut-short walk already ran. Slice 2's first half sidestepped it with a syntactic
precondition (`pattern_is_rule_call_free`), which admits **leaf rules only**.

## The change

`src/runtime/regex/regex_call_graph.rs` asks the real question: **can this rule
reach a call to its own name?** Edges come from the same resolution the matcher
uses, `<.ws>` is an edge to `ws`, a name resolving to no rule is a builtin
assertion (no edge) unless the grammar has a method of that name, and anything
unresolvable answers "may re-enter" — so `true` means proven safe and `false`
only means *not proven*.

With re-entry ruled out the seed loop is a formality, and
`drive_named_subrule_candidates` (`regex_match_lazy_subrule.rs`) walks the
subrule body through a `MatchSink::Cont`, wrapping each end into the atom's
capture delta as it is produced. A ratchet on the calling token stops the stream
after the first end — what the ratcheted half needed `first_only` for — so
**non-leaf rules under a ratcheted caller are streamed too**.

Everything the path declines (a call with arguments, a proto, several resolved
candidates, `<::(EXPR)>`, a custom-HOW grammar, `:m`, a program declaring any
dynamic rule parameter, a rule that really is part of a call cycle) falls back to
the eager arm unchanged. The activation is still registered while streaming, so a
`{ … }` block that re-enters the key by hand reads the empty seed and fails
instead of recursing forever; if the seed was consulted and nothing has committed
yet, the call is handed back to the eager growing-seed path.

## Performance

Re-deciding the analysis per call cost **+22% instructions** on
`bench-yaml-parse` (`callgrind`, 804M vs 657M Ir), almost all `malloc`/`free`.
Three memo layers keyed on `TOKEN_DEFS_GEN` bring that to **+1.6%**, with
`bench-grammar-parse` / `-deep` at parity (A/B in one binary: 17/15/158 ms with
streaming, 17/15/154 ms with it disabled). The hot probe is a two-level
`package -> atom text` map so it borrows `&str` instead of building a
`(String, String)` key, and it is asked *before* the atom's name is parsed.

A body that splices a value into its own pattern text is answered "not knowable"
**and cached as such** — a `Regex`-valued scalar is interpolated as pattern
*source*, so its edges really can change between attempts. A sigil inside a
`{ … }` code block does not count, because parse-time interpolation treats code
blocks as opaque; without that distinction the common
`token part { \w+ { $n++ } }` shape would have been ineligible.

## Tests

`t/regex-lazy-candidate-enumeration.t`: E1, E2 and E6 lose their `todo`, and
seven rows are added — a non-leaf rule under a ratcheted caller, mutual recursion
(which the call graph refuses, keeping the growing-seed loop), a `rule` caller's
`<.ws>`, a quantified subrule under a non-ratcheted caller, and backtracking
through two subrule levels. All new expectations were measured against `raku`
2026.07 except the two recursion rows, which Rakudo hangs on.

`make test` green (3828 files / 40467 tests); the S05 / S03-smartmatch / grammar
/ S12-meta roast whitelist subset (122 files) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAtJGeybgQKe7By5gwjXQ6

---
_Generated by [Claude Code](https://claude.ai/code/session_01KAtJGeybgQKe7By5gwjXQ6)_