### PR TITLE
perf(vm): share a closure literal's signature instead of cloning it per creation

### DIFF
--- a/news/2026-09/closure-literal-signature-shared-not-cloned.md
+++ b/news/2026-09/closure-literal-signature-shared-not-cloned.md
@@ -1,0 +1,87 @@
+# A closure literal's signature is shared, not deep-cloned per creation
+
+`SubData::body` stopped being a `Vec<Stmt>` in the Part C slice of
+[#7557](https://github.com/tokuhirom/mutsu/issues/7557): the block's AST is
+pool-owned and immutable, so every closure created from one literal shares one
+`Arc` instead of deep-cloning the body on each creation. The signature — the
+other pool-owned, immutable half of a closure literal — was left behind, and
+that is what this change fixes.
+
+## The cost
+
+`SubData::params` was a `Vec<String>` and `SubData::param_defs` a
+`Vec<ParamDef>`, both cloned out of the `stmt_pool` on every closure creation.
+`ParamDef` is fat: a `String` name, an `Option<Expr>` default, an
+`Option<Vec<ParamDef>>` sub-signature, an `Option<Box<Expr>>` where-constraint
+and a `Vec<String>` of traits. Cloning one is several allocations, and a
+creation cloned one per parameter — on the path that runs once per
+`.map({...})` / `.grep({...})` / callback-literal evaluation.
+
+The scaling is easy to see by varying only the parameter count. Two loops
+building 100000 pointy blocks, one with a single parameter and one with eight,
+counted with callgrind (deterministic, so the container's four noisy cores do
+not matter):
+
+| | 1 parameter | 8 parameters | difference |
+|---|---|---|---|
+| before | 2,086,890,637 | 2,859,420,599 | +772,529,962 |
+| after | 2,025,362,566 | 2,038,812,420 | +13,449,854 |
+
+Seven extra parameters used to add **~1100 instructions to every single
+creation**; they now add ~19. Per creation (control loop subtracted), the
+8-parameter literal went from 24,820 to 16,687 instructions, **−32.8%**.
+
+A bare block pays a second, related cost: its `params` are the implicit
+placeholder variables (`$^a`, `@_`, …), which `collect_placeholders_shallow`
+derives by walking *and sorting* the body. That is a pure function of the pool
+entry too, and it ran on every creation.
+
+## The change
+
+`SubData::params` is now `Arc<Vec<String>>` and `param_defs` is
+`Arc<Vec<ParamDef>>`, and `CompiledCode::closure_signature(idx)` builds the pair
+once per `stmt_pool` slot behind a `OnceLock` — the exact shape
+`closure_body_arc` already uses for the body, including its fallback for a chunk
+whose pool grew after the side table was sized. The cached entry for a
+`Stmt::Block` slot carries the placeholder scan, so that walk-and-sort is now
+also paid once per literal rather than once per creation.
+
+All four closure-creation opcodes (`MakeLambda`, `MakeAnonSub`,
+`MakeAnonSubParams`, `MakeBlockClosure`) take their signature from there.
+`MakeBlockClosure` deliberately does not: a block closure takes no signature at
+all, and asks for `value::empty_params()` / `value::empty_param_defs()` — one
+shared empty `Arc` per thread, because `Arc::new(Vec::new())` still allocates a
+control block per creation, which is precisely the allocation sharing the field
+was meant to remove.
+
+Nothing mutates a `SubData`'s signature after construction, which is what makes
+the sharing sound. The places that *appear* to (`.assuming` building a primed
+signature, `.^add_multi_method` copying a signature into a `MethodDef`,
+`callable_signature` handing an owned pair to callers that edit it) take an
+owned copy explicitly, exactly as they did before — they simply say so now.
+
+## Effect on the other numbers
+
+| repro | before | after | |
+|---|---|---|---|
+| `my $c = * + 1;` × 200000 | 4,741,856,528 | 4,548,975,732 | −4.1% |
+| `-> $a { $a }` × 100000 | 2,086,890,637 | 2,025,362,566 | −2.9% |
+| `-> $a … $h { $a }` × 100000 | 2,859,420,599 | 2,038,812,420 | −28.7% |
+| `-> $a, $b, Int $c = 3, :$named, *@rest {…}` × 100000 | 2,640,465,916 | 2,035,588,516 | −22.9% |
+
+A one-parameter `WhateverCode` was never where the signature clone hurt, so its
+few percent is the floor; the win grows with the signature, which is what
+"O(signature) per creation" meant.
+
+## What is still open on #7557
+
+The kept-set narrowing that Part B actually asks for. `capture_closure_env`
+keeps every env key `is_plain_user_lexical` rejects, which is over-broad by
+construction; #7624 memoized the resulting `Env` one entry deep, but a capture
+that *misses* that memo still pays O(kept env). That needs the design pass the
+issue describes — mostly a question about the built-in dynamics — and is not a
+drive-by.
+
+Pinned by `t/closure-shared-signature.t`, which checks that closures built from
+one literal in a loop keep independent behaviour, and that priming one with
+`.assuming` leaves its siblings' arity, defaults and parameter list untouched.

--- a/news/2026-09/closure-literal-signature-shared-not-cloned.md
+++ b/news/2026-09/closure-literal-signature-shared-not-cloned.md
@@ -73,6 +73,19 @@ A one-parameter `WhateverCode` was never where the signature clone hurt, so its
 few percent is the floor; the win grows with the signature, which is what
 "O(signature) per creation" meant.
 
+The whole-program benchmarks move by a little, and none of them the wrong way
+(same callgrind method, the two binaries measured back to back):
+
+| | before | after | |
+|---|---|---|---|
+| `bench-ctor` | 1,327,445,176 | 1,313,646,631 | −1.04% |
+| `bench-class` | 1,171,901,705 | 1,162,528,513 | −0.80% |
+| `bench-grammar-parse` | 65,585,593 | 65,330,697 | −0.39% |
+| `bench-yaml-parse` | 12,986,021 | 12,938,248 | −0.37% |
+
+These are instruction counts, not the wall-clock series: the numbers that belong
+in a benchmark record still come from the bench CI history.
+
 ## What is still open on #7557
 
 The kept-set narrowing that Part B actually asks for. `capture_closure_env`

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -5002,6 +5002,12 @@ pub(crate) struct CompiledCode {
     /// A `SubData`'s body used to be deep-cloned out of the pool on every
     /// closure creation; the `Arc` is built once per slot instead.
     pub(crate) stmt_pool_bodies: std::sync::OnceLock<StmtPoolBodies>,
+    /// Lazily-built shared signature per `stmt_pool` slot (see
+    /// `closure_signature`). The twin of `stmt_pool_bodies` for the other two
+    /// pool-owned, immutable parts of a closure literal: a `SubData`'s
+    /// `params`/`param_defs` used to be cloned out of the pool on every
+    /// creation, which is O(signature) with a fat `ParamDef` element.
+    pub(crate) stmt_pool_signatures: std::sync::OnceLock<StmtPoolSignatures>,
     /// Per-chunk JIT hotness counter and compiled-entry cache (ADR-0004 J1).
     #[cfg(feature = "jit")]
     pub(crate) jit: JitCodeState,
@@ -5067,6 +5073,20 @@ pub(crate) type LocalAttrKeys = Box<[Option<(Symbol, bool)>]>;
 /// [`CompiledCode::closure_body_arc`]): one lazily-filled slot per pool entry,
 /// each holding the `Arc` every closure created from that entry shares.
 pub(crate) type StmtPoolBodies = Box<[std::sync::OnceLock<std::sync::Arc<Vec<Stmt>>>]>;
+
+/// The shared signature of one closure-declaring `stmt_pool` slot (see
+/// [`CompiledCode::closure_signature`]). Both halves are `Arc`s handed straight
+/// to the `SubData` being built, so a creation costs two refcount bumps instead
+/// of a deep clone of the whole signature.
+#[derive(Debug, Clone)]
+pub(crate) struct ClosureSignature {
+    pub(crate) params: std::sync::Arc<Vec<String>>,
+    pub(crate) param_defs: std::sync::Arc<Vec<crate::ast::ParamDef>>,
+}
+
+/// The per-`stmt_pool`-slot shared signature table of a chunk; see
+/// [`CompiledCode::closure_signature`].
+pub(crate) type StmtPoolSignatures = Box<[std::sync::OnceLock<ClosureSignature>]>;
 
 /// JIT hotness/entry state carried on each `CompiledCode` (ADR-0004 layer 4).
 /// `entry` caches the compiled native entry so the per-call cost once compiled
@@ -5409,6 +5429,7 @@ impl CompiledCode {
             free_var_sym_set: std::sync::OnceLock::new(),
             local_sym_set: std::sync::OnceLock::new(),
             stmt_pool_bodies: std::sync::OnceLock::new(),
+            stmt_pool_signatures: std::sync::OnceLock::new(),
             #[cfg(feature = "jit")]
             jit: JitCodeState::default(),
         }
@@ -5457,6 +5478,57 @@ impl CompiledCode {
             Some(slot) => slot.get_or_init(|| extract(idx)).clone(),
             // The pool grew after the side table was sized (a chunk still being
             // built): fall back to an uncached clone rather than mis-indexing.
+            None => extract(idx),
+        }
+    }
+
+    /// The shared signature of the closure declaration at `stmt_pool[idx]`,
+    /// built once per slot — the `closure_body_arc` treatment applied to the
+    /// other two pool-owned, immutable parts of a closure literal.
+    ///
+    /// A `SubData`'s `params`/`param_defs` are never mutated after
+    /// construction, so every closure created from a slot can share one `Arc`
+    /// pair instead of deep-cloning the signature. That clone was O(signature
+    /// size) on the once-per-`.map({...})`-CALL path, and `ParamDef` is fat: an
+    /// 8-parameter pointy block paid ~1100 instructions *per extra parameter*
+    /// on every creation.
+    ///
+    /// A `Stmt::Block` slot has no declared signature; its `params` are the
+    /// block's implicit placeholder variables (`$^a`, `@_`, …), which
+    /// `collect_placeholders_shallow` derives by walking — and then sorting —
+    /// the body. That is a pure function of the pool entry too, so it is cached
+    /// here rather than recomputed per creation. `MakeBlockClosure` deliberately
+    /// does NOT use this: a block closure takes no placeholder signature, and
+    /// asks for `value::empty_params()` instead.
+    pub(crate) fn closure_signature(&self, idx: usize) -> ClosureSignature {
+        let extract = |i: usize| -> ClosureSignature {
+            match self.stmt_pool.get(i) {
+                Some(Stmt::SubDecl {
+                    params, param_defs, ..
+                }) => ClosureSignature {
+                    params: std::sync::Arc::new(params.clone()),
+                    param_defs: std::sync::Arc::new(param_defs.clone()),
+                },
+                Some(Stmt::Block(body)) => ClosureSignature {
+                    params: std::sync::Arc::new(crate::ast::collect_placeholders_shallow(body)),
+                    param_defs: crate::value::empty_param_defs(),
+                },
+                _ => ClosureSignature {
+                    params: crate::value::empty_params(),
+                    param_defs: crate::value::empty_param_defs(),
+                },
+            }
+        };
+        let slots = self.stmt_pool_signatures.get_or_init(|| {
+            (0..self.stmt_pool.len())
+                .map(|_| std::sync::OnceLock::new())
+                .collect()
+        });
+        match slots.get(idx) {
+            Some(slot) => slot.get_or_init(|| extract(idx)).clone(),
+            // The pool grew after the side table was sized (a chunk still being
+            // built): fall back to an uncached build rather than mis-indexing.
+            // Same guard as `closure_body_arc`.
             None => extract(idx),
         }
     }

--- a/src/runtime/accessors_state.rs
+++ b/src/runtime/accessors_state.rs
@@ -6,7 +6,9 @@ use crate::symbol::Symbol;
 impl Interpreter {
     pub(crate) fn callable_signature(&self, callable: &Value) -> (Vec<String>, Vec<ParamDef>) {
         match callable.view() {
-            ValueView::Sub(data) => (data.params.clone(), data.param_defs.clone()),
+            // `SubData` shares these behind an `Arc` (see `SubData::params`);
+            // this accessor hands back an owned, caller-mutable pair.
+            ValueView::Sub(data) => (data.params.to_vec(), data.param_defs.to_vec()),
             ValueView::Routine { name, .. } => {
                 if let Some(def) = self.resolve_function(&name.resolve()) {
                     return (def.params.clone(), def.param_defs.clone());

--- a/src/runtime/methods_classhow_attribute.rs
+++ b/src/runtime/methods_classhow_attribute.rs
@@ -269,8 +269,8 @@ impl Interpreter {
                 let sub_data = crate::value::SubData {
                     package: Symbol::intern("GLOBAL"),
                     name: Symbol::intern("<attribute-build>"),
-                    params: Vec::new(),
-                    param_defs: Vec::new(),
+                    params: crate::value::empty_params(),
+                    param_defs: crate::value::empty_param_defs(),
                     body: std::sync::Arc::new(body),
                     is_rw: false,
                     is_raw: false,

--- a/src/runtime/methods_classhow_dispatch.rs
+++ b/src/runtime/methods_classhow_dispatch.rs
@@ -1151,8 +1151,8 @@ impl Interpreter {
                 };
                 let def = MethodDef {
                     lexical_package: sub_data.package,
-                    params: sub_data.params.clone(),
-                    param_defs: sub_data.param_defs.clone(),
+                    params: sub_data.params.to_vec(),
+                    param_defs: sub_data.param_defs.to_vec(),
                     body: sub_data.body.clone(),
                     is_rw: sub_data.is_rw,
                     is_raw: sub_data.is_raw,

--- a/src/runtime/methods_instance_ops.rs
+++ b/src/runtime/methods_instance_ops.rs
@@ -2483,7 +2483,7 @@ impl Interpreter {
                         _ => Value::NIL,
                     };
                     let params = match callable.view() {
-                        ValueView::Sub(data) if !data.params.is_empty() => data.params.clone(),
+                        ValueView::Sub(data) if !data.params.is_empty() => data.params.to_vec(),
                         _ => vec!["_".to_string()],
                     };
 

--- a/src/runtime/methods_promise_class.rs
+++ b/src/runtime/methods_promise_class.rs
@@ -104,8 +104,8 @@ impl Interpreter {
         Value::sub_value(crate::gc::Gc::new(crate::value::SubData {
             package: Symbol::intern("GLOBAL"),
             name: Symbol::intern(""),
-            params: Vec::new(),
-            param_defs: Vec::new(),
+            params: crate::value::empty_params(),
+            param_defs: crate::value::empty_param_defs(),
             body: std::sync::Arc::new(body),
             is_rw: false,
             is_raw: false,

--- a/src/runtime/methods_signature.rs
+++ b/src/runtime/methods_signature.rs
@@ -128,7 +128,9 @@ impl Interpreter {
         if data.param_defs.is_empty() {
             return None;
         }
-        let mut param_defs = data.param_defs.clone();
+        // Owned: this builds the *primed* signature of an `.assuming` wrapper
+        // by editing the copy, so it cannot share the `SubData`'s `Arc`.
+        let mut param_defs = data.param_defs.to_vec();
         // Build type capture mappings from assumed positional args
         let mut type_captures: std::collections::HashMap<String, String> =
             std::collections::HashMap::new();

--- a/src/runtime/methods_sub.rs
+++ b/src/runtime/methods_sub.rs
@@ -87,8 +87,8 @@ impl Interpreter {
             let mut sub_data = crate::value::SubData {
                 package: Symbol::intern(package),
                 name: Symbol::intern(name),
-                params: Vec::new(),
-                param_defs: Vec::new(),
+                params: crate::value::empty_params(),
+                param_defs: crate::value::empty_param_defs(),
                 body: std::sync::Arc::new(vec![]),
                 is_rw: false,
                 is_raw: false,

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -4244,8 +4244,8 @@ mod tests {
         let block = crate::gc::Gc::new(SubData {
             package: Symbol::intern("GLOBAL"),
             name: Symbol::intern("__protect_test__"),
-            params: vec![],
-            param_defs: vec![],
+            params: crate::value::empty_params(),
+            param_defs: crate::value::empty_param_defs(),
             body: std::sync::Arc::new(vec![Stmt::Expr(Expr::Literal(Value::int(0)))]),
             is_rw: false,
             is_raw: false,

--- a/src/runtime/native_methods/scheduled_tap_pump.rs
+++ b/src/runtime/native_methods/scheduled_tap_pump.rs
@@ -116,8 +116,8 @@ impl Interpreter {
         Value::sub_value(crate::gc::Gc::new(crate::value::SubData {
             package: Symbol::intern("GLOBAL"),
             name: Symbol::intern(""),
-            params: Vec::new(),
-            param_defs: Vec::new(),
+            params: crate::value::empty_params(),
+            param_defs: crate::value::empty_param_defs(),
             body: std::sync::Arc::new(body),
             is_rw: false,
             is_raw: false,

--- a/src/runtime/native_methods/supply_collector.rs
+++ b/src/runtime/native_methods/supply_collector.rs
@@ -118,8 +118,8 @@ impl Interpreter {
         Value::sub_value(crate::gc::Gc::new(crate::value::SubData {
             package: Symbol::intern("GLOBAL"),
             name: Symbol::intern(""),
-            params,
-            param_defs,
+            params: std::sync::Arc::new(params),
+            param_defs: std::sync::Arc::new(param_defs),
             body: std::sync::Arc::new(body),
             is_rw: false,
             is_raw: false,

--- a/src/runtime/native_methods/supply_quit_forwarder.rs
+++ b/src/runtime/native_methods/supply_quit_forwarder.rs
@@ -137,8 +137,8 @@ impl Interpreter {
         Value::sub_value(crate::gc::Gc::new(crate::value::SubData {
             package: Symbol::intern("GLOBAL"),
             name: Symbol::intern(""),
-            params: vec!["v".to_string()],
-            param_defs: vec![crate::ast::ParamDef {
+            params: std::sync::Arc::new(vec!["v".to_string()]),
+            param_defs: std::sync::Arc::new(vec![crate::ast::ParamDef {
                 name: "v".to_string(),
                 default: None,
                 multi_invocant: true,
@@ -159,7 +159,7 @@ impl Interpreter {
                 is_invocant: false,
                 shape_constraints: None,
                 block_param: false,
-            }],
+            }]),
             body: std::sync::Arc::new(body),
             is_rw: false,
             is_raw: false,

--- a/src/runtime/native_supply_mut_methods.rs
+++ b/src/runtime/native_supply_mut_methods.rs
@@ -1585,8 +1585,8 @@ impl Interpreter {
         let tick = Value::sub_value(crate::gc::Gc::new(crate::value::SubData {
             package: Symbol::intern("GLOBAL"),
             name: Symbol::intern(""),
-            params: Vec::new(),
-            param_defs: Vec::new(),
+            params: crate::value::empty_params(),
+            param_defs: crate::value::empty_param_defs(),
             body: std::sync::Arc::new(body),
             is_rw: false,
             is_raw: false,
@@ -1701,8 +1701,8 @@ impl Interpreter {
         Value::sub_value(crate::gc::Gc::new(crate::value::SubData {
             package: Symbol::intern("GLOBAL"),
             name: Symbol::intern(""),
-            params,
-            param_defs,
+            params: std::sync::Arc::new(params),
+            param_defs: std::sync::Arc::new(param_defs),
             body: std::sync::Arc::new(body),
             is_rw: false,
             is_raw: false,

--- a/src/runtime/resolution_call_sub.rs
+++ b/src/runtime/resolution_call_sub.rs
@@ -1106,7 +1106,7 @@ impl Interpreter {
                 // such as `|c(Str $x)` would clobber a caller variable that
                 // happens to share the parameter's name).
                 let mut subsig_names = std::collections::HashSet::new();
-                for pd in &data.param_defs {
+                for pd in data.param_defs.iter() {
                     Self::collect_sub_signature_names(&pd.sub_signature, &mut subsig_names);
                 }
                 for (k, v) in self.env.iter() {

--- a/src/runtime/resolution_map_grep.rs
+++ b/src/runtime/resolution_map_grep.rs
@@ -540,7 +540,7 @@ impl Interpreter {
                     touched_keys.push(k.resolve());
                 }
             }
-            for p in &data.params {
+            for p in data.params.iter() {
                 if !touched_keys.contains(p) {
                     touched_keys.push(p.clone());
                 }
@@ -954,7 +954,7 @@ impl Interpreter {
                 touched_keys.push(k.resolve());
             }
         }
-        for p in &data.params {
+        for p in data.params.iter() {
             if !touched_keys.contains(p) {
                 touched_keys.push(p.clone());
             }

--- a/src/runtime/resolution_map_grep_rw.rs
+++ b/src/runtime/resolution_map_grep_rw.rs
@@ -216,7 +216,7 @@ impl Interpreter {
                     touched_keys.push(k.resolve());
                 }
             }
-            for p in &data.params {
+            for p in data.params.iter() {
                 if !touched_keys.contains(p) {
                     touched_keys.push(p.clone());
                 }
@@ -593,7 +593,7 @@ impl Interpreter {
                     touched_keys.push(k.resolve());
                 }
             }
-            for p in &data.params {
+            for p in data.params.iter() {
                 if !touched_keys.contains(p) {
                     touched_keys.push(p.clone());
                 }

--- a/src/runtime/run_main.rs
+++ b/src/runtime/run_main.rs
@@ -202,8 +202,8 @@ impl Interpreter {
         Value::sub_value(crate::gc::Gc::new(crate::value::SubData {
             package: crate::symbol::Symbol::intern("GLOBAL"),
             name: crate::symbol::Symbol::intern(name),
-            params: Vec::new(),
-            param_defs: Vec::new(),
+            params: crate::value::empty_params(),
+            param_defs: crate::value::empty_param_defs(),
             body: std::sync::Arc::new(Vec::new()),
             is_rw: false,
             is_raw: false,

--- a/src/runtime/subtest.rs
+++ b/src/runtime/subtest.rs
@@ -459,7 +459,7 @@ impl Interpreter {
         let callback = stamp(Value::make_sub_owning(
             Symbol::intern(&self.current_package()),
             Symbol::intern(""),
-            param.iter().cloned().collect(),
+            param.iter().cloned().collect::<Vec<String>>(),
             main_param_defs,
             main_body,
             false,

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -715,6 +715,26 @@ fn write_attrs(cell: &RwLock<AttrMap>) -> std::sync::RwLockWriteGuard<'_, AttrMa
     cell.write().unwrap_or_else(|e| e.into_inner())
 }
 
+thread_local! {
+    /// One shared empty [`SubData::params`] / [`SubData::param_defs`] per
+    /// thread. `Arc::new(Vec::new())` does not allocate the `Vec`, but it does
+    /// allocate the `Arc`'s control block — once per closure creation on the
+    /// signature-less paths (`MakeBlockClosure`, `MakeAnonSub`), which is
+    /// exactly what sharing the field was meant to avoid.
+    static EMPTY_PARAMS: Arc<Vec<String>> = Arc::new(Vec::new());
+    static EMPTY_PARAM_DEFS: Arc<Vec<ParamDef>> = Arc::new(Vec::new());
+}
+
+/// The shared empty parameter-name list; see [`EMPTY_PARAMS`].
+pub(crate) fn empty_params() -> Arc<Vec<String>> {
+    EMPTY_PARAMS.with(Arc::clone)
+}
+
+/// The shared empty parameter-description list; see [`EMPTY_PARAMS`].
+pub(crate) fn empty_param_defs() -> Arc<Vec<ParamDef>> {
+    EMPTY_PARAM_DEFS.with(Arc::clone)
+}
+
 pub(crate) fn next_instance_id() -> u64 {
     INSTANCE_ID_COUNTER.fetch_add(1, Ordering::Relaxed)
 }
@@ -822,8 +842,21 @@ pub enum JunctionKind {
 pub struct SubData {
     pub package: Symbol,
     pub name: Symbol,
-    pub params: Vec<String>,
-    pub(crate) param_defs: Vec<ParamDef>,
+    /// The signature's parameter *names*, shared. Like [`Self::body`] below,
+    /// this is pool-owned and immutable: a closure literal's `params` are a
+    /// pure function of the `SubDecl`/`Block` it was created from, so cloning
+    /// the `Vec<String>` per creation bought nothing but a `String` allocation
+    /// per parameter. `CompiledCode::closure_signature` builds the `Arc` once
+    /// per `stmt_pool` slot and every later creation is an `Arc` bump.
+    pub params: Arc<Vec<String>>,
+    /// The signature's parameter descriptions, shared for the same reason as
+    /// [`Self::params`] — and with far more to gain: `ParamDef` is fat (a
+    /// `String` name, an `Option<Expr>` default, a nested `Vec<ParamDef>`
+    /// sub-signature, a `Vec<String>` of traits), so the per-creation clone
+    /// was O(signature size) with a large constant. Measured on a
+    /// `-> $a, $b, … { … }` literal built in a loop, each extra parameter cost
+    /// ~1100 instructions on *every* creation before this was shared.
+    pub(crate) param_defs: Arc<Vec<ParamDef>>,
     /// The block's AST, shared. Closure creation happens once per `.map({...})`
     /// CALL, so a `Vec<Stmt>` here meant deep-cloning the whole body every time
     /// -- 5.9us per creation for a 29-statement block, and O(body) for any

--- a/src/value/nanbox/tests.rs
+++ b/src/value/nanbox/tests.rs
@@ -5,7 +5,6 @@
 //! round-trips (`cargo miri test value::nanbox`).
 
 use super::*;
-use crate::ast::ParamDef;
 use crate::env::Env;
 
 fn roundtrip(repr: ValueRepr) -> ValueRepr {
@@ -212,8 +211,8 @@ fn sample_sub() -> Gc<SubData> {
     Gc::new(SubData {
         package: Symbol::intern("Main"),
         name: Symbol::intern("nanbox-test-sub"),
-        params: vec![],
-        param_defs: Vec::<ParamDef>::new(),
+        params: crate::value::empty_params(),
+        param_defs: crate::value::empty_param_defs(),
         body: std::sync::Arc::new(vec![]),
         is_rw: false,
         is_raw: false,

--- a/src/value/value_gc.rs
+++ b/src/value/value_gc.rs
@@ -755,8 +755,8 @@ mod tests {
         SubData {
             package: crate::symbol::Symbol::intern("GLOBAL"),
             name: crate::symbol::Symbol::intern("__gc_test__"),
-            params: vec![],
-            param_defs: vec![],
+            params: crate::value::empty_params(),
+            param_defs: crate::value::empty_param_defs(),
             body: std::sync::Arc::new(vec![]),
             is_rw: false,
             is_raw: false,

--- a/src/value/value_methods_b.rs
+++ b/src/value/value_methods_b.rs
@@ -493,8 +493,8 @@ impl Value {
     fn new_code_object(
         package: Symbol,
         name: Symbol,
-        params: Vec<String>,
-        param_defs: Vec<ParamDef>,
+        params: impl Into<std::sync::Arc<Vec<String>>>,
+        param_defs: impl Into<std::sync::Arc<Vec<ParamDef>>>,
         body: impl Into<std::sync::Arc<Vec<Stmt>>>,
         is_rw: bool,
         env: Env,
@@ -502,8 +502,11 @@ impl Value {
         SubData {
             package,
             name,
-            params,
-            param_defs,
+            // Like `body`, both halves of the signature are shared behind an
+            // `Arc` (see `SubData::params`); `impl Into` keeps the existing
+            // `Vec`-passing call sites working.
+            params: params.into(),
+            param_defs: param_defs.into(),
             body: body.into(),
             is_rw,
             is_raw: false,
@@ -531,8 +534,8 @@ impl Value {
     pub(crate) fn make_sub(
         package: Symbol,
         name: Symbol,
-        params: Vec<String>,
-        param_defs: Vec<ParamDef>,
+        params: impl Into<std::sync::Arc<Vec<String>>>,
+        param_defs: impl Into<std::sync::Arc<Vec<ParamDef>>>,
         body: impl Into<std::sync::Arc<Vec<Stmt>>>,
         is_rw: bool,
         env: Env,
@@ -554,8 +557,8 @@ impl Value {
     pub(crate) fn make_sub_for_routine(
         package: Symbol,
         name: Symbol,
-        params: Vec<String>,
-        param_defs: Vec<ParamDef>,
+        params: impl Into<std::sync::Arc<Vec<String>>>,
+        param_defs: impl Into<std::sync::Arc<Vec<ParamDef>>>,
         body: impl Into<std::sync::Arc<Vec<Stmt>>>,
         is_rw: bool,
         env: Env,
@@ -584,8 +587,8 @@ impl Value {
     pub(crate) fn make_sub_for_routine_owning(
         package: Symbol,
         name: Symbol,
-        params: Vec<String>,
-        param_defs: Vec<ParamDef>,
+        params: impl Into<std::sync::Arc<Vec<String>>>,
+        param_defs: impl Into<std::sync::Arc<Vec<ParamDef>>>,
         body: impl Into<std::sync::Arc<Vec<Stmt>>>,
         is_rw: bool,
         env: Env,
@@ -614,8 +617,8 @@ impl Value {
     pub(crate) fn make_sub_with_id(
         package: Symbol,
         name: Symbol,
-        params: Vec<String>,
-        param_defs: Vec<ParamDef>,
+        params: impl Into<std::sync::Arc<Vec<String>>>,
+        param_defs: impl Into<std::sync::Arc<Vec<ParamDef>>>,
         body: impl Into<std::sync::Arc<Vec<Stmt>>>,
         is_rw: bool,
         env: Env,
@@ -638,8 +641,8 @@ impl Value {
     pub(crate) fn make_sub_owning(
         package: Symbol,
         name: Symbol,
-        params: Vec<String>,
-        param_defs: Vec<ParamDef>,
+        params: impl Into<std::sync::Arc<Vec<String>>>,
+        param_defs: impl Into<std::sync::Arc<Vec<ParamDef>>>,
         body: impl Into<std::sync::Arc<Vec<Stmt>>>,
         is_rw: bool,
         env: Env,

--- a/src/vm/vm_closure_dispatch.rs
+++ b/src/vm/vm_closure_dispatch.rs
@@ -1390,13 +1390,13 @@ impl Interpreter {
         // call, so a cryptographic hash over the small integer key dominated the
         // profile (~5% of mzef-ctor self time in `SipHasher::hash_one<Symbol>`).
         let mut param_names: rustc_hash::FxHashSet<Symbol> = rustc_hash::FxHashSet::default();
-        for p in &data.params {
+        for p in data.params.iter() {
             param_names.insert(Symbol::intern(p));
         }
         // Collect names bound by subsignature parameters (e.g. `|c(Str $x)`),
         // which are also strictly call-local and must not leak to the caller.
         let mut subsig_names: std::collections::HashSet<String> = std::collections::HashSet::new();
-        for pd in &data.param_defs {
+        for pd in data.param_defs.iter() {
             if !pd.name.is_empty() {
                 param_names.insert(Symbol::intern(&pd.name));
             }

--- a/src/vm/vm_register_ops.rs
+++ b/src/vm/vm_register_ops.rs
@@ -561,8 +561,11 @@ impl Interpreter {
         // channel (not just the return value).
         self.closures_created += 1;
         let stmt = &code.stmt_pool[idx as usize];
-        if let Stmt::Block(body) = stmt {
-            let params = crate::ast::collect_placeholders_shallow(body);
+        if let Stmt::Block(_) = stmt {
+            // Shared per pool slot (`closure_signature`): the block's implicit
+            // placeholder parameters are a pure function of its body, but the
+            // walk-and-sort that derives them used to run on every creation.
+            let signature = code.closure_signature(idx as usize);
             let compiled_code = Self::resolve_closure_code(code, cc_idx);
             // A bare block that performs a regex match is not a routine
             // boundary: its `$/` belongs to the lexical scope where it was
@@ -635,8 +638,8 @@ impl Interpreter {
                 // empty literal on every block creation hashed a string for a
                 // constant answer.
                 name: crate::symbol::well_known::anon(),
-                params,
-                param_defs: Vec::new(),
+                params: signature.params,
+                param_defs: signature.param_defs,
                 body: code.closure_body_arc(idx as usize),
                 is_rw: false,
                 is_raw: false,
@@ -688,11 +691,12 @@ impl Interpreter {
         let stmt = &code.stmt_pool[idx as usize];
         if let Stmt::SubDecl {
             name,
-            params,
             param_defs,
             return_type,
-            // The body itself comes from `closure_body_arc` (shared, built once
-            // per pool slot) rather than being deep-cloned out of the pool here.
+            // The body and the signature both come from the shared per-pool-slot
+            // caches (`closure_body_arc` / `closure_signature`) rather than being
+            // deep-cloned out of the pool here.
+            params: _,
             body: _,
             is_rw,
             is_raw,
@@ -700,6 +704,7 @@ impl Interpreter {
         } = stmt
         {
             self.check_param_custom_traits(param_defs)?;
+            let signature = code.closure_signature(idx as usize);
             let compiled_code = Self::resolve_closure_code(code, cc_idx);
             self.box_captured_lexicals(code, &compiled_code);
             let owned_captures = self.compute_owned_captures(&compiled_code);
@@ -745,8 +750,9 @@ impl Interpreter {
                 // Anonymous closures pool a SubDecl with an empty name; a
                 // named `anon sub NAME` decl carries its name through here.
                 name: *name,
-                params: params.clone(),
-                param_defs: param_defs.clone(),
+                empty_sig: signature.params.is_empty() && signature.param_defs.is_empty(),
+                params: signature.params,
+                param_defs: signature.param_defs,
                 body: code.closure_body_arc(idx as usize),
                 is_rw: *is_rw,
                 is_raw: *is_raw,
@@ -754,7 +760,6 @@ impl Interpreter {
                 assumed_positional: Vec::new(),
                 assumed_named: std::collections::HashMap::new(),
                 id: crate::value::next_instance_id(),
-                empty_sig: params.is_empty() && param_defs.is_empty(),
                 // A pointy block (`-> $x {...}`) is a `Block`, not a `Sub`. Named
                 // anonymous subs (`sub {...}`) have `is_pointy_block == false` and
                 // stay `Sub`. (`WhateverCode` already overrides via callable_type.)

--- a/src/vm/vm_register_sub_ops.rs
+++ b/src/vm/vm_register_sub_ops.rs
@@ -70,10 +70,11 @@ impl Interpreter {
         self.closures_created += 1;
         let stmt = &code.stmt_pool[idx as usize];
         if let Stmt::SubDecl {
-            params,
             param_defs,
             return_type,
-            // See `closure_body_arc`: the body is shared, not cloned out here.
+            // See `closure_body_arc` / `closure_signature`: the body AND the
+            // signature are shared, not cloned out here.
+            params: _,
             body: _,
             is_rw,
             is_raw,
@@ -81,6 +82,7 @@ impl Interpreter {
         } = stmt
         {
             self.check_param_custom_traits(param_defs)?;
+            let signature = code.closure_signature(idx as usize);
             let compiled_code = Self::resolve_closure_code(code, cc_idx);
             self.box_captured_lexicals(code, &compiled_code);
             let owned_captures = self.compute_owned_captures(&compiled_code);
@@ -121,8 +123,9 @@ impl Interpreter {
             let val = Value::sub_value(crate::gc::Gc::new(crate::value::SubData {
                 package: self.lexical_closure_package_sym(),
                 name: crate::symbol::well_known::anon(),
-                params: params.clone(),
-                param_defs: param_defs.clone(),
+                empty_sig: signature.params.is_empty() && signature.param_defs.is_empty(),
+                params: signature.params,
+                param_defs: signature.param_defs,
                 body: code.closure_body_arc(idx as usize),
                 is_rw: *is_rw,
                 is_raw: *is_raw,
@@ -130,7 +133,6 @@ impl Interpreter {
                 assumed_positional: Vec::new(),
                 assumed_named: std::collections::HashMap::new(),
                 id: crate::value::next_instance_id(),
-                empty_sig: params.is_empty() && param_defs.is_empty(),
                 // A pointy block (`-> $x {...}`) is a `Block`, not a `Sub` — mark it
                 // so `.WHAT`/`.^name`/smartmatch report `Block`. Named anonymous subs
                 // (`sub {...}`) have `is_pointy_block == false` and stay `Sub`.
@@ -180,8 +182,10 @@ impl Interpreter {
             let val = Value::sub_value(crate::gc::Gc::new(crate::value::SubData {
                 package: self.lexical_closure_package_sym(),
                 name: crate::symbol::well_known::anon(),
-                params: vec![],
-                param_defs: Vec::new(),
+                // A block closure takes no signature at all; the shared empty
+                // avoids an `Arc` control-block allocation per creation.
+                params: crate::value::empty_params(),
+                param_defs: crate::value::empty_param_defs(),
                 body: code.closure_body_arc(idx as usize),
                 is_rw: false,
                 is_raw: false,

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -410,7 +410,7 @@ impl Interpreter {
         if let ValueView::Sub(data) = idx.view() {
             let mut sub_env = data.env.clone();
             // Pass length for ALL WhateverCode parameters (e.g. *-4 .. *-2 has 2 params)
-            for p in &data.params {
+            for p in data.params.iter() {
                 sub_env.insert(p.to_string(), Value::int(len));
             }
             let saved_env = std::mem::take(self.env_mut());
@@ -433,7 +433,7 @@ impl Interpreter {
                 for item in items.iter() {
                     if let ValueView::Sub(data) = item.view() {
                         let mut sub_env = data.env.clone();
-                        for p in &data.params {
+                        for p in data.params.iter() {
                             sub_env.insert(p.to_string(), Value::int(len));
                         }
                         let saved_env = std::mem::take(self.env_mut());

--- a/src/vm/vm_var_assign_typed.rs
+++ b/src/vm/vm_var_assign_typed.rs
@@ -536,7 +536,7 @@ impl Interpreter {
                     ValueView::Int(i) => i,
                     ValueView::Sub(data) => {
                         let mut sub_env = data.env.clone();
-                        for p in &data.params {
+                        for p in data.params.iter() {
                             sub_env.insert(p.to_string(), Value::int(len));
                         }
                         let saved_env = std::mem::take(vm.env_mut());

--- a/src/vm/vm_var_delete_ops.rs
+++ b/src/vm/vm_var_delete_ops.rs
@@ -12,7 +12,7 @@ impl Interpreter {
             ValueView::Sub(data) => {
                 let len = arr_len as i64;
                 let mut sub_env = data.env.clone();
-                for p in &data.params {
+                for p in data.params.iter() {
                     sub_env.insert(p.to_string(), Value::int(len));
                 }
                 let saved_env = std::mem::take(self.env_mut());

--- a/src/vm/vm_var_index_ops.rs
+++ b/src/vm/vm_var_index_ops.rs
@@ -453,7 +453,7 @@ impl Interpreter {
             return None;
         };
         let mut sub_env = data.env.clone();
-        for p in &data.params {
+        for p in data.params.iter() {
             sub_env.insert(p.to_string(), Value::int(len));
         }
         let saved_env = std::mem::take(self.env_mut());
@@ -1228,7 +1228,7 @@ impl Interpreter {
             (ValueView::Seq(items), ValueView::Sub(data)) => {
                 let len = items.len() as i64;
                 let mut sub_env = data.env.clone();
-                for p in &data.params {
+                for p in data.params.iter() {
                     sub_env.insert(p.to_string(), Value::int(len));
                 }
                 let saved_env = std::mem::take(self.env_mut());
@@ -1324,7 +1324,7 @@ impl Interpreter {
             (ValueView::Hash(items), ValueView::Sub(data)) => {
                 let len = items.len() as i64;
                 let mut sub_env = data.env.clone();
-                for p in &data.params {
+                for p in data.params.iter() {
                     sub_env.insert(p.to_string(), Value::int(len));
                 }
                 let saved_env = std::mem::take(self.env_mut());
@@ -1957,7 +1957,7 @@ impl Interpreter {
                 let range = &target;
                 let len = crate::runtime::Interpreter::range_elems_f64(range) as i64;
                 let mut sub_env = data.env.clone();
-                for p in &data.params {
+                for p in data.params.iter() {
                     sub_env.insert(p.to_string(), Value::int(len));
                 }
                 let saved_env = std::mem::take(self.env_mut());
@@ -2136,7 +2136,7 @@ impl Interpreter {
                 let len = items.len() as i64;
                 let mut sub_env = data.env.clone();
                 // Pass array length for ALL WhateverCode parameters (e.g. *-4 .. *-2 has 2 params)
-                for p in &data.params {
+                for p in data.params.iter() {
                     sub_env.insert(p.to_string(), Value::int(len));
                 }
                 let saved_env = std::mem::take(self.env_mut());
@@ -2202,7 +2202,7 @@ impl Interpreter {
                     0
                 };
                 let mut sub_env = data.env.clone();
-                for p in &data.params {
+                for p in data.params.iter() {
                     sub_env.insert(p.to_string(), Value::int(len));
                 }
                 let saved_env = std::mem::take(self.env_mut());
@@ -2255,7 +2255,7 @@ impl Interpreter {
                         ValueView::Whatever => len,
                         ValueView::Sub(data) => {
                             let mut sub_env = data.env.clone();
-                            for p in &data.params {
+                            for p in data.params.iter() {
                                 sub_env.insert(p.to_string(), Value::int(len));
                             }
                             let saved_env = std::mem::take(self.env_mut());
@@ -2299,7 +2299,7 @@ impl Interpreter {
                 let chars: Vec<char> = u.text.chars().collect();
                 let len = chars.len() as i64;
                 let mut sub_env = data.env.clone();
-                for p in &data.params {
+                for p in data.params.iter() {
                     sub_env.insert(p.to_string(), Value::int(len));
                 }
                 let saved_env = std::mem::take(self.env_mut());
@@ -2556,7 +2556,7 @@ impl Interpreter {
                 ) =>
             {
                 let mut sub_env = data.env.clone();
-                for p in &data.params {
+                for p in data.params.iter() {
                     sub_env.insert(p.to_string(), Value::int(1)); // elems = 1
                 }
                 let saved_env = std::mem::take(self.env_mut());

--- a/t/closure-shared-signature.t
+++ b/t/closure-shared-signature.t
@@ -1,0 +1,55 @@
+use Test;
+
+# A closure literal's `params` / `param_defs` are shared (an `Arc` per
+# `stmt_pool` slot) instead of being deep-cloned on every creation. Every
+# closure built from the SAME literal therefore hands out the SAME signature
+# object, so anything that appears to "edit" one closure's signature must
+# produce a fresh signature rather than mutating the shared one.
+
+plan 20;
+
+# --- Two closures from one literal in a loop ---------------------------------
+my @made;
+for 1..3 {
+    @made.push: -> $a, $b = 10, :$c = 20 { $a + $b + $c };
+}
+is @made.elems, 3, 'three closures created from one literal';
+is @made[0](1), 31, 'first closure applies its defaults';
+is @made[2](1), 31, 'third closure applies the same defaults';
+is @made[1](1, 2, :c(3)), 6, 'explicit arguments still win';
+is @made[0].arity, 1, 'arity is read off the shared signature';
+is @made[0].count, 2, 'count is read off the shared signature';
+is @made[0].signature.params.elems, 3, 'all three parameters are visible';
+
+# --- .assuming must not disturb the literal it primed ------------------------
+my $primed = @made[0].assuming(5);
+is $primed(), 35, 'the primed closure binds its assumed argument';
+is @made[0](1), 31, 'priming one closure leaves it callable unchanged';
+is @made[1](1), 31, 'priming does not leak into a sibling from the same literal';
+is @made[1].arity, 1, 'a sibling keeps its own arity after a sibling is primed';
+is @made[1].signature.params.elems, 3,
+    'a sibling keeps its full parameter list after a sibling is primed';
+
+# --- Implicit placeholder signatures are also derived once per literal -------
+my @ph;
+for 1..3 {
+    @ph.push: { $^x - $^y };
+}
+is @ph[0](10, 4), 6, 'a placeholder block from a loop binds both placeholders';
+is @ph[2](10, 4), 6, 'the last placeholder block binds them the same way';
+is @ph[1].arity, 2, 'the placeholder signature reports arity 2';
+
+# --- A nested literal in a closure that is itself created repeatedly ---------
+sub make-adder($n) { return -> $x { $x + $n } }
+my @adders = (1, 2, 3).map({ make-adder($_) });
+is @adders[0](10), 11, 'first adder closes over its own capture';
+is @adders[2](10), 13, 'third adder closes over its own capture';
+is @adders[1].signature.params.elems, 1, 'each adder reports one parameter';
+
+# --- A signature with sub-signatures and slurpies ---------------------------
+my @slurpy;
+for 1..2 {
+    @slurpy.push: -> $head, *@tail { "$head|" ~ @tail.join(',') };
+}
+is @slurpy[0](1, 2, 3), '1|2,3', 'slurpy parameter binds on the first copy';
+is @slurpy[1](1, 2, 3), '1|2,3', 'slurpy parameter binds on the second copy';


### PR DESCRIPTION
Picks up the second of the two items [#7557](https://github.com/tokuhirom/mutsu/issues/7557) was left open on after #7624: the per-creation `params` / `param_defs` clones. The kept-set narrowing (the first item) is untouched — it still wants its own design pass.

## The gap this closes

`SubData::body` stopped being a `Vec<Stmt>` in the Part C slice of #7557: the block's AST is pool-owned and immutable, so every closure created from one literal shares one `Arc` instead of deep-cloning the body on each creation. The **signature** — the other pool-owned, immutable half of a closure literal — was left behind.

`SubData::params` was a `Vec<String>` and `param_defs` a `Vec<ParamDef>`, both cloned out of the `stmt_pool` on every closure creation. `ParamDef` is fat (a `String` name, an `Option<Expr>` default, a nested `Vec<ParamDef>` sub-signature, an `Option<Box<Expr>>` where-constraint, a `Vec<String>` of traits), so the clone was O(signature) with a large constant — on the path that runs once per `.map({...})` / `.grep({...})` / callback-literal evaluation.

A bare block paid a second, related cost: its `params` are the implicit placeholder variables (`$^a`, `@_`, …), which `collect_placeholders_shallow` derives by walking *and sorting* the body. That is a pure function of the pool entry too, and it ran on every creation.

## The change

Both fields are now `Arc`s built once per `stmt_pool` slot by `CompiledCode::closure_signature` — the exact shape `closure_body_arc` already uses for the body, including its fallback for a chunk whose pool grew after the side table was sized. A `Stmt::Block` slot's cached entry carries the placeholder scan, so that walk-and-sort is also paid once per literal now.

All four closure-creation opcodes take their signature from there, except `MakeBlockClosure`, which takes no signature at all and asks for the shared `value::empty_params()` / `empty_param_defs()` — `Arc::new(Vec::new())` still allocates a control block per creation, which is exactly the allocation sharing the field was meant to remove.

Nothing mutates a `SubData`'s signature after construction, which is what makes the sharing sound. The places that *appear* to (`.assuming` building a primed signature, `.^add_multi_method` copying one into a `MethodDef`, `callable_signature` handing an owned pair to callers that edit it) take an owned copy explicitly, exactly as they did before — they simply say so now.

## Measurement

Callgrind instruction counts (deterministic, so this container's four noisy cores do not matter), before → after:

| repro | before | after | |
|---|---|---|---|
| `-> $a { $a }` × 100000 | 2,086,890,637 | 2,025,362,566 | −2.9% |
| `-> $a … $h { $a }` × 100000 | 2,859,420,599 | 2,038,812,420 | **−28.7%** |
| `-> $a, $b, Int $c = 3, :$named, *@rest {…}` × 100000 | 2,640,465,916 | 2,035,588,516 | **−22.9%** |
| `my $c = * + 1;` × 200000 | 4,741,856,528 | 4,548,975,732 | −4.1% |

The **O(signature) scaling is what goes away**: seven extra parameters used to add ~1100 instructions to *every* creation and now add ~19 (`+772,529,962` → `+13,449,854` over 100000 creations). Per creation with the control loop subtracted, the 8-parameter literal went from 24,820 to 16,687 instructions, **−32.8%**. A one-parameter `WhateverCode` was never where the signature clone hurt, so its few percent is the floor.

Whole-program benchmarks, same method, the two binaries run back to back — all four move slightly in the right direction and none regresses:

| | before | after | |
|---|---|---|---|
| `bench-ctor` | 1,327,445,176 | 1,313,646,631 | −1.04% |
| `bench-class` | 1,171,901,705 | 1,162,528,513 | −0.80% |
| `bench-grammar-parse` | 65,585,593 | 65,330,697 | −0.39% |
| `bench-yaml-parse` | 12,986,021 | 12,938,248 | −0.37% |

These are instruction counts, not the wall-clock series; the numbers that belong in a benchmark record still come from the bench CI history.

## Testing

- `t/closure-shared-signature.t` (new, 20 tests) pins the semantics the sharing could break: closures built from one literal in a loop keep independent behaviour, and priming one with `.assuming` leaves its siblings' arity, defaults and parameter list untouched. It passes under **rakudo** as well as mutsu, so it is a spec test rather than a mutsu-shaped one.
- `make lint` green in all four configurations (default clippy, `jit` off, wasm32 lib, rustdoc).
- `make test` green: `Files=3880, Tests=41143`, `Result: PASS`.
- `make roast` green apart from the three failures [`docs/agent-environments.md`](https://github.com/tokuhirom/mutsu/blob/main/docs/agent-environments.md) documents for this container — `6.c/S32-io/file-tests.t` (4, runs as uid 0), `S16-filehandles/filetest.t` (25, same), `S32-io/IO-Socket-Async.t` (exit 124, sandboxed network) — each matching the documented failure shape and test numbers exactly.

## What stays open on #7557

The kept-set narrowing. `capture_closure_env` keeps every env key `is_plain_user_lexical` rejects, which is over-broad by construction; #7624 memoized the resulting `Env` one entry deep, but a capture that *misses* that memo still pays O(kept env). That is the design pass the issue asks for — mostly a question about the built-in dynamics — and not a drive-by, so the issue stays open.

Refs #7557

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011TpDocfYsndU5r7nbXwZ99

---
_Generated by [Claude Code](https://claude.ai/code/session_011TpDocfYsndU5r7nbXwZ99)_