### PR TITLE
fix(value): preserve ContainerRef holder itemization

### DIFF
--- a/docs/adr/0079-container-itemization-is-a-holder-property-tagged-on-the-containerref-word.md
+++ b/docs/adr/0079-container-itemization-is-a-holder-property-tagged-on-the-containerref-word.md
@@ -278,6 +278,6 @@ unconditional and delete it.
 | --- | --- |
 | 0 — comment justification | Complete (2026-09-09; comments now state the RHS `List` rule) |
 | 1 — `Kind::ContainerRefItemized` | Complete (2026-09-09; the holder flavour is encoded, decoded, probed, projected through the unchanged `ValueView::ContainerRef`, traced by GC, and covered by NanBox round-trip tests) |
-| 2 — `$`-share holder (rows 1, 3, 4) | Not started |
+| 2 — `$`-share holder (rows 1, 3, 4) | Complete (2026-09-09; scalar shares and scalar parameter binds now carry itemization on the target word, while source words remain plain; dereference and hash-initializer consumers preserve the distinction) |
 | 3 — audit remaining producers | Not started |
 | 4 — drop the `unwrap_contained_pair` hedge | Not started |

--- a/news/2026-09/containerref-itemization-slice-2.md
+++ b/news/2026-09/containerref-itemization-slice-2.md
@@ -1,0 +1,12 @@
+# Shared scalar holders retain itemization locally
+
+ADR-0079 Slice 2 now gives `$`-share targets an itemized
+`ContainerRefItemized` word while leaving the source `@`/`%` holder plain over
+the same cell. Dereference, array-element reads, and hash initialization honor
+that word-local flavour, so a shared scalar renders as `$[...]` or `${...}`
+without changing the aggregate source's rendering or flattening behavior.
+
+Plain scalar parameters that share an array or hash container use the same
+itemized target holder. Focused regressions cover array/hash shares, scalar
+parameter binding, source-holder preservation, and the existing odd-number
+hash-initializer guard.

--- a/src/builtins/map_hash_coerce.rs
+++ b/src/builtins/map_hash_coerce.rs
@@ -51,10 +51,16 @@ fn make_odd_number_error(items: &[Value]) -> RuntimeError {
 pub(crate) fn unwrap_contained_pair(v: &Value) -> Value {
     let held = match v.view() {
         ValueView::Scalar(inner) => inner.clone(),
-        ValueView::ContainerRef(cell) => cell.lock().unwrap().clone(),
+        ValueView::ContainerRef(_) => v.deref_container(),
         _ => return v.clone(),
     };
     if matches!(held.view(), ValueView::Pair(..) | ValueView::ValuePair(..)) {
+        held
+    } else if v.is_container_ref() && v.container_ref_is_itemized() {
+        // An itemized ContainerRef is a scalar holder, so its value stays
+        // opaque to hash initialization. Returning the itemized value rather
+        // than the wrapper keeps downstream value consumers consistent; the
+        // odd-element check still rejects it.
         held
     } else {
         v.clone()

--- a/src/runtime/types/binding_signature.rs
+++ b/src/runtime/types/binding_signature.rs
@@ -1609,7 +1609,7 @@ impl Interpreter {
                                 })
                                 .filter(|s| s.starts_with('@') || s.starts_with('%'))
                         {
-                            bound_value = Value::container_ref(crate::gc::Gc::new(
+                            bound_value = Value::container_ref_itemized(crate::gc::Gc::new(
                                 crate::value::ContainerCell::new(bound_value),
                             ));
                             rw_bindings.push((pd.name.clone(), source_name));
@@ -2493,7 +2493,7 @@ impl Interpreter {
                             && let Some(source_name) = &source_name
                             && (source_name.starts_with('@') || source_name.starts_with('%'))
                         {
-                            value = Value::container_ref(crate::gc::Gc::new(
+                            value = Value::container_ref_itemized(crate::gc::Gc::new(
                                 crate::value::ContainerCell::new(value),
                             ));
                             rw_bindings.push((pd.name.clone(), source_name.clone()));

--- a/src/runtime/types/mod.rs
+++ b/src/runtime/types/mod.rs
@@ -588,6 +588,16 @@ impl Interpreter {
                     *arc.lock().unwrap() = updated;
                     continue;
                 }
+                // A scalar parameter's itemized holder is a distinct word over
+                // the shared cell. If the caller's aggregate source was still a
+                // plain value, write the cell's raw value back rather than
+                // leaking the parameter holder's itemization onto that source.
+                if updated.container_ref_is_itemized()
+                    && let ValueView::ContainerRef(incoming) = updated.view()
+                {
+                    target_env.insert(source_name.clone(), incoming.lock().unwrap().clone());
+                    continue;
+                }
                 target_env.insert(source_name.clone(), updated);
             }
         }

--- a/src/value/value_methods_a.rs
+++ b/src/value/value_methods_a.rs
@@ -536,13 +536,26 @@ impl Value {
     /// `f` to the inner value WITHOUT cloning it.
     pub fn with_deref<R>(&self, f: impl FnOnce(&Value) -> R) -> R {
         match self.view() {
-            ValueView::ContainerRef(arc) | ValueView::ContainerView(arc) => {
+            ValueView::ContainerRef(arc) => {
                 // ADR-0068: the cell's own `Mutex` does not exclude the element
                 // store, which derives a raw pointer into this same slot and
                 // then mutates it with the lock released. Without this a
                 // concurrent read clones a half-overwritten `Value` and takes a
                 // refcount on a node the writer already dropped. A no-op (one
                 // relaxed load) until a VM mutator thread is spawned.
+                let _cross_thread =
+                    crate::value::container_lock::ContainerStructGuard::acquire_for_cell(&arc);
+                let inner = arc.lock().unwrap();
+                if self.container_ref_is_itemized() {
+                    let itemized = inner.clone().itemize_for_element_store();
+                    f(&itemized)
+                } else {
+                    f(&inner)
+                }
+            }
+            ValueView::ContainerView(arc) => {
+                // Explicit `.VAR` views expose the cell itself and do not carry
+                // the holder-local itemization flavour.
                 let _cross_thread =
                     crate::value::container_lock::ContainerStructGuard::acquire_for_cell(&arc);
                 f(&arc.lock().unwrap())
@@ -578,7 +591,12 @@ impl Value {
             // See `with_deref`: the cell lock alone does not exclude the store.
             let _cross_thread =
                 crate::value::container_lock::ContainerStructGuard::acquire_for_cell(&arc);
-            return arc.lock().unwrap().clone();
+            let inner = arc.lock().unwrap().clone();
+            return if self.container_ref_is_itemized() {
+                inner.itemize_for_element_store()
+            } else {
+                inner
+            };
         }
         self
     }

--- a/src/vm/vm_var_assign_coerce.rs
+++ b/src/vm/vm_var_assign_coerce.rs
@@ -815,6 +815,10 @@ impl Interpreter {
                 _ => crate::gc::Gc::new(crate::value::ContainerCell::new(val.clone())),
             },
         };
+        // The source and target own different holder words over this one cell:
+        // the aggregate source remains plain, while the scalar target is an
+        // itemized holder. Keeping the flavour on the word is what preserves
+        // `%h.raku` while making `$hi.raku` render `${...}`.
         let container = Value::container_ref(cell.clone());
         // Compiler-generated temporaries are implementation details rather than
         // user-visible scalar bindings. Keep their historical bare cell shape so
@@ -823,7 +827,7 @@ impl Interpreter {
         let itemized_container = if Self::name_is_itemize_exempt(&name) {
             container.clone()
         } else {
-            Value::container_ref(cell).item()
+            Value::container_ref_itemized(cell.clone())
         };
         // Promote the SOURCE container variable to the same cell so its own
         // `.push` / whole-reassign (`@z = (...)`) mutate through and stay visible
@@ -872,8 +876,10 @@ impl Interpreter {
         // the same name (this `=` share is itemized, not a `:=` decont alias).
         self.update_bound_decont_marker(&name, false, &val);
         // Mark the scalar so a later whole reassignment replaces the slot.
-        self.env_mut()
-            .insert(format!("__mutsu_array_share::{}", name), Value::TRUE);
+        self.env_mut().insert(
+            format!("__mutsu_array_share::{}", name),
+            itemized_container.clone(),
+        );
         self.array_share_active = true;
         self.set_env_with_main_alias(&name, itemized_container);
         self.flush_local_to_env(code, idx);

--- a/src/vm/vm_var_ops.rs
+++ b/src/vm/vm_var_ops.rs
@@ -137,7 +137,7 @@ impl Interpreter {
                 // Phase 2 element container: a `:=`-bound element holds a shared
                 // `ContainerRef` cell. Reading the element decontainerizes it (the
                 // single read chokepoint), so value contexts never see the cell.
-                ValueView::ContainerRef(cell) => cell.lock().unwrap().clone(),
+                ValueView::ContainerRef(_) => value.deref_container(),
                 // A bound slice can hold a deferred array-entry token for an
                 // out-of-range element. Resolve it here just like a scalar bind:
                 // the read must report the array hole without growing the array.

--- a/t/hash-itemization-flag.t
+++ b/t/hash-itemization-flag.t
@@ -1,9 +1,9 @@
 use Test;
 
-plan 18;
+plan 24;
 
 # A bare `%h` in a list flattens into its pairs on hash-assignment / hash-context,
-# but a hash sourced from a `$` scalar carries HashData.itemized and stays opaque.
+# but a hash sourced from a `$` scalar carries holder-local itemization and stays opaque.
 # (Container itemization mirrors ArrayKind: the value stays a Value::Hash, so it
 # never leaks a wrapper to value operations — `(elem)`, callable mappers, etc.)
 
@@ -73,6 +73,24 @@ my %h = a => 1, b => 2;
 # Reflection: a $-sourced hash reflects as a Scalar container, % as Hash.
 {
     my $hi = %h;
+    is $hi.raku, '${:a(1), :b(2)}', '$-sourced hash keeps holder itemization';
+    is %h.raku, '{:a(1), :b(2)}', '%-sourced hash remains plain after sharing';
     is $hi.VAR.^name, 'Scalar', '$-sourced hash reflects as Scalar container';
     is %h.VAR.^name, 'Hash', '%-sourced hash reflects as Hash';
+}
+
+# A shared scalar array has the same holder-local itemization as a shared hash.
+{
+    my @a = 1, 2;
+    my $itemized = @a;
+    is $itemized.raku, '$[1, 2]', '$-sourced array keeps holder itemization';
+    is @a.raku, '[1, 2]', '@-sourced array remains plain after sharing';
+}
+
+# A plain scalar parameter receives the itemized holder when its argument is an
+# array/hash variable; the caller's aggregate remains a plain holder.
+{
+    sub show($value) { $value.raku }
+    is show(%h), '${:a(1), :b(2)}', 'scalar parameter share is itemized';
+    is %h.raku, '{:a(1), :b(2)}', 'scalar parameter writeback keeps source plain';
 }


### PR DESCRIPTION
Part of #7542. Implements ADR-0079 Slice 2.

Summary:
- preserve holder-local itemization with `Kind::ContainerRefItemized` during `$`-share assignment and scalar parameter binding
- make dereference, array reads, and hash initialization honor the holder word
- keep aggregate source holders plain, including scalar-parameter writeback
- add focused regression coverage and a news entry

Validation:
- `cargo fmt --all`
- `make lint`
- `make test`
- `make roast`

Remaining ADR-0079 work in #7542: Slice 3 producer audit and Slice 4 removal of the pair-only unwrap hedge.