### PR TITLE
fix: resolve a `*-1` subscript at every chain level, and decide a qualified private call lexically

### DIFF
--- a/docs/batteries/templates.md
+++ b/docs/batteries/templates.md
@@ -49,19 +49,44 @@ plain checkout of the dist with `-I lib`.
 | Candidate | Version | Released | License | Runtime deps | Dependents¹ | raku | **mutsu** |
 | --- | --- | --- | --- | --- | --- | --- | --- |
 | **`Template::Mustache`** | 1.2.6 | 2026-01-12 | Artistic-2.0 | **0** | **11** | 11/13² | **13/13** |
-| `Template6` | 0.16.0 | 2026-02-04³ | Artistic-2.0 | **0** | 7 | **12/12** | **12/12** ⬆ |
-| `Template::Jinja2` | 0.2.0 | 2026-04-29 | Artistic-2.0 | 1 (`JSON::Fast`, native) | 2 | 22/23 | **3/23** ⬆ |
-| `Template::Mojo` | 0.2.2 | 2023-07-31 | MIT | **0** | 3 | **5/5** | **4/5** |
-| `Template::Nest::Fast` | 0.3.0 | 2024-11-18 | ISC | **0** | 0 | **10/10** | **10/10** ⬆ |
+| `Template6` | 0.16.0 | 2025-08-04³ | Artistic-2.0 | **0** | 7 | **12/12** | **12/12** |
+| `Template::Jinja2` | 0.3.0 | 2026-08-21 | Artistic-2.0 | 1 (`JSON::Fast`, native) | 2 | 23/24 | **8/24** ⬆ |
+| `Template::Mojo` | 0.2.2 | 2023-07-31 | MIT | **0** | 3 | **5/5** | **5/5** ⬆ |
+| `Template::Nest::Fast` | 0.3.0 | 2024-11-18 | ISC | **0** | 0 | **10/10** | **10/10** |
 | `SP6` | 0.2.1 | 2021-09-04 | Apache-2.0 | **0** | 0 | 10/11 | **10/11** |
 | `Template::Classic` | 0.0.3 | 2020-04-11 | BSD-3-Clause | **0** | 1 | **1/1** | 0/1 |
-| `Template::HAML` | 0.9.5 | 2026-06-27 | Artistic-2.0 | **0** | 2 | 82/83 | 39/83⁴ |
+| `Template::HAML` | 0.9.6 | 2026-08-02 | Artistic-2.0 | **0** | 2 | 84/85 | 3/85⁴ ⁵ |
 | `Template::Protone` | 0.1.4 | 2021-01-20 | Artistic-2.0 | **0** | 0 | *ships no tests* | *ships no tests* |
 | `ERK` | 1.1.4 | 2025-11-14 | Artistic-2.0 | **0** | 1 | *ships no tests* | *ships no tests* |
 
-The mutsu column was **re-measured in full on 2026-09-06** (debug build). Do not
-quote a row without re-running the survey: on that re-run four of the eight rows
-had moved since the last measurement, all from unrelated work.
+**Both** columns were re-measured in full on **2026-09-09** (debug build, every
+tarball re-fetched from the REA archive). Do not quote a row without re-running
+the survey — on this run three of the pinned versions had moved under the table
+(`Template::Jinja2` 0.2.0 → 0.3.0, `Template::HAML` 0.9.5 → 0.9.6,
+`Template6`'s REA copy 0.15.0 → 0.16.0), and two rows moved for reasons that had
+nothing to do with the version:
+
+- `Template::Jinja2` **3/23 → 8/24** on the two general fixes in
+  `news/2026-09/whatever-index-at-a-non-final-subscript-level.md` and
+  `news/2026-09/qualified-private-call-decided-by-the-dynamic-caller.md`.
+- `Template::HAML` measures **3/85**, against the 39/83 this table recorded for
+  0.9.5. That figure does not reproduce: 0.9.5 re-fetched and re-run today gives
+  **3/83**, and the blocking error is present on a clean `main` build, so it is
+  not a regression from anything in flight. Almost every file dies before the
+  module loads, on `Unknown function: default-emit-mode` — an attribute/parameter
+  default that *calls* a file-scoped sub cannot see it when `.new` runs inside
+  another module. Filed as
+  [#7733](https://github.com/tokuhirom/mutsu/issues/7733); it is the non-closure
+  sibling of the already-fixed default-closure package bug, and fixing it should
+  move this row a long way in one step.
+- `Template::Classic`, recorded as 1/1 on 2026-09-08, is **0/1** again. That is
+  not a regression from those fixes (neither touches the regex engine): the
+  #7614 fix was real, and behind it sits one more bug — an aliased subrule
+  (`$<part> = <text>`) inside an alternation loses the subrule's `.made`, so the
+  dist's `Actions.TOP` builds an empty `lazy gather { }`. Filed as
+  [#7730](https://github.com/tokuhirom/mutsu/issues/7730) with the full matrix.
+  Three times running this row's "the diagnosis is now settled" note has been
+  premature; treat it as one bug from 1/1, not zero.
 
 ⬆ `Template6` went **0/12 → 10/12 → 11/12 → 12/12** on 2026-09-06 — the dist is
 complete. Its long-standing
@@ -109,33 +134,37 @@ computed over the 2506 distinct dist names in the local REA + fez indices
 (`~/.zef/store/{rea,fez}/*.json`), the same data `mzef` uses.
 ² The two `91/92-specs` files need `JSON::Fast` from the ecosystem, which is not
 installed for the raku baseline; they are a harness gap, not a raku failure.
-³ REA's newest is 0.15.0 (2026-02-04); fez carries 0.16.0, which is what was
-measured.
-⁴ `Template::HAML` is also **slower under mutsu than under raku** — a separate
+³ REA now serves 0.16.0 itself (it carried only 0.15.0 when this row was first
+measured, and fez was used instead).
+⁵ `Template::HAML` is also **slower under mutsu than under raku** — a separate
 finding from the failures. In a *release* build the gap is ~2–3× and looks like a
 fixed module-load cost (`use Template::HAML` alone: mutsu 0.79s vs raku 0.35s),
 not a per-test blow-up. (A debug build shows ~20×, which is debug overhead, not
-the real figure — measure release.) See
-`todo/tickets/grammar-heavy-module-load-slower-than-raku.md`.
+the real figure — measure release.) This was recorded as
+`todo/tickets/grammar-heavy-module-load-slower-than-raku.md`, a path retired with
+the `todo/` directory on 2026-09-08 and **not** carried into
+[docs/todo-issue-map.md](../todo-issue-map.md); there is no issue for it, so
+re-file one if it is picked up.
 
 ### First observed failure under mutsu
 
-As of the 2026-09-06 re-measurement. None of these are module rot — raku runs
+As of the 2026-09-09 re-measurement. None of these are module rot — raku runs
 them all.
 
 | Candidate | Symptom |
 | --- | --- |
 | `Template::Mustache` | none; 13/13 |
 | `Template6` | none; 12/12. The last file (`05-includes`) was fixed 2026-09-06: the no-capture regex matcher matched frugal quantifiers greedily, so `.comb(/ \" .*? \" | \S+ /)` collapsed a whole `[% INCLUDE ... %]` statement into one token (`news/2026-09/frugal-quantifier-in-the-no-capture-matcher.md`) |
-| `Template::Jinja2` | loads now (3/23); the rest are ordinary per-feature failures. Its last load blocker — `Renderer.rakumod:114`'s `when If {` read as a call — was fixed 2026-09-06 |
-| `Template::Mojo` | `00-basic` only; `todo/tickets/template-mojo-residual-failures.md` |
+| `Template::Jinja2` | 8/24; ordinary per-feature failures, plus four files that **abort** with a stack overflow instead of failing ([#7729](https://github.com/tokuhirom/mutsu/issues/7729)) |
+| `Template::Mojo` | none; 5/5 as of 2026-09-09. Its last failure (`00-basic` test 17) was a placeholder sub not rejecting extra positionals — [#7619](https://github.com/tokuhirom/mutsu/issues/7619), closed by #7628 |
 | `Template::Nest::Fast` | none; 10/10 as of 2026-09-07. The recorded `with EXPR -> @m` symptom was real but only worth 2/10; the rest came from three unrelated general bugs (`news/2026-09/template-nest-fast-zero-to-ten-of-ten.md`) |
-| `Template::Classic` | `Unterminated <%` from its own grammar — the `$<part> = <rule>` capture-assignment form inside a `||` chain does not match |
+| `Template::Classic` | the grammar parses now (#7614 fixed Unicode-quoted literals being read as pattern), but `$<part> = <text>` inside an alternation loses the subrule's `.made`, so `Actions.TOP` builds an empty `lazy gather { }` — [#7730](https://github.com/tokuhirom/mutsu/issues/7730) |
+| `Template::HAML` | 3/85; almost every file dies before the module loads, on `Unknown function: default-emit-mode` — an attribute/parameter default that *calls* a file-scoped sub cannot see it when `.new` runs in another module ([#7733](https://github.com/tokuhirom/mutsu/issues/7733)) |
 | `SP6` | at parity with raku (both 10/11, same file) |
 
 The old "`Use of Nil in string context`" entries are gone: that line was a
 *warning* in both implementations and never the diagnosis, exactly as
-`todo/deep/template-engines-blocked-on-mutsu.md` warned. Every row that was
+[#7553](https://github.com/tokuhirom/mutsu/issues/7553) warned. Every row that was
 reduced turned out to be something else entirely.
 
 Confirmed and separately filed so far (all three of the older entries here are
@@ -158,13 +187,23 @@ survey):
   **not** the last Jinja2 load blocker — an imported-`is export`ed-type parse
   bug was stacked behind it, fixed 2026-09-06 (pin
   `t/when-imported-exported-type.t`).
-- Open, from the 2026-09-06 re-measurement:
-  `todo/tickets/array-arg-mutation-lost-on-the-second-call-through-a-slurpy-relay.md`,
-  `todo/tickets/template6-include-local-data-not-reaching-the-included-stash.md`,
-  `todo/tickets/trailing-comma-in-attribute-default-drops-the-declaration.md`,
-  `todo/tickets/template-mojo-residual-failures.md`,
-  `todo/tickets/grammar-heavy-module-load-slower-than-raku.md`.
-- `todo/deep/template-engines-blocked-on-mutsu.md` — this matrix as a work item.
+- Open, from the 2026-09-09 re-measurement:
+  [#7733](https://github.com/tokuhirom/mutsu/issues/7733) (an attribute/parameter
+  default that calls a file-scoped sub cannot see it when `.new` runs in another
+  module — the `Template::HAML` blocker),
+  [#7730](https://github.com/tokuhirom/mutsu/issues/7730) (an aliased subrule
+  inside an alternation loses its `.made` — the `Template::Classic` blocker), and
+  [#7729](https://github.com/tokuhirom/mutsu/issues/7729) (a resolved `Sub` value
+  invoking the wrong closure, aborting four `Template::Jinja2` files with a stack
+  overflow).
+- The five `todo/tickets/...` paths this section used to list were retired with
+  the `todo/` directory on 2026-09-08. Only one of them is resolvable:
+  `template-mojo-residual-failures.md` became
+  [#7619](https://github.com/tokuhirom/mutsu/issues/7619) and is closed. The rest
+  are not in [docs/todo-issue-map.md](../todo-issue-map.md) — per that file's own
+  rule they were resolved before the migration.
+- [#7553](https://github.com/tokuhirom/mutsu/issues/7553) — this matrix as a work
+  item.
 
 ## How the field was surveyed
 
@@ -221,7 +260,7 @@ version and its own suite run under both `raku` and `target/debug/mutsu`
 The deciding move was that Mustache's failure turned out to be **one interpreter
 bug**, not a pile of them, so fixing it both unblocked the strongest candidate
 and improved mutsu generally. The other engines' blockers stay on the work list
-(`todo/deep/template-engines-blocked-on-mutsu.md`). `Template6` was fixed for
+([#7553](https://github.com/tokuhirom/mutsu/issues/7553)). `Template6` was fixed for
 exactly that reason — so the slot has a real second option rather than a single
 viable choice — and now runs **all 12** of its files
 (`news/2026-09/template6-zero-to-ten-of-twelve.md`,

--- a/news/2026-09/qualified-private-call-decided-by-the-dynamic-caller.md
+++ b/news/2026-09/qualified-private-call-decided-by-the-dynamic-caller.md
@@ -1,0 +1,60 @@
+# A qualified private call in a callback was refused by the wrong class
+
+```raku
+class Holder {
+    has &.cb is rw;
+    method set-cb(&c) { &!cb = &c }
+    method run() { &!cb() }
+}
+class Owner {
+    method !secret() { 'SECRET' }
+    method go() {
+        my $self = self;
+        my $h = Holder.new;
+        $h.set-cb(sub () { $self!Owner::secret() });
+        $h.run;
+    }
+}
+say Owner.new.go;
+# raku:  SECRET
+# mutsu: Cannot call private method 'secret' on package Owner
+#        because it does not trust Holder
+```
+
+Raku decides a private call's permission **lexically** — what matters is the
+class the call is written inside, not whichever class's method happens to be
+running when control reaches it. mutsu read the caller off
+`method_class_stack`, which names the *dynamic* caller, so a call written inside
+`Owner` but reached through `Holder.run` was attributed to `Holder` and refused.
+
+The unqualified spelling (`self!secret`) already had the right fallback:
+`lexical_self_allows_private` checks the captured `self` in the running env, on
+the reasoning — recorded in its own doc comment — that a closure runs with the
+`self` of the scope it was written in, so an env `self` whose class is (or
+inherits from) the owner marks code that was written inside that class. The
+**qualified** spelling (`$o!Owner::meth`) never consulted it: both instance
+dispatch paths in `src/runtime/methods_instance_ops.rs` returned the permission
+error from an earlier gate, before the one that has the fallback. Adding the same
+check to those two gates is the whole fix.
+
+The check still bites where it should, and getting that boundary right took a
+second pass. Reusing `lexical_self_allows_private` verbatim was **too loose**: it
+accepts a `self` that merely *inherits* from the owner, which is exactly the
+shape a subclass uses to reach into its parent
+(`class Untrusty is Order { method try-priv { self!Order::compute_discount() } }`),
+and Raku refuses that unless the parent `trusts` the subclass.
+`roast/integration/advent2011-day11.t` pins it, and the first version of this fix
+broke that file. The qualified path therefore gets its own strict sibling,
+`lexical_self_is_private_owner`, which requires the captured `self` to be an
+instance of the owner **itself** — still enough to identify code written inside
+the owner, which is all the callback case needs. An untrusted class reaching in
+is refused exactly as before, because its captured `self` is not the owner; an
+explicit `trusts` declaration still grants access through the ordinary path.
+
+Found reducing `Template::Jinja2` for
+[#7553](https://github.com/tokuhirom/mutsu/issues/7553): its `Renderer` builds a
+recursion callback as `$renderer!Renderer::render-for-items(...)` inside a closure
+stored on a `LoopContext`, so every recursive `{% for %}` died with
+"does not trust ... LoopContext". Pin:
+`t/private-method-qualified-in-callback.t`, 8 assertions (including the subclass
+refusal), passing unchanged under rakudo.

--- a/news/2026-09/whatever-index-at-a-non-final-subscript-level.md
+++ b/news/2026-09/whatever-index-at-a-non-final-subscript-level.md
@@ -1,0 +1,55 @@
+# A `*-1` subscript only resolved when it was the last level of a chain
+
+`@a[*-1]<x> = 'A'` silently did nothing. So did `@b[*-1][0] = 9`,
+`@a[*-1]<h><y> = 'A'`, `%m<k>[*-1]<x> = 'M'`, `@c[*-1]<x>++` and
+`@d[*-1]<n> += 5`. Reading through the same shape (`@a[*-1]<y>`) was always
+correct, and so was a whatever subscript at the *end* of a chain
+(`@a[0][*-1] = 9`, `%h<k>[*-1] = 9`) — which is why the gap survived this long.
+
+## Root cause
+
+A `*-1`-style subscript is a `WhateverCode`: it has to be evaluated against the
+length of the container it indexes before it means anything. The chained-index
+assignment ops resolved it for the **outermost** subscript only.
+`exec_index_assign_expr_nested_op` had the resolution for its `outer_idx` and
+nothing for its `inner_idx`; `exec_index_assign_deep_nested_op` (3+ levels) had
+none at all, stringifying every index up front with
+
+```rust
+let indices: Vec<String> = indices_val.iter().map(|v| v.to_string_value()).collect();
+```
+
+`to_string_value` on an unresolved `WhateverCode` yields a non-numeric key, so
+the walk autovivified a garbage slot, wrote into it, and a later read of the real
+element saw `Any`. Nothing threw — the write was simply lost.
+
+The fix resolves the index at every level, against the container *that* level
+indexes. For the two-level op that container is the root variable itself. For the
+deep op it is only known by walking down to it, so the resolution runs as a
+read-only pre-pass over the chain **before** the existing raw-pointer walk
+starts: evaluating a `WhateverCode` runs its body, and that must not happen while
+a `*mut Value` into the environment is live — the resolver takes the environment
+out from under it (`std::mem::take(self.env_mut())`), which would leave the
+pointer dangling. A level that does not exist yet resolves against length 0,
+which is what its autovivified empty container would give anyway.
+
+## Where it was found
+
+Reducing `Template::Jinja2` for
+[#7553](https://github.com/tokuhirom/mutsu/issues/7553). Its `Context` class
+keeps a stack of scopes in an array attribute and pushes one per `{% for %}`
+iteration:
+
+```raku
+method set(Str:D $name, $value) { @!scope-stack[*-1]{$name} = $value }
+```
+
+Every loop variable binding therefore vanished, and `{% for x in items %}[{{ x }}]{% endfor %}`
+rendered `[][][]` — the right number of iterations with nothing in them. That is
+the shape the survey's "first failure" line pointed at; as usual it was a general
+bug in a subsystem the template machinery never mentions.
+
+The dist went from 3/24 to 8/24 on this fix alone (raku: 23/24).
+
+Pin: `t/whatever-index-in-subscript-chain.t`, 18 assertions, passing unchanged
+under rakudo.

--- a/src/runtime/methods_instance_ops.rs
+++ b/src/runtime/methods_instance_ops.rs
@@ -105,6 +105,30 @@ impl Interpreter {
                 .any(|s| s.resolve() == resolved_owner)
     }
 
+    /// The strict sibling of [`Interpreter::lexical_self_allows_private`], for a
+    /// **qualified** private call (`$o!Owner::meth`).
+    ///
+    /// The loose form accepts an env `self` that merely *inherits* from the
+    /// owner, which is right for the unqualified spelling but wrong here:
+    /// writing the owner's name out is exactly how a subclass tries to reach a
+    /// parent's private method, and Raku refuses that unless the parent
+    /// `trusts` it (`roast/integration/advent2011-day11.t`'s `Untrusty is Order`
+    /// pins the `X::Method::Private::Permission`). Requiring the captured
+    /// `self` to be an instance of the owner *itself* still identifies code
+    /// written inside the owner — which is all the callback case needs — without
+    /// handing a subclass an inheritance-shaped grant the trust check already
+    /// denied.
+    fn lexical_self_is_private_owner(&mut self, resolved_owner: &str) -> bool {
+        let Some(ValueView::Instance {
+            class_name: self_cls,
+            ..
+        }) = self.env.get("self").map(Value::view)
+        else {
+            return false;
+        };
+        self_cls.resolve() == resolved_owner
+    }
+
     /// Mu's default `.gist`/`.raku`/`.perl` rendering for a plain user
     /// instance (`ClassName.new(...)`, with special cases for `is Array`
     /// subclasses, `ObjAt`/`ValueObjAt`, `X::AdHoc`, schedulers,
@@ -392,49 +416,57 @@ impl Interpreter {
                 // Split at the LAST `::` — the owner class may itself be a nested
                 // name (`$c!Jar::Cookie::secret` is owner `Jar::Cookie`, method
                 // `secret`, NOT owner `Jar`, method `Cookie::secret`).
-                let (pm_name, owner_only, resolved) =
-                    if let Some((owner_class, pm_name)) = private_rest.rsplit_once("::") {
-                        // `owner_class` is the short name as written in
-                        // source; canonicalize it relative to the caller's
-                        // package chain before using it both for the trust
-                        // check and for the actual MRO lookup below — an
-                        // uncanonicalized short name never matches a fully
-                        // qualified MRO entry (`"A" != "M::A"`).
-                        let invocant_class = class_name.resolve();
-                        let (canonical_owner, caller_allowed) = self
-                            .resolve_and_check_private_owner_on(
-                                caller_class.as_deref(),
-                                owner_class,
-                                Some(&invocant_class),
-                            );
-                        if !caller_allowed {
-                            return Err(make_private_permission_error(
-                                pm_name,
-                                &canonical_owner,
-                                caller_class.as_deref().unwrap_or("GLOBAL"),
-                            ));
-                        }
-                        (
+                let (pm_name, owner_only, resolved) = if let Some((owner_class, pm_name)) =
+                    private_rest.rsplit_once("::")
+                {
+                    // `owner_class` is the short name as written in
+                    // source; canonicalize it relative to the caller's
+                    // package chain before using it both for the trust
+                    // check and for the actual MRO lookup below — an
+                    // uncanonicalized short name never matches a fully
+                    // qualified MRO entry (`"A" != "M::A"`).
+                    let invocant_class = class_name.resolve();
+                    let (canonical_owner, caller_allowed) = self
+                        .resolve_and_check_private_owner_on(
+                            caller_class.as_deref(),
+                            owner_class,
+                            Some(&invocant_class),
+                        );
+                    // A qualified private call is resolved LEXICALLY, like
+                    // the unqualified one below: `method_class_stack` names
+                    // whoever *invoked* the running code, which is the wrong
+                    // class when the call sits in a closure that some other
+                    // object calls back into (`$holder.run: { $self!R::p }`).
+                    // Fall back to the captured `self` the same way, instead
+                    // of denying the call outright.
+                    if !caller_allowed && !self.lexical_self_is_private_owner(&canonical_owner) {
+                        return Err(make_private_permission_error(
                             pm_name,
-                            Some(canonical_owner.clone()),
-                            self.resolve_private_method_with_owner(
-                                &class_name.resolve(),
-                                &canonical_owner,
-                                pm_name,
-                                &args,
-                            ),
-                        )
-                    } else {
-                        (
+                            &canonical_owner,
+                            caller_class.as_deref().unwrap_or("GLOBAL"),
+                        ));
+                    }
+                    (
+                        pm_name,
+                        Some(canonical_owner.clone()),
+                        self.resolve_private_method_with_owner(
+                            &class_name.resolve(),
+                            &canonical_owner,
+                            pm_name,
+                            &args,
+                        ),
+                    )
+                } else {
+                    (
+                        private_rest,
+                        None,
+                        self.resolve_private_method_any_owner(
+                            &class_name.resolve(),
                             private_rest,
-                            None,
-                            self.resolve_private_method_any_owner(
-                                &class_name.resolve(),
-                                private_rest,
-                                &args,
-                            ),
-                        )
-                    };
+                            &args,
+                        ),
+                    )
+                };
                 // Nothing matched by signature. That is not the same as "no such
                 // private method": the class may declare exactly this method with
                 // parameters these arguments fail to bind, and raku reports the
@@ -1838,7 +1870,8 @@ impl Interpreter {
                             owner_class,
                             Some(&invocant_class),
                         );
-                    if !caller_allowed {
+                    // Same lexical fallback as the instance path above.
+                    if !caller_allowed && !self.lexical_self_is_private_owner(&canonical_owner) {
                         return Err(make_private_permission_error(
                             pm_name,
                             &canonical_owner,

--- a/src/vm/vm_var_assign_index_named.rs
+++ b/src/vm/vm_var_assign_index_named.rs
@@ -3371,6 +3371,19 @@ impl Interpreter {
                 }
             }
         }
+        // A `*-1`-style INNER subscript (`@a[*-1]<k> = v`) resolves against the
+        // container that level indexes -- here the root variable itself, since
+        // the inner level is the first subscript applied to it. Without this the
+        // unresolved `WhateverCode` was stringified straight into a key, so the
+        // write landed in a garbage slot and a later read of the real one
+        // returned Any. (The outer subscript already had this resolution, just
+        // below; only the inner one was missing.)
+        let inner_idx = if matches!(inner_idx.view(), ValueView::Sub(_)) {
+            let root = self.env().get(&var_name).cloned();
+            self.resolve_whatever_index_for_target(inner_idx, root.as_ref())
+        } else {
+            inner_idx
+        };
         let inner_key = inner_idx.to_string_value();
         // A WhateverCode array index (`%h<k>[*-0] = v` / `@a[0][*-1] = v`) must be
         // resolved against the inner container's current length before it becomes
@@ -4128,6 +4141,31 @@ impl Interpreter {
         ))
     }
 
+    /// Step one subscript level down a container **by value**, for the
+    /// read-only pre-pass that resolves `*-1`-style subscripts in
+    /// [`Interpreter::exec_index_assign_deep_nested_op`]. Returns `None` when
+    /// that level does not exist (or is not a container), which the caller
+    /// treats as "length 0".
+    fn subscript_peek_step(container: &Value, key: &str, is_positional: bool) -> Option<Value> {
+        let container = container.deref_container();
+        match container.view() {
+            ValueView::Array(items, ..) if is_positional => key
+                .parse::<usize>()
+                .ok()
+                .and_then(|i| items.get(i).cloned()),
+            ValueView::Seq(items) if is_positional => key
+                .parse::<usize>()
+                .ok()
+                .and_then(|i| items.get(i).cloned()),
+            ValueView::Slip(items) if is_positional => key
+                .parse::<usize>()
+                .ok()
+                .and_then(|i| items.get(i).cloned()),
+            ValueView::Hash(map) => map.get(key).cloned(),
+            _ => None,
+        }
+    }
+
     pub(super) fn exec_index_assign_deep_nested_op(
         &mut self,
         code: &CompiledCode,
@@ -4217,6 +4255,45 @@ impl Interpreter {
             return Ok(());
         }
 
+        // Extract positional flags from constant
+        let flags_val = code.constants[positional_flags_idx as usize].clone();
+        let positional_flags: Vec<bool> = if let ValueView::Array(arr, _) = flags_val.view() {
+            arr.iter()
+                .map(|v| matches!(v.view(), ValueView::Bool(true)))
+                .collect()
+        } else {
+            vec![true; depth]
+        };
+
+        // A `*-1`-style subscript resolves against the container the level it
+        // sits at indexes -- which, for every level but the first, is only known
+        // by walking down to it. Do that walk here, read-only and by value:
+        // resolving a `WhateverCode` evaluates its body, and that must not run
+        // while the raw-pointer walk below holds a `*mut Value` into the
+        // environment. A level that does not exist yet resolves against length
+        // 0, which is what its autovivified empty container would give anyway.
+        // Without this the unresolved `WhateverCode` was stringified straight
+        // into a key at every level, so `@a[*-1]<h><y> = v` wrote into a garbage
+        // slot and the assignment was silently lost.
+        if indices_val
+            .iter()
+            .any(|v| matches!(v.view(), ValueView::Sub(_)))
+        {
+            let mut cur = self.env().get(&var_name).cloned();
+            for level in 0..depth {
+                if matches!(indices_val[level].view(), ValueView::Sub(_)) {
+                    indices_val[level] = self.resolve_whatever_index_for_target(
+                        indices_val[level].clone(),
+                        cur.as_ref(),
+                    );
+                }
+                let key = indices_val[level].to_string_value();
+                cur = cur
+                    .as_ref()
+                    .and_then(|c| Self::subscript_peek_step(c, &key, positional_flags[level]));
+            }
+        }
+
         let indices: Vec<String> = indices_val.iter().map(|v| v.to_string_value()).collect();
         let val = raw_val_for_junction;
 
@@ -4245,16 +4322,6 @@ impl Interpreter {
             val
         } else {
             val.itemize_for_element_store()
-        };
-
-        // Extract positional flags from constant
-        let flags_val = code.constants[positional_flags_idx as usize].clone();
-        let positional_flags: Vec<bool> = if let ValueView::Array(arr, _) = flags_val.view() {
-            arr.iter()
-                .map(|v| matches!(v.view(), ValueView::Bool(true)))
-                .collect()
-        } else {
-            vec![true; depth]
         };
 
         // Invalidate local cache for the variable

--- a/t/private-method-qualified-in-callback.t
+++ b/t/private-method-qualified-in-callback.t
@@ -1,0 +1,85 @@
+use Test;
+
+# A qualified private call (`$o!Owner::meth`) is permitted LEXICALLY: what
+# matters is the class the call is written inside, not the class whose method
+# happens to be running when control reaches it. mutsu decided it from
+# `method_class_stack` — the *dynamic* caller — so a call written inside a
+# closure that another object calls back into was refused with
+# "does not trust <that other class>". The unqualified spelling already had the
+# captured-`self` fallback; only the qualified one was missing it.
+# Every assertion below also passes under rakudo.
+
+plan 8;
+
+class Holder {
+    has &.cb is rw;
+    method set-cb(&c) { &!cb = &c }
+    method run(|c) { &!cb(|c) }
+}
+
+class Owner {
+    method !secret($n = 1) { "SECRET$n" }
+
+    method via-closure() {
+        my $self = self;
+        my $h = Holder.new;
+        $h.set-cb(sub () { $self!Owner::secret() });
+        $h.run;
+    }
+
+    method via-closure-with-args() {
+        my $self = self;
+        my $h = Holder.new;
+        $h.set-cb(sub ($n) { $self!Owner::secret($n) });
+        $h.run(7);
+    }
+
+    method direct() { self!Owner::secret() }
+
+    method unqualified-via-closure() {
+        my $h = Holder.new;
+        $h.set-cb(sub () { self!secret() });
+        $h.run;
+    }
+}
+
+is Owner.new.direct, 'SECRET1', 'a qualified private call in the owner itself still works';
+is Owner.new.via-closure, 'SECRET1',
+        'a qualified private call inside a closure another class invokes';
+is Owner.new.via-closure-with-args, 'SECRET7', 'same, with arguments threaded through';
+is Owner.new.unqualified-via-closure, 'SECRET1',
+        'the unqualified spelling keeps working (it already had the fallback)';
+
+# The permission check must still bite where it should: a class that really is
+# not the owner and is not trusted cannot reach in. rakudo refuses this at
+# COMPILE time, so it has to be built in a string rather than written inline.
+eval-dies-ok q:to/CODE/, 'an untrusted class calling in is still refused';
+    class Owner2 { method !secret() { 'S' } }
+    class Intruder { has $.o; method poke() { $!o!Owner2::secret() } }
+    Intruder.new(o => Owner2.new).poke;
+    CODE
+
+class Trusted { ... }
+class Trusting {
+    trusts Trusted;
+    method !inner() { 'INNER' }
+}
+class Trusted {
+    method reach($t) { $t!Trusting::inner() }
+}
+is Trusted.new.reach(Trusting.new), 'INNER', 'an explicit `trusts` still grants access';
+
+# A SUBCLASS is not the owner. Naming the owner out loud is exactly how a
+# subclass tries to reach a parent's private method, and Raku refuses it unless
+# the parent `trusts` the subclass — so the lexical fallback above must key on
+# the captured `self` being an instance of the owner ITSELF, not merely of
+# something that inherits from it. (`roast/integration/advent2011-day11.t` pins
+# the same rule; a looser fallback silently granted the subclass access.)
+class Parent { method !hidden() { 'HIDDEN' } }
+class Child is Parent {
+    method reach()   { EVAL 'self!Parent::hidden()' }
+    method public()  { 'PUBLIC' }
+}
+is Child.new.public, 'PUBLIC', 'an ordinary inherited call is unaffected';
+throws-like { Child.new.reach }, X::Method::Private::Permission,
+        'a subclass still cannot reach its parent\'s private method';

--- a/t/whatever-index-in-subscript-chain.t
+++ b/t/whatever-index-in-subscript-chain.t
@@ -1,0 +1,120 @@
+use Test;
+
+# A `*-1`-style subscript only ever resolved against its container when it was
+# the LAST level of a chain. At any earlier level the unresolved WhateverCode
+# was stringified straight into a key, so the write landed in a garbage slot and
+# was silently lost. Every assertion below also passes under rakudo.
+
+plan 18;
+
+# --- two-level chain, whatever at the inner level ---
+{
+    my @a = ({},);
+    @a[*-1]<x> = 'A';
+    is @a[0]<x>, 'A', 'array[*-1]<key> = v writes through';
+    is @a.elems, 1, 'and does not grow the array';
+}
+
+{
+    my @a = ({},);
+    @a[*-1]{'x'} = 'A';
+    is @a[0]<x>, 'A', 'array[*-1]{key} = v writes through';
+}
+
+{
+    my @b = ([1, 2],);
+    @b[*-1][0] = 9;
+    is @b[0][0], 9, 'array[*-1][idx] = v writes through';
+    is @b[0][1], 2, 'and leaves the sibling element alone';
+}
+
+{
+    my @a = ({}, {});
+    @a[*-2]<z> = 'Z';
+    is @a[0]<z>, 'Z', '*-2 resolves against the container length too';
+    nok @a[1]<z>.defined, 'and does not touch the last element';
+}
+
+# --- three-level chains ---
+{
+    my @a = ({ h => {} },);
+    @a[*-1]<h><y> = 'A';
+    is @a[0]<h><y>, 'A', 'whatever at the first of three levels';
+}
+
+{
+    my @b = ([[0],],);
+    @b[*-1][0][0] = 9;
+    is @b[0][0][0], 9, 'whatever ahead of two positional levels';
+}
+
+{
+    my %m = (k => [{},]);
+    %m<k>[*-1]<x> = 'M';
+    is %m<k>[0]<x>, 'M', 'whatever in the MIDDLE of a three-level chain';
+}
+
+# --- read-modify-write through the same shape ---
+{
+    my @c = ({},);
+    @c[*-1]<x>++;
+    is @c[0]<x>, 1, 'postfix ++ through a whatever level';
+}
+
+{
+    my @d = ({ n => 1 },);
+    @d[*-1]<n> += 5;
+    is @d[0]<n>, 6, 'metaassign += through a whatever level';
+}
+
+# --- the shape that found this: a scope stack held in an attribute ---
+{
+    class Ctx {
+        has @.scope-stack;
+        method set(Str:D $name, $value) { @!scope-stack[*-1]{$name} = $value }
+        method push-scope(%vars = {}) { @!scope-stack.push: %vars }
+        method pop-scope() { @!scope-stack.pop if @!scope-stack.elems > 1 }
+        method resolve(Str:D $name) {
+            for @!scope-stack.reverse -> %scope {
+                return %scope{$name} if %scope{$name}:exists;
+            }
+            'UNDEF';
+        }
+    }
+
+    my $c = Ctx.new;
+    $c.push-scope({});
+    my @seen;
+    for <a b c> -> $item {
+        $c.push-scope({});
+        $c.set('x', $item);
+        @seen.push: $c.resolve('x');
+        $c.pop-scope;
+    }
+    is @seen.join(','), 'a,b,c', 'a per-iteration scope pushed onto an attribute array';
+    is $c.resolve('x'), 'UNDEF', 'and each scope really was popped';
+}
+
+# --- levels that already worked must keep working ---
+{
+    my @a = (1, 2, 3);
+    @a[*-1] = 99;
+    is @a[2], 99, 'a single-level whatever subscript still assigns';
+}
+
+{
+    my @a = ([1, 2],);
+    @a[0][*-1] = 9;
+    is @a[0][1], 9, 'a whatever at the LAST level still assigns';
+}
+
+{
+    my %h = (k => [1, 2]);
+    %h<k>[*-1] = 9;
+    is %h<k>[1], 9, 'whatever at the last level below a hash key';
+}
+
+{
+    my @a = ({ y => 1 },);
+    is @a[*-1]<y>, 1, 'reading through a whatever level was never broken';
+}


### PR DESCRIPTION
The next slice of #7553. Two general interpreter bugs, both found by reducing
`Template::Jinja2`, plus the full re-measurement the ticket's standing
instruction asks for after every fix.

`Template::Jinja2` goes **3/24 → 8/24** (raku: 23/24), and `Template::Mojo` is
confirmed at **5/5** now that #7628 has landed.

## 1. A `*-1` subscript only resolved when it was the LAST level of a chain

```raku
my @a = ({},);      @a[*-1]<x>    = 'A';   # raku [{:x("A")},]   mutsu [{},]
my @b = ([1,2],);   @b[*-1][0]    = 9;     # raku [[9, 2],]      mutsu [[1, 2],]
my @c = ({h=>{}},); @c[*-1]<h><y> = 'A';   # raku nested         mutsu unchanged
my %m = (k=>[{},]); %m<k>[*-1]<x> = 'M';   # whatever in the MIDDLE
my @d = ({n=>1},);  @d[*-1]<n>   += 5;     # ++ and += too
```

A `*-1`-style subscript is a `WhateverCode` and only means anything once it has
been evaluated against the length of the container it indexes. The chained-index
assignment ops did that for the **outermost** subscript only:
`exec_index_assign_expr_nested_op` resolved its `outer_idx` and nothing for its
`inner_idx`, and `exec_index_assign_deep_nested_op` (3+ levels) stringified every
index up front with `indices_val.iter().map(|v| v.to_string_value())`.
`to_string_value` on an unresolved `WhateverCode` yields a non-numeric key, so
the walk autovivified a garbage slot, wrote into it, and a later read of the real
element saw `Any`. Nothing threw — the write was simply lost. Reading through the
same shape, and a whatever subscript at the *end* of a chain, were always
correct, which is why this survived.

The two-level op now resolves its inner index against the root variable. The deep
op resolves every level in a **read-only pre-pass, before its raw-pointer walk
starts** — evaluating a `WhateverCode` runs its body, and the resolver does
`std::mem::take(self.env_mut())`, which would leave a live `*mut Value` into the
environment dangling.

Found because `Template::Jinja2`'s `Context` keeps its scope stack in an array
attribute and writes `@!scope-stack[*-1]{$name} = $value`. Every `{% for %}` loop
variable therefore vanished and `[{{ x }}]` rendered `[][][]` — the right number
of iterations with nothing in them.

## 2. A qualified private call in a callback was refused by the wrong class

```raku
class Holder { has &.cb is rw; method set-cb(&c) { &!cb = &c }; method run { &!cb() } }
class Owner {
    method !secret() { 'SECRET' }
    method go() { my $self = self; my $h = Holder.new;
                  $h.set-cb(sub () { $self!Owner::secret() }); $h.run }
}
say Owner.new.go;
# raku:  SECRET
# mutsu: Cannot call private method 'secret' on package Owner
#        because it does not trust Holder
```

Raku decides a private call's permission lexically; mutsu read the caller off
`method_class_stack`, which names the *dynamic* caller. The unqualified spelling
already had the captured-`self` fallback (`lexical_self_allows_private`); the
qualified one returned from an earlier gate that never consulted it.

The qualified path gets its own **strict** sibling,
`lexical_self_is_private_owner`. The loose form accepts a `self` that merely
*inherits* from the owner, which is exactly how a subclass tries to reach into
its parent — and Raku refuses that unless the parent `trusts` it.
`roast/integration/advent2011-day11.t`'s `class Untrusty is Order` pins it, and
the first version of this fix broke that file; requiring the captured `self` to
be an instance of the owner *itself* still identifies code written inside the
owner, which is all the callback case needs.

This is what killed every recursive `{% for %}` in `Template::Jinja2`: its
`Renderer` builds the recursion callback as
`$renderer!Renderer::render-for-items(...)` inside a closure stored on a
`LoopContext`.

## The survey re-measurement

Both columns re-run 2026-09-09, every tarball re-fetched from the REA archive
(debug build). Three of the table's pinned versions had moved under it.

| dist | version | raku | mutsu | was |
| --- | --- | --- | --- | --- |
| `Template::Mustache` | 1.2.6 | 11/13 | 13/13 | 13/13 |
| `Template6` | 0.16.0 | 12/12 | 12/12 | 12/12 |
| `Template::Jinja2` | 0.2.0 → **0.3.0** | 23/24 | **8/24** | 3/23 |
| `Template::Mojo` | 0.2.2 | 5/5 | **5/5** | 4/5 |
| `Template::Nest::Fast` | 0.3.0 | 10/10 | 10/10 | 10/10 |
| `SP6` | 0.2.1 | 10/11 | 10/11 | 10/11 |
| `Template::Classic` | 0.0.3 | 1/1 | **0/1** | 1/1 (2026-09-08) |
| `Template::HAML` | 0.9.5 → **0.9.6** | 84/85 | **3/85** | 39/83 |

Two of those numbers are worse than the record, and **neither is a regression
from this PR** — both were verified against a clean `main` build (`git stash` +
rebuild) and reproduce there unchanged:

- **`Template::Classic` 1/1 → 0/1.** #7614's fix was real; behind it sits one
  more bug — an aliased subrule (`$<part> = <text>`) inside an alternation loses
  the subrule's `.made`, so the dist's `Actions.TOP` builds an empty
  `lazy gather { }`. Filed as **#7730** with the full matrix.
- **`Template::HAML` 39/83 → 3/85.** The 39 does not reproduce at 0.9.5 either
  (3/83 today). Nearly every file dies before the module loads, on
  `Unknown function: default-emit-mode` — an attribute/parameter default that
  *calls* a file-scoped sub cannot see it when `.new` runs in another module.
  Filed as **#7733**; it is the non-closure sibling of the already-fixed
  default-*closure* package bug, and should move that row a long way in one step.

Also filed: **#7729** — four `Template::Jinja2` files abort with a stack overflow
rather than failing, because invoking a correctly-resolved `Sub` value re-enters
a different closure.

`docs/batteries/templates.md` is refreshed throughout, including its stale
`todo/tickets/...` citations (those paths stopped resolving when the `todo/`
directory was retired; only one of the five is in `docs/todo-issue-map.md`).

## Test plan

- `make test` — **PASS**, 3905 files / 41519 tests.
- `make roast` — the three documented container-only failures only
  (`6.c/S32-io/file-tests.t` and `S16-filehandles/filetest.t` run as `uid 0`,
  `S32-io/IO-Socket-Async.t` sandboxed network; see `docs/agent-environments.md`).
  `roast/integration/advent2011-day11.t`, which the first cut of fix 2 broke, is
  green.
- `cargo fmt --all` and `make lint` (all four configurations) clean.
- New pins, both passing unchanged under rakudo:
  - `t/whatever-index-in-subscript-chain.t` — 18 assertions, including the levels
    that already worked.
  - `t/private-method-qualified-in-callback.t` — 8 assertions, including the
    subclass refusal and an explicit `trusts` still granting access.

Advances #7553 (it stays open — `HAML`, `Jinja2` and `Classic` remain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NwAgiaPick93SW9Q8a1kyG

---
_Generated by [Claude Code](https://claude.ai/code/session_01NwAgiaPick93SW9Q8a1kyG)_