### PR TITLE
fix(parser): distribute a hyper assignment's RHS across a list-of-lvalues target

### DIFF
--- a/news/2026-09/hyper-assign-list-target-distribution.md
+++ b/news/2026-09/hyper-assign-list-target-distribution.md
@@ -1,0 +1,59 @@
+# A hyper assignment into a list of lvalues now distributes its RHS
+
+`($x, $y) »=» 5` died with `Index out of range. Is: 1, should be in 0..0`
+where raku broadcasts the `5` into both targets. Every *other* hyper target
+already broadcast a scalar RHS — `@a »=» 7` and `%h »=» 7` fill every slot —
+so a literal list of lvalues was the one shape that could not take one.
+
+## Root cause
+
+`lower_hyper_assign_target` lowered a literal list of lvalues by *positional
+index into the RHS*: element `i` of the target was assigned
+`Expr::Index { target: source, index: i }`. That is a second, much weaker
+implementation of the hyper distribution rule, and it got three things wrong
+at once:
+
+- a scalar RHS became `5[1]`, an out-of-range index rather than a broadcast;
+- a short RHS padded with `Any` (`($x, $y, $z) »=» (5, 6)` gave `(5, 6, Any)`)
+  instead of cycling to raku's `(5, 6, 5)`;
+- a length mismatch under a non-dwimmy right arrow truncated silently
+  (`($x, $y) »=« (5, 6, 7)` gave `(5, 6)`) instead of raising
+  `X::HyperOp::NonDWIM`.
+
+The element-wise lowering itself is not the problem — it is what makes nested
+sublists work (`(($a, ($b, $c)), $d) »=« ((4, (5, 6)), 7)`, pinned by
+`t/hyper-assign-nested-destructuring.t`). Only its source of elements was.
+
+## The fix
+
+The RHS is now distributed across the target's shape *before* the
+destructuring walk, by the ordinary hyper machinery: the lowering binds a
+shape temp holding the target read back, then a second temp holding
+`HyperOp { op: "=", left: shape, right: value }` with the same dwim arrows.
+`»=»`'s leaf op yields its right operand, so that hyper op is exactly the
+distribution and nothing else — the dwim rules, the cycling, and the
+`X::HyperOp::NonDWIM` error all come from the one shared implementation in
+`hyper_op_pair`. The destructuring below it is then a plain positional walk
+over an already correctly-sized list.
+
+Reading the target back is what supplies the shape, and it is what makes a
+listy target element behave: raku fills `@a` in `(@a, $x) »=» 5` with one `5`
+per existing element, which only a runtime read of `@a` can know. The one leaf
+that cannot be read is a target element that *declares* its variable
+(`(my $a, my $b) »=» (1, 2)`); it stands in as a scalar placeholder, which is
+what a freshly declared scalar contributes anyway.
+
+The RHS still evaluates exactly once — it is the distribution's right operand,
+bound to a temp before any target is touched.
+
+## Also fixed
+
+The assignment's own value was the last element stored, not the distributed
+list: `my $r = (($x, $y) »=» (5, 6))` yielded `6` where raku yields `$(5, 6)`.
+The distributed list is now a named temp, so yielding it is what the lowered
+block ends with.
+
+`t/hyper-assign-list-target-distribution.t` pins all of it, and passes under
+rakudo as well as mutsu.
+
+Closes [#7586](https://github.com/tokuhirom/mutsu/issues/7586).

--- a/src/parser/expr/precedence_meta_ops/hyper_concat.rs
+++ b/src/parser/expr/precedence_meta_ops/hyper_concat.rs
@@ -124,6 +124,30 @@ fn parse_hyper_op(input: &str) -> Option<(String, bool, bool, usize)> {
     None
 }
 
+/// Build the *shape* operand for a hyper assignment into a literal list of
+/// lvalues.
+///
+/// `»=»`'s leaf op yields its right operand, so the left operand's values never
+/// reach the result -- only its shape does, and that shape is what the dwim
+/// rules measure. Reading the target back is the shape: a listy leaf carries
+/// its own length, which is why raku fills `@a` in `(@a, $x) »=» 5` with one
+/// `5` per existing element rather than a single one.
+///
+/// One leaf cannot be read: a target element that *declares* its variable
+/// (`(my $a, my $b) »=» (1, 2)`) has nothing to read yet, and evaluating the
+/// declaration here would run it twice. Such a leaf stands in as a scalar
+/// placeholder, which is exactly what a freshly declared scalar contributes.
+fn hyper_assign_shape(target: &Expr) -> Expr {
+    match target {
+        Expr::Grouped(inner) => hyper_assign_shape(inner),
+        Expr::ArrayLiteral(items) => {
+            Expr::ArrayLiteral(items.iter().map(hyper_assign_shape).collect())
+        }
+        Expr::DoStmt(_) => Expr::Literal(crate::value::Value::NIL),
+        other => other.clone(),
+    }
+}
+
 fn lower_hyper_assign_target(target: Expr, source: Expr) -> Expr {
     match target {
         Expr::Grouped(inner) => lower_hyper_assign_target(*inner, source),
@@ -169,25 +193,58 @@ fn lower_hyper_assignment(target: Expr, value: Expr, dwim_left: bool, dwim_right
             dwim_right,
         };
     }
-    let temp_name = format!(
-        "__mutsu_hyper_assign_{}",
-        TMP_INDEX_COUNTER.fetch_add(1, Ordering::Relaxed)
-    );
+    let index = TMP_INDEX_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let shape_name = format!("__mutsu_hyper_shape_{}", index);
+    let temp_name = format!("__mutsu_hyper_assign_{}", index);
+    // Distribute the RHS across the target's shape BEFORE destructuring it, so
+    // the destructuring below is a plain positional walk over an already
+    // correctly-sized list. Indexing the raw RHS instead re-implemented the
+    // distribution rule with a bare `source[i]`, which made a scalar RHS
+    // (`($x, $y) »=» 5`, a broadcast in raku) an out-of-range index, a short
+    // list pad with Any instead of cycling, and a non-dwim length mismatch
+    // truncate silently instead of raising X::HyperOp::NonDWIM.
+    //
+    // `»=»`'s leaf yields its right operand, so this hyper op is exactly the
+    // distribution and nothing else. Its left operand is the shape temp rather
+    // than the target itself because the compiler routes an assignment hyper op
+    // over a literal list of lvalues through `__mutsu_assign_callable_lvalue`,
+    // which cannot reach nested sublists; the write-back it emits for a plain
+    // scalar left just re-stores the shape temp, which is inert.
+    //
+    // The RHS still evaluates exactly once: it is this hyper op's right
+    // operand, and the result is bound to a temp before any target is touched.
+    let distributed = Expr::HyperOp {
+        op: "=".to_string(),
+        left: Box::new(Expr::Var(shape_name.clone())),
+        right: Box::new(value),
+        dwim_left,
+        dwim_right,
+    };
+    let temp_decl = |name: String, expr: Expr| crate::ast::Stmt::VarDecl {
+        name,
+        expr,
+        type_constraint: None,
+        is_state: false,
+        is_our: false,
+        is_dynamic: false,
+        is_export: false,
+        export_tags: Vec::new(),
+        custom_traits: Vec::new(),
+        where_constraint: None,
+    };
     Expr::DoBlock {
         body: vec![
-            crate::ast::Stmt::VarDecl {
-                name: temp_name.clone(),
-                expr: value,
-                type_constraint: None,
-                is_state: false,
-                is_our: false,
-                is_dynamic: false,
-                is_export: false,
-                export_tags: Vec::new(),
-                custom_traits: Vec::new(),
-                where_constraint: None,
-            },
-            crate::ast::Stmt::Expr(lower_hyper_assign_target(target, Expr::Var(temp_name))),
+            temp_decl(shape_name, hyper_assign_shape(&target)),
+            temp_decl(temp_name.clone(), distributed),
+            crate::ast::Stmt::Expr(lower_hyper_assign_target(
+                target,
+                Expr::Var(temp_name.clone()),
+            )),
+            // The assignment's own value is the distributed list, not the last
+            // element stored: `my $r = (($x, $y) »=» (5, 6))` is `$(5, 6)` in
+            // raku. The temp is itemized by its `my $` declaration, which is
+            // the itemization raku shows.
+            crate::ast::Stmt::Expr(Expr::Var(temp_name)),
         ],
         label: None,
     }

--- a/t/hyper-assign-list-target-distribution.t
+++ b/t/hyper-assign-list-target-distribution.t
@@ -1,0 +1,80 @@
+use Test;
+
+# A hyper assignment into a literal list of lvalues distributes its RHS across
+# the target's shape with the ordinary hyper dwim rules, exactly like every
+# other hyper target. It used to index the RHS positionally instead, which made
+# a scalar RHS an out-of-range index and a short list pad with Any.
+
+plan 12;
+
+{
+    my ($x, $y);
+    ($x, $y) »=» 5;
+    is "$x,$y", "5,5", 'a scalar RHS broadcasts across a list of lvalues';
+}
+
+{
+    my ($x, $y);
+    ($x, $y) «=» 5;
+    is "$x,$y", "5,5", 'a scalar RHS broadcasts when both sides dwim';
+}
+
+{
+    my ($a, $b, $c);
+    (($a, $b), $c) »=» 9;
+    is "$a,$b,$c", "9,9,9", 'a scalar RHS broadcasts into nested sublists';
+}
+
+{
+    my ($x, $y, $z);
+    ($x, $y, $z) »=» (5, 6);
+    is "$x,$y,$z", "5,6,5", 'a short dwimmy RHS cycles instead of padding with Any';
+}
+
+{
+    my ($x, $y);
+    ($x, $y) »=» (5, 6, 7);
+    is "$x,$y", "5,6", 'a long dwimmy RHS is truncated to the target shape';
+}
+
+{
+    my ($x, $y);
+    ($x, $y) »=» (5, 6);
+    is "$x,$y", "5,6", 'an equal-length RHS still assigns element-wise';
+}
+
+# The arrows decide which side may adapt: only `»` on the right lets the RHS
+# grow or shrink to the target's length.
+throws-like { EVAL 'my ($x, $y); ($x, $y) «=« 5' }, X::HyperOp::NonDWIM,
+    'a scalar RHS under a non-dwimmy right arrow is X::HyperOp::NonDWIM';
+
+throws-like { EVAL 'my ($x, $y); ($x, $y) »=« (5, 6, 7)' }, X::HyperOp::NonDWIM,
+    'a length mismatch under a non-dwimmy right arrow is X::HyperOp::NonDWIM';
+
+{
+    my @a = 1, 2, 3;
+    my $x;
+    (@a, $x) »=» 5;
+    is "@a[]/$x", "5 5 5/5", 'a listy target element takes one broadcast value per slot';
+}
+
+{
+    my ($x, $y);
+    ($x, $y) «=» ();
+    ok !$x.defined && !$y.defined, 'an empty RHS leaves every target undefined';
+}
+
+# The assignment's own value is the distributed list, not the last element
+# stored.
+{
+    my ($x, $y);
+    my $r = (($x, $y) »=» (5, 6));
+    is $r.raku, '$(5, 6)', 'a list-target hyper assignment evaluates to the distributed list';
+}
+
+{
+    my ($a, $b);
+    my $evaluations = 0;
+    ($a, $b) »=» do { $evaluations++; 7 };
+    is "$a,$b/$evaluations", "7,7/1", 'a broadcast RHS is still evaluated exactly once';
+}


### PR DESCRIPTION
`($x, $y) »=» 5` died with `Index out of range. Is: 1, should be in 0..0`
where raku broadcasts the `5` into both targets. Every *other* hyper target
already broadcast a scalar RHS — `@a »=» 7` and `%h »=» 7` fill every slot — so
a literal list of lvalues was the one shape that could not take one.

## Root cause

`lower_hyper_assign_target` lowered a literal list of lvalues by *positional
index into the RHS*: element `i` of the target was assigned
`Expr::Index { target: source, index: i }`. That is a second, much weaker
implementation of the hyper distribution rule, and it got three things wrong at
once:

| case | before | raku |
|---|---|---|
| `my ($x,$y); ($x,$y) »=» 5` | `Index out of range` | `(5, 5)` |
| `my ($x,$y,$z); ($x,$y,$z) »=» (5,6)` | `(5, 6, Any)` | `(5, 6, 5)` |
| `my ($x,$y); ($x,$y) »=« (5,6,7)` | `(5, 6)` (silent truncation) | `X::HyperOp::NonDWIM` |
| `my @a=1,2,3; my $x; (@a,$x) »=» 5` | `Index out of range` | `([5, 5, 5], 5)` |

The element-wise lowering itself is not the problem — it is what makes nested
sublists work (`(($a, ($b, $c)), $d) »=« ((4, (5, 6)), 7)`, pinned by
`t/hyper-assign-nested-destructuring.t`). Only its source of elements was.

## The fix

The RHS is now distributed across the target's shape *before* the destructuring
walk, by the ordinary hyper machinery: the lowering binds a shape temp holding
the target read back, then a second temp holding
`HyperOp { op: "=", left: shape, right: value }` with the same dwim arrows.
`»=»`'s leaf op yields its right operand, so that hyper op is exactly the
distribution and nothing else — the dwim rules, the cycling and the
`X::HyperOp::NonDWIM` error all come from the one shared implementation in
`hyper_op_pair`. The destructuring below it is then a plain positional walk over
an already correctly-sized list. This is shape (1) from the issue: it removes
the second implementation of the distribution rule rather than adding one.

Its left operand is the shape *temp* rather than the target itself because the
compiler routes an assignment hyper op over a literal list of lvalues through
`__mutsu_assign_callable_lvalue`, which cannot reach nested sublists; the
write-back it emits for a plain scalar left just re-stores the shape temp,
which is inert.

Reading the target back is what supplies the shape, and it is also what makes a
listy target element behave — raku fills `@a` in `(@a, $x) »=» 5` with one `5`
per existing element, which only a runtime read of `@a` can know. The one leaf
that cannot be read is a target element that *declares* its variable
(`(my $a, my $b) »=» (1, 2)`); it stands in as a scalar placeholder, which is
what a freshly declared scalar contributes anyway.

The RHS still evaluates exactly once — it is the distribution's right operand,
bound to a temp before any target is touched (subtest 3 of
`t/hyper-assign-nested-destructuring.t` asserts this, and the new pin repeats it
for the broadcast case).

## Also fixed

The assignment's own value was the last element stored, not the distributed
list: `my $r = (($x, $y) »=» (5, 6))` yielded `6` where raku yields `$(5, 6)`.
Now that the distributed list is a named temp, yielding it is what the lowered
block ends with.

## Tests

`t/hyper-assign-list-target-distribution.t` — 12 subtests covering broadcast
under each arrow pair, cycling, truncation, both `X::HyperOp::NonDWIM` shapes,
nested sublists, a listy target element, an empty RHS, the expression's own
value, and evaluate-once. It passes under **`raku` as well as `mutsu`**, so it
is a spec pin rather than a mutsu-shaped one.

`cargo fmt --all`, `make lint`, `make test` (PASS) and `make roast` were all run
locally. `make roast`'s only red files are the three environment-only ones this
container cannot pass, with exactly the shapes documented in
`docs/agent-environments.md` (`6.c/S32-io/file-tests.t` 6-8/10 and
`S16-filehandles/filetest.t` under `uid 0`; `S32-io/IO-Socket-Async.t` timing out
in the network sandbox).

Closes #7586

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TAdHjoCdB8QjLBEDy87tXS

---
_Generated by [Claude Code](https://claude.ai/code/session_01TAdHjoCdB8QjLBEDy87tXS)_