### PR TITLE
fix(vm): a sibling `my %h` no longer cancels an `is default(...)` container

### DIFF
--- a/news/2026-09/container-default-survives-sibling-declaration.md
+++ b/news/2026-09/container-default-survives-sibling-declaration.md
@@ -1,0 +1,56 @@
+# A same-named `my %h` in another block no longer cancels `is default(...)`
+
+```raku
+{ my $z = (my %u is default(42)); say "A ", $z<nope>; }
+{ my %u; say "B ", %u.elems; }
+```
+
+rakudo prints `A 42` / `B 0`; mutsu printed `A (Any)` / `B 0`. The two blocks
+are disjoint lexical scopes and neither runs before the other, and reversing
+them changed nothing — both orders lost the default, which is what marked this
+as a *compile-time* interaction rather than a runtime one.
+
+## Narrowed by measurement
+
+- Only a **bare** later declaration was needed, but it had to be **used**:
+  `{ my %u; }` alone was harmless, `{ my %u; %u.elems; }` triggered it. Using
+  the variable is what makes the compiler give it a local slot.
+- `@` behaved exactly like `%`; a `$` scalar was unaffected (different
+  compilation path).
+- `is SetHash` was unaffected, so this was specific to the container's embedded
+  default rather than to trait application generally.
+- Moving the sibling declaration into a **sub** — its own `locals` list — made
+  it go away, while nesting it in another bare block did not.
+
+That last row is the whole story, and `--dump-bytecode` shows it directly: the
+two programs compile to the *same* mainline ops for the first block; the only
+difference is that `code.locals` gains a `"%u"` entry for the sibling block's
+slot.
+
+## Root cause
+
+The expression-position declaration stores its container with `SetGlobal` and
+then applies the trait with `ApplyVarTrait { slot: None }` — no compile-time
+slot, because the declaration shadows nothing. With no slot, the VM's
+`read_var_trait_target` falls back to a **by-name search of `code.locals`**, and
+that list is shared by every bare block at the same level. So it found the
+*sibling* block's `%u` slot, which is still uninitialized at that point, tagged
+that `Nil` with the default, and stored it back — over the env binding the
+expression's read-back (`GetHashVar`) then reads. `$z` therefore received a
+tagged `Nil` instead of the defaulted hash.
+
+## The fix
+
+A slot value that is not a container is never this declaration's container, so
+the slot-resolved read is now filtered on actually being an `Array`/`Hash`
+before it wins over the env value. The by-name fallback stays for the cases it
+exists to serve; it just cannot hijack an unrelated, unfilled slot any more.
+
+`t/container-default-survives-sibling-declaration.t` pins both orders, both
+sigils and the `is SetHash` control, and passes under rakudo as well as mutsu.
+
+The underlying sharpness — that `code.locals` is name-keyed and shared across
+sibling bare blocks, so any by-name slot search can cross a scope boundary —
+is unchanged and remains part of the locals/env dual-store debt.
+
+Closes [#7621](https://github.com/tokuhirom/mutsu/issues/7621).

--- a/src/vm/vm_var_trait_ops.rs
+++ b/src/vm/vm_var_trait_ops.rs
@@ -155,9 +155,20 @@ impl Interpreter {
             // an anonymous `(my % is default(...))` in expression position is
             // stored via SetGlobal, not a local, so the embedded default would
             // otherwise be skipped and lost when the value flows out.
+            // The slot-resolved read must actually BE a container. With no
+            // compile-time slot the read falls back to a by-NAME search of
+            // `code.locals`, and that list is shared by every bare block at the
+            // same level -- so a same-named `my %u` in a *disjoint sibling
+            // block* is found, and its slot is still uninitialized when this
+            // declaration runs. Tagging that Nil and storing it back clobbered
+            // the env binding the read-back reads, which is how a later
+            // `{ my %u; ... }` elsewhere in the file cancelled
+            // `(my %u is default(42))`. A non-container slot value is never
+            // this declaration's container, so fall through to env.
             if (name.starts_with('@') || name.starts_with('%'))
                 && let Some(container) = self
                     .read_var_trait_target(code, eff_slot, &name)
+                    .filter(|v| matches!(v.view(), ValueView::Array(..) | ValueView::Hash(_)))
                     .or_else(|| self.get_env_with_main_alias(&name))
             {
                 let container = self.tag_container_default(container, default_value.clone());

--- a/t/container-default-survives-sibling-declaration.t
+++ b/t/container-default-survives-sibling-declaration.t
@@ -1,0 +1,50 @@
+use Test;
+
+# An `is default(...)` container declared in EXPRESSION position kept its
+# default only while no other block in the file declared the same name. The
+# top-level `locals` list is shared by every bare block at the same level, so a
+# by-name slot search from one block reached a sibling block's slot -- still
+# uninitialized -- and the default was tagged onto that instead of onto the
+# container the expression returns.
+
+plan 8;
+
+# The repro: two disjoint blocks, neither running before the other's compile.
+{
+    my $z = (my %u is default(42));
+    is $z<nope>, 42, 'a hash default survives a same-named sibling declaration';
+}
+{
+    my %u;
+    is %u.elems, 0, 'and the sibling hash is unaffected';
+}
+
+# Reversed order: the interaction is compile-time, so both orders must hold.
+{
+    my %v;
+    is %v.elems, 0, 'the sibling hash comes first here';
+}
+{
+    my $z = (my %v is default(7));
+    is $z<nope>, 7, 'a hash default survives a sibling declared EARLIER';
+}
+
+# The same for the `@` sigil.
+{
+    my $z = (my @a is default(9));
+    is $z[5], 9, 'an array default survives a same-named sibling declaration';
+}
+{
+    my @a;
+    is @a.elems, 0, 'and the sibling array is unaffected';
+}
+
+# A container-replacing trait was never affected and must stay that way.
+{
+    my $z = (my %w is SetHash);
+    is $z.^name, 'SetHash', 'a container trait still replaces the container';
+}
+{
+    my %w;
+    is %w.elems, 0, 'and its sibling is unaffected too';
+}


### PR DESCRIPTION
```raku
{ my $z = (my %u is default(42)); say "A ", $z<nope>; }
{ my %u; say "B ", %u.elems; }
```

rakudo prints `A 42` / `B 0`; mutsu printed `A (Any)` / `B 0`. The two blocks are
disjoint lexical scopes and neither runs before the other, and **reversing them
changed nothing** — both orders lost the default, which is what marked this as a
compile-time interaction rather than a runtime one.

## Narrowed by measurement

| probe | result |
|---|---|
| `{ my %u; }` alone as the sibling | harmless |
| `{ my %u; %u.elems; }` as the sibling | **triggers it** — *using* the variable is what gives it a local slot |
| the `@` sigil | behaves exactly like `%` |
| a `$` scalar | unaffected (different compilation path) |
| `is SetHash` instead of `is default` | unaffected |
| sibling moved into a **sub** (its own `locals`) | goes away |
| sibling nested in another **bare block** | still fails |

That last pair is the whole story, and `--dump-bytecode` shows it directly: the
two programs compile to the *same* mainline ops for the first block, and differ
only in that `code.locals` gains a `"%u"` entry for the sibling block's slot.

## Root cause

The expression-position declaration stores its container with `SetGlobal` and
then applies the trait with `ApplyVarTrait { slot: None }` — no compile-time
slot, because the declaration shadows nothing. With no slot, the VM's
`read_var_trait_target` falls back to a **by-name search of `code.locals`**, and
that list is shared by every bare block at the same level. So it found the
*sibling* block's `%u` slot, which is still uninitialized at that point, tagged
that `Nil` with the default, and stored it back — over the env binding the
expression's read-back (`GetHashVar`) then reads. `$z` therefore received a
tagged `Nil` instead of the defaulted hash.

## The fix

A slot value that is not a container is never this declaration's container, so
the slot-resolved read is now filtered on actually being an `Array`/`Hash`
before it wins over the env value. The by-name fallback stays for the cases it
exists to serve; it just cannot hijack an unrelated, unfilled slot any more.

The underlying sharpness — `code.locals` is name-keyed and shared across sibling
bare blocks, so *any* by-name slot search can cross a scope boundary — is
unchanged, and stays part of the locals/env dual-store debt rather than being
rewritten here.

## Tests

`t/container-default-survives-sibling-declaration.t` — 8 subtests: the repro,
the reversed order (both must hold, since the interaction is compile-time), the
`@` sigil twin, and the `is SetHash` control that was already correct. It passes
under **`raku` as well as `mutsu`**.

The ticket's other named checks pass unchanged:
`t/do-block-tail-declaration-trait.t`, `t/inline-container-trait-expression.t`,
and every `t/*trait*.t` / `t/*default*.t` file (86 files, 664 tests).

`cargo fmt --all`, `make lint`, `make test` (PASS, 41051 tests) and `make roast`
were run locally on this exact tree. `make roast`'s only red files are the three
environment-only ones this container cannot pass, with exactly the shapes
documented in `docs/agent-environments.md`.

Closes #7621

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TAdHjoCdB8QjLBEDy87tXS

---
_Generated by [Claude Code](https://claude.ai/code/session_01TAdHjoCdB8QjLBEDy87tXS)_