### PR TITLE
fix: preserve scalar aggregate itemization in .raku

### DIFF
--- a/news/2026-09/scalar-held-container-raku-itemization.md
+++ b/news/2026-09/scalar-held-container-raku-itemization.md
@@ -1,0 +1,8 @@
+# Scalar-held arrays and hashes retain their `.raku` itemization
+
+`$scalar = @array` and `$scalar = %hash` now retain Rakudo's `$` marker in
+`.raku`, including when the value is an `is Array` or `is Hash` subclass. The
+shared container remains usable for method calls, indexing, and write-through
+mutation.
+
+Fixes #7658.

--- a/src/builtins/methods_0arg/mod.rs
+++ b/src/builtins/methods_0arg/mod.rs
@@ -390,7 +390,12 @@ pub(crate) fn native_method_0arg(
         if method == "raku" || method == "perl" {
             return Some(Ok(Value::str(raku_repr::raku_value(target))));
         }
-        return native_method_0arg(inner, method_sym);
+        let inner = if inner.is_container_ref() {
+            inner.deref_container()
+        } else {
+            inner.clone()
+        };
+        return native_method_0arg(&inner, method_sym);
     }
 
     // `.dynamic` on a container VALUE — a literal `[1,2,3]`/`{a=>1}`, or an

--- a/src/builtins/methods_0arg/raku_repr.rs
+++ b/src/builtins/methods_0arg/raku_repr.rs
@@ -181,6 +181,19 @@ pub(crate) const RAKU_RAW_KEY: &str = "__mutsu_raku_raw";
 /// placeholder erased the element's Iterable-ness and the comma was dropped.
 pub(crate) const RAKU_RAW_ITERABLE_KEY: &str = "__mutsu_raku_raw_iterable";
 
+/// Marker attached to an Array/Hash subclass when a scalar assignment stores
+/// it in a `$` slot. The instance itself stays bare for normal type and method
+/// semantics; only the `.raku` renderer observes this marker.
+pub(crate) const RAKU_SCALAR_ITEMIZED_KEY: &str = "__mutsu_raku_scalar_itemized";
+
+pub(crate) fn raku_scalar_itemized(v: &Value) -> bool {
+    matches!(
+        v.view(),
+        ValueView::Instance { attributes, .. }
+            if attributes.contains_key(RAKU_SCALAR_ITEMIZED_KEY)
+    )
+}
+
 /// Wrap an already-rendered `.raku` fragment so `raku_value` emits it verbatim.
 pub(crate) fn raku_raw(rendered: String) -> Value {
     Value::pair(RAKU_RAW_KEY.to_string(), Value::str(rendered))
@@ -464,6 +477,17 @@ pub(crate) fn itemize_scalar_repr(v: &Value, base: String) -> String {
                 format!("$({base})")
             }
         }
+        // An `is Array` / `is Hash` subclass is rendered through the
+        // interpreter-side dispatch placeholder. Preserve the fact that the
+        // placeholder came from an Iterable instance, so an explicit scalar
+        // container around it still prints the `$` marker.
+        ValueView::Pair(name, _) if name == RAKU_RAW_ITERABLE_KEY => {
+            if base.starts_with(['{', '[', '(']) {
+                format!("${base}")
+            } else {
+                format!("$({base})")
+            }
+        }
         ValueView::Seq(_) => format!("$({base})"),
         _ => base,
     }
@@ -505,6 +529,11 @@ fn raku_value_as_element(v: &Value) -> String {
             raku_value(&v.clone().with_hash_itemized(false))
         }
         ValueView::Scalar(inner) if matches!(inner.view(), ValueView::Seq(_)) => raku_value(inner),
+        // A scalar-held Array/Hash subclass is expanded to a raw `.raku`
+        // placeholder before the outer array is rendered. Real `@` elements
+        // decontainerize that wrapper, just as they do for an itemized native
+        // Array/Hash, so the placeholder must not reintroduce `$` here.
+        ValueView::Scalar(inner) if raku_raw_repr(inner).is_some() => raku_value(inner),
         // A `:=`-bound element holds a `ContainerRef` cell (ADR-0036's
         // element-cell promotion). Its contents are itemized like any other
         // stored element (ADR-0040 slices 1-2), so the de-itemization above

--- a/src/runtime/builtins_multidim_assign.rs
+++ b/src/runtime/builtins_multidim_assign.rs
@@ -3,6 +3,17 @@ use super::*;
 use crate::value::ValueView;
 
 impl Interpreter {
+    fn deref_lvalue_value(mut value: Value) -> Value {
+        for _ in 0..256 {
+            match value.view() {
+                ValueView::ContainerRef(_) => value = value.deref_container(),
+                ValueView::Scalar(inner) => value = inner.clone(),
+                _ => return value,
+            }
+        }
+        value
+    }
+
     fn detached_lvalue_value(value: &Value) -> Value {
         match value.view() {
             ValueView::ContainerRef(cell) => {
@@ -121,12 +132,13 @@ impl Interpreter {
         // when `invocant_guard` above already locked this thread's one stripe.
         let attr_cell_addr = match current.view() {
             ValueView::ContainerRef(cell) => Some(crate::gc::Gc::as_ptr(&cell) as usize),
+            ValueView::Scalar(inner) if inner.is_container_ref() => match inner.view() {
+                ValueView::ContainerRef(cell) => Some(crate::gc::Gc::as_ptr(&cell) as usize),
+                _ => None,
+            },
             _ => None,
         };
-        let current = match current.view() {
-            ValueView::ContainerRef(cell) => cell.lock().unwrap().clone(),
-            _ => current,
-        };
+        let current = Self::deref_lvalue_value(current);
         let _struct_guard = invocant_guard.or_else(|| {
             crate::value::container_lock::ContainerStructGuard::acquire_for(
                 attr_cell_addr,

--- a/src/runtime/methods_call_dispatch.rs
+++ b/src/runtime/methods_call_dispatch.rs
@@ -329,6 +329,12 @@ impl Interpreter {
         // receiver by stringifying it, which is how `$v."$m"()` with `$m` =
         // `join` answered `R()` instead of `12` even though the call reached
         // this function's own tail.
+        if method == "raku"
+            && crate::builtins::methods_0arg::raku_repr::raku_scalar_itemized(&target)
+            && let Some(rendered) = self.raku_repr_with_dispatch(&target)
+        {
+            return Ok(Value::str(rendered));
+        }
         if self.delegates_to_array_storage(&target, method)
             && let ValueView::Instance { attributes, .. } = target.view()
         {
@@ -638,8 +644,23 @@ impl Interpreter {
                     crate::builtins::methods_0arg::raku_repr::raku_value(&target),
                 ));
             }
-            let inner = inner.clone();
+            // A scalar shared with an array/hash variable is represented as
+            // `Scalar(ContainerRef(cell))`: keep the outer wrapper for the
+            // renderer, but read through the cell for every ordinary method.
+            // Otherwise `$shared.elems` sees the wrapper as a one-element value
+            // and mutators such as `.push` fail to reach the backing container.
+            let inner = if inner.is_container_ref() {
+                inner.deref_container()
+            } else {
+                inner.clone()
+            };
             return self.call_method_with_values(inner, method, args);
+        }
+        if method == "raku"
+            && crate::builtins::methods_0arg::raku_repr::raku_scalar_itemized(&target)
+            && let Some(rendered) = self.raku_repr_with_dispatch(&target)
+        {
+            return Ok(Value::str(rendered));
         }
         // An itemized Array/List invocant is likewise a Scalar container:
         // method dispatch decontainerizes it (`$list.tail` reaches the last

--- a/src/runtime/methods_raku_dispatch.rs
+++ b/src/runtime/methods_raku_dispatch.rs
@@ -16,7 +16,8 @@
 
 use super::Interpreter;
 use crate::builtins::methods_0arg::raku_repr::{
-    needs_raku_dispatch, raku_leaf_is_iterable, raku_raw, raku_raw_iterable,
+    RAKU_SCALAR_ITEMIZED_KEY, needs_raku_dispatch, raku_leaf_is_iterable, raku_raw,
+    raku_raw_iterable, raku_scalar_itemized,
 };
 use crate::value::{ArrayData, HashData, RuntimeError, Value, ValueView};
 
@@ -137,6 +138,29 @@ pub(crate) fn container_needs_raku_dispatch(value: &Value) -> bool {
 }
 
 impl Interpreter {
+    fn raku_dispatch_target(value: &Value) -> Value {
+        let ValueView::Instance {
+            class_name,
+            attributes,
+            id,
+        } = value.view()
+        else {
+            return value.clone();
+        };
+        if !attributes.contains_key(RAKU_SCALAR_ITEMIZED_KEY) {
+            return value.clone();
+        }
+        let mut attrs = attributes.to_map();
+        attrs.remove(RAKU_SCALAR_ITEMIZED_KEY);
+        Value::instance_parts(
+            class_name,
+            crate::gc::Gc::new(crate::value::InstanceAttrs::new(
+                class_name, attrs, id, true,
+            )),
+            id,
+        )
+    }
+
     /// Rebuild `value` with every dispatch-needing leaf replaced by its
     /// interpreter-rendered `.raku` text. Containers are rebuilt in place with
     /// their kind/metadata preserved so the pure renderer still sees the same
@@ -167,7 +191,8 @@ impl Interpreter {
 
     fn expand_container(&mut self, value: &Value, active: &mut Vec<usize>, depth: usize) -> Value {
         if needs_raku_dispatch(value) {
-            return match self.dispatch_raku_leaf(value) {
+            let dispatch_target = Self::raku_dispatch_target(value);
+            return match self.dispatch_raku_leaf(&dispatch_target) {
                 // The placeholder has to remember whether the leaf was
                 // Iterable: the container splicing it back in applies raku's
                 // trailing-comma rule to a lone Iterable element, and the
@@ -356,6 +381,21 @@ impl Interpreter {
     /// The `.raku`/`.perl` text of a container holding a dispatch-needing leaf,
     /// or `None` when the pure renderer already handles the value on its own.
     pub(crate) fn raku_repr_with_dispatch(&mut self, target: &Value) -> Option<String> {
+        if raku_scalar_itemized(target) {
+            let dispatch_target = Self::raku_dispatch_target(target);
+            let rendered = self
+                .dispatch_raku_leaf(&dispatch_target)
+                .ok()?
+                .to_string_value();
+            let raw = if raku_leaf_is_iterable(target) {
+                raku_raw_iterable(rendered)
+            } else {
+                raku_raw(rendered)
+            };
+            return Some(crate::builtins::methods_0arg::raku_repr::raku_value(
+                &Value::scalar(raw),
+            ));
+        }
         if !container_needs_raku_dispatch(target) {
             return None;
         }

--- a/src/runtime/regex_parse_modifier.rs
+++ b/src/runtime/regex_parse_modifier.rs
@@ -593,7 +593,10 @@ impl Interpreter {
                             .cloned()
                             .or_else(|| self.env.get(&format!("${bare_name}")).cloned())
                             .unwrap_or(Value::NIL);
-                        let value = value.into_deref();
+                        // `@$scalar` explicitly asks for the aggregate held
+                        // by the scalar, so strip the item wrapper before
+                        // reading through a shared cell.
+                        let value = value.into_descalarized().into_deref();
                         let elements = match value.view() {
                             ValueView::Array(arr, _) => arr.as_ref().clone(),
                             ValueView::Seq(items) => crate::value::ArrayData::new(items.to_vec()),
@@ -648,7 +651,10 @@ impl Interpreter {
                     // Slice 2a: a `=`-array-shared source (`my $r = @var`) promotes
                     // `@var` to a `ContainerRef` cell; deref it so the array
                     // interpolates as alternation instead of stringifying the cell.
-                    let value = value.into_deref();
+                    // A scalar assignment may preserve itemization as
+                    // `Scalar(ContainerRef(cell))`; bare `@name` needs the
+                    // aggregate behind that wrapper for alternation.
+                    let value = value.into_descalarized().into_deref();
                     let elements = match value.view() {
                         ValueView::Array(arr, _) => arr.as_ref().clone(),
                         ValueView::Seq(items) => crate::value::ArrayData::new(items.to_vec()),

--- a/src/runtime/utils/radix_numeric.rs
+++ b/src/runtime/utils/radix_numeric.rs
@@ -135,6 +135,13 @@ pub(crate) fn parse_radix_number_body(body: &str, base: u32) -> Option<Value> {
 pub(crate) fn coerce_to_numeric(val: Value) -> Value {
     let val = val.into_descalarized();
     match val.view() {
+        // A scalar-held shared aggregate is represented as
+        // `Scalar(ContainerRef(cell))` so `.raku` can retain the `$` marker.
+        // Numeric coercion normally sees a bare `ContainerRef` only after the
+        // GetLocal decontainerization step, but the scalar wrapper deliberately
+        // survives that step to preserve itemization. Read through the cell
+        // here before applying the ordinary aggregate cardinality rules.
+        ValueView::ContainerRef(cell) => coerce_to_numeric(cell.lock().unwrap().clone()),
         ValueView::Mixin(inner, _) => coerce_to_numeric(inner.as_ref().clone()),
         ValueView::Int(_)
         | ValueView::BigInt(_)

--- a/src/vm/vm_call_method_mut_ops.rs
+++ b/src/vm/vm_call_method_mut_ops.rs
@@ -649,6 +649,15 @@ impl Interpreter {
         let target = self.stack.pop().ok_or_else(|| {
             RuntimeError::new("Interpreter stack underflow in CallMethodMut target".to_string())
         })?;
+        if method == "raku"
+            && crate::builtins::methods_0arg::raku_repr::raku_scalar_itemized(&target)
+        {
+            let rendered = self
+                .raku_repr_with_dispatch(&target)
+                .unwrap_or_else(|| crate::builtins::methods_0arg::raku_repr::raku_value(&target));
+            self.stack.push(Value::str(rendered));
+            return Ok(());
+        }
         crate::alloc_scope_end!(_sc_cmm_args);
         let stash_target = if method == "BIND-KEY" && args.len() == 2 {
             match target.view() {

--- a/src/vm/vm_call_method_ops.rs
+++ b/src/vm/vm_call_method_ops.rs
@@ -709,6 +709,13 @@ impl Interpreter {
         // `LazyIoLines` special case). Introspection must not consume the
         // underlying handle: asking for its type is side-effect free.
         let target = self.reify_or_consume_seq_target(target, method)?;
+        if method == "raku"
+            && crate::builtins::methods_0arg::raku_repr::raku_scalar_itemized(&target)
+            && let Some(rendered) = self.raku_repr_with_dispatch(&target)
+        {
+            self.stack.push(Value::str(rendered));
+            return Ok(());
+        }
         if method == "BIND-KEY"
             && args.len() == 2
             && matches!(

--- a/src/vm/vm_native_json.rs
+++ b/src/vm/vm_native_json.rs
@@ -34,6 +34,14 @@ impl Interpreter {
         let clean_args: Vec<Value> = clean_args
             .into_iter()
             .map(crate::runtime::types::unwrap_varref_value)
+            // A scalar assigned from an array/hash keeps an itemization
+            // wrapper for list and `.raku` contexts. A normal value argument
+            // still fetches the shared cell before the native serializer sees
+            // it, just as the pre-itemization representation did.
+            .map(|value| match value.view() {
+                ValueView::Scalar(inner) if inner.is_container_ref() => inner.deref_container(),
+                _ => value,
+            })
             .collect();
         match name {
             "to-json" => {

--- a/src/vm/vm_run_loop.rs
+++ b/src/vm/vm_run_loop.rs
@@ -1049,6 +1049,19 @@ impl Interpreter {
             | ValueView::RangeExclStart(..)
             | ValueView::RangeExclBoth(..)
             | ValueView::GenericRange { .. } => val.item(),
+            // Array/Hash subclasses keep their bare Instance representation so
+            // type checks, lvalue writes, and subclass delegation remain
+            // transparent. Record scalar itemization only as renderer metadata.
+            ValueView::Instance { attributes, .. }
+                if attributes.contains_key("__mutsu_array_storage")
+                    || attributes.contains_key("__mutsu_hash_storage") =>
+            {
+                attributes.insert(
+                    crate::builtins::methods_0arg::raku_repr::RAKU_SCALAR_ITEMIZED_KEY,
+                    Value::TRUE,
+                );
+                val
+            }
             // A `but`-mixed container keeps the itemization the `$` confers —
             // see the Mixin arm of `itemize_value`.
             ValueView::Mixin(inner, overrides) => Value::mixin_parts(

--- a/src/vm/vm_set_ops.rs
+++ b/src/vm/vm_set_ops.rs
@@ -149,6 +149,15 @@ impl Interpreter {
         // in raku -- `Set.new($[1, 2])` -- so membership by `.WHICH` has to see
         // the value exactly as it was stored.)
         let container = container.descalarize();
+        // A scalar-held aggregate share has both wrappers: the outer Scalar
+        // carries itemization and the inner ContainerRef carries aliasing.
+        // Membership must inspect the aggregate behind both, just as method
+        // dispatch and indexed mutation do.
+        let container = if container.is_container_ref() {
+            container.deref_container()
+        } else {
+            container.clone()
+        };
         // Set/Bag/Mix stores are `.WHICH`-keyed: membership is element
         // identity (`===`), so `<1> ∈ (1,).Set` is False (IntStr vs Int)
         // and `"1" ∈ (1,).Set` is False (Str vs Int) — matching Rakudo.
@@ -160,7 +169,7 @@ impl Interpreter {
             ValueView::Set(s, _) => s.contains(&key),
             ValueView::Bag(b, _) => b.get(&key).is_some_and(num_traits::Signed::is_positive),
             ValueView::Mix(m, _) => m.get(&key).is_some_and(|weight| *weight != 0.0),
-            ValueView::Hash(h) => self.hash_contains(&h, needle, container),
+            ValueView::Hash(h) => self.hash_contains(&h, needle, &container),
             _ if container.as_list_items().is_some() => container
                 .as_list_items()
                 .unwrap()
@@ -170,7 +179,7 @@ impl Interpreter {
                 // So `42 ∈ < 42 >` is False (Int vs the IntStr allomorph) and
                 // `"1" ∈ (1,)` is False (Str vs Int) — matching Rakudo.
                 .any(|item| crate::runtime::utils::values_identical(item, needle)),
-            _ if container.is_range() => Self::range_contains(container, needle),
+            _ if container.is_range() => Self::range_contains(&container, needle),
             _ => false,
         }
     }

--- a/src/vm/vm_var_assign_coerce.rs
+++ b/src/vm/vm_var_assign_coerce.rs
@@ -799,12 +799,24 @@ impl Interpreter {
         // value or already held by the source variable, else wrap the snapshot.
         let cell = match val.view() {
             ValueView::ContainerRef(arc) => arc.clone(),
+            // A scalar holding an array share is represented as
+            // `Scalar(ContainerRef(cell))` so its `.raku` keeps the `$`
+            // marker without changing the source array's own rendering.
+            // Chained `$r = $q` must nevertheless reuse that same cell.
+            ValueView::Scalar(inner) if inner.is_container_ref() => {
+                if let ValueView::ContainerRef(arc) = inner.view() {
+                    arc.clone()
+                } else {
+                    unreachable!("ContainerRef tag changed while extracting share cell")
+                }
+            }
             _ => match self.env().get(&resolved_source).map(Value::view) {
                 Some(ValueView::ContainerRef(arc)) => arc.clone(),
                 _ => crate::gc::Gc::new(crate::value::ContainerCell::new(val.clone())),
             },
         };
-        let container = Value::container_ref(cell);
+        let container = Value::container_ref(cell.clone());
+        let itemized_container = Value::container_ref(cell).item();
         // Promote the SOURCE container variable to the same cell so its own
         // `.push` / whole-reassign (`@z = (...)`) mutate through and stay visible
         // via the scalar.
@@ -847,7 +859,7 @@ impl Interpreter {
             *self.locals.absolute_slot_mut(slot) = container.clone();
         }
         // Store the shared cell in the scalar target (itemized scalar).
-        self.locals[idx] = container.clone();
+        self.locals[idx] = itemized_container.clone();
         // Clear any stale bound-decont marker inherited from an earlier bind of
         // the same name (this `=` share is itemized, not a `:=` decont alias).
         self.update_bound_decont_marker(&name, false, &val);
@@ -855,7 +867,7 @@ impl Interpreter {
         self.env_mut()
             .insert(format!("__mutsu_array_share::{}", name), Value::TRUE);
         self.array_share_active = true;
-        self.set_env_with_main_alias(&name, container.clone());
+        self.set_env_with_main_alias(&name, itemized_container);
         self.flush_local_to_env(code, idx);
         Ok(())
     }

--- a/src/vm/vm_var_assign_coerce.rs
+++ b/src/vm/vm_var_assign_coerce.rs
@@ -816,7 +816,15 @@ impl Interpreter {
             },
         };
         let container = Value::container_ref(cell.clone());
-        let itemized_container = Value::container_ref(cell).item();
+        // Compiler-generated temporaries are implementation details rather than
+        // user-visible scalar bindings. Keep their historical bare cell shape so
+        // internal binding paths such as `if $cond -> @items` still decontainerize
+        // the temporary before binding the pointy block's `@` parameter.
+        let itemized_container = if Self::name_is_itemize_exempt(&name) {
+            container.clone()
+        } else {
+            Value::container_ref(cell).item()
+        };
         // Promote the SOURCE container variable to the same cell so its own
         // `.push` / whole-reassign (`@z = (...)`) mutate through and stay visible
         // via the scalar.

--- a/src/vm/vm_var_assign_index_named.rs
+++ b/src/vm/vm_var_assign_index_named.rs
@@ -3930,6 +3930,15 @@ impl Interpreter {
         for _ in 0..MAX_DESCENT {
             let cell = match unsafe { &*current }.view() {
                 ValueView::ContainerRef(cell) => cell.clone(),
+                // A scalar assignment from an array/hash variable preserves
+                // the itemized Scalar wrapper around the shared cell. Index
+                // assignment must still descend through that wrapper so
+                // `$scalar[0] = value` writes the aliased aggregate rather
+                // than detaching a new one-element value.
+                ValueView::Scalar(inner) if inner.is_container_ref() => match inner.view() {
+                    ValueView::ContainerRef(cell) => cell.clone(),
+                    _ => return current,
+                },
                 _ => return current,
             };
             if first_cell.is_none() {

--- a/src/vm/vm_var_assign_post_incdec.rs
+++ b/src/vm/vm_var_assign_post_incdec.rs
@@ -462,7 +462,20 @@ impl Interpreter {
         // arms, and `%h<k>++` silently did nothing. The write side is handled
         // separately, at the in-place writeback below.
         let container_raw = container.clone();
-        let container = container.map(|c| c.deref_container());
+        let container = container.map(|c| {
+            // A scalar assignment from an aggregate preserves the shared
+            // `ContainerRef` inside the Scalar wrapper.  The element logic
+            // below needs the aggregate for classification and reading, so
+            // unwrap that one additional Scalar layer before dereferencing the
+            // shared cell.
+            if let ValueView::Scalar(inner) = c.view()
+                && inner.is_container_ref()
+            {
+                inner.deref_container()
+            } else {
+                c.deref_container()
+            }
+        });
         // Resolve a WhateverCode / Whatever index (`@a[*-1]++`, `@a[*-2]--`)
         // against the container's length before using it as the key — otherwise
         // the raw closure stringifies to a bogus key and the increment is lost.
@@ -931,7 +944,7 @@ impl Interpreter {
             Some(s) => self.locals.get(s),
             None => self.env().get(&name),
         }
-        .and_then(|v| match v.view() {
+        .and_then(|v| match v.descalarize().view() {
             ValueView::ContainerRef(cell) => Some(cell.clone()),
             _ => None,
         });

--- a/t/scalar-itemize-raku.t
+++ b/t/scalar-itemize-raku.t
@@ -6,7 +6,7 @@ use Test;
 # Binds (`:=`), `constant`, and sigilless declarations install the value
 # itself (no Scalar container) and must NOT itemize.
 
-plan 26;
+plan 37;
 
 # --- plain scalar assignment itemizes ---
 {
@@ -79,6 +79,34 @@ plan 26;
     is ($c >>[&infix:<+>]<< $c).raku, '(2, 4, 6)', 'hyper func op on bound scalars';
     is ($c >>[&infix:<+>]<< $c).raku, '(2, 4, 6)', 'writeback does not itemize a bound scalar';
     is $c.raku, '(1, 2, 3)', 'bound scalar keeps its bare List after hyper func op';
+}
+
+# --- a scalar holding a shared Array keeps its itemization marker ---
+{
+    class ScalarArraySubclass is Array { }
+    class ScalarHashSubclass is Hash { }
+
+    my @source = 1, 2;
+    my $held = @source;
+    is $held.raku, '$[1, 2]', 'a scalar-held Array renders the $ marker';
+    is $held.WHAT.gist, '(Array)', 'the scalar-held Array keeps its type';
+    ok $held === @source, 'the scalar-held Array is still the same container';
+    my @items = $held, 3;
+    is @items.elems, 2, 'the scalar-held Array stays one item in list context';
+    $held[0] = 9;
+    is @source.raku, '[9, 2]', 'element assignment still writes through the share';
+    is $($held).raku, '$[9, 2]', 'explicit itemization keeps the $ marker';
+    my $bound := @source;
+    is $bound.raku, '[9, 2]', 'a bound scalar renders the bare Array';
+
+    my $array_subclass = ScalarArraySubclass.new(1, 2);
+    is $array_subclass.raku, '$[1, 2]', 'an Array subclass in a scalar gets the $ marker';
+    is $array_subclass.elems, 2, 'an itemized Array subclass still delegates methods';
+    my $hash_subclass = ScalarHashSubclass.new(a => 1);
+    is $hash_subclass.raku, '${:a(1)}', 'a Hash subclass in a scalar gets the $ marker';
+    my %hash_source = a => 1;
+    my $held_hash = %hash_source;
+    is $held_hash.raku, '${:a(1)}', 'a scalar-held Hash renders the $ marker';
 }
 
 done-testing;


### PR DESCRIPTION
## Summary

- Preserve Rakudo's `$` itemization marker when an Array or Hash is assigned into a scalar, including Array/Hash subclasses.
- Keep shared-cell identity and write-through behavior for methods, indexing, inc/dec, and Pair-derived lvalues.
- Add focused regression coverage and a news entry.

Fixes #7658.

## Validation

- `cargo fmt --all`
- `cargo clippy -- -D warnings`
- `make test` (pass: 993 Rust tests and 41,284 TAP assertions)
- `make roast` (pass: 1,436 files and 218,962 tests)
- Focused scalar/container and subclass tests pass.
