### PR TITLE
fix(vm): a scalar subscript store follows the Positional/Associative protocol

### DIFF
--- a/news/2026-09/scalar-subscript-follows-the-positional-associative-protocol.md
+++ b/news/2026-09/scalar-subscript-follows-the-positional-associative-protocol.md
@@ -1,0 +1,71 @@
+# A subscript store into a scalar follows the Positional/Associative protocol
+
+A subscript store into a `$` that already holds a **defined** value is governed
+by whether that value does the subscript's role. Rakudo refuses the ones that do
+not:
+
+```
+my $s = (1,2,3).Seq; $s<k> = 5   X::AdHoc  "Type Seq does not support associative indexing."
+my $s = [1,2,3];     $s<k> = 5   X::AdHoc  "Type Array does not support associative indexing."
+my $s = 1..3;        $s<k> = 5   X::AdHoc  "Type Range does not support associative indexing."
+my $s = 42;          $s<k> = 5   X::AdHoc  "Type Int does not support associative indexing."
+my $s = 42;          $s[0] = 5   X::Assignment::RO  "Cannot modify an immutable Int (42)"
+my $s = "str";       $s[0] = 5   X::Assignment::RO  "Cannot modify an immutable Str (str)"
+```
+
+mutsu did none of that. An associative store replaced the value outright with a
+fresh `Hash` — `my $s = 42; $s<k> = 5` left `$s` as `{k => 5}`, and so did a
+`Seq` and a `Str` — while an `Array` answered "Index out of bounds" and a
+positional store into an `Int` or `Str` replaced it with `[5]`.
+
+This is section E of the immutable-lvalue survey
+([#7556](https://github.com/tokuhirom/mutsu/issues/7556)), which had it filed
+under "not an immutability row at all — it belongs with whatever enforces the
+Positional/Associative protocol per type". That is exactly right, and measuring
+the whole cross-product of ten receivers against both subscripts turned one
+recorded row into eight.
+
+`Interpreter::scalar_subscript_protocol_error` is that enforcement. It is
+deliberately **not** the `subscript_descent_refusal` predicate added for section
+C2: that one answers "may a chained store *descend* through this slot", where an
+`Array` of any kind is a legitimate target. Here the subscript is the last one,
+so the question is whether the value does the role at all — and an `Array` does
+not do `Associative`. Conflating the two would have regressed every chained
+store through an array element.
+
+Both refusal sets are explicit rather than "everything that is not a container",
+because a `$` can hold an `Instance` doing `Associative`, a `Buf`, a `Proxy`, a
+`Mixin` or a user container subclass, and each has its own store path that must
+keep working. The guard is also restricted to `$`/sigilless names: an `@`/`%`
+name's sigil already fixes the container kind, and `%h<k> = v` on a real `Hash`
+is the whole point.
+
+Two things the measurement changed about the plan:
+
+**A `Range` needed a guard *removed*, not added.** `exec_index_assign_expr_named_op`
+refused every subscript store into a `Range` as immutable, positional or not. A
+`Range` does do `Positional`, so `$r[0] = 5` really is an immutability error —
+but it does not do `Associative`, so `$r<k> = 5` never reaches a store in rakudo
+and answers the protocol error instead. That guard is now positional-only.
+
+**The value has to be read through its container.** The predicate consults the
+VM local slot first — authoritative for a lexical scalar between env
+synchronization points, the same reason the `Range` guard above does — and then
+looks *through* the `Scalar`/`ContainerRef` wrapper, or it would classify the
+container instead of the value it holds and never fire.
+
+Two rows are left, both recorded as `TODO`s rather than guessed at. A `Buf`
+reaches this store as an `Instance` carrying `__mutsu_array_storage` and is
+served by the instance arm far above, so it still answers "Index out of range"
+where rakudo answers the protocol error; refusing it belongs there. And
+`Set`/`Bag`/`Mix` refuse the store with the right class but render it as
+"Cannot modify an immutable value (Set)" where rakudo says "Cannot modify an
+immutable Set (Set(1 2))" — one of the survey's existing "close but not exact"
+rows, untouched here.
+
+Pinned by `t/scalar-subscript-protocol.t`, 28 assertions passing unchanged under
+`raku` as well as under mutsu: the refusals, and everything that must keep
+working — an undefined scalar and a type object still autovivifying, a `Hash`
+and an `Array` still storing, a `Buf` still writing a byte positionally, a user
+class doing `Associative` still dispatching `AT-KEY`, and the `@`/`%` names the
+rule does not touch.

--- a/src/vm/vm_var_assign_element.rs
+++ b/src/vm/vm_var_assign_element.rs
@@ -570,10 +570,17 @@ impl Interpreter {
         // The VM local slot is authoritative for a lexical scalar between env
         // synchronization points.  A Range receiver is immutable even when the
         // scalar wrapper came from ordinary `my $r = ...` assignment.
-        if let Some(value) = target_slot
-            .and_then(|slot| self.locals.get(slot as usize))
-            .map(|value| value.deref_container().descalarize().clone())
-            .filter(|value| value.is_range())
+        //
+        // Only for a POSITIONAL subscript. A Range does `Positional`, so
+        // `$r[0] = 5` reaches the store and is refused as immutable; it does
+        // NOT do `Associative`, so `$r<k> = 5` never gets that far and rakudo
+        // answers the protocol error instead ("Type Range does not support
+        // associative indexing.") -- see `scalar_subscript_protocol_error`.
+        if is_positional
+            && let Some(value) = target_slot
+                .and_then(|slot| self.locals.get(slot as usize))
+                .map(|value| value.deref_container().descalarize().clone())
+                .filter(|value| value.is_range())
         {
             return Err(RuntimeError::assignment_ro_value(value));
         }
@@ -584,6 +591,12 @@ impl Interpreter {
             .map(|value| value.deref_container().descalarize().clone())
             .filter(|value| value.is_range())
         {
+            if !is_positional {
+                return Err(RuntimeError::new(format!(
+                    "Type {} does not support associative indexing.",
+                    crate::runtime::utils::value_type_name(&value)
+                )));
+            }
             return Err(RuntimeError::assignment_ro_value(value));
         }
         // `%h{*} = ...` is refused: an associative slice has no order to assign

--- a/src/vm/vm_var_assign_index_named.rs
+++ b/src/vm/vm_var_assign_index_named.rs
@@ -279,6 +279,94 @@ impl Interpreter {
             .any(|parent| CONTAINER_BASES.contains(&parent.resolve().as_str()))
     }
 
+    /// The error rakudo raises for a SINGLE-level subscript store into a `$`
+    /// that already holds a defined value the subscript's protocol does not
+    /// apply to, or `None` when the store is legitimate.
+    ///
+    /// ```text
+    /// my $s = (1,2,3).Seq; $s<k> = 5   X::AdHoc  "Type Seq does not support associative indexing."
+    /// my $s = 42;          $s<k> = 5   X::AdHoc  "Type Int does not support associative indexing."
+    /// my $s = 42;          $s[0] = 5   X::Assignment::RO  "Cannot modify an immutable Int (42)"
+    /// ```
+    ///
+    /// mutsu replaced the value with a fresh `Hash` (`$s` became `{k => 5}`)
+    /// or, for an `Array`, answered "Index out of bounds". An UNDEFINED `$`
+    /// still autovivifies -- `my $s; $s<k> = 5` is `{k => 5}` in rakudo too --
+    /// and so does a type object, so this asks about a defined value only.
+    ///
+    /// This is section E of #7556, and it is deliberately NOT
+    /// [`Interpreter::subscript_descent_refusal`]: that one answers "may a
+    /// chained store DESCEND through this slot", where an `Array` of any kind
+    /// is a legitimate target. Here the subscript is the LAST one, so the
+    /// question is whether the value does `Positional`/`Associative` at all --
+    /// and an `Array` does not do `Associative`.
+    ///
+    /// The refusal sets are explicit rather than "everything that is not a
+    /// container": a `$` can hold an `Instance` doing `Associative`, a `Buf`, a
+    /// `Proxy`, a `Mixin` or a user container subclass, and every one of those
+    /// has its own store path that must keep working.
+    fn scalar_subscript_protocol_error(
+        &self,
+        target: &Value,
+        is_positional: bool,
+    ) -> Option<RuntimeError> {
+        let view = target.view();
+        // Scalar numeric/string values do neither protocol.
+        let bare_scalar = matches!(
+            view,
+            ValueView::Int(_)
+                | ValueView::BigInt(_)
+                | ValueView::Num(_)
+                | ValueView::Str(_)
+                | ValueView::Bool(_)
+                | ValueView::Rat(..)
+                | ValueView::FatRat(..)
+                | ValueView::BigRat(..)
+                | ValueView::Complex(..)
+        );
+        if is_positional {
+            // A `List`/`Array`/`Range`/`Seq` DOES do Positional, so a positional
+            // store into one is a store, refused (or not) by the element rules
+            // that already run below.
+            if !bare_scalar {
+                return None;
+            }
+            return Some(RuntimeError::assignment_ro_typename(
+                crate::runtime::utils::value_type_name(target),
+                &crate::runtime::utils::gist_value(target),
+            ));
+        }
+        // Associative: the Positional shapes do not do it either.
+        //
+        // TODO: compile to bytecode -- a `Buf` is missing from this set. It
+        // reaches this store as an `Instance` carrying `__mutsu_array_storage`
+        // and is served by the instance arm far above, which coerces the key
+        // and answers "Index out of range" where rakudo answers "Type Buf does
+        // not support associative indexing."; refusing it belongs there, not
+        // here.
+        let positional_only = matches!(
+            view,
+            ValueView::Array(..)
+                | ValueView::Seq(_)
+                | ValueView::HyperSeq(_)
+                | ValueView::RaceSeq(_)
+                | ValueView::Slip(_)
+                | ValueView::LazyList(_)
+                | ValueView::Range(..)
+                | ValueView::RangeExcl(..)
+                | ValueView::RangeExclStart(..)
+                | ValueView::RangeExclBoth(..)
+                | ValueView::GenericRange { .. }
+        );
+        if !bare_scalar && !positional_only {
+            return None;
+        }
+        Some(RuntimeError::new(format!(
+            "Type {} does not support associative indexing.",
+            crate::runtime::utils::value_type_name(target)
+        )))
+    }
+
     pub(crate) fn exec_index_assign_expr_named_op_inner(
         &mut self,
         code: &CompiledCode,
@@ -795,6 +883,29 @@ impl Interpreter {
             }
             _ => (raw_val, false, Vec::new()),
         };
+        // A `$` holding a DEFINED value the subscript's protocol does not apply
+        // to refuses the store instead of being replaced by a fresh container.
+        // Restricted to a `$`/sigilless name: an `@`/`%` name's sigil already
+        // fixes the container kind, and `%h<k> = v` on a real Hash is the whole
+        // point. A `:=` bind is excluded -- rakudo answers a different error
+        // there ("Cannot bind to Seq"), which is a separate row.
+        // The VM local slot is authoritative for a lexical scalar between env
+        // synchronization points, so consult it first exactly as the Range
+        // guard in `exec_index_assign_expr_named_op` does; and look THROUGH the
+        // `Scalar`/`ContainerRef` wrapper, or the predicate would see the
+        // container rather than the value it holds.
+        if !bind_mode
+            && !var_name.starts_with(['@', '%'])
+            && let Some(target) = target_slot
+                .and_then(|slot| self.locals.get(slot as usize))
+                .cloned()
+                .or_else(|| self.get_env_with_main_alias(&var_name))
+                .map(|v| v.deref_container().descalarize().clone())
+            && crate::runtime::types::value_is_defined(&target)
+            && let Some(err) = self.scalar_subscript_protocol_error(&target, is_positional)
+        {
+            return Err(err);
+        }
         // An element ASSIGNMENT stores a COPY of the value; only the `:=` bind
         // handled just above aliases. The RHS can still BE a first-class element
         // cell whenever it came from a read that does not decontainerize (a

--- a/t/scalar-subscript-protocol.t
+++ b/t/scalar-subscript-protocol.t
@@ -1,0 +1,162 @@
+use Test;
+
+plan 28;
+
+# A subscript store into a `$` that already holds a DEFINED value follows
+# rakudo's Positional/Associative protocol: a value that does not do the
+# subscript's role refuses the store. mutsu instead replaced the value with a
+# fresh container (`my $s = 42; $s<k> = 5` left `$s` as `{k => 5}`) or, for an
+# Array, answered "Index out of bounds".
+
+# --- associative subscript: X::AdHoc, rakudo's Any.AT-KEY wording ------------
+
+{
+    my $s = (1, 2, 3).Seq;
+    throws-like { $s<k> = 5 }, X::AdHoc,
+        message => 'Type Seq does not support associative indexing.',
+        'a Seq refuses an associative store';
+    throws-like { $s{'k'} = 5 }, X::AdHoc,
+        message => 'Type Seq does not support associative indexing.',
+        'and the brace spelling of it';
+}
+
+{
+    my $s = (1, 2, 3);
+    throws-like { $s<k> = 5 }, X::AdHoc,
+        message => 'Type List does not support associative indexing.',
+        'a List refuses one';
+}
+
+{
+    my $s = [1, 2, 3];
+    throws-like { $s<k> = 5 }, X::AdHoc,
+        message => 'Type Array does not support associative indexing.',
+        'an Array refuses one -- it does Positional, not Associative';
+    is $s.elems, 3, 'and is left alone';
+}
+
+{
+    my $s = 1 .. 3;
+    throws-like { $s<k> = 5 }, X::AdHoc,
+        message => 'Type Range does not support associative indexing.',
+        'a Range answers the protocol error, not an immutability one';
+}
+
+{
+    my $s = 42;
+    throws-like { $s<k> = 5 }, X::AdHoc,
+        message => 'Type Int does not support associative indexing.',
+        'an Int refuses one';
+    is $s, 42, 'and is not replaced by a Hash';
+}
+
+{
+    my $s = "str";
+    throws-like { $s<k> = 5 }, X::AdHoc,
+        message => 'Type Str does not support associative indexing.',
+        'a Str refuses one';
+    is $s, "str", 'and is not replaced by a Hash';
+}
+
+# The same through a `:=` alias to the scalar.
+{
+    my $s = 42;
+    my $r := $s;
+    throws-like { $r<k> = 5 }, X::AdHoc,
+        message => 'Type Int does not support associative indexing.',
+        'an alias to the scalar refuses it too';
+    is $s, 42, 'and the aliased scalar is untouched';
+}
+
+# --- positional subscript: X::Assignment::RO naming the value ---------------
+
+{
+    my $s = 42;
+    throws-like { $s[0] = 5 }, X::Assignment::RO,
+        message => 'Cannot modify an immutable Int (42)',
+        'a positional store into an Int is refused';
+    is $s, 42, 'and is not replaced by an Array';
+}
+
+{
+    my $s = "str";
+    throws-like { $s[0] = 5 }, X::Assignment::RO,
+        message => 'Cannot modify an immutable Str (str)',
+        'a positional store into a Str is refused';
+    is $s, "str", 'and is not replaced by an Array';
+}
+
+{
+    my $s = 1 .. 3;
+    throws-like { $s[0] = 5 }, X::Assignment::RO,
+        message => 'Cannot modify an immutable Range (1..3)',
+        'a Range DOES do Positional, so it is refused as immutable';
+}
+
+{
+    my $s = (1, 2, 3);
+    throws-like { $s[0] = 5 }, X::Assignment::RO,
+        message => 'Cannot modify an immutable List ((1 2 3))',
+        'and so does a List';
+}
+
+# --- what must keep working -------------------------------------------------
+
+{
+    my $s;
+    $s<k> = 5;
+    is-deeply $s, {k => 5}, 'an UNDEFINED scalar still autovivifies to a Hash';
+}
+
+{
+    my $s = Any;
+    $s<k> = 5;
+    is $s<k>, 5, 'a type object still autovivifies';
+}
+
+{
+    my $s;
+    $s[0] = 5;
+    is-deeply $s, $[5], 'the positional twin still autovivifies to an Array';
+}
+
+{
+    my $s = {a => 1};
+    $s<k> = 5;
+    is $s<k>, 5, 'a Hash still stores';
+    is $s<a>, 1, 'without disturbing what was there';
+}
+
+{
+    my $s = [1, 2, 3];
+    $s[0] = 9;
+    is $s[0], 9, 'an Array still stores positionally';
+}
+
+{
+    my $s = Buf.new(1, 2, 3);
+    $s[0] = 9;
+    is $s[0], 9, 'a Buf still writes a byte positionally';
+}
+
+{
+    my class AssocThing does Associative {
+        has %.h;
+        method AT-KEY($k) is rw { %!h{$k} }
+    }
+    my $s = AssocThing.new;
+    $s<k> = 5;
+    is $s<k>, 5, 'a user class doing Associative still dispatches AT-KEY';
+}
+
+{
+    my %h;
+    %h<a><b> = 1;
+    is %h<a><b>, 1, 'a %-sigiled name is untouched by the scalar rule';
+}
+
+{
+    my @a;
+    @a[0] = 5;
+    is @a[0], 5, 'and so is an @-sigiled one';
+}


### PR DESCRIPTION
Section E of the immutable-lvalue survey, #7556.

## The divergence

A subscript store into a `$` that already holds a **defined** value is governed
by whether that value does the subscript's role. Measuring the cross-product of
ten receivers against both subscripts turned the ticket's one recorded row into
eight:

| code | raku | mutsu (before) |
| --- | --- | --- |
| `my $s = (1,2,3).Seq; $s<k> = 5` | `X::AdHoc` "Type Seq does not support associative indexing." | `$s` becomes `{k => 5}` |
| `my $s = [1,2,3]; $s<k> = 5` | `X::AdHoc` "Type Array does not support associative indexing." | "Index out of bounds" |
| `my $s = 1..3; $s<k> = 5` | `X::AdHoc` "Type Range does not support associative indexing." | an immutability error (wrong class) |
| `my $s = 42; $s<k> = 5` | `X::AdHoc` "Type Int does not support associative indexing." | `$s` becomes `{k => 5}` |
| `my $s = "str"; $s<k> = 5` | `X::AdHoc` "Type Str does not support associative indexing." | `$s` becomes `{k => 5}` |
| `my $s = 42; $s[0] = 5` | `X::Assignment::RO` "Cannot modify an immutable Int (42)" | `$s` becomes `[5]` |
| `my $s = "str"; $s[0] = 5` | `X::Assignment::RO` "Cannot modify an immutable Str (str)" | `$s` becomes `[5]` |

## The fix

`Interpreter::scalar_subscript_protocol_error` is that enforcement. It is
deliberately **not** the `subscript_descent_refusal` predicate added for section
C2 in #7601: that one answers "may a chained store *descend* through this slot",
where an `Array` of any kind is a legitimate target. Here the subscript is the
last one, so the question is whether the value does the role at all — and an
`Array` does not do `Associative`. Conflating them would regress every chained
store through an array element.

Both refusal sets are explicit rather than "everything that is not a container",
because a `$` can hold an `Instance` doing `Associative`, a `Buf`, a `Proxy`, a
`Mixin` or a user container subclass, and each has its own store path that must
keep working. The guard is restricted to `$`/sigilless names: an `@`/`%` sigil
already fixes the container kind, and `%h<k> = v` on a real `Hash` is the point.

## Two things the measurement changed about the plan

**A `Range` needed a guard *removed*, not added.**
`exec_index_assign_expr_named_op` refused every subscript store into a `Range` as
immutable, positional or not. A `Range` does do `Positional`, so `$r[0] = 5`
really is an immutability error — but it does not do `Associative`, so
`$r<k> = 5` never reaches a store in rakudo and answers the protocol error
instead. That guard is now positional-only.

**The value has to be read through its container.** The predicate consults the VM
local slot first — authoritative for a lexical scalar between env synchronization
points, the same reason the `Range` guard above does — and then looks *through*
the `Scalar`/`ContainerRef` wrapper, or it classifies the container instead of
the value it holds and never fires.

## Deliberately left as TODOs

- A `Buf` reaches this store as an `Instance` carrying `__mutsu_array_storage`
  and is served by the instance arm far above, so `$buf<k> = 5` still answers
  "Index out of range" where rakudo answers the protocol error. Refusing it
  belongs there, not here.
- `Set`/`Bag`/`Mix` refuse with the right class but render it as "Cannot modify
  an immutable value (Set)" where rakudo says "Cannot modify an immutable Set
  (Set(1 2))" — one of the survey's existing "close but not exact" rows,
  untouched here.

## Testing

`t/scalar-subscript-protocol.t`, 28 assertions, passing **unchanged under `raku`
as well as under mutsu**: the refusals, and everything that must keep working —
an undefined scalar and a type object still autovivifying, a `Hash` and an
`Array` still storing, a `Buf` still writing a byte positionally, a user class
doing `Associative` still dispatching `AT-KEY`, an alias to the scalar behaving
the same, and the `@`/`%` names the rule does not touch.

`cargo fmt`, `cargo clippy --all-targets -- -D warnings`, `make test` (Result:
PASS — 3844 files, 40711 tests) and `make roast` all run, and the roast result
was confirmed on a second, uncontended run. `make roast` reports three failures,
byte-identical to a run without this diff and all environmental to this
container:

- `roast/6.c/S32-io/file-tests.t` and `roast/S16-filehandles/filetest.t` — the
  session runs as **root**, which bypasses the `0333`/`0222`/`0111` mode bits
  those assertions test.
- `roast/S32-io/IO-Socket-Async.t` — hangs at the `# host=::1` round;
  `/proc/net/if_inet6` does not exist here, so there is no IPv6 loopback.

Rebased onto current `main` and re-verified after the rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ExzRnHAQq5kawQ2oVpLMM9

---
_Generated by [Claude Code](https://claude.ai/code/session_01ExzRnHAQq5kawQ2oVpLMM9)_