### PR TITLE
fix: make placeholder block parameters readonly

### DIFF
--- a/docs/adr/0048-placeholder-scope-is-a-block-invocation-contract.md
+++ b/docs/adr/0048-placeholder-scope-is-a-block-invocation-contract.md
@@ -1,6 +1,6 @@
 # ADR-0048: Placeholder scope is a per-construct block-invocation contract, not a per-AST-arm boundary flag
 
-- Status: Accepted (P1-P4 landed; P5's scope half landed, its value half deferred — see Phase 5)
+- Status: Accepted (P1-P4 landed; P5's scope half landed, its value half deferred; P6 landed — see Phase 6)
 - Date: 2026-08-20
 - Supersedes the framing of: `todo/deep/placeholder-scope-loop-while-block-boundaries.md`
   (and, transitively, the retired `todo/tickets/placeholder-scope-while-loop-not-a-boundary.md`).
@@ -624,6 +624,19 @@ not a real `Mu` either — it is one null per declared placeholder, which is wha
      role body for now. Recorded in
      `todo/deep/role-body-placeholder-mu-supply.md` and pinned (both the
      divergence and the arity fix) in `t/placeholder-scope-rejecting.t`.
+6. **Readonly placeholder parameters (A6, #7556): LANDED (2026-09-09).**
+   A scalar placeholder parameter such as `$^x` is a non-`rw` alias and must
+   reject assignment just like an ordinary non-`rw` scalar parameter. The
+   shallow placeholder collector now also inspects statement assignment
+   targets, so a block whose only use is `{ $^x = 9 }` still gets the implicit
+   `^x` parameter. The VM marks scalar caret/named placeholder parameters at
+   each closure call site while the call's readonly frame is active; the
+   native map/grep/first fast paths apply the same mark inside their existing
+   readonly guards. This keeps the mark scoped to one invocation and avoids a
+   body `MarkReadonly` prologue leaking through `run_reuse`.
+   `t/placeholder-block-readonly.t` pins direct calls plus map, grep, and first
+   fast loops, and `news/2026-09/placeholder-block-params-readonly.md` records
+   the user-visible change.
 
 ## Verification
 

--- a/news/2026-09/placeholder-block-params-readonly.md
+++ b/news/2026-09/placeholder-block-params-readonly.md
@@ -1,0 +1,8 @@
+# Placeholder block parameters are readonly
+
+Placeholder block parameters such as `$^x` now reject assignments with the
+same readonly-variable error as ordinary non-`rw` scalar parameters. The mark
+is applied at each call site, including map, grep, and first fast loops, so it is
+scoped to the invocation and does not leak into later bindings.
+
+Resolves Section A6 of #7556.

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -2900,7 +2900,10 @@ fn collect_ph_stmt_shallow(stmt: &Stmt, out: &mut Vec<String>) {
         | Stmt::Goto(e) => {
             collect_ph_expr_shallow(e, out);
         }
-        Stmt::VarDecl { expr, .. } | Stmt::Assign { expr, .. } => {
+        Stmt::VarDecl { name, expr, .. } | Stmt::Assign { name, expr, .. } => {
+            // A placeholder can occur only as an assignment target. It still
+            // declares a parameter of the surrounding placeholder block.
+            push_if_placeholder(name, out);
             collect_ph_expr_shallow(expr, out)
         }
         Stmt::Call { args, .. } => {

--- a/src/runtime/resolution_map_grep.rs
+++ b/src/runtime/resolution_map_grep.rs
@@ -715,6 +715,7 @@ impl Interpreter {
                     // `resolution_map_grep_rw.rs`).
                     let _readonly_guard =
                         crate::vm::vm_call_state_guard::ReadonlyFrameGuard::new(vm);
+                    vm.mark_placeholder_params_readonly(&data.params);
                     set_loop_topic_readonly(vm, immutable_topic);
                     match vm.run_reuse(&code, &compiled_fns) {
                         Ok(()) => {
@@ -1035,6 +1036,7 @@ impl Interpreter {
                     // permanently (see the sibling comment in the grep loop).
                     let _readonly_guard =
                         crate::vm::vm_call_state_guard::ReadonlyFrameGuard::new(vm);
+                    vm.mark_placeholder_params_readonly(&data.params);
                     set_loop_topic_readonly(vm, immutable_topic);
                     match vm.run_reuse(&code, &compiled_fns) {
                         Ok(()) => {

--- a/src/runtime/resolution_map_grep_rw.rs
+++ b/src/runtime/resolution_map_grep_rw.rs
@@ -376,6 +376,7 @@ impl Interpreter {
                     // same isolation `call_compiled_closure_with_topic` does.
                     let _readonly_guard =
                         crate::vm::vm_call_state_guard::ReadonlyFrameGuard::new(vm);
+                    vm.mark_placeholder_params_readonly(&data.params);
                     super::resolution_map_grep::set_loop_topic_readonly(vm, immutable_topic);
                     match vm.run_reuse(&code, &compiled_fns) {
                         Ok(()) => {
@@ -725,6 +726,7 @@ impl Interpreter {
                         // leak permanently (see `mark_readonly_sym_with`).
                         let _readonly_guard =
                             crate::vm::vm_call_state_guard::ReadonlyFrameGuard::new(vm);
+                        vm.mark_placeholder_params_readonly(&data.params);
                         super::resolution_map_grep::set_loop_topic_readonly(vm, immutable_topic);
                         match vm.run_reuse(&code, &compiled_fns) {
                             Ok(()) => {

--- a/src/runtime/types/mod.rs
+++ b/src/runtime/types/mod.rs
@@ -261,6 +261,24 @@ impl Interpreter {
         self.mark_readonly_sym(Symbol::intern(name));
     }
 
+    /// Mark the scalar parameters synthesized for a placeholder block as
+    /// readonly aliases. Placeholder parameters are stored with their twigil
+    /// (`^name`/`:name`) in `SubData::params`, and assignment targets preserve
+    /// that name. Also mark the de-twigilled spelling because reads and some
+    /// lowered writes resolve through that alias. Aggregate placeholders have
+    /// their own container semantics and are deliberately left out here.
+    pub(crate) fn mark_placeholder_params_readonly(&mut self, params: &[String]) {
+        for param in params {
+            let Some(name) = param.strip_prefix('^').or_else(|| param.strip_prefix(':')) else {
+                continue;
+            };
+            if !name.is_empty() {
+                self.mark_readonly(param);
+                self.mark_readonly(name);
+            }
+        }
+    }
+
     /// Mark a variable as readonly, recording *why*.
     pub(crate) fn mark_readonly_with(&mut self, name: &str, kind: ReadonlyKind) {
         self.mark_readonly_sym_with(Symbol::intern(name), kind);

--- a/src/vm/vm_closure_dispatch.rs
+++ b/src/vm/vm_closure_dispatch.rs
@@ -644,6 +644,15 @@ impl Interpreter {
             }
         };
 
+        // Placeholder parameters (`{ $^x = ... }`) are readonly aliases in
+        // Raku, just like ordinary non-rw scalar parameters. They use the
+        // legacy parameter binder, so the ordinary ParamDef readonly marking
+        // does not see them. Mark at the call site while this call's readonly
+        // frame is active; putting a MarkReadonly in the body would leak from
+        // native map/grep/first loops that execute the body without a call
+        // frame.
+        self.mark_placeholder_params_readonly(&data.params);
+
         // A plain `$`-sigiled single pointy-block parameter (`-> $v { }`,
         // `cc.pointy_alias_param`) reached `bind_function_args_values`'s
         // legacy path above (empty `param_defs`), which carries no trait

--- a/t/placeholder-block-readonly.t
+++ b/t/placeholder-block-readonly.t
@@ -1,0 +1,26 @@
+use Test;
+
+# A scalar placeholder parameter is a readonly alias. This is distinct from
+# the implicit topic of a bare block: the placeholder remains readonly even
+# when the callback receives a real array element.
+plan 5;
+
+throws-like { my $b = { $^x = 9 }; $b(1) }, X::AdHoc,
+    message => /'Cannot assign to a readonly variable or a value'/,
+    'a scalar placeholder parameter rejects assignment';
+
+throws-like { my $v = 1; my $b = { $^x = 9 }; $b($v) }, X::AdHoc,
+    message => /'Cannot assign to a readonly variable or a value'/,
+    'a scalar placeholder parameter rejects assignment from a variable';
+
+throws-like { my @a = 1, 2; @a.map({ $^x = 9 }).eager }, X::AdHoc,
+    message => /'Cannot assign to a readonly variable or a value'/,
+    'a map fast loop keeps scalar placeholder parameters readonly';
+
+throws-like { my @a = 1, 2; @a.grep({ $^x = 9 }).eager }, X::AdHoc,
+    message => /'Cannot assign to a readonly variable or a value'/,
+    'a grep fast loop keeps scalar placeholder parameters readonly';
+
+throws-like { my @a = 1, 2; @a.first({ $^x = 9 }) }, X::AdHoc,
+    message => /'Cannot assign to a readonly variable or a value'/,
+    'a first fast loop keeps scalar placeholder parameters readonly';


### PR DESCRIPTION
## Summary

- Count assignment-target placeholders when deriving a bare block signature.
- Mark scalar placeholder parameters readonly at closure call sites and in map/grep/first fast loops, within the invocation readonly frame.
- Add regression coverage, news, and the ADR-0048 Phase 6 record.

Part of #7556 (Section A6).

## Validation

- `make lint`
- `make test`
- `make roast`