### PR TITLE
perf(vm): take the constant pool's Symbol on the hash element and container paths

### DIFF
--- a/news/2026-09/hash-path-constant-pool-symbols.md
+++ b/news/2026-09/hash-path-constant-pool-symbols.md
@@ -1,0 +1,74 @@
+# Hash element store and container reads take the constant pool's Symbol
+
+`hash-access` and `bench-hash` had been drifting upward at roughly 2%/day with
+no single culprit commit ([#7559](https://github.com/tokuhirom/mutsu/issues/7559)).
+A callgrind bisect had already established the shape of the problem — diffuse,
+no frame dominating the delta — and named the largest remaining item precisely:
+`Symbol::intern` was still called about 155,000 times for a benchmark with
+20,000 loop iterations, almost all of it re-interning *constant* names on hot
+paths.
+
+The env is `Symbol`-keyed, so every by-name helper (`Env::get`,
+`Env::get_mut`, `Env::contains_key`, `Interpreter::is_readonly`) begins by
+interning its `&str` argument: a thread-local `RefCell` borrow plus a string
+hash. But the names those helpers were asked about are opcode operands —
+constant-pool indices whose string the compiler fixed long before the loop ran.
+`CompiledCode::const_sym` already memoizes the `Symbol` for a constant-pool
+entry, and `GetGlobal`'s scalar shortcut already used it; the element-store and
+container-read paths did not.
+
+This change threads that memoized `Symbol` through them.
+
+- **`try_fast_hash_element_assign`** resolved `var_name` once and now passes the
+  symbol to all four of its probes (`env().get`, `env_mut().get_mut`, the local
+  slot re-read, and `is_readonly`), which each re-interned the same name.
+- **`exec_index_assign_expr_named_op`** and its two inner layers do the same for
+  the `Range`-receiver guard, the unit-lexical cell seed/restore, the `Seq`/
+  `Proxy` destination lookup, and the six container-metadata probes that bracket
+  the assignment.
+- **`get_env_with_main_alias`** gained a symbol-taking twin,
+  `get_env_with_main_alias_sym`, used by `GetGlobal`, `GetArrayVar` and
+  `GetHashVar`. This is the single largest item: it is the *only* read path an
+  `@`/`%` name has, because `GetGlobal`'s scalar shortcut excludes those sigils
+  by construction, so a container-heavy program paid one intern per element
+  access.
+- **`reify_lazy_array_slot`** — a probe that runs on every element store and
+  delete for the sake of the rare lazy `@`-array — takes the symbol too.
+
+Three allocations went with them. The element-store path built a `String` copy
+of the variable name on every store (three times over, across its layers) purely
+to hand a `&str` to helpers; the name is borrowed from the constant pool
+instead, which outlives the op and is a distinct borrow from `&mut self`. The
+hash fast path stringified its key twice and then cloned it a third time; it now
+stringifies once and moves the `String` into the insert, rebuilding it only in
+the `%*ENV` branch that no ordinary hash takes. And `unit_lexical_container_cell`
+— consulted on every element store and delete — now opens with the same
+`unit_lexicals.is_empty()` gate `unit_lexical_slot` already had, so a program
+whose mainline subs capture nothing skips two SipHash string lookups per store
+rather than missing them one at a time.
+
+Instructions retired (`MUTSU_JIT=off`, callgrind, one release build per point —
+Ir is stable across runs and unaffected by runner speed, which is why the ticket
+uses it rather than wall clock):
+
+| benchmark | before | after | delta |
+| --- | --- | --- | --- |
+| `hash-access` | 240,872,402 | 220,592,761 | -8.4% |
+| `bench-hash` | 294,077,225 | 272,657,254 | -7.3% |
+
+That recovers roughly four days of the creep the ticket measured. The other
+benchmarks are unmoved (`array-ops` -0.8%; `bench-array`, `bench-string`,
+`bench-mandelbrot`, `bench-class`, `method-call`, `word-count` all within
+±0.2%), which is the expected shape: the change removes work from paths a
+container-heavy program runs per element and leaves scalar-heavy code alone.
+
+`t/hash-element-store-symbol-keyed.t` pins the behaviour the symbol-keyed probes
+must keep agreeing on — the plain fast path and each of its bail-outs (readonly
+binds, `:=`-bound elements, typed hashes, `is default(...)`), the unit-lexical
+cell in its open state, the lazy-array reify and its delete twin, and `%*ENV`.
+
+What the ticket lists as still open is untouched and stays open: the remaining
+`Symbol::intern` callers that build a *fresh* name (`format!`-ed metadata keys),
+and `HashData`'s use of std's SipHash, which is 6% of `hash-access` but trades
+away HashDoS resistance on user-controlled keys and so needs an explicit
+decision, not a drive-by change.

--- a/src/vm/vm_env_helpers.rs
+++ b/src/vm/vm_env_helpers.rs
@@ -515,6 +515,14 @@ impl Interpreter {
         &self,
         name: &str,
     ) -> Option<crate::gc::Gc<crate::value::ContainerCell>> {
+        // Same gate [`Self::unit_lexical_slot`] opens with, hoisted above the
+        // MAINLINE bucket probe below: a program with no unit lexicals at all
+        // (no mainline sub captured a file-scope `my`) cannot have a cell here,
+        // and this runs on EVERY element store and delete. Without it those
+        // stores paid two SipHash string lookups plus a name scan each.
+        if self.unit_lexicals.is_empty() {
+            return None;
+        }
         if crate::runtime::utils::has_anon_marker(name) {
             return None;
         }
@@ -1077,7 +1085,23 @@ impl Interpreter {
         self.unit_scope_lexical(name).map(Value::into_deref)
     }
 
+    #[inline]
     pub(crate) fn get_env_with_main_alias(&self, name: &str) -> Option<Value> {
+        self.get_env_with_main_alias_sym(name, Symbol::intern(name))
+    }
+
+    /// [`Self::get_env_with_main_alias`] for a caller that already holds
+    /// `name`'s interned form — an opcode whose name operand is a constant-pool
+    /// index, which [`CompiledCode::const_sym`] memoizes per chunk.
+    ///
+    /// The env is `Symbol`-keyed, so this chokepoint interned its `&str`
+    /// argument again on every read. That is a thread-local `RefCell` borrow
+    /// plus a string hash per variable read, and it is the *only* read path for
+    /// an `@`/`%` name (the `GetGlobal` scalar shortcut excludes those sigils by
+    /// construction), so a hash-heavy program paid it once per element access.
+    /// Every branch below the direct env probe is a miss-path alias cascade
+    /// building its own fresh name, so only that probe takes the symbol.
+    pub(crate) fn get_env_with_main_alias_sym(&self, name: &str, sym: Symbol) -> Option<Value> {
         // A file-scope lexical of the running routine's own compunit is NOT in
         // `env` — that key belongs to whatever scope loaded the module. This is
         // the by-name chokepoint every remaining reader goes through (a mutating
@@ -1113,14 +1137,14 @@ impl Interpreter {
         // Try the kebab-case equivalent first if the name contains underscores.
         if name.contains('_') {
             let kebab = name.replace('_', "-");
-            if let Some(val) = self.get_env_with_main_alias_inner(&kebab) {
+            if let Some(val) = self.get_env_with_main_alias_inner(&kebab, Symbol::intern(&kebab)) {
                 return Some(val);
             }
         }
-        self.get_env_with_main_alias_inner(name)
+        self.get_env_with_main_alias_inner(name, sym)
     }
 
-    fn get_env_with_main_alias_inner(&self, name: &str) -> Option<Value> {
+    fn get_env_with_main_alias_inner(&self, name: &str, sym: Symbol) -> Option<Value> {
         // Atomic array/hash CAS stores the authoritative copy under an internal
         // key. Always check it first so both thread-clone and non-clone reads
         // observe the latest CAS'd value. Without the hash arm, a thread's own
@@ -1169,7 +1193,7 @@ impl Interpreter {
         // lexical variables take precedence over shared_vars. Without this,
         // recursive `start` blocks can read stale parameter values from
         // shared_vars instead of the locally-bound ones.
-        if let Some(val) = self.env().get(name) {
+        if let Some(val) = self.env().get_sym(sym) {
             return Some(val.clone());
         }
         // $*DISTRO/$*PERL/$*RAKU/$*VM/$*KERNEL are not in env or the base

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -360,7 +360,13 @@ impl Interpreter {
                     // NB: `get_env_with_main_alias` is also where a file-scope `my`
                     // of the running routine's own compunit resolves — `env` is not
                     // authoritative for that name. See `unit_lexicals`.
-                    .or_else(|| self.get_env_with_main_alias(name))
+                    // The name is a constant-pool entry, so hand over its
+                    // memoized `Symbol` rather than making the chokepoint
+                    // re-intern it on every read. This is the only read path an
+                    // `@`/`%` name has -- the scalar shortcut above excludes
+                    // those sigils -- so a container-heavy program paid one
+                    // intern per element access without it.
+                    .or_else(|| self.get_env_with_main_alias_sym(name, code.const_sym(*name_idx)))
                     .or_else(|| {
                         // Fall back to the persistent our_vars store for `our`-scoped
                         // variables accessed via package-qualified names (e.g., $Pkg::var).
@@ -630,7 +636,9 @@ impl Interpreter {
                     return Ok(());
                 }
                 let val = self
-                    .get_env_with_main_alias(name)
+                    // Constant-pool name: hand over the chunk's memoized
+                    // `Symbol` instead of re-interning it on every array read.
+                    .get_env_with_main_alias_sym(name, code.const_sym(*name_idx))
                     .or_else(|| self.get_local_by_bare_name(code, name))
                     .or_else(|| {
                         // Fallback: check bare name in env (for closures capturing params)
@@ -736,7 +744,9 @@ impl Interpreter {
                     return Ok(());
                 }
                 let val = self
-                    .get_env_with_main_alias(name)
+                    // Constant-pool name: hand over the chunk's memoized
+                    // `Symbol` instead of re-interning it on every hash read.
+                    .get_env_with_main_alias_sym(name, code.const_sym(*name_idx))
                     .or_else(|| self.get_local_by_bare_name(code, name))
                     .or_else(|| {
                         name.strip_prefix('%')

--- a/src/vm/vm_helpers_lazy.rs
+++ b/src/vm/vm_helpers_lazy.rs
@@ -783,12 +783,17 @@ impl Interpreter {
     /// collapse it into a finite Array (raku: `@a.is-lazy` stays `True`,
     /// `@a.elems` keeps throwing `X::Cannot::Lazy`, and a later out-of-range
     /// read keeps pulling from the live source). (L2, bounded reify follow-up)
+    ///
+    /// `sym` is `name`'s interned form, passed in rather than re-interned: this
+    /// probe runs on EVERY element store and delete, and a lazy `@`-array is
+    /// rare, so the probe itself must not cost a string hash.
     pub(super) fn reify_lazy_array_slot(
         &mut self,
         name: &str,
+        sym: crate::symbol::Symbol,
         touched_index: Option<i64>,
     ) -> Result<Option<crate::gc::Gc<LazyList>>, RuntimeError> {
-        let lazy = match self.env().get(name).map(Value::view) {
+        let lazy = match self.env().get_sym(sym).map(Value::view) {
             // Any `@`-array-context lazy list must materialize before an element
             // mutation, not just the cache-backed infinite specs: a finite
             // `(1..10).lazy` / `lazy gather {...}` is also a `LazyList` value with

--- a/src/vm/vm_var_assign_element.rs
+++ b/src/vm/vm_var_assign_element.rs
@@ -232,6 +232,12 @@ impl Interpreter {
         if !var_name.starts_with('%') {
             return None;
         }
+        // Resolved once through the chunk's memoized constant-symbol table and
+        // threaded through every env probe below (`get_sym`/`get_mut_sym`/
+        // `is_readonly_sym`). This path re-interned `var_name` at each of them
+        // -- a thread-local `RefCell` borrow plus a string hash per probe, four
+        // per store, for a name the compiler already knew.
+        let var_sym = code.const_sym(name_idx);
         // Peek at stack to check for bind-mode marker and complex indices
         // without popping (we'll pop only if we commit to the fast path)
         let stack_len = self.stack.len();
@@ -287,10 +293,10 @@ impl Interpreter {
         // instead of 2, permanently falling off the fast path and losing its
         // itemization (`t/hash-key-single-itemize.t`).
         {
-            let current = self.env().get(var_name).cloned().unwrap_or(Value::NIL);
+            let current = self.env().get_sym(var_sym).cloned().unwrap_or(Value::NIL);
             if self.container_type_metadata(&current).is_some()
                 || self.var_default(var_name).is_some()
-                || self.is_readonly(var_name)
+                || self.is_readonly_sym(var_sym)
             {
                 return None;
             }
@@ -315,7 +321,7 @@ impl Interpreter {
         // Check that the variable exists in env as a plain Hash
         // and that it has no container type metadata
         let env = self.env();
-        match env.get(var_name).map(Value::view) {
+        match env.get_sym(var_sym).map(Value::view) {
             Some(ValueView::Hash(hash_arc)) => {
                 let strong_count = crate::gc::Gc::strong_count_of(&hash_arc);
                 // Reject if the hash Arc has more than 2 refs (e.g. HashEntryRef binding)
@@ -338,9 +344,12 @@ impl Interpreter {
                 if hash_arc.has_type_meta() {
                     return None;
                 }
-                // Peek at the key to check if the existing element is a bound ref
-                let peek_key = self.stack[stack_len - 1].to_string_value();
-                if let Some(existing) = hash_arc.get(&peek_key) {
+                // Peek at the key to check if the existing element is a bound
+                // ref. This is the key the commit below stores under, so it is
+                // stringified ONCE here and moved into the insert -- `%h{$k} =
+                // $v` used to build the same `String` twice per store.
+                let key = self.stack[stack_len - 1].to_string_value();
+                if let Some(existing) = hash_arc.get(&key) {
                     let is_bound = match existing.view() {
                         ValueView::HashEntryRef { .. } | ValueView::Scalar(..) => true,
                         // Slice 2b: a `=`-shared (or `:=`-bound) element holds a
@@ -355,30 +364,35 @@ impl Interpreter {
                     }
                 }
                 // All checks passed — commit to fast path
-                let idx = self.stack.pop().unwrap();
+                self.stack.pop();
                 let val = self.stack.pop().unwrap();
-                let key = idx.to_string_value();
+                // `key` is moved into the insert below. `%*ENV` is the one
+                // destination that needs it afterwards, so only that
+                // destination pays the clone -- an ordinary hash store keeps
+                // the single `String` it built at the peek above.
+                #[cfg(not(target_family = "wasm"))]
+                let os_env_key = (var_name == "%*ENV").then(|| key.clone());
                 // When locals and env share the same Arc (strong_count == 2),
                 // drop the local ref first so Arc::make_mut can mutate in-place
                 // instead of cloning the entire HashMap (O(n) → O(1) per insert).
                 if let Some(slot) = local_slot {
                     self.locals[slot] = Value::NIL;
                 }
-                if let Some(entry) = self.env_mut().get_mut(var_name) {
+                if let Some(entry) = self.env_mut().get_mut_sym(var_sym) {
                     entry.with_hash_mut(|hash| {
                         // ADR-0040 slice 1: itemize the stored value, not the
                         // rvalue pushed below (that push is a pre-existing,
                         // separate scalar-context-itemization concern).
                         Value::hash_insert_through(
                             &mut crate::gc::Gc::make_mut(hash).map,
-                            key.clone(),
+                            key,
                             Self::itemize_value(val.clone()),
                         );
                     });
                 }
                 // Restore the local slot to point to the (now mutated) env Arc
                 if let Some(slot) = local_slot
-                    && let Some(env_val) = self.env().get(var_name).cloned()
+                    && let Some(env_val) = self.env().get_sym(var_sym).cloned()
                 {
                     self.locals[slot] = env_val;
                 }
@@ -398,13 +412,13 @@ impl Interpreter {
                 // identical) — it only matters on the single-store path.
                 if local_slot.is_none()
                     && let Some(slot) = self.find_local_slot(code, var_name)
-                    && let Some(env_val) = self.env().get(var_name).cloned()
+                    && let Some(env_val) = self.env().get_sym(var_sym).cloned()
                 {
                     self.locals[slot] = env_val;
                 }
                 // Sync OS environment when %*ENV is modified
                 #[cfg(not(target_family = "wasm"))]
-                if var_name == "%*ENV" {
+                if let Some(key) = os_env_key {
                     // SAFETY: std::env::set_var is unsafe because mutating the
                     // process environment races with any concurrent env access
                     // on another thread. mutsu writes %*ENV from the executing
@@ -584,10 +598,10 @@ impl Interpreter {
         {
             return Err(RuntimeError::assignment_ro_value(value));
         }
-        let var_name = Self::const_str(code, name_idx);
+        let var_sym = code.const_sym(name_idx);
         if let Some(value) = self
             .env()
-            .get(var_name)
+            .get_sym(var_sym)
             .map(|value| value.deref_container().descalarize().clone())
             .filter(|value| value.is_range())
         {
@@ -643,18 +657,21 @@ impl Interpreter {
         // temporarily seed env with the cell's inner container, run the op,
         // write the mutated result back through the cell, then restore env to
         // whatever it held before.
-        let var_name_for_cell = Self::const_str(code, name_idx).to_string();
-        let unit_cell = self.unit_lexical_container_cell(&var_name_for_cell);
+        // Borrowed from the constant pool, not copied: `code` outlives the op
+        // and is a distinct borrow from `&mut self`, so this probe -- which runs
+        // on EVERY element store -- no longer allocates a `String` per store.
+        let var_name_for_cell = Self::const_str(code, name_idx);
+        let unit_cell = self.unit_lexical_container_cell(var_name_for_cell);
         let saved_env_entry = unit_cell.as_ref().map(|cell| {
-            let saved = self.env().get(&var_name_for_cell).cloned();
+            let saved = self.env().get_sym(var_sym).cloned();
             let inner = cell.lock().unwrap().clone();
-            self.env_mut().insert(var_name_for_cell.clone(), inner);
+            self.env_mut().insert(var_name_for_cell.to_string(), inner);
             saved
         });
         let result =
             self.exec_index_assign_expr_named_op_seeded(code, name_idx, is_positional, target_slot);
         if let Some(cell) = unit_cell {
-            if let Some(mutated) = self.env().get(&var_name_for_cell).cloned() {
+            if let Some(mutated) = self.env().get_sym(var_sym).cloned() {
                 *cell.lock().unwrap() = mutated;
             }
             // `saved_env_entry` is `Some(_)` whenever `unit_cell` is (both
@@ -664,10 +681,10 @@ impl Interpreter {
             // "did we even seed" flag.
             match saved_env_entry.flatten() {
                 Some(v) => {
-                    self.env_mut().insert(var_name_for_cell.clone(), v);
+                    self.env_mut().insert(var_name_for_cell.to_string(), v);
                 }
                 None => {
-                    self.env_mut().remove(&var_name_for_cell);
+                    self.env_mut().remove(var_name_for_cell);
                 }
             }
         }
@@ -691,12 +708,13 @@ impl Interpreter {
         is_positional: bool,
         target_slot: Option<u32>,
     ) -> Result<(), RuntimeError> {
-        let var_name = Self::const_str(code, name_idx).to_string();
+        let var_name = Self::const_str(code, name_idx);
         let touched_index = self.stack.last().and_then(|idx| match idx.view() {
             ValueView::Int(n) if n >= 0 => Some(n),
             _ => None,
         });
-        let lazy_source = self.reify_lazy_array_slot(&var_name, touched_index)?;
+        let lazy_source =
+            self.reify_lazy_array_slot(var_name, code.const_sym(name_idx), touched_index)?;
         let result = self.exec_index_assign_expr_named_op_seeded_inner(
             code,
             name_idx,
@@ -704,7 +722,7 @@ impl Interpreter {
             target_slot,
         );
         if let Some(ll) = lazy_source {
-            self.restore_lazy_array_slot(code, &var_name, ll);
+            self.restore_lazy_array_slot(code, var_name, ll);
         }
         result
     }
@@ -821,7 +839,7 @@ impl Interpreter {
         if self.stack.len() >= 2
             && let Some(target) = target_slot
                 .and_then(|slot| self.locals.get(slot as usize).cloned())
-                .or_else(|| self.env().get(Self::const_str(code, name_idx)).cloned())
+                .or_else(|| self.env().get_sym(code.const_sym(name_idx)).cloned())
         {
             if matches!(target.view(), ValueView::Seq(body)
                 if body.has_element_containers() || !body.has_deferred_source())
@@ -912,21 +930,22 @@ impl Interpreter {
         // reconstruct the array Arc, changing the pointer used as the
         // metadata key. Reapply them on the final container so typed-array
         // hole semantics and `is default(...)` are preserved.
-        let save_var_name = Self::const_str(code, name_idx).to_string();
+        let save_var_name = Self::const_str(code, name_idx);
+        let save_var_sym = code.const_sym(name_idx);
         // Hash type metadata (including the object-hash key constraint) is now
         // embedded in `HashData` and travels with the hash across copy-on-write,
         // so the old name-based reconcile healing is no longer needed.
         let saved_type_meta_outer = self
             .env()
-            .get(&save_var_name)
+            .get_sym(save_var_sym)
             .cloned()
             .and_then(|v| self.container_type_metadata(&v));
         // Guard against stale pointer-keyed defaults (Arc reuse across
         // allocations): only trust the saved default when a name-based
         // var_default is also registered.
-        let saved_default_outer = if self.var_default(&save_var_name).is_some() {
+        let saved_default_outer = if self.var_default(save_var_name).is_some() {
             self.env()
-                .get(&save_var_name)
+                .get_sym(save_var_sym)
                 .and_then(|v| self.container_default(v))
         } else {
             None
@@ -939,7 +958,7 @@ impl Interpreter {
         // the write back to the caller.
         let saved_hash_subclass_instance = save_var_name
             .starts_with('$')
-            .then(|| self.env().get(&save_var_name).cloned())
+            .then(|| self.env().get_sym(save_var_sym).cloned())
             .flatten()
             .and_then(|v| {
                 let instance = v.deref_container();
@@ -960,10 +979,10 @@ impl Interpreter {
         if result.is_ok()
             && let Some(instance) = saved_hash_subclass_instance
             && let ValueView::Instance { attributes, .. } = instance.view()
-            && let Some(ValueView::Hash(hash)) = self.env().get(&save_var_name).map(Value::view)
+            && let Some(ValueView::Hash(hash)) = self.env().get_sym(save_var_sym).map(Value::view)
         {
             attributes.commit_attrs(hash.map.clone().into());
-            self.env_mut().insert(save_var_name.clone(), instance);
+            self.env_mut().insert(save_var_name.to_string(), instance);
         }
         // Restore metadata on the post-assignment container when the
         // identity-keyed map lost it OR holds a stale entry. Copy-on-write
@@ -976,7 +995,7 @@ impl Interpreter {
         // (the read op has no variable name to fall back on), so a stale/lost
         // entry silently degrades them to string-keyed lookups returning Nil.
         if let Some(info) = saved_type_meta_outer
-            && let Some(container) = self.env().get(&save_var_name).cloned()
+            && let Some(container) = self.env().get_sym(save_var_sym).cloned()
             && self.container_type_metadata(&container).as_ref() != Some(&info)
         {
             // Hashes embed metadata in `HashData`, so the re-tagged value must
@@ -984,16 +1003,18 @@ impl Interpreter {
             // (`tag_container_metadata` returns the same Arc for non-hash
             // containers, whose Arc-pointer side table is updated in place).
             let tagged = self.tag_container_metadata(container, info);
-            self.env_mut().insert(save_var_name.clone(), tagged.clone());
-            self.locals_set_by_name(code, &save_var_name, tagged);
+            self.env_mut()
+                .insert(save_var_name.to_string(), tagged.clone());
+            self.locals_set_by_name(code, save_var_name, tagged);
         }
         if let Some(def) = saved_default_outer
-            && let Some(container) = self.env().get(&save_var_name).cloned()
+            && let Some(container) = self.env().get_sym(save_var_sym).cloned()
             && self.container_default(&container).is_none()
         {
             let tagged = self.tag_container_default(container, def);
-            self.env_mut().insert(save_var_name.clone(), tagged.clone());
-            self.locals_set_by_name(code, &save_var_name, tagged);
+            self.env_mut()
+                .insert(save_var_name.to_string(), tagged.clone());
+            self.locals_set_by_name(code, save_var_name, tagged);
         }
         // Object-hash original keys are embedded in `HashData` and travel with
         // the hash across copy-on-write, so no pointer migration is needed.
@@ -1015,12 +1036,12 @@ impl Interpreter {
         // as an Instance/Mixin, so this only fires for object subscript targets.
         if result.is_ok()
             && matches!(
-                self.env().get(&save_var_name).map(Value::view),
+                self.env().get_sym(save_var_sym).map(Value::view),
                 Some(ValueView::Instance { .. }) | Some(ValueView::Mixin(..))
             )
-            && let Some(v) = self.env().get(&save_var_name).cloned()
+            && let Some(v) = self.env().get_sym(save_var_sym).cloned()
         {
-            self.locals_set_by_name(code, &save_var_name, v);
+            self.locals_set_by_name(code, save_var_name, v);
         }
         result
     }

--- a/src/vm/vm_var_delete_ops.rs
+++ b/src/vm/vm_var_delete_ops.rs
@@ -208,7 +208,8 @@ impl Interpreter {
             ValueView::Int(n) if n >= 0 => Some(n),
             _ => None,
         });
-        let lazy_source = self.reify_lazy_array_slot(&var_name, delete_touched_index)?;
+        let lazy_source =
+            self.reify_lazy_array_slot(&var_name, code.const_sym(name_idx), delete_touched_index)?;
         // A lazy array's reified prefix has a live tail beyond it, so
         // deleting its LAST touched slot must NOT shrink the array the way
         // `trim_trailing_array_holes` shrinks a genuinely finite one (raku:

--- a/t/hash-element-store-symbol-keyed.t
+++ b/t/hash-element-store-symbol-keyed.t
@@ -1,0 +1,83 @@
+use Test;
+
+# The element-store and container-read paths resolve their variable name
+# through the chunk's memoized constant-pool Symbol instead of re-interning the
+# name string at every env probe. `Env::get_sym` / `get_mut_sym` /
+# `is_readonly_sym` must agree exactly with their `&str` twins, so this file
+# pins the shapes those probes gate on: the plain fast path, each of its
+# bail-outs, and the two probes that were narrowed (the unit-lexical cell and
+# the lazy-array reify).
+
+plan 22;
+
+# --- the plain fast path -------------------------------------------------
+my %h;
+%h{"a"} = 1;
+%h{"b"} = 2;
+is %h<a>, 1, 'plain hash element store, read back';
+is %h<b>, 2, 'second plain hash element store';
+is %h.elems, 2, 'both keys landed';
+
+# A store of an aggregate itemizes (the fast path pushes an itemized rvalue).
+my @z = (%h<c> = (1, 2));
+is @z.elems, 1, 'hash-element store itemizes its rvalue';
+is %h<c>.elems, 2, 'the stored aggregate kept its elements';
+
+# --- readonly bail-out ---------------------------------------------------
+# `is_readonly_sym` must see a `:=`-bound name exactly as `is_readonly` did.
+my %ro;
+%ro<k> = 'v';
+my %alias := %ro;
+%alias<k2> = 'v2';
+is %ro<k2>, 'v2', 'a `:=`-bound hash writes through to its target';
+
+# An element `:=`-bound to an immutable literal must still be refused.
+my %bound;
+%bound<i> := 137;
+is %bound<i>, 137, 'element bind installed';
+dies-ok { %bound<i> = 5 }, 'assigning over a `:=`-bound literal element dies';
+
+# --- typed / defaulted hashes must stay off the fast path ----------------
+my Int %typed;
+%typed<n> = 7;
+is %typed<n>, 7, 'typed hash accepts a matching value';
+dies-ok { %typed<n> = 'str' }, 'typed hash still rejects a bad value';
+
+my %defaulted is default(42);
+is %defaulted<missing>, 42, 'is default(...) survives the element-store path';
+%defaulted<here> = 1;
+is %defaulted<here>, 1, 'a real key still wins over the default';
+is %defaulted<gone>, 42, 'the default is still in place after a store';
+
+# --- the unit-lexical container cell -------------------------------------
+# `unit_lexical_container_cell` now returns early when NO unit lexicals exist.
+# A mainline named sub that captures a mainline `my` populates that store, so
+# these two subs exercise the gate in its open state: the hash element write
+# must reach the captured container, not a fresh env entry.
+my %captured;
+sub stash($k, $v) { %captured{$k} = $v }
+sub fetch($k) { %captured{$k} }
+stash('x', 10);
+stash('y', 20);
+is fetch('x'), 10, 'a sub stores into the captured mainline hash';
+is fetch('y'), 20, 'and a second key lands in the same hash';
+is %captured.elems, 2, 'the mainline sees both writes through the cell';
+
+# --- the lazy-array reify probe ------------------------------------------
+# `reify_lazy_array_slot` takes the interned name now; an element write to a
+# lazy array must still materialize a prefix and keep the array lazy.
+my @lazy = (1, 2, 4 ... Inf);
+@lazy[2] = 99;
+is @lazy[2], 99, 'element write into a lazy array lands';
+is @lazy[1], 2, 'the reified prefix kept its earlier elements';
+ok @lazy.is-lazy, 'the array is still lazy after the element write';
+
+# The delete twin runs through the same probe.
+my @lazy2 = (1, 2, 4 ... Inf);
+@lazy2[1]:delete;
+nok @lazy2[1].defined, 'deleted element of a lazy array is a hole';
+ok @lazy2.is-lazy, 'the array is still lazy after the element delete';
+
+# --- %*ENV keeps its OS write-through ------------------------------------
+%*ENV<MUTSU_SYMBOL_KEYED_PIN> = 'ok';
+is %*ENV<MUTSU_SYMBOL_KEYED_PIN>, 'ok', '%*ENV element store reads back';


### PR DESCRIPTION
Works the "What is left, and where to look next" section of #7559.

## The problem

`hash-access` and `bench-hash` had been drifting upward at ~2%/day with no
single culprit commit. The ticket's callgrind bisect had already established the
shape (diffuse, no frame dominating the delta) and named the largest remaining
item precisely: `Symbol::intern` was still called **~155,000 times** for a
benchmark with 20,000 loop iterations, almost all of it re-interning *constant*
names on hot paths.

The env is `Symbol`-keyed, so every by-name helper (`Env::get`, `Env::get_mut`,
`Env::contains_key`, `Interpreter::is_readonly`) begins by interning its `&str`
argument: a thread-local `RefCell` borrow plus a string hash. But the names
those helpers are asked about are opcode operands — constant-pool indices whose
string the compiler fixed long before the loop ran.
`CompiledCode::const_sym` already memoizes the `Symbol` for a constant-pool
entry, and `GetGlobal`'s scalar shortcut already used it; the element-store and
container-read paths did not.

## What changed

- **`try_fast_hash_element_assign`** resolves `var_name` once and passes the
  symbol to all four probes (`env().get`, `env_mut().get_mut`, the local-slot
  re-read, `is_readonly`) that each re-interned the same name.
- **`exec_index_assign_expr_named_op`** and its two inner layers do the same for
  the `Range`-receiver guard, the unit-lexical cell seed/restore, the
  `Seq`/`Proxy` destination lookup, and the container-metadata probes that
  bracket the assignment.
- **`get_env_with_main_alias`** gains a symbol-taking twin,
  `get_env_with_main_alias_sym`, used by `GetGlobal`, `GetArrayVar` and
  `GetHashVar`. This is the single largest item: it is the *only* read path an
  `@`/`%` name has, because `GetGlobal`'s scalar shortcut excludes those sigils
  by construction, so a container-heavy program paid one intern per element
  access.
- **`reify_lazy_array_slot`** — run on every element store and delete for the
  sake of the rare lazy `@`-array — takes the symbol too.

Three allocations went with them:

- the element-store path no longer copies the variable name into a `String` per
  store (three times over, across its layers); it borrows the constant pool,
  which outlives the op and is a distinct borrow from `&mut self`;
- the hash fast path stringified its key twice and cloned it a third time. It
  now stringifies once and moves the `String` into the insert, cloning only for
  the `%*ENV` destination that no ordinary hash takes;
- `unit_lexical_container_cell` opens with the same `unit_lexicals.is_empty()`
  gate `unit_lexical_slot` already had, so a program whose mainline subs capture
  nothing skips two SipHash string lookups per element store rather than missing
  them one at a time.

## Measurements

Instructions retired, per the ticket's own "Reproduce" recipe
(`MUTSU_JIT=off`, callgrind, one release build per point — Ir is stable across
runs and unaffected by runner speed, which is why the ticket uses it rather than
wall clock):

| benchmark | before | after | delta |
| --- | --- | --- | --- |
| `hash-access` | 240,872,402 | 220,592,761 | **-8.4%** |
| `bench-hash` | 294,077,225 | 272,657,254 | **-7.3%** |

That recovers roughly four days of the creep the ticket measured. Both
benchmarks produce byte-identical output before and after.

The other benchmarks are unmoved, which is the expected shape — the change
removes work from paths a container-heavy program runs per element and leaves
scalar-heavy code alone:

| benchmark | delta |
| --- | --- |
| `array-ops` | -0.76% |
| `bench-mandelbrot` | +0.08% |
| `bench-array` | +0.10% |
| `bench-string` | +0.16% |
| `bench-class` | +0.01% |
| `method-call` | +0.02% |
| `word-count` | +0.12% |

(These are local callgrind A/B numbers for the in-flight decision, not document
figures; the bench CI history remains the source of truth for
PERFORMANCE.md/PLAN.md.)

## Tests

`t/hash-element-store-symbol-keyed.t` pins the behaviour the symbol-keyed probes
must keep agreeing on: the plain fast path and each of its bail-outs (readonly
binds, `:=`-bound elements, typed hashes, `is default(...)`), the unit-lexical
cell in its **open** state (a mainline sub capturing a file-scope `my`, so the
new `is_empty()` gate is exercised both ways), the lazy-array reify and its
delete twin, and `%*ENV`. It passes on `main` too — it is a behaviour pin, not
a new feature.

Run locally before publishing:

- `cargo fmt --all`, `make lint` — all four configurations green.
- `make test` — 3854 files, 40854 tests, PASS.
- `make roast` — the only failures are the three documented container-environment
  ones (`6.c/S32-io/file-tests.t`, `S16-filehandles/filetest.t`,
  `S32-io/IO-Socket-Async.t`), matching
  [docs/agent-environments.md](https://github.com/tokuhirom/mutsu/blob/main/docs/agent-environments.md)
  test-for-test (uid 0 makes the `chmod` tests meaningless; the sandboxed
  network breaks the socket test).

## Scope

#7559 stays **open**. Two items it lists are deliberately untouched:

- the remaining `Symbol::intern` callers that build a *fresh* name (`format!`-ed
  metadata keys) rather than re-interning a constant;
- `HashData`'s use of std's SipHash — 6% of `hash-access`, but switching it
  trades away HashDoS resistance on user-controlled keys, which the ticket
  itself says needs an ADR, not a drive-by change.

Refs #7559

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H1912FGbAUqqnWhEn1rqZj

---
_Generated by [Claude Code](https://claude.ai/code/session_01H1912FGbAUqqnWhEn1rqZj)_