### PR TITLE
fix(supply): make Channel.Supply taps competing consumers, not a broadcast audience

### DIFF
--- a/news/2026-09/channel-supply-taps-are-competing-consumers.md
+++ b/news/2026-09/channel-supply-taps-are-competing-consumers.md
@@ -1,0 +1,68 @@
+# `Channel.Supply` taps compete for values instead of each getting a copy
+
+Two taps on a `Channel`'s `Supply` are **competing consumers** in rakudo — each
+sent value is delivered to exactly one of them — but mutsu **broadcast** the
+value to all of them, so every tap saw the whole stream:
+
+```raku
+my $c = Channel.new;
+my (@a, @b);
+my $s = $c.Supply;
+$s.tap: { @a.push($_) }
+$s.tap: { @b.push($_) }
+$c.send($_) for 1..6;
+$c.close;
+sleep 0.5;
+say "a={@a.join(',')} b={@b.join(',')}";
+# raku:            a=1,3,5 b=2,4,6
+# mutsu (before):  a=1,2,3,4,5,6 b=1,2,3,4,5,6
+```
+
+A single tap — by far the common case — was unaffected, which is why it went
+unnoticed. But a program fanning work out to several workers over one channel
+did every unit of work N times instead of once: silent duplicated side effects,
+not a wrong scalar.
+
+## Why the two shapes differ
+
+A `Supplier` is a genuine broadcast point, and mutsu already agreed with rakudo
+there. A `Channel` is a queue, so `Channel.Supply` is a view onto a `.receive`
+loop — a value one consumer takes is gone for the others.
+
+The `whenever` route already got this right: a react drive loop drains the
+channel queue itself, so two `whenever`s on `$c.Supply` partitioned the stream
+exactly as rakudo does. The divergence was confined to the *eager send-time* tap
+dispatch in `Channel.send`, which looped over every one of the channel's
+supplier ids and ran every tap registered on each.
+
+## The fix
+
+`Channel.send` now enumerates the channel's live taps across all of its
+`Supply` objects (`supplier_live_tap_indices`, which applies the same
+closed / `head_limit` skips the emit loop does) and hands the value to exactly
+one of them, chosen by a round-robin cursor kept on the channel
+(`ChannelState::supply_turn`). `supplier_emit_callbacks_for_tap` is the
+single-tap form of the existing `supplier_emit_callbacks`, so competing delivery
+goes through the same per-tap machinery — `head`, `unique`, `batch`, `lines`,
+`produce` and the rest all behave as before, they are just reached by one tap
+per value.
+
+The per-supplier `supplier_emit` bookkeeping (the sinks a react loop polls, and
+the recorded emission list) is untouched, so nothing that reads a supplier's
+state changes behaviour.
+
+## Pins
+
+`t/channel-supply-competing-consumers.t` covers the shared-`$s` spelling, two
+separate `$c.Supply` calls, the `Supplier` broadcast control, and a single tap
+seeing the whole stream in order. Because which tap wins a given value is not
+specified, it asserts the *partition* — every value delivered exactly once, and
+the union being the whole stream — rather than a particular split, so it passes
+under real rakudo too.
+
+This also removes one source of noise from the ADR-0068 §3 route-5 concurrency
+probe: the three-tap-writer FizzBuzz idiom recorded there cannot fill its array
+under rakudo's competing-consumer semantics, so part of that "values
+dropped/misordered" reading was this divergence seen from the other side.
+
+Closes [#7604](https://github.com/tokuhirom/mutsu/issues/7604).

--- a/src/runtime/methods_promise.rs
+++ b/src/runtime/methods_promise.rs
@@ -361,15 +361,37 @@ impl Interpreter {
                     return Err(Self::channel_send_closed_error());
                 }
                 let value = args.into_iter().next().unwrap_or(Value::NIL);
+                use crate::runtime::native_methods::state::supplier_emit;
+                use crate::runtime::native_methods::state_supplier::{
+                    SupplierEmitAction, supplier_emit_callbacks_for_tap, supplier_live_tap_indices,
+                };
                 let sids = ch.supplier_ids();
                 for sid in &sids {
-                    use crate::runtime::native_methods::state::supplier_emit;
-                    use crate::runtime::native_methods::state_supplier::{
-                        SupplierEmitAction, supplier_emit_callbacks,
-                    };
                     supplier_emit(*sid, value.clone());
-                    let actions = supplier_emit_callbacks(*sid, &value);
-                    for action in actions {
+                }
+                // A `Channel` is a queue, not a broadcast point: rakudo's
+                // `Channel.Supply` is a view onto a `.receive` loop, so taps on
+                // it are COMPETING consumers and each sent value reaches
+                // exactly one of them. This used to hand the value to every tap
+                // of every one of the channel's Supplies, so a program fanning
+                // work out to N workers over one channel did every unit N times
+                // (#7604). A `Supplier` is the genuine broadcaster and never
+                // reaches this path, so it keeps fanning out.
+                //
+                // Only this eager send-time dispatch broadcast: a `whenever` on
+                // a channel-backed Supply already competes correctly, because
+                // the react drive loop drains the channel queue itself.
+                let mut targets: Vec<(u64, usize)> = Vec::new();
+                for sid in &sids {
+                    targets.extend(
+                        supplier_live_tap_indices(*sid)
+                            .into_iter()
+                            .map(|i| (*sid, i)),
+                    );
+                }
+                if !targets.is_empty() {
+                    let (sid, tap_index) = targets[ch.next_supply_turn() % targets.len()];
+                    for action in supplier_emit_callbacks_for_tap(sid, tap_index, &value) {
                         if let SupplierEmitAction::Call(tap, emitted, delay_seconds) = action {
                             Self::sleep_for_supply_delay(delay_seconds);
                             let _ = self.call_sub_value(tap, vec![emitted], true);

--- a/src/runtime/native_methods/state_supplier.rs
+++ b/src/runtime/native_methods/state_supplier.rs
@@ -896,8 +896,53 @@ pub(in crate::runtime) enum SupplierEmitAction {
     },
 }
 
+/// The taps of `supplier_id` that would receive an emission right now — not
+/// closed, and not already past their `head_limit`. These are the same two
+/// skip conditions [`supplier_emit_callbacks_inner`]'s loop applies, so an index
+/// this returns is one that loop will act on.
+///
+/// A `Channel`-backed Supply's taps are *competing* consumers rather than a
+/// broadcast audience (a `Channel` is a queue: rakudo's `Channel.Supply` is a
+/// view onto a `.receive` loop), so `Channel.send` enumerates them and hands the
+/// value to exactly one.
+pub(in crate::runtime) fn supplier_live_tap_indices(supplier_id: u64) -> Vec<usize> {
+    let Ok(map) = supplier_subscriptions_map().lock() else {
+        return Vec::new();
+    };
+    let Some(subs) = map.get(&supplier_id) else {
+        return Vec::new();
+    };
+    subs.taps
+        .iter()
+        .enumerate()
+        .filter(|(_, tap)| !tap.closed && tap.head_limit.is_none_or(|limit| tap.head_count < limit))
+        .map(|(idx, _)| idx)
+        .collect()
+}
+
 pub(in crate::runtime) fn supplier_emit_callbacks(
     supplier_id: u64,
+    emitted_value: &Value,
+) -> Vec<SupplierEmitAction> {
+    supplier_emit_callbacks_inner(supplier_id, None, emitted_value)
+}
+
+/// [`supplier_emit_callbacks`] restricted to a SINGLE tap of the supplier —
+/// the competing-consumer delivery a `Channel`-backed Supply needs, where a
+/// value one tap takes is gone for the others. `tap_index` comes from
+/// [`supplier_live_tap_indices`]; a stale index (the tap closed in between)
+/// simply produces no actions.
+pub(in crate::runtime) fn supplier_emit_callbacks_for_tap(
+    supplier_id: u64,
+    tap_index: usize,
+    emitted_value: &Value,
+) -> Vec<SupplierEmitAction> {
+    supplier_emit_callbacks_inner(supplier_id, Some(tap_index), emitted_value)
+}
+
+fn supplier_emit_callbacks_inner(
+    supplier_id: u64,
+    only_tap: Option<usize>,
     emitted_value: &Value,
 ) -> Vec<SupplierEmitAction> {
     let mut actions = Vec::new();
@@ -905,6 +950,9 @@ pub(in crate::runtime) fn supplier_emit_callbacks(
         && let Some(subs) = map.get_mut(&supplier_id)
     {
         for (idx, tap) in subs.taps.iter_mut().enumerate() {
+            if only_tap.is_some_and(|only| only != idx) {
+                continue;
+            }
             if tap.closed {
                 continue;
             }

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -2354,6 +2354,11 @@ struct ChannelState {
     failure: Option<Value>,
     closed_promise: SharedPromise,
     supplier_ids: Vec<u64>,
+    /// Round-robin cursor over the live taps of this channel's Supplies. A
+    /// `Channel` is a queue, not a broadcast point, so each sent value goes to
+    /// exactly one of them; this is what picks which. Bumped once per `send`
+    /// that has a live tap to hand the value to.
+    supply_turn: usize,
     /// Drive-loop wakers to poke on every send/close/fail, so a react
     /// polling this channel wakes immediately instead of on its poll cap.
     wakers: Vec<crate::value::waker::ReactWaker>,

--- a/src/value/value_async.rs
+++ b/src/value/value_async.rs
@@ -310,6 +310,7 @@ impl SharedChannel {
                     failure: None,
                     closed_promise,
                     supplier_ids: Vec::new(),
+                    supply_turn: 0,
                     wakers: Vec::new(),
                 }),
                 Condvar::new(),
@@ -454,6 +455,16 @@ impl SharedChannel {
     pub(crate) fn supplier_ids(&self) -> Vec<u64> {
         let (lock, _) = &*self.inner;
         lock.lock().unwrap().supplier_ids.clone()
+    }
+
+    /// Take the next round-robin turn over this channel's competing tap
+    /// consumers, advancing the cursor. See `ChannelState::supply_turn`.
+    pub(crate) fn next_supply_turn(&self) -> usize {
+        let (lock, _) = &*self.inner;
+        let mut state = lock.lock().unwrap();
+        let turn = state.supply_turn;
+        state.supply_turn = state.supply_turn.wrapping_add(1);
+        turn
     }
 }
 

--- a/t/channel-supply-competing-consumers.t
+++ b/t/channel-supply-competing-consumers.t
@@ -1,0 +1,63 @@
+use Test;
+
+# A `Channel` is a queue, not a broadcast point: `Channel.Supply` is a view onto
+# a `.receive` loop, so two taps on it are COMPETING consumers and each sent
+# value reaches exactly one of them. A `Supplier` is the genuine broadcaster and
+# still fans out to every tap. See GitHub issue #7604.
+#
+# Which tap wins each value is not specified, so these assert the PARTITION
+# (every value delivered exactly once, nothing duplicated) rather than a
+# particular split -- the file passes under rakudo too.
+
+plan 6;
+
+sub union(@a, @b) { (flat @a, @b).sort.join(',') }
+
+# 1-2. One `$c.Supply` object, two taps on it.
+{
+    my $c = Channel.new;
+    my (@a, @b);
+    my $s = $c.Supply;
+    $s.tap: { @a.push($_) }
+    $s.tap: { @b.push($_) }
+    $c.send($_) for 1..6;
+    $c.close;
+    sleep 0.5;
+    is @a.elems + @b.elems, 6, 'shared Supply: each value delivered once, not broadcast';
+    is union(@a, @b), '1,2,3,4,5,6', 'shared Supply: the two taps partition the stream';
+}
+
+# 3-4. Two separate `$c.Supply` calls on the same channel.
+{
+    my $c = Channel.new;
+    my (@a, @b);
+    $c.Supply.tap: { @a.push($_) }
+    $c.Supply.tap: { @b.push($_) }
+    $c.send($_) for 1..6;
+    $c.close;
+    sleep 0.5;
+    is @a.elems + @b.elems, 6, 'two Supply calls: each value delivered once';
+    is union(@a, @b), '1,2,3,4,5,6', 'two Supply calls: the two taps partition the stream';
+}
+
+# 5. A `Supplier` is a real broadcaster: every tap sees every value.
+{
+    my $sup = Supplier.new;
+    my (@a, @b);
+    $sup.Supply.tap: { @a.push($_) }
+    $sup.Supply.tap: { @b.push($_) }
+    $sup.emit($_) for 1..6;
+    is "{@a.join(',')}|{@b.join(',')}", '1,2,3,4,5,6|1,2,3,4,5,6',
+       'Supplier still broadcasts to every tap';
+}
+
+# 6. A single tap still sees the whole stream, in order.
+{
+    my $c = Channel.new;
+    my @one;
+    $c.Supply.tap: { @one.push($_) }
+    $c.send($_) for 1..6;
+    $c.close;
+    sleep 0.5;
+    is @one.join(','), '1,2,3,4,5,6', 'a single tap still sees the whole stream in order';
+}


### PR DESCRIPTION
Two taps on a `Channel`'s `Supply` are **competing consumers** in rakudo — each sent value reaches exactly one of them — but mutsu **broadcast** the value to all of them, so every tap saw the whole stream:

```raku
my $c = Channel.new;
my (@a, @b);
my $s = $c.Supply;
$s.tap: { @a.push($_) }
$s.tap: { @b.push($_) }
$c.send($_) for 1..6;
$c.close;
sleep 0.5;
say "a={@a.join(',')} b={@b.join(',')}";
# raku:            a=1,3,5 b=2,4,6
# mutsu (before):  a=1,2,3,4,5,6 b=1,2,3,4,5,6
```

A single tap — by far the common case — was unaffected, which is why this went unnoticed. But a program fanning work out to several workers over one channel did every unit of work N times instead of once: silent duplicated side effects, not a wrong scalar.

## Root cause

A `Supplier` is a genuine broadcast point, and mutsu already agreed with rakudo there. A `Channel` is a queue, so `Channel.Supply` is a view onto a `.receive` loop — a value one consumer takes is gone for the others.

The `whenever` route already got this right: a react drive loop drains the channel queue itself, so two `whenever`s on `$c.Supply` partitioned the stream exactly as rakudo does (verified against rakudo `v2026.07` before touching anything). The divergence was confined to the *eager send-time* tap dispatch in `Channel.send`, which looped over every one of the channel's supplier ids and ran every tap registered on each.

## The fix

`Channel.send` now enumerates the channel's live taps across all of its `Supply` objects and hands the value to exactly one of them:

- `supplier_live_tap_indices` reports the taps that would receive an emission right now, applying the same `closed` / `head_limit` skips the emit loop itself applies, so an index it returns is one that loop will act on.
- `ChannelState::supply_turn` is a round-robin cursor on the channel, bumped once per `send` that has a live tap to hand the value to.
- `supplier_emit_callbacks_for_tap` is the single-tap form of the existing `supplier_emit_callbacks` (both now share one `_inner`), so competing delivery still goes through the same per-tap machinery — `head`, `unique`, `batch`, `lines`, `words`, `produce`, `classify` and the rest behave exactly as before, they are just reached by one tap per value.

The per-supplier `supplier_emit` bookkeeping (the sinks a react loop polls, and the recorded emission list) is deliberately untouched, so nothing that reads a supplier's state changes behaviour.

## Tests

`t/channel-supply-competing-consumers.t` (new) covers all four acceptance rows from the issue: the shared-`$s` spelling, two separate `$c.Supply` calls, the `Supplier` broadcast control, and a single tap seeing the whole stream in order. Because *which* tap wins a given value is unspecified, it asserts the **partition** — every value delivered exactly once, and the union being the whole stream — rather than a particular split, so it passes under real rakudo too (verified: 6/6 under `raku v2026.07`).

All 99 whitelisted `S17-*` roast files were run separately against this change and pass.

## Verification

- `cargo fmt --all`, `make lint` — all four configurations green.
- `make test` — 3870 files, 41040 tests, `Result: PASS`.
- `make roast` — 1436 files, 218939 tests. The only failures are the three documented remote-container environment-only files, matching [`docs/agent-environments.md`](https://github.com/tokuhirom/mutsu/blob/main/docs/agent-environments.md) by name and subtest range: `roast/6.c/S32-io/file-tests.t` (`Failed: 4`, tests 6-8, 10), `roast/S16-filehandles/filetest.t` (`Failed: 25`, tests 57-64, 69-72, 77-80, 101/103/105/107/109/111/117/121/125) — both because the container runs as `uid 0` — and `roast/S32-io/IO-Socket-Async.t` (exit 124, "planned 40 ran 17", sandboxed network).

Closes #7604

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0122oqVGqfXxNqf9uJEABZvB

---
_Generated by [Claude Code](https://claude.ai/code/session_0122oqVGqfXxNqf9uJEABZvB)_