### PR TITLE
perf(multi): resolve a multi call once and memoise its compiled-key probe

### DIFF
--- a/news/2026-09/multi-call-resolves-once-and-memoises-its-probe-chain.md
+++ b/news/2026-09/multi-call-resolves-once-and-memoises-its-probe-chain.md
@@ -1,0 +1,83 @@
+# A `multi` call resolves once, and remembers what the compiled-key probe found
+
+Calling a `multi sub` cost 23 124 more retired instructions than calling a plain
+`sub` with an identical signature — measured with callgrind on a 20 000-iteration
+loop over `multi sub m(Mu $c, $d = '')` against `sub s(Mu $c, $d = '')`, both
+called `(1, "x")`. That surcharge is now **13 235 Ir, a 42.8% cut**, and the whole
+benchmark went from 596.3 M to 398.7 M retired instructions (-33.1%). It is the
+first of the two items [#7573](https://github.com/tokuhirom/mutsu/issues/7573)
+left open after #7684, which had already brought the surcharge down from 41 553.
+
+Everything below is dispatch bookkeeping. The opcode stream is byte-identical
+before and after, as it was for #7684 — reducing opcode count is not what makes a
+call cheap.
+
+## The call resolved itself twice
+
+`dispatch_func_call_inner` asks `find_compiled_function` for a compiled body
+first. For a `multi` whose winning candidate does not live in the caller's
+`compiled_fns` table — the ordinary shape — that returns `None`, and the multi
+branch below it then resolves the winner itself and runs it through
+`compile_and_call_function_def`. Both halves called
+`resolve_function_multi_cached`, so `multi_arg_type_keys` built the same cache
+key twice per call: a `Symbol` per argument, plus one per argument *property*
+(definedness, a `VarRef`'s declared type, an enum member).
+
+`find_compiled_function_memo` now hands its resolution back to the caller, which
+uses it instead of resolving again. The memo is only filled when the answer came
+from the *type-keyed* path — `resolve_function_multi_cached_keyed` reports that
+as a second return value. This matters: the un-keyed fallback runs the full
+`resolve_function_with_types` candidate walk, which reads
+`pending_call_arg_sources` (an `is rw` parameter accepts only a writable
+lvalue), and the two call sites run under different pending sources. A candidate
+set containing an `is rw` parameter is exactly what
+`func_multi_dispatch_type_cacheable` refuses, so the two conditions line up and
+a shared resolution is only ever reused where nothing else about the call could
+have changed the answer.
+
+## The probe chain ran in full on every call
+
+The larger half. `find_compiled_function_inner` looks for a compiled body by
+building candidate key strings and probing `compiled_fns` with each: package-
+qualified, arity-qualified, type-signature-qualified, fingerprint-qualified,
+walking outwards from the innermost package to `GLOBAL`. Around fifteen
+`format!`ed `String`s per call. For a non-multi the answer is memoised in
+`fn_resolve_cache` and the chain runs once; a `multi` is deliberately excluded
+from that cache, because its key cannot tell apart two calls that share a type
+signature but pick different candidates. So the chain ran in full on every
+single multi call — and for the common shape all fifteen probes fail and the
+answer is a constant `None`.
+
+`multi_compiled_key_cache` memoises it, keyed by the *resolved winner's body
+fingerprint* alongside everything else the chain reads: the name, the current
+package and the innermost lexical package (the two inputs `bare_name_packages()`
+derives its search list from), the arity and the positional arity, and the
+argument type signature. The fingerprint is what makes this sound where a plain
+type-signature key is not — the resolution has already picked the winner, and
+the probes only ever accept a body matching it. Unlike `fn_resolve_cache` this
+memo also stores the negative answer, which is the whole point. A positive hit
+is still re-validated against the table and falls back to a fresh probe if it
+has gone stale; the whole memo is cleared with `fn_resolve_cache` whenever
+`fn_resolve_gen` moves.
+
+While there: the type signature these keys are built from is now
+`Vec<&'static str>` rather than `Vec<String>`. `value_type_name` returns a
+`&'static str` to begin with, so a key that is rebuilt on every call was
+heap-allocating a `String` per argument for no reason.
+
+## What is left
+
+`find_compiled_function_inner` is down from 225.0 M inclusive instructions
+(37.7% of the benchmark) to 45.6 M, and the single remaining resolution is
+40.9 M. The next-largest item on this path is `compile_and_call_function_def` at
+114.9 M — 5 745 Ir per call against the 1 090 Ir an ordinary sub pays through
+`call_compiled_function_positional_light`. Item 2 of #7573 (whether the
+`__mutsu_test_callsite_line` marker should still be a runtime named argument)
+and the flat interpretation cost of the vendored `Test` module are untouched.
+
+`t/multi-dispatch-resolution-cache.t` pins the shapes a key-blind memo would get
+wrong: one call site alternating between candidates, arity-selected candidates,
+`:D`/`:U` smileys sharing a type name, a subset and a `where` constraint making
+the winner depend on the value, an `is rw` candidate selected by the call site
+rather than the argument type, the same bare name resolving differently in two
+packages, and a redeclared body reached through `EVAL`.

--- a/src/runtime/accessors_state.rs
+++ b/src/runtime/accessors_state.rs
@@ -862,8 +862,29 @@ impl Interpreter {
         name: &str,
         args: &[Value],
     ) -> Option<Arc<FunctionDef>> {
+        self.resolve_function_multi_cached_keyed(name, args).0
+    }
+
+    /// [`Self::resolve_function_multi_cached`], plus whether the answer came
+    /// from the sound *type-keyed* path — i.e. is a pure function of
+    /// `(package, name, argument type keys)` and so depends on nothing else
+    /// about the call, `pending_call_arg_sources` included.
+    ///
+    /// Only a `true` here licenses reusing one resolution for two consumers:
+    /// the un-keyed fallback runs the full `resolve_function_with_types`
+    /// candidate walk, which *does* read `pending_call_arg_sources` (an `is rw`
+    /// parameter accepts only a writable lvalue), so two resolutions of the
+    /// same call under different pending sources may legitimately differ. A
+    /// candidate set containing an `is rw` parameter is exactly what
+    /// `func_multi_dispatch_type_cacheable` refuses, so the two conditions line
+    /// up (#7573).
+    pub(crate) fn resolve_function_multi_cached_keyed(
+        &mut self,
+        name: &str,
+        args: &[Value],
+    ) -> (Option<Arc<FunctionDef>>, bool) {
         let Some(arg_keys) = self.multi_arg_type_keys(args) else {
-            return self.resolve_function_with_types(name, args);
+            return (self.resolve_function_with_types(name, args), false);
         };
         // The atomic mirror, not `current_package()`: the owned form is a
         // `RwLock` read plus a `String` heap allocation on a path that runs on
@@ -871,11 +892,11 @@ impl Interpreter {
         let pkg_sym = self.current_package_sym();
         let name_sym = Symbol::intern(name);
         if !self.func_multi_dispatch_type_cacheable(pkg_sym, name_sym, name) {
-            return self.resolve_function_with_types(name, args);
+            return (self.resolve_function_with_types(name, args), false);
         }
         let key = (pkg_sym, name_sym, arg_keys);
         if let Some(hit) = self.func_multi_resolve_cache.get(&key) {
-            return hit.clone();
+            return (hit.clone(), true);
         }
         let resolved = self.resolve_function_with_types(name, args);
         // Ambiguity is signaled by `None` + a pending dispatch error; that must be
@@ -884,7 +905,7 @@ impl Interpreter {
         if !ambiguous {
             self.func_multi_resolve_cache.insert(key, resolved.clone());
         }
-        resolved
+        (resolved, !ambiguous)
     }
 
     /// True when `class_name`'s MRO (or direct parents) includes a builtin

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1597,6 +1597,29 @@ pub(crate) mod end_order {
     }
 }
 
+/// Key of [`Interpreter::multi_compiled_key_cache`]: everything
+/// `find_compiled_function_inner`'s probe chain reads for a bare `multi` name.
+///
+/// `pkg` and `lexical_pkg` are the two inputs `bare_name_packages()` derives its
+/// search list from, so a hit can never answer for the wrong package scope
+/// (the same pair `has_proto`'s memo keys on). `arity`/`pos_arity` are both
+/// present because the probe chain builds keys from each, and two calls sharing
+/// a type signature can still differ in how many of their arguments are
+/// string-keyed `Pair`s. `fingerprint` is the resolved winner's body
+/// fingerprint, which every probe filters on. Names containing `::` are never
+/// cached here — their probe chain additionally consults `env` for prefix
+/// visibility, which this key does not capture.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct MultiCompiledKey {
+    pub(crate) name: Symbol,
+    pub(crate) pkg: Symbol,
+    pub(crate) lexical_pkg: Option<Symbol>,
+    pub(crate) arity: usize,
+    pub(crate) pos_arity: usize,
+    pub(crate) fingerprint: u64,
+    pub(crate) type_sig: Vec<&'static str>,
+}
+
 /// What a `(name, callsite package)` pair in `pos_light_call_cache` resolves to.
 ///
 /// Both variants denote a body that `is_positional_light_call_eligible` has
@@ -3311,10 +3334,26 @@ pub struct Interpreter {
     /// package-sensitive: `PkgA::which` and `PkgB::which` are different
     /// routines reached by the same bare name, and a package-blind key let
     /// whichever package called first answer for both.
+    /// The type names are `&'static str` (that is what `value_type_name`
+    /// returns), so building a probe key costs one `Vec` and no `String` — this
+    /// key is rebuilt on every call that reaches `find_compiled_function`.
     pub(crate) fn_resolve_cache:
-        rustc_hash::FxHashMap<(Symbol, Symbol, usize, Vec<String>), (Symbol, u64, String)>,
+        rustc_hash::FxHashMap<(Symbol, Symbol, usize, Vec<&'static str>), (Symbol, u64, String)>,
     pub(crate) fn_resolve_gen: u64,
     pub(crate) fn_resolve_cache_gen: u64,
+    /// Memo for the compiled-key probe chain of a `multi` name
+    /// (`find_compiled_function_inner`). `fn_resolve_cache` above deliberately
+    /// withholds itself from a multi, because its key cannot tell two calls
+    /// apart that share a type signature but pick different candidates — so
+    /// every multi call re-ran ~15 `format!`ed key probes against
+    /// `compiled_fns`, which for the common shape (the winning candidate is not
+    /// in the caller's table) all fail. Keying on the *resolved winner's*
+    /// fingerprint sidesteps that: the resolution itself is the sound part, and
+    /// the probe outcome is a pure function of this key. Unlike
+    /// `fn_resolve_cache` this memo also stores the NEGATIVE answer, which is
+    /// the whole point (#7573). Invalidated wholesale with `fn_resolve_cache`
+    /// on a `fn_resolve_gen` change.
+    pub(crate) multi_compiled_key_cache: rustc_hash::FxHashMap<MultiCompiledKey, Option<Symbol>>,
     pub(crate) multi_candidates_cache: rustc_hash::FxHashMap<Symbol, bool>,
     pub(crate) multi_candidates_cache_gen: u64,
     /// Memo for [`Self::has_proto`], keyed by the full bare-name lookup

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -3216,6 +3216,7 @@ impl Interpreter {
             fn_resolve_cache: Default::default(),
             fn_resolve_gen: 0,
             fn_resolve_cache_gen: 0,
+            multi_compiled_key_cache: Default::default(),
             multi_candidates_cache: Default::default(),
             multi_candidates_cache_gen: 0,
             has_proto_cache: Default::default(),

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -925,6 +925,7 @@ impl Interpreter {
             fn_resolve_cache: Default::default(),
             fn_resolve_gen: 0,
             fn_resolve_cache_gen: 0,
+            multi_compiled_key_cache: Default::default(),
             multi_candidates_cache: Default::default(),
             multi_candidates_cache_gen: 0,
             has_proto_cache: Default::default(),

--- a/src/vm/vm_call_func_ops.rs
+++ b/src/vm/vm_call_func_ops.rs
@@ -983,7 +983,7 @@ impl Interpreter {
                 name_sym,
                 self.current_package_sym(),
                 0usize,
-                Vec::<String>::new(),
+                Vec::<&'static str>::new(),
             );
             let use_cache = !self.has_multi_candidates_cached(name_str);
             if use_cache
@@ -1501,8 +1501,11 @@ impl Interpreter {
             loan_env!(self, maybe_fetch_rw_proxy(result, true))
         } else {
             self.set_pending_call_arg_sources(arg_sources.clone());
+            // The multi winner this resolves on the way, so the multi branch
+            // below does not resolve the identical call a second time (#7573).
+            let mut multi_def_memo: Option<Arc<crate::ast::FunctionDef>> = None;
             let compiled = if !self.has_proto_cached(name) {
-                self.find_compiled_function(compiled_fns, name, &args)
+                self.find_compiled_function_memo(compiled_fns, name, &args, &mut multi_def_memo)
             } else {
                 None
             };
@@ -1702,7 +1705,13 @@ impl Interpreter {
                         // per-call registry walk + candidate match/rank/dedup;
                         // value-dependent / un-keyable / ambiguous calls resolve
                         // fresh (byte-identical to `resolve_function_with_types`).
-                        && let Some(def) = loan_env!(self, resolve_function_multi_cached(name, &args))
+                        && let Some(def) = match multi_def_memo.take() {
+                            // Already resolved by `find_compiled_function_memo`
+                            // above, and only ever memoised when that answer is
+                            // a pure function of the argument type keys.
+                            memoised @ Some(_) => memoised,
+                            None => loan_env!(self, resolve_function_multi_cached(name, &args)),
+                        }
                         // A genuine multi candidate: the name is multi-cached, so
                         // `compile_and_call_function_def` never name-caches this
                         // candidate — a default param is safe here (unlike the

--- a/src/vm/vm_call_resolve.rs
+++ b/src/vm/vm_call_resolve.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::runtime::MultiCompiledKey;
 
 impl Interpreter {
     pub(super) fn find_compiled_function<'a>(
@@ -7,11 +8,31 @@ impl Interpreter {
         name: &str,
         args: &[Value],
     ) -> Option<&'a Arc<CompiledFunction>> {
+        self.find_compiled_function_memo(compiled_fns, name, args, &mut None)
+    }
+
+    /// [`Self::find_compiled_function`], handing back the multi resolution it
+    /// performed on the way.
+    ///
+    /// `dispatch_func_call_inner` needs the same winner immediately afterwards
+    /// when this returns `None` for a `multi` name, and used to resolve it a
+    /// second time — rebuilding `multi_arg_type_keys` (a `Symbol` per argument
+    /// property) for an answer already in hand. `memo` is filled only when the
+    /// resolution came from the type-keyed path, which by construction cannot
+    /// depend on anything about the call that changed in between; see
+    /// [`Interpreter::resolve_function_multi_cached_keyed`] (#7573).
+    pub(super) fn find_compiled_function_memo<'a>(
+        &mut self,
+        compiled_fns: &'a CompiledFns,
+        name: &str,
+        args: &[Value],
+        memo: &mut Option<Arc<crate::ast::FunctionDef>>,
+    ) -> Option<&'a Arc<CompiledFunction>> {
         // Pseudo-package names need interpreter's special resolution
         if self.is_interpreter_handled_function(name) {
             return None;
         }
-        self.find_compiled_function_inner(compiled_fns, name, args)
+        self.find_compiled_function_inner(compiled_fns, name, args, memo)
     }
 
     /// Get the cached package for a function, if available.
@@ -27,24 +48,26 @@ impl Interpreter {
         compiled_fns: &'a CompiledFns,
         name: &str,
         args: &[Value],
+        memo: &mut Option<Arc<crate::ast::FunctionDef>>,
     ) -> Option<&'a Arc<CompiledFunction>> {
         let arity = args.len();
         let name_sym = Symbol::intern(name);
-        // ONE type signature, shared by the resolution-cache key and by the
-        // compiled-key probes further down. Both used to build the identical
-        // `Vec<String>` independently, so every call allocated a `String` per
-        // argument twice over, plus a third `Vec` for the key's `clone` -- and
-        // on a MULTI name, where `use_cache` is false, every one of the key's
-        // allocations was for a lookup that never happens. `find_compiled_function_inner`
-        // is 40% of a multi call's retired instructions (#7573).
-        let type_sig: Vec<String> = args
-            .iter()
-            .map(|v| runtime::value_type_name(v).to_string())
-            .collect();
+        // ONE type signature, shared by both resolution-cache keys and by the
+        // compiled-key probes further down. The probes used to build their own
+        // copy, so every call allocated a `String` per argument twice over; the
+        // names are `&'static str` to begin with, so neither copy needs to own
+        // one at all. `find_compiled_function_inner` was 40% of a multi call's
+        // retired instructions (#7573).
+        let type_sig: Vec<&'static str> = args.iter().map(runtime::value_type_name).collect();
         // Check the resolution cache first to avoid expensive resolve_function_with_types.
         // Skip cache for multi functions since subset type dispatch depends on values.
-        let use_cache = !self.has_multi_candidates_cached(name);
-        let cache_key = use_cache.then(|| {
+        let is_multi = self.has_multi_candidates_cached(name);
+        if self.fn_resolve_cache_gen != self.fn_resolve_gen {
+            self.fn_resolve_cache.clear();
+            self.multi_compiled_key_cache.clear();
+            self.fn_resolve_cache_gen = self.fn_resolve_gen;
+        }
+        let cache_key = (!is_multi).then(|| {
             (
                 name_sym,
                 self.current_package_sym(),
@@ -53,25 +76,23 @@ impl Interpreter {
             )
         });
         if let Some(cache_key) = &cache_key
-            && self.fn_resolve_cache_gen == self.fn_resolve_gen
+            && let Some((cached_key, cached_fp, _)) = self.fn_resolve_cache.get(cache_key)
+            && let Some(cf) = compiled_fns.get(cached_key)
+            && cf.fingerprint == *cached_fp
         {
-            if let Some((cached_key, cached_fp, _)) = self.fn_resolve_cache.get(cache_key)
-                && let Some(cf) = compiled_fns.get(cached_key)
-                && cf.fingerprint == *cached_fp
-            {
-                return Some(cf);
-            }
-        } else if self.fn_resolve_cache_gen != self.fn_resolve_gen {
-            self.fn_resolve_cache.clear();
-            self.fn_resolve_cache_gen = self.fn_resolve_gen;
+            return Some(cf);
         }
         // Same sound multi-resolution cache the interpreter's dispatch uses:
-        // `use_cache` above deliberately withholds the *compiled-key* cache from
+        // `cache_key` above deliberately withholds the *compiled-key* cache from
         // a multi name (its winner depends on argument types), but the
         // resolution itself is still cacheable whenever the candidates are
         // type+arity deterministic, and for a `multi` this call was otherwise a
         // full candidate walk on every single dispatch.
-        let resolved_def = loan_env!(self, resolve_function_multi_cached(name, args));
+        let (resolved_def, type_keyed) =
+            loan_env!(self, resolve_function_multi_cached_keyed(name, args));
+        if type_keyed {
+            memo.clone_from(&resolved_def);
+        }
         let expected_fingerprint = resolved_def.as_ref().map(|def| def.body_fingerprint());
         // If runtime resolution fails, avoid reusing stale compiled cache entries.
         // This can happen across repeated EVAL calls that redefine the same routine name.
@@ -85,6 +106,46 @@ impl Interpreter {
                     .count()
             })
             .unwrap_or(arity);
+        // Positional arity (the probe chain builds keys from it as well as from
+        // the raw arity, and it is part of the multi memo key below).
+        let pos_arity = args.iter().filter(|a| !a.is_string_pair_value()).count();
+        // The multi memo (#7573). A `multi` is excluded from `fn_resolve_cache`
+        // above, so without this every call re-ran the whole `format!` probe
+        // chain below — ~15 heap-allocated key strings and as many
+        // `Symbol::lookup`s — even though for the common shape (the winning
+        // candidate lives outside the caller's `compiled_fns`) they all fail and
+        // the answer is a constant `None`. Keyed by the resolved winner's
+        // fingerprint plus everything else the chain reads, so a hit reproduces
+        // the probe result exactly; a positive hit is still re-validated against
+        // the table and falls through to a fresh probe if it has gone stale.
+        let multi_memo_key = (is_multi && !name.contains("::")).then(|| MultiCompiledKey {
+            name: name_sym,
+            pkg: self.current_package_sym(),
+            lexical_pkg: self
+                .routine_stack()
+                .last()
+                .and_then(|frame| frame.lexical_package),
+            arity,
+            pos_arity,
+            fingerprint: expected_fingerprint,
+            type_sig: type_sig.clone(),
+        });
+        if let Some(memo_key) = &multi_memo_key
+            && let Some(hit) = self.multi_compiled_key_cache.get(memo_key).copied()
+        {
+            match hit {
+                None => return None,
+                Some(key) => {
+                    if let Some(cf) = compiled_fns
+                        .get(&key)
+                        .filter(|cf| cf.fingerprint == expected_fingerprint)
+                    {
+                        return Some(cf);
+                    }
+                    // Stale entry: re-probe below rather than answering `None`.
+                }
+            }
+        }
         let matches_resolved = |cf: &CompiledFunction| cf.fingerprint == expected_fingerprint;
         // Probe a candidate key string. The map is keyed by `Symbol`; every real
         // key was interned at compile time, so `Symbol::lookup` (no interning)
@@ -126,7 +187,6 @@ impl Interpreter {
                 }
             }
         } else {
-            let pos_arity = || args.iter().filter(|a| !a.is_string_pair_value()).count();
             // Innermost package first, then each enclosing package, then GLOBAL:
             // a method of `NL::Searcher` calling a bare name must reach `NL`'s
             // compiled routine (see `bare_name_packages`). The GLOBAL fallback
@@ -149,11 +209,10 @@ impl Interpreter {
                 // and then discards it (the `else { found_key = None }` below).
                 // Behaviour-preserving — the def-arity fallback re-resolves.
                 let simple_or_pos = probe(&format!("{}::{}", pkg, name)).or_else(|| {
-                    let pos = pos_arity();
-                    if pos != arity {
+                    if pos_arity != arity {
                         probe(&format!(
                             "{}::{}/{}#{:x}",
-                            pkg, name, pos, expected_fingerprint
+                            pkg, name, pos_arity, expected_fingerprint
                         ))
                     } else {
                         None
@@ -167,11 +226,10 @@ impl Interpreter {
                     .or_else(|| probe(&format!("GLOBAL::{}", name)))
                     .or_else(|| {
                         // Try with positional-only arity (excluding Pair named args)
-                        let pos = pos_arity();
-                        if pos != arity {
+                        if pos_arity != arity {
                             probe(&format!(
                                 "GLOBAL::{}/{}#{:x}",
-                                name, pos, expected_fingerprint
+                                name, pos_arity, expected_fingerprint
                             ))
                         } else {
                             None
@@ -199,6 +257,9 @@ impl Interpreter {
                     None
                 }
             });
+        }
+        if let Some(memo_key) = multi_memo_key {
+            self.multi_compiled_key_cache.insert(memo_key, found_key);
         }
         if let Some(key) = found_key {
             // Cache the resolution result for future lookups

--- a/t/multi-dispatch-resolution-cache.t
+++ b/t/multi-dispatch-resolution-cache.t
@@ -1,0 +1,91 @@
+use v6;
+use Test;
+
+# The multi call path memoises two things per call site (#7573): the winning
+# candidate resolved by `resolve_function_multi_cached`, and the outcome of the
+# compiled-key probe chain that looks for a compiled body for that winner. Both
+# memos are keyed by the argument type signature and by the winner's body
+# fingerprint. Every test below is a shape where a key-blind memo would hand a
+# later call the earlier call's answer.
+
+plan 23;
+
+# --- the winner varies with the argument types at one call site -------------
+multi sub kind(Int $x) { "Int" }
+multi sub kind(Str $x) { "Str" }
+multi sub kind(Rat $x) { "Rat" }
+
+my @mixed = 1, "a", 1.5, 2, "b", 2.5;
+my @kinds = @mixed.map({ kind($_) });
+is @kinds.join(","), "Int,Str,Rat,Int,Str,Rat", "one call site alternating between candidates";
+
+# Repeating the whole sequence must not drift once every bucket is warm.
+is @mixed.map({ kind($_) }).join(","), "Int,Str,Rat,Int,Str,Rat", "same sequence again, caches warm";
+
+# --- arity is part of the key ----------------------------------------------
+multi sub how-many() { 0 }
+multi sub how-many($a) { 1 }
+multi sub how-many($a, $b) { 2 }
+
+is how-many(), 0, "zero-arity candidate";
+is how-many("x"), 1, "one-arity candidate";
+is how-many("x", "y"), 2, "two-arity candidate";
+is how-many(), 0, "zero-arity again after the others";
+
+# --- definedness refines within one type name ------------------------------
+multi sub smiley(Int:D $x) { "defined" }
+multi sub smiley(Int:U $x) { "undefined" }
+
+my Int $def = 7;
+my Int $undef;
+is smiley($def), "defined", "Int:D candidate";
+is smiley($undef), "undefined", "Int:U candidate (same type name as Int:D)";
+is smiley($def), "defined", "Int:D again after Int:U";
+
+# --- a subset makes the winner depend on the VALUE, not just the type ------
+subset Small of Int where * < 10;
+multi sub bucket(Small $x) { "small" }
+multi sub bucket(Int $x) { "big" }
+
+is bucket(3), "small", "subset candidate wins for a small value";
+is bucket(300), "big", "plain Int candidate wins for a big value (same type name)";
+is bucket(4), "small", "subset candidate again";
+
+# --- a `where` constraint, likewise value-dependent ------------------------
+multi sub parity(Int $x where * %% 2) { "even" }
+multi sub parity(Int $x) { "odd" }
+
+is parity(4), "even", "where-constrained candidate";
+is parity(5), "odd", "unconstrained candidate (identical type name)";
+
+# --- `is rw` matches on the call site, not the argument type ---------------
+multi sub touch($x is rw) { "rw" }
+multi sub touch($x) { "ro" }
+
+my $lvalue = 1;
+is touch($lvalue), "rw", "writable lvalue picks the `is rw` candidate";
+is touch(1), "ro", "literal picks the read-only candidate";
+is touch($lvalue), "rw", "writable lvalue again after the literal";
+
+# --- package scoping: the same bare name in two packages -------------------
+module Alpha {
+    multi sub which($x) { "alpha" }
+    our sub ask() { which(1) }
+}
+module Beta {
+    multi sub which($x) { "beta" }
+    our sub ask() { which(1) }
+}
+is Alpha::ask(), "alpha", "bare multi name resolves in its own package";
+is Beta::ask(), "beta", "the same bare name resolves in the other package";
+is Alpha::ask(), "alpha", "and back again";
+
+# --- a redeclared multi body must not be answered from the earlier memo -----
+# Same name, same call, same argument type signature, different body: only the
+# winner's body fingerprint tells the two apart.
+is EVAL('multi sub late($x) { "first" }; late(1)'), "first",
+    "EVAL-declared multi candidate";
+is EVAL('multi sub late($x) { "second" }; late(1)'), "second",
+    "a redeclared body is not answered from the previous EVAL's memo";
+is EVAL('multi sub late($x) { "third" }; multi sub late(Str $x) { "str" }; late(1) ~ late("s")'),
+    "thirdstr", "a candidate added alongside it dispatches on type as usual";


### PR DESCRIPTION
Item 1 of [#7573](https://github.com/tokuhirom/mutsu/issues/7573)'s "Where to start next": collapse the double multi resolution in `dispatch_func_call_inner`. The ticket estimated it at "roughly half of what is left"; it lands at 42.8%.

## Measurement

callgrind retired instructions (exact, load-independent — wall clock on this box wobbles ±13%, larger than most effects on this ticket). 20 000-iteration loop, release build, accumulator returned and printed so the loop is not optimised away:

```raku
multi sub m(Mu $c, $d = '') { $c }   # vs   sub s(Mu $c, $d = '') { $c }
my $acc = 0;
for ^20000 { $acc = $acc + m(1, "x") }
say $acc;
```

| | plain `sub` | `multi` | multi surcharge / call |
| --- | --- | --- | --- |
| before (`main`) | 133.78 M | 596.26 M | 23 124 Ir |
| after | 133.97 M | 398.67 M | **13 235 Ir (-42.8%)** |

Whole benchmark 596.3 M -> 398.7 M Ir (**-33.1%**). The opcode stream is byte-identical before and after — this is all dispatch bookkeeping, exactly as it was for #7684.

## What was wrong

Both causes are on the path `dispatch_func_call_inner` takes for a `multi` whose winning candidate does not live in the caller's `compiled_fns` table — the ordinary shape.

### 1. The call resolved itself twice

`find_compiled_function` resolved the winner to get a fingerprint to probe with, returned `None`, and the multi branch below it resolved the identical call again. So `multi_arg_type_keys` built the same key twice per call: a `Symbol` per argument plus one per argument *property* (definedness, a `VarRef`'s declared type, an enum member).

`find_compiled_function_memo` now hands its resolution back to the caller. The memo is filled **only** when the answer came from the type-keyed path, which `resolve_function_multi_cached_keyed` now reports as a second return value. That gate matters: the un-keyed fallback runs the full `resolve_function_with_types` candidate walk, which reads `pending_call_arg_sources` (an `is rw` parameter accepts only a writable lvalue), and the two call sites run under different pending sources. A candidate set containing an `is rw` parameter is exactly what `func_multi_dispatch_type_cacheable` refuses, so the two conditions line up and a resolution is only ever shared where nothing about the call could have changed the answer.

`resolve_function_multi_cached` inclusive: 81.5 M -> 40.9 M.

### 2. The compiled-key probe chain ran in full on every call

The larger half. `find_compiled_function_inner` looks for a compiled body by building candidate key strings and probing `compiled_fns` with each — package-qualified, arity-qualified, type-signature-qualified, fingerprint-qualified, walking outwards from the innermost package to `GLOBAL`. Around fifteen `format!`ed `String`s per call. A non-multi memoises the outcome in `fn_resolve_cache`; a `multi` is deliberately excluded from that cache, because its key cannot tell apart two calls that share a type signature but pick different candidates. So the chain ran in full on every single multi call — and for the common shape all fifteen probes fail and the answer is a constant `None`.

`multi_compiled_key_cache` memoises it, keyed by the **resolved winner's body fingerprint** alongside everything else the chain reads: the name, the current package and the innermost lexical package (the two inputs `bare_name_packages()` derives its search list from), the arity and the positional arity, and the argument type signature. The fingerprint is what makes this sound where a plain type-signature key is not — the resolution has already picked the winner, and the probes only ever accept a body matching it.

Unlike `fn_resolve_cache` this memo also stores the **negative** answer, which is the point. Safety rails: a positive hit is re-validated against the table and re-probes if stale; the whole memo is cleared alongside `fn_resolve_cache` on a `fn_resolve_gen` change; names containing `::` are not cached at all, because their chain additionally consults `env` for prefix visibility, which the key does not capture.

`find_compiled_function_inner` inclusive: 225.0 M (37.7% of the benchmark) -> 45.6 M. The probe chain now runs 4 times in the whole program instead of 20 000.

### Also

The type signature both keys are built from is `Vec<&'static str>` rather than `Vec<String>`. `value_type_name` returns a `&'static str`, so a key rebuilt on every call was heap-allocating a `String` per argument for nothing.

## Tests

`t/multi-dispatch-resolution-cache.t` (23 assertions) pins the shapes a key-blind memo would get wrong, and passes under `raku` as well as mutsu:

- one call site alternating between `Int`/`Str`/`Rat` candidates, twice through
- arity-selected candidates (0/1/2), revisited after the others
- `Int:D` vs `Int:U` — a definedness refinement inside one type name
- a `subset` and a `where` constraint making the winner depend on the *value*
- an `is rw` candidate selected by the call site rather than the argument type
- the same bare `multi` name resolving differently in two packages, and back
- a redeclared body reached through `EVAL` (same name, same call, same type signature, different fingerprint)

`cargo fmt --all`, `make lint` (all four configurations), `make test` (3887 files / 41279 tests, PASS) and `make roast` (1436 files / 218939 tests) all run locally. The only roast failures are the three documented container-environment ones — `6.c/S32-io/file-tests.t` and `S16-filehandles/filetest.t` (this container runs as `uid 0`, so `chmod`-based assertions are meaningless) and `S32-io/IO-Socket-Async.t` (sandboxed network) — with failure shapes identical to the table in `docs/agent-environments.md`.

## What is left on #7573

The next-largest item on this path is `compile_and_call_function_def` at 114.9 M inclusive — 5 745 Ir per call, against the 1 090 Ir an ordinary sub pays through `call_compiled_function_positional_light`. Item 2 of the ticket (whether `__mutsu_test_callsite_line` should still be a runtime named argument) and the flat interpretation cost of the vendored `Test` module are untouched, so the issue stays open.

Refs #7573

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U6TpRAdKUHxxXSyHeEVwke

---
_Generated by [Claude Code](https://claude.ai/code/session_01U6TpRAdKUHxxXSyHeEVwke)_