### PR TITLE
perf(vm): frame slots share one contiguous stack (ADR-0077 Slice 2)

### DIFF
--- a/docs/adr/0077-locals-are-a-window-into-a-contiguous-stack.md
+++ b/docs/adr/0077-locals-are-a-window-into-a-contiguous-stack.md
@@ -1,6 +1,6 @@
 # ADR-0077: A call's locals are a window into one contiguous stack, not a pooled `Vec`
 
-- Status: **Proposed** (Slice 0 implemented — see "What Slice 0 actually built"; Slices 1-3 open)
+- Status: **Accepted** (Slices 0 and 2 implemented; Slice 1 withdrawn into Slice 2; Slice 3 and the leading-parameter form open — see the two "What Slice N actually built" sections)
 - Date: 2026-09-08
 - Related: [#7562](https://github.com/tokuhirom/mutsu/issues/7562) (the perf
   finding this ADR unblocks), [#7579](https://github.com/tokuhirom/mutsu/issues/7579)
@@ -207,22 +207,94 @@ representation still has exactly one home. `Index` is implemented explicitly
 rather than left to `Deref` so that Slice 2 can address `stack[base + i]` with a
 single bounds check instead of slicing the window and then indexing it.
 
-**Slice 1 — frame bookkeeping.** `VmCallFrame::saved_locals: Vec<Value>` →
-`saved_locals_base: usize`; collapse `gc_roots`' per-frame visit into one slice
-visit. Still on a pooled `Vec` for the live frame, so this slice is testable on
-its own.
+**Slice 1 — frame bookkeeping. WITHDRAWN; folded into Slice 2.** It read
+"`VmCallFrame::saved_locals: Vec<Value>` → `saved_locals_base: usize`, still on
+a pooled `Vec` for the live frame, so this slice is testable on its own". That
+state does not exist: a base index means nothing until the frames share a stack,
+so there is nothing for the intermediate slice to be tested against. Its two
+pieces — the frame field and the `gc_roots` collapse — landed with Slice 2.
 
-**Slice 2 — the representation.** `locals_stack` + `locals_base`; delete
-`locals_pool`, `take_locals_from_pool`, `recycle_locals`; teach
-`vm_jit_layout`/`vm_jit_tier_b` the base; add the leading-parameter
-`locals_base = args_base` fast path. This is the slice the measurement below
-belongs to.
+**Slice 2 — the representation. SHIPPED, except the leading-parameter fast
+path; see "What Slice 2 actually built".** The shared stack, the deletion of
+`locals_pool`/`take_locals_from_pool`/`recycle_locals`, the frame field, the
+`gc_roots` collapse, and the JIT's base. The leading-parameter
+`locals_base = args_base` form is **not** in it — see open question 1, which the
+implementation settled differently from the way this ADR first framed it.
 
 **Slice 3 (optional, separable) — fold `outer_scope_locals` in.**
 `outer_scope_locals: Vec<Vec<Value>>` (`src/runtime/mod.rs:3582`) is a second
 stack-of-locals for block scopes. Once locals live on a contiguous stack, a
 block scope is just another base index and that field can go away. Not required
 by this ADR; recorded so the next reader sees the whole shape.
+
+### What Slice 2 actually built
+
+The representation is one vector plus the executing frame's base, both inside
+`Locals` rather than as two `Interpreter` fields:
+
+```rust
+pub(crate) struct Locals { slots: Vec<Value>, base: usize }
+```
+
+Keeping the stack *inside* the type is what makes the migration a local one: the
+`Interpreter` still has a single `locals` field, `Index` becomes
+`slots[base + slot]`, `Deref` becomes `slots[base..]`, and no call site needs to
+borrow two `Interpreter` fields at once. Slice 0's newtype paid off exactly as
+intended — the ~330 index sites and the ~100 `Deref` sites did not move again.
+
+The ~40 structural sites reduced to three shapes:
+
+| shape | API | example |
+| --- | --- | --- |
+| open / close a frame | `push_frame(n) -> CallerFrame`, `pop_frame(CallerFrame)` | every `mem::take(&mut self.locals)` … restore pair; `push_call_frame`/`pop_call_frame`; the retired pool |
+| replace the executing frame's slots | `refill_slots(n)`, `refill_from(&[Value])`, `resize_slots(n)` | `self.locals = vec![Nil; n]`; the top-level `run` entry, which sizes then seeds and so must keep surviving slots |
+| copy a frame out or in | `to_vec()`, `push_frame_from`, `install_root_frame` | a suspended `gather` coroutine, an inline `CATCH` handler, a hyper/race worker's seed |
+
+**A frame handle is not `Copy`, and `pop_frame` consumes it.** This is the one
+piece of the design that was *not* obvious up front, and it was found the hard
+way: an earlier version returned a bare `usize`, documented `pop_frame` as
+idempotent, and its own unit test failed — closing a frame twice truncates the
+*caller's* slots, because the second call truncates to a base that is already
+the caller's. The old moved `Vec<Value>` had made a double close a compile
+error, and several paths (e.g. `vm_arith_int_ops`) close on more than one
+exclusive exit branch, where that move was the only proof the branches really
+were exclusive. A non-`Copy` handle restores exactly that protection.
+`#[must_use]` then immediately found the hyper/race worker pushing a root frame
+it never closes — legitimate, since a worker VM is discarded whole, and now
+stated as `install_root_frame`.
+
+**The JIT.** Slice 0's `size_of::<Locals>()` assertion failed the build until
+Tier B's GetLocal emitter learned the base, which is what it was for. The
+emitter loads `locals_base` alongside the `Vec` header words on every slot
+access — a push can reallocate and every call moves the base, so neither may be
+cached — reads the absolute element `base + idx`, and bounds-checks against
+`len - base` behind a `base <= len` guard. `JitLayout::locals` now means the
+*stack* inside the field, with the two byte offsets exported from `Locals` as
+consts because its fields are private.
+
+**GC roots — the one way this slice could have broken silently.** `gc_roots`
+visited `&self.locals` plus each frame's `saved_locals`. `Deref` now yields only
+the executing frame, so a root scan reading through it would miss every
+suspended caller's slots and free live values while the program kept running. It
+visits `all_slots()` instead and the per-frame walk is gone, which also makes
+the scan one slice visit rather than one per frame.
+`t/locals-frame-stack-gc-roots.t` pins the end-to-end property (values, cyclic
+objects and containers held only by deeply suspended frames survive, including
+past the retired pool's 64-entry bound), and a unit test pins that `all_slots()`
+and the `Deref` window disagree in the direction they must.
+
+**Two deliberate copies remain.** `vm_call_method_compiled` reads the enclosing
+frame's slots through `outer_local_slots` *and* writes the block's
+free-variable writes back into them, then restores the whole array on exit — so
+the detached copy is the semantics, not an artifact of the old representation.
+Writing through to the live region below `base` instead would change behavior on
+the panic path (where the restore never runs), so it is left for its own slice.
+And the shared-container propagation in `vm_var_assign_coerce`, which walked
+`call_frames` writing `frame.saved_locals[i]`, now derives each saved frame's
+`[base, end)` region — walking downwards, a frame's region ends where its own
+base begins, and the topmost ends at the executing base — collects the absolute
+indices during the walk (which borrows `call_frames` mutably for the env
+inserts) and applies them afterwards.
 
 ### What Slice 0 actually built
 
@@ -356,21 +428,35 @@ could be much larger than a few percent.
   locals become the cheap store, which is the premise of making `env` a lazily
   materialized name view.
 
-## Open questions (for Slice 2, not blocking this ADR)
+## Open questions
 
-1. **One stack or two?** Reusing `self.stack` for locals makes
-   `locals_base = args_base` free but interleaves operand-stack and locals
-   traffic in one buffer, where a `push` during body execution would sit above
-   the callee's slots. A sibling `locals_stack` keeps the two disciplines
-   separate at the cost of copying arguments into it. Measure both; the
-   leading-parameter fast path is the reason to prefer reuse, and the operand
-   stack's own `truncate` discipline is the reason it might not work.
+1. **One stack or two? — settled as two, and the reasoning changed.** This was
+   framed as a measurement between reusing `self.stack` (making
+   `locals_base = args_base` free) and a sibling stack (costing an argument
+   copy). Slice 2 shipped the sibling — the slots live in `Locals` — and the
+   reason is not a measurement but the `Deref` contract Slice 0 established:
+   the executing frame is `[base ..]`, "everything above the base". An operand
+   push during body execution would land inside that window, so sharing
+   `self.stack` requires a per-frame *length* as well as a base, and every
+   `.len()` / `.iter()` / `&self.locals` site starts meaning something subtly
+   different. That is a second, larger change wearing the first one's clothes.
+
+   The leading-parameter `locals_base = args_base` form is therefore **not
+   shipped and not free**: it needs the fused stack, hence the per-frame length,
+   hence its own slice with its own measurement. Slice 2's win is the pool, the
+   `Vec` header traffic and the `mem::take` pairs; the remaining argument move
+   loop is the next thing to attack, not something this slice quietly dropped.
 2. **Overflow policy.** A growable `Vec` inherits Rust's allocation failure
    behavior on runaway recursion. mutsu has no explicit call-depth limit today;
    whether to add one (a real VM's stack limit, raising an `X::` rather than
-   aborting) is a separate decision and should not be smuggled in here.
-3. **The named light path.** `call_compiled_function_light` still copies into
-   the same buffer shape (#7579 item 1) and also uses
-   `take_locals_from_pool(0)` as a general scratch buffer
-   (`src/vm/vm_call_func_ops.rs:344`). Deleting the pool means giving those
-   sites a scratch `Vec` of their own; that is bookkeeping, not a design fork.
+   aborting) is a separate decision and was deliberately not smuggled into
+   Slice 2, which changes where slots live but not how deep they may go.
+3. **The named light path — closed by Slice 0.** `call_compiled_function_light`
+   used `take_locals_from_pool(0)` as a general argument buffer, which a window
+   into a shared stack cannot serve. Slice 0 gave those three sites their own
+   `args_scratch_pool`, so Slice 2 could delete the locals pool outright. What
+   remains of #7579 item 1 is the *copy* on the named path, not the pool.
+4. **The two remaining detached copies** (`vm_call_method_compiled`'s enclosing
+   frame, `vm_var_assign_coerce`'s cross-frame propagation) — see "What Slice 2
+   actually built". Both are now expressed against the shared stack; the first
+   still copies because writing through changes panic-path behavior.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -102,4 +102,4 @@ The role of an ADR is to preserve the *context of the judgment* — something th
 | [0074](0074-a-channel-backed-supply-broadcasts-to-its-taps.md) | A channel-backed Supply broadcasts to its taps; the receiver is not an exclusive transfer | Accepted (implemented) |
 | [0075](0075-make-test-runs-tap-on-release-binary.md) | `make test` runs the TAP (`t/`) suite on the release binary (supersedes 0014); `gc-stress`/`jit-stress` keep the debug pass | Accepted |
 | [0076](0076-bare-block-lowering-and-block-scope-opcodes.md) | One bare-block lowering shared by both source positions; `BlockScope` and `DoBlockExpr` stay two opcodes | Accepted (shared lowering landed; opcode merge deferred — §6) |
-| [0077](0077-locals-are-a-window-into-a-contiguous-stack.md) | A call's locals are a window into one contiguous stack, not a pooled `Vec` | Proposed (Slice 0 implemented; Slices 1-3 open) |
+| [0077](0077-locals-are-a-window-into-a-contiguous-stack.md) | A call's locals are a window into one contiguous stack, not a pooled `Vec` | Accepted (Slices 0 and 2 implemented; Slice 1 withdrawn into 2; Slice 3 and the leading-parameter form open) |

--- a/news/2026-09/frame-slots-share-one-stack.md
+++ b/news/2026-09/frame-slots-share-one-stack.md
@@ -1,0 +1,102 @@
+# Frame slots share one stack
+
+ADR-0077 Slice 2. Until now each call got its own `Vec<Value>` of slots,
+borrowed from `locals_pool`: pop a vector, `clear` it, `resize` it with
+`Value::NIL`, `mem::take` the caller's aside, run the body, push the used one
+back. [#7562](https://github.com/tokuhirom/mutsu/issues/7562) put that at ~5.7%
+of `bench-fib`'s profile, and a callgrind cross-check on the current head found
+the two surviving halves at 2.03% (`Vec::resize`) and 1.95% (`recycle_locals`)
+of retired instructions, once per call each — to hold one value, since `fib`'s
+only local is its parameter.
+
+Every live frame's slots now live in one contiguous vector, and the executing
+frame is the window at the top of it:
+
+```rust
+pub(crate) struct Locals { slots: Vec<Value>, base: usize }
+```
+
+A call extends the vector, a return truncates it. `locals_pool`,
+`take_locals_from_pool`, `recycle_locals` and every `mem::take(&mut
+self.locals)` are gone, and `VmCallFrame` carries a frame handle instead of a
+whole vector.
+
+Keeping the stack *inside* `Locals` rather than as a second `Interpreter` field
+is what made this a local change: there is still one `locals` field, `Index`
+became `slots[base + slot]`, `Deref` became `slots[base..]`, and nothing has to
+borrow two interpreter fields at once. Slice 0's newtype then paid off exactly
+as designed — the ~330 `self.locals[i]` sites and the ~100 that read through
+`Deref` did not move again. The ~40 structural sites reduced to three shapes:
+open/close a frame, replace the executing frame's slots, or copy a frame out
+and back for a snapshot that outlives it (a suspended `gather` coroutine, an
+inline `CATCH` handler frame, a hyper/race worker's seed).
+
+## The handle is not `Copy`, and that was learned the hard way
+
+The first version of this returned a bare `usize` from `push_frame` and
+documented `pop_frame` as idempotent. Its own unit test failed: closing a frame
+twice truncates the **caller's** slots, because the second call truncates to a
+base that is already the caller's.
+
+The old code had been protected from that by accident — it moved a
+`Vec<Value>`, so a double restore did not compile — and several paths, such as
+`vm_arith_int_ops`, close a frame on more than one exclusive exit branch, where
+that move was the only proof the branches really were exclusive. Replacing the
+vector with a plain integer silently discarded the proof. So `push_frame`
+returns a non-`Copy` `CallerFrame` that `pop_frame` consumes, restoring exactly
+the guarantee, and `#[must_use]` immediately found the hyper/race worker
+pushing a root frame it never closes — legitimate, since a worker VM is
+discarded whole, and now stated as `install_root_frame` rather than left as a
+warning.
+
+## The GC hazard
+
+`gc_roots` used to visit `&self.locals` plus each call frame's `saved_locals`
+separately. `Deref` now yields only the executing frame, so a root scan reading
+through it would miss every suspended caller's slots and free live values while
+the program kept running — the one way this slice could have broken silently. It
+visits `all_slots()` instead, which also makes the scan a single slice visit
+rather than one per frame. `t/locals-frame-stack-gc-roots.t` pins the
+end-to-end property: values, cyclic objects and containers held only by frames
+suspended under a deep call survive, including past the retired pool's 64-entry
+bound.
+
+That bound is worth a note of its own. `LOCALS_POOL_MAX` was 64, so a recursion
+deeper than that missed the pool *structurally* — the descent always found it
+empty — and paid a malloc and a free per call. No benchmark measured it
+(`fib`'s depth is 30), and it is simply gone now: the stack grows once.
+
+## The JIT
+
+Slice 0 left a `const { assert!(size_of::<Locals>() == size_of::<Vec<Value>>()) }`
+next to `vm_jit_layout`'s existing probe assertion, precisely so this slice
+could not land without dealing with Tier B. It fired, as intended. The GetLocal
+emitter now loads `locals_base` alongside the `Vec` header words on every slot
+access — a push can reallocate the stack and every call moves the base, so
+neither may be cached — reads the absolute element `base + idx`, and
+bounds-checks against `len - base` behind a `base <= len` guard. The
+call- and loop-shaped benchmarks agree under `MUTSU_JIT=on` and `off`.
+
+## What is deliberately not in it
+
+The strongest form of the fix — `locals_base = args_base`, where a callee whose
+locals are exactly its leading parameters pays *nothing*, because the argument
+the caller pushed already sits in the cell the slot wants — needs locals to live
+on the *operand* stack. ADR-0077 framed the choice between one stack and two as
+a measurement; it is really a consequence of the `Deref` contract. "The
+executing frame is everything above `base`" stops being true the moment an
+operand push can land inside the window, so a fused stack needs a per-frame
+length as well as a base, and every `.len()` / `.iter()` / `&self.locals` site
+starts meaning something subtly different. That is a second, larger change, and
+it gets its own slice and its own measurement rather than riding along here.
+
+Two detached copies also remain on purpose. `vm_call_method_compiled` reads the
+enclosing frame's slots and writes a block's free-variable writes back into
+them before restoring the whole array, so the copy is the semantics rather than
+an artifact of the old representation — writing through to the live region below
+`base` changes behavior on the panic path, where the restore never runs. And the
+shared-container propagation in `vm_var_assign_coerce`, which walked
+`call_frames` writing `frame.saved_locals[i]`, now derives each saved frame's
+`[base, end)` region (walking downwards, a frame's region ends where its own
+base begins, and the topmost ends at the executing base), collects the absolute
+indices during the walk, and applies them afterwards.

--- a/src/runtime/catch_inline.rs
+++ b/src/runtime/catch_inline.rs
@@ -25,7 +25,7 @@ use crate::value::CatchInlineVerdict;
 /// Saved execution state for a handler run against the *installing* frame's
 /// lexicals while `self.locals` belongs to the deep throw/raise site.
 pub(crate) struct InstallingFrame {
-    saved_locals: crate::runtime::Locals,
+    saved_locals_base: crate::runtime::locals::CallerFrame,
     saved_upvalues: Vec<Option<Value>>,
     /// The reconstructed locals as seeded, so the flush writes back only slots
     /// the handler actually changed.
@@ -58,13 +58,10 @@ impl Interpreter {
             })
             .collect();
         let seeded = handler_locals.clone();
-        let saved_locals = std::mem::replace(
-            &mut self.locals,
-            crate::runtime::Locals::from_vec(handler_locals),
-        );
+        let saved_locals_base = self.locals.push_frame_from(&handler_locals);
         let saved_upvalues = std::mem::take(&mut self.upvalues);
         InstallingFrame {
-            saved_locals,
+            saved_locals_base,
             saved_upvalues,
             seeded,
         }
@@ -76,11 +73,14 @@ impl Interpreter {
     /// blast radius minimal.
     pub(crate) fn leave_installing_frame(&mut self, code: &CompiledCode, st: InstallingFrame) {
         let InstallingFrame {
-            saved_locals,
+            saved_locals_base,
             saved_upvalues,
             seeded,
         } = st;
-        let handler_locals = std::mem::replace(&mut self.locals, saved_locals);
+        // The flush below reads the handler's slots, so copy them out before
+        // closing the frame — a frame's slots do not outlive it (ADR-0077).
+        let handler_locals = self.locals.to_vec();
+        self.locals.pop_frame(saved_locals_base);
         self.upvalues = saved_upvalues;
         for (i, name) in code.locals.iter().enumerate() {
             if name.is_empty() {

--- a/src/runtime/gc_roots.rs
+++ b/src/runtime/gc_roots.rs
@@ -61,7 +61,9 @@ impl Interpreter {
     /// execution registers.
     fn visit_vm_registers(&self, visitor: &mut dyn RootVisitor) {
         visit_slice(visitor, &self.stack);
-        visit_slice(visitor, &self.locals);
+        // Every frame's slots, not just the executing window (ADR-0077):
+        // suspended callers below `base` hold live values too.
+        visit_slice(visitor, self.locals.all_slots());
         for v in &self.upvalues {
             visit_opt(visitor, v);
         }
@@ -75,7 +77,6 @@ impl Interpreter {
         }
         for frame in &self.call_frames {
             frame.saved_env.visit_values(visitor);
-            visit_slice(visitor, &frame.saved_locals);
             for v in &frame.saved_upvalues {
                 visit_opt(visitor, v);
             }

--- a/src/runtime/locals.rs
+++ b/src/runtime/locals.rs
@@ -1,107 +1,208 @@
-//! The executing frame's slot array ([`Locals`]).
+//! The frame slot stack ([`Locals`]) — ADR-0077.
 //!
-//! This is ADR-0077 Slice 0: a newtype chokepoint around the representation,
-//! introduced *before* the representation changes. Today it wraps the
-//! `Vec<Value>` the pool hands out; Slice 2 replaces the inside with a window
-//! (`{ stack, base }`) into one contiguous locals stack, and the call sites
-//! that index or iterate slots do not have to change again when it does.
+//! Every live frame's slots live in **one contiguous `Vec<Value>`**, and the
+//! executing frame is the window `[base ..]` at the top of it. A call extends
+//! the vector (amortized O(1), no allocation once warm); a return truncates it.
+//! There is no per-frame vector, no free list, and no `mem::take` of the slot
+//! array — the caller's slots are simply the region below the callee's base.
 //!
-//! Two contracts the Slice 2 rewrite must preserve, because code all over the
-//! VM already relies on them:
+//! Slice 0 introduced this type as a `#[repr(transparent)]` newtype over the
+//! pooled `Vec<Value>` so the ~330 `self.locals[i]` sites and the ~100 that
+//! read through `Deref` would not have to change when the inside did. This is
+//! that change, and those sites indeed did not move.
 //!
-//! - **`self.locals[i]` addresses slot `i` of the *current* frame**, so
-//!   [`std::ops::Index`] must add the frame base rather than index the raw
-//!   stack.
-//! - **[`std::ops::Deref`] yields exactly the current frame's slots**, so `.len()`,
-//!   `.get()`, `.iter()` and the `&self.locals` → `&[Value]` coercions all
-//!   speak about this frame and nothing below it. That is what makes
-//!   ADR-0077's open question 1 (one stack or two) a real question: a locals
-//!   region that shared the operand stack would need a per-frame length here
-//!   rather than "everything above `base`".
+//! Three invariants the rest of the VM depends on:
 //!
-//! The JIT reads the slot words out of this field directly
-//! (`vm_jit_layout::JitLayout::locals`, `vm_jit_tier_b`'s GetLocal fast path),
-//! which is why the type is `#[repr(transparent)]` for now — see the
-//! size assertion in `vm_jit_layout`.
+//! - **The executing frame is always the top region.** [`Self::push_frame`]
+//!   sets `base` to the current length, so `[base ..]` is exactly this frame
+//!   and nothing else. `Index` and `Deref` are defined in those terms.
+//! - **A frame handle is an index, never a pointer.** Pushing a frame can
+//!   reallocate the vector, so nothing — Rust or JIT-emitted — may cache the
+//!   data pointer across a push. The JIT reloads it per access already
+//!   (`vm_jit_tier_b`'s GetLocal fast path), which is what makes this cheap.
+//! - **An enclosing frame is reached only through its base**, with
+//!   [`Self::frame_slots`], which stops at the executing frame's base. Reading
+//!   past a lower frame's length must not silently reach into the frame above
+//!   it.
+//!
+//! GC roots must visit [`Self::all_slots`], not the `Deref` window: the window
+//! is one frame, and every frame below it holds live values too.
 
 use crate::value::Value;
 
-/// The slot array of the frame currently executing.
-#[repr(transparent)]
+/// A handle to the frame that was executing when a frame was opened.
+///
+/// Deliberately **not `Copy`**: [`Locals::pop_frame`] consumes it, so the
+/// compiler enforces one close per open exactly as the moved `Vec<Value>` did
+/// before frames shared a stack. That protection matters, because closing a
+/// frame twice is silently destructive — the second close truncates the
+/// *caller's* slots — and several call paths close on more than one exclusive
+/// exit branch, where only the move proves the branches really are exclusive.
+#[must_use = "an opened frame must be closed with Locals::pop_frame"]
+#[derive(Debug)]
+pub(crate) struct CallerFrame(usize);
+
+impl CallerFrame {
+    /// The caller's base, for the cross-frame sites that only need to *read*
+    /// where a saved frame starts. Reading is unrestricted; closing is not.
+    #[inline]
+    pub(crate) fn base(&self) -> usize {
+        self.0
+    }
+}
+
+/// All live frames' slots, plus the executing frame's base.
 #[derive(Debug, Default)]
-pub(crate) struct Locals(Vec<Value>);
+pub(crate) struct Locals {
+    /// Frame slots, oldest frame first. The executing frame occupies
+    /// `slots[base ..]`; everything below belongs to suspended callers.
+    slots: Vec<Value>,
+    /// Index of the executing frame's slot 0.
+    base: usize,
+}
 
 impl Clone for Locals {
     #[inline]
     fn clone(&self) -> Self {
-        Locals(self.0.clone())
+        Locals {
+            slots: self.slots.clone(),
+            base: self.base,
+        }
     }
 
-    /// Hand-written so it keeps `Vec`'s buffer reuse. `#[derive(Clone)]` would
-    /// inherit the default `clone_from` (`*self = source.clone()`), which
-    /// allocates — and the one caller (`clone_for_thread` seeding a hyper/race
-    /// worker's frame) reuses the vector on purpose.
+    /// Hand-written so it keeps `Vec`'s buffer reuse; `#[derive(Clone)]` would
+    /// inherit the allocating default (`*self = source.clone()`).
     #[inline]
     fn clone_from(&mut self, source: &Self) {
-        self.0.clone_from(&source.0);
+        self.slots.clone_from(&source.slots);
+        self.base = source.base;
     }
 }
 
 impl Locals {
-    /// An empty slot array (no frame, or a frame with no locals).
+    /// Byte offset of the slot vector inside `Locals`, for the Tier B JIT
+    /// emitter, which loads the `Vec` header words itself. Kept here because
+    /// the fields are private (see `vm_jit_layout`).
+    pub(crate) const SLOTS_BYTE_OFFSET: usize = std::mem::offset_of!(Locals, slots);
+    /// Byte offset of the executing frame's base, for the same reason.
+    pub(crate) const BASE_BYTE_OFFSET: usize = std::mem::offset_of!(Locals, base);
+
+    /// An empty stack with no frame.
     #[inline]
     pub(crate) fn new() -> Self {
-        Locals(Vec::new())
+        Locals {
+            slots: Vec::new(),
+            base: 0,
+        }
     }
 
-    /// Adopt an owned slot vector — a restored snapshot (a suspended `gather`
-    /// coroutine, an inline `CATCH` handler frame), not a live frame.
+    /// Open a frame of `num_locals` `Nil` slots on top of the stack and return
+    /// the **caller's base**, to be handed back to [`Self::pop_frame`]. This
+    /// replaces both `mem::take(&mut self.locals)` (`push_frame(0)`) and the
+    /// old locals pool (`push_frame(n)`).
     #[inline]
-    pub(crate) fn from_vec(v: Vec<Value>) -> Self {
-        Locals(v)
+    pub(crate) fn push_frame(&mut self, num_locals: usize) -> CallerFrame {
+        let caller_base = self.base;
+        self.base = self.slots.len();
+        self.slots.resize(self.base + num_locals, Value::NIL);
+        CallerFrame(caller_base)
     }
 
-    /// Copy the frame's slots out into an owned vector, for a snapshot that
-    /// outlives the frame.
+    /// Open a frame holding a copy of `slots` — restoring an owned snapshot
+    /// (a suspended `gather` coroutine, a hyper/race worker's seed frame).
     #[inline]
-    pub(crate) fn to_vec(&self) -> Vec<Value> {
-        self.0.clone()
+    pub(crate) fn push_frame_from(&mut self, slots: &[Value]) -> CallerFrame {
+        let caller_base = self.base;
+        self.base = self.slots.len();
+        self.slots.extend_from_slice(slots);
+        CallerFrame(caller_base)
     }
 
-    /// A fresh frame of `num_locals` `Nil` slots. Used by the inline-exec sites
-    /// that install a frame without going through the pool (a `gather` body, a
-    /// closure entered outside the light call path); Slice 2 turns each of them
-    /// into a base push.
+    /// Seed the *root* frame of an interpreter whose frame stack starts empty —
+    /// a worker VM that is discarded whole when its task ends, so this frame is
+    /// never closed and there is no handle to return.
     #[inline]
-    pub(crate) fn nils(num_locals: usize) -> Self {
-        Locals(vec![Value::NIL; num_locals])
+    pub(crate) fn install_root_frame(&mut self, slots: &[Value]) {
+        debug_assert!(
+            self.slots.is_empty() && self.base == 0,
+            "install_root_frame is for a fresh stack; use push_frame_from otherwise"
+        );
+        self.slots.extend_from_slice(slots);
     }
 
-    /// Resize the frame to `num_locals` slots, keeping the values of the slots
-    /// that survive and filling any new ones with `Nil` — `Vec::resize`
-    /// semantics, unlike [`Self::refill`], which drops every existing value.
-    /// The top-level `run` entry needs this: it sizes the program frame and
-    /// then seeds slots from `env`, and a re-entrant run must not lose the
-    /// slots already there.
+    /// Drop the executing frame's slots and make the caller's frame current
+    /// again. Consumes the handle, because doing this twice would truncate the
+    /// caller's own slots.
+    #[inline]
+    pub(crate) fn pop_frame(&mut self, caller: CallerFrame) {
+        self.slots.truncate(self.base);
+        self.base = caller.0;
+    }
+
+    /// Replace the executing frame with `num_locals` fresh `Nil` slots, keeping
+    /// its base. This is what "install a new slot array in the current frame"
+    /// (`self.locals = vec![Nil; n]`) means once frames share a stack.
+    #[inline]
+    pub(crate) fn refill_slots(&mut self, num_locals: usize) {
+        self.slots.truncate(self.base);
+        self.slots.resize(self.base + num_locals, Value::NIL);
+    }
+
+    /// Replace the executing frame's slots with a copy of `slots`, keeping its
+    /// base.
+    #[inline]
+    pub(crate) fn refill_from(&mut self, slots: &[Value]) {
+        self.slots.truncate(self.base);
+        self.slots.extend_from_slice(slots);
+    }
+
+    /// Resize the executing frame to `num_locals` slots, *keeping* the values
+    /// of the slots that survive — `Vec::resize` semantics, unlike
+    /// [`Self::refill_slots`]. The top-level `run` entry needs this: it sizes
+    /// the program frame and then seeds slots from `env`, and a re-entrant run
+    /// must not lose the slots already there.
     #[inline]
     pub(crate) fn resize_slots(&mut self, num_locals: usize) {
-        self.0.resize(num_locals, Value::NIL);
+        self.slots.resize(self.base + num_locals, Value::NIL);
     }
 
-    /// Reset to `num_locals` `Nil` slots, reusing the buffer. Pairs with
-    /// [`Self::release`]; together they are the whole of the pool's API, so
-    /// Slice 2 replaces the pool by rewriting these two and nothing else.
+    /// Copy the executing frame's slots out, for a snapshot that outlives it.
     #[inline]
-    pub(crate) fn refill(&mut self, num_locals: usize) {
-        self.0.clear();
-        self.0.resize(num_locals, Value::NIL);
+    pub(crate) fn to_vec(&self) -> Vec<Value> {
+        self.slots[self.base..].to_vec()
     }
 
-    /// Drop the frame's slot values but keep the buffer, at a well-defined
-    /// point rather than inside the pool.
+    /// The executing frame's base, i.e. the handle [`Self::push_frame`] would
+    /// hand back. Needed to bound the topmost *saved* frame's region.
     #[inline]
-    pub(crate) fn release(&mut self) {
-        self.0.clear();
+    pub(crate) fn base(&self) -> usize {
+        self.base
+    }
+
+    /// The slots of the frame based at `base`, which must be the frame directly
+    /// below the executing one: the region stops at the executing frame's base,
+    /// so an out-of-range slot cannot reach into the frame above it.
+    #[inline]
+    pub(crate) fn frame_slots(&self, caller: &CallerFrame) -> &[Value] {
+        &self.slots[caller.0..self.base]
+    }
+
+    /// One slot by *absolute* stack index, for the cross-frame propagation sites
+    /// (a shared container has to reach the same lexical in every suspended
+    /// frame that owns it). The caller derives the index from a frame's region,
+    /// which is why this cannot bound-check the frame for you — see
+    /// `propagate_shared_container_to_frames`.
+    #[inline]
+    pub(crate) fn absolute_slot_mut(&mut self, index: usize) -> &mut Value {
+        &mut self.slots[index]
+    }
+
+    /// Every live slot in every frame. **This, not the `Deref` window, is what
+    /// a GC root scan must visit** — the window covers one frame, and the
+    /// frames below it hold live values.
+    #[inline]
+    pub(crate) fn all_slots(&self) -> &[Value] {
+        &self.slots
     }
 }
 
@@ -110,14 +211,14 @@ impl std::ops::Index<usize> for Locals {
 
     #[inline]
     fn index(&self, slot: usize) -> &Value {
-        &self.0[slot]
+        &self.slots[self.base + slot]
     }
 }
 
 impl std::ops::IndexMut<usize> for Locals {
     #[inline]
     fn index_mut(&mut self, slot: usize) -> &mut Value {
-        &mut self.0[slot]
+        &mut self.slots[self.base + slot]
     }
 }
 
@@ -126,14 +227,14 @@ impl std::ops::Deref for Locals {
 
     #[inline]
     fn deref(&self) -> &[Value] {
-        &self.0
+        &self.slots[self.base..]
     }
 }
 
 impl std::ops::DerefMut for Locals {
     #[inline]
     fn deref_mut(&mut self) -> &mut [Value] {
-        &mut self.0
+        &mut self.slots[self.base..]
     }
 }
 
@@ -141,33 +242,134 @@ impl std::ops::DerefMut for Locals {
 mod tests {
     use super::*;
 
-    #[test]
-    fn refill_and_release_reuse_the_buffer() {
-        let mut l = Locals::new();
-        l.refill(3);
-        assert_eq!(l.len(), 3);
-        assert!(l.iter().all(|v| v.is_nil()));
-        l[1] = Value::int(7);
-        assert_eq!(l[1].as_int(), Some(7));
-        let cap_before = l.to_vec().capacity();
-        l.release();
-        assert_eq!(l.len(), 0);
-        l.refill(2);
-        assert_eq!(l.len(), 2);
-        // The point of the pool: refilling after a release does not have to
-        // grow from zero again.
-        assert!(cap_before > 0);
+    fn ints(l: &Locals) -> Vec<Option<i64>> {
+        l.iter().map(|v| v.as_int()).collect()
     }
 
-    /// `Deref` is the frame window every `.len()` / `.iter()` / `&self.locals`
-    /// site reads through, so pin that it agrees with `Index`.
     #[test]
-    fn deref_window_agrees_with_index() {
-        let mut l = Locals::from_vec(vec![Value::int(1), Value::int(2)]);
-        assert_eq!(l.len(), 2);
-        assert_eq!(l.get(1).and_then(|v| v.as_int()), Some(2));
+    fn a_frame_is_the_top_window() {
+        let mut l = Locals::new();
+        let outer = l.push_frame(2);
+        assert_eq!(outer.base(), 0);
+        l[0] = Value::int(1);
+        l[1] = Value::int(2);
+        assert_eq!(ints(&l), vec![Some(1), Some(2)]);
+
+        // A callee's frame hides the caller's, and indexing is frame-relative.
+        let caller = l.push_frame(1);
+        assert_eq!(l.len(), 1);
         l[0] = Value::int(9);
-        assert_eq!(l.first().and_then(|v| v.as_int()), Some(9));
-        assert_eq!(l.to_vec().len(), 2);
+        assert_eq!(ints(&l), vec![Some(9)]);
+
+        // The caller's slots are still there, reachable only through its base,
+        // and the region stops at the callee's base — the callee's own slot 0
+        // must not be reachable as the caller's slot 2.
+        let outer_slots: Vec<_> = l.frame_slots(&caller).iter().map(|v| v.as_int()).collect();
+        assert_eq!(outer_slots, vec![Some(1), Some(2)]);
+
+        l.pop_frame(caller);
+        assert_eq!(ints(&l), vec![Some(1), Some(2)]);
+        l.pop_frame(outer);
+        assert_eq!(l.len(), 0);
+    }
+
+    #[test]
+    fn push_frame_zero_is_an_empty_window_over_a_live_caller() {
+        let mut l = Locals::new();
+        let outer = l.push_frame(1);
+        l[0] = Value::int(7);
+        // What `mem::take(&mut self.locals)` used to do: the frame reads empty.
+        let caller = l.push_frame(0);
+        assert!(l.is_empty());
+        // The callee then sizes its own frame in place.
+        l.refill_slots(2);
+        assert_eq!(ints(&l), vec![None, None]);
+        l.pop_frame(caller);
+        assert_eq!(ints(&l), vec![Some(7)]);
+        l.pop_frame(outer);
+    }
+
+    #[test]
+    fn refill_replaces_and_resize_keeps() {
+        let mut l = Locals::new();
+        let _root = l.push_frame(2);
+        l[0] = Value::int(1);
+        l[1] = Value::int(2);
+
+        l.resize_slots(3);
+        assert_eq!(
+            ints(&l),
+            vec![Some(1), Some(2), None],
+            "resize keeps values"
+        );
+
+        l.refill_slots(2);
+        assert_eq!(ints(&l), vec![None, None], "refill drops them");
+
+        l.refill_from(&[Value::int(5)]);
+        assert_eq!(ints(&l), vec![Some(5)]);
+    }
+
+    /// The GC hazard this slice introduces: `Deref` is one frame, so a root
+    /// scan that reads through it would miss every suspended caller's slots.
+    #[test]
+    fn all_slots_spans_every_frame_not_just_the_window() {
+        let mut l = Locals::new();
+        let _root = l.push_frame(2);
+        l[0] = Value::int(1);
+        l[1] = Value::int(2);
+        let caller = l.push_frame(1);
+        l[0] = Value::int(3);
+
+        assert_eq!(l.len(), 1, "the window is the executing frame");
+        assert_eq!(l.all_slots().len(), 3, "roots span all frames");
+        let all: Vec<_> = l.all_slots().iter().map(|v| v.as_int()).collect();
+        assert_eq!(all, vec![Some(1), Some(2), Some(3)]);
+        l.pop_frame(caller);
+    }
+
+    #[test]
+    fn snapshots_round_trip_through_an_owned_vec() {
+        let mut l = Locals::new();
+        let _root = l.push_frame(2);
+        l[0] = Value::int(1);
+        l[1] = Value::int(2);
+        let snap = l.to_vec();
+        assert_eq!(
+            snap.len(),
+            2,
+            "a snapshot is the frame, not the whole stack"
+        );
+
+        let caller = l.push_frame_from(&snap);
+        assert_eq!(ints(&l), vec![Some(1), Some(2)]);
+        l.pop_frame(caller);
+        assert_eq!(ints(&l), vec![Some(1), Some(2)]);
+    }
+
+    /// Closing a frame restores the caller's slots exactly, at any depth. The
+    /// handle is consumed, so closing twice is a compile error rather than the
+    /// silent truncation of the caller's own slots it would otherwise be —
+    /// several call paths close on more than one exclusive exit branch, and that
+    /// move is what proves the branches are exclusive.
+    #[test]
+    fn closing_a_frame_restores_the_caller_at_any_depth() {
+        let mut l = Locals::new();
+        let f0 = l.push_frame(1);
+        l[0] = Value::int(4);
+        let f1 = l.push_frame(2);
+        l[0] = Value::int(5);
+        let f2 = l.push_frame(0);
+        l.refill_slots(1);
+        l[0] = Value::int(6);
+        assert_eq!(l.all_slots().len(), 4);
+
+        l.pop_frame(f2);
+        assert_eq!(ints(&l), vec![Some(5), None]);
+        l.pop_frame(f1);
+        assert_eq!(ints(&l), vec![Some(4)]);
+        l.pop_frame(f0);
+        assert_eq!(l.len(), 0);
+        assert_eq!(l.all_slots().len(), 0, "the stack drains with the frames");
     }
 }

--- a/src/runtime/locals.rs
+++ b/src/runtime/locals.rs
@@ -82,9 +82,14 @@ impl Clone for Locals {
 impl Locals {
     /// Byte offset of the slot vector inside `Locals`, for the Tier B JIT
     /// emitter, which loads the `Vec` header words itself. Kept here because
-    /// the fields are private (see `vm_jit_layout`).
+    /// the fields are private (see `vm_jit_layout`). Gated like its only
+    /// consumer: with `jit` off, `vm_jit_layout` is not compiled and these
+    /// would be dead code — a warning only the `--no-default-features
+    /// --features native` lint configuration can see.
+    #[cfg(feature = "jit")]
     pub(crate) const SLOTS_BYTE_OFFSET: usize = std::mem::offset_of!(Locals, slots);
     /// Byte offset of the executing frame's base, for the same reason.
+    #[cfg(feature = "jit")]
     pub(crate) const BASE_BYTE_OFFSET: usize = std::mem::offset_of!(Locals, base);
 
     /// An empty stack with no frame.

--- a/src/runtime/locals.rs
+++ b/src/runtime/locals.rs
@@ -13,7 +13,7 @@
 //!
 //! Three invariants the rest of the VM depends on:
 //!
-//! - **The executing frame is always the top region.** [`Self::push_frame`]
+//! - **The executing frame is always the top region.** [`Locals::push_frame`]
 //!   sets `base` to the current length, so `[base ..]` is exactly this frame
 //!   and nothing else. `Index` and `Deref` are defined in those terms.
 //! - **A frame handle is an index, never a pointer.** Pushing a frame can
@@ -21,11 +21,11 @@
 //!   data pointer across a push. The JIT reloads it per access already
 //!   (`vm_jit_tier_b`'s GetLocal fast path), which is what makes this cheap.
 //! - **An enclosing frame is reached only through its base**, with
-//!   [`Self::frame_slots`], which stops at the executing frame's base. Reading
+//!   [`Locals::frame_slots`], which stops at the executing frame's base. Reading
 //!   past a lower frame's length must not silently reach into the frame above
 //!   it.
 //!
-//! GC roots must visit [`Self::all_slots`], not the `Deref` window: the window
+//! GC roots must visit [`Locals::all_slots`], not the `Deref` window: the window
 //! is one frame, and every frame below it holds live values too.
 
 use crate::value::Value;

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1883,18 +1883,12 @@ pub struct Interpreter {
     /// rendered frame of its own; this origin supplies its enclosing location
     /// without inventing a mainline frame for every worker backtrace.
     pub(crate) thread_spawn_origin: Option<(Symbol, u32)>,
-    /// Recycled `locals` backing vectors. The frame-less VM fast paths take the
-    /// caller's `locals` aside and need a fresh Vec per call; popping one here
-    /// instead of allocating removes a malloc/free pair per call (recursion
-    /// otherwise allocates one per frame down the whole chain). Entries are
-    /// cleared before being returned to the pool; bounded by `LOCALS_POOL_MAX`.
-    pub(crate) locals_pool: Vec<Locals>,
     /// Recycled *argument* buffers for the named/spec light call paths, which
     /// need a contiguous `Vec<Value>` of the drained arguments rather than a
-    /// frame's slot array. These used to borrow `locals_pool`, which conflated
+    /// frame's slot array. These used to borrow the locals pool, which conflated
     /// two different things: ADR-0077 makes `Locals` a window into one
     /// contiguous stack, and a window cannot be handed out as an owned buffer.
-    /// Same bound and same clear-before-return discipline as `locals_pool`.
+    /// Bounded, and cleared before being returned to the pool.
     pub(crate) args_scratch_pool: Vec<Vec<Value>>,
     /// Number of active CONTROL handlers in the current VM stack. Tracked
     /// on the interpreter (rather than per-VM) so that nested VMs (e.g.

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -2963,7 +2963,6 @@ impl Interpreter {
             test_pending_callsite_line: None,
             cur_source_line: 1,
             thread_spawn_origin: None,
-            locals_pool: Vec::new(),
             args_scratch_pool: Vec::new(),
             control_handler_depth: 0,
             test_assertion_line_stack: Vec::new(),

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -604,7 +604,6 @@ impl Interpreter {
             test_pending_callsite_line: None,
             cur_source_line: 1,
             thread_spawn_origin,
-            locals_pool: Vec::new(),
             args_scratch_pool: Vec::new(),
             control_handler_depth: 0,
             test_assertion_line_stack: Vec::new(),

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -360,7 +360,11 @@ pub(crate) struct VmCallFrame {
     /// The caller's `cur_source_line` at frame push, restored on pop (the line
     /// the callee body's ops advanced to must not leak into the caller).
     pub saved_cur_line: i64,
-    pub saved_locals: crate::runtime::locals::Locals,
+    /// Handle to the caller's slot frame, closed by `pop_call_frame` (ADR-0077:
+    /// a frame is a region of the shared slot stack, not its own vector). In an
+    /// `Option` only so that pop can move the handle out — closing a frame
+    /// consumes it — while still handing the frame back to its caller.
+    pub saved_locals_base: Option<crate::runtime::locals::CallerFrame>,
     pub saved_upvalues: Vec<Option<Value>>,
     pub saved_stack_depth: usize,
     /// Rollback mark of this frame's readonly scope (see

--- a/src/vm/vm_arith_int_ops.rs
+++ b/src/vm/vm_arith_int_ops.rs
@@ -205,7 +205,7 @@ impl Interpreter {
         // Run N times, collecting results
         let mut out = Vec::with_capacity(n);
         let saved_stack = std::mem::take(&mut self.stack);
-        let saved_locals = std::mem::take(&mut self.locals);
+        let saved_locals_base = self.locals.push_frame(0);
         // `run_reuse` executes the thunk's compiled ops directly on `self`
         // without resetting `self.upvalues` (unlike `with_nested_registers`,
         // which the map/grep eager loops go through) -- so a `GetUpvalue` in
@@ -230,7 +230,7 @@ impl Interpreter {
                 }
                 Err(e) => {
                     self.stack = saved_stack;
-                    self.locals = saved_locals;
+                    self.locals.pop_frame(saved_locals_base);
                     self.upvalues = saved_upvalues;
                     // Restore env
                     for (k, orig) in saved {
@@ -249,7 +249,7 @@ impl Interpreter {
         }
 
         self.stack = saved_stack;
-        self.locals = saved_locals;
+        self.locals.pop_frame(saved_locals_base);
         self.upvalues = saved_upvalues;
         // Restore env, but keep mutations to arrays (e.g. shift/pop
         // inside the thunk should persist).

--- a/src/vm/vm_call_fast.rs
+++ b/src/vm/vm_call_fast.rs
@@ -102,7 +102,7 @@ impl Interpreter {
         } else {
             None
         };
-        let saved_locals = std::mem::take(&mut self.locals);
+        let saved_locals_base = self.locals.push_frame(0);
         let saved_stack_depth = self.stack.len();
         // Isolate the caller's loop-body-local declaration scope. `run()` saves
         // and restores these per invocation; this fast path bypasses `run()` and
@@ -152,7 +152,7 @@ impl Interpreter {
 
         // Reuse a pooled locals vec to avoid per-call allocation
         let num_locals = cf.code.locals.len();
-        self.locals = self.take_locals_from_pool(num_locals);
+        self.locals.refill_slots(num_locals);
         // Seed from the pre-interned local names (see the matching comment in
         // `call_compiled_function_positional_light`).
         if cf.code.locals_sym.len() == num_locals {
@@ -296,8 +296,7 @@ impl Interpreter {
         // are visible in env for the merge step below.
 
         // Restore state
-        let used = std::mem::replace(&mut self.locals, saved_locals);
-        self.recycle_locals(used);
+        self.locals.pop_frame(saved_locals_base);
         self.loop_local_vars = saved_loop_local_vars;
         self.loop_local_saved_env = saved_loop_local_saved_env;
         self.active_loop_param_names = saved_active_loop_param_names;

--- a/src/vm/vm_call_light.rs
+++ b/src/vm/vm_call_light.rs
@@ -192,7 +192,7 @@ impl Interpreter {
             }
         }
 
-        let saved_locals = std::mem::take(&mut self.locals);
+        let saved_locals_base = self.locals.push_frame(0);
         // Isolate the caller's loop-body-local declaration scope (mirrors
         // `call_compiled_function` in vm_call_fast.rs). This fast path bypasses
         // `push_call_frame`/`run()`, so without clearing these a callee's
@@ -248,7 +248,7 @@ impl Interpreter {
         };
 
         let num_locals = cf.code.locals.len();
-        self.locals = self.take_locals_from_pool(num_locals);
+        self.locals.refill_slots(num_locals);
 
         // Read-through to the caller (parent tier) for the initial value of a
         // local that shadows a same-named caller variable, matching the prior
@@ -356,8 +356,7 @@ impl Interpreter {
                     }
                 }
             }
-            let used = std::mem::replace(&mut self.locals, saved_locals);
-            self.recycle_locals(used);
+            self.locals.pop_frame(saved_locals_base);
             self.loop_local_vars = saved_loop_local_vars;
             self.loop_local_saved_env = saved_loop_local_saved_env;
             self.active_loop_param_names = saved_active_loop_param_names;
@@ -632,8 +631,7 @@ impl Interpreter {
                 self.restore_pragma_state(saved_pragmas);
                 self.stack.truncate(saved_stack_depth.min(self.stack.len()));
                 self.cur_source_line = saved_line;
-                let used = std::mem::replace(&mut self.locals, saved_locals);
-                self.recycle_locals(used);
+                self.locals.pop_frame(saved_locals_base);
                 self.loop_local_vars = saved_loop_local_vars;
                 self.loop_local_saved_env = saved_loop_local_saved_env;
                 self.active_loop_param_names = saved_active_loop_param_names;
@@ -682,8 +680,7 @@ impl Interpreter {
         self.stack.truncate(saved_stack_depth);
 
         self.cur_source_line = saved_line;
-        let used = std::mem::replace(&mut self.locals, saved_locals);
-        self.recycle_locals(used);
+        self.locals.pop_frame(saved_locals_base);
         self.loop_local_vars = saved_loop_local_vars;
         self.loop_local_saved_env = saved_loop_local_saved_env;
         self.active_loop_param_names = saved_active_loop_param_names;

--- a/src/vm/vm_call_light_typed.rs
+++ b/src/vm/vm_call_light_typed.rs
@@ -65,7 +65,7 @@ impl Interpreter {
         };
         let saved_unit = self.enter_compilation_unit(cf);
         // Save caller locals and create callee locals
-        let saved_locals = std::mem::take(&mut self.locals);
+        let saved_locals_base = self.locals.push_frame(0);
         // Isolate the caller's loop-body-local declaration scope (mirrors
         // vm_call_fast.rs / the positional-light path). Without this a callee's
         // body-local `my $x` — e.g. a recursive call from inside the caller's
@@ -105,7 +105,7 @@ impl Interpreter {
         };
 
         let num_locals = cf.code.locals.len();
-        self.locals = self.take_locals_from_pool(num_locals);
+        self.locals.refill_slots(num_locals);
 
         // Borrow-deref a possibly-VarRef-wrapped argument without cloning it.
         #[inline]
@@ -374,8 +374,7 @@ impl Interpreter {
                     }
                 }
             }
-            let used = std::mem::replace(&mut self.locals, saved_locals);
-            self.recycle_locals(used);
+            self.locals.pop_frame(saved_locals_base);
             self.loop_local_vars = saved_loop_local_vars;
             self.loop_local_saved_env = saved_loop_local_saved_env;
             self.active_loop_param_names = saved_active_loop_param_names;
@@ -604,8 +603,7 @@ impl Interpreter {
                 self.restore_pragma_state(saved_pragmas);
                 self.stack.truncate(saved_stack_depth.min(self.stack.len()));
                 self.cur_source_line = saved_line;
-                let used = std::mem::replace(&mut self.locals, saved_locals);
-                self.recycle_locals(used);
+                self.locals.pop_frame(saved_locals_base);
                 self.loop_local_vars = saved_loop_local_vars;
                 self.loop_local_saved_env = saved_loop_local_saved_env;
                 self.active_loop_param_names = saved_active_loop_param_names;
@@ -655,8 +653,7 @@ impl Interpreter {
 
         self.cur_source_line = saved_line;
         // Restore locals
-        let used = std::mem::replace(&mut self.locals, saved_locals);
-        self.recycle_locals(used);
+        self.locals.pop_frame(saved_locals_base);
         self.loop_local_vars = saved_loop_local_vars;
         self.loop_local_saved_env = saved_loop_local_saved_env;
         self.active_loop_param_names = saved_active_loop_param_names;

--- a/src/vm/vm_call_method_compiled.rs
+++ b/src/vm/vm_call_method_compiled.rs
@@ -140,11 +140,20 @@ impl Interpreter {
         // protect block's own vardecl/store opcodes.
         let _mark_context_guard = crate::vm::vm_call_state_guard::MarkContextGuard::new(self);
         // Save/swap stack and locals for the block
-        let mut saved_locals = std::mem::take(&mut self.locals);
+        let saved_locals_base = self.locals.push_frame(0);
         let saved_stack = std::mem::take(&mut self.stack);
+        // A detached copy of the enclosing frame's slots. This path reads the
+        // enclosing lexicals through `outer_local_slots` *and* writes the
+        // block's free-variable writes back into them, then restores the whole
+        // array on exit — so the copy is the semantics, not an artifact of the
+        // old per-frame `Vec` (ADR-0077 Slice 2 kept it deliberately; making it
+        // copy-free means writing through to the live region below `base`,
+        // which is a behavior change on the panic path and belongs in its own
+        // slice).
+        let mut saved_locals = self.locals.frame_slots(&saved_locals_base).to_vec();
 
         // Initialize locals for the block
-        self.locals = crate::runtime::Locals::nils(block_cc.locals.len());
+        self.locals.refill_slots(block_cc.locals.len());
         if captured_env.is_some() {
             for (slot, name) in captured_bindings.iter() {
                 if (name.starts_with('@') || name.starts_with('%'))
@@ -266,8 +275,10 @@ impl Interpreter {
         // Get return value before restoring state
         let ret_val = self.stack.pop().unwrap_or(Value::NIL);
 
-        // Restore outer state
-        self.locals = saved_locals;
+        // Restore outer state: close the block's frame, then write the enclosing
+        // frame's slots back from the copy the writeback above mutated.
+        self.locals.pop_frame(saved_locals_base);
+        self.locals.refill_from(&saved_locals);
         self.stack = saved_stack;
 
         match exec_err {

--- a/src/vm/vm_call_named_inner.rs
+++ b/src/vm/vm_call_named_inner.rs
@@ -266,7 +266,7 @@ impl Interpreter {
             );
         }
 
-        self.locals = crate::runtime::Locals::nils(cf.code.locals.len());
+        self.locals.refill_slots(cf.code.locals.len());
         // `locals_sym` is the pre-interned twin of `locals` (empty only for a
         // hand-built chunk that never ran `compute_locals_sym`); reading the
         // seed values through it saves one string intern per local per call.

--- a/src/vm/vm_closure_dispatch.rs
+++ b/src/vm/vm_closure_dispatch.rs
@@ -866,7 +866,7 @@ impl Interpreter {
             }
         }
 
-        self.locals = crate::runtime::Locals::nils(cc.locals.len());
+        self.locals.refill_slots(cc.locals.len());
         for (i, local_name) in cc.locals.iter().enumerate() {
             if let Some(val) = self.env().get(local_name) {
                 self.locals[i] = val.clone();

--- a/src/vm/vm_env_helpers.rs
+++ b/src/vm/vm_env_helpers.rs
@@ -19,7 +19,8 @@ impl Interpreter {
     /// [`Self::recycle_args_scratch`].
     ///
     /// This is deliberately *not* the locals pool, which it used to borrow: an
-    /// argument buffer is an owned vector, and ADR-0077 turns [`Locals`] into a
+    /// argument buffer is an owned vector, and ADR-0077 turns
+    /// [`crate::runtime::Locals`] into a
     /// window into a shared stack that cannot be handed out as one.
     #[inline]
     pub(super) fn take_args_scratch(&mut self) -> Vec<Value> {

--- a/src/vm/vm_env_helpers.rs
+++ b/src/vm/vm_env_helpers.rs
@@ -1,5 +1,4 @@
 use super::*;
-use crate::runtime::Locals;
 
 impl Interpreter {
     /// Collapse the interpreter's env to a flat (`parent=None`) env if it is
@@ -11,32 +10,6 @@ impl Interpreter {
         if self.env().is_scoped() {
             let flat = self.env().flattened();
             *self.env_mut() = flat;
-        }
-    }
-
-    /// Grab a slot array from the recycle pool (or allocate the first time),
-    /// sized to `num_locals` with `Nil` slots. Pair with [`Self::recycle_locals`].
-    ///
-    /// These two functions are the *whole* of the pool's API (ADR-0077 Slice 0):
-    /// every other site speaks to [`Locals`] through indexing or `Deref`, so
-    /// Slice 2 retires the pool by rewriting this pair and the frame
-    /// save/restore sites, not the hundreds of slot accesses.
-    #[inline]
-    pub(super) fn take_locals_from_pool(&mut self, num_locals: usize) -> Locals {
-        let mut v = self.locals_pool.pop().unwrap_or_default();
-        v.refill(num_locals);
-        v
-    }
-
-    /// Return a used slot array to the recycle pool (bounded; excess is
-    /// simply dropped). Releasing here also drops the callee's slot values at a
-    /// well-defined point instead of inside the pool.
-    #[inline]
-    pub(super) fn recycle_locals(&mut self, mut used: Locals) {
-        const LOCALS_POOL_MAX: usize = 64;
-        if self.locals_pool.len() < LOCALS_POOL_MAX {
-            used.release();
-            self.locals_pool.push(used);
         }
     }
 
@@ -84,7 +57,7 @@ impl Interpreter {
             saved_env: self.env().clone(),
             saved_cur_line: self.cur_source_line,
             readonly_mark: self.enter_readonly_frame(),
-            saved_locals: std::mem::take(&mut self.locals),
+            saved_locals_base: Some(self.locals.push_frame(0)),
             saved_upvalues: std::mem::take(&mut self.upvalues),
             saved_stack_depth: self.stack.len(),
             saved_local_bind_pairs: std::mem::take(&mut self.local_bind_pairs),
@@ -117,7 +90,7 @@ impl Interpreter {
             saved_env: self.env().clone(),
             saved_cur_line: self.cur_source_line,
             readonly_mark: self.enter_readonly_frame(),
-            saved_locals: std::mem::take(&mut self.locals),
+            saved_locals_base: Some(self.locals.push_frame(0)),
             saved_upvalues: std::mem::take(&mut self.upvalues),
             saved_stack_depth: self.stack.len(),
             saved_local_bind_pairs: std::mem::take(&mut self.local_bind_pairs),
@@ -143,7 +116,9 @@ impl Interpreter {
             .pop()
             .expect("pop_call_frame: no frame to pop");
         self.cur_source_line = frame.saved_cur_line;
-        self.locals = std::mem::take(&mut frame.saved_locals);
+        if let Some(caller) = frame.saved_locals_base.take() {
+            self.locals.pop_frame(caller);
+        }
         self.upvalues = std::mem::take(&mut frame.saved_upvalues);
         self.local_bind_pairs = std::mem::take(&mut frame.saved_local_bind_pairs);
         self.loop_local_vars = std::mem::take(&mut frame.saved_loop_local_vars);

--- a/src/vm/vm_helpers_lazy.rs
+++ b/src/vm/vm_helpers_lazy.rs
@@ -1194,7 +1194,7 @@ impl Interpreter {
         // here; we restore locals directly on return.
         crate::vm::vm_stats::record_clone_env();
         let saved_env = self.clone_env();
-        let saved_locals = std::mem::take(&mut self.locals);
+        let saved_locals_base = self.locals.push_frame(0);
         let saved_stack = std::mem::take(&mut self.stack);
         // `LazyList` has no upvalue array of its own (its captures live in
         // `list.env`, installed as the scoped env below) -- this inline exec
@@ -1238,7 +1238,7 @@ impl Interpreter {
         self.push_gather_take_limit(None);
 
         // Initialize locals for the compiled code
-        self.locals = crate::runtime::Locals::nils(cc.locals.len());
+        self.locals.refill_slots(cc.locals.len());
         for (i, name) in cc.locals.iter().enumerate() {
             if let Some(val) = self.env().get(name) {
                 self.locals[i] = val.clone();
@@ -1346,7 +1346,7 @@ impl Interpreter {
 
         // Restore Interpreter state
         self.state_scope_id.set(saved_state_scope);
-        self.locals = saved_locals;
+        self.locals.pop_frame(saved_locals_base);
         self.stack = saved_stack;
         self.upvalues = saved_upvalues;
 

--- a/src/vm/vm_helpers_lazy_pull.rs
+++ b/src/vm/vm_helpers_lazy_pull.rs
@@ -87,7 +87,7 @@ impl Interpreter {
         // Save current Interpreter state
         crate::vm::vm_stats::record_clone_env();
         let saved_env = self.clone_env();
-        let saved_locals = std::mem::take(&mut self.locals);
+        let saved_locals_base = self.locals.push_frame(0);
         let saved_stack = std::mem::take(&mut self.stack);
         // See the matching comment in `force_lazy_list_vm_inner`: this inline
         // exec bypasses closure dispatch, and `LazyList` has no upvalue array
@@ -119,7 +119,7 @@ impl Interpreter {
             if !coro.finished && (coro.ip > 0 || coro.started) {
                 // Resume from saved state
                 ip = coro.ip;
-                self.locals = crate::runtime::Locals::from_vec(coro.locals.clone());
+                self.locals.refill_from(&coro.locals.clone());
                 self.stack = coro.stack.clone();
                 *self.env_mut() = coro.env.clone();
                 self.gather_for_loop_resume = coro.for_loop_resume.clone();
@@ -132,7 +132,7 @@ impl Interpreter {
                 // accumulate across takes without forking `list.env`.
                 ip = 0;
                 *self.env_mut() = crate::env::Env::scoped_child(list.env.flattened());
-                self.locals = crate::runtime::Locals::nils(cc.locals.len());
+                self.locals.refill_slots(cc.locals.len());
                 for (i, name) in cc.locals.iter().enumerate() {
                     if let Some(val) = self.env().get(name) {
                         self.locals[i] = val.clone();
@@ -145,7 +145,7 @@ impl Interpreter {
             // Fresh start (no coroutine slot yet)
             ip = 0;
             *self.env_mut() = crate::env::Env::scoped_child(list.env.flattened());
-            self.locals = crate::runtime::Locals::nils(cc.locals.len());
+            self.locals.refill_slots(cc.locals.len());
             for (i, name) in cc.locals.iter().enumerate() {
                 if let Some(val) = self.env().get(name) {
                     self.locals[i] = val.clone();
@@ -302,7 +302,7 @@ impl Interpreter {
 
         // Restore Interpreter state
         self.state_scope_id.set(saved_state_scope);
-        self.locals = saved_locals;
+        self.locals.pop_frame(saved_locals_base);
         self.stack = saved_stack;
         self.upvalues = saved_upvalues;
 

--- a/src/vm/vm_hyper_race_parallel.rs
+++ b/src/vm/vm_hyper_race_parallel.rs
@@ -61,7 +61,7 @@ impl Interpreter {
             .map(|chunk| chunk.to_vec())
             .collect();
         let pre_shared_keys = self.shared_var_keys_snapshot();
-        let locals_snapshot = self.locals.clone();
+        let locals_snapshot = self.locals.to_vec();
         type ThreadResult = (Result<Vec<Value>, RuntimeError>, Vec<Value>, String, String);
         let mut batch_results: Vec<ThreadResult> = Vec::with_capacity(batches.len());
         let collect = spec.collect;
@@ -75,7 +75,7 @@ impl Interpreter {
             // GetLocal slots must exist. `clone_for_thread` starts a
             // fresh frame for `start {}` / Promise workers; copy the
             // current locals (and upvalues) so the body can run here.
-            vm.locals.clone_from(&locals_snapshot);
+            vm.locals.install_root_frame(&locals_snapshot);
             vm.upvalues.clone_from(&self.upvalues);
             // Joined hyper/race fan-out belongs on the elastic worker pool
             // (ADR-0020 §3.6), not on one fresh OS thread per batch.

--- a/src/vm/vm_jit_layout.rs
+++ b/src/vm/vm_jit_layout.rs
@@ -15,9 +15,17 @@ use super::*;
 pub(super) struct JitLayout {
     /// Byte offset of `Interpreter::stack` (a `Vec<Value>`).
     pub(super) stack: i32,
-    /// Byte offset of `Interpreter::locals` (a `Vec<Value>`) — the Tier B
-    /// GetLocal fast path reads slot words in place (ADR-0004 J4d).
+    /// Byte offset of the slot `Vec<Value>` inside `Interpreter::locals` — the
+    /// Tier B GetLocal fast path reads slot words in place (ADR-0004 J4d).
+    /// `locals` is a [`crate::runtime::Locals`] (ADR-0077): one shared stack
+    /// plus the executing frame's base, so this is the *stack*, and slot `i` of
+    /// the current frame is at `locals_base + i`.
     pub(super) locals: i32,
+    /// Byte offset of the executing frame's base word (a `usize`) inside
+    /// `Interpreter::locals`. Tier B must add it to every slot index and
+    /// subtract it from the length when bounds-checking; it changes on every
+    /// call, so it is loaded per access exactly like the `Vec` header words.
+    pub(super) locals_base: i32,
     /// Byte offsets of the per-Interpreter gate flags the GetLocal fast path
     /// loads (both plain `bool` fields).
     pub(super) atomic_var_seen: i32,
@@ -35,14 +43,6 @@ fn probe_vec_layout() -> Option<(i32, i32, i32)> {
     const WORD: usize = std::mem::size_of::<usize>();
     const {
         assert!(std::mem::size_of::<Vec<Value>>() == 3 * WORD);
-        // `Interpreter::locals` is a `Locals` (ADR-0077 Slice 0), and the
-        // GetLocal fast path applies the probed `Vec<Value>` word offsets at
-        // that field's address. That is sound only while `Locals` is
-        // `#[repr(transparent)]` over the vector. Slice 2 gives `Locals` a base
-        // index, at which point this assertion fires and the emitter in
-        // `vm_jit_tier_b` must learn the base — which is the intended tripwire,
-        // not an obstacle.
-        assert!(std::mem::size_of::<crate::runtime::Locals>() == std::mem::size_of::<Vec<Value>>());
     }
     let mut v: Vec<Value> = Vec::with_capacity(7);
     v.push(Value::int(1));
@@ -75,7 +75,10 @@ pub(super) fn layout() -> Option<&'static JitLayout> {
             let (vec_ptr, vec_len, vec_cap) = probe_vec_layout()?;
             Some(JitLayout {
                 stack: std::mem::offset_of!(Interpreter, stack) as i32,
-                locals: std::mem::offset_of!(Interpreter, locals) as i32,
+                locals: (std::mem::offset_of!(Interpreter, locals)
+                    + crate::runtime::Locals::SLOTS_BYTE_OFFSET) as i32,
+                locals_base: (std::mem::offset_of!(Interpreter, locals)
+                    + crate::runtime::Locals::BASE_BYTE_OFFSET) as i32,
                 atomic_var_seen: std::mem::offset_of!(Interpreter, atomic_var_seen) as i32,
                 sigilless_attrs_active: std::mem::offset_of!(Interpreter, sigilless_attrs_active)
                     as i32,

--- a/src/vm/vm_jit_tier_b.rs
+++ b/src/vm/vm_jit_tier_b.rs
@@ -547,8 +547,13 @@ impl TierB {
         let word_chk = b.create_block();
         b.ins().brif(spoiled, slow_blk, &[], word_chk, &[]);
 
-        // -- slot word load (bounds-checked: a non-standard runner may have
-        // installed a shorter locals vec; the shim handles that shape).
+        // -- slot word load. Slots live in one shared stack and the executing
+        // frame starts at `locals_base` (ADR-0077), so slot `idx` is the
+        // absolute element `base + idx`, and the frame's length is
+        // `len - base`. Both words are loaded per access — a push can
+        // reallocate the stack and every call moves the base, so neither may be
+        // cached across an access. Bounds-checked because a non-standard runner
+        // may have installed a shorter frame; the shim handles that shape.
         b.switch_to_block(word_chk);
         let lptr = b.ins().load(
             self.ptr_ty,
@@ -562,14 +567,31 @@ impl TierB {
             self.interp,
             self.lay.locals + self.lay.vec_len,
         );
+        let lbase = b
+            .ins()
+            .load(types::I64, Self::mf(), self.interp, self.lay.locals_base);
+        // `len - base` is the frame's slot count. An unsigned compare against
+        // it also rejects the (impossible, but not statically provable) case of
+        // a base past the length: the wrapped-around difference is huge, so
+        // guard the subtraction with `base <= len` first.
+        let base_ok = b.ins().icmp(IntCC::UnsignedLessThanOrEqual, lbase, llen);
+        let len_chk = b.create_block();
+        b.ins().brif(base_ok, len_chk, &[], slow_blk, &[]);
+        b.switch_to_block(len_chk);
+        let frame_len = b.ins().isub(llen, lbase);
         let inbounds = b
             .ins()
-            .icmp_imm(IntCC::UnsignedGreaterThan, llen, idx as i64);
+            .icmp_imm(IntCC::UnsignedGreaterThan, frame_len, idx as i64);
         let tag_chk = b.create_block();
         b.ins().brif(inbounds, tag_chk, &[], slow_blk, &[]);
 
         b.switch_to_block(tag_chk);
-        let word = b.ins().load(types::I64, Self::mf(), lptr, (idx as i32) * 8);
+        // byte offset = (base + idx) * 8, computed from the base register since
+        // only `idx` is a compile-time constant.
+        let abs = b.ins().iadd_imm(lbase, idx as i64);
+        let byte_off = b.ins().imul_imm(abs, 8);
+        let slot_addr = b.ins().iadd(lptr, byte_off);
+        let word = b.ins().load(types::I64, Self::mf(), slot_addr, 0);
         // Refcount-free scalar probe: small Int page, encoded-Num page range,
         // Bool kind, or Package kind. Everything else (Nil included — the arm
         // has a whole undeclared-check branch for it) goes to the shim.

--- a/src/vm/vm_method_dispatch.rs
+++ b/src/vm/vm_method_dispatch.rs
@@ -773,7 +773,7 @@ impl Interpreter {
             crate::vm::vm_call_state_guard::ThreadParamMaskGuard::new(self, bind_param_defs.iter());
 
         // Initialize locals from env
-        self.locals = crate::runtime::Locals::nils(cc.locals.len());
+        self.locals.refill_slots(cc.locals.len());
         for (i, local_name) in cc.locals.iter().enumerate() {
             if let Some(val) = self.env().get(local_name) {
                 self.locals[i] = val.clone();
@@ -1834,7 +1834,7 @@ impl Interpreter {
         // Populate locals directly. Attribute reads take one read guard over
         // the live cell for the whole loop (dropped before the body runs) —
         // no whole-map snapshot is materialized.
-        self.locals = crate::runtime::Locals::nils(cc.locals.len());
+        self.locals.refill_slots(cc.locals.len());
 
         {
             let attrs_guard = attrs_cell.as_ref().map(|c| c.as_map());

--- a/src/vm/vm_misc_block.rs
+++ b/src/vm/vm_misc_block.rs
@@ -89,7 +89,7 @@ impl Interpreter {
         // declares a routine, so the common case pays nothing.
         let routine_snapshot = scope_routines.then(|| self.snapshot_routine_registry());
         let saved_env = if scope_isolate {
-            Some((self.env().clone(), self.locals.clone()))
+            Some((self.env().clone(), self.locals.to_vec()))
         } else {
             None
         };

--- a/src/vm/vm_misc_reduction_scan.rs
+++ b/src/vm/vm_misc_reduction_scan.rs
@@ -291,7 +291,7 @@ impl Interpreter {
         let body_end = body_end as usize;
         let saved = self.current_package().to_string();
         let saved_env = self.env().clone();
-        let saved_locals = self.locals.clone();
+        let saved_locals = self.locals.to_vec();
         self.set_current_package(name.clone());
         self.run_range(code, *ip + 1, body_end, compiled_fns)?;
         self.set_current_package(saved);
@@ -373,7 +373,7 @@ impl Interpreter {
                 restored_env.insert_sym(*k, v.clone());
             }
         }
-        self.locals = saved_locals;
+        self.locals.refill_from(&saved_locals);
         // Only pull a slot's value back from `env` when the compiler actually
         // keeps that slot's env mirror live (`code.needs_env_sync`,
         // `compute_needs_env_sync` in `opcode.rs`). `env`'s bare keys are

--- a/src/vm/vm_run_loop.rs
+++ b/src/vm/vm_run_loop.rs
@@ -118,7 +118,7 @@ impl Interpreter {
     ) -> Result<Option<Value>, RuntimeError> {
         Self::validate_labels(code)?;
         // Initialize local variable slots
-        self.locals = crate::runtime::Locals::nils(code.locals.len());
+        self.locals.refill_slots(code.locals.len());
         for (i, name) in code.locals.iter().enumerate() {
             if let Some(val) = self.env().get(name) {
                 self.locals[i] = val.clone();
@@ -311,7 +311,7 @@ impl Interpreter {
         // Save the per-execution registers (the fields `Interpreter::new` initializes
         // fresh) and reset them to their fresh-Interpreter defaults for the nested run.
         let saved_stack = std::mem::take(&mut self.stack);
-        let saved_locals = std::mem::take(&mut self.locals);
+        let saved_locals_base = self.locals.push_frame(0);
         let saved_upvalues = std::mem::take(&mut self.upvalues);
         let saved_call_frames = std::mem::take(&mut self.call_frames);
         let saved_resume_ip = self.resume_ip.take();
@@ -405,7 +405,7 @@ impl Interpreter {
 
         // Restore the outer execution registers.
         self.stack = saved_stack;
-        self.locals = saved_locals;
+        self.locals.pop_frame(saved_locals_base);
         self.upvalues = saved_upvalues;
         self.call_frames = saved_call_frames;
         self.resume_ip = saved_resume_ip;

--- a/src/vm/vm_var_assign_coerce.rs
+++ b/src/vm/vm_var_assign_coerce.rs
@@ -815,9 +815,20 @@ impl Interpreter {
         self.set_env_with_main_alias(&resolved_source, container.clone());
         // Propagate the shared cell into saved call frames so the sharing
         // survives method returns (env restore).
+        // Slots now live in one shared stack (ADR-0077), so a saved frame is a
+        // `[base, end)` region rather than its own vector: walking downwards,
+        // the region a frame saved ends where that frame's own base begins, and
+        // the topmost one ends at the executing frame's base. Collect the writes
+        // during the walk (which borrows `call_frames` mutably for the env
+        // inserts) and apply them to the slot stack afterwards.
+        let mut end = self.locals.base();
+        let mut shared_slot_writes: Vec<usize> = Vec::new();
         for frame in self.call_frames.iter_mut().rev() {
+            let Some(base) = frame.saved_locals_base.as_ref().map(|c| c.base()) else {
+                continue;
+            };
             // `code.locals` is this frame's slot layout, not the parent's; only
-            // write a parent frame's `saved_locals` when that frame owns the source
+            // write a parent frame's slots when that frame owns the source
             // lexical (its saved env holds the name), else the callee slot index
             // clobbers an unrelated same-index local.
             if frame.saved_env.contains_key_own_tier(&resolved_source) {
@@ -825,11 +836,15 @@ impl Interpreter {
                     .saved_env
                     .insert(resolved_source.clone(), container.clone());
                 for (i, local_name) in code.locals.iter().enumerate() {
-                    if local_name == &resolved_source && i < frame.saved_locals.len() {
-                        frame.saved_locals[i] = container.clone();
+                    if local_name == &resolved_source && base + i < end {
+                        shared_slot_writes.push(base + i);
                     }
                 }
             }
+            end = base;
+        }
+        for slot in shared_slot_writes {
+            *self.locals.absolute_slot_mut(slot) = container.clone();
         }
         // Store the shared cell in the scalar target (itemized scalar).
         self.locals[idx] = container.clone();

--- a/t/locals-frame-stack-gc-roots.t
+++ b/t/locals-frame-stack-gc-roots.t
@@ -1,0 +1,56 @@
+use v6;
+use Test;
+
+# ADR-0077: every live frame's slots share one contiguous stack, and the
+# executing frame is the window at the top of it. A GC root scan must therefore
+# visit the WHOLE stack, not the window -- the frames below hold live values that
+# nothing else references. Reading roots through the window instead was the one
+# way this slice could break silently: the program keeps running and only frees
+# values it should not have.
+#
+# Each test below holds a heap value in a slot of a frame that is then suspended
+# by a deeper call, forces collector work while it is suspended, and checks the
+# value on the way back out.
+
+plan 4;
+
+class Node { has $.v is rw; has $.next is rw }
+
+# 1. A plain suspended-frame slot survives a deep call under GC pressure.
+sub deep-scalar($n) {
+    my $held = Node.new(v => $n);
+    deep-scalar($n - 1) if $n > 0;
+    return $held.defined && $held.v == $n;
+}
+ok deep-scalar(150), 'a suspended frame keeps its slot value across a deep call';
+
+# 2. Cycle-capable objects (the collector's actual subject) held only by
+#    suspended frames.
+sub deep-cycle($n) {
+    my $a = Node.new(v => $n);
+    my $b = Node.new(v => $n * 2);
+    $a.next = $b;
+    $b.next = $a;             # a cycle: only the collector can free it
+    my $sum = $n > 0 ?? deep-cycle($n - 1) !! 0;
+    return $sum + $a.v + $a.next.v;
+}
+is deep-cycle(60), (^61).map({ $_ * 3 }).sum,
+    'cyclic objects held only by suspended frames stay reachable';
+
+# 3. Containers, not just scalars, in suspended frames.
+sub deep-array($n) {
+    my @held = $n, $n + 1, $n + 2;
+    my %map = a => $n;
+    deep-array($n - 1) if $n > 0;
+    return @held.join(',') eq "$n,{$n + 1},{$n + 2}" && %map<a> == $n;
+}
+ok deep-array(120), 'suspended frames keep array and hash slots';
+
+# 4. Recursion far deeper than the retired locals pool's 64-entry bound, which
+#    is where a per-frame vector used to start allocating and freeing per call.
+sub deep-count($n) {
+    my $x = $n;
+    return $x if $n == 0;
+    return $x + deep-count($n - 1);
+}
+is deep-count(800), (1..800).sum, 'deep recursion past the old pool bound is correct';


### PR DESCRIPTION
Until now each call got its own `Vec<Value>` of slots, borrowed from `locals_pool`: pop a vector, `clear` it, `resize` it with `Value::NIL`, `mem::take` the caller's aside, run the body, push the used one back. [#7562](https://github.com/tokuhirom/mutsu/issues/7562) put that at ~5.7% of `bench-fib`'s profile, and the callgrind cross-check recorded in ADR-0077 found the two surviving halves at 2.03% (`Vec::resize`) and 1.95% (`recycle_locals`) of retired instructions, once per call each — to hold one value, since `fib`'s only local is its parameter.

Every live frame's slots now live in one contiguous vector, with the executing frame as the window at the top:

```rust
pub(crate) struct Locals { slots: Vec<Value>, base: usize }
```

A call extends the vector; a return truncates it. `locals_pool`, `take_locals_from_pool`, `recycle_locals` and every `mem::take(&mut self.locals)` are gone, and `VmCallFrame` carries a frame handle instead of a whole vector. **Slice 1 of the ADR folds in here** — it described turning `saved_locals` into a base index while keeping a pooled vector for the live frame, which is not a state that exists, so there was nothing for an intermediate slice to be tested against.

Keeping the stack *inside* `Locals` rather than as a second `Interpreter` field is what kept the migration local: there is still one `locals` field, `Index` became `slots[base + slot]`, `Deref` became `slots[base..]`, and nothing has to borrow two interpreter fields at once. **Slice 0's newtype paid off exactly as designed — the ~330 `self.locals[i]` sites and the ~100 that read through `Deref` did not move again.** The ~40 structural sites reduced to three shapes: open/close a frame, replace the executing frame's slots, or copy a frame out and back for a snapshot that outlives it (a suspended `gather` coroutine, an inline `CATCH` handler frame, a hyper/race worker's seed).

## The frame handle is not `Copy`, and that was learned the hard way

The first version returned a bare `usize` from `push_frame` and documented `pop_frame` as idempotent. **Its own unit test failed**: closing a frame twice truncates the *caller's* slots, because the second call truncates to a base that is already the caller's.

The old code had been protected from that by accident — it moved a `Vec<Value>`, so a double restore did not compile — and several paths (`vm_arith_int_ops`) close a frame on more than one exclusive exit branch, where that move was the only proof the branches really were exclusive. Replacing the vector with a plain integer silently discarded the proof. `push_frame` now returns a non-`Copy` `CallerFrame` that `pop_frame` consumes, restoring exactly that guarantee, and `#[must_use]` immediately found the hyper/race worker pushing a root frame it never closes — legitimate, since a worker VM is discarded whole, and now stated as `install_root_frame` rather than left as a warning.

## The GC hazard, and the test that pins it

`gc_roots` visited `&self.locals` plus each call frame's `saved_locals`. `Deref` now yields only the executing frame, so a root scan reading through it would miss every suspended caller's slots and free live values while the program kept running — the one way this slice could have broken silently. It visits `all_slots()` instead, which also makes the scan one slice visit rather than one per frame.

`t/locals-frame-stack-gc-roots.t` pins the end-to-end property: values, cyclic objects and containers held only by frames suspended under a deep call survive, including past the retired pool's 64-entry bound. A unit test pins that `all_slots()` and the `Deref` window disagree in the direction they must.

That bound deserves its own note: `LOCALS_POOL_MAX` was 64, so a recursion deeper than that missed the pool **structurally** — the descent always found it empty — and paid a malloc and a free per call. No benchmark measured it (`fib`'s depth is 30); it is simply gone now.

## The JIT

Slice 0 left a `const { assert!(size_of::<Locals>() == size_of::<Vec<Value>>()) }` beside `vm_jit_layout`'s probe assertion precisely so this slice could not land without dealing with Tier B. It fired, as intended. The GetLocal emitter now loads `locals_base` alongside the `Vec` header words on every slot access — a push can reallocate and every call moves the base, so neither may be cached — reads the absolute element `base + idx`, and bounds-checks against `len - base` behind a `base <= len` guard. Verified by running the call- and loop-shaped benchmarks under `MUTSU_JIT=on` and `off` and comparing output.

## What is deliberately *not* in it

The strongest form — `locals_base = args_base`, where a callee whose locals are exactly its leading parameters pays *nothing* because the argument already sits in the cell the slot wants — needs locals on the **operand** stack. ADR-0077 framed "one stack or two" as a measurement; it is really a consequence of the `Deref` contract. "The executing frame is everything above `base`" stops holding the moment an operand push can land inside the window, so a fused stack needs a per-frame *length* as well as a base, and every `.len()` / `.iter()` / `&self.locals` site starts meaning something subtly different. That is a second, larger change wearing the first one's clothes, so it gets its own slice and its own measurement. The ADR's open question 1 is rewritten to say so, rather than leaving it looking like this slice dropped the win.

Two detached copies also remain on purpose. `vm_call_method_compiled` reads the enclosing frame's slots and writes a block's free-variable writes back into them before restoring the whole array, so the copy *is* the semantics — writing through to the live region below `base` changes behavior on the panic path, where the restore never runs. And the shared-container propagation in `vm_var_assign_coerce`, which walked `call_frames` writing `frame.saved_locals[i]`, now derives each saved frame's `[base, end)` region (walking downwards, a frame's region ends where its own base begins; the topmost ends at the executing base), collects the absolute indices during the walk, and applies them afterwards.

## Verification (all run locally before opening this PR)

| gate | result |
| --- | --- |
| `cargo fmt --all` | clean |
| `make lint` — clippy default, `jit` off, wasm32 lib, rustdoc | **green** |
| `make test` — `cargo test` + `prove t/` on release | **green** — Files=3869, Tests=41027, `Result: PASS` |
| `make roast` | **green modulo the three documented container artifacts** |
| `MUTSU_JIT=on` vs `off` | identical output on call- and loop-shaped programs |

The roast failures match `docs/agent-environments.md`'s container-artifact table down to the individual test numbers (`6.c/S32-io/file-tests.t` 6-8/10 and `S16-filehandles/filetest.t` 57-64/69-72/77-80/101…125 both `chmod` and assert `.r`/`.w`/`.x` is `False`, impossible as `uid 0`; `S32-io/IO-Socket-Async.t` times out at "planned 40 ran 17" behind the network sandbox). Nothing else failed.

**`make lint` failed three times getting here, and every one would have been a red `lint-configs` plus a fix-up commit** — worth recording, since all three were invisible to the pre-commit hook:

| # | configuration | cause |
| --- | --- | --- |
| 1 (Slice 0) | rustdoc | ``[`Index`]`` / ``[`Deref`]`` with neither trait imported in that module |
| 2 | clippy `--no-default-features --features native` | the JIT slot-offset consts are dead code with `jit` off |
| 3 | rustdoc | `Self::` in a `//!` module doc (rustdoc resolves against the *module*), plus a link that lost its import in this slice |

## Next

Open on #7562: the leading-parameter form (above), ADR-0077 Slice 3 (folding `outer_scope_locals` into the same stack, now that a block scope is just another base), and the two remaining copies.

Refs #7562

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KeMrW2npKb8WCC6zNH1osM

---
_Generated by [Claude Code](https://claude.ai/code/session_01KeMrW2npKb8WCC6zNH1osM)_