### PR TITLE
docs: treat a queue request as a standing instruction, not a negotiation

### DIFF
--- a/.agents/skills/mutsu-ticket-flow/SKILL.md
+++ b/.agents/skills/mutsu-ticket-flow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mutsu-ticket-flow
-description: Implement up to five mutsu backlog issues end-to-end, including deep-ticket triage, PR publication, and verified merges. Use when asked to fix or work through the todo:ticket issue queue.
+description: Implement up to five mutsu backlog issues end-to-end, including deep-ticket triage, PR publication, and verified merges. Use when asked to fix, process or work through todo:ticket issues — the whole queue or a named slice of it, such as the tier:N tickets, the ones with no tier label yet, or "keep opening PRs for them".
 metadata:
   short-description: Deliver up to five mutsu tickets through merge
 ---
@@ -17,6 +17,30 @@ The `gh` commands below are the local-dev-box form. A remote container has no `g
 with the mapping table in [docs/agent-environments.md](../../../docs/agent-environments.md) and use
 the GitHub MCP tools instead. Every step of the flow is available in both; only the command surface
 differs.
+
+## The request is already complete — do not ask what this file settles
+
+A request to work a slice of the queue ("the `todo:ticket` issues with no `tier:*` yet, oldest
+first, open the PRs", "process the `tier:N` tickets and keep the PRs coming") is a standing
+instruction. Everything about *how* is decided here, so asking it back — "one PR per issue?", "shall
+I continue with the next one?", "should I open the PR now?" — costs a round-trip and answers
+nothing. The settled defaults:
+
+| Question you might be tempted to ask | The standing answer |
+| --- | --- |
+| One PR per issue, or one for the batch? | **One issue, one PR.** Never bundle, never stack. |
+| Which issues are in scope? | The filter the user named, oldest-first, skipping `working` / live claims. No `tier:*` is a workable state, not a blocker. |
+| Should I claim it / add `working`? | Yes — the protocol below, every time. |
+| Add a test? Write `news/`? `Closes #NNNN`? | Yes to all three, on every code fix. |
+| May I open the PR / enable auto-merge? | Yes. The request already said so; use the merge method, then watch CI and fix forward. |
+| Shall I continue to the next ticket? | Yes, straight on, up to the five-ticket run cap below. |
+| This one turns out to be deep / already fixed — is that OK? | Yes. Re-triage to `todo:deep` or close it with the evidence; both are legitimate outcomes. |
+
+Ask only when the answer is genuinely the user's — a decision `CLAUDE.md` reserves for them (a
+rung-3 native provider, a new or superseding ADR, weakening a CI gate, dropping a whitelisted test),
+or two readings of the issue that give materially different implementations and cannot be settled
+from its own evidence. Even then: park that one issue, finish the rest of the batch, and raise the
+question in the final report instead of idling the queue.
 
 ## Claim the issue before you start
 
@@ -35,7 +59,10 @@ When you are done — merged, stopped, or blocked — post `Releasing: <your bra
 not the label, is the record.
 
 Process at most **five tickets in one user-triggered run**, and only continue beyond the first
-when the user explicitly asks to process multiple tickets or the queue. Count a ticket when its
+when the user explicitly asks to process multiple tickets or the queue. Any request that names a
+*set* — "the `tier:N` tickets", "the ones with no tier", "the queue", "one after another", "keep the
+PRs coming" — **is** that explicit ask; do not treat it as a single-ticket request and do not ask
+for confirmation before the second one. Count a ticket when its
 re-triage or implementation PR has merged. For a single-ticket request, report the next actionable
 issue number after its verified merge but do not start it. After the fifth verified merge, report
 the next actionable issue number but do not start it. A later user request starts a new run and
@@ -111,8 +138,10 @@ After each verified merge, close the issue (the PR body's `Closes #NNNN` does th
 actually closed), remove any lingering `working` label, and write the accomplishment up as
 `news/YYYY-MM/<slug>.md`.
 
-Then choose the next actionable open `todo:ticket` issue — oldest first, **skipping every issue
-labelled `working`**, plus deliberate non-divergence records, blocked tickets, and items whose
+Then choose the next actionable open issue **from the slice the user named** (the whole
+`todo:ticket` queue, or the `tier:N` / no-tier subset they asked for) — oldest first, **skipping
+every issue labelled `working`** or carrying a live claim, plus deliberate non-divergence records,
+blocked tickets, and items whose
 current evidence makes them deep (relabel the latter through this workflow). Never start a dependent
 ticket before its prerequisite merge is verified. For a single-ticket request, report that issue
 number and stop. Continue only when the user explicitly requested multiple tickets or queue

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,15 @@ For a request to implement a `todo:ticket` issue, use the `mutsu-ticket-flow`
 skill. It defines the required lifecycle through a verified merge and selection
 of the next ticket.
 
+A request to work a *slice* of that queue ("the `tier:N` tickets", "the ones
+with no tier yet", "one after another, open the PRs") is a complete standing
+instruction, not the start of a negotiation. The mechanics are already settled
+— one issue per PR, oldest-first within the named slice, claim before starting,
+a regression test and a `news/` entry per fix, auto-merge enabled, straight on
+to the next after each verified merge — so do not ask them back. Raise only a
+decision that is genuinely the user's, and raise it in the final report while
+the rest of the batch continues.
+
 Self-contained procedures live under `.agents/skills/<name>/SKILL.md` rather
 than in this file; read the matching one before starting such a task. Currently:
 `cut-release` (releasing), `install-raku` (installing the Rakudo oracle when

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -601,6 +601,35 @@ Each slang has its own grammar rules (e.g., `+` means repetition in Regex slang 
   3. Roast tests related to in-progress features
   4. `todo:deep` and `todo:ticket` issues, oldest-first (see "The issue-backlog parallel-agent pipeline" below) — both queues get worked in parallel, not one after the other, so neither backlog grows unchecked while the other drains. **`todo:perf` is NOT part of that pipeline**: perf work is batched into its own profiling-heavy session and its implementation agent runs solo (see below). [docs/triage.md](docs/triage.md) ranks the open backlog so a session can pick without re-reading every issue.
 
+### A queue request is a standing instruction — do not re-ask what is already settled
+
+"Work the `todo:ticket` issues that have no `tier:*` label yet, one after another, and open the
+PRs", "process the `tier:N` tickets, keep the PRs coming", "drain the queue" and the like are
+**complete instructions**, not the opening of a negotiation. How such a run is executed is already
+decided — here and in `.agents/skills/mutsu-ticket-flow/SKILL.md` — so stopping to confirm any of it
+is itself the failure. In particular, these are settled; **never ask them**:
+
+- **One issue, one PR.** Never bundle several issues into one PR, never stack PRs.
+- **Selection** is the filter the user named (a label, a tier, "no tier yet", "the queue"),
+  oldest-first within it, skipping anything carrying `working` or a live claim. A missing `tier:*`
+  is a normal workable state — do not stop to triage tiers first, and do not ask which issues count.
+- **Claim and release every issue** by the `Claiming:` / re-read / `Releasing:` protocol above.
+- **Every code fix carries a focused regression test**, a `news/YYYY-MM/<slug>.md` entry, and
+  `Closes #NNNN` in the PR body.
+- **Open the PR, enable auto-merge (merge method), watch CI, fix forward.** "PR を出して" *is* the
+  permission; asking for it again is asking twice.
+- **Go straight on to the next issue after each verified merge**, up to the run cap in the skill —
+  no "shall I continue?" between tickets.
+- **Re-triaging a ticket to `todo:deep`, or closing it as already fixed, is a legitimate outcome**
+  of the run, not something to seek approval for.
+
+Stop and ask only when the answer is genuinely the user's: the fix would need a decision this file
+reserves for them (a rung-3 native provider, a new or superseding ADR, weakening a CI gate, dropping
+a whitelisted test), or two readings of the issue lead to materially different implementations and
+its own evidence cannot settle it. Even then, prefer to park that one issue, carry on with the rest
+of the batch, and put the question in the run's final report rather than idling the whole queue on
+it.
+
 ### The issue-backlog parallel-agent pipeline
 
 When working through the issue backlog (as opposed to a single focused task), run it as a batch pipeline of disposable, fully-independent worktree agents rather than one long serial session:

--- a/news/2026-09/queue-requests-are-standing-instructions.md
+++ b/news/2026-09/queue-requests-are-standing-instructions.md
@@ -1,0 +1,37 @@
+# A queue request is a standing instruction, not the start of a negotiation
+
+Requests like "work the `todo:ticket` issues that have no `tier:*` label yet, one after another, and
+open the PRs" or "process the `tier:N` tickets, keep the PRs coming" were being answered with a
+round of confirmation questions — *one PR per issue or one for the batch? shall I continue to the
+next one? may I open the PR?* — every one of which the repository had already answered. The cost is
+not just the round-trip: a queue run that pauses after each ticket is not a queue run.
+
+The mechanics are now recorded as settled defaults that must not be asked back, in `CLAUDE.md`
+("A queue request is a standing instruction"), in `.agents/skills/mutsu-ticket-flow/SKILL.md` as a
+table of the tempting question against its standing answer, and in one paragraph of `AGENTS.md`:
+
+- one issue, one PR — never bundled, never stacked;
+- selection is the slice the user named (a label, a tier, "no tier yet", "the queue"), oldest-first
+  within it, skipping anything carrying `working` or a live claim — a missing `tier:*` is a workable
+  state, not a reason to stop and triage tiers first;
+- claim and release every issue by the `Claiming:` / re-read / `Releasing:` protocol;
+- every code fix carries a focused regression test, a `news/YYYY-MM/<slug>.md` entry and
+  `Closes #NNNN`;
+- open the PR, enable auto-merge with the merge method, watch CI and fix forward — "open the PRs" is
+  already the permission;
+- go straight on to the next issue after each verified merge, up to the five-ticket run cap;
+- re-triaging a ticket to `todo:deep` or closing it as already fixed is a legitimate outcome of the
+  run, not something to seek approval for.
+
+The skill's run cap needed the same treatment. It processes at most five tickets per run and
+continues past the first "only when the user explicitly asks to process multiple tickets or the
+queue" — which was being read too narrowly, so a request naming a *set* now explicitly counts as
+that ask. Its "choose the next actionable issue" step also now says to stay inside the named slice
+rather than falling back to the whole `todo:ticket` queue, and its description lists the filtered
+phrasings so the skill actually triggers on them.
+
+The rule is not "never ask". Two things still stop a run: a decision `CLAUDE.md` reserves for the
+user (a rung-3 native provider, a new or superseding ADR, weakening a CI gate, dropping a
+whitelisted test), and an issue whose own evidence cannot settle between two materially different
+implementations. Both are handled by parking that one issue, finishing the rest of the batch, and
+raising the question in the final report — never by idling the whole queue on it.


### PR DESCRIPTION
## The problem

"Work the `todo:ticket` issues that have no `tier:*` label yet, one after another, and open the PRs" / "process the `tier:N` tickets, keep the PRs coming" is a complete instruction. It was being answered with a round of confirmation questions — *one PR per issue or one for the batch? shall I continue to the next one? may I open the PR?* — every one of which this repository had already answered somewhere.

The cost is not only the round-trip. A queue run that pauses for approval after each ticket is not a queue run, and the user has to re-authorize work they already authorized.

## What changes

The mechanics become **settled defaults that must not be asked back**, recorded where each kind of session will actually see them:

- **`CLAUDE.md`** — a new "A queue request is a standing instruction — do not re-ask what is already settled" subsection in the agent-workflow section.
- **`.agents/skills/mutsu-ticket-flow/SKILL.md`** — the same as a table of *the tempting question* against *its standing answer*, since this skill is what such a request invokes.
- **`AGENTS.md`** — one paragraph, so the Codex-side guidance says it too.

The settled points:

| Question | Standing answer |
| --- | --- |
| One PR per issue, or one for the batch? | **One issue, one PR.** Never bundled, never stacked. |
| Which issues are in scope? | The slice the user named (a label, a tier, "no tier yet", "the queue"), oldest-first within it, skipping `working` / live claims. A missing `tier:*` is a workable state, not a reason to stop and triage tiers first. |
| Claim it / add `working`? | Yes, the `Claiming:` / re-read / `Releasing:` protocol, every time. |
| Test? `news/` entry? `Closes #NNNN`? | Yes to all three, on every code fix. |
| May I open the PR / enable auto-merge? | Yes — "open the PRs" *is* the permission. Merge method, then watch CI and fix forward. |
| Shall I continue to the next ticket? | Yes, straight on, up to the five-ticket run cap. |
| It turns out deep / already fixed — OK? | Yes; re-triage to `todo:deep` or close it with the evidence. Both are legitimate outcomes of the run. |

## Two fixes in the skill this exposed

- **The run cap was being read too narrowly.** It continues past the first ticket "only when the user explicitly asks to process multiple tickets or the queue" — so a request naming a *set* now explicitly counts as that ask, rather than being treated as a single-ticket request that must stop and confirm before the second one.
- **Next-ticket selection fell back to the whole queue.** It now stays inside the slice the user named (the `tier:N` subset, the untriaged subset) instead of drifting into unrelated tickets after the first merge. The skill's `description` also lists the filtered phrasings, so it triggers on them at all.

## Not "never ask"

Two things still stop a run: a decision `CLAUDE.md` reserves for the user (a rung-3 native provider, a new or superseding ADR, weakening a CI gate, dropping a whitelisted test), and an issue whose own evidence cannot settle between two materially different implementations. Both are handled by **parking that one issue, finishing the rest of the batch, and raising the question in the final report** — never by idling the whole queue on it.

## Testing

Documentation only — no Rust touched. `scripts/ci-docs-only.sh --classify` returns `true` for this diff, so the build jobs report `skipped`, which is the intended behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HPD3SCKSCumVc4UMZCfRBi

---
_Generated by [Claude Code](https://claude.ai/code/session_01HPD3SCKSCumVc4UMZCfRBi)_