### PR TITLE
test: pin the state reset against every block shape, not just the plain one

### DIFF
--- a/t/block-position-parity.t
+++ b/t/block-position-parity.t
@@ -11,7 +11,7 @@ use Test;
 # ADR-0076). This file pins the three divergences that unification fixed, plus
 # the shapes that must NOT change with it.
 
-plan 30;
+plan 34;
 
 # --- 1. `temp` is restored by BOTH positions ------------------------------
 # The statement pass wrapped a `let`/`temp`-bearing block in `OpCode::LetBlock`;
@@ -130,6 +130,31 @@ ok $caught.defined || !$caught.defined, 'a CATCH in a value block swallows the t
 my $ran = 0;
 { CATCH { default { $ran = 1 } }; die "boom"; }
 is $ran, 1, 'a CATCH in a statement block swallows the throw';
+
+# The `state` reset and the shape dispatch are INDEPENDENT: a `state` restarts
+# per execution in every shape, not just the plain one. The value pass used to
+# emit its `ResetStateLocals` only on the paths below its CATCH/CONTROL and
+# ENTER/LEAVE early returns, so adding either phaser to an otherwise identical
+# `do` block silently turned the counter into a persistent one (1 2 3 instead of
+# 1 1 1) while the plain form above and both statement spellings stayed correct.
+# The unified skeleton emits the reset before the dispatch; these pin that it
+# stays there.
+sub counted-catch() { do { state $n = 0; $n++; CATCH { default { } }; $n } }
+is counted-catch() ~ counted-catch(), '11', 'state restarts in a CATCH-bearing value block';
+sub counted-enter() { do { state $n = 0; $n++; ENTER { }; $n } }
+is counted-enter() ~ counted-enter(), '11', 'state restarts in an ENTER-bearing value block';
+
+my $stmt-catch;
+sub counted-catch-stmt() { { state $n = 0; $n++; $stmt-catch = $n; CATCH { default { } } } }
+counted-catch-stmt();
+counted-catch-stmt();
+is $stmt-catch, 1, 'state restarts in a CATCH-bearing statement block';
+
+my $stmt-enter;
+sub counted-enter-stmt() { { state $n = 0; $n++; $stmt-enter = $n; ENTER { } } }
+counted-enter-stmt();
+counted-enter-stmt();
+is $stmt-enter, 1, 'state restarts in an ENTER-bearing statement block';
 
 # ENTER/LEAVE still run, and the block still yields its body value.
 my @order;


### PR DESCRIPTION
A four-assertion gap in `t/block-position-parity.t`, found while investigating #7569 on the branch that lost the race to #7636.

## The gap

The file covers a `state` in a plain value block, and covers `CATCH` and `ENTER` separately — but not their intersection, which is the case the unified lowering actually fixed.

Before the shared skeleton, the value pass emitted its per-execution `ResetStateLocals` only on the paths *below* its CATCH/CONTROL and ENTER/LEAVE early returns:

```raku
sub f() { do { state $n = 0; $n++; CATCH { default {} }; $n } }
say f(); say f(); say f();   # raku: 1 1 1   mutsu, pre-#7636: 1 2 3
```

The same block *without* the `CATCH` restarted correctly, and so did both statement-position spellings — the statement arm always computed the reset before its dispatch. `main` gets this right now because the reset precedes the shape dispatch in both positions, which makes the two decisions independent. Nothing pinned that independence, so a change moving the reset back inside an arm would have gone unnoticed by the suite.

## The pins

Four assertions, one per (shape × position) corner: `CATCH` and `ENTER`, in value and in statement position. Plan 30 → 34.

These are real pins, not vacuous ones: the failing behaviour was measured directly on a pre-unification binary earlier today (`1 2 3` where the assertion demands `'11'`).

Test-only; no source change.

## Verification

| | result |
| --- | --- |
| `raku t/block-position-parity.t` | **34/34** unchanged |
| `prove -e target/release/mutsu` on the file | **34/34** |
| `make test` | 3859 files, 40899 tests, **PASS** |
| `make roast` | 1436 files, 218939 tests — only the three container-only failures documented in `docs/agent-environments.md` (`file-tests.t` 4 and `filetest.t` 25 under `uid 0`; `IO-Socket-Async.t` under the network sandbox), matching the recorded counts |

No `news/` entry: this closes a coverage gap in work already recorded by #7636's entry, and the reasoning lives in the test file's own comment rather than being restated as an accomplishment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JLq8g9GoujE4i6STRxeD1v

---
_Generated by [Claude Code](https://claude.ai/code/session_01JLq8g9GoujE4i6STRxeD1v)_