### PR TITLE
fix(map): preserve writable Array elements through list views

### DIFF
--- a/news/2026-09/map-list-writeback.md
+++ b/news/2026-09/map-list-writeback.md
@@ -1,0 +1,8 @@
+# `.list.map` preserves writable Array elements
+
+`map` now keeps the backing Array identity when its receiver is a real Array
+reached through a value-producing expression such as `@a.list` or a scalar
+holding `[1, 2, 3]`. A callback that assigns to `$_` therefore writes through to
+the source Array when the deferred `Seq` is consumed, matching Rakudo.
+
+Immutable `List` receivers remain on the readonly topic path.

--- a/src/runtime/methods_dispatch_match2.rs
+++ b/src/runtime/methods_dispatch_match2.rs
@@ -623,11 +623,25 @@ impl Interpreter {
         // in `pull_seq_source`), which is rakudo's timing: a `die` in the
         // callback escapes a `try` that merely encloses the `.map` call, and
         // a plain side effect happens at first consumption rather than here.
+        // A real Array's elements are writable containers even when the Array
+        // reached this dispatcher through a value-producing expression such as
+        // `@a.list` or a scalar holding `[1, 2, 3]`. The named `@a.map` spelling
+        // already carries this source through `MapGrepMode::MapRw`; preserve
+        // the same source identity here so the deferred callback can publish
+        // its `$_` writeback at consumption time. Immutable List values stay on
+        // the plain `Map` path and retain their readonly-topic behavior.
+        let mode = match target.view() {
+            ValueView::Array(
+                _,
+                crate::value::ArrayKind::Array | crate::value::ArrayKind::ItemArray,
+            ) => crate::value::MapGrepMode::MapRw(target.clone()),
+            _ => crate::value::MapGrepMode::Map,
+        };
         Ok(Value::seq_deferred(crate::value::SeqSource::MapGrep {
             items: std::sync::Arc::new(items),
             func: args.first().cloned(),
             fatal: self.fatal_mode,
-            mode: crate::value::MapGrepMode::Map,
+            mode,
         }))
     }
     /// Dispatch "min" and "max" methods.

--- a/src/runtime/resolution_map_grep_rw.rs
+++ b/src/runtime/resolution_map_grep_rw.rs
@@ -86,6 +86,7 @@ impl Interpreter {
                 || super::resolution_map_grep::sub_is_call_carrier(&data)
             {
                 // Fall through to call_sub_value path for complex cases
+                let keeps_outer_topic = super::resolution_map_grep::block_keeps_outer_topic(&data);
                 let mut result = Vec::new();
                 let arity = if !data.params.is_empty() {
                     let effective = data
@@ -135,6 +136,7 @@ impl Interpreter {
                         let v =
                             self.call_sub_value(Value::sub_value(data.clone()), chunk, false)?;
                         if arity == 1
+                            && !keeps_outer_topic
                             && let Some(mutated) = self.env.get(topic_key).cloned()
                         {
                             list_items[i] = mutated;

--- a/src/value/seq_body.rs
+++ b/src/value/seq_body.rs
@@ -27,8 +27,9 @@ use std::sync::{Arc, Mutex};
 pub(crate) enum MapGrepMode {
     /// `.map` over already-materialized items.
     Map,
-    /// `@a.map({ $_++ })`: Raku rw-binds `$_` to the source element, so the
-    /// callback's writes have to reach the container. The pull runs
+    /// A map over a real Array (`@a.map({ $_++ })`, or an Array reached through
+    /// `@a.list`/a scalar) rw-binds `$_` to the source element, so the callback's
+    /// writes have to reach the container. The pull runs
     /// `eval_map_over_items_rw` and publishes the write-back by mutating this
     /// container's `ArrayData` IN PLACE, which is frame-independent — the pull
     /// happens wherever the Seq is consumed, long after the frame whose `env`

--- a/src/vm/vm_helpers_lazy.rs
+++ b/src/vm/vm_helpers_lazy.rs
@@ -137,9 +137,9 @@ impl Interpreter {
         }
     }
 
-    /// Pull a deferred `.map` whose receiver was an `@`-sigil container
-    /// (`SeqSource::MapGrep::rw_source`): run the rw map loop, then publish
-    /// any element the callback wrote back into that container.
+    /// Pull a deferred `.map` whose receiver was a real Array
+    /// (`SeqSource::MapGrep::MapRw`): run the rw map loop, then publish any
+    /// element the callback wrote back into that container.
     fn pull_rw_map(
         &mut self,
         func: Option<Value>,

--- a/t/map-list-writeback.t
+++ b/t/map-list-writeback.t
@@ -1,0 +1,39 @@
+use Test;
+
+# A real Array can reach the generic map dispatcher through a value-producing
+# expression (`@a.list`) or through an itemized scalar holding `$[...]`. Its elements are
+# still writable containers, so `$_` mutations must reach the backing Array at
+# consumption time. A List literal remains immutable and is covered by the
+# ordinary map topic tests.
+
+plan 10;
+
+my @a = 1, 2, 3;
+my $mapped = @a.list.map({ $_ = 7 });
+is $mapped.^name, 'Seq', '@a.list.map returns a Seq';
+is-deeply @a, [1, 2, 3], '@a.list.map does not write before consumption';
+$mapped.eager;
+is-deeply @a, [7, 7, 7], '@a.list.map writes through at consumption';
+
+my @b = 1, 2, 3;
+@b.list.map({ $_++ }).eager;
+is-deeply @b, [2, 3, 4], '@a.list.map preserves increment writeback';
+
+my $array = $[1, 2, 3];
+my $scalar_map = $array.map({ $_ = 5 });
+is $scalar_map.^name, 'Seq', 'a scalar-held Array map returns a Seq';
+is-deeply $array, [1, 2, 3], 'scalar-held Array map is lazy';
+$scalar_map.eager;
+is-deeply $array, [5, 5, 5], 'scalar-held Array map writes through';
+
+my @c = 1, 2, 3;
+@c.list.grep({ $_ = 9 }).eager;
+is-deeply @c, [9, 9, 9], 'the existing list grep writeback remains intact';
+
+throws-like {
+    (1, 2, 3).map({ $_ = 4 }).eager;
+}, X::AdHoc, 'an immutable List map still rejects topic assignment';
+
+my $literal_array = [1, 2, 3];
+$literal_array.map({ $_ = 4 }).eager;
+is-deeply $literal_array, [4, 4, 4], 'a real Array map may assign to its elements';

--- a/t/map-list-writeback.t
+++ b/t/map-list-writeback.t
@@ -6,7 +6,7 @@ use Test;
 # consumption time. A List literal remains immutable and is covered by the
 # ordinary map topic tests.
 
-plan 10;
+plan 12;
 
 my @a = 1, 2, 3;
 my $mapped = @a.list.map({ $_ = 7 });
@@ -37,3 +37,13 @@ throws-like {
 my $literal_array = [1, 2, 3];
 $literal_array.map({ $_ = 4 }).eager;
 is-deeply $literal_array, [4, 4, 4], 'a real Array map may assign to its elements';
+
+my @explicit = 1, 2, 3;
+@explicit.list.map(-> \x { x.Str }).eager;
+is-deeply @explicit, [1, 2, 3], 'an explicit map parameter does not write back the outer topic';
+
+my @nested = [["bar", "baz", "foo"]];
+for @nested -> $row {
+    $row.map(-> \x { x.Str }).eager;
+}
+is-deeply @nested, [["bar", "baz", "foo"]], 'nested Array maps preserve their source elements';


### PR DESCRIPTION
Completes the B(1) .list-feeding-map producer remainder from #7556.\n\nA real Array reached through @a.list or an itemized scalar still exposes writable element containers. Preserve that source identity in the deferred map mode so callback assignments to  are published when the Seq is consumed. Immutable List receivers retain the readonly topic behavior.\n\nAdded regression coverage for lazy writeback, increments, scalar-held Arrays, existing grep writeback, immutable Lists, and Array literals.\n\nValidation:\n\n- cargo fmt --all\n\n- make lint\n\n- make test\n\n- make roast