### PR TITLE
fix(runtime): render an itemized container-subclass array element instead of its class name

### DIFF
--- a/news/2026-09/itemized-container-subclass-element-gist-str.md
+++ b/news/2026-09/itemized-container-subclass-element-gist-str.md
@@ -1,0 +1,72 @@
+# An itemized `is Array` subclass element rendered as its class name
+
+`my @h = $c`, with `$c` holding an `is Array` (or `is List`) subclass instance,
+made `@h.gist`, `@h.Str` and `@h.join` all answer `SA()` — the class name in
+type-object shape — instead of rendering the element. `say @h` (the *implicit*
+gist) was correct throughout, which is what kept the divergence hidden.
+Reported as [#7660](https://github.com/tokuhirom/mutsu/issues/7660), found while
+fixing [#7594](https://github.com/tokuhirom/mutsu/issues/7594).
+
+```
+$ raku  -e 'class SA is Array {}; my $c = SA.new(3,2,1,4); my @h = $c; say @h.gist'
+[[3 2 1 4]]
+$ mutsu -e 'class SA is Array {}; my $c = SA.new(3,2,1,4); my @h = $c; say @h.gist'
+SA()          # before
+[[3 2 1 4]]   # after
+```
+
+## Root cause
+
+Not the `is Array` delegation machinery the issue suspected, and not a wrong
+invocant: the receiver was the array all along. The trigger is **itemization**.
+
+`my @h = $c` compiles an `ItemizeVar` for the right-hand scalar, so the array's
+one element is a `Scalar` wrapping the instance, not the bare instance. Three
+independent probes decide whether rendering a list needs the interpreter — the
+answer must be "yes" whenever an element may carry a user-defined `gist`/`Str`,
+because the pure renderers cannot dispatch a method — and all three looked
+through a `:=`-bound `ContainerRef` cell but **not** through that `Scalar`:
+
+- `collection_contains_instance_seen` (`runtime/methods_call_dispatch.rs`), the
+  guard on the dispatching collection-gist renderer;
+- `element_needs_interpreter` (`runtime/list_element_stringify.rs`), the guard
+  on the `.Str`/`.Stringy` element resolver;
+- the native `join` fast path (`builtins/methods_narg/dispatch_1arg.rs`), which
+  declines to runtime when an element is an instance.
+
+Each therefore answered "no interpreter needed" and the pure renderer printed
+the generic `ClassName()` fallback for the element. The builtins-side gist twin
+(`gist_route` in `dispatch_core_repr`) has always looked through both wrappers,
+so the *native* path correctly declined — and then the runtime path it deferred
+to declined to take over. That disagreement between the two halves is exactly
+what produced a wrong answer rather than merely a slow one.
+
+`say @h` escaped because the implicit gist does not go through the explicit
+method-dispatch entry, and `.raku` escaped because its own probe
+(`contains_dispatch_leaf_seen`) already descended itemization.
+
+## Fix
+
+Look through itemization at all three probes, and at the two resolvers that
+follow them, so the probe and the resolver agree on what an element *is*:
+
+- `collection_contains_instance_seen` gained `Scalar` and `ContainerRef` arms
+  (with the cell's contents cloned out before recursing, so a cycle closing
+  through a cell cannot deadlock against the lock `gist_item` holds), and cells
+  now carry a container identity of their own in the visited set;
+- `gist_item` gained the matching arms, dropping the itemization sigil exactly
+  as its pure twin does;
+- `element_needs_interpreter` and `resolve_elements` descalarize, so the
+  element's own `Str` is dispatched;
+- `dispatch_join_method` and the native `join` fast path descalarize for the
+  same reason — `.join` stringifies each element with `.Str`, and a method call
+  deconts its invocant.
+
+## Pin
+
+`t/array-subclass-element-gist-str.t` — 18 assertions covering implicit gist,
+explicit `.gist`, `.Str`, `.join` and `.raku` for both an `is Array` and an
+`is List` element, the nested case, and the four controls that were already
+correct (a non-container instance element, a plain array element, the
+instance's own gist/Str, and a *pushed* — hence non-itemized — element). The
+file passes under `raku` unchanged.

--- a/src/builtins/methods_narg/dispatch_1arg.rs
+++ b/src/builtins/methods_narg/dispatch_1arg.rs
@@ -852,11 +852,16 @@ pub(crate) fn native_method_1arg(
                 // If any item is an Instance, fall through to runtime
                 // so user-defined Str() methods can be called. A `ContainerRef`
                 // element (grep rw alias / `:=`-bound slot) is decontainerized
-                // first so a cell-wrapped Instance is also routed to runtime.
+                // first so a cell-wrapped Instance is also routed to runtime,
+                // and an ITEMIZED one (`my @h = $x` compiles an `ItemizeVar`)
+                // is descalarized for the same reason -- `.join` stringifies
+                // each element with `.Str`, whose dispatch deconts its invocant,
+                // so `my @h = $c` with an `is Array` subclass instance must not
+                // be answered here with the pure `SA()` fallback.
                 if items.iter().any(|v| {
                     v.with_deref(|inner| {
                         matches!(
-                            inner.view(),
+                            inner.descalarize().view(),
                             ValueView::Instance { .. } | ValueView::Mixin(..)
                         )
                     })

--- a/src/runtime/list_element_stringify.rs
+++ b/src/runtime/list_element_stringify.rs
@@ -57,10 +57,18 @@ impl crate::Interpreter {
 
     fn element_needs_interpreter(item: &Value) -> bool {
         let item = item.deref_container();
+        // An element assigned from a scalar arrives ITEMIZED (`my @h = $x`
+        // compiles an `ItemizeVar`), so an `Instance` element sits one `Scalar`
+        // down. `.Str` on a list calls `.Str` on each element and a method call
+        // deconts its invocant, so the itemization is looked through here for
+        // the same reason the cell above is. Without it `my @h = $c` (with `$c`
+        // an `is Array` subclass instance) reported "no interpreter needed" and
+        // the pure renderer printed the `SA()` fallback for the element.
+        let item = item.descalarize();
         matches!(
             item.view(),
             ValueView::Instance { .. } | ValueView::Mixin(..) | ValueView::Proxy { .. }
-        ) || Self::list_str_needs_interpreter(&item)
+        ) || Self::list_str_needs_interpreter(item)
     }
 
     /// Replace every `Instance` element with the string its class's `Str`
@@ -114,11 +122,16 @@ impl crate::Interpreter {
             } else {
                 item
             };
+            // Look through itemization for the same reason
+            // `element_needs_interpreter` does -- the probe and the resolver
+            // must agree on what an element *is*, or a list the probe accepted
+            // would fall through this loop unchanged.
+            let inner = item.descalarize();
             if matches!(
-                item.view(),
+                inner.view(),
                 ValueView::Instance { .. } | ValueView::Mixin(..)
             ) {
-                let s = self.call_method_with_values(item.clone(), "Str", vec![])?;
+                let s = self.call_method_with_values(inner.clone(), "Str", vec![])?;
                 out.push(Value::str(s.to_string_value()));
             } else if Self::list_str_needs_interpreter(&item) {
                 out.push(self.resolve_list_element_stringifiers(&item)?);

--- a/src/runtime/methods_call_dispatch.rs
+++ b/src/runtime/methods_call_dispatch.rs
@@ -2767,6 +2767,9 @@ impl Interpreter {
                 let id = match value.view() {
                     ValueView::Array(data, _) => Some(crate::gc::Gc::as_ptr(&data) as usize),
                     ValueView::Hash(data) => Some(crate::gc::Gc::as_ptr(&data) as usize),
+                    // A `:=`-bound element holds a cell, and a cycle can close
+                    // through one, so cells have an identity of their own.
+                    ValueView::ContainerRef(cell) => Some(crate::gc::Gc::as_ptr(&cell) as usize),
                     _ => None,
                 };
                 if let Some(id) = id
@@ -2792,6 +2795,26 @@ impl Interpreter {
                         collection_contains_instance_seen(k, seen, depth + 1)
                             || collection_contains_instance_seen(v, seen, depth + 1)
                     }
+                    // An element assigned from a scalar arrives ITEMIZED
+                    // (`my @h = $c` compiles an `ItemizeVar`), so the instance
+                    // that needs dispatch sits one `Scalar` down. Without this
+                    // the probe answered `false` for `my @h = SomeArraySubclass
+                    // .new(1,2)` and `@h.gist` fell through to the generic
+                    // stringifying fallback, which rendered the element as
+                    // `SA()`. The builtins-side twin (`gist_route` in
+                    // `dispatch_core_repr`) has always looked through both, which
+                    // is why the native probe correctly declined while this one
+                    // then declined to take over.
+                    ValueView::Scalar(inner) => {
+                        collection_contains_instance_seen(inner, seen, depth + 1)
+                    }
+                    // Clone the contents out and drop the guard before
+                    // recursing: `gist_item` holds this very lock across its own
+                    // recursion, so a cell reached twice would deadlock.
+                    ValueView::ContainerRef(cell) => {
+                        let inner = cell.lock().unwrap().clone();
+                        collection_contains_instance_seen(&inner, seen, depth + 1)
+                    }
                     _ => false,
                 }
             }
@@ -2807,6 +2830,19 @@ impl Interpreter {
                 }
                 match value.view() {
                     ValueView::Nil => "Nil".to_string(),
+                    // `.gist` drops the itemization sigil, so an itemized
+                    // element (`$(...)`, and every element `my @h = $x`
+                    // produces) gists like its inner value -- the same rule the
+                    // pure renderer's `gist_item` twin carries.
+                    ValueView::Scalar(inner) => gist_item(interp, inner),
+                    // Clone the contents out and drop the guard before
+                    // recursing: a cycle can close through a cell
+                    // (`my @e; @e.push(@e)`), and holding the lock across the
+                    // recursion deadlocks instead of recursing.
+                    ValueView::ContainerRef(cell) => {
+                        let inner = cell.lock().unwrap().clone();
+                        gist_item(interp, &inner)
+                    }
                     ValueView::Array(items, kind) => {
                         // Shaped arrays join their rows with a newline, like
                         // the pure fast path (`say my @a[2,2]` is one row per

--- a/src/runtime/methods_dispatch_match3.rs
+++ b/src/runtime/methods_dispatch_match3.rs
@@ -722,6 +722,12 @@ impl Interpreter {
             // Decontainerize a `ContainerRef` element (grep rw alias / `:=`-bound
             // slot) so a cell-wrapped Instance still gets its user-defined `.Str`.
             let v = v.deref_container();
+            // Look through itemization too: an element assigned from a scalar
+            // arrives itemized (`my @h = $x` compiles an `ItemizeVar`), and
+            // `.join` stringifies each element with `.Str`, whose dispatch
+            // deconts its invocant. Without this `my @h = $c` (an `is Array`
+            // subclass instance) joined to the `SA()` fallback.
+            let v = v.descalarize().clone();
             if matches!(v.view(), ValueView::Instance { .. } | ValueView::Mixin(..)) {
                 let s = match self.call_method_with_values(v.clone(), "Str", vec![]) {
                     Ok(s) => s,

--- a/t/array-subclass-element-gist-str.t
+++ b/t/array-subclass-element-gist-str.t
@@ -1,0 +1,81 @@
+use Test;
+
+# An `is Array` / `is List` subclass instance assigned into an array arrives
+# ITEMIZED (`my @h = $c` compiles an itemization of `$c`), so the instance that
+# needs method dispatch sits one Scalar down from the element slot. The probes
+# that decide "does rendering this list need the interpreter?" only looked
+# through a `:=`-bound cell, not through that itemization, so the pure renderers
+# answered for the element and printed the `SA()` type-object-shaped fallback:
+# `@h.gist`, `@h.Str` and `@h.join` all came back as `SA()`, while `say @h` (the
+# implicit gist, which takes a different route) was right all along.
+#
+# Every expectation here was measured against rakudo, and the file passes under
+# `raku` unchanged.
+
+plan 18;
+
+class SA is Array { }
+class SL is List { }
+class P { has $.x }
+
+# --- the reported shapes: an `is Array` element ------------------------------
+{
+    my $c = SA.new(3, 2, 1, 4);
+    my @h = $c;
+
+    is @h.elems, 1, 'an Array subclass instance is stored as one element';
+    is @h.gist, '[[3 2 1 4]]', 'explicit .gist renders the element through its own gist';
+    is ~@h, '3 2 1 4', 'the implicit gist (say/~) was always right and stays right';
+    is @h.Str, '3 2 1 4', 'explicit .Str stringifies the element through its own Str';
+    is @h.join('|'), '3 2 1 4', '.join stringifies it the same way';
+    is @h.raku, '[[3, 2, 1, 4],]', '.raku is unchanged';
+}
+
+# --- the same shapes for an `is List` subclass -------------------------------
+{
+    my $l = SL.new(3, 2, 1);
+    my @g = $l;
+
+    is @g.gist, '[(3 2 1)]', 'a List subclass element keeps its parenthesized gist';
+    is @g.Str, '3 2 1', 'and stringifies through its own Str';
+    is @g.join('|'), '3 2 1', 'and joins through it too';
+}
+
+# --- nested: the array holding the instance is itself an element -------------
+{
+    my $c = SA.new(3, 2, 1, 4);
+    my @h = $c;
+    my @outer = @h,;
+
+    is @outer.gist, '[[[3 2 1 4]]]', 'the nested case renders at both levels';
+    is @outer.Str, '3 2 1 4', 'and stringifies through the leaf instance';
+}
+
+# --- controls that were already correct and must stay so ---------------------
+{
+    my $p = P.new(x => 1);
+    my @q = $p;
+    is @q.gist, '[P.new(x => 1)]', 'a NON-container instance element is unchanged';
+}
+
+{
+    my @r = [1, 2],;
+    is @r.gist, '[[1 2]]', 'a plain array element is unchanged';
+    is @r.Str, '1 2', 'and so is its Str';
+}
+
+{
+    my $c = SA.new(1, 2);
+    is $c.gist, '[1 2]', "the instance's OWN gist is unchanged";
+    is $c.Str, '1 2', "and its OWN Str";
+}
+
+# An element pushed (rather than assigned) is NOT itemized -- that spelling
+# always worked, and is the control proving the fix did not move the answer.
+{
+    my $c = SA.new(1, 2);
+    my @h;
+    @h.push($c);
+    is @h.gist, '[[1 2]]', 'a pushed (non-itemized) element still gists correctly';
+    is @h.Str, '1 2', 'and still stringifies correctly';
+}


### PR DESCRIPTION
`my @h = $c`, with `$c` holding an `is Array` / `is List` subclass instance, made
`@h.gist`, `@h.Str` and `@h.join` answer `SA()` — the class name in type-object
shape — instead of rendering the element. `say @h` (the *implicit* gist) was
correct throughout, which is what kept the divergence hidden.

```
$ raku  -e 'class SA is Array {}; my $c = SA.new(3,2,1,4); my @h = $c; say @h.gist'
[[3 2 1 4]]
$ mutsu -e 'class SA is Array {}; my $c = SA.new(3,2,1,4); my @h = $c; say @h.gist'
SA()          # before
[[3 2 1 4]]   # after
```

## Root cause

Not the `is Array` delegation machinery the issue suspected, and not a wrong
invocant — the receiver was the array all along. The trigger is **itemization**.

`my @h = $c` compiles an `ItemizeVar` for the right-hand scalar, so the array's
one element is a `Scalar` wrapping the instance, not the bare instance. Three
independent probes decide whether rendering a list needs the interpreter — the
answer must be "yes" whenever an element may carry a user-defined `gist`/`Str`,
because the pure renderers cannot dispatch a method — and all three looked
through a `:=`-bound `ContainerRef` cell but **not** through that `Scalar`:

- `collection_contains_instance_seen` (`src/runtime/methods_call_dispatch.rs`),
  the guard on the dispatching collection-gist renderer;
- `element_needs_interpreter` (`src/runtime/list_element_stringify.rs`), the
  guard on the `.Str`/`.Stringy` element resolver;
- the native `join` fast path (`src/builtins/methods_narg/dispatch_1arg.rs`),
  which declines to the runtime when an element is an instance.

Each therefore answered "no interpreter needed" and the pure renderer printed
the generic `ClassName()` fallback for the element. The builtins-side gist twin
(`gist_route` in `dispatch_core_repr`) has always looked through both wrappers,
so the *native* path correctly declined — and then the runtime path it deferred
to declined to take over. That disagreement between the two halves is what
produced a wrong answer rather than merely a slow one.

`say @h` escaped because the implicit gist does not go through the explicit
method-dispatch entry, and `.raku` escaped because its own probe
(`contains_dispatch_leaf_seen`) already descended itemization.

## Fix

Look through itemization at all three probes, and at the two resolvers that
follow them, so a probe and its resolver agree on what an element *is*:

- `collection_contains_instance_seen` and `gist_item` gained `Scalar` and
  `ContainerRef` arms. The cell's contents are cloned out before recursing, so
  a cycle closing through a cell cannot deadlock against the lock `gist_item`
  holds; cells now also carry a container identity of their own in the visited
  set. `gist_item` drops the itemization sigil exactly as its pure twin does.
- `element_needs_interpreter` and `resolve_elements` descalarize, so the
  element's own `Str` is dispatched.
- `dispatch_join_method` and the native `join` probe descalarize for the same
  reason — `.join` stringifies each element with `.Str`, and a method call
  deconts its invocant.

## Test

`t/array-subclass-element-gist-str.t` — 18 assertions covering implicit gist,
explicit `.gist`, `.Str`, `.join` and `.raku` for both an `is Array` and an
`is List` element, the nested case (`my @h = $c; my @outer = @h,`), and the
controls that were already correct: a non-container instance element, a plain
array element, the instance's own gist/Str, and a *pushed* — hence
non-itemized — element. The file passes under `raku` unchanged.

## Verification

- `cargo fmt --all`, `make lint` — clean.
- `make test` — PASS (3883 files, 41201 tests).
- `make roast` — the only failures are the three documented environment-only
  files, by name and by the exact subtest ranges listed in
  `docs/agent-environments.md`: `roast/6.c/S32-io/file-tests.t` (Failed: 4,
  tests 6-8, 10) and `roast/S16-filehandles/filetest.t` (Failed: 25, tests
  57-64, 69-72, 77-80, 101/103/105/107/109/111/117/121/125) both from running
  as `uid 0`, and `roast/S32-io/IO-Socket-Async.t` (exit 124, planned 40 ran
  17) from the sandboxed network.

Closes #7660

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PJJo83QEMRm4qnaYdqJd9E

---
_Generated by [Claude Code](https://claude.ai/code/session_01PJJo83QEMRm4qnaYdqJd9E)_