### PR TITLE
perf: drain caller-var writebacks by walking frame locals, not the pending set

### DIFF
--- a/news/2026-09/caller-var-writeback-drain-locals-outwards.md
+++ b/news/2026-09/caller-var-writeback-drain-locals-outwards.md
@@ -1,0 +1,97 @@
+# The caller-var writeback drain searches frame-locals outwards
+
+Profiling the HTTP/2 header path of [#7667](https://github.com/tokuhirom/mutsu/issues/7667)
+turned up an interpreter-wide cost that has nothing to do with HTTP/2: the drain
+of the pending caller-var writeback set was quadratic in a set that only ever
+grows.
+
+## The mechanism
+
+`pending_caller_var_writeback` is a work queue of "refresh some frame's local
+slot from env". Entries arrive from `$CALLER::x = v` style writers
+(`record_caller_var_writeback`), from the shared-variable sync, and — far more
+often — from the retain-on-miss branch of `apply_pending_rw_writeback_slow`: a
+source that is not a local of the frame currently draining is kept rather than
+dropped, because the frame that owns the slot may live further up the stack (the
+sibling `submethod BUILD` case pinned by `t/build-sibling-writeback-coherence.t`).
+
+Retain-on-miss has no exit. Nothing removes a name that no frame will *ever* own,
+and `merge_method_env` supplies those generously: its `changed_caller_locals`
+collects every caller-visible env key a method changed, and loading a module
+changes hundreds — enum values, constants, exported symbols, none of which is any
+frame's compiled local. Running `Cro::HTTP2::RequestParser`'s header path left
+**313 permanently unclaimable entries** (`PROTOCOL_ERROR`, `State::header-c`,
+`CBOR::Simple::CBORMajorType::CBOR_Array`,
+`&EXPORT::decode-percents::decode-percents`, …).
+
+The drain then looked each of them up with `find_local_slot`, a linear
+`code.locals` scan, on **every** call return: about 6000 string comparisons per
+return, some 3000 times over four HEADERS frames. In a local `callgrind` run of
+that bench at 60 frames — instruction counts, which are deterministic and
+load-independent — `apply_pending_caller_var_writeback_slow` was **8.0% of all
+instructions executed**, second only to `malloc`, with
+`apply_pending_rw_writeback_slow` a further 2.9%.
+
+## The fix
+
+Search frame-locals outwards instead of pending-sources inwards: walk this
+frame's `code.locals` once and ask the pending set about each name, rather than
+asking `find_local_slot` about each pending source. The set answers in O(1), so
+the drain costs O(locals) hash lookups instead of O(pending × locals) string
+comparisons — and no longer scales with the accumulated set at all.
+
+The answer is the same. A source names one variable, so no two of them can want
+the same slot and the drain order cannot matter; taking slots in index order
+still resolves a duplicated name to its first slot, exactly as `find_local_slot`
+did; and `HashSet::remove` doubles as the membership test and the
+"matched → do not retain" step, so a source is still applied at most once.
+`pending_caller_var_writeback` becomes an `FxHashSet<String>` accordingly, which
+also makes the dedup-on-insert every producer performs O(1) instead of linear in
+the accumulated size.
+
+## What was tried and rejected
+
+Dropping an unclaimed source when the drain reaches the outermost frame — on the
+reasoning that no ancestor is left to own the slot — looks right and is not. A
+proxy-bound writeback is recorded while a `code` that does not carry the slot is
+current, and is claimed by a *later* drain in the very same frame:
+
+```raku
+my $str = "gorch ding";
+my $r := substr-rw($str, 0, 5);
+$r = "gloop";
+is $str, "gloop ding";     # t/substr-rw-lvalue-writeback-coherence.t
+```
+
+That test caught it. The names therefore still accumulate; what stops costing is
+looking at them.
+
+## What it buys, and what it does not
+
+`t/caller-writeback-drain-coherence.t` pins that every writeback a real frame can
+claim still arrives: across an intervening deeper call, two frames up with a miss
+in between, sibling `BUILD` submethods, captured-outer mutation from a method
+(with and without a nested call inside it), `is rw` parameters, a repeatedly
+called closure, and after an `enum` registration.
+
+Measured the same deterministic way, an A/B of two release builds over the same
+bench at 12 frames:
+
+| | before | after |
+| --- | --- | --- |
+| `apply_pending_caller_var_writeback_slow` | 112.5M Ir (1.27%) | 0.67M Ir (0.01%) |
+| `apply_pending_rw_writeback_slow` | 75.0M Ir (0.84%) | 9.3M Ir (0.11%) |
+| whole program | 8.888G Ir | 8.666G Ir (-2.5%) |
+
+The second row falls out of the same change: that drain's retain-on-miss arm
+tested set membership before pushing, which was the same linear scan.
+
+(The share the two functions take grows with the number of frames — 8.0%/2.9% at
+60 frames against 1.27%/0.84% at 12, where process start-up is a larger slice —
+so the whole-program figure above is the conservative end.)
+
+It does **not** move #7667's headline number. A HEADERS frame still costs ~25 ms,
+and the per-stage breakdown recorded on that issue shows why: the cost is spread
+across HPACK decoding, `Cro::HTTP::Request` construction, the per-stream
+`whenever` registration and the `supply` plumbing, with no single dominant term.
+That issue stays open with the measurements attached.

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -3226,7 +3226,16 @@ pub struct Interpreter {
     /// intervening *deeper* call (the writer making another call before returning)
     /// must not consume it; (2) the value is read from env at drain time, same as
     /// the rw list. Drained at the same call sites, with retain-on-miss semantics.
-    pub(crate) pending_caller_var_writeback: Vec<String>,
+    ///
+    /// A **set**, not a list: the entries are an unordered pending-work set (each
+    /// names a distinct variable, so no two of them target the same slot and the
+    /// drain order cannot matter), every producer already deduplicated against it
+    /// before pushing, and retain-on-miss means it is long-lived — after loading a
+    /// handful of modules it holds hundreds of names that no frame will ever own
+    /// (enum values, constants, exported symbols; see
+    /// `apply_pending_caller_var_writeback_slow`). A `Vec` made both the
+    /// dedup-on-insert and the drain linear in that accumulated size.
+    pub(crate) pending_caller_var_writeback: rustc_hash::FxHashSet<String>,
     /// Appended every time a resume-safe `CONTROL` handler is run INLINE at a
     /// warn raise site (`try_resume_safe_control_inline`) and writes one of the
     /// installing frame's lexicals into `env`; each entry is the `Symbol` of

--- a/src/runtime/runtime_caller_env.rs
+++ b/src/runtime/runtime_caller_env.rs
@@ -240,8 +240,8 @@ impl Interpreter {
     /// the write happens inside a nested callee/closure (e.g. a Proxy STORE whose
     /// referent lexical is owned by the caller of the `$proxy = v` assignment).
     pub(crate) fn record_caller_var_writeback(&mut self, name: &str) {
-        if !self.pending_caller_var_writeback.iter().any(|n| n == name) {
-            self.pending_caller_var_writeback.push(name.to_string());
+        if !self.pending_caller_var_writeback.contains(name) {
+            self.pending_caller_var_writeback.insert(name.to_string());
         }
     }
 

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -3205,7 +3205,7 @@ impl Interpreter {
             shaped_decl_context: false,
             vardecl_init_raw: None,
             pending_rw_writeback_sources: Vec::new(),
-            pending_caller_var_writeback: Vec::new(),
+            pending_caller_var_writeback: rustc_hash::FxHashSet::default(),
             inline_control_env_writes: Vec::new(),
             local_bind_pairs: Vec::new(),
             otf_compile_cache: HashMap::new(),

--- a/src/runtime/runtime_shared_vars.rs
+++ b/src/runtime/runtime_shared_vars.rs
@@ -706,9 +706,7 @@ impl Interpreter {
         // (`pending_caller_var_writeback`) instead, which carries the source up the
         // frame chain until the frame whose `code` actually has the slot drains it.
         for (key, val) in updates {
-            if !self.pending_caller_var_writeback.contains(&key) {
-                self.pending_caller_var_writeback.push(key.clone());
-            }
+            self.pending_caller_var_writeback.insert(key.clone());
             // ADR-0024: a mainline named sub's captured free variable may be
             // reassigned from a worker thread (e.g. `$port = await
             // $tap.socket-port` completing a real async I/O wait, not a

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -911,7 +911,7 @@ impl Interpreter {
             shaped_decl_context: false,
             vardecl_init_raw: None,
             pending_rw_writeback_sources: Vec::new(),
-            pending_caller_var_writeback: Vec::new(),
+            pending_caller_var_writeback: rustc_hash::FxHashSet::default(),
             inline_control_env_writes: Vec::new(),
             local_bind_pairs: Vec::new(),
             otf_compile_cache: HashMap::new(),

--- a/src/vm/vm_call_method_mut_ops.rs
+++ b/src/vm/vm_call_method_mut_ops.rs
@@ -1119,7 +1119,7 @@ impl Interpreter {
                 let pending: Vec<String> = self
                     .pending_rw_writeback_sources
                     .drain(..)
-                    .chain(self.pending_caller_var_writeback.drain(..))
+                    .chain(self.pending_caller_var_writeback.drain())
                     .collect();
                 for name in pending {
                     self.record_caller_var_writeback(&name);

--- a/src/vm/vm_call_method_ops.rs
+++ b/src/vm/vm_call_method_ops.rs
@@ -1096,7 +1096,7 @@ impl Interpreter {
                 let pending: Vec<String> = self
                     .pending_rw_writeback_sources
                     .drain(..)
-                    .chain(self.pending_caller_var_writeback.drain(..))
+                    .chain(self.pending_caller_var_writeback.drain())
                     .collect();
                 for name in pending {
                     self.record_caller_var_writeback(&name);

--- a/src/vm/vm_env_helpers.rs
+++ b/src/vm/vm_env_helpers.rs
@@ -2072,7 +2072,7 @@ impl Interpreter {
                     {
                         self.locals[slot] = val;
                     }
-                } else if !self.pending_caller_var_writeback.contains(&source) {
+                } else {
                     // The owning slot is not in THIS frame. Don't drop the source:
                     // it belongs to a frame further up the stack (e.g. a sibling
                     // `submethod BUILD`'s `$counter++` queued for the outer `.new`
@@ -2080,7 +2080,7 @@ impl Interpreter {
                     // S12-construction/BUILD.t). Move it to the retain-on-miss
                     // caller-var list so the owning frame's drain refreshes its slot
                     // instead of leaving it stale.
-                    self.pending_caller_var_writeback.push(source);
+                    self.pending_caller_var_writeback.insert(source);
                 }
             }
         }
@@ -2142,30 +2142,55 @@ impl Interpreter {
         self.apply_pending_caller_var_writeback_slow(code);
     }
 
+    /// The search runs **frame-locals outwards**, not pending-sources inwards:
+    /// walk this frame's `code.locals` once and ask the pending set about each,
+    /// rather than asking `find_local_slot` — a linear `code.locals` scan — about
+    /// each pending source. Same answer (a source names one variable, so no two
+    /// can want the same slot, and taking slots in index order still resolves a
+    /// duplicated name to its first slot exactly as `find_local_slot` did), at
+    /// O(locals) hash lookups instead of O(pending * locals) string comparisons.
+    ///
+    /// That matters because the pending set is long-lived and large. Retain-on-miss
+    /// never removes a name no frame will ever own, and `merge_method_env` feeds it
+    /// every caller-visible env key a method changed — which, while a module loads,
+    /// means its enum values, constants and exported symbols. Running
+    /// `Cro::HTTP2::RequestParser`'s HTTP/2 header path left 313 such permanently
+    /// unclaimable names (`PROTOCOL_ERROR`, `State::header-c`,
+    /// `CBOR::Simple::CBORMajorType::CBOR_Array`, …), and rescanning all of them on
+    /// every call return made this function 8.0% of all instructions executed in a
+    /// local `callgrind` run — second only to `malloc`. See
+    /// [#7667](https://github.com/tokuhirom/mutsu/issues/7667).
+    ///
+    /// The names themselves still accumulate; what stops costing is looking at
+    /// them. Dropping an unclaimed source instead is NOT sound: a proxy-bound
+    /// writeback (`my $r := substr-rw($s, 0, 5); $r = "..."`) is recorded while a
+    /// `code` without the slot is current and is claimed by a later drain in the
+    /// very same frame (`t/substr-rw-lvalue-writeback-coherence.t`).
     #[inline(never)]
     fn apply_pending_caller_var_writeback_slow(&mut self, code: &CompiledCode) {
-        let sources = std::mem::take(&mut self.pending_caller_var_writeback);
-        let mut retained = Vec::new();
-        for source in sources {
-            if let Some(slot) = self.find_local_slot(code, &source) {
-                if !matches!(self.locals[slot].view(), ValueView::HashEntryRef { .. })
-                    && let Some(val) = self.env().get(&source).cloned()
-                {
-                    self.locals[slot] = val;
-                }
-                // matched (slot exists in this frame) → applied, do not retain.
-                // Keep the runtime-name list in step: once the frame that owns the
-                // slot has absorbed the value there is nothing left to carry across
-                // further frame exits, and leaving the entry behind would keep
-                // replaying a stale value upward.
-                if !self.pending_runtime_name_writes.is_empty() {
-                    self.pending_runtime_name_writes.retain(|n| n != &source);
-                }
-            } else {
-                retained.push(source);
+        // `code.locals` can in principle outrun the frame's live slot region; only
+        // slots that exist are writable, and a name past the end stays pending.
+        let live = self.locals.len();
+        for (slot, name) in code.locals.iter().enumerate().take(live) {
+            // `remove` is the membership test and the "matched -> do not retain"
+            // step in one: a source is applied at most once, at the first slot
+            // bearing its name.
+            if !self.pending_caller_var_writeback.remove(name.as_str()) {
+                continue;
+            }
+            if !matches!(self.locals[slot].view(), ValueView::HashEntryRef { .. })
+                && let Some(val) = self.env().get(name).cloned()
+            {
+                self.locals[slot] = val;
+            }
+            // Keep the runtime-name list in step: once the frame that owns the
+            // slot has absorbed the value there is nothing left to carry across
+            // further frame exits, and leaving the entry behind would keep
+            // replaying a stale value upward.
+            if !self.pending_runtime_name_writes.is_empty() {
+                self.pending_runtime_name_writes.retain(|n| n != name);
             }
         }
-        self.pending_caller_var_writeback = retained;
     }
 
     /// Drain `pending_local_updates` logged by an embedded regex `{ ... }` block

--- a/t/caller-writeback-drain-coherence.t
+++ b/t/caller-writeback-drain-coherence.t
@@ -1,0 +1,122 @@
+use Test;
+
+# The caller-var writeback drain walks this frame's locals and asks the pending
+# set about each, instead of asking `find_local_slot` -- a linear `code.locals`
+# scan -- about each pending source. Same answer, O(locals) hash lookups instead
+# of O(pending * locals) string comparisons.
+#
+# The rewrite matters because the pending set is long-lived and large:
+# retain-on-miss never removes a name no frame will ever own, and
+# `merge_method_env` feeds it every caller-visible env key a method changed --
+# so while a module loads, its enum values, constants and exported symbols. The
+# Cro HTTP/2 header path left 313 such permanently unclaimable names, and
+# rescanning them on every call return was 8% of all instructions executed
+# (#7667).
+#
+# This file pins that the rewrite still delivers every writeback a real frame
+# can claim, across the frame shapes that feed the retain-on-miss list. Dropping
+# an unclaimed source instead is NOT sound -- see the proxy-bind case in
+# t/substr-rw-lvalue-writeback-coherence.t, which is recorded while a `code`
+# without the slot is current and claimed by a later drain in the same frame.
+
+plan 10;
+
+# --- retained across an intervening deeper call, then claimed at the mainline ---
+{
+    sub deeper() { 99 }
+    sub writer() {
+        callframe(1).my.<$a> = 7;
+        deeper();               # drains at depth 1: must NOT drop
+    }
+    my $a is dynamic = 0;
+    writer();
+    is $a, 7, 'caller-frame write survives an intervening deeper call';
+}
+
+# --- $CALLER:: read-modify-write from the mainline ---
+{
+    my sub bump { $CALLER::b++ }
+    my $b is dynamic = 41;
+    bump();
+    is $b, 42, '$CALLER::b++ reaches the mainline slot';
+}
+
+# --- claimed two frames up, with the miss happening in between ---
+{
+    sub inner() { callframe(2).my.<$c> = 5 }
+    sub middle() { inner() }    # drains at depth 1 and misses: must retain
+    my $c is dynamic = 0;
+    middle();
+    is $c, 5, 'a write targeting the grandparent frame survives the miss between';
+}
+
+# --- sibling BUILD writes are not consumed by a nested dispatch ---
+{
+    my $parent-builds = 0;
+    class S { }
+    class P { submethod BUILD { $parent-builds++ } }
+    class C is P { submethod BUILD { my $x = S.new } }
+    C.new;
+    is $parent-builds, 1, 'nested .new in child BUILD keeps the parent BUILD write';
+}
+
+# --- captured-outer mutation from a method, claimed at the mainline ---
+{
+    my $total = 0;
+    class Acc { method add($n) { $total += $n } }
+    my $acc = Acc.new;
+    $acc.add(3);
+    $acc.add(4);
+    is $total, 7, 'a method mutating a captured mainline lexical accumulates';
+}
+
+# --- the same, with a nested call inside the method ---
+{
+    my $seen = 0;
+    class Nest {
+        method helper() { 1 }
+        method go() { $seen += self.helper() }
+    }
+    my $n = Nest.new;
+    $n.go();
+    $n.go();
+    is $seen, 2, 'captured-outer write survives a nested call inside the method';
+}
+
+# --- is rw parameter writeback from the mainline ---
+{
+    sub setit($x is rw) { $x = 11 }
+    my $r = 0;
+    setit($r);
+    is $r, 11, 'is rw parameter writes back to the mainline slot';
+}
+
+# --- is rw writeback with a deeper call before the callee returns ---
+{
+    sub noise() { 1 }
+    sub setit2($x is rw) { $x = 12; noise() }
+    my $r2 = 0;
+    setit2($r2);
+    is $r2, 12, 'is rw writeback survives a deeper call inside the callee';
+}
+
+# --- a closure mutating a mainline lexical, called repeatedly ---
+{
+    my $count = 0;
+    my $inc = { $count++ };
+    $inc() for ^3;
+    is $count, 3, 'closure mutating a mainline lexical accumulates across calls';
+}
+
+# --- enum registration (the shape that filled the list) must not disturb a
+#     live mainline lexical whose slot a later call refreshes ---
+{
+    my $keep = 0;
+    enum Colour <RED GREEN BLUE>;
+    class Painter { method paint() { $keep++ } }
+    my $p = Painter.new;
+    $p.paint();
+    $p.paint();
+    ok $keep == 2 && GREEN.value == 1,
+        'enum registration leaves later caller-slot refreshes working';
+}


### PR DESCRIPTION
Profiling the HTTP/2 header path of #7667 turned up an interpreter-wide cost that
has nothing to do with HTTP/2.

## The problem

`pending_caller_var_writeback` is a queue of "refresh some frame's local slot from
env". Its drain looked up each pending source with `find_local_slot` — a linear
`code.locals` scan — on every call return, so the cost was O(pending × locals) per
return **in a set that only ever grows**.

Retain-on-miss has no exit: nothing removes a name that no frame will ever own,
and `merge_method_env` supplies those generously, since `changed_caller_locals`
collects every caller-visible env key a method changed and loading a module
changes hundreds — enum values, constants, exported symbols, none of which is any
frame's compiled local. Running `Cro::HTTP2::RequestParser`'s header path left
**313 permanently unclaimable entries** (`PROTOCOL_ERROR`, `State::header-c`,
`CBOR::Simple::CBORMajorType::CBOR_Array`,
`&EXPORT::decode-percents::decode-percents`, …), rescanned about 3000 times over
four HEADERS frames.

## The fix

Search frame-locals outwards instead of pending-sources inwards: walk this frame's
`code.locals` once and ask the pending set about each name. O(locals) hash lookups,
independent of the accumulated set.

The answer is the same. A source names one variable, so no two of them can want the
same slot and the drain order cannot matter; taking slots in index order still
resolves a duplicated name to its first slot exactly as `find_local_slot` did; and
`HashSet::remove` is the membership test and the "matched → do not retain" step in
one, so a source is applied at most once. The field becomes an `FxHashSet<String>`,
which also makes the dedup-on-insert every producer performs O(1) rather than
linear in the accumulated size.

## What was tried first and rejected

Dropping an unclaimed source when the drain reaches the outermost frame — no
ancestor left to own the slot — looks right and is not sound. A proxy-bound
writeback is recorded while a `code` without the slot is current and is claimed by
a *later* drain in the very same frame:

```raku
my $str = "gorch ding";
my $r := substr-rw($str, 0, 5);
$r = "gloop";
is $str, "gloop ding";     # t/substr-rw-lvalue-writeback-coherence.t
```

That test caught it, in the pre-publication `make test`. The names therefore still
accumulate; what stops costing is looking at them.

## Measurements

Deterministic instruction counts from a local `callgrind` A/B of two release builds
over the same HTTP/2 header bench at 12 frames:

| | before | after |
| --- | --- | --- |
| `apply_pending_caller_var_writeback_slow` | 112.5M Ir (1.27%) | 0.67M Ir (0.01%) |
| `apply_pending_rw_writeback_slow` | 75.0M Ir (0.84%) | 9.3M Ir (0.11%) |
| whole program | 8.888G Ir | 8.666G Ir (−2.5%) |

The second row falls out of the same change: that drain's retain-on-miss arm tested
set membership before pushing, which was the same linear scan. The share the two
functions take grows with the number of frames — 8.0% / 2.9% at 60 frames, where
`apply_pending_caller_var_writeback_slow` was second only to `malloc` — so the
whole-program figure is the conservative end. These are local numbers, not bench-CI
ones.

This does **not** move #7667's headline HEADERS-frame latency (~25 ms). The
per-stage breakdown I measured is spread across HPACK decoding,
`Cro::HTTP::Request` construction, the per-stream `whenever` registration and the
`supply` plumbing with no dominant term, so that issue stays open with the
measurements attached rather than being closed here.

## Tests

`t/caller-writeback-drain-coherence.t` (new, 10 cases) pins that every writeback a
real frame can claim still arrives: across an intervening deeper call, two frames
up with a miss in between, sibling `BUILD` submethods, captured-outer mutation from
a method (with and without a nested call inside it), `is rw` parameters, a
repeatedly called closure, and after an `enum` registration.

Run locally before publishing:

- `cargo fmt --all` — clean
- `make lint` — green in all four configurations
- `make test` — **PASS**, 3880 files / 41133 tests
- `make roast` — the only files with `Failed: N > 0` are the three container-only
  ones documented in `docs/agent-environments.md`
  (`roast/6.c/S32-io/file-tests.t` 6-8/10 and `roast/S16-filehandles/filetest.t`
  57-64/69-72/77-80/101…125, both because this container runs as `uid 0` so root
  bypasses the permission bits; `roast/S32-io/IO-Socket-Async.t` exit 124 from the
  network sandbox), with exactly the subtest ranges that document lists.

## Related findings filed separately

- #7680 — `Buf.push` is O(n) per element, so building a buffer byte by byte is O(n²)
- #7681 — `now-$x` inside string interpolation silently evaluates to `-$x`

Refs #7667

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QsXWb3kSus36HLpPUyeQj8

---
_Generated by [Claude Code](https://claude.ai/code/session_01QsXWb3kSus36HLpPUyeQj8)_