### PR TITLE
fix(runtime): make the idempotent sub re-registration check identity, not presence

### DIFF
--- a/news/2026-09/inner-sub-registration-identity.md
+++ b/news/2026-09/inner-sub-registration-identity.md
@@ -1,0 +1,64 @@
+# A routine's inner `sub` is no longer displaced by another routine's same-named one
+
+`Digest::SHA2`'s `sha256` computed a **wrong digest** — silently, no error — as
+soon as a `sha384`/`sha512` call had run earlier in the same process and the
+`sha256` body was re-entered. The RFC 4231 HMAC vectors caught it
+(`Digest`'s `t/rfc4231.t`, one of the four bundled-library regressions in
+[#7555](https://github.com/tokuhirom/mutsu/issues/7555)), where five of the
+28 assertions came back with plausible-looking but incorrect bytes.
+
+## What was actually wrong
+
+Both compression functions in that module declare their helpers as inner subs of
+the routine that uses them, and both use the same names:
+
+```raku
+multi sha256(blob8 $data, blob32 :$initial-hash = …) {
+  sub rotr(uint32 $n, UInt $b) { $n +> $b +| $n +< (32 - $b) }
+  sub Σ0 { rotr($^x,  2) +^ rotr($x, 13) +^ rotr($x, 22) }
+  …
+}
+multi sha512(blob8 $data, blob64 :$initial-hash = …) {
+  sub rotr($n, $b) { $n +> $b +| $n +< (64 - $b) }
+  sub Σ0 { rotr($^x, 28) +^ rotr($x, 34) +^ rotr($x, 39) }
+  …
+}
+```
+
+In Raku each set is lexical to its own routine. In mutsu routines live in one
+name-keyed registry (`Digest::SHA2::rotr`), and a routine scope snapshots that
+registry on entry and restores the whole snapshot on exit — so after `sha512`
+had run, the key could legitimately hold *its* `rotr` again while `sha256` was
+about to run.
+
+That is fine on its own: `sha256`'s body re-registers its own helpers each time
+it runs. What broke was the registrar's **idempotent re-registration fast
+path**, which exists so a `my sub` inside a hot routine is not re-derived on
+every call. It asked two questions — "is the last fingerprint recorded under
+this name mine?" and "is *something* registered under this name?" — and answered
+"already installed" when both held. After a scope restore had put a *different*
+declaration back under the name, both still held and the fast path returned
+without installing anything. `sha256` then ran its whole compression loop
+calling `sha512`'s 64-bit `rotr` and `Σ0`, producing a digest that is wrong in
+every byte but has the right length.
+
+The failure was invisible from inside the module: `$initial-hash`, the message
+schedule `$w`, the round constants and the block count were all correct, which
+is why the first investigation localized it to `subtest` and to `sha512`. The
+one measurement that settles it is a `note` inside each `rotr` — under the
+failing call it is `sha512`'s that prints.
+
+## The fix
+
+`registered_fn_fingerprints` now records the fingerprint **and the exact
+`Arc<FunctionDef>` that was installed**, and the fast path takes the no-op only
+when the registry still holds that same definition (`Arc::ptr_eq`). Presence
+under the name is no longer accepted as proof of identity. A genuine
+re-registration of an unchanged declaration still hits the fast path — the
+pointer matches — so the hot `my sub` case keeps its shortcut; only the
+displaced case now falls through to the full path, which is exactly what it
+needs.
+
+Pinned by `t/inner-sub-same-name-across-routines.t`, which runs the RFC 4231
+case-4 and case-5 vectors in that order through the bundled `Digest`/`HMAC`
+batteries.

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -3356,14 +3356,27 @@ pub struct Interpreter {
     /// (rakudo rejects it at compile time). Populated at proto registration;
     /// checked cheaply (guarded by `is_empty()`) on each call.
     pub(crate) empty_sig_proto_names: std::collections::HashSet<Symbol>,
-    /// Fingerprint of the sub declaration currently installed under each
-    /// `package::name` (single, non-multi) routine key. A re-executed
-    /// `RegisterSub` whose compile-time fingerprint matches the installed one is
-    /// an idempotent no-op (see [`crate::ast::sub_registration_fingerprint`]),
-    /// so the registrar can return early without re-deriving the FunctionDef and
-    /// without invalidating the resolution caches. Entries are best-effort: a
-    /// miss simply takes the full registration path.
-    pub(crate) registered_fn_fingerprints: rustc_hash::FxHashMap<Symbol, u64>,
+    /// Fingerprint of the sub declaration this registrar last installed under
+    /// each `package::name` (single, non-multi) routine key, together with the
+    /// exact `FunctionDef` it installed. A re-executed `RegisterSub` whose
+    /// compile-time fingerprint matches -- AND whose recorded definition is
+    /// still the one the registry holds -- is an idempotent no-op (see
+    /// [`crate::ast::sub_registration_fingerprint`]), so the registrar can
+    /// return early without re-deriving the FunctionDef and without
+    /// invalidating the resolution caches.
+    ///
+    /// The recorded `Arc` is what makes the identity check exact. This map is
+    /// name-keyed and is NOT updated by `restore_routine_registry`, which puts
+    /// a whole snapshot of `registry.functions` back when a routine scope ends
+    /// -- so after an inner `sub r` of routine A returns, the key `Pkg::r` can
+    /// again hold a DIFFERENT routine B's inner `sub r`, while this map still
+    /// names A's. A presence-only check ("something is installed under this
+    /// name") then wrongly reports A's declaration as already installed and
+    /// leaves B's definition live inside A's body. `Digest::SHA2` is the real
+    /// case: `sha256` and `sha512` each declare `rotr`/`Σ0`/`Σ1`/`σ0`/`σ1`, and
+    /// `sha256` silently computed with `sha512`'s 64-bit rotations.
+    pub(crate) registered_fn_fingerprints:
+        rustc_hash::FxHashMap<Symbol, (u64, std::sync::Arc<FunctionDef>)>,
     /// Declaration sites (fully-qualified name, compile-time site fingerprint)
     /// that registered a yada-stub routine. A `RegisterSub` executes both
     /// hoisted at block top and in place, so a stub's in-place re-arrival can

--- a/src/runtime/registration_sub.rs
+++ b/src/runtime/registration_sub.rs
@@ -807,9 +807,25 @@ impl Interpreter {
         {
             let fq = format!("{}::{}", self.current_package(), name);
             let fq_sym = Symbol::intern(&fq);
-            if self.registered_fn_fingerprints.get(&fq_sym) == Some(&site_fp)
-                && self.registry().functions.contains_key(&fq_sym)
-            {
+            // Identity, not mere presence: `restore_routine_registry` puts a
+            // whole snapshot of `registry.functions` back when a routine scope
+            // ends, so this name can now hold a DIFFERENT declaration (another
+            // routine's same-named inner `sub`) than the one recorded here. A
+            // `contains_key` test would then report "already installed" and
+            // leave that other routine's definition live inside this body —
+            // `Digest::SHA2`'s `sha256` computing with `sha512`'s `rotr`.
+            let already_installed =
+                self.registered_fn_fingerprints
+                    .get(&fq_sym)
+                    .is_some_and(|(fp, installed)| {
+                        *fp == site_fp
+                            && self
+                                .registry()
+                                .functions
+                                .get(&fq_sym)
+                                .is_some_and(|current| std::sync::Arc::ptr_eq(current, installed))
+                    });
+            if already_installed {
                 let callable_key =
                     format!("__mutsu_callable_id::{}::{}", self.current_package(), name);
                 self.env.insert(
@@ -845,10 +861,11 @@ impl Interpreter {
                     .filter(|(fp, _)| *fp == site_fp)
                     .map(|(_, arc)| arc.clone())
             {
-                self.registry_mut().functions.insert(fq_sym, cached);
+                self.registry_mut().functions.insert(fq_sym, cached.clone());
                 // Invalidate name-keyed resolution caches.
                 self.fn_resolve_gen += 1;
-                self.registered_fn_fingerprints.insert(fq_sym, site_fp);
+                self.registered_fn_fingerprints
+                    .insert(fq_sym, (site_fp, cached));
                 if pkg != "GLOBAL" {
                     self.mark_my_scoped_package_item(fq);
                 }
@@ -1330,7 +1347,8 @@ impl Interpreter {
             // which (for a `my sub` whose lexical scope is snapshot/restored each
             // enclosing call) is exactly the per-call cost this is meant to avoid.
             if let Some(fp) = site_fingerprint {
-                self.registered_fn_fingerprints.insert(fq_sym, fp);
+                self.registered_fn_fingerprints
+                    .insert(fq_sym, (fp, arc.clone()));
                 // A stub site is remembered permanently (not just as the last
                 // fingerprint): the real definition it forward-declares will
                 // overwrite `registered_fn_fingerprints`, and the stub's own

--- a/t/inner-sub-same-name-across-routines.t
+++ b/t/inner-sub-same-name-across-routines.t
@@ -1,0 +1,43 @@
+use Test;
+
+# Two routines may each declare an inner `sub` of the SAME name; each body must
+# see its own. mutsu's registry is name-keyed (`Pkg::name`), and a routine scope
+# restores a whole snapshot of it when the body ends -- so the key can hold
+# another routine's same-named inner sub by the time this one runs again. The
+# registrar's idempotent re-registration fast path used to accept that as
+# "already installed" (it only tested that SOMETHING was registered under the
+# name), leaving the other routine's definition live inside this body.
+#
+# `Digest::SHA2` is the real case: `sha256` and `sha512` each declare
+# `rotr`/`Sigma0`/`Sigma1`/`sigma0`/`sigma1`, and after a `sha384` call (which
+# runs `sha512`'s body) `sha256` silently computed with `sha512`'s 64-bit
+# rotations -- a wrong digest, no error. See
+# https://github.com/tokuhirom/mutsu/issues/7555.
+
+use Digest::SHA2;
+use HMAC;
+
+plan 4;
+
+sub run-in-block(&body) { body() }
+
+run-in-block {
+    my ($key, $msg) = Blob.new(1..25), Blob.new(0xcd xx 50);
+    is hmac(:$key, :$msg, hash => &sha384, block-size => 128).list».fmt('%02x').join,
+        '3e8a69b7783c25851933ab6290af6ca77a9981480850009cc5577c6e1f573b4e' ~
+        '6801dd23c4a7d679ccf8a386c674cffb',
+        'HMAC-SHA-384 matches RFC 4231 test case 4';
+}
+
+run-in-block {
+    my ($key, $msg) = Blob.new(0x0c xx 20), "Test With Truncation";
+    is hmac(:$key, :$msg, hash => &sha224, block-size => 64).subbuf(0, 16).list».fmt('%02x').join,
+        '0e2aea68a90c8d37c988bcdb9fca6fa8',
+        'HMAC-SHA-224 matches RFC 4231 test case 5';
+    is hmac(:$key, :$msg, hash => &sha256, block-size => 64).subbuf(0, 16).list».fmt('%02x').join,
+        'a3b6167473100ee06e0c796c2955552b',
+        'HMAC-SHA-256 still uses its own rotr after a SHA-512 call';
+    is hmac(:$key, :$msg, hash => &sha512, block-size => 128).subbuf(0, 16).list».fmt('%02x').join,
+        '415fad6271580a531d4179bc891d87a6',
+        'HMAC-SHA-512 is right in the same run';
+}


### PR DESCRIPTION
## Root cause

`Digest`'s `t/rfc4231.t` — one of the four bundled-library regressions in #7555 —
fails five of its 28 assertions under the vendored `Test` module, with **wrong
computed digests**, not a reporting difference. The switch is not the cause; it
only changes the call ordering that exposes an interpreter bug.

Both SHA-2 compression functions declare their helpers as inner subs of the
routine that uses them, and both use the same names:

```raku
multi sha256(blob8 $data, blob32 :$initial-hash = …) {
  sub rotr(uint32 $n, UInt $b) { $n +> $b +| $n +< (32 - $b) }
  sub Σ0 { rotr($^x,  2) +^ rotr($x, 13) +^ rotr($x, 22) }
  …
}
multi sha512(blob8 $data, blob64 :$initial-hash = …) {
  sub rotr($n, $b) { $n +> $b +| $n +< (64 - $b) }
  sub Σ0 { rotr($^x, 28) +^ rotr($x, 34) +^ rotr($x, 39) }
  …
}
```

In Raku each set is lexical to its own routine. mutsu keeps routines in one
name-keyed registry (`Digest::SHA2::rotr`), and `OpCode::RoutineScope` restores
a whole snapshot of that registry when a body ends — so the key can legitimately
hold `sha512`'s `rotr` again by the time `sha256` runs. That is fine on its own:
`sha256`'s body re-registers its own helpers on every run.

What broke is the registrar's **idempotent re-registration fast path**
(`register_sub_decl_with_metadata`), which exists so a `my sub` inside a hot
routine is not re-derived per call. It asked only:

1. is the last fingerprint recorded under this name mine? and
2. is *something* registered under this name?

After a scope restore had put a different declaration back under the name, both
still held, so it returned `Unchanged` and installed nothing. `sha256` then ran
its entire compression loop calling `sha512`'s 64-bit `rotr`/`Σ0`, producing a
digest that is wrong in every byte and has the right length.

## How it was pinned

Everything inside the module measured correct — `$initial-hash`, the message
schedule `$w`, the round constants, the block count — which is why the first
investigation localized this to `subtest` and to `sha512`. The measurement that
settles it is a `note` inside each `rotr`: under the failing call it is
`sha512`'s that prints. Renaming `sha512`'s five helpers in a scratch copy of
the module makes the whole file pass, with no interpreter change.

The reduction also shows the vendored `Test` is incidental — a three-line
`sub run-in-block(&body) { body() }` reproduces it with no `Test` anywhere.

## The fix

`registered_fn_fingerprints` now records the fingerprint **together with the
exact `Arc<FunctionDef>` installed**, and the fast path takes the no-op only
when the registry still holds that same definition (`Arc::ptr_eq`). Presence
under the name is no longer accepted as proof of identity.

An unchanged declaration re-arriving still hits the fast path — the pointer
matches — so the hot `my sub` case keeps its shortcut. Only the displaced case
falls through to the full registration path, which is exactly what it needs.

## Verification

- `Digest`'s upstream `t/rfc4231.t` now passes **7/7 under the vendored `Test`**
  (`MUTSU_REAL_TEST=1`); before this it was 4/7 with five wrong digests.
- New `t/inner-sub-same-name-across-routines.t` pins RFC 4231 case 4 and case 5
  in that order through the bundled `Digest`/`HMAC` batteries. It fails on
  `main` and passes here.
- `make test` PASS (3860 files, 40899 tests), `make lint` clean in all four
  configurations, `make roast` green apart from the three container-only files
  `docs/agent-environments.md` documents (`6.c/S32-io/file-tests.t`,
  `S16-filehandles/filetest.t`, `S32-io/IO-Socket-Async.t`), matching their
  recorded shapes exactly.

Refs #7555 (this is item 2 of the four; the `NativeLibs` custom-`EXPORT` item
and the two `Cro::HTTP` items are unaffected and stay open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vfxeym2iMEoeTaWPbvCiqu

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vfxeym2iMEoeTaWPbvCiqu)_