### PR TITLE
fix: %% and % by zero return a soft Failure instead of throwing eagerly

### DIFF
--- a/news/2026-09/modulo-divisible-by-zero-is-a-failure.md
+++ b/news/2026-09/modulo-divisible-by-zero-is-a-failure.md
@@ -1,0 +1,36 @@
+# `%%` and `%` by zero now return a soft Failure like Rakudo
+
+`div` already routed a zero divisor through mutsu's lazy-`Failure` machinery,
+but `%%` (`infix:<%%>`, "is divisible by") and `%` (modulo) still threw an
+eager `X::Numeric::DivideByZero` straight out of the operator. That made the
+common idiom `(^10).grep: 10 %% *` — "all divisors of 10" — crash on the `0`
+element instead of skipping it, and any other `grep`/`so`/boolean use of a
+`%%`/`%` expression that could hit a zero divisor died instead of answering
+`False`.
+
+Fixed in two places:
+
+- `arith_mod` (`src/builtins/arith/mul_div_mod.rs`) built its `Int`/`BigInt`
+  by-zero result with `Err(...)`, which propagates as an immediate `?`
+  throw. Rakudo's `%` treats this exactly like `div`: a soft `Failure`,
+  returned rather than thrown. Changed the four integer by-zero arms (and
+  the `Num % Int(0)` combination, previously missing a zero guard entirely
+  and silently returning `NaN`) to `Ok(RuntimeError::divide_by_zero_failure(...))`.
+- `is_divisible` (`src/vm/vm_smartmatch_ops.rs`, backing `%%`) had its own
+  eager `Err(...)` for a zero right-hand side, independent of `arith_mod`.
+  Reworked it into `divisible_by_values`, returning the `Failure` value
+  directly (mirroring `arith_mod`'s own zero handling now that it is fixed)
+  instead of converting to a `Result<bool, _>` that could only carry an
+  eager throw. `not_divisible_by_values` (`!%%`) negates through the
+  `Failure`: boolifying it for `not` marks it handled and reads `False`, so
+  `6 !%% 0` now answers a plain `True` `Bool`, matching Rakudo, instead of
+  raising or propagating the `Failure` itself.
+
+mutsu's existing sink/demand machinery (the same one that makes `div`'s
+`Failure` throw on `.sink`, `say`, or any other value-demanding context)
+required no changes — it already handles a `Failure` returned from any
+producer uniformly. Pinned by `t/issue-7752-modulo-divisible-failure.t`,
+verified against both mutsu and `raku`; the existing `t/divisible-rational.t`
+and `t/divide-by-zero-message.t` continue to pass unchanged.
+
+Closes #7752.

--- a/src/builtins/arith/mul_div_mod.rs
+++ b/src/builtins/arith/mul_div_mod.rs
@@ -319,22 +319,23 @@ pub(crate) fn arith_mod(left: Value, right: Value) -> Result<Value, RuntimeError
     }
     {
         // Integer `%` by zero reports the dividend and `using %`, like Rakudo
-        // (`Attempt to divide 7 by zero using %`).
+        // (`Attempt to divide 7 by zero using %`). Like `div`, this is a soft
+        // Failure (returned, not thrown) — it only dies when sunk or demanded.
         let mod_div0 = |dividend: &Value| {
-            RuntimeError::numeric_divide_by_zero_full(Some(dividend.clone()), Some("%"))
+            RuntimeError::divide_by_zero_failure(Some(dividend.clone()), Some("%"))
         };
         Ok(match (l.view(), r.view()) {
             (ValueView::Int(a), ValueView::Int(0)) => {
-                return Err(mod_div0(&Value::int(a)));
+                return Ok(mod_div0(&Value::int(a)));
             }
             (ValueView::BigInt(a), ValueView::Int(0)) => {
-                return Err(mod_div0(&Value::from_bigint((**a).clone())));
+                return Ok(mod_div0(&Value::from_bigint((**a).clone())));
             }
             (ValueView::Int(a), ValueView::BigInt(b)) if b.is_zero() => {
-                return Err(mod_div0(&Value::int(a)));
+                return Ok(mod_div0(&Value::int(a)));
             }
             (ValueView::BigInt(a), ValueView::BigInt(b)) if b.is_zero() => {
-                return Err(mod_div0(&Value::from_bigint((**a).clone())));
+                return Ok(mod_div0(&Value::from_bigint((**a).clone())));
             }
             (ValueView::Int(a), ValueView::Int(b)) => {
                 Value::int(num_integer::Integer::mod_floor(&a, &b))
@@ -364,6 +365,12 @@ pub(crate) fn arith_mod(left: Value, right: Value) -> Result<Value, RuntimeError
                 ));
             }
             (ValueView::Int(a), ValueView::Num(b)) => Value::num(float_mod_floor(a as f64, b)),
+            (ValueView::Num(a), ValueView::Int(0)) => {
+                return Ok(RuntimeError::divide_by_zero_failure(
+                    Some(Value::num(a)),
+                    Some("%"),
+                ));
+            }
             (ValueView::Num(a), ValueView::Int(b)) => Value::num(float_mod_floor(a, b as f64)),
             _ => Value::int(0),
         })

--- a/src/vm/vm_smartmatch_ops.rs
+++ b/src/vm/vm_smartmatch_ops.rs
@@ -456,24 +456,24 @@ impl Interpreter {
         Ok(())
     }
 
-    fn divisible_by_values(&self, left: Value, right: Value) -> Result<Value, RuntimeError> {
-        Ok(Value::truth(self.is_divisible(left, right)?))
-    }
-
     /// `$a %% $b` is `$a % $b == 0`. Compute the modulo with the exact-rational
     /// semantics of `arith_mod` (so Rat/Num/BigInt operands work, not just Int),
-    /// then test the remainder for zero. A zero divisor reports the dividend and
-    /// `infix:<%%>`, matching Rakudo.
-    fn is_divisible(&self, left: Value, right: Value) -> Result<bool, RuntimeError> {
+    /// then test the remainder for zero. A zero divisor is a soft `Failure`
+    /// (dividend and `infix:<%%>`, matching Rakudo) — it is returned, not
+    /// thrown, so `grep: 10 %% *` treats it as false instead of dying.
+    fn divisible_by_values(&self, left: Value, right: Value) -> Result<Value, RuntimeError> {
         let (l, r) = runtime::coerce_numeric(left.clone(), right);
         if !r.truthy() {
-            return Err(RuntimeError::numeric_divide_by_zero_full(
+            return Ok(RuntimeError::divide_by_zero_failure(
                 Some(left),
                 Some("infix:<%%>"),
             ));
         }
         let remainder = crate::builtins::arith_mod(l, r)?;
-        Ok(!remainder.truthy())
+        if Self::is_failure_value(&remainder) {
+            return Ok(remainder);
+        }
+        Ok(Value::truth(!remainder.truthy()))
     }
 
     pub(super) fn exec_not_divisible_by_op(&mut self) -> Result<(), RuntimeError> {
@@ -494,7 +494,14 @@ impl Interpreter {
         Ok(())
     }
 
+    /// `$a !%% $b` is `not ($a %% $b)`. Negating a `Failure` in a boolean
+    /// context marks it handled and reads as `False` (so `!%%` itself never
+    /// dies on a zero divisor), matching Rakudo's `6 !%% 0` => `True`.
     fn not_divisible_by_values(&self, left: Value, right: Value) -> Result<Value, RuntimeError> {
-        Ok(Value::truth(!self.is_divisible(left, right)?))
+        let result = self.divisible_by_values(left, right)?;
+        if Self::is_failure_value(&result) {
+            result.mark_failure_handled();
+        }
+        Ok(Value::truth(!result.truthy()))
     }
 }

--- a/t/issue-7752-modulo-divisible-failure.t
+++ b/t/issue-7752-modulo-divisible-failure.t
@@ -1,0 +1,64 @@
+use Test;
+
+# `%%` and `%` by a zero divisor must produce a soft Failure (like `div`
+# already does), not throw eagerly at the operator. See
+# https://github.com/tokuhirom/mutsu/issues/7752
+plan 13;
+
+# The four repro lines from the issue.
+{
+    my $f = 6 %% 0;
+    is $f.^name, 'Failure', '6 %% 0 is a Failure, not an eager throw';
+}
+{
+    my $g = 6 % 0;
+    is $g.^name, 'Failure', '6 % 0 is a Failure, not an eager throw';
+}
+is (so (6 %% 0)), False, 'so (6 %% 0) is False';
+is-deeply (^10).grep({ 10 %% $_ }).List, (1, 2, 5).List,
+    'grep with 10 %% * skips the zero divisor instead of dying';
+
+# Both Int and Num operands behave the same.
+{
+    my $n = 6e0 %% 0;
+    is $n.^name, 'Failure', '6e0 %% 0 (Num) is also a Failure';
+}
+{
+    my $m = 6e0 % 0;
+    is $m.^name, 'Failure', '6e0 % 0 (Num) is also a Failure';
+}
+
+# The Failure still throws when sunk or when a value is demanded.
+{
+    my $died = False;
+    { (6 %% 0).sink; CATCH { default { $died = True } } }
+    ok $died, 'a sunk %% 0 Failure throws';
+}
+{
+    my $died = False;
+    { (6 % 0).sink; CATCH { default { $died = True } } }
+    ok $died, 'a sunk % 0 Failure throws';
+}
+{
+    my $died = False;
+    { say 6 %% 0; CATCH { default { $died = True } } }
+    ok $died, 'say 6 %% 0 demands the value and dies';
+}
+
+# `!%%` negates through the Failure (boolifying it marks it handled), so it
+# never dies on a zero divisor.
+{
+    my $p = 6 !%% 0;
+    is $p.^name, 'Bool', '6 !%% 0 is a plain Bool, not a Failure';
+    is $p, True, '6 !%% 0 is True';
+}
+
+# Controls that were already correct stay correct.
+{
+    my $h = 6 div 0;
+    is $h.^name, 'Failure', '6 div 0 is still a Failure (unaffected control)';
+}
+is-deeply (^10).grep({ $_ %% 2 }).List, (0, 2, 4, 6, 8).List,
+    'grep with * %% 2 (no zero divisor) is unaffected';
+
+done-testing;


### PR DESCRIPTION
## Summary

- `div` already routed a zero divisor through mutsu's lazy-`Failure` machinery, but `%%` (`infix:<%%>`) and `%` (modulo) still threw an eager `X::Numeric::DivideByZero` straight out of the operator. That made `(^10).grep: 10 %% *` ("all divisors of 10") crash on the `0` element instead of skipping it.
- `arith_mod` (`src/builtins/arith/mul_div_mod.rs`): the `Int`/`BigInt` by-zero arms built their result with `Err(...)`, which propagates as an immediate throw instead of the lazy `Failure` Rakudo produces. Changed the four integer by-zero arms to `Ok(RuntimeError::divide_by_zero_failure(...))`, matching the existing `Num`/`Num` zero arm.
- Also fixed a separate bug found while investigating: `Num % Int(0)` (e.g. `6e0 % 0`) had no zero guard at all and silently returned `NaN` instead of a `Failure`.
- `is_divisible` (`src/vm/vm_smartmatch_ops.rs`, backing `%%`) had its own independent eager `Err(...)` for a zero divisor. Reworked into `divisible_by_values`, which now returns the `Failure` value directly instead of converting to a `Result<bool, _>` that could only carry an eager throw.
- `not_divisible_by_values` (`!%%`) negates through the `Failure`: boolifying it for `not` marks it handled and reads `False`, so `6 !%% 0` now answers a plain `True` `Bool` (matching Rakudo) instead of raising or propagating the `Failure` itself.
- mutsu's existing sink/demand machinery (the same one that makes `div`'s `Failure` throw on `.sink`, `say`, or any other value-demanding context) required no changes — it already handles a `Failure` from any producer uniformly.

## Test plan

- [x] New `t/issue-7752-modulo-divisible-failure.t`, verified against both `target/debug/mutsu` and `raku` — all 13 assertions match.
- [x] Existing `t/divisible-rational.t` (24 tests) and `t/divide-by-zero-message.t` (8 tests) still pass unchanged.
- [x] `cargo fmt --all`
- [x] `make lint` — clean (default clippy, `jit`-off clippy, wasm32 clippy, rustdoc)
- [x] `make test` — `Result: PASS`
- [x] `make roast` — the only failures are the three known remote-container environment-only files (`roast/6.c/S32-io/file-tests.t`, `roast/S16-filehandles/filetest.t`, `roast/S32-io/IO-Socket-Async.t`), matching `docs/agent-environments.md` by name and subtest range exactly.

Closes #7752

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5YdUpBfVMSGjEwVvGwUg7

---
_Generated by [Claude Code](https://claude.ai/code/session_01M5YdUpBfVMSGjEwVvGwUg7)_