### PR TITLE
test: classify ADR-0068's three unexercised lane-decline reasons

### DIFF
--- a/docs/adr/0068-cross-thread-container-writes-need-a-synchronized-store.md
+++ b/docs/adr/0068-cross-thread-container-writes-need-a-synchronized-store.md
@@ -87,7 +87,9 @@ MUTSU_FUDGE=1 rust-gdb -batch \
 
 Breakpoint 1 is the unsynchronized aliased element store (the site the crash backtrace named);
 breakpoint 2 is the synchronized lane. `already hit N times` on 1 with nothing on 2 means the
-workload is **exposed**. This oracle is deterministic, costs one debug run, and settled every
+workload is **exposed**. **STALE since §7 — read §13.1 before using this.** The guard §7 added
+lexically contains that store site, so breakpoint 1 now fires on covered writes too; the
+discriminator is the store site hit *without* the guard, which needs a third breakpoint. This oracle is deterministic, costs one debug run, and settled every
 route in §3 in minutes — where the stress harness needs hundreds of runs to say the same thing
 probabilistically.
 
@@ -666,8 +668,82 @@ also records the candidates this measurement does *not* exclude (the
 reaping state).
 
 With §11 and this section, **nothing in §3 is Exposed-and-unmeasured any more.**
-What is left of §4 step 3 is the §2 lane-decline reasons that no route has yet
-exercised: a twigil'd name, a name masked as re-declared, and a container that
-was never in a spawning frame's env. Each wants its own oracle-classified probe;
-§12.1 is the reminder to run the oracle rather than to reason from a route's
+What was left of §4 step 3 at that point — the §2 lane-decline reasons that no
+route had yet exercised — is measured in **§13**: a twigil'd name, a name masked
+as re-declared, and a container that was never in a spawning frame's env are all
+covered. §12.1 is the reminder to run the oracle rather than to reason from a
+route's shape, and §13.1 corrects the oracle recipe itself.
+
+## 13. Step 3, final slice (2026-09-08): the three unexercised §2 reasons, and a correction to §1.2
+
+§2 lists five reasons the name-keyed lane declines a container element store.
+Three had never been exercised by a probe: the name is not a plain lexical
+`@`/`%` (a twigil), the name is masked as re-declared, and the container was
+never in a spawning frame's env. Each now has its own oracle-classified probe
+and stress acceptance, and **all three are covered** — by one funnel or the
+other, with nothing reaching an unguarded store.
+
+### 13.1 Read this before using §1.2's recipe again — it is stale
+
+§1.2 says to break on "the unsynchronized aliased element store" and reads
+`already hit N times` there, with nothing on the lane, as **exposed**. That was
+true when it was written. It is **not true now**, and following it verbatim
+produces a false positive: §7 put `ContainerStructGuard::acquire_for` at
+`vm_var_assign_index_named.rs:2379`, and that guard is a scope guard whose
+region lexically contains both the hash store and the array store further down
+the same function. So the store site fires on covered writes too.
+
+The discriminator today is **the store site hit *without* the guard**. Break on
+three things, not two — `ContainerStructGuard::acquire_for`, the lane
+(`shared_array_elem_set`), and the store site — and read:
+
+| guard | lane | store site | verdict |
+|---|---|---|---|
+| N | 0 | N | covered by the cell-keyed guard |
+| 0 | N | 0 | covered by the name-keyed lane |
+| 0 | 0 | N | **exposed** |
+| 0 | 0 | 0 | the workload does no aliased container write at all (see §12) |
+
+### 13.2 The probes and what they measured
+
+Breakpoint 3 below is `assign_array_elem_to_shared_var`, the lane's *entry*: it
+counts declines as well as acceptances, so it confirms the probe really did put
+the intended §2 reason in front of the lane rather than missing it.
+
+| probe (§2 reason) | guard | lane entry | lane accept | array store | hash store | verdict |
+|---|---|---|---|---|---|---|
+| dynamic `@*log` via a named sub (not a plain lexical name) | 1000 | 1000 | 0 | 1000 | — | covered, cell |
+| dynamic `%*reg` via a named sub (the hash twin) | 1000 | — | — | — | 1000 | covered, cell |
+| `@seen` masked by a slurpy `*@seen` parameter (re-declared) | 0 | 1000 | **1000** | 0 | — | covered, lane |
+| `@a` reaching the writer only as a parameter (never in a spawning frame's env) | 1000 | 1000 | 0 | 1000 | — | covered, cell |
+
+The re-declared row is the interesting one: `thread_redeclared_vars` is keyed by
+**name, not by scope**, so a slurpy parameter anywhere in the program masks the
+outer container's writes too — and that decline lands them on the atomic
+`__mutsu_atomic_arr::` store rather than off the edge.
+
+### 13.3 Acceptance (debug build, `MUTSU_GC=on MUTSU_GC_EVERY_CANDIDATE=1024 MUTSU_GC_VERIFY=1`, 24-way)
+
+**0 / 96 failures on each of the four probes** — 0 / 384 in total.
+
+Pin: `t/concurrent-lane-decline-routes.t`. Note what it pins: rakudo gives
+concurrent `@a[$i] = ...` no atomicity at all and loses updates on three of the
+four blocks (1 of 4 passing, on each of three runs), so this is **mutsu's
+exclusion invariant**, not a Raku guarantee — which is precisely what this ADR
+set out to buy.
+
+### 13.4 Step 3 is complete
+
+All five §2 reasons are now classified, every §3 route is measured, and §12 took
+the one unexplained crash off this ledger. The evidence across §8, §10, §11 and
+§13 is consistent: this class has **three funnels** — the named element store,
+the attribute-rooted element store, and the mutating method — and every route
+tried since arrives at one of them. §8's advice stands for anything new: probe
+first, with the corrected §13.1 recipe, rather than reasoning from a route's
 shape.
+
+What remains is not exposure but a **measurement**, and it is a perf question
+rather than a correctness one: §7's read-side guard sits in `Value::with_deref`
+/ `into_deref`, which are hot, and a threaded program now takes a mutex on every
+celled-container read. Nothing has measured it. Tracked separately as
+[#7613](https://github.com/tokuhirom/mutsu/issues/7613).

--- a/news/2026-09/lane-decline-reasons-are-all-classified.md
+++ b/news/2026-09/lane-decline-reasons-are-all-classified.md
@@ -1,0 +1,80 @@
+# ADR-0068 step 3 is complete: all five lane-decline reasons are classified
+
+ADR-0068 §2 lists five reasons the name-keyed cross-thread lane declines a
+container element store, and the campaign's remaining scope was exactly "the set
+of ways a container becomes cross-thread reachable while the lane declines".
+Three of the five had never been exercised by a probe: the name is not a plain
+lexical `@`/`%` (a twigil), the name is masked as re-declared, and the container
+was never in a spawning frame's env. Each now has its own oracle-classified
+probe and its own stress acceptance, and all three are **covered**.
+
+## First, a correction to the oracle recipe
+
+ADR-0068 §1.2's `rust-gdb` ignore-counter oracle says to break on "the
+unsynchronized aliased element store" and read `already hit N times` there, with
+nothing on the lane, as **exposed**. That was true when it was written and it is
+**not true now**: §7 put `ContainerStructGuard::acquire_for` at
+`vm_var_assign_index_named.rs:2379`, and that guard is a *scope* guard whose
+region lexically contains both the hash store and the array store further down
+the same function. The store site therefore fires on covered writes too, and
+following the old recipe verbatim produces a false positive.
+
+The discriminator today is **the store site hit without the guard**. Break on
+three things, not two:
+
+| guard | lane | store site | verdict |
+|---|---|---|---|
+| N | 0 | N | covered by the cell-keyed guard |
+| 0 | N | 0 | covered by the name-keyed lane |
+| 0 | 0 | N | **exposed** |
+| 0 | 0 | 0 | the workload does no aliased container write at all |
+
+## The probes
+
+Each writes 1000 elements from 20 concurrent threads, reaching the container
+through exactly one §2 reason. The "lane entry" column counts
+`assign_array_elem_to_shared_var` calls including *declines*, which is how you
+confirm the probe really put the intended reason in front of the lane instead of
+missing it.
+
+| probe (§2 reason) | guard | lane entry | lane accept | array store | hash store | verdict |
+|---|---|---|---|---|---|---|
+| dynamic `@*log` via a named sub | 1000 | 1000 | 0 | 1000 | — | covered, cell |
+| dynamic `%*reg` via a named sub | 1000 | — | — | — | 1000 | covered, cell |
+| `@seen` masked by a slurpy `*@seen` parameter | 0 | 1000 | **1000** | 0 | — | covered, lane |
+| `@a` reaching the writer only as a parameter | 1000 | 1000 | 0 | 1000 | — | covered, cell |
+
+The twigil rows are covered because `is_plain_lexical_name` requires an
+alphabetic second byte, so a dynamic's `*` declines the atomic lane and the
+named sub cells the container instead — straight onto the guard.
+
+The re-declared row is the interesting one. `thread_redeclared_vars` is keyed by
+**name, not by scope**, so a slurpy `*@seen` parameter anywhere in the program
+masks the *outer* `@seen`'s writes too. That decline does not drop the write off
+the edge; it lands it on the atomic `__mutsu_atomic_arr::` store.
+
+## Acceptance
+
+Debug build, `MUTSU_GC=on MUTSU_GC_EVERY_CANDIDATE=1024 MUTSU_GC_VERIFY=1`,
+24-way on 12 cores: **0 / 96 on each of the four probes, 0 / 384 in total.**
+
+Pinned as `t/concurrent-lane-decline-routes.t`. Worth being clear about what
+that file pins: rakudo gives concurrent `@a[$i] = ...` no atomicity at all and
+loses updates on three of the four blocks (1 of 4 passing, on each of three
+runs). This is **mutsu's exclusion invariant**, not a Raku guarantee — which is
+exactly what ADR-0068 set out to buy.
+
+## Step 3 is complete
+
+With §11 (route 5), §12 (the `S17-procasync/stress.t` SIGSEGV, ruled out of this
+class) and §13, all five §2 reasons are classified, every §3 route is measured,
+and the one unexplained crash is off the ledger. The evidence across §8, §10,
+§11 and §13 is consistent: this class has **three funnels** — the named element
+store, the attribute-rooted element store, and the mutating method — and every
+route tried since has arrived at one of them.
+
+`#7543` closes. What is left of ADR-0068 is not exposure but a measurement, and
+a perf one at that: §7's read-side guard sits in `Value::with_deref` /
+`into_deref`, which are hot, and a threaded program now takes a mutex on every
+celled-container read. Nothing has measured it, and it is tracked as
+[#7613](https://github.com/tokuhirom/mutsu/issues/7613).

--- a/t/concurrent-lane-decline-routes.t
+++ b/t/concurrent-lane-decline-routes.t
@@ -1,0 +1,66 @@
+use Test;
+
+# ADR-0068 §2 lists five reasons the name-keyed cross-thread lane declines a
+# container element store. Three of them had never been exercised by a probe:
+# the name is not a plain lexical `@`/`%` (a twigil), the name is masked as
+# re-declared, and the container was never in a spawning frame's env.
+#
+# Each block below reaches a container through exactly one of those reasons and
+# writes 1000 elements from 20 concurrent threads. Measured with the §1.2
+# oracle, the twigil'd and parameter-only routes land on the cell-keyed
+# `ContainerStructGuard` and the re-declared route lands on the name-keyed
+# `shared_array_elem_set` lane -- so all three are covered, by one funnel or the
+# other, and none reaches an unguarded aliased store.
+#
+# These pin MUTSU's exclusion invariant, not a Raku guarantee: rakudo gives
+# concurrent `@a[$i] = ...` no atomicity at all and loses updates on three of
+# the four blocks below (measured 2026-09-08: 1 of 4 passing, on each of three
+# runs). mutsu is deterministic here -- 0 failures in 384 runs at 24-way on 12
+# cores under the gc-stress environment -- because the lane and the guard make
+# it so, which is exactly what ADR-0068 set out to buy.
+
+plan 4;
+
+# Reason 1: the name is not a plain lexical `@`/`%`. `is_plain_lexical_name`
+# requires an alphabetic second byte, so a dynamic's `*` twigil declines the
+# atomic lane; the container is celled by the named sub instead.
+{
+    my @*log;
+    sub put-it($i) { @*log[$i] = 1 }
+    await (^20).map: -> $t { start { for ^50 -> $k { put-it($t * 50 + $k) } } };
+    is @*log.grep(*.defined).elems, 1000,
+        'every element store through a dynamic array lands';
+}
+
+# The hash twin of the same reason.
+{
+    my %*reg;
+    sub set-it($k) { %*reg{$k} = 1 }
+    await (^20).map: -> $t { start { for ^50 -> $k { set-it("k{$t * 50 + $k}") } } };
+    is %*reg.elems, 1000, 'every key store through a dynamic hash lands';
+}
+
+# Reason 2: the name is masked as re-declared. A slurpy parameter of the same
+# name records it in `thread_redeclared_vars`, which is keyed by NAME and not by
+# scope, so the lane declines for the outer container's writes too.
+{
+    my @seen;
+    sub helper(*@seen) { @seen.elems }
+    sub put-seen($i) { @seen[$i] = 1 }
+    helper(1, 2);
+    await (^20).map: -> $t { start { for ^50 -> $k { put-seen($t * 50 + $k) } } };
+    is @seen.grep(*.defined).elems, 1000,
+        'every element store through a re-declared-masked name lands';
+}
+
+# Reason 4: the container was never in a spawning frame's env. It reaches the
+# writer only as a parameter, and no thread body ever names it, so the escape
+# analysis has nothing to see.
+{
+    my @a;
+    sub worker(@dst, $i) { @dst[$i] = 1 }
+    sub drive($i) { worker(@a, $i) }
+    await (^20).map: -> $t { start { for ^50 -> $k { drive($t * 50 + $k) } } };
+    is @a.grep(*.defined).elems, 1000,
+        'every element store through a parameter-only container lands';
+}


### PR DESCRIPTION
ADR-0068 §2 lists five reasons the name-keyed cross-thread lane declines a
container element store, and #7543's remaining scope was exactly *"the set of
ways a container becomes cross-thread reachable while the lane declines"*. Three
had never been exercised by a probe:

- the name is not a plain lexical `@`/`%` (a twigil);
- the name is masked as re-declared;
- the container was never in a spawning frame's env.

Each now has its own oracle-classified probe and its own stress acceptance, and
**all three are covered** — by one funnel or the other, with nothing reaching an
unguarded store.

## First, a correction the next investigator needs: §1.2's recipe is stale

§1.2 says to break on "the unsynchronized aliased element store" and read
`already hit N times` there, with nothing on the lane, as **exposed**. That was
true when it was written and it is **not true now**: §7 put
`ContainerStructGuard::acquire_for` at `vm_var_assign_index_named.rs:2379`, and
that guard is a *scope* guard whose region lexically contains both the hash
store and the array store further down the same function. The store site
therefore fires on covered writes too, and following the old recipe verbatim
produces a false positive.

The discriminator today is **the store site hit without the guard** — three
breakpoints, not two:

| guard | lane | store site | verdict |
|---|---|---|---|
| N | 0 | N | covered by the cell-keyed guard |
| 0 | N | 0 | covered by the name-keyed lane |
| 0 | 0 | N | **exposed** |
| 0 | 0 | 0 | the workload does no aliased container write at all (§12) |

## The probes

Each writes 1000 elements from 20 concurrent threads, reaching the container
through exactly one §2 reason. The **lane entry** column counts
`assign_array_elem_to_shared_var` calls *including declines* — that is how you
confirm the probe really put the intended reason in front of the lane instead of
missing it.

| probe (§2 reason) | guard | lane entry | lane accept | array store | hash store | verdict |
|---|---|---|---|---|---|---|
| dynamic `@*log` via a named sub | 1000 | 1000 | 0 | 1000 | — | covered, cell |
| dynamic `%*reg` via a named sub | 1000 | — | — | — | 1000 | covered, cell |
| `@seen` masked by a slurpy `*@seen` parameter | 0 | 1000 | **1000** | 0 | — | covered, lane |
| `@a` reaching the writer only as a parameter | 1000 | 1000 | 0 | 1000 | — | covered, cell |

The twigil rows are covered because `is_plain_lexical_name` requires an
alphabetic second byte, so a dynamic's `*` declines the atomic lane and the
named sub cells the container instead — straight onto the guard.

The re-declared row is the interesting one. `thread_redeclared_vars` is keyed by
**name, not by scope**, so a slurpy `*@seen` parameter *anywhere* in the program
masks the outer `@seen`'s writes too. That decline does not drop the write off
the edge; it lands it on the atomic `__mutsu_atomic_arr::` store.

## Acceptance

Debug build, `MUTSU_GC=on MUTSU_GC_EVERY_CANDIDATE=1024 MUTSU_GC_VERIFY=1`,
24-way on 12 cores: **0 / 96 on each of the four probes, 0 / 384 in total.**

## Changes

- `t/concurrent-lane-decline-routes.t` (4 assertions). Be clear about what it
  pins: **rakudo gives concurrent `@a[$i] = ...` no atomicity at all** and loses
  updates on three of the four blocks (1 of 4 passing, on each of three runs).
  This is mutsu's *exclusion invariant*, not a Raku guarantee — which is exactly
  what ADR-0068 set out to buy. The test comment says so.
- ADR-0068 gains **§13**, and §1.2 carries a `STALE since §7` warning pointing
  at §13.1.
- `news/2026-09/lane-decline-reasons-are-all-classified.md`.

`make test` PASS (3844 files, 40687 tests). `make roast`'s failure set is
byte-identical to the run before this branch (this container's `uid 0` `chmod`
file tests and the sandboxed `IO-Socket-Async.t`; all three pass in CI).

## This closes #7543

With #7605 (route 5), #7610 (the `S17-procasync/stress.t` SIGSEGV, ruled out of
this class) and this PR, ADR-0068 §4 step 3 is complete: all five §2 reasons
classified, every §3 route measured, the one unexplained crash off the ledger
(tracked as #7609). The evidence across §8, §10, §11 and §13 is consistent —
this class has **three funnels** (the named element store, the attribute-rooted
element store, the mutating method) and every route tried since has arrived at
one of them.

What is left of ADR-0068 is not exposure but a **measurement**, and a perf one:
§7's read-side guard sits in `Value::with_deref` / `into_deref`, which are hot,
and a threaded program now takes a mutex on every celled-container read. Nothing
has measured it. Filed as #7613 (`todo:perf`).

Closes #7543

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013c4HPfEPoHvhg6JwWQpQhU


---
_Generated by [Claude Code](https://claude.ai/code/session_013c4HPfEPoHvhg6JwWQpQhU)_