### PR TITLE
perf(env): index a scope's routine bindings instead of scanning the whole env

### DIFF
--- a/news/2026-09/block-scope-code-var-index.md
+++ b/news/2026-09/block-scope-code-var-index.md
@@ -1,0 +1,88 @@
+# A block scope no longer scans the whole env to save its routine bindings
+
+`eval_block_value_inner` — the carrier that runs a `where` clause, a role type
+argument, an `EVAL`'d unit and, above all, a regex `<?{ … }>` assertion body —
+has to save the `&`-routine bindings visible in the scope it runs in and put
+them back on exit, so a block-local `sub foo { }` or `my &foo = …` cannot leak
+into the caller. It did that with two full walks of the env:
+
+```rust
+let saved_code_env: HashMap<Symbol, Value> = self.env.iter()
+    .filter(|(k, _)| k.starts_with("&") || k.starts_with("__mutsu_callable_id::"))
+    .map(|(k, v)| (*k, v.clone())).collect();
+// ... body ...
+self.env.retain(|k, _| !(k.starts_with("&") || k.starts_with("__mutsu_callable_id::")));
+for (k, v) in saved_code_env { self.env.insert_sym(k, v); }
+```
+
+A carrier block is not a rare thing to run. A `<?{ … }>` assertion is evaluated
+once per *cursor position*, and a grammar `token` body runs dozens of times per
+parse; each one paid two O(env) scans in which every key was resolved to a
+`&str` and rescanned for two prefixes. On the benchmark [#7575] measures — a
+`.subst(/<?{ rand < .001 }> . /, …)` over 290,000 cursor positions — that pair
+cost about as much as everything else the assertion did.
+
+`Env` now keeps an index of exactly those keys, so both halves are
+O(routine bindings in scope) instead of O(env) — and zero work for the
+overwhelmingly common scope that declares no routines at all.
+
+## How the index stays honest
+
+Three properties make it safe to trust:
+
+- **It is a superset, never a subset.** A removal does not prune it, so a key it
+  names may be gone; every consumer reads the key back through
+  `Env::overlay_get_sym` instead of assuming it is present. What it must never
+  do is *miss* a key that is present, so `insert_sym` and the parent-tier
+  promotion inside `get_mut_sym` — the two paths that can add a key to an
+  overlay — extend it, and every whole-map rebuild that cannot maintain it
+  (`flattened`, `filtered_flat`, `From<HashMap>`, `inner_mut`) resets it to
+  "unindexed" rather than carry a stale one forward. The bulk *filters*
+  (`retain`, `retain_overlay`, `retain_frame_writes`, `values_mut`) only remove
+  keys, so they leave it valid by construction.
+- **It costs nothing on the envs that never use it.** Every env starts
+  unindexed and stays that way until something asks; the maintenance hook in
+  `insert_sym` is one branch on a field that insert already touched. Only
+  `Env::code_env_keys` turns the index on, and only a block-scope save calls
+  that, so the general insert path never pays the `Symbol::is_code_env_entry`
+  memo lookup. `bench-fib` and `bench-ctor` are unchanged.
+- **The predicate is one memoized bit.** `flags::CODE_ENV_ENTRY` joins the
+  `SymFlags` word in `src/symbol.rs`, fusing `starts_with("&")` and
+  `starts_with("__mutsu_callable_id::")` into a single lookup for the index
+  rebuild and for `note_code_entry`.
+
+The exit path also stopped using `retain`. `Env::remove_overlay_sym` drops a key
+from *this* tier without tombstoning it, which is what `retain`'s filter
+semantics were: an enclosing tier's routine binding has to shadow back through,
+not be recorded as deleted in this scope. A scope that holds no routine bindings
+at all now skips the whole save/restore pair, so it no longer invalidates the
+frame-write log or re-derives `?FILE` either.
+
+## Numbers
+
+Release, interleaved A/B against the merge-base binary, 9 runs each, median
+(this box is slower in absolute terms than the one that filed the ticket):
+
+| | main | with the index |
+| --- | --- | --- |
+| `for ^10000 { $seed.subst(/<?{ rand < .001 }> . /, "X", :global) }` | 0.978s | **0.765s** |
+
+That is 22% off the benchmark — slightly more than the 17% the ticket measured
+for deleting both halves outright (an unsound experiment), because skipping the
+pair also skips `retain`'s `refresh_file_sym` and its frame-write invalidation.
+`bench-fib`, `bench-ctor`, `bench-class` and `bench-grammar-parse[-deep]` are
+unchanged within noise.
+
+## What is still on the table
+
+The ticket's other measured region is untouched: `eval_regex_inline_code` builds
+its per-cursor-position bindings as `String` keys (`i.to_string()`,
+`format!("<{}>", k)`, a clone of every `:my` lexical name) and re-interns each
+one on the way into the env, which is where the profile's `Symbol::intern` and
+malloc traffic come from. Its two *disproven* hypotheses — the registry snapshot
+and building `$/` — remain disproven and are recorded on the issue.
+
+`t/block-scope-code-vars.t` pins the language-level invariant the index has to
+keep, and `src/env.rs`'s unit tests pin the superset property directly.
+
+[#7575]: https://github.com/tokuhirom/mutsu/issues/7575

--- a/src/env.rs
+++ b/src/env.rs
@@ -481,6 +481,28 @@ pub struct Env {
     /// on the swap path) stays a refcount bump; the log is copy-on-write like
     /// `inner`.
     frame_writes: Option<Arc<Vec<Symbol>>>,
+    /// Index of the overlay keys that are *code env entries* (`&foo` and their
+    /// `__mutsu_callable_id::` markers — see [`Symbol::is_code_env_entry`]),
+    /// so a block scope can save/restore them in O(routine bindings) instead of
+    /// O(whole env). See [`Self::code_env_keys`].
+    ///
+    /// `None` means "not indexed": the answer is recomputed by one overlay scan
+    /// on the next ask. Every env starts that way and stays that way unless
+    /// something actually asks — which keeps the maintenance hook in
+    /// [`Self::insert_sym`] down to one `is_some()` branch on the envs (nearly
+    /// all of them) that never run a block-scope save.
+    ///
+    /// A *superset* index, never a subset: it may name a key that has since
+    /// been removed (removals do not prune it), so every consumer re-reads the
+    /// overlay through the key. It must never MISS a present key, which is why
+    /// the two bulk paths that can add keys without passing `insert_sym`
+    /// ([`Self::inner_mut`]) and every whole-map rebuild (`flattened`,
+    /// `filtered_flat`, `From<HashMap>`) reset it to `None` rather than carry a
+    /// stale one forward.
+    ///
+    /// `Arc` for the same reason as `frame_writes`: an env clone stays a
+    /// refcount bump.
+    code_entries: Option<Arc<Vec<Symbol>>>,
 }
 
 /// Maximum overlay chain length before [`Env::scoped_child`] flattens the parent.
@@ -532,6 +554,7 @@ impl Env {
             depth: 0,
             file_sym: None,
             frame_writes: None,
+            code_entries: None,
         }
     }
 
@@ -585,6 +608,7 @@ impl Env {
                     tombstones: None,
                     file_sym,
                     frame_writes: None,
+                    code_entries: None,
                 };
             }
             return Self {
@@ -594,6 +618,7 @@ impl Env {
                 tombstones: None,
                 file_sym,
                 frame_writes: None,
+                code_entries: None,
             };
         }
         let parent = if parent.depth >= MAX_OVERLAY_DEPTH {
@@ -608,6 +633,7 @@ impl Env {
             tombstones: None,
             file_sym,
             frame_writes: None,
+            code_entries: None,
         }
     }
 
@@ -734,6 +760,81 @@ impl Env {
         }
     }
 
+    /// Keep [`Self::code_entries`] a superset of the overlay's code-var keys
+    /// across an `insert`. A no-op — one branch on a field the insert already
+    /// touched — for every env that has never been asked for the index, which
+    /// is nearly all of them: only [`Self::code_env_keys`] turns the index on,
+    /// and only a block-scope save/restore calls that. `Symbol::is_code_env_entry`
+    /// (a thread-local memo lookup) is therefore never paid on the general
+    /// insert path.
+    #[inline(always)]
+    fn note_code_entry(&mut self, key: Symbol) {
+        if let Some(idx) = &mut self.code_entries
+            && key.is_code_env_entry()
+            && !idx.contains(&key)
+        {
+            Arc::make_mut(idx).push(key);
+        }
+    }
+
+    /// The overlay keys that are code env entries — `&foo` routine bindings and
+    /// their `__mutsu_callable_id::` markers (see [`Symbol::is_code_env_entry`]).
+    ///
+    /// These are exactly the keys a block scope has to snapshot on entry and
+    /// restore on exit, so that a block-local `sub`/`my &foo` does not leak into
+    /// the caller. Doing that by scanning the whole overlay twice per block was
+    /// the measured cost of running a carrier block (#7575): two full env walks
+    /// per `<?{ … }>` assertion evaluation, per grammar `token` body, per
+    /// `where` clause. The index makes both walks O(routine bindings in scope) —
+    /// zero for the overwhelmingly common scope that declares no routines.
+    ///
+    /// The returned list is a *superset*: a key it names may have been removed
+    /// since, so read each one back through [`Self::overlay_get_sym`] rather than
+    /// assuming it is present. It never misses a key that IS present.
+    ///
+    /// Takes `&mut self` because the first ask materializes (and memoizes) the
+    /// index with one overlay scan.
+    pub(crate) fn code_env_keys(&mut self) -> Arc<Vec<Symbol>> {
+        let inner = &self.inner;
+        self.code_entries
+            .get_or_insert_with(|| {
+                Arc::new(
+                    inner
+                        .keys()
+                        .copied()
+                        .filter(|k| k.is_code_env_entry())
+                        .collect(),
+                )
+            })
+            .clone()
+    }
+
+    /// Drop this env's frame-write log, for a caller that has just made a bulk
+    /// edit it cannot describe key-by-key (see [`Self::frame_writes`]). A no-op
+    /// for the envs — nearly all of them — that carry no log.
+    #[inline]
+    pub(crate) fn forget_frame_writes(&mut self) {
+        self.frame_writes = None;
+    }
+
+    /// Drop `key` from this tier's overlay **without** tombstoning it, so a
+    /// parent-tier binding of the same name shadows back through.
+    ///
+    /// This is `retain`'s per-key removal semantics ("filter my own overlay"),
+    /// not `remove_sym`'s ("this name is deleted in this scope"). A block-scope
+    /// restore wants the former: it undoes writes the block made to THIS tier
+    /// and must leave an enclosing tier's routine binding visible.
+    pub(crate) fn remove_overlay_sym(&mut self, key: Symbol) -> Option<Value> {
+        if !self.inner.contains_key(&key) {
+            return None;
+        }
+        if key == file_key() {
+            self.file_sym = None;
+        }
+        self.note_frame_write(key);
+        self.cow_mut().remove(&key)
+    }
+
     /// Drop the frame's own by-name writes from a *flattened* env, consulting
     /// [`Self::frame_writes`] instead of scanning the whole map: the
     /// [`Self::retain_overlay`] return merge, replayed at O(frame writes) after
@@ -855,6 +956,7 @@ impl Env {
                     // `flattened_for_frame` is what records the collapsed tier's
                     // writes when a light frame needs them (#7630).
                     frame_writes: None,
+                    code_entries: None,
                 }
             }
         }
@@ -918,6 +1020,7 @@ impl Env {
             depth: 0,
             file_sym,
             frame_writes: None,
+            code_entries: None,
         }
     }
 
@@ -1097,6 +1200,7 @@ impl Env {
         }
         self.untombstone(key);
         self.note_frame_write(key);
+        self.note_code_entry(key);
         self.cow_mut().insert(key, value)
     }
 
@@ -1205,6 +1309,9 @@ impl Env {
                 .cloned();
             if let Some(v) = promote {
                 self.untombstone(key);
+                // A promotion ADDS a key to this overlay, so it has to reach the
+                // code-entry index exactly as an `insert` does.
+                self.note_code_entry(key);
                 self.cow_mut().insert(key, v);
             }
         }
@@ -1383,8 +1490,13 @@ impl Env {
     }
 
     /// Direct access to the inner HashMap (for bulk mutation).
+    ///
+    /// The one write path that can add a key without passing through
+    /// [`Self::insert_sym`], so it drops the code-entry index rather than let a
+    /// bulk insert make it miss a key — see [`Self::code_entries`].
     #[allow(dead_code)]
     pub(crate) fn inner_mut(&mut self) -> &mut SymMap {
+        self.code_entries = None;
         self.cow_mut()
     }
 
@@ -1487,6 +1599,7 @@ impl From<HashMap<String, Value>> for Env {
             depth: 0,
             file_sym,
             frame_writes: None,
+            code_entries: None,
         }
     }
 }
@@ -1502,6 +1615,7 @@ impl From<HashMap<Symbol, Value>> for Env {
             depth: 0,
             file_sym,
             frame_writes: None,
+            code_entries: None,
         }
     }
 }
@@ -1581,6 +1695,110 @@ mod tests {
         }
         // Empty string is not a plain user lexical.
         assert!(!is_plain_user_lexical(""));
+    }
+
+    /// Every key the code-entry index must name, and the ones it must not,
+    /// derived by brute force from the overlay. The index is allowed to be a
+    /// *superset* (removals do not prune it), never a subset.
+    fn code_entries_are_a_superset(env: &mut Env) {
+        let index = env.code_env_keys();
+        let actual: Vec<Symbol> = env
+            .inner
+            .keys()
+            .copied()
+            .filter(|k| k.is_code_env_entry())
+            .collect();
+        for k in &actual {
+            assert!(
+                index.contains(k),
+                "index missed a present code entry: {}",
+                k.as_str()
+            );
+        }
+        for k in index.iter() {
+            assert!(
+                k.is_code_env_entry(),
+                "index named a non-code key: {}",
+                k.as_str()
+            );
+        }
+    }
+
+    #[test]
+    fn code_env_key_classification() {
+        for k in [
+            "&helper",
+            "&?BLOCK",
+            "&?ROUTINE",
+            "__mutsu_callable_id::M::f",
+        ] {
+            assert!(s(k).is_code_env_entry(), "{k} is a code env entry");
+        }
+        for k in ["x", "@arr", "%h", "self", "_", "?FILE", "__mutsu_type::x"] {
+            assert!(!s(k).is_code_env_entry(), "{k} is not a code env entry");
+        }
+    }
+
+    #[test]
+    fn code_entry_index_tracks_inserts_and_survives_removals() {
+        let mut env = Env::new();
+        env.insert("x".into(), Value::int(1));
+        env.insert("&f".into(), Value::int(2));
+        // First ask materializes the index from the overlay.
+        code_entries_are_a_superset(&mut env);
+        assert_eq!(env.code_env_keys().len(), 1);
+        // A later insert extends the live index rather than invalidating it.
+        env.insert("__mutsu_callable_id::MAIN::f".into(), Value::int(3));
+        env.insert("&g".into(), Value::int(4));
+        code_entries_are_a_superset(&mut env);
+        assert_eq!(env.code_env_keys().len(), 3);
+        // Re-inserting a known key does not duplicate it.
+        env.insert("&g".into(), Value::int(5));
+        assert_eq!(env.code_env_keys().len(), 3);
+        // A removal may leave a stale entry behind (superset), but every key the
+        // index names must still be readable back through the overlay or absent.
+        env.remove("&g");
+        code_entries_are_a_superset(&mut env);
+        assert!(env.overlay_get_sym(s("&g")).is_none());
+    }
+
+    #[test]
+    fn code_entry_index_rebuilt_after_a_whole_map_replacement() {
+        let mut src: HashMap<Symbol, Value> = HashMap::new();
+        src.insert(s("&f"), Value::int(1));
+        src.insert(s("y"), Value::int(2));
+        // `From<HashMap>` cannot maintain an index, so it must start unindexed
+        // and rebuild on the first ask rather than report an empty one.
+        let mut env: Env = src.into();
+        assert_eq!(env.code_env_keys().len(), 1);
+        code_entries_are_a_superset(&mut env);
+
+        // A flatten merges parent tiers into the overlay, which adds code keys
+        // this env's index never saw; it must be rebuilt, not carried over.
+        let mut root = Env::new();
+        root.insert("&outer".into(), Value::int(1));
+        let mut leaf = scoped_with(root, &[("z", 3)]);
+        assert_eq!(
+            leaf.code_env_keys().len(),
+            0,
+            "overlay-only, parent excluded"
+        );
+        let mut flat = leaf.flattened();
+        assert_eq!(flat.code_env_keys().len(), 1);
+        code_entries_are_a_superset(&mut flat);
+    }
+
+    #[test]
+    fn remove_overlay_sym_does_not_tombstone_the_parent_tier() {
+        let mut root = Env::new();
+        root.insert("&f".into(), Value::int(1));
+        let mut leaf = scoped_with(root, &[]);
+        leaf.insert("&f".into(), Value::int(2));
+        assert_eq!(leaf.get_sym(s("&f")), Some(&Value::int(2)));
+        // Undoing this tier's write must let the parent's binding shadow back
+        // through -- unlike `remove_sym`, which would tombstone the name.
+        leaf.remove_overlay_sym(s("&f"));
+        assert_eq!(leaf.get_sym(s("&f")), Some(&Value::int(1)));
     }
 
     fn scoped_with(parent: Env, writes: &[(&str, i64)]) -> Env {

--- a/src/runtime/resolution_eval.rs
+++ b/src/runtime/resolution_eval.rs
@@ -403,11 +403,16 @@ impl Interpreter {
         // `&`-code vars and their `__mutsu_callable_id::` markers are lexical to
         // this block too; snapshot them so a block-local `sub`/`my &foo` binding
         // does not leak its env entries into the caller.
-        let saved_code_env: std::collections::HashMap<Symbol, Value> = self
-            .env
+        //
+        // Driven off `Env::code_env_keys`, the env's own index of those keys,
+        // rather than a full overlay walk: a carrier block runs *per regex
+        // cursor position* / per grammar `token` body, and the two O(env) scans
+        // this pair used to cost were ~17% of a `<?{ … }>`-driven match (#7575).
+        // The index is a superset, so read each key back through `overlay_get`.
+        let code_keys = self.env.code_env_keys();
+        let saved_code_env: std::collections::HashMap<Symbol, Value> = code_keys
             .iter()
-            .filter(|(k, _)| k.starts_with("&") || k.starts_with("__mutsu_callable_id::"))
-            .map(|(k, v)| (*k, v.clone()))
+            .filter_map(|k| self.env.overlay_get_sym(*k).map(|v| (*k, v.clone())))
             .collect();
         // The compiled chunk can be reused across calls to the SAME `SubData`
         // (cache_id) only when nothing below would mutate it per-call — a
@@ -568,10 +573,37 @@ impl Interpreter {
             self.operator_assoc = saved_operator_assoc;
             self.user_declared_infix_ops = saved_user_declared_infix_ops;
         }
-        self.env
-            .retain(|k, _| !(k.starts_with("&") || k.starts_with("__mutsu_callable_id::")));
-        for (k, v) in saved_code_env {
-            self.env.insert_sym(k, v);
+        // Undo the block's own code-var writes: drop every code entry the
+        // overlay now holds that was not in the entry snapshot, then reinstate
+        // the snapshot (a block may have *rebound* an existing name, not just
+        // added one). `remove_overlay_sym`, not `remove_sym`: this filters THIS
+        // tier the way the `retain` it replaces did, so an enclosing tier's
+        // routine binding shadows back through instead of being tombstoned.
+        //
+        // A scope holding no routine bindings at all — the common carrier block,
+        // and every block in the `<?{ … }>` benchmark of #7575 — skips the pair
+        // entirely: there is nothing to drop and nothing to put back, so it also
+        // leaves the frame-write log alone instead of invalidating it.
+        let code_keys_after = self.env.code_env_keys();
+        if !saved_code_env.is_empty()
+            || code_keys_after
+                .iter()
+                .any(|k| self.env.overlay_get_sym(*k).is_some())
+        {
+            for k in code_keys_after.iter() {
+                if !saved_code_env.contains_key(k) {
+                    self.env.remove_overlay_sym(*k);
+                }
+            }
+            for (k, v) in saved_code_env {
+                self.env.insert_sym(k, v);
+            }
+            // The `retain` this replaces dropped the frame-write log wholesale
+            // (it could not log key-by-key). Keep doing so once this scope has
+            // actually rewritten code entries: the reinstated bindings are the
+            // CALLER's, not writes this frame made, and logging them as such
+            // would make the enclosing frame's unwind drop them.
+            self.env.forget_frame_writes();
         }
         // Blocks are scope boundaries for temp/let saves.
         self.restore_let_saves(let_mark);

--- a/src/symbol.rs
+++ b/src/symbol.rs
@@ -208,6 +208,17 @@ pub(crate) mod flags {
     /// that does — an escaping closure whose `use`-inside-`EVAL` scope has
     /// already been popped — is served precisely by `capture_bare_callees`.
     pub(crate) const CALLABLE_ID_META: u16 = 1 << 8;
+    /// A *code env entry*: a `&`-sigil routine binding (`&foo`, `&?BLOCK`) or
+    /// the `__mutsu_callable_id::` marker installed beside it. Together these
+    /// are exactly the env keys a block scope has to save and restore, so that
+    /// a block-local `sub`/`my &foo` does not leak into the caller
+    /// ([`crate::env::Env::code_env_keys`]).
+    ///
+    /// A superset of [`CALLABLE_ID_META`], deliberately: the block-scope
+    /// predicate asks the two questions together, and fusing them into one bit
+    /// makes it a single memoized lookup instead of two `as_str()` round trips
+    /// plus two `starts_with` scans per key.
+    pub(crate) const CODE_ENV_ENTRY: u16 = 1 << 9;
     /// Set once the flag word has been computed (so a symbol with no flags is
     /// not recomputed on every lookup).
     pub(crate) const COMPUTED: u16 = 1 << 15;
@@ -240,6 +251,9 @@ fn compute_flags(s: &str) -> u16 {
     }
     if s.starts_with(CALLABLE_ID_META_PREFIX) {
         f |= flags::CALLABLE_ID_META;
+    }
+    if s.starts_with('&') || s.starts_with(CALLABLE_ID_META_PREFIX) {
+        f |= flags::CODE_ENV_ENTRY;
     }
     if crate::env::is_plain_user_lexical(s) {
         f |= flags::PLAIN_USER_LEXICAL;
@@ -506,6 +520,14 @@ impl Symbol {
     #[inline]
     pub(crate) fn is_dynamic_var_env_key(self) -> bool {
         self.flags() & flags::DYNAMIC_VAR_ENV_KEY != 0
+    }
+
+    /// Memoized "is this a `&`-routine binding or its `__mutsu_callable_id::`
+    /// marker" — the block-scope save/restore predicate. See
+    /// [`flags::CODE_ENV_ENTRY`].
+    #[inline]
+    pub(crate) fn is_code_env_entry(self) -> bool {
+        self.flags() & flags::CODE_ENV_ENTRY != 0
     }
 
     /// Resolve the symbol back to its string representation.

--- a/t/block-scope-code-vars.t
+++ b/t/block-scope-code-vars.t
@@ -1,0 +1,36 @@
+use Test;
+
+# A carrier block (`do { }`, a `where` clause, a regex `<?{ }>` assertion) saves
+# and restores the `&`-routine bindings visible in the scope it runs in, so a
+# block-local `sub` cannot leak into the caller and an enclosing binding is
+# still there afterwards. #7575 replaced the two whole-env scans that did that
+# with an index of exactly those keys; these are the semantics the index has to
+# keep.
+
+plan 10;
+
+sub outer() { "outer" }
+
+# A `sub` declared inside a carrier block does not leak out of it.
+my $inner-value = do { sub inner-only() { "inner" }; inner-only() };
+is $inner-value, "inner", "a block-local sub is callable inside the block";
+ok !::('&inner-only').defined, "a block-local sub does not leak into the caller";
+is outer(), "outer", "an existing outer sub still resolves after the block";
+
+# Repeated carrier blocks each get a clean slate.
+for ^3 -> $i {
+    my $v = do { sub loop-local($n) { "n$n" }; loop-local($i) };
+    is $v, "n$i", "iteration $i sees its own block-local sub";
+}
+
+# A regex assertion body is a carrier block run once per cursor position; the
+# routines it calls must stay resolvable for every one of them.
+sub keep($c) { $c eq "b" }
+is "abc".subst(/ <?{ keep("b") }> b /, "X"), "aXc",
+    "a sub called from a regex assertion resolves at every cursor position";
+is keep("b"), True, "the sub is still bound after the match";
+
+# `where` clauses are carrier blocks too.
+sub small($n where { $^x < 10 }) { $n * 2 }
+is small(4), 8, "a where clause runs as a carrier block";
+is outer(), "outer", "outer bindings survive a where clause";


### PR DESCRIPTION
Closes #7575.

## The problem

`eval_block_value_inner` — the carrier that runs a `where` clause, a role type argument, an `EVAL`'d unit and, above all, a regex `<?{ … }>` assertion body — saves the `&`-routine bindings visible in its scope on entry and restores them on exit, so a block-local `sub foo { }` / `my &foo = …` cannot leak into the caller. It did that with **two full env walks**, each resolving every key to a `&str` and rescanning it for two prefixes:

```rust
let saved_code_env: HashMap<Symbol, Value> = self.env.iter()
    .filter(|(k, _)| k.starts_with("&") || k.starts_with("__mutsu_callable_id::"))
    .map(|(k, v)| (*k, v.clone())).collect();
// ... body ...
self.env.retain(|k, _| !(k.starts_with("&") || k.starts_with("__mutsu_callable_id::")));
for (k, v) in saved_code_env { self.env.insert_sym(k, v); }
```

A carrier block is not rare: a `<?{ … }>` assertion is evaluated once per *cursor position* and a grammar `token` body dozens of times per parse. On #7575's benchmark (290,000 evaluations of a two-operand comparison) that pair was the measured lead.

## The change

`Env` now keeps `code_entries`, an index of exactly those overlay keys, so both halves are O(routine bindings in scope) — zero for the overwhelmingly common scope that declares none.

Three properties make it safe to trust:

- **Superset, never subset.** Removals do not prune it, so consumers read each key back through `overlay_get_sym`; what it must never do is *miss* a present key. `insert_sym` and the parent-tier promotion inside `get_mut_sym` (the two paths that can add an overlay key) extend it; every whole-map rebuild that cannot maintain it — `flattened`, `filtered_flat`, `From<HashMap>`, `inner_mut` — resets it to "unindexed" and it is rebuilt by one scan on the next ask. The bulk filters (`retain`, `retain_overlay`, `retain_frame_writes`, `values_mut`) only remove keys, so they leave it valid by construction.
- **Free where it is not used.** Every env starts unindexed and stays so until something asks, and only `code_env_keys` (i.e. only a block-scope save) turns it on. The maintenance hook in `insert_sym` is one branch on a field the insert already touched, so the general insert path never pays the `is_code_env_entry` memo lookup.
- **One memoized bit.** `flags::CODE_ENV_ENTRY` joins the `SymFlags` word, fusing `starts_with("&")` and `starts_with("__mutsu_callable_id::")`.

Supporting changes:

- `Env::remove_overlay_sym` drops a key from *this* tier without tombstoning it — the `retain` filter semantics the exit path needs, so an enclosing tier's routine binding shadows back through rather than being recorded as deleted in this scope.
- A scope holding no routine bindings skips the save/restore pair outright, so it no longer invalidates the frame-write log or re-derives `?FILE` either.

## Numbers

Release, **interleaved** A/B against the merge-base binary (alternating runs so drift hits both equally), 9 runs each, median. This box is ~4 cores and slower in absolute terms than the one that filed the ticket:

| benchmark | main | this PR |
| --- | --- | --- |
| `for ^10000 { $seed.subst(/<?{ rand < .001 }> . /, "X", :global) }` | 0.978s | **0.765s** (−22%) |

That is slightly more than the 17% the ticket measured for deleting both halves outright (an unsound experiment), because skipping the pair also skips `retain`'s `refresh_file_sym` and its frame-write invalidation.

Regression check, same protocol (13–15 runs for the short ones): `bench-fib` 0.095 → 0.096, `bench-ctor` 0.220 → 0.211, `bench-class` 0.158 → 0.156, `bench-grammar-parse-deep` 0.017 → 0.016 — all within noise.

These are local A/B numbers for the PR only; the bench CI history remains the source of truth for documents.

## Tests

- `t/block-scope-code-vars.t` (new) pins the language-level invariant the index has to keep: a block-local `sub` does not leak out, an outer one still resolves afterwards, repeated carrier blocks each get a clean slate, and a sub called from a regex assertion resolves at every cursor position. Validated against the `raku` oracle (10/10).
- New `src/env.rs` unit tests pin the superset property directly (brute-forced against the overlay), the rebuild after a whole-map replacement, and that `remove_overlay_sym` does not tombstone the parent tier.
- `make lint` green (all four configurations). `make test` green — 3918 files, 41638 tests.
- `make roast`: the only failures are the three documented container-only ones (`6.c/S32-io/file-tests.t` and `S16-filehandles/filetest.t` — this container runs as `uid 0`, so root bypasses the permission bits; `S32-io/IO-Socket-Async.t` — sandboxed network), matching `docs/agent-environments.md` test-for-test.

## Still open on the ticket

The other measured region is untouched: `eval_regex_inline_code` builds its per-cursor-position bindings as `String` keys (`i.to_string()`, `format!("<{}>", k)`) and re-interns each one into the env, which is where the profile's `Symbol::intern` and malloc traffic come from. The ticket's two disproven hypotheses (the registry snapshot; building `$/`) remain disproven.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RmToxXsRxi3YyCe9P5dRC5

---
_Generated by [Claude Code](https://claude.ai/code/session_01RmToxXsRxi3YyCe9P5dRC5)_