### PR TITLE
rakuast: preserve basic type captures

### DIFF
--- a/docs/adr/0011-rakuast-model-layer-and-phasing.md
+++ b/docs/adr/0011-rakuast-model-layer-and-phasing.md
@@ -607,8 +607,9 @@ earlier ones.
   `sub { }` (deferred). Plain positional and array-destructuring sub-signatures are handled
   (2026-09-09, issue #7685): `Parameter.sub-signature` is a recursive `Signature`, and the lowerer
   rebuilds `ParamDef.sub_signature` so the existing binder executes the same destructuring. Named
-  aliases, capture sub-signatures, type captures, and array-shape metadata remain separate
-  boundaries.
+  aliases, capture sub-signatures, and array-shape metadata remain separate boundaries. Basic
+  unconstrained type captures (`::T`) are handled (2026-09-09, issue #7694); smiley-constrained
+  and richer type-capture spellings remain deferred.
 - **Routine return types (2026-08-22, both directions).** raku models the two spellings with
   different nodes and mutsu's internal AST keeps them apart, so the converter never guesses:
   `sub f(--> Int)` → `signature => Signature(parameters => …, returns => Type::Simple(Name))`
@@ -750,6 +751,18 @@ earlier ones.
   (`to_string_value`) to the gist, so `.Str`/`~` also produce the constructor form. This is a
   harmless divergence (no existing code stringifies a RakuAST node, and the raku form embeds a
   non-deterministic address); revisit if/when `.gist` and `.Str` need to diverge.
+
+## Slice outcomes
+
+### 1. Basic type captures (2026-09-09, issue #7694)
+
+The existing `ParamDef.type_constraint` representation is sufficient for the
+basic `::T` form, so no parser or execution redesign was needed. The read and
+write directions now map it to `Parameter.type-captures` containing a
+`Type::Capture` node, preserving the measured Rakudo shape for positional,
+named, bare, and pointy-block parameters. Smiley-constrained captures such as
+`::T:D` still need additional representation if their distinction is to be
+preserved.
 
 ## References
 

--- a/news/2026-09/rakuast-type-captures.md
+++ b/news/2026-09/rakuast-type-captures.md
@@ -1,0 +1,26 @@
+# RakuAST preserves basic type captures
+
+Basic type-capture parameters such as `::T $value` now round-trip through
+mutsu's RakuAST model. The parser and binder already retained the capture in
+`ParamDef.type_constraint` and executed it correctly; the missing piece was the
+model representation.
+
+## Change
+
+- `RakuAST::Type::Capture` is now registered with its constructor and `name`
+  accessor.
+- `RakuAST::Parameter` now reads, constructs, and exposes its
+  `type-captures` list, including bare `::T` parameters without a fabricated
+  target.
+- RakuAST lowering rebuilds the existing `::T` parameter metadata and sends it
+  through the normal compiler and VM path.
+
+Smiley-constrained and other richer type-capture spellings remain separate
+boundaries because the current internal parameter metadata does not preserve
+their full RakuAST distinction.
+
+## Coverage
+
+`t/rakuast-type-capture.t` pins the measured read shape, accessors,
+construction, positional/named/bare/pointy forms, and EVAL execution under both
+mutsu and Rakudo.

--- a/src/rakuast/convert.rs
+++ b/src/rakuast/convert.rs
@@ -2137,8 +2137,8 @@ fn signature(
 }
 
 /// One `Parameter`. Positional sub-signatures are represented recursively as
-/// `sub-signature => Signature`; richer capture forms remain the coverage
-/// boundary.
+/// `sub-signature => Signature`, and a basic `::T` type capture becomes the
+/// `type-captures` field. Richer capture forms remain the coverage boundary.
 fn parameter(pd: &ParamDef, type_setting: bool) -> Result<RakuAstNode, RuntimeError> {
     if pd.onearg
         || pd.literal_value.is_some()
@@ -2160,6 +2160,41 @@ fn parameter(pd: &ParamDef, type_setting: bool) -> Result<RakuAstNode, RuntimeEr
     {
         return Err(unsupported("non-positional signature sub-signature"));
     }
+    let type_capture = match pd.type_constraint.as_deref() {
+        Some(type_constraint) if type_constraint.starts_with("::") => {
+            Some(type_capture_node(type_constraint)?)
+        }
+        _ => None,
+    };
+    // A bare `::T` is represented internally by a synthetic parameter name,
+    // but RakuAST models it as a Parameter with no target. Keep the synthetic
+    // name only in the internal AST used by the existing binder.
+    if pd.name.starts_with("__type_capture__") {
+        let Some(type_capture) = type_capture else {
+            return Err(unsupported("type capture without a capture node"));
+        };
+        let mut fields = Vec::with_capacity(4);
+        if type_setting {
+            fields.push(node_field(Some("type"), type_setting_any()));
+        }
+        fields.push(type_captures_field(type_capture));
+        match &pd.default {
+            Some(default) => fields.push(node_field(Some("default"), convert_expr(default)?)),
+            None => fields.push(RakuAstField {
+                name: Some("optional"),
+                value: RakuAstFieldValue::Node(Value::truth(false)),
+            }),
+        }
+        return Ok(RakuAstNode {
+            class: RakuAstClass::Parameter,
+            fields,
+        });
+    }
+    let ordinary_type_constraint = if type_capture.is_some() {
+        None
+    } else {
+        pd.type_constraint.as_deref()
+    };
     let (sigil, desigil) = split_sigil(&pd.name);
     let mut node = if pd.slurpy || pd.double_slurpy {
         // A typed or where-constrained slurpy carries richer shape; defer.
@@ -2169,7 +2204,10 @@ fn parameter(pd: &ParamDef, type_setting: bool) -> Result<RakuAstNode, RuntimeEr
         slurpy_parameter(sigil, desigil, pd.double_slurpy)?
     } else if pd.named {
         // A typed/defaulted/where-constrained named param carries richer shape.
-        if pd.type_constraint.is_some() || pd.default.is_some() || pd.where_constraint.is_some() {
+        if (pd.type_constraint.is_some() && type_capture.is_none())
+            || pd.default.is_some()
+            || pd.where_constraint.is_some()
+        {
             return Err(unsupported("typed/defaulted named parameter"));
         }
         named_parameter(sigil, desigil, type_setting)?
@@ -2177,12 +2215,21 @@ fn parameter(pd: &ParamDef, type_setting: bool) -> Result<RakuAstNode, RuntimeEr
         simple_parameter(
             sigil,
             desigil,
-            pd.type_constraint.as_deref(),
+            ordinary_type_constraint,
             pd.default.as_ref(),
             type_setting,
             pd.where_constraint.as_deref(),
         )?
     };
+    if let Some(type_capture) = type_capture {
+        let target_index = node
+            .fields
+            .iter()
+            .position(|field| field.name == Some("target"))
+            .ok_or_else(|| unsupported("type capture without a parameter target"))?;
+        node.fields
+            .insert(target_index, type_captures_field(type_capture));
+    }
     if let Some(sub_params) = &pd.sub_signature {
         node.fields.push(node_field(
             Some("sub-signature"),
@@ -2190,6 +2237,33 @@ fn parameter(pd: &ParamDef, type_setting: bool) -> Result<RakuAstNode, RuntimeEr
         ));
     }
     Ok(node)
+}
+
+/// A basic `::T` capture is represented by `Parameter.type-captures` rather
+/// than by the parameter's ordinary `type` node. Smiley-constrained and other
+/// richer capture spellings need more internal metadata and remain deferred.
+fn type_capture_node(type_constraint: &str) -> Result<RakuAstNode, RuntimeError> {
+    let Some(name) = type_constraint.strip_prefix("::") else {
+        return Err(unsupported("type capture"));
+    };
+    if name.is_empty()
+        || !name
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || ch == '_' || ch == '-')
+    {
+        return Err(unsupported("complex type capture"));
+    }
+    Ok(RakuAstNode {
+        class: RakuAstClass::TypeCapture,
+        fields: vec![node_field(None, name_from_identifier(name))],
+    })
+}
+
+fn type_captures_field(type_capture: RakuAstNode) -> RakuAstField {
+    RakuAstField {
+        name: Some("type-captures"),
+        value: RakuAstFieldValue::List(vec![Value::rakuast(Box::new(type_capture))]),
+    }
 }
 
 /// A slurpy parameter `*@a` / `**@a` -> `Parameter(target => …, slurpy =>

--- a/src/rakuast/lower.rs
+++ b/src/rakuast/lower.rs
@@ -654,12 +654,44 @@ fn lower_parameter(parameter: &RakuAstNode, owner: &RakuAstNode) -> Result<Param
     if parameter.class != RakuAstClass::Parameter {
         return Err(unsupported(owner));
     }
-    let target = named_child(parameter, "target")?;
-    if target.class != RakuAstClass::ParameterTargetVar {
+    let type_capture = if let Some(type_captures) = parameter
+        .fields
+        .iter()
+        .find(|f| f.name == Some("type-captures"))
+    {
+        let RakuAstFieldValue::List(items) = &type_captures.value else {
+            return Err(unsupported(owner));
+        };
+        let [type_capture] = items.as_slice() else {
+            return Err(unsupported(owner));
+        };
+        let ValueView::RakuAst(type_capture) = type_capture.view() else {
+            return Err(unsupported(owner));
+        };
+        if type_capture.class != RakuAstClass::TypeCapture {
+            return Err(unsupported(owner));
+        }
+        let name_node = named_child_or_positional(type_capture)?;
+        let name_value = positional_leaf(name_node)?;
+        let ValueView::Str(name) = name_value.view() else {
+            return Err(unsupported(owner));
+        };
+        Some(name.to_string())
+    } else {
+        None
+    };
+    let name = if let Some(target) = parameter.fields.iter().find(|f| f.name == Some("target")) {
+        let target = child_node(&target.value)?;
+        if target.class != RakuAstClass::ParameterTargetVar {
+            return Err(unsupported(owner));
+        }
+        let raw = leaf_str(target, "name")?;
+        raw.strip_prefix('$').map(str::to_string).unwrap_or(raw)
+    } else if let Some(type_capture) = &type_capture {
+        format!("__type_capture__{type_capture}")
+    } else {
         return Err(unsupported(owner));
-    }
-    let raw = leaf_str(target, "name")?;
-    let name = raw.strip_prefix('$').map(str::to_string).unwrap_or(raw);
+    };
     let mut def = positional_param(&name);
     // A named parameter `:$x` carries a `names` list; it binds by name and is
     // optional by default.
@@ -716,6 +748,12 @@ fn lower_parameter(parameter: &RakuAstNode, owner: &RakuAstNode) -> Result<Param
         } else {
             return Err(unsupported(owner));
         }
+    }
+    if let Some(type_capture) = type_capture {
+        if def.type_constraint.is_some() {
+            return Err(unsupported(owner));
+        }
+        def.type_constraint = Some(format!("::{type_capture}"));
     }
     // `$y = EXPR` -> an optional positional with a default value.
     if let Some(d) = parameter.fields.iter().find(|f| f.name == Some("default")) {

--- a/src/rakuast/mod.rs
+++ b/src/rakuast/mod.rs
@@ -116,6 +116,8 @@ pub enum RakuAstClass {
     TypeParameterized,
     // Phase 2 slice 29: coercion types (`Int()`).
     TypeCoercion,
+    // Type parameters such as `::T $value`.
+    TypeCapture,
     // Phase 2 slice 13: class and method declarations.
     Class,
     Method,
@@ -258,6 +260,7 @@ impl RakuAstClass {
             TraitOf => "RakuAST::Trait::Of",
             TypeParameterized => "RakuAST::Type::Parameterized",
             TypeCoercion => "RakuAST::Type::Coercion",
+            TypeCapture => "RakuAST::Type::Capture",
             Class => "RakuAST::Class",
             Method => "RakuAST::Method",
             Role => "RakuAST::Role",
@@ -562,6 +565,7 @@ const RAKUAST_CLASSES: &[RakuAstClass] = &[
     RakuAstClass::TraitOf,
     RakuAstClass::TypeParameterized,
     RakuAstClass::TypeCoercion,
+    RakuAstClass::TypeCapture,
     RakuAstClass::Class,
     RakuAstClass::Method,
     RakuAstClass::Role,
@@ -762,15 +766,15 @@ pub fn construct(
         }))));
     }
     if class_name == "RakuAST::Parameter" && method == "new" {
-        let target = named_arg(args, "target").ok_or_else(|| {
-            RuntimeError::new("RakuAST::Parameter.new requires a `target` argument")
-        })?;
-        require_rakuast_class(
-            &target,
-            RakuAstClass::ParameterTargetVar,
-            "RakuAST::Parameter.new",
-        )?;
-        let mut fields = Vec::with_capacity(6);
+        let target = named_arg(args, "target");
+        if let Some(target) = &target {
+            require_rakuast_class(
+                target,
+                RakuAstClass::ParameterTargetVar,
+                "RakuAST::Parameter.new",
+            )?;
+        }
+        let mut fields = Vec::with_capacity(7);
         if let Some(type_node) = named_arg(args, "type") {
             require_rakuast_type(&type_node, "RakuAST::Parameter.new")?;
             fields.push(RakuAstField {
@@ -798,10 +802,31 @@ pub fn construct(
                 value: RakuAstFieldValue::List(names),
             });
         }
-        fields.push(RakuAstField {
-            name: Some("target"),
-            value: RakuAstFieldValue::Node(target),
-        });
+        if let Some(type_captures) = named_arg(args, "type-captures") {
+            let type_captures = type_captures
+                .as_list_items()
+                .map(<[Value]>::to_vec)
+                .ok_or_else(|| {
+                    RuntimeError::new("RakuAST::Parameter.new expects `type-captures` to be a list")
+                })?;
+            for type_capture in &type_captures {
+                require_rakuast_class(
+                    type_capture,
+                    RakuAstClass::TypeCapture,
+                    "RakuAST::Parameter.new",
+                )?;
+            }
+            fields.push(RakuAstField {
+                name: Some("type-captures"),
+                value: RakuAstFieldValue::List(type_captures),
+            });
+        }
+        if let Some(target) = target {
+            fields.push(RakuAstField {
+                name: Some("target"),
+                value: RakuAstFieldValue::Node(target),
+            });
+        }
         if let Some(optional) = named_arg(args, "optional") {
             if !matches!(optional.view(), ValueView::Bool(_)) {
                 return Err(RuntimeError::new(
@@ -1038,6 +1063,7 @@ fn single_positional_class(class_name: &str, method: &str) -> Option<RakuAstClas
         ("RakuAST::Initializer::Assign", "new") => RakuAstClass::InitializerAssign,
         ("RakuAST::Type::Simple", "new") => RakuAstClass::TypeSimple,
         ("RakuAST::Type::Setting", "new") => RakuAstClass::TypeSetting,
+        ("RakuAST::Type::Capture", "new") => RakuAstClass::TypeCapture,
         ("RakuAST::Trait::Returns", "new") => RakuAstClass::TraitReturns,
         ("RakuAST::Trait::Of", "new") => RakuAstClass::TraitOf,
         _ => return None,
@@ -1115,7 +1141,9 @@ pub fn node_accessor(node: &RakuAstNode, method: &str) -> Option<Value> {
         RakuAstClass::Blockoid => Some("statement-list"),
         RakuAstClass::InitializerAssign => Some("expression"),
         RakuAstClass::MetaInfixAssign => Some("infix"),
-        RakuAstClass::TypeSimple | RakuAstClass::TypeSetting => Some("name"),
+        RakuAstClass::TypeSimple | RakuAstClass::TypeSetting | RakuAstClass::TypeCapture => {
+            Some("name")
+        }
         RakuAstClass::TraitReturns | RakuAstClass::TraitOf => Some("type"),
         _ => None,
     };
@@ -1224,6 +1252,7 @@ fn constructor_is_supported(class: RakuAstClass) -> bool {
             | RakuAstClass::InitializerAssign
             | RakuAstClass::TypeSimple
             | RakuAstClass::TypeSetting
+            | RakuAstClass::TypeCapture
     )
 }
 
@@ -1249,6 +1278,7 @@ fn accessor_names(class: RakuAstClass) -> &'static [&'static str] {
         Parameter => &[
             "type",
             "names",
+            "type-captures",
             "target",
             "optional",
             "default",
@@ -1259,7 +1289,7 @@ fn accessor_names(class: RakuAstClass) -> &'static [&'static str] {
         ParameterTargetVar => &["name"],
         VarDeclarationSimple => &["sigil", "desigilname", "initializer"],
         InitializerAssign => &["expression"],
-        TypeSimple | TypeSetting => &["name"],
+        TypeSimple | TypeSetting | TypeCapture => &["name"],
         _ => &[],
     }
 }

--- a/t/rakuast-type-capture.t
+++ b/t/rakuast-type-capture.t
@@ -1,0 +1,79 @@
+use v6;
+use MONKEY-SEE-NO-EVAL;
+use experimental :rakuast;
+use Test;
+
+# RakuAST type captures. The parser and binder already preserve and execute a
+# basic `::T` capture; this slice exposes that representation in both RakuAST
+# directions without adding another execution path.
+
+plan 17;
+
+my $ast = Q[sub f(::T $x) { $x.^name }].AST;
+my $parameter = $ast.statements[0].expression.signature.parameters[0];
+my $capture = ($parameter.type-captures)[0];
+
+is $parameter.type-captures.elems, 1,
+    'a type-capture parameter exposes one type capture';
+is $capture.^name, 'RakuAST::Type::Capture',
+    'the type capture has the measured RakuAST class';
+is $capture.name.gist, RakuAST::Name.from-identifier('T').gist,
+    'the type capture exposes its captured name';
+ok $ast.gist.contains('type-captures => (')
+    && $ast.gist.contains('RakuAST::Type::Capture.new('),
+    'the read direction renders Parameter.type-captures';
+ok 'name' (elem) RakuAST::Type::Capture.^methods(:local)>>.name,
+    'Type::Capture introspection exposes its name accessor';
+ok 'type-captures' (elem) RakuAST::Parameter.^methods(:local)>>.name,
+    'Parameter introspection exposes type-captures';
+
+is EVAL(Q[sub f(::T $x) { $x.^name }; f(42)].AST), 'Int',
+    'a scalar argument binds through a read-direction type capture';
+is EVAL(Q[sub f(::T $x) { $x.^name }; f('text')].AST), 'Str',
+    'a string argument binds through a read-direction type capture';
+is EVAL(Q[sub f(::T :$x) { $x.^name }; f(:x(42))].AST), 'Int',
+    'a named argument retains its type capture';
+
+my $bare = Q[sub f(::T) { 1 }].AST;
+ok !$bare.statements[0].expression.signature.parameters[0].gist.contains('target =>'),
+    'a bare type capture has no fabricated parameter target';
+is EVAL(Q[sub f(::T) { 1 }; f(Int)].AST), 1,
+    'a bare type capture lowers through EVAL';
+
+my $pointy = Q[-> ::T $x { $x.^name }].AST;
+is (($pointy.statements[0].expression.signature.parameters[0]
+    .type-captures)[0]).^name,
+    'RakuAST::Type::Capture',
+    'pointy-block type captures use the same model node';
+is EVAL(Q[my $f = -> ::T $x { $x.^name }; $f(42)].AST), 'Int',
+    'a pointy-block type capture lowers through EVAL';
+
+my $tc = RakuAST::Type::Capture.new(
+    RakuAST::Name.from-identifier('T'),
+);
+is $tc.name.gist, RakuAST::Name.from-identifier('T').gist,
+    'Type::Capture.new constructs the measured node';
+
+my $constructed-parameter = RakuAST::Parameter.new(
+    type-captures => [$tc],
+    target => RakuAST::ParameterTarget::Var.new(name => '$x'),
+);
+is ($constructed-parameter.type-captures)[0], $tc,
+    'Parameter.new accepts and exposes a type-capture list';
+ok $constructed-parameter.gist.contains('type-captures => ('),
+    'constructed type-capture parameters render their field';
+
+my $statements = RakuAST::StatementList.new;
+$statements.add-statement(
+    RakuAST::Statement::Expression.new(
+        expression => RakuAST::Var::Lexical.new('$x'),
+    ),
+);
+my $constructed = RakuAST::Sub.new(
+    name => RakuAST::Name.from-identifier('constructed-type-capture'),
+    signature => RakuAST::Signature.new(parameters => [$constructed-parameter]),
+    body => RakuAST::Blockoid.new($statements),
+);
+my $callable = EVAL($constructed);
+is $callable(42).^name, 'Int',
+    'a constructed type-capture parameter lowers and executes';


### PR DESCRIPTION
## Summary

- Add the `RakuAST::Type::Capture` model node and `Parameter.type-captures` field.
- Preserve basic unconstrained `::T` captures in read conversion, including bare, positional, named, and pointy-block forms.
- Lower constructed RakuAST captures back into the existing `ParamDef.type_constraint` binder path.
- Add regression coverage, a news entry, and the ADR slice outcome.

## Scope

Smiley-constrained and richer type-capture spellings remain deferred because the current internal parameter metadata does not preserve their full distinction.

Closes #7694
Related to #7564

## Validation

- `cargo fmt --all`
- `make lint`
- `make test`
- `make roast`
- `target/debug/mutsu t/rakuast-type-capture.t`
- `raku t/rakuast-type-capture.t`