### PR TITLE
fix(vm): make `%h{$composite}++` on an object hash accumulate

### DIFF
--- a/news/2026-09/object-hash-composite-key-increment.md
+++ b/news/2026-09/object-hash-composite-key-increment.md
@@ -1,0 +1,46 @@
+# `%h{$composite}++` on an object hash accumulates again
+
+```raku
+my %p{Any};
+my $p = (3, 4);
+%p{$p} = 1;
+%p{$p}++;
+say %p{$p};      # raku: 2   mutsu (before): 1
+say %p.elems;    # raku: 1   mutsu (before): 2
+```
+
+An object hash keyed by a *composite* value — a `List`, an `Array`, a `Hash` —
+stored the `++` result under a second key. `.elems` reported 2 for what the
+program had written as one entry, and the read still found the original, so the
+increment looked like it had silently done nothing. A scalar key was fine, and
+so were `+=` and `~=`; only the `++`/`--` read-modify-write path diverged.
+
+## Root cause
+
+An itemized aggregate used as a hash subscript is **one key, not a slice**, and
+the read / assign / `:exists` / `:delete` paths all normalize such an index to a
+`Scalar` wrapper before keying — that wrapper is the one shape the slice
+machinery does not read as a list, and it is what makes those four paths agree.
+`exec_inc_dec_index_op` never applied that normalization. So `=` keyed the entry
+by the wrapper's `.WHICH` (`List|3 4`) while `++` keyed it by the raw list node's
+own per-node identity (`Array|1`), and the two landed in different buckets.
+
+`+=`/`~=` were unaffected because a compound assignment routes through the
+element-assign path, which does normalize.
+
+## The fix
+
+`exec_inc_dec_index_op` (`src/vm/vm_var_assign_post_incdec.rs`) now applies the
+same itemized-aggregate → `Scalar` normalization as the element-assign path,
+gated on a hash target so a positional subscript keeps its own rule (an itemized
+list is a single *numeric* index there). The `original_keys` record it writes for
+an object hash also goes through `Interpreter::object_hash_key_value`, so the key
+handed back by `.keys`/`.kv`/`.raku` is de-itemized exactly as the assign path
+records it.
+
+Pinned by `t/object-hash-composite-key-increment.t`, whose 23 assertions pass
+unchanged under rakudo: `++`, `--`, prefix `++`, `+=` and `~=` over `List`,
+itemized `List`, `Array`, `Hash`, instance and scalar keys, plus the
+autovivifying `++` on an absent composite key.
+
+Closes #7538.

--- a/src/vm/vm_var_assign_index_named.rs
+++ b/src/vm/vm_var_assign_index_named.rs
@@ -51,7 +51,7 @@ impl Interpreter {
     /// Unwrapping only the RECORDED value is safe for the round-trip: the
     /// `.WHICH` string the entry is filed under is still computed from the
     /// index as given, so a later `%h{$t}` finds the same entry.
-    fn object_hash_key_value(idx: &Value) -> Value {
+    pub(crate) fn object_hash_key_value(idx: &Value) -> Value {
         // `deref_container` first: the index arrives as the variable's own
         // `ContainerRef` cell when the key was written as `%h{$t}`, and
         // `deitemize_element` looks through a `Scalar`/itemized-kind wrapper,

--- a/src/vm/vm_var_assign_post_incdec.rs
+++ b/src/vm/vm_var_assign_post_incdec.rs
@@ -471,6 +471,30 @@ impl Interpreter {
         } else {
             idx_val
         };
+        // An ITEMIZED aggregate used as a HASH subscript is ONE key, not a
+        // slice, and the read / assign / `:exists` / `:delete` paths all
+        // normalize it to the same `Scalar` wrapper before keying
+        // (`vm_var_assign_index_named.rs`, "An ITEMIZED aggregate used as a
+        // HASH subscript"). The read-modify-write path skipped that
+        // normalization, so an object hash keyed the entry by the raw list
+        // node's per-node `.WHICH` identity while `=` keyed it by the wrapper's
+        // -- `%h{$k}++` landed in a second bucket and never accumulated.
+        // Positional subscripts keep their own rule (an itemized list is a
+        // single NUMERIC index there), so this is gated on a hash target.
+        let idx_val = if matches!(
+            idx_val.view(),
+            ValueView::Array(
+                _,
+                crate::value::ArrayKind::ItemList | crate::value::ArrayKind::ItemArray
+            )
+        ) && matches!(
+            container.as_ref().map(Value::view),
+            Some(ValueView::Hash(_))
+        ) {
+            Value::scalar(idx_val)
+        } else {
+            idx_val
+        };
         // QuantHash element stores are `.WHICH`-keyed (a plain hash/array keeps
         // the display-string key); the element object goes into `original_keys`
         // on the write side below.
@@ -942,9 +966,13 @@ impl Interpreter {
                 // Object hash: remember the key object under its `.WHICH` store
                 // key so `.keys`/`.kv`/`.raku` recover it (`typed_key`).
                 if object_hash_key_type.is_some() {
+                    // Record the key DE-ITEMIZED, exactly as the element-assign
+                    // path does (`Self::object_hash_key_value`): the `Scalar`
+                    // wrapper above is transport for the subscript, not part of
+                    // the key rakudo hands back from `.keys` / `.kv` / `.raku`.
                     data.original_keys
                         .get_or_insert_with(std::collections::HashMap::new)
-                        .insert(key.clone(), idx_val.clone());
+                        .insert(key.clone(), Self::object_hash_key_value(&idx_val));
                 }
                 Value::hash_insert_through(&mut data.map, key.clone(), new_val.clone());
                 true

--- a/t/object-hash-composite-key-increment.t
+++ b/t/object-hash-composite-key-increment.t
@@ -1,0 +1,119 @@
+use v6;
+use Test;
+
+# A `.WHICH`-derived (composite) object-hash key must select the SAME entry for
+# a read-modify-write (`++`, `--`, `+=`, `~=`) as it does for a plain store.
+# It used to key `++` by the raw list node's own identity while `=` keyed it by
+# the canonical `Scalar`-wrapped subscript, so the increment landed in a second
+# bucket and never accumulated (GH #7538).
+
+plan 23;
+
+class IncKey { has $.n }
+
+# --- List key -----------------------------------------------------------
+{
+    my %h{Any};
+    my $k = (3, 4);
+    %h{$k} = 1;
+    %h{$k}++;
+    is %h{$k}, 2, 'List key: ++ accumulates';
+    is %h.elems, 1, 'List key: ++ does not add a second entry';
+    is %h.keys[0].raku, '(3, 4)', 'List key: the recorded key stays de-itemized';
+}
+
+{
+    my %h{Any};
+    my $k = (3, 4);
+    %h{$k} = 1;
+    %h{$k}--;
+    is %h{$k}, 0, 'List key: -- accumulates';
+    is %h.elems, 1, 'List key: -- does not add a second entry';
+}
+
+{
+    my %h{Any};
+    my $k = (3, 4);
+    %h{$k} = 1;
+    ++%h{$k};
+    is %h{$k}, 2, 'List key: prefix ++ accumulates';
+    is %h.elems, 1, 'List key: prefix ++ does not add a second entry';
+}
+
+{
+    my %h{Any};
+    my $k = (3, 4);
+    %h{$k} = 1;
+    %h{$k} += 5;
+    is %h{$k}, 6, 'List key: += accumulates';
+    is %h.elems, 1, 'List key: += does not add a second entry';
+}
+
+{
+    my %h{Any};
+    my $k = (3, 4);
+    %h{$k} = "a";
+    %h{$k} ~= "b";
+    is %h{$k}, "ab", 'List key: ~= accumulates';
+    is %h.elems, 1, 'List key: ~= does not add a second entry';
+}
+
+# --- itemized List key --------------------------------------------------
+{
+    my %h{Any};
+    my $k = $(3, 4);
+    %h{$k} = 1;
+    %h{$k}++;
+    is %h{$k}, 2, 'itemized List key: ++ accumulates';
+    is %h.elems, 1, 'itemized List key: ++ does not add a second entry';
+    is %h.keys[0].raku, '(3, 4)', 'itemized List key: the recorded key stays de-itemized';
+}
+
+# --- Array key ----------------------------------------------------------
+{
+    my %h{Any};
+    my $k = [3, 4];
+    %h{$k} = 1;
+    %h{$k}++;
+    is %h{$k}, 2, 'Array key: ++ accumulates';
+    is %h.elems, 1, 'Array key: ++ does not add a second entry';
+    is %h.keys[0].raku, '[3, 4]', 'Array key: the recorded key keeps its Array shape';
+}
+
+# --- Hash key -----------------------------------------------------------
+{
+    my %h{Any};
+    my $k = { a => 1 };
+    %h{$k} = 1;
+    %h{$k}++;
+    is %h{$k}, 2, 'Hash key: ++ accumulates';
+    is %h.elems, 1, 'Hash key: ++ does not add a second entry';
+}
+
+# --- instance key (already worked; pinned so it stays that way) ---------
+{
+    my %h{Any};
+    my $k = IncKey.new(n => 1);
+    %h{$k} = 1;
+    %h{$k}++;
+    is %h{$k}, 2, 'instance key: ++ accumulates';
+    is %h.elems, 1, 'instance key: ++ does not add a second entry';
+}
+
+# --- scalar key (already worked; pinned so it stays that way) ----------
+{
+    my %h{Any};
+    my $k = 5;
+    %h{$k} = 1;
+    %h{$k}++;
+    is %h{$k}, 2, 'scalar key: ++ accumulates';
+}
+
+# --- autovivifying ++ on an absent composite key -----------------------
+{
+    my %h{Any};
+    my $k = (3, 4);
+    %h{$k}++;
+    %h{$k}++;
+    is %h{$k}, 2, 'List key: ++ autovivifies then accumulates';
+}


### PR DESCRIPTION
An object hash keyed by a composite (`.WHICH`-derived) value — a `List`, an
`Array`, a `Hash` — stored the `++` result under a **second** key:

```raku
my %p{Any}; my $p = (3, 4); %p{$p} = 1; %p{$p}++;
say %p{$p};    # raku: 2   mutsu: 1
say %p.elems;  # raku: 1   mutsu: 2
```

The read still found the original entry, so the increment looked like it had
silently done nothing, and `.elems` reported 2 for what the program had written
as one entry. A scalar key was fine, and so were `+=` and `~=`.

## Root cause

An itemized aggregate used as a hash subscript is **one key, not a slice**, and
the read / assign / `:exists` / `:delete` paths all normalize such an index to a
`Scalar` wrapper before keying — that wrapper is the one shape the slice
machinery does not read as a list, and it is what makes those four paths agree
on the entry.

`exec_inc_dec_index_op` never applied that normalization. Measured with a
breakpoint on both key computations: `=` produced `List|3 4` (the wrapper's
`.WHICH`) while `++` produced `Array|1` (the raw list node's own per-node
identity) — two different buckets. `+=`/`~=` were unaffected because a compound
assignment routes through the element-assign path, which does normalize.

## The fix

`exec_inc_dec_index_op` (`src/vm/vm_var_assign_post_incdec.rs`) applies the same
itemized-aggregate → `Scalar` normalization as the element-assign path, gated on
a hash target so a positional subscript keeps its own rule (an itemized list is
a single *numeric* index there). The `original_keys` record it writes for an
object hash now goes through `Interpreter::object_hash_key_value`, so the key
`.keys`/`.kv`/`.raku` hand back is de-itemized exactly as the assign path
records it.

## Testing

- `t/object-hash-composite-key-increment.t` (new, 23 assertions): `++`, `--`,
  prefix `++`, `+=` and `~=` over `List`, itemized `List`, `Array`, `Hash`,
  instance and scalar keys, plus the autovivifying `++` on an absent composite
  key. The whole file passes **unchanged under rakudo**.
- `t/object-hash-key-is-deitemized.t` and `t/itemized-hash-subscript.t` (the
  neighbouring pins) unmoved.
- `cargo fmt --all`, `cargo clippy --all-targets -- -D warnings`, `make test`
  (3838 files, 40559 tests, all successful).
- `make roast`: the only failures are this container's own environment —
  `6.c/S32-io/file-tests.t` and `S16-filehandles/filetest.t` (`chmod` permission
  assertions, which a uid-0 session bypasses) and an `IO-Socket-Async.t`
  timeout. None of them touch hash keying.

Closes #7538

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LLx8uvQEDwyt9iydWiPgpp

---
_Generated by [Claude Code](https://claude.ai/code/session_01LLx8uvQEDwyt9iydWiPgpp)_