### PR TITLE
fix: compose built-in hierarchy roles

### DIFF
--- a/news/2026-09/builtin-type-hierarchy-roles.md
+++ b/news/2026-09/builtin-type-hierarchy-roles.md
@@ -1,0 +1,25 @@
+# Built-in type hierarchy roles can be composed by user code
+
+`QuantHash`, `Stringy`, `Systemic`, `Baggy`, `PositionalBindFailover` and
+`Blob[T]` are roles in Raku's built-in type hierarchy. mutsu already modeled
+their native behavior, but did not consistently recognize them as roles when a
+user declared a role with `does`:
+
+```raku
+role R does QuantHash { }
+role S does Blob[uint8] { }
+class C does Systemic { }
+```
+
+Those declarations now compile. The shared built-in-role registry is used by
+role declaration, class composition, role type checking and the role-parent
+walk. Native parent relationships such as `Baggy` → `QuantHash` and
+`Blob[T]` → `Stringy` are included as well, so a user role that composes one of
+these roles retains the expected type relationships and its methods compose
+onto consuming classes.
+
+The built-in `Compiler`, `Distro`, `Kernel`, `Raku` and `VM` classes now record
+their `Systemic` composition, making `$*DISTRO ~~ Systemic` agree with Rakudo.
+
+The behavior is pinned by
+`t/issue-7780-builtin-type-hierarchy-roles.t`.

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -32,7 +32,9 @@ impl Compiler {
             // Well-known builtin types should not be package-qualified.
             // "Grammar" inside a module should stay "Grammar", not become
             // "MyModule::Grammar".
-            if matches!(
+            if crate::runtime::types::is_builtin_role_name(
+                p.split_once('[').map(|(base, _)| base).unwrap_or(p),
+            ) || matches!(
                 p.as_str(),
                 "Any"
                     | "Cool"

--- a/src/runtime/methods_classhow_parents.rs
+++ b/src/runtime/methods_classhow_parents.rs
@@ -85,7 +85,7 @@ impl Interpreter {
     /// only, never composed roles.
     fn parent_is_role(&self, name: &str) -> bool {
         let base = name.split_once('[').map(|(b, _)| b).unwrap_or(name);
-        self.is_role(base)
+        self.is_role_type_name(base)
     }
 
     /// The direct parents used to build a `:tree`, filling in the implicit
@@ -211,7 +211,14 @@ impl Interpreter {
         // the name itself must use role semantics
         // (`X::Syntax.^roles` -> `(X::Comp)`, not `()`).
         // For instances (punned roles), include the role itself in the list.
-        let is_role = self.registry().roles.contains_key(class_name);
+        // `Blob` and `Buf` are represented by native ClassDefs as well as
+        // native roles. Keep their class-side composed-role metadata as the
+        // source for `.^roles`; treating those dual names as bare roles would
+        // incorrectly turn `Buf.^roles(:!transitive)` from `Blob[T]` into the
+        // full role-parent closure.
+        let is_role = self.is_role(class_name)
+            || (crate::runtime::types::is_builtin_role_name(class_name)
+                && !self.registry().classes.contains_key(class_name));
         if is_role {
             let mut result = Vec::new();
             // For instances of punned roles, include the role itself first
@@ -219,23 +226,20 @@ impl Interpreter {
                 result.push(class_name.to_string());
             }
             if non_transitive {
-                if !is_instance && let Some(parents) = self.registry().role_parents.get(class_name)
-                {
-                    result.extend(parents.clone());
+                if !is_instance {
+                    result.extend(self.registry().role_parents_of(class_name));
                 }
                 return result;
             }
-            if let Some(parents) = self.registry().role_parents.get(class_name) {
-                let mut seen: std::collections::HashSet<String> = result.iter().cloned().collect();
-                for p in parents {
-                    if seen.insert(p.clone()) {
-                        result.push(p.clone());
-                    }
+            let parents = self.registry().role_parents_of(class_name);
+            let mut seen: std::collections::HashSet<String> = result.iter().cloned().collect();
+            for p in &parents {
+                if seen.insert(p.clone()) {
+                    result.push(p.clone());
                 }
-                let parents_clone = parents.clone();
-                for p in &parents_clone {
-                    self.collect_transitive_roles(p, &mut result, &mut seen);
-                }
+            }
+            for p in &parents {
+                self.collect_transitive_roles(p, &mut result, &mut seen);
             }
             return result;
         }
@@ -337,11 +341,9 @@ impl Interpreter {
         let mut transitive = std::collections::HashSet::new();
         for r in &all {
             let base = r.split_once('[').map(|(b, _)| b).unwrap_or(r.as_str());
-            if let Some(parents) = self.registry().role_parents.get(base).cloned() {
-                for p in parents {
-                    transitive.insert(p.clone());
-                    self.collect_transitive_set(&p, &mut transitive);
-                }
+            for p in self.registry().role_parents_of(base) {
+                transitive.insert(p.clone());
+                self.collect_transitive_set(&p, &mut transitive);
             }
         }
         all.into_iter()
@@ -359,11 +361,9 @@ impl Interpreter {
             .split_once('[')
             .map(|(b, _)| b)
             .unwrap_or(role_name);
-        if let Some(parents) = self.registry().role_parents.get(base) {
-            for p in parents {
-                if result.insert(p.clone()) {
-                    self.collect_transitive_set(p, result);
-                }
+        for p in self.registry().role_parents_of(base) {
+            if result.insert(p.clone()) {
+                self.collect_transitive_set(&p, result);
             }
         }
     }
@@ -378,12 +378,10 @@ impl Interpreter {
             .split_once('[')
             .map(|(b, _)| b)
             .unwrap_or(role_name);
-        if let Some(parents) = self.registry().role_parents.get(base) {
-            for p in parents {
-                if seen.insert(p.clone()) {
-                    result.push(p.clone());
-                    self.collect_transitive_roles(p, result, seen);
-                }
+        for p in self.registry().role_parents_of(base) {
+            if seen.insert(p.clone()) {
+                result.push(p.clone());
+                self.collect_transitive_roles(&p, result, seen);
             }
         }
     }

--- a/src/runtime/registration_class_body_does.rs
+++ b/src/runtime/registration_class_body_does.rs
@@ -30,11 +30,8 @@ impl Interpreter {
             .split_once('[')
             .map(|(base, _)| base)
             .unwrap_or(role_name_str.as_str());
-        if !self.registry().roles.contains_key(&role_name_str)
-            && matches!(
-                role_name_str.as_str(),
-                "Real" | "Numeric" | "Cool" | "Any" | "Mu" | "Positional" | "Associative"
-            )
+        if !self.registry().roles.contains_key(base_role_name)
+            && crate::runtime::types::is_builtin_role_name(base_role_name)
         {
             if !cx.class_def.parents.iter().any(|p| p == &role_name_str) {
                 cx.class_def.parents.insert(0, role_name_str.clone());

--- a/src/runtime/registration_class_compose_body.rs
+++ b/src/runtime/registration_class_compose_body.rs
@@ -438,6 +438,7 @@ impl Interpreter {
                         }
                     }
                 } else if self.registry().classes.contains_key(parent_base)
+                    && !self.is_role_type_name(parent_base)
                     && !cx.class_def.parents.iter().any(|p| p == &resolved_parent)
                 {
                     cx.class_def.parents.push(resolved_parent.clone());
@@ -473,7 +474,7 @@ impl Interpreter {
                     if let Some(rparents) = self.registry().role_parents.get(&role_name).cloned() {
                         for rp in rparents {
                             let rp_base = rp.split_once('[').map(|(b, _)| b).unwrap_or(rp.as_str());
-                            if self.registry().roles.contains_key(rp_base) {
+                            if self.is_role_type_name(rp_base) {
                                 // It's a role - add as composed role and recurse
                                 if !punned_composed_roles.contains(&rp) {
                                     punned_composed_roles.push(rp.clone());

--- a/src/runtime/registration_class_compose_record.rs
+++ b/src/runtime/registration_class_compose_record.rs
@@ -99,7 +99,7 @@ impl Interpreter {
                     if let Some(rparents) = self.registry().role_parents.get(&role_name).cloned() {
                         for rp in rparents {
                             let rp_base = rp.split_once('[').map(|(b, _)| b).unwrap_or(rp.as_str());
-                            if self.registry().roles.contains_key(rp_base) {
+                            if self.is_role_type_name(rp_base) {
                                 // It's a sub-role, recurse
                                 role_stack.push(rp_base.to_string());
                             } else if self.registry().classes.contains_key(rp_base)
@@ -149,7 +149,7 @@ impl Interpreter {
                     if let Some(rparents) = self.registry().role_parents.get(&role_name).cloned() {
                         for rp in rparents {
                             let rp_base = rp.split_once('[').map(|(b, _)| b).unwrap_or(rp.as_str());
-                            if self.registry().roles.contains_key(rp_base) {
+                            if self.is_role_type_name(rp_base) {
                                 role_stack.push(rp_base.to_string());
                             }
                         }

--- a/src/runtime/registration_role_body.rs
+++ b/src/runtime/registration_role_body.rs
@@ -187,12 +187,12 @@ impl Interpreter {
         // resolution the class-body DoesDecl path already does.
         // JSON::Unmarshal composes all its CustomUnmarshaller roles
         // this way.
-        let role_name_str = if !self.registry().roles.contains_key(&role_name_str)
+        let role_name_str = if !self.is_role_type_name(&role_name_str)
             && !self.registry().classes.contains_key(&role_name_str)
             && !role_name_str.contains('[')
         {
             let resolved = self.resolve_declared_type_name(&role_name_str);
-            if self.registry().roles.contains_key(&resolved) {
+            if self.is_role_type_name(&resolved) {
                 resolved
             } else {
                 role_name_str
@@ -213,11 +213,7 @@ impl Interpreter {
             .map(|(b, _)| b)
             .unwrap_or(role_name_str.as_str());
         if cx.type_params.iter().any(|tp| tp == base_role_name)
-            || (!self.registry().roles.contains_key(base_role_name)
-                && matches!(
-                    base_role_name,
-                    "Real" | "Numeric" | "Cool" | "Any" | "Mu" | "Positional" | "Associative"
-                ))
+            || crate::runtime::types::is_builtin_role_name(base_role_name)
         {
             self.registry_mut()
                 .role_parents

--- a/src/runtime/registry.rs
+++ b/src/runtime/registry.rs
@@ -1343,20 +1343,29 @@ impl Registry {
     pub(crate) fn builtin_role_parents(role_name: &str) -> &'static [&'static str] {
         match role_name {
             "Real" => &["Numeric"],
+            "QuantHash" => &["Associative"],
             "Setty" | "Baggy" => &["QuantHash", "Associative"],
             "Mixy" => &["Baggy"],
+            "Sequence" => &["PositionalBindFailover"],
+            "Blob" => &["Positional[T]", "Stringy"],
+            "Buf" => &["Blob[T]", "Positional[T]", "Stringy"],
             _ => &[],
         }
     }
 
     /// Every role the named role composes, declared or built-in.
     pub(crate) fn role_parents_of(&self, role_name: &str) -> Vec<String> {
+        let base_role_name = role_name
+            .split_once('[')
+            .map(|(base, _)| base)
+            .unwrap_or(role_name);
         let mut parents: Vec<String> = self
             .role_parents
             .get(role_name)
+            .or_else(|| self.role_parents.get(base_role_name))
             .cloned()
             .unwrap_or_default();
-        for builtin in Self::builtin_role_parents(role_name) {
+        for builtin in Self::builtin_role_parents(base_role_name) {
             if !parents.iter().any(|p| p == builtin) {
                 parents.push((*builtin).to_string());
             }

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -2528,6 +2528,9 @@ impl Interpreter {
                 roles.iter().map(|r| (*r).to_string()).collect(),
             );
         }
+        for class_name in ["Compiler", "Distro", "Kernel", "Raku", "VM"] {
+            ccr.insert(class_name.to_string(), vec!["Systemic".to_string()]);
+        }
         // Built-in role definitions (PR-A slice 4: roles now live in the
         // shared Registry instead of an Interpreter field).
         registry.roles = {

--- a/src/runtime/seq_helpers/role_type.rs
+++ b/src/runtime/seq_helpers/role_type.rs
@@ -7,25 +7,29 @@ impl Interpreter {
         if lhs_role == rhs_role {
             return true;
         }
-        let mut stack = vec![lhs_role.to_string()];
+        let mut stack = vec![
+            lhs_role
+                .split_once('[')
+                .map(|(base, _)| base)
+                .unwrap_or(lhs_role)
+                .to_string(),
+        ];
         let mut seen = HashSet::new();
         while let Some(role) = stack.pop() {
             if !seen.insert(role.clone()) {
                 continue;
             }
-            if let Some(parents) = self.registry().role_parents.get(&role) {
-                for parent in parents {
-                    // A parent may be recorded in parametric form ("P2[Int]");
-                    // compare and continue the walk on its base name.
-                    let parent_base = parent
-                        .split_once('[')
-                        .map(|(base, _)| base)
-                        .unwrap_or(parent.as_str());
-                    if parent_base == rhs_role {
-                        return true;
-                    }
-                    stack.push(parent_base.to_string());
+            for parent in self.registry().role_parents_of(&role) {
+                // A parent may be recorded in parametric form ("P2[Int]");
+                // compare and continue the walk on its base name.
+                let parent_base = parent
+                    .split_once('[')
+                    .map(|(base, _)| base)
+                    .unwrap_or(parent.as_str());
+                if parent_base == rhs_role {
+                    return true;
                 }
+                stack.push(parent_base.to_string());
             }
         }
         false

--- a/src/runtime/types/type_matching.rs
+++ b/src/runtime/types/type_matching.rs
@@ -4,7 +4,7 @@ impl Interpreter {
     pub(crate) fn type_arg_value_from_name(&self, name: &str) -> Value {
         let trimmed = name.trim().trim_start_matches('(').trim_end_matches(')');
         if let Some((base, args)) = Self::parse_parametric_type_name(trimmed)
-            && self.is_role(&base)
+            && self.is_role_type_name(&base)
         {
             return Value::parametric_role(
                 Symbol::intern(&base),
@@ -350,7 +350,7 @@ impl Interpreter {
     /// If `name` is in `self.registry().roles`, returns it as-is. Otherwise, if `name`
     /// contains `::`, tries the short name (after the last `::`).
     pub(in crate::runtime) fn resolve_role_key(&self, name: &str) -> Option<String> {
-        if self.registry().roles.contains_key(name) {
+        if self.is_role_type_name(name) {
             return Some(name.to_string());
         }
         // Same topic exclusion as the class-side lookups: see
@@ -359,12 +359,12 @@ impl Interpreter {
             && let Some(ValueView::Package(pkg)) = self.env.get(name).map(Value::view)
         {
             let resolved = pkg.resolve();
-            if self.registry().roles.contains_key(&resolved) {
+            if self.is_role_type_name(&resolved) {
                 return Some(resolved);
             }
         }
         if let Some(short) = name.rsplit("::").next()
-            && self.registry().roles.contains_key(short)
+            && self.is_role_type_name(short)
         {
             return Some(short.to_string());
         }
@@ -1158,7 +1158,7 @@ impl Interpreter {
         }
         if let Some((constraint_base, constraint_args)) =
             Self::parse_parametric_type_name(constraint)
-            && self.is_role(&constraint_base)
+            && self.is_role_type_name(&constraint_base)
             && let ValueView::Mixin(_, mixins) = value.view()
         {
             let key = format!(
@@ -1188,7 +1188,7 @@ impl Interpreter {
         // `__mutsu_role_typeargs__` markers the mixin branch above reads.
         if let Some((constraint_base, constraint_args)) =
             Self::parse_parametric_type_name(constraint)
-            && self.is_role(&constraint_base)
+            && self.is_role_type_name(&constraint_base)
             && let Some(class_name) = Self::instance_class_name_of(value)
         {
             let expected: Vec<Value> = constraint_args
@@ -1417,7 +1417,7 @@ impl Interpreter {
                 .split_once('[')
                 .map(|(b, _)| b)
                 .unwrap_or(&pkg_resolved);
-            if self.registry().roles.contains_key(pkg_base) {
+            if self.is_role_type_name(pkg_base) {
                 // For role groups, use candidate-specific parents:
                 // - Curried roles (e.g. R[Int]): use parametric candidate's parents
                 // - Bare role name: use non-parametric candidate's parents
@@ -1440,9 +1440,8 @@ impl Interpreter {
                                     .map(|c| c.parents.clone())
                             }
                         });
-                let initial_parents = candidate_parents
-                    .or_else(|| self.registry().role_parents.get(pkg_base).cloned())
-                    .unwrap_or_default();
+                let initial_parents =
+                    candidate_parents.unwrap_or_else(|| self.registry().role_parents_of(pkg_base));
                 let mut stack: Vec<String> = initial_parents;
                 let mut seen = HashSet::new();
                 while let Some(parent) = stack.pop() {

--- a/src/runtime/types/type_registry.rs
+++ b/src/runtime/types/type_registry.rs
@@ -38,6 +38,7 @@ pub(crate) const BUILTIN_ROLE_NAMES: &[&str] = &[
     "Scheduler",
     "Sequence",
     "PositionalBindFailover",
+    "Systemic",
 ];
 
 /// Is `name` one of [`BUILTIN_ROLE_NAMES`]?

--- a/t/issue-7780-builtin-type-hierarchy-roles.t
+++ b/t/issue-7780-builtin-type-hierarchy-roles.t
@@ -1,0 +1,56 @@
+use Test;
+
+plan 17;
+
+# These roles are part of the built-in type hierarchy, even though mutsu
+# models their implementations natively rather than registering RoleDefs.
+role QuantHashProbe does QuantHash {
+    method marker { "QuantHash" }
+}
+role StringyProbe does Stringy {
+    method marker { "Stringy" }
+}
+role BaggyProbe does Baggy {
+    method marker { "Baggy" }
+}
+role PositionalBindFailoverProbe does PositionalBindFailover {
+    method marker { "PositionalBindFailover" }
+}
+role BlobProbe does Blob[uint8] {
+    method marker { "Blob" }
+}
+
+class SystemicProbe does Systemic {
+    method marker { "Systemic" }
+}
+class QuantHashConsumer does QuantHashProbe { }
+class StringyConsumer does StringyProbe { }
+class BaggyConsumer does BaggyProbe { }
+class PositionalBindFailoverConsumer does PositionalBindFailoverProbe { }
+class BlobConsumer does BlobProbe { }
+
+ok(Bag ~~ Baggy, "Bag composes Baggy");
+ok(Bag ~~ QuantHash, "Bag composes QuantHash");
+ok(Buf ~~ Blob, "Buf composes Blob");
+ok(Str ~~ Stringy, "Str composes Stringy");
+ok($*DISTRO ~~ Systemic, "Distro composes Systemic");
+
+is(QuantHashConsumer.new.marker, "QuantHash", "a class receives a QuantHash role method");
+ok(QuantHashConsumer.new ~~ QuantHash, "a class doing QuantHash type-checks as QuantHash");
+is(StringyConsumer.new.marker, "Stringy", "a class receives a Stringy role method");
+ok(StringyConsumer.new ~~ Stringy, "a class doing Stringy type-checks as Stringy");
+is(BaggyConsumer.new.marker, "Baggy", "a class receives a Baggy role method");
+ok(BaggyConsumer.new ~~ Baggy, "a class doing Baggy type-checks as Baggy");
+is(
+    PositionalBindFailoverConsumer.new.marker,
+    "PositionalBindFailover",
+    "a class receives a PositionalBindFailover role method",
+);
+ok(
+    PositionalBindFailoverConsumer.new ~~ PositionalBindFailover,
+    "a class doing PositionalBindFailover type-checks as PositionalBindFailover",
+);
+is(BlobConsumer.new.marker, "Blob", "a class receives a Blob role method");
+ok(BlobConsumer.new ~~ Blob, "a class doing Blob[uint8] type-checks as Blob");
+ok(BlobConsumer.new ~~ Stringy, "Blob[uint8] carries Stringy through its role hierarchy");
+is(SystemicProbe.new.marker, "Systemic", "a class receives a Systemic role method");


### PR DESCRIPTION
Closes #7780

## Summary
- recognize QuantHash, Stringy, Systemic, Baggy, PositionalBindFailover, and Blob[T] as composable built-in roles
- model their built-in parent relationships and Systemic compositions
- preserve native class behavior for Blob and Buf
- add focused regression coverage and a news entry

## Validation
- make lint
- make test
- make roast