### PR TITLE
fix(runtime): scope a prelude splice to the compunits it was spliced into

### DIFF
--- a/news/2026-09/prelude-splice-is-lexical-to-its-compunit.md
+++ b/news/2026-09/prelude-splice-is-lexical-to-its-compunit.md
@@ -1,0 +1,81 @@
+# A prelude splice is lexical to the compunits it was spliced into
+
+`use`ing a module that itself uses the native-call module left that module's
+helpers — `nativecast`, `nativesizeof`, `cglobal`, `explicitly-manage`,
+`refresh` — declared in the *using* scope, two levels up, where rakudo leaves
+them undeclared. GH #7612 tracked it as the flat routine registry leaking a
+nested module's imports; measuring it first showed the leak is narrower and has
+a different cause.
+
+## What actually leaked
+
+An ordinary nested import of a **routine** does not leak. With three plain user
+modules — a leaf exporting `sub leafy`, a middle module that `use`s it, and a
+script that `use`s only the middle one — mutsu and rakudo agree exactly: `leafy`
+is undeclared in the script, and the middle module's own routines still resolve
+it. The flat registry is already scoped correctly there, by the
+`module_registered_functions` delta that #7580 introduced. (An imported
+*variable* or *class* is a different story — see "What is still open" below.)
+
+What leaked was the **prelude splice**. mutsu has no `NativeCall.rakumod`; the
+five helper routines are injected as an `our sub` prelude into every compunit
+whose source mentions the module (`inject_nativecall_subs_prelude`), and each
+registers under `GLOBAL::` rather than under the host compunit's package. That
+`GLOBAL::` registration is deliberate and still necessary — a method body
+running under *any* package has to be able to call the helper by bare name,
+which is the shape `NativeHelpers::Pointer` has, and registering under the host
+package instead left those bodies unable to see it. But a process-global
+registration is also process-global *visibility*: once any compunit anywhere had
+pulled the prelude in, `&nativecast` resolved from every scope in the process.
+
+The issue's own repro is exactly this shape — `BlockUseNestedOuter` →
+`BlockUseNestedInner` → the native-call module — which is why it reproduced with
+no block anywhere, and why it did not reproduce with ordinary user modules.
+
+## The fix
+
+Keep the registration process-global; make the *visibility* lexical.
+
+`prelude_declaring_units` records, per prelude key, the compilation units the
+declaration was actually spliced into (`?FILE` at registration time, normalized
+so the main script is `main_unit()`). A splice is per compunit and idempotent —
+the first registration wins and later ones return `Unchanged` — so this set is
+what records the later ones, which the routine registry alone cannot.
+
+Routine resolution then consults the compunit that is *executing*:
+`executing_unit_sym()` is the allocation-free `Symbol` form of the existing
+`executing_source_file()` walk (innermost frame's `def_file`, skipping inlined
+bare blocks, falling back to `?FILE`), and `prelude_visible_here` answers
+whether a resolved key is reachable from there. `resolve_function` skips a
+prelude key that is not, and `has_declared_function` agrees with it.
+
+This is the "consult the compilation unit a routine is being resolved from"
+model the issue asked for, applied at the one place the leak actually lives. It
+costs nothing on the normal path: every non-prelude key answers `true` without
+touching the map, and the whole check short-circuits on the empty prelude set,
+which is every program that does not use the native-call module.
+
+The result matches rakudo on both edges: the using scope no longer sees the
+helper, and the declaring module's own routines still do — including through an
+enclosing block's import-scope pop, which is the direction #7580 fixed.
+
+## What is still open
+
+Two genuine flat-namespace leaks remain, both measured against rakudo while
+investigating this, and both a different shape from the prelude one: a nested
+module's imported `our ... is export` **variable**, and its imported **class**,
+are still reachable from the using scope. Fixing those needs module-scoped
+variable and type resolution to work for a `unit module`'s own subs, which
+`lookup_in_running_package` cannot do today because it keys on the running
+frame's *package* — GLOBAL for a unit module's subs — rather than on its
+compunit. Filed separately, with the repro, as #7692.
+
+## Tests
+
+- `t/nested-module-native-prelude-not-visible-to-user.t` — the full shape, in
+  both directions, plain and block-scoped. Every helper name is assembled at
+  runtime: the splice gate is a source-text check over the file's *code*
+  (comments and Pod are stripped first), so spelling one plainly would inject
+  the prelude into the test compunit and legitimately declare it.
+- `t/block-use-keeps-nested-module-imports.t` — its `todo`-note for this
+  divergence is now an assertion.

--- a/src/runtime/compunit_scope.rs
+++ b/src/runtime/compunit_scope.rs
@@ -1,0 +1,118 @@
+//! Compilation-unit scoping for routines whose registration is process-global.
+//!
+//! mutsu's routine registry is flat and keyed by `PACKAGE::name`, which models
+//! Raku's lexical scoping well enough for ordinary declarations and imports: a
+//! module's own routines register under its package, and an import alias is
+//! installed for — and removed with — the scope that asked for it.
+//!
+//! A *prelude splice* fits neither shape. mutsu has no `NativeCall.rakumod`, so
+//! its five helpers (`nativecast`, `nativesizeof`, `cglobal`,
+//! `explicitly-manage`, `refresh`) are injected as an `our sub` prelude into
+//! every compunit whose source mentions the module, and each registers under
+//! `GLOBAL::` rather than under the host compunit's package — because a method
+//! body running under *any* package has to reach it by bare name (see
+//! `NATIVECALL_SUB_PRELUDES`). That makes the registration process-global, and
+//! until GH #7612 it made the *visibility* process-global too: once any compunit anywhere had pulled the prelude in, `&nativecast`
+//! resolved from every scope in the process, including a script that merely
+//! `use`d such a module two levels up. Rakudo leaves the name undeclared there.
+//!
+//! This module keeps the registration global and makes the visibility lexical:
+//! the splice records which compunits it went into, and routine resolution asks
+//! which compunit is executing.
+
+use super::*;
+use crate::symbol::Symbol;
+
+impl Interpreter {
+    /// `Symbol` form of [`Self::executing_source_file`], normalized so that
+    /// "the main script" is always [`crate::runtime::main_unit`] rather than
+    /// `None` or the program path.
+    ///
+    /// Allocation-free (the `String` variant resolves the interned path), which
+    /// matters because the prelude-visibility gate that reads it sits on the
+    /// routine-resolution path.
+    pub(crate) fn executing_unit_sym(&self) -> Symbol {
+        for frame in self.routine_stack.iter().rev() {
+            match frame.def_file {
+                Some(file) => return self.unit_of_source_sym(Some(file)),
+                None if frame.is_block => continue,
+                None => break,
+            }
+        }
+        self.unit_of_source_sym(self.current_source_file_sym())
+    }
+
+    /// The unit a routine *declared* in `file` belongs to. Mirrors
+    /// [`Self::executing_unit_sym`]'s normalization so the two agree on the
+    /// main script.
+    pub(crate) fn declaring_unit_sym(&self) -> Symbol {
+        self.unit_of_source_sym(self.current_source_file_sym())
+    }
+
+    fn unit_of_source_sym(&self, file: Option<Symbol>) -> Symbol {
+        match (file, self.program_path.as_deref()) {
+            (None, _) => crate::runtime::main_unit(),
+            (Some(f), Some(prog)) if f.resolve() == prog => crate::runtime::main_unit(),
+            (Some(f), _) => f,
+        }
+    }
+
+    /// Whether a routine registered under `key` is visible to the code that is
+    /// running right now.
+    ///
+    /// Only prelude splices (`prelude_registered_functions`) are ever hidden:
+    /// they register process-globally under `GLOBAL::` so that a method body
+    /// under any package can call them, but rakudo exports them from
+    /// `NativeCall.rakumod`, so a compunit that never mentioned NativeCall must
+    /// not see them. `use`ing a module that itself uses NativeCall therefore
+    /// must not make `&nativecast` resolvable in the using scope (GH #7612).
+    ///
+    /// Every other key answers `true` without touching the map, and the whole
+    /// check short-circuits on the (overwhelmingly common) empty prelude set.
+    pub(crate) fn prelude_visible_here(&self, key: Symbol) -> bool {
+        if self.prelude_registered_functions.is_empty()
+            || !self.prelude_registered_functions.contains(&key)
+        {
+            return true;
+        }
+        match self.prelude_declaring_units.get(&key) {
+            // No provenance recorded (a thread clone that predates the splice,
+            // a synthetic registration): stay permissive rather than hide a
+            // helper the running code legitimately declared.
+            None => true,
+            // Two anchors, because neither covers the other. `?FILE` (via
+            // `executing_unit_sym`) is the only one that is right while a
+            // module's MAINLINE runs -- `current_unit` is not switched around
+            // `load_module`'s `run_block`, so it still names whoever triggered
+            // the load. `current_unit` is the only one that names an EVAL unit
+            // whose `?FILE` a nested frame has since moved on from. Both walk
+            // the EVAL parent chain, since `EVAL` compiles in its caller's
+            // lexical scope.
+            Some(units) => {
+                self.unit_chain_contains(self.executing_unit_sym(), units)
+                    || self.unit_chain_contains(self.current_unit, units)
+            }
+        }
+    }
+
+    /// Whether `start`, or any unit it was `EVAL`ed inside of, is in `units`.
+    ///
+    /// `EVAL` compiles in its caller's lexical scope, so a declaration made by
+    /// the enclosing unit is in scope for the `EVAL`ed code, while one made BY
+    /// that code is scoped to the `EVAL` unit alone. Shared with operator
+    /// scoping (`Interpreter::user_infix_override`), which asks the same
+    /// question of `user_declared_infix_ops`.
+    pub(crate) fn unit_chain_contains(&self, start: Symbol, units: &HashSet<Symbol>) -> bool {
+        let mut unit = Some(start);
+        // An EVAL nested in an EVAL nested in ... is bounded in practice; the
+        // cap only stops a cycle from hanging the VM.
+        for _ in 0..64 {
+            let Some(sym) = unit else { return false };
+            if units.contains(&sym) {
+                return true;
+            }
+            unit = crate::runtime::eval_unit_parent(sym);
+        }
+        false
+    }
+}

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -444,6 +444,7 @@ mod class_dispatch;
 mod class_introspection;
 mod code_frame;
 pub(crate) use code_frame::{CodeFrame, LazyRoutineCode};
+mod compunit_scope;
 mod ctor_phase_plan;
 mod nqp_ops;
 mod nqp_ops_builtin;
@@ -2035,6 +2036,23 @@ pub struct Interpreter {
     /// unable to resolve the helper its own body calls, since `loaded_modules`
     /// still claimed it was loaded and the later real `use` short-circuited.
     prelude_registered_functions: HashSet<Symbol>,
+    /// For each prelude key in `prelude_registered_functions`, the compilation
+    /// units the declaration was actually spliced into (`?FILE` at registration
+    /// time; `main_unit()` for the main script).
+    ///
+    /// The registration is process-global by design — a prelude routine has to
+    /// be callable by bare name from a method body running under any package
+    /// (see `NATIVECALL_SUB_PRELUDES`) — but its *visibility* is not: rakudo
+    /// exports these from `NativeCall.rakumod`, so a compunit that never
+    /// mentioned NativeCall must not see them. Without this, one module's
+    /// `use NativeCall` made `&nativecast` resolvable from every scope in the
+    /// process, including the script that merely `use`d that module two levels
+    /// up (GH #7612).
+    ///
+    /// A splice happens per compunit and is idempotent (the first registration
+    /// wins, later ones return `Unchanged`), so this set is what records the
+    /// later ones. `prelude_visible_here` reads it.
+    prelude_declaring_units: HashMap<Symbol, HashSet<Symbol>>,
     /// The package-qualified globals (`Base::flag`, `$NativeLibs::config`) each
     /// loaded module declared with `our`, keyed by module name.
     ///

--- a/src/runtime/registration.rs
+++ b/src/runtime/registration.rs
@@ -1028,9 +1028,17 @@ impl Interpreter {
     }
 
     pub(crate) fn has_declared_function(&self, name: &str) -> bool {
-        self.bare_name_packages()
-            .iter()
-            .any(|pkg| self.registry().has_declared_function(pkg, name))
+        // The prelude-visibility gate (see `prelude_visible_here`) has to agree
+        // with `resolve_function`, or a hidden helper is reported as declared
+        // and then fails to resolve. It is skipped entirely — no key built, no
+        // allocation — for the overwhelmingly common case of a program that
+        // spliced no prelude at all.
+        let gate = !self.prelude_registered_functions.is_empty();
+        self.bare_name_packages().iter().any(|pkg| {
+            self.registry().has_declared_function(pkg, name)
+                && (!gate
+                    || self.prelude_visible_here(Symbol::intern(&format!("{}::{}", pkg, name))))
+        })
     }
 
     pub(crate) fn is_implicit_zero_arg_builtin(name: &str) -> bool {

--- a/src/runtime/registration_sub.rs
+++ b/src/runtime/registration_sub.rs
@@ -754,6 +754,17 @@ impl Interpreter {
             // to put it back after a scope rollback — see
             // `prelude_registered_functions`.
             self.prelude_registered_functions.insert(global_key);
+            // ...and record WHICH compunit this copy was spliced into, before
+            // the idempotence check below can swallow it. The registration is
+            // process-global so that a method body under any package can reach
+            // the helper, but rakudo scopes these names to the compunits that
+            // `use NativeCall`, so resolution consults this set — see
+            // `prelude_declaring_units` / `prelude_visible_here`.
+            let unit = self.declaring_unit_sym();
+            self.prelude_declaring_units
+                .entry(global_key)
+                .or_default()
+                .insert(unit);
             // Every compunit that uses NativeCall carries its own copy of the
             // declaration, and they are identical by construction, so the first
             // one wins and the rest are no-ops rather than redeclarations.

--- a/src/runtime/resolution.rs
+++ b/src/runtime/resolution.rs
@@ -104,12 +104,14 @@ impl Interpreter {
         let cur_pkg = self.current_package();
         // Innermost package first, then each enclosing one, ending at GLOBAL.
         for pkg in self.bare_name_packages() {
-            if let Some(def) = self
-                .registry()
-                .functions
-                .get(&Symbol::intern(&format!("{}::{}", pkg, name)))
-                .cloned()
-            {
+            let key = Symbol::intern(&format!("{}::{}", pkg, name));
+            if let Some(def) = self.registry().functions.get(&key).cloned() {
+                // A prelude splice is registered under `GLOBAL::` for every
+                // package to reach, but is lexical to the compunits it was
+                // spliced into — see `prelude_visible_here`.
+                if !self.prelude_visible_here(key) {
+                    continue;
+                }
                 return Some(def);
             }
         }

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -3000,6 +3000,7 @@ impl Interpreter {
             loaded_modules: HashSet::new(),
             module_registered_functions: HashSet::new(),
             prelude_registered_functions: HashSet::new(),
+            prelude_declaring_units: HashMap::new(),
             module_package_globals: HashMap::new(),
             need_hidden_classes: HashSet::new(),
             cur_repo: Box::new(CurRepoState::default()),

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -644,6 +644,7 @@ impl Interpreter {
             loaded_modules: self.loaded_modules.clone(),
             module_registered_functions: self.module_registered_functions.clone(),
             prelude_registered_functions: self.prelude_registered_functions.clone(),
+            prelude_declaring_units: self.prelude_declaring_units.clone(),
             module_package_globals: self.module_package_globals.clone(),
             need_hidden_classes: self.need_hidden_classes.clone(),
             cur_repo: self.cur_repo.clone(),

--- a/src/vm/vm_arith_ops.rs
+++ b/src/vm/vm_arith_ops.rs
@@ -75,17 +75,7 @@ impl Interpreter {
     /// Only reached once a user-declared infix of this name exists, so the env
     /// lookup stays off ordinary arithmetic.
     fn declaring_unit_is_in_scope(&self, files: &HashSet<Symbol>) -> bool {
-        let mut unit = Some(self.current_unit);
-        // An EVAL nested in an EVAL nested in ... is bounded in practice; the
-        // cap only stops a cycle from hanging the VM.
-        for _ in 0..64 {
-            let Some(sym) = unit else { return false };
-            if files.contains(&sym) {
-                return true;
-            }
-            unit = crate::runtime::eval_unit_parent(sym);
-        }
-        false
+        self.unit_chain_contains(self.current_unit, files)
     }
 
     /// METAOP_ASSIGN identity substitution (`$x OP= $y` with an undefined `$x`).

--- a/t/block-use-keeps-nested-module-imports.t
+++ b/t/block-use-keeps-nested-module-imports.t
@@ -13,13 +13,15 @@
 # holds because the module-body delta is taken BEFORE `import_module`, so an
 # alias installed for the IMPORTING scope is never in the retained set.
 #
-# The opposite edge -- that the nested module's import is also visible to the
-# USING scope, where rakudo hides it -- is pre-existing and tracked as GH #7612;
-# it reproduces with no block at all, so it is deliberately not asserted here.
+# The opposite edge -- that the nested module's import was also visible to the
+# USING scope, where rakudo hides it -- was GH #7612, fixed by scoping the
+# prelude splice to the compunits it was spliced into. It is asserted at the
+# bottom of this file, and covered in full by
+# `t/nested-module-native-prelude-not-visible-to-user.t`.
 use lib $?FILE.IO.parent.add('lib').Str;
 use Test;
 
-plan 4;
+plan 5;
 
 {
     use BlockUseNestedOuter;
@@ -52,3 +54,10 @@ nok defined(::('&leaf-probe')),
     use BlockUseNestedInner;
 }
 is outer-probe(), 'visible', 'the chain still resolves after a repeated block-scoped use';
+
+# GH #7612: the same chain must NOT make the helper visible HERE. The splice
+# gate is a source-text check over this file's code, so the name is assembled
+# at runtime -- spelling it plainly would inject the prelude into this compunit
+# and legitimately declare it.
+nok defined(::('&native' ~ 'cast')),
+    "the nested module's own prelude splice stays invisible to the using scope";

--- a/t/nested-module-native-prelude-not-visible-to-user.t
+++ b/t/nested-module-native-prelude-not-visible-to-user.t
@@ -1,0 +1,53 @@
+# A prelude splice is lexical to the compunits it was spliced into.
+#
+# mutsu injects `nativecast`/`nativesizeof`/`cglobal`/`explicitly-manage`/
+# `refresh` as an `our sub` prelude into every compunit whose source mentions
+# NativeCall (`inject_nativecall_subs_prelude`), and registers each under
+# `GLOBAL::` rather than the host package so a method body running under ANY
+# package can call it (see `NATIVECALL_SUB_PRELUDES`). That registration is
+# process-global, which used to make the helper resolvable from every scope in
+# the process once any module anywhere had pulled it in -- so `use`ing a module
+# that itself uses the native-call module left `&nativecast` declared in the
+# using scope, where rakudo leaves it undeclared (GH #7612).
+#
+# The registration still has to be process-global; only its VISIBILITY is now
+# lexical: `prelude_declaring_units` records which compunits each splice went
+# into, and routine resolution consults the compunit that is executing
+# (`prelude_visible_here`).
+#
+# IMPORTANT: the splice gate is a source-TEXT check over this file's code
+# (comments and Pod are stripped first, `CodeText::from_source`). Spelling any
+# of the five helper names -- or the module's name -- in *code* here, even
+# inside a string, would inject the prelude into this compunit and legitimately
+# declare the names. So every name below is assembled at runtime.
+use lib $?FILE.IO.parent.add('lib').Str;
+use Test;
+
+plan 5;
+
+my $cast = '&native' ~ 'cast';
+my $sizeof = '&native' ~ 'sizeof';
+
+# `BlockUseNestedOuter` -> `BlockUseNestedInner` -> the native-call module.
+# Nothing in this file's code names it, so the helpers must not be declared
+# here.
+use BlockUseNestedOuter;
+
+nok defined(::($cast)),
+    "a nested module's own prelude splice is not visible to the using scope";
+nok defined(::($sizeof)),
+    'the same for the other helpers of that splice';
+
+# ...while the module that actually declared it still sees its own copy. This is
+# the direction GH #7580 fixed and must not regress.
+is outer-probe(), 'visible',
+   "the declaring module's own routines still resolve the helper";
+
+# A block-scoped `use` of the same chain: same on both counts.
+{
+    use BlockUseNestedInner;
+}
+nok defined(::($cast)),
+    'a block-scoped use of the chain does not leak the helper either';
+is outer-probe(), 'visible',
+   'and the chain still resolves after the block-scoped use';


### PR DESCRIPTION
`use`ing a module that itself uses the native-call module left that module's
helpers — `nativecast`, `nativesizeof`, `cglobal`, `explicitly-manage`,
`refresh` — declared in the *using* scope, two levels up, where rakudo leaves
them undeclared.

```raku
use lib 't/lib';
use BlockUseNestedOuter;      # -> BlockUseNestedInner -> the native-call module
say defined(::('&nativecast'));
# raku:  False
# mutsu: True   (before)  /  False (after)
```

## What actually leaked

#7612 tracked this as the flat routine registry leaking a nested module's
imports. Measuring it first showed a narrower, differently shaped cause.

An ordinary nested import of a **routine** does not leak. With a leaf module
exporting `sub leafy`, a middle module that `use`s it, and a script that `use`s
only the middle one, mutsu and rakudo agree exactly: `leafy` is undeclared in
the script, and the middle module's own routines still resolve it. The
`module_registered_functions` delta introduced by #7580 already scopes that
correctly.

What leaked was the **prelude splice**. mutsu has no `NativeCall.rakumod`, so
the five helpers are injected as an `our sub` prelude into every compunit whose
source mentions the module (`inject_nativecall_subs_prelude`), and each
registers under `GLOBAL::` rather than under the host compunit's package —
because a method body running under *any* package has to reach it by bare name,
which is the shape `NativeHelpers::Pointer` has. That registration is deliberate
and still necessary, but a process-global registration was also process-global
*visibility*: once any compunit anywhere had pulled the prelude in,
`&nativecast` resolved from every scope in the process. The issue's own repro is
exactly this shape, which is why it reproduced with no block anywhere and did
not reproduce with ordinary user modules.

## The fix

Keep the registration global; make the visibility lexical.

`prelude_declaring_units` records, per prelude key, the compilation units the
declaration was actually spliced into (`?FILE` at registration time, normalized
so the main script is `main_unit()`). A splice is per compunit and idempotent —
the first registration wins and later ones return `Unchanged` — so this set is
what records the later ones, which the registry alone cannot.

Resolution then consults the compunit that is *executing*. `prelude_visible_here`
checks two anchors, since neither covers the other:

- `executing_unit_sym()` — the `Symbol` form of the existing
  `executing_source_file()` frame walk — is the only one that is right while a
  module's **mainline** runs, because `current_unit` is not switched around
  `load_module`'s `run_block`;
- `current_unit` is the only one that names an **EVAL** unit a nested frame's
  `?FILE` has since moved on from.

Both walk the EVAL parent chain, since `EVAL` compiles in its caller's lexical
scope — the same walk operator scoping already used, now shared as
`unit_chain_contains`.

`resolve_function` skips a prelude key that is not visible, and
`has_declared_function` agrees with it so a hidden helper is never reported as
declared and then failing to resolve. The gate costs nothing on the normal path:
every non-prelude key answers `true` without touching the map, and the whole
check short-circuits on the empty prelude set — every program that does not use
the native-call module.

This is the "consult the compilation unit a routine is being resolved from"
model the issue asked for, applied at the one place the leak actually lives.

## Verified against rakudo 2026.07

| | before | after | raku |
| --- | --- | --- | --- |
| `::('&nativecast')` in the using scope | `True` | `False` | `False` |
| the declaring module's own routines | `visible` | `visible` | `visible` |
| same, through a block-scoped `use` | `visible` | `visible` | `visible` |
| own script `use NativeCall` | ok | ok | ok |
| method body under another package | ok | ok | ok |
| `EVAL 'nativesizeof(int32)'` | `4` | `4` | `4` |
| `start { nativesizeof(int32) }` | `4` | `4` | `4` |

## Tests

- `t/nested-module-native-prelude-not-visible-to-user.t` — new; the full shape,
  in both directions, plain and block-scoped. Passes unchanged under `raku`.
  Every helper name is assembled at runtime: the splice gate is a source-text
  check over the file's *code* (comments and Pod are stripped first), so
  spelling one plainly would inject the prelude into the test compunit and
  legitimately declare it.
- `t/block-use-keeps-nested-module-imports.t` — its `todo`-note for this
  divergence is now an assertion, as the issue's checklist asked.
- `roast/S11-modules/lexical.t` and `roast/S11-modules/require.t` (the two the
  issue named as pinning the direction that already worked) pass.
- All 69 `t/*.t` files that exercise NativeCall pass.

## What is still open

Two genuine flat-namespace leaks found while measuring this remain, both a
different shape from the prelude one: a nested module's imported
`our ... is export` **variable**, and its imported **class**, are still
reachable from the using scope. Both need module-scoped variable and type
resolution to work for a `unit module`'s own subs, which
`lookup_in_running_package` cannot do today because it keys on the running
frame's *package* — GLOBAL for a unit module's subs — rather than on its
compunit. Filed with the repro as #7692.

## Local verification

`cargo fmt --all`, `make lint` (all four configurations), `make test`
(3887 files / 41262 tests, PASS), `make roast` — the only failures are the
three documented container-only ones (`roast/6.c/S32-io/file-tests.t`,
`roast/S16-filehandles/filetest.t` under `uid 0`, and
`roast/S32-io/IO-Socket-Async.t` under the sandboxed network), matching
`docs/agent-environments.md` down to the individual test numbers.

Closes #7612

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RsGKaUsBinoXjoX3TgrUv2

---
_Generated by [Claude Code](https://claude.ai/code/session_01RsGKaUsBinoXjoX3TgrUv2)_