### PR TITLE
fix(doc-diff): gate on oracle reproducibility, cap output, drop the drift bucket

### DIFF
--- a/docs/doc-diff-backlog.md
+++ b/docs/doc-diff-backlog.md
@@ -21,8 +21,8 @@ minimal-repro reports), `progress.txt` (one stats line per file), `summary.txt`
 `summary.txt`, and the counts drop as fixes land — that is the visible progress
 signal.
 
-**When a finding is confirmed real (not raku-drift, not a harness false positive —
-see "Known harness false positive" below), file it as an issue immediately** on
+**When a finding is confirmed real (not a harness false positive — see "Known
+harness false positive" below), file it as an issue immediately** on
 `tokuhirom/mutsu`, labelled `todo:ticket` (or `todo:deep` for high-blast-radius
 ones) per `docs/issue-workflow.md`, and add a row to
 [Ticketed](#ticketed-open--linked-to-todo) below linking the doc location to that
@@ -36,14 +36,25 @@ repros without re-running the sweep. Re-copy it (see that dir's `README.md`) whe
 you refresh the survey.
 
 **Always re-verify a finding directly before treating it as a real bug.** The
-harness oracle-gates on raku, but doc examples drift and the harness can only compare
-`# OUTPUT:`-style blocks.
+harness oracle-gates on raku, but it can only compare what a doc block actually
+prints.
 
-**Do NOT skip the `raku-drift` bucket.** It used to be described here as
-"version skew, not mutsu bugs — lowest priority". That was measured wrong on
-2026-09-07b: the bucket is only reachable *after* mutsu has already been found to
-differ from raku, and 67 of its 114 blocks are confirmed real mutsu bugs against
-5 that the name actually describes. See the ⚠ section under Corpus snapshot.
+**The `raku-drift` bucket no longer exists** (#7590). It was described here as
+"version skew, not mutsu bugs — lowest priority", and that was measured wrong on
+2026-09-07b: the bucket was only reachable *after* mutsu had already been found to
+differ from raku, so it filed real divergences as non-bugs — 67 of its 114 blocks
+were confirmed real mutsu bugs against 5 that the name actually described. Whether
+raku still matches the doc's own `# OUTPUT:` is **provenance, not priority**, so it
+now rides along as an annotation on an ordinary `output-mismatch` finding
+("mutsu matches the doc's own `# OUTPUT:` here; raku does not").
+
+**`nondet` in a summary is the noise floor, not a finding.** The harness runs the
+oracle twice and drops any block whose *raku* output is not reproducible — unordered
+container iteration (`Set`/`Bag`/`Mix`/`*Hash`/`Map`/`Hash.kv`/enum `.keys`), object
+addresses and `WHICH` ids, thread ids. Those blocks used to be compared, diverge on
+the unreproducible token alone, and land in the low-priority bucket on every run
+forever; nine real mutsu bugs hid there, #7587 among them. A rising `nondet` count
+means the corpus has more such examples, not that mutsu got worse.
 
 ## Corpus snapshot
 
@@ -59,7 +70,7 @@ differ from raku, and 67 of its 114 blocks are confirmed real mutsu bugs against
   day: the blocks are not disappearing from the corpus, they are being answered
   correctly.
 
-### ⚠ `raku-drift` is NOT a "not a mutsu bug" bucket — measured 2026-09-07b
+### ⚠ `raku-drift` was NOT a "not a mutsu bug" bucket — measured 2026-09-07b (bucket retired by #7590)
 
 **Read this before using the survey table to pick work.** The harness bucketing
 (`scripts/doc-diff-harness.raku:72-93`) is:
@@ -301,7 +312,7 @@ delete the row here.
 | `Language/traps.rakudoc:858` | a lazy Seq (`.map`/`.grep`/`...`/`gather`) passed to a user `*@a` slurpy arrives **empty**; the `.grep` face is a **regression bisected to PR #7501** | [lazy-seq-argument-vanishes-into-a-user-slurpy.md](../todo/tickets/lazy-seq-argument-vanishes-into-a-user-slurpy.md) |
 | `Language/objects.rakudoc:1397` | `@a[0 .. $n]` **hangs forever** when `$n` holds a negative value (raku: `()`) | [array-slice-with-a-runtime-empty-reversed-range-hangs.md](../todo/tickets/array-slice-with-a-runtime-empty-reversed-range-hangs.md) |
 | `Type/Code.rakudoc:140` | a `Block` inside a list renders as the empty string, so a one-element list prints as `()` | [code-object-renders-as-nothing-inside-a-list.md](../todo/tickets/code-object-renders-as-nothing-inside-a-list.md) |
-| *(harness itself)* | no output cap, and `raku-drift` used as a priority bucket when it only ever contains mutsu-vs-oracle divergences | [doc-diff-harness-has-no-output-cap-or-nondeterminism-gate.md](../todo/tickets/doc-diff-harness-has-no-output-cap-or-nondeterminism-gate.md) |
+| *(harness itself)* | no output cap, and `raku-drift` used as a priority bucket when it only ever contains mutsu-vs-oracle divergences | [#7590](https://github.com/tokuhirom/mutsu/issues/7590) — **fixed** |
 
 #### Triaged real, not yet filed (2026-09-07b)
 
@@ -464,8 +475,11 @@ full or the tree has moved. Re-verify each block against `raku` before writing a
 ## Survey — files with divergences (high-signal first)
 
 `mism` = output-mismatch · `crash` = mutsu exited non-zero where raku succeeded ·
-`drift` = raku-drift-from-doc — **not low priority**: 59% of that bucket is
-confirmed-real mutsu divergence (see the ⚠ section under Corpus snapshot).
+`drift` = the retired `raku-drift-from-doc` bucket, as this (2026-09-07b) sweep
+recorded it — **not low priority**: 59% of it is confirmed-real mutsu divergence
+(see the ⚠ section under Corpus snapshot). #7590 removed that bucket; a summary
+produced after it has a `nondet` column instead, counting blocks dropped because
+raku disagreed with itself — the noise floor, not findings.
 
 **This table under-reports.** It ranks by `mism + crash`, so a file whose only
 findings are `drift` scores 0 and does not appear at all — that is **61 findings

--- a/docs/doc-diff-sweep/README.md
+++ b/docs/doc-diff-sweep/README.md
@@ -23,7 +23,13 @@ cp tmp/sweep-final/{summary.txt,progress.txt} docs/doc-diff-sweep/
 cp -r tmp/sweep-final/reports docs/doc-diff-sweep/reports
 ```
 
-**Cap captured output before committing** — the harness does not (see `todo/tickets/doc-diff-harness-has-no-output-cap-or-nondeterminism-gate.md`); the 2026-09-07b sweep needed 11 MB → 412 KB of truncation. Keep only the reports for files listed in `summary.txt`.
+Captured output is capped by the harness itself now (#7590): each section is cut to
+40 lines with an explicit `... [truncated by doc-diff-harness: N more line(s) of M]`
+marker, and every block runs in a scratch directory rather than the repo root. Before
+that, the recipe above was not safe as written — the 2026-09-07b sweep needed 11 MB →
+412 KB of truncation BY HAND (one `sub MAIN` that `.dir`-walks its cwd produced a
+131_492-line, 8.4 MB report), and it left stray `bar` / `foo.txt` files behind. Keep
+only the reports for files listed in `summary.txt`.
 
 Then regenerate the survey table + Corpus snapshot in
 [../doc-diff-backlog.md](../doc-diff-backlog.md) from the new `summary.txt`, and

--- a/docs/qa-doc-diff-harness.md
+++ b/docs/qa-doc-diff-harness.md
@@ -19,11 +19,21 @@ disagree.
 - **Noise control.**
   - Non-deterministic examples (`rand`/`.pick`/`.roll`/`now`/`Supply`/…) and explicit
     `# ERROR` examples are skipped by heuristic.
-  - Every mismatch is cross-checked against the block's own `# OUTPUT: «…»` annotation.
-    When raku no longer matches the doc, the finding is bucketed as
-    **`raku-drift-from-doc`** (raku changed since the doc was written; mutsu may well
-    match the doc) and de-prioritised versus a true `output-mismatch` where raku and the
-    doc agree but mutsu is wrong. This implements the §8.4 language-version caveat.
+  - **The oracle is run twice and the block is dropped unless raku agrees with
+    itself.** This is the whole nondeterminism policy, and it deliberately replaces
+    growing the pattern list above: no list can practically enumerate unordered
+    container iteration (`Set`/`Bag`/`Mix`/`*Hash`/`Map`/`Hash.kv`/enum `.keys`),
+    object addresses and `WHICH` ids, thread ids, `$*DISTRO`/`$*VM`/`dir` order. Such
+    blocks otherwise diverge on the unreproducible token alone, every run, forever.
+    They are counted as `skipped (oracle not reproducible)` — the noise floor, not
+    findings.
+  - Every mismatch is cross-checked against the block's own `# OUTPUT: «…»` annotation,
+    and when *mutsu* matches the doc the finding carries a note saying so. That is an
+    **annotation, not a bucket**: it records provenance (the doc was written against an
+    older raku), never priority. There used to be a separate `raku-drift-from-doc`
+    bucket described as "not mutsu bugs, lowest priority"; because it was only
+    reachable once mutsu already differed from raku, 67 of its 114 blocks were real
+    mutsu bugs against 5 the name fit, and nine bugs hid there. See #7590.
 
 ## Usage
 
@@ -37,9 +47,10 @@ Defaults: `--mutsu=target/debug/mutsu`, `--timeout=10`, corpus =
 The debug and release binaries produce identical output, so the debug build is fine
 for correctness triage (only speed differs).
 
-The report groups findings by kind (`output-mismatch`, `mutsu-error`,
-`raku-drift-from-doc`), each with the exact program, raku stdout, and mutsu
-stdout/stderr — i.e. a ready-made minimal repro.
+The report groups findings by kind (`output-mismatch`, `mutsu-error`), each with the
+exact program, raku stdout, and mutsu stdout/stderr — i.e. a ready-made minimal repro.
+Each captured section is capped at 40 lines with an explicit truncation marker, so one
+runaway example cannot bury a sweep.
 
 The harness writes each candidate program to a per-PID scratch file
 (`tmp/ddh/prog-<pid>.raku`), so multiple invocations may run **concurrently**
@@ -59,14 +70,14 @@ Defaults: `-j8`, `-o tmp/sweep`, `-m target/debug/mutsu`, corpus = Type +
 Language. Outputs `OUTDIR/reports/<file>.txt` (per file), `OUTDIR/progress.txt`
 (one stats line per file), and `OUTDIR/summary.txt` (corpus totals + files
 ranked by `mismatch + crash`, high-signal first). Always re-verify a finding
-directly before treating it as a real bug — doc examples drift, and version
-drift is bucketed separately as `raku-drift-from-doc`.
+directly before treating it as a real bug — the harness can only compare what a
+doc block actually prints.
 
 ## First run (2026-07-18, 8 core Type files: Str/Array/List/Hash/Num/Rat/Range/Map)
 
 525 blocks extracted → 270 raku-clean comparisons → **50 high-signal divergences
-(18.5%)**: 25 `output-mismatch` + 25 `mutsu-error`, plus 8 low-priority
-`raku-drift-from-doc`. ~2 min wall-clock (debug mutsu). The signal is dense and the
+(18.5%)**: 25 `output-mismatch` + 25 `mutsu-error`, plus 8 in the since-retired
+`raku-drift-from-doc` bucket (#7590). ~2 min wall-clock (debug mutsu). The signal is dense and the
 findings are genuine and cluster by root cause — validating §8.1's premise.
 
 ### First root-cause cluster found: sequence/lazy argument truncation

--- a/news/2026-09/doc-diff-harness-oracle-gate-and-output-cap.md
+++ b/news/2026-09/doc-diff-harness-oracle-gate-and-output-cap.md
@@ -1,0 +1,83 @@
+# The doc-diff harness gates on the oracle's own reproducibility
+
+Four defects in `scripts/doc-diff-harness.raku` that between them misdirected the
+whole doc-diff campaign. All four were measured on the 2026-09-07b full-corpus
+sweep.
+
+## `raku-drift-from-doc` was a priority signal derived from a provenance fact
+
+The harness cross-checked every mutsu-vs-raku divergence against the doc block's
+own `# OUTPUT:` annotation, and when raku no longer matched the doc it filed the
+finding in a separate bucket documented as "version skew, not mutsu bugs —
+lowest priority".
+
+But that branch is only reachable *once mutsu already differs from raku*.
+Whether the doc is stale says nothing about whether mutsu is wrong. Measured
+composition of the 114 blocks in that bucket: 67 real deterministic mutsu
+divergences, 33 whose entire diff was an unreproducible token, 9 environment-only,
+and 5 — 4% — that the bucket's name actually described.
+
+The bucket is gone. Every divergence is one `output-mismatch` finding, and the
+doc comparison survives as an annotation on it ("mutsu matches the doc's own
+`# OUTPUT:` here; raku does not"), which is what the fact actually supports.
+
+## The oracle was never checked against itself
+
+37% of those blocks (42 of 114) were there only because the doc froze a token
+that **raku itself cannot reproduce twice**: unordered-container iteration order
+(27 blocks — `Set`/`Bag`/`Mix`/`*Hash`/`Map`/`Hash.kv`/enum `.keys`), object
+addresses and `WHICH` ids (13), a thread id, and one explicitly racy example.
+Such a block diverges on the unreproducible token alone, on every run, forever —
+so it lands in the low-priority bucket permanently. Nine real mutsu bugs hid
+there, [#7587](https://github.com/tokuhirom/mutsu/issues/7587) among them.
+
+The harness now runs the **oracle twice** and drops the block unless raku agrees
+with itself. That is the whole policy: one rule, no pattern list. It deliberately
+replaces growing the existing `nondeterministic()` heuristic, which already
+skipped `.WHERE` but not `.WHICH`, `now`/`time` but not `$*DISTRO`/`$*VM`/`dir` —
+enumerating every unordered-container spelling is exactly the brittle path to
+avoid. The count is reported as `skipped (oracle not reproducible)` beside
+match/mismatch/crash so the noise floor is visible rather than silent.
+
+## No cap on captured output
+
+A single example could bury a sweep. `Type/IO/Path.rakudoc:509` is a `sub MAIN`
+that recursively `.dir`-walks its working directory; it enumerated the whole repo
+including `.git/` and produced a **131 492-line, 8.4 MB** report.
+`Language/ipc.rakudoc:34` shells out and captured a 1.6 MB git log. The
+2026-09-07b sweep could only be committed after truncating 11 MB down to 412 KB
+**by hand**, which is what the refresh recipe told the reader to do.
+
+Each captured section is now cut to 40 lines with an explicit
+`... [truncated by doc-diff-harness: N more line(s) of M]` marker, so a truncated
+section is never mistaken for a whole output and the recipe is safe as written.
+
+## Sweeps wrote into the repository root
+
+Doc examples that `spurt`/`open` a relative path ran with the repo root as cwd,
+so the 2026-09-07b sweep left empty `bar` and `foo.txt` behind. Every block now
+runs inside a throwaway scratch directory, recreated empty before each run — also
+required by the double-oracle gate, since a block that merely *appends* to a file
+would otherwise look non-reproducible. (Making the runs chdir meant absolutising
+the `--mutsu` path, which is relative by default.)
+
+That change alone shrank the `Type/IO/Path.rakudoc` report from 8.4 MB to 427
+bytes: the recursive `.dir` walk now finds an empty directory instead of the repo.
+
+## Verified
+
+On `Type/{Bag,Set,Code}.rakudoc`, 4 blocks are dropped by the new gate — the
+`Set`/`Bag` iteration-order class the ticket named — and the remaining 24
+comparisons resolve to 21 match / 2 mismatch / 1 crash instead of being scattered
+into a low-priority bucket. A fixture with a 61-line divergent output truncates
+both sections at 40 lines with the marker. A sweep leaves the working tree clean.
+
+`docs/doc-diff-backlog.md`, `docs/qa-doc-diff-harness.md` and
+`docs/doc-diff-sweep/README.md` are updated: the backlog's "Always re-verify"
+guidance no longer tells the reader that drift findings are "not mutsu bugs", and
+the README no longer instructs a manual truncation pass. The dated 2026-09-07b
+corpus snapshots keep their original numbers as history, marked as recording the
+retired bucket. `scripts/doc-diff-sweep.sh` aggregates the new `nondet` key in
+place of `raku-drift`.
+
+Closes #7590.

--- a/scripts/doc-diff-harness.raku
+++ b/scripts/doc-diff-harness.raku
@@ -22,6 +22,15 @@ sub MAIN(
     Str  :$report  = 'tmp/doc-diff-report.txt',
     Bool :$verbose = False,
 ) {
+    # Every run below happens with its cwd set to a scratch directory, so a relative
+    # `--mutsu=` (the default `target/debug/mutsu`) would no longer resolve. Absolutize
+    # it here, once, against the cwd the user actually invoked the harness from.
+    my $mutsu-bin = $mutsu.IO.absolute;
+    unless $mutsu-bin.IO.e {
+        note "doc-diff-harness: mutsu binary not found at $mutsu-bin — build it first.";
+        exit 2;
+    }
+
     my @files = collect-files(@paths);
     note "Scanning { +@files } .rakudoc files ...";
 
@@ -35,11 +44,18 @@ sub MAIN(
     # Per-process scratch file so concurrent harness invocations (a parallel sweep
     # over many files) never clobber each other's program between the raku run and
     # the mutsu run — a shared path races and yields phantom "divergences".
-    my $prog-path = "tmp/ddh/prog-{$*PID}.raku";
+    # ABSOLUTE, because every run below executes with its cwd set to the scratch
+    # directory rather than the repo root.
+    my $prog-path = "tmp/ddh/prog-{$*PID}.raku".IO.absolute;
+    # A doc example that `spurt`s or `open`s a relative path writes into its cwd.
+    # Run every block inside a throwaway directory so a sweep cannot leave strays
+    # in the repository root (the 2026-09-07b sweep left `bar` and `foo.txt`).
+    my $scratch = "tmp/ddh/run-{$*PID}".IO.absolute;
 
     my %stat = skipped-marker => 0, skipped-nondet => 0,
+               skipped-oracle-nondet => 0,
                no-oracle => 0, match => 0, mismatch => 0,
-               mutsu-crash => 0, raku-drift => 0;
+               mutsu-crash => 0, matches-doc => 0;
     my @findings;
 
     my $i = 0;
@@ -60,14 +76,28 @@ sub MAIN(
         my $path = $prog-path;
         spurt $path, $program;
 
-        my $r = run-capture('raku', $path, $timeout);
+        my $r = run-capture('raku', $path, $timeout, $scratch);
         # Oracle gate: raku must run it cleanly and produce output.
         unless $r<exit> == 0 && $r<out>.chars > 0 && $r<err> !~~ /SORRY/ {
             %stat<no-oracle>++;
             next;
         }
 
-        my $m = run-capture($mutsu, $path, $timeout);
+        # Reproducibility gate: run the ORACLE twice and drop the block unless raku
+        # agrees with itself. This is the whole nondeterminism policy — one rule, no
+        # pattern list. It catches what no pattern list practically can: unordered
+        # container iteration (`Set`/`Bag`/`Mix`/`*Hash`/`Map`/`Hash.kv`/enum `.keys`),
+        # object addresses and `WHICH` ids, thread ids, `$*DISTRO`/`$*VM`/`dir` order.
+        # Those blocks used to be compared, diverge on the unreproducible token alone,
+        # and then get filed under the lowest-priority bucket forever — which is how
+        # nine real mutsu bugs stayed hidden (see #7587).
+        my $r2 = run-capture('raku', $path, $timeout, $scratch);
+        unless $r2<exit> == 0 && normalize($r2<out>) eq normalize($r<out>) {
+            %stat<skipped-oracle-nondet>++;
+            next;
+        }
+
+        my $m = run-capture($mutsu-bin, $path, $timeout, $scratch);
 
         if normalize($m<out>) eq normalize($r<out>) {
             %stat<match>++;
@@ -77,19 +107,21 @@ sub MAIN(
             @findings.push: finding(%b, $program, $r, $m, 'mutsu-error');
         }
         else {
-            # Cross-check against the doc's own `# OUTPUT:` annotation. When raku
-            # itself no longer matches the doc, this is version drift (raku changed
-            # since the doc was written) and mutsu may well match the doc — lower
-            # priority than a case where raku and the doc agree but mutsu is wrong.
+            # Every mutsu-vs-raku divergence is one finding: `output-mismatch`.
+            #
+            # The doc's own `# OUTPUT:` annotation used to select a SEPARATE, lower-
+            # priority `raku-drift-from-doc` bucket whenever raku no longer matched the
+            # doc. That read a *provenance* fact as a *priority* one: the branch is only
+            # reachable once mutsu already differs from raku, so it filed real
+            # divergences under "not mutsu bugs". Measured on the 2026-09-07b sweep, 67
+            # of its 114 blocks were real mutsu bugs against 5 that the name described.
+            # The comparison survives as an ANNOTATION on the finding.
             my $expected = doc-expected(%b<code>);
-            if $expected.defined && normalize($expected) ne normalize($r<out>) {
-                %stat<raku-drift>++;
-                @findings.push: finding(%b, $program, $r, $m, 'raku-drift-from-doc');
-            }
-            else {
-                %stat<mismatch>++;
-                @findings.push: finding(%b, $program, $r, $m, 'output-mismatch');
-            }
+            my $matches-doc = $expected.defined
+                              && normalize($expected) eq normalize($m<out>);
+            %stat<matches-doc>++ if $matches-doc;
+            %stat<mismatch>++;
+            @findings.push: finding(%b, $program, $r, $m, 'output-mismatch', $matches-doc);
         }
 
         if $verbose && $i %% 50 {
@@ -98,6 +130,7 @@ sub MAIN(
     }
 
     unlink $prog-path if $prog-path.IO.e;
+    rm-rf($scratch);
     write-report($report, %stat, @findings);
     print-summary(%stat, @findings, $report);
 }
@@ -251,11 +284,34 @@ sub doc-expected(Str $code) {
 }
 
 #| Run a program through `timeout N bin file`, returning { out, err, exit }.
-sub run-capture(Str $bin, Str $file, Int $timeout) {
-    my $proc = run 'timeout', "$timeout", $bin, $file, :out, :err;
+#|
+#| `$cwd` is a scratch directory, recreated empty before every run: a doc example
+#| that writes a relative path must not touch the repo, and the two oracle runs of
+#| the reproducibility gate must each start from the same (empty) state, or a block
+#| that merely appends to a file would look non-reproducible.
+sub run-capture(Str $bin, Str $file, Int $timeout, Str $cwd) {
+    rm-rf($cwd);
+    mkdir $cwd;
+    my $proc = run 'timeout', "$timeout", $bin, $file, :out, :err, :$cwd;
     my $out = $proc.out.slurp(:close);
     my $err = $proc.err.slurp(:close);
     { out => $out, err => $err, exit => $proc.exitcode };
+}
+
+#| Recursively delete `$dir` if it exists. Confined to the harness's own scratch
+#| tree by its callers; there is no core `rmtree`.
+sub rm-rf(Str $dir) {
+    my $io = $dir.IO;
+    return unless $io.e;
+    if $io.d {
+        for $io.dir -> $e {
+            $e.d ?? rm-rf($e.absolute) !! unlink($e);
+        }
+        rmdir $io;
+    }
+    else {
+        unlink $io;
+    }
 }
 
 #| Normalize output for comparison: strip trailing whitespace on each line and overall.
@@ -263,7 +319,7 @@ sub normalize(Str $s) {
     $s.lines.map(*.trim-trailing).join("\n").trim-trailing;
 }
 
-sub finding(%b, Str $program, %raku, %mutsu, Str $kind) {
+sub finding(%b, Str $program, %raku, %mutsu, Str $kind, Bool $matches-doc = False) {
     {
         kind     => $kind,
         file     => %b<file>,
@@ -273,7 +329,33 @@ sub finding(%b, Str $program, %raku, %mutsu, Str $kind) {
         mutsu-out => %mutsu<out>,
         mutsu-err => %mutsu<err>,
         mutsu-exit => %mutsu<exit>,
+        matches-doc => $matches-doc,
     };
+}
+
+#| Lines kept per captured section in the report.
+#|
+#| Without a cap a single example can bury the sweep: `Type/IO/Path.rakudoc:509` is a
+#| `sub MAIN` that recursively `.dir`-walks its working directory and produced a
+#| 131_492-line, 8.4 MB report, and `Language/ipc.rakudoc:34` shells out and captured
+#| a 1.6 MB git log. The 2026-09-07b sweep could only be committed after truncating
+#| 11 MB down to 412 KB BY HAND, which is what the refresh recipe in
+#| `docs/doc-diff-sweep/README.md` told the reader to do. Capping here makes that
+#| recipe safe as written.
+constant SECTION-CAP = 40;
+
+#| Emit `$text` under `$label`, keeping at most SECTION-CAP lines and marking the cut
+#| explicitly so a truncated section is never mistaken for the whole output.
+sub say-capped($fh, Str $label, Str $text) {
+    $fh.say: $label;
+    my @lines = $text.trim-trailing.lines;
+    if @lines > SECTION-CAP {
+        $fh.say: @lines.head(SECTION-CAP).join("\n");
+        $fh.say: "... [truncated by doc-diff-harness: { @lines - SECTION-CAP } more line(s) of { +@lines }]";
+    }
+    else {
+        $fh.say: @lines.join("\n");
+    }
 }
 
 sub write-report(Str $report, %stat, @findings) {
@@ -284,12 +366,12 @@ sub write-report(Str $report, %stat, @findings) {
     for @findings.kv -> $idx, %f {
         $fh.say: "=" x 78;
         $fh.say: "[{ $idx + 1 }] { %f<kind> }  { %f<file> }:{ %f<line> }";
-        $fh.say: "--- program ---";
-        $fh.say: %f<program>;
-        $fh.say: "--- raku stdout ---";
-        $fh.say: %f<raku-out>.trim-trailing;
-        $fh.say: "--- mutsu stdout (exit { %f<mutsu-exit> }) ---";
-        $fh.say: %f<mutsu-out>.trim-trailing;
+        # Provenance, not priority: this used to select a separate low-priority bucket.
+        $fh.say: "note: mutsu matches the doc's own `# OUTPUT:` here; raku does not."
+            if %f<matches-doc>;
+        say-capped($fh, "--- program ---", %f<program>);
+        say-capped($fh, "--- raku stdout ---", %f<raku-out>);
+        say-capped($fh, "--- mutsu stdout (exit { %f<mutsu-exit> }) ---", %f<mutsu-out>);
         if %f<kind> eq 'mutsu-error' && %f<mutsu-err>.trim ne '' {
             $fh.say: "--- mutsu stderr ---";
             $fh.say: %f<mutsu-err>.trim-trailing.lines.head(6).join("\n");
@@ -304,14 +386,15 @@ sub print-summary(%stat, @findings, Str $report) {
     say "";
     say "==== doc-diff-harness summary ====";
     say "  skipped (marker):        %stat<skipped-marker>";
-    say "  skipped (nondet):        %stat<skipped-nondet>";
+    say "  skipped (nondet pattern): %stat<skipped-nondet>";
+    say "  skipped (oracle not reproducible): %stat<skipped-oracle-nondet>   (raku disagreed with itself — the noise floor)";
     say "  no oracle (raku unclean): %stat<no-oracle>";
     say "  ------------------------------------";
     say "  compared (raku-clean):   $compared";
     say "    match:                 %stat<match>";
     say "    output mismatch (★real): %stat<mismatch>";
     say "    mutsu error/crash (★real): %stat<mutsu-crash>";
-    say "    raku drifted from doc:  %stat<raku-drift>   (lower priority — raku changed since doc)";
+    say "      of which mutsu matches the doc: %stat<matches-doc>   (annotation only — still a real divergence)";
     if $compared > 0 {
         my $real = %stat<mismatch> + %stat<mutsu-crash>;
         my $rate = (100 * $real / $compared).round(0.1);

--- a/scripts/doc-diff-sweep.sh
+++ b/scripts/doc-diff-sweep.sh
@@ -25,8 +25,14 @@
 #                                         (mismatch + crash), high-signal first
 #
 # Re-verify each finding directly before treating it as a real bug — the oracle
-# gate keeps the report honest, but doc examples drift and some divergences are
-# raku-version drift (bucketed separately as `raku-drift-from-doc`).
+# gate keeps the report honest, but the harness can only compare what a doc block
+# actually prints.
+#
+# `nondet` counts blocks dropped because the ORACLE disagreed with itself across two
+# runs (unordered-container order, addresses, thread ids). It is the noise floor, not
+# a finding. There is no longer a `raku-drift-from-doc` bucket: whether raku still
+# matches the doc's own `# OUTPUT:` is provenance, not priority, and is reported as an
+# annotation on the finding instead.
 set -u
 
 JOBS=8
@@ -74,19 +80,19 @@ xargs -P "$JOBS" -I{} bash -c 'run_one "$@"' _ {} < "$FILELIST" \
 awk '
   / :: / {
     idx = index($0, " :: "); file = substr($0, 1, idx - 1)
-    m = 0; mm = 0; cr = 0; dr = 0
+    m = 0; mm = 0; cr = 0; nd = 0
     nn = split(substr($0, idx), T, " ")
     for (k = 1; k <= nn; k++) {
       if      (T[k] ~ /^match=/)        { s = T[k]; sub(/^match=/, "", s);        m  = s + 0 }
       else if (T[k] ~ /^mismatch=/)     { s = T[k]; sub(/^mismatch=/, "", s);     mm = s + 0 }
       else if (T[k] ~ /^mutsu-crash=/)  { s = T[k]; sub(/^mutsu-crash=/, "", s);  cr = s + 0 }
-      else if (T[k] ~ /^raku-drift=/)   { s = T[k]; sub(/^raku-drift=/, "", s);   dr = s + 0 }
+      else if (T[k] ~ /^skipped-oracle-nondet=/) { s = T[k]; sub(/^skipped-oracle-nondet=/, "", s); nd = s + 0 }
     }
-    tm += m; tmm += mm; tcr += cr; tdr += dr
+    tm += m; tmm += mm; tcr += cr; tnd += nd
     sig = mm + cr
-    if (sig > 0) printf "%4d  mism=%-3d crash=%-3d drift=%-3d  %s\n", sig, mm, cr, dr, file
+    if (sig > 0) printf "%4d  mism=%-3d crash=%-3d nondet=%-3d  %s\n", sig, mm, cr, nd, file
   }
-  END { printf "\n==== corpus totals ====\nmatch=%d  mismatch=%d  crash=%d  raku-drift=%d\n", tm, tmm, tcr, tdr }
+  END { printf "\n==== corpus totals ====\nmatch=%d  mismatch=%d  crash=%d  oracle-nondet=%d\n", tm, tmm, tcr, tnd }
 ' "$OUTDIR/progress.txt" | sort -rn > "$OUTDIR/summary.txt"
 
 echo "SWEEP-DONE" >> "$OUTDIR/progress.txt"


### PR DESCRIPTION
Four defects in `scripts/doc-diff-harness.raku` that between them misdirected the doc-diff campaign. All four were measured on the 2026-09-07b full-corpus sweep.

## 1. `raku-drift-from-doc` was a priority signal derived from a provenance fact

The harness cross-checked each divergence against the block's `# OUTPUT:` annotation and, when raku no longer matched the doc, filed it in a bucket documented as *"version skew, not mutsu bugs — lowest priority"*.

But that branch is **only reachable once mutsu already differs from raku**. Whether the doc is stale says nothing about whether mutsu is wrong. Measured composition of its 114 blocks:

| verdict | count | share |
|---|---|---|
| real deterministic mutsu divergence | 67 | 59% |
| nondeterministic token only | 33 | 29% |
| environment-only | 9 | 8% |
| **what the bucket name describes** | **5** | **4%** |

The bucket is gone. Every divergence is one `output-mismatch`; the doc comparison survives as an annotation on the finding.

## 2. The oracle was never checked against itself

37% of those blocks (42/114) were there only because the doc froze a token **raku itself cannot reproduce twice**: unordered-container iteration (27), addresses and `WHICH` ids (13), a thread id, one racy example. Such a block diverges on that token alone on *every* run, forever — so it sits in the low-priority bucket permanently. Nine real bugs hid there, #7587 among them.

The harness now runs the **oracle twice** and drops the block unless raku agrees with itself. One rule, no pattern list — deliberately instead of growing `nondeterministic()`, which already skipped `.WHERE` but not `.WHICH`, `now` but not `$*DISTRO`/`dir`. Reported as its own counter so the noise floor is visible rather than silent.

## 3. No cap on captured output

`Type/IO/Path.rakudoc:509` is a `sub MAIN` that recursively `.dir`-walks its cwd; it enumerated the repo including `.git/` and produced a **131 492-line, 8.4 MB** report. `Language/ipc.rakudoc:34` captured a 1.6 MB git log. The 2026-09-07b sweep was committable only after truncating 11 MB → 412 KB **by hand** — which is what the refresh recipe told the reader to do.

Sections are now cut to 40 lines with an explicit `... [truncated by doc-diff-harness: N more line(s) of M]` marker, so a truncated section is never mistaken for a whole output.

## 4. Sweeps wrote into the repository root

Doc examples that `spurt`/`open` a relative path ran with the repo root as cwd; the 2026-09-07b sweep left `bar` and `foo.txt` behind. Every block now runs in a scratch directory, recreated empty before each run — which the double-oracle gate needs anyway, since a block that merely *appends* to a file would otherwise look non-reproducible.

Making the runs chdir meant absolutising the `--mutsu` path (relative by default). That was caught here by a 23/23 crash rate that was too clean to be real.

## Verification

- On `Type/{Bag,Set,Code}.rakudoc`: 4 blocks dropped by the gate — the `Set`/`Bag` iteration-order class the ticket named — and the remaining 24 comparisons resolve to 21 match / 2 mismatch / 1 crash instead of scattering into a low-priority bucket.
- A fixture with 61 lines of divergent output truncates both sections at 40 with the marker. (The first fixture I wrote was itself dropped by the new gate, because printing a `Block` prints its address — a fair demonstration.)
- `Type/IO/Path.rakudoc` report: **8.4 MB → 427 bytes**.
- A sweep leaves `git status` clean.
- `cargo fmt --all`; `make lint` exit 0 (all four configurations); `make test` 3861 files / 40929 tests `Result: PASS`; `make roast` 1436 files / 218939 tests with only the three documented environment-only failures (`6.c/S32-io/file-tests.t` 6-8/10, `S16-filehandles/filetest.t` 57-64/…/125 from `uid 0`; `S32-io/IO-Socket-Async.t` exit 124 from the network sandbox).

A full 443-file corpus re-sweep is running; I will add its before/after noise-floor numbers as a comment. Committing a refreshed `docs/doc-diff-sweep/` is the campaign's own refresh step (per that directory's README) and is deliberately not bundled here.

## Docs

Updated so they no longer instruct the retired behaviour: the backlog's "Always re-verify" guidance (it told the reader drift findings are "not mutsu bugs"), the sweep README's manual-truncation step, and the harness method doc. The dated 2026-09-07b snapshots keep their original numbers as history, marked as recording the retired bucket. `doc-diff-sweep.sh` aggregates the new `nondet` key in place of `raku-drift`.

Closes #7590.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014zqc6o7emGLDGXUp8knhMy

---
_Generated by [Claude Code](https://claude.ai/code/session_014zqc6o7emGLDGXUp8knhMy)_