### PR TITLE
perf(vm): give the frame's slot array its own type (ADR-0077 Slice 0)

### DIFF
--- a/docs/adr/0077-locals-are-a-window-into-a-contiguous-stack.md
+++ b/docs/adr/0077-locals-are-a-window-into-a-contiguous-stack.md
@@ -1,6 +1,6 @@
 # ADR-0077: A call's locals are a window into one contiguous stack, not a pooled `Vec`
 
-- Status: **Proposed**
+- Status: **Proposed** (Slice 0 implemented — see "What Slice 0 actually built"; Slices 1-3 open)
 - Date: 2026-09-08
 - Related: [#7562](https://github.com/tokuhirom/mutsu/issues/7562) (the perf
   finding this ADR unblocks), [#7579](https://github.com/tokuhirom/mutsu/issues/7579)
@@ -111,11 +111,16 @@ left to Slice 2's measurement (see "Open questions").
 
 ## Why this is worth an ADR rather than a slice
 
-`self.locals` is read or written at **507 sites across 65 files** (up from the
-484/60 #7562 recorded). The change is mechanical at 331 of them and structural
-at the rest, and it reaches the JIT's view of `Interpreter`'s layout. That is a
-migration to sequence deliberately, which is what the rest of this document
-does.
+`Interpreter::locals` is read or written at **464 sites across 62 files**, of
+which **330 are plain `self.locals[i]` indexing** and the rest are structural
+(frame save/restore, whole-array installs, snapshots). The change also reaches
+the JIT's view of `Interpreter`'s layout. That is a migration to sequence
+deliberately, which is what the rest of this document does.
+
+(#7562 counted 484/60 and this ADR first said 507/65; both over-count. A plain
+`self.locals` grep also matches `CompiledCode::locals: Vec<String>` — the local
+*names* — in `src/opcode.rs`, which is an unrelated field. The numbers above
+exclude it.)
 
 It is, however, **materially less dangerous than #7562 assumed**. Three of the
 four reasons that issue gives for its blast radius do not survive reading the
@@ -186,14 +191,21 @@ consumers; see Slice 3.
 
 ## Migration order
 
-**Slice 0 — accessors (no representation change).** Introduce
-`#[inline] fn local(&self, i) -> &Value`, `local_mut`, `set_local`,
-`locals_len`, `locals_slice`, `locals_slice_mut` on `Interpreter`, and convert
-the 331 `self.locals[i]` sites to them. Purely mechanical, zero behavior
-change, no perf change (everything inlines to the same code). Its value is that
-it shrinks the representation swap from 507 sites to ~50 and makes the
-two-frame-borrow sites (§4 above) show up as compile errors rather than as
-subtle aliasing later.
+**Slice 0 — a newtype chokepoint (no representation change). SHIPPED; see
+"What Slice 0 actually built" below, which supersedes the accessor plan this
+paragraph originally described.** The plan was to introduce
+`local(i)` / `local_mut(i)` / `set_local(i, v)` / `locals_slice()` accessors on
+`Interpreter` and convert every `self.locals[i]` site to them, so that the
+representation swap would touch ~50 sites instead of all of them.
+
+That was the wrong shape. Converting the index sites is churn in service of a
+boundary that a newtype provides for free, so what shipped is a
+`#[repr(transparent)] struct Locals(Vec<Value>)` with `Index`/`IndexMut` and
+`Deref<Target = [Value]>`: `self.locals[i]`, `.len()`, `.get()`, `.iter()` and
+the `&self.locals` → `&[Value]` coercions all keep working verbatim, and the
+representation still has exactly one home. `Index` is implemented explicitly
+rather than left to `Deref` so that Slice 2 can address `stack[base + i]` with a
+single bounds check instead of slicing the window and then indexing it.
 
 **Slice 1 — frame bookkeeping.** `VmCallFrame::saved_locals: Vec<Value>` →
 `saved_locals_base: usize`; collapse `gc_roots`' per-frame visit into one slice
@@ -211,6 +223,52 @@ belongs to.
 stack-of-locals for block scopes. Once locals live on a contiguous stack, a
 block scope is just another base index and that field can go away. Not required
 by this ADR; recorded so the next reader sees the whole shape.
+
+### What Slice 0 actually built
+
+`src/runtime/locals.rs` — `#[repr(transparent)] struct Locals(Vec<Value>)` with
+`Index`/`IndexMut`, `Deref`/`DerefMut` to `[Value]`, a hand-written `Clone` (so
+`clone_from` keeps `Vec`'s buffer reuse, which the hyper/race worker seeding
+relies on), and a five-method inherent API that names every *structural* thing
+the VM does to a frame: `new`, `nils(n)` (a fresh un-pooled frame),
+`resize_slots(n)` (`Vec::resize` semantics, for the top-level `run` entry that
+sizes then seeds), `refill(n)` + `release()` (the pool's whole API), and
+`from_vec`/`to_vec` (owned snapshots that outlive a frame — a suspended `gather`
+coroutine, an inline `CATCH` handler frame, a hyper/race worker's slots crossing
+a thread boundary).
+
+The result is 18 files changed, +94/−39, instead of the ~330 mechanical edits
+the accessor plan implied. The 330 index sites and the ~100 `Deref` sites
+(`.len()`, `.get()`, `.iter()`, `&self.locals`) did not have to be touched at
+all, which is the point: the representation now has one home without a churn
+commit in front of it.
+
+Two things fell out of it that the plan had not anticipated:
+
+- **The args-scratch pool had to be separated first.** Three sites in
+  `vm_call_func_ops.rs` called `take_locals_from_pool(0)` and `extend`ed it —
+  borrowing the *locals* pool as an argument buffer for the named/spec light
+  call paths. A window into a shared stack cannot be handed out as an owned
+  buffer, so this is a hard blocker for Slice 2 (it is ADR-0077 open question 3).
+  Slice 0 gives those sites their own `args_scratch_pool: Vec<Vec<Value>>` with
+  the same bound and the same clear-before-return discipline, so the two uses
+  stop being conflated. Behavior is unchanged; the only cost is up to 64 more
+  retained buffers.
+- **The JIT coupling now has a compile-time tripwire.** `vm_jit_layout` applies
+  the probed `Vec<Value>` word offsets at `offset_of!(Interpreter, locals)`,
+  which is sound only while `Locals` is transparent over the vector. A
+  `const { assert!(size_of::<Locals>() == size_of::<Vec<Value>>()) }` next to
+  the existing probe assertion makes Slice 2 fail to compile until
+  `vm_jit_tier_b`'s GetLocal emitter learns the base, rather than silently
+  emitting native code against the wrong words.
+
+`Locals`' module doc records the two contracts Slice 2 must preserve: `Index`
+addresses the *current* frame (so it must add the base), and `Deref` yields
+exactly the current frame's slots (so `.len()` and `.iter()` speak about this
+frame and nothing below it). The second is what makes open question 1 — one
+stack or two — a real question rather than a preference: a locals region sharing
+the operand stack would need a per-frame length here, not "everything above
+`base`".
 
 ## Measurement protocol
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -102,4 +102,4 @@ The role of an ADR is to preserve the *context of the judgment* — something th
 | [0074](0074-a-channel-backed-supply-broadcasts-to-its-taps.md) | A channel-backed Supply broadcasts to its taps; the receiver is not an exclusive transfer | Accepted (implemented) |
 | [0075](0075-make-test-runs-tap-on-release-binary.md) | `make test` runs the TAP (`t/`) suite on the release binary (supersedes 0014); `gc-stress`/`jit-stress` keep the debug pass | Accepted |
 | [0076](0076-bare-block-lowering-and-block-scope-opcodes.md) | One bare-block lowering shared by both source positions; `BlockScope` and `DoBlockExpr` stay two opcodes | Accepted (shared lowering landed; opcode merge deferred — §6) |
-| [0077](0077-locals-are-a-window-into-a-contiguous-stack.md) | A call's locals are a window into one contiguous stack, not a pooled `Vec` | Proposed (design only; no implementation) |
+| [0077](0077-locals-are-a-window-into-a-contiguous-stack.md) | A call's locals are a window into one contiguous stack, not a pooled `Vec` | Proposed (Slice 0 implemented; Slices 1-3 open) |

--- a/news/2026-09/locals-newtype-chokepoint.md
+++ b/news/2026-09/locals-newtype-chokepoint.md
@@ -1,0 +1,69 @@
+# The frame's slot array gets a type of its own
+
+ADR-0077 Slice 0. `Interpreter::locals` was a bare `Vec<Value>` handed out by
+`locals_pool`, referenced at 464 sites across 62 files. The ADR wants to replace
+that representation with a window into one contiguous locals stack
+(`{ stack, base }`), and the first job is to give the representation a single
+home so the swap does not have to touch every slot access.
+
+The ADR's own plan for this slice was an accessor layer — `local(i)`,
+`set_local(i, v)`, `locals_slice()` — applied mechanically to the 330
+`self.locals[i]` sites. That was the wrong shape: it is a large churn commit in
+service of a boundary a newtype provides for free. What shipped instead is
+`src/runtime/locals.rs`:
+
+```rust
+#[repr(transparent)]
+pub(crate) struct Locals(Vec<Value>);
+```
+
+with `Index`/`IndexMut`, `Deref`/`DerefMut` to `[Value]`, and a hand-written
+`Clone` whose `clone_from` keeps `Vec`'s buffer reuse (the derived one would
+inherit the allocating default, and the hyper/race worker seeding reuses the
+vector on purpose). `Index` is written out rather than left to `Deref` so that
+Slice 2 can address `stack[base + i]` with one bounds check instead of slicing
+the window and then indexing it.
+
+So `self.locals[i]`, `.len()`, `.get()`, `.iter()` and every
+`&self.locals` → `&[Value]` coercion keep working verbatim — 18 files changed,
++94/−39, against the ~330 edits the accessor plan implied. What *did* have to
+change is exactly the structural set, and each one now has a name:
+`nils(n)` for the inline-exec sites that install a fresh un-pooled frame,
+`resize_slots(n)` for the top-level `run` entry that sizes a frame and then
+seeds it from `env`, `refill(n)`/`release()` as the pool's whole API, and
+`from_vec`/`to_vec` for the owned snapshots that outlive a frame — a suspended
+`gather` coroutine, an inline `CATCH` handler frame, a hyper/race worker's slots
+crossing a thread boundary.
+
+Two things came out of the slice that the plan had not anticipated.
+
+**The args-scratch pool had to be separated first.** Three sites in
+`vm_call_func_ops.rs` called `take_locals_from_pool(0)` and `extend`ed it —
+borrowing the *locals* pool as an argument buffer for the named and spec light
+call paths. A window into a shared stack cannot be handed out as an owned
+buffer, so that conflation is a hard blocker for Slice 2, not a cosmetic one
+(it is ADR-0077's open question 3). Those sites now take from their own
+`args_scratch_pool: Vec<Vec<Value>>`, with the same bound and the same
+clear-before-return discipline. Behavior is unchanged; the cost is up to 64 more
+retained buffers.
+
+**The JIT coupling now trips at compile time.** `vm_jit_layout` probes
+`Vec<Value>`'s word layout once and applies those offsets at
+`offset_of!(Interpreter, locals)`, which Tier B's GetLocal fast path reads on
+every slot access. That is sound only while `Locals` is `#[repr(transparent)]`
+over the vector, so a `const { assert!(size_of::<Locals>() ==
+size_of::<Vec<Value>>()) }` now sits next to the existing probe assertion. When
+Slice 2 gives `Locals` a base index, the build fails until
+`vm_jit_tier_b`'s emitter learns about it — rather than silently emitting native
+code against the wrong words.
+
+The module doc records the two contracts Slice 2 has to preserve, since code all
+over the VM already depends on them: `Index` addresses slot `i` of the *current*
+frame, so it must add the base; and `Deref` yields exactly the current frame's
+slots, so `.len()`, `.get()` and `.iter()` speak about this frame and nothing
+below it. The second is what turns ADR-0077's open question 1 — one stack or two
+— into a real question: a locals region sharing the operand stack would need a
+per-frame length there, not "everything above `base`".
+
+No behavior change and no measurable perf change: every accessor is `#[inline]`
+over the same `Vec`, and the representation is byte-identical.

--- a/src/runtime/catch_inline.rs
+++ b/src/runtime/catch_inline.rs
@@ -25,7 +25,7 @@ use crate::value::CatchInlineVerdict;
 /// Saved execution state for a handler run against the *installing* frame's
 /// lexicals while `self.locals` belongs to the deep throw/raise site.
 pub(crate) struct InstallingFrame {
-    saved_locals: Vec<Value>,
+    saved_locals: crate::runtime::Locals,
     saved_upvalues: Vec<Option<Value>>,
     /// The reconstructed locals as seeded, so the flush writes back only slots
     /// the handler actually changed.
@@ -58,7 +58,10 @@ impl Interpreter {
             })
             .collect();
         let seeded = handler_locals.clone();
-        let saved_locals = std::mem::replace(&mut self.locals, handler_locals);
+        let saved_locals = std::mem::replace(
+            &mut self.locals,
+            crate::runtime::Locals::from_vec(handler_locals),
+        );
         let saved_upvalues = std::mem::take(&mut self.upvalues);
         InstallingFrame {
             saved_locals,

--- a/src/runtime/gc_roots.rs
+++ b/src/runtime/gc_roots.rs
@@ -283,7 +283,8 @@ mod tests {
         let mut interp = Interpreter::new();
         interp.stack.push(Value::int(1));
         interp.stack.push(Value::int(2));
-        interp.locals.push(Value::int(3));
+        interp.locals.resize_slots(1);
+        interp.locals[0] = Value::int(3);
 
         let mut visitor = CountingVisitor { count: 0 };
         interp.visit_roots(&mut visitor);

--- a/src/runtime/locals.rs
+++ b/src/runtime/locals.rs
@@ -10,8 +10,9 @@
 //! VM already relies on them:
 //!
 //! - **`self.locals[i]` addresses slot `i` of the *current* frame**, so
-//!   [`Index`] must add the frame base rather than index the raw stack.
-//! - **[`Deref`] yields exactly the current frame's slots**, so `.len()`,
+//!   [`std::ops::Index`] must add the frame base rather than index the raw
+//!   stack.
+//! - **[`std::ops::Deref`] yields exactly the current frame's slots**, so `.len()`,
 //!   `.get()`, `.iter()` and the `&self.locals` → `&[Value]` coercions all
 //!   speak about this frame and nothing below it. That is what makes
 //!   ADR-0077's open question 1 (one stack or two) a real question: a locals

--- a/src/runtime/locals.rs
+++ b/src/runtime/locals.rs
@@ -1,0 +1,172 @@
+//! The executing frame's slot array ([`Locals`]).
+//!
+//! This is ADR-0077 Slice 0: a newtype chokepoint around the representation,
+//! introduced *before* the representation changes. Today it wraps the
+//! `Vec<Value>` the pool hands out; Slice 2 replaces the inside with a window
+//! (`{ stack, base }`) into one contiguous locals stack, and the call sites
+//! that index or iterate slots do not have to change again when it does.
+//!
+//! Two contracts the Slice 2 rewrite must preserve, because code all over the
+//! VM already relies on them:
+//!
+//! - **`self.locals[i]` addresses slot `i` of the *current* frame**, so
+//!   [`Index`] must add the frame base rather than index the raw stack.
+//! - **[`Deref`] yields exactly the current frame's slots**, so `.len()`,
+//!   `.get()`, `.iter()` and the `&self.locals` → `&[Value]` coercions all
+//!   speak about this frame and nothing below it. That is what makes
+//!   ADR-0077's open question 1 (one stack or two) a real question: a locals
+//!   region that shared the operand stack would need a per-frame length here
+//!   rather than "everything above `base`".
+//!
+//! The JIT reads the slot words out of this field directly
+//! (`vm_jit_layout::JitLayout::locals`, `vm_jit_tier_b`'s GetLocal fast path),
+//! which is why the type is `#[repr(transparent)]` for now — see the
+//! size assertion in `vm_jit_layout`.
+
+use crate::value::Value;
+
+/// The slot array of the frame currently executing.
+#[repr(transparent)]
+#[derive(Debug, Default)]
+pub(crate) struct Locals(Vec<Value>);
+
+impl Clone for Locals {
+    #[inline]
+    fn clone(&self) -> Self {
+        Locals(self.0.clone())
+    }
+
+    /// Hand-written so it keeps `Vec`'s buffer reuse. `#[derive(Clone)]` would
+    /// inherit the default `clone_from` (`*self = source.clone()`), which
+    /// allocates — and the one caller (`clone_for_thread` seeding a hyper/race
+    /// worker's frame) reuses the vector on purpose.
+    #[inline]
+    fn clone_from(&mut self, source: &Self) {
+        self.0.clone_from(&source.0);
+    }
+}
+
+impl Locals {
+    /// An empty slot array (no frame, or a frame with no locals).
+    #[inline]
+    pub(crate) fn new() -> Self {
+        Locals(Vec::new())
+    }
+
+    /// Adopt an owned slot vector — a restored snapshot (a suspended `gather`
+    /// coroutine, an inline `CATCH` handler frame), not a live frame.
+    #[inline]
+    pub(crate) fn from_vec(v: Vec<Value>) -> Self {
+        Locals(v)
+    }
+
+    /// Copy the frame's slots out into an owned vector, for a snapshot that
+    /// outlives the frame.
+    #[inline]
+    pub(crate) fn to_vec(&self) -> Vec<Value> {
+        self.0.clone()
+    }
+
+    /// A fresh frame of `num_locals` `Nil` slots. Used by the inline-exec sites
+    /// that install a frame without going through the pool (a `gather` body, a
+    /// closure entered outside the light call path); Slice 2 turns each of them
+    /// into a base push.
+    #[inline]
+    pub(crate) fn nils(num_locals: usize) -> Self {
+        Locals(vec![Value::NIL; num_locals])
+    }
+
+    /// Resize the frame to `num_locals` slots, keeping the values of the slots
+    /// that survive and filling any new ones with `Nil` — `Vec::resize`
+    /// semantics, unlike [`Self::refill`], which drops every existing value.
+    /// The top-level `run` entry needs this: it sizes the program frame and
+    /// then seeds slots from `env`, and a re-entrant run must not lose the
+    /// slots already there.
+    #[inline]
+    pub(crate) fn resize_slots(&mut self, num_locals: usize) {
+        self.0.resize(num_locals, Value::NIL);
+    }
+
+    /// Reset to `num_locals` `Nil` slots, reusing the buffer. Pairs with
+    /// [`Self::release`]; together they are the whole of the pool's API, so
+    /// Slice 2 replaces the pool by rewriting these two and nothing else.
+    #[inline]
+    pub(crate) fn refill(&mut self, num_locals: usize) {
+        self.0.clear();
+        self.0.resize(num_locals, Value::NIL);
+    }
+
+    /// Drop the frame's slot values but keep the buffer, at a well-defined
+    /// point rather than inside the pool.
+    #[inline]
+    pub(crate) fn release(&mut self) {
+        self.0.clear();
+    }
+}
+
+impl std::ops::Index<usize> for Locals {
+    type Output = Value;
+
+    #[inline]
+    fn index(&self, slot: usize) -> &Value {
+        &self.0[slot]
+    }
+}
+
+impl std::ops::IndexMut<usize> for Locals {
+    #[inline]
+    fn index_mut(&mut self, slot: usize) -> &mut Value {
+        &mut self.0[slot]
+    }
+}
+
+impl std::ops::Deref for Locals {
+    type Target = [Value];
+
+    #[inline]
+    fn deref(&self) -> &[Value] {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for Locals {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut [Value] {
+        &mut self.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn refill_and_release_reuse_the_buffer() {
+        let mut l = Locals::new();
+        l.refill(3);
+        assert_eq!(l.len(), 3);
+        assert!(l.iter().all(|v| v.is_nil()));
+        l[1] = Value::int(7);
+        assert_eq!(l[1].as_int(), Some(7));
+        let cap_before = l.to_vec().capacity();
+        l.release();
+        assert_eq!(l.len(), 0);
+        l.refill(2);
+        assert_eq!(l.len(), 2);
+        // The point of the pool: refilling after a release does not have to
+        // grow from zero again.
+        assert!(cap_before > 0);
+    }
+
+    /// `Deref` is the frame window every `.len()` / `.iter()` / `&self.locals`
+    /// site reads through, so pin that it agrees with `Index`.
+    #[test]
+    fn deref_window_agrees_with_index() {
+        let mut l = Locals::from_vec(vec![Value::int(1), Value::int(2)]);
+        assert_eq!(l.len(), 2);
+        assert_eq!(l.get(1).and_then(|v| v.as_int()), Some(2));
+        l[0] = Value::int(9);
+        assert_eq!(l.first().and_then(|v| v.as_int()), Some(9));
+        assert_eq!(l.to_vec().len(), 2);
+    }
+}

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -494,6 +494,7 @@ mod iterator_protocol;
 pub(crate) mod json;
 mod list_element_stringify;
 mod listop_functions;
+pub(crate) mod locals;
 mod lock_async_recursion;
 mod lock_reentry;
 pub(crate) mod loop_handler_depth;
@@ -706,6 +707,7 @@ pub(crate) mod wasm_sched;
 mod which_identity;
 /// Elastic worker pool for short-lived user tasks (ADR-0020).
 pub(crate) mod worker_pool;
+pub(crate) use self::locals::Locals;
 pub(crate) use self::match_target::MatchTarget;
 pub(crate) use self::methods_subscript_protocol::refuse_map_removal;
 pub(crate) use self::output_sink::OutputSink;
@@ -1886,7 +1888,14 @@ pub struct Interpreter {
     /// instead of allocating removes a malloc/free pair per call (recursion
     /// otherwise allocates one per frame down the whole chain). Entries are
     /// cleared before being returned to the pool; bounded by `LOCALS_POOL_MAX`.
-    pub(crate) locals_pool: Vec<Vec<Value>>,
+    pub(crate) locals_pool: Vec<Locals>,
+    /// Recycled *argument* buffers for the named/spec light call paths, which
+    /// need a contiguous `Vec<Value>` of the drained arguments rather than a
+    /// frame's slot array. These used to borrow `locals_pool`, which conflated
+    /// two different things: ADR-0077 makes `Locals` a window into one
+    /// contiguous stack, and a window cannot be handed out as an owned buffer.
+    /// Same bound and same clear-before-return discipline as `locals_pool`.
+    pub(crate) args_scratch_pool: Vec<Vec<Value>>,
     /// Number of active CONTROL handlers in the current VM stack. Tracked
     /// on the interpreter (rather than per-VM) so that nested VMs (e.g.
     /// EVAL) can observe handlers installed by the outer VM and propagate
@@ -3003,7 +3012,7 @@ pub struct Interpreter {
     // dissolved into the Interpreter; these were the per-execution fields of the
     // former `VM` struct). The Interpreter IS the bytecode VM now. ===
     pub(crate) stack: Vec<Value>,
-    pub(crate) locals: Vec<Value>,
+    pub(crate) locals: Locals,
     /// Current frame's captured upvalue array, indexed by the running
     /// `CompiledCode::upvalue_syms` order. Read by `GetUpvalue(i)`. Set from
     /// `SubData::upvalues` on closure entry and saved/restored across call frames

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -2964,6 +2964,7 @@ impl Interpreter {
             cur_source_line: 1,
             thread_spawn_origin: None,
             locals_pool: Vec::new(),
+            args_scratch_pool: Vec::new(),
             control_handler_depth: 0,
             test_assertion_line_stack: Vec::new(),
             block_stack: Vec::new(),
@@ -3160,7 +3161,7 @@ impl Interpreter {
             // Merged VM execution registers (CP-3 collapse) — same defaults the
             // former `VM::new` installed.
             stack: Vec::new(),
-            locals: Vec::new(),
+            locals: crate::runtime::locals::Locals::new(),
             upvalues: Vec::new(),
             frame_authoritative: Vec::new(),
             frame_owned: Vec::new(),

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -605,6 +605,7 @@ impl Interpreter {
             cur_source_line: 1,
             thread_spawn_origin,
             locals_pool: Vec::new(),
+            args_scratch_pool: Vec::new(),
             control_handler_depth: 0,
             test_assertion_line_stack: Vec::new(),
             block_stack: Vec::new(),
@@ -866,7 +867,7 @@ impl Interpreter {
             // with fresh per-execution registers, exactly as the former
             // `VM::new(thread_interp)` did for a spawned thread.
             stack: Vec::new(),
-            locals: Vec::new(),
+            locals: crate::runtime::locals::Locals::new(),
             upvalues: Vec::new(),
             frame_authoritative: Vec::new(),
             frame_owned: Vec::new(),

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -360,7 +360,7 @@ pub(crate) struct VmCallFrame {
     /// The caller's `cur_source_line` at frame push, restored on pop (the line
     /// the callee body's ops advanced to must not leak into the caller).
     pub saved_cur_line: i64,
-    pub saved_locals: Vec<Value>,
+    pub saved_locals: crate::runtime::locals::Locals,
     pub saved_upvalues: Vec<Option<Value>>,
     pub saved_stack_depth: usize,
     /// Rollback mark of this frame's readonly scope (see

--- a/src/vm/vm_call_func_ops.rs
+++ b/src/vm/vm_call_func_ops.rs
@@ -341,7 +341,7 @@ impl Interpreter {
                     }
                 });
                 if !needs_slow {
-                    let mut args = self.take_locals_from_pool(0);
+                    let mut args = self.take_args_scratch();
                     args.extend(self.stack.drain(base..));
                     let cl = crate::runtime::Interpreter::peek_callsite_line(&args);
                     if cl.is_some() {
@@ -356,7 +356,7 @@ impl Interpreter {
                         code.const_sym(name_idx),
                         Some(spec),
                     );
-                    self.recycle_locals(args);
+                    self.recycle_args_scratch(args);
                     self.stack.push(result?);
                     self.drain_and_reconcile_after_cached_call(code);
                     return Ok(());
@@ -742,9 +742,9 @@ impl Interpreter {
                     {
                         let start = self.stack.len() - arity_usize;
                         // Pooled args buffer (J4d): `drain(..).collect()` was one
-                        // malloc/free per call; borrow the locals pool's recycled
-                        // `Vec<Value>` instead (mirrors the positional cached path).
-                        let mut args = self.take_locals_from_pool(0);
+                        // malloc/free per call; take one from the args-scratch
+                        // pool instead (mirrors the positional cached path).
+                        let mut args = self.take_args_scratch();
                         args.extend(self.stack.drain(start..));
                         // Extract callsite line for deprecation tracking
                         let cl = crate::runtime::Interpreter::peek_callsite_line(&args);
@@ -759,7 +759,7 @@ impl Interpreter {
                             name_str,
                             code.const_sym(name_idx),
                         );
-                        self.recycle_locals(args);
+                        self.recycle_args_scratch(args);
                         self.stack.push(result?);
                         // Slice F: drain captured-outer writes through to this
                         // caller frame's local slots (see the positional-light
@@ -815,8 +815,8 @@ impl Interpreter {
                         // per call on this path, which every block-local sub call
                         // takes. Only the cold `call_compiled_function_named` arm
                         // consumes the `Vec`; the light arms borrow it and it goes
-                        // back to the pool below.
-                        let mut args = self.take_locals_from_pool(0);
+                        // back to the args-scratch pool below.
+                        let mut args = self.take_args_scratch();
                         args.extend(self.stack.drain(start..));
 
                         // Extract callsite line for deprecation tracking
@@ -919,7 +919,7 @@ impl Interpreter {
                             }
                             r
                         };
-                        self.recycle_locals(args);
+                        self.recycle_args_scratch(args);
                         let result = result?;
                         // Slice F: drain this frame's recorded captured-outer
                         // writes, plus (env_dirty-gated) reconcile to catch a

--- a/src/vm/vm_call_method_compiled.rs
+++ b/src/vm/vm_call_method_compiled.rs
@@ -144,7 +144,7 @@ impl Interpreter {
         let saved_stack = std::mem::take(&mut self.stack);
 
         // Initialize locals for the block
-        self.locals = vec![Value::NIL; block_cc.locals.len()];
+        self.locals = crate::runtime::Locals::nils(block_cc.locals.len());
         if captured_env.is_some() {
             for (slot, name) in captured_bindings.iter() {
                 if (name.starts_with('@') || name.starts_with('%'))

--- a/src/vm/vm_call_named_inner.rs
+++ b/src/vm/vm_call_named_inner.rs
@@ -266,7 +266,7 @@ impl Interpreter {
             );
         }
 
-        self.locals = vec![Value::NIL; cf.code.locals.len()];
+        self.locals = crate::runtime::Locals::nils(cf.code.locals.len());
         // `locals_sym` is the pre-interned twin of `locals` (empty only for a
         // hand-built chunk that never ran `compute_locals_sym`); reading the
         // seed values through it saves one string intern per local per call.

--- a/src/vm/vm_closure_dispatch.rs
+++ b/src/vm/vm_closure_dispatch.rs
@@ -864,7 +864,7 @@ impl Interpreter {
             }
         }
 
-        self.locals = vec![Value::NIL; cc.locals.len()];
+        self.locals = crate::runtime::Locals::nils(cc.locals.len());
         for (i, local_name) in cc.locals.iter().enumerate() {
             if let Some(val) = self.env().get(local_name) {
                 self.locals[i] = val.clone();

--- a/src/vm/vm_env_helpers.rs
+++ b/src/vm/vm_env_helpers.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::runtime::Locals;
 
 impl Interpreter {
     /// Collapse the interpreter's env to a flat (`parent=None`) env if it is
@@ -13,25 +14,56 @@ impl Interpreter {
         }
     }
 
-    /// Grab a locals vector from the recycle pool (or allocate the first time),
+    /// Grab a slot array from the recycle pool (or allocate the first time),
     /// sized to `num_locals` with `Nil` slots. Pair with [`Self::recycle_locals`].
+    ///
+    /// These two functions are the *whole* of the pool's API (ADR-0077 Slice 0):
+    /// every other site speaks to [`Locals`] through indexing or `Deref`, so
+    /// Slice 2 retires the pool by rewriting this pair and the frame
+    /// save/restore sites, not the hundreds of slot accesses.
     #[inline]
-    pub(super) fn take_locals_from_pool(&mut self, num_locals: usize) -> Vec<Value> {
+    pub(super) fn take_locals_from_pool(&mut self, num_locals: usize) -> Locals {
         let mut v = self.locals_pool.pop().unwrap_or_default();
-        v.clear();
-        v.resize(num_locals, Value::NIL);
+        v.refill(num_locals);
         v
     }
 
-    /// Return a used locals vector to the recycle pool (bounded; excess is
-    /// simply dropped). Clearing here also drops the callee's slot values at a
+    /// Return a used slot array to the recycle pool (bounded; excess is
+    /// simply dropped). Releasing here also drops the callee's slot values at a
     /// well-defined point instead of inside the pool.
     #[inline]
-    pub(super) fn recycle_locals(&mut self, mut used: Vec<Value>) {
+    pub(super) fn recycle_locals(&mut self, mut used: Locals) {
         const LOCALS_POOL_MAX: usize = 64;
         if self.locals_pool.len() < LOCALS_POOL_MAX {
-            used.clear();
+            used.release();
             self.locals_pool.push(used);
+        }
+    }
+
+    /// Grab an argument buffer from the args-scratch pool. The named/spec light
+    /// call paths drain `self.stack` into a contiguous `Vec<Value>` to bind
+    /// from; `drain(..).collect()` was a malloc/free pair per call. Pair with
+    /// [`Self::recycle_args_scratch`].
+    ///
+    /// This is deliberately *not* the locals pool, which it used to borrow: an
+    /// argument buffer is an owned vector, and ADR-0077 turns [`Locals`] into a
+    /// window into a shared stack that cannot be handed out as one.
+    #[inline]
+    pub(super) fn take_args_scratch(&mut self) -> Vec<Value> {
+        let mut v = self.args_scratch_pool.pop().unwrap_or_default();
+        v.clear();
+        v
+    }
+
+    /// Return an argument buffer to the args-scratch pool (bounded; excess is
+    /// dropped). Clearing here drops the argument values at a well-defined
+    /// point instead of inside the pool.
+    #[inline]
+    pub(super) fn recycle_args_scratch(&mut self, mut used: Vec<Value>) {
+        const ARGS_SCRATCH_POOL_MAX: usize = 64;
+        if self.args_scratch_pool.len() < ARGS_SCRATCH_POOL_MAX {
+            used.clear();
+            self.args_scratch_pool.push(used);
         }
     }
 

--- a/src/vm/vm_helpers_lazy.rs
+++ b/src/vm/vm_helpers_lazy.rs
@@ -1238,7 +1238,7 @@ impl Interpreter {
         self.push_gather_take_limit(None);
 
         // Initialize locals for the compiled code
-        self.locals = vec![Value::NIL; cc.locals.len()];
+        self.locals = crate::runtime::Locals::nils(cc.locals.len());
         for (i, name) in cc.locals.iter().enumerate() {
             if let Some(val) = self.env().get(name) {
                 self.locals[i] = val.clone();

--- a/src/vm/vm_helpers_lazy_pull.rs
+++ b/src/vm/vm_helpers_lazy_pull.rs
@@ -119,7 +119,7 @@ impl Interpreter {
             if !coro.finished && (coro.ip > 0 || coro.started) {
                 // Resume from saved state
                 ip = coro.ip;
-                self.locals = coro.locals.clone();
+                self.locals = crate::runtime::Locals::from_vec(coro.locals.clone());
                 self.stack = coro.stack.clone();
                 *self.env_mut() = coro.env.clone();
                 self.gather_for_loop_resume = coro.for_loop_resume.clone();
@@ -132,7 +132,7 @@ impl Interpreter {
                 // accumulate across takes without forking `list.env`.
                 ip = 0;
                 *self.env_mut() = crate::env::Env::scoped_child(list.env.flattened());
-                self.locals = vec![Value::NIL; cc.locals.len()];
+                self.locals = crate::runtime::Locals::nils(cc.locals.len());
                 for (i, name) in cc.locals.iter().enumerate() {
                     if let Some(val) = self.env().get(name) {
                         self.locals[i] = val.clone();
@@ -145,7 +145,7 @@ impl Interpreter {
             // Fresh start (no coroutine slot yet)
             ip = 0;
             *self.env_mut() = crate::env::Env::scoped_child(list.env.flattened());
-            self.locals = vec![Value::NIL; cc.locals.len()];
+            self.locals = crate::runtime::Locals::nils(cc.locals.len());
             for (i, name) in cc.locals.iter().enumerate() {
                 if let Some(val) = self.env().get(name) {
                     self.locals[i] = val.clone();
@@ -253,7 +253,7 @@ impl Interpreter {
             let for_loop_resume = self.gather_for_loop_resume.take();
             let coro_state = GatherCoroutineState {
                 ip,
-                locals: self.locals.clone(),
+                locals: self.locals.to_vec(),
                 stack: self.stack.clone(),
                 env: self.env().clone(),
                 finished: false,

--- a/src/vm/vm_hyper_race_parallel.rs
+++ b/src/vm/vm_hyper_race_parallel.rs
@@ -97,7 +97,7 @@ impl Interpreter {
                     };
                     Ok(collected)
                 });
-                let wlocals = vm.locals.clone();
+                let wlocals = vm.locals.to_vec();
                 let output = vm.take_output();
                 let stderr = vm.take_stderr_output();
                 (run, wlocals, output, stderr)

--- a/src/vm/vm_jit_layout.rs
+++ b/src/vm/vm_jit_layout.rs
@@ -35,6 +35,14 @@ fn probe_vec_layout() -> Option<(i32, i32, i32)> {
     const WORD: usize = std::mem::size_of::<usize>();
     const {
         assert!(std::mem::size_of::<Vec<Value>>() == 3 * WORD);
+        // `Interpreter::locals` is a `Locals` (ADR-0077 Slice 0), and the
+        // GetLocal fast path applies the probed `Vec<Value>` word offsets at
+        // that field's address. That is sound only while `Locals` is
+        // `#[repr(transparent)]` over the vector. Slice 2 gives `Locals` a base
+        // index, at which point this assertion fires and the emitter in
+        // `vm_jit_tier_b` must learn the base — which is the intended tripwire,
+        // not an obstacle.
+        assert!(std::mem::size_of::<crate::runtime::Locals>() == std::mem::size_of::<Vec<Value>>());
     }
     let mut v: Vec<Value> = Vec::with_capacity(7);
     v.push(Value::int(1));

--- a/src/vm/vm_method_dispatch.rs
+++ b/src/vm/vm_method_dispatch.rs
@@ -773,7 +773,7 @@ impl Interpreter {
             crate::vm::vm_call_state_guard::ThreadParamMaskGuard::new(self, bind_param_defs.iter());
 
         // Initialize locals from env
-        self.locals = vec![Value::NIL; cc.locals.len()];
+        self.locals = crate::runtime::Locals::nils(cc.locals.len());
         for (i, local_name) in cc.locals.iter().enumerate() {
             if let Some(val) = self.env().get(local_name) {
                 self.locals[i] = val.clone();
@@ -1834,7 +1834,7 @@ impl Interpreter {
         // Populate locals directly. Attribute reads take one read guard over
         // the live cell for the whole loop (dropped before the body runs) —
         // no whole-map snapshot is materialized.
-        self.locals = vec![Value::NIL; cc.locals.len()];
+        self.locals = crate::runtime::Locals::nils(cc.locals.len());
 
         {
             let attrs_guard = attrs_cell.as_ref().map(|c| c.as_map());

--- a/src/vm/vm_misc_scope.rs
+++ b/src/vm/vm_misc_scope.rs
@@ -537,7 +537,7 @@ impl Interpreter {
             self.outer_scope_locals.push(Vec::new());
         } else {
             self.outer_scope_locals
-                .push(saved_locals.as_ref().expect("opt-out snapshot").clone());
+                .push(saved_locals.as_ref().expect("opt-out snapshot").to_vec());
         }
         // Baseline for the ENTER-result stack: any value captured by this block's
         // ENTER section (PushEnterResult) must be cleared on exit even if the body

--- a/src/vm/vm_run_loop.rs
+++ b/src/vm/vm_run_loop.rs
@@ -118,7 +118,7 @@ impl Interpreter {
     ) -> Result<Option<Value>, RuntimeError> {
         Self::validate_labels(code)?;
         // Initialize local variable slots
-        self.locals = vec![Value::NIL; code.locals.len()];
+        self.locals = crate::runtime::Locals::nils(code.locals.len());
         for (i, name) in code.locals.iter().enumerate() {
             if let Some(val) = self.env().get(name) {
                 self.locals[i] = val.clone();
@@ -467,7 +467,7 @@ impl Interpreter {
         Self::validate_labels(code)?;
         self.stack.clear();
         // Initialize local variable slots
-        self.locals.resize(code.locals.len(), Value::NIL);
+        self.locals.resize_slots(code.locals.len());
         for (i, name) in code.locals.iter().enumerate() {
             if let Some(val) = self.env().get(name) {
                 self.locals[i] = val.clone();


### PR DESCRIPTION
`Interpreter::locals` was a bare `Vec<Value>` handed out by `locals_pool`, referenced at 464 sites across 62 files. [ADR-0077](https://github.com/tokuhirom/mutsu/blob/main/docs/adr/0077-locals-are-a-window-into-a-contiguous-stack.md) replaces that representation with a window into one contiguous locals stack; the first job is to give the representation a single home so the swap does not have to touch every slot access.

**No behavior change and no expected perf change** — every accessor is `#[inline]` over the same `Vec` and the representation is byte-identical.

## The ADR's plan for this slice was the wrong shape

It said: introduce `local(i)` / `set_local(i, v)` / `locals_slice()` accessors on `Interpreter` and convert the 330 `self.locals[i]` sites to them. That is a large churn commit in service of a boundary a newtype provides for free. What this PR does instead — `src/runtime/locals.rs`:

```rust
#[repr(transparent)]
pub(crate) struct Locals(Vec<Value>);
```

with `Index`/`IndexMut`, `Deref`/`DerefMut` to `[Value]`, and a hand-written `Clone` whose `clone_from` keeps `Vec`'s buffer reuse (the derived one inherits the allocating default, and `clone_for_thread`'s hyper/race worker seeding reuses the vector on purpose). `Index` is written out rather than left to `Deref` so Slice 2 can address `stack[base + i]` with one bounds check instead of slicing the window and then indexing it.

So `self.locals[i]`, `.len()`, `.get()`, `.iter()` and every `&self.locals` → `&[Value]` coercion keep working verbatim: **18 files changed** against the ~330 edits the accessor plan implied. What did change is exactly the structural set, and each operation now has a name:

| method | who needs it |
| --- | --- |
| `nils(n)` | the inline-exec sites that install a fresh un-pooled frame (a `gather` body, a closure entered off the light path) |
| `resize_slots(n)` | the top-level `run` entry, which sizes a frame and *then* seeds it from `env` — `Vec::resize` semantics, unlike `refill` |
| `refill(n)` / `release()` | the pool's whole API |
| `from_vec` / `to_vec` | owned snapshots that outlive a frame — a suspended `gather` coroutine, an inline `CATCH` handler frame, a hyper/race worker's slots crossing a thread boundary |

## Two things the slice turned up that the plan had not anticipated

**The args-scratch pool had to be separated first.** Three sites in `vm_call_func_ops.rs` called `take_locals_from_pool(0)` and `extend`ed it — borrowing the *locals* pool as an argument buffer for the named and spec light call paths. A window into a shared stack cannot be handed out as an owned buffer, so that conflation is a hard blocker for Slice 2, not a cosmetic one (it is ADR-0077's open question 3). Those sites now take from their own `args_scratch_pool: Vec<Vec<Value>>`, same bound and same clear-before-return discipline. Behavior unchanged; the cost is up to 64 more retained buffers.

**The JIT coupling now trips at compile time.** `vm_jit_layout` probes `Vec<Value>`'s word layout once and applies those offsets at `offset_of!(Interpreter, locals)`, which Tier B's GetLocal fast path reads on every slot access. That is sound only while `Locals` is `#[repr(transparent)]` over the vector, so a `const { assert!(size_of::<Locals>() == size_of::<Vec<Value>>()) }` now sits beside the existing probe assertion. Slice 2 will fail to compile until `vm_jit_tier_b`'s emitter learns the base, instead of silently emitting native code against the wrong words.

The module doc records the two contracts Slice 2 must preserve, because code all over the VM already depends on them: `Index` addresses slot `i` of the *current* frame (so it must add the base), and `Deref` yields exactly the current frame's slots (so `.len()`/`.get()`/`.iter()` speak about this frame and nothing below it). The latter is what turns ADR-0077's open question 1 — one stack or two — into a real question rather than a preference.

## Docs

ADR-0077's Slice 0 paragraph is superseded in place with what shipped (per the convention that an ADR records its own implementation state), its status is now `Proposed (Slice 0 implemented; Slices 1-3 open)`, and its site counts are corrected: a plain `self.locals` grep also matches `CompiledCode::locals: Vec<String>` in `src/opcode.rs`, an unrelated field, so the real figures are **464 sites / 62 files / 330 index sites**, not 507/65/331. Plus `news/2026-09/locals-newtype-chokepoint.md`.

## Verification (all run locally before opening this PR)

| gate | result |
| --- | --- |
| `cargo fmt --all` | clean |
| `make lint` — clippy default, `--no-default-features --features native`, wasm32 lib, rustdoc | **green** |
| `make test` — `cargo test` + `prove t/` on the release binary | **green** — Files=3861, Tests=40929, `Result: PASS`; 989 unit tests pass |
| `make roast` | **green modulo the three documented container artifacts** |

The first `make lint` run failed, and it is worth recording why: rustdoc rejected ``[`Index`]`` and ``[`Deref`]`` in the new module doc because neither trait is imported there (the impls spell them `std::ops::…`). Clippy never resolves intra-doc links, so the pre-commit hook was green throughout — exactly the trap CLAUDE.md's Conventions section describes. Fixed in `4e33768`.

The three roast failures match `docs/agent-environments.md`'s container-artifact table down to the individual test numbers — `6.c/S32-io/file-tests.t` (Failed: 4 — tests 6-8, 10) and `S16-filehandles/filetest.t` (Failed: 25 — 57-64, 69-72, 77-80, 101/103/105/107/109/111/117/121/125) both `chmod` a file and assert `.r`/`.w`/`.x` is `False`, which cannot hold as `uid 0`; `S32-io/IO-Socket-Async.t` times out at "planned 40 ran 17" behind the network sandbox. Nothing else failed.

## Next

Slices 1-3 stay open on #7562. Two corrections to the ADR's plan that Slice 2 will have to carry, found while designing it (not in this PR):

- **Slice 1 does not stand alone.** It reads "`VmCallFrame::saved_locals` → `saved_locals_base: usize`, still on a pooled `Vec` for the live frame", but a base index means nothing without the shared stack. Slice 1 folds into Slice 2.
- **A GC hazard.** `gc_roots` visits `&self.locals` plus each frame's `saved_locals` separately today. Once the stack is shared, `Deref` exposes only the *current* window, so `visit_slice(visitor, &self.locals)` would miss every lower frame's slots and GC could free live values. Slice 2 needs an explicit `all_slots()` and a regression test for it.

Refs #7562

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KeMrW2npKb8WCC6zNH1osM

---
_Generated by [Claude Code](https://claude.ai/code/session_01KeMrW2npKb8WCC6zNH1osM)_