### PR TITLE
fix(compiler): restart a nested phaser-carrying block's state on every clone

### DIFF
--- a/news/2026-09/state-in-a-nested-phaser-block-restarts-per-clone.md
+++ b/news/2026-09/state-in-a-nested-phaser-block-restarts-per-clone.md
@@ -1,0 +1,56 @@
+# `state` in a nested phaser-carrying block restarts per clone again
+
+A nested source `{ ... }` block is a block literal its enclosing block re-clones
+on every execution, so its own `state` restarts each time. mutsu models that with
+an `OpCode::ResetStateLocals` bracket. A block carrying an ENTER/LEAVE/KEEP/UNDO
+phaser has to run through a real `BlockScope` instead of being inlined (inlining
+would silently drop the phasers), and that route emitted no bracket — so in
+**value** position the block kept its `state` across iterations:
+
+```raku
+my @r = do for ^2 { { LEAVE { }; state $q = 0; $q++ } };
+say @r;
+# raku:            [0 0]
+# mutsu (before):  [0 1]
+```
+
+The phaser-free control next to it (`do for ^2 { { state $q = 0; $q++ } }`) was
+always correct, which isolated the phaser branch as the cause.
+
+## Narrowed further than the ticket assumed
+
+Only the value-position tail diverged. The statement-position spelling
+(`for ^2 { { LEAVE { }; state $q = 0; ... } }`) was already right, because
+`compile_block_stmt` emits its `ResetStateLocals` *before* dispatching on the
+block's shape, so the `PhaserScope` shape inherits it. A phaser block in a
+routine tail was right for the same reason. The gap was confined to the two
+value-position tail arms whose phaser-free sibling is `compile_bare_block_inline`
+— the value-collecting `do for` body (`helpers_control_flow.rs`) and
+`compile_block_inline`'s own tail arm.
+
+## The fix
+
+`compile_phaser_block_literal_inline` is `compile_bare_block_inline`'s twin for a
+tail block that carries a phaser: the same `ResetStateLocals` bracket around
+`compile_phaser_block_scope` instead of around the inline compile (the phaser
+path's `BlockScope` already supplies the frame, so it adds no
+`PushBlockFrame`/`PopBlockFrame`).
+
+The bracket deliberately lives at the call site rather than inside
+`compile_phaser_block_scope`, which is shared with `if`/`unless` branches: a
+postfix statement modifier introduces no block at all, so its `state` must *not*
+restart — the distinction `emit_branch_state_reset` exists to make. Bracketing
+that function unconditionally would have broken those callers.
+
+## Pins
+
+`t/state-nested-phaser-block-clone.t` covers the value and statement positions
+for both LEAVE and ENTER, a phaser block in a routine tail, and the two
+deliberate *persist* cases that must not gain a reset — a loop body's own
+non-nested `state`, and a postfix statement modifier. All eight assertions were
+checked against rakudo.
+
+`t/state-var-per-block-clone.t` and `t/state-nested-block-value-position-for.t`
+(including their sole-block-loop-body persist cases) still pass unchanged.
+
+Closes [#7632](https://github.com/tokuhirom/mutsu/issues/7632).

--- a/src/compiler/helpers_block_inline.rs
+++ b/src/compiler/helpers_block_inline.rs
@@ -145,6 +145,24 @@ impl Compiler {
         self.patch_nested_block_state_reset(state_reset);
     }
 
+    /// [`Compiler::compile_bare_block_inline`]'s twin for a tail block that
+    /// carries an ENTER/LEAVE/KEEP/UNDO phaser: those must run through a real
+    /// `BlockScope` (inlining would silently drop them), but the block is still
+    /// a genuine source `{ … }` its enclosing block re-clones on every run, so
+    /// its own `state` restarts per execution just the same.
+    ///
+    /// The `ResetStateLocals` bracket has to live here, at the call site, rather
+    /// than inside [`Compiler::compile_phaser_block_scope`]: that function is
+    /// shared with `if`/`unless` branches, and a postfix statement modifier
+    /// introduces no block at all, so its `state` must NOT restart — the
+    /// distinction [`Compiler::emit_branch_state_reset`] exists to make.
+    /// Bracketing unconditionally would break those callers.
+    pub(super) fn compile_phaser_block_literal_inline(&mut self, stmts: &[Stmt]) {
+        let state_reset = self.emit_nested_block_state_reset(stmts);
+        self.compile_phaser_block_scope(stmts, PhaserBlockResult::Push);
+        self.patch_nested_block_state_reset(state_reset);
+    }
+
     /// Compile a block inline (for blocks without placeholders).
     pub(super) fn compile_block_inline(&mut self, stmts: &[Stmt]) {
         let saved = self.push_dynamic_scope_lexical();
@@ -223,7 +241,11 @@ impl Compiler {
                         // `result_on_stack` keeps its value on the stack, matching
                         // the inline path.
                         if Self::has_block_enter_leave_phasers(inner) {
-                            self.compile_phaser_block_scope(inner, PhaserBlockResult::Push);
+                            if matches!(stmt, Stmt::Block(_)) {
+                                self.compile_phaser_block_literal_inline(inner);
+                            } else {
+                                self.compile_phaser_block_scope(inner, PhaserBlockResult::Push);
+                            }
                         } else if matches!(stmt, Stmt::Block(_)) {
                             // Genuine source `{ ... }` is a callframe.
                             self.compile_bare_block_inline(inner);

--- a/src/compiler/helpers_control_flow.rs
+++ b/src/compiler/helpers_control_flow.rs
@@ -88,7 +88,7 @@ impl Compiler {
                     // tail arm already routes this way — this mirrors it.
                     Stmt::Block(inner) => {
                         if Self::has_block_enter_leave_phasers(inner) {
-                            self.compile_phaser_block_scope(inner, PhaserBlockResult::Push);
+                            self.compile_phaser_block_literal_inline(inner);
                         } else {
                             self.compile_bare_block_inline(inner);
                         }

--- a/t/state-nested-phaser-block-clone.t
+++ b/t/state-nested-phaser-block-clone.t
@@ -1,0 +1,47 @@
+use Test;
+
+# A nested source `{ ... }` block is a block literal its enclosing block
+# re-clones on every execution, so its own `state` restarts each time. A block
+# carrying an ENTER/LEAVE/KEEP/UNDO phaser must run through a real `BlockScope`
+# (inlining would drop the phasers), and that path used to skip the
+# `ResetStateLocals` bracket its phaser-free sibling emits -- so the same block
+# kept its `state` across iterations in VALUE position. See GitHub issue #7632.
+
+plan 8;
+
+# 1-2. Value position: the collecting `do for` tail. This is the shape that
+#      diverged; the phaser-free control next to it always worked.
+my @phaser-value = do for ^2 { { LEAVE { }; state $q = 0; $q++ } };
+is @phaser-value.join(','), '0,0', 'a phaser block in value position re-clones its state';
+
+my @plain-value = do for ^2 { { state $q = 0; $q++ } };
+is @plain-value.join(','), '0,0', 'the phaser-free control still re-clones its state';
+
+# 3-4. Statement position, both flavours.
+my @phaser-stmt;
+for ^2 { { LEAVE { }; state $q = 0; @phaser-stmt.push($q++) } }
+is @phaser-stmt.join(','), '0,0', 'a phaser block in statement position re-clones its state';
+
+my @plain-stmt;
+for ^2 { { state $q = 0; @plain-stmt.push($q++) } }
+is @plain-stmt.join(','), '0,0', 'the phaser-free statement control still re-clones its state';
+
+# 5. ENTER, not just LEAVE.
+my @entered = do for ^2 { { ENTER { }; state $q = 0; $q++ } };
+is @entered.join(','), '0,0', 'an ENTER phaser block re-clones its state too';
+
+# 6. A routine tail already behaved; keep it pinned.
+sub h { { LEAVE { }; state $q = 0; $q++ } }
+is "{h()},{h()}", '0,0', 'a phaser block in a routine tail re-clones its state';
+
+# The deliberate PERSIST cases, which must NOT gain a reset.
+
+# 7. The loop body's OWN `state` (no nested block) persists across iterations.
+my @loop-own;
+for ^3 { state $p = 0; @loop-own.push($p++) }
+is @loop-own.join(','), '0,1,2', "a loop body's own state persists across iterations";
+
+# 8. A postfix statement modifier introduces no block, so its `state` persists.
+my @modifier;
+for ^3 { state $n = 0; $n++ if True; @modifier.push($n) }
+is @modifier.join(','), '1,2,3', 'a statement modifier does not restart state';


### PR DESCRIPTION
A nested source `{ ... }` block is a block literal its enclosing block re-clones on every execution, so its own `state` restarts each time; mutsu models that with an `OpCode::ResetStateLocals` bracket. A block carrying an ENTER/LEAVE/KEEP/UNDO phaser has to run through a real `BlockScope` instead of being inlined (inlining would silently drop the phasers), and that route emitted no bracket — so in **value** position the block kept its `state` across iterations:

```raku
my @r = do for ^2 { { LEAVE { }; state $q = 0; $q++ } };
say @r;
# raku:            [0 0]
# mutsu (before):  [0 1]
```

The phaser-free control next to it (`do for ^2 { { state $q = 0; $q++ } }`) was always correct, which isolates the phaser branch as the cause.

## Narrowed further than the ticket assumed

Only the **value-position** tail diverged. Measured against rakudo `v2026.07` across eight shapes before touching anything:

| shape | raku | mutsu before |
|---|---|---|
| `do for ^2 { { LEAVE { }; state $q = 0; $q++ } }` | `[0 0]` | **`[0 1]`** |
| `do for ^2 { { state $q = 0; $q++ } }` | `[0 0]` | `[0 0]` |
| `for ^2 { { LEAVE { }; state $q = 0; … } }` (statement) | `[0 0]` | `[0 0]` |
| `sub h { { LEAVE { }; state $q = 0; $q++ } }` | `0 0` | `0 0` |
| loop body's own `state`, sole-block body, statement modifier | persist | persist |

The statement-position spelling was already right because `compile_block_stmt` emits its `ResetStateLocals` *before* dispatching on the block's shape, so the `PhaserScope` shape inherits it — which is also why a routine tail was right. The gap was confined to the two value-position tail arms whose phaser-free sibling is `compile_bare_block_inline`: the value-collecting `do for` body (`helpers_control_flow.rs`, #7585's route) and `compile_block_inline`'s own tail arm.

## The fix

`compile_phaser_block_literal_inline` is `compile_bare_block_inline`'s twin for a tail block that carries a phaser — the same `ResetStateLocals` bracket, around `compile_phaser_block_scope` instead of around the inline compile. It adds no `PushBlockFrame`/`PopBlockFrame`, since the phaser path's `BlockScope` already supplies the frame.

The bracket deliberately lives at the call site rather than inside `compile_phaser_block_scope`, exactly as the ticket warns: that function is shared with `if`/`unless` branches, and a postfix statement modifier introduces no block at all, so its `state` must *not* restart — the distinction `emit_branch_state_reset` exists to make. Bracketing it unconditionally would break those callers.

## Tests

`t/state-nested-phaser-block-clone.t` (new) covers value and statement position for both LEAVE and ENTER, a phaser block in a routine tail, and the two deliberate *persist* cases that must not gain a reset — a loop body's own non-nested `state`, and a postfix statement modifier. All eight assertions were checked against rakudo (8/8 there too).

`t/state-var-per-block-clone.t` and `t/state-nested-block-value-position-for.t`, including their sole-block-loop-body persist cases, pass unchanged.

## Verification

- `cargo fmt --all`, `make lint` — all four configurations green.
- `make test` — 3871 files, 41048 tests, `Result: PASS`.
- `make roast` — 1436 files, 218939 tests. The only failures are the three documented remote-container environment-only files, matching [`docs/agent-environments.md`](https://github.com/tokuhirom/mutsu/blob/main/docs/agent-environments.md) by name and subtest range: `roast/6.c/S32-io/file-tests.t` (`Failed: 4`, tests 6-8, 10), `roast/S16-filehandles/filetest.t` (`Failed: 25`, tests 57-64, 69-72, 77-80, 101/103/105/107/109/111/117/121/125) — both because the container runs as `uid 0` — and `roast/S32-io/IO-Socket-Async.t` (exit 124, "planned 40 ran 17", sandboxed network).

Closes #7632

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0122oqVGqfXxNqf9uJEABZvB

---
_Generated by [Claude Code](https://claude.ai/code/session_0122oqVGqfXxNqf9uJEABZvB)_