### PR TITLE
fix: a placeholder sub rejects extra positionals; `%_` never bought the leniency

### DIFF
--- a/news/2026-09/placeholder-sub-rejects-extra-positionals.md
+++ b/news/2026-09/placeholder-sub-rejects-extra-positionals.md
@@ -1,0 +1,80 @@
+# A placeholder sub rejects extra positionals, and `%_` never bought the leniency
+
+`sub f { $^a + $^b }` called with three arguments silently succeeded. Rakudo
+refuses it:
+
+```
+sub direct { $^a + $^b }
+direct(23, 1, 4)
+    # raku:  Too many positionals passed; expected 2 arguments but got 3
+    # mutsu: silently succeeds
+```
+
+The **block** spelling of the same signature was already correct, and `.arity`
+and `.count` both answered `2`; only the surplus went unchecked, and only for a
+routine whose parameters come from `^`-twigil placeholders.
+
+## The exclusion was real but three times too wide
+
+`bind_function_args_values`'s legacy branch gated its "too many" check on
+`all_plain_positional` — a `params` list with no `^`/`:` placeholder — and
+`news/2026-08/fast-binder-too-many-positionals-check.md` recorded why: a
+placeholder sub "whose body also reads a bare `@_`/`%_` legitimately accepts
+more positionals than its placeholders declare".
+
+Measured against rakudo, that is half true. Four placeholder subs called as
+`f(1, 2, 3)`:
+
+| sub | raku |
+| --- | --- |
+| `sub a { $^x }` | **dies**, "expected 1 argument but got 3" |
+| `sub b { $^x; @_.elems }` | 2 — the surplus really is `@_` |
+| `sub c { @_.elems }` | 3 |
+| `sub d { $^x; %_.elems }` | **dies** |
+
+Row `d` is the correction: a `%_` read is about *named* arguments and has no
+bearing on positional arity, so it buys nothing. Row `a` is the common case, and
+it was refused outright. The leniency is keyed on a bare **`@_`** read alone.
+
+## Where the answer had to live
+
+`news/2026-08/template-mojo-triage-closed.md` had already dispositioned this and
+named the fix: "a dedicated field threaded from the AST through to the runtime
+`Sub` value". It also recorded what *not* to do — the one attempt made then
+reserved a synthetic `params` entry, which leaked into the ~80 call sites that
+read a Sub's raw `params` (multi-dispatch candidate arity matching among them).
+
+So the flag is `CompiledCode::reads_args_array`, set by the same op-scanning
+pass that already computes `writes_topic`, and the binder takes it as an
+`Option<bool>` rather than deriving it from the body. Deriving it from the body
+is what the first attempt here did, and it is wrong in a way worth recording: a
+**compiled closure's `SubData::body` is empty** — the AST is gone once the
+bytecode exists — so walking it answers a confident and wrong "no", which turned
+row `b` into a spurious throw on the `&sub` Code-object path while looking
+correct on the direct-call path. `Interpreter::routine_reads_args_array` asks the
+`CompiledCode` when there is one, the body when the routine is interpreted, and
+answers `None` (stay lenient) when it can tell neither.
+
+The op scan also carries the trap `CLAUDE.md`'s debugging section warns about:
+`GetArrayVar`'s constant is the **sigiled** name `"@_"`, where the topic's env
+key is a bare `"_"`. Matching `"_"` — by analogy with the neighbouring
+`writes_topic` scan — made the flag silently never fire. A `--dump-bytecode`
+read settled it in one step.
+
+While here, the "too many" message learned rakudo's singular: "expected 1
+argument", not "1 arguments", reusing the `argument{}` shape the "too few" arm a
+few lines up already had.
+
+## Result
+
+`Template::Mojo` 0.2.2 goes **4/5 → 5/5** — `00-basic` test 17 was the last
+failure, and it asserts this error's text.
+[#7553](https://github.com/tokuhirom/mutsu/issues/7553)'s table row can be
+struck.
+
+Pinned by `t/placeholder-sub-rejects-extra-positionals.t`, 17 assertions passing
+unchanged under `raku` as well as under mutsu. Every *throwing* case in it goes
+through a `&sub` Code object deliberately: rakudo rejects a literal over- or
+under-supplied call to a statically-visible signature at **compile** time, so the
+runtime binder check is only observable through an indirect call. mutsu has no
+such static check — a separate gap, noted in the test rather than pinned.

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -3253,6 +3253,24 @@ pub(crate) fn has_var_decl(stmts: &[Stmt], name: &str) -> bool {
     false
 }
 
+/// Whether `stmts` reads the legacy argument array `@_` anywhere.
+///
+/// This is the ONE thing that makes a routine accept more positional arguments
+/// than its signature names: rakudo refuses a surplus for `sub f { $^x }` but
+/// allows it for `sub f { $^x; @_.elems }`, where the leftovers flow into `@_`.
+/// Measured 2026-09-08 — and note that a `%_` read does NOT buy the same
+/// leniency (`sub f { $^x; %_.elems }` called with three positionals dies),
+/// because `%_` is about *named* arguments and has no bearing on positional
+/// arity.
+///
+/// The debug-format probe is the same one `make_anon_sub` has always used for
+/// the signature-less-block case; it is deliberately conservative, since a
+/// false positive only makes a call more permissive than rakudo and a false
+/// negative only leaves the pre-existing behaviour.
+pub(crate) fn body_reads_args_array(stmts: &[Stmt]) -> bool {
+    format!("{stmts:?}").contains("ArrayVar(\"_\")")
+}
+
 /// Create an `Expr::AnonSub` or `Expr::AnonSubParams` depending on whether
 /// the block body contains placeholder variables (`$^a`, `$^b`, etc.).
 pub(crate) fn make_anon_sub(stmts: Vec<Stmt>) -> Expr {
@@ -3261,8 +3279,7 @@ pub(crate) fn make_anon_sub(stmts: Vec<Stmt>) -> Expr {
         // A signature-less block has an implicit `*@_` when it reads the
         // legacy argument array. Keep that distinction from an explicitly
         // empty `-> {}` signature, which still rejects positional arguments.
-        let body_debug = format!("{stmts:?}");
-        let uses_at_underscore = body_debug.contains("ArrayVar(\"_\")");
+        let uses_at_underscore = body_reads_args_array(&stmts);
         if uses_at_underscore {
             let legacy_params = vec!["@_".to_string()];
             let param_defs = legacy_params

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -4431,6 +4431,23 @@ pub(crate) struct CompiledCode {
     /// `logging.rakutest` reported the OUTER task's id for the inner task's
     /// end entry).
     pub(crate) writes_topic: bool,
+    /// Whether this code READS the legacy argument array `@_`.
+    ///
+    /// This is the one thing that lets a routine accept more positional
+    /// arguments than its signature names: rakudo refuses a surplus for
+    /// `sub f { $^x }` but allows it for `sub f { $^x; @_.elems }`, where the
+    /// leftovers flow into `@_`. Measured against rakudo 2026.07 (#7619); note
+    /// a `%_` read does NOT buy the same leniency, because `%_` is about
+    /// *named* arguments and has no bearing on positional arity.
+    ///
+    /// It lives here rather than being derived from the body at bind time
+    /// because a compiled closure's `SubData::body` is EMPTY — the AST is gone
+    /// once `cc` exists — so the binder cannot re-derive it. This is the
+    /// "dedicated field threaded from the AST through to the runtime `Sub`"
+    /// that `news/2026-08/template-mojo-triage-closed.md` said the fix needed;
+    /// the alternative it rejected (reserving a synthetic `params` entry) leaks
+    /// into every site that reads a Sub's raw `params`.
+    pub(crate) reads_args_array: bool,
     /// Whether this code contains opcodes that write to env (SetGlobal,
     /// AssignExpr, PostIncrement, etc.). Used by call_compiled_method to
     /// skip the expensive env merge when the method body is read-only.
@@ -5329,6 +5346,7 @@ impl CompiledCode {
             pointy_alias_param: false,
             immutable_topic: false,
             writes_topic: false,
+            reads_args_array: false,
             has_env_writes: false,
             may_capture_outer_vars: false,
             needs_env_sync: Vec::new(),
@@ -7549,6 +7567,16 @@ impl CompiledCode {
             && name.as_ref() == "_"
         {
             self.writes_topic = true;
+        }
+        // NOTE the sigil: `GetArrayVar`'s constant is the SIGILED name `"@_"`,
+        // unlike the topic, whose env key is a bare `"_"` (which is exactly the
+        // trap `CLAUDE.md`'s debugging section records — do not guess the key).
+        if !self.reads_args_array
+            && let OpCode::GetArrayVar(idx) = &op
+            && let Some(ValueView::Str(name)) = self.constants.get(*idx as usize).map(Value::view)
+            && matches!(name.as_str(), "@_" | "_")
+        {
+            self.reads_args_array = true;
         }
         if !self.has_env_writes {
             self.has_env_writes = matches!(

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -226,15 +226,19 @@ impl Interpreter {
         }
         let saved_env = self.env.clone();
         let saved_readonly = self.enter_readonly_frame();
-        let rw_bindings =
-            match self.bind_function_args_values(&def.param_defs, &def.params, arg_values) {
-                Ok(bindings) => bindings,
-                Err(e) => {
-                    self.env = saved_env;
-                    self.exit_readonly_frame(saved_readonly);
-                    return Err(e);
-                }
-            };
+        let rw_bindings = match self.bind_function_args_values_with_argspec(
+            &def.param_defs,
+            &def.params,
+            arg_values,
+            Some(crate::ast::body_reads_args_array(&def.body)),
+        ) {
+            Ok(bindings) => bindings,
+            Err(e) => {
+                self.env = saved_env;
+                self.exit_readonly_frame(saved_readonly);
+                return Err(e);
+            }
+        };
         let invocation_id = self.take_invocation_id();
         self.routine_stack.push(RoutineFrame {
             package: def.package,

--- a/src/runtime/dispatch_proto.rs
+++ b/src/runtime/dispatch_proto.rs
@@ -83,7 +83,12 @@ impl Interpreter {
         }
         let saved_env = self.env.clone();
         let saved_readonly = self.enter_readonly_frame();
-        let rw_bindings = match self.bind_function_args_values(&def.param_defs, &def.params, args) {
+        let rw_bindings = match self.bind_function_args_values_with_argspec(
+            &def.param_defs,
+            &def.params,
+            args,
+            Some(crate::ast::body_reads_args_array(&def.body)),
+        ) {
             Ok(bindings) => bindings,
             Err(e) => {
                 self.env = saved_env;

--- a/src/runtime/resolution_call_sub.rs
+++ b/src/runtime/resolution_call_sub.rs
@@ -697,16 +697,20 @@ impl Interpreter {
                 self.exit_readonly_frame(saved_readonly);
                 return Err(Self::reject_args_for_empty_sig(&call_args));
             }
-            let rw_bindings =
-                match self.bind_function_args_values(&data.param_defs, &data.params, &call_args) {
-                    Ok(bindings) => bindings,
-                    Err(e) => {
-                        self.pop_caller_env();
-                        self.env = saved_env;
-                        self.exit_readonly_frame(saved_readonly);
-                        return Err(e);
-                    }
-                };
+            let rw_bindings = match self.bind_function_args_values_with_argspec(
+                &data.param_defs,
+                &data.params,
+                &call_args,
+                Self::routine_reads_args_array(&data),
+            ) {
+                Ok(bindings) => bindings,
+                Err(e) => {
+                    self.pop_caller_env();
+                    self.env = saved_env;
+                    self.exit_readonly_frame(saved_readonly);
+                    return Err(e);
+                }
+            };
             new_env = self.env.clone();
             if data.params.is_empty() {
                 for arg in &sanitized_args {

--- a/src/runtime/types/binding_signature.rs
+++ b/src/runtime/types/binding_signature.rs
@@ -472,7 +472,43 @@ impl Interpreter {
         params: &[String],
         args: &[Value],
     ) -> Result<Vec<(String, String)>, RuntimeError> {
-        let result = self.bind_function_args_values_inner(param_defs, params, args);
+        self.bind_function_args_values_with_argspec(param_defs, params, args, None)
+    }
+
+    /// Whether `data`'s body reads the legacy argument array `@_`, or `None`
+    /// when it cannot be told.
+    ///
+    /// A COMPILED routine carries the answer on its `CompiledCode`; its
+    /// `SubData::body` is empty, because the AST is gone once the bytecode
+    /// exists, so asking the body there would answer a confident and wrong
+    /// "no". An interpreted one still has its body and is asked directly.
+    pub(crate) fn routine_reads_args_array(data: &crate::value::SubData) -> Option<bool> {
+        if let Some(cc) = data.compiled_code.as_ref() {
+            return Some(cc.reads_args_array);
+        }
+        if data.body.is_empty() {
+            return None;
+        }
+        Some(crate::ast::body_reads_args_array(&data.body))
+    }
+
+    /// [`Interpreter::bind_function_args_values`] plus the one fact about the
+    /// routine the params list cannot carry: whether its body reads the legacy
+    /// argument array `@_`.
+    ///
+    /// That decides whether a `^`-placeholder routine may be over-supplied with
+    /// positionals — see [`crate::opcode::CompiledCode::reads_args_array`] and
+    /// #7619. `None` means the caller cannot tell, and keeps the historical
+    /// lenient behaviour.
+    pub(crate) fn bind_function_args_values_with_argspec(
+        &mut self,
+        param_defs: &[ParamDef],
+        params: &[String],
+        args: &[Value],
+        reads_args_array: Option<bool>,
+    ) -> Result<Vec<(String, String)>, RuntimeError> {
+        let result =
+            self.bind_function_args_values_inner(param_defs, params, args, reads_args_array);
         let declares_self = crate::ast::signature_declares_self_lexical(param_defs)
             // The legacy binding path: a single pointy-block parameter
             // (`-> $self { }`) arrives as a bare name with no `ParamDef`.
@@ -488,6 +524,7 @@ impl Interpreter {
         param_defs: &[ParamDef],
         params: &[String],
         args: &[Value],
+        reads_args_array: Option<bool>,
     ) -> Result<Vec<(String, String)>, RuntimeError> {
         let filtered_args: Vec<Value> = args
             .iter()
@@ -758,32 +795,53 @@ impl Interpreter {
                     )));
                 }
             }
-            // A `^`-twigil placeholder or named (`:name`) placeholder sub may
-            // legitimately accept more positionals than its placeholders
-            // declare, via a bare `@_`/`%_` read in its body (see the comment
-            // above `required_positional_count`) -- so the "too many" check
-            // below is confined to a params list made ENTIRELY of plain
-            // (non-placeholder) identifiers. That shape only arises from an
-            // explicit single-param pointy block (`-> $a { }`, compiled via
-            // `Expr::Lambda`) or a non-mutating WhateverCode (`*+1`), neither
-            // of which can coexist with a body `@_`/`%_` read -- Raku rejects
-            // that combination at compile time (`X::Signature::Placeholder`,
-            // "Placeholder variable '@_' cannot override existing
-            // signature"), so a caret/colon-free params list here is never
-            // ambiguous (`todo/tickets/fast-binder-skips-too-many-positionals-check.md`).
-            let all_plain_positional = params.iter().all(|p| {
-                !p.starts_with('^')
-                    && !p.starts_with("@^")
-                    && !p.starts_with("%^")
-                    && !p.starts_with("&^")
-                    && !p.starts_with(':')
-                    && !p.starts_with("@:")
-                    && !p.starts_with("%:")
-            });
-            if all_plain_positional && positional_idx < positional_args.len() {
+            // A params list made ENTIRELY of plain (non-placeholder)
+            // identifiers always rejects a surplus. That shape only arises
+            // from an explicit single-param pointy block (`-> $a { }`,
+            // compiled via `Expr::Lambda`) or a non-mutating WhateverCode
+            // (`*+1`), neither of which can coexist with a body `@_`/`%_`
+            // read -- Raku rejects that combination at compile time
+            // (`X::Signature::Placeholder`, "Placeholder variable '@_' cannot
+            // override existing signature"), so it is never ambiguous.
+            let has_placeholder = |p: &String| {
+                p.starts_with('^')
+                    || p.starts_with("@^")
+                    || p.starts_with("%^")
+                    || p.starts_with("&^")
+            };
+            let has_named_placeholder =
+                |p: &String| p.starts_with(':') || p.starts_with("@:") || p.starts_with("%:");
+            let all_plain_positional = params
+                .iter()
+                .all(|p| !has_placeholder(p) && !has_named_placeholder(p));
+            // A `^`-twigil placeholder routine rejects a surplus too -- UNLESS
+            // its body reads a bare `@_`, which is where the leftovers go.
+            // Measured against rakudo 2026.07 (#7619):
+            //
+            //   sub a { $^x }              f(1,2,3)  dies, "expected 1 argument but got 3"
+            //   sub b { $^x; @_.elems }    f(1,2,3)  answers 2 -- the surplus IS `@_`
+            //   sub d { $^x; %_.elems }    f(1,2,3)  dies -- `%_` does NOT buy it
+            //
+            // A caller that cannot tell `a` from `b` passes `None` and stays
+            // lenient. A `:name` placeholder is left alone: mutsu does not yet
+            // bind one in a named sub at all (rakudo rejects the call at
+            // compile time), so there is no measured behaviour to match.
+            let caret_placeholders_reject_surplus = !all_plain_positional
+                && !params.iter().any(has_named_placeholder)
+                && reads_args_array == Some(false);
+            if (all_plain_positional || caret_placeholders_reject_surplus)
+                && positional_idx < positional_args.len()
+            {
                 return Err(RuntimeError::new(format!(
-                    "Too many positionals passed; expected {} arguments but got {}",
+                    // Rakudo says "1 argument", not "1 arguments"; the
+                    // same `argument{}` shape the "too few" arm above uses.
+                    "Too many positionals passed; expected {} argument{} but got {}",
                     required_positional_count,
+                    if required_positional_count == 1 {
+                        ""
+                    } else {
+                        "s"
+                    },
                     positional_args.len()
                 )));
             }

--- a/src/vm/vm_closure_dispatch.rs
+++ b/src/vm/vm_closure_dispatch.rs
@@ -611,7 +611,12 @@ impl Interpreter {
         // Bind parameters
         let mut rw_bindings = match loan_env!(
             self,
-            bind_function_args_values(&data.param_defs, &data.params, &args)
+            bind_function_args_values_with_argspec(
+                &data.param_defs,
+                &data.params,
+                &args,
+                Some(cc.reads_args_array)
+            )
         ) {
             Ok(bindings) => bindings,
             Err(e) => {

--- a/t/placeholder-sub-rejects-extra-positionals.t
+++ b/t/placeholder-sub-rejects-extra-positionals.t
@@ -1,0 +1,118 @@
+use Test;
+
+plan 17;
+
+# A `^`-twigil placeholder routine rejects a surplus of positional arguments,
+# exactly as one with an explicit signature does -- UNLESS its body reads the
+# legacy argument array `@_`, which is where the leftovers go. mutsu used to
+# skip the check for EVERY placeholder routine, so `sub f { $^a + $^b }` called
+# with three arguments silently succeeded.
+#
+# Every *throwing* case goes through a `&sub` Code object on purpose: rakudo
+# rejects a literal over- or under-supplied call to a statically-visible
+# signature at COMPILE time ("Calling f(Int, Int, Int) will never work with
+# declared signature ..."), so the runtime binder check this file is about is
+# only observable through an indirect call. mutsu has no such static check --
+# that is a separate gap, not what is pinned here.
+
+# --- the surplus is refused ------------------------------------------------
+
+{
+    sub two { $^a + $^b }
+    my $c = &two;
+    throws-like { $c(23, 1, 4) }, X::AdHoc,
+        message => 'Too many positionals passed; expected 2 arguments but got 3',
+        'a named placeholder sub refuses a surplus';
+    is two(23, 1), 24, 'and still binds the exact arity';
+}
+
+{
+    sub one { $^x }
+    my $c = &one;
+    throws-like { $c(1, 2, 3) }, X::AdHoc,
+        message => 'Too many positionals passed; expected 1 argument but got 3',
+        'the message is singular for one expected argument';
+}
+
+# A `%_` read is about NAMED arguments and buys no positional leniency --
+# rakudo refuses this one too.
+{
+    sub named-slurpy { $^x; %_.elems }
+    my $c = &named-slurpy;
+    throws-like { $c(1, 2, 3) }, X::AdHoc,
+        message => 'Too many positionals passed; expected 1 argument but got 3',
+        'a %_ read does not make a placeholder sub accept extra positionals';
+}
+
+{
+    use MONKEY-SEE-NO-EVAL;
+    my $ev = EVAL 'sub g { $^a + $^b }';
+    throws-like { $ev(23, 1, 4) }, X::AdHoc,
+        message => 'Too many positionals passed; expected 2 arguments but got 3',
+        'and through EVAL -- the Template::Mojo shape';
+    is $ev(2, 3), 5, 'the EVAL-built sub still binds its exact arity';
+}
+
+# --- a bare `@_` read is what buys the leniency ----------------------------
+
+{
+    sub with-args { $^x; @_.elems }
+    is with-args(1, 2, 3), 2,
+        'a placeholder sub whose body reads @_ accepts the surplus';
+    is with-args(1), 0, 'and @_ is empty when nothing is left over';
+}
+
+{
+    sub only-args { @_.elems }
+    is only-args(1, 2, 3), 3, 'a sub with no placeholders at all still slurps';
+    is only-args(), 0, 'including with no arguments';
+}
+
+# A compiled closure's `SubData::body` is empty -- the AST is gone once the
+# bytecode exists -- so the answer has to come off its `CompiledCode`, not from
+# re-deriving it from the body at bind time.
+{
+    sub with-args-c { $^x; @_.elems }
+    my $c = &with-args-c;
+    is $c(1, 2, 3), 2, 'the @_ leniency survives a Code-object call';
+}
+
+# --- the shortfall direction is unchanged ----------------------------------
+
+{
+    sub two-f { $^a + $^b }
+    my $f = &two-f;
+    throws-like { $f(1) }, X::AdHoc,
+        message => 'Too few positionals passed; expected 2 arguments but got 1',
+        'too few still reports the shortfall';
+}
+
+# --- explicit signatures and blocks are untouched --------------------------
+
+{
+    sub explicit($a, $b) { $a + $b }
+    my $e = &explicit;
+    throws-like { $e(1, 2, 3) }, X::AdHoc,
+        message => 'Too many positionals passed; expected 2 arguments but got 3',
+        'an explicit signature is unaffected';
+}
+
+{
+    my $b = { $^a + $^b };
+    throws-like { $b(23, 1, 4) }, X::AdHoc,
+        message => 'Too many positionals passed; expected 2 arguments but got 3',
+        'a placeholder block was already correct and stays so';
+    is $b(2, 3), 5, 'and still binds its exact arity';
+}
+
+{
+    my $p = -> $a { $a };
+    throws-like { $p(1, 2) }, X::AdHoc,
+        message => 'Too many positionals passed; expected 1 argument but got 2',
+        'a pointy block is unaffected';
+}
+
+{
+    sub slurpy($x, *@rest) { $x + @rest.elems }
+    is slurpy(1, 2, 3), 3, 'a declared slurpy still accepts extras';
+}


### PR DESCRIPTION
Closes #7619. Takes `Template::Mojo` 0.2.2 from **4/5 to 5/5**, striking that row from #7553.

## The divergence

```raku
sub direct { $^a + $^b }
direct(23, 1, 4)
    # raku:  Too many positionals passed; expected 2 arguments but got 3
    # mutsu: silently succeeds
```

The **block** spelling of the same signature was already correct, and `.arity`
and `.count` both answered `2`; only the surplus went unchecked, and only for a
routine whose parameters come from `^`-twigil placeholders.

## The exclusion was real, but three times too wide

`bind_function_args_values`'s legacy branch gated its "too many" check on
`all_plain_positional` — a `params` list with no `^`/`:` placeholder — and
`news/2026-08/fast-binder-too-many-positionals-check.md` recorded why: a
placeholder sub "whose body also reads a bare `@_`/`%_` legitimately accepts
more positionals than its placeholders declare".

Measured against rakudo, that is half true. Each of these called as `f(1, 2, 3)`:

| sub | raku |
| --- | --- |
| `sub a { $^x }` | **dies**, "expected 1 argument but got 3" |
| `sub b { $^x; @_.elems }` | `2` — the surplus really is `@_` |
| `sub c { @_.elems }` | `3` |
| `sub d { $^x; %_.elems }` | **dies** |

Row `d` is the correction: a `%_` read is about *named* arguments and has no
bearing on positional arity, so it buys nothing. Row `a` is the common case and
was refused outright. The leniency is keyed on a bare **`@_`** read alone.

## Where the answer had to live

`news/2026-08/template-mojo-triage-closed.md` had already dispositioned this and
named the fix — "a dedicated field threaded from the AST through to the runtime
`Sub` value" — and recorded what *not* to do: the attempt made then reserved a
synthetic `params` entry, which leaked into the ~80 call sites that read a Sub's
raw `params` (multi-dispatch candidate arity matching among them). This PR does
not repeat that.

The flag is `CompiledCode::reads_args_array`, set by the same op-scanning pass
that already computes `writes_topic`, and the binder takes it as an
`Option<bool>` rather than deriving it from the body.

**Deriving it from the body was tried first here, and is wrong in a way worth
recording.** A *compiled* closure's `SubData::body` is **empty** — the AST is
gone once the bytecode exists — so walking it answers a confident and wrong
"no". That turned row `b` into a spurious throw on the `&sub` Code-object path
while looking correct on the direct-call path; a `rust-gdb` breakpoint printing
`body` (`Some(&[Stmt](size=0))`) is what settled it.
`Interpreter::routine_reads_args_array` now asks the `CompiledCode` when there
is one, the body when the routine is interpreted, and answers `None` (stay
lenient) when it can tell neither.

The op scan also carries the trap `CLAUDE.md`'s debugging section warns about:
`GetArrayVar`'s constant is the **sigiled** name `"@_"`, where the topic's env
key is a bare `"_"`. Matching `"_"`, by analogy with the neighbouring
`writes_topic` scan, made the flag silently never fire — one `--dump-bytecode`
read found it.

While here, the "too many" message learned rakudo's singular ("expected 1
**argument**", not "1 arguments"), reusing the `argument{}` shape the "too few"
arm a few lines up already had.

## Testing

`t/placeholder-sub-rejects-extra-positionals.t`, 17 assertions, passing
**unchanged under `raku` as well as under mutsu**.

Every *throwing* case in it goes through a `&sub` Code object deliberately:
rakudo rejects a literal over- or under-supplied call to a statically-visible
signature at **compile** time ("Calling f(Int, Int, Int) will never work with
declared signature ..."), so the runtime binder check this PR is about is only
observable through an indirect call. mutsu has no such static check — a separate
gap, noted in the test rather than pinned by it.

The upstream dist now passes its own suite in full:

```
PASS t/00-basic.rakutest      <- was the only failure, on test 17
PASS t/01-template.rakutest
PASS t/02-complex.rakutest
PASS t/03-capture.rakutest
PASS t/04-native-named.rakutest
```

`cargo fmt`, `cargo clippy --all-targets -- -D warnings`, `make test` (Result:
PASS) and `make roast` all run. `make roast` reports three failures, byte-identical
to a run without this diff and all environmental to this container:

- `roast/6.c/S32-io/file-tests.t` and `roast/S16-filehandles/filetest.t` — the
  session runs as **root**, which bypasses the `0333`/`0222`/`0111` mode bits
  those assertions test.
- `roast/S32-io/IO-Socket-Async.t` — hangs at the `# host=::1` round;
  `/proc/net/if_inet6` does not exist here, so there is no IPv6 loopback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ExzRnHAQq5kawQ2oVpLMM9

---
_Generated by [Claude Code](https://claude.ai/code/session_01ExzRnHAQq5kawQ2oVpLMM9)_