### PR TITLE
docs: clarify destructuring staging list semantics

### DIFF
--- a/docs/adr/0079-container-itemization-is-a-holder-property-tagged-on-the-containerref-word.md
+++ b/docs/adr/0079-container-itemization-is-a-holder-property-tagged-on-the-containerref-word.md
@@ -276,7 +276,7 @@ unconditional and delete it.
 
 | Slice | State |
 | --- | --- |
-| 0 — comment justification | Not started |
+| 0 — comment justification | Complete (2026-09-09; comments now state the RHS `List` rule) |
 | 1 — `Kind::ContainerRefItemized` | Not started |
 | 2 — `$`-share holder (rows 1, 3, 4) | Not started |
 | 3 — audit remaining producers | Not started |

--- a/news/2026-09/containerref-itemization-slice-0.md
+++ b/news/2026-09/containerref-itemization-slice-0.md
@@ -1,0 +1,7 @@
+# Clarify why destructuring staging values are not element containers
+
+The comments around the list-destructuring staging temporary now record the
+measured Raku rule: it models the right-hand-side `List`, whose elements are
+values rather than `Array` element containers. The staging-temp exclusion is
+therefore independent of the later `ContainerRef` holder-itemization work in
+ADR-0079, and is not an ambiguity workaround.

--- a/src/runtime/utils/coerce_containers.rs
+++ b/src/runtime/utils/coerce_containers.rs
@@ -75,9 +75,10 @@ pub(crate) fn itemize_real_array_elements(mut value: Value) -> Value {
 
 /// The mirror of [`itemize_real_array_elements`], for the one container that
 /// must NOT carry the property: the list-destructuring desugar's synthetic
-/// staging temp, which is the RHS list rather than a user `Array` (see
-/// `Interpreter::itemize_elements_for_var_assign`). Same
-/// scan-then-rebuild-only-if-needed shape.
+/// staging temp, which models the RHS `List` rather than a user `Array`. A
+/// `List`'s elements are values, not containers, so this temp must not carry
+/// Array element itemization (see `Interpreter::itemize_elements_for_var_assign`
+/// and ADR-0079 §1.1). Same scan-then-rebuild-only-if-needed shape.
 pub(crate) fn deitemize_real_array_elements(mut value: Value) -> Value {
     let needs = match value.view() {
         ValueView::Array(items, ArrayKind::Array | ArrayKind::Shaped | ArrayKind::ItemArray) => {

--- a/src/vm/vm_element_producers.rs
+++ b/src/vm/vm_element_producers.rs
@@ -234,14 +234,14 @@ impl Interpreter {
             return None;
         }
         // The list-destructuring staging temp is NOT a user Array -- it IS the
-        // RHS list, and every target reads a VALUE out of it (see the note in
-        // `parser/stmt/decl/destructure.rs`; ADR-0040 slice 2 already suppresses
-        // element itemization for it for the same reason). Handing out its slots
-        // would make a `%`/`@` slurpy target -- `my ($g, %rest) = f(...)`,
-        // compiled as `@__destructure_tmp__[1..*]` -- receive containers where it
-        // needs the values behind them, and a `ContainerRef` holding a `Hash` is
-        // indistinguishable from the `$`-scalar itemization mutsu spells the same
-        // way, so the hash initializer cannot decontainerize it safely.
+        // RHS List, and a List's elements are values rather than containers (see
+        // the note in `parser/stmt/decl/destructure.rs`; ADR-0040 slice 2 already
+        // suppresses element itemization for it for the same reason). Handing
+        // out its slots would make a `%`/`@` slurpy target --
+        // `my ($g, %rest) = f(...)`, compiled as `@__destructure_tmp__[1..*]` --
+        // receive element containers where it needs the values behind them.
+        // This is the List-vs-Array rule, not a workaround for an ambiguity
+        // between two ContainerRef shapes; see ADR-0079 §1.1.
         if data
             .descriptor_name
             .as_deref()


### PR DESCRIPTION
Part of #7542

## Summary
- clarify that the destructuring staging temporary models the RHS List
- remove the obsolete ContainerRef ambiguity explanation
- record ADR-0079 Slice 0 as complete and add the news entry

## Validation
- `cargo fmt --all`
- `make lint`
- `make test`
- `make roast`
- `git diff --check`

This is ADR-0079 Slice 0; the remaining ContainerRef representation and semantic slices stay tracked in #7542.