### PR TITLE
fix(runtime): scope a transitively-`use`d module's package name to its own importer

### DIFF
--- a/news/2026-09/transitive-module-package-name-no-longer-leaks.md
+++ b/news/2026-09/transitive-module-package-name-no-longer-leaks.md
@@ -1,0 +1,61 @@
+# A transitively-`use`d module's package name no longer leaks into the importer
+
+`use Outer;` — where `Outer.rakumod` itself begins `use Inner;` — left the bare
+name `Inner` resolvable in the importing file, which never asked for it and
+where rakudo reports an "Undeclared name":
+
+```raku
+# lib/Inner.rakumod:  unit module Inner; class InnerClass is export { }
+# lib/Outer.rakumod:  use Inner; unit module Outer; class OuterClass is export { }
+
+use Outer;
+OuterClass.new;                # correct: Outer exported it
+Inner::InnerClass.new;         # rakudo: Could not find symbol.  mutsu: resolved
+```
+
+This is the last piece of issue #7555 item 1's divergence (b). The alias half of
+that divergence — the *classes and roles* a transitively-loaded module declares,
+and the variables and subs it exports — was closed by #7743 (issue #7692), which
+scopes a module's imports to its own compunit. Measured against that fix, one
+binding still escaped: the module's own package name.
+
+## Root cause
+
+`OpCode::RegisterPackage` binds a `unit module X` under its bare name with
+`env.insert`, and a module body runs in the **caller's** env
+(`load_module_inner` → `run_block`) rather than in an env of its own. So when
+`Outer`'s body executes its `use Inner;`, the `Inner` package binding lands in
+whatever frame triggered the load — the importing file, for a compile-time `use`
+at file scope. #7743's cleanup restores the caller's plain bindings and undoes
+the aliases `import_module` recorded, but a package name is neither: it is a new
+env key nobody registered as an import.
+
+It is now dropped at the end of the load that introduced it, unless it names the
+module being loaded or something nested under it. A direct `use Inner;` is
+unaffected — that load keeps its own package name, exactly as rakudo puts it in
+the importing scope's `MY::`.
+
+The registry diff is consulted alongside the name test, because a module file
+with no `unit` declarator can register a class under a name unrelated to its own:
+`roast/packages/RT128156/lib/RT128156/Top1.rakumod` declares a plain
+`class Top1`, which roast's `S10-packages/precompilation.t` requires to be
+visible in the loading scope's `MY::`. A name test alone drops it and fails that
+test.
+
+Pinned by `t/module-transitive-use-does-not-leak-types.t`, which passes 9/9
+verbatim under rakudo v2026.07 as well as under mutsu, and covers the parts
+#7743 fixed as well as this one — including the two-hop case (a module that
+`use`s a module that `use`s a third), whose method bodies resolve bare names
+through their own class's package chain rather than through `env`.
+
+## What is still divergent
+
+A module's `constant`s and enum values reach the importer the same way and are
+deliberately left alone. Removing them needs somewhere else for the module's own
+top-level subs to find them: `module_scope_lexicals` is keyed by package and a
+module's plain `sub` runs under `GLOBAL`, so dropping the env binding turns
+`Log::Async`'s `sub trace { ... :level(TRACE) ... }` into a bareword `Str`.
+mutsu also keeps module package names in `GLOBAL::` where rakudo keeps them in
+the importing compunit's `MY::`; the fix here scopes their *visibility*
+correctly without moving that storage. Both belong to the module-lexical scoping
+campaign #7555 describes.

--- a/src/runtime/run_modules.rs
+++ b/src/runtime/run_modules.rs
@@ -892,6 +892,60 @@ impl Interpreter {
                     self.env.remove_sym(key);
                 }
             }
+            // `OpCode::RegisterPackage` binds a `unit module X` under its own
+            // bare name, and the module body runs in the CALLER's env -- so a
+            // module reached only through THIS module's own `use` statements
+            // left its package name sitting in the importing scope. rakudo
+            // makes that binding lexical to the compunit that asked for it, so
+            // a file that never `use`d `Inner` reports an "Undeclared name" for
+            // it (#7555 item 1, divergence (b); the alias half of the same
+            // divergence is handled by the `imported` restore just above, and
+            // by the `owned_types` filter on `new_types` below):
+            //
+            //     # Outer.rakumod:  use Inner; unit module Outer; ...
+            //     use Outer;
+            //     Inner::InnerClass.new;   # rakudo: Could not find symbol
+            //
+            // A package this module declares itself stays, and so does anything
+            // nested under it. So does a *class* the load registered under an
+            // unrelated name: a module file with no `unit` declarator can do
+            // that (`RT128156/Top1.rakumod` declares plain `class Top1`, which
+            // roast's `S10-packages/precompilation.t` requires in the loading
+            // scope's `MY::`), which is why the registry diff is consulted
+            // rather than the name alone.
+            let registered_here: std::collections::HashSet<String> = self
+                .registry()
+                .classes
+                .keys()
+                .filter(|k| !before_class_names.contains(*k))
+                .chain(
+                    self.registry()
+                        .roles
+                        .keys()
+                        .filter(|k| !before_role_names.contains(*k)),
+                )
+                .cloned()
+                .collect();
+            let leaked_packages: Vec<String> = module_scope_names
+                .iter()
+                .filter(|(name, value)| {
+                    if name.starts_with(['@', '%', '&', '$']) {
+                        return false;
+                    }
+                    match value.view() {
+                        ValueView::Package(target) => {
+                            let target = target.resolve();
+                            !Self::package_is_owned_by(&target, module)
+                                && !registered_here.contains(&target)
+                        }
+                        _ => false,
+                    }
+                })
+                .map(|(name, _)| name.clone())
+                .collect();
+            for name in &leaked_packages {
+                self.env.remove(name);
+            }
             module_type_aliases = self.module_type_aliases_of(&module_scope_names);
             // Take the compunit's own file-scope lexicals out of `env` and into
             // `unit_lexicals`, restoring the loading scope's values under those
@@ -1176,6 +1230,16 @@ impl Interpreter {
             }
         }
         names
+    }
+
+    /// Whether the qualified package/type name `target` is `module` itself or
+    /// something nested under it, rather than something `module` reached
+    /// through one of its own `use` statements.
+    fn package_is_owned_by(target: &str, module: &str) -> bool {
+        target == module
+            || target
+                .strip_prefix(module)
+                .is_some_and(|rest| rest.starts_with("::"))
     }
 
     /// The subset of [`Self::collect_module_scope_names`] that are short-name type

--- a/t/lib/TransitiveLeakDirect.rakumod
+++ b/t/lib/TransitiveLeakDirect.rakumod
@@ -1,0 +1,9 @@
+use TransitiveLeakInner;
+unit module TransitiveLeakDirect;
+
+# A sibling-package NativeCall shape: this module references a class declared
+# by another module bare, from its own method body.
+class Direct {
+    method inner-name() { InnerClass.^name }
+}
+sub direct-probe() is export { Direct.new.inner-name }

--- a/t/lib/TransitiveLeakGrand.rakumod
+++ b/t/lib/TransitiveLeakGrand.rakumod
@@ -1,0 +1,16 @@
+use TransitiveLeakOuter;
+unit module TransitiveLeakGrand;
+
+# This module `use`s TransitiveLeakOuter, which itself `use`s
+# TransitiveLeakInner. Inner's classes are two hops away and must not be
+# resolvable bare from here -- not even from a method body, which resolves
+# bare names through its own class's package chain rather than through `env`.
+class GrandHolder is export {
+    method peek-inner() {
+        my $c = ::('InnerClass');
+        $c ~~ Failure ?? 'MISSING' !! $c.^name;
+    }
+    method peek-outer() { OuterClass.^name }
+}
+sub grand-probe() is export { GrandHolder.new.peek-inner }
+sub grand-outer-probe() is export { GrandHolder.new.peek-outer }

--- a/t/lib/TransitiveLeakInner.rakumod
+++ b/t/lib/TransitiveLeakInner.rakumod
@@ -1,0 +1,6 @@
+unit module TransitiveLeakInner;
+
+class InnerClass is export { method who() { 'inner-class' } }
+role InnerRole is export { method tagged() { 'inner-role' } }
+constant InnerConst is export = 'inner-const';
+sub inner-sub() is export { 'inner-sub' }

--- a/t/lib/TransitiveLeakOuter.rakumod
+++ b/t/lib/TransitiveLeakOuter.rakumod
@@ -1,0 +1,11 @@
+use TransitiveLeakInner;
+unit module TransitiveLeakOuter;
+
+class OuterClass is export { method who() { 'outer-class' } }
+
+# The module's own routines must keep resolving the short names it imported,
+# even though the importer of this module must not see them.
+sub outer-uses-inner() is export { InnerClass.new.who ~ '/' ~ InnerConst }
+class OuterHolder is export {
+    method make-inner() { InnerClass.new.who }
+}

--- a/t/module-transitive-use-does-not-leak-types.t
+++ b/t/module-transitive-use-does-not-leak-types.t
@@ -1,0 +1,55 @@
+use v6;
+use lib 't/lib';
+use Test;
+use TransitiveLeakOuter;
+use TransitiveLeakDirect;
+use TransitiveLeakGrand;
+
+plan 9;
+
+# A module body runs in the *caller's* env, so the short-name type aliases a
+# module's own `use` statements install used to be left behind in whatever
+# scope triggered the load. That made a transitively-`use`d module's classes
+# resolvable bare from a file that never `use`d it, where rakudo reports an
+# "Undeclared name" (issue #7555, item 1 divergence (b)):
+#
+#     # TransitiveLeakOuter.rakumod:  use TransitiveLeakInner; unit module ...
+#     use TransitiveLeakOuter;
+#     InnerClass.new;    # rakudo: Undeclared name
+#
+# The aliases are recorded against the declaring module instead, so its own
+# routines keep resolving them.
+
+# What the importer legitimately gets from the module it actually used.
+is OuterClass.new.who, 'outer-class', 'the used module exports its own class';
+
+# What it must NOT get: anything the used module reached through its own `use`.
+ok ::('InnerClass') ~~ Failure,
+    'a transitively-used module class does not leak into the importer';
+ok ::('InnerRole') ~~ Failure, 'a transitively-used role does not leak either';
+# The module's own name is not visible either -- the importer never asked
+# for the package, only for what its own module exported.
+ok ::('TransitiveLeakInner') ~~ Failure,
+    'the transitively-used module package itself does not leak';
+
+# The declaring module's own routines and methods must still see the short
+# names it imported -- that is the whole point of recording them against the
+# module rather than leaving them in the loading frame.
+is outer-uses-inner(), 'inner-class/inner-const',
+    'the module sub still resolves its own imported class and constant';
+is OuterHolder.new.make-inner, 'inner-class',
+    'a method of a class the module declares still resolves them too';
+
+# The sibling-package NativeCall shape (`unit module Foo::Native; class Handle`
+# used bare from a sibling class's method) keeps working: a module that `use`s
+# another one references its classes bare from its own method bodies.
+is direct-probe(), 'TransitiveLeakInner::InnerClass',
+    'a module referencing another module class bare still resolves it';
+
+# Two hops out: a module that `use`s TransitiveLeakOuter must not see what
+# *Outer* imported either, including from a method body -- which resolves bare
+# names through its own class's package chain, a separate path from `env`.
+isnt grand-probe(), 'TransitiveLeakInner::InnerClass',
+    'a two-hop transitive class is not resolvable from the middle importer';
+is grand-outer-probe(), 'TransitiveLeakOuter::OuterClass',
+    'while what that importer did import stays resolvable';


### PR DESCRIPTION
`use Outer;` — where `Outer.rakumod` itself begins `use Inner;` — left the bare name `Inner` resolvable in the importing file, which never asked for it and where rakudo reports an "Undeclared name".

```raku
# lib/Inner.rakumod:  unit module Inner; class InnerClass is export { }
# lib/Outer.rakumod:  use Inner; unit module Outer; class OuterClass is export { }

use Outer;
OuterClass.new;          # correct: Outer exported it
Inner::InnerClass.new;   # rakudo: Could not find symbol.  mutsu: resolved
```

This is the last piece of #7555 item 1's divergence (b). The alias half of that divergence — the classes and roles a transitively-loaded module declares, and the variables and subs it exports — was closed by #7743 (issue #7692), which scopes a module's imports to its own compunit. Re-measured against `main` at d7a6906, exactly one binding still escaped:

| bare name in the importer | rakudo v2026.07 | mutsu at d7a6906 | with this PR |
| --- | --- | --- | --- |
| `OuterClass` | `OuterPkg::OuterClass` | same | same |
| `OuterPkg` | `OuterPkg` | same | same |
| `InnerClass` | MISSING | MISSING (#7743) | MISSING |
| `InnerRole` | MISSING | MISSING (#7743) | MISSING |
| **`InnerPkg`** | **MISSING** | **`InnerPkg`** | **MISSING** |

## Root cause

`OpCode::RegisterPackage` binds a `unit module X` under its bare name with a plain `env.insert`, and a module body runs in the **caller's** env (`load_module_inner` → `run_block`) rather than in an env of its own. So `Outer`'s own `use Inner;` left the `Inner` package binding in whatever frame triggered the load — the importing file, for a compile-time `use` at file scope. #7743's cleanup restores the caller's plain bindings and undoes the aliases `import_module` recorded; a package name is neither of those, so nothing reached it.

It is dropped now at the end of the load that introduced it, unless it names the module being loaded or something nested under it. A direct `use Inner;` is unaffected — that load keeps its own package name, exactly as rakudo puts it in the importing scope's `MY::`.

### Why the registry diff is consulted, not just the name

The obvious ownership test — "does the qualified name start with the module's own name" — is not sufficient. A module file with no `unit` declarator can register a class under an unrelated name: `roast/packages/RT128156/lib/RT128156/Top1.rakumod` declares a plain `class Top1`, and roast's `S10-packages/precompilation.t` tests 40-41 require it in the *loading* scope's `MY::`. A name-prefix test alone drops it and turns those two green tests red — measured, `make roast` caught it.

## What is deliberately still divergent

A module's `constant`s and enum values reach the importer by the same route and are left alone. Dropping them needs somewhere else for the module's own top-level subs to read them: `module_scope_lexicals` is keyed by package and a module's plain `sub` runs under `GLOBAL`, so removing the env binding turns `Log::Async`'s `sub trace { ... :level(TRACE) ... }` into a bareword `Str` (measured — `t/log-async-battery.t` aborts at test 2). mutsu also keeps module package names in `GLOBAL::` where rakudo keeps them in the importing compunit's `MY::`; this scopes their *visibility* to match without moving that storage. Both belong to the module-lexical scoping campaign #7555 describes.

## Tests

`t/module-transitive-use-does-not-leak-types.t` (new, 9 assertions) passes verbatim under rakudo v2026.07 as well as under mutsu. It covers what #7743 fixed alongside this one, so the whole scoping contract stays pinned from one file:

- a transitively-used class, role and package are all unresolvable in the importer;
- what the used module itself exports still resolves;
- the declaring module's own subs and its classes' methods still resolve the short names it imported;
- the sibling-package NativeCall shape (`unit module Foo::Native; class Handle`, referenced bare from a sibling class's method) still works;
- the two-hop case — a module that `use`s a module that `use`s a third — whose method bodies resolve bare names through their own class's package chain rather than through `env`, so the env path alone does not cover it.

## Verification

- `make lint` — clean in all four configurations (default clippy, `jit` off, wasm32 lib, rustdoc).
- `make test` — PASS, 3919 files / 41648 tests.
- `make roast` — no regression. The only failures are the three container-caused ones `docs/agent-environments.md` records, with exactly the documented signatures: `6.c/S32-io/file-tests.t` and `S16-filehandles/filetest.t` (this container runs as `uid 0`, so the `chmod`-based assertions are meaningless) and `S32-io/IO-Socket-Async.t` (sandboxed network).

Part of #7555 (item 1, divergence (b)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ARX7Pe67YipLQtH6Sb1hmA

---
_Generated by [Claude Code](https://claude.ai/code/session_01ARX7Pe67YipLQtH6Sb1hmA)_