### PR TITLE
feat(regex): measure which subrule-call streaming declines actually happen

### DIFF
--- a/news/2026-09/subrule-stream-declines-are-measured.md
+++ b/news/2026-09/subrule-stream-declines-are-measured.md
@@ -1,0 +1,97 @@
+# The `<subrule>` streaming residue is measured, and it is not what the ticket ranked
+
+[#7548](https://github.com/tokuhirom/mutsu/issues/7548) lists six shapes the
+streamed `<subrule>` path declines, "roughly in descending order of how often
+they come up", and then says plainly what to do before opening any of them:
+
+> Before opening any of these, measure how often the declined shapes actually
+> occur: the streamable verdict is memoized per (package, subrule atom text) in
+> `regex_call_graph.rs`'s `STREAMABLE`, so a counter there would say directly
+> which of the six is worth the work.
+
+That measurement now exists, and the ordering it produces is close to the
+reverse of the guess.
+
+## The instrument
+
+`Interpreter::subrule_call_is_streamable` answered a bare `bool`, so a decline
+carried no reason. It is now `subrule_call_stream_decline`, answering
+`Option<StreamDecline>` — a fieldless enum with one variant per declined shape —
+and every `<subrule>` call reaching `drive_named_subrule_candidates` reports
+exactly one verdict to a `MUTSU_VM_STATS` histogram. The verdict is memoized
+exactly as the boolean was, so the reason costs nothing on a repeated call.
+
+Two of the buckets needed splitting before they could say anything. The
+reachability walk's "may re-enter" answer conflated a real call cycle with an
+edge it simply could not resolve, and the unresolvable half conflated three
+mechanisms with completely different prices. Both are now separate variants.
+
+`scripts/subrule-stream-survey.sh` aggregates the histogram over a file list, so
+the table below is reproducible rather than a claim.
+
+## The measurement
+
+Whole roast whitelist plus `t/` — 5 276 files, of which 167 make at least one
+subrule call; 8 454 calls:
+
+| verdict | calls | share | #7548's rank |
+|---|---:|---:|---|
+| **streamed** | 4 632 | 54.79% | — |
+| not-a-rule | 1 978 | 23.40% | not listed |
+| **callee-interpolates** | **796** | **9.42%** | **item 5** |
+| call-arguments | 345 | 4.08% | item 4 |
+| several-candidates | 307 | 3.63% | item 3 |
+| reenters-own-name | 183 | 2.16% | **item 1** |
+| dynamic-rule-param | 123 | 1.45% | item 6 |
+| callee-edge-unresolvable | 31 | 0.37% | item 6 |
+| custom-how-grammar | 26 | 0.31% | item 6 |
+| ignore-mark | 18 | 0.21% | item 6 |
+| **proto-candidate** | **14** | **0.17%** | **item 2** |
+| callee-is-grammar-method | 1 | 0.01% | item 6 |
+| symbolic-indirection, lr-key-active, seed-consulted, reachable-set-too-large | 0 | 0.00% | items 1 / 6 |
+
+## What it says
+
+**Item 5 is the largest clearable residue, and it is also the cheap half.** The
+ticket puts "a body that splices a value into its own pattern text" fifth and
+files it under "widening the analysis is the cheap half of items 4-6". It is in
+fact 796 calls — more than items 1, 2 and 3 put together — and it is one
+mechanism, not a family: splitting the old unknowable bucket three ways shows
+the grammar-method case, which no widening could ever fix, is **1 call**.
+
+**Item 2 is measured dead.** A proto/`multi` subrule declines 14 calls in the
+entire corpus, 0.17%. Item 1, the "genuinely hard residue" the ticket ranks
+first, is 183 — sixth place, and less than a quarter of item 5. Building the
+seed-loop continuation machinery would buy less than a quarter of what
+tightening the interpolation check buys, at many times the cost.
+
+**`not-a-rule` is not a residue** and must not be read as one. It is `<ws>`,
+`<alpha>`, `<sym>` and friends: builtin assertions and character classes that
+cannot dispatch to a user rule and contain no `{ … }` block to over-fire.
+Excluding them, the streamed share is **71.5%** (4 632 of 6 476).
+
+**Three of the six shapes never occurred once**: `<::(EXPR)>` symbolic
+indirection, an already-LR-active key, and the mid-stream seed-consulted
+fallback.
+
+## The next slice, named precisely
+
+Per file, item 5 is two mechanisms and 90% of it is the first:
+
+- **596 of 796 are `t/yaml-battery.t`** — `YAMLish`'s indentation-driven rules,
+  which interpolate a **typed** rule parameter: `token block-ws(Str $indent) {
+  … <.comment> <.line-break> $indent <.space>* … }`. A `Str`-declared parameter
+  provably cannot be spliced as pattern *source*
+  (`interpolate_bound_regex_scalars` splices a `Regex`-valued scalar; anything
+  else interpolates as a literal), so such an interpolation can never introduce
+  a rule call. The analysis refuses anyway, because
+  `pattern_text_is_static_outside_code_blocks` sees only the pattern text and
+  not the rule's signature.
+- **69 are `roast/integration/advent2013-day18.t`** — a different mechanism:
+  `rule deal { :my %*PLAYED = (); <hand>+ % ';' }`. A `:my` is a *declaration*,
+  not an interpolation, and splices nothing; the sigil scan does not know that.
+
+Both are static, sound widenings of one function, and together they are ~84% of
+the residue. Neither is attempted here: this entry is the measurement the ticket
+asked for, and the widening is its own slice — the value of doing them in that
+order is exactly that the priority order changed.

--- a/scripts/subrule-stream-survey.sh
+++ b/scripts/subrule-stream-survey.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Aggregate the `MUTSU_VM_STATS` subrule-stream verdict histogram across many
+# scripts, so the six declined shapes in
+# https://github.com/tokuhirom/mutsu/issues/7548 can be ranked by how often they
+# actually occur rather than by how plausible they sound.
+#
+# Every `<subrule>` call that reaches `drive_named_subrule_candidates` reports
+# exactly one verdict: `streamed`, or the shape that declined it. The streamed
+# path is *correct* today, so what clearing a residue buys is only fewer
+# `{ ... }` block runs on paths raku never enters -- which makes the per-call
+# counts the deciding measurement.
+#
+# Usage:
+#   scripts/subrule-stream-survey.sh <file.t|file.raku> ...
+#   scripts/subrule-stream-survey.sh $(cat roast-whitelist.txt)
+#
+# Honours MUTSU_BIN (default target/release/mutsu) and MUTSU_JOBS (default 8).
+# Roast files are run with MUTSU_FUDGE=1, as `make roast` does.
+set -u
+
+BIN="${MUTSU_BIN:-target/release/mutsu}"
+JOBS="${MUTSU_JOBS:-8}"
+TIMEOUT="${MUTSU_SURVEY_TIMEOUT:-60}"
+
+if [ ! -x "$BIN" ]; then
+    echo "no such binary: $BIN (set MUTSU_BIN, or cargo build --release)" >&2
+    exit 2
+fi
+if [ "$#" -eq 0 ]; then
+    echo "usage: $0 <script> ..." >&2
+    exit 2
+fi
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+run_one() {
+    local file="$1" fudge=""
+    case "$file" in
+        roast/*) fudge=1 ;;
+    esac
+    MUTSU_VM_STATS=1 MUTSU_FUDGE="$fudge" timeout "$TIMEOUT" "$BIN" "$file" 2>&1 >/dev/null |
+        grep -F '[mutsu vm-stats] subrule-stream verdicts'
+}
+export -f run_one
+export BIN TIMEOUT
+
+printf '%s\n' "$@" | xargs -P "$JOBS" -I{} bash -c 'run_one "$@"' _ {} > "$work/lines" 2>/dev/null
+
+files_with_calls=$(wc -l < "$work/lines")
+echo "files reporting at least one subrule call: $files_with_calls (of $#)"
+echo
+
+# A line reads `... total=N streamed=M (P%): reason=count reason=count ...`.
+# Drop everything through the `): ` so the header's own `total=`/`streamed=` are
+# not summed a second time alongside the per-reason body.
+sed 's/^.*): //' "$work/lines" |
+    tr ' ' '\n' |
+    grep -E '^[a-z-]+=[0-9]+$' |
+    awk -F= '{ n[$1] += $2; total += $2 }
+             END {
+                 for (r in n) printf "%-26s %12d  %6.2f%%\n", r, n[r], 100 * n[r] / total
+                 printf "%-26s %12d\n", "TOTAL", total
+             }' |
+    sort -k2 -nr

--- a/src/runtime/regex/regex_call_graph.rs
+++ b/src/runtime/regex/regex_call_graph.rs
@@ -47,12 +47,95 @@ type RuleNode = (String, String);
 /// analysis exists to save work, not to spend it.
 const MAX_REACHABLE_RULES: usize = 512;
 
+/// Why a `<subrule>` call could not take the streamed path.
+///
+/// Each variant is one of the declined shapes #7548 enumerates, kept separate
+/// because they cost very different amounts to clear: widening the *analysis*
+/// (`NotKnowable`, `Arguments`, `Symbolic`) is cheap, while streaming through
+/// the growing-seed loop (`ReentersOwnName`), a proto's rank-then-match
+/// dispatch (`Proto`) or several candidates' interleaved walks
+/// (`SeveralCandidates`) is the expensive machinery. `Str` names are what the
+/// `MUTSU_VM_STATS` histogram reports.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum StreamDecline {
+    /// `<expr($p-1)>` — the arguments are part of the left-recursion key and
+    /// are evaluated per call, so the memoized verdict cannot apply.
+    Arguments,
+    /// `<::(EXPR)>` symbolic indirection: the target resolves per call.
+    Symbolic,
+    /// The name answers to no token/regex/rule here — a builtin assertion or
+    /// character class, or a plain grammar method (arbitrary user code).
+    NotARule,
+    /// Several resolved candidates without a proto: the eager arm deduplicates
+    /// ends *across* them, which a stream would have to interleave to preserve.
+    SeveralCandidates,
+    /// A proto/`multi` subrule: ADR-0046 dispatch wants the winning
+    /// candidate's whole end set.
+    Proto,
+    /// `:m` remaps positions across the whole result set.
+    IgnoreMark,
+    /// The rule really is part of a call cycle. Left recursion is why the
+    /// growing-seed loop exists; this is the genuinely hard residue.
+    ReentersOwnName,
+    /// Some rule in the call cone is a plain grammar METHOD — arbitrary user
+    /// code, whose dispatch targets are not a property of the token
+    /// generation. Nothing short of running it can widen this.
+    CalleeIsMethod,
+    /// Some rule in the call cone splices a value into its own pattern text
+    /// outside a `{ ... }` code block, so its call edges are not stable across
+    /// attempts. Widening this means tracking *which* interpolations can
+    /// introduce a rule call, rather than refusing on any of them.
+    CalleeInterpolates,
+    /// Some rule in the call cone contains a construct
+    /// (`<{ ... }>` closure interpolation, `<~~>`, ...) whose dispatch target
+    /// `collect_pattern_calls` will not name.
+    CalleeEdgeUnresolvable,
+    /// The reachable set hit [`MAX_REACHABLE_RULES`].
+    ReachableSetTooLarge,
+    /// A `$*`-twigil rule parameter is declared somewhere in the program, so
+    /// the call has to install and tear down a dynamic scope around itself.
+    DynamicRuleParam,
+    /// The grammar has a custom HOW, so dispatch is not static.
+    CustomHow,
+    /// This `(name, position)` key is already left-recursion-active.
+    LrKeyActive,
+    /// An embedded `{ ... }` block re-entered the key mid-stream, so the single
+    /// pass was not the growing-seed loop's answer and the call was handed back
+    /// to the eager arm.
+    SeedConsulted,
+}
+
+impl StreamDecline {
+    /// Short stable name for the `MUTSU_VM_STATS` histogram.
+    pub(super) fn as_str(self) -> &'static str {
+        match self {
+            Self::Arguments => "call-arguments",
+            Self::Symbolic => "symbolic-indirection",
+            Self::NotARule => "not-a-rule",
+            Self::SeveralCandidates => "several-candidates",
+            Self::Proto => "proto-candidate",
+            Self::IgnoreMark => "ignore-mark",
+            Self::ReentersOwnName => "reenters-own-name",
+            Self::CalleeIsMethod => "callee-is-grammar-method",
+            Self::CalleeInterpolates => "callee-interpolates",
+            Self::CalleeEdgeUnresolvable => "callee-edge-unresolvable",
+            Self::ReachableSetTooLarge => "reachable-set-too-large",
+            Self::DynamicRuleParam => "dynamic-rule-param",
+            Self::CustomHow => "custom-how-grammar",
+            Self::LrKeyActive => "lr-key-active",
+            Self::SeedConsulted => "seed-consulted",
+        }
+    }
+}
+
 thread_local! {
-    /// `(name, pkg) -> the rules its candidates call directly`, or `None` when
+    /// `(name, pkg) -> the rules its candidates call directly`, or the reason
     /// some construct in one of them cannot be resolved. Same generation key.
     #[allow(clippy::type_complexity)]
-    static DIRECT_CALLS: RefCell<(u64, HashMap<RuleNode, Option<std::sync::Arc<Vec<RuleNode>>>>)> =
-        RefCell::new((0, HashMap::new()));
+    static DIRECT_CALLS: RefCell<(
+        u64,
+        HashMap<RuleNode, Result<std::sync::Arc<Vec<RuleNode>>, StreamDecline>>,
+    )> = RefCell::new((0, HashMap::new()));
 
     /// `pkg -> subrule atom text -> may this call be streamed?`. This is the
     /// hot lookup: it is consulted before the call is resolved (and before its
@@ -60,8 +143,12 @@ thread_local! {
     /// borrowed hash lookups rather than a resolution plus a graph walk. The
     /// two-level shape is what keeps it allocation-free — a `(String, String)`
     /// key would have to be built to probe it. Same generation key.
+    ///
+    /// `None` is "streamable"; `Some(reason)` names the shape that declined it,
+    /// so the memoized answer still feeds the per-call histogram
+    /// ([`crate::vm::vm_stats::record_subrule_stream`]) without recomputing.
     #[allow(clippy::type_complexity)]
-    static STREAMABLE: RefCell<(u64, HashMap<String, HashMap<String, bool>>)> =
+    static STREAMABLE: RefCell<(u64, HashMap<String, HashMap<String, Option<StreamDecline>>>)> =
         RefCell::new((0, HashMap::new()));
 }
 
@@ -71,30 +158,34 @@ fn token_defs_gen() -> u64 {
 
 impl Interpreter {
     /// The reachability walk itself: is a call to `name` reachable from
-    /// `(pkg, name)`?
-    fn cannot_reenter(&mut self, name: &str, pkg: &str) -> bool {
+    /// `(pkg, name)`? `None` when it is proven unreachable; otherwise the
+    /// reason the walk gave up, which is not the same question -- a real cycle
+    /// and an unresolvable edge both mean "may re-enter" but cost entirely
+    /// different work to clear.
+    fn reenter_decline(&mut self, name: &str, pkg: &str) -> Option<StreamDecline> {
         let start: RuleNode = (pkg.to_string(), name.to_string());
         let mut seen: HashSet<RuleNode> = HashSet::from([start.clone()]);
         let mut queue: VecDeque<RuleNode> = VecDeque::from([start]);
         while let Some((cur_pkg, cur_name)) = queue.pop_front() {
-            let Some(calls) = self.direct_rule_calls(&cur_name, &cur_pkg) else {
-                return false;
+            let calls = match self.direct_rule_calls(&cur_name, &cur_pkg) {
+                Ok(calls) => calls,
+                Err(reason) => return Some(reason),
             };
             for callee in calls.iter() {
                 // Reaching the starting NAME again closes the loop the
                 // growing-seed algorithm exists for.
                 if callee.1 == name {
-                    return false;
+                    return Some(StreamDecline::ReentersOwnName);
                 }
                 if seen.len() >= MAX_REACHABLE_RULES {
-                    return false;
+                    return Some(StreamDecline::ReachableSetTooLarge);
                 }
                 if seen.insert(callee.clone()) {
                     queue.push_back(callee.clone());
                 }
             }
         }
-        true
+        None
     }
 
     /// The rules every candidate of `<name>` in `pkg` calls directly, or `None`
@@ -108,7 +199,7 @@ impl Interpreter {
         &mut self,
         name: &str,
         pkg: &str,
-    ) -> Option<std::sync::Arc<Vec<RuleNode>>> {
+    ) -> Result<std::sync::Arc<Vec<RuleNode>>, StreamDecline> {
         let generation = token_defs_gen();
         let key = (pkg.to_string(), name.to_string());
         if let Some(hit) = DIRECT_CALLS.with(|c| {
@@ -136,7 +227,7 @@ impl Interpreter {
                 let (candidates, raw_empty) = self.parsed_subrule_candidates(&spec, pkg, &[]);
                 self.rule_calls_of(name, pkg, &candidates, raw_empty)
             }
-            None => None,
+            None => Err(StreamDecline::CalleeInterpolates),
         };
         DIRECT_CALLS.with(|c| {
             let mut c = c.borrow_mut();
@@ -156,17 +247,16 @@ impl Interpreter {
         pkg: &str,
         candidates: &[super::regex_token_resolve::ParsedTokenCandidate],
         raw_empty: bool,
-    ) -> Option<std::sync::Arc<Vec<RuleNode>>> {
+    ) -> Result<std::sync::Arc<Vec<RuleNode>>, StreamDecline> {
         if raw_empty || candidates.is_empty() {
             // No token/regex/rule answers to this name here. It is either a
             // builtin assertion or character class (`<alpha>`, `<ws>` with no
             // grammar override, `<sym>`), which cannot dispatch to a user rule,
             // or a plain grammar METHOD — arbitrary user code, so unknowable.
-            return self
-                .registry()
-                .user_method_overloads(pkg, name)
-                .is_none()
-                .then(|| std::sync::Arc::new(Vec::new()));
+            return match self.registry().user_method_overloads(pkg, name) {
+                None => Ok(std::sync::Arc::new(Vec::new())),
+                Some(_) => Err(StreamDecline::CalleeIsMethod),
+            };
         }
         let mut out: Vec<RuleNode> = Vec::new();
         for (parsed, sub_pkg, _) in candidates.iter() {
@@ -174,12 +264,12 @@ impl Interpreter {
             // references against the package that DEFINED it, not against the
             // caller's — the same rule `subrule_candidate_ends` matches under.
             if !collect_pattern_calls(parsed, sub_pkg, &mut out) {
-                return None;
+                return Err(StreamDecline::CalleeEdgeUnresolvable);
             }
         }
         out.sort();
         out.dedup();
-        Some(std::sync::Arc::new(out))
+        Ok(std::sync::Arc::new(out))
     }
 }
 
@@ -191,7 +281,11 @@ impl Interpreter {
     ///
     /// `atom_text` is the subrule atom exactly as written,
     /// so `<foo>` and `<&foo>` get their own entries rather than sharing one.
-    pub(super) fn subrule_call_is_streamable(&mut self, atom_text: &str, pkg: &str) -> bool {
+    pub(super) fn subrule_call_stream_decline(
+        &mut self,
+        atom_text: &str,
+        pkg: &str,
+    ) -> Option<StreamDecline> {
         let generation = token_defs_gen();
         if let Some(hit) = STREAMABLE.with(|c| {
             let c = c.borrow();
@@ -201,7 +295,7 @@ impl Interpreter {
         }) {
             return hit;
         }
-        let verdict = self.compute_streamable(atom_text, pkg);
+        let verdict = self.compute_stream_decline(atom_text, pkg);
         STREAMABLE.with(|c| {
             let mut c = c.borrow_mut();
             if c.0 != generation {
@@ -215,12 +309,15 @@ impl Interpreter {
         verdict
     }
 
-    fn compute_streamable(&mut self, atom_text: &str, pkg: &str) -> bool {
+    fn compute_stream_decline(&mut self, atom_text: &str, pkg: &str) -> Option<StreamDecline> {
         let spec = Self::parse_named_regex_lookup_spec(atom_text);
         // A rule call with arguments, and `<::(EXPR)>` symbolic indirection,
         // both resolve per call; neither is a shape this path handles.
-        if !spec.arg_exprs.is_empty() || spec.lookup_name == "::" {
-            return false;
+        if !spec.arg_exprs.is_empty() {
+            return Some(StreamDecline::Arguments);
+        }
+        if spec.lookup_name == "::" {
+            return Some(StreamDecline::Symbolic);
         }
         let (candidates, raw_empty) = self.parsed_subrule_candidates(&spec, pkg, &[]);
         // Exactly one plain candidate. A proto keeps its rank-then-match
@@ -229,9 +326,19 @@ impl Interpreter {
         // result set. All three are properties of the rule's DEFINITIONS, so the
         // verdict holds for the whole token generation even when the body's
         // parse does not.
-        let shape_ok = !raw_empty
-            && matches!(&candidates[..], [(parsed, _, sym)] if sym.is_none() && !parsed.ignore_mark);
-        shape_ok && self.cannot_reenter(&spec.lookup_name, pkg)
+        if raw_empty || candidates.is_empty() {
+            return Some(StreamDecline::NotARule);
+        }
+        let [(parsed, _, sym)] = &candidates[..] else {
+            return Some(StreamDecline::SeveralCandidates);
+        };
+        if sym.is_some() {
+            return Some(StreamDecline::Proto);
+        }
+        if parsed.ignore_mark {
+            return Some(StreamDecline::IgnoreMark);
+        }
+        self.reenter_decline(&spec.lookup_name, pkg)
     }
 
     /// `true` when every definition answering to `<name>` in `pkg` compiles to

--- a/src/runtime/regex/regex_match_lazy_subrule.rs
+++ b/src/runtime/regex/regex_match_lazy_subrule.rs
@@ -16,6 +16,7 @@
 //! wrong.
 
 use super::super::*;
+use super::regex_call_graph::StreamDecline;
 use super::regex_match_core::MatchSink;
 use super::regex_match_lazy::AtomCandidateCont;
 use super::regex_trail::CapStore;
@@ -64,33 +65,36 @@ impl Interpreter {
         if crate::runtime::regex::regex_dynparams::ANY_DYNAMIC_TOKEN_PARAM
             .load(std::sync::atomic::Ordering::Relaxed)
         {
-            return None;
+            return decline(StreamDecline::DynamicRuleParam);
         }
         if !self.registry().grammar_custom_how.is_empty() {
-            return None;
+            return decline(StreamDecline::CustomHow);
         }
         // Memoized per (package, atom text), and asked FIRST: the rule resolves
         // to exactly one plain argument-less candidate AND the call graph proves
         // it cannot reach a call to its own name. A call that fails this costs
         // two borrowed hash lookups — no name parse, no resolution the eager arm
         // would then repeat.
-        if !self.subrule_call_is_streamable(name, pkg) {
-            return None;
+        if let Some(reason) = self.subrule_call_stream_decline(name, pkg) {
+            return decline(reason);
         }
         let spec = Self::parse_named_regex_lookup_spec(name);
         let lr_key = (spec.lookup_name.clone(), chars.len() - pos);
         if super::regex_match_atom::lr_key_is_active(&lr_key) {
-            return None;
+            return decline(StreamDecline::LrKeyActive);
         }
         // Same resolution the eager arm performs (memoized for a static body,
         // per-call otherwise). The shape was settled above, but a body that is
         // re-parsed per call is re-checked rather than assumed.
         let (candidates, _) = self.parsed_subrule_candidates(&spec, pkg, &[]);
         let [(parsed, sub_pkg, sym_key)] = &candidates[..] else {
-            return None;
+            return decline(StreamDecline::SeveralCandidates);
         };
-        if sym_key.is_some() || parsed.ignore_mark {
-            return None;
+        if sym_key.is_some() {
+            return decline(StreamDecline::Proto);
+        }
+        if parsed.ignore_mark {
+            return decline(StreamDecline::IgnoreMark);
         }
         let parsed = std::sync::Arc::clone(parsed);
         let sub_pkg = sub_pkg.clone();
@@ -141,8 +145,22 @@ impl Interpreter {
             // pass above is not the growing-seed loop's answer. Nothing has
             // committed (the continuation rejected every streamed end), so hand
             // the call back to the eager arm.
-            return None;
+            return decline(StreamDecline::SeedConsulted);
         }
+        crate::vm::vm_stats::record_subrule_stream("streamed");
         Some(unwind)
     }
+}
+
+/// Count one declined call in the `MUTSU_VM_STATS` histogram and answer `None`,
+/// so every `return` in the eligibility cascade above reads as one expression.
+///
+/// The histogram is the measurement #7548 asks for before any of its six
+/// residues is opened: the streamed path is correct today, and what a residue
+/// buys is only fewer `{ ... }` block runs on paths raku never enters, so the
+/// per-call counts are what say which residue is worth its machinery.
+#[inline]
+fn decline(reason: StreamDecline) -> Option<bool> {
+    crate::vm::vm_stats::record_subrule_stream(reason.as_str());
+    None
 }

--- a/src/vm/vm_stats.rs
+++ b/src/vm/vm_stats.rs
@@ -778,6 +778,19 @@ fn dispatch_entry_outcome_by_key() -> &'static Mutex<HashMap<String, u64>> {
     BY_KEY.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
+/// Per-reason histogram of `<subrule>` streaming verdicts (only populated when
+/// stats are on). One entry per *call* through
+/// `Interpreter::drive_named_subrule_candidates`, so it reports how often each
+/// declined shape actually occurs rather than how many distinct rules have it.
+/// This is the measurement #7548 asks for before any of its six residues is
+/// opened: the streamed path is correct today, so the only thing a residue buys
+/// is fewer `{ ... }` block runs on paths raku never enters, and the counts say
+/// which one is worth the machinery.
+fn subrule_stream_by_reason() -> &'static Mutex<HashMap<String, u64>> {
+    static BY_REASON: OnceLock<Mutex<HashMap<String, u64>>> = OnceLock::new();
+    BY_REASON.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
 fn dispatch_entry_intercept_by_arm() -> &'static Mutex<HashMap<String, u64>> {
     static BY_ARM: OnceLock<Mutex<HashMap<String, u64>>> = OnceLock::new();
     BY_ARM.get_or_init(|| Mutex::new(HashMap::new()))
@@ -807,6 +820,21 @@ pub(crate) fn record_dispatch_entry_intercept(entry: &str, arm: &str) {
     record_dispatch_entry_outcome(entry, "intercept");
     if let Ok(mut map) = dispatch_entry_intercept_by_arm().lock() {
         *map.entry(format!("{entry}:{arm}")).or_insert(0) += 1;
+    }
+}
+
+/// Record one `<subrule>` call's streaming verdict. `reason` is `"streamed"`
+/// for a call the streamed path took, and otherwise a short stable name for the
+/// shape that declined it -- see
+/// `runtime::regex::regex_call_graph`'s `StreamDecline` (a private module,
+/// so this is not an intra-doc link).
+#[inline]
+pub(crate) fn record_subrule_stream(reason: &str) {
+    if !enabled() {
+        return;
+    }
+    if let Ok(mut map) = subrule_stream_by_reason().lock() {
+        *map.entry(reason.to_string()).or_insert(0) += 1;
     }
 }
 
@@ -1475,6 +1503,27 @@ pub(crate) fn dump() {
             total,
             top.len(),
             top.join(" ")
+        );
+    }
+    if let Ok(map) = subrule_stream_by_reason().lock()
+        && !map.is_empty()
+    {
+        let total: u64 = map.values().sum();
+        let streamed = map.get("streamed").copied().unwrap_or(0);
+        let mut entries: Vec<(&String, &u64)> = map.iter().collect();
+        entries.sort_by(|a, b| b.1.cmp(a.1).then_with(|| a.0.cmp(b.0)));
+        let rows: Vec<String> = entries
+            .iter()
+            .map(|(reason, count)| format!("{reason}={count}"))
+            .collect();
+        eprintln!(
+            "[mutsu vm-stats] subrule-stream verdicts total={total} streamed={streamed} ({:.1}%): {}",
+            if total == 0 {
+                0.0
+            } else {
+                100.0 * streamed as f64 / total as f64
+            },
+            rows.join(" ")
         );
     }
     if let Ok(map) = function_carrier_by_name().lock()


### PR DESCRIPTION
#7548 lists six shapes the streamed `<subrule>` path declines, "roughly in descending order of how often they come up", and then says plainly what to do before opening any of them:

> Before opening any of these, measure how often the declined shapes actually occur: the streamable verdict is memoized per (package, subrule atom text) in `regex_call_graph.rs`'s `STREAMABLE`, so a counter there would say directly which of the six is worth the work.

This is that measurement. **The ordering it produces is close to the reverse of the guess.**

## The instrument

`subrule_call_is_streamable` answered a bare `bool`, so a decline carried no reason. It is now `subrule_call_stream_decline`, answering `Option<StreamDecline>` — a fieldless enum with one variant per declined shape — and every call reaching `drive_named_subrule_candidates` reports exactly one verdict to a `MUTSU_VM_STATS` histogram. **Every decline condition is unchanged; only the label is new.** The verdict is memoized exactly as the boolean was, so the reason costs nothing on a repeated call.

Two buckets needed splitting before they could say anything: the reachability walk's "may re-enter" conflated a real call cycle with an edge it could not resolve, and the unresolvable half conflated three mechanisms with completely different prices. `direct_rule_calls` therefore answers a `Result` carrying the reason rather than a bare `Option`.

`scripts/subrule-stream-survey.sh` aggregates the histogram over a file list, so the table below is reproducible rather than a claim.

## The measurement

Whole roast whitelist plus `t/` — 5 276 files, 167 of which make at least one subrule call; 8 454 calls:

| verdict | calls | share | #7548's rank |
|---|---:|---:|---|
| **streamed** | 4 632 | 54.79% | — |
| not-a-rule | 1 978 | 23.40% | not listed |
| **callee-interpolates** | **796** | **9.42%** | **item 5** |
| call-arguments | 345 | 4.08% | item 4 |
| several-candidates | 307 | 3.63% | item 3 |
| reenters-own-name | 183 | 2.16% | **item 1** |
| dynamic-rule-param | 123 | 1.45% | item 6 |
| callee-edge-unresolvable | 31 | 0.37% | item 6 |
| custom-how-grammar | 26 | 0.31% | item 6 |
| ignore-mark | 18 | 0.21% | item 6 |
| **proto-candidate** | **14** | **0.17%** | **item 2** |
| callee-is-grammar-method | 1 | 0.01% | item 6 |
| symbolic-indirection, lr-key-active, seed-consulted, reachable-set-too-large | 0 | 0.00% | items 1 / 6 |

## What it says

- **Item 5 is the largest clearable residue, not the fifth** — more than items 1, 2 and 3 combined — and it is the one the ticket files under the *cheap* half ("widening the analysis"). Splitting the old unknowable bucket three ways shows it is one mechanism, not a family: the grammar-method case, which no widening could ever fix, is **1 call**.
- **Item 2 is measured dead** at 0.17%, and item 1 — the "genuinely hard residue" ranked first — is sixth at 2.16%. Building the seed-loop continuation machinery would buy less than a quarter of what tightening the interpolation check buys, at many times the cost.
- **`not-a-rule` is not a residue** and must not be read as one: `<ws>`, `<alpha>`, `<sym>` and friends are builtin assertions and character classes that cannot dispatch to a user rule and contain no `{ … }` block to over-fire. Excluding them the streamed share is **71.5%** (4 632 of 6 476).
- **Three of the six shapes never occurred once**: `<::(EXPR)>` symbolic indirection, an already-LR-active key, and the mid-stream seed-consulted fallback.

## The next slice, named precisely

Per file, item 5 is two mechanisms and 90% of it is the first:

- **596 of 796 are `t/yaml-battery.t`** — `YAMLish`'s indentation-driven rules interpolate a **typed** rule parameter: `token block-ws(Str $indent) { … <.comment> <.line-break> $indent <.space>* … }`. A `Str`-declared parameter provably cannot be spliced as pattern *source* (`interpolate_bound_regex_scalars` splices a `Regex`-valued scalar; anything else interpolates as a literal), so such an interpolation can never introduce a rule call. The analysis refuses anyway, because `pattern_text_is_static_outside_code_blocks` sees only the pattern text and not the rule's signature.
- **69 are `roast/integration/advent2013-day18.t`** — a different mechanism: `rule deal { :my %*PLAYED = (); <hand>+ % ';' }`. A `:my` is a *declaration*, not an interpolation, and splices nothing; the sigil scan does not know that.

Both are static, sound widenings of one function, and together they are ~84% of the residue. **Neither is attempted here** — the value of measuring first is exactly that the priority order changed, and each widening deserves its own regression pins.

## Verification

- `make test`: `Files=3840, Tests=40618 … Result: PASS`.
- `make roast`: identical failure set to the baseline runs earlier in this session — `6.c/S32-io/file-tests.t`, `S16-filehandles/filetest.t`, `S32-io/IO-Socket-Async.t`. This container runs as `root`, so `.r`/`.w`/`.x` assertions expecting a permission denial pass instead.
- 208 regex/grammar/token `t/` files pass on the rebased branch.
- `cargo fmt --all` and `make lint` clean. (`make lint` earned its keep here: it caught a rustdoc intra-doc link to the private `regex_call_graph` module that the default clippy cannot see.)

Part of #7548.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012BaTE6YdzbdFki2k3dQqq1

---
_Generated by [Claude Code](https://claude.ai/code/session_012BaTE6YdzbdFki2k3dQqq1)_