### PR TITLE
fix: flatten a finite gather/sequence LazyList into a user slurpy

### DIFF
--- a/news/2026-09/gather-seq-into-a-user-slurpy.md
+++ b/news/2026-09/gather-seq-into-a-user-slurpy.md
@@ -1,0 +1,59 @@
+# A `gather` / sequence-operator Seq arrived as one element in a user slurpy
+
+```raku
+sub f(*@a) { say @a.elems }; f(gather { take $_ for 1..4 });  # mutsu 1, raku 4
+sub f(*@a) { say @a.elems }; f((1, *+1 ... 4));               # mutsu 1, raku 4
+sub f(+@a) { say @a.elems }; f(gather { take $_ for 1..4 });  # mutsu 1, raku 4
+```
+
+This is the surviving half of the "a lazy Seq vanishes into a user slurpy"
+report. The `.map` and `.grep` halves were fixed earlier, when the `*@a` binder
+learned to reify a deferred map/grep `Seq` (the `*@` twin of ADR-0058 step 3b's
+`+@` reification). `gather` and the sequence operator kept failing, and with a
+**different mechanism**: the slurpy was not empty, it held the sequence itself
+as a single element (`@a[0].^name` was `Seq`, `@a[0].elems` was 4).
+
+## Root cause
+
+The binder's flatten arm matches on `arg.view()`, and its iterable arms name
+`Array`, the four `Range` shapes, `GenericRange`, `Seq` and `Slip`. A `gather`
+block and a sequence-operator sequence are neither: they are `ValueView::
+LazyList`. So they fell through to the catch-all `_ => items.push(arg)` and
+became one element.
+
+The single-argument `single_lazy_value` branch above the loop *does* look at
+`LazyList`, but it only fires for a **genuinely lazy** one — deliberately, since
+that is what keeps `f(1..Inf)` from hanging. A finite `gather` reports
+`is_genuinely_lazy()` false (its `closure_seq` has an endpoint), so it fell past
+that branch as well, and then past every iterable arm.
+
+`flatten_into_slurpy` itself could not have covered this: forcing a `gather`
+means running user code, and it is a pure function with no `Interpreter`.
+
+## The fix
+
+Both slurpy binders now force a `LazyList` argument that reports itself finite,
+and flatten the result:
+
+- the `*@a` flatten loop, for every positional argument;
+- the `+@a` single-argument rule, whose `_ => vec![single]` arm boxed the same
+  values (`sub f(+@a) { @a.elems }; f(gather {...})` was also `1`).
+
+Forcing goes through `Interpreter::force_lazy_list_vm`, so a gather body runs
+under the VM the way every other consumer runs it. A genuinely lazy source is
+left alone — the guard is `!ll.is_genuinely_lazy()` — so `f(1..Inf)` still binds
+lazily through the `single_lazy_value` branch and `f((1..Inf).map(*+1))` is
+still reify-on-index rather than a hang.
+
+## Pin
+
+`t/lazy-seq-into-user-slurpy.t` grows from 12 to 31 assertions. Its `todo` on
+the gather row is gone, and it now covers all four producers (`.map`, `.grep`,
+`gather`, the sequence operator) into a `*@a` slurpy, a `+@a` slurpy and a
+non-slurpy `@a`, alone and alongside other arguments — the three paths used to
+disagree with each other. The laziness controls (`.is-lazy` on an infinite
+Range and an infinite sequence, indexing into an infinite `.map` pipe) are the
+guard rail: forcing any of them would hang. The whole file also passes
+unmodified under real Rakudo.
+
+Closes [#7591](https://github.com/tokuhirom/mutsu/issues/7591).

--- a/src/runtime/types/binding_signature.rs
+++ b/src/runtime/types/binding_signature.rs
@@ -933,22 +933,37 @@ impl Interpreter {
                     // empty seed and answered `()`. Tag-probed, so this is one
                     // relaxed check for every other argument shape.
                     self.reify_map_grep_seq(&single)?;
-                    match single.view() {
-                        ValueView::Array(arr, kind) if !kind.is_itemized() => arr.to_vec(),
-                        ValueView::Slip(arr) => arr.to_vec(),
-                        ValueView::Seq(arr) => arr.to_vec(),
-                        ValueView::Range(..)
-                        | ValueView::RangeExcl(..)
-                        | ValueView::RangeExclStart(..)
-                        | ValueView::RangeExclBoth(..)
-                        | ValueView::GenericRange { .. } => {
-                            // A single iterable argument is used as the argument
-                            // list: a finite range flattens to its elements.
-                            let mut items = Vec::new();
-                            flatten_into_slurpy(std::slice::from_ref(&single), &mut items);
-                            items
+                    // The `gather` / sequence-operator twin of the `.map`/`.grep`
+                    // reification above: a finite LazyList is an iterable single
+                    // argument, so it becomes the argument LIST rather than one
+                    // element of it. A genuinely lazy one never gets here -- the
+                    // `single_lazy` branch above binds it whole and `continue`s.
+                    let forced = match single.view() {
+                        ValueView::LazyList(ll) if !ll.is_genuinely_lazy() => {
+                            Some(self.force_lazy_list_vm(&ll)?)
                         }
-                        _ => vec![single.clone()],
+                        _ => None,
+                    };
+                    if let Some(values) = forced {
+                        values
+                    } else {
+                        match single.view() {
+                            ValueView::Array(arr, kind) if !kind.is_itemized() => arr.to_vec(),
+                            ValueView::Slip(arr) => arr.to_vec(),
+                            ValueView::Seq(arr) => arr.to_vec(),
+                            ValueView::Range(..)
+                            | ValueView::RangeExcl(..)
+                            | ValueView::RangeExclStart(..)
+                            | ValueView::RangeExclBoth(..)
+                            | ValueView::GenericRange { .. } => {
+                                // A single iterable argument is used as the argument
+                                // list: a finite range flattens to its elements.
+                                let mut items = Vec::new();
+                                flatten_into_slurpy(std::slice::from_ref(&single), &mut items);
+                                items
+                            }
+                            _ => vec![single.clone()],
+                        }
                     }
                 } else {
                     // Multiple top-level args: the single-argument rule does NOT
@@ -1293,6 +1308,28 @@ impl Interpreter {
                         // hand it the whole `arg`, not its extracted elements, matching
                         // every other call site (`sprintf`, `catdir`, ...).
                         let arg = unwrap_varref_value(raw_arg);
+                        // A `gather` / sequence-operator argument is a LazyList,
+                        // not a `Seq` body, so it matched none of the iterable
+                        // arms below and arrived as ONE slurpy element holding
+                        // the whole sequence. Only a genuinely lazy one may stay
+                        // whole -- and the single-argument case never reaches
+                        // here, the `single_lazy_value` branch above binds it
+                        // lazily and `continue`s -- so a finite lazy source is
+                        // forced through the VM and flattened like any other
+                        // list. Forcing needs the VM (a gather body is user
+                        // code), which is why `flatten_into_slurpy`, a pure
+                        // function, cannot do it itself.
+                        let forced = match arg.view() {
+                            ValueView::LazyList(ll) if !ll.is_genuinely_lazy() => {
+                                Some(self.force_lazy_list_vm(&ll)?)
+                            }
+                            _ => None,
+                        };
+                        if let Some(values) = forced {
+                            flatten_into_slurpy(&values, &mut items);
+                            positional_idx += 1;
+                            continue;
+                        }
                         match arg.view() {
                             ValueView::Pair(..) => {
                                 // Named arg -- leave for *%_ slurpy or post-loop check

--- a/t/lazy-seq-into-user-slurpy.t
+++ b/t/lazy-seq-into-user-slurpy.t
@@ -10,8 +10,15 @@ use Test;
 # still-eager `.grep` — so deferring `grep` turned `*@a` from 3 elements to 0.
 # The discriminator is LAZINESS, not slurpiness: every eager shape below was
 # always correct, and a non-slurpy `@a` receives the Seq intact.
+#
+# A `gather` / sequence-operator argument had a SECOND mechanism: it is a
+# LazyList rather than a `Seq` body, so it matched none of the binder's iterable
+# arms and arrived as ONE slurpy element holding the whole sequence. Forcing it
+# needs the VM -- a gather body is user code -- which is why the pure
+# `flatten_into_slurpy` could not do it. Only a *genuinely* lazy source stays
+# whole, or an infinite one would hang.
 
-plan 12;
+plan 31;
 
 # --- the deferred map/grep Seqs (the bug) ---
 
@@ -40,11 +47,51 @@ is head3(1 .. Inf), '1,2,3', 'control: an infinite lazy source stays lazy in *@a
 sub whole(@a) { @a.elems }
 is whole((1..3).map(* + 0)), 3, 'control: a non-slurpy @a receives the Seq intact';
 
-# --- still open: a `gather` / sequence-operator Seq binds as ONE element ---
-#
-# A different mechanism from the map/grep hole above: the slurpy is not empty,
-# it holds the Seq itself (`@a[0].^name` is `Seq`, `@a[0].elems` is 4), so
-# `flatten_into_slurpy` is declining to flatten it rather than reading an empty
-# seed. Tracked in todo/tickets/lazy-seq-argument-vanishes-into-a-user-slurpy.md.
-todo 'a gather Seq is bound as one element instead of being flattened', 1;
+# --- the gather / sequence-operator producers (the LazyList half) ---
+
 is count(gather { take $_ for 1 .. 4 }), 4, 'gather into *@a flattens';
+is items(gather { take $_ for 1 .. 4 }).raku, '[1, 2, 3, 4]',
+    'gather into *@a flattens to its elements, not to one Seq';
+is count(1, *+1 ... 4), 4, 'the sequence operator into *@a flattens';
+is count(gather {}), 0, 'an empty gather contributes no elements';
+
+# The same four producers alongside other arguments: a slurpy collects every
+# top-level argument, so the flattened sequence has to compose with them.
+is count((gather { take $_ for 1 .. 4 }), 9), 5, 'gather flattens next to a plain argument';
+is count((1, 2), gather { take $_ for 1 .. 4 }), 6, 'gather flattens after a list argument';
+is count((1, *+1 ... 4), 9), 5, 'a sequence flattens next to a plain argument';
+is count((1..3).map(* + 0), gather { take 9 }), 4, 'a .map Seq and a gather flatten together';
+
+# --- the same four producers into a non-slurpy `@a` ---
+#
+# The two paths used to disagree: `@a` reified all four while `*@a` dropped or
+# boxed two of them.
+
+is whole((1..3).grep(* > 0)), 3, 'a .grep Seq into a non-slurpy @a';
+is whole(gather { take $_ for 1 .. 4 }), 4, 'a gather into a non-slurpy @a';
+is whole(1, *+1 ... 4), 4, 'a sequence into a non-slurpy @a';
+
+# --- and into a `+@a` "one-argument rule" slurpy ---
+
+sub plus-count(+@a) { @a.elems }
+
+is plus-count((1..3).map(* + 0)), 3, 'a .map Seq into +@a flattens';
+is plus-count((1..3).grep(* > 0)), 3, 'a .grep Seq into +@a flattens';
+is plus-count(gather { take $_ for 1 .. 4 }), 4, 'a gather into +@a flattens';
+is plus-count(1, *+1 ... 4), 4, 'a sequence into +@a flattens';
+is plus-count((1, 2), gather { take $_ for 1 .. 4 }), 2,
+    'control: +@a does NOT flatten when there is more than one argument';
+
+sub plus-name(+@a) { @a.^name }
+is plus-name(1 ... *), 'List', 'control: an infinite source into +@a stays lazy';
+
+# --- laziness controls: a genuinely lazy source must never be forced ---
+#
+# Forcing any of these would hang, so they are the guard rail on the fix: only a
+# LazyList that reports itself finite is reified into the slurpy.
+
+sub lazily(*@a) { @a.is-lazy }
+
+is head3((1..Inf).map(* + 1)), '2,3,4', 'control: an infinite .map pipe stays lazy in *@a';
+is lazily(1 .. Inf), True, 'control: an infinite Range slurpy still reports .is-lazy';
+is lazily(1 ... *), True, 'control: an infinite sequence slurpy still reports .is-lazy';


### PR DESCRIPTION
## Problem

```raku
sub f(*@a) { say @a.elems }; f(gather { take $_ for 1..4 });  # mutsu 1, raku 4
sub f(*@a) { say @a.elems }; f((1, *+1 ... 4));               # mutsu 1, raku 4
sub f(+@a) { say @a.elems }; f(gather { take $_ for 1..4 });  # mutsu 1, raku 4
```

This is the surviving half of "a lazy `Seq` passed to a user `*@a` slurpy
vanishes". The `.map` and `.grep` halves were fixed when the `*@a` binder
learned to reify a deferred map/grep `Seq` (the `*@` twin of ADR-0058 step 3b's
`+@` reification). `gather` and the sequence operator kept failing, and with a
**different mechanism**: the slurpy was not empty, it held the sequence itself
as a single element.

```raku
sub f(*@a) { say @a[0].^name; say @a[0].elems }; f(gather { take $_ for 1..4 });
# mutsu: Seq / 4
```

## Root cause

The binder's flatten arm matches on `arg.view()`, and its iterable arms name
`Array`, the four `Range` shapes, `GenericRange`, `Seq` and `Slip`. A `gather`
block and a sequence-operator sequence are none of those — they are
`ValueView::LazyList` — so they fell through to the catch-all
`_ => items.push(arg)` and became one element.

The single-argument `single_lazy_value` branch above the loop *does* look at
`LazyList`, but only for a **genuinely lazy** one — deliberately, since that is
what keeps `f(1..Inf)` from hanging. A finite `gather` reports
`is_genuinely_lazy()` false (its `closure_seq` has an endpoint), so it fell past
that branch as well, and then past every iterable arm.

`flatten_into_slurpy` itself could not have covered this: forcing a `gather`
means running user code, and it is a pure function with no `Interpreter`.

## The fix

Both slurpy binders now force a `LazyList` argument that reports itself finite,
and flatten the result:

- the `*@a` flatten loop, for every positional argument;
- the `+@a` single-argument rule, whose `_ => vec[single]` arm boxed the same
  values (`sub f(+@a) { @a.elems }; f(gather {...})` was also `1`).

Forcing goes through `Interpreter::force_lazy_list_vm`, so a gather body runs
under the VM the way every other consumer runs it. The guard is
`!ll.is_genuinely_lazy()`, so a genuinely lazy source is untouched: `f(1..Inf)`
still binds lazily through `single_lazy_value`, and `f((1..Inf).map(*+1))` is
still reify-on-index rather than a hang.

## Measured against raku

| call | before | after | raku |
|---|---|---|---|
| `f(*@a)` ← `gather` | 1 | **4** | 4 |
| `f(*@a)` ← `1, *+1 ... 4` | 1 | **4** | 4 |
| `f(*@a)` ← `gather, 9` | 2 | **5** | 5 |
| `f(*@a)` ← `(1,2), gather` | 3 | **6** | 6 |
| `f(+@a)` ← `gather` | 1 | **4** | 4 |
| `f(+@a)` ← `(1,2), gather` | 2 | 2 | 2 |
| `f(*@a)` ← `1..Inf`, `.is-lazy` | True | True | True |
| `f(*@a)` ← `(1..Inf).map(*+1)`, `@a[5]` | 7 | 7 | 7 |

## Tests

`t/lazy-seq-into-user-slurpy.t` grows from 12 to 31 assertions and drops its
`todo` on the gather row. It now covers all four producers (`.map`, `.grep`,
`gather`, the sequence operator) into a `*@a` slurpy, a `+@a` slurpy and a
non-slurpy `@a`, alone and alongside other arguments — the three paths used to
disagree with each other. The laziness controls (`.is-lazy` on an infinite Range
and an infinite sequence, indexing into an infinite `.map` pipe) are the guard
rail: forcing any of them would hang.

**The whole file also passes unmodified under real Rakudo**
(`prove -e raku t/lazy-seq-into-user-slurpy.t` → 31/31).

`make test` PASS (3838 files, 40578 tests). `make roast`: the failure set is
byte-identical to the pre-change run on this container — the `chmod`-based
`.r`/`.w` file tests (`roast/6.c/S32-io/file-tests.t`,
`roast/S16-filehandles/filetest.t`) cannot fail as `uid 0`, and
`roast/S32-io/IO-Socket-Async.t` times out on the sandboxed network. All three
pass in CI.

Closes #7591

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013c4HPfEPoHvhg6JwWQpQhU


---
_Generated by [Claude Code](https://claude.ai/code/session_013c4HPfEPoHvhg6JwWQpQhU)_