### PR TITLE
docs: stop assuming the local dev box — record the local vs remote environment differences

### DIFF
--- a/.agents/skills/cut-release/SKILL.md
+++ b/.agents/skills/cut-release/SKILL.md
@@ -11,6 +11,11 @@ Releases are cut by **one manual trigger** — the `tag-release.yml` workflow. t
 (2026-07-25): there is no release PR, no `CHANGELOG.md`, and no `minor`/`major` version-bump
 label to apply on ordinary PRs.
 
+The `gh` commands below are the local-dev-box form. A remote container has no `gh` — translate them
+with the mapping table in [docs/agent-environments.md](../../../docs/agent-environments.md)
+(`actions_run_trigger` fires the workflow, `actions_list` / `get_job_logs` follow the run,
+`get_release_by_tag` verifies the Release).
+
 ## 1. Pick the version by hand
 
 There is no label-driven *version* automation. Use semver judgment over what actually merged

--- a/.agents/skills/mutsu-ticket-flow/SKILL.md
+++ b/.agents/skills/mutsu-ticket-flow/SKILL.md
@@ -13,6 +13,11 @@ GitHub and in `origin/main`.
 
 Never file, label, comment on or close an issue in any repository other than `tokuhirom/mutsu`.
 
+The `gh` commands below are the local-dev-box form. A remote container has no `gh` — translate them
+with the mapping table in [docs/agent-environments.md](../../../docs/agent-environments.md) and use
+the GitHub MCP tools instead. Every step of the flow is available in both; only the command surface
+differs.
+
 ## Claim the issue before you start
 
 Agents run in parallel, and every one of them posts as the same GitHub user, so a claim has to name

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,4 +128,6 @@ actually mis-filed a mutsu issue before.
 Some sessions have no `gh` (ephemeral remote containers generally do not, and
 direct `api.github.com` calls from them are rejected by the session proxy).
 There, use the GitHub MCP tools with `owner: tokuhirom`, `repo: mutsu` for the
-same steps.
+same steps; `docs/agent-environments.md` maps each `gh` command above to its
+tool, and records the other differences between the two environments (cores,
+disk, provisioning) — `git` itself and every build/test command are identical.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,28 @@ before starting one of these tasks:
 | [`mutsu-ticket-flow`](.agents/skills/mutsu-ticket-flow/SKILL.md) | Working `todo:ticket` issues end-to-end through merge |
 | [`rakuast-implementation`](.agents/skills/rakuast-implementation/SKILL.md) | A RakuAST compatibility slice (`src/rakuast/`, `t/rakuast*.t`) |
 
+## Where this session is running — check before following any shell recipe
+
+Sessions run in **two different environments**, and the recipes in this file are written for the
+first one:
+
+- the maintainer's **local dev box** (an LXC container): `gh` is installed and authenticated, 12
+  cores, a warm `target/`;
+- an **ephemeral remote container** (a session started from the Claude app or Claude Code on the
+  web): **no `gh` at all**, direct `api.github.com` calls rejected by the session proxy, ~4 cores, a
+  fixed disk allowance, reclaimed when the session ends.
+
+`command -v gh || echo remote` settles which one you are in — **check, don't assume**, and don't
+conclude a task is impossible just because the command this file names is missing.
+
+**[docs/agent-environments.md](docs/agent-environments.md) is the single place the differences are
+recorded**: the `gh` → GitHub-MCP-tool mapping table (`create_pull_request`, `pull_request_read`,
+`enable_pr_auto_merge`, `issue_write`, ...; all with `owner: tokuhirom`, `repo: mutsu`), how rust and
+raku get provisioned, how to scale the parallel-agent caps to the box you actually have, and what
+stays identical in both (every `cargo`/`make`/`prove` command, all `git` operations, and the whole PR
+policy). Read it when a recipe below does not fit your environment; the rest of this file names the
+`gh` form only for brevity.
+
 ## Build & run
 
 - Build: `cargo build`
@@ -36,7 +58,7 @@ before starting one of these tasks:
   - Example: `cargo run -- -I lib script.raku`
   - Example: `MUTSULIB=/path/to/lib1:/path/to/lib2 cargo run -- script.raku`
 - Help: `cargo run -- --help`
-- GitHub operations: use the `gh` CLI where it exists. It is already authenticated via `~/.config/gh/hosts.yml`. Do NOT wrap `gh` in `dotenvx run --` — the `GH_TOKEN` in `.env` is stale and would override the working token with bad credentials. **Ephemeral remote containers generally have no `gh` at all**, and direct `api.github.com` calls from them are rejected by the session proxy; there, use the GitHub MCP tools (`list_issues`, `issue_write`, `pull_request_read`, ...) with `owner: tokuhirom`, `repo: mutsu`. Check which is present rather than assuming.
+- GitHub operations: on the local box use the `gh` CLI (already authenticated via `~/.config/gh/hosts.yml`; never wrap it in `dotenvx run --` — the `GH_TOKEN` in `.env` is stale and would override the working token). In a remote container `gh` does not exist and the GitHub MCP tools are the only path — see the mapping table in [docs/agent-environments.md](docs/agent-environments.md). `git` itself is identical in both.
 
 ## Architecture
 
@@ -133,17 +155,17 @@ Executes compiled bytecode. `vm.rs` holds the (unified `Interpreter`) struct, `r
 - PR workflow:
   1. Create a feature branch from main: `git checkout -b <branch-name>`
   2. Commit changes to the feature branch.
-  3. Push and open a PR with `gh pr create`. No version-bump label is needed — the release version is chosen by hand at release time (see "Cutting a release" below), not aggregated from PR labels.
-  4. Enable auto-merge: `gh pr merge --auto --merge <pr-number>`. **Use `--merge`, not `--squash`** — squash merging is disabled on this repository, and `--squash` fails with `GraphQL: Merge method squash merging is not allowed on this repository (enablePullRequestAutoMerge)`, silently leaving auto-merge off. (`--rebase` is also allowed if you prefer it.)
-  5. **Immediately after opening the PR, verify it is mergeable — do NOT assume it is.** Run `gh pr view <pr-number> --json mergeStateStatus,state -q '.state + " / " + .mergeStateStatus'`. If `mergeStateStatus` is `DIRTY` (merge conflict) or CI never registers (no workflow runs appear within ~1 min via `gh run list --branch <branch>`), the branch has conflicted with `main` — a sibling PR almost certainly touched the same file (docs/ledger files are the usual culprit, since slices update the same survey table). **Rebase onto `main` and resolve the conflict before relying on auto-merge:** `git fetch origin main && git rebase origin/main`, resolve, `git rebase --continue`, then `git push --force-with-lease`. A `DIRTY` PR will sit unmerged forever and CI will not run — catching it at open time (not hours later) is the rule. This conflict is frequent when landing many small slices in sequence; expect it.
+  3. Push (`git push -u origin <branch>` — identical in both environments) and open a PR: `gh pr create`, or the `create_pull_request` MCP tool where there is no `gh`. No version-bump label is needed — the release version is chosen by hand at release time (see "Cutting a release" below), not aggregated from PR labels.
+  4. Enable auto-merge: `gh pr merge --auto --merge <pr-number>`, or the `enable_pr_auto_merge` MCP tool with `mergeMethod: "MERGE"`. **Use merge, not squash** — squash merging is disabled on this repository, and `--squash` / `mergeMethod: "SQUASH"` fails with `GraphQL: Merge method squash merging is not allowed on this repository (enablePullRequestAutoMerge)`, silently leaving auto-merge off. (Rebase is also allowed if you prefer it.)
+  5. **Immediately after opening the PR, verify it is mergeable — do NOT assume it is.** Run `gh pr view <pr-number> --json mergeStateStatus,state -q '.state + " / " + .mergeStateStatus'` (remote: `pull_request_read` method `get`, whose payload carries the same `mergeable`/`mergeable_state`). If it is `DIRTY` (merge conflict) or CI never registers (no workflow runs appear within ~1 min via `gh run list --branch <branch>`, or `actions_list` method `list_workflow_runs` filtered to the branch), the branch has conflicted with `main` — a sibling PR almost certainly touched the same file (docs/ledger files are the usual culprit, since slices update the same survey table). **Rebase onto `main` and resolve the conflict before relying on auto-merge:** `git fetch origin main && git rebase origin/main`, resolve, `git rebase --continue`, then `git push --force-with-lease`. A `DIRTY` PR will sit unmerged forever and CI will not run — catching it at open time (not hours later) is the rule. This conflict is frequent when landing many small slices in sequence; expect it.
   6. CI (GitHub Actions) runs `make test` and `make roast`. The PR merges automatically when CI passes.
-     - **A documentation-only PR skips the five build jobs on purpose.** `ci.yml`'s `changes` job classifies the diff (`scripts/ci-docs-only.sh`); when every changed path is under `docs/`, `news/`, `TODO_roast/`, `old-design-docs/`, `raku-doc/`, or is a top-level `*.md`, the `test` / `lint-configs` / `wasm-e2e` / `gc-stress` / `jit-stress` jobs report `skipped`, which counts as success for branch protection. So `gh pr checks` showing those as skipped on a docs PR is **correct**, not a stuck CI — the PR is mergeable. Anything else in the diff (including `.github/**` and any nested `README.md`) runs the full suite. If you add a new documentation directory, add it to the allowlist in that script *and* to `bench.yml`'s `paths-ignore`, and extend the script's `--self-test` cases.
-  7. **Watch the new PR's CI in the background, never foreground-block on it.** Use a `run_in_background` bash poll loop on `gh pr checks <pr-number>` that exits when no check is `pending` (the harness notifies you on completion). Do NOT use foreground `gh pr checks --watch` — it blocks ~13 min and wastes the session. The background watch surfaces a red CI within minutes so you can fix-forward instead of leaving it unnoticed; auto-merge still lands the PR on its own once CI is green. If you have genuinely-independent, non-conflicting work, do it in parallel; in the final stretch there usually isn't any, so the watch itself is the productive thing.
+     - **A documentation-only PR skips the five build jobs on purpose.** `ci.yml`'s `changes` job classifies the diff (`scripts/ci-docs-only.sh`); when every changed path is under `docs/`, `news/`, `TODO_roast/`, `old-design-docs/`, `raku-doc/`, or is a top-level `*.md`, the `test` / `lint-configs` / `wasm-e2e` / `gc-stress` / `jit-stress` jobs report `skipped`, which counts as success for branch protection. So a checks listing showing those as skipped on a docs PR is **correct**, not a stuck CI — the PR is mergeable. Anything else in the diff (including `.github/**` and any nested `README.md`) runs the full suite. If you add a new documentation directory, add it to the allowlist in that script *and* to `bench.yml`'s `paths-ignore`, and extend the script's `--self-test` cases.
+  7. **Watch the new PR's CI in the background, never foreground-block on it.** Locally: a `run_in_background` bash poll loop on `gh pr checks <pr-number>` that exits when no check is `pending` (the harness notifies you on completion). Do NOT use foreground `gh pr checks --watch` — it blocks ~13 min and wastes the session. In a remote container there is no command to loop on: either call `pull_request_read` method `get_check_runs` again after doing other work, or `subscribe_pr_activity` so CI results and review comments wake the session; never `sleep` to wait for CI. The background watch surfaces a red CI within minutes so you can fix-forward instead of leaving it unnoticed; auto-merge still lands the PR on its own once CI is green. If you have genuinely-independent, non-conflicting work, do it in parallel; in the final stretch there usually isn't any, so the watch itself is the productive thing.
   8. **Before going idle, decide the next slice.** Don't wait on the merge with nothing queued. Re-read the relevant ledger/PLAN (`PLAN.md`, `TODO_roast/BLOCKERS.md`) and pick the next concrete unit of work — start it on a fresh branch off `main` if it's independent of the open PR, or lay out options and confirm with the user when the next step is a strategic fork.
 - **Do NOT use stacked PRs (`gh stack`).** Even when the change spans several ordered slices, use the single-branch flow above (one PR, or a sequence of PRs off `main`).
 - If CI fails, fix on the same branch and push again (the background watch notifies you; re-watch after pushing).
   - **Flaky-looking CI failures:** consult the "Known flaky tests" section below before re-triggering. (`roast/S02-names-vars/perl.t`'s historical `Failed: 0` abort no longer reproduces as of 2026-07-05 and was re-whitelisted — treat a new failure there as real first, per the triage protocol.)
-- **Never close a PR without preserving its knowledge.** If a PR has rebase conflicts, rebase it (manually or with an agent that reads the PR diff via `gh pr diff <number>`). The PR diff itself is the best documentation of the change — do not just close it and write a summary. Reopen and fix it, or have a new agent read the diff and re-implement on a fresh branch.
+- **Never close a PR without preserving its knowledge.** If a PR has rebase conflicts, rebase it (manually or with an agent that reads the PR diff via `gh pr diff <number>`, or `pull_request_read` method `get_diff`). The PR diff itself is the best documentation of the change — do not just close it and write a summary. Reopen and fix it, or have a new agent read the diff and re-implement on a fresh branch.
 - Write all documents, code comments, and commit messages in English. This explicitly includes ADRs (`docs/adr/`), everything under `news/` (`news/*.md` and `news/YYYY-MM/*.md`), `PLAN.md`, `TODO_roast/*.md`, design docs under `docs/`, and PR titles/descriptions. Conversing with the user in Japanese does NOT change this — repository artifacts are always English.
 - Do not use `echo`, `cat`, `printf`, or heredoc via Bash to create files. Always use the Write tool.
 - Temporary test scripts must be written to `./tmp/` (project-local, gitignored) using the Write tool. Never write to `/tmp/` or `/tmp/claude-1000/`.
@@ -152,7 +174,7 @@ Executes compiled bytecode. `vm.rs` holds the (unified `Interpreter`) struct, `r
 
 ## Cutting a release
 
-Releases are cut by **one manual trigger** — `gh workflow run tag-release.yml -f version=X.Y.Z` (no `v` prefix). tagpr was removed (2026-07-25): there is no release PR, no `CHANGELOG.md`, and no version-bump label on ordinary PRs. **Keep the `type:` / `type(scope):` PR title convention** — it drives the auto-applied category label and hence the release-note section.
+Releases are cut by **one manual trigger** — `gh workflow run tag-release.yml -f version=X.Y.Z` (no `v` prefix; remotely, `actions_run_trigger` method `run_workflow` with `workflow_id: "tag-release.yml"`, `ref: "main"`, `inputs: {version: "X.Y.Z"}`). tagpr was removed (2026-07-25): there is no release PR, no `CHANGELOG.md`, and no version-bump label on ordinary PRs. **Keep the `type:` / `type(scope):` PR title convention** — it drives the auto-applied category label and hence the release-note section.
 
 Full procedure — version choice, what the two workflows do, how to verify the tarballs/npm/Release actually landed, and the one-time infra prerequisites — is in **`.agents/skills/cut-release/SKILL.md`**. Read it before releasing.
 
@@ -434,11 +456,18 @@ timeout 30 target/debug/mutsu --dump-ast <file>
 
 Agent worktrees under `.claude/worktrees/` and cargo caches under `target/` are the two disk hogs; both are disposable. **Clean up worktrees at least once per hour** during long sessions and between agent batches. The commands — worktree removal, `cargo sweep`, nuking `target/*/incremental` (the dominant offender), and the optional mold + sccache setup — are in **`.agents/skills/reclaim-disk/SKILL.md`**.
 
-## LXC container environment
+In a remote container the writable disk is a **fixed per-session allowance**, so `df` misleads: a
+near-zero "Avail" with a low "Used" means the allowance is spent, not that the machine is broken.
+Deletes still succeed while writes fail, so free space with the same commands and keep going.
 
-This development environment runs inside a dedicated mutsu LXC container. The container may be destroyed at any time — always commit important changes and push PRs promptly.
+## Container environments — both are disposable
 
-### Ephemeral containers self-provision via a SessionStart hook
+Whichever of the two environments you are in (see "Where this session is running" at the top), the
+container may be destroyed at any time: the local LXC container can be rebuilt, and a remote
+container is reclaimed when the session ends. **Always commit important changes and push promptly** —
+anything not on `origin` is not saved.
+
+### Remote containers self-provision via a SessionStart hook
 
 Sessions started from the Claude app / Claude Code on the web get a **fresh container** whose base
 image usually ships a rustc older than this repo compiles under and no `raku` at all. Both are fixed
@@ -451,10 +480,11 @@ local checkout unless `MUTSU_SETUP_FORCE=1` is set — a developer machine is pi
 and owns its own toolchain.
 
 So **do not hand-install rustc or rakudo at the start of a remote session** — it has already
-happened. If a build still fails with `E0658`, the hook did not run (check for its
-`session-start: environment ready` line) and `.claude/skills/rustc-too-old/SKILL.md` applies.
-Whenever a version pin moves, the hook follows it with no edit; only the *sources* of the pins are
-hardcoded, so add a new one there if the repo ever grows a `rust-toolchain.toml`.
+happened, and the `raku` oracle is available there too. If a build still fails with `E0658`, the hook
+did not run (check for its `session-start: environment ready` line) and
+`.claude/skills/rustc-too-old/SKILL.md` applies. Whenever a version pin moves, the hook follows it
+with no edit; only the *sources* of the pins are hardcoded, so add a new one there if the repo ever
+grows a `rust-toolchain.toml`.
 
 ## Test::Util function workout
 
@@ -563,6 +593,7 @@ Each slang has its own grammar rules (e.g., `+` means repetition in Regex slang 
 
 - **Sub-agents are allowed (policy updated 2026-06-15).** Use them where they help — read-only fan-out searches (Explore), independent non-conflicting implementation slices, or sweeping across many files where you only need the conclusion. Be deliberate, not reflexive: Rust builds are expensive and each parallel worktree agent multiplies `cargo build`/`clippy`/`make test` cost and accumulates large `target/` worktrees, so reach for a sub-agent when the task genuinely fans out, not for trivial single-file work you can do inline. Read-only Explore/research agents are cheap; worktree-isolated build agents are not.
 - **Keep at most 3 concurrent agents that build** (user decision, 2026-08-22, tightening the previous cap of 4). This caps agents actually *doing work*, not agents idling on a CI run: an agent whose PR is open and waiting on GitHub Actions uses no local CPU, so it is fine to launch a fresh agent past the nominal cap while others are purely CI-pending (user-confirmed 2026-08-20). **Even so, never exceed 10 agents in total (working + CI-idle combined)** (user-confirmed 2026-08-20) — check `ListAgents` before launching a new one when the count is already high. Read-only Explore/research agents do not count against the build cap. Clean up worktrees per the "Disk cleanup" section.
+  - **That cap is a 12-core number — scale it to the box you actually have.** A remote container has roughly 4 cores, where one building agent is the equivalent and running the work inline (no worktree copy of `target/`) is usually better; see [docs/agent-environments.md](docs/agent-environments.md). The same goes for every wall-clock figure quoted in this file (`make lint` "about 5 minutes", roast timings): budget more on a smaller box, and let CI run the full suite.
   - **Why 3 and not more:** on this 12-core box, five worktree agents drove the load average to 70 with 17 concurrent `rustc` processes, and builds stopped completing. That does not merely slow the batch down — it makes agents *unable to verify their own work*: the `residual-try-cell-eager-seq-reification-divergences` agent had to revert a measured prototype and downgrade to a `Proposed` ADR because its from-scratch `cargo build` never finished under load. Over-parallelising costs correctness, not just wall-clock. When in doubt, check `uptime` and `pgrep -c -x rustc` before launching (a two-digit `rustc` count on 12 cores is already oversubscribed).
 - **Task selection order:**
   1. PLAN.md current quarter priorities
@@ -577,9 +608,9 @@ When working through the issue backlog (as opposed to a single focused task), ru
 - **One fresh agent per ticket, never reused.** Every `todo:deep` / `todo:ticket` issue gets its own `Agent` call with `isolation: "worktree"` and a fully self-contained prompt (the ticket's own content summarized + exact task steps + the PR workflow instructions) — a subagent starts with zero context, so the prompt must stand alone. Once an agent's PR is merged, it is done; do not send it a new, unrelated ticket. The next ticket always gets a brand-new `Agent` call, not a `SendMessage` to a "graduated" one.
 - **Oldest-first, `todo:deep` and `todo:ticket` interleaved, skipping anything labelled `working`.** Pick a small batch (3, per the build-agent cap above) from the oldest open issues each round (**not** `todo:perf` — see the perf rule below), read each issue first to write an informed prompt (don't dispatch blind) — a ticket's stated blast radius/priority often changes what the right prompt asks for (e.g. "check whether this is worth it before implementing" needs a corpus-grep triage step, not a straight implementation).
 - **Every agent claims its issue before it starts**, by the `Claiming:` / re-read / `Releasing:` protocol above. The orchestrator must not hand two agents the same issue; the claim comment is how a *different* session finds that out, and the `working` label is the cheap filter that keeps it out of the next round's listing.
-- **Every agent prompt must include the full PR workflow**, not just "fix the bug": branch off `main`, commit (English, explain root cause, `Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>` trailer), push, `gh pr create`, immediately verify `mergeStateStatus` isn't `DIRTY`, enable auto-merge (`gh pr merge --auto --merge`, never `--squash`), and watch its own CI in the background until green or red — the agent should land its own PR end-to-end, not hand back a diff for the orchestrator to land.
+- **Every agent prompt must include the full PR workflow**, not just "fix the bug": branch off `main`, commit (English, explain root cause, `Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>` trailer), push, open the PR, immediately verify `mergeStateStatus` isn't `DIRTY`, enable auto-merge (merge method, never squash), and watch its own CI until green or red — a subagent inherits this environment, so tell it to use `gh` or the GitHub MCP tools per [docs/agent-environments.md](docs/agent-environments.md) rather than hardcoding one. The agent should land its own PR end-to-end, not hand back a diff for the orchestrator to land.
 - **A ticket does not always end in a code fix.** A large fraction of investigations correctly conclude one of: the ticket is stale (already fixed by something else) — verify, close the issue, write it up in `news/`, and pin a regression test so it can't silently regress; the ticket needs a priority/scope judgment call before any code (e.g. "is deep MOP machinery worth it for one dist?") — grep the available corpus for other consumers of the same gap and let that evidence decide implement-vs-defer; or the real fix is genuinely bigger than the ticket assumed — file a narrower, better-scoped issue (or write an ADR) recording exactly what was learned, rather than forcing an undersized fix through. All of these are legitimate, valuable outcomes — do not treat "closed the ticket without shipping code" as a failure.
-- **The orchestrator monitors PRs directly via `gh`, not by trusting an agent's self-report of "still waiting."** A known harness quirk: a worktree-subagent's own `run_in_background` jobs (its `cargo build`/`prove t/` chains) don't reliably notify it back, so it can report "completed" while stuck re-polling its own build with no new information, burning tokens each cycle. When a `<task-notification>` says "still waiting" with no new evidence, check `gh pr checks <n>` / `git log`/`ps` in that agent's worktree yourself first. If genuinely still building, just wait (schedule the next check, don't nudge). If the agent seems to have lost track of a job that's actually done, `SendMessage` it a nudge with what you observed. If CI has actually finished (merged or clearly green/red) and the agent is *still* polling redundantly, `SendMessage` it to stand down — you're handling it directly.
+- **The orchestrator monitors PRs itself (via `gh` or the MCP tools), not by trusting an agent's self-report of "still waiting."** A known harness quirk: a worktree-subagent's own `run_in_background` jobs (its `cargo build`/`prove t/` chains) don't reliably notify it back, so it can report "completed" while stuck re-polling its own build with no new information, burning tokens each cycle. When a `<task-notification>` says "still waiting" with no new evidence, check the PR's checks (`gh pr checks <n>`, or `pull_request_read` method `get_check_runs`) and `git log`/`ps` in that agent's worktree yourself first. If genuinely still building, just wait (schedule the next check, don't nudge). If the agent seems to have lost track of a job that's actually done, `SendMessage` it a nudge with what you observed. If CI has actually finished (merged or clearly green/red) and the agent is *still* polling redundantly, `SendMessage` it to stand down — you're handling it directly.
 - **Rebase-on-`DIRTY` is common and expected** when several of these agents land PRs in the same rough time window, especially when two tickets touch overlapping files (e.g. two slices of the same ADR). Handle it by messaging the specific agent whose PR went `DIRTY` — it understands its own diff best — asking it to rebase onto `main`, resolve conflicts by composing both changes (not blindly picking one side), re-verify, force-push, and re-arm its CI watch.
 - **`todo:perf` is worked separately, and its implementation agent runs SOLO.** Never put a perf finding into the parallel batch above: two perf agents on one box produce measurements that drift and never converge, and the whole point of a perf finding is a trustworthy number. Batch several `todo:perf` issues into one profiling-heavy session instead, so the profiler setup is amortized. Numbers that end up in a document must come from the bench CI (see "Benchmark numbers in documents come from the bench CI" above), not from that session's local runs.
 - **Clean up worktrees between batches**, once every agent in the round has either merged or been confirmed stopped — `git worktree remove --force` each `.claude/worktrees/agent-*`, then `git worktree prune`.

--- a/docs/agent-environments.md
+++ b/docs/agent-environments.md
@@ -1,0 +1,134 @@
+# Agent environments: the local box vs. a remote container
+
+`CLAUDE.md` is written as a set of shell recipes, and most of them were first written on the
+maintainer's own machine. Sessions actually run in **two different kinds of environment**, and a
+recipe that is exactly right in one is impossible in the other — `gh pr create` does not exist in a
+remote container, and `.claude/worktrees/` sub-agent batches sized for a 12-core box wedge a 4-core
+one. This file is the single place where those differences are recorded. When a recipe elsewhere in
+the repo assumes the wrong environment, translate it with the tables below rather than concluding
+that the task cannot be done.
+
+## Which one am I in?
+
+Check, do not assume — the same repo, the same branch and the same `CLAUDE.md` are present in both.
+
+| Signal | Local dev box | Remote container |
+| --- | --- | --- |
+| `command -v gh` | a path | nothing |
+| `/root/.ccr/` | absent | present (agent proxy CA bundle, `README.md`) |
+| `SessionStart` output | hook is a no-op | `session-start: environment ready` (see below) |
+| `nproc` | 12 | typically 4 |
+| GitHub MCP tools (`mcp__github__*`) | usually absent | present |
+
+One command that settles it: `command -v gh || echo remote`.
+
+**Local dev box** — the dedicated mutsu LXC container the maintainer develops in. `gh` is
+authenticated via `~/.config/gh/hosts.yml`, rustup and rakudo are already installed, `.mise.toml`
+pins the toolchain, and `target/` is warm across sessions.
+
+**Remote container** — a fresh, ephemeral container created for a session started from the Claude
+app or Claude Code on the web. The repo is cloned at session start, there is no `gh`, outbound
+HTTPS goes through a session proxy, and the container is reclaimed when the session ends.
+
+## GitHub operations
+
+On the local box use `gh`. In a remote container `gh` is absent **and direct `api.github.com` calls
+are rejected by the session proxy**, so the GitHub MCP tools are the only path. `GH_TOKEN` /
+`GITHUB_TOKEN` may be set in the environment there — they do not help, do not try to use them with
+`curl`. Note also that on the local box `gh` must never be wrapped in `dotenvx run --`: the
+`GH_TOKEN` in `.env` is stale and would override the working token.
+
+All MCP calls take `owner: tokuhirom`, `repo: mutsu`.
+
+| Operation | Local (`gh`) | Remote (MCP tool) |
+| --- | --- | --- |
+| Open a PR | `gh pr create` | `create_pull_request` |
+| Read a PR | `gh pr view <n> --json ...` | `pull_request_read` method `get` |
+| PR diff | `gh pr diff <n>` | `pull_request_read` method `get_diff` |
+| CI status of a PR | `gh pr checks <n>` | `pull_request_read` method `get_check_runs` (or `get_status`) |
+| Failing job logs | `gh run view --log-failed` | `get_job_logs` with `run_id`, `failed_only: true`, `return_content: true` |
+| Enable auto-merge | `gh pr merge --auto --merge <n>` | `enable_pr_auto_merge` with `mergeMethod: "MERGE"` |
+| List workflow runs | `gh run list --branch <b>` | `actions_list` method `list_workflow_runs`, `workflow_runs_filter: {branch: <b>}` |
+| Dispatch a workflow | `gh workflow run tag-release.yml -f version=X.Y.Z` | `actions_run_trigger` method `run_workflow` (`workflow_id`, `ref`, `inputs`) |
+| File / update an issue | `gh issue create` / `gh issue edit` | `issue_write` method `create` / `update` (labels go in `labels`) |
+| Update the branch from base | `git fetch origin main && git rebase origin/main` | same, or `update_pull_request_branch` |
+| Comment on an issue | `gh issue comment` | `add_issue_comment` |
+| Read issues | `gh issue list --label todo:ticket` | `list_issues` / `issue_read` |
+
+`git` itself works identically in both (the remote container pushes through a git proxy), so
+`git checkout -b`, `git commit`, `git push -u origin <branch>`, `git fetch`, and rebases need no
+translation. **Only the GitHub API layer differs.**
+
+Two consequences worth spelling out:
+
+- **`--merge`, never `--squash`.** Squash merging is disabled on this repository. In MCP terms that
+  is `mergeMethod: "MERGE"` (`"REBASE"` is also allowed); `"SQUASH"` fails and silently leaves
+  auto-merge off.
+- **`issue_write` with `method: "update"` replaces the whole label set.** To add `working` you must
+  pass the issue's existing labels alongside it — read them first, or you silently drop its kind and
+  tier labels. `gh issue edit --add-label` / `--remove-label` have no such hazard. The rest of the
+  issue conventions are in [issue-workflow.md](issue-workflow.md).
+- **Watching CI is a polled read in both worlds.** Locally, a `run_in_background` loop over
+  `gh pr checks`. Remotely there is no shell command to loop on, so either call
+  `pull_request_read`/`get_check_runs` again after doing other work, or use
+  `subscribe_pr_activity` so CI results and review comments wake the session.
+
+## Provisioning: rust and raku
+
+`.claude/hooks/session-start.sh` (registered as a `SessionStart` hook in `.claude/settings.json`)
+installs the highest Rust version the repo declares, runs `.agents/skills/install-raku/install-raku.sh`
+when `raku` is missing, and warms the crate cache with `cargo fetch`. It is idempotent (~0.3s when
+everything is in place) and does nothing on a local checkout unless `MUTSU_SETUP_FORCE=1` is set —
+a developer machine is pinned by `.mise.toml` and owns its own toolchain.
+
+So **do not hand-install rustc or rakudo at the start of a remote session** — it has already
+happened, and `raku` is available as the oracle. If a build still fails with `E0658`, the hook did
+not run (look for its `session-start: environment ready` line) and
+`.claude/skills/rustc-too-old/SKILL.md` applies. When a version pin moves the hook follows it with
+no edit; only the *sources* of the pins are hardcoded, so add a new one there if the repo ever
+grows a `rust-toolchain.toml`.
+
+## Cores, parallelism and sub-agents
+
+The concurrency numbers in `CLAUDE.md` ("at most 3 concurrent agents that build") were measured on
+the 12-core local box. **They are a ratio, not a constant** — on a 4-core remote container, roughly
+one building agent is the equivalent, and running the batch inline in the main session is usually
+better than paying for worktree copies of `target/`. Check `nproc`, `uptime` and `pgrep -c -x rustc`
+before launching anything parallel; a two-digit `rustc` count is oversubscribed on any of these
+boxes.
+
+The same ratio applies to timings quoted anywhere in the repo: `make lint` at "about 5 minutes" and
+the roast suite's wall-clock are 12-core numbers, so budget more on a smaller container and prefer
+running only the specific tests your change touches — the full roast run belongs to CI regardless of
+which environment you are in.
+
+## Disk
+
+Local: `target/` and `.claude/worktrees/` are the two hogs; clean them per
+`.agents/skills/reclaim-disk/SKILL.md`.
+
+Remote: writable disk is a **fixed per-session allowance**, so `df` misleads — "Avail" near zero
+with low "Used" means the allowance is spent, not that the machine is broken. Deletes still succeed
+while writes fail, so on "no space left on device" remove build artifacts, caches and stale clones
+(`target/*/incremental` first, per the same skill) and the freed space is immediately writable.
+
+## Ephemerality
+
+Both environments can disappear: the local LXC container may be destroyed at any time, and a remote
+container is reclaimed after the session ends or goes idle. The rule is the same in both — **commit
+and push promptly**; anything not pushed to a branch on `origin` is not saved. This is also why the
+PR workflow insists an agent lands its own PR end-to-end instead of handing back an unpushed diff.
+
+## What does *not* differ
+
+Do not "adapt" these to the environment — they are the same everywhere, and a remote session is not
+a licence to relax them:
+
+- Build, test and run commands: `cargo build`, `make test`, `make roast`, `prove -e 'target/debug/mutsu'`,
+  `MUTSU_FUDGE=1` for roast, `timeout 30` when running mutsu.
+- The PR policy: never commit to `main`, always a feature branch and a PR, auto-merge with `--merge`,
+  verify the PR is not `DIRTY` right after opening it, fix CI forward on the same branch.
+- Repository artifacts (commits, PR titles/bodies, docs, `news/`, ADRs, code comments) are written
+  in English even when the conversation is in Japanese.
+- Temporary scripts go to the project-local `tmp/`, never to `/tmp/`.
+- Issues and PRs are only ever filed against `tokuhirom/mutsu`.

--- a/docs/issue-workflow.md
+++ b/docs/issue-workflow.md
@@ -161,7 +161,9 @@ happen to hit via a roast test still gets a `todo:deep` issue.)
 Some sessions have the `gh` CLI (already authenticated via
 `~/.config/gh/hosts.yml`); ephemeral remote containers generally do **not**, and
 direct `api.github.com` calls from them are rejected by the proxy. Use whichever
-is actually present:
+is actually present — the full environment comparison and the `gh` → MCP mapping
+for PRs and workflows are in
+[agent-environments.md](agent-environments.md):
 
 ```sh
 # gh, where it exists

--- a/news/2026-09/agent-environments-local-vs-remote.md
+++ b/news/2026-09/agent-environments-local-vs-remote.md
@@ -30,4 +30,5 @@ The differences are now recorded once, in **`docs/agent-environments.md`**:
 a command that half of all sessions do not have (PR open, auto-merge, mergeability check, CI watch,
 PR diff, release workflow dispatch). The two `gh`-heavy skills (`mutsu-ticket-flow`, `cut-release`)
 now say up front that their commands are the local form and point at the mapping table, and
-`docs/issue-workflow.md` — which already handled both worlds for issues — cross-links it.
+`docs/issue-workflow.md` and `AGENTS.md` — which already said in prose that a remote session has no
+`gh` — cross-link it for the command-by-command translation.

--- a/news/2026-09/agent-environments-local-vs-remote.md
+++ b/news/2026-09/agent-environments-local-vs-remote.md
@@ -1,0 +1,33 @@
+# CLAUDE.md no longer assumes the maintainer's local box
+
+`CLAUDE.md` grew up on the maintainer's LXC dev box, so its recipes named `gh` unconditionally,
+quoted 12-core concurrency caps and wall-clock timings, and described "the container" as if there
+were only one. A growing share of sessions now start from the Claude app / Claude Code on the web
+and land in an ephemeral remote container instead, where `gh` does not exist at all, direct
+`api.github.com` calls are rejected by the session proxy, there are roughly four cores, and disk is
+a fixed per-session allowance. The mismatch was a recurring source of confusion: an agent reading
+"open a PR with `gh pr create`" in an environment with no `gh` has to rediscover the GitHub MCP
+tools from scratch, and one reading "at most 3 concurrent building agents" on a 4-core box takes the
+number literally.
+
+The differences are now recorded once, in **`docs/agent-environments.md`**:
+
+- how to tell the two environments apart (`command -v gh || echo remote`, `/root/.ccr/`, `nproc`,
+  the `SessionStart` hook's `environment ready` line);
+- a `gh` → GitHub-MCP mapping table covering the whole PR lifecycle (`create_pull_request`,
+  `pull_request_read` with its `get` / `get_diff` / `get_check_runs` methods, `enable_pr_auto_merge`
+  with `mergeMethod: "MERGE"`, `actions_list`, `actions_run_trigger`, `get_job_logs`, `issue_write`),
+  plus the `issue_write` label-replacement hazard;
+- how rust and raku get provisioned by `.claude/hooks/session-start.sh`, so no session hand-installs
+  a toolchain that is already there;
+- that the parallel-agent caps and quoted timings are 12-core numbers to be scaled, not constants;
+- the remote disk allowance behaviour, where `df` misleads;
+- and, deliberately, a list of what does **not** differ: every `cargo` / `make` / `prove` command,
+  all `git` operations, and the entire PR policy — a remote session is not a licence to relax them.
+
+`CLAUDE.md` itself gained a short "Where this session is running" section near the top and keeps the
+`gh` form inline for brevity, with the MCP equivalent named at each point where it previously implied
+a command that half of all sessions do not have (PR open, auto-merge, mergeability check, CI watch,
+PR diff, release workflow dispatch). The two `gh`-heavy skills (`mutsu-ticket-flow`, `cut-release`)
+now say up front that their commands are the local form and point at the mapping table, and
+`docs/issue-workflow.md` — which already handled both worlds for issues — cross-links it.


### PR DESCRIPTION
`CLAUDE.md` grew up on the maintainer's LXC dev box, and it shows: it names `gh` unconditionally, quotes 12-core concurrency caps and wall-clock timings as if they were constants, and calls the machine "the container" as though there were only one. A large share of sessions now start from the Claude app / Claude Code on the web and land in an ephemeral remote container instead, where **`gh` does not exist at all**, direct `api.github.com` calls are rejected by the session proxy, there are ~4 cores, and disk is a fixed per-session allowance.

The result is confusion at exactly the wrong moments. An agent that reads "open a PR with `gh pr create`" in an environment without `gh` has to rediscover the MCP tool surface from scratch (or concludes the step is impossible); one that reads "at most 3 concurrent building agents" on a 4-core box takes the number literally and wedges the machine.

The fix is not to strip the local recipes — they are correct where they were written — but to **record the differences once** and point at them.

## `docs/agent-environments.md` (new)

The single place the two environments are compared:

- **Which one am I in** — a signal table (`command -v gh`, `/root/.ccr/`, `nproc`, the SessionStart hook's `environment ready` line) and the one-liner that settles it: `command -v gh || echo remote`. Check, don't assume: the same repo, branch and `CLAUDE.md` are present in both.
- **A `gh` → GitHub-MCP mapping table** covering the whole PR lifecycle — `create_pull_request`, `pull_request_read` (`get` / `get_diff` / `get_status` / `get_check_runs`), `enable_pr_auto_merge` with `mergeMethod: "MERGE"`, `actions_list`, `actions_run_trigger`, `get_job_logs`, `issue_write`, `add_issue_comment` — plus the `issue_write` label-replacement hazard already documented in `issue-workflow.md`. Method and parameter names were read off the live tool schemas, not recalled.
- **`git` is not in the table on purpose**: branch, commit, push, fetch and rebase are identical in both (the remote container pushes through a git proxy). Only the GitHub API layer differs, and saying so is half the confusion gone.
- **Provisioning** — `.claude/hooks/session-start.sh` installs rust and raku, so no remote session hand-installs a toolchain that is already there, and the `raku` oracle is available there too.
- **Cores and disk** — the agent caps and quoted timings are 12-core numbers to be *scaled*, and the remote disk allowance makes `df` misleading (near-zero "Avail" with low "Used" means the allowance is spent, and deletes still succeed while writes fail).
- **What does *not* differ** — every `cargo`/`make`/`prove` command, all `git` operations, the whole PR policy, English artifacts, `tmp/` not `/tmp/`, issues only in `tokuhirom/mutsu`. Stated explicitly so a remote session is not read as a licence to relax any of it.

## `CLAUDE.md`

A short "Where this session is running" section near the top, and the MCP equivalent named inline at each point that previously implied a command half the sessions do not have: PR open, auto-merge, the `DIRTY` mergeability check, the CI watch (where a remote session has no shell loop to run — poll `get_check_runs` or `subscribe_pr_activity`, never `sleep`), `gh pr diff`, and the release workflow dispatch. The `gh` form stays inline for brevity; the doc carries the translation.

Two sections stop being local-only: "LXC container environment" becomes "Container environments — both are disposable" (the commit-and-push-promptly rule holds in both, for different reasons), and the sub-agent cap gains an explicit note that 3 is a 12-core number.

## Elsewhere

The two `gh`-heavy skills (`mutsu-ticket-flow`, `cut-release`) say up front that their commands are the local form and point at the table. `docs/issue-workflow.md` and `AGENTS.md` already said in prose that a remote container has no `gh`; both now cross-link the command-by-command mapping.

## Testing

Documentation only — no Rust touched. `scripts/ci-docs-only.sh --classify` returns `true` for this diff, so the five build jobs report `skipped`, which is the intended behaviour (and possible at all because #7596 added `.agents/**` to the allowlist — this PR was rebased onto that).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HPD3SCKSCumVc4UMZCfRBi

---
_Generated by [Claude Code](https://claude.ai/code/session_01HPD3SCKSCumVc4UMZCfRBi)_