### PR TITLE
fix: preserve Crane copy isolation through rw accessors

### DIFF
--- a/docs/adr/0040-array-hash-elements-are-itemized-at-the-store.md
+++ b/docs/adr/0040-array-hash-elements-are-itemized-at-the-store.md
@@ -1225,6 +1225,27 @@ value-context read does anyway, and only ever when there is a Proxy inside.
 
 Pinned by `t/proxy-renders-through-fetch.t`.
 
+## 10. Copy isolation after lvalue promotion (added 2026-09-09)
+
+The store-side itemization rule shares a boundary with the lvalue-container
+machinery in ADR-0059 and ADR-0067. An `is rw`/`return-rw` accessor can promote an
+aggregate element to a `ContainerRef` before a collection is copied. The cell
+is a location, not a scalar leaf: if `deepmap({ .clone })` classifies it as a
+leaf, `.clone` copies only the cell handle and the aggregate remains shared with
+the source.
+
+The invariant for collection copies is therefore: **dereference a promoted
+element before deciding whether it is a deepmap leaf, and recursively copy the
+aggregate behind the cell**. The corresponding writeback invariant is that a
+nested rw call follows the caller's alias chain to its root; method-local alias
+metadata must not be merged back over the caller's chain. Together these keep
+the copy boundary intact even after a prior read has promoted an element.
+
+`t/deepmap-containerref-copy.t` pins both invariants. The Crane `add` and
+`copy` suites' "Original container is unchanged" checks pass for the affected
+cases; their remaining failures are separate positional/error and ordering
+gaps recorded in `docs/batteries/toml.md`.
+
 ---
 
 *If the mechanism judgment changes later, supersede this ADR rather than rewriting it.*

--- a/news/2026-09/crane-deepmap-copy-isolates-promoted-elements.md
+++ b/news/2026-09/crane-deepmap-copy-isolates-promoted-elements.md
@@ -1,0 +1,13 @@
+# Crane deep copies isolate elements promoted by rw accessors
+
+`deepmap({ .clone })` now descends through a `ContainerRef` when that cell holds
+an aggregate. Previously the cell was mistaken for a scalar leaf, so cloning it
+copied only the cell handle and left the aggregate shared with the source.
+
+The rw writeback path also resolves an argument's sigilless alias chain to its
+root and keeps method-parameter alias metadata local to the method frame. This
+prevents a nested static rw method from redirecting a caller's alias to the
+copied container's immediate parameter name.
+
+Pinned by `t/deepmap-containerref-copy.t`; the test covers both promoted
+aggregate cloning and a nested static rw method, and matches `raku`.

--- a/src/runtime/builtins_collection_deepmap.rs
+++ b/src/runtime/builtins_collection_deepmap.rs
@@ -22,11 +22,17 @@ use crate::value::ValueView;
 /// decided separately, by `deepmap_iterate_inner`'s `itemize_result`.
 fn deepmap_element_is_leaf(v: &Value) -> bool {
     let v = v.descalarize();
-    !v.is_range()
-        && !matches!(
-            v.view(),
-            ValueView::Package(_) | ValueView::Array(..) | ValueView::Seq(_) | ValueView::Hash(_)
-        )
+    v.with_deref(|v| {
+        let v = v.descalarize();
+        !v.is_range()
+            && !matches!(
+                v.view(),
+                ValueView::Package(_)
+                    | ValueView::Array(..)
+                    | ValueView::Seq(_)
+                    | ValueView::Hash(_)
+            )
+    })
 }
 
 fn range_as_list(value: &Value) -> Option<Value> {
@@ -411,6 +417,15 @@ impl Interpreter {
         // `Hash` element needs no unwrapping: its itemization is a kind/flag,
         // so it still matches `ValueView::Array`/`ValueView::Hash`.)
         let target = target.descalarize();
+        // An `is rw`/`return-rw` accessor can promote an aggregate element to a
+        // `ContainerRef`. That cell is still an aggregate for deepmap's
+        // leaf-vs-descend decision. Treating it as a leaf passes the cell to
+        // `.clone`, which only clones the cell's handle and lets a later write
+        // into the mapped copy reach the original aggregate as well.
+        if matches!(target.view(), ValueView::ContainerRef(_)) && !deepmap_element_is_leaf(target) {
+            let inner = target.deref_container();
+            return self.deepmap_iterate_inner(block, &inner, itemize_result);
+        }
         if let Some(list) = range_as_list(target) {
             return self.deepmap_iterate_inner(block, &list, itemize_result);
         }

--- a/src/runtime/types/binding_signature.rs
+++ b/src/runtime/types/binding_signature.rs
@@ -1902,7 +1902,16 @@ impl Interpreter {
                                 varref_from_value(&args[positional_idx]).map(|(name, _)| name)
                             });
                         if let Some(source_name) = source_name {
-                            rw_bindings.push((pd.name.clone(), source_name.clone()));
+                            // Write back to the root of a sigilless alias chain.
+                            // The argument may itself be a `\name` parameter in
+                            // the caller. Using the immediate source name here
+                            // would let a nested method's same-named parameter
+                            // replace that intermediate binding instead of
+                            // updating the caller's original container (e.g.
+                            // `inner(\container)` calling `Replace.replace(container)`).
+                            let writeback_source =
+                                self.resolve_sigilless_alias_source_name(&source_name);
+                            rw_bindings.push((pd.name.clone(), writeback_source));
                             // A plain scalar param aliasing a plain scalar caller
                             // variable binds through a shared `ContainerRef` cell
                             // (installed after type checks, below): the caller's

--- a/src/vm/vm_method_dispatch.rs
+++ b/src/vm/vm_method_dispatch.rs
@@ -1002,6 +1002,15 @@ impl Interpreter {
                     || cc.env_only_decls.iter().any(|n| n == s)
                     || attr_twigil_local(attributes, s)
                     || (has_attr_aliases && attr_alias_local(attributes, s))
+                    // Sigilless alias/readonly markers for a method parameter
+                    // are frame-local bookkeeping. A raw parameter may reuse a
+                    // caller's name, so merging `__mutsu_sigilless_alias::p`
+                    // back would overwrite the caller's alias chain with the
+                    // callee's immediate argument name.
+                    || s.strip_prefix("__mutsu_sigilless_alias::")
+                        .is_some_and(|name| method_def.param_defs.iter().any(|pd| pd.name == name))
+                    || s.strip_prefix("__mutsu_sigilless_readonly::")
+                        .is_some_and(|name| method_def.param_defs.iter().any(|pd| pd.name == name))
             };
             let is_unwritten_capture = |sym: Symbol, v: &Value| -> bool {
                 method_def.captured_env.as_ref().is_some_and(|c| {
@@ -2181,6 +2190,10 @@ impl Interpreter {
                         || attrs_cell
                             .as_ref()
                             .is_some_and(|c| attr_twigil_local(&c.as_map(), s))
+                        || s.strip_prefix("__mutsu_sigilless_alias::")
+                            .is_some_and(|name| method_def.param_defs.iter().any(|pd| pd.name == name))
+                        || s.strip_prefix("__mutsu_sigilless_readonly::")
+                            .is_some_and(|name| method_def.param_defs.iter().any(|pd| pd.name == name))
                 };
                 let is_unwritten_capture = |sym: Symbol, v: &Value| -> bool {
                     method_def.captured_env.as_ref().is_some_and(|c| {

--- a/t/deepmap-containerref-copy.t
+++ b/t/deepmap-containerref-copy.t
@@ -1,0 +1,59 @@
+use v6;
+use Test;
+
+plan 6;
+
+# A return-rw accessor promotes the selected aggregate to a ContainerRef.
+# deepmap({ .clone }) must still descend into that aggregate when building a
+# copy; otherwise the copy retains the original cell's aggregate.
+class PathAccessor {
+    method at($container, *@steps) is rw {
+        my $root := $container;
+        return-rw at($root, @steps);
+    }
+}
+
+multi sub at(Associative:D $container, @steps where .elems == 1) is rw {
+    my $root := $container;
+    $root := $root{@steps[0]};
+    return-rw $root;
+}
+
+my %original = a => { b => { d => 1 } };
+my $ignored = PathAccessor.at(%original, 'a');
+my %copy = %original.deepmap({ .clone });
+
+isnt %copy<a>.WHICH, %original<a>.WHICH,
+    'deepmap makes a fresh copy of a promoted aggregate';
+isnt %copy<a><b>.WHICH, %original<a><b>.WHICH,
+    'deepmap makes fresh copies below a promoted aggregate';
+
+%copy<a><b><c> = 2;
+is %original<a><b><c>:exists, False,
+    'writing to the copy does not mutate the original';
+is %copy<a><b><c>, 2, 'the copy remains writable';
+
+# A nested sigilless call can pass the deepmap result through a static method
+# whose parameter has the same name. Its writeback must follow the caller's
+# existing alias chain instead of replacing the original container binding.
+class StaticReplacer {
+    method replace(\container) {
+        container = { replacement => True };
+        container
+    }
+}
+
+sub copy-and-replace(\container) {
+    my $copy = container.deepmap({ .clone });
+    StaticReplacer.replace($copy);
+    $copy
+}
+
+my %source = a => { b => { d => 1 } };
+my $promoted = PathAccessor.at(%source, 'a');
+my $replaced = copy-and-replace(%source);
+
+is %source<a><replacement>:exists, False,
+    'a nested static method does not mutate the original after deepmap';
+is $replaced<replacement>, True,
+    'the nested static method still updates the copied container';


### PR DESCRIPTION
## Summary

- descend through promoted aggregate `ContainerRef` values before deciding whether a deepmap element is a leaf;
- resolve sigilless rw writeback to the alias-chain root;
- keep method-parameter sigilless alias/readonly metadata local to the method frame;
- add a focused regression test and document the invariant in ADR-0040.

This fixes the Blocker 1 Crane copy-isolation slice from #7539. The affected "Original container is unchanged" checks in Crane `add.rakutest`, `copy.rakutest`, and `transform.rakutest` now pass. Remaining failures are separate positional/error-handling and ordering gaps.

## Validation

- `cargo fmt --all`
- `make lint`
- `make test`
- `make roast`
- focused regression under both mutsu and Rakudo

Refs #7539