### PR TITLE
perf: measure ADR-0068's read-side container guard on threaded programs

### DIFF
--- a/benchmarks/bench-threads.raku
+++ b/benchmarks/bench-threads.raku
@@ -1,0 +1,55 @@
+# Concurrency - cross-thread traffic through ALIASED (celled) containers.
+#
+# Deliberately routes through `:=`-bound containers rather than plain lexicals.
+# A plain `my @a` captured by a `start` block is served by the name-keyed
+# shared-variable lanes; a bound one becomes a shared ContainerRef cell, which
+# is the path ADR-0068's cross-thread container guard actually covers -
+# `Value::with_deref` / `into_deref` on the read side, the element store on the
+# write side. Drop the `:=` and this benchmark measures neither of them (issue
+# #7613 measured that: the obvious plain-lexical shape takes zero guards).
+#
+# Threaded wall-clock on a shared CI runner is noisier than the single-threaded
+# benchmarks here, and the worker count is fixed rather than derived from the
+# runner: read the trend across commits, not a single row.
+
+my $checksum = 0;
+
+# Read-hot: four workers reading one shared cell. Every read of @alias and
+# $sref goes through that cell, so this section is dominated by the read-side
+# guard once a worker has been spawned.
+my @data = ^256;
+my @alias := @data;
+my $seed = 7;
+my $sref := $seed;
+
+my @readers;
+for ^4 {
+    @readers.push: start {
+        my $s = 0;
+        for ^150000 -> $i {
+            $s += @alias[$i +& 255] + $sref;
+        }
+        $s
+    }
+}
+$checksum += [+] await @readers;
+
+# Write side: disjoint slots of one aliased container. Each worker owns 16
+# indices and writes them repeatedly, so the surviving values - and hence the
+# checksum - do not depend on how the workers interleave.
+my @backing = 0 xx 64;
+my @slots := @backing;
+
+my @writers;
+for ^4 -> $t {
+    @writers.push: start {
+        for ^20000 -> $i {
+            @slots[$t * 16 + ($i +& 15)] = $t * 1000 + $i;
+        }
+        1
+    }
+}
+await @writers;
+$checksum += [+] @slots;
+
+say "checksum = $checksum";

--- a/docs/adr/0068-cross-thread-container-writes-need-a-synchronized-store.md
+++ b/docs/adr/0068-cross-thread-container-writes-need-a-synchronized-store.md
@@ -1,6 +1,6 @@
 # ADR-0068: A cross-thread aliased container write needs a synchronized store, not a name-keyed lane
 
-- Status: **Accepted** (2026-09-06; §4 steps 1-2 implemented, step 3 in progress — see §8, §10)
+- Status: **Accepted** (2026-09-06; §4 steps 1-3 implemented — see §13.4; the read-side guard's cost measured in §14)
 - Date: 2026-09-05
 - Relates to: [ADR-0001](0001-gc-strategy-and-phasing.md) §7 (layer 3c),
   [ADR-0013](0013-container-interior-mutability-cellvalue.md) §1.3-2 / §3 / §5 Q2,
@@ -261,9 +261,13 @@ mutual-exclusion edge. This ADR does not argue that case and must not be read as
    delivery one. With the idiom corrected the route reaches the cell-keyed guard (capture shape)
    or the name-keyed lane (named-sub shape) and the unsynchronized store not at all: 0 / 240 at
    24-way.
-4. **Does the (C) flag belong in `gc_contents_mut` itself** (one relaxed load at the primitive,
+4. ~~**Does the (C) flag belong in `gc_contents_mut` itself** (one relaxed load at the primitive,
    for every site at once) or at each synchronized store? Measuring the primitive-level load
-   against the bench CI is the deciding datum, and it was not taken this session.
+   against the bench CI is the deciding datum, and it was not taken this session.~~
+   **ANSWERED (2026-09-09, §14).** It stays at the guard. The gate as placed is free — a program
+   that never spawns a mutator thread measures −0.5% (noise) over 6.4M reads that would each
+   have locked — so moving the load down to the primitive's 149 sites would buy nothing it does
+   not already have.
 
 ## 7. Implementation (2026-09-06): what was measured, and which premises above were wrong
 
@@ -745,5 +749,49 @@ shape.
 What remains is not exposure but a **measurement**, and it is a perf question
 rather than a correctness one: §7's read-side guard sits in `Value::with_deref`
 / `into_deref`, which are hot, and a threaded program now takes a mutex on every
-celled-container read. Nothing has measured it. Tracked separately as
-[#7613](https://github.com/tokuhirom/mutsu/issues/7613).
+celled-container read. Tracked separately as
+[#7613](https://github.com/tokuhirom/mutsu/issues/7613) and **taken in §14** —
+no threaded regression; on a shared cell the guard is a net win.
+
+## 14. The read-side guard, measured (2026-09-09): no threaded regression
+
+§13.4's remaining item — the perf cost of the read-side guard on a threaded
+program — is now measured ([#7613](https://github.com/tokuhirom/mutsu/issues/7613)).
+Full write-up in `news/2026-09/adr-0068-read-side-container-guard-measured.md`;
+the operative results:
+
+- **§4 step 1's gate is free, measured and not merely by placement.** A program
+  that never spawns a VM mutator thread is within noise (−0.5%) over 6.4M reads
+  that would each have locked. This is the datum §6 question 4 asked for, taken
+  at the guard rather than at `gc_contents_mut`.
+- **The cost is +5–7%, and it lands on a shape the ticket did not predict** —
+  not the threaded program but the one that spawns a worker early and then does
+  heavy *single-threaded* work through a bound container, paying the
+  uncontended lock for the rest of its life because the gate is sticky. That is
+  the ceiling, on a loop that does nothing but celled reads.
+- **On genuinely concurrent programs the guard is a net win**: −12% with four
+  workers on one shared cell, −13% oversubscribed 12-on-4 (−9% with JIT off).
+  Serializing readers on a stripe is cheaper than four cores contending on the
+  cell's own `Mutex<Value>` and on the inner node's refcount atomics. The guard
+  removes a contention storm it was not designed to remove.
+- **Striping granularity is not a lever.** Four independent cells measure
+  −0.6% / +3.2%, so 64 stripes leave no false sharing worth chasing; and where
+  the cost concentrates (one hot cell) more stripes cannot help, since the
+  exclusion on that cell is what correctness requires.
+
+No change was made. Two process notes for anyone measuring in this area again:
+
+- **§1.1's "a minimal probe is not a substitute" applies to benchmarks too.**
+  The obvious workloads — four `start` blocks over a captured `my @shared`, a
+  captured scalar, a captured scalar holding an array, an attribute-rooted
+  `$b.items[...]` — take *zero* guards, because a plain `@`/`%` lexical named by
+  a `start` block is served by the name-keyed lanes and never becomes a
+  `ContainerRef`. Benchmarking those yields a null result that means nothing.
+  A `:=`-bound container is what reaches the read-side guard.
+- **§13.1's corrected oracle is also the benchmark-validation tool.** Breaking
+  on `container_lock::stripe_for` counts the mutexes a workload actually takes
+  (it sits past both gates in `acquire`), so "does this benchmark exercise the
+  thing" is one debug run and no rebuild.
+
+`benchmarks/bench-threads.raku` was added so the bench CI carries a concurrency
+series in `bench-history.tsv` from here on; there was none before.

--- a/news/2026-09/adr-0068-read-side-container-guard-measured.md
+++ b/news/2026-09/adr-0068-read-side-container-guard-measured.md
@@ -1,0 +1,112 @@
+# ADR-0068's read-side container guard, measured: no threaded regression, and a shared-cell speedup
+
+ADR-0068 §7 put the cross-thread exclusion on the **read** side as well as the
+write side, because the dominant race was writer-versus-reader: the element
+store derives a raw pointer into a `ContainerCell`'s slot and releases the
+cell's `Mutex`, while readers take that same `Mutex` to clone the inner `Value`
+out, so the two never excluded each other and a reader could take a refcount on
+a node the writer had already dropped. Locking only the write side left 13/96
+failures standing.
+
+That guard therefore sits in `Value::with_deref` / `Value::into_deref`, which
+are hot, and a threaded program now takes a striped mutex on every celled
+container read. §13.4 closed step 3 by naming the one thing left as a
+measurement rather than a correctness question, and
+[#7613](https://github.com/tokuhirom/mutsu/issues/7613) tracked it. This is that
+measurement.
+
+## The obvious probe measures nothing — a repeat of §1.1's lesson
+
+The first four workloads written for this — four `start` blocks hammering a
+captured `my @shared`, a captured scalar, a captured scalar holding an array,
+and an attribute-rooted `$b.items[...]` — took **zero** guards. A plain
+`@`/`%` lexical named by a `start` block is served by the name-keyed
+shared-variable lanes in `runtime/runtime_shared_vars.rs`; it never becomes a
+`ContainerRef`, so `with_deref` never sees a cell and the guard is not on its
+path at all. Benchmarking those would have produced a clean null result that
+meant nothing, which is exactly the trap ADR-0068 §1.1 recorded for the
+correctness work ("a hand-written minimal probe is not a substitute for the real
+file").
+
+The §1.2 path oracle settles it in one debug run and no rebuild, using gdb's
+ignore counter as a free call counter. `stripe_for` is reached only after both
+gates in `ContainerStructGuard::acquire` pass, so its hit count is the number of
+mutexes actually taken:
+
+```bash
+rust-gdb -batch \
+  -ex 'break mutsu::value::container_lock::stripe_for' \
+  -ex 'break mutsu::value::container_lock::ContainerStructGuard::acquire_for_cell' \
+  -ex 'ignore 1 100000000' -ex 'ignore 2 100000000' \
+  -ex 'run' -ex 'info breakpoints' \
+  --args ./target/debug/mutsu <file>
+```
+
+What does reach the guard is a **`:=`-bound** container read across threads:
+`my @alias := @data` makes the workers share a cell, and then every read of
+`@alias` locks — 160,000 acquisitions for 80,000 loop iterations reading two
+bound variables, i.e. 100% of them, with the two breakpoints in lockstep.
+
+## The A/B
+
+Two release binaries off the same tree, differing only in whether
+`with_deref`/`into_deref` acquire the guard, run alternately (A/B/A/B, so
+thermal and scheduler drift hits both arms), median of 9, on a 4-core container.
+Negative means the guard is **faster**.
+
+| workload | celled reads | JIT on | JIT off |
+|---|---|---|---|
+| 1 thread, never spawned (gate off) | 6.4M would-be | −0.5% | — |
+| 1 thread, after one trivial spawn (gate on, uncontended) | 6.4M | **+7.1%** | **+5.3%** |
+| 4 workers, 4 independent cells | 3.2M | −0.6% | +3.2% |
+| 4 workers, one shared cell | 6.4M | **−12.0%** | −0.5% |
+| 12 workers on 4 cores, one shared cell | 4.8M | **−13.0%** | **−9.0%** |
+| `benchmarks/bench-threads.raku` as shipped | 1.2M + stores | −3.7% | −1.7% |
+
+On provenance: `CLAUDE.md` requires numbers in documents to come from the bench
+CI history, and this table deliberately cannot — the CI builds one binary, and
+an A/B needs two. What the bench CI *can* carry is the absolute concurrency
+series, which is what `benchmarks/bench-threads.raku` adds below; the deltas
+here are local, taken on an idle box with the arms interleaved so drift cancels,
+and are reported as deltas rather than absolute times for exactly that reason.
+
+Three things fall out of it.
+
+**The §4 step 1 gate is free, as claimed.** A program that never spawns a VM
+mutator thread measures −0.5% — noise — over 6.4M reads that would each have
+locked. ADR-0068 §7.4 answered §6 question 4 "by placement rather than
+measurement"; the placement is now measured too.
+
+**The cost is real but small, and it is not where the ticket expected it.** The
+worst case is not the threaded program: it is the program that spawns one worker
+early and then does heavy single-threaded work through a bound container, which
+pays the *uncontended* lock on every read for the rest of its life (the gate is
+deliberately sticky). +5–7% on a loop that does essentially nothing but celled
+reads is the ceiling for that shape; any real program dilutes it with work that
+does not touch a cell.
+
+**On genuinely concurrent programs the guard is a net win.** Four workers on one
+shared cell run 12% faster *with* it, and oversubscribed 12-on-4 the margin is
+13% (9% with JIT off). Serializing the readers on a stripe is cheaper than
+letting four cores contend on the cell's own `Mutex<Value>` and on the atomic
+refcount of the inner node that `into_deref`'s clone touches. The guard removes
+a contention storm it was never designed to remove.
+
+**Per-cell striping granularity — the ticket's named first knob — is not the
+lever.** With four independent cells the delta is −0.6% / +3.2%, so 64 stripes
+leave no false-sharing cost worth chasing; and where the cost *is* concentrated
+(one hot cell) more stripes cannot help, because the exclusion on that cell is
+what correctness requires. Nothing to tune.
+
+## What shipped
+
+`benchmarks/bench-threads.raku`, so the bench CI records a concurrency series in
+`bench-history.tsv` from the next main push onward — there was none before, which
+is why the ticket's "measure against the bench CI history" had nothing to measure
+against. It is built out of `:=`-bound containers on purpose, with a comment
+saying why: the plain-lexical shape would leave it measuring a path the guard is
+not on. Its read half stresses `with_deref`/`into_deref` on one shared cell; its
+write half drives the store-side guard through disjoint slots, so the checksum
+does not depend on how the workers interleave (mutsu and rakudo agree on it).
+
+No code changed. The read-side guard stays exactly as ADR-0068 §7.4 built it.

--- a/src/value/container_lock.rs
+++ b/src/value/container_lock.rs
@@ -47,6 +47,20 @@
 //!   mutation itself, not around a region that can call back into user Raku
 //!   code, so a holder never blocks on another thread while holding it.
 //!
+//! Measured (2026-09-09, ADR-0068 §14, [#7613]): "affordable" holds in both
+//! directions. A program that never spawns a mutator thread is within noise
+//! over 6.4M reads that would each have locked; a program that spawns one and
+//! then reads a bound container single-threaded pays +5-7% on a loop that does
+//! nothing else; and a genuinely concurrent one runs 12-13% FASTER with these
+//! locks than without, because serializing readers on a stripe is cheaper than
+//! letting several cores contend on the cell's own `Mutex<Value>` and on the
+//! inner node's refcount atomics. `STRIPES` is not a lever either: four
+//! independent cells measure -0.6% / +3.2%, and where the cost concentrates
+//! (one hot cell) more stripes cannot help, since excluding on that cell is
+//! what correctness requires.
+//!
+//! [#7613]: https://github.com/tokuhirom/mutsu/issues/7613
+//!
 //! The at-most-one rule leaves a known hole — a read of a *different* cell,
 //! reached from inside a guarded store, is unprotected. ADR-0068 §6 question 1
 //! anticipated exactly this and set the stress harness rather than the argument


### PR DESCRIPTION
ADR-0068 §7 put the cross-thread exclusion on the **read** side as well as the write side, because the dominant race was writer-versus-reader. That guard therefore sits in `Value::with_deref` / `into_deref`, which are hot, and a threaded program takes a striped mutex on every celled-container read. §13.4 named this as the one item of the campaign left open, and it was never a correctness question. This measures it.

## The obvious probes measure nothing

Four `start` blocks over a captured `my @shared`, a captured scalar, a captured scalar holding an array, and an attribute-rooted `$b.items[...]` all take **zero** guards. A plain `@`/`%` lexical named by a `start` block is served by the name-keyed shared-variable lanes and never becomes a `ContainerRef`, so `with_deref` never sees a cell. Benchmarking those would have produced a clean null result that meant nothing — the benchmark twin of §1.1's "a minimal probe is not a substitute for the real file".

A `:=`-bound container is what reaches the guard, and §13.1's oracle (break on `container_lock::stripe_for`, which sits past both gates in `acquire`) confirms it in one debug run with no rebuild: 160,000 mutexes for 80,000 iterations reading two bound variables — 100% of the reads.

## The A/B

Two release binaries off the same tree, differing only in whether `with_deref`/`into_deref` acquire the guard, run alternately (A/B/A/B so drift hits both arms), median of 9, on an idle 4-core container. Negative means the guard is **faster**.

| workload | celled reads | JIT on | JIT off |
|---|---|---|---|
| 1 thread, never spawned (gate off) | 6.4M would-be | −0.5% | — |
| 1 thread, after one trivial spawn (uncontended) | 6.4M | **+7.1%** | **+5.3%** |
| 4 workers, 4 independent cells | 3.2M | −0.6% | +3.2% |
| 4 workers, one shared cell | 6.4M | **−12.0%** | −0.5% |
| 12 workers on 4 cores, one shared cell | 4.8M | **−13.0%** | **−9.0%** |
| `benchmarks/bench-threads.raku` as shipped | 1.2M + stores | −3.7% | −1.7% |

- **No threaded regression to fix.** The §4 step 1 gate is free as claimed — which is also the datum §6 question 4 asked for, so that question is now answered and the flag stays at the guard rather than moving down to `gc_contents_mut`'s 149 sites.
- **The cost lands on a shape the ticket did not predict**: spawn a worker early, then do heavy *single-threaded* work through a bound container, paying the uncontended lock forever because the gate is sticky. +5–7% on a loop that does nothing but celled reads is the ceiling.
- **On genuinely concurrent programs the guard is a net win.** Serializing readers on a stripe is cheaper than letting several cores contend on the cell's own `Mutex<Value>` and on the inner node's refcount atomics.
- **Per-cell striping granularity — the knob the ticket named first — is not the lever.** Four independent cells measure −0.6% / +3.2%, and where the cost concentrates (one hot cell) more stripes cannot help, since excluding on that cell is what correctness requires.

Provenance: `CLAUDE.md` wants document numbers from the bench CI, and an A/B structurally cannot come from it (the CI builds one binary). What the bench CI *can* carry is the absolute concurrency series, which this PR adds; the deltas are local, interleaved, and reported as deltas for exactly that reason. Both the news entry and ADR §14 say so.

## Changes

- `benchmarks/bench-threads.raku` (new) — a concurrency benchmark for the bench CI, so `bench-history.tsv` carries a threaded series from the next main push (there was none, which is why "measure against the bench CI history" had nothing to measure against). Built out of `:=`-bound containers on purpose, with a comment saying why; the write half drives the store-side guard through disjoint slots, so the checksum is interleaving-independent (mutsu and rakudo agree on it).
- `news/2026-09/adr-0068-read-side-container-guard-measured.md` (new) — the write-up.
- ADR-0068 — §14 records the result, §6 question 4 is marked answered, §13.4 points at §14, and the status line updates.
- `src/value/container_lock.rs` — module doc gains the measured numbers behind its "affordable" claim. Doc comment only; no behaviour change.

## Verification

`make lint` (with `wasm32-unknown-unknown` installed), `make test`, `make roast` all run locally. lint and test are clean; roast's only failures are the three documented in `docs/agent-environments.md` as container artifacts, with exactly the listed test numbers: `6.c/S32-io/file-tests.t` (4, uid 0), `S16-filehandles/filetest.t` (25, uid 0), `S32-io/IO-Socket-Async.t` (exit 124, sandboxed network).

Closes #7613

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NPac2bWVsKpVjxTUccgW55

---
_Generated by [Claude Code](https://claude.ai/code/session_01NPac2bWVsKpVjxTUccgW55)_