### PR TITLE
fix(runtime): splice on an immutable List resolves no candidate

### DIFF
--- a/news/2026-09/splice-on-an-immutable-list-has-no-candidate.md
+++ b/news/2026-09/splice-on-an-immutable-list-has-no-candidate.md
@@ -1,0 +1,48 @@
+# `splice` on an immutable List resolves no candidate, it is not an immutability error
+
+Six of the seven list mutators are declared on `List`, so calling one on an
+immutable invocant reaches an immutability check and dies with `X::Immutable`:
+
+```
+my $l = (1,2,3); $l.push(9)    X::Immutable  "Cannot call 'push' on an immutable 'List'"
+my $r = 1..3;    $r.push(9)    X::Immutable  "Cannot call 'push' on an immutable 'Range'"
+```
+
+`splice` is the seventh, and it is not one of them. Rakudo declares `splice` on
+`Array` only, so a `List` or `Range` invocant resolves no candidate at all and
+never reaches an immutability check:
+
+```
+my $l = (1,2,3); $l.splice(0,1)
+    X::Multi::NoMatch
+    "Cannot resolve caller splice(List:D, Int:D, Int:D); Routine does not have
+     any candidates.  Is only the proto defined?"
+```
+
+mutsu routed all seven through the same `X::Immutable` arm, in both the
+value-path (`methods_call_dispatch.rs`) and the lvalue-path
+(`methods_mut_dispatch.rs`) dispatchers, so `splice` came out with the wrong
+exception class *and* the wrong message.
+
+That is not cosmetic. It is one of the two remaining residues of the
+`X::OutOfRange` / `CATCH` descent in the `Config::TOML` battery ticket
+([#7539](https://github.com/tokuhirom/mutsu/issues/7539)): `Crane`'s `add`
+descent catches the failure and maps it to `X::Crane::Add::RO`, and it matches
+on rakudo's spelling, so under mutsu the `CATCH` fell through and the wrong
+exception escaped.
+
+`make_no_candidates_error` renders rakudo's wording — note the two spaces before
+"Is only the proto defined?" — from the invocant and the actual arguments, each
+as its type name plus a `:D`/`:U` smiley, so the signature tracks both the arity
+and the argument types (`splice(List:D, Str:D)` for `$l.splice("x")`). It sits
+beside `make_multi_no_match_error`, which is the *different* `X::Multi::NoMatch`
+case: a routine that has candidates and none of them bound ("none of these
+signatures matches").
+
+Pinned by `t/splice-on-immutable-list-has-no-candidate.t`, 17 assertions passing
+unchanged under `raku` as well as under mutsu: the no-candidate rows across five
+arities and both invocant types, the six mutators that must still answer
+`X::Immutable`, and `splice` on a real `Array` — including the `*-0` start,
+whose "inserts at index 0 instead of at the end" symptom the same ticket
+records. That symptom did not reproduce on re-measurement; `@a.splice(*-0, 0, 9)`
+appends correctly, so only the exception-class residue was live.

--- a/src/runtime/methods_call_dispatch.rs
+++ b/src/runtime/methods_call_dispatch.rs
@@ -4,7 +4,8 @@ use super::methods::{
     multidim_exists_pos, shaped_multidim_exists_pos,
 };
 use super::methods_signature_errors::{
-    make_method_not_found_error, make_multi_no_match_error, make_x_immutable_error,
+    make_method_not_found_error, make_multi_no_match_error, make_no_candidates_error,
+    make_x_immutable_error,
 };
 use super::*;
 use crate::symbol::Symbol;
@@ -1538,7 +1539,12 @@ impl Interpreter {
             self.exit_readonly_frame(saved_readonly);
             return Ok(Value::str(rendered.to_string_value()));
         }
-        // Immutable List/Range: push/pop/shift/unshift/append/prepend/splice must throw
+        // Immutable List/Range: the six mutators rakudo DOES define on them
+        // throw X::Immutable. `splice` is not among them -- rakudo declares it
+        // on Array only, so a List/Range invocant resolves no candidate at all
+        // and raises X::Multi::NoMatch instead ("Cannot resolve caller
+        // splice(List:D, Int:D, Int:D); Routine does not have any candidates."),
+        // which is the spelling Crane's CATCH maps to X::Crane::Add::RO.
         if matches!(
             method,
             "push" | "pop" | "shift" | "unshift" | "append" | "prepend" | "splice"
@@ -1553,6 +1559,9 @@ impl Interpreter {
                 _ => false,
             };
             if is_immutable {
+                if method == "splice" {
+                    return Err(make_no_candidates_error(method, &target, &args));
+                }
                 let typename = match target.view() {
                     ValueView::Array(..) => "List",
                     _ => "Range",

--- a/src/runtime/methods_mut_dispatch.rs
+++ b/src/runtime/methods_mut_dispatch.rs
@@ -115,6 +115,16 @@ impl Interpreter {
                 "callmethodmutwithvalues",
                 "immutable-list-reject",
             );
+            // `splice` is an Array-only routine in rakudo, so a List invocant
+            // resolves no candidate rather than hitting an immutability check.
+            // See the twin arm in methods_call_dispatch.rs.
+            if method == "splice" {
+                return Err(
+                    crate::runtime::methods_signature_errors::make_no_candidates_error(
+                        method, &target, &args,
+                    ),
+                );
+            }
             return Err(make_x_immutable_error(method, "List"));
         }
         if scalar_like_target

--- a/src/runtime/methods_signature_errors.rs
+++ b/src/runtime/methods_signature_errors.rs
@@ -112,6 +112,50 @@ pub(crate) fn make_x_immutable_error(method_name: &str, typename: &str) -> Runti
     err
 }
 
+/// `X::Multi::NoMatch` in rakudo's "there are no candidates at all" spelling:
+///
+/// ```text
+/// Cannot resolve caller splice(List:D, Int:D, Int:D); Routine does not have
+/// any candidates.  Is only the proto defined?
+/// ```
+///
+/// (Two spaces before "Is", as rakudo prints it.) This is what a method the
+/// invocant's type simply does not have produces, as distinct from
+/// [`make_multi_no_match_error`]'s "none of these signatures matches", which is
+/// for a routine that HAS candidates and none of them bound.
+///
+/// The signature lists the invocant first and then each argument, each rendered
+/// as its type name plus a `:D`/`:U` smiley.
+pub(crate) fn make_no_candidates_error(
+    method_name: &str,
+    invocant: &Value,
+    args: &[Value],
+) -> RuntimeError {
+    fn typed(v: &Value) -> String {
+        let smiley = if crate::runtime::types::value_is_defined(v) {
+            ":D"
+        } else {
+            ":U"
+        };
+        format!("{}{}", crate::runtime::utils::value_type_name(v), smiley)
+    }
+    let mut sig = String::from(typed(invocant).as_str());
+    for arg in args {
+        sig.push_str(", ");
+        sig.push_str(&typed(arg));
+    }
+    let msg = format!(
+        "Cannot resolve caller {}({}); Routine does not have any candidates.  Is only the proto defined?",
+        method_name, sig
+    );
+    let mut attrs = std::collections::HashMap::new();
+    attrs.insert("message".to_string(), Value::str(msg.clone()));
+    let ex = Value::make_instance(Symbol::intern("X::Multi::NoMatch"), attrs);
+    let mut err = RuntimeError::new(msg);
+    err.exception = Some(Box::new(ex));
+    err
+}
+
 /// Create a structured X::Multi::NoMatch error.
 pub(crate) fn make_multi_no_match_error(method_name: &str) -> RuntimeError {
     let msg = format!("No matching candidates for method: {}", method_name);

--- a/t/splice-on-immutable-list-has-no-candidate.t
+++ b/t/splice-on-immutable-list-has-no-candidate.t
@@ -1,0 +1,86 @@
+use Test;
+
+plan 17;
+
+# `splice` is declared on Array only. A List or Range invocant therefore
+# resolves NO candidate at all and raises X::Multi::NoMatch -- it never reaches
+# an immutability check, unlike the six mutators rakudo does define on them.
+# mutsu used to route all seven through the same X::Immutable arm, which is the
+# wrong class AND the wrong message; Crane's CATCH maps only rakudo's spelling
+# to X::Crane::Add::RO.
+
+my $no-candidates = 'Routine does not have any candidates.  Is only the proto defined?';
+
+# --- splice: no candidate --------------------------------------------------
+
+{
+    my $l = (1, 2, 3);
+    throws-like { $l.splice(0, 1) }, X::Multi::NoMatch,
+        message => "Cannot resolve caller splice(List:D, Int:D, Int:D); $no-candidates",
+        'splice on a List resolves no candidate';
+    is $l.elems, 3, 'the List is untouched';
+}
+
+{
+    my @a := (1, 2, 3);
+    throws-like { @a.splice(0, 1) }, X::Multi::NoMatch,
+        message => "Cannot resolve caller splice(List:D, Int:D, Int:D); $no-candidates",
+        'the same through an @-sigiled bind to a List';
+}
+
+{
+    my $r = 1 .. 3;
+    throws-like { $r.splice(0, 1) }, X::Multi::NoMatch,
+        message => "Cannot resolve caller splice(Range:D, Int:D, Int:D); $no-candidates",
+        'splice on a Range names Range in the signature';
+}
+
+# The rendered signature is the invocant plus every argument, so it tracks both
+# the arity and the argument types.
+{
+    my $l = (1, 2, 3);
+    throws-like { $l.splice() }, X::Multi::NoMatch,
+        message => "Cannot resolve caller splice(List:D); $no-candidates",
+        'no arguments renders the invocant alone';
+    throws-like { $l.splice(0) }, X::Multi::NoMatch,
+        message => "Cannot resolve caller splice(List:D, Int:D); $no-candidates",
+        'one argument';
+    throws-like { $l.splice(0, 1, 9) }, X::Multi::NoMatch,
+        message => "Cannot resolve caller splice(List:D, Int:D, Int:D, Int:D); $no-candidates",
+        'a replacement argument is listed too';
+    throws-like { $l.splice("x") }, X::Multi::NoMatch,
+        message => "Cannot resolve caller splice(List:D, Str:D); $no-candidates",
+        'the argument type is the real one, not a coerced Int';
+}
+
+# --- the six that DO exist on a List still throw X::Immutable ---------------
+
+{
+    my $l = (1, 2, 3);
+    for <push pop shift unshift append prepend> -> $m {
+        throws-like { $l."$m"(9) }, X::Immutable,
+            message => "Cannot call '$m' on an immutable 'List'",
+            "$m on a List is still X::Immutable";
+    }
+}
+
+{
+    my $r = 1 .. 3;
+    throws-like { $r.push(9) }, X::Immutable,
+        message => "Cannot call 'push' on an immutable 'Range'",
+        'push on a Range is still X::Immutable';
+}
+
+# --- splice on a real Array is untouched -----------------------------------
+
+{
+    my @a = 1, 2, 3;
+    @a.splice(1, 1, 9);
+    is-deeply @a, [1, 9, 3], 'splice on a mutable Array still works';
+}
+
+{
+    my @a = 1, 2, 3;
+    @a.splice(*-0, 0, 9);
+    is-deeply @a, [1, 2, 3, 9], 'a Whatever-closure start still appends at the end';
+}


### PR DESCRIPTION
One of the two remaining `X::OutOfRange` / `CATCH` descent residues in #7539.

## The divergence

Six of the seven list mutators are declared on `List`, so calling one on an
immutable invocant reaches an immutability check and dies with `X::Immutable`.
`splice` is the seventh and is **not** one of them — rakudo declares it on
`Array` only, so a `List` or `Range` invocant resolves no candidate at all:

| code | raku | mutsu (before) |
| --- | --- | --- |
| `my $l = (1,2,3); $l.push(9)` | `X::Immutable` "Cannot call 'push' on an immutable 'List'" | same ✅ |
| `my $r = 1..3; $r.push(9)` | `X::Immutable` "Cannot call 'push' on an immutable 'Range'" | same ✅ |
| `my $l = (1,2,3); $l.splice(0,1)` | `X::Multi::NoMatch` "Cannot resolve caller splice(List:D, Int:D, Int:D); Routine does not have any candidates.  Is only the proto defined?" | `X::Immutable` "Cannot call 'splice' on an immutable 'List'" ❌ |
| `my $r = 1..3; $r.splice(0,1)` | same, with `Range:D` | `X::Immutable` ❌ |

mutsu routed all seven through the same `X::Immutable` arm, in both the
value-path (`methods_call_dispatch.rs`) and the lvalue-path
(`methods_mut_dispatch.rs`) dispatchers, so `splice` came out with the wrong
exception class *and* the wrong message.

That is not cosmetic. `Crane`'s `add` descent catches the failure and maps it to
`X::Crane::Add::RO`, matching on rakudo's spelling — so under mutsu the `CATCH`
fell through and the wrong exception escaped, which is exactly what #7539
records under blocker 1.

## The fix

`make_no_candidates_error` renders rakudo's wording (note the two spaces before
"Is only the proto defined?") from the invocant and the *actual* arguments, each
as its type name plus a `:D`/`:U` smiley, so the signature tracks both the arity
and the argument types — `$l.splice("x")` reports `splice(List:D, Str:D)`, not a
coerced `Int`.

It sits beside the existing `make_multi_no_match_error`, which is the *other*
`X::Multi::NoMatch` case: a routine that HAS candidates and none of them bound
("none of these signatures matches"). Keeping the two spellings apart is the
point — Crane distinguishes them.

## The ticket's other residue did not reproduce

#7539 also records "a `splice` reached through Crane's `*-0` path inserts at
index 0 instead of at the end". Re-measured on a fresh build: `@a.splice(*-0, 0,
9)` on `[1,2,3]` answers `[1 2 3 9]`, matching raku, and so do `*-1` and the
empty-array case. It is already fixed; the test pins it as a passing row so it
cannot silently regress.

## Testing

`t/splice-on-immutable-list-has-no-candidate.t`, 17 assertions, passing
**unchanged under `raku` as well as under mutsu**: the no-candidate rows across
five arities and both invocant types, the six mutators that must still answer
`X::Immutable`, and `splice` on a real `Array` including the `*-0` start.

`cargo fmt`, `cargo clippy --all-targets -- -D warnings`, `make test` (Result:
PASS) and `make roast` all run. `make roast` reports three failures, identical
to a run without this diff and all environmental to this container:

- `roast/6.c/S32-io/file-tests.t` and `roast/S16-filehandles/filetest.t` — the
  session runs as **root**, which bypasses the `0333`/`0222`/`0111` mode bits
  those assertions test.
- `roast/S32-io/IO-Socket-Async.t` — hangs at the `# host=::1` round;
  `/proc/net/if_inet6` does not exist here, so there is no IPv6 loopback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ExzRnHAQq5kawQ2oVpLMM9

---
_Generated by [Claude Code](https://claude.ai/code/session_01ExzRnHAQq5kawQ2oVpLMM9)_