### PR TITLE
docs: record that #7803's plain-sub qualified-call report is invalid

### DIFF
--- a/news/2026-09/issue-7803-plain-sub-qualified-call-not-a-bug.md
+++ b/news/2026-09/issue-7803-plain-sub-qualified-call-not-a-bug.md
@@ -1,0 +1,26 @@
+# Investigated #7803: plain `sub is export` not reachable via `Module::name()` is correct, not a bug
+
+Issue #7803 claimed that a plain (non-`our`) `sub NAME() is export { ... }`
+declared inside a `unit module` should be callable package-qualified as
+`Module::NAME()` from an importer, and that mutsu's
+`Could not find symbol '&NAME' in 'Module'` error for that call was a bug.
+
+Verification against the live Rakudo oracle (v2026.07) shows the premise was
+wrong: `raku` throws the exact same error, with the exact same wording, for
+the same repro. A plain `sub` declaration is `my`-scoped (lexically scoped)
+by default; `is export` only affects what `use` imports into the caller's
+lexical scope, it does not place the routine in the package's stash. Only an
+`our sub` is a package symbol, so only `our sub ... is export` is reachable
+via package-qualified `Module::name()` syntax. `raku-doc/doc/Language/packages.rakudoc`
+documents this directly ("ensure you use the 'our' declarator" before a
+package-qualified-access example).
+
+mutsu already implements this correctly, and already carries a dedicated
+regression test pinning it: `t/module-sub-package-visibility.t` (added for an
+earlier, real version of this same bug) asserts that a lexical `sub`/`multi
+sub` is not reachable via `Package::name()` — including from inside the
+package's own code — while an `our sub`/`our proto` is. That test passes on
+`main`.
+
+No code change was needed; issue #7803 was closed as not planned with this
+finding recorded in the issue thread.


### PR DESCRIPTION
## Summary

Investigated #7803 ("A `unit module`'s exported `sub` is not callable via
`Module::sub-name()` qualified-call syntax"). The issue's premise turned out
to be factually wrong, so no code change was made.

- Reproduced the exact repro from the issue against the live `raku` oracle
  (v2026.07): `raku` throws the **exact same** `Could not find symbol
  '&NAME' in 'Module'` error mutsu does. A plain (non-`our`) `sub ... is
  export` is `my`-scoped (lexically scoped); `is export` only controls what
  `use` imports, it does not place the routine in the package stash. Only
  `our sub ... is export` is a package symbol reachable via
  `Module::name()`.
- `raku-doc/doc/Language/packages.rakudoc` documents this directly
  ("ensure you use the 'our' declarator" before a package-qualified-access
  example).
- mutsu already implements this correctly, and it is already pinned by an
  existing regression test, `t/module-sub-package-visibility.t` (added for
  an earlier, real instance of this bug) — confirmed still passing on
  `main`.

This PR adds a `news/` entry recording the investigation. Issue #7803 is
being closed as not planned (not via this PR's merge, since there is
nothing to "complete") with the same explanation posted to the issue
thread.

## Test plan

- [x] `prove -e 'target/debug/mutsu' t/module-sub-package-visibility.t` — passes on `main`, confirming the correct behavior is already implemented and pinned.
- [x] Documentation-only change (`news/` only); CI's build/roast jobs are expected to skip per `scripts/ci-docs-only.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TcTKDfbG8TYFHQXkbwVejh

---
_Generated by [Claude Code](https://claude.ai/code/session_01TcTKDfbG8TYFHQXkbwVejh)_