### PR TITLE
fix(runtime): preserve compunit scope in construction defaults

### DIFF
--- a/news/2026-09/file-scoped-default-call-in-construction.md
+++ b/news/2026-09/file-scoped-default-call-in-construction.md
@@ -1,0 +1,12 @@
+# File-scoped subs remain visible to construction-time defaults
+
+Attribute initializers and `BUILD` parameter defaults now resolve bare calls
+in the compilation unit that declared their class. This keeps a private helper
+beside a class visible when another module constructs it, including both
+`has $.value = helper()` and `submethod BUILD(:$!value = helper())`.
+
+The construction paths already knew the class or method declaration involved,
+but evaluated these expressions while the caller's compilation unit was
+active. That made compunit-private helpers look undeclared after module loading
+moved them out of the shared `GLOBAL` routine table. The regression is pinned by
+`t/attr-default-file-scoped-call.t`.

--- a/src/runtime/attr_build_defaults.rs
+++ b/src/runtime/attr_build_defaults.rs
@@ -335,7 +335,16 @@ impl Interpreter {
         // `constructing_class` fallback).
         let saved_constructing = self.constructing_class.take();
         self.constructing_class = Some(class_key.to_string());
+        // The default chunk runs during construction, not while the class's
+        // compilation unit is active. Restore that lexical unit explicitly so
+        // a bare call can reach a compunit-private sub declared beside the
+        // class even when a foreign module called `.new`.
+        let saved_unit = self.current_unit;
+        if let Some(&unit) = self.class_declaring_units.get(class_key) {
+            self.current_unit = unit;
+        }
         let result = self.eval_decl_trait_arg(arg);
+        self.current_unit = saved_unit;
         self.constructing_class = saved_constructing;
         self.set_current_package(saved_package);
         for (key, old_val) in saved_attr_env {

--- a/src/runtime/class_dispatch.rs
+++ b/src/runtime/class_dispatch.rs
@@ -615,6 +615,8 @@ impl Interpreter {
         let saved_pending = std::mem::take(&mut self.pending_rw_writeback_sources);
         crate::alloc_scope_end!(_sc_cc);
         crate::alloc_scope_named!(_sc_call, "resolved-method-celled:call");
+        let saved_unit = self.current_unit;
+        self.current_unit = self.unit_of_source(method_def.source_file.as_deref());
         let call_result = self.call_compiled_method(
             receiver_class_name,
             owner_class,
@@ -626,6 +628,12 @@ impl Interpreter {
             invocant,
             fns_ref,
         );
+        // Parameter defaults are evaluated while binding, before the method
+        // routine frame is pushed. Anchor that phase to the method's defining
+        // compunit so its file-private helpers remain visible across modules.
+        // The method body itself already records the same source file on its
+        // routine frame; this only covers the pre-frame bind phase.
+        self.current_unit = saved_unit;
         crate::alloc_scope_end!(_sc_call);
         // MERGE the saved sibling writes (e.g. a sibling BUILD's captured-outer
         // write queued for the outer `.new` caller to drain, #3620) with the

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1744,6 +1744,12 @@ pub struct Interpreter {
     /// resolution is unit-dependent and therefore must bypass the name-keyed
     /// resolution caches (which are not keyed by unit).
     pub(crate) unit_private_names: HashSet<Symbol>,
+    /// The compilation unit that declared each user class. Attribute defaults
+    /// run later, while constructing an instance from an arbitrary caller, so
+    /// they need the same unit anchor as the class body to resolve compunit-
+    /// private routines. Method parameter defaults use this metadata before the
+    /// method's routine frame exists as well.
+    pub(crate) class_declaring_units: HashMap<String, Symbol>,
     /// Routines installed by a prelude spliced into a host compunit
     /// (`PRELUDE_SUB_TRAIT`, e.g. NativeCall's `nativecast`/`nativesizeof`).
     /// They deliberately live under `GLOBAL` for every compunit that uses them

--- a/src/runtime/registration_class_decl.rs
+++ b/src/runtime/registration_class_decl.rs
@@ -276,6 +276,13 @@ impl Interpreter {
             is_hoisted_shell,
         )?;
         self.finalize_class_registration(name, parents, class_def, &snapshot)?;
+        // Construction-time attribute defaults and BUILD parameter defaults
+        // execute after this declaration, often from another compunit. Keep
+        // the declaring unit so those evaluations can still see this file's
+        // private top-level routines.
+        let declaring_unit = self.unit_of_declaring_file(self.current_source_file().as_deref());
+        self.class_declaring_units
+            .insert(name.to_string(), declaring_unit);
         self.install_class_exporthow(name, parents)?;
         Ok(deferred_custom_traits)
     }

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -2941,6 +2941,7 @@ impl Interpreter {
             user_declared_infix_ops: HashMap::new(),
             unit_private_routines: HashMap::new(),
             unit_private_names: HashSet::new(),
+            class_declaring_units: HashMap::new(),
             prelude_sub_names: HashSet::new(),
             current_unit: crate::runtime::main_unit(),
             closures_created: 0,

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -572,6 +572,7 @@ impl Interpreter {
             user_declared_infix_ops: self.user_declared_infix_ops.clone(),
             unit_private_routines: self.unit_private_routines.clone(),
             unit_private_names: self.unit_private_names.clone(),
+            class_declaring_units: self.class_declaring_units.clone(),
             prelude_sub_names: self.prelude_sub_names.clone(),
             current_unit: self.current_unit,
             closures_created: 0,

--- a/t/attr-default-file-scoped-call.t
+++ b/t/attr-default-file-scoped-call.t
@@ -1,0 +1,18 @@
+use lib 't/lib';
+use Test;
+use Issue7733::Conf;
+use Issue7733::User;
+
+plan 4;
+
+my $direct = Issue7733::Conf.new;
+is $direct.attribute-default, 'direct',
+   'an attribute default sees a file-scoped sub from the mainline';
+is $direct.build-default, 'direct',
+   'a BUILD parameter default sees a file-scoped sub from the mainline';
+
+my $foreign = Issue7733::User.new;
+is $foreign.config.attribute-default, 'direct',
+   'an attribute default sees its file-scoped sub across a module boundary';
+is $foreign.config.build-default, 'direct',
+   'a BUILD parameter default sees its file-scoped sub across a module boundary';

--- a/t/lib/Issue7733/Conf.rakumod
+++ b/t/lib/Issue7733/Conf.rakumod
@@ -1,0 +1,8 @@
+sub default-mode(--> Str) { 'direct' }
+
+class Issue7733::Conf is export {
+    has Str $.attribute-default = default-mode();
+    has Str $.build-default;
+
+    submethod BUILD(Str :$!build-default = default-mode()) { }
+}

--- a/t/lib/Issue7733/User.rakumod
+++ b/t/lib/Issue7733/User.rakumod
@@ -1,0 +1,9 @@
+use Issue7733::Conf;
+
+class Issue7733::User is export {
+    has Issue7733::Conf $.config;
+
+    submethod BUILD(Issue7733::Conf :$config) {
+        $!config = $config // Issue7733::Conf.new;
+    }
+}


### PR DESCRIPTION
Closes #7733

## Summary
- preserve each class's declaring compilation unit for construction-time defaults
- resolve file-scoped helpers from attribute initializers and BUILD parameter defaults across module boundaries
- add a focused regression test and news entry

## Tests
- cargo fmt --all
- make lint
- make test
- make roast