### PR TITLE
fix: preserve collected for containers past the loop

### DIFF
--- a/docs/adr/0082-a-collecting-for-gathers-containers-not-snapshots.md
+++ b/docs/adr/0082-a-collecting-for-gathers-containers-not-snapshots.md
@@ -1,6 +1,6 @@
 # ADR-0082: A value-collecting `for` gathers containers, not snapshots
 
-- Status: Accepted (implemented)
+- Status: Superseded by ADR-0083
 - Date: 2026-09-09
 - Related: [ADR-0045](0045-for-loop-parameters-bind-the-element-container.md)
   (a `for` parameter binds the element container),

--- a/docs/adr/0083-a-collected-for-retains-containers-past-the-loop.md
+++ b/docs/adr/0083-a-collected-for-retains-containers-past-the-loop.md
@@ -1,0 +1,94 @@
+# ADR-0083: A collected `for` retains lvalue containers past the loop
+
+- Status: Accepted (implemented)
+- Date: 2026-09-09
+- Supersedes: [ADR-0082](0082-a-collecting-for-gathers-containers-not-snapshots.md)'s
+  rejection of collecting a real `ContainerRef`
+- Addresses: GitHub issue [#7734](https://github.com/tokuhirom/mutsu/issues/7734)
+- Related: [ADR-0040](0040-array-hash-elements-are-itemized-at-the-store.md)
+  (ordinary `@` stores decontainerize their input elements),
+  [ADR-0059](0059-is-rw-routines-return-a-container.md) (an lvalue result is a
+  container), and [ADR-0067](0067-a-routine-hands-back-the-container-it-was-given.md)
+  (container identity must survive a return)
+
+## Context
+
+ADR-0082 fixed the in-loop value-collecting `for` shapes by tagging a tail
+container and reading its name once after the loop. That was deliberately a
+deferred re-read rather than a real cell, so the list itself lost the lvalue
+identity at the loop boundary:
+
+```raku
+my $g = 1;
+my $s = do for 1..2 { $g };
+$g = 5;
+say $s;                         # (5 5) in raku, (1 1) before this ADR
+```
+
+The same divergence occurs for a `:=` binding. The nearby `@` shape is the
+important control case:
+
+```raku
+my $g = 1;
+my @v = do for 1..2 { $g };
+$g = 5;
+say @v;                         # [1 1] in both implementations
+```
+
+The list returned by `do for` must therefore carry the container, while the
+later real-Array store must copy its value. The repository already has both
+chokepoints: `ContainerRef` is the representation of a shared scalar cell,
+and `coerce_to_array` decontainerizes cells when `=` populates an `@` variable.
+
+## Decision
+
+When the VM consumes a `TagContainerRef` signal for a collected iteration, it
+resolves the tagged local slot (falling back to the environment) and ensures
+that binding is represented by a `ContainerRef`. The cell is installed in the
+authoritative local slot and its environment mirror on the first tagged
+iteration. Each collected slot then stores the same cell, rather than the
+value read from it after the loop.
+
+This applies to the existing tagged lvalue-tail mechanism, including bare
+variable tails and assignment-expression tails. It does not broaden the
+compiler's tagging rule: loop parameters, `$_`, and body-local `my` bindings
+remain per-iteration values; `state` and outer bindings remain shared cells.
+
+The resulting List keeps its cells through scalar assignment and `:=` binding.
+When the List is assigned to a real `@` array, `coerce_to_array` decontainerizes
+the `ContainerRef` elements before the array's element-store itemization, so
+the array snapshot remains `[1 1]`. No special case for this issue is added to
+the array consumer.
+
+## Invariants and acceptance
+
+- `my $s = do for 1..2 { $g }` and `my $s := do for 1..2 { $g }` both observe a
+  later `$g = 5` as `(5 5)`.
+- `my @v = do for 1..2 { $g }` remains `[1 1]` after the later mutation.
+- The nine existing rows in `t/for-collect-container-tail.t` remain green,
+  including `temp`, `state`, loop-parameter, topic, and body-local cases.
+- The five assignment-tail rows in `t/for-collect-assign-container.t` remain
+  green; assignment tails continue to collect their lvalue container.
+
+## Consequences
+
+- The collected List now contains first-class `ContainerRef` values for tagged
+  lvalue tails. This is the Raku-compatible identity needed after the loop,
+  and existing List/Array conversion boundaries determine whether that identity
+  is retained or copied.
+- The loop no longer performs a deferred end-of-loop value replacement. The
+  cell is promoted at collection time, so a mutation between loop completion
+  and list consumption is observable only where the result still carries the
+  List's containers.
+- The compiler's conservative tagging rule remains the boundary for which
+  names are eligible; subscript tails remain governed by the separate element
+  container and store decisions in ADR-0036 and ADR-0040.
+
+## Alternative rejected
+
+Keep the ADR-0082 deferred name re-read and record the post-loop divergence as
+an accepted limitation. That keeps the collected List cheap but contradicts
+Raku's lvalue identity exactly at the point where the result escapes the loop.
+The existing `ContainerRef` representation and Array store boundary make the
+identity-preserving implementation bounded, so the limitation is no longer
+justified.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -107,4 +107,5 @@ The role of an ADR is to preserve the *context of the judgment* — something th
 | [0079](0079-container-itemization-is-a-holder-property-tagged-on-the-containerref-word.md) | Container itemization is a property of the *holder*, tagged on the `ContainerRef` word (not on the shared cell) | Proposed |
 | [0080](0080-hash-element-containerization-is-per-value.md) | Hash element containerization is a per-value property, not a hash-wide slurpy flag | Proposed |
 | [0081](0081-compunit-scoped-module-import-aliases.md) | A unit module's imported aliases are scoped to its compilation unit | Proposed |
-| [0082](0082-a-collecting-for-gathers-containers-not-snapshots.md) | A value-collecting `for` gathers containers, not snapshots | Accepted (implemented) |
+| [0082](0082-a-collecting-for-gathers-containers-not-snapshots.md) | A value-collecting `for` gathers containers, not snapshots | Superseded by 0083 |
+| [0083](0083-a-collected-for-retains-containers-past-the-loop.md) | A collected `for` retains lvalue containers past the loop | Accepted (implemented) |

--- a/news/2026-09/collected-for-retains-containers.md
+++ b/news/2026-09/collected-for-retains-containers.md
@@ -1,0 +1,15 @@
+# Collected `for` results retain lvalue containers
+
+A value-collecting `for` now keeps the `ContainerRef` for a bare lvalue tail in
+its returned List instead of reading the variable once when the loop ends.
+Consequently, both scalar assignment and `:=` binding observe later mutations:
+
+```raku
+my $g = 1; my $s = do for 1..2 { $g }; $g = 5; say $s;  # (5 5)
+```
+
+Assigning the result to a real `@` array still snapshots the values, because the
+existing array coercion decontainerizes its input elements. This resolves
+[#7734](https://github.com/tokuhirom/mutsu/issues/7734) and supersedes the
+rejected alternative recorded in ADR-0082; see ADR-0083 for the representation
+and store-boundary reasoning.

--- a/src/vm/vm_for_loop_body.rs
+++ b/src/vm/vm_for_loop_body.rs
@@ -194,11 +194,9 @@ impl Interpreter {
         // `when`) piled up one value per pass.
         let stack_base = self.stack.len();
         let mut collected = if spec.collect { Some(Vec::new()) } else { None };
-        // Collected slots whose value is a CONTAINER, not a snapshot: the name
-        // (and the emitting site's baked local slot) of the variable each one
-        // denotes, re-read once the loop is over. See the fix-up at the end of
-        // this function.
-        let mut deferred_container_refs: Vec<(usize, String, Option<u32>)> = Vec::new();
+        // Collected slots whose value is a CONTAINER, not a snapshot. The
+        // emitting site's baked local slot is used to promote the source to a
+        // real ContainerRef while the iteration is still being collected.
         // A `for` block owns its topic (raku binds `$_` as the block's own
         // implicit parameter), so the enclosing `$_` is restored on every exit —
         // normal, `last`/`next`, and error.
@@ -993,8 +991,10 @@ impl Interpreter {
                             Self::collect_loop_value(coll, val);
                             if let Some((name, slot)) = deferred_ref
                                 && coll.len() == coll_start_len + 1
+                                && let Some(container) =
+                                    self.collect_container_ref(code, &name, slot)
                             {
-                                deferred_container_refs.push((coll_start_len, name, slot));
+                                coll[coll_start_len] = container;
                             }
                         }
                         // Drain anything else this iteration left behind.
@@ -1376,30 +1376,47 @@ impl Interpreter {
         self.quanthash_bind_params = saved_quanthash_bind.clone();
         self.restore_loop_topic(saved_topic, saved_topic_local);
         if let Some(coll) = collected {
-            let mut coll = coll;
-            // Every collected container is read here, once, with the loop over —
-            // so after the last iteration's `temp` restore, and at the same value
-            // for all of them, which is what makes `do for 1..2 { temp $g = 9;
-            // $g }` `(1 1)` and `do for 1..2 { $g = $g + 1; $g }` `(3 3)`.
-            // Slot-first, env-fallback (§1.5, docs/lexical-scope-slot-campaign.md):
-            // a plain `my $g` lexical keeps its live value in its local slot and
-            // its env mirror is suppressed, so the env read alone saw `Any`.
-            for (idx, name, slot) in deferred_container_refs {
-                if idx >= coll.len() {
-                    continue;
-                }
-                let current = self
-                    .gate_local_slot_at(code, slot, &name)
-                    .and_then(|s| self.locals.get(s).cloned())
-                    .filter(|v| !v.is_nil())
-                    .or_else(|| self.get_env_with_main_alias(&name));
-                if let Some(v) = current {
-                    coll[idx] = v;
-                }
-            }
             self.stack.push(Value::array(coll));
         }
         Ok(completed_all)
+    }
+
+    /// Return the live container for a tagged collected value, promoting a
+    /// plain scalar binding to a shared cell when this is the first iteration.
+    ///
+    /// A value-collecting `for` preserves the block's lvalue container. The
+    /// old implementation remembered the name and read its value once after
+    /// the loop, which got the nine in-loop shapes right but lost the cell as
+    /// soon as the resulting List escaped the loop. Installing the cell while
+    /// collecting makes both occurrences in the List point at the same
+    /// storage, while `coerce_to_array` still decontainerizes those cells for
+    /// an ordinary `@` assignment.
+    fn collect_container_ref(
+        &mut self,
+        code: &CompiledCode,
+        name: &str,
+        slot: Option<u32>,
+    ) -> Option<Value> {
+        let local_slot = self.resolve_local_slot(code, slot, name);
+        let current = local_slot
+            .and_then(|idx| self.locals.get(idx).cloned())
+            .filter(|v| !v.is_nil())
+            .or_else(|| self.get_env_with_main_alias(name))?;
+
+        if let ValueView::ContainerRef(cell) = current.view() {
+            return Some(Value::container_ref(cell.clone()));
+        }
+
+        let container = Value::container_ref(crate::gc::Gc::new(crate::value::ContainerCell::new(
+            current,
+        )));
+        if let Some(idx) = local_slot {
+            self.locals[idx] = container.clone();
+            self.flush_local_to_env(code, idx);
+        } else {
+            self.set_env_with_main_alias(name, container.clone());
+        }
+        Some(container)
     }
 
     /// Break a multi-parameter loop variable's binding away from any shared

--- a/t/for-collect-container-tail.t
+++ b/t/for-collect-container-tail.t
@@ -1,6 +1,6 @@
 use Test;
 
-plan 9;
+plan 11;
 
 # A Raku block's value is not decontainerized, so a value-collecting `for`
 # whose body ends in a bare variable read gathers that variable's *container*.
@@ -27,7 +27,21 @@ plan 9;
     my $g = 1;
     my @v = do for 1..2 { $g };
     $g = 5;
-    is-deeply @v, [1, 1], 'the container is read when the list is built, not later';
+    is-deeply @v, [1, 1], 'an array assignment decontainerizes the collected cells';
+}
+
+{
+    my $g = 1;
+    my $s = do for 1..2 { $g };
+    $g = 5;
+    is-deeply $s, (5, 5), 'a scalar-bound collected List keeps the containers past the loop';
+}
+
+{
+    my $g = 1;
+    my $s := do for 1..2 { $g };
+    $g = 5;
+    is-deeply $s, (5, 5), 'a bound collected List keeps the containers past the loop';
 }
 
 {


### PR DESCRIPTION
## Summary

- Preserve the shared `ContainerRef` when a value-collecting `for` returns a tagged lvalue tail.
- Keep the existing array-assignment boundary that decontainerizes collected cells into a snapshot.
- Add regression coverage for scalar assignment and `:=`, plus ADR-0083 and a news entry.

Closes #7734

## Validation

- `cargo fmt --all`
- `make lint`
- `make test`
- `make roast`
- `target/debug/mutsu t/for-collect-container-tail.t`
- `target/debug/mutsu t/for-collect-assign-container.t`
- `target/debug/mutsu t/loop-body-let-resolution.t`
