### PR TITLE
perf(vm): decide the reflective closure capture per chunk, not per process

### DIFF
--- a/news/2026-09/use-test-taxes-every-hot-loop-per-chunk-capture.md
+++ b/news/2026-09/use-test-taxes-every-hot-loop-per-chunk-capture.md
@@ -1,0 +1,87 @@
+# The reflective closure capture becomes a per-chunk decision
+
+Loading a module made unrelated hot loops in the importing file slower in
+proportion to how much that module exported ([#7565]). The measurement that
+named the problem was a 20 000-iteration loop in a file whose only other
+content was `use Test`, and three mechanisms fed it. #7656 took the first (the
+END-phaser refresh's string round-trip). This takes the remaining two, which
+were two faces of one thing: *the capture is as wide as the creating scope*.
+
+## A process-global latch decided a per-closure question
+
+`opcode::reflective_name_access_possible()` is a monotonic, process-global flag,
+set at compile time when any chunk anywhere contains a spelling that can reach a
+lexical by a dynamic name -- `EVAL`, `CALLER::`/`OUTER::`, a symbolic deref, a
+pseudo-stash, an indirect code lookup. `capture_closure_env` read it to decide
+whether a closure must snapshot the WHOLE visible env by name instead of the
+filtered upvalue set.
+
+That is the wrong granularity. Upstream `Test.rakumod`'s `throws-like` contains
+an `EVAL`, so a bare `use Test` latched the flag for the rest of the process and
+every closure in the program -- including `sub ($v) { $v + 1000 }`, which has no
+free variables at all -- captured the importer's entire env, then re-merged it
+key by key into the callee's overlay on every call.
+
+The scan that sets the global flag now also records its answer on the chunk it
+scanned (`CompiledCode::needs_reflective_capture`), and the capture requires
+both. The per-chunk answer is deliberately wider than the global one, because a
+missed case here is a silently truncated lexical view rather than the merely
+conservative over-set the global flag can afford: it takes the global flag's op
+scan, plus `uses_callframe`, plus the `gather`/`whenever`/`package` bodies that
+live in `stmt_pool` where no free-variable scan can see them, plus a
+constant-pool scan for the reflective names (the same sound over-approximation
+`reads_topic` already uses, which catches `$code.EVAL` and the other method-call
+spellings), plus the flag of every closure literal nested in the chunk.
+
+## Two thirds of what the capture kept was routine-registration metadata
+
+With the narrow path restored, the capture of a closure created inside a routine
+in that file still held 90 entries -- and 55 of them were
+`__mutsu_callable_id::Test::<name>`, one per routine `use Test` had made visible.
+No closure body can name one: they are registration markers, and every consumer
+(`sub_state_scope_id`, `registration_clone_id`, the call-eligibility probe) reads
+them from the *live* env at call time, where the frame chain still has them. They
+are excluded from the capture now, marked by a new `Symbol::flags` bit so the
+filter costs no string scan. The one case that genuinely needs the marker carried
+-- a closure escaping a `use`-inside-`EVAL` scope that `PopImportScope` is about
+to strip -- is pinned by name in `capture_bare_callees`, alongside the `&name`
+alias it already pinned. That gate also learned to pin an alias whose registry
+entry is *already* gone, which is the state a closure created by an outer
+EVAL-returned closure runs in (`t/eval-closure-imported-sub.t`).
+
+## The END-phaser refresh still flattened the env it only ever indexed
+
+`call_compiled_closure_in_unit` ends by refreshing END phasers' captured envs for
+the returning closure's captured names. It read the live values through
+`clone_env()` -- a whole-scope flatten, plus its drop, on every closure return in
+any program that has an `END` (which `use Test` also supplies, as its plan
+check). But `update_end_phaser_envs_for_keys` looks the values up one key at a
+time with `get_sym`, and a scoped env's `get_sym` already walks its parent chain:
+it needs the full lexical *view*, not a flat *map*. Loaning the live env out and
+back is O(1).
+
+## Measured
+
+Callgrind, release, `MUTSU_JIT=off`, `MUTSU_GC=off`, warm precompilation, slope
+between 6 000 and 14 000 iterations of the ticket's loop:
+
+| | instructions per iteration |
+| --- | --- |
+| the loop with no `use Test` (the floor) | 74 908 |
+| `+ use Test`, before | 121 419 |
+| `+ use Test`, after | **105 391** |
+
+The tax the ticket is about -- what `use Test` adds to a loop that never calls
+into it -- falls from 46 511 to 30 694 instructions per iteration, a 34%
+reduction, and the loop's total cost falls 13%. The no-`use Test` floor is
+unchanged (74 908 -> 74 697).
+
+What remains is the constant part of the capture: about twenty built-in dynamics
+(`$*IN`, `$*OUT`, `%*ENV`, ...) and the `__mutsu_type::` constraint keys, which
+still scale with the importing scope. Making those cheap needs a capture that
+does not walk the whole env at all; a per-tier memo of the key-only filter was
+built and measured for this change and did NOT pay -- the tier it would memoize
+is written on every loop iteration, so the memo never armed. That is recorded on
+the issue, which stays open.
+
+[#7565]: https://github.com/tokuhirom/mutsu/issues/7565

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -4889,6 +4889,16 @@ pub(crate) struct CompiledCode {
     /// after every interpreter-native call, which kept such routines
     /// permanently out of the name-keyed call caches by accident.)
     pub(crate) uses_callframe: bool,
+    /// True if *this* chunk (or any closure literal nested in it) can reach a
+    /// lexical by a name the compile-time free-variable scan cannot see, so a
+    /// closure created from it must capture the WHOLE visible env rather than
+    /// the filtered upvalue set. Computed by
+    /// [`Self::scan_reflective_name_access`].
+    ///
+    /// The process-global [`REFLECTIVE_NAME_ACCESS_SEEN`] latch answers the
+    /// same question for the *program*; this answers it for one chunk, which
+    /// is what `capture_closure_env` actually needs. Set during `finalize`.
+    pub(crate) needs_reflective_capture: bool,
     /// True if this code directly calls `callsame`/`nextsame`/`callwith`/
     /// `nextwith`. Set during `emit()`. The compiled method fast paths
     /// (`call_compiled_method`/`call_compiled_method_fast`) push a
@@ -5373,6 +5383,7 @@ impl CompiledCode {
             reads_topic: false,
             has_once: false,
             uses_callframe: false,
+            needs_reflective_capture: false,
             uses_dispatcher: false,
             may_observe_named_slurpy: false,
             source_line: None,
@@ -6253,14 +6264,23 @@ impl CompiledCode {
 
     /// Scan this code's ops for reflective by-name access to a caller frame's
     /// lexicals (`CALLER::`/`OUTER::`, symbolic deref, pseudo-stash, indirect
-    /// code lookup, `EVAL`/`EVALFILE`) and set the process-global
-    /// [`REFLECTIVE_NAME_ACCESS_SEEN`] flag. Runs unconditionally at finalize
-    /// (before the `needs_env_sync` early returns) so the flag covers loop/block
-    /// frames and zero-local frames too. Monotonic: only ever sets `true`.
-    pub(crate) fn scan_reflective_name_access(&self) {
-        if REFLECTIVE_NAME_ACCESS_SEEN.load(Ordering::Relaxed) {
-            return;
-        }
+    /// code lookup, `EVAL`/`EVALFILE`), setting both the process-global
+    /// [`REFLECTIVE_NAME_ACCESS_SEEN`] flag and this chunk's own
+    /// [`Self::needs_reflective_capture`]. Runs unconditionally at finalize
+    /// (before the `needs_env_sync` early returns) so both cover loop/block
+    /// frames and zero-local frames too. Both are monotonic: only ever set
+    /// `true`.
+    ///
+    /// The global flag says "somewhere in this *program* a lexical may be
+    /// reached by a dynamic name"; the per-chunk flag says it of one chunk.
+    /// `capture_closure_env` needs the second: with the global latch alone, a
+    /// single `EVAL` anywhere — including inside a module the program never
+    /// calls into, e.g. upstream `Test.rakumod`'s `throws-like` — made EVERY
+    /// closure in the process capture the whole visible env by name, so both
+    /// the creation-time flatten and the per-call capture merge became linear
+    /// in the importing scope's size (#7565).
+    pub(crate) fn scan_reflective_name_access(&mut self) {
+        let mut own_reflective = false;
         for op in &self.ops {
             let reflective = match op {
                 OpCode::GetCallerVar { .. }
@@ -6299,10 +6319,67 @@ impl CompiledCode {
                 _ => false,
             };
             if reflective {
-                REFLECTIVE_NAME_ACCESS_SEEN.store(true, Ordering::Relaxed);
-                return;
+                own_reflective = true;
+                break;
             }
         }
+        if own_reflective {
+            REFLECTIVE_NAME_ACCESS_SEEN.store(true, Ordering::Relaxed);
+        }
+        self.needs_reflective_capture |= own_reflective || self.chunk_reflective_capture_traits();
+    }
+
+    /// The per-chunk half of [`Self::scan_reflective_name_access`]: everything
+    /// beyond this chunk's own reflective ops that still forces a whole-env
+    /// capture. Deliberately wider than the global latch's op scan, because a
+    /// missed case here is a silently truncated lexical view rather than the
+    /// merely-conservative over-set the global flag can afford.
+    fn chunk_reflective_capture_traits(&self) -> bool {
+        // A `callframe`/`callframes` observer reads its caller frame's
+        // lexicals by name (`callframe.my<$x>`), which no free-var scan sees.
+        if self.uses_callframe {
+            return true;
+        }
+        // `gather`/`whenever` stash their body in `stmt_pool` and run it by
+        // name against the live env, so it is not in `closure_compiled_codes`
+        // and the nested scan below cannot see which lexicals it reads.
+        if self.ops.iter().any(|op| {
+            matches!(
+                op,
+                OpCode::MakeGather(..) | OpCode::WheneverScope { .. } | OpCode::PackageScope { .. }
+            )
+        }) {
+            return true;
+        }
+        // Constant-pool scan, the same sound over-approximation `reads_topic`
+        // uses: it catches the reflective spellings that do NOT compile to one
+        // of the ops above — `$code.EVAL` and `&::($n)` as method calls, a
+        // pseudo-stash named through a string, an `EVAL` reached from a body
+        // this chunk only stashes. A stray literal of the same text costs one
+        // chunk its filtered capture, which is conservative, never wrong.
+        const REFLECTIVE_NAMES: [&str; 11] = [
+            "EVAL",
+            "EVALFILE",
+            "CALLER",
+            "CALLERS",
+            "OUTER",
+            "LEXICAL",
+            "DYNAMIC",
+            "MY",
+            "UNIT",
+            "SETTING",
+            "callframe",
+        ];
+        if self.constants.iter().any(
+            |c| matches!(c.view(), ValueView::Str(s) if REFLECTIVE_NAMES.contains(&s.as_str())),
+        ) {
+            return true;
+        }
+        // A closure literal nested here captures from an env this chunk's own
+        // frame supplies, so its need is this chunk's need too.
+        self.closure_compiled_codes
+            .iter()
+            .any(|c| c.needs_reflective_capture)
     }
 
     /// The constant-pool index naming the variable an op reads/writes by name,

--- a/src/symbol.rs
+++ b/src/symbol.rs
@@ -145,7 +145,7 @@ thread_local! {
     /// merge/dispatch paths ask about a name. Same validity argument as
     /// `RESOLVE_CACHE`: ids are append-only and a symbol's string never
     /// changes, so a computed answer is good for the life of the process.
-    static FLAG_CACHE: RefCell<Vec<u8>> = const { RefCell::new(Vec::new()) };
+    static FLAG_CACHE: RefCell<Vec<u16>> = const { RefCell::new(Vec::new()) };
 }
 
 /// Pure, string-derived properties of a symbol, computed once per symbol.
@@ -163,20 +163,20 @@ pub(crate) mod flags {
     /// `<name>`) — the names scoped per *routine*, which a return merge must
     /// never copy back into the caller. Mirrors
     /// `crate::runtime::utils::is_routine_scoped_implicit_var`.
-    pub(crate) const ROUTINE_SCOPED_IMPLICIT: u8 = 1 << 0;
+    pub(crate) const ROUTINE_SCOPED_IMPLICIT: u16 = 1 << 0;
     /// A per-call-site index-rw / call-result temporary. Mirrors
     /// `crate::runtime::utils::is_index_rw_call_temp`.
-    pub(crate) const INDEX_RW_CALL_TEMP: u8 = 1 << 1;
+    pub(crate) const INDEX_RW_CALL_TEMP: u16 = 1 << 1;
     /// A `__mutsu_type::<name>` typed-lexical metadata key.
-    pub(crate) const TYPE_META: u8 = 1 << 2;
+    pub(crate) const TYPE_META: u16 = 1 << 2;
     /// An `nqp::<op>` routine name: a compiler-known primitive in a reserved
     /// namespace no user routine can be declared in, so a call op carrying
     /// this name dispatches straight to the op table
     /// (`Interpreter::exec_nqp_call_op`).
-    pub(crate) const NQP_OP: u8 = 1 << 3;
+    pub(crate) const NQP_OP: u16 = 1 << 3;
     /// A *plain user lexical* env key. Mirrors
     /// `crate::env::is_plain_user_lexical`.
-    pub(crate) const PLAIN_USER_LEXICAL: u8 = 1 << 4;
+    pub(crate) const PLAIN_USER_LEXICAL: u16 = 1 << 4;
     /// An attribute-twigil env key (`!x`, `@!x`, `%.x`). Mirrors
     /// `crate::env::is_attr_twigil_env_key`.
     ///
@@ -185,7 +185,7 @@ pub(crate) mod flags {
     /// the symbol to a `&str` and re-scanning the bytes twice per key. Fusing
     /// them into the memoized byte makes the filter one thread-local lookup
     /// instead of two plus two string scans.
-    pub(crate) const ATTR_TWIGIL_ENV_KEY: u8 = 1 << 5;
+    pub(crate) const ATTR_TWIGIL_ENV_KEY: u16 = 1 << 5;
     /// A *dynamic* variable's env key (`*x`, `$*OUT`, `@*ARGS`, `%*ENV`).
     /// Mirrors `crate::env::is_dynamic_var_env_key`.
     ///
@@ -196,10 +196,21 @@ pub(crate) mod flags {
     /// reflective latch has widened to a whole-env snapshot, walks hundreds of
     /// keys here per closure call, which put this one scan at ~11% of the whole
     /// program (#7565).
-    pub(crate) const DYNAMIC_VAR_ENV_KEY: u8 = 1 << 6;
-    /// Set once the byte has been computed (so a symbol with no flags is not
-    /// recomputed on every lookup).
-    pub(crate) const COMPUTED: u8 = 1 << 7;
+    pub(crate) const DYNAMIC_VAR_ENV_KEY: u16 = 1 << 6;
+    /// A `__mutsu_callable_id::<package>::<name>` routine-registration marker.
+    ///
+    /// One such key is installed per *named routine visible in the scope*, so a
+    /// file that imported a module with a broad export list carries dozens of
+    /// them — 55 of the 90 entries a closure captured after a bare `use Test`
+    /// (#7565). Every consumer reads the marker from the LIVE env at call time
+    /// (`sub_state_scope_id`, `registration_clone_id`, the call-eligibility
+    /// probe), so the closure capture does not need to carry it; the one place
+    /// that does — an escaping closure whose `use`-inside-`EVAL` scope has
+    /// already been popped — is served precisely by `capture_bare_callees`.
+    pub(crate) const CALLABLE_ID_META: u16 = 1 << 8;
+    /// Set once the flag word has been computed (so a symbol with no flags is
+    /// not recomputed on every lookup).
+    pub(crate) const COMPUTED: u16 = 1 << 15;
 }
 
 /// The `__mutsu_type::` prefix `flags::TYPE_META` marks. Kept next to the flag
@@ -209,7 +220,11 @@ pub(crate) const TYPE_META_PREFIX: &str = "__mutsu_type::";
 /// The `nqp::` prefix `flags::NQP_OP` marks.
 pub(crate) const NQP_OP_PREFIX: &str = "nqp::";
 
-fn compute_flags(s: &str) -> u8 {
+/// The `__mutsu_callable_id::` prefix `flags::CALLABLE_ID_META` marks. Kept
+/// next to the flag so the two cannot drift.
+pub(crate) const CALLABLE_ID_META_PREFIX: &str = "__mutsu_callable_id::";
+
+fn compute_flags(s: &str) -> u16 {
     let mut f = flags::COMPUTED;
     if crate::runtime::utils::is_routine_scoped_implicit_var(s) {
         f |= flags::ROUTINE_SCOPED_IMPLICIT;
@@ -222,6 +237,9 @@ fn compute_flags(s: &str) -> u8 {
     }
     if s.starts_with(NQP_OP_PREFIX) {
         f |= flags::NQP_OP;
+    }
+    if s.starts_with(CALLABLE_ID_META_PREFIX) {
+        f |= flags::CALLABLE_ID_META;
     }
     if crate::env::is_plain_user_lexical(s) {
         f |= flags::PLAIN_USER_LEXICAL;
@@ -446,13 +464,13 @@ impl Symbol {
         })
     }
 
-    /// This symbol's memoized [`flags`] byte — see that module for what the
+    /// This symbol's memoized [`flags`] word — see that module for what the
     /// bits mean and why the merge path needs them fused into one lookup.
     ///
     /// Computed on first ask and cached per thread. Test the result with the
     /// `flags::*` constants, e.g.
     /// `sym.flags() & flags::ROUTINE_SCOPED_IMPLICIT != 0`.
-    pub(crate) fn flags(self) -> u8 {
+    pub(crate) fn flags(self) -> u16 {
         let idx = self.0 as usize;
         if let Some(f) = FLAG_CACHE.with(|c| c.borrow().get(idx).copied())
             && f & flags::COMPUTED != 0

--- a/src/vm/vm_closure_dispatch.rs
+++ b/src/vm/vm_closure_dispatch.rs
@@ -1777,10 +1777,17 @@ impl Interpreter {
         // off every closure return in a program that merely declares an `END`
         // (#7565).
         if self.has_end_phasers() && !data.env.is_empty() && self.end_phasers_watch_any(&data.env) {
-            // Flatten: END phasers run at program exit with this captured env;
-            // it must hold the full lexical view, not a transient scoped overlay.
-            let current = self.clone_env();
+            // The refresh reads the live env ONE KEY AT A TIME
+            // (`current_env.get_sym`), and a scoped env's `get_sym` already
+            // walks its parent chain — so it needs the full lexical *view*, not
+            // a flat *map*. Loaning the live env out and back is O(1) where the
+            // `clone_env()` flatten that used to stand here was a whole-scope
+            // map clone (plus its drop) on every closure return: 5.6k
+            // instructions per iteration of a loop in a file that had done
+            // nothing but `use Test` (#7565).
+            let current = self.take_env();
             self.update_end_phaser_envs_for_keys(&data.env, &current);
+            self.set_env(current);
         }
 
         let return_spec = data

--- a/src/vm/vm_register_ops.rs
+++ b/src/vm/vm_register_ops.rs
@@ -975,7 +975,16 @@ impl Interpreter {
         let Some(cc) = cc else {
             return self.clone_env();
         };
-        if crate::opcode::reflective_name_access_possible() {
+        // The whole-env-by-name capture is needed only when a lexical in this
+        // closure's reach can be named dynamically. The process-global latch
+        // says the *program* contains such a spelling somewhere; `cc`'s own
+        // flag says THIS closure (or one nested in it) does. Requiring both
+        // keeps the filtered upvalue capture for the ordinary closures of a
+        // program that merely loaded a module containing an `EVAL` — the
+        // monotonic, process-global deoptimization #7565 measured, where a bare
+        // `use Test` made every closure creation clone the importer's whole env
+        // and every closure call merge it back key by key.
+        if crate::opcode::reflective_name_access_possible() && cc.needs_reflective_capture {
             let mut flat = self.clone_env();
             // Even when capturing the whole env by name, a slot-only local (a
             // pointy-block/sub parameter that this frame never mirrors into `env`,
@@ -1070,9 +1079,9 @@ impl Interpreter {
             if k == callable_type_sym {
                 return false;
             }
-            // One memoized flags byte answers both string questions this filter
+            // One memoized flags word answers the string questions this filter
             // asks per key (see `symbol::flags`), instead of resolving the
-            // symbol and re-scanning its bytes twice.
+            // symbol and re-scanning its bytes.
             let flags = k.flags();
             // Attribute-twigil keys (`!x`, `@!x`, `%.x`, …) are per-frame
             // materializations of `self`'s attributes, not lexicals: the
@@ -1081,6 +1090,17 @@ impl Interpreter {
             // mutates — a `start` block reading `@!before` inside
             // Cro::CompositeConnector.connect saw an empty pre-mutation copy.
             if flags & crate::symbol::flags::ATTR_TWIGIL_ENV_KEY != 0 {
+                return false;
+            }
+            // `__mutsu_callable_id::<pkg>::<name>` is a routine-registration
+            // marker, one per named routine visible in the creating scope —
+            // after a bare `use Test` that is 55 of the 90 entries this filter
+            // used to keep, none of which any closure body can name. Every
+            // consumer reads it from the LIVE env at call time, where it is
+            // still visible through the frame chain; the single case that is
+            // not (an escaping closure whose `use`-inside-`EVAL` scope has been
+            // popped) is pinned by name in `capture_bare_callees`.
+            if flags & crate::symbol::flags::CALLABLE_ID_META != 0 {
                 return false;
             }
             free.contains(&k)
@@ -1159,10 +1179,25 @@ impl Interpreter {
             if self.has_proto(&resolved_name) || self.has_multi_candidates(&resolved_name) {
                 continue;
             }
+            let code_name = name.with_str(|name| format!("&{name}"));
+            let code_sym = Symbol::intern(&code_name);
             let Some(def) = self
                 .resolve_function(&resolved_name)
                 .map(|def| (*def).clone())
             else {
+                // No registry entry left to classify: the import alias this
+                // gate exists for has already been popped (`PopImportScope`),
+                // which is exactly the state a closure created by an OUTER
+                // EVAL-returned closure runs in. A live lexical `&name` — the
+                // one this very gate pinned into the outer closure — is then
+                // the only surviving binding, so carry it into the inner
+                // capture, which filters plain `&user-name` keys out (they are
+                // not free variables). `t/eval-closure-imported-sub.t`.
+                if !env.contains_key_sym(code_sym)
+                    && let Some(value) = self.env().get_sym(code_sym)
+                {
+                    env.insert_sym(code_sym, value.clone());
+                }
                 continue;
             };
             // Same-package routines continue to use normal compiled/registry
@@ -1175,14 +1210,22 @@ impl Interpreter {
             {
                 continue;
             }
-            let code_name = name.with_str(|name| format!("&{name}"));
-            let code_sym = Symbol::intern(&code_name);
+            let id_key = Self::callable_id_key_for_syms(def.package, def.name);
             if !env.contains_key_sym(code_sym)
                 && let Some(value) = self.env().get_sym(code_sym)
             {
                 env.insert_sym(code_sym, value.clone());
             } else if !env.contains_key_sym(code_sym) {
                 env.insert_sym(code_sym, self.sub_value_from_function_def(def));
+            }
+            // The alias's registration marker travels with it: the ordinary
+            // capture filter drops every `__mutsu_callable_id::` key (they are
+            // read from the live env, which still has them), but this closure's
+            // EVAL scope is about to be popped, taking the marker with it.
+            if !env.contains_key_sym(id_key)
+                && let Some(value) = self.env().get_sym(id_key)
+            {
+                env.insert_sym(id_key, value.clone());
             }
         }
     }

--- a/t/closure-capture-reflective-scope.t
+++ b/t/closure-capture-reflective-scope.t
@@ -1,0 +1,82 @@
+use Test;
+use MONKEY-SEE-NO-EVAL;
+
+plan 11;
+
+# Whether a closure captures the WHOLE visible env by name is decided per
+# compiled chunk, not by a process-global "some EVAL happened somewhere" latch
+# (#7565). Every assertion below runs in a file that has already evaluated a
+# string, so the latch is set and only the per-chunk determination decides.
+is EVAL('1'), 1, 'the program has EVALed, so the reflective latch is set';
+
+# A closure whose own body names a lexical dynamically still reaches its
+# creating scope after escaping it -- one case per spelling the per-chunk scan
+# has to recognise.
+sub make-evaler() {
+    my $secret = 'creation-scope';
+    sub { EVAL '$secret' };
+}
+is make-evaler()(), 'creation-scope', 'an EVAL in a closure body reads the creating scope';
+
+sub make-dereffer() {
+    my $hidden = 'deref-scope';
+    sub { $::('hidden') };
+}
+is make-dereffer()(), 'deref-scope', 'a symbolic deref in a closure body reads the creating scope';
+
+sub make-outer() {
+    my $o = 'outer-scope';
+    sub { $OUTER::o };
+}
+is make-outer()(), 'outer-scope', 'an OUTER:: read in a closure body reads the creating scope';
+
+# The need propagates outward: the OUTER closure escapes its creating scope and
+# only then creates the reflective one, so it is the outer capture that has to
+# be wide.
+sub make-factory() {
+    my $deep = 'deep-creation-scope';
+    sub { sub { EVAL '$deep' } };
+}
+is make-factory()()(), 'deep-creation-scope',
+    'a closure nested inside an escaping one still reads the outer creating scope';
+
+# The ordinary closures of the same file take the narrow upvalue capture even
+# though the latch is set, and must be unaffected by it.
+sub make-counter() {
+    my $n = 0;
+    sub { $n = $n + 1; $n };
+}
+my $counter = make-counter();
+$counter();
+is $counter(), 2, 'a non-reflective escaping closure keeps its own free variable';
+
+my @adders = (1, 2, 3).map(-> $k { sub ($x) { $x + $k } });
+is @adders[0](10) ~ ',' ~ @adders[1](10) ~ ',' ~ @adders[2](10), '11,12,13',
+    'each closure of a loop keeps its own captured value';
+
+# A routine's registration marker (`__mutsu_callable_id::Pkg::name`) is no
+# longer carried in the closure capture -- it is read from the live env. `state`
+# scoping is keyed off it, so these pin that it is still found.
+sub make-stateful() {
+    sub { state $seen = 0; $seen = $seen + 1; $seen };
+}
+my $first = make-stateful();
+my $second = make-stateful();
+$first(); $first();
+is $first(), 3, 'a closure state variable counts its own invocations';
+is $second(), 1, 'a separate closure instance gets its own state variable';
+
+# A closure body calling a routine imported into the file scope: the capture
+# filter drops the lexical `&name`, so this resolves through the registry.
+my $uses-import = sub { is 1 + 1, 2, 'a closure body calls an imported routine' };
+$uses-import();
+
+# The END-phaser refresh that runs on every closure return reads the live env
+# key by key instead of flattening it; it must still observe the write.
+our $watched = 'initial';
+my $writer = sub { $watched = 'written-by-closure' };
+$writer();
+
+END {
+    is $watched, 'written-by-closure', 'an END phaser sees the value a closure wrote';
+}


### PR DESCRIPTION
Loading a module made unrelated hot loops in the importing file slower in proportion to how much that module exported ([#7565]). Three mechanisms fed it; #7656 took the first (the END-phaser refresh's string round-trip). This takes the remaining two, which are two faces of one thing: *the capture is as wide as the creating scope*.

## A process-global latch decided a per-closure question

`opcode::reflective_name_access_possible()` is a monotonic, process-global flag, set at compile time when any chunk anywhere contains a spelling that can reach a lexical by a dynamic name — `EVAL`, `CALLER::`/`OUTER::`, a symbolic deref, a pseudo-stash, an indirect code lookup. `capture_closure_env` read it to decide whether a closure must snapshot the **whole** visible env by name instead of the filtered upvalue set.

That is the wrong granularity. Upstream `Test.rakumod`'s `throws-like` contains an `EVAL`, so a bare `use Test` latched the flag for the rest of the process and every closure in the program — including `sub ($v) { $v + 1000 }`, which has no free variables at all — captured the importer's entire env, then re-merged it key by key into the callee's overlay on every call.

The scan that sets the global flag now also records its answer on the chunk it scanned (`CompiledCode::needs_reflective_capture`), and the capture requires both. The per-chunk answer is deliberately **wider** than the global one, because a missed case here is a silently truncated lexical view rather than the merely conservative over-set the global flag can afford. It takes:

- the global flag's op scan;
- `uses_callframe` (`callframe.my<$x>` names a caller lexical dynamically);
- the `gather` / `whenever` / `package` bodies that live in `stmt_pool`, where no free-variable scan can see them;
- a constant-pool scan for the reflective names — the same sound over-approximation `reads_topic` already uses, which catches `$code.EVAL` and the other method-call spellings;
- the flag of every closure literal nested in the chunk, so the need propagates outward.

## Two thirds of what the capture kept was routine-registration metadata

With the narrow path restored, the capture of a closure created inside a routine in such a file still held 90 entries — and **55 of them were `__mutsu_callable_id::Test::<name>`**, one per routine `use Test` had made visible. No closure body can name one: they are registration markers, and every consumer (`sub_state_scope_id`, `registration_clone_id`, the call-eligibility probe) reads them from the *live* env at call time, where the frame chain still has them. They are excluded from the capture now, marked by a new `Symbol::flags` bit so the filter costs no string scan.

The one case that genuinely needs the marker carried — a closure escaping a `use`-inside-`EVAL` scope that `PopImportScope` is about to strip — is pinned by name in `capture_bare_callees`, alongside the `&name` alias it already pinned. That gate also learned to pin an alias whose registry entry is *already* gone, which is the state a closure created by an outer EVAL-returned closure runs in (`t/eval-closure-imported-sub.t`, which caught this).

## The END-phaser refresh still flattened the env it only ever indexed

`call_compiled_closure_in_unit` ends by refreshing END phasers' captured envs for the returning closure's captured names. It read the live values through `clone_env()` — a whole-scope flatten, plus its drop, on every closure return in any program that has an `END` (which `use Test` also supplies, as its plan check). But `update_end_phaser_envs_for_keys` looks the values up one key at a time with `get_sym`, and a scoped env's `get_sym` already walks its parent chain: it needs the full lexical *view*, not a flat *map*. Loaning the live env out and back is O(1).

## Measured

Callgrind, release, `MUTSU_JIT=off`, `MUTSU_GC=off`, warm precompilation, slope between 6 000 and 14 000 iterations of the ticket's loop (wall clock on this 4-core box is too noisy to rank these; instruction counts are deterministic):

| | instructions per iteration |
| --- | --- |
| the loop with no `use Test` (the floor) | 74 908 |
| `+ use Test`, before | 121 419 |
| `+ use Test`, after | **105 391** |

The tax this ticket is about — what `use Test` adds to a loop that never calls into it — falls from 46 511 to 30 694 instructions per iteration, a **34% reduction**, and the loop's total cost falls **13%**. The no-`use Test` floor is unchanged (74 908 → 74 697), as expected: nothing on that path changes for a program that never evaluates a string.

## What is left

The constant part of the capture: about twenty built-in dynamics (`$*IN`, `$*OUT`, `%*ENV`, …) and the `__mutsu_type::` constraint keys, which still scale with the importing scope. Making those cheap needs a capture that does not walk the whole env at all. The per-tier memo of the key-only filter that #7565 suggests for this was built and measured as part of this work and did **not** pay — the tier it would memoize is written on every loop iteration, so the memo never armed. That is recorded on the issue, which stays open.

Also recorded there: the ticket's own numbers are *debug* wall clock, and a debug build is dominated by a `debug_assertions`-only staleness audit in `fn_base_name_registered` that rescans the whole registry per resolution (13.7% of the debug profile, and it scales with import count too). It does not exist in release, so it inflates the ticket's reported ratio but costs shipped code nothing.

## Testing

- `t/closure-capture-reflective-scope.t` (new, 11 assertions, agrees with Rakudo): in a file that has already `EVAL`ed, a closure whose body names a lexical dynamically (`EVAL`, `$::(…)`, `$OUTER::`) still reaches its creating scope after escaping it; so does one created by an escaping outer closure; ordinary closures of the same file keep their free variables; `state` scoping and imported-routine calls still work with the registration marker out of the capture; an END phaser still sees a closure's write.
- `make lint` green (all four configurations).
- `make test` green — 3895 files, 41384 tests.
- `make roast` green apart from the three failures [docs/agent-environments.md](https://github.com/tokuhirom/mutsu/blob/main/docs/agent-environments.md) documents for this container (`6.c/S32-io/file-tests.t` and `S16-filehandles/filetest.t` run as `uid 0`; `S32-io/IO-Socket-Async.t` needs unsandboxed network), each failing exactly the subtests recorded there.

Refs [#7565] — the ticket stays open, with the remaining terms measured on it.

[#7565]: https://github.com/tokuhirom/mutsu/issues/7565

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JX78YRq1KSWqaCX7RPV9Cb

---
_Generated by [Claude Code](https://claude.ai/code/session_01JX78YRq1KSWqaCX7RPV9Cb)_