### PR TITLE
fix(vm): compile `@`/`%` reads to a slot (ADR-0039 slice 2)

### DIFF
--- a/docs/adr/0039-container-lexicals-resolve-lexically.md
+++ b/docs/adr/0039-container-lexicals-resolve-lexically.md
@@ -21,7 +21,10 @@
   green `prove t/` AND a green full `make roast` with the flip on, and was
   stopped by the bundled-library battery gate. §12 records what it measured, the
   seven repairs it needed, and the one blocker left; the work item carries the
-  re-derivable detail.
+  re-derivable detail. **Attempt 4 (2026-09-08) LANDED the read side** — see
+  §13, which also records that §12's recorded blocker did not survive
+  re-measurement and should not be planned around. §4.2's second and third
+  bullets remain.
 - Date: 2026-08-20
 - Related: ADR-0013 (container interior mutability — `gc_contents_mut`),
   ADR-0024 (mainline lexicals for named subs — the scalar half of this bug),
@@ -1088,3 +1091,66 @@ shadow.
 **Process note for attempt 4.** `t/` and `make roast` are not sufficient evidence
 for this change — both were green. `scripts/battery-testsuite.sh` is, and it runs
 locally in about ten minutes.
+
+## 13. Attempt 4 (2026-09-08): slice 2's read side is LANDED
+
+The read flip shipped. `Expr::ArrayVar` / `Expr::HashVar` emit `GetLocal(slot)`
+for a plain user lexical (`Compiler::container_read_slot`), and §4.2's first
+bullet is done. `prove t/`, a full local `make roast` and the bundled-library
+battery gate are all green with it on. What is left of §4.2 is its second and
+third bullets (`compute_upvalues`'s `@`/`%` exclusion, and the unconditional env
+mirror on every container `SetLocal`); the container special cases §4.2 predicted
+could then be *deleted* are now deletable but have not been deleted.
+
+**§12's re-derivable detail was the whole reason this attempt worked**, and its
+own advice — re-measure, do not plan around a recorded diagnosis — again earned
+its keep. Of §12's two battery blockers, the zef one did not reproduce at all
+once the six unlanded repairs were re-derived (differently, in two cases), and
+the Cro one failed for a reason unrelated to the `gather`/atomic-lane story §12
+recorded. **That story should not be planned around**: no evidence for it
+survives this attempt.
+
+**The blocker that was actually there is `GetLocal`'s bare-name store probe.**
+§12 got the *class* of defect right and one instance of it: the lane probe
+ordering, fixed by the cell-identity gate. The second instance is its neighbour,
+and it is a preference-vs-fallback distinction rather than an ordering one.
+`get_env_with_main_alias_inner` — the by-name read this op replaces — gates its
+own `shared_vars` base-name probe on `is_thread_clone()` and otherwise reads
+`env` first, so on the main thread that store is a *fallback*. `GetLocal`'s
+`@`/`%` arm preferred it unconditionally. That is invisible while the by-name
+read answers, and wrong the moment the slot does: `shared_vars` is keyed by bare
+name process-wide, and `mask_thread_redeclared_params` deliberately leaves a
+plain non-slurpy `@`/`%` **parameter** unmasked precisely so its entry can serve
+as a fallback for a nested spawn that did not capture the name lexically. So
+`Cro::HTTP`'s `method !append-middleware(Supply $pipeline, @middleware, ...)`
+read a *different* handler's `@middleware` in 17 of 36 calls, the before-matched
+auth middleware never ran, and every request 401'd. Aligning the two read paths
+is the repair.
+
+**The reduction harness is worth keeping, and it is kept.**
+`MUTSU_SLOT_READ_DUMP` prints every name the flip applies to;
+`MUTSU_SLOT_READ_FILTER` restricts the flip to a comma-separated list. Setting
+the filter to a name that does not exist turns the flip off wholesale, which is
+also the cheapest way to ask "is this failure mine?" without a rebuild. ddmin
+over the 95 names a Cro::HTTP run touches took about four minutes to reach one
+name. Both are inert when unset.
+
+**Container identity generalised once more.** §12 named
+`store_container_preserving_identity` as the primitive; this attempt factored its
+kind-matching core out as `container_rebuild_in_place` and applied it at two more
+sites — the mutating-hyper writeback (§12's repair 6) and
+`overwrite_{array,hash}_bindings_by_identity`, whose by-name `env` sweep plus
+`pending_rw_writeback_sources` drain could not reach a `:=`-bound alias's slot at
+all (`t/attribute-accessor-container-identity.t` 5/7). The rule now has six call
+sites and no counterexample: **a runtime helper that rebuilds a variable's
+container copies the result into the existing backing node; every by-name slot
+search such a helper uses to "also update the slot" is both unnecessary and wrong
+under a shadow.** Its one exception is worth recording because it was measured:
+a helper whose caller RETURNS the pre-mutation container (`$b>>--` on a
+QuantHash) must not write in place, because the returned value shares the node —
+hence the mutating-hyper writeback is restricted to an `@`/`%` target.
+
+**Process note for whoever takes §4.2's remaining bullets.** `t/` and `make
+roast` are still not sufficient evidence for a change in this area — both were
+green for attempt 3 too. `scripts/battery-testsuite.sh` is, and it runs locally
+in about ten minutes.

--- a/news/2026-09/container-reads-compile-to-a-slot.md
+++ b/news/2026-09/container-reads-compile-to-a-slot.md
@@ -1,0 +1,100 @@
+# `@`/`%` reads compile to a slot — ADR-0039 slice 2 lands
+
+A container read (`Expr::ArrayVar` / `Expr::HashVar`) used to compile to a
+by-name `GetArrayVar` / `GetHashVar` where a scalar read compiles to
+`GetLocal(slot)`. Container lexical scoping was therefore *dynamic*: every
+same-named declaration anywhere in the process — a consumer's `my`, an inner
+block's shadow, a sibling routine's local — could hijack the name, because the
+read re-resolved it against whatever `env` happened to hold. A plain user
+lexical container now resolves through its slot, exactly as a scalar does.
+
+This is ADR-0039 §4.2's first bullet, and the fourth attempt at it. Attempts 1-3
+were each withdrawn; §12 recorded attempt 3's seven repairs in enough detail to
+be **re-derived rather than re-measured**, which is what this one did.
+
+## Why the by-name read had to go
+
+It was not only wrong in itself, it *hid store-lane bugs*: two paths that end up
+naming different containers under one name look fine as long as every read
+re-resolves the name. Six of the repairs below are real bug fixes that simply had
+no observable symptom while the read stayed by-name.
+
+## The restriction is a requirement, not a safety margin
+
+The flip covers **plain user lexicals** only (`env::is_plain_user_lexical` on the
+sigiled name). The by-name read's tail is load-bearing for every other shape: its
+`None` arm supplies the empty container that makes `%_` read as `{}` on the fast
+method-dispatch path that deliberately leaves it unbound, and its cascade is the
+only route by which `%!attr`/`%.attr` reach `self`'s attribute cell and `@*dyn` /
+`%?RESOURCES` / `::`-qualified names resolve at all. Those are not lexical
+bindings of the frame; slice 2 is about the ones that are. Any future widening
+has to supply those behaviours first.
+
+## What was repaired
+
+1. **`GetLocal` must not prefer a name-keyed store over this frame's own
+   binding.** Two separate corrections. Its `@`/`%` arms consult the
+   `__mutsu_atomic_*` lanes before the slot; when the slot holds the very
+   `ContainerRef` cell that `env` names, that ordering is backwards, so the lane
+   probe is skipped on cell identity. And its *bare-name* `shared_vars` probe was
+   an unconditional **preference** where the by-name read it replaces treats the
+   same store as a **fallback** (`get_env_with_main_alias_inner` gates its
+   base-name probe on `is_thread_clone`, reading `env` first otherwise). It is
+   now gated the same way; the Nil arm at the end of the op already supplies the
+   fallback.
+2. **An expression-position container declaration takes the slot the read
+   resolves to.** `local_map` is monotonic, so a popped sibling block's `@a` slot
+   stays reachable and `{ my @a = 5,7,9 } (my @a).push: $_ for ^3` stored into
+   `env` alone.
+3. **`try_fast_hash_element_assign` uses its compiler-baked `target_slot`.**
+   `find_local_slot` is a `position` search, so with a same-named shadow
+   (`code.locals == ["%h", "%h"]`) it nil'd and re-seeded the OUTER binding.
+4. **`write_back_hyper_target_var` writes THROUGH the container node.** Its
+   fallback did `set_env_with_main_alias` plus a by-name `locals_set_by_name`,
+   which under a shadow wrote the outer slot and made `@r»++` answer `1 2 3`.
+   Mutating the existing node reaches every holder and needs no slot search —
+   which is why a baked `HyperMethodCall` target slot turned out to be
+   unnecessary. Restricted to an `@`/`%` target: a scalar-held QuantHash
+   (`$b>>--`) RETURNS the original, and that return value shares the node.
+5. **The `is BagHash`/`SetHash`/`MixHash` trait handler re-syncs its slot** after
+   registering the name-keyed constraint, which re-tags `env`'s value through
+   `Gc::make_mut` and so COPIES a node the slot shares.
+6. **`overwrite_{array,hash}_bindings_by_identity` preserve container
+   identity.** They replaced every `env` entry holding the old node with a fresh
+   one and relied on a name-keyed writeback drain to reach the local slots. They
+   now copy the rebuild into the original node first, so a local slot, a
+   by-value capture and a `:=` alias all observe an element store made through
+   an accessor.
+
+`store_container_preserving_identity`'s Set/Bag/Mix arms — attempt 3's seventh
+repair — had already shipped on their own.
+
+## The blocker attempt 3 left, and the one this attempt found
+
+Attempt 3 reached a green `prove t/` and a green `make roast` and was stopped by
+the bundled-library battery gate on `Cro::HTTP/router-auth.rakutest` and
+`zef/distribution-depends-parsing.rakutest`. Its diagnosis — a `gather` body's
+container append reaching the atomic lane instead of the owner's cell — did not
+survive this attempt's differently-derived repairs: the zef file passes
+unchanged, and the Cro file failed for an unrelated reason.
+
+The reduction harness §12 asked for was rebuilt and is kept:
+`MUTSU_SLOT_READ_DUMP` prints every name the flip applies to, and
+`MUTSU_SLOT_READ_FILTER` restricts the flip to a comma-separated list of them.
+Delta debugging over the 95 names a Cro run touches reduced the failure to a
+single one, `@middleware`, in about four minutes — after which a slot-vs-env
+probe showed the slot and `env` agreeing on this frame's binding in all 36 calls
+while `shared_vars` held a *different* handler's array, and `GetLocal` answered
+the store in 17 of them. Repair 1's second half is that finding. Note the shape:
+a plain non-slurpy `@` parameter is deliberately left unmasked by
+`mask_thread_redeclared_params` precisely so its bare-name entry can serve as a
+*fallback* for a nested spawn — which is exactly why preferring it was wrong.
+
+## Acceptance
+
+`prove t/` (3861 files, 40929 tests), a full local `make roast`, and
+`MUTSU_BIN=target/release/mutsu scripts/battery-testsuite.sh` are all green with
+the flip on. `t/nested-frame-container-mutation-reaches-owner.t` and
+`t/container-lexical-declarator-matrix.t` keep passing, and the repairs above are
+pinned by `t/container-slot-read-repairs.t` plus
+`t/attribute-accessor-container-identity.t`.

--- a/src/compiler/expr.rs
+++ b/src/compiler/expr.rs
@@ -155,6 +155,12 @@ impl Compiler {
             }
             Expr::ArrayVar(name) => {
                 let sigiled = format!("@{}", name);
+                // ADR-0039 slice 2: a plain lexical container read resolves
+                // through its slot, exactly as a scalar read does.
+                if let Some(slot) = self.container_read_slot(&sigiled) {
+                    self.code.emit(OpCode::GetLocal(slot));
+                    return;
+                }
                 let var_name = if self.local_map.contains_key(sigiled.as_str()) {
                     sigiled
                 } else {
@@ -191,6 +197,11 @@ impl Compiler {
                     return;
                 }
                 let sigiled = format!("%{}", name);
+                // ADR-0039 slice 2 — see the `ArrayVar` twin above.
+                if let Some(slot) = self.container_read_slot(&sigiled) {
+                    self.code.emit(OpCode::GetLocal(slot));
+                    return;
+                }
                 let var_name = if self.local_map.contains_key(sigiled.as_str()) {
                     sigiled
                 } else {

--- a/src/compiler/expr_block.rs
+++ b/src/compiler/expr_block.rs
@@ -182,8 +182,18 @@ impl Compiler {
                 // (including a captured ContainerRef cell) from being overwritten.
                 let decl_slot = if !*is_our && !is_promoted && predeclared_shadow {
                     self.local_map.get(name).copied()
+                } else if !*is_our
+                    && !is_promoted
+                    && (shadows_outer || Self::container_slot_read_applies(name))
+                {
+                    // ADR-0039 slice 2: a container declaration in expression
+                    // position must take the slot its own READS resolve to —
+                    // see `Compiler::container_slot_read_applies`. Without it
+                    // `(my @a)` stored into `env` alone while a popped
+                    // sibling's slot answered every read of the name.
+                    Some(self.declare_local(name))
                 } else {
-                    (!*is_our && !is_promoted && shadows_outer).then(|| self.declare_local(name))
+                    None
                 };
                 if decl_slot.is_some() {
                     let name_idx = self.code.add_constant(Value::str(name.clone()));
@@ -293,6 +303,19 @@ impl Compiler {
                         self.code.emit(OpCode::MarkExplicitInitializerContext);
                     }
                     self.code.emit(OpCode::MarkVarDeclContext);
+                    // A shaped declaration (`(my @b[3] = <a b c>)`) keeps its
+                    // declared shape; mark it so the `SetLocal` store does not
+                    // strip the shape the way an unshaped value-copy
+                    // (`my @u = @shaped`) does. The statement-position decl
+                    // emits the identical mark. Only reachable since ADR-0039
+                    // slice 2 gave a plain container decl in expression
+                    // position a slot: the `SetGlobal` route never needed it
+                    // (`roast/S06-signature/shape.t` 36-37).
+                    if decl_slot.is_some()
+                        && custom_traits.iter().any(|(t, _)| t == "__shaped_decl")
+                    {
+                        self.code.emit(OpCode::MarkShapedDeclContext);
+                    }
                     if let Some(slot) = decl_slot {
                         self.code.emit(OpCode::SetLocal(slot));
                     } else {

--- a/src/compiler/expr_helpers.rs
+++ b/src/compiler/expr_helpers.rs
@@ -801,3 +801,81 @@ impl Compiler {
         self.code.patch_smart_match_rhs_end(sm_idx);
     }
 }
+
+/// ADR-0039 slice 2 reduction harness. `MUTSU_SLOT_READ_FILTER` restricts the
+/// container read flip to a comma-separated list of sigiled names;
+/// `MUTSU_SLOT_READ_DUMP` prints every name the flip would apply to. Together
+/// they turn "a 3000-line vendored library misbehaves" into "one variable" by
+/// delta debugging over the names a run touches — the reduction that found
+/// attempt 3's blocker (see ADR-0039 §12). Both are inert when unset.
+fn slot_read_filter() -> Option<&'static Vec<String>> {
+    static FILTER: std::sync::OnceLock<Option<Vec<String>>> = std::sync::OnceLock::new();
+    FILTER
+        .get_or_init(|| {
+            std::env::var("MUTSU_SLOT_READ_FILTER").ok().map(|raw| {
+                raw.split(',')
+                    .map(|s| s.trim().to_string())
+                    .filter(|s| !s.is_empty())
+                    .collect()
+            })
+        })
+        .as_ref()
+}
+
+fn slot_read_dump_enabled() -> bool {
+    static DUMP: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *DUMP.get_or_init(|| std::env::var("MUTSU_SLOT_READ_DUMP").is_ok())
+}
+
+impl Compiler {
+    /// ADR-0039 slice 2: the local slot an `@`/`%` READ resolves to, or `None`
+    /// when the read must stay on the by-name `GetArrayVar`/`GetHashVar` path.
+    ///
+    /// A container read compiled to `GetLocal(slot)` is what makes container
+    /// lexical scoping *lexical*: a same-named declaration in an unrelated
+    /// scope can no longer hijack it, because the read never consults `env` by
+    /// name (§1.2, §4.2 first bullet).
+    ///
+    /// The flip is restricted to **plain user lexicals**, and that restriction
+    /// is a requirement rather than a safety margin (§12). The by-name read's
+    /// tail is load-bearing for every other shape: its `None` arm supplies the
+    /// empty container that makes `%_` read as `{}` on the fast
+    /// method-dispatch path that deliberately leaves it unbound, and its
+    /// cascade is the only route by which `%!attr`/`%.attr` reach `self`'s
+    /// attribute cell and `@*dyn` / `%?RESOURCES` / `::`-qualified names
+    /// resolve at all. Those are not lexical bindings of this frame; slice 2 is
+    /// about the ones that are. Any future widening has to supply those
+    /// behaviours first.
+    pub(super) fn container_read_slot(&self, sigiled: &str) -> Option<u32> {
+        if !Self::container_slot_read_applies(sigiled) {
+            return None;
+        }
+        let &slot = self.local_map.get(sigiled)?;
+        if slot_read_dump_enabled() {
+            eprintln!("mutsu-slot-read: {sigiled}");
+        }
+        Some(slot)
+    }
+
+    /// Whether ADR-0039 slice 2's read flip covers `sigiled` at all — the
+    /// name-shape predicate of [`Compiler::container_read_slot`], without
+    /// requiring that a slot already exists.
+    ///
+    /// The declaration side has to ask the same question: a container
+    /// declaration compiled in EXPRESSION position (`(my @a).push: ...`)
+    /// allocated no slot unless it shadowed an active outer, storing into `env`
+    /// alone. `local_map` is monotonic in the default build, so a popped
+    /// sibling block's `@a` slot stays reachable and the read resolved to a
+    /// slot the declaration never wrote (`{ my @a = 5,7,9 } (my @a).push: $_
+    /// for ^3`). `declare_local` resolves get-or-create by name in the default
+    /// build, so declaring here reuses the very slot the read resolves to.
+    pub(super) fn container_slot_read_applies(sigiled: &str) -> bool {
+        if !sigiled.starts_with(['@', '%']) || !crate::env::is_plain_user_lexical(sigiled) {
+            return false;
+        }
+        match slot_read_filter() {
+            Some(filter) => filter.iter().any(|n| n == sigiled),
+            None => true,
+        }
+    }
+}

--- a/src/runtime/methods_mut.rs
+++ b/src/runtime/methods_mut.rs
@@ -350,6 +350,21 @@ impl Interpreter {
         needle: &crate::gc::Gc<crate::value::ArrayData>,
         replacement: Value,
     ) {
+        // ADR-0039 slice 2: copy the replacement's contents into `needle`
+        // ITSELF first, so every holder of that node observes the element
+        // write — a local slot, a by-value capture, a `:=` alias — not just the
+        // `env` keys the by-name sweep below can see. The sweep still runs, to
+        // give each env entry the replacement's array KIND and to reach any
+        // holder that has already moved off this node; but it is no longer the
+        // only route, which is what `$h.bag[2] = 'x'` needed: the mutation
+        // replaced `env`'s `@alias` while the binding's own slot kept the
+        // original node (`t/attribute-accessor-container-identity.t` 5/7).
+        let replacement = match replacement.view() {
+            ValueView::Array(new_gc, kind) if !crate::gc::Gc::ptr_eq(needle, &new_gc) => {
+                Self::array_inplace_reassign_inheriting_meta(needle, &new_gc, kind)
+            }
+            _ => replacement,
+        };
         let mut keys: Vec<Symbol> = Vec::new();
         // Slice 2a: a `=`-array-shared scalar (`my $n = @z`) holds the array
         // inside a shared `ContainerRef` cell, so its inner Arc — not the
@@ -393,6 +408,13 @@ impl Interpreter {
         needle: &crate::gc::Gc<crate::value::HashData>,
         replacement: Value,
     ) {
+        // ADR-0039 slice 2 — see the array counterpart above.
+        let replacement = match replacement.view() {
+            ValueView::Hash(new_gc) if !crate::gc::Gc::ptr_eq(needle, &new_gc) => {
+                Self::hash_inplace_reassign_inheriting_meta(needle, &new_gc)
+            }
+            _ => replacement,
+        };
         let mut keys: Vec<Symbol> = Vec::new();
         let mut cells: Vec<crate::gc::Gc<crate::value::ContainerCell>> = Vec::new();
         for (name, value) in self.env.iter() {

--- a/src/vm/vm_hyper_method_ops.rs
+++ b/src/vm/vm_hyper_method_ops.rs
@@ -387,6 +387,28 @@ impl Interpreter {
             *cell.lock().unwrap() = new_val;
             return;
         }
+        // ADR-0039 slice 2: otherwise write THROUGH the existing container
+        // node. The old fallback was `set_env_with_main_alias` plus
+        // `locals_set_by_name`, and the latter is a `position` search over
+        // `code.locals` — so under a same-named shadow (a file-scope `my @r;`
+        // plus a block's own `my @r = (1,2,3)`) it wrote the OUTER slot and
+        // `@r»++` answered `1 2 3`. Copying the result into the node the
+        // binding already holds reaches every holder — the slot, a by-value
+        // capture, a `:=` alias — and needs no slot search at all. That is also
+        // why a compiler-baked `HyperMethodCall` target slot is unnecessary
+        // here.
+        //
+        // Restricted to an `@`/`%` target on purpose. A scalar-held QuantHash
+        // (`my $b := <a b>.BagHash; $b>>--`) must keep its node: the hyper
+        // RETURNS the original QuantHash, and that return value shares the very
+        // node an in-place overwrite would rewrite (`t/hyper-postfix-quanthash.t`
+        // "returns the original").
+        if var.starts_with(['@', '%'])
+            && let Some(current) = self.get_env_with_main_alias(var)
+            && Self::container_rebuild_in_place(&current.into_deref(), &new_val).is_some()
+        {
+            return;
+        }
         self.set_env_with_main_alias(var, new_val.clone());
         self.locals_set_by_name(code, var, new_val);
     }

--- a/src/vm/vm_var_assign_element.rs
+++ b/src/vm/vm_var_assign_element.rs
@@ -222,6 +222,7 @@ impl Interpreter {
         code: &CompiledCode,
         name_idx: u32,
         _is_positional: bool,
+        target_slot: Option<u32>,
     ) -> Option<Result<(), RuntimeError>> {
         // Reject if there are any local bind pairs (`:=` bindings in scope)
         if !self.local_bind_pairs.is_empty() {
@@ -332,8 +333,15 @@ impl Interpreter {
                     return None;
                 }
                 let local_slot = if strong_count == 2 {
-                    // The extra ref should be from locals — verify
-                    match self.find_local_slot(code, var_name) {
+                    // The extra ref should be from locals — verify.
+                    //
+                    // ADR-0039 slice 2: through the compiler-baked
+                    // `target_slot`, never a by-name search. `find_local_slot`
+                    // is a `position` over `code.locals`, so with a same-named
+                    // shadow (`code.locals == ["%h", "%h"]`) it answered the
+                    // OUTER binding's slot — which this path then nil'd and
+                    // re-seeded, corrupting a variable the store never touched.
+                    match self.resolve_local_slot(code, target_slot, var_name) {
                         Some(slot) => Some(slot),
                         None => return None,
                     }
@@ -411,7 +419,7 @@ impl Interpreter {
                 // default build's blanket reconcile makes it redundant (byte-
                 // identical) — it only matters on the single-store path.
                 if local_slot.is_none()
-                    && let Some(slot) = self.find_local_slot(code, var_name)
+                    && let Some(slot) = self.resolve_local_slot(code, target_slot, var_name)
                     && let Some(env_val) = self.env().get_sym(var_sym).cloned()
                 {
                     self.locals[slot] = env_val;
@@ -922,7 +930,9 @@ impl Interpreter {
         // --- Fast path for simple hash element assignment ---
         // Handles the common case: %h{$key} = $val with no type constraints,
         // no binding, no special containers. Skips ~16 HashMap lookups.
-        if let Some(result) = self.try_fast_hash_element_assign(code, name_idx, is_positional) {
+        if let Some(result) =
+            self.try_fast_hash_element_assign(code, name_idx, is_positional, target_slot)
+        {
             return result;
         }
         // Save type metadata and container default by pointer BEFORE the

--- a/src/vm/vm_var_assign_local_get.rs
+++ b/src/vm/vm_var_assign_local_get.rs
@@ -192,8 +192,37 @@ impl Interpreter {
         // them would resurrect a foreign container over this frame's own `my
         // @a` (the write side is masked in `set_shared_var_sym`; this is its
         // read twin, mirroring the scalar gate further down).
-        let container_redeclared = self.container_name_is_redeclared(name);
-        if container_redeclared {
+        //
+        // Nor does any of it apply while THIS FRAME'S SLOT holds the very
+        // `ContainerRef` cell that `env` names under this key (ADR-0039 slice
+        // 2). `get_env_with_main_alias` has always preferred that cell — its
+        // first act is `unit_scope_lexical`, before its `_inner`'s lane probe —
+        // so once an `@`/`%` read resolves through its slot, consulting the
+        // name-keyed lanes FIRST is backwards: the lane entry is keyed by bare
+        // name across the whole process, and it wins over the binding this
+        // frame actually holds.
+        //
+        // Both neighbouring conditions were measured and are wrong. "the slot
+        // holds any cell" breaks `roast/S32-io/IO-Socket-Async.t` 37 — a
+        // `supply`/tap body's shared block lexical is cell-boxed too, but the
+        // lane does not write through that cell, so a tap callback's
+        // `@got.append` lands in the lane and in `env` while the cell stays
+        // empty. "the slot holds the *unit-lexical* cell" excludes the
+        // `my %h; await (^3).map: -> $i { start { %h{$i} = $i } }` case the
+        // gate exists for. The condition that holds is the identity one below:
+        // the slot's cell is still what this frame's `env` names.
+        let slot_cell_is_env_binding = (name.starts_with('@') || name.starts_with('%'))
+            && match self.locals[idx].view() {
+                ValueView::ContainerRef(slot_cell) => matches!(
+                    self.env().get(name).map(Value::view),
+                    Some(ValueView::ContainerRef(env_cell))
+                        if crate::gc::Gc::ptr_eq(&slot_cell, &env_cell)
+                ),
+                _ => false,
+            };
+        let skip_name_keyed_store =
+            slot_cell_is_env_binding || self.container_name_is_redeclared(name);
+        if skip_name_keyed_store || !crate::runtime::shared_store::atomic_lane_entries_exist() {
             // fall through to the local/env read
         } else if name.starts_with('@') {
             let atomic_key = format!("__mutsu_atomic_arr::{name}");
@@ -210,10 +239,28 @@ impl Interpreter {
                 return Ok(());
             }
         }
-        // Shared @/% variables may be mutated by sibling threads while this Interpreter
-        // still holds an old local snapshot. Prefer the shared copy so reads
-        // observe the latest value without forcing array COW on every push.
-        if !container_redeclared
+        // A THREAD CLONE's `@`/`%` may have been mutated by a sibling thread
+        // while this Interpreter still holds an old local snapshot, so prefer
+        // the shared copy there — reads observe the latest value without
+        // forcing array COW on every push.
+        //
+        // ADR-0039 slice 2: only there. On the main thread the bare-name store
+        // is a FALLBACK, not a preference — that is exactly how the by-name
+        // read this op replaces treats it (`get_env_with_main_alias_inner`
+        // gates its own base-name probe on `is_thread_clone` and otherwise
+        // reads `env` first), and the Nil arm at the bottom of this function
+        // already supplies the fallback. Preferring it here made a read of a
+        // frame's OWN binding answer an unrelated frame's: `shared_vars` is
+        // keyed by bare name process-wide, and a plain non-slurpy `@`/`%`
+        // parameter is deliberately left unmasked by
+        // `mask_thread_redeclared_params` precisely because that entry is
+        // meant to serve as a fallback for a nested spawn. Cro::HTTP's
+        // `method !append-middleware(Supply $pipeline, @middleware, ...)` read
+        // a *different* handler's `@middleware` in 17 of 36 calls, so the
+        // before-matched auth middleware never ran and every request 401'd
+        // (`Cro::HTTP/router-auth.rakutest`).
+        if !skip_name_keyed_store
+            && self.is_thread_clone()
             && (name.starts_with('@') || name.starts_with('%'))
             && let Some(shared_val) = self.get_shared_var(name)
         {

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -714,47 +714,9 @@ impl Interpreter {
         // entry into this frame's overlay, which is a real change in env shape
         // for a `:=`-bound target (`:into(my %b := BagHash.new)`).
         let current = self.env().get(var_name).map(|v| v.clone().into_deref());
-        let rebuilt = match &current {
-            Some(cur) => {
-                let old_view = cur.view();
-                let new_view = new_val.view();
-                match (&old_view, &new_view) {
-                    (ValueView::Array(old_gc, _), ValueView::Array(new_gc, kind))
-                        if !crate::gc::Gc::ptr_eq(old_gc, new_gc) =>
-                    {
-                        Some(Self::array_inplace_reassign(old_gc, new_gc, *kind))
-                    }
-                    (ValueView::Hash(old_gc), ValueView::Hash(new_gc))
-                        if !crate::gc::Gc::ptr_eq(old_gc, new_gc) =>
-                    {
-                        Some(Self::hash_inplace_reassign(old_gc, new_gc))
-                    }
-                    // ADR-0039 slice 2: the QuantHash kinds, for the same reason
-                    // and by the same rule. `classify(..., :into(my %b :=
-                    // BagHash.new))` rebuilds the bag and used to drop the fresh
-                    // node into `env`, which only a by-name read could see; the
-                    // binding's own slot kept the empty original
-                    // (`roast/S32-list/classify.t` 25-27).
-                    (ValueView::Set(old_gc, _), ValueView::Set(new_gc, m)) => {
-                        Self::quanthash_inplace_reassign(old_gc, new_gc, |gc| {
-                            Value::set_parts(gc, *m)
-                        })
-                    }
-                    (ValueView::Bag(old_gc, _), ValueView::Bag(new_gc, m)) => {
-                        Self::quanthash_inplace_reassign(old_gc, new_gc, |gc| {
-                            Value::bag_parts(gc, *m)
-                        })
-                    }
-                    (ValueView::Mix(old_gc, _), ValueView::Mix(new_gc, m)) => {
-                        Self::quanthash_inplace_reassign(old_gc, new_gc, |gc| {
-                            Value::mix_parts(gc, *m)
-                        })
-                    }
-                    _ => None,
-                }
-            }
-            None => None,
-        };
+        let rebuilt = current
+            .as_ref()
+            .and_then(|cur| Self::container_rebuild_in_place(cur, &new_val));
         drop(current);
         match rebuilt {
             Some(updated) => {
@@ -765,6 +727,47 @@ impl Interpreter {
             None => {
                 self.env_mut().insert(var_name.to_string(), new_val);
             }
+        }
+    }
+
+    /// Copy `new_val`'s container contents into the node `current` already
+    /// holds, when the two are the same container kind backed by different
+    /// nodes. Returns the value backed by the ORIGINAL node — every holder of
+    /// it (a local slot, a by-value capture, a `:=` alias) therefore observes
+    /// the rebuild. `None` means this is a genuine REBINDING rather than a
+    /// mutation (autovivification, a type change, a `Bag` replacing a `Hash`,
+    /// or the two already being the same node), and the caller should store
+    /// `new_val` normally.
+    pub(crate) fn container_rebuild_in_place(current: &Value, new_val: &Value) -> Option<Value> {
+        let old_view = current.view();
+        let new_view = new_val.view();
+        match (&old_view, &new_view) {
+            (ValueView::Array(old_gc, _), ValueView::Array(new_gc, kind))
+                if !crate::gc::Gc::ptr_eq(old_gc, new_gc) =>
+            {
+                Some(Self::array_inplace_reassign(old_gc, new_gc, *kind))
+            }
+            (ValueView::Hash(old_gc), ValueView::Hash(new_gc))
+                if !crate::gc::Gc::ptr_eq(old_gc, new_gc) =>
+            {
+                Some(Self::hash_inplace_reassign(old_gc, new_gc))
+            }
+            // ADR-0039 slice 2: the QuantHash kinds, for the same reason
+            // and by the same rule. `classify(..., :into(my %b :=
+            // BagHash.new))` rebuilds the bag and used to drop the fresh
+            // node into `env`, which only a by-name read could see; the
+            // binding's own slot kept the empty original
+            // (`roast/S32-list/classify.t` 25-27).
+            (ValueView::Set(old_gc, _), ValueView::Set(new_gc, m)) => {
+                Self::quanthash_inplace_reassign(old_gc, new_gc, |gc| Value::set_parts(gc, *m))
+            }
+            (ValueView::Bag(old_gc, _), ValueView::Bag(new_gc, m)) => {
+                Self::quanthash_inplace_reassign(old_gc, new_gc, |gc| Value::bag_parts(gc, *m))
+            }
+            (ValueView::Mix(old_gc, _), ValueView::Mix(new_gc, m)) => {
+                Self::quanthash_inplace_reassign(old_gc, new_gc, |gc| Value::mix_parts(gc, *m))
+            }
+            _ => None,
         }
     }
 
@@ -796,13 +799,45 @@ impl Interpreter {
     /// a `\param`) — and redirect any self-reference that (after circular-ref
     /// fixup) pointed at the about-to-be-dropped `new_gc` back to `old_gc`. Returns
     /// the `Array` value that should be stored in the slot (backed by `old_gc`).
-    pub(super) fn array_inplace_reassign(
+    pub(crate) fn array_inplace_reassign(
         old_gc: &crate::gc::Gc<crate::value::ArrayData>,
         new_gc: &crate::gc::Gc<crate::value::ArrayData>,
         kind: ArrayKind,
     ) -> Value {
+        Self::array_inplace_reassign_inner(old_gc, new_gc, kind, false)
+    }
+
+    /// [`Interpreter::array_inplace_reassign`] for a caller whose `new_gc` is an
+    /// ELEMENT-level rebuild rather than a whole rebuilt container: the
+    /// declared container metadata (`my CSV::Field @f`'s element type, an `is
+    /// default(...)`, a shape) lives on `old_gc` and the rebuild does not carry
+    /// it, so the plain form's wholesale overwrite would erase it. Fields the
+    /// rebuild *does* set still win. ADR-0039 slice 2.
+    pub(crate) fn array_inplace_reassign_inheriting_meta(
+        old_gc: &crate::gc::Gc<crate::value::ArrayData>,
+        new_gc: &crate::gc::Gc<crate::value::ArrayData>,
+        kind: ArrayKind,
+    ) -> Value {
+        Self::array_inplace_reassign_inner(old_gc, new_gc, kind, true)
+    }
+
+    fn array_inplace_reassign_inner(
+        old_gc: &crate::gc::Gc<crate::value::ArrayData>,
+        new_gc: &crate::gc::Gc<crate::value::ArrayData>,
+        kind: ArrayKind,
+        inherit_meta: bool,
+    ) -> Value {
         let new_ptr = crate::gc::Gc::as_ptr(new_gc) as usize;
         let mut new_data = (**new_gc).clone();
+        if inherit_meta {
+            new_data.value_type = new_data.value_type.or_else(|| old_gc.value_type.clone());
+            new_data.key_type = new_data.key_type.or_else(|| old_gc.key_type.clone());
+            new_data.declared_type = new_data
+                .declared_type
+                .or_else(|| old_gc.declared_type.clone());
+            new_data.default = new_data.default.or_else(|| old_gc.default.clone());
+            new_data.shape = new_data.shape.or_else(|| old_gc.shape.clone());
+        }
         let mut seen = Vec::new();
         for item in new_data.items_mut().iter_mut() {
             Self::replace_array_refs_in_value(item, new_ptr, old_gc, kind, &mut seen);
@@ -1031,12 +1066,40 @@ impl Interpreter {
 
     /// The `Hash` analogue of [`Self::array_inplace_reassign`]. Redirects any
     /// self-referencing hash value that pointed at `new_gc` back to `old_gc`.
-    pub(super) fn hash_inplace_reassign(
+    pub(crate) fn hash_inplace_reassign(
         old_gc: &crate::gc::Gc<crate::value::HashData>,
         new_gc: &crate::gc::Gc<crate::value::HashData>,
     ) -> Value {
+        Self::hash_inplace_reassign_inner(old_gc, new_gc, false)
+    }
+
+    /// The `Hash` twin of
+    /// [`Interpreter::array_inplace_reassign_inheriting_meta`].
+    pub(crate) fn hash_inplace_reassign_inheriting_meta(
+        old_gc: &crate::gc::Gc<crate::value::HashData>,
+        new_gc: &crate::gc::Gc<crate::value::HashData>,
+    ) -> Value {
+        Self::hash_inplace_reassign_inner(old_gc, new_gc, true)
+    }
+
+    fn hash_inplace_reassign_inner(
+        old_gc: &crate::gc::Gc<crate::value::HashData>,
+        new_gc: &crate::gc::Gc<crate::value::HashData>,
+        inherit_meta: bool,
+    ) -> Value {
         let new_ptr = crate::gc::Gc::as_ptr(new_gc) as usize;
         let mut new_data = (**new_gc).clone();
+        if inherit_meta {
+            new_data.value_type = new_data.value_type.or_else(|| old_gc.value_type.clone());
+            new_data.key_type = new_data.key_type.or_else(|| old_gc.key_type.clone());
+            new_data.declared_type = new_data
+                .declared_type
+                .or_else(|| old_gc.declared_type.clone());
+            new_data.default = new_data.default.or_else(|| old_gc.default.clone());
+            new_data.descriptor_name = new_data
+                .descriptor_name
+                .or_else(|| old_gc.descriptor_name.clone());
+        }
         for v in new_data.map.values_mut() {
             if let ValueView::Hash(inner) = v.view()
                 && crate::gc::Gc::as_ptr(&inner) as usize == new_ptr

--- a/src/vm/vm_var_trait_ops.rs
+++ b/src/vm/vm_var_trait_ops.rs
@@ -545,6 +545,36 @@ impl Interpreter {
                 }
                 // Set type constraint so future assignments are coerced correctly
                 self.vm_set_var_type_constraint(&name_str, Some(trait_name.clone()));
+                // ADR-0039 slice 2: that registration re-tags `env`'s value via
+                // `register_var_container_type_metadata` ->
+                // `tag_container_metadata` -> `Gc::make_mut`, which COPIES a
+                // node whose only other holder is the slot written just above.
+                // `env` therefore ends up on the tagged copy while the slot
+                // keeps the untagged original — invisible while `%h` reads
+                // resolve by name, wrong the moment they resolve through the
+                // slot (`my %h is MixHash = ...; %h<a>--`). Read `env` back and
+                // re-store it.
+                //
+                // Two neighbouring repairs were measured and are WRONG. Making
+                // `register_var_container_type_metadata` itself store
+                // identity-preservingly breaks `t/typed-bind-recursion.t`: a
+                // call frame's flattened env carries the caller's same-named
+                // entry, so a recursive `my @ret := Array[T].new` re-tags the
+                // CALLER's container, and restricting it to the frame's own
+                // overlay does not help. Moving the registration to run BEFORE
+                // the trait's own stores breaks `t/quanthash-hyper-funcop.t`,
+                // `t/pairs-element-container.t` and
+                // `t/quanthash-declared-init-identity.t`.
+                //
+                // A celled binding needs nothing: the cell IS the identity and
+                // both halves already share it.
+                if let Some(tagged) = self.env().get(&name_str).cloned()
+                    && !tagged.is_container_ref()
+                    && let Some(s) = self.resolve_local_slot(code, eff_slot, &name_str)
+                    && !self.locals[s].is_container_ref()
+                {
+                    self.locals[s] = tagged;
+                }
                 return Ok(());
             }
         }

--- a/t/container-slot-read-repairs.t
+++ b/t/container-slot-read-repairs.t
@@ -1,0 +1,117 @@
+use Test;
+
+# ADR-0039 slice 2: `@`/`%` reads compile to `GetLocal(slot)` for a plain user
+# lexical, so container scoping is lexical rather than dynamic.
+#
+# Turning the read into a slot read exposed a family of store-side defects that
+# the by-name read had been papering over: two paths that end up naming
+# different containers under one name look fine as long as every read
+# re-resolves the name. Each block below is one of those defects. They are
+# collected here because each was found through the flip rather than through a
+# feature, so no existing file covers them as a set.
+
+plan 14;
+
+# Repair 3 — a container declaration in EXPRESSION position must take the slot
+# its own reads resolve to. `local_map` is monotonic, so a popped sibling
+# block's `@a` slot stays reachable and the expression-position declaration
+# stored into `env` alone while every read answered the sibling's slot.
+{
+    { my @a = 5, 7, 9 }
+    (my @a).push: $_ for ^3;
+    is @a.join(','), '0,1,2', 'expression-position @ declaration takes the read slot';
+}
+{
+    { my %sib = :a(1) }
+    (my %h)<k> = 'v';
+    is %h.keys.join(','), 'k', 'expression-position % declaration takes the read slot';
+}
+
+# A SHAPED declaration in expression position keeps its declared shape. The
+# `SetGlobal` route the expression path used to take never needed the marker the
+# statement path emits; taking the slot route made it load-bearing.
+{
+    is (-> @a[3] { @a[1] })(my @b[3] = <a b c>), 'b',
+        'a shaped expression-position declaration keeps its shape';
+    is (my @c[3] = <p q r>).shape.join(','), '3',
+        'and reports it back through the declaration expression';
+}
+
+# Repair 4 — the fast hash-element-assign path must resolve its target through
+# the compiler-baked slot. `find_local_slot` is a `position` search, so with a
+# same-named shadow (`code.locals == ["%h", "%h"]`) it nil'd and re-seeded the
+# OUTER binding.
+{
+    my %h = :outer(1);
+    {
+        my %h;
+        %h<k> = 'inner';
+        is %h.keys.join(','), 'k', 'a shadowing hash element-assign stays in the shadow';
+    }
+    is %h.keys.join(','), 'outer', 'and leaves the outer hash untouched';
+}
+
+# Repair 6 — a mutating hyper must write its result THROUGH the target's
+# container node. The old fallback searched `code.locals` by name for a slot to
+# keep in sync, so under a same-named shadow it wrote the OUTER slot and `@r>>++`
+# answered the unincremented `1 2 3`.
+{
+    my @r;
+    {
+        my @r = (1, 2, 3);
+        @r>>++;
+        is @r.join(','), '2,3,4', 'a shadowing @ hyper-postfix writes its own binding';
+    }
+    is @r.elems, 0, 'and leaves the outer array untouched';
+}
+
+# Repair 7 — the `is BagHash`/`SetHash`/`MixHash` trait handler re-syncs its
+# slot after registering the name-keyed constraint. That registration re-tags
+# `env`'s value through `Gc::make_mut`, which COPIES a node the slot shares, so
+# `env` ended up on the tagged copy while the slot kept the untagged original.
+{
+    my %m is MixHash = a => 2, b => 1;
+    %m<a>--;
+    is %m.pairs.sort(*.key).map({ .key ~ '=' ~ .value }).join(','), 'a=1,b=1',
+        'a MixHash declared with a trait stays coherent with its slot';
+}
+{
+    my %b is BagHash = <a a b>;
+    %b<a>--;
+    is %b.pairs.sort(*.key).map({ .key ~ '=' ~ .value }).join(','), 'a=1,b=1',
+        'and so does a BagHash';
+}
+
+# The container-identity rule the repairs generalise: a runtime helper that
+# REBUILDS a variable's container copies the result into the existing backing
+# node instead of dropping a fresh node into `env`. An element store reached
+# through an accessor is the shape that exercises the by-identity alias sweep.
+{
+    class A { has @.seen; method bag() { @!seen } }
+    my $a = A.new(seen => []);
+    my @alias := $a.bag;
+    $a.bag[1] = 'x';
+    is @alias[1], 'x', 'an accessor element store reaches an aliased binding';
+}
+# ...and that in-place copy must not erase the destination's declared container
+# metadata. An element-level rebuild does not carry the variable's element type,
+# so overwriting the node wholesale dropped `my CSV::Field @f`'s `of` and the
+# next call that wanted `(CSV::Field:D @fld)` no longer bound (Text::CSV's
+# `10_base.t`).
+{
+    class F { has $.v }
+    class R { has F @.fields; method f() { @!fields } }
+    sub takes(F:D @fld) { @fld.elems }
+    my $r = R.new(fields => [F.new(v => 1)]);
+    $r.f[1] = F.new(v => 2);
+    is takes($r.fields), 2, 'a typed array attribute keeps its element type across an element store';
+    is $r.fields.of.^name, 'F', 'and still reports it through .of';
+}
+
+{
+    class H { has %.seen; method bag() { %!seen } }
+    my $h = H.new(seen => {});
+    my %alias := $h.bag;
+    $h.bag<c> = 3;
+    is %alias<c>, 3, 'and the hash twin does too';
+}


### PR DESCRIPTION
ADR-0039 §4.2's first bullet, attempt 4 — and this one lands.

A container read (`Expr::ArrayVar` / `Expr::HashVar`) compiled to a by-name
`GetArrayVar` / `GetHashVar` where a scalar read compiles to `GetLocal(slot)`.
Container lexical scoping was therefore **dynamic**: the read re-resolved the
name against whatever `env` currently held, so any same-named declaration
anywhere in the process — a consumer's `my`, an inner block's shadow, a sibling
routine's local — could hijack it. A plain user lexical container now resolves
through its slot, exactly as a scalar does.

The by-name read was also what **hid store-lane bugs**: two paths that end up
naming different containers under one name look fine as long as every read
re-resolves the name. Six of the repairs below are real bug fixes that simply
had no observable symptom before.

## The repairs

1. **`GetLocal` must not prefer a name-keyed store over this frame's own
   binding.** Two corrections. Its `__mutsu_atomic_*` lane probe is skipped when
   the slot holds the very `ContainerRef` cell that `env` names. And its
   *bare-name* `shared_vars` probe was an unconditional **preference** where the
   by-name read it replaces treats the same store as a **fallback** —
   `get_env_with_main_alias_inner` gates its base-name probe on
   `is_thread_clone()` and otherwise reads `env` first. It is now gated the same
   way; the Nil arm at the end of the op already supplies the fallback.
2. **An expression-position container declaration takes the slot the read
   resolves to**, and emits the shaped-decl marker the statement path emits.
3. **`try_fast_hash_element_assign` uses its compiler-baked `target_slot`** —
   `find_local_slot` is a `position` search that, under a same-named shadow,
   nil'd and re-seeded the *outer* binding.
4. **`write_back_hyper_target_var` writes THROUGH the container node** instead
   of replacing the binding and then searching `code.locals` by name (which
   under a shadow wrote the outer slot and made `@r»++` answer `1 2 3`).
   Restricted to an `@`/`%` target: a scalar-held QuantHash (`$b>>--`) *returns*
   the original, and that return value shares the node.
5. **The `is BagHash`/`SetHash`/`MixHash` trait handler re-syncs its slot** after
   the constraint registration re-tags `env`'s value through `Gc::make_mut`,
   which copies a node the slot shares.
6. **`overwrite_{array,hash}_bindings_by_identity` preserve container
   identity**, inheriting the destination's declared element type so an
   element-level rebuild cannot erase it.

The flip covers **plain user lexicals only**, and that is a requirement rather
than a safety margin: the by-name read's tail supplies the empty container that
makes `%_` read as `{}` on the fast method-dispatch path, and its cascade is the
only route by which `%!attr`/`%.attr` reach `self`'s attribute cell and `@*dyn`
/ `%?RESOURCES` / `::`-qualified names resolve at all.

## How the blocker was found

`MUTSU_SLOT_READ_DUMP` prints every name the flip applies to;
`MUTSU_SLOT_READ_FILTER` restricts the flip to a comma-separated list of them
(and, pointed at a name that does not exist, turns the flip off wholesale with
no rebuild). ADR-0039 §12 asked for this harness back; it is rebuilt and kept.

ddmin over the 95 names a `Cro::HTTP/router-auth.rakutest` run touches reduced
the failure to one, `@middleware`, in about four minutes. A slot-vs-env probe
then showed the slot and `env` agreeing on this frame's binding in all 36 calls
while `shared_vars` held a *different* handler's array — and `GetLocal`
answering the store in 17 of them, so the before-matched auth middleware never
ran and every request 401'd. Repair 1's second half is that finding. Note the
shape: a plain non-slurpy `@`/`%` **parameter** is deliberately left unmasked by
`mask_thread_redeclared_params` precisely so its bare-name entry can serve as a
*fallback* for a nested spawn — which is exactly why preferring it was wrong.

§12's own recorded blocker (a `gather` body's append reaching the atomic lane
instead of the owner's cell) did **not** survive re-measurement: with the six
unlanded repairs re-derived, `zef/distribution-depends-parsing.rakutest` passes
unchanged and the Cro file failed for an unrelated reason. ADR-0039 §13 records
that so it is not planned around again.

## Verification

- `make test` — 3862 files, 40943 tests, **PASS**.
- `make roast` — 1436 files, 218939 tests; only the three failures
  [docs/agent-environments.md](https://github.com/tokuhirom/mutsu/blob/main/docs/agent-environments.md)
  lists as container artefacts (`6.c/S32-io/file-tests.t`,
  `S16-filehandles/filetest.t` run as uid 0; `S32-io/IO-Socket-Async.t`
  sandboxed network), with byte-identical test numbers.
- `MUTSU_BIN=target/release/mutsu scripts/battery-testsuite.sh` — 283/312, with
  **both former blockers passing**. The only remaining rows are six DBIish MySQL
  files, which fail in this container for lack of `libmysqlclient`
  (`NativeCall: symbol 'mysql_init' not found`) and fail identically on a
  baseline build.
- `make lint` — all four configurations clean.

One regression was caught by the gate and fixed rather than papered over:
`Text::CSV 10_base.t` lost `my CSV::Field @f`'s element type because repair 6's
in-place copy overwrote the destination node's metadata wholesale. Pinned.

## Pins

`t/container-slot-read-repairs.t` (new, 14 assertions, verified green under
rakudo too) collects the repair shapes; `t/attribute-accessor-container-identity.t`
covers the identity sweep. `t/nested-frame-container-mutation-reaches-owner.t`
and `t/container-lexical-declarator-matrix.t` keep passing.

Filed along the way: #7661 — a `supply whenever` body captures an `@`/`%`
parameter by name, so a second call's binding overwrites the first's. It is
pre-existing (reproduces with the flip off) and is the same territory as
ADR-0039 §4.2's second bullet.

Closes #7541

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013tc1cyj98yUXftadqXXAGu

---
_Generated by [Claude Code](https://claude.ai/code/session_013tc1cyj98yUXftadqXXAGu)_