### PR TITLE
fix(compiler): resolve a loop body's own let/temp saves, once per iteration

### DIFF
--- a/news/2026-09/loop-body-let-temp-resolution.md
+++ b/news/2026-09/loop-body-let-temp-resolution.md
@@ -1,0 +1,90 @@
+# A loop body now resolves its own `let`/`temp` saves, once per iteration
+
+`let` and `temp` are resolved at the end of the enclosing **block** — `temp`
+always restores the saved value, `let` restores it unless the block succeeded.
+A loop body is a Raku block, so it owes that resolution to every one of its
+iterations. mutsu gave it to none of them:
+
+```raku
+my $k = 1;
+for 1..2 { temp $k = 2; }
+say $k;                     # raku: 1   mutsu (before): 2
+```
+
+The save was not resolved *per iteration* either, so the second iteration
+observed the first one's temporized value:
+
+```raku
+my $j = 1;
+for 1..2 { say "in: $j"; temp $j = 2; }
+# raku:            in: 1 / in: 1
+# mutsu (before):  in: 1 / in: 2
+```
+
+`while`, `until`, C-style `loop` and `repeat` diverged identically, and so did
+`let`:
+
+```raku
+my $n = 1;
+for 1..2 { let $n = 2; Nil }
+say $n;                     # raku: 1   mutsu (before): 2
+```
+
+## Root cause
+
+Only three lowerings implemented the resolution: the statement-position bare
+block and the value-position `do` block, both through `OpCode::LetBlock`
+(GH-7635), and routine/method/closure frame teardown together with the
+`try`/implicit-`CATCH` region (GH-7646). A loop body is compiled by none of
+them — `OpCode::ForLoop` / `WhileLoop` / `CStyleLoop` / `RepeatLoop` run their
+body range directly, taking no `let_saves` mark — so a save made inside one
+survived until some outer block happened to resolve it, or forever.
+
+## The fix
+
+The save frame is emitted **inside the loop's own body range**, at its head.
+That placement is what makes it per-iteration for free: the loop opcodes
+re-run the range on every pass, so `OpCode::LetBlock` re-executes, re-marks,
+and resolves what that one iteration recorded. No loop opcode changed, and a
+body with no `let`/`temp` in it emits nothing at all, so the overwhelming
+majority of loops pay nothing.
+
+The ticket (GH-7677) framed the hard part correctly: a real `let` decides from
+the block's own value whether to roll back, and a loop body is compiled in sink
+context, so it has no value to offer. The two existing lowerings deliver that
+value in different ways — the statement block routes its tail statement through
+the topic, the `do` block leaves it on the value stack — and only the second is
+available here: a loop body's topic **is** the loop variable, so writing it
+would clobber the binding the iteration runs under. So a body containing a real
+`let` has its tail statement compiled for value (`value_on_stack: true`) and the
+frame is followed by a `Pop` that keeps the body range stack-balanced. A
+`temp`-only body needs no value at all — `temp` restores unconditionally — and
+keeps its ordinary sink lowering. The value-collecting `for` expression already
+leaves the iteration's value on the stack, so there the frame is a bracket and
+nothing else.
+
+An iteration that exits early through `next`, `last` or a `return` out of the
+enclosing routine is an unsuccessful block exit: the frame's error path restores
+both kinds of save, which is what Rakudo does (measured — a `let` rolled back by
+each of the three).
+
+## Tests
+
+`t/loop-body-let-resolution.t` (28 assertions) pins the whole matrix: `temp`
+restored by all five loop forms, the per-iteration property spelled out as the
+sequence of values successive iterations observe, `let` rolling back on an
+undefined iteration value and committing on a defined one, the three early-exit
+routes, a `temp` nested in an `if` branch, the loop variable staying undisturbed
+by the tail-value routing, and the collecting `for` yielding the temporized
+value while still restoring it. All 28 pass under Rakudo v2026.07 as well as
+mutsu. `t/do-block-let-resolution.t` and `t/routine-body-let-resolution.t` pin
+the two lowerings that were already correct and stay green.
+
+## Left open
+
+`my $g = 1; my @v = do for 1..2 { temp $g = 9; $g }` — a collecting `for` whose
+tail is the bare temporized variable — yields `[1 1]` under Rakudo and `[9 9]`
+under mutsu. That is a container-identity divergence (Rakudo collects the
+`Scalar` container and reads it after the restore; mutsu collects the value),
+independent of this fix and unchanged by it: with the tail decontainerized
+(`$g + 0`) both give `[9 9]`. Filed as GH-7718.

--- a/src/compiler/helpers_control_flow.rs
+++ b/src/compiler/helpers_control_flow.rs
@@ -506,7 +506,7 @@ impl Compiler {
         });
         // `succeed_boundary: true` already absorbs the succeed at exactly this
         // level, so the body does not need its own `SucceedBarrier`.
-        self.in_scope_restored_body(|c| c.compile_body_with_implicit_try_inner(stmts));
+        self.in_scope_restored_body(|c| c.compile_body_with_implicit_try_inner(stmts, false));
         self.code.patch_block_local_body_end(idx);
     }
 
@@ -517,19 +517,80 @@ impl Compiler {
     /// here can use the env-only `SetVarTypeScoped` instead of also writing the
     /// enclosing scope's type metadata.
     pub(super) fn compile_scope_restored_loop_body(&mut self, stmts: &[Stmt]) {
-        self.in_scope_restored_body(|c| c.compile_body_with_implicit_try(stmts));
+        let Some(needs_value) = Self::loop_body_let_frame(stmts) else {
+            self.in_scope_restored_body(|c| c.compile_body_with_implicit_try(stmts));
+            return;
+        };
+        let idx = self.code.emit(OpCode::LetBlock {
+            body_end: 0,
+            value_on_stack: needs_value,
+        });
+        if needs_value {
+            // A real `let` is rolled back unless the iteration succeeded, so the
+            // op needs the iteration's own value — which a sink-context loop
+            // body does not otherwise produce. Route it through the value STACK,
+            // not the topic the statement-position block uses
+            // (`emit_body_let_frame`): a loop body's topic is the loop variable,
+            // so writing it would clobber the binding the iteration runs under.
+            self.in_scope_restored_body(|c| c.compile_body_with_implicit_try_value(stmts));
+        } else {
+            // A `temp`-only body always restores, so the op needs no value and
+            // the body keeps its ordinary sink lowering. `value_on_stack: false`
+            // makes the op read the topic, whose success verdict only `let`
+            // entries consult and this body has none.
+            self.in_scope_restored_body(|c| c.compile_body_with_implicit_try(stmts));
+        }
+        self.code.patch_let_block_end(idx);
+        if needs_value {
+            // The op leaves the value it peeked in place; drop it so the body
+            // range stays stack-balanced across iterations.
+            self.code.emit(OpCode::Pop);
+        }
+    }
+
+    /// The `let`/`temp` save frame a loop body owes each of its iterations
+    /// (#7677).
+    ///
+    /// A loop body is a Raku block, so it owns the `let`/`temp` saves its body
+    /// records and resolves them at the end of **each iteration** — `temp`
+    /// always restores, `let` restores unless the iteration's own value was
+    /// defined. The loop opcodes run the body range directly, with no
+    /// `OpCode::BlockScope` around it, so the frame has to live *inside* that
+    /// range: `OpCode::LetBlock` at its head re-executes, and so re-marks, once
+    /// per iteration, which is exactly the per-iteration resolution Raku asks
+    /// for.
+    ///
+    /// `Some(true)` — a real `let` is present and the op needs the iteration's
+    /// own value. `Some(false)` — a `temp`-only body, which restores
+    /// unconditionally and needs no value. `None`, the overwhelmingly common
+    /// case, emits nothing at all, so a loop with no `let`/`temp` in its body
+    /// pays nothing for this.
+    fn loop_body_let_frame(stmts: &[Stmt]) -> Option<bool> {
+        Self::has_let_deep(stmts).then(|| Self::has_real_let_deep(stmts))
     }
 
     /// [`Self::compile_scope_restored_loop_body`] for a value-collecting loop
     /// body (the `for` expression form), which compiles through
     /// `compile_stmts_value` instead.
     pub(super) fn compile_scope_restored_body_value(&mut self, stmts: &[Stmt]) {
+        // The collecting form already leaves the iteration's value on the stack
+        // for the loop to gather, so the `let` frame (#7677) needs no lowering
+        // change here — only the bracket, reading that same value.
+        let let_frame = Self::loop_body_let_frame(stmts).map(|_| {
+            self.code.emit(OpCode::LetBlock {
+                body_end: 0,
+                value_on_stack: true,
+            })
+        });
         self.in_scope_restored_body(|c| {
             // Same block-start declaration visibility as the statement-position
             // loop body above (`compile_body_with_implicit_try_inner`).
             c.hoist_typed_var_decls(stmts);
             c.compile_stmts_value(stmts)
         });
+        if let Some(idx) = let_frame {
+            self.code.patch_let_block_end(idx);
+        }
     }
 
     /// Run `f` with `lexically_in_block` set, restoring the previous value
@@ -781,10 +842,25 @@ impl Compiler {
     /// CATCH or CONTROL blocks. This should be used for any block context (bare blocks,
     /// if branches, loop bodies, sub bodies) to ensure CATCH/CONTROL are not silently ignored.
     pub(super) fn compile_body_with_implicit_try(&mut self, stmts: &[Stmt]) {
-        self.with_succeed_barrier(stmts, |c| c.compile_body_with_implicit_try_inner(stmts));
+        self.with_succeed_barrier(stmts, |c| {
+            c.compile_body_with_implicit_try_inner(stmts, false)
+        });
     }
 
-    fn compile_body_with_implicit_try_inner(&mut self, stmts: &[Stmt]) {
+    /// [`Self::compile_body_with_implicit_try`], but leaving the body's own
+    /// value on the value stack instead of discarding it.
+    ///
+    /// Used by the loop-body `let` frame (#7677): `OpCode::LetBlock` judges a
+    /// real `let` from the block's own value, and a loop body is compiled in
+    /// sink context, so the tail statement has to be compiled for value to
+    /// produce one. The caller balances the stack.
+    pub(super) fn compile_body_with_implicit_try_value(&mut self, stmts: &[Stmt]) {
+        self.with_succeed_barrier(stmts, |c| {
+            c.compile_body_with_implicit_try_inner(stmts, true)
+        });
+    }
+
+    fn compile_body_with_implicit_try_inner(&mut self, stmts: &[Stmt], tail_as_value: bool) {
         let saved = self.push_dynamic_scope_lexical();
         // A block's `my TYPE $x` is in effect for the WHOLE block, so register
         // the constraints at entry (see `hoist_typed_var_decls`). This is the
@@ -793,10 +869,19 @@ impl Compiler {
         // which hoists on its own, so hoist only in the plain arm.
         if Self::has_catch_or_control(stmts) {
             self.compile_implicit_try(stmts);
-            self.code.emit(OpCode::Pop);
+            // The implicit-try region leaves the body's value on the stack; a
+            // caller that asked for that value keeps it instead of popping.
+            if !tail_as_value {
+                self.code.emit(OpCode::Pop);
+            }
         } else {
             self.hoist_typed_var_decls(stmts);
-            for s in stmts {
+            let last = stmts.len().wrapping_sub(1);
+            for (i, s) in stmts.iter().enumerate() {
+                if tail_as_value && i == last {
+                    self.compile_last_stmt_as_value(s);
+                    continue;
+                }
                 self.compile_stmt(s);
                 // A statement `given` always nets one stack value (see
                 // `exec_given_op`). This body is statement position — its value
@@ -807,6 +892,10 @@ impl Compiler {
                 if Self::stmt_nets_a_stack_value(s) {
                     self.code.emit(OpCode::Pop);
                 }
+            }
+            if tail_as_value && stmts.is_empty() {
+                // An empty body still owes the frame a value to judge.
+                self.code.emit(OpCode::LoadTrue);
             }
         }
         self.pop_dynamic_scope_lexical(saved);

--- a/t/loop-body-let-resolution.t
+++ b/t/loop-body-let-resolution.t
@@ -1,0 +1,194 @@
+use Test;
+
+# GH-7677: `let`/`temp` resolve their saves at the end of the enclosing BLOCK,
+# and a loop body IS one — resolved once per ITERATION, not once for the whole
+# loop. `for`/`while`/`until`/C-style `loop`/`repeat` bodies used to be compiled
+# by none of the three lowerings that implement the resolution (the bare block
+# and value-position `do` via `OpCode::LetBlock`, and routine-frame teardown via
+# GH-7646), so a `temp` inside any loop body survived the loop entirely and the
+# next iteration observed the previous one's temporized value.
+#
+# The frame is now emitted INSIDE the loop's own body range, so the loop opcodes
+# re-execute it — and so re-mark — on every iteration. A `temp`-only body keeps
+# its ordinary sink lowering (`temp` always restores, so the frame needs no
+# value); a body with a real `let` has its tail statement compiled for value, on
+# the value stack rather than through the topic, because a loop body's topic is
+# the loop variable and must not be clobbered.
+#
+# Every assertion below was measured against `raku` (v2026.07) first.
+
+plan 28;
+
+# --- `temp` is restored at the end of the loop body, in every loop form ------
+
+{
+    my $x = 1;
+    for 1..2 { temp $x = 2; }
+    is $x, 1, '`for` body restores a `temp`';
+}
+
+{
+    my $x = 1;
+    my $c = 0;
+    while $c++ < 2 { temp $x = 2; }
+    is $x, 1, '`while` body restores a `temp`';
+}
+
+{
+    my $x = 1;
+    my $c = 0;
+    until $c++ >= 2 { temp $x = 2; }
+    is $x, 1, '`until` body restores a `temp`';
+}
+
+{
+    my $x = 1;
+    loop (my $i = 0; $i < 2; $i++) { temp $x = 2; }
+    is $x, 1, 'C-style `loop` body restores a `temp`';
+}
+
+{
+    my $x = 1;
+    my $c = 0;
+    repeat { temp $x = 2; } while $c++ < 1;
+    is $x, 1, '`repeat` body restores a `temp`';
+}
+
+{
+    my $x = 1;
+    for 1..2 -> $e { temp $x = 2; }
+    is $x, 1, 'a `for` with a named parameter restores a `temp`';
+}
+
+# --- the resolution is PER ITERATION, not per loop ---------------------------
+
+{
+    my $x = 1;
+    my @seen;
+    for 1..3 { @seen.push($x); temp $x = 2; }
+    is @seen, [1, 1, 1],
+        'each `for` iteration starts from the restored value, not the previous temporized one';
+}
+
+{
+    my $x = 1;
+    my @seen;
+    my $c = 0;
+    while $c++ < 3 { @seen.push($x); temp $x = 2; }
+    is @seen, [1, 1, 1], 'each `while` iteration starts from the restored value';
+}
+
+{
+    my $x = 1;
+    my @seen;
+    loop (my $i = 0; $i < 3; $i++) { @seen.push($x); temp $x = 2; }
+    is @seen, [1, 1, 1], 'each C-style `loop` iteration starts from the restored value';
+}
+
+# --- a real `let` judges the ITERATION's own value ---------------------------
+
+{
+    my $x = 1;
+    for 1..2 { let $x = 2; Nil }
+    is $x, 1, 'a `for` iteration yielding an undefined value rolls back a `let`';
+}
+
+{
+    my $x = 1;
+    for 1..2 { let $x = 2; 42 }
+    is $x, 2, 'a `for` iteration yielding a defined value commits a `let`';
+}
+
+{
+    my $x = 1;
+    for 1..2 { let $x = 2 }
+    is $x, 2, 'the `let` assignment is itself a defined tail value, so it commits';
+}
+
+{
+    my $x = 1;
+    my $c = 0;
+    while $c++ < 2 { let $x = 2; Nil }
+    is $x, 1, 'a `while` iteration yielding an undefined value rolls back a `let`';
+}
+
+{
+    my $x = 1;
+    my $c = 0;
+    while $c++ < 2 { let $x = 2; 42 }
+    is $x, 2, 'a `while` iteration yielding a defined value commits a `let`';
+}
+
+{
+    # The iteration's value comes off the value stack, NOT the topic: writing the
+    # topic would clobber the loop variable the iteration runs under.
+    my $x = 1;
+    my @seen;
+    for 1..2 { @seen.push($_); let $x = 2; Nil }
+    is @seen, [1, 2], 'routing the tail value out does not disturb the loop variable';
+    is $x, 1, '...and the `let` still rolls back';
+}
+
+{
+    my $x = 1;
+    for 1..2 { let $x = 2; Nil }
+    is $_.defined, False, 'the enclosing topic is untouched by a `let` loop body';
+}
+
+# --- an iteration that exits early is an UNSUCCESSFUL exit -------------------
+
+{
+    my $x = 1;
+    for 1..3 { temp $x = 2; next if $_ == 2; }
+    is $x, 1, '`next` out of an iteration still restores its `temp`';
+}
+
+{
+    my $x = 1;
+    for 1..2 { temp $x = 2; last }
+    is $x, 1, '`last` out of an iteration still restores its `temp`';
+}
+
+{
+    my $x = 1;
+    for 1..2 { let $x = 2; next }
+    is $x, 1, '`next` is an unsuccessful exit, so it rolls back a `let`';
+}
+
+{
+    my $x = 1;
+    for 1..2 { let $x = 2; last }
+    is $x, 1, '`last` is an unsuccessful exit, so it rolls back a `let`';
+}
+
+{
+    my $x = 1;
+    sub returns-from-loop() { for 1..2 { let $x = 5; return 7 } }
+    is returns-from-loop(), 7, 'a `return` out of a loop body still returns its value';
+    is $x, 1, '...and is an unsuccessful block exit, so it rolls back a `let`';
+}
+
+# --- the save is owned by the body, wherever in it the `temp` sits -----------
+
+{
+    my $x = 1;
+    for 1..2 { if True { temp $x = 2 } }
+    is $x, 1, 'a `temp` in a nested `if` branch is resolved by the loop body';
+}
+
+{
+    my $x = 1;
+    my @seen;
+    for 1..2 { temp $x = 2; { @seen.push($x) } }
+    is @seen, [2, 2], 'a nested bare block still sees the temporized value';
+    is $x, 1, '...and the loop body restores it at the end of the iteration';
+}
+
+# --- a value-collecting `for` collects the value BEFORE the restore ----------
+
+{
+    my $x = 1;
+    my @collected = do for 1..2 { temp $x = 9; $x + 0 };
+    is @collected, [9, 9], 'a collecting `for` yields each iteration its temporized value';
+    is $x, 1, '...and still restores the `temp` per iteration';
+}


### PR DESCRIPTION
Closes #7677.

`let`/`temp` are resolved at the end of the enclosing **block** — `temp` always restores the saved value, `let` restores it unless the block succeeded — and a loop body is a Raku block, so it owes that resolution to every one of its iterations. mutsu gave it to none of them.

```raku
my $k = 1;
for 1..2 { temp $k = 2; }
say $k;                                # raku: 1   mutsu (before): 2
```

The save was not resolved *per iteration* either, so the second iteration observed the first one's temporized value:

```raku
my $j = 1;
for 1..2 { say "in: $j"; temp $j = 2; }
# raku:            in: 1 / in: 1
# mutsu (before):  in: 1 / in: 2
```

`while`, `until`, C-style `loop` and `repeat` diverged identically, and so did `let` (`for 1..2 { let $n = 2; Nil }` left `$n` at 2 where raku rolls it back to 1).

## Root cause

Only three lowerings implemented the resolution: the statement-position bare block and the value-position `do` block, both through `OpCode::LetBlock` (#7635), and routine/method/closure frame teardown together with the `try`/implicit-`CATCH` region (#7646). A loop body is compiled by none of them — `OpCode::ForLoop` / `WhileLoop` / `CStyleLoop` / `RepeatLoop` run their body range directly and take no `let_saves` mark — so a save made inside one survived until some outer block happened to resolve it, or forever.

## The change

The save frame is emitted **inside the loop's own body range**, at its head. That placement is what makes it per-iteration for free: the loop opcodes re-run the range on every pass, so `OpCode::LetBlock` re-executes, re-marks, and resolves what that one iteration recorded. No loop opcode changed, all five loop forms funnel through the two body-compilation helpers the frame lives in, and a body with no `let`/`temp` emits nothing at all — so the overwhelming majority of loops pay nothing for this.

The ticket named the hard part: a real `let` decides from the block's own value whether to roll back, and a loop body is compiled in sink context, so it has no value to offer. The two existing lowerings deliver that value in different ways — the statement block routes its tail statement through the topic, the `do` block leaves it on the value stack — and only the second is available here: **a loop body's topic *is* the loop variable**, so writing it would clobber the binding the iteration runs under. So:

- a body with a real `let` has its tail statement compiled for value (`value_on_stack: true`), and the frame is followed by a `Pop` that keeps the body range stack-balanced;
- a `temp`-only body needs no value at all — `temp` restores unconditionally — and keeps its ordinary sink lowering;
- the value-collecting `for` expression already leaves the iteration's value on the stack, so there the frame is a bracket and nothing else.

The ticket offered a `temp`-only partial fix as the cheap option. It is not enough: `for 1..2 { let $n = 2; Nil }` and its `while` twin need the valued lowering, and the existing `has_real_let_deep` / `LetFrame::needs_value` split already draws exactly the line that keeps it free for everyone else — so this goes straight to the full shape.

An iteration that exits early through `next`, `last` or a `return` out of the enclosing routine is an unsuccessful block exit: the frame's error path restores both kinds of save. Measured against rakudo, which rolls a `let` back on each of the three.

## Verification

Every assertion was measured against `raku` v2026.07 first, and the whole test file passes under rakudo as well as mutsu (28/28 both).

- `cargo fmt --all` — clean.
- `make lint` — all four configurations clean (the wasm32 target needed `rustup target add wasm32-unknown-unknown` in this container first).
- `make test` — `Result: PASS`, 3900 files / 41429 tests, 0 failures.
- `make roast` — the three documented environment-only failures and nothing else, matching `docs/agent-environments.md:115-117` subtest range for subtest range: `6.c/S32-io/file-tests.t` tests 6-8/10 and `S16-filehandles/filetest.t` tests 57-64/69-72/77-80/101-125-odd under `uid 0`, `S32-io/IO-Socket-Async.t` exit 124 "planned 40 ran 17" under the sandboxed network.

## Tests

`t/loop-body-let-resolution.t` (28 assertions) pins the whole matrix: `temp` restored by all five loop forms, the per-iteration property spelled out as the sequence of values successive iterations observe, `let` rolling back on an undefined iteration value and committing on a defined one, the three early-exit routes, a `temp` nested in an `if` branch, the loop variable and the enclosing topic staying undisturbed by the tail-value routing, and the collecting `for` yielding the temporized value while still restoring it. `t/do-block-let-resolution.t` and `t/routine-body-let-resolution.t` — the two lowerings that were already correct — stay green.

## Follow-up

`my @v = do for 1..2 { temp $g = 9; $g }` yields `[1 1]` under rakudo and `[9 9]` under mutsu: rakudo collects the `Scalar` container and reads it after the restore, mutsu collects the value. That is a container-identity/laziness divergence, independent of this fix and unchanged by it in either direction (with the tail decontainerized, `$g + 0`, both give `[9 9]`). Filed separately as #7718.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HrKUTnZAmieC5duPmLyQmd

---
_Generated by [Claude Code](https://claude.ai/code/session_01HrKUTnZAmieC5duPmLyQmd)_