### PR TITLE
fix(vm): clip Whatever-ended Range slice assignments

### DIFF
--- a/news/2026-09/whatever-ended-range-slice-assignment.md
+++ b/news/2026-09/whatever-ended-range-slice-assignment.md
@@ -1,0 +1,22 @@
+# Whatever-ended Range slice assignments stop at the array length
+
+Assignments such as `@d[1..*] = 9` now clip the Range to the array's current
+length, matching Rakudo. They no longer grow a five-element array to 100,002
+elements through the eager lazy-range prefix.
+
+The assignment value is also the clipped slice, including `Any` padding:
+
+```raku
+my @d = 1..5;
+say (@d[1..*] = 9).raku; # (9, Any, Any, Any)
+say @d.raku;             # [1, 9, Any, Any, Any]
+```
+
+The existing unbounded-range helper is now used before assignment normalizes
+the index. It expands only against a known positional array length; an
+unbounded Range targeting a value without a positional length is left
+unexpanded instead of being eagerly enumerated.
+
+The regression coverage is in `t/whatever-ended-range-slice-assign.t`.
+
+Closes [#7674](https://github.com/tokuhirom/mutsu/issues/7674).

--- a/src/vm/vm_var_assign_index_named.rs
+++ b/src/vm/vm_var_assign_index_named.rs
@@ -856,28 +856,36 @@ impl Interpreter {
                 crate::value::Value::array_arc(items.to_vec()),
                 crate::value::ArrayKind::List,
             ),
-            ValueView::Range(a, b) if expand_range || finite_positional_range(b) => {
+            ValueView::Range(a, b)
+                if (expand_range && b != i64::MAX) || finite_positional_range(b) =>
+            {
                 let items: Vec<Value> = (a..=b).map(Value::int).collect();
                 Value::array_with_kind(
                     crate::gc::Gc::new(crate::value::ArrayData::new(items)),
                     crate::value::ArrayKind::List,
                 )
             }
-            ValueView::RangeExcl(a, b) if expand_range || finite_positional_range(b) => {
+            ValueView::RangeExcl(a, b)
+                if (expand_range && b != i64::MAX) || finite_positional_range(b) =>
+            {
                 let items: Vec<Value> = (a..b).map(Value::int).collect();
                 Value::array_with_kind(
                     crate::gc::Gc::new(crate::value::ArrayData::new(items)),
                     crate::value::ArrayKind::List,
                 )
             }
-            ValueView::RangeExclStart(a, b) if expand_range || finite_positional_range(b) => {
+            ValueView::RangeExclStart(a, b)
+                if (expand_range && b != i64::MAX) || finite_positional_range(b) =>
+            {
                 let items: Vec<Value> = ((a + 1)..=b).map(Value::int).collect();
                 Value::array_with_kind(
                     crate::gc::Gc::new(crate::value::ArrayData::new(items)),
                     crate::value::ArrayKind::List,
                 )
             }
-            ValueView::RangeExclBoth(a, b) if expand_range || finite_positional_range(b) => {
+            ValueView::RangeExclBoth(a, b)
+                if (expand_range && b != i64::MAX) || finite_positional_range(b) =>
+            {
                 let items: Vec<Value> = ((a + 1)..b).map(Value::int).collect();
                 Value::array_with_kind(
                     crate::gc::Gc::new(crate::value::ArrayData::new(items)),
@@ -887,7 +895,9 @@ impl Interpreter {
             // Non-integer (e.g. string) ranges: `%h{'x'..'z'} = ...` is a hash
             // slice over the enumerated keys `x`, `y`, `z`, not a single
             // stringified `"x y z"` key. Expand via the range's own list.
-            ValueView::GenericRange { .. } if expand_range => {
+            ValueView::GenericRange { .. }
+                if expand_range && !crate::runtime::utils::subscript_range_end_unbounded(&idx) =>
+            {
                 let items = crate::runtime::utils::value_to_list(&idx);
                 Value::array_with_kind(
                     crate::gc::Gc::new(crate::value::ArrayData::new(items)),
@@ -1683,6 +1693,7 @@ impl Interpreter {
                     // one contributes the element's undefined value). That list,
                     // not the raw RHS, is the assignment's rvalue in raku.
                     let mut assigned_values: Vec<Value> = Vec::new();
+                    let empty_slice = keys.is_empty();
                     if is_shaped {
                         if bind_mode && is_bound_index {
                             return Err(RuntimeError::assignment_ro(None));
@@ -1783,6 +1794,8 @@ impl Interpreter {
                         nested
                     } else if idx_is_single_element && idx_is_scalar_subscript {
                         Self::itemize_value(val)
+                    } else if empty_slice {
+                        Value::array(Vec::new())
                     } else if !assigned_values.is_empty() {
                         Value::array(assigned_values)
                     } else {

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -388,17 +388,18 @@ impl Interpreter {
         idx: Value,
         target: Option<&Value>,
     ) -> Value {
-        let len = match target.map(Value::view) {
-            Some(ValueView::Array(items, ..)) => items.len() as i64,
+        let target_array_len = match target.map(Value::view) {
+            Some(ValueView::Array(items, ..)) => Some(items.len()),
             // A `:=`-bound array is held in a `ContainerRef` cell; descend it so
             // a from-end index (`@a[*-1]`) resolves the real length instead of 0
             // (which would yield a negative effective index and X::OutOfRange).
             Some(ValueView::ContainerRef(cell)) => match cell.lock().unwrap().view() {
-                ValueView::Array(items, ..) => items.len() as i64,
-                _ => 0,
+                ValueView::Array(items, ..) => Some(items.len()),
+                _ => None,
             },
-            _ => 0,
+            _ => None,
         };
+        let len = target_array_len.map(|len| len as i64).unwrap_or(0);
         // Bare Whatever (*) in array subscript means all indices: 0, 1, ..., len-1
         if matches!(idx.view(), ValueView::Whatever) {
             let indices: Vec<Value> = (0..len).map(Value::int).collect();
@@ -406,6 +407,19 @@ impl Interpreter {
                 crate::gc::Gc::new(crate::value::ArrayData::new(indices)),
                 crate::value::ArrayKind::List,
             );
+        }
+        // An unbounded-end Range subscript means "from this index to the end"
+        // when the target is an array. Resolve it against the target's current
+        // length before the assignment path's finite-range gate; otherwise the
+        // i64::MAX sentinel is mistaken for a real bound and the slice expands
+        // to 100,000 elements. Keep an unbounded range untouched for targets
+        // without a positional length (notably hash slices), so this resolution
+        // never turns an infinite range into an eager enumeration there.
+        if let Some(array_len) = target_array_len
+            && let Some(indices) =
+                crate::runtime::utils::expand_unbounded_range_dim(&idx, array_len)
+        {
+            return Value::array(indices);
         }
         if let ValueView::Sub(data) = idx.view() {
             let mut sub_env = data.env.clone();

--- a/t/whatever-ended-range-slice-assign.t
+++ b/t/whatever-ended-range-slice-assign.t
@@ -1,0 +1,55 @@
+use Test;
+
+# A Whatever- or Inf-ended Range slice is clipped to the target array's
+# current length instead of being expanded to the lazy-range prefix. See
+# GitHub issue #7674.
+
+plan 10;
+
+{
+    my @d = 1..5;
+    is (@d[1..*] = 9).raku, '(9, Any, Any, Any)',
+        '1..* reports the values assigned through the clipped slice';
+    is @d.raku, '[1, 9, Any, Any, Any]',
+        '1..* stores only through the end of the existing array';
+}
+
+{
+    my @d = 1..5;
+    is (@d[1..^Inf] = 9).raku, '(9, Any, Any, Any)',
+        '1..^Inf is clipped to the array length';
+}
+
+{
+    my @d = 1..5;
+    is (@d[1^..Inf] = 9).raku, '(9, Any, Any)',
+        '1^..Inf is clipped after excluding its start';
+}
+
+{
+    my @d = 1..5;
+    is (@d[1^..^Inf] = 9).raku, '(9, Any, Any)',
+        '1^..^Inf is clipped with both endpoint rules';
+}
+
+{
+    my @d = 1..5;
+    is (@d[^Inf] = 9).raku, '(9, Any, Any, Any, Any)',
+        '^Inf selects the whole existing array';
+}
+
+{
+    my @d = 1..5;
+    is (@d[5..*] = 9).raku, '()',
+        'a Whatever-ended slice starting at the end is empty';
+    is @d.raku, '[1, 2, 3, 4, 5]',
+        'an empty Whatever-ended slice leaves the array unchanged';
+}
+
+{
+    my @d;
+    is (@d[0..*] = 1).raku, '()',
+        'an unbounded slice on an empty array is empty';
+    is @d.raku, '[]',
+        'an unbounded slice does not autovivify an empty array';
+}


### PR DESCRIPTION
Closes #7674

`resolve_whatever_index_for_target` now clips unbounded-end Range indices to a known array's current length before assignment normalization. This prevents `@a[1..*] = 9` from expanding to the lazy-range prefix and keeps unbounded ranges without a positional target length unexpanded. Empty clipped slices return an empty list.

Tests:
- `make lint`
- `make test`
- `make roast`
- `MUTSU_FUDGE=1 prove -v -e target/debug/mutsu roast/S09-subscript/slice.t`