### PR TITLE
fix: preserve contents of Hash mixins

### DIFF
--- a/news/2026-09/hash-mixin-preserves-contents.md
+++ b/news/2026-09/hash-mixin-preserves-contents.md
@@ -1,0 +1,8 @@
+# Hash mixins preserve their contents during assignment and mutation
+
+`%(2 => 3) but Role` now remains an associative Hash value when it is bound,
+assigned to a `%` variable, indexed, or deleted from. Existing entries are no
+longer lost when a later store falls through the ordinary Hash assignment path.
+
+Parameterized `Associative[Value, Key]` mixins also report their value type
+through `.of`, while retaining normal Hash mutation behavior.

--- a/src/runtime/methods_mixin_dispatch.rs
+++ b/src/runtime/methods_mixin_dispatch.rs
@@ -2,6 +2,25 @@ use super::*;
 use crate::symbol::Symbol;
 
 impl Interpreter {
+    /// Return the value type supplied by a parameterized container role mixed
+    /// onto a value, if any. Unlike native Hash/Array metadata, this lives in
+    /// the Mixin marker map and must not be copied onto the shared inner
+    /// container just to answer `.of`.
+    pub(crate) fn mixin_container_role_value_type(&self, target: &Value) -> Option<Value> {
+        let ValueView::Mixin(_, mixins) = target.view() else {
+            return None;
+        };
+        for base in ["Associative", "Positional"] {
+            let key = format!("__mutsu_role_typeargs__{base}");
+            if let Some(ValueView::Array(items, ..)) = mixins.get(&key).map(Value::view)
+                && let Some(value_type) = items.iter().next()
+            {
+                return Some(value_type.clone());
+            }
+        }
+        None
+    }
+
     /// The user-visible `.Stringy`/`.Str` of a role-mixed (`but`/`does`) value,
     /// when the composition — or the wrapped value's own class — supplies one.
     /// `None` means "nothing user-defined here", so the caller must keep its
@@ -142,6 +161,13 @@ impl Interpreter {
                 Err(e) => return Some(Err(e)),
             };
             return Some(Ok(Value::mixin(inner_clone, new_mixins)));
+        }
+
+        if method == "of"
+            && args.is_empty()
+            && let Some(value_type) = self.mixin_container_role_value_type(target)
+        {
+            return Some(Ok(value_type));
         }
 
         if args.is_empty() {

--- a/src/runtime/methods_mut_dispatch.rs
+++ b/src/runtime/methods_mut_dispatch.rs
@@ -444,6 +444,9 @@ impl Interpreter {
             {
                 return Ok(Value::package(Symbol::intern(&value_type)));
             }
+            if let Some(value_type) = self.mixin_container_role_value_type(&target) {
+                return Ok(value_type);
+            }
             // Embedded metadata first: it travels with the value, so it stays
             // correct when a recursive call clobbers the name-keyed constraint
             // store (`my @ret := Array[T].new` re-bound in an inner frame).

--- a/src/runtime/methods_signature.rs
+++ b/src/runtime/methods_signature.rs
@@ -13,6 +13,15 @@ impl Interpreter {
     /// is safe for any Instance. `Match` keeps its dedicated `%(...)` handling
     /// in `coerce_to_hash`.
     pub(crate) fn coerce_object_to_hash(&mut self, value: Value) -> Value {
+        // A role mixed into a Hash is still an associative value. Coercing the
+        // wrapper itself would stringify its raku representation into one
+        // bogus key; assignment to a % variable must see the wrapped Hash's
+        // entries instead.
+        if let ValueView::Mixin(inner, _) = value.view()
+            && matches!(inner.view(), ValueView::Hash(_))
+        {
+            return crate::runtime::utils::coerce_to_hash(inner.as_ref().clone());
+        }
         if let ValueView::Instance { .. } = value.view()
             && !value.is_match_instance()
             && let Ok(listed) = self.call_method_with_values(value.clone(), "list", Vec::new())

--- a/src/runtime/methods_subscript_protocol.rs
+++ b/src/runtime/methods_subscript_protocol.rs
@@ -39,7 +39,7 @@ impl Interpreter {
     /// `%h.DELETE-KEY($key)` on a hash value: remove the entry and return the
     /// value it held, or the hash's `is default(...)` value (else its element
     /// type object) when the key was absent.
-    pub(super) fn hash_delete_key_value(
+    pub(crate) fn hash_delete_key_value(
         &mut self,
         target: &Value,
         key_arg: &Value,

--- a/src/vm/vm_var_assign_coerce.rs
+++ b/src/vm/vm_var_assign_coerce.rs
@@ -402,6 +402,9 @@ impl Interpreter {
             | ValueView::Set(..)
             | ValueView::Bag(..)
             | ValueView::Mix(..) => Ok(value),
+            ValueView::Mixin(inner, _) if matches!(inner.view(), ValueView::Hash(_)) => {
+                Ok(inner.as_ref().clone())
+            }
             // Instance objects: check if they do Associative
             ValueView::Instance { class_name, .. } => {
                 let cn = class_name.resolve();

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -104,6 +104,39 @@ impl Interpreter {
         };
         let (inner, mixins) = (inner.clone(), mixins.clone());
         let mut updated_mixins = (*mixins).clone();
+        // A role mixed into a Hash keeps the Hash as the Mixin's inner value.
+        // Handle ordinary associative stores before the role-attribute
+        // delegation below: the generic variable-assignment path only knows
+        // how to mutate an exact Hash, so without this arm it replaces the
+        // whole Mixin with a new one-entry Hash and silently drops every
+        // existing entry.
+        if range_slice.is_none()
+            && !matches!(
+                idx.view(),
+                ValueView::Array(..)
+                    | ValueView::Seq(_)
+                    | ValueView::Slip(_)
+                    | ValueView::Range(..)
+                    | ValueView::RangeExcl(..)
+                    | ValueView::RangeExclStart(..)
+                    | ValueView::RangeExclBoth(..)
+                    | ValueView::GenericRange { .. }
+                    | ValueView::Whatever
+                    | ValueView::Junction { .. }
+            )
+            && let ValueView::Hash(hash) = inner.view()
+        {
+            let object_hash = hash.key_type.is_some();
+            let key = if object_hash {
+                crate::runtime::utils::value_which_key(idx)
+            } else if matches!(idx.view(), ValueView::Package(_)) {
+                self.coerce_type_object_hash_key(idx)?
+            } else {
+                idx.to_string_value()
+            };
+            inner.hash_assign_at(&key, Self::itemize_value(val.clone()));
+            return Ok(Some(target.clone()));
+        }
         // Refresh each `__mutsu_attr__` marker from the cell before mutating, so
         // an element write made directly inside a role method (`%!h<k> = 1`,
         // which goes to the cell) is not overwritten by a stale marker.

--- a/src/vm/vm_var_delete_ops.rs
+++ b/src/vm/vm_var_delete_ops.rs
@@ -515,6 +515,25 @@ impl Interpreter {
                 return Ok(());
             }
         }
+        // A plain role mixin around a Hash has no user-defined DELETE-KEY
+        // method, but its inner Hash is still the mutable associative value.
+        // Reach it directly before the generic container path, which only
+        // recognizes an exact Hash and would otherwise return the wrong value
+        // without removing the entry.
+        if let Some(target) = self.env().get(&var_name).cloned()
+            && let ValueView::Mixin(inner, _) = target.view()
+            && matches!(inner.view(), ValueView::Hash(_))
+        {
+            let idx_arg = match idx.view() {
+                ValueView::Array(items, _) if items.len() == 1 => items[0].clone(),
+                ValueView::Seq(items) if items.len() == 1 => items[0].clone(),
+                ValueView::Slip(items) if items.len() == 1 => items[0].clone(),
+                _ => idx.clone(),
+            };
+            let result = self.hash_delete_key_value(inner.as_ref(), &idx_arg)?;
+            self.stack.push(result);
+            return Ok(());
+        }
         // Fast path for simple hash delete
         if let Some(result) = self.try_fast_hash_delete(code, &var_name, slot, &idx) {
             self.stack.push(result?);

--- a/t/issue-7747-hash-mixin.t
+++ b/t/issue-7747-hash-mixin.t
@@ -1,0 +1,35 @@
+use v6;
+use Test;
+
+plan 15;
+
+role R { }
+
+my %bound := %(2 => 3) but R;
+is %bound.raku, '{"2" => 3}', 'binding a Hash mixin keeps its initial entry';
+ok %bound<2>:exists, 'the initial Hash mixin entry exists';
+is %bound.elems, 1, 'the bound Hash mixin has one entry before storing';
+
+%bound<3> = 4;
+is %bound.raku, '{"2" => 3, "3" => 4}', 'storing through a Hash mixin preserves old entries';
+is %bound.keys.sort.join(','), '2,3', 'storing through a Hash mixin keeps both keys';
+is %bound.elems, 2, 'storing through a Hash mixin updates elems';
+
+my $deleted = %bound<2>:delete;
+is $deleted, 3, 'deleting through a Hash mixin returns the old value';
+nok %bound<2>:exists, 'deleting through a Hash mixin removes the entry';
+is %bound.raku, '{"3" => 4}', 'deleting through a Hash mixin preserves the other entry';
+
+my %assigned = %(2 => 3) but R;
+is %assigned.raku, '{"2" => 3}', 'assignment from a Hash mixin copies its entries';
+%assigned<3> = 4;
+is %assigned.keys.sort.join(','), '2,3', 'an assigned Hash mixin remains a normal Hash';
+
+my %typed := %(2 => 3) but Associative[Int, Int];
+is %typed.of, Int, 'a parameterized Associative mixin reports its value type';
+is %typed{'2'}, 3, 'a parameterized Associative mixin keeps its entry';
+%typed<3> = 4;
+is %typed.elems, 2, 'a parameterized Associative mixin remains writable';
+is %typed.raku, '{"2" => 3, "3" => 4}', 'a parameterized Associative mixin keeps both entries';
+
+done-testing;


### PR DESCRIPTION
Closes #7747

## Summary
- preserve wrapped Hash entries across bind, assignment, element stores, and deletion
- expose parameterized container-role value types through `.of`
- add focused regression coverage and a news entry

## Verification
- `make lint`
- `make test`
- `make roast`