### PR TITLE
docs: split tier:icebox by reason with a new icebox:* label axis

### DIFF
--- a/docs/issue-workflow.md
+++ b/docs/issue-workflow.md
@@ -67,7 +67,40 @@ Leave it off when you file; a missing tier just means "not yet triaged".
 | `tier:S` | Soundness. Silent data loss, hangs, wrong answers with no diagnostic. |
 | `tier:B` | Broad correctness — a whole language construct, or a dist-blocking battery gap. |
 | `tier:N` | Narrow correctness, diagnostics, permissiveness. |
-| `tier:icebox` | Blocked on a decision, or a pure record with no actionable next step. |
+| `tier:icebox` | Not in the queue. **Why** it is not is a separate label — see the icebox-reason axis below, which every `tier:icebox` issue also carries. |
+
+### Icebox reason — why an iceboxed issue is not queued
+
+`tier:icebox` says an issue is out of the queue; it does not say *why*, and the
+reasons are not interchangeable. One is unblocked by somebody making a decision,
+another by an unrelated PR merging, another by nothing at all. Carrying them
+under one label made the whole icebox read as "ignore this", which is wrong for
+three of the four.
+
+**Every `tier:icebox` issue also carries exactly one `icebox:*` label**, chosen
+by a single question: *what would make this actionable?*
+
+| Label | Meaning | What makes it actionable |
+| --- | --- | --- |
+| `icebox:decision` | A design or product call has to be made before any code. The shape of the fix is genuinely open — typically the body says it "wants an ADR paragraph", or names a measurement whose result decides the design. | Somebody deciding: an ADR, an amendment to one, or a user call on a question CLAUDE.md reserves for them. |
+| `icebox:blocked` | The design is settled; it waits on *other* work landing — another issue, or a slice of an ADR that already exists. **The body must name the blocker** as an issue number or an ADR slice. A blocker named only as a `todo/...md` path is stale: add a comment giving the issue number. | That work merging. The issue then becomes ordinary queue work. |
+| `icebox:opportunistic` | Real, understood, and measured as not worth a session of its own — a corpus scan found no consumers, or what remains is a non-gating cleanup. Not blocked on anything and not waiting for a decision. | Somebody being in that code for another reason. Land it as a rider on the next change that touches the same plumbing. |
+| `icebox:record` | No actionable next step at all. The issue exists so a settled decision or an expensive measurement is not re-derived, and it states its own reopen conditions. | Only those reopen conditions coming true — and then a re-measurement, never the recorded numbers. |
+
+The distinction that matters most is **`decision` vs `blocked`**: a `decision`
+issue is waiting on *this project's judgement* and can be unblocked in a single
+conversation, while a `blocked` one is waiting on *code* and cannot be hurried
+by talking about it. Reading an icebox listing without that split makes both
+look equally dead.
+
+Relabel freely as the state changes — the reason is a property of *now*, not of
+the filing. An `icebox:decision` issue becomes `icebox:blocked` the moment its
+ADR is written but not yet implemented, and an `icebox:blocked` issue whose
+blocker lands leaves the icebox entirely: drop both labels and let the next
+triage regen tier it.
+
+A `tier:icebox` issue with no `icebox:*` label has not been classified since
+2026-09-09. Treat that as unknown, not as `icebox:record`.
 
 ### `working` — someone is on it right now
 

--- a/docs/triage.md
+++ b/docs/triage.md
@@ -13,6 +13,13 @@ Read it accordingly:
 - The **tier this file assigns is now a label on the issue** (`tier:S`,
   `tier:B`, `tier:N`, `tier:icebox`), applied from the rows below. An issue
   with no tier label has not been triaged since the migration.
+- **`tier:icebox` no longer stands alone.** Since 2026-09-09 every iceboxed
+  issue also carries an `icebox:*` label saying why it is out of the queue —
+  `icebox:decision`, `icebox:blocked`, `icebox:opportunistic` or
+  `icebox:record`; see [issue-workflow.md](issue-workflow.md). A regen must
+  reconcile that label too, and it is the one place this file's own prose was
+  actively misleading: the four states differ in *who* unblocks them, not in
+  how much they matter.
 - Nothing here has been re-verified against the current `main`.
 
 This is a **snapshot, not a ledger**. Resolving an issue does *not* require
@@ -143,8 +150,12 @@ first probe tried was a near-miss of the one that fails.
   message*, or mutsu accepting code raku rejects.
 - **Perf.** Batched into their own profiling-heavy session; the
   implementation agent for a perf item **runs solo**.
-- **Icebox.** Blocked on a design decision or an explicit user call, or a
-  pure decision/measurement/cleanup record with no failing repro.
+- **Icebox.** Out of the queue. Four distinct states, kept apart by the
+  `icebox:*` axis rather than lumped together: blocked on a design decision or
+  an explicit user call (`icebox:decision`); waiting on another issue or ADR
+  slice landing (`icebox:blocked`); real but measured as not worth a session of
+  its own, to be ridden along on nearby work (`icebox:opportunistic`); or a
+  pure decision/measurement record with no next step (`icebox:record`).
 
 **Effort** (S/M/L/XL) is shown but does not change tier.
 

--- a/news/2026-09/icebox-reason-labels.md
+++ b/news/2026-09/icebox-reason-labels.md
@@ -1,0 +1,39 @@
+# The icebox now says why: an `icebox:*` reason axis beside `tier:icebox`
+
+`tier:icebox` recorded that an issue was out of the queue but not why, and the
+seven issues carrying it turned out to be in four genuinely different states.
+Two were waiting on a design call this project can make in one conversation
+(#7542's itemization representation "wants an ADR paragraph"; #7547's LSP
+`references` side table needs a measurement before ADR-0065 D6 can be amended).
+Two were waiting on code, not judgement (#7545's R5 sits behind #7554; #7546's
+two structural gaps are retired by ADR-0055 slices 3-5). One was a settled
+decision kept so it is not re-derived (#7560, NativeCall's 61-op gap, with
+explicit reopen conditions). Two were real, understood, and measured as not
+worth a session of their own (#7550 has zero corpus hits and rakudo's own
+behaviour there is a `VMNull` artifact; #7540's E2 remnant is a non-gating
+cleanup behind a monitoring counter).
+
+Those four states differ in **who unblocks them**, which is exactly what a
+priority tier cannot express. Under one label the whole icebox read as "ignore
+this" — wrong for three of the four, and most wrong for the decision-blocked
+pair, which is the only group a maintainer can clear by deciding.
+
+So the icebox reason became its own axis. `tier:icebox` stays as the ranking
+value, so the triage regen's contract and every existing listing query are
+unchanged; alongside it every iceboxed issue now carries exactly one of
+`icebox:decision`, `icebox:blocked`, `icebox:opportunistic` or `icebox:record`.
+The label is chosen by one question — *what would make this actionable?* —
+which is also what makes relabelling mechanical as the state moves: a
+`decision` issue becomes `blocked` once its ADR is written, and a `blocked`
+issue leaves the icebox entirely when its blocker merges.
+
+`icebox:blocked` carries one obligation the others do not: the body must name
+its blocker as an issue number or an ADR slice. Half the current pair named it
+as a `todo/...md` path instead, which stopped resolving at the 2026-09-08
+migration — the same rot that motivated moving the backlog to issues in the
+first place.
+
+All seven open issues were classified, and the axis is documented in
+[`docs/issue-workflow.md`](../../docs/issue-workflow.md); `docs/triage.md`'s
+ranking prose, which described the icebox as a single state, was corrected to
+match.


### PR DESCRIPTION
`tier:icebox` recorded that an issue was out of the queue but not *why*, and the seven issues carrying it turned out to be in four genuinely different states:

| Issue | State | New label |
| --- | --- | --- |
| #7542 `ContainerRef`/Hash itemization | the real fix "wants an ADR paragraph"; a stopgap is in place | `icebox:decision` |
| #7547 LSP `references` side table | needs a measurement, then an ADR-0065 D6/S5b amendment | `icebox:decision` |
| #7545 `X::` exception ancestry | only R5 left, gated on #7554 landing | `icebox:blocked` |
| #7546 `call_compiled_closure` `merge_all` | structural only; retired by ADR-0055 slices 3-5 | `icebox:blocked` |
| #7540 ADR-0019 E2/E3/E4 | E3/E4 closed; E2 is a non-gating cleanup behind a monitoring counter | `icebox:opportunistic` |
| #7550 `role` body placeholder `Mu` | zero corpus hits, and rakudo's own behaviour there is a `VMNull` artifact | `icebox:opportunistic` |
| #7560 NativeCall cannot be vendored | settled decision with explicit reopen conditions; no next step | `icebox:record` |

Those four states differ in **who unblocks them**, which is exactly what a priority tier cannot express. Under one label the whole icebox read as "ignore this" — wrong for three of the four, and most wrong for the decision-blocked pair, the only group a maintainer can clear by deciding.

## What changed

- **A new orthogonal reason axis**, documented in `docs/issue-workflow.md`. `tier:icebox` stays as the ranking value — so the triage regen's contract and every existing listing query are unchanged — and every iceboxed issue additionally carries exactly one of `icebox:decision`, `icebox:blocked`, `icebox:opportunistic`, `icebox:record`. The label is picked by one question: *what would make this actionable?* That is also what makes relabelling mechanical as the state moves (a `decision` issue becomes `blocked` once its ADR is written; a `blocked` issue leaves the icebox entirely when its blocker merges).
- **`icebox:blocked` carries one extra obligation**: the body must name its blocker as an issue number or an ADR slice. #7545 named it as `todo/deep/vendor-real-test-module.md` instead — a path that stopped resolving at the 2026-09-08 migration, which is the same rot that motivated moving the backlog to issues — so a comment there now gives the number (#7554).
- **`docs/triage.md` corrected.** Its "How the ranking works" prose described the icebox as a single state; it now names the four and points at the axis, and the header note on tier labels says a regen must reconcile `icebox:*` too.
- **`news/2026-09/icebox-reason-labels.md`** records the change.

All seven open issues were classified on GitHub while this PR was written — the labels are live, this PR is the documentation half.

## Follow-up the MCP surface could not do

The four labels were auto-created by applying them, so they all have GitHub's default grey (`ededed`) and no description. Setting colours/descriptions needs the labels API, which this session (a remote container, no `gh`) cannot reach. Worth a minute in the web UI; nothing depends on it.

Docs-only, so `ci.yml`'s build jobs are expected to report `skipped` (verified: `scripts/ci-docs-only.sh --classify` says `true` for this diff) — that counts as success for branch protection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XKLPM3gVtEVUPM8CxMhkVY

---
_Generated by [Claude Code](https://claude.ai/code/session_01XKLPM3gVtEVUPM8CxMhkVY)_