### PR TITLE
fix: reject ambiguous now-$x interpolation

### DIFF
--- a/news/2026-09/string-interpolation-hyphen-boundary.md
+++ b/news/2026-09/string-interpolation-hyphen-boundary.md
@@ -1,0 +1,14 @@
+# Unspaced hyphens no longer turn `now-$x` into a silent negative duration
+
+`now-$x` can begin a kebab-case identifier, so it is not the same spelling as
+`now - $x`. mutsu previously parsed the form as a bareword subtraction. Inside
+a string interpolation block that bareword numerified to zero, silently
+producing `-$x` instead of reporting a compile-time error.
+
+The expression parser now reports the same undeclared-`now` error in ordinary
+expressions and in `{ ... }` interpolation blocks. Interpolation parsing also
+propagates fatal errors from its nested expression parser instead of silently
+discarding the block.
+
+The regression test pins both rejection paths and confirms that whitespace
+continues to select subtraction.

--- a/src/parser/primary/ident/term_literals.rs
+++ b/src/parser/primary/ident/term_literals.rs
@@ -395,6 +395,26 @@ pub(crate) fn keyword_literal(input: &str) -> PResult<'_, Expr> {
             ));
         }
     }
+    // A hyphen immediately after `now` is part of a possible identifier. If
+    // the following character cannot continue that identifier, do not let the
+    // additive parser reinterpret the text as `now - ...`: Raku diagnoses the
+    // ambiguous spelling as an undeclared `now` routine, and doing so here also
+    // keeps the main expression and string-interpolation parsers consistent.
+    if input.starts_with("now-")
+        && !input[4..]
+            .chars()
+            .next()
+            .is_some_and(crate::parser::helpers::is_raku_identifier_start)
+    {
+        return Err(PError::fatal_at(
+            format!(
+                "X::Undeclared::Symbols: Undeclared routine:\n    now used at line {}",
+                current_line_number(input)
+            ),
+            input,
+        ));
+    }
+
     // now — returns current time as Instant (term)
     if input.starts_with("now")
         && !input[3..].starts_with(|c: char| c.is_alphanumeric() || c == '_' || c == '-')

--- a/src/parser/primary/string/interp_content.rs
+++ b/src/parser/primary/string/interp_content.rs
@@ -1,6 +1,7 @@
 use super::*;
 use crate::ast::Expr;
 use crate::parser::expr::expression;
+use crate::parser::parse_result::PError;
 use crate::value::ValueView;
 
 use super::helpers::literal_str;
@@ -113,28 +114,32 @@ pub(in crate::parser::primary) fn parse_braced_closure_body(inner: &str) -> Opti
 /// its own block, so a bare `$` in it is a `state` of that block and its
 /// implicit declaration belongs inside the returned statement list, not hoisted
 /// into the enclosing routine.
-pub(in crate::parser::primary) fn parse_interpolation_block(block_src: &str) -> Option<Expr> {
+pub(in crate::parser::primary) fn parse_interpolation_block(
+    block_src: &str,
+) -> Result<Option<Expr>, PError> {
     crate::parser::stmt::simple::push_scope();
     let stmts = parse_interpolation_block_stmts(block_src);
     crate::parser::stmt::simple::pop_scope();
-    stmts.map(|stmts| Expr::DoStmt(Box::new(crate::ast::Stmt::Block(stmts))))
+    stmts.map(|stmts| stmts.map(|stmts| Expr::DoStmt(Box::new(crate::ast::Stmt::Block(stmts)))))
 }
 
 /// [`parse_interpolation_block`]'s body, with the block's scope already pushed.
-fn parse_interpolation_block_stmts(block_src: &str) -> Option<Vec<crate::ast::Stmt>> {
-    let mut stmts = if let Ok((sr, stmts)) = crate::parser::stmt::stmt_list_pub(block_src)
-        && sr.trim().is_empty()
-    {
-        stmts
-    } else if let Ok((expr_rest, expr)) = expression(block_src)
-        && expr_rest.trim().is_empty()
-    {
-        vec![crate::ast::Stmt::Expr(expr)]
-    } else {
-        return None;
+fn parse_interpolation_block_stmts(
+    block_src: &str,
+) -> Result<Option<Vec<crate::ast::Stmt>>, PError> {
+    let mut stmts = match crate::parser::stmt::stmt_list_pub(block_src) {
+        Ok((sr, stmts)) if sr.trim().is_empty() => stmts,
+        Err(error) if error.is_fatal() => return Err(error),
+        _ => match expression(block_src) {
+            Ok((expr_rest, expr)) if expr_rest.trim().is_empty() => {
+                vec![crate::ast::Stmt::Expr(expr)]
+            }
+            Err(error) if error.is_fatal() => return Err(error),
+            _ => return Ok(None),
+        },
     };
     crate::parser::stmt::simple::prepend_anon_state_decls(&mut stmts);
-    Some(stmts)
+    Ok(Some(stmts))
 }
 
 /// [`parse_braced_closure_body`]'s body, run with the block's own lexical scope

--- a/src/parser/primary/string/quoted.rs
+++ b/src/parser/primary/string/quoted.rs
@@ -298,7 +298,7 @@ pub(crate) fn double_quoted_string(input: &str) -> PResult<'_, Expr> {
                     // leak, and a bare `$` is a `state` of THIS block (see
                     // `parse_interpolation_block`).
                     if let Some(block) =
-                        crate::parser::primary::string::parse_interpolation_block(block_src)
+                        crate::parser::primary::string::parse_interpolation_block(block_src)?
                     {
                         parts.push(block);
                     }
@@ -447,7 +447,7 @@ pub(crate) fn smart_double_quoted_string(input: &str) -> PResult<'_, Expr> {
                     // leak, and a bare `$` is a `state` of THIS block (see
                     // `parse_interpolation_block`).
                     if let Some(block) =
-                        crate::parser::primary::string::parse_interpolation_block(block_src)
+                        crate::parser::primary::string::parse_interpolation_block(block_src)?
                     {
                         parts.push(block);
                     }

--- a/t/string-interpolation-hyphen-boundary.t
+++ b/t/string-interpolation-hyphen-boundary.t
@@ -1,0 +1,21 @@
+use Test;
+
+# A hyphen without surrounding whitespace can start a kebab-case identifier.
+# `now-$T0` is therefore not the subtraction `now - $T0`; Rakudo rejects the
+# ambiguous spelling as an undeclared `now` routine. The rejection must be the
+# same in an interpolation block and in ordinary expression position.
+
+plan 3;
+
+throws-like {
+    EVAL q[my $T0 = now; "A { ((now-$T0)*1000).round(0.01) }"]
+}, X::Undeclared::Symbols,
+    'an unspaced hyphen in an interpolation block does not become subtraction';
+
+throws-like {
+    EVAL q[my $T0 = now; ((now-$T0)*1000).round(0.01)]
+}, X::Undeclared::Symbols,
+    'the same unspaced hyphen is rejected outside interpolation';
+
+my $elapsed = EVAL q[my $T0 = now; ((now - $T0)*1000).round(0.01)];
+ok $elapsed >= 0, 'whitespace still selects the subtraction operator';


### PR DESCRIPTION
Closes #7681

## Summary

- Reject `now-$x` as an undeclared `now` routine instead of silently treating it as subtraction.
- Propagate fatal parse errors from `{ ... }` string interpolation blocks.
- Add a regression test and news entry covering interpolation and ordinary expressions.

## Testing

- `cargo fmt --all`
- `make lint`
- `make test`
- `make roast`
