### PR TITLE
fix(parser): do not distribute a metamethod over a hyper postfix

### DIFF
--- a/news/2026-09/hyper-postfix-does-not-distribute-a-metamethod.md
+++ b/news/2026-09/hyper-postfix-does-not-distribute-a-metamethod.md
@@ -1,0 +1,46 @@
+# A hyper postfix no longer distributes a metamethod
+
+`».` hypers ordinary method calls only. A **metamethod** after it (`».^name`) is
+not distributed — rakudo applies it to the container. mutsu distributed it, so
+the two disagreed on every `>>.^...` expression:
+
+```raku
+my @a = Int, Str;
+say (@a>>.^name).raku;
+# raku:            "Array"
+# mutsu (before):  ["Int", "Str"]
+```
+
+The gap was specific to the `.^` form. An ordinary method after `».` distributes
+in both (`@a>>.Str` is `["1", "2"]` either way), and mutsu already agreed with
+rakudo on the other introspection dotties — `».WHAT`, `».HOW`, `».VAR` and
+`».DEFINITE` all answer about the container in both implementations. Only `.^`
+was hypered.
+
+## The fix
+
+A parse-level one, as the ticket expected. In the hyper-postfix branch of the
+postfix loop, a `.^` immediately after `»`/`>>` (followed by a method-name start)
+now hands the `.^meth` back to the plain dotted-call branch with the target
+expression untouched, so it compiles exactly as the hyper-less spelling would.
+Everything else after `».` — plain methods, `.?`, `.+`, `.*`, `.[...]`,
+`.{...}`, `.(...)`, `.++` — keeps hypering as before.
+
+## Why it matters beyond the literal expression
+
+The spelling people actually reach for, `.^mro>>.^name`, was affected: it means
+different things in the two implementations, which is how this was found —
+writing `t/pseudostash-type.t` for
+[#7588](https://github.com/tokuhirom/mutsu/issues/7588), the natural
+`PseudoStash.^mro>>.^name.join(' ')` passed under mutsu and failed under rakudo,
+and the difference turned out to be this rather than the MRO under test. Such a
+pin can now be written the natural way.
+
+## Pins
+
+`t/hyper-postfix-metamethod.t` covers the `Array`, `List` and instance-array
+forms, the `»` spelling, a chained `».^name.^name`, the `.^mro>>.^name` spelling
+above, and three controls where an ordinary method after `».` must still
+distribute. All nine assertions were checked against rakudo.
+
+Closes [#7643](https://github.com/tokuhirom/mutsu/issues/7643).

--- a/src/parser/expr/postfix/loop_.rs
+++ b/src/parser/expr/postfix/loop_.rs
@@ -2941,6 +2941,24 @@ fn postfix_expr_loop_from(
             // Check for ».method / >>.method and modifier forms like ».?method, ».+method, »!Type::meth.
             let had_dot = after_hyper.starts_with('.');
             let r = after_hyper.strip_prefix('.').unwrap_or(after_hyper);
+            // `».^meth` / `>>.^meth` does NOT distribute: `».` hypers ordinary
+            // method calls, and rakudo applies the metamethod to the CONTAINER
+            // (`my @a = Int, Str; @a>>.^name` is `"Array"`, not
+            // `["Int", "Str"]`). The other introspection dotties mutsu already
+            // treats this way (`».WHAT`/`».HOW`/`».VAR`/`».DEFINITE` all answer
+            // about the container in both implementations); only the `.^` form
+            // was distributing. Hand the `.^meth` back to the plain dotted-call
+            // branch at the top of this loop, with `expr` untouched, so it
+            // compiles exactly as the hyper-less spelling would.
+            if had_dot
+                && let Some(after_caret) = r.strip_prefix('^')
+                && after_caret.chars().next().is_some_and(|c| {
+                    c.is_alphanumeric() || matches!(c, '_' | '$' | '@' | '%' | '&')
+                })
+            {
+                rest = after_hyper;
+                continue;
+            }
             // Hyper dotted postfix update: >>.++ / >>.--
             if let Some((op, len)) = parse_postfix_update_op(r) {
                 let name = match op.token_kind() {

--- a/t/hyper-postfix-metamethod.t
+++ b/t/hyper-postfix-metamethod.t
@@ -1,0 +1,32 @@
+use Test;
+
+# `».` hypers ordinary method calls only. A METAMETHOD after it (`».^name`) is
+# not distributed: rakudo applies it to the container. See GitHub issue #7643.
+#
+# Every assertion here was checked against rakudo, so the file passes there too.
+
+plan 9;
+
+# 1-3. The metamethod applies to the container, not to each element.
+my @a = Int, Str;
+is (@a>>.^name).raku, '"Array"', 'a hyper metamethod names the Array, not its elements';
+
+is ((Int, Str)>>.^name).raku, '"List"', 'the same for a List';
+
+my @b = 1, 2;
+is (@b>>.^name).raku, '"Array"', 'and for an Array of instances';
+
+# 4. The Unicode spelling behaves identically.
+is (@b».^name).raku, '"Array"', 'the » spelling behaves the same';
+
+# 5. Chained: the second metamethod applies to the first one's Str result.
+is (@b>>.^name.^name).raku, '"Str"', 'a chained metamethod applies to the result';
+
+# 6. The spelling this was found through (`.^mro>>.^name`).
+is (Int.^mro>>.^name).raku, '"List"', '.^mro>>.^name names the mro list itself';
+
+# 7-9. Controls: an ordinary method after `».` still distributes.
+is (@b>>.Str).raku, '["1", "2"]', 'a plain method after ». still distributes';
+is (@b>>.Str>>.chars).raku, '[1, 1]', 'two hypered plain methods still distribute';
+my @c = <a b>;
+is (@c>>.uc).raku, '["A", "B"]', 'and so does a hypered .uc';


### PR DESCRIPTION
`».` hypers ordinary method calls only. A **metamethod** after it (`».^name`) is not distributed — rakudo applies it to the container. mutsu distributed it, so the two disagreed on every `>>.^...` expression:

```raku
my @a = Int, Str;
say (@a>>.^name).raku;
# raku:            "Array"
# mutsu (before):  ["Int", "Str"]
```

## The gap is specific to `.^`

Measured against rakudo `v2026.07` across the whole dotty family before touching anything — mutsu already agreed on every introspection dotty except `.^`:

| expression | raku | mutsu before |
|---|---|---|
| `(@a>>.^name).raku` | `"Array"` | **`["Int", "Int"]`** |
| `(@a>>.WHAT).raku` | `Array` | `Array` |
| `(@a>>.HOW).^name` | `…ClassHOW+…` | same |
| `(@a>>.DEFINITE).raku` | `Bool::True` | same |
| `(@a>>.VAR).^name` | `Array` | same |
| `(@a>>.Str).raku` | `["1", "2"]` | same |
| `(@a>>.?Str).raku` | `["1", "2"]` | same |

## The fix

A parse-level one, as the ticket expected. In the hyper-postfix branch of the postfix loop, a `.^` immediately after `»`/`>>` (followed by a method-name start) now hands the `.^meth` back to the plain dotted-call branch at the top of the loop with the target expression untouched, so it compiles exactly as the hyper-less spelling would. Everything else after `».` — plain methods, `.?`, `.+`, `.*`, `.[...]`, `.{...}`, `.(...)`, `.++`/`.--` — keeps hypering as before.

## Why it matters beyond the literal expression

The spelling people actually reach for, `.^mro>>.^name`, was affected: it meant different things in the two implementations, which is how this was found — writing `t/pseudostash-type.t` for #7588, the natural `PseudoStash.^mro>>.^name.join(' ')` passed under mutsu and failed under rakudo, and the difference turned out to be this rather than the MRO under test. Such a pin can now be written the natural way.

## Tests

`t/hyper-postfix-metamethod.t` (new) covers the `Array`, `List` and instance-array forms from the issue, the `»` spelling, a chained `».^name.^name`, the `.^mro>>.^name` spelling above, and three controls where an ordinary method after `».` must still distribute. All nine assertions were checked against rakudo (9/9 there too).

Two remaining `>>.^…` differences are *content*, not distribution, and are out of scope here — both operands now agree on the receiver: `Array.WHO` (mutsu returns an empty stash) and `Array.^can("Str")` (rakudo finds 2 candidates, mutsu 1).

## Verification

- `cargo fmt --all`, `make lint` — all four configurations green.
- TAP suite on the release binary — 3873 files, 41057 tests, `Result: PASS`.
- `make roast` — 1436 files, 218939 tests. The only failures are the three documented remote-container environment-only files, matching [`docs/agent-environments.md`](https://github.com/tokuhirom/mutsu/blob/main/docs/agent-environments.md) by name and subtest range: `roast/6.c/S32-io/file-tests.t` (`Failed: 4`, tests 6-8, 10), `roast/S16-filehandles/filetest.t` (`Failed: 25`, tests 57-64, 69-72, 77-80, 101/103/105/107/109/111/117/121/125) — both because the container runs as `uid 0` — and `roast/S32-io/IO-Socket-Async.t` (exit 124, "planned 40 ran 17", sandboxed network).

Closes #7643

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0122oqVGqfXxNqf9uJEABZvB

---
_Generated by [Claude Code](https://claude.ai/code/session_0122oqVGqfXxNqf9uJEABZvB)_