### PR TITLE
fix(compiler): a `let` save frame is something a block has, not a kind of block it is

### DIFF
--- a/news/2026-09/let-frame-is-a-block-property-not-a-block-shape.md
+++ b/news/2026-09/let-frame-is-a-block-property-not-a-block-shape.md
@@ -1,0 +1,61 @@
+# A `let` save frame is something a block *has*, not a kind of block it *is*
+
+`let`/`temp` save their target and resolve at the end of the enclosing block:
+the saves are discarded when the block succeeds and rolled back when it fails.
+Which block that is, and whether it gets the `OpCode::LetBlock` frame that does
+the resolving, was decided by `Compiler::has_let_deep` — and it walked only the
+statement kinds that hold an expression *directly* (`Stmt::Expr`, `Stmt::Call`,
+`Stmt::Say`/`Print`/`Note`, plus the `Stmt::Block`/`Stmt::If` recursions). A
+`let` reached through a declaration's or an assignment's initializer was
+invisible to it:
+
+```raku
+my $a = 42;
+{ my $seen = $( let $a = 23; $a ); Nil };
+say $a;      # raku: 42   mutsu: 23
+```
+
+The failure mode was not "the save resolves somewhere else". Item context
+`$( ... )` is a synthesized `Expr::DoBlock`, which since GH-7635 deliberately
+owns no save frame and defers to the real enclosing block — and that block, not
+being classified as a `let` block, had no frame either. So *nothing* resolved
+the save and the speculative value simply became permanent. The
+expression-statement spelling of the very same code (`{ $( let $a = 23; $a );
+Nil }`) was correct, because `Stmt::Expr` was one of the arms that existed.
+
+## Two halves, both needed
+
+Adding the missing `Stmt::VarDecl` / `Stmt::Assign` arms (and, one level down,
+an `Expr::CompoundAssign` arm, which is how `$t += $( let $a = 23; 1 )` parses)
+fixes the divergence — but on its own it hands the newly-classified blocks a
+worse deal than the one they had. `BlockShape::LetScope` was an *alternative* to
+`BlockShape::Plain`: it emitted `OpCode::LetBlock` around the body statements
+**instead of** the position's ordinary scope opcode, so every block the new arms
+newly classified would have traded its env restore for a save frame. That is
+visible directly:
+
+```raku
+my $x = 42;
+{ let $x = 1; my $*dyn = 'inner'; Nil };
+say $*dyn.defined;   # raku: False   mutsu (before): True
+```
+
+So the shape is now the plain shape *plus* a frame. In value position that was
+already the arrangement (`LetBlock` wrapping `DoBlockExpr`); statement position
+now nests the frame **inside** `OpCode::BlockScope`, around the body statements,
+via `Compiler::emit_body_let_frame`. Inside rather than outside is load-bearing:
+`exec_let_block_op` decides success from the block's own value, the statement
+form delivers that value through the topic (`compile_last_stmt_as_topic`), and
+`BlockScope`'s exit deliberately does not write a block-bound topic back to the
+enclosing scope — a frame placed outside would read the *enclosing* topic and
+decide from the wrong value.
+
+The net effect is that `BlockShape::LetScope` stopped being a shape that
+replaces the plain lowering and became one that decorates it, which is what
+[ADR-0076](../../docs/adr/0076-bare-block-lowering-and-block-scope-opcodes.md)'s
+layering question wanted for this corner.
+
+Pin: `t/let-block-initializer-classifier.t` (14 assertions, every one measured
+against `raku` first), alongside the existing `t/do-block-let-resolution.t`
+which keeps the GH-7635 boundary — a synthesized wrapper still defers, a genuine
+`do { ... }` still resolves at itself.

--- a/src/compiler/control_block.rs
+++ b/src/compiler/control_block.rs
@@ -89,9 +89,22 @@ pub(super) enum BlockShape {
     /// `ENTER`/`LEAVE`/`KEEP`/`UNDO` make it a real phaser block scope.
     PhaserScope,
     /// `let`/`temp` need the save/restore frame of `OpCode::LetBlock`.
+    ///
+    /// This is the plain shape PLUS a save frame, not an alternative to it: the
+    /// frame nests inside the position's ordinary scope opcode so a `let` block
+    /// keeps the env restore that stops its own `my` from leaking (GH-7645).
     LetScope,
     /// An ordinary block scope.
     Plain,
+}
+
+/// The `let`/`temp` save frame a block body is bracketed by.
+#[derive(Clone, Copy)]
+pub(super) struct LetFrame {
+    /// A real `let` (not just a `temp`) is present, so the block's own value
+    /// decides whether the saves are kept or rolled back and has to reach the
+    /// place `exec_let_block_op` reads it from.
+    pub(super) needs_value: bool,
 }
 
 /// Every question both positions used to answer for themselves.
@@ -109,9 +122,7 @@ pub(super) struct BlockPlan {
     /// routine registry has to be snapshotted around it (`OpCode::DoBlockExpr`'s
     /// `scope_routines`; `OpCode::BlockScope` always snapshots).
     declares_routines: bool,
-    /// A real `let` (not just a `temp`) is present, so the block's own value
-    /// decides whether the saves are kept or rolled back and has to reach the
-    /// topic register `exec_let_block_op` reads.
+    /// A real `let` (not just a `temp`) is present. See [`LetFrame::needs_value`].
     let_needs_value: bool,
     /// An escaping `when`/`default` succeed stops unwinding at this block.
     /// Statement position only: the value form catches `succeed` inside
@@ -137,6 +148,13 @@ impl BlockPlan {
             let_needs_value: shape == BlockShape::LetScope && Compiler::has_real_let_deep(stmts),
             succeed_barrier: !position.is_value() && Compiler::body_has_toplevel_when(stmts),
         }
+    }
+
+    /// The save frame this block's body is bracketed by, if any.
+    fn let_frame(&self) -> Option<LetFrame> {
+        (self.shape == BlockShape::LetScope).then_some(LetFrame {
+            needs_value: self.let_needs_value,
+        })
     }
 }
 
@@ -368,42 +386,35 @@ impl Compiler {
                     self.compile_phaser_block_scope(stmts, PhaserBlockResult::Discard);
                 }
             }
-            BlockShape::LetScope => {
-                // Block contains `let`/`temp` — wrap in LetBlock for
-                // save/restore. `exec_let_block_op` never touches the value
-                // stack, so the inner shape decides the block's value.
-                //
-                // A real `let` rolls its saves back unless the block succeeded,
-                // so `exec_let_block_op` needs the block's own value — and the
-                // two positions leave it in different places. The statement form
-                // routes its last statement through `compile_last_stmt_as_topic`
-                // and the op reads the topic; the value form already has the
-                // value on the stack and must NOT write the topic, or a
-                // `do { ... }` would clobber `$_` for the enclosing scope
-                // (GH-7635). `value_on_stack` is which of the two the op reads.
+            // A `let`/`temp` block is the plain block PLUS an
+            // `OpCode::LetBlock` save frame, so both arms go through
+            // `emit_plain_block` and differ only in where the frame nests.
+            //
+            // A real `let` rolls its saves back unless the block succeeded, so
+            // `exec_let_block_op` needs the block's own value — and the two
+            // positions leave it in different places. The statement form routes
+            // its last statement through `compile_last_stmt_as_topic` and the op
+            // reads the topic; the value form already has the value on the stack
+            // and must NOT write the topic, or a `do { ... }` would clobber `$_`
+            // for the enclosing scope (GH-7635). `value_on_stack` is which of the
+            // two the op reads.
+            //
+            // Value position: the frame wraps `OpCode::DoBlockExpr`, whose value
+            // is on the stack for the op to peek once the block is done.
+            // Statement position: the frame nests INSIDE `OpCode::BlockScope`
+            // (`emit_body_let_frame`), because the topic it reads is one
+            // `BlockScope`'s exit deliberately does not propagate outwards.
+            BlockShape::LetScope if position.is_value() => {
                 let idx = self.code.emit(OpCode::LetBlock {
                     body_end: 0,
-                    value_on_stack: position.is_value(),
+                    value_on_stack: true,
                 });
-                if position.is_value() {
-                    self.emit_plain_block(stmts, label, position, plan, is_bare);
-                } else {
-                    // Raku's "declarations are in effect at block start" rule
-                    // (see `hoist_typed_var_decls`).
-                    self.hoist_typed_var_decls(stmts);
-                    for (i, s) in stmts.iter().enumerate() {
-                        if i == stmts.len() - 1 && plan.let_needs_value {
-                            // For `let` blocks, set topic from the last
-                            // statement's value so we can check success/failure.
-                            self.compile_last_stmt_as_topic(s);
-                        } else {
-                            self.compile_stmt(s);
-                        }
-                    }
-                }
+                self.emit_plain_block(stmts, label, position, plan, is_bare);
                 self.code.patch_let_block_end(idx);
             }
-            BlockShape::Plain => self.emit_plain_block(stmts, label, position, plan, is_bare),
+            BlockShape::LetScope | BlockShape::Plain => {
+                self.emit_plain_block(stmts, label, position, plan, is_bare)
+            }
         }
     }
 
@@ -418,7 +429,7 @@ impl Compiler {
         is_bare: bool,
     ) {
         if !position.is_value() {
-            self.emit_statement_block_scope(stmts, is_bare);
+            self.emit_statement_block_scope(stmts, is_bare, plan.let_frame());
             return;
         }
         let idx = self.emit_do_block_expr(label, position, plan);

--- a/src/compiler/control_block_scope.rs
+++ b/src/compiler/control_block_scope.rs
@@ -7,13 +7,25 @@
 //! deserve its own file.
 
 use super::*;
+use crate::compiler::control_block::LetFrame;
 
 impl Compiler {
     /// Emit `OpCode::BlockScope` around `stmts` compiled as statements.
     ///
     /// `is_bare` distinguishes a genuine source `{ ... }` (a Raku callframe)
     /// from a synthesized `if`/`while`/`loop` body re-wrapped in `Stmt::Block`.
-    pub(super) fn emit_statement_block_scope(&mut self, stmts: &[Stmt], is_bare: bool) {
+    ///
+    /// `let_frame` asks for an `OpCode::LetBlock` *inside* this scope, around
+    /// the body statements: a `let`/`temp` block is an ordinary block that also
+    /// owns a save frame, not a different kind of block (GH-7645). See
+    /// [`Compiler::emit_body_let_frame`] for why the frame nests inside rather
+    /// than outside.
+    pub(super) fn emit_statement_block_scope(
+        &mut self,
+        stmts: &[Stmt],
+        is_bare: bool,
+        let_frame: Option<LetFrame>,
+    ) {
         // Plain blocks still create a lexical routine scope.
         // `BlockScope` snapshots env before the body and restores
         // it after (dropping any new env key), so a `my TYPE $x`
@@ -126,14 +138,45 @@ impl Compiler {
         // lost its declared types just because a statement followed
         // it (`t/typed-decl-hoist-block-forms.t`).
         self.hoist_typed_var_decls(stmts);
-        for s in stmts {
-            self.compile_stmt(s);
-        }
+        self.emit_body_let_frame(stmts, let_frame);
         self.code.patch_block_body_end(idx);
         self.code.patch_block_keep_start(idx);
         self.code.patch_block_undo_start(idx);
         self.code.patch_block_post_start(idx);
         self.code.patch_loop_end(idx);
         self.lexically_in_block = saved_lexically_in_block;
+    }
+
+    /// Compile `stmts` as the body of a statement-position block, optionally
+    /// bracketed by the `let`/`temp` save frame `let_frame` describes.
+    ///
+    /// The frame nests INSIDE `OpCode::BlockScope` rather than wrapping it,
+    /// because `exec_let_block_op` decides success from the block's own value
+    /// and the statement form delivers that value through the topic
+    /// (`compile_last_stmt_as_topic`). `BlockScope`'s exit deliberately does not
+    /// write a block-bound topic back to the enclosing scope, so a frame placed
+    /// outside would read the *enclosing* topic instead of the block's value.
+    pub(super) fn emit_body_let_frame(&mut self, stmts: &[Stmt], let_frame: Option<LetFrame>) {
+        let Some(frame) = let_frame else {
+            for s in stmts {
+                self.compile_stmt(s);
+            }
+            return;
+        };
+        let idx = self.code.emit(OpCode::LetBlock {
+            body_end: 0,
+            value_on_stack: false,
+        });
+        for (i, s) in stmts.iter().enumerate() {
+            if i == stmts.len() - 1 && frame.needs_value {
+                // A real `let` rolls its saves back unless the block succeeded,
+                // so route the last statement's value through the topic for
+                // `exec_let_block_op` to test.
+                self.compile_last_stmt_as_topic(s);
+            } else {
+                self.compile_stmt(s);
+            }
+        }
+        self.code.patch_let_block_end(idx);
     }
 }

--- a/src/compiler/helpers_stmt_analysis.rs
+++ b/src/compiler/helpers_stmt_analysis.rs
@@ -65,10 +65,22 @@ impl Compiler {
     }
 
     /// Check if a statement list contains `let` or `temp` statements (not inside sub/lambda bodies).
+    ///
+    /// This is what decides whether a block gets an `OpCode::LetBlock` save
+    /// frame, so every statement kind that can carry an expression a `let` can
+    /// hide in has to be walked — a declaration's or an assignment's initializer
+    /// included (`my $seen = $( let $a = 23; $a )`, GH-7645). Missing one does
+    /// not merely defer the resolution to the enclosing block: nothing resolves
+    /// the save at all and the speculative value becomes permanent.
     pub(super) fn has_let_deep(stmts: &[Stmt]) -> bool {
         for s in stmts {
             match s {
                 Stmt::Let { .. } | Stmt::TempMethodAssign { .. } => return true,
+                Stmt::VarDecl { expr, .. } | Stmt::Assign { expr, .. } => {
+                    if Self::expr_has_let_deep(expr) {
+                        return true;
+                    }
+                }
                 Stmt::Block(inner) => {
                     if Self::has_let_deep(inner) {
                         return true;
@@ -116,6 +128,11 @@ impl Compiler {
         for s in stmts {
             match s {
                 Stmt::Let { is_temp: false, .. } => return true,
+                Stmt::VarDecl { expr, .. } | Stmt::Assign { expr, .. } => {
+                    if Self::expr_has_real_let_deep(expr) {
+                        return true;
+                    }
+                }
                 Stmt::Block(inner) => {
                     if Self::has_real_let_deep(inner) {
                         return true;
@@ -155,7 +172,19 @@ impl Compiler {
     fn expr_has_real_let_deep(expr: &Expr) -> bool {
         match expr {
             Expr::DoBlock { body, .. } => Self::has_real_let_deep(body),
+            Expr::DoStmt(stmt) => Self::has_real_let_deep(std::slice::from_ref(stmt)),
             Expr::Try { body, .. } => Self::has_real_let_deep(body),
+            Expr::Grouped(inner) => Self::expr_has_real_let_deep(inner),
+            Expr::CompoundAssign {
+                target,
+                rhs,
+                expanded,
+                ..
+            } => {
+                Self::expr_has_real_let_deep(target)
+                    || Self::expr_has_real_let_deep(rhs)
+                    || Self::expr_has_real_let_deep(expanded)
+            }
             Expr::Call { args, .. } | Expr::UserRoutineCall { args, .. } => {
                 args.iter().any(Self::expr_has_real_let_deep)
             }
@@ -183,6 +212,18 @@ impl Compiler {
             Expr::DoStmt(stmt) => Self::has_let_deep(&[*stmt.clone()]),
             Expr::Try { body, .. } => Self::has_let_deep(body),
             Expr::Grouped(inner) => Self::expr_has_let_deep(inner),
+            // `$t += $( let $a = 23; 1 )` parses as a `Stmt::Assign` whose expr
+            // is the compound node, so the save hides two levels down.
+            Expr::CompoundAssign {
+                target,
+                rhs,
+                expanded,
+                ..
+            } => {
+                Self::expr_has_let_deep(target)
+                    || Self::expr_has_let_deep(rhs)
+                    || Self::expr_has_let_deep(expanded)
+            }
             Expr::IndexAssign {
                 target,
                 index,

--- a/t/let-block-initializer-classifier.t
+++ b/t/let-block-initializer-classifier.t
@@ -1,0 +1,89 @@
+use Test;
+
+# GH-7645: `Compiler::has_let_deep` decides whether a block gets an
+# `OpCode::LetBlock` save frame. It walked statements that hold an expression
+# directly (`Stmt::Expr`, `Stmt::Say`, ...) but not a declaration's or an
+# assignment's initializer, so a `let`/`temp` reached only through one was
+# invisible and NOTHING resolved the save -- the speculative value became
+# permanent instead of being rolled back at the enclosing block.
+#
+# The companion half is that a `let` block is now the plain block PLUS a save
+# frame (the frame nests inside `OpCode::BlockScope`) rather than a different
+# kind of block that skips the env restore.
+#
+# Every expectation below was measured against `raku` first.
+
+plan 14;
+
+# --- a `let` in a declaration's initializer resolves at the block ---------
+
+{
+    my $a = 42;
+    { my $seen = $( let $a = 23; $a ); Nil };
+    is $a, 42, 'a `let` in a declaration initializer is rolled back by a failing block';
+}
+
+{
+    my $a = 42;
+    my $seen;
+    { my $s = $( let $a = 23; $a ); $seen = $s; 42 };
+    is $a, 23, 'and committed by a succeeding one';
+    is $seen, 23, 'the initializer still sees the speculative value';
+}
+
+{
+    my $a = 42;
+    { my $s = $( temp $a = 23; $a ); 42 };
+    is $a, 42, '`temp` in a declaration initializer restores even on success';
+}
+
+# --- the same through a plain assignment ---------------------------------
+
+{
+    my $a = 42;
+    my $seen;
+    { $seen = $( let $a = 23; $a ); Nil };
+    is $a, 42, 'a `let` in an assignment initializer is rolled back by a failing block';
+    is $seen, 23, 'and the assignment still saw the speculative value';
+}
+
+{
+    my $a = 42;
+    my $t = 0;
+    { $t += $( let $a = 23; 1 ); Nil };
+    is $a, 42, 'a `let` inside a compound assignment is rolled back too';
+    is $t, 1, 'and the compound assignment still ran';
+}
+
+# --- a genuine `do { ... }` still resolves at itself ----------------------
+
+{
+    # The inner `do` IS a block (GH-7635), so it commits its own save and the
+    # failing outer block must not undo it.
+    my $a = 42;
+    { my $s = do { let $a = 23; 42 }; Nil };
+    is $a, 23, 'a `do` block in an initializer still resolves at the `do`';
+}
+
+# --- a `let` block keeps the scope semantics of a plain block -------------
+
+{
+    my $x = 42;
+    { let $x = 1; my $*dyn = 'inner'; Nil };
+    is $x, 42, 'the `let` still rolls back';
+    nok $*dyn.defined, 'a `my $*dyn` declared in a `let` block does not leak out';
+}
+
+{
+    my $x = 42;
+    { let $x = 1; my $*dyn2 = 'inner'; 99 };
+    is $x, 1, 'a succeeding `let` block still commits';
+    nok $*dyn2.defined, 'and its `my $*dyn` is block-scoped as well';
+}
+
+{
+    my $x = 42;
+    my $shadowed = 'outer';
+    { let $x = 1; my $shadowed = 'inner'; Nil };
+    is $shadowed, 'outer', 'a shadowing `my` in a `let` block does not leak either';
+}


### PR DESCRIPTION
Closes #7645

## The divergence

`Compiler::has_let_deep` decides whether a block gets the `OpCode::LetBlock` save frame that resolves `let`/`temp` at block exit. It walked only the statement kinds holding an expression *directly* (`Stmt::Expr`, `Stmt::Call`, `Stmt::Say`/`Print`/`Note`, plus the `Stmt::Block`/`Stmt::If` recursions), so a `let` reached through a declaration's or an assignment's initializer was invisible to it:

```raku
my $a = 42;
{ my $seen = $( let $a = 23; $a ); Nil };
say $a;      # raku: 42   mutsu: 23
```

The failure mode was *not* "the save resolves at some other block". Item context `$( ... )` is a synthesized `Expr::DoBlock`, which since #7635 deliberately owns no save frame and defers to the real enclosing block — and that block, unclassified, had no frame either. So nothing resolved the save at all and the speculative value became permanent. The expression-statement spelling of the same code (`{ $( let $a = 23; $a ); Nil }`) was already correct, because `Stmt::Expr` was one of the arms that existed.

## Half one — the classifier

Adds the missing `Stmt::VarDecl` / `Stmt::Assign` arms to `has_let_deep` and `has_real_let_deep`, plus an `Expr::CompoundAssign` arm one level down (`$t += $( let $a = 23; 1 )` parses as a `Stmt::Assign` whose expr is the compound node), and aligns `expr_has_real_let_deep` with `expr_has_let_deep` on the wrapper nodes it was missing (`DoStmt`, `Grouped`) — a real `let` misread as temp-only would leave `let_needs_value` false and decide success from the *enclosing* topic.

Statement kinds that were checked and need no arm: index/slice assignments (`@a[0] = ...`, `%h<k> = ...`) already parse as `Stmt::Expr`, and `my $x := ...` parses as a plain `Stmt::VarDecl`, not a `Stmt::SyntheticBlock`.

## Half two — the shape

The classifier fix alone hands the newly-classified blocks a worse deal, which is the "why it is large" the issue flagged. `BlockShape::LetScope` was an *alternative* to `BlockShape::Plain`: it emitted `OpCode::LetBlock` around the body statements **instead of** the position's ordinary scope opcode, so a block newly classified as a `let` block traded its env restore for a save frame. That is directly observable today:

```raku
my $x = 42;
{ let $x = 1; my $*dyn = 'inner'; Nil };
say $*dyn.defined;   # raku: False   mutsu (before): True
```

So the shape is now the plain shape **plus** a frame. Value position already had that arrangement (`LetBlock` wrapping `DoBlockExpr`); statement position now nests the frame **inside** `OpCode::BlockScope`, around the body statements, via the new `Compiler::emit_body_let_frame`.

Inside rather than outside is load-bearing: `exec_let_block_op` decides success from the block's own value, the statement form delivers that value through the topic (`compile_last_stmt_as_topic`), and `BlockScope`'s exit deliberately does not write a block-bound topic back to the enclosing scope — a frame placed outside would read the *enclosing* topic and decide from the wrong value.

Net effect: `BlockShape::LetScope` stopped being a shape that *replaces* the plain lowering and became one that *decorates* it, which is what ADR-0076's layering question wanted for this corner.

## Tests

New pin `t/let-block-initializer-classifier.t` — 14 assertions covering `let`/`temp` through a declaration initializer, a plain assignment, a compound assignment, a genuine `do { ... }` in an initializer (must still resolve at the `do`), and the scope semantics the frame must not cost (`my $*dyn` and a shadowing `my` stay block-scoped in both the failing and succeeding cases). **Every assertion was measured against `raku` first**, and the file passes unmodified under `raku` as well as under mutsu.

`t/do-block-let-resolution.t` keeps the #7635 boundary intact and is unchanged.

## Verification

- `cargo fmt --all` — clean
- `make lint` — exit 0 (all four configurations: default clippy, `jit`-off, wasm32, rustdoc)
- `make test` — **PASS**, 3878 files / 41113 tests, plus `cargo test`
- `make roast` — 1436 files / 218939 tests; the only failures are the three documented container-environment ones (`roast/6.c/S32-io/file-tests.t` and `roast/S16-filehandles/filetest.t` run as `uid 0`, `roast/S32-io/IO-Socket-Async.t` sandboxed network), matching `docs/agent-environments.md` file-for-file and test-number-for-test-number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GSW36mTpLepCivqTk1zWyj

---
_Generated by [Claude Code](https://claude.ai/code/session_01GSW36mTpLepCivqTk1zWyj)_