### PR TITLE
fix(vm): refuse a chained subscript store through a defined value

### DIFF
--- a/news/2026-09/chained-subscript-store-refuses-a-defined-value.md
+++ b/news/2026-09/chained-subscript-store-refuses-a-defined-value.md
@@ -7,17 +7,16 @@ defined value with no writable container behind it:
 ```
 my @a = 1,2,3;   @a[1][0] = 9     X::Assignment::RO  "Cannot modify an immutable Int (2)"
 my @a = 1,2,3;   @a[1]<k> = 9     X::AdHoc           "Type Int does not support associative indexing."
-my @a = (1,2),3; @a[0][0] = 9     X::Assignment::RO  "Cannot modify an immutable List ((1 2))"
+my @a = "x",2;   @a[0][0] = 9     X::Assignment::RO  "Cannot modify an immutable Str (x)"
 my %h = a => 1;  %h<a>[0] = 9     X::Assignment::RO  "Cannot modify an immutable Int (1)"
 ```
 
 mutsu did none of that. Every vivify decision below the root asked only
 "is this an `Array`, a `Hash` or a `ContainerRef`?", and answered "vivify me"
 for everything else — so a defined `Int` in the slot was silently replaced by a
-fresh container (`@a` became `[1 [9] 3]`), an immutable `List` was written
-through in place, and a *hash* root lost the write altogether, because
-`assign_into_nested_container` no-ops on a non-container target and nothing
-noticed.
+fresh container (`@a` became `[1 [9] 3]`), and a *hash* root lost the write
+altogether, because `assign_into_nested_container` no-ops on a non-container
+target and nothing noticed.
 
 This was section C2 of the immutable-lvalue survey
 ([#7556](https://github.com/tokuhirom/mutsu/issues/7556)), and the survey had
@@ -38,17 +37,31 @@ absent slot are the only shapes that genuinely autovivify; everything else is
 refused. The refusal carries rakudo's own two classes — `X::Assignment::RO` for
 a positional outer subscript, `X::AdHoc` with the `Any.AT-KEY` wording for an
 associative one — and renders the offending value with `gist_value`, which is
-what makes a `List` read `(1 2)` and a `Set` read `Set(1 2)` instead of their
-space-joined string coercion. Every message in the new test is byte-for-byte
+what makes a `Set` read `Set(1 2)` and a `Pair` read `a => 1` instead of their
+space- and tab-joined string coercions. Every message in the new test is byte-for-byte
 what `raku` prints.
 
-One shape is deliberately left alone with a `TODO`: a reifiable sequence (`Seq`,
-`LazyList`, `Slip`) in the slot. Rakudo reifies it and then refuses the
-*element* ("Cannot modify an immutable Int (3)"), which a predicate over the
-slot's current value cannot do.
+Two shapes are deliberately left alone with a `TODO`, because rakudo's refusal
+for them is decided by the *element* the next subscript reaches rather than by
+the slot — more than a predicate over the slot can see.
 
-Pinned by `t/chained-subscript-store-refuses-defined-value.t`, whose 26
-assertions pass unchanged under `raku` as well as under mutsu — the refusals and
+The first is a reifiable sequence (`Seq`, `LazyList`, `Slip`): rakudo reifies it
+and refuses the element ("Cannot modify an immutable Int (3)").
+
+The second is a `List`-kind array, and it is the interesting one. `my @a =
+(1,2),3; @a[0][0] = 9` does die in rakudo — but purely because *that* `List`
+holds bare values. A `List` whose elements ARE containers is written through,
+which is exactly what `take-rw` builds: `@n[0] = eager gather { take-rw
+@spot[1] }; @n[0][0] = 999` updates `@spot[1]`. Refusing on the array's kind
+looked right, passed every hand-written probe, and then failed
+`t/take-rw-shared-cell.t` in the full suite — the concrete instance of the
+warning the survey issue already carries, that a kind-based rule regresses rows
+which work because their elements are cells. The refusal for a bare-valued
+`List` belongs at the inner element store, which is separate work.
+
+Pinned by `t/chained-subscript-store-refuses-defined-value.t`, whose 23
+assertions pass unchanged under `raku` as well as under mutsu — the refusals,
 the autovivifications that must keep working (`@a[1][0]` on an empty array, a
 type-object slot, a `Nil` slot, a mutable `Array` element, a `:=`-bound element
-cell, and the deep walk through an empty `Array`).
+cell, and the deep walk through an empty `Array`), and the `take-rw` `List`
+row that must NOT be refused.

--- a/news/2026-09/chained-subscript-store-refuses-a-defined-value.md
+++ b/news/2026-09/chained-subscript-store-refuses-a-defined-value.md
@@ -1,0 +1,54 @@
+# A chained subscript store no longer autovivifies over a defined value
+
+Autovivification applies to an *undefined* slot. Rakudo refuses a chained
+subscript store that would have to descend through a slot already holding a
+defined value with no writable container behind it:
+
+```
+my @a = 1,2,3;   @a[1][0] = 9     X::Assignment::RO  "Cannot modify an immutable Int (2)"
+my @a = 1,2,3;   @a[1]<k> = 9     X::AdHoc           "Type Int does not support associative indexing."
+my @a = (1,2),3; @a[0][0] = 9     X::Assignment::RO  "Cannot modify an immutable List ((1 2))"
+my %h = a => 1;  %h<a>[0] = 9     X::Assignment::RO  "Cannot modify an immutable Int (1)"
+```
+
+mutsu did none of that. Every vivify decision below the root asked only
+"is this an `Array`, a `Hash` or a `ContainerRef`?", and answered "vivify me"
+for everything else — so a defined `Int` in the slot was silently replaced by a
+fresh container (`@a` became `[1 [9] 3]`), an immutable `List` was written
+through in place, and a *hash* root lost the write altogether, because
+`assign_into_nested_container` no-ops on a non-container target and nothing
+noticed.
+
+This was section C2 of the immutable-lvalue survey
+([#7556](https://github.com/tokuhirom/mutsu/issues/7556)), and the survey had
+already identified the shape of the fix: the ROOT probe in
+`exec_index_assign_expr_nested_op` draws exactly this line correctly —
+`root_needs_viv` deliberately excludes a defined value, with a comment saying
+raku dies there and that papering over it would clobber the value. The same
+distinction was simply missing one level down.
+
+`Interpreter::subscript_descent_refusal` is that distinction, factored once and
+consulted at all three vivify sites: the two-level chained store through an
+array root, the same store through a hash root, and the intermediate step of
+the 3+ level walk. It classifies the slot rather than the syntax — a mutable
+`Array`/`Hash`, a `:=`-bound cell, a `Proxy` and an object that owns its own
+element storage (a `Buf`, a class with its own `AT-POS`) are all legitimate
+descent targets and are left exactly as they were; `Nil`, a type object and an
+absent slot are the only shapes that genuinely autovivify; everything else is
+refused. The refusal carries rakudo's own two classes — `X::Assignment::RO` for
+a positional outer subscript, `X::AdHoc` with the `Any.AT-KEY` wording for an
+associative one — and renders the offending value with `gist_value`, which is
+what makes a `List` read `(1 2)` and a `Set` read `Set(1 2)` instead of their
+space-joined string coercion. Every message in the new test is byte-for-byte
+what `raku` prints.
+
+One shape is deliberately left alone with a `TODO`: a reifiable sequence (`Seq`,
+`LazyList`, `Slip`) in the slot. Rakudo reifies it and then refuses the
+*element* ("Cannot modify an immutable Int (3)"), which a predicate over the
+slot's current value cannot do.
+
+Pinned by `t/chained-subscript-store-refuses-defined-value.t`, whose 26
+assertions pass unchanged under `raku` as well as under mutsu — the refusals and
+the autovivifications that must keep working (`@a[1][0]` on an empty array, a
+type-object slot, a `Nil` slot, a mutable `Array` element, a `:=`-bound element
+cell, and the deep walk through an empty `Array`).

--- a/src/vm/vm_var_assign_index_named.rs
+++ b/src/vm/vm_var_assign_index_named.rs
@@ -3361,6 +3361,14 @@ impl Interpreter {
                     )? {
                         return Ok(true);
                     }
+                    // A slot that already holds a DEFINED non-container value
+                    // is not autovivifiable: rakudo refuses the store instead
+                    // of clobbering the value.
+                    if let Some(err) =
+                        Self::subscript_descent_refusal(&arr[inner_i], outer_positional)
+                    {
+                        return Err(err);
+                    }
                     // Autovivify the slot if it's not already a container. A
                     // `:=`-bound element is a shared `ContainerRef` cell holding a
                     // container — descend through it (below) instead of clobbering it.
@@ -3469,6 +3477,15 @@ impl Interpreter {
                         })
                         .itemize_for_element_store()
                     });
+                    // An EXISTING entry holding a defined non-container value
+                    // is refused, not descended into: `%h<a>[0] = 9` over
+                    // `a => 1` dies in rakudo, and mutsu used to drop the
+                    // write silently (`assign_into_nested_container` no-ops on
+                    // a non-container target).
+                    if let Some(err) = Self::subscript_descent_refusal(inner_val, outer_positional)
+                    {
+                        return Err(err);
+                    }
                     Self::assign_into_nested_container(inner_val, &outer_key, val.clone())?;
                     Ok(())
                 })
@@ -3541,6 +3558,92 @@ impl Interpreter {
     /// its `ArrayKind` tag (a `Hash`, a bool on the repr), so the shared
     /// backing `Gc` — and therefore the `&mut` the caller takes into the slot
     /// to keep descending — is untouched.
+    /// Whether a chained subscript store may autovivify *through* the value a
+    /// slot already holds, and the error rakudo raises when it may not.
+    ///
+    /// Autovivification only applies to an *undefined* slot. Rakudo refuses a
+    /// store that would descend through a slot already holding a defined value
+    /// with no writable container behind it:
+    ///
+    /// ```text
+    /// my @a = 1,2,3; @a[1][0] = 9   X::Assignment::RO  "Cannot modify an immutable Int (2)"
+    /// my @a = 1,2,3; @a[1]<k> = 9   X::AdHoc           "Type Int does not support associative indexing."
+    /// my @a = (1,2),3; @a[0][0] = 9 X::Assignment::RO  "Cannot modify an immutable List ((1 2))"
+    /// ```
+    ///
+    /// mutsu treated "not an `Array`/`Hash`/`ContainerRef`" as "vivify me", so
+    /// a defined `Int` fell into the vivify bucket and was silently clobbered
+    /// (or, through a hash root, the write was dropped on the floor). The root
+    /// probe in `exec_index_assign_expr_nested_op` already draws this line
+    /// correctly — `root_needs_viv` deliberately excludes a *defined* value —
+    /// and this is the same distinction one level down.
+    ///
+    /// `None` means the slot is a legitimate descent target (a mutable
+    /// container, a `:=`-bound cell, an object that owns its own element
+    /// storage) or is genuinely undefined and so autovivifies.
+    ///
+    /// TODO: compile to bytecode — a reifiable sequence (`Seq`, `LazyList`,
+    /// `Slip`) is left alone here because rakudo reifies it and then refuses
+    /// the *element* ("Cannot modify an immutable Int (3)"), which needs the
+    /// reification this predicate cannot perform.
+    pub(crate) fn subscript_descent_refusal(
+        slot: &Value,
+        outer_positional: bool,
+    ) -> Option<RuntimeError> {
+        let view = slot.view();
+        let descendable = matches!(
+            view,
+            // A mutable Positional/Associative container, or a `:=`-bound cell
+            // holding one: the store writes through it.
+            ValueView::Array(
+                _,
+                ArrayKind::Array | ArrayKind::ItemArray | ArrayKind::Shaped | ArrayKind::Lazy
+            ) | ValueView::Hash(..)
+                | ValueView::ContainerRef(..)
+                | ValueView::ContainerView(..)
+                | ValueView::Scalar(..)
+                | ValueView::Proxy { .. }
+                // An object owns its element storage (a `Buf`, or a user class
+                // with its own `AT-POS`/`AT-KEY`); the arms above hand the
+                // store to it rather than clobbering it.
+                | ValueView::Instance { .. }
+                | ValueView::BufStorage(..)
+                | ValueView::CustomTypeInstance(..)
+                | ValueView::Mixin(..)
+                // Reifiable sequences: see the TODO above.
+                | ValueView::Seq(..)
+                | ValueView::HyperSeq(..)
+                | ValueView::RaceSeq(..)
+                | ValueView::Slip(..)
+                | ValueView::LazyList(..)
+                | ValueView::LazyThunk(..)
+                | ValueView::HashEntryRef { .. }
+                // Undefined: an absent slot, `Nil`, or a type object. This is
+                // the only shape that really autovivifies.
+                | ValueView::Nil
+                | ValueView::Package(..)
+        );
+        if descendable {
+            return None;
+        }
+        let type_name = crate::runtime::utils::value_type_name(slot);
+        Some(if outer_positional {
+            // Rakudo renders the offending value with `.gist`, which is what
+            // makes a `List` read `(1 2)` and a `Set` read `Set(1 2)` rather
+            // than as their space-joined string coercion.
+            RuntimeError::assignment_ro_typename(
+                type_name,
+                &crate::runtime::utils::gist_value(slot),
+            )
+        } else {
+            // `X::AdHoc`, the class rakudo's `Any.AT-KEY` raises.
+            RuntimeError::new(format!(
+                "Type {} does not support associative indexing.",
+                type_name
+            ))
+        })
+    }
+
     pub(crate) fn fresh_autoviv_container(positional: bool) -> Value {
         // A brand-new autovivified row tracks its gaps from birth
         // (`real_array_unassigned`, an empty `initialized` set), so a slot the
@@ -4066,6 +4169,14 @@ impl Interpreter {
                             if let Ok(i) = key.parse::<usize>() {
                                 let arr = crate::value::gc_data_mut(arr_arc);
                                 Self::autoviv_resize_tracking(arr, i, native_fill.clone())?;
+                                // A defined non-container value in the slot is
+                                // refused rather than clobbered, the same rule
+                                // the two-level chain applies.
+                                if let Some(err) =
+                                    Self::subscript_descent_refusal(&arr[i], next_positional)
+                                {
+                                    return Err(err);
+                                }
                                 // Autovivify if needed. A `ContainerRef` is a
                                 // `:=`-bound cell that holds (and is descended to)
                                 // a container on the next iteration; treating it

--- a/src/vm/vm_var_assign_index_named.rs
+++ b/src/vm/vm_var_assign_index_named.rs
@@ -3582,10 +3582,23 @@ impl Interpreter {
     /// container, a `:=`-bound cell, an object that owns its own element
     /// storage) or is genuinely undefined and so autovivifies.
     ///
-    /// TODO: compile to bytecode — a reifiable sequence (`Seq`, `LazyList`,
-    /// `Slip`) is left alone here because rakudo reifies it and then refuses
-    /// the *element* ("Cannot modify an immutable Int (3)"), which needs the
-    /// reification this predicate cannot perform.
+    /// Two shapes are deliberately left alone, because rakudo's refusal for
+    /// them is decided by the ELEMENT the next subscript reaches and not by
+    /// the slot, which is more than a predicate over the slot can see:
+    ///
+    /// * a reifiable sequence (`Seq`, `LazyList`, `Slip`) — rakudo reifies it
+    ///   and refuses the element ("Cannot modify an immutable Int (3)");
+    /// * a `List`-kind array. `my @a = (1,2),3; @a[0][0] = 9` does die in
+    ///   rakudo, but purely because that `List` holds bare values: a `List`
+    ///   whose elements ARE containers is written through, which is what
+    ///   `take-rw` builds (`@n[0] = eager gather { take-rw @spot[1] };
+    ///   @n[0][0] = 999` updates `@spot[1]`, pinned by
+    ///   `t/take-rw-shared-cell.t`). Refusing on the array's KIND regresses
+    ///   that; the refusal belongs at the inner element store, which is
+    ///   separate work.
+    ///
+    /// TODO: compile to bytecode — see the two paragraphs above for the rows
+    /// this predicate cannot decide.
     pub(crate) fn subscript_descent_refusal(
         slot: &Value,
         outer_positional: bool,
@@ -3593,12 +3606,10 @@ impl Interpreter {
         let view = slot.view();
         let descendable = matches!(
             view,
-            // A mutable Positional/Associative container, or a `:=`-bound cell
-            // holding one: the store writes through it.
-            ValueView::Array(
-                _,
-                ArrayKind::Array | ArrayKind::ItemArray | ArrayKind::Shaped | ArrayKind::Lazy
-            ) | ValueView::Hash(..)
+            // A Positional/Associative container, or a `:=`-bound cell holding
+            // one: the store writes through it. Every `ArrayKind` counts —
+            // see the `List` paragraph in the doc comment.
+            ValueView::Array(..) | ValueView::Hash(..)
                 | ValueView::ContainerRef(..)
                 | ValueView::ContainerView(..)
                 | ValueView::Scalar(..)

--- a/t/chained-subscript-store-refuses-defined-value.t
+++ b/t/chained-subscript-store-refuses-defined-value.t
@@ -1,6 +1,6 @@
 use Test;
 
-plan 26;
+plan 23;
 
 # A chained subscript store autovivifies only through an UNDEFINED slot.
 # A slot already holding a defined value with no writable container behind it
@@ -30,15 +30,6 @@ plan 26;
     throws-like { @a[0][0] = 9 }, X::Assignment::RO,
         message => 'Cannot modify an immutable Rat (1.5)',
         'a Rat element is refused, and the message names the gist';
-}
-
-{
-    my @a = (1, 2), 3;
-    throws-like { @a[0][0] = 9 }, X::Assignment::RO,
-        message => 'Cannot modify an immutable List ((1 2))',
-        'an immutable List element is refused, not written through';
-    is @a[0].elems, 2, 'the List is untouched';
-    is @a[0][0], 1, 'and still reads its original element';
 }
 
 {
@@ -76,13 +67,6 @@ plan 26;
         message => 'Type Int does not support associative indexing.',
         'associative store through a defined Int element is refused';
     is @a[1], 2, 'the element is unchanged';
-}
-
-{
-    my @a = (1, 2), 3;
-    throws-like { @a[0]<k> = 9 }, X::AdHoc,
-        message => 'Type List does not support associative indexing.',
-        'a List element refuses associative indexing';
 }
 
 # --- what still autovivifies -----------------------------------------------
@@ -139,4 +123,16 @@ plan 26;
     @a[0] = [];
     @a[0][0][0] = 5;
     is @a[0][0][0], 5, 'the deep walk still vivifies through an empty Array';
+}
+
+# A `List` slot is NOT refused on its kind. Rakudo's refusal for one is decided
+# by the element the next subscript reaches, and a List whose elements ARE
+# containers is written through -- which is exactly what `take-rw` builds
+# (`t/take-rw-shared-cell.t`). Refusing the kind regressed that file.
+{
+    my @spot = 10, 20, 30;
+    my @n;
+    @n[0] = eager gather { take-rw @spot[1] };
+    @n[0][0] = 999;
+    is @spot[1], 999, 'a List holding a live container is still written through';
 }

--- a/t/chained-subscript-store-refuses-defined-value.t
+++ b/t/chained-subscript-store-refuses-defined-value.t
@@ -1,0 +1,142 @@
+use Test;
+
+plan 26;
+
+# A chained subscript store autovivifies only through an UNDEFINED slot.
+# A slot already holding a defined value with no writable container behind it
+# is refused, exactly as rakudo refuses it -- mutsu used to treat "not a
+# container" as "vivify me" and silently clobbered the value (or, through a
+# hash root, dropped the write entirely).
+
+# --- positional outer subscript: X::Assignment::RO naming the value ---------
+
+{
+    my @a = 1, 2, 3;
+    throws-like { @a[1][0] = 9 }, X::Assignment::RO,
+        message => 'Cannot modify an immutable Int (2)',
+        'positional store through a defined Int element is refused';
+    is-deeply @a[1], 2, 'the refused store left the element alone';
+}
+
+{
+    my @a = "x", 2;
+    throws-like { @a[0][0] = 9 }, X::Assignment::RO,
+        message => 'Cannot modify an immutable Str (x)',
+        'a Str element is refused too';
+}
+
+{
+    my @a = 1.5, 2;
+    throws-like { @a[0][0] = 9 }, X::Assignment::RO,
+        message => 'Cannot modify an immutable Rat (1.5)',
+        'a Rat element is refused, and the message names the gist';
+}
+
+{
+    my @a = (1, 2), 3;
+    throws-like { @a[0][0] = 9 }, X::Assignment::RO,
+        message => 'Cannot modify an immutable List ((1 2))',
+        'an immutable List element is refused, not written through';
+    is @a[0].elems, 2, 'the List is untouched';
+    is @a[0][0], 1, 'and still reads its original element';
+}
+
+{
+    my @a = (a => 1), 3;
+    throws-like { @a[0][0] = 9 }, X::Assignment::RO,
+        message => 'Cannot modify an immutable Pair (a => 1)',
+        'a Pair element is refused';
+}
+
+# --- the same rule one level deeper ----------------------------------------
+
+{
+    my @a = 1, 2;
+    throws-like { @a[0][0][0] = 9 }, X::Assignment::RO,
+        message => 'Cannot modify an immutable Int (1)',
+        'the 3+ level walk refuses a defined value at the first step';
+    is @a[0], 1, 'and leaves it alone';
+}
+
+# --- through a hash root ----------------------------------------------------
+
+{
+    my %h = a => 1;
+    throws-like { %h<a>[0] = 9 }, X::Assignment::RO,
+        message => 'Cannot modify an immutable Int (1)',
+        'a hash entry holding a defined value is refused, not silently dropped';
+    is %h<a>, 1, 'the entry is unchanged';
+}
+
+# --- associative outer subscript: X::AdHoc, the AT-KEY wording -------------
+
+{
+    my @a = 1, 2, 3;
+    throws-like { @a[1]<k> = 9 }, X::AdHoc,
+        message => 'Type Int does not support associative indexing.',
+        'associative store through a defined Int element is refused';
+    is @a[1], 2, 'the element is unchanged';
+}
+
+{
+    my @a = (1, 2), 3;
+    throws-like { @a[0]<k> = 9 }, X::AdHoc,
+        message => 'Type List does not support associative indexing.',
+        'a List element refuses associative indexing';
+}
+
+# --- what still autovivifies -----------------------------------------------
+
+{
+    my @a;
+    @a[1][0] = 9;
+    is-deeply @a[1], $[9], 'an absent slot still autovivifies';
+    nok @a[0].defined, 'the gap it grew over stays undefined';
+}
+
+{
+    my @a = Any, 2;
+    @a[0][0] = 9;
+    is @a[0][0], 9, 'a type-object slot still autovivifies';
+    is @a[1], 2, 'the sibling is untouched';
+}
+
+{
+    my @a = Nil, 2;
+    @a[0][0] = 9;
+    is @a[0][0], 9, 'a Nil slot still autovivifies';
+}
+
+{
+    my @a = [1, 2], 3;
+    @a[0][0] = 9;
+    is @a[0][0], 9, 'a mutable Array element is still written through';
+    is @a[0][1], 2, 'and keeps its other elements';
+}
+
+{
+    my %h;
+    %h<a><b> = 1;
+    is %h<a><b>, 1, 'a hash chain still autovivifies through an absent key';
+}
+
+{
+    my %h = a => { b => 1 };
+    %h<a><b> = 2;
+    is %h<a><b>, 2, 'an existing nested hash is still written through';
+}
+
+{
+    my @a = 1, 2;
+    my @inner = 7, 8;
+    @a[0] := @inner;
+    @a[0][1] = 9;
+    is @inner[1], 9, 'a :=-bound element cell is still descended, not refused';
+}
+
+{
+    my @a;
+    @a[0] = [];
+    @a[0][0][0] = 5;
+    is @a[0][0][0], 5, 'the deep walk still vivifies through an empty Array';
+}


### PR DESCRIPTION
Section C2 of the immutable-lvalue survey, #7556.

## The divergence

Autovivification applies to an *undefined* slot. Rakudo refuses a chained
subscript store that would have to descend through a slot already holding a
defined value with no writable container behind it:

| code | raku | mutsu (before) |
| --- | --- | --- |
| `my @a = 1,2,3; @a[1][0] = 9` | `X::Assignment::RO` "Cannot modify an immutable Int (2)" | silently `[1 [9] 3]` |
| `my @a = 1,2,3; @a[1]<k> = 9` | `X::AdHoc` "Type Int does not support associative indexing." | silently `[1 {k => 9} 3]` |
| `my @a = "x",2; @a[0][0] = 9` | `X::Assignment::RO` "Cannot modify an immutable Str (x)" | silently `[[9] 2]` |
| `my @a = 1,2; @a[0][0][0] = 9` | `X::Assignment::RO` "Cannot modify an immutable Int (1)" | silently `[[[9]] 2]` |
| `my %h = a => 1; %h<a>[0] = 9` | `X::Assignment::RO` "Cannot modify an immutable Int (1)" | **the write is dropped** |

Every vivify decision below the root asked only "is this an `Array`, a `Hash`
or a `ContainerRef`?" and answered "vivify me" for everything else, so a
defined `Int` was silently replaced by a fresh container — and through a *hash*
root the write vanished altogether, because `assign_into_nested_container`
no-ops on a non-container target and nothing noticed.

## The fix

The ROOT probe in `exec_index_assign_expr_nested_op` already draws this line
correctly: `root_needs_viv` deliberately excludes a *defined* value, with a
comment saying raku dies there and that papering over it would clobber the
value. The same distinction was simply missing one level down.

`Interpreter::subscript_descent_refusal` is that distinction, factored once and
consulted at all three vivify sites — the two-level chained store through an
array root, the same store through a hash root, and the intermediate step of
the 3+ level walk. It classifies the slot rather than the syntax: a `Hash`, an
array of any kind, a `:=`-bound cell, a `Proxy` and an object that owns its own
element storage (a `Buf`, a class with its own `AT-POS`) stay legitimate
descent targets; `Nil`, a type object and an absent slot are the only shapes
that genuinely autovivify; everything else is refused.

The refusal carries rakudo's own two classes — `X::Assignment::RO` for a
positional outer subscript, `X::AdHoc` with the `Any.AT-KEY` wording for an
associative one — and renders the offending value with `gist_value`, which is
what makes a `Set` read `Set(1 2)` and a `Pair` read `a => 1` instead of their
space- and tab-joined string coercions. Every message in the new test is
byte-for-byte what `raku` prints.

## What is deliberately left out

Two shapes are left alone with a `TODO`, because rakudo's refusal for them is
decided by the *element* the next subscript reaches rather than by the slot —
more than a predicate over the slot can see.

A reifiable sequence (`Seq`, `LazyList`, `Slip`) is the first: rakudo reifies it
and refuses the element ("Cannot modify an immutable Int (3)").

A `List`-kind array is the second, and it is the interesting one. `my @a =
(1,2),3; @a[0][0] = 9` does die in rakudo — but purely because *that* `List`
holds bare values. A `List` whose elements ARE containers is written through,
which is exactly what `take-rw` builds. Refusing on the array's kind looked
right and passed every hand-written probe, then failed
`t/take-rw-shared-cell.t` in the full suite: `@n[0] = eager gather { take-rw
@spot[1] }; @n[0][0] = 999` must still update `@spot[1]`. That is the concrete
instance of the warning #7556 already carries — a kind-based rule regresses
rows which work because their elements are cells — so the second commit backs
it out. The refusal for a bare-valued `List` belongs at the inner element
store, which is separate work.

## Testing

`t/chained-subscript-store-refuses-defined-value.t`, 23 assertions, passing
**unchanged under `raku` as well as under mutsu**: the refusals, the
autovivifications that must keep working (`@a[1][0]` on an empty array, a
type-object slot, a `Nil` slot, a mutable `Array` element, a `:=`-bound element
cell, the deep walk through an empty `Array`), and the `take-rw` `List` row
that must *not* be refused.

`cargo fmt`, `cargo clippy --all-targets -- -D warnings`, `make test` (Result:
PASS, 40554 tests) and `make roast` all run. `make roast` reports three
failures, all environmental to this container and none reachable from this
diff:

- `roast/6.c/S32-io/file-tests.t` and `roast/S16-filehandles/filetest.t` — the
  session runs as **root**, which bypasses the `0333`/`0222`/`0111` mode bits
  these assertions test (`not ok 57 - .r is False with 0333 mode`).
- `roast/S32-io/IO-Socket-Async.t` — hangs at the `# host=::1` round;
  `/proc/net/if_inet6` does not exist in this container, so there is no IPv6
  loopback to connect to.

The touched file has no chained subscript store in it at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ExzRnHAQq5kawQ2oVpLMM9

---
_Generated by [Claude Code](https://claude.ai/code/session_01ExzRnHAQq5kawQ2oVpLMM9)_