### PR TITLE
fix: parse adjacent colonpairs after declared s

### DIFF
--- a/news/2026-09/adjacent-colonpairs-after-declared-s.md
+++ b/news/2026-09/adjacent-colonpairs-after-declared-s.md
@@ -1,0 +1,2 @@
+Declared routines named `s` now accept adjacent colonpair arguments after
+whitespace instead of being misparsed as substitution regex adverbs.

--- a/src/parser/quote_shadow.rs
+++ b/src/parser/quote_shadow.rs
@@ -62,12 +62,17 @@ fn leading_ident_len(input: &str) -> usize {
 }
 
 /// Whether `rest` opens with an explicit quote adverb (`:g`, `:i`, `:!ratchet`,
-/// `:2nd`, ...), optionally after horizontal whitespace (`s :g/…/…/`).
+/// `:2nd`, ...).
 ///
 /// `::` is a package qualification, never an adverb.
 fn starts_with_quote_adverb(rest: &str) -> bool {
-    let trimmed = rest.trim_start_matches([' ', '\t']);
-    let Some(after_colon) = trimmed.strip_prefix(':') else {
+    // A space after a quote-language name makes it a normal call/listop
+    // boundary.  In particular, `sub s(*%h) { ... }; s :a1:b2` must call the
+    // declared routine; treating `:a1` as a quote adverb would commit the
+    // parser to a substitution and reject it as an unsupported regex adverb.
+    // The quote parser itself still accepts whitespace before an adverb when
+    // the name is not shadowed (`s :g/.../.../`).
+    let Some(after_colon) = rest.strip_prefix(':') else {
         return false;
     };
     after_colon
@@ -110,7 +115,7 @@ mod tests {
     #[test]
     fn adverb_detection() {
         assert!(starts_with_quote_adverb(":g/a/b/"));
-        assert!(starts_with_quote_adverb(" :g/a/b/"));
+        assert!(!starts_with_quote_adverb(" :g/a/b/"));
         assert!(starts_with_quote_adverb(":!ratchet/a/"));
         assert!(starts_with_quote_adverb(":2nd/a/"));
         assert!(!starts_with_quote_adverb("::Foo"));

--- a/t/issue-7749-adjacent-colonpairs.t
+++ b/t/issue-7749-adjacent-colonpairs.t
@@ -1,0 +1,20 @@
+use Test;
+
+plan 7;
+
+no worries;
+
+my $manna = :a1:b2:c3;
+is $manna.^name, 'Pair', 'an adjacent colonpair run stays a Pair';
+is $manna.raku, ':a1', 'the first value-shorthand pair wins as the term value';
+
+my $list = (:a1:b2:c3);
+is $list.^name, 'List', 'an adjacent colonpair run in parens is a List';
+is $list.elems, 3, 'the parenthesised list keeps all three pairs';
+
+sub s(*%h) {
+    is %h.elems, 2, 'a slurpy named argument receives both pairs';
+    is %h<a1>, True, 'the first slurpy named pair is present';
+    is %h<b2>, True, 'the second slurpy named pair is present';
+}
+s :a1:b2;


### PR DESCRIPTION
## Summary

- let whitespace-separated colonpairs call a declared `s` routine instead of entering substitution parsing
- add regression coverage for term, parenthesized-list, and slurpy named-argument forms
- add a release note

Closes #7749

## Validation

- `cargo fmt --all`
- `cargo clippy -- -D warnings`
- `make test`
- `make roast`