### PR TITLE
fix: preserve native subclass payloads through bless

### DIFF
--- a/news/2026-09/bless-fills-native-subclass-payload.md
+++ b/news/2026-09/bless-fills-native-subclass-payload.md
@@ -1,0 +1,14 @@
+# `bless` preserves native scalar subclass payloads
+
+`Mu.new` already stored the payload for `Str` and `Int` subclasses in reserved
+attributes, but `Mu.bless` assembled instances through a separate constructor
+path and skipped those slots. A custom `Str` constructor using
+`self.bless(value => $str)` therefore rendered `Str()` instead of `$str`.
+
+Both construction paths now share the native-subclass payload seeding helper.
+The existing string and integer payload readers consequently work for
+`.Str`, `.gist`, `.raku`, interpolation, and numeric comparisons on instances
+created with either spelling. The regression coverage also records Rakudo's
+rule that `Int.bless(value => ...)` leaves the integer payload at zero.
+
+Pinned by `t/str-coercion-and-dispatch.t`.

--- a/src/runtime/methods_dispatch_new.rs
+++ b/src/runtime/methods_dispatch_new.rs
@@ -572,6 +572,13 @@ impl Interpreter {
                 attributes.insert("__mutsu_hash_storage", storage);
             }
         }
+        let class_mro = self.class_mro(cn_resolved);
+        let positional_args: Vec<Value> = args
+            .iter()
+            .filter(|arg| !matches!(arg.view(), ValueView::Pair(..)))
+            .cloned()
+            .collect();
+        super::seed_native_subclass_payloads(&mut attributes, &class_mro, &args, &positional_args);
         // Embed `is default(...)` element defaults into `@`/`%` containers.
         self.apply_container_attribute_defaults(cn_resolved, &mut attributes);
         crate::alloc_scope_end!(_sc_container);

--- a/src/runtime/methods_instance_ops.rs
+++ b/src/runtime/methods_instance_ops.rs
@@ -183,6 +183,9 @@ impl Interpreter {
         if let Some(payload) = attributes.as_map().get("__mutsu_str_value").cloned() {
             return Some(self.call_method_with_values(payload, method, vec![]));
         }
+        if let Some(payload) = attributes.as_map().get("__mutsu_int_value").cloned() {
+            return Some(self.call_method_with_values(payload, method, vec![]));
+        }
         if let Some(storage) = attributes.as_map().get("__mutsu_array_storage").cloned() {
             return Some(self.call_method_with_values(storage, method, vec![]));
         }

--- a/src/runtime/methods_object_dispatch_new.rs
+++ b/src/runtime/methods_object_dispatch_new.rs
@@ -2031,16 +2031,12 @@ impl Interpreter {
                 }
                 self.enforce_attribute_where_constraints(class_key, &class_attrs_info, &attrs)?;
                 self.enforce_attribute_smiley_constraints(class_key, &attrs, None)?;
-                let int_ctor_val = if matches!(
+                if matches!(
                     positional_ctor_args.first().map(Value::view),
                     Some(ValueView::Package(_))
                 ) {
                     return Err(RuntimeError::new("Cannot convert type object to Int"));
-                } else {
-                    positional_ctor_args
-                        .first()
-                        .map_or(0, crate::runtime::to_int)
-                };
+                }
                 if class_mro.iter().any(|n| *n == "Array" || *n == "List")
                     && !attrs.contains_key("__mutsu_array_storage")
                     && !positional_ctor_args.is_empty()
@@ -2050,30 +2046,12 @@ impl Interpreter {
                     let storage = self.positional_base_storage(class_key, elems);
                     attrs.insert("__mutsu_array_storage".to_string(), storage);
                 }
-                if class_mro.iter().any(|name| name == "Int")
-                    && !attrs.contains_key("__mutsu_int_value")
-                {
-                    attrs.insert("__mutsu_int_value".to_string(), Value::int(int_ctor_val));
-                }
-                // A subclass of native `Str` (`class Foo is Str {}`) inherits the
-                // parent's single `$!value` attribute, which `Mu.new` fills from
-                // the `:value` named argument -- `Foo.new(:value("hi")).Str` is
-                // `"hi"` and `Foo.new.Str` is `""`. Stored in the reserved
-                // `__mutsu_str_value` slot, the string twin of the
-                // `__mutsu_int_value` payload above, so every stringification
-                // path can find it without a class-registry lookup.
-                if class_mro.iter().any(|name| name == "Str")
-                    && !attrs.contains_key("__mutsu_str_value")
-                {
-                    let payload = args
-                        .iter()
-                        .find_map(|a| match a.view() {
-                            ValueView::Pair(k, v) if k == "value" => Some(v.to_str_context()),
-                            _ => None,
-                        })
-                        .unwrap_or_default();
-                    attrs.insert("__mutsu_str_value".to_string(), Value::str(payload));
-                }
+                super::seed_native_subclass_payloads(
+                    &mut attrs,
+                    &class_mro,
+                    &args,
+                    &positional_ctor_args,
+                );
                 // Then evaluate defaults for attributes not provided by args,
                 // binding `self` so default expressions like `self.x` work.
                 // Restore role parameter bindings so that default expressions

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -78,6 +78,35 @@ pub(crate) fn phaser_prepost_error(is_pre: bool, condition: &str) -> RuntimeErro
     err
 }
 
+/// Seed the representation payload carried by a subclass of a native scalar.
+///
+/// `Mu.new` and `Mu.bless` both construct an ordinary instance, but the native
+/// `Int`/`Str` implementations need their scalar value in a reserved attribute
+/// so value-level coercion and rendering can see it without consulting the
+/// class registry. Keep the convention in one place so the two constructor
+/// paths cannot drift again.
+pub(crate) fn seed_native_subclass_payloads(
+    attrs: &mut AttrMap,
+    class_mro: &[Symbol],
+    args: &[Value],
+    positional_args: &[Value],
+) {
+    if class_mro.iter().any(|name| name == "Int") && !attrs.contains_key("__mutsu_int_value") {
+        let payload = positional_args.first().map_or(0, crate::runtime::to_int);
+        attrs.insert("__mutsu_int_value", Value::int(payload));
+    }
+    if class_mro.iter().any(|name| name == "Str") && !attrs.contains_key("__mutsu_str_value") {
+        let payload = args
+            .iter()
+            .find_map(|arg| match arg.view() {
+                ValueView::Pair(key, value) if key == "value" => Some(value.to_str_context()),
+                _ => None,
+            })
+            .unwrap_or_default();
+        attrs.insert("__mutsu_str_value", Value::str(payload));
+    }
+}
+
 /// Flatten arguments for `append` using Raku's "one-arg rule":
 /// if exactly one non-itemized Array/List argument is passed, its elements
 /// are flattened into the result. With multiple arguments, each is appended as-is.

--- a/src/runtime/utils/gist.rs
+++ b/src/runtime/utils/gist.rs
@@ -484,6 +484,14 @@ pub(crate) fn gist_value(value: &Value) -> String {
                 .map(crate::value::Value::to_string_value)
                 .unwrap_or_default()
         }
+        // An `is Int` subclass gists as its integer payload, just like Int.
+        ValueView::Instance { attributes, .. } if attributes.contains_key("__mutsu_int_value") => {
+            attributes
+                .as_map()
+                .get("__mutsu_int_value")
+                .map(crate::value::Value::to_string_value)
+                .unwrap_or_default()
+        }
         // An `is Array` subclass instance gists as its backing array elements
         // (`Vector.new(1,2,3).gist` → `[1 2 3]`), not the generic `Class.new`.
         ValueView::Instance { attributes, .. }

--- a/src/value/display.rs
+++ b/src/value/display.rs
@@ -1046,6 +1046,17 @@ impl Value {
                     .map(Value::to_string_value)
                     .unwrap_or_default()
             }
+            // A subclass of native `Int` carries its numeric payload in the
+            // reserved slot seeded by both `new` and `bless`.
+            ValueView::Instance { attributes, .. }
+                if attributes.contains_key("__mutsu_int_value") =>
+            {
+                attributes
+                    .as_map()
+                    .get("__mutsu_int_value")
+                    .map(Value::to_string_value)
+                    .unwrap_or_default()
+            }
             ValueView::Instance { class_name, .. } => format!("{}()", class_name),
             ValueView::Junction { kind, values } => {
                 let kind_str = match kind {

--- a/t/str-coercion-and-dispatch.t
+++ b/t/str-coercion-and-dispatch.t
@@ -156,4 +156,36 @@ ok "abc123def".comb(/\d/, :match).head ~~ Match,
     is $empty.chars, 0, 'and has zero chars';
 }
 
+# `bless` uses the same native scalar payload convention as the default
+# constructor. For Int, Raku's `bless` does not consume the named `value`
+# argument, so it keeps the zero payload; the assertions pin that distinction
+# as well as the representation paths.
+{
+    my class BlessStr is Str { }
+    my $new-str = BlessStr.new(value => "from-new");
+    my $bless-str = BlessStr.bless(value => "from-bless");
+    is $new-str.Str, "from-new", 'Str subclass .new keeps its payload';
+    is $bless-str.Str, "from-bless", 'Str subclass .bless keeps its payload';
+    is $new-str.gist, "from-new", 'Str subclass .new gist uses its payload';
+    is $bless-str.gist, "from-bless", 'Str subclass .bless gist uses its payload';
+    is $new-str.raku, '"from-new"', 'Str subclass .new raku uses its payload';
+    is $bless-str.raku, '"from-bless"', 'Str subclass .bless raku uses its payload';
+    is "$new-str", "from-new", 'Str subclass .new interpolation uses its payload';
+    is "$bless-str", "from-bless", 'Str subclass .bless interpolation uses its payload';
+
+    my class BlessInt is Int { }
+    my $new-int = BlessInt.new(42);
+    my $bless-int = BlessInt.bless(value => 42);
+    ok $new-int == 42, 'Int subclass .new keeps its numeric payload';
+    ok $bless-int == 0, 'Int subclass .bless keeps Raku\'s zero payload';
+    is $new-int.Str, "42", 'Int subclass .new Str uses its payload';
+    is $bless-int.Str, "0", 'Int subclass .bless Str uses its payload';
+    is $new-int.gist, "42", 'Int subclass .new gist uses its payload';
+    is $bless-int.gist, "0", 'Int subclass .bless gist uses its payload';
+    is $new-int.raku, "42", 'Int subclass .new raku uses its payload';
+    is $bless-int.raku, "0", 'Int subclass .bless raku uses its payload';
+    is "$new-int", "42", 'Int subclass .new interpolation uses its payload';
+    is "$bless-int", "0", 'Int subclass .bless interpolation uses its payload';
+}
+
 done-testing;


### PR DESCRIPTION
Closes #7759

## Summary

- Share native `Int`/`Str` subclass payload seeding between `new` and `bless`.
- Preserve the payload through stringification, gist, Raku representation, interpolation, and numeric comparisons.
- Add regression coverage for `new` and `bless`, plus a news entry.

## Tests

- `cargo fmt --all`
- `make lint`
- `make test`
- `make roast`
- `MUTSU_FUDGE=1 target/debug/mutsu t/str-coercion-and-dispatch.t`
