### PR TITLE
fix(compiler): mark a block's let/temp scope on the AST node

### DIFF
--- a/news/2026-09/do-block-let-scope-marked-on-the-ast-node.md
+++ b/news/2026-09/do-block-let-scope-marked-on-the-ast-node.md
@@ -1,0 +1,110 @@
+# A block's `let`/`temp` scope is decided by the AST node, not by a sentinel label
+
+`let` and `temp` save a variable's previous value and resolve that save at the end of the
+enclosing **block** — `temp` always restores, `let` restores when the block fails and commits
+when it succeeds.
+
+The bare-block unification (GH-7569, ADR-0076) gave the value position the `let`/`temp` branch
+the statement position always had, which closed the divergence GH-7635 was filed for:
+
+```raku
+my $x = 1;
+do { let $x = 2; Nil };
+say $x;      # raku: 1
+```
+
+It had to answer a second question to do that. **`Expr::DoBlock` is not a Raku block.** Around
+forty parser and compiler desugars build one as a generic "run these statements, yield a value"
+vehicle: item context `$( ... )`, the chained-comparison temp-var lowering, `cas`, compound
+assignment, `.=` writeback, hyper-op destructuring. None of those open a scope at which a save
+may resolve, and treating one as a block resolves the save at the innermost wrapper rather than
+at the real block — which breaks the idiom roast leans on throughout:
+
+```raku
+my $a = 42;
+{
+  is($(let $a = 23; $a), 23, "let() changed the variable");
+  Mu;
+}
+is $a, 42, "let() should restore the variable, as our block failed";
+```
+
+The answer at the time was a **denylist**: a sentinel label
+(`STMT_LIST_CONTEXTUALIZER_LABEL`) on the one node known to need the exemption, `$( ... )`, with
+every other `Expr::DoBlock` owning a save frame by default.
+
+## The marker moves onto the node, and becomes an allowlist
+
+`Expr::DoBlock` now carries a `DoBlockOrigin`, which is what GH-7635 asked for.
+`DoBlockOrigin::SourceBlock` is set at the handful of sites that mint a node from real source
+braces that *are* a Raku block:
+
+- the `do` keyword's own braces (`parser/primary/ident/identifier_call.rs`) — the single site
+  that parses that form;
+- a labelled `L: do { ... }` and a labelled bare `L: { ... }`
+  (`parser/stmt/control/labeled_loop.rs`);
+- the statement prefixes whose block runs inline in the current frame rather than as a closure —
+  `lazy`, `sink`, `quietly` — which re-host the user's own braces in a `DoBlock`;
+- the RakuAST round-trip of `StatementPrefixDo` (`rakuast/lower.rs`).
+
+Everything else is `DoBlockOrigin::Desugar`, which is what the new `Expr::desugar_block`
+constructor produces, so a future desugar gets the right answer without having to know the rule
+exists. That is the point of the direction change: a denylist is only correct for the exemptions
+somebody thought to write down, and it was already wrong for one that nobody had.
+
+`BlockPosition::Value` carries the origin, so `BlockPlan::analyze` reads the answer off the
+position it is already given and the sentinel label is gone — leaving `label` to mean the
+block's label again.
+
+## Two divergences the allowlist fixes
+
+**A string-interpolation block owned a save frame it should not.** `temp` restores
+unconditionally at the block that owns the save, so it is the sharp test for whether a construct
+is one, and Rakudo says an interpolation block is not:
+
+```raku
+my $x = 1;
+my $s = "{ temp $x = 2; 'v' }";
+say $x;      # raku: 2   mutsu (before): 1
+```
+
+Interpolation builds `DoStmt(Stmt::Block(...))` and reached the value-position block lowering
+with no exemption. It is `Desugar` now, with the measurement recorded at the site.
+
+**A value-position `let` block clobbered the enclosing topic.** `OpCode::LetBlock` reads the
+block's own value to decide restore-vs-commit, and the two positions leave that value in
+different places: the statement form routes its last statement through
+`compile_last_stmt_as_topic`, so the op read `$_`; the value form had the value on the stack and
+was made to fit by emitting `Dup; SetTopic`. That wrote the enclosing scope's topic:
+
+```raku
+my $x = 1;
+$_ = 'topic';
+do { let $x = 2; 99 };
+say $_;      # raku: topic   mutsu (before): 99
+```
+
+The opcode now carries `value_on_stack`, and `exec_let_block_op` peeks the stack top instead of
+reading the topic when it is set. No `Dup`/`SetTopic`, no collateral damage.
+
+## Two consequences of widening the node
+
+The AST is what the precompilation cache stores, so an older build's cached `DoBlock`
+deserializes a field short — `precomp.rs`'s `CACHE_FORMAT_VERSION` goes to 11 accordingly.
+
+`rakuast/convert.rs` now refuses to convert a `Desugar` node to `StatementPrefixDo`. It would
+otherwise round-trip back through `lower.rs` as a genuine source block, handing back a node with
+block semantics the original never had.
+
+Pin: `t/do-block-let-resolution.t`, 21 assertions, all of which pass unchanged under `raku`.
+
+## Still open
+
+Two neighbouring divergences share the subsystem but not the root cause, and are filed
+separately rather than widened into this change:
+
+- GH-7645: `Compiler::has_let_deep` does not look inside a declaration's or an assignment's
+  initializer, so `{ my $seen = $( let $a = 23; $a ); Nil }` never classifies its enclosing block
+  as a `let` block at all.
+- GH-7646: a routine body does not resolve its own saves — `sub f() { let $x = 2; Nil }` leaves
+  `$x` at 2 where `raku` restores it to 1.

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -491,17 +491,6 @@ pub(crate) enum PhaserKind {
     Close,
 }
 
-/// Sentinel [`Expr::DoBlock`] label for `$( stmt; ... )`, the statement-list
-/// contextualizer.
-///
-/// `$( ... )` is lowered to a `DoBlock` because it carries a statement list,
-/// but it is NOT a Raku block: a `let`/`temp` written inside it belongs to the
-/// ENCLOSING block's save frame, so `{ $(let $a = 23; $a); Mu }` still restores
-/// `$a` when that block fails (roast `S04-blocks-and-statements/let.t`,
-/// `temp.t`). `Compiler::compile_block_construct` reads this label to skip the
-/// `let`/`temp` scope, and never forwards it to `OpCode::DoBlockExpr`.
-pub(crate) const STMT_LIST_CONTEXTUALIZER_LABEL: &str = "__mutsu_stmt_list_contextualizer__";
-
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[allow(clippy::enum_variant_names, dead_code)]
 pub(crate) enum Expr {
@@ -868,13 +857,23 @@ pub(crate) enum Expr {
         append: bool,
         left_is_source: bool,
     },
+    /// Run `body` and yield its last value.
+    ///
+    /// This node is overloaded: it is *both* the AST for a genuine source
+    /// `do { ... }` block *and* the generic "run these statements, yield a
+    /// value" vehicle that around forty parser/compiler desugars build (the
+    /// chained-comparison temp-var lowering, `cas`, compound assignment,
+    /// `.=` writeback, item context `$( ... )`, ...). Only the first kind is a
+    /// Raku block, and `origin` is what tells them apart — see
+    /// [`DoBlockOrigin`]. Build a desugar's node with
+    /// [`Expr::desugar_block`] rather than writing the origin out by hand.
     DoBlock {
         body: Vec<Stmt>,
-        /// The block's own label, or one of the compiler sentinels
-        /// ([`STMT_LIST_CONTEXTUALIZER_LABEL`], `__mutsu_check_phaser__`) that
-        /// mark a `DoBlock` the parser synthesized for something that is not a
-        /// source-level `do { ... }`.
+        /// The block's own label, or the `__mutsu_check_phaser__` sentinel a
+        /// lifted CHECK phaser body carries. Whether the node is a source-level
+        /// block is `origin`'s job, not this field's.
         label: Option<String>,
+        origin: DoBlockOrigin,
     },
     DoStmt(Box<Stmt>),
     ControlFlow {
@@ -909,6 +908,33 @@ pub(crate) enum Expr {
         target: Box<Expr>,
         adverb: HyperSliceAdverb,
     },
+}
+
+/// What a [`Expr::DoBlock`] node actually is.
+///
+/// The node has two unrelated jobs, and telling them apart matters wherever a
+/// question is really being asked about *Raku block scope* rather than about
+/// "some statements that yield a value". The motivating one is `let`/`temp`:
+/// those save the previous value and resolve it — restore on failure, commit
+/// on success — **at the end of the enclosing block**. A synthesized wrapper
+/// is not that block, so resolving a save at one would resolve it far too
+/// early (GH-7635).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub(crate) enum DoBlockOrigin {
+    /// Real `{ ... }` braces the user wrote, which *are* a Raku block: `do {
+    /// ... }`, a labelled `L: { ... }`, and the statement prefixes whose block
+    /// runs inline in the current frame (`lazy`/`sink`/`quietly`).
+    SourceBlock,
+    /// A parser or compiler desugar using the node as a generic sequencing
+    /// vehicle. It introduces no scope of its own, so a `let` inside one still
+    /// belongs to whatever real block encloses it.
+    ///
+    /// Item context `$( ... )` is deliberately here: `{ $seen = $(let $a = 23;
+    /// $a); Mu }` restores `$a` when the *outer* block fails, an idiom roast
+    /// leans on throughout (`S04-blocks-and-statements/let.t`). String
+    /// interpolation `"{ ... }"` is here too — measured against Rakudo, its
+    /// block does not resolve a save either.
+    Desugar,
 }
 
 /// Secondary adverb on :exists subscript adverb
@@ -1856,6 +1882,21 @@ fn collect_assign_ph_stmt(stmt: &Stmt, out: &mut Vec<String>) {
 }
 
 impl Expr {
+    /// A [`DoBlockOrigin::Desugar`] [`Expr::DoBlock`]: run `body`, yield its
+    /// last value, introduce no scope.
+    ///
+    /// This is the constructor every parser/compiler desugar wants. A genuine
+    /// source `do { ... }` writes the struct literal out instead, with
+    /// [`DoBlockOrigin::SourceBlock`] — there are only a handful of those, and
+    /// spelling them the verbose way keeps them greppable.
+    pub(crate) fn desugar_block(body: Vec<Stmt>) -> Expr {
+        Expr::DoBlock {
+            body,
+            label: None,
+            origin: DoBlockOrigin::Desugar,
+        }
+    }
+
     /// Look through the parenthesization markers the parser records, returning
     /// the expression the source actually wrote inside the parentheses.
     ///

--- a/src/chain_compare.rs
+++ b/src/chain_compare.rs
@@ -78,28 +78,25 @@ fn build_chain_cmp_expr(
     let tmp_var = Expr::Var(tmp_name.clone());
     let cmp = make_chain_cmp(left, op, tmp_var.clone(), negated);
     let rest = build_chain_cmp_expr(operands, ops, index + 1, tmp_var.clone());
-    Expr::DoBlock {
-        body: vec![
-            Stmt::VarDecl {
-                name: tmp_name,
-                expr: operands[index + 1].clone(),
-                type_constraint: None,
-                is_state: false,
-                is_our: false,
-                is_dynamic: false,
-                is_export: false,
-                export_tags: Vec::new(),
-                custom_traits: Vec::new(),
-                where_constraint: None,
-            },
-            Stmt::Expr(Expr::Binary {
-                left: Box::new(cmp),
-                op: TokenKind::AndAnd,
-                right: Box::new(rest),
-            }),
-        ],
-        label: None,
-    }
+    Expr::desugar_block(vec![
+        Stmt::VarDecl {
+            name: tmp_name,
+            expr: operands[index + 1].clone(),
+            type_constraint: None,
+            is_state: false,
+            is_our: false,
+            is_dynamic: false,
+            is_export: false,
+            export_tags: Vec::new(),
+            custom_traits: Vec::new(),
+            where_constraint: None,
+        },
+        Stmt::Expr(Expr::Binary {
+            left: Box::new(cmp),
+            op: TokenKind::AndAnd,
+            right: Box::new(rest),
+        }),
+    ])
 }
 
 /// Expand an `Expr::ChainedCompare { operands, ops }` marker into its runtime

--- a/src/compiler/control_block.rs
+++ b/src/compiler/control_block.rs
@@ -47,6 +47,11 @@ pub(super) enum BlockPosition {
         /// scalar/array `my`/`state` declarations on exit while letting
         /// mutations of outer variables persist.
         isolate: bool,
+        /// Whether the node came from real source braces that *are* a Raku
+        /// block, or from one of the ~40 desugars that use `Expr::DoBlock` as a
+        /// generic sequencing vehicle. Only the first owns a `let`/`temp` save
+        /// frame — see [`crate::ast::DoBlockOrigin`] and GH-7635.
+        origin: crate::ast::DoBlockOrigin,
     },
 }
 
@@ -56,7 +61,20 @@ impl BlockPosition {
     }
 
     fn isolate(self) -> bool {
-        matches!(self, Self::Value { isolate: true })
+        matches!(self, Self::Value { isolate: true, .. })
+    }
+
+    /// Whether a `let`/`temp` in the body resolves at THIS block.
+    ///
+    /// A statement `{ ... }` always is a block. A value-position node is one
+    /// only when the parser minted it from source braces; a desugar's node
+    /// opens no scope, so a save inside it belongs to whatever real block
+    /// encloses it.
+    fn owns_let_scope(self) -> bool {
+        match self {
+            Self::Statement => true,
+            Self::Value { origin, .. } => origin == crate::ast::DoBlockOrigin::SourceBlock,
+        }
     }
 }
 
@@ -102,15 +120,12 @@ pub(super) struct BlockPlan {
 }
 
 impl BlockPlan {
-    /// `owns_let_scope` is false for a `DoBlock` the parser synthesized for
-    /// something that is not a source-level block -- see
-    /// [`crate::ast::STMT_LIST_CONTEXTUALIZER_LABEL`].
-    fn analyze(stmts: &[Stmt], position: BlockPosition, owns_let_scope: bool) -> Self {
+    fn analyze(stmts: &[Stmt], position: BlockPosition) -> Self {
         let shape = if Compiler::has_catch_or_control(stmts) {
             BlockShape::ImplicitTry
         } else if Compiler::has_block_enter_leave_phasers(stmts) {
             BlockShape::PhaserScope
-        } else if owns_let_scope && Compiler::has_let_deep(stmts) {
+        } else if position.owns_let_scope() && Compiler::has_let_deep(stmts) {
             BlockShape::LetScope
         } else {
             BlockShape::Plain
@@ -154,17 +169,7 @@ impl Compiler {
             return;
         }
 
-        // `$( stmt; ... )` carries a statement list in a `DoBlock` but is not a
-        // Raku block: a `let`/`temp` in it belongs to the ENCLOSING block's save
-        // frame. Strip the sentinel here so it can never reach
-        // `OpCode::DoBlockExpr`'s `leave LABEL` matching.
-        let (label, owns_let_scope) = if matches!(label, Some(l) if l == crate::ast::STMT_LIST_CONTEXTUALIZER_LABEL)
-        {
-            (&None, false)
-        } else {
-            (label, true)
-        };
-        let plan = BlockPlan::analyze(stmts, position, owns_let_scope);
+        let plan = BlockPlan::analyze(stmts, position);
 
         // A bare block is where an escaping `when`/`default` succeed stops
         // unwinding when nothing closer (a `given`, another bare block, an `if`
@@ -367,18 +372,21 @@ impl Compiler {
                 // Block contains `let`/`temp` — wrap in LetBlock for
                 // save/restore. `exec_let_block_op` never touches the value
                 // stack, so the inner shape decides the block's value.
-                let idx = self.code.emit(OpCode::LetBlock { body_end: 0 });
+                //
+                // A real `let` rolls its saves back unless the block succeeded,
+                // so `exec_let_block_op` needs the block's own value — and the
+                // two positions leave it in different places. The statement form
+                // routes its last statement through `compile_last_stmt_as_topic`
+                // and the op reads the topic; the value form already has the
+                // value on the stack and must NOT write the topic, or a
+                // `do { ... }` would clobber `$_` for the enclosing scope
+                // (GH-7635). `value_on_stack` is which of the two the op reads.
+                let idx = self.code.emit(OpCode::LetBlock {
+                    body_end: 0,
+                    value_on_stack: position.is_value(),
+                });
                 if position.is_value() {
                     self.emit_plain_block(stmts, label, position, plan, is_bare);
-                    if plan.let_needs_value {
-                        // A real `let` rolls its saves back unless the block
-                        // succeeded, and `exec_let_block_op` reads that verdict
-                        // off the topic register. The statement form routes its
-                        // last statement through `compile_last_stmt_as_topic`;
-                        // the value form already has the value on the stack.
-                        self.code.emit(OpCode::Dup);
-                        self.code.emit(OpCode::SetTopic);
-                    }
                 } else {
                     // Raku's "declarations are in effect at block start" rule
                     // (see `hoist_typed_var_decls`).

--- a/src/compiler/expr.rs
+++ b/src/compiler/expr.rs
@@ -673,7 +673,12 @@ impl Compiler {
                 // which reuses the ordinary list `.lazy` marking.
                 let do_block = Expr::DoBlock {
                     body: body.clone(),
+                    // The braces are the user's own block, merely re-hosted to
+                    // run inline instead of as a closure, so it keeps that
+                    // block's identity: `lazy { let $x = 2; Nil }` resolves the
+                    // save here (GH-7635).
                     label: None,
+                    origin: crate::ast::DoBlockOrigin::SourceBlock,
                 };
                 self.compile_expr(&Expr::MethodCall {
                     target: Box::new(do_block),
@@ -1004,10 +1009,12 @@ impl Compiler {
             Expr::Try { body, catch } => {
                 self.compile_try(body, catch);
             }
-            Expr::DoBlock { .. } => {
-                if let Expr::DoBlock { body, label } = expr {
-                    self.compile_do_block_expr(body, label);
-                }
+            Expr::DoBlock {
+                body,
+                label,
+                origin,
+            } => {
+                self.compile_do_block_expr(body, label, *origin);
             }
             Expr::DoStmt(stmt) => {
                 self.compile_expr_do_stmt(stmt);

--- a/src/compiler/expr_block.rs
+++ b/src/compiler/expr_block.rs
@@ -807,7 +807,16 @@ impl Compiler {
                 self.compile_stmt(stmt);
             }
             Stmt::Block(inner) => {
-                self.compile_do_block_expr_scoped(inner, &None);
+                // Not a `let`/`temp` save frame, measured against Rakudo. The
+                // shape that reaches here is a contextualizer wrapping a
+                // statement list -- string interpolation builds
+                // `DoStmt(Stmt::Block(...))` -- and `temp`, which restores
+                // unconditionally at the block that owns the save, does NOT
+                // restore across one: `my $x = 1; my $s = "{ temp $x = 2; 'v' }"`
+                // leaves `$x` at 2 in `raku`. A genuine value-position block
+                // arrives as an `Expr::DoBlock` carrying
+                // `DoBlockOrigin::SourceBlock` instead (GH-7635).
+                self.compile_do_block_expr_scoped(inner, &None, crate::ast::DoBlockOrigin::Desugar);
             }
             Stmt::SyntheticBlock(inner)
                 if inner.last().is_some_and(|s| {
@@ -910,7 +919,9 @@ impl Compiler {
                 self.compile_expr(&Expr::ArrayLiteral(values));
             }
             Stmt::SyntheticBlock(inner) => {
-                self.compile_do_block_expr_scoped(inner, &None);
+                // Synthesized by a compile site, not written as braces, so it
+                // opens no scope a save could resolve at.
+                self.compile_do_block_expr_scoped(inner, &None, crate::ast::DoBlockOrigin::Desugar);
             }
             Stmt::Let {
                 name,

--- a/src/compiler/expr_call.rs
+++ b/src/compiler/expr_call.rs
@@ -1344,10 +1344,8 @@ impl Compiler {
                         _ => true,
                     },
                 };
-                let do_block = Expr::DoBlock {
-                    body: vec![Stmt::Expr(viv_assign), Stmt::Expr(writeback)],
-                    label: None,
-                };
+                let do_block =
+                    Expr::desugar_block(vec![Stmt::Expr(viv_assign), Stmt::Expr(writeback)]);
                 self.compile_expr(&do_block);
             } else {
                 let method_call = Expr::MethodCall {
@@ -1373,10 +1371,13 @@ impl Compiler {
                 // compile it as a genuine arity-N closure and merely sink the
                 // closure *value* itself.
                 Expr::AnonSub { body, .. } | Expr::AnonSubParams { body, .. } => {
-                    // sink { ... } -- execute the block body inline via do block
+                    // sink { ... } -- execute the block body inline via do block.
+                    // Re-hosted user braces, so the node keeps that block's
+                    // identity (GH-7635).
                     let do_block = Expr::DoBlock {
                         body: body.clone(),
                         label: None,
+                        origin: crate::ast::DoBlockOrigin::SourceBlock,
                     };
                     self.compile_expr(&do_block);
                     // Discard the block result and push Nil
@@ -1422,11 +1423,14 @@ impl Compiler {
         else if name == "quietly" && args.len() == 1 {
             match &args[0] {
                 Expr::AnonSub { body, .. } | Expr::AnonSubParams { body, .. } => {
-                    // `quietly { ... }` -- run the block body inline as a do-block.
+                    // `quietly { ... }` -- run the block body inline as a
+                    // do-block. Re-hosted user braces, so the node keeps that
+                    // block's identity (GH-7635).
                     self.code.emit(OpCode::WarnSuppressPush);
                     let do_block = Expr::DoBlock {
                         body: body.clone(),
                         label: None,
+                        origin: crate::ast::DoBlockOrigin::SourceBlock,
                     };
                     self.compile_expr(&do_block);
                     self.code.emit(OpCode::WarnSuppressPop);
@@ -1543,36 +1547,33 @@ impl Compiler {
                         "__mutsu_cas_seen_{}",
                         STATE_COUNTER.fetch_add(1, Ordering::Relaxed)
                     );
-                    let cas_expr = Expr::DoBlock {
-                        body: vec![
-                            Stmt::VarDecl {
-                                name: seen_name.clone(),
-                                expr: args[0].clone(),
-                                type_constraint: None,
-                                is_state: false,
-                                is_our: false,
-                                is_dynamic: false,
-                                is_export: false,
-                                export_tags: Vec::new(),
-                                custom_traits: Vec::new(),
-                                where_constraint: None,
+                    let cas_expr = Expr::desugar_block(vec![
+                        Stmt::VarDecl {
+                            name: seen_name.clone(),
+                            expr: args[0].clone(),
+                            type_constraint: None,
+                            is_state: false,
+                            is_our: false,
+                            is_dynamic: false,
+                            is_export: false,
+                            export_tags: Vec::new(),
+                            custom_traits: Vec::new(),
+                            where_constraint: None,
+                        },
+                        Stmt::If {
+                            cond: Expr::Binary {
+                                left: Box::new(Expr::Var(seen_name.clone())),
+                                op: TokenKind::EqEq,
+                                right: Box::new(args[1].clone()),
                             },
-                            Stmt::If {
-                                cond: Expr::Binary {
-                                    left: Box::new(Expr::Var(seen_name.clone())),
-                                    op: TokenKind::EqEq,
-                                    right: Box::new(args[1].clone()),
-                                },
-                                then_branch: vec![assign_stmt],
-                                else_branch: vec![],
-                                binding_var: None,
-                                is_statement_modifier: false,
-                                is_unless: false,
-                            },
-                            Stmt::Expr(Expr::Var(seen_name)),
-                        ],
-                        label: None,
-                    };
+                            then_branch: vec![assign_stmt],
+                            else_branch: vec![],
+                            binding_var: None,
+                            is_statement_modifier: false,
+                            is_unless: false,
+                        },
+                        Stmt::Expr(Expr::Var(seen_name)),
+                    ]);
                     self.compile_expr(&cas_expr);
                 } else {
                     let arity = args.len() as u32;

--- a/src/compiler/expr_method.rs
+++ b/src/compiler/expr_method.rs
@@ -626,10 +626,11 @@ impl Compiler {
                     modifier: None,
                     quoted: false,
                 };
-                self.compile_expr(&Expr::DoBlock {
-                    body: vec![Stmt::MarkBind, bind_decl, Stmt::Expr(delete_through)],
-                    label: None,
-                });
+                self.compile_expr(&Expr::desugar_block(vec![
+                    Stmt::MarkBind,
+                    bind_decl,
+                    Stmt::Expr(delete_through),
+                ]));
                 return;
             }
             if let Some(var_name) = Self::postfix_index_name(delete_target) {

--- a/src/compiler/helpers_ast_utils.rs
+++ b/src/compiler/helpers_ast_utils.rs
@@ -161,16 +161,15 @@ impl Compiler {
     /// immutable value". Used to desugar a ternary lvalue on the LHS of `=` where
     /// one branch may not be assignable.
     pub(super) fn ternary_branch_assign(target: &Expr, value: &Expr) -> Expr {
-        Self::assign_expr_for_lvalue(target, value).unwrap_or_else(|| Expr::DoBlock {
-            body: vec![
+        Self::assign_expr_for_lvalue(target, value).unwrap_or_else(|| {
+            Expr::desugar_block(vec![
                 Stmt::Expr(target.clone()),
                 Stmt::Expr(value.clone()),
                 Stmt::Expr(Expr::Call {
                     name: crate::symbol::Symbol::intern("__mutsu_assignment_ro"),
                     args: Vec::new(),
                 }),
-            ],
-            label: None,
+            ])
         })
     }
 

--- a/src/compiler/helpers_do_expr.rs
+++ b/src/compiler/helpers_do_expr.rs
@@ -5,22 +5,42 @@ impl Compiler {
     /// term). A thin wrapper over the shared lowering in `control_block.rs`;
     /// the only difference from the statement form is
     /// [`BlockPosition::Value`](crate::compiler::control_block::BlockPosition).
-    pub(super) fn compile_do_block_expr(&mut self, body: &[Stmt], label: &Option<String>) {
+    ///
+    /// `origin` says whether the node is a Raku block at all: `Expr::DoBlock` is
+    /// also the generic "run these statements, yield a value" vehicle of some
+    /// forty desugars, and only a real one owns a `let`/`temp` save frame.
+    pub(super) fn compile_do_block_expr(
+        &mut self,
+        body: &[Stmt],
+        label: &Option<String>,
+        origin: crate::ast::DoBlockOrigin,
+    ) {
         self.compile_block_construct(
             body,
             label,
-            crate::compiler::control_block::BlockPosition::Value { isolate: false },
+            crate::compiler::control_block::BlockPosition::Value {
+                isolate: false,
+                origin,
+            },
         );
     }
 
     /// [`Compiler::compile_do_block_expr`] with `OpCode::DoBlockExpr`'s
     /// `scope_isolate` on: the block's own scalar/array `my`/`state`
     /// declarations revert on exit while mutations of outer variables persist.
-    pub(super) fn compile_do_block_expr_scoped(&mut self, body: &[Stmt], label: &Option<String>) {
+    pub(super) fn compile_do_block_expr_scoped(
+        &mut self,
+        body: &[Stmt],
+        label: &Option<String>,
+        origin: crate::ast::DoBlockOrigin,
+    ) {
         self.compile_block_construct(
             body,
             label,
-            crate::compiler::control_block::BlockPosition::Value { isolate: true },
+            crate::compiler::control_block::BlockPosition::Value {
+                isolate: true,
+                origin,
+            },
         );
     }
 
@@ -83,7 +103,11 @@ impl Compiler {
                         && matches!(&items[0], Expr::Literal(lit) if lit.is_nil())
             )
         {
-            self.compile_do_block_expr(body, label);
+            // Behaviour-preserving: this dummy `for Nil` shape has no producer
+            // left in the parser (a labelled block lowers straight to a
+            // labelled `Expr::DoBlock`), so keep it off the block path rather
+            // than granting it `let` resolution this cannot exercise.
+            self.compile_do_block_expr(body, label, crate::ast::DoBlockOrigin::Desugar);
             return;
         }
         self.compile_for_construct(crate::compiler::control_for::ForParts {

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -2709,10 +2709,24 @@ pub(crate) enum OpCode {
         slot: Option<u32>,
     },
 
-    /// Block with `let` scope management. Executes body, then checks
-    /// the topic ($_) to decide whether to restore or discard let saves.
+    /// Block with `let` scope management. Executes body, then decides from the
+    /// block's own value whether to restore the `let` saves (the block failed)
+    /// or discard them (it succeeded).
+    ///
+    /// Where that value is read from depends on the source position, because
+    /// the two block lowerings leave it in different places:
+    ///
+    /// - `value_on_stack: false` — statement position. The body's last
+    ///   statement was compiled through `compile_last_stmt_as_topic`, so the
+    ///   value is in the topic (`$_`) and the stack is balanced.
+    /// - `value_on_stack: true` — value position (`do { ... }`). The body
+    ///   leaves its value on the value stack for the enclosing expression to
+    ///   consume, so the success test peeks the stack top instead. Routing it
+    ///   through the topic here would clobber `$_` for the enclosing scope,
+    ///   which a `do { ... }` must not do.
     LetBlock {
         body_end: u32,
+        value_on_stack: bool,
     },
 }
 

--- a/src/parser/expr/postfix/dot_assign.rs
+++ b/src/parser/expr/postfix/dot_assign.rs
@@ -48,13 +48,10 @@ fn chained_assign_writeback(
         Expr::Var(assign_name.clone())
     };
     let method_result = method_call_fn(var_expr);
-    Expr::DoBlock {
-        body: vec![
-            Stmt::Expr(target),
-            Stmt::Expr(dot_assign_to_name(assign_name, method_result)),
-        ],
-        label: None,
-    }
+    Expr::desugar_block(vec![
+        Stmt::Expr(target),
+        Stmt::Expr(dot_assign_to_name(assign_name, method_result)),
+    ])
 }
 
 /// The `.=` expansion for a simple-variable lvalue, tagged with its
@@ -140,29 +137,26 @@ pub(crate) fn wrap_dot_assign(target: Expr, method_call_fn: impl FnOnce(Expr) ->
                 is_positional: *is_positional,
             };
             let assigned_value = method_call_fn(lhs_expr);
-            Expr::DoBlock {
-                body: vec![
-                    Stmt::VarDecl {
-                        name: tmp_idx.clone(),
-                        expr: *index.clone(),
-                        type_constraint: None,
-                        is_state: false,
-                        is_our: false,
-                        is_dynamic: false,
-                        is_export: false,
-                        export_tags: Vec::new(),
-                        custom_traits: Vec::new(),
-                        where_constraint: None,
-                    },
-                    Stmt::Expr(Expr::IndexAssign {
-                        target: idx_target.clone(),
-                        index: Box::new(tmp_idx_expr),
-                        value: Box::new(assigned_value),
-                        is_positional: *is_positional,
-                    }),
-                ],
-                label: None,
-            }
+            Expr::desugar_block(vec![
+                Stmt::VarDecl {
+                    name: tmp_idx.clone(),
+                    expr: *index.clone(),
+                    type_constraint: None,
+                    is_state: false,
+                    is_our: false,
+                    is_dynamic: false,
+                    is_export: false,
+                    export_tags: Vec::new(),
+                    custom_traits: Vec::new(),
+                    where_constraint: None,
+                },
+                Stmt::Expr(Expr::IndexAssign {
+                    target: idx_target.clone(),
+                    index: Box::new(tmp_idx_expr),
+                    value: Box::new(assigned_value),
+                    is_positional: *is_positional,
+                }),
+            ])
         }
         // ($var = expr).=method => evaluate the assignment, then $var = $var.method
         Expr::AssignExpr { name, .. } => {
@@ -193,7 +187,7 @@ pub(crate) fn wrap_dot_assign(target: Expr, method_call_fn: impl FnOnce(Expr) ->
         // Re-read `@a[idx]` (now holding m1's result, via the already-declared `idx`
         // temp), apply this method, and write it back to the same element so the
         // chain keeps mutating `@a[i]` rather than a detached copy.
-        Expr::DoBlock { body, .. }
+        Expr::DoBlock { body, origin, .. }
             if matches!(body.last(), Some(Stmt::Expr(Expr::IndexAssign { .. }))) =>
         {
             let (idx_target, index, is_positional) = match body.last() {
@@ -218,9 +212,12 @@ pub(crate) fn wrap_dot_assign(target: Expr, method_call_fn: impl FnOnce(Expr) ->
                 value: Box::new(new_value),
                 is_positional,
             }));
+            // A rewrap of the node that came in: appending the writeback does
+            // not change whether it was a block, so carry its origin over.
             Expr::DoBlock {
                 body: new_body,
                 label: None,
+                origin: *origin,
             }
         }
         // A `do { … }` block whose value is an lvalue (`do { …; ($x .= new) }.= new`)
@@ -300,10 +297,8 @@ pub(crate) fn wrap_dot_assign(target: Expr, method_call_fn: impl FnOnce(Expr) ->
                 modifier: None,
                 quoted: false,
             };
-            let then_expr = Expr::DoBlock {
-                body: vec![Stmt::Expr(store_call), Stmt::Expr(cur_var.clone())],
-                label: None,
-            };
+            let then_expr =
+                Expr::desugar_block(vec![Stmt::Expr(store_call), Stmt::Expr(cur_var.clone())]);
             // Writeback branch: `$inv.attr = $cur.meth` through the accessor slot.
             let writeback = crate::parser::stmt::assign::method_lvalue_assign_expr(
                 inv_var,
@@ -324,36 +319,33 @@ pub(crate) fn wrap_dot_assign(target: Expr, method_call_fn: impl FnOnce(Expr) ->
                 then_expr: Box::new(then_expr),
                 else_expr: Box::new(writeback),
             };
-            Expr::DoBlock {
-                body: vec![
-                    Stmt::VarDecl {
-                        name: inv_tmp,
-                        expr: *inv.clone(),
-                        type_constraint: None,
-                        is_state: false,
-                        is_our: false,
-                        is_dynamic: false,
-                        is_export: false,
-                        export_tags: Vec::new(),
-                        custom_traits: Vec::new(),
-                        where_constraint: None,
-                    },
-                    Stmt::VarDecl {
-                        name: cur_tmp,
-                        expr: read_expr,
-                        type_constraint: None,
-                        is_state: false,
-                        is_our: false,
-                        is_dynamic: false,
-                        is_export: false,
-                        export_tags: Vec::new(),
-                        custom_traits: Vec::new(),
-                        where_constraint: None,
-                    },
-                    Stmt::Expr(ternary),
-                ],
-                label: None,
-            }
+            Expr::desugar_block(vec![
+                Stmt::VarDecl {
+                    name: inv_tmp,
+                    expr: *inv.clone(),
+                    type_constraint: None,
+                    is_state: false,
+                    is_our: false,
+                    is_dynamic: false,
+                    is_export: false,
+                    export_tags: Vec::new(),
+                    custom_traits: Vec::new(),
+                    where_constraint: None,
+                },
+                Stmt::VarDecl {
+                    name: cur_tmp,
+                    expr: read_expr,
+                    type_constraint: None,
+                    is_state: false,
+                    is_our: false,
+                    is_dynamic: false,
+                    is_export: false,
+                    export_tags: Vec::new(),
+                    custom_traits: Vec::new(),
+                    where_constraint: None,
+                },
+                Stmt::Expr(ternary),
+            ])
         }
         // A non-lvalue target (`(Foo.new).=meth`, `Foo.new.=meth`, ...). In Raku
         // `X.=meth` is `X = X.meth`; when X (evaluated once) provides a `STORE`
@@ -391,33 +383,28 @@ pub(crate) fn wrap_dot_assign(target: Expr, method_call_fn: impl FnOnce(Expr) ->
                 modifier: None,
                 quoted: false,
             };
-            let then_expr = Expr::DoBlock {
-                body: vec![Stmt::Expr(store_call), Stmt::Expr(tmp_var.clone())],
-                label: None,
-            };
+            let then_expr =
+                Expr::desugar_block(vec![Stmt::Expr(store_call), Stmt::Expr(tmp_var.clone())]);
             let ternary = Expr::Ternary {
                 cond: Box::new(can_store),
                 then_expr: Box::new(then_expr),
                 else_expr: Box::new(meth_result),
             };
-            Expr::DoBlock {
-                body: vec![
-                    Stmt::VarDecl {
-                        name: tmp,
-                        expr: target,
-                        type_constraint: None,
-                        is_state: false,
-                        is_our: false,
-                        is_dynamic: false,
-                        is_export: false,
-                        export_tags: Vec::new(),
-                        custom_traits: Vec::new(),
-                        where_constraint: None,
-                    },
-                    Stmt::Expr(ternary),
-                ],
-                label: None,
-            }
+            Expr::desugar_block(vec![
+                Stmt::VarDecl {
+                    name: tmp,
+                    expr: target,
+                    type_constraint: None,
+                    is_state: false,
+                    is_our: false,
+                    is_dynamic: false,
+                    is_export: false,
+                    export_tags: Vec::new(),
+                    custom_traits: Vec::new(),
+                    where_constraint: None,
+                },
+                Stmt::Expr(ternary),
+            ])
         }
     }
 }

--- a/src/parser/expr/precedence/assign.rs
+++ b/src/parser/expr/precedence/assign.rs
@@ -1,17 +1,14 @@
 use super::*;
 
 pub(crate) fn assignment_ro_expr(lhs: Expr, rhs: Expr) -> Expr {
-    Expr::DoBlock {
-        body: vec![
-            Stmt::Expr(lhs),
-            Stmt::Expr(rhs),
-            Stmt::Expr(Expr::Call {
-                name: Symbol::intern("__mutsu_assignment_ro"),
-                args: Vec::new(),
-            }),
-        ],
-        label: None,
-    }
+    Expr::desugar_block(vec![
+        Stmt::Expr(lhs),
+        Stmt::Expr(rhs),
+        Stmt::Expr(Expr::Call {
+            name: Symbol::intern("__mutsu_assignment_ro"),
+            args: Vec::new(),
+        }),
+    ])
 }
 
 pub(crate) fn unwrap_grouped_lvalue(target: Expr) -> Expr {

--- a/src/parser/expr/precedence_meta_ops/hyper_concat.rs
+++ b/src/parser/expr/precedence_meta_ops/hyper_concat.rs
@@ -151,8 +151,8 @@ fn hyper_assign_shape(target: &Expr) -> Expr {
 fn lower_hyper_assign_target(target: Expr, source: Expr) -> Expr {
     match target {
         Expr::Grouped(inner) => lower_hyper_assign_target(*inner, source),
-        Expr::ArrayLiteral(items) => Expr::DoBlock {
-            body: items
+        Expr::ArrayLiteral(items) => Expr::desugar_block(
+            items
                 .into_iter()
                 .enumerate()
                 .map(|(index, item)| {
@@ -166,8 +166,7 @@ fn lower_hyper_assign_target(target: Expr, source: Expr) -> Expr {
                     ))
                 })
                 .collect(),
-            label: None,
-        },
+        ),
         target => crate::parser::expr::precedence::assign_to_target_expr(target, source),
     }
 }
@@ -232,22 +231,19 @@ fn lower_hyper_assignment(target: Expr, value: Expr, dwim_left: bool, dwim_right
         custom_traits: Vec::new(),
         where_constraint: None,
     };
-    Expr::DoBlock {
-        body: vec![
-            temp_decl(shape_name, hyper_assign_shape(&target)),
-            temp_decl(temp_name.clone(), distributed),
-            crate::ast::Stmt::Expr(lower_hyper_assign_target(
-                target,
-                Expr::Var(temp_name.clone()),
-            )),
-            // The assignment's own value is the distributed list, not the last
-            // element stored: `my $r = (($x, $y) »=» (5, 6))` is `$(5, 6)` in
-            // raku. The temp is itemized by its `my $` declaration, which is
-            // the itemization raku shows.
-            crate::ast::Stmt::Expr(Expr::Var(temp_name)),
-        ],
-        label: None,
-    }
+    Expr::desugar_block(vec![
+        temp_decl(shape_name, hyper_assign_shape(&target)),
+        temp_decl(temp_name.clone(), distributed),
+        crate::ast::Stmt::Expr(lower_hyper_assign_target(
+            target,
+            Expr::Var(temp_name.clone()),
+        )),
+        // The assignment's own value is the distributed list, not the last
+        // element stored: `my $r = (($x, $y) »=» (5, 6))` is `$(5, 6)` in
+        // raku. The temp is itemized by its `my $` declaration, which is
+        // the itemization raku shows.
+        crate::ast::Stmt::Expr(Expr::Var(temp_name)),
+    ])
 }
 
 /// Parse hyper operator with function reference: `>>[&func]<<`, `<<[&func]>>`, etc.

--- a/src/parser/primary/ident/identifier_call.rs
+++ b/src/parser/primary/ident/identifier_call.rs
@@ -518,7 +518,18 @@ pub(crate) fn identifier_or_call(input: &str) -> PResult<'_, Expr> {
                         ));
                     }
                 }
-                return Ok((r, Expr::DoBlock { body, label: None }));
+                // The one site that parses the `do` keyword's own braces, and
+                // so the one that mints a value-position node which really is
+                // a Raku block — `let`/`temp` inside it resolve here, not at
+                // the enclosing block (GH-7635).
+                return Ok((
+                    r,
+                    Expr::DoBlock {
+                        body,
+                        label: None,
+                        origin: crate::ast::DoBlockOrigin::SourceBlock,
+                    },
+                ));
             }
             // do if/unless/given/for/while — wrap the control flow statement
             {
@@ -978,13 +989,7 @@ pub(crate) fn identifier_or_call(input: &str) -> PResult<'_, Expr> {
                         is_whatever_code: false,
                         is_sub: false,
                     };
-                    return Ok((
-                        r2,
-                        Expr::DoBlock {
-                            body: vec![stmt, Stmt::Expr(anon_sub)],
-                            label: None,
-                        },
-                    ));
+                    return Ok((r2, Expr::desugar_block(vec![stmt, Stmt::Expr(anon_sub)])));
                 }
                 // Check for anonymous multi sub
                 let after_sub = keyword("sub", r).unwrap();
@@ -1047,7 +1052,10 @@ pub(crate) fn identifier_or_call(input: &str) -> PResult<'_, Expr> {
                 // lazy-gather coroutine suspend at each take (it can only
                 // suspend at the body's top level, not inside a nested
                 // DoBlockExpr frame).
-                if let crate::ast::Stmt::Expr(Expr::DoBlock { body, label: None }) = &stmt {
+                if let crate::ast::Stmt::Expr(Expr::DoBlock {
+                    body, label: None, ..
+                }) = &stmt
+                {
                     return Ok((r_after, Expr::Gather(body.clone())));
                 }
                 return Ok((r_after, Expr::Gather(vec![stmt])));
@@ -1600,7 +1608,10 @@ pub(crate) fn identifier_or_call(input: &str) -> PResult<'_, Expr> {
         // As for `gather`, the statement parse eats the terminating `;` but the
         // supply expression must stop before it.
         let r_after = restore_do_stmt_terminator(r, r_after);
-        if let crate::ast::Stmt::Expr(Expr::DoBlock { body, label: None }) = &stmt {
+        if let crate::ast::Stmt::Expr(Expr::DoBlock {
+            body, label: None, ..
+        }) = &stmt
+        {
             return Ok((r_after, supply_method_call(body.clone())));
         }
         return Ok((r_after, supply_method_call(vec![stmt])));

--- a/src/parser/primary/ident/supply.rs
+++ b/src/parser/primary/ident/supply.rs
@@ -33,7 +33,7 @@ pub(crate) fn supply_method_call(body: Vec<Stmt>) -> Expr {
         .into_iter()
         .any(|ph| ph != "%_")
     {
-        return Expr::DoBlock { body, label: None };
+        return Expr::desugar_block(body);
     }
     // Each `supply { ... }` block gets a UNIQUE emitter variable name. The
     // emitter is bound as the on-demand lambda's parameter and `emit` is

--- a/src/parser/primary/ident/supply_emit_expr.rs
+++ b/src/parser/primary/ident/supply_emit_expr.rs
@@ -101,9 +101,14 @@ pub(crate) fn rewrite_expr(expr: Expr, emitter: &str) -> Expr {
         // Inline blocks run in this frame, so their `emit`s belong to this
         // supply — hand them back to the statement rewriter.
         Expr::Block(body) => Expr::Block(rewrite_stmts(body, emitter)),
-        Expr::DoBlock { body, label } => Expr::DoBlock {
+        Expr::DoBlock {
+            body,
+            label,
+            origin,
+        } => Expr::DoBlock {
             body: rewrite_stmts(body, emitter),
             label,
+            origin,
         },
         other => other,
     }

--- a/src/parser/primary/string/interp_content.rs
+++ b/src/parser/primary/string/interp_content.rs
@@ -148,10 +148,7 @@ fn parse_braced_closure_body_scoped(inner: &str) -> Option<Expr> {
         return Some(if stmts.len() == 1 {
             Expr::DoStmt(Box::new(stmts.into_iter().next().unwrap()))
         } else {
-            Expr::DoBlock {
-                body: stmts,
-                label: None,
-            }
+            Expr::desugar_block(stmts)
         });
     }
     if let Ok((leftover, expr)) = expression(inner)
@@ -165,10 +162,7 @@ fn parse_braced_closure_body_scoped(inner: &str) -> Option<Expr> {
             };
             return Some(expr);
         }
-        return Some(Expr::DoBlock {
-            body: stmts,
-            label: None,
-        });
+        return Some(Expr::desugar_block(stmts));
     }
     None
 }

--- a/src/parser/primary/string/interp_var.rs
+++ b/src/parser/primary/string/interp_var.rs
@@ -334,10 +334,7 @@ pub(crate) fn try_interpolate_var<'a>(
                     if stmts.len() == 1 {
                         Some(Expr::DoStmt(Box::new(stmts.into_iter().next().unwrap())))
                     } else {
-                        Some(Expr::DoBlock {
-                            body: stmts,
-                            label: None,
-                        })
+                        Some(Expr::desugar_block(stmts))
                     }
                 } else if let Ok((leftover, expr)) = expression(inner.trim())
                     && leftover.trim().is_empty()

--- a/src/parser/primary/var/scalar.rs
+++ b/src/parser/primary/var/scalar.rs
@@ -420,19 +420,11 @@ fn parse_dollar_paren_block(input: &str) -> PResult<'_, Expr> {
         return Err(PError::expected("statement block with multiple statements"));
     }
     let (rest, _) = parse_char(rest, ')')?;
-    Ok((
-        rest,
-        Expr::DoBlock {
-            body: stmts,
-            // `$( ... )` is a statement-list CONTEXTUALIZER, not a block: raku
-            // scopes a `let`/`temp` inside it to the enclosing block, so
-            // `{ $(let $a = 23; $a); Mu }` still restores `$a` when the
-            // enclosing block fails (roast S04-blocks-and-statements/let.t,
-            // temp.t). We reuse `Expr::DoBlock` to carry the statement list, so
-            // the compiler is told by this sentinel label not to open a
-            // `let`/`temp` save frame of its own -- see
-            // `Compiler::compile_block_construct`.
-            label: Some(crate::ast::STMT_LIST_CONTEXTUALIZER_LABEL.to_string()),
-        },
-    ))
+    // `$( ... )` is a statement-list CONTEXTUALIZER, not a block: raku scopes a
+    // `let`/`temp` inside it to the enclosing block, so `{ $(let $a = 23; $a);
+    // Mu }` still restores `$a` when the enclosing block fails (roast
+    // S04-blocks-and-statements/let.t, temp.t). `Expr::DoBlock` is reused here
+    // only to carry the statement list, which is exactly what
+    // `DoBlockOrigin::Desugar` marks.
+    Ok((rest, Expr::desugar_block(stmts)))
 }

--- a/src/parser/stmt/assign/compound_expr.rs
+++ b/src/parser/stmt/assign/compound_expr.rs
@@ -47,7 +47,7 @@ where
         is_positional,
     };
     body.push(Stmt::Expr(store(build_assigned_value(lhs_expr))));
-    Expr::DoBlock { body, label: None }
+    Expr::desugar_block(body)
 }
 
 /// [`compound_index_assign_expr`] for a plain compound-assignment operator,
@@ -95,7 +95,7 @@ fn compound_index_assign_op_expr(
     };
     let tail = short_circuit_subscript_assign(keep, lhs_expr, rhs, &mut body, store);
     body.push(Stmt::Expr(tail));
-    Expr::DoBlock { body, label: None }
+    Expr::desugar_block(body)
 }
 
 /// The subscript twin of [`short_circuit_compound_assign_expr`]: `//=`/`||=`/
@@ -288,7 +288,7 @@ pub(crate) fn build_compound_assign_expr(
                 }
             };
             body.push(Stmt::Expr(tail));
-            Expr::DoBlock { body, label: None }
+            Expr::desugar_block(body)
         }
         Expr::MethodCall {
             target,
@@ -501,29 +501,23 @@ pub(crate) fn build_compound_assign_expr(
                 Expr::Binary {
                     left: Box::new(other),
                     op: op.token_kind(),
-                    right: Box::new(Expr::DoBlock {
-                        body: vec![
-                            Stmt::Expr(rhs),
-                            Stmt::Expr(Expr::Call {
-                                name: Symbol::intern("__mutsu_assignment_ro"),
-                                args: Vec::new(),
-                            }),
-                        ],
-                        label: None,
-                    }),
-                }
-            } else {
-                Expr::DoBlock {
-                    body: vec![
-                        Stmt::Expr(other),
+                    right: Box::new(Expr::desugar_block(vec![
                         Stmt::Expr(rhs),
                         Stmt::Expr(Expr::Call {
                             name: Symbol::intern("__mutsu_assignment_ro"),
                             args: Vec::new(),
                         }),
-                    ],
-                    label: None,
+                    ])),
                 }
+            } else {
+                Expr::desugar_block(vec![
+                    Stmt::Expr(other),
+                    Stmt::Expr(rhs),
+                    Stmt::Expr(Expr::Call {
+                        name: Symbol::intern("__mutsu_assignment_ro"),
+                        args: Vec::new(),
+                    }),
+                ])
             }
         }
     })

--- a/src/parser/stmt/assign/op.rs
+++ b/src/parser/stmt/assign/op.rs
@@ -258,24 +258,21 @@ pub(crate) fn short_circuit_compound_assign_expr(
         },
         ShortCircuitKeep::True | ShortCircuitKeep::False => tmp_var.clone(),
     };
-    let cond = Expr::DoBlock {
-        body: vec![
-            Stmt::VarDecl {
-                name: tmp_name.clone(),
-                expr: lhs,
-                type_constraint: None,
-                is_state: false,
-                is_our: false,
-                is_dynamic: false,
-                is_export: false,
-                export_tags: Vec::new(),
-                custom_traits: Vec::new(),
-                where_constraint: None,
-            },
-            Stmt::Expr(test),
-        ],
-        label: None,
-    };
+    let cond = Expr::desugar_block(vec![
+        Stmt::VarDecl {
+            name: tmp_name.clone(),
+            expr: lhs,
+            type_constraint: None,
+            is_state: false,
+            is_our: false,
+            is_dynamic: false,
+            is_export: false,
+            export_tags: Vec::new(),
+            custom_traits: Vec::new(),
+            where_constraint: None,
+        },
+        Stmt::Expr(test),
+    ]);
     let store = Expr::AssignExpr {
         name: name.to_string(),
         expr: Box::new(rhs),
@@ -298,10 +295,7 @@ pub(crate) fn short_circuit_compound_assign_expr(
             args: vec![Expr::Literal(Value::str(name.to_string()))],
         }),
         then_expr: Box::new(Expr::Var(name.to_string())),
-        else_expr: Box::new(Expr::DoBlock {
-            body: vec![Stmt::Expr(tmp_var)],
-            label: None,
-        }),
+        else_expr: Box::new(Expr::desugar_block(vec![Stmt::Expr(tmp_var)])),
     };
     let (then_expr, else_expr) = match keep {
         // `&&=` stores when the LHS is TRUE, keeps it otherwise.
@@ -323,27 +317,24 @@ pub(crate) fn compound_assigned_value_expr(lhs: Expr, op: CompoundAssignOp, rhs:
         );
         let tmp_var = Expr::Var(tmp_name.clone());
         Expr::Ternary {
-            cond: Box::new(Expr::DoBlock {
-                body: vec![
-                    Stmt::VarDecl {
-                        name: tmp_name.clone(),
-                        expr: lhs,
-                        type_constraint: None,
-                        is_state: false,
-                        is_our: false,
-                        is_dynamic: false,
-                        is_export: false,
-                        export_tags: Vec::new(),
-                        custom_traits: Vec::new(),
-                        where_constraint: None,
-                    },
-                    Stmt::Expr(Expr::Call {
-                        name: Symbol::intern("defined"),
-                        args: vec![tmp_var.clone()],
-                    }),
-                ],
-                label: None,
-            }),
+            cond: Box::new(Expr::desugar_block(vec![
+                Stmt::VarDecl {
+                    name: tmp_name.clone(),
+                    expr: lhs,
+                    type_constraint: None,
+                    is_state: false,
+                    is_our: false,
+                    is_dynamic: false,
+                    is_export: false,
+                    export_tags: Vec::new(),
+                    custom_traits: Vec::new(),
+                    where_constraint: None,
+                },
+                Stmt::Expr(Expr::Call {
+                    name: Symbol::intern("defined"),
+                    args: vec![tmp_var.clone()],
+                }),
+            ])),
             then_expr: Box::new(tmp_var),
             else_expr: Box::new(rhs),
         }
@@ -361,27 +352,24 @@ pub(crate) fn compound_assigned_value_expr(lhs: Expr, op: CompoundAssignOp, rhs:
             (tmp_var.clone(), rhs)
         };
         Expr::Ternary {
-            cond: Box::new(Expr::DoBlock {
-                body: vec![
-                    Stmt::VarDecl {
-                        name: tmp_name.clone(),
-                        expr: lhs,
-                        type_constraint: None,
-                        is_state: false,
-                        is_our: false,
-                        is_dynamic: false,
-                        is_export: false,
-                        export_tags: Vec::new(),
-                        custom_traits: Vec::new(),
-                        where_constraint: None,
-                    },
-                    Stmt::Expr(Expr::Call {
-                        name: Symbol::intern("defined"),
-                        args: vec![tmp_var.clone()],
-                    }),
-                ],
-                label: None,
-            }),
+            cond: Box::new(Expr::desugar_block(vec![
+                Stmt::VarDecl {
+                    name: tmp_name.clone(),
+                    expr: lhs,
+                    type_constraint: None,
+                    is_state: false,
+                    is_our: false,
+                    is_dynamic: false,
+                    is_export: false,
+                    export_tags: Vec::new(),
+                    custom_traits: Vec::new(),
+                    where_constraint: None,
+                },
+                Stmt::Expr(Expr::Call {
+                    name: Symbol::intern("defined"),
+                    args: vec![tmp_var.clone()],
+                }),
+            ])),
             then_expr: Box::new(then_branch),
             else_expr: Box::new(else_branch),
         }

--- a/src/parser/stmt/control/labeled_loop.rs
+++ b/src/parser/stmt/control/labeled_loop.rs
@@ -187,6 +187,7 @@ pub(crate) fn labeled_loop_stmt(input: &str) -> PResult<'_, Stmt> {
             Stmt::Expr(Expr::DoBlock {
                 body,
                 label: Some(label),
+                origin: crate::ast::DoBlockOrigin::SourceBlock,
             }),
         ));
     }
@@ -197,6 +198,7 @@ pub(crate) fn labeled_loop_stmt(input: &str) -> PResult<'_, Stmt> {
             Stmt::Expr(Expr::DoBlock {
                 body,
                 label: Some(label),
+                origin: crate::ast::DoBlockOrigin::SourceBlock,
             }),
         ));
     }

--- a/src/parser/stmt/control/loop_repeat.rs
+++ b/src/parser/stmt/control/loop_repeat.rs
@@ -255,13 +255,7 @@ pub(crate) fn loop_stmt(input: &str) -> PResult<'_, Stmt> {
             } else {
                 // Wrap multiple step expressions in a DoBlock
                 let stmts: Vec<Stmt> = exprs.into_iter().map(Stmt::Expr).collect();
-                (
-                    r,
-                    Some(Expr::DoBlock {
-                        body: stmts,
-                        label: None,
-                    }),
-                )
+                (r, Some(Expr::desugar_block(stmts)))
             }
         };
         let (rest, _) = ws(rest)?;

--- a/src/parser/stmt/decl/constant_subset.rs
+++ b/src/parser/stmt/decl/constant_subset.rs
@@ -408,9 +408,6 @@ pub(in crate::parser) fn inline_subset_term(input: &str) -> PResult<'_, Expr> {
     };
     Ok((
         rest,
-        Expr::DoBlock {
-            body: vec![decl, Stmt::Expr(Expr::BareWord(name))],
-            label: None,
-        },
+        Expr::desugar_block(vec![decl, Stmt::Expr(Expr::BareWord(name))]),
     ))
 }

--- a/src/parser/stmt/simple_expr_stmt/core.rs
+++ b/src/parser/stmt/simple_expr_stmt/core.rs
@@ -349,29 +349,26 @@ pub(crate) fn expr_stmt(input: &str) -> PResult<'_, Stmt> {
                     is_positional,
                 };
                 let assigned_value = make_rhs(lhs_expr);
-                let stmt = Stmt::Expr(Expr::DoBlock {
-                    body: vec![
-                        Stmt::VarDecl {
-                            name: tmp_idx.clone(),
-                            expr: *index,
-                            type_constraint: None,
-                            is_state: false,
-                            is_our: false,
-                            is_dynamic: false,
-                            is_export: false,
-                            export_tags: Vec::new(),
-                            custom_traits: Vec::new(),
-                            where_constraint: None,
-                        },
-                        Stmt::Expr(Expr::IndexAssign {
-                            target,
-                            index: Box::new(tmp_idx_expr),
-                            value: Box::new(assigned_value),
-                            is_positional: true,
-                        }),
-                    ],
-                    label: None,
-                });
+                let stmt = Stmt::Expr(Expr::desugar_block(vec![
+                    Stmt::VarDecl {
+                        name: tmp_idx.clone(),
+                        expr: *index,
+                        type_constraint: None,
+                        is_state: false,
+                        is_our: false,
+                        is_dynamic: false,
+                        is_export: false,
+                        export_tags: Vec::new(),
+                        custom_traits: Vec::new(),
+                        where_constraint: None,
+                    },
+                    Stmt::Expr(Expr::IndexAssign {
+                        target,
+                        index: Box::new(tmp_idx_expr),
+                        value: Box::new(assigned_value),
+                        is_positional: true,
+                    }),
+                ]));
                 return parse_statement_modifier(r, stmt);
             }
             _ => {
@@ -506,29 +503,26 @@ pub(crate) fn expr_stmt(input: &str) -> PResult<'_, Stmt> {
                     is_positional,
                 };
                 let assigned_value = make_rhs(lhs_expr);
-                let stmt = Stmt::Expr(Expr::DoBlock {
-                    body: vec![
-                        Stmt::VarDecl {
-                            name: tmp_idx.clone(),
-                            expr: *index,
-                            type_constraint: None,
-                            is_state: false,
-                            is_our: false,
-                            is_dynamic: false,
-                            is_export: false,
-                            export_tags: Vec::new(),
-                            custom_traits: Vec::new(),
-                            where_constraint: None,
-                        },
-                        Stmt::Expr(Expr::IndexAssign {
-                            target,
-                            index: Box::new(tmp_idx_expr),
-                            value: Box::new(assigned_value),
-                            is_positional: true,
-                        }),
-                    ],
-                    label: None,
-                });
+                let stmt = Stmt::Expr(Expr::desugar_block(vec![
+                    Stmt::VarDecl {
+                        name: tmp_idx.clone(),
+                        expr: *index,
+                        type_constraint: None,
+                        is_state: false,
+                        is_our: false,
+                        is_dynamic: false,
+                        is_export: false,
+                        export_tags: Vec::new(),
+                        custom_traits: Vec::new(),
+                        where_constraint: None,
+                    },
+                    Stmt::Expr(Expr::IndexAssign {
+                        target,
+                        index: Box::new(tmp_idx_expr),
+                        value: Box::new(assigned_value),
+                        is_positional: true,
+                    }),
+                ]));
                 return parse_statement_modifier(r, stmt);
             }
             Expr::BareWord(ref name) => {
@@ -962,16 +956,13 @@ pub(crate) fn expr_stmt(input: &str) -> PResult<'_, Stmt> {
                     Expr::LiteralSrc(v, _) => Expr::Literal(v),
                     other => other,
                 };
-                Stmt::Expr(Expr::DoBlock {
-                    body: vec![
-                        Stmt::Expr(rhs),
-                        Stmt::Expr(Expr::Call {
-                            name: Symbol::intern("__mutsu_assignment_ro"),
-                            args: vec![lit],
-                        }),
-                    ],
-                    label: None,
-                })
+                Stmt::Expr(Expr::desugar_block(vec![
+                    Stmt::Expr(rhs),
+                    Stmt::Expr(Expr::Call {
+                        name: Symbol::intern("__mutsu_assignment_ro"),
+                        args: vec![lit],
+                    }),
+                ]))
             }
             Expr::BareWord(_) => Stmt::Block(vec![Stmt::Expr(expr), Stmt::Expr(rhs)]),
             Expr::SymbolicDeref { sigil, expr: inner } => Stmt::Expr(Expr::SymbolicDerefAssign {
@@ -1303,29 +1294,26 @@ pub(crate) fn expr_stmt(input: &str) -> PResult<'_, Stmt> {
                 op: set_tok,
                 right: Box::new(rhs),
             };
-            let stmt = Stmt::Expr(Expr::DoBlock {
-                body: vec![
-                    Stmt::VarDecl {
-                        name: tmp_idx.clone(),
-                        expr: (*index.clone()),
-                        type_constraint: None,
-                        is_state: false,
-                        is_our: false,
-                        is_dynamic: false,
-                        is_export: false,
-                        export_tags: Vec::new(),
-                        custom_traits: Vec::new(),
-                        where_constraint: None,
-                    },
-                    Stmt::Expr(Expr::IndexAssign {
-                        target: target.clone(),
-                        index: Box::new(tmp_idx_expr),
-                        value: Box::new(assigned_value),
-                        is_positional: *is_positional,
-                    }),
-                ],
-                label: None,
-            });
+            let stmt = Stmt::Expr(Expr::desugar_block(vec![
+                Stmt::VarDecl {
+                    name: tmp_idx.clone(),
+                    expr: (*index.clone()),
+                    type_constraint: None,
+                    is_state: false,
+                    is_our: false,
+                    is_dynamic: false,
+                    is_export: false,
+                    export_tags: Vec::new(),
+                    custom_traits: Vec::new(),
+                    where_constraint: None,
+                },
+                Stmt::Expr(Expr::IndexAssign {
+                    target: target.clone(),
+                    index: Box::new(tmp_idx_expr),
+                    value: Box::new(assigned_value),
+                    is_positional: *is_positional,
+                }),
+            ]));
             return parse_statement_modifier(r, stmt);
         }
         if let Expr::MethodCall {
@@ -1422,29 +1410,26 @@ pub(crate) fn expr_stmt(input: &str) -> PResult<'_, Stmt> {
                     right: Box::new(rhs),
                 }
             };
-            let expanded = Expr::DoBlock {
-                body: vec![
-                    Stmt::VarDecl {
-                        name: tmp_idx.clone(),
-                        expr: (*index.clone()),
-                        type_constraint: None,
-                        is_state: false,
-                        is_our: false,
-                        is_dynamic: false,
-                        is_export: false,
-                        export_tags: Vec::new(),
-                        custom_traits: Vec::new(),
-                        where_constraint: None,
-                    },
-                    Stmt::Expr(Expr::IndexAssign {
-                        target: target.clone(),
-                        index: Box::new(tmp_idx_expr),
-                        value: Box::new(assigned_value),
-                        is_positional: true,
-                    }),
-                ],
-                label: None,
-            };
+            let expanded = Expr::desugar_block(vec![
+                Stmt::VarDecl {
+                    name: tmp_idx.clone(),
+                    expr: (*index.clone()),
+                    type_constraint: None,
+                    is_state: false,
+                    is_our: false,
+                    is_dynamic: false,
+                    is_export: false,
+                    export_tags: Vec::new(),
+                    custom_traits: Vec::new(),
+                    where_constraint: None,
+                },
+                Stmt::Expr(Expr::IndexAssign {
+                    target: target.clone(),
+                    index: Box::new(tmp_idx_expr),
+                    value: Box::new(assigned_value),
+                    is_positional: true,
+                }),
+            ]);
             let stmt = Stmt::Expr(compound_assign_marker(
                 expr.clone(),
                 op,
@@ -1527,29 +1512,23 @@ pub(crate) fn expr_stmt(input: &str) -> PResult<'_, Stmt> {
                 Stmt::Expr(Expr::Binary {
                     left: Box::new(expr),
                     op: op.token_kind(),
-                    right: Box::new(Expr::DoBlock {
-                        body: vec![
-                            Stmt::Expr(rhs),
-                            Stmt::Expr(Expr::Call {
-                                name: Symbol::intern("__mutsu_assignment_ro"),
-                                args: Vec::new(),
-                            }),
-                        ],
-                        label: None,
-                    }),
-                })
-            } else {
-                Stmt::Expr(Expr::DoBlock {
-                    body: vec![
-                        Stmt::Expr(expr),
+                    right: Box::new(Expr::desugar_block(vec![
                         Stmt::Expr(rhs),
                         Stmt::Expr(Expr::Call {
                             name: Symbol::intern("__mutsu_assignment_ro"),
                             args: Vec::new(),
                         }),
-                    ],
-                    label: None,
+                    ])),
                 })
+            } else {
+                Stmt::Expr(Expr::desugar_block(vec![
+                    Stmt::Expr(expr),
+                    Stmt::Expr(rhs),
+                    Stmt::Expr(Expr::Call {
+                        name: Symbol::intern("__mutsu_assignment_ro"),
+                        args: Vec::new(),
+                    }),
+                ]))
             };
         return parse_statement_modifier(r, stmt);
     }

--- a/src/precomp.rs
+++ b/src/precomp.rs
@@ -98,7 +98,9 @@ fn interpreter_version() -> String {
     // serialized `SerValue` discriminants after `Array`.
     // 10: `BufStorage`'s element descriptor became `ElemKind` (ADR-0015 P3),
     // so its third field serializes as an enum rather than a bool.
-    const CACHE_FORMAT_VERSION: u32 = 10;
+    // 11: `Expr::DoBlock` gained `origin: DoBlockOrigin` (GH-7635), so a
+    // cached node from an older build deserializes a field short.
+    const CACHE_FORMAT_VERSION: u32 = 11;
     // The exe mtime cannot change while this process runs, so stat it once —
     // every cache validation used to re-stat the (large) binary per module.
     static VERSION: std::sync::OnceLock<String> = std::sync::OnceLock::new();

--- a/src/rakuast/convert.rs
+++ b/src/rakuast/convert.rs
@@ -1146,9 +1146,20 @@ fn convert_expr(expr: &Expr) -> Result<RakuAstNode, RuntimeError> {
         // structurally at lowering. Convert straight through to the body.
         Expr::WhateverCurry(body) => convert_expr(body),
         // `do { … }` -> `StatementPrefix::Do(Block)`. A labelled do stays the boundary.
-        Expr::DoBlock { body, label } => {
+        Expr::DoBlock {
+            body,
+            label,
+            origin,
+        } => {
             if label.is_some() {
                 return Err(unsupported("labelled do block"));
+            }
+            // `StatementPrefixDo` round-trips back through `lower.rs` as a
+            // genuine source block. A desugar's node is not one, so converting
+            // it would hand back a node with block semantics (`let`/`temp`
+            // resolution) the original never had -- GH-7635.
+            if origin != &crate::ast::DoBlockOrigin::SourceBlock {
+                return Err(unsupported("desugared do-block"));
             }
             Ok(RakuAstNode {
                 class: RakuAstClass::StatementPrefixDo,

--- a/src/rakuast/lower.rs
+++ b/src/rakuast/lower.rs
@@ -1248,6 +1248,9 @@ fn lower_expr(node: &RakuAstNode) -> Result<Expr, RuntimeError> {
             Ok(Expr::DoBlock {
                 body: lower_block(block)?,
                 label: None,
+                // The round-trip of a source `do { … }`, so it carries the same
+                // block identity the parser gives that form (GH-7635).
+                origin: crate::ast::DoBlockOrigin::SourceBlock,
             })
         }
         // `try { … }` -> a try expression over the lowered block body.

--- a/src/runtime/dispatch_proto_rewrite.rs
+++ b/src/runtime/dispatch_proto_rewrite.rs
@@ -251,9 +251,14 @@ impl Interpreter {
                 expanded: Box::new(Self::rewrite_proto_dispatch_expr(expanded)),
             },
             Expr::Block(stmts) => Expr::Block(Self::rewrite_proto_dispatch_stmts(stmts)),
-            Expr::DoBlock { body, label } => Expr::DoBlock {
+            Expr::DoBlock {
+                body,
+                label,
+                origin,
+            } => Expr::DoBlock {
                 body: Self::rewrite_proto_dispatch_stmts(body),
                 label: label.clone(),
+                origin: *origin,
             },
             Expr::Try { body, catch } => Expr::Try {
                 body: Self::rewrite_proto_dispatch_stmts(body),

--- a/src/runtime/phasers.rs
+++ b/src/runtime/phasers.rs
@@ -326,7 +326,15 @@ fn extract_phasers_from_stmts(
                 };
                 let assign = Stmt::Assign {
                     name: temp_name,
-                    expr: Expr::DoBlock { body, label },
+                    // The phaser body's braces are real, but this node is
+                    // only the vehicle of the `my $tmp; $tmp = do{BODY}` hoist
+                    // -- the save resolution measured against Rakudo already
+                    // matches without claiming block identity here (GH-7635).
+                    expr: Expr::DoBlock {
+                        body,
+                        label,
+                        origin: crate::ast::DoBlockOrigin::Desugar,
+                    },
                     op: AssignOp::Assign,
                 };
                 match kind {
@@ -380,7 +388,7 @@ fn extract_begin_from_stmts(stmts: &mut [Stmt], begin: &mut Vec<Stmt>) {
                 };
                 let assign = Stmt::Assign {
                     name: temp_name,
-                    expr: Expr::DoBlock { body, label: None },
+                    expr: Expr::desugar_block(body),
                     op: AssignOp::Assign,
                 };
                 begin.push(var_decl);
@@ -457,7 +465,11 @@ fn lift_phasers_from_expr_inner(
             };
             let assign = Stmt::Assign {
                 name: temp_name,
-                expr: Expr::DoBlock { body, label },
+                expr: Expr::DoBlock {
+                    body,
+                    label,
+                    origin: crate::ast::DoBlockOrigin::Desugar,
+                },
                 op: AssignOp::Assign,
             };
             match kind {

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -5736,9 +5736,12 @@ impl Interpreter {
                 self.exec_let_save_op(code, *name_idx, *index_mode, *is_temp, *slot);
                 *ip += 1;
             }
-            OpCode::LetBlock { body_end } => {
+            OpCode::LetBlock {
+                body_end,
+                value_on_stack,
+            } => {
                 self.sync_source_line(code, *ip);
-                self.exec_let_block_op(code, *body_end, ip, compiled_fns)?;
+                self.exec_let_block_op(code, *body_end, *value_on_stack, ip, compiled_fns)?;
             }
         }
         Ok(())

--- a/src/vm/vm_misc_block.rs
+++ b/src/vm/vm_misc_block.rs
@@ -413,6 +413,7 @@ impl Interpreter {
         &mut self,
         code: &CompiledCode,
         body_end: u32,
+        value_on_stack: bool,
         ip: &mut usize,
         compiled_fns: &CompiledFns,
     ) -> Result<(), RuntimeError> {
@@ -421,8 +422,15 @@ impl Interpreter {
         let end = body_end as usize;
         match self.run_range(code, body_start, end, compiled_fns) {
             Ok(()) => {
-                let topic = self.env().get("_").cloned().unwrap_or(Value::NIL);
-                let success = Self::is_let_success(&topic);
+                // A value-position block left its value on the stack for the
+                // enclosing expression; peek it rather than reading the topic,
+                // which it never wrote (see `OpCode::LetBlock`).
+                let result = if value_on_stack {
+                    self.stack.last().cloned().unwrap_or(Value::NIL)
+                } else {
+                    self.env().get("_").cloned().unwrap_or(Value::NIL)
+                };
+                let success = Self::is_let_success(&result);
                 loan_env!(self, resolve_let_saves_on_success(mark, success));
                 // `let`/`temp` restore writes the saved value back into `env` only;
                 // the matching local slot still holds the in-block value. The restore

--- a/t/do-block-let-resolution.t
+++ b/t/do-block-let-resolution.t
@@ -1,0 +1,160 @@
+use Test;
+
+# GH-7635: `let`/`temp` resolve their saves at the end of the enclosing BLOCK.
+# A value-position `do { ... }` IS that block, so it must resolve its own saves
+# instead of leaking the speculative value to whatever encloses it. A
+# synthesized `Expr::DoBlock` (item context, compound-assignment lowering, the
+# chained-comparison desugar, ...) is NOT a block and must keep deferring to the
+# real one -- `Expr::DoBlock` carries `DoBlockOrigin` to tell the two apart.
+#
+# Every assertion below was measured against `raku` first.
+
+plan 21;
+
+# --- a genuine `do { ... }` resolves its own saves -----------------------
+
+{
+    my $x = 1;
+    do { let $x = 2; Nil };
+    is $x, 1, 'do block that fails restores a `let`';
+}
+
+{
+    my $x = 1;
+    do { let $x = 2; 42 };
+    is $x, 2, 'do block that succeeds commits a `let`';
+}
+
+{
+    my $x = 1;
+    my $v = do { let $x = 2; Nil };
+    is $x, 1, 'do block in value position restores a `let`';
+    ok !$v.defined, 'and still yields the block value';
+}
+
+{
+    my $x = 1;
+    do { temp $x = 2; 42 };
+    is $x, 1, '`temp` in a do block restores even when the block succeeds';
+}
+
+{
+    # The inner `do` succeeds, so it COMMITS the save; the outer one failing
+    # afterwards must not undo it -- proof that the save resolved at the inner
+    # block rather than at the enclosing one.
+    my $x = 1;
+    do { do { let $x = 2; 42 }; Nil };
+    is $x, 2, 'a nested do block resolves at the inner block';
+}
+
+{
+    my $x = 1;
+    L: do { let $x = 2; Nil };
+    is $x, 1, 'a labelled do block resolves its own saves';
+}
+
+{
+    my $x = 1;
+    L2: { let $x = 2; Nil };
+    is $x, 1, 'a labelled bare block resolves its own saves';
+}
+
+# --- statement prefixes whose block runs inline are blocks too -----------
+
+{
+    my $x = 1;
+    quietly { let $x = 2; Nil };
+    is $x, 1, '`quietly BLOCK` resolves its own saves';
+}
+
+{
+    my $x = 1;
+    sink { let $x = 2; Nil };
+    is $x, 1, '`sink BLOCK` resolves its own saves';
+}
+
+{
+    my $x = 1;
+    lazy { let $x = 2; Nil };
+    is $x, 1, '`lazy BLOCK` resolves its own saves';
+}
+
+# --- a statement-position bare block is unchanged ------------------------
+
+{
+    my $x = 1;
+    { let $x = 2; Nil };
+    is $x, 1, 'a statement-position bare block still restores a `let`';
+}
+
+{
+    my $x = 1;
+    { let $x = 2; 42 };
+    is $x, 2, 'a statement-position bare block still commits a `let`';
+}
+
+# --- a synthesized DoBlock is NOT a block -------------------------------
+
+{
+    # Item context `$( ... )` is compiled as an `Expr::DoBlock`, but it opens no
+    # scope: the save belongs to the enclosing block, which succeeds here.
+    # roast/S04-blocks-and-statements/let.t leans on this shape.
+    my $a = 42;
+    my $seen;
+    { $seen = $( let $a = 23; $a ); 42 };
+    is $seen, 23, 'item context sees the speculative value';
+    is $a, 23, 'and the enclosing block, having succeeded, commits it';
+}
+
+{
+    # The same shape with a failing enclosing block: still resolved THERE, so
+    # the restore happens -- not at the `$( ... )` wrapper.
+    my $a = 42;
+    do { $( let $a = 23; $a ); Nil };
+    is $a, 42, 'a synthesized wrapper defers resolution to the real block';
+}
+
+{
+    # The sharp discriminator. The `$( ... )` wrapper's own value is undefined
+    # (a failure), the enclosing `do` succeeds. Resolution happens at the `do`,
+    # so the save COMMITS; a wrapper that resolved on its own would have
+    # restored 42.
+    my $a = 42;
+    do { $( let $a = 23; Nil ); 42 };
+    is $a, 23, 'the wrapper value does not decide the resolution';
+}
+
+{
+    my $a = 42;
+    do { $( temp $a = 23; $a ); 42 };
+    is $a, 42, '`temp` through a wrapper still restores at the do block';
+}
+
+# --- a string-interpolation block is not one either ----------------------
+
+{
+    # `temp` restores unconditionally at the block that OWNS the save, so it is
+    # the sharp test for whether a construct is such a block. Measured against
+    # `raku`: an interpolation block is not, and the save outlives it.
+    my $x = 1;
+    my $s = "{ temp $x = 2; 'v' }";
+    is $x, 2, 'a string-interpolation block owns no save frame';
+}
+
+{
+    my $x = 1;
+    my $s = "{ let $x = 2; Nil }";
+    is $x, 2, 'and so does not roll a `let` back either';
+}
+
+# --- the topic is not collateral damage ---------------------------------
+
+{
+    # The statement form routes the block value through `$_` to decide
+    # success/failure; the value form must not, or `do { ... }` would clobber
+    # the enclosing topic.
+    my $x = 1;
+    $_ = 'topic';
+    do { let $x = 2; 99 };
+    is $_, 'topic', 'a value-position let block leaves the topic alone';
+}


### PR DESCRIPTION
The bare-block unification (#7569, ADR-0076) gave the value position the `let`/`temp` branch the statement position always had, which closed the divergence #7635 was filed for. It had to answer a second question to do that, and this PR changes the answer's *direction*.

## The question

**`Expr::DoBlock` is not a Raku block.** Around forty parser and compiler desugars build one as a generic "run these statements, yield a value" vehicle — item context `$( ... )`, the chained-comparison lowering, `cas`, compound assignment, `.=` writeback, hyper-op destructuring. None of those open a scope at which a `let`/`temp` save may resolve, and treating one as a block resolves the save at the innermost wrapper rather than at the real block, which breaks the idiom roast leans on throughout:

```raku
my $a = 42;
{
  is($(let $a = 23; $a), 23, "let() changed the variable");
  Mu;
}
is $a, 42, "let() should restore the variable, as our block failed";
```

The answer on `main` is a **denylist**: a sentinel label (`STMT_LIST_CONTEXTUALIZER_LABEL`) on the one node known to need the exemption, with every other `Expr::DoBlock` owning a save frame by default.

## The change: the marker moves onto the node, and inverts

A denylist is only correct for the exemptions somebody thought to write down, and it was already wrong for one nobody had (below). `Expr::DoBlock` now carries a `DoBlockOrigin` — the marker #7635 asked for — and `DoBlockOrigin::SourceBlock` is set at the few sites that mint a node from real source braces that *are* a Raku block:

- the `do` keyword's own braces (`parser/primary/ident/identifier_call.rs`), the single site that parses that form;
- a labelled `L: do { ... }` and a labelled bare `L: { ... }` (`parser/stmt/control/labeled_loop.rs`);
- the statement prefixes whose block runs inline in the current frame rather than as a closure — `lazy`, `sink`, `quietly` — which re-host the user's own braces in a `DoBlock`;
- the RakuAST round-trip of `StatementPrefixDo` (`rakuast/lower.rs`).

Every other site is `DoBlockOrigin::Desugar`, which is what the new `Expr::desugar_block` constructor produces — so a future desugar gets the right answer without having to know the rule exists. `BlockPosition::Value` carries the origin, so `BlockPlan::analyze` reads the answer off the position it is already given, and the sentinel label is gone, leaving `label` to mean the block's label again.

## Two divergences from `raku` the inversion fixes

**A string-interpolation block owned a save frame it should not.** `temp` restores unconditionally at the block that owns the save, so it is the sharp test for whether a construct is one — and Rakudo says an interpolation block is not:

```raku
my $x = 1;
my $s = "{ temp $x = 2; 'v' }";
say $x;      # raku: 2   main: 1
```

Interpolation builds `DoStmt(Stmt::Block(...))` and reached the value-position lowering with no exemption. It is `Desugar` now, with the measurement recorded at the site.

**A value-position `let` block clobbered the enclosing topic.** `OpCode::LetBlock` reads the block's own value to decide restore-vs-commit, and the two positions leave that value in different places: the statement form routes its last statement through `compile_last_stmt_as_topic` so the op reads `$_`, while the value form has the value on the stack and was made to fit by emitting `Dup; SetTopic` — which wrote the enclosing scope's topic:

```raku
my $x = 1;
$_ = 'topic';
do { let $x = 2; 99 };
say $_;      # raku: topic   main: 99
```

The opcode carries `value_on_stack` now, and `exec_let_block_op` peeks the stack top instead of reading the topic when it is set. No `Dup`/`SetTopic`, no collateral damage.

## Two consequences of widening the node

The precompilation cache stores the AST, so an older build's cached `DoBlock` deserializes a field short — `CACHE_FORMAT_VERSION` goes to 11.

`rakuast/convert.rs` refuses to convert a `Desugar` node to `StatementPrefixDo`, which would otherwise round-trip back through `lower.rs` as a genuine source block, handing back a node with block semantics the original never had. All 113 `t/rakuast*.t` files pass unchanged.

## Tests

`t/do-block-let-resolution.t` — 21 assertions covering the genuine `do`/labelled/`lazy`/`sink`/`quietly` forms, the statement form's unchanged behaviour, the `$( ... )` wrapper deferring to the real block (including a discriminator where the wrapper's own value is a failure and the enclosing `do` succeeds), the interpolation shapes, and the topic. **All 21 pass unchanged under `raku`.**

## Verification

| | result |
| --- | --- |
| `cargo fmt --all` | clean |
| `make lint` (all four configurations) | green |
| `make test` | 3861 files, 40928 tests, **PASS** |
| `make roast` | 1436 files, 218939 tests — only the three container-only failures documented in `docs/agent-environments.md`, matching subtest-for-subtest: `file-tests.t` tests 6-8/10 and `filetest.t` tests 57-64/69-72/77-80/101-125 (both `uid 0`, confirmed `id -u` = 0), and `IO-Socket-Async.t` exit 124 ran 17 (sandboxed network). The three other summary entries are `TODO passed`, not failures. |

## Still open

Two neighbouring divergences share the subsystem but not the root cause, and are filed separately rather than widened into this change:

- #7645 — `Compiler::has_let_deep` does not look inside a declaration's or an assignment's initializer, so `{ my $seen = $( let $a = 23; $a ); Nil }` never classifies its enclosing block as a `let` block at all. Fixing it moves blocks from `BlockScope` to `LetBlock`, which does not restore the env — a much larger blast radius.
- #7646 — a routine body does not resolve its own saves: `sub f() { let $x = 2; Nil }` leaves `$x` at 2 where `raku` restores it to 1.

Closes #7635

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ApzAyGMeHkBw98JDGfGGFB

---
_Generated by [Claude Code](https://claude.ai/code/session_01ApzAyGMeHkBw98JDGfGGFB)_