### PR TITLE
fix(vm): restore current_unit before the positional-light return-type check

### DIFF
--- a/news/2026-09/light-call-restores-its-compilation-unit-before-the-return-type-check.md
+++ b/news/2026-09/light-call-restores-its-compilation-unit-before-the-return-type-check.md
@@ -1,0 +1,52 @@
+# The positional-light call path restores `current_unit` before its return-type check
+
+[#7558](https://github.com/tokuhirom/mutsu/issues/7558) parks a full
+implementation of module-private top-level sub scoping (closed PR #7436) behind
+a blocker of its own, and names two independent pre-existing bugs that branch
+fixed on the way, "both worth salvaging separately if this stays parked". This
+is the second of them:
+
+> `call_compiled_function_positional_light_at`'s return-type-check failure path
+> returned **without restoring `current_unit`** — a leak that also mis-scoped
+> user-declared operators.
+
+## The defect
+
+`call_compiled_function_positional_light_at` saves the caller's compilation unit
+on entry (`enter_compilation_unit`) and restores it on the way out. Every other
+piece of per-call state — locals, loop-local scopes, block-declared vars, the
+env overlay, the routine package, pragma state — is restored in one block just
+before the function's tail. `current_unit` was not: it sat *after* the
+return-type check, which has its own `return Err(...)`.
+
+So a routine whose declared return type its body violates left the caller
+running with `current_unit` still naming the callee's unit. That matters because
+`current_unit` is what user-declared operator scoping resolves against —
+`user_infix_override` → `declaring_unit_is_in_scope` walks it, and the `EVAL`
+parent chain, to decide whether an `infix:<...>` declared in some compilation
+unit is visible here. A *caught* return-type failure would therefore silently
+re-scope the caller's operators for the rest of the program.
+
+The fix is to restore it with everything else, immediately after
+`leave_routine_package`. Nothing between there and the old restore point reads
+`current_unit`, so the move is behaviour-preserving.
+
+## The leak is latent on `main`, and that is worth recording
+
+The closed branch found this because it made cross-unit light calls reachable.
+On `main` they are not: a call into another compilation unit does not take this
+path at all. Verified under `rust-gdb`, breaking on the return-type-failure
+`return` for a `use`d module whose exported sub is light-eligible
+(`our sub bad-return(Int $n --> Int) is export { "not an Int" }`) — none of
+`bad-return(1)`, `RetTypeUnitLeak::bad-return(1)` or `&bad-return(1)` reaches
+`call_compiled_function_positional_light_at`, while the identical sub declared
+in the *same* unit does. So there is no observable repro to pin, and none is
+claimed here.
+
+That is the useful half of the finding for anyone picking #7558 back up: of its
+two "salvage separately" items, this one is a two-line reorder that becomes
+load-bearing the moment cross-unit light calls exist, and the other (the
+name-keyed call caches `pos_light_call_cache` / `light_call_cache` /
+`otf_call_cache` / `func_multi_resolve_cache` / `fn_resolve_cache` being keyed
+by `(name, package)`, with no room for a winner that depends on which unit is
+asking) is a design observation with nothing to fix until the same point.

--- a/src/vm/vm_call_light.rs
+++ b/src/vm/vm_call_light.rs
@@ -705,6 +705,22 @@ impl Interpreter {
         // the callee's own overlay.
         self.finish_positional_light_env(cf, caller_env);
         self.leave_routine_package(saved_package);
+        // Leave the callee's compilation unit HERE, alongside every other
+        // piece of per-call state, and not after the return-type check below:
+        // that check has its own `return Err(...)`, and with the restore after
+        // it the caller resumed with `current_unit` still naming the callee's
+        // unit. `current_unit` is what user-declared operator scoping resolves
+        // against (`user_infix_override` -> `declaring_unit_is_in_scope`), so a
+        // caught return-type failure would silently re-scope the caller's
+        // operators. Found while working #7558, whose closed branch made
+        // cross-unit light calls reachable; on `main` the leak is latent,
+        // because a call into another compilation unit does not take this path
+        // today (verified under `rust-gdb`: neither `bad-return(1)`,
+        // `Mod::bad-return(1)` nor `&bad-return(1)` for a `use`d module reaches
+        // this function). Nothing between here and the old restore point reads
+        // `current_unit`, so moving it up is behaviour-preserving today and
+        // correct once such a call does arrive.
+        self.current_unit = saved_unit;
 
         // Return type check (if specified). Allows type objects, Nil, and Failure through.
         if result.is_ok()
@@ -737,7 +753,6 @@ impl Interpreter {
             });
         }
 
-        self.current_unit = saved_unit;
         match result {
             Ok(()) if fail_bypass => Ok(ret_val),
             Ok(()) => {


### PR DESCRIPTION
#7558 parks a full implementation of module-private top-level sub scoping (closed PR #7436) behind a blocker of its own, and names two independent pre-existing bugs that branch fixed on the way, "**both worth salvaging separately if this stays parked**". This is the second of them:

> `call_compiled_function_positional_light_at`'s return-type-check failure path returned **without restoring `current_unit`** — a leak that also mis-scoped user-declared operators.

## The defect

`call_compiled_function_positional_light_at` saves the caller's compilation unit on entry and restores it on the way out. Every other piece of per-call state — locals, loop-local scopes, block-declared vars, the env overlay, the routine package, pragma state — is restored in **one block** just before the tail. `current_unit` was not: it sat *after* the return-type check, which has its own `return Err(...)`.

So a routine whose body violates its declared return type left the caller running with `current_unit` still naming the callee's unit. That matters because `current_unit` is what user-declared operator scoping resolves against — `user_infix_override` → `declaring_unit_is_in_scope` walks it (and the `EVAL` parent chain) to decide whether an `infix:<…>` declared in some compilation unit is visible here. A **caught** return-type failure would therefore silently re-scope the caller's operators for the rest of the program.

The fix is to restore it with everything else, immediately after `leave_routine_package`. Nothing between there and the old restore point reads `current_unit`, so the move is behaviour-preserving.

## No pin, and none is claimed: the leak is latent on `main`

Cross-unit calls do not take this path today. Verified under `rust-gdb`, breaking on the return-type-failure `return` for a `use`d module whose exported sub is light-eligible:

```raku
# t/lib/RetTypeUnitLeak.rakumod
unit module RetTypeUnitLeak;
our sub bad-return(Int $n --> Int) is export { "not an Int" }
```

| call | reaches `call_compiled_function_positional_light_at`? |
|---|---|
| `bad-return(1)` | no |
| `RetTypeUnitLeak::bad-return(1)` | no |
| `&bad-return(1)` | no |
| the identical sub declared in the *same* unit | **yes** |

The closed branch found this precisely because it made such calls reachable. Rather than invent a repro that does not exist, the reachability finding is recorded in the news entry and on the issue — it is what tells the next attempt at #7558 that of its two salvage items, this one is a two-line reorder that becomes load-bearing the moment cross-unit light calls exist, and the other (the name-keyed caches `pos_light_call_cache` / `light_call_cache` / `otf_call_cache` / `func_multi_resolve_cache` / `fn_resolve_cache` keyed by `(name, package)`, with no room for a winner that depends on which unit is asking) is a design observation with nothing yet to fix.

The main body of #7558 — the `call_sub_value` / `decl_unit` change plus a solo `scripts/battery-testsuite.sh` gate — is **not** attempted here, so the issue stays open.

## Verification

- `make test`: `Files=3845, Tests=40733 … Result: PASS`.
- `make roast`: identical failure set to the baseline runs earlier in this session — `6.c/S32-io/file-tests.t`, `S16-filehandles/filetest.t`, `S32-io/IO-Socket-Async.t`. This container runs as `root`, so `.r`/`.w`/`.x` assertions expecting a permission denial pass instead.
- 185 `t/` files covering units, operators, infixes, return types and `EVAL` pass on the rebased branch.
- `cargo fmt --all` and `make lint` clean.

Part of #7558.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012BaTE6YdzbdFki2k3dQqq1

---
_Generated by [Claude Code](https://claude.ai/code/session_012BaTE6YdzbdFki2k3dQqq1)_