### PR TITLE
fix: preserve container parameters in supply whenever

### DIFF
--- a/docs/adr/0039-container-lexicals-resolve-lexically.md
+++ b/docs/adr/0039-container-lexicals-resolve-lexically.md
@@ -1154,3 +1154,31 @@ hence the mutating-hyper writeback is restricted to an `@`/`%` target.
 roast` are still not sufficient evidence for a change in this area — both were
 green for attempt 3 too. `scripts/battery-testsuite.sh` is, and it runs locally
 in about ten minutes.
+
+## 14. `supply whenever` captures container parameters per emitter (2026-09-09)
+
+Issue #7661 exposed a narrower consequence of the remaining container capture
+gap. In
+
+```raku
+sub wrap(Supply $p, @tag) {
+    supply whenever $p { emit @tag.join(",") ~ ":" ~ $_ }
+}
+```
+
+two nested calls with `@tag` values `A` and `B` produced `B:B:1` in mutsu,
+while Rakudo produced `B:A:1`. The scalar form already had the correct
+per-invocation cell.
+
+The `whenever` body is stashed as AST and compiled when the emitter dispatches
+it. The ordinary closure escape analysis consequently treats the generated
+supply emitter as a non-escaping call argument, so its `@`/`%` capture is not
+included in the general unvouched-container set. At the `MakeLambda` boundary
+for a supply emitter, mutsu now resolves its plain `@`/`%` free variables via
+the baked parent slots and boxes those bindings before the emitter environment
+is snapshotted. Each `supply` invocation therefore gets the correct
+`ContainerRef` for the later callback.
+
+This is a supply-specific repair for the issue's stashed-body path, not the
+completion of §4.2's second bullet. The remaining `compute_upvalues` and
+container `SetLocal` work still needs its own measurement and battery gate.

--- a/news/2026-09/supply-whenever-container-parameter-capture.md
+++ b/news/2026-09/supply-whenever-container-parameter-capture.md
@@ -1,0 +1,6 @@
+# `supply whenever` keeps each `@`/`%` parameter binding
+
+A `supply whenever` body now retains the array or hash parameter belonging to
+the `supply` invocation that created it. A later invocation with the same
+parameter name no longer overwrites the earlier pipeline's captured binding.
+This fixes [#7661](https://github.com/tokuhirom/mutsu/issues/7661).

--- a/src/vm/vm_register_ops.rs
+++ b/src/vm/vm_register_ops.rs
@@ -1539,4 +1539,35 @@ impl Interpreter {
             }
         }
     }
+
+    /// Box a captured container of a `supply` emitter before its
+    /// captured environment is snapshotted. The emitter's body is a normal
+    /// compiled closure, but its `whenever` bodies are stashed AST and are
+    /// compiled later from the emitter's environment. A captured `@`/`%`
+    /// parameter therefore cannot rely on the ordinary slot-read path: the
+    /// later callback would otherwise resolve the name against the frame that
+    /// happens to dispatch it. Keep the operation supply-specific because the
+    /// general closure path deliberately boxes containers at declaration time,
+    /// not once per closure creation.
+    pub(super) fn box_supply_container_captures(
+        &mut self,
+        code: &CompiledCode,
+        cc: &Option<std::sync::Arc<CompiledCode>>,
+    ) {
+        let Some(cc) = cc else { return };
+        for (fv_i, sym) in cc.free_var_syms.iter().enumerate() {
+            let name = sym.resolve();
+            if !crate::env::is_plain_user_lexical(&name) || !name.starts_with(['@', '%']) {
+                continue;
+            }
+            let Some(idx) = Self::resolve_capture_slot(code, &cc.free_var_parent_slots, fv_i, *sym)
+            else {
+                continue;
+            };
+            // Keep an existing cell when another emitter in the same supply
+            // frame captures the binding; all callbacks must share that one
+            // per-invocation binding.
+            self.box_decl_local_container_cell(code, idx, false);
+        }
+    }
 }

--- a/src/vm/vm_register_sub_ops.rs
+++ b/src/vm/vm_register_sub_ops.rs
@@ -85,6 +85,12 @@ impl Interpreter {
             let signature = code.closure_signature(idx as usize);
             let compiled_code = Self::resolve_closure_code(code, cc_idx);
             self.box_captured_lexicals(code, &compiled_code);
+            if compiled_code
+                .as_ref()
+                .is_some_and(|cc| cc.is_supply_block_body)
+            {
+                self.box_supply_container_captures(code, &compiled_code);
+            }
             let owned_captures = self.compute_owned_captures(&compiled_code);
             let authoritative_captures = self.compute_authoritative_captures(&compiled_code);
             let upvalues = self.capture_upvalues(code, &compiled_code);

--- a/t/supply-whenever-container-parameter-capture.t
+++ b/t/supply-whenever-container-parameter-capture.t
@@ -1,0 +1,35 @@
+use Test;
+
+plan 2;
+
+# A supply emitter is compiled before its `whenever` body is dispatched. Each
+# invocation must therefore retain the container parameter belonging to that
+# invocation, rather than resolving the name through the latest caller frame.
+sub wrap-array(Supply $source, @tag --> Supply) {
+    supply whenever $source {
+        emit @tag.join(",") ~ ":" ~ $_;
+    }
+}
+
+my $source = Supplier.new;
+my $first = wrap-array($source.Supply, ["A"]);
+my $second = wrap-array($first, ["B"]);
+my @array-got;
+$second.tap({ @array-got.push($_) });
+$source.emit(1);
+is @array-got.join("|"), "B:A:1",
+    'nested supply instances keep their array parameter bindings';
+
+sub wrap-hash(Supply $source, %tag --> Supply) {
+    supply whenever $source {
+        emit %tag<value> ~ ":" ~ $_;
+    }
+}
+
+my $hash-first = wrap-hash($source.Supply, { value => "A" });
+my $hash-second = wrap-hash($hash-first, { value => "B" });
+my @hash-got;
+$hash-second.tap({ @hash-got.push($_) });
+$source.emit(2);
+is @hash-got.join("|"), "B:A:2",
+    'nested supply instances keep their hash parameter bindings';


### PR DESCRIPTION
## Summary

- Box plain `@`/`%` free-variable bindings at the `supply` emitter MakeLambda boundary, using the baked parent slot before the emitter environment is captured.
- Reuse an existing cell when multiple `whenever` emitters in one supply frame capture the same binding.
- Add array/hash regressions, a news entry, and ADR-0039 design notes.

This fixes the nested pipeline result from `B:B:1` to `B:A:1` for issue #7661.

Closes #7661

## Validation

- `make lint`
- `make test` — 3897 files, 41381 tests, PASS
- `make roast` — 1436 files, 218962 tests, PASS