### PR TITLE
fix(vm): a one-element slice assignment yields a one-element list

### DIFF
--- a/news/2026-09/slice-assign-one-element-rvalue.md
+++ b/news/2026-09/slice-assign-one-element-rvalue.md
@@ -1,0 +1,53 @@
+# A one-element slice assignment yields a one-element list again
+
+A slice assignment's value is the list it stored, however short. mutsu
+collapsed a one-slot slice to its element:
+
+```
+$ ./target/debug/mutsu -e 'my @d; say (@d[0,] = 5).raku'   # was: 5
+$ raku               -e 'my @d; say (@d[0,] = 5).raku'     # (5,)
+```
+
+`.elems` agreed on both (1), and the *storage* was always right — only the
+shape of the assignment's own value was wrong. The controls are what made this
+narrow: a genuine single-index assignment yields the bare value on both
+(`(@d[0] = 5)` is `5`, `(%h<a> = 5)` is `5`). A one-element **slice**
+(`@d[0,]`, with the trailing comma) names a list of one slot, and that is the
+shape that diverged.
+
+## Root cause
+
+`idx_is_single_element` (`src/vm/vm_var_assign_index_named.rs`) was doing two
+different jobs. Its real job is answering "does this subscript name exactly one
+key" — which is what keeps an *itemized* index a single key rather than a slice
+(`my $s = $(1,2); %c{$s}` is one key, not two), and that job is load-bearing.
+It was also being reused to decide the **rvalue's shape**, and the two questions
+have different answers for a one-element list subscript: it names one key, but
+it is still a slice.
+
+## The fix
+
+A companion `idx_is_scalar_subscript`, computed from the same raw index, answers
+only the rvalue question: a non-itemized `Array`/`Seq`/`Slip` subscript is a
+list however short, everything else is a scalar index. `idx_is_single_element`
+is untouched, so the itemized-key logic keeps the answer it needs, and the
+slice arm's result now itemizes only when *both* hold.
+
+The slice's own arity decides the rvalue's length, not the RHS's, which falls
+out of using the values actually stored: `(@d[0,] = 5, 6)` is `(5,)` and `@d` is
+`[5]`, matching rakudo.
+
+`t/slice-assign-one-element-rvalue.t` pins it — including every control the
+ticket named — and passes under rakudo as well as mutsu.
+
+## Not fixed here
+
+The **Range** spelling of the same shape (`@d[0..0] = 5`) still yields a bare
+`5`. It has a different root cause: a Range subscript on a plain positional
+array is never expanded into an index list, so it never reaches the slice arm
+that builds the stored-value list, and the multi-element case only looks right
+because returning the raw RHS happens to match. Filed as
+[#7651](https://github.com/tokuhirom/mutsu/issues/7651) rather than widening
+this change.
+
+Closes [#7589](https://github.com/tokuhirom/mutsu/issues/7589).

--- a/src/vm/vm_var_assign_index_named.rs
+++ b/src/vm/vm_var_assign_index_named.rs
@@ -754,6 +754,20 @@ impl Interpreter {
             | ValueView::GenericRange { .. } => false,
             _ => true,
         };
+        // Whether the subscript is a single SCALAR index rather than a list of
+        // one. Both name one slot, so `idx_is_single_element` cannot tell them
+        // apart -- and it must not, because the itemized-key logic below
+        // depends on a one-element list answering "single". But raku does tell
+        // them apart for the assignment's VALUE: a slice yields the list it
+        // stored however short, so `(@a[0,] = 5)` is `(5,)` where
+        // `(@a[0] = 5)` is a bare `5`. The raw index carries the difference --
+        // `@a[0,]` arrives as a one-element non-itemized Array, `@a[0]` as a
+        // bare `Int` -- and only the rvalue shape consults it.
+        let idx_is_scalar_subscript = match idx.view() {
+            ValueView::Array(_, kind) => kind.is_itemized(),
+            ValueView::Seq(_) | ValueView::Slip(_) => false,
+            _ => true,
+        };
         // An *itemized* list/Range subscript is a SINGLE subscript, not a slice
         // — itemization makes it one item. A bare `@a[7,8,9] = …` stays a
         // slice. It reaches here as `ArrayKind::ItemList` or a `Scalar`-wrapped
@@ -1739,13 +1753,14 @@ impl Interpreter {
                     if bind_mode {
                         self.mark_bound_index(&var_name, encoded_idx);
                     }
-                    // A 1-element slice (`@a[0,]`) names a single scalar slot, so
-                    // its rvalue itemizes like a single-index assignment. A
-                    // nested-key assignment (`@a[1,(lazy 3,4,5)] = ...`) instead
-                    // returns the nested shape built while assigning.
+                    // A slice keeps the list it stored as its value, however
+                    // short: `(@a[0,] = 5)` is `(5,)`, not `5`. Only a genuinely
+                    // scalar subscript itemizes. A nested-key assignment
+                    // (`@a[1,(lazy 3,4,5)] = ...`) instead returns the nested
+                    // shape built while assigning.
                     let result = if let Some(nested) = nested_result {
                         nested
-                    } else if idx_is_single_element {
+                    } else if idx_is_single_element && idx_is_scalar_subscript {
                         Self::itemize_value(val)
                     } else if !assigned_values.is_empty() {
                         Value::array(assigned_values)

--- a/t/slice-assign-one-element-rvalue.t
+++ b/t/slice-assign-one-element-rvalue.t
@@ -1,0 +1,79 @@
+use Test;
+
+# A slice assignment's value is the list it stored, however short: `@a[0,]`
+# names a list of one slot, so `(@a[0,] = 5)` is `(5,)`. mutsu used to collapse
+# it to the bare element, because the flag that answers "this subscript names
+# one key" (needed so an itemized index stays a single key) was also deciding
+# the rvalue's shape.
+
+plan 12;
+
+{
+    my @d;
+    is (@d[0,] = 5).raku, '(5,)', 'a one-element slice yields a one-element list';
+}
+
+{
+    my @d;
+    is (@d[0,] = 5).^name, 'List', 'and its type is List, not the element type';
+}
+
+{
+    my @d;
+    is (@d[(0,)] = 5).raku, '(5,)', 'a parenthesised one-element index list is a slice too';
+}
+
+# The controls: a genuine single-index assignment still yields the bare value.
+{
+    my @d;
+    is (@d[0] = 5).raku, '5', 'a single positional index yields the bare value';
+}
+
+{
+    my %h;
+    is (%h<a> = 5).raku, '5', 'a single hash key yields the bare value';
+}
+
+{
+    my %h;
+    is (%h{'a',} = 5).raku, '(5,)', 'a one-element hash slice yields a one-element list';
+}
+
+# An *itemized* subscript is one index, not a slice -- that is what the
+# single-element flag exists for, and it must keep answering "single".
+{
+    my @d;
+    is (@d[$(0,)] = 5).raku, '5', 'an itemized subscript is a single index, not a slice';
+}
+
+{
+    my $s = $(1, 2);
+    my %c;
+    %c{$s} = 'x';
+    is %c.keys.elems, 1, 'an itemized hash subscript is still one key';
+}
+
+# A multi-element slice is unaffected.
+{
+    my @d;
+    is (@d[0, 1] = 5, 6).raku, '(5, 6)', 'a multi-element slice keeps the flat list';
+}
+
+# The slice's own arity decides the rvalue's length, not the RHS's.
+{
+    my @d;
+    is (@d[0,] = 5, 6).raku, '(5,)', 'a one-slot slice reports only the value it stored';
+}
+
+{
+    my @d;
+    @d[0,] = 5, 6;
+    is @d.raku, '[5]', 'and it stores only that one slot';
+}
+
+# The rvalue flattens into a list assignment as one element.
+{
+    my @a;
+    my @z = (@a[0,] = 1, 2);
+    is @z.elems, 1, 'a one-element slice rvalue contributes one element';
+}


### PR DESCRIPTION
A slice assignment's value is the list it stored, however short. mutsu
collapsed a one-slot slice to its element:

```
$ ./target/debug/mutsu -e 'my @d; say (@d[0,] = 5).raku'   # was 5
$ raku               -e 'my @d; say (@d[0,] = 5).raku'     # (5,)
```

`.elems` agreed on both (1), and the **storage** was always right — only the
shape of the assignment's own value was wrong. The controls are what make this
narrow: a genuine single-index assignment yields the bare value on both
(`(@d[0] = 5)` is `5`, `(%h<a> = 5)` is `5`). A one-element *slice* (`@d[0,]`,
with the trailing comma) names a list of one slot, and that is the shape that
diverged.

## Root cause

`idx_is_single_element` (`src/vm/vm_var_assign_index_named.rs`) was doing two
different jobs. Its real job is answering **"does this subscript name exactly
one key"** — what keeps an *itemized* index a single key rather than a slice
(`my $s = $(1,2); %c{$s}` is one key, not two), and that job is load-bearing.
It was also being reused to decide the **rvalue's shape**, and the two questions
have different answers for a one-element list subscript: it names one key, but
it is still a slice.

## The fix

A companion `idx_is_scalar_subscript`, computed from the same raw index,
answers only the rvalue question: a non-itemized `Array`/`Seq`/`Slip` subscript
is a list however short, everything else is a scalar index.
`idx_is_single_element` is untouched, so the itemized-key logic keeps the answer
it needs, and the slice arm itemizes only when *both* hold.

The slice's own arity now decides the rvalue's length rather than the RHS's,
which falls out of using the values actually stored: `(@d[0,] = 5, 6)` is
`(5,)` and `@d` is `[5]`, matching rakudo.

| case | before | after / raku |
|---|---|---|
| `(@d[0,] = 5)` | `5` | `(5,)` |
| `(@d[(0,)] = 5)` | `5` | `(5,)` |
| `(@d[0,] = 5, 6)` | `$(5, 6)` | `(5,)` |
| `(@d[0] = 5)` | `5` | `5` (unchanged) |
| `(%h<a> = 5)` | `5` | `5` (unchanged) |
| `(@d[$(0,)] = 5)` | `5` | `5` (unchanged — itemized is one index) |
| `(@d[0,1] = 5, 6)` | `(5, 6)` | `(5, 6)` (unchanged) |

## Not fixed here

The **Range** spelling of the same shape (`@d[0..0] = 5`) still yields a bare
`5`. It has a different root cause — a Range subscript on a plain positional
array is never expanded into an index list, so it never reaches the slice arm
that builds the stored-value list, and the multi-element case only *looks*
right because returning the raw RHS happens to match what was stored. Filed as
#7651 with the evidence, rather than widening this change.

## Tests

`t/slice-assign-one-element-rvalue.t` — 12 subtests covering the fixed shapes
and every control the ticket named (single positional index, single hash key,
one-element hash slice, itemized subscript, itemized hash key, multi-element
slice, and the list-assignment arity). It passes under **`raku` as well as
`mutsu`**.

The ticket's other named checks were run and pass: `roast/S09-subscript/slice.t`,
`roast/S32-hash/adverbs.t`, and `t/slice-assign-pads-short-rhs.t` (the pin the
ticket refers to as `t/slice-assign-short-rhs-padding.t`).

`cargo fmt --all`, `make lint`, `make test` (PASS, 40963 tests) and `make roast`
were run locally on this exact tree. `make roast`'s only red files are the three
environment-only ones this container cannot pass, with exactly the shapes
documented in `docs/agent-environments.md`.

Closes #7589

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TAdHjoCdB8QjLBEDy87tXS

---
_Generated by [Claude Code](https://claude.ai/code/session_01TAdHjoCdB8QjLBEDy87tXS)_