### PR TITLE
perf(construction): stop re-deriving names construction already knows

### DIFF
--- a/news/2026-09/bench-ctor-name-rederivation.md
+++ b/news/2026-09/bench-ctor-name-rederivation.md
@@ -1,0 +1,111 @@
+# bench-ctor: construction stopped re-deriving names it already knew
+
+`todo/perf/bench-ctor-construction-parity.md` round 6. The two leads round 5
+left open inside `dispatch_bless` turned out to be the small half of the
+finding. Profiling the whole benchmark with **callgrind** (this container has
+no `perf`, and callgrind's instruction counts are deterministic, which is what
+a perf iteration wants anyway) put `std::thread::local::LocalKey<T>::with` at
+**9.2% of the entire run**, and its dominant caller was `Symbol::intern`:
+**732,232 calls for 5000 constructions — 146 name interns per constructed
+object**, each a thread-local round trip plus a string hash and a `memcmp`.
+Almost all of them re-derived a `Symbol` from a name the caller already had,
+or had computed once per class already.
+
+The second finding is next to it: **every instance death cloned its whole
+attribute map into a DESTROY queue** that, in a program with no `DESTROY`
+anywhere, was walked and thrown away — a 21-entry `AttrMap` clone, a sharded
+mutex, and an MRO walk interning two names per level, per constructed object.
+
+Whole-bench instruction count, `benchmarks/bench-ctor.raku` (5000
+constructions, release, `taskset`-pinned, callgrind): **1,715,336,347 →
+1,480,264,577, −13.7%** (343k → 296k instructions per construction). An
+interleaved same-session wall-clock A/B (release builds of `main` and of this
+change, alternating, `taskset -c 2`, best of 9) reads **0.302s → 0.225s,
+−25%** — larger than the instruction delta because much of what went away was
+cache-unfriendly (thread-local + hash + `memcmp` round trips, and a 21-entry
+`AttrMap` clone per constructed object). Wall-clock confirmation belongs to the
+bench CI (`bench-history.tsv` on `bench-data`), per the ticket's measurement
+notes.
+
+## What changed
+
+**`NativeCtorPlan` learned the two things `dispatch_bless` re-derived per
+construction** — the ticket's own round-5 leads:
+
+- `attr_index`: attribute name -> index. The named-argument override loop
+  answered "does this argument name a declared attribute?" with a linear
+  `class_attrs.iter().position(...)` scan *per argument* — on the
+  `Zef::Distribution` shape that is 7 args x 21 attributes of `memcmp` per
+  construction. Now one hash probe per argument, resolved once and reused by
+  both the seed loop and the override loop. First-wins, matching the scan it
+  replaces (an MRO can collect two same-named attributes).
+- `attr_seeds`: the no-initializer seed value of each attribute, as a small
+  `AttrSeed` enum. Deriving it meant a `type_constraints` lookup, a
+  `nominal_type_object_name_for_constraint` walk and a `Symbol::intern` of the
+  resulting type name for *every unfilled attribute of every construction* —
+  16 interns per construction here. It is pure class shape, so it is computed
+  once per class alongside the rest of the plan.
+
+**A process-global "some user DESTROY exists" latch** (`ANY_DESTROY_DECLARED`
+in `src/value/mod.rs`). Monotonic and armed from the two places a user
+`DESTROY` can appear — `Registry::reindex_user_method_name` (the single
+reverse-index hook every class-side method mutator calls: class bodies,
+`augment`, `.^add_method`) and role registration (a role submethod `DESTROY`
+is dispatched straight off `RoleDef::methods`, never through the class method
+table). `InstanceAttrs::finalize_destroy` reads it at **drop** time, not at
+construction, so a `DESTROY` installed later still fires for everything that
+dies after it; it is read *after* the `live_instance_refcounts` bookkeeping, so
+skipping the queue cannot leak refcount entries. Pinned by
+`t/destroy-latch-late-registration.t`.
+
+**Symbol-keyed MRO probes for method presence.** `has_user_method` walked the
+MRO calling `Registry::user_method_overloads(cn.as_str(), name)`, which
+re-interned *both* names at every level and then **cloned the whole
+`Vec<MethodDef>`** — a ~300-byte struct with `String`s, `Arc`s and `Vec`s —
+purely to read one boolean off it. That single function was 1.6% of the bench.
+It now asks the new `Registry::user_method_public_presence(owner, name)`, which
+allocates nothing; the MRO entries are already `Symbol`s and the method name is
+interned once for the whole walk. `has_public_accessor` and
+`resolve_user_method_or_accessor` got the same treatment through new
+`accessor_is_public_sym` / `user_method_local_role_presence_sym`.
+
+**`Symbol::intern("Any")` -> `crate::symbol::wk::any()`** across the tree (115
+call sites). The well-known-symbol accessor already existed for exactly this;
+`Any` is the single most-interned name in an OO program (it is every untyped
+attribute's seed and every routine's fresh topic).
+
+**`AttrReadGuard::drop` no longer consults the deferred-write queue** unless
+something is actually deferred. Deferral is a rare self-deadlock escape hatch,
+but every attribute read paid a second thread-local access, a `RefCell` borrow
+and a `Vec::retain` to discover that — ~40 reads per construction. A relaxed
+load of the new global `PENDING_CELL_WRITE_COUNT` answers it in a couple of
+instructions (global rather than per-thread on purpose: over-reporting only
+makes this thread run the correct, empty, scan).
+
+**A dedicated `__mutsu_sigilless_readonly::` latch** (round 5's third open
+item). `closure_meta_keys_possible()` lumps four unrelated key families
+together, so creating a `state` variable armed the readonly probe too — and
+that probe runs on *every* whole-variable assignment (`OpCode::CheckReadOnly`),
+building a `format!` key and hashing it into the env for a key the program
+never created. `sigilless_readonly_keys_possible()` is the narrower gate, armed
+from the same `note_env_key` chokepoint every creation site flows through.
+
+**Interning hoists in method dispatch.** `call_compiled_method{,_fast}`
+interned the owner class name twice per call (once for `::?CLASS`, once for the
+routine-frame push) and the non-fast path built `String`s for the fixed
+`"?CLASS"` / `"?ROLE"` env keys instead of using the well-known symbols the
+fast path already uses. An attributive parameter bind interned its attribute
+name twice and allocated a `String` for the cell insert; it now interns once
+and inserts by `Symbol`.
+
+## Still open
+
+The remaining `Symbol::intern` traffic is concentrated in three places, each
+needing its own surgery: `native_lever_a_user_override` (2 interns per native
+method dispatch — `value_type_name` returns a `&'static str`, so a
+pointer-keyed memo or a `value_type_sym` would do it),
+`get_env_with_main_alias_inner` (name-keyed env reads, ~16 per construction —
+wants symbol-threaded callers), and the routine-frame push's
+`lexical_package` / `method_name` (wants pre-interned symbols on `MethodDef`,
+which is 18 struct-literal construction sites). Together they are ~3% of the
+bench.

--- a/src/builtins/methods_0arg/coercion.rs
+++ b/src/builtins/methods_0arg/coercion.rs
@@ -254,7 +254,7 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
                     items
                         .iter()
                         .map(|v| match v.view() {
-                            ValueView::Nil => Value::package(crate::symbol::Symbol::intern("Any")),
+                            ValueView::Nil => Value::package(crate::symbol::wk::any()),
                             _ => v.clone(),
                         })
                         .collect()

--- a/src/builtins/methods_0arg/dispatch_core_numeric.rs
+++ b/src/builtins/methods_0arg/dispatch_core_numeric.rs
@@ -188,7 +188,9 @@ pub(super) fn dispatch(
                     a.default.as_deref().cloned().unwrap()
                 }
                 ValueView::Hash(h) if h.default.is_some() => h.default.as_deref().cloned().unwrap(),
-                ValueView::Array(..) | ValueView::Hash(..) => Value::package(Symbol::intern("Any")),
+                ValueView::Array(..) | ValueView::Hash(..) => {
+                    Value::package(crate::symbol::wk::any())
+                }
                 ValueView::Set(..) => Value::FALSE,
                 ValueView::Bag(..) | ValueView::Mix(..) => Value::int(0),
                 _ => return Some(None),

--- a/src/builtins/methods_narg/dispatch_1arg.rs
+++ b/src/builtins/methods_narg/dispatch_1arg.rs
@@ -2228,9 +2228,9 @@ pub(crate) fn native_method_1arg(
                     Value::NIL
                 }))
             }
-            ValueView::Nil => Some(Ok(Value::package(Symbol::intern("Any")))),
+            ValueView::Nil => Some(Ok(Value::package(crate::symbol::wk::any()))),
             ValueView::Package(name) if matches!(name.resolve().as_str(), "Any" | "Mu") => {
-                Some(Ok(Value::package(Symbol::intern("Any"))))
+                Some(Ok(Value::package(crate::symbol::wk::any())))
             }
             // Anything else does not do `Associative`, and raku's `Any.AT-KEY`
             // fails for it. An Instance/Mixin/Package may carry a user-defined

--- a/src/builtins/native_method_row.rs
+++ b/src/builtins/native_method_row.rs
@@ -1057,7 +1057,7 @@ mod tests {
         match_interp.run("'foo' ~~ /f(o)(o)/;").unwrap();
         let match_sample = match_interp.env().get("/").cloned().unwrap();
         let samples: &[(&str, Value)] = &[
-            ("Any", Value::package(Symbol::intern("Any"))),
+            ("Any", Value::package(crate::symbol::wk::any())),
             ("Mu", Value::package(Symbol::intern("Mu"))),
             ("Nil", Value::NIL),
             ("Version", get("version")),
@@ -1476,7 +1476,7 @@ mod tests {
         // "small spread" discipline as `native_method_arities`).
         let int_sample = Value::int(2);
         let numeric_str_sample = Value::str_from("5");
-        let any_type_obj = Value::package(Symbol::intern("Any"));
+        let any_type_obj = Value::package(crate::symbol::wk::any());
         let mu_type_obj = Value::package(Symbol::intern("Mu"));
 
         let mut sub_interp = crate::runtime::Interpreter::new();

--- a/src/compiler/expr.rs
+++ b/src/compiler/expr.rs
@@ -1187,7 +1187,7 @@ impl Compiler {
                     // [//] () and [orelse] () return Any (type object)
                     let any_idx = self
                         .code
-                        .add_constant(Value::package(crate::symbol::Symbol::intern("Any")));
+                        .add_constant(Value::package(crate::symbol::wk::any()));
                     self.code.emit(OpCode::LoadConst(any_idx));
                 }
                 _ => {
@@ -1407,7 +1407,7 @@ impl Compiler {
                 "//" | "orelse" => {
                     let any_idx = self
                         .code
-                        .add_constant(Value::package(crate::symbol::Symbol::intern("Any")));
+                        .add_constant(Value::package(crate::symbol::wk::any()));
                     self.code.emit(OpCode::LoadConst(any_idx));
                 }
                 "&&" | "and" => {

--- a/src/compiler/expr_call.rs
+++ b/src/compiler/expr_call.rs
@@ -1125,7 +1125,7 @@ impl Compiler {
                     } else {
                         let any_idx = self
                             .code
-                            .add_constant(Value::package(crate::symbol::Symbol::intern("Any")));
+                            .add_constant(Value::package(crate::symbol::wk::any()));
                         self.code.emit(OpCode::LoadConst(any_idx));
                         self.emit_assign_local_or_name(&vname);
                     }
@@ -1159,7 +1159,7 @@ impl Compiler {
                 } else {
                     let any_idx = self
                         .code
-                        .add_constant(Value::package(crate::symbol::Symbol::intern("Any")));
+                        .add_constant(Value::package(crate::symbol::wk::any()));
                     self.code.emit(OpCode::LoadConst(any_idx));
                     self.emit_assign_local_or_name(&vname);
                 }

--- a/src/compiler/helpers_ast_utils.rs
+++ b/src/compiler/helpers_ast_utils.rs
@@ -37,7 +37,7 @@ impl Compiler {
     /// The `Any` type-object literal seeded by
     /// `uninit_untyped_scalar_defaults_to_any` sites.
     pub(super) fn any_type_object_expr() -> Expr {
-        Expr::Literal(Value::package(crate::symbol::Symbol::intern("Any")))
+        Expr::Literal(Value::package(crate::symbol::wk::any()))
     }
 
     /// Check if a method call is a known mutating method on an indexed target

--- a/src/env.rs
+++ b/src/env.rs
@@ -214,6 +214,21 @@ pub(crate) fn is_dynamic_var_name(name: &str) -> bool {
 /// reads it, so `Relaxed` ordering suffices.
 static CLOSURE_META_KEY_SEEN: AtomicBool = AtomicBool::new(false);
 
+/// Monotonic, process-global flag for `__mutsu_sigilless_readonly::*` keys
+/// alone.
+///
+/// [`CLOSURE_META_KEY_SEEN`] lumps four unrelated key families together, so a
+/// program that creates a `__mutsu_state_key::` (a `state` variable) or a
+/// `__mutsu_predictive_seq_iter::` arms the readonly probe too -- and that
+/// probe runs on EVERY whole-variable assignment (`OpCode::CheckReadOnly`),
+/// building a `format!("__mutsu_sigilless_readonly::{name}")` and hashing it
+/// into the env for a key the program never created. Sigilless/`:=` readonly
+/// markers are much rarer than `state` variables, so they deserve their own
+/// latch. Same soundness argument as [`CLOSURE_META_KEY_SEEN`]: every creation
+/// site is a String-keyed [`Env::insert`], the flag is monotonic, and an
+/// over-set only makes the (correct) probe run.
+static SIGILLESS_READONLY_KEY_SEEN: AtomicBool = AtomicBool::new(false);
+
 /// Monotonic, process-global flag for `__mutsu_bound::*` keys (the `:=`-bound
 /// container markers consulted by `CheckReadOnly` on every whole-variable
 /// assignment). Same soundness argument as [`CLOSURE_META_KEY_SEEN`]: every
@@ -267,6 +282,15 @@ static PLACEHOLDER_KEY_SEEN: AtomicBool = AtomicBool::new(false);
 /// program order than any return that could observe the binding, and an over-set
 /// only makes the (correct) probe run.
 static RETURN_REBOUND_SEEN: AtomicBool = AtomicBool::new(false);
+
+/// True if a `__mutsu_sigilless_readonly::*` key may exist in some env. See
+/// [`SIGILLESS_READONLY_KEY_SEEN`]. Strictly narrower than
+/// [`closure_meta_keys_possible`], so it is the right gate for a probe that
+/// only looks for that one key family.
+#[inline]
+pub(crate) fn sigilless_readonly_keys_possible() -> bool {
+    SIGILLESS_READONLY_KEY_SEEN.load(Ordering::Relaxed)
+}
 
 /// True if any closure-writeback metadata key may exist in some env. See
 /// [`CLOSURE_META_KEY_SEEN`].
@@ -331,6 +355,9 @@ pub(crate) fn note_env_key(key: &str) {
             || key.starts_with("__mutsu_predictive_seq_iter::")
         {
             CLOSURE_META_KEY_SEEN.store(true, Ordering::Relaxed);
+            if key.starts_with("__mutsu_sigilless_readonly::") {
+                SIGILLESS_READONLY_KEY_SEEN.store(true, Ordering::Relaxed);
+            }
         } else if key.starts_with("__mutsu_bound::") {
             BOUND_KEY_SEEN.store(true, Ordering::Relaxed);
         } else if key.starts_with("__mutsu_bound_array_slice::") {

--- a/src/parser/primary/ident/term_literals.rs
+++ b/src/parser/primary/ident/term_literals.rs
@@ -332,7 +332,7 @@ pub(crate) fn keyword_literal(input: &str) -> PResult<'_, Expr> {
     if let Ok(r) = try_kw("Empty", Value::slip_arc(std::sync::Arc::new(vec![]))) {
         return Ok(r);
     }
-    if let Ok(r) = try_kw("Any", Value::package(Symbol::intern("Any"))) {
+    if let Ok(r) = try_kw("Any", Value::package(crate::symbol::wk::any())) {
         return Ok(r);
     }
     // Unicode: ∅ (U+2205 EMPTY SET)

--- a/src/runtime/attr_build_defaults.rs
+++ b/src/runtime/attr_build_defaults.rs
@@ -273,7 +273,7 @@ impl Interpreter {
                     let nominal = self.nominal_type_object_name_for_constraint(tc);
                     Value::package(Symbol::intern(&nominal))
                 }
-                None => Value::package(Symbol::intern("Any")),
+                None => Value::package(crate::symbol::wk::any()),
             },
         }
     }

--- a/src/runtime/builtins.rs
+++ b/src/runtime/builtins.rs
@@ -295,7 +295,7 @@ impl Interpreter {
                 self.var_type_constraint(source_name)
                     .map(|tc| Value::package(Symbol::intern(&tc)))
             })
-            .unwrap_or_else(|| Value::package(Symbol::intern("Any")));
+            .unwrap_or_else(|| Value::package(crate::symbol::wk::any()));
         attributes.insert("default".to_string(), default_val);
         let of_type = container
             .as_ref()
@@ -673,7 +673,7 @@ impl Interpreter {
             "__mutsu_words_atom" => self.builtin_words_atom(&args),
             "__mutsu_qw_result" => Ok(args.first().cloned().unwrap_or(Value::NIL)),
             "__mutsu_unknown_backslash_escape" => self.builtin_unknown_backslash_escape(&args),
-            "undefine" => Ok(Value::package(crate::symbol::Symbol::intern("Any"))),
+            "undefine" => Ok(Value::package(crate::symbol::wk::any())),
             "__mutsu_undefine_rvalue" => {
                 // Called when undefine receives a non-variable expression.
                 // Immutable types (Bool, Int, Str, etc.) must die.

--- a/src/runtime/builtins_collection_classify.rs
+++ b/src/runtime/builtins_collection_classify.rs
@@ -23,7 +23,7 @@ impl Interpreter {
         /// it does not hold: the `Any` type object, which is what the
         /// equivalent subscript read (`@mapper[6]`, `%mapper<z>`) answers.
         fn mapper_miss() -> Value {
-            Value::package(crate::symbol::Symbol::intern("Any"))
+            Value::package(crate::symbol::wk::any())
         }
 
         /// Returns (paths, is_multi_level).

--- a/src/runtime/builtins_io_stream.rs
+++ b/src/runtime/builtins_io_stream.rs
@@ -124,10 +124,10 @@ impl Interpreter {
             // `get`), not an empty string: `prompt(...).defined` is False.
             return Ok(match self.read_line_from_handle_value(&handle)? {
                 Some(line) => Value::str(line),
-                None => Value::package(crate::symbol::Symbol::intern("Any")),
+                None => Value::package(crate::symbol::wk::any()),
             });
         }
-        Ok(Value::package(crate::symbol::Symbol::intern("Any")))
+        Ok(Value::package(crate::symbol::wk::any()))
     }
 
     pub(super) fn builtin_get(&mut self, args: &[Value]) -> Result<Value, RuntimeError> {

--- a/src/runtime/builtins_lvalue.rs
+++ b/src/runtime/builtins_lvalue.rs
@@ -664,7 +664,7 @@ impl Interpreter {
         if self.readonly_kind(&name).is_some() {
             return Ok(Value::FALSE);
         }
-        if crate::env::closure_meta_keys_possible() {
+        if crate::env::sigilless_readonly_keys_possible() {
             let key = crate::runtime::sigilless_readonly_key(&name);
             if matches!(
                 self.env.get(&key).map(Value::view),

--- a/src/runtime/builtins_multidim.rs
+++ b/src/runtime/builtins_multidim.rs
@@ -88,7 +88,7 @@ pub(super) fn multidim_index(target: &Value, indices: &[Value]) -> Value {
 
 /// Delete element from a multi-dimensional array, returning the deleted value.
 pub(super) fn multidim_delete(target: &mut Value, indices: &[Value]) -> Value {
-    let default = || Value::package(crate::symbol::Symbol::intern("Any"));
+    let default = || Value::package(crate::symbol::wk::any());
     // A file-scoped `@a`/`%h` shared across frames (or a nested cell-promoted
     // element) is a `ContainerRef` cell: mutate the inner container in place
     // through the lock so every alias (env entry + caller local slot, which

--- a/src/runtime/builtins_multidim_assign.rs
+++ b/src/runtime/builtins_multidim_assign.rs
@@ -157,7 +157,7 @@ impl Interpreter {
                         Self::autoviv_resize(
                             items,
                             index + 1,
-                            Value::package(crate::symbol::Symbol::intern("Any")),
+                            Value::package(crate::symbol::wk::any()),
                         )?;
                         Value::assign_element_slot(&mut items[index], value.clone());
                         if let Some(root) = method_args.first() {
@@ -450,10 +450,7 @@ impl Interpreter {
                         if crate::runtime::utils::is_shaped_array(&current) {
                             return Err(RuntimeError::new("Index out of bounds"));
                         }
-                        new_items.resize(
-                            idx + 1,
-                            Value::package(crate::symbol::Symbol::intern("Any")),
-                        );
+                        new_items.resize(idx + 1, Value::package(crate::symbol::wk::any()));
                     }
                     new_items[idx] = effective_value.clone();
                     Value::array_with_kind(crate::gc::Gc::new(new_items), kind)
@@ -627,10 +624,7 @@ impl Interpreter {
                 let idx = dims[0];
                 let mut new_items = (**items).clone();
                 if idx >= new_items.len() {
-                    new_items.resize(
-                        idx + 1,
-                        Value::package(crate::symbol::Symbol::intern("Any")),
-                    );
+                    new_items.resize(idx + 1, Value::package(crate::symbol::wk::any()));
                 }
                 if dims.len() == 1 {
                     new_items[idx] = value;
@@ -650,8 +644,7 @@ impl Interpreter {
                 // If it's not an array, wrap the assignment in a fresh array
                 if dims.len() == 1 {
                     let idx = dims[0];
-                    let mut new_items =
-                        vec![Value::package(crate::symbol::Symbol::intern("Any")); idx + 1];
+                    let mut new_items = vec![Value::package(crate::symbol::wk::any()); idx + 1];
                     new_items[idx] = value;
                     Ok(Value::real_array(new_items))
                 } else {

--- a/src/runtime/builtins_multidim_subscript.rs
+++ b/src/runtime/builtins_multidim_subscript.rs
@@ -465,7 +465,7 @@ impl Interpreter {
                 .or(type_constraint_default)
                 .unwrap_or_else(|| {
                     if target_is_real_array {
-                        Value::package(Symbol::intern("Any"))
+                        Value::package(crate::symbol::wk::any())
                     } else {
                         Value::NIL
                     }
@@ -621,7 +621,7 @@ impl Interpreter {
                             .and_then(|name| self.var_type_constraint(name))
                             .map(|t| Value::package(Symbol::intern(&t)))
                     })
-                    .unwrap_or_else(|| Value::package(Symbol::intern("Any")));
+                    .unwrap_or_else(|| Value::package(crate::symbol::wk::any()));
                 // Object hashes (`my %h{Int}`) store `.WHICH`-encoded keys, so
                 // the subscript value must be encoded the same way to find the
                 // entry; the *displayed* key is the original typed subscript.
@@ -748,7 +748,7 @@ impl Interpreter {
     /// `Int<a>:!v` is `Any` where `5<a>:!v` is the Failure.
     pub(crate) fn any_at_key_value(target: &Value) -> Value {
         match target.view() {
-            ValueView::Package(_) => Value::package(Symbol::intern("Any")),
+            ValueView::Package(_) => Value::package(crate::symbol::wk::any()),
             _ => {
                 RuntimeError::assoc_indexing_failure(crate::runtime::utils::value_type_name(target))
             }

--- a/src/runtime/catch_inline.rs
+++ b/src/runtime/catch_inline.rs
@@ -169,7 +169,7 @@ impl Interpreter {
         self.catch_handlers.push(entry);
 
         match outcome {
-            Ok(()) => Ok(Value::package(crate::symbol::Symbol::intern("Any"))),
+            Ok(()) => Ok(Value::package(crate::symbol::wk::any())),
             Err((verdict, mut e)) => {
                 e.set_catch_inline_verdict(Some((token, verdict)));
                 Err(e)

--- a/src/runtime/class_introspection.rs
+++ b/src/runtime/class_introspection.rs
@@ -253,12 +253,15 @@ impl Interpreter {
 
     pub(crate) fn has_user_method(&mut self, class_name: &str, method_name: &str) -> bool {
         let mro = self.class_mro(class_name);
+        // Symbol-keyed: the MRO is already `Symbol`s, so the per-level probe
+        // interns nothing (the `&str` API re-interned owner AND name at every
+        // level) and clones no candidate list (see
+        // `Registry::user_method_public_presence`).
+        let name_sym = crate::symbol::Symbol::intern(method_name);
+        let registry = self.registry();
         for cn in mro.iter() {
-            if let Some(defs) = self
-                .registry()
-                .user_method_overloads(cn.as_str(), method_name)
-            {
-                return defs.iter().any(|d| !d.is_private);
+            if let Some(any_public) = registry.user_method_public_presence(*cn, name_sym) {
+                return any_public;
             }
         }
         false
@@ -290,8 +293,12 @@ impl Interpreter {
     /// this sits on the per-call method-dispatch path.
     pub(crate) fn has_public_accessor(&mut self, class_name: &str, method_name: &str) -> bool {
         let mro = self.class_mro(class_name);
+        // Symbol-keyed per level: the MRO entries already ARE symbols, and the
+        // method name is interned once for the whole walk.
+        let name_sym = crate::symbol::Symbol::intern(method_name);
+        let registry = self.registry();
         for cn in mro.iter() {
-            if let Some(is_public) = self.registry().accessor_is_public(cn.as_str(), method_name) {
+            if let Some(is_public) = registry.accessor_is_public_sym(*cn, name_sym) {
                 return is_public;
             }
         }
@@ -315,17 +322,18 @@ impl Interpreter {
         method_name: &str,
     ) -> Option<UserMethodOrAccessor> {
         let mro = self.class_mro(class_name);
+        // The method name is interned once for the whole walk, and each level's
+        // own name is already a `Symbol` -- the `&str` probes below re-interned
+        // both on every MRO level of every dispatch.
+        let name_sym = crate::symbol::Symbol::intern(method_name);
         for cn in mro.iter() {
             let is_ancestor = cn.as_str() != class_name;
             let (has_local_method, has_role_method, has_attr, has_native) = {
                 let registry = self.registry();
                 if let Some(class_def) = registry.classes.get(cn.as_str()) {
-                    let (local, role) = registry.user_method_local_role_presence(
-                        cn.as_str(),
-                        method_name,
-                        is_ancestor,
-                    );
-                    let attr = registry.accessor_is_public(cn.as_str(), method_name) == Some(true);
+                    let (local, role) =
+                        registry.user_method_local_role_presence_sym(*cn, name_sym, is_ancestor);
+                    let attr = registry.accessor_is_public_sym(*cn, name_sym) == Some(true);
                     // A built-in class (e.g. Proc) may register a public attribute
                     // for `.raku`/introspection while a native method of the same
                     // name is the real getter (its computed fallbacks differ from

--- a/src/runtime/end_phasers.rs
+++ b/src/runtime/end_phasers.rs
@@ -166,7 +166,7 @@ impl Interpreter {
             Some('%') => crate::value::Value::hash(std::collections::HashMap::new()),
             // Scalars are stored under their BARE name (no `$`), the same
             // convention `Stmt::VarDecl::name` uses — see `push_lexical`.
-            _ => crate::value::Value::package(Symbol::intern("Any")),
+            _ => crate::value::Value::package(crate::symbol::wk::any()),
         }
     }
 

--- a/src/runtime/json.rs
+++ b/src/runtime/json.rs
@@ -502,9 +502,7 @@ impl<'a> Parser<'a> {
             Some(b'"') => Ok(Value::str(self.parse_string()?)),
             Some(b't') => self.parse_literal("true", Value::TRUE),
             Some(b'f') => self.parse_literal("false", Value::FALSE),
-            Some(b'n') => {
-                self.parse_literal("null", Value::package(crate::symbol::Symbol::intern("Any")))
-            }
+            Some(b'n') => self.parse_literal("null", Value::package(crate::symbol::wk::any())),
             Some(c) if c == b'-' || c.is_ascii_digit() => self.parse_number(),
             Some(c) => Err(format!("Unexpected character in JSON: {}", c as char)),
             None => Err("Unexpected end of JSON".to_string()),

--- a/src/runtime/lock_async_recursion.rs
+++ b/src/runtime/lock_async_recursion.rs
@@ -72,7 +72,7 @@ impl Interpreter {
         // but only after the queue has drained -- rakudo's `LEAVE self.unlock`
         // hands the lock on regardless of how the block ended.
         result?;
-        Ok(Value::package(crate::symbol::Symbol::intern("Any")))
+        Ok(Value::package(crate::symbol::wk::any()))
     }
 
     /// `Lock::Async.with-lock-hidden-from-recursion-check(&code)`: run `&code`

--- a/src/runtime/methods.rs
+++ b/src/runtime/methods.rs
@@ -43,7 +43,7 @@ pub(crate) fn multidim_at_pos(target: &Value, indices: &[Value]) -> Value {
         };
         cur = items.get(i).cloned().unwrap_or_else(|| {
             if is_real_array {
-                Value::package(Symbol::intern("Any"))
+                Value::package(crate::symbol::wk::any())
             } else {
                 Value::NIL
             }
@@ -182,7 +182,7 @@ pub(crate) fn multidim_assign_pos(
             return Err(RuntimeError::assignment_ro(None));
         }
         if i >= updated.len() {
-            updated.resize(i + 1, Value::package(Symbol::intern("Any")));
+            updated.resize(i + 1, Value::package(crate::symbol::wk::any()));
         }
         updated[i] = value;
     } else {
@@ -221,7 +221,7 @@ pub(crate) fn multidim_bind_pos(
     let mut updated = items.to_vec();
     if indices.len() == 1 {
         if i >= updated.len() {
-            updated.resize(i + 1, Value::package(Symbol::intern("Any")));
+            updated.resize(i + 1, Value::package(crate::symbol::wk::any()));
         }
         updated[i] = Value::scalar(value);
     } else {
@@ -270,7 +270,7 @@ pub(crate) fn multidim_delete_pos(
             // `Nil` is no longer a hole sentinel, only `initialized` is
             // (mirrors the single-dimension `.DELETE-POS`,
             // `array_delete_pos_value` in methods_subscript_protocol.rs).
-            let old = std::mem::replace(&mut updated[i], Value::package(Symbol::intern("Any")));
+            let old = std::mem::replace(&mut updated[i], Value::package(crate::symbol::wk::any()));
             deleted = match old.view() {
                 ValueView::Scalar(inner) => inner.clone(),
                 _ => old.clone(),

--- a/src/runtime/methods_call_dispatch.rs
+++ b/src/runtime/methods_call_dispatch.rs
@@ -2334,7 +2334,7 @@ impl Interpreter {
                     let enc = match cn.as_str() {
                         "utf8" => Value::str("utf-8".to_string()),
                         "utf16" => Value::str("utf-16".to_string()),
-                        _ => Value::package(crate::symbol::Symbol::intern("Any")),
+                        _ => Value::package(crate::symbol::wk::any()),
                     };
                     return Ok(enc);
                 }
@@ -2346,7 +2346,7 @@ impl Interpreter {
                     let enc = match cn.as_str() {
                         "utf8" => Value::str("utf-8".to_string()),
                         "utf16" => Value::str("utf-16".to_string()),
-                        _ => Value::package(crate::symbol::Symbol::intern("Any")),
+                        _ => Value::package(crate::symbol::wk::any()),
                     };
                     return Ok(enc);
                 }
@@ -3120,7 +3120,7 @@ impl Interpreter {
                         return Err(RuntimeError::assignment_ro(None));
                     }
                     if index >= updated.len() {
-                        updated.resize(index + 1, Value::package(Symbol::intern("Any")));
+                        updated.resize(index + 1, Value::package(crate::symbol::wk::any()));
                     }
                     updated[index] = value.clone();
                     let replacement = Value::array_with_kind(
@@ -3147,7 +3147,7 @@ impl Interpreter {
                     };
                     let mut updated = items.to_vec();
                     if index >= updated.len() {
-                        updated.resize(index + 1, Value::package(Symbol::intern("Any")));
+                        updated.resize(index + 1, Value::package(crate::symbol::wk::any()));
                     }
                     updated[index] = Value::scalar(value.clone());
                     let replacement = Value::array_with_kind(

--- a/src/runtime/methods_dispatch_new.rs
+++ b/src/runtime/methods_dispatch_new.rs
@@ -357,7 +357,22 @@ impl Interpreter {
         let mut attributes = AttrMap::with_capacity(plan.class_attrs.len());
         let mut deferred_defaults: Vec<super::attr_build_defaults::DeferredAttrDefault> =
             Vec::new();
-        for (attr, &attr_sym) in plan.class_attrs.iter().zip(plan.attr_syms.iter()) {
+        // Resolve every named argument to its declared-attribute index ONCE (a
+        // hash lookup each) instead of re-scanning `class_attrs` linearly per
+        // argument below, and per `@`/`%` attribute in the seed loop.
+        let arg_attr_idx: Vec<Option<u32>> = args
+            .iter()
+            .map(|a| match a.view() {
+                ValueView::Pair(key, _) => plan.attr_index.get(key.as_str()).copied(),
+                _ => None,
+            })
+            .collect();
+        for (i, (attr, &attr_sym)) in plan
+            .class_attrs
+            .iter()
+            .zip(plan.attr_syms.iter())
+            .enumerate()
+        {
             let attr_name = &attr.name;
             let default = &attr.default;
             let sigil = &attr.sigil;
@@ -369,9 +384,7 @@ impl Interpreter {
             // HashData/ArrayData allocation per unfilled construction.
             if default.is_none()
                 && (*sigil == '@' || *sigil == '%')
-                && args
-                    .iter()
-                    .any(|a| matches!(a.view(), ValueView::Pair(k, _) if k == attr_name))
+                && arg_attr_idx.contains(&Some(i as u32))
             {
                 continue;
             }
@@ -430,18 +443,18 @@ impl Interpreter {
                 // A non-native attribute with no default seeds its nominal
                 // type object (`has $!z` reads as Any, `has Int $!x` as Int),
                 // matching raku — not Nil.
-                match plan.type_constraints.get(attr_name).map(String::as_str) {
-                    Some(
-                        "int" | "int8" | "int16" | "int32" | "int64" | "uint" | "uint8" | "uint16"
-                        | "uint32" | "uint64" | "byte" | "atomicint",
-                    ) => Value::int(0),
-                    Some("num" | "num32" | "num64") => Value::num(0.0),
-                    Some("str") => Value::str("".to_string()),
-                    Some(tc) => {
-                        let nominal = self.nominal_type_object_name_for_constraint(tc);
-                        Value::package(crate::symbol::Symbol::intern(&nominal))
-                    }
-                    None => Value::package(crate::symbol::Symbol::intern("Any")),
+                // The seed is pure class shape, precomputed in the plan: this
+                // used to re-run a `type_constraints` lookup, a
+                // `nominal_type_object_name_for_constraint` walk and a
+                // `Symbol::intern` for EVERY unfilled attribute of EVERY bless.
+                match plan.attr_seeds[i] {
+                    super::AttrSeed::NativeInt => Value::int(0),
+                    super::AttrSeed::NativeNum => Value::num(0.0),
+                    super::AttrSeed::NativeStr => Value::str(String::new()),
+                    super::AttrSeed::TypeObject(sym) => Value::package(sym),
+                    // `@`/`%` attributes never reach here (the container arm
+                    // above handles them); seed defensively as raku's `Any`.
+                    super::AttrSeed::Container => Value::package(crate::symbol::wk::any()),
                 }
             };
             if is_deferred {
@@ -460,13 +473,9 @@ impl Interpreter {
         // Override with named args from bless call. A key that names a declared
         // attribute reuses its pre-interned Symbol (the common case — `|%_`
         // passthrough in a user `new`); anything else interns as before.
-        for arg in &args {
+        for (arg, attr_idx) in args.iter().zip(arg_attr_idx.iter()) {
             if let ValueView::Pair(key, value) = arg.view() {
-                match plan
-                    .class_attrs
-                    .iter()
-                    .position(|a| a.name.as_str() == &**key)
-                {
+                match attr_idx.map(|i| i as usize) {
                     Some(i) => {
                         // Sigil-coerce like `dispatch_new` does: a `%`-attribute
                         // provided as a (list of) Pair(s) becomes a Hash, a
@@ -839,7 +848,7 @@ impl Interpreter {
                     let nominal = self.nominal_type_object_name_for_constraint(tc);
                     Value::package(crate::symbol::Symbol::intern(&nominal))
                 }
-                None => Value::package(crate::symbol::Symbol::intern("Any")),
+                None => Value::package(crate::symbol::wk::any()),
             };
             attributes.insert(attr_name, val);
         }

--- a/src/runtime/methods_instance_ops.rs
+++ b/src/runtime/methods_instance_ops.rs
@@ -2892,7 +2892,7 @@ impl Interpreter {
                         return Ok(Value::package(Symbol::intern(&candidate)));
                     }
                 }
-                Ok(Value::package(Symbol::intern("Any")))
+                Ok(Value::package(crate::symbol::wk::any()))
             }
             [expected] => {
                 let expected_type = self.are_expected_type_name(expected);

--- a/src/runtime/methods_io_dispatch.rs
+++ b/src/runtime/methods_io_dispatch.rs
@@ -373,7 +373,7 @@ impl Interpreter {
             return Some(Ok(def));
         }
         if matches!(target.view(), ValueView::Array(..)) {
-            return Some(Ok(Value::package(Symbol::intern("Any"))));
+            return Some(Ok(Value::package(crate::symbol::wk::any())));
         }
         if matches!(target.view(), ValueView::Set(_, _)) {
             return Some(Ok(Value::FALSE));

--- a/src/runtime/methods_mut_dispatch.rs
+++ b/src/runtime/methods_mut_dispatch.rs
@@ -347,7 +347,7 @@ impl Interpreter {
                 // (S02-types/nil.t: `$/.VAR.default === Nil`).
                 Value::NIL
             } else {
-                Value::package(Symbol::intern("Any"))
+                Value::package(crate::symbol::wk::any())
             };
             attributes.insert("default".to_string(), default_val);
             // ADR-0064: the value this container currently holds. The descriptor

--- a/src/runtime/methods_object.rs
+++ b/src/runtime/methods_object.rs
@@ -432,6 +432,49 @@ impl Interpreter {
         } else {
             Vec::new()
         });
+        // Attribute name -> index, and the per-attribute no-initializer seed.
+        // Both are pure class shape that `dispatch_bless` / the native default
+        // constructor otherwise re-derive on every single construction (a
+        // linear name scan per named argument, and a
+        // `nominal_type_object_name_for_constraint` + `Symbol::intern` per
+        // unfilled attribute).
+        let attr_index = std::sync::Arc::new({
+            let mut m: rustc_hash::FxHashMap<Box<str>, u32> =
+                rustc_hash::FxHashMap::with_capacity_and_hasher(
+                    class_attrs.len(),
+                    Default::default(),
+                );
+            // First-wins, matching the `iter().position(..)` scan this replaces:
+            // an MRO can collect two same-named attributes (a child re-declaring
+            // a parent's), and the earlier entry is the one construction used.
+            for (i, a) in class_attrs.iter().enumerate() {
+                m.entry(a.name.as_str().into()).or_insert(i as u32);
+            }
+            m
+        });
+        let attr_seeds = std::sync::Arc::new(
+            class_attrs
+                .iter()
+                .map(|a| {
+                    if a.sigil == '@' || a.sigil == '%' {
+                        return super::AttrSeed::Container;
+                    }
+                    match type_constraints.get(&a.name).map(String::as_str) {
+                        Some(
+                            "int" | "int8" | "int16" | "int32" | "int64" | "uint" | "uint8"
+                            | "uint16" | "uint32" | "uint64" | "byte" | "atomicint",
+                        ) => super::AttrSeed::NativeInt,
+                        Some("num" | "num32" | "num64") => super::AttrSeed::NativeNum,
+                        Some("str") => super::AttrSeed::NativeStr,
+                        Some(tc) => {
+                            let nominal = self.nominal_type_object_name_for_constraint(tc);
+                            super::AttrSeed::TypeObject(crate::symbol::Symbol::intern(&nominal))
+                        }
+                        None => super::AttrSeed::TypeObject(crate::symbol::wk::any()),
+                    }
+                })
+                .collect::<Vec<_>>(),
+        );
         let probe_skeleton = std::sync::Arc::new(
             attr_syms
                 .iter()
@@ -451,6 +494,8 @@ impl Interpreter {
             has_custom_bless,
             has_container_defaults,
             attr_is_types,
+            attr_index,
+            attr_seeds,
             build_steps,
             tweak_steps,
             probe_skeleton,

--- a/src/runtime/methods_object_default_ctor.rs
+++ b/src/runtime/methods_object_default_ctor.rs
@@ -24,8 +24,10 @@ impl Interpreter {
         let class_attrs = &*plan.class_attrs;
         let type_constraints = &*plan.type_constraints;
 
+        // One hash lookup instead of a linear `class_attrs` name scan per
+        // named argument (`NativeCtorPlan::attr_index`).
         let attr_idx_of =
-            |name: &str| -> Option<usize> { class_attrs.iter().position(|a| a.name == name) };
+            |name: &str| -> Option<usize> { plan.attr_index.get(name).map(|&i| i as usize) };
         let sigil_of = |name: &str| -> char {
             attr_idx_of(name)
                 .map(|i| class_attrs[i].sigil)
@@ -248,7 +250,7 @@ impl Interpreter {
                         '%' => Value::hash(HashMap::new()),
                         _ => match type_constraints.get(attr_name) {
                             Some(c) => Self::native_scalar_default(c).unwrap_or(Value::NIL),
-                            None => Value::package(crate::symbol::Symbol::intern("Any")),
+                            None => Value::package(crate::symbol::wk::any()),
                         },
                     };
                     attrs.insert(attr_sym, empty);

--- a/src/runtime/methods_signature_shaped.rs
+++ b/src/runtime/methods_signature_shaped.rs
@@ -105,7 +105,7 @@ impl Interpreter {
         // re-seeds these cells with its element type via
         // coerce_typed_array_elements (the unset-seed arm); the `array[T].new`
         // / `Array[T].new` constructors pass their seed directly.
-        Self::make_shaped_array_seeded(dims, &Value::package(Symbol::intern("Any")))
+        Self::make_shaped_array_seeded(dims, &Value::package(crate::symbol::wk::any()))
     }
 
     /// [`Self::make_shaped_array`] with an explicit unset-cell seed, for a

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -195,7 +195,7 @@ pub(crate) fn flatten_splice_replacement_args(args: &[Value]) -> Vec<Value> {
     out.into_iter()
         .map(|v| {
             if v.is_nil() {
-                Value::package(crate::symbol::Symbol::intern("Any"))
+                Value::package(crate::symbol::wk::any())
             } else {
                 v.itemize_for_element_store()
             }
@@ -1133,6 +1133,23 @@ pub(crate) struct NativeCtorPlan {
     /// `run_construction_phase_steps`), so the per-construction whole-cell
     /// `to_map()` value clone is skipped.
     pub(crate) probe_skeleton: Arc<crate::value::AttrMap>,
+    /// Attribute name -> index into `class_attrs` / `attr_syms` / `attr_seeds`.
+    ///
+    /// `dispatch_bless` used to answer "does this named argument name a
+    /// declared attribute?" with a linear `class_attrs.iter().position(...)`
+    /// string scan PER ARGUMENT — on the `Zef::Distribution` shape that is 7
+    /// args x 21 attributes = ~147 `memcmp`s per construction (`bench-ctor`
+    /// profile: `__memcmp_avx2_movbe` at 1.7%). The map answers it with one
+    /// hash, and the answer is pure class shape.
+    pub(crate) attr_index: Arc<rustc_hash::FxHashMap<Box<str>, u32>>,
+    /// The value a no-initializer attribute seeds with, one per `class_attrs`
+    /// entry. Re-deriving it per construction meant a `type_constraints` hash
+    /// lookup plus — for the overwhelmingly common untyped/class-typed `$`
+    /// attribute — a `nominal_type_object_name_for_constraint` walk and a
+    /// `Symbol::intern` of the resulting type name, on EVERY attribute of
+    /// EVERY construction (16 interns per `bench-ctor` construction, each a
+    /// thread-local + string-hash round trip). It is pure class shape.
+    pub(crate) attr_seeds: Arc<Vec<AttrSeed>>,
     /// Which user-defined whole-object build hook this class's MRO declares —
     /// `Some("BUILDALL")`, `Some("POPULATE")`, or `None` (the overwhelmingly
     /// common case). `run_user_buildall_hook` probed this per construction with
@@ -1140,6 +1157,24 @@ pub(crate) struct NativeCtorPlan {
     /// interning both names; the answer is pure class shape, so it belongs in
     /// the plan next to `has_build`/`has_tweak`/`has_custom_bless`.
     pub(crate) user_buildall: Option<&'static str>,
+}
+
+/// The no-initializer seed of one `$`-sigil attribute, precomputed per class
+/// (see `NativeCtorPlan::attr_seeds`). `@`/`%` attributes seed an empty
+/// container (or an `is Type` one) instead and carry [`AttrSeed::Container`].
+#[derive(Clone, Copy)]
+pub(crate) enum AttrSeed {
+    /// A native integer attribute (`int`, `uint8`, `byte`, `atomicint`, ...).
+    NativeInt,
+    /// A native float attribute (`num`, `num32`, `num64`).
+    NativeNum,
+    /// A native string attribute (`str`).
+    NativeStr,
+    /// A non-native `$` attribute: its nominal type object (`Any` when
+    /// untyped, `Int` for `has Int $.x`, the subset's base for a subset, ...).
+    TypeObject(crate::symbol::Symbol),
+    /// An `@`/`%` attribute — seeded by the container logic, not from here.
+    Container,
 }
 
 /// One pre-derived step of a construction phase (BUILD or TWEAK) — see

--- a/src/runtime/registration_role_decl.rs
+++ b/src/runtime/registration_role_decl.rs
@@ -253,6 +253,13 @@ impl Interpreter {
             .get(name)
             .is_none_or(|existing| existing.is_stub_role || type_params.is_empty())
         {
+            // A role-composed `DESTROY` submethod is dispatched straight off
+            // `RoleDef::methods` (6.e role-submethod DESTROY), never through
+            // the class method table, so it needs its own arming of the
+            // "some user DESTROY exists" latch instance death consults.
+            if role_def.methods.contains_key("DESTROY") {
+                crate::value::note_destroy_method_declared();
+            }
             self.registry_mut().roles.insert(name.to_string(), role_def);
             self.registry_mut()
                 .user_declared_roles

--- a/src/runtime/registry.rs
+++ b/src/runtime/registry.rs
@@ -507,18 +507,35 @@ impl Registry {
             .map(|entry| entry.user_candidates.clone())
     }
 
-    /// Visibility of the auto-generated accessor `method_name` declares
-    /// directly on `class_name`, if any (ADR-0019 D2d). `None` means this
-    /// class does not declare an attribute of that name at all — distinct
-    /// from `Some(false)` (a private attribute, which still occupies the
-    /// name and must not fall through to an ancestor's same-named accessor).
-    pub(crate) fn accessor_is_public(&self, class_name: &str, method_name: &str) -> Option<bool> {
+    /// Visibility of the auto-generated accessor `name` declares directly on
+    /// `owner`, if any (ADR-0019 D2d). `None` means this class does not
+    /// declare an attribute of that name at all — distinct from `Some(false)`
+    /// (a private attribute, which still occupies the name and must not fall
+    /// through to an ancestor's same-named accessor).
+    /// Keyed by already-interned symbols; see
+    /// [`Self::user_method_local_role_presence_sym`] for why the MRO walks
+    /// need this form.
+    pub(crate) fn accessor_is_public_sym(&self, owner: Symbol, name: Symbol) -> Option<bool> {
         self.method_entries
-            .get(&MethodEntryKey {
-                owner: Symbol::intern(class_name),
-                name: Symbol::intern(method_name),
-            })
+            .get(&MethodEntryKey { owner, name })
             .and_then(|entry| entry.accessor)
+    }
+
+    /// Whether `(owner, name)` has any live user candidate, and if so whether
+    /// any of them is public -- `None` when the class does not declare the
+    /// name at all.
+    ///
+    /// The Symbol-keyed, allocation-free twin of
+    /// [`Self::user_method_overloads`] for the presence question. The MRO walk
+    /// in `has_user_method` asked it per level through the `&str` API, which
+    /// re-interned BOTH names per level and then CLONED the whole
+    /// `Vec<MethodDef>` (a ~300-byte struct with Strings, Arcs and Vecs) purely
+    /// to read one boolean off it -- 1.6% of `bench-ctor`.
+    pub(crate) fn user_method_public_presence(&self, owner: Symbol, name: Symbol) -> Option<bool> {
+        self.method_entries
+            .get(&MethodEntryKey { owner, name })
+            .filter(|entry| !entry.user_candidates.is_empty())
+            .map(|entry| entry.user_candidates.iter().any(|d| !d.is_private))
     }
 
     /// Per-level (`has_local_method`, `has_role_method`) presence used by
@@ -528,16 +545,16 @@ impl Registry {
     /// in a composed role. A table probe against `method_entries` instead of
     /// `class_def.methods.get(...)` plus a `Vec<MethodDef>` clone — same data,
     /// no allocation, since only the two booleans are needed here.
-    pub(crate) fn user_method_local_role_presence(
+    /// Keyed by already-interned symbols -- the form the MRO walks want, since
+    /// their level names are `Symbol`s already and re-interning them per level
+    /// is pure overhead.
+    pub(crate) fn user_method_local_role_presence_sym(
         &self,
-        class_name: &str,
-        method_name: &str,
+        owner: Symbol,
+        name: Symbol,
         is_ancestor: bool,
     ) -> (bool, bool) {
-        let Some(entry) = self.method_entries.get(&MethodEntryKey {
-            owner: Symbol::intern(class_name),
-            name: Symbol::intern(method_name),
-        }) else {
+        let Some(entry) = self.method_entries.get(&MethodEntryKey { owner, name }) else {
             return (false, false);
         };
         let (mut local, mut role) = (false, false);

--- a/src/runtime/registry_method_table.rs
+++ b/src/runtime/registry_method_table.rs
@@ -241,6 +241,15 @@ impl Registry {
     /// currently non-empty). Internal -- every mutator below calls this
     /// after touching `user_candidates`, never the raw field.
     fn reindex_user_method_name(&mut self, owner: Symbol, name: Symbol, live: bool) {
+        // Arm the process-global "some user DESTROY exists" latch. Instance
+        // death skips the whole queue-and-MRO-walk dance while it reads false
+        // (`crate::value::any_destroy_method_declared`), so every path that can
+        // register a class-side `DESTROY` -- a class body, `augment`,
+        // `.^add_method` -- has to pass through here. They all do: this is the
+        // single reverse-index hook every `user_candidates` mutator calls.
+        if live && name.with_str(|n| n == "DESTROY") {
+            crate::value::note_destroy_method_declared();
+        }
         if live {
             let names = self.owner_method_names.entry(owner).or_default();
             if !names.contains(&name) {

--- a/src/runtime/types/mod.rs
+++ b/src/runtime/types/mod.rs
@@ -425,7 +425,7 @@ impl Interpreter {
         if self.is_readonly(name) {
             return true;
         }
-        crate::env::closure_meta_keys_possible()
+        crate::env::sigilless_readonly_keys_possible()
             && matches!(
                 self.env()
                     .get(&crate::runtime::utils::sigilless_readonly_key(name))
@@ -685,7 +685,7 @@ impl Interpreter {
             ValueView::Package(name) => Value::package(name),
             ValueView::ParametricRole { .. } => value.clone(),
             ValueView::Instance { class_name, .. } => Value::package(class_name),
-            ValueView::Nil => Value::package(Symbol::intern("Any")),
+            ValueView::Nil => Value::package(crate::symbol::wk::any()),
             _ => Value::package(Symbol::intern(super::value_type_name(value))),
         }
     }

--- a/src/runtime/types/roles.rs
+++ b/src/runtime/types/roles.rs
@@ -829,7 +829,7 @@ impl Interpreter {
                     match sigil {
                         '@' => Value::real_array(Vec::new()),
                         '%' => Value::hash_with_data(Value::hash_arc(HashMap::new())),
-                        _ => Value::package(crate::symbol::Symbol::intern("Any")),
+                        _ => Value::package(crate::symbol::wk::any()),
                     }
                 };
                 mixins.insert(format!("__mutsu_attr__{}", attr_name), value);

--- a/src/runtime/utils/coerce_containers.rs
+++ b/src/runtime/utils/coerce_containers.rs
@@ -20,7 +20,7 @@ pub(crate) fn hash_pair_keys(key: &Value) -> Vec<Value> {
 /// divergence unrelated to this ADR).
 fn decay_nil_hash_value(v: Value) -> Value {
     if v.is_nil() {
-        Value::package(crate::symbol::Symbol::intern("Any"))
+        Value::package(crate::symbol::wk::any())
     } else {
         v
     }
@@ -161,7 +161,7 @@ pub(crate) fn coerce_to_hash(value: Value) -> Value {
                     let val = if i + 1 < flat.len() {
                         flat[i + 1].clone()
                     } else {
-                        Value::package(crate::symbol::Symbol::intern("Any"))
+                        Value::package(crate::symbol::wk::any())
                     };
                     map.insert(str_key, val.itemize_for_element_store());
                     i += 2;
@@ -200,7 +200,7 @@ pub(crate) fn coerce_to_hash(value: Value) -> Value {
                     let val = if i + 1 < items.len() {
                         items[i + 1].clone()
                     } else {
-                        Value::package(crate::symbol::Symbol::intern("Any"))
+                        Value::package(crate::symbol::wk::any())
                     };
                     map.insert(str_key, val.itemize_for_element_store());
                     i += 2;
@@ -331,7 +331,7 @@ pub(crate) fn coerce_to_hash(value: Value) -> Value {
             let mut map = HashMap::new();
             map.insert(
                 value.to_string_value(),
-                Value::package(crate::symbol::Symbol::intern("Any")),
+                Value::package(crate::symbol::wk::any()),
             );
             Value::hash(map)
         }
@@ -504,9 +504,7 @@ fn coerce_to_array_inner(value: Value) -> Value {
                 Value::array_with_kind(items, ArrayKind::Array)
             }
         }
-        ValueView::Nil => {
-            Value::real_array(vec![Value::package(crate::symbol::Symbol::intern("Any"))])
-        }
+        ValueView::Nil => Value::real_array(vec![Value::package(crate::symbol::wk::any())]),
         ValueView::Range(a, b) => {
             if b == i64::MAX {
                 // Infinite range — mark as lazy, capped to

--- a/src/runtime/utils/type_misc.rs
+++ b/src/runtime/utils/type_misc.rs
@@ -287,7 +287,7 @@ pub(crate) fn reduction_identity_opt(op: &str) -> Option<Value> {
         "&&" | "and" | "?&" => Value::TRUE,
         "||" | "or" | "?|" | "^^" => Value::FALSE,
         "?^" => Value::FALSE,
-        "//" => Value::package(Symbol::intern("Any")),
+        "//" => Value::package(crate::symbol::wk::any()),
         "orelse" => Value::NIL,
         "andthen" | "notandthen" => Value::TRUE,
         "xor" => Value::FALSE,

--- a/src/value/entry_path.rs
+++ b/src/value/entry_path.rs
@@ -279,7 +279,7 @@ impl EntryTerminal {
     /// what the eventual write leaves behind.
     pub(crate) fn unwritten_read(&self) -> Value {
         match self {
-            EntryTerminal::Hash(..) => Value::Package(crate::symbol::Symbol::intern("Any")),
+            EntryTerminal::Hash(..) => Value::Package(crate::symbol::wk::any()),
             // SAFETY: a shared read of the aliased container, mirroring `peek`.
             // The clone ends the borrow before any caller can mutate through
             // `gc_contents_mut`.

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -1,7 +1,7 @@
 use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
 use std::ops::{Deref, DerefMut};
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, Condvar, Mutex, OnceLock, RwLock};
 
 use crate::ast::{ParamDef, Stmt};
@@ -323,6 +323,32 @@ thread_local! {
     static IN_DESTROY_HANDLER: RefCell<bool> = const { RefCell::new(false) };
 }
 
+/// Whether the program has EVER registered a user `DESTROY` submethod (on a
+/// class or in a role). Monotonic and process-global: registration only ever
+/// adds one, so a `false` reading means no `DESTROY` exists anywhere, and the
+/// whole queue-and-walk dance around instance death is provably a no-op.
+///
+/// Without this every user instance death cloned its entire attribute map into
+/// a pending queue, and `run_pending_instance_destroys` then walked the MRO
+/// looking for a `DESTROY` that cannot exist -- two `Symbol::intern`s per MRO
+/// level, per dead instance. On `bench-ctor` (a 21-attribute class) that was
+/// ~8 interns plus a 21-entry map clone per construction, all discarded.
+/// Read at DROP time, not at construction, so a `DESTROY` added later (an
+/// `.^add_method`, an `EVAL`ed class) still fires for everything that dies
+/// after it is registered.
+static ANY_DESTROY_DECLARED: AtomicBool = AtomicBool::new(false);
+
+/// Record that a user `DESTROY` submethod now exists (see
+/// [`ANY_DESTROY_DECLARED`]). Idempotent; never cleared.
+pub(crate) fn note_destroy_method_declared() {
+    ANY_DESTROY_DECLARED.store(true, Ordering::Release);
+}
+
+/// Whether any user `DESTROY` submethod has been registered.
+pub(crate) fn any_destroy_method_declared() -> bool {
+    ANY_DESTROY_DECLARED.load(Ordering::Acquire)
+}
+
 /// Set the in-destroy-handler flag to suppress recursive DESTROY queuing.
 pub(crate) fn set_in_destroy_handler(value: bool) {
     IN_DESTROY_HANDLER.with(|flag| *flag.borrow_mut() = value);
@@ -376,6 +402,32 @@ thread_local! {
 /// A deferred cell write: `(cell address, cell, new map)`. See
 /// [`PENDING_CELL_WRITES`].
 type PendingCellWrite = (usize, AttrCell, AttrMap);
+
+/// How many deferred cell writes exist across all threads. Deferral is a rare
+/// self-deadlock escape hatch, but EVERY [`AttrReadGuard`] drop had to consult
+/// the (per-thread) queue to find out -- a second thread-local access plus a
+/// `RefCell` borrow and a `Vec::retain` per attribute read, ~40 reads per
+/// `bench-ctor` construction. A relaxed load of this counter answers "nothing
+/// is deferred anywhere" in a couple of instructions. Global rather than
+/// per-thread on purpose: over-reporting (another thread has a deferral) only
+/// makes this thread run the correct, and empty, scan.
+static PENDING_CELL_WRITE_COUNT: AtomicUsize = AtomicUsize::new(0);
+
+/// Whether any deferred cell write may exist; see [`PENDING_CELL_WRITE_COUNT`].
+pub(super) fn pending_cell_writes_possible() -> bool {
+    PENDING_CELL_WRITE_COUNT.load(Ordering::Relaxed) > 0
+}
+
+/// Record that a deferred cell write was queued / drained.
+pub(super) fn note_pending_cell_write_pushed() {
+    PENDING_CELL_WRITE_COUNT.fetch_add(1, Ordering::Relaxed);
+}
+
+pub(super) fn note_pending_cell_writes_drained(n: usize) {
+    if n > 0 {
+        PENDING_CELL_WRITE_COUNT.fetch_sub(n, Ordering::Relaxed);
+    }
+}
 
 fn cell_addr(cell: &RwLock<AttrMap>) -> usize {
     cell as *const RwLock<AttrMap> as usize
@@ -640,6 +692,7 @@ fn write_cell_respecting_reads(cell: &AttrCell, map: AttrMap) {
     let addr = cell_addr(cell);
     if HELD_READ_CELLS.with(|c| c.borrow().contains(&addr)) {
         PENDING_CELL_WRITES.with(|p| p.borrow_mut().push((addr, cell.clone(), map)));
+        note_pending_cell_write_pushed();
         return;
     }
     *write_attrs(cell) = map;

--- a/src/value/signature.rs
+++ b/src/value/signature.rs
@@ -528,7 +528,7 @@ fn build_parameter_attrs(p: &SigParam, interp: Option<&Interpreter>) -> HashMap<
         Some(t) if t.starts_with("::") => {
             // Type capture like ::T — type is Any, capture name is T
             type_captures.push(Value::str(t[2..].to_string()));
-            Value::Package(Symbol::intern("Any"))
+            Value::Package(crate::symbol::wk::any())
         }
         // `Int @x` / `Int %h` constrain the *element* type; the parameter's
         // own type is the parameterized container role.

--- a/src/value/value_instance.rs
+++ b/src/value/value_instance.rs
@@ -32,6 +32,11 @@ impl Drop for AttrReadGuard<'_> {
         if still_held {
             return;
         }
+        // Deferred writes are a rare self-deadlock escape hatch; the counter
+        // answers "none anywhere" without a second thread-local round trip.
+        if !super::pending_cell_writes_possible() {
+            return;
+        }
         let flush = PENDING_CELL_WRITES.with(|p| {
             let mut v = p.borrow_mut();
             let mut mine: Vec<(AttrCell, AttrMap)> = Vec::new();
@@ -45,6 +50,7 @@ impl Drop for AttrReadGuard<'_> {
             });
             mine
         });
+        super::note_pending_cell_writes_drained(flush.len());
         for (cell, map) in flush {
             *write_attrs(&cell) = map;
         }
@@ -377,6 +383,14 @@ impl InstanceAttrs {
             true
         };
         if !should_queue {
+            return;
+        }
+        // Nothing in this program declares a user `DESTROY`, so the queued item
+        // could only be walked and thrown away. Checked AFTER the refcount
+        // bookkeeping above (skipping that would leak `live_instance_refcounts`
+        // entries) and at DROP time, so a `DESTROY` registered later still
+        // fires for every instance that dies after it.
+        if !super::any_destroy_method_declared() {
             return;
         }
         let _ = PENDING_INSTANCE_DESTROYS.try_with(|pending| {

--- a/src/value/value_methods_a.rs
+++ b/src/value/value_methods_a.rs
@@ -895,7 +895,7 @@ impl Value {
         // container kind their step addresses) has no terminal yet — the
         // deferred bind reads as `Any` without creating anything.
         let Some(terminal) = self.hash_entry_locate() else {
-            return Value::Package(crate::symbol::Symbol::intern("Any"));
+            return Value::Package(crate::symbol::wk::any());
         };
         // An unconnected slot reads as what an unwritten slot of that container
         // holds: `Any` for a hash entry, the element hole (`Int`, an

--- a/src/vm/vm_call_method_mut_ops.rs
+++ b/src/vm/vm_call_method_mut_ops.rs
@@ -1514,7 +1514,7 @@ impl Interpreter {
             // A single failed match yields the `Any` type object (matching `$/`
             // after a failed `s///`), where `.match` alone would yield `Nil`.
             let ret = if !global && match_result.is_nil() {
-                Value::package(crate::symbol::Symbol::intern("Any"))
+                Value::package(crate::symbol::wk::any())
             } else {
                 match_result
             };
@@ -2315,7 +2315,7 @@ impl Interpreter {
                     };
                     let mut updated = items.to_vec();
                     if i >= updated.len() {
-                        updated.resize(i + 1, Value::package(Symbol::intern("Any")));
+                        updated.resize(i + 1, Value::package(crate::symbol::wk::any()));
                     }
                     updated[i] = Value::container_ref(cell);
                     let new_array = Value::array_with_kind(

--- a/src/vm/vm_closure_dispatch.rs
+++ b/src/vm/vm_closure_dispatch.rs
@@ -795,7 +795,7 @@ impl Interpreter {
         {
             self.env_mut().insert_sym(
                 crate::symbol::Symbol::intern("_"),
-                Value::package(crate::symbol::Symbol::intern("Any")),
+                Value::package(crate::symbol::wk::any()),
             );
             // ...and that fresh `$_` is WRITABLE, whatever the caller's topic
             // was. `readonly_vars` is keyed by bare name, so a construct that

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -506,12 +506,12 @@ impl Interpreter {
                             // S02-types/nil.t 39). Only the not-found fallback:
                             // a topic explicitly set to Nil (e.g. `Xorelse`
                             // topicalizing a Nil operand) must stay Nil.
-                            Ok(Value::package(Symbol::intern("Any")))
+                            Ok(Value::package(crate::symbol::wk::any()))
                         } else if name.starts_with("__ANON_STATE_") {
                             // An anonymous scalar (`$`) is a declared but
                             // uninitialized scalar: it reads as the Any type
                             // object, like `my $x` (S03-operators/context.t).
-                            Ok(Value::package(Symbol::intern("Any")))
+                            Ok(Value::package(crate::symbol::wk::any()))
                         } else if self.strict_mode && !Self::strict_read_exempt(name) {
                             // Read-side counterpart of the `SetGlobal` write
                             // check above: a plain scalar name that resolved
@@ -5583,7 +5583,7 @@ impl Interpreter {
                 // `:=` binding (e.g. binding to a readonly sub parameter
                 // in a closure).  The readonly_vars set is scope-local
                 // and gets restored on frame pop, but the env key persists.
-                if crate::env::closure_meta_keys_possible() {
+                if crate::env::sigilless_readonly_keys_possible() {
                     let readonly_key = format!("__mutsu_sigilless_readonly::{}", name);
                     if matches!(
                         self.env().get(&readonly_key).map(Value::view),
@@ -5651,7 +5651,7 @@ impl Interpreter {
                         // never carries this marker.
                         Some((name, _, _)) => {
                             return !name.with_str(|s| {
-                                crate::env::closure_meta_keys_possible()
+                                crate::env::sigilless_readonly_keys_possible()
                                     && matches!(
                                         self.env()
                                             .get(&crate::runtime::sigilless_readonly_key(s))

--- a/src/vm/vm_hyper_method_ops.rs
+++ b/src/vm/vm_hyper_method_ops.rs
@@ -735,7 +735,7 @@ impl Interpreter {
                                 "hypermethodcall",
                                 "native",
                             );
-                            native_result.unwrap_or(Value::package(Symbol::intern("Any")))
+                            native_result.unwrap_or(Value::package(crate::symbol::wk::any()))
                         } else {
                             crate::vm::vm_stats::record_dispatch_entry_outcome(
                                 "hypermethodcall",
@@ -748,7 +748,7 @@ impl Interpreter {
                                     *item = updated;
                                     v
                                 }
-                                Err(_) => Value::package(Symbol::intern("Any")),
+                                Err(_) => Value::package(crate::symbol::wk::any()),
                             }
                         }
                     } else {
@@ -761,7 +761,7 @@ impl Interpreter {
                                 *item = updated;
                                 v
                             }
-                            Err(_) => Value::package(Symbol::intern("Any")),
+                            Err(_) => Value::package(crate::symbol::wk::any()),
                         }
                     };
                     results.push(val);
@@ -1267,7 +1267,7 @@ impl Interpreter {
                 match modifier {
                     Some("?") => Ok(self
                         .vm_call_on_value(callable.clone(), call_args, None)
-                        .unwrap_or_else(|_| Value::package(Symbol::intern("Any")))),
+                        .unwrap_or_else(|_| Value::package(crate::symbol::wk::any()))),
                     Some("+") => {
                         let val = self.vm_call_on_value(callable.clone(), call_args, None)?;
                         Ok(Value::array(vec![val]))
@@ -1376,7 +1376,7 @@ impl Interpreter {
                     let val = match modifier {
                         Some("?") => self
                             .vm_call_on_value(name_val.clone(), call_args, None)
-                            .unwrap_or_else(|_| Value::package(Symbol::intern("Any"))),
+                            .unwrap_or_else(|_| Value::package(crate::symbol::wk::any())),
                         Some("+") => Value::array(vec![self.vm_call_on_value(
                             name_val.clone(),
                             call_args,
@@ -1413,7 +1413,7 @@ impl Interpreter {
                             "hypermethodcalldynamic",
                             "native",
                         );
-                        native_result.unwrap_or(Value::package(Symbol::intern("Any")))
+                        native_result.unwrap_or(Value::package(crate::symbol::wk::any()))
                     } else {
                         crate::vm::vm_stats::record_dispatch_entry_outcome(
                             "hypermethodcalldynamic",
@@ -1424,7 +1424,7 @@ impl Interpreter {
                                 *item = updated;
                                 v
                             }
-                            Err(_) => Value::package(Symbol::intern("Any")),
+                            Err(_) => Value::package(crate::symbol::wk::any()),
                         }
                     };
                     results.push(val);

--- a/src/vm/vm_method_dispatch.rs
+++ b/src/vm/vm_method_dispatch.rs
@@ -383,18 +383,20 @@ impl Interpreter {
                 .cloned()
         };
 
-        // Set ::?CLASS / ::?ROLE
-        self.env_mut().insert(
-            "?CLASS".to_string(),
-            Value::package(crate::symbol::Symbol::intern(owner_class)),
-        );
+        // Set ::?CLASS / ::?ROLE. Symbol-keyed via the well-known accessors
+        // (as the fast path already does): a `String` allocation plus a
+        // re-intern of two fixed key names on every method call otherwise.
+        // `owner_sym` is reused by the routine frame push below.
+        let owner_sym = crate::symbol::Symbol::intern(owner_class);
+        self.env_mut()
+            .insert_sym(crate::symbol::wk::class_decl(), Value::package(owner_sym));
         if let Some(role_name) = role_context {
-            self.env_mut().insert(
-                "?ROLE".to_string(),
+            self.env_mut().insert_sym(
+                crate::symbol::wk::role_decl(),
                 Value::package(crate::symbol::Symbol::intern(&role_name)),
             );
         } else {
-            self.env_mut().remove("?ROLE");
+            self.env_mut().remove_sym(crate::symbol::wk::role_decl());
         }
 
         // Set current_package so class-scoped subs are found during method execution.
@@ -804,7 +806,7 @@ impl Interpreter {
 
         // Push routine_stack so &?ROUTINE can find the current method
         self.push_method_routine_with_location(
-            Symbol::intern(owner_class),
+            owner_sym,
             Symbol::intern(&method_def.lexical_package),
             Symbol::intern(method_name),
             self.current_source_line(),
@@ -1641,8 +1643,11 @@ impl Interpreter {
                     // type object). The slow path records this via its exit
                     // attr-local sync through `write_attr_cell_by_key`; the
                     // fast path records it here. No-op outside BUILD.
-                    self.record_build_attr_write(cell, crate::symbol::Symbol::intern(attr_name));
-                    cell.insert(attr_name.to_string(), val.clone());
+                    // One intern for both uses: the symbol-keyed insert also
+                    // saves the `String` allocation the name-keyed one paid.
+                    let attr_sym = crate::symbol::Symbol::intern(attr_name);
+                    self.record_build_attr_write(cell, attr_sym);
+                    cell.insert(attr_sym, val.clone());
                 }
                 param_values.push((param_name, val));
                 continue;
@@ -1695,10 +1700,13 @@ impl Interpreter {
 
         crate::alloc_scope_end!(_sc_bind);
         crate::alloc_scope_named!(_sc_env, "mfast:env-setup");
-        // Build class value for ?CLASS
-        let class_val = Value::package(crate::symbol::Symbol::intern(owner_class));
+        // Build class value for ?CLASS. Interned once and reused by the routine
+        // frame push at the bottom — re-interning a name is a thread-local
+        // string-hash round trip, not free.
+        let owner_sym = crate::symbol::Symbol::intern(owner_class);
+        let class_val = Value::package(owner_sym);
         let method_callable_id = crate::value::next_instance_id();
-        let any_val = Value::package(crate::symbol::Symbol::intern("Any"));
+        let any_val = Value::package(crate::symbol::wk::any());
 
         // For can_skip_merge methods with no closures, reduce env inserts.
         // Only insert ?CLASS/?ROLE (used by ::?CLASS/::?ROLE resolution and
@@ -1928,7 +1936,7 @@ impl Interpreter {
         crate::alloc_scope_end!(_sc_loc);
         crate::alloc_scope_named!(_sc_body, "mfast:body");
         self.push_method_routine_with_location(
-            Symbol::intern(owner_class),
+            owner_sym,
             Symbol::intern(&method_def.lexical_package),
             Symbol::intern(method_name),
             self.current_source_line(),

--- a/src/vm/vm_misc_codevar.rs
+++ b/src/vm/vm_misc_codevar.rs
@@ -129,7 +129,7 @@ impl Interpreter {
         // in `A`'s `&`-symbols). Unqualified `&name` keeps returning Nil — custom
         // `EXPORT` routines probe it that way.
         if val.is_nil() && name.contains("::") {
-            val = Value::package(crate::symbol::Symbol::intern("Any"));
+            val = Value::package(crate::symbol::wk::any());
         }
         self.stack.push(val);
         Ok(())

--- a/src/vm/vm_run_loop.rs
+++ b/src/vm/vm_run_loop.rs
@@ -1116,7 +1116,7 @@ impl Interpreter {
             {
                 return Value::package(crate::symbol::Symbol::intern(&tc));
             }
-            Value::package(crate::symbol::Symbol::intern("Any"))
+            Value::package(crate::symbol::wk::any())
         } else {
             val
         }

--- a/src/vm/vm_try_catch_ops.rs
+++ b/src/vm/vm_try_catch_ops.rs
@@ -212,7 +212,7 @@ impl Interpreter {
                 }
                 self.env_mut().insert(
                     "!".to_string(),
-                    failure_exception.unwrap_or_else(|| Value::package(Symbol::intern("Any"))),
+                    failure_exception.unwrap_or_else(|| Value::package(crate::symbol::wk::any())),
                 );
                 *ip = end;
                 Ok(())

--- a/src/vm/vm_var_assign_coerce.rs
+++ b/src/vm/vm_var_assign_coerce.rs
@@ -593,7 +593,7 @@ impl Interpreter {
     pub(crate) fn slice_pad_value(&mut self, var_name: &str) -> Value {
         match loan_env!(self, var_type_constraint(var_name)) {
             Some(constraint) => self.typed_scalar_nil_seed_value(var_name, &constraint),
-            None => Value::package(crate::symbol::Symbol::intern("Any")),
+            None => Value::package(crate::symbol::wk::any()),
         }
     }
 

--- a/src/vm/vm_var_assign_index_named.rs
+++ b/src/vm/vm_var_assign_index_named.rs
@@ -2472,7 +2472,7 @@ impl Interpreter {
                                         Self::autoviv_resize(
                                             arr,
                                             max_idx + 1,
-                                            Value::package(Symbol::intern("Any")),
+                                            Value::package(crate::symbol::wk::any()),
                                         )?;
                                     }
                                     Ok(())
@@ -2686,7 +2686,7 @@ impl Interpreter {
                             || (is_positional && !var_name.starts_with('%')))
                             && let Some(i) = Self::index_to_usize(&idx)
                         {
-                            let mut arr = vec![Value::package(Symbol::intern("Any")); i + 1];
+                            let mut arr = vec![Value::package(crate::symbol::wk::any()); i + 1];
                             // ADR-0040 slice 1: itemize the stored value.
                             arr[i] = Self::itemize_value(val.clone());
                             *container = Value::real_array_initialized_at(arr, i);
@@ -2707,7 +2707,7 @@ impl Interpreter {
                     if (var_name.starts_with('@') || (is_positional && !var_name.starts_with('%')))
                         && let Some(i) = Self::index_to_usize(&idx)
                     {
-                        let mut arr = vec![Value::package(Symbol::intern("Any")); i + 1];
+                        let mut arr = vec![Value::package(crate::symbol::wk::any()); i + 1];
                         // ADR-0040 slice 1: itemize the stored value.
                         arr[i] = Self::itemize_value(val.clone());
                         self.env_mut()
@@ -3608,7 +3608,7 @@ impl Interpreter {
                 // Autovivified gaps fill with the `Any` type object (matching
                 // a direct `@a[i] = v`), not `Nil`. A nested hash/array element
                 // container is untyped here, so `Any` is the correct hole.
-                let fill = Value::package(crate::symbol::Symbol::intern("Any"));
+                let fill = Value::package(crate::symbol::wk::any());
                 // Container identity (§3): write through a shared node.
                 let a = crate::value::gc_data_mut(arr);
                 Self::autoviv_resize_tracking(a, i, fill)?;
@@ -4112,7 +4112,7 @@ impl Interpreter {
                                     Self::autoviv_resize_tracking(
                                         arr,
                                         i,
-                                        Value::package(Symbol::intern("Any")),
+                                        Value::package(crate::symbol::wk::any()),
                                     )?;
                                     arr[i] = Self::fresh_autoviv_container(next_positional);
                                     Ok(&mut arr[i] as *mut Value)
@@ -4443,11 +4443,7 @@ impl Interpreter {
                     // change is visible to all holders of the same Arc; see
                     // `gc_contents_mut`.
                     let v = unsafe { crate::value::gc_contents_mut(&arc) }.items_mut();
-                    Self::autoviv_resize(
-                        v,
-                        i + 1,
-                        Value::package(crate::symbol::Symbol::intern("Any")),
-                    )?;
+                    Self::autoviv_resize(v, i + 1, Value::package(crate::symbol::wk::any()))?;
                     match &bind_cell {
                         // Bind mode installs the shared cell at the element;
                         // the same cell is written back to the source var
@@ -4589,10 +4585,9 @@ impl Interpreter {
                             ),
                         };
                         if i >= items.items().len() {
-                            items.items_mut().resize(
-                                i + 1,
-                                Value::package(crate::symbol::Symbol::intern("Any")),
-                            );
+                            items
+                                .items_mut()
+                                .resize(i + 1, Value::package(crate::symbol::wk::any()));
                         }
                         match &bind_cell {
                             Some((_, cell)) => {

--- a/src/vm/vm_var_assign_local.rs
+++ b/src/vm/vm_var_assign_local.rs
@@ -138,7 +138,7 @@ impl Interpreter {
                 let v = rhs_vals
                     .get(i)
                     .cloned()
-                    .unwrap_or_else(|| Value::package(Symbol::intern("Any")));
+                    .unwrap_or_else(|| Value::package(crate::symbol::wk::any()));
                 if let ValueView::ContainerRef(cell) = cell_val.view() {
                     Value::store_through_cell(&cell, &v);
                 } else if matches!(cell_val.view(), ValueView::HashEntryRef { .. }) {

--- a/src/vm/vm_var_assign_nil_decay.rs
+++ b/src/vm/vm_var_assign_nil_decay.rs
@@ -34,7 +34,7 @@ impl Interpreter {
                 return def;
             }
             return if info.value_type.is_empty() {
-                Value::package(Symbol::intern("Any"))
+                Value::package(crate::symbol::wk::any())
             } else {
                 Value::package(Symbol::intern(&info.value_type))
             };

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -26,12 +26,12 @@ impl Interpreter {
                     .trim_end_matches(":D")
                     .trim_end_matches(":U");
                 if base.is_empty() || base == "Any" || base == "Mu" || base.contains('[') {
-                    Value::package(Symbol::intern("Any"))
+                    Value::package(crate::symbol::wk::any())
                 } else {
                     Value::package(Symbol::intern(base))
                 }
             }
-            None => Value::package(Symbol::intern("Any")),
+            None => Value::package(crate::symbol::wk::any()),
         }
     }
 
@@ -221,7 +221,7 @@ impl Interpreter {
                         Self::autoviv_resize(
                             &mut updated,
                             max_idx + 1,
-                            Value::package(Symbol::intern("Any")),
+                            Value::package(crate::symbol::wk::any()),
                         )?;
                     }
                     for (offset, i) in slice_indices.iter().enumerate() {
@@ -231,7 +231,7 @@ impl Interpreter {
                     Self::autoviv_resize(
                         &mut updated,
                         i + 1,
-                        Value::package(Symbol::intern("Any")),
+                        Value::package(crate::symbol::wk::any()),
                     )?;
                     updated[i] = val.clone();
                 } else {
@@ -253,7 +253,7 @@ impl Interpreter {
                         Self::autoviv_resize(
                             &mut updated,
                             max_idx + 1,
-                            Value::package(Symbol::intern("Any")),
+                            Value::package(crate::symbol::wk::any()),
                         )?;
                     }
                     for (offset, i) in slice_indices.iter().enumerate() {
@@ -263,7 +263,7 @@ impl Interpreter {
                     Self::autoviv_resize(
                         &mut updated,
                         i + 1,
-                        Value::package(Symbol::intern("Any")),
+                        Value::package(crate::symbol::wk::any()),
                     )?;
                     updated[i] = val.clone();
                 } else {
@@ -340,7 +340,7 @@ impl Interpreter {
                 };
                 if let Some(res) = container.with_array_mut(|items, _| {
                     let arr = crate::value::gc_data_mut(items);
-                    Self::autoviv_resize(arr, i + 1, Value::package(Symbol::intern("Any")))?;
+                    Self::autoviv_resize(arr, i + 1, Value::package(crate::symbol::wk::any()))?;
                     arr[i] = value.take().unwrap_or(Value::NIL);
                     Ok(())
                 }) {
@@ -370,7 +370,7 @@ impl Interpreter {
             };
             let Some(res) = container.with_array_mut(|items, _| {
                 let arr = crate::value::gc_data_mut(items);
-                Self::autoviv_resize(arr, i + 1, Value::package(Symbol::intern("Any")))?;
+                Self::autoviv_resize(arr, i + 1, Value::package(crate::symbol::wk::any()))?;
                 arr[i] = value;
                 Ok(())
             }) else {

--- a/src/vm/vm_var_assign_set_local.rs
+++ b/src/vm/vm_var_assign_set_local.rs
@@ -134,7 +134,7 @@ impl Interpreter {
             let v = rhs_vals
                 .get(i)
                 .cloned()
-                .unwrap_or_else(|| Value::package(crate::symbol::Symbol::intern("Any")));
+                .unwrap_or_else(|| Value::package(crate::symbol::wk::any()));
             if let ValueView::ContainerRef(cell) = cell_val.view() {
                 Value::store_through_cell(&cell, &v);
             } else if matches!(cell_val.view(), ValueView::HashEntryRef { .. }) {
@@ -709,7 +709,7 @@ impl Interpreter {
             // scope (e.g. a for-loop `\result` shouldn't block `my $result`
             // in a called sub). Same latch: the `__mutsu_sigilless_readonly::*`
             // key only exists once the program creates a sigilless/`:=` alias.
-            if crate::env::closure_meta_keys_possible()
+            if crate::env::sigilless_readonly_keys_possible()
                 && let Some(sym) = code.readonly_sym(idx)
             {
                 self.env_mut().remove_sym(sym);
@@ -893,13 +893,13 @@ impl Interpreter {
                     let v = rhs_vals
                         .get(i)
                         .cloned()
-                        .unwrap_or_else(|| Value::package(Symbol::intern("Any")));
+                        .unwrap_or_else(|| Value::package(crate::symbol::wk::any()));
                     Value::store_through_cell(&cell, &v);
                 } else if matches!(cell_val.view(), ValueView::HashEntryRef { .. }) {
                     let v = rhs_vals
                         .get(i)
                         .cloned()
-                        .unwrap_or_else(|| Value::package(Symbol::intern("Any")));
+                        .unwrap_or_else(|| Value::package(crate::symbol::wk::any()));
                     let cell =
                         crate::gc::Gc::new(crate::value::ContainerCell::new(cell_val.clone()));
                     Value::store_through_cell(&cell, &v);
@@ -1585,7 +1585,7 @@ impl Interpreter {
         // outright when no `__mutsu_sigilless_*` key has ever been created, so a
         // program with no sigilless/`:=` binding pays no `format!` per store.
         if !is_vardecl
-            && crate::env::closure_meta_keys_possible()
+            && crate::env::sigilless_readonly_keys_possible()
             && let Some(readonly_sym) = code.readonly_sym(idx)
             && let Some(alias_sym) = code.alias_sym(idx)
             && matches!(
@@ -2645,7 +2645,7 @@ impl Interpreter {
             } else if name.starts_with('%') {
                 Value::hash(std::collections::HashMap::new())
             } else {
-                Value::package(crate::symbol::Symbol::intern("Any"))
+                Value::package(crate::symbol::wk::any())
             };
             crate::env::note_env_key(name);
             self.env_mut().insert_sym(name_sym, default);

--- a/src/vm/vm_var_delete_ops.rs
+++ b/src/vm/vm_var_delete_ops.rs
@@ -162,7 +162,7 @@ impl Interpreter {
                 // fast path, so the hole type is always Any here).
                 let removed = removed
                     .or(container_default)
-                    .unwrap_or_else(|| Value::package(crate::symbol::Symbol::intern("Any")));
+                    .unwrap_or_else(|| Value::package(crate::symbol::wk::any()));
                 if let Some(slot) = local_slot
                     && let Some(env_val) = self.env().get(var_name).cloned()
                 {
@@ -315,7 +315,7 @@ impl Interpreter {
                 container.with_array_mut(|items, _kind| {
                     let arr = crate::value::gc_data_mut(items);
                     while arr.len() < min_len {
-                        arr.push(Value::package(crate::symbol::Symbol::intern("Any")));
+                        arr.push(Value::package(crate::symbol::wk::any()));
                     }
                 });
                 if let Some(padded_val) = self.env().get(&var_name).cloned() {
@@ -936,7 +936,7 @@ impl Interpreter {
         // Deleting from a container that was never vivified: every addressed
         // slot is absent, so each deletes to the Any hole (matching raku's
         // `my %j; (%j<x>:delete).raku` → `Any`), not Nil.
-        let missing = Value::package(crate::symbol::Symbol::intern("Any"));
+        let missing = Value::package(crate::symbol::wk::any());
         match idx.view() {
             ValueView::Array(keys, ..) => Value::array(vec![missing; keys.len()]),
             _ => missing,

--- a/src/vm/vm_var_index_ops.rs
+++ b/src/vm/vm_var_index_ops.rs
@@ -2388,10 +2388,10 @@ impl Interpreter {
                     ValueView::Array(items, kind) if !kind.is_itemized() => Value::array(
                         items
                             .iter()
-                            .map(|_| Value::package(Symbol::intern("Any")))
+                            .map(|_| Value::package(crate::symbol::wk::any()))
                             .collect(),
                     ),
-                    _ => Value::package(Symbol::intern("Any")),
+                    _ => Value::package(crate::symbol::wk::any()),
                 }
             }
             // Postcircumfix POSITIONAL index (`[idx]`) on the bare Any type object —
@@ -2410,10 +2410,10 @@ impl Interpreter {
                     ValueView::Array(items, ..) => Value::array(
                         items
                             .iter()
-                            .map(|_| Value::package(Symbol::intern("Any")))
+                            .map(|_| Value::package(crate::symbol::wk::any()))
                             .collect(),
                     ),
-                    _ => Value::package(Symbol::intern("Any")),
+                    _ => Value::package(crate::symbol::wk::any()),
                 }
             }
             // Parameterizing a user-declared class / package / module that is NOT

--- a/src/vm/vm_var_multidim_helpers.rs
+++ b/src/vm/vm_var_multidim_helpers.rs
@@ -119,7 +119,7 @@ impl Interpreter {
             // (`Any`), like a single-dim out-of-range read; a List miss
             // stays Nil (S32-array/multislice-6e.t).
             if kind.is_real_array() {
-                return Ok(Value::package(Symbol::intern("Any")));
+                return Ok(Value::package(crate::symbol::wk::any()));
             }
             return Ok(Value::NIL);
         }

--- a/src/vm/vm_var_multidim_ops.rs
+++ b/src/vm/vm_var_multidim_ops.rs
@@ -46,7 +46,7 @@ impl Interpreter {
             // with a bare `Nil` because the whole intermediate is missing, not
             // just the leaf.
             if result.is_nil() {
-                result = Value::package(crate::symbol::Symbol::intern("Any"));
+                result = Value::package(crate::symbol::wk::any());
             }
             result = Value::array(vec![result]);
         }
@@ -680,7 +680,7 @@ impl Interpreter {
                             // A missing slot of a real Array reads as its
                             // element default, Any (indexing further into the
                             // Any type object stays Any, matching raku).
-                            Value::package(Symbol::intern("Any"))
+                            Value::package(crate::symbol::wk::any())
                         } else {
                             self.multi_dim_index_read(&Value::NIL, rest)?
                         }
@@ -725,7 +725,7 @@ impl Interpreter {
                     } else if is_real {
                         // Out of bounds on a real Array: the element default
                         // (Any), like a single-dim OOB read; a List stays Nil.
-                        Ok(Value::package(Symbol::intern("Any")))
+                        Ok(Value::package(crate::symbol::wk::any()))
                     } else {
                         // Out of bounds — return Nil for scalar index
                         Ok(Value::NIL)
@@ -741,7 +741,7 @@ impl Interpreter {
                         if i < items.len() {
                             self.multi_dim_index_read(&items[i], rest)
                         } else if is_real {
-                            Ok(Value::package(Symbol::intern("Any")))
+                            Ok(Value::package(crate::symbol::wk::any()))
                         } else {
                             Ok(Value::NIL)
                         }
@@ -776,7 +776,7 @@ impl Interpreter {
                         };
                         this.multi_dim_index_read(&inner, rest)
                     }
-                    None => Ok(Value::package(crate::symbol::Symbol::intern("Any"))),
+                    None => Ok(Value::package(crate::symbol::wk::any())),
                 }
             };
 
@@ -1212,7 +1212,7 @@ impl Interpreter {
                 let existed = map.contains_key(&key);
                 let entry = map
                     .entry(key.clone())
-                    .or_insert_with(|| Value::package(crate::symbol::Symbol::intern("Any")));
+                    .or_insert_with(|| Value::package(crate::symbol::wk::any()));
                 let r = self.assign_chain_into_slot(entry, rest, dims, value, is_positional);
                 if r.is_err() && !existed {
                     map.remove(&key);
@@ -1481,7 +1481,7 @@ impl Interpreter {
         let k = Value::hash_key_encode(key);
         let entry = map
             .entry(k)
-            .or_insert_with(|| Value::package(crate::symbol::Symbol::intern("Any")));
+            .or_insert_with(|| Value::package(crate::symbol::wk::any()));
         if !is_leaf && matches!(entry.view(), ValueView::Nil | ValueView::Package(..)) {
             *entry = Self::fresh_assoc_level();
         }
@@ -1511,7 +1511,7 @@ impl Interpreter {
             let v = values
                 .get(*vi)
                 .cloned()
-                .unwrap_or_else(|| Value::package(crate::symbol::Symbol::intern("Any")));
+                .unwrap_or_else(|| Value::package(crate::symbol::wk::any()));
             *vi += 1;
             // Write through a `ContainerRef` leaf (Track B element cell /
             // `:=`-bound element) so every snapshot holder observes the write.
@@ -1571,9 +1571,9 @@ impl Interpreter {
                 target
                     .with_hash_mut(|map| {
                         let map = crate::value::gc_data_mut(map);
-                        let entry = map.entry(s.as_str().to_string()).or_insert_with(|| {
-                            Value::package(crate::symbol::Symbol::intern("Any"))
-                        });
+                        let entry = map
+                            .entry(s.as_str().to_string())
+                            .or_insert_with(|| Value::package(crate::symbol::wk::any()));
                         self.multi_dim_assign_slice(entry, rest, values, vi, is_positional)
                     })
                     .transpose()?;
@@ -1653,7 +1653,7 @@ impl Interpreter {
                     let map = crate::value::gc_data_mut(map);
                     let entry = map
                         .entry(s.as_str().to_string())
-                        .or_insert_with(|| Value::package(crate::symbol::Symbol::intern("Any")));
+                        .or_insert_with(|| Value::package(crate::symbol::wk::any()));
                     self.multi_dim_assign_scalar(entry, rest, value, is_positional)
                 })
                 .transpose()?;
@@ -1772,10 +1772,7 @@ impl Interpreter {
                 if items.len() < min_size {
                     let old_len = items.len();
                     let items = crate::value::gc_data_mut(items);
-                    items.resize(
-                        min_size,
-                        Value::package(crate::symbol::Symbol::intern("Any")),
-                    );
+                    items.resize(min_size, Value::package(crate::symbol::wk::any()));
                     // The newly appended slots are unassigned gaps
                     // (`ArrayData::hole_at`, ADR-0049 §1.6/§4 slice 5). An
                     // array that never tracked gaps (`initialized: None`,
@@ -1791,10 +1788,7 @@ impl Interpreter {
             && matches!(target.view(), ValueView::Nil | ValueView::Package(..))
         {
             let mut items = Vec::with_capacity(min_size);
-            items.resize(
-                min_size,
-                Value::package(crate::symbol::Symbol::intern("Any")),
-            );
+            items.resize(min_size, Value::package(crate::symbol::wk::any()));
             // A brand-new autovivified array/row: every slot is an
             // unassigned gap until a later multidim leaf write marks its
             // index (see `multi_dim_assign_scalar`'s `initialized.insert`).

--- a/src/vm/vm_var_ops.rs
+++ b/src/vm/vm_var_ops.rs
@@ -387,7 +387,7 @@ impl Interpreter {
             // object hash with only a key type) defaults like an untyped
             // container: `Any`.
             if info.value_type.is_empty() {
-                return Value::package(Symbol::intern("Any"));
+                return Value::package(crate::symbol::wk::any());
             }
             Value::package(Symbol::intern(&info.value_type))
         } else if matches!(target.view(), ValueView::Hash(_))
@@ -397,13 +397,13 @@ impl Interpreter {
             // type object (raku: `my @a; @a[5]` is `Any`), not `Nil`. A *List*
             // (`(1,2,3)[11]`, `()[0]`) is out-of-range → `Nil`, so only a real
             // `Array` (`[...]`/`my @a`) gets the `Any` default.
-            Value::package(Symbol::intern("Any"))
+            Value::package(crate::symbol::wk::any())
         } else if let ValueView::Instance { class_name, .. } = target.view() {
             // A user subclass of Array/Hash (`class A is Array {}`) defaults
             // its missing elements to `Any` like its base container does
             // (S12-introspection/WHAT.t: `A.new[0].WHAT === Any`).
             if self.class_inherits_array_or_hash(&class_name.resolve()) {
-                Value::package(Symbol::intern("Any"))
+                Value::package(crate::symbol::wk::any())
             } else {
                 Value::NIL
             }

--- a/t/bless-attr-seed-plan.t
+++ b/t/bless-attr-seed-plan.t
@@ -1,0 +1,54 @@
+use Test;
+
+# `dispatch_bless` seeds every attribute the caller did not supply. That seed —
+# a native zero, or the attribute's nominal type object — is a pure function of
+# the class shape, so it is precomputed once per class in `NativeCtorPlan`
+# rather than re-derived (a type-constraint lookup, a nominal-type walk and a
+# `Symbol::intern`) on every construction. Same for the named-argument →
+# attribute-index lookup, which is a hash probe rather than a linear name scan.
+plan 12;
+
+subset Small of Int where * < 10;
+
+class Seeds {
+    has $.untyped;
+    has Int $.typed;
+    has Str $.stringy;
+    has Small $.subsetted;
+    has int $.native-int;
+    has num $.native-num;
+    has str $.native-str;
+    has @.list;
+    has %.map;
+    has $.given;
+
+    method new(*%_) { self.bless(|%_) }
+}
+
+my $s = Seeds.new(given => 42);
+
+is $s.untyped.gist, "(Any)", "an untyped attribute seeds Any";
+is $s.typed.gist, "(Int)", "a typed attribute seeds its declared type object";
+is $s.stringy.gist, "(Str)", "Str-typed attribute seeds Str";
+is $s.subsetted.gist, "(Small)", "a subset-typed attribute seeds the subset type object";
+is $s.native-int, 0, "a native int attribute seeds 0";
+is $s.native-num, 0e0, "a native num attribute seeds 0e0";
+is $s.native-str, "", "a native str attribute seeds the empty string";
+is-deeply $s.list, [], "an untouched \@ attribute seeds an empty Array";
+is-deeply $s.map, {}, "an untouched \% attribute seeds an empty Hash";
+is $s.given, 42, "a supplied named argument still wins over the seed";
+
+# A named argument that matches no declared attribute is dropped (raku's
+# default BUILDALL ignores it), and the index lookup must not confuse it for
+# one that does.
+my $t = Seeds.new(typed => 3, nosuchthing => 9);
+is $t.typed, 3, "the matching named argument lands on its attribute";
+
+# A child re-declaring a parent attribute name: the bless override must pick
+# the same attribute the seed loop filled, not a later same-named entry.
+class Parent { has $.dup }
+class Child is Parent {
+    has $.own;
+    method new(*%_) { self.bless(|%_) }
+}
+is Child.new(dup => 7, own => 8).dup, 7, "a re-declared attribute name resolves to one slot";

--- a/t/destroy-latch-late-registration.t
+++ b/t/destroy-latch-late-registration.t
@@ -1,0 +1,28 @@
+use Test;
+
+# The interpreter keeps a monotonic, process-global latch recording whether any
+# user DESTROY submethod has been registered anywhere; instance death skips the
+# whole queue-and-MRO-walk dance while it reads false. The latch is consulted at
+# DROP time, not at construction, so a DESTROY installed AFTER instances of the
+# class have already lived and died still fires for everything dying later.
+# (t/destroy.t covers the ordinary declared-in-the-class-body case.)
+plan 2;
+
+my @events;
+
+class Early { has $.x }
+
+# Instances that live and die entirely before any DESTROY exists anywhere: the
+# latch is unarmed here, so nothing is queued and nothing runs.
+{ my $e = Early.new(x => 1); }
+{ my $e = Early.new(x => 2); }
+quietly $*VM.request-garbage-collection;
+is-deeply @events, [], "no DESTROY registered anywhere yet: nothing fires";
+
+# Arm the latch through the metamodel, after those deaths.
+my $late = method DESTROY { @events.push("early") };
+Early.^add_method('DESTROY', $late);
+
+{ my $e = Early.new(x => 3); }
+quietly $*VM.request-garbage-collection;
+is-deeply @events, ["early"], "a DESTROY added later fires for later deaths";

--- a/todo/perf/bench-ctor-construction-parity.md
+++ b/todo/perf/bench-ctor-construction-parity.md
@@ -64,7 +64,7 @@ specializes the whole new -> bless -> BUILDALL chain.
   case). Also avoid the unconditional `cell.to_map()` probe when no alias
   refresh is needed and the resolved candidate doesn't consume it.
   Expected: removes most of the 30us/construction TWEAK overhead.
-- [ ] **S2: trim the custom-new -> bless argument plumbing** — avoid
+- [~] **S2: trim the custom-new -> bless argument plumbing** — avoid
   rebuilding the named-arg hash/pair vector twice (`%_` slurpy then
   `:meta(%_)` slip flatten), and chase the 3 env_deep_copies/construction on
   this path. **2026-08-14 investigation (this session) root-caused the
@@ -474,6 +474,77 @@ open, from the same repro: `CheckReadOnly` builds
 assignment once `closure_meta_keys_possible()` is armed — and that flag is shared
 with `__mutsu_state_key::` / `__mutsu_sigilless_alias::` / predictive-seq keys, so
 creating any of those arms the readonly probe too; it wants its own flag.
+
+## Update (2026-09-08, round 6 — construction was re-deriving names it already knew)
+
+Landed; write-up in `news/2026-09/bench-ctor-name-rederivation.md`. Whole-bench
+instruction count **1,715,336,347 -> 1,480,264,577 (-13.7%)**, i.e. 343k -> 296k
+instructions per construction, measured with **callgrind** (this container has
+no `perf`; callgrind's counts are deterministic, which is what a perf iteration
+wants anyway). An interleaved same-session wall-clock A/B (release builds of
+`main` and of the change, alternating, `taskset -c 2`, best of 9) reads
+**0.302s -> 0.225s, -25%**; the wall delta exceeds the instruction delta
+because most of what went away was cache-unfriendly (thread-local + hash +
+`memcmp` round trips, plus a 21-entry `AttrMap` clone per constructed object).
+Confirm on the bench CI.
+
+Round 5's two open `dispatch_bless` leads were real but the small half. The
+dominant residual was **name re-derivation**: `LocalKey<T>::with` was 9.2% of
+the whole run and its dominant caller was `Symbol::intern` at **732,232 calls
+for 5000 constructions — 146 per constructed object**. Next to it, **every
+instance death cloned its whole 21-entry attribute map into a DESTROY queue**
+that no `DESTROY` could ever consume, then walked the MRO interning two names
+per level to discover that.
+
+What landed:
+
+- **S2-adjacent (the round-5 leads):** `NativeCtorPlan` gained `attr_index`
+  (attribute name -> index; the override loop's linear per-argument name scan
+  becomes one hash probe, resolved once and shared with the seed loop) and
+  `attr_seeds` (the per-attribute no-initializer seed, so the
+  `type_constraints` lookup + `nominal_type_object_name_for_constraint` walk +
+  `Symbol::intern` per unfilled attribute — 16 interns/construction — is paid
+  once per class).
+- **DESTROY latch:** a monotonic process-global "some user DESTROY exists"
+  flag, armed from `Registry::reindex_user_method_name` and role registration,
+  read at DROP time by `InstanceAttrs::finalize_destroy` (after the refcount
+  bookkeeping, so no leak; at drop rather than construction, so a late
+  `.^add_method` DESTROY still fires). Pinned by
+  `t/destroy-latch-late-registration.t`.
+- **Symbol-keyed MRO presence probes:** `has_user_method` cloned the whole
+  `Vec<MethodDef>` per level just to read one boolean (1.6% of the bench on its
+  own) and re-interned both names per level. New
+  `Registry::user_method_public_presence` / `accessor_is_public_sym` /
+  `user_method_local_role_presence_sym` allocate and intern nothing.
+- `Symbol::intern("Any")` -> `wk::any()` tree-wide (115 sites).
+- `AttrReadGuard::drop` skips the deferred-write queue scan behind a global
+  `PENDING_CELL_WRITE_COUNT` (~40 attribute reads/construction each paid a
+  second thread-local + `RefCell` borrow + `Vec::retain`).
+- **Round 5's `CheckReadOnly` item:** `__mutsu_sigilless_readonly::` got its own
+  latch (`sigilless_readonly_keys_possible`) instead of sharing
+  `closure_meta_keys_possible` with `__mutsu_state_key::` & co.
+- Interning hoists in `call_compiled_method{,_fast}` (owner class interned once
+  per call, not twice; `"?CLASS"`/`"?ROLE"` inserted by well-known symbol
+  instead of a fresh `String`; an attributive param bind interns its attribute
+  name once and inserts by `Symbol`).
+
+**Still open (~3% of the bench between them), each needing its own surgery:**
+`native_lever_a_user_override` (2 interns per native method dispatch;
+`value_type_name` returns a `&'static str`, so a pointer-keyed memo or a
+`value_type_sym` would do it), `get_env_with_main_alias_inner` (~16
+interns/construction from name-keyed env reads — wants symbol-threaded
+callers), and the routine-frame push's `lexical_package`/`method_name` (wants
+pre-interned symbols on `MethodDef`, which is 18 struct-literal sites). The
+older structural items are unchanged: S2's `env_deep_copies` remainder stays
+gated on `docs/vm-single-store.md` §3, S3 stays closed, and S4's
+construction-pipeline campaign is still the long-term lever.
+
+**Lesson for the next round, alongside round 5's:** a flat profile can also
+hide *name re-derivation*. `Symbol::intern` never appears as a single hot
+symbol — its cost lands in `LocalKey::with`, `hashbrown`, `memcmp` and
+`malloc`, the same bucket rounds 2-4 read as "no dominant function". Count the
+calls (`callgrind_annotate --tree=caller` on `Symbol::intern`) before believing
+it.
 
 ## Measurement notes
 


### PR DESCRIPTION
`todo/perf/bench-ctor-construction-parity.md` round 6.

## Measured

| metric | before | after |
|---|---:|---:|
| whole-bench instructions (callgrind, 5000 constructions) | 1,715,336,347 | **1,480,264,577 (−13.7%)** |
| per construction | 343k | 296k |
| wall clock (interleaved same-session A/B, `taskset -c 2`, best of 9) | 0.302s | **0.225s (−25%)** |

This container has no `perf`, so profiling used **callgrind** — its instruction counts are deterministic, which is what a perf iteration wants anyway. The wall delta exceeds the instruction delta because most of what went away was cache-unfriendly (thread-local + hash + `memcmp` round trips, plus a 21-entry `AttrMap` clone per constructed object). Bench CI (`bench-history.tsv` on `bench-data`) remains the authority for the recorded ratio.

## The finding

Rounds 2–5 all read the profile as "flat, no dominant function". Counting *calls* instead of samples says otherwise: `LocalKey<T>::with` was **9.2% of the entire run**, and its dominant caller was `Symbol::intern` at **732,232 calls for 5000 constructions — 146 name interns per constructed object**. Nearly all of them re-derived a `Symbol` from a name the caller already held, or from data that is pure class shape and already cached once per class.

Next to it: **every instance death cloned its whole attribute map into a DESTROY queue** that, in a program declaring no `DESTROY` anywhere, was walked and thrown away — a 21-entry `AttrMap` clone, a sharded mutex, and an MRO walk interning two names per level, per constructed object.

## What changed

**`NativeCtorPlan` learned the two things `dispatch_bless` re-derived per construction** — the leads round 5 left open:
- `attr_index` (attribute name → index): the named-argument override loop answered "does this argument name a declared attribute?" with a linear `class_attrs.iter().position(...)` scan *per argument* — 7 args × 21 attributes of `memcmp` on this shape. Now one hash probe per argument, resolved once and shared with the seed loop. First-wins, matching the scan it replaces (an MRO can collect two same-named attributes).
- `attr_seeds`: the per-attribute no-initializer seed. Deriving it meant a `type_constraints` lookup + a `nominal_type_object_name_for_constraint` walk + a `Symbol::intern` for every unfilled attribute of every construction (16 interns/construction here). Pure class shape, so it is computed once per class.

**A monotonic process-global "some user DESTROY exists" latch.** Armed from `Registry::reindex_user_method_name` (the single reverse-index hook every class-side method mutator passes through: class bodies, `augment`, `.^add_method`) and from role registration (a role submethod `DESTROY` dispatches straight off `RoleDef::methods`, never through the class method table). `InstanceAttrs::finalize_destroy` reads it **at drop time, not at construction** — so a `DESTROY` installed later still fires for everything that dies after it — and **after** the `live_instance_refcounts` bookkeeping, so skipping the queue cannot leak refcount entries.

**Symbol-keyed MRO presence probes.** `has_user_method` walked the MRO calling `user_method_overloads(cn.as_str(), name)`, which re-interned *both* names at every level and then **cloned the whole `Vec<MethodDef>`** — a ~300-byte struct with `String`s, `Arc`s and `Vec`s — purely to read one boolean off it. That function alone was 1.6% of the bench. New `Registry::user_method_public_presence` allocates and interns nothing; `has_public_accessor` and `resolve_user_method_or_accessor` got the same treatment via `accessor_is_public_sym` / `user_method_local_role_presence_sym`.

**`Symbol::intern("Any")` → `crate::symbol::wk::any()`** tree-wide (115 sites). The well-known-symbol accessor already existed for exactly this, and `Any` is the most-interned name in an OO program (every untyped attribute's seed, every routine's fresh topic).

**`AttrReadGuard::drop` skips the deferred-write queue scan** behind a global `PENDING_CELL_WRITE_COUNT`. Deferral is a rare self-deadlock escape hatch, but every attribute read (~40/construction) paid a second thread-local access, a `RefCell` borrow and a `Vec::retain` to discover that. Global rather than per-thread on purpose: over-reporting only makes this thread run the correct, empty, scan.

**A dedicated `__mutsu_sigilless_readonly::` latch** — round 5's third open item. `closure_meta_keys_possible()` lumps four unrelated key families together, so declaring a `state` variable armed the readonly probe too, and that probe runs on *every* whole-variable assignment (`OpCode::CheckReadOnly`), building a `format!` key for a key the program never created. `sigilless_readonly_keys_possible()` is the narrower gate, armed from the same `note_env_key` chokepoint every creation site flows through.

**Interning hoists in method dispatch.** `call_compiled_method{,_fast}` interned the owner class name twice per call; the non-fast path built `String`s for the fixed `"?CLASS"`/`"?ROLE"` env keys instead of using the well-known symbols the fast path already uses; an attributive parameter bind interned its attribute name twice and allocated a `String` for the cell insert (now one intern, `Symbol`-keyed insert).

## Tests

- New: `t/destroy-latch-late-registration.t` (a `DESTROY` added by `.^add_method` after earlier instances have already lived and died still fires for later deaths), `t/bless-attr-seed-plan.t` (every seed shape — untyped/typed/subset/native int-num-str/`@`/`%` — plus the supplied-argument override, an unknown named argument, and a re-declared attribute name resolving to one slot).
- `make test` PASS; `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` clean.
- Roast spot-check on the areas this touches (299 whitelisted files across `S12-*`, `S14-*`, `S02-names-vars/*`, `S06-*`, `S04-*`): PASS. Full `make roast` is CI's.

## Still open

The remaining `Symbol::intern` traffic (~3% of the bench) sits in three places, each needing its own surgery, recorded in the news file and the ticket: `native_lever_a_user_override` (2 interns per native method dispatch — `value_type_name` returns a `&'static str`, so a pointer-keyed memo or a `value_type_sym` would do it), `get_env_with_main_alias_inner` (~16/construction from name-keyed env reads — wants symbol-threaded callers), and the routine-frame push's `lexical_package`/`method_name` (wants pre-interned symbols on `MethodDef`, which is 18 struct-literal sites).

**Lesson recorded for the next round**, alongside round 5's: a flat profile can hide *name re-derivation* too. `Symbol::intern` never appears as one hot symbol — its cost lands in `LocalKey::with`, `hashbrown`, `memcmp` and `malloc`, exactly the bucket rounds 2–4 read as "no dominant function". Count the calls before believing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VuW2Fo3p5JriWuMVLVNPMR


---
_Generated by [Claude Code](https://claude.ai/code/session_01VuW2Fo3p5JriWuMVLVNPMR)_