### PR TITLE
perf(vm): memoize the closure-capture env instead of rebuilding it per creation

### DIFF
--- a/news/2026-09/closure-capture-env-memo.md
+++ b/news/2026-09/closure-capture-env-memo.md
@@ -1,0 +1,103 @@
+# Closure creation stops rebuilding the same captured env every time
+
+Creating a closure literal was O(enclosing env): `capture_closure_env` handed
+`Env::filtered_flat` a filter, and `filtered_flat` walked every visible env key
+and inserted the kept ones into a brand-new map — per creation. On a
+200000-iteration `my $c = * + 1;` loop that one call was **41% of the program's
+instructions**, and adding 30 unrelated lexicals to the enclosing scope added
+~24ns to every creation ([#7557](https://github.com/tokuhirom/mutsu/issues/7557)
+part B).
+
+## What is actually in a capture
+
+Dumping the kept set for a one-line script settled what the issue could only
+guess at. A closure created at the top of an otherwise empty program captures
+**23 entries**, and 20 of them are the built-in dynamics seeded once at startup:
+
+```
+$*ARGFILES $*CWD $*ERR $*HOME $*IN $*OUT $*TMPDIR %*ENV
+*ARGFILES *CWD *ERR *HOME *IN *OUT *PROGRAM *PROGRAM-NAME *REPO *SCHEDULER
+*TMPDIR @*ARGS =pod ?FILE Any
+```
+
+None of them is a free variable of any closure; they are kept because they are
+not *plain user lexicals* (`env::is_plain_user_lexical`), which is the
+deliberately conservative rule that keeps dynamics, magic vars, `self`, type
+names and `__mutsu_*` metadata reachable from a closure body. So the filter
+result is not merely expensive to compute — it is the *same* result over and
+over.
+
+## The memo
+
+`filtered_flat`'s filter here reads only the KEY, never the value, so the
+captured map is a pure function of the visible env contents and of the closure's
+own `CompiledCode`. `src/vm/vm_capture_cache.rs` memoizes exactly that: one
+entry, holding the env tiers it was built from, the chunk, and the resulting
+env. A creation whose inputs are unchanged clones the memoized `Env` (an `Arc`
+bump) instead of rebuilding the map; everything that varies per creation — the
+free-var upvalue reads from the frame's live slots, the ADR-0024 mainline
+lexical overrides, `capture_bare_callees`, the `self` materialization — still
+runs afresh, factored out into `finish_closure_capture`.
+
+**Why comparing tier addresses is sound.** An armed entry holds an `Arc` on
+every tier's overlay map. That both keeps the allocations from being freed and
+recycled at the same address *and* pushes `Env::cow_mut`'s `Arc::make_mut` onto
+its cloning path, so any by-name write moves the written tier to a new address.
+Matching addresses therefore prove the contents are the ones the entry was built
+from. A chain carrying tombstones is refused outright (a tombstone set is a
+plain `FxHashSet` the memo cannot pin). A write *through* a captured
+`ContainerRef` cell is deliberately not a mismatch: the memo holds the same
+cell, exactly as a freshly built capture would. `t/closure-capture-memo.t` pins
+the observable semantics and two `env.rs` unit tests pin the address invariant
+itself.
+
+**Why arming waits for a repeat.** Holding those `Arc`s costs one
+copy-on-write clone on the next write to a pinned tier. An entry is therefore
+armed only after two consecutive captures have seen the same chain and chunk: a
+scope that churns is tracked with bare addresses (nothing held, nothing pinned)
+and never pays for a memo that could not hit. The cache itself is boxed on the
+`Interpreter` alongside `cur_repo` — inlining ~180 bytes of closure-only state
+would push the per-opcode hot fields apart for every program.
+
+## Also in this change
+
+Fixed per-creation costs on the same path, all semantics-free:
+
+- The capture filter asked two string questions about every visible env key
+  (`is_plain_user_lexical`, `is_attr_twigil_env_key`) by resolving the symbol and
+  re-scanning its bytes, twice per key. Both are now bits in the memoized
+  `Symbol::flags()` byte, so the filter is one thread-local lookup per key.
+- `Symbol::intern(&self.lexical_closure_package())` allocated a `String` and
+  re-hashed it per creation just to intern it. `lexical_closure_package_sym()`
+  answers with the `Symbol` directly; the common case (no method frame in the
+  way) is an atomic load.
+- `materialize_frame_self_into_capture` re-interned `"self"` and allocated a
+  `String` key per creation; it is symbol-keyed now.
+
+## Result
+
+Deterministic instruction counts (callgrind, load-independent — the wall-clock
+rows will come from the bench CI):
+
+| | before | after | |
+|---|---|---|---|
+| `my $c = * + 1;` × 200000 | 4,561,796,171 | 2,667,115,037 | **−41.5%** |
+| the same with 30 extra enclosing lexicals | 6,924,565,867 | 3,224,306,708 | **−53.4%** |
+| `bench-ctor` | 1,481,775,564 | 1,462,503,952 | −1.3% |
+| `bench-class` | 1,246,662,130 | 1,245,785,315 | −0.1% |
+| `word-count` | 1,132,877,066 | 1,132,704,822 | −0.0% |
+| `bench-fib` | 1,408,905,100 | 1,408,911,125 | +0.0% |
+| `bench-tak` | 1,682,291,882 | 1,682,305,527 | +0.0% |
+
+The scaling that named the issue is what moved most: those 30 unrelated
+lexicals used to add ~24ns to every creation and now add ~4ns, because a memo
+hit no longer touches the enclosing env at all.
+
+## Still open
+
+The kept set is still over-broad by construction, and a capture that *misses*
+the memo still pays O(kept env). Narrowing the rule — deciding which of those
+names are genuinely read by runtime by-name mechanisms and which only through a
+compiled `GetLocal`/`GetGlobal` the free-var pass already sees — remains the
+design question #7557 part B poses, and the dump above is the evidence a future
+pass should start from: the answer is mostly about the built-in dynamics.

--- a/src/env.rs
+++ b/src/env.rs
@@ -13,7 +13,7 @@ use crate::value::Value;
 /// cost dominated method/variable-heavy benchmarks (perf: ~7% of self time in
 /// `SipHasher::write`/`hash_one`). Iteration order is unspecified either way, so
 /// no env-iteration consumer (`iter`/`keys`/`values`/pseudo-stash) is affected.
-type SymMap = rustc_hash::FxHashMap<Symbol, Value>;
+pub(crate) type SymMap = rustc_hash::FxHashMap<Symbol, Value>;
 
 /// Process-wide immutable "base" tier of the environment.
 ///
@@ -138,6 +138,25 @@ pub(crate) fn is_plain_user_lexical(name: &str) -> bool {
         Some(first)
     };
     matches!(decider, Some(c) if c.is_ascii_lowercase())
+}
+
+/// True for an *attribute-twigil* env key (`!x`, `@!x`, `%.x`, `$.y`, …): a
+/// per-frame materialization of one of `self`'s attributes rather than a
+/// lexical.
+///
+/// The closure capture must never snapshot one: the closure has to read the
+/// attribute through its captured `self` at RUN time, because a creation-time
+/// copy goes stale the moment the instance mutates (a `start` block reading
+/// `@!before` inside `Cro::CompositeConnector.connect` saw an empty
+/// pre-mutation copy).
+#[inline]
+pub(crate) fn is_attr_twigil_env_key(name: &str) -> bool {
+    let bare = match name.as_bytes().first() {
+        Some(b'@' | b'%' | b'&' | b'$') => &name[1..],
+        _ => name,
+    };
+    let b = bare.as_bytes();
+    matches!(b.first(), Some(b'!') | Some(b'.')) && b.len() > 1 && b[1].is_ascii_alphabetic()
 }
 
 /// True when `name` is a sigil-less env key that holds a *magic variable* rather
@@ -1144,6 +1163,78 @@ impl Env {
     pub(crate) fn inner(&self) -> &SymMap {
         &self.inner
     }
+
+    /// Non-owning identity of this env's tier chain: the address of each tier's
+    /// overlay map, leaf first. `None` when the chain is not describable this
+    /// way -- it carries tombstones (a plain `FxHashSet` this cannot pin, so a
+    /// removal would be invisible to the comparison) or is deeper than
+    /// [`MAX_IDENTITY_TIERS`].
+    ///
+    /// Addresses alone are a *heuristic*: a dropped map's allocation can be
+    /// recycled at the same address. Pair them with [`Self::tier_maps`], which
+    /// holds each tier's `Arc` and so keeps the addresses from being recycled,
+    /// before treating a match as proof that the contents are unchanged. See
+    /// `Interpreter::capture_closure_env`.
+    pub(crate) fn tier_addrs(&self) -> Option<TierAddrs> {
+        let mut addrs = [0usize; MAX_IDENTITY_TIERS];
+        let mut len = 0usize;
+        let mut cur = self;
+        loop {
+            if cur.tombstones.is_some() || len == MAX_IDENTITY_TIERS {
+                return None;
+            }
+            addrs[len] = Arc::as_ptr(&cur.inner) as usize;
+            len += 1;
+            match &cur.parent {
+                Some(parent) => cur = parent,
+                None => break,
+            }
+        }
+        Some(TierAddrs { addrs, len })
+    }
+
+    /// Owning twin of [`Self::tier_addrs`]: an `Arc` handle on every tier's
+    /// overlay map, leaf first. Holding these pins the addresses (nothing can
+    /// be freed and re-allocated at one of them) AND forces copy-on-write on
+    /// the next by-name write to any tier, so an address match proves the
+    /// visible contents are byte-for-byte the ones that were there before.
+    pub(crate) fn tier_maps(&self) -> Vec<Arc<SymMap>> {
+        let mut maps = Vec::new();
+        let mut cur = self;
+        loop {
+            maps.push(Arc::clone(&cur.inner));
+            match &cur.parent {
+                Some(parent) => cur = parent,
+                None => break,
+            }
+        }
+        maps
+    }
+}
+
+/// Longest tier chain [`Env::tier_addrs`] describes. Deeper chains are simply
+/// reported as un-identifiable; [`MAX_OVERLAY_DEPTH`] bounds the chain anyway
+/// and ordinary nesting is a handful of tiers.
+const MAX_IDENTITY_TIERS: usize = 8;
+
+/// The address of each tier's overlay map in one env chain -- see
+/// [`Env::tier_addrs`].
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) struct TierAddrs {
+    addrs: [usize; MAX_IDENTITY_TIERS],
+    len: usize,
+}
+
+impl TierAddrs {
+    /// True when `maps` (an owning [`Env::tier_maps`] snapshot) is exactly the
+    /// chain these addresses describe.
+    pub(crate) fn matches(&self, maps: &[Arc<SymMap>]) -> bool {
+        maps.len() == self.len
+            && maps
+                .iter()
+                .zip(&self.addrs[..self.len])
+                .all(|(map, addr)| Arc::as_ptr(map) as usize == *addr)
+    }
 }
 
 impl Default for Env {
@@ -1314,6 +1405,50 @@ mod tests {
         // Re-inserting clears the tombstone.
         leaf.insert("a".into(), Value::int(5));
         assert_eq!(leaf.get_sym(s("a")), Some(&Value::int(5)));
+    }
+
+    #[test]
+    fn tier_addrs_match_only_while_the_held_maps_are_untouched() {
+        // The closure-capture memo reuses a captured env whenever the tier
+        // ADDRESSES still match the `Arc`s it holds. That is only sound because
+        // holding those `Arc`s makes `cow_mut`'s `Arc::make_mut` clone before
+        // any by-name write, so a written tier necessarily moves — which is
+        // exactly what this pins.
+        let mut root = Env::new();
+        root.insert("a".into(), Value::int(1));
+        let mut leaf = Env::scoped_child(root);
+        leaf.insert("b".into(), Value::int(2));
+
+        let held = leaf.tier_maps();
+        assert_eq!(held.len(), 2, "leaf overlay plus the root tier");
+        let addrs = leaf.tier_addrs().expect("no tombstones, shallow chain");
+        assert!(
+            addrs.matches(&held),
+            "an untouched chain keeps its addresses"
+        );
+        // A read must not disturb them.
+        assert_eq!(leaf.get_sym(s("a")), Some(&Value::int(1)));
+        assert!(addrs.matches(&held));
+
+        // Writing to the leaf moves it, so the recorded addresses stop matching.
+        leaf.insert("c".into(), Value::int(3));
+        let after = leaf.tier_addrs().expect("still no tombstones");
+        assert!(
+            !after.matches(&held),
+            "a by-name write must break the address match"
+        );
+    }
+
+    #[test]
+    fn tier_addrs_refuses_a_tombstoned_chain() {
+        // Tombstones are a plain `FxHashSet` the memo cannot pin, so a chain
+        // carrying one is reported as un-identifiable rather than compared.
+        let mut root = Env::new();
+        root.insert("a".into(), Value::int(1));
+        let mut leaf = Env::scoped_child(root);
+        assert!(leaf.tier_addrs().is_some());
+        leaf.remove("a");
+        assert!(leaf.tier_addrs().is_none());
     }
 
     #[test]

--- a/src/runtime/accessors_state.rs
+++ b/src/runtime/accessors_state.rs
@@ -594,7 +594,13 @@ impl Interpreter {
     /// invoked later from a foreign frame. `current_package` is only switched to
     /// the class for some method shapes (class-scoped subs, package lexicals, a
     /// `::`-qualified owner), so fall back to the running method's class.
-    pub(crate) fn lexical_closure_package(&self) -> String {
+    ///
+    /// Answers with the interned `Symbol` every caller wants: each closure
+    /// literal stamps this onto its `SubData`, and building the `String` first
+    /// cost a heap allocation plus a re-intern (a thread-local hash of the whole
+    /// package name) per creation. The common answer — the current package, with
+    /// no method frame in the way — is an atomic load.
+    pub(crate) fn lexical_closure_package_sym(&self) -> crate::symbol::Symbol {
         // An attribute default (`has $.x = -> { helper() }`) is lowered at class
         // declaration time but RUN inside the constructing caller's frame, so
         // the routine walk below would see the caller's method and stamp the
@@ -606,7 +612,7 @@ impl Interpreter {
         // attribute default of this class", so it is the authoritative answer
         // here.
         if let Some(class) = &self.constructing_class {
-            return class.clone();
+            return crate::symbol::Symbol::intern(class);
         }
         // A closure created inside a METHOD body lexically belongs to that
         // method's class, even when `current_package` still holds the CALLER's
@@ -625,15 +631,15 @@ impl Interpreter {
             if f.is_method
                 && let Some(class) = self.method_class_stack.last()
             {
-                return class.clone();
+                return crate::symbol::Symbol::intern(class);
             }
             break;
         }
-        let pkg = self.current_package();
-        if (pkg.is_empty() || pkg == "GLOBAL")
+        let pkg = self.current_package_sym();
+        if (pkg == crate::symbol::wk::empty_package() || pkg == crate::symbol::wk::global_package())
             && let Some(class) = self.method_class_stack.last()
         {
-            return class.clone();
+            return crate::symbol::Symbol::intern(class);
         }
         pkg
     }

--- a/src/runtime/gc_roots.rs
+++ b/src/runtime/gc_roots.rs
@@ -113,6 +113,7 @@ impl Interpreter {
         for env in self.closure_env_overrides.values() {
             env.visit_values(visitor);
         }
+        self.capture_cache.visit_roots(visitor);
         for env in &self.caller_env_stack {
             env.visit_values(visitor);
         }

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -2047,6 +2047,13 @@ pub struct Interpreter {
     /// Used to propagate package declarations when a module is re-used.
     module_packages: HashMap<String, HashSet<String>>,
     closure_env_overrides: HashMap<u64, Env>,
+    /// One-entry memo of the last closure-capture env, so a closure literal
+    /// created over and over from an unchanged scope (`.map({...})` in a loop)
+    /// stops rebuilding the same map every time. See
+    /// [`crate::vm::vm_capture_cache`]. Boxed like `cur_repo`: it is touched
+    /// only by closure creation, and inlining ~180 bytes of it would push the
+    /// per-opcode hot fields apart for every program.
+    pub(crate) capture_cache: Box<crate::vm::vm_capture_cache::CaptureCache>,
     /// Sigilless parameter names (`\attr`, `my \x`) of the routine whose body is
     /// about to be compiled by the interpret path (`compile_block_value_opts`).
     /// The multi/user-sub fallback runs a body via a *fresh* `Compiler`, which

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -2968,6 +2968,7 @@ impl Interpreter {
             chain_declared_packages: HashSet::new(),
             module_packages: HashMap::new(),
             closure_env_overrides: HashMap::new(),
+            capture_cache: Default::default(),
             pending_eval_sigilless: Vec::new(),
             pending_eval_placeholder_params: Vec::new(),
             pending_eval_rw_tail: false,

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -650,6 +650,10 @@ impl Interpreter {
             chain_declared_packages: self.chain_declared_packages.clone(),
             module_packages: self.module_packages.clone(),
             closure_env_overrides: self.closure_env_overrides.clone(),
+            // A fresh thread starts with an empty memo: the entry holds `Arc`s
+            // on the parent thread's env tiers, which this interpreter neither
+            // shares nor should pin.
+            capture_cache: Default::default(),
             pending_eval_sigilless: Vec::new(),
             pending_eval_placeholder_params: Vec::new(),
             pending_eval_rw_tail: false,

--- a/src/symbol.rs
+++ b/src/symbol.rs
@@ -165,6 +165,18 @@ pub(crate) mod flags {
     /// this name dispatches straight to the op table
     /// (`Interpreter::exec_nqp_call_op`).
     pub(crate) const NQP_OP: u8 = 1 << 3;
+    /// A *plain user lexical* env key. Mirrors
+    /// `crate::env::is_plain_user_lexical`.
+    pub(crate) const PLAIN_USER_LEXICAL: u8 = 1 << 4;
+    /// An attribute-twigil env key (`!x`, `@!x`, `%.x`). Mirrors
+    /// `crate::env::is_attr_twigil_env_key`.
+    ///
+    /// This bit and the one above are the two questions the closure-capture
+    /// filter asks about EVERY visible env key, and it asked them by resolving
+    /// the symbol to a `&str` and re-scanning the bytes twice per key. Fusing
+    /// them into the memoized byte makes the filter one thread-local lookup
+    /// instead of two plus two string scans.
+    pub(crate) const ATTR_TWIGIL_ENV_KEY: u8 = 1 << 5;
     /// Set once the byte has been computed (so a symbol with no flags is not
     /// recomputed on every lookup).
     pub(crate) const COMPUTED: u8 = 1 << 7;
@@ -190,6 +202,12 @@ fn compute_flags(s: &str) -> u8 {
     }
     if s.starts_with(NQP_OP_PREFIX) {
         f |= flags::NQP_OP;
+    }
+    if crate::env::is_plain_user_lexical(s) {
+        f |= flags::PLAIN_USER_LEXICAL;
+    }
+    if crate::env::is_attr_twigil_env_key(s) {
+        f |= flags::ATTR_TWIGIL_ENV_KEY;
     }
     f
 }
@@ -249,6 +267,10 @@ pub(crate) mod wk {
         /// The routine-frame name a nameless compiled routine is pushed under
         /// (so `&?ROUTINE` works inside an anonymous sub).
         anon_routine => "<anon>";
+        /// The empty package name, i.e. "no package set".
+        empty_package => "";
+        /// The default top-level package every unqualified declaration lands in.
+        global_package => "GLOBAL";
     }
 
     /// Whether `key` is one of the fixed per-call env keys the well-known
@@ -410,6 +432,18 @@ impl Symbol {
             cache[idx] = f;
         });
         f
+    }
+
+    /// Memoized [`crate::env::is_plain_user_lexical`] for this symbol's string.
+    #[inline]
+    pub(crate) fn is_plain_user_lexical(self) -> bool {
+        self.flags() & flags::PLAIN_USER_LEXICAL != 0
+    }
+
+    /// Memoized [`crate::env::is_attr_twigil_env_key`] for this symbol's string.
+    #[inline]
+    pub(crate) fn is_attr_twigil_env_key(self) -> bool {
+        self.flags() & flags::ATTR_TWIGIL_ENV_KEY != 0
     }
 
     /// Resolve the symbol back to its string representation.

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -150,6 +150,7 @@ mod vm_call_named_inner;
 mod vm_call_nqp;
 mod vm_call_resolve;
 pub(crate) mod vm_call_state_guard;
+pub(crate) mod vm_capture_cache;
 mod vm_catch_dispatch;
 mod vm_closure_dispatch;
 mod vm_coerce_concat_ops;

--- a/src/vm/vm_capture_cache.rs
+++ b/src/vm/vm_capture_cache.rs
@@ -1,0 +1,116 @@
+//! Reuse of the closure-capture env across repeated creations of the same
+//! closure literal.
+//!
+//! `Interpreter::capture_closure_env` builds the closure's captured env with
+//! `Env::filtered_flat`, which walks every visible env key and inserts the kept
+//! ones into a brand-new map. That is O(kept env) *per closure creation*, and
+//! the kept set is dominated by names no closure body varies: the built-in
+//! dynamics (`$*IN`, `$*OUT`, `$*CWD`, `%*ENV`, `@*ARGS`, ...) seeded once at
+//! startup, `?FILE`, and `Any`. A trivial mainline script captures 23 such
+//! entries per closure literal, and `filtered_flat` was 41% of the instructions
+//! of a 200000-iteration `my $c = * + 1;` loop.
+//!
+//! The result is a pure function of the visible env contents and the closure's
+//! own `CompiledCode` (the filter reads only the key, never the value), so a
+//! creation whose inputs are unchanged since the last one can hand back the
+//! same map. This module holds that one-entry memo.
+//!
+//! **Why an address comparison is sound here.** An armed entry holds an `Arc`
+//! on every tier's overlay map. That does two things at once: the allocations
+//! cannot be freed and recycled at the same address, and the extra strong count
+//! makes `Env::cow_mut`'s `Arc::make_mut` clone the map before *any* by-name
+//! write — so a tier that is written to necessarily moves to a new address.
+//! Matching addresses therefore prove the contents are the ones the cached env
+//! was built from. A write *through* a captured `ContainerRef` cell mutates
+//! neither map and is deliberately not a mismatch: the cached env holds the
+//! same cell, exactly as a freshly built capture would.
+//!
+//! **Why arming waits for a repeat.** Holding those `Arc`s costs a
+//! copy-on-write clone on the next write to a pinned tier. In a loop that
+//! writes the env by name on every iteration the memo could never hit anyway,
+//! so an entry is armed only after two consecutive captures have seen the same
+//! chain: a churning env is tracked with plain addresses (nothing held, nothing
+//! pinned) and never pays for a memo that cannot pay off.
+
+use std::sync::Arc;
+
+use crate::env::{Env, SymMap, TierAddrs};
+use crate::opcode::CompiledCode;
+
+/// One armed memo: the inputs it was built from, held, plus the result.
+struct ArmedCapture {
+    /// Every tier's overlay map, leaf first — see the module docs for why these
+    /// are held rather than merely addressed.
+    tiers: Vec<Arc<SymMap>>,
+    /// The closure chunk whose free-var / own-local sets shaped the filter.
+    /// Held so `Arc::ptr_eq` against a later chunk cannot be fooled by a
+    /// recycled allocation.
+    code: Arc<CompiledCode>,
+    /// The captured env `filtered_flat` produced for those inputs.
+    env: Env,
+}
+
+/// The one-entry closure-capture memo. See the module docs.
+#[derive(Default)]
+pub(crate) struct CaptureCache {
+    armed: Option<ArmedCapture>,
+    /// Inputs the *previous* capture ran against, as bare addresses: nothing is
+    /// held, so this observation pins nothing and can only ever be used to
+    /// decide whether arming is worth it.
+    last: Option<(TierAddrs, usize)>,
+}
+
+impl CaptureCache {
+    /// The memoized capture for `(env, code)`, if this exact pair produced the
+    /// armed entry. `addrs` is `env.tier_addrs()`, computed once by the caller
+    /// because it needs it for [`Self::record`] too.
+    pub(crate) fn get(&self, addrs: Option<TierAddrs>, code: &Arc<CompiledCode>) -> Option<&Env> {
+        let addrs = addrs?;
+        let armed = self.armed.as_ref()?;
+        (Arc::ptr_eq(&armed.code, code) && addrs.matches(&armed.tiers)).then_some(&armed.env)
+    }
+
+    /// True when a capture that just ran against `(addrs, code)` is worth
+    /// arming — i.e. the previous one ran against the same chain and chunk (see
+    /// the module docs on why arming waits for a repeat). The caller passes the
+    /// resulting `Env::tier_maps()` to [`Self::record`].
+    pub(crate) fn wants_arm(&self, addrs: Option<TierAddrs>, code: &Arc<CompiledCode>) -> bool {
+        let (Some(addrs), Some((last_addrs, last_code))) = (addrs, &self.last) else {
+            return false;
+        };
+        *last_addrs == addrs && *last_code == Arc::as_ptr(code) as usize
+    }
+
+    /// Record a freshly built capture, arming the memo with `tiers` when
+    /// [`Self::wants_arm`] said so. Disarms otherwise, so a stale entry never
+    /// keeps tiers pinned once the env starts churning.
+    pub(crate) fn record(
+        &mut self,
+        addrs: Option<TierAddrs>,
+        code: &Arc<CompiledCode>,
+        tiers: Option<Vec<Arc<SymMap>>>,
+        captured: &Env,
+    ) {
+        self.last = addrs.map(|addrs| (addrs, Arc::as_ptr(code) as usize));
+        self.armed = tiers.map(|tiers| ArmedCapture {
+            tiers,
+            code: Arc::clone(code),
+            env: captured.clone(),
+        });
+    }
+
+    /// GC roots: an armed entry holds a whole captured env of live values, plus
+    /// an `Arc` on each source tier's map — which outlives the env it was taken
+    /// from (that is the point), so its values are roots of their own.
+    pub(crate) fn visit_roots(&self, visitor: &mut dyn crate::gc::RootVisitor) {
+        let Some(armed) = &self.armed else {
+            return;
+        };
+        armed.env.visit_values(visitor);
+        for tier in &armed.tiers {
+            for value in tier.values() {
+                visitor.visit_value(value);
+            }
+        }
+    }
+}

--- a/src/vm/vm_register_ops.rs
+++ b/src/vm/vm_register_ops.rs
@@ -305,7 +305,7 @@ impl Interpreter {
             // Dynamics (`$*x`), the topic, attribute twigils and `__mutsu_*`
             // metadata resolve through their own stores against the LIVE frame
             // by design — never freeze one into a lexical snapshot.
-            if !sym.with_str(crate::env::is_plain_user_lexical) {
+            if !sym.is_plain_user_lexical() {
                 continue;
             }
             if let Some(slot) =
@@ -630,8 +630,11 @@ impl Interpreter {
                 .as_ref()
                 .and_then(|cc| cc.compiled_fns.clone());
             let val = Value::sub_value(crate::gc::Gc::new(crate::value::SubData {
-                package: Symbol::intern(&self.lexical_closure_package()),
-                name: Symbol::intern(""),
+                package: self.lexical_closure_package_sym(),
+                // Pre-interned like its `MakeLambda` twin: re-interning the
+                // empty literal on every block creation hashed a string for a
+                // constant answer.
+                name: crate::symbol::well_known::anon(),
                 params,
                 param_defs: Vec::new(),
                 body: code.closure_body_arc(idx as usize),
@@ -738,7 +741,7 @@ impl Interpreter {
                 .as_ref()
                 .and_then(|cc| cc.compiled_fns.clone());
             let val = Value::sub_value(crate::gc::Gc::new(crate::value::SubData {
-                package: Symbol::intern(&self.lexical_closure_package()),
+                package: self.lexical_closure_package_sym(),
                 // Anonymous closures pool a SubDecl with an empty name; a
                 // named `anon sub NAME` decl carries its name through here.
                 name: *name,
@@ -960,7 +963,7 @@ impl Interpreter {
     /// `ContainerRef` cell that `box_captured_lexicals` installs in both the slot
     /// and `env`.
     pub(super) fn capture_closure_env(
-        &self,
+        &mut self,
         code: &CompiledCode,
         cc: &Option<std::sync::Arc<CompiledCode>>,
     ) -> Env {
@@ -1018,7 +1021,7 @@ impl Interpreter {
             flat.remove_sym(crate::symbol::well_known::callable_type());
             // Attribute-twigil keys are per-frame materializations of `self`'s
             // attributes — never snapshot them (see the filtered branch below).
-            flat.retain(|k, _| !k.with_str(Self::is_attr_twigil_env_key));
+            flat.retain(|k, _| !k.is_attr_twigil_env_key());
             self.capture_bare_callees(cc, &mut flat);
             self.materialize_frame_self_into_capture(code, &mut flat);
             return flat;
@@ -1045,23 +1048,54 @@ impl Interpreter {
         // ordinary inner block would be mis-detected as a WhateverCode (see the
         // by-name path above).
         let callable_type_sym = crate::symbol::well_known::callable_type();
+        // The filter below reads only the KEY, so its result is a pure function
+        // of the visible env contents and of `cc` — which is what lets a
+        // repeated creation of the same closure literal from an unchanged scope
+        // reuse the previous map instead of rebuilding it (the built-in
+        // dynamics alone put ~23 entries in every capture). See
+        // `crate::vm::vm_capture_cache` for why an address comparison settles
+        // "unchanged".
+        let tier_addrs = self.env().tier_addrs();
+        if let Some(cached) = self.capture_cache.get(tier_addrs, cc) {
+            let mut env = cached.clone();
+            self.finish_closure_capture(code, cc, &mut env);
+            return env;
+        }
         let mut env = self.env().filtered_flat(&|k, _v| {
             if k == callable_type_sym {
                 return false;
             }
+            // One memoized flags byte answers both string questions this filter
+            // asks per key (see `symbol::flags`), instead of resolving the
+            // symbol and re-scanning its bytes twice.
+            let flags = k.flags();
             // Attribute-twigil keys (`!x`, `@!x`, `%.x`, …) are per-frame
             // materializations of `self`'s attributes, not lexicals: the
             // closure must read them through its captured `self` at RUN time.
             // A creation-time snapshot goes stale the moment the instance
             // mutates — a `start` block reading `@!before` inside
             // Cro::CompositeConnector.connect saw an empty pre-mutation copy.
-            if k.with_str(Self::is_attr_twigil_env_key) {
+            if flags & crate::symbol::flags::ATTR_TWIGIL_ENV_KEY != 0 {
                 return false;
             }
             free.contains(&k)
                 || (!own_locals.contains(&k)
-                    && k.with_str(|s| !crate::env::is_plain_user_lexical(s)))
+                    && flags & crate::symbol::flags::PLAIN_USER_LEXICAL == 0)
         });
+        let tiers = self
+            .capture_cache
+            .wants_arm(tier_addrs, cc)
+            .then(|| self.env().tier_maps());
+        self.capture_cache.record(tier_addrs, cc, tiers, &env);
+        self.finish_closure_capture(code, cc, &mut env);
+        env
+    }
+
+    /// The per-creation half of [`Self::capture_closure_env`]: everything that
+    /// depends on the CREATING frame's live state rather than on the visible
+    /// env, so it must run afresh for every closure — including one whose
+    /// filtered env came back from the memo.
+    fn finish_closure_capture(&mut self, code: &CompiledCode, cc: &CompiledCode, env: &mut Env) {
         // Upvalue read: override this frame's own free-var slots with the live
         // local value. Authoritative even after the closure-driven env flush is
         // gone (a slot-only local is no longer mirrored into `env`).
@@ -1073,16 +1107,15 @@ impl Interpreter {
             }
         }
         // ADR-0024 §4: see the identical override in the reflective path above.
-        self.inject_mainline_lexical_captures(cc, &mut env);
+        self.inject_mainline_lexical_captures(cc, env);
         // A bare call records only its sigilless callee in bytecode, so it is
         // not normally part of `free_var_syms`. Preserve an existing lexical
         // code binding for each callee the closure (or a nested closure it may
         // create later) actually references. This is the escape gate for an
         // imported sub installed by `use` inside EVAL: PopImportScope may remove
         // the registry alias, while the escaping closure still owns `&name`.
-        self.capture_bare_callees(cc, &mut env);
-        self.materialize_frame_self_into_capture(code, &mut env);
-        env
+        self.capture_bare_callees(cc, env);
+        self.materialize_frame_self_into_capture(code, env);
     }
 
     /// ADR-0024 §4: while [`Self::mainline_lexical_frame_active`] holds (a
@@ -1149,18 +1182,6 @@ impl Interpreter {
         }
     }
 
-    /// Attribute-twigil env keys (`!x`, `@!x`, `%.x`, …): per-frame
-    /// materializations of `self`'s attributes that a closure capture must NOT
-    /// snapshot (see the capture filter).
-    fn is_attr_twigil_env_key(s: &str) -> bool {
-        let bare = match s.as_bytes().first() {
-            Some(b'@' | b'%' | b'&' | b'$') => &s[1..],
-            _ => s,
-        };
-        let b = bare.as_bytes();
-        matches!(b.first(), Some(b'!') | Some(b'.')) && b.len() > 1 && b[1].is_ascii_alphabetic()
-    }
-
     /// `self` is lexical: a closure created inside a method body must capture
     /// that method's invocant. On the fast method path (skip_env_setup) `self`
     /// lives ONLY in a local slot, so the env-based capture above misses it and
@@ -1169,12 +1190,19 @@ impl Interpreter {
     /// in `Sink.sinker` and tapped from another object's method read `$!sum`
     /// off that other object (Cro::Service.start's assembled pipeline).
     fn materialize_frame_self_into_capture(&self, code: &CompiledCode, env: &mut Env) {
-        if env.get("self").is_none()
+        // Symbol-keyed: this runs on every closure creation, where interning
+        // the literal (a thread-local hash of the string) and allocating a
+        // `String` for the insert were pure per-creation overhead.
+        let self_sym = crate::symbol::wk::self_();
+        if env.get_sym(self_sym).is_none()
             && let Some(slot) = code.locals.iter().position(|n| n == "self")
             && let Some(val) = self.locals.get(slot)
             && !val.is_nil()
         {
-            env.insert("self".to_string(), val.clone());
+            // `note_env_key` has nothing to latch for `self` (it only tracks
+            // `^`- and `__mutsu_`-prefixed keys), so the symbol-keyed insert is
+            // equivalent to the `String`-keyed one.
+            env.insert_sym(self_sym, val.clone());
         }
     }
 

--- a/src/vm/vm_register_sub_ops.rs
+++ b/src/vm/vm_register_sub_ops.rs
@@ -119,7 +119,7 @@ impl Interpreter {
                 .as_ref()
                 .and_then(|cc| cc.compiled_fns.clone());
             let val = Value::sub_value(crate::gc::Gc::new(crate::value::SubData {
-                package: Symbol::intern(&self.lexical_closure_package()),
+                package: self.lexical_closure_package_sym(),
                 name: crate::symbol::well_known::anon(),
                 params: params.clone(),
                 param_defs: param_defs.clone(),
@@ -178,7 +178,7 @@ impl Interpreter {
                 .as_ref()
                 .and_then(|cc| cc.compiled_fns.clone());
             let val = Value::sub_value(crate::gc::Gc::new(crate::value::SubData {
-                package: Symbol::intern(&self.lexical_closure_package()),
+                package: self.lexical_closure_package_sym(),
                 name: crate::symbol::well_known::anon(),
                 params: vec![],
                 param_defs: Vec::new(),
@@ -735,7 +735,7 @@ impl Interpreter {
                     .cloned();
                 let sub_val = if let Some(def) = installed {
                     Value::make_sub_for_routine(
-                        Symbol::intern(&self.lexical_closure_package()),
+                        self.lexical_closure_package_sym(),
                         Symbol::intern(&resolved_name),
                         def.params.clone(),
                         def.param_defs.clone(),
@@ -746,7 +746,7 @@ impl Interpreter {
                     )
                 } else {
                     Value::make_sub(
-                        Symbol::intern(&self.lexical_closure_package()),
+                        self.lexical_closure_package_sym(),
                         Symbol::intern(&resolved_name),
                         params.clone(),
                         param_defs.clone(),

--- a/t/closure-capture-memo.t
+++ b/t/closure-capture-memo.t
@@ -1,0 +1,61 @@
+use Test;
+
+# The closure-capture env is memoized across repeated creations of the same
+# closure literal from an unchanged scope (`src/vm/vm_capture_cache.rs`). These
+# pin the observable semantics that memo must not change: a reused capture is
+# only ever legal while the visible env is byte-for-byte the one it was built
+# from, and everything that varies per creation still has to be re-applied.
+
+plan 8;
+
+# A free variable is re-read from the creating frame's live slot on every
+# creation, so a closure literal in a loop must capture that iteration's value
+# even once the memo is armed (creation 3 onwards).
+my @per-iteration;
+for ^5 -> $i {
+    @per-iteration.push({ $i * 10 });
+}
+is(
+    @per-iteration.map({ $_.() }).join(','),
+    '0,10,20,30,40',
+    'a loop-created closure keeps its own iteration value once the memo is armed',
+);
+
+# The same shape for a WhateverCode, which additionally writes its own
+# closure-identity marker into the captured env after the memo hands it back.
+my @whatevers;
+for ^4 -> $n {
+    @whatevers.push($n + *);
+}
+is(
+    @whatevers.map({ $_.(1) }).join(','),
+    '1,2,3,4',
+    'a WhateverCode created in a loop is not confused by a reused capture',
+);
+
+# A dynamic variable lives in the env, so changing one between two creations of
+# the same literal has to invalidate the memo.
+my $*topicish = 'first';
+my $before = { $*topicish };
+$*topicish = 'second';
+my $after = { $*topicish };
+is($after.(), 'second', 'a closure created after a dynamic changed sees the new value');
+is($before.(), 'second', 'a dynamic is read at call time, not frozen at creation');
+
+# Declaring a new lexical between two creations changes the visible env too.
+my $seen-before = { $^a + 1 };
+my $mid = 41;
+my $seen-after = { $mid + $^a };
+is($seen-before.(1), 2, 'a closure created before a later declaration still runs');
+is($seen-after.(1), 42, 'a closure created after it captures the new lexical');
+
+# `self` is materialized into the capture from the creating frame, so two
+# instances calling the same method must not share one memoized capture.
+class Counter {
+    has $.tag;
+    method make-closure() { return { $.tag } }
+}
+my $a-closure = Counter.new(tag => 'a').make-closure;
+my $b-closure = Counter.new(tag => 'b').make-closure;
+is($a-closure.(), 'a', 'the first instance closure keeps its own invocant');
+is($b-closure.(), 'b', 'the second instance closure does not inherit the first');


### PR DESCRIPTION
Advances [#7557](https://github.com/tokuhirom/mutsu/issues/7557) part B (does **not** close it — see "Still open" below).

## The problem, and what the kept set actually is

Creating a closure literal was O(enclosing env): `capture_closure_env` handed `Env::filtered_flat` a key-only filter, and `filtered_flat` walked every visible env key and inserted the kept ones into a brand-new map — per creation. On a 200000-iteration `my $c = * + 1;` loop that one call was **41% of the program's instructions**, and 30 unrelated lexicals in the enclosing scope added ~24ns to every creation.

Dumping the kept set settled what the issue could only guess at. A closure created in an otherwise empty program captures **23 entries**, and 20 of them are the built-in dynamics seeded once at startup:

```
$*ARGFILES $*CWD $*ERR $*HOME $*IN $*OUT $*TMPDIR %*ENV
*ARGFILES *CWD *ERR *HOME *IN *OUT *PROGRAM *PROGRAM-NAME *REPO *SCHEDULER
*TMPDIR @*ARGS =pod ?FILE Any
```

None is a free variable of any closure. They are kept because they are not *plain user lexicals* — the deliberately conservative rule that keeps dynamics, magic vars, `self`, type names and `__mutsu_*` metadata reachable from a closure body. So the filter was not merely expensive to compute; it recomputed the same answer over and over.

## The memo

The filter reads only the KEY, so the captured map is a pure function of the visible env contents and of the closure's own `CompiledCode`. `src/vm/vm_capture_cache.rs` memoizes exactly that, one entry deep. A creation whose inputs are unchanged clones the memoized `Env` (an `Arc` bump) instead of rebuilding the map; everything that varies per creation — the free-var upvalue reads from the frame's live slots, the ADR-0024 mainline lexical overrides, `capture_bare_callees`, the `self` materialization — still runs afresh, factored into `finish_closure_capture`.

**Why comparing tier addresses is sound.** An armed entry holds an `Arc` on every tier's overlay map. That both keeps the allocations from being freed and recycled at the same address *and* pushes `Env::cow_mut`'s `Arc::make_mut` onto its cloning path, so any by-name write moves the written tier to a new address. Matching addresses therefore prove the contents are the ones the entry was built from. A chain carrying tombstones is refused outright (a tombstone set is a plain `FxHashSet` the memo cannot pin). A write *through* a captured `ContainerRef` cell is deliberately not a mismatch — the memo holds the same cell, exactly as a freshly built capture would.

**Why arming waits for a repeat.** Holding those `Arc`s costs one copy-on-write clone on the next write to a pinned tier, so an entry is armed only after two consecutive captures have seen the same chain and chunk: a churning scope is tracked with bare addresses (nothing held, nothing pinned) and never pays for a memo that could not hit.

The cache is boxed on the `Interpreter` alongside `cur_repo`. That is not cosmetic: inlining ~180 bytes of closure-only state measurably pushed the per-opcode hot fields apart, and `word-count` regressed 5% until it was boxed.

## Also on the same path (all semantics-free)

- The filter asked two string questions about every visible env key (`is_plain_user_lexical`, `is_attr_twigil_env_key`) by resolving the symbol and re-scanning its bytes, twice per key. Both are bits in the memoized `Symbol::flags()` byte now, so the filter is one thread-local lookup per key.
- `Symbol::intern(&self.lexical_closure_package())` allocated a `String` and re-hashed it per creation just to intern it. `lexical_closure_package_sym()` answers with the `Symbol` directly; the common case is an atomic load.
- `materialize_frame_self_into_capture` re-interned `"self"` and allocated a `String` key per creation; both are symbol-keyed now, as is the anonymous block's empty name.

## Numbers

Deterministic instruction counts (callgrind — load-independent; wall-clock rows belong to the bench CI):

| | before | after | |
|---|---|---|---|
| `my $c = * + 1;` × 200000 | 4,561,796,171 | 2,667,115,037 | **−41.5%** |
| the same with 30 extra enclosing lexicals | 6,924,565,867 | 3,224,306,708 | **−53.4%** |
| `bench-ctor` | 1,481,775,564 | 1,462,503,952 | −1.3% |
| `bench-class` | 1,246,662,130 | 1,245,785,315 | −0.1% |
| `word-count` | 1,132,877,066 | 1,132,704,822 | −0.0% |
| `bench-fib` | 1,408,905,100 | 1,408,911,125 | +0.0% |
| `bench-tak` | 1,682,291,882 | 1,682,305,527 | +0.0% |

(The `fib`/`tak` rows are there on purpose: their wall clock swung ±5% between runs on this box, and the byte-identical instruction counts show that is layout drift, not work.)

The scaling that named the issue is what moved most: those 30 unrelated lexicals used to add ~24ns per creation and now add ~4ns, because a memo hit does not touch the enclosing env at all.

## Tests

- `t/closure-capture-memo.t` — 8 assertions pinning the semantics a reused capture must not change: per-iteration free variables in a loop (creations 3+ are memo hits), a WhateverCode that writes its identity marker into a reused capture, invalidation when a dynamic or a new lexical changes the visible env between two creations, and two instances' `self` not sharing one capture.
- Two `env.rs` unit tests pinning the address invariant itself: an untouched chain keeps its addresses (reads included), a by-name write breaks the match, and a tombstoned chain is refused.

## Verification

- `make test` — 3842 files, 40658 tests, **all successful**; `cargo test` green.
- `make lint` — all four configurations clean (default clippy, `jit` off, wasm32, rustdoc).
- `make roast` — 1436 files, 218939 tests. Three files fail, and all three fail **identically on the `main` binary in this container**: `roast/S16-filehandles/filetest.t` and `roast/6.c/S32-io/file-tests.t` (permission-bit assertions that do not hold when running as root) and `roast/S32-io/IO-Socket-Async.t` (times out with or without this change). CI runs as a normal user and is the real gate for these.

## Still open

The kept set is still over-broad by construction, and a capture that *misses* the memo still pays O(kept env). Narrowing the rule — deciding which of those names are genuinely read by runtime by-name mechanisms and which only through a compiled `GetLocal`/`GetGlobal` the free-var pass already sees — remains the design question #7557 part B poses. The dump above is the evidence a future pass should start from: the answer is mostly about the built-in dynamics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R4t4VRPfqUPixoakhhLFLM

---
_Generated by [Claude Code](https://claude.ai/code/session_01R4t4VRPfqUPixoakhhLFLM)_