### PR TITLE
perf: memoize the Real/Numeric native-dispatch probe per receiver class

### DIFF
--- a/news/2026-09/numeric-bridge-probe-memoized-per-class.md
+++ b/news/2026-09/numeric-bridge-probe-memoized-per-class.md
@@ -1,0 +1,61 @@
+# The Real/Numeric native-dispatch probe is memoized per class
+
+Before it will decline a method, `try_native_method_raw` asks of **every**
+instance receiver whether that receiver must route through the interpreter's
+Numeric bridge: does it match `Real`, or `Numeric`, or does its class provide a
+`Bridge` method? Asked inline, that was two full `type_matches_value` walks per
+instance method call — each one walking the receiver class's MRO *and* the
+transitive closure of its composed roles — plus a method lookup. On the
+`Buf.push` loop in #7712 that single call site dominated the profile, and
+nothing about it was `Buf`-specific: the probe runs for any instance receiver
+whose class `is_native_method` declines.
+
+The probe's answer is a property of the **class**, not of the call. Given a
+fixed registry, "does an instance of `C` match `Real`/`Numeric`, or have a
+`Bridge` method" cannot differ between two calls with the same receiver class,
+so it wants memoizing per class symbol. The obstacle #7712 named was
+invalidation, not the cache: the answer is derived from `registry.classes`
+(parents and MRO), `registry.class_composed_roles`, `registry.role_parents` and
+`registry.subsets`, and `Registry::method_generation` covers none of them. A
+hand-enumerated invalidation list over the ~30 sites that mutate those five
+maps is exactly the "correct only under an incomplete static analysis" shape
+CLAUDE.md rules out — a site missed today, or added next month, would not fail
+loudly, it would silently serve a wrong type answer.
+
+**The choke point turned out to already exist.** All five maps live behind
+`Interpreter::registry_mut()`, the sole write path to the shared
+`Arc<RwLock<Arc<Registry>>>`, and that accessor already bumps
+`registry_write_gen` on *acquisition* — a counter several resolution caches
+(regex code parsing, routine resolution) consult for exactly this reason. Keying
+the memo on it is sound *by construction* rather than by enumeration: a registry
+write that does not bump the generation is not expressible, so a mutation site
+added later is covered with no edit to the cache. It over-invalidates — a
+method-table write drops type-relation answers too — which costs one rewalk per
+class per registry write and never a wrong answer.
+
+Two things the generation deliberately does not cover are handled explicitly in
+`src/runtime/numeric_bridge_probe.rs`:
+
+- A user `subset Real` / `subset Numeric` shadowing the builtin name makes the
+  probe run a `where` predicate. That is user code, whose side effects roast
+  counts (`S12-subset/subtypes.t`) and whose answer may legitimately differ
+  between two calls, so the memo switches itself off entirely while either name
+  is shadowed.
+- "The answer depends only on the class" is a property of `type_matches_value`'s
+  instance arms, not of the registry, and no generation can police it. Debug
+  builds therefore re-derive the answer on every cache hit and assert it matches
+  the memoized one, so a future arm that starts reading the *instance* fails
+  loudly instead of silently serving a stale answer — the loud-failure property
+  the hand-enumerated route could not offer. `make test` drives `t/` with the
+  release binary, so the tripwire costs CI nothing; the whole suite was run
+  against `target/debug/mutsu` with it armed (3902 files, 41466 tests, green)
+  as evidence for the class-only property it guards.
+
+`t/numeric-bridge-probe-memo.t` pins both halves: a class that reaches `Real`
+directly, through a composed role and through a parent keeps bridging on every
+call (not just the first), a plain neighbour class does not acquire a `Bridge`
+from the memo, and a `Bridge` method added by a runtime `augment` — after the
+class has already been probed and cached — is still seen.
+
+The speedup itself is recorded by the bench CI row for the merge commit; see
+#7712 for the callgrind attribution that motivated the work.

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -602,6 +602,7 @@ pub(crate) mod nativecall_callback;
 pub(crate) mod nativecall_cast;
 pub(crate) mod nativecall_global;
 pub(crate) mod nativecall_manage;
+mod numeric_bridge_probe;
 pub(crate) mod once_store;
 mod ops_bits;
 mod ops_compare;
@@ -1986,6 +1987,10 @@ pub struct Interpreter {
     /// checked". `AtomicU64` (not `Cell`) so `Interpreter` stays `Send`/`Sync` —
     /// `registry_mut()` takes `&self`.
     registry_write_gen: std::sync::atomic::AtomicU64,
+    /// Per-class memo of the native-dispatch numeric-bridge probe, keyed by the
+    /// `registry_write_gen` above. See [`numeric_bridge_probe`] for why that
+    /// generation is a sound invalidation key (#7712).
+    numeric_bridge_probe: numeric_bridge_probe::NumericBridgeProbeCache,
     /// Active `{*}` proto dispatch frames: (proto_name, args, method_ctx).
     /// `method_ctx` is `Some` when the active proto is a `proto method` body, so
     /// `{*}` redispatches to a multi *method* candidate on the invocant rather

--- a/src/runtime/numeric_bridge_probe.rs
+++ b/src/runtime/numeric_bridge_probe.rs
@@ -1,0 +1,125 @@
+//! Memoized "does an instance of this class need the interpreter's Numeric
+//! bridge?" probe (#7712).
+//!
+//! `try_native_method_raw` asks this of **every** instance receiver before it
+//! will decline a method, and the question is three type-graph walks deep:
+//! `Real`, then `Numeric` (each walking the class's MRO *and* the transitive
+//! closure of its composed roles), then a `Bridge` method lookup. On a
+//! `Buf.push` loop those two `type_matches_value` walks alone were 52% of the
+//! whole program.
+//!
+//! The answer is a property of the **class**, not of the call: given a fixed
+//! registry, "does an instance of `C` match `Real`/`Numeric`, or have a
+//! `Bridge` method" cannot vary between two calls with the same receiver
+//! class. So it memoizes per class symbol — the only real question is
+//! invalidation.
+//!
+//! **The choke point already exists.** The answer is derived from
+//! `registry.classes` (parents + MRO), `registry.class_composed_roles`,
+//! `registry.role_parents` and `registry.subsets`, none of which
+//! `Registry::method_generation` covers. But every one of those maps lives
+//! behind `Interpreter::registry_mut()` — the sole write path to the shared
+//! `Arc<RwLock<Arc<Registry>>>` — and that accessor already bumps
+//! `registry_write_gen` on *acquisition*. Keying the cache on
+//! [`Interpreter::registry_write_generation`] is therefore sound *by
+//! construction* rather than under an enumeration of mutation sites: a
+//! registry write that does not bump it is not expressible, so a mutation site
+//! added later is covered with no edit here. It over-invalidates (a
+//! method-table write drops type-relation answers too), which costs one rewalk
+//! per class per registry write and never a wrong answer.
+//!
+//! Two things the generation deliberately does not cover, handled explicitly:
+//!
+//! * A user `subset Real`/`subset Numeric` shadowing the builtin name makes the
+//!   probe run a `where` predicate — user code, whose side effects roast counts
+//!   (`S12-subset/subtypes.t`) and whose answer may differ per call. The cache
+//!   switches itself off entirely while either name is shadowed.
+//! * "The answer depends only on the class" is a property of
+//!   `type_matches_value`'s instance arms, not of the registry. Debug builds
+//!   therefore re-derive the answer on every cache hit and assert it matches,
+//!   so a future arm that reads the *instance* fails loudly instead of
+//!   silently serving a stale answer. `make test` runs `t/` against the
+//!   *release* binary, so the tripwire costs CI nothing there; run the suite
+//!   against `target/debug/mutsu` to exercise it
+//!   (`MUTSU_BIN=target/debug/mutsu prove -e scripts/run-t-test.sh t/`).
+
+use crate::runtime::Interpreter;
+use crate::symbol::Symbol;
+use crate::value::Value;
+use std::collections::HashMap;
+
+/// Per-class memo of the native-dispatch numeric-bridge probe. See the module
+/// docs for why keying on the registry write generation is sound.
+#[derive(Default, Clone)]
+pub(crate) struct NumericBridgeProbeCache {
+    /// class symbol -> probe answer, valid only at [`Self::generation`].
+    answers: HashMap<Symbol, bool>,
+    /// The `registry_write_gen` `answers` was built under; `None` until the
+    /// first probe.
+    generation: Option<u64>,
+    /// `Real` or `Numeric` is shadowed by a user `subset` at
+    /// [`Self::generation`] — the probe runs user code, so nothing is cached.
+    subset_shadowed: bool,
+}
+
+impl Interpreter {
+    /// Whether an instance of `class_name` must decline the pure-native fast
+    /// path in favour of the interpreter's Numeric bridge: it matches `Real`
+    /// or `Numeric`, or its class provides a `Bridge` method.
+    ///
+    /// `target` must be the receiver whose `ValueView::Instance` supplied
+    /// `class_name`; it is what the underlying `type_matches_value` walks (and,
+    /// in debug builds, what the cache is verified against).
+    pub(crate) fn instance_needs_numeric_bridge(
+        &mut self,
+        class_name: Symbol,
+        target: &Value,
+    ) -> bool {
+        let generation = self.registry_write_generation();
+        if self.numeric_bridge_probe.generation != Some(generation) {
+            self.numeric_bridge_probe.answers.clear();
+            self.numeric_bridge_probe.generation = Some(generation);
+            self.numeric_bridge_probe.subset_shadowed = {
+                let registry = self.registry();
+                registry.subsets.contains_key("Real") || registry.subsets.contains_key("Numeric")
+            };
+        }
+        if self.numeric_bridge_probe.subset_shadowed {
+            return self.compute_numeric_bridge_probe(class_name, target);
+        }
+        let cached = self.numeric_bridge_probe.answers.get(&class_name).copied();
+        if let Some(cached) = cached {
+            #[cfg(debug_assertions)]
+            {
+                let fresh = self.compute_numeric_bridge_probe(class_name, target);
+                assert_eq!(
+                    cached,
+                    fresh,
+                    "numeric-bridge probe is not a function of the receiver class alone: \
+                     class `{}` cached {cached} but re-derived {fresh} with no registry write \
+                     in between. A `type_matches_value` arm now reads the instance; the memo in \
+                     `numeric_bridge_probe.rs` must gate on that shape (see #7712).",
+                    class_name.as_str(),
+                );
+            }
+            return cached;
+        }
+        let answer = self.compute_numeric_bridge_probe(class_name, target);
+        // The walk itself may have taken a registry write guard (an MRO cache
+        // fill goes through `registry_mut()`), which bumps the generation the
+        // entry would be filed under. Publish only when it did not, so an entry
+        // is never keyed to a generation it was not computed at.
+        if self.registry_write_generation() == generation {
+            self.numeric_bridge_probe.answers.insert(class_name, answer);
+        }
+        answer
+    }
+
+    /// The un-memoized probe: the three questions `try_native_method_raw` used
+    /// to ask inline.
+    fn compute_numeric_bridge_probe(&mut self, class_name: Symbol, target: &Value) -> bool {
+        self.type_matches_value("Real", target)
+            || self.type_matches_value("Numeric", target)
+            || self.has_user_method(class_name.as_str(), "Bridge")
+    }
+}

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -2993,6 +2993,7 @@ impl Interpreter {
                 Self::shared_builtin_registry()
             })),
             registry_write_gen: std::sync::atomic::AtomicU64::new(0),
+            numeric_bridge_probe: Default::default(),
             proto_dispatch_stack: Vec::new(),
             pending_dispatch_error: None,
             skip_postcircumfix_overload: false,

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -629,6 +629,7 @@ impl Interpreter {
             // side writes the registry, the deep clone (and its drop) never happens.
             registry: Arc::new(RwLock::new(Arc::clone(&self.registry.read().unwrap()))),
             registry_write_gen: std::sync::atomic::AtomicU64::new(0),
+            numeric_bridge_probe: Default::default(),
             proto_dispatch_stack: Vec::new(),
             pending_dispatch_error: None,
             skip_postcircumfix_overload: false,

--- a/src/vm/vm_native_dispatch.rs
+++ b/src/vm/vm_native_dispatch.rs
@@ -341,10 +341,16 @@ impl Interpreter {
                     "gist" | "Str" | "Stringy" | "raku" | "perl"
                 );
                 let render_overridden = is_pure_render && self.has_user_method(&cn, &method_name);
+                // The probe (`~~ Real`, `~~ Numeric`, own `Bridge` method)
+                // is a property of the receiver's CLASS, not of the call, so
+                // it is memoized per class symbol. Asked inline it made two
+                // full `type_matches_value` walks -- each over the class MRO
+                // *and* the transitive closure of its composed roles -- 52% of
+                // a `Buf.push` loop. The memo is keyed on the registry write
+                // generation, bumped by the registry's sole write path, so no
+                // enumeration of mutation sites can go stale (#7712).
                 if (!is_pure_render || render_overridden)
-                    && (self.type_matches_value("Real", target)
-                        || self.type_matches_value("Numeric", target)
-                        || self.has_user_method(&cn, "Bridge"))
+                    && self.instance_needs_numeric_bridge(class_name, target)
                 {
                     return None;
                 }

--- a/t/numeric-bridge-probe-memo.t
+++ b/t/numeric-bridge-probe-memo.t
@@ -1,0 +1,72 @@
+use v6;
+use Test;
+
+plan 12;
+
+# `try_native_method_raw` asks, of every instance receiver, whether it must
+# decline the pure-native fast path in favour of the interpreter's Numeric
+# bridge: does the receiver match `Real` or `Numeric`, or does its class provide
+# a `Bridge` method? That probe is now MEMOIZED per receiver class, keyed on the
+# registry write generation (#7712) — two full type-graph walks per instance
+# method call were 52% of a `Buf.push` loop.
+#
+# The memo is only correct while two things hold, and this file pins both:
+#
+#   1. the answer is a property of the CLASS, so a class that does `Real` (or
+#      reaches it through a role, or through inheritance) must keep bridging on
+#      every call, not just the first;
+#   2. anything that could change the answer goes through a registry write, and
+#      a registry write invalidates the memo — so a `Bridge` method (or a whole
+#      numeric class) that only exists *after* the class was already probed must
+#      still be seen.
+
+# --- 1. a class that does Real bridges, repeatedly -------------------------
+
+class Temp does Real {
+    has $.deg;
+    method Bridge { $!deg.Num }
+}
+
+my $t = Temp.new(deg => 3);
+is $t + 1, 4, 'Real-role instance bridges for arithmetic';
+is $t.Int, 3, 'Real-role instance bridges for .Int';
+is $t.Int, 3, '... and again, off the memoized probe';
+is $t.abs, 3, '... and for a Cool-only numeric method';
+ok $t < 4, 'Real-role instance bridges for comparison';
+
+# A SECOND instance of the same class takes the memo hit rather than the walk.
+my $t2 = Temp.new(deg => 7);
+is $t2.Int, 7, 'a second instance of the same class bridges identically';
+
+# --- 2. the answer reaches Real through a role and through inheritance -----
+
+role Scaled does Real {
+    has $.raw;
+    method Bridge { $!raw.Num * 2 }
+}
+class Doubled does Scaled { }
+is Doubled.new(raw => 4).Int, 8, 'Real reached through a composed role bridges';
+
+class Warmer is Temp { }
+is Warmer.new(deg => 9).Int, 9, 'Real reached through a parent class bridges';
+
+# A plain class next to them is NOT numeric, and stays that way — the memo is
+# per class, so a numeric neighbour must not leak into it.
+class Plain { has $.n }
+my $p = Plain.new(n => 5);
+is $p.n, 5, 'a plain class keeps working as a plain class';
+nok (try $p.Int).defined, 'a plain class does not acquire a Bridge from its neighbours';
+
+# --- 3. a registry write after the class was probed invalidates the memo ---
+
+# `Late` is probed here (no Bridge, not Real) and the answer memoized...
+class Late { has $.n }
+my $l = Late.new(n => 5);
+is $l.n, 5, 'the pre-augment probe runs and is memoized';
+
+# ... and then `augment` adds the `Bridge` that flips the answer. `augment`
+# writes the registry, which bumps the write generation the memo is keyed on, so
+# the stale `false` must not survive. EVAL keeps the augment at RUNTIME, after
+# the probe above has already cached.
+EVAL 'use MONKEY-TYPING; augment class Late { method Bridge { self.n.Num } }';
+is $l.Int, 5, 'a Bridge added after the class was probed invalidates the memo';


### PR DESCRIPTION
Closes #7712

## The change

`try_native_method_raw` asked, of **every** instance receiver, whether it must decline the pure-native fast path in favour of the interpreter's Numeric bridge:

```rust
if (!is_pure_render || render_overridden)
    && (self.type_matches_value("Real", target)
        || self.type_matches_value("Numeric", target)
        || self.has_user_method(&cn, "Bridge"))
```

Two full `type_matches_value` walks per instance method call — each over the receiver class's MRO *and* the transitive closure of its composed roles. That call site dominated the profile of the issue's `Buf.push` repro, and nothing about it is `Buf`-specific.

The answer is a property of the **class**, not of the call, so it is now memoized per class symbol in `src/runtime/numeric_bridge_probe.rs`.

## Why the invalidation is sound (the part #7712 called a refactor)

The issue's blocker was invalidation, not the cache: the answer is derived from `registry.classes` (parents + MRO), `registry.class_composed_roles`, `registry.role_parents` and `registry.subsets`, `Registry::method_generation` covers none of them, and hand-enumerating the ~30 sites that mutate those five `pub(crate)` maps is exactly the "correct only under an incomplete static analysis" shape CLAUDE.md rules out. It proposed refactoring `Registry`'s field visibility to build a `type_relation_generation` choke point first.

**That choke point already exists.** All five maps live behind `Interpreter::registry_mut()` — the sole write path to the shared `Arc<RwLock<Arc<Registry>>>` (no `registry.write()` call sites exist outside it) — and that accessor already bumps `registry_write_gen` on *acquisition*, for the benefit of the regex-parse and routine-resolution caches. Keying the memo on `registry_write_generation()` is therefore sound **by construction** rather than by enumeration: a registry write that does not bump the generation is not expressible, so a mutation site added later is covered with no edit to the cache. It over-invalidates (a method-table write drops type-relation answers too), which costs one rewalk per class per registry write and never a wrong answer. No `Registry` refactor was needed.

Two things the generation deliberately does not cover are handled explicitly:

- A user `subset Real` / `subset Numeric` makes the probe run a `where` predicate — user code, whose side effects roast counts (`S12-subset/subtypes.t`) and whose answer may legitimately differ between calls. The memo switches itself off entirely while either name is shadowed.
- "The answer depends only on the class" is a property of `type_matches_value`'s instance arms, not of the registry, and no generation can police it. Debug builds re-derive the answer on every cache hit and assert it matches the memoized one, so a future arm that starts reading the *instance* fails loudly instead of silently serving a stale answer — the loud-failure property the hand-enumerated route could not offer.

Also considered and not needed: alternative 1 in the issue (folding `Real` into `Numeric`) would have halved the cost of a walk that now runs once per class instead of once per call, and proving it over the whole value-shape matrix is risk with no remaining payoff.

## Measurements

Local A/B on this container (4 cores), release build, same binary pair for both rows. `callgrind` instruction counts are deterministic; the bench CI row for the merge commit is the number of record.

`my $big = Buf.new(1 xx 1000); for ^2000 { $big.push(1) }`, total Ir:

| | before | after | |
| --- | ---: | ---: | ---: |
| `MUTSU_JIT=off` | 113,276,403 | 65,757,776 | **−41.9%** |
| JIT default-on | 114,403,531 | 67,315,554 | **−41.2%** |

The issue's own repro (500 iterations, median of 3 runs), `push onto 1000-byte buf x10`: 0.061 ms → 0.037 ms. `Array.push x100` is unchanged at ~0.039 ms, as expected — it is intercepted well before this probe.

## Tests

`t/numeric-bridge-probe-memo.t` (12 tests, new) pins both halves of the memo's contract, and passes identically against the pre-change binary — it is a regression test, not new behaviour:

- a class that reaches `Real` directly, through a composed role, and through a parent keeps bridging on *every* call, not just the first;
- a second instance of the same class takes the memo hit and behaves identically;
- a plain neighbour class does not acquire a `Bridge` from the memo;
- a `Bridge` method added by a runtime `augment`, **after** the class was already probed and cached, is still seen — the invalidation path.

Verification run on this container:

- `make test` — PASS (3902 files, 41466 tests).
- The whole `t/` suite re-run against `target/debug/mutsu`, so the debug tripwire was armed on every cache hit — PASS (3902 files, 41466 tests). `make test` drives `t/` with the release binary, so the tripwire costs CI nothing.
- `make roast` — 1436 files, 218939 tests. Three files fail, all **pre-existing and environmental**, verified failing identically against the pre-change binary: `roast/6.c/S32-io/file-tests.t` and `roast/S16-filehandles/filetest.t` (permission-bit assertions that cannot hold for uid 0 in this container) and `roast/S32-io/IO-Socket-Async.t` (exit 124, network sandbox).
- `make lint` — clean across all four configurations (default clippy, `jit` off, wasm32, rustdoc).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P7scCKdWK7RfKx5vxVqDqq

---
_Generated by [Claude Code](https://claude.ai/code/session_01P7scCKdWK7RfKx5vxVqDqq)_