### PR TITLE
perf(vm): CallMethod answers a scalar native method before the env flatten

### DIFF
--- a/news/2026-09/callmethod-answers-a-scalar-native-before-the-env-flatten.md
+++ b/news/2026-09/callmethod-answers-a-scalar-native-before-the-env-flatten.md
@@ -1,0 +1,59 @@
+# `CallMethod` answers a scalar native method before the env flatten
+
+`exec_call_method_op_impl` collapses a scoped overlay env to a flat env before
+any dispatch that gets past the pure-read accessor fast path. On a scoped env
+that is a whole-scope map clone, so the cost of one method call is linear in how
+many names are in scope anywhere up the stack. `CallMethodMut` has had a gate in
+front of that guard since #7554 — `try_env_pure_mut_dispatch` answers a pure
+native method on an immutable scalar receiver (`Str`, `Int`, `Num`, `Bool`)
+without flattening, because such a dispatch provably reaches nothing that
+captures or iterates the env. The plain `CallMethod` opcode never got the same
+gate.
+
+It wants it. `benchmarks/method-call.raku` — a `Point.distance-to` loop whose
+body ends in `(...).sqrt` — flattened the env 10,000 times, every one of them
+from `CallMethod`, and every one of them resolving to a native method. The
+receiver is a `Num` inside a scoped method frame, which is exactly case 1 of the
+existing gate.
+
+Case 1 is now a shared helper, `try_env_pure_scalar_native_dispatch`, called by
+both opcodes; `try_env_pure_mut_dispatch` keeps its `IO::Handle` output arm and
+delegates the scalar arm. The name-exclusion list it consults grew `VAR`, which
+`exec_call_method_op_impl` hard-codes into its `skip_native` seed, and is now
+documented as shared by both paths rather than specific to the mut one — it only
+ever makes the gate more conservative.
+
+Everything the general path would have decided for such a receiver is still
+decided identically: the same `quoted`/modifier exclusions, the same
+junction-argument autothreading deferral, the same `native_lever_a_user_override`
+gate, and the methods that own a dedicated branch on either path
+(`new`, `WHO`, `protect`, `make`, `subst-mutate`, `hyper`/`race`, the
+xxx-KEY/BIND-POS mutators, the `push` family, `VAR`) are left to it. Both
+opcodes' remaining pre-probe branches are receiver-typed on values the arm never
+accepts — `Junction`, `LazyList`, `Failure`, `Package`, `Instance`, `Array`,
+`Regex`, `Proxy` — and the four that could otherwise have applied to a scalar
+(`.return`, the NativeCall `is native` hook, `proto` body dispatch, and
+`Exception.Str`-via-`message`) all sit *before* the flatten on both paths
+already, so none of them is stolen.
+
+Measured with callgrind (deterministic instruction counts, `MUTSU_JIT=off`):
+
+| benchmark | before | after | |
+| --- | --- | --- | --- |
+| `method-call` | 1,116,758,033 | 875,193,995 | **-21.6%** |
+| `bench-class` | 1,256,230,586 | 1,253,912,753 | -0.2% |
+| `word-count` | 1,120,162,872 | 1,119,097,351 | -0.1% |
+| `bench-fib` | 2,713,379,355 | 2,713,380,971 | 0.0% |
+
+Wall clock on `method-call` (best of 7, release, `MUTSU_JIT=off`) goes
+0.248 s -> 0.214 s. The change is inert wherever the gated shape does not occur,
+which is what the `bench-fib` row is there to show.
+
+`t/callmethod-env-pure-native-gate.t` pins both halves: the gated shape itself,
+the two lexical views that must still be whole after a gated call (a closure
+capture and a `MY::` read in the same frame), and the seven cases the gate must
+leave to the general path. All sixteen agree with rakudo.
+
+This does not close #7563. The guard still fires on every user-defined method
+dispatch from a scoped frame, which is where the ticket's pathology now lives —
+see the re-measurement recorded there.

--- a/src/vm/vm_call_method_mut_prenative.rs
+++ b/src/vm/vm_call_method_mut_prenative.rs
@@ -1,18 +1,24 @@
 use super::*;
 
 impl Interpreter {
-    /// Method names `exec_call_method_mut_op_impl` gives a dedicated branch
-    /// between its scoped-env flatten and its general native probe that can
-    /// apply to a plain scalar receiver: the undeclared-type `.new` check on a
-    /// `Str`, `subst-mutate`, the `hyper`/`race` configuration form, the
+    /// Method names either `CallMethod` or `CallMethodMut` gives a dedicated
+    /// branch between its scoped-env flatten and its general native probe that
+    /// can apply to a plain scalar receiver: the undeclared-type `.new` check on
+    /// a `Str`, `subst-mutate`, the `hyper`/`race` configuration form, the
     /// xxx-KEY / BIND-POS / `add`/`remove` mutators (their `Nil`/type-object
-    /// arms), the `push`-family autovivification, and the Lock/Match/WHO
-    /// arms (receiver-typed, listed for completeness). A call to any of them
-    /// keeps the full dispatch path so that branch still sees it.
-    fn mut_dispatch_branches_before_native_probe(method: &str) -> bool {
+    /// arms), the `push`-family autovivification, `VAR` (which
+    /// `exec_call_method_op_impl` hard-codes into its `skip_native` seed), and
+    /// the Lock/Match/WHO arms (receiver-typed, listed for completeness). A call
+    /// to any of them keeps the full dispatch path so that branch still sees it.
+    ///
+    /// The list is shared by both opcodes rather than split per opcode: it only
+    /// ever makes the gate MORE conservative, and a name that has a dedicated
+    /// branch on one path is not worth gating on the other.
+    fn dispatch_branches_before_native_probe(method: &str) -> bool {
         matches!(
             method,
             "new"
+                | "VAR"
                 | "WHO"
                 | "protect"
                 | "protect-or-queue-on-recursion"
@@ -45,15 +51,12 @@ impl Interpreter {
     /// vendored `Test.rakumod` assertion makes (`$desc.Str`, `$output.say`):
     ///
     /// 1. **A pure native method on an immutable scalar receiver** (`Str`,
-    ///    `Int`, `Num`, `Bool`). `try_native_method` is Rust over the value;
-    ///    an immutable receiver has no writeback, so none of the by-name or
-    ///    by-identity env scans the container mutators perform can be
-    ///    reached. Everything the general path would have decided for such a
-    ///    receiver is decided identically here: the same `quoted`/modifier
-    ///    exclusions, the same junction-argument autothreading deferral, the
-    ///    same `native_lever_a_user_override` gate (an augmented `Str.uc`
-    ///    still wins), and the methods that own a dedicated branch on the
-    ///    general path are left to it (`mut_dispatch_branches_before_native_probe`).
+    ///    `Int`, `Num`, `Bool`) -- lifted into
+    ///    [`Self::try_env_pure_scalar_native_dispatch`], which the plain
+    ///    `CallMethod` opcode shares. Everything the general path would have
+    ///    decided for such a receiver is decided identically there -- see that
+    ///    function for the exclusions and for why no dedicated pre-probe branch
+    ///    of either opcode is stolen.
     /// 2. **Text output to a native `IO::Handle`** (`print`/`put`/`say`/
     ///    `printf`/`print-nl` on an exact `IO::Handle` instance, no augmented
     ///    override). `try_native_io_handle_output` writes handle-table state
@@ -85,25 +88,16 @@ impl Interpreter {
         if modifier.is_some() || quoted {
             return None;
         }
-        if matches!(
-            target.view(),
-            ValueView::Str(_) | ValueView::Int(_) | ValueView::Num(_) | ValueView::Bool(_)
+        if let Some(result) = self.try_env_pure_scalar_native_dispatch(
+            "callmethodmut",
+            target,
+            method,
+            method_sym,
+            args,
+            modifier,
+            quoted,
         ) {
-            if Self::mut_dispatch_branches_before_native_probe(method)
-                || args
-                    .iter()
-                    .any(|a| matches!(a.view(), ValueView::Junction { .. }))
-                || self.native_lever_a_user_override(target, method)
-            {
-                return None;
-            }
-            let native_result = self.try_native_method(target, method_sym, args)?;
-            // Same bookkeeping as the general path's native completion: a
-            // value-returning native on an immutable receiver is env-pure.
-            self.method_dispatch_pure = true;
-            crate::vm::vm_stats::record_dispatch_entry_outcome("callmethodmut", "native");
-            self.shadow_check_native_row_candidate(target, method, method_sym, args.len(), true);
-            return Some(native_result);
+            return Some(result);
         }
         if let ValueView::Instance { class_name, .. } = target.view()
             && class_name == "IO::Handle"
@@ -120,5 +114,65 @@ impl Interpreter {
             return Some(result);
         }
         None
+    }
+
+    /// Case 1 of [`Self::try_env_pure_mut_dispatch`], shared with the plain
+    /// `CallMethod` opcode: **a pure native method on an immutable scalar
+    /// receiver** (`Str`, `Int`, `Num`, `Bool`), answered BEFORE either
+    /// opcode's `flatten_scoped_env` guard.
+    ///
+    /// `try_native_method` is Rust over the value; an immutable receiver has no
+    /// writeback, so none of the by-name or by-identity env scans the container
+    /// mutators perform can be reached, and nothing between the guard and the
+    /// native probe captures or iterates the env for such a receiver. Every
+    /// decision the general path would have made for it is made identically
+    /// here: the same `quoted`/modifier exclusions, the same junction-argument
+    /// autothreading deferral, the same `native_lever_a_user_override` gate (an
+    /// augmented `Str.uc` still wins), and the methods that own a dedicated
+    /// branch on either path are left to it
+    /// ([`Self::dispatch_branches_before_native_probe`]). Both paths' remaining
+    /// pre-probe branches are receiver-typed on values this arm never accepts
+    /// (`Junction`, `LazyList`, `Failure`, `Package`, `Instance`, `Array`,
+    /// `Regex`, `Proxy`), so none of them is stolen.
+    ///
+    /// `entry` is the dispatch-entry label the caller reports under
+    /// (`"callmethod"` / `"callmethodmut"`).
+    ///
+    /// Returns `None` to continue with the general path unchanged.
+    #[allow(clippy::too_many_arguments)]
+    pub(super) fn try_env_pure_scalar_native_dispatch(
+        &mut self,
+        entry: &str,
+        target: &Value,
+        method: &str,
+        method_sym: crate::symbol::Symbol,
+        args: &[Value],
+        modifier: Option<&str>,
+        quoted: bool,
+    ) -> Option<Result<Value, RuntimeError>> {
+        if modifier.is_some() || quoted {
+            return None;
+        }
+        if !matches!(
+            target.view(),
+            ValueView::Str(_) | ValueView::Int(_) | ValueView::Num(_) | ValueView::Bool(_)
+        ) {
+            return None;
+        }
+        if Self::dispatch_branches_before_native_probe(method)
+            || args
+                .iter()
+                .any(|a| matches!(a.view(), ValueView::Junction { .. }))
+            || self.native_lever_a_user_override(target, method)
+        {
+            return None;
+        }
+        let native_result = self.try_native_method(target, method_sym, args)?;
+        // Same bookkeeping as the general path's native completion: a
+        // value-returning native on an immutable receiver is env-pure.
+        self.method_dispatch_pure = true;
+        crate::vm::vm_stats::record_dispatch_entry_outcome(entry, "native");
+        self.shadow_check_native_row_candidate(target, method, method_sym, args.len(), true);
+        Some(native_result)
     }
 }

--- a/src/vm/vm_call_method_ops.rs
+++ b/src/vm/vm_call_method_ops.rs
@@ -1031,6 +1031,29 @@ impl Interpreter {
                 return Ok(());
             }
         }
+        // A pure native method on an immutable scalar receiver touches no env,
+        // so -- like the accessor read above -- it is answered before the
+        // flatten below. This is the `CallMethodMut` gate (#7554) applied to the
+        // plain opcode: `(...).sqrt` inside a method body is a `CallMethod`, and
+        // it was paying a whole-scope env clone per call (#7563). See
+        // `try_env_pure_scalar_native_dispatch` for why nothing between here and
+        // the native probe needs the flat view for such a receiver.
+        if let Some(result) = self.try_env_pure_scalar_native_dispatch(
+            "callmethod",
+            &target,
+            method,
+            method_sym,
+            &args,
+            modifier,
+            quoted,
+        ) {
+            self.stack.push(result?);
+            // The tail this early return replaces: `mark_dirty` is false for a
+            // pure dispatch (its body is empty anyway) and `hyper_race_wrap` is
+            // not yet set, so the drain is all that is left of it.
+            self.drain_and_reconcile_after_cached_call(code);
+            return Ok(());
+        }
         // Full method dispatch from here on may capture the env into a Sub /
         // closure or run an interpreter fallback that iterates it; collapse a
         // transient scoped overlay env to a flat env first so the full lexical

--- a/t/callmethod-env-pure-native-gate.t
+++ b/t/callmethod-env-pure-native-gate.t
@@ -1,0 +1,67 @@
+use Test;
+use MONKEY-TYPING;
+
+# The plain `CallMethod` opcode answers a pure native method on an immutable
+# scalar receiver before its scoped-env flatten guard (#7563), the way
+# `CallMethodMut` already did (#7554). These pin the cases the gate must NOT
+# steal from the general dispatch path, and the lexical views that must still
+# be whole after a gated call.
+
+plan 16;
+
+# --- the gated shape itself -------------------------------------------------
+class P {
+    has $.x;
+    has $.y;
+    method dist() { (($!x * $!x) + ($!y * $!y)).sqrt }
+}
+is P.new(x => 3, y => 4).dist, 5e0, 'native method on a scalar receiver inside a method body';
+
+# A gated call must not starve a later closure capture in the same frame: the
+# capture needs the whole lexical view, which the skipped flatten used to
+# materialize eagerly.
+sub capture-after-native() {
+    my $outer = 41;
+    my $n = (4e0).sqrt;          # gated: native on a Num
+    my $c = sub { $outer + $n };
+    $outer = 40;
+    $c();
+}
+is capture-after-native(), 42e0, 'a closure capture after a gated call sees the whole lexical view';
+
+# ... and neither may a pseudo-stash read.
+sub stash-after-native() {
+    my $here = 7;
+    my $ignored = (9e0).sqrt;    # gated
+    MY::<$here>;
+}
+is stash-after-native(), 7, 'MY:: after a gated call still resolves an outer-declared lexical';
+
+# --- cases the gate must leave to the general path --------------------------
+augment class Str { method shout() { self.uc ~ '!' } }
+sub augmented() { 'hi'.shout }
+is augmented(), 'HI!', 'an augmented Str method still reaches the general path';
+
+sub junction-arg() { 'abc'.contains(any('a', 'z')) }
+ok junction-arg() ~~ Junction, 'a junction argument still autothreads instead of being gated';
+
+sub quoted-name() { 'ab'."uc"() }
+is quoted-name(), 'AB', 'a quoted method name still reaches the general path';
+
+sub modifier-maybe() { 'ab'.?uc }
+is modifier-maybe(), 'AB', '.? modifier still reaches the general path';
+
+sub dot-return() { 'early'.return; 'late' }
+is dot-return(), 'early', '.return on a Str still returns from the enclosing sub';
+
+sub var-on-scalar() { my $v = 5; $v.VAR.WHAT }
+ok var-on-scalar() ~~ Scalar, '.VAR on a scalar still reaches the general path';
+
+# --- values, types, and failure modes are unchanged -------------------------
+is (2e0).sqrt, 2e0.sqrt, 'Num.sqrt';
+is 255.base(16), 'FF', 'Int.base with an argument';
+is 'Hello'.substr(1, 3), 'ell', 'Str.substr with arguments';
+is True.Int, 1, 'Bool.Int';
+is 'abc'.chars, 3, 'Str.chars';
+is (-7).abs, 7, 'Int.abs';
+dies-ok { 'abc'.no-such-method-here }, 'an unknown method on a Str still dies';


### PR DESCRIPTION
Found while re-running the kill-switch measurement #7563 asks for. The
full re-measurement is posted on that ticket; this PR is the one bounded
slice it turned up that pays on its own.

## The gap

`exec_call_method_op_impl` collapses a scoped overlay env to a flat env before
any dispatch past its pure-read accessor fast path. On a scoped env that is a
whole-scope map clone, so the cost of one method call is linear in how many
names are in scope anywhere up the stack.

`CallMethodMut` has had a gate in front of that guard since #7554 —
`try_env_pure_mut_dispatch` answers a pure native method on an immutable scalar
receiver (`Str`, `Int`, `Num`, `Bool`) without flattening, because such a
dispatch provably reaches nothing that captures or iterates the env. The plain
`CallMethod` opcode never got the same gate.

It wants one. `benchmarks/method-call.raku` — a `Point.distance-to` loop whose
body ends in `(...).sqrt` — flattened the env 10,000 times, every one of them
from `CallMethod` and every one of them resolving to `callmethod:native`, on a
`Num` receiver inside a scoped method frame. That is exactly case 1 of the
existing gate.

## The change

Case 1 becomes a shared helper, `try_env_pure_scalar_native_dispatch`, called by
both opcodes; `try_env_pure_mut_dispatch` keeps its `IO::Handle` output arm and
delegates the scalar arm. The name-exclusion list it consults grew `VAR`, which
`exec_call_method_op_impl` hard-codes into its `skip_native` seed, and is now
documented as shared by both paths rather than specific to the mut one — it only
ever makes the gate more conservative.

Why nothing is stolen from the general path: both opcodes' remaining pre-probe
branches are receiver-typed on values the arm never accepts (`Junction`,
`LazyList`, `Failure`, `Package`, `Instance`, `Array`, `Regex`, `Proxy`), and the
four that could otherwise have applied to a scalar — `.return`, the NativeCall
`is native` hook, `proto` body dispatch, and `Exception.Str`-via-`message` — all
sit *before* the flatten on both paths already. The `quoted`/modifier exclusions,
the junction-argument autothreading deferral and the
`native_lever_a_user_override` gate are the same ones the mut path applies.

## Measurement

Callgrind, deterministic instruction counts, `MUTSU_JIT=off`:

| benchmark | before | after | |
| --- | --- | --- | --- |
| `method-call` | 1,116,758,033 | 875,193,995 | **-21.6%** |
| `bench-class` | 1,256,230,586 | 1,253,912,753 | -0.2% |
| `word-count` | 1,120,162,872 | 1,119,097,351 | -0.1% |
| `bench-fib` | 2,713,379,355 | 2,713,380,971 | 0.0% |

Wall clock on `method-call` (best of 7, release): 0.248 s → 0.214 s. The
`bench-fib` row is there to show the change is inert where the gated shape does
not occur.

## Tests

`t/callmethod-env-pure-native-gate.t` (16 assertions, all agreeing with rakudo)
pins the gated shape, the two lexical views that must still be whole after a
gated call — a closure capture and a `MY::` read in the same frame — and the
cases the gate must leave to the general path: an augmented `Str` method, a
junction argument, a quoted method name, the `.?` modifier, `.return`, `.VAR`,
and an unknown method still dying.

`make test` passes (3849 files, 40785 tests). `make roast` has three failures,
all environmental and all reproducing identically on a baseline binary built
from `main`: `S16-filehandles/filetest.t` and `6.c/S32-io/file-tests.t` test
permission bits that root bypasses, and `S32-io/IO-Socket-Async.t` times out
with no outbound sockets. `make lint` is clean in all four configurations.

This does **not** close #7563 — the guard still fires on every user-defined
method dispatch from a scoped frame, which is where that ticket's pathology now
lives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012RASCtfbthPxqBcHxgPKcu

---
_Generated by [Claude Code](https://claude.ai/code/session_012RASCtfbthPxqBcHxgPKcu)_