### PR TITLE
fix(vm): compare Sub values by identity in cheaply_unchanged

### DIFF
--- a/news/2026-09/sub-lexical-rewound-by-caller-env-merge.md
+++ b/news/2026-09/sub-lexical-rewound-by-caller-env-merge.md
@@ -1,0 +1,68 @@
+# A Sub-valued lexical was rewound to the caller's routine by the post-call env merge
+
+`Template::Jinja2`'s `{% call %}` blocks did not merely produce a wrong answer
+under mutsu — they took the process down with
+`fatal runtime error: stack overflow, aborting`, which is why four of that
+dist's test files could not even be counted ([#7729](https://github.com/tokuhirom/mutsu/issues/7729)).
+The renderer resolved the `caller` closure correctly, then invoked the *macro*
+closure instead; each wrong dispatch pushed another scope, and the
+`render-body → !eval → !eval-call → render-body → …` cycle ran until the stack
+ran out.
+
+## Root cause
+
+`cheaply_unchanged` (`src/vm/vm_method_dispatch.rs`) is the O(1), conservative
+"did the callee change this value?" test. It proves equality by Arc/Gc pointer
+identity for the heap container types (`Str`, `Array`, `Hash`, `ContainerRef`)
+and by value for the immutable scalars; anything it cannot cheaply prove counts
+as changed. It had **no arm for `Sub`**, so two env entries holding literally
+the same routine object always compared as changed.
+
+That matters because a nested method call flattens the caller's scoped overlay,
+copying every parent lexical into the callee's env. On return,
+`merge_method_env` merges the callee overlay back and reports the entries it
+considers changed in `changed_caller_locals`; the Slice F write-through then
+replaces each of those names in the caller's compiled **local slot** with the
+env value. For a Sub-valued lexical, that write-through fired on every
+non-pure nested call even though nothing had changed.
+
+Normally the env copy and the slot agree, so the redundant write-through is
+invisible. It stops being invisible in a routine that is **re-entered through a
+Sub stored in a data structure**:
+
+1. the outer invocation binds `$callable` to the macro closure, and its
+   `$callable ~~ Callable` smartmatch flushes the frame's locals into env
+   (`sync_regex_interpolation_env_from_locals`), so env now carries that Sub;
+2. `$callable(|@args)` runs the macro, which re-enters the same routine;
+3. the inner invocation binds its own `$callable` to the `caller` closure — in
+   its local slot; env still holds the *outer* invocation's Sub, inherited
+   through the flattened overlay;
+4. the inner invocation makes an ordinary nested method call, the merge reports
+   the inherited Sub as "changed", and the write-through rewinds the inner
+   slot to the outer routine;
+5. calling it re-enters the macro. Repeat until the stack overflows.
+
+## Fix
+
+Give `cheaply_unchanged` the `Sub` arm it was missing, with the same
+pointer-identity proof the other Gc-backed values already use:
+
+```rust
+(ValueView::Sub(a), ValueView::Sub(b)) => crate::gc::Gc::ptr_eq(&a, &b),
+```
+
+Distinct routine objects stay "changed" (conservative), so this only removes
+write-throughs that were provably no-ops.
+
+## Result
+
+The reduced `{% macro %}` + `{% call %}` repro now prints `[[data]]`, matching
+Rakudo. All four `Template::Jinja2` files that aborted now run to completion and
+report ordinary TAP failures instead — including `15-reference-remaining` and
+`18-reference-final`, which the issue had flagged as possibly a *different*
+overflow. One fix covered all four.
+
+Pinned by `t/lexical-sub-not-clobbered-by-nested-call.t` (a plain-Raku reduction
+of the renderer's shape: a re-entrant private method whose Sub lexical must
+survive an intervening method call) and by two unit tests on
+`cheaply_unchanged` itself.

--- a/src/vm/vm_method_dispatch.rs
+++ b/src/vm/vm_method_dispatch.rs
@@ -2321,6 +2321,18 @@ pub(crate) fn cheaply_unchanged(old: &Value, new: &Value) -> bool {
         // stay "changed" (conservative).
         (ValueView::ContainerRef(a), ValueView::ContainerRef(b)) => crate::gc::Gc::ptr_eq(&a, &b),
         (ValueView::Instance { id: a, .. }, ValueView::Instance { id: b, .. }) => a == b,
+        // A `Sub` is a Gc-backed heap value like `Str`/`Array`/`Hash` above, so
+        // the same pointer-identity proof applies: the same routine object under
+        // both names means the callee did not change the caller's variable.
+        // Without this arm every Sub-valued env entry a callee merely INHERITED
+        // from the flattened overlay was reported as changed, so
+        // `merge_method_env` listed it in `changed_caller_locals` and the Slice F
+        // write-through replaced the caller's live local slot with the env copy.
+        // In a routine re-entered through a Sub held in a data structure, env
+        // still carried the OUTER invocation's routine, so the inner frame's
+        // freshly resolved callable was overwritten by its caller's and calling
+        // it re-entered the wrong closure until the stack overflowed (#7729).
+        (ValueView::Sub(a), ValueView::Sub(b)) => crate::gc::Gc::ptr_eq(&a, &b),
         _ => false,
     }
 }
@@ -2531,6 +2543,18 @@ mod cheaply_unchanged_tests {
     use super::cheaply_unchanged;
     use crate::value::Value;
 
+    fn make_sub() -> Value {
+        Value::make_sub(
+            crate::symbol::Symbol::intern("MAIN"),
+            crate::symbol::well_known::anon(),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            false,
+            crate::env::Env::new(),
+        )
+    }
+
     #[test]
     fn container_ref_same_cell_is_unchanged() {
         // The single-store identity primitive: `my @a := @b` installs one shared
@@ -2544,6 +2568,21 @@ mod cheaply_unchanged_tests {
         let a = Value::container_ref(cell.clone());
         let b = Value::container_ref(cell);
         assert!(cheaply_unchanged(&a, &b));
+    }
+
+    #[test]
+    fn same_sub_object_is_unchanged() {
+        // #7729: two env entries holding the SAME routine object must compare
+        // unchanged, or `merge_method_env` reports the callee's inherited copy
+        // as a caller-visible write and the write-through rewinds the caller's
+        // local slot to it.
+        let sub = make_sub();
+        assert!(cheaply_unchanged(&sub, &sub.clone()));
+    }
+
+    #[test]
+    fn distinct_subs_are_changed() {
+        assert!(!cheaply_unchanged(&make_sub(), &make_sub()));
     }
 
     #[test]

--- a/t/lexical-sub-not-clobbered-by-nested-call.t
+++ b/t/lexical-sub-not-clobbered-by-nested-call.t
@@ -1,0 +1,75 @@
+use Test;
+
+plan 2;
+
+# A lexical holding a Sub must survive a nested method call made in the same
+# routine -- even when an OUTER, still-live invocation of that same routine
+# holds a different Sub under the same name.
+#
+# The env->locals write-through that keeps a caller's slots coherent after a
+# method call is driven by "did the callee change this value?". That test
+# (`cheaply_unchanged`) had no arm for `Sub`, so a Sub-valued env entry the
+# callee had merely INHERITED from the flattened overlay was reported as
+# changed, and the write-through then replaced the live local slot with the env
+# copy -- which, in a routine re-entered through a Sub stored in a data
+# structure, still held the OUTER frame's routine. Calling it re-entered the
+# wrong closure, and each wrong dispatch recursed one level deeper until the
+# process died with a stack overflow (#7729, found in Template::Jinja2's
+# `{% call %}` blocks).
+
+class Ctx {
+    has @.stack;
+    method resolve($n) {
+        for @!stack.reverse -> %s { return %s{$n} if %s{$n}:exists }
+        Nil;
+    }
+    method push-scope(%v) { @!stack.push: %v }
+    # Deliberately not a pure accessor: the callee has to write its own frame
+    # for the caller-env merge (and hence the write-through) to run at all.
+    method depth() { my $d = @!stack.elems; $d }
+}
+
+class Renderer {
+    method !install($ctx) {
+        my $renderer = self;
+        # The outer routine's `$callable` ends up holding this one ...
+        my $macro = sub (*@args) {
+            $ctx.push-scope({});
+            '[[' ~ $renderer!Renderer::call('caller', $ctx, ['data']) ~ ']]';
+        };
+        # ... while the inner, re-entrant invocation resolves this one.
+        my $caller-fn = sub (*@args) { "CALLED(@args[])" };
+        $ctx.push-scope({ test => $macro, caller => $caller-fn });
+        $renderer!Renderer::call('test', $ctx, []);
+    }
+
+    method !call($name, $ctx, @a) {
+        my $callable = $ctx.resolve($name);
+        # A nested method call between the assignment and the use.
+        my $ignored = $ctx.depth();
+        # The smartmatch flushes this frame's locals into env, which is how the
+        # outer invocation's Sub becomes visible to the inner one's overlay.
+        return $callable ~~ Callable ?? $callable(|@a) !! 'NOT-CALLABLE';
+    }
+
+    method run { my $ctx = Ctx.new; $ctx.push-scope({}); self!install($ctx) }
+}
+
+is Renderer.new.run, '[[CALLED(data)]]',
+    're-entrant routine calls the Sub IT resolved, not its caller\'s';
+
+# The same shape without the recursion: a Sub-valued lexical must not be
+# rewound by an intervening method call.
+class Plain {
+    method depth() { my $d = 1; $d }
+    method go() {
+        my $first = sub { 'first' };
+        my $chosen = $first;
+        my $second = sub { 'second' };
+        $chosen = $second;
+        my $ignored = self.depth();
+        return $chosen ~~ Callable ?? $chosen() !! 'NOT-CALLABLE';
+    }
+}
+
+is Plain.new.go, 'second', 'a reassigned Sub lexical survives a nested method call';


### PR DESCRIPTION
## Problem

`Template::Jinja2`'s `{% macro %}` + `{% call %}` combination did not merely
produce a wrong answer under mutsu — it died with
`fatal runtime error: stack overflow, aborting`. The renderer resolved the
`caller` closure correctly and then invoked the **macro** closure instead; each
wrong dispatch pushed another scope, so `render-body → !eval → !eval-call →
render-body → …` recursed until the process died with no diagnostic.

```
raku               -I lib /tmp/j1.raku   # [[data]]
target/debug/mutsu -I lib /tmp/j1.raku   # thread 'mutsu-main' has overflowed its stack
```

## Root cause

`cheaply_unchanged` (`src/vm/vm_method_dispatch.rs`) is the O(1), conservative
"did the callee change this value?" test behind `merge_method_env`'s
`changed_caller_locals` and the Slice F env→locals write-through. It proves
equality by Gc/Arc pointer identity for the heap container types (`Str`,
`Array`, `Hash`, `ContainerRef`) and by value for the immutable scalars;
anything it cannot cheaply prove counts as changed. It had **no arm for `Sub`**,
so two env entries holding literally the same routine object always compared as
changed.

A nested method call flattens the caller's scoped overlay, copying every parent
lexical into the callee's env. On return the merge therefore reported every
Sub-valued entry the callee had merely *inherited* as a caller-visible write,
and the write-through replaced the caller's live local slot with the env copy.

Normally env and the slot agree, so that redundant write-through is invisible.
It stops being invisible in a routine **re-entered through a Sub held in a data
structure**:

1. the outer invocation binds `$callable` to the macro closure, and its
   `$callable ~~ Callable` smartmatch flushes the frame's locals into env
   (`sync_regex_interpolation_env_from_locals`), so env now carries that Sub;
2. `$callable(|@args)` runs the macro, which re-enters the same routine;
3. the inner invocation binds its own `$callable` (the `caller` closure) — in
   its local slot; env still holds the *outer* invocation's Sub, inherited
   through the flattened overlay;
4. the inner invocation makes an ordinary nested method call, the merge reports
   the inherited Sub as "changed", and the write-through rewinds the inner slot
   to the outer routine;
5. calling it re-enters the macro. Repeat until the stack overflows.

Confirmed directly: without the fix the write-through fires 135 times on
`callable` with `old_is_sub=true new_is_sub=true`.

## Fix

Give `cheaply_unchanged` the `Sub` arm it was missing, with the same
pointer-identity proof the other Gc-backed values already use:

```rust
(ValueView::Sub(a), ValueView::Sub(b)) => crate::gc::Gc::ptr_eq(&a, &b),
```

Distinct routine objects stay "changed" (conservative), so this only removes
write-throughs that were provably no-ops.

## Result

The reduced repro now prints `[[data]]`, matching Rakudo. **All four**
`Template::Jinja2` files that aborted now run to completion and report ordinary
TAP failures instead:

| file | before | after |
| --- | --- | --- |
| `12-advanced-tags` | stack overflow | `You failed 3 tests of 29` |
| `13-ported-remaining` | stack overflow | `You failed 12 tests of 49` |
| `15-reference-remaining` | stack overflow | `You failed 10 tests of 34` |
| `18-reference-final` | stack overflow | `You failed 9 tests of 54` |

Note this includes `15-reference-remaining` and `18-reference-final`, which
[#7729's comment](https://github.com/tokuhirom/mutsu/issues/7729#issuecomment-5600614071)
flagged as containing no `{% call %}` block and possibly a *different* overflow.
One fix covered all four.

## Tests

- `t/lexical-sub-not-clobbered-by-nested-call.t` — a plain-Raku reduction of the
  renderer's shape (a re-entrant private method whose Sub lexical must survive
  an intervening method call). Overflows the stack without the fix; passes with
  it and under `raku`.
- Two unit tests on `cheaply_unchanged` itself (same Sub unchanged, distinct
  Subs changed), alongside the existing `ContainerRef` pair.

## Verification

| gate | result |
| --- | --- |
| `cargo fmt --all` | clean |
| `make lint` | rc=0, no warnings (default / `jit` off / wasm32 / rustdoc) |
| `make test` | PASS — 3919 files, 41641 tests |
| `make roast` | 1436 files, 218939 tests; only the three failures [docs/agent-environments.md](docs/agent-environments.md) records as container artefacts (`6.c/S32-io/file-tests.t` and `S16-filehandles/filetest.t` run as `uid 0`; `S32-io/IO-Socket-Async.t` needs the sandboxed network) |

Closes #7729

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013E3MvCBa1Ym3RZej8oVEMg

---
_Generated by [Claude Code](https://claude.ai/code/session_013E3MvCBa1Ym3RZej8oVEMg)_