### PR TITLE
fix: an inclusive slice with a runtime negative range end hung forever

### DIFF
--- a/news/2026-09/array-slice-runtime-negative-range-hang.md
+++ b/news/2026-09/array-slice-runtime-negative-range-hang.md
@@ -1,0 +1,56 @@
+# An array slice whose range end came from a negative variable hung forever
+
+`my @el = (4,); my $e = -1; say @el[0 .. $e]` never returned. The Range itself
+was always right — `(0 .. $e).elems` is `0` and `(0 .. $e).raku` is `0..-1` —
+so the fault was entirely in the subscript, and only with a *runtime* endpoint:
+the literal spelling `@el[0 .. -1]` is rejected up front by both mutsu and raku
+("Unsupported use of a negative -1 subscript to index from the end"), which is
+why the hole survived so long unnoticed.
+
+## Root cause
+
+The inclusive-range subscript arms computed their end index as
+`b.max(-1) as usize`. For a negative `b` that is `(-1) as usize`, i.e.
+`usize::MAX`, and the slice loop then ran `for i in start..=usize::MAX`,
+resolving each out-of-bounds slot to the container's typed default and pushing
+it. The process grew a list of `Any`s until it was killed. A hang is worse than
+a wrong answer — it takes the whole process out with no diagnostic — and
+`0 .. $n-1` over a computed length is one of the most common slice idioms
+there is; this was the real cause of the `Language/objects.rakudoc:1397`
+doc-diff timeout that had been blamed on the BinaryTree role example.
+
+Three arms in `src/vm/vm_var_index_ops.rs` carried the same cast: the `Array`
+one (which hung), and the `Seq` and `Range`-target ones, which were guarded
+against the runaway loop by a `min(len - 1)` clamp but therefore answered the
+*whole* list where raku answers the empty one.
+
+## The fix
+
+All three now go through one helper, `Interpreter::inclusive_range_window`,
+which resolves `a .. b` to a half-open `[start, end)` window entirely in `i64`
+before any `usize` cast, and answers `None` when the range is empty. Doing the
+comparison in signed arithmetic is what makes the negative end simply empty
+instead of enormous.
+
+Two behaviours fell out of routing every arm through the one helper:
+
+- `@a[0 .. *]` on an *empty* array is now `()`. The old unbounded-end
+  expression was `items.len().saturating_sub(1)` used as an *inclusive* end, so
+  a zero-length array produced the window `0..=0` and the slice answered
+  `(Any,)`. raku answers `()`.
+- A negative slice *start* now throws `X::OutOfRange` ("Index out of range.
+  Is: -1, should be in 0..^Inf") instead of silently clamping to 0. That is
+  what raku does — `my $s = -1; @a[$s .. 2]` is an error there, exactly as a
+  plain `@a[$s]` read is — and mutsu used to answer a quietly wrong `(1, 2, 3)`.
+
+## Pin
+
+`t/array-slice-runtime-negative-range.t` covers the reported repro, the
+`List`/`Seq`/itemized-array/`comb`/`Range`-target and associative twins, the
+negative-start throws, and the ordinary slice shapes (padding, unbounded end,
+`*-1` counting, the exclusive-end twin) as controls. Its last assertion is a
+`Test::Util` `doesn't-hang` run of the original repro in a child process, so a
+regression fails the test instead of wedging the suite. The whole file also
+passes unmodified under real Rakudo.
+
+Closes [#7578](https://github.com/tokuhirom/mutsu/issues/7578).

--- a/src/vm/vm_var_index_ops.rs
+++ b/src/vm/vm_var_index_ops.rs
@@ -45,6 +45,43 @@ impl Interpreter {
         }
     }
 
+    /// The half-open `[start, end)` index window an *inclusive* `a..b` subscript
+    /// addresses over a container of `len` elements, or `None` when the range is
+    /// empty. An unbounded end (`@a[3..*]`) stops at `len`; a bounded one keeps
+    /// its own end so an over-long range still pads with the typed default
+    /// (`@a[0..5]` on a 3-element array is `(1, 2, 3, Any, Any, Any)`).
+    ///
+    /// Doing this in `i64` matters: `b` can be negative at runtime (`my $e = -1;
+    /// @a[0 .. $e]`), and casting that end to `usize` first turned `-1` into
+    /// `usize::MAX`, so the slice loop ran essentially forever instead of
+    /// answering the empty list raku answers.
+    ///
+    /// A negative *start* is an error rather than an empty slice, matching raku:
+    /// `@a[$s .. 2]` with `$s == -1` throws `X::OutOfRange`, the same way a plain
+    /// `@a[$s]` read does.
+    fn inclusive_range_window(
+        a: i64,
+        b: i64,
+        len: usize,
+    ) -> Result<Option<(usize, usize)>, RuntimeError> {
+        if a < 0 {
+            return Err(RuntimeError::out_of_range(
+                "Index",
+                Value::int(a),
+                "0..^Inf",
+            ));
+        }
+        let end_excl = if Self::range_end_is_unbounded(b) {
+            len as i64
+        } else {
+            b.saturating_add(1)
+        };
+        if end_excl <= a {
+            return Ok(None);
+        }
+        Ok(Some((a as usize, end_excl as usize)))
+    }
+
     /// The `.Int` of a numified subscript: an integer passes through exactly (so
     /// a big index keeps its value), anything else truncates toward zero the way
     /// `Int()` does — `@a["1.9"]` is `@a[1]`.
@@ -1093,19 +1130,18 @@ impl Interpreter {
                 }
             }
             (ValueView::Array(items, kind), ValueView::Range(a, b)) => {
-                let start = a.max(0) as usize;
-                let end = if Self::range_end_is_unbounded(b) {
-                    items.len().saturating_sub(1)
-                } else {
-                    b.max(-1) as usize
-                };
                 let source = Value::array_with_kind(items.clone(), kind);
-                let default = self.typed_container_default(&source);
-                let mut slice = Vec::new();
-                for i in start..=end {
-                    slice.push(self.resolve_array_entry(&items, kind, i, default.clone()));
+                match Self::inclusive_range_window(a, b, items.len())? {
+                    Some((start, end_excl)) => {
+                        let default = self.typed_container_default(&source);
+                        let mut slice = Vec::new();
+                        for i in start..end_excl {
+                            slice.push(self.resolve_array_entry(&items, kind, i, default.clone()));
+                        }
+                        self.slice_result_value(&source, slice)
+                    }
+                    None => self.slice_result_value(&source, Vec::new()),
                 }
-                self.slice_result_value(&source, slice)
             }
             (ValueView::Array(items, kind), ValueView::RangeExcl(a, b)) => {
                 let start = a.max(0) as usize;
@@ -1165,13 +1201,11 @@ impl Interpreter {
                 }
             }
             (ValueView::Seq(items), ValueView::Range(a, b)) => {
-                let start = a.max(0) as usize;
-                let end = b.max(-1) as usize;
-                let slice = if start >= items.len() {
-                    Vec::new()
-                } else {
-                    let end = end.min(items.len().saturating_sub(1));
-                    items[start..=end].to_vec()
+                let slice = match Self::inclusive_range_window(a, b, items.len())? {
+                    Some((start, end_excl)) if start < items.len() => {
+                        items[start..end_excl.min(items.len())].to_vec()
+                    }
+                    _ => Vec::new(),
                 };
                 Value::seq(slice)
             }
@@ -2018,24 +2052,26 @@ impl Interpreter {
                 let range = &target;
                 if let Some((start, end, _excl_start, excl_end)) = range_params(range) {
                     let actual_end = if excl_end { end - 1 } else { end };
+                    let len = usize::try_from((actual_end - start).saturating_add(1).max(0))
+                        .unwrap_or(usize::MAX);
                     let mut result = Vec::new();
-                    for i in a..=b {
-                        let val = start + i;
-                        if val > actual_end {
-                            break;
+                    if let Some((first, end_excl)) = Self::inclusive_range_window(a, b, len)? {
+                        for i in first..end_excl {
+                            let val = start + i as i64;
+                            if val > actual_end {
+                                break;
+                            }
+                            result.push(Value::int(val));
                         }
-                        result.push(Value::int(val));
                     }
                     Value::array(result)
                 } else {
                     let items = crate::runtime::utils::value_to_list(range);
-                    let start = a.max(0) as usize;
-                    let end = b.max(-1) as usize;
-                    if start >= items.len() {
-                        Value::array(Vec::new())
-                    } else {
-                        let end = end.min(items.len().saturating_sub(1));
-                        Value::array(items[start..=end].to_vec())
+                    match Self::inclusive_range_window(a, b, items.len())? {
+                        Some((start, end_excl)) if start < items.len() => {
+                            Value::array(items[start..end_excl.min(items.len())].to_vec())
+                        }
+                        _ => Value::array(Vec::new()),
                     }
                 }
             }

--- a/t/array-slice-runtime-negative-range.t
+++ b/t/array-slice-runtime-negative-range.t
@@ -1,0 +1,92 @@
+use Test;
+use lib $*PROGRAM.parent(2).add("roast/packages/Test-Helpers/lib");
+use Test::Util;
+
+# An inclusive `a .. b` subscript whose endpoint arrives through a VARIABLE that
+# happens to be negative used to cast `-1` straight to `usize`, so the slice loop
+# ran from 0 to `usize::MAX` and the process hung with no diagnostic. The Range
+# itself was always correct -- `(0 .. -1).elems` is 0 -- it was the subscript
+# that never noticed the range was empty.
+#
+# A negative START is a different case: raku throws X::OutOfRange there, exactly
+# as it does for a plain `@a[$neg]` read, rather than clamping to 0.
+
+plan 23;
+
+# The reported hang, and the empty answer raku gives.
+{
+    my @el = (4,);
+    my $e = -1;
+    is-deeply @el[0 .. $e], (), 'array slice with a runtime negative end is empty';
+}
+
+{
+    my @a = 1, 2, 3;
+    my $e = -1;
+    is @a[0 .. $e].elems, 0, 'runtime negative end yields no elements';
+    my $far = -3;
+    is-deeply @a[0 .. $far], (), 'a more negative end is still empty';
+    my $one = 0;
+    is-deeply @a[0 .. $one], (1,), 'a zero end still addresses index 0';
+}
+
+# The same window logic backs List/Seq/Range targets, so pin them too.
+{
+    my $e = -1;
+    is-deeply (1, 2, 3).List[0 .. $e], (), 'List slice with a runtime negative end is empty';
+    is-deeply (1, 2, 3).Seq[0 .. $e], (), 'Seq slice with a runtime negative end is empty';
+    is-deeply [1, 2, 3][0 .. $e], (), 'itemized array slice with a runtime negative end is empty';
+    is-deeply "abcd".comb[0 .. $e], (), 'comb slice with a runtime negative end is empty';
+    is-deeply (10 .. 20)[0 .. $e], (), 'Range slice with a runtime negative end is empty';
+}
+
+# The associative twin shares the subscript entry point.
+{
+    my %h = a => 1;
+    my $e = -1;
+    is-deeply %h{0 .. $e}, (), 'hash slice with a runtime negative end is empty';
+}
+
+# A negative START throws, matching raku.
+{
+    my @a = 1, 2, 3;
+    my $s = -1;
+    throws-like { @a[$s .. 2] }, X::OutOfRange,
+        'a runtime negative slice start throws X::OutOfRange';
+    throws-like { @a[$s .. $s] }, X::OutOfRange,
+        'a wholly negative runtime slice range throws X::OutOfRange';
+    throws-like { (1, 2, 3).Seq[$s .. 2] }, X::OutOfRange,
+        'a runtime negative Seq slice start throws X::OutOfRange';
+    throws-like { (10 .. 20)[$s .. 2] }, X::OutOfRange,
+        'a runtime negative Range slice start throws X::OutOfRange';
+}
+
+# Controls: nothing about the ordinary slice shapes changed.
+{
+    my @a = 1, 2, 3;
+    is-deeply @a[0 .. 2], (1, 2, 3), 'a full inclusive slice is unchanged';
+    is-deeply @a[1 .. *], (2, 3), 'an unbounded end still clips at the boundary';
+    is-deeply @a[*-2 .. *-1], (2, 3), 'a WhateverCode range still counts from the end';
+    my $big = 5;
+    is-deeply @a[0 .. $big], (1, 2, 3, Any, Any, Any),
+        'an over-long end still pads with the array default';
+    is-deeply @a[0 ..^ 2], (1, 2), 'the exclusive-end twin is unchanged';
+}
+
+{
+    my @empty;
+    is-deeply @empty[0 .. *], (), 'an unbounded slice of an empty array is empty';
+    is-deeply @empty[0 .. 2], (Any, Any, Any),
+        'a bounded slice of an empty array still pads with Any';
+}
+
+# The literal spelling stays a hard error, the way raku rejects it at compile time.
+{
+    throws-like 'my @el = (4,); @el[0 .. -1]', Exception,
+        'a literal negative subscript is still rejected';
+}
+
+# The hang guard: run the repro in a child process with a wall-clock bound, so a
+# regression fails the test instead of wedging the whole suite.
+doesn't-hang 'my @el = (4,); my $e = -1; say @el[0 .. $e].elems;',
+    'a runtime negative slice end terminates', :out("0\n");


### PR DESCRIPTION
## Problem

```raku
my @el = (4,); my $e = -1; say @el[0 .. $e].raku;
# mutsu: hangs (killed at `timeout 10`)
# raku:  ()
```

The `Range` itself was always correct — `(0 .. $e).elems` is `0` and
`(0 .. $e).raku` is `0..-1` — so the fault was entirely in the **subscript**,
and only when the endpoint arrived through a *variable*: the literal spelling
`@el[0 .. -1]` is rejected up front by both mutsu and raku ("Unsupported use of
a negative -1 subscript to index from the end"), which is why the hole survived
unnoticed.

A hang is worse than a wrong answer — it takes the whole process out with no
diagnostic — and `0 .. $n-1` over a computed length is one of the most common
slice idioms there is.

## Root cause

The inclusive-range subscript arms computed their end index as
`b.max(-1) as usize`. For a negative `b` that is `(-1) as usize`, i.e.
`usize::MAX`, and the slice loop then ran `for i in start..=usize::MAX`,
resolving each out-of-bounds slot to the container's typed default and pushing
it.

Three arms in `src/vm/vm_var_index_ops.rs` carried the same cast:

| arm | symptom |
|---|---|
| `Array` × `Range` | hung |
| `Seq` × `Range` | saved from the runaway loop by a `min(len - 1)` clamp, so it answered the **whole** list where raku answers `()` |
| `Range`-target × `Range` | same |

## The fix

All three now go through one helper, `Interpreter::inclusive_range_window`,
which resolves `a .. b` to a half-open `[start, end)` window entirely in `i64`
before any `usize` cast, and answers `None` when the range is empty. Doing the
comparison in signed arithmetic is what makes a negative end simply *empty*
instead of enormous.

Two behaviours fall out of routing every arm through the one helper, both
moving mutsu toward raku:

- `@a[0 .. *]` on an **empty** array is now `()`. The old unbounded-end
  expression was `items.len().saturating_sub(1)` used as an *inclusive* end, so
  a zero-length array produced the window `0..=0` and the slice answered
  `(Any,)`.
- A negative slice **start** now throws `X::OutOfRange` ("Index out of range.
  Is: -1, should be in 0..^Inf") instead of silently clamping to 0. That is what
  raku does — `my $s = -1; @a[$s .. 2]` is an error there, exactly as a plain
  `@a[$s]` read is — where mutsu answered a quietly wrong `(1, 2, 3)`.

## Tests

`t/array-slice-runtime-negative-range.t` (23 assertions) covers the reported
repro, the `List`/`Seq`/itemized-array/`comb`/`Range`-target and associative
twins, the negative-start throws, and the ordinary slice shapes (`Any` padding,
unbounded end, `*-1` counting, the exclusive-end twin, the literal-negative
rejection) as controls. The last assertion is a `Test::Util` `doesn't-hang` run
of the original repro in a child process, so a regression fails the test instead
of wedging the suite.

**The whole file also passes unmodified under real Rakudo**
(`prove -e raku t/array-slice-runtime-negative-range.t` → 23/23), so the pin
encodes raku's behaviour rather than mutsu's.

`make test` PASS (3838 files, 40559 tests). `make roast`: the only failures are
this container's environment — the `chmod`-based `.r`/`.w` file tests
(`roast/6.c/S32-io/file-tests.t`, `roast/S16-filehandles/filetest.t`) cannot
fail as `uid 0`, and `roast/S32-io/IO-Socket-Async.t` times out on the sandboxed
network. None of them touches a range subscript.

Closes #7578

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013c4HPfEPoHvhg6JwWQpQhU


---
_Generated by [Claude Code](https://claude.ai/code/session_013c4HPfEPoHvhg6JwWQpQhU)_