### PR TITLE
fix(proxy): an is-rw routine returns its Proxy as a container

### DIFF
--- a/news/2026-09/proxy-rw-routine-return-container.md
+++ b/news/2026-09/proxy-rw-routine-return-container.md
@@ -1,0 +1,92 @@
+# `Proxy` returned from an `is rw` routine now reaches the caller as a container
+
+`Proxy` is the documented core type whose whole purpose is to be bound to a
+name and then read and written through its `FETCH`/`STORE` methods. The
+`Type/Proxy.rakudoc` synopsis — an `is rw` sub returning a `Proxy`, bound with
+`:=` and then assigned to — did not work in mutsu at all:
+
+```raku
+sub double() is rw {
+    my $storage = 0;
+    Proxy.new(
+        FETCH => method ()     { $storage * 2    },
+        STORE => method ($new) { $storage = $new },
+    )
+}
+my $doubled := double();
+$doubled = 4;
+say $doubled;      # raku: 8   mutsu: Cannot assign to an immutable value
+```
+
+## Root cause: the wrong half of the decontainerization rule
+
+Raku decontainerizes a routine's return value, so a `Proxy` built inside an
+ordinary `sub` reaches the caller already FETCHed. `is raw` and `is rw` both
+suppress that: the caller receives the `Proxy` itself and the FETCH happens at
+the next *use*. That is what makes the synopsis work — the `:=` binds a
+container, so the later `=` has a `STORE` to run.
+
+mutsu's return path tested `is raw` alone (`cf_auto_fetch = !cf.is_raw`), and
+the code-object path had the rule inverted outright (`auto_fetch = data.is_rw`,
+so an `is rw` routine was the *only* shape that FETCHed). Every `is rw` return
+was therefore resolved at the call, the binding held a plain value, and the
+assignment died as immutable.
+
+The decision is now stated once per carrier and reads the whole ADR-0067 rule
+— `is rw`, `is raw`, **or** an explicit `return-rw`:
+
+- ADR-0067's existing `Interpreter::routine_is_rw_capable` /
+  `method_is_rw_capable` wherever a resolved def was already in hand;
+- `CompiledFunction::returns_container()` for the compiled path, which carries
+  no body AST and so gets a new `uses_return_rw` computed once at declaration
+  time (so `sub f() { return-rw Proxy.new(...) }` binds a container now too);
+- `SubData::returns_container()` for the code-object path.
+
+`SubData` answers *container* for anything it cannot prove decontainerizes: a
+bare or pointy block returns raw in Raku anyway, and an anonymous `sub` is built
+from an `Expr::AnonSubParams`, which records `is_rw` but has no field for
+`is_raw` — so `sub () is raw { ... }` is indistinguishable there from a plain
+one and keeps the pre-existing no-FETCH answer.
+
+## Two bugs the fix uncovered
+
+**`try` did not evaluate its value.** With the container now reaching the
+caller, `(try dying-fetch-proxy()).defined` would FETCH *outside* the `try` and
+escape it. Rakudo evaluates a genuine `try`'s value inside the protected region
+— a throwing FETCH is caught and the `try` yields `Nil`, while an untroubled one
+still hands the `Proxy` back (`my $p := try f(); $p.VAR.^name` is `Proxy`). The
+`TryCatch` op now probes its body's value the same way, which also fixes the
+same escape for an `is raw` routine, where it was reachable before this change.
+
+**A captured `Proxy` never ran `STORE`.** An assignment inside a block or a
+named sub reaches the variable by name (`SetGlobal`), never through a local
+slot, and that path replaced the captured container with the plain value instead
+of running `STORE` — the write silently vanished and the program carried on:
+
+```raku
+my $cell = 0;
+my $p := Proxy.new(FETCH => method () { $cell }, STORE => method ($n) { $cell = $n });
+my $b = { $p = 2 }; $b();      # raku: $cell is 2;  mutsu: still 0
+sub s1() { $p = 3 }; s1();     # raku: $cell is 3;  mutsu: still 0
+```
+
+The store now checks for a `Proxy` before both write-throughs on that path (the
+compunit-lexical store and the generic `ContainerRef` one), each of which would
+otherwise rebind the name rather than write through it. This was live on `main`
+independently of the return rule; it stayed hidden because a bound name almost
+never held a real `Proxy` before.
+
+## Pin
+
+`t/proxy-rw-routine-return-bind.t` (25 tests, verified identical under rakudo):
+read, write and read-after-write through the binding; `FETCH`/`STORE` counted
+exactly once per access, including in interpolation and as a sub argument; a
+`Proxy` returned from a method behaving as one returned from a sub; a plain
+`sub` still decontainerizing its return; `return-rw` without either trait; the
+`try` probe; and the three captured-`Proxy` store shapes.
+
+`t/thread-shared-scalar-visibility.t`'s "STORE through a captured Proxy is
+visible" loses its `todo`: a `start` block's write is one of the captured-name
+stores the second fix repairs.
+
+Closes #7748.

--- a/news/2026-09/proxy-rw-routine-return-container.md
+++ b/news/2026-09/proxy-rw-routine-return-container.md
@@ -48,7 +48,7 @@ from an `Expr::AnonSubParams`, which records `is_rw` but has no field for
 `is_raw` — so `sub () is raw { ... }` is indistinguishable there from a plain
 one and keeps the pre-existing no-FETCH answer.
 
-## Two bugs the fix uncovered
+## Three bugs the fix uncovered
 
 **`try` did not evaluate its value.** With the container now reaching the
 caller, `(try dying-fetch-proxy()).defined` would FETCH *outside* the `try` and
@@ -76,14 +76,35 @@ otherwise rebind the name rather than write through it. This was live on `main`
 independently of the return rule; it stayed hidden because a bound name almost
 never held a real `Proxy` before.
 
+**A subscript did not decontainerize a `Proxy` receiver.** This is XML's shape
+— `XML::Element::AT-POS` is `is rw` and returns a `Proxy` over the node list —
+and it is what the bundled-library gate caught:
+
+```raku
+$xml[1][0].string      # No such method 'string' for invocant of type 'XML::Element'
+```
+
+With the container now reaching the caller, the *second* subscript arrives
+holding the `Proxy` itself and indexed it as though it were a one-element list.
+`Index` FETCHes a `Proxy` receiver now, which is the decont raku performs on a
+subscript's invocant.
+
+Fusing the two levels on the *write* side (`$obj[i][j] = v` where `AT-POS` is
+`is rw`) had never worked, on `main` either: the chained-subscript store read
+the inner collection through the accessor and then had no way to descend past
+it. It does now — when the inner instance has no `ASSIGN-POS`/`ASSIGN-KEY`, its
+own rw accessor is asked for the location and the value is stored through
+that.
+
 ## Pin
 
-`t/proxy-rw-routine-return-bind.t` (25 tests, verified identical under rakudo):
+`t/proxy-rw-routine-return-bind.t` (28 tests, verified identical under rakudo):
 read, write and read-after-write through the binding; `FETCH`/`STORE` counted
 exactly once per access, including in interpolation and as a sub argument; a
 `Proxy` returned from a method behaving as one returned from a sub; a plain
 `sub` still decontainerizing its return; `return-rw` without either trait; the
-`try` probe; and the three captured-`Proxy` store shapes.
+`try` probe; a chained subscript reading and writing through an `is rw`
+`AT-POS`; and the three captured-`Proxy` store shapes.
 
 `t/thread-shared-scalar-visibility.t`'s "STORE through a captured Proxy is
 visible" loses its `todo`: a `start` block's write is one of the captured-name

--- a/src/compiler/helpers_method_body.rs
+++ b/src/compiler/helpers_method_body.rs
@@ -208,6 +208,7 @@ impl Compiler {
             empty_sig: false,
             is_rw,
             is_raw: false,
+            uses_return_rw: crate::opcode::body_uses_return_rw(body),
             is_cached: false,
             param_local_slots: None,
             params_fill_frame: false,

--- a/src/compiler/helpers_sub_body.rs
+++ b/src/compiler/helpers_sub_body.rs
@@ -569,6 +569,9 @@ impl Compiler {
                 && !Self::body_uses_legacy_args(body),
             is_rw,
             is_raw,
+            // ADR-0067's third rw-capability fact, computed here because a
+            // compiled routine keeps no body AST to re-derive it from.
+            uses_return_rw: crate::opcode::body_uses_return_rw(body),
             is_cached,
             param_local_slots: None,
             params_fill_frame: false,

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -8916,6 +8916,14 @@ pub(crate) struct CompiledFunction {
     pub(crate) is_cached: bool,
     /// When true, this sub is declared `is raw` and Proxy values should NOT be auto-FETCHed.
     pub(crate) is_raw: bool,
+    /// Whether the declared body spells an explicit `return-rw`. The third
+    /// input to [`CompiledFunction::returns_container`] — a routine that
+    /// returns through `return-rw` hands its caller a container without
+    /// carrying either trait (ADR-0067's `routine_is_rw_capable` reads the
+    /// same three facts off a `FunctionDef`). Computed once where the
+    /// declaration's body is still in hand; a compiled routine keeps no body
+    /// AST to re-derive it from.
+    pub(crate) uses_return_rw: bool,
     /// Pre-computed mapping from positional parameter index to locals slot index.
     /// Used by the positional light call fast path to avoid name-based lookup per call.
     pub(crate) param_local_slots: Option<Vec<usize>>,
@@ -9030,6 +9038,27 @@ pub(crate) struct CompiledFunction {
 }
 
 impl CompiledFunction {
+    /// Whether this routine hands its return value back as a **container**
+    /// rather than decontainerizing it.
+    ///
+    /// Raku's rule: an ordinary `sub` decontainerizes what it returns, so a
+    /// `Proxy` built in its body reaches the caller already FETCHed; `is raw`,
+    /// `is rw` and an explicit `return-rw` each suppress that, so the caller
+    /// receives the `Proxy` itself and the FETCH happens at the next *use*.
+    /// Only `is raw` used to be tested here, which made `my $x := rw-sub()`
+    /// bind the FETCHed value and left the resulting name unassignable
+    /// (#7748).
+    ///
+    /// The same three facts ADR-0067's [`Interpreter::routine_is_rw_capable`]
+    /// reads off a `FunctionDef` — this is that oracle asked of a compiled
+    /// routine, which carries no body AST and so gets `uses_return_rw`
+    /// precomputed at declaration time.
+    ///
+    /// [`Interpreter::routine_is_rw_capable`]: crate::runtime::Interpreter::routine_is_rw_capable
+    pub(crate) fn returns_container(&self) -> bool {
+        self.is_raw || self.is_rw || self.uses_return_rw
+    }
+
     /// Stamp a compiled routine and its nested named-subs with their enclosing
     /// routine's source file. Nested bodies are compiled as part of the parent
     /// and otherwise have no independent source metadata.
@@ -9425,6 +9454,7 @@ mod compiled_fns_identity {
             is_rw: false,
             is_cached: false,
             is_raw: false,
+            uses_return_rw: false,
             param_local_slots: None,
             params_fill_frame: false,
             has_inner_subs: false,

--- a/src/runtime/builtins_lvalue.rs
+++ b/src/runtime/builtins_lvalue.rs
@@ -266,6 +266,41 @@ impl Interpreter {
         def.is_rw || def.is_raw || crate::opcode::body_uses_return_rw(&def.body)
     }
 
+    /// [`Interpreter::method_is_rw_capable`] asked by NAME, for the dispatch
+    /// sites that no longer hold the resolved [`MethodDef`] (the invocant's
+    /// arguments have already been moved into the call by the time the result
+    /// is judged). Answers yes when *any* non-private candidate for `method`
+    /// anywhere in `class_name`'s MRO is rw-capable.
+    ///
+    /// Its one consumer is the "did this method return a `Proxy` that must
+    /// survive?" test, which runs only once a `Proxy` is actually in hand — so
+    /// the MRO walk is off every ordinary dispatch, and over-approximating a
+    /// multi whose candidates disagree about `is rw` costs nothing there.
+    pub(crate) fn class_method_is_rw_capable(&mut self, class_name: &str, method: &str) -> bool {
+        let mro = self.class_mro(class_name);
+        mro.iter().any(|cn| {
+            self.registry()
+                .user_method_overloads(cn.as_str(), method)
+                .is_some_and(|defs| {
+                    defs.iter()
+                        .any(|d| !d.is_private && Self::method_is_rw_capable(d))
+                })
+        })
+    }
+
+    /// Whether a `Proxy` a just-finished method call produced must be FETCHed
+    /// here or handed back as a container.
+    ///
+    /// A plain `method` decontainerizes its return exactly as a plain `sub`
+    /// does, so the `Proxy` is resolved at the call. An rw-capable method
+    /// (ADR-0067: `is rw`, `is raw`, or an explicit `return-rw`) returns the
+    /// container instead, and the FETCH belongs at the next *use* — which is
+    /// what makes `my $s := $obj.slot; $s = 9` STORE through the `Proxy`
+    /// rather than die on an immutable value (#7748).
+    pub(crate) fn should_fetch_returned_proxy(&mut self, class_name: &str, method: &str) -> bool {
+        !self.in_lvalue_assignment && !self.class_method_is_rw_capable(class_name, method)
+    }
+
     /// The write half of `f() = value` once the routine has run: the routine
     /// handed back a container (ADR-0059) and `value` is stored through it, or
     /// it handed back a plain value and the assignment is `X::Assignment::RO`

--- a/src/runtime/builtins_operators_fallback.rs
+++ b/src/runtime/builtins_operators_fallback.rs
@@ -534,14 +534,14 @@ impl Interpreter {
             // finalizes the return-type spec; only the multi/samewith frames
             // (for callsame/nextsame) and the is-raw/rw Proxy tail stay here.
             if Self::def_module_single_sig_body_ok_ignoring_state(&def) {
-                let fold_is_rw = !def.is_raw;
+                let fold_is_rw = !Self::routine_is_rw_capable(&def);
                 let result = self.call_routine_def(&def, args.to_vec());
                 self.pop_samewith_context();
                 if pushed_dispatch {
                     self.multi_dispatch_stack.pop();
                 }
                 return result.and_then(|v| {
-                    let v = if def.is_raw {
+                    let v = if Self::routine_is_rw_capable(&def) {
                         // Mark Proxy as decontainerized so the VM's auto-FETCH
                         // doesn't strip it (mirrors the interpreter arm's tail).
                         if matches!(v.view(), ValueView::Proxy { .. }) {
@@ -560,7 +560,7 @@ impl Interpreter {
                 self.pop_samewith_context();
                 return Err(Self::reject_args_for_empty_sig(args));
             }
-            let routine_is_rw = !def.is_raw;
+            let routine_is_rw = !Self::routine_is_rw_capable(&def);
             let return_spec = self.routine_return_spec_by_name(&def.name.resolve());
             let saved_env = self.env.clone();
             let saved_readonly = self.enter_readonly_frame();
@@ -766,7 +766,7 @@ impl Interpreter {
             let finalized =
                 self.finalize_return_with_spec(result, effective_return_spec.as_deref());
             return finalized.and_then(|v| {
-                let v = if def.is_raw {
+                let v = if Self::routine_is_rw_capable(&def) {
                     // Mark Proxy as decontainerized so the VM's auto-FETCH doesn't strip it
                     if matches!(v.view(), ValueView::Proxy { .. }) {
                         let (fetcher, storer, subclass, _) = v.into_proxy_parts().unwrap();

--- a/src/runtime/methods_instance_ops.rs
+++ b/src/runtime/methods_instance_ops.rs
@@ -1547,7 +1547,8 @@ impl Interpreter {
                 {
                     let result = result?;
                     let updated = attributes.to_map();
-                    if !self.in_lvalue_assignment
+                    if result.is_proxy_value()
+                        && self.should_fetch_returned_proxy(&class_name.resolve(), method)
                         && let ValueView::Proxy { fetcher, .. } = result.view()
                     {
                         return self.proxy_fetch(
@@ -1570,7 +1571,8 @@ impl Interpreter {
                 )?;
                 attributes.commit_attrs(updated.clone());
                 // Auto-FETCH if the method returned a Proxy
-                if !self.in_lvalue_assignment
+                if result.is_proxy_value()
+                    && self.should_fetch_returned_proxy(&class_name.resolve(), method)
                     && let ValueView::Proxy { fetcher, .. } = result.view()
                 {
                     return self.proxy_fetch(

--- a/src/runtime/methods_mut_dispatch.rs
+++ b/src/runtime/methods_mut_dispatch.rs
@@ -3068,7 +3068,8 @@ impl Interpreter {
                         target_var.to_string(),
                         Value::instance_sharing_cell(&attributes, class_name, target_id),
                     );
-                    if !self.in_lvalue_assignment
+                    if result.is_proxy_value()
+                        && self.should_fetch_returned_proxy(&class_name.resolve(), method)
                         && let ValueView::Proxy { fetcher, .. } = result.view()
                     {
                         return self.proxy_fetch(
@@ -3096,7 +3097,8 @@ impl Interpreter {
                     Value::instance_sharing_cell(&attributes, class_name, target_id),
                 );
                 // Auto-FETCH if the method returned a Proxy
-                if !self.in_lvalue_assignment
+                if result.is_proxy_value()
+                    && self.should_fetch_returned_proxy(&class_name.resolve(), method)
                     && let ValueView::Proxy { fetcher, .. } = result.view()
                 {
                     return self.proxy_fetch(

--- a/src/runtime/methods_qualified.rs
+++ b/src/runtime/methods_qualified.rs
@@ -414,7 +414,8 @@ impl Interpreter {
                 Err(e) => return Some(Err(e)),
             };
             attributes.commit_attrs(updated);
-            if !self.in_lvalue_assignment
+            if result.is_proxy_value()
+                && self.should_fetch_returned_proxy(qualifier, actual_method)
                 && let ValueView::Proxy { fetcher, .. } = result.view()
             {
                 return Some(self.proxy_fetch(fetcher, None, qualifier, &attributes.to_map(), 0));

--- a/src/runtime/resolution_call_sub.rs
+++ b/src/runtime/resolution_call_sub.rs
@@ -1246,7 +1246,11 @@ impl Interpreter {
             };
             let finalized =
                 self.finalize_return_with_spec(result, effective_return_spec.as_deref());
-            let fetch_rw = data.is_rw && !data.is_raw;
+            // Only a plain `sub`/`method` decontainerizes its return value, so
+            // only there is a `Proxy` result FETCHed at the call. `is raw` /
+            // `is rw` routines and non-Routine blocks hand the container back
+            // as-is, and the FETCH happens at the next use (#7748).
+            let fetch_rw = !data.returns_container();
             return finalized.and_then(|v| {
                 let v = if let ValueView::LazyList(list) = v.view() {
                     let mut env = list.env.clone();

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -964,6 +964,39 @@ pub struct SubData {
     pub(crate) captured_fatal_mode: bool,
 }
 
+impl SubData {
+    /// Whether calling this code object hands its return value back as a
+    /// **container** rather than decontainerizing it — i.e. whether a `Proxy`
+    /// it produced must reach the caller un-FETCHed.
+    ///
+    /// Only a plain `sub`/`method` decontainerizes. Three things put a code
+    /// object outside that class:
+    ///
+    /// - it is declared `is raw` or `is rw` (the rule
+    ///   [`crate::opcode::CompiledFunction::returns_container`] states for a
+    ///   compiled routine);
+    /// - it is not a `Routine` at all — a bare block (`{ ... }`) and a pointy
+    ///   block (`-> { ... }`) return raw;
+    /// - it is a routine whose traits this code object no longer carries. An
+    ///   anonymous `sub` is built from an `Expr::AnonSubParams`, and that AST
+    ///   variant records `is_rw` but has no field for `is_raw`, so
+    ///   `sub () is raw { Proxy.new(...) }` is indistinguishable here from a
+    ///   plain one. "Unknown" therefore answers *container*, which is what
+    ///   every shape but `is rw` already did before #7748; a declared routine
+    ///   (which does carry its own `CompiledFunction`) is answered exactly.
+    pub(crate) fn returns_container(&self) -> bool {
+        if self.is_raw || self.is_rw {
+            return true;
+        }
+        if self.is_bare_block || self.compiled_code.as_ref().is_some_and(|cc| !cc.is_routine) {
+            return true;
+        }
+        self.compiled_routine
+            .as_ref()
+            .is_none_or(|cf| cf.returns_container())
+    }
+}
+
 fn gcd(mut a: i64, mut b: i64) -> i64 {
     a = a.wrapping_abs();
     b = b.wrapping_abs();

--- a/src/vm/vm_call_dispatch.rs
+++ b/src/vm/vm_call_dispatch.rs
@@ -306,6 +306,7 @@ impl Interpreter {
             empty_sig: def.empty_sig,
             is_rw: def.is_rw,
             is_raw: def.is_raw,
+            uses_return_rw: crate::opcode::body_uses_return_rw(&def.body),
             is_cached: def.is_cached,
             param_local_slots: None,
             params_fill_frame: false,

--- a/src/vm/vm_call_func_ops.rs
+++ b/src/vm/vm_call_func_ops.rs
@@ -1362,8 +1362,11 @@ impl Interpreter {
             target
         };
 
+        // A plain `sub`/`method` decontainerizes its return, so a `Proxy` it
+        // produced is FETCHed here; `is raw` / `is rw` and every non-Routine
+        // block hand the container back untouched (#7748).
         let sub_is_rw = if let ValueView::Sub(data) = target.view() {
-            data.is_rw
+            !data.returns_container()
         } else {
             false
         };
@@ -1444,7 +1447,7 @@ impl Interpreter {
         }
         let result = if !target.is_nil() {
             let sub_is_rw = if let ValueView::Sub(data) = target.view() {
-                data.is_rw
+                !data.returns_container()
             } else {
                 false
             };
@@ -1462,7 +1465,7 @@ impl Interpreter {
         } else if !self.has_proto_cached(&name)
             && let Some(cf) = self.find_compiled_function(compiled_fns, &name, &args)
         {
-            let cf_auto_fetch = !cf.is_raw;
+            let cf_auto_fetch = !cf.returns_container();
             let pkg = self.current_package().to_string();
             self.set_pending_call_arg_sources(arg_sources.clone());
             let result = self.call_compiled_function_named(cf, args, compiled_fns, &pkg, &name);
@@ -1567,7 +1570,7 @@ impl Interpreter {
                         name_sym,
                     );
                     let result = result?;
-                    return loan_env!(self, maybe_fetch_rw_proxy(result, true));
+                    return loan_env!(self, maybe_fetch_rw_proxy(result, !cf.returns_container()));
                 }
                 // Try light call path for simple functions in tight loops.
                 // This avoids the expensive env clone/restore cycle.
@@ -1610,7 +1613,7 @@ impl Interpreter {
                     let result =
                         self.call_compiled_function_light(cf, &args, compiled_fns, name, name_sym);
                     let result = result?;
-                    return loan_env!(self, maybe_fetch_rw_proxy(result, true));
+                    return loan_env!(self, maybe_fetch_rw_proxy(result, !cf.returns_container()));
                 }
                 self.set_pending_call_arg_sources(arg_sources.clone());
                 let pushed_dispatch = loan_env!(self, push_multi_dispatch_frame(name, &args));
@@ -1630,7 +1633,7 @@ impl Interpreter {
                         .map(|def| def.package.resolve())
                         .unwrap_or_else(|| self.current_package().to_string())
                 };
-                let cf_auto_fetch = !cf.is_raw;
+                let cf_auto_fetch = !cf.returns_container();
                 let result = self.call_compiled_function_named(cf, args, compiled_fns, &pkg, name);
                 self.set_pending_call_arg_sources(None);
                 self.pop_samewith_context();
@@ -1668,9 +1671,9 @@ impl Interpreter {
                     // `nextsame`/`callsame`/`callwith`/`samewith` from the selected
                     // candidate still work because compile_and_call_function_def pushes
                     // the same multi-dispatch + samewith frames the interpreter would.
-                    let is_raw = def.is_raw;
+                    let returns_container = Self::routine_is_rw_capable(&def);
                     let result = self.compile_and_call_function_def(&def, args, compiled_fns)?;
-                    loan_env!(self, maybe_fetch_rw_proxy(result, !is_raw))
+                    loan_env!(self, maybe_fetch_rw_proxy(result, !returns_container))
                 } else if self.has_proto_cached(name)
                     && let Some(result) =
                         self.vm_try_run_nontrivial_proto_body(name, args.clone(), compiled_fns)
@@ -1727,10 +1730,10 @@ impl Interpreter {
                         // `def_is_otf_compilable_multi_candidate`.
                         && Self::def_is_otf_compilable_multi_candidate(&def)
                     {
-                        let is_raw = def.is_raw;
+                        let returns_container = Self::routine_is_rw_capable(&def);
                         let result =
                             self.compile_and_call_function_def(&def, args, compiled_fns)?;
-                        loan_env!(self, maybe_fetch_rw_proxy(result, !is_raw))
+                        loan_env!(self, maybe_fetch_rw_proxy(result, !returns_container))
                     } else {
                         crate::vm::vm_stats::record_function_fallback(name);
                         self.set_pending_call_arg_sources(arg_sources);
@@ -1776,7 +1779,10 @@ impl Interpreter {
                                 &pkg,
                                 name,
                             )?;
-                            return loan_env!(self, maybe_fetch_rw_proxy(result, !shared.is_raw));
+                            return loan_env!(
+                                self,
+                                maybe_fetch_rw_proxy(result, !shared.returns_container())
+                            );
                         }
                         let gate_ok = if is_builtin {
                             // Genuine builtin shadow: strict gate (no default —
@@ -1789,10 +1795,13 @@ impl Interpreter {
                             Self::def_is_otf_compilable_module_single(&def)
                         };
                         if gate_ok {
-                            let is_raw = def.is_raw;
+                            let returns_container = Self::routine_is_rw_capable(&def);
                             let result =
                                 self.compile_and_call_function_def(&def, args, compiled_fns)?;
-                            return loan_env!(self, maybe_fetch_rw_proxy(result, !is_raw));
+                            return loan_env!(
+                                self,
+                                maybe_fetch_rw_proxy(result, !returns_container)
+                            );
                         }
                     }
                     crate::vm::vm_stats::record_function_fallback(name);
@@ -1812,9 +1821,9 @@ impl Interpreter {
                 // code params (&foo), no where constraints, no closures.
                 && Self::def_is_otf_compilable(&def)
                 {
-                    let is_raw = def.is_raw;
+                    let returns_container = Self::routine_is_rw_capable(&def);
                     let result = self.compile_and_call_function_def(&def, args, compiled_fns)?;
-                    loan_env!(self, maybe_fetch_rw_proxy(result, !is_raw))
+                    loan_env!(self, maybe_fetch_rw_proxy(result, !returns_container))
                 } else if let Some(result) = self.try_native_test_function(name, &args) {
                     // Dispatch Test functions straight to their typed handler (lever A).
                     result

--- a/src/vm/vm_call_method_compiled_cache.rs
+++ b/src/vm/vm_call_method_compiled_cache.rs
@@ -646,7 +646,9 @@ impl Interpreter {
             if let (Some(m), Some(cell)) = (&reconciled, &attrs_cell) {
                 cell.commit_attrs(m.clone());
             }
-            if !self.in_lvalue_assignment
+            if result.is_proxy_value()
+                && !self.in_lvalue_assignment
+                && !Self::method_is_rw_capable(method_def)
                 && let ValueView::Proxy { fetcher, .. } = result.view()
             {
                 // Without a `:=` adjustment the returned map is absent —

--- a/src/vm/vm_call_method_compiled_interpret.rs
+++ b/src/vm/vm_call_method_compiled_interpret.rs
@@ -432,7 +432,9 @@ impl Interpreter {
                             if let (Some(m), Some(cell)) = (&reconciled, &attrs_cell) {
                                 cell.commit_attrs(m.clone());
                             }
-                            if !self.in_lvalue_assignment
+                            if result.is_proxy_value()
+                                && !self.in_lvalue_assignment
+                                && !Self::method_is_rw_capable(&method_def)
                                 && let ValueView::Proxy { fetcher, .. } = result.view()
                             {
                                 // Without a `:=` adjustment the returned map is

--- a/src/vm/vm_call_method_compiled_mut.rs
+++ b/src/vm/vm_call_method_compiled_mut.rs
@@ -327,7 +327,9 @@ impl Interpreter {
                             if let (Some(m), Some(cell)) = (&reconciled, &attrs_cell) {
                                 cell.commit_attrs(m.clone());
                             }
-                            if !self.in_lvalue_assignment
+                            if result.is_proxy_value()
+                                && !self.in_lvalue_assignment
+                                && !Self::method_is_rw_capable(&method_def)
                                 && let ValueView::Proxy { fetcher, .. } = result.view()
                             {
                                 // Without a `:=` adjustment the returned map is
@@ -446,7 +448,9 @@ impl Interpreter {
                     if let (Some(m), Some(cell)) = (&reconciled, &attrs_cell) {
                         cell.commit_attrs(m.clone());
                     }
-                    if !self.in_lvalue_assignment
+                    if result.is_proxy_value()
+                        && !self.in_lvalue_assignment
+                        && !Self::method_is_rw_capable(&method_def)
                         && let ValueView::Proxy { fetcher, .. } = result.view()
                     {
                         // Without a `:=` adjustment the returned map is absent —

--- a/src/vm/vm_env_helpers.rs
+++ b/src/vm/vm_env_helpers.rs
@@ -672,7 +672,7 @@ impl Interpreter {
     ///   what an END phaser declared in a `unit module` does. Resolved only when the
     ///   qualifier IS the current package: an explicitly written `$Other::x` is a
     ///   package variable and must never reach a `my` lexical.
-    fn unit_lexical_slot(&self, name: &str) -> Option<&Value> {
+    pub(super) fn unit_lexical_slot(&self, name: &str) -> Option<&Value> {
         if self.unit_lexicals.is_empty() || name.is_empty() {
             return None;
         }

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -1697,6 +1697,51 @@ impl Interpreter {
                             .push((name.clone(), resolved_source));
                     }
                 }
+                // A name that currently denotes a `Proxy` takes a plain `=`
+                // through its STORE instead of being rebound — the same rule
+                // `exec_set_local_op_inner` applies to a slot-held `Proxy`. A
+                // closure or a named sub that captured a `:=`-bound `Proxy`
+                // reaches its assignment HERE, by name, never through a local
+                // slot, so without this the write silently vanished: `my $p :=
+                // Proxy.new(...); my $b = { $p = 2 }; $b()` left the backing
+                // store untouched and still reported success (#7748).
+                //
+                // It has to run before BOTH write-throughs below — the
+                // compunit-lexical store and the generic `ContainerRef` one —
+                // since each would replace the boxed `Proxy` with the plain
+                // value, which is exactly the rebinding a `=` must not do. The
+                // captured lexical can sit in either store, so both are asked.
+                // `fresh_binding_decl` (hoisted here from the write-throughs,
+                // which read it too) is the exclusion they already state: an
+                // expression-position `my` of the same name declares a NEW
+                // variable rather than writing the captured `Proxy`.
+                //
+                // Tag probes first (`is_proxy_value` / `is_container_ref`), so
+                // an ordinary store pays no clone and cannot materialize a lazy
+                // `Match` merely to learn it is not a `Proxy`.
+                let fresh_binding_decl =
+                    self.vardecl_context().get() && code.expr_declared_syms.contains(&name_sym);
+                if !is_rebind && !raw_mode && !is_bind_ctx && !fresh_binding_decl {
+                    let proxy_val = match self
+                        .unit_lexical_slot(&name)
+                        .or_else(|| self.env().get(&name))
+                    {
+                        Some(v) if v.is_proxy_value() => Some(v.clone()),
+                        Some(v) if v.is_container_ref() => {
+                            let inner = v.deref_container();
+                            inner.is_proxy_value().then_some(inner)
+                        }
+                        _ => None,
+                    };
+                    if let Some(proxy_val) = proxy_val
+                        && let ValueView::Proxy { storer, .. } = proxy_val.view()
+                        && !storer.is_nil()
+                    {
+                        loan_env!(self, assign_proxy_lvalue(proxy_val.clone(), val))?;
+                        *ip += 1;
+                        return Ok(());
+                    }
+                }
                 // ADR-0024: a mainline named sub's write to one of its OWN
                 // captured lexicals must route through the shared cell in
                 // `unit_lexicals[MAINLINE_UNIT_KEY]`, checked BEFORE the
@@ -1734,8 +1779,6 @@ impl Interpreter {
                 // the OTHER `expr_declared_syms`-based protections (capture
                 // filter, free-var-write drain) ever run for it — this check is
                 // the one that does.
-                let fresh_binding_decl = self.vardecl_context().get()
-                    && code.expr_declared_syms.contains(&Symbol::intern(&name));
                 // Write through ContainerRef: update inner value for env-based variables.
                 // Return early to avoid overwriting the ContainerRef in env with a plain value.
                 if !is_rebind && !raw_mode {

--- a/src/vm/vm_try_catch_ops.rs
+++ b/src/vm/vm_try_catch_ops.rs
@@ -175,6 +175,28 @@ impl Interpreter {
         // Rust panic (overflow/OOB/unwrap) raised anywhere inside it becomes a
         // catchable exception routed to the CATCH handler, instead of crashing.
         let body_result = self.run_range_guarded(code, body_start, catch_begin, compiled_fns);
+        // A genuine `try` *evaluates* its value, so a `Proxy` the body produced
+        // is FETCHed inside the protected region: a throwing FETCH is caught
+        // here and the `try` yields Nil, exactly as rakudo does. The container
+        // itself still survives an untroubled FETCH -- in raku
+        // `my $p := try proxy-returning(); $p.VAR.^name` is `Proxy` -- so the
+        // probe discards its value and leaves the `Proxy` on the stack.
+        //
+        // Before #7748 an `is rw` routine FETCHed its `Proxy` return at the
+        // call, which hid the need for this: with the container now reaching
+        // the caller, `(try dying-fetch-proxy()).defined` would otherwise
+        // FETCH *outside* the `try` and escape it.
+        let body_result = body_result.and_then(|()| {
+            if traps
+                && self.stack.len() > saved_depth
+                && let Some(top) = self.stack.last()
+                && top.is_proxy_value()
+            {
+                let probe = top.clone();
+                self.auto_fetch_proxy(&probe)?;
+            }
+            Ok(())
+        });
         if has_control {
             self.control_handler_depth -= 1;
             self.control_handlers.pop();

--- a/src/vm/vm_var_assign_index_named.rs
+++ b/src/vm/vm_var_assign_index_named.rs
@@ -3303,7 +3303,16 @@ impl Interpreter {
                 // discarded the container on this line, which is why an `is rw`
                 // accessor's location was never written through.
                 let returned = self.call_method_with_values(target, at, vec![inner_idx.clone()])?;
-                let inner = returned.deref_container();
+                // An `is rw` accessor hands its `Proxy` back as a container
+                // (#7748), so FETCH to reach the collection the OUTER subscript
+                // addresses. `deref_container` alone answers the `Proxy` itself,
+                // and every reader below (the instance probe, the element scan)
+                // would then miss.
+                let inner = if returned.is_proxy_value() {
+                    loan_env!(self, auto_fetch_proxy(&returned))?
+                } else {
+                    returned.deref_container()
+                };
                 // The inner collection is itself a user-defined instance: route
                 // the outermost write through its ASSIGN-POS/ASSIGN-KEY
                 // (`$obj<support><source> = v` with both levels custom
@@ -3328,6 +3337,27 @@ impl Interpreter {
                         )?;
                         self.stack.push(val);
                         return Ok(());
+                    }
+                    // No `ASSIGN-POS`/`ASSIGN-KEY`, but the inner instance may
+                    // still hand back a writable LOCATION from its own rw
+                    // accessor — an `is rw` `AT-POS` returning a `Proxy`, the
+                    // shape `$obj[i] = v` already writes through at one level.
+                    // Fusing the two levels (`$obj[i][j] = v`) used to drop the
+                    // write: nothing here descended past the inner collection.
+                    if let Some(at_outer) = self.object_subscript_accessor(&inner, outer_positional)
+                        && self.class_method_is_rw_capable(&icn, at_outer)
+                    {
+                        let location = self.call_method_with_values(
+                            inner.clone(),
+                            at_outer,
+                            vec![outer_idx.clone()],
+                        )?;
+                        if let Some(assigned) = self.assign_lvalue_container(&location, val.clone())
+                        {
+                            assigned?;
+                            self.stack.push(val);
+                            return Ok(());
+                        }
                     }
                 }
                 let idx_u = crate::runtime::to_int(&outer_idx) as usize;

--- a/src/vm/vm_var_index_ops.rs
+++ b/src/vm/vm_var_index_ops.rs
@@ -518,6 +518,17 @@ impl Interpreter {
             index = Value::scalar(index.clone());
         }
         let mut target = self.stack.pop().unwrap();
+        // A subscript decontainerizes its invocant, so a `Proxy` receiver is
+        // FETCHed and the subscript addresses what it FETCHes to. This is
+        // reachable since #7748: an `is rw` `AT-POS`/`AT-KEY` now hands its
+        // `Proxy` back as a container, so a chained subscript (`$xml[1][0]`,
+        // XML::Element's shape) arrives here holding the `Proxy` itself —
+        // without the FETCH the second subscript indexed the container as if
+        // it were a one-element list. Tag-probed, so an ordinary subscript
+        // pays one relaxed check.
+        if target.is_proxy_value() {
+            target = loan_env!(self, auto_fetch_proxy(&target))?;
+        }
         // A scalar-held Range is a Range receiver for its own positional
         // indexing; only an itemized Range *index* above remains a single index.
         if target.descalarize().is_range() {

--- a/t/proxy-rw-routine-return-bind.t
+++ b/t/proxy-rw-routine-return-bind.t
@@ -1,0 +1,153 @@
+use Test;
+
+# A `Proxy` bound to a name must read through FETCH and write through STORE.
+#
+# An ordinary `sub` decontainerizes what it returns, so a `Proxy` built in its
+# body reaches the caller already FETCHed; `is rw` (like `is raw`) suppresses
+# that and hands the container back, which is what makes the documented
+# `Type/Proxy.rakudoc` synopsis -- an `is rw` routine returning a `Proxy`, bound
+# with `:=` and then assigned to -- work at all. mutsu FETCHed an `is rw`
+# return unconditionally, so the bound name held a plain value and `$doubled = 4`
+# died with "Cannot assign to an immutable value" (#7748).
+
+plan 25;
+
+# --- the Type/Proxy.rakudoc:17 synopsis -------------------------------------
+
+sub double() is rw {
+    my $storage = 0;
+    Proxy.new(
+        FETCH => method ()     { $storage * 2    },
+        STORE => method ($new) { $storage = $new },
+    )
+}
+
+my $doubled := double();
+is $doubled, 0, 'reading a freshly bound Proxy runs FETCH';
+$doubled = 4;
+is $doubled, 8, 'assigning runs STORE, and the next read runs FETCH again';
+$doubled = 10;
+is $doubled, 20, 'read-after-write sees the second STORE';
+
+# --- the binding keeps the container, it does not snapshot a value ----------
+
+is $doubled.VAR.^name, 'Proxy', 'the bound name still denotes the Proxy itself';
+
+# --- FETCH/STORE run exactly once per access --------------------------------
+
+my $fetches = 0;
+my $stores  = 0;
+my $cell    = 1;
+sub counted() is rw {
+    Proxy.new(
+        FETCH => method ()     { $fetches++; $cell },
+        STORE => method ($new) { $stores++; $cell = $new },
+    )
+}
+
+my $c := counted();
+$fetches = 0; $stores = 0;
+my $read = $c;
+is $read, 1, 'plain read through the binding';
+is $fetches, 1, 'exactly one FETCH per read';
+is $stores, 0, 'a read runs no STORE';
+
+$fetches = 0; $stores = 0;
+$c = 7;
+is $stores, 1, 'exactly one STORE per assignment';
+is $cell, 7, 'the STORE body ran and updated the backing store';
+
+# --- FETCH fires in interpolation and when passed as a sub argument ---------
+
+$fetches = 0;
+is "$c", '7', 'string interpolation reads through FETCH';
+ok $fetches >= 1, 'interpolation runs FETCH';
+
+sub takes($v) { $v + 1 }
+$fetches = 0;
+is takes($c), 8, 'passing the binding as a sub argument reads through FETCH';
+is $fetches, 1, 'the argument runs FETCH exactly once';
+
+# --- a Proxy from a method behaves the same as one from a sub ---------------
+
+class Holder {
+    has $.value is rw = 5;
+    method slot() is rw {
+        Proxy.new(
+            FETCH => -> $       { self.value      },
+            STORE => -> $, $new { self.value = $new },
+        )
+    }
+}
+
+my $h = Holder.new;
+my $slot := $h.slot;
+is $slot.VAR.^name, 'Proxy', 'a method-returned Proxy binds as a container too';
+is $slot, 5, 'reading it runs FETCH';
+$slot = 9;
+is $slot, 9, 'writing it runs STORE';
+
+# --- `return-rw` hands the container back without either trait --------------
+
+sub returned() {
+    my $storage = 4;
+    return-rw Proxy.new(
+        FETCH => method ()     { $storage      },
+        STORE => method ($new) { $storage = $new },
+    )
+}
+my $rr := returned();
+is $rr.VAR.^name, 'Proxy', 'an explicit return-rw keeps the container too';
+$rr = 6;
+is $rr, 6, 'and STOREs through it';
+
+# --- a plain sub still decontainerizes its return ---------------------------
+
+sub plain() {
+    my $storage = 3;
+    Proxy.new(
+        FETCH => method ()     { $storage      },
+        STORE => method ($new) { $storage = $new },
+    )
+}
+my $p := plain();
+is $p.VAR.^name, 'Int', 'a non-rw sub still FETCHes its Proxy return at the call';
+
+# --- `try` evaluates its value, so a throwing FETCH is caught inside it -----
+
+sub bad() is rw {
+    Proxy.new(FETCH => method () { die 'boom' }, STORE => method ($) { })
+}
+nok (try bad()).defined, 'a throwing FETCH is caught by the try around the call';
+
+my $ok := try double();
+is $ok.VAR.^name, 'Proxy', 'an untroubled try still hands the container back';
+
+# --- a Proxy captured by a closure/sub still STOREs through --------------
+
+# The assignment inside a block or a named sub reaches the variable BY NAME
+# (`SetGlobal`), not through a local slot, and that path replaced the captured
+# container instead of running STORE: the write vanished and the program
+# carried on. Only visible once an `is rw` return actually reaches the caller
+# as a Proxy -- before that, the bound name held a plain value and the same
+# assignment died as immutable.
+
+my $backing = 0;
+my $seen    = 0;
+my $cap := Proxy.new(
+    FETCH => method ()     { $backing },
+    STORE => method ($new) { $seen++; $backing = $new },
+);
+
+$cap = 1;
+is $backing, 1, 'a direct assignment STOREs';
+
+my $writer = { $cap = 2 };
+$writer();
+is $backing, 2, 'an assignment inside a block STOREs through the capture';
+
+sub write-it() { $cap = 3 }
+write-it();
+is $backing, 3, 'an assignment inside a named sub STOREs through the capture';
+
+is $seen, 3, 'each of the three assignments ran STORE exactly once';

--- a/t/proxy-rw-routine-return-bind.t
+++ b/t/proxy-rw-routine-return-bind.t
@@ -10,7 +10,7 @@ use Test;
 # return unconditionally, so the bound name held a plain value and `$doubled = 4`
 # died with "Cannot assign to an immutable value" (#7748).
 
-plan 25;
+plan 28;
 
 # --- the Type/Proxy.rakudoc:17 synopsis -------------------------------------
 
@@ -122,6 +122,31 @@ nok (try bad()).defined, 'a throwing FETCH is caught by the try around the call'
 
 my $ok := try double();
 is $ok.VAR.^name, 'Proxy', 'an untroubled try still hands the container back';
+
+# --- a subscript decontainerizes a Proxy receiver ---------------------------
+
+# XML::Element's shape: an `is rw` AT-POS returning a Proxy over the node list.
+# Now that such a return reaches the caller as a container, a CHAINED subscript
+# arrives holding the Proxy itself, and the second subscript has to FETCH it
+# rather than index the container as a one-element list.
+
+class Node {
+    has @.kids;
+    method AT-POS($i) is rw {
+        my $self = self;
+        Proxy.new(
+            FETCH => method ()   { $self.kids[$i]      },
+            STORE => method ($v) { $self.kids[$i] = $v },
+        )
+    }
+}
+
+my $leaf = Node.new(kids => <a b c>);
+my $tree = Node.new(kids => [$leaf]);
+is $tree[0][1], 'b', 'a chained subscript FETCHes the intermediate Proxy';
+is $tree[0].kids.join(','), 'a,b,c', 'a method call on it FETCHes too';
+$tree[0][1] = 'B';
+is $leaf.kids.join(','), 'a,B,c', 'and writing through the chain STOREs';
 
 # --- a Proxy captured by a closure/sub still STOREs through --------------
 

--- a/t/thread-shared-scalar-visibility.t
+++ b/t/thread-shared-scalar-visibility.t
@@ -60,7 +60,9 @@ plan 9;
 
 # --- scalar holding a Proxy ----------------------------------------------
 {
-    todo 'STORE through a Proxy bound in the parent does not reach the parent (PLAN.md §6)';
+    # Un-TODO'd with #7748: the write reaches the parent now. The assignment
+    # inside the `start` block resolves the captured `$p` by NAME, and that
+    # store path used to replace the container instead of running STORE.
     my $backing = 0;
     my $p := Proxy.new(FETCH => method () { $backing }, STORE => method ($v) { $backing = $v });
     await start { $p = 9 };


### PR DESCRIPTION
`Proxy`'s whole purpose is to be bound to a name and then read and written through `FETCH`/`STORE`, and the `Type/Proxy.rakudoc:17` synopsis did not work at all:

```raku
sub double() is rw {
    my $storage = 0;
    Proxy.new(
        FETCH => method ()     { $storage * 2    },
        STORE => method ($new) { $storage = $new },
    )
}
my $doubled := double();
$doubled = 4;
say $doubled;      # raku: 8   mutsu: Cannot assign to an immutable value
```

## Root cause

Raku decontainerizes an ordinary `sub`'s return, so a `Proxy` built in its body reaches the caller already FETCHed. `is raw`, `is rw` and an explicit `return-rw` each suppress that: the caller receives the `Proxy` itself and the FETCH happens at the next *use*. That is what makes the synopsis work — the `:=` binds a container, so the later `=` has a `STORE` to run.

The return path tested `is raw` alone (`cf_auto_fetch = !cf.is_raw`), and the code-object path had the rule inverted outright (`auto_fetch = data.is_rw`, so an `is rw` routine was the *only* shape that FETCHed). Every `is rw` return was therefore resolved at the call, the binding held a plain value, and the assignment died as immutable.

## The fix

State the decision once per carrier, reading the whole ADR-0067 rule (`is rw`, `is raw`, **or** `return-rw`):

- **`Interpreter::routine_is_rw_capable` / `method_is_rw_capable`** wherever a resolved def was already in hand. This also brings the nine method-return auto-FETCH sites under the rule, so a `Proxy` returned from a method behaves as one returned from a sub. The two sites that no longer hold the def get `class_method_is_rw_capable`, an MRO walk that runs only once a `Proxy` is actually in hand.
- **`CompiledFunction::returns_container()`** for the compiled path. It carries no body AST, so it gets a new `uses_return_rw` precomputed at declaration time — which makes `sub f() { return-rw Proxy.new(...) }` bind a container too.
- **`SubData::returns_container()`** for the code-object path. It answers *container* for anything it cannot prove decontainerizes: a bare or pointy block returns raw in Raku anyway, and an anonymous `sub` is built from an `Expr::AnonSubParams`, which records `is_rw` but has no field for `is_raw` — so `sub () is raw { ... }` is indistinguishable there and keeps the pre-existing no-FETCH answer.

## Three bugs this uncovered, fixed here

**`try` did not evaluate its value.** With the container now reaching the caller, `(try dying-fetch-proxy()).defined` would FETCH *outside* the `try` and escape it. Rakudo evaluates a genuine `try`'s value inside the protected region — a throwing FETCH is caught and the `try` yields `Nil`, while an untroubled one still hands the `Proxy` back (`my $p := try f(); $p.VAR.^name` is `Proxy`). `TryCatch` now probes its body's value the same way, which also fixes the same escape for an `is raw` routine, where it was already reachable.

**A captured `Proxy` never ran `STORE`.** An assignment inside a block or a named sub reaches the variable by name (`SetGlobal`), never through a local slot, and that path replaced the captured container with the plain value instead of running `STORE` — the write silently vanished and the program carried on:

```raku
my $cell = 0;
my $p := Proxy.new(FETCH => method () { $cell }, STORE => method ($n) { $cell = $n });
my $b = { $p = 2 }; $b();      # raku: $cell is 2;  mutsu: still 0
sub s1() { $p = 3 }; s1();     # raku: $cell is 3;  mutsu: still 0
```

The store now checks for a `Proxy` before both write-throughs on that path (the compunit-lexical store and the generic `ContainerRef` one), each of which would otherwise rebind the name rather than write through it. This was live on `main` independently of the return rule; it stayed hidden because a bound name almost never held a real `Proxy` before.

**A subscript did not decontainerize a `Proxy` receiver.** This is XML's shape — `XML::Element::AT-POS` is `is rw` and returns a `Proxy` over the node list — and it is what the bundled-library gate caught on the first push (`XML/proxies.rakutest` and `XML/example.rakutest` fell below their baseline):

```raku
$xml[1][0].string      # No such method 'string' for invocant of type 'XML::Element'
```

The *second* subscript arrives holding the `Proxy` itself and indexed it as though it were a one-element list. `Index` FETCHes a `Proxy` receiver now, which is the decont raku performs on a subscript's invocant. Fusing the two levels on the *write* side (`$obj[i][j] = v` where `AT-POS` is `is rw`) had never worked, on `main` either — the chained-subscript store read the inner collection through the accessor and then had no way to descend past it — so when the inner instance has no `ASSIGN-POS`/`ASSIGN-KEY`, its own rw accessor is now asked for the location and the value stored through that.

## Tests

- New pin `t/proxy-rw-routine-return-bind.t` — 28 tests, verified to pass identically under rakudo: read, write and read-after-write through the binding; `FETCH`/`STORE` counted exactly once per access, including in interpolation and as a sub argument; a `Proxy` returned from a method; a plain `sub` still decontainerizing its return; `return-rw` without either trait; the `try` probe; a chained subscript reading and writing through an `is rw` `AT-POS`; and the three captured-`Proxy` store shapes.
- `t/thread-shared-scalar-visibility.t` loses its "STORE through a captured Proxy is visible" `todo` — a `start` block's write is one of the captured-name stores the second fix repairs.
- `cargo fmt`, `make lint` (all four configurations), `make test` (41816 tests), `make roast` and `scripts/battery-testsuite.sh` all run locally. The only failures are the documented container-only ones: roast's `6.c/S32-io/file-tests.t` + `S16-filehandles/filetest.t` under `uid 0` and `S32-io/IO-Socket-Async.t` under the network sandbox (exact subtest ranges as `docs/agent-environments.md` records), and the battery gate's six DBIish MySQL files with no `libmysqlclient` installed. XML is clean in the gate.

Closes #7748.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Djo5f9tJ1zhSi7agc1NRMK