### PR TITLE
fix(grammar): preserve direct alias .made in alternations

### DIFF
--- a/news/2026-09/direct-alias-made-in-ordered-alternation.md
+++ b/news/2026-09/direct-alias-made-in-ordered-alternation.md
@@ -1,0 +1,25 @@
+# Direct regex aliases preserve subrule `.made` across alternation
+
+Grammar captures written as `$<part> = <rule>` now retain the action-produced
+`.made` value when the alias appears inside an ordered alternation. This also
+works when the same alias names different rules in different branches, as in
+`$<part> = <text> || $<part> = <code>`.
+
+## Root cause
+
+The alias and the original subrule capture share one `CapNode`, but the
+sigil-prefixed alias path did not record which rule's action should dispatch for
+that node. When the alias entry was visited before the original rule-name entry,
+the action walk treated it as an actionless capture and the shared node never
+received its `.made` value. Alternation wrappers also dropped the alias metadata
+while reshaping inner capture deltas.
+
+## Fix
+
+The matcher now tags each direct-alias capture node with its original rule name,
+and all alternation/group delta paths preserve capture alias metadata. Dispatch
+therefore remains node-specific and does not confuse repeated aliases that select
+different rules.
+
+Pinned by `t/grammar-direct-alias-made-alternation.t` (8 assertions), including
+both branch orders, fallback to the second branch, and repeated mixed matches.

--- a/src/runtime/regex/regex_match_atom.rs
+++ b/src/runtime/regex/regex_match_atom.rs
@@ -110,6 +110,9 @@ impl Interpreter {
             for (k, v) in inner_caps.named.drain() {
                 new_caps.named.entry(k).or_default().merge(v);
             }
+            for (k, v) in inner_caps.capture_alias_map.drain() {
+                new_caps.capture_alias_map.insert(k, v);
+            }
             new_caps.positional.append(&mut inner_caps.positional);
             super::regex_helpers::adopt_inline_ast(&mut new_caps, &mut inner_caps);
             new_caps
@@ -189,6 +192,9 @@ impl Interpreter {
                     let mut new_caps = RegexCaptures::default();
                     for (k, v) in inner_caps.named.drain() {
                         new_caps.named.entry(k).or_default().merge(v);
+                    }
+                    for (k, v) in inner_caps.capture_alias_map.drain() {
+                        new_caps.capture_alias_map.insert(k, v);
                     }
                     new_caps.positional.append(&mut inner_caps.positional);
                     super::regex_helpers::adopt_inline_ast(&mut new_caps, &mut inner_caps);
@@ -535,6 +541,9 @@ impl Interpreter {
                     let mut new_caps = RegexCaptures::default();
                     for (k, v) in inner_caps.named.drain() {
                         new_caps.named.entry(k).or_default().merge(v);
+                    }
+                    for (k, v) in inner_caps.capture_alias_map.drain() {
+                        new_caps.capture_alias_map.insert(k, v);
                     }
                     new_caps.positional.append(&mut inner_caps.positional);
                     super::regex_helpers::adopt_inline_ast(&mut new_caps, &mut inner_caps);

--- a/src/runtime/regex/regex_match_capture.rs
+++ b/src/runtime/regex/regex_match_capture.rs
@@ -318,6 +318,9 @@ impl Interpreter {
                         for (k, v) in inner_caps.named.drain() {
                             new_caps.named.entry(k).or_default().merge(v);
                         }
+                        for (k, v) in inner_caps.capture_alias_map.drain() {
+                            new_caps.capture_alias_map.insert(k, v);
+                        }
                         new_caps.positional.append(&mut inner_caps.positional);
                         super::regex_helpers::adopt_inline_ast(&mut new_caps, &mut inner_caps);
                         new_caps.regex_vars.extend(inner_caps.regex_vars);

--- a/src/runtime/regex/regex_match_core.rs
+++ b/src/runtime/regex/regex_match_core.rs
@@ -420,7 +420,7 @@ impl Interpreter {
         } else {
             None
         };
-        let sub = if let Some(mut gs) = group_subcap.take() {
+        let mut sub = if let Some(mut gs) = group_subcap.take() {
             // Keep the group's nested captures, but pin the span to the
             // aliased group's extent.
             let gsm = std::sync::Arc::make_mut(&mut gs);
@@ -436,6 +436,32 @@ impl Interpreter {
                 ..Default::default()
             })
         };
+        // A sigil-prefixed alias (`$<alias> = <rule>`) shares the subrule's
+        // capture node with the original rule-name entry, just like the
+        // angle-bracket form (`<alias=rule>`). Tag that shared node with the
+        // original rule name so the grammar action walk can dispatch through
+        // the alias even when the alias entry is visited first. This must be
+        // per node: one alias name can select different rules in different
+        // alternatives (`$<part> = <text> || $<part> = <code>`).
+        if let RegexAtom::Named(atom_name) = &token.atom {
+            let spec = Self::parse_named_regex_lookup_spec(atom_name);
+            if !spec.silent
+                && !spec.lookup_name.is_empty()
+                && name != &spec.lookup_name
+                && let Some(original) = store
+                    .caps_mut()
+                    .named
+                    .get_mut(&Symbol::intern(&spec.lookup_name))
+                    .and_then(|slot| slot.nodes.last_mut())
+                && original.from == from
+                && original.to == to
+                && std::sync::Arc::ptr_eq(original, &sub)
+            {
+                let node = std::sync::Arc::make_mut(original);
+                node.action_name = Some(spec.lookup_name);
+                sub = std::sync::Arc::clone(original);
+            }
+        }
         store.push_named_node(name, sub);
         // `@<name>=` array-sigil alias forces list context: mark the name as
         // quantified so the Match builder always presents it as a List, even

--- a/src/runtime/regex/regex_match_delta.rs
+++ b/src/runtime/regex/regex_match_delta.rs
@@ -41,6 +41,9 @@ pub(super) fn group_merge_delta(mut inner_caps: RegexCaptures) -> RegexCaptures 
     for (k, v) in inner_caps.named.drain() {
         new_caps.named.entry(k).or_default().merge(v);
     }
+    for (k, v) in inner_caps.capture_alias_map.drain() {
+        new_caps.capture_alias_map.insert(k, v);
+    }
     new_caps.positional.append(&mut inner_caps.positional);
     super::regex_helpers::adopt_inline_ast(&mut new_caps, &mut inner_caps);
     new_caps
@@ -92,6 +95,9 @@ pub(super) fn alternation_branch_delta(
     let mut new_caps = RegexCaptures::default();
     for (k, v) in inner_caps.named.drain() {
         new_caps.named.entry(k).or_default().merge(v);
+    }
+    for (k, v) in inner_caps.capture_alias_map.drain() {
+        new_caps.capture_alias_map.insert(k, v);
     }
     new_caps.positional.append(&mut inner_caps.positional);
     super::regex_helpers::adopt_inline_ast(&mut new_caps, &mut inner_caps);

--- a/src/runtime/regex/regex_trail.rs
+++ b/src/runtime/regex/regex_trail.rs
@@ -89,6 +89,11 @@ impl CapStore {
         &self.caps
     }
 
+    #[inline]
+    pub(super) fn caps_mut(&mut self) -> &mut RegexCaptures {
+        &mut self.caps
+    }
+
     /// Clone the accumulated captures — used once per complete match to
     /// materialize an engine result. Nested sub-captures are `Arc`-shared, so
     /// this copies only this pattern level's own state.

--- a/t/grammar-direct-alias-made-alternation.t
+++ b/t/grammar-direct-alias-made-alternation.t
@@ -1,0 +1,48 @@
+use Test;
+
+# A sigil-prefixed alias (`$<part> = <rule>`) shares the subrule's Match node
+# with the rule-name capture. The node must still carry the action method's
+# `.made` value when the alias occurs in an ordered alternation, including when
+# the same alias name selects different rules in different branches.
+
+plan 8;
+
+grammar Forward {
+    token TOP { ^ [ $<part> = <text> || $<part> = <code> ]* $ }
+    token text { <-[<]>+ }
+    token code { '<' \w+ '>' }
+}
+
+grammar Reverse {
+    token TOP { ^ [ $<part> = <code> || $<part> = <text> ]* $ }
+    token text { <-[<]>+ }
+    token code { '<' \w+ '>' }
+}
+
+class Actions {
+    method text($/) { make 'T:' ~ $/.Str }
+    method code($/) { make 'C:' ~ $/.Str }
+    method TOP($/) { make $<part>.map({ .made // 'NIL' }).join(',') }
+}
+
+my $forward = Forward.parse('ab<x>cd', actions => Actions);
+is $forward.made, 'T:ab,C:<x>,T:cd',
+    'aliases in the first branch preserve every subrule .made';
+is $forward<part>[0].made, 'T:ab', 'the first forward alias carries .made';
+is $forward<part>[1].made, 'C:<x>', 'the code branch carries .made';
+
+my $reverse-text = Reverse.parse('abcd', actions => Actions);
+is $reverse-text.made, 'T:abcd',
+    'a text match in the second branch carries its .made';
+
+my $reverse-code = Reverse.parse('<x>', actions => Actions);
+is $reverse-code.made, 'C:<x>',
+    'a code match in the second branch carries its .made';
+
+my $reverse-mixed = Reverse.parse('ab<x>cd', actions => Actions);
+is $reverse-mixed.made, 'T:ab,C:<x>,T:cd',
+    'the same alias can select different action-bearing rules per iteration';
+is $reverse-mixed<part>[0].made, 'T:ab',
+    'the first reverse iteration retains its own rule action';
+is $reverse-mixed<part>[1].made, 'C:<x>',
+    'the second reverse iteration retains its own rule action';


### PR DESCRIPTION
## Summary

- preserve `.made` on sigil-prefixed subrule aliases inside ordered alternations
- keep alias metadata through regex group and alternation capture deltas
- add focused regression coverage and a news entry

The alias and its original subrule capture share one capture node. The matcher now records the original rule name on that node so grammar action dispatch remains correct regardless of capture-map traversal order, while preserving per-node behavior when one alias name selects different rules in different alternatives.

Closes #7730

## Validation

- `cargo fmt --all`
- `make lint`
- `make test`
- `make roast`
