### PR TITLE
perf(vm): the element inc/dec opcode stops re-interning its variable name

### DIFF
--- a/news/2026-09/incdec-index-name-symbol.md
+++ b/news/2026-09/incdec-index-name-symbol.md
@@ -1,0 +1,75 @@
+# The element inc/dec opcode stops re-interning its variable name
+
+`exec_inc_dec_index_op` — the opcode behind `%h{$k}++` and `@a[$i]++` — read its
+variable's name out of the chunk's constant pool as a `&str` and then let every
+probe on that name rediscover the corresponding `Symbol` for itself.
+`Symbol::intern` is a thread-local, string-keyed hash lookup (a `LocalKey`
+access, a `RefCell` borrow, an `FxHashMap<String, Symbol>` probe and the
+`memcmp` that confirms the hit), so the same name was re-hashed three times per
+increment:
+
+| call site | calls | Ir |
+| --- | ---: | ---: |
+| `get_env_with_main_alias` | 100,000 | 15.39 M |
+| `var_hash_key_constraint` | 100,001 | 15.39 M |
+| `Env::get_mut` | 100,000 | 15.39 M |
+
+The fix hoists `code.const_sym(name_idx)` once — `const_sym` interns once per
+constant slot for the life of the chunk — and threads that `Symbol` through
+every probe the opcode makes on the name: the declared type constraint, the
+element-container read, the object-hash key-type lane, and the write-back.
+`var_type_constraint_sym`, `get_env_with_main_alias_sym` and `Env::get_mut_sym`
+already existed; `var_hash_key_constraint_sym` is new, added alongside them. Its
+attribute fallback still takes the `&str`, because an object-hash *attribute*
+(`has Callable %!Conv{Mu:U}`) is not a lexical — its key type comes from the
+class registry, resolved by spelling.
+
+## Measured
+
+`benchmarks/word-count.raku`, whose inner loop is `%counts{$w}++`, under
+callgrind. Instruction counts are deterministic and layout-insensitive, which
+matters here: this box has no `perf`, and issue #7579's own method notes record
+that the ~5% code-layout lottery makes a cross-build cycle comparison unable to
+support a conclusion at this effect size.
+
+| | before | after | delta |
+| --- | ---: | ---: | ---: |
+| `word-count` total | 1,136,132,456 | 1,046,851,308 | **−7.86%** |
+| `bench-string` (control) | 530,662,736 | 530,857,721 | +0.04% |
+
+The removal is visible directly in the profile rather than only in the total:
+`Symbol::intern`'s self time (20.69 M) and the intern cache's `LocalKey::with`
+(33.90 M) both leave the profile entirely, and `__memcmp_avx2_movbe` falls from
+33.47 M to 21.67 M as the cache's string comparisons stop happening.
+
+Two controls establish that this is work *removed* rather than work *skipped* —
+the failure mode where a change measures faster because it quietly stopped doing
+something. `malloc`/`_int_free` are unmoved (46.64 M / 72.02 M before, 46.63 M /
+72.06 M after), so nothing was allocated or freed differently; and
+`benchmarks/word-count.raku`'s output is byte-identical across the two builds.
+`bench-string` is the negative control: it contains no `%h{$k}++`, and it does
+not move.
+
+## A correction to issue #7579's item 4
+
+The ticket's item 4 predicted that the remaining `Symbol::intern` cost lived in
+roughly 75 call sites that probe the env with a *literal* key — `env().get("_")`,
+`env().get("/")`, `env().get("!")` — and proposed sweeping them onto the
+well-known pre-interned symbols. The profile does not support that. `Env::get`'s
+string-keyed form is called **60 times in the whole of `word-count`**; a sweep of
+those sites would have bought essentially nothing on this benchmark.
+
+The cost is in names that are only known at *runtime* — a variable name coming
+out of a constant pool, re-interned per execution — not in fixed literals. That
+distinction is what this change acts on, and it is worth carrying into any
+further work on the ticket: prefer looking for a `&str` that a caller already
+holds a `Symbol` for over looking for a string literal.
+
+## Pinned
+
+`t/incdec-index-name-symbol.t` exercises each probe the change touches: the
+object-hash key-type lane and the declared key type surviving an increment
+(`my %h{Int}`, `my %h{Any}`), the attribute fallback that still resolves by
+string, the typed-container autovivification lane (`BagHash`, `MixHash`), and
+increments through shared and captured containers. Verified against Rakudo as
+the oracle.

--- a/src/runtime/runtime_var_meta.rs
+++ b/src/runtime/runtime_var_meta.rs
@@ -724,7 +724,23 @@ impl Interpreter {
     /// stays — an attribute's declared type lives in the class registry and is
     /// not a lexical at all.
     pub(crate) fn var_hash_key_constraint(&self, name: &str) -> Option<String> {
-        let meta_key = Self::hash_key_meta_key_for_sym(Symbol::intern(name));
+        self.var_hash_key_constraint_sym(name, Symbol::intern(name))
+    }
+
+    /// [`Self::var_hash_key_constraint`] for a caller that already holds the
+    /// name as a symbol, mirroring [`Self::var_type_constraint_sym`].
+    ///
+    /// The `&str` is still needed for the attribute fallback, which splits the
+    /// twigil off the spelling; only the meta-key derivation takes the symbol.
+    /// That is what the intern bought: `%h{$k}++` probes this once per
+    /// increment, and re-hashing the name to rediscover a symbol the opcode's
+    /// constant pool already holds was 1.35% of `benchmarks/word-count.raku`.
+    pub(crate) fn var_hash_key_constraint_sym(
+        &self,
+        name: &str,
+        name_sym: Symbol,
+    ) -> Option<String> {
+        let meta_key = Self::hash_key_meta_key_for_sym(name_sym);
         if let Some(ValueView::Str(tc)) = self.env.get_sym(meta_key).map(Value::view) {
             return Some(tc.as_str().to_owned());
         }

--- a/src/vm/vm_var_assign_post_incdec.rs
+++ b/src/vm/vm_var_assign_post_incdec.rs
@@ -436,12 +436,22 @@ impl Interpreter {
         return_new: bool,
     ) -> Result<(), RuntimeError> {
         let name = Self::const_str(code, name_idx).to_string();
+        // The variable's name as a `Symbol`, taken once from the chunk's
+        // constant-symbol table rather than re-interned by each of the probes
+        // below. `%h{$k}++` ran three separate `Symbol::intern`s of the same
+        // name per increment -- the element-container read, the object-hash
+        // key-type probe and the write-back's `get_mut` -- and a `Symbol::intern`
+        // is a thread-local string-keyed hash lookup, so on
+        // `benchmarks/word-count.raku` (whose inner loop is `%counts{$w}++`)
+        // those three were 4.1% of the whole run. `const_sym` interns once per
+        // constant slot for the life of the chunk.
+        let name_sym = code.const_sym(name_idx);
         // Element type constraint of the variable, used to fill array holes with
         // the proper type object (`(Int)`) instead of Nil when autovivifying.
-        let declared_constraint_incdec = loan_env!(self, var_type_constraint(&name));
+        let declared_constraint_incdec = loan_env!(self, var_type_constraint_sym(name_sym));
         let declared_type_incdec = self
             .env()
-            .get(&name)
+            .get_sym(name_sym)
             .cloned()
             .and_then(|v| self.container_type_metadata(&v))
             .and_then(|info| info.declared_type);
@@ -466,7 +476,7 @@ impl Interpreter {
         // the env read is used exactly as before.
         let container = self
             .gate_local_slot_value_at(code, slot, &name)
-            .or_else(|| self.get_env_with_main_alias(&name));
+            .or_else(|| self.get_env_with_main_alias_sym(&name, name_sym));
         // A `%h`/`@a` an escaping closure captured is held in a shared
         // `ContainerCell` (ADR-0055's container lane), so every classification
         // and read below has to look THROUGH the cell -- a celled `BagHash`
@@ -555,7 +565,7 @@ impl Interpreter {
         // destructured into an anonymous `%a is raw` parameter, say), and the
         // two would land in different buckets.
         let object_hash_key_type: Option<String> = if name.starts_with('%') {
-            loan_env!(self, var_hash_key_constraint(&name))
+            loan_env!(self, var_hash_key_constraint_sym(&name, name_sym))
         } else {
             None
         };
@@ -966,7 +976,7 @@ impl Interpreter {
         // does, so every arm below is unchanged.
         let cell = match gate_slot {
             Some(s) => self.locals.get(s),
-            None => self.env().get(&name),
+            None => self.env().get_sym(name_sym),
         }
         .and_then(|v| match v.descalarize().view() {
             ValueView::ContainerRef(cell) => Some(cell.clone()),
@@ -979,7 +989,7 @@ impl Interpreter {
             Some(guard) => Some(&mut **guard),
             None => match gate_slot {
                 Some(s) => self.locals.get_mut(s),
-                None => self.env_mut().get_mut(&name),
+                None => self.env_mut().get_mut_sym(name_sym),
             },
         } {
             if let Some(done) = container_value.with_hash_mut(|h| {
@@ -1196,7 +1206,7 @@ impl Interpreter {
             // mutation already landed in the slot (above), and `env` is the stale
             // half, so pulling env->slot here would clobber the live slot — skip it.
             if gate_slot.is_none()
-                && let Some(val) = self.env().get(&name).cloned()
+                && let Some(val) = self.env().get_sym(name_sym).cloned()
             {
                 self.update_local_if_exists(code, &name, &val);
             }
@@ -1207,7 +1217,7 @@ impl Interpreter {
             self.writeback_critical_var(&name);
         } else {
             // Autovivify typed containers for inc/dec on undefined variables
-            let constraint = loan_env!(self, var_type_constraint(&name));
+            let constraint = loan_env!(self, var_type_constraint_sym(name_sym));
             let effective_type = declared_type_incdec.as_deref().or(constraint.as_deref());
             if let Some(type_name) = effective_type
                 && matches!(type_name, "MixHash" | "BagHash" | "SetHash")

--- a/t/incdec-index-name-symbol.t
+++ b/t/incdec-index-name-symbol.t
@@ -1,0 +1,82 @@
+use Test;
+
+# `%h{$k}++` / `@a[$i]++` resolve the *variable's* name through the chunk's
+# pre-interned constant symbol rather than re-interning the constant string on
+# every execution. Every probe the opcode makes on that name -- the declared
+# type constraint, the element-container read, the object-hash key-type lane,
+# and the write-back -- now takes the symbol, so this pins that each of those
+# still answers exactly what the string-keyed spelling answered.
+
+plan 12;
+
+# The plain lane: no constraint of any kind on the name.
+my %plain;
+%plain<a>++;
+%plain<a>++;
+is %plain<a>, 2, 'plain hash element increments';
+
+my @arr = 1, 2, 3;
+@arr[1]++;
+is @arr.join(','), '1,3,3', 'plain array element increments';
+
+# The object-hash key-type lane (`var_hash_key_constraint`): the declared key
+# type must survive the increment, so the key is stored as an Int and not
+# stringified.
+my %keyed{Int};
+%keyed{3}++;
+%keyed{3}++;
+is %keyed{3}, 2, 'object-hash element increments';
+is %keyed.keys[0].^name, 'Int', 'object-hash key keeps its declared type across ++';
+
+my %anykey{Any};
+%anykey{1}++;
+is %anykey.keys[0].^name, 'Int', 'Any-keyed object hash keeps the key type';
+
+# The same lane reached through an *attribute* (`%!conv`), which is not a
+# lexical at all -- its key type comes from the class registry, so this arm
+# still resolves by name string and must be unaffected.
+class Counter {
+    has %.conv{Str};
+    method bump($k) { %!conv{$k}++ }
+    method peek($k) { %!conv{$k} }
+}
+my $c = Counter.new;
+$c.bump('x');
+$c.bump('x');
+is $c.peek('x'), 2, 'object-hash attribute element increments';
+is $c.conv.keys[0].^name, 'Str', 'object-hash attribute keeps its declared key type';
+
+# The typed-container autovivification lane (`var_type_constraint`), which the
+# opcode consults when the element write did not land in place.
+my BagHash $bag .= new;
+$bag<a>++;
+$bag<a>++;
+is $bag<a>, 2, 'BagHash weight increments';
+
+my MixHash $mix .= new;
+$mix<z>++;
+is $mix<z>, 1, 'MixHash weight increments';
+
+# A hash reached through a scalar binding shares the caller's container, so the
+# increment must be visible through the original name too.
+my %shared;
+%shared<k>++;
+my $alias = %shared;
+$alias<k>++;
+is %shared<k>, 2, 'increment through a scalar-bound hash is visible at the source';
+
+# A hash mutated from inside a routine that captured it.
+my %captured;
+sub bump-captured() { %captured<n>++ }
+bump-captured();
+bump-captured();
+is %captured<n>, 2, 'increment of a captured outer hash accumulates';
+
+# Two same-named-key increments on *different* variables must not share state:
+# the opcode's per-name symbol is the variable's name, not the element key.
+my %left;
+my %right;
+%left<same>++;
+%right<same>++;
+%right<same>++;
+is "{%left<same>} {%right<same>}", '1 2', 'two hashes with the same key stay independent';


### PR DESCRIPTION
`exec_inc_dec_index_op` — the opcode behind `%h{$k}++` and `@a[$i]++` — read its
variable's name out of the chunk's constant pool as a `&str` and then let every
probe on that name rediscover the corresponding `Symbol` for itself.
`Symbol::intern` is a thread-local, string-keyed hash lookup (a `LocalKey`
access, a `RefCell` borrow, an `FxHashMap<String, Symbol>` probe and the
`memcmp` that confirms the hit), so the same name was re-hashed three times per
increment:

| call site | calls | Ir |
| --- | ---: | ---: |
| `get_env_with_main_alias` | 100,000 | 15.39 M |
| `var_hash_key_constraint` | 100,001 | 15.39 M |
| `Env::get_mut` | 100,000 | 15.39 M |

This hoists `code.const_sym(name_idx)` once — `const_sym` interns once per
constant slot for the life of the chunk — and threads that `Symbol` through
every probe the opcode makes on the name: the declared type constraint, the
element-container read, the object-hash key-type lane, and the write-back.
`var_type_constraint_sym`, `get_env_with_main_alias_sym` and `Env::get_mut_sym`
already existed; `var_hash_key_constraint_sym` is new, added alongside them. Its
attribute fallback still takes the `&str`, because an object-hash *attribute*
(`has Callable %!Conv{Mu:U}`) is not a lexical — its key type comes from the
class registry, resolved by spelling.

## Measured

`benchmarks/word-count.raku`, whose inner loop is `%counts{$w}++`, under
callgrind. Instruction counts are deterministic and layout-insensitive, which
matters here: this box has no `perf`, and #7579's own method notes record that
the ~5% code-layout lottery leaves a cross-build cycle comparison unable to
support a conclusion at this effect size.

| | before | after | delta |
| --- | ---: | ---: | ---: |
| `word-count` total | 1,136,132,456 | 1,046,851,308 | **−7.86%** |
| `bench-string` (control) | 530,662,736 | 530,857,721 | +0.04% |

The removal is visible directly in the profile, not only in the total:
`Symbol::intern`'s self time (20.69 M) and the intern cache's `LocalKey::with`
(33.90 M) both leave the profile entirely, and `__memcmp_avx2_movbe` falls from
33.47 M to 21.67 M as the cache's string comparisons stop happening.

Two controls establish this is work *removed* rather than work *skipped* — the
failure mode where a change measures faster because it quietly stopped doing
something. `malloc`/`_int_free` are unmoved (46.64 M / 72.02 M before, 46.63 M /
72.06 M after), so nothing is allocated or freed differently; and
`word-count`'s output is byte-identical across the two builds. `bench-string`
is the negative control: no `%h{$k}++` in it, and it does not move.

Per CLAUDE.md these local numbers are for this description only — anything
destined for PERFORMANCE.md/PLAN.md comes from the bench CI.

## A correction to #7579's item 4

Item 4 predicted the remaining `Symbol::intern` cost lived in ~75 call sites
probing the env with a *literal* key (`env().get("_")`, `env().get("/")`), and
proposed sweeping them onto the well-known pre-interned symbols. The profile
does not support that: `Env::get`'s string-keyed form is called **60 times in
the whole of `word-count`**, so that sweep would have bought essentially nothing
here.

The cost is in names known only at *runtime* — a variable name coming out of a
constant pool and re-interned per execution — not in fixed literals. Recorded in
the news entry so the next session on this ticket does not spend itself on the
sweep.

## Testing

- `t/incdec-index-name-symbol.t` (new, 12 assertions) exercises each probe the
  change touches: the object-hash key-type lane and its declared key type
  surviving an increment (`my %h{Int}`, `my %h{Any}`), the attribute fallback
  that still resolves by string, the typed-container autovivification lane
  (`BagHash`, `MixHash`), and increments through shared and captured containers.
  Verified against Rakudo as the oracle before running it on mutsu.
- `make test` — PASS, 3904 files / 41505 tests.
- `make roast` — 1436 files / 218,939 tests. The only failures are the three
  documented container-environment ones from `docs/agent-environments.md`,
  matching their recorded shapes exactly: `6.c/S32-io/file-tests.t` (`Failed: 4`,
  tests 6-8/10) and `S16-filehandles/filetest.t` (`Failed: 25`, tests
  57-64/69-72/77-80/101/103/105/107/109/111/117/121/125), both because the
  container runs as `uid 0` and root bypasses the permission bits those tests
  assert on (`id -u` confirms `0`), plus `S32-io/IO-Socket-Async.t` (exit 124,
  "planned 40 ran 17") from the network sandbox. Nothing else is red.
- `make lint` — clean across all four configurations (default clippy, `jit` off,
  wasm32 lib, rustdoc), exit 0 with zero warnings.

Refs #7579 (one item of a multi-part perf ticket; the ticket stays open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AwyzwY1Ssnq7esugcTfPNY

---
_Generated by [Claude Code](https://claude.ai/code/session_01AwyzwY1Ssnq7esugcTfPNY)_