### PR TITLE
fix(compiler): apply a variable trait on a `do` block's tail declaration

### DIFF
--- a/news/2026-09/do-block-tail-declaration-trait.md
+++ b/news/2026-09/do-block-tail-declaration-trait.md
@@ -1,0 +1,54 @@
+# A `do` block's tail declaration keeps its variable trait
+
+```raku
+my $z = do { my %u is SetHash };
+say $z.^name;                      # raku: SetHash   mutsu: Hash
+
+my $y = do { my $s is default(7) };
+say $y;                            # raku: 7         mutsu: (Any)
+```
+
+Split off from the ticket that fixed the *parenthesised* expression position
+(`news/2026-09/inline-container-trait-in-expression-position.md`). This is the
+one row of that neighbourhood that turned out to be a different bug: there the
+trait ran and the expression merely returned the pre-trait value; here **no
+`ApplyVarTrait` op was emitted at all**.
+
+## Root cause
+
+`compile_block_inline` has a hand-inlined `Stmt::VarDecl` arm for the *block-final*
+position — it exists so a block-final declaration yields its value, and it is
+neither the statement-position `Stmt::VarDecl` path in `stmt.rs` nor the
+expression-position one in `expr_block.rs`. It emitted a bare
+`SetVarDynamic / MakeHash / Dup / SetGlobal`, never looking at `custom_traits`.
+
+That position needs both halves: a container trait (`is SetHash`, `is BagHash`,
+`is Buf`) *replaces* the declared container and `is default(...)` embeds a
+default in it, so the trait has to be applied **after** the store and the
+container read back — while the arm yielded the value from a `Dup` taken
+**before** it.
+
+## The fix
+
+The expression-position path already does exactly that, so a block-final
+declaration carrying a non-internal trait routes through `compile_expr_do_stmt`
+instead of growing a second copy of the rule. Untraited declarations are
+untouched and keep the hand-inlined arm.
+
+Pinned by `t/do-block-tail-declaration-trait.t`, whose 16 assertions pass
+unchanged under rakudo (8 of them fail on the unfixed binary):
+`is SetHash`/`BagHash`/`MixHash`/`Buf` as the tail, `is default(...)` for all
+three sigils, a routine's tail declaration, and four controls that were already
+correct. `t/inline-container-trait-expression.t`,
+`t/container-capture-cell-dichotomy.t` and
+`roast/S02-types/{baghash,mixhash,sethash}.t` are unmoved.
+
+## A side finding, filed separately
+
+Every declaration in the pin uses its own variable name on purpose: a same-named
+`my %h` elsewhere in the same file cancels an `is default(...)` container, which
+is [#7621](https://github.com/tokuhirom/mutsu/issues/7621) — pre-existing and
+independent (it reproduces on unmodified `main` through the parenthesised
+expression path, which this change does not touch).
+
+Closes #7583.

--- a/src/compiler/helpers_block_inline.rs
+++ b/src/compiler/helpers_block_inline.rs
@@ -293,6 +293,25 @@ impl Compiler {
                         self.pop_dynamic_scope_lexical(saved);
                         return;
                     }
+                    // A block-final declaration carrying a variable TRAIT is
+                    // the one shape this hand-inlined arm cannot serve. A
+                    // CONTAINER trait (`is SetHash`, `is BagHash`, `is Buf`)
+                    // replaces the declared container and `is default(...)`
+                    // embeds a default in it, so both have to be applied AFTER
+                    // the store and the container read back -- while this arm
+                    // yields the value from a `Dup` taken BEFORE it. It emitted
+                    // no `ApplyVarTrait` at all, so `my $z = do { my %u is
+                    // SetHash }` was a plain `Hash` (GH #7583). The
+                    // expression-position path already applies the traits and
+                    // reads the container back, so route the declaration
+                    // through it rather than growing a second copy of the rule.
+                    Stmt::VarDecl { custom_traits, .. }
+                        if custom_traits.iter().any(|(t, _)| !t.starts_with("__")) =>
+                    {
+                        self.compile_expr_do_stmt(stmt);
+                        self.pop_dynamic_scope_lexical(saved);
+                        return;
+                    }
                     Stmt::VarDecl {
                         name,
                         expr,

--- a/t/do-block-tail-declaration-trait.t
+++ b/t/do-block-tail-declaration-trait.t
@@ -1,0 +1,92 @@
+use v6;
+use Test;
+
+# A declaration that is a `do` block's TAIL statement must still get its
+# variable trait. The block-final `Stmt::VarDecl` arm of `compile_block_inline`
+# is a hand-inlined compile path -- needed so a block-final declaration yields
+# its value -- and it emitted no `ApplyVarTrait` at all, so
+# `my $z = do { my %u is SetHash }` produced a plain `Hash` (GH #7583).
+#
+# It is not specific to container traits: `is default(...)` was lost the same
+# way, for both sigils, which is what shows the trait was never applied rather
+# than applied too late.
+
+# NOTE: every declaration below uses its OWN variable name on purpose. A
+# same-named `my %h` elsewhere in the same file cancels an `is default(...)`
+# container (GH #7621) -- a separate, pre-existing bug that has nothing to do
+# with the tail position, and one this file must not accidentally exercise.
+
+plan 16;
+
+# --- container traits as the tail --------------------------------------
+{
+    my $z = do { my %sh is SetHash };
+    is $z.^name, 'SetHash', 'do-block tail: is SetHash';
+}
+{
+    my $z = do { my %bh is BagHash };
+    is $z.^name, 'BagHash', 'do-block tail: is BagHash';
+}
+{
+    my $z = do { my %mh is MixHash };
+    is $z.^name, 'MixHash', 'do-block tail: is MixHash';
+}
+{
+    my $z = do { my @buf is Buf };
+    is $z.^name, 'Buf', 'do-block tail: is Buf';
+}
+
+# --- `is default(...)`, whose argument must be compiled before the op ---
+{
+    my $z = do { my %hd is default(42) };
+    is $z<nope>, 42, 'do-block tail: a hash keeps its is default(...)';
+}
+{
+    my $y = do { my $sd is default(7) };
+    is $y, 7, 'do-block tail: a scalar keeps its is default(...)';
+}
+{
+    my $z = do { my @ad is default('x') };
+    is $z[5], 'x', 'do-block tail: an array keeps its is default(...)';
+}
+
+# --- the same declaration as a bare block used as a value --------------
+{
+    sub f { my %fsh is SetHash }
+    is f().^name, 'SetHash', "a routine's tail declaration keeps its trait";
+}
+
+# --- controls that already worked and must not move --------------------
+{
+    is (do { my %stmt is SetHash; %stmt.^name }), 'SetHash',
+       'an ordinary statement inside the block was already correct';
+}
+{
+    my $z = (my %pe is SetHash);
+    is $z.^name, 'SetHash', 'the parenthesised expression position is unmoved';
+}
+{
+    my $z = do { my $plain = 5 };
+    is $z, 5, 'an untraited tail declaration still yields its value';
+}
+{
+    my $z = do { my Int $typed = 5 };
+    is $z, 5, 'a typed untraited tail declaration still yields its value';
+    is $z.^name, 'Int', 'and keeps its type';
+}
+{
+    my $z = do { my $bare };
+    nok $z.defined, 'a bare tail declaration still yields an undefined value';
+}
+
+# --- the declared variable itself is still the traited container -------
+{
+    my %earlier;
+    my $z = do { %earlier = SetHash.new; my %v is SetHash };
+    is $z.^name, 'SetHash', 'the trait applies to the tail declaration, not an earlier one';
+}
+{
+    my $z = do { my %rt is SetHash };
+    $z<a> = True;
+    is $z<a>, True, 'the returned container behaves as its traited type';
+}


### PR DESCRIPTION
```raku
my $z = do { my %u is SetHash };
say $z.^name;                      # raku: SetHash   mutsu: Hash

my $y = do { my $s is default(7) };
say $y;                            # raku: 7         mutsu: (Any)
```

Split off from the ticket that fixed the *parenthesised* expression position
(`news/2026-09/inline-container-trait-in-expression-position.md`). This is the
one row of that neighbourhood that turned out to be a different bug: there the
trait ran and the expression merely returned the pre-trait value; here **no
`ApplyVarTrait` op was emitted at all**.

## Root cause

`compile_block_inline` has a hand-inlined `Stmt::VarDecl` arm for the
*block-final* position — it exists so a block-final declaration yields its
value, and it is neither the statement-position `Stmt::VarDecl` path in
`stmt.rs` nor the expression-position one in `expr_block.rs`. It emitted a bare
`SetVarDynamic / MakeHash / Dup / SetGlobal`, never looking at `custom_traits`.

That position needs both halves: a container trait (`is SetHash`, `is BagHash`,
`is Buf`) *replaces* the declared container and `is default(...)` embeds a
default in it, so the trait has to be applied **after** the store and the
container read back — while the arm yielded the value from a `Dup` taken
**before** it.

## The fix

The expression-position path already does exactly that, so a block-final
declaration carrying a non-internal trait routes through `compile_expr_do_stmt`
instead of growing a second copy of the rule — which is what the ticket
proposed. Untraited declarations are untouched and keep the hand-inlined arm.

## Testing

- `t/do-block-tail-declaration-trait.t` (new, 16 assertions) passes **unchanged
  under rakudo**; **8 of its assertions fail on the unfixed binary**. It covers
  `is SetHash`/`BagHash`/`MixHash`/`Buf` as the tail, `is default(...)` for all
  three sigils, a routine's tail declaration, and four controls that were
  already correct.
- `t/inline-container-trait-expression.t`,
  `t/container-capture-cell-dichotomy.t` and
  `roast/S02-types/{baghash,mixhash,sethash}.t` — the pins the ticket names —
  run directly and are unmoved.
- `cargo fmt --all`, `cargo clippy --all-targets -- -D warnings`, `make test`
  (3848 files, 40757 tests, all successful).
- `make roast`: byte-identical to this branch's own pre-change baseline — the
  only failures are this container's environment (`6.c/S32-io/file-tests.t` and
  `S16-filehandles/filetest.t` `chmod` assertions, which a uid-0 session
  bypasses, and an `IO-Socket-Async.t` timeout).

## A side finding, filed separately

Every declaration in the pin uses its own variable name on purpose: a same-named
`my %h` elsewhere in the same file cancels an `is default(...)` container, which
is **#7621** — pre-existing and independent (it reproduces on unmodified `main`
through the parenthesised expression path, which this change does not touch).

Closes #7583

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LLx8uvQEDwyt9iydWiPgpp

---
_Generated by [Claude Code](https://claude.ai/code/session_01LLx8uvQEDwyt9iydWiPgpp)_