### PR TITLE
perf(vm): order the method-exit merge's filter arms by cost

### DIFF
--- a/news/2026-09/method-exit-merge-filter-order.md
+++ b/news/2026-09/method-exit-merge-filter-order.md
@@ -1,0 +1,69 @@
+# The method-exit merge asked the expensive question first
+
+`bench-ctor`'s round 7 (issue #7568). Rounds 5 and 6 each found the same shape
+of bug — work that a flat profile hides because it is spread across
+`malloc`/`hashbrown`/`memcmp` rather than concentrated in one hot symbol. This
+round's is a third instance, and the cheapest yet to fix: **`merge_method_env`
+ran its string-predicate battery before the O(1) test that drops most of the
+keys it was asked about.**
+
+Every non-pure method return merges the callee's scoped env overlay back into
+the caller's. A nested method call *flattens* that overlay, so the callee's
+overlay carries a copy of every parent lexical and global — `%*ENV`, `@*ARGS`,
+`$*OUT`, `$*CWD`, the type names in scope, `=pod`, the caller's own lexicals.
+The filter that decides what merges had two independent `return None` arms:
+
+1. **the frame-key predicate** — is this key frame state (a param, a compiled
+   local, `self`/`?CLASS`, an attribute twigil form, an index-rw temp, a
+   `__mutsu_type::` marker, ...) that must not leak to the caller? Every arm
+   needs the key back as a *string*: a `Symbol::as_str()` thread-local round
+   trip, then a scan of the frame's params/locals/`env_only_decls` by name, plus
+   a live attribute-map read guard for the twigil check.
+2. **the inherited-entry test** — is the caller already holding exactly this
+   value? One `Env::get_sym` (Symbol-keyed) plus `cheaply_unchanged`, an O(1)
+   pointer/scalar compare.
+
+(1) ran first, so every inherited entry paid the whole battery before (2) threw
+it away. On `benchmarks/bench-ctor.raku` the overlay carries ~24 keys per method
+call and (2) alone accounts for ~19 of them.
+
+Both arms `return None`, so which fires first cannot change the outcome for any
+key — only what it costs to reach it. Swapping them is a pure reordering.
+
+## Measured
+
+Whole-bench instruction count, `benchmarks/bench-ctor.raku` (5000
+constructions, release, callgrind — this container has no `perf`, and
+callgrind's counts are deterministic, which is what a perf iteration wants
+anyway): **1,464,985,648 -> 1,371,782,759, −6.4%** (293k -> 274k instructions
+per construction).
+
+The three symbols that carried the removed work all left the profile's top
+list: `call_compiled_method_fast::{{closure}}` (the predicate body, 3.07%),
+`Symbol::with_str` (1.22%) and `__memcmp_avx2_movbe` (1.53%).
+
+Interleaved same-session wall-clock A/B (release builds of `main` and of this
+change, alternating, `taskset -c 2`, best of 9):
+
+| benchmark | before | after |
+|---|---|---|
+| `bench-ctor`  | 0.417s | 0.404s (−3.1%) |
+| `bench-class` | 0.268s | 0.263s (−2.0%) |
+| `method-call` | 0.243s | 0.222s (−8.5%) |
+
+The wall delta is smaller than the instruction delta because what went away was
+cache-friendly (repeat scans over strings already resolved and hot). This is not
+a `bench-ctor`-specific fix: every non-pure method return in every program pays
+this merge, which is why `method-call` moves the most. Wall-clock confirmation
+belongs to the bench CI (`bench-history.tsv` on `bench-data`), per the ticket's
+measurement notes.
+
+## Lesson, alongside rounds 5 and 6
+
+Rounds 5 and 6 warned that a flat profile can hide a per-call *compile* and
+per-call *name re-derivation*. This one adds: it can also hide a **filter whose
+arms are in the wrong order**. Nothing here was doing unnecessary work in
+isolation — every predicate was needed by some key — but 80% of the keys were
+answered by the arm that ran last. When a `filter_map` has several independent
+early-outs, order them by cost, and say so in a comment so the next edit does
+not silently undo it.

--- a/src/vm/vm_method_dispatch.rs
+++ b/src/vm/vm_method_dispatch.rs
@@ -2379,6 +2379,36 @@ fn merge_method_env(
             if is_unwritten_capture(*k, v) {
                 return None;
             }
+            // An entry the callee overlay merely *inherited* would merge back a
+            // value the caller already holds. A nested method call flattens the
+            // scoped overlay, copying every parent lexical/global into the
+            // callee's (the same reason the `changed_caller_locals` scan below
+            // exists), so `submethod TWEAK(:$!spec) { }` -- an empty body --
+            // collected 26 of these on every call: `%*ENV`, `@*ARGS`, `$*OUT`,
+            // `$*CWD`, the type names in scope, `=pod`, and the caller's own
+            // lexicals. Re-inserting a value `cheaply_unchanged` proves identical
+            // is a no-op, so drop it here instead: it keeps the `writes` Vec
+            // empty and spares the caller env's `cow_mut` overlay clone.
+            //
+            // This cannot change `changed_caller_locals`: that scan pushes a key
+            // only when `saved.get_sym(k)` is absent or `cheaply_unchanged` is
+            // false, i.e. exactly the entries this test keeps.
+            //
+            // Ordered FIRST, ahead of the frame-key predicate below, because it
+            // is the cheap test that drops most keys: one Symbol-keyed
+            // `Env::get_sym` plus an O(1) compare, against a battery of string
+            // predicates that each need `Symbol::as_str()` (a thread-local
+            // round trip) and then scan the frame's params/locals/attributes by
+            // name. Both arms `return None`, so which one fires first cannot
+            // change the outcome for any key -- only how much it costs to reach
+            // it. On `benchmarks/bench-ctor.raku` the overlay carries ~24 keys
+            // per method call and this test alone accounts for ~19 of them.
+            if saved
+                .get_sym(*k)
+                .is_some_and(|old| cheaply_unchanged(old, v))
+            {
+                return None;
+            }
             // Skip keys introduced by the method frame (params, self, attributes,
             // locals) -- these must not leak back into the caller. The membership
             // test is a call-site predicate over the frame's params/locals/attr
@@ -2414,26 +2444,6 @@ fn merge_method_env(
                     // instead of the global map).
                     || s.strip_prefix("__mutsu_type::").is_some_and(is_method_local)
             }) {
-                return None;
-            }
-            // An entry the callee overlay merely *inherited* would merge back a
-            // value the caller already holds. A nested method call flattens the
-            // scoped overlay, copying every parent lexical/global into the
-            // callee's (the same reason the `changed_caller_locals` scan below
-            // exists), so `submethod TWEAK(:$!spec) { }` -- an empty body --
-            // collected 26 of these on every call: `%*ENV`, `@*ARGS`, `$*OUT`,
-            // `$*CWD`, the type names in scope, `=pod`, and the caller's own
-            // lexicals. Re-inserting a value `cheaply_unchanged` proves identical
-            // is a no-op, so drop it here instead: it keeps the `writes` Vec
-            // empty and spares the caller env's `cow_mut` overlay clone.
-            //
-            // This cannot change `changed_caller_locals`: that scan pushes a key
-            // only when `saved.get_sym(k)` is absent or `cheaply_unchanged` is
-            // false, i.e. exactly the entries this test keeps.
-            if saved
-                .get_sym(*k)
-                .is_some_and(|old| cheaply_unchanged(old, v))
-            {
                 return None;
             }
             let keep = saved.contains_key_sym(*k)


### PR DESCRIPTION
`bench-ctor` round 7 (#7568), slice 1.

## The finding

`merge_method_env` decides which of a returning method's overlay keys merge back into the caller. Its `filter_map` had two independent `return None` arms, and ran the expensive one first:

1. **the frame-key predicate** — is this key frame state (a param, a compiled local, `self`/`?CLASS`, an attribute twigil form, an index-rw temp, a `__mutsu_type::` marker, …)? Every arm needs the key back as a *string*: a `Symbol::as_str()` thread-local round trip, then a scan of the frame's params/locals/`env_only_decls` by name, plus a live attribute-map read guard for the twigil check.
2. **the inherited-entry test** — is the caller already holding exactly this value? One Symbol-keyed `Env::get_sym` plus `cheaply_unchanged`, an O(1) pointer/scalar compare.

A nested method call *flattens* the scoped overlay, so the callee's overlay carries a copy of every parent lexical and global — `%*ENV`, `@*ARGS`, `$*OUT`, `$*CWD`, the type names in scope, `=pod`, the caller's own lexicals. Those inherited entries are precisely what (2) drops — and every one of them paid the whole of (1) first. On `benchmarks/bench-ctor.raku` the overlay carries ~24 keys per method call and (2) alone accounts for ~19 of them.

## Why the swap is safe

Both arms `return None`, so which one fires first cannot change the outcome for any key — only what it costs to reach it. `Env::get_sym` is a read through `&Env` with no side effects. The comment now states the ordering rationale so a later edit does not silently undo it.

## Measured

`benchmarks/bench-ctor.raku`, 5000 constructions, release, **callgrind** (this container has no `perf`; callgrind's counts are deterministic, which is what a perf iteration wants anyway):

**1,464,985,648 → 1,371,782,759 instructions, −6.4%** (293k → 274k per construction).

The three symbols carrying the removed work all left the profile's top list: `call_compiled_method_fast::{{closure}}` (the predicate body, 3.07%), `Symbol::with_str` (1.22%), `__memcmp_avx2_movbe` (1.53%).

Interleaved same-session wall-clock A/B (release builds of `main` and of this change, alternating, `taskset -c 2`, best of 9):

| benchmark | before | after |
|---|---|---|
| `bench-ctor`  | 0.417s | 0.404s (−3.1%) |
| `bench-class` | 0.268s | 0.263s (−2.0%) |
| `method-call` | 0.243s | 0.222s (−8.5%) |

Not a bench-ctor-specific fix: every non-pure method return in every program pays this merge, which is why `method-call` moves the most. Wall-clock confirmation belongs to the bench CI (`bench-history.tsv` on `bench-data`), per the ticket's measurement notes.

## Testing

No behaviour change, so no new pin — the existing suites are the gate, and both ran locally before publishing:

- `make test` — 3853 files, 40832 tests, `Result: PASS`
- `make roast` — the only red files are the three documented container-caused ones (`6.c/S32-io/file-tests.t` and `S16-filehandles/filetest.t` under `uid 0`, `S32-io/IO-Socket-Async.t` under the network sandbox), with exactly the subtest sets `docs/agent-environments.md` records
- `make lint` — all four configurations clean
- `cargo fmt --all`

Write-up: `news/2026-09/method-exit-merge-filter-order.md`. Refs #7568 (the ticket stays open; further slices follow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019eBZJJxUuTryUW982Ggz3r

---
_Generated by [Claude Code](https://claude.ai/code/session_019eBZJJxUuTryUW982Ggz3r)_