### PR TITLE
perf: share one built-in registry per process, and let Interpreter::new drain its own GC candidates

### DIFF
--- a/docs/gc-level1-detailed-design.md
+++ b/docs/gc-level1-detailed-design.md
@@ -516,6 +516,13 @@ Level 1a collectable safepoints:
   - join / merge boundaries of `start` / `hyper` / `race`
 - `manual`
   - debug hook / explicit collect
+- `construct`
+  - top-level `Interpreter::new`. An embedder that builds one interpreter per
+    request (a language server, `analysis::check`) may never execute bytecode
+    and so never reach a dispatch-loop safepoint at all; without this kind the
+    candidate buffer grew without bound across construct-and-drop cycles
+    (#7572). Not emitted for `new_regex_scratch`, which is built from inside
+    regex/grammar evaluation rather than at a re-entry boundary.
 
 NOT collectable in Level 1a:
 

--- a/news/2026-09/interpreter-new-shares-one-builtin-registry.md
+++ b/news/2026-09/interpreter-new-shares-one-builtin-registry.md
@@ -1,0 +1,136 @@
+# `Interpreter::new` shares one built-in registry, and drains its own garbage
+
+[#7572](https://github.com/tokuhirom/mutsu/issues/7572) recorded two properties
+of `Interpreter::new()`, measured while building ADR-0065 S2: **9.17 ms per
+construction** and **+7.2 KiB retained per construction, linear** (debug build,
+4000 construct-and-drop cycles). The issue's own guess was that the retention
+lived somewhere in `runtime_init.rs` — "a `Box::leak`, a push into a
+process-global registry, or a `Gc` allocation that outlives the drop" — and that
+the `%*ENV` sweep was the wall-clock suspect. Both guesses were wrong, and the
+two properties turned out to have nothing to do with each other.
+
+Re-measured on the same probe, now in **release**: **1.17 ms → 0.26 ms** per
+construction (4.5×), and the retention is gone. It used to grow in a straight
+line; it now flattens:
+
+| release, constructions | resident growth, before | after |
+| --- | --- | --- |
+| 1000 | +1.9 MB | +1.2 MB |
+| 4000 | +4.9 MB (0.99 KiB/call, linear) | +2.2 MB |
+| 16000 | (~16 MB, extrapolated) | +2.3 MB |
+
+The debug build the issue measured tells the same story: 9.17 ms → 1.70 ms, and
++7.2 KiB/construction → +1.1 MB *total* over 4000.
+
+## The retention was never in `Interpreter::new`
+
+One measurement settled it:
+
+| release, 4000 construct-and-drop cycles | KiB retained per construction |
+| --- | --- |
+| `MUTSU_GC` unset (on, the default) | 1.44 |
+| `MUTSU_GC=off` | 0.08 |
+
+Nothing in the constructor leaks. What accumulates is the GC's **cycle-candidate
+buffer**: `Gc::drop` buffers a possible cycle root, and the buffer is drained by
+`gc_safepoint`, which only the VM's dispatch loops and its call/await/join
+boundaries emit. A loop that constructs an interpreter, drops it, and *never runs
+any bytecode* therefore never reaches a single safepoint. Every dropped
+interpreter's dead nodes were buffered and nothing ever came to collect them.
+
+This also explains the line in the issue that reads like a dead end — "`MUTSU_GC=on`
+changes nothing (9.26 ms, 7.31 KiB/call), so this is not a GC cycle waiting for a
+collector that never runs in that loop". `MUTSU_GC=on` is the *default* (ADR-0003
+§5), so that probe changed nothing about the configuration. It is exactly a
+collector that never runs in that loop; `off` is the direction that shows it.
+
+So `Interpreter::new` now emits a safepoint of its own, a new
+`SafepointKind::Construct`. A top-level construction is a proper re-entry
+boundary — no borrow, no lock, no `gc_contents_mut` is held — and for an embedder
+driving mutsu per request it may be the only boundary it ever reaches. Scratch
+interpreters (`new_regex_scratch`) are excluded: those are built from *inside*
+regex/grammar evaluation, which is not a boundary.
+
+## The wall clock was the registry, not `%*ENV`
+
+A callgrind profile of 30 construct-and-drop cycles, 245.5M instructions total:
+
+| | Ir | share |
+| --- | --- | --- |
+| `Interpreter::new` | 209.2M | 85% |
+| ⤷ `build_builtin_registry` | 146.2M | 60% |
+| ⤷ `os_env_hash` (the `%*ENV` sweep) | ~31.5M | 13% |
+| `drop_glue::<Interpreter>` | 34.4M | 14% |
+| ⤷ dropping that same registry | 29.7M | 12% |
+
+Building ~450 `ClassDef`s and then throwing them away again was 72% of the cycle.
+The `%*ENV` sweep the issue suspected was 13%.
+
+That registry is identical in every interpreter in the process, and it has been
+copy-on-write for as long as `clone_for_thread` has existed: every mutation goes
+through `RegistryWriteGuard`, whose `deref_mut` is an `Arc::make_mut`. So it is
+now built **once per process** and handed out as a shared `Arc`
+(`Interpreter::shared_builtin_registry`). Sharing a process-wide template is the
+same share `clone_for_thread` already performs between threads, one level up.
+
+### The write that made the share worthless
+
+Sharing alone only bought 41%, and the profile said why: 33% of what was left had
+moved into `RegistryWriteGuard::deref_mut`. Something was *writing* the registry
+during construction, and the first write forks a private deep copy — so every
+construction was still paying for a whole registry, now as a clone instead of a
+build.
+
+The writers were the five `init_*_enum` calls. Each one built the base-tier
+`Value`s for a built-in enum (`Order`, `Endian`, `ProtocolFamily`, `Signal`,
+`SeekType`) *and* recorded the enum type itself through `self.registry_mut()`.
+Those five entries are process constants, so they belong in the template: the
+variant lists are now shared between `init_*_enum` (values) and a new
+`seed_builtin_enum_types` (types), which `build_builtin_registry` calls. The
+`init_*_enum` functions no longer take `&mut self` at all, which is the honest
+statement that they no longer touch the registry.
+
+With the write gone, 1.17 ms → 0.28 ms.
+
+### `val()` stopped copying every string it was about to reject
+
+What that leaves at the top of the profile is the `%*ENV` sweep after all — 55%
+of the remainder, of which three quarters is `builtin_val`, because `%*ENV`
+values are allomorphs and every one of ~40 environment variables goes through the
+full Raku numeric-string parser.
+
+Two allocations per attempt were pure waste. `normalize_minus` copied the whole
+string just to leave it unchanged when no U+2212 MINUS SIGN was present, and
+`strip_underscores` built a fresh `String` for *every* candidate the parser tried
+— including the ones it rejected on the next line, and almost nothing reaching it
+has an underscore at all. `strip_underscores` alone was 18% of a construction.
+Both now return `Cow` and borrow when there is nothing to change, which is a win
+for every `val()` in the language, not only this sweep: 0.28 ms → 0.26 ms here.
+
+## What a one-shot `mutsu script.raku` pays
+
+The template `Arc` is held by a `OnceLock`, so a single-interpreter process's
+registry is no longer uniquely owned and its first registry write pays one
+`Arc::make_mut` deep clone — measured at ~1.6M Ir, under a third of the ~5.3M Ir
+the build it replaces still costs once. Against that it drops five `registry_mut`
+acquisitions from startup and gets the `val()` improvement. Programs that declare
+nothing never write the registry and pay nothing at all.
+
+## Pins
+
+`tests/long_lived_parse.rs`, the file the issue points its repro at, grew two:
+
+- `repeated_interpreter_construction_does_not_grow_without_bound` — the retention
+  gate. Its bound is deliberately **independent of the iteration count**, because
+  that is now the property: the candidate buffer is capped by the collector's
+  size threshold, so a 4000-construction run must grow like a 1000-construction
+  one. The old behaviour blew through it at `MUTSU_S0_ITERATIONS=4000`, where it
+  retained 28.9 MB.
+- `a_declaration_in_one_interpreter_is_invisible_to_another` — the correctness
+  gate on the share. Two interpreters alive at once really do hold the same
+  template `Arc`; a class declared in one must not be visible in the other, which
+  is the copy-on-write fork actually happening.
+
+Wall-clock figures here are local probe runs (this container, release unless
+stated), not bench-CI rows; the instruction counts are callgrind, which is
+load-independent.

--- a/src/gc/safepoint.rs
+++ b/src/gc/safepoint.rs
@@ -69,6 +69,11 @@ pub(crate) enum SafepointKind {
     ThreadJoin,
     /// Explicit debug / manual collect.
     Manual,
+    /// Top-level `Interpreter::new` construction boundary. Emitted so an
+    /// embedder that builds one interpreter per request (a language server,
+    /// `analysis::check`) still reaches a safepoint even though it may never
+    /// execute bytecode; without it the candidate buffer grew unboundedly.
+    Construct,
 }
 
 impl SafepointKind {
@@ -85,6 +90,7 @@ impl SafepointKind {
             SafepointKind::NestedRun => "nested_run",
             SafepointKind::ThreadJoin => "thread_join",
             SafepointKind::Manual => "manual",
+            SafepointKind::Construct => "construct",
         }
     }
 
@@ -104,6 +110,7 @@ impl SafepointKind {
             "nested_run" => SafepointKind::NestedRun,
             "thread_join" => SafepointKind::ThreadJoin,
             "manual" => SafepointKind::Manual,
+            "construct" => SafepointKind::Construct,
             _ => return None,
         })
     }

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -69,6 +69,29 @@ impl Interpreter {
     /// scratch interpreter per subrule-with-arguments call and per embedded
     /// code block (207 of them on `benchmarks/bench-yaml-parse.raku`, where a
     /// callgrind profile attributed ~48% of the whole run to this work).
+    /// The built-in declaration registry, built **once per process** and shared
+    /// by every top-level interpreter.
+    ///
+    /// [`Self::build_builtin_registry`] is the single most expensive thing
+    /// `Interpreter::new` does — ~70% of a construct-and-drop cycle's
+    /// instructions (#7572), split between building ~450 `ClassDef`s plus
+    /// their seeded method entries and then dropping them again. The result is
+    /// the same for every interpreter in the process, so it is built once and
+    /// handed out as a shared `Arc`.
+    ///
+    /// Safe because the registry is already copy-on-write: every mutation goes
+    /// through [`RegistryWriteGuard`], whose `deref_mut` calls `Arc::make_mut`,
+    /// so the first write an interpreter performs forks it a private copy. This
+    /// is exactly the mechanism `clone_for_thread` has always used to share one
+    /// registry snapshot between threads — a shared process-wide template is
+    /// the same share, one level up.
+    ///
+    /// [`RegistryWriteGuard`]: crate::runtime::registry::RegistryWriteGuard
+    fn shared_builtin_registry() -> Arc<Registry> {
+        static TEMPLATE: std::sync::OnceLock<Arc<Registry>> = std::sync::OnceLock::new();
+        Arc::clone(TEMPLATE.get_or_init(|| Arc::new(Self::build_builtin_registry())))
+    }
+
     fn build_builtin_registry() -> Registry {
         let mut classes = rustc_hash::FxHashMap::default();
         classes.insert(
@@ -2848,10 +2871,25 @@ impl Interpreter {
         for class_name in class_names {
             registry.sync_accessor_entries(crate::symbol::Symbol::intern(&class_name));
         }
+        Self::seed_builtin_enum_types(&mut registry);
         registry
     }
 
     pub fn new() -> Self {
+        // Constructing a top-level interpreter is a GC re-entry boundary (no
+        // borrow, no lock, no `gc_contents_mut` is held here), and for an
+        // embedder that drives mutsu by building one interpreter per request it
+        // may be the ONLY one it ever reaches: the candidate buffer is drained
+        // by `gc_safepoint`, which the VM emits from its dispatch loops, so a
+        // construct-and-drop loop that never runs bytecode buffered the dead
+        // nodes of every interpreter it dropped and never collected them (that
+        // was the whole of the ~7 KiB/construction retention in #7572 — with
+        // `MUTSU_GC=off`, which buffers nothing, it measured 0.08 KiB). A
+        // scratch interpreter is excluded: it is built from inside regex/grammar
+        // evaluation, which is not a re-entry boundary.
+        if !Self::is_building_scratch() {
+            crate::gc::gc_safepoint(crate::gc::SafepointKind::Construct);
+        }
         let mut env = HashMap::new();
         env.insert("*PID".to_string(), Value::int(current_process_id()));
         env.insert("*TZ".to_string(), Value::int(local_timezone_offset_secs()));
@@ -2938,11 +2976,11 @@ impl Interpreter {
             gather_items: Vec::new(),
             gather_take_limits: Vec::new(),
             block_scope_depth: 0,
-            registry: Arc::new(RwLock::new(Arc::new(if Self::is_building_scratch() {
-                Registry::default()
+            registry: Arc::new(RwLock::new(if Self::is_building_scratch() {
+                Arc::new(Registry::default())
             } else {
-                Self::build_builtin_registry()
-            }))),
+                Self::shared_builtin_registry()
+            })),
             registry_write_gen: std::sync::atomic::AtomicU64::new(0),
             proto_dispatch_stack: Vec::new(),
             pending_dispatch_error: None,
@@ -3253,11 +3291,15 @@ impl Interpreter {
             // process-wide immutables: collect them into the shared base tier
             // instead of every per-frame env overlay (docs/vm-dual-store.md 4b).
             let mut enum_base: HashMap<Symbol, Value> = HashMap::new();
-            interpreter.init_order_enum(&mut enum_base);
-            interpreter.init_endian_enum(&mut enum_base);
-            interpreter.init_protocol_family_enum(&mut enum_base);
-            interpreter.init_signal_enum(&mut enum_base);
-            interpreter.init_seek_type_enum(&mut enum_base);
+            // Only the base-tier `Value`s are built here; the enum TYPES
+            // themselves are already in the shared built-in registry template
+            // (`seed_builtin_enum_types`), so this no longer takes a registry
+            // write guard — which used to deep-clone the whole registry.
+            Self::init_order_enum(&mut enum_base);
+            Self::init_endian_enum(&mut enum_base);
+            Self::init_protocol_family_enum(&mut enum_base);
+            Self::init_signal_enum(&mut enum_base);
+            Self::init_seek_type_enum(&mut enum_base);
             // Hoist the immutable process-constant magic/dynamic vars out of every
             // per-frame env overlay into the shared base tier (docs/vm-dual-store.md
             // 4c "natural extension"). These are set once at interpreter start and

--- a/src/runtime/str_numeric.rs
+++ b/src/runtime/str_numeric.rs
@@ -5,6 +5,7 @@
 //! Complex (`1+2i`), Inf, NaN, and U+2212 MINUS SIGN.
 
 use crate::value::{Value, ValueView};
+use std::borrow::Cow;
 
 /// Result of attempting to parse a Raku numeric string.
 /// Returns `Some(value)` on success, `None` on failure (invalid format).
@@ -16,7 +17,7 @@ pub(crate) fn parse_raku_str_to_numeric(input: &str) -> Option<Value> {
 
     // Normalize U+2212 MINUS SIGN to ASCII hyphen-minus
     let normalized = normalize_minus(s);
-    let s = normalized.as_str();
+    let s = normalized.as_ref();
 
     // If the string contains Unicode decimal digits (Nd category), normalize
     // them to their ASCII equivalents before further parsing.
@@ -171,11 +172,15 @@ fn numeric_prefix_end_byte(s: &str) -> usize {
 }
 
 /// Normalize U+2212 MINUS SIGN to ASCII hyphen-minus.
-fn normalize_minus(s: &str) -> String {
+fn normalize_minus(s: &str) -> Cow<'_, str> {
+    // Borrowed unless a MINUS SIGN is actually present: this runs on every
+    // string `val()` looks at, including all ~40 values of the `%*ENV` sweep
+    // `Interpreter::new` does, and copying each one just to leave it unchanged
+    // was a plain allocation per call (#7572).
     if s.contains('\u{2212}') {
-        s.replace('\u{2212}', "-")
+        Cow::Owned(s.replace('\u{2212}', "-"))
     } else {
-        s.to_string()
+        Cow::Borrowed(s)
     }
 }
 
@@ -230,11 +235,21 @@ fn validate_underscores(s: &str) -> bool {
 }
 
 /// Strip underscores from a string, returning None if underscores are invalid.
-fn strip_underscores(s: &str) -> Option<String> {
+///
+/// Borrowed when there is nothing to strip. Almost no string reaching the
+/// numeric parser contains an underscore, and the parser calls this on every
+/// candidate it tries — including the ones it is about to reject — so the
+/// unconditional `String` this used to build was the single largest allocation
+/// source in `val()` (18% of `Interpreter::new`'s instructions via the `%*ENV`
+/// sweep, #7572).
+fn strip_underscores(s: &str) -> Option<Cow<'_, str>> {
     if !validate_underscores(s) {
         return None;
     }
-    Some(s.chars().filter(|&c| c != '_').collect())
+    if !s.contains('_') {
+        return Some(Cow::Borrowed(s));
+    }
+    Some(Cow::Owned(s.chars().filter(|&c| c != '_').collect()))
 }
 
 fn try_parse_inf_nan(s: &str) -> Option<Value> {
@@ -525,7 +540,7 @@ fn parse_fraction_part(s: &str, allow_sign: bool) -> Option<(i64, i64)> {
         let int_clean = strip_underscores(int_str)?;
         let frac_clean = strip_underscores(frac_str)?;
         let int_clean = if int_clean.is_empty() {
-            "0".to_string()
+            Cow::Borrowed("0")
         } else {
             int_clean
         };
@@ -626,7 +641,7 @@ fn parse_mantissa(s: &str) -> Option<f64> {
         let int_clean = strip_underscores(int_str)?;
         let frac_clean = strip_underscores(frac_str)?;
         let int_clean = if int_clean.is_empty() {
-            "0".to_string()
+            Cow::Borrowed("0")
         } else {
             int_clean
         };
@@ -663,7 +678,7 @@ fn try_parse_decimal_rat(body: &str, sign: i32) -> Option<Value> {
 
     // Allow empty integer part (e.g., ".13" → "0.13")
     let int_clean = if int_clean.is_empty() {
-        "0".to_string()
+        Cow::Borrowed("0")
     } else {
         int_clean
     };

--- a/src/runtime/types/type_registry.rs
+++ b/src/runtime/types/type_registry.rs
@@ -92,15 +92,8 @@ impl Interpreter {
 }
 
 impl Interpreter {
-    pub(in crate::runtime) fn init_endian_enum(&mut self, base: &mut HashMap<Symbol, Value>) {
-        let variants = vec![
-            ("NativeEndian".to_string(), EnumValue::Int(0)),
-            ("LittleEndian".to_string(), EnumValue::Int(1)),
-            ("BigEndian".to_string(), EnumValue::Int(2)),
-        ];
-        self.registry_mut()
-            .enum_types
-            .insert("Endian".to_string(), variants.clone());
+    pub(in crate::runtime) fn init_endian_enum(base: &mut HashMap<Symbol, Value>) {
+        let variants = Self::endian_enum_variants();
         base.insert(Symbol::intern("Endian"), Value::str_from("Endian"));
         for (index, (key, val)) in variants.iter().enumerate() {
             let enum_val = Value::enum_parts(
@@ -118,21 +111,8 @@ impl Interpreter {
         }
     }
 
-    pub(in crate::runtime) fn init_protocol_family_enum(
-        &mut self,
-        base: &mut HashMap<Symbol, Value>,
-    ) {
-        let variants = vec![
-            ("PF_UNSPEC".to_string(), EnumValue::Int(0)),
-            ("PF_INET".to_string(), EnumValue::Int(1)),
-            ("PF_INET6".to_string(), EnumValue::Int(2)),
-            ("PF_LOCAL".to_string(), EnumValue::Int(3)),
-            ("PF_UNIX".to_string(), EnumValue::Int(3)),
-            ("PF_MAX".to_string(), EnumValue::Int(4)),
-        ];
-        self.registry_mut()
-            .enum_types
-            .insert("ProtocolFamily".to_string(), variants.clone());
+    pub(in crate::runtime) fn init_protocol_family_enum(base: &mut HashMap<Symbol, Value>) {
+        let variants = Self::protocol_family_enum_variants();
         base.insert(
             Symbol::intern("ProtocolFamily"),
             Value::package(Symbol::intern("ProtocolFamily")),
@@ -152,15 +132,8 @@ impl Interpreter {
         }
     }
 
-    pub(in crate::runtime) fn init_order_enum(&mut self, base: &mut HashMap<Symbol, Value>) {
-        let variants = vec![
-            ("Less".to_string(), EnumValue::Int(-1)),
-            ("Same".to_string(), EnumValue::Int(0)),
-            ("More".to_string(), EnumValue::Int(1)),
-        ];
-        self.registry_mut()
-            .enum_types
-            .insert("Order".to_string(), variants.clone());
+    pub(in crate::runtime) fn init_order_enum(base: &mut HashMap<Symbol, Value>) {
+        let variants = Self::order_enum_variants();
         base.insert(Symbol::intern("Order"), Value::str_from("Order"));
         for (index, (key, val)) in variants.iter().enumerate() {
             let enum_val = Value::enum_parts(
@@ -174,19 +147,12 @@ impl Interpreter {
         }
     }
 
-    pub(in crate::runtime) fn init_seek_type_enum(&mut self, base: &mut HashMap<Symbol, Value>) {
+    pub(in crate::runtime) fn init_seek_type_enum(base: &mut HashMap<Symbol, Value>) {
         // The `SeekType` enum used by IO::Handle.seek (and user IO classes that
         // subclass it, e.g. IO::Blob): SeekFromBeginning(0)/SeekFromCurrent(1)/
         // SeekFromEnd(2). Registering it as a real enum makes `SeekType:D`
         // parameter/default type checks pass and the values smartmatch SeekType.
-        let variants = vec![
-            ("SeekFromBeginning".to_string(), EnumValue::Int(0)),
-            ("SeekFromCurrent".to_string(), EnumValue::Int(1)),
-            ("SeekFromEnd".to_string(), EnumValue::Int(2)),
-        ];
-        self.registry_mut()
-            .enum_types
-            .insert("SeekType".to_string(), variants.clone());
+        let variants = Self::seek_type_enum_variants();
         base.insert(Symbol::intern("SeekType"), Value::str_from("SeekType"));
         for (index, (key, val)) in variants.iter().enumerate() {
             let enum_val = Value::enum_parts(
@@ -203,9 +169,78 @@ impl Interpreter {
         }
     }
 
-    pub(in crate::runtime) fn init_signal_enum(&mut self, base: &mut HashMap<Symbol, Value>) {
+    pub(in crate::runtime) fn init_signal_enum(base: &mut HashMap<Symbol, Value>) {
+        let variants = Self::signal_enum_variants();
+        base.insert(Symbol::intern("Signal"), Value::str_from("Signal"));
+        for (index, (key, val)) in variants.iter().enumerate() {
+            let enum_val = Value::enum_parts(
+                Symbol::intern("Signal"),
+                Symbol::intern(key),
+                val.clone(),
+                index,
+            );
+            base.insert(
+                Symbol::intern(&format!("Signal::{}", key)),
+                enum_val.clone(),
+            );
+            base.insert(Symbol::intern(key), enum_val);
+        }
+    }
+
+    /// The `Endian` enum's variants. Shared by [`Self::init_endian_enum`] (which
+    /// builds their `Value`s for the global base tier) and
+    /// [`Self::seed_builtin_enum_types`] (which records the type itself in the
+    /// built-in registry template).
+    fn endian_enum_variants() -> Vec<(String, EnumValue)> {
+        vec![
+            ("NativeEndian".to_string(), EnumValue::Int(0)),
+            ("LittleEndian".to_string(), EnumValue::Int(1)),
+            ("BigEndian".to_string(), EnumValue::Int(2)),
+        ]
+    }
+    /// The `ProtocolFamily` enum's variants. Shared by [`Self::init_protocol_family_enum`] (which
+    /// builds their `Value`s for the global base tier) and
+    /// [`Self::seed_builtin_enum_types`] (which records the type itself in the
+    /// built-in registry template).
+    fn protocol_family_enum_variants() -> Vec<(String, EnumValue)> {
+        vec![
+            ("PF_UNSPEC".to_string(), EnumValue::Int(0)),
+            ("PF_INET".to_string(), EnumValue::Int(1)),
+            ("PF_INET6".to_string(), EnumValue::Int(2)),
+            ("PF_LOCAL".to_string(), EnumValue::Int(3)),
+            ("PF_UNIX".to_string(), EnumValue::Int(3)),
+            ("PF_MAX".to_string(), EnumValue::Int(4)),
+        ]
+    }
+    /// The `Order` enum's variants. Shared by [`Self::init_order_enum`] (which
+    /// builds their `Value`s for the global base tier) and
+    /// [`Self::seed_builtin_enum_types`] (which records the type itself in the
+    /// built-in registry template).
+    fn order_enum_variants() -> Vec<(String, EnumValue)> {
+        vec![
+            ("Less".to_string(), EnumValue::Int(-1)),
+            ("Same".to_string(), EnumValue::Int(0)),
+            ("More".to_string(), EnumValue::Int(1)),
+        ]
+    }
+    /// The `SeekType` enum's variants. Shared by [`Self::init_seek_type_enum`] (which
+    /// builds their `Value`s for the global base tier) and
+    /// [`Self::seed_builtin_enum_types`] (which records the type itself in the
+    /// built-in registry template).
+    fn seek_type_enum_variants() -> Vec<(String, EnumValue)> {
+        vec![
+            ("SeekFromBeginning".to_string(), EnumValue::Int(0)),
+            ("SeekFromCurrent".to_string(), EnumValue::Int(1)),
+            ("SeekFromEnd".to_string(), EnumValue::Int(2)),
+        ]
+    }
+    /// The `Signal` enum's variants. Shared by [`Self::init_signal_enum`] (which
+    /// builds their `Value`s for the global base tier) and
+    /// [`Self::seed_builtin_enum_types`] (which records the type itself in the
+    /// built-in registry template).
+    fn signal_enum_variants() -> Vec<(String, EnumValue)> {
         // Use libc constants on Unix, standard POSIX numbers on other platforms
-        let variants = vec![
+        vec![
             // Signals that share value 0 on this platform (Rakudo lists them so
             // `Signal.keys` is complete, e.g. `Signal.keys.sort[^3]` needs SIGBREAK).
             ("SIGINFO".to_string(), EnumValue::Int(Self::sig_num(0))),
@@ -243,24 +278,34 @@ impl Interpreter {
             ("SIGIO".to_string(), EnumValue::Int(Self::sig_num(29))),
             ("SIGPWR".to_string(), EnumValue::Int(Self::sig_num(30))),
             ("SIGSYS".to_string(), EnumValue::Int(Self::sig_num(31))),
-        ];
-        self.registry_mut()
+        ]
+    }
+
+    /// Record the process-constant built-in enum types (`Endian`,
+    /// `ProtocolFamily`, `Order`, `SeekType`, `Signal`) in a registry.
+    ///
+    /// Called while BUILDING the shared built-in registry template, not per
+    /// interpreter: these five entries are identical in every interpreter, but
+    /// writing them through `registry_mut()` from `Interpreter::new` took a
+    /// write guard on the shared registry and so deep-cloned all ~450 built-in
+    /// `ClassDef`s on every single construction (#7572).
+    pub(in crate::runtime) fn seed_builtin_enum_types(registry: &mut Registry) {
+        registry
             .enum_types
-            .insert("Signal".to_string(), variants.clone());
-        base.insert(Symbol::intern("Signal"), Value::str_from("Signal"));
-        for (index, (key, val)) in variants.iter().enumerate() {
-            let enum_val = Value::enum_parts(
-                Symbol::intern("Signal"),
-                Symbol::intern(key),
-                val.clone(),
-                index,
-            );
-            base.insert(
-                Symbol::intern(&format!("Signal::{}", key)),
-                enum_val.clone(),
-            );
-            base.insert(Symbol::intern(key), enum_val);
-        }
+            .insert("Endian".to_string(), Self::endian_enum_variants());
+        registry.enum_types.insert(
+            "ProtocolFamily".to_string(),
+            Self::protocol_family_enum_variants(),
+        );
+        registry
+            .enum_types
+            .insert("Order".to_string(), Self::order_enum_variants());
+        registry
+            .enum_types
+            .insert("SeekType".to_string(), Self::seek_type_enum_variants());
+        registry
+            .enum_types
+            .insert("Signal".to_string(), Self::signal_enum_variants());
     }
 
     /// Get signal number — use the POSIX default value on all platforms.

--- a/tests/long_lived_parse.rs
+++ b/tests/long_lived_parse.rs
@@ -510,6 +510,99 @@ fn repeated_analysis_of_an_unchanged_document_is_stable() {
     }
 }
 
+/// The construct-and-drop shape ADR-0065 S2 briefly had, and the one any
+/// embedder driving mutsu per request has: one fresh `Interpreter` per unit of
+/// work, rather than one resident interpreter re-parsing.
+///
+/// #7572 measured this leaking ~7 KiB per construction (debug), growing
+/// strictly linearly from 1000 to 4000 constructions. The cause was not in
+/// `Interpreter::new` at all: the GC's cycle-candidate buffer is drained by
+/// `gc_safepoint`, which only the VM's dispatch loops emit, so a loop that
+/// constructs and drops interpreters without ever running bytecode buffered
+/// every dropped interpreter's dead nodes and never collected them.
+/// `Interpreter::new` now emits a `construct` safepoint of its own.
+///
+/// The bound below is therefore deliberately **independent of `n`**: the
+/// buffer is capped by the collector's size threshold, so the growth of a
+/// 4000-construction run must look like that of a 1000-construction one. A
+/// return of the per-construction leak fails this at
+/// `MUTSU_S0_ITERATIONS=4000`, where it was 28.9 MB.
+#[test]
+fn repeated_interpreter_construction_does_not_grow_without_bound() {
+    let _guard = exclusive();
+    let n = iterations();
+
+    // The first constructions build the process-wide things `Interpreter::new`
+    // shares rather than rebuilds (the built-in registry template, the symbol
+    // table's fixed names, the global base tier). Measure the steady state.
+    for _ in 0..3 {
+        drop(mutsu::Interpreter::new());
+    }
+
+    let rss_before = rss_kib();
+    let started = Instant::now();
+    for _ in 0..n {
+        std::hint::black_box(mutsu::Interpreter::new());
+    }
+    let elapsed = started.elapsed();
+    let rss_after = rss_kib();
+
+    println!("--- ADR-0065 S0 probe: {n} Interpreter::new constructions ---");
+    println!(
+        "  wall clock      : {elapsed:?} total, {:?} per construction",
+        elapsed / n as u32
+    );
+    if let (Some(before), Some(after)) = (rss_before, rss_after) {
+        println!(
+            "  resident memory : {:+} KiB ({:.3} KiB/construction)",
+            after as isize - before as isize,
+            (after as f64 - before as f64) / n as f64,
+        );
+    }
+
+    if let (Some(before), Some(after)) = (rss_before, rss_after) {
+        let growth = after.saturating_sub(before);
+        assert!(
+            growth < 16 * 1024,
+            "resident memory grew {growth} KiB over {n} interpreter constructions; \
+             the bound is n-independent on purpose (see this test's doc comment), \
+             so a growth that scales with MUTSU_S0_ITERATIONS is the regression"
+        );
+    }
+}
+
+/// Every interpreter starts from ONE shared, copy-on-write built-in
+/// declaration registry (`Interpreter::shared_builtin_registry`) instead of
+/// rebuilding ~450 `ClassDef`s per construction. The share is only sound
+/// because the first write forks a private copy, so pin the fork: a class
+/// declared in one live interpreter must be invisible to another constructed
+/// while it is still alive.
+#[test]
+fn a_declaration_in_one_interpreter_is_invisible_to_another() {
+    let _guard = exclusive();
+
+    let mut first = mutsu::Interpreter::new();
+    let declared = first
+        .run("class OnlyInTheFirst { method answer() { 42 } }\nsay OnlyInTheFirst.new.answer;")
+        .expect("the declaring program runs");
+    assert!(
+        declared.contains("42"),
+        "the probe's own declaration did not take effect: {declared:?}"
+    );
+
+    // Constructed while `first` is still alive, so the two really do share the
+    // template `Arc` rather than each getting a private build.
+    let mut second = mutsu::Interpreter::new();
+    let leaked = second.run("say OnlyInTheFirst.new.answer;");
+    assert!(
+        leaked
+            .as_ref()
+            .map(|out| !out.contains("42"))
+            .unwrap_or(true),
+        "a class declared in one interpreter was visible in another: {leaked:?}"
+    );
+}
+
 /// The other analysis entry point. `symbols` runs its own recovering parse, and
 /// a server calls it on every keystroke, so its leak would have been the larger
 /// of the two. Same rule, same zero.


### PR DESCRIPTION
Closes #7572.

`Interpreter::new()` cost **9.17 ms** and appeared to retain **~7.2 KiB per construction, linearly** (#7572, debug, 4000 construct-and-drop cycles). The two properties have separate causes, and neither is where the issue guessed.

Release, same probe: **1.17 ms → 0.26 ms** per construction, and the retention is gone.

| release, constructions | resident growth, before | after |
| --- | --- | --- |
| 1000 | +1.9 MB | +1.2 MB |
| 4000 | +4.9 MB (0.99 KiB/call, linear) | +2.2 MB |
| 16000 | (~16 MB, extrapolated) | +2.3 MB |

Debug tells the same story: 9.17 ms → 1.70 ms, +7.2 KiB/construction → +1.1 MB *total* over 4000.

## The retention was never in the constructor

One measurement settles it (release, 4000 cycles):

| | KiB retained per construction |
| --- | --- |
| `MUTSU_GC` unset (on, the default) | 1.44 |
| `MUTSU_GC=off` | 0.08 |

What accumulates is the GC's **cycle-candidate buffer**. It is drained by `gc_safepoint`, which only the VM's dispatch loops and its call/await/join boundaries emit — so a loop that constructs an interpreter, drops it, and never runs any bytecode reaches no safepoint at all, and every dropped interpreter's dead nodes stay buffered forever.

This also explains the line in the issue that reads like a dead end: `MUTSU_GC=on` is already the default (ADR-0003 §5), so that probe changed nothing. It *is* a collector that never runs in that loop; `off` is the direction that shows it.

`Interpreter::new` now emits a `SafepointKind::Construct` safepoint. A top-level construction is a proper re-entry boundary (no borrow, no lock, no `gc_contents_mut` held) and for an embedder driving mutsu per request it may be the only one it ever reaches. `new_regex_scratch` is excluded — those are built from *inside* regex/grammar evaluation, which is not a boundary.

## The wall clock was the registry, not `%*ENV`

Callgrind, 30 construct-and-drop cycles, 245.5M Ir total:

| | Ir | share |
| --- | --- | --- |
| `Interpreter::new` | 209.2M | 85% |
| ⤷ `build_builtin_registry` | 146.2M | 60% |
| ⤷ `os_env_hash` (the `%*ENV` sweep) | ~31.5M | 13% |
| `drop_glue::<Interpreter>` | 34.4M | 14% |
| ⤷ dropping that same registry | 29.7M | 12% |

Building ~450 `ClassDef`s and throwing them away again was 72% of the cycle; the `%*ENV` sweep the issue suspected was 13%.

That registry is identical in every interpreter, and it has been copy-on-write for as long as `clone_for_thread` has existed — every mutation goes through `RegistryWriteGuard`, whose `deref_mut` is an `Arc::make_mut`. It is now built **once per process** and handed out as a shared `Arc` (`Interpreter::shared_builtin_registry`): the same share `clone_for_thread` already performs between threads, one level up.

**Sharing alone only bought 41%**, and the profile said why: 33% of the remainder had moved into `RegistryWriteGuard::deref_mut`. The five `init_*_enum` calls were *writing* the registry during construction, so the first write forked a private deep copy and every construction still paid for a whole registry. Those five enum types (`Order`, `Endian`, `ProtocolFamily`, `Signal`, `SeekType`) are process constants, so they move into the template via a new `seed_builtin_enum_types`; the variant lists are shared with `init_*_enum`, which now builds only the base-tier `Value`s and no longer takes `&mut self` at all. 1.17 ms → 0.28 ms.

## `val()` stopped copying every string it was about to reject

That leaves the `%*ENV` sweep on top (55% of what remains; `%*ENV` values are allomorphs, so all ~40 go through the full numeric-string parser). Two allocations per attempt were pure waste: `normalize_minus` copied the whole string just to leave it unchanged when no U+2212 was present, and `strip_underscores` built a fresh `String` for *every* candidate the parser tried, including the ones rejected on the next line — 18% of a construction on its own. Both now return `Cow`. A win for every `val()` in the language, not only this sweep. 0.28 ms → 0.26 ms.

## What a one-shot `mutsu script.raku` pays

The template `Arc` is held by a `OnceLock`, so a single-interpreter process's registry is no longer uniquely owned and its first registry write pays one `Arc::make_mut` deep clone — ~1.6M Ir, under a third of the ~5.3M Ir build it replaces (which still happens once). Against that it drops five `registry_mut` acquisitions from startup and gets the `val()` improvement. A program that declares nothing never writes the registry and pays nothing.

## Pins

`tests/long_lived_parse.rs`, the file the issue points its repro at, grew two:

- `repeated_interpreter_construction_does_not_grow_without_bound` — the retention gate. Its bound is deliberately **independent of the iteration count**, because that is now the property: the buffer is capped by the collector's size threshold, so a 4000-construction run must grow like a 1000-construction one. The old behaviour blew through it at `MUTSU_S0_ITERATIONS=4000`, where it retained 28.9 MB.
- `a_declaration_in_one_interpreter_is_invisible_to_another` — the correctness gate on the share: two interpreters alive at once really do hold the same template `Arc`, so a class declared in one must not be visible in the other. That is the copy-on-write fork actually happening.

## Verification

- `cargo test -- --test-threads=1` — green; `cargo test -p mutsu-lsp` — green.
- `t/` on the release binary: **3841 files, 40650 tests, all pass**.
- `make roast`: 1436 files / 218939 tests. The only failures are `roast/6.c/S32-io/file-tests.t`, `roast/S16-filehandles/filetest.t` (permission-bit tests, this container runs as uid 0) and a timeout in `roast/S32-io/IO-Socket-Async.t` — all three reproduce identically on unmodified `main`.
- `cargo clippy --workspace --all-targets`, `--no-default-features --features native`, wasm32 `--features wasm`, and `cargo doc` all produce a byte-identical finding set before and after this change (this container's toolchain is newer than the pinned MSRV and flags 49 pre-existing lints on `main`).

Wall-clock figures are local probe runs on one container, not bench-CI rows; the instruction counts are callgrind, which is load-independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0198rM9DTmDE8GT4RwaEa9hu

---
_Generated by [Claude Code](https://claude.ai/code/session_0198rM9DTmDE8GT4RwaEa9hu)_