### PR TITLE
fix: scope nested module imports to their compunit

### DIFF
--- a/news/2026-09/unit-module-import-aliases-are-compunit-scoped.md
+++ b/news/2026-09/unit-module-import-aliases-are-compunit-scoped.md
@@ -1,0 +1,8 @@
+---
+title: unit module imports are scoped to their compilation unit
+---
+
+Imported variables and types from a `unit module` no longer leak into the
+scope that loaded the module. The module's routines and nested blocks continue
+to resolve those imports, while a direct `use` still installs its exports in the
+caller.

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -8603,6 +8603,24 @@ impl CompiledFns {
         self.map.insert(key, value);
     }
 
+    /// Nested named subs are compiled as part of their enclosing routine and
+    /// therefore do not have a source file at compiler construction time. Once
+    /// the enclosing routine's definition is known, stamp that file through
+    /// the nested table so its unit metadata follows the lexical declaration.
+    pub(crate) fn stamp_source_file(&mut self, source_file: Option<String>) {
+        for value in self.map.values_mut() {
+            let function = Arc::make_mut(value);
+            if function.source_file.is_none() {
+                function.source_file = source_file.clone();
+                function.source_file_sym_cache = std::sync::OnceLock::new();
+            }
+            if let Some(nested) = &mut function.compiled_fns {
+                Arc::make_mut(nested).stamp_source_file(source_file.clone());
+            }
+        }
+        self.id = Self::next_id();
+    }
+
     pub(crate) fn retain(
         &mut self,
         mut f: impl FnMut(&crate::symbol::Symbol, &CompiledFunction) -> bool,
@@ -9009,6 +9027,19 @@ pub(crate) struct CompiledFunction {
 }
 
 impl CompiledFunction {
+    /// Stamp a compiled routine and its nested named-subs with their enclosing
+    /// routine's source file. Nested bodies are compiled as part of the parent
+    /// and otherwise have no independent source metadata.
+    pub(crate) fn stamp_source_file(&mut self, source_file: Option<String>) {
+        if self.source_file.is_none() {
+            self.source_file = source_file.clone();
+            self.source_file_sym_cache = std::sync::OnceLock::new();
+        }
+        if let Some(nested) = &mut self.compiled_fns {
+            Arc::make_mut(nested).stamp_source_file(source_file);
+        }
+    }
+
     /// The declaring package as a `Symbol`, interned once per compiled
     /// function. Every call that pushes a `RoutineFrame` needs it, so
     /// interning it per call re-hashed the package string on the hottest

--- a/src/runtime/accessors_stack.rs
+++ b/src/runtime/accessors_stack.rs
@@ -82,9 +82,10 @@ impl Interpreter {
         def_file: Option<Symbol>,
     ) {
         let invocation_id = self.take_invocation_id();
+        let lexical_package = self.lexical_package_for_frame(def_file);
         self.routine_stack.push(super::RoutineFrame {
             package,
-            lexical_package: None,
+            lexical_package,
             name,
             line,
             file,
@@ -154,6 +155,25 @@ impl Interpreter {
             def_file,
             invocation_id,
         });
+    }
+
+    /// Find the unit-module package owning a routine or closure's body. EVAL
+    /// units are not registered as modules themselves, but their parent unit
+    /// is, so walk the same parent chain used by compilation-unit scoping.
+    fn lexical_package_for_frame(&self, def_file: Option<Symbol>) -> Option<Symbol> {
+        let unit = def_file
+            .map(|file| {
+                let source = file.resolve();
+                self.unit_of_source(Some(&source))
+            })
+            .unwrap_or(self.current_unit);
+        let mut unit = unit;
+        loop {
+            if let Some(package) = self.unit_module_packages.get(&unit) {
+                return Some(*package);
+            }
+            unit = crate::runtime::eval_unit_parent(unit)?;
+        }
     }
 
     pub(crate) fn pop_routine(&mut self) {

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -2387,7 +2387,17 @@ pub struct Interpreter {
     /// nothing to `env`, so `DBDish::mysql::StatementHandle`'s `use
     /// DBDish::mysql::Native` looked like a no-op even though `intptr` is part of
     /// its lexical scope. Saved/restored around each nested load.
-    pub(crate) module_imported_names: Vec<(String, Value)>,
+    pub(crate) module_imported_names: Vec<(String, Value, Option<Value>)>,
+    /// Imported bare names recorded for each module owner. This is narrower
+    /// than `module_scope_lexicals`: the latter also contains a module's own
+    /// `our`/class-body names, while the VM's env fallback must only redirect
+    /// aliases imported from a nested module.
+    pub(crate) module_imported_lexical_names: PackageKeyed<bool>,
+    /// Compilation units declared by `unit module`/`unit class` files, keyed by
+    /// their compilation-unit symbol. A unit module body runs under GLOBAL, so
+    /// its routines need this metadata after the load has finished in order to
+    /// resolve the module's own imported aliases lexically.
+    pub(crate) unit_module_packages: HashMap<Symbol, Symbol>,
     /// Exported subroutine symbols by package and export tag.
     exported_subs: HashMap<String, HashMap<String, HashSet<String>>>,
     /// Exported variable/constant symbols by package and export tag.

--- a/src/runtime/registration_sub.rs
+++ b/src/runtime/registration_sub.rs
@@ -688,6 +688,7 @@ impl Interpreter {
         adapted.is_rw = def.is_rw;
         adapted.is_raw = def.is_raw;
         adapted.source_file.clone_from(&def.source_file);
+        adapted.stamp_source_file(def.source_file.clone());
         adapted.precompute_param_local_slots();
         adapted.precompute_named_call_plan();
         adapted.precompute_param_name_syms();
@@ -1030,7 +1031,7 @@ impl Interpreter {
             return_type: return_type.cloned(),
             is_default: custom_traits.iter().any(|(t, _)| t == "default"),
             deprecated_message,
-            source_file: self.current_source_file(),
+            source_file: self.executing_source_file(),
             source_line: None,
             decl_order: crate::runtime::resolution::next_decl_order(),
             compiled: None,

--- a/src/runtime/run_modules.rs
+++ b/src/runtime/run_modules.rs
@@ -769,6 +769,7 @@ impl Interpreter {
         Self::validate_exporthow_directives(&stmts)?;
         let mut module_scope_names: HashMap<String, Value> = HashMap::new();
         let mut module_type_aliases: HashMap<String, String> = HashMap::new();
+        let mut imported_lexical_names: HashSet<String> = HashSet::new();
         if !Self::should_skip_runtime_for_use_only_module(&stmts) {
             // Module files should be compiled in a fresh GLOBAL scope, not
             // inheriting the caller's current_package.  Otherwise the compiler
@@ -781,6 +782,12 @@ impl Interpreter {
             // record X so that `register_exported_sub` can mirror exports into
             // `unit_module_exported_subs` for tag validation.
             let unit_name = Self::detect_unit_package_name(&stmts);
+            if let Some(name) = unit_name.as_deref() {
+                let source = source_path.to_string_lossy();
+                let unit = self.unit_of_source(Some(&source));
+                self.unit_module_packages
+                    .insert(unit, crate::symbol::Symbol::intern(name));
+            }
             let pushed_unit = if let Some(name) = unit_name.clone() {
                 self.unit_module_loading_stack.push(name);
                 true
@@ -824,7 +831,20 @@ impl Interpreter {
             // env so the new ones can be recorded against the module itself.
             let before_env_keys: std::collections::HashSet<crate::symbol::Symbol> =
                 self.env.keys().copied().collect();
+            // A module body executes against the loading scope's env for
+            // historical reasons, but plain names already owned by that scope
+            // must be restored after the body. In particular, an `our $x` in a
+            // module can replace a same-named caller lexical's env entry before
+            // the module's exports are installed, so the import-time `previous`
+            // value alone is too late to recover it.
+            let saved_plain_env: HashMap<crate::symbol::Symbol, Value> = self
+                .env
+                .keys()
+                .filter(|key| !key.resolve().contains("::"))
+                .filter_map(|key| self.env.get_sym(*key).map(|value| (*key, value.clone())))
+                .collect();
             let saved_imports = std::mem::take(&mut self.module_imported_names);
+            let saved_pending_rw_writeback_len = self.pending_rw_writeback_sources.len();
             // Pragmas set by a module are lexical to that module. The module
             // mainline runs in this interpreter, so restore the caller's mode
             // after it finishes instead of letting `use strict` leak outward.
@@ -835,13 +855,42 @@ impl Interpreter {
             // scope already declared.
             let hidden_toplevel = self.hide_toplevel_global_routines();
             let result = self.run_block(&stmts);
+            self.pending_rw_writeback_sources
+                .truncate(saved_pending_rw_writeback_len);
             self.strict_mode = saved_strict_mode;
             let imported = std::mem::replace(&mut self.module_imported_names, saved_imports);
             module_scope_names = self.collect_module_scope_names(&before_env_keys);
             // A re-import of a name an earlier module already installed adds
             // nothing to `env`, so the diff misses it even though it is part of
             // this module's scope (see `module_imported_names`).
-            module_scope_names.extend(imported);
+            module_scope_names.extend(
+                imported
+                    .iter()
+                    .map(|(name, value, _)| (name.clone(), value.clone())),
+            );
+            imported_lexical_names.extend(imported.iter().flat_map(|(name, _, _)| {
+                [
+                    name.clone(),
+                    name.strip_prefix(['$', '@', '%'])
+                        .unwrap_or(name)
+                        .to_string(),
+                ]
+            }));
+            // Module bodies execute in the caller's env for compatibility with
+            // existing declaration machinery. Imported variables/constants need
+            // their pre-load value restored, including a caller binding they
+            // shadowed. Other names created by the module body are retained here
+            // for the package-variable and declaration machinery below; only
+            // names explicitly recorded by `import_module` are aliases whose
+            // visibility must be undone at the end of this compunit.
+            for (name, _, _) in imported.iter().rev() {
+                let key = crate::symbol::Symbol::intern(name);
+                if let Some(value) = saved_plain_env.get(&key) {
+                    self.env.insert_sym(key, value.clone());
+                } else {
+                    self.env.remove_sym(key);
+                }
+            }
             module_type_aliases = self.module_type_aliases_of(&module_scope_names);
             // Take the compunit's own file-scope lexicals out of `env` and into
             // `unit_lexicals`, restoring the loading scope's values under those
@@ -874,6 +923,12 @@ impl Interpreter {
                         }
                     }
                 }
+            }
+            // Restore every plain caller binding after the module's own lexical
+            // values have been extracted above. Qualified package globals and
+            // newly-created module names are intentionally left alone.
+            for (key, value) in &saved_plain_env {
+                self.env.insert_sym(*key, value.clone());
             }
             match saved_qfile {
                 Some(f) => {
@@ -948,8 +1003,15 @@ impl Interpreter {
         // package (see `todo/tickets/package-short-name-alias-is-global.md`,
         // "Attempt #1" for the regression this fixes).
         if !new_types.is_empty() {
-            let aliases: Vec<(String, String)> = new_types
-                .iter()
+            // `new_types` also includes classes registered by transitive
+            // dependencies loaded from this module. Those aliases belong to
+            // this module's own package (the nested load recorded that), not to
+            // the package that imported this module. Only the declarations
+            // owned by this compunit may be visible in the importer's scope.
+            let owned_types = new_types.iter().filter(|qualified| {
+                *qualified == module || qualified.starts_with(&format!("{module}::"))
+            });
+            let aliases: Vec<(String, String)> = owned_types
                 .filter_map(|qualified| {
                     qualified
                         .rsplit_once("::")
@@ -984,6 +1046,7 @@ impl Interpreter {
             }
             owners.push(module.to_string());
             for owner in owners {
+                let class_static_names = self.class_body_static_names.get(&owner);
                 if !module_type_aliases.is_empty() {
                     self.package_type_aliases
                         .entry(owner.clone())
@@ -994,11 +1057,22 @@ impl Interpreter {
                                 .map(|(k, v)| (k.clone(), v.clone())),
                         );
                 }
-                self.module_scope_lexicals.entry(owner).or_default().extend(
-                    module_scope_names
-                        .iter()
-                        .map(|(k, v)| (k.clone(), v.clone())),
-                );
+                self.module_scope_lexicals
+                    .entry(owner.clone())
+                    .or_default()
+                    .extend(
+                        module_scope_names
+                            .iter()
+                            .filter(|(name, _)| {
+                                !class_static_names
+                                    .is_some_and(|names| names.contains(name.as_str()))
+                            })
+                            .map(|(k, v)| (k.clone(), v.clone())),
+                    );
+                let imported_names = self.module_imported_lexical_names.entry(owner).or_default();
+                for name in &imported_lexical_names {
+                    imported_names.entry(name.clone()).or_insert(true);
+                }
             }
         }
         crate::parser::set_current_language_version(&saved_language_version);

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -3050,6 +3050,8 @@ impl Interpreter {
             package_type_aliases: PackageKeyed::default(),
             module_scope_lexicals: PackageLexicals::default(),
             module_imported_names: Vec::new(),
+            module_imported_lexical_names: PackageKeyed::default(),
+            unit_module_packages: HashMap::new(),
             exported_subs: HashMap::new(),
             exported_sub_values: HashMap::new(),
             exported_vars: HashMap::new(),

--- a/src/runtime/runtime_module.rs
+++ b/src/runtime/runtime_module.rs
@@ -1,6 +1,10 @@
 use super::*;
 
 impl Interpreter {
+    pub(crate) fn module_load_in_progress(&self) -> bool {
+        !self.module_load_stack.is_empty()
+    }
+
     /// Whether `use Test` should load the vendored upstream `Test.rakumod`
     /// (`modules/Rakudo-Core/lib/Test.rakumod`) instead of being recognized as a
     /// no-op that leaves mutsu's native TAP provider in charge.

--- a/src/runtime/runtime_module_exports.rs
+++ b/src/runtime/runtime_module_exports.rs
@@ -528,8 +528,9 @@ impl Interpreter {
                 // Part of the LOADING module's own lexical scope, whether or not
                 // it is new to `env` (see `module_imported_names`).
                 if !self.module_load_stack.is_empty() && !target.contains("::") {
+                    let previous = self.env.get(&target).cloned();
                     self.module_imported_names
-                        .push((target.clone(), value.clone()));
+                        .push((target.clone(), value.clone(), previous));
                 }
                 self.record_import_env_key(&target);
                 self.env.insert(target, value);

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -689,6 +689,8 @@ impl Interpreter {
             package_type_aliases: self.package_type_aliases.clone(),
             module_scope_lexicals: self.module_scope_lexicals.clone(),
             module_imported_names: Vec::new(),
+            module_imported_lexical_names: self.module_imported_lexical_names.clone(),
+            unit_module_packages: self.unit_module_packages.clone(),
             exported_subs: self.exported_subs.clone(),
             exported_vars: self.exported_vars.clone(),
             exported_sub_values: self.exported_sub_values.clone(),

--- a/src/runtime/types/type_registry.rs
+++ b/src/runtime/types/type_registry.rs
@@ -465,28 +465,58 @@ impl Interpreter {
     /// scope, for a name the live `env` no longer accounts for. The LAST resort in
     /// bareword resolution — see `module_scope_lexicals`.
     pub(crate) fn module_scope_lexical(&self, name: &str) -> Option<&Value> {
-        if self.module_scope_lexicals.is_empty() || name.contains("::") || name.is_empty() {
+        // `$_` is the topic, not a module-scope lexical. A module body may
+        // transiently put the topic's backing hash under the plain `_` key
+        // while its declarations run, but consulting that entry here would
+        // make every imported routine's topic read see the stale module value.
+        if self.module_scope_lexicals.is_empty()
+            || name.contains("::")
+            || name.is_empty()
+            || matches!(name, "_" | "@_" | "%_")
+        {
             return None;
         }
         self.lookup_in_running_package(&self.module_scope_lexicals, name)
     }
 
+    /// The module-scope value for a name that came from a nested `use`, rather
+    /// than a name declared by the module itself. The distinction matters to
+    /// the env read fallback: a captured local in an anonymous block must beat
+    /// the module's own `our $name`, while an imported alias must beat the
+    /// caller's same-named env entry.
+    pub(crate) fn module_imported_lexical(&self, name: &str) -> Option<&Value> {
+        if self.module_imported_lexical_names.is_empty() || name.is_empty() || name.contains("::") {
+            return None;
+        }
+        let imported = self.lookup_in_running_package(&self.module_imported_lexical_names, name)?;
+        (*imported)
+            .then(|| self.module_scope_lexical(name))
+            .flatten()
+    }
+
     /// Look `name` up in a per-package table, keyed by the package of the frame
     /// that is actually running. `current_package` is GLOBAL while a method body
     /// runs (module bodies execute under GLOBAL), so the owning package has to
-    /// come from the running frame: the method's class first, then the routine
-    /// frame's package, then whatever package is current — each walked up its
-    /// `::` chain like `resolve_type_name_for_owner`.
+    /// come from the running frame: the method's class first, then the nearest
+    /// enclosing named routine (anonymous blocks inherit that lexical owner),
+    /// then whatever package is current — each walked up its `::` chain like
+    /// `resolve_type_name_for_owner`.
     pub(crate) fn lookup_in_running_package<'a, V>(
         &'a self,
         table: &'a crate::runtime::PackageKeyed<V>,
         name: &str,
     ) -> Option<&'a V> {
         let current = self.current_package();
+        let frame = self
+            .routine_stack
+            .iter()
+            .rev()
+            .find(|frame| !frame.is_block)
+            .or_else(|| self.routine_stack.last());
         let candidates = [
             self.method_class_stack_top_str(),
-            self.routine_stack
-                .last()
+            frame.and_then(|frame| frame.lexical_package.map(|pkg| pkg.as_str())),
+            frame
                 .map(|frame| frame.package.as_str())
                 .filter(|pkg| !pkg.is_empty() && *pkg != "GLOBAL"),
             Some(current.as_str()),

--- a/src/vm/vm_call_dispatch.rs
+++ b/src/vm/vm_call_dispatch.rs
@@ -285,6 +285,8 @@ impl Interpreter {
             );
             (cc, compiler.take_compiled_functions())
         };
+        let mut own_compiled_fns = own_compiled_fns;
+        own_compiled_fns.stamp_source_file(def.source_file.clone());
         let deprecated_info = def.deprecated_message.as_ref().map(|msg| {
             let kind = if def.is_method { "Method" } else { "Sub" };
             (

--- a/src/vm/vm_env_helpers.rs
+++ b/src/vm/vm_env_helpers.rs
@@ -1208,6 +1208,20 @@ impl Interpreter {
         if let Some(v) = self.our_package_scalar(name) {
             return Some(v);
         }
+        // A unit module's imported file-scope names are lexical to the module,
+        // not dynamically inherited from the scope that happened to load it.
+        // The compiler emits a global read for such a name, so prefer the
+        // module table here when the running routine carries the unit owner;
+        // ordinary local lexicals use a local-slot opcode and are unaffected.
+        if self
+            .routine_stack()
+            .iter()
+            .rev()
+            .any(|frame| frame.lexical_package.is_some())
+            && let Some(v) = self.module_imported_lexical(name)
+        {
+            return Some(v.clone());
+        }
         // Raku allows underscore variants of kebab-case identifiers
         // (e.g. $*EXECUTABLE_NAME is equivalent to $*EXECUTABLE-NAME).
         // Try the kebab-case equivalent first if the name contains underscores.

--- a/src/vm/vm_module_ops.rs
+++ b/src/vm/vm_module_ops.rs
@@ -102,7 +102,9 @@ impl Interpreter {
         // Slice F: write imported symbols through to the caller's local slots
         // (import_module recorded their names); keeps an imported `constant c`
         // coherent without the reverse pull. This op holds the outer `code`.
-        self.apply_pending_rw_writeback(code);
+        if !self.module_load_in_progress() {
+            self.apply_pending_rw_writeback(code);
+        }
         // A module load writes imported symbols into env by name; flag the env so
         // the next GetLocal barrier reconciles them into locals. (An eager
         // sync_locals_from_env here is unsafe: it can clobber a fresh in-place

--- a/t/lib/Issue7692/Mid.rakumod
+++ b/t/lib/Issue7692/Mid.rakumod
@@ -1,0 +1,16 @@
+unit module Issue7692::Mid;
+use Issue7692::Vars;
+
+sub i7692-mid() is export {
+    $issue7692-value ~ '/' ~ I7692Class.new.hi
+}
+
+sub i7692-nested() is export {
+    sub inner() { $issue7692-value }
+    inner()
+}
+
+sub i7692-block() is export {
+    my $inner = { $issue7692-value ~ '/' ~ I7692Class.new.hi }
+    $inner()
+}

--- a/t/lib/Issue7692/Vars.rakumod
+++ b/t/lib/Issue7692/Vars.rakumod
@@ -1,0 +1,10 @@
+unit module Issue7692::Vars;
+
+our $issue7692-value is export = 42;
+our $issue7692-only is export = 'only-in-vars';
+
+class I7692Class is export {
+    method hi() { 'hi' }
+}
+
+sub i7692-exported is export { 'exported' }

--- a/t/module-import-alias-scope.t
+++ b/t/module-import-alias-scope.t
@@ -1,0 +1,37 @@
+use v6;
+use lib 't/lib';
+use Test;
+
+# A unit module's body currently executes in the caller's env. Its imports
+# must remain visible to its own routines without leaving the imported aliases
+# in the caller after the module load (tokuhirom/mutsu#7692).
+
+plan 11;
+
+my $issue7692-value = 'caller-value';
+use Issue7692::Mid;
+
+is i7692-mid(), '42/hi', 'a unit module routine sees its imported variable and class';
+is i7692-nested(), '42', 'a nested sub inherits the unit module import scope';
+is i7692-block(), '42/hi', 'a nested block inherits the unit module import scope';
+is $issue7692-value, 'caller-value', 'a same-named caller variable is restored';
+nok (try $issue7692-only).defined, 'an imported variable does not leak to the caller';
+nok (try I7692Class.new.hi).defined, 'an imported class does not leak to the caller';
+nok (try i7692-exported()).defined, 'a transitive imported sub does not leak to the caller';
+
+is EVAL(q:to/CODE/), 'only-in-vars', 'a direct use still imports the variable';
+    use Issue7692::Vars;
+    ::('$issue7692-only')
+CODE
+
+is EVAL(q:to/CODE/), 'hi', 'a direct use still imports the class';
+    use Issue7692::Vars;
+    I7692Class.new.hi
+CODE
+
+is EVAL(q:to/CODE/), 'exported', 'a direct use still imports the sub';
+    use Issue7692::Vars;
+    i7692-exported()
+CODE
+
+is $issue7692-value, 42, 'a direct import installs the imported value in the caller';


### PR DESCRIPTION
## Summary

- keep `unit module` imports scoped to the module compilation unit
- preserve imported aliases for module routines and nested blocks without leaking them into the caller
- add regression coverage for nested imports, caller shadowing, direct imports, and transitive type/sub visibility

Fixes #7692

## Validation

- `cargo fmt --all`
- `cargo clippy -- -D warnings`
- `make test`
- `make roast`
