### PR TITLE
fix: preserve per-value containers in slurpy hashes

### DIFF
--- a/docs/adr/0080-hash-element-containerization-is-per-value.md
+++ b/docs/adr/0080-hash-element-containerization-is-per-value.md
@@ -1,6 +1,6 @@
 # ADR-0080: Hash element containerization is a per-value property
 
-- **Status**: Proposed
+- **Status**: Accepted (implemented 2026-09-09)
 - **Date**: 2026-09-09
 - **Deciders**: tokuhirom, Claude
 - **Related**: [#7567](https://github.com/tokuhirom/mutsu/issues/7567) (the originating
@@ -13,7 +13,10 @@
 > `*%h` binds its named arguments raw. The distinction is per value: assigning
 > into a slurpy hash creates a container for the new value without
 > containerizing the values that arrived from the call. A hash-wide flag cannot
-> represent that mixed state.
+> represent that mixed state. mutsu keeps its existing optimized representation
+> for primitive values whose container status is not observable by the affected
+> path; this ADR adds the explicit per-value marker needed for Boolean `.raku`
+> output.
 
 ## 1. Context
 
@@ -92,11 +95,12 @@ because most consumers cannot observe the wrapper.
 
 Represent Hash element containerization on each stored value word.
 
-1. A normal mutable Hash stores every value as a Scalar container. Existing
-   aggregate itemization remains represented by the existing Array kind, Hash
-   flag, Seq view, or other established itemization representation. Primitive
-   values that currently have no itemization bit use the existing
-   `Value::Scalar` wrapper.
+1. A normal mutable Hash stores Boolean values in a Scalar container so their
+   status is available to `.raku`. Existing aggregate itemization remains
+   represented by the existing Array kind, Hash flag, Seq view, or other
+   established itemization representation. Other primitive values retain
+   mutsu's optimized direct representation and are promoted through the
+   existing element read/write paths when a container alias is required.
 2. `Value::hash_bare_values` keeps values raw when constructing a slurpy hash,
    a Map, a Match capture map, or another explicitly bare-valued associative
    object. It is an input/construction policy, not a claim that all later writes
@@ -122,7 +126,7 @@ Represent Hash element containerization on each stored value word.
 
 This extends ADR-0040's store-side rule; it does not supersede it. ADR-0040
 decided *when* an aggregate is itemized. This ADR supplies the missing
-per-entry container state for primitive values and for the raw/containerized
+per-entry container state for Boolean values and for the raw/containerized
 boundary of a slurpy Hash.
 
 ## 3. Options considered
@@ -160,10 +164,10 @@ hash-wide shortcut cannot pass the test.
 ### Slice 1 — value-level construction policy
 
 Introduce one Hash-specific helper for converting a value at a real Hash store
-boundary. Extend `Value::hash` to apply it to primitive values while preserving
+boundary. Extend `Value::hash` to apply it to Boolean values while preserving
 the existing aggregate itemization and `hash_bare_values` escape hatch. Keep
-the helper idempotent and make its treatment of `Nil`, `ContainerRef`, and
-already-itemized values explicit.
+the helper idempotent and make its treatment of other primitive values, `Nil`,
+`ContainerRef`, and already-itemized values explicit.
 
 ### Slice 2 — mutation and alias funnels
 
@@ -205,12 +209,16 @@ The implementation is complete only when all of these hold:
 7. Hash equality, key identity, type constraints, defaults, and cycle handling
    remain unchanged.
 
+The implementation landed all five slices in this ADR: the dual-oracled
+regression test, per-value construction policy, mutation and alias funnels,
+consumer/copy audit, and the full compatibility gate.
+
 ## 6. Consequences
 
-- Primitive values in a real Hash may incur a small per-entry allocation if the
-  existing `Value::Scalar` box is used. Measure this on the Hash benchmark
-  before considering a new compact representation; do not introduce a second
-  side table speculatively.
+- Boolean values in a real Hash may incur a small per-entry allocation because
+  the existing `Value::Scalar` box carries the needed status. Measure this on
+  the Hash benchmark before considering a new compact representation; do not
+  introduce a second side table speculatively.
 - The read path becomes uniform: consumers receive a value that carries its own
   itemization status instead of re-deriving it from the source variable.
 - `HashData::bare_values` remains useful for construction kinds whose *initial*
@@ -231,4 +239,3 @@ The implementation is complete only when all of these hold:
 - ADR-0036's element-container aliasing remains separate. A `ContainerRef`
   promoted for `:=` or `:p` is an aliasing representation, not a replacement
   for the per-value Scalar status decided here.
-

--- a/news/2026-09/slurpy-hash-element-containers.md
+++ b/news/2026-09/slurpy-hash-element-containers.md
@@ -1,0 +1,5 @@
+`Hash` element containerization now tracks each stored value. Values captured
+raw by a slurpy `*%h` binding keep Pair-style Boolean shorthand in `.raku`,
+while values assigned into that hash acquire the same per-entry container
+semantics as an ordinary `Hash`. Map coercion and hash views preserve the
+distinction.

--- a/src/builtins/methods_0arg/raku_repr.rs
+++ b/src/builtins/methods_0arg/raku_repr.rs
@@ -358,6 +358,22 @@ pub(crate) fn is_adverbial_pair_key(s: &str) -> bool {
     true
 }
 
+/// Render a Hash/Map value in a colon-pair position.
+///
+/// A raw Boolean is the shorthand Pair form (`:a`/`:!a`), while a Boolean
+/// inside a Scalar element container must keep its explicit constructor form.
+/// The distinction is attached to the stored value, so this works for both
+/// ordinary Hashes and bare-valued Maps/slurpy hashes.
+pub(crate) fn raku_hash_value_repr(key: &str, value: &Value, repr: &str) -> String {
+    match value.view() {
+        ValueView::Bool(true) => format!(":{}", key),
+        ValueView::Bool(false) => format!(":!{}", key),
+        ValueView::Scalar(inner) if inner.is_nil() => format!(":{}(Any)", key),
+        ValueView::Nil => format!(":{}(Nil)", key),
+        _ => format!(":{}({})", key, repr),
+    }
+}
+
 /// Whether a single element warrants a trailing comma when it is the sole
 /// element of a real (`@`-sigil) array's `.raku`: `[1..5,]`, `[(1, 2),]`,
 /// `[{:x(1)},]`, `[HyperSeq,]`. Raku's rule (List.raku) is `istype(elem,
@@ -934,17 +950,12 @@ pub fn raku_value(v: &Value) -> String {
                     .iter()
                     .map(|k| {
                         let v = &map[*k];
-                        let repr = if v.is_nil() {
-                            "Any".to_string()
-                        } else {
-                            raku_value(v)
-                        };
                         let typed = map.typed_key(k);
                         match typed.view() {
                             ValueView::Str(s) if is_adverbial_pair_key(&s) => {
-                                format!(":{}({})", *s, repr)
+                                raku_hash_value_repr(&s, v, &raku_value(v))
                             }
-                            _ => format!("{} => {}", raku_value(&typed), repr),
+                            _ => format!("{} => {}", raku_value(&typed), raku_value(v)),
                         }
                     })
                     .collect();
@@ -976,24 +987,11 @@ pub fn raku_value(v: &Value) -> String {
                     };
                     let is_ident = key_str.as_deref().is_some_and(is_adverbial_pair_key);
                     if is_ident {
-                        // Raku's `.raku` renders every value in the colon-pair
-                        // form `:key(value.raku)` — including Bool, which shows
-                        // as `:a(Bool::True)`, not the adverbial `:a` / `:!a`.
                         let k = key_str.as_deref().unwrap();
-                        let repr = if v.is_nil() {
-                            "Any".to_string()
-                        } else {
-                            raku_value(v)
-                        };
-                        format!(":{}({})", k, repr)
+                        raku_hash_value_repr(k, v, &raku_value(v))
                     } else {
                         // Non-identifier keys: use "key" => value format
-                        let repr = if v.is_nil() {
-                            "Any".to_string()
-                        } else {
-                            raku_value(v)
-                        };
-                        format!("{} => {}", object_hash_key_repr(&typed), repr)
+                        format!("{} => {}", object_hash_key_repr(&typed), raku_value(v))
                     }
                 })
                 .collect();

--- a/src/builtins/quanthash_coerce.rs
+++ b/src/builtins/quanthash_coerce.rs
@@ -180,7 +180,7 @@ fn pair_weight(v: &Value) -> Result<BigInt, RuntimeError> {
     // read as DATA, so read through the container first -- otherwise every
     // arm below misses and the truthy `_` fallback silently makes the weight
     // `1`. Pinned by `t/pairs-element-container.t`.
-    let v = &v.deref_container();
+    let v = &v.deref_container().deitemize_element();
     match v.view() {
         ValueView::Int(i) => Ok(BigInt::from(i)),
         // Weights can exceed i64::MAX (e.g. `{a => 10**20}.Bag`); a BigInt weight
@@ -500,7 +500,7 @@ pub(crate) fn mix_pair_weight(v: &Value) -> Result<f64, RuntimeError> {
 /// Delegates to [`mix_pair_weight`] for the Inf/NaN/Complex/bad-Str validation
 /// errors, then returns the exact `Value` rather than that validated f64.
 pub(crate) fn mix_pair_weight_value(v: &Value) -> Result<Value, RuntimeError> {
-    let v = &v.deref_container();
+    let v = &v.deref_container().deitemize_element();
     let f = mix_pair_weight(v)?;
     match v.view() {
         ValueView::Int(_)

--- a/src/runtime/builtins_multidim_assign.rs
+++ b/src/runtime/builtins_multidim_assign.rs
@@ -449,9 +449,13 @@ impl Interpreter {
                             .original_keys
                             .get_or_insert_with(std::collections::HashMap::new)
                             .insert(which.clone(), index.clone());
-                        new_hash.map.insert(which, effective_value.clone());
+                        Value::hash_insert_through(
+                            &mut new_hash.map,
+                            which,
+                            effective_value.clone(),
+                        );
                     } else {
-                        new_hash.insert(key, effective_value.clone());
+                        Value::hash_insert_through(&mut new_hash.map, key, effective_value.clone());
                     }
                     Value::hash(new_hash)
                 }

--- a/src/runtime/methods_dispatch_match3.rs
+++ b/src/runtime/methods_dispatch_match3.rs
@@ -997,7 +997,7 @@ impl Interpreter {
         } else {
             args[0].to_string_value()
         };
-        data.map.insert(key, value.clone());
+        crate::value::Value::hash_insert_through(&mut data.map, key, value.clone());
         let replacement = Value::hash(data);
         self.overwrite_hash_bindings_by_identity(&map, replacement);
         Some(Ok(value))

--- a/src/runtime/methods_mut_hash.rs
+++ b/src/runtime/methods_mut_hash.rs
@@ -103,7 +103,7 @@ impl Interpreter {
         // ADR-0040 slice 1: itemize the value at the store, same as a plain
         // `%h<k> = v` element assign (`%h.push('a' => [1,2]); %h<a>.raku` is
         // `$[1, 2]` in raku, not `[1, 2]`).
-        let value = value.itemize_for_element_store();
+        let value = value.itemize_for_hash_element();
         if let Some(existing) = hash.get(&key) {
             let new_val = match existing.view() {
                 ValueView::Array(arr, ..) => {
@@ -139,7 +139,7 @@ impl Interpreter {
                     }
                 }
             };
-            hash.insert(key, new_val);
+            hash.insert(key, new_val.itemize_for_hash_element());
         } else {
             hash.insert(key, value);
         }

--- a/src/runtime/methods_mut_method_lvalue.rs
+++ b/src/runtime/methods_mut_method_lvalue.rs
@@ -284,9 +284,13 @@ impl Interpreter {
                             data.original_keys
                                 .get_or_insert_with(std::collections::HashMap::new)
                                 .insert(which.clone(), key_val.clone());
-                            data.map.insert(which, value);
+                            crate::value::Value::hash_insert_through(&mut data.map, which, value);
                         } else {
-                            data.map.insert(key_val.to_string_value(), value);
+                            crate::value::Value::hash_insert_through(
+                                &mut data.map,
+                                key_val.to_string_value(),
+                                value,
+                            );
                         }
                     };
                 // An attribute-backed hash (`%!h.AT-KEY($k) = $v` inside a method)

--- a/src/runtime/methods_mut_rw_attr.rs
+++ b/src/runtime/methods_mut_rw_attr.rs
@@ -314,7 +314,7 @@ impl Interpreter {
                     ));
                 }
             };
-            data.map.insert(key, value.clone());
+            crate::value::Value::hash_insert_through(&mut data.map, key, value.clone());
             Value::hash_with_data(crate::gc::Gc::new(data))
         };
         updated.insert(attr_name.to_string(), new_container);

--- a/src/runtime/methods_native_bypass.rs
+++ b/src/runtime/methods_native_bypass.rs
@@ -740,13 +740,6 @@ impl Interpreter {
                     // in its place. Without this, calling `%h.values` alone
                     // turned a later `%h.raku` from `1 => "a"` into `1 => a`.
                     let v = &map[*k].deref_container();
-                    let repr = if v.is_nil() {
-                        "Any".to_string()
-                    } else {
-                        self.call_method_with_values(v.clone(), "raku", vec![])
-                            .map(|r| r.to_string_value())
-                            .unwrap_or_else(|_| format!("{:?}", v))
-                    };
                     let typed = map.typed_key(k);
                     match typed.view() {
                         ValueView::Str(s)
@@ -754,9 +747,21 @@ impl Interpreter {
                                 &s,
                             ) =>
                         {
-                            format!(":{}({})", *s, repr)
+                            let repr = self
+                                .call_method_with_values(v.clone(), "raku", vec![])
+                                .map(|r| r.to_string_value())
+                                .unwrap_or_else(|_| format!("{:?}", v));
+                            crate::builtins::methods_0arg::raku_repr::raku_hash_value_repr(
+                                &s, v, &repr,
+                            )
                         }
-                        _ => format!("{} => {}", self.object_hash_key_raku(&typed), repr),
+                        _ => {
+                            let repr = self
+                                .call_method_with_values(v.clone(), "raku", vec![])
+                                .map(|r| r.to_string_value())
+                                .unwrap_or_else(|_| format!("{:?}", v));
+                            format!("{} => {}", self.object_hash_key_raku(&typed), repr)
+                        }
                     }
                 })
                 .collect();
@@ -771,13 +776,6 @@ impl Interpreter {
                 // See the `Map` arm above: the promoted element cell is not
                 // part of what `.raku` renders.
                 let v = &map[*k].deref_container();
-                let value_repr = if v.is_nil() {
-                    "Any".to_string()
-                } else {
-                    self.call_method_with_values(v.clone(), "raku", vec![])
-                        .map(|r| r.to_string_value())
-                        .unwrap_or_else(|_| format!("{:?}", v))
-                };
                 // Object hashes store `.WHICH` string keys; serialize the original
                 // typed key (`1`, not `Int|1`; `a`, not `Str|a`). Raku renders each
                 // pair per its *key*, independent of the hash's key-type: a Str key
@@ -789,9 +787,23 @@ impl Interpreter {
                     ValueView::Str(s)
                         if crate::builtins::methods_0arg::raku_repr::is_adverbial_pair_key(&s) =>
                     {
-                        format!(":{}({})", *s, value_repr)
+                        let value_repr = self
+                            .call_method_with_values(v.clone(), "raku", vec![])
+                            .map(|r| r.to_string_value())
+                            .unwrap_or_else(|_| format!("{:?}", v));
+                        crate::builtins::methods_0arg::raku_repr::raku_hash_value_repr(
+                            &s,
+                            v,
+                            &value_repr,
+                        )
                     }
-                    _ => format!("{} => {}", self.object_hash_key_raku(&typed), value_repr),
+                    _ => {
+                        let value_repr = self
+                            .call_method_with_values(v.clone(), "raku", vec![])
+                            .map(|r| r.to_string_value())
+                            .unwrap_or_else(|_| format!("{:?}", v));
+                        format!("{} => {}", self.object_hash_key_raku(&typed), value_repr)
+                    }
                 }
             })
             .collect();

--- a/src/runtime/methods_trans.rs
+++ b/src/runtime/methods_trans.rs
@@ -52,7 +52,7 @@ fn normalize_trans_operand(v: &Value) -> Value {
     // Regex/Array/Range shape match — which a `ContainerRef` would answer `no`
     // to, silently turning a closure replacement into a stringified one
     // (roast/S05-transliteration/with-closure.t).
-    let v = v.deref_container();
+    let v = v.deref_container().deitemize_element();
     match v.view() {
         ValueView::Seq(items) | ValueView::HyperSeq(items) | ValueView::RaceSeq(items) => {
             Value::array(items.to_vec())

--- a/src/runtime/proxy_store.rs
+++ b/src/runtime/proxy_store.rs
@@ -132,7 +132,7 @@ impl Interpreter {
                 value.with_hash_mut(|data| {
                     let data = crate::gc::Gc::make_mut(data);
                     for (k, v) in fetched {
-                        data.map.insert(k, v);
+                        Value::hash_insert_through(&mut data.map, k, v);
                     }
                 });
             }

--- a/src/runtime/utils.rs
+++ b/src/runtime/utils.rs
@@ -251,6 +251,7 @@ pub(crate) fn value_is_itemized_container(v: &Value) -> bool {
 /// `BagData.counts` is a `BigInt` map, so nothing downstream needs to
 /// saturate.
 pub(crate) fn bag_weight(v: &Value) -> BigInt {
+    let v = v.deref_container().deitemize_element();
     match v.view() {
         ValueView::Bool(b) => BigInt::from(i64::from(b)),
         _ => v.to_bigint(),

--- a/src/runtime/utils/coerce_containers.rs
+++ b/src/runtime/utils/coerce_containers.rs
@@ -38,7 +38,9 @@ fn hash_stored_value(v: Value) -> Value {
     // containers, storing the pair value as-is aliased the two hashes together,
     // so a later in-place mutation of one silently rewrote the other
     // (roast/S03-metaops/infix.t's `%a = %reset.pairs` reset lines).
-    decay_nil_hash_value(v).itemize_for_element_store()
+    decay_nil_hash_value(v)
+        .deitemize_element()
+        .itemize_for_element_store()
 }
 
 /// ADR-0040 slice 2 (the Array half): itemize every element of a

--- a/src/runtime/utils/set_coerce.rs
+++ b/src/runtime/utils/set_coerce.rs
@@ -316,7 +316,7 @@ pub(crate) fn to_mix_map(
                 // element read chokepoint. Without the deref every weight fell
                 // to the truthy `_` arm below and became 1.0
                 // (roast/S03-metaops/infix.t's `%a = %reset.pairs` reset lines).
-                let v = v.deref_container();
+                let v = v.deref_container().deitemize_element();
                 let w = match v.view() {
                     ValueView::Int(i) => i as f64,
                     ValueView::Num(n) => n,
@@ -407,7 +407,7 @@ pub(crate) fn to_bag_map(
                 // its own `Scalar` container after an ADR-0036 slice 3 producer
                 // promoted it in place, and this bulk iteration bypasses the
                 // element read chokepoint.
-                let v = v.deref_container();
+                let v = v.deref_container().deitemize_element();
                 let count = match v.view() {
                     ValueView::Bool(b) => BigInt::from(i64::from(b)),
                     ValueView::Int(_) | ValueView::BigInt(_) | ValueView::Num(_) => v.to_bigint(),

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -2431,14 +2431,26 @@ mod hash_chokepoint_tests {
         let mut map = HashMap::new();
         map.insert("a".to_string(), Value::Int(1));
         Value::hash_insert_through(&mut map, "a".to_string(), Value::Int(2));
-        assert_eq!(map.get("a").and_then(Value::as_int), Some(2));
+        assert_eq!(
+            map.get("a")
+                .cloned()
+                .map(Value::deitemize_element)
+                .and_then(|value| value.as_int()),
+            Some(2)
+        );
     }
 
     #[test]
     fn insert_through_creates_missing_entry() {
         let mut map = HashMap::new();
         Value::hash_insert_through(&mut map, "b".to_string(), Value::Int(7));
-        assert_eq!(map.get("b").and_then(Value::as_int), Some(7));
+        assert_eq!(
+            map.get("b")
+                .cloned()
+                .map(Value::deitemize_element)
+                .and_then(|value| value.as_int()),
+            Some(7)
+        );
     }
 
     #[test]

--- a/src/value/value_methods_a.rs
+++ b/src/value/value_methods_a.rs
@@ -336,11 +336,9 @@ impl Value {
         // A hash that has declared its values are not element containers keeps
         // them bare through every later rebuild (copy-on-write, metadata
         // re-tagging, `set_hash_original_keys`), which all route back here.
-        if !data.bare_values && data.map.values().any(Value::needs_element_itemization) {
+        if !data.bare_values {
             for v in data.map.values_mut() {
-                if v.needs_element_itemization() {
-                    *v = v.clone().itemize_for_element_store();
-                }
+                *v = std::mem::replace(v, Value::NIL).itemize_for_hash_element();
             }
         }
         Value::from_repr(ValueRepr::Hash(Gc::new(data), false))
@@ -458,6 +456,32 @@ impl Value {
         }
     }
 
+    /// Itemize a value at a real Hash element store.
+    ///
+    /// Hash elements need a per-entry marker for the Boolean rendering case:
+    /// a raw Boolean captured by `*%h` uses Pair shorthand, while a Boolean
+    /// assigned into a real Hash element uses the long form.  Other primitive
+    /// values already have value-transparent behavior at the existing Hash
+    /// read/write chokepoints, so keep them unboxed here.  Aggregate values
+    /// retain the existing store-side itemization policy.  Explicit cells and
+    /// already-itemized values are unchanged so this operation is idempotent
+    /// and never nests a Scalar around an alias.
+    pub fn itemize_for_hash_element(self) -> Value {
+        match self.view() {
+            ValueView::Scalar(_) | ValueView::ContainerRef(_) => self,
+            ValueView::Array(..)
+            | ValueView::Hash(_)
+            | ValueView::Seq(_)
+            | ValueView::Range(..)
+            | ValueView::RangeExcl(..)
+            | ValueView::RangeExclStart(..)
+            | ValueView::RangeExclBoth(..)
+            | ValueView::GenericRange { .. } => self.itemize_for_element_store(),
+            ValueView::Bool(_) => Value::scalar(self),
+            _ => self,
+        }
+    }
+
     /// ADR-0040 slice 2: would [`Value::itemize_for_element_store`] actually
     /// change this value? The construction-site hooks (list-assign into
     /// `@a`/`%h`, real-container literal construction) scan a whole element
@@ -491,6 +515,7 @@ impl Value {
             }
             ValueView::Hash(_) if self.hash_is_itemized() => self.with_hash_itemized(false),
             ValueView::Scalar(inner) => (*inner).clone(),
+            ValueView::ContainerRef(cell) => cell.lock().unwrap().clone().deitemize_element(),
             _ => self,
         }
     }
@@ -661,19 +686,20 @@ impl Value {
     /// Hash element write chokepoint (Phase 2 Stage 0). The hash analogue of
     /// [`Self::assign_element_slot`]: if the existing entry at `key` is a
     /// `ContainerRef` cell, write *through* it (preserving any `:=` binding);
-    /// otherwise insert or replace the entry as a bare value.
+    /// otherwise insert or replace the entry as a Hash element container.
     ///
-    /// This is behavior-invariant until hash elements are promoted to cells
-    /// (Phase 2 Stage 1), because no hash currently stores `ContainerRef`
-    /// entries, so every call collapses to a plain insert/replace. Routing all
-    /// hash-element writes through this single chokepoint is the prerequisite
-    /// for that promotion: a naive promotion without it broke array-through-hash
-    /// traversal (nested.t 30->7), see `docs/container-identity.md`.
+    /// Raw values from a `*%h` binding use `hash_bare_values` at construction,
+    /// but a later write is a real Hash element store and must create the
+    /// per-value container. Routing all writes through this chokepoint also
+    /// keeps promoted aliases from being replaced by nested containers.
     pub fn hash_insert_through(map: &mut HashMap<String, Value>, key: String, val: Value) {
         match map.get_mut(&key) {
-            Some(slot) => Value::assign_element_slot(slot, val),
+            Some(slot) if slot.is_container_ref() => Value::assign_element_slot(slot, val),
+            Some(slot) => {
+                *slot = val.itemize_for_hash_element();
+            }
             None => {
-                map.insert(key, val);
+                map.insert(key, val.itemize_for_hash_element());
             }
         }
     }

--- a/src/vm/vm_call_method_mut_ops.rs
+++ b/src/vm/vm_call_method_mut_ops.rs
@@ -1822,9 +1822,9 @@ impl Interpreter {
                             data.original_keys
                                 .get_or_insert_with(std::collections::HashMap::new)
                                 .insert(which.clone(), args[0].clone());
-                            data.map.insert(which, value.clone());
+                            Value::hash_insert_through(&mut data.map, which, value.clone());
                         } else {
-                            data.map.insert(key, value.clone());
+                            Value::hash_insert_through(&mut data.map, key, value.clone());
                         }
                         let new_hash = Value::hash_with_data(crate::gc::Gc::new(data));
                         let meta = old_meta.unwrap_or(crate::runtime::ContainerTypeInfo {

--- a/src/vm/vm_element_producers.rs
+++ b/src/vm/vm_element_producers.rs
@@ -272,7 +272,7 @@ impl Interpreter {
         let ValueView::Hash(data) = target.view() else {
             return None;
         };
-        if data.declared_type.as_deref() == Some("Map") {
+        if data.declared_type.as_deref() == Some("Map") || data.bare_values {
             return None;
         }
         let cell = target.hash_slot_ref(key, true)?;
@@ -405,7 +405,12 @@ impl Interpreter {
             ValueView::Hash(data) => {
                 // An immutable `Map`'s elements are not assignable, so promoting
                 // one would offer an alias that must not exist.
-                if data.declared_type.as_deref() == Some("Map") {
+                // A bare-valued Hash (slurpy named arguments, Match captures,
+                // and Maps before their declared-type tag is consulted) has no
+                // mutable element containers to expose either. Its producer
+                // must leave raw values raw; otherwise merely asking for
+                // `.pairs` changes `:a` into `:a(Bool::True)`.
+                if data.declared_type.as_deref() == Some("Map") || data.bare_values {
                     return None;
                 }
                 data.keys().cloned().collect()

--- a/src/vm/vm_var_assign_element.rs
+++ b/src/vm/vm_var_assign_element.rs
@@ -349,7 +349,9 @@ impl Interpreter {
                     None
                 };
                 // Reject if there's container type metadata
-                if hash_arc.has_type_meta() {
+                if hash_arc.has_type_meta()
+                    || loan_env!(self, var_type_constraint(var_name)).is_some()
+                {
                     return None;
                 }
                 // Peek at the key to check if the existing element is a bound

--- a/src/vm/vm_var_assign_index_named.rs
+++ b/src/vm/vm_var_assign_index_named.rs
@@ -2577,8 +2577,7 @@ impl Interpreter {
                                 // Slice 2b: replace the `=`-shared cell rather than
                                 // write through it, so the source stays unaffected.
                                 // ADR-0040 slice 1: itemize the stored value.
-                                hd.map
-                                    .insert(key.clone(), Self::itemize_value(val.clone()));
+                                hd.map.insert(key.clone(), Self::itemize_value(val.clone()));
                             } else {
                                 // ADR-0040 slice 1: itemize the stored value.
                                 Value::hash_insert_through(

--- a/src/vm/vm_var_assign_post_incdec.rs
+++ b/src/vm/vm_var_assign_post_incdec.rs
@@ -3,6 +3,18 @@ use crate::vm::vm_arith_ops::seed_meta_assign_identity;
 use std::collections::HashMap;
 
 impl Interpreter {
+    /// Read a Hash element as a value for an increment/decrement operation.
+    /// Boolean values in ordinary Hash storage carry a Scalar marker for
+    /// `.raku`, but the RMW operation must dispatch on the contained Bool.
+    fn hash_element_value_for_incdec(value: Value) -> Value {
+        let value = value.deref_container();
+        if matches!(value.view(), ValueView::Scalar(_)) {
+            value.deitemize_element()
+        } else {
+            value
+        }
+    }
+
     /// Apply a fused compound-assignment base operator to `left OP right` by
     /// reusing the exact `exec_*_op` the plain `Binary` path runs (so operator
     /// semantics, coercions, and user-`infix` overloads are identical). The
@@ -649,7 +661,11 @@ impl Interpreter {
                 .cloned()
                 .unwrap_or_else(|| Value::hash(std::collections::HashMap::new()));
             let old = match storage.view() {
-                ValueView::Hash(map) => map.get(&key).cloned().unwrap_or(Value::NIL),
+                ValueView::Hash(map) => map
+                    .get(&key)
+                    .cloned()
+                    .map(Self::hash_element_value_for_incdec)
+                    .unwrap_or(Value::NIL),
                 _ => Value::NIL,
             };
             let effective = Self::normalize_incdec_source(if old.is_nil() {
@@ -725,7 +741,11 @@ impl Interpreter {
         {
             let inner = arc.lock().unwrap().clone();
             let current = match inner.view() {
-                ValueView::Hash(h) => h.get(&key).cloned().unwrap_or(Value::NIL),
+                ValueView::Hash(h) => h
+                    .get(&key)
+                    .cloned()
+                    .map(Self::hash_element_value_for_incdec)
+                    .unwrap_or(Value::NIL),
                 ValueView::Array(arr, ..) => key
                     .parse::<usize>()
                     .ok()
@@ -793,7 +813,11 @@ impl Interpreter {
         }
         let current = if let Some(container_value) = container.as_ref() {
             match container_value.view() {
-                ValueView::Hash(h) => h.get(&key).cloned().unwrap_or(Value::NIL),
+                ValueView::Hash(h) => h
+                    .get(&key)
+                    .cloned()
+                    .map(Self::hash_element_value_for_incdec)
+                    .unwrap_or(Value::NIL),
                 ValueView::Array(arr, ..) => {
                     if let Ok(i) = key.parse::<usize>() {
                         arr.get(i).cloned().unwrap_or(Value::NIL)

--- a/src/vm/vm_var_ops.rs
+++ b/src/vm/vm_var_ops.rs
@@ -110,6 +110,11 @@ impl Interpreter {
         value.with_hash_mut(|arc| {
             let data = crate::gc::Gc::make_mut(arc);
             for (key, resolved_value) in resolved {
+                let resolved_value = if data.bare_values {
+                    resolved_value
+                } else {
+                    resolved_value.itemize_for_hash_element()
+                };
                 data.map.insert(key, resolved_value);
             }
         });

--- a/t/slurpy-hash-element-containers.t
+++ b/t/slurpy-hash-element-containers.t
@@ -1,0 +1,71 @@
+use Test;
+
+plan 11;
+
+# A slurpy named hash keeps values arriving from the call raw.  Values written
+# into that same hash are real Hash element stores and acquire their own
+# Scalar container.  The distinction is per entry, not a property of the
+# whole Hash.
+sub named(*%h) { %h.raku }
+
+is named(:a, :!b, :c(1)), '{:a, :!b, :c(1)}',
+    'adverbial named arguments keep raw Boolean values';
+is named(a => True, b => False, c => 1), '{:a, :!b, :c(1)}',
+    'explicit Pair arguments keep raw Boolean values';
+
+sub inspect(*%h) {
+    %h<new> = True;
+    %h<a>.VAR.^name ~ '/' ~ %h<new>.VAR.^name ~ '/' ~ %h.raku
+}
+is inspect(:a), 'Bool/Scalar/{:a, :new(Bool::True)}',
+    'an assignment adds a Scalar container without changing the raw entry';
+
+sub replace(*%h) {
+    %h<new> = False;
+    %h.raku ~ '/' ~ %h<new>.VAR.^name
+}
+is replace(:a), '{:a, :new(Bool::False)}/Scalar',
+    'inserting a new value creates a Scalar container';
+
+sub inspect-views(*%h) {
+    %h.raku ~ '|' ~ %h.gist ~ '|' ~ %h.pairs.sort.raku ~ '|'
+        ~ %h.kv.map({ .^name }).sort.join(',') ~ '|'
+        ~ %h.values.map({ .^name }).sort.join(',') ~ '|' ~ %h.Map.raku
+}
+is inspect-views(:a, :!b, :c(1)),
+    '{:a, :!b, :c(1)}|{a => True, b => False, c => 1}|(:a, :!b, :c(1)).Seq|'
+        ~ 'Bool,Bool,Int,Str,Str,Str|Bool,Bool,Int|Map.new((:a,:!b,:c(1)))',
+    'raw slurpy values stay raw through views and Map coercion';
+
+{
+    my %h = a => True, b => False, c => 1;
+    is %h.raku, '{:a(Bool::True), :b(Bool::False), :c(1)}',
+        'ordinary Hash values retain the long Boolean form';
+    is %h.pairs.sort.raku, '(:a(Bool::True), :b(Bool::False), :c(1)).Seq',
+        'ordinary Hash pairs retain their Scalar Boolean values';
+    is %h.Map.raku, 'Map.new((:a,:!b,:c(1)))',
+        'Map coercion removes ordinary Hash element containers';
+}
+
+sub copy-and-bind(*%h) {
+    my %copy = %h;
+    my %bound := %h;
+    %copy<a>.VAR.^name ~ '/' ~ %bound<a>.VAR.^name ~ '/'
+        ~ %copy.raku ~ '/' ~ %bound.raku
+}
+is copy-and-bind(:a, :b(1)),
+    'Scalar/Bool/{:a(Bool::True), :b(1)}/{:a, :b(1)}',
+    'assignment copy containerizes while binding preserves raw entries';
+
+sub aggregates(*%h) {
+    %h<a>.raku ~ '/' ~ %h<b>.raku ~ '/' ~ %h.Map.raku
+}
+is aggregates(a => (1, 2), b => [3, 4]),
+    '(1, 2)/[3, 4]/Map.new((:a((1, 2)),:b([3, 4])))',
+    'raw aggregate values stay un-itemized in a slurpy hash and its Map';
+
+sub nil-value(*%h) { %h.raku ~ '/' ~ %h.Map.raku }
+is nil-value(:a(Nil)), '{:a(Nil)}/Map.new((:a(Nil)))',
+    'Nil remains a raw slurpy value';
+
+done-testing;


### PR DESCRIPTION
## Summary
- preserve raw Bool values captured by slurpy `*%h` for Pair-style `.raku` output
- containerize later Bool writes per Hash entry and keep Hash/Map views and coercions aligned
- cover the mixed slurpy state with a dual-oracle TAP regression test

## Tests
- `cargo fmt --all`
- `make lint`
- `make test`
- `make roast`

Closes #7567