### PR TITLE
fix(channel): close/fail complete the taps on a Channel.Supply

### DIFF
--- a/news/2026-09/channel-close-completes-its-supply-taps.md
+++ b/news/2026-09/channel-close-completes-its-supply-taps.md
@@ -1,0 +1,53 @@
+# `Channel.close` completes the taps on its `Supply`
+
+Tapping the `Supply` view of a `Channel` and then closing the channel delivered
+every value but never ran the tap's `done` callback:
+
+```raku
+my $c = Channel.new;
+my $p = Promise.new;
+$c.Supply.tap(-> $v { }, done => { $p.keep });
+$c.send(1);
+$c.close;
+sleep 1;
+say "kept=", $p.status;   # mutsu: Planned    raku: Kept
+```
+
+`Channel.close` did mark every supplier the channel had been bridged to as
+done, and that was easy to mistake for the whole job — `supplier_done` raises
+the terminal flag, stamps a terminal sequence number and wakes the registered
+sinks. What it does *not* do is run anything: a `.tap(&emit, done => { ... })`
+parks its completion callback in the supplier's pending-callback list, and only
+an explicit `take_supplier_done_callbacks` drain invokes it. `Supplier.done`
+performs that drain; the channel path never did, so for a channel-backed Supply
+the callbacks sat in the list until the process exited.
+
+`Channel.fail` was a wider miss on the same completion edge. It never touched
+the suppliers at all, so a tap's `quit => { ... }` handler — the only thing that
+observes a failing channel — could not fire either.
+
+Both are now signalled from `dispatch_channel_method`: `close` drains and
+invokes the done callbacks of every bridged supplier after closing the channel,
+and `fail` records the quit reason on each supplier and runs its quit handlers.
+Marking still happens before `ch.close()` exactly as before, so the existing
+`whenever`/react channel-drain path (which reads the queue and never consults
+the supplier ids) is untouched.
+
+Completion is per tap and exactly once, whether several taps share one
+`Channel.Supply` value or each comes from its own `.Supply` call, and it lands
+after the last value rather than instead of it. `t/channel-supply-tap-completion.t`
+pins all five properties through `Promise` status rather than printed output, so
+it does not depend on how writes from different threads interleave; the file
+passes unchanged on rakudo.
+
+This unblocks what `Channel.Supply`'s delivery fix (`187fc2eff`) left standing:
+route 5 of the `gc_contents_mut` cross-thread aliased-write investigation needs a
+tap that can be measured to a deterministic end, which a tap that never signals
+completion could not provide.
+
+Note that the value-distribution difference visible with two taps on one
+`Channel.Supply` — mutsu broadcasts each value to every tap where rakudo hands
+it to exactly one — is a separate bug tracked in its own issue, and is not
+touched here.
+
+Closes #7584.

--- a/src/runtime/methods_promise.rs
+++ b/src/runtime/methods_promise.rs
@@ -395,22 +395,51 @@ impl Interpreter {
                 Err(_) => Ok(Value::NIL),
             },
             "close" => {
+                use crate::runtime::native_methods::state::supplier_done;
+                use crate::runtime::native_methods::take_supplier_done_callbacks;
                 let sids = ch.supplier_ids();
-                if !sids.is_empty() {
-                    use crate::runtime::native_methods::state::supplier_done;
-                    for sid in &sids {
-                        supplier_done(*sid);
-                    }
+                for sid in &sids {
+                    supplier_done(*sid);
                 }
                 ch.close();
+                // `supplier_done` only raises the terminal flag and wakes the
+                // sinks; the `done => { ... }` callbacks a `.tap` registered on
+                // the supplier stay in its pending list, and for a
+                // channel-backed Supply nothing else ever drained them, so
+                // closing the channel delivered every value but never signalled
+                // completion. Run them here, exactly once per tap, the way
+                // `Supplier.done` does for a supplier-backed Supply.
+                for sid in &sids {
+                    for done_cb in take_supplier_done_callbacks(*sid) {
+                        if self.invoke_done_callback_or_quit(done_cb, *sid)? {
+                            break;
+                        }
+                    }
+                }
                 Ok(Value::NIL)
             }
             "fail" => {
+                use crate::runtime::native_methods::state::supplier_quit;
+                use crate::runtime::native_methods::take_supplier_quit_callbacks;
                 let reason = args
                     .into_iter()
                     .next()
                     .unwrap_or_else(|| Value::str_from("Died"));
-                ch.fail(Self::as_exception_value(reason));
+                let reason = Self::as_exception_value(reason);
+                // The same completion edge as `close` above, on the failing
+                // side: a tap's `quit => { ... }` handler is the only thing that
+                // observes `$channel.fail`, so the supplier has to carry the
+                // quit reason and its handlers have to run.
+                let sids = ch.supplier_ids();
+                for sid in &sids {
+                    supplier_quit(*sid, reason.clone());
+                }
+                ch.fail(reason.clone());
+                for sid in &sids {
+                    for quit_cb in take_supplier_quit_callbacks(*sid) {
+                        self.call_supply_quit_handler(quit_cb, reason.clone())?;
+                    }
+                }
                 Ok(Value::NIL)
             }
             "list" | "List" | "Array" | "Seq" => {

--- a/t/channel-supply-tap-completion.t
+++ b/t/channel-supply-tap-completion.t
@@ -1,0 +1,73 @@
+use Test;
+
+plan 5;
+
+# Closing a `Channel` completes the taps on its `Supply`. `Channel.close` used
+# to mark each bridged supplier done -- which raises the terminal flag and wakes
+# the sinks -- but never drained the `done => { ... }` callbacks those taps had
+# registered, so every value arrived and the completion signal never did.
+# `Channel.fail` did not even reach the supplier, so `quit => { ... }` never ran.
+#
+# Every assertion below observes a `Promise` the handler keeps rather than
+# printed output, so it does not depend on the ordering of writes across
+# threads.
+
+# 1. `.close` runs the tap's `done` callback.
+{
+    my $c = Channel.new;
+    my $p = Promise.new;
+    $c.Supply.tap(-> $v { }, done => { $p.keep });
+    $c.send(1);
+    $c.close;
+    is await(Promise.anyof($p, Promise.in(5))) && $p.status, 'Kept',
+        'Channel.close fires the tap done callback';
+}
+
+# 2. `.fail` runs the tap's `quit` callback -- the same completion edge.
+{
+    my $c = Channel.new;
+    my $p = Promise.new;
+    $c.Supply.tap(-> $v { }, quit => -> $ex { $p.keep });
+    $c.send(1);
+    $c.fail("boom");
+    is await(Promise.anyof($p, Promise.in(5))) && $p.status, 'Kept',
+        'Channel.fail fires the tap quit callback';
+}
+
+# 3. done fires exactly once per tap when one Supply carries several taps.
+{
+    my $c = Channel.new;
+    my $n = 0;
+    my $s = $c.Supply;
+    $s.tap(-> $v { }, done => { $n++ });
+    $s.tap(-> $v { }, done => { $n++ });
+    $c.send(1);
+    $c.close;
+    sleep 1;
+    is $n, 2, 'each tap on one Channel.Supply is completed exactly once';
+}
+
+# 4. ... and when each tap comes from its own `.Supply` call (a distinct
+#    supplier bridged onto the same channel).
+{
+    my $c = Channel.new;
+    my $n = 0;
+    $c.Supply.tap(-> $v { }, done => { $n++ });
+    $c.Supply.tap(-> $v { }, done => { $n++ });
+    $c.send(1);
+    $c.close;
+    sleep 1;
+    is $n, 2, 'each Channel.Supply view is completed exactly once';
+}
+
+# 5. Completion comes after the values, not instead of them.
+{
+    my $c = Channel.new;
+    my @got;
+    $c.Supply.tap(-> $v { @got.push($v) }, done => { @got.push('DONE') });
+    $c.send(1);
+    $c.send(2);
+    $c.close;
+    sleep 1;
+    is @got.tail, 'DONE', 'done runs after the last value, not before it';
+}


### PR DESCRIPTION
Tapping the `Supply` view of a `Channel` delivered every value but never signalled completion:

```raku
my $c = Channel.new;
my $p = Promise.new;
$c.Supply.tap(-> $v { }, done => { $p.keep });
$c.send(1);
$c.close;
sleep 1;
say "kept=", $p.status;   # mutsu: Planned    raku: Kept
```

## Root cause

`Channel.close` did mark every supplier the channel had been bridged to as done, and that is easy to mistake for the whole job — `supplier_done` raises the terminal flag, stamps a terminal sequence number and wakes the registered sinks. What it does *not* do is run anything: a `.tap(&emit, done => { ... })` parks its completion callback in the supplier's pending-callback list, and only an explicit `take_supplier_done_callbacks` drain invokes it. `Supplier.done` performs that drain; the channel path never did, so for a channel-backed Supply the callbacks sat in the list until the process exited.

`Channel.fail` was a wider miss on the same completion edge. It never touched the suppliers at all, so a tap's `quit => { ... }` handler — the only thing that observes a failing channel — could not fire either.

## Fix

Both are now signalled from `dispatch_channel_method`: `close` drains and invokes the done callbacks of every bridged supplier after closing the channel, and `fail` records the quit reason on each supplier and runs its quit handlers. Marking still happens before `ch.close()` exactly as before, so the existing `whenever`/react channel-drain path (which reads the queue and never consults the supplier ids) is untouched.

## Verification

Completion is per tap and exactly once, whether several taps share one `Channel.Supply` value or each comes from its own `.Supply` call, and it lands after the last value rather than instead of it.

`t/channel-supply-tap-completion.t` pins all five properties through `Promise` status rather than printed output, so it does not depend on how writes from different threads interleave. The file **passes unchanged on rakudo v2026.07**, so it pins real Raku semantics rather than mutsu-shaped behaviour.

- `cargo fmt --all`: clean
- `make test`: 3851 files, 40799 tests, all pass
- `make roast`: 1436 files, 218939 tests. The only failures are the three documented environment-only files, matching `docs/agent-environments.md` by name and subtest range (`6.c/S32-io/file-tests.t` 6-8/10 and `S16-filehandles/filetest.t` 57-64/69-72/77-80/101-125 both from running as `uid 0`; `S32-io/IO-Socket-Async.t` exit 124 from the network sandbox).
- `make lint`: the two host-target clippy configurations pass locally. **Correction to an earlier version of this description:** the wasm32 and rustdoc configurations did *not* run locally — this container had no `wasm32-unknown-unknown` target installed, and the failure was masked because the run was piped through `tail`, so the shell reported `tail`'s exit status rather than `make`'s. The target has since been installed and the full `make lint` is being re-run. All four configurations are covered by CI's `lint-configs` job on this PR, which is green.

The value-distribution difference visible with two taps on one `Channel.Supply` — mutsu broadcasts each value to every tap where rakudo hands it to exactly one — is a separate bug tracked in #7604 and is not touched here.

Closes #7584.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014zqc6o7emGLDGXUp8knhMy