### PR TITLE
fix(module): keep a nested module's own imports across a block's import-scope pop

### DIFF
--- a/news/2026-09/block-use-keeps-nested-module-imports.md
+++ b/news/2026-09/block-use-keeps-nested-module-imports.md
@@ -1,0 +1,59 @@
+# A `use` inside a block keeps a nested module's own imports
+
+```raku
+# Inner.rakumod:  unit module Inner; use NativeCall;
+#                 sub inner-probe() is export { defined(&nativecast) ?? 'visible' !! 'MISSING' }
+# Outer.rakumod:  unit module Outer; use NativeCall; use Inner;
+#                 sub outer-probe() is export { inner-probe() }
+
+use lib 'lib';
+{ use Outer; }
+use Outer;
+say outer-probe();     # rakudo: visible    mutsu: MISSING
+```
+
+The block twin of the EVAL bug fixed in
+`news/2026-09/module-loaded-in-an-eval-keeps-its-imports.md` — same symptom,
+different mechanism. What went missing was `Inner`'s own view of `&nativecast`,
+not the script's.
+
+## Root cause
+
+A `unit module`'s body runs at `current_package() == GLOBAL`, so its own
+`use NativeCall` registers `GLOBAL::nativecast`. `pop_import_scope` retained from
+`registry.functions` only keys that are package-qualified *and* not
+`GLOBAL::`-prefixed, so that entry went with the enclosing block's import scope.
+`loaded_modules` is never rolled back, so the later top-level `use Outer`
+short-circuited and could not restore it: the module was left permanently
+half-loaded.
+
+## The fix
+
+`pop_import_scope` now also retains a key that is in
+`module_registered_functions`. That set already holds exactly the right thing:
+its delta is taken **before** `import_module`, so an alias installed for the
+*importing* scope is never in it, and `{ use Foo } foo()` still dies
+(`roast/S11-modules/lexical.t`), as does `{ require NoModule <&bar>; }`'s `&bar`
+(`roast/S11-modules/require.t` test 10). It is the block twin of the carve-out
+`reinstate_module_functions` already gives the EVAL rollback, and it consults
+the existing set rather than recomputing the rule.
+
+Pinned by `t/block-use-keeps-nested-module-imports.t` (plus three fixtures under
+`t/lib/`), which fails on the unfixed binary and passes unchanged under rakudo.
+
+## Two side findings, filed separately
+
+Writing that pin surfaced two things that are not this fix:
+
+- **[#7611](https://github.com/tokuhirom/mutsu/issues/7611)** — a provider
+  module named only inside a **comment** is loaded and imported. The first draft
+  of the pin passed on an *unfixed* binary purely because its header comment
+  said `use NativeCall`; the file now carries a `NOTE:` warning readers off that
+  wording until the scan is driven off the AST instead of the source text.
+- **[#7612](https://github.com/tokuhirom/mutsu/issues/7612)** — the opposite
+  edge: a nested module's import is also visible to the *using* scope, where
+  rakudo hides it. That is pre-existing (it reproduces with no block at all) and
+  needs real lexical scoping for imports rather than another retain rule, so it
+  is filed as `todo:deep`.
+
+Closes #7580.

--- a/src/runtime/runtime_module.rs
+++ b/src/runtime/runtime_module.rs
@@ -105,13 +105,27 @@ impl Interpreter {
             // The IMPORTED aliases (bare names and `GLOBAL::name`) are still
             // removed, so a bare call after the block exits still dies (roast
             // S11-modules/lexical.t: `{ use Foo } EVAL('foo()')`).
+            // `GLOBAL::`-prefixed entries the block itself imported still go,
+            // but one a LOADED MODULE's own body installed stays: a `unit
+            // module`'s body runs at `current_package() == GLOBAL`, so its own
+            // `use NativeCall` registers `GLOBAL::nativecast`, and dropping that
+            // when an enclosing block's import scope popped left the module
+            // half-loaded -- `loaded_modules` still claimed it was loaded, so
+            // the later top-level `use` short-circuited and could not put it
+            // back. `module_registered_functions` is exactly that set: its delta
+            // is taken BEFORE `import_module`, so an alias installed for the
+            // IMPORTING scope is never in it and `{ use Foo } foo()` still dies
+            // (`roast/S11-modules/lexical.t`). This is the block twin of the
+            // carve-out `reinstate_module_functions` gives the EVAL rollback.
+            let module_keys = std::mem::take(&mut self.module_registered_functions);
             self.registry_mut().functions.retain(|key, _| {
-                if func_snapshot.contains(key) {
+                if func_snapshot.contains(key) || module_keys.contains(key) {
                     return true;
                 }
                 let ks = key.resolve();
                 ks.contains("::") && !ks.starts_with("GLOBAL::")
             });
+            self.module_registered_functions = module_keys;
             // Same exception for classes: a module's own package-qualified
             // classes (`ScanCacheHelper::ScanCacheThing`) persist as long as the
             // module is loaded. `loaded_modules` is never rolled back, so a

--- a/t/block-use-keeps-nested-module-imports.t
+++ b/t/block-use-keeps-nested-module-imports.t
@@ -1,0 +1,59 @@
+# A `use` inside a block must not drop a NESTED module's own imports.
+#
+# A `unit module`'s body runs at `current_package() == GLOBAL`, so a `use` in
+# that body registers its aliases under `GLOBAL::`. `pop_import_scope` dropped
+# every `GLOBAL::`-prefixed entry the scope had added, and `loaded_modules` is
+# never rolled back -- so after `{ use Outer; }` the later top-level `use Outer`
+# was a no-op that could not restore what the pop had taken, and the chain saw
+# its own import as missing (GH #7580). The block twin of the EVAL bug fixed in
+# `news/2026-09/module-loaded-in-an-eval-keeps-its-imports.md`.
+#
+# The constraint in the other direction is `roast/S11-modules/lexical.t`:
+# `{ use Foo }` must still leave `foo()` unresolvable outside the block. That
+# holds because the module-body delta is taken BEFORE `import_module`, so an
+# alias installed for the IMPORTING scope is never in the retained set.
+#
+# NOTE: do NOT name the provider the fixtures import in a comment here. mutsu
+# picks a provider module out of the source text even inside a comment, which
+# loads it at the top level and masks the very failure this file pins (GH
+# #7611). Delete this paragraph when that is fixed.
+#
+# The opposite edge -- that the nested module's import is also visible to the
+# USING scope, where rakudo hides it -- is pre-existing and tracked as GH #7612;
+# it reproduces with no block at all, so it is deliberately not asserted here.
+use lib $?FILE.IO.parent.add('lib').Str;
+use Test;
+
+plan 4;
+
+{
+    use BlockUseNestedOuter;
+}
+use BlockUseNestedOuter;
+is outer-probe(), 'visible',
+   "a nested module's own import survives an enclosing block's import-scope pop";
+
+# The same shape one level down: the block-scoped `use` is of the module that
+# does the nested import itself.
+{
+    use BlockUseNestedInner;
+}
+use BlockUseNestedInner;
+is inner-probe(), 'visible',
+   "the nested importer's own view of its import survives too";
+
+# The constraint in the other direction, with a plain module: a block-scoped
+# `use` must still not leak its own imported alias past the block. That alias is
+# installed by `import_module` AFTER the module-body delta is taken, so it is
+# not in the retained set.
+{
+    use BlockUseNestedLeaf;
+}
+nok defined(::('&leaf-probe')),
+    "a block-scoped use does not leak the importing scope's own alias";
+
+# And the chain still resolves after yet another block-scoped `use`.
+{
+    use BlockUseNestedInner;
+}
+is outer-probe(), 'visible', 'the chain still resolves after a repeated block-scoped use';

--- a/t/lib/BlockUseNestedInner.rakumod
+++ b/t/lib/BlockUseNestedInner.rakumod
@@ -1,0 +1,8 @@
+unit module BlockUseNestedInner;
+use NativeCall;
+
+# `Inner`'s OWN view of `&nativecast`, not the script's. A `unit module` body
+# runs at `current_package() == GLOBAL`, so this import registers
+# `GLOBAL::nativecast` -- an entry an enclosing block's import-scope pop used to
+# drop. See `t/block-use-keeps-nested-module-imports.t`.
+sub inner-probe() is export { defined(&nativecast) ?? 'visible' !! 'MISSING' }

--- a/t/lib/BlockUseNestedLeaf.rakumod
+++ b/t/lib/BlockUseNestedLeaf.rakumod
@@ -1,0 +1,7 @@
+unit module BlockUseNestedLeaf;
+
+# A plain exporting module, used to pin the OTHER direction: a block-scoped
+# `use` of it must not leak its export past the block
+# (`roast/S11-modules/lexical.t`'s rule). See
+# `t/block-use-keeps-nested-module-imports.t`.
+sub leaf-probe() is export { 'leaf' }

--- a/t/lib/BlockUseNestedOuter.rakumod
+++ b/t/lib/BlockUseNestedOuter.rakumod
@@ -1,0 +1,5 @@
+unit module BlockUseNestedOuter;
+use NativeCall;
+use BlockUseNestedInner;
+
+sub outer-probe() is export { inner-probe() }


### PR DESCRIPTION
```raku
# Inner.rakumod:  unit module Inner; use NativeCall;
#                 sub inner-probe() is export { defined(&nativecast) ?? 'visible' !! 'MISSING' }
# Outer.rakumod:  unit module Outer; use NativeCall; use Inner;
#                 sub outer-probe() is export { inner-probe() }

use lib 'lib';
{ use Outer; }
use Outer;
say outer-probe();     # rakudo: visible    mutsu: MISSING
```

The block twin of the EVAL bug fixed in
`news/2026-09/module-loaded-in-an-eval-keeps-its-imports.md`. What went missing
is `Inner`'s own view of `&nativecast` — the nested module's import, not the
script's.

## Root cause

A `unit module`'s body runs at `current_package() == GLOBAL`, so its own
`use NativeCall` registers `GLOBAL::nativecast`. `pop_import_scope` retained from
`registry.functions` only keys that are package-qualified *and* not
`GLOBAL::`-prefixed, so that entry went with the enclosing block's import scope.
`loaded_modules` is never rolled back, so the later top-level `use Outer`
short-circuited and could not restore it: the module was left permanently
half-loaded.

## The fix

`pop_import_scope` now also retains a key that is in
`module_registered_functions`. That set already holds exactly the right thing:
its delta is taken **before** `import_module`, so an alias installed for the
*importing* scope is never in it. It is the block twin of the carve-out
`reinstate_module_functions` already gives the EVAL rollback, and — as the
ticket predicted — it consults the existing set rather than recomputing the
rule.

Both constraint tests still pass: `roast/S11-modules/lexical.t`
(`{ use Foo } foo()` must still die) and `roast/S11-modules/require.t` test 10
(`{ require NoModule <&bar>; }` must not leak `&bar`).

## Testing

- `t/block-use-keeps-nested-module-imports.t` (new, 4 assertions) plus three
  fixtures under `t/lib/`. It **fails on the unfixed binary** and passes
  unchanged under rakudo. It also pins the other direction with a plain module:
  a block-scoped `use` must not leak the importing scope's own alias.
- `roast/S11-modules/{lexical,require}.t` and `t/module-reuse-class-in-block.t`
  run directly.
- `cargo fmt --all`, `cargo clippy --all-targets -- -D warnings`, `make test`
  (3843 files, 40670 tests, all successful).
- `make roast`: byte-identical to this branch's own pre-change baseline — the
  only failures are this container's environment (`6.c/S32-io/file-tests.t` and
  `S16-filehandles/filetest.t` `chmod` assertions, which a uid-0 session
  bypasses, and an `IO-Socket-Async.t` timeout).

## Two side findings, filed separately

Writing that pin surfaced two things that are **not** this fix:

- **#7611** — a provider module named only inside a **comment** is loaded and
  imported. The first draft of the pin passed on an *unfixed* binary purely
  because its header comment said `use NativeCall`; the file now carries a
  `NOTE:` warning readers off that wording until the scan is driven off the AST.
- **#7612** — the opposite edge: a nested module's import is also visible to the
  *using* scope, where rakudo hides it. Pre-existing (it reproduces with no
  block at all) and needs real lexical scoping for imports, so it is filed as
  `todo:deep`.

Closes #7580

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LLx8uvQEDwyt9iydWiPgpp

---
_Generated by [Claude Code](https://claude.ai/code/session_01LLx8uvQEDwyt9iydWiPgpp)_