### PR TITLE
fix: report unhandled sunk start exceptions

### DIFF
--- a/news/2026-09/unobserved-start-exceptions.md
+++ b/news/2026-09/unobserved-start-exceptions.md
@@ -1,0 +1,1 @@
+`start` blocks sunk without retaining their Promise now report unhandled worker exceptions when the broken Promise is discarded, while awaited and status-inspected Promises keep their existing behavior.

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -927,6 +927,10 @@ impl Compiler {
         )
     }
 
+    fn is_start_call(expr: &Expr) -> bool {
+        matches!(expr, Expr::Call { name, .. } if name.resolve() == "start")
+    }
+
     pub(super) fn compile_stmt(&mut self, stmt: &Stmt) {
         // See `Compiler::compile_expr` — the declaration side of a BEGIN-time
         // interpolated extended identifier (`my $a:foo«$c» = 1`).
@@ -949,6 +953,9 @@ impl Compiler {
                 }
                 self.compile_condition_expr(expr);
                 self.sunk_list_assign_result = false;
+                if Self::is_start_call(expr) {
+                    self.code.emit(OpCode::MarkPromiseSink);
+                }
                 // Assignment statements are wanted, not sunk (rakudo): storing
                 // an unhandled Failure via `%h{$k} = ...;` / `@a[$i] = ...;`
                 // (also with an `if`/`with` statement modifier) must not throw

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,6 +60,9 @@ static ALLOC: alloc_stats::CountingAllocator = alloc_stats::CountingAllocator;
 /// worker's. Embedders that drive `Interpreter` from a long-lived thread and
 /// enable `MUTSU_GC` should call this on that thread too.
 pub fn gc_register_main_thread() {
+    // Initialize the process-local mutsu thread identity before any worker can
+    // ask for its fallback OS-thread-derived id.
+    let _ = runtime::current_mutsu_thread_id();
     gc::enter_mutator_worker();
     gc::mark_thread_registered(true);
 }

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -1342,6 +1342,9 @@ pub(crate) enum OpCode {
     // -- Stack manipulation --
     Dup,
     Pop,
+    /// Mark a sunk `start` promise for Raku's deferred unhandled-exception
+    /// diagnostic, then let the following `SinkPop` discard its value.
+    MarkPromiseSink,
     /// Pop with sink context — throws unhandled Failures.
     /// The first bool (`user_sink`) is `true` when the sunk value is a
     /// syntactically fresh rvalue (e.g. a method call / `Foo.new`) that may

--- a/src/runtime/builtins_system.rs
+++ b/src/runtime/builtins_system.rs
@@ -229,6 +229,7 @@ impl Interpreter {
             // CP-3 collapse: the thread's cloned Interpreter *is* the VM — run the
             // block on it directly instead of wrapping it in a sub-VM.
             let mut thread_interp = thread_interp;
+            promise.set_thread_id(crate::runtime::current_mutsu_thread_id());
             // Worker bodies run via `call_value` without the main thread's
             // `run_top` panic boundary, so guard them here: a Rust panic in
             // user code becomes a catchable broken-Promise error (X::AdHoc)

--- a/src/runtime/methods_promise.rs
+++ b/src/runtime/methods_promise.rs
@@ -130,6 +130,7 @@ impl Interpreter {
         args: Vec<Value>,
         target: &Value,
     ) -> Result<Value, RuntimeError> {
+        shared.mark_observed();
         match method {
             "result" => {
                 // Wait for the promise to resolve (blocks if Planned)

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -2373,6 +2373,20 @@ struct PromiseState {
     /// (and mutsu's own internal resolution paths, which bypass the
     /// user-facing methods) may resolve a vowed promise afterwards.
     vow_taken: bool,
+    /// Whether this promise was a `start` expression whose value was sunk.
+    /// Raku reports a failure from that shape when the promise is destroyed,
+    /// but not from an explicitly retained `Promise`.
+    report_unhandled: bool,
+    /// Whether user code observed this promise's result or status. An
+    /// observed Broken promise belongs to its observer and must not also emit
+    /// the sink-context diagnostic at destruction time.
+    observed: bool,
+    /// Guards the diagnostic against both the GC finalizer and Rust `Drop`
+    /// seeing the same promise death.
+    unhandled_reported: bool,
+    /// The mutsu thread that ran the scheduled code, used in the diagnostic
+    /// printed for an unobserved Broken promise.
+    thread_id: i64,
 }
 
 #[derive(Debug, Clone)]

--- a/src/value/value_async.rs
+++ b/src/value/value_async.rs
@@ -12,6 +12,53 @@ impl std::fmt::Debug for PromiseState {
     }
 }
 
+impl PromiseState {
+    pub(super) fn take_unhandled_report(&mut self) -> Option<(Value, i64)> {
+        if !self.report_unhandled
+            || self.status != "Broken"
+            || self.observed
+            || self.unhandled_reported
+        {
+            return None;
+        }
+        self.unhandled_reported = true;
+        Some((self.result.clone(), self.thread_id))
+    }
+}
+
+impl Drop for PromiseState {
+    fn drop(&mut self) {
+        if let Some((result, thread_id)) = self.take_unhandled_report() {
+            report_unhandled_promise(&result, thread_id);
+        }
+    }
+}
+
+pub(super) fn report_unhandled_promise(result: &Value, thread_id: i64) {
+    let (message, backtrace) = match result.view() {
+        ValueView::Instance { attributes, .. } => {
+            let attrs = attributes.as_map();
+            let message = attrs
+                .get("message")
+                .map(Value::to_string_value)
+                .unwrap_or_else(|| result.to_string_value());
+            let backtrace = attrs.get("backtrace").map(Value::to_string_value);
+            (message, backtrace)
+        }
+        _ => (result.to_string_value(), None),
+    };
+    eprintln!(
+        "Unhandled exception in code scheduled on thread {}",
+        thread_id
+    );
+    eprintln!("{message}");
+    if let Some(backtrace) = backtrace
+        && !backtrace.is_empty()
+    {
+        eprintln!("{backtrace}");
+    }
+}
+
 impl SharedPromise {
     /// This promise's never-reused `.WHICH` id. It replaces the inner
     /// allocation's ADDRESS, which is unique only among live objects:
@@ -39,6 +86,10 @@ impl SharedPromise {
                     thread_payload: None,
                     waiters: Vec::new(),
                     vow_taken: false,
+                    report_unhandled: false,
+                    observed: false,
+                    unhandled_reported: false,
+                    thread_id: 0,
                 }),
                 Condvar::new(),
             )),
@@ -59,6 +110,10 @@ impl SharedPromise {
                     thread_payload: None,
                     waiters: Vec::new(),
                     vow_taken: false,
+                    report_unhandled: false,
+                    observed: false,
+                    unhandled_reported: false,
+                    thread_id: 0,
                 }),
                 Condvar::new(),
             )),
@@ -89,6 +144,26 @@ impl SharedPromise {
     pub(crate) fn mark_vowed(&self) {
         let (lock, _) = &*self.inner;
         lock.lock().unwrap().vow_taken = true;
+    }
+
+    /// Mark a sunk `start` promise so a Broken result is reported if nobody
+    /// observes it before the last reference disappears.
+    pub(crate) fn mark_unhandled(&self) {
+        let (lock, _) = &*self.inner;
+        lock.lock().unwrap().report_unhandled = true;
+    }
+
+    /// Mark the promise as observed by user code. This suppresses the
+    /// destruction-time diagnostic; `await`/`.result` still rethrow Broken
+    /// promises through their normal paths.
+    pub(crate) fn mark_observed(&self) {
+        let (lock, _) = &*self.inner;
+        lock.lock().unwrap().observed = true;
+    }
+
+    pub(crate) fn set_thread_id(&self, thread_id: i64) {
+        let (lock, _) = &*self.inner;
+        lock.lock().unwrap().thread_id = thread_id;
     }
 
     pub(crate) fn class_name(&self) -> Symbol {
@@ -254,6 +329,7 @@ impl SharedPromise {
     }
 
     pub(crate) fn wait(&self) -> (Value, String, String) {
+        self.mark_observed();
         // GC safepoint (§9.2a `await`): the await entry boundary, before the
         // state lock is taken (a collect here can run finalizers that touch
         // other promises/channels, so it must not hold this mutex).

--- a/src/value/value_gc.rs
+++ b/src/value/value_gc.rs
@@ -229,6 +229,14 @@ impl Trace for (Mutex<PromiseState>, Condvar) {
             state.waiters.clear();
         }
     }
+
+    fn finalize(&self) {
+        if let Ok(mut state) = self.0.lock()
+            && let Some((result, thread_id)) = state.take_unhandled_report()
+        {
+            super::value_async::report_unhandled_promise(&result, thread_id);
+        }
+    }
 }
 
 /// A channel node's `Value` edges are its buffered `queue`, its `failure`, and

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -3236,6 +3236,12 @@ impl Interpreter {
                 self.pop_warn_suppression();
                 *ip += 1;
             }
+            OpCode::MarkPromiseSink => {
+                if let Some(ValueView::Promise(shared)) = self.stack.last().map(Value::view) {
+                    shared.mark_unhandled();
+                }
+                *ip += 1;
+            }
             OpCode::SinkPopAssign => {
                 self.sync_source_line(code, *ip);
                 if let Some(val) = self.stack.pop() {

--- a/src/vm/vm_jit_support.rs
+++ b/src/vm/vm_jit_support.rs
@@ -57,6 +57,7 @@ pub(super) fn step_supported(op: &OpCode) -> bool {
             | OpCode::LoadFalse
             | OpCode::Dup
             | OpCode::Pop
+            | OpCode::MarkPromiseSink
             // Variable reads
             | OpCode::GetGlobal(_)
             | OpCode::GetOurVar(_)

--- a/t/issue-7771-unhandled-start.t
+++ b/t/issue-7771-unhandled-start.t
@@ -1,0 +1,38 @@
+use Test;
+
+# A sunk `start` owns an implicit unhandled-exception handler. The diagnostic
+# is emitted only when the Broken Promise is destroyed without being observed;
+# retaining it, awaiting it, or inspecting its status leaves the existing
+# Promise behavior in place.
+
+plan 11;
+
+{
+    my $p = run $*EXECUTABLE, '-e',
+        'start { die "boom" }; sleep 0.3; say "hello";', :out, :err;
+    is $p.exitcode, 0, 'an unawaited start does not change the process exit status';
+    is $p.out.slurp(:close), "hello\n", 'the mainline output is preserved';
+    my $err = $p.err.slurp(:close);
+    like $err, /'Unhandled exception in code scheduled on thread'/,
+        'an unobserved sunk start reports its unhandled exception';
+    like $err, /'boom'/, 'the diagnostic includes the exception message';
+
+    # The worker-side exception retains its source backtrace as well.
+    like $err, /'in block'/, 'the diagnostic includes the worker backtrace';
+}
+
+{
+    my $p = run $*EXECUTABLE, '-e',
+        'my $p = start { die "boom" }; try await $p; say "hello";', :out, :err;
+    is $p.exitcode, 0, 'awaiting a broken start remains catchable';
+    is $p.out.slurp(:close), "hello\n", 'the awaited case reaches the mainline';
+    is $p.err.slurp(:close), '', 'awaiting a broken start does not report twice';
+}
+
+{
+    my $p = run $*EXECUTABLE, '-e',
+        'my $p = start { die "boom" }; sleep 0.3; say $p.status;', :out, :err;
+    is $p.exitcode, 0, 'status inspection keeps the process successful';
+    is $p.out.slurp(:close), "Broken\n", 'status inspection sees the Broken state';
+    is $p.err.slurp(:close), '', 'status inspection suppresses the sink diagnostic';
+}


### PR DESCRIPTION
## Summary

- report failures from sunk `start` Promises when the broken Promise is discarded
- suppress duplicate diagnostics when the Promise is awaited or its status is inspected
- add regression coverage and a release note

## Tests

- `make lint`
- `make test`
- `make roast`

Closes #7771
