### PR TITLE
perf(buf): encode only the new elements on push/append

### DIFF
--- a/news/2026-09/buf-push-encodes-only-new-elements.md
+++ b/news/2026-09/buf-push-encodes-only-new-elements.md
@@ -1,0 +1,107 @@
+# `Buf.push` encodes only the new elements, so filling a buffer is linear again
+
+Assembling a buffer one element at a time — what every binary-protocol routine
+does, from `HTTP::HPACK`'s Huffman `decode-str` to Cro's frame serializers — was
+quadratic in the buffer's length. `$buf.push($byte)` cost time proportional to
+how many bytes `$buf` already held, so the cost of filling an n-byte buffer went
+as n².
+
+## What was happening
+
+A `Buf`/`Blob` stores packed bytes in a `BufData` node, which is the right
+representation. But `push`/`append` reached it through the *element* level of
+`value_buf.rs`'s accessors — the encode/decode boundary that hands out
+`Vec<Value>` — and so round-tripped the **whole buffer** on every call:
+
+1. `buf_elems_or_empty` decoded the storage into one boxed `Value::Int` **per
+   existing byte**;
+2. the new items were appended to that `Vec<Value>`;
+3. `buf_attrs` re-encoded all n+k elements into a fresh `Vec<u8>`;
+4. `write_back_sharing` rebuilt the instance's whole attribute map around it.
+
+Steps 1 and 3 are O(n) per push, and only step 2 has anything to do with what
+the caller asked for. The rvalue path (`Buf.new($x).append: $y`, which has no
+container to write back into) did the same round trip.
+
+## What it does now
+
+The module's doc comment already promised a **byte** level of accessors that
+"speak what the node stores, so a caller that only wants bytes or a count never
+round-trips through boxed `Value`s". `push`/`append`/`unshift`/`prepend` have
+joined it. `extend_buf_elems` reads the element width and kind off the node,
+encodes **only the new elements** at that width, and appends those bytes onto
+the node's storage in place — the same audited unshared-node write
+`put_bytes` performs for `$b[i] = v`, which ADR-0013's `GcBox`/`UnsafeCell`
+interior mutability makes sound. The existing bytes are never read. A
+`Back` push is therefore amortized O(k) in the number of elements pushed,
+independent of the buffer's length; `Front` still shifts the existing bytes, as
+any prepend onto contiguous storage must, but it too no longer decodes them.
+The rvalue path gets `buf_attrs_extended`, the same encode-the-new-elements-only
+construction against a fresh attribute map.
+
+The write goes through the instance's shared attribute cell, so an alias sees the
+push — `my $a = Buf.new(1,2); my $b = $a; $a.push(3)` leaves `$b` with three
+elements, because both names denote the same mutable `Buf` object, which is what
+Raku means. Storage *shared by a re-tagging coercion* (`.Buf`/`.Blob`, which move
+one buffer's node under another name without copying it) is forked instead, so a
+push through one tag is not seen through the other.
+
+## Measurements
+
+Release build, 500 iterations each, this container (`raku` is v2026.07):
+
+| | before | after | rakudo |
+| --- | --- | --- | --- |
+| `Buf.new` + 10 pushes | 0.078 ms | 0.075 ms | 0.043 ms |
+| `Buf.new` + 100 pushes | 0.715 ms | 0.622 ms | 0.009 ms |
+| 10 pushes onto a 200-byte buf | 0.411 ms | 0.075 ms | 0.003 ms |
+| 10 pushes onto a 1000-byte buf | — | 0.059 ms | 0.003 ms |
+| 10 pushes onto a 4000-byte buf | — | 0.059 ms | 0.003 ms |
+
+The last three rows are the point: pushing 10 elements now costs the same
+whether the buffer holds 200 bytes or 4000, where before it scaled with the
+length (a 200-byte buffer already cost 5x an empty one). The 5.5x on the
+200-byte row is what a *small* buffer recovers; the win grows without bound with
+the buffer.
+
+What is left is a flat per-push constant of about 7 µs, roughly 16x an
+`Array.push`, and it is not buffer work at all: a callgrind profile of a
+push-only loop attributes it to `type_matches`, class-name substring searching
+and `composed_roles_seed` — the instance method-dispatch path in front of the
+buffer code, not the buffer code itself. That is filed separately as #7696.
+
+## A truncation the round trip caused
+
+Encoding at the node's own width also fixed a data-corrupting bug the element
+round trip had. `.Buf`/`.Blob` move a buffer's storage node under another class
+name without decoding it, so `buf16.new(0x1234, 0x5678).Buf` is an instance
+whose *class* says width 1 while its *node* is width 2. The old push re-encoded
+the decoded elements at `elem_type(class_name)` — width 1 — and silently
+truncated them:
+
+```
+# before
+my $c = buf16.new(0x1234, 0x5678).Buf;
+say $c.raku;      # Buf.new(4660,22136)
+$c.push(9);
+say $c.raku;      # Buf.new(52,120,9)     <-- both existing elements truncated
+
+# after (and the element values Rakudo gives)
+$c.push(9);
+say $c.raku;      # Buf.new(4660,22136,9)
+```
+
+(mutsu still names that buffer `Buf` where Rakudo names it `Buf[uint16]` — a
+separate gap in the `.Buf` coercion, untouched here.)
+
+## A Blob that could be mutated
+
+`Blob` is immutable, and the rvalue path, `pop`, `shift` and `splice` all refuse
+to modify one. The named-variable `push`/`append` path never checked: `my $blob =
+Blob.new(1,2); $blob.push(3)` silently grew it to three elements instead of
+dying. Since the write it performs is now explicitly in place, the missing check
+went in alongside — `t/buf-push-linear-growth.t` pins it, together with argument
+flattening, width-preserving encoding for `buf16`, element truncation, the
+`X::TypeCheck` on a `Str` element, the alias and `.Blob`-fork semantics above,
+and a 20,000-element fill loop that is a fraction of a second under the
+byte-level path and minutes under the quadratic one.

--- a/src/runtime/methods_call_dispatch.rs
+++ b/src/runtime/methods_call_dispatch.rs
@@ -2421,18 +2421,21 @@ impl Interpreter {
                         return Err(err);
                     }
                 }
-                let mut bytes = buf_elems_or_empty(&attributes);
                 let new_items = Self::flatten_buf_args(args);
-                match method {
-                    "append" | "push" => bytes.extend(new_items),
-                    "prepend" | "unshift" => {
-                        let mut combined = new_items;
-                        combined.extend(bytes);
-                        bytes = combined;
-                    }
+                let end = match method {
+                    "append" | "push" => crate::value::value_buf::BufEnd::Back,
+                    "prepend" | "unshift" => crate::value::value_buf::BufEnd::Front,
                     _ => unreachable!(),
-                }
-                return Ok(make_buf(class_name, bytes));
+                };
+                // Only the new elements are encoded; the existing bytes are
+                // carried across without being decoded to boxed `Value`s (#7680).
+                let attrs = crate::value::value_buf::buf_attrs_extended(
+                    &attributes,
+                    class_name,
+                    &new_items,
+                    end,
+                );
+                return Ok(Value::make_instance(class_name, attrs));
             }
         }
         // Buf/Blob pop/shift on non-variable targets (e.g. Buf.new.pop throws X::Cannot::Empty)

--- a/src/runtime/methods_mut_substr_buf.rs
+++ b/src/runtime/methods_mut_substr_buf.rs
@@ -1,6 +1,8 @@
 use super::*;
 use crate::symbol::Symbol;
-use crate::value::value_buf::{buf_attrs, buf_elems, buf_elems_or_empty, make_buf};
+use crate::value::value_buf::{
+    BufEnd, buf_attrs, buf_elems, buf_elems_or_empty, extend_buf_elems, make_buf,
+};
 
 impl Interpreter {
     pub(crate) fn assign_substr_rw(
@@ -313,19 +315,24 @@ impl Interpreter {
         method: &str,
         args: Vec<Value>,
     ) -> Result<Value, RuntimeError> {
-        let (class_name_sym, mut bytes, orig_id, attrs_cell) = if let ValueView::Instance {
+        let (class_name_sym, orig_id, attrs_cell) = if let ValueView::Instance {
             class_name,
             attributes,
             id,
             ..
         } = target.view()
         {
-            (
-                class_name,
-                buf_elems_or_empty(&attributes),
-                id,
-                attributes.clone(),
-            )
+            // Blob is immutable. The rvalue path below and `buf_pop_shift_splice`
+            // both refuse here; this path used to let a named `Blob` be pushed
+            // to, which mutated it in place.
+            let cn = class_name.resolve();
+            if crate::runtime::utils::is_blob_like_class(&cn) {
+                return Err(RuntimeError::new(format!(
+                    "Cannot modify immutable {} with {}",
+                    cn, method
+                )));
+            }
+            (class_name, id, attributes.clone())
         } else {
             return Err(RuntimeError::new("Not a Buf".to_string()));
         };
@@ -348,24 +355,16 @@ impl Interpreter {
         }
         let new_items: Vec<Value> = Self::flatten_buf_args(args);
 
-        match method {
-            "append" | "push" => {
-                bytes.extend(new_items);
-            }
-            "prepend" | "unshift" => {
-                let mut combined = new_items;
-                combined.extend(bytes);
-                bytes = combined;
-            }
+        let end = match method {
+            "append" | "push" => BufEnd::Back,
+            "prepend" | "unshift" => BufEnd::Front,
             _ => unreachable!(),
-        }
-
-        let updated = Value::write_back_sharing(
-            &attrs_cell,
-            class_name_sym,
-            buf_attrs(class_name_sym, bytes),
-            orig_id,
-        );
+        };
+        // Encode and append only the *new* elements. Rebuilding the whole
+        // attribute map here (decode every existing byte to a boxed `Value`,
+        // extend, re-encode) made filling a buffer quadratic — see #7680.
+        extend_buf_elems(&attrs_cell, class_name_sym, &new_items, end);
+        let updated = Value::instance_sharing_cell(&attrs_cell, class_name_sym, orig_id);
         self.env.insert(target_var.to_string(), updated.clone());
         Ok(updated)
     }

--- a/src/value/value_buf.rs
+++ b/src/value/value_buf.rs
@@ -395,6 +395,112 @@ pub(crate) fn with_buf_elems_mut<R>(
     Some(out)
 }
 
+/// Where [`extend_buf_elems`] puts the new elements.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum BufEnd {
+    /// `push`/`append`.
+    Back,
+    /// `unshift`/`prepend`.
+    Front,
+}
+
+/// Add `new_elems` to one end of a buffer's storage, encoding **only the new
+/// elements** and leaving the bytes already there untouched.
+///
+/// This is the byte-level counterpart of `buf_elems` + `set_buf_elems` for the
+/// one operation that dominates binary-protocol code: assembling a buffer an
+/// element at a time. Going through the element level made that quadratic — a
+/// `push` decoded every existing byte into a boxed `Value::Int`, appended one,
+/// and re-encoded the lot, so the cost of each push scaled with the buffer's
+/// current length (#7680). Here the existing bytes are never read: the new
+/// elements are encoded at the width the node already carries and appended in
+/// place, which is amortized O(k) for a `Back` push.
+///
+/// The `Front` case still shifts the existing bytes, as any prepend onto
+/// contiguous storage must, but it too avoids decoding them.
+///
+/// `class_name` is needed only for the buffer that has no storage node yet,
+/// where the element type has nowhere else to come from — see the module note
+/// on why reads need no class name and construction does.
+pub(crate) fn extend_buf_elems(
+    attrs: &InstanceAttrs,
+    class_name: Symbol,
+    new_elems: &[Value],
+    end: BufEnd,
+) {
+    // Read the element type off the node, then encode the new elements outside
+    // the guard: `elem_to_u64` can call back into the interpreter's numeric
+    // coercion for an allomorph or a `ContainerRef` element.
+    let existing = {
+        let map = attrs.as_map();
+        node_in(&map).map(|node| (node.width, node.kind))
+    };
+    let (width, kind) = existing.unwrap_or_else(|| elem_type(&class_name.resolve()));
+    let added = encode_elems(new_elems, width, kind);
+
+    if existing.is_none() {
+        attrs.insert(ELEMS_ATTR, storage_value(added, width, kind));
+        return;
+    }
+
+    {
+        let map = attrs.as_map();
+        if let Some(node) = node_in(&map)
+            && node.strong_count() == 1
+        {
+            // SAFETY: audited aliased in-place container write (see
+            // `value::aliased_mut`), the same one [`put_bytes`] performs. The
+            // node is unshared, no borrow into it is live across the write, and
+            // the read guard above covers only the attribute map — which is not
+            // what is being mutated.
+            let data = unsafe { crate::value::gc_contents_mut(&node) };
+            splice_in(&mut data.bytes, added, end);
+            return;
+        }
+        // A shared node (`.Buf`/`.Blob` re-tagged this storage under another
+        // name) must be forked, exactly as [`put_bytes`] forks it.
+        let mut bytes = node_in(&map)
+            .map(|node| node.bytes.clone())
+            .unwrap_or_default();
+        drop(map);
+        splice_in(&mut bytes, added, end);
+        attrs.insert(ELEMS_ATTR, storage_value(bytes, width, kind));
+    }
+}
+
+/// The new elements' bytes onto one end of the bytes already there.
+fn splice_in(bytes: &mut Vec<u8>, added: Vec<u8>, end: BufEnd) {
+    match end {
+        BufEnd::Back => bytes.extend_from_slice(&added),
+        BufEnd::Front => {
+            bytes.splice(0..0, added);
+        }
+    }
+}
+
+/// [`extend_buf_elems`] against a fresh `AttrMap` — the rvalue paths, which have
+/// no instance to write back into and build a new buffer from the old one's
+/// bytes plus the encoded new elements.
+pub(crate) fn buf_attrs_extended(
+    attrs: &InstanceAttrs,
+    class_name: Symbol,
+    new_elems: &[Value],
+    end: BufEnd,
+) -> AttrMap {
+    let existing = {
+        let map = attrs.as_map();
+        node_in(&map).map(|node| (node.bytes.clone(), node.width, node.kind))
+    };
+    let (mut bytes, width, kind) = existing.unwrap_or_else(|| {
+        let (w, k) = elem_type(&class_name.resolve());
+        (Vec::new(), w, k)
+    });
+    splice_in(&mut bytes, encode_elems(new_elems, width, kind), end);
+    let mut map = AttrMap::new();
+    map.insert(ELEMS_ATTR, storage_value(bytes, width, kind));
+    map
+}
+
 /// The element container itself, cloned, for the coercions that re-tag a buffer
 /// without looking inside it (`.Buf`, `.Blob`). Pair with [`set_buf_storage`].
 pub(crate) fn buf_storage(map: &AttrMap) -> Option<Value> {

--- a/t/buf-push-linear-growth.t
+++ b/t/buf-push-linear-growth.t
@@ -1,0 +1,128 @@
+use Test;
+
+plan 23;
+
+# `$buf.push(...)` used to round-trip the WHOLE buffer through boxed `Value`s on
+# every call -- decode every existing byte to a `Value::Int`, extend, re-encode --
+# so the cost of one push scaled with the buffer's current length and filling a
+# buffer was O(n^2) (#7680). Only the new elements are encoded now, appended onto
+# the storage node's bytes in place.
+#
+# This file pins both halves: that growth is linear (the 20_000-push loop below
+# is minutes of work under the quadratic path and a fraction of a second under
+# the byte-level one, so a regression shows up as a timeout, not a flaky
+# threshold), and every semantic the element-level round trip used to provide.
+
+# ---------------------------------------------------------------------------
+# Linear growth.
+# ---------------------------------------------------------------------------
+{
+    my $b = Buf.new;
+    $b.push($_ +& 0xFF) for ^20000;
+    is $b.elems, 20000, 'pushing 20_000 elements one at a time completes';
+    is $b[0], 0, 'first pushed element survives';
+    is $b[255], 255, 'a mid-buffer element survives';
+    is $b[19999], 19999 +& 0xFF, 'last pushed element survives';
+}
+
+# ---------------------------------------------------------------------------
+# Ordering, at both ends, on a buffer that already has content.
+# ---------------------------------------------------------------------------
+{
+    my $b = Buf.new(1, 2);
+    $b.push(3);
+    $b.append(4, 5);
+    is $b.raku, 'Buf.new(1,2,3,4,5)', 'push then append go on the end, in order';
+    $b.unshift(0);
+    $b.prepend(254, 255);
+    is $b.raku, 'Buf.new(254,255,0,1,2,3,4,5)', 'unshift/prepend go on the front, in order';
+}
+
+# Pushing onto a buffer that has no elements yet still creates storage.
+{
+    my $b = Buf.new;
+    $b.push(7);
+    is $b.raku, 'Buf.new(7)', 'push onto an empty Buf';
+    my $u = Buf.new;
+    $u.unshift(7);
+    is $u.raku, 'Buf.new(7)', 'unshift onto an empty Buf';
+}
+
+# ---------------------------------------------------------------------------
+# The buffer is one mutable object: an alias sees the push.
+# ---------------------------------------------------------------------------
+{
+    my $a = Buf.new(1, 2);
+    my $alias = $a;
+    $a.push(3);
+    is $alias.raku, 'Buf.new(1,2,3)', 'a second name for the same Buf sees the push';
+}
+
+# ...but storage shared by a re-tagging coercion (.Blob/.Buf) must be forked, so
+# the push is NOT seen through the other tag.
+{
+    my $b = Buf.new(1, 2);
+    my $tag = $b.Blob;
+    $b.push(9);
+    is $b.elems, 3, 'the pushed-to Buf grew';
+    is $tag.elems, 2, '.Blob storage shared with it did not';
+    is $tag.raku, 'Blob.new(1,2)', 'and still holds its own bytes';
+}
+
+# ---------------------------------------------------------------------------
+# Element width: the new elements are encoded at the width the node already
+# has, not at one guessed per call.
+# ---------------------------------------------------------------------------
+{
+    my $w = buf16.new(0x1170, 2);
+    $w.push(0xABCD);
+    is $w.elems, 3, 'buf16 push counts elements, not bytes';
+    is $w[2], 0xABCD, 'a 16-bit element round-trips through push';
+    is $w.raku, 'Buf[uint16].new(4464,2,43981)', 'buf16 keeps its element type across a push';
+}
+
+# `.Buf`/`.Blob` move the storage node under another class name without decoding
+# it, so the instance's class can say width 1 while its node is width 2. The
+# element round trip re-encoded at the CLASS's width and silently truncated the
+# existing elements; encoding at the node's width does not.
+{
+    my $c = buf16.new(0x1234, 0x5678).Buf;
+    is $c.list.Array, [4660, 22136], 're-tagged buf16 keeps its element values';
+    $c.push(9);
+    is $c.list.Array, [4660, 22136, 9],
+      'pushing onto a re-tagged wide buffer does not truncate what was there';
+}
+
+# Out-of-range elements truncate to the element width, as `.new` does.
+{
+    my $b = Buf.new;
+    $b.push(300);
+    $b.push(-1);
+    is $b.raku, 'Buf.new(44,255)', 'push truncates to the element width';
+}
+
+# ---------------------------------------------------------------------------
+# Argument flattening: Buf/Blob, Array and Seq arguments spread their elements.
+# ---------------------------------------------------------------------------
+{
+    my $b = Buf.new(1);
+    $b.push(Buf.new(2, 3));
+    $b.append([4, 5]);
+    $b.append((6, 7).Seq);
+    is $b.raku, 'Buf.new(1,2,3,4,5,6,7)', 'Buf/Array/Seq arguments flatten';
+}
+
+# ---------------------------------------------------------------------------
+# The two checks the element-level path implemented, which the byte-level one
+# must keep: Blob is immutable, and a Str element is a type error.
+# ---------------------------------------------------------------------------
+{
+    my $blob = Blob.new(1, 2);
+    dies-ok { $blob.push(3) }, 'Blob.push dies (immutable)';
+    is $blob.elems, 2, 'and the Blob is unchanged';
+}
+{
+    my $b = Buf.new(1);
+    throws-like { $b.push("x") }, X::TypeCheck, 'pushing a Str is a type check failure';
+    is $b.elems, 1, 'and the Buf is unchanged';
+}


### PR DESCRIPTION
Closes #7680.

Assembling a `Buf` one element at a time — what every binary-protocol routine does, from `HTTP::HPACK`'s Huffman `decode-str` to Cro's frame serializers — was quadratic in the buffer's length.

## Root cause

`push`/`append`/`unshift`/`prepend` reached the storage through the **element** level of `value_buf.rs`'s accessors, so every call round-tripped the whole buffer:

1. `buf_elems_or_empty` decoded the storage into one boxed `Value::Int` **per existing byte**;
2. the new items were appended to that `Vec<Value>`;
3. `buf_attrs` re-encoded all n+k elements into a fresh `Vec<u8>`;
4. `write_back_sharing` rebuilt the instance's whole attribute map around the result.

Steps 1 and 3 are O(n) per push, and neither has anything to do with what the caller asked for. The rvalue path (`Buf.new($x).append: $y`) did the same round trip.

## The change

`extend_buf_elems` joins the **byte** level of accessors the module already documents ("speak what the node stores, so a caller that only wants bytes or a count never round-trips through boxed `Value`s"). It reads the element width and kind off the storage node, encodes **only the new elements** at that width, and appends those bytes onto the node's storage in place — the same audited unshared-node write `put_bytes` performs for `$b[i] = v`, which ADR-0013's `GcBox`/`UnsafeCell` interior mutability makes sound. The existing bytes are never read, so a `Back` push is amortized O(k) in the number of elements pushed, independent of the buffer's length. `Front` still shifts the existing bytes, as any prepend onto contiguous storage must, but it too no longer decodes them.

The rvalue path gets `buf_attrs_extended`, the same encode-the-new-elements-only construction against a fresh attribute map.

The write goes through the instance's shared attribute cell, so an alias sees the push (`my $a = Buf.new(1,2); my $b = $a; $a.push(3)` leaves `$b` with three elements — both names denote the same mutable `Buf`). Storage shared by a *re-tagging* coercion (`.Buf`/`.Blob`) is forked instead, so a push through one tag is not seen through the other.

## Measurements

Release build, 500 iterations each, remote container (`raku` v2026.07):

| | before | after | rakudo |
| --- | --- | --- | --- |
| `Buf.new` + 10 pushes | 0.078 ms | 0.075 ms | 0.043 ms |
| `Buf.new` + 100 pushes | 0.715 ms | 0.622 ms | 0.009 ms |
| 10 pushes onto a **200**-byte buf | 0.411 ms | 0.075 ms | 0.003 ms |
| 10 pushes onto a **1000**-byte buf | — | 0.059 ms | 0.003 ms |
| 10 pushes onto a **4000**-byte buf | — | 0.059 ms | 0.003 ms |

The last three rows are the point: ten pushes now cost the same whether the buffer holds 200 bytes or 4000, where before the cost scaled with the length (a 200-byte buffer already cost 5x an empty one). The win grows without bound with the buffer.

(Local `perf`-style numbers, per the repo convention — not from the bench CI, so they belong in this description rather than in a document.)

## Two correctness fixes that fall out

Encoding at the **node's** own width, rather than at the width the class name implies, fixed a data-corrupting truncation. `.Buf`/`.Blob` move a storage node under another class name without decoding it, so an instance's class can say width 1 while its node is width 2:

```raku
my $c = buf16.new(0x1234, 0x5678).Buf;
say $c.raku;      # Buf.new(4660,22136)
$c.push(9);
# before: Buf.new(52,120,9)      <- both existing elements silently truncated
# after:  Buf.new(4660,22136,9)  <- the element values Rakudo gives
```

And `Blob` is immutable — the rvalue path, `pop`, `shift` and `splice` all refuse to modify one, but the named-variable `push`/`append` path never checked, so `my $blob = Blob.new(1,2); $blob.push(3)` grew it in place instead of dying. Since the write it performs is now explicitly in place, the missing check went in alongside.

## Tests

`t/buf-push-linear-growth.t` (23 assertions) pins both fixes plus everything the element round trip used to provide: ordering at both ends, pushing onto empty storage, argument flattening (Buf/Array/Seq), width-preserving encoding for `buf16`, element truncation, the `X::TypeCheck` on a `Str` element, and the alias / `.Blob`-fork semantics. The growth half is a 20,000-element fill loop — a fraction of a second under the byte-level path and minutes under the quadratic one — so a regression shows up as a timeout rather than a flaky threshold. All 23 pass under Rakudo v2026.07 as well as mutsu.

## Verification

- `cargo fmt --all`, `make lint` (all four configurations) — clean.
- `make test` — `Result: PASS`, 0 failures.
- `make roast` — the three documented environment-only failures and nothing else (`6.c/S32-io/file-tests.t` tests 6-8/10 and `S16-filehandles/filetest.t` under `uid 0`; `S32-io/IO-Socket-Async.t` exit 124 under the sandboxed network), matching `docs/agent-environments.md` exactly.

## Follow-up

What remains is a flat ~7 µs per call — roughly 16x an `Array.push` — and callgrind attributes it to the instance method-dispatch path in front of the buffer code (`type_matches`, class-name substring scans, `composed_roles_seed`), not to buffer work. Filed separately as #7696.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JA6zJefUzr27YTT1wikgZn

---
_Generated by [Claude Code](https://claude.ai/code/session_01JA6zJefUzr27YTT1wikgZn)_