### PR TITLE
fix(vm): avoid structural comparison of cyclic values

### DIFF
--- a/news/2026-09/recursive-cycle-positional-light.md
+++ b/news/2026-09/recursive-cycle-positional-light.md
@@ -1,0 +1,8 @@
+---
+title: Recursive positional-light calls no longer recurse through cyclic objects
+category: fix
+---
+
+The positional-light call path no longer structurally compares cyclic objects
+while tracking loop-local declarations. Recursive subs that build reference
+cycles now return normally instead of hanging or overflowing the Rust stack.

--- a/src/vm/vm_call_func_ops.rs
+++ b/src/vm/vm_call_func_ops.rs
@@ -1291,7 +1291,9 @@ impl Interpreter {
             // leaves `prev == val == the live slot value` (a no-op pull anyway).
             && (package_index_lvalue
                 || match lvalue_writeback_pre {
-                    Some(Some(ref prev)) => !prev.same_variant(&val) || *prev != val,
+                    Some(Some(ref prev)) => {
+                        !crate::vm::vm_method_dispatch::cheaply_unchanged(prev, &val)
+                    }
                     _ => true,
                 })
         {

--- a/src/vm/vm_env_helpers.rs
+++ b/src/vm/vm_env_helpers.rs
@@ -1675,7 +1675,9 @@ impl Interpreter {
                 // Gate OFF this is byte-identical: env tracks the slot, so a
                 // fired type-change here always had `prev != cur` anyway.
                 let env_changed = match pre_env.get(i) {
-                    Some(Some(prev)) => !prev.same_variant(&cur) || *prev != cur,
+                    Some(Some(prev)) => {
+                        !crate::vm::vm_method_dispatch::cheaply_unchanged(prev, &cur)
+                    }
                     // No prior env value snapshotted (a name the carrier
                     // introduced): treat as a genuine change.
                     _ => true,
@@ -1683,8 +1685,8 @@ impl Interpreter {
                 if env_changed && !self.locals[i].same_variant(&cur) {
                     self.locals[i] = cur;
                 } else if let Some(Some(prev)) = pre_env.get(i)
-                    && *prev == self.locals[i]
-                    && *prev != cur
+                    && crate::vm::vm_method_dispatch::cheaply_unchanged(prev, &self.locals[i])
+                    && !crate::vm::vm_method_dispatch::cheaply_unchanged(prev, &cur)
                 {
                     self.locals[i] = cur;
                 }
@@ -1694,10 +1696,10 @@ impl Interpreter {
             // the two values as equal: `Mixin(Int(0), …)` compares EQUAL to
             // `Int(0)` (Mixin PartialEq delegates to its inner value), so a
             // `$a does Role` that turns an `Int` slot into an allomorphic `Mixin`
-            // would otherwise be missed. Compare the enum discriminant first, then
-            // the value.
+            // would otherwise be missed. The identity-aware helper handles this
+            // case without descending into potentially cyclic heap values.
             let changed = match pre_env.get(i) {
-                Some(Some(prev)) => !prev.same_variant(&cur) || *prev != cur,
+                Some(Some(prev)) => !crate::vm::vm_method_dispatch::cheaply_unchanged(prev, &cur),
                 _ => true,
             };
             if changed {

--- a/src/vm/vm_var_assign_set_local.rs
+++ b/src/vm/vm_var_assign_set_local.rs
@@ -2619,11 +2619,18 @@ impl Interpreter {
             // accumulating statement-modifier loop, env and slot agree on the
             // partial result, which would spuriously look coherent; that value is
             // the loop's own, not an enclosing binding.
-            let has_coherent_slot = code
-                .locals
-                .iter()
-                .enumerate()
-                .any(|(i, n)| n.as_str() == name && self.locals.get(i) == Some(&prev));
+            // Do not use Value's structural equality here. An instance can
+            // contain a reference cycle, and comparing such a value against
+            // the env snapshot would recurse through its attributes forever.
+            // The coherence test only needs an O(1), conservative proof that
+            // the slot still holds the same value; the shared identity helper
+            // handles heap values by identity and scalars by value.
+            let has_coherent_slot = code.locals.iter().enumerate().any(|(i, n)| {
+                n.as_str() == name
+                    && self.locals.get(i).is_some_and(|slot| {
+                        crate::vm::vm_method_dispatch::cheaply_unchanged(slot, &prev)
+                    })
+            });
             if has_coherent_slot
                 && let Some(saved) = self.loop_local_saved_env.last_mut()
                 && !saved.contains_key(name)

--- a/t/recursive-cycle-positional-light.t
+++ b/t/recursive-cycle-positional-light.t
@@ -1,0 +1,18 @@
+# This file deliberately does not `use Test`: loading Test enables reflective
+# name access and sends the recursive sub through the env-mirroring path. The
+# bug only appeared on the optimized positional-light path.
+
+class Node { has $.v is rw; has $.next is rw }
+
+sub deep-cycle($n) {
+    my $a = Node.new(v => $n);
+    my $b = Node.new(v => $n * 2);
+    $a.next = $b;
+    $b.next = $a;
+    my $sum = $n > 0 ?? deep-cycle($n - 1) !! 0;
+    return $sum + $a.v + $a.next.v;
+}
+
+my $got = deep-cycle(3);
+say '1..1';
+say $got == 18 ?? 'ok 1 - recursive cycles complete on positional-light' !! "not ok 1 - recursive cycles complete on positional-light (got $got)";


### PR DESCRIPTION
Closes #7697

## Summary

The positional-light recursive call path could structurally compare `Value`
instances while synchronizing locals and lvalue writeback. A pair of mutually
referencing objects therefore caused equality to recurse forever.

Use the existing conservative identity-aware comparison helper for these
coherence checks. It compares scalars by value and heap values by identity,
so cyclic instances are handled in constant time without changing the
interpreter's execution pipeline.

The regression test intentionally does not load `Test`, because that changes
the call path and hides the original failure.

## Validation

- `cargo fmt --all`
- `make lint`
- `make test`
- `make roast`
