### PR TITLE
perf: cache the compiled chunk for a whenever callback instead of recompiling per value

### DIFF
--- a/news/2026-09/whenever-callbacks-stopped-recompiling-per-value.md
+++ b/news/2026-09/whenever-callbacks-stopped-recompiling-per-value.md
@@ -1,0 +1,75 @@
+# A `whenever` callback body was compiled from AST on every emitted value
+
+`eval_block_value_inner` caches the bytecode it compiles for a carrier block,
+keyed by the code object's `SubData.id` plus the ambient compile context. But it
+*bypassed* that cache whenever any of four per-code-object mutations had to be
+applied to the freshly compiled chunk -- the supply-body mark, the emitter name,
+the vouched capture set, and the inherited owned-lexical set:
+
+```rust
+let needs_fresh_mutation = is_supply_block_body
+    || supply_emitter_sym.is_some()
+    || !supply_authoritative_free_vars.is_empty()
+    || !whenever_inherited_owned.is_empty();
+```
+
+The stated reason was sound: a cached `Arc` must stay byte-identical to what a
+fresh compile would have produced, and these four fields are what the uncached
+path mutates afterwards. The conclusion was not. All four are derived from the
+**code object being run**, not from the ambient frame, so for one cache id they
+are the same on every call. They are a *key*, not a reason to bypass.
+
+A `whenever` callback's `authoritative_captures` is never empty, so it took that
+branch on **every emitted value**. One full `Compiler::compile` over the
+callback's AST per item through the supply -- and with it, one full `core::fmt`
+Debug traversal of that AST for each `function_body_fingerprint` the compiler
+computes along the way, which costs more than the compilation it is identifying.
+
+The four values are part of `CarrierCompileCtxKey` now, and applied to the fresh
+chunk before it is shared, so the byte-identity argument still holds and the
+cache serves.
+
+## Results
+
+A supply whose `whenever` callback runs once per emitted value, counted with the
+new `carrier-compile: hits=.. misses=..` vm-stat:
+
+| emits | misses before | misses after |
+| --- | --- | --- |
+| 10 | 12 | 3 |
+| 40 | 42 | 3 |
+
+Exactly one compile per value before; a constant after.
+
+On the HTTP/2 request parser (release build, this container):
+
+| | before | after |
+| --- | --- | --- |
+| DATA frame | 2.12 ms | 1.23 ms |
+| HEADERS frame | 13.7 ms | ~11 ms |
+
+## The motivating case now passes
+
+`cro-http`'s `t/http2-request-parser.rakutest` under `MUTSU_REAL_TEST=1` -- item 3
+of the vendored-`Test` battery gate, [#7555](https://github.com/tokuhirom/mutsu/issues/7555),
+and the reason [#7667](https://github.com/tokuhirom/mutsu/issues/7667) was filed:
+
+| | passes |
+| --- | --- |
+| before any of this work | 0 / 15 |
+| after the registry-COW fix (#7786) | 3 / 15 |
+| after sharing the program tables (#7796) | 15 / 20 |
+| after the scoped candidate-match overlay (#7800) | 16 / 20 |
+| after this change | **29 / 30** |
+
+The test loses a race whose two sides start at the same instant: one waits for a
+DATA frame and then reads `*.body-blob.result`, the other runs three `ok`
+assertions. Every fix in that list moved the losing side specifically -- the DATA
+frame and `body-blob`, not the `ok`s -- which is why they moved the outcome where
+a uniformly faster interpreter would not have.
+
+`tests/carrier_compile_cache_serves_whenever_callbacks.rs` pins the miss count
+against the emit count; `t/whenever-callback-recompile-semantics.t` pins what the
+cached chunk must still do -- chained supplies keep their own emitters, captured
+lexicals accumulate, `state` persists, a nested `whenever` registers per value,
+and `LAST` still runs.

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -371,6 +371,22 @@ struct CarrierCompileCtxKey {
     /// eval_context_dead_routine`). Must stay in the key or the cache could
     /// serve a unit compiled under the wrong classification.
     eval_context_routine: Option<EvalContextRoutineState>,
+    /// The four post-compile mutations `eval_block_value_inner` applies to the
+    /// chunk it just compiled: the supply-body mark, the emitter name, the
+    /// vouched capture set and the inherited owned-lexical set. They come from
+    /// the `SubData` being run, so they are the same on every call for one
+    /// `cache_id` -- but they are *not* the same across two different code
+    /// objects that happen to share one, so they belong in the key.
+    ///
+    /// They used to bypass the cache instead ("compile fresh, don't store"),
+    /// which meant a `whenever` callback -- whose `authoritative_captures` is
+    /// never empty -- was re-compiled from AST on every single emitted value.
+    /// On Cro's HTTP/2 parser that was one full `Compiler::compile` per DATA
+    /// frame, 38% of the frame's instructions (#7667).
+    supply_block_body: bool,
+    supply_emitter_sym: Option<Symbol>,
+    supply_authoritative_free_vars: Vec<Symbol>,
+    whenever_inherited_owned: Vec<Symbol>,
 }
 
 /// Per-`SubData.id` cache of `(context, compiled)` pairs for

--- a/src/runtime/resolution_eval.rs
+++ b/src/runtime/resolution_eval.rs
@@ -7,6 +7,33 @@ type ProtectBlockCapturedBindings = std::sync::Arc<Vec<(usize, String)>>;
 type ProtectBlockWritebackBindings = std::sync::Arc<Vec<(usize, String)>>;
 type ProtectBlockCapturedNames = std::sync::Arc<Vec<String>>;
 
+/// The four per-`SubData` mutations `eval_block_value_inner` applies to the
+/// chunk it compiles for a carrier block, gathered so they can be both keyed on
+/// and applied in one place.
+///
+/// They are derived from the code object being run, not from the ambient frame,
+/// so for one `cache_id` they are the same on every call -- which is what makes
+/// caching a chunk carrying them sound. See [`CarrierCompileCtxKey`].
+pub(super) struct CarrierPostCompile {
+    is_supply_block_body: bool,
+    supply_emitter_sym: Option<crate::symbol::Symbol>,
+    authoritative_free_vars: Vec<crate::symbol::Symbol>,
+    inherited_owned_lexicals: Vec<crate::symbol::Symbol>,
+}
+
+impl CarrierPostCompile {
+    fn apply(&self, code: &mut crate::opcode::CompiledCode) {
+        code.is_supply_block_body = self.is_supply_block_body;
+        code.supply_emitter_sym = self.supply_emitter_sym;
+        code.inherited_owned_lexicals = self.inherited_owned_lexicals.clone();
+        for sym in &self.authoritative_free_vars {
+            if !code.authoritative_free_vars.contains(sym) {
+                code.authoritative_free_vars.push(*sym);
+            }
+        }
+    }
+}
+
 impl Interpreter {
     pub(crate) fn composed_result_to_args(value: Value, prefer_single: bool) -> Vec<Value> {
         if prefer_single {
@@ -293,7 +320,11 @@ impl Interpreter {
     /// since a genuine wrong-key situation just means the two computations
     /// disagree and this key stops matching future identical calls — but
     /// keep them matching so the cache actually helps.
-    fn carrier_compile_ctx_key(&self, is_eval_unit: bool) -> CarrierCompileCtxKey {
+    fn carrier_compile_ctx_key(
+        &self,
+        is_eval_unit: bool,
+        post: &CarrierPostCompile,
+    ) -> CarrierCompileCtxKey {
         let in_routine = if is_eval_unit {
             self.eval_unit_in_routine()
         } else {
@@ -322,6 +353,10 @@ impl Interpreter {
             } else {
                 None
             },
+            supply_block_body: post.is_supply_block_body,
+            supply_emitter_sym: post.supply_emitter_sym,
+            supply_authoritative_free_vars: post.authoritative_free_vars.clone(),
+            whenever_inherited_owned: post.inherited_owned_lexicals.clone(),
         }
     }
 
@@ -335,17 +370,26 @@ impl Interpreter {
         body: &[Stmt],
         is_eval_unit: bool,
         cache_id: u64,
+        post: &CarrierPostCompile,
     ) -> (
         std::sync::Arc<crate::opcode::CompiledCode>,
         std::sync::Arc<crate::opcode::CompiledFns>,
     ) {
-        let key = self.carrier_compile_ctx_key(is_eval_unit);
+        let key = self.carrier_compile_ctx_key(is_eval_unit, post);
         if let Some(entries) = self.carrier_compile_cache.get(&cache_id)
             && let Some((_, code, fns)) = entries.iter().find(|(k, ..)| *k == key)
         {
+            crate::vm::vm_stats::record_carrier_compile(true);
             return (code.clone(), fns.clone());
         }
-        let (code, fns) = self.compile_block_value_opts(body, is_eval_unit);
+        crate::vm::vm_stats::record_carrier_compile(false);
+        let (mut code, fns) = self.compile_block_value_opts(body, is_eval_unit);
+        // The four per-`SubData` mutations, applied BEFORE the chunk is shared.
+        // They are part of the key above, so an entry served from the cache is
+        // byte-identical to what this fresh path produces for the same key --
+        // which is what lets them be cached at all rather than forcing a
+        // re-compile (see `CarrierCompileCtxKey`'s doc).
+        post.apply(&mut code);
         let code = std::sync::Arc::new(code);
         let fns = std::sync::Arc::new(fns);
         let entries = self.carrier_compile_cache.entry(cache_id).or_default();
@@ -421,26 +465,21 @@ impl Interpreter {
         // exactly what the plain (uncached) path below mutates post-compile.
         // Bypass the cache (compile fresh, don't store) rather than caching a
         // wrong/stale mutation.
-        let needs_fresh_mutation = is_supply_block_body
-            || supply_emitter_sym.is_some()
-            || !supply_authoritative_free_vars.is_empty()
-            || !whenever_inherited_owned.is_empty();
+        let post = CarrierPostCompile {
+            is_supply_block_body,
+            supply_emitter_sym,
+            authoritative_free_vars: supply_authoritative_free_vars,
+            inherited_owned_lexicals: whenever_inherited_owned,
+        };
         // Re-armed only for the duration of the compile below (the cache key
         // and `compile_block_value_opts` read it), then cleared before the body
         // runs so nothing compiled during execution inherits it.
         self.pending_eval_rw_tail = rw_tail;
-        let (code, compiled_fns) = if !needs_fresh_mutation && let Some(id) = cache_id {
-            self.compile_block_value_cached(body, is_eval_unit, id)
+        let (code, compiled_fns) = if let Some(id) = cache_id {
+            self.compile_block_value_cached(body, is_eval_unit, id, &post)
         } else {
             let (mut code, fns) = self.compile_block_value_opts(body, is_eval_unit);
-            code.is_supply_block_body = is_supply_block_body;
-            code.supply_emitter_sym = supply_emitter_sym;
-            code.inherited_owned_lexicals = whenever_inherited_owned;
-            for sym in supply_authoritative_free_vars {
-                if !code.authoritative_free_vars.contains(&sym) {
-                    code.authoritative_free_vars.push(sym);
-                }
-            }
+            post.apply(&mut code);
             (std::sync::Arc::new(code), std::sync::Arc::new(fns))
         };
         self.pending_eval_rw_tail = false;

--- a/src/vm/vm_stats.rs
+++ b/src/vm/vm_stats.rs
@@ -240,6 +240,24 @@ pub(crate) fn record_program_table_cow_clone() {
     }
 }
 
+/// Carrier-block compiles served from / missed by `carrier_compile_cache`
+/// (`eval_block_value_inner`). Reported as `carrier-compile: hits=.. misses=..`.
+/// A misses count that grows with the number of times a block RUNS -- rather
+/// than with the number of distinct blocks and ambient contexts -- means the
+/// cache is being bypassed and the body is re-compiled from AST per call.
+static CARRIER_COMPILE_HITS: AtomicU64 = AtomicU64::new(0);
+static CARRIER_COMPILE_MISSES: AtomicU64 = AtomicU64::new(0);
+
+pub(crate) fn record_carrier_compile(hit: bool) {
+    if enabled() {
+        if hit {
+            CARRIER_COMPILE_HITS.fetch_add(1, Ordering::Relaxed);
+        } else {
+            CARRIER_COMPILE_MISSES.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+}
+
 // Per-spawn lineage seeding (docs/per-task-clone-slimming.md slice 5 step A):
 // `SPAWN_SEED_KEYS` counts env entries walked by the `clone_for_thread`
 // seeding loop; `SPAWN_SEED_INSERTS` the subset that actually landed in the
@@ -1151,6 +1169,9 @@ pub(crate) fn dump() {
     eprintln!("[mutsu vm-stats] registry-cow: clones={registry_cow_clones}");
     let program_table_cow_clones = PROGRAM_TABLE_COW_CLONES.load(Ordering::Relaxed);
     eprintln!("[mutsu vm-stats] program-table-cow: clones={program_table_cow_clones}");
+    let carrier_hits = CARRIER_COMPILE_HITS.load(Ordering::Relaxed);
+    let carrier_misses = CARRIER_COMPILE_MISSES.load(Ordering::Relaxed);
+    eprintln!("[mutsu vm-stats] carrier-compile: hits={carrier_hits} misses={carrier_misses}");
     let mainline_lexical_boxes = MAINLINE_LEXICAL_BOXES.load(Ordering::Relaxed);
     let mainline_lexical_hits = MAINLINE_LEXICAL_HITS.load(Ordering::Relaxed);
     eprintln!(

--- a/t/whenever-callback-recompile-semantics.t
+++ b/t/whenever-callback-recompile-semantics.t
@@ -1,0 +1,60 @@
+use Test;
+
+# A `whenever` callback body's compiled chunk is cached across emitted values
+# (#7667). The four per-code-object mutations that used to force a fresh compile
+# -- the supply-body mark, the emitter name, the vouched capture set, the
+# inherited owned-lexical set -- are part of the cache key now, so the cached
+# chunk must behave exactly as a freshly compiled one did.
+
+plan 6;
+
+# The callback's `emit` must keep reaching its OWN supply's emitter across many
+# values, not a sibling instance's.
+sub doubler(Supply $in) { supply { whenever $in -> $v { emit $v * 2 } } }
+my $s1 = Supplier.new;
+my @got;
+doubler(doubler($s1.Supply)).tap({ @got.push($_) });
+$s1.emit($_) for 1..5;
+is @got, [4, 8, 12, 16, 20], 'a chained supply pair keeps its emitters straight over many values';
+
+# A lexical the callback closes over stays shared across every invocation.
+my $sup = Supplier.new;
+my $total = 0;
+my $out = supply { whenever $sup -> $v { $total += $v; emit $total } };
+my @running;
+$out.tap({ @running.push($_) });
+$sup.emit($_) for 1..4;
+is @running, [1, 3, 6, 10], 'a captured lexical accumulates across cached-chunk runs';
+is $total, 10, 'and the outer binding sees the final value';
+
+# `state` inside a callback restarts per code object, not per call.
+my $sup2 = Supplier.new;
+my @seen;
+supply { whenever $sup2 -> $v { state $n = 0; $n++; emit $n } }.tap({ @seen.push($_) });
+$sup2.emit('x') for ^4;
+is @seen, [1, 2, 3, 4], 'a `state` variable in a whenever body persists across values';
+
+# A nested whenever inside the callback still registers each time. The nested
+# body runs when the promise is kept, so the emitted value is what proves it ran
+# -- awaited through the outer supply rather than slept on.
+my $sup3 = Supplier.new;
+my @fired;
+my $done = Promise.new;
+my $sup3out = supply {
+    whenever $sup3 -> $v {
+        my $p = Promise.new;
+        whenever $p { emit $v * 10 }
+        $p.keep;
+    }
+};
+$sup3out.tap({ @fired.push($_); $done.keep if @fired.elems == 3 });
+$sup3.emit($_) for 1..3;
+await Promise.anyof($done, Promise.in(5));
+is @fired, [10, 20, 30], 'a nested whenever inside the callback fires once per value';
+
+# LAST still runs when the source is done.
+my $sup4 = Supplier.new;
+my @tail;
+supply { whenever $sup4 -> $v { emit $v; LAST emit 'done' } }.tap({ @tail.push($_) });
+$sup4.emit(7); $sup4.emit(8); $sup4.done;
+is @tail, [7, 8, 'done'], 'a LAST phaser in a whenever body still runs after many values';

--- a/tests/carrier_compile_cache_serves_whenever_callbacks.rs
+++ b/tests/carrier_compile_cache_serves_whenever_callbacks.rs
@@ -1,0 +1,79 @@
+//! Pins the carrier-compile cache against `whenever` callback bodies (#7667).
+//!
+//! `eval_block_value_inner` caches the bytecode it compiles for a carrier block,
+//! keyed by the code object's `SubData.id` plus the ambient compile context. But
+//! it used to *bypass* the cache whenever any of four per-`SubData` mutations
+//! applied to the freshly compiled chunk -- the supply-body mark, the emitter
+//! name, the vouched capture set, the inherited owned-lexical set -- on the
+//! grounds that a cached `Arc` must stay byte-identical to a fresh compile.
+//!
+//! A `whenever` callback's `authoritative_captures` is never empty, so it took
+//! that branch on *every emitted value*: one full `Compiler::compile` over the
+//! callback's AST per item through the supply, and with it a full Debug
+//! traversal of that AST for each `function_body_fingerprint` the compiler
+//! computes. On Cro's HTTP/2 request parser that was 38% of a DATA frame.
+//!
+//! The four values are derived from the code object, not the ambient frame, so
+//! they are the same on every call for one cache id -- which makes them a *key*,
+//! not a reason to bypass. They are part of `CarrierCompileCtxKey` now and
+//! applied before the chunk is shared, so the byte-identity argument still holds
+//! and the cache serves.
+//!
+//! A regression shows up as `carrier-compile: misses=` growing with the number
+//! of values pushed through the supply instead of staying constant.
+
+use std::process::Command;
+
+/// A supply whose `whenever` callback runs once per emitted value.
+const PROGRAM: &str = r#"
+my $sup = Supplier.new;
+my $out = supply { whenever $sup -> $v { emit $v * 2 } };
+my $n = +@*ARGS[0];
+my $sum = 0;
+$out.tap({ $sum += $_ });
+for ^$n { $sup.emit($_) }
+say $sum;
+"#;
+
+/// `(sum the tap accumulated, carrier-compile misses)`.
+fn run(emits: u32) -> (u64, u64) {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_mutsu"));
+    cmd.arg("-e").arg(PROGRAM).arg(emits.to_string());
+    cmd.env("MUTSU_VM_STATS", "1");
+    let out = cmd.output().expect("failed to spawn mutsu");
+    let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
+    assert!(
+        out.status.success(),
+        "run failed\nstdout: {stdout}\nstderr: {stderr}"
+    );
+    let sum = stdout
+        .lines()
+        .last()
+        .and_then(|l| l.trim().parse().ok())
+        .unwrap_or_else(|| panic!("no sum on stdout: {stdout}"));
+    let misses = stderr
+        .lines()
+        .find_map(|l| l.split("carrier-compile: ").nth(1))
+        .and_then(|rest| rest.split("misses=").nth(1))
+        .and_then(|v| v.split_whitespace().next())
+        .and_then(|v| v.parse().ok())
+        .unwrap_or_else(|| panic!("no carrier-compile line in stats: {stderr}"));
+    (sum, misses)
+}
+
+#[test]
+fn a_whenever_callback_body_is_compiled_once_not_once_per_emitted_value() {
+    let (few_sum, few_misses) = run(10);
+    let (many_sum, many_misses) = run(40);
+    // sum of 2*i for i in 0..n
+    assert_eq!(few_sum, 90, "the tap did not see every emitted value");
+    assert_eq!(many_sum, 1560, "the tap did not see every emitted value");
+    // Before the fix these were 12 and 42 -- exactly `emits + 2`.
+    assert!(
+        many_misses <= few_misses + 2,
+        "carrier compiles grew with the number of emitted values: {few_misses} for 10 \
+         emits, {many_misses} for 40 -- the whenever callback body is being re-compiled \
+         from AST per item again (see CarrierCompileCtxKey)"
+    );
+}


### PR DESCRIPTION
## What

`eval_block_value_inner` caches the bytecode it compiles for a carrier block,
keyed by the code object's `SubData.id` plus the ambient compile context. But it
**bypassed** that cache whenever any of four per-code-object mutations had to be
applied to the freshly compiled chunk — the supply-body mark, the emitter name,
the vouched capture set, and the inherited owned-lexical set:

```rust
let needs_fresh_mutation = is_supply_block_body
    || supply_emitter_sym.is_some()
    || !supply_authoritative_free_vars.is_empty()
    || !whenever_inherited_owned.is_empty();
```

The stated reason was sound: a cached `Arc` must stay byte-identical to what a
fresh compile would have produced, and these four fields are exactly what the
uncached path mutates afterwards. The conclusion was not. All four are derived
from the **code object being run**, not from the ambient frame, so for one cache
id they are the same on every call. They are a *key*, not a reason to bypass.

A `whenever` callback's `authoritative_captures` is never empty, so it took that
branch on **every emitted value**: one full `Compiler::compile` over the
callback's AST per item through the supply — and with it a full `core::fmt` Debug
traversal of that AST for each `function_body_fingerprint` the compiler computes
along the way, which costs more than the compilation it is identifying.

Confirmed with `callgrind` on Cro's HTTP/2 parser: exactly 40 extra
`Compiler::compile` calls for 40 DATA frames, 38% of the frame's instructions.

## How

The four values are gathered into a `CarrierPostCompile` that both goes into
`CarrierCompileCtxKey` and applies them to the fresh chunk before it is shared —
so the byte-identity argument still holds and the cache serves.

A new `carrier-compile: hits=.. misses=..` vm-stat makes the bypass visible.

## Measurements

A supply whose `whenever` callback runs once per emitted value:

| emits | misses before | misses after |
| --- | --- | --- |
| 10 | 12 | 3 |
| 40 | 42 | 3 |

Exactly one compile per value before; a constant after.

HTTP/2 request parser, release build, this container:

| | before | after |
| --- | --- | --- |
| DATA frame | 2.12 ms | **1.23 ms** |
| HEADERS frame | 13.7 ms | ~11 ms |

## The motivating case now passes

`cro-http`'s `t/http2-request-parser.rakutest` under `MUTSU_REAL_TEST=1` — item 3
of the vendored-`Test` battery gate (#7555), and the reason #7667 was filed:

| | passes |
| --- | --- |
| before any of this work | 0 / 15 |
| after #7786 (registry COW) | 3 / 15 |
| after #7796 (shared program tables) | 15 / 20 |
| after #7800 (scoped candidate-match overlay) | 16 / 20 |
| after this change | **29 / 30** |

The test loses a race whose two sides start at the same instant: one waits for a
DATA frame and then reads `*.body-blob.result`, the other runs three `ok`
assertions. Every fix in that list moved the losing side specifically — the DATA
frame and `body-blob`, not the `ok`s — which is why they moved the outcome where a
uniformly faster interpreter would not have.

## Tests

- `tests/carrier_compile_cache_serves_whenever_callbacks.rs` — asserts the carrier
  compile miss count does not grow with the number of emitted values (it was
  `emits + 2` before).
- `t/whenever-callback-recompile-semantics.t` — pins what the cached chunk must
  still do: chained supplies keep their own emitters over many values, a captured
  lexical accumulates, `state` persists, a nested `whenever` registers once per
  value, and `LAST` still runs.

Local `cargo fmt`, `make lint`, `make test` (3933 files, 41822 tests, PASS) and
`make roast` were all run. `make roast` reports only the three container-only
failures documented in `docs/agent-environments.md`, with exactly the test numbers
that doc lists.

Part of #7667.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NX9vs4NbdKXUu6MoAaHpSz

---
_Generated by [Claude Code](https://claude.ai/code/session_01NX9vs4NbdKXUu6MoAaHpSz)_