### PR TITLE
fix: run a `unit module`'s custom `sub EXPORT`

### DIFF
--- a/news/2026-09/unit-module-custom-export-sub.md
+++ b/news/2026-09/unit-module-custom-export-sub.md
@@ -1,0 +1,124 @@
+# A `unit module`'s custom `sub EXPORT` now runs
+
+`NativeLibs t/01-basic.t` was the first of the four bundled-library regressions
+in [#7555](https://github.com/tokuhirom/mutsu/issues/7555) — the ones blocking
+the vendored-`Test`-by-default flip. Under the vendored module its test 6
+(`ok ::('NativeCall') !~~ Failure`) reported `MISSING`; under the native
+provider it passed, but for the wrong reason. It now passes **23/23 under both
+providers**, and it does so through the mechanism rakudo uses.
+
+Four independent interpreter bugs sat between here and there. Each is general;
+none is about `Test`.
+
+## 1. A `sub EXPORT` above the `unit module` line was never called
+
+`unit module Foo;` packages *the rest of the scope*. What precedes it stays in
+the compilation unit's outer scope — and that positional rule is the whole
+mechanism behind a custom export hook, because `use` looks the hook up in the
+compunit's outer scope, not inside the module. Every module that has one
+therefore writes it above the line, as `NativeLibs` does:
+
+```raku
+use NativeCall;
+sub EXPORT(|) {
+    my $exp = &trait_mod:<is>.candidates.first: { .signature ~~ :(Routine, :$native!) };
+    Map.new('NativeCall' => NativeCall, '&trait_mod:<is>' => $exp.dispatcher)
+}
+unit module NativeLibs:auth<salortiz>:ver<0.0.9>;
+```
+
+`compile_unit` emitted the runtime package switch for the *whole* compilation
+unit before the sub-hoist pass, so the hook registered as `Foo::EXPORT` and
+`apply_module_export`'s `GLOBAL::EXPORT` lookup missed it. The custom export of
+every `unit module` in the ecosystem was silently a no-op. The hoist is now
+split at the declaration: what precedes it registers under `GLOBAL`, and the
+runtime package is handed back for those statements' own execution, so the
+declaration re-establishes it when execution reaches it. Measured against
+rakudo: above the line runs, below it does not.
+
+## 2. `.dispatcher` answered the candidate, not the proto
+
+Raku generates a dispatcher even for a `multi` written with no `proto`, and
+`.dispatcher` on a candidate returns it. mutsu answered the candidate itself —
+and, for a `Sub`-shaped value, an ADR-0070 `<composed-method:dispatcher>` stub,
+because nothing handled the method at all on that shape. Either way
+`.dispatcher.candidates` reported a single entry, which silently narrows a whole
+multi to the one candidate that was introspected. That is exactly what the
+`Map.new('&name' => $candidate.dispatcher)` re-export idiom does, so
+`NativeLibs` handed its importers a one-candidate `&trait_mod:<is>`. `Routine`
+handles now also answer `.is_dispatcher`/`.multi`, which the fixed
+`.dispatcher` makes reachable.
+
+## 3. NativeCall exported a content-free `trait_mod:<is>`
+
+Rakudo's `NativeCall.rakumod` declares its four trait candidates
+(`:$native!`, `:$symbol!`, `:$nativeconv!`, `:$encoded!`) as ordinary multis and
+exports them, which is what makes `&trait_mod:<is>.candidates` introspectable.
+mutsu registered only a bare exported *name*, so `.candidates` answered one
+entry with no signature, `.first` gave `Nil`, and the module died on
+`Any.dispatcher`. The four candidates are now spliced in as a prelude, gated on
+the compunit both using NativeCall and naming `trait_mod:<is>` itself — the
+gate matters, because their mere presence flips
+`has_proto`/`has_multi_candidates` and would route every other unknown `is`
+trait in the file through custom dispatch. Their bodies are empty on purpose:
+mutsu applies all four natively at declaration time
+(`register_native_call_sub`), and `registration_sub.rs` already excludes them
+from the custom-`trait_mod:<is>` loop for that reason, so these candidates are
+never what applies the trait — they exist to make the export surface
+introspectable, as rakudo's do.
+
+Two lifetime bugs surfaced with them. A prelude splice declared as a `multi`
+registers under arity-suffixed keys (`GLOBAL::name/2`, and the chained `__mN`
+slots), never under the bare `GLOBAL::name` the single-sub path records, so the
+prelude bookkeeping missed it entirely: `reinstate_module_functions` dropped the
+candidates as importer-scoped `GLOBAL::` aliases the first time a block scope
+unwound. And Raku re-runs `sub EXPORT` on *every* later import of an
+already-loaded module, by which time the importer's scope holds none of the
+module's own lexicals — `Map.new('NativeCall' => NativeCall, …)` quietly
+degraded to the bareword string `"NativeCall"`, which then shadowed the real
+package. The remembered hook now carries the module-scope env it was first
+called in, and both call paths anchor to the module's own compunit.
+
+## 4. A `Signature` literal lost its parameters across the precompilation cache
+
+This one is independent of `EXPORT` and reproduces in plain Raku:
+
+```raku
+# lib/SigRT.rakumod
+unit module SigRT;
+multi sub mm(Routine $r, :$native!) is export { 'native' }
+multi sub mm(Routine $r, :$symbol!) is export { 'symbol' }
+our sub probe is export {
+    &mm.candidates.map({ (.signature ~~ :(Routine, :$native!)).Str }).join(",")
+}
+```
+
+```
+cold: True,False      # rakudo: True,False
+warm: False,False
+```
+
+A `Signature` literal is an `Expr::Literal` holding a `Signature` instance, but
+its structured parameter data lives in a process-global side table keyed by that
+instance's id — which nothing in a serialized value can reach. A module restored
+from the cache came back with a literal whose id named nothing,
+`extract_sig_info` fell through to its empty-params legacy shape, and the
+smartmatch went from True to False. Only the *second* run of a program sees it,
+which is precisely what CI's always-cold runners cannot catch.
+
+`SerValue::Instance` now carries the `SigInfo` alongside a `Signature`, and the
+value is rebuilt whole from it on load — under a *fresh* id, so it cannot
+collide with an unrelated instance holding the recorded id in this process.
+`CACHE_FORMAT_VERSION` moves to 12.
+
+## Verification
+
+`NativeLibs`' upstream suite passes under both providers, cold and warm.
+Pinned by `t/unit-module-export-sub.t`, `t/multi-candidate-dispatcher.t`,
+`t/nativecall-trait-mod-is-candidates.t` and
+`t/signature-literal-precomp-warm-cache.t` — all four fail on the previous
+`main`, and all four pass under real `raku` unchanged.
+
+Items 2 and 4 of #7555 were fixed earlier (#7653, #7663) and item 3 is tracked
+separately as [#7667](https://github.com/tokuhirom/mutsu/issues/7667); this
+closes the last one.

--- a/news/2026-09/unit-module-custom-export-sub.md
+++ b/news/2026-09/unit-module-custom-export-sub.md
@@ -122,3 +122,27 @@ Pinned by `t/unit-module-export-sub.t`, `t/multi-candidate-dispatcher.t`,
 Items 2 and 4 of #7555 were fixed earlier (#7653, #7663) and item 3 is tracked
 separately as [#7667](https://github.com/tokuhirom/mutsu/issues/7667); this
 closes the last one.
+
+## A fifth bug the gate surfaced: calling an enum value
+
+`Log::Async`'s `16-imports2.rakutest` was on the bundled-library whitelist and
+started failing under the change above — but it had been passing for the wrong
+reason. Its `sub EXPORT` reads `@*ARGS`, and the re-run used to see the
+*importer's* copy: mutsu matched the module's `--log=` branch against the test's
+`--level=trace` (with a `Use of Nil in string context` warning), which left
+`$level` a `WhateverCode`. Running the hook in the module's own scope — what
+rakudo does — makes `$level` the plain enum value rakudo produces there, and
+the test then calls it.
+
+Rakudo answers that call: `Lv::DEBUG(1)` is the same coercion as `Lv(1)`, both
+giving `Lv::TRACE`, and an undefined value when the enum holds no such value.
+mutsu implemented only the type-object half. `vm_call_on_value` already routes
+an invoked `Package` to the bare-name call path — "invoking a type object is a
+coercion, not a `CALL-ME` call" — but an enum *value* is a `ValueView::Enum`,
+matched neither that arm nor the `Instance | Package` one, and fell through to
+the `CALL-ME` fallback. Pinned by `t/enum-value-call-coercion.t`.
+
+One divergence is left untouched because it predates this and belongs to the
+shared coercion helper, not to the new arm: `Lv('DEBUG')` answers `Lv::DEBUG` in
+mutsu where rakudo answers `Nil`. The value form now agrees with the type form,
+which is the property that matters here.

--- a/src/compiler/helpers_ast_utils.rs
+++ b/src/compiler/helpers_ast_utils.rs
@@ -438,21 +438,23 @@ impl Compiler {
             .any(|s| matches!(s, Stmt::SubDecl { .. } | Stmt::ProtoDecl { .. }))
     }
 
-    /// Constant-pool index for the qualified name of a top-level
-    /// `unit module`/`unit package` declaration in `stmts`, if there is one.
-    /// Used to emit the runtime package switch ahead of the sub-hoist pass; see
-    /// the call site in `compile()`.
-    pub(super) fn unit_package_name_const(&mut self, stmts: &[Stmt]) -> Option<u32> {
-        let name = stmts.iter().find_map(|s| match s {
+    /// Position of a top-level `unit module`/`unit package` declaration in
+    /// `stmts`, plus the constant-pool index of its qualified name. Used to
+    /// emit the runtime package switch ahead of the sub-hoist pass, and to
+    /// tell the statements that precede the declaration (which are *not* in
+    /// the package) from the ones that follow it; see the call site in
+    /// `compile_unit()`.
+    pub(super) fn unit_package_split(&mut self, stmts: &[Stmt]) -> Option<(usize, u32)> {
+        let (pos, name) = stmts.iter().enumerate().find_map(|(i, s)| match s {
             Stmt::Package {
                 name,
                 is_unit: true,
                 ..
-            } => Some(name.resolve()),
+            } => Some((i, name.resolve())),
             _ => None,
         })?;
         let qualified = self.qualify_package_name(&name);
-        Some(self.code.add_constant(Value::str(qualified)))
+        Some((pos, self.code.add_constant(Value::str(qualified))))
     }
 
     /// Hoist sub declarations: emit RegisterDecl(Sub) for all SubDecl statements

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -3807,10 +3807,31 @@ impl Compiler {
         // routine that stays callable from the consumer's scope (PLAN 8.22).
         // The compiler's own `current_package` is still switched by the
         // declaration itself, so this must not qualify anything here.
-        if let Some(name_idx) = self.unit_package_name_const(stmts) {
-            self.code.emit(OpCode::SetCurrentPackage { name_idx });
+        // Routines declared *textually above* the `unit module` line are not in
+        // the module: the declaration only packages "the rest of the scope", so
+        // what precedes it stays in the compilation unit's outer (GLOBAL)
+        // scope. That positional rule is the whole mechanism behind a custom
+        // `sub EXPORT`, which a module must declare above its `unit module`
+        // line for `use` to find it (`apply_module_export` looks up
+        // `GLOBAL::EXPORT`); hoisting the prefix under the package registered
+        // it as `Foo::EXPORT` and the export sub was silently never called.
+        let unit_split = self.unit_package_split(stmts);
+        let outer_prefix =
+            unit_split.is_some_and(|(pos, _)| Self::stmts_declare_routines(&stmts[..pos]));
+        match unit_split {
+            Some((pos, name_idx)) if outer_prefix => {
+                // The runtime package is still GLOBAL here, which is where the
+                // prefix's routines belong.
+                self.hoist_sub_decls(&stmts[..pos], false);
+                self.code.emit(OpCode::SetCurrentPackage { name_idx });
+                self.hoist_sub_decls(&stmts[pos..], false);
+            }
+            Some((_, name_idx)) => {
+                self.code.emit(OpCode::SetCurrentPackage { name_idx });
+                self.hoist_sub_decls(stmts, false);
+            }
+            None => self.hoist_sub_decls(stmts, false),
         }
-        self.hoist_sub_decls(stmts, false);
         // Pre-register declaration-only shells of class/role declarations so a
         // mainline statement that runs before the textual declaration can
         // already construct the type (Raku type declarations are compile-time;
@@ -3822,6 +3843,17 @@ impl Compiler {
         self.hoist_nested_our_subs(stmts);
         // Hoist `my TYPE $var;` type constraints (see `hoist_typed_var_decls`).
         self.hoist_typed_var_decls(stmts);
+        // The remaining hoist passes above want the package, but the prefix
+        // statements themselves run outside it, so hand the runtime back to
+        // GLOBAL for them. The `unit` declaration emits its own
+        // `SetCurrentPackage` when execution reaches it, which closes the
+        // window again for everything that follows.
+        if outer_prefix {
+            let global_idx = self.code.add_constant(Value::str("GLOBAL".to_string()));
+            self.code.emit(OpCode::SetCurrentPackage {
+                name_idx: global_idx,
+            });
+        }
         // If the top-level body contains a CATCH or CONTROL block, wrap in
         // an implicit try so the phaser can observe exceptions / control
         // signals from the surrounding statements.

--- a/src/precomp.rs
+++ b/src/precomp.rs
@@ -100,7 +100,10 @@ fn interpreter_version() -> String {
     // so its third field serializes as an enum rather than a bool.
     // 11: `Expr::DoBlock` gained `origin: DoBlockOrigin` (GH-7635), so a
     // cached node from an older build deserializes a field short.
-    const CACHE_FORMAT_VERSION: u32 = 11;
+    // 12: `SerValue::Instance` gained `sig_info`, so a cached `Signature`
+    // literal now carries its structured parameter data instead of an id
+    // pointing at a side table the cache cannot reach.
+    const CACHE_FORMAT_VERSION: u32 = 12;
     // The exe mtime cannot change while this process runs, so stat it once —
     // every cache validation used to re-stat the (large) binary per module.
     static VERSION: std::sync::OnceLock<String> = std::sync::OnceLock::new();

--- a/src/runtime/compunit_scope.rs
+++ b/src/runtime/compunit_scope.rs
@@ -49,6 +49,14 @@ impl Interpreter {
         self.unit_of_source_sym(self.current_source_file_sym())
     }
 
+    /// The compunit a routine declared in `file` belongs to, for a path held
+    /// as a `String` (`FunctionDef::source_file`). Used to run a module's
+    /// `sub EXPORT` anchored to the module's own unit rather than to whoever
+    /// happens to be importing it.
+    pub(crate) fn unit_of_declaring_file(&self, file: Option<&str>) -> Symbol {
+        self.unit_of_source_sym(file.map(Symbol::intern))
+    }
+
     fn unit_of_source_sym(&self, file: Option<Symbol>) -> Symbol {
         match (file, self.program_path.as_deref()) {
             (None, _) => crate::runtime::main_unit(),

--- a/src/runtime/methods_instance_ops.rs
+++ b/src/runtime/methods_instance_ops.rs
@@ -2225,6 +2225,40 @@ impl Interpreter {
                     Self::sub_multi_method_dispatcher_name(&data).is_some(),
                 ))
             }
+            // `.dispatcher` on a multi candidate is the proto that dispatches
+            // it -- Raku generates one even when the source declares no
+            // `proto`. Answered here rather than left to fall through to
+            // ADR-0070 method composition, which handed back a
+            // `<composed-method:dispatcher>` Sub that answers `.candidates`
+            // with just itself. That is how the `NativeLibs` distribution's
+            // custom `sub EXPORT` lost the multi it was re-exporting: it hands
+            // its importers `'&trait_mod:<is>' => $candidate.dispatcher`, and
+            // the stub narrowed a whole multi to one candidate.
+            //
+            // A routine that is part of no multi has no dispatcher; Rakudo
+            // answers an NQPMu there, which is falsy, so `Nil` is the
+            // observable match (`&plain.dispatcher` is `?? !!`-tested by
+            // callers, not named).
+            //
+            // TODO: asking a dispatcher for its own `.dispatcher` should be
+            // `Nil` too. mutsu cannot yet tell `&mm` from `&mm.candidates[0]`
+            // -- neither carries the `__mutsu_is_multi_candidate` fact the
+            // `.multi` arm below reads -- so it answers a handle to itself.
+            "dispatcher" if args.is_empty() && matches!(target.view(), ValueView::Sub(_)) => {
+                let ValueView::Sub(data) = target.view() else {
+                    unreachable!()
+                };
+                let name = data.name.resolve();
+                let qualified = format!("{}::{}", data.package.resolve(), name);
+                if self.resolve_proto_function(&qualified).is_some()
+                    || self.resolve_proto_function_with_alias(&name).is_some()
+                    || self.has_multi_candidates(&name)
+                {
+                    Ok(Value::routine_parts(data.package, data.name, false))
+                } else {
+                    Ok(Value::NIL)
+                }
+            }
             "multi" if args.is_empty() && matches!(target.view(), ValueView::Sub(_)) => {
                 let ValueView::Sub(data) = target.view() else {
                     unreachable!()

--- a/src/runtime/methods_sub.rs
+++ b/src/runtime/methods_sub.rs
@@ -298,14 +298,19 @@ impl Interpreter {
         }
         if method == "dispatcher" && args.is_empty() {
             let qualified = format!("{}::{}", package, name);
-            if self.resolve_proto_function(&qualified).is_some() {
-                return Some(Ok(Value::routine_parts(
-                    Symbol::intern(package),
-                    Symbol::intern(name),
-                    false,
-                )));
-            }
-            if self.resolve_proto_function_with_alias(name).is_some() {
+            // A `proto` declaration makes the dispatcher explicit, but a set of
+            // `multi`s written without one still has a dispatcher (Raku
+            // generates it), and `.dispatcher` on a candidate returns it in
+            // either case. Without the third arm this returned the *candidate*,
+            // whose `.candidates` is then just itself -- so re-exporting
+            // `.dispatcher` under the routine's name (the `NativeLibs`
+            // custom-`EXPORT` idiom, which hands its importers
+            // `'&trait_mod:<is>' => $candidate.dispatcher`) silently narrowed
+            // the multi to the one candidate that was introspected.
+            if self.resolve_proto_function(&qualified).is_some()
+                || self.resolve_proto_function_with_alias(name).is_some()
+                || self.has_multi_candidates(name)
+            {
                 return Some(Ok(Value::routine_parts(
                     Symbol::intern(package),
                     Symbol::intern(name),
@@ -313,6 +318,18 @@ impl Interpreter {
                 )));
             }
             return Some(Ok(target.clone()));
+        }
+        // A `Routine` handle names a whole multi, so it *is* the dispatcher --
+        // which is what `.dispatcher` above hands back. Rakudo answers `True`
+        // for `.is_dispatcher` and a falsy `.multi` on it; without these the
+        // `Sub`-shaped arms in `methods_instance_ops.rs` never see the value
+        // and the call dies with "No such method".
+        if matches!(method, "is_dispatcher" | "multi") && args.is_empty() {
+            let qualified = format!("{}::{}", package, name);
+            let is_multi = self.resolve_proto_function(&qualified).is_some()
+                || self.resolve_proto_function_with_alias(name).is_some()
+                || self.has_multi_candidates(name);
+            return Some(Ok(Value::truth(is_multi && method == "is_dispatcher")));
         }
         if method == "can" {
             let method_name = args

--- a/src/runtime/registration_sub.rs
+++ b/src/runtime/registration_sub.rs
@@ -749,31 +749,42 @@ impl Interpreter {
             .any(|(t, _)| t == crate::runtime::PRELUDE_SUB_TRAIT)
         {
             let global_key = Symbol::intern(&format!("GLOBAL::{}", name));
-            // Remember that this `GLOBAL::` key is a prelude splice, not an
-            // import alias. `reinstate_module_functions` needs the distinction
-            // to put it back after a scope rollback — see
-            // `prelude_registered_functions`.
-            self.prelude_registered_functions.insert(global_key);
-            // ...and record WHICH compunit this copy was spliced into, before
-            // the idempotence check below can swallow it. The registration is
-            // process-global so that a method body under any package can reach
-            // the helper, but rakudo scopes these names to the compunits that
-            // `use NativeCall`, so resolution consults this set — see
-            // `prelude_declaring_units` / `prelude_visible_here`.
-            let unit = self.declaring_unit_sym();
-            self.prelude_declaring_units
-                .entry(global_key)
-                .or_default()
-                .insert(unit);
+            // Only a *single* sub registers under the bare `GLOBAL::name`; a
+            // `multi` lands on arity-suffixed keys instead, and claiming the
+            // bare name for it would gate somebody else's real `GLOBAL::name`
+            // (NativeCall's own exported `trait_mod:<is>` entry) behind this
+            // splice's compunit and hide it everywhere else. The multi keys are
+            // recorded after registration instead — see the prelude-multi block
+            // further down.
+            if !multi {
+                // Remember that this `GLOBAL::` key is a prelude splice, not an
+                // import alias. `reinstate_module_functions` needs the distinction
+                // to put it back after a scope rollback — see
+                // `prelude_registered_functions`.
+                self.prelude_registered_functions.insert(global_key);
+                // ...and record WHICH compunit this copy was spliced into, before
+                // the idempotence check below can swallow it. The registration is
+                // process-global so that a method body under any package can reach
+                // the helper, but rakudo scopes these names to the compunits that
+                // `use NativeCall`, so resolution consults this set — see
+                // `prelude_declaring_units` / `prelude_visible_here`.
+                let unit = self.declaring_unit_sym();
+                self.prelude_declaring_units
+                    .entry(global_key)
+                    .or_default()
+                    .insert(unit);
+            }
             // Remember the bare name as ambient, so the post-load seclusion of
             // a compunit's *private* top-level routines
             // (`seclude_private_toplevel_routines`) leaves it in `GLOBAL` where
-            // every compunit's bodies can reach it.
+            // every compunit's bodies can reach it. This is about the NAME, so
+            // a `multi` prelude needs it too — its candidates live under
+            // `GLOBAL::name/N`, but the name they answer to is the same one.
             self.prelude_sub_names.insert(Symbol::intern(name));
             // Every compunit that uses NativeCall carries its own copy of the
             // declaration, and they are identical by construction, so the first
             // one wins and the rest are no-ops rather than redeclarations.
-            if self.registry().functions.contains_key(&global_key) {
+            if !multi && self.registry().functions.contains_key(&global_key) {
                 return Ok(SubRegisterOutcome::Unchanged);
             }
             if self.current_package() != "GLOBAL" {
@@ -1390,6 +1401,38 @@ impl Interpreter {
             self.registry_mut().functions.insert(fq_sym, arc);
             // Invalidate name-keyed resolution caches.
             self.fn_resolve_gen += 1;
+        }
+        // A prelude splice declared as a `multi` registers under arity-suffixed
+        // keys (`GLOBAL::name/2`, and the chained `…__mN` slots
+        // `insert_multi_overload` uses), never under the bare `GLOBAL::name`
+        // the single-sub branch above records. Record the real keys here, so
+        // `reinstate_module_functions` puts them back when a block scope
+        // unwinds rather than dropping them as importer-scoped `GLOBAL::`
+        // aliases. Dropping them is what left a module's `sub EXPORT` -- which
+        // Raku re-runs on every later import, long after the module's own load
+        // -- unable to see the candidates its compunit had spliced in
+        // (`NativeLibs` introspecting `&trait_mod:<is>.candidates`).
+        if multi
+            && custom_traits
+                .iter()
+                .any(|(t, _)| t == crate::runtime::PRELUDE_SUB_TRAIT)
+        {
+            let prefix = format!("GLOBAL::{}/", name);
+            let unit = self.declaring_unit_sym();
+            let keys: Vec<Symbol> = self
+                .registry()
+                .functions
+                .keys()
+                .filter(|k| k.resolve().starts_with(&prefix))
+                .copied()
+                .collect();
+            for key in keys {
+                self.prelude_registered_functions.insert(key);
+                self.prelude_declaring_units
+                    .entry(key)
+                    .or_default()
+                    .insert(unit);
+            }
         }
         // If this is an our-scoped sub, also store it in the persistent our_scoped_functions
         // so it survives block scope restoration.

--- a/src/runtime/run.rs
+++ b/src/runtime/run.rs
@@ -242,6 +242,41 @@ multi sub trait_mod:<does>(Mu $doee, Mu $role) is export {
 }
 "#;
 
+/// `trait_mod:<is>`'s NativeCall candidates. Rakudo's `NativeCall.rakumod`
+/// declares these as ordinary multis and exports them, which is what makes
+/// `&trait_mod:<is>.candidates` introspectable after `use NativeCall` — the
+/// `NativeLibs` distribution's custom `sub EXPORT` picks its `:$native!`
+/// candidate out of that list and re-exports `.dispatcher` so its own
+/// importers get `is native` too:
+///
+/// ```raku
+/// sub EXPORT(|) {
+///     my $exp = &trait_mod:<is>.candidates.first: { .signature ~~ :(Routine, :$native!) };
+///     Map.new('NativeCall' => NativeCall, '&trait_mod:<is>' => $exp.dispatcher)
+/// }
+/// ```
+///
+/// Without them `.candidates` holds only the bare exported-name shell, `.first`
+/// returns `Nil`, and the module dies on `Any.dispatcher`.
+///
+/// The bodies are empty on purpose, and that is not a stub standing in for an
+/// unimplemented feature: mutsu applies all four traits *natively* when the
+/// routine is declared (`register_native_call_sub`), and
+/// `registration_sub.rs`'s custom-`trait_mod:<is>` loop explicitly excludes
+/// `native`/`symbol`/`nativeconv`/`encoded` for that reason, so these
+/// candidates are never the thing that applies the trait — they exist to make
+/// the export surface introspectable, exactly as Rakudo's do.
+// TODO: calling one of these explicitly (`trait_mod:<is>($r, :native<foo>)`)
+// should apply the trait like Rakudo's does; that needs the C-FFI descriptor
+// to be installable on an already-registered Routine, which `register_native_
+// call_sub` can only do from the declaration site today.
+pub(super) const TRAIT_MOD_IS_NATIVECALL_PRELUDE: &str = r#"
+multi sub trait_mod:<is>(Routine $r, :$native!) is export { }
+multi sub trait_mod:<is>(Routine $r, :$symbol!) is export { }
+multi sub trait_mod:<is>(Routine $r, :$nativeconv!) is export { }
+multi sub trait_mod:<is>(Routine $r, :$encoded!) is export { }
+"#;
+
 /// `Metamodel::Naming` and `Metamodel::Stashing` -- the two metaroles a custom
 /// HOW composes to become a *named* metaobject.
 ///
@@ -530,6 +565,7 @@ impl Interpreter {
         Self::inject_nativecall_subs_prelude(&code, &mut stmts);
         Self::inject_iosocket_prelude(&code, &mut stmts);
         Self::inject_trait_mod_does_prelude(&code, &mut stmts);
+        Self::inject_trait_mod_is_prelude(&code, &mut stmts);
         Self::inject_metamodel_role_prelude(&code, &mut stmts);
         // Install EVERY END phaser this compunit declares — top-level, inside
         // a block, inside a sub or a method — before the VM runs a single

--- a/src/runtime/run_modules.rs
+++ b/src/runtime/run_modules.rs
@@ -527,6 +527,7 @@ impl Interpreter {
         Self::inject_nativecall_subs_prelude(&code, &mut stmts);
         Self::inject_iosocket_prelude(&code, &mut stmts);
         Self::inject_trait_mod_does_prelude(&code, &mut stmts);
+        Self::inject_trait_mod_is_prelude(&code, &mut stmts);
 
         // Save to precompilation cache when the module is eligible.
         if precomp_eligible {

--- a/src/runtime/run_prelude.rs
+++ b/src/runtime/run_prelude.rs
@@ -1,6 +1,7 @@
 use super::run::{
     IO_SOCKET_ROLE_PRELUDE, METAMODEL_ROLE_PRELUDE, NATIVECALL_POINTER_PRELUDE,
     NATIVECALL_SUB_PRELUDES, RATIONAL_ROLE_PRELUDE, TRAIT_MOD_DOES_PRELUDE,
+    TRAIT_MOD_IS_NATIVECALL_PRELUDE,
 };
 use super::source_code_text::CodeText;
 use super::*;
@@ -188,6 +189,46 @@ impl Interpreter {
     /// collide with) a user-declared candidate of the same name, and that
     /// collision is exactly what proves the builtin is registered correctly
     /// (see `TRAIT_MOD_DOES_PRELUDE`'s doc comment).
+    /// Prepend NativeCall's `trait_mod:<is>` candidates (see
+    /// [`TRAIT_MOD_IS_NATIVECALL_PRELUDE`]) to a program that both uses
+    /// NativeCall and names `trait_mod:<is>` itself.
+    ///
+    /// Both halves of that gate matter. Without `use NativeCall` the candidates
+    /// do not exist in Rakudo either, so injecting them would be wrong. And
+    /// naming `trait_mod:<is>` is what tells this apart from the overwhelmingly
+    /// common case of a program that merely *declares* `is native` routines:
+    /// there the candidates are unobservable (mutsu applies those traits
+    /// natively), while their mere presence would flip
+    /// `has_proto`/`has_multi_candidates` and route every other unknown `is`
+    /// trait in the file through custom dispatch.
+    ///
+    /// A file that declares its own `trait_mod:<is>` keeps it: injecting
+    /// alongside it would be a redeclaration, and the user's handler is the one
+    /// that should win.
+    pub(super) fn inject_trait_mod_is_prelude(source: &CodeText<'_>, stmts: &mut Vec<Stmt>) {
+        if !source.contains("trait_mod:<is>")
+            || !source.contains("NativeCall")
+            || Self::declares_toplevel_sub(stmts, "trait_mod:<is>")
+        {
+            return;
+        }
+        use std::sync::OnceLock;
+        static TRAIT_MOD_IS_STMTS: OnceLock<Vec<Stmt>> = OnceLock::new();
+        let prelude = TRAIT_MOD_IS_STMTS.get_or_init(|| {
+            let mut stmts = crate::parse_dispatch::parse_source(TRAIT_MOD_IS_NATIVECALL_PRELUDE)
+                .map(|(s, _)| s)
+                .unwrap_or_default();
+            Self::mark_prelude_subs(&mut stmts);
+            stmts
+        });
+        if prelude.is_empty() {
+            return;
+        }
+        let mut combined = prelude.clone();
+        combined.append(stmts);
+        *stmts = combined;
+    }
+
     pub(super) fn inject_trait_mod_does_prelude(source: &CodeText<'_>, stmts: &mut Vec<Stmt>) {
         if !source.contains("trait_mod:<does>") {
             return;

--- a/src/runtime/runtime_module_export_sub.rs
+++ b/src/runtime/runtime_module_export_sub.rs
@@ -12,8 +12,14 @@ use crate::value::ValueView;
 /// (Raku runs `sub EXPORT` on every import, not once per process).
 #[derive(Clone)]
 pub(crate) enum ModuleExportDef {
-    /// The module's own `sub EXPORT`.
-    Sub(Arc<FunctionDef>),
+    /// The module's own `sub EXPORT`, together with the module-scope env it
+    /// was first called in. Raku's `EXPORT` is a closure over its own
+    /// compunit, so a re-`use` of an already-loaded module has to run it there
+    /// too: the new importer's scope holds none of the module's lexicals, and
+    /// `NativeLibs`' `Map.new('NativeCall' => NativeCall, ...)` quietly
+    /// degraded to the *bareword string* `"NativeCall"` when re-run against it
+    /// -- which then shadowed the real package for the importer.
+    Sub(Arc<FunctionDef>, crate::env::Env),
     /// An `&EXPORT` the module imported from another module's EXPORT map
     /// (the Slangify pattern).
     Value(Value),
@@ -73,14 +79,26 @@ impl Interpreter {
         // control flow (die/note/exit), not caller-env mutation.
         let empty_fns = crate::opcode::CompiledFns::default();
         let saved_env = self.env.clone();
-        let result = self.compile_and_call_function_def(&def, export_args, &empty_fns)?;
-        self.env = saved_env;
+        // Anchor the call to the module's own compunit. `EXPORT` is the
+        // module's code, so a prelude splice made into the module's unit (the
+        // NativeCall `trait_mod:<is>` candidates `NativeLibs` introspects) has
+        // to be visible while it runs -- `prelude_visible_here` otherwise hides
+        // it as soon as the importer's frames are what the unit walk reaches.
+        let saved_unit = self.current_unit;
+        self.current_unit = self.unit_of_declaring_file(def.source_file.as_deref());
+        let result = self.compile_and_call_function_def(&def, export_args, &empty_fns);
+        self.current_unit = saved_unit;
+        let result = result?;
+        self.env = saved_env.clone();
         // `EXPORT` must not itself become a callable in (or leak from) the
         // module; drop every registered `EXPORT` routine now that it has run.
         self.remove_export_routine();
         self.install_export_map(&result, importer.as_deref());
         if let Some(m) = self.module_load_stack.last().cloned() {
-            self.module_export_defs.insert(m, ModuleExportDef::Sub(def));
+            // `saved_env` is the module's own scope: `apply_module_export` runs
+            // right after the module body, before the load unwinds.
+            self.module_export_defs
+                .insert(m, ModuleExportDef::Sub(def, saved_env));
         }
         Ok(())
     }
@@ -95,9 +113,15 @@ impl Interpreter {
         let export_args = self.pending_use_export_args.take().unwrap_or_default();
         let saved_env = self.env.clone();
         let result = match def {
-            ModuleExportDef::Sub(d) => {
+            ModuleExportDef::Sub(d, module_env) => {
                 let empty_fns = crate::opcode::CompiledFns::default();
-                self.compile_and_call_function_def(&d, export_args, &empty_fns)?
+                self.env = module_env;
+                // Same compunit anchoring as the first-load path above.
+                let saved_unit = self.current_unit;
+                self.current_unit = self.unit_of_declaring_file(d.source_file.as_deref());
+                let r = self.compile_and_call_function_def(&d, export_args, &empty_fns);
+                self.current_unit = saved_unit;
+                r?
             }
             ModuleExportDef::Value(v) => self.call_sub_value(v, export_args, false)?,
         };

--- a/src/value/serde_support.rs
+++ b/src/value/serde_support.rs
@@ -98,6 +98,16 @@ enum SerValue {
         class_name: Symbol,
         attributes: HashMap<String, SerValue>,
         id: u64,
+        /// A `Signature`'s structured parameter data. It normally lives in a
+        /// process-global side table keyed by the instance id, which nothing in
+        /// a serialized value can reach: a `Signature` literal restored from
+        /// the precompilation cache came back with an id that no longer names
+        /// anything, and `extract_sig_info` fell through to its empty-params
+        /// legacy shape -- so `.signature ~~ :(Routine, :$native!)` was True on
+        /// a cold run and False on a warm one. Carrying the info alongside lets
+        /// the value be rebuilt whole, under a fresh id.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        sig_info: Option<crate::value::signature::SigInfo>,
     },
     Mixin(Box<SerValue>, HashMap<String, SerValue>),
     Capture {
@@ -285,10 +295,14 @@ fn value_to_ser(v: &Value) -> Result<SerValue, String> {
                 .iter()
                 .map(|(k, v)| value_to_ser(v).map(|sv| (k.resolve(), sv)))
                 .collect();
+            let sig_info = (class_name == "Signature")
+                .then(|| crate::value::signature::lookup_sig_info(id))
+                .flatten();
             Ok(SerValue::Instance {
                 class_name,
                 attributes: ser_attrs?,
                 id,
+                sig_info,
             })
         }
         ValueView::Mixin(inner, overrides) => {
@@ -490,10 +504,21 @@ fn ser_to_value(sv: SerValue) -> Value {
             minus,
             text,
         }),
+        // A `Signature` that carried its structured info is rebuilt from that
+        // info rather than from the serialized attributes: `make_signature_value`
+        // derives every attribute from it and registers it under a *fresh* id,
+        // so the restored value is self-consistent and cannot collide with an
+        // unrelated instance that happens to hold the recorded id in this
+        // process.
+        SerValue::Instance {
+            sig_info: Some(info),
+            ..
+        } => crate::value::signature::make_signature_value(info, None),
         SerValue::Instance {
             class_name,
             attributes,
             id,
+            ..
         } => Value::from_repr(ValueRepr::Instance {
             class_name,
             attributes: crate::gc::Gc::new(crate::value::InstanceAttrs::new(

--- a/src/value/signature.rs
+++ b/src/value/signature.rs
@@ -8,7 +8,12 @@ use std::collections::HashMap;
 use std::sync::Mutex;
 
 /// Lightweight representation of a signature parameter for runtime use.
-#[derive(Debug, Clone, Default)]
+///
+/// Serializable so a `Signature` literal survives the precompilation cache:
+/// the structured data lives in a process-global side table keyed by the
+/// instance id ([`SIG_REGISTRY`]), which a cached AST cannot carry, so it
+/// travels with the serialized instance instead (see `value::serde_support`).
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
 pub(crate) struct SigParam {
     pub(crate) name: String,
     pub(crate) type_constraint: Option<String>,
@@ -35,7 +40,7 @@ pub(crate) struct SigParam {
 }
 
 /// Complete signature info stored at runtime.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
 pub(crate) struct SigInfo {
     pub(crate) params: Vec<SigParam>,
     pub(crate) return_type: Option<String>,

--- a/src/vm/vm_dispatch_helpers.rs
+++ b/src/vm/vm_dispatch_helpers.rs
@@ -995,6 +995,23 @@ impl Interpreter {
             }
         }
 
+        // Invoking an enum *value* is the same coercion as invoking its enum
+        // type: rakudo answers `Lv::TRACE` for `Lv(1)` and for `Lv::DEBUG(1)`
+        // alike, and `Nil` when the enum has no such value. The type-object
+        // rule above already routes `Lv(1)` to the bare-name call path; a value
+        // reached through a variable landed on the `CALL-ME` fallback instead
+        // and died -- `Log::Async` hands its `$level` (an enum value whenever
+        // no CLI flag replaces it with a `* >= LEVEL` matcher) to a consumer
+        // that calls it.
+        if let ValueView::Enum { enum_type, .. } = target.view()
+            && !args.is_empty()
+        {
+            let name = enum_type.resolve();
+            if !self.class_has_method(&name, "CALL-ME") {
+                return self.call_function(&name, args);
+            }
+        }
+
         // Instance or Package (type object): CALL-ME -- try compiled method path first
         if matches!(
             target.view(),

--- a/t/enum-value-call-coercion.t
+++ b/t/enum-value-call-coercion.t
@@ -1,0 +1,27 @@
+use Test;
+
+# Calling an enum VALUE is the same coercion as calling the enum type object:
+# rakudo answers `Lv::TRACE` for `Lv(1)` and for `Lv::DEBUG(1)` alike, and `Nil`
+# when the enum holds no such value.
+#
+# mutsu implemented only the type-object half, so an enum value reached through
+# a variable fell through to the `CALL-ME` fallback and died with
+# "No such method 'CALL-ME'". `Log::Async` hits this: its `$level` is an enum
+# value whenever no CLI flag replaces it with a `* >= LEVEL` matcher, and it
+# hands that to a consumer that calls it.
+plan 6;
+
+enum Lv <<:TRACE(1) DEBUG INFO>>;
+
+my $v = DEBUG;
+is $v(TRACE), TRACE, 'an enum value called with another value of its enum coerces';
+is $v(2), DEBUG, '...and with the underlying numeric value';
+nok $v(99).defined, '...answering an undefined value when the enum has no such value';
+
+# The type-object form is unchanged, and the two now agree.
+is Lv(1), TRACE, 'the type object still coerces';
+is $v(1), Lv(1), 'value-call and type-call agree';
+
+# The invocant is only the coercer: it does not colour the result.
+my $other = INFO;
+is $other(1), TRACE, 'which value is the invocant makes no difference';

--- a/t/lib/SignatureLiteralProbe.rakumod
+++ b/t/lib/SignatureLiteralProbe.rakumod
@@ -1,0 +1,11 @@
+unit module SignatureLiteralProbe;
+
+# The module's own body holds both sides of the comparison, so BOTH the
+# candidate signatures and the `Signature` literal come from the cached AST on
+# a warm run.
+multi sub probe-multi(Routine $r, :$native!) is export { 'native' }
+multi sub probe-multi(Routine $r, :$symbol!) is export { 'symbol' }
+
+our sub signature-probe is export {
+    &probe-multi.candidates.map({ (.signature ~~ :(Routine, :$native!)).Str }).join(',')
+}

--- a/t/lib/UnitModuleExportSub.rakumod
+++ b/t/lib/UnitModuleExportSub.rakumod
@@ -1,0 +1,9 @@
+# `sub EXPORT` declared ABOVE the `unit module` line: it belongs to the
+# compilation unit's outer scope, so `use` finds and runs it, and the Map it
+# returns is the whole of what the importer gets.
+sub EXPORT(|) {
+    Map.new('MyAlias' => Int, '&exported-by-export' => sub { 'from EXPORT' })
+}
+unit module UnitModuleExportSub;
+
+our sub not-exported { 'should not be visible' }

--- a/t/lib/UnitModuleExportSubBelow.rakumod
+++ b/t/lib/UnitModuleExportSubBelow.rakumod
@@ -1,0 +1,8 @@
+# `sub EXPORT` declared BELOW the `unit module` line is inside the module's
+# package, not the compunit's outer scope, so Raku never calls it as the
+# module's custom export hook.
+unit module UnitModuleExportSubBelow;
+
+sub EXPORT(|) { Map.new('BelowAlias' => Int) }
+
+our sub plain-export is export { 'ordinary export' }

--- a/t/multi-candidate-dispatcher.t
+++ b/t/multi-candidate-dispatcher.t
@@ -1,0 +1,39 @@
+use Test;
+
+# `.dispatcher` on a multi candidate is the proto that dispatches it -- Raku
+# generates one even when the source declares no `proto`, and `.candidates` on
+# it lists the whole multi.
+#
+# mutsu answered the *candidate itself* (and, for a `Sub`-shaped value, an
+# ADR-0070 `<composed-method:dispatcher>` stub), so `.dispatcher.candidates`
+# reported a single candidate. That silently narrows the
+# `Map.new('&name' => $candidate.dispatcher)` idiom a custom `sub EXPORT` uses
+# to re-export a multi -- `NativeLibs` re-exports `&trait_mod:<is>` that way.
+#
+# Ground truth from rakudo 2026.07: a candidate's `.dispatcher` is a `Sub` with
+# `.is_dispatcher` True and every candidate; a routine in no multi has no
+# dispatcher at all (rakudo answers an NQPMu, which is falsy).
+plan 8;
+
+sub plain($x) { $x }
+multi sub no-proto(Int $x) { 'int' }
+multi sub no-proto(Str $s) { 'str' }
+proto sub with-proto(|) {*}
+multi sub with-proto(Int $x) { 'int' }
+multi sub with-proto(Str $s) { 'str' }
+
+nok &plain.dispatcher, 'a routine in no multi has no dispatcher';
+
+for '&no-proto', '&with-proto' -> $name {
+    my $cand = ::($name).candidates[0];
+    my $disp = $cand.dispatcher;
+    ok $disp, "$name candidate has a dispatcher";
+    is $disp.candidates.elems, 2, "$name dispatcher lists every candidate";
+    ok $disp.is_dispatcher, "$name dispatcher answers .is_dispatcher";
+}
+
+# The shape the `sub EXPORT` idiom depends on: pick a candidate by matching its
+# signature, then re-export the dispatcher, and the multi is still whole.
+my $native-ish = &no-proto.candidates.first({ .signature ~~ :(Str) });
+is $native-ish.dispatcher.candidates.elems, 2,
+    'a dispatcher reached through .candidates.first still carries the whole multi';

--- a/t/nativecall-trait-mod-is-candidates.t
+++ b/t/nativecall-trait-mod-is-candidates.t
@@ -1,0 +1,27 @@
+use Test;
+
+# Rakudo's `NativeCall.rakumod` declares `trait_mod:<is>` candidates for its own
+# traits and exports them, so `&trait_mod:<is>.candidates` is introspectable
+# after `use NativeCall`. The `NativeLibs` distribution depends on exactly that:
+# its custom `sub EXPORT` picks the `:$native!` candidate out of the list and
+# re-exports `.dispatcher`, so its own importers get `is native` too.
+#
+# mutsu applies these four traits natively at declaration time, and used to
+# register only a content-free shell under the exported name -- `.candidates`
+# answered one entry with no signature, `.first` gave Nil, and the module died
+# on `Any.dispatcher`.
+plan 4;
+
+use NativeCall;
+
+my $native = &trait_mod:<is>.candidates.first: { .signature ~~ :(Routine, :$native!) };
+ok $native.defined, 'NativeCall exports a `trait_mod:<is>` candidate for `is native`';
+is $native.signature.gist, '(Routine $r, :$native!)', '...with the signature rakudo declares';
+
+ok &trait_mod:<is>.candidates.first({ .signature ~~ :(Routine, :$symbol!) }).defined,
+    '...and one for `is symbol`';
+
+# The whole `NativeLibs` idiom in one line: the re-exported dispatcher must
+# still carry every candidate, not just the one that was matched.
+ok $native.dispatcher.candidates.elems >= 2,
+    'the candidate\'s dispatcher carries the whole multi';

--- a/t/signature-literal-precomp-warm-cache.t
+++ b/t/signature-literal-precomp-warm-cache.t
@@ -1,0 +1,56 @@
+use Test;
+
+# A `Signature` literal (`:(Routine, :$native!)`) is an `Expr::Literal` holding a
+# `Signature` instance, but its structured parameter data lives in a
+# process-global side table keyed by that instance's id -- which nothing in a
+# serialized value can reach. A module restored from the precompilation cache
+# therefore came back with a literal whose id named nothing, `extract_sig_info`
+# fell through to its empty-params legacy shape, and `Signature ~~ Signature`
+# went from True on a cold run to False on a warm one.
+#
+# Only the SECOND run of a program sees it, which is exactly what CI's always-cold
+# runners cannot catch -- so pin it here, the way `t/precomp-warm-cache-parity.t`
+# does for the other replay effects.
+plan 3;
+
+my $lib = $?FILE.IO.parent.add('lib').Str;
+my $cache = $*TMPDIR.add("mutsu-sig-precomp-{$*PID}");
+my $script = $cache.add('probe.raku');
+
+$cache.mkdir;
+$script.spurt: qq:to/PROBE/;
+    use lib '$lib';
+    use SignatureLiteralProbe;
+    say signature-probe();
+    PROBE
+
+# Our own cache directory, so the first run really is cold whatever the
+# developer's ~/.cache holds.
+%*ENV<XDG_CACHE_HOME> = $cache.Str;
+
+sub run-probe() {
+    my $proc = run($*EXECUTABLE, $script.Str, :out, :err);
+    $proc.err.slurp;
+    $proc.out.slurp.chomp;
+}
+
+my $cold = run-probe();
+my $warm = run-probe();
+
+is $cold, 'True,False',
+    'cold run: the signature literal matches exactly the one candidate it names';
+is $warm, $cold,
+    'warm run from the precompilation cache gives the identical answer';
+is $warm, 'True,False',
+    'the restored signature literal still carries its parameters';
+
+END {
+    try $cache.&rmtree if $cache.e;
+}
+
+sub rmtree(IO::Path $d) {
+    for $d.dir -> $e {
+        $e.d ?? rmtree($e) !! $e.unlink;
+    }
+    $d.rmdir;
+}

--- a/t/unit-module-export-sub.t
+++ b/t/unit-module-export-sub.t
@@ -1,0 +1,29 @@
+use Test;
+
+# A module's custom `sub EXPORT` hook is positional: Raku packages "the rest of
+# the scope" from the `unit module` line onward, so a routine declared ABOVE it
+# stays in the compunit's outer scope. That is the only place `sub EXPORT` can
+# live, because `use` looks it up there.
+#
+# mutsu switched the runtime package for the WHOLE compilation unit before the
+# sub-hoist pass, so the hook registered as `Foo::EXPORT` and the `GLOBAL::EXPORT`
+# lookup missed it -- the custom export of every `unit module` was silently never
+# called. Measured against rakudo (2026-09-09), which runs the above-the-line
+# form and leaves the below-the-line one alone.
+plan 5;
+
+use lib $?FILE.IO.parent.add('lib').Str;
+use UnitModuleExportSub;
+use UnitModuleExportSubBelow;
+
+is MyAlias.^name, 'Int',
+    'a custom EXPORT above the `unit module` line installs its type object';
+is exported-by-export(), 'from EXPORT',
+    '...and its routines';
+ok ::('&not-exported') ~~ Failure,
+    'a custom EXPORT replaces the default import: `our sub` is not pulled in';
+
+is plain-export(), 'ordinary export',
+    'a `sub EXPORT` BELOW the `unit module` line is not the hook: normal exports still happen';
+ok ::('BelowAlias') ~~ Failure,
+    '...and the Map it would have returned is not installed';


### PR DESCRIPTION
`NativeLibs t/01-basic.t` is the last open item of #7555, the four
bundled-library regressions blocking the vendored-`Test`-by-default flip. Under
the vendored module its test 6 reported `MISSING`; under the native provider it
passed only because a file-scope `use` leak happened to supply the answer rakudo
gets from the module's custom export. It now passes **23/23 under both
providers, cold and warm**, through the mechanism rakudo uses.

Five independent interpreter bugs sat in the way. None of them is about `Test` —
the switch only changes which code shapes get reached.

## 1. A `sub EXPORT` above the `unit module` line was never called

`unit module Foo;` packages *the rest of the scope*, so what precedes it stays in
the compilation unit's outer scope — which is the whole mechanism behind a custom
export hook, since `use` looks it up there. Every module that has one writes it
above the line, as `NativeLibs` does:

```raku
use NativeCall;
sub EXPORT(|) {
    my $exp = &trait_mod:<is>.candidates.first: { .signature ~~ :(Routine, :$native!) };
    Map.new('NativeCall' => NativeCall, '&trait_mod:<is>' => $exp.dispatcher)
}
unit module NativeLibs:auth<salortiz>:ver<0.0.9>;
```

`compile_unit` emitted the runtime package switch for the *whole* compilation
unit before the sub-hoist pass, so the hook registered as `Foo::EXPORT` and
`apply_module_export`'s `GLOBAL::EXPORT` lookup missed it. The custom export of
every `unit module` was silently a no-op. The hoist is now split at the
declaration, and the runtime package handed back for the preceding statements'
own execution, so the declaration re-establishes it when execution reaches it.
Measured against rakudo: above the line runs, below it does not.

## 2. `.dispatcher` answered the candidate, not the proto

Raku generates a dispatcher even for a `multi` written with no `proto`, and
`.dispatcher` on a candidate returns it. mutsu answered the candidate itself —
and, for a `Sub`-shaped value, an ADR-0070 `<composed-method:dispatcher>` stub,
because nothing handled the method at all on that shape. Either way
`.dispatcher.candidates` reported a single entry, which silently narrows a whole
multi to the one candidate that was introspected. That is exactly what the
`Map.new('&name' => $candidate.dispatcher)` re-export idiom does. `Routine`
handles now also answer `.is_dispatcher`/`.multi`, which the fixed `.dispatcher`
makes reachable.

## 3. NativeCall exported a content-free `trait_mod:<is>`

Rakudo's `NativeCall.rakumod` declares its four trait candidates (`:$native!`,
`:$symbol!`, `:$nativeconv!`, `:$encoded!`) as ordinary multis and exports them,
which is what makes `&trait_mod:<is>.candidates` introspectable. mutsu registered
only a bare exported *name*, so `.candidates` answered one entry with no
signature, `.first` gave `Nil`, and the module died on `Any.dispatcher`.

The four are now spliced in as a prelude, gated on the compunit both using
NativeCall and naming `trait_mod:<is>` itself. Both halves of the gate matter:
their mere presence flips `has_proto`/`has_multi_candidates`, which would route
every other unknown `is` trait in the file through custom dispatch. Their bodies
are empty on purpose and this is not a stub standing in for an unimplemented
feature — mutsu applies all four natively at declaration time
(`register_native_call_sub`), and `registration_sub.rs` already excludes
`native`/`symbol`/`nativeconv`/`encoded` from the custom-`trait_mod:<is>` loop
for that reason, so these candidates are never what applies the trait. They exist
to make the export surface introspectable, exactly as rakudo's do. A `TODO` marks
the one remaining gap (calling one explicitly should apply the trait, which needs
the C-FFI descriptor to be installable on an already-registered `Routine`).

Two lifetime bugs surfaced with them:

- A prelude splice declared as a `multi` registers under arity-suffixed keys
  (`GLOBAL::name/2`, and the chained `__mN` slots), never under the bare
  `GLOBAL::name` the single-sub path records — so the prelude bookkeeping missed
  it and `reinstate_module_functions` dropped the candidates as importer-scoped
  `GLOBAL::` aliases the first time a block scope unwound. Recording the bare
  name instead would have gated NativeCall's own `GLOBAL::trait_mod:<is>` entry
  behind this splice's compunit and hidden it everywhere else, so the real keys
  are recorded after registration.
- Raku re-runs `sub EXPORT` on *every* later import of an already-loaded module,
  by which time the importer's scope holds none of the module's own lexicals —
  `Map.new('NativeCall' => NativeCall, …)` quietly degraded to the bareword
  string `"NativeCall"`, which then shadowed the real package. The remembered
  hook now carries the module-scope env it was first called in, and both call
  paths anchor to the module's own compunit.

## 4. A `Signature` literal lost its parameters across the precompilation cache

Independent of `EXPORT`, and reproducible in plain Raku:

```raku
# lib/SigRT.rakumod
unit module SigRT;
multi sub mm(Routine $r, :$native!) is export { 'native' }
multi sub mm(Routine $r, :$symbol!) is export { 'symbol' }
our sub probe is export {
    &mm.candidates.map({ (.signature ~~ :(Routine, :$native!)).Str }).join(",")
}
```

```
cold: True,False      # rakudo: True,False
warm: False,False
```

A `Signature` literal is an `Expr::Literal` holding a `Signature` instance, but
its structured parameter data lives in a process-global side table keyed by that
instance's id — which nothing in a serialized value can reach. A module restored
from the cache came back with a literal whose id named nothing,
`extract_sig_info` fell through to its empty-params legacy shape, and the
smartmatch flipped from True to False. Only the **second** run of a program sees
it, which is precisely what CI's always-cold runners cannot catch.

`SerValue::Instance` now carries the `SigInfo` alongside a `Signature`, and the
value is rebuilt whole from it on load — under a *fresh* id, so it cannot collide
with an unrelated instance holding the recorded id in this process.
`CACHE_FORMAT_VERSION` moves to 12.

## 5. Calling an enum value is a coercion, like calling its enum type

Surfaced by the bundled-library gate: `Log::Async 16-imports2.rakutest` had been
passing **for the wrong reason**. Its `sub EXPORT` reads `@*ARGS`, and the re-run
used to see the *importer's* copy, so mutsu matched the module's `--log=` branch
against the test's `--level=trace` (with a `Use of Nil in string context`
warning) and left `$level` a `WhateverCode`. Running the hook in the module's own
scope — item 3 above, and what rakudo does — makes `$level` the plain enum value
rakudo also produces there, and the test then calls it.

Rakudo answers that call. `Lv::DEBUG(1)` is the same coercion as `Lv(1)`, both
giving `Lv::TRACE`, and an undefined value when the enum holds no such value.
mutsu implemented only the type-object half: `vm_call_on_value` already routes an
invoked `Package` to the bare-name call path — "invoking a type object is a
coercion, not a `CALL-ME` call" — but an enum *value* is a `ValueView::Enum`,
matched neither that arm nor the `Instance | Package` one, and fell through to
the `CALL-ME` fallback, dying with "No such method 'CALL-ME'".

One divergence is deliberately left alone because it predates this and lives in
the shared coercion helper rather than the new arm: `Lv('DEBUG')` answers
`Lv::DEBUG` in mutsu where rakudo answers `Nil`. The value form now agrees with
the type form, which is the property this needs.

## Verification

- `NativeLibs`' upstream suite (`batteries.lock` commit `f3e78510`) under the
  release binary: `01-basic.t` **23/23** in all four combinations of
  provider × cold/warm cache. `02-cannon-name.t` and `20-compile.t` green;
  `10-search.t`'s single failure is the host-dependent `mysqlclient` one
  `scripts/battery-testsuite.sh` already documents, unchanged from `main`.
- `scripts/battery-testsuite.sh`: `Log::Async 16-imports2.rakutest` PASS. The
  only rows still regressed locally are the six `DBIish` mysql ones, which need
  a live MySQL server this container has no service for — they pass in CI's own
  run of the same gate.
- Five new pins, each of which **fails on `main`** and **passes under real `raku`
  unchanged**: `t/unit-module-export-sub.t`, `t/multi-candidate-dispatcher.t`,
  `t/nativecall-trait-mod-is-candidates.t`,
  `t/signature-literal-precomp-warm-cache.t` (built on
  `t/precomp-warm-cache-parity.t`'s cold/warm subprocess pattern, since a
  same-process test cannot see the bug) and `t/enum-value-call-coercion.t`.
- `make test` **PASS** (3906 files, 41480 tests). `make lint` clean in all four
  configurations. `make roast` byte-identical to the pre-change run: green apart
  from the three container-only files `docs/agent-environments.md` documents
  (`6.c/S32-io/file-tests.t`, `S16-filehandles/filetest.t`,
  `S32-io/IO-Socket-Async.t`), each matching its recorded failure shape exactly.

Rebased onto `main` after #7717/#7715 landed; the conflict in
`registration_sub.rs` is resolved by composing both sides — `main`'s new
`prelude_sub_names` insert is kept (and left outside the new `!multi` guard,
since it records the ambient *name*, which a multi prelude needs too).

Refs #7555 — item 1 of the four. Items 2 and 4 landed in #7653 and #7663; item 3
is tracked separately as #7667 (`todo:perf`), so this is the last of the four
that is fixable here. The issue itself is left open until that one lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019oTR3uw7PrAokSmncMtPsM