### PR TITLE
fix(vm): resolve a routine body's own let/temp saves at frame teardown

### DIFF
--- a/news/2026-09/routine-body-resolves-its-own-let-temp-saves.md
+++ b/news/2026-09/routine-body-resolves-its-own-let-temp-saves.md
@@ -1,0 +1,65 @@
+# A routine body resolves its own `let`/`temp` saves
+
+`let` and `temp` resolve their saves at the end of the enclosing **block**, and a routine body
+is one: `temp` restores the pre-scope value unconditionally, `let` restores it only when the
+block exited unsuccessfully. mutsu implemented that rule for exactly two lowerings — the
+statement-position bare block and, since GH-7635, the genuine value-position `do { ... }` —
+both of which emit `OpCode::LetBlock`. A routine body is compiled by neither: it goes through
+the closure/sub-body path, which emits no `LetBlock` at all. So a save recorded by
+`OpCode::LetSave` inside a routine was never resolved by the frame that owned it; it survived
+until some outer block happened to resolve it, or forever.
+
+```raku
+my $x = 1;
+sub f() { let $x = 2; Nil }
+f();
+say $x;             # raku: 1   mutsu (before): 2
+```
+
+Methods diverged for `temp` as well as `let`, because the method-dispatch path discarded the
+saves outright on an explicit `return` and did not touch them at all on a natural fall-through:
+
+```raku
+my $x = 1;
+class C { method m() { temp $x = 2; 42 } }
+C.m;
+say $x;             # raku: 1   mutsu (before): 2
+```
+
+## Resolving at frame teardown
+
+The saves are resolved where the frame is torn down rather than by wrapping a bytecode range,
+because a routine has several ways to produce its result — a tail expression, an explicit
+`return`, `fail`, an exception unwinding the frame — and `OpCode::LetBlock` can read the value
+from only one place. Every dispatch path already took a `let_saves` mark on entry and already
+called `resolve_let_saves_on_success(mark, true)` on exit; the hard-coded `true` is what made
+`temp` work (it restores either way) and `let` never restore. The new
+`Interpreter::resolve_frame_let_saves` takes the frame's actual result value instead, and every
+routine, method and closure dispatch path now hands it the value it is about to return —
+including the explicit-`return` arms, which previously discarded the saves.
+
+The `try`/implicit-CATCH region got the same treatment. It is a block in its own right, and it
+is also how a routine body carrying a `CATCH` phaser is compiled, so
+`sub f() { temp $x = 2; CATCH { default { } }; 7 }` had no other place to resolve its saves at
+all.
+
+## A tail `let` is an assignment
+
+Judging the exit by the frame's value exposed a second gap: `let $x = 42` is an assignment and
+its value is 42, but in block-final position mutsu compiled it through the valueless default
+arm and yielded `Nil`. That was invisible while the saves leaked; once the value decides
+whether the save is kept, a `sub f() { let $x = 2; }` looked like a failed block and rolled
+itself back. The tail-statement lowerings — the routine-body, closure-body, phaser-body and
+inline-block ones, alongside the existing expression-position arm — now share
+`Compiler::compile_let_stmt_as_value`, which runs the save plus the assignment and pushes the
+temporized variable. `do { let $x = 5 }` is `5` now, as it is in rakudo.
+
+## Still open
+
+A loop body is a block too, and it resolves nothing: `for 1..2 { temp $k = 2; }` leaks the
+temporized value, and the second iteration observes the first one's. That is filed separately
+as GH-7677 — a loop body is compiled in sink context, so the "did this block succeed" value
+that `let` needs does not exist for it without a second body-lowering shape.
+
+Pinned by `t/routine-body-let-resolution.t` (28 assertions, each measured against `raku`
+first).

--- a/src/compiler/expr_block.rs
+++ b/src/compiler/expr_block.rs
@@ -41,6 +41,26 @@ impl Compiler {
     }
 
     /// Compile DoStmt expression (do { ... }, do if, do for, etc.).
+    /// Compile a `let`/`temp` statement so it leaves its value on the stack.
+    ///
+    /// `let $x = 42` is an assignment, so its value is the assigned one — this
+    /// runs the save plus the assignment and then pushes the temporized
+    /// variable. Used both for `(temp $x = 42)` in genuine expression position
+    /// and for a block-final `let`/`temp`, whose value is the block's value and
+    /// therefore decides whether the frame's `let` saves are kept or restored
+    /// (#7646).
+    pub(super) fn compile_let_stmt_as_value(&mut self, stmt: &Stmt, name: &str) {
+        self.compile_stmt(stmt);
+        // Reuse the same logic as Expr::ArrayVar/HashVar/Var compilation.
+        if let Some(stripped) = name.strip_prefix('@') {
+            self.compile_expr(&Expr::ArrayVar(stripped.to_string()));
+        } else if let Some(stripped) = name.strip_prefix('%') {
+            self.compile_expr(&Expr::HashVar(stripped.to_string()));
+        } else {
+            self.compile_expr(&Expr::Var(name.to_string()));
+        }
+    }
+
     pub(super) fn compile_expr_do_stmt(&mut self, stmt: &Stmt) {
         match stmt {
             Stmt::If {
@@ -946,27 +966,9 @@ impl Compiler {
                 // opens no scope a save could resolve at.
                 self.compile_do_block_expr_scoped(inner, &None, crate::ast::DoBlockOrigin::Desugar);
             }
-            Stmt::Let {
-                name,
-                index: _,
-                value: _,
-                is_temp: _,
-                undefine_first: _,
-            } => {
-                // Compile the temp/let statement, then push the variable as result.
-                // This handles `(temp @a)` / `(temp $x = 42)` in expression position.
-                self.compile_stmt(stmt);
-                // Push the variable value as the expression result.
-                // Reuse the same logic as Expr::ArrayVar/HashVar/Var compilation.
-                if name.starts_with('@') {
-                    let stripped = name.strip_prefix('@').unwrap_or(name);
-                    self.compile_expr(&Expr::ArrayVar(stripped.to_string()));
-                } else if name.starts_with('%') {
-                    let stripped = name.strip_prefix('%').unwrap_or(name);
-                    self.compile_expr(&Expr::HashVar(stripped.to_string()));
-                } else {
-                    self.compile_expr(&Expr::Var(name.clone()));
-                }
+            Stmt::Let { name, .. } => {
+                let name = name.clone();
+                self.compile_let_stmt_as_value(stmt, &name);
             }
             // `anon sub NAME ... {...}` (marked `__anon_decl` by the parser):
             // build the routine value carrying its declared name WITHOUT

--- a/src/compiler/helpers_block_inline.rs
+++ b/src/compiler/helpers_block_inline.rs
@@ -445,6 +445,16 @@ impl Compiler {
                         self.pop_dynamic_scope_lexical(saved);
                         return;
                     }
+                    // `let $x = 42` in block-final position is an assignment
+                    // too, so the block's value is the assigned one — and that
+                    // is exactly what `OpCode::LetBlock` reads to decide whether
+                    // the block succeeded (#7646).
+                    Stmt::Let { name, .. } => {
+                        let name = name.clone();
+                        self.compile_let_stmt_as_value(stmt, &name);
+                        self.pop_dynamic_scope_lexical(saved);
+                        return;
+                    }
                     Stmt::Phaser {
                         kind: PhaserKind::Begin | PhaserKind::Check | PhaserKind::Init,
                         body,

--- a/src/compiler/helpers_sub_body.rs
+++ b/src/compiler/helpers_sub_body.rs
@@ -835,6 +835,16 @@ impl Compiler {
                         }
                         continue;
                     }
+                    // `let`/`temp` as last statement is an assignment too, so it
+                    // returns the assigned value. That value is what decides
+                    // whether the frame keeps or restores its own `let` saves
+                    // (#7646), so it must not fall through to the valueless
+                    // default.
+                    Stmt::Let { name, .. } => {
+                        let name = name.clone();
+                        sub_compiler.compile_let_stmt_as_value(stmt, &name);
+                        continue;
+                    }
                     Stmt::Say(_) | Stmt::Put(_) | Stmt::Print(_) | Stmt::Note(_) => {
                         // A statement-form I/O builtin tail (`say`/`put`/`print`/
                         // `note`) prints and returns True, so leave True on the
@@ -1323,6 +1333,13 @@ impl Compiler {
                     }
                     continue;
                 }
+                // `let`/`temp` is an assignment too — see the twin arm in
+                // `compile_routine_body_stmts` (#7646).
+                if is_value && let Stmt::Let { name, .. } = stmt {
+                    let name = name.clone();
+                    sub_compiler.compile_let_stmt_as_value(stmt, &name);
+                    continue;
+                }
                 sub_compiler.compile_stmt(stmt);
                 // A non-value statement `given` nets one stack value that would
                 // pollute the stack under the closure's real value — pop it.
@@ -1490,6 +1507,13 @@ impl Compiler {
                                 ));
                                 sub_compiler.code.emit(OpCode::GetGlobal(idx));
                             }
+                            continue;
+                        }
+                        // `let`/`temp` is an assignment too — see the twin arm
+                        // in `compile_routine_body_stmts` (#7646).
+                        Stmt::Let { name, .. } => {
+                            let name = name.clone();
+                            sub_compiler.compile_let_stmt_as_value(stmt, &name);
                             continue;
                         }
                         Stmt::Say(_) | Stmt::Put(_) | Stmt::Print(_) | Stmt::Note(_) => {

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -4397,6 +4397,16 @@ impl Compiler {
                 let slot = self.alloc_local(&var_name);
                 self.code.emit(OpCode::GetLocal(slot));
             }
+            // `sub f { let $x = 42 }` yields 42, exactly like the bare
+            // assignment arm below: the save is bookkeeping, the value is the
+            // assignment's. The block's value is what decides whether the
+            // frame's `let` saves are kept or restored, so a tail `let` that
+            // yielded the fallback `True`/`Nil` made that decision on a value
+            // the source never produced (#7646).
+            Stmt::Let { name, .. } => {
+                let name = name.clone();
+                self.compile_let_stmt_as_value(stmt, &name);
+            }
             Stmt::Assign { name, .. } => {
                 self.compile_stmt(stmt);
                 if let Some(&slot) = self.local_map.get(name) {

--- a/src/runtime/resolution_call_sub.rs
+++ b/src/runtime/resolution_call_sub.rs
@@ -973,15 +973,16 @@ impl Interpreter {
                 .map(|spec| self.resolved_type_capture_name(spec));
             self.block_stack.pop();
             self.routine_stack.pop();
-            // Manage let saves based on sub result
+            // Manage let saves based on sub result. `temp` always restores;
+            // `let` restores only when the body exited unsuccessfully, which for
+            // a normal exit means it produced an undefined value (#7646).
             match &result {
-                Ok(_) => {
-                    // Successful completion — restore temps, discard lets
-                    self.resolve_let_saves_on_success(let_mark, true);
+                Ok(v) => {
+                    self.resolve_frame_let_saves(let_mark, v);
                 }
                 Err(e) if e.return_value.is_some() => {
-                    // Explicit return — restore temps, discard lets
-                    self.resolve_let_saves_on_success(let_mark, true);
+                    let ret = e.return_value.clone().unwrap_or(Value::NIL);
+                    self.resolve_frame_let_saves(let_mark, &ret);
                 }
                 Err(_) => {
                     // Exception/fail — restore saves

--- a/src/vm/vm_call_fast.rs
+++ b/src/vm/vm_call_fast.rs
@@ -229,8 +229,8 @@ impl Interpreter {
                     let ret_val = e.return_value.unwrap();
                     explicit_return = Some(ret_val.clone());
                     self.stack.truncate(saved_stack_depth);
-                    self.stack.push(ret_val);
-                    self.resolve_let_saves_on_success(let_mark, true);
+                    self.stack.push(ret_val.clone());
+                    self.resolve_frame_let_saves(let_mark, &ret_val);
                     result = Ok(());
                     break;
                 }
@@ -254,14 +254,6 @@ impl Interpreter {
             }
         }
 
-        // Natural fall-through completion (no explicit return / fail / error
-        // break arm): restore any `temp` bindings the body introduced so a
-        // `sub f { temp $x = ... }` with no explicit return does not leak the
-        // temporized value into the caller's scope.
-        if result.is_ok() && explicit_return.is_none() && !fail_bypass {
-            self.resolve_let_saves_on_success(let_mark, true);
-        }
-
         let ret_val = if result.is_ok() {
             if self.stack.len() > saved_stack_depth {
                 self.stack.pop().unwrap_or(Value::NIL)
@@ -271,6 +263,15 @@ impl Interpreter {
         } else {
             Value::NIL
         };
+
+        // Natural fall-through completion (no explicit return / fail / error
+        // break arm): resolve the body's own `let`/`temp` saves against the
+        // value it produced, so a `sub f { temp $x = ... }` with no explicit
+        // return does not leak the temporized value into the caller's scope and
+        // a `sub f { let $x = ...; Nil }` restores it (#7646).
+        if result.is_ok() && explicit_return.is_none() && !fail_bypass {
+            self.resolve_frame_let_saves(let_mark, &ret_val);
+        }
 
         self.stack.truncate(saved_stack_depth);
         self.pop_routine();

--- a/src/vm/vm_call_light.rs
+++ b/src/vm/vm_call_light.rs
@@ -590,8 +590,8 @@ impl Interpreter {
                         let ret_val = e.return_value.unwrap();
                         explicit_return = Some(ret_val.clone());
                         self.stack.truncate(saved_stack_depth);
-                        self.stack.push(ret_val);
-                        self.resolve_let_saves_on_success(let_mark, true);
+                        self.stack.push(ret_val.clone());
+                        self.resolve_frame_let_saves(let_mark, &ret_val);
                         result = Ok(());
                         break;
                     }
@@ -659,14 +659,6 @@ impl Interpreter {
         // Restore the caller's pragma state (fatal/strict/newline/monkey-typing).
         self.restore_pragma_state(saved_pragmas);
 
-        // Natural fall-through completion (no explicit return / fail / error
-        // break arm): restore any `temp` bindings the body introduced so a
-        // `sub f { temp $x = ... }` with no explicit return does not leak the
-        // temporized value into the caller's scope.
-        if result.is_ok() && explicit_return.is_none() && !fail_bypass {
-            self.resolve_let_saves_on_success(let_mark, true);
-        }
-
         let ret_val = if result.is_ok() {
             if self.stack.len() > saved_stack_depth {
                 self.stack.pop().unwrap_or(Value::NIL)
@@ -676,6 +668,15 @@ impl Interpreter {
         } else {
             Value::NIL
         };
+
+        // Natural fall-through completion (no explicit return / fail / error
+        // break arm): resolve the body's own `let`/`temp` saves against the
+        // value it produced, so a `sub f { temp $x = ... }` with no explicit
+        // return does not leak the temporized value into the caller's scope and
+        // a `sub f { let $x = ...; Nil }` restores it (#7646).
+        if result.is_ok() && explicit_return.is_none() && !fail_bypass {
+            self.resolve_frame_let_saves(let_mark, &ret_val);
+        }
 
         self.stack.truncate(saved_stack_depth);
 

--- a/src/vm/vm_call_light_typed.rs
+++ b/src/vm/vm_call_light_typed.rs
@@ -562,8 +562,8 @@ impl Interpreter {
                         let ret_val = e.return_value.unwrap();
                         explicit_return = Some(ret_val.clone());
                         self.stack.truncate(saved_stack_depth);
-                        self.stack.push(ret_val);
-                        self.resolve_let_saves_on_success(let_mark, true);
+                        self.stack.push(ret_val.clone());
+                        self.resolve_frame_let_saves(let_mark, &ret_val);
                         result = Ok(());
                         break;
                     }
@@ -631,14 +631,6 @@ impl Interpreter {
         // Restore the caller's pragma state (fatal/strict/newline/monkey-typing).
         self.restore_pragma_state(saved_pragmas);
 
-        // Natural fall-through completion (no explicit return / fail / error
-        // break arm): restore any `temp` bindings the body introduced so a
-        // `sub f { temp $x = ... }` with no explicit return does not leak the
-        // temporized value into the caller's scope.
-        if result.is_ok() && explicit_return.is_none() && !fail_bypass {
-            self.resolve_let_saves_on_success(let_mark, true);
-        }
-
         let ret_val = if result.is_ok() {
             if self.stack.len() > saved_stack_depth {
                 self.stack.pop().unwrap_or(Value::NIL)
@@ -648,6 +640,15 @@ impl Interpreter {
         } else {
             Value::NIL
         };
+
+        // Natural fall-through completion (no explicit return / fail / error
+        // break arm): resolve the body's own `let`/`temp` saves against the
+        // value it produced, so a `sub f { temp $x = ... }` with no explicit
+        // return does not leak the temporized value into the caller's scope and
+        // a `sub f { let $x = ...; Nil }` restores it (#7646).
+        if result.is_ok() && explicit_return.is_none() && !fail_bypass {
+            self.resolve_frame_let_saves(let_mark, &ret_val);
+        }
 
         self.stack.truncate(saved_stack_depth);
 

--- a/src/vm/vm_call_named_inner.rs
+++ b/src/vm/vm_call_named_inner.rs
@@ -353,8 +353,8 @@ impl Interpreter {
                         let ret_val = e.return_value.unwrap_or(Value::NIL);
                         explicit_return = Some(ret_val.clone());
                         self.stack.truncate(saved_stack_depth);
-                        self.stack.push(ret_val);
-                        self.resolve_let_saves_on_success(let_mark, true);
+                        self.stack.push(ret_val.clone());
+                        self.resolve_frame_let_saves(let_mark, &ret_val);
                         result = Ok(());
                         break;
                     }
@@ -375,8 +375,8 @@ impl Interpreter {
                     let ret_val = e.return_value.unwrap();
                     explicit_return = Some(ret_val.clone());
                     self.stack.truncate(saved_stack_depth);
-                    self.stack.push(ret_val);
-                    self.resolve_let_saves_on_success(let_mark, true);
+                    self.stack.push(ret_val.clone());
+                    self.resolve_frame_let_saves(let_mark, &ret_val);
                     result = Ok(());
                     break;
                 }
@@ -409,14 +409,6 @@ impl Interpreter {
         // even though this line is never reached.
         drop(when_matched_guard);
 
-        // Natural fall-through completion (no explicit return / fail / error
-        // break arm): restore any `temp` bindings the body introduced so a
-        // `sub f { temp $x = ... }` with no explicit return does not leak the
-        // temporized value into the caller's scope.
-        if result.is_ok() && explicit_return.is_none() && !fail_bypass {
-            self.resolve_let_saves_on_success(let_mark, true);
-        }
-
         let mut ret_val = if result.is_ok() {
             if self.stack.len() > saved_stack_depth {
                 self.stack.pop().unwrap_or(Value::NIL)
@@ -426,6 +418,15 @@ impl Interpreter {
         } else {
             Value::NIL
         };
+
+        // Natural fall-through completion (no explicit return / fail / error
+        // break arm): resolve the body's own `let`/`temp` saves against the
+        // value it produced, so a `sub f { temp $x = ... }` with no explicit
+        // return does not leak the temporized value into the caller's scope and
+        // a `sub f { let $x = ...; Nil }` restores it (#7646).
+        if result.is_ok() && explicit_return.is_none() && !fail_bypass {
+            self.resolve_frame_let_saves(let_mark, &ret_val);
+        }
         // Raku semantics: `sub foo(...) { ... }` as the last statement
         // of a block returns the Sub. If the return value is Nil/Any and
         // the last opcode was RegisterDecl(Sub), create the Sub value.

--- a/src/vm/vm_closure_dispatch.rs
+++ b/src/vm/vm_closure_dispatch.rs
@@ -1003,8 +1003,8 @@ impl Interpreter {
                         let ret_val = e.return_value.unwrap_or(Value::NIL);
                         explicit_return = Some(ret_val.clone());
                         self.stack.truncate(saved_stack_depth);
-                        self.stack.push(ret_val);
-                        self.resolve_let_saves_on_success(let_mark, true);
+                        self.stack.push(ret_val.clone());
+                        self.resolve_frame_let_saves(let_mark, &ret_val);
                         handled_let_saves = true;
                         result = Ok(());
                         break;
@@ -1020,8 +1020,8 @@ impl Interpreter {
                     let ret_val = e.return_value.unwrap_or(Value::NIL);
                     explicit_return = Some(ret_val.clone());
                     self.stack.truncate(saved_stack_depth);
-                    self.stack.push(ret_val);
-                    self.resolve_let_saves_on_success(let_mark, true);
+                    self.stack.push(ret_val.clone());
+                    self.resolve_frame_let_saves(let_mark, &ret_val);
                     handled_let_saves = true;
                     result = Ok(());
                     break;
@@ -1037,7 +1037,9 @@ impl Interpreter {
                     let ret_val = Value::NIL;
                     explicit_return = Some(ret_val.clone());
                     self.stack.truncate(saved_stack_depth);
-                    self.stack.push(ret_val);
+                    self.stack.push(ret_val.clone());
+                    // A `supply` body's own `done` terminator is not a failed
+                    // exit; its Nil is a terminator, not a result value.
                     self.resolve_let_saves_on_success(let_mark, true);
                     handled_let_saves = true;
                     result = Ok(());
@@ -1080,8 +1082,8 @@ impl Interpreter {
                     let ret_val = e.return_value.unwrap();
                     explicit_return = Some(ret_val.clone());
                     self.stack.truncate(saved_stack_depth);
-                    self.stack.push(ret_val);
-                    self.resolve_let_saves_on_success(let_mark, true);
+                    self.stack.push(ret_val.clone());
+                    self.resolve_frame_let_saves(let_mark, &ret_val);
                     handled_let_saves = true;
                     result = Ok(());
                     break;
@@ -1116,13 +1118,6 @@ impl Interpreter {
         // even though this line is never reached.
         drop(pkg_guard);
 
-        // Natural fall-through completion (no explicit return / break arm): a
-        // routine body that ends with `temp $x = ...` must restore the `temp`
-        // binding here, otherwise it leaks into the caller's scope.
-        if !handled_let_saves {
-            self.resolve_let_saves_on_success(let_mark, true);
-        }
-
         let ret_val = if result.is_ok() {
             if self.stack.len() > saved_stack_depth {
                 self.stack.pop().unwrap_or(Value::NIL)
@@ -1132,6 +1127,14 @@ impl Interpreter {
         } else {
             Value::NIL
         };
+
+        // Natural fall-through completion (no explicit return / break arm): a
+        // body that ends with `temp $x = ...` must restore the `temp` binding
+        // here, otherwise it leaks into the caller's scope, and a `let` whose
+        // block produced an undefined value must be restored too (#7646).
+        if !handled_let_saves {
+            self.resolve_frame_let_saves(let_mark, &ret_val);
+        }
 
         self.stack.truncate(saved_stack_depth);
 

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -5785,6 +5785,25 @@ impl Interpreter {
         crate::runtime::types::value_is_defined(val)
     }
 
+    /// Resolve a routine/method/closure frame's own `let`/`temp` saves at
+    /// frame teardown (#7646).
+    ///
+    /// `let`/`temp` are resolved at the end of the enclosing *block*, and a
+    /// routine body is one. The block lowerings (`OpCode::LetBlock`) only cover
+    /// bare and `do` blocks; a routine body is compiled by the closure/sub-body
+    /// path instead, which emits no `LetBlock`, so the frame teardown is the
+    /// only place its saves can be resolved. `temp` always restores; `let`
+    /// restores only when the frame exited unsuccessfully, which for a normal
+    /// (non-throwing) exit means it produced an undefined value.
+    ///
+    /// Must be called while the callee frame's `env`/`locals` are still live —
+    /// `restore_let_value` writes through the baked slot and records a
+    /// caller-frame writeback, both of which need the frame that owns them.
+    pub(crate) fn resolve_frame_let_saves(&mut self, mark: usize, frame_result: &Value) {
+        let success = Self::is_let_success(frame_result);
+        self.resolve_let_saves_on_success(mark, success);
+    }
+
     /// Pull back into the compiler-baked local slots any slot-backing env entry
     /// an internally-dispatched method changed (`pre_env` is the snapshot taken
     /// before the dispatch). Used by the sink-context arms, which run user code

--- a/src/vm/vm_method_dispatch.rs
+++ b/src/vm/vm_method_dispatch.rs
@@ -865,8 +865,8 @@ impl Interpreter {
                         let ret_val = e.return_value.unwrap_or(Value::NIL);
                         explicit_return = Some(ret_val.clone());
                         self.stack.truncate(saved_stack_depth);
-                        self.stack.push(ret_val);
-                        self.discard_let_saves(let_mark);
+                        self.stack.push(ret_val.clone());
+                        self.resolve_frame_let_saves(let_mark, &ret_val);
                         result = Ok(());
                         break;
                     }
@@ -887,8 +887,8 @@ impl Interpreter {
                     let ret_val = e.return_value.unwrap();
                     explicit_return = Some(ret_val.clone());
                     self.stack.truncate(saved_stack_depth);
-                    self.stack.push(ret_val);
-                    self.discard_let_saves(let_mark);
+                    self.stack.push(ret_val.clone());
+                    self.resolve_frame_let_saves(let_mark, &ret_val);
                     result = Ok(());
                     break;
                 }
@@ -925,6 +925,14 @@ impl Interpreter {
         } else {
             Value::NIL
         };
+
+        // Natural fall-through completion: resolve the body's own `let`/`temp`
+        // saves against the value it produced. A method body is a block, so it
+        // owns the saves its `let`/`temp` recorded; without this they leaked
+        // into the caller's scope (#7646).
+        if result.is_ok() && explicit_return.is_none() {
+            self.resolve_frame_let_saves(let_mark, &ret_val);
+        }
 
         self.stack.truncate(saved_stack_depth);
 
@@ -2001,8 +2009,8 @@ impl Interpreter {
                         let ret_val = e.return_value.unwrap_or(Value::NIL);
                         explicit_return = Some(ret_val.clone());
                         self.stack.truncate(saved_stack_depth);
-                        self.stack.push(ret_val);
-                        self.discard_let_saves(let_mark);
+                        self.stack.push(ret_val.clone());
+                        self.resolve_frame_let_saves(let_mark, &ret_val);
                         result = Ok(());
                         break;
                     }
@@ -2021,8 +2029,8 @@ impl Interpreter {
                     let ret_val = e.return_value.unwrap();
                     explicit_return = Some(ret_val.clone());
                     self.stack.truncate(saved_stack_depth);
-                    self.stack.push(ret_val);
-                    self.discard_let_saves(let_mark);
+                    self.stack.push(ret_val.clone());
+                    self.resolve_frame_let_saves(let_mark, &ret_val);
                     result = Ok(());
                     break;
                 }
@@ -2057,6 +2065,14 @@ impl Interpreter {
         } else {
             Value::NIL
         };
+
+        // Natural fall-through completion: resolve the body's own `let`/`temp`
+        // saves against the value it produced. A method body is a block, so it
+        // owns the saves its `let`/`temp` recorded; without this they leaked
+        // into the caller's scope (#7646).
+        if result.is_ok() && explicit_return.is_none() {
+            self.resolve_frame_let_saves(let_mark, &ret_val);
+        }
 
         self.stack.truncate(saved_stack_depth);
 

--- a/src/vm/vm_try_catch_ops.rs
+++ b/src/vm/vm_try_catch_ops.rs
@@ -184,7 +184,20 @@ impl Interpreter {
         }
         match body_result {
             Ok(()) => {
-                self.discard_let_saves(let_mark);
+                // A `try`/implicit-CATCH region is a block, so it owns the
+                // `let`/`temp` saves its body recorded: `temp` restores here and
+                // `let` restores when the body produced an undefined value
+                // (#7646). A routine body carrying a `CATCH` phaser is compiled
+                // as exactly this region, so without it such a body never
+                // resolved its saves at all. When the body left no value on the
+                // stack there is nothing to judge failure by, so it counts as a
+                // successful exit (`temp` still restores).
+                if self.stack.len() > saved_depth {
+                    let body_value = self.stack.last().cloned().unwrap_or(Value::NIL);
+                    self.resolve_frame_let_saves(let_mark, &body_value);
+                } else {
+                    self.resolve_let_saves_on_success(let_mark, true);
+                }
                 // A `try` that completes normally but yields a soft Failure value
                 // (e.g. the result of an expression that returned a Failure rather
                 // than throwing) handles that Failure: its value is now "caught",

--- a/t/routine-body-let-resolution.t
+++ b/t/routine-body-let-resolution.t
@@ -1,0 +1,218 @@
+use Test;
+
+# GH-7646: `let`/`temp` resolve their saves at the end of the enclosing BLOCK,
+# and a routine body IS one. Only the bare-block (`OpCode::LetBlock`) and the
+# value-position `do { ... }` (GH-7635) lowerings used to implement that; a
+# routine body is compiled by the closure/sub-body path instead, which emits no
+# `LetBlock`, so its saves were never resolved by the frame that owned them.
+# They are resolved at frame teardown now, against the value the frame produced.
+#
+# Every assertion below was measured against `raku` first.
+
+plan 28;
+
+# --- a named sub resolves its own saves ---------------------------------
+
+{
+    my $x = 1;
+    sub f-let-fail() { let $x = 2; Nil }
+    f-let-fail();
+    is $x, 1, 'sub that yields an undefined value restores a `let`';
+}
+
+{
+    my $x = 1;
+    sub f-let-ok() { let $x = 2; 42 }
+    f-let-ok();
+    is $x, 2, 'sub that yields a defined value commits a `let`';
+}
+
+{
+    my $x = 1;
+    sub f-temp() { temp $x = 2; 42 }
+    f-temp();
+    is $x, 1, '`temp` in a sub restores even when the sub succeeds';
+}
+
+{
+    my $x = 1;
+    sub f-tail-let() { let $x = 2; }
+    my $r = f-tail-let();
+    is $r, 2, 'a tail `let $x = V` yields V, like any other assignment';
+    is $x, 2, 'and that defined value commits the `let`';
+}
+
+# --- explicit `return` is a frame exit too ------------------------------
+
+{
+    my $x = 1;
+    sub r-let-ok() { let $x = 2; return 42 }
+    r-let-ok();
+    is $x, 2, '`return` of a defined value commits a `let`';
+}
+
+{
+    my $x = 1;
+    sub r-let-fail() { let $x = 2; return Nil }
+    r-let-fail();
+    is $x, 1, '`return` of an undefined value restores a `let`';
+}
+
+{
+    my $x = 1;
+    sub r-temp() { temp $x = 2; return 42 }
+    r-temp();
+    is $x, 1, '`temp` restores across an explicit `return`';
+}
+
+# --- an exception unwinding the frame always restores -------------------
+
+{
+    my $x = 1;
+    sub d-let() { let $x = 2; die 'boom' }
+    try d-let();
+    is $x, 1, 'a `die` restores a `let`';
+}
+
+{
+    my $x = 1;
+    sub fl-let() { let $x = 2; fail 'boom' }
+    my $f = fl-let();
+    is $x, 1, 'a `fail` restores a `let`';
+    $f.so;  # defuse the Failure
+}
+
+# --- the save belongs to the frame that recorded it ---------------------
+
+{
+    my $x = 1;
+    sub inner-let() { let $x = 2; Nil }
+    sub outer-let() { inner-let(); 99 }
+    outer-let();
+    is $x, 1, "the callee's `let` is resolved by the callee, not the caller";
+}
+
+{
+    my $x = 1;
+    sub inner-ok() { let $x = 2; 7 }
+    sub outer-nil() { inner-ok(); Nil }
+    outer-nil();
+    is $x, 2, "a successful callee's `let` survives an unsuccessful caller";
+}
+
+# --- methods -------------------------------------------------------------
+
+{
+    my $x = 1;
+    class LetMethodFail { method m() { let $x = 2; Nil } }
+    LetMethodFail.m;
+    is $x, 1, 'method that yields an undefined value restores a `let`';
+}
+
+{
+    my $x = 1;
+    class LetMethodOk { method m() { let $x = 2; 42 } }
+    LetMethodOk.m;
+    is $x, 2, 'method that yields a defined value commits a `let`';
+}
+
+{
+    my $x = 1;
+    class TempMethod { method m() { temp $x = 2; 42 } }
+    TempMethod.m;
+    is $x, 1, '`temp` in a method restores';
+}
+
+{
+    my $x = 1;
+    class LetMethodReturn { method m() { let $x = 2; return Nil } }
+    LetMethodReturn.m;
+    is $x, 1, 'method `return` of an undefined value restores a `let`';
+}
+
+# --- closures ------------------------------------------------------------
+
+{
+    my $x = 1;
+    my $b = -> { let $x = 2; Nil };
+    $b();
+    is $x, 1, 'pointy block that fails restores a `let`';
+}
+
+{
+    my $x = 1;
+    my $b = -> { let $x = 2; 42 };
+    $b();
+    is $x, 2, 'pointy block that succeeds commits a `let`';
+}
+
+{
+    my $x = 1;
+    my $b = sub { temp $x = 2; 42 };
+    $b();
+    is $x, 1, '`temp` in an anonymous sub restores';
+}
+
+{
+    my $x = 1;
+    my $b = { let $x = 2; Nil };
+    $b();
+    is $x, 1, 'invoked bare block that fails restores a `let`';
+}
+
+# --- a `try` / implicit-CATCH region is a block too ----------------------
+
+{
+    my $x = 1;
+    try { temp $x = 2; };
+    is $x, 1, '`temp` in a `try` block restores at the block end';
+}
+
+{
+    my $x = 1;
+    try { let $x = 2; Nil };
+    is $x, 1, '`try` block that fails restores a `let`';
+}
+
+{
+    my $x = 1;
+    try { let $x = 2; 5 };
+    is $x, 2, '`try` block that succeeds commits a `let`';
+}
+
+{
+    my $x = 1;
+    sub catch-temp() { temp $x = 2; CATCH { default { } }; 7 }
+    catch-temp();
+    is $x, 1, 'a routine body carrying a CATCH still restores its `temp`';
+}
+
+{
+    my $x = 1;
+    sub catch-let() { let $x = 2; CATCH { default { } }; Nil }
+    catch-let();
+    is $x, 1, 'a routine body carrying a CATCH restores a failed `let`';
+}
+
+# --- container targets ---------------------------------------------------
+
+{
+    my @a = 1, 2;
+    sub arr-let() { let @a = 3, 4; Nil }
+    arr-let();
+    is @a.join(','), '1,2', 'a failed `let` restores an array';
+}
+
+{
+    my %h = a => 1;
+    sub hash-let() { let %h = b => 2; Nil }
+    hash-let();
+    is %h.keys.sort.join(','), 'a', 'a failed `let` restores a hash';
+}
+
+# --- the value of a `let` statement --------------------------------------
+
+{
+    my $x = 1;
+    is (do { let $x = 5 }), 5, 'a tail `let` is the value of a `do` block';
+}


### PR DESCRIPTION
Closes #7646.

`let`/`temp` resolve their saves at the end of the enclosing **block**, and a routine body is one.
Only two lowerings implemented that rule — the statement-position bare block and the value-position
`do { ... }` (#7635) — both via `OpCode::LetBlock`. A routine body is compiled by neither: it goes
through the closure/sub-body path, which emits no `LetBlock`, so a save recorded by
`OpCode::LetSave` was never resolved by the frame that owned it.

```raku
my $x = 1;
sub f() { let $x = 2; Nil }
f();
say $x;             # raku: 1   mutsu (before): 2
```

Methods diverged for `temp` as well as `let`, because the method-dispatch paths discarded the saves
outright on an explicit `return` and did not touch them at all on a natural fall-through:

```raku
my $x = 1;
class C { method m() { temp $x = 2; 42 } }
C.m;
say $x;             # raku: 1   mutsu (before): 2
```

## Approach

Resolve at **frame teardown** rather than by wrapping a bytecode range, as the ticket anticipated: a
routine has several ways to produce its result (tail expression, explicit `return`, `fail`, an
exception unwinding the frame) and `OpCode::LetBlock` can read the value from only one place.

Every dispatch path already took a `let_saves` mark on entry and already called
`resolve_let_saves_on_success(mark, true)` on exit — the hard-coded `true` is exactly what made
`temp` work (it restores either way) and `let` never restore. The new
`Interpreter::resolve_frame_let_saves` derives the flag from the frame's actual result, and each
routine / method / closure dispatch path now hands it the value it is about to return, including the
explicit-`return` arms that previously discarded the saves.

The `try`/implicit-CATCH region gets the same treatment. It is a block in its own right, and it is
also how a routine body carrying a `CATCH` phaser is compiled, so
`sub f() { temp $x = 2; CATCH { default { } }; 7 }` had no other place to resolve its saves at all.

## A tail `let` is an assignment

Judging the exit by the frame's value exposed a second gap: `let $x = 42` is an assignment and its
value is 42, but in block-final position it compiled through the valueless default arm and yielded
`Nil`. That was invisible while the saves leaked; once the value decides whether the save is kept, a
`sub f() { let $x = 2; }` looked like a failed block and rolled itself back. The tail-statement
lowerings (routine body, closure body, phaser body, inline block) now share
`Compiler::compile_let_stmt_as_value` with the existing expression-position arm, so
`do { let $x = 5 }` is `5`, as in rakudo.

## Still open

A loop body is a block too and resolves nothing: `for 1..2 { temp $k = 2; }` leaks, and the second
iteration observes the first one's value. Filed separately as #7677 — a loop body is compiled in
sink context, so the "did this block succeed" value `let` needs does not exist for it without a
second body-lowering shape.

## Testing

- New `t/routine-body-let-resolution.t` — 28 assertions covering named subs, methods, closures,
  explicit `return`, `die`/`fail`, nested frames, `try`/CATCH regions and array/hash targets. Every
  assertion was measured against `raku` first and the file passes under `raku` unchanged.
- `make test`: PASS (3880 files, 41151 tests).
- `make roast`: the only failures are the three documented container-only files
  (`roast/6.c/S32-io/file-tests.t`, `roast/S16-filehandles/filetest.t` — both `uid 0`;
  `roast/S32-io/IO-Socket-Async.t` — sandboxed network), with exactly the subtest ranges listed in
  `docs/agent-environments.md`.
- `make lint`: clean (default clippy, `jit` off, wasm32, rustdoc).
- Spot-checked the neighbouring pins: `t/do-block-let-resolution.t`, `t/let-temp.t`,
  `t/temp-scope-restore.t`, `t/gate-b-let-temp-slot-save.t`,
  `t/let-temp-restore-writeback-coherence.t`, `t/let-block-initializer-classifier.t`,
  `t/index-rw-arg-temp-reuse.t`, `t/temp-postfix-incdec.t`,
  `roast/S04-blocks-and-statements/{let,temp}.t` — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ADsnhfp6vaXL8PyBjbJqKZ


---
_Generated by [Claude Code](https://claude.ai/code/session_01ADsnhfp6vaXL8PyBjbJqKZ)_