### PR TITLE
fix(compiler): collect the container a for body's tail names, not a snapshot

### DIFF
--- a/docs/adr/0082-a-collecting-for-gathers-containers-not-snapshots.md
+++ b/docs/adr/0082-a-collecting-for-gathers-containers-not-snapshots.md
@@ -1,0 +1,132 @@
+# ADR-0082: A value-collecting `for` gathers containers, not snapshots
+
+- Status: Accepted (implemented)
+- Date: 2026-09-09
+- Related: [ADR-0045](0045-for-loop-parameters-bind-the-element-container.md)
+  (a `for` parameter binds the element container),
+  [ADR-0059](0059-is-rw-routines-return-a-container.md) and
+  [ADR-0067](0067-a-routine-hands-back-the-container-it-was-given.md) (a routine
+  hands back a container, not a copy of its value),
+  [ADR-0036](0036-element-container-pairs-from-subscripts-and-pairs.md) (a Pair
+  from a subscript carries the element container),
+  [ADR-0052](0052-a-when-clause-produces-its-value-on-the-stack.md) (a `when`
+  clause's value reaches the collecting loop on the stack)
+- Addresses: [#7718](https://github.com/tokuhirom/mutsu/issues/7718). Depends on
+  [#7677](https://github.com/tokuhirom/mutsu/issues/7677) (a loop body resolves
+  its own `let`/`temp` saves, PR #7722), which landed while this was in flight.
+  Findings filed out of scope:
+  [#7720](https://github.com/tokuhirom/mutsu/issues/7720) (the same `temp` gap,
+  still open for `if`/`unless`/`with` branches);
+  [#7721](https://github.com/tokuhirom/mutsu/issues/7721) (withdrawn)
+
+## Context
+
+A Raku block's value is **not** decontainerized. A collecting `for` whose body
+ends in `$g` therefore gathers the `Scalar` container `$g` denotes, and every
+collected slot reads it when the list is consumed — not when the iteration ran:
+
+```raku
+my $g = 1; my @v = do for 1..2 { temp $g = 9; $g };      # raku: [1 1]
+my $g = 1; my @v = do for 1..2 { $g = $g + 1; $g };      # raku: [3 3]
+my $g = 1; my @v = do for 1..2 { temp $g = 9; $g + 0 };  # raku: [9 9]
+```
+
+The third line is the control: `$g + 0` is a value expression, so it opts back
+out and the snapshot is right there.
+
+mutsu answered `[9 9]`, `[2 3]` and `[9 9]`. The loop pushed each iteration's
+*value*, so the first two were snapshots taken mid-iteration.
+
+Half the mechanism already existed. `compile_expr_assign` emits
+`OpCode::TagContainerRef` after an assignment used as an expression, and
+`exec_for_loop_body` records the tagged slot in `deferred_container_refs` and
+re-reads it once the loop is over — which is why `do for 1..3 { $s += $_ }` was
+already `(6 6 6)` (`t/for-collect-assign-container.t`). What had no tag was the
+other shape a container reaches tail position in: a **bare variable read**.
+
+The first line has a second bug in it, and it is not this one: `temp` in a loop
+body was never restored, so even a correctly collected container still held 9.
+That is #7677, fixed by PR #7722 before this change landed. This ADR is only
+about what the loop *collects*.
+
+## Decision
+
+### 1. A bare variable read in tail position is tagged as a container
+
+When the body of a collecting `for` ends in `Stmt::Expr(Expr::Var(_))`, the
+lowering emits `TagContainerRef` for that name, so the loop collects the
+container the same way it already collects a tail assignment's lvalue.
+
+The tag is emitted **after** `compile_scope_restored_body_value`, so outside the
+body's own `let`/`temp` save frame (#7677) — `exec_let_block_op` jumps the ip
+past everything inside that frame's range, and this tag has to run. Being
+outside it is what the container semantics want anyway: the tag records a name
+whose value is read once the whole loop is over.
+
+### 2. Only a container that outlives the iteration qualifies
+
+A name is tagged only when it is not rebound per iteration:
+
+| Tail | raku | Reason |
+| --- | --- | --- |
+| `do for 1..2 { $g }` (outer `my`, `our`) | `(1 1)` | one container for the loop — **tagged** |
+| `do for 1..3 { state $s = 0; $s = $s + $_; $s }` | `(6 6 6)` | `state` storage is one cell — **tagged** |
+| `do for 1..3 -> $i { $i }` | `(1 2 3)` | the parameter is rebound per iteration |
+| `do for 1..3 { $_ }` | `(1 2 3)` | so is the topic |
+| `do for 1..3 { my $x = $_ * 2; $x }` | `(2 4 6)` | a body `my` is a fresh container per iteration |
+| `do for 1..2 { temp $g = 9; $g + 0 }` | `(9 9)` | not a variable read at all |
+
+`state` is the one declaration inside the body that is still tagged, and it is
+the case that proves the rule is about *storage*, not about where the name was
+written: mutsu answered `(1 3 6)` before this ADR.
+
+Twigil'd and punctuation names (`$*d`, `$!a`, `$^a`, `$/`) are deliberately left
+alone. They do not resolve through the plain lexical lookup the VM's re-read
+uses, and nothing here has measured what raku does with them in this position.
+
+### 3. The re-read is slot-first, env-fallback
+
+`deferred_container_refs` now carries the tag's compile-time-baked local slot
+alongside the name, and the end-of-loop re-read goes through
+`gate_local_slot_at` before falling back to `get_env_with_main_alias`. That is
+the §1.5 order of `docs/lexical-scope-slot-campaign.md`: a plain `my $g` keeps
+its live value in its slot and its env mirror is suppressed, so the env-only
+read this mechanism shipped with saw `Any` for every `my` lexical. It went
+unnoticed because the only shape that reached it — a tail assignment — happens
+to refresh the env on its way through.
+
+### What was rejected
+
+**Collecting a real `ContainerRef` cell instead of a deferred name.** This is
+the container-shaped answer, and it is the one raku actually implements: it
+would also fix `my $s = do for 1..2 { $g }; $g = 5; say $s`, which raku prints
+as `(5 5)` and mutsu (still) prints as `(1 1)`, because the collected list holds
+the container past the loop rather than a value read at its end. It was rejected
+for *this* change because it puts `ContainerRef` cells into an ordinary Array
+and its blast radius is every consumer of a collected list — a cost these three
+repro lines do not justify. The deferred re-read is the mechanism the repository
+already chose for the assignment shape; this extends it rather than introducing
+a second one beside it.
+
+**Widening the rule to a subscript tail.** `do for 0..2 -> $i { @a[$i] }` is an
+element container in raku too, but the collected list is decontainerized at the
+store before anything can mutate `@a`, so mutsu's snapshot already agrees
+(`[1 2 3]`, and a later `@a[0] = 9` does not change it). There is no measured
+divergence to fix, and a tag there would need the element's identity rather than
+a name.
+
+## Consequences
+
+- `src/compiler/control_for.rs` owns the tagging, so the statement and
+  expression positions get it together — the drift this module was created to
+  end (see its header) does not reopen.
+- The end-of-loop re-read is now the mechanism's only reader of a variable, and
+  it goes through the same slot-first chokepoint as the rest of the VM. Any
+  future tag site inherits that.
+- `t/for-collect-container-tail.t` pins nine rows and runs green under both
+  `mutsu` and `raku`, so the oracle is in the suite rather than in this
+  document. The per-iteration `temp` restore its first row depends on is
+  #7677's, pinned by `t/loop-body-let-resolution.t`.
+- Still divergent, by choice: a collected list does not survive as containers
+  past the loop (`my $s = do for 1..2 { $g }; $g = 5; say $s`). Reopen with the
+  rejected alternative above if that shape ever matters.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -107,3 +107,4 @@ The role of an ADR is to preserve the *context of the judgment* — something th
 | [0079](0079-container-itemization-is-a-holder-property-tagged-on-the-containerref-word.md) | Container itemization is a property of the *holder*, tagged on the `ContainerRef` word (not on the shared cell) | Proposed |
 | [0080](0080-hash-element-containerization-is-per-value.md) | Hash element containerization is a per-value property, not a hash-wide slurpy flag | Proposed |
 | [0081](0081-compunit-scoped-module-import-aliases.md) | A unit module's imported aliases are scoped to its compilation unit | Proposed |
+| [0082](0082-a-collecting-for-gathers-containers-not-snapshots.md) | A value-collecting `for` gathers containers, not snapshots | Accepted (implemented) |

--- a/news/2026-09/a-collecting-for-gathers-containers.md
+++ b/news/2026-09/a-collecting-for-gathers-containers.md
@@ -1,0 +1,75 @@
+# A collecting `for` gathers containers, not snapshots
+
+A Raku block's value is not decontainerized, so a value-collecting `for` whose
+body ends in `$g` gathers the Scalar container `$g` denotes. Every collected
+slot then reads that one container when the list is built — after the loop, so
+after the last iteration's `temp` restore. mutsu pushed each iteration's *value*
+instead, and issue [#7718](https://github.com/tokuhirom/mutsu/issues/7718) had
+the three lines that show it:
+
+```raku
+my $g = 1; my @v = do for 1..2 { temp $g = 9; $g };     # raku [1 1], mutsu was [9 9]
+my $g = 1; my @v = do for 1..2 { $g = $g + 1; $g };     # raku [3 3], mutsu was [2 3]
+my $g = 1; my @v = do for 1..2 { temp $g = 9; $g + 0 }; # raku [9 9], mutsu [9 9]
+```
+
+The third is the control: `$g + 0` is a value, so the snapshot is right there.
+
+## The mechanism was already half-built
+
+`compile_expr_assign` has emitted `OpCode::TagContainerRef` after an
+expression-position assignment for a while, and `exec_for_loop_body` records the
+tagged slot and re-reads it once the loop is over. That is why
+`do for 1..3 { $s += $_ }` was already `(6 6 6)` — pinned by
+`t/for-collect-assign-container.t`. What had no tag was the *other* way a
+container reaches tail position: a bare variable read. Adding it is a handful of
+lines in `src/compiler/control_for.rs`.
+
+Two things then had to be settled that the issue did not raise.
+
+**Which names count.** Only a container that outlives the iteration. The loop
+parameter, the topic and a body-local `my` are each rebound per iteration, so
+`do for 1..3 -> $i { $i }` stays `(1 2 3)` and
+`do for 1..3 { my $x = $_ * 2; $x }` stays `(2 4 6)`. `state` is the exception
+that proves the rule is about storage rather than about where the name was
+written — one cell for the whole loop, so
+`do for 1..3 { state $s = 0; $s = $s + $_; $s }` is `(6 6 6)`, where mutsu had
+been answering `(1 3 6)`.
+
+**Where the re-read reads from.** The existing one went to the env only, and a
+plain `my $g` keeps its live value in its local slot with the env mirror
+suppressed — so it came back `Any` for every `my` lexical. Nobody had noticed,
+because the one shape that reached it, a tail assignment, refreshes the env on
+its way through. It now goes slot-first through `gate_local_slot_at` and falls
+back to the env, which is the §1.5 order the rest of the VM uses.
+
+## The other bug in the same repro
+
+With the tag in place the first line still read `[9 9]`, for a reason that had
+nothing to do with collection: a `temp` in a loop body was never restored, so
+the container this change correctly collects was still holding 9 when the loop
+ended. That is [#7677](https://github.com/tokuhirom/mutsu/issues/7677), and
+[PR #7722](https://github.com/tokuhirom/mutsu/pull/7722) landed its fix — a
+per-iteration `LetBlock` frame, including the stack-routed value a real `let`
+needs — while this work was in flight. The two together are what make the first
+line `[1 1]`, so `t/for-collect-container-tail.t` leans on
+`t/loop-body-let-resolution.t` for that half rather than re-pinning it.
+
+The same `temp` gap is still open one branch over:
+`if 1 { temp $g = 9 }` leaves 9 where raku leaves 1, and so do `unless` and
+`with`. Filed as [#7720](https://github.com/tokuhirom/mutsu/issues/7720).
+
+## What is still divergent
+
+A collected list does not survive as containers *past* the loop:
+
+```raku
+my $g = 1; my $s = do for 1..2 { $g }; $g = 5; say $s;   # raku (5 5), mutsu (1 1)
+```
+
+That needs real `ContainerRef` cells in an ordinary Array, whose blast radius is
+every consumer of a collected list. The deferred re-read is the mechanism this
+repository already chose for the assignment shape, and this change extends it
+rather than standing a second one up beside it. The reasoning, and what would
+justify revisiting it, is in
+[ADR-0082](../../docs/adr/0082-a-collecting-for-gathers-containers-not-snapshots.md).

--- a/src/compiler/control_for.rs
+++ b/src/compiler/control_for.rs
@@ -39,6 +39,68 @@ pub(super) struct ForParts<'a> {
 }
 
 impl Compiler {
+    /// The variable whose *container* a value-collecting `for` body hands back,
+    /// when the body's tail statement is a bare read of one.
+    ///
+    /// A Raku block's value is not decontainerized, so a collecting `for` whose
+    /// body ends in `$g` gathers the `Scalar` container `$g` denotes and every
+    /// collected slot reads it at the point the list is consumed — after the
+    /// loop, so after each iteration's `temp` restore. `do for 1..2 { temp $g =
+    /// 9; $g }` is therefore `(1 1)` and not `(9 9)`, and `do for 1..2 { $g =
+    /// $g + 1; $g }` is `(3 3)` and not `(2 3)`. Decontainerizing the tail
+    /// (`$g + 0`) opts back out, because that expression is a value.
+    ///
+    /// Returning the name here makes the loop tag it with `TagContainerRef`,
+    /// which is the same signal `compile_expr_assign` already emits for a tail
+    /// *assignment* (`do for 1..3 { $s += $_ }` → `(6 6 6)`); the VM re-reads
+    /// every tagged slot once the loop is over.
+    ///
+    /// Only a container that outlives the iteration qualifies:
+    ///
+    /// - the loop's own parameters and the topic are rebound per iteration, so
+    ///   `do for 1..3 -> $i { $i }` must stay `(1 2 3)`;
+    /// - so is a `my` declared anywhere in the body, hence
+    ///   `do for 1..3 { my $x = $_ * 2; $x }` is `(2 4 6)`. A `state`
+    ///   declaration is the exception — its storage is one cell for the whole
+    ///   loop, and raku collects it as one (`(6 6 6)`, not `(1 3 6)`);
+    /// - a twigil'd or punctuation name (`$*d`, `$!a`, `$^a`, `$/`) is left
+    ///   alone: those do not resolve through the plain env lookup the VM's
+    ///   re-read uses, and nothing here has measured them.
+    fn collected_tail_container_name(
+        body: &[Stmt],
+        param: &Option<String>,
+        params: &[String],
+    ) -> Option<String> {
+        let Some(Stmt::Expr(Expr::Var(name))) = body.last() else {
+            return None;
+        };
+        if name == "_"
+            || !name.starts_with(|c: char| c.is_ascii_alphabetic() || c == '_')
+            || param.as_deref() == Some(name.as_str())
+            || params
+                .iter()
+                .any(|p| p.strip_prefix('\\').unwrap_or(p) == name)
+        {
+            return None;
+        }
+        let mut body_declared = std::collections::HashSet::new();
+        crate::ast::collect_all_my_decl_names(body, &mut body_declared);
+        let declared_as_state = body.iter().any(|s| {
+            matches!(
+                s,
+                Stmt::VarDecl {
+                    name: declared,
+                    is_state: true,
+                    ..
+                } if declared == name
+            )
+        });
+        if body_declared.contains(name.as_str()) && !declared_as_state {
+            return None;
+        }
+        Some(name.clone())
+    }
+
     /// Compile a `for` construct in either position.
     ///
     /// Statement callers must have run the statement-level source desugars
@@ -423,6 +485,24 @@ impl Compiler {
             // statement form, so a `my TYPE $x` here is env-restored on exit and
             // can use the env-only scoped constraint opcode.
             self.compile_scope_restored_body_value(&loop_body);
+            // Emitted AFTER that call, so outside the body's own `let`/`temp`
+            // save frame (#7677): `exec_let_block_op` jumps the ip past
+            // everything inside the frame's range, and this tag has to run.
+            // Being outside it is also what the container semantics want — the
+            // tag records a name whose value is read once the whole loop is
+            // over, by which point every iteration's `temp` has been restored.
+            //
+            // A bare variable read in tail position hands back that variable's
+            // CONTAINER, exactly as a tail assignment does (see the
+            // `TagContainerRef` emitted by `compile_expr_assign`). Tag it so the
+            // `ForLoop` opcode collects the container rather than a snapshot of
+            // what it held mid-iteration.
+            if let Some(name) = Self::collected_tail_container_name(&loop_body, param, params) {
+                let source_slot = self.local_map.get(name.as_str()).copied();
+                let name_idx = self.code.add_constant(Value::str(name));
+                self.code
+                    .emit(OpCode::TagContainerRef(name_idx, source_slot));
+            }
         } else {
             self.compile_scope_restored_loop_body(&loop_body);
         }

--- a/src/vm/vm_for_loop_body.rs
+++ b/src/vm/vm_for_loop_body.rs
@@ -194,7 +194,11 @@ impl Interpreter {
         // `when`) piled up one value per pass.
         let stack_base = self.stack.len();
         let mut collected = if spec.collect { Some(Vec::new()) } else { None };
-        let mut deferred_container_refs: Vec<(usize, String)> = Vec::new();
+        // Collected slots whose value is a CONTAINER, not a snapshot: the name
+        // (and the emitting site's baked local slot) of the variable each one
+        // denotes, re-read once the loop is over. See the fix-up at the end of
+        // this function.
+        let mut deferred_container_refs: Vec<(usize, String, Option<u32>)> = Vec::new();
         // A `for` block owns its topic (raku binds `$_` as the block's own
         // implicit parameter), so the enclosing `$_` is restored on every exit —
         // normal, `last`/`next`, and error.
@@ -984,13 +988,13 @@ impl Interpreter {
                             && self.stack.len() > stack_base
                         {
                             let val = self.stack.pop().unwrap();
-                            let deferred_ref = self.take_container_ref_for(code).map(|(n, _)| n);
+                            let deferred_ref = self.take_container_ref_for(code);
                             let coll_start_len = coll.len();
                             Self::collect_loop_value(coll, val);
-                            if let Some(name) = deferred_ref
+                            if let Some((name, slot)) = deferred_ref
                                 && coll.len() == coll_start_len + 1
                             {
-                                deferred_container_refs.push((coll_start_len, name));
+                                deferred_container_refs.push((coll_start_len, name, slot));
                             }
                         }
                         // Drain anything else this iteration left behind.
@@ -1373,10 +1377,23 @@ impl Interpreter {
         self.restore_loop_topic(saved_topic, saved_topic_local);
         if let Some(coll) = collected {
             let mut coll = coll;
-            for (idx, name) in deferred_container_refs {
-                if idx < coll.len()
-                    && let Some(v) = self.get_env_with_main_alias(&name)
-                {
+            // Every collected container is read here, once, with the loop over —
+            // so after the last iteration's `temp` restore, and at the same value
+            // for all of them, which is what makes `do for 1..2 { temp $g = 9;
+            // $g }` `(1 1)` and `do for 1..2 { $g = $g + 1; $g }` `(3 3)`.
+            // Slot-first, env-fallback (§1.5, docs/lexical-scope-slot-campaign.md):
+            // a plain `my $g` lexical keeps its live value in its local slot and
+            // its env mirror is suppressed, so the env read alone saw `Any`.
+            for (idx, name, slot) in deferred_container_refs {
+                if idx >= coll.len() {
+                    continue;
+                }
+                let current = self
+                    .gate_local_slot_at(code, slot, &name)
+                    .and_then(|s| self.locals.get(s).cloned())
+                    .filter(|v| !v.is_nil())
+                    .or_else(|| self.get_env_with_main_alias(&name));
+                if let Some(v) = current {
                     coll[idx] = v;
                 }
             }

--- a/t/for-collect-container-tail.t
+++ b/t/for-collect-container-tail.t
@@ -1,0 +1,66 @@
+use Test;
+
+plan 9;
+
+# A Raku block's value is not decontainerized, so a value-collecting `for`
+# whose body ends in a bare variable read gathers that variable's *container*.
+# Every collected slot therefore reads it once the loop is over -- after the
+# last iteration's `temp` restore.
+# https://github.com/tokuhirom/mutsu/issues/7718
+#
+# The per-iteration `temp` restore itself is #7677's, pinned by
+# t/loop-body-let-resolution.t; what is pinned here is what the loop collects.
+
+{
+    my $g = 1;
+    my @v = do for 1..2 { temp $g = 9; $g };
+    is-deeply @v, [1, 1], 'a temp-ed container is collected, not its in-block value';
+}
+
+{
+    my $g = 1;
+    my @v = do for 1..2 { temp $g = 9; $g + 0 };
+    is-deeply @v, [9, 9], 'decontainerizing the tail opts back out';
+}
+
+{
+    my $g = 1;
+    my @v = do for 1..2 { $g };
+    $g = 5;
+    is-deeply @v, [1, 1], 'the container is read when the list is built, not later';
+}
+
+{
+    my $g = 1;
+    my @v = do for 1..2 { $g = $g + 1; $g };
+    is-deeply @v, [3, 3], 'every slot holds the same container, so every slot reads 3';
+}
+
+{
+    our $o = 1;
+    my @v = do for 1..2 { temp $o = 9; $o };
+    is-deeply @v, [1, 1], 'an `our` container collects the same way a `my` one does';
+}
+
+# `state` storage is one cell for the whole loop, so it collects as one.
+{
+    my @v = do for 1..3 { state $s = 0; $s = $s + $_; $s };
+    is-deeply @v, [6, 6, 6], 'a state tail is one container across the iterations';
+}
+
+# A container that is rebound per iteration is NOT shared: the loop parameter,
+# the topic, and a `my` declared in the body each get a fresh one.
+{
+    my @v = do for 1..3 -> $i { $i };
+    is-deeply @v, [1, 2, 3], 'the loop parameter is rebound per iteration';
+}
+
+{
+    my @v = do for 1..3 { $_ };
+    is-deeply @v, [1, 2, 3], 'the topic is rebound per iteration';
+}
+
+{
+    my @v = do for 1..3 { my $x = $_ * 2; $x };
+    is-deeply @v, [2, 4, 6], 'a body-local `my` is a fresh container per iteration';
+}


### PR DESCRIPTION
Closes #7718

A Raku block's value is not decontainerized, so a value-collecting `for` whose body ends in `$g` gathers the `Scalar` container `$g` denotes — every collected slot reads it when the list is built, after the loop and so after the last iteration's `temp` restore. mutsu pushed each iteration's *value* instead.

```raku
my $g = 1; my @v = do for 1..2 { temp $g = 9; $g };     # raku [1 1], mutsu was [9 9]
my $g = 1; my @v = do for 1..2 { $g = $g + 1; $g };     # raku [3 3], mutsu was [2 3]
my $g = 1; my @v = do for 1..2 { temp $g = 9; $g + 0 }; # raku [9 9], mutsu [9 9]
```

The third line is the control: `$g + 0` is a value expression, so the snapshot is right there.

## What changed

**Half the mechanism was already built.** `compile_expr_assign` tags an expression-position assignment with `OpCode::TagContainerRef`, and `exec_for_loop_body` records the tagged slot and re-reads it once the loop is over — which is why `do for 1..3 { $s += $_ }` was already `(6 6 6)` (`t/for-collect-assign-container.t`). The other shape a container reaches tail position in, a **bare variable read**, had no tag. This adds it, in `src/compiler/control_for.rs` so both source positions get it together.

**Which names count** — only a container that outlives the iteration. The loop parameter, the topic and a body-local `my` are rebound per iteration, so `do for 1..3 -> $i { $i }` stays `(1 2 3)` and `do for 1..3 { my $x = $_ * 2; $x }` stays `(2 4 6)`. `state` is the exception that shows the rule is about *storage* rather than about where the name was written — one cell for the whole loop, so `do for 1..3 { state $s = 0; $s = $s + $_; $s }` goes from `(1 3 6)` to `(6 6 6)`.

**The re-read was reading the wrong half.** It went to the env only, and a plain `my $g` keeps its live value in its local slot with the env mirror suppressed, so it came back `Any` for every `my` lexical. Nothing had noticed, because the one shape that reached it — a tail assignment — refreshes the env on its way through. It now carries the tag's compile-time-baked slot and reads slot-first, env-fallback (§1.5 of `docs/lexical-scope-slot-campaign.md`), the order the rest of the VM uses.

## Relationship to #7677

The first repro has a second bug in it, and it is not this one: a `temp` in a loop body was never restored, so even a correctly collected container still held 9. That is #7677, and PR #7722 landed its fix while this work was in flight. This branch was rebased onto it and its own duplicate save frame dropped; `t/for-collect-container-tail.t` leans on `t/loop-body-let-resolution.t` for that half rather than re-pinning it.

Two findings filed rather than folded in:

- **#7720** — the same `temp` gap, still open one branch over: `if 1 { temp $g = 9 }` leaves 9 where raku leaves 1, and so do `unless` and `with`.
- **#7721** — withdrawn. Filed on a wrong premise about `let` (which rolls back on an *undefined* block value, not a false one) and about a value route #7722 had already built.

## What is still divergent, deliberately

A collected list does not survive as containers past the loop: `my $s = do for 1..2 { $g }; $g = 5; say $s` is `(5 5)` in raku and `(1 1)` here. That needs real `ContainerRef` cells inside an ordinary Array, whose blast radius is every consumer of a collected list — a cost these repros do not justify. The reasoning and the reopening trigger are in ADR-0082.

## Verification

- `t/for-collect-container-tail.t` — 9 new rows, green under **both** `mutsu` and `raku` (rakudo v2026.07 as the oracle).
- `make test` — green (3904 files, 41502 tests).
- `make roast` — the three documented environment-only failures and nothing else (`6.c/S32-io/file-tests.t` 6-8/10, `S16-filehandles/filetest.t` 57-64/69-72/77-80/101-125 odd, `S32-io/IO-Socket-Async.t` exit 124), matching `docs/agent-environments.md` by name and subtest range.
- `make lint` — green in all four configurations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013N7diGrpBap46GcHp1RxLf

---
_Generated by [Claude Code](https://claude.ai/code/session_013N7diGrpBap46GcHp1RxLf)_