### PR TITLE
perf: stop deep-cloning the registry to answer a pure method-presence question

### DIFF
--- a/news/2026-09/registry-cow-clone-per-pure-read-dispatch.md
+++ b/news/2026-09/registry-cow-clone-per-pure-read-dispatch.md
@@ -1,0 +1,43 @@
+# A pure-read dispatch probe was deep-cloning the whole declaration registry
+
+`Interpreter::class_has_method` and `class_has_user_method` ask a question —
+"does this class, or anything in its MRO, define this method?" — and answer it
+from the declaration registry without writing anything. Both asked it through
+`registry_mut()`.
+
+That is not free. The registry is copy-on-write behind an `Arc`
+(`RegistryWriteGuard::deref_mut`): the first *mutable* deref taken while any
+other holder shares the `Arc` deep-clones the entire `Registry` — every class,
+role, method entry, function key and subset, with all of their `String` keys.
+With the Cro/OpenSSL/CBOR stack loaded that is 631 classes, 1757 method entries
+and 332 function keys, and the copy costs about 8.1 million instructions.
+
+The share is not exotic. A `supply` block that registers a `whenever` clones the
+interpreter for the callback (`clone_for_thread_excluding`), and the clone holds
+a registry share for as long as it lives. From that point on, *any* registry
+write pays a full copy.
+
+`Cro::HTTP2::GeneralParser` puts both halves in one loop. Each HEADERS frame
+registers one `whenever $cancellation` for the new stream, and dispatching the
+frame's `self!set-headers` private method reaches `class_has_user_method`. So
+every frame shared the `Arc` and then immediately wrote through it: one full
+registry deep clone per frame, `registry-cow: clones=` tracking the frame count
+exactly (61 clones for 60 frames).
+
+Both probes now consult `Registry::class_has_method_readonly` /
+`class_has_user_method_readonly` under a **read** guard first. These are twins of
+the existing `Registry::class_mro_readonly`, whose own doc comment already spelled
+out the rule these two call sites had missed: resolve every MRO shape that needs
+no cache write, and return `None` exactly when the write side would compute *and*
+cache, so the caller can fall back. Only that genuine cache-fill case now takes
+`registry_mut()`.
+
+On the HTTP/2 request-parser benchmark from
+[#7667](https://github.com/tokuhirom/mutsu/issues/7667) — 60 HEADERS frames fed
+straight into `Cro::HTTP2::RequestParser` — the registry COW clones drop from 61
+to 2, and the per-frame cost falls from 94.3M to 82.4M instructions, **12.6%
+fewer**, measured with `callgrind` as the difference between a 60-frame and a
+0-frame run so module loading cancels out.
+
+`tests/registry_cow_not_paid_per_supply_registration.rs` pins it by parsing 4 and
+then 24 frames and asserting the clone count does not grow with the frame count.

--- a/src/runtime/class_introspection.rs
+++ b/src/runtime/class_introspection.rs
@@ -15,11 +15,31 @@ pub(crate) enum UserMethodOrAccessor {
 
 impl Interpreter {
     pub(crate) fn class_has_method(&mut self, class_name: &str, method_name: &str) -> bool {
+        // Read guard first: this is a pure question, and `registry_mut()`'s
+        // first mutable deref deep-clones the WHOLE registry whenever a thread
+        // clone shares the `Arc` (`RegistryWriteGuard::deref_mut`). A `supply`
+        // block registering one `whenever` is enough to make that share
+        // permanent, so asking through the write side cost one full registry
+        // copy per dispatch that reached here — 8.7% of the per-frame work in
+        // Cro's HTTP/2 request parser (#7667).
+        if let Some(answer) = self
+            .registry()
+            .class_has_method_readonly(class_name, method_name)
+        {
+            return answer;
+        }
         self.registry_mut()
             .class_has_method(class_name, method_name)
     }
 
     pub(super) fn class_has_user_method(&mut self, class_name: &str, method_name: &str) -> bool {
+        // See `class_has_method` above for why the read guard comes first.
+        if let Some(answer) = self
+            .registry()
+            .class_has_user_method_readonly(class_name, method_name)
+        {
+            return answer;
+        }
         self.registry_mut()
             .class_has_user_method(class_name, method_name)
     }

--- a/src/runtime/registry.rs
+++ b/src/runtime/registry.rs
@@ -1147,6 +1147,43 @@ impl Registry {
     /// user coercion method (e.g. `method Str {...}`) via `run_instance_method`
     /// versus routing a native builtin method (e.g. `IO::Path.Str`) through the
     /// native dispatcher. Pure registry MRO walk.
+    /// Read-only twin of [`Registry::class_has_method`]: answers from
+    /// [`Registry::class_mro_readonly`] and returns `None` exactly when that
+    /// declines (a registered class whose MRO is not cached yet), so the caller
+    /// falls back to the `&mut` side. Asking this question through
+    /// `registry_mut()` used to pay a full-registry COW clone on every call
+    /// made while a thread clone shares the `Arc` — see the note on
+    /// [`Registry::class_mro_readonly`].
+    pub(crate) fn class_has_method_readonly(
+        &self,
+        class_name: &str,
+        method_name: &str,
+    ) -> Option<bool> {
+        let mro = self.class_mro_readonly(class_name)?;
+        Some(mro.iter().any(|cn| {
+            self.user_method_overloads(cn.as_str(), method_name)
+                .is_some()
+                || self
+                    .classes
+                    .get(cn.as_str())
+                    .is_some_and(|class| class.native_methods.contains(method_name))
+        }))
+    }
+
+    /// Read-only twin of [`Registry::class_has_user_method`]. Same contract as
+    /// [`Registry::class_has_method_readonly`].
+    pub(crate) fn class_has_user_method_readonly(
+        &self,
+        class_name: &str,
+        method_name: &str,
+    ) -> Option<bool> {
+        let mro = self.class_mro_readonly(class_name)?;
+        Some(mro.iter().any(|cn| {
+            self.user_method_overloads(cn.as_str(), method_name)
+                .is_some()
+        }))
+    }
+
     pub(crate) fn class_has_user_method(&mut self, class_name: &str, method_name: &str) -> bool {
         let mro = self.class_mro(class_name);
         for cn in mro.iter() {

--- a/tests/registry_cow_not_paid_per_supply_registration.rs
+++ b/tests/registry_cow_not_paid_per_supply_registration.rs
@@ -1,0 +1,95 @@
+//! Pins the read-guard fast path in `Interpreter::class_has_method` /
+//! `class_has_user_method` (#7667).
+//!
+//! The declaration registry is copy-on-write behind an `Arc`
+//! (`RegistryWriteGuard::deref_mut`): the first *mutable* deref after any other
+//! holder shares the `Arc` deep-clones the whole `Registry` -- every class,
+//! role, method entry and function key, with all their `String` keys. A
+//! `supply` block that registers a `whenever` clones the interpreter for the
+//! callback (`clone_for_thread_excluding`), and that clone holds a share, so
+//! from then on *any* registry write pays a full copy.
+//!
+//! `class_has_method` / `class_has_user_method` ask a pure question, but used
+//! to ask it through `registry_mut()`. Cro's HTTP/2 request parser reaches
+//! `class_has_user_method` once per HEADERS frame (the `self!set-headers`
+//! private dispatch) and registers one `whenever` per stream, so the two
+//! interleaved: one full registry deep clone per frame, 8.7% of the frame's
+//! instructions. Both now consult `class_mro_readonly` under a read guard and
+//! only fall back to the write side when that declines.
+//!
+//! A regression shows up as `registry-cow: clones=` growing with the frame
+//! count instead of staying flat.
+
+use std::process::Command;
+
+const PROGRAM: &str = r#"
+use Cro::HTTP2::Frame;
+use Cro::HTTP2::RequestParser;
+use Cro::HTTP2::ConnectionState;
+use HTTP::HPACK;
+
+my $enc = HTTP::HPACK::Encoder.new;
+my $blob = $enc.encode-headers([
+    HTTP::HPACK::Header.new(name => ':method',    value => 'GET'),
+    HTTP::HPACK::Header.new(name => ':path',      value => '/'),
+    HTTP::HPACK::Header.new(name => ':scheme',    value => 'https'),
+    HTTP::HPACK::Header.new(name => ':authority', value => 'example.com'),
+]);
+my $n = +@*ARGS[0];
+my $cs = Cro::HTTP2::ConnectionState.new;
+my $in = Supplier.new;
+my $out = Cro::HTTP2::RequestParser.new.transformer($in.Supply, connection-state => $cs);
+my $seen = 0;
+$out.tap({ $seen++ });
+for ^$n -> $i {
+    $in.emit(Cro::HTTP2::Frame::Headers.new(
+        flags => 5, stream-identifier => 1 + 2 * $i, headers => $blob));
+}
+say $seen;
+"#;
+
+/// `(requests parsed, registry COW clones)` for a run that feeds `frames`
+/// HEADERS frames through the HTTP/2 request parser.
+fn run(frames: u32) -> (u32, u64) {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_mutsu"));
+    cmd.arg("-e").arg(PROGRAM).arg(frames.to_string());
+    cmd.env("MUTSU_VM_STATS", "1");
+    let out = cmd.output().expect("failed to spawn mutsu");
+    let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
+    assert!(
+        out.status.success(),
+        "run failed\nstdout: {stdout}\nstderr: {stderr}"
+    );
+    let parsed = stdout
+        .lines()
+        .last()
+        .and_then(|l| l.trim().parse().ok())
+        .unwrap_or_else(|| panic!("no frame count on stdout: {stdout}"));
+    let clones = stderr
+        .lines()
+        .find_map(|l| l.split("registry-cow: clones=").nth(1))
+        .and_then(|v| v.trim().parse().ok())
+        .unwrap_or_else(|| panic!("no registry-cow line in stats: {stderr}"));
+    (parsed, clones)
+}
+
+#[test]
+fn parsing_more_http2_headers_frames_does_not_clone_the_registry_more() {
+    let (few_parsed, few_clones) = run(4);
+    let (many_parsed, many_clones) = run(24);
+    assert_eq!(few_parsed, 4, "parser did not emit one request per frame");
+    assert_eq!(many_parsed, 24, "parser did not emit one request per frame");
+    // Before the fix this was `frames + 1` on both runs (5 and 25). The bound
+    // is deliberately loose: what must not happen is *growth with the frame
+    // count*, not any particular small constant.
+    assert!(
+        many_clones <= few_clones + 2,
+        "registry COW clones grew with the frame count: {few_clones} for 4 frames, \
+         {many_clones} for 24 -- a pure-read dispatch probe is taking registry_mut() again"
+    );
+    assert!(
+        many_clones < 10,
+        "registry COW clones should stay a small constant, got {many_clones}"
+    );
+}


### PR DESCRIPTION
## What

`Interpreter::class_has_method` and `class_has_user_method` ask whether a class
or its MRO defines a method. Neither writes anything, but both asked through
`registry_mut()`.

That is not free. The declaration registry is copy-on-write behind an `Arc`:
`RegistryWriteGuard::deref_mut`'s first mutable deref taken while another holder
shares the `Arc` deep-clones the whole `Registry` — every class, role, method
entry, function key and subset, with all their `String` keys. With the
Cro/OpenSSL/CBOR stack loaded that is 631 classes, 1757 method entries and 332
function keys, and the copy costs ~8.1M instructions.

The share is ordinary, not exotic: a `supply` block that registers a `whenever`
clones the interpreter for the callback (`clone_for_thread_excluding`), and the
clone holds a registry share for as long as it lives. From then on *any* registry
write pays a full copy.

`Cro::HTTP2::GeneralParser` puts both halves in one loop. Each HEADERS frame
registers one `whenever $cancellation` for the new stream, and dispatching the
frame's `self!set-headers` private method reaches `class_has_user_method`. So
every frame shared the `Arc` and then immediately wrote through it: one full
registry deep clone per frame, with `registry-cow: clones=` tracking the frame
count exactly (61 clones for 60 frames).

## How

Both probes now consult the new `Registry::class_has_method_readonly` /
`class_has_user_method_readonly` under a **read** guard first. These are twins of
the existing `Registry::class_mro_readonly`, whose own doc comment already spelled
out the rule these two call sites had missed: resolve every MRO shape that needs
no cache write, and return `None` exactly when the write side would compute *and*
cache, so the caller can fall back. Only that genuine cache-fill case still takes
`registry_mut()`.

No behaviour change — the readonly twins walk the same MRO and consult the same
`user_method_overloads` / `ClassDef::native_methods` the write-side versions do.

## Measurements

HTTP/2 request-parser benchmark from #7667 (60 HEADERS frames fed straight into
`Cro::HTTP2::RequestParser`), release build, `callgrind`, taking the difference
between a 60-frame and a 0-frame run so module loading cancels out:

| | before | after |
| --- | --- | --- |
| `registry-cow: clones` over 60 frames | 61 | 2 |
| instructions per HEADERS frame | 94,292,987 | 82,388,759 |

**12.6% fewer instructions per frame.** (Local wall clock moved from ~26 ms to
~20 ms per frame, but the instruction counts are the deterministic number.)

## Test

`tests/registry_cow_not_paid_per_supply_registration.rs` parses 4 and then 24
HEADERS frames through the real bundled `Cro::HTTP2::RequestParser` and asserts
the COW clone count does not grow with the frame count. Before the fix it was
`frames + 1` on both runs (5 and 25); it is now 2 on both.

Local `make lint`, `make test` (3919 files, 41662 tests, PASS) and `make roast`
were all run. `make roast` reports only the three container-only failures
documented in `docs/agent-environments.md` (`6.c/S32-io/file-tests.t` and
`S16-filehandles/filetest.t` — `chmod` assertions meaningless under `uid 0` — and
`S32-io/IO-Socket-Async.t` — sandboxed network), with exactly the test numbers
that doc lists.

Part of #7667 (not a full fix — the remaining per-frame cost is dominated by
`clone_for_thread_excluding` at 17.2%, which is the next slice).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NX9vs4NbdKXUu6MoAaHpSz

---
_Generated by [Claude Code](https://claude.ai/code/session_01NX9vs4NbdKXUu6MoAaHpSz)_