### PR TITLE
perf: carry the Symbol a call already has instead of re-interning its name

### DIFF
--- a/news/2026-09/per-assertion-symbol-intern-hoist.md
+++ b/news/2026-09/per-assertion-symbol-intern-hoist.md
@@ -1,0 +1,106 @@
+# Halve the `Symbol::intern` calls a Test assertion pays
+
+[#7736](https://github.com/tokuhirom/mutsu/issues/7736) attributed the per-assertion
+budget of the vendored `Test` module's `ok` and found `Symbol::intern` at the top:
+**~78 interns per assertion, 5.6% of the run**, half of it reached from the signature
+binder. The pattern was the one ADR-0037 and [#7571](https://github.com/tokuhirom/mutsu/issues/7571)
+have been paying down elsewhere — a helper takes `&str`, so every call re-hashes a
+name whose `Symbol` the caller already had, or which is a fixed literal that could be
+interned once for the process.
+
+Nothing here changes what is computed. Each site now carries the `Symbol` it already
+had (or a pre-interned one) to the helper that needed it, instead of handing over the
+string and making the helper find the symbol again.
+
+## What was threaded where
+
+**Fixed per-call keys.** `bind_function_args_values_inner` writes `@_` and probes
+`self` / `?CLASS` on every compiled call, and `current_source_file` probes `?FILE` on
+every caller-frame push. All four have pre-interned symbols in `symbol::wk` already;
+they now use them.
+
+**The declaring source file and package.** `CompiledFunction` has cached
+`source_file_sym` and `package_sym` accessors, interned once per routine.
+`enter_compilation_unit` was going through the `&str` form, re-hashing the whole
+declaring path — 60+ bytes for a module — on every named call, and the package switch
+re-hashed the package name the same way. Both now take the cached symbol
+(`Interpreter::unit_of_source_sym`, `enter_package_guarded_with_sym`).
+
+**The per-parameter path.** The binder resolved each parameter's name separately in
+every helper it passed — the value bind, the type-constraint registration, the
+readonly mark. It now interns the name at most once per parameter and hands that
+symbol to `bind_param_value_sym` / `bind_param_type_constraint_sym` /
+`mark_readonly_sym`. The intern is lazy (a `OnceCell` per parameter), so an arm that
+never names the parameter still interns nothing.
+
+**The store paths.** `SetLocal`'s slot symbol (`CompiledCode::locals_sym`) and
+`SetGlobal`'s constant symbol now reach the env probe, the readonly check, the
+typed-lexical clear, and the two `__mutsu_sigilless_*` metadata keys — the last of
+which also drops two `format!` allocations per store, since those keys are memoized
+per name symbol (`sigilless_readonly_key_for_sym` and its alias twin).
+
+Two `&str` entry points that had no remaining callers after this are gone:
+`Interpreter::type_meta_key_sym` folded into `type_meta_key_for_sym`, whose doc
+comment now records that every caller holds a symbol.
+
+`Env` gained two small helpers for the sites that needed them: `get_for`, for a caller
+whose symbol is `Option` (a compiled slot has one, a hand-built chunk does not), and
+`insert_sym_noting`, which latches the monotonic key-family flags `note_env_key`
+maintains. That second one matters: `insert_sym` deliberately skips that latch,
+because its existing callers pass ordinary lexical names, so a site converted *from*
+a by-name `insert` — a placeholder parameter stored under its `^`-twigil name, a
+`__mutsu_sigilless_*` metadata key — has to keep arming the flag or a later gated
+fast path silently skips work it should do.
+
+## Measured
+
+Release build, callgrind, `use Test; plan 2000; for ^2000 { ok 1, "x" }` under
+`MUTSU_REAL_TEST=1`, warm precompilation cache:
+
+| | before | after |
+| --- | --- | --- |
+| `Symbol::intern` calls | 156,998 | 94,807 (−39.6%) |
+| its inclusive cost | 21.57 M Ir (4.53%) | 13.18 M Ir (2.85%) |
+| whole run | 475.87 M Ir | 462.67 M Ir (−2.8%) |
+
+Per caller, the interns the change removed:
+
+| caller | before | after |
+| --- | --- | --- |
+| `bind_function_args_values_inner` | 28,004 | 14,001 |
+| `exec_set_local_op_inner` | 16,046 | 4,022 |
+| `exec_one_dispatch` (`SetGlobal`) | 12,076 | 4,034 |
+| `bind_param_value` | 10,001 | 0 |
+| `bind_param_type_constraint` | 10,001 | 0 |
+| `set_var_type_constraint_impl` | 4,044 | 22 |
+| `check_readonly_for_modify` | 4,021 | 0 |
+| `set_current_package` | 4,012 | 2 |
+| `current_source_file` | 2,109 | 0 |
+| `call_compiled_function_named` | 4,003 | 0 |
+
+Counted a second way, with a temporary per-string histogram in `Symbol::intern` and
+the steady-state slope taken between a 101- and a 201-assertion run, the per-assertion
+budget fell from **72.0 interns to 35.4**. Instruction counts are deterministic and
+load-independent, so these are the numbers the change was iterated against; a
+wall-clock figure for a document must still come from the bench CI.
+
+## Still open
+
+The binder is down to about 7 interns per assertion but not to zero:
+`CompiledFunction::precompute_param_name_syms` already bakes every parameter's symbol
+at registration time, and threading that slice into
+`bind_function_args_values_with_argspec` would remove the remaining per-parameter
+intern outright. That is slice 2 of [#7736](https://github.com/tokuhirom/mutsu/issues/7736)
+finished properly, and it needs a signature change across the binder's callers rather
+than the local substitutions this change made.
+
+The rest of what is left is spread thin across dispatch: the routine-name intern in
+`call_compiled_function_named_inner`, the receiver-class names in the compiled-method
+cache, and the `__mutsu_scalar_bind_no_container::` key, which wants its own
+pre-interned per-local vector next to `locals_readonly_sym`.
+
+`t/param-bind-symbol-keys.t` pins the behaviour the threading could get wrong — a
+*name* being bound, marked or cleared under the wrong key rather than a slowdown:
+`@_`, `self`/`::?CLASS`/`$?FILE`, positional/optional/named binding, readonly versus
+`is copy`/`is rw`, placeholder and sigilless parameters, and typed-parameter
+constraint scoping.

--- a/src/env.rs
+++ b/src/env.rs
@@ -956,6 +956,21 @@ impl Env {
         self.get_sym(Symbol::intern(key))
     }
 
+    /// [`Self::get`] for a caller that *may* already hold the key's `Symbol` —
+    /// a compiled slot whose `locals_sym` entry exists, or a hand-built chunk
+    /// where it does not. Saves the re-hash on the common (pre-interned) side
+    /// without forcing every such call site to spell the `match` out (#7736).
+    #[inline]
+    pub(crate) fn get_for(&self, key: &str, key_sym: Option<Symbol>) -> Option<&Value> {
+        match key_sym {
+            Some(sym) => {
+                debug_assert_eq!(sym, Symbol::intern(key));
+                self.get_sym(sym)
+            }
+            None => self.get(key),
+        }
+    }
+
     #[inline]
     pub fn get_sym(&self, key: Symbol) -> Option<&Value> {
         if let Some(v) = self.inner.get(&key) {
@@ -1051,6 +1066,22 @@ impl Env {
         note_env_key(&key);
         let sym = Symbol::intern(&key);
         self.insert_sym(sym, value)
+    }
+
+    /// [`Self::insert_sym`] for a caller whose key symbol was pre-interned but
+    /// whose key may belong to one of the families [`note_env_key`] latches
+    /// (a `__mutsu_*` metadata key, a `^`-twigil placeholder).
+    ///
+    /// The plain symbol entry point deliberately skips that latch — its callers
+    /// pass ordinary lexical names, none of which arm a flag — so a site that
+    /// replaces a by-name [`Self::insert`] must come here instead to keep the
+    /// flags monotonic. Resolving the symbol is a cached array read, so this is
+    /// still far cheaper than rebuilding the `String` key and re-interning it
+    /// (#7736).
+    #[inline]
+    pub(crate) fn insert_sym_noting(&mut self, key: Symbol, value: Value) -> Option<Value> {
+        note_env_key(key.as_str());
+        self.insert_sym(key, value)
     }
 
     #[inline]

--- a/src/runtime/accessors_stack.rs
+++ b/src/runtime/accessors_stack.rs
@@ -467,10 +467,18 @@ impl Interpreter {
     }
 
     pub(crate) fn set_current_package(&mut self, pkg: String) {
-        self.current_package_sym.store(
-            Symbol::intern(&pkg).id(),
-            std::sync::atomic::Ordering::Relaxed,
-        );
+        let sym = Symbol::intern(&pkg);
+        self.set_current_package_with_sym(pkg, sym);
+    }
+
+    /// [`Self::set_current_package`] for a caller that already holds the
+    /// package's `Symbol` (a `CompiledFunction`'s cached `package_sym`). The
+    /// by-name entry point re-hashed the package name on every named call
+    /// (#7736).
+    pub(crate) fn set_current_package_with_sym(&mut self, pkg: String, sym: Symbol) {
+        debug_assert_eq!(sym, Symbol::intern(&pkg));
+        self.current_package_sym
+            .store(sym.id(), std::sync::atomic::Ordering::Relaxed);
         *self.current_package.write().unwrap() = pkg;
     }
 
@@ -497,9 +505,20 @@ impl Interpreter {
     /// An RAII guard self-heals regardless of what a future unwind boundary
     /// looks like.
     pub(crate) fn enter_package_guarded(&mut self, pkg: String) -> CurrentPackageGuard {
+        let sym = Symbol::intern(&pkg);
+        self.enter_package_guarded_with_sym(pkg, sym)
+    }
+
+    /// [`Self::enter_package_guarded`] for a caller that already holds the
+    /// package's `Symbol` — see [`Self::set_current_package_with_sym`].
+    pub(crate) fn enter_package_guarded_with_sym(
+        &mut self,
+        pkg: String,
+        sym: Symbol,
+    ) -> CurrentPackageGuard {
         let saved_str = self.current_package();
         let saved_sym_id = self.current_package_sym().id();
-        self.set_current_package(pkg);
+        self.set_current_package_with_sym(pkg, sym);
         CurrentPackageGuard {
             pkg_lock: std::sync::Arc::clone(&self.current_package),
             pkg_sym: std::sync::Arc::clone(&self.current_package_sym),

--- a/src/runtime/compunit_scope.rs
+++ b/src/runtime/compunit_scope.rs
@@ -57,7 +57,10 @@ impl Interpreter {
         self.unit_of_source_sym(file.map(Symbol::intern))
     }
 
-    fn unit_of_source_sym(&self, file: Option<Symbol>) -> Symbol {
+    /// The compunit a routine declared in `file` belongs to, for a caller that
+    /// already holds the path as a `Symbol` (a `CompiledFunction`'s cached
+    /// `source_file_sym`, a routine frame's `def_file`).
+    pub(crate) fn unit_of_source_sym(&self, file: Option<Symbol>) -> Symbol {
         match (file, self.program_path.as_deref()) {
             (None, _) => crate::runtime::main_unit(),
             (Some(f), Some(prog)) if f.resolve() == prog => crate::runtime::main_unit(),

--- a/src/runtime/runtime_var_meta.rs
+++ b/src/runtime/runtime_var_meta.rs
@@ -58,8 +58,8 @@ impl Interpreter {
         std::mem::take(&mut self.env)
     }
 
-    /// The env key for `name`'s type-constraint metadata, `__mutsu_type::<name>`,
-    /// as a pre-interned `Symbol`.
+    /// The env key for a name's type-constraint metadata,
+    /// `__mutsu_type::<name>`, as a pre-interned `Symbol`.
     ///
     /// Every typed-lexical probe (`var_type_constraint`, the bind/set writers)
     /// used to `format!` the key and intern the fresh `String`; once any
@@ -67,13 +67,11 @@ impl Interpreter {
     /// `SetGlobal` and parameter bind in it. The `name -> key` mapping never
     /// changes (symbols are append-only), so it is memoized per thread, keyed
     /// by the name's own symbol.
-    pub(crate) fn type_meta_key_sym(name: &str) -> Symbol {
-        Self::type_meta_key_for_sym(Symbol::intern(name))
-    }
-
-    /// [`Self::type_meta_key_sym`] for a caller that already holds the name
-    /// as a symbol (a compiled `SetLocal` slot, a `SetGlobal` constant): no
-    /// string is hashed at all, only the `Symbol -> Symbol` memo.
+    ///
+    /// Takes the name as a `Symbol`: every caller either holds one already (a
+    /// compiled `SetLocal` slot, a `SetGlobal` constant, a bound parameter) or
+    /// needs it for something else in the same operation, so no string is
+    /// hashed here at all — only the `Symbol -> Symbol` memo.
     pub(crate) fn type_meta_key_for_sym(name_sym: Symbol) -> Symbol {
         thread_local! {
             static META_KEYS: std::cell::RefCell<rustc_hash::FxHashMap<Symbol, Symbol>> =
@@ -114,7 +112,8 @@ impl Interpreter {
 
     /// The env key a routine's registration clone id is stored under,
     /// `__mutsu_callable_id::<package>::<name>`, memoized per
-    /// `(package, name)` symbol pair exactly like [`Self::type_meta_key_sym`].
+    /// `(package, name)` symbol pair exactly like
+    /// [`Self::type_meta_key_for_sym`].
     ///
     /// Every named compiled call probes this key on entry
     /// (`call_compiled_function_named_inner`), and building it cost a `format!`
@@ -202,7 +201,7 @@ impl Interpreter {
 
     /// The env key for `name`'s placeholder-parameter twin, `^<name>`, as a
     /// pre-interned `Symbol`, memoized per name symbol exactly like
-    /// [`Self::type_meta_key_sym`] (the mapping never changes).
+    /// [`Self::type_meta_key_for_sym`] (the mapping never changes).
     pub(crate) fn placeholder_key_sym(name_sym: Symbol) -> Symbol {
         thread_local! {
             static PLACEHOLDER_KEYS: std::cell::RefCell<rustc_hash::FxHashMap<Symbol, Symbol>> =
@@ -249,7 +248,21 @@ impl Interpreter {
     }
 
     pub(crate) fn set_var_type_constraint(&mut self, name: &str, constraint: Option<String>) {
-        self.set_var_type_constraint_impl(name, constraint, true);
+        self.set_var_type_constraint_impl(name, None, constraint, true);
+    }
+
+    /// [`Self::set_var_type_constraint`] for a caller that already holds the
+    /// name's `Symbol` — the compiled declaration path, which clears the
+    /// inherited constraint on EVERY `my` and re-hashed the name to do it
+    /// (#7736). `None` falls back to interning, for hand-built chunks with no
+    /// pre-interned slot symbol.
+    pub(crate) fn set_var_type_constraint_for(
+        &mut self,
+        name: &str,
+        name_sym: Option<Symbol>,
+        constraint: Option<String>,
+    ) {
+        self.set_var_type_constraint_impl(name, name_sym, constraint, true);
     }
 
     /// [`Self::set_var_type_constraint`] for DECLARATION position (`my Int
@@ -263,7 +276,7 @@ impl Interpreter {
     /// variable's own value is tagged by the assignment/default paths, which
     /// consult the name-keyed constraint registered here.
     pub(crate) fn set_var_type_constraint_decl(&mut self, name: &str, constraint: Option<String>) {
-        self.set_var_type_constraint_impl(name, constraint, false);
+        self.set_var_type_constraint_impl(name, None, constraint, false);
     }
 
     /// [`Self::set_var_type_constraint_decl`] for a scalar `my`/`state`
@@ -311,11 +324,13 @@ impl Interpreter {
     fn set_var_type_constraint_impl(
         &mut self,
         name: &str,
+        name_sym: Option<Symbol>,
         constraint: Option<String>,
         tag_env_value: bool,
     ) {
+        debug_assert!(name_sym.is_none_or(|sym| sym == Symbol::intern(name)));
         if let Some(constraint) = constraint {
-            let name_sym = Symbol::intern(name);
+            let name_sym = name_sym.unwrap_or_else(|| Symbol::intern(name));
             let meta_key = Self::type_meta_key_for_sym(name_sym);
             let info = Self::parse_container_constraint(name, &constraint);
             if info.value_type == "atomicint" || constraint.contains("atomicint") {
@@ -351,7 +366,7 @@ impl Interpreter {
             if !Self::env_type_constraint_seen() {
                 return;
             }
-            let name_sym = Symbol::intern(name);
+            let name_sym = name_sym.unwrap_or_else(|| Symbol::intern(name));
             self.env.remove_sym(Self::type_meta_key_for_sym(name_sym));
             self.env
                 .remove_sym(Self::hash_key_meta_key_for_sym(name_sym));
@@ -410,12 +425,26 @@ impl Interpreter {
     /// the full `set_var_type_constraint`, which also tags the bound value so
     /// element checks can read the constraint off the container.
     pub(crate) fn bind_param_type_constraint(&mut self, name: &str, constraint: Option<String>) {
+        self.bind_param_type_constraint_sym(name, Symbol::intern(name), constraint);
+    }
+
+    /// [`Self::bind_param_type_constraint`] for a caller that already holds the
+    /// parameter name's `Symbol` — see [`Interpreter::bind_param_value_sym`]
+    /// for why the binder threads one symbol through the whole per-parameter
+    /// path (#7736).
+    pub(crate) fn bind_param_type_constraint_sym(
+        &mut self,
+        name: &str,
+        name_sym: Symbol,
+        constraint: Option<String>,
+    ) {
+        debug_assert_eq!(name_sym, Symbol::intern(name));
         if name.starts_with('@') || name.starts_with('%') {
             let constraint = self.keep_object_hash_key_type(name, constraint);
             self.set_var_type_constraint(name, constraint);
             return;
         }
-        let meta_key = Self::type_meta_key_sym(name);
+        let meta_key = Self::type_meta_key_for_sym(name_sym);
         match constraint {
             Some(c) => {
                 let info = Self::parse_container_constraint(name, &c);

--- a/src/runtime/types/binding_signature.rs
+++ b/src/runtime/types/binding_signature.rs
@@ -539,13 +539,17 @@ impl Interpreter {
         // Always set @_ for legacy Perl-style argument access.
         // Skip the insert when args are empty and @_ is already empty,
         // to avoid triggering Arc::make_mut deep clone on the CoW env.
+        // `@_` is one of the fixed env keys EVERY compiled call writes, so its
+        // symbol is pre-interned (`wk::positional_slurpy`) rather than re-hashed
+        // per call (#7736).
+        let args_key = crate::symbol::wk::positional_slurpy();
         let skip_at_underscore = plain_args.is_empty()
-            && self.env.get("@_").is_some_and(
+            && self.env.get_sym(args_key).is_some_and(
                 |v| matches!(v.view(), ValueView::Array(elems, _) if elems.is_empty()),
             );
         if !skip_at_underscore {
             self.env
-                .insert("@_".to_string(), Value::array(plain_args.clone()));
+                .insert_sym(args_key, Value::array(plain_args.clone()));
         }
         // Single-argument rule: when exactly one positional arg is a Seq/List
         // and the function expects multiple positional params, flatten the Seq/List
@@ -636,11 +640,13 @@ impl Interpreter {
         // name instead of "element".
         let mut container_param_sources: Vec<(String, String)> = Vec::new();
         let mut raw_nonlvalue_params: Vec<String> = Vec::new();
+        // Both are fixed per-call method-entry keys with pre-interned symbols
+        // (#7736): a by-name probe re-hashed them on every bind.
         if let Some(invocant_value) = self
             .env
-            .get("self")
+            .get_sym(crate::symbol::wk::self_())
             .cloned()
-            .or_else(|| self.env.get("?CLASS").cloned())
+            .or_else(|| self.env.get_sym(crate::symbol::wk::class_decl()).cloned())
         {
             for pd in param_defs {
                 if !(pd.is_invocant || pd.traits.iter().any(|t| t == "invocant")) {
@@ -912,6 +918,12 @@ impl Interpreter {
             .collect();
         let mut positional_idx = 0usize;
         for pd in param_defs {
+            // One intern per parameter for the whole per-parameter path below
+            // (value bind, type constraint, readonly mark), instead of one per
+            // helper. Lazy, so an arm that never names the parameter still
+            // interns nothing (#7736).
+            let pd_name_cell = std::cell::OnceCell::new();
+            let pd_name_sym = || *pd_name_cell.get_or_init(|| Symbol::intern(&pd.name));
             if pd.onearg {
                 // +@ (single-argument rule slurpy): if exactly one remaining positional
                 // arg is Iterable (Array, List, etc.), use its elements directly.
@@ -966,7 +978,7 @@ impl Interpreter {
                             self.env
                                 .insert(sigilless_readonly_key(&pd.name), Value::TRUE);
                             self.env.remove(&sigilless_alias_key(&pd.name));
-                            self.bind_param_value(&pd.name, lazy_value.clone());
+                            self.bind_param_value_sym(&pd.name, pd_name_sym(), lazy_value.clone());
                         } else {
                             let key = if pd.name.starts_with('@') {
                                 pd.name.clone()
@@ -1081,7 +1093,7 @@ impl Interpreter {
                         self.env
                             .insert(sigilless_readonly_key(&pd.name), Value::TRUE);
                         self.env.remove(&sigilless_alias_key(&pd.name));
-                        self.bind_param_value(&pd.name, slurpy_value.clone());
+                        self.bind_param_value_sym(&pd.name, pd_name_sym(), slurpy_value.clone());
                     }
                 } else if !pd.name.is_empty() {
                     let key = if pd.name.starts_with('@') {
@@ -1127,8 +1139,12 @@ impl Interpreter {
                     }
                     let capture_value = Value::capture(positional, named);
                     if !pd.name.is_empty() {
-                        self.bind_param_value(&pd.name, capture_value.clone());
-                        self.bind_param_type_constraint(&pd.name, pd.type_constraint.clone());
+                        self.bind_param_value_sym(&pd.name, pd_name_sym(), capture_value.clone());
+                        self.bind_param_type_constraint_sym(
+                            &pd.name,
+                            pd_name_sym(),
+                            pd.type_constraint.clone(),
+                        );
                     }
                     if let Some(sub_params) = &pd.sub_signature {
                         bind_sub_signature_from_value(self, sub_params, &capture_value)?;
@@ -1187,8 +1203,16 @@ impl Interpreter {
                         }
                     }
                     if !pd.name.is_empty() {
-                        self.bind_param_value(&pd.name, Value::hash_bare_values(hash_items));
-                        self.bind_param_type_constraint(&pd.name, pd.type_constraint.clone());
+                        self.bind_param_value_sym(
+                            &pd.name,
+                            pd_name_sym(),
+                            Value::hash_bare_values(hash_items),
+                        );
+                        self.bind_param_type_constraint_sym(
+                            &pd.name,
+                            pd_name_sym(),
+                            pd.type_constraint.clone(),
+                        );
                     }
                 } else if pd.double_slurpy {
                     // **@ (non-flattening slurpy): keep each argument as-is, skip Pairs
@@ -1229,8 +1253,12 @@ impl Interpreter {
                         break;
                     }
                     if !pd.name.is_empty() {
-                        self.bind_param_value(&pd.name, value.clone());
-                        self.bind_param_type_constraint(&pd.name, pd.type_constraint.clone());
+                        self.bind_param_value_sym(&pd.name, pd_name_sym(), value.clone());
+                        self.bind_param_type_constraint_sym(
+                            &pd.name,
+                            pd_name_sym(),
+                            pd.type_constraint.clone(),
+                        );
                     }
                 } else {
                     let mut items = Vec::new();
@@ -1700,8 +1728,12 @@ impl Interpreter {
                             // `f(v => [1,2])` binds `$v` as `$[1, 2]`); rw
                             // cells pass through untouched.
                             let bound_value = Self::itemize_plain_scalar_param(pd, bound_value);
-                            self.bind_param_value(&pd.name, bound_value);
-                            self.bind_param_type_constraint(&pd.name, pd.type_constraint.clone());
+                            self.bind_param_value_sym(&pd.name, pd_name_sym(), bound_value);
+                            self.bind_param_type_constraint_sym(
+                                &pd.name,
+                                pd_name_sym(),
+                                pd.type_constraint.clone(),
+                            );
                         }
                         found = true;
                         break;
@@ -1769,12 +1801,20 @@ impl Interpreter {
                     {
                         self.bind_type_capture(captured_name, &value);
                         if !pd.name.is_empty() && !is_rename {
-                            self.bind_param_value(&pd.name, value.clone());
-                            self.bind_param_type_constraint(&pd.name, pd.type_constraint.clone());
+                            self.bind_param_value_sym(&pd.name, pd_name_sym(), value.clone());
+                            self.bind_param_type_constraint_sym(
+                                &pd.name,
+                                pd_name_sym(),
+                                pd.type_constraint.clone(),
+                            );
                         }
                     } else if !pd.name.is_empty() && !is_rename {
-                        self.bind_param_value(&pd.name, value.clone());
-                        self.bind_param_type_constraint(&pd.name, pd.type_constraint.clone());
+                        self.bind_param_value_sym(&pd.name, pd_name_sym(), value.clone());
+                        self.bind_param_type_constraint_sym(
+                            &pd.name,
+                            pd_name_sym(),
+                            pd.type_constraint.clone(),
+                        );
                     }
                     // For renamed named params like :foo($y) = $x, also bind the
                     // sub-signature variable ($y) to the default value.
@@ -1807,8 +1847,12 @@ impl Interpreter {
                     // A rename param binds only its leaf variable (below); skip
                     // binding the param's own name when a sub-signature exists.
                     if pd.sub_signature.is_none() {
-                        self.bind_param_value(&pd.name, value.clone());
-                        self.bind_param_type_constraint(&pd.name, pd.type_constraint.clone());
+                        self.bind_param_value_sym(&pd.name, pd_name_sym(), value.clone());
+                        self.bind_param_type_constraint_sym(
+                            &pd.name,
+                            pd_name_sym(),
+                            pd.type_constraint.clone(),
+                        );
                     }
                     // A `:color(:$colour)` alias chain declares its inner
                     // variable(s); bind them to the same unsupplied default so
@@ -2075,10 +2119,22 @@ impl Interpreter {
                                     None => info.value_type,
                                 });
                         }
-                        self.var_type_constraint(source_name).or_else(|| {
-                            self.var_type_constraint(
-                                source_name.trim_start_matches(['$', '@', '%', '&']),
-                            )
+                        // No typed lexical has ever been declared: neither
+                        // spelling can have an entry, so skip the interning
+                        // entirely (the same gate `var_type_constraint` applies).
+                        if !Self::env_type_constraint_seen() {
+                            return None;
+                        }
+                        // The sigil-stripped retry is skipped when the source
+                        // name carries no sigil: the two spellings are then the
+                        // same string, so the second probe re-hashed the name to
+                        // reach the same (already-missed) key (#7736).
+                        let source_sym = Symbol::intern(source_name);
+                        self.var_type_constraint_sym(source_sym).or_else(|| {
+                            let bare = source_name.trim_start_matches(['$', '@', '%', '&']);
+                            (bare.len() != source_name.len())
+                                .then(|| self.var_type_constraint(bare))
+                                .flatten()
                         })
                     });
                     let bound_type_constraint = source_type_constraint
@@ -2388,7 +2444,7 @@ impl Interpreter {
                             self.env.get(&pd.name).cloned()
                         };
                         if !pd.name.is_empty() {
-                            self.bind_param_value(&pd.name, value.clone());
+                            self.bind_param_value_sym(&pd.name, pd_name_sym(), value.clone());
                         }
                         let saved_topic = self.env.get("_").cloned();
                         self.env.insert("_".to_string(), value.clone());
@@ -2464,9 +2520,10 @@ impl Interpreter {
                                     map.insert(k.clone(), v.clone());
                                 }
                             }
-                            self.bind_param_value(&pd.name, Value::hash(map));
-                            self.bind_param_type_constraint(
+                            self.bind_param_value_sym(&pd.name, pd_name_sym(), Value::hash(map));
+                            self.bind_param_type_constraint_sym(
                                 &pd.name,
+                                pd_name_sym(),
                                 bound_type_constraint.clone(),
                             );
                             if let Some(sub_params) = &pd.sub_signature {
@@ -2564,8 +2621,12 @@ impl Interpreter {
                         // params pass through untouched (a ContainerRef has no
                         // Array view, so the itemize helper is a no-op on it).
                         let value = Self::itemize_plain_scalar_param(pd, value);
-                        self.bind_param_value(&pd.name, value);
-                        self.bind_param_type_constraint(&pd.name, bound_type_constraint.clone());
+                        self.bind_param_value_sym(&pd.name, pd_name_sym(), value);
+                        self.bind_param_type_constraint_sym(
+                            &pd.name,
+                            pd_name_sym(),
+                            bound_type_constraint.clone(),
+                        );
                     }
                     if let Some(sub_params) = &pd.sub_signature {
                         let target = self
@@ -2586,8 +2647,12 @@ impl Interpreter {
                     {
                         self.bind_type_capture(captured_name, &value);
                     } else if !pd.name.is_empty() {
-                        self.bind_param_value(&pd.name, value);
-                        self.bind_param_type_constraint(&pd.name, pd.type_constraint.clone());
+                        self.bind_param_value_sym(&pd.name, pd_name_sym(), value);
+                        self.bind_param_type_constraint_sym(
+                            &pd.name,
+                            pd_name_sym(),
+                            pd.type_constraint.clone(),
+                        );
                     }
                     if let Some(sub_params) = &pd.sub_signature {
                         let target = self.env.get(&pd.name).cloned().unwrap_or(Value::NIL);
@@ -2623,8 +2688,16 @@ impl Interpreter {
                     )));
                 } else if !pd.name.is_empty() {
                     // Optional parameters use typed empties/type objects when omitted.
-                    self.bind_param_value(&pd.name, Self::missing_optional_param_value(pd));
-                    self.bind_param_type_constraint(&pd.name, pd.type_constraint.clone());
+                    self.bind_param_value_sym(
+                        &pd.name,
+                        pd_name_sym(),
+                        Self::missing_optional_param_value(pd),
+                    );
+                    self.bind_param_type_constraint_sym(
+                        &pd.name,
+                        pd_name_sym(),
+                        pd.type_constraint.clone(),
+                    );
                 }
             }
         }
@@ -2732,8 +2805,10 @@ impl Interpreter {
             // attribute binds, already skipped above.)
             let is_container_param = pd.name.starts_with('@') || pd.name.starts_with('%');
             if !is_container_param {
+                // One intern for both arms below (#7736).
+                let pd_name_sym = Symbol::intern(&pd.name);
                 if !has_mutable_trait || raw_nonlvalue_params.contains(&pd.name) {
-                    self.mark_readonly(&pd.name);
+                    self.mark_readonly_sym(pd_name_sym);
                 } else {
                     // Writable `is copy`/`is rw`/`is raw` scalar param: the
                     // readonly set is keyed by bare name and shared across frames,
@@ -2741,7 +2816,7 @@ impl Interpreter {
                     // would otherwise leak in and make this writable param appear
                     // readonly. Drop the mark; the surrounding call path restores
                     // the caller's readonly state via `restore_readonly_vars`.
-                    self.unmark_readonly(&pd.name);
+                    self.unmark_readonly_sym(pd_name_sym);
                 }
             }
         }

--- a/src/runtime/types/mod.rs
+++ b/src/runtime/types/mod.rs
@@ -225,10 +225,13 @@ impl Interpreter {
     /// Why `name` is readonly, or `None` when it is writable.
     #[inline]
     pub(crate) fn readonly_kind(&self, name: &str) -> Option<ReadonlyKind> {
-        self.readonly_vars
-            .borrow()
-            .get(&Symbol::intern(name))
-            .copied()
+        self.readonly_kind_sym(Symbol::intern(name))
+    }
+
+    /// [`Self::readonly_kind`] for an already-interned name.
+    #[inline]
+    pub(crate) fn readonly_kind_sym(&self, sym: Symbol) -> Option<ReadonlyKind> {
+        self.readonly_vars.borrow().get(&sym).copied()
     }
 
     /// True when the `$`-sigil (or sigilless) name `name` is bound **directly
@@ -402,7 +405,21 @@ impl Interpreter {
     ///   (sigilless `constant PI`, `is List` array): `X::Assignment::RO`,
     ///   "Cannot modify an immutable TYPE (VALUE)".
     pub(crate) fn check_readonly_for_modify(&self, name: &str) -> Result<(), RuntimeError> {
-        match self.readonly_kind(name) {
+        self.check_readonly_for_modify_sym(name, Symbol::intern(name))
+    }
+
+    /// [`Self::check_readonly_for_modify`] for a caller that already holds the
+    /// name's `Symbol` (a `SetLocal` slot, a `SetGlobal` constant, a bound
+    /// parameter). The `&str` is still needed for the cold error message; the
+    /// hot path is the `readonly_vars` probe, which the `&str` entry point
+    /// re-hashed the name for on every store (#7736).
+    pub(crate) fn check_readonly_for_modify_sym(
+        &self,
+        name: &str,
+        name_sym: Symbol,
+    ) -> Result<(), RuntimeError> {
+        debug_assert_eq!(name_sym, Symbol::intern(name));
+        match self.readonly_kind_sym(name_sym) {
             None => Ok(()),
             Some(ReadonlyKind::Alias) => Err(RuntimeError::readonly_variable()),
             Some(ReadonlyKind::Immutable) => Err(RuntimeError::immutable_value()),
@@ -621,6 +638,19 @@ impl Interpreter {
     }
 
     pub(in crate::runtime) fn bind_param_value(&mut self, name: &str, value: Value) {
+        self.bind_param_value_sym(name, Symbol::intern(name), value);
+    }
+
+    /// [`Self::bind_param_value`] for a caller that already holds the
+    /// parameter name's `Symbol`. The signature binder resolves each parameter
+    /// name several times per call (bind, type constraint, readonly mark); this
+    /// lets it hash the name once instead of once per helper (#7736).
+    pub(in crate::runtime) fn bind_param_value_sym(
+        &mut self,
+        name: &str,
+        name_sym: Symbol,
+        value: Value,
+    ) {
         // An `@`-sigiled parameter is a positional binding: whatever Positional it
         // is given becomes *the array's elements*. An attributive one
         // (`submethod BUILD(:@!elems)`) writes straight through to the attribute,
@@ -641,7 +671,10 @@ impl Interpreter {
         // and would freeze a spawned block's view of it at the first spawn's
         // value (`reduce -> $h, @words { $h + await start { [+] @words } }`).
         self.note_param_bound_aggregate(name, &value);
-        self.env.insert(name.to_string(), value.clone());
+        debug_assert_eq!(name_sym, Symbol::intern(name));
+        // `insert_sym_noting`, not `insert_sym`: a placeholder parameter is
+        // stored under its `^`-twigil name, which arms `PLACEHOLDER_KEY_SEEN`.
+        self.env.insert_sym_noting(name_sym, value.clone());
         // Extract attribute name from twigil params: $!x -> "x", @!types -> "types", %!h -> "h"
         let attr_name = if let Some(a) = name.strip_prefix('!') {
             Some(a)

--- a/src/vm/vm_call_named_inner.rs
+++ b/src/vm/vm_call_named_inner.rs
@@ -156,12 +156,15 @@ impl Interpreter {
         // call read/wrote package vars under `GLOBAL` and silently lost them.
         // Skip a mangled state-scope package (`Pkg::&sub/arity`, used for nested
         // subs) and fall back to the passed name in that case.
-        let def_package: &str = if !cf.package.is_empty()
+        // Carried as a `(name, symbol)` pair so the package switch below does
+        // not re-intern it: `CompiledFunction::package_sym` is interned once per
+        // routine, and `fn_package_sym` once per call above (#7736).
+        let (def_package, def_package_sym): (&str, Symbol) = if !cf.package.is_empty()
             && !crate::runtime::utils::has_routine_scope_marker(&cf.package)
         {
-            cf.package.as_str()
+            (cf.package.as_str(), cf.package_sym())
         } else {
-            fn_package
+            (fn_package, fn_package_sym)
         };
         // RAII (`CurrentPackageGuard`, `todo/deep/panic-unwind-leaks-side-channel-call-state.md`):
         // restores `current_package` on drop -- including on a Rust panic
@@ -170,7 +173,7 @@ impl Interpreter {
         // `self.set_current_package(saved)` calls this replaced, which a
         // panic unwind would skip entirely.
         let pkg_guard = (!def_package.is_empty() && def_package != "GLOBAL")
-            .then(|| self.enter_package_guarded(def_package.to_string()));
+            .then(|| self.enter_package_guarded_with_sym(def_package.to_string(), def_package_sym));
         // When the function has where constraints and there is a &name Sub in
         // env (which carries closure env), merge the Sub's captured variables
         // into the current env so where-constraint expressions can access them.

--- a/src/vm/vm_core_helpers.rs
+++ b/src/vm/vm_core_helpers.rs
@@ -255,7 +255,19 @@ impl Interpreter {
 
     #[inline]
     pub(crate) fn vm_set_var_type_constraint(&mut self, name: &str, constraint: Option<String>) {
-        self.loan_env_for(|i| i.set_var_type_constraint(name, constraint))
+        self.vm_set_var_type_constraint_for(name, None, constraint)
+    }
+
+    /// [`Self::vm_set_var_type_constraint`] for a caller that already holds the
+    /// name's `Symbol` (a `SetLocal` slot's `locals_sym` entry).
+    #[inline]
+    pub(crate) fn vm_set_var_type_constraint_for(
+        &mut self,
+        name: &str,
+        name_sym: Option<Symbol>,
+        constraint: Option<String>,
+    ) {
+        self.loan_env_for(|i| i.set_var_type_constraint_for(name, name_sym, constraint))
     }
 
     /// Declaration-position variant (`my Int @a`): registers the constraint

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -1129,9 +1129,9 @@ impl Interpreter {
                 // called from `new (Str $str!)`.)
                 if !raw_mode && !is_bind_ctx && !is_bound_container {
                     if self.vardecl_context.get() {
-                        self.unmark_readonly(&name);
+                        self.unmark_readonly_sym(name_sym);
                     } else {
-                        self.check_readonly_for_modify(&name)?;
+                        self.check_readonly_for_modify_sym(&name, name_sym)?;
                     }
                 } else if raw_mode {
                     // Clear any previous readonly marking so this constant
@@ -1264,7 +1264,7 @@ impl Interpreter {
                     // `lives-ok` correctly caught and reported as a test
                     // failure, even though nothing in the block actually
                     // "died").
-                    let current_view = self.env().get(&name).map(Value::view);
+                    let current_view = self.env().get_sym(name_sym).map(Value::view);
                     let first_letter_uppercase = name.starts_with(|c: char| c.is_uppercase());
                     let unbound_type_slot = match current_view {
                         Some(ValueView::Package(p)) if p == "Any" && name != "Any" => {
@@ -1512,13 +1512,15 @@ impl Interpreter {
                 {
                     return Err(err);
                 }
-                let readonly_key = format!("__mutsu_sigilless_readonly::{}", name);
-                let alias_key = format!("__mutsu_sigilless_alias::{}", name);
+                // Both keys are memoized per name symbol, so a store neither
+                // allocates the `format!` string nor re-hashes it (#7736).
+                let readonly_key = Interpreter::sigilless_readonly_key_for_sym(name_sym);
+                let alias_key = Interpreter::sigilless_alias_key_for_sym(name_sym);
                 if matches!(
-                    self.env().get(&readonly_key).map(Value::view),
+                    self.env().get_sym(readonly_key).map(Value::view),
                     Some(ValueView::Bool(true))
                 ) && !matches!(
-                    self.env().get(&alias_key).map(Value::view),
+                    self.env().get_sym(alias_key).map(Value::view),
                     Some(ValueView::Str(_))
                 ) {
                     return Err(RuntimeError::assignment_ro(None));
@@ -1546,7 +1548,7 @@ impl Interpreter {
                         bind_source_slot,
                     );
                     self.env_mut()
-                        .insert(alias_key.clone(), Value::str(resolved_source.clone()));
+                        .insert_sym_noting(alias_key, Value::str(resolved_source.clone()));
                     self.mark_sigilless_alias_seen();
                     // Propagate readonly status from the source variable.
                     // Binding to a readonly parameter should make the target
@@ -1554,7 +1556,7 @@ impl Interpreter {
                     let source_kind = self.readonly_kind(source_name);
                     let source_readonly = source_kind.is_some();
                     self.env_mut()
-                        .insert(readonly_key.clone(), Value::truth(source_readonly));
+                        .insert_sym_noting(readonly_key, Value::truth(source_readonly));
                     if let Some(kind) = source_kind {
                         self.mark_readonly_with(&name, kind);
                     }
@@ -1985,7 +1987,7 @@ impl Interpreter {
                 if !(unit_lexical_write || our_scalar_write || raw_mode && name.starts_with('@')) {
                     loan_env!(self, set_shared_var(&name, val.clone()));
                 }
-                let mut alias_name = self.env().get(&alias_key).and_then(|v| {
+                let mut alias_name = self.env().get_sym(alias_key).and_then(|v| {
                     if let ValueView::Str(name) = v.view() {
                         Some(name.to_string())
                     } else {

--- a/src/vm/vm_helpers.rs
+++ b/src/vm/vm_helpers.rs
@@ -14,7 +14,10 @@ impl Interpreter {
     /// `None` (an AOT-compiled body) means the main script.
     #[inline]
     pub(super) fn enter_compilation_unit(&mut self, cf: &CompiledFunction) -> Symbol {
-        let unit = self.unit_of_source(cf.source_file.as_deref());
+        // `CompiledFunction::source_file_sym` interns the declaring path ONCE
+        // per routine. Going through the `&str` form re-hashed the whole path
+        // (often 60+ bytes) on every named call (#7736).
+        let unit = self.unit_of_source_sym(cf.source_file_sym());
         std::mem::replace(&mut self.current_unit, unit)
     }
 

--- a/src/vm/vm_register_ops.rs
+++ b/src/vm/vm_register_ops.rs
@@ -18,11 +18,16 @@ impl Interpreter {
     }
 
     /// Get the current source file from the interpreter env.
+    ///
+    /// `?FILE` is a fixed key with a pre-interned symbol (`wk::file`); the
+    /// by-name probe re-hashed it on every caller-frame push (#7736).
     pub(crate) fn current_source_file(&self) -> Option<String> {
-        self.env().get("?FILE").and_then(|v| match v.view() {
-            ValueView::Str(s) => Some(s.to_string()),
-            _ => None,
-        })
+        self.env()
+            .get_sym(crate::symbol::wk::file())
+            .and_then(|v| match v.view() {
+                ValueView::Str(s) => Some(s.to_string()),
+                _ => None,
+            })
     }
 
     /// `Symbol` variant of [`Self::current_source_file`] — the file a
@@ -52,10 +57,12 @@ impl Interpreter {
     /// [`Self::current_source_file_sym`] the slow, authoritative way: a full
     /// env-chain walk plus an intern. Only the debug assertion uses it.
     fn source_file_sym_by_walk(&self) -> Option<Symbol> {
-        self.env().get("?FILE").and_then(|v| match v.view() {
-            ValueView::Str(s) => Some(Symbol::intern(s.as_str())),
-            _ => None,
-        })
+        self.env()
+            .get_sym(crate::symbol::wk::file())
+            .and_then(|v| match v.view() {
+                ValueView::Str(s) => Some(Symbol::intern(s.as_str())),
+                _ => None,
+            })
     }
 
     /// Attach the defining scope to an interpolating regex literal

--- a/src/vm/vm_var_assign_set_local.rs
+++ b/src/vm/vm_var_assign_set_local.rs
@@ -752,7 +752,14 @@ impl Interpreter {
             // the bare name (this runs on every declaration).
             if !self.no_readonly_vars() {
                 let bare = name.trim_start_matches(['$', '@', '%', '&']);
-                self.unmark_readonly(bare);
+                // A scalar local is already stored sigil-less, so the strip is a
+                // no-op and the slot's pre-interned symbol IS the bare name's
+                // (equal strings intern to equal symbols) — the common case, and
+                // the one that runs per declaration (#7736).
+                match code.locals_sym.get(idx).copied() {
+                    Some(sym) if bare.len() == name.len() => self.unmark_readonly_sym(sym),
+                    _ => self.unmark_readonly(bare),
+                }
             }
             // A self-recursive closure declaration (`my $f = -> $n { $f($n-1) }`)
             // boxed this very local into a cell while evaluating its own
@@ -2023,11 +2030,14 @@ impl Interpreter {
                     | ValueView::Sub(..)
                     | ValueView::Instance { .. }
             )
-            && let Some(container) = self.env().get(name).and_then(|v| match v.view() {
-                ValueView::ContainerRef(arc) => Some(Value::container_ref(arc.clone())),
-                ValueView::Proxy { .. } => Some(v.clone()),
-                _ => None,
-            })
+            && let Some(container) =
+                self.env()
+                    .get_for(name, name_sym)
+                    .and_then(|v| match v.view() {
+                        ValueView::ContainerRef(arc) => Some(Value::container_ref(arc.clone())),
+                        ValueView::Proxy { .. } => Some(v.clone()),
+                        _ => None,
+                    })
         {
             self.locals[idx] = container;
         }
@@ -2526,8 +2536,9 @@ impl Interpreter {
             }
         }
         // A fresh declaration without an explicit type must not inherit stale
-        // constraints from an earlier lexical with the same name.
-        self.vm_set_var_type_constraint(name, None);
+        // constraints from an earlier lexical with the same name. The slot's
+        // pre-interned symbol spares the clear a re-hash of the name (#7736).
+        self.vm_set_var_type_constraint_for(name, Some(name_sym), None);
         if !name.starts_with('@') && !name.starts_with('%') && !name.starts_with('&') {
             loan_env!(self, reset_atomic_var_key_decl(name));
         }

--- a/t/param-bind-symbol-keys.t
+++ b/t/param-bind-symbol-keys.t
@@ -1,0 +1,82 @@
+use v6;
+use Test;
+
+# Pins the behaviour that the #7736 intern-reduction threads a single
+# pre-interned Symbol through: the fixed per-call env keys (`@_`, `self`,
+# `?CLASS`, `?FILE`), the per-parameter path (value bind, type constraint,
+# readonly mark) and the declaring-package switch. Each of these used to
+# resolve its name through `Symbol::intern` at every helper it passed; they now
+# share one symbol, so a mix-up would show up as a *wrong name* being bound,
+# marked or cleared rather than as a slowdown.
+
+plan 21;
+
+# --- the fixed per-call keys -------------------------------------------------
+
+sub legacy-args { @_.join(",") }
+is legacy-args(1, 2, 3), "1,2,3", '@_ still carries the positional arguments';
+is legacy-args(), "", '@_ is empty for a no-argument call';
+
+sub nested-args { legacy-args(7, 8) ~ "|" ~ @_.join(",") }
+is nested-args(9), "7,8|9", 'a nested call restores the caller @_';
+
+class Invocant {
+    has $.tag = "t";
+    method who() { self.tag ~ "/" ~ ::?CLASS.^name }
+}
+is Invocant.new.who, "t/Invocant", 'self and ::?CLASS resolve inside a method';
+
+ok $?FILE.ends-with("param-bind-symbol-keys.t"), '$?FILE names this file';
+
+# --- per-parameter binding ---------------------------------------------------
+
+sub two-params($cond, $desc) { "$cond:$desc" }
+is two-params(1, "x"), "1:x", 'two positional parameters bind to their own names';
+
+sub with-default($a, $b = "d") { "$a$b" }
+is with-default("q"), "qd", 'an omitted optional parameter binds its default';
+is with-default("q", "r"), "qr", 'a supplied optional parameter wins over the default';
+
+sub named-param(:$unescaped-prefix = "n") { $unescaped-prefix }
+is named-param(), "n", 'a named parameter falls back to its default';
+is named-param(:unescaped-prefix<y>), "y", 'a named parameter binds by name';
+
+# --- readonly marking --------------------------------------------------------
+
+sub readonly-param($x) { $x = 5 }
+dies-ok { readonly-param(1) }, 'a plain scalar parameter is readonly';
+
+sub copy-param($x is copy) { $x = 5; $x }
+is copy-param(1), 5, 'an `is copy` parameter is writable';
+
+my $outer = 1;
+sub shadow($outer is copy) { $outer = 2; $outer }
+is shadow(9), 2, 'a writable parameter is not held readonly by an outer name';
+lives-ok { $outer = 3 }, 'the caller lexical stays writable after the call';
+
+# --- placeholder parameters (the `^`-twigil env key) -------------------------
+
+my &placeholder = { $^first ~ $^second };
+is placeholder("a", "b"), "ab", 'placeholder parameters bind in order';
+
+# --- sigilless / raw parameters ----------------------------------------------
+
+sub sigilless(\v) { v * 2 }
+is sigilless(21), 42, 'a sigilless parameter binds the raw value';
+
+sub raw-alias($x is rw) { $x = $x + 1 }
+my $rw = 1;
+raw-alias($rw);
+is $rw, 2, 'an `is rw` parameter writes back through the caller container';
+
+# --- typed parameters and constraint scoping ---------------------------------
+
+sub typed(Int $n) { $n + 1 }
+is typed(1), 2, 'a typed parameter accepts a matching argument';
+my $bad = "s";
+dies-ok { typed($bad) }, 'a typed parameter rejects a mismatching argument';
+
+sub untyped-inner($v) { $v }
+my Str $v = "s";
+is untyped-inner(1), 1, "an untyped parameter shadows the caller's typed lexical";
+lives-ok { $v = "t" }, "the caller's own typed lexical keeps its constraint";


### PR DESCRIPTION
A Test assertion cost **~78 `Symbol::intern` calls, 5.6% of the run** (#7736), because helpers on the call path take `&str`: each one re-hashed a name whose `Symbol` its caller already held, or a fixed literal that could be interned once for the process. Nothing about *what* is computed changes here — the symbol is now threaded to the helper that needed it.

## What was threaded where

- **Fixed per-call keys.** `bind_function_args_values_inner` writes `@_` and probes `self` / `?CLASS` on every compiled call; `current_source_file` probes `?FILE` on every caller-frame push. All four already have pre-interned symbols in `symbol::wk`.
- **The declaring source file and package.** `CompiledFunction` caches `source_file_sym` and `package_sym`, interned once per routine, but `enter_compilation_unit` went through the `&str` form and re-hashed the whole declaring path — 60+ bytes for a module — on every named call; the package switch re-hashed the package name the same way.
- **The per-parameter path.** The binder resolved each parameter's name separately in the value bind, the type-constraint registration and the readonly mark. It now interns it at most once per parameter — lazily, so an arm that never names the parameter still interns nothing — and hands that symbol to the new `bind_param_value_sym` / `bind_param_type_constraint_sym` / `mark_readonly_sym`.
- **The store paths.** `SetLocal`'s `locals_sym` slot symbol and `SetGlobal`'s constant symbol now reach the env probe, the readonly check, the typed-lexical clear and the two `__mutsu_sigilless_*` metadata keys — the last of which also drops two `format!` allocations per store, those keys being memoized per name symbol.

`Env` gains `get_for` (for a caller whose symbol is `Option`: a compiled slot has one, a hand-built chunk does not) and `insert_sym_noting`, which latches the monotonic key-family flags `note_env_key` maintains. That second one matters: `insert_sym` deliberately skips that latch because its existing callers pass ordinary lexical names, so a site converted *from* a by-name `insert` — a placeholder parameter under its `^`-twigil name, a `__mutsu_sigilless_*` key — has to keep arming the flag or a later gated fast path silently skips work it should do. `Interpreter::type_meta_key_sym` had no callers left and folded into `type_meta_key_for_sym`.

## Measured

Release build, callgrind, `use Test; plan 2000; for ^2000 { ok 1, "x" }` under `MUTSU_REAL_TEST=1`, warm precompilation cache — the issue's own protocol:

| | before | after |
| --- | --- | --- |
| `Symbol::intern` calls | 156,998 | 94,807 (−39.6%) |
| its inclusive cost | 21.57 M Ir (4.53%) | 13.18 M Ir (2.85%) |
| whole run | 475.87 M Ir | 462.67 M Ir (**−2.8%**) |

Per caller:

| caller | before | after |
| --- | --- | --- |
| `bind_function_args_values_inner` | 28,004 | 14,001 |
| `exec_set_local_op_inner` | 16,046 | 4,022 |
| `exec_one_dispatch` (`SetGlobal`) | 12,076 | 4,034 |
| `bind_param_value` | 10,001 | 0 |
| `bind_param_type_constraint` | 10,001 | 0 |
| `set_var_type_constraint_impl` | 4,044 | 22 |
| `check_readonly_for_modify` | 4,021 | 0 |
| `set_current_package` | 4,012 | 2 |
| `current_source_file` | 2,109 | 0 |
| `call_compiled_function_named` | 4,003 | 0 |

Counted a second way — a temporary per-string histogram in `Symbol::intern`, steady-state slope between a 101- and a 201-assertion run — the per-assertion budget falls from **72.0 interns to 35.4**. Instruction counts are deterministic and load-independent, so these are the numbers the change was iterated against; a wall-clock figure for a document must still come from the bench CI.

## Still open (recorded in the news entry)

The binder is down to ~7 interns per assertion but not to zero: `precompute_param_name_syms` already bakes every parameter's symbol at registration, and threading that slice into `bind_function_args_values_with_argspec` would remove the remainder — that is slice 2 of #7736 finished properly, and it needs a signature change across the binder's callers rather than the local substitutions made here. The rest is spread thin across dispatch (the routine-name intern in `call_compiled_function_named_inner`, the receiver-class names in the compiled-method cache, and the `__mutsu_scalar_bind_no_container::` key, which wants its own pre-interned per-local vector next to `locals_readonly_sym`).

## Testing

- `t/param-bind-symbol-keys.t` (new, 21 assertions) pins what the threading could get wrong — a *name* bound, marked or cleared under the wrong key rather than a slowdown: `@_` across nested calls, `self` / `::?CLASS` / `$?FILE`, positional/optional/named binding, readonly versus `is copy` / `is rw`, placeholder and sigilless parameters, and typed-parameter constraint scoping. Verified against rakudo first (all 21 pass there).
- `cargo fmt --all`, `make lint` — clean.
- `make test` — `Files=3915, Tests=41619, Result: PASS`.
- `make roast` — the only red files are the remote container's documented environment-only set (`6.c/S32-io/file-tests.t` and `S16-filehandles/filetest.t`, both `uid 0`; `S32-io/IO-Socket-Async.t`, sandboxed network), with exactly the subtest ranges `docs/agent-environments.md` names.

Closes #7736

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015hFKrWhze7eV8bgvd2sKU9

---
_Generated by [Claude Code](https://claude.ai/code/session_015hFKrWhze7eV8bgvd2sKU9)_