### PR TITLE
fix: prevent FatRat arithmetic overflow

### DIFF
--- a/news/2026-09/fatrat-addition-promotes-on-overflow.md
+++ b/news/2026-09/fatrat-addition-promotes-on-overflow.md
@@ -1,0 +1,13 @@
+# FatRat addition promotes overflowing cross-products to BigInt
+
+Adding two `FatRat` values whose intermediate numerator or denominator does not
+fit in `i64` no longer panics the interpreter. The arithmetic now uses checked
+`i64` operations and promotes the whole calculation to arbitrary-precision
+integers when needed; subtraction follows the same path.
+
+This fixes the golden-ratio sequence from the math documentation, where
+`@phis[200].Str.chars` now returns `50` and the exact `FatRat` result is kept.
+
+Pinned by `t/fatrat-add-overflow.t`.
+
+Closes #7746.

--- a/src/builtins/arith/add_sub.rs
+++ b/src/builtins/arith/add_sub.rs
@@ -11,6 +11,7 @@ use super::temporal::{
 };
 use crate::symbol::Symbol;
 use crate::value::{RuntimeError, Value, ValueView, make_big_fat_rat, make_big_rat_arith};
+use num_bigint::BigInt as NumBigInt;
 
 // ── Arithmetic operators ─────────────────────────────────────────────
 pub(crate) fn arith_add(left: Value, right: Value) -> Result<Value, RuntimeError> {
@@ -165,9 +166,24 @@ fn arith_add_coerced(l: Value, r: Value) -> Value {
         let has_fat_rat = is_fat_rat_like(&l) || is_fat_rat_like(&r);
         if has_rat {
             if has_fat_rat {
-                let n = an * bd + bn * ad;
-                let d = ad * bd;
-                make_fat_rat(n, d)
+                if let (Some(n), Some(d)) = (
+                    an.checked_mul(bd).and_then(|left| {
+                        bn.checked_mul(ad).and_then(|right| left.checked_add(right))
+                    }),
+                    ad.checked_mul(bd),
+                ) {
+                    make_fat_rat(n, d)
+                } else {
+                    let n = NumBigInt::from(an) * NumBigInt::from(bd)
+                        + NumBigInt::from(bn) * NumBigInt::from(ad);
+                    let d = NumBigInt::from(ad) * NumBigInt::from(bd);
+                    let result = make_big_fat_rat(n, d);
+                    if let ValueView::Rat(n, d) = result.view() {
+                        Value::fat_rat_raw(n, d)
+                    } else {
+                        result
+                    }
+                }
             } else {
                 rat_add_checked(an, ad, bn, bd)
             }
@@ -315,9 +331,24 @@ pub(crate) fn arith_sub(left: Value, right: Value) -> Value {
         let has_fat_rat = is_fat_rat_like(&l) || is_fat_rat_like(&r);
         if has_rat {
             if has_fat_rat {
-                let n = an * bd - bn * ad;
-                let d = ad * bd;
-                make_fat_rat(n, d)
+                if let (Some(n), Some(d)) = (
+                    an.checked_mul(bd).and_then(|left| {
+                        bn.checked_mul(ad).and_then(|right| left.checked_sub(right))
+                    }),
+                    ad.checked_mul(bd),
+                ) {
+                    make_fat_rat(n, d)
+                } else {
+                    let n = NumBigInt::from(an) * NumBigInt::from(bd)
+                        - NumBigInt::from(bn) * NumBigInt::from(ad);
+                    let d = NumBigInt::from(ad) * NumBigInt::from(bd);
+                    let result = make_big_fat_rat(n, d);
+                    if let ValueView::Rat(n, d) = result.view() {
+                        Value::fat_rat_raw(n, d)
+                    } else {
+                        result
+                    }
+                }
             } else {
                 rat_sub_checked(an, ad, bn, bd)
             }

--- a/t/fatrat-add-overflow.t
+++ b/t/fatrat-add-overflow.t
@@ -1,0 +1,23 @@
+use Test;
+
+plan 6;
+
+my $large = FatRat.new(9223372036854775807, 2);
+
+is ($large + $large).raku,
+    'FatRat.new(9223372036854775807, 1)',
+    'large FatRat addition promotes before cross-product overflow';
+is ($large - $large).raku,
+    'FatRat.new(0, 1)',
+    'large FatRat subtraction promotes before cross-product overflow';
+is ($large + $large).Str,
+    '9223372036854775807',
+    'large FatRat addition keeps the exact result';
+
+my @phis = (2.FatRat, 1 + 1 / * ... *);
+is @phis[200].Str.chars, 50,
+    'the golden-ratio FatRat sequence reaches its 200th element';
+is @phis[200].^name, 'FatRat',
+    'the golden-ratio sequence retains its FatRat type';
+is @phis[200].Str, '1.618033988749894848204586834365638117720309179806',
+    'the golden-ratio sequence remains exact';


### PR DESCRIPTION
## Summary

- use checked `i64` cross-products for FatRat addition and subtraction
- promote overflowing intermediate values to arbitrary-precision FatRat parts
- add direct large-FatRat and golden-ratio sequence regressions

## Verification

- `make lint`
- `make test`
- `make roast`

Closes #7746