### PR TITLE
perf(env): pre-size the two env maps that knew their own size

### DIFF
--- a/news/2026-09/env-maps-grew-one-rehash-at-a-time.md
+++ b/news/2026-09/env-maps-grew-one-rehash-at-a-time.md
@@ -1,0 +1,85 @@
+# The env maps knew their size and grew one rehash at a time
+
+`bench-ctor`'s round 7, third slice (issue #7568). Rounds 5 and 6 each found
+work hidden inside the profile's flat `malloc`/`hashbrown` bucket — a per-call
+compile, then per-call name re-derivation. This is a third resident of that
+bucket, and the plainest one: **two hot maps were built by inserting into a
+zero-capacity `HashMap`, so each one climbed hashbrown's growth ladder on every
+single call.**
+
+The tool that showed it is the deterministic allocation counter
+(`--features alloc-stats` + `MUTSU_ALLOC_STATS=1`), not a profiler:
+`benchmarks/bench-ctor.raku` was spending **1,320,688 allocations on 5000
+constructions — 264 per constructed object.**
+
+## What changed
+
+**`Env::filtered_flat` pre-sizes its output.** This is the closure-capture
+primitive: it walks every visible env tier and copies the kept entries into a
+fresh map. `#5571` already stopped it materializing `GLOBAL_BASE`, and
+`vm_capture_cache` memoizes the result — but that memo is keyed on the tier
+addresses, so it can never hit for a closure created inside a *method* frame,
+whose env is fresh on every call. `@!resources.map(*.flat)` inside `TWEAK` is
+exactly that shape. So on this bench it ran in full 5000 times, inserting 31
+entries into a map starting at zero capacity: five reallocations and ~52 entry
+moves per construction.
+
+The chain's total overlay count is an upper bound on the result (`keep` can only
+reject entries, and a shadowing leaf entry overwrites a parent's rather than
+adding to it), so one walk up the parent chain gives a capacity that is right by
+construction.
+
+**The method frame's env overlay is reserved for its entry-time writes.** A
+method frame's overlay starts empty and immediately takes a known, fixed set:
+`self`, `__ANON_STATE__`, `?CLASS`, the topic, `$!`, the callable id, then one
+per bound parameter. That is 0 -> 3 -> 7 -> 14 on the growth ladder, per call.
+The call site knows the count, so a new `Env::reserve` pays one allocation
+instead. It goes through the same copy-on-write path the first `insert` would,
+so it does not bring the dual-store deep copy forward.
+
+**One thing measured and NOT kept.** `Env::flattened` looks like the same bug —
+it clones the root tier's map (exact capacity) and then inserts each tier's
+entries on top. Reserving the tiers' total there made the bench *slower*
+(+0.06% instructions): most tier keys shadow a root key rather than adding one,
+so the reserve buys a guaranteed rehash of an already-large cloned map to avoid
+a growth step that usually does not happen. Left alone, with this note so the
+next reader does not re-derive it.
+
+## Measured
+
+`benchmarks/bench-ctor.raku`, 5000 constructions, release, callgrind
+(deterministic instruction counts; this container has no `perf`):
+
+**1,351,955,875 -> 1,330,520,039 instructions, −1.59%.** Attributed by
+building each half on its own: the `filtered_flat` pre-size is about −1.3% of
+it and the method-frame reserve about −0.3%.
+
+Allocations over the run: **1,320,691 -> 1,290,691** (264 -> 258 per
+construction, −2.3%); bytes allocated **85.5 MB -> 78.8 MB, −7.9%**.
+
+Every other benchmark improves or is neutral — this is env machinery, not
+construction machinery (callgrind, same pair of binaries):
+
+| benchmark | before | after | |
+|---|---:|---:|---:|
+| `bench-ctor`  | 1,351,955,875 | 1,330,520,039 | −1.59% |
+| `poly-call`   |   579,516,389 |   574,559,327 | −0.86% |
+| `bench-class` | 1,179,747,564 | 1,171,770,757 | −0.68% |
+| `method-call` |   849,558,100 |   845,464,187 | −0.48% |
+| `bench-fib`   | 1,406,202,385 | 1,406,203,987 | +0.0001% |
+
+**Wall clock:** an interleaved same-session A/B (`taskset -c 2`, best of 15)
+reads 0.394s -> 0.391s, about −0.6%. Do not read that as the size of the win in
+either direction — this 4-core container's wall clock swings several percent
+between runs of the same binary (an earlier best-of-9 pair of the same two
+binaries read −2.8%), which is exactly why the ticket's measurement notes send
+document numbers to the bench CI (`bench-history.tsv` on `bench-data`) and why
+this write-up leads with instruction and allocation counts instead.
+
+## Lesson
+
+`alloc-stats` answers "how much does this region allocate" exactly and
+load-independently, and it named this in one run where three rounds of flat perf
+profiles had filed it under "malloc, no dominant function". When a profile is
+flat and allocation-heavy, count the allocations before reading the samples
+again.

--- a/src/env.rs
+++ b/src/env.rs
@@ -763,7 +763,25 @@ impl Env {
                 }
             }
         }
-        let mut out = SymMap::default();
+        // Pre-size from the chain's total overlay count. That is an upper
+        // bound on the result (`keep` can only reject entries, and a shadowing
+        // leaf entry overwrites a parent's rather than adding to it), so the
+        // map is allocated once instead of growing through hashbrown's
+        // `reserve_rehash` ladder. This runs per closure creation and the
+        // capture memo cannot help a closure created inside a *method* frame
+        // (its env is fresh on every call, so the tier addresses never repeat)
+        // -- on `benchmarks/bench-ctor.raku` that is 31 inserts into a map
+        // starting at zero capacity, i.e. five reallocations and ~52 entry
+        // moves, on every construction.
+        let mut cap = 0usize;
+        {
+            let mut cur = Some(self);
+            while let Some(env) = cur {
+                cap += env.inner.len();
+                cur = env.parent.as_deref();
+            }
+        }
+        let mut out = SymMap::with_capacity_and_hasher(cap, Default::default());
         collect(self, &mut out, keep);
         // `keep` may have rejected `?FILE`, so re-derive rather than inherit.
         let file_sym = out.get(&file_key()).and_then(file_sym_of);
@@ -877,6 +895,19 @@ impl Env {
             crate::vm::vm_stats::record_env_deep_copy();
         }
         Arc::make_mut(&mut self.inner)
+    }
+
+    /// Reserve room in this env's own overlay for `additional` more entries.
+    ///
+    /// A method frame's overlay starts empty and immediately takes a known,
+    /// fixed set of entry-time writes (`self`, `?CLASS`, the topic, `$!`, the
+    /// callable id, then one per bound parameter), which otherwise walk
+    /// hashbrown's `reserve_rehash` growth ladder — 0 -> 3 -> 7 -> 14 — on
+    /// every single call. The caller knows the count, so it can pay one
+    /// allocation instead. Takes the copy-on-write path exactly as the first
+    /// `insert` would, so this does not bring a deep copy forward.
+    pub(crate) fn reserve(&mut self, additional: usize) {
+        self.cow_mut().reserve(additional);
     }
 
     /// Clear a tombstone for `key` (it is being re-inserted, so it is no longer

--- a/src/vm/vm_method_dispatch.rs
+++ b/src/vm/vm_method_dispatch.rs
@@ -1720,6 +1720,9 @@ impl Interpreter {
         self.inject_class_body_statics(owner_class);
         if skip_env_setup {
             let env = self.env_mut();
+            // 4 fixed keys below (`self`, `__ANON_STATE__`, `?CLASS`, the
+            // topic) plus one per bound parameter -- see `Env::reserve`.
+            env.reserve(4 + param_values.len());
             env.insert_sym(crate::symbol::wk::self_(), base.clone());
             env.insert_sym(crate::symbol::wk::anon_state(), base.clone());
             env.insert_sym(crate::symbol::wk::class_decl(), class_val.clone());
@@ -1735,6 +1738,9 @@ impl Interpreter {
             Self::insert_fast_param_values(env, &param_values);
         } else {
             let env = self.env_mut();
+            // 6 fixed keys below plus one per bound parameter -- see
+            // `Env::reserve`.
+            env.reserve(6 + param_values.len());
             env.insert_sym(crate::symbol::wk::self_(), base.clone());
             env.insert_sym(crate::symbol::wk::anon_state(), base.clone());
             env.insert_sym(crate::symbol::wk::class_decl(), class_val.clone());


### PR DESCRIPTION
`bench-ctor` round 7 (#7568), slice 3. Follows #7641 and #7654.

Rounds 5 and 6 each found work hidden inside the profile's flat `malloc`/`hashbrown` bucket — a per-call *compile*, then per-call *name re-derivation*. This is a third resident of that bucket and the plainest one: **two hot maps were built by inserting into a zero-capacity `HashMap`, so each climbed hashbrown's growth ladder on every call.**

The tool that showed it is the deterministic allocation counter (`--features alloc-stats` + `MUTSU_ALLOC_STATS=1`), not a profiler: `benchmarks/bench-ctor.raku` was spending **1,320,691 allocations on 5000 constructions — 264 per constructed object.**

## What changed

**`Env::filtered_flat` pre-sizes its output.** This is the closure-capture primitive: it walks every visible env tier and copies the kept entries into a fresh map. #5571 already stopped it materializing `GLOBAL_BASE`, and `vm_capture_cache` memoizes the result — but that memo is keyed on the tier addresses, so **it can never hit for a closure created inside a *method* frame**, whose env is fresh on every call. `@!resources.map(*.flat)` inside `TWEAK` is exactly that shape, so on this bench it ran in full 5000 times, inserting 31 entries into a map starting at zero capacity: five reallocations and ~52 entry moves per construction.

The chain's total overlay count is an upper bound on the result (`keep` can only reject entries, and a shadowing leaf entry overwrites a parent's rather than adding one), so one walk up the parent chain gives a capacity that is right by construction.

**The method frame's env overlay is reserved for its entry-time writes.** A method frame's overlay starts empty and immediately takes a known, fixed set: `self`, `__ANON_STATE__`, `?CLASS`, the topic, `$!`, the callable id, then one per bound parameter. That is 0 → 3 → 7 → 14 on the growth ladder, per call. The call site knows the count, so a new `Env::reserve` pays one allocation instead. It goes through the same copy-on-write path the first `insert` would, so it does **not** bring the dual-store deep copy forward.

**One thing measured and NOT kept.** `Env::flattened` looks like the same bug — it clones the root tier's map (exact capacity) and then inserts each tier's entries on top. Reserving the tiers' total there made the bench *slower* (+0.06% instructions): most tier keys shadow a root key rather than adding one, so the reserve buys a guaranteed rehash of an already-large cloned map to avoid a growth step that usually does not happen. Left alone, with a note in the news entry so the next reader does not re-derive it.

## Measured

`benchmarks/bench-ctor.raku`, 5000 constructions, release, callgrind (deterministic counts; this container has no `perf`):

**1,351,955,875 → 1,330,520,039 instructions, −1.59%.**

Allocations over the run: **1,320,691 → 1,290,691** (264 → 258 per construction, −2.3%); bytes allocated **85.5 MB → 78.8 MB, −7.9%**.

Every other benchmark improves or is neutral — this is env machinery, not construction machinery (callgrind, same pair of binaries):

| benchmark | before | after | |
|---|---:|---:|---:|
| `bench-ctor`  | 1,351,955,875 | 1,330,520,039 | −1.59% |
| `poly-call`   |   579,516,389 |   574,559,327 | −0.86% |
| `bench-class` | 1,179,747,564 | 1,171,770,757 | −0.68% |
| `method-call` |   849,558,100 |   845,464,187 | −0.48% |
| `bench-fib`   | 1,406,202,385 | 1,406,203,987 | +0.0001% |

**Wall clock:** interleaved A/B (`taskset -c 2`, best of 15) reads 0.394s → 0.391s, about −0.6%. Please don't read that as the size of the win in either direction — this 4-core container swings several percent between runs of the *same* binary (an earlier best-of-9 of the same two binaries read −2.8%), which is why the ticket's measurement notes send document numbers to the bench CI (`bench-history.tsv` on `bench-data`) and why this leads with instruction and allocation counts.

## Testing

No behaviour change, so no new pin — the existing suites are the gate, and all ran locally on this exact tree before publishing:

- `make test` — 3872 files, 41064 tests, `Result: PASS`
- `make roast` — the only red files are the three documented container-caused ones (`6.c/S32-io/file-tests.t` and `S16-filehandles/filetest.t` under `uid 0`, `S32-io/IO-Socket-Async.t` under the network sandbox), with exactly the subtest sets `docs/agent-environments.md` records
- `make lint` — all four configurations clean
- `cargo fmt --all`

Write-up: `news/2026-09/env-maps-grew-one-rehash-at-a-time.md`. Refs #7568 (the ticket stays open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019eBZJJxUuTryUW982Ggz3r

---
_Generated by [Claude Code](https://claude.ai/code/session_019eBZJJxUuTryUW982Ggz3r)_