### PR TITLE
fix: gate builtin preludes on the code, not on the prose around it

### DIFF
--- a/news/2026-09/a-comment-is-not-a-use.md
+++ b/news/2026-09/a-comment-is-not-a-use.md
@@ -1,0 +1,67 @@
+# A module named only in a comment no longer loads
+
+mutsu splices several builtin preludes into a compilation unit when its source
+*mentions* a name: NativeCall's `Pointer` family and its exported helper
+routines (`nativecast`, `cglobal`, `nativesizeof`, `explicitly-manage`,
+`refresh`), the parametric `Rational` role, the `IO::Socket` role, the
+`trait_mod:<does>` CORE.setting candidates, and the `Metamodel::Naming` /
+`Metamodel::Stashing` metaroles. Every one of those gates was a
+`source.contains(...)` over the raw program text — so a name written in a
+**comment** switched the prelude on:
+
+```raku
+# `use NativeCall` registers `GLOBAL::nativecast`.
+say defined(::('&nativecast'));   # mutsu: True, rakudo: False
+```
+
+Deleting that comment line changed the program's output. A comment is not code,
+and the observable was a routine the program never asked for becoming
+resolvable at the top level.
+
+The cost was not hypothetical. `t/block-use-keeps-nested-module-imports.t`, the
+pin for GH #7580, passed on an *unfixed* binary purely because its header
+paragraph named the provider its fixtures import: the prelude the test existed
+to observe was being installed by the prose describing it. The file carried a
+`NOTE:` paragraph warning readers not to name the provider in a comment; that
+warning is gone now, and so is the trap it warned about.
+
+## The fix
+
+`src/runtime/source_code_text.rs` introduces `CodeText`, a view of a
+compilation unit's source with `#` comments and Pod blocks removed, and it is
+now the only thing the prelude gates can be asked about — they take a
+`&CodeText<'_>` rather than a `&str`, so a gate added later cannot quietly go
+back to reading raw source. One mechanism, applied to all six preludes, rather
+than a per-module carve-out for NativeCall.
+
+Two judgement calls are worth recording:
+
+- **String literals are left alone.** A string *is* code — `require ::('Foo')`
+  names its module in one — and recognising every Raku quoting construct
+  (`q//`, `qq{}`, heredocs, `«»`) well enough to blank them out would risk
+  dropping real code from the view. Prose is the part that is definitionally
+  not code, and prose is what is removed.
+- **Every ambiguity is resolved toward keeping text.** The comment scan tracks
+  single- and double-quoted strings so `say "#"; use NativeCall;` keeps its
+  `use`; when a line ends inside a quote — an in-flight multi-line string this
+  line-oriented pass cannot see the end of — the line is kept verbatim. Keeping
+  too much only preserves the old over-eager behaviour for that one line;
+  dropping too much would lose a prelude a real program needs.
+
+A real `use` is untouched, including one nested inside a block or inside a
+module body: the prelude remains a whole-compunit splice, gated on the code
+rather than on the prose around it.
+
+## Pins
+
+- `t/comment-does-not-load-provider.t` — a header paragraph and a Pod block that
+  both name `use NativeCall` and its helper routines, asserting none of them is
+  visible. It passes under rakudo too.
+- `t/nativecall-prelude-gate-sees-real-use.t` — the other direction: a
+  block-scoped `use NativeCall` still brings in `Pointer` and `nativesizeof`.
+- Nine unit tests in `src/runtime/source_code_text.rs` cover the stripper
+  itself: trailing comments, a `#` inside a string, Raku's identifier-internal
+  apostrophe (`don't`), unterminated quotes, delimited and abbreviated Pod, and
+  `=finish`.
+
+Closes GH #7611.

--- a/news/2026-09/a-comment-is-not-a-use.md
+++ b/news/2026-09/a-comment-is-not-a-use.md
@@ -52,6 +52,43 @@ A real `use` is untouched, including one nested inside a block or inside a
 module body: the prelude remains a whole-compunit splice, gated on the code
 rather than on the prose around it.
 
+## The bug it was masking
+
+Removing the masking turned `t/nativecall-helpers-are-not-reexported.t` red,
+and the failure was real. mutsu splices NativeCall's helper routines into every
+compunit that calls one, registering each under `GLOBAL::`
+(`PRELUDE_SUB_TRAIT`). A routine call restores the routine registry on the way
+out, and that rollback dropped `GLOBAL::` entries wholesale -- including the
+splice a module's own body had received while it loaded. `loaded_modules` is
+never rolled back, so the later real `use` was a no-op that could not put it
+back, and the module's routine died with "Unknown function: nativecast" ever
+after:
+
+```raku
+lives-ok { EVAL 'use NativeCallHelperUser; 1' }, 'loads';   # a routine call
+use NativeCallHelperUser;
+cast-through(Str, Pointer);   # Unknown function: nativecast
+```
+
+That file passed only because its own header paragraph names `nativecast`
+several times, which gave the *main* compunit a copy of the helper that the
+module then found. The same masking, one file over.
+
+`reinstate_module_functions` already puts a loaded module's own routines back
+after such a rollback, but deliberately withholds the `GLOBAL::`-qualified ones
+unless the caller is the `EVAL` rollback: a file with no `unit module` runs its
+body at `current_package() == GLOBAL`, so its `sub foo is export` registers
+`GLOBAL::foo` -- indistinguishable from an alias installed *for the importing
+scope*, and reinstating those leaked `&bar` past the block in
+`{ require NoModule <&bar>; }` (`roast/S11-modules/require.t` test 10).
+
+A prelude splice carries no such ambiguity. It is ambient compunit machinery,
+never an import alias, and `registration_sub` already treats it that way when
+it declines the block-lexical escape hatch for one. So the `GLOBAL::` keys that
+came from a prelude splice are now tracked (`prelude_registered_functions`) and
+reinstated either way; every other `GLOBAL::` key keeps the old rule, and the
+`require` constraint is untouched.
+
 ## Pins
 
 - `t/comment-does-not-load-provider.t` — a header paragraph and a Pod block that
@@ -63,5 +100,7 @@ rather than on the prose around it.
   itself: trailing comments, a `#` inside a string, Raku's identifier-internal
   apostrophe (`don't`), unterminated quotes, delimited and abbreviated Pod, and
   `=finish`.
+- `t/module-loaded-in-a-call-keeps-its-prelude.t` — the unmasked bug on its own,
+  independent of which comments the file happens to carry.
 
 Closes GH #7611.

--- a/src/runtime/accessors_misc.rs
+++ b/src/runtime/accessors_misc.rs
@@ -87,7 +87,14 @@ impl Interpreter {
             if functions.contains_key(key) {
                 continue;
             }
-            if !include_global_aliases && key.resolve().starts_with("GLOBAL::") {
+            // A `GLOBAL::` key is normally left out unless the EVAL rollback
+            // asked for it, because it may be an alias installed for the
+            // importing scope. A PRELUDE splice is never that (see
+            // `prelude_registered_functions`), so it comes back either way.
+            if !include_global_aliases
+                && key.resolve().starts_with("GLOBAL::")
+                && !self.prelude_registered_functions.contains(key)
+            {
                 continue;
             }
             if let Some(def) = registry.functions.get(key) {

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -2016,6 +2016,22 @@ pub struct Interpreter {
     /// routines are gone, and a re-`use` — being a no-op — could not bring them
     /// back. See `reinstate_module_functions`.
     module_registered_functions: HashSet<Symbol>,
+    /// The `GLOBAL::`-qualified keys of routines spliced in as a PRELUDE
+    /// (`PRELUDE_SUB_TRAIT` — mutsu's NativeCall helpers).
+    ///
+    /// `module_registered_functions` deliberately does not let its `GLOBAL::`
+    /// members be reinstated after an ordinary scope rollback, because a file
+    /// with no `unit module` runs its body at `current_package() == GLOBAL` and
+    /// its `sub foo is export` is then indistinguishable from an alias
+    /// installed *for the importing scope* (`{ require NoModule <&bar>; }` must
+    /// not leak `&bar`). A prelude routine carries no such ambiguity: it is
+    /// ambient compunit machinery, never an import alias, and every compunit
+    /// that needs one carries an identical copy of which only the first
+    /// registration wins. Dropping it on a rollback therefore left a module
+    /// loaded inside a routine call — `lives-ok { EVAL 'use M' }` — permanently
+    /// unable to resolve the helper its own body calls, since `loaded_modules`
+    /// still claimed it was loaded and the later real `use` short-circuited.
+    prelude_registered_functions: HashSet<Symbol>,
     /// The package-qualified globals (`Base::flag`, `$NativeLibs::config`) each
     /// loaded module declared with `our`, keyed by module name.
     ///

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -673,6 +673,7 @@ mod sequence;
 pub(crate) mod shared_store;
 mod signal_watcher;
 pub(crate) mod slang_activation;
+mod source_code_text;
 pub(super) mod sprintf;
 mod sprintf_helpers;
 mod sprintf_validate;

--- a/src/runtime/registration_sub.rs
+++ b/src/runtime/registration_sub.rs
@@ -749,6 +749,11 @@ impl Interpreter {
             .any(|(t, _)| t == crate::runtime::PRELUDE_SUB_TRAIT)
         {
             let global_key = Symbol::intern(&format!("GLOBAL::{}", name));
+            // Remember that this `GLOBAL::` key is a prelude splice, not an
+            // import alias. `reinstate_module_functions` needs the distinction
+            // to put it back after a scope rollback — see
+            // `prelude_registered_functions`.
+            self.prelude_registered_functions.insert(global_key);
             // Every compunit that uses NativeCall carries its own copy of the
             // declaration, and they are identical by construction, so the first
             // one wins and the rest are no-ops rather than redeclarations.

--- a/src/runtime/run.rs
+++ b/src/runtime/run.rs
@@ -522,12 +522,15 @@ impl Interpreter {
         // Inject builtin prelude role definitions (e.g. the parametric `Rational`
         // role) when the program references them. These are registered through the
         // normal RoleDecl/VM path by prepending their statements to the body.
-        Self::inject_prelude_roles(&preprocessed, &mut stmts);
-        Self::inject_nativecall_prelude(&preprocessed, &mut stmts);
-        Self::inject_nativecall_subs_prelude(&preprocessed, &mut stmts);
-        Self::inject_iosocket_prelude(&preprocessed, &mut stmts);
-        Self::inject_trait_mod_does_prelude(&preprocessed, &mut stmts);
-        Self::inject_metamodel_role_prelude(&preprocessed, &mut stmts);
+        // Gated on the PROSE-FREE view of the source: a module named only in a
+        // comment or a Pod block must not switch a prelude on (GH #7611).
+        let code = crate::runtime::source_code_text::CodeText::from_source(&preprocessed);
+        Self::inject_prelude_roles(&code, &mut stmts);
+        Self::inject_nativecall_prelude(&code, &mut stmts);
+        Self::inject_nativecall_subs_prelude(&code, &mut stmts);
+        Self::inject_iosocket_prelude(&code, &mut stmts);
+        Self::inject_trait_mod_does_prelude(&code, &mut stmts);
+        Self::inject_metamodel_role_prelude(&code, &mut stmts);
         // Install EVERY END phaser this compunit declares — top-level, inside
         // a block, inside a sub or a method — before the VM runs a single
         // statement, in source order. That is what rakudo does (it installs at

--- a/src/runtime/run_modules.rs
+++ b/src/runtime/run_modules.rs
@@ -522,10 +522,11 @@ impl Interpreter {
         // builtin `Pointer` prelude class too — the main-program injection only
         // sees the main source, so a NativeCall binding distributed as a module
         // would otherwise hit an undeclared `Pointer`.
-        Self::inject_nativecall_prelude(&preprocessed, &mut stmts);
-        Self::inject_nativecall_subs_prelude(&preprocessed, &mut stmts);
-        Self::inject_iosocket_prelude(&preprocessed, &mut stmts);
-        Self::inject_trait_mod_does_prelude(&preprocessed, &mut stmts);
+        let code = crate::runtime::source_code_text::CodeText::from_source(&preprocessed);
+        Self::inject_nativecall_prelude(&code, &mut stmts);
+        Self::inject_nativecall_subs_prelude(&code, &mut stmts);
+        Self::inject_iosocket_prelude(&code, &mut stmts);
+        Self::inject_trait_mod_does_prelude(&code, &mut stmts);
 
         // Save to precompilation cache when the module is eligible.
         if precomp_eligible {

--- a/src/runtime/run_prelude.rs
+++ b/src/runtime/run_prelude.rs
@@ -2,6 +2,7 @@ use super::run::{
     IO_SOCKET_ROLE_PRELUDE, METAMODEL_ROLE_PRELUDE, NATIVECALL_POINTER_PRELUDE,
     NATIVECALL_SUB_PRELUDES, RATIONAL_ROLE_PRELUDE, TRAIT_MOD_DOES_PRELUDE,
 };
+use super::source_code_text::CodeText;
 use super::*;
 
 impl Interpreter {
@@ -9,7 +10,11 @@ impl Interpreter {
     /// references them. Currently this provides the parametric `Rational` role
     /// for user classes written as `does Rational[...]`. The prelude is parsed
     /// once and cached.
-    pub(super) fn inject_prelude_roles(source: &str, stmts: &mut Vec<Stmt>) {
+    ///
+    /// Like every gate in this file it is asked of a [`CodeText`], not of the
+    /// raw source: a name that appears only in a comment or a Pod block is
+    /// prose, and prose must not switch a prelude on (GH #7611).
+    pub(super) fn inject_prelude_roles(source: &CodeText<'_>, stmts: &mut Vec<Stmt>) {
         // Only inject when the program mentions `Rational` and does not declare
         // its own role of that name (which would conflict).
         if !source.contains("Rational") || source.contains("role Rational") {
@@ -38,7 +43,12 @@ impl Interpreter {
     /// source also naming `Pointer` meant `use NativeCall; say void.^name` --
     /// or any of the other three -- saw an undeclared bareword, since only one
     /// of the four names gated all of them.
-    pub(super) fn inject_nativecall_prelude(source: &str, stmts: &mut Vec<Stmt>) {
+    ///
+    /// It reads a [`CodeText`], so `# use NativeCall` in a comment no longer
+    /// counts; a real `use` anywhere in the compunit -- inside a block, inside
+    /// a module body -- still does, because the prelude is a whole-compunit
+    /// splice.
+    pub(super) fn inject_nativecall_prelude(source: &CodeText<'_>, stmts: &mut Vec<Stmt>) {
         if !source.contains("NativeCall")
             || source.contains("class Pointer")
             || source.contains("class void")
@@ -80,7 +90,7 @@ impl Interpreter {
     /// that merely *uses* NativeCall would re-export the helper to its own
     /// importers, and the re-exported copy collides with the importer's own
     /// injected copy as an `X::Redeclaration` (see [`NATIVECALL_SUB_PRELUDES`]).
-    pub(super) fn inject_nativecall_subs_prelude(source: &str, stmts: &mut Vec<Stmt>) {
+    pub(super) fn inject_nativecall_subs_prelude(source: &CodeText<'_>, stmts: &mut Vec<Stmt>) {
         if !source.contains("NativeCall") {
             return;
         }
@@ -148,7 +158,7 @@ impl Interpreter {
     /// (`does IO::Socket`) without declaring its own. Enables the community
     /// `IO::Socket::SSL` binding, whose class header is
     /// `class IO::Socket::SSL does IO::Socket`. Parsed once and cached.
-    pub(super) fn inject_iosocket_prelude(source: &str, stmts: &mut Vec<Stmt>) {
+    pub(super) fn inject_iosocket_prelude(source: &CodeText<'_>, stmts: &mut Vec<Stmt>) {
         if !source.contains("does IO::Socket") || source.contains("role IO::Socket") {
             return;
         }
@@ -170,14 +180,15 @@ impl Interpreter {
     /// Prepend the `trait_mod:<does>` CORE.setting candidates when the source
     /// calls it as a plain function (`trait_mod:<does>(v, role)`, the
     /// `Hash::Restricted`/`Injector` idiom for mixing a role into a declared
-    /// variable at `is`-trait time). Gated on the literal name appearing in
-    /// source, like the other preludes in this file — a program that never
-    /// mentions it pays nothing. Not gated on "does the source already
-    /// declare its own candidate": Rakudo's builtin coexists with (and can
+    /// variable at `is`-trait time). Gated on the literal name appearing in the
+    /// compunit's CODE, like the other preludes in this file — a program that
+    /// never mentions it pays nothing, and a comment that mentions it is prose,
+    /// not a mention. Not gated on "does the source already declare its own
+    /// candidate": Rakudo's builtin coexists with (and can
     /// collide with) a user-declared candidate of the same name, and that
     /// collision is exactly what proves the builtin is registered correctly
     /// (see `TRAIT_MOD_DOES_PRELUDE`'s doc comment).
-    pub(super) fn inject_trait_mod_does_prelude(source: &str, stmts: &mut Vec<Stmt>) {
+    pub(super) fn inject_trait_mod_does_prelude(source: &CodeText<'_>, stmts: &mut Vec<Stmt>) {
         if !source.contains("trait_mod:<does>") {
             return;
         }
@@ -206,7 +217,7 @@ impl Interpreter {
     /// programs that merely introspect. A program declaring its own role of
     /// either name keeps it (the prelude would collide with it), exactly as
     /// [`Self::inject_prelude_roles`] treats `role Rational`.
-    pub(super) fn inject_metamodel_role_prelude(source: &str, stmts: &mut Vec<Stmt>) {
+    pub(super) fn inject_metamodel_role_prelude(source: &CodeText<'_>, stmts: &mut Vec<Stmt>) {
         let wants_naming =
             source.contains("Metamodel::Naming") && !source.contains("role Metamodel::Naming");
         let wants_stashing =

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -2999,6 +2999,7 @@ impl Interpreter {
             chroot_root: None,
             loaded_modules: HashSet::new(),
             module_registered_functions: HashSet::new(),
+            prelude_registered_functions: HashSet::new(),
             module_package_globals: HashMap::new(),
             need_hidden_classes: HashSet::new(),
             cur_repo: Box::new(CurRepoState::default()),

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -643,6 +643,7 @@ impl Interpreter {
             chroot_root: self.chroot_root.clone(),
             loaded_modules: self.loaded_modules.clone(),
             module_registered_functions: self.module_registered_functions.clone(),
+            prelude_registered_functions: self.prelude_registered_functions.clone(),
             module_package_globals: self.module_package_globals.clone(),
             need_hidden_classes: self.need_hidden_classes.clone(),
             cur_repo: self.cur_repo.clone(),

--- a/src/runtime/source_code_text.rs
+++ b/src/runtime/source_code_text.rs
@@ -1,0 +1,238 @@
+//! A prose-free view of a compilation unit's source text.
+//!
+//! Several builtin preludes are gated on the source *mentioning* a name --
+//! `NativeCall`, `does IO::Socket`, `trait_mod:<does>`, `Metamodel::Naming`
+//! (see [`crate::runtime::run_prelude`]). Those gates used to run against the
+//! raw source, so a name that appeared only in a **comment** switched the
+//! prelude on: `# use NativeCall registers GLOBAL::nativecast` alone made
+//! `&nativecast` resolvable in a program that never asked for it, and it
+//! silently masked the failure a `t/` pin existed to catch (GH #7611).
+//!
+//! A comment is not code, and neither is a Pod block. [`CodeText`] is the one
+//! place that distinction is made: it holds the source with `#` comments and
+//! Pod blocks removed, and it is the only thing the prelude gates can be asked
+//! about, so a gate added later cannot go back to reading raw text by mistake.
+//!
+//! String literals are deliberately left alone. A string *is* code -- a
+//! `require ::('NativeCall')` names its module in one -- and recognising every
+//! Raku quoting construct (`q//`, `qq{}`, heredocs, `«»`) well enough to blank
+//! them out would risk dropping real code from the view. Prose is the part
+//! that is definitionally not code, and prose is what this removes.
+//!
+//! Every judgement call here is biased toward *keeping* text: when a line
+//! cannot be resolved with confidence (an unterminated quote, i.e. a
+//! multi-line string), the line is kept verbatim. Keeping too much only
+//! preserves the previous, over-eager behaviour for that one line; dropping
+//! too much would lose a prelude a real program needs.
+
+use std::borrow::Cow;
+
+/// A compilation unit's source with comments and Pod removed.
+///
+/// Construct it with [`CodeText::from_source`]; the inner text is not exposed
+/// as a plain `&str` for gating, only through [`CodeText::contains`], so the
+/// prelude gates cannot accidentally be handed raw source.
+pub(crate) struct CodeText<'a>(Cow<'a, str>);
+
+impl<'a> CodeText<'a> {
+    /// Strip `#` comments and Pod blocks from `source`.
+    pub(crate) fn from_source(source: &'a str) -> Self {
+        if !has_prose_marker(source) {
+            return CodeText(Cow::Borrowed(source));
+        }
+        CodeText(Cow::Owned(strip_prose(source)))
+    }
+
+    /// Whether the code -- as opposed to the prose around it -- contains
+    /// `needle`.
+    pub(crate) fn contains(&self, needle: &str) -> bool {
+        self.0.contains(needle)
+    }
+}
+
+/// Cheap pre-check: a source with no `#` and no line starting with `=` has no
+/// comment and no Pod block, so it is its own code view.
+fn has_prose_marker(source: &str) -> bool {
+    source.as_bytes().contains(&b'#') || source.starts_with('=') || source.contains("\n=")
+}
+
+/// The prose-removal pass. Line-oriented: both `#` comments and Pod blocks are
+/// line-terminated constructs, and working a line at a time keeps a
+/// misjudgement contained to that line.
+fn strip_prose(source: &str) -> String {
+    let mut out = String::with_capacity(source.len());
+    // `Some(name)` while inside `=begin NAME` ... `=end NAME`.
+    let mut in_delimited_pod: Option<String> = None;
+    // Inside an abbreviated/`=for` Pod block, which runs to the next blank line.
+    let mut in_pod_paragraph = false;
+    for line in source.lines() {
+        let trimmed = line.trim_start();
+        if let Some(name) = &in_delimited_pod {
+            if let Some(rest) = trimmed.strip_prefix("=end")
+                && rest.trim() == name.as_str()
+            {
+                in_delimited_pod = None;
+            }
+            out.push('\n');
+            continue;
+        }
+        if in_pod_paragraph {
+            if trimmed.is_empty() {
+                in_pod_paragraph = false;
+            }
+            out.push('\n');
+            continue;
+        }
+        if is_pod_directive(trimmed) {
+            if let Some(rest) = trimmed.strip_prefix("=begin ") {
+                in_delimited_pod = Some(rest.trim().to_string());
+            } else if trimmed == "=finish" || trimmed.starts_with("=finish ") {
+                // Everything after `=finish` is the `$=finish` data section,
+                // not code at all.
+                break;
+            } else if !trimmed.starts_with("=end ") {
+                in_pod_paragraph = true;
+            }
+            out.push('\n');
+            continue;
+        }
+        out.push_str(strip_line_comment(line));
+        out.push('\n');
+    }
+    out
+}
+
+/// Whether a (left-trimmed) line opens or continues a Pod block: `=` followed
+/// by an identifier character. Raku itself reads a line-initial `=word` as Pod,
+/// so this cannot swallow a line that would have parsed as code.
+fn is_pod_directive(trimmed: &str) -> bool {
+    let mut chars = trimmed.chars();
+    chars.next() == Some('=')
+        && chars
+            .next()
+            .is_some_and(|c| c.is_ascii_alphabetic() || c == '_')
+}
+
+/// Return `line` up to a `#` that starts a comment, or the whole line when it
+/// has none.
+///
+/// The scan tracks single- and double-quoted strings so a `#` inside one is not
+/// mistaken for a comment (`say "#"; use NativeCall;` keeps its `use`). If the
+/// line ends inside a quote it is part of a multi-line string this
+/// line-oriented pass cannot see the end of, so the line is kept whole rather
+/// than guessed at.
+fn strip_line_comment(line: &str) -> &str {
+    #[derive(PartialEq)]
+    enum Quote {
+        None,
+        Single,
+        Double,
+    }
+    let bytes = line.as_bytes();
+    let mut quote = Quote::None;
+    let mut i = 0;
+    while i < bytes.len() {
+        let b = bytes[i];
+        match quote {
+            Quote::None => match b {
+                b'#' => return &line[..i],
+                b'"' => quote = Quote::Double,
+                // `'` is also an identifier character in Raku (`isn't-ok`),
+                // but only between two word characters; anywhere else it opens
+                // a string.
+                b'\'' if !is_identifier_apostrophe(bytes, i) => quote = Quote::Single,
+                _ => {}
+            },
+            Quote::Single => match b {
+                b'\\' => i += 1,
+                b'\'' => quote = Quote::None,
+                _ => {}
+            },
+            Quote::Double => match b {
+                b'\\' => i += 1,
+                b'"' => quote = Quote::None,
+                _ => {}
+            },
+        }
+        i += 1;
+    }
+    // Unterminated quote: an in-flight multi-line string. Keep the line.
+    line
+}
+
+/// Whether the `'` at `i` is the identifier-internal apostrophe Raku allows
+/// (`don't`), which requires a word character on both sides.
+fn is_identifier_apostrophe(bytes: &[u8], i: usize) -> bool {
+    let word = |b: u8| b.is_ascii_alphanumeric() || b == b'_';
+    i > 0 && word(bytes[i - 1]) && bytes.get(i + 1).copied().is_some_and(word)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::CodeText;
+
+    fn code(source: &str) -> String {
+        // Round-trip through the public constructor so the tests exercise the
+        // same path the prelude gates take.
+        CodeText::from_source(source).0.into_owned()
+    }
+
+    #[test]
+    fn line_comment_is_dropped() {
+        assert!(!CodeText::from_source("# use NativeCall\nsay 1;\n").contains("NativeCall"));
+        assert!(CodeText::from_source("use NativeCall;\nsay 1;\n").contains("NativeCall"));
+    }
+
+    #[test]
+    fn trailing_comment_keeps_the_code_before_it() {
+        let text = CodeText::from_source("use NativeCall; # NativeCall notes\n");
+        assert!(text.contains("use NativeCall;"));
+        assert_eq!(code("say 1; # hi\n"), "say 1; \n");
+    }
+
+    #[test]
+    fn hash_inside_a_string_is_not_a_comment() {
+        assert!(CodeText::from_source("say \"#\"; use NativeCall;\n").contains("NativeCall"));
+        assert!(CodeText::from_source("say '#'; use NativeCall;\n").contains("NativeCall"));
+        assert!(CodeText::from_source("say \"a\\\"#\"; use NativeCall;\n").contains("NativeCall"));
+    }
+
+    #[test]
+    fn an_apostrophe_in_an_identifier_does_not_open_a_string() {
+        // `don't` is one identifier; the `#` after it still starts a comment.
+        assert!(!CodeText::from_source("don't-do(); # use NativeCall\n").contains("NativeCall"));
+    }
+
+    #[test]
+    fn an_unterminated_quote_keeps_the_line() {
+        // A multi-line string this line-oriented pass cannot resolve: keep it
+        // rather than guess, which is the previous behaviour for that line only.
+        assert_eq!(code("say 'a # b\n"), "say 'a # b\n");
+    }
+
+    #[test]
+    fn delimited_pod_is_dropped() {
+        let src = "=begin pod\nuse NativeCall in prose\n=end pod\nsay 1;\n";
+        assert!(!CodeText::from_source(src).contains("NativeCall"));
+        assert!(CodeText::from_source(src).contains("say 1;"));
+    }
+
+    #[test]
+    fn abbreviated_pod_runs_to_the_blank_line() {
+        let src = "=head1 use NativeCall\nstill NativeCall prose\n\nsay 1;\n";
+        assert!(!CodeText::from_source(src).contains("NativeCall"));
+        assert!(CodeText::from_source(src).contains("say 1;"));
+    }
+
+    #[test]
+    fn finish_section_is_not_code() {
+        let src = "say 1;\n=finish\nuse NativeCall\n";
+        assert!(!CodeText::from_source(src).contains("NativeCall"));
+    }
+
+    #[test]
+    fn source_without_prose_is_borrowed_unchanged() {
+        let src = "use NativeCall;\nsay nativesizeof(int32);\n";
+        assert_eq!(code(src), src);
+    }
+}

--- a/t/block-use-keeps-nested-module-imports.t
+++ b/t/block-use-keeps-nested-module-imports.t
@@ -13,11 +13,6 @@
 # holds because the module-body delta is taken BEFORE `import_module`, so an
 # alias installed for the IMPORTING scope is never in the retained set.
 #
-# NOTE: do NOT name the provider the fixtures import in a comment here. mutsu
-# picks a provider module out of the source text even inside a comment, which
-# loads it at the top level and masks the very failure this file pins (GH
-# #7611). Delete this paragraph when that is fixed.
-#
 # The opposite edge -- that the nested module's import is also visible to the
 # USING scope, where rakudo hides it -- is pre-existing and tracked as GH #7612;
 # it reproduces with no block at all, so it is deliberately not asserted here.

--- a/t/comment-does-not-load-provider.t
+++ b/t/comment-does-not-load-provider.t
@@ -1,0 +1,45 @@
+# A comment is not code: a module named only in prose must not be loaded.
+#
+# mutsu gates several builtin preludes on the compunit's source *mentioning* a
+# name (`NativeCall`, `does IO::Socket`, `trait_mod:<does>`, ...). Those gates
+# used to read the raw source, so `use NativeCall` written in a COMMENT was
+# enough to inject NativeCall's exported helpers at the top level: the routines
+# below became resolvable in a program that never asked for them, and a `t/`
+# pin whose header discussed a provider silently stopped testing what it
+# existed to test (GH #7611).
+#
+# So the sentences in this header are the fixture. `use NativeCall;` appears
+# above as prose, `cglobal`, `nativecast`, `nativesizeof` and
+# `explicitly-manage` are all named here, and none of them may be visible.
+use Test;
+
+plan 6;
+
+nok defined(::('&nativecast')),
+    'a provider named only in a comment does not register its exported routines';
+nok defined(::('&cglobal')),
+    'the same for every routine the prose names, not just the first';
+nok defined(::('&nativesizeof')),
+    'and for a routine named on its own line of prose';
+
+# The same for Pod, which is prose too.
+
+=begin pod
+
+This block mentions C<use NativeCall> and C<explicitly-manage> the way any
+documented module would.
+
+=end pod
+
+nok defined(::('&explicitly-manage')),
+    'a provider named only in a Pod block does not register its routines either';
+
+# A `#` inside a string is not a comment, so the code around it must survive
+# the prose-stripping pass unchanged.
+is "# not a comment", '# not a comment', 'a hash inside a string is code';
+
+# And a comment naming a routine still does not conjure it after real code has
+# run: the gate is decided once, for the whole compunit.
+# nativecast() nativesizeof() cglobal()
+nok defined(::('&nativecast')),
+    'still not visible after the mainline has started';

--- a/t/module-loaded-in-a-call-keeps-its-prelude.t
+++ b/t/module-loaded-in-a-call-keeps-its-prelude.t
@@ -1,0 +1,37 @@
+# A module first loaded inside a ROUTINE CALL keeps the prelude routines its
+# own body calls.
+#
+# mutsu has no `NativeCall.rakumod` to import from, so it splices NativeCall's
+# helper routines into every compunit that calls one, registering each under
+# `GLOBAL::` (`PRELUDE_SUB_TRAIT`). A routine call restores the routine
+# registry on the way out, and that rollback dropped `GLOBAL::` entries
+# wholesale -- including the splice a module's own body received while it
+# loaded. `loaded_modules` is never rolled back, so the later real `use` was a
+# no-op that could not put it back, and the module's routine died with
+# "Unknown function" ever after.
+#
+# `lives-ok { ... }` is the routine call here: `Test`'s block argument is
+# invoked like any other callable. The `EVAL` is only how `use-ok`-shaped code
+# loads a module from inside one; the same shape without `EVAL` is fine, which
+# is why the rollback -- not the `EVAL` -- is what this pins.
+#
+# The sibling constraint is that an ordinary import alias must still go out of
+# scope with its block (`roast/S11-modules/lexical.t`,
+# `roast/S11-modules/require.t` test 10). A prelude splice is not an alias, so
+# only the splice is exempted.
+use Test;
+use lib $?FILE.IO.parent.add('lib').Str;
+use NativeCall;
+
+plan 2;
+
+lives-ok { EVAL 'use NativeCallHelperUser; 1' },
+    'a module loads from inside a routine call';
+
+use NativeCallHelperUser;
+
+# `NativeCallHelperUser`'s exported routine calls the spliced helper that its
+# own body never declares. Type objects are enough to reach the call: it dies
+# on the missing routine long before it would touch a real pointer.
+lives-ok { cast-through(Str, Pointer) },
+    "the module's body still reaches its spliced helper afterwards";

--- a/t/nativecall-prelude-gate-sees-real-use.t
+++ b/t/nativecall-prelude-gate-sees-real-use.t
@@ -1,0 +1,21 @@
+# The other half of GH #7611: making the NativeCall prelude gate blind to
+# prose must not make it blind to a real `use`. A `use NativeCall` nested
+# inside a block is still a use, and the prelude it gates -- the `Pointer`
+# family of type objects and the exported helper routines -- has to be there.
+#
+# (The module-body case is pinned by `t/nativecall-helpers-are-not-reexported.t`,
+# whose fixture is a `unit module` that uses NativeCall.)
+use Test;
+
+plan 3;
+
+{
+    use NativeCall;
+
+    is Pointer.^name, 'NativeCall::Types::Pointer',
+       'a block-scoped use NativeCall still brings in the Pointer type objects';
+    is nativesizeof(int32), 4,
+       'and its exported helper routines';
+    ok defined(::('&nativecast')),
+       'and nativecast is resolvable, as a real use asks for';
+}


### PR DESCRIPTION
Six builtin preludes are spliced into a compilation unit when its source *mentions* a name: NativeCall's `Pointer` type objects and its exported helper routines, the parametric `Rational` role, the `IO::Socket` role, the `trait_mod:<does>` CORE.setting candidates, and the `Metamodel::Naming` / `Metamodel::Stashing` metaroles. Every gate was a `source.contains(...)` over the raw program text, so a name written in a **comment** switched the prelude on:

```raku
# `use NativeCall` registers `GLOBAL::nativecast`.
say defined(::('&nativecast'));   # mutsu: True, rakudo: False
```

Deleting that comment changed the program's output, and the observable was a routine the program never asked for becoming resolvable at the top level.

## The mechanism

`src/runtime/source_code_text.rs` adds `CodeText`, a view of a compilation unit's source with `#` comments and Pod blocks removed, and makes it the only thing the prelude gates can be asked about — they take a `&CodeText<'_>` rather than a `&str`, so a gate added later cannot quietly go back to reading raw source. One mechanism for all six preludes rather than a carve-out for NativeCall.

Two judgement calls:

- **String literals are left alone.** A string *is* code — `require ::('Foo')` names its module in one — and recognising every Raku quoting construct (`q//`, `qq{}`, heredocs, `«»`) well enough to blank them out would risk dropping real code from the view. Prose is the part that is definitionally not code.
- **Every ambiguity resolves toward keeping text.** The comment scan tracks single- and double-quoted strings so `say "#"; use NativeCall;` keeps its `use`, and Raku's identifier-internal apostrophe (`don't`) does not open a string; when a line ends inside a quote — an in-flight multi-line string this line-oriented pass cannot see the end of — the line is kept verbatim. Keeping too much only preserves the old over-eager behaviour for that line; dropping too much would lose a prelude a real program needs.

A real `use` is untouched, including one nested inside a block or inside a module body: the prelude remains a whole-compunit splice.

## The bug it was masking

The issue notes that this masks real failures, and it did — the pin for #7580 passed on an unfixed binary because its header named the provider. It also masked a second, unrelated bug one file over: removing the masking turned `t/nativecall-helpers-are-not-reexported.t` red.

A routine call restores the routine registry on the way out, and that rollback dropped `GLOBAL::` entries wholesale — including the prelude splice a module's own body received while it loaded. `loaded_modules` is never rolled back, so the later real `use` was a no-op that could not put it back:

```raku
lives-ok { EVAL 'use NativeCallHelperUser; 1' }, 'loads';   # a routine call
use NativeCallHelperUser;
cast-through(Str, Pointer);   # Unknown function: nativecast
```

That file passed only because its own header paragraph names `nativecast` several times, giving the *main* compunit a copy of the helper that the module then found.

`reinstate_module_functions` already puts a loaded module's own routines back after such a rollback, but withholds the `GLOBAL::`-qualified ones unless the caller is the `EVAL` rollback — a file with no `unit module` runs its body at `current_package() == GLOBAL`, so its `sub foo is export` registers `GLOBAL::foo`, indistinguishable from an alias installed for the *importing* scope (`{ require NoModule <&bar>; }` must not leak `&bar`, `roast/S11-modules/require.t` test 10). A prelude splice carries no such ambiguity, and `registration_sub` already treats it that way when it declines the block-lexical escape hatch for one. So splice keys are now tracked (`prelude_registered_functions`) and reinstated either way; every other `GLOBAL::` key keeps the old rule.

## Acceptance

- Both programs in the issue print `False`, matching rakudo.
- The gate change is one general mechanism covering all six preludes, not a per-module carve-out.
- A real `use NativeCall` still works at the top level, inside a block, and inside a module body.
- The stale `NOTE:` paragraph in `t/block-use-keeps-nested-module-imports.t` is deleted; the file still passes, and adding a comment naming the provider no longer changes anything.

## Tests

- `t/comment-does-not-load-provider.t` — a header paragraph and a Pod block that both name `use NativeCall` and its helpers, asserting none is visible. Passes under rakudo too.
- `t/nativecall-prelude-gate-sees-real-use.t` — the other direction: a block-scoped `use NativeCall` still brings in `Pointer` and `nativesizeof`. Passes under rakudo too.
- `t/module-loaded-in-a-call-keeps-its-prelude.t` — the unmasked rollback bug on its own; fails without the `reinstate_module_functions` change.
- Nine unit tests on the stripper: trailing comments, a `#` inside a string, `don't`, unterminated quotes, delimited and abbreviated Pod, `=finish`.

`cargo fmt --all`, `make lint`, `make test` (3854 files, 40821 tests, PASS) and `make roast` all run locally; roast's only failures are the three documented container-only ones (`6.c/S32-io/file-tests.t` and `S16-filehandles/filetest.t` under `uid 0`, `S32-io/IO-Socket-Async.t` under the sandboxed network), with exactly the failure shapes [docs/agent-environments.md](https://github.com/tokuhirom/mutsu/blob/main/docs/agent-environments.md) records.

Closes #7611

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D9EnFrBXsP186vGTJauWX6

---
_Generated by [Claude Code](https://claude.ai/code/session_01D9EnFrBXsP186vGTJauWX6)_