### PR TITLE
docs(regex): point at regex_match_lazy_subrule.rs, not regex_match_lazy.rs

### DIFF
--- a/docs/adr/0073-regex-atom-candidates-are-demand-driven.md
+++ b/docs/adr/0073-regex-atom-candidates-are-demand-driven.md
@@ -309,9 +309,9 @@ it can be adopted incrementally.
   runtime fallback (redo the iteration with the full set) for the case a `{ … }`
   block re-enters the rule by hand.
 - **Slice 2 (streamed half) — IMPLEMENTED 2026-09-08.**
-  `drive_named_subrule_candidates` (`regex_match_lazy.rs`) walks the subrule's
-  body through a `MatchSink::Cont`, wrapping each end into the atom's capture
-  delta as it is produced, so end *k+1* is computed only once the real
+  `drive_named_subrule_candidates` (`regex_match_lazy_subrule.rs`) walks the
+  subrule's body through a `MatchSink::Cont`, wrapping each end into the atom's
+  capture delta as it is produced, so end *k+1* is computed only once the real
   continuation has rejected end *k*. It takes the separable case named above —
   no arguments, no proto, exactly one resolved candidate, no custom-HOW
   dispatch, no `:m`, no dynamic (`$*`) rule parameters anywhere in the program,

--- a/news/2026-09/subrule-calls-stream-their-candidates.md
+++ b/news/2026-09/subrule-calls-stream-their-candidates.md
@@ -100,16 +100,16 @@ work exists for — would have been ineligible.
 
 With re-entry ruled out, the growing-seed loop is a formality — one iteration,
 seed unconsulted, first result final — and the call can be **streamed**.
-`drive_named_subrule_candidates` (`regex_match_lazy.rs`) walks the subrule body
-through a `MatchSink::Cont`, wrapping each end into the atom's capture delta as
-it is produced, so end *k+1* is computed only after the real continuation has
-rejected end *k*. It takes only the shape where none of the `Named` arm's other
-machinery is in play: an argument-less call, exactly one non-proto candidate, no
-custom-HOW dispatch, no `:m`, no dynamic (`$*`) rule parameters anywhere in the
-program, and a key that is not already LR-active. A ratchet on the calling token
-simply stops the stream after the first end, which is what the ratcheted half
-used `first_only` for — so non-leaf rules under a ratcheted caller are now
-streamed too.
+`drive_named_subrule_candidates` (`regex_match_lazy_subrule.rs`) walks the
+subrule body through a `MatchSink::Cont`, wrapping each end into the atom's
+capture delta as it is produced, so end *k+1* is computed only after the real
+continuation has rejected end *k*. It takes only the shape where none of the
+`Named` arm's other machinery is in play: an argument-less call, exactly one
+non-proto candidate, no custom-HOW dispatch, no `:m`, no dynamic (`$*`) rule
+parameters anywhere in the program, and a key that is not already LR-active. A
+ratchet on the calling token simply stops the stream after the first end, which
+is what the ratcheted half used `first_only` for — so non-leaf rules under a
+ratcheted caller are now streamed too.
 
 The one construct the call graph deliberately treats as harmless is an embedded
 `{ … }` block: it is user code and could re-enter the rule by hand. The

--- a/src/runtime/regex/regex_call_graph.rs
+++ b/src/runtime/regex/regex_call_graph.rs
@@ -31,7 +31,7 @@
 //! principle re-enter the same rule at the same position by hand; the callers
 //! keep a runtime escape for that (`regex_match_atom.rs`'s `first_only`
 //! retry, and the streamed subrule's seed-consulted fallback in
-//! `regex_match_lazy.rs`), exactly as the first half of Slice 2 does.
+//! `regex_match_lazy_subrule.rs`), exactly as the first half of Slice 2 does.
 
 use std::cell::RefCell;
 use std::collections::{HashMap, HashSet, VecDeque};
@@ -184,9 +184,9 @@ impl Interpreter {
 }
 
 impl Interpreter {
-    /// Whether the streamed `<subrule>` path in `regex_match_lazy.rs` may take
-    /// this call at all: the memoized front door, consulted BEFORE the call is
-    /// resolved so an ineligible one costs a hash lookup instead of a
+    /// Whether the streamed `<subrule>` path in `regex_match_lazy_subrule.rs`
+    /// may take this call at all: the memoized front door, consulted BEFORE the
+    /// call is resolved so an ineligible one costs a hash lookup instead of a
     /// resolution plus a call-graph walk.
     ///
     /// `atom_text` is the subrule atom exactly as written,

--- a/todo/deep/ordered-alternation-eager-candidate-enumeration.md
+++ b/todo/deep/ordered-alternation-eager-candidate-enumeration.md
@@ -10,9 +10,9 @@ ratcheted half (`news/2026-09/ratcheted-subrule-calls-are-first-only.md`).
 
 ## What is left
 
-`drive_named_subrule_candidates` (`src/runtime/regex/regex_match_lazy.rs`) takes
-one shape and one only: an argument-less call resolving to exactly one non-proto
-candidate, with no custom-HOW dispatch, no `:m`, no dynamic (`$*`) rule
+`drive_named_subrule_candidates` (`src/runtime/regex/regex_match_lazy_subrule.rs`)
+takes one shape and one only: an argument-less call resolving to exactly one
+non-proto candidate, with no custom-HOW dispatch, no `:m`, no dynamic (`$*`) rule
 parameters declared anywhere in the program, a key that is not already LR-active,
 and a rule the call graph (`regex_call_graph.rs`) proves cannot reach a call to
 its own name. Everything else still goes to the eager `Named` arm in


### PR DESCRIPTION
Follow-up to #7534. The streamed `<subrule>` driver landed in its own module
(`regex_match_lazy_subrule.rs`, split out to keep `regex_match_lazy.rs` under the
500-line rule), but four "where does this live" pointers written before the split
still named `regex_match_lazy.rs`:

- `src/runtime/regex/regex_call_graph.rs` — module header, and the
  `subrule_call_is_streamable` doc comment
- `docs/adr/0073-regex-atom-candidates-are-demand-driven.md` — the Slice 2
  (streamed half) entry
- `news/2026-09/subrule-calls-stream-their-candidates.md`
- `todo/deep/ordered-alternation-eager-candidate-enumeration.md`

`for_each_atom_candidate` and the delta shape really are in
`regex_match_lazy.rs`, so the references to those are left alone.

Comments and prose only; no behaviour change. (It touches a `.rs` file, so CI
runs the full suite rather than taking the docs-only skip.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAtJGeybgQKe7By5gwjXQ6

---
_Generated by [Claude Code](https://claude.ai/code/session_01KAtJGeybgQKe7By5gwjXQ6)_