### PR TITLE
fix(compiler): restart a nested block's state in a value-position for

### DIFF
--- a/news/2026-09/nested-block-state-restarts-in-a-value-position-for.md
+++ b/news/2026-09/nested-block-state-restarts-in-a-value-position-for.md
@@ -1,0 +1,47 @@
+# A nested block's `state` restarts inside a value-position `for`
+
+```raku
+my @r = do for ^3 { { state $x = 0; $x++ } };
+say @r;   # mutsu: [0 1 2]    raku: [0 0 0]
+```
+
+`state` restart semantics are decided by block *cloning*: the inner `{ ... }` is
+a block literal that the loop body re-clones on every iteration, so its `state`
+starts over each time. mutsu models this with a compile-time
+`OpCode::ResetStateLocals` bracket rather than by actually re-cloning the block,
+and `compile_bare_block_inline` is the function that emits it.
+
+The value-collecting `for` body compiled its tail statement through
+`compile_stmts_value`, whose `Stmt::Block` arm called the raw
+`compile_block_inline` — which inlines the block's statements with no bracket at
+all. `compile_block_inline`'s *own* tail-`Block` arm has always routed to
+`compile_bare_block_inline`; the value path was simply the one place that did
+not, which is why every neighbouring case already behaved. The statement-position
+form (`for ^3 { { state $x = 0; ... } }`), a value-position block outside a loop
+(`sub g { do { { state $x = 0; ... } } }`) and even a *doubly* nested block in a
+value-position `for` were all correct, the last one because only the outermost
+nested block reached the broken arm.
+
+The arm now mirrors its sibling: a genuine source `{ ... }` in tail position goes
+through `compile_bare_block_inline`, and a block carrying ENTER/LEAVE/KEEP/UNDO
+phasers goes through `compile_phaser_block_scope` so the phasers still run
+against a real block scope.
+
+Getting this right had to leave the opposite case alone. A *sole-block*
+statement-modifier body (`{ state $n = 0; $n++ } for 1..3`) is not a nested
+block: that block **is** the loop's body, cloned once for the whole loop, so its
+`state` must persist across iterations and still yields `0 1 2`. So must the loop
+body's own non-nested `state`. `t/state-nested-block-value-position-for.t` pins
+both directions together — three restart cases, two persist cases, and one that
+a tail block carrying a `LEAVE` still runs it and still yields its value — and
+the file passes unchanged on rakudo.
+
+One neighbouring divergence is *not* fixed here and was verified to predate this
+change: a nested block that carries a phaser does not restart its `state` at all
+(`do for ^2 { { LEAVE { }; state $q = 0; $q++ } }` gives `[0 1]` where raku gives
+`[0 0]`), because `compile_phaser_block_scope` emits no reset bracket of its own.
+That function is shared with `if`/`unless` branches and several other callers,
+which have their own `state` rules, so bracketing it is a wider change than this
+ticket. It is filed as #7632.
+
+Closes #7585.

--- a/src/compiler/helpers_control_flow.rs
+++ b/src/compiler/helpers_control_flow.rs
@@ -74,7 +74,25 @@ impl Compiler {
                         binding_var,
                         *is_statement_modifier,
                     ),
-                    Stmt::Block(inner) => self.compile_block_inline(inner),
+                    // A genuine source `{ ... }` in tail position is a block
+                    // literal the enclosing block re-clones on every run, so its
+                    // own `state` restarts per execution. That is what
+                    // `compile_bare_block_inline` adds over the raw inline
+                    // compile (an `OpCode::ResetStateLocals` bracket, plus the
+                    // `PushBlockFrame` that makes it an anonymous callframe in a
+                    // backtrace); calling the raw one here made the value-
+                    // collecting `for` body the one path that kept a nested
+                    // block's `state` across iterations, so
+                    // `do for ^3 { { state $x = 0; $x++ } }` gave `[0 1 2]`
+                    // where raku gives `[0 0 0]`. `compile_block_inline`'s own
+                    // tail arm already routes this way — this mirrors it.
+                    Stmt::Block(inner) => {
+                        if Self::has_block_enter_leave_phasers(inner) {
+                            self.compile_phaser_block_scope(inner, PhaserBlockResult::Push);
+                        } else {
+                            self.compile_bare_block_inline(inner);
+                        }
+                    }
                     Stmt::SyntheticBlock(inner) => self.compile_synthetic_block_inline(inner),
                     Stmt::VarDecl { name, .. } => {
                         self.compile_stmt(stmt);

--- a/t/state-nested-block-value-position-for.t
+++ b/t/state-nested-block-value-position-for.t
@@ -1,0 +1,60 @@
+use Test;
+
+plan 6;
+
+# `state` restart is decided by block CLONING: a nested `{ ... }` inside a loop
+# body is a block literal the body re-clones on every iteration, so its `state`
+# restarts each time. mutsu models that with an `OpCode::ResetStateLocals`
+# bracket, emitted by `compile_bare_block_inline`.
+#
+# The value-collecting `for` body (`do for ... { ... }`) compiled its tail
+# `Stmt::Block` through the raw `compile_block_inline`, which emits no such
+# bracket, so it was the one path where a nested block's `state` survived across
+# iterations.
+
+{
+    my @r = do for ^3 { { state $x = 0; $x++ } };
+    is-deeply @r, [0, 0, 0],
+        'a nested block in a value-position for restarts its state each iteration';
+}
+
+# The statement-position form was already correct -- keep it that way.
+{
+    my @r;
+    for ^3 { { state $x = 0; @r.push($x++) } }
+    is-deeply @r, [0, 0, 0],
+        'a nested block in a statement-position for restarts its state each iteration';
+}
+
+# ... as was a value-position block outside any loop.
+{
+    my sub g { do { { state $x = 0; $x++ } } }
+    is-deeply [g(), g()], [0, 0],
+        'a nested block in a value-position do restarts its state each call';
+}
+
+# The sole-block statement-modifier form is the OPPOSITE case and must not
+# regress: there the block IS the loop's body, cloned once for the whole loop,
+# so its state persists across iterations.
+{
+    my @r;
+    { state $n = 0; @r.push($n++) } for 1..3;
+    is-deeply @r, [0, 1, 2],
+        'a sole-block loop body keeps its state across iterations';
+}
+
+# The loop body's own (non-nested) state likewise persists.
+{
+    my @r = do for ^3 { state $w = 0; $w++ };
+    is-deeply @r, [0, 1, 2],
+        "a value-position for body's own state persists across iterations";
+}
+
+# Routing the tail block through the bare-block compile must not drop a phaser
+# it carries, nor the value it yields.
+{
+    my @log;
+    my @r = do for ^2 { { LEAVE { @log.push('L') }; 'v' } };
+    is-deeply [@r, @log], [['v', 'v'], ['L', 'L']],
+        'a tail block carrying a LEAVE still runs it and still yields its value';
+}


### PR DESCRIPTION
```raku
my @r = do for ^3 { { state $x = 0; $x++ } };
say @r;   # mutsu: [0 1 2]    raku: [0 0 0]
```

## Root cause

`state` restart is decided by block *cloning*: a nested `{ ... }` inside a loop body is a block literal the body re-clones on every iteration, so its `state` starts over each time. mutsu models that with a compile-time `OpCode::ResetStateLocals` bracket, which `compile_bare_block_inline` emits.

`compile_stmts_value` — the value-collecting `for` body path — compiled its tail `Stmt::Block` through the raw `compile_block_inline`, which inlines the block's statements with no bracket at all. `compile_block_inline`'s *own* tail-`Block` arm has always routed to `compile_bare_block_inline`; the value path was simply the one place that did not.

That asymmetry is why every neighbouring case already passed — including a *doubly* nested block, where only the outermost block reaches the broken arm. The issue's own note that this is not `suppress_loop_block_state_reset` was correct.

## Fix

The arm now mirrors its sibling: a genuine source block goes through `compile_bare_block_inline`, and one carrying ENTER/LEAVE/KEEP/UNDO phasers goes through `compile_phaser_block_scope` so the phasers still run against a real block scope.

## Verification

Six shapes were compared against rakudo v2026.07, and the fix had to move the first without disturbing the rest — two of them are the *opposite* rule:

| shape | expected | note |
|---|---|---|
| `do for ^3 { { state $x = 0; $x++ } }` | `[0 0 0]` | the bug |
| `for ^3 { { state $x = 0; ... } }` | `0 0 0` | statement position, already correct |
| `sub g { do { { state $x = 0; $x++ } } }` | `0 0` | value position outside a loop, already correct |
| `{ state $n = 0; $n++ } for 1..3` | `[0 1 2]` | **must persist** — the block IS the loop body, cloned once |
| `do for ^3 { state $w = 0; $w++ }` | `[0 1 2]` | **must persist** — the body's own non-nested state |
| `do for ^2 { { LEAVE {…}; 'v' } }` | value and phaser both preserved | the new phaser route |

`t/state-nested-block-value-position-for.t` pins all six and passes unchanged on rakudo. `t/state-var-per-block-clone.t` and 54 other `state`/`for`/`loop` files still pass.

- `cargo fmt --all`; `make lint`: exit 0 across all four configurations (this container needed `rustup target add wasm32-unknown-unknown` first)
- `make test`: 3854 files, 40838 tests, `Result: PASS`
- `make roast`: 1436 files, 218939 tests. Failures are only the three documented environment-only files, matching `docs/agent-environments.md` by name and subtest range (`6.c/S32-io/file-tests.t` 6-8/10 and `S16-filehandles/filetest.t` 57-64/69-72/77-80/101-125 from running as `uid 0`; `S32-io/IO-Socket-Async.t` exit 124 from the network sandbox). The other three summary rows are `TODO passed` with `Failed: 0`.

## Deliberately not fixed here

A nested block that *carries a phaser* does not restart its `state` at all (`do for ^2 { { LEAVE { }; state $q = 0; $q++ } }` gives `[0 1]` where raku gives `[0 0]`), because `compile_phaser_block_scope` emits no bracket of its own. This was measured on the commit **before** this change and gave `[0 1]` there too, so it predates the fix rather than being caused by it. That function is shared with `if`/`unless` branches, which have the opposite rule for statement modifiers, so bracketing it is a wider change — filed as #7632.

Closes #7585.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014zqc6o7emGLDGXUp8knhMy

---
_Generated by [Claude Code](https://claude.ai/code/session_014zqc6o7emGLDGXUp8knhMy)_