### PR TITLE
perf: keep the END-phaser refresh off every closure return

### DIFF
--- a/news/2026-09/end-phaser-refresh-taxed-every-closure-return.md
+++ b/news/2026-09/end-phaser-refresh-taxed-every-closure-return.md
@@ -1,0 +1,98 @@
+# The END-phaser refresh taxed every closure return, in proportion to the importing scope
+
+`use Test` — the vendored upstream module, `MUTSU_REAL_TEST=1` — made unrelated
+hot loops in the *importing* file 2.6x slower on a 4-core box: the loop of
+`t/rebound-return-hot-loop.t`, reduced to a file of its own, went from 7.5 s to
+19.5 s with nothing but `use Test;` prepended. Issue #7565 had already
+apportioned most of that between two known costs — work linear in the mainline
+env's size, and the process-global reflective latch that one `EVAL` anywhere
+sets forever — and noted that the two together predicted about two thirds of
+what was measured. Finding the rest was the first job.
+
+## The third term
+
+It is a block at the end of `call_compiled_closure`, which runs on **every
+closure return** once any `END` phaser is registered:
+
+```rust
+if self.has_end_phasers() && !data.env.is_empty() {
+    let captured_strs: Vec<String> = data.env.keys().map(|s| s.resolve()).collect();
+    let captured_names: HashSet<&str> = captured_strs.iter().map(|s| s.as_str()).collect();
+    let current = self.clone_env();
+    self.update_end_phaser_envs_for_keys(&captured_names, &current);
+}
+```
+
+`data.env` is the calling closure's captured env, and its width is set by the
+scope the closure was *created* in, not by the closure: importing a module with
+a wide export list widens every capture made in the importing scope, and the
+reflective latch widens it further to a whole-env snapshot. So the loop below
+walked a few hundred names per closure call, resolving each interned `Symbol`
+back to a fresh `String` and then re-interning it three times over — once for
+`dead_keys`, once for the phaser's captured env, once for the live env — on top
+of an `Env::flattened()` of the whole live env for the `current` argument.
+
+Upstream `Test.rakumod` registers an `END` (its final plan check) and its
+`throws-like` contains an `EVAL`, so a bare `use Test` arms all three
+conditions at once. A callgrind diff of the reduced program at 150 and 450
+iterations put this one block at **30% of the entire per-iteration cost**, with
+`Symbol::intern` — almost all of it from here — at another 21%.
+
+That is why the three costs did not add up: they *multiply*. Measured on the
+same box, debug build, medians of three, over a 20 000-iteration loop:
+
+| variant | before | after |
+| --- | --- | --- |
+| the loop alone | 7.7 s | 7.5 s |
+| `+ END { }` | 9.3 s | 7.5 s |
+| `+ 60 mainline `our`s` | 10.9 s | 10.8 s |
+| `+ 60 `our`s + END { }` | 13.6 s | 10.8 s |
+| `+ 60 `our`s + EVAL + END { }` | 16.1 s | 11.7 s |
+| `+ use Test` (vendored) | 19.5 s | 14.6 s |
+
+## What changed
+
+`update_end_phaser_envs_for_keys` now takes the captured `Env` itself and works
+in interned-`Symbol` space throughout — no `String` is allocated and no name is
+re-interned. The membership questions it asks are unchanged, key for key: the
+phaser side stays the chain-walking `contains_key_sym` it always used, and the
+captured side stays that env's own overlay keys.
+
+Its call site asks a new `end_phasers_watch_any` first. The update is a no-op
+unless some phaser captured one of these names, so asking is what keeps the
+`clone_env()` flatten — `O(env)` for a scoped frame — off every closure return
+in a program that merely declares an `END`. The guard is the loop body's own
+precondition minus one lookup, so it can never skip work the loop would have
+done.
+
+The same closure-call path asked three string questions about every captured
+name: whether it is a dynamic variable (a leading-sigil scan), whether it is
+`self`, and whether it is `$_`/`$!`. The first now reads a memoized
+`Symbol` flag bit, `DYNAMIC_VAR_ENV_KEY`, alongside the ones the capture filter
+already uses; the other two are `Symbol` equality against the well-known
+symbols. The predicate the new bit memoizes is lifted verbatim into
+`env::is_dynamic_var_env_key`, deliberately *not* reusing the neighbouring
+`is_dynamic_var_name`: that one strips at most one `@`/`%`/`&` and so answers
+`false` for `$*OUT`, which the built-in dynamics are seeded under. On the
+`EVAL`-latched 240-name variant this alone is a 8.8% instruction-count
+reduction.
+
+## What is left, and one finding worth recording
+
+The remaining 14.6 s against a 7.5 s floor is the two costs #7565 already named,
+and both are now the whole of it. Under the latch the per-closure-*call* capture
+merge re-inserts every captured name into the callee's overlay
+(`Env::insert_sym` is 25% of the reduced program); with the latch off, closure
+*creation* pays `Env::filtered_flat`, which walks every visible key to keep
+about twenty-three (26% of the no-latch variant). Neither is `Test`-specific and
+neither is addressed here.
+
+Recorded for whoever picks those up: the whole `t/` suite (3860 files, 40903
+tests) passes with this refresh removed outright, not merely made cheap. It is
+kept because it is not provably dead — the exit-time overlay in
+`Interpreter::run` prefers the *live* env value for every non-frozen captured
+key, which is what makes the refresh unobservable in all of those tests, but it
+does fall back to the captured value for a key that is missing from the exit env
+entirely. `t/end-phaser-wide-capture-refresh.t` pins the END semantics that hold
+under exactly the conditions that widen a capture, so the capture work still
+outstanding cannot quietly change them.

--- a/src/env.rs
+++ b/src/env.rs
@@ -213,6 +213,23 @@ pub(crate) fn is_dynamic_var_name(name: &str) -> bool {
     decider == Some(b'*')
 }
 
+/// Whether `key` — an *env key*, not a source-level variable name — names a
+/// dynamic variable: `*x`, `$*OUT`, `@*ARGS`, `%*ENV`, `&*foo`.
+///
+/// Deliberately distinct from [`is_dynamic_var_name`], which strips at most one
+/// `@`/`%`/`&` and so answers `false` for a key that kept its `$` sigil. Env
+/// keys are *mostly* stored sigil-less for scalars, but not always — the
+/// built-in dynamics are seeded under their full spelling (`$*OUT`,
+/// `$*ERR`, …; see `Interpreter::init_io_environment_impl`), and the
+/// closure-capture merge must recognize exactly those. This predicate is the
+/// one that merge has always used, lifted out of it verbatim so the memoized
+/// [`crate::symbol::flags::DYNAMIC_VAR_ENV_KEY`] bit cannot drift from it.
+#[inline]
+pub(crate) fn is_dynamic_var_env_key(key: &str) -> bool {
+    key.trim_start_matches(['$', '@', '%', '&'])
+        .starts_with('*')
+}
+
 /// Monotonic, process-global flag: set the first time any closure-writeback
 /// metadata key is inserted into *any* env. These keys --
 /// `__mutsu_sigilless_readonly::*`, `__mutsu_sigilless_alias::*`,

--- a/src/runtime/end_phasers.rs
+++ b/src/runtime/end_phasers.rs
@@ -265,12 +265,31 @@ impl Interpreter {
         }
     }
 
-    /// Update captured envs of ALL END phasers, but only for the specified
-    /// variable names.  Used after closure calls to propagate changes to
+    /// True when at least one key of `captured` names a live (non-frozen) entry
+    /// of some END phaser's captured env — i.e. when
+    /// [`Self::update_end_phaser_envs_for_keys`] has anything at all to do.
+    ///
+    /// This is the cheap half of that update: it asks the same two membership
+    /// questions but skips the third lookup and, crucially, lets the caller
+    /// skip flattening the live env (`clone_env`, O(env) for a scoped frame)
+    /// when the answer is no. A closure whose capture shares no name with any
+    /// phaser — the overwhelmingly common case, and every case at all once a
+    /// module with a wide export list has widened the capture — then costs two
+    /// integer-keyed lookups per captured name instead of a whole-env flatten.
+    pub(crate) fn end_phasers_watch_any(&self, captured: &Env) -> bool {
+        self.end_phasers.iter().any(|phaser| {
+            captured
+                .keys()
+                .any(|k| !phaser.dead_keys.contains(k) && phaser.env.contains_key_sym(*k))
+        })
+    }
+
+    /// Update captured envs of ALL END phasers, but only for the names
+    /// `captured` holds.  Used after closure calls to propagate changes to
     /// captured variables without overwriting unrelated variables.
     ///
-    /// `keys` names the *calling closure's* own captured free variables, which
-    /// only coincidentally share a name with a phaser's captured entry — they
+    /// `captured` is the *calling closure's* own captured env, whose names only
+    /// coincidentally share a name with a phaser's captured entry — they
     /// are not necessarily the same binding (a same-named `my` in a sibling
     /// scope is a common case: `{ my $a = 42; END { say $a } }; my $a = 0;
     /// callit { $a }` calls a closure that captured the SECOND `$a`, which must
@@ -279,21 +298,27 @@ impl Interpreter {
     /// see `update_end_phaser_envs`) is the phaser's authoritative surviving
     /// binding for that name and must never be overwritten by an unrelated
     /// same-named capture from elsewhere.
-    pub(crate) fn update_end_phaser_envs_for_keys(
-        &mut self,
-        keys: &std::collections::HashSet<&str>,
-        current_env: &Env,
-    ) {
+    ///
+    /// The names are taken as interned [`Symbol`]s straight off `captured`'s
+    /// own overlay, never resolved back to strings. This runs on EVERY closure
+    /// return once any END phaser exists, over a capture whose width is set by
+    /// the *creating scope* rather than by the closure — so a program that
+    /// `use`s a module with a wide export list, or one the reflective latch has
+    /// widened to a whole-env snapshot, walks hundreds of names here per call.
+    /// Resolving each to a `String` and re-interning it three times over
+    /// (`dead_keys`, the phaser env, the live env) made this ~30% of the hot
+    /// loop of a program that merely had `use Test` at the top (#7565).
+    pub(crate) fn update_end_phaser_envs_for_keys(&mut self, captured: &Env, current_env: &Env) {
         for phaser in self.end_phasers.iter_mut() {
-            let captured = &mut phaser.env;
-            for k in keys {
-                if phaser.dead_keys.contains(&Symbol::intern(k)) {
+            for k in captured.keys() {
+                if phaser.dead_keys.contains(k) {
                     continue;
                 }
-                if captured.contains_key(k)
-                    && let Some(v) = current_env.get(k)
+                if phaser.env.contains_key_sym(*k)
+                    && let Some(v) = current_env.get_sym(*k)
                 {
-                    captured.insert(k.to_string(), v.clone());
+                    let v = v.clone();
+                    phaser.env.insert_sym(*k, v);
                 }
             }
         }

--- a/src/symbol.rs
+++ b/src/symbol.rs
@@ -177,6 +177,17 @@ pub(crate) mod flags {
     /// them into the memoized byte makes the filter one thread-local lookup
     /// instead of two plus two string scans.
     pub(crate) const ATTR_TWIGIL_ENV_KEY: u8 = 1 << 5;
+    /// A *dynamic* variable's env key (`*x`, `$*OUT`, `@*ARGS`, `%*ENV`).
+    /// Mirrors `crate::env::is_dynamic_var_env_key`.
+    ///
+    /// The closure-call capture merge asks this about every entry of the
+    /// captured env, and asked it by resolving the symbol and scanning its
+    /// leading sigils. That capture is as wide as the *creating* scope — a
+    /// program that `use`s a module with a broad export list, or one the
+    /// reflective latch has widened to a whole-env snapshot, walks hundreds of
+    /// keys here per closure call, which put this one scan at ~11% of the whole
+    /// program (#7565).
+    pub(crate) const DYNAMIC_VAR_ENV_KEY: u8 = 1 << 6;
     /// Set once the byte has been computed (so a symbol with no flags is not
     /// recomputed on every lookup).
     pub(crate) const COMPUTED: u8 = 1 << 7;
@@ -208,6 +219,9 @@ fn compute_flags(s: &str) -> u8 {
     }
     if crate::env::is_attr_twigil_env_key(s) {
         f |= flags::ATTR_TWIGIL_ENV_KEY;
+    }
+    if crate::env::is_dynamic_var_env_key(s) {
+        f |= flags::DYNAMIC_VAR_ENV_KEY;
     }
     f
 }
@@ -444,6 +458,12 @@ impl Symbol {
     #[inline]
     pub(crate) fn is_attr_twigil_env_key(self) -> bool {
         self.flags() & flags::ATTR_TWIGIL_ENV_KEY != 0
+    }
+
+    /// Memoized [`crate::env::is_dynamic_var_env_key`] for this symbol's string.
+    #[inline]
+    pub(crate) fn is_dynamic_var_env_key(self) -> bool {
+        self.flags() & flags::DYNAMIC_VAR_ENV_KEY != 0
     }
 
     /// Resolve the symbol back to its string representation.

--- a/src/vm/vm_closure_dispatch.rs
+++ b/src/vm/vm_closure_dispatch.rs
@@ -389,12 +389,12 @@ impl Interpreter {
                 // already excluded from `authoritative_free_vars` below for the same
                 // reason; do the same for the box-on-capture cell — don't overwrite,
                 // so the live dynamic binding stands.
-                if k.with_str(|s| s.trim_start_matches(['$', '@', '%', '&']).starts_with('*')) {
+                if k.is_dynamic_var_env_key() {
                     self.env_mut().entry_or_insert_sym(*k, v.clone());
                 } else {
                     self.env_mut().insert_sym(*k, v.clone());
                 }
-            } else if k.with_str(|s| s == "self") {
+            } else if *k == crate::symbol::wk::self_() {
                 // `self` is LEXICAL in Raku: a block has no invocant of its own, so
                 // a `self` inside it resolves outwards to the enclosing method's
                 // invocant — the one this closure captured. The don't-overwrite
@@ -409,7 +409,9 @@ impl Interpreter {
                 // A method's own invocant is bound from its args further below,
                 // after this merge, so it still wins over the captured value.
                 self.env_mut().insert_sym(*k, v.clone());
-            } else if !cc.is_routine && k.with_str(|s| s == "_" || s == "!") {
+            } else if !cc.is_routine
+                && (*k == crate::symbol::wk::topic() || *k == crate::symbol::wk::error_var())
+            {
                 // `$_` (the topic) and `$!` (the last error) are LEXICAL in a
                 // block: a block lexically captures them from its creation
                 // scope and must see those values when called from another
@@ -445,9 +447,9 @@ impl Interpreter {
         // for a closure captured under a scoped overlay. Resolve through the
         // tier-walking get and force-install (interpreter-path twin in
         // `call_sub_value`).
-        if let Some(captured_self) = data.env.get("self").cloned() {
+        if let Some(captured_self) = data.env.get_sym(crate::symbol::wk::self_()).cloned() {
             self.env_mut()
-                .insert_sym(crate::symbol::Symbol::intern("self"), captured_self);
+                .insert_sym(crate::symbol::wk::self_(), captured_self);
         }
         // A closure's free variables are lexically bound in its captured env, so an
         // *authoritative* capture must OVERWRITE whatever the caller env happens to
@@ -1740,14 +1742,16 @@ impl Interpreter {
         // ensures END phasers see the final values rather than stale copies.
         // Only update keys matching the closure's captured variable names to
         // avoid overwriting unrelated captured lexicals in other END phasers.
-        if self.has_end_phasers() && !data.env.is_empty() {
-            let captured_strs: Vec<String> = data.env.keys().map(|s| s.resolve()).collect();
-            let captured_names: std::collections::HashSet<&str> =
-                captured_strs.iter().map(|s| s.as_str()).collect();
+        // `end_phasers_watch_any` is the guard, not an optimization detail: the
+        // update itself is a no-op unless some phaser captured one of these
+        // names, and asking first is what keeps the `clone_env()` flatten below
+        // off every closure return in a program that merely declares an `END`
+        // (#7565).
+        if self.has_end_phasers() && !data.env.is_empty() && self.end_phasers_watch_any(&data.env) {
             // Flatten: END phasers run at program exit with this captured env;
             // it must hold the full lexical view, not a transient scoped overlay.
             let current = self.clone_env();
-            self.update_end_phaser_envs_for_keys(&captured_names, &current);
+            self.update_end_phaser_envs_for_keys(&data.env, &current);
         }
 
         let return_spec = data

--- a/t/end-phaser-wide-capture-refresh.t
+++ b/t/end-phaser-wide-capture-refresh.t
@@ -1,0 +1,115 @@
+use v6;
+use Test;
+
+# The post-closure-call END-phaser refresh (`update_end_phaser_envs_for_keys`)
+# walks the calling closure's captured env and copies the live value of every
+# name that some phaser also captured. Two things decide how much env it walks,
+# and neither is under the closure's control:
+#
+#   * how many names the *creating* scope holds -- a `use` of a module with a
+#     wide export list widens every capture made in the importing scope; and
+#   * whether the process has latched `reflective_name_access_possible()`, which
+#     makes `capture_closure_env` snapshot the WHOLE visible env instead of the
+#     closure's own free variables. One `EVAL` anywhere latches it for good.
+#
+# That refresh used to resolve every one of those names back to a `String` and
+# re-intern it three times over (`dead_keys`, the phaser env, the live env),
+# which made it ~30% of the hot loop of a program whose only sin was `use Test`
+# at the top (#7565). It now works in interned-`Symbol` space and asks first
+# whether any phaser watches any of the names at all, so a capture that shares
+# no name with any phaser skips the whole-env flatten too.
+#
+# This file pins the SEMANTICS that rewrite has to preserve under exactly the
+# conditions that widen the capture: the refresh must still happen for a name a
+# phaser really captured, and must still not happen for anything else.
+
+plan 8;
+
+my $dir = $*TMPDIR.child("mutsu-end-wide-{$*PID}");
+$dir.mkdir;
+END { try { .unlink for $dir.dir; $dir.rmdir } }
+
+sub run-snippet($name, $source) {
+    my $file = $dir.child($name);
+    $file.spurt($source);
+    my $proc = run($*EXECUTABLE, $file.absolute, :out, :err);
+    my $out = $proc.out.slurp(:close);
+    $proc.err.slurp(:close);
+    $out.trim
+}
+
+# A prelude that forces both widening conditions at once: sixty extra mainline
+# names for the capture to carry, and an `EVAL` to latch the whole-env snapshot.
+my $wide = "use MONKEY-SEE-NO-EVAL;\nmy \$latch = EVAL '1';\n"
+    ~ (1..60).map({ "our \$pad$_ = $_;\n" }).join;
+
+# 1. The propagation the refresh exists for still happens when the capture has
+#    been widened to a whole-env snapshot.
+is run-snippet('wide-same.raku', $wide ~ 'my $x = 1;
+END { say "x=", $x }
+my $c = { $x = 2 };
+$c();
+'), 'x=2',
+    'a closure mutating the binding an END captured propagates under a wide capture';
+
+# 2. Same, called through another sub rather than invoked directly -- the shape
+#    that reaches the closure-call refresh rather than a direct frame return.
+is run-snippet('wide-called.raku', $wide ~ 'sub callit(&c) { c() }
+my $x = 1;
+END { say "x=", $x }
+callit { $x = 9 };
+'), 'x=9',
+    'the same propagation through an intermediate sub call';
+
+# 3. The dead-scope binding still wins: a widened capture drags in every
+#    mainline name, so the `dead_keys` guard is doing more work than ever.
+is run-snippet('wide-dead.raku', $wide ~ 'sub callit(&c) { c() }
+{ my $a = 42; END { say "a=", $a }; }
+my $a = 0;
+callit { $a };
+'), 'a=42',
+    'a dead-scope END binding survives a same-named widened capture';
+
+# 4. Two dead-scope phasers sharing a name each keep their own value.
+is run-snippet('wide-two-dead.raku', $wide ~ 'sub callit(&c) { c() }
+{ my $a = 1; END { say "first a=$a" }; }
+{ my $a = 2; END { say "second a=$a" }; }
+my $a = 0;
+callit { $a };
+').lines.sort.join('|'), 'first a=1|second a=2',
+    'two same-named dead-scope phasers keep their own bindings under a wide capture';
+
+# 5. The widened names themselves are not phaser business: a phaser that
+#    captured none of them must be unaffected by a closure call that carries
+#    all sixty.
+is run-snippet('wide-untouched.raku', $wide ~ 'my $only = 5;
+END { say "only=", $only }
+my $c = { $pad7 };
+$c();
+'), 'only=5',
+    'a closure carrying sixty unrelated names leaves an unrelated phaser alone';
+
+# 6. A mainline `our` the phaser DID capture must still refresh -- the widened
+#    names are ordinary lexicals, not exempt from the propagation.
+is run-snippet('wide-our.raku', $wide ~ 'END { say "pad3=", $pad3 }
+my $c = { $pad3 = 99 };
+$c();
+'), 'pad3=99',
+    'a widened name an END captured still refreshes when a closure mutates it';
+
+# 7. No phaser at all: the guard must not change what a closure call does.
+is run-snippet('wide-nophaser.raku', $wide ~ 'my $x = 1;
+my $c = { $x = 3 };
+$c();
+say "x=", $x;
+'), 'x=3',
+    'a closure call with no END phaser registered behaves unchanged';
+
+# 8. The latch alone (no extra names) still refreshes -- the whole-env snapshot
+#    path is the one that carries the phaser name in a parent tier.
+is run-snippet('latch-only.raku', "use MONKEY-SEE-NO-EVAL;\nmy \$latch = EVAL '1';\n" ~ 'my $x = 1;
+END { say "x=", $x }
+sub callit(&c) { c() }
+callit { $x = 4 };
+'), 'x=4',
+    'the reflective whole-env capture path still refreshes the phaser';


### PR DESCRIPTION
The third, unaccounted-for term of #7565.

`use Test` (the vendored upstream module, `MUTSU_REAL_TEST=1`) made unrelated hot loops in the *importing* file 2.6x slower — the loop of `t/rebound-return-hot-loop.t`, reduced to a file of its own, went from 7.5 s to 19.5 s with nothing but `use Test;` prepended. #7565 apportioned most of that between two known costs (work linear in the mainline env's size, and the process-global reflective latch) and noted that the two together predicted only about two thirds of what was measured. Finding the rest was its stated first job.

## The third term

It is the block at the end of `call_compiled_closure` that refreshes END phasers' captured envs, which runs on **every closure return** once any `END` phaser is registered:

```rust
let captured_strs: Vec<String> = data.env.keys().map(|s| s.resolve()).collect();
let captured_names: HashSet<&str> = captured_strs.iter().map(|s| s.as_str()).collect();
let current = self.clone_env();
self.update_end_phaser_envs_for_keys(&captured_names, &current);
```

`data.env` is the calling closure's captured env, and its width is set by the scope the closure was *created* in, not by the closure. Importing a module with a wide export list widens every capture made in the importing scope; the reflective latch widens it further to a whole-env snapshot. So this walked a few hundred names per closure call, resolving each interned `Symbol` back to a fresh `String` and re-interning it three times over (`dead_keys`, the phaser env, the live env), on top of an `Env::flattened()` of the whole live env.

Upstream `Test.rakumod` registers an `END` (its final plan check) and its `throws-like` contains an `EVAL`, so a bare `use Test` arms all three conditions at once. A callgrind diff of the reduced program at 150 and 450 iterations put this one block at **30% of the entire per-iteration cost**, with `Symbol::intern` — almost all of it from here — at another 21%.

That is why the costs did not add up: they *multiply*.

## What changed

- `update_end_phaser_envs_for_keys` takes the captured `Env` itself and works in interned-`Symbol` space throughout. The membership questions are unchanged key for key: the phaser side keeps the chain-walking `contains_key_sym` it always used, the captured side keeps that env's own overlay keys.
- Its call site asks a new `end_phasers_watch_any` first. The update is a no-op unless some phaser captured one of these names, and asking is what keeps the `clone_env()` flatten — `O(env)` for a scoped frame — off every closure return in a program that merely declares an `END`. The guard is the loop body's own precondition minus one lookup, so it can never skip work the loop would have done.
- The same closure-call path asked three string questions about every captured name. Whether it is a dynamic variable now reads a memoized `Symbol` flag bit, `DYNAMIC_VAR_ENV_KEY`, alongside the ones the capture filter already uses; `self` and `$_`/`$!` are `Symbol` equality against the well-known symbols. The predicate the new bit memoizes is lifted verbatim into `env::is_dynamic_var_env_key`, deliberately *not* reusing the neighbouring `is_dynamic_var_name`: that one strips at most one `@`/`%`/`&` and so answers `false` for `$*OUT`, which the built-in dynamics are seeded under. On the `EVAL`-latched 240-name variant this is a further 8.8% instruction-count reduction.

## Numbers

4-core box, debug build, medians of three, 20 000-iteration loop. Local wall-clock, adequate for ranking the variants against each other — not a document figure, which per CLAUDE.md must come from the bench CI.

| variant | before | after |
| --- | --- | --- |
| the loop alone | 7.7 s | 7.5 s |
| `+ END { }` | 9.3 s | 7.5 s |
| `+ 60 mainline `our`s` | 10.9 s | 10.8 s |
| `+ 60 `our`s + END { }` | 13.6 s | 10.8 s |
| `+ 60 `our`s + EVAL + END { }` | 16.1 s | 11.7 s |
| `+ use Test` (vendored) | 19.5 s | **14.6 s** |

## What this does not fix

The remaining 14.6 s against a 7.5 s floor is the two costs #7565 already named, and they are now the whole of it. Under the latch the per-closure-*call* capture merge re-inserts every captured name into the callee's overlay (`Env::insert_sym` is 25% of the reduced program); with the latch off, closure *creation* pays `Env::filtered_flat`, which walks every visible key to keep about twenty-three (26% of the no-latch variant). Both are architectural (the per-compunit reflective determination, and a capture that does not walk the whole env) and belong in their own PRs, so #7565 stays **open** rather than being closed here — the tax is reduced, not eliminated. What is left maps onto #7563.

## One finding worth recording

The whole `t/` suite (3860 files, 40903 tests) passes with this refresh removed *outright*, not merely made cheap. It is kept because it is not provably dead: the exit-time overlay in `Interpreter::run` prefers the *live* env value for every non-frozen captured key, which is what makes the refresh unobservable in all of those tests, but it does fall back to the captured value for a key that is missing from the exit env entirely. This is written up in the news entry for whoever takes the remaining terms.

## Tests

New `t/end-phaser-wide-capture-refresh.t` (8 assertions) pins the END semantics under exactly the conditions that widen a capture — sixty extra mainline names plus an `EVAL` to latch the whole-env snapshot — so the capture work still outstanding cannot quietly change them. The existing `t/end-phaser-same-name-different-binding.t` and `t/end-phaser-live-lexical.t` already cover the rewritten function's positive and negative controls.

## Verification

Run locally before publishing, per CLAUDE.md:

- `cargo fmt --all` — clean
- `make lint` — all four configurations clean (default clippy, `jit` off, wasm32 lib, rustdoc)
- `make test` — **PASS**, `Files=3860, Tests=40903`
- `make roast` — `Files=1436, Tests=218939`; the only failures are the three container-only files [docs/agent-environments.md](https://github.com/tokuhirom/mutsu/blob/main/docs/agent-environments.md) licenses, at exactly their documented shapes (`6.c/S32-io/file-tests.t` Failed 4 / tests 6-8,10 and `S16-filehandles/filetest.t` Failed 25 — both `uid 0`, confirmed with `id -u`; `S32-io/IO-Socket-Async.t` exit 124 "planned 40 ran 17" — sandboxed network). Nothing else is red.

Refs #7565

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M8chErSe1DTyRyiW4b6KZT

---
_Generated by [Claude Code](https://claude.ai/code/session_01M8chErSe1DTyRyiW4b6KZT)_