### PR TITLE
fix: do not leak a unit module's file-scope constants and enum values into the importer

### DIFF
--- a/news/2026-09/unit-module-constants-no-longer-leak-into-the-importer.md
+++ b/news/2026-09/unit-module-constants-no-longer-leak-into-the-importer.md
@@ -1,0 +1,85 @@
+# A `unit module`'s file-scope `constant`s and enum values no longer leak into the importer
+
+Closes the last piece of #7555 item 1's divergence (b). #7743 scoped a module's
+imports, classes and roles to its own compunit and #7764 scoped a
+transitively-`use`d module's package name; what was left was a module's own
+file-scope `constant`s and enum values, which were still installed under a plain
+name in whatever scope triggered the load.
+
+```raku
+# lib/InnerConst.rakumod:  unit module InnerConst; constant INNER-CONST = 42; enum InnerEnum <ALPHA BETA>;
+# lib/OuterConst.rakumod:  use InnerConst; unit module OuterConst; constant OUTER-CONST = 7; enum OuterEnum <GAMMA DELTA>;
+use OuterConst;             # the importer says only this
+say OUTER-CONST;            # rakudo: Undeclared name    mutsu was: 7
+say GAMMA;                  # rakudo: Undeclared name    mutsu was: GAMMA
+say INNER-CONST;            # rakudo: Undeclared name    mutsu was: 42
+say ALPHA;                  # rakudo: Undeclared name    mutsu was: ALPHA
+```
+
+The leaked binding was not merely extra, it was arbitrary. Two `unit module`s
+declaring the same constant name and both `use`d gave the importer whichever one
+loaded first, even though each module's own routines correctly read their own
+value.
+
+## Root cause
+
+A module body runs in the **caller's** `env` (`load_module_inner` → `run_block`),
+so every file-scope bare name it declares lands under a plain env key in the
+loading scope. The end-of-load cleanup in `run_modules.rs` already undid three
+classes of those — names `import_module` recorded, a `unit` compunit's own `my`
+variables (into `unit_lexicals`), and since #7764 package names the module only
+reached through its own `use`. `constant`s and enum values were in none of them:
+they were folded into the package-keyed `module_scope_lexicals` but their env
+binding was never removed.
+
+`collect_unit_lexical_names` could not cover them — it only walks `Stmt::VarDecl`
+and rejects `is_our`, and a `constant` parses to
+`VarDecl { is_our: true, custom_traits: [("__constant", _), ...] }`, while an
+`enum` is a separate `Stmt::EnumDecl` node it does not look at at all.
+
+## The fix
+
+A new `collect_unit_package_scope_names` walks the compunit's top-level
+statements for `VarDecl`s carrying the `__constant` trait and for `EnumDecl`s
+(their type name and every variant name), skipping `is export` declarations,
+whose lifetime `import_module` already owns. `load_module_inner` removes those
+`env` bindings at the end of the load, next to the `leaked_packages` removal.
+
+Unlike the `my` variables, these are deliberately **not** moved into
+`unit_lexicals`: they stay in `module_scope_names`, and hence in the
+package-keyed `module_scope_lexicals`, which is where the declaring module's own
+routines and methods already read them from. Only the `env` binding goes. The
+transitive rows fall out for free — the removal runs at the end of *every*
+`unit` load, so a nested module's constants are gone before the outer module's
+env diff is taken.
+
+## Two measurements that narrowed the issue's own analysis
+
+The issue expected the fix to need a parser-level discriminator between
+`constant FOO` and `our constant FOO`, since `--dump-ast` gives an identical
+`VarDecl { is_our: true, ... }` for both. Measured against rakudo v2026.07, the
+distinction does not arise: inside a `unit module`, `our constant OUR-CONST` is
+exactly as invisible to the importer as the bare form — both resolve only as
+`M::OUR-CONST` — and the same holds for `our enum`. So both forms are collected
+and no new discriminator was needed.
+
+The second measurement confirms the carve-out the issue inferred from the
+same-name collision test but had not verified by actually removing the binding:
+with the env binding gone, a `unit` compunit's own top-level subs *and* the
+methods of classes it declares still read its `constant`s and enum values
+through `module_scope_lexicals`. `t/log-async-battery.t` — the regression the
+#7555 note worried about — stays green, because `Log::Async` has no `unit`
+declarator and this fix is scoped to `unit` compunits. For that no-`unit` shape
+rakudo also makes the names visible in the importer, so leaving it alone is the
+compatible answer, not a gap.
+
+## Still open
+
+Package-qualified access to a module the importer never `use`d is unchanged:
+`InnerConst::INNER-CONST` still resolves in a file that only `use`d
+`OuterConst`, where rakudo reports it missing. That is the `GLOBAL::`-versus-
+per-compunit *storage* question, which #7764 also left open for package names;
+this change scopes visibility of the short name without moving the storage.
+
+`t/module-transitive-use-does-not-leak-types.t` grew from 9 to 27 assertions and
+passes verbatim under rakudo v2026.07.

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -2420,6 +2420,14 @@ pub struct Interpreter {
     /// is the motivating case: `constant Offset` is read by the exported
     /// `OBJECT_BODY` sub of the same module, and resolved to the string
     /// `"Offset"` once the frame that loaded the module was gone.
+    ///
+    /// For a `unit` compunit's own `constant`s and enum values this is no longer
+    /// a fallback but the ONLY store: `load_module_inner` drops their `env`
+    /// binding at the end of the load, because the module body ran in the
+    /// caller's env and rakudo makes those names package symbols of the
+    /// compunit rather than names the importer sees bare (#7787). The value
+    /// stays here so the declaring module's own routines and methods still read
+    /// it; see `collect_unit_package_scope_names`.
     pub(crate) module_scope_lexicals: PackageLexicals,
     /// Names the module currently being loaded imported from another module,
     /// accumulated by `import_module` and folded into `module_scope_lexicals`

--- a/src/runtime/run_modules.rs
+++ b/src/runtime/run_modules.rs
@@ -946,6 +946,18 @@ impl Interpreter {
             for name in &leaked_packages {
                 self.env.remove(name);
             }
+            // A `unit` compunit's own file-scope `constant`s and enum values are
+            // package symbols of that compunit in rakudo, not names the importer
+            // sees bare (#7787). The module body ran in the CALLER's env, so drop
+            // the plain binding here; `module_scope_names` keeps the value, so the
+            // module's own routines still read it through `module_scope_lexicals`,
+            // and the `saved_plain_env` restore below puts back whatever the
+            // loading scope had under the same name.
+            if unit_name.is_some() {
+                for name in Self::collect_unit_package_scope_names(&stmts) {
+                    self.env.remove(&name);
+                }
+            }
             module_type_aliases = self.module_type_aliases_of(&module_scope_names);
             // Take the compunit's own file-scope lexicals out of `env` and into
             // `unit_lexicals`, restoring the loading scope's values under those
@@ -1191,6 +1203,93 @@ impl Interpreter {
             }
             if !names.iter().any(|n| n == name) {
                 names.push(name.clone());
+            }
+        }
+        names
+    }
+
+    /// The file-scope `constant` and `enum`-value names a `unit` compunit
+    /// declares. Like [`Interpreter::collect_unit_lexical_names`] these must not
+    /// stay visible under a plain `env` key once the load finishes — the module
+    /// body runs in the CALLER's env, so `constant FOO = 42` inside
+    /// `unit module M` otherwise leaves a bare `FOO` resolvable in whatever
+    /// scope triggered the load (#7787), and in a transitively-`use`d module it
+    /// leaks two levels out. rakudo makes them package symbols of `M` visible
+    /// only as `M::FOO`.
+    ///
+    /// Unlike the `my` variables above, these are NOT moved into `unit_lexicals`:
+    /// they stay in `module_scope_names` (and hence in the package-keyed
+    /// `module_scope_lexicals`), which is where the module's own routines already
+    /// read them from. Only the `env` binding goes.
+    ///
+    /// `our constant` / `our enum` are collected too. That is not an oversight:
+    /// measured against rakudo v2026.07, `our constant OUR-CONST` in a
+    /// `unit module` is exactly as invisible to the importer as the bare form
+    /// (both resolve only as `M::OUR-CONST`), so the `our`-versus-bare
+    /// discriminator #7787 expected to need does not arise here.
+    ///
+    /// `is export` declarations are excluded — those are meant to reach the
+    /// caller, and `import_module` already owns their lifetime.
+    ///
+    /// Only `unit` compunits qualify. A module file with no `unit` declarator
+    /// (`modules/Log-Async/lib/Log/Async.rakumod`, whose `enum Loglevels` sits at
+    /// file scope beside a braced `class Log::Async { ... }`) makes those names
+    /// visible to the importer under rakudo too, so removing them there would be
+    /// a divergence rather than a fix.
+    fn collect_unit_package_scope_names(stmts: &[crate::ast::Stmt]) -> Vec<String> {
+        let mut names: Vec<String> = Vec::new();
+        let mut push = |name: &str| {
+            if name.contains("::") || name.contains("__ANON") {
+                return;
+            }
+            let bare = name.strip_prefix(['@', '%', '&', '$']).unwrap_or(name);
+            if !bare
+                .chars()
+                .next()
+                .is_some_and(|c| c.is_ascii_alphabetic() || c == '_')
+            {
+                return;
+            }
+            if !names.iter().any(|n| n == name) {
+                names.push(name.to_string());
+            }
+        };
+        for s in stmts {
+            match s {
+                crate::ast::Stmt::VarDecl {
+                    name,
+                    is_export,
+                    is_dynamic,
+                    custom_traits,
+                    ..
+                } => {
+                    // A `constant` parses to `VarDecl { is_our: true, .. }` with
+                    // a `__constant` trait; `is_our` alone cannot tell it from an
+                    // ordinary `our $x`, which is a package variable the loading
+                    // scope may legitimately share.
+                    if *is_export
+                        || *is_dynamic
+                        || !custom_traits.iter().any(|(t, _)| t == "__constant")
+                    {
+                        continue;
+                    }
+                    push(name);
+                }
+                crate::ast::Stmt::EnumDecl {
+                    name,
+                    variants,
+                    is_export,
+                    ..
+                } => {
+                    if *is_export {
+                        continue;
+                    }
+                    push(&name.resolve());
+                    for (variant, _) in variants {
+                        push(variant);
+                    }
+                }
+                _ => {}
             }
         }
         names

--- a/t/lib/TransitiveLeakConstA.rakumod
+++ b/t/lib/TransitiveLeakConstA.rakumod
@@ -1,0 +1,3 @@
+unit module TransitiveLeakConstA;
+constant SHARED-CONST-NAME = 'from-A';
+sub a-reads-shared() is export { SHARED-CONST-NAME }

--- a/t/lib/TransitiveLeakConstB.rakumod
+++ b/t/lib/TransitiveLeakConstB.rakumod
@@ -1,0 +1,3 @@
+unit module TransitiveLeakConstB;
+constant SHARED-CONST-NAME = 'from-B';
+sub b-reads-shared() is export { SHARED-CONST-NAME }

--- a/t/lib/TransitiveLeakInner.rakumod
+++ b/t/lib/TransitiveLeakInner.rakumod
@@ -4,3 +4,15 @@ class InnerClass is export { method who() { 'inner-class' } }
 role InnerRole is export { method tagged() { 'inner-role' } }
 constant InnerConst is export = 'inner-const';
 sub inner-sub() is export { 'inner-sub' }
+
+# Not exported: a `unit module`'s own file-scope `constant`s and enum values are
+# package symbols of this compunit in rakudo, so the importer must not see the
+# bare names -- while this module's own routines and methods still must (#7787).
+constant INNER-PRIVATE = 'inner-private';
+enum InnerEnum <INNER-ALPHA INNER-BETA>;
+our constant INNER-OUR = 'inner-our';
+
+sub inner-reads-private() is export { INNER-PRIVATE ~ '/' ~ INNER-ALPHA.key ~ '/' ~ INNER-OUR }
+class InnerReader is export {
+    method peek() { INNER-PRIVATE ~ '/' ~ INNER-BETA.key }
+}

--- a/t/lib/TransitiveLeakOuter.rakumod
+++ b/t/lib/TransitiveLeakOuter.rakumod
@@ -9,3 +9,27 @@ sub outer-uses-inner() is export { InnerClass.new.who ~ '/' ~ InnerConst }
 class OuterHolder is export {
     method make-inner() { InnerClass.new.who }
 }
+
+# This module's own non-exported `constant`s and enum values -- see the note in
+# TransitiveLeakInner.rakumod (#7787).
+constant OUTER-PRIVATE = 'outer-private';
+enum OuterEnum <OUTER-GAMMA OUTER-DELTA>;
+
+sub outer-reads-private() is export { OUTER-PRIVATE ~ '/' ~ OUTER-GAMMA.key }
+class OuterReader is export {
+    method peek() { OUTER-PRIVATE ~ '/' ~ OUTER-DELTA.key }
+}
+
+# What this module can see of a module it `use`d: rakudo does not make an
+# unexported constant of TransitiveLeakInner visible here either.
+sub outer-peeks-inner-private() is export {
+    my $v = ::('INNER-PRIVATE');
+    ($v.defined and $v !~~ Failure) ?? $v.gist !! 'MISSING';
+}
+
+# The inner module's own routines/methods must keep reading its unexported
+# constants and enum values; the importer of *this* module cannot reach them
+# directly (they are exported one hop away), so probe them from here.
+sub outer-probes-inner-reads() is export { inner-reads-private() }
+sub outer-probes-inner-method() is export { InnerReader.new.peek() }
+sub outer-probes-inner-const() is export { InnerConst }

--- a/t/module-transitive-use-does-not-leak-types.t
+++ b/t/module-transitive-use-does-not-leak-types.t
@@ -4,8 +4,10 @@ use Test;
 use TransitiveLeakOuter;
 use TransitiveLeakDirect;
 use TransitiveLeakGrand;
+use TransitiveLeakConstA;
+use TransitiveLeakConstB;
 
-plan 9;
+plan 27;
 
 # A module body runs in the *caller's* env, so the short-name type aliases a
 # module's own `use` statements install used to be left behind in whatever
@@ -53,3 +55,61 @@ isnt grand-probe(), 'TransitiveLeakInner::InnerClass',
     'a two-hop transitive class is not resolvable from the middle importer';
 is grand-outer-probe(), 'TransitiveLeakOuter::OuterClass',
     'while what that importer did import stays resolvable';
+
+# ---------------------------------------------------------------------------
+# #7787: the same contract for a `unit module`'s own file-scope `constant`s and
+# enum values. They are package symbols of the declaring compunit in rakudo, so
+# the bare name must not be resolvable in whatever scope triggered the load --
+# neither for the module the importer actually used, nor for one it only
+# reached transitively.
+
+sub missing($name) {
+    my $v = ::($name);
+    ($v.defined and $v !~~ Failure) ?? $v.gist !! 'MISSING';
+}
+
+is missing('OUTER-PRIVATE'), 'MISSING',
+    'a used module constant does not leak into the importer';
+is missing('OUTER-GAMMA'), 'MISSING',
+    'a used module enum value does not leak into the importer';
+is missing('INNER-PRIVATE'), 'MISSING',
+    'a transitively-used module constant does not leak either';
+is missing('INNER-ALPHA'), 'MISSING',
+    'nor does a transitively-used module enum value';
+is missing('INNER-OUR'), 'MISSING',
+    'an `our constant` is no more visible to the importer than a bare one';
+is missing('OuterEnum'), 'MISSING', 'nor is the enum type name itself';
+is missing('InnerEnum'), 'MISSING', 'nor a transitively-used enum type name';
+
+# What the importer legitimately keeps: an `is export` constant, and package-
+# qualified access to the module it actually used.
+is outer-probes-inner-const(), 'inner-const',
+    'an `is export` constant still reaches the module that used it';
+is TransitiveLeakOuter::OUTER-PRIVATE, 'outer-private',
+    'the used module constant is still a package symbol of that module';
+is TransitiveLeakOuter::OUTER-GAMMA.key, 'OUTER-GAMMA',
+    'and so is its enum value';
+
+# The declaring module's own code must still read them -- from a top-level sub
+# and from a method of a class it declares, which resolve bare names by
+# different paths.
+is outer-reads-private(), 'outer-private/OUTER-GAMMA',
+    'the module sub still reads its own constant and enum value';
+is OuterReader.new.peek(), 'outer-private/OUTER-DELTA',
+    'a method of a class the module declares reads them too';
+is outer-probes-inner-reads(), 'inner-private/INNER-ALPHA/inner-our',
+    'a transitively-loaded module sub still reads its own, including `our constant`';
+is outer-probes-inner-method(), 'inner-private/INNER-BETA',
+    'and so does a method of a class it declares';
+
+# A module does not see an unexported constant of a module it `use`s.
+is outer-peeks-inner-private(), 'MISSING',
+    'the middle module does not see the inner module unexported constant';
+
+# The leaked binding was not merely extra, it was arbitrary: whichever module
+# loaded first won the name. Both must read their own value, and neither may
+# install the short name in the importer.
+is a-reads-shared(), 'from-A', 'each module reads its own same-named constant (A)';
+is b-reads-shared(), 'from-B', 'each module reads its own same-named constant (B)';
+is missing('SHARED-CONST-NAME'), 'MISSING',
+    'and no arbitrary winner is left behind in the importer';


### PR DESCRIPTION
Closes #7787 — the last piece of #7555 item 1's divergence (b). #7743 scoped a
module's imports, classes and roles to its own compunit and #7764 scoped a
transitively-`use`d module's package name; what was left was a module's own
file-scope `constant`s and enum values.

## The divergence

```raku
# lib/InnerConst.rakumod:  unit module InnerConst; constant INNER-CONST = 42; enum InnerEnum <ALPHA BETA>;
# lib/OuterConst.rakumod:  use InnerConst; unit module OuterConst;
#                          constant OUTER-CONST = 7; enum OuterEnum <GAMMA DELTA>;
use OuterConst;             # the importer says only this
say OUTER-CONST;            # rakudo: Undeclared name    was: 7
say GAMMA;                  # rakudo: Undeclared name    was: GAMMA
say INNER-CONST;            # rakudo: Undeclared name    was: 42   (two hops out)
say ALPHA;                  # rakudo: Undeclared name    was: ALPHA
```

The leaked binding was not merely extra, it was arbitrary: two `unit module`s
declaring the same constant name and both `use`d gave the importer whichever one
loaded first, even though each module's own routines correctly read their own
value.

## Root cause

A module body runs in the **caller's** `env` (`load_module_inner` → `run_block`),
so every file-scope bare name it declares lands under a plain env key in the
loading scope. The end-of-load cleanup already undid three classes of those —
names `import_module` recorded, a `unit` compunit's own `my` variables (into
`unit_lexicals`), and since #7764 package names the module only reached through
its own `use`. `constant`s and enum values were in none of them: they were folded
into the package-keyed `module_scope_lexicals` but the env binding was never
removed.

`collect_unit_lexical_names` could not cover them — it only walks
`Stmt::VarDecl` and rejects `is_our`, and a `constant` parses to
`VarDecl { is_our: true, custom_traits: [("__constant", _), ...] }`, while an
`enum` is a separate `Stmt::EnumDecl` node it does not look at at all.

## The fix

A new `collect_unit_package_scope_names` walks the compunit's top-level
statements for `VarDecl`s carrying the `__constant` trait and for `EnumDecl`s
(their type name and every variant name), skipping `is export` declarations
whose lifetime `import_module` already owns. `load_module_inner` removes those
`env` bindings at the end of the load, next to the `leaked_packages` removal.

Unlike the `my` variables, these are deliberately **not** moved into
`unit_lexicals`: they stay in `module_scope_names`, and hence in the
package-keyed `module_scope_lexicals`, which is where the declaring module's own
routines and methods already read them from. Only the `env` binding goes. The
transitive rows fall out for free — the removal runs at the end of *every* `unit`
load, so a nested module's constants are gone before the outer module's env diff
is taken.

## Two measurements that narrowed the issue's own analysis

The issue expected the fix to need a parser-level discriminator between
`constant FOO` and `our constant FOO`, since `--dump-ast` gives an identical
`VarDecl { is_our: true, ... }` for both. Measured against rakudo v2026.07 the
distinction does not arise: inside a `unit module`, `our constant OUR-CONST` is
exactly as invisible to the importer as the bare form — both resolve only as
`M::OUR-CONST` — and the same holds for `our enum`. So both forms are collected
and no new discriminator was needed.

The second measurement confirms the carve-out the issue inferred from the
same-name collision test but had not verified by actually removing the binding:
with the env binding gone, a `unit` compunit's own top-level subs *and* the
methods of classes it declares still read its `constant`s and enum values
through `module_scope_lexicals`. `t/log-async-battery.t` — the regression the
#7555 note worried about — stays green, because `Log::Async` has no `unit`
declarator and this fix is scoped to `unit` compunits. For that no-`unit` shape
rakudo also makes the names visible in the importer (measured), so leaving it
alone is the compatible answer, not a gap.

## Still open (deliberately out of scope)

Package-qualified access to a module the importer never `use`d is unchanged:
`InnerConst::INNER-CONST` still resolves in a file that only `use`d
`OuterConst`, where rakudo reports it missing. That is the `GLOBAL::`-versus-
per-compunit *storage* question, which #7764 also left open for package names;
this change scopes visibility of the short name without moving the storage.

## Verification

- `t/module-transitive-use-does-not-leak-types.t` extended from 9 to 27
  assertions (the issue's stated verification bar — extend, don't add a parallel
  file). It **passes verbatim under rakudo v2026.07**, covering: bare names
  missing in the importer for both the used and the transitively-used module,
  `our constant`/`our enum` likewise, the enum type names, qualified access still
  resolving, the declaring module's own sub *and* method reads, the middle module
  not seeing the inner module's unexported constant, and the same-name collision.
- `t/log-async-battery.t` and `roast/S10-packages/precompilation.t` — the two
  regressions previous slices of this divergence actually hit — both green.
- `cargo fmt --all`, `make lint`, `make test` (Files=3927, Tests=41760,
  `Result: PASS`) and `make roast` run locally. `make roast` reports only the
  three container-environment failures documented in `docs/agent-environments.md`
  (`6.c/S32-io/file-tests.t` and `S16-filehandles/filetest.t` under `uid 0`,
  `S32-io/IO-Socket-Async.t` under the sandboxed network), with the exact failed
  test numbers that table records.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C8tSjb6EERguVSs3XWcJiy

---
_Generated by [Claude Code](https://claude.ai/code/session_01C8tSjb6EERguVSs3XWcJiy)_