### PR TITLE
fix(value): add itemized ContainerRef representation

### DIFF
--- a/docs/adr/0079-container-itemization-is-a-holder-property-tagged-on-the-containerref-word.md
+++ b/docs/adr/0079-container-itemization-is-a-holder-property-tagged-on-the-containerref-word.md
@@ -277,7 +277,7 @@ unconditional and delete it.
 | Slice | State |
 | --- | --- |
 | 0 — comment justification | Complete (2026-09-09; comments now state the RHS `List` rule) |
-| 1 — `Kind::ContainerRefItemized` | Not started |
+| 1 — `Kind::ContainerRefItemized` | Complete (2026-09-09; the holder flavour is encoded, decoded, probed, projected through the unchanged `ValueView::ContainerRef`, traced by GC, and covered by NanBox round-trip tests) |
 | 2 — `$`-share holder (rows 1, 3, 4) | Not started |
 | 3 — audit remaining producers | Not started |
 | 4 — drop the `unwrap_contained_pair` hedge | Not started |

--- a/news/2026-09/containerref-itemized-representation.md
+++ b/news/2026-09/containerref-itemized-representation.md
@@ -1,0 +1,16 @@
+# `ContainerRef` can carry a holder-local itemization flavour
+
+The NaN-box representation now distinguishes a plain `ContainerRef` from an
+itemized holder without changing the shared cell or the public `ValueView`:
+both flavours project as `ValueView::ContainerRef`, and existing constructors
+continue to create the plain flavour.
+
+`Value::container_ref_itemized(cell)` and
+`Value::container_ref_is_itemized()` provide the representation seam needed by
+the later holder-semantics slice of [ADR-0079](../../docs/adr/0079-container-itemization-is-a-holder-property-tagged-on-the-containerref-word.md).
+The new `Kind::ContainerRefItemized` is included in encoding, decoding, tag
+probes, variant comparisons, stringifiable-list checks, and GC tracing, with
+round-trip tests pinning the cell identity and flavour bit.
+
+No runtime producer opts into the new flavour yet, so this slice is
+behaviour-neutral.

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -1558,8 +1558,9 @@ pub(in crate::value) enum ValueRepr {
     /// Prevents one level of flattening in list/array context.
     Scalar(Box<Value>),
     /// A shared mutable Scalar container for `:=` binding.
-    /// Two variables bound together share the same `ContainerRef`.
-    ContainerRef(Gc<crate::value::ContainerCell>),
+    /// Two variables bound together share the same `ContainerRef`. The bool is
+    /// a per-holder itemization flag; it does not change the shared cell.
+    ContainerRef(Gc<crate::value::ContainerCell>, bool),
     /// An explicit view of a `ContainerRef` returned by `.VAR`.
     ///
     /// It carries the same cell identity as `ContainerRef`, but stays distinct
@@ -1837,7 +1838,11 @@ impl Value {
     }
     #[inline]
     pub(in crate::value) fn ContainerRef(cell: Gc<crate::value::ContainerCell>) -> Value {
-        Value::from_repr(ValueRepr::ContainerRef(cell))
+        Value::from_repr(ValueRepr::ContainerRef(cell, false))
+    }
+    #[inline]
+    pub(in crate::value) fn ContainerRefItemized(cell: Gc<crate::value::ContainerCell>) -> Value {
+        Value::from_repr(ValueRepr::ContainerRef(cell, true))
     }
     #[inline]
     pub(in crate::value) fn ContainerView(cell: Gc<crate::value::ContainerCell>) -> Value {

--- a/src/value/nanbox/decode.rs
+++ b/src/value/nanbox/decode.rs
@@ -188,9 +188,14 @@ unsafe fn decode_kind(kind: Kind, bits: u64) -> ValueRepr {
         Kind::Sub => ValueRepr::Sub(unsafe { take_gc::<SubData>(bits) }),
         Kind::WeakSub => ValueRepr::WeakSub(unsafe { take_weak::<SubData>(bits) }),
         Kind::LazyList => ValueRepr::LazyList(unsafe { take_gc::<LazyList>(bits) }),
-        Kind::ContainerRef => {
-            ValueRepr::ContainerRef(unsafe { take_gc::<crate::value::ContainerCell>(bits) })
-        }
+        Kind::ContainerRef => ValueRepr::ContainerRef(
+            unsafe { take_gc::<crate::value::ContainerCell>(bits) },
+            false,
+        ),
+        Kind::ContainerRefItemized => ValueRepr::ContainerRef(
+            unsafe { take_gc::<crate::value::ContainerCell>(bits) },
+            true,
+        ),
         Kind::ContainerView => {
             ValueRepr::ContainerView(unsafe { take_gc::<crate::value::ContainerCell>(bits) })
         }

--- a/src/value/nanbox/encode.rs
+++ b/src/value/nanbox/encode.rs
@@ -217,13 +217,20 @@ impl NanBox {
             ValueRepr::CustomType(d) => pack_arc(Kind::CustomType, Arc::new(*d)),
             ValueRepr::CustomTypeInstance(d) => pack_arc(Kind::CustomTypeInstance, Arc::new(*d)),
             ValueRepr::Scalar(inner) => pack_arc(Kind::Scalar, Arc::new(*inner)),
-            ValueRepr::ContainerRef(cell) => {
+            ValueRepr::ContainerRef(cell, itemized) => {
                 // Latch for the Tier B inline GetLocal fast path: this is the
                 // single point every ContainerRef word passes through, so a
                 // zero counter proves no cell exists anywhere (see
                 // `vm_jit::CONTAINER_CELLS`).
                 crate::vm::vm_jit::note_container_cell();
-                pack_gc(Kind::ContainerRef, cell)
+                pack_gc(
+                    if itemized {
+                        Kind::ContainerRefItemized
+                    } else {
+                        Kind::ContainerRef
+                    },
+                    cell,
+                )
             }
             ValueRepr::ContainerView(cell) => pack_gc(Kind::ContainerView, cell),
             ValueRepr::LazyThunk(t) => pack_arc(Kind::LazyThunk, t),

--- a/src/value/nanbox/mod.rs
+++ b/src/value/nanbox/mod.rs
@@ -148,6 +148,7 @@ pub(in crate::value) enum Kind {
     WeakSub,
     LazyList,
     ContainerRef,
+    ContainerRefItemized,
     ContainerView,
     Promise,
     Channel,
@@ -438,7 +439,7 @@ unsafe fn payload_op(kind: Kind, bits: u64, op: PayloadOp) {
             Kind::Sub => gc_op::<SubData>(bits, op),
             Kind::WeakSub => weak_op::<SubData>(bits, op),
             Kind::LazyList => gc_op::<LazyList>(bits, op),
-            Kind::ContainerRef | Kind::ContainerView => {
+            Kind::ContainerRef | Kind::ContainerRefItemized | Kind::ContainerView => {
                 gc_op::<crate::value::ContainerCell>(bits, op)
             }
             Kind::Promise => gc_op::<(Mutex<PromiseState>, Condvar)>(bits, op),

--- a/src/value/nanbox/peek.rs
+++ b/src/value/nanbox/peek.rs
@@ -312,7 +312,20 @@ impl NanBox {
     /// every `GetLocal`; same motivation as [`Self::is_junction`]).
     #[inline]
     pub(in crate::value) fn is_container_ref(&self) -> bool {
-        matches!(classify(self.0.get()), Classified::Kind(Kind::ContainerRef))
+        matches!(
+            classify(self.0.get()),
+            Classified::Kind(Kind::ContainerRef | Kind::ContainerRefItemized)
+        )
+    }
+
+    /// Whether this word is an itemized `ContainerRef` holder. This is a pure
+    /// tag probe; the shared cell payload is identical to the plain flavour.
+    #[inline]
+    pub(in crate::value) fn is_container_ref_itemized(&self) -> bool {
+        matches!(
+            classify(self.0.get()),
+            Classified::Kind(Kind::ContainerRefItemized)
+        )
     }
 
     /// Whether this word is a `HashEntryRef` — a pure tag probe (checked on
@@ -408,6 +421,7 @@ impl NanBox {
                     | Kind::HyperSeq
                     | Kind::RaceSeq
                     | Kind::ContainerRef
+                    | Kind::ContainerRefItemized
                     | Kind::ContainerView
                     | Kind::HashEntryRef
                     | Kind::Scalar
@@ -461,6 +475,9 @@ impl NanBox {
                 | Kind::ArrayShaped
                 | Kind::ArrayLazy => VARIANT_ARRAY,
                 Kind::HashPlain | Kind::HashItemized => VARIANT_HASH,
+                Kind::ContainerRef | Kind::ContainerRefItemized => {
+                    VARIANT_KIND_BASE + Kind::ContainerRef as u8
+                }
                 Kind::SetImm | Kind::SetMut => VARIANT_SET,
                 Kind::BagImm | Kind::BagMut => VARIANT_BAG,
                 Kind::MixImm | Kind::MixMut => VARIANT_MIX,
@@ -651,7 +668,9 @@ unsafe fn view_kind<'a>(kind: Kind, bits: u64) -> ValueView<'a> {
                 ValueView::WeakSub(RefGuard::from_reconstructed(take_weak::<SubData>(bits)))
             }
             Kind::LazyList => ValueView::LazyList(gc_guard(bits)),
-            Kind::ContainerRef => ValueView::ContainerRef(gc_guard(bits)),
+            Kind::ContainerRef | Kind::ContainerRefItemized => {
+                ValueView::ContainerRef(gc_guard(bits))
+            }
             Kind::ContainerView => ValueView::ContainerView(gc_guard(bits)),
             Kind::Promise => ValueView::Promise(RefGuard::from_reconstructed(SharedPromise {
                 inner: take_gc(bits),

--- a/src/value/nanbox/tests.rs
+++ b/src/value/nanbox/tests.rs
@@ -197,14 +197,44 @@ fn array_kind_and_container_flags_travel_in_the_tag() {
 #[test]
 fn container_ref_cell_identity_survives() {
     let cell = Gc::new(crate::value::ContainerCell::new(Value::int(7)));
-    match roundtrip(ValueRepr::ContainerRef(cell.clone())) {
-        ValueRepr::ContainerRef(back) => {
+    for itemized in [false, true] {
+        match roundtrip(ValueRepr::ContainerRef(cell.clone(), itemized)) {
+            ValueRepr::ContainerRef(back, back_itemized) => {
+                assert_eq!(back_itemized, itemized);
+                assert!(Gc::ptr_eq(&back, &cell), ":= binding identity preserved");
+                *back.lock().unwrap() = Value::int(9);
+            }
+            other => panic!("decoded as {other:?}"),
+        }
+    }
+    assert_eq!(cell.lock().unwrap().as_int(), Some(9));
+}
+
+#[test]
+fn container_ref_itemization_is_holder_local() {
+    let cell = Gc::new(crate::value::ContainerCell::new(Value::int(7)));
+    let plain = Value::container_ref(cell.clone());
+    let itemized = Value::container_ref_itemized(cell);
+
+    assert!(plain.is_container_ref());
+    assert!(itemized.is_container_ref());
+    assert!(!plain.container_ref_is_itemized());
+    assert!(itemized.container_ref_is_itemized());
+    assert!(plain.same_variant(&itemized));
+    assert!(matches!(plain.view(), ValueView::ContainerRef(_)));
+    assert!(matches!(itemized.view(), ValueView::ContainerRef(_)));
+}
+
+#[test]
+fn container_ref_itemized_roundtrips_as_the_same_value_repr_variant() {
+    let cell = Gc::new(crate::value::ContainerCell::new(Value::int(3)));
+    match roundtrip(ValueRepr::ContainerRef(cell.clone(), true)) {
+        ValueRepr::ContainerRef(back, itemized) => {
+            assert!(itemized);
             assert!(Gc::ptr_eq(&back, &cell), ":= binding identity preserved");
-            *back.lock().unwrap() = Value::int(9);
         }
         other => panic!("decoded as {other:?}"),
     }
-    assert_eq!(cell.lock().unwrap().as_int(), Some(9));
 }
 
 fn sample_sub() -> Gc<SubData> {
@@ -528,7 +558,10 @@ fn every_variant_roundtrips_losslessly() {
             id: 2,
         })),
         ValueRepr::Scalar(Box::new(Value::int(11))),
-        ValueRepr::ContainerRef(Gc::new(crate::value::ContainerCell::new(Value::int(3)))),
+        ValueRepr::ContainerRef(
+            Gc::new(crate::value::ContainerCell::new(Value::int(3))),
+            false,
+        ),
         ValueRepr::LazyThunk(Arc::new(LazyThunkData {
             thunk: Value::NIL,
             cache: Mutex::new(Some(Value::int(5))),

--- a/src/value/value_methods_a.rs
+++ b/src/value/value_methods_a.rs
@@ -685,6 +685,11 @@ impl Value {
         self.0.is_container_ref()
     }
 
+    /// Whether this `ContainerRef` holder carries the itemized flavour.
+    pub fn container_ref_is_itemized(&self) -> bool {
+        self.0.is_container_ref_itemized()
+    }
+
     /// Autovivify a hash entry: if the key doesn't exist, insert an empty Hash.
     /// Returns a `HashEntryRef` pointing to the entry in the parent hash.
     /// Uses interior mutation of the `Arc<HashMap>` so that **all** clones of

--- a/src/value/view.rs
+++ b/src/value/view.rs
@@ -304,6 +304,13 @@ impl Value {
         Value::ContainerRef(cell)
     }
 
+    /// Construct an itemized `ContainerRef` holder from an existing cell.
+    #[inline]
+    #[allow(dead_code)]
+    pub(crate) fn container_ref_itemized(cell: Gc<crate::value::ContainerCell>) -> Self {
+        Value::ContainerRefItemized(cell)
+    }
+
     /// Construct an explicit `.VAR` view of an existing container cell.
     #[inline]
     pub(crate) fn container_view(cell: Gc<crate::value::ContainerCell>) -> Self {


### PR DESCRIPTION
Part of #7542

## Summary
- add the holder-local `ContainerRef` itemization flag and `Kind::ContainerRefItemized`
- preserve the single `ValueView::ContainerRef` projection while threading the kind through encode/decode, probes, variant tags, stringifiable-list checks, and GC tracing
- keep all existing constructors plain and cover both flavours with NanBox round-trip and identity tests
- mark ADR-0079 Slice 1 complete and document the representation seam

## Validation
- `cargo fmt --all`
- `make lint`
- `make test`
- `make roast`

No runtime producer opts into the new flavour yet; this slice is behaviour-neutral.