### PR TITLE
refactor(compiler): share one shape classifier between the two bare-block compile passes

### DIFF
--- a/docs/adr/0076-bare-block-keeps-two-opcodes-one-shape.md
+++ b/docs/adr/0076-bare-block-keeps-two-opcodes-one-shape.md
@@ -1,0 +1,167 @@
+# ADR-0076: A bare block keeps two opcodes, but has one shape classifier
+
+- **Status**: Accepted
+- **Date**: 2026-09-08
+- **Related**: [GH-7569](https://github.com/tokuhirom/mutsu/issues/7569),
+  `src/compiler/block_shape.rs`, the `Stmt::Block` arm of `src/compiler/stmt.rs`,
+  `src/compiler/helpers_do_expr.rs`, `OpCode::BlockScope` / `OpCode::DoBlockExpr` /
+  `OpCode::LetBlock` in `src/opcode.rs`, `src/vm/vm_misc_scope.rs`,
+  `src/vm/vm_misc_block.rs`,
+  `news/2026-09/unify-statement-expression-control-construct-compilation.md`
+
+## 1. Context
+
+The campaign recorded in
+`news/2026-09/unify-statement-expression-control-construct-compilation.md` gave every
+statement/expression control construct a single lowering shared by both source positions:
+`for` (`src/compiler/control_for.rs`) and `if`/`elsif` (`src/compiler/control_if.rs`) each
+have one, and `while` / C-style `loop` / `lazy for` in expression position are thin
+`gather`-desugaring wrappers over the statement path.
+
+The bare `{ ... }` block was the one construct left compiled by two independent passes:
+
+- **statement position** — the `Stmt::Block` arm of `Compiler::compile_stmt`, emitting
+  `OpCode::BlockScope`;
+- **value position** — `compile_do_block_expr` / `compile_do_block_expr_scoped`, emitting
+  `OpCode::DoBlockExpr`.
+
+GH-7569 asked the question that has to be settled before any unification lands: **should
+`BlockScope` and `DoBlockExpr` be one opcode?** The two arms share neither an opcode nor a
+skeleton, which is exactly why the `for`/`if` unification did not sweep them up.
+
+## 2. Decision
+
+**Two opcodes, one shape classifier.**
+
+1. `BlockScope` and `DoBlockExpr` stay separate opcodes with separate runtime contracts
+   (§3). This is not a deferral: it is the answer.
+2. The *classification* both passes were computing independently — "what kind of block is
+   this" — becomes a single shared function,
+   [`Compiler::classify_block_shape`](../../src/compiler/block_shape.rs), returning a
+   `BlockShape` (`ImplicitTry` / `PhaserScope` / `LetBlock` / `ImportScope` / `Plain`).
+   Both passes `match` on it, in the same order, over the same case set.
+3. The per-execution `state` reset is emitted **before** the shape dispatch in both passes,
+   as an unconditional part of the skeleton rather than a per-arm decision.
+
+## 3. Why the opcodes stay separate
+
+The pair looked like duplication, but the two ops carry genuinely different runtime
+obligations, and the cheap one is by far the hot one.
+
+`BlockScope` is a **lexical scope boundary**. `exec_block_scope_op` clones the env, scans
+its own opcode range for `SetLocalDecl` / `DeclareOurScalar` / `StateVarInit` slots and for
+topic-binding ops, pushes an `outer_scope_locals` frame, a block-scope depth, a lexical
+class scope, an enum scope and a once scope, snapshots the routine registry, pushes an
+anonymous callframe when the block is a genuine source `{ ... }`, and runs seven ranges —
+PRE, ENTER, body, KEEP, UNDO, POST — which is what its seven patch points are for. It
+produces no value.
+
+`DoBlockExpr` is a **value-producing body with control-flow catching**. It pushes a once
+scope and an enum scope, optionally snapshots the routine registry (only when the body
+actually declares one), catches a matching `leave` and a `succeed` and turns each into the
+block's value, and deliberately does *not* restore the env in the common case.
+
+Merging them would mean giving every value-position block the seven-section, env-cloning,
+callframe-pushing machinery. That is the wrong direction on cost: `DoBlockExpr` is emitted
+for every `do { ... }`, every routine tail block and every string-interpolation `{ ... }`,
+so it is executed far more often than `BlockScope`, and the union variant would also have
+to carry both payloads while `size_of::<OpCode>() <= 48` stays pinned by
+`opcode_size_guard`.
+
+The reverse direction — expressing the statement form as the value form with the result
+discarded — fails on semantics rather than cost. The statement form's env restore is what
+stops a block-local `my` from leaking; the value form deliberately lets an outer mutation
+inside `do { ... }` persist (its `scope_isolate` variant exists precisely because *some*
+callers want the restore and most must not have it). Collapsing the statement form onto the
+value form would either drop the restore or impose it on every `do`.
+
+So the shared thing is not the opcode. It is the *decision* — and that is what the two
+passes were getting wrong.
+
+## 4. What the split classification actually cost
+
+Two divergences, both real bugs against Rakudo, both fixed by the shared classifier rather
+than patched individually:
+
+**The value form's `state` reset sat after its early returns.** `compile_do_block_expr`
+returned early for the CATCH/CONTROL and ENTER/LEAVE shapes, and only computed
+`emit_value_block_state_reset` on the paths below them. So a `state` counter restarted per
+execution in `do { state $n = 0; $n++; $n }` but persisted in the same block with a `CATCH`
+or an `ENTER` added:
+
+```
+sub f() { do { state $n = 0; $n++; CATCH { default {} }; $n } }
+say f(); say f(); say f();   # raku: 1 1 1   mutsu (before): 1 2 3
+```
+
+The statement form always got this right, because it computes the reset before its
+dispatch. Hoisting the value form's reset to the same place fixes both phaser shapes at
+once.
+
+Pinned by `t/block-shape-statement-value-parity.t`, whose assertions all pass under `raku`
+unchanged.
+
+The second divergence the split had hidden — the value form having no `let`/`temp` arm at
+all, so `my $x = 1; do { let $x = 2; Nil }` leaves `$x` at 2 where raku restores it to 1 —
+is **real but not fixed here**, for the reason in §5.
+
+## 5. `BlockShape::LetBlock` is a shape the value path declines
+
+The obvious completion of §4 — give `compile_do_block_expr` the `LetBlock` arm the statement
+form has — was implemented, measured against roast, and backed out. It is recorded here
+because the reason generalises well beyond `let`.
+
+**`Expr::DoBlock` is not a Raku block.** The parser and about a dozen compiler desugars use
+it as a generic "run these statements, yield a value" node: item context
+(`$( let $a = 23; $a )`), the chained-comparison desugar (`src/chain_compare.rs`), `cas`,
+compound-assignment lowering, method-body wrappers. None of those introduce a scope at which
+a `let` may resolve. Emitting a `LetBlock` for every `Expr::DoBlock` resolved the save at the
+innermost wrapper instead of the enclosing block, and broke the idiom roast leans on
+throughout:
+
+```raku
+my $a = 42;
+{
+  is($(let $a = 23; $a), 23, "let() changed the variable");
+  Mu;
+}
+is $a, 42, "let() should restore the variable, as our block failed";
+```
+
+That cost 3 subtests in `roast/S04-blocks-and-statements/let.t` and 1 in `temp.t`, both
+whitelisted. So the value path keeps `BlockShape::LetBlock` folded into its plain arm, with
+the reason stated at the fold, and `t/block-shape-statement-value-parity.t` pins the
+`$( ... )` direction so a future attempt fails loudly instead of silently.
+
+This is the sharpest evidence for §3's conclusion. The two source positions are not "the
+same construct compiled twice": one of the two opcodes stands for a **Raku block**, and the
+other stands for **a statement sequence that yields a value**, only *some* of whose
+instances are blocks. Sharing the classification is sound precisely because a shape is a
+question about the body; sharing the *response* to a shape is not, wherever the response
+depends on being a real scope.
+
+Closing the gap needs a marker distinguishing a genuine source block from a synthesized
+wrapper, carried on the AST node — tracked as
+[GH-7635](https://github.com/tokuhirom/mutsu/issues/7635). `ast.rs`'s own
+placeholder-classification comments flag the same overloading from a different angle, so the
+marker would likely pay for itself more than once.
+
+## 6. Consequences
+
+- The two passes can no longer disagree about what a block *is*. A body that is an implicit
+  `try` in one position is an implicit `try` in the other, and a shape added to
+  `BlockShape` is offered to both arms rather than to whichever one the author was editing.
+  Where an arm declines a shape (§5), that is now a stated decision at a single site rather
+  than an absence nobody had noticed.
+- The remaining differences between the arms are now exactly the ones that are genuinely
+  positional, and they are visible as such: which opcode carries the scope, whether the
+  result is pushed or discarded, the placeholder rule (statement position binds them as the
+  block's own parameters per ADR-0048 D3/D6; value position rejects them as
+  `X::Placeholder::Block`), and the statement-only setup that has no value-position
+  counterpart (`SucceedBarrier`, `seed_user_listop_shadows`, sigilless-type-name scoping).
+- The dispatch *order* is now a documented property of one enum rather than an emergent
+  property of two `if`/`else if` chains. The order is load-bearing — a body with both a
+  `CATCH` and a `use` is an implicit `try`, and the import scope is not applied — and both
+  passes have always agreed on it, so it is preserved verbatim rather than "fixed".
+- GH-7569's premise that a full opcode merge might be required is answered: it is not, and
+  a future session should not re-open it without new evidence of a cost the split imposes.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -101,3 +101,4 @@ The role of an ADR is to preserve the *context of the judgment* — something th
 | [0073](0073-regex-atom-candidates-are-demand-driven.md) | Regex atom candidates are produced on demand, driven by the continuation — an embedded code block runs once per candidate ENTERED | Proposed (Slices 1 and 3 implemented; Slice 2, the `<subrule>` boundary, open) |
 | [0074](0074-a-channel-backed-supply-broadcasts-to-its-taps.md) | A channel-backed Supply broadcasts to its taps; the receiver is not an exclusive transfer | Accepted (implemented) |
 | [0075](0075-make-test-runs-tap-on-release-binary.md) | `make test` runs the TAP (`t/`) suite on the release binary (supersedes 0014); `gc-stress`/`jit-stress` keep the debug pass | Accepted |
+| [0076](0076-bare-block-keeps-two-opcodes-one-shape.md) | A bare block keeps two opcodes (`BlockScope`/`DoBlockExpr`), but has one shared shape classifier | Accepted |

--- a/news/2026-09/bare-block-shape-classifier.md
+++ b/news/2026-09/bare-block-shape-classifier.md
@@ -1,0 +1,94 @@
+# A bare block's shape is decided once, not once per compile pass
+
+A bare `{ ... }` block was the last control construct compiled by two fully
+independent passes: the `Stmt::Block` arm of `Compiler::compile_stmt` for
+statement position, and `compile_do_block_expr` for value position. The
+`for`/`if` unification recorded in
+`unify-statement-expression-control-construct-compilation.md` did not sweep the
+block pair up, because those two constructs shared a single opcode and a single
+skeleton and the block forms share neither — statement position emits
+`OpCode::BlockScope`, value position `OpCode::DoBlockExpr`.
+
+GH-7569 asked whether those two opcodes should be merged. The answer, recorded in
+[ADR-0076](../../docs/adr/0076-bare-block-keeps-two-opcodes-one-shape.md), is no.
+They carry genuinely different runtime contracts — `BlockScope` is a lexical
+scope boundary that clones the env, pushes an `$OUTER::` frame and an anonymous
+callframe, and runs seven PRE/ENTER/body/KEEP/UNDO/POST ranges; `DoBlockExpr` is
+a value-producing body that catches `leave`/`succeed` and deliberately does *not*
+restore the env. Merging them would impose the seven-section machinery on the far
+hotter of the two, since every `do { ... }`, every routine tail block and every
+string-interpolation `{ ... }` goes through `DoBlockExpr`.
+
+What genuinely was duplicated is the *classification*: whether the block is an
+implicit `try`, whether it needs a phaser block scope, whether it has
+`let`/`temp`, whether it scopes imports. Each pass computed that separately, in a
+different order and over a different case set, and each wrote its own answer.
+That is now one shared function — `Compiler::classify_block_shape` in
+`src/compiler/block_shape.rs`, returning a `BlockShape` both passes `match` on.
+
+Sharing it fixed two divergences from Rakudo, neither of which was reachable from
+the position that had the logic right.
+
+**A `state` in a `do` block stopped restarting as soon as the block grew a
+phaser.** The value form emitted its per-execution `ResetStateLocals` only on the
+paths *below* its CATCH/CONTROL and ENTER/LEAVE early returns, so:
+
+```raku
+sub f() { do { state $n = 0; $n++; CATCH { default {} }; $n } }
+say f(); say f(); say f();   # raku: 1 1 1   mutsu was: 1 2 3
+```
+
+The same block without the `CATCH` restarted correctly, and so did both
+statement-position spellings — the statement arm computes the reset before its
+dispatch. The value arm now does too, which fixes the CATCH and the ENTER shapes
+together.
+
+**A `do` block never rolls back a `let`** -- and that one is *not* fixed here.
+`Stmt::Block` has a `has_let_deep` branch emitting `OpCode::LetBlock`; the
+value form has no such arm, so `my $x = 1; do { let $x = 2; Nil }` leaves `$x`
+at 2 where raku restores it to 1. Adding the arm was the obvious completion, and
+it was implemented, run against roast, and backed out.
+
+The reason generalises well past `let`. **`Expr::DoBlock` is not a Raku block.**
+The parser and about a dozen compiler desugars use it as a generic "run these
+statements, yield a value" node -- item context (`$( let $a = 23; $a )`), the
+chained-comparison desugar, `cas`, compound-assignment lowering, method-body
+wrappers -- and none of those introduce a scope at which a `let` may resolve.
+Emitting a `LetBlock` for every `Expr::DoBlock` resolved the save at the
+innermost wrapper instead of the enclosing block, which broke the idiom roast
+leans on throughout:
+
+```raku
+my $a = 42;
+{
+  is($(let $a = 23; $a), 23, "let() changed the variable");
+  Mu;
+}
+is $a, 42, "let() should restore the variable, as our block failed";
+```
+
+That cost 3 subtests in `roast/S04-blocks-and-statements/let.t` and 1 in
+`temp.t`, both whitelisted. So the value path folds `BlockShape::LetBlock` into
+its plain arm with the reason stated at the fold, and the test file pins the
+`$( ... )` direction so a future attempt fails loudly rather than silently. The
+genuine `do { let ... }` gap is filed as GH-7635; closing it needs a marker
+distinguishing a real source block from a synthesized wrapper on the AST node
+itself.
+
+This is the sharpest evidence for the two-opcode decision. The two positions are
+not "the same construct compiled twice": one opcode stands for a *Raku block*,
+the other for *a statement sequence that yields a value*, only some of whose
+instances are blocks. Sharing the classification is sound because a shape is a
+question about the body; sharing the *response* to a shape is not, wherever that
+response depends on being a real scope.
+
+`t/block-shape-statement-value-parity.t` pins both halves -- the `state` restart
+in every value-position shape, and the `$( ... )` `let` scoping -- and all 12
+assertions pass unchanged under `raku`.
+
+The differences that remain between the two arms are now exactly the positional
+ones — which opcode carries the scope, whether the result is pushed or discarded,
+the placeholder rule (statement position binds them as the block's own parameters
+per ADR-0048 D3/D6, value position rejects them as `X::Placeholder::Block`), and
+the statement-only setup with no value-position counterpart (`SucceedBarrier`,
+`seed_user_listop_shadows`, sigilless-type-name scoping).

--- a/src/compiler/block_shape.rs
+++ b/src/compiler/block_shape.rs
@@ -1,0 +1,56 @@
+//! The single classification of a `{ ... }` block body's shape.
+//!
+//! A bare block is compiled by two passes — the `Stmt::Block` arm of
+//! [`Compiler::compile_stmt`](crate::compiler::Compiler::compile_stmt) for
+//! statement position, and
+//! [`Compiler::compile_do_block_expr`](crate::compiler::Compiler::compile_do_block_expr)
+//! for value position. They emit different opcodes for the scope itself
+//! (`BlockScope` vs `DoBlockExpr`, see `docs/adr/0076-bare-block-keeps-two-opcodes-one-shape.md`
+//! for why that stays), but the question "*what kind* of block is this" has one
+//! answer, and each pass used to compute it separately — in a different order,
+//! with a different set of cases. That is how the value form ended up with no
+//! `let`/`temp` handling at all, and with its per-execution `state` reset
+//! computed *after* the CATCH/phaser early-returns rather than before them
+//! (`news/2026-09/bare-block-shape-classifier.md`).
+//!
+//! Both passes now dispatch on [`BlockShape`], so a body that is an implicit
+//! `try` in one position is an implicit `try` in the other by construction.
+
+use super::*;
+
+/// What a `{ ... }` body needs wrapped around it, independent of whether the
+/// block appears in statement or value position.
+///
+/// The variant order is the dispatch order, and it is significant: a body with
+/// both a `CATCH` and a `use` is an implicit `try` (the import scope is not
+/// applied), because that is what both passes have always done.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum BlockShape {
+    /// Contains `CATCH`/`CONTROL`: the block is an implicit `try`.
+    ImplicitTry,
+    /// Contains `ENTER`/`LEAVE`/`KEEP`/`UNDO`: needs a real phaser block scope.
+    PhaserScope,
+    /// Contains `let`/`temp`: needs `LetBlock` save/restore.
+    LetBlock,
+    /// Contains `use`: imports are lexical to this block.
+    ImportScope,
+    /// Nothing special.
+    Plain,
+}
+
+impl Compiler {
+    /// Classify a block body. See [`BlockShape`] for why the order matters.
+    pub(super) fn classify_block_shape(stmts: &[Stmt]) -> BlockShape {
+        if Self::has_catch_or_control(stmts) {
+            BlockShape::ImplicitTry
+        } else if Self::has_block_enter_leave_phasers(stmts) {
+            BlockShape::PhaserScope
+        } else if Self::has_let_deep(stmts) {
+            BlockShape::LetBlock
+        } else if Self::has_use_stmt(stmts) {
+            BlockShape::ImportScope
+        } else {
+            BlockShape::Plain
+        }
+    }
+}

--- a/src/compiler/helpers_do_expr.rs
+++ b/src/compiler/helpers_do_expr.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::compiler::block_shape::BlockShape;
 
 impl Compiler {
     pub(super) fn compile_do_block_expr(&mut self, body: &[Stmt], label: &Option<String>) {
@@ -64,56 +65,84 @@ impl Compiler {
             }
             return;
         }
-        // If the do block contains CATCH/CONTROL, compile as try so exceptions are handled.
-        if Self::has_catch_or_control(body) {
-            self.compile_implicit_try(body);
-            return;
-        }
-        // If the do block contains ENTER/LEAVE/KEEP/UNDO phasers, wrap in
-        // DoBlockExpr + BlockScope so phaser semantics are preserved.
-        if Self::has_block_enter_leave_phasers(body) {
-            let do_idx = self.code.emit(OpCode::DoBlockExpr {
-                body_end: 0,
-                label: label.clone(),
-                scope_isolate: false,
-                isolate_decls_idx: u32::MAX,
-                scope_routines: Self::stmts_declare_routines(body),
-            });
-            let saved = self.push_dynamic_scope_lexical();
-            self.compile_phaser_block_scope(body, PhaserBlockResult::Push);
-            self.pop_dynamic_scope_lexical(saved);
-            self.code.patch_body_end(do_idx);
-            return;
-        }
-        // An import is lexical to the block that asked for it, and a `do {}`
-        // block is a block: `my (&plan) = do { use Test; (&plan) }` must take
-        // the routines it names as values and leave everything else the module
-        // exports out of the enclosing scope (roast/S32-list/skip.t imports
-        // selectively precisely so the CORE `skip` stays visible). The
-        // statement-form bare block already does this in `Stmt::Block`.
-        let import_scoped = Self::has_use_stmt(body);
-        if import_scoped {
-            self.code.emit(OpCode::PushImportScope);
-        }
         // A value-position block (`do { … }`, a routine's tail `{ … }`, a
         // string-interpolation `{ … }`) is a block literal re-cloned every time
         // its ENCLOSING block runs, so its own `state` restarts per execution —
         // see `OpCode::ResetStateLocals`. This is what makes raku's documented
         // trap `sub count-it { say "Count is {$++}" }` print `0` every call.
+        //
+        // Emitted BEFORE the shape dispatch, exactly as the statement form does
+        // it in `Stmt::Block`. It used to sit after the CATCH/phaser arms'
+        // early returns, so `do { state $n = 0; $n++; CATCH {…}; $n }` counted
+        // 1, 2, 3 across calls where the same block without the `CATCH` — and
+        // the statement-position spelling of either — correctly restarted at 1.
         let state_reset = self.emit_value_block_state_reset(body);
-        let idx = self.code.emit(OpCode::DoBlockExpr {
-            body_end: 0,
-            label: label.clone(),
-            scope_isolate: false,
-            isolate_decls_idx: u32::MAX,
-            scope_routines: Self::stmts_declare_routines(body),
-        });
-        self.compile_block_inline(body);
-        self.code.patch_body_end(idx);
-        self.patch_nested_block_state_reset(state_reset);
-        if import_scoped {
-            self.code.emit(OpCode::PopImportScope);
+        // The shape decision is shared with the statement-position form
+        // (`Stmt::Block`) so the two passes cannot disagree about what this
+        // block is — see `BlockShape`.
+        match Self::classify_block_shape(body) {
+            // Compile as try so exceptions are handled.
+            BlockShape::ImplicitTry => {
+                self.compile_implicit_try(body);
+            }
+            // Wrap in DoBlockExpr + BlockScope so phaser semantics are preserved.
+            BlockShape::PhaserScope => {
+                let do_idx = self.code.emit(OpCode::DoBlockExpr {
+                    body_end: 0,
+                    label: label.clone(),
+                    scope_isolate: false,
+                    isolate_decls_idx: u32::MAX,
+                    scope_routines: Self::stmts_declare_routines(body),
+                });
+                let saved = self.push_dynamic_scope_lexical();
+                self.compile_phaser_block_scope(body, PhaserBlockResult::Push);
+                self.pop_dynamic_scope_lexical(saved);
+                self.code.patch_body_end(do_idx);
+            }
+            // `BlockShape::LetBlock` is deliberately NOT taken here, and falls
+            // through to the plain arm: `Expr::DoBlock` is not a Raku block.
+            // The parser and a dozen compiler desugars use it as a generic
+            // "run these statements, yield a value" node — item context
+            // (`$( let $a = 23; $a )`), the chained-comparison desugar, `cas`,
+            // compound-assignment lowering — and NONE of those introduce a
+            // scope a `let` may resolve at. Making this arm emit its own
+            // `LetBlock` resolved the save at the innermost wrapper instead of
+            // the enclosing block, so roast's
+            // `{ is($(let $a = 23; $a), 23, …); Mu }` stopped restoring `$a`
+            // (S04-blocks-and-statements/let.t, temp.t).
+            //
+            // A genuine source `do { let $x = 2; Nil }` therefore still fails
+            // to roll back, matching the behaviour that predates the shared
+            // classifier. Fixing it needs a marker distinguishing a real source
+            // block from a synthesized wrapper on the AST node itself — see
+            // GH-7635 and ADR-0076 §5.
+            shape @ (BlockShape::LetBlock | BlockShape::ImportScope | BlockShape::Plain) => {
+                // An import is lexical to the block that asked for it, and a
+                // `do {}` block is a block: `my (&plan) = do { use Test;
+                // (&plan) }` must take the routines it names as values and
+                // leave everything else the module exports out of the enclosing
+                // scope (roast/S32-list/skip.t imports selectively precisely so
+                // the CORE `skip` stays visible). The statement-form bare block
+                // already does this in `Stmt::Block`.
+                let import_scoped = shape == BlockShape::ImportScope;
+                if import_scoped {
+                    self.code.emit(OpCode::PushImportScope);
+                }
+                let idx = self.code.emit(OpCode::DoBlockExpr {
+                    body_end: 0,
+                    label: label.clone(),
+                    scope_isolate: false,
+                    isolate_decls_idx: u32::MAX,
+                    scope_routines: Self::stmts_declare_routines(body),
+                });
+                self.compile_block_inline(body);
+                self.code.patch_body_end(idx);
+                if import_scoped {
+                    self.code.emit(OpCode::PopImportScope);
+                }
+            }
         }
+        self.patch_nested_block_state_reset(state_reset);
     }
 
     /// [`Compiler::emit_nested_block_state_reset`] for a value-position block,

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -1103,6 +1103,7 @@ mod declaration_plan_tests {
     }
 }
 mod adverb_interp;
+mod block_shape;
 mod const_fold;
 mod control_for;
 mod control_if;

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::compiler::block_shape::BlockShape;
 use crate::symbol::Symbol;
 use crate::value::ValueView;
 
@@ -1076,89 +1077,99 @@ impl Compiler {
                 let state_reset = (is_bare && !suppress_loop_reset)
                     .then(|| self.emit_nested_block_state_reset(stmts))
                     .flatten();
-                if Self::has_catch_or_control(stmts) {
-                    self.next_try_is_bare_block = is_bare;
-                    self.compile_implicit_try(stmts);
-                    self.next_try_is_bare_block = false;
-                    self.code.emit(OpCode::Pop);
-                } else if Self::has_block_enter_leave_phasers(stmts) {
-                    self.compile_phaser_block_scope(stmts, PhaserBlockResult::Discard);
-                } else if Self::has_let_deep(stmts) {
-                    // Block contains `let`/`temp` — wrap in LetBlock for save/restore
-                    let idx = self.code.emit(OpCode::LetBlock { body_end: 0 });
-                    // Raku's "declarations are in effect at block start" rule
-                    // (see `hoist_typed_var_decls`).
-                    self.hoist_typed_var_decls(stmts);
-                    let needs_topic = Self::has_real_let_deep(stmts);
-                    for (i, s) in stmts.iter().enumerate() {
-                        let is_last = i == stmts.len() - 1;
-                        if is_last && needs_topic {
-                            // For `let` blocks, set topic from the last statement's
-                            // value so we can check success/failure
-                            self.compile_last_stmt_as_topic(s);
-                        } else {
+                // The shape decision is shared with the value-position form
+                // (`compile_do_block_expr`) so the two passes cannot disagree
+                // about what this block is — see `BlockShape`.
+                match Self::classify_block_shape(stmts) {
+                    BlockShape::ImplicitTry => {
+                        self.next_try_is_bare_block = is_bare;
+                        self.compile_implicit_try(stmts);
+                        self.next_try_is_bare_block = false;
+                        self.code.emit(OpCode::Pop);
+                    }
+                    BlockShape::PhaserScope => {
+                        self.compile_phaser_block_scope(stmts, PhaserBlockResult::Discard);
+                    }
+                    BlockShape::LetBlock => {
+                        // Block contains `let`/`temp` — wrap in LetBlock for save/restore.
+                        // The statement form has no value on the stack, so the
+                        // success decision reads the topic (see `OpCode::LetBlock`).
+                        let idx = self.code.emit(OpCode::LetBlock { body_end: 0 });
+                        // Raku's "declarations are in effect at block start" rule
+                        // (see `hoist_typed_var_decls`).
+                        self.hoist_typed_var_decls(stmts);
+                        let needs_topic = Self::has_real_let_deep(stmts);
+                        for (i, s) in stmts.iter().enumerate() {
+                            let is_last = i == stmts.len() - 1;
+                            if is_last && needs_topic {
+                                // For `let` blocks, set topic from the last statement's
+                                // value so we can check success/failure
+                                self.compile_last_stmt_as_topic(s);
+                            } else {
+                                self.compile_stmt(s);
+                            }
+                        }
+                        self.code.patch_let_block_end(idx);
+                    }
+                    BlockShape::ImportScope => {
+                        // Block contains `use` — wrap with import scope save/restore
+                        // so imports are lexically scoped to this block
+                        self.code.emit(OpCode::PushImportScope);
+                        // Raku's "declarations are in effect at block start" rule
+                        // (see `hoist_typed_var_decls`).
+                        self.hoist_typed_var_decls(stmts);
+                        for s in stmts {
                             self.compile_stmt(s);
                         }
+                        self.code.emit(OpCode::PopImportScope);
                     }
-                    self.code.patch_let_block_end(idx);
-                } else if Self::has_use_stmt(stmts) {
-                    // Block contains `use` — wrap with import scope save/restore
-                    // so imports are lexically scoped to this block
-                    self.code.emit(OpCode::PushImportScope);
-                    // Raku's "declarations are in effect at block start" rule
-                    // (see `hoist_typed_var_decls`).
-                    self.hoist_typed_var_decls(stmts);
-                    for s in stmts {
-                        self.compile_stmt(s);
-                    }
-                    self.code.emit(OpCode::PopImportScope);
-                } else {
-                    // Plain blocks still create a lexical routine scope.
-                    // `BlockScope` snapshots env before the body and restores
-                    // it after (dropping any new env key), so a `my TYPE $x`
-                    // compiled while this flag is set can safely use the
-                    // env-only SetVarTypeScoped opcode — see
-                    // `lexically_in_block`'s doc comment.
-                    let saved_lexically_in_block =
-                        std::mem::replace(&mut self.lexically_in_block, true);
-                    let idx = self.code.emit(OpCode::BlockScope {
-                        pre_end: 0,
-                        enter_end: 0,
-                        body_end: 0,
-                        keep_start: 0,
-                        undo_start: 0,
-                        post_start: 0,
-                        end: 0,
-                        is_bare_block: is_bare,
-                    });
-                    self.code.patch_block_pre_end(idx);
-                    self.code.patch_block_enter_end(idx);
-                    // Raku's `my` declarations are visible for the entire
-                    // enclosing block, even though the value is only
-                    // (re-)initialized when execution reaches the declaration
-                    // statement. mutsu's per-routine local-slot storage
-                    // (`alloc_local` reuses the slot for a same-named
-                    // declaration) means a block's own `my $x` only shadows a
-                    // same-named outer local once its VarDecl statement
-                    // actually runs — so a hoisted nested `sub` invoked (via
-                    // forward reference) before that point would wrongly
-                    // observe the OUTER value instead of an undefined one.
-                    // Reset such shadowing slots to Nil right at block entry,
-                    // before hoisting nested subs, so the shadow is visible
-                    // from the very start of the block (roast
-                    // S04-declarations/my-6e.t: "declared below the calling
-                    // position"). Scoped narrowly to blocks that actually
-                    // declare a nested `sub` (the only way to observe the
-                    // early value) and to plain `$`-sigil scalars, to avoid
-                    // clobbering a lingering type constraint that a sibling
-                    // block left on a reused `@`/`%` slot (e.g. `my Int @a`
-                    // followed later by an untyped `my @a` sharing the slot —
-                    // an unconditional Nil reset there would fail the typed
-                    // slot's type check; a real initializer's value normally
-                    // satisfies it, so only the premature reset is unsafe).
-                    if stmts.iter().any(|s| matches!(s, Stmt::SubDecl { .. })) {
-                        for s in stmts.iter() {
-                            if let Stmt::VarDecl {
+                    BlockShape::Plain => {
+                        // Plain blocks still create a lexical routine scope.
+                        // `BlockScope` snapshots env before the body and restores
+                        // it after (dropping any new env key), so a `my TYPE $x`
+                        // compiled while this flag is set can safely use the
+                        // env-only SetVarTypeScoped opcode — see
+                        // `lexically_in_block`'s doc comment.
+                        let saved_lexically_in_block =
+                            std::mem::replace(&mut self.lexically_in_block, true);
+                        let idx = self.code.emit(OpCode::BlockScope {
+                            pre_end: 0,
+                            enter_end: 0,
+                            body_end: 0,
+                            keep_start: 0,
+                            undo_start: 0,
+                            post_start: 0,
+                            end: 0,
+                            is_bare_block: is_bare,
+                        });
+                        self.code.patch_block_pre_end(idx);
+                        self.code.patch_block_enter_end(idx);
+                        // Raku's `my` declarations are visible for the entire
+                        // enclosing block, even though the value is only
+                        // (re-)initialized when execution reaches the declaration
+                        // statement. mutsu's per-routine local-slot storage
+                        // (`alloc_local` reuses the slot for a same-named
+                        // declaration) means a block's own `my $x` only shadows a
+                        // same-named outer local once its VarDecl statement
+                        // actually runs — so a hoisted nested `sub` invoked (via
+                        // forward reference) before that point would wrongly
+                        // observe the OUTER value instead of an undefined one.
+                        // Reset such shadowing slots to Nil right at block entry,
+                        // before hoisting nested subs, so the shadow is visible
+                        // from the very start of the block (roast
+                        // S04-declarations/my-6e.t: "declared below the calling
+                        // position"). Scoped narrowly to blocks that actually
+                        // declare a nested `sub` (the only way to observe the
+                        // early value) and to plain `$`-sigil scalars, to avoid
+                        // clobbering a lingering type constraint that a sibling
+                        // block left on a reused `@`/`%` slot (e.g. `my Int @a`
+                        // followed later by an untyped `my @a` sharing the slot —
+                        // an unconditional Nil reset there would fail the typed
+                        // slot's type check; a real initializer's value normally
+                        // satisfies it, so only the premature reset is unsafe).
+                        if stmts.iter().any(|s| matches!(s, Stmt::SubDecl { .. })) {
+                            for s in stmts.iter() {
+                                if let Stmt::VarDecl {
                                 name,
                                 is_state: false,
                                 is_our: false,
@@ -1177,66 +1188,67 @@ impl Compiler {
                                 && !name.contains("::")
                                 && let Some(&slot) = self.local_map.get(name.as_str())
                                 && !custom_traits.iter().any(|(t, _)| t == "__constant")
-                            {
-                                self.code.emit(OpCode::LoadNil);
-                                self.code.emit(OpCode::SetLocal(slot));
-                            }
-                        }
-                    }
-                    // Hoist sub declarations: register subs first so forward
-                    // references like `&fa` work before the sub is textually
-                    // declared (Raku sub hoisting semantics).
-                    // Strip non-internal custom traits during hoisting — types/roles
-                    // may not be registered yet; traits are applied during the normal pass.
-                    for s in stmts.iter() {
-                        if let Stmt::SubDecl { .. } = s {
-                            let mut hoisted = s.clone();
-                            if let Stmt::SubDecl { custom_traits, .. } = &mut hoisted {
-                                custom_traits.retain(|(t, _)| {
-                                    t.starts_with("__")
-                                        || t == "default"
-                                        || t.starts_with("DEPRECATED")
-                                });
-                                // Mark this copy as a hoist-pass registration,
-                                // exactly as `hoist_sub_decls` does for the
-                                // value-position (inline) block path. Without the
-                                // marker the pre-pass looked like a real
-                                // declaration, and an `our multi` inside a
-                                // statement-form bare block hit the "Cannot
-                                // declare individual multi candidates in 'our'
-                                // scope" check here — before the block's own
-                                // `our proto` had run. The in-sequence
-                                // registration below runs after the proto and
-                                // enforces the check for real.
-                                if !custom_traits.iter().any(|(t, _)| t == "__lexical_hoist") {
-                                    custom_traits.push(("__lexical_hoist".to_string(), None));
-                                }
-                                if !custom_traits.iter().any(|(t, _)| t == "__hoisted") {
-                                    custom_traits.push(("__hoisted".to_string(), None));
+                                {
+                                    self.code.emit(OpCode::LoadNil);
+                                    self.code.emit(OpCode::SetLocal(slot));
                                 }
                             }
-                            self.compile_stmt(&hoisted);
                         }
+                        // Hoist sub declarations: register subs first so forward
+                        // references like `&fa` work before the sub is textually
+                        // declared (Raku sub hoisting semantics).
+                        // Strip non-internal custom traits during hoisting — types/roles
+                        // may not be registered yet; traits are applied during the normal pass.
+                        for s in stmts.iter() {
+                            if let Stmt::SubDecl { .. } = s {
+                                let mut hoisted = s.clone();
+                                if let Stmt::SubDecl { custom_traits, .. } = &mut hoisted {
+                                    custom_traits.retain(|(t, _)| {
+                                        t.starts_with("__")
+                                            || t == "default"
+                                            || t.starts_with("DEPRECATED")
+                                    });
+                                    // Mark this copy as a hoist-pass registration,
+                                    // exactly as `hoist_sub_decls` does for the
+                                    // value-position (inline) block path. Without the
+                                    // marker the pre-pass looked like a real
+                                    // declaration, and an `our multi` inside a
+                                    // statement-form bare block hit the "Cannot
+                                    // declare individual multi candidates in 'our'
+                                    // scope" check here — before the block's own
+                                    // `our proto` had run. The in-sequence
+                                    // registration below runs after the proto and
+                                    // enforces the check for real.
+                                    if !custom_traits.iter().any(|(t, _)| t == "__lexical_hoist") {
+                                        custom_traits.push(("__lexical_hoist".to_string(), None));
+                                    }
+                                    if !custom_traits.iter().any(|(t, _)| t == "__hoisted") {
+                                        custom_traits.push(("__hoisted".to_string(), None));
+                                    }
+                                }
+                                self.compile_stmt(&hoisted);
+                            }
+                        }
+                        // Raku's `my TYPE $x` is in effect for the WHOLE block, not
+                        // just from its textual position, so an earlier statement
+                        // that reaches the name (an `EVAL '$x = ...'`, a nested sub
+                        // called before the declaration) must already see the
+                        // constraint. The value-position/inline block path does this
+                        // in `compile_block_inline`; this statement-position
+                        // `BlockScope` path did not, so the very same block silently
+                        // lost its declared types just because a statement followed
+                        // it (`t/typed-decl-hoist-block-forms.t`).
+                        self.hoist_typed_var_decls(stmts);
+                        for s in stmts {
+                            self.compile_stmt(s);
+                        }
+                        self.code.patch_block_body_end(idx);
+                        self.code.patch_block_keep_start(idx);
+                        self.code.patch_block_undo_start(idx);
+                        self.code.patch_block_post_start(idx);
+                        self.code.patch_loop_end(idx);
+                        self.lexically_in_block = saved_lexically_in_block;
                     }
-                    // Raku's `my TYPE $x` is in effect for the WHOLE block, not
-                    // just from its textual position, so an earlier statement
-                    // that reaches the name (an `EVAL '$x = ...'`, a nested sub
-                    // called before the declaration) must already see the
-                    // constraint. The value-position/inline block path does this
-                    // in `compile_block_inline`; this statement-position
-                    // `BlockScope` path did not, so the very same block silently
-                    // lost its declared types just because a statement followed
-                    // it (`t/typed-decl-hoist-block-forms.t`).
-                    self.hoist_typed_var_decls(stmts);
-                    for s in stmts {
-                        self.compile_stmt(s);
-                    }
-                    self.code.patch_block_body_end(idx);
-                    self.code.patch_block_keep_start(idx);
-                    self.code.patch_block_undo_start(idx);
-                    self.code.patch_block_post_start(idx);
-                    self.code.patch_loop_end(idx);
-                    self.lexically_in_block = saved_lexically_in_block;
                 }
                 self.sigilless_locals.retain(|n| {
                     sigilless_type_names_before.contains(n)

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -2711,6 +2711,12 @@ pub(crate) enum OpCode {
 
     /// Block with `let` scope management. Executes body, then checks
     /// the topic ($_) to decide whether to restore or discard let saves.
+    ///
+    /// Only the statement-position bare block emits this: its compile site
+    /// routes the block's last statement through the topic
+    /// (`compile_last_stmt_as_topic`), which is what makes the `$_` read here
+    /// the block's own value. The value-position form deliberately does not —
+    /// `Expr::DoBlock` is not a Raku block (see `compile_do_block_expr`).
     LetBlock {
         body_end: u32,
     },

--- a/t/block-shape-statement-value-parity.t
+++ b/t/block-shape-statement-value-parity.t
@@ -1,0 +1,66 @@
+use Test;
+
+# A bare `{ ... }` block is compiled by two passes -- `Stmt::Block` for
+# statement position and `compile_do_block_expr` for value position -- and both
+# used to decide independently what kind of block they were looking at. This
+# file pins the cases where the two answers disagreed; both passes now dispatch
+# on the shared `BlockShape` classifier. See GH-7569 and
+# docs/adr/0076-bare-block-keeps-two-opcodes-one-shape.md.
+
+plan 12;
+
+# --- per-execution `state` restart -------------------------------------------
+# A block literal is re-cloned every time its ENCLOSING block runs, so its own
+# `state` restarts per execution. The value form computed that reset only AFTER
+# its CATCH / phaser early-returns, so adding a `CATCH` or an `ENTER` to an
+# otherwise identical `do` block silently turned the counter into a persistent
+# one.
+
+sub plain-do() { do { state $n = 0; $n++; $n } }
+is plain-do(), 1, 'do { state } restarts on the first call';
+is plain-do(), 1, 'do { state } restarts on the second call';
+
+sub catch-do() { do { state $n = 0; $n++; CATCH { default { } }; $n } }
+is catch-do(), 1, 'do { state; CATCH } restarts on the first call';
+is catch-do(), 1, 'do { state; CATCH } restarts on the second call';
+
+sub enter-do() { do { state $n = 0; $n++; ENTER { }; $n } }
+is enter-do(), 1, 'do { state; ENTER } restarts on the first call';
+is enter-do(), 1, 'do { state; ENTER } restarts on the second call';
+
+# The statement-position spellings always did the right thing; pin them so the
+# shared classifier cannot regress that direction either.
+my $stmt-catch;
+sub catch-stmt() { { state $n = 0; $n++; $stmt-catch = $n; CATCH { default { } } } }
+catch-stmt();
+catch-stmt();
+is $stmt-catch, 1, '{ state; CATCH } as a statement restarts per execution';
+
+my $stmt-enter;
+sub enter-stmt() { { state $n = 0; $n++; $stmt-enter = $n; ENTER { } } }
+enter-stmt();
+enter-stmt();
+is $stmt-enter, 1, '{ state; ENTER } as a statement restarts per execution';
+
+# --- `let`/`temp` stays a statement-position shape -------------------------
+# `BlockShape::LetBlock` exists in the shared classifier but the value path
+# declines it on purpose: `Expr::DoBlock` is not a Raku block -- item context
+# (`$( ... )`), the chained-comparison desugar, `cas` and compound-assignment
+# lowering all use the same node, and none of them may resolve a `let`. Pin the
+# idiom roast relies on: the `let` inside `$( ... )` belongs to the enclosing
+# block, so that block's exit is what restores it.
+# (A genuine `do { let $x = 2; Nil }` does not roll back yet -- GH-7635.)
+
+my $item-ctx = 42;
+{
+    is $(let $item-ctx = 23; $item-ctx), 23, 'let inside $( ) takes effect there';
+    Mu;
+}
+is $item-ctx, 42, 'let inside $( ) is restored by the ENCLOSING block, not by $( )';
+
+my @arr = (0, 1, 2);
+{
+    is $(let @arr[1] = 42; @arr[1]), 42, 'let on an array element inside $( )';
+    Mu;
+}
+is @arr[1], 1, 'let on an array element is restored by the enclosing block';


### PR DESCRIPTION
A bare `{ ... }` block was the last control construct compiled by two fully independent passes: the `Stmt::Block` arm of `compile_stmt` for statement position (emitting `OpCode::BlockScope`) and `compile_do_block_expr` for value position (emitting `OpCode::DoBlockExpr`). Both decided the same things about the body — implicit try, phaser scope, `let`/`temp`, import scope, per-execution `state` reset — and each wrote its own answer, in a different order and over a different case set.

## The opcode question, answered

GH-7569 asked what has to be settled before any unification lands: **should `BlockScope` and `DoBlockExpr` be one opcode?** [ADR-0076](https://github.com/tokuhirom/mutsu/blob/claude/mutsu-issue-7569-offd89/docs/adr/0076-bare-block-keeps-two-opcodes-one-shape.md) records the answer as **no**, with the reasoning.

The two ops carry genuinely different runtime contracts. `BlockScope` is a lexical scope boundary: it clones the env, scans its own opcode range for owned/state slots and topic-binding ops, pushes an `outer_scope_locals` frame, a block-scope depth, a lexical class scope and an enum scope, snapshots the routine registry, pushes an anonymous callframe for a genuine source block, and runs seven PRE/ENTER/body/KEEP/UNDO/POST ranges. `DoBlockExpr` is a value-producing body that catches `leave`/`succeed` and deliberately does *not* restore the env.

Merging them would impose the seven-section, env-cloning machinery on the far hotter of the two — every `do { ... }`, every routine tail block and every string-interpolation `{ ... }` goes through `DoBlockExpr` — while the union variant would also have to carry both payloads under the pinned `size_of::<OpCode>() <= 48`. The reverse direction fails on semantics: the statement form's env restore is what stops a block-local `my` from leaking, and the value form must not have it.

## What was actually duplicated

The *classification*, not the opcode. That moves into one shared `Compiler::classify_block_shape` (`src/compiler/block_shape.rs`) returning a `BlockShape` both passes `match` on, in the same order, over the same case set.

Sharing it fixes a divergence from Rakudo that was unreachable from the position which had the logic right. The value form emitted its per-execution `ResetStateLocals` only on the paths *below* its CATCH/CONTROL and ENTER/LEAVE early returns, so a `state` counter restarted correctly in a plain `do` block but persisted as soon as the same block grew a phaser:

```raku
sub f() { do { state $n = 0; $n++; CATCH { default {} }; $n } }
say f(); say f(); say f();   # raku: 1 1 1   mutsu (before): 1 2 3
```

Both statement-position spellings were already correct — that arm computes the reset before its dispatch. The value arm now does too, which fixes the CATCH and the ENTER shapes together.

The statement-side change is a mechanical `if`/`else if` → `match` conversion with identical arm bodies, so that path is behaviour-identical.

## A shape the value path declines, and why

`BlockShape::LetBlock` is deliberately folded into the value path's plain arm. Giving `compile_do_block_expr` the `let` arm the statement form has was the obvious completion — it was implemented, measured against roast, and backed out.

**`Expr::DoBlock` is not a Raku block.** The parser and about a dozen compiler desugars use it as a generic "run these statements, yield a value" node: item context (`$( let $a = 23; $a )`), the chained-comparison desugar, `cas`, compound-assignment lowering, method-body wrappers. None of those introduce a scope at which a `let` may resolve. Emitting a `LetBlock` for every `Expr::DoBlock` resolved the save at the innermost wrapper instead of the enclosing block, and broke the idiom roast leans on throughout:

```raku
my $a = 42;
{
  is($(let $a = 23; $a), 23, "let() changed the variable");
  Mu;
}
is $a, 42, "let() should restore the variable, as our block failed";
```

That cost 3 subtests in `roast/S04-blocks-and-statements/let.t` and 1 in `temp.t`, both whitelisted. So the value path declines the shape with the reason stated at the fold, and the new test pins the `$( ... )` direction so a future attempt fails loudly rather than silently. The genuine `do { let $x = 2; Nil }` gap this leaves is real and filed as #7635 — closing it needs a marker distinguishing a real source block from a synthesized wrapper on the AST node itself.

`src/vm/` and `src/opcode.rs` are consequently back to `main` apart from one clarified doc comment; the diff is compiler-side.

## Tests

`t/block-shape-statement-value-parity.t` — 12 assertions covering the `state` restart in every value-position shape and the `$( ... )` `let` scoping. **All 12 pass unchanged under `raku`.**

## Verification

| | result |
| --- | --- |
| `cargo fmt --all` | clean |
| `make lint` (all four configurations) | green |
| `make test` | 3853 files, 40839 tests, **PASS** |
| `make roast` | 1436 files, 218939 tests — only the three container-only failures documented in `docs/agent-environments.md` (`file-tests.t` 4 and `filetest.t` 25, both `uid 0`; `IO-Socket-Async.t`, sandboxed network), matching the documented counts exactly |

Closes #7569

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JLq8g9GoujE4i6STRxeD1v

---
_Generated by [Claude Code](https://claude.ai/code/session_01JLq8g9GoujE4i6STRxeD1v)_