### PR TITLE
fix(compiler): resolve if branch let and temp saves

### DIFF
--- a/news/2026-09/if-body-let-temp-resolution.md
+++ b/news/2026-09/if-body-let-temp-resolution.md
@@ -1,0 +1,24 @@
+# `if` and `unless` branches now resolve `let`/`temp` saves
+
+An `if`/`unless` branch is a Raku block and must resolve the `let`/`temp`
+saves written in its body when the selected branch exits. mutsu previously
+compiled ordinary branches directly, so a `temp` could survive past the
+branch:
+
+```raku
+my $g = 1;
+if 1 { temp $g = 9 }
+say $g;                 # 1 in raku and mutsu now
+```
+
+The compiler now brackets a branch containing `let` or `temp` with
+`OpCode::LetBlock`. A real `let` uses the branch's value on the value stack to
+decide whether to keep or restore the save; a `temp`-only branch keeps the
+ordinary sink lowering because it always restores. The same bracket is applied
+to value-position and routine-tail `if` branches, without routing the branch
+value through the enclosing topic.
+
+`t/if-body-let-resolution.t` covers `if`, `unless`, `else`, constant and
+runtime-selected branches, `let` commit/rollback, nested/block-local branches,
+value-position branches, and routine-tail branches. All assertions pass under
+Rakudo and mutsu.

--- a/src/compiler/control_if.rs
+++ b/src/compiler/control_if.rs
@@ -192,22 +192,70 @@ impl Compiler {
             // (checked by every value-position caller) has already rejected the
             // phaser shapes the statement emitters below exist for, so
             // `compile_block_inline` covers everything that reaches here.
-            IfPosition::Value => self.compile_block_inline(branch),
-            IfPosition::Statement => {
-                if Self::has_block_enter_leave_phasers(branch) {
-                    // A branch with ENTER/LEAVE/KEEP/UNDO phasers is a real
-                    // block scope: its LEAVE must fire when the branch exits
-                    // (OO::Monitors unlocks its monitor lock this way).
-                    self.compile_phaser_block_scope(branch, PhaserBlockResult::Discard);
-                } else if Self::body_mutates_topic(branch) {
-                    self.synthetic_block_body = true;
-                    self.compile_stmt(&Stmt::Block(branch.to_vec()));
-                } else if Self::branch_declares_block_local(branch) {
-                    self.compile_block_local_branch(branch);
-                } else {
-                    self.compile_body_with_implicit_try(branch);
-                }
+            IfPosition::Value => {
+                self.compile_if_value_branch(branch, |c| c.compile_block_inline(branch))
             }
+            IfPosition::Statement => self.compile_if_statement_branch(branch),
+        }
+    }
+
+    /// Compile a statement-position branch, including the branch's own
+    /// `let`/`temp` save frame. This is shared with constant-condition folding,
+    /// which bypasses the ordinary `compile_if_construct` path.
+    pub(super) fn compile_if_statement_branch(&mut self, branch: &[Stmt]) {
+        if Self::has_block_enter_leave_phasers(branch) {
+            // A branch with ENTER/LEAVE/KEEP/UNDO phasers is a real block
+            // scope: its LEAVE must fire when the branch exits (OO::Monitors
+            // unlocks its monitor lock this way).
+            let needs_value = Self::has_real_let_deep(branch);
+            let let_frame = Self::has_let_deep(branch).then(|| {
+                self.code.emit(OpCode::LetBlock {
+                    body_end: 0,
+                    value_on_stack: needs_value,
+                })
+            });
+            self.compile_phaser_block_scope(
+                branch,
+                if needs_value {
+                    PhaserBlockResult::Push
+                } else {
+                    PhaserBlockResult::Discard
+                },
+            );
+            if let Some(idx) = let_frame {
+                self.code.patch_let_block_end(idx);
+            }
+            if needs_value {
+                self.code.emit(OpCode::Pop);
+            }
+        } else if Self::body_mutates_topic(branch) {
+            self.synthetic_block_body = true;
+            self.compile_stmt(&Stmt::Block(branch.to_vec()));
+        } else if Self::branch_declares_block_local(branch) {
+            if Self::has_let_deep(branch) {
+                self.compile_block_local_branch_with_let(branch);
+            } else {
+                self.compile_block_local_branch(branch);
+            }
+        } else if Self::has_let_deep(branch) {
+            let needs_value = Self::has_real_let_deep(branch);
+            let idx = self.code.emit(OpCode::LetBlock {
+                body_end: 0,
+                value_on_stack: needs_value,
+            });
+            if needs_value {
+                self.compile_body_with_implicit_try_value(branch);
+            } else {
+                self.compile_body_with_implicit_try(branch);
+            }
+            self.code.patch_let_block_end(idx);
+            if needs_value {
+                // The frame peeks the body value to decide a real `let`, so
+                // discard it after the branch has resolved its saves.
+                self.code.emit(OpCode::Pop);
+            }
+        } else {
+            self.compile_body_with_implicit_try(branch);
         }
     }
 }

--- a/src/compiler/expr_block.rs
+++ b/src/compiler/expr_block.rs
@@ -148,7 +148,7 @@ impl Compiler {
                     self.emit_inlined_body_placeholder_binds(body, ArgSupply::Topic);
                 }
                 let given_idx = self.code.emit(OpCode::DoGivenExpr { body_end: 0 });
-                self.compile_block_inline(body);
+                self.compile_if_value_branch(body, |c| c.compile_block_inline(body));
                 self.code.patch_body_end(given_idx);
             }
             Stmt::Assign { name, expr, .. } => {

--- a/src/compiler/helpers_control_flow.rs
+++ b/src/compiler/helpers_control_flow.rs
@@ -342,11 +342,13 @@ impl Compiler {
         // Value position changes nothing about the branch being a block literal
         // re-cloned per execution — see `OpCode::ResetStateLocals`.
         let then_state_reset = self.emit_branch_state_reset(then_branch, is_statement_modifier);
-        if Self::has_block_enter_leave_phasers(then_branch) {
-            self.compile_phaser_block_scope(then_branch, PhaserBlockResult::Push);
-        } else {
-            self.compile_stmts_value(then_branch);
-        }
+        self.compile_if_value_branch(then_branch, |c| {
+            if Self::has_block_enter_leave_phasers(then_branch) {
+                c.compile_phaser_block_scope(then_branch, PhaserBlockResult::Push);
+            } else {
+                c.compile_stmts_value(then_branch);
+            }
+        });
         self.patch_nested_block_state_reset(then_state_reset);
         let jump_end = self.code.emit(OpCode::Jump(0));
         self.code.patch_jump(jump_else);
@@ -359,11 +361,13 @@ impl Compiler {
             self.code.emit(OpCode::LoadConst(empty_idx));
         } else {
             let else_state_reset = self.emit_branch_state_reset(else_branch, is_statement_modifier);
-            if Self::has_block_enter_leave_phasers(else_branch) {
-                self.compile_phaser_block_scope(else_branch, PhaserBlockResult::Push);
-            } else {
-                self.compile_stmts_value(else_branch);
-            }
+            self.compile_if_value_branch(else_branch, |c| {
+                if Self::has_block_enter_leave_phasers(else_branch) {
+                    c.compile_phaser_block_scope(else_branch, PhaserBlockResult::Push);
+                } else {
+                    c.compile_stmts_value(else_branch);
+                }
+            });
             self.patch_nested_block_state_reset(else_state_reset);
         }
         self.code.patch_jump(jump_end);
@@ -510,6 +514,51 @@ impl Compiler {
         self.code.patch_block_local_body_end(idx);
     }
 
+    /// Compile an `if`/`unless`/`else` branch whose block-local declarations
+    /// coexist with a `let`/`temp` save. The block-local scope remains the
+    /// outer scope so its declaration cleanup still runs after the save frame.
+    pub(super) fn compile_block_local_branch_with_let(&mut self, stmts: &[Stmt]) {
+        let needs_value = Self::has_real_let_deep(stmts);
+        let idx = self.code.emit(OpCode::BlockLocalScope {
+            body_end: 0,
+            succeed_boundary: true,
+        });
+        self.in_scope_restored_body(|c| {
+            let let_idx = c.code.emit(OpCode::LetBlock {
+                body_end: 0,
+                value_on_stack: needs_value,
+            });
+            if needs_value {
+                c.compile_body_with_implicit_try_value(stmts);
+            } else {
+                c.compile_body_with_implicit_try(stmts);
+            }
+            c.code.patch_let_block_end(let_idx);
+            if needs_value {
+                // Keep the block-local scope stack-balanced after the frame
+                // has inspected the branch's value.
+                c.code.emit(OpCode::Pop);
+            }
+        });
+        self.code.patch_block_local_body_end(idx);
+    }
+
+    /// Bracket an if-branch value with the save frame owned by the branch.
+    /// `body` supplies the position-specific branch lowering while the frame
+    /// consistently reads the value stack, preserving the enclosing topic.
+    pub(super) fn compile_if_value_branch(&mut self, stmts: &[Stmt], body: impl FnOnce(&mut Self)) {
+        let let_frame = Self::has_let_deep(stmts).then(|| {
+            self.code.emit(OpCode::LetBlock {
+                body_end: 0,
+                value_on_stack: true,
+            })
+        });
+        body(self);
+        if let Some(idx) = let_frame {
+            self.code.patch_let_block_end(idx);
+        }
+    }
+
     /// Compile a loop body (`while`/`until`/C-style `loop`/`repeat`/`for`) as a
     /// scope whose env is restored on exit. The loop opcodes bracket the body
     /// with `push_loop_local_scope`/`pop_loop_local_scope`, which is exactly the
@@ -631,13 +680,8 @@ impl Compiler {
             // one case. Deliberately `has_block_leave_worthy_phasers`, not
             // `has_block_enter_leave_phasers` — see that function's doc.
             self.compile_phaser_block_scope(stmts, PhaserBlockResult::Discard);
-        } else if Self::body_mutates_topic(stmts) {
-            self.synthetic_block_body = true;
-            self.compile_stmt(&Stmt::Block(stmts.to_vec()));
-        } else if Self::branch_declares_block_local(stmts) {
-            self.compile_block_local_branch(stmts);
         } else {
-            self.compile_body_with_implicit_try(stmts);
+            self.compile_if_statement_branch(stmts);
         }
     }
 

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -2943,6 +2943,17 @@ impl Compiler {
                         succeed_boundary: false,
                     })
                 });
+                // `given`/`with` bodies are blocks too. Keep their own
+                // `let`/`temp` saves inside the topicalizer, so a `with`
+                // branch resolves a save before execution continues after the
+                // enclosing `if`.
+                let needs_value = Self::has_real_let_deep(body);
+                let let_frame = Self::has_let_deep(body).then(|| {
+                    self.code.emit(OpCode::LetBlock {
+                        body_end: 0,
+                        value_on_stack: needs_value,
+                    })
+                });
                 let saved_scope =
                     (!*is_statement_modifier).then(|| self.push_dynamic_scope_lexical());
                 if Self::has_block_leave_worthy_phasers(body) {
@@ -2978,10 +2989,19 @@ impl Compiler {
                     // sink-context warning, same as raku) and `do given`
                     // expression context (the value still comes through
                     // correctly, via the separate `Push`-mode path).
-                    self.compile_phaser_block_scope(body, PhaserBlockResult::Discard);
+                    self.compile_phaser_block_scope(
+                        body,
+                        if needs_value {
+                            PhaserBlockResult::Push
+                        } else {
+                            PhaserBlockResult::Discard
+                        },
+                    );
                 } else if Self::has_catch_or_control(body) {
                     self.compile_implicit_try(body);
-                    self.code.emit(OpCode::Pop);
+                    if !needs_value {
+                        self.code.emit(OpCode::Pop);
+                    }
                 } else {
                     for (i, s) in body.iter().enumerate() {
                         let is_last = i == body.len() - 1;
@@ -2993,6 +3013,9 @@ impl Compiler {
                             self.compile_stmt(s);
                         }
                     }
+                }
+                if let Some(idx) = let_frame {
+                    self.code.patch_let_block_end(idx);
                 }
                 if let Some(saved) = saved_scope {
                     self.pop_dynamic_scope_lexical(saved);

--- a/t/if-body-let-resolution.t
+++ b/t/if-body-let-resolution.t
@@ -1,0 +1,81 @@
+use Test;
+
+# GH-7720: an `if`/`unless` branch is a Raku block and owns the
+# `let`/`temp` saves written in its body. The statement lowering used to
+# compile the branch directly, so a save survived until an unrelated outer
+# scope (or the end of the program) instead of resolving at branch exit.
+#
+# The value-position checks use a decontainerized tail where the value itself
+# is observable before the branch restores its save. The branch must still
+# restore the outer variable before the following statement runs.
+
+plan 13;
+
+{
+    my $g = 1;
+    if 1 { temp $g = 9; }
+    is $g, 1, '`if` restores a `temp` in a constant-selected branch';
+}
+
+{
+    my $g = 1;
+    my $take = True;
+    if $take { temp $g = 9; }
+    is $g, 1, '`if` restores a `temp` in a runtime-selected branch';
+}
+
+{
+    my $g = 1;
+    unless 0 { temp $g = 9; }
+    is $g, 1, '`unless` restores a `temp`';
+}
+
+{
+    my $g = 1;
+    with 1 { temp $g = 9; }
+    is $g, 1, '`with` restores a `temp` in its branch';
+}
+
+{
+    my $g = 1;
+    if False { temp $g = 9; } else { temp $g = 8; }
+    is $g, 1, 'the selected `else` branch restores a `temp`';
+}
+
+{
+    my $g = 1;
+    if True { let $g = 9; Nil }
+    is $g, 1, 'an undefined `if` branch value rolls back a `let`';
+}
+
+{
+    my $g = 1;
+    if True { let $g = 9 }
+    is $g, 9, 'a defined `if` branch value commits a `let`';
+}
+
+{
+    my $g = 1;
+    if True { my $local = 2; temp $g = 9; }
+    is $g, 1, 'a branch-local declaration does not bypass `temp` restoration';
+}
+
+{
+    my $g = 1;
+    if True { if True { temp $g = 9; } }
+    is $g, 1, 'a nested `if` branch restores its `temp`';
+}
+
+{
+    my $g = 1;
+    my $value = do if True { temp $g = 9; $g + 0 };
+    is $value, 9, 'a value-position `if` exposes its branch value';
+    is $g, 1, 'a value-position `if` restores its `temp`';
+}
+
+{
+    my $g = 1;
+    sub branch-value() { if True { temp $g = 9; $g + 0 } else { 0 } }
+    is branch-value(), 9, 'a routine-tail `if` exposes its branch value';
+    is $g, 1, 'a routine-tail `if` restores its `temp`';
+}


### PR DESCRIPTION
Closes #7720

## Summary

- bracket `if`/`unless` branch bodies with `LetBlock` when they contain `let` or `temp`
- preserve branch values on the value stack so real `let` saves commit or roll back from the branch result
- apply the same save-frame handling to constant-folded branches and `with`/`given` paths
- add focused mutsu/Rakudo regression coverage and a news entry

## Tests

- `make lint`
- `make test`
- `make roast`
- `target/debug/mutsu t/if-body-let-resolution.t`
- `raku t/if-body-let-resolution.t`
