### PR TITLE
fix(compiler): keep a value-position for's result across NEXT/LEAVE phasers

### DIFF
--- a/news/2026-09/next-phaser-no-longer-clobbers-a-collected-loop-value.md
+++ b/news/2026-09/next-phaser-no-longer-clobbers-a-collected-loop-value.md
@@ -1,0 +1,61 @@
+# A `NEXT` phaser no longer clobbers a value-position `for`'s result
+
+```raku
+my @seen;
+my @doubled = do for 1, 2, 3 {
+    NEXT { @seen.push: 'next' }
+    $_ * 2
+};
+say @doubled;   # raku: [2 4 6]   mutsu: the pushes, once per iteration
+```
+
+The loop-phaser lowering (`Compiler::expand_loop_phasers`) implements `NEXT` by
+**appending the phaser body to the end of the loop body**, and splicing it in at
+every `next` target as well. In statement position that is invisible: the body's
+trailing value is sunk. In expression position it is not — the shared `for`
+lowering collects the body's *last statement* as that iteration's result, and
+after the expansion the last statement is the phaser body.
+
+`LEAVE` is spliced by the same rewrite and had the same defect
+(`do for 1, 2 { LEAVE { 77 }; $_ + 100 }` collected `77, 77`). `FIRST` and `LAST`
+were never at risk: `FIRST` is prepended as a guarded `if`, and `LAST` lands in
+the post-loop statements.
+
+## The mechanism already existed
+
+`expand_loop_phasers` already captured the body's trailing expression into a temp
+and re-emitted it — for KEEP/UNDO (`result_var`) and POST (`post_topic_var`), and
+for the gather-lowered `Stmt::Take` form. Two things were wrong with it rather
+than missing:
+
+- It was keyed off **which phasers were present**, not off whether anyone wanted
+  the value. A body with only a `NEXT` phaser allocated no temp at all.
+- Its re-emit sat **before** the appended `leave_ph`/`next_ph`, so even a
+  KEEP/UNDO body — which did have a temp — still ended with the phaser body as its
+  last statement.
+
+So the fix threads a `wants_value` flag through: `ForParts::collect` is exactly
+"this caller collects the body's trailing value", and the statement forms
+(`while`, `repeat`, C-style `loop`) pass `false`. When it is set, a capture temp is
+allocated even with no KEEP/UNDO/POST, and the re-emit moves to *after* every
+appended phaser body.
+
+The `take`n case keeps its existing exemption: when the body's value was already
+`take`n into an enclosing gather it is not re-emitted, because sinking a taken
+`Failure` would throw.
+
+## Verified against rakudo
+
+`t/loop-phaser-value-position-result.t` pins twelve shapes and passes unchanged on
+rakudo v2026.07 — the two bugs (`NEXT`, `LEAVE`, each also asserting the phaser
+still ran every iteration), and the neighbours that were already correct and had to
+stay so: statement position, `FIRST`, `LAST`, a phaser-free value-position `for`,
+`KEEP`, `NEXT`+`KEEP` together, a `gather`/`take` body with `NEXT`, and `next` as
+control flow (which still skips its iteration entirely). The ticket's own named pin
+`t/control-construct-value-position.t` also still passes.
+
+This predates the statement/expression unification: the old duplicated
+`compile_do_for_expr` called `expand_loop_phasers` the same way, so value position
+has always been wrong here and statement position has always been right.
+
+Closes #7592.

--- a/src/compiler/control_for.rs
+++ b/src/compiler/control_for.rs
@@ -101,7 +101,11 @@ impl Compiler {
             None
         };
 
-        let (pre_stmts, loop_body, post_stmts) = self.expand_loop_phasers(body, label.as_deref());
+        // `collect` is exactly "this caller wants the body's trailing value", which is
+        // what decides whether the phaser lowering must preserve it across appended
+        // NEXT/LEAVE bodies.
+        let (pre_stmts, loop_body, post_stmts) =
+            self.expand_loop_phasers(body, label.as_deref(), collect);
         for s in &pre_stmts {
             self.compile_stmt(s);
         }

--- a/src/compiler/helpers_phasers.rs
+++ b/src/compiler/helpers_phasers.rs
@@ -351,10 +351,22 @@ impl Compiler {
             .collect()
     }
 
+    /// `wants_value` is set by a caller that COLLECTS the body's trailing value
+    /// (`ForParts::collect` — the expression form `do for ... { ... }`), and clear
+    /// for the statement forms, which sink it.
+    ///
+    /// It matters because the phaser lowering appends `NEXT`/`LEAVE` bodies to the
+    /// end of the loop body. In statement position that is invisible; in expression
+    /// position it made the phaser body's value the iteration's result, so
+    /// `do for 1,2,3 { NEXT { @seen.push: 'next' }; $_ * 2 }` collected the pushes
+    /// instead of `2, 4, 6`. The capture-into-a-temp mechanism this needs already
+    /// existed for KEEP/UNDO/POST; it was just keyed off which phasers were present
+    /// rather than off whether anyone wanted the value.
     pub(super) fn expand_loop_phasers(
         &mut self,
         body: &[Stmt],
         label: Option<&str>,
+        wants_value: bool,
     ) -> (Vec<Stmt>, Vec<Stmt>, Vec<Stmt>) {
         if !Self::has_phasers(body) && !Self::stmts_have_enter_phaser_expr(body) {
             return (Vec::new(), body.to_vec(), Vec::new());
@@ -433,6 +445,14 @@ impl Compiler {
         } else {
             Some(self.next_tmp_name("__mutsu_loop_post_topic_"))
         };
+        // A value-collecting caller needs the user's trailing expression held
+        // somewhere across the appended phaser bodies even when no KEEP/UNDO/POST
+        // phaser supplies a temp of its own.
+        let value_var = if wants_value && result_var.is_none() && post_topic_var.is_none() {
+            Some(self.next_tmp_name("__mutsu_loop_value_"))
+        } else {
+            None
+        };
 
         let mut pre = vec![
             Stmt::VarDecl {
@@ -477,6 +497,20 @@ impl Compiler {
         if let Some(last_topic_var) = last_topic_var.clone() {
             pre.push(Stmt::VarDecl {
                 name: last_topic_var,
+                expr: Expr::Literal(Value::NIL),
+                type_constraint: None,
+                is_state: false,
+                is_our: false,
+                is_dynamic: false,
+                is_export: false,
+                export_tags: Vec::new(),
+                custom_traits: Vec::new(),
+                where_constraint: None,
+            });
+        }
+        if let Some(value_var) = value_var.clone() {
+            pre.push(Stmt::VarDecl {
+                name: value_var,
                 expr: Expr::Literal(Value::NIL),
                 type_constraint: None,
                 is_state: false,
@@ -588,7 +622,10 @@ impl Compiler {
         loop_body.extend(pre_ph);
         // When we have both result_var (KEEP/UNDO) and post_topic_var (POST),
         // we need to capture the body's last expression into both.
-        let capture_var = result_var.clone().or(post_topic_var.clone());
+        let capture_var = result_var
+            .clone()
+            .or(post_topic_var.clone())
+            .or(value_var.clone());
         let body_taken = matches!(
             body_main.last(),
             Some(Stmt::Take(_, false)) if capture_var.is_some()
@@ -680,18 +717,23 @@ impl Compiler {
             });
         }
         loop_body.extend(leave_ph);
-        if let Some(result_var) = result_var.clone() {
-            // Preserve loop-body value for expression contexts that collect
-            // iteration results. Not needed (and harmful — sinking a taken
-            // Failure would throw) when the body's value was already `take`n
-            // into the enclosing gather.
-            if !body_taken {
-                loop_body.push(Stmt::Expr(Expr::Var(result_var)));
-            }
-        }
         // NEXT runs after KEEP/UNDO, before the next iteration begins.
         // next_ph was already reversed above for LIFO order.
         loop_body.extend(next_ph);
+        // Re-emit the captured trailing value LAST, after every appended phaser
+        // body. This has to come after `leave_ph`/`next_ph`, not before them: those
+        // are spliced onto the end of the body, so a value emitted first is no
+        // longer the body's last statement and a collecting caller takes the
+        // phaser's value instead (`do for 1,2,3 { NEXT {...}; $_ * 2 }`).
+        //
+        // Not emitted (and harmful — sinking a taken Failure would throw) when the
+        // body's value was already `take`n into the enclosing gather.
+        if let Some(capture_var) = capture_var.clone()
+            && !body_taken
+            && (wants_value || result_var.is_some())
+        {
+            loop_body.push(Stmt::Expr(Expr::Var(capture_var)));
+        }
 
         let post = if last_ph.is_empty() {
             Vec::new()

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -2270,7 +2270,7 @@ impl Compiler {
                 is_until,
             } => {
                 let (pre_stmts, loop_body, post_stmts) =
-                    self.expand_loop_phasers(body, label.as_deref());
+                    self.expand_loop_phasers(body, label.as_deref(), false);
                 for s in &pre_stmts {
                     self.compile_stmt(s);
                 }
@@ -2450,7 +2450,7 @@ impl Compiler {
                 ..
             } if !*repeat => {
                 let (pre_stmts, loop_body, post_stmts) =
-                    self.expand_loop_phasers(body, label.as_deref());
+                    self.expand_loop_phasers(body, label.as_deref(), false);
                 // Compile init statement (if any) before the loop opcode
                 if let Some(init_stmt) = init {
                     self.compile_stmt(init_stmt);
@@ -3090,7 +3090,7 @@ impl Compiler {
                 is_until,
             } if *repeat => {
                 let (pre_stmts, loop_body, post_stmts) =
-                    self.expand_loop_phasers(body, label.as_deref());
+                    self.expand_loop_phasers(body, label.as_deref(), false);
                 if let Some(init_stmt) = init {
                     self.compile_stmt(init_stmt);
                 }

--- a/t/loop-phaser-value-position-result.t
+++ b/t/loop-phaser-value-position-result.t
@@ -1,0 +1,79 @@
+use Test;
+
+plan 12;
+
+# The loop-phaser lowering appends `NEXT`/`LEAVE` bodies to the END of the loop
+# body. In statement position that is invisible, because the body's trailing
+# value is sunk. In expression position -- `do for ... { ... }`, which collects
+# each iteration's trailing value -- it made the PHASER body's value the
+# iteration's result.
+#
+# The capture-into-a-temp mechanism already existed for KEEP/UNDO/POST; it was
+# keyed off which phasers were present rather than off whether the caller wanted
+# the value, and its re-emit sat BEFORE the appended phaser bodies rather than
+# after them.
+
+# --- the bug --------------------------------------------------------------
+
+{
+    my @seen;
+    my @doubled = do for 1, 2, 3 {
+        NEXT { @seen.push: 'next' }
+        $_ * 2
+    };
+    is-deeply @doubled, [2, 4, 6], 'a NEXT phaser does not clobber the collected value';
+    is @seen.elems, 3, '... and the NEXT phaser still ran every iteration';
+}
+
+# LEAVE is spliced by the same rewrite, so it had the same defect.
+{
+    my @left;
+    my @r = do for 1, 2 {
+        LEAVE { @left.push: 'leave' }
+        $_ + 100
+    };
+    is-deeply @r, [101, 102], 'a LEAVE phaser does not clobber the collected value';
+    is @left.elems, 2, '... and the LEAVE phaser still ran every iteration';
+}
+
+# --- the cases that were already correct, and must stay so ----------------
+
+{
+    my @s;
+    for 1, 2, 3 { NEXT { @s.push('n') }; @s.push($_ * 2) }
+    is-deeply @s, [2, 'n', 4, 'n', 6, 'n'],
+        'statement position is unchanged (value sunk, phaser still runs)';
+}
+
+{
+    my @f = do for 1, 2 { FIRST { 99 }; $_ * 10 };
+    is-deeply @f, [10, 20], 'FIRST is prepended as a guard and never was at risk';
+    my @l = do for 1, 2 { LAST { 99 }; $_ * 10 };
+    is-deeply @l, [10, 20], 'LAST lands in the post-loop statements';
+}
+
+{
+    my @plain = do for 1, 2, 3 { $_ * 2 };
+    is-deeply @plain, [2, 4, 6], 'a phaser-free value-position for is unchanged';
+}
+
+# KEEP/UNDO already allocated the capture temp; the re-emit had to move after
+# the appended phaser bodies without disturbing them.
+{
+    my @k = do for 1, 2 { KEEP { 88 }; $_ * 3 };
+    is-deeply @k, [3, 6], 'KEEP does not clobber the collected value';
+    my @nk = do for 1, 2 { NEXT { 5 }; KEEP { 6 }; $_ + 1 };
+    is-deeply @nk, [2, 3], 'NEXT and KEEP together do not clobber it either';
+}
+
+# A `take`n body value must NOT be re-emitted (sinking a taken Failure throws).
+{
+    my @g = gather for 1, 2 { NEXT { 1 }; take $_ * 7 };
+    is-deeply @g, [7, 14], 'a gather/take body with NEXT still takes the right value';
+}
+
+# `next` as control flow (not the phaser) skips the iteration entirely.
+{
+    my @n = do for 1, 2, 3 { next if $_ == 2; $_ * 2 };
+    is-deeply @n, [2, 6], 'a `next` control exception still skips its iteration';
+}


### PR DESCRIPTION
```raku
my @seen;
my @doubled = do for 1, 2, 3 {
    NEXT { @seen.push: 'next' }
    $_ * 2
};
say @doubled;   # raku: [2 4 6]   mutsu: the pushes, once per iteration
```

## Root cause

`expand_loop_phasers` implements `NEXT` by **appending the phaser body to the end of the loop body** (and splicing it at every `next` target). In statement position that is invisible — the body's trailing value is sunk. In expression position the shared `for` lowering collects the body's *last statement* as that iteration's result, and after the expansion that is the phaser body.

`LEAVE` is spliced by the same rewrite and had the same defect: `do for 1, 2 { LEAVE { 77 }; $_ + 100 }` collected `77, 77`. `FIRST`/`LAST` were never at risk — `FIRST` is prepended as a guarded `if`, `LAST` lands in the post-loop statements — which the issue predicted correctly.

## The mechanism already existed

`expand_loop_phasers` already captured the body's trailing expression into a temp and re-emitted it, for KEEP/UNDO (`result_var`), POST (`post_topic_var`) and the gather-lowered `Stmt::Take`. Two things were wrong with it rather than missing:

- it was keyed off **which phasers were present** rather than off whether the caller wanted the value, so a `NEXT`-only body allocated no temp at all;
- its re-emit sat **before** the appended `leave_ph`/`next_ph`, so even a KEEP/UNDO body — which *did* have a temp — still ended with the phaser body as its last statement.

So a `wants_value` flag is threaded through. `ForParts::collect` is exactly "this caller collects the body's trailing value"; the statement forms (`while`, `repeat`, C-style `loop`) pass `false`. When set, a capture temp is allocated even with no KEEP/UNDO/POST, and the re-emit moves to *after* every appended phaser body.

The `take`n exemption is kept: when the body's value was already `take`n into an enclosing gather it is not re-emitted, because sinking a taken `Failure` would throw.

## Verification

Twelve shapes compared against rakudo v2026.07 — the two bugs, and the neighbours that were already correct and had to stay so:

| shape | expected |
|---|---|
| `do for 1,2,3 { NEXT {…}; $_ * 2 }` | `[2 4 6]` (and the phaser ran 3×) — **the bug** |
| `do for 1,2 { LEAVE {…}; $_ + 100 }` | `[101 102]` (and the phaser ran 2×) — **same defect** |
| `for 1,2,3 { NEXT {…}; … }` | statement position unchanged |
| `FIRST` / `LAST` in a value-position `for` | unchanged |
| phaser-free value-position `for` | unchanged |
| `KEEP` alone / `NEXT`+`KEEP` | not clobbered |
| `gather for … { NEXT {…}; take … }` | still takes the right value |
| `next` as *control flow* | still skips its iteration |

`t/loop-phaser-value-position-result.t` pins all twelve and passes unchanged on rakudo. The issue's own named pin `t/control-construct-value-position.t` still passes.

- `cargo fmt --all`; `make lint`: exit 0 across all four configurations
- `make test`: 3864 files, 40978 tests, `Result: PASS`
- `make roast`: 1436 files, 218939 tests. Failures are only the three documented environment-only files, matching `docs/agent-environments.md` by name and subtest range (`6.c/S32-io/file-tests.t` 6-8/10, `S16-filehandles/filetest.t` 57-64/69-72/77-80/101-125 from `uid 0`; `S32-io/IO-Socket-Async.t` exit 124 from the network sandbox). The other three summary rows are `TODO passed` with `Failed: 0`.

This predates the statement/expression unification: the old duplicated `compile_do_for_expr` called `expand_loop_phasers` the same way, so value position has always been wrong here and statement position always right.

Closes #7592.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014zqc6o7emGLDGXUp8knhMy

---
_Generated by [Claude Code](https://claude.ai/code/session_014zqc6o7emGLDGXUp8knhMy)_