### PR TITLE
fix(builtins): declare subst and trans accepted nameds

### DIFF
--- a/docs/adr/0070-native-methods-declare-the-named-arguments-they-accept.md
+++ b/docs/adr/0070-native-methods-declare-the-named-arguments-they-accept.md
@@ -1,6 +1,6 @@
 # ADR-0070: A builtin method declares the named arguments it accepts, and the arity cascade drops the rest
 
-- Status: **Proposed** (slice 1 implemented 2026-09-07)
+- Status: **Proposed** (slices 1–3 implemented 2026-09-09)
 - Date: 2026-09-07
 - Related: [ADR-0021](0021-argument-namedness-is-a-call-site-property.md)
   (argument named-ness is a call-site property),
@@ -252,5 +252,33 @@ ran.
   (`(+*%_)` vs `(+*%options)`), which makes the *declared*-slurpy readers
   visible, but a `--` row still has to be confirmed behaviourally.
 
-- **Slice 3 (open).** `subst` / `trans`, `new`, and the plain-call divergences
-  the sweep surfaces. Recorded in the narrowed `todo/deep/` file.
+- **Slice 3 (implemented 2026-09-09).** The manually established accepted-name
+  sets for `subst` and `trans` are now declared in `accepted_nameds.rs`, with
+  focused pins in `t/native-method-accepted-nameds.t`. The survey's
+  `subst -- (+*%options)` and `trans -- (+*%_)` output is only a lower bound:
+  `subst` reads the match controls and replacement transforms listed in the
+  table, while `trans` reads `:s`/`:squash`, `:d`/`:delete`, and
+  `:c`/`:complement`. The table preserves the additional match-control names
+  (`:i`, `:m`, `:ov`, `:ex`) even where mutsu does not yet consume them, so
+  future support is not stripped at the dispatch boundary. No `:qqzz9` probe
+  changed before this slice; this is hardening. See
+  `news/2026-09/native-method-accepted-nameds-slice-3.md`.
+
+## Slice 3 (2026-09-09): slurpy named readers
+
+The signature survey cannot distinguish a method that merely carries the
+implicit `*%_` from one that reads adverbs out of a slurpy. Its measurements
+were:
+
+```
+subst          -- (+*%options)
+trans          -- (+*%_)
+```
+
+The manual set for `subst` covers the `Str.subst` documentation's global,
+match-count, position, continuation, case/mark/space transforms, and the
+match-style short and long controls. The set for `trans` is the three options
+and their aliases that `dispatch_trans` reads. The focused test keeps real
+adverbs working and verifies that an unknown named remains invisible. The
+constructor `new` and the unrelated plain-call divergences listed in the
+campaign issue remain open for later slices.

--- a/news/2026-09/native-method-accepted-nameds-slice-3.md
+++ b/news/2026-09/native-method-accepted-nameds-slice-3.md
@@ -1,0 +1,21 @@
+# `subst` and `trans` declare the named arguments they read
+
+ADR-0070's signature survey reports only a lower bound for methods whose
+adverbs arrive through a slurpy. The current Rakudo measurement is:
+
+```
+subst          -- (+*%options)
+trans          -- (+*%_)
+```
+
+This slice records the manually established sets in
+`src/builtins/accepted_nameds.rs`. `subst` keeps its global, match-count,
+position, continuation, transform, and match-style controls, including their
+short and long spellings. `trans` keeps `:s`/`:squash`, `:d`/`:delete`, and
+`:c`/`:complement`. The extra match-control names are preserved at the
+dispatch boundary even where mutsu does not yet consume them.
+
+The focused regression test covers working `subst` and `trans` adverbs and an
+unknown named. This is hardening: neither method changed its `:qqzz9` sweep
+answer before the row was added. The campaign's constructor and unrelated
+plain-call residue remain open.

--- a/src/builtins/accepted_nameds.rs
+++ b/src/builtins/accepted_nameds.rs
@@ -75,6 +75,51 @@ pub(crate) fn native_method_accepted_nameds(method: &str) -> Option<&'static [&'
         "map" => &[
             "batch", "deep", "degree", "duck", "flat", "item", "label", "node",
         ],
+        // Slice 3: these two methods read selected adverbs from a slurpy, so
+        // the signature survey reports only a lower bound. The set for
+        // `subst` is established from Str's documentation, its match-style
+        // controls, and the aliases handled by dispatch_subst. Keep the
+        // match controls that Rakudo forwards through the slurpy (`i`/`m`/`s`
+        // and `ov`/`ex`) even where mutsu does not yet use them, so a future
+        // implementation can see the call-site adverb. `trans` has the six
+        // short/long spellings read by dispatch_trans.
+        "subst" => &[
+            "1st",
+            "2nd",
+            "3rd",
+            "4th",
+            "c",
+            "continue",
+            "ex",
+            "exhaustive",
+            "first",
+            "fourth",
+            "g",
+            "global",
+            "i",
+            "ii",
+            "m",
+            "mm",
+            "nd",
+            "nth",
+            "ov",
+            "overlap",
+            "p",
+            "pos",
+            "rd",
+            "s",
+            "samecase",
+            "samemark",
+            "samespace",
+            "second",
+            "sigspace",
+            "ss",
+            "st",
+            "th",
+            "third",
+            "x",
+        ],
+        "trans" => &["c", "complement", "d", "delete", "s", "squash"],
         _ => return None,
     })
 }
@@ -148,5 +193,24 @@ mod tests {
     fn nothing_to_strip_allocates_nothing() {
         let args = vec![Value::int(1), Value::int(2)];
         assert!(strip_undeclared_nameds("chop", &args).is_none());
+    }
+
+    #[test]
+    fn slurpy_reader_rows_keep_their_established_adverbs() {
+        let subst_args = vec![
+            Value::pair("global".to_string(), Value::TRUE),
+            Value::pair("samecase".to_string(), Value::TRUE),
+            Value::pair("qqzz9".to_string(), Value::TRUE),
+        ];
+        let kept = strip_undeclared_nameds("subst", &subst_args).expect("qqzz9 must go");
+        assert_eq!(kept.len(), 2);
+
+        let trans_args = vec![
+            Value::pair("squash".to_string(), Value::TRUE),
+            Value::pair("complement".to_string(), Value::TRUE),
+            Value::pair("qqzz9".to_string(), Value::TRUE),
+        ];
+        let kept = strip_undeclared_nameds("trans", &trans_args).expect("qqzz9 must go");
+        assert_eq!(kept.len(), 2);
     }
 }

--- a/t/native-method-accepted-nameds.t
+++ b/t/native-method-accepted-nameds.t
@@ -138,6 +138,21 @@ is 4.log(:base(2)), 4.log, 'log(:base) still falls back to the 0-ary log';
 is "abc".uc(:foo), "ABC", 'uc(:foo) still swallows the named';
 is (1,2,3).map({ $_ * 2 }).join("-", :foo), "2-4-6", 'a Seq body is consumed exactly once';
 
+# --- slurpy readers: subst / trans -----------------------------------------
+#
+# The signature survey can only report a lower bound for these methods. Their
+# accepted sets are recorded manually in accepted_nameds.rs from the Raku docs
+# and the adverbs read by the native implementations.
+
+is "aaa".subst(/a/, "x", :g), "xxx", 'subst keeps :g';
+is "aaa".subst(/a/, "x", :nth(2)), "axa", 'subst keeps :nth';
+is "a".subst(/a/, "X", :samecase), "x", 'subst keeps :samecase';
+is "aabb".trans("a" => "x", :squash), "xbb", 'trans keeps :squash';
+is "abc".trans("a" => "x", :delete), "xbc", 'trans keeps :delete';
+is "abc".trans("a" => "x", :complement), "axx", 'trans keeps :complement';
+is "abc".trans("a" => "x", :c), "axx", 'trans keeps :c';
+is "abc".trans("a" => "x", :qqzz9), "xbc", 'trans ignores an undeclared named';
+
 # ===========================================================================
 # Slice 2: the residue of the same survey.
 # ===========================================================================


### PR DESCRIPTION
## Summary

- Declare the manually established accepted named-argument sets for native `subst` and `trans`.
- Preserve their documented adverbs and dispatch aliases while filtering unknown names through the common path.
- Add focused Rust and TAP regressions, document ADR-0070 Slice 3, and add a news entry.

## Validation

- `cargo fmt --all`
- `make lint`
- `make test`
- `make roast`
- `cargo test accepted_nameds -- --nocapture`
- `raku t/native-method-accepted-nameds.t`

Closes #7544
