### PR TITLE
fix(numeric): roots answers Rakudo's complex roots, and Complex.Str reuses Num.Str

### DIFF
--- a/news/2026-09/roots-answers-complex-roots.md
+++ b/news/2026-09/roots-answers-complex-roots.md
@@ -1,0 +1,84 @@
+# `Numeric.roots` answers Rakudo's complex roots, and `Complex.Str` stops inventing a second Num format
+
+`4.roots(2)` answered `(2e0, -2e0)` where Rakudo answers
+`(2+0i, -2+2.4492935982947064e-16i)`. The divergence was recorded in
+[#7544](https://github.com/tokuhirom/mutsu/issues/7544)'s "plain-call
+divergences" section, found by the native-method adverb sweep: the sweep can
+only compare the `:qqzz9` arm against the plain arm, so a method whose *plain*
+answer is already wrong shows up there without being a named-argument bug at
+all.
+
+## Two mechanisms, both in the rendering of a root
+
+### `compute_roots` collapsed a root back to a `Num`
+
+`src/builtins/methods_narg/numeric.rs` computed the polar form correctly and
+then undid it:
+
+```rust
+if ii.abs() < 1e-12 {
+    roots.push(Value::num(rr));
+} else {
+    roots.push(Value::complex(rr, ii));
+}
+```
+
+The intent — "this root is real, so say so" — is exactly what Rakudo does not
+do. `Numeric.roots` is
+
+```raku
+(^$n).map: { Complex.new-from-polar($mag ** (1/$n), ($angle + $_ * 2 * pi) / $n) }
+```
+
+so every element is a `Complex`, epsilon imaginary part and all; the
+`2.4492935982947064e-16` in `4.roots(2)` *is* `2 * sin(pi)`, and Rakudo prints
+it. Removing the collapse also removed the need for the zero special case:
+`0.roots(2)` falls out of the general formula as `(0+0i -0+0i)`, negative zero
+included, which is what Rakudo prints.
+
+Aligning the function surfaced three more scalar-vs-list divergences in the same
+routine, all now matching:
+
+| | mutsu before | mutsu / raku now |
+|---|---|---|
+| `4.roots(0)`, `4.roots(-1)` | `(NaN)` — a one-element list | `NaN` — a bare `Num` |
+| `4.roots(1)` | `(4)` | `4+0i` — the receiver as a `Complex` |
+| `Inf.roots(2)`, `NaN.roots(2)`, `(Inf+1i).roots(2)` | `(Inf+NaN\i -Inf+Inf\i)` and friends | `NaN` |
+
+The Inf/NaN case is a guard on the *polar magnitude*, not on the receiver's
+type, which is why `Inf.roots(1)` still answers `Inf+0i`: the `$n == 1` return
+happens first.
+
+`roast/S32-num/roots.t` (whitelisted) keeps passing throughout — it writes every
+case as `my @l = roots(...)`, and assigning a scalar `NaN` into an `@` variable
+gives the same one-element array it was already asserting.
+
+### `Complex.Str` had its own float formatter
+
+The second half only became visible once the roots were `Complex`:
+`say 6.123233995736766e-17` printed `6.123233995736766e-17` but
+`say 6.123233995736766e-17 + 1i` printed
+`0.00000000000000006123233995736766+1i`.
+
+`format_complex` in `src/value/display.rs` carried a private `fmt_num` that
+predated the `Num` arm of `to_string_value` and never learned its
+scientific-notation threshold — so `Complex.new(1e16, 2)` rendered
+`10000000000000000+2i` and `Complex.new(1, 1e20)` rendered `1+1e20i` (no
+exponent sign). Rakudo's `Complex.Str` is literally
+`$!re ~ sign ~ $!im.abs ~ 'i'`, i.e. two `Num.Str` calls, so there is nothing
+for a second formatter to do.
+
+The `Num` arm is now `pub fn format_num` and `format_complex` calls it. That is
+the whole fix, and it makes the threshold unable to drift again.
+
+## Pin
+
+`t/roots-are-complex.t`, 26 assertions, passing under `raku` unmodified. It
+covers the element type and rendering of the list form, the three scalar
+returns, and the three `Complex.Str` component cases that had their own
+formatter.
+
+## Not done
+
+`4.roots(2).^name` is `List` in mutsu and `Seq` in Rakudo. That is the return
+container, not the roots, and it is untouched here.

--- a/src/builtins/methods_narg/numeric.rs
+++ b/src/builtins/methods_narg/numeric.rs
@@ -93,8 +93,22 @@ pub(crate) fn int_to_subscript(n: i64) -> String {
 // ── 1-arg method dispatch ────────────────────────────────────────────
 /// Try to dispatch a 1-argument method call on a Value.
 /// Compute the nth roots of a number. Used by both the `.roots` method and the
-/// `roots()` builtin function. Handles edge cases: n <= 0 returns `NaN`,
-/// NaN/Inf inputs with n=1 return the input as Complex.
+/// `roots()` builtin function.
+///
+/// Rakudo's `Numeric.roots` is `(^$n).map: { Complex.new-from-polar($mag ** (1/$n),
+/// ($angle + $_ * 2 * pi) / $n) }`, guarded by three scalar early returns, and
+/// this mirrors it exactly:
+///
+/// - `$n < 1` answers a bare `NaN` (a `Num`, not a one-element list);
+/// - `$n == 1` answers the receiver coerced to `Complex` (`4.roots(1)` is
+///   `4+0i`, `Inf.roots(1)` is `Inf+0i`);
+/// - a non-finite polar magnitude or angle answers a bare `NaN`
+///   (`Inf.roots(2)`, `NaN.roots(2)`, `(Inf+1i).roots(2)`).
+///
+/// Every element of the list form is a `Complex`. The tempting cleanup -- turn
+/// a root whose imaginary part is a rounding-error epsilon back into a `Num` --
+/// is what made `4.roots(2)` answer `(2e0, -2e0)` where Rakudo answers
+/// `(2+0i, -2+2.4492935982947064e-16i)`.
 pub(crate) fn compute_roots(target: &Value, n_arg: &Value) -> Value {
     let n_int = match n_arg.view() {
         ValueView::Int(i) => i,
@@ -115,9 +129,9 @@ pub(crate) fn compute_roots(target: &Value, n_arg: &Value) -> Value {
         _ => runtime::to_int(n_arg),
     };
 
-    // n <= 0: return [NaN]
-    if n_int <= 0 {
-        return Value::array(vec![Value::num(f64::NAN)]);
+    // n < 1: a bare NaN, not a list.
+    if n_int < 1 {
+        return Value::num(f64::NAN);
     }
 
     let n = n_int as usize;
@@ -132,62 +146,24 @@ pub(crate) fn compute_roots(target: &Value, n_arg: &Value) -> Value {
         }
     };
 
-    // Handle NaN: return [NaN+0i] (Complex NaN)
-    if re.is_nan() || im.is_nan() {
-        let mut roots = Vec::with_capacity(n);
-        for _ in 0..n {
-            roots.push(Value::complex(f64::NAN, 0.0));
-        }
-        return Value::array(roots);
+    // n == 1: the receiver itself, as a Complex.
+    if n == 1 {
+        return Value::complex(re, im);
     }
 
-    // Handle Inf/-Inf: return [Inf+0i] or [-Inf+0i] etc.
-    if re.is_infinite() || im.is_infinite() {
-        let mut roots = Vec::with_capacity(n);
-        // For n=1, return the value itself as Complex
-        // For n>1, the roots involve Inf which is complex
-        for k in 0..n {
-            if n == 1 {
-                roots.push(Value::complex(re, im));
-            } else {
-                // Infinity roots: magnitude is Inf, angles vary
-                let theta = im.atan2(re);
-                let angle = (theta + 2.0 * std::f64::consts::PI * k as f64) / n as f64;
-                let rr = f64::INFINITY * angle.cos();
-                let ii = f64::INFINITY * angle.sin();
-                if ii.abs() < 1e-12 {
-                    roots.push(Value::num(rr));
-                } else {
-                    roots.push(Value::complex(rr, ii));
-                }
-            }
-        }
-        return Value::array(roots);
-    }
-
-    // Check if target is zero
-    if re == 0.0 && im == 0.0 {
-        let mut roots = Vec::with_capacity(n);
-        for _ in 0..n {
-            roots.push(Value::complex(0.0, 0.0));
-        }
-        return Value::array(roots);
-    }
-
-    // Normal case: compute nth roots using polar form
+    // Polar form. A non-finite magnitude or angle has no meaningful root set;
+    // Rakudo answers a bare NaN rather than a list of Inf/NaN components.
     let r = (re * re + im * im).sqrt();
     let theta = im.atan2(re);
+    if !r.is_finite() || !theta.is_finite() {
+        return Value::num(f64::NAN);
+    }
+
     let mag = r.powf(1.0 / n as f64);
     let mut roots = Vec::with_capacity(n);
     for k in 0..n {
         let angle = (theta + 2.0 * std::f64::consts::PI * k as f64) / n as f64;
-        let rr = mag * angle.cos();
-        let ii = mag * angle.sin();
-        if ii.abs() < 1e-12 {
-            roots.push(Value::num(rr));
-        } else {
-            roots.push(Value::complex(rr, ii));
-        }
+        roots.push(Value::complex(mag * angle.cos(), mag * angle.sin()));
     }
     Value::array(roots)
 }

--- a/src/value/display.rs
+++ b/src/value/display.rs
@@ -188,6 +188,45 @@ fn format_num_scientific(f: f64) -> String {
     }
 }
 
+/// Format a `Num` exactly as Rakudo's `Num.Str` does.
+///
+/// This is the single definition of Raku `Num` rendering: `Complex.Str` builds
+/// its two components with it too (Rakudo's `Complex.Str` is literally
+/// `$!re ~ sign ~ $!im.abs ~ 'i'`), so the scientific-notation threshold cannot
+/// drift between `say 6.1e-17` and `say 6.1e-17 + 1i`.
+pub fn format_num(f: f64) -> String {
+    if f.is_nan() {
+        "NaN".to_string()
+    } else if f.is_infinite() {
+        if f > 0.0 {
+            "Inf".to_string()
+        } else {
+            "-Inf".to_string()
+        }
+    } else if f == 0.0 && f.is_sign_negative() {
+        "-0".to_string()
+    } else if f.fract() == 0.0 {
+        let abs = f.abs();
+        if abs >= 1e15 || (abs != 0.0 && abs < 1e-4) {
+            // Scientific notation for very large/small integer-valued Nums
+            format_num_scientific(f)
+        } else {
+            format!("{}", f as i64)
+        }
+    } else {
+        // Fractional Num: Raku renders in scientific notation once the
+        // magnitude leaves [1e-4, 1e15) -- e.g. `1e-5` prints `1e-05`,
+        // not `0.00001`. Rust's `{}` never switches to scientific, so
+        // apply the same threshold as the integer-valued branch.
+        let abs = f.abs();
+        if !(1e-4..1e15).contains(&abs) {
+            format_num_scientific(f)
+        } else {
+            format!("{}", f)
+        }
+    }
+}
+
 /// Apply tclc (titlecase first char, lowercase rest) to a string.
 pub fn tclc_str(s: &str) -> String {
     let mut result = String::new();
@@ -274,34 +313,10 @@ pub fn wordcase_with(s: &str, mut transform: impl FnMut(&str) -> String) -> Stri
 }
 
 pub fn format_complex(r: f64, i: f64) -> String {
-    /// Format a float component of a Complex, preserving the sign of negative zero.
-    fn fmt_num(v: f64) -> String {
-        if v.is_nan() {
-            "NaN".to_string()
-        } else if v.is_infinite() {
-            if v.is_sign_positive() {
-                "Inf".to_string()
-            } else {
-                "-Inf".to_string()
-            }
-        } else if v.fract() == 0.0 {
-            // Preserve sign of -0.0
-            // Check if value fits in i64 range before casting (large floats saturate)
-            let abs_v = v.abs();
-            if abs_v <= i64::MAX as f64 {
-                if v.is_sign_negative() {
-                    format!("-{}", (-v) as i64)
-                } else {
-                    format!("{}", v as i64)
-                }
-            } else {
-                // Large float that doesn't fit in i64: use scientific notation
-                format!("{:e}", v)
-            }
-        } else {
-            format!("{}", v)
-        }
-    }
+    // A Complex component renders exactly as the `Num` it is: Rakudo's
+    // `Complex.Str` concatenates `$!re.Str` and `$!im.abs.Str`, so the
+    // scientific-notation threshold is `Num.Str`'s, not a second one.
+    let fmt_num = format_num;
     // Use \i notation when imaginary part is Inf, -Inf, or NaN
     let imag_special = i.is_infinite() || i.is_nan();
     let suffix = if imag_special { "\\i" } else { "i" };
@@ -402,38 +417,7 @@ impl Value {
             ValueView::RakuAst(node) => crate::rakuast::node_gist(node),
             ValueView::Int(i) => i.to_string(),
             ValueView::BigInt(n) => n.to_string(),
-            ValueView::Num(f) => {
-                if f.is_nan() {
-                    "NaN".to_string()
-                } else if f.is_infinite() {
-                    if f > 0.0 {
-                        "Inf".to_string()
-                    } else {
-                        "-Inf".to_string()
-                    }
-                } else if f == 0.0 && f.is_sign_negative() {
-                    "-0".to_string()
-                } else if f.fract() == 0.0 && f.is_finite() {
-                    let abs = f.abs();
-                    if abs >= 1e15 || (abs != 0.0 && abs < 1e-4) {
-                        // Scientific notation for very large/small integer-valued Nums
-                        format_num_scientific(f)
-                    } else {
-                        format!("{}", f as i64)
-                    }
-                } else {
-                    // Fractional Num: Raku renders in scientific notation once the
-                    // magnitude leaves [1e-4, 1e15) — e.g. `1e-5` prints `1e-05`,
-                    // not `0.00001`. Rust's `{}` never switches to scientific, so
-                    // apply the same threshold as the integer-valued branch.
-                    let abs = f.abs();
-                    if !(1e-4..1e15).contains(&abs) {
-                        format_num_scientific(f)
-                    } else {
-                        format!("{}", f)
-                    }
-                }
-            }
+            ValueView::Num(f) => format_num(f),
             ValueView::Str(s) => (**s).clone(),
             ValueView::Bool(true) => "True".to_string(),
             ValueView::Bool(false) => "False".to_string(),

--- a/t/roots-are-complex.t
+++ b/t/roots-are-complex.t
@@ -1,0 +1,60 @@
+use Test;
+
+# `Numeric.roots` mirrors Rakudo's
+#   (^$n).map: { Complex.new-from-polar($mag ** (1/$n), ($angle + $_*2*pi)/$n) }
+# guarded by three scalar early returns. Every assertion below was verified
+# against Rakudo, and this file passes under `raku` unmodified.
+
+plan 26;
+
+# --- Every element of the list form is a Complex -----------------------------
+# The regression this pins: collapsing a root whose imaginary part is a
+# rounding-error epsilon back to a Num made `4.roots(2)` answer `(2e0, -2e0)`.
+
+is 4.roots(2).elems, 2, '4.roots(2) has two roots';
+is 4.roots(2)[0].WHAT.^name, 'Complex', 'first root of 4 is a Complex';
+is 4.roots(2)[1].WHAT.^name, 'Complex', 'second root of 4 is a Complex';
+is 4.roots(2).Str, '2+0i -2+2.4492935982947064e-16i', '4.roots(2) renders as Rakudo does';
+
+is 4.roots(3).elems, 3, '4.roots(3) has three roots';
+ok 4.roots(3).all ~~ Complex, 'every cube root of 4 is a Complex';
+
+is 1.roots(4)[0].WHAT.^name, 'Complex', 'a root that is exactly real is still a Complex';
+is 1.roots(4).Str,
+   '1+0i 6.123233995736766e-17+1i -1+1.2246467991473532e-16i -1.8369701987210297e-16-1i',
+   '1.roots(4) renders as Rakudo does';
+
+# Zero is not special-cased: the general polar formula produces the -0 real part.
+is 0.roots(2).Str, '0+0i -0+0i', '0.roots(2) keeps the negative zero of the general formula';
+
+# --- n < 1 answers a bare NaN, not a one-element list ------------------------
+
+ok 4.roots(0) ~~ NaN, '4.roots(0) is NaN';
+is 4.roots(0).WHAT.^name, 'Num', '4.roots(0) is a bare Num, not a list';
+ok 4.roots(-1) ~~ NaN, '4.roots(-1) is NaN';
+is 4.roots(-1).WHAT.^name, 'Num', '4.roots(-1) is a bare Num, not a list';
+
+# --- n == 1 answers the receiver as a Complex --------------------------------
+
+is 4.roots(1).WHAT.^name, 'Complex', '4.roots(1) is a Complex';
+is 4.roots(1).Str, '4+0i', '4.roots(1) is the receiver coerced to Complex';
+is (2+3i).roots(1).Str, '2+3i', 'a Complex receiver comes back unchanged';
+is Inf.roots(1).Str, 'Inf+0i', 'Inf.roots(1) is Inf+0i';
+is NaN.roots(1).Str, 'NaN+0i', 'NaN.roots(1) is NaN+0i';
+
+# --- a non-finite polar magnitude answers a bare NaN -------------------------
+
+ok Inf.roots(2) ~~ NaN, 'Inf.roots(2) is NaN';
+is Inf.roots(2).WHAT.^name, 'Num', 'Inf.roots(2) is a bare Num';
+ok NaN.roots(2) ~~ NaN, 'NaN.roots(2) is NaN';
+ok (Inf+1i).roots(2) ~~ NaN, 'a Complex with an infinite component is NaN';
+ok (NaN+1i).roots(2) ~~ NaN, 'a Complex with a NaN component is NaN';
+
+# --- Complex.Str renders its components exactly as Num.Str -------------------
+# Rakudo's Complex.Str is `$!re ~ sign ~ $!im.abs ~ 'i'`, so the
+# scientific-notation threshold is Num.Str's and cannot drift from it.
+
+is (6.123233995736766e-17 + 1i).Str, '6.123233995736766e-17+1i',
+   'a tiny real part uses scientific notation, as `say 6.1e-17` does';
+is Complex.new(1e16, 2).Str, '1e+16+2i', 'a large integral real part uses scientific notation';
+is Complex.new(1, 1e20).Str, '1+1e+20i', 'a large imaginary part uses scientific notation';


### PR DESCRIPTION
`4.roots(2)` answered `(2e0, -2e0)` where Rakudo answers `(2+0i, -2+2.4492935982947064e-16i)`.

This is the first slice of [#7544](https://github.com/tokuhirom/mutsu/issues/7544)'s **"plain-call divergences the sweep surfaces (not named-argument bugs)"** section. Those land in the native-method adverb sweep only because the sweep compares a method's `:qqzz9` arm against its *plain* arm — a method whose plain answer is already wrong cannot agree with itself either.

## Two mechanisms, both in how a root is rendered

### 1. `compute_roots` undid its own polar computation

```rust
if ii.abs() < 1e-12 {
    roots.push(Value::num(rr));   // "this root is real, so say so"
} else {
    roots.push(Value::complex(rr, ii));
}
```

Rakudo's `Numeric.roots` is

```raku
(^$n).map: { Complex.new-from-polar($mag ** (1/$n), ($angle + $_ * 2 * pi) / $n) }
```

so every element is a `Complex`, epsilon imaginary part included — the `2.4492935982947064e-16` in `4.roots(2)` *is* `2 * sin(pi)`, and Rakudo prints it. Dropping the collapse also made the zero special case unnecessary: `0.roots(2)` falls out of the general formula as `(0+0i -0+0i)`, negative zero and all.

Aligning the routine with Rakudo's three scalar early returns fixed three more divergences in the same function:

| | before | after (= `raku`) |
|---|---|---|
| `4.roots(0)`, `4.roots(-1)` | `(NaN)` — a one-element list | `NaN` — a bare `Num` |
| `4.roots(1)` | `(4)` | `4+0i` — the receiver as a `Complex` |
| `Inf.roots(2)`, `NaN.roots(2)`, `(Inf+1i).roots(2)` | `(Inf+NaN\i -Inf+Inf\i)` &c. | `NaN` |

The Inf/NaN guard is on the *polar magnitude*, not on the receiver's type, which is why `Inf.roots(1)` still answers `Inf+0i` — the `n == 1` return happens first.

### 2. `Complex.Str` had its own float formatter

Only visible once the roots were `Complex`:

```
say 6.123233995736766e-17        # 6.123233995736766e-17            (correct)
say 6.123233995736766e-17 + 1i   # 0.00000000000000006123233995736766+1i
```

`format_complex` carried a private `fmt_num` that predated the `Num` arm of `to_string_value` and never learned its scientific-notation threshold, so `Complex.new(1e16, 2)` rendered `10000000000000000+2i` and `Complex.new(1, 1e20)` rendered `1+1e20i` (no exponent sign).

Rakudo's `Complex.Str` is literally `$!re ~ sign ~ $!im.abs ~ 'i'` — two `Num.Str` calls — so there is nothing for a second formatter to do. The `Num` arm is now `pub fn format_num` and `format_complex` calls it; the threshold can no longer drift between the two.

## Verification

30 probes covering both halves now match `raku` byte for byte, including `4.roots(3)`, `1.roots(4)`, `(-8).roots(3)`, `(1/2).roots(2)`, `"4".roots(2)`, `roots(4,2)`, and the `Complex.Str` component cases.

- **Pin:** `t/roots-are-complex.t`, 26 assertions, **passing under `raku` unmodified**.
- `roast/S32-num/roots.t` (whitelisted) keeps passing — it writes every case as `my @l = roots(...)`, and assigning a scalar `NaN` into an `@` variable gives the same one-element array it was already asserting.
- `make test`: `Files=3838, Tests=40562 … Result: PASS`.
- `make roast`: the only failures are `6.c/S32-io/file-tests.t`, `S16-filehandles/filetest.t` and `S32-io/IO-Socket-Async.t` — this container runs as `root`, so `.r`/`.w`/`.x` assertions that expect a permission denial pass instead. Nothing in the diff touches IO.
- `cargo fmt --all`, `cargo clippy --all-targets -- -D warnings` clean.

## Not done

`4.roots(2).^name` is `List` in mutsu and `Seq` in Rakudo. That is the return container, not the roots, and it is untouched here.

Part of #7544.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012BaTE6YdzbdFki2k3dQqq1

---
_Generated by [Claude Code](https://claude.ai/code/session_012BaTE6YdzbdFki2k3dQqq1)_