### PR TITLE
perf: bind multi candidate matching into a scoped env overlay

### DIFF
--- a/news/2026-09/candidate-matching-binds-into-a-scoped-overlay.md
+++ b/news/2026-09/candidate-matching-binds-into-a-scoped-overlay.md
@@ -1,0 +1,55 @@
+# Multi candidate matching stopped deep-copying the frame env per candidate
+
+`Interpreter::method_args_match_for_invocant` decides whether one `multi method`
+candidate accepts a call. It is a *speculative* window: it binds the role's type
+parameters, the candidate's own `role_param_bindings`, the method's captured
+lexical scope, `self`, and any `::T` type captures; it runs the `where`
+constraints; and then it rolls the whole lot back. A multi with four candidates
+runs it four times per call.
+
+It bound all of that into the running frame's own env. And the rollback needs a
+snapshot -- `let saved_env = self.env.clone()` -- which shares the env's `Arc`.
+So the *first* of those binds hit `Arc::make_mut` and deep-copied the entire map.
+Every candidate of every multi method call paid one O(env) copy of a map whose
+size is the number of names in scope.
+
+It binds into an `Env::scoped_child` overlay now. That is exactly what scoped
+envs are for, and their doc comment already said so: "an empty overlay that reads
+through to `parent` ... so the inherited entries are never `make_mut`-deep-copied".
+The same writes are O(1) into the empty tier, and the rollback is dropping the
+tier rather than restoring a copied map. `restore_env_preserving_dynamics` gets
+faster for free: the `iter()` it scans for dynamic-variable writes now walks the
+overlay -- exactly the writes made in the window -- instead of every name in
+scope.
+
+## Measurement
+
+`env_deep_copies` counted these, but the count could not distinguish a copy of a
+900-entry frame env from a copy of an empty overlay, and only the first is a cost
+that grows with the program. So the counter gained a companion,
+`env_deep_copy_entries`, which sums the map's length at each copy. That is the
+number that matters, and it is what the regression test asserts.
+
+Measured as the slope against the call count, so the program's fixed setup cancels
+out. A `class` with two `multi method` candidates, one `where`-guarded, called 50
+and then 250 times:
+
+| | entries deep-copied per call |
+| --- | --- |
+| before | 121 |
+| after | 1 |
+
+Independent of how many names are in scope, which was the point: padding the file
+scope with 400 extra lexicals leaves the slope at 1.
+
+On the HTTP/2 request parser this is the largest single source of env deep copies
+(547 copies of an 888-entry env over a 20-frame run), and removing it takes a
+HEADERS frame from 15.4 ms to 13.7 ms.
+
+## Found while writing the tests
+
+A `where` clause on a method parameter cannot read `$.attr` through the invocant
+(`multi method f($x where { $x > $.limit })` never matches). That is a
+long-standing gap, not a regression -- it fails identically before and after this
+change -- and is filed as
+[#7799](https://github.com/tokuhirom/mutsu/issues/7799).

--- a/src/env.rs
+++ b/src/env.rs
@@ -1137,7 +1137,7 @@ impl Env {
     #[inline]
     fn cow_mut(&mut self) -> &mut SymMap {
         if crate::vm::vm_stats::enabled() && Arc::strong_count(&self.inner) > 1 {
-            crate::vm::vm_stats::record_env_deep_copy();
+            crate::vm::vm_stats::record_env_deep_copy(self.inner.len());
         }
         Arc::make_mut(&mut self.inner)
     }

--- a/src/runtime/resolution_method.rs
+++ b/src/runtime/resolution_method.rs
@@ -19,7 +19,18 @@ impl Interpreter {
         role_bindings: Option<&rustc_hash::FxHashMap<String, Value>>,
         invocant: Option<&Value>,
     ) -> bool {
+        // Candidate matching is a *speculative* window: everything it binds
+        // (role type params, the method's captured lexical scope, `self`, type
+        // captures) is rolled back when it ends, and it can run for every
+        // candidate of a multi. Bind into a scoped overlay rather than into the
+        // frame's own env: a `saved_env` clone shares the env's `Arc`, so the
+        // first write used to `make_mut`-deep-copy the whole map -- 888 entries
+        // with Cro's module stack loaded, 547 times over a 20-frame HTTP/2 run,
+        // and it is the single biggest source of env deep copies on that path.
+        // The overlay starts empty, so the same writes are O(1) and the
+        // rollback is dropping a tier.
         let saved_env = self.env.clone();
+        self.env = crate::env::Env::scoped_child(std::mem::take(&mut self.env));
         // The passed-in class-level map goes first (it also carries nested
         // generic-class rename entries, not just type-param bindings — see
         // the identical comment in `call_compiled_method`,

--- a/src/vm/vm_stats.rs
+++ b/src/vm/vm_stats.rs
@@ -99,6 +99,11 @@ fn resolver_method_by_name() -> &'static Mutex<HashMap<String, u64>> {
 // Dual-store (locals <-> env) sync cost. See docs/vm-dual-store.md.
 static CLONE_ENV: AtomicU64 = AtomicU64::new(0);
 static ENV_DEEP_COPY: AtomicU64 = AtomicU64::new(0);
+/// Entries actually copied by those deep copies (the sum of the map's length at
+/// each one). The *count* alone cannot tell a copy of a 900-entry frame env from
+/// a copy of an empty scoped overlay, and only the former is a cost that grows
+/// with the size of the program; this is the number that does.
+static ENV_DEEP_COPY_ENTRIES: AtomicU64 = AtomicU64::new(0);
 static ENV_FLUSH: AtomicU64 = AtomicU64::new(0);
 static ENV_SLOTS_FLUSHED: AtomicU64 = AtomicU64::new(0);
 
@@ -967,9 +972,10 @@ pub(crate) fn record_clone_env() {
 /// write inside a method body whose frame holds a clone of the env). This is
 /// the real cost the dual-store work targets, not `clone_env`.
 #[inline]
-pub(crate) fn record_env_deep_copy() {
+pub(crate) fn record_env_deep_copy(entries: usize) {
     if enabled() {
         ENV_DEEP_COPY.fetch_add(1, Ordering::Relaxed);
+        ENV_DEEP_COPY_ENTRIES.fetch_add(entries as u64, Ordering::Relaxed);
     }
 }
 
@@ -1089,10 +1095,11 @@ pub(crate) fn dump() {
     );
     let clone_env = CLONE_ENV.load(Ordering::Relaxed);
     let deep_copy = ENV_DEEP_COPY.load(Ordering::Relaxed);
+    let deep_copy_entries = ENV_DEEP_COPY_ENTRIES.load(Ordering::Relaxed);
     let env_flush = ENV_FLUSH.load(Ordering::Relaxed);
     let slots = ENV_SLOTS_FLUSHED.load(Ordering::Relaxed);
     eprintln!(
-        "[mutsu vm-stats] dual-store: clone_env={clone_env} (O(1) Arc bumps) env_deep_copies={deep_copy} (O(env) make_mut) env_flushes={env_flush} slots_flushed={slots}"
+        "[mutsu vm-stats] dual-store: clone_env={clone_env} (O(1) Arc bumps) env_deep_copies={deep_copy} (O(env) make_mut) env_deep_copy_entries={deep_copy_entries} env_flushes={env_flush} slots_flushed={slots}"
     );
     let default_evals = PARAM_DEFAULT_EVALS.load(Ordering::Relaxed);
     let default_consts = PARAM_DEFAULT_CONSTS.load(Ordering::Relaxed);

--- a/t/multi-candidate-match-scoped-window.t
+++ b/t/multi-candidate-match-scoped-window.t
@@ -1,0 +1,44 @@
+use Test;
+
+# Candidate matching for a `multi` binds into a scoped env overlay rather than
+# into the running frame's env (#7667). The overlay must be invisible: the
+# bindings it makes are rolled back, but a `where` clause's writes to *dynamic*
+# variables are real side effects and must survive.
+
+plan 8;
+
+class C {
+    multi method m(Int $x where { $x > 100 }) { 'big' }
+    multi method m(Int $x)                    { 'small' }
+    multi method m(Str $s)                    { 'str' }
+}
+my $c = C.new;
+is $c.m(5),    'small', 'the wider candidate wins when the where fails';
+is $c.m(500),  'big',   'the narrower candidate wins when the where holds';
+is $c.m('x'),  'str',   'a type-only candidate still dispatches';
+
+# A `where` clause is user code; its writes to a dynamic must survive the
+# speculative window's rollback.
+my $*trace = '';
+class D {
+    multi method n($x where { $*trace ~= 'w'; $x > 10 }) { 'hi' }
+    multi method n($x)                                   { 'lo' }
+}
+is D.new.n(3), 'lo', 'where-guarded candidate declined';
+ok $*trace.contains('w'), 'a where clause side effect on a dynamic survives the rollback';
+
+# The window must not leak: names bound during matching are rolled back.
+my $outer = 'untouched';
+class F {
+    multi method g($x where { $x > 3 }) { 'gt' }
+    multi method g($x)                  { 'le' }
+}
+is F.new.g(1), 'le', 'rollback path taken (first candidate declined)';
+is $outer, 'untouched', 'a caller lexical is unchanged after candidate matching';
+
+# Nested multi dispatch inside a where clause still resolves both levels.
+class G {
+    multi method h($x where { F.new.g($x) eq 'gt' }) { 'nested-gt' }
+    multi method h($x)                               { 'nested-le' }
+}
+is G.new.h(9), 'nested-gt', 'a where clause may itself dispatch a multi';

--- a/tests/multi_candidate_match_does_not_copy_the_frame_env.rs
+++ b/tests/multi_candidate_match_does_not_copy_the_frame_env.rs
@@ -1,0 +1,75 @@
+//! Pins the scoped overlay `method_args_match_for_invocant` binds into (#7667).
+//!
+//! Candidate matching is a speculative window: it binds role type parameters,
+//! the candidate's captured lexical scope, `self` and type captures, runs the
+//! `where` constraints, and then rolls the whole lot back. It used to bind them
+//! into the running frame's own env -- and since the rollback needs
+//! `saved_env = self.env.clone()`, which shares the env's `Arc`, the *first*
+//! such bind hit `Arc::make_mut` and deep-copied the entire map. Every candidate
+//! of every multi call paid one O(env) copy.
+//!
+//! It binds into an `Env::scoped_child` overlay now: an empty tier that reads
+//! through to the frame env, so the same writes are O(1) and the rollback is
+//! dropping the tier.
+//!
+//! Measured as the *slope* of `env_deep_copy_entries` against the call count, so
+//! the program's fixed setup cost cancels out and only the per-call cost is
+//! asserted. Before the change the slope was ~121 entries per call (the size of
+//! the frame env being copied); it is 1 now.
+
+use std::process::Command;
+
+/// One multi with a `where` constraint, called `n` times. Every call runs
+/// candidate matching against both candidates.
+const PROGRAM: &str = r#"
+class C {
+    multi method m(Int $x where { $x > 100 }) { 'big' }
+    multi method m(Int $x) { 'small' }
+}
+my $c = C.new;
+my $n = +@*ARGS[0];
+my $r = '';
+for ^$n { $r = $c.m(5) }
+say $r;
+"#;
+
+fn env_deep_copy_entries(calls: u32) -> u64 {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_mutsu"));
+    cmd.arg("-e").arg(PROGRAM).arg(calls.to_string());
+    cmd.env("MUTSU_VM_STATS", "1");
+    let out = cmd.output().expect("failed to spawn mutsu");
+    let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
+    assert!(
+        out.status.success(),
+        "run failed\nstdout: {stdout}\nstderr: {stderr}"
+    );
+    assert_eq!(
+        stdout.trim(),
+        "small",
+        "the narrower candidate should not have won"
+    );
+    stderr
+        .lines()
+        .find_map(|l| l.split("env_deep_copy_entries=").nth(1))
+        .and_then(|v| v.split_whitespace().next())
+        .and_then(|v| v.parse().ok())
+        .unwrap_or_else(|| panic!("no env_deep_copy_entries in stats: {stderr}"))
+}
+
+#[test]
+fn a_multi_call_does_not_deep_copy_the_frame_env_per_candidate() {
+    let few = env_deep_copy_entries(50);
+    let many = env_deep_copy_entries(250);
+    assert!(
+        many >= few,
+        "counter went backwards: {few} for 50 calls, {many} for 250"
+    );
+    let per_call = (many - few) as f64 / 200.0;
+    assert!(
+        per_call < 10.0,
+        "each multi call deep-copies {per_call:.1} env entries ({few} for 50 calls, \
+         {many} for 250) -- candidate matching is binding into the frame env again \
+         instead of an Env::scoped_child overlay. It was ~121 before the fix, 1 after."
+    );
+}


### PR DESCRIPTION
## What

`Interpreter::method_args_match_for_invocant` decides whether one `multi method`
candidate accepts a call. It is a *speculative* window: it binds the role's type
parameters, the candidate's own `role_param_bindings`, the method's captured
lexical scope, `self` and any `::T` type captures; it runs the `where`
constraints; and then it rolls the whole lot back. A multi with four candidates
runs it four times per call.

It bound all of that into the running frame's own env. And the rollback needs a
snapshot — `let saved_env = self.env.clone()` — which shares the env's `Arc`. So
the **first** of those binds hit `Arc::make_mut` and deep-copied the entire map.
Every candidate of every multi method call paid one O(env) copy of a map whose
size is the number of names in scope.

## How

It binds into an `Env::scoped_child` overlay now. That is exactly what scoped
envs are for, and their doc comment already said so — *"an empty overlay that
reads through to `parent` … so the inherited entries are never
`make_mut`-deep-copied"*. The same writes are O(1) into the empty tier, and the
rollback is dropping the tier rather than restoring a copied map.

`restore_env_preserving_dynamics` gets faster for free: the `iter()` it scans for
dynamic-variable writes now walks the overlay — exactly the writes made in the
window — instead of every name in scope. Same result, because an entry the window
did not write is by definition equal to the saved one and was filtered out anyway.

## Measurement

`env_deep_copies` could not measure this: the count cannot tell a copy of a
900-entry frame env from a copy of an empty overlay, and only the first is a cost
that grows with the program. So it gained a companion, `env_deep_copy_entries`,
which sums the map's length at each copy — the number that actually matters, and
what the regression test asserts.

Measured as the **slope** against the call count, so the program's fixed setup
cancels out. A class with two `multi method` candidates, one `where`-guarded,
called 50 and then 250 times:

| | entries deep-copied per call |
| --- | --- |
| before | 121 |
| after | 1 |

Independent of how many names are in scope, which was the point: padding the file
scope with 400 extra lexicals leaves the slope at 1 (and left it at 121 before).

On the HTTP/2 request parser from #7667 this is the largest single source of env
deep copies — 547 copies of an 888-entry env over a 20-frame run — and removing
it takes a HEADERS frame from **15.4 ms to 13.7 ms**.

## Tests

- `tests/multi_candidate_match_does_not_copy_the_frame_env.rs` — asserts the
  per-call slope of `env_deep_copy_entries` stays under 10 (121 before, 1 now).
- `t/multi-candidate-match-scoped-window.t` — pins the semantics the overlay must
  not disturb: both `where`-guarded and type-only candidates still dispatch
  correctly, a `where` clause's side effect on a **dynamic** survives the
  rollback, a caller lexical is untouched afterwards, and a `where` clause may
  itself dispatch a multi (nested windows).

Local `cargo fmt`, `make lint`, `make test` (3932 files, 41816 tests, PASS) and
`make roast` were all run. `make roast` reports only the three container-only
failures documented in `docs/agent-environments.md`, with exactly the test numbers
that doc lists.

## Found while writing the tests

A `where` clause on a method parameter cannot read `$.attr` through the invocant
(`multi method f($x where { $x > $.limit })` never matches, and the call dies
rather than falling through to the wider candidate). Verified as a long-standing
gap, not a regression — it fails identically with and without this change — and
filed separately as #7799.

Part of #7667.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NX9vs4NbdKXUu6MoAaHpSz

---
_Generated by [Claude Code](https://claude.ai/code/session_01NX9vs4NbdKXUu6MoAaHpSz)_