### PR TITLE
fix(value): render a `Rat` with an over-64-bit denominator the way rakudo does

### DIFF
--- a/news/2026-09/big-denominator-rat-str.md
+++ b/news/2026-09/big-denominator-rat-str.md
@@ -1,0 +1,57 @@
+# A `Rat` with an over-64-bit denominator renders rakudo's digits
+
+```raku
+my $a = .1234567890123456789012345;
+say $a.Str;
+# raku:  0.1234567890123456824475648
+# mutsu: 0.12345678901234568
+```
+
+The *value* was already right — `.numerator`, `.denominator` and `.raku` were
+byte-identical to rakudo, so the literal parsed exactly. Only the rendering
+diverged, and only for a denominator that does not fit 64 bits: mutsu shortcut
+such a `Rat` through its `Num` value and printed f64's 17-digit shortest
+round-trip.
+
+## What rakudo actually does
+
+`Rat` is `Rational[Int, uint64]`, so an arithmetic result whose denominator does
+not fit `uint64` degrades to `Num`. `Rational.Str` reaches its fractional part
+through such an operation, which means the digit budget it then applies
+(`|denom| < 100_000 ?? 6 !! chars(|denom|) + 1`) is filled from **f64**, not from
+the exact fraction. So rakudo's 25 digits are neither the exact expansion
+(`0.1234567890123456789012345`) nor f64's shortest form — they are
+`round(fract * 10^digits)` evaluated in f64 and then zero-stripped.
+
+`FatRat` is `Rational[Int, Int]` and never degrades, so it keeps the exact
+expansion. That contrast is what pins the rule: the same numerator/denominator
+pair renders `0.1234567890123456824475648` as a `Rat` and
+`0.1234567890123456789012345` as a `FatRat`, and the boundary is exactly
+`uint64` — `2^64-1` is still exact, `2^64` is not.
+
+## The fix
+
+`format_rat_str_bigint` (`src/value/display.rs`) grew that degradation as
+`f64_scaled_fraction`: for a non-FatRat whose denominator exceeds `u64::MAX`, the
+scaled rounding runs in f64 the way rakudo's degraded arithmetic does. The
+`BigRat` arm of `to_string_value` no longer shortcuts a big-denominator `Rat`
+through `Num` at all; it hands every `BigRat` to the digit-budget formatter,
+which now owns the whole rule. A fraction that underflows f64 still renders as
+its whole part (`Rat.new(1, 10**400).Str` is `0`, as in rakudo), and a scale too
+large for f64 falls back to the exact expansion — rakudo is not self-consistent
+that far out, so staying finite beats emitting `Inf`.
+
+The sign row of the ticket's matrix turned out to be a second, adjacent bug:
+`prefix:<->` on a big-denominator `Rat` literal produced a **FatRat**, because
+`arith_negate` routed it through the *arithmetic* constructor and
+`is_fat_rat_like` reads an over-`uint64` denominator as proof of FatRat-ness.
+Negation cannot change the denominator, so it never degrades; the `BigRat` arm
+now consults the stored FatRat flag (which its own comment already calls
+authoritative) and uses the non-degrading constructor.
+`(-1.1234567890123456789012345).^name` is `Rat` again.
+
+Pinned by `t/big-denominator-rat-str.t`, whose 27 assertions pass unchanged
+under rakudo. `t/decimal-literal-big-integer-part.t`, which pins the value half,
+is unmoved.
+
+Closes #7577.

--- a/src/builtins/arith/pow_negate.rs
+++ b/src/builtins/arith/pow_negate.rs
@@ -1,8 +1,8 @@
 //! Power (exponentiation) and unary negation operators.
 
-use super::rat::{bigint_ratio_to_f64, is_fat_rat_like, make_fat_rat};
+use super::rat::{bigint_ratio_to_f64, make_fat_rat};
 use crate::value::{
-    RuntimeError, Value, ValueView, make_big_fat_rat, make_big_rat_arith, make_rat,
+    RuntimeError, Value, ValueView, make_big_fat_rat, make_big_rat, make_big_rat_arith, make_rat,
 };
 use num_bigint::{BigInt as NumBigInt, Sign};
 use num_traits::{ToPrimitive, Zero};
@@ -380,10 +380,17 @@ pub(crate) fn arith_negate(val: Value) -> Result<Value, RuntimeError> {
             }
         }
         ValueView::BigRat(n, d) => {
-            if is_fat_rat_like(&val) {
+            // `prefix:<->` cannot change the denominator, so it never degrades:
+            // rakudo hands back the same `Rational` type with a negated
+            // numerator (`(-1.1234567890123456789012345).^name` is `Rat`).
+            // The arithmetic constructor used here degraded an over-`uint64`
+            // denominator, and `is_fat_rat_like` reads such a denominator as
+            // proof of FatRat-ness -- together they turned a negated big-Rat
+            // LITERAL into a FatRat. The stored flag is the authoritative one.
+            if val.is_bigfatrat() {
                 Ok(make_big_fat_rat(-n.clone(), d.clone()))
             } else {
-                Ok(make_big_rat_arith(-n.clone(), d.clone()))
+                Ok(make_big_rat(-n.clone(), d.clone()))
             }
         }
         ValueView::Complex(r, i) => {

--- a/src/value/display.rs
+++ b/src/value/display.rs
@@ -343,6 +343,15 @@ pub fn format_complex(r: f64, i: f64) -> String {
 ///   FatRat: |denom| < 100_000 ? 6 : chars(|denom|) + chars(whole) + 5
 /// then `round(fract * 10^digits)`, left-zero-padded to `digits`, trailing
 /// zeros stripped.
+///
+/// `Rat` is `Rational[Int, uint64]` in Rakudo, so an arithmetic result whose
+/// denominator does not fit `uint64` degrades to `Num`. `Rational.Str` reaches
+/// its fractional part through such an operation, which means a `Rat` with an
+/// over-64-bit denominator computes `round(fract * 10^digits)` in **f64**, not
+/// exactly -- `0.1234567890123456789012345.Str` is `0.1234567890123456824475648`
+/// there, the f64 value re-expanded to the digit budget, and not the exact
+/// `0.1234567890123456789012345`. `FatRat` is `Rational[Int, Int]` and never
+/// degrades, so it keeps the exact expansion. See `f64_scaled_fraction` below.
 fn format_rat_str_bigint(numer: &NumBigInt, denom: &NumBigInt, is_fatrat: bool) -> String {
     // Callers guarantee denom != 0.
     let sign = numer.is_negative() ^ denom.is_negative();
@@ -374,8 +383,22 @@ fn format_rat_str_bigint(numer: &NumBigInt, denom: &NumBigInt, is_fatrat: bool) 
     // s = round(fract * 10^digits) = round(rem * 10^digits / d), rounding half
     // up (Rakudo `.round` = floor(x + 1/2); rem/d is non-negative).
     let scale = NumBigInt::from(10u8).pow(digits as u32);
-    let scaled = &rem * &scale;
-    let rounded = (&scaled * 2u8 + &d) / (&d * 2u8);
+    // A `Rat` whose denominator does not fit `uint64` reaches this product
+    // through a degraded (`Num`) operation in Rakudo, so the multiply and the
+    // rounding both happen in f64 there. Falls back to the exact computation
+    // when f64 cannot carry the scale at all (a denominator of a few hundred
+    // digits overflows to infinity; rakudo itself is not self-consistent in
+    // that regime, so staying finite and exact is the better answer).
+    let rounded = match (!is_fatrat && d > NumBigInt::from(u64::MAX))
+        .then(|| f64_scaled_fraction(&rem, &d, &scale))
+        .flatten()
+    {
+        Some(via_f64) => via_f64,
+        None => {
+            let scaled = &rem * &scale;
+            (&scaled * 2u8 + &d) / (&d * 2u8)
+        }
+    };
 
     let mut s = rounded.to_string();
     // Defensive carry guard: if rounding rolled fract over to 10^digits, the
@@ -393,6 +416,30 @@ fn format_rat_str_bigint(numer: &NumBigInt, denom: &NumBigInt, is_fatrat: bool) 
     } else {
         format!("{}{}.{}", sign_str, whole, trimmed)
     }
+}
+
+/// `round(rem / d * scale)` evaluated in f64, as Rakudo's degraded-`Rat`
+/// `Rational.Str` does it: the fraction and the power of ten each become a
+/// `Num` first, so the product carries only f64 precision and the digits the
+/// caller emits are the f64 value's, not the fraction's.
+///
+/// Returns `None` when the f64 route cannot produce an answer at all -- the
+/// scale overflows to infinity -- leaving the caller on its exact path. (Rakudo
+/// is not self-consistent for a denominator that large; an exact expansion is
+/// the better answer there than an `Inf`.)
+fn f64_scaled_fraction(rem: &NumBigInt, d: &NumBigInt, scale: &NumBigInt) -> Option<NumBigInt> {
+    use num_traits::{FromPrimitive, ToPrimitive};
+    let fract = crate::value::bigrat_to_f64(rem, d);
+    if fract == 0.0 {
+        // The fraction underflowed f64, so every digit rakudo emits is a zero
+        // and the whole part is the answer (`Rat.new(1, 10**400).Str` is `0`).
+        return Some(NumBigInt::from(0u8));
+    }
+    let rounded = (fract * scale.to_f64()? + 0.5).floor();
+    if !rounded.is_finite() {
+        return None;
+    }
+    NumBigInt::from_f64(rounded)
 }
 
 impl Value {
@@ -622,19 +669,16 @@ impl Value {
                     // computes the decimal directly, so a huge denominator never
                     // produces `Inf`, unlike an f64 fallback).
                     format_rat_str_bigint(n, d, true)
-                } else if d.abs().to_string().len() > 20 {
-                    // A plain Rat with an astronomically large denominator (beyond
-                    // ~u64 range) is a degenerate Rat: raku stringifies it via its
-                    // Num value, so a vanishingly small ratio prints as `0` rather
-                    // than a thousand-digit fraction. A denominator that merely
-                    // overflows i64 but stays around u64 range still uses the exact
-                    // budget below (e.g. `<1/99999999999999999999>`).
-                    let val = crate::value::bigrat_to_f64(n, d);
-                    Value::Num(val).to_string_value()
                 } else {
-                    // A big Rat with an in-range denominator follows raku's fixed
-                    // digit-budget rounding (`Rational.Str`): `|denom| < 100_000 ?
-                    // 6 : chars(|denom|) + 1`. Mirrors the i64 Rat arm above.
+                    // A big Rat follows raku's fixed digit-budget rounding
+                    // (`Rational.Str`): `|denom| < 100_000 ? 6 : chars(|denom|) + 1`.
+                    // Mirrors the i64 Rat arm above. An over-`uint64` denominator
+                    // additionally makes the digits come out of f64, as rakudo's
+                    // degraded-`Rat` arithmetic does -- `format_rat_str_bigint`
+                    // owns that rule, so this arm does not need to know about it.
+                    // (It used to shortcut such a Rat through its `Num` value
+                    // entirely, which is what dropped
+                    // `0.1234567890123456789012345.Str` to 17 significant digits.)
                     format_rat_str_bigint(n, d, false)
                 }
             }

--- a/t/big-denominator-rat-str.t
+++ b/t/big-denominator-rat-str.t
@@ -1,0 +1,93 @@
+use v6;
+use Test;
+
+# `Rat` is `Rational[Int, uint64]` in rakudo, so an arithmetic result whose
+# denominator does not fit `uint64` degrades to `Num`. `Rational.Str` reaches
+# its fractional part through such an operation, which means a `Rat` with an
+# over-64-bit denominator renders the f64 value re-expanded to the digit budget
+# -- NOT the exact expansion, and NOT f64's own 17-digit shortest round-trip,
+# which is what mutsu used to print (GH #7577).
+#
+# `FatRat` is `Rational[Int, Int]` and never degrades, so it keeps the exact
+# expansion; that contrast is the discriminator this file pins.
+
+plan 27;
+
+# --- the reported repro ------------------------------------------------
+{
+    my $a = .1234567890123456789012345;
+    is $a.numerator,   246913578024691357802469,  'the literal parses exactly (numerator)';
+    is $a.denominator, 2000000000000000000000000, 'the literal parses exactly (denominator)';
+    is $a.raku, '<246913578024691357802469/2000000000000000000000000>', '.raku stays exact';
+    is $a.Str,  '0.1234567890123456824475648', '.Str re-expands the f64 to the digit budget';
+    is $a.gist, '0.1234567890123456824475648', '.gist agrees with .Str';
+    is $a.^name, 'Rat', 'a big-denominator decimal literal is a Rat';
+}
+
+# --- a nonzero integer part --------------------------------------------
+{
+    my $a = 1.1234567890123456789012345;
+    is $a.Str, '1.1234567890123456824475648', 'nonzero integer part keeps the same fraction digits';
+}
+
+# --- the sign case -----------------------------------------------------
+{
+    my $a = -1.1234567890123456789012345;
+    is $a.^name, 'Rat', 'negating a big-denominator Rat literal stays a Rat';
+    is $a.Str, '-1.1234567890123456824475648', 'the negated literal renders like its positive twin';
+    is $a.numerator, -2246913578024691357802469, 'the negated literal keeps its exact numerator';
+}
+{
+    my $a = 1.1234567890123456789012345;
+    is (-$a).^name, 'Rat', 'prefix:<-> on a big-denominator Rat stays a Rat';
+    is (-$a).Str, '-1.1234567890123456824475648', 'prefix:<-> renders like the literal';
+}
+
+# --- FatRat never degrades ---------------------------------------------
+{
+    my $f = FatRat.new(246913578024691357802469, 2000000000000000000000000);
+    is $f.Str, '0.1234567890123456789012345', 'FatRat keeps the exact expansion';
+    is (-$f).^name, 'FatRat', 'prefix:<-> on a FatRat stays a FatRat';
+    is (-$f).Str, '-0.1234567890123456789012345', 'a negated FatRat is still exact';
+}
+
+# --- the uint64 boundary is where the degradation starts ---------------
+{
+    # 2^64 - 1 still fits, so these digits are the EXACT expansion.
+    my $r = Rat.new(12345678901234567891, 18446744073709551615);
+    is $r.Str, '0.669260594276348691851', 'a denominator of 2^64-1 keeps the exact expansion';
+}
+{
+    # 2^64 does not fit, so these digits come from f64.
+    my $r = Rat.new(12345678901234567891, 18446744073709551616);
+    is $r.Str, '0.669260594276348592128', 'a denominator of 2^64 renders through f64';
+}
+{
+    my $f = FatRat.new(12345678901234567891, 18446744073709551616);
+    is $f.Str, '0.669260594276348691814265', 'the FatRat twin of that denominator is exact';
+}
+
+# --- a denominator that fits 64 bits must not change -------------------
+{
+    my $a = 0.1234567890123456789;
+    is $a.Str, '0.1234567890123456789', 'a 19-digit denominator is unchanged';
+    is $a.^name, 'Rat', 'and is still a Rat';
+}
+is (1/3).Str,  '0.333333', 'the small-denominator six-digit budget is unchanged';
+is (1/7).Str,  '0.142857', 'the small-denominator budget applies to 1/7 too';
+is (1/2).Str,  '0.5',      'a terminating small Rat is unchanged';
+
+# --- a fraction that rounds up to the next integer ---------------------
+is Rat.new(99999999999999999999999999, 100000000000000000000000000).Str, '1',
+   'a Rat whose f64 fraction is 1.0 renders as the next integer';
+is FatRat.new(99999999999999999999999999, 100000000000000000000000000).Str,
+   '0.99999999999999999999999999',
+   'the FatRat twin keeps every nine';
+
+# --- a fraction that underflows f64 -----------------------------------
+is Rat.new(1, 10**400).Str, '0',
+   'a Rat whose fraction underflows f64 renders as its whole part';
+
+# --- a long but representable fraction --------------------------------
+is Rat.new(1, 10**40).Str, '0.' ~ '0' x 39 ~ '1',
+   'a 41-digit denominator still renders its digits, not a Num';


### PR DESCRIPTION
```raku
my $a = .1234567890123456789012345;
say $a.Str;
# raku:  0.1234567890123456824475648
# mutsu: 0.12345678901234568
```

The *value* was already right — `.numerator`, `.denominator` and `.raku` were
byte-identical to rakudo, so the literal parsed exactly. Only the rendering
diverged: the `BigRat` arm of `to_string_value` shortcut any `Rat` whose
denominator ran past ~20 digits through its `Num` value, printing f64's 17-digit
shortest round-trip.

## What rakudo actually does

`Rat` is `Rational[Int, uint64]`, so an arithmetic result whose denominator does
not fit `uint64` degrades to `Num`. `Rational.Str` reaches its fractional part
through such an operation, which means the digit budget it then applies
(`|denom| < 100_000 ?? 6 !! chars(|denom|) + 1`) is filled from **f64**. Rakudo's
25 digits are therefore neither the exact expansion
(`0.1234567890123456789012345`) nor f64's shortest form — they are
`round(fract * 10^digits)` evaluated in f64 and zero-stripped.

`FatRat` is `Rational[Int, Int]` and never degrades, which is what pins the
rule: the same numerator/denominator pair renders `0.1234567890123456824475648`
as a `Rat` and `0.1234567890123456789012345` as a `FatRat`. The boundary is
exactly `uint64` — a denominator of `2^64-1` is still exact, `2^64` is not
(measured against rakudo 2026.07).

## The fix

- `format_rat_str_bigint` (`src/value/display.rs`) grew that degradation as
  `f64_scaled_fraction`, and the `BigRat` arm now hands it *every* big rational
  instead of shortcutting through `Num`. A fraction that underflows f64 still
  renders as its whole part (`Rat.new(1, 10**400).Str` is `0`, as in rakudo); a
  scale too large for f64 falls back to the exact expansion, since rakudo is not
  self-consistent that far out (it dies with a P6opaque unbox error) and staying
  finite beats emitting `Inf`.
- The ticket's **sign row** turned out to be a second, adjacent bug:
  `prefix:<->` on a big-denominator `Rat` literal produced a **FatRat**, because
  `arith_negate` routed it through the *arithmetic* constructor and
  `is_fat_rat_like` reads an over-`uint64` denominator as proof of FatRat-ness.
  Negation cannot change the denominator, so it never degrades; the arm now
  consults the stored FatRat flag (which its own comment already calls
  authoritative) and uses the non-degrading constructor.
  `(-1.1234567890123456789012345).^name` is `Rat` again.

## Testing

- A 62-row `Rat`/`FatRat` × denominator matrix (including both sides of the
  `uint64` boundary, negative values, the round-up-to-integer case and
  underflowing fractions) is now **byte-identical to rakudo**; it was 12 rows
  apart before.
- `t/big-denominator-rat-str.t` (new, 27 assertions) passes **unchanged under
  rakudo**. `t/decimal-literal-big-integer-part.t`, which pins the value half,
  is unmoved.
- `cargo fmt --all`, `cargo clippy --all-targets -- -D warnings`, `make test`
  (3840 files, 40612 tests, all successful).
- `make roast`: byte-identical to this branch's own pre-change baseline — the
  only failures are this container's environment (`6.c/S32-io/file-tests.t` and
  `S16-filehandles/filetest.t` `chmod` assertions, which a uid-0 session
  bypasses, and an `IO-Socket-Async.t` timeout).

Closes #7577

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LLx8uvQEDwyt9iydWiPgpp

---
_Generated by [Claude Code](https://claude.ai/code/session_01LLx8uvQEDwyt9iydWiPgpp)_