### PR TITLE
perf(types): take type-name string scans off the instance-dispatch hot path

### DIFF
--- a/news/2026-09/type-name-scans-off-the-dispatch-hot-path.md
+++ b/news/2026-09/type-name-scans-off-the-dispatch-hot-path.md
@@ -1,0 +1,89 @@
+# Type-name string scans taken off the instance-dispatch hot path
+
+[#7696](https://github.com/tokuhirom/mutsu/issues/7696) measured a flat ~7us
+constant on every `Buf` method call, sitting in front of the buffer code rather
+than in it. Profiling the dispatch path found the constant, but not where the
+ticket expected it.
+
+## What the profile actually said
+
+`callgrind` on `my $big = Buf.new(1 xx 1000); for ^2000 { $big.push(1) }`
+(143.9M instructions) with caller attribution:
+
+- **52% of the whole program** was `try_native_method_raw` →
+  `type_matches_value`. `vm_native_dispatch` probes every instance receiver
+  with `type_matches_value("Real", …) || type_matches_value("Numeric", …)`
+  before it will decline a method, and each probe walks the receiver class's
+  MRO and its composed-role closure. Two walks per `push`, ~40 `type_matches`
+  calls between them.
+- **~13% was substring searching**, and it belonged to `type_matches`, not to
+  the `Buf` predicates. `type_matches` asked `str::contains("::")` three times
+  and `contains('[')` once per call; `str::contains(&str)` builds a two-way
+  searcher per call, and on names this short that setup *is* the cost. At
+  313,719 searches for 80,000 `type_matches` calls it was the single largest
+  line item.
+- **~15% was malloc/free**, 132,580 allocations for 2000 pushes — 63 per push.
+  Almost all of it was `Symbol::resolve()` handing out a fresh `String` where
+  `as_str()` would have handed out the interned `&'static str`, plus the
+  `Vec<String>` work stacks and `HashSet<String>` seen-sets of the role walks.
+
+The ticket's suggested first step — making `is_buf_like_class` /
+`is_blob_like_class` / `is_buf_or_blob_class` answer from the interned symbol
+instead of scanning the name — turned out to target the wrong thing: those three
+predicates together are **0.15%** of the loop. The `is_contained_in` cost the
+ticket attributed to them is `type_matches`'s.
+
+## What changed
+
+All of it is local, and none of it caches a type relation:
+
+- `type_matches` hoists its three `"::"` searches into two byte scans
+  (`runtime::utils::has_double_colon`, which already existed from
+  [#7554](https://github.com/tokuhirom/mutsu/issues/7554)) and its `[` search
+  into `has_bracket` / `split_once_bracket`, new single-byte twins in the same
+  module.
+- `parse_parametric_type_name`, `parse_generic_constraint`,
+  `parse_coercion_type` and `is_known_type_constraint` now let their O(1)
+  `ends_with(']')` / `ends_with(')')` reject an unparameterized name *before*
+  scanning for the opening bracket, rather than after.
+- The `ValueView::Instance` arm of `type_matches_value` resolves its class name
+  once, as `as_str()` rather than `resolve()`, for all four of its uses; it had
+  been allocating a `String` per use. It also reuses the `Arc<[Symbol]>` MRO it
+  already fetched instead of re-entering the registry for a second
+  String-keyed lookup.
+- `Registry::composed_roles_seed` returns `Vec<Symbol>` instead of
+  `Vec<String>`, so the three role walks that consume it keep a `Copy` work
+  stack and a `HashSet<Symbol>` seen-set — no allocation per role pushed and
+  none per `seen` insert.
+
+## Result
+
+Instruction count on the profiled push loop: **143.9M → 114.7M (−20.3%)**,
+deterministic. Wall clock in this container, best of five (a slower box than
+the ticket's, so the absolute numbers are higher):
+
+| | before | after |
+| --- | --- | --- |
+| `Buf.new` + 100 pushes | 1.011 ms | 0.861 ms |
+| 10 pushes onto a 1000-byte buf | 0.1182 ms | 0.1014 ms |
+| 10 pushes onto a 4000-byte buf | 0.1183 ms | 0.1019 ms |
+
+`type_matches` is on every signature bind, so the win is not `Buf`-specific,
+but it is small elsewhere: the standard benchmarks move by less than the noise
+floor except `bench-ctor` (−1.7%). The figures above are local A/B runs on one
+binary pair, quoted for this change only — the numbers of record stay the bench
+CI's `bench-history.tsv`.
+
+## What is left
+
+The 52% item is untouched, and it is the larger half. Declining a native method
+for an instance receiver should not need two full type-graph walks when the
+receiver's class is already known; the answer is a property of the class, not
+of the call. Caching it needs an invalidation signal that covers `classes`,
+`roles`, `role_parents`, `class_composed_roles` and `subsets` — `method_generation`
+covers none of those — and a hand-enumerated list of ~30 mutation sites is
+exactly the "correct only under an incomplete static analysis" shape CLAUDE.md
+rules out, since a missed site is a silent wrong type answer rather than a
+detectable failure. It is filed with the measurement as
+[#7712](https://github.com/tokuhirom/mutsu/issues/7712), rather than guessed at
+here.

--- a/src/runtime/methods_signature_shaped.rs
+++ b/src/runtime/methods_signature_shaped.rs
@@ -183,10 +183,12 @@ impl Interpreter {
     /// parametric-role attribute (`role Box[::T] { has Box[T] $.child }`) was
     /// type-checked against the doubled name.
     pub(super) fn parse_parametric_type_name(name: &str) -> Option<(String, Vec<String>)> {
-        let base_end = name.find('[')?;
+        // `ends_with` is O(1) and rejects every unparameterized name, so it
+        // runs before the `[` scan rather than after it (#7696).
         if !name.ends_with(']') {
             return None;
         }
+        let base_end = name.as_bytes().iter().position(|&b| b == b'[')?;
         let mut depth = 0usize;
         for (offset, ch) in name[base_end..].char_indices() {
             match ch {

--- a/src/runtime/registry.rs
+++ b/src/runtime/registry.rs
@@ -1364,13 +1364,22 @@ impl Registry {
         parents
     }
 
-    pub(crate) fn composed_roles_seed(&self, mro: &[Symbol]) -> Vec<String> {
+    /// The base names of every role composed anywhere along `mro`, as interned
+    /// symbols.
+    ///
+    /// Returns `Symbol`s rather than `String`s so the role walks that consume
+    /// this can keep a `Copy` work stack and a `HashSet<Symbol>` of seen names:
+    /// the `String` seed plus a clone per `seen` insert was an allocation pair
+    /// per role per type check, on a path every instance method call runs
+    /// (#7696). Interning is a hash lookup and allocates only the first time a
+    /// given role name is seen in the process.
+    pub(crate) fn composed_roles_seed(&self, mro: &[Symbol]) -> Vec<Symbol> {
         let mut seed = Vec::new();
         for cn in mro {
             if let Some(composed) = self.class_composed_roles.get(cn.as_str()) {
                 for cr in composed {
                     let base = cr.split_once('[').map(|(b, _)| b).unwrap_or(cr.as_str());
-                    seed.push(base.to_string());
+                    seed.push(Symbol::intern(base));
                 }
             }
         }

--- a/src/runtime/types/coercion.rs
+++ b/src/runtime/types/coercion.rs
@@ -10,8 +10,10 @@ fn is_failure_value(value: &Value) -> bool {
 /// Parse a coercion type like "Int()" or "Int(Rat)".
 /// Returns Some((target_type, optional_source_type)) if it's a coercion type.
 pub(crate) fn parse_coercion_type(constraint: &str) -> Option<(&str, Option<&str>)> {
-    if let Some(open) = constraint.find('(')
-        && constraint.ends_with(')')
+    // `ends_with` is O(1) and rejects every non-coercion name, so it gates the
+    // `(` scan rather than following it (#7696).
+    if constraint.ends_with(')')
+        && let Some(open) = constraint.as_bytes().iter().position(|&b| b == b'(')
     {
         let target = &constraint[..open];
         let source = &constraint[open + 1..constraint.len() - 1];

--- a/src/runtime/types/mod.rs
+++ b/src/runtime/types/mod.rs
@@ -1011,8 +1011,13 @@ impl Interpreter {
     }
 
     pub(in crate::runtime) fn parse_generic_constraint(constraint: &str) -> Option<(&str, &str)> {
-        let open = constraint.find('[')?;
-        if open == 0 || !constraint.ends_with(']') {
+        // `ends_with` is O(1) and rejects every unparameterized name, so it
+        // runs before the `[` scan rather than after it (#7696).
+        if !constraint.ends_with(']') {
+            return None;
+        }
+        let open = constraint.as_bytes().iter().position(|&b| b == b'[')?;
+        if open == 0 {
             return None;
         }
         let base = &constraint[..open];

--- a/src/runtime/types/type_matching.rs
+++ b/src/runtime/types/type_matching.rs
@@ -1340,18 +1340,18 @@ impl Interpreter {
             // a user-declared role, so the registry walk below — gated on
             // `resolved_constraint` — never reaches them.
             {
-                let mut stack: Vec<String> = mro.iter().map(|s| s.resolve()).collect();
+                let mut stack: Vec<Symbol> = mro.to_vec();
                 stack.extend(self.registry().composed_roles_seed(&mro));
                 let mut seen = HashSet::new();
                 while let Some(role_name) = stack.pop() {
-                    if !seen.insert(role_name.clone()) {
+                    if !seen.insert(role_name) {
                         continue;
                     }
-                    for rp in Registry::builtin_role_parents(&role_name) {
+                    for rp in Registry::builtin_role_parents(role_name.as_str()) {
                         if Self::type_matches(effective_constraint, rp) {
                             return true;
                         }
-                        stack.push((*rp).to_string());
+                        stack.push(Symbol::intern(rp));
                     }
                 }
             }
@@ -1370,28 +1370,29 @@ impl Interpreter {
                 if let Some(composed) = self
                     .registry()
                     .class_composed_roles
-                    .get(&package_name.resolve())
+                    .get(package_name.as_str())
                 {
                     role_stack.extend(composed.iter().map(|role| {
-                        role.split_once('[')
-                            .map(|(base, _)| base)
-                            .unwrap_or(role.as_str())
-                            .to_string()
+                        Symbol::intern(
+                            role.split_once('[')
+                                .map(|(base, _)| base)
+                                .unwrap_or(role.as_str()),
+                        )
                     }));
                 }
                 let mut seen_roles = HashSet::new();
                 while let Some(role_name) = role_stack.pop() {
-                    if !seen_roles.insert(role_name.clone()) {
+                    if !seen_roles.insert(role_name) {
                         continue;
                     }
-                    if Self::type_matches(effective_constraint, &role_name) {
+                    if Self::type_matches(effective_constraint, role_name.as_str()) {
                         return true;
                     }
-                    if let Some(rparents) = self.registry().role_parents.get(&role_name) {
+                    if let Some(rparents) = self.registry().role_parents.get(role_name.as_str()) {
                         for rp in rparents {
                             let rp_base = rp.split_once('[').map(|(b, _)| b).unwrap_or(rp.as_str());
                             if self.resolve_role_key(rp_base).is_some() {
-                                role_stack.push(rp_base.to_string());
+                                role_stack.push(Symbol::intern(rp_base));
                             }
                         }
                     }
@@ -1399,8 +1400,8 @@ impl Interpreter {
                     // `resolve_role_key` cannot find them either, so push them
                     // unconditionally — `Real does Numeric` is as true for a
                     // user class as a declared composition would be.
-                    for rp in Registry::builtin_role_parents(&role_name) {
-                        role_stack.push((*rp).to_string());
+                    for rp in Registry::builtin_role_parents(role_name.as_str()) {
+                        role_stack.push(Symbol::intern(rp));
                     }
                 }
             }
@@ -1476,7 +1477,10 @@ impl Interpreter {
         }
         // Check Instance class name against constraint (including parent classes)
         if let ValueView::Instance { class_name, .. } = value.view() {
-            let cn = class_name.resolve();
+            // `as_str` hands out the interned `&'static str`; `resolve()` would
+            // allocate a fresh `String` on every one of the four uses below, on
+            // a path a `Buf.push` loop reaches twice per push (#7696).
+            let cn = class_name.as_str();
             // ADR-0047: a lexical `my class`/`my grammar` instance's own
             // `class_name` is the unconditionally-mangled storage identity
             // (`Foo\u{0}<decl-id>`), never the bare source-written name. A
@@ -1487,17 +1491,17 @@ impl Interpreter {
             // string. Trying the raw string FIRST keeps a caller that already
             // passes a mangled constraint (e.g. a recursive same-identity
             // check elsewhere in this file) working unchanged.
-            if Self::type_matches(constraint, &cn)
-                || Self::type_matches(constraint, &crate::value::user_facing_type_name(&cn))
+            if Self::type_matches(constraint, cn)
+                || Self::type_matches(constraint, &crate::value::user_facing_type_name(cn))
             {
                 return true;
             }
             // Buf/Blob hierarchy: Buf[uint8] isa Buf, buf8 isa Buf, etc.
             if (constraint == "Buf" || constraint == "Blob")
-                && crate::runtime::utils::is_buf_or_blob_class(&cn)
+                && crate::runtime::utils::is_buf_or_blob_class(cn)
             {
                 // Buf constraint accepts any Buf-like, Blob constraint accepts any Blob-like
-                if constraint == "Buf" && crate::runtime::utils::is_buf_like_class(&cn) {
+                if constraint == "Buf" && crate::runtime::utils::is_buf_like_class(cn) {
                     return true;
                 }
                 if constraint == "Blob" {
@@ -1506,10 +1510,10 @@ impl Interpreter {
             }
             // blob8/buf8 aliases: blob8 == Blob[uint8], etc.
             if crate::runtime::utils::is_buf_or_blob_class(constraint)
-                && crate::runtime::utils::is_buf_or_blob_class(&cn)
+                && crate::runtime::utils::is_buf_or_blob_class(cn)
             {
                 let nc = crate::runtime::utils::normalize_buf_type_name(constraint);
-                let nv = crate::runtime::utils::normalize_buf_type_name(&cn);
+                let nv = crate::runtime::utils::normalize_buf_type_name(cn);
                 if nc == nv {
                     return true;
                 }
@@ -1522,7 +1526,7 @@ impl Interpreter {
                 }
             }
             // Check parent classes of the instance
-            if let Some(class_def) = self.registry().classes.get(&class_name.resolve()) {
+            if let Some(class_def) = self.registry().classes.get(cn) {
                 for parent in class_def.parents.clone() {
                     if Self::type_matches(constraint, &parent) {
                         return true;
@@ -1530,7 +1534,7 @@ impl Interpreter {
                 }
             }
             // Check MRO (handles built-in type hierarchies like Match -> Capture -> Cool)
-            let mro = self.class_mro(&class_name.resolve());
+            let mro = self.class_mro(cn);
             if mro
                 .iter()
                 .any(|parent| Self::type_matches(constraint, parent.as_str()))
@@ -1546,19 +1550,21 @@ impl Interpreter {
             // are pushed unconditionally — mirroring the `.does` introspection
             // walk in `methods_classhow_dispatch`.
             {
-                let mro = self.class_mro(&class_name.resolve());
+                // `mro` above is the same `Arc` this walk needs; recomputing it
+                // re-entered the registry for a second String-keyed lookup on
+                // every call (#7696).
                 let mut role_stack = self.registry().composed_roles_seed(&mro);
                 let mut seen_roles = HashSet::new();
                 while let Some(role_name) = role_stack.pop() {
-                    if !seen_roles.insert(role_name.clone()) {
+                    if !seen_roles.insert(role_name) {
                         continue;
                     }
-                    if Self::type_matches(constraint, &role_name) {
+                    if Self::type_matches(constraint, role_name.as_str()) {
                         return true;
                     }
-                    for rp in self.registry().role_parents_of(&role_name) {
+                    for rp in self.registry().role_parents_of(role_name.as_str()) {
                         let rp_base = rp.split_once('[').map(|(b, _)| b).unwrap_or(rp.as_str());
-                        role_stack.push(rp_base.to_string());
+                        role_stack.push(Symbol::intern(rp_base));
                     }
                 }
             }

--- a/src/runtime/types/type_matching_static.rs
+++ b/src/runtime/types/type_matching_static.rs
@@ -1,5 +1,7 @@
 use super::*;
 
+use crate::runtime::utils::{has_bracket, has_double_colon, split_once_bracket};
+
 impl Interpreter {
     /// Whether `qualified`'s trailing component may stand in for the bare name
     /// `short` (see the "qualified name matching" bridge in [`Self::type_matches`]).
@@ -44,8 +46,8 @@ impl Interpreter {
         // true — a bare `CArray` value does not satisfy `CArray[uint8]` — and the
         // parameterized-vs-parameterized comparison is handled by the callers
         // that know how to match the inner types.)
-        if !constraint.contains('[')
-            && let Some((value_base, _)) = value_type.split_once('[')
+        if !has_bracket(constraint)
+            && let Some((value_base, _)) = split_once_bracket(value_type)
             && value_base == constraint
         {
             return true;
@@ -55,14 +57,21 @@ impl Interpreter {
         // check if the short name matches the last component of the qualified name.
         // This bridges a registration gap: a type declared under a `unit module`
         // is registered qualified but referred to bare inside that module.
-        if constraint.contains("::")
-            && !value_type.contains("::")
+        //
+        // `str::contains("::")` builds a two-way searcher per call; on these
+        // short names that setup is the whole cost, and `type_matches` asked
+        // for it three times per call. Hoisting the two answers into one byte
+        // scan each was 9% of a `Buf.push` loop (#7696).
+        let constraint_qualified = has_double_colon(constraint);
+        let value_type_qualified = has_double_colon(value_type);
+        if constraint_qualified
+            && !value_type_qualified
             && Self::short_name_bridges(constraint, value_type)
         {
             return true;
         }
-        if value_type.contains("::")
-            && !constraint.contains("::")
+        if value_type_qualified
+            && !constraint_qualified
             && Self::short_name_bridges(value_type, constraint)
         {
             return true;

--- a/src/runtime/utils/str_scan.rs
+++ b/src/runtime/utils/str_scan.rs
@@ -41,6 +41,28 @@ pub(crate) fn has_anon_marker(name: impl AsRef<str>) -> bool {
     has_ascii(name, b"__ANON")
 }
 
+/// `name` is parameterized: it contains a `[`.
+///
+/// The single-byte twin of [`has_double_colon`]. `str::contains(char)` builds a
+/// `CharSearcher` and drives the generic `Searcher` protocol; on the short type
+/// names the type-matching paths ask this about, that setup is the whole cost.
+/// It was 4.5% of a `Buf.push` loop (#7696), where `type_matches` and the
+/// parametric/coercion name parsers each ask it once per type check.
+#[inline]
+pub(crate) fn has_bracket(name: &str) -> bool {
+    name.as_bytes().contains(&b'[')
+}
+
+/// `name.split_once('[')`, without the `CharSearcher` setup.
+///
+/// `[` is ASCII, so its byte offset is always a char boundary and the split is
+/// byte-for-byte what `split_once` returns.
+#[inline]
+pub(crate) fn split_once_bracket(name: &str) -> Option<(&str, &str)> {
+    let at = name.as_bytes().iter().position(|&b| b == b'[')?;
+    Some((&name[..at], &name[at + 1..]))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -64,6 +86,25 @@ mod tests {
             assert_eq!(has_double_colon(s), s.contains("::"), "{s:?}");
             assert_eq!(has_routine_scope_marker(s), s.contains("::&"), "{s:?}");
             assert_eq!(has_anon_marker(s), s.contains("__ANON"), "{s:?}");
+        }
+    }
+
+    #[test]
+    fn bracket_scans_agree_with_str() {
+        for s in [
+            "",
+            "[",
+            "Buf",
+            "Buf[uint8]",
+            "Blob[uint8]",
+            "CArray[Pointer[void]]",
+            "R[Int]",
+            "]",
+            "Numeric",
+            "\u{3042}[Int]",
+        ] {
+            assert_eq!(has_bracket(s), s.contains('['), "{s:?}");
+            assert_eq!(split_once_bracket(s), s.split_once('['), "{s:?}");
         }
     }
 }

--- a/src/runtime/utils/type_constraints.rs
+++ b/src/runtime/utils/type_constraints.rs
@@ -2,10 +2,11 @@ pub(crate) fn is_known_type_constraint(constraint: &str) -> bool {
     if crate::runtime::native_types::is_native_int_type(constraint) {
         return true;
     }
-    // Handle parameterized types like Array[Int], Hash[Str], etc.
-    if let Some(base) = constraint.split('[').next()
-        && constraint.contains('[')
-        && constraint.ends_with(']')
+    // Handle parameterized types like Array[Int], Hash[Str], etc. `ends_with`
+    // is O(1) and rejects every unparameterized name, so it gates the `[` scan
+    // rather than following it (#7696).
+    if constraint.ends_with(']')
+        && let Some((base, _)) = crate::runtime::utils::split_once_bracket(constraint)
         && is_known_type_constraint(base)
     {
         return true;

--- a/t/type-match-name-scans.t
+++ b/t/type-match-name-scans.t
@@ -1,0 +1,90 @@
+use v6;
+use Test;
+
+# The type-matching hot path scans type names for the ASCII markers `::`, `[`
+# and `(` to decide whether a name is package-qualified, parameterized, or a
+# coercion. Those scans were rewritten as byte scans and reordered so the O(1)
+# `ends_with` rejects an unparameterized name before any scan runs (#7696).
+# This file pins the behaviour each scan gates, in both directions, so a future
+# reordering cannot quietly change which names match.
+
+plan 31;
+
+# --- parameterized names: `[` -------------------------------------------------
+
+ok Buf[uint8].new(1, 2) ~~ Buf,      'Buf[uint8] instance matches bare Buf';
+ok Buf[uint8].new(1, 2) ~~ Blob,     'Buf[uint8] instance matches bare Blob';
+ok blob8.new(1) ~~ Blob,             'blob8 instance matches bare Blob';
+nok Blob.new(1) ~~ Buf,              'a Blob is not a Buf';
+ok Array[Int].new(1, 2) ~~ Array,    'Array[Int] matches bare Array';
+ok Array[Int] ~~ Array,              'Array[Int] type object matches bare Array';
+nok Array ~~ Array[Int],             'bare Array does not match Array[Int]';
+
+my $parameterized = Array[Int].new(1);
+ok $parameterized ~~ Positional,     'Array[Int] still does Positional';
+
+# A name that merely *ends* with `]` is not parameterized, and a name that
+# merely *contains* `[` is not either — both orderings must agree.
+ok 'Int' ~~ Str,                     'a plain name is still a Str';
+is Buf[uint8].^name, 'Buf[uint8]',   'parameterized name round-trips';
+
+# --- coercion names: `(` ------------------------------------------------------
+
+sub takes-int(Int() $n) { $n }
+is takes-int('42'), 42,              'Int() coerces a Str argument';
+is takes-int(42), 42,                'Int() passes an Int argument through';
+is takes-int(4.2), 4,                'Int() coerces a Rat argument';
+
+sub takes-str-of-int(Str(Int) $s) { $s }
+is takes-str-of-int(7), '7',         'Str(Int) coerces the named source type';
+
+# A name ending in `)` that is not a coercion must not be parsed as one.
+ok Int ~~ Any,                       'a bare type object still matches Any';
+ok 42 ~~ Int,                        'a plain Int still matches Int';
+
+# --- qualified names: `::` ----------------------------------------------------
+
+module Outer {
+    class Inner is export {
+        method label() { 'inner' }
+    }
+}
+
+my $inner = Outer::Inner.new;
+ok $inner ~~ Outer::Inner,           'instance matches its fully-qualified name';
+is $inner.label, 'inner',            'qualified class method dispatches';
+is Outer::Inner.^name, 'Outer::Inner', 'qualified name round-trips';
+
+# The short-name bridge must NOT equate a nested core-setting name with the
+# core type it shadows (the `Foo::Any` trap `short_name_bridges` guards).
+module Shadow {
+    class Any is export {
+        method tag() { 'shadow' }
+    }
+}
+my $shadowed = Shadow::Any.new;
+is $shadowed.tag, 'shadow',          'a nested class named Any is its own type';
+nok 42 ~~ Shadow::Any,               'an Int does not match a nested Shadow::Any';
+nok 'x' ~~ Shadow::Any,              'a Str does not match a nested Shadow::Any';
+ok $shadowed ~~ Shadow::Any,         'the nested instance does match it';
+
+# A single colon is not a qualification.
+ok 'a:b' ~~ Str,                     'a single colon in a value is irrelevant';
+
+# --- roles and the MRO/role walk ---------------------------------------------
+
+role Ticker { method tick() { 'tick' } }
+class Clock does Ticker { }
+ok Clock.new ~~ Ticker,              'an instance matches a composed role';
+ok Clock ~~ Ticker,                  'the class type object matches it too';
+
+role Countable does Ticker { }
+class Counter does Countable { }
+ok Counter.new ~~ Ticker,            'a transitively composed role matches';
+ok Counter.new ~~ Countable,         'the directly composed role matches';
+
+# `Real does Numeric` is a built-in role parent, which is the exact walk the
+# native-dispatch numeric probe runs on every instance method call.
+ok 42 ~~ Real,                       'an Int is Real';
+ok 42 ~~ Numeric,                    'an Int is Numeric';
+nok Buf.new(1) ~~ Numeric,           'a Buf is not Numeric';


### PR DESCRIPTION
Closes #7696.

## What the profile actually said

`callgrind` on `my $big = Buf.new(1 xx 1000); for ^2000 { $big.push(1) }`
(release, 143.9M instructions) with **caller attribution** — which is what
changes the conclusion:

| | share | what |
| --- | --- | --- |
| `try_native_method_raw` → `type_matches_value` | **52%** | two full type-graph walks per instance method call |
| substring searching | ~13% | `type_matches`'s `contains("::")` ×3 and `contains('[')` per call |
| malloc/free | ~15% | 132,580 allocations, 63 per push |

The ticket's suggested first step — making `is_buf_like_class` /
`is_blob_like_class` / `is_buf_or_blob_class` answer from the interned symbol
instead of scanning the class name — **targets the wrong thing**. Those three
predicates together are 0.15% of the loop. The `is_contained_in` cost the
ticket attributed to them belongs to `Interpreter::type_matches`, which asks
`str::contains("::")` three times and `contains('[')` once on every call:
313,719 searches for 80,000 `type_matches` calls. `str::contains(&str)` builds
a two-way searcher per call, and on names this short that setup *is* the cost.

The allocations were almost all `Symbol::resolve()` handing out a fresh
`String` where `as_str()` hands out the interned `&'static str`, plus the
`Vec<String>` work stacks and `HashSet<String>` seen-sets of the role walks.

## What changed

Every change is local, and **none of it caches a type relation**:

- `type_matches` hoists its three `"::"` searches into two byte scans (reusing
  `runtime::utils::has_double_colon`, which already existed from #7554) and its
  `[` search into `has_bracket` / `split_once_bracket`, new single-byte twins in
  that module.
- `parse_parametric_type_name`, `parse_generic_constraint`,
  `parse_coercion_type` and `is_known_type_constraint` let their O(1)
  `ends_with(']')` / `ends_with(')')` reject an unparameterized name *before*
  scanning for the opening bracket, rather than after.
- The `ValueView::Instance` arm of `type_matches_value` resolves its class name
  once, as `as_str()`, for all four of its uses, and reuses the `Arc<[Symbol]>`
  MRO it already fetched instead of re-entering the registry for a second
  String-keyed lookup.
- `Registry::composed_roles_seed` returns `Vec<Symbol>`, so the three role walks
  that consume it keep a `Copy` work stack and a `HashSet<Symbol>` seen-set —
  no allocation per role pushed, none per `seen` insert.

## Result

Instruction count on the profiled push loop: **143.9M → 114.7M (−20.3%)**,
deterministic. Wall clock in this container, best of five (slower box than the
ticket's, so absolutes are higher):

| | before | after |
| --- | --- | --- |
| `Buf.new` + 100 pushes | 1.011 ms | 0.861 ms |
| 10 pushes onto a 1000-byte buf | 0.1182 ms | 0.1014 ms |
| 10 pushes onto a 4000-byte buf | 0.1183 ms | 0.1019 ms |

`type_matches` is on every signature bind, so this is not `Buf`-specific, but
it is small elsewhere: the standard benchmarks move by less than the noise floor
except `bench-ctor` (−1.7%). These are local A/B runs on one binary pair, quoted
for this change only — the numbers of record stay the bench CI's
`bench-history.tsv`.

## Test

`t/type-match-name-scans.t` (31 assertions) pins the behaviour each scan gates,
in both directions: parameterized names (`Buf[uint8] ~~ Buf`, `Array[Int] ~~
Array`, and the negative `Array !~~ Array[Int]`), coercion names (`Int()`,
`Str(Int)`), qualified names including the `Foo::Any` short-name-bridge trap
`short_name_bridges` guards, and the MRO/role walk (`Real does Numeric`,
transitive role composition). It **passes under Rakudo as well as mutsu**, so it
pins spec behaviour rather than mutsu's current answers.

## What is left

The 52% item is untouched, and it is the larger half. Declining a native method
for an instance receiver should not need two type-graph walks when the
receiver's class is already known — the answer is a property of the class, not
of the call. Caching it needs an invalidation signal covering `classes`,
`roles`, `role_parents`, `class_composed_roles` and `subsets`;
`method_generation` reaches none of them, and those five maps are `pub(crate)`
fields mutated directly from ~30 sites. A hand-enumerated invalidation list is
exactly the "correct only under an incomplete static analysis" shape CLAUDE.md's
gain/risk section rules out, since a missed site returns a silently wrong type
answer rather than failing loudly. Filed with the measurement as #7712 rather
than guessed at here.

## Verification

- `cargo fmt --all`, `make lint` — green (all four configurations)
- `make test` — **PASS**, 3897 files / 41409 tests
- `make roast` — the only red files are the three documented in
  `docs/agent-environments.md` as container-only, at exactly their documented
  shapes: `6.c/S32-io/file-tests.t` (Failed 4: tests 6-8, 10),
  `S16-filehandles/filetest.t` (Failed 25: 57-64, 69-72, 77-80,
  101/103/105/107/109/111/117/121/125) — both `uid 0` bypassing permission bits
  — and `S32-io/IO-Socket-Async.t` (exit 124, planned 40 ran 17, sandboxed
  network).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018zGmCvW3PJzjxtWT1t9QKG

---
_Generated by [Claude Code](https://claude.ai/code/session_018zGmCvW3PJzjxtWT1t9QKG)_