### PR TITLE
feat(runtime): give mutsu a PseudoStash type distinct from Stash

### DIFF
--- a/news/2026-09/pseudostash-type.md
+++ b/news/2026-09/pseudostash-type.md
@@ -1,0 +1,69 @@
+# mutsu has a `PseudoStash` type
+
+Raku keeps a **package** symbol table (`Stash`) apart from a **pseudo-package**
+view of a lexical pad (`PseudoStash`). mutsu had only the first, and the
+spellings that never reached a stash at all answered a bare `Hash`:
+
+| spelling | before | raku |
+|---|---|---|
+| `CALLER::` `CALLERS::` `CORE::` `UNIT::` `SETTING::` `CLIENT::` `OUTERS::` | `Stash` | `PseudoStash` |
+| `MY::` `OUTER::` `DYNAMIC::` `LEXICAL::` | `Hash` | `PseudoStash` |
+| `OUR::` `GLOBAL::` `PROCESS::` | `Stash` | `Stash` |
+
+All fourteen rows match rakudo now, including the three that are genuine
+package symbol tables and stay `Stash`.
+
+## Why the type had to exist first
+
+[#7588](https://github.com/tokuhirom/mutsu/issues/7588) filed this as a
+prerequisite, not a cosmetic gap. `Stash.BIND-KEY` / `CALLER::.BIND-KEY` — what
+`P5tie` and `annotations` need to bind a container into a symbol table — has to
+bind into a *package* in one case and into a *lexical pad* in the other. While
+`OUR::` and `CALLER::CALLER::` were the same mutsu value, implementing one
+would have given the other the wrong semantics. They are distinct types now, so
+that work can proceed.
+
+## What it is, and what it is not
+
+Measured against rakudo: `PseudoStash.^mro` is
+`(PseudoStash Map Cool Any Mu)`. It is a **sibling** of `Stash` under `Map`, not
+a subclass, so it must never be modelled as `class PseudoStash is Stash`. The
+row added to `builtins/builtin_type_catalog.rs` (the ADR-0051 single source of
+truth for built-in ancestry) says exactly that, and `t/pseudostash-type.t`
+asserts `Stash` does not appear anywhere in the MRO.
+
+## How it is represented
+
+The two spelling groups reach different internal representations, and each
+keeps the one it had:
+
+- `CALLER::` and the other package-stash-backed spellings are instances
+  carrying a `symbols` attribute. `Interpreter::stash_class_for_package` now
+  picks the class from the package name, so `make_stash_instance` mints a
+  `PseudoStash` for a pseudo-package spelling and a `Stash` for a real one —
+  one decision point, every caller included. Every code path that used to ask
+  `class_name == "Stash"` asks `crate::value::types::is_stash_class_name`
+  instead, so a pseudo-stash keeps all the behaviour a stash had (`.keys`,
+  `:exists`, `BIND-KEY`, `EVAL ..., context => $stash`, identity under
+  `unique`/`eqv`).
+- `MY::`, `OUTER::`, `LEXICAL::` and `DYNAMIC::` are pad snapshots kept as
+  ordinary hashes — their `.keys`, `.{...}` and iteration all ride the Hash
+  paths — so the type travels as the hash's declared type, exactly the way
+  `Map` already does.
+
+Unifying those two representations is a bigger job than unifying the reported
+type, and nothing here needs it; the type predicate answers the same for both.
+
+`Stash`'s own MRO stays `(Stash Any Mu)` where rakudo has
+`(Stash Hash Map Cool Any Mu)`. That is a separate, pre-existing divergence and
+the ticket explicitly asked for existing `Stash` behaviour to be left alone.
+
+## Found on the way
+
+Writing a pin that passes under rakudo as well as mutsu turned up a second
+divergence: `@a>>.^name` distributes the metamethod in mutsu but applies
+`.^name` to the container in rakudo (`"Array"`). Filed as
+[#7643](https://github.com/tokuhirom/mutsu/issues/7643); the pin uses
+`.map(*.^name)` so it is portable.
+
+Closes [#7588](https://github.com/tokuhirom/mutsu/issues/7588).

--- a/src/builtins/builtin_type_catalog.rs
+++ b/src/builtins/builtin_type_catalog.rs
@@ -135,6 +135,17 @@ static CATALOG: &[BuiltinTypeInfo] = &[
         roles: ["Associative", "Iterable"],
         owner: "Hash",
     ),
+    // A pseudo-package view of a lexical pad (`MY::`, `CALLER::`, `UNIT::`,
+    // ...). Raku keeps it apart from the package symbol table `Stash`: they
+    // are SIBLINGS under `Map`, not parent and child (measured against
+    // rakudo, `PseudoStash.^mro` is `(PseudoStash Map Cool Any Mu)`), so
+    // `PseudoStash` must never be modelled as a `Stash` subclass.
+    row!(
+        "PseudoStash",
+        mro: ["PseudoStash", "Map", "Cool", "Any", "Mu"],
+        roles: ["Associative", "Iterable"],
+        owner: "Hash",
+    ),
     row!(
         "Range",
         mro: ["Range", "Cool", "Any", "Mu"],

--- a/src/builtins/methods_0arg/dispatch_core_coerce.rs
+++ b/src/builtins/methods_0arg/dispatch_core_coerce.rs
@@ -8,6 +8,7 @@ use num_traits::{ToPrimitive, Zero};
 use std::sync::Arc;
 
 use super::parse_raku_int_from_str;
+use crate::value::types::is_stash_class_name;
 
 /// Build the `X::Str::Numeric` attribute map for a string that cannot be
 /// numified, deriving `pos`/`reason` from the same analyzer the numeric
@@ -1218,7 +1219,7 @@ pub(super) fn dispatch(
                     class_name,
                     attributes,
                     ..
-                } if class_name == "Stash" => {
+                } if is_stash_class_name(class_name.as_str()) => {
                     let count = match attributes.as_map().get("symbols").map(Value::view) {
                         Some(ValueView::Hash(map)) => map.len() as i64,
                         _ => 0,

--- a/src/builtins/methods_0arg/dispatch_core_numeric.rs
+++ b/src/builtins/methods_0arg/dispatch_core_numeric.rs
@@ -4,6 +4,7 @@ use crate::builtins::rng::builtin_rand;
 /// uc, lc, fc, tc, sign
 use crate::runtime;
 use crate::symbol::Symbol;
+use crate::value::types::is_stash_class_name;
 use crate::value::{RuntimeError, Value, ValueView};
 use num_traits::Signed;
 
@@ -169,7 +170,7 @@ pub(super) fn dispatch(
                     class_name,
                     attributes,
                     ..
-                } if class_name == "Stash" => {
+                } if is_stash_class_name(class_name.as_str()) => {
                     match attributes.as_map().get("symbols").map(Value::view) {
                         Some(ValueView::Hash(map)) => Value::int(map.len() as i64),
                         _ => Value::int(0),

--- a/src/builtins/methods_0arg/dispatch_core_repr.rs
+++ b/src/builtins/methods_0arg/dispatch_core_repr.rs
@@ -4,6 +4,7 @@ use crate::value::{RuntimeError, Value, ValueView};
 
 use super::raku_repr::{promise_raku_repr, raku_value};
 use super::{format_temporal_num, gist_array_wrap, range_gist_string};
+use crate::value::types::is_stash_class_name;
 
 /// Rakudo caps an aggregate's `.gist` at the first 100 elements, then appends
 /// ` ...`, so a huge array/list does not flood terminal output.
@@ -525,7 +526,7 @@ pub(super) fn dispatch(
             class_name,
             attributes,
             ..
-        } if class_name == "Stash" && (method == "gist" || method == "Str") => {
+        } if is_stash_class_name(class_name.as_str()) && (method == "gist" || method == "Str") => {
             // Stash.gist and Stash.Str return the package name
             if let Some(ValueView::Str(name)) = attributes.as_map().get("name").map(Value::view) {
                 Some(Ok(Value::str(name.to_string())))

--- a/src/builtins/methods_0arg/raku_repr.rs
+++ b/src/builtins/methods_0arg/raku_repr.rs
@@ -342,6 +342,7 @@ fn element_needs_trailing_comma(v: &Value) -> bool {
                 | "Map"
                 | "Hash"
                 | "Stash"
+                | "PseudoStash"
         ),
         _ => false,
     }

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -47,6 +47,7 @@ impl Compiler {
                     | "IO"
                     | "Exception"
                     | "Stash"
+                    | "PseudoStash"
                     | "Array"
                     | "Hash"
                     | "List"

--- a/src/runtime/accessors_stash.rs
+++ b/src/runtime/accessors_stash.rs
@@ -1,6 +1,7 @@
 //! Symbolic stash member lookup and package/indirect-type-name resolution.
 use super::*;
 use crate::value::ValueView;
+use crate::value::types::is_stash_class_name;
 
 impl Interpreter {
     fn stash_symbol_key_from_env_tail(rest: &str) -> String {
@@ -171,7 +172,7 @@ impl Interpreter {
                 class_name,
                 attributes,
                 ..
-            } if class_name == "Stash" => {
+            } if is_stash_class_name(class_name.as_str()) => {
                 let map = attributes.as_map();
                 if let Some(origin) = map.get(Self::STASH_ORIGIN_PACKAGE_ATTR) {
                     return Some(origin.to_string_value());
@@ -200,7 +201,7 @@ impl Interpreter {
                 class_name,
                 attributes,
                 ..
-            } if class_name == "Stash" => {
+            } if is_stash_class_name(class_name.as_str()) => {
                 let map = attributes.as_map();
                 map.get(Self::STASH_ORIGIN_ROUTINE_ATTR)
                     .map(|v| v.to_string_value())
@@ -213,7 +214,33 @@ impl Interpreter {
         let mut attrs = HashMap::new();
         attrs.insert("name".to_string(), Value::str(package.to_string()));
         attrs.insert("symbols".to_string(), Value::hash(symbols));
-        Value::make_instance(Symbol::intern("Stash"), attrs)
+        Value::make_instance(
+            Symbol::intern(Self::stash_class_for_package(package)),
+            attrs,
+        )
+    }
+
+    /// The class a stash for `package` carries: `Stash` for a real package
+    /// symbol table, `PseudoStash` for a pseudo-package view of a lexical pad.
+    ///
+    /// Raku keeps the two apart — `PseudoStash.^mro` is
+    /// `(PseudoStash Map Cool Any Mu)`, so it is a *sibling* of `Stash`, not a
+    /// subclass — and the distinction is what lets a future `BIND-KEY` bind
+    /// into a pad rather than into a package. Measured against rakudo:
+    /// `MY OUTER OUTERS LEXICAL DYNAMIC CALLER CALLERS CORE SETTING UNIT
+    /// CLIENT` answer `PseudoStash`; `OUR`, `GLOBAL` and `PROCESS` are genuine
+    /// package symbol tables and stay `Stash`.
+    ///
+    /// A repeated spelling (`CALLER::CALLER::`) is still a pseudo-stash, which
+    /// is why every component has to be one; a qualified name whose head only
+    /// looks pseudo (`CORE::Foo`) is a package.
+    pub(crate) fn stash_class_for_package(package: &str) -> &'static str {
+        let normalized = Self::normalize_stash_package(package);
+        let is_pseudo = !normalized.is_empty()
+            && normalized.split("::").all(|part| {
+                Self::is_pseudo_package_name(part) && !matches!(part, "OUR" | "GLOBAL")
+            });
+        if is_pseudo { "PseudoStash" } else { "Stash" }
     }
 
     /// Parse a stash made exclusively from repeated `CALLER` components.
@@ -259,7 +286,7 @@ impl Interpreter {
         else {
             return Err(RuntimeError::new("BIND-KEY requires a Stash invocant"));
         };
-        if class_name != "Stash" {
+        if !is_stash_class_name(class_name.as_str()) {
             return Err(RuntimeError::new("BIND-KEY requires a Stash invocant"));
         }
 
@@ -403,7 +430,7 @@ impl Interpreter {
         else {
             return None;
         };
-        if class_name != "Stash" {
+        if !is_stash_class_name(class_name.as_str()) {
             return None;
         }
         let map = attributes.as_map();
@@ -545,7 +572,9 @@ impl Interpreter {
                         return Self::no_such_symbol_failure(name);
                     }
                 }
-                ValueView::Instance { class_name, .. } if class_name == "Stash" => {
+                ValueView::Instance { class_name, .. }
+                    if is_stash_class_name(class_name.as_str()) =>
+                {
                     if let Some(value) = Self::stash_lookup_symbol(&current, part) {
                         value
                     } else {

--- a/src/runtime/builtins_multidim_exists_adverb.rs
+++ b/src/runtime/builtins_multidim_exists_adverb.rs
@@ -7,6 +7,8 @@
 use super::*;
 use crate::value::ArrayKind;
 
+use crate::value::types::is_stash_class_name;
+
 use super::builtins_multidim::{
     has_multi_indices, leaf_key_tuple, make_key_tuple, multidim_collect_leaves, multidim_delete,
     multidim_index_with_hole,
@@ -47,7 +49,7 @@ impl Interpreter {
             attributes,
             ..
         } = target.view()
-            && class_name == "Stash"
+            && is_stash_class_name(class_name.as_str())
             && let Some(ValueView::Hash(symbols)) =
                 attributes.as_map().get("symbols").map(Value::view)
         {

--- a/src/runtime/methods_collection_ops/unique_squish.rs
+++ b/src/runtime/methods_collection_ops/unique_squish.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::value::types::is_stash_class_name;
 
 /// Read a `:as(...)` / `:with(...)` adverb argument regardless of Pair
 /// flavour (ADR-0021 P3a prep): these are always written as literal named
@@ -110,7 +111,7 @@ impl Interpreter {
                     if seen_id == 0
                         && key_id == 0
                         && seen_class == key_class
-                        && seen_class.resolve() != "Stash"
+                        && !is_stash_class_name(seen_class.as_str())
                         && seen_class.resolve() != "Supply"
                     {
                         false
@@ -201,7 +202,7 @@ impl Interpreter {
                     if seen_id == 0
                         && key_id == 0
                         && seen_class == key_class
-                        && seen_class.resolve() != "Stash"
+                        && !is_stash_class_name(seen_class.as_str())
                         && seen_class.resolve() != "Supply"
                     {
                         false

--- a/src/runtime/methods_dispatch_match3.rs
+++ b/src/runtime/methods_dispatch_match3.rs
@@ -1,6 +1,7 @@
 use super::*;
 use crate::symbol::Symbol;
 use crate::value::ValueView;
+use crate::value::types::is_stash_class_name;
 
 impl Interpreter {
     /// Dispatch remaining methods by name (Supply, networking, temporal, misc).
@@ -823,7 +824,7 @@ impl Interpreter {
                 class_name,
                 attributes,
                 ..
-            } if class_name == "Stash" => {
+            } if is_stash_class_name(class_name.as_str()) => {
                 let keys = match attributes.as_map().get("symbols").map(Value::view) {
                     Some(ValueView::Hash(map)) => {
                         map.keys().cloned().map(Value::str).collect::<Vec<Value>>()
@@ -878,7 +879,7 @@ impl Interpreter {
                 class_name,
                 attributes,
                 ..
-            } if class_name == "Stash" => {
+            } if is_stash_class_name(class_name.as_str()) => {
                 let vals = match attributes.as_map().get("symbols").map(Value::view) {
                     Some(ValueView::Hash(map)) => map.values().cloned().collect(),
                     _ => Vec::new(),
@@ -922,7 +923,7 @@ impl Interpreter {
                 );
                 return Some(Ok(Value::truth(exists)));
             }
-            if class_name == "Stash" {
+            if is_stash_class_name(class_name.as_str()) {
                 // Exact-key membership only — unlike the Stash `AT-KEY` arm, raku's
                 // `EXISTS-KEY` does NOT sigil-fallback (`Foo::.EXISTS-KEY('baz')` is
                 // False even when `$baz` exists). Dists query the full sigil'd name
@@ -1009,7 +1010,7 @@ impl Interpreter {
                     ..
                 },
                 idx,
-            ) if class_name == "Stash" => {
+            ) if is_stash_class_name(class_name.as_str()) => {
                 if let Some(ValueView::Hash(symbols)) =
                     attributes.as_map().get("symbols").map(Value::view)
                 {

--- a/src/runtime/methods_instance_ops.rs
+++ b/src/runtime/methods_instance_ops.rs
@@ -6,6 +6,7 @@ use super::*;
 use crate::symbol::Symbol;
 use crate::value::AttrMap;
 use crate::value::ValueView;
+use crate::value::types::is_stash_class_name;
 
 impl Interpreter {
     fn is_pod_block_instance(&mut self, value: &Value) -> bool {
@@ -240,7 +241,9 @@ impl Interpreter {
                     rendered.join(",")
                 ))));
             }
-            "Stash" if method == "raku" || method == "perl" => {
+            _ if is_stash_class_name(class_name.as_str())
+                && (method == "raku" || method == "perl") =>
+            {
                 let symbols = attributes
                     .as_map()
                     .get("symbols")
@@ -1150,7 +1153,7 @@ impl Interpreter {
                     self.make_globalish_package(attributes.as_map().get("globalish-symbols"))
                 );
             }
-            if class_name == "Stash" && method == "merge-symbols" {
+            if is_stash_class_name(class_name.as_str()) && method == "merge-symbols" {
                 let pkg = args.first().cloned().unwrap_or(Value::NIL);
                 return Ok(self.merge_global_symbols(&pkg));
             }

--- a/src/runtime/methods_native_bypass.rs
+++ b/src/runtime/methods_native_bypass.rs
@@ -1,6 +1,7 @@
 use super::resolution_sequence::ResolvedCandidate;
 use super::*;
 use crate::symbol::Symbol;
+use crate::value::types::is_stash_class_name;
 
 impl Interpreter {
     /// Check if a metamodel class name is a HOW type.
@@ -294,7 +295,7 @@ impl Interpreter {
             // misread an Instance receiver as a one-element list instead of
             // reading the Stash's own hash (step 7). `Stash.AT-KEY` needs no
             // gate — it has no cascade arm at all.
-            || (matches!(target.view(), ValueView::Instance { class_name, .. } if class_name == "Stash")
+            || (matches!(target.view(), ValueView::Instance { class_name, .. } if is_stash_class_name(class_name.as_str()))
                 && matches!(method, "keys" | "values"))
             || (method == "keys"
                 && args.is_empty()

--- a/src/runtime/methods_object_dispatch_new.rs
+++ b/src/runtime/methods_object_dispatch_new.rs
@@ -932,12 +932,11 @@ impl Interpreter {
                     // (`try_native_builtin_construct`).
                     return Ok(Value::channel(SharedChannel::new()));
                 }
-                "Stash" => {
-                    // Stash is essentially a Hash but with type Stash
-                    return Ok(Value::make_instance(
-                        Symbol::intern("Stash"),
-                        HashMap::new(),
-                    ));
+                name if crate::value::types::is_stash_class_name(name) => {
+                    // A Stash is essentially a Hash but with type Stash; a
+                    // PseudoStash is its lexical-pad sibling and constructs the
+                    // same way.
+                    return Ok(Value::make_instance(Symbol::intern(name), HashMap::new()));
                 }
                 // A Supply cannot be constructed directly (Rakudo throws
                 // X::Supply::New); live supplies come from a Supplier, on-demand

--- a/src/runtime/methods_object_native_ctors_io.rs
+++ b/src/runtime/methods_object_native_ctors_io.rs
@@ -1,6 +1,7 @@
 use super::*;
 use crate::symbol::Symbol;
 use crate::value::ValueView;
+use crate::value::types::is_stash_class_name;
 
 impl Interpreter {
     pub(crate) fn try_native_io_path_construct(
@@ -389,7 +390,7 @@ impl Interpreter {
             Some(Self::build_native_duration_value(args))
         } else if cn == "StrDistance" {
             Some(Ok(Self::build_native_strdistance_value(args)))
-        } else if cn == "Stash" {
+        } else if is_stash_class_name(cn.as_str()) {
             // A `Stash` is an empty Hash-typed instance.
             Some(Ok(Value::make_instance(class_name, HashMap::new())))
         } else if matches!(

--- a/src/runtime/registration_class.rs
+++ b/src/runtime/registration_class.rs
@@ -644,6 +644,7 @@ impl Interpreter {
                     | "IO"
                     | "Exception"
                     | "Stash"
+                    | "PseudoStash"
             )
         {
             return format!("{}{}", lookup, suffix);

--- a/src/runtime/registration_class_decl.rs
+++ b/src/runtime/registration_class_decl.rs
@@ -102,6 +102,7 @@ pub(crate) const BUILTIN_PARENT_TYPES: &[&str] = &[
     "Proxy",
     "Signature",
     "Stash",
+    "PseudoStash",
     "Metamodel::ClassHOW",
     "Perl6::Metamodel::ClassHOW",
     "Metamodel::GrammarHOW",

--- a/src/runtime/types/type_registry.rs
+++ b/src/runtime/types/type_registry.rs
@@ -1045,6 +1045,7 @@ impl Interpreter {
                 | "Signature"
                 | "Parameter"
                 | "Stash"
+                | "PseudoStash"
                 | "Grammar"
                 | "Proc"
         ) {

--- a/src/runtime/utils/shaped.rs
+++ b/src/runtime/utils/shaped.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::value::types::is_stash_class_name;
 
 /// Check if an array is a shaped (multidimensional) array.
 /// A shaped array is one explicitly created as multidimensional via `:shape`.
@@ -283,7 +284,9 @@ pub(crate) fn values_identical(left: &Value, right: &Value) -> bool {
                 return a_which == b_which;
             }
             if a_name == b_name
-                && (a_name == "Stash" || a_name == "Supply" || a_name == "IO::Special")
+                && (is_stash_class_name(a_name.as_str())
+                    || a_name == "Supply"
+                    || a_name == "IO::Special")
             {
                 left.eqv(right)
             } else if a_name == b_name && (a_name == "ObjAt" || a_name == "ValueObjAt") {

--- a/src/runtime/utils/type_misc.rs
+++ b/src/runtime/utils/type_misc.rs
@@ -37,6 +37,13 @@ pub(crate) fn value_type_name(value: &Value) -> &'static str {
         ValueView::LazyList(ll) if ll.is_genuinely_lazy() => "Seq",
         ValueView::LazyList(_) => "Array",
         ValueView::Hash(ref h) if h.declared_type.as_deref() == Some("Map") => "Map",
+        // A pseudo-package view of a lexical pad (`MY::`, `OUTER::`,
+        // `LEXICAL::`, `DYNAMIC::`) is a `PseudoStash` in raku, not a `Hash`.
+        // mutsu keeps the pad snapshot as a hash and carries the type as its
+        // declared type, the same way `Map` is carried.
+        ValueView::Hash(ref h) if h.declared_type.as_deref() == Some("PseudoStash") => {
+            "PseudoStash"
+        }
         ValueView::Hash(_) => "Hash",
         ValueView::Range(_, _)
         | ValueView::RangeExcl(_, _)

--- a/src/value/display.rs
+++ b/src/value/display.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::value::types::is_stash_class_name;
 use num_bigint::BigInt as NumBigInt;
 use num_traits::{Signed, Zero};
 
@@ -947,7 +948,7 @@ impl Value {
                 class_name,
                 attributes,
                 ..
-            } if class_name == "Stash" => attributes
+            } if is_stash_class_name(class_name.as_str()) => attributes
                 .as_map()
                 .get("name")
                 .map(|v: &Value| v.to_string_value())

--- a/src/value/signature.rs
+++ b/src/value/signature.rs
@@ -1340,6 +1340,7 @@ fn is_supertype_of(t1: &str, t2: &str) -> bool {
                 | "Map"
                 | "Pair"
                 | "Stash"
+                | "PseudoStash"
                 | "QuantHash"
                 | "Set"
                 | "Bag"

--- a/src/value/types.rs
+++ b/src/value/types.rs
@@ -39,6 +39,19 @@ fn anon_role_entries(
         })
 }
 
+/// Whether `class_name` names one of the two symbol-table classes.
+///
+/// Raku splits a package symbol table (`Stash`) from a pseudo-package view of
+/// a lexical pad (`PseudoStash`); they are siblings under `Map`, not parent
+/// and child. mutsu represents both as an instance carrying a `symbols`
+/// attribute and every stash code path treats them alike, so this is the
+/// predicate those paths ask instead of naming one class. Which spelling
+/// produces which class is decided by
+/// `Interpreter::stash_class_for_package`.
+pub(crate) fn is_stash_class_name(class_name: &str) -> bool {
+    matches!(class_name, "Stash" | "PseudoStash")
+}
+
 /// Returns the Raku type name for a value (used in error messages).
 /// The name one argument of a CURRIED parametric role contributes to the
 /// role's own name. Rakudo names `R["x"]` after the argument's TYPE

--- a/src/vm/vm_call_method_mut_ops.rs
+++ b/src/vm/vm_call_method_mut_ops.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::symbol::Symbol;
+use crate::value::types::is_stash_class_name;
 
 impl Interpreter {
     /// The invocant of a `.&sub(...)` call is always bound positionally to the
@@ -638,7 +639,9 @@ impl Interpreter {
         })?;
         let stash_target = if method == "BIND-KEY" && args.len() == 2 {
             match target.view() {
-                ValueView::Instance { class_name, .. } if class_name == "Stash" => {
+                ValueView::Instance { class_name, .. }
+                    if is_stash_class_name(class_name.as_str()) =>
+                {
                     Some(target.clone())
                 }
                 _ => Self::caller_stash_depth(&target_name)
@@ -1420,7 +1423,7 @@ impl Interpreter {
         }
         if !skip_native
             && matches!(method.as_str(), "AT-KEY" | "keys" | "values")
-            && matches!(target.view(), ValueView::Instance { class_name, .. } if class_name == "Stash")
+            && matches!(target.view(), ValueView::Instance { class_name, .. } if is_stash_class_name(class_name.as_str()))
         {
             skip_native = true;
         }

--- a/src/vm/vm_call_method_ops.rs
+++ b/src/vm/vm_call_method_ops.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::symbol::Symbol;
+use crate::value::types::is_stash_class_name;
 
 /// True when a method call on `Nil` is absorbed by Raku's `Nil.FALLBACK` — i.e.
 /// `Nil` does not actually define it, so the call yields `Nil` instead of a
@@ -712,7 +713,7 @@ impl Interpreter {
             && args.len() == 2
             && matches!(
                 target.view(),
-                ValueView::Instance { class_name, .. } if class_name == "Stash"
+                ValueView::Instance { class_name, .. } if is_stash_class_name(class_name.as_str())
             )
         {
             let key = args[0].to_string_value();
@@ -1277,7 +1278,7 @@ impl Interpreter {
         }
         if !skip_native
             && matches!(method, "AT-KEY" | "keys" | "values")
-            && matches!(target.view(), ValueView::Instance { class_name, .. } if class_name == "Stash")
+            && matches!(target.view(), ValueView::Instance { class_name, .. } if is_stash_class_name(class_name.as_str()))
         {
             skip_native = true;
         }

--- a/src/vm/vm_misc_ops.rs
+++ b/src/vm/vm_misc_ops.rs
@@ -61,6 +61,7 @@ pub(super) fn is_core_raku_type(name: &str) -> bool {
             | "HyperWhatever"
             | "WhateverCode"
             | "Stash"
+            | "PseudoStash"
             | "Scalar"
             | "Numeric"
             | "Real"

--- a/src/vm/vm_value_helpers.rs
+++ b/src/vm/vm_value_helpers.rs
@@ -422,6 +422,7 @@ impl Interpreter {
                 | "WhateverCode"
                 | "HyperWhatever"
                 | "Stash"
+                | "PseudoStash"
                 | "StrDistance"
                 | "Scalar"
                 | "SetHash"

--- a/src/vm/vm_var_assign_index_named.rs
+++ b/src/vm/vm_var_assign_index_named.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::symbol::Symbol;
+use crate::value::types::is_stash_class_name;
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -4734,7 +4735,7 @@ impl Interpreter {
                 class_name,
                 attributes,
                 ..
-            } if class_name == "Stash" => {
+            } if is_stash_class_name(class_name.as_str()) => {
                 let package = attributes
                     .as_map()
                     .get("name")

--- a/src/vm/vm_var_assign_local.rs
+++ b/src/vm/vm_var_assign_local.rs
@@ -468,8 +468,8 @@ impl Interpreter {
                 let display_key = Self::add_sigil_prefix(&key_str);
                 entries.insert(display_key, val.clone());
             }
-            self.stack
-                .push(Value::hash_with_data(Value::hash_arc(entries)));
+            let stash = self.pseudo_stash_hash(entries);
+            self.stack.push(stash);
             return;
         }
         if name.strip_suffix("::") == Some("OUR") {
@@ -479,8 +479,8 @@ impl Interpreter {
         }
         if name.strip_suffix("::") == Some("DYNAMIC") {
             let entries = self.dynamic_pseudo_stash_entries();
-            self.stack
-                .push(Value::hash_with_data(Value::hash_arc(entries)));
+            let stash = self.pseudo_stash_hash(entries);
+            self.stack.push(stash);
             return;
         }
         if let Some(kind) = name.strip_suffix("::")
@@ -535,8 +535,29 @@ impl Interpreter {
             entries.entry(display_key).or_insert_with(|| val.clone());
         }
         self.add_visible_routines_to_pseudo_stash(&mut entries);
-        self.stack
-            .push(Value::hash_with_data(Value::hash_arc(entries)));
+        let stash = self.pseudo_stash_hash(entries);
+        self.stack.push(stash);
+    }
+
+    /// Wrap a lexical-pad snapshot as a `PseudoStash`.
+    ///
+    /// Raku reports every pseudo-package view of a pad (`MY::`, `OUTER::`,
+    /// `LEXICAL::`, `DYNAMIC::`) as `PseudoStash`, a `Map` descendant that is a
+    /// *sibling* of `Stash`, not a subclass. mutsu keeps the snapshot as an
+    /// ordinary hash — its `.keys`, `.{...}` and iteration all ride the Hash
+    /// paths — so the type travels as the hash's declared type, exactly the way
+    /// a `Map` does. Without this the spellings answered a bare `Hash`, with no
+    /// symbol-table type at all.
+    fn pseudo_stash_hash(&mut self, entries: HashMap<String, Value>) -> Value {
+        let hash = Value::hash_with_data(Value::hash_arc(entries));
+        self.tag_container_metadata(
+            hash,
+            crate::runtime::ContainerTypeInfo {
+                value_type: String::new(),
+                key_type: None,
+                declared_type: Some("PseudoStash".to_string()),
+            },
+        )
     }
 
     /// Build a pseudo-stash hash for a given pseudo-package name.
@@ -552,7 +573,7 @@ impl Interpreter {
                 let display_key = Self::add_sigil_prefix(&key_str);
                 entries.insert(display_key, val.clone());
             }
-            return Value::hash_with_data(Value::hash_arc(entries));
+            return self.pseudo_stash_hash(entries);
         }
         if name == "OUR" {
             return self.our_pseudo_stash();
@@ -576,7 +597,7 @@ impl Interpreter {
             entries.entry(display_key).or_insert_with(|| val.clone());
         }
         self.add_visible_routines_to_pseudo_stash(&mut entries);
-        Value::hash_with_data(Value::hash_arc(entries))
+        self.pseudo_stash_hash(entries)
     }
 
     fn add_visible_routines_to_pseudo_stash(&self, entries: &mut HashMap<String, Value>) {

--- a/src/vm/vm_var_exists_ops.rs
+++ b/src/vm/vm_var_exists_ops.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::value::types::is_stash_class_name;
 
 impl Interpreter {
     /// Rich :exists adverb handler supporting negation, parameterized arg,
@@ -188,7 +189,7 @@ impl Interpreter {
                     class_name,
                     attributes,
                     ..
-                } if class_name == "Stash" => {
+                } if is_stash_class_name(class_name.as_str()) => {
                     match attributes.as_map().get("symbols").map(Value::view) {
                         Some(ValueView::Hash(map)) => Some(map.clone()),
                         _ => None,
@@ -554,7 +555,8 @@ impl Interpreter {
                 ..
             } = target.view()
             {
-                let is_stash = class_name == "Stash" && attributes.contains_key("symbols");
+                let is_stash =
+                    is_stash_class_name(class_name.as_str()) && attributes.contains_key("symbols");
                 if !is_stash
                     && let Some(result) = self.instance_exists_pos_result(
                         &target,
@@ -686,7 +688,7 @@ impl Interpreter {
                                     ..
                                 },
                                 ValueView::Str(key),
-                            ) if class_name == "Stash" => {
+                            ) if is_stash_class_name(class_name.as_str()) => {
                                 if let Some(ValueView::Hash(symbols)) =
                                     attributes.as_map().get("symbols").map(Value::view)
                                 {
@@ -702,7 +704,7 @@ impl Interpreter {
                                     ..
                                 },
                                 _,
-                            ) if class_name == "Stash" => {
+                            ) if is_stash_class_name(class_name.as_str()) => {
                                 if let Some(ValueView::Hash(symbols)) =
                                     attributes.as_map().get("symbols").map(Value::view)
                                 {

--- a/t/pseudostash-type.t
+++ b/t/pseudostash-type.t
@@ -1,0 +1,37 @@
+use Test;
+
+# Raku keeps a package symbol table (`Stash`) apart from a pseudo-package view
+# of a lexical pad (`PseudoStash`). mutsu used to collapse both into `Stash`,
+# and the lexical/dynamic spellings that never reached a stash at all answered
+# a bare `Hash`.
+
+plan 18;
+
+is MY::.^name,      'PseudoStash', 'MY:: is a PseudoStash';
+is OUTER::.^name,   'PseudoStash', 'OUTER:: is a PseudoStash';
+is OUTERS::.^name,  'PseudoStash', 'OUTERS:: is a PseudoStash';
+is LEXICAL::.^name, 'PseudoStash', 'LEXICAL:: is a PseudoStash';
+is DYNAMIC::.^name, 'PseudoStash', 'DYNAMIC:: is a PseudoStash';
+is CALLER::.^name,  'PseudoStash', 'CALLER:: is a PseudoStash';
+is CALLERS::.^name, 'PseudoStash', 'CALLERS:: is a PseudoStash';
+is CORE::.^name,    'PseudoStash', 'CORE:: is a PseudoStash';
+is SETTING::.^name, 'PseudoStash', 'SETTING:: is a PseudoStash';
+is UNIT::.^name,    'PseudoStash', 'UNIT:: is a PseudoStash';
+is CLIENT::.^name,  'PseudoStash', 'CLIENT:: is a PseudoStash';
+
+# The three spellings that name a genuine package symbol table stay Stash.
+is OUR::.^name,     'Stash', 'OUR:: is a real package Stash';
+is GLOBAL::.^name,  'Stash', 'GLOBAL:: is a real package Stash';
+is PROCESS::.^name, 'Stash', 'PROCESS:: is a real package Stash';
+
+sub in-a-sub { CALLER::.^name }
+is in-a-sub(), 'PseudoStash', 'CALLER:: taken inside a routine is a PseudoStash';
+
+# PseudoStash is a Map descendant and a *sibling* of Stash, never a subclass:
+# implementing it as `class PseudoStash is Stash` would be wrong.
+is PseudoStash.^mro.map(*.^name).join(' '), 'PseudoStash Map Cool Any Mu',
+    'PseudoStash descends from Map';
+nok PseudoStash.^mro.map(*.^name).any eq 'Stash',
+    'PseudoStash is not derived from Stash';
+is MY::.^mro.map(*.^name).join(' '), 'PseudoStash Map Cool Any Mu',
+    'a live pseudo-stash carries that same MRO';


### PR DESCRIPTION
Raku keeps a **package** symbol table (`Stash`) apart from a **pseudo-package**
view of a lexical pad (`PseudoStash`). mutsu had only the first, and the
spellings that never reached a stash at all answered a bare `Hash`.

| spelling | before | raku / after |
|---|---|---|
| `CALLER::` `CALLERS::` `CORE::` `UNIT::` `SETTING::` `CLIENT::` `OUTERS::` | `Stash` | `PseudoStash` |
| `MY::` `OUTER::` `DYNAMIC::` `LEXICAL::` | **`Hash`** | `PseudoStash` |
| `OUR::` `GLOBAL::` `PROCESS::` | `Stash` | `Stash` (unchanged) |

All fourteen spellings match rakudo now, including the three that name a
genuine package symbol table and stay `Stash`.

## Why this is a prerequisite, not a cosmetic gap

`Stash.BIND-KEY` / `CALLER::.BIND-KEY` — what `P5tie` and `annotations` need to
bind a container into a symbol table — has to bind into a *package* in one case
and into a *lexical pad* in the other. While `OUR::` and `CALLER::CALLER::`
were the same mutsu value, implementing one would have given the other the
wrong semantics. They are distinct types now, so that work can proceed.

## What PseudoStash is, and what it is not

Measured against rakudo: `PseudoStash.^mro` is `(PseudoStash Map Cool Any Mu)`.
It is a **sibling** of `Stash` under `Map`, not a subclass, so it must never be
modelled as `class PseudoStash is Stash`. The row added to
`builtins/builtin_type_catalog.rs` — the ADR-0051 single source of truth for
built-in ancestry — says exactly that, and the pin asserts `Stash` appears
nowhere in the MRO.

## Representation

The two spelling groups keep the internal shape they already had:

- `CALLER::` and the other package-stash-backed spellings are instances
  carrying a `symbols` attribute. `Interpreter::stash_class_for_package` now
  picks the class from the package name, so `make_stash_instance` mints a
  `PseudoStash` for a pseudo-package spelling and a `Stash` for a real one —
  one decision point, every caller included. Every path that used to ask
  `class_name == "Stash"` asks `crate::value::types::is_stash_class_name`
  instead, so a pseudo-stash keeps all the behaviour a stash had (`.keys`,
  `:exists`, `BIND-KEY`, `EVAL ..., context => $stash`, identity under
  `unique`/`eqv`).
- `MY::`, `OUTER::`, `LEXICAL::` and `DYNAMIC::` are pad snapshots kept as
  ordinary hashes — their `.keys`, `.{...}` and iteration all ride the Hash
  paths — so the type travels as the hash's declared type, exactly the way
  `Map` already does.

Unifying those two representations is a bigger job than unifying the reported
type and nothing here needs it; the predicate answers the same for both.

## Deliberately out of scope

`Stash`'s own MRO stays `(Stash Any Mu)` where rakudo has
`(Stash Hash Map Cool Any Mu)`. That is a separate, pre-existing divergence and
the ticket explicitly asked for existing `Stash` behaviour to be left alone.

## Tests

`t/pseudostash-type.t` — 18 subtests: every pseudo-package spelling and the
type it produces (including the three that must stay `Stash`), `CALLER::` taken
from inside a routine, `PseudoStash.^mro`, and an explicit assertion that
`Stash` is **not** in that MRO. It passes under **`raku` as well as `mutsu`**,
so it is a spec pin rather than a mutsu-shaped one.

`cargo fmt --all`, `make lint`, `make test` (PASS, 40862 tests) and
`make roast` were run locally. `make roast`'s only red files are the three
environment-only ones this container cannot pass, with exactly the shapes
documented in `docs/agent-environments.md` (`6.c/S32-io/file-tests.t` tests
6-8/10 and `S16-filehandles/filetest.t` under `uid 0`;
`S32-io/IO-Socket-Async.t` timing out in the network sandbox).

## Found on the way

Writing a pin that passes under rakudo as well as mutsu turned up a second
divergence: `@a>>.^name` distributes the metamethod in mutsu but applies
`.^name` to the container in rakudo (`"Array"`). Filed as #7643 rather than
widened into this PR; the pin uses `.map(*.^name)` so it is portable.

Closes #7588

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TAdHjoCdB8QjLBEDy87tXS

---
_Generated by [Claude Code](https://claude.ai/code/session_01TAdHjoCdB8QjLBEDy87tXS)_