### PR TITLE
docs: run both full suites before publishing, instead of delegating to CI

### DIFF
--- a/.agents/skills/mutsu-ticket-flow/SKILL.md
+++ b/.agents/skills/mutsu-ticket-flow/SKILL.md
@@ -102,10 +102,18 @@ Then create a fresh focused branch from that updated `main`, without overwriting
 Follow the Parser -> Compiler -> VM architecture, add focused regressions, and run targeted tests
 while iterating.
 
-Before publishing an implementation PR, run `cargo fmt --all`,
-`cargo clippy -- -D warnings`, `make test`, and `make roast` once each. Inspect
-`tmp/make-test.log` and `tmp/make-roast.log`. Do not publish an implementation
-PR until both full suites succeed.
+Before publishing an implementation PR, run `cargo fmt --all`, `make lint`, `make test`, and
+`make roast` once each (`make lint` rather than a bare `cargo clippy` — it adds the three
+configurations CI's `lint-configs` job gates on and the default clippy is blind to). Inspect
+`tmp/make-test.log` and `tmp/make-roast.log` with the Grep tool rather than rerunning a suite for
+its output. Do not publish an implementation PR until both full suites succeed.
+
+In a remote container `make roast` has a fixed set of three environment-only failures it cannot
+avoid (`uid 0` breaks two `chmod`-based file-test files; the network sandbox times out one socket
+file). Confirm the failing set is a subset of the table in
+[docs/agent-environments.md](../../../docs/agent-environments.md) **by name** before treating a red
+roast as publishable — a fourth file, or a different subtest range inside those three, is your
+change.
 
 ## Publish, monitor, and verify merge
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -387,13 +387,30 @@ abort with "cannot run test while file ... exists".
 
 The `t/` TAP suite is **fatal** in CI (`prove ... t/`, no `|| echo` fallback) — a deterministic `t/` failure fails the CI job, same as roast.
 
-## Delegate the full roast run to CI
+## Run both full suites yourself before publishing a PR — do NOT delegate that to CI
 
-Running the entire roast suite locally is wasteful and slow — **let CI run the full `make roast`.** Locally, run only the specific tests relevant to your change:
+**Before opening a PR, run `cargo fmt --all`, `make lint`, `make test` and `make roast` once each,
+and do not publish until both suites are green.** CI is the safety net for what you could not
+foresee, not the thing that tells you whether your change works. Discovering a regression from a red
+CI costs a wake, a fix-up commit and a reviewer's attention; discovering it locally costs one run.
+
+(This supersedes the older "let CI run the full roast, push and rely on it" rule, which contradicted
+`.agents/skills/mutsu-ticket-flow/SKILL.md` and lost that trade.)
+
+**While you are iterating**, still run only the specific tests relevant to your change — the full
+suites are a pre-publication gate, not an inner loop:
 
 - Run individual roast tests with `MUTSU_FUDGE=1 prove -e 'target/debug/mutsu' roast/<path>.t` (the `MUTSU_FUDGE=1` is required — see the build/run section above), or the exact files you touched / suspect regressed.
+- Read the saved logs (`tmp/make-test.log`, `tmp/make-roast.log`) with the Grep tool instead of re-running a suite to see its output.
+- **Some `make roast` failures are the container, not your change** — running as `uid 0` makes the
+  `chmod`-based file tests meaningless, and the sandboxed network breaks one socket test. The exact
+  files, the discriminator for each, and how to tell them from a real failure are in
+  [docs/agent-environments.md](docs/agent-environments.md). That list is the ONLY licence to ship
+  with a red `make roast`; anything else failing is yours, per "do NOT dismiss them as pre-existing"
+  above.
 - CI does not invoke `make test`; its `test` job runs the steps individually. It builds **release once** and runs **both** the TAP suite (`prove t/`) and `make roast` on it (`MUTSU_BIN=target/release/mutsu`); local `make test` matches (see `docs/adr/0075-make-test-runs-tap-on-release-binary.md`, superseding ADR-0014). The **`gc-stress` and `jit-stress` jobs still run `prove t/` on the debug binary**, serially — that is where the 75 `debug_assert!`s in `src/` get their suite-wide pass, so do not "align" those jobs onto release. `cargo test` is debug everywhere. A *debug* run of a heavy file is ~3.3x slower than release, so a local timeout on one does not by itself indicate a real failure — confirm on `target/release/mutsu` before assuming a regression.
-- Push the branch and rely on CI for the comprehensive roast result rather than running the whole suite locally.
+- The one exception is a **documentation-only** change, where CI skips the build jobs too
+  (`scripts/ci-docs-only.sh`) and there is nothing for the suites to catch.
 - To pick roast work, or to investigate why one file fails, read `.agents/skills/roast-triage/SKILL.md`.
 
 ## Build profiles and benchmark numbers
@@ -593,7 +610,7 @@ Each slang has its own grammar rules (e.g., `+` means repetition in Regex slang 
 
 - **Sub-agents are allowed (policy updated 2026-06-15).** Use them where they help — read-only fan-out searches (Explore), independent non-conflicting implementation slices, or sweeping across many files where you only need the conclusion. Be deliberate, not reflexive: Rust builds are expensive and each parallel worktree agent multiplies `cargo build`/`clippy`/`make test` cost and accumulates large `target/` worktrees, so reach for a sub-agent when the task genuinely fans out, not for trivial single-file work you can do inline. Read-only Explore/research agents are cheap; worktree-isolated build agents are not.
 - **Keep at most 3 concurrent agents that build** (user decision, 2026-08-22, tightening the previous cap of 4). This caps agents actually *doing work*, not agents idling on a CI run: an agent whose PR is open and waiting on GitHub Actions uses no local CPU, so it is fine to launch a fresh agent past the nominal cap while others are purely CI-pending (user-confirmed 2026-08-20). **Even so, never exceed 10 agents in total (working + CI-idle combined)** (user-confirmed 2026-08-20) — check `ListAgents` before launching a new one when the count is already high. Read-only Explore/research agents do not count against the build cap. Clean up worktrees per the "Disk cleanup" section.
-  - **That cap is a 12-core number — scale it to the box you actually have.** A remote container has roughly 4 cores, where one building agent is the equivalent and running the work inline (no worktree copy of `target/`) is usually better; see [docs/agent-environments.md](docs/agent-environments.md). The same goes for every wall-clock figure quoted in this file (`make lint` "about 5 minutes", roast timings): budget more on a smaller box, and let CI run the full suite.
+  - **That cap is a 12-core number — scale it to the box you actually have.** A remote container has roughly 4 cores, where one building agent is the equivalent and running the work inline (no worktree copy of `target/`) is usually better; see [docs/agent-environments.md](docs/agent-environments.md). The same goes for every wall-clock figure quoted in this file (`make lint` "about 5 minutes", roast timings): budget more on a smaller box. A slower box makes the pre-publication full-suite gate cost more, not make it optional.
   - **Why 3 and not more:** on this 12-core box, five worktree agents drove the load average to 70 with 17 concurrent `rustc` processes, and builds stopped completing. That does not merely slow the batch down — it makes agents *unable to verify their own work*: the `residual-try-cell-eager-seq-reification-divergences` agent had to revert a measured prototype and downgrade to a `Proposed` ADR because its from-scratch `cargo build` never finished under load. Over-parallelising costs correctness, not just wall-clock. When in doubt, check `uptime` and `pgrep -c -x rustc` before launching (a two-digit `rustc` count on 12 cores is already oversubscribed).
 - **Task selection order:**
   1. PLAN.md current quarter priorities

--- a/docs/agent-environments.md
+++ b/docs/agent-environments.md
@@ -98,9 +98,40 @@ before launching anything parallel; a two-digit `rustc` count is oversubscribed 
 boxes.
 
 The same ratio applies to timings quoted anywhere in the repo: `make lint` at "about 5 minutes" and
-the roast suite's wall-clock are 12-core numbers, so budget more on a smaller container and prefer
-running only the specific tests your change touches — the full roast run belongs to CI regardless of
-which environment you are in.
+the roast suite's wall-clock are 12-core numbers, so budget more on a smaller container. Run only
+the specific tests your change touches while you iterate — but the pre-publication gate (`make test`
+and `make roast` once each, both green, before opening the PR) is the same in both environments. A
+smaller box makes that gate slower, not optional.
+
+## Environment-only `make roast` failures — the remote container's fixed set
+
+`make roast` cannot come back fully green in a remote container, for reasons that have nothing to do
+with any change. Re-deriving this every session is pure waste, so here is the whole set. **These
+three files, and only these three, may be red when you publish**; anything else is a real failure and
+the "do NOT dismiss them as pre-existing" rule in `CLAUDE.md` applies in full.
+
+| File | Shape | Why |
+|---|---|---|
+| `roast/6.c/S32-io/file-tests.t` | `Failed: 4` — tests 6-8, 10 | runs as `uid 0` |
+| `roast/S16-filehandles/filetest.t` | `Failed: 25` — tests 57-64, 69-72, 77-80, and 101/103/105/107/109/111/117/121/125 | runs as `uid 0` |
+| `roast/S32-io/IO-Socket-Async.t` | exit 124, "planned 40 ran 17" | sandboxed network |
+
+The first two are the same cause: both `chmod` a file and then assert `.r` / `.w` / `.x` is `False`,
+and **root bypasses the permission bits**, so every such assertion is `True`. Check with `id -u` —
+`0` means these cannot pass, no matter how correct the interpreter is. They pass in CI, which runs as
+an ordinary user.
+
+`IO-Socket-Async.t` times out part-way through in this container and passes in CI; the container's
+network sandbox is the difference. The mechanism has not been pinned down further, so treat a *new*
+failure shape there (a concrete `not ok`, rather than the timeout) as real.
+
+Two things this list is not:
+
+- **It is not a licence to skim the summary.** Read the `Test Summary Report` and confirm the failing
+  set is a subset of these three by name. A fourth file, or a different subtest range inside these,
+  is your change.
+- **It does not apply to the local box**, which runs as an ordinary user with a working network.
+  There, `make roast` is expected to be green.
 
 ## Disk
 


### PR DESCRIPTION
## The contradiction

CLAUDE.md's **"Delegate the full roast run to CI"** said:

> Running the entire roast suite locally is wasteful and slow — **let CI run the
> full `make roast`.** […] Push the branch and rely on CI for the comprehensive
> roast result rather than running the whole suite locally.

`.agents/skills/mutsu-ticket-flow/SKILL.md` said the opposite:

> Before publishing an implementation PR, run `cargo fmt --all`,
> `cargo clippy -- -D warnings`, `make test`, and `make roast` once each. […] Do
> not publish an implementation PR until both full suites succeed.

An agent working the ticket queue had both of those in front of it on every
ticket.

## The resolution

Per the user's decision, the skill wins. The full suites are a **pre-publication
gate the agent owns**; CI is the safety net for what could not be foreseen.
Discovering a regression from a red CI costs a wake, a fix-up commit and a
reviewer's attention; discovering it locally costs one run.

The "run only the tests relevant to your change" advice is kept — but scoped to
**iteration**, rather than usable as a reason to skip the gate. The section is
retitled so the old name cannot be cited as the rule any more.

## Two consequences the change needs to be workable

**1. `make roast` cannot come back green in a remote container.** A rule that
says "do not publish until it succeeds" is unusable there unless the exceptions
are named, so `docs/agent-environments.md` gains the fixed set:

| File | Shape | Why |
|---|---|---|
| `roast/6.c/S32-io/file-tests.t` | `Failed: 4` — tests 6-8, 10 | runs as `uid 0` |
| `roast/S16-filehandles/filetest.t` | `Failed: 25` — 57-64, 69-72, 77-80, 101/103/105/107/109/111/117/121/125 | runs as `uid 0` |
| `roast/S32-io/IO-Socket-Async.t` | exit 124, "planned 40 ran 17" | sandboxed network |

The first two share one cause: both `chmod` a file and then assert `.r`/`.w`/`.x`
is `False`, and **root bypasses the permission bits**, so every such assertion is
`True`. `id -u` is the discriminator. All three pass in CI.

The doc is explicit that this is the *only* licence to ship with a red
`make roast`, that the failing set must be checked **by name**, and that a fourth
file — or a different subtest range inside these three — is the agent's change,
per the existing "do NOT dismiss them as pre-existing" rule. This session
re-derived all of it from scratch and then re-justified it in four PR
descriptions; that was pure waste.

**2. The skill's checklist moves to `make lint`** (from a bare
`cargo clippy -- -D warnings`), which is what CLAUDE.md's Conventions section
already required and what CI's `lint-configs` job actually gates on — the default
clippy is structurally blind to three of the four configurations.

## Also

Drops the trailing "and let CI run the full suite" from the agent-workflow
section, which restated the same rule a second time. A slower box makes the gate
cost more, not make it optional.

Left alone deliberately: `docs/adr/0014-…` cites the old section title, but ADRs
are superseded rather than rewritten (and 0014 is already superseded by 0075);
and `docs/per-task-clone-slimming.md`'s slice checklist has a "Push, let CI run
full roast" step, which is a *proposal* for a future campaign rather than a rule,
so rewriting someone's design doc was out of scope here. Worth a follow-up if you
want them consistent.

Documentation only, so `ci.yml`'s `changes` job classifies it as docs-only
(verified: `--classify` returns `true`) and the five build jobs report `skipped`.
That is correct here, not a stuck CI — and it is the one exception the new
section itself carves out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013c4HPfEPoHvhg6JwWQpQhU


---
_Generated by [Claude Code](https://claude.ai/code/session_013c4HPfEPoHvhg6JwWQpQhU)_