### PR TITLE
rakuast: preserve positional sub-signatures

### DIFF
--- a/docs/adr/0011-rakuast-model-layer-and-phasing.md
+++ b/docs/adr/0011-rakuast-model-layer-and-phasing.md
@@ -604,8 +604,11 @@ earlier ones.
   pointy-block parameters do not — the `signature`/`parameter`/`simple_parameter` helpers thread a
   `type_setting` flag to add it. Boundary (explicit `RuntimeError`): traits, `multi`, `is export`,
   operator subs (associativity/precedence), alternate signatures, and anonymous
-  `sub { }` (deferred). Parameters reuse the slice-3 plain-positional boundary (typed/named/slurpy/
-  `where`/… still error).
+  `sub { }` (deferred). Plain positional and array-destructuring sub-signatures are handled
+  (2026-09-09, issue #7685): `Parameter.sub-signature` is a recursive `Signature`, and the lowerer
+  rebuilds `ParamDef.sub_signature` so the existing binder executes the same destructuring. Named
+  aliases, capture sub-signatures, type captures, and array-shape metadata remain separate
+  boundaries.
 - **Routine return types (2026-08-22, both directions).** raku models the two spellings with
   different nodes and mutsu's internal AST keeps them apart, so the converter never guesses:
   `sub f(--> Int)` → `signature => Signature(parameters => …, returns => Type::Simple(Name))`

--- a/news/2026-09/rakuast-sub-signatures.md
+++ b/news/2026-09/rakuast-sub-signatures.md
@@ -1,0 +1,26 @@
+# RakuAST preserves positional sub-signatures
+
+`sub f($x ($a, $b)) { $a + $b }` and array-destructuring parameters now render
+their nested `RakuAST::Signature` instead of failing with
+`non-trivial signature parameter`. The parser already retained the distinction
+in `ParamDef.sub_signature`; this slice exposes it through the RakuAST model and
+reuses the existing signature binder when lowering.
+
+## Change
+
+- `src/rakuast/convert.rs` recursively emits `Parameter.sub-signature` for
+  ordinary positional and array-destructuring parameters.
+- `src/rakuast/mod.rs` accepts and exposes `sub-signature` on
+  `RakuAST::Parameter` construction and introspection.
+- `src/rakuast/lower.rs` recursively rebuilds nested `ParamDef` values for
+  `EVAL`, without introducing another execution path.
+
+Named aliases, capture sub-signatures, type captures, and array-shape metadata
+remain explicit follow-up boundaries.
+
+## Coverage
+
+`t/rakuast-subsig.t` pins the nested node and accessor shape, the implicit
+`Type::Setting(Any)` on nested routine parameters, positional and array
+destructuring EVAL round trips, and a hand-constructed nested signature that
+lowers and executes. It passes verbatim under both mutsu and Rakudo.

--- a/src/rakuast/convert.rs
+++ b/src/rakuast/convert.rs
@@ -2136,13 +2136,12 @@ fn signature(
     })
 }
 
-/// One `Parameter`. Only plain positional params (name + optional default) are
-/// modelled; anything richer (typed, named, slurpy, `where`, sub-signature,
-/// traits, optional-marker, invocant, shaped) is the coverage boundary.
+/// One `Parameter`. Positional sub-signatures are represented recursively as
+/// `sub-signature => Signature`; richer capture forms remain the coverage
+/// boundary.
 fn parameter(pd: &ParamDef, type_setting: bool) -> Result<RakuAstNode, RuntimeError> {
     if pd.onearg
         || pd.literal_value.is_some()
-        || pd.sub_signature.is_some()
         || !pd.traits.is_empty()
         || pd.optional_marker
         || pd.is_invocant
@@ -2152,29 +2151,45 @@ fn parameter(pd: &ParamDef, type_setting: bool) -> Result<RakuAstNode, RuntimeEr
     {
         return Err(unsupported("non-trivial signature parameter"));
     }
+    // Named aliases (`:s(:$sort)`) and capture parameters also use the
+    // internal `sub_signature` slot, but RakuAST represents those with fields
+    // other than `sub-signature`. Keep this slice to ordinary positional and
+    // array-destructuring parameters whose target is preserved by mutsu.
+    if pd.sub_signature.is_some()
+        && (pd.named || pd.slurpy || pd.double_slurpy || pd.sigilless || pd.name.starts_with("__"))
+    {
+        return Err(unsupported("non-positional signature sub-signature"));
+    }
     let (sigil, desigil) = split_sigil(&pd.name);
-    if pd.slurpy || pd.double_slurpy {
+    let mut node = if pd.slurpy || pd.double_slurpy {
         // A typed or where-constrained slurpy carries richer shape; defer.
         if pd.type_constraint.is_some() || pd.where_constraint.is_some() {
             return Err(unsupported("typed slurpy parameter"));
         }
-        return slurpy_parameter(sigil, desigil, pd.double_slurpy);
-    }
-    if pd.named {
+        slurpy_parameter(sigil, desigil, pd.double_slurpy)?
+    } else if pd.named {
         // A typed/defaulted/where-constrained named param carries richer shape.
         if pd.type_constraint.is_some() || pd.default.is_some() || pd.where_constraint.is_some() {
             return Err(unsupported("typed/defaulted named parameter"));
         }
-        return named_parameter(sigil, desigil, type_setting);
+        named_parameter(sigil, desigil, type_setting)?
+    } else {
+        simple_parameter(
+            sigil,
+            desigil,
+            pd.type_constraint.as_deref(),
+            pd.default.as_ref(),
+            type_setting,
+            pd.where_constraint.as_deref(),
+        )?
+    };
+    if let Some(sub_params) = &pd.sub_signature {
+        node.fields.push(node_field(
+            Some("sub-signature"),
+            signature(sub_params, type_setting, None)?,
+        ));
     }
-    simple_parameter(
-        sigil,
-        desigil,
-        pd.type_constraint.as_deref(),
-        pd.default.as_ref(),
-        type_setting,
-        pd.where_constraint.as_deref(),
-    )
+    Ok(node)
 }
 
 /// A slurpy parameter `*@a` / `**@a` -> `Parameter(target => …, slurpy =>

--- a/src/rakuast/lower.rs
+++ b/src/rakuast/lower.rs
@@ -607,9 +607,9 @@ fn simple_type_name(node: &RakuAstNode, type_node: &RakuAstNode) -> Result<Strin
     }
 }
 
-/// The positional scalar parameter names of a routine's `signature`, each with
-/// its `$` sigil stripped. A parameter carrying anything beyond a plain scalar
-/// `target` (a name, a slurpy/named marker, a default) is the coverage boundary.
+/// The positional parameter names of a routine's `signature`, each with its
+/// `$` sigil stripped. Nested `sub-signature` nodes are lowered recursively
+/// into `ParamDef.sub_signature`.
 #[allow(clippy::type_complexity)]
 fn signature_positional_params(
     node: &RakuAstNode,
@@ -617,108 +617,137 @@ fn signature_positional_params(
     let Ok(sig) = named_child(node, "signature") else {
         return Ok((Vec::new(), Vec::new()));
     };
-    let params = match sig.fields.iter().find(|f| f.name == Some("parameters")) {
+    let defs = lower_signature_parameters(sig, node)?;
+    let names = defs.iter().map(|def| def.name.clone()).collect();
+    Ok((names, defs))
+}
+
+fn lower_signature_parameters(
+    signature: &RakuAstNode,
+    owner: &RakuAstNode,
+) -> Result<Vec<ParamDef>, RuntimeError> {
+    if signature.class != RakuAstClass::Signature {
+        return Err(unsupported(owner));
+    }
+    let params = match signature
+        .fields
+        .iter()
+        .find(|f| f.name == Some("parameters"))
+    {
         Some(f) => match &f.value {
             RakuAstFieldValue::List(items) => items,
-            _ => return Err(unsupported(node)),
+            _ => return Err(unsupported(owner)),
         },
-        None => return Ok((Vec::new(), Vec::new())),
+        None => return Ok(Vec::new()),
     };
-    let mut names = Vec::with_capacity(params.len());
     let mut defs = Vec::with_capacity(params.len());
     for v in params {
         let ValueView::RakuAst(p) = v.view() else {
-            return Err(unsupported(node));
+            return Err(unsupported(owner));
         };
-        let target = named_child(p, "target")?;
-        if target.class != RakuAstClass::ParameterTargetVar {
-            return Err(unsupported(node));
-        }
-        let raw = leaf_str(target, "name")?;
-        let name = raw.strip_prefix('$').map(str::to_string).unwrap_or(raw);
-        let mut def = positional_param(&name);
-        // A named parameter `:$x` carries a `names` list; it binds by name and is
-        // optional by default.
-        if p.fields.iter().any(|f| f.name == Some("names")) {
-            def.named = true;
-            def.required = false;
-        }
-        // `optional => True` makes a positional parameter optional. For named
-        // parameters, an explicit False marks it required.
-        if let Some(optional) = p.fields.iter().find(|f| f.name == Some("optional")) {
-            let RakuAstFieldValue::Node(value) = &optional.value else {
-                return Err(unsupported(node));
-            };
-            let ValueView::Bool(is_optional) = value.view() else {
-                return Err(unsupported(node));
-            };
-            def.required = !is_optional;
-            def.optional_marker = is_optional;
-        }
-        // A slurpy parameter `*@a` / `**@a` carries a `slurpy` marker node.
-        if let Some(s) = p.fields.iter().find(|f| f.name == Some("slurpy")) {
-            if let RakuAstFieldValue::Node(val) = &s.value
-                && let ValueView::RakuAst(marker) = val.view()
-            {
-                match marker.class {
-                    RakuAstClass::ParameterSlurpyFlattened => def.slurpy = true,
-                    RakuAstClass::ParameterSlurpyUnflattened => def.double_slurpy = true,
-                    _ => return Err(unsupported(node)),
-                }
-                def.required = false;
-            } else {
-                return Err(unsupported(node));
-            }
-        }
-        // `Int $x` -> a type constraint. `Type::Simple` (a plain type name) is
-        // handled; the implicit `Type::Setting(Any)` on an untyped param is
-        // ignored, and richer type forms (definite/coercion/parameterised) defer.
-        if let Some(t) = p.fields.iter().find(|f| f.name == Some("type")) {
-            if let RakuAstFieldValue::Node(val) = &t.value
-                && let ValueView::RakuAst(type_node) = val.view()
-            {
-                match type_node.class {
-                    RakuAstClass::TypeSimple => {
-                        let name_node = named_child_or_positional(type_node)?;
-                        if let ValueView::Str(s) = positional_leaf(name_node)?.view() {
-                            def.type_constraint = Some(s.to_string());
-                        } else {
-                            return Err(unsupported(node));
-                        }
-                    }
-                    RakuAstClass::TypeSetting => {} // implicit `Any`
-                    _ => return Err(unsupported(node)),
-                }
-            } else {
-                return Err(unsupported(node));
-            }
-        }
-        // `$y = EXPR` -> an optional positional with a default value.
-        if let Some(d) = p.fields.iter().find(|f| f.name == Some("default")) {
-            let default_node = match &d.value {
-                RakuAstFieldValue::Node(val) => match val.view() {
-                    ValueView::RakuAst(child) => child,
-                    _ => return Err(unsupported(node)),
-                },
-                _ => return Err(unsupported(node)),
-            };
-            def.default = Some(lower_expr(default_node)?);
-            def.required = false;
-        }
-        if let Some(w) = p.fields.iter().find(|f| f.name == Some("where")) {
-            let where_node = match &w.value {
-                RakuAstFieldValue::Node(val) => match val.view() {
-                    ValueView::RakuAst(child) => child,
-                    _ => return Err(unsupported(node)),
-                },
-                _ => return Err(unsupported(node)),
-            };
-            def.where_constraint = Some(Box::new(lower_expr(where_node)?));
-        }
-        names.push(name);
-        defs.push(def);
+        defs.push(lower_parameter(p, owner)?);
     }
-    Ok((names, defs))
+    Ok(defs)
+}
+
+fn lower_parameter(parameter: &RakuAstNode, owner: &RakuAstNode) -> Result<ParamDef, RuntimeError> {
+    if parameter.class != RakuAstClass::Parameter {
+        return Err(unsupported(owner));
+    }
+    let target = named_child(parameter, "target")?;
+    if target.class != RakuAstClass::ParameterTargetVar {
+        return Err(unsupported(owner));
+    }
+    let raw = leaf_str(target, "name")?;
+    let name = raw.strip_prefix('$').map(str::to_string).unwrap_or(raw);
+    let mut def = positional_param(&name);
+    // A named parameter `:$x` carries a `names` list; it binds by name and is
+    // optional by default.
+    if parameter.fields.iter().any(|f| f.name == Some("names")) {
+        def.named = true;
+        def.required = false;
+    }
+    // `optional => True` makes a positional parameter optional. For named
+    // parameters, an explicit False marks it required.
+    if let Some(optional) = parameter.fields.iter().find(|f| f.name == Some("optional")) {
+        let RakuAstFieldValue::Node(value) = &optional.value else {
+            return Err(unsupported(owner));
+        };
+        let ValueView::Bool(is_optional) = value.view() else {
+            return Err(unsupported(owner));
+        };
+        def.required = !is_optional;
+        def.optional_marker = is_optional;
+    }
+    // A slurpy parameter `*@a` / `**@a` carries a `slurpy` marker node.
+    if let Some(s) = parameter.fields.iter().find(|f| f.name == Some("slurpy")) {
+        if let RakuAstFieldValue::Node(val) = &s.value
+            && let ValueView::RakuAst(marker) = val.view()
+        {
+            match marker.class {
+                RakuAstClass::ParameterSlurpyFlattened => def.slurpy = true,
+                RakuAstClass::ParameterSlurpyUnflattened => def.double_slurpy = true,
+                _ => return Err(unsupported(owner)),
+            }
+            def.required = false;
+        } else {
+            return Err(unsupported(owner));
+        }
+    }
+    // `Int $x` -> a type constraint. `Type::Simple` (a plain type name) is
+    // handled; the implicit `Type::Setting(Any)` on an untyped param is
+    // ignored, and richer type forms (definite/coercion/parameterised) defer.
+    if let Some(t) = parameter.fields.iter().find(|f| f.name == Some("type")) {
+        if let RakuAstFieldValue::Node(val) = &t.value
+            && let ValueView::RakuAst(type_node) = val.view()
+        {
+            match type_node.class {
+                RakuAstClass::TypeSimple => {
+                    let name_node = named_child_or_positional(type_node)?;
+                    if let ValueView::Str(s) = positional_leaf(name_node)?.view() {
+                        def.type_constraint = Some(s.to_string());
+                    } else {
+                        return Err(unsupported(owner));
+                    }
+                }
+                RakuAstClass::TypeSetting => {} // implicit `Any`
+                _ => return Err(unsupported(owner)),
+            }
+        } else {
+            return Err(unsupported(owner));
+        }
+    }
+    // `$y = EXPR` -> an optional positional with a default value.
+    if let Some(d) = parameter.fields.iter().find(|f| f.name == Some("default")) {
+        let default_node = match &d.value {
+            RakuAstFieldValue::Node(val) => match val.view() {
+                ValueView::RakuAst(child) => child,
+                _ => return Err(unsupported(owner)),
+            },
+            _ => return Err(unsupported(owner)),
+        };
+        def.default = Some(lower_expr(default_node)?);
+        def.required = false;
+    }
+    if let Some(w) = parameter.fields.iter().find(|f| f.name == Some("where")) {
+        let where_node = match &w.value {
+            RakuAstFieldValue::Node(val) => match val.view() {
+                ValueView::RakuAst(child) => child,
+                _ => return Err(unsupported(owner)),
+            },
+            _ => return Err(unsupported(owner)),
+        };
+        def.where_constraint = Some(Box::new(lower_expr(where_node)?));
+    }
+    if let Some(sub_signature) = parameter
+        .fields
+        .iter()
+        .find(|f| f.name == Some("sub-signature"))
+    {
+        let sub_signature = child_node(&sub_signature.value)?;
+        def.sub_signature = Some(lower_signature_parameters(sub_signature, owner)?);
+    }
+    Ok(def)
 }
 
 /// A default positional (required, non-slurpy, untyped) `ParamDef` for `name`.

--- a/src/rakuast/mod.rs
+++ b/src/rakuast/mod.rs
@@ -770,7 +770,7 @@ pub fn construct(
             RakuAstClass::ParameterTargetVar,
             "RakuAST::Parameter.new",
         )?;
-        let mut fields = Vec::with_capacity(5);
+        let mut fields = Vec::with_capacity(6);
         if let Some(type_node) = named_arg(args, "type") {
             require_rakuast_type(&type_node, "RakuAST::Parameter.new")?;
             fields.push(RakuAstField {
@@ -832,6 +832,17 @@ pub fn construct(
             fields.push(RakuAstField {
                 name: Some("slurpy"),
                 value: RakuAstFieldValue::Node(slurpy),
+            });
+        }
+        if let Some(sub_signature) = named_arg(args, "sub-signature") {
+            require_rakuast_class(
+                &sub_signature,
+                RakuAstClass::Signature,
+                "RakuAST::Parameter.new",
+            )?;
+            fields.push(RakuAstField {
+                name: Some("sub-signature"),
+                value: RakuAstFieldValue::Node(sub_signature),
             });
         }
         return Ok(Some(Value::rakuast(Box::new(RakuAstNode {
@@ -1236,7 +1247,14 @@ fn accessor_names(class: RakuAstClass) -> &'static [&'static str] {
         MetaInfixHyper => &["dwim-left", "infix", "dwim-right"],
         TraitReturns | TraitOf => &["type"],
         Parameter => &[
-            "type", "names", "target", "optional", "default", "where", "slurpy",
+            "type",
+            "names",
+            "target",
+            "optional",
+            "default",
+            "where",
+            "slurpy",
+            "sub-signature",
         ],
         ParameterTargetVar => &["name"],
         VarDeclarationSimple => &["sigil", "desigilname", "initializer"],

--- a/t/rakuast-subsig.t
+++ b/t/rakuast-subsig.t
@@ -1,0 +1,79 @@
+use v6;
+use MONKEY-SEE-NO-EVAL;
+use experimental :rakuast;
+use Test;
+
+# RakuAST positional/destructuring sub-signatures. The parser already keeps
+# these in ParamDef.sub_signature, so this slice covers the model conversion,
+# construction, and lowering without changing the execution pipeline.
+
+plan 11;
+
+my $ast = Q[sub f($x ($a, $b)) { $a + $b }].AST;
+my $gist = $ast.gist;
+ok $gist.contains('sub-signature => RakuAST::Signature.new('),
+    'a positional sub-signature renders as a nested Signature';
+is $ast.statements[0].expression.signature.parameters[0].sub-signature.^name,
+    'RakuAST::Signature',
+    'the sub-signature accessor returns a Signature node';
+is $ast.statements[0].expression.signature.parameters[0].sub-signature.parameters.elems,
+    2,
+    'the nested Signature exposes its parameters';
+my @inner-parameters = $ast.statements[0].expression.signature.parameters[0]
+    .sub-signature.parameters;
+is @inner-parameters[0].type.^name,
+    'RakuAST::Type::Setting',
+    'nested routine parameters retain the implicit Any type';
+my @parameter-methods = RakuAST::Parameter.^methods(:local)>>.name;
+ok 'sub-signature' (elem) @parameter-methods,
+    'Parameter introspection exposes the sub-signature accessor';
+
+is EVAL(Q[sub f($x ($a, $b)) { $a + $b }; f([10, 32])].AST),
+    42,
+    'a positional sub-signature round-trips through EVAL';
+
+my $array-ast = Q[sub g(@x [$a, $b]) { $a + $b }].AST;
+is $array-ast.statements[0].expression.signature.parameters[0].target.name,
+    '@x',
+    'an array destructuring sub-signature retains its array target';
+ok $array-ast.gist.contains('sub-signature => RakuAST::Signature.new('),
+    'an array destructuring sub-signature renders recursively';
+is EVAL(Q[sub g(@x [$a, $b]) { $a + $b }; g([10, 32])].AST),
+    42,
+    'an array destructuring sub-signature executes after EVAL';
+
+sub target($name) {
+    RakuAST::ParameterTarget::Var.new(name => $name)
+}
+
+sub parameter($name) {
+    RakuAST::Parameter.new(target => target($name))
+}
+
+my $inner = RakuAST::Signature.new(
+    parameters => [parameter('$a'), parameter('$b')],
+);
+my $outer = RakuAST::Parameter.new(
+    target => target('$x'),
+    sub-signature => $inner,
+);
+is $outer.sub-signature, $inner,
+    'Parameter.new accepts and exposes a constructed sub-signature';
+
+my $sum = RakuAST::ApplyInfix.new(
+    left => RakuAST::Var::Lexical.new('$a'),
+    infix => RakuAST::Infix.new('+'),
+    right => RakuAST::Var::Lexical.new('$b'),
+);
+my $statements = RakuAST::StatementList.new;
+$statements.add-statement(
+    RakuAST::Statement::Expression.new(expression => $sum),
+);
+my $body = RakuAST::Blockoid.new($statements);
+my $constructed = RakuAST::Sub.new(
+    signature => RakuAST::Signature.new(parameters => [$outer]),
+    body => $body,
+);
+my $callable = EVAL($constructed);
+is $callable([10, 32]), 42,
+    'a constructed sub-signature lowers and executes';


### PR DESCRIPTION
## Summary

- preserve positional and array-destructuring sub-signatures in RakuAST read conversion
- expose `Parameter.sub-signature` through construction and accessors, and recursively lower it for `EVAL`
- add dual-oracle regression coverage and document the remaining boundaries

Closes #7685

Related to #7564

## Validation

- `make lint`
- `make test`
- `make roast`
