### PR TITLE
fix: preserve runtime binding failures

### DIFF
--- a/news/2026-09/runtime-binding-errors-keep-runtime-exceptions.md
+++ b/news/2026-09/runtime-binding-errors-keep-runtime-exceptions.md
@@ -1,0 +1,1 @@
+Runtime parameter binding failures now retain their `X::TypeCheck::Binding::Parameter` or `X::Parameter::InvalidConcreteness` exception and Raku-compatible message instead of being wrapped in a compile-time call diagnostic. Callable signature checks, `PositionalBindFailover`, and `:U`/`:D` invocant hints now follow the same runtime binding path.

--- a/src/runtime/calls.rs
+++ b/src/runtime/calls.rs
@@ -452,6 +452,67 @@ impl Interpreter {
         {
             return err;
         }
+        // Concreteness failures are already complete runtime exceptions. In
+        // particular, wrapping them would both change `.Str` and hide the
+        // `:U` invocant hint (`multi` versus `.new`). Ordinary sub calls do
+        // not have the routine name on the binder's context stack, so repair
+        // that one field here while the call site still knows `func_name`.
+        let concreteness = err.exception.as_ref().and_then(|ex| {
+            let ValueView::Instance {
+                class_name,
+                attributes,
+                ..
+            } = ex.as_ref().view()
+            else {
+                return None;
+            };
+            if class_name.resolve() != "X::Parameter::InvalidConcreteness" {
+                return None;
+            }
+            let attrs = attributes.as_map();
+            Some((
+                attrs
+                    .get("expected")
+                    .map(Value::to_string_value)
+                    .unwrap_or_default(),
+                attrs
+                    .get("got")
+                    .map(Value::to_string_value)
+                    .unwrap_or_default(),
+                attrs
+                    .get("routine")
+                    .map(Value::to_string_value)
+                    .unwrap_or_default(),
+                attrs
+                    .get("param")
+                    .map(Value::to_string_value)
+                    .unwrap_or_default(),
+                attrs
+                    .get("should-be-concrete")
+                    .is_some_and(|v| matches!(v.view(), ValueView::Bool(true))),
+                attrs
+                    .get("param-is-invocant")
+                    .is_some_and(|v| matches!(v.view(), ValueView::Bool(true))),
+            ))
+        });
+        if let Some((expected, got, routine, param, should_be_concrete, param_is_invocant)) =
+            concreteness
+        {
+            if !param_is_invocant && routine == "<anon>" {
+                let hint = err.take_hint();
+                let mut fixed = RuntimeError::parameter_invalid_concreteness(
+                    &expected,
+                    &got,
+                    func_name,
+                    &param,
+                    should_be_concrete,
+                    false,
+                );
+                fixed.set_hint(hint);
+                return fixed;
+            }
+            return err;
+        }
         // A signature with a generic type capture (`sub c(::T $x, T $y, $z)`)
         // cannot be checked at compile time at all -- what `T` means is only
         // known once `$x` binds -- so rakudo reports a plain RUNTIME
@@ -504,6 +565,9 @@ impl Interpreter {
         let has_type_captures = param_defs
             .iter()
             .any(|pd| pd.name.starts_with("::") || pd.name == "__type_capture__");
+        let has_subsignature = param_defs
+            .iter()
+            .any(|pd| pd.sub_signature.is_some() || pd.outer_sub_signature.is_some());
         let is_binding_param_exception = err.exception.as_ref().is_some_and(|ex| {
             if let ValueView::Instance { class_name, .. } = ex.as_ref().view() {
                 class_name.resolve() == "X::TypeCheck::Binding::Parameter"
@@ -511,21 +575,35 @@ impl Interpreter {
                 false
             }
         });
+        let named_binding_failure = err
+            .message
+            .split_once("parameter '")
+            .and_then(|(_, rest)| rest.split_once('\''))
+            .is_some_and(|(param, _)| {
+                let key = param.strip_prefix(['$', '@', '%', '&']).unwrap_or(param);
+                args.iter().any(|arg| {
+                    matches!(
+                        arg.view(),
+                        ValueView::Pair(pair_key, _) if pair_key == key
+                    )
+                })
+            });
         let is_type_only_mismatch = (is_binding_param_exception
             || (err.exception.is_none()
                 && err
                     .message
                     .contains("X::TypeCheck::Binding::Parameter: Type check failed")))
             && !has_type_captures
-            // Only convert when ALL typed parameters are simple scalar types.
-            // Sigiled parameters (@, %, &) have container-level type constraints
-            // that should remain as binding errors.
-            && !param_defs.iter().any(|pd| {
-                pd.type_constraint.is_some()
-                    && (pd.name.starts_with('@')
-                        || pd.name.starts_with('%')
-                        || pd.name.starts_with('&'))
-            })
+            // Sigiled parameters such as `@a` and `%h` use container-level
+            // constraints (`Positional`/`Associative`), which are still simple
+            // enough for a statically visible positional call to receive the
+            // compile-time-style wrapper. Runtime where constraints, named
+            // colonpairs, and callable-signature checks have already been
+            // excluded above or use non-simple expected types.
+            // Named colon-pair arguments are bound at run time. Even a simple
+            // nominal type such as `Int :$i` must retain its binding exception
+            // rather than receive the static-call wrapper.
+            && !named_binding_failure
             // Gate on the *failing* parameter's expected type (parsed from the
             // error message), NOT on whether any param happens to be simple. A
             // call like `foo(Sub $c, Str $a); foo(-> {}, "a")` fails on the `Sub`
@@ -544,10 +622,27 @@ impl Interpreter {
                     // compile-time X::TypeCheck::Argument — it stays a runtime
                     // X::TypeCheck::Binding::Parameter.
                     Self::is_simple_argument_type(expected)
-                        && param_defs
+                        && (param_defs
                             .iter()
                             .any(|pd| pd.type_constraint.as_deref() == Some(expected))
+                            // The binder supplies these implicit constraints
+                            // for ordinary `@`/`%` parameters. A positional
+                            // call with a scalar therefore gets the same
+                            // compile-time-style diagnostic as an explicit
+                            // simple type constraint.
+                            || (!has_subsignature
+                                && expected == "Positional"
+                                && err.message.contains("parameter '@"))
+                            || (!has_subsignature
+                                && expected == "Associative"
+                                && err.message.contains("parameter '%")))
                 });
+        if !((is_arity_error || is_type_only_mismatch)
+            && (err.exception.is_none() || is_binding_param_exception))
+        {
+            err.set_hint(hint);
+            return err;
+        }
         if (is_arity_error || is_type_only_mismatch)
             && (err.exception.is_none() || is_binding_param_exception)
         {

--- a/src/runtime/types/binding_signature.rs
+++ b/src/runtime/types/binding_signature.rs
@@ -124,12 +124,9 @@ impl Interpreter {
             self.env.remove("_");
         }
         if !ok {
-            return Err(Self::parameter_binding_error(
-                format!(
-                    "X::TypeCheck::Binding::Parameter: where constraint failed for parameter '{}'",
-                    pd.name
-                ),
+            return Err(Self::parameter_where_binding_error(
                 pd,
+                &bound_val,
                 Some(&*self),
             ));
         }
@@ -178,6 +175,75 @@ impl Interpreter {
             Value::make_instance(Symbol::intern("X::TypeCheck::Binding::Parameter"), ex_attrs);
         err.exception = Some(Box::new(exception));
         err.with_parameter_object(pd, interp)
+    }
+
+    /// Build the runtime error used when an anonymous `where` predicate does
+    /// not accept its bound value. Keep this in the binder rather than in the
+    /// call-site formatter: the binder still has the actual value needed for
+    /// Raku's `got TYPE (gist)` text.
+    fn parameter_where_binding_error(
+        pd: &ParamDef,
+        value: &Value,
+        interp: Option<&Interpreter>,
+    ) -> RuntimeError {
+        RuntimeError::typecheck_binding_parameter_where(&param_display_name(pd), value)
+            .with_parameter_object(pd, interp)
+    }
+
+    /// Coerce a value which composes `PositionalBindFailover` before checking
+    /// an `@` parameter. Raku asks the value for an iterator and binds the
+    /// resulting cached List; this is deliberately part of signature binding
+    /// so it also applies to indirect calls and multi candidates.
+    fn coerce_positional_bind_failover(&mut self, value: Value) -> Result<Value, RuntimeError> {
+        let iterator = self.call_method_with_values(value, "iterator", vec![])?;
+        let items = if let ValueView::Instance {
+            class_name,
+            attributes,
+            ..
+        } = iterator.view()
+            && class_name == "Iterator"
+        {
+            let all = match attributes.as_map().get("items").map(Value::view) {
+                Some(ValueView::Array(values, ..)) => values.to_vec(),
+                _ => Vec::new(),
+            };
+            let index = match attributes.as_map().get("index").map(Value::view) {
+                Some(ValueView::Int(i)) if i >= 0 => (i as usize).min(all.len()),
+                _ => 0,
+            };
+            all[index..].to_vec()
+        } else {
+            let mut items = Vec::new();
+            loop {
+                let item = self.call_method_with_values(iterator.clone(), "pull-one", vec![])?;
+                if matches!(item.view(), ValueView::Str(s) if s.as_str() == "IterationEnd")
+                    || matches!(item.view(), ValueView::Package(name) if name == Symbol::intern("IterationEnd"))
+                {
+                    break;
+                }
+                items.push(item);
+            }
+            items
+        };
+        Ok(Value::array_with_kind(
+            crate::gc::Gc::new(crate::value::ArrayData::new(items)),
+            crate::value::ArrayKind::List,
+        ))
+    }
+
+    fn callable_signature_for_error(&self, value: &Value) -> String {
+        let (_, param_defs) = self.callable_signature(value);
+        Self::signature_constraint_for_error(&param_defs)
+    }
+
+    fn signature_constraint_for_error(param_defs: &[ParamDef]) -> String {
+        let mut defs = param_defs.to_vec();
+        for pd in &mut defs {
+            if pd.name == "__type_only__" {
+                pd.name = "__ANON_STATE__".to_string();
+            }
+        }
+        format!(":{}", Self::build_signature_string(&defs))
     }
 
     fn normalize_coercion_binding_error(
@@ -232,6 +298,15 @@ impl Interpreter {
         source_name: Option<&str>,
         source_type_constraint: Option<&str>,
     ) -> Result<Value, RuntimeError> {
+        let is_builtin_seq = matches!(value.view(), ValueView::Seq(..));
+        let is_positional_bind_failover =
+            is_builtin_seq || self.type_matches_value("PositionalBindFailover", &value);
+        if pd.name.starts_with('@')
+            && is_positional_bind_failover
+            && (is_builtin_seq || !self.type_matches_value("Positional", &value))
+        {
+            value = self.coerce_positional_bind_failover(value)?;
+        }
         if let Some(constraint) = &pd.type_constraint
             && (pd.name != "__type_only__" || self.is_resolvable_type(constraint))
         {
@@ -1180,12 +1255,9 @@ impl Interpreter {
                             self.env.remove("_");
                         }
                         if !ok {
-                            return Err(Self::parameter_binding_error(
-                                format!(
-                                    "X::TypeCheck::Binding::Parameter: where constraint failed for parameter '{}'",
-                                    pd.name
-                                ),
+                            return Err(Self::parameter_where_binding_error(
                                 pd,
+                                &capture_value,
                                 Some(&*self),
                             ));
                         }
@@ -1485,12 +1557,9 @@ impl Interpreter {
                             self.env.remove("_");
                         }
                         if !ok {
-                            return Err(Self::parameter_binding_error(
-                                format!(
-                                    "X::TypeCheck::Binding::Parameter: where constraint failed for parameter '{}'",
-                                    pd.name
-                                ),
+                            return Err(Self::parameter_where_binding_error(
                                 pd,
+                                &slurpy_value,
                                 Some(&*self),
                             ));
                         }
@@ -1540,20 +1609,14 @@ impl Interpreter {
                         if let Some((sig_params, sig_ret)) = &pd.code_signature
                             && !code_signature_matches_value(self, sig_params, sig_ret, val)
                         {
-                            let mut err = RuntimeError::new(format!(
-                                "X::TypeCheck::Binding::Parameter: Type check failed in binding to parameter '{}'; expected Callable with matching signature, got {}",
-                                pd.name,
-                                crate::runtime::value_type_name(val)
-                            ));
-                            let mut ex_attrs = std::collections::HashMap::new();
-                            ex_attrs
-                                .insert("message".to_string(), Value::str(err.message.to_string()));
-                            let exception = Value::make_instance(
-                                Symbol::intern("X::TypeCheck::Binding::Parameter"),
-                                ex_attrs,
-                            );
-                            err.exception = Some(Box::new(exception));
-                            return Err(err);
+                            let expected = Self::signature_constraint_for_error(sig_params);
+                            let got = self.callable_signature_for_error(val);
+                            return Err(RuntimeError::typecheck_binding_parameter_signature(
+                                &param_display_name(pd),
+                                &expected,
+                                &got,
+                            )
+                            .with_parameter_object(pd, Some(&*self)));
                         }
                         // Slice 2d (named follow-up): an `@`/`%` *variable* passed by
                         // name to a plain readonly scalar `$` named param binds the
@@ -1775,19 +1838,14 @@ impl Interpreter {
                     if let Some((sig_params, sig_ret)) = &pd.code_signature
                         && !code_signature_matches_value(self, sig_params, sig_ret, &value)
                     {
-                        let mut err = RuntimeError::new(format!(
-                            "X::TypeCheck::Binding::Parameter: Type check failed in binding to parameter '{}'; expected Callable with matching signature, got {}",
-                            pd.name,
-                            crate::runtime::value_type_name(&value)
-                        ));
-                        let mut ex_attrs = std::collections::HashMap::new();
-                        ex_attrs.insert("message".to_string(), Value::str(err.message.to_string()));
-                        let exception = Value::make_instance(
-                            Symbol::intern("X::TypeCheck::Binding::Parameter"),
-                            ex_attrs,
-                        );
-                        err.exception = Some(Box::new(exception));
-                        return Err(err);
+                        let expected = Self::signature_constraint_for_error(sig_params);
+                        let got = self.callable_signature_for_error(&value);
+                        return Err(RuntimeError::typecheck_binding_parameter_signature(
+                            &param_display_name(pd),
+                            &expected,
+                            &got,
+                        )
+                        .with_parameter_object(pd, Some(&*self)));
                     }
                     // A rename param `:min(:$minutes)` binds only its leaf
                     // variable (below); its own name is a caller key, not a body
@@ -2432,19 +2490,14 @@ impl Interpreter {
                     if let Some((sig_params, sig_ret)) = &pd.code_signature
                         && !code_signature_matches_value(self, sig_params, sig_ret, &value)
                     {
-                        let mut err = RuntimeError::new(format!(
-                            "X::TypeCheck::Binding::Parameter: Type check failed in binding to parameter '{}'; expected Callable with matching signature, got {}",
-                            pd.name,
-                            crate::runtime::value_type_name(&value)
-                        ));
-                        let mut ex_attrs = std::collections::HashMap::new();
-                        ex_attrs.insert("message".to_string(), Value::str(err.message.to_string()));
-                        let exception = Value::make_instance(
-                            Symbol::intern("X::TypeCheck::Binding::Parameter"),
-                            ex_attrs,
-                        );
-                        err.exception = Some(Box::new(exception));
-                        return Err(err);
+                        let expected = Self::signature_constraint_for_error(sig_params);
+                        let got = self.callable_signature_for_error(&value);
+                        return Err(RuntimeError::typecheck_binding_parameter_signature(
+                            &param_display_name(pd),
+                            &expected,
+                            &got,
+                        )
+                        .with_parameter_object(pd, Some(&*self)));
                     }
                     if let Some(where_expr) = &pd.where_constraint {
                         let saved_param = if pd.name.is_empty() {
@@ -2496,12 +2549,9 @@ impl Interpreter {
                             }
                         }
                         if !ok {
-                            return Err(Self::parameter_binding_error(
-                                format!(
-                                    "X::TypeCheck::Binding::Parameter: where constraint failed for parameter '{}'",
-                                    pd.name
-                                ),
+                            return Err(Self::parameter_where_binding_error(
                                 pd,
+                                &value,
                                 Some(&*self),
                             ));
                         }

--- a/src/value/error_typed.rs
+++ b/src/value/error_typed.rs
@@ -554,20 +554,34 @@ impl RuntimeError {
         should_be_concrete: bool,
         param_is_invocant: bool,
     ) -> Self {
-        let kind = if should_be_concrete {
-            "an object instance"
+        let (kind, actual_kind, hint) = if should_be_concrete {
+            ("an object instance", "a type object", ".new")
         } else {
-            "a type object"
+            ("a type object", "an object instance", "multi")
         };
-        let actual_kind = if should_be_concrete {
-            "a type object"
+        let display_param = if param.starts_with(['$', '@', '%', '&']) {
+            param.to_string()
         } else {
-            "an object instance"
+            format!("${}", param)
         };
-        let msg = format!(
-            "Invocant of method '{}' must be {} of type\n'{}', not {} of type '{}'.  Did you forget a '.new'?",
-            routine, kind, expected, actual_kind, got
-        );
+        let msg = if param_is_invocant {
+            if should_be_concrete {
+                format!(
+                    "Invocant of method '{}' must be {} of type\n'{}', not {} of type '{}'. Did you forget a '{}'?",
+                    routine, kind, expected, actual_kind, got, hint
+                )
+            } else {
+                format!(
+                    "Invocant of method '{}' must be a type object of type '{}', not an object\ninstance of type '{}'. Did you forget a '{}'?",
+                    routine, expected, got, hint
+                )
+            }
+        } else {
+            format!(
+                "Parameter '{}' of routine '{}' must be {} of\ntype '{}', not {} of type '{}'. Did you forget a '.new'?",
+                display_param, routine, kind, expected, actual_kind, got
+            )
+        };
         let mut attrs = HashMap::new();
         attrs.insert("expected".to_string(), Value::str(expected.to_string()));
         attrs.insert("got".to_string(), Value::str(got.to_string()));
@@ -774,6 +788,46 @@ but got '{}' ({}) as a value without a container.",
         attrs.insert("parameter".to_string(), Value::str(param.to_string()));
         attrs.insert("expected".to_string(), expected_type_object(expected));
         attrs.insert("got".to_string(), value.clone());
+        attrs.insert("message".to_string(), Value::str(msg.clone()));
+        Self::typed("X::TypeCheck::Binding::Parameter", attrs)
+    }
+
+    /// X::TypeCheck::Binding::Parameter for a `where` constraint. Raku exposes
+    /// the anonymous predicate as the expected value and includes the bound
+    /// value's gist in the one-line runtime message.
+    pub(crate) fn typecheck_binding_parameter_where(param: &str, value: &Value) -> Self {
+        let got = crate::runtime::utils::got_type_name(value);
+        let msg = format!(
+            "Constraint type check failed in binding to parameter '{}'; expected anonymous constraint to be met but got {} ({})",
+            param,
+            got,
+            crate::builtins::methods_0arg::raku_repr::raku_value(value),
+        );
+        let mut attrs = HashMap::new();
+        attrs.insert("parameter".to_string(), Value::str(param.to_string()));
+        attrs.insert(
+            "expected".to_string(),
+            Value::str("anonymous constraint".to_string()),
+        );
+        attrs.insert("got".to_string(), value.clone());
+        attrs.insert("message".to_string(), Value::str(msg.clone()));
+        Self::typed("X::TypeCheck::Binding::Parameter", attrs)
+    }
+
+    /// X::TypeCheck::Binding::Parameter for a callable signature mismatch.
+    pub(crate) fn typecheck_binding_parameter_signature(
+        param: &str,
+        expected: &str,
+        got: &str,
+    ) -> Self {
+        let msg = format!(
+            "Signature constraint check failed in binding to parameter '{}'; expected {} but got {}",
+            param, expected, got
+        );
+        let mut attrs = HashMap::new();
+        attrs.insert("parameter".to_string(), Value::str(param.to_string()));
+        attrs.insert("expected".to_string(), Value::str(expected.to_string()));
+        attrs.insert("got".to_string(), Value::str(got.to_string()));
         attrs.insert("message".to_string(), Value::str(msg.clone()));
         Self::typed("X::TypeCheck::Binding::Parameter", attrs)
     }

--- a/t/issue-7750-runtime-binding-errors.t
+++ b/t/issue-7750-runtime-binding-errors.t
@@ -1,0 +1,80 @@
+use Test;
+
+plan 14;
+
+sub compact($message) { $message.subst(/\s+/, ' ', :g).trim }
+
+# Runtime binding failures must keep their runtime exception and message. The
+# "will never work" wrapper belongs only to a mismatch the compiler can prove
+# from a statically visible call.
+sub named-typed(Int :$i) { }
+try { named-typed :i<forty-two> }
+my $ex = $!;
+isa-ok $ex, X::TypeCheck::Binding::Parameter,
+    'typed named parameter keeps its runtime exception';
+is compact($ex.Str),
+    q{Type check failed in binding to parameter '$i'; expected Int but got Str ("forty-two")},
+    'typed named parameter uses the runtime message';
+
+sub constrained-slurpy(*@a where {$_.all ~~ Int}) { }
+try { constrained-slurpy(<a>) }
+$ex = $!;
+isa-ok $ex, X::TypeCheck::Binding::Parameter,
+    'where-constrained slurpy keeps its runtime exception';
+is compact($ex.Str),
+    q{Constraint type check failed in binding to parameter '@a'; expected anonymous constraint to be met but got Array (["a"])},
+    'where-constrained slurpy uses the runtime message';
+
+sub callback-signature(&c:(Int)) { }
+sub callback-with-str(Str) { }
+try { callback-signature(&callback-with-str) }
+$ex = $!;
+isa-ok $ex, X::TypeCheck::Binding::Parameter,
+    'callable signature mismatch keeps its runtime exception';
+is compact($ex.Str),
+    q{Signature constraint check failed in binding to parameter '&c'; expected :(Int $) but got :(Str $)},
+    'callable signature mismatch uses both signatures';
+
+sub concrete-routine(Str:D $s, Int $limit) { }
+try { concrete-routine Str, 3 }
+$ex = $!;
+isa-ok $ex, X::Parameter::InvalidConcreteness,
+    'a routine concreteness failure keeps its exception type';
+is compact($ex.Str),
+    q{Parameter '$s' of routine 'concrete-routine' must be an object instance of type 'Str', not a type object of type 'Str'. Did you forget a '.new'?},
+    'a routine concreteness failure names the routine and parameter';
+
+class InvocantHints {
+    method wants-type(::?CLASS:U:) { }
+    method wants-instance(::?CLASS:D:) { }
+}
+try { InvocantHints.new.wants-type }
+$ex = $!;
+isa-ok $ex, X::Parameter::InvalidConcreteness,
+    ':U invocant failure keeps its exception type';
+is compact($ex.Str),
+    q{Invocant of method 'wants-type' must be a type object of type 'InvocantHints', not an object instance of type 'InvocantHints'. Did you forget a 'multi'?},
+    ':U invocant failure suggests multi';
+
+try { InvocantHints.wants-instance }
+$ex = $!;
+isa-ok $ex, X::Parameter::InvalidConcreteness,
+    ':D invocant failure keeps its exception type';
+is compact($ex.Str),
+    q{Invocant of method 'wants-instance' must be an object instance of type 'InvocantHints', not a type object of type 'InvocantHints'. Did you forget a '.new'?},
+    ':D invocant failure suggests .new';
+
+class FallbackSource does PositionalBindFailover {
+    method iterator {
+        class :: does Iterator {
+            method pull-one { return 42 unless $++; IterationEnd }
+        }.new
+    }
+}
+sub first-five(@a) { @a[^5] }
+is first-five(FallbackSource.new).raku,
+    '(42, Nil, Nil, Nil, Nil)',
+    'PositionalBindFailover coerces through its iterator during binding';
+is first-five((1, 2).Seq).raku,
+    '(1, 2, Nil, Nil, Nil)',
+    'the built-in Seq failover also binds as a cached List';


### PR DESCRIPTION
## Summary
- preserve runtime binding exception classes and Raku-compatible messages
- add callable signature, PositionalBindFailover, and :U/:D invocant handling
- keep compile-time-style call diagnostics for statically provable mismatches

## Tests
- cargo fmt --all
- cargo clippy -- -D warnings
- make test
- make roast

Closes #7750