### PR TITLE
fix(regex): a Unicode-quoted literal's contents are data, not operators

### DIFF
--- a/src/runtime/regex_parse.rs
+++ b/src/runtime/regex_parse.rs
@@ -185,6 +185,36 @@ pub(crate) fn regex_pattern_is_static(pattern: &str) -> bool {
     true
 }
 
+/// The closing delimiter for a Raku quote opener, or `None` when `ch` does not
+/// open a quoted literal.
+///
+/// Raku's quoting language is not limited to `'`/`"`: the smart-quote pairs
+/// `‘...’` / `‚...’` and `“...”` / `„...”`, and the Q-lang corner brackets
+/// `｢...｣`, are ordinary string literals too. Their contents are DATA, so a
+/// structural scanner that walks a pattern looking for regex operators must
+/// skip them exactly as it skips `'...'` -- otherwise a `%`, `|`, `&`, `<` or
+/// `>` inside one is mistaken for the separated-quantifier operator, an
+/// alternation, a conjunction or an assertion bracket.
+///
+/// Every Unicode pair closes with a character that differs from its opener,
+/// which is why callers track the CLOSER returned here instead of comparing
+/// against the character that opened the span. That is the whole reason the
+/// `in_single_quote`/`in_double_quote` boolean pairs these scanners used could
+/// not simply be extended: a bool cannot say *which* delimiter ends the span.
+///
+/// Nesting is not modelled -- rakudo lets `‘a ‘b’ c’` nest, but the first closer
+/// ends the span here, matching how the `'`/`"` spans have always been scanned.
+pub(super) fn regex_quote_closer(ch: char) -> Option<char> {
+    match ch {
+        '\'' => Some('\''),
+        '"' => Some('"'),
+        '\u{2018}' | '\u{201A}' => Some('\u{2019}'),
+        '\u{201C}' | '\u{201E}' => Some('\u{201D}'),
+        '\u{FF62}' => Some('\u{FF63}'),
+        _ => None,
+    }
+}
+
 /// Return the character index immediately after a regex comment beginning at
 /// `start`, or `None` when `start` is not a comment marker.
 ///

--- a/src/runtime/regex_parse_core.rs
+++ b/src/runtime/regex_parse_core.rs
@@ -73,8 +73,12 @@ fn scan_angle_assertion_body(rest: &[char], honor_quotes: bool) -> AngleBodyScan
             '\'' if apostrophe_in_ident => {
                 name.push(ch);
             }
-            '\'' | '"' if honor_quotes && bracket_depth == 0 => {
-                quote = Some(ch);
+            opener
+                if honor_quotes
+                    && bracket_depth == 0
+                    && super::regex_parse::regex_quote_closer(opener).is_some() =>
+            {
+                quote = super::regex_parse::regex_quote_closer(opener);
                 name.push(ch);
             }
             // `(`/`)`/`{`/`}` only nest outside an enumerated char class
@@ -2298,7 +2302,12 @@ impl Interpreter {
                             // A quoted literal inside the assertion may contain
                             // the angle brackets themselves (`<!before '%>' >`,
                             // `<!before '<%' >`), so its content must not move
-                            // the angle-depth count.
+                            // the angle-depth count. `regex_quote_closer`
+                            // recognizes the Unicode quote pairs as well as
+                            // `'`/`"` -- `<!before ‘<%’>` is how
+                            // `Template::Classic` writes exactly this -- and it
+                            // answers the CLOSER, which differs from the opener
+                            // for every Unicode pair.
                             let mut quote: Option<char> = None;
                             while let Some(ch) = chars.next() {
                                 if ch == '\\' {
@@ -2320,8 +2329,8 @@ impl Interpreter {
                                     inner.push(ch);
                                     continue;
                                 }
-                                if ch == '\'' || ch == '"' {
-                                    quote = Some(ch);
+                                if let Some(closer) = super::regex_parse::regex_quote_closer(ch) {
+                                    quote = Some(closer);
                                     inner.push(ch);
                                 } else if ch == '<' && {
                                     let mut la = chars.clone();

--- a/src/runtime/regex_parse_ltm.rs
+++ b/src/runtime/regex_parse_ltm.rs
@@ -110,8 +110,10 @@ impl Interpreter {
         let mut depth_brace = 0i32;
         let mut depth_angle = 0i32;
         let mut escaped = false;
-        let mut in_single_quote = false;
-        let mut in_double_quote = false;
+        // The closer of the quoted literal currently open, if any. Tracking the
+        // CLOSER (not a per-delimiter bool) is what lets the Unicode quote
+        // pairs be skipped too -- see `regex_quote_closer`.
+        let mut quote: Option<char> = None;
         let mut is_sequential = false;
         let mut chars = pattern.chars().peekable();
 
@@ -127,8 +129,7 @@ impl Interpreter {
                 continue;
             }
             if depth_angle == 0
-                && !in_single_quote
-                && !in_double_quote
+                && quote.is_none()
                 && consume_regex_comment(ch, &mut chars, &mut current)
             {
                 continue;
@@ -140,17 +141,17 @@ impl Interpreter {
             // following `||` never split. The split operators below all require
             // `depth_angle == 0` anyway, so an assertion's contents cannot produce
             // a spurious split and need no quote tracking at all.
-            if ch == '\'' && !in_double_quote && depth_angle == 0 {
-                in_single_quote = !in_single_quote;
+            if let Some(closer) = quote {
+                if ch == closer {
+                    quote = None;
+                }
                 current.push(ch);
                 continue;
             }
-            if ch == '"' && !in_single_quote && depth_angle == 0 {
-                in_double_quote = !in_double_quote;
-                current.push(ch);
-                continue;
-            }
-            if in_single_quote || in_double_quote {
+            if depth_angle == 0
+                && let Some(closer) = super::regex_parse::regex_quote_closer(ch)
+            {
+                quote = Some(closer);
                 current.push(ch);
                 continue;
             }
@@ -236,8 +237,10 @@ impl Interpreter {
         let mut depth_brace = 0i32;
         let mut depth_angle = 0i32;
         let mut escaped = false;
-        let mut in_single_quote = false;
-        let mut in_double_quote = false;
+        // The closer of the quoted literal currently open, if any. Tracking the
+        // CLOSER (not a per-delimiter bool) is what lets the Unicode quote
+        // pairs be skipped too -- see `regex_quote_closer`.
+        let mut quote: Option<char> = None;
         let mut chars = pattern.chars().peekable();
 
         while let Some(ch) = chars.next() {
@@ -252,8 +255,7 @@ impl Interpreter {
                 continue;
             }
             if depth_angle == 0
-                && !in_single_quote
-                && !in_double_quote
+                && quote.is_none()
                 && consume_regex_comment(ch, &mut chars, &mut current)
             {
                 continue;
@@ -261,17 +263,17 @@ impl Interpreter {
             // See `split_top_level_alternation`: `'`/`"` inside a `<...>` assertion
             // are literal word characters, and the `&`/`&&` split below requires
             // `depth_angle == 0`, so quote tracking must pause inside an assertion.
-            if ch == '\'' && !in_double_quote && depth_angle == 0 {
-                in_single_quote = !in_single_quote;
+            if let Some(closer) = quote {
+                if ch == closer {
+                    quote = None;
+                }
                 current.push(ch);
                 continue;
             }
-            if ch == '"' && !in_single_quote && depth_angle == 0 {
-                in_double_quote = !in_double_quote;
-                current.push(ch);
-                continue;
-            }
-            if in_single_quote || in_double_quote {
+            if depth_angle == 0
+                && let Some(closer) = super::regex_parse::regex_quote_closer(ch)
+            {
+                quote = Some(closer);
                 current.push(ch);
                 continue;
             }
@@ -334,8 +336,10 @@ impl Interpreter {
     }
 
     fn has_unquoted_ltm_separator(pattern: &str) -> bool {
-        let mut in_single = false;
-        let mut in_double = false;
+        // See `regex_quote_closer`: a `%` inside ANY quoted literal is data.
+        // Tracking only `'`/`"` here made `/ ‘a%b’ /` look like a separated
+        // quantifier, and the string rewrite below then mangled the pattern.
+        let mut quote: Option<char> = None;
         let mut escaped = false;
         let chars_vec: Vec<char> = pattern.chars().collect();
         let mut i = 0;
@@ -351,19 +355,21 @@ impl Interpreter {
                 i += 1;
                 continue;
             }
-            if ch == '\'' && !in_double {
-                in_single = !in_single;
+            if let Some(closer) = quote {
+                if ch == closer {
+                    quote = None;
+                }
                 i += 1;
                 continue;
             }
-            if ch == '"' && !in_single {
-                in_double = !in_double;
+            if let Some(closer) = super::regex_parse::regex_quote_closer(ch) {
+                quote = Some(closer);
                 i += 1;
                 continue;
             }
             // Skip <...> angle brackets — % inside assertions/character classes
             // is not a separator
-            if !in_single && !in_double && ch == '<' {
+            if quote.is_none() && ch == '<' {
                 i += 1;
                 let mut angle_depth = 1u32;
                 while i < chars_vec.len() && angle_depth > 0 {
@@ -383,7 +389,7 @@ impl Interpreter {
             }
             // Skip [...] bracket groups — % inside bracket character classes
             // is not a separator
-            if !in_single && !in_double && ch == '[' {
+            if quote.is_none() && ch == '[' {
                 i += 1;
                 let mut bracket_depth = 1u32;
                 while i < chars_vec.len() && bracket_depth > 0 {
@@ -403,7 +409,7 @@ impl Interpreter {
             }
             // Skip { ... } code blocks — a `%` inside embedded main-slang code
             // is not a regex separator.
-            if !in_single && !in_double && ch == '{' {
+            if quote.is_none() && ch == '{' {
                 i += 1;
                 let mut brace_depth = 1u32;
                 while i < chars_vec.len() && brace_depth > 0 {
@@ -419,7 +425,7 @@ impl Interpreter {
             // Skip an embedded declaration `:my … ;` / `:our …` / `:constant …` —
             // its body is main-slang code, so a `%*var` in it (`:my %*PLAYED = ()`)
             // is not a regex separator.
-            if !in_single && !in_double && ch == ':' {
+            if quote.is_none() && ch == ':' {
                 let rest: String = chars_vec[i + 1..].iter().collect();
                 if rest.starts_with("my ")
                     || rest.starts_with("our ")
@@ -437,7 +443,7 @@ impl Interpreter {
                     continue;
                 }
             }
-            if !in_single && !in_double && ch == '%' {
+            if quote.is_none() && ch == '%' {
                 // Check if this is hash aliasing: %<name>= or %ident=
                 let mut j = i + 1;
                 if j < chars_vec.len() && chars_vec[j] == '<' {
@@ -751,16 +757,9 @@ impl Interpreter {
                 }
                 j
             }
-            // Quoted strings: '...' / "..." and unicode quote pairs
-            '\'' | '"' | '\u{2018}' | '\u{201A}' | '\u{201C}' | '\u{201E}' | '\u{FF62}' => {
-                let close = match chars[0] {
-                    '\'' => '\'',
-                    '"' => '"',
-                    '\u{2018}' | '\u{201A}' => '\u{2019}',
-                    '\u{201C}' | '\u{201E}' => '\u{201D}',
-                    '\u{FF62}' => '\u{FF63}',
-                    _ => chars[0],
-                };
+            // Quoted strings: '...' / "..." and the unicode quote pairs.
+            c if super::regex_parse::regex_quote_closer(c).is_some() => {
+                let close = super::regex_parse::regex_quote_closer(chars[0]).unwrap_or(chars[0]);
                 let mut j = 1;
                 while j < chars.len() {
                     if chars[j] == '\\' {

--- a/t/regex-unicode-quoted-literal-is-opaque.t
+++ b/t/regex-unicode-quoted-literal-is-opaque.t
@@ -1,0 +1,62 @@
+use Test;
+
+plan 23;
+
+# A quoted literal's contents are DATA. The structural scanners that walk a
+# pattern looking for regex operators skipped `'...'` and `"..."` but not the
+# Unicode quote pairs, so a `%`, `|`, `&`, `<` or `>` inside one of those was
+# mistaken for the separated-quantifier operator, an alternation, a conjunction
+# or an assertion bracket. Every Unicode pair closes with a character that
+# differs from its opener, which is why the old `in_single`/`in_double` boolean
+# pairs could not express it -- a bool cannot say which delimiter ends the span.
+
+# --- the separated-quantifier operator ---------------------------------------
+
+ok 'a%b' ~~ / ^ ‘a%b’ $ /,   'a % inside a smart-quoted literal is a literal %';
+ok 'a%b' ~~ / ^ “a%b” $ /,   'the same in double smart quotes';
+ok 'a%b' ~~ / ^ ｢a%b｣ $ /,   'the same in Q-lang corner brackets';
+ok 'a%b' ~~ / ^ 'a%b' $ /,   'the plain-quote form, which always worked';
+ok '%'   ~~ / ^ ‘%’ $ /,     'a lone % is a literal';
+ok 'a%%b' ~~ / ^ ‘a%%b’ $ /, 'a doubled %% is a literal too';
+
+# The real separator quantifier must keep working beside it.
+ok 'a,b,c' ~~ / ^ [ \w+ ]+ % ‘,’ $ /,
+    'a smart-quoted separator still parses AS a separator';
+ok 'a,b,c' ~~ / ^ [ \w+ ]+ % ',' $ /,
+    'and so does the plain-quoted one';
+
+# --- alternation and conjunction ---------------------------------------------
+
+ok 'a|b'  ~~ / ^ ‘a|b’ $ /,  'a | inside a smart-quoted literal is a literal |';
+ok 'a||b' ~~ / ^ ‘a||b’ $ /, 'and so is a doubled ||';
+ok 'a&b'  ~~ / ^ ‘a&b’ $ /,  'an & inside one is a literal &';
+ok 'a'    ~~ / ^ [ ‘a|b’ | ‘a’ ] $ /,
+    'a real alternation beside a quoted | still splits correctly';
+
+# --- angle brackets, in and out of an assertion ------------------------------
+
+ok '<%' ~~ / ^ ‘<%’ $ /,     'an angle bracket inside a smart-quoted literal';
+ok '%>' ~~ / ^ ‘%>’ $ /,     'and the closing one';
+ok 'a'  ~~ / <!before ‘<%’> . /,
+    'a smart-quoted literal carrying < inside a lookahead assertion';
+ok 'a'  ~~ / <!before ‘%>’> . /,
+    'and one carrying > -- the assertion must not close early';
+ok 'a'  ~~ / <!before ｢<%｣> . /, 'the corner-bracket form of the same';
+nok '<%' ~~ / ^ <!before ‘<%’> . /,
+    'the assertion still actually fires when it should';
+
+# --- the shape Template::Classic is built from -------------------------------
+
+{
+    my grammar G {
+        token TOP  { ^ [ $<part> = <text> || $<part> = <code> || <!before $> { die 'Unterminated' } ]* $ }
+        token text { [ <!before ‘<%’> . ]+ }
+        token code { ‘<%’ [ $<put> = ‘=’ ]? $<source> = [ <!before ‘%>’> . ]* ‘%>’ }
+    }
+    my $m = G.parse('<ul><% x %></ul>');
+    ok $m.defined, 'the Template::Classic grammar parses';
+    is $m<part>.elems, 3, 'and finds all three parts';
+    is $m<part>[0].Str, '<ul>', 'the leading text part';
+    is $m<part>[1].Str, '<% x %>', 'the code part';
+    is $m<part>[2].Str, '</ul>', 'the trailing text part';
+}


### PR DESCRIPTION
Closes the `Template::Classic` row of #7553 (0/1 → **1/1**).

## The divergence

A quoted literal's contents are DATA. The structural scanners that walk a
pattern looking for regex operators skipped `'...'` and `"..."` but not the
Unicode quote pairs, so a `%`, `|`, `&`, `<` or `>` inside one was mistaken for
the separated-quantifier operator, an alternation, a conjunction or an assertion
bracket:

| pattern | raku | mutsu (before) |
| --- | --- | --- |
| `'a%b' ~~ / ^ ‘a%b’ $ /` | True | **False** |
| `'a%b' ~~ / ^ ｢a%b｣ $ /` | True | **False** |
| `'a|b' ~~ / ^ ‘a|b’ $ /` | True | **dies**, "Unrecognized regex metacharacter ’" |
| `'a&b' ~~ / ^ ‘a&b’ $ /` | True | **dies** |
| `'a' ~~ / <!before ‘<%’> . /` | True | **False** |
| `'a%b' ~~ / ^ 'a%b' $ /` | True | True ✅ (the ASCII form always worked) |

## The fix

Every Unicode pair closes with a character that *differs* from its opener, which
is why the `in_single_quote` / `in_double_quote` boolean pairs these scanners
used could not simply be extended: **a bool cannot say which delimiter ends the
span.** `regex_quote_closer` answers the closer, and the four scanners now track
that instead of a pair of flags:

- `split_top_level_alternation` and `split_top_level_conjunction`
  (`regex_parse_ltm.rs`) — the `|` / `&` rows;
- `has_unquoted_ltm_separator` (`regex_parse_ltm.rs`) — the `%` row. This one
  gates a **string rewrite**, so a false positive did not merely mis-split, it
  mangled the pattern;
- `scan_angle_assertion_body` and the lookaround-body scanner
  (`regex_parse_core.rs`) — the `<` / `>` rows. The latter's comment already
  named ``<!before '%>' >`` as the exact case it existed for; it just never
  learned the Unicode spelling of it.

The atom-length table in `regex_parse_ltm.rs` already carried its own private
copy of the opener→closer mapping, so it now calls the shared helper too — one
source of truth for the set (`'`, `"`, `‘…’`, `‚…’`, `“…”`, `„…”`, `｢…｣`).

## The ticket's recorded diagnosis was wrong

#7553 says of `Template::Classic`:

> The `$<part> = <rule>` capture-assignment form inside a `||` chain does not
> match.

It does match — transcribing the module's grammar with ASCII quotes makes it pass
unchanged. The dist simply writes **every** literal with curly quotes
(`‘<%’`, `‘%>’`, `‘=’`), and `‘%>’` contains both a `%` and a `>`.

This is the ticket's own standing instruction paying off again: *reduce the real
module rather than theorise from the error message.* Reducing by hand from a
hand-typed grammar found nothing, because I had typed ASCII quotes; running the
actual vendored source and then diffing it against my working transcription made
the cause fall out in one step.

It is also the same bug class as #5468, which fixed `Template::Mojo` — "a quoted
`<`/`>` was counted toward the angle-bracket nesting depth". That fix taught the
scanner about `'` and `"`; the Unicode spelling was left behind.

## Testing

`t/regex-unicode-quoted-literal-is-opaque.t`, 23 assertions, passing **unchanged
under `raku` as well as under mutsu**: the `%`/`|`/`&`/`<`/`>` rows in all three
Unicode quote flavours, the real separator quantifier and a real alternation
still working *beside* a quoted one, the negative case (the assertion still fires
when it should), and the `Template::Classic` grammar itself parsing to its three
parts.

The upstream dist now passes its own suite:

```
$ mutsu -I lib t/test.t
ok 1 -
ok 2 -
ok 3 -
1..3
```

`cargo fmt`, `cargo clippy --all-targets -- -D warnings`, `make test` (Result:
PASS) and `make roast` all run. `make roast` reports three failures, byte-identical
to a run without this diff and all environmental to this container:

- `roast/6.c/S32-io/file-tests.t` and `roast/S16-filehandles/filetest.t` — the
  session runs as **root**, which bypasses the `0333`/`0222`/`0111` mode bits
  those assertions test.
- `roast/S32-io/IO-Socket-Async.t` — hangs at the `# host=::1` round;
  `/proc/net/if_inet6` does not exist here, so there is no IPv6 loopback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ExzRnHAQq5kawQ2oVpLMM9

---
_Generated by [Claude Code](https://claude.ai/code/session_01ExzRnHAQq5kawQ2oVpLMM9)_