### PR TITLE
fix(vm): report what a Range slice assignment stored, not the raw RHS

### DIFF
--- a/news/2026-09/range-slice-assignment-reports-what-it-stored.md
+++ b/news/2026-09/range-slice-assignment-reports-what-it-stored.md
@@ -1,0 +1,67 @@
+# A Range slice assignment reports the list it stored
+
+`(@d[0..0] = 5)` answered the bare `5` where rakudo answers `(5,)`:
+
+```raku
+my @d; say (@d[0..0] = 5).raku;    # raku: (5,)   mutsu (before): 5
+my @d; say (@d[0..^1] = 5).raku;   # raku: (5,)   mutsu (before): 5
+```
+
+This is the sibling of the `@d[0,]` comma spelling fixed in #7589, with a
+different root cause — which is why it was left out of that PR rather than
+widening it.
+
+## Root cause
+
+A Range subscript on a plain (non-native, non-hash) positional array was **not**
+expanded into an index list: the `expand_range` gate in
+`src/vm/vm_var_assign_index_named.rs` was limited to hash variables and native
+typed arrays. So the Range never reached the `ValueView::Array(keys, kind)`
+slice arm that builds `assigned_values`, and fell through to the shared tail,
+where `idx_is_single_element` is false for a Range and the fallback simply
+returns the raw RHS.
+
+That is why the multi-element case *looked* right: `@d[0..1] = 5, 6` returned the
+RHS list `(5, 6)`, which happens to equal the stored list. With one slot the raw
+RHS is the bare `5` and the accident stops working — and a short RHS exposed the
+same gap the other way, `@d[0..2] = 5,` answering `(5,)` instead of rakudo's
+padded `(5, Any, Any)`.
+
+## The fix
+
+The second of the two shapes the ticket sketched, the one that removes a
+duplicate rule rather than adding one: `expand_range` now also covers a plain
+positional array, so a finite Range subscript becomes the index list the
+existing slice arm already handles correctly — for the storage *and* for the
+value it reports.
+
+It is guarded on a finite end (`b != i64::MAX && b >= 0`), the same precedent the
+Buf slice arm nearby uses, so an infinite or `Whatever`-ended Range (`@a[0..*]`,
+`@a[^Inf]`) is still never enumerated.
+
+A bonus from routing through the one arm: the short-RHS *storage* padding lines
+up with rakudo too. `my @d; @d[0..2] = 5,` used to leave `[5, Nil, Nil]` and now
+leaves `[5, Any, Any]`.
+
+## Pins
+
+`t/range-slice-assign-rvalue.t` covers the three one-element Range spellings
+(`0..0`, `0..^1`, `^1`), the padded short RHS, the multi-element and
+single-index controls, the `@d[0,]` comma spelling from #7589, and three
+storage assertions. All ten were checked against rakudo.
+
+`t/range-slice-assignment.t`, `t/slice-assign-generic-range.t`,
+`t/hash-range-slice-assign.t`, `t/slice-assign-pads-short-rhs.t`,
+`t/slice-assign-one-element-rvalue.t` and `roast/S09-subscript/slice.t` pass
+unchanged.
+
+## Left open
+
+A `Whatever`-ended Range slice assignment (`@d[1..*] = 9`) grows the array to
+100002 elements instead of clipping to its current length. That reproduces
+identically with and without this change — verified by building both ways — so
+it is pre-existing and filed separately as
+[#7674](https://github.com/tokuhirom/mutsu/issues/7674) rather than widening
+this fix.
+
+Closes [#7651](https://github.com/tokuhirom/mutsu/issues/7651).

--- a/src/vm/vm_var_assign_index_named.rs
+++ b/src/vm/vm_var_assign_index_named.rs
@@ -826,6 +826,27 @@ impl Interpreter {
             )
             && (vtc_native || ct_native);
         let expand_range = var_name.starts_with('%') || array_var_is_native;
+        // A finite Range subscript on a PLAIN positional array is a slice too,
+        // exactly like a comma list — so expand it here and let the one slice
+        // arm below both store the values and report what it stored. Left
+        // unexpanded, the Range fell through to the shared tail, where
+        // `idx_is_single_element` is false for a Range and the fallback simply
+        // returns the raw RHS: `(@d[0..0] = 5)` answered the bare `5` where
+        // rakudo answers `(5,)`, and a short RHS (`@d[0..2] = 5,`) answered
+        // `(5,)` instead of the padded `(5, Any, Any)`. The multi-element case
+        // only looked right by accident, the raw RHS list happening to equal
+        // the stored one. (#7651; #7589 fixed the `@d[0,]` comma spelling,
+        // whose root cause was a different one.)
+        //
+        // Guarded on a finite end: an infinite or `Whatever`-ended Range
+        // (`@a[0..*]`, `@a[^Inf]`) must not be enumerated. That is the same
+        // `b != i64::MAX` precedent the Buf slice arm below uses.
+        let expand_positional_range = !var_name.starts_with('%')
+            && matches!(
+                index_target_deref.as_ref().map(Value::view),
+                Some(ValueView::Array(..))
+            );
+        let finite_positional_range = |b: i64| expand_positional_range && b != i64::MAX && b >= 0;
         let idx = match idx.view() {
             ValueView::Seq(items) => Value::array_with_kind(
                 crate::value::Value::array_arc(items.to_vec()),
@@ -835,28 +856,28 @@ impl Interpreter {
                 crate::value::Value::array_arc(items.to_vec()),
                 crate::value::ArrayKind::List,
             ),
-            ValueView::Range(a, b) if expand_range => {
+            ValueView::Range(a, b) if expand_range || finite_positional_range(b) => {
                 let items: Vec<Value> = (a..=b).map(Value::int).collect();
                 Value::array_with_kind(
                     crate::gc::Gc::new(crate::value::ArrayData::new(items)),
                     crate::value::ArrayKind::List,
                 )
             }
-            ValueView::RangeExcl(a, b) if expand_range => {
+            ValueView::RangeExcl(a, b) if expand_range || finite_positional_range(b) => {
                 let items: Vec<Value> = (a..b).map(Value::int).collect();
                 Value::array_with_kind(
                     crate::gc::Gc::new(crate::value::ArrayData::new(items)),
                     crate::value::ArrayKind::List,
                 )
             }
-            ValueView::RangeExclStart(a, b) if expand_range => {
+            ValueView::RangeExclStart(a, b) if expand_range || finite_positional_range(b) => {
                 let items: Vec<Value> = ((a + 1)..=b).map(Value::int).collect();
                 Value::array_with_kind(
                     crate::gc::Gc::new(crate::value::ArrayData::new(items)),
                     crate::value::ArrayKind::List,
                 )
             }
-            ValueView::RangeExclBoth(a, b) if expand_range => {
+            ValueView::RangeExclBoth(a, b) if expand_range || finite_positional_range(b) => {
                 let items: Vec<Value> = ((a + 1)..b).map(Value::int).collect();
                 Value::array_with_kind(
                     crate::gc::Gc::new(crate::value::ArrayData::new(items)),

--- a/t/range-slice-assign-rvalue.t
+++ b/t/range-slice-assign-rvalue.t
@@ -1,0 +1,64 @@
+use Test;
+
+# A Range subscript on a plain positional array is a SLICE, so the assignment's
+# own value is the list it stored -- a one-element Range yields a one-element
+# list, not the bare element, and a short RHS reports the padded list. See
+# GitHub issue #7651 (sibling of #7589, which fixed the `@d[0,]` comma
+# spelling and had a different root cause).
+#
+# Every assertion was checked against rakudo, so the file passes there too.
+
+plan 10;
+
+# 1-3. The one-element Range spellings.
+{
+    my @d;
+    is (@d[0..0] = 5).raku, '(5,)', 'an inclusive one-element Range slice yields a one-element list';
+}
+{
+    my @d;
+    is (@d[0..^1] = 5).raku, '(5,)', 'the exclusive-end spelling yields a one-element list';
+}
+{
+    my @d;
+    is (@d[^1] = 5).raku, '(5,)', 'and so does the ^1 spelling';
+}
+
+# 4. A short RHS reports the padded list, not just what was given.
+{
+    my @d;
+    is (@d[0..2] = 5,).raku, '(5, Any, Any)', 'a short RHS over a Range reports the padded list';
+}
+
+# 5-6. Controls: a multi-element Range and a plain scalar subscript.
+{
+    my @d;
+    is (@d[0..1] = 5, 6).raku, '(5, 6)', 'a multi-element Range slice is unchanged';
+}
+{
+    my @d;
+    is (@d[0] = 5).raku, '5', 'a single-index subscript still yields the bare element';
+}
+
+# 7. The comma-list spelling (#7589) is unchanged.
+{
+    my @d;
+    is (@d[0,] = 5).raku, '(5,)', 'the one-element comma slice is unchanged';
+}
+
+# 8-10. Storage stays correct, including the short-RHS padding.
+{
+    my @d;
+    @d[0..0] = 5;
+    is @d.raku, '[5]', 'a one-element Range slice stores one element';
+}
+{
+    my @d;
+    @d[1..2] = 5, 6;
+    is @d.raku, '[Any, 5, 6]', 'an offset Range slice stores at the right indices';
+}
+{
+    my @d;
+    @d[0..2] = 5,;
+    is @d.raku, '[5, Any, Any]', 'a short RHS pads the remaining slots with Any';
+}


### PR DESCRIPTION
`(@d[0..0] = 5)` answered the bare `5` where rakudo answers `(5,)`:

```raku
my @d; say (@d[0..0] = 5).raku;    # raku: (5,)   mutsu (before): 5
my @d; say (@d[0..^1] = 5).raku;   # raku: (5,)   mutsu (before): 5
```

Sibling of the `@d[0,]` comma spelling fixed in #7589, with a different root cause — which is why it was left out of that PR.

## Root cause

A Range subscript on a plain (non-native, non-hash) positional array was **not** expanded into an index list: the `expand_range` gate in `src/vm/vm_var_assign_index_named.rs` covered only hash variables and native typed arrays. So the Range never reached the `ValueView::Array(keys, kind)` slice arm that builds `assigned_values`, and fell through to the shared tail, where `idx_is_single_element` is false for a Range and the fallback simply returns the raw RHS.

That is why the multi-element case only *looked* right: `@d[0..1] = 5, 6` returned the RHS list `(5, 6)`, which happens to equal the stored list. With one slot the raw RHS is the bare `5` and the accident stops working — and a short RHS exposed the same gap the other way, `@d[0..2] = 5,` answering `(5,)` instead of rakudo's padded `(5, Any, Any)`.

## The fix

The second of the ticket's two sketches — the one that removes a duplicate rule rather than adding one. `expand_range` now also covers a plain positional array, so a finite Range subscript becomes the index list the existing slice arm already handles correctly, for the storage *and* for the value it reports.

Guarded on a finite end (`b != i64::MAX && b >= 0`), the same precedent the Buf slice arm nearby uses, so an infinite or `Whatever`-ended Range (`@a[0..*]`, `@a[^Inf]`) is still never enumerated.

Routing through the one arm also lines the short-RHS **storage** padding up with rakudo: `my @d; @d[0..2] = 5,` left `[5, Nil, Nil]` and now leaves `[5, Any, Any]`.

## Tests

`t/range-slice-assign-rvalue.t` (new) covers the three one-element Range spellings (`0..0`, `0..^1`, `^1`), the padded short RHS, the multi-element and single-index controls, the `@d[0,]` comma spelling from #7589, and three storage assertions. All ten were checked against rakudo (10/10 there too).

Every file the ticket named passes unchanged: `t/range-slice-assignment.t`, `t/slice-assign-generic-range.t`, `t/hash-range-slice-assign.t`, `t/slice-assign-pads-short-rhs.t`, `t/slice-assign-one-element-rvalue.t`, and `roast/S09-subscript/slice.t`.

## Left open, filed separately

A `Whatever`-ended Range slice assignment (`@d[1..*] = 9`) grows the array to 100002 elements instead of clipping to its current length. It reproduces **identically with and without this change** — verified by building both ways, `100002` either way — so it is pre-existing and outside this ticket. Filed as #7674 rather than widening the fix.

## Verification

- `cargo fmt --all`, `make lint` — all four configurations green.
- `make test` — 3874 files, 41067 tests, `Result: PASS`.
- `make roast` — 1436 files, 218939 tests. The only failures are the three documented remote-container environment-only files, matching [`docs/agent-environments.md`](https://github.com/tokuhirom/mutsu/blob/main/docs/agent-environments.md) by name and subtest range: `roast/6.c/S32-io/file-tests.t` (`Failed: 4`, tests 6-8, 10), `roast/S16-filehandles/filetest.t` (`Failed: 25`, tests 57-64, 69-72, 77-80, 101/103/105/107/109/111/117/121/125) — both because the container runs as `uid 0` — and `roast/S32-io/IO-Socket-Async.t` (exit 124, "planned 40 ran 17", sandboxed network).

Closes #7651

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0122oqVGqfXxNqf9uJEABZvB

---
_Generated by [Claude Code](https://claude.ai/code/session_0122oqVGqfXxNqf9uJEABZvB)_