### PR TITLE
docs: record PositionalBindFailover binding as already fixed

### DIFF
--- a/news/2026-09/positional-bind-failover-already-fixed.md
+++ b/news/2026-09/positional-bind-failover-already-fixed.md
@@ -1,0 +1,26 @@
+# `does PositionalBindFailover` binding already fixed
+
+Issue #7751 reported that a class composing `PositionalBindFailover` could not
+bind to an `@`-sigilled parameter: mutsu rejected it with a plain
+`Positional` type check instead of falling back to the object's `.iterator`,
+as Raku requires.
+
+Investigating the issue found that `check_and_coerce_param_type` in
+`src/runtime/types/binding_signature.rs` already special-cases
+`PositionalBindFailover` (and the built-in `Seq` failover) by calling
+`coerce_positional_bind_failover`, which asks the value for its `.iterator`
+and binds the reified list. This landed as part of `fix: preserve runtime
+binding failures` (fb90c40), together with a regression test,
+`t/issue-7750-runtime-binding-errors.t`, that pins exactly the scenario from
+#7751:
+
+- `first-five(FallbackSource.new)` binds through the custom `.iterator` and
+  reads back `(42, Nil, Nil, Nil, Nil)`.
+- `first-five((1, 2).Seq)` binds the built-in `Seq` failover the same way.
+
+Both match Rakudo's output. Slurpy `*@a` binding was also checked against
+Rakudo: a slurpy parameter captures the raw argument list without consulting
+`PositionalBindFailover` in either implementation, so no further change was
+needed there.
+
+No code change was required; issue #7751 was closed as already resolved.


### PR DESCRIPTION
## Summary

- Investigated #7751 (`does PositionalBindFailover` is ignored when binding to `@a`).
- The repro from the issue already produces the correct `(42 Nil Nil Nil Nil)` output: `check_and_coerce_param_type` (`src/runtime/types/binding_signature.rs`) already special-cases `PositionalBindFailover` and coerces through `.iterator` via `coerce_positional_bind_failover`. This landed in fb90c40 (`fix: preserve runtime binding failures`).
- An existing regression test, `t/issue-7750-runtime-binding-errors.t`, already pins the exact scenario from #7751 (both a custom `PositionalBindFailover` class and the built-in `Seq` failover), and it passes.
- Also checked the slurpy `*@a` case from the issue's acceptance criteria against `raku`: a slurpy parameter captures the raw argument list without consulting `PositionalBindFailover` in Rakudo either, so mutsu's current behavior already matches — no change needed there.
- No code change was required. Added a `news/` entry recording the investigation and closing the issue.

## Test plan

- [x] `prove -e 'target/debug/mutsu' t/issue-7750-runtime-binding-errors.t` — passes (existing pin).
- [x] Manually verified the issue's repro and the slurpy variant against both `raku` and `target/debug/mutsu`.
- [x] Documentation-only change (`news/`) — CI's build jobs are skipped per `scripts/ci-docs-only.sh`.

Closes #7751

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5YdUpBfVMSGjEwVvGwUg7

---
_Generated by [Claude Code](https://claude.ai/code/session_01M5YdUpBfVMSGjEwVvGwUg7)_