### PR TITLE
perf(vm): carry a frame's own env writes across the method-dispatch flatten

### DIFF
--- a/news/2026-09/light-frame-return-merge-survives-the-method-dispatch-flatten.md
+++ b/news/2026-09/light-frame-return-merge-survives-the-method-dispatch-flatten.md
@@ -1,0 +1,111 @@
+# The light-frame return merge survives the method-dispatch flatten
+
+A light-called routine that makes one full method dispatch used to pay a
+scope-sized return merge for the rest of its life, however few names it actually
+wrote. It now pays for its own writes and nothing else: on the ticket's own
+workload the return merge drops from 2530 to 191 instructions per call, and the
+whole loop from 65,533 to 50,666 instructions per iteration. Closes #7630.
+
+## What the flatten took away
+
+`Env::overlay_is_shared_empty()` is the ADR-0004 J4d frame-reuse latch, and the
+scoped overlay it inspects is the reason the light-call unwind is cheap at all:
+a scoped env's overlay *is* the list of names the frame wrote, because a fresh
+tier starts empty and everything else is out of reach in the parent. So
+`finish_positional_light_env` merges what is in the overlay and discards the
+rest, at O(callee writes).
+
+`flatten_scoped_env` — the guard `exec_call_method_op_impl` /
+`exec_call_method_mut_op_impl` run before any dispatch past their fast paths, so
+that a capture or a full-view iteration downstream is not starved of parent
+lexicals — collapses the whole chain into one `parent: None` map. After it,
+"the overlay" and "the whole visible scope" are the same set. The unwind cannot
+tell a callee write from a caller lexical by looking at the map any more, so it
+fell through to `retain_overlay` over everything visible, resolving each
+`Symbol` to a string (`k.with_str(...)`) and asking `cf.is_callee_local_sym`
+about it. The answer stayed correct — a caller lexical is not a callee-local, so
+it survived the retain — but the work was O(scope), and one dispatch put the
+frame in that state permanently: `parent.is_some()` is the latch's first
+condition, and a flattened env can never satisfy it again.
+
+## The fix: the collapse hands the writes forward
+
+The ticket sketched three routes and validated none. The one taken is the first,
+carried all the way: **`Env` records the frame's writes when, and only when,
+the flatten is about to erase them.**
+
+`Env::flattened_for_frame()` — the collapse `flatten_scoped_env` now performs —
+is `flattened()` plus the tier's own key set, kept on the flat env as
+`frame_writes`. Recording it is O(overlay), the same size the merge would have
+been. The ticket's open question was the second half, writes made *after* the
+flatten: those are logged as they happen, because `insert_sym` / `remove_sym` /
+`get_mut_sym` all know the key they are touching and append it. A bulk edit that
+cannot be logged key-by-key (`retain`, `values_mut`, `retain_overlay`) drops the
+log instead of leaving it stale, which costs only the full scan this replaces.
+Every other env carries `None` and pays one predictable branch per write: a
+scoped tier IS its own log, and nothing else has a frame to record.
+
+The three unwinds then read the log where there is one —
+`finish_positional_light_env`, its typed cousin `finish_light_env`, and
+`call_compiled_function_fast`'s scoped-path merge. The reused-frame arm becomes
+`Env::retain_frame_writes`, which replays exactly the `retain_overlay` predicate
+over the logged names and re-logs the survivors for the enclosing frame; the
+swap-path arm walks the log instead of `overlay_iter`, looking each name up in
+the flat map.
+
+The latch itself is untouched: nothing about when a frame may be reused changes,
+only what the unwind knows once the frame's env has been flattened. So this
+needs no ADR — ADR-0004 J4d's scheme is what it restores, not what it replaces.
+
+## Measurements
+
+The ticket's workload, callgrind on the release binary with `MUTSU_JIT=off`, a
+one-iteration run subtracted as the baseline:
+
+```raku
+class C { has $.n; method bump() { $!n = $!n + 1 } }
+sub work($c) { my $a = 1; my $b = 2; $c.bump(); $a + $b }
+my $c = C.new(n => 0);
+for ^2000 { work($c) }
+```
+
+|                                    | before               | after               |
+| ---------------------------------- | -------------------- | ------------------- |
+| `finish_positional_light_env`      | 5,060,000 Ir (3.51%) | 382,000 Ir (0.33%)  |
+| `Symbol::as_str`                   | 15,704,522 (10.88%)  | 3,467,505 (3.03%)   |
+| `CompiledFunction::is_callee_local_sym` | 3,012,000 (2.09%) | 216,000 (0.19%)   |
+| `Env::insert_sym`                  | 3,830,061 (2.65%)    | 1,100,187 (0.96%)   |
+| `Env::flattened_for_frame` (the log itself) | —           | 146,000 (0.13%)     |
+| whole loop, per iteration          | 65,533 Ir            | 50,666 Ir (-22.7%)  |
+
+Per call the merge is 2530 Ir → 191 Ir. The ticket measured that *removing* the
+guard entirely — an unsound kill switch — was worth 70,741 → 48,369 Ir per
+iteration on its box; keeping the guard and handing the writes forward recovers
+essentially the same ground, and the scope is no longer the multiplier.
+
+Instruction counts are deterministic, so both columns are reproducible directly;
+they are local A/B numbers for this change and not a bench-CI series.
+
+## One behavioural difference, in the right direction
+
+The flat-path merge used to apply its "per-frame private name" filter to every
+name the flatten had swept up, which meant a light call whose body dispatched a
+method deleted the *caller's* `?FILE` / `?LINE` from its env along with the
+callee's. Driving the merge from the log means only names the callee actually
+wrote are considered, so the caller keeps its own contextual vars. That is what
+the filter always meant; the flat path just could not express it.
+
+## Pins
+
+- `t/light-frame-latch-across-method-dispatch.t` — 19 assertions on the merge
+  rules with a user-defined method dispatch in every body: a callee-local does
+  not leak and does not clobber the caller's same-named lexical, a captured-outer
+  write reaches the caller whether it happens before or after the dispatch, the
+  topic and `$!` stay per-frame, a closure and a `MY::` lookup made after the
+  dispatch still see the whole frame, and nesting and recursion are unaffected.
+  It passes unchanged under rakudo.
+- Four `src/env.rs` unit tests on the log itself: what
+  `flattened_for_frame` records, that a post-flatten write and removal join it,
+  that `retain_frame_writes` drops only the frame's own names (and leaves the
+  caller's `?FILE` alone), and that a bulk overlay edit drops the log rather than
+  leaving it stale.

--- a/src/env.rs
+++ b/src/env.rs
@@ -471,6 +471,16 @@ pub struct Env {
     depth: u16,
     /// This env's visible `?FILE`, pre-interned — see [`Env::source_file_sym`].
     file_sym: Option<Symbol>,
+    /// The by-name writes this env's **frame tier** has taken since the frame
+    /// opened, recorded only for an env whose tier was collapsed into the flat
+    /// map by [`Self::flattened_for_frame`]. `None` everywhere else — a scoped
+    /// env's overlay *is* that record, so there is nothing to keep beside it.
+    /// See [`Self::flattened_for_frame`].
+    ///
+    /// `Arc` rather than a plain `Vec` so cloning an env (once per light call,
+    /// on the swap path) stays a refcount bump; the log is copy-on-write like
+    /// `inner`.
+    frame_writes: Option<Arc<Vec<Symbol>>>,
 }
 
 /// Maximum overlay chain length before [`Env::scoped_child`] flattens the parent.
@@ -521,6 +531,7 @@ impl Env {
             tombstones: None,
             depth: 0,
             file_sym: None,
+            frame_writes: None,
         }
     }
 
@@ -573,6 +584,7 @@ impl Env {
                     parent: Some(Arc::new(flat)),
                     tombstones: None,
                     file_sym,
+                    frame_writes: None,
                 };
             }
             return Self {
@@ -581,6 +593,7 @@ impl Env {
                 parent: Some(arc),
                 tombstones: None,
                 file_sym,
+                frame_writes: None,
             };
         }
         let parent = if parent.depth >= MAX_OVERLAY_DEPTH {
@@ -594,6 +607,7 @@ impl Env {
             parent: Some(Arc::new(parent)),
             tombstones: None,
             file_sym,
+            frame_writes: None,
         }
     }
 
@@ -657,6 +671,104 @@ impl Env {
             && Arc::ptr_eq(&self.inner, empty_overlay_ref())
     }
 
+    /// The by-name writes this env's frame tier has taken since the frame that
+    /// owns it opened, or `None` when they are not recorded (see
+    /// [`Self::flattened_for_frame`]). May hold a key more than once, and may
+    /// name a key that is no longer present.
+    #[inline(always)]
+    pub(crate) fn frame_writes(&self) -> Option<&[Symbol]> {
+        self.frame_writes.as_ref().map(|w| w.as_slice())
+    }
+
+    /// [`Self::flattened`] for the guard a full method dispatch runs before it
+    /// can capture or iterate the env (`Interpreter::flatten_scoped_env`): the
+    /// result is the same flat env, but it carries the collapsed tier's own
+    /// by-name writes forward as a log.
+    ///
+    /// Why the log exists. The light-call frame-reuse unwind (ADR-0004 J4d) is
+    /// O(callee writes) because a scoped env's overlay *is* the list of writes
+    /// the frame made: everything in it is a callee write and everything else
+    /// is out of reach in the parent tier. Flattening destroys exactly that
+    /// distinction -- afterwards "the overlay" and "the whole visible scope" are
+    /// the same map -- so the unwind fell back to scanning every visible name,
+    /// resolving each `Symbol` to a string and asking `is_callee_local_sym`
+    /// about it. Correct (a caller lexical is not a callee-local, so it
+    /// survives) but O(scope) where O(callee writes) was intended, and one
+    /// method dispatch put a frame in that state for the rest of its life
+    /// (#7630).
+    ///
+    /// Recording the tier's key set here is O(overlay) -- the same size the
+    /// merge itself would have been -- and [`Self::insert_sym`] /
+    /// [`Self::remove_sym`] / [`Self::get_mut_sym`] extend it, so a write made
+    /// *after* the flatten is logged too and the record stays complete. A bulk
+    /// edit that cannot be logged key-by-key (`retain`, `values_mut`,
+    /// `retain_overlay`) drops the log instead, which costs only the full scan
+    /// this replaces.
+    pub(crate) fn flattened_for_frame(&self) -> Self {
+        // Only a scoped env has a frame tier to record: on a flat one `inner` is
+        // already the whole scope, and logging that would claim every caller
+        // lexical as this frame's write.
+        debug_assert!(
+            self.is_scoped(),
+            "flattened_for_frame is the scoped-env collapse; a flat env has no tier to record"
+        );
+        let mut flat = self.flattened();
+        let mut writes: Vec<Symbol> = self.inner.keys().copied().collect();
+        if let Some(tomb) = &self.tombstones {
+            // A `remove` in this tier is a write the frame made too: the unwind
+            // has to consider the name even though the flatten already applied
+            // the tombstone and the key is gone from the merged map.
+            writes.extend(tomb.iter().copied());
+        }
+        flat.frame_writes = Some(Arc::new(writes));
+        flat
+    }
+
+    /// Log a by-name write against [`Self::frame_writes`], for an env that is
+    /// recording them. A no-op (one predictable branch) for every other env,
+    /// which is nearly all of them.
+    #[inline(always)]
+    fn note_frame_write(&mut self, key: Symbol) {
+        if let Some(log) = &mut self.frame_writes {
+            Arc::make_mut(log).push(key);
+        }
+    }
+
+    /// Drop the frame's own by-name writes from a *flattened* env, consulting
+    /// [`Self::frame_writes`] instead of scanning the whole map: the
+    /// [`Self::retain_overlay`] return merge, replayed at O(frame writes) after
+    /// a [`Self::flattened_for_frame`]. `keep` sees each logged key; a key it
+    /// rejects is removed, the rest stay and remain logged for the enclosing
+    /// frame. Does nothing when this env carries no log.
+    ///
+    /// Unlike `retain_overlay` this touches only the names the frame wrote, so
+    /// a caller lexical that merely *looks* like a per-frame private name (a
+    /// `?`-prefixed contextual var of the caller's own, swept up by the flatten)
+    /// is no longer dropped along with the callee's.
+    pub(crate) fn retain_frame_writes(&mut self, mut keep: impl FnMut(Symbol) -> bool) -> bool {
+        // Taken, not borrowed: the `remove_sym` below would otherwise log the
+        // very keys it is removing, and taking it also leaves the `Arc`
+        // uniquely owned so the filter below runs in place with no allocation.
+        let Some(mut writes) = self.frame_writes.take() else {
+            return false;
+        };
+        let log = Arc::make_mut(&mut writes);
+        let mut i = 0;
+        while i < log.len() {
+            let k = log[i];
+            if keep(k) {
+                i += 1;
+            } else {
+                // Order does not matter: the log is a set of names to consider,
+                // read once per unwind.
+                log.swap_remove(i);
+                self.remove_sym(k);
+            }
+        }
+        self.frame_writes = Some(writes);
+        true
+    }
+
     /// Filter this env's overlay in place, keeping only entries `keep` accepts,
     /// and drop any tombstones. When the overlay ends up empty it is reset to
     /// the shared empty singleton so the [`Self::overlay_is_shared_empty`] latch
@@ -671,6 +783,10 @@ impl Env {
         if map.is_empty() {
             self.inner = empty_overlay();
         }
+        // A wholesale filter cannot be logged key-by-key, so the frame-write
+        // record (if any) is dropped rather than left stale -- see
+        // `flattened_for_frame`.
+        self.frame_writes = None;
         self.refresh_file_sym();
     }
 
@@ -693,7 +809,13 @@ impl Env {
             // same "empty tier is not a tier" rule `scoped_child` applies when
             // it chains over an empty parent instead of stacking on it.
             Some(parent) if self.inner.is_empty() && self.tombstones.is_none() => {
-                parent.flattened()
+                let mut flat = parent.flattened();
+                // The collapsed tier is this frame's and the parent's is the
+                // caller's, so a frame-write log the parent happens to carry
+                // describes the wrong frame: drop it. `flattened_for_frame`
+                // installs this env's own (see #7630).
+                flat.frame_writes = None;
+                flat
             }
             Some(_) => {
                 // Collapse the whole chain in ONE pass: clone the flat root
@@ -729,6 +851,10 @@ impl Env {
                     depth: 0,
                     // Flattening preserves every visible value, `?FILE` included.
                     file_sym: self.file_sym,
+                    // The merged map is no longer any one frame's tier;
+                    // `flattened_for_frame` is what records the collapsed tier's
+                    // writes when a light frame needs them (#7630).
+                    frame_writes: None,
                 }
             }
         }
@@ -791,6 +917,7 @@ impl Env {
             tombstones: None,
             depth: 0,
             file_sym,
+            frame_writes: None,
         }
     }
 
@@ -938,6 +1065,7 @@ impl Env {
             RETURN_REBOUND_SEEN.store(true, Ordering::Relaxed);
         }
         self.untombstone(key);
+        self.note_frame_write(key);
         self.cow_mut().insert(key, value)
     }
 
@@ -997,6 +1125,7 @@ impl Env {
         if self.parent.is_none() && !self.inner.contains_key(&key) {
             return None;
         }
+        self.note_frame_write(key);
         let from_overlay = self.cow_mut().remove(&key);
         // Scoped env: if the key still exists in the parent/base tier, record a
         // tombstone so it stops shadowing through. The visible value before
@@ -1048,6 +1177,9 @@ impl Env {
                 self.cow_mut().insert(key, v);
             }
         }
+        // Handing out `&mut` is a write to this key whatever the caller does
+        // with it, so it is logged like an `insert` (see `frame_writes`).
+        self.note_frame_write(key);
         self.cow_mut().get_mut(&key)
     }
 
@@ -1056,6 +1188,9 @@ impl Env {
         F: FnMut(&Symbol, &mut Value) -> bool,
     {
         self.cow_mut().retain(f);
+        // Not loggable key-by-key: drop the frame-write record rather than
+        // leave it stale (see `flattened_for_frame`).
+        self.frame_writes = None;
         self.refresh_file_sym();
     }
 
@@ -1072,6 +1207,9 @@ impl Env {
     }
 
     pub fn values_mut(&mut self) -> std::collections::hash_map::ValuesMut<'_, Symbol, Value> {
+        // Every value in the map is about to be writable and none of the writes
+        // names a key: drop the frame-write record (see `flattened_for_frame`).
+        self.frame_writes = None;
         self.cow_mut().values_mut()
     }
 
@@ -1317,6 +1455,7 @@ impl From<HashMap<String, Value>> for Env {
             tombstones: None,
             depth: 0,
             file_sym,
+            frame_writes: None,
         }
     }
 }
@@ -1331,6 +1470,7 @@ impl From<HashMap<Symbol, Value>> for Env {
             tombstones: None,
             depth: 0,
             file_sym,
+            frame_writes: None,
         }
     }
 }
@@ -1619,5 +1759,82 @@ mod tests {
         }
         // The original root lexical is still reachable through the flattened tiers.
         assert_eq!(env.get_sym(s("root")), Some(&Value::int(42)));
+    }
+
+    #[test]
+    fn flattened_for_frame_carries_the_tier_writes_as_a_log() {
+        // The collapse is what the light-call unwind loses its footing on: after
+        // it, "the overlay" and "the whole visible scope" are one map. The log is
+        // what keeps the frame's own writes distinguishable (#7630).
+        let mut caller = Env::new();
+        caller.insert("caller-lex".into(), Value::int(1));
+        let leaf = scoped_with(caller, &[("mine", 2)]);
+        assert!(
+            leaf.frame_writes().is_none(),
+            "a scoped tier IS its own log"
+        );
+
+        let flat = leaf.flattened_for_frame();
+        assert!(!flat.is_scoped(), "the guard needs a flat env");
+        assert_eq!(flat.get_sym(s("caller-lex")), Some(&Value::int(1)));
+        assert_eq!(flat.frame_writes(), Some(&[s("mine")][..]));
+    }
+
+    #[test]
+    fn a_write_after_the_flatten_is_logged_too() {
+        let mut caller = Env::new();
+        caller.insert("caller-lex".into(), Value::int(1));
+        let mut flat = scoped_with(caller, &[("before", 2)]).flattened_for_frame();
+        flat.insert("after".into(), Value::int(3));
+        flat.remove("gone");
+
+        let logged: Vec<String> = flat
+            .frame_writes()
+            .expect("still recording")
+            .iter()
+            .map(|k| k.resolve())
+            .collect();
+        assert!(logged.contains(&"before".to_string()));
+        assert!(logged.contains(&"after".to_string()));
+        // `remove` of an absent key on a flat env is a no-op, so it is not a write.
+        assert!(!logged.contains(&"gone".to_string()));
+        // The caller lexical the flatten swept in is NOT this frame's write.
+        assert!(!logged.contains(&"caller-lex".to_string()));
+    }
+
+    #[test]
+    fn retain_frame_writes_drops_only_the_frames_own_names() {
+        let mut caller = Env::new();
+        caller.insert("caller-lex".into(), Value::int(1));
+        caller.insert("?FILE".into(), Value::str("outer.raku".to_string()));
+        let mut flat = scoped_with(caller, &[("mine", 2), ("escapes", 3)]).flattened_for_frame();
+
+        let ran = flat.retain_frame_writes(|k| k != "mine");
+        assert!(ran, "a flattened frame env reports its log");
+        // The frame's own local is gone; its captured-outer write stays, and so
+        // does everything the flatten merely swept in from the caller.
+        assert!(flat.get_sym(s("mine")).is_none());
+        assert_eq!(flat.get_sym(s("escapes")), Some(&Value::int(3)));
+        assert_eq!(flat.get_sym(s("caller-lex")), Some(&Value::int(1)));
+        assert_eq!(flat.source_file_sym(), Some(s("outer.raku")));
+        // The kept name is still logged for the enclosing frame.
+        assert_eq!(flat.frame_writes(), Some(&[s("escapes")][..]));
+        // An env that never carried a log says so, and is left alone.
+        let mut plain = scoped_with(Env::new(), &[("x", 1)]);
+        assert!(!plain.retain_frame_writes(|_| false));
+        assert_eq!(plain.get_sym(s("x")), Some(&Value::int(1)));
+    }
+
+    #[test]
+    fn a_bulk_overlay_edit_drops_the_log_rather_than_leaving_it_stale() {
+        let mut caller = Env::new();
+        caller.insert("caller-lex".into(), Value::int(1));
+        let mut flat = scoped_with(caller, &[("mine", 2)]).flattened_for_frame();
+        assert!(flat.frame_writes().is_some());
+        flat.retain(|_, _| true);
+        assert!(
+            flat.frame_writes().is_none(),
+            "a retain cannot be logged key-by-key, so the log must go"
+        );
     }
 }

--- a/src/vm/vm_call_fast.rs
+++ b/src/vm/vm_call_fast.rs
@@ -325,19 +325,36 @@ impl Interpreter {
             // of building a `HashSet<&str>` on every call (see
             // `call_compiled_function_positional_light`).
             let scoped = std::mem::replace(self.env_mut(), caller_env);
-            for (k, v) in scoped.overlay_iter() {
-                // The callee's private topic / arg array / routine-id / `$!` must
-                // not leak to the caller (the caller env already holds its own).
-                if *k == "_"
-                    || *k == "@_"
-                    || *k == "%_"
-                    || *k == "__mutsu_callable_id"
+            // The callee's private topic / arg array / routine-id / `$!` must not
+            // leak to the caller (the caller env already holds its own).
+            let is_callee_private = |k: Symbol| {
+                k == "_"
+                    || k == "@_"
+                    || k == "%_"
+                    || k == "__mutsu_callable_id"
                     || (bang_is_callee_private
                         && k.with_str(crate::runtime::utils::is_routine_scoped_implicit_var))
-                {
-                    continue;
+                    || cf.is_callee_local_sym(k)
+            };
+            // A full method dispatch in the body runs `flatten_scoped_env`, after
+            // which `scoped` is the whole visible scope rather than the callee's
+            // own writes -- so the loop below would walk every caller lexical for
+            // a callee that wrote two names. Drive the merge from the log the
+            // flatten left behind instead (#7630).
+            if let Some(writes) = scoped.frame_writes() {
+                for k in writes {
+                    if is_callee_private(*k) {
+                        continue;
+                    }
+                    if let Some(v) = scoped.overlay_get_sym(*k) {
+                        self.env_mut().insert_sym(*k, v.clone());
+                    }
                 }
-                if !cf.is_callee_local_sym(*k) {
+            } else {
+                for (k, v) in scoped.overlay_iter() {
+                    if is_callee_private(*k) {
+                        continue;
+                    }
                     self.env_mut().insert_sym(*k, v.clone());
                 }
             }

--- a/src/vm/vm_call_light.rs
+++ b/src/vm/vm_call_light.rs
@@ -804,6 +804,25 @@ impl Interpreter {
         caller_env: Option<crate::env::Env>,
     ) {
         let bang_is_callee_private = cf.code.is_routine;
+        // The callee's private topic / arg array / routine id, and the per-frame
+        // contextual vars (`?LINE`/`?FILE`/...), must not propagate to the caller
+        // (which retains its own). Skipping the `?`-prefixed ones also avoids
+        // spurious `env_dirty` churn from the per-statement `?LINE` write on
+        // every recursive call. A `my enum` the callee declared is one of its own
+        // lexicals too, but it gets no local slot, so `is_callee_local_sym` does
+        // not see it and the binding leaked into the caller -- clobbering a
+        // same-named outer symbol for the rest of the program.
+        let is_callee_private = |k: Symbol| {
+            k == "_"
+                || k == "@_"
+                || k == "%_"
+                || k == "__mutsu_callable_id"
+                || k.with_str(|s| s.starts_with('?'))
+                || (bang_is_callee_private
+                    && k.with_str(crate::runtime::utils::is_routine_scoped_implicit_var))
+                || cf.is_callee_local_sym(k)
+                || cf.code.my_declared_enum_sym.contains(&k)
+        };
         match caller_env {
             Some(caller_env) => {
                 // The callee-local test reads the compile-time `Symbol` set
@@ -812,55 +831,58 @@ impl Interpreter {
                 // (a body whose params/locals are all slot-resolved never writes
                 // env), and hashed every local name with SipHash to build it.
                 let scoped = std::mem::replace(self.env_mut(), caller_env);
+                // A full method dispatch in the body flattens the env
+                // (`flatten_scoped_env`), after which `scoped` is the whole
+                // visible scope rather than the callee's own writes -- so the
+                // `overlay_iter` loop below would walk every caller lexical, and
+                // re-insert most of them into the caller's own tier, for a callee
+                // that wrote two names. The flatten leaves the frame's writes
+                // behind as a log; drive the merge from that instead (#7630).
+                if let Some(writes) = scoped.frame_writes() {
+                    for k in writes {
+                        if is_callee_private(*k) {
+                            continue;
+                        }
+                        if let Some(v) = scoped.overlay_get_sym(*k) {
+                            self.env_mut().insert_sym(*k, v.clone());
+                        }
+                    }
+                    return;
+                }
                 for (k, v) in scoped.overlay_iter() {
-                    // The callee's private topic / arg array / routine id, and the
-                    // per-frame contextual vars (`?LINE`/`?FILE`/...), must not
-                    // propagate to the caller (which retains its own). Skipping the
-                    // `?`-prefixed ones also avoids spurious `env_dirty` churn from
-                    // the per-statement `?LINE` write on every recursive call.
-                    if *k == "_"
-                        || *k == "@_"
-                        || *k == "%_"
-                        || *k == "__mutsu_callable_id"
-                        || k.with_str(|s| s.starts_with('?'))
-                        || (bang_is_callee_private
-                            && k.with_str(crate::runtime::utils::is_routine_scoped_implicit_var))
-                    {
+                    if is_callee_private(*k) {
                         continue;
                     }
-                    // A `my enum` the callee declared is one of its own lexicals
-                    // too, but it gets no local slot, so `is_callee_local_sym`
-                    // does not see it and the binding leaked into the caller —
-                    // clobbering a same-named outer symbol for the rest of the
-                    // program.
-                    if !cf.is_callee_local_sym(*k) && !cf.code.my_declared_enum_sym.contains(k) {
-                        self.env_mut().insert_sym(*k, v.clone());
-                    }
+                    self.env_mut().insert_sym(*k, v.clone());
                 }
             }
             None => {
                 // Reused frame: the caller's overlay was the shared empty
                 // singleton at entry, so if the latch is still armed the body
-                // never wrote env — nothing to merge or restore. Otherwise
+                // never wrote env -- nothing to merge or restore. Otherwise
                 // every overlay entry is a write made by this call; replay the
-                // swap path's return merge in place — keep captured-outer
+                // swap path's return merge in place -- keep captured-outer
                 // writes (they are already sitting in the caller's env, which
                 // is where the merge would put them) and drop callee-locals
                 // and the per-frame private names.
+                //
+                // Once a full method dispatch has run `flatten_scoped_env` the
+                // overlay-identity latch is permanently disarmed (the env has no
+                // parent tier any more) and "the overlay" is the whole flattened
+                // scope, so the `retain_overlay` below scanned every visible name
+                // -- correct, since a caller lexical is not a callee-local, but
+                // O(scope) in `Symbol` resolves where O(callee writes) was
+                // intended. `retain_frame_writes` replays the same merge over the
+                // log the flatten left behind, and reports whether there was one
+                // (#7630).
+                if self
+                    .env_mut()
+                    .retain_frame_writes(|k| !is_callee_private(k))
+                {
+                    return;
+                }
                 if !self.env().overlay_is_shared_empty() {
-                    self.env_mut().retain_overlay(|k, _| {
-                        !(*k == "_"
-                            || *k == "@_"
-                            || *k == "%_"
-                            || *k == "__mutsu_callable_id"
-                            || k.with_str(|s| s.starts_with('?'))
-                            || (bang_is_callee_private
-                                && k.with_str(
-                                    crate::runtime::utils::is_routine_scoped_implicit_var,
-                                ))
-                            || cf.is_callee_local_sym(*k)
-                            || cf.code.my_declared_enum_sym.contains(k))
-                    });
+                    self.env_mut().retain_overlay(|k, _| !is_callee_private(*k));
                 }
             }
         }

--- a/src/vm/vm_call_light_typed.rs
+++ b/src/vm/vm_call_light_typed.rs
@@ -738,46 +738,64 @@ impl Interpreter {
     /// original inline code.)
     fn finish_light_env(&mut self, cf: &CompiledFunction, caller_env: Option<crate::env::Env>) {
         let bang_is_callee_private = cf.code.is_routine;
+        let is_callee_private = |k: Symbol| {
+            k == "_"
+                || k == "@_"
+                || k == "%_"
+                || k == "__mutsu_callable_id"
+                || k.with_str(|s| s.starts_with('?'))
+                || (bang_is_callee_private
+                    && k.with_str(crate::runtime::utils::is_routine_scoped_implicit_var))
+                || cf.is_callee_local_sym(k)
+        };
         match caller_env {
             Some(caller_env) => {
                 let scoped = std::mem::replace(self.env_mut(), caller_env);
+                // After a `flatten_scoped_env` in the body, `scoped` is the whole
+                // visible scope rather than the callee's own writes; drive the
+                // merge from the log the flatten left behind instead of walking
+                // every caller lexical (#7630; mirrors
+                // `finish_positional_light_env`).
+                if let Some(writes) = scoped.frame_writes() {
+                    for k in writes {
+                        if is_callee_private(*k) {
+                            continue;
+                        }
+                        if let Some(v) = scoped.overlay_get_sym(*k) {
+                            self.env_mut().insert_sym(*k, v.clone());
+                        }
+                    }
+                    return;
+                }
                 for (k, v) in scoped.overlay_iter() {
-                    if *k == "_"
-                        || *k == "@_"
-                        || *k == "%_"
-                        || *k == "__mutsu_callable_id"
-                        || k.with_str(|s| s.starts_with('?'))
-                        || (bang_is_callee_private
-                            && k.with_str(crate::runtime::utils::is_routine_scoped_implicit_var))
-                    {
+                    if is_callee_private(*k) {
                         continue;
                     }
-                    if !cf.is_callee_local_sym(*k) {
-                        self.env_mut().insert_sym(*k, v.clone());
-                    }
+                    self.env_mut().insert_sym(*k, v.clone());
                 }
             }
             None => {
                 // Reused frame: the caller's overlay was the shared empty
                 // singleton at entry. If the latch is still armed the body
-                // never wrote env — nothing to merge or restore. Otherwise
+                // never wrote env -- nothing to merge or restore. Otherwise
                 // every overlay entry is a write made by this call; replay the
-                // swap path's return merge in place — keep captured-outer
+                // swap path's return merge in place -- keep captured-outer
                 // writes (already sitting in the caller's env) and drop
                 // callee-locals and the per-frame private names.
+                //
+                // A full method dispatch in the body disarms the
+                // overlay-identity latch for good (`flatten_scoped_env` leaves no
+                // parent tier), which turned this into a `retain_overlay` over
+                // the whole flattened scope. `retain_frame_writes` replays the
+                // same merge over the flatten's own log (#7630).
+                if self
+                    .env_mut()
+                    .retain_frame_writes(|k| !is_callee_private(k))
+                {
+                    return;
+                }
                 if !self.env().overlay_is_shared_empty() {
-                    self.env_mut().retain_overlay(|k, _| {
-                        !(*k == "_"
-                            || *k == "@_"
-                            || *k == "%_"
-                            || *k == "__mutsu_callable_id"
-                            || k.with_str(|s| s.starts_with('?'))
-                            || (bang_is_callee_private
-                                && k.with_str(
-                                    crate::runtime::utils::is_routine_scoped_implicit_var,
-                                ))
-                            || cf.is_callee_local_sym(*k))
-                    });
+                    self.env_mut().retain_overlay(|k, _| !is_callee_private(*k));
                 }
             }
         }

--- a/src/vm/vm_env_helpers.rs
+++ b/src/vm/vm_env_helpers.rs
@@ -8,7 +8,12 @@ impl Interpreter {
     #[inline]
     pub(super) fn flatten_scoped_env(&mut self) {
         if self.env().is_scoped() {
-            let flat = self.env().flattened();
+            // `flattened_for_frame`, not `flattened`: collapsing the tier
+            // otherwise erases the one thing the light-call return merge reads --
+            // which names this frame wrote by itself -- and leaves the unwind
+            // scanning the whole flattened scope for the rest of the frame's
+            // life (#7630). Carrying the log forward is O(overlay) to record.
+            let flat = self.env().flattened_for_frame();
             *self.env_mut() = flat;
         }
     }

--- a/t/light-frame-latch-across-method-dispatch.t
+++ b/t/light-frame-latch-across-method-dispatch.t
@@ -1,0 +1,100 @@
+use Test;
+
+# ADR-0004 J4d's light-call frame-reuse latch proves "this frame wrote no env by
+# name" from the shape of its scoped overlay. A full method dispatch runs
+# `flatten_scoped_env` first, which produces a `parent: None` env and so used to
+# disarm that latch for the rest of the frame's life: the return merge then ran
+# over the WHOLE flattened scope instead of over the callee's own writes (#7630).
+# The latch now travels with the env across the flatten, which means the unwind
+# takes a different arm than before for any routine that dispatches a method.
+#
+# These pin the merge rules that arm must keep obeying -- what a callee may leak
+# into its caller and what it must still hand back -- with a full method dispatch
+# (a user-defined method on an instance, which no fast path can answer) somewhere
+# in every body.
+
+plan 19;
+
+class Counter {
+    has $.n is rw;
+    method bump() { $!n = $!n + 1 }
+}
+my $c = Counter.new(n => 0);
+
+# --- a callee-local must not leak, however the frame unwinds ----------------
+my $a = 'caller';
+sub shadowing() { my $a = 'callee'; $c.bump(); $a }
+is shadowing(), 'callee', 'a callee-local shadowing a caller lexical reads its own value';
+is $a, 'caller', 'and does not overwrite the caller lexical after a method dispatch';
+
+sub declaring-fresh() { my $only-here = 'x'; $c.bump(); $only-here }
+is declaring-fresh(), 'x', 'a callee-only local is visible inside the callee';
+nok (try MY::<$only-here>).defined, 'and does not appear in the caller scope';
+
+# --- a captured-outer by-name write must still reach the caller -------------
+my $seen = 0;
+sub writes-outer($v) { $c.bump(); $seen = $v }
+writes-outer(41);
+is $seen, 41, 'a callee write to a captured outer lexical survives the return merge';
+
+my @log;
+sub pushes-outer($v) { $c.bump(); @log.push($v) }
+pushes-outer('a');
+pushes-outer('b');
+is @log.join(','), 'a,b', 'a callee write to a captured outer array survives too';
+
+# ... including when the write happens BEFORE the dispatch, so it sits in the
+# overlay the flatten collapses.
+my $before = 0;
+sub writes-then-dispatches($v) { $before = $v; $c.bump(); $before }
+is writes-then-dispatches(7), 7, 'a write made before the dispatch is readable after it';
+is $before, 7, 'and still reaches the caller';
+
+# --- the per-frame private names stay private -------------------------------
+sub topic-untouched() { $_ = 'callee-topic'; $c.bump(); $_ }
+$_ = 'caller-topic';
+is topic-untouched(), 'callee-topic', 'the callee gets its own topic';
+is $_, 'caller-topic', 'and the caller keeps its own across the merge';
+
+sub bang-private() { $c.bump(); try die 'inner'; $!.Str }
+$! = Nil;
+like bang-private(), /inner/, 'the callee sees its own $!';
+nok $!.defined, 'and the caller keeps its own $! after the merge';
+
+# --- the whole lexical view must survive the flatten ------------------------
+sub capture-after-dispatch() {
+    my $outer = 41;
+    $c.bump();
+    my $add = sub { $outer + 1 };
+    $add();
+}
+is capture-after-dispatch(), 42, 'a closure created after a dispatch still sees the frame lexicals';
+
+sub stash-after-dispatch() {
+    my $here = 7;
+    $c.bump();
+    MY::<$here>;
+}
+is stash-after-dispatch(), 7, 'MY:: after a dispatch still resolves the frame lexical';
+
+# --- nesting and recursion --------------------------------------------------
+sub inner-call($n) { $c.bump(); $n * 2 }
+sub outer-call($n) { my $t = inner-call($n); $c.bump(); $t + 1 }
+is outer-call(5), 11, 'a light call nested inside a dispatching frame returns its own value';
+
+sub countdown($n) { $c.bump(); $n <= 0 ?? 0 !! $n + countdown($n - 1) }
+is countdown(4), 10, 'recursion through a dispatching frame is unaffected';
+
+# --- the dispatch really is a dispatch, not something a fast path answered ---
+my $n0 = $c.n;
+shadowing();
+is $c.n, $n0 + 1, 'the dispatch inside a light-called frame really runs the method body';
+
+# --- the workload the ticket measured still computes ------------------------
+class C2 { has $.n is rw; method bump() { $!n = $!n + 1 } }
+sub work($o) { my $x = 1; my $y = 2; $o.bump(); $x + $y }
+my $c2 = C2.new(n => 0);
+my $sum = 0;
+for ^20 { $sum += work($c2) }
+is $sum, 60, 'the measured workload returns the same sum';
+is $c2.n, 20, 'and mutated the receiver once per iteration';


### PR DESCRIPTION
Closes #7630

## What the flatten took away

The light-call return merge is O(callee writes) only because a scoped env's overlay **is** the list of names the frame wrote: a fresh tier starts empty, and everything else is out of reach in the parent. `flatten_scoped_env` — the guard `exec_call_method_op_impl` / `exec_call_method_mut_op_impl` run before any dispatch past their fast paths — collapses the chain into one `parent: None` map, and afterwards "the overlay" and "the whole visible scope" are the same set. The unwind could no longer tell a callee write from a caller lexical by looking at the map, so it fell through to `retain_overlay` over everything visible, resolving each `Symbol` to a string (`k.with_str(...)`) and asking `cf.is_callee_local_sym` about it. Still correct — a caller lexical is not a callee-local, so it survived — but O(scope), and `parent.is_some()` is the latch's first condition, so one dispatch left a frame in that state for the rest of its life.

## The fix

Record the tier's own writes at the moment the flatten would erase them.

- `Env::flattened_for_frame()` is `flattened()` plus the collapsed tier's key set (plus its tombstones), kept on the flat env as `frame_writes`. Recording it is O(overlay) — the size the merge itself would have been. `flatten_scoped_env` calls this instead of `flattened`.
- The ticket's open question was the second half, writes made *after* the flatten. Those are logged as they happen: `insert_sym` / `remove_sym` / `get_mut_sym` all know the key they touch and append it, so the record stays complete. A bulk edit that cannot be logged key-by-key (`retain`, `values_mut`, `retain_overlay`) drops the log instead of leaving it stale, which costs only the full scan this replaces.
- Every env that never carried a frame keeps `None` and pays one predictable branch per write — a scoped tier IS its own log, and nothing else has a frame to record.
- The three unwinds read the log where there is one: `finish_positional_light_env`, its typed cousin `finish_light_env`, and `call_compiled_function_fast`'s scoped-path merge. The reused-frame arm becomes `Env::retain_frame_writes`, which replays the same predicate over the logged names and re-logs the survivors for the enclosing frame; the swap-path arms walk the log instead of `overlay_iter`.

Nothing about **when** a frame may be reused changes — only what the unwind knows once the env has been flattened. ADR-0004 J4d's scheme is restored, not replaced, so no new ADR is due.

## Measurements

The ticket's own workload, callgrind on the release binary with `MUTSU_JIT=off`, a one-iteration run subtracted as the baseline. Both columns are local A/B numbers for this change (instruction counts are deterministic), not a bench-CI series.

```raku
class C { has $.n; method bump() { $!n = $!n + 1 } }
sub work($c) { my $a = 1; my $b = 2; $c.bump(); $a + $b }
my $c = C.new(n => 0);
for ^2000 { work($c) }
```

|                                         | before               | after              |
| --------------------------------------- | -------------------- | ------------------ |
| `finish_positional_light_env`           | 5,060,000 Ir (3.51%) | 382,000 Ir (0.33%) |
| `Symbol::as_str`                        | 15,704,522 (10.88%)  | 3,467,505 (3.03%)  |
| `CompiledFunction::is_callee_local_sym` | 3,012,000 (2.09%)    | 216,000 (0.19%)    |
| `Env::insert_sym`                       | 3,830,061 (2.65%)    | 1,100,187 (0.96%)  |
| `Env::flattened_for_frame` (the log)    | —                    | 146,000 (0.13%)    |
| whole loop, per iteration               | 65,533 Ir            | 50,666 Ir (-22.7%) |

Per call the merge is 2530 Ir → 191 Ir. The ticket measured that *removing* the guard entirely — an unsound kill switch — was worth 70,741 → 48,369 Ir per iteration on its box; keeping the guard and handing the writes forward recovers essentially the same ground, and the scope is no longer the multiplier.

## One behavioural difference, in the right direction

The flat-path merge used to apply its "per-frame private name" filter to every name the flatten had swept up, so a light call whose body dispatched a method deleted the **caller's** `?FILE` / `?LINE` from its env along with the callee's. Driving the merge from the log means only names the callee actually wrote are considered, so the caller keeps its own contextual vars. That is what the filter always meant; the flat path just could not express it.

## Pins

- `t/light-frame-latch-across-method-dispatch.t` — 19 assertions on the merge rules, with a user-defined method dispatch in every body: a callee-local does not leak and does not clobber the caller's same-named lexical, a captured-outer write reaches the caller whether it happens before or after the dispatch, the topic and `$!` stay per-frame, a closure and a `MY::` lookup made after the dispatch still see the whole frame, and nesting and recursion are unaffected. It passes unchanged under rakudo (2026.07).
- Four `src/env.rs` unit tests on the log itself: what `flattened_for_frame` records, that a post-flatten write and removal join it, that `retain_frame_writes` drops only the frame's own names (and leaves the caller's `?FILE` alone), and that a bulk overlay edit drops the log rather than leaving it stale.

## Verification

- `make test` — `Files=3900, Tests=41420 … Result: PASS` (plus `cargo test`'s 1039 unit tests).
- `make roast` — `Files=1436, Tests=218939`. The only failures are the three documented container-only ones in `docs/agent-environments.md`, matching its listed test numbers exactly: `6.c/S32-io/file-tests.t` and `S16-filehandles/filetest.t` (this container runs as `uid 0`, so the `chmod`-based assertions are meaningless) and `S32-io/IO-Socket-Async.t` (sandboxed network).
- `cargo clippy --all-targets -- -D warnings` reports nothing in any file this PR touches. (The toolchain available here is 1.98, newer than CI's, and it raises pre-existing lints in ~35 untouched files.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BiCnKJMXfk5qjG5Et76BeG

---
_Generated by [Claude Code](https://claude.ai/code/session_01BiCnKJMXfk5qjG5Et76BeG)_