### PR TITLE
fix(raku): a lone `is Array` subclass element keeps its trailing comma

### DIFF
--- a/news/2026-09/array-subclass-element-raku-trailing-comma.md
+++ b/news/2026-09/array-subclass-element-raku-trailing-comma.md
@@ -1,0 +1,65 @@
+# A lone `is Array` subclass element gets its trailing comma back
+
+A real array holding a single Iterable element renders a trailing comma so the
+`.raku` round-trip does not flatten it — `[[1, 2],]`, `[1..5,]`. mutsu applied
+that rule to plain containers but not to an `is Array` / `is Hash` subclass
+instance:
+
+```raku
+class SA is Array { }
+my $c = SA.new(3, 2, 1, 4);
+my @h = $c;
+say @h.raku;
+# raku:  [[3, 2, 1, 4],]
+# mutsu: [[3, 2, 1, 4]]      <- was
+```
+
+`.elems` and `.^name` agreed on both, and the plain-container controls
+(`[[1, 2],].raku`, `my $p = [1,2]; my @q = $p; @q.raku`) were already correct —
+so this was purely the outer array's rendering, and only for that one element
+shape.
+
+## Root cause
+
+An instance's `.raku` needs interpreter method dispatch, so
+`Interpreter::expand_raku_leaves` renders such leaves itself and splices the
+resulting text back into the tree as a `raku_raw` placeholder before handing the
+tree to the pure renderer. That design is deliberate — its own doc comment says
+it exists "so every container keeps its exact bracket / itemization /
+trailing-comma rules instead of a duplicated walk having to re-derive them" —
+but the placeholder is a `Str`, and a `Str` is not Iterable. By the time
+`element_needs_trailing_comma` looked at the element, the one fact it needed had
+been erased.
+
+## The fix
+
+The placeholder now carries it. `RAKU_RAW_ITERABLE_KEY` is the twin marker for a
+leaf that itself does Iterable, and `expand_container` picks it via
+`raku_leaf_is_iterable` — an instance is container-backed exactly when it
+carries the `__mutsu_array_storage` / `__mutsu_hash_storage` attribute that every
+container method on it delegates to. `element_needs_trailing_comma` recognises
+that marker, and also handles a container-backed instance reaching it directly,
+for the paths that do not go through dispatch expansion.
+
+`t/array-subclass-element-raku-trailing-comma.t` pins it — including the
+non-Iterable instance, the two-element arity control and both plain-container
+controls — and passes under rakudo as well as mutsu.
+
+## Two rows split out rather than folded in
+
+The ticket listed two more divergences; both turned out to have different root
+causes, and both got their own issue:
+
+- [#7658](https://github.com/tokuhirom/mutsu/issues/7658) — `$d.raku` on a
+  scalar holding such an instance drops rakudo's `$` marker. Measurement shows
+  this is **not** subclass-specific: a plain `my $f = @b` loses it too, and the
+  semantics are already right (`my @z = $f, 3` does not flatten, `$($f).raku`
+  renders `$[1, 2]`). It is the scalar-assignment *store* not itemizing, which
+  is ADR-0040's territory, not a rendering row.
+- [#7660](https://github.com/tokuhirom/mutsu/issues/7660) — an explicit
+  `@h.gist` / `@h.Str` on such an array answers `SA()`, the element class's type
+  object. The ticket asked for `.gist` to be verified against rakudo before
+  touching it; it was, and mutsu is wrong. The implicit `say @h` is correct, so
+  it is an explicit-dispatch delegation bug, not a rendering one.
+
+Closes [#7594](https://github.com/tokuhirom/mutsu/issues/7594).

--- a/src/builtins/methods_0arg/raku_repr.rs
+++ b/src/builtins/methods_0arg/raku_repr.rs
@@ -171,14 +171,46 @@ pub(crate) fn format_num_str(f: f64) -> String {
 /// trailing-comma rules instead of a duplicated walk having to re-derive them.
 pub(crate) const RAKU_RAW_KEY: &str = "__mutsu_raku_raw";
 
+/// Twin of [`RAKU_RAW_KEY`] for a leaf that itself does `Iterable` -- an
+/// `is Array` / `is List` / `is Hash` subclass instance.
+///
+/// The rendered text alone cannot say whether the leaf was Iterable, and the
+/// container that splices it back in has to know: a real array holding one
+/// Iterable element renders a trailing comma (`[[3, 2, 1, 4],]`), which is
+/// exactly the rule the marker exists to preserve. Without the distinction the
+/// placeholder erased the element's Iterable-ness and the comma was dropped.
+pub(crate) const RAKU_RAW_ITERABLE_KEY: &str = "__mutsu_raku_raw_iterable";
+
 /// Wrap an already-rendered `.raku` fragment so `raku_value` emits it verbatim.
 pub(crate) fn raku_raw(rendered: String) -> Value {
     Value::pair(RAKU_RAW_KEY.to_string(), Value::str(rendered))
 }
 
+/// [`raku_raw`] for a leaf that does `Iterable`; see [`RAKU_RAW_ITERABLE_KEY`].
+pub(crate) fn raku_raw_iterable(rendered: String) -> Value {
+    Value::pair(RAKU_RAW_ITERABLE_KEY.to_string(), Value::str(rendered))
+}
+
+/// Whether a leaf whose `.raku` needs method dispatch is itself `Iterable`.
+///
+/// An `is Array` / `is List` / `is Hash` subclass instance keeps its elements
+/// in the backing-store attribute every container method on it delegates to;
+/// carrying that attribute is what makes the instance container-backed at all.
+pub(crate) fn raku_leaf_is_iterable(v: &Value) -> bool {
+    match v.view() {
+        ValueView::Instance { attributes, .. } => {
+            attributes.contains_key("__mutsu_array_storage")
+                || attributes.contains_key("__mutsu_hash_storage")
+        }
+        _ => false,
+    }
+}
+
 fn raku_raw_repr(v: &Value) -> Option<String> {
     match v.view() {
-        ValueView::Pair(name, inner) if name == RAKU_RAW_KEY => Some(inner.to_string_value()),
+        ValueView::Pair(name, inner) if name == RAKU_RAW_KEY || name == RAKU_RAW_ITERABLE_KEY => {
+            Some(inner.to_string_value())
+        }
         _ => None,
     }
 }
@@ -350,6 +382,14 @@ fn element_needs_trailing_comma(v: &Value) -> bool {
                 | "Stash"
                 | "PseudoStash"
         ),
+        // An `is Array` / `is List` / `is Hash` subclass instance does
+        // Iterable just as much as the container it wraps, so it takes the
+        // same trailing comma: rakudo renders `my @h = SA.new(3, 2, 1, 4)` as
+        // `[[3, 2, 1, 4],]`. Such a leaf usually arrives here already replaced
+        // by the dispatch placeholder, which carries the same fact under
+        // `RAKU_RAW_ITERABLE_KEY`; this arm covers the direct-render path.
+        ValueView::Pair(name, _) if name == RAKU_RAW_ITERABLE_KEY => true,
+        ValueView::Instance { .. } => raku_leaf_is_iterable(v),
         _ => false,
     }
 }

--- a/src/runtime/methods_raku_dispatch.rs
+++ b/src/runtime/methods_raku_dispatch.rs
@@ -15,7 +15,9 @@
 //! tree as a `raku_raw` marker that `raku_value` emits verbatim.
 
 use super::Interpreter;
-use crate::builtins::methods_0arg::raku_repr::{needs_raku_dispatch, raku_raw};
+use crate::builtins::methods_0arg::raku_repr::{
+    needs_raku_dispatch, raku_leaf_is_iterable, raku_raw, raku_raw_iterable,
+};
 use crate::value::{ArrayData, HashData, RuntimeError, Value, ValueView};
 
 /// Depth cap for the walk. Cycles are caught by container identity (below);
@@ -166,7 +168,18 @@ impl Interpreter {
     fn expand_container(&mut self, value: &Value, active: &mut Vec<usize>, depth: usize) -> Value {
         if needs_raku_dispatch(value) {
             return match self.dispatch_raku_leaf(value) {
-                Ok(rendered) => raku_raw(rendered.to_string_value()),
+                // The placeholder has to remember whether the leaf was
+                // Iterable: the container splicing it back in applies raku's
+                // trailing-comma rule to a lone Iterable element, and the
+                // rendered text alone cannot say.
+                Ok(rendered) => {
+                    let text = rendered.to_string_value();
+                    if raku_leaf_is_iterable(value) {
+                        raku_raw_iterable(text)
+                    } else {
+                        raku_raw(text)
+                    }
+                }
                 Err(_) => value.clone(),
             };
         }

--- a/t/array-subclass-element-raku-trailing-comma.t
+++ b/t/array-subclass-element-raku-trailing-comma.t
@@ -1,0 +1,64 @@
+use Test;
+
+# A real array with a single Iterable element renders a trailing comma, so the
+# `.raku` round-trip does not flatten it. An `is Array` / `is Hash` subclass
+# instance does Iterable too, but it reaches `.raku` through method dispatch:
+# the leaf is rendered by the interpreter and spliced back in as a placeholder,
+# and the placeholder used to erase the fact that the leaf was Iterable.
+
+plan 9;
+
+class SA is Array { }
+class SH is Hash { }
+class P { has $.x }
+
+# The instance has to arrive through a scalar: `my @h = SA.new(...)` flattens
+# its elements, exactly as `my @h = [1, 2]` would.
+{
+    my $c = SA.new(3, 2, 1, 4);
+    my @h = $c;
+    is @h.elems, 1, 'an Array subclass instance is stored as one element';
+    is @h.raku, '[[3, 2, 1, 4],]', 'and a lone one renders with the trailing comma';
+}
+
+{
+    my $h = SH.new;
+    $h<k> = 1;
+    my @c = $h;
+    is @c.raku, '[{:k(1)},]', 'a lone Hash subclass instance renders with it too';
+}
+
+# A non-Iterable instance must NOT gain one.
+{
+    my $p = P.new(x => 1);
+    my @d = $p;
+    is @d.raku, '[P.new(x => 1)]', 'a plain instance element takes no trailing comma';
+}
+
+# Arity is still part of the rule: two elements never take one.
+{
+    my @b = [SA.new(1, 2), 3];
+    is @b.raku, '[[1, 2], 3]', 'a two-element array takes no trailing comma';
+}
+
+{
+    my ($s1, $s2) = SA.new(1), SA.new(2);
+    my @two = $s1, $s2;
+    is @two.raku, '[[1], [2]]', 'two subclass instances take no trailing comma either';
+}
+
+# The controls that were already correct, so the fix cannot regress them.
+{
+    is [[1, 2],].raku, '[[1, 2],]', 'a lone plain array element still renders the comma';
+}
+
+{
+    my $p = [1, 2];
+    my @q = $p;
+    is @q.raku, '[[1, 2],]', 'a lone array through a scalar still renders the comma';
+}
+
+{
+    my @e = 1;
+    is @e.raku, '[1]', 'a lone non-Iterable element takes no trailing comma';
+}


### PR DESCRIPTION
A real array holding a single Iterable element renders a trailing comma so the
`.raku` round-trip does not flatten it — `[[1, 2],]`, `[1..5,]`. mutsu applied
that rule to plain containers but not to an `is Array` / `is Hash` subclass
instance:

```raku
class SA is Array { }
my $c = SA.new(3, 2, 1, 4);
my @h = $c;
say @h.raku;
# raku:  [[3, 2, 1, 4],]
# mutsu: [[3, 2, 1, 4]]      <- was
```

`.elems` and `.^name` agreed on both, and the plain-container controls
(`[[1, 2],].raku`, `my $p = [1,2]; my @q = $p; @q.raku`) were already correct —
so this was purely the outer array's rendering, and only for that one element
shape.

## Root cause

An instance's `.raku` needs interpreter method dispatch, so
`Interpreter::expand_raku_leaves` renders such leaves itself and splices the
resulting text back into the tree as a `raku_raw` placeholder before handing the
tree to the pure renderer. That design is deliberate — its own doc comment says
it exists *"so every container keeps its exact bracket / itemization /
trailing-comma rules instead of a duplicated walk having to re-derive them"* —
but the placeholder is a `Str`, and a `Str` is not Iterable. By the time
`element_needs_trailing_comma` looked at the element, the one fact it needed had
been erased.

## The fix

The placeholder now carries it. `RAKU_RAW_ITERABLE_KEY` is the twin marker for a
leaf that itself does Iterable, chosen by `raku_leaf_is_iterable` — an instance
is container-backed exactly when it carries the `__mutsu_array_storage` /
`__mutsu_hash_storage` attribute that every container method on it delegates to.
`element_needs_trailing_comma` recognises that marker, and also a
container-backed instance reaching it directly, for the paths that do not go
through dispatch expansion.

## Two rows split out rather than folded in

The ticket listed two more divergences; both turned out to have **different root
causes**, and both got their own issue with the measurements:

- **#7658** — `$d.raku` on a scalar holding such an instance drops rakudo's `$`
  marker. Measurement shows this is *not* subclass-specific: a plain
  `my $f = @b; say $f.raku` loses it too, while the semantics are already right
  (`my @z = $f, 3` does not flatten, `$($f).raku` renders `$[1, 2]`, `my $g := @b`
  correctly does *not* itemize). It is the scalar-assignment **store** not
  itemizing — ADR-0040's territory — not a rendering row.
- **#7660** — an explicit `@h.gist` / `@h.Str` on such an array answers `SA()`,
  the element class's type object. The ticket asked for `.gist` to be verified
  against rakudo before touching it; it was, and mutsu is wrong. The implicit
  `say @h` is correct, so it is an explicit-dispatch delegation bug, not a
  rendering one.

## Tests

`t/array-subclass-element-raku-trailing-comma.t` — 9 subtests: the repro, an
`is Hash` subclass element, a non-Iterable instance element (must **not** gain a
comma), two arity controls, and both plain-container controls. It passes under
**`raku` as well as `mutsu`**.

`t/array-subclass-value-position-assign.t` (the pin the ticket names) passes
unchanged.

`cargo fmt --all`, `make lint`, `make test` (PASS, 41020 tests) and `make roast`
were run locally on this tree. `make roast`'s only red files are the three
environment-only ones this container cannot pass, with exactly the shapes
documented in `docs/agent-environments.md`.

Closes #7594

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TAdHjoCdB8QjLBEDy87tXS

---
_Generated by [Claude Code](https://claude.ai/code/session_01TAdHjoCdB8QjLBEDy87tXS)_