### PR TITLE
feat(mop): Metamodel::Naming and Metamodel::Stashing are composable roles

### DIFF
--- a/news/2026-09/metamodel-naming-and-stashing-are-real-roles.md
+++ b/news/2026-09/metamodel-naming-and-stashing-are-real-roles.md
@@ -1,0 +1,105 @@
+# `Metamodel::Naming` and `Metamodel::Stashing` are composable roles
+
+`Type/Metamodel/Stashing.rakudoc:45`'s worked example — the documented way to
+write a minimal custom HOW — died on its first line:
+
+```raku
+class WithStashHOW
+    does Metamodel::Naming
+    does Metamodel::Stashing
+{ ... }
+```
+
+```
+X::InvalidType: Invalid typename 'Metamodel::Naming'
+```
+
+The `does` clause failed before the class body was read, because neither name
+existed as anything a user could compose. This is the headline of
+[#7551](https://github.com/tokuhirom/mutsu/issues/7551), which by then had had
+three earlier framings closed under it, each measured wrong or already fixed
+before the next was written.
+
+## What was actually missing
+
+Measured first, on `ac24142`, by replacing the two `Metamodel::` roles with
+locally-declared stand-ins. Everything else in the example already worked: the
+`WithStashHOW:_:` invocant smiley, the `:=` bindings, the `Str:D :$name!`
+named parameter, `Metamodel::Primitives.create_type`, role composition, and the
+`$meta.set_name(...)` dispatch. Exactly two things were absent:
+
+1. the two role names, and
+2. any path from a `create_type` type object to a name given to it afterwards —
+   `create_type` mints the type with `Symbol::intern("")` and `.^set_name`'s
+   handler had no `CustomType` arm, so `$type.^name` stayed `CustomType` and
+   `$type.WHO` stayed the empty stash.
+
+## The name is state on the metaobject, not on the type
+
+The obvious implementation — record the name against the type, keyed by its id —
+is wrong, and `raku` says so directly. After the example above:
+
+```
+WithStash.^name                     # WithStash
+WithStashHOW.new.name(WithStash)    # ''      <- a *different* metaobject
+```
+
+Rakudo's `Metamodel::Naming` is `role { has $!name; method name($obj) { $!name } }`:
+the name is an attribute of the **metaobject**, and `$obj` is ignored. `.^name`
+is `$type.HOW.name($type)`, so a type minted by `create_type` reports whatever
+its own `$meta` was told, and a second `WithStashHOW.new` — which was told
+nothing — reports the empty string. A type-keyed store would make those two
+agree, which is a different language.
+
+So the roles are provided as real Raku source in a prelude
+(`METAMODEL_ROLE_PRELUDE`, injected the way `RATIONAL_ROLE_PRELUDE` and the
+`trait_mod:<does>` candidates already are), with no native primitives at all:
+
+```raku
+role GLOBAL::Metamodel::Naming {
+    has $!name;
+    method name(Mu $obj) { $!name // '' }
+    method set_name(Mu $obj, $new_name) { $!name = $new_name }
+}
+role GLOBAL::Metamodel::Stashing {
+    method add_stash(Mu $type_obj) { $type_obj.WHO; $type_obj }
+}
+```
+
+`add_stash` "creates and sets a stash for a type, returning `$type_obj`".
+mutsu's package stashes are created on demand and keyed by the type's name, so
+asking for `.WHO` *is* the creation step — but the method still has to answer the
+type object, because the documented HOW ends `new_type` with it.
+
+The other half is on the Rust side: `.^name`, `.WHO` and `.WHAT` on a
+`ValueView::CustomType` now ask the type's own metaobject
+(`Interpreter::custom_type_how_name`), which is Rakudo's protocol taken
+literally rather than a new store. A HOW that composes no naming role has no
+`name` method to ask, and the type keeps the name it was minted with — so
+nothing that does not opt in changes. `.^set_name` on such a type object is
+routed to the metaobject's `set_name` for the same reason.
+
+One fidelity detail worth keeping: an un-named `create_type` type object reports
+the **empty string**, not a placeholder, because that is what its metaobject
+answers. `None` from `custom_type_how_name` means only "this HOW has no name to
+give", which is a different thing from "the name is empty".
+
+## Verification
+
+`t/metamodel-naming-stashing.t`, 14 assertions, passing under `raku` unmodified.
+Beyond the doc's example it pins the metaobject-scoping (`WithStashHOW.new` knows
+no name), the empty-string answer for an un-named type, the `set_name`/`name`
+round trip, `add_stash`'s return value, `Metamodel::Naming` composing on its own,
+and that a builtin type is untouched.
+
+## Not done
+
+The issue's two smaller residues stay deferred on their own corpus evidence: the
+installed method reporting the name it was *added* under rather than the
+routine's own, and a plain `sub` used as a method not receiving the invocant as
+its first positional. Neither is touched here.
+
+Also unchanged: `Metamodel::Primitives.create_type` still registers a plain
+empty class and answers a bare type object, so a type minted through
+`Metamodel::ParametricRoleHOW.new_type(...)` still introspects as
+`ClassHOW`-shaped. That is the issue's other half and has its own repro.

--- a/src/runtime/methods_classhow_dispatch.rs
+++ b/src/runtime/methods_classhow_dispatch.rs
@@ -234,6 +234,24 @@ impl Interpreter {
                 // human-readable name for display. Persist the name so a later
                 // `.^name` returns it.
                 let new_name = args[1].to_string_value();
+                // `.^set_name` on a `Metamodel::Primitives.create_type` type
+                // object is `$type.HOW.set_name($type, $name)`, the write half
+                // of the same `Metamodel::Naming` protocol `.^name` reads --
+                // the name is state on the metaobject, so there is nothing to
+                // record on the type itself. A HOW that composes no naming
+                // role has nowhere to put the name; leave it anonymous rather
+                // than inventing a store the metaobject cannot see.
+                if let ValueView::CustomType(c) = args[0].view() {
+                    let how = (*c.how).clone();
+                    if self.value_can_method(&how, "set_name") {
+                        self.call_method_with_values(
+                            how,
+                            "set_name",
+                            vec![args[0].clone(), Value::str(new_name.clone())],
+                        )?;
+                    }
+                    return Ok(Value::str(new_name));
+                }
                 match args[0].view() {
                     ValueView::Mixin(inner, mixins) => {
                         // Resolve to the composition-keyed shared node
@@ -393,6 +411,11 @@ impl Interpreter {
                         None => crate::value::what_type_name(&args[0]),
                     };
                     return Ok(Value::str(name));
+                }
+                if matches!(args[0].view(), ValueView::CustomType(_)) {
+                    // Same `$type.HOW.name($type)` resolution the `.^name`
+                    // fast path performs -- one definition, not two.
+                    return self.dispatch_caret_name(&args[0]);
                 }
                 let name = match args[0].view() {
                     ValueView::Package(name) => self

--- a/src/runtime/methods_introspect.rs
+++ b/src/runtime/methods_introspect.rs
@@ -182,7 +182,11 @@ impl Interpreter {
             }
             ValueView::Proxy { .. } => "Proxy",
             ValueView::CustomType(c) => {
-                return Ok(Value::package(c.name));
+                let named = self.custom_type_how_name(target)?;
+                return Ok(Value::package(match named {
+                    Some(name) => Symbol::intern(&name),
+                    None => c.name,
+                }));
             }
             ValueView::CustomTypeInstance(d) => {
                 return Ok(Value::package(d.type_name));
@@ -414,7 +418,7 @@ impl Interpreter {
     }
 
     /// Dispatch .WHO method
-    pub(super) fn dispatch_who(&self, target: &Value) -> Result<Value, RuntimeError> {
+    pub(super) fn dispatch_who(&mut self, target: &Value) -> Result<Value, RuntimeError> {
         if let ValueView::Package(name) = target.view() {
             return Ok(self.package_stash_value(&name.resolve()));
         }
@@ -423,11 +427,47 @@ impl Interpreter {
             return Ok(self.package_stash_value(&class_name.resolve()));
         }
         if let ValueView::CustomType(c) = target.view() {
-            return Ok(self.package_stash_value(&c.name.resolve()));
+            let name = match self.custom_type_how_name(target)? {
+                Some(name) => name,
+                None => c.name.resolve(),
+            };
+            return Ok(self.package_stash_value(&name));
         }
         // Builtin values (Int, Str, Array, ...) also answer .WHO with their
         // type's Stash, same as the type object (raku: 42.WHO.^name is Stash).
         Ok(self.package_stash_value(value_type_name(target)))
+    }
+
+    /// The name a `create_type` type object's own metaobject answers to, or
+    /// `None` when that metaobject has no `name` method to ask.
+    ///
+    /// This is Rakudo's `.^name` protocol taken literally: `.^name` is
+    /// `$type.HOW.name($type)`, and `Metamodel::Naming` -- which is where a
+    /// custom HOW gets `name`/`set_name` from -- keeps the name as state on the
+    /// *metaobject*, not on the type. So a rename made through
+    /// `$meta.set_name($type, $name)` is visible from every copy of the type
+    /// object (they share the HOW) and, faithfully, only from the metaobject
+    /// that was told: a second `WithStashHOW.new` names nothing, the same way
+    /// it answers the empty string in Rakudo.
+    ///
+    /// `None` (rather than a name) for a HOW that composes no naming role, so
+    /// the caller keeps whatever name the type was minted with. The type object
+    /// itself is passed as the argument, matching the role's
+    /// `method name($obj)` signature.
+    fn custom_type_how_name(&mut self, type_val: &Value) -> Result<Option<String>, RuntimeError> {
+        let ValueView::CustomType(c) = type_val.view() else {
+            return Ok(None);
+        };
+        let how = (*c.how).clone();
+        if !self.value_can_method(&how, "name") {
+            return Ok(None);
+        }
+        // Whatever the metaobject answers is the name, the empty string
+        // included: an un-named `create_type` type object reports `""` under
+        // `raku` too, not a placeholder. `None` here means only "this HOW has
+        // no name to give", which is a different thing.
+        let named = self.call_method_with_values(how, "name", vec![type_val.clone()])?;
+        Ok(Some(named.to_string_value()))
     }
 
     /// Dispatch .WHY method — returns a Pod::Block::Declarator instance
@@ -798,6 +838,22 @@ impl Interpreter {
             ValueView::Promise(p) => {
                 crate::value::user_facing_type_name(&p.class_name().resolve()).to_string()
             }
+            // A `Metamodel::Primitives.create_type` type object gets its name
+            // from its own metaobject, exactly as Rakudo's `.^name` does
+            // (`$type.HOW.name($type)`): the name is state on the HOW, not on
+            // the type. A HOW that does not compose `Metamodel::Naming` has no
+            // name to give, and the type reports its minted one.
+            ValueView::CustomType(c) => match self.custom_type_how_name(target)? {
+                Some(name) => name,
+                None => {
+                    let minted = c.name.resolve();
+                    if minted.is_empty() {
+                        "CustomType".to_string()
+                    } else {
+                        minted
+                    }
+                }
+            },
             ValueView::ParametricRole {
                 base_name,
                 type_args,

--- a/src/runtime/run.rs
+++ b/src/runtime/run.rs
@@ -242,6 +242,53 @@ multi sub trait_mod:<does>(Mu $doee, Mu $role) is export {
 }
 "#;
 
+/// `Metamodel::Naming` and `Metamodel::Stashing` -- the two metaroles a custom
+/// HOW composes to become a *named* metaobject.
+///
+/// `Type/Metamodel/Stashing.rakudoc:45` is the worked example, and it is a
+/// `does` clause, not a `Metamodel::`-prefixed name a match happens to accept:
+///
+/// ```raku
+/// class WithStashHOW does Metamodel::Naming does Metamodel::Stashing {
+///     method new_type(WithStashHOW:_: Str:D :$name! --> Mu) {
+///         my WithStashHOW:D $meta := self.new;
+///         my Mu             $type := Metamodel::Primitives.create_type: $meta, 'Uninstantiable';
+///         $meta.set_name: $type, $name;
+///         self.add_stash: $type
+///     }
+/// }
+/// ```
+///
+/// They are provided as real roles rather than as names the `does` validator is
+/// taught to wave through, because a user HOW has to be able to `.^does` them,
+/// call them on `self`, and override them.
+///
+/// **The name is state on the METAOBJECT, not on the type.** That is Rakudo's
+/// shape (`role Metamodel::Naming { has $!name; method name($obj) { $!name } }`)
+/// and it is load-bearing, not an implementation detail: `.^name` is
+/// `$type.HOW.name($type)`, so a type minted by `create_type` reports the name
+/// its own `$meta` was told, and a *different* instance of the same HOW class
+/// reports nothing. Verified against `raku`: after the example above,
+/// `WithStashHOW.new.name(WithStash)` answers the empty string, while
+/// `WithStash.^name` answers `WithStash`. Storing the name against the type
+/// instead would make those two agree and be wrong.
+///
+/// `add_stash` "creates and sets a stash for a type, returning `$type_obj`"
+/// (`Type/Metamodel/Stashing.rakudoc`). mutsu's package stashes are created on
+/// demand and keyed by the type's name, so asking for the type's `.WHO` is the
+/// creation step; the method still has to answer `$type_obj`, since the
+/// documented HOW ends `new_type` with it.
+pub(super) const METAMODEL_ROLE_PRELUDE: &str = r#"
+role GLOBAL::Metamodel::Naming {
+    has $!name;
+    method name(Mu $obj) { $!name // '' }
+    method set_name(Mu $obj, $new_name) { $!name = $new_name }
+}
+role GLOBAL::Metamodel::Stashing {
+    method add_stash(Mu $type_obj) { $type_obj.WHO; $type_obj }
+}
+"#;
+
 impl Interpreter {
     /// Populate `$=pod` and the declarator doc-comment table (what `.WHY`
     /// reads) from the program source.
@@ -480,6 +527,7 @@ impl Interpreter {
         Self::inject_nativecall_subs_prelude(&preprocessed, &mut stmts);
         Self::inject_iosocket_prelude(&preprocessed, &mut stmts);
         Self::inject_trait_mod_does_prelude(&preprocessed, &mut stmts);
+        Self::inject_metamodel_role_prelude(&preprocessed, &mut stmts);
         // Install EVERY END phaser this compunit declares — top-level, inside
         // a block, inside a sub or a method — before the VM runs a single
         // statement, in source order. That is what rakudo does (it installs at

--- a/src/runtime/run_prelude.rs
+++ b/src/runtime/run_prelude.rs
@@ -1,6 +1,6 @@
 use super::run::{
-    IO_SOCKET_ROLE_PRELUDE, NATIVECALL_POINTER_PRELUDE, NATIVECALL_SUB_PRELUDES,
-    RATIONAL_ROLE_PRELUDE, TRAIT_MOD_DOES_PRELUDE,
+    IO_SOCKET_ROLE_PRELUDE, METAMODEL_ROLE_PRELUDE, NATIVECALL_POINTER_PRELUDE,
+    NATIVECALL_SUB_PRELUDES, RATIONAL_ROLE_PRELUDE, TRAIT_MOD_DOES_PRELUDE,
 };
 use super::*;
 
@@ -185,6 +185,39 @@ impl Interpreter {
         static TRAIT_MOD_DOES_STMTS: OnceLock<Vec<Stmt>> = OnceLock::new();
         let prelude = TRAIT_MOD_DOES_STMTS.get_or_init(|| {
             crate::parse_dispatch::parse_source(TRAIT_MOD_DOES_PRELUDE)
+                .map(|(s, _)| s)
+                .unwrap_or_default()
+        });
+        if prelude.is_empty() {
+            return;
+        }
+        let mut combined = prelude.clone();
+        combined.append(stmts);
+        *stmts = combined;
+    }
+
+    /// Prepend the `Metamodel::Naming` / `Metamodel::Stashing` metaroles
+    /// ([`METAMODEL_ROLE_PRELUDE`]) to a program that composes either of them.
+    ///
+    /// Gated on the role names themselves rather than on a bare `Metamodel`:
+    /// `Metamodel::Primitives` is dispatched natively and needs nothing
+    /// injected, and `.^name`/`.^compose` mention no `Metamodel::` name at all,
+    /// so keying on the prefix would prepend two role declarations to most
+    /// programs that merely introspect. A program declaring its own role of
+    /// either name keeps it (the prelude would collide with it), exactly as
+    /// [`Self::inject_prelude_roles`] treats `role Rational`.
+    pub(super) fn inject_metamodel_role_prelude(source: &str, stmts: &mut Vec<Stmt>) {
+        let wants_naming =
+            source.contains("Metamodel::Naming") && !source.contains("role Metamodel::Naming");
+        let wants_stashing =
+            source.contains("Metamodel::Stashing") && !source.contains("role Metamodel::Stashing");
+        if !wants_naming && !wants_stashing {
+            return;
+        }
+        use std::sync::OnceLock;
+        static METAMODEL_ROLE_STMTS: OnceLock<Vec<Stmt>> = OnceLock::new();
+        let prelude = METAMODEL_ROLE_STMTS.get_or_init(|| {
+            crate::parse_dispatch::parse_source(METAMODEL_ROLE_PRELUDE)
                 .map(|(s, _)| s)
                 .unwrap_or_default()
         });

--- a/t/metamodel-naming-stashing.t
+++ b/t/metamodel-naming-stashing.t
@@ -1,0 +1,64 @@
+use Test;
+
+# `Metamodel::Naming` and `Metamodel::Stashing` are real composable metaroles:
+# a custom HOW does them to become a named metaobject. The worked example is
+# `Type/Metamodel/Stashing.rakudoc:45`. Every assertion below was verified
+# against Rakudo, and this file passes under `raku` unmodified.
+
+plan 14;
+
+class WithStashHOW
+    does Metamodel::Naming
+    does Metamodel::Stashing
+{
+    method new_type(WithStashHOW:_: Str:D :$name! --> Mu) {
+        my WithStashHOW:D $meta := self.new;
+        my Mu             $type := Metamodel::Primitives.create_type: $meta, 'Uninstantiable';
+        $meta.set_name: $type, $name;
+        self.add_stash: $type
+    }
+}
+
+ok WithStashHOW.^does(Metamodel::Naming),   'a custom HOW can compose Metamodel::Naming';
+ok WithStashHOW.^does(Metamodel::Stashing), 'a custom HOW can compose Metamodel::Stashing';
+
+my Mu constant WithStash = WithStashHOW.new_type: :name<WithStash>;
+
+is WithStash.WHO.Str, 'WithStash', 'the stashed type answers its stash';
+is WithStash.WHO.^name, 'Stash',   'and that stash is a Stash';
+is WithStash.^name, 'WithStash',   '.^name asks the type its own metaobject';
+
+# The name is state on the METAOBJECT, not on the type: `.^name` is
+# `$type.HOW.name($type)`, so a *different* instance of the same HOW class was
+# never told the name and answers the empty string.
+is WithStashHOW.new.name(WithStash), '',
+   'a fresh metaobject of the same HOW class knows no name';
+
+# An un-named create_type type object answers the empty string, not a
+# placeholder -- its metaobject simply has nothing recorded.
+my $anon := Metamodel::Primitives.create_type(WithStashHOW.new, 'Uninstantiable');
+is WithStashHOW.new.name($anon), '', 'an un-named type object has no name';
+
+# set_name/name round-trip on one metaobject.
+my $meta := WithStashHOW.new;
+my $late := Metamodel::Primitives.create_type($meta, 'Uninstantiable');
+is $meta.name($late), '', 'the metaobject starts un-named';
+$meta.set_name($late, 'Later');
+is $meta.name($late), 'Later', 'set_name records the name on the metaobject';
+is $late.^name, 'Later', 'and .^name reads it back off the type';
+
+# add_stash answers the type object it was handed -- the documented HOW ends
+# `new_type` with it, so returning anything else breaks the whole idiom.
+my $stashed := $meta.add_stash($late);
+is $stashed.^name, 'Later', 'add_stash answers the type object';
+
+# Naming is composable on its own, without Stashing.
+class NamingOnlyHOW does Metamodel::Naming { }
+ok NamingOnlyHOW.^does(Metamodel::Naming), 'Metamodel::Naming composes on its own';
+my $n := NamingOnlyHOW.new;
+my $nt := Metamodel::Primitives.create_type($n, 'Uninstantiable');
+$n.set_name($nt, 'JustNamed');
+is $nt.^name, 'JustNamed', 'a Naming-only HOW names its type';
+
+# Ordinary types are untouched by any of this.
+is Int.^name, 'Int', 'a builtin type still reports its own name';


### PR DESCRIPTION
`Type/Metamodel/Stashing.rakudoc:45`'s worked example — the documented way to write a minimal custom HOW — died on its first line:

```raku
class WithStashHOW
    does Metamodel::Naming
    does Metamodel::Stashing
{ ... }
```
```
X::InvalidType: Invalid typename 'Metamodel::Naming'
```

The `does` clause failed before the class body was read. This is the headline of #7551, which by then had had three earlier framings closed under it, each measured wrong or already fixed before the next was written.

## Measured first

Replacing the two `Metamodel::` roles with locally-declared stand-ins showed that **everything else in the example already worked**: the `WithStashHOW:_:` invocant smiley, the `:=` bindings, the `Str:D :$name!` parameter, `Metamodel::Primitives.create_type`, role composition, and the `$meta.set_name(...)` dispatch. Exactly two things were missing:

1. the two role names, and
2. any path from a `create_type` type object to a name given to it *afterwards* — `create_type` mints with `Symbol::intern("")`, and `.^set_name`'s handler had no `CustomType` arm, so `$type.^name` stayed `CustomType` and `$type.WHO` stayed the empty stash.

## The name is state on the metaobject, not on the type

The obvious implementation — record the name against the type, keyed by its id — is wrong, and `raku` says so directly. After the doc's example:

```
WithStash.^name                     # WithStash
WithStashHOW.new.name(WithStash)    # ''      <- a *different* metaobject
```

Rakudo's `Metamodel::Naming` is `role { has $!name; method name($obj) { $!name } }` — the name is an attribute of the **metaobject**, and `$obj` is ignored. `.^name` is `$type.HOW.name($type)`, so a type minted by `create_type` reports what its own `$meta` was told, and a second `WithStashHOW.new` — told nothing — reports the empty string. A type-keyed store would make those two agree, which is a different language.

So the roles are provided as real Raku source in a prelude (`METAMODEL_ROLE_PRELUDE`, injected the way `RATIONAL_ROLE_PRELUDE` and the `trait_mod:<does>` candidates already are), with **no native primitives at all**:

```raku
role GLOBAL::Metamodel::Naming {
    has $!name;
    method name(Mu $obj) { $!name // '' }
    method set_name(Mu $obj, $new_name) { $!name = $new_name }
}
role GLOBAL::Metamodel::Stashing {
    method add_stash(Mu $type_obj) { $type_obj.WHO; $type_obj }
}
```

`add_stash` "creates and sets a stash for a type, returning `$type_obj`". mutsu's package stashes are created on demand and keyed by the type's name, so asking for `.WHO` *is* the creation step — but the method still has to answer the type object, because the documented HOW ends `new_type` with it.

The Rust half: `.^name`, `.WHO` and `.WHAT` on a `ValueView::CustomType` now ask the type's own metaobject (`Interpreter::custom_type_how_name`) — Rakudo's protocol taken literally rather than a new store — and `.^set_name` on such a type object routes to the metaobject's `set_name`. **A HOW that composes no naming role has no `name` method to ask, and the type keeps the name it was minted with, so nothing that does not opt in changes.**

One fidelity detail: an un-named `create_type` type object reports the **empty string**, not a placeholder, because that is what its metaobject answers. `None` from `custom_type_how_name` means only "this HOW has no name to give", which is a different thing from "the name is empty".

The prelude is gated on the role names themselves, not on a bare `Metamodel` — `Metamodel::Primitives` is dispatched natively and needs nothing injected, and `.^name`/`.^compose` mention no `Metamodel::` name at all.

## Verification

- **Pin:** `t/metamodel-naming-stashing.t`, 14 assertions, **passing under `raku` unmodified**. Beyond the doc's example it pins the metaobject-scoping, the empty-string answer for an un-named type, the `set_name`/`name` round trip, `add_stash`'s return value, `Metamodel::Naming` composing on its own, and that a builtin type is untouched.
- The doc's example plus 10 further probes are now **byte-identical** to `raku` (`diff` clean).
- `make test`: `Files=3839, Tests=40576 … Result: PASS`.
- `make roast`: identical failure set to the pre-change baseline run — `6.c/S32-io/file-tests.t`, `S16-filehandles/filetest.t`, `S32-io/IO-Socket-Async.t`. This container runs as `root`, so `.r`/`.w`/`.x` assertions expecting a permission denial pass instead. No new failures.
- `cargo fmt --all` and `make lint` (default clippy, clippy without `jit`, wasm32 clippy, rustdoc) clean.

## Not done

The issue's two smaller residues stay deferred on their own corpus evidence: the installed method reporting the name it was *added* under, and a plain `sub` used as a method not receiving the invocant as its first positional. Also unchanged: the generic `Metamodel::*.new_type` dispatch still registers a plain empty class, so a type minted through `Metamodel::ParametricRoleHOW.new_type(...)` still introspects as `ClassHOW`-shaped — the issue's other half, which has its own repro.

Closes #7551

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012BaTE6YdzbdFki2k3dQqq1

---
_Generated by [Claude Code](https://claude.ai/code/session_012BaTE6YdzbdFki2k3dQqq1)_