### PR TITLE
fix(regex): carry an assertion's outer-lexical write back to the caller's slot

### DIFF
--- a/news/2026-09/regex-assertion-scalar-write-to-outer-lexical.md
+++ b/news/2026-09/regex-assertion-scalar-write-to-outer-lexical.md
@@ -1,0 +1,64 @@
+# A regex assertion's write to an outer scalar lexical now reaches the caller
+
+An embedded `<?{ … }>` / `<!{ … }>` assertion that assigned to a scalar lexical
+declared outside the regex left the caller's variable untouched:
+
+```raku
+my $n = 0;
+"aaaa" ~~ / [ <?{ $n++; True }> . ]+ /;
+say $n;        # raku: 5      mutsu (before): 0
+```
+
+A plain `{ … }` code block in the same position wrote back correctly, and so did
+a *mutation* of a container from inside an assertion (`@a.push(1)` — the caller's
+slot already shares that allocation). Only a scalar rebinding was lost, and it
+died with the match.
+
+## Why it was lost
+
+`eval_regex_inline_code` takes a `writes_back_to_caller` flag. A plain `{ … }`
+block passes `true` and runs through `eval_regex_code_block_body`, which
+snapshots the env, diffs it by binding identity afterwards, and logs every
+rebound name into `pending_local_updates` so the VM refreshes the caller's
+compiled local slot. An assertion passed `false`: ADR-0009 deliberately kept
+that path snapshot-free, because an assertion is evaluated at *every cursor
+position* and a full env snapshot plus identity diff per position is exactly the
+cost that path exists to avoid.
+
+Leaving the write in `env` was enough for a later `$name` interpolation or
+assertion inside the same match to read it back, and enough for a mutated
+container, but nothing ever refreshed the caller's slot — so the value
+disappeared as soon as the match ended.
+
+## The fix
+
+The compiler already knows precisely which free variables a block assigns:
+`CompiledCode::free_var_writes`, the same set `eval_block_value_recording_writes`
+uses for a `where` clause. That set is exactly what the env diff would have
+found, and it is computed at compile time, so an assertion that assigns nothing
+reports nothing and pays nothing — the hot path keeps ADR-0009's property.
+
+`eval_block_value_cached_reporting_writes` runs the cached chunk and hands the
+names back to the caller, and the regex layer owns the filtering policy it needs:
+the regex's own `:my` / `:let` lexicals, `$/` / `$¢` / `$0`…, the body's own `my`
+declarations and the `make` slot are all regex-scoped and must not reach a caller
+slot, and a body compiled inside `grammar G { … }` records the write under the
+auto-package-qualified `G::x` while `in_regex_code_block` redirects the write
+itself onto the bare lexical, so the package prefix is stripped before the two
+names are compared. Names already logged are skipped, which keeps the log bounded
+by the number of distinct variables rather than by the number of cursor positions
+the assertion ran at.
+
+## Pins
+
+`t/regex-assertion-outer-scalar-write.t` covers the positive and negative
+assertion forms, a plain assignment, the two shapes that already worked, a write
+that survives a failing match, an assertion's own `my` staying lexical, a
+routine-local slot, and a grammar token's assertion. Every assertion in it was
+checked against rakudo.
+
+`t/regex-inline-code-compile-cache.t` had routed its counters through `@` / `%`
+containers specifically to dodge this bug; it now pins the scalar forms too, so
+serving a cached compile cannot lose the per-evaluation writeback either.
+
+Closes [#7593](https://github.com/tokuhirom/mutsu/issues/7593).

--- a/src/runtime/regex/regex_eval.rs
+++ b/src/runtime/regex/regex_eval.rs
@@ -212,13 +212,17 @@ impl Interpreter {
     /// `RegexCaptures::ast`, where the match trail can undo them on
     /// backtracking.
     ///
-    /// `writes_back_to_caller` selects how a write to an *outer* lexical is
-    /// propagated. A plain `{ … }` block must reach the caller's compiled local
-    /// slots (`'123' ~~ / (\d) { $seen = $/.Str } \d+ /` has to leave `$seen`
-    /// set), which is the env-diff → `pending_local_updates` bookkeeping the
-    /// reduce-time replay does; an assertion keeps ADR-0009's cheaper behaviour of
-    /// simply leaving the write in `env`, so the hot `<?{ … }>` path does not take
-    /// on a full env snapshot per cursor position.
+    /// `writes_back_to_caller` selects *how* a write to an *outer* lexical is
+    /// propagated — both routes reach the caller's compiled local slots, they
+    /// just pay for the name set differently. A plain `{ … }` block
+    /// (`'123' ~~ / (\d) { $seen = $/.Str } \d+ /` has to leave `$seen` set)
+    /// takes the env-diff → `pending_local_updates` bookkeeping of
+    /// [`Interpreter::eval_regex_code_block_body`], which sees a write however
+    /// it was spelled. An assertion is evaluated at every cursor position, so
+    /// ADR-0009 kept its path free of that per-position snapshot: it uses the
+    /// compiled body's `free_var_writes` instead
+    /// (`writeback_assertion_free_var_writes` below), which the compiler already
+    /// computed, so an assertion that assigns nothing pays nothing.
     pub(super) fn eval_regex_inline_code(
         &mut self,
         code: &str,
@@ -393,8 +397,14 @@ impl Interpreter {
             // position, and recompiling its handful of statements every time
             // was the dominant cost of a `<?{ … }>`-driven match (see
             // `news/2026-09/regex-inline-code-recompiled-per-cursor-position.md`).
-            let r = self.eval_block_value_cached(&stmts, code_cache_id);
+            let mut free_var_writes: Vec<String> = Vec::new();
+            let r = self.eval_block_value_cached_reporting_writes(
+                &stmts,
+                code_cache_id,
+                &mut free_var_writes,
+            );
             self.in_regex_code_block = saved_in_block;
+            self.writeback_assertion_free_var_writes(&free_var_writes, &scoped);
             r
         };
         // Harvest writes to the in-regex lexicals *before* restoring them: the
@@ -446,6 +456,67 @@ impl Interpreter {
             value,
             writes,
             made,
+        }
+    }
+
+    /// Carry an assertion body's assignments to *outer* lexicals through to the
+    /// caller's compiled local slots.
+    ///
+    /// A plain `{ … }` block gets this from `eval_regex_code_block_body`'s env
+    /// snapshot + binding-identity diff. An assertion is evaluated at every
+    /// cursor position, so ADR-0009 kept its path snapshot-free — and the write
+    /// consequently only ever landed in `env`. That is enough for a later atom
+    /// of the same match to read it back, and enough for a *mutated* container
+    /// (the caller's slot already shares that allocation), but a scalar
+    /// rebinding died with the match: `my $n = 0; "aaaa" ~~ / [ <?{ $n++; True }> . ]+ /`
+    /// left `$n` at 0 where rakudo leaves 5. The compiler's `free_var_writes` is
+    /// exactly the set the diff would have found, at no per-position cost — an
+    /// assertion that assigns nothing reports nothing and returns immediately.
+    ///
+    /// `scoped` holds the names this evaluation installed and is about to
+    /// restore (the regex's own `:my`/`:let` lexicals, `$/` / `$¢` / `$0`…, and
+    /// the body's own `my` declarations); none of them is a caller lexical.
+    /// `made` is engine state, not a variable the caller can declare.
+    fn writeback_assertion_free_var_writes(&mut self, names: &[String], scoped: &[String]) {
+        if names.is_empty() {
+            return;
+        }
+        // A body compiled inside `grammar G { … }` records a write to an outer
+        // `$x` under the auto-package-qualified `G::x`, while
+        // `in_regex_code_block` redirects the write itself back onto the bare
+        // lexical in `env` — strip the package so the two names agree (the same
+        // adjustment the deferred class/role body drain in `run.rs` makes).
+        let pkg = self.current_package();
+        let pkg_prefix = if pkg == "GLOBAL" {
+            String::new()
+        } else {
+            format!("{pkg}::")
+        };
+        for name in names {
+            let name = if pkg_prefix.is_empty() {
+                name.as_str()
+            } else {
+                name.strip_prefix(&pkg_prefix).unwrap_or(name.as_str())
+            };
+            if matches!(name, "made" | "_" | "$_" | "@_" | "%_") || scoped.iter().any(|s| s == name)
+            {
+                continue;
+            }
+            let Some(v) = self.env.get(name).cloned() else {
+                continue;
+            };
+            if let Some(set) = self.carrier_writes.as_mut() {
+                set.insert(name.to_string());
+            }
+            // Both drains (`drain_pending_local_updates_after_call`,
+            // `vm_smartmatch_ops`) key on the NAME and re-read the value from
+            // `env`, so a repeat of a name already logged is redundant. Skipping
+            // it keeps the log bounded by the number of distinct names rather
+            // than by the number of cursor positions the assertion ran at.
+            if self.pending_local_updates.iter().any(|(n, _)| n == name) {
+                continue;
+            }
+            self.pending_local_updates.push((name.to_string(), v));
         }
     }
 

--- a/src/runtime/resolution_eval.rs
+++ b/src/runtime/resolution_eval.rs
@@ -215,7 +215,33 @@ impl Interpreter {
         body: &[Stmt],
         cache_id: u64,
     ) -> Result<Value, RuntimeError> {
-        self.eval_block_value_inner(body, false, false, Some(cache_id))
+        self.eval_block_value_inner(body, false, false, Some(cache_id), None)
+    }
+
+    /// [`Interpreter::eval_block_value_cached`], additionally reporting the
+    /// block's compile-time `free_var_writes` — the free variables the body
+    /// *assigns* — into `free_var_writes_out`.
+    ///
+    /// The regex engine's `<?{ … }>` / `<!{ … }>` assertion path uses this to
+    /// carry an assignment through to the caller's compiled local slot without
+    /// the env snapshot + binding-identity diff a plain `{ … }` block pays
+    /// (`eval_regex_code_block_body`): an assertion is evaluated at *every*
+    /// cursor position, and ADR-0009 deliberately kept that path snapshot-free.
+    /// The compiler already knows the exact set, so an assertion that assigns
+    /// nothing reports nothing and costs nothing.
+    pub(crate) fn eval_block_value_cached_reporting_writes(
+        &mut self,
+        body: &[Stmt],
+        cache_id: u64,
+        free_var_writes_out: &mut Vec<String>,
+    ) -> Result<Value, RuntimeError> {
+        self.eval_block_value_inner(
+            body,
+            false,
+            false,
+            Some(cache_id),
+            Some(free_var_writes_out),
+        )
     }
 
     /// `eval_block_value`, additionally recording the block's compile-time
@@ -233,7 +259,7 @@ impl Interpreter {
         &mut self,
         body: &[Stmt],
     ) -> Result<Value, RuntimeError> {
-        self.eval_block_value_inner(body, false, true, None)
+        self.eval_block_value_inner(body, false, true, None, None)
     }
 
     /// `eval_block_value`, with `is_eval_unit` marking `body` as an EVAL'd
@@ -255,7 +281,7 @@ impl Interpreter {
         // retain-on-miss list then refreshes the slot in whichever frame declares
         // the lexical, and `propagate_pending_caller_writes` carries the value
         // across each intervening frame exit.
-        self.eval_block_value_inner(body, is_eval_unit, is_eval_unit, None)
+        self.eval_block_value_inner(body, is_eval_unit, is_eval_unit, None, None)
     }
 
     /// The ambient compile context `compile_block_value_opts` folds into a
@@ -336,6 +362,7 @@ impl Interpreter {
         is_eval_unit: bool,
         record_free_var_writes: bool,
         cache_id: Option<u64>,
+        free_var_writes_out: Option<&mut Vec<String>>,
     ) -> Result<Value, RuntimeError> {
         // Taken first, unconditionally: it belongs to THIS body's compile only
         // (see the field doc), and an empty body must not leave it armed.
@@ -417,6 +444,13 @@ impl Interpreter {
         // frames, so the by-name write survives the owner frame's env restore.
         // No-op in the default build (gated on cell_boxing_active).
         self.box_carrier_free_var_writes(&code);
+        // Report (rather than act on) the compile-time free-variable writes, for
+        // a caller that owns the writeback policy itself — the regex assertion
+        // path, which has to filter the regex's own scoped bindings out of the
+        // set before it reaches the caller's slots.
+        if let Some(out) = free_var_writes_out {
+            out.extend(code.free_var_writes.iter().map(|sym| sym.resolve()));
+        }
         if record_free_var_writes {
             for sym in &code.free_var_writes {
                 let name = sym.resolve();

--- a/t/regex-assertion-outer-scalar-write.t
+++ b/t/regex-assertion-outer-scalar-write.t
@@ -1,0 +1,58 @@
+use Test;
+
+# An embedded `<?{ … }>` / `<!{ … }>` assertion that assigns to a scalar lexical
+# declared OUTSIDE the regex must leave the caller's variable set, exactly as a
+# plain `{ … }` block does. The assertion path deliberately does not snapshot the
+# env at every cursor position (ADR-0009), so the write is carried through by the
+# compiled body's `free_var_writes` instead. See GitHub issue #7593.
+
+plan 9;
+
+my $n = 0;
+"aaaa" ~~ / [ <?{ $n++; True }> . ]+ /;
+is $n, 5, 'a positive assertion increments the caller scalar';
+
+my $neg = 0;
+"aaaa" ~~ / [ <!{ $neg++; False }> . ]+ /;
+is $neg, 5, 'a negative assertion increments the caller scalar too';
+
+my $assigned = '';
+"abc" ~~ / . <?{ $assigned = 'yes'; True }> . /;
+is $assigned, 'yes', 'a plain assignment (not just ++) reaches the caller';
+
+# Still true for the two shapes that already worked, so the new writeback did
+# not displace them.
+my @a;
+"aaaa" ~~ / [ <?{ @a.push(1); True }> . ]+ /;
+is @a.elems, 5, 'a container mutated from an assertion still works';
+
+my $c = 0;
+"aaaa" ~~ / [ { $c++ } . ]+ /;
+is $c, 5, 'a plain code block still writes back';
+
+# The side effect survives a match that ultimately fails.
+my $failed = 0;
+"aaaa" ~~ / <?{ $failed = 42; True }> b /;
+is $failed, 42, 'the write survives a failing match';
+
+# The assertion's own `my` is lexical to it and must NOT reach the caller.
+my $x = 'outer';
+"ab" ~~ / <?{ my $x = 'inner'; True }> . /;
+is $x, 'outer', 'the assertion own my-declaration does not clobber the caller';
+
+# Inside a routine, where the owning slot is the routine's own local.
+sub counted() {
+    my $k = 0;
+    "aaaa" ~~ / [ <?{ $k++; True }> . ]+ /;
+    $k;
+}
+is counted(), 5, 'the write reaches a routine-local slot';
+
+# Inside a grammar, where the body's write compiles to the package-qualified
+# name but lands on the bare lexical in env.
+my $g = 0;
+grammar G {
+    token TOP { [ <?{ $g = $g + 1; True }> . ]+ }
+}
+G.parse("abc");
+is $g, 4, 'a grammar token assertion reaches the outer lexical';

--- a/t/regex-inline-code-compile-cache.t
+++ b/t/regex-inline-code-compile-cache.t
@@ -6,11 +6,14 @@ use Test;
 # compile many times must not let per-evaluation state survive into the next
 # evaluation, nor across two regexes that share the same code text.
 #
-# The counters below live in a container (`@`/`%`), not a plain scalar: a write
-# to an *outer scalar* lexical from inside an assertion does not reach the
-# caller's slot yet (todo/tickets/regex-assertion-scalar-write-to-outer-lexical-is-lost.md).
+# The counters below mostly live in a container (`@`/`%`) for historical
+# reasons: a write to an *outer scalar* lexical from inside an assertion used
+# not to reach the caller's slot at all (GitHub issue #7593, fixed). The scalar
+# forms are pinned here too, since serving a cached compile must not lose the
+# per-evaluation writeback either; `t/regex-assertion-outer-scalar-write.t`
+# pins the underlying behaviour.
 
-plan 8;
+plan 10;
 
 # 1. An assertion is re-evaluated per cursor position, and its own `my`
 #    declaration must be re-initialized every time rather than carried over.
@@ -46,3 +49,13 @@ is @seen.join(','), 'a1,b2,c3', "positional captures are re-bound per evaluation
 my @tries;
 ok ("aaaa" ~~ / a <?{ @tries.push: 1; @tries.elems == 3 }> a /).so,
    "assertion decided per cursor position, not once";
+
+# 6. The same, with an outer *scalar* counter: a cached compile must still carry
+#    each evaluation's write through to the caller's slot (#7593).
+my $scalar-count = 0;
+"aaaa" ~~ / [ <?{ $scalar-count++; True }> . ]+ /;
+is $scalar-count, 5, "a cached assertion writes an outer scalar once per position";
+
+my $second = 0;
+"bbb" ~~ / [ <?{ $second++; True }> . ]+ /;
+is $second, 4, "a second regex reusing the cache writes its own outer scalar";


### PR DESCRIPTION
An embedded `<?{ … }>` / `<!{ … }>` assertion that assigned to a scalar lexical declared outside the regex left the caller's variable untouched:

```raku
my $n = 0;
"aaaa" ~~ / [ <?{ $n++; True }> . ]+ /;
say $n;        # raku: 5      mutsu (before): 0
```

A plain `{ … }` block in the same position wrote back correctly, and so did a *mutation* of a container from inside an assertion (`@a.push(1)` — the caller's slot already shares that allocation). Only a scalar rebinding was lost, and it died with the match.

## Root cause

`eval_regex_inline_code`'s `writes_back_to_caller` flag. A plain block passes `true` and runs through `eval_regex_code_block_body`, which snapshots the env, diffs it by binding identity afterwards, and logs every rebound name into `pending_local_updates` so the VM refreshes the caller's compiled local slot. An assertion passed `false`, because ADR-0009 deliberately kept that path snapshot-free: an assertion is evaluated at *every cursor position*, and a full env snapshot plus identity diff per position is exactly the cost that path exists to avoid.

Leaving the write in `env` was enough for a later `$name` interpolation or assertion inside the same match to read it back, and enough for a mutated container, but nothing ever refreshed the caller's slot.

## The fix

The compiler already knows precisely which free variables a block assigns: `CompiledCode::free_var_writes`, the same set `eval_block_value_recording_writes` uses for a `where` clause. That is exactly what the env diff would have found, and it is computed at compile time — so an assertion that assigns nothing reports nothing and pays nothing, and the hot path keeps its ADR-0009 property.

`eval_block_value_cached_reporting_writes` runs the cached chunk and reports those names back; the regex layer owns the filtering policy it needs:

- the regex's own `:my` / `:let` lexicals, `$/` / `$¢` / `$0`…, the body's own `my` declarations and the `make` slot are regex-scoped and must not reach a caller slot;
- a body compiled inside `grammar G { … }` records the write under the auto-package-qualified `G::x` while `in_regex_code_block` redirects the write itself onto the bare lexical, so the package prefix is stripped before the two names are compared (the same adjustment `run.rs`'s deferred class/role body drain makes);
- a name already logged is skipped, which bounds the log by the number of distinct variables rather than by the number of cursor positions the assertion ran at — both drains key on the name and re-read the value from `env`.

## Tests

`t/regex-assertion-outer-scalar-write.t` (new) pins the positive and negative assertion forms, a plain assignment, the two shapes that already worked, a write surviving a failing match, an assertion's own `my` staying lexical, a routine-local slot, and a grammar token's assertion. Every assertion in it was checked against rakudo `v2026.07`.

`t/regex-inline-code-compile-cache.t` had routed its counters through `@` / `%` containers specifically to dodge this bug; it now pins the scalar forms too, so serving a cached compile cannot lose the per-evaluation writeback either.

## Verification

- `cargo fmt --all`, `make lint` — all four configurations green.
- `make test` — 3866 files, 41002 tests, `Result: PASS`.
- `make roast` — 1436 files, 218939 tests. The only failures are the three documented remote-container environment-only files, matching [`docs/agent-environments.md`](https://github.com/tokuhirom/mutsu/blob/main/docs/agent-environments.md) by name and subtest range: `roast/6.c/S32-io/file-tests.t` (`Failed: 4`, tests 6-8, 10), `roast/S16-filehandles/filetest.t` (`Failed: 25`, tests 57-64, 69-72, 77-80, 101/103/105/107/109/111/117/121/125) — both because the container runs as `uid 0` — and `roast/S32-io/IO-Socket-Async.t` (exit 124, "planned 40 ran 17", sandboxed network).

Closes #7593

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0122oqVGqfXxNqf9uJEABZvB

---
_Generated by [Claude Code](https://claude.ai/code/session_0122oqVGqfXxNqf9uJEABZvB)_