### PR TITLE
perf(vm): route a resolved multi candidate through the positional-light call path

### DIFF
--- a/news/2026-09/multi-call-takes-the-positional-light-path.md
+++ b/news/2026-09/multi-call-takes-the-positional-light-path.md
@@ -1,0 +1,118 @@
+# A `multi` call no longer pays the general frame-pushing call path
+
+Calling a `multi sub` cost **8.5x** what calling an identically-shaped plain
+`sub` cost, with the same opcode count, the same JIT behaviour and zero
+interpreter fallbacks on either side. All of the difference was in the call
+machinery a `multi` was routed through.
+
+Measured with callgrind (release, 20 000 calls, deterministic retired
+instructions), `multi sub m(Mu $c, $d = '')` against `sub s(Mu $c, $d = '')`,
+both called `m(1, "x")` / `s(1, "x")` in a loop:
+
+| | before | after |
+| --- | --- | --- |
+| plain `sub` call | 5 750 Ir | 5 750 Ir (unchanged) |
+| `multi` call | 47 303 Ir | 28 992 Ir |
+| the `multi` surcharge over the plain `sub` | 41 553 Ir | 23 242 Ir (**-44.1%**) |
+| whole-benchmark instructions | 969.2 M | 602.8 M (**-37.8%**) |
+
+Wall clock on the same loop: 0.847 s -> 0.469 s. (Wall clock on this box wobbles
+±13% between runs of the identical binary, which is why the table is retired
+instructions; they are exact and load-independent.)
+
+## What the surcharge was
+
+`dispatch_func_call_inner` resolves the winning candidate, then hands it to
+`compile_and_call_function_def`, which ran it through
+`call_compiled_function_named` — the general, frame-pushing call entry. That
+entry was 18 600 of the 41 553 surplus instructions: a `push_call_frame`, a
+lazy routine-code push, a scoped-overlay env child, a `$!` reset probe, a `$_`
+seed, and the full `bind_function_args_values` binder.
+
+An ordinary `sub` of exactly that signature does not go there. It takes
+`call_compiled_function_positional_light`, which binds straight into
+precomputed local slots. The two light paths in `dispatch_func_call_inner` are
+explicitly skipped for a multi (`!self.has_multi_candidates_cached(name)`), and
+that guard is right *there*: those sites populate the name-keyed
+`pos_light_call_cache` / `light_call_cache`, and a name-keyed entry would make a
+later call with different argument types reuse the first call's candidate.
+
+But `compile_and_call_function_def` populates no such cache — it is reached
+*after* `resolve_function_multi_cached` has already picked the winner for these
+exact arguments. So the candidate can take the same positional-light entry, with
+every other guard that path applies (container-into-scalar sharing, the
+`is test-assertion` trait, a `wrap` chain, a mainline-lexical capture) applied
+here too, plus one this site needs and the others get for free: the callee must
+be in the caller's own **compilation unit**. That is the invariant the light
+path is written under — a module's file-scope `my` is lexical to its compunit,
+and only the general entry's `is_unit_lexical_of` check keeps a module sub's
+write to one off the loading script's same-named lexical
+(`t/module-file-scope-lexical.t`). `compile_and_call_function_def` is the entry
+an *imported* sub reaches, so without the gate that isolation was lost.
+
+`nextsame`/`callsame`/`samewith` keep working because the multi-dispatch and
+samewith frames are pushed *around* this call, not inside the callee entry —
+`t/multi-positional-light-dispatch.t` pins that, together with per-call
+re-resolution across alternating argument types, `:D`/`:U` discrimination,
+defaulted positionals, topic freshness and parameter read-onlyness.
+
+## Two latent holes in the light path the routing change made reachable
+
+Both were real bugs that had simply never been reachable from the call shapes
+that used to arrive there.
+
+### An untyped return-type failure
+
+The positional-light path enforces a fast return type itself, and raised a plain
+`RuntimeError` for a failure. So `throws-like 'f()', X::TypeCheck::Return` saw
+an untyped exception and failed for any routine with a return type that reached
+that path (`roast/S02-types/type.t`, eight subtests). It now raises through the
+same `throw_type_check_return` the general return-value path uses.
+
+### `Cool` treated as a wildcard
+
+`FastParamType` classified `Cool` alongside `Any` and `Mu` as "satisfied by
+every value", and the by-name `fast_type_check` had the same `"Any" | "Mu" |
+"Cool" => true` arm. That is wrong: `Cool` is a real type, and a user class
+instance does not do it. `t/light-call-type-check-tags.t` has always pinned
+`dies-ok { bad-wide(Widget.new) }` for `sub bad-wide(Cool $c)`; it passed only
+because that particular call shape never reached a light path. Routing more
+calls there exposed it, so `Cool` is no longer a fast type name at all: a
+`Cool`-constrained parameter or return type leaves the light paths and is
+enforced by the general binder, which consults the class MRO.
+
+## Three allocation/interning leaks on the same path
+
+The remaining surcharge is the *resolution*, and three pieces of it were pure
+waste:
+
+- **`find_compiled_function_inner` built the argument type signature twice** —
+  a `Vec<String>` with a heap-allocated `String` per argument, once for the
+  resolution-cache key and once for the compiled-key probes — and then `clone`d
+  it into the key. For a multi name the key is never used at all (`use_cache` is
+  false), so every one of those allocations was for a lookup that cannot happen.
+  Now the signature is built once and the key only when it will be consulted.
+- **`multi_arg_type_keys` re-interned its reserved marker names on every use.**
+  It runs twice per multi call (the callsite resolution and
+  `resolve_function_multi_cached` each build the key) and emitted up to three
+  markers per argument; on the two-argument benchmark it interned 12 names per
+  call, 8 of them compile-time constants. Those are now interned once per
+  process.
+- **`call_compiled_function_named_inner` built `__mutsu_callable_id::<pkg>::<name>`
+  with `format!` on every named call** — a heap allocation plus a hash of ~40
+  bytes to intern it — for a mapping fixed for the life of the routine. It is
+  now memoized per `(package, name)` symbol pair, next to the sibling
+  `type_meta_key_for_sym` / `placeholder_key_sym` memos.
+
+## What this does *not* fix
+
+The vendored `Test.rakumod` assertion path is unchanged: 191 347 retired
+instructions per `ok 1, "x"` before and after. Its `ok` reaches the callee
+through `ExecCallPairs` (the parser attaches a `__mutsu_test_callsite_line`
+named argument to every test-assertion call), not through
+`dispatch_func_call_inner`, and two thirds of the cost is inside `proclaim`,
+whose `Bool(Mu) $cond` coercion and `$desc is copy` trait exclude it from the
+light path by construction. That deficit is flat — the largest single entry in
+its per-assertion profile is 5.9%, and it is `malloc` — so it is general
+interpretation cost, not one hotspot. Recorded on
+[#7573](https://github.com/tokuhirom/mutsu/issues/7573).

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -8670,7 +8670,14 @@ pub(crate) enum FastParamType {
     Num,
     Bool,
     Rat,
-    /// `Any` / `Mu` / `Cool`: satisfied by every value.
+    /// `Any` / `Mu`: satisfied by every value.
+    ///
+    /// `Cool` is deliberately NOT here. It is a real type: a user class
+    /// instance does not do `Cool`, so treating it as a wildcard made
+    /// `sub f(Cool $c)` accept anything (`t/light-call-type-check-tags.t`
+    /// pins the rejection). A `Cool` constraint is therefore not a fast type
+    /// at all -- it leaves the light paths and is enforced by the general
+    /// binder, which consults the class MRO (#7573).
     Wild,
 }
 
@@ -8685,7 +8692,7 @@ impl FastParamType {
             "Num" => Self::Num,
             "Bool" => Self::Bool,
             "Rat" => Self::Rat,
-            "Any" | "Mu" | "Cool" => Self::Wild,
+            "Any" | "Mu" => Self::Wild,
             _ => return None,
         })
     }

--- a/src/runtime/accessors.rs
+++ b/src/runtime/accessors.rs
@@ -470,8 +470,13 @@ impl Interpreter {
         }
     }
 
-    /// Create an X::TypeCheck::Return exception
-    fn throw_type_check_return(&self, expected: &str, got: &Value) -> RuntimeError {
+    /// Create an X::TypeCheck::Return exception.
+    ///
+    /// Shared with the positional-light call path, which enforces a fast return
+    /// type itself: raising a bare `RuntimeError` there made
+    /// `throws-like ..., X::TypeCheck::Return` fail whenever a routine with a
+    /// return type reached that path (roast/S02-types/type.t, #7573).
+    pub(crate) fn throw_type_check_return(&self, expected: &str, got: &Value) -> RuntimeError {
         let got_type = Self::display_type_name(got);
         let got_gist = Self::display_gist(got);
         let msg = format!(

--- a/src/runtime/runtime_var_meta.rs
+++ b/src/runtime/runtime_var_meta.rs
@@ -112,6 +112,34 @@ impl Interpreter {
         sym
     }
 
+    /// The env key a routine's registration clone id is stored under,
+    /// `__mutsu_callable_id::<package>::<name>`, memoized per
+    /// `(package, name)` symbol pair exactly like [`Self::type_meta_key_sym`].
+    ///
+    /// Every named compiled call probes this key on entry
+    /// (`call_compiled_function_named_inner`), and building it cost a `format!`
+    /// of a ~40-byte string — a heap allocation, the formatting machinery, and
+    /// then a hash of those 40 bytes to intern it — per call, for a mapping
+    /// that is fixed for the life of the routine (#7573).
+    pub(crate) fn callable_id_key_for_syms(package_sym: Symbol, name_sym: Symbol) -> Symbol {
+        thread_local! {
+            static CALLABLE_ID_KEYS: std::cell::RefCell<
+                rustc_hash::FxHashMap<(Symbol, Symbol), Symbol>,
+            > = std::cell::RefCell::new(rustc_hash::FxHashMap::default());
+        }
+        let pair = (package_sym, name_sym);
+        if let Some(sym) = CALLABLE_ID_KEYS.with(|c| c.borrow().get(&pair).copied()) {
+            return sym;
+        }
+        let sym = package_sym.with_str(|pkg| {
+            name_sym.with_str(|name| Symbol::intern(&format!("__mutsu_callable_id::{pkg}::{name}")))
+        });
+        CALLABLE_ID_KEYS.with(|c| {
+            c.borrow_mut().insert(pair, sym);
+        });
+        sym
+    }
+
     /// The env key for `name`'s placeholder-parameter twin, `^<name>`, as a
     /// pre-interned `Symbol`, memoized per name symbol exactly like
     /// [`Self::type_meta_key_sym`] (the mapping never changes).

--- a/src/vm/vm_call_dispatch.rs
+++ b/src/vm/vm_call_dispatch.rs
@@ -415,7 +415,42 @@ impl Interpreter {
         // C6e-3c), and a plan-compiled/OTF-compiled `cf` always carries the
         // table it was compiled alongside.
         let fns = cf.compiled_fns.as_deref().unwrap_or(compiled_fns);
-        let result = self.call_compiled_function_named(&cf, args, fns, &pkg, &name);
+        // The winning candidate is already in hand, so a plain all-positional
+        // signature can take the same positional-light entry an ordinary sub of
+        // that shape takes (`dispatch_func_call_inner`), instead of the general
+        // frame-pushing `call_compiled_function_named`. Every guard that path
+        // applies is applied here too; the one it additionally carries — "never
+        // for a multi" — guards its NAME-KEYED `pos_light_call_cache`, which
+        // this site does not populate, so a later call with different argument
+        // types still re-resolves through `resolve_function_multi_cached` above
+        // and reaches its own candidate. `nextsame`/`callsame`/`samewith` from
+        // the body keep working: the multi-dispatch and samewith frames are
+        // pushed around this call, not inside the callee entry.
+        //
+        // Measured (release, callgrind, `multi sub m(Mu $c, $d = '')` against
+        // the identically-shaped plain `sub`): the named entry is 18.6k retired
+        // instructions of a multi call's 47.3k, against 5.75k for the plain
+        // sub. #7573.
+        //
+        // Restricted to a callee in the CALLER'S OWN compilation unit, which is
+        // the invariant the light path is written under (`vm_call_light.rs`:
+        // "a call into another compilation unit does not take this path"). A
+        // module's file-scope `my` is lexical to its compunit, and only the
+        // general entry's `is_unit_lexical_of` check keeps a module sub's write
+        // to one off the loading script's same-named lexical
+        // (`t/module-file-scope-lexical.t`).
+        let light_eligible = self.unit_of_source(cf.source_file.as_deref()) == self.current_unit
+            && Self::is_positional_light_call_eligible(&cf, &name)
+            && !Self::call_shares_container_into_scalar_param(&cf, &args)
+            && !loan_env!(self, routine_is_test_assertion_by_name(&name, &args))
+            && self.wrap_sub_id_for_name(&name).is_none()
+            && !self.light_call_blocked_by_mainline_capture(&name);
+        let result = if light_eligible {
+            let name_sym = Symbol::intern(&name);
+            self.call_compiled_function_positional_light(&cf, &args, fns, &name, name_sym)
+        } else {
+            self.call_compiled_function_named(&cf, args, fns, &pkg, &name)
+        };
 
         self.pop_samewith_context();
         if pushed_dispatch {

--- a/src/vm/vm_call_func_ops.rs
+++ b/src/vm/vm_call_func_ops.rs
@@ -100,7 +100,7 @@ impl Interpreter {
     /// common program, so this is one `is_empty` test beyond what those
     /// checks already do.
     #[inline]
-    fn light_call_blocked_by_mainline_capture(&self, name: &str) -> bool {
+    pub(super) fn light_call_blocked_by_mainline_capture(&self, name: &str) -> bool {
         !self.mainline_lexical_subs.is_empty() && self.mainline_lexical_subs.contains_key(name)
     }
 

--- a/src/vm/vm_call_light.rs
+++ b/src/vm/vm_call_light.rs
@@ -53,19 +53,6 @@ fn positional_light_type_error(
     RuntimeError::typed("X::TypeCheck::Argument", attrs)
 }
 
-/// Build the error for a positional-light routine whose return value failed
-/// the declared return type. `#[cold]` for the same reason as
-/// [`positional_light_arity_error`].
-#[cold]
-#[inline(never)]
-fn positional_light_return_type_error(rt: &str, got: &Value) -> RuntimeError {
-    RuntimeError::new(format!(
-        "Type check failed for return value; expected {}, got {}",
-        rt,
-        runtime::value_type_name(got)
-    ))
-}
-
 impl Interpreter {
     /// Slice-taking wrapper over [`Self::call_compiled_function_positional_light_at`]
     /// for the cold call sites that already hold an owned argument vector
@@ -731,7 +718,10 @@ impl Interpreter {
                 _ => Self::light_return_type_check(check_val, rt),
             };
             if !passed {
-                return Err(positional_light_return_type_error(rt, check_val));
+                // The SAME typed `X::TypeCheck::Return` the general return-value
+                // path raises. A bare `RuntimeError` here was invisible to
+                // `throws-like ..., X::TypeCheck::Return` (#7573).
+                return Err(self.throw_type_check_return(rt, check_val));
             }
         }
 
@@ -862,7 +852,7 @@ impl Interpreter {
             // in the by-name form: an `IntStr` satisfies both `Int` and `Str`.
             ValueView::Mixin(..) => name_sym.with_str(|n| val.isa_check(n)),
             // A bare type object satisfies a smiley-less nominal constraint of
-            // its own name (`Int` for `Int $a`), and any of `Any`/`Mu`/`Cool`.
+            // its own name (`Int` for `Int $a`), and `Any`/`Mu`.
             // Interning is injective, so the `Symbol` compare is exactly the
             // by-name form's `sym.resolve() == type_name`.
             ValueView::Package(sym) => kind == T::Wild || sym == name_sym,
@@ -871,7 +861,7 @@ impl Interpreter {
             ValueView::Num(_) => matches!(kind, T::Num | T::Wild),
             ValueView::Bool(_) => matches!(kind, T::Bool | T::Wild),
             ValueView::Rat(_, _) => matches!(kind, T::Rat | T::Wild),
-            // Every other value shape satisfies only `Any`/`Mu`/`Cool` -- the
+            // Every other value shape satisfies only `Any`/`Mu` -- the
             // by-name form's `_` arm compares `value_type_name(val)` against a
             // name that, on this path, is always one of the five concrete
             // types above, so it can only be false.
@@ -917,7 +907,7 @@ impl Interpreter {
         }
         match val.view() {
             // A `Failure` passes any return type; any other instance satisfies
-            // only `Any`/`Mu`/`Cool`, exactly as `fast_type_check`'s `_` arm
+            // only `Any`/`Mu`, exactly as `fast_type_check`'s `_` arm
             // does (`value_type_name` can never equal one of the five concrete
             // type names for an instance).
             ValueView::Instance { class_name, .. } => {
@@ -956,13 +946,15 @@ impl Interpreter {
         // full `bind_function_args_values` path, which enforces the smiley
         // correctly. Only the true bare form reaches here, and it must accept
         // the matching type object (`is { sub a(Int $a) { $a }; a Int }(),
-        // Int`, roast/S06-parameters/smiley.t). `Any`/`Mu`/`Cool` are handled
+        // Int`, roast/S06-parameters/smiley.t). `Any`/`Mu` are handled
         // by their own `=> true` arm below (they accept every value,
         // defined or not, including a type object of any name) rather than
         // this by-name match — a bare-word `Str` passed to an `Any $a` param
-        // must not be rejected just because `"Str" != "Any"`.
+        // must not be rejected just because `"Str" != "Any"`. `Cool` is NOT
+        // one of them: a user class instance does not do `Cool`, so it is not
+        // a fast type name at all and never reaches here (#7573).
         if let ValueView::Package(sym) = val.view()
-            && !matches!(type_name, "Any" | "Mu" | "Cool")
+            && !matches!(type_name, "Any" | "Mu")
         {
             return sym.resolve() == type_name;
         }
@@ -972,7 +964,7 @@ impl Interpreter {
             "Num" => matches!(val.view(), ValueView::Num(_)),
             "Bool" => matches!(val.view(), ValueView::Bool(_)),
             "Rat" => matches!(val.view(), ValueView::Rat(_, _)),
-            "Any" | "Mu" | "Cool" => true,
+            "Any" | "Mu" => true,
             _ => {
                 let actual = runtime::value_type_name(val);
                 actual == type_name

--- a/src/vm/vm_call_method_compiled_cache.rs
+++ b/src/vm/vm_call_method_compiled_cache.rs
@@ -33,6 +33,41 @@ const LITERAL_NATIVE_KEY: &str = "__mutsu_key_literal_native";
 /// distinct buckets.
 const ENUM_MEMBER_KEY: &str = "__mutsu_key_enum_member";
 
+/// The reserved marker names above, plus the three native type names a literal
+/// argument keys as, interned ONCE per process instead of on every use.
+///
+/// `multi_arg_type_keys` runs on every multi call — twice, since the callsite
+/// resolution and `resolve_function_multi_cached` each build the key — and
+/// emitted up to three of these per argument. Each was a `Symbol::intern` of a
+/// compile-time constant: a thread-local borrow plus a hash of a ~25-byte
+/// string, for an answer that can never change. Measured on a 200 000-iteration
+/// `multi sub m(Mu $c, $d = '')` loop, `multi_arg_type_keys` interned 12 names
+/// per call, 8 of them from this fixed set (#7573).
+mod key_syms {
+    use crate::symbol::Symbol;
+
+    macro_rules! key_sym {
+        ($($f:ident => $s:expr;)*) => {$(
+            #[inline(always)]
+            pub(super) fn $f() -> Symbol {
+                static CELL: std::sync::OnceLock<Symbol> = std::sync::OnceLock::new();
+                *CELL.get_or_init(|| Symbol::intern($s))
+            }
+        )*};
+    }
+
+    key_sym! {
+        callsite_line_marker => super::CALLSITE_LINE_MARKER_KEY;
+        undefined_arg => super::UNDEFINED_ARG_KEY;
+        declared_type => super::DECLARED_TYPE_KEY;
+        literal_native => super::LITERAL_NATIVE_KEY;
+        enum_member => super::ENUM_MEMBER_KEY;
+        native_int => "int";
+        native_num => "num";
+        native_str => "str";
+    }
+}
+
 impl Interpreter {
     pub(crate) fn refresh_method_caches_for_generation(&mut self) {
         let generation = self.registry().method_generation;
@@ -98,7 +133,7 @@ impl Interpreter {
             let a = match raw.view() {
                 ValueView::VarRef { name, value, .. } => {
                     if let Some(tc) = name.with_str(|n| self.var_type_constraint(n)) {
-                        keys.push(crate::symbol::Symbol::intern(DECLARED_TYPE_KEY));
+                        keys.push(key_syms::declared_type());
                         keys.push(crate::symbol::Symbol::intern(&tc));
                     }
                     value.clone()
@@ -115,14 +150,14 @@ impl Interpreter {
                     if pos_idx < 32
                         && self.literal_native_args & (1 << pos_idx) != 0
                         && let Some(nt) = match raw.view() {
-                            ValueView::Int(_) => Some("int"),
-                            ValueView::Num(_) => Some("num"),
-                            ValueView::Str(_) => Some("str"),
+                            ValueView::Int(_) => Some(key_syms::native_int()),
+                            ValueView::Num(_) => Some(key_syms::native_num()),
+                            ValueView::Str(_) => Some(key_syms::native_str()),
                             _ => None,
                         }
                     {
-                        keys.push(crate::symbol::Symbol::intern(LITERAL_NATIVE_KEY));
-                        keys.push(crate::symbol::Symbol::intern(nt));
+                        keys.push(key_syms::literal_native());
+                        keys.push(nt);
                     }
                     raw.clone()
                 }
@@ -150,7 +185,7 @@ impl Interpreter {
                     // interned `"Type::Member"` string: no per-call `format!`,
                     // and no way for the pair to be read as the plain type name
                     // of some other argument.
-                    keys.push(crate::symbol::Symbol::intern(ENUM_MEMBER_KEY));
+                    keys.push(key_syms::enum_member());
                     keys.push(enum_type);
                     k
                 }
@@ -169,7 +204,7 @@ impl Interpreter {
                 // subset / smiley / coercion) makes the whole name un-cacheable in
                 // `func_multi_dispatch_type_cacheable` before this key is used.
                 _ if Self::is_callsite_line_marker(a) => {
-                    crate::symbol::Symbol::intern(CALLSITE_LINE_MARKER_KEY)
+                    key_syms::callsite_line_marker()
                 }
                 ValueView::Junction { .. }
                 | ValueView::Mixin(..)
@@ -199,7 +234,7 @@ impl Interpreter {
             // the views it would have to lock through (`ContainerRef`, `Mixin`)
             // already returned `None` above.
             if !crate::runtime::types::value_is_defined(a) {
-                keys.push(crate::symbol::Symbol::intern(UNDEFINED_ARG_KEY));
+                keys.push(key_syms::undefined_arg());
             }
         }
         Some(keys)
@@ -448,7 +483,7 @@ impl Interpreter {
             // the second is served the first's candidate
             // (`t/multi-method-invocant-definedness.t`).
             if !crate::runtime::types::value_is_defined(target) {
-                arg_keys.insert(0, crate::symbol::Symbol::intern(UNDEFINED_ARG_KEY));
+                arg_keys.insert(0, key_syms::undefined_arg());
             }
             let mkey = (class_sym, method_sym, arg_keys);
             if let Some(hit) = self.multi_resolve_cache.get(&mkey) {

--- a/src/vm/vm_call_named_inner.rs
+++ b/src/vm/vm_call_named_inner.rs
@@ -103,10 +103,14 @@ impl Interpreter {
         );
         let mut callable_id: Option<u64> = None;
         if !fn_name.is_empty() {
-            let callable_key = format!("__mutsu_callable_id::{fn_package}::{fn_name}");
+            // Memoized per (package, name) symbol pair: the key is fixed for
+            // the routine, and the `format!` + intern of its ~40-byte string
+            // used to run on every named call (#7573).
+            let callable_key =
+                crate::runtime::Interpreter::callable_id_key_for_syms(fn_package_sym, fn_name_sym);
             let resolved_callable_id = self
                 .env()
-                .get(&callable_key)
+                .get_sym(callable_key)
                 .and_then(|v| match v.view() {
                     ValueView::Int(i) => Some(i),
                     _ => None,

--- a/src/vm/vm_call_resolve.rs
+++ b/src/vm/vm_call_resolve.rs
@@ -30,22 +30,32 @@ impl Interpreter {
     ) -> Option<&'a Arc<CompiledFunction>> {
         let arity = args.len();
         let name_sym = Symbol::intern(name);
-        // Build a type signature for cache key to handle multi dispatch correctly
+        // ONE type signature, shared by the resolution-cache key and by the
+        // compiled-key probes further down. Both used to build the identical
+        // `Vec<String>` independently, so every call allocated a `String` per
+        // argument twice over, plus a third `Vec` for the key's `clone` -- and
+        // on a MULTI name, where `use_cache` is false, every one of the key's
+        // allocations was for a lookup that never happens. `find_compiled_function_inner`
+        // is 40% of a multi call's retired instructions (#7573).
         let type_sig: Vec<String> = args
             .iter()
             .map(|v| runtime::value_type_name(v).to_string())
             .collect();
-        let cache_key = (
-            name_sym,
-            self.current_package_sym(),
-            arity,
-            type_sig.clone(),
-        );
         // Check the resolution cache first to avoid expensive resolve_function_with_types.
         // Skip cache for multi functions since subset type dispatch depends on values.
         let use_cache = !self.has_multi_candidates_cached(name);
-        if use_cache && self.fn_resolve_cache_gen == self.fn_resolve_gen {
-            if let Some((cached_key, cached_fp, _)) = self.fn_resolve_cache.get(&cache_key)
+        let cache_key = use_cache.then(|| {
+            (
+                name_sym,
+                self.current_package_sym(),
+                arity,
+                type_sig.clone(),
+            )
+        });
+        if let Some(cache_key) = &cache_key
+            && self.fn_resolve_cache_gen == self.fn_resolve_gen
+        {
+            if let Some((cached_key, cached_fp, _)) = self.fn_resolve_cache.get(cache_key)
                 && let Some(cf) = compiled_fns.get(cached_key)
                 && cf.fingerprint == *cached_fp
             {
@@ -88,10 +98,6 @@ impl Interpreter {
                 .map(|_| sym)
         };
         let pkg = self.current_package();
-        let type_sig: Vec<String> = args
-            .iter()
-            .map(|v| runtime::value_type_name(v).to_string())
-            .collect();
         // Try all key patterns and remember which one matched for caching
         let mut found_key: Option<Symbol>;
         if name.contains("::") {
@@ -199,7 +205,7 @@ impl Interpreter {
             let cached_pkg = resolved_def
                 .map(|def| def.package.resolve())
                 .unwrap_or_else(|| self.current_package().to_string());
-            if use_cache {
+            if let Some(cache_key) = cache_key {
                 self.fn_resolve_cache
                     .insert(cache_key, (key, expected_fingerprint, cached_pkg));
             }

--- a/t/multi-positional-light-dispatch.t
+++ b/t/multi-positional-light-dispatch.t
@@ -1,0 +1,91 @@
+use v6;
+use Test;
+
+# A `multi` candidate with a plain all-positional signature now runs through the
+# same positional-light call entry an ordinary `sub` of that shape takes
+# (`compile_and_call_function_def`, #7573). The entry is chosen per call, after
+# the winner has already been resolved, and nothing about it is cached under the
+# bare name -- these tests pin the behaviour that would break if it were.
+
+plan 20;
+
+multi sub tw(Int $x) { "int:$x" }
+multi sub tw(Str $x) { "str:$x" }
+
+# Repeated calls must re-resolve per argument type, not reuse the first winner.
+is tw(1), 'int:1', 'Int candidate';
+is tw('a'), 'str:a', 'Str candidate after Int';
+is tw(2), 'int:2', 'Int candidate again';
+is tw('b'), 'str:b', 'Str candidate again';
+
+# Alternating in a loop is the shape a name-keyed light-call cache would break.
+my @seen;
+for 1 .. 4 -> $i {
+    @seen.push(tw($i));
+    @seen.push(tw("$i"));
+}
+is @seen.join(','),
+    'int:1,str:1,int:2,str:2,int:3,str:3,int:4,str:4',
+    'alternating types resolve independently on every call';
+
+# A defaulted trailing positional (the shape `multi sub ok(Mu $c, $desc = '')`
+# takes in the vendored Test module) still binds its constant fill.
+multi sub deflt(Mu $cond, $desc = 'none') { "$cond/$desc" }
+is deflt(1), '1/none', 'omitted default binds the constant fill';
+is deflt(1, 'x'), '1/x', 'supplied argument wins over the default';
+
+# `nextsame` from inside a candidate still reaches the next one: the
+# multi-dispatch frame is pushed around the call, not inside the callee entry.
+multi sub chain(Int $x) { nextsame }
+multi sub chain(Any $x) { 'any' }
+is chain(3), 'any', 'nextsame from a light-eligible candidate reaches the next one';
+
+# `callsame` likewise, and hands the next candidate's value back to this one.
+multi sub cs(Int $x) { 'int+' ~ callsame() }
+multi sub cs(Any $x) { 'any' }
+is cs(3), 'int+any', 'callsame returns the next candidate value';
+
+# A candidate gets a fresh `$_`, not the caller's topic.
+multi sub topicless(Int $x) { $_.defined ?? 'leaked' !! 'fresh' }
+is (given 'outer' { topicless(1) }), 'fresh', 'candidate does not inherit the caller topic';
+
+# Parameters are readonly.
+multi sub ro(Int $x) { $x = 5; 'assigned' }
+dies-ok { ro(1) }, 'a candidate parameter stays readonly';
+
+# Return values are not containers leaking the callee slot.
+multi sub ret(Int $x) { my $r = $x * 2; $r }
+is ret(4), 8, 'candidate return value';
+
+# Recursion through a multi keeps each frame's locals separate.
+multi sub fact(Int $n where * <= 1) { 1 }
+multi sub fact(Int $n) { $n * fact($n - 1) }
+is fact(6), 720, 'recursive multi dispatch';
+
+# A type constraint still rejects a non-matching argument.
+multi sub only-int(Int $x) { $x }
+my $wrong = 'nope';
+dies-ok { only-int($wrong) }, 'no candidate for a wrong-typed argument';
+
+# Definedness (`:D`/`:U`) still discriminates across repeated calls.
+multi sub smiley(Int:D $x) { 'defined' }
+multi sub smiley(Int:U $x) { 'undefined' }
+is smiley(1), 'defined', 'Int:D candidate';
+is smiley(Int), 'undefined', 'Int:U candidate';
+is smiley(2), 'defined', 'Int:D candidate again';
+
+# A candidate declared in a package resolves its own package's lexicals.
+# `Cool` is a real type, not a wildcard: a user class instance does not do it.
+# Reaching the light path made this observable, so pin both directions.
+class Gadget { }
+multi sub coolish(Cool $c) { 'cool' }
+my $gadget = Gadget.new;
+dies-ok { coolish($gadget) }, 'a Cool parameter rejects a user class instance';
+is coolish(1), 'cool', 'a Cool parameter still accepts an Int';
+
+module MPkg {
+    our $tag = 'mpkg';
+    our proto sub tagged(|) {*}
+    multi sub tagged(Int $x) { "$tag:$x" }
+}
+is MPkg::tagged(7), 'mpkg:7', 'candidate body runs under its defining package';


### PR DESCRIPTION
A `multi sub` call cost **8.5x** an identically-shaped plain `sub` call, while executing a
byte-identical opcode stream with the same JIT behaviour (`jit: compiles=2 entries=399802
bailouts=0`) and `interpreter_fallbacks=0` on both sides. All of the difference was the call
machinery a multi was routed through.

Measured with callgrind (release, 20 000 calls, retired instructions — exact and load-independent,
which matters because wall clock on this box wobbles ±13% between runs of the identical binary),
`multi sub m(Mu $c, $d = '')` against `sub s(Mu $c, $d = '')`, both called `(1, "x")` in a loop:

| | before | after |
| --- | --- | --- |
| plain `sub` call | 5 750 Ir | 5 750 Ir (unchanged) |
| `multi` call | 47 303 Ir | 28 992 Ir |
| the `multi` surcharge over the plain `sub` | 41 553 Ir | **23 242 Ir (-44.1%)** |
| whole-benchmark instructions | 969.2 M | **602.8 M (-37.8%)** |

Wall clock on the same loop: 0.847 s -> 0.469 s. The plain-sub benchmark is unchanged
(138.16 M -> 137.93 M Ir).

## The change

`compile_and_call_function_def` ran the already-resolved candidate through
`call_compiled_function_named`, the general frame-pushing entry — 18 600 of the 41 553 surplus
instructions (a `push_call_frame`, a lazy routine-code push, a scoped-overlay env child, a `$!`
reset probe, a `$_` seed, and the full `bind_function_args_values` binder).

The two light branches in `dispatch_func_call_inner` are explicitly skipped for a multi, but that
guard is protecting *their* name-keyed `pos_light_call_cache` / `light_call_cache`: a name-keyed
entry would make a later call with different argument types reuse the first call's candidate.
`compile_and_call_function_def` populates no such cache, and is reached *after*
`resolve_function_multi_cached` has picked the winner for these exact arguments. So the candidate
now takes the same positional-light entry an ordinary sub of that signature takes, with every guard
those sites apply, plus one this site needs and they get for free: the callee must be in the
caller's own **compilation unit** — the invariant the light path is written under (a module's
file-scope `my` is lexical to its compunit, and only the general entry's `is_unit_lexical_of` check
keeps a module sub's write to one off the loading script's same-named lexical).
`nextsame`/`callsame`/`samewith` are unaffected: the multi-dispatch and samewith frames are pushed
*around* this call, not inside the callee entry.

Three allocation/interning leaks on the same path, all measured:

- **`find_compiled_function_inner` built the argument type signature twice** — a `Vec<String>` with
  a heap-allocated `String` per argument, once for the resolution-cache key and once for the
  compiled-key probes — and then cloned it into the key. On a multi name the key is never consulted
  (`use_cache` is false), so all of it was for a lookup that cannot happen.
- **`multi_arg_type_keys` re-interned its reserved marker names on every use.** It runs twice per
  multi call and emits up to three markers per argument; on the two-argument benchmark it interned
  12 names per call, 8 of them compile-time constants.
- **`call_compiled_function_named_inner` built `__mutsu_callable_id::<pkg>::<name>` with `format!`
  on every named call**, then hashed those ~40 bytes to intern it, for a mapping fixed for the life
  of the routine. Now memoized per `(package, name)` symbol pair, next to the sibling
  `type_meta_key_for_sym` memo.

## Two latent light-path bugs the routing change made reachable

Both are real bugs that had simply never been reachable from the call shapes that used to arrive
there, and both are fixed here rather than papered over:

- A failed **return-type** check raised a bare `RuntimeError`, so `throws-like ...,
  X::TypeCheck::Return` could not see it (`roast/S02-types/type.t`, eight subtests). It now raises
  through the same `throw_type_check_return` the general return-value path uses.
- `FastParamType` classified **`Cool`** alongside `Any`/`Mu` as "satisfied by every value". A user
  class instance does not do `Cool`, and `t/light-call-type-check-tags.t` has always pinned the
  rejection — it passed only because that call shape never reached a light path. `Cool` is no
  longer a fast type name, so such a parameter or return type is enforced by the general binder.

## What this does *not* fix

The vendored `Test.rakumod` assertion path is **unchanged**: 191 347 Ir per `ok 1, "x"` before and
after. Its `ok` arrives via `ExecCallPairs` (the parser attaches a `__mutsu_test_callsite_line`
named argument to every test-assertion call), not through `dispatch_func_call_inner`, and two
thirds of the cost is inside `proclaim`, whose `Bool(Mu) $cond` coercion and `$desc is copy` trait
exclude it from any light path by construction. That profile is flat — the largest single
per-assertion entry is 5.9% and it is `malloc` — so it is general interpretation cost, not one
hotspot. The issue is being rewritten with that diagnosis and the next concrete steps.

Also on #7573: the two previous diagnoses recorded there are both now closed and verified so.
`function-full-resolve` on a 2 000-assertion real-`Test` run is **15** (was 50 060) and
`interpreter_fallbacks` is **0.0%** (was 83.3%) — the `nqp::` short-circuit that landed 2026-09-07
closed them, and the per-assertion cost fell 0.2412 ms -> 0.0212 ms with it.

## Testing

- New `t/multi-positional-light-dispatch.t` (20 assertions), verified to pass identically under
  rakudo 2026.07: per-call re-resolution across alternating argument types, `:D`/`:U`
  discrimination, defaulted positionals, `nextsame`/`callsame`, topic freshness, parameter
  read-onlyness, recursion, the `Cool` rejection, and a package-scoped candidate.
- `cargo fmt --all`, `make lint` (all four configurations) — clean.
- `make test` — PASS, 3880 files / 41143 tests.
- `make roast` — the only failures are the three documented container-environment ones
  (`6.c/S32-io/file-tests.t` and `S16-filehandles/filetest.t` under `uid 0`, `S32-io/IO-Socket-Async.t`
  under the sandboxed network), with exactly the subtest numbers
  [docs/agent-environments.md](https://github.com/tokuhirom/mutsu/blob/main/docs/agent-environments.md)
  records.

Refs #7573

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CdHfukCTRY8un9CpxGx5ve

---
_Generated by [Claude Code](https://claude.ai/code/session_01CdHfukCTRY8un9CpxGx5ve)_