### PR TITLE
fix: gate package-qualified names by which compunit `use`d the package

### DIFF
--- a/news/2026-09/package-qualified-name-transitive-use-leak.md
+++ b/news/2026-09/package-qualified-name-transitive-use-leak.md
@@ -21,41 +21,84 @@ into the *importing compunit's* `MY::` only, so a compunit that never `use`d
 `InnerConst` itself has no path to `InnerConst::anything`, even through a
 module it did `use` that in turn `use`d `InnerConst`.
 
+## The visibility rule turned out to have three parts, not one
+
+The naive fix — a compunit sees `Pkg::x` only if it `use`d `Pkg` itself —
+passes the issue's own repro and the local `t`/`roast` suites, but fails
+`scripts/battery-testsuite.sh` (the gate that runs 17 real, vendored
+distributions' own upstream test suites): it broke Cro::HTTP, HTTP::UserAgent,
+XML, OpenSSL, and DBIish's mysql driver, all in the same shape. Chasing that
+down against real `raku` (not just the issue's own repro) turned up two more
+genuinely-permissive rules mutsu had been relying on by accident:
+
+1. **Direct grant.** A compunit that `use`/`need`/`require`d `Pkg` directly
+   may reference `Pkg::anything` — the rule the issue asks for.
+2. **Package-ancestor.** Code running with current package `Foo` may
+   reference `Foo::Bar::anything` even without `use`ing `Foo::Bar` itself —
+   confirmed against the real, vendored `OpenSSL` module: `unit class
+   OpenSSL`'s `method new` calls `OpenSSL::Ctx::SSL_CTX_new(...)` without
+   ever `use`ing `OpenSSL::Ctx` (only transitively, through its own `use
+   OpenSSL::SSL`). A minimal repro with an unrelated current package
+   (`unit class Outer; use Bar; method probe { Baz::greet() }`, where
+   `Bar.rakumod` does `use Baz;`) correctly fails under real `raku` — the
+   difference is the shared name, not the `use` chain.
+3. **Same top-level namespace.** A compunit that `use`d *anything* under a
+   given top-level `::`-segment may reference *any other* package under that
+   same segment — confirmed with `IO::Socket::Async::SSL.rakumod` (no `unit`
+   declarator, so rule 2 cannot apply): a top-level `my constant ... =
+   OpenSSL::Version::version_num() ...;` resolves under real `raku` even
+   though the file's own `use` list never mentions `OpenSSL::Version`, only
+   sibling packages (`OpenSSL`, `OpenSSL::Bio`, `OpenSSL::Ctx`, ...) under the
+   same `OpenSSL::` prefix.
+
+None of this is written down anywhere; it was reverse-engineered by running
+real `raku` against both the failing vendored modules and minimal repros
+until each rule's exact boundary was pinned down.
+
 ## The fix
 
-Two new per-compunit tables, mirroring the existing `prelude_declaring_units`/
-`prelude_visible_here` mechanism built for the analogous NativeCall-prelude
-visibility gate (#7612):
+`Interpreter::qualified_name_visible_here` checks all three, in order, at the
+two chokepoints where a source-written qualified name resolves — the
+bareword term path (`exec_get_bare_word_op`) and the qualified function-call
+path (`exec_call_func_op_inner`):
 
-- `package_declaring_units`: which compunit a `use`/`need`/`require`d
-  top-level package belongs to (first `::`-segment granularity, matching the
-  coarseness the three earlier bare-name slices already use).
-- `compunit_visible_packages`: which such packages a given compunit earned
-  visibility to, by `use`ing them *directly* — populated at the end of a
-  successful module load, whether that's the first load (`load_module_inner`)
-  or a re-`use` of an already-loaded module (which used to skip the grant
-  entirely, since nothing new needs registering there for the OLDER
-  bare-name/class-alias mechanisms).
+- `current_package_is_ancestor_of` (rule 2) — a pure string ancestor-walk of
+  `self.current_package()`, no bookkeeping needed.
+- `package_granted_in_unit_chain` (rule 3) — a coarse top-level-segment
+  membership check against `compunit_visible_packages`.
+- `longest_declared_package_prefix` + `package_visible_in_unit_chain` (rule
+  1, plus a compunit's unconditional view of its own declarations) — an
+  exact-prefix match against `package_declaring_units`.
 
-`Interpreter::qualified_name_visible_here` consults both, walking the `EVAL`
-parent chain exactly as `prelude_visible_here` does, and gates the two
-chokepoints where a source-written qualified name resolves: the bareword term
-path (`exec_get_bare_word_op` — constants, enum values/types, classes, roles)
-and the qualified function-call path (`exec_call_func_op_inner`).
+Two new per-compunit tables populated at the end of every successful module
+load (mirroring `prelude_declaring_units`/`prelude_visible_here`, the
+existing NativeCall-prelude visibility gate from #7612):
 
-## The harder half: which compunit is "running" during a module load
+- `package_declaring_units`: **full package name** → declaring compunit.
+  Deliberately NOT truncated to a first `::`-segment: a real multi-file
+  distribution routinely has several unrelated compunits sharing a namespace
+  prefix (`XML::Entity` and `XML::Element` are separate `unit class`-scoped
+  files, both under `XML::`) — keying this by `"XML"` let whichever loaded
+  first claim the whole prefix and made every sibling's OWN qualified
+  self-reference to its own name look foreign (`XML::Entity.rakumod`
+  referencing `XML::Entity.new` inside its own body).
+- `compunit_visible_packages`: for each compunit, both the full names AND the
+  top-level segments of everything it `use`d directly (rules 1 and 3) —
+  populated on first load and, since a re-`use` of an already-loaded module
+  skips `load_module_inner` entirely, on the already-loaded fast path too.
 
-Getting the *visibility* gate right exposed a second, sharper bug in how
-mutsu decides "which compunit is executing right now" while a module's own
+## Which compunit is "running" during a module load
+
+Getting all of this right also exposed a sharper, separate bug in how mutsu
+decides "which compunit is executing right now" while a module's own
 top-level mainline is running. `Interpreter::executing_unit_sym` prioritizes
 the topmost `routine_stack` frame — correct for an ordinary call, but wrong
 for a module body, which runs via `run_block` and pushes no frame of its own.
 `DBIish.install-driver('SQLite')` does a dynamic `require ::($module)` from
-inside a method; the loaded module's own top-level `use NativeLibs;` (and a
-`constant LIB = NativeLibs::is-win ?? ... !! ...;` reading a qualified name
-from *another* nested module) then misattributed to `install-driver`'s own
-compunit instead of to the module whose mainline was actually running,
-because `install-driver`'s stale frame was still on top of `routine_stack`.
+inside a method; the loaded module's own top-level `use NativeLibs;` then
+misattributed to `install-driver`'s own compunit instead of to the module
+whose mainline was actually running, because `install-driver`'s stale frame
+was still on top of `routine_stack`.
 
 `module_loading_unit_stack` now records `(compunit, routine_stack depth)`
 around every module load's `run_block`; `executing_unit_sym_for_module_load`
@@ -68,14 +111,17 @@ compunit entirely — happens in between.
 
 Extends `t/module-transitive-use-does-not-leak-types.t` (the pin for the
 bare-name half) with the qualified-name assertions, rather than adding a
-parallel file, per the issue's own instruction. `make test` (41,855
-assertions) and `make roast` are unaffected beyond the fix; three module-load
-edge cases in `t/` that depend on the mainline-attribution fix above
-(`t/attr-default-file-scoped-call.t`, `t/enum-member-nested-module-load.t`,
-`t/prelude-helper-not-block-lexical.t`) needed no changes themselves — they
-started passing once `executing_unit_sym_for_module_load` existed.
+parallel file, per the issue's own instruction. `cargo fmt`, `make lint`
+(all four configurations), `make test` (41,855 assertions), `make roast`
+(clean except the three documented container-only discrepancies), and
+`scripts/battery-testsuite.sh` (all 17 bundled distributions' own upstream
+suites — the gate that caught rules 2 and 3, which neither `make test` nor
+`make roast` exercises) all pass.
 
-Filed #7803 for an unrelated pre-existing gap found while extending the pinned
-test: a `unit module`'s plain `sub NAME() is export` (as opposed to `our sub`)
-is not callable via `Module::NAME()` qualified-call syntax at all, regardless
-of visibility.
+Filed #7803 for an unrelated pre-existing gap found while extending the
+pinned test: a `unit module`'s plain `sub NAME() is export` (as opposed to
+`our sub`) is not callable via `Module::NAME()` qualified-call syntax at all,
+regardless of visibility. Filed #7811 for an unrelated flaky test
+(`t/whenever-callback-recompile-semantics.t` subtest 5) found while
+investigating an initial CI failure — a genuine emit-order race between two
+async `whenever`/`Promise.keep` continuations, reproducing on `main` too.

--- a/news/2026-09/package-qualified-name-transitive-use-leak.md
+++ b/news/2026-09/package-qualified-name-transitive-use-leak.md
@@ -1,0 +1,81 @@
+# A package-qualified name no longer leaks through a transitively-`use`d module
+
+```raku
+# InnerConst.rakumod: unit module InnerConst; constant INNER-CONST = 42;
+# OuterConst.rakumod: use InnerConst; unit module OuterConst;
+
+use OuterConst;   # never `use InnerConst` itself
+say InnerConst::INNER-CONST;   # raku: Could not find symbol   mutsu was: 42
+```
+
+The bare-name half of this divergence (#7555 item 1(b)) closed across three
+earlier slices — #7743 (imports/classes/roles), #7764 (package names), #7791
+(constants/enum values) — so a *bare* `InnerConst` reference already correctly
+went undeclared for an importer that only `use`d `OuterConst`. The
+**package-qualified** form (`InnerConst::INNER-CONST`, `InnerConst::InnerClass`,
+`InnerConst::InnerEnum`, a qualified call to one of `InnerConst`'s subs, ...)
+still resolved, because mutsu's package symbols — `our`-scoped constants/vars,
+classes, roles, enums — live in process-global stores keyed by their qualified
+name, with no notion of who may see an entry. Rakudo installs a `use`d package
+into the *importing compunit's* `MY::` only, so a compunit that never `use`d
+`InnerConst` itself has no path to `InnerConst::anything`, even through a
+module it did `use` that in turn `use`d `InnerConst`.
+
+## The fix
+
+Two new per-compunit tables, mirroring the existing `prelude_declaring_units`/
+`prelude_visible_here` mechanism built for the analogous NativeCall-prelude
+visibility gate (#7612):
+
+- `package_declaring_units`: which compunit a `use`/`need`/`require`d
+  top-level package belongs to (first `::`-segment granularity, matching the
+  coarseness the three earlier bare-name slices already use).
+- `compunit_visible_packages`: which such packages a given compunit earned
+  visibility to, by `use`ing them *directly* — populated at the end of a
+  successful module load, whether that's the first load (`load_module_inner`)
+  or a re-`use` of an already-loaded module (which used to skip the grant
+  entirely, since nothing new needs registering there for the OLDER
+  bare-name/class-alias mechanisms).
+
+`Interpreter::qualified_name_visible_here` consults both, walking the `EVAL`
+parent chain exactly as `prelude_visible_here` does, and gates the two
+chokepoints where a source-written qualified name resolves: the bareword term
+path (`exec_get_bare_word_op` — constants, enum values/types, classes, roles)
+and the qualified function-call path (`exec_call_func_op_inner`).
+
+## The harder half: which compunit is "running" during a module load
+
+Getting the *visibility* gate right exposed a second, sharper bug in how
+mutsu decides "which compunit is executing right now" while a module's own
+top-level mainline is running. `Interpreter::executing_unit_sym` prioritizes
+the topmost `routine_stack` frame — correct for an ordinary call, but wrong
+for a module body, which runs via `run_block` and pushes no frame of its own.
+`DBIish.install-driver('SQLite')` does a dynamic `require ::($module)` from
+inside a method; the loaded module's own top-level `use NativeLibs;` (and a
+`constant LIB = NativeLibs::is-win ?? ... !! ...;` reading a qualified name
+from *another* nested module) then misattributed to `install-driver`'s own
+compunit instead of to the module whose mainline was actually running,
+because `install-driver`'s stale frame was still on top of `routine_stack`.
+
+`module_loading_unit_stack` now records `(compunit, routine_stack depth)`
+around every module load's `run_block`; `executing_unit_sym_for_module_load`
+trusts the stack's top only while that depth hasn't grown since (nothing has
+been *called* since the module's mainline started), and falls back to
+`executing_unit_sym` the moment a routine call — possibly into a different
+compunit entirely — happens in between.
+
+## Verification
+
+Extends `t/module-transitive-use-does-not-leak-types.t` (the pin for the
+bare-name half) with the qualified-name assertions, rather than adding a
+parallel file, per the issue's own instruction. `make test` (41,855
+assertions) and `make roast` are unaffected beyond the fix; three module-load
+edge cases in `t/` that depend on the mainline-attribution fix above
+(`t/attr-default-file-scoped-call.t`, `t/enum-member-nested-module-load.t`,
+`t/prelude-helper-not-block-lexical.t`) needed no changes themselves — they
+started passing once `executing_unit_sym_for_module_load` existed.
+
+Filed #7803 for an unrelated pre-existing gap found while extending the pinned
+test: a `unit module`'s plain `sub NAME() is export` (as opposed to `our sub`)
+is not callable via `Module::NAME()` qualified-call syntax at all, regardless
+of visibility.

--- a/src/runtime/compunit_scope.rs
+++ b/src/runtime/compunit_scope.rs
@@ -203,7 +203,12 @@ impl Interpreter {
     /// names*) instead of a flat `HashSet<Symbol>`, plus the unconditional
     /// self-visibility check `unit_chain_contains` has no equivalent for: a
     /// compunit always sees a package it declares itself.
-    fn package_visible_in_unit_chain(&self, start: Symbol, top: &str, declaring_unit: Symbol) -> bool {
+    fn package_visible_in_unit_chain(
+        &self,
+        start: Symbol,
+        top: &str,
+        declaring_unit: Symbol,
+    ) -> bool {
         let mut unit = Some(start);
         for _ in 0..64 {
             let Some(sym) = unit else { return false };

--- a/src/runtime/compunit_scope.rs
+++ b/src/runtime/compunit_scope.rs
@@ -136,6 +136,71 @@ impl Interpreter {
         }
     }
 
+    /// Whether a package-qualified name (`Pkg::name`) written in source is
+    /// visible from the code that is running right now (#7797).
+    ///
+    /// mutsu's package symbols (`our`-scoped constants/vars, classes, roles,
+    /// enums) live in process-global stores keyed by their qualified name,
+    /// with no notion of who may see an entry. Rakudo instead installs a
+    /// `use`d package into the importing compunit's `MY::`, so a compunit
+    /// that never `use`d `Pkg` — even one that reaches it transitively,
+    /// through a module it DID `use` — has no path to `Pkg::anything` at
+    /// all. This reconstructs that rule on top of the flat stores:
+    /// `package_declaring_units` says which compunit a top-level package
+    /// belongs to, and `compunit_visible_packages` says which packages a
+    /// given compunit earned visibility to by `use`/`need`/`require`ing
+    /// them directly (see `Interpreter::load_module_inner`).
+    ///
+    /// A name with no `::` is not this gate's concern (the three earlier
+    /// visibility slices — #7743, #7764, #7791 — already handle a *bare*
+    /// name). A `::`-name whose leading segment names no *known* foreign
+    /// package (nothing ever `use`d it into `package_declaring_units`) is
+    /// left permissive: that covers a same-compunit `package Foo { }`
+    /// block and a script's own top-level `unit module Foo`, neither of
+    /// which goes through `load_module_inner` and so never earns an entry
+    /// there — deliberately, since both are visible to their own compunit
+    /// unconditionally and this gate only ever RESTRICTS cross-compunit
+    /// reach, never a compunit's view of its own declarations.
+    pub(crate) fn qualified_name_visible_here(&self, name: &str) -> bool {
+        let Some((top, _)) = name.split_once("::") else {
+            return true;
+        };
+        if self.package_declaring_units.is_empty() {
+            return true;
+        }
+        let Some(&declaring_unit) = self.package_declaring_units.get(top) else {
+            return true;
+        };
+        self.package_visible_in_unit_chain(self.executing_unit_sym(), top, declaring_unit)
+            || self.package_visible_in_unit_chain(self.current_unit, top, declaring_unit)
+    }
+
+    /// Whether `top` (a package `declaring_unit` owns) is visible from
+    /// `start`, or any unit `start` was `EVAL`ed inside of — the same
+    /// EVAL-parent walk as [`Self::unit_chain_contains`], but consulting
+    /// `compunit_visible_packages` (keyed by unit, holding a *set of package
+    /// names*) instead of a flat `HashSet<Symbol>`, plus the unconditional
+    /// self-visibility check `unit_chain_contains` has no equivalent for: a
+    /// compunit always sees a package it declares itself.
+    fn package_visible_in_unit_chain(&self, start: Symbol, top: &str, declaring_unit: Symbol) -> bool {
+        let mut unit = Some(start);
+        for _ in 0..64 {
+            let Some(sym) = unit else { return false };
+            if sym == declaring_unit {
+                return true;
+            }
+            if self
+                .compunit_visible_packages
+                .get(&sym)
+                .is_some_and(|granted| granted.contains(top))
+            {
+                return true;
+            }
+            unit = crate::runtime::eval_unit_parent(sym);
+        }
+        false
+    }
+
     /// Whether `start`, or any unit it was `EVAL`ed inside of, is in `units`.
     ///
     /// `EVAL` compiles in its caller's lexical scope, so a declaration made by

--- a/src/runtime/compunit_scope.rs
+++ b/src/runtime/compunit_scope.rs
@@ -136,6 +136,24 @@ impl Interpreter {
         }
     }
 
+    /// [`Self::executing_unit_sym`], corrected for code running directly in a
+    /// module's own top-level mainline (`load_module_inner`'s `run_block`)
+    /// while an unrelated routine call is still on `routine_stack` — see
+    /// `module_loading_unit_stack`'s doc comment for why that accessor alone
+    /// gets this wrong. `routine_stack.len()` unchanged since the innermost
+    /// still-loading module's mainline started means nothing has been
+    /// CALLED since, so that module IS what's running; a change means a
+    /// routine call happened, and `executing_unit_sym`'s normal
+    /// frame-based answer (now reflecting that call) is correct instead.
+    pub(crate) fn executing_unit_sym_for_module_load(&self) -> Symbol {
+        if let Some(&(unit, depth_at_push)) = self.module_loading_unit_stack.last()
+            && self.routine_stack.len() == depth_at_push
+        {
+            return unit;
+        }
+        self.executing_unit_sym()
+    }
+
     /// Whether a package-qualified name (`Pkg::name`) written in source is
     /// visible from the code that is running right now (#7797).
     ///
@@ -171,8 +189,11 @@ impl Interpreter {
         let Some(&declaring_unit) = self.package_declaring_units.get(top) else {
             return true;
         };
-        self.package_visible_in_unit_chain(self.executing_unit_sym(), top, declaring_unit)
-            || self.package_visible_in_unit_chain(self.current_unit, top, declaring_unit)
+        self.package_visible_in_unit_chain(
+            self.executing_unit_sym_for_module_load(),
+            top,
+            declaring_unit,
+        ) || self.package_visible_in_unit_chain(self.current_unit, top, declaring_unit)
     }
 
     /// Whether `top` (a package `declaring_unit` owns) is visible from

--- a/src/runtime/compunit_scope.rs
+++ b/src/runtime/compunit_scope.rs
@@ -171,42 +171,168 @@ impl Interpreter {
     ///
     /// A name with no `::` is not this gate's concern (the three earlier
     /// visibility slices — #7743, #7764, #7791 — already handle a *bare*
-    /// name). A `::`-name whose leading segment names no *known* foreign
-    /// package (nothing ever `use`d it into `package_declaring_units`) is
-    /// left permissive: that covers a same-compunit `package Foo { }`
-    /// block and a script's own top-level `unit module Foo`, neither of
-    /// which goes through `load_module_inner` and so never earns an entry
-    /// there — deliberately, since both are visible to their own compunit
+    /// name). A `::`-name with no registered ancestor prefix at all (nothing
+    /// ever `use`d it into `package_declaring_units`) is left permissive:
+    /// that covers a same-compunit `package Foo { }` block and a script's
+    /// own top-level `unit module Foo`, neither of which goes through
+    /// `load_module_inner` and so never earns an entry there —
+    /// deliberately, since both are visible to their own compunit
     /// unconditionally and this gate only ever RESTRICTS cross-compunit
     /// reach, never a compunit's view of its own declarations.
+    ///
+    /// Matches on the LONGEST registered ancestor prefix of `name`, not just
+    /// its first `::`-segment: `package_declaring_units` is keyed by full
+    /// package names (`"XML::Entity"`, not `"XML"`), because a first-segment
+    /// key is too coarse for a real multi-file distribution where several
+    /// UNRELATED compunits share a namespace prefix (`XML::Entity` and
+    /// `XML::Element` are separate files, each `unit class`-scoped to its
+    /// own name) — keying by `"XML"` alone let whichever of them loaded
+    /// first claim the whole prefix and made every sibling's OWN qualified
+    /// self-reference to its OWN name look foreign (`XML::Entity.rakumod`
+    /// referencing `XML::Entity.new` inside its own body, in the bundled
+    /// XML battery — caught by the `battery-testsuite.sh` gate, not by
+    /// `make test`/`make roast`). Mirrors the ancestor-walk style
+    /// `Interpreter::resolve_type_in_current_package` already uses for the
+    /// analogous "prepend each enclosing package in turn" problem.
     pub(crate) fn qualified_name_visible_here(&self, name: &str) -> bool {
-        let Some((top, _)) = name.split_once("::") else {
-            return true;
-        };
-        if self.package_declaring_units.is_empty() {
+        if !name.contains("::") || self.package_declaring_units.is_empty() {
             return true;
         }
-        let Some(&declaring_unit) = self.package_declaring_units.get(top) else {
+        // A qualified name is ALSO visible when the running code's own
+        // current package is an ancestor of (or equal to) it, independent of
+        // any `use` grant — verified empirically against real rakudo (not
+        // documented in the issue, whose own repro never exercises this
+        // shape): `unit class OpenSSL;`'s `method new` calls
+        // `OpenSSL::Ctx::SSL_CTX_new(...)` and never itself `use`s
+        // `OpenSSL::Ctx` (only transitively, via its own `use OpenSSL::SSL;`,
+        // whose body `use`s `OpenSSL::Ctx`) — yet real `raku`, run directly
+        // against the vendored module, resolves it fine, while the
+        // structurally-identical case with an UNRELATED current package
+        // (confirmed with a minimal repro: `unit class Outer; use Bar;
+        // method probe { Baz::greet() }`, `Bar.rakumod` doing `use Baz;`)
+        // correctly reports "Could not find symbol". The difference is
+        // `OpenSSL::Ctx` nesting under the current package's own name
+        // (`OpenSSL`), not the `use` chain. This is the qualified-name
+        // counterpart of `resolve_type_in_current_package`'s bare-name
+        // ancestor walk, and exists for the same reason: a package's own
+        // sibling/descendant files can reference each other by nesting
+        // alone, the same way nested nested `package`/`class` blocks in ONE
+        // file always could.
+        if self.current_package_is_ancestor_of(name) {
+            return true;
+        }
+        let executing = self.executing_unit_sym_for_module_load();
+        // A qualified name is ALSO visible when the running compunit `use`d
+        // ANY package under the same top-level `::`-segment as `name` —
+        // coarser than a `use` of `name`'s own exact ancestor, but verified
+        // against real rakudo for exactly this shape: `IO::Socket::Async::
+        // SSL.rakumod` (no `unit` declarator, so `current_package` is
+        // `GLOBAL` here — the ancestor check above cannot fire) has a
+        // top-level `my constant ... = OpenSSL::Version::version_num() ...;`
+        // yet its own `use` list never mentions `OpenSSL::Version` — only
+        // `OpenSSL`, `OpenSSL::Bio`, `OpenSSL::Ctx`, and others, all sharing
+        // the `OpenSSL` prefix `OpenSSL::Version` does too. Real `raku`
+        // resolves it fine; a from-scratch top-level script that never
+        // `use`s anything under `OpenSSL::` at all does not (confirmed with
+        // a minimal repro). A distribution's own files, in other words, get
+        // to reference each other by shared top-level namespace, not only by
+        // the exact package each individual `use` names — this is coarser
+        // than `Self::longest_declared_package_prefix`'s exact-prefix match
+        // on purpose, and is why THAT match alone (checked below) is not
+        // enough here.
+        let top = name.split_once("::").map_or(name, |(top, _)| top);
+        if self.package_granted_in_unit_chain(executing, top)
+            || self.package_granted_in_unit_chain(self.current_unit, top)
+        {
+            return true;
+        }
+        // Exact-prefix fallback: a compunit always sees a package it
+        // declares ITSELF, even one sharing no top-level segment with
+        // anything it `use`d (a file with no `use` statements of its own
+        // at all still needs to reference its own `unit class Foo::Bar;`
+        // qualified) — the top-level-segment grant above requires having
+        // `use`d SOMETHING under that segment, which a self-reference does
+        // not, so this exact-prefix self-check is not redundant with it.
+        let Some((prefix, declaring_unit)) = self.longest_declared_package_prefix(name) else {
             return true;
         };
-        self.package_visible_in_unit_chain(
-            self.executing_unit_sym_for_module_load(),
-            top,
-            declaring_unit,
-        ) || self.package_visible_in_unit_chain(self.current_unit, top, declaring_unit)
+        self.package_visible_in_unit_chain(executing, prefix, declaring_unit)
+            || self.package_visible_in_unit_chain(self.current_unit, prefix, declaring_unit)
     }
 
-    /// Whether `top` (a package `declaring_unit` owns) is visible from
-    /// `start`, or any unit `start` was `EVAL`ed inside of — the same
-    /// EVAL-parent walk as [`Self::unit_chain_contains`], but consulting
-    /// `compunit_visible_packages` (keyed by unit, holding a *set of package
-    /// names*) instead of a flat `HashSet<Symbol>`, plus the unconditional
-    /// self-visibility check `unit_chain_contains` has no equivalent for: a
-    /// compunit always sees a package it declares itself.
+    /// Whether the top-level `::`-segment `top` is among the packages
+    /// `start`, or any unit it was `EVAL`ed inside of, earned visibility to
+    /// by `use`ing something under it directly (see
+    /// `Interpreter::load_module_inner`'s registration). Same EVAL-parent
+    /// walk as [`Self::package_visible_in_unit_chain`], without that
+    /// function's declaring-unit self-check — this is purely a grant lookup.
+    fn package_granted_in_unit_chain(&self, start: Symbol, top: &str) -> bool {
+        let mut unit = Some(start);
+        for _ in 0..64 {
+            let Some(sym) = unit else { return false };
+            if self
+                .compunit_visible_packages
+                .get(&sym)
+                .is_some_and(|granted| granted.contains(top))
+            {
+                return true;
+            }
+            unit = crate::runtime::eval_unit_parent(sym);
+        }
+        false
+    }
+
+    /// Whether `self.current_package()`, or one of ITS ancestor packages, is
+    /// a prefix of (or equal to) `name` — the same ancestor-walk shape
+    /// `resolve_type_in_current_package` uses, but testing containment the
+    /// other way around (is the current package an ancestor of `name`,
+    /// rather than "prepend the current package to `name` and look that
+    /// up"). `"GLOBAL"` is excluded: it is the default/top-level package
+    /// name, not a real declared package, and treating it as an ancestor of
+    /// everything would defeat this gate for any code running outside a
+    /// declared package.
+    fn current_package_is_ancestor_of(&self, name: &str) -> bool {
+        let owned = self.current_package();
+        let mut pkg: &str = &owned;
+        loop {
+            if !pkg.is_empty()
+                && pkg != "GLOBAL"
+                && (name == pkg || name.starts_with(&format!("{pkg}::")))
+            {
+                return true;
+            }
+            match pkg.rsplit_once("::") {
+                Some((parent, _)) => pkg = parent,
+                None => return false,
+            }
+        }
+    }
+
+    /// The longest prefix of `name` (stopping at a `::` boundary each step)
+    /// that `package_declaring_units` has an entry for, plus that entry's
+    /// declaring unit. `None` when no ancestor of `name` was ever registered
+    /// by a module load.
+    fn longest_declared_package_prefix<'a>(&self, name: &'a str) -> Option<(&'a str, Symbol)> {
+        let mut candidate = name;
+        loop {
+            if let Some(&unit) = self.package_declaring_units.get(candidate) {
+                return Some((candidate, unit));
+            }
+            candidate = candidate.rsplit_once("::")?.0;
+        }
+    }
+
+    /// Whether `prefix` (a full package name `declaring_unit` owns) is
+    /// visible from `start`, or any unit `start` was `EVAL`ed inside of —
+    /// the same EVAL-parent walk as [`Self::unit_chain_contains`], but
+    /// consulting `compunit_visible_packages` (keyed by unit, holding a
+    /// *set of package names*) instead of a flat `HashSet<Symbol>`, plus the
+    /// unconditional self-visibility check `unit_chain_contains` has no
+    /// equivalent for: a compunit always sees a package it declares itself.
     fn package_visible_in_unit_chain(
         &self,
         start: Symbol,
-        top: &str,
+        prefix: &str,
         declaring_unit: Symbol,
     ) -> bool {
         let mut unit = Some(start);
@@ -218,7 +344,7 @@ impl Interpreter {
             if self
                 .compunit_visible_packages
                 .get(&sym)
-                .is_some_and(|granted| granted.contains(top))
+                .is_some_and(|granted| granted.contains(prefix))
             {
                 return true;
             }

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -2547,6 +2547,33 @@ pub struct Interpreter {
     /// `register_exported_sub` to mirror GLOBAL registrations into
     /// `unit_module_exported_subs`.
     unit_module_loading_stack: Vec<String>,
+    /// #7797: stack of compunits whose OWN mainline is currently executing
+    /// via `load_module_inner`'s `run_block`, pushed/popped around exactly
+    /// the same window as `unit_module_loading_stack` (but keyed by every
+    /// load, not only ones with a `unit module`/`unit class` name). Each
+    /// entry also carries `routine_stack.len()` at the moment it was pushed,
+    /// so `Interpreter::executing_unit_sym_for_module_load` can tell "still
+    /// directly in this module's mainline" (the length hasn't grown, so
+    /// nothing has been CALLED since) from "a routine call happened since"
+    /// (the length grew, so a fresh frame -- possibly from yet another
+    /// compunit -- is what's actually running now).
+    ///
+    /// `Interpreter::executing_unit_sym` cannot serve this purpose on its
+    /// own: it prioritizes `routine_stack`'s topmost frame, which is correct
+    /// for an ordinary call but wrong here — a module body runs via
+    /// `run_block`, which pushes no routine frame, so a `use` (or any other
+    /// qualified-name resolution) reached from a module's mainline while
+    /// some UNRELATED routine call is still on the stack (`DBIish
+    /// .install-driver` doing `require ::($module)`, whose loaded module in
+    /// turn does its own top-level `use NativeLibs;`, or even just reads
+    /// `NativeLibs::is-win` in a top-level `constant` initializer) would
+    /// otherwise misattribute to that routine's own compunit instead of to
+    /// the module whose mainline is actually running. `?FILE` alone has the
+    /// opposite problem: an ordinary (non-loading) routine call never
+    /// updates it, so consulting it OUTSIDE a load would misattribute to
+    /// whichever compunit happened to load last. This stack is unambiguous
+    /// exactly because `load_module_inner` is the only writer.
+    module_loading_unit_stack: Vec<(Symbol, usize)>,
     /// Exports each module registered while it was the module currently being
     /// loaded (attributed via `module_load_stack`), mapping module -> name ->
     /// tags. Unlike `exported_subs["GLOBAL"]`, which pools every unit-module

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1841,6 +1841,27 @@ pub struct Interpreter {
     /// private routines. Method parameter defaults use this metadata before the
     /// method's routine frame exists as well.
     pub(crate) class_declaring_units: std::sync::Arc<HashMap<String, Symbol>>,
+    /// #7797: the compunit that declared each `use`/`need`/`require`d
+    /// top-level package, keyed by the first `::`-segment of the `use`
+    /// argument (or the module's own `unit module` name — the two normally
+    /// agree). A package NOT in this map has no known foreign declaring
+    /// compunit, so `Interpreter::qualified_name_visible_here` treats a
+    /// reference to it as permissive (same-compunit `package Foo { }`
+    /// blocks, and a script's own top-level `unit module`, never populate
+    /// this table, so they are never mistakenly gated).
+    pub(crate) package_declaring_units: std::sync::Arc<HashMap<String, Symbol>>,
+    /// #7797: for a compunit that successfully `use`d/`need`d/`require`d a
+    /// module, the top-level package names (same first-segment granularity
+    /// as `package_declaring_units`) it is therefore entitled to reference
+    /// package-qualified — e.g. `use OuterConst;` grants `"OuterConst"`, but
+    /// NOT `"InnerConst"` even though `OuterConst.rakumod` itself `use`d
+    /// `InnerConst`: rakudo installs a `use`d package into the *importing*
+    /// compunit's `MY::` only, so visibility does not transit through a
+    /// second `use`. `Interpreter::qualified_name_visible_here` walks the
+    /// `EVAL` parent chain (`eval_unit_parent`) from the executing unit
+    /// consulting this table, exactly as `prelude_visible_here` does for
+    /// prelude splices.
+    pub(crate) compunit_visible_packages: std::sync::Arc<HashMap<Symbol, HashSet<String>>>,
     /// Routines installed by a prelude spliced into a host compunit
     /// (`PRELUDE_SUB_TRAIT`, e.g. NativeCall's `nativecast`/`nativesizeof`).
     /// They deliberately live under `GLOBAL` for every compunit that uses them

--- a/src/runtime/run_modules.rs
+++ b/src/runtime/run_modules.rs
@@ -1076,26 +1076,29 @@ impl Interpreter {
             .cloned()
             .collect();
         // #7797: record that `importer_unit` may reference this load's own
-        // top-level package(s) qualified (`Module::whatever`), but NOT a
-        // package reached only through one of ITS `use` statements —
-        // `owned_types`' filter just below already draws exactly that line
-        // for bare-name aliasing, so this reuses it rather than re-deriving
-        // "which of `new_types` belongs to this load" a second way.
-        // Coarse first-`::`-segment granularity, matching the existing
-        // `!key.contains("::")` bare-name gates (#7743/#7764/#7787): a
-        // `unit module A::B` grants `"A"`, not the full `"A::B"`.
-        fn top_segment(s: &str) -> &str {
-            s.split_once("::").map_or(s, |(top, _)| top)
-        }
+        // package(s) qualified (`Module::whatever`), but NOT a package
+        // reached only through one of ITS `use` statements — `owned_types`'
+        // filter just below already draws exactly that line for bare-name
+        // aliasing, so this reuses it rather than re-deriving "which of
+        // `new_types` belongs to this load" a second way.
+        //
+        // Full-name granularity, NOT a truncated first `::`-segment: a real
+        // multi-file distribution routinely has several UNRELATED compunits
+        // sharing a namespace prefix (`XML::Entity` and `XML::Element` are
+        // separate `unit class`-scoped files, both under `XML::`). Keying
+        // this by `"XML"` let whichever of them loaded first claim the
+        // whole prefix and made every sibling's OWN qualified self-reference
+        // to its OWN name look foreign — caught by `battery-testsuite.sh`,
+        // not by `make test`/`make roast`.
         let module_unit = self.unit_of_source(Some(&source_path.to_string_lossy()));
         let mut granted_packages: HashSet<&str> = HashSet::new();
-        granted_packages.insert(top_segment(module));
+        granted_packages.insert(module);
         if let Some(name) = unit_name.as_deref() {
-            granted_packages.insert(top_segment(name));
+            granted_packages.insert(name);
         }
         for qualified in &new_types {
             if *qualified == module || qualified.starts_with(&format!("{module}::")) {
-                granted_packages.insert(top_segment(qualified));
+                granted_packages.insert(qualified);
             }
         }
         {
@@ -1104,10 +1107,23 @@ impl Interpreter {
                 declaring.entry(pkg.to_string()).or_insert(module_unit);
             }
         }
-        crate::runtime::cow_table_mut(&mut self.compunit_visible_packages)
+        // The grant side additionally records each package's top-level
+        // `::`-segment (never `package_declaring_units`, which stays
+        // full-name-only — see the comment above): a distribution's own
+        // files reference each other by shared top-level namespace alone,
+        // not only by the exact package an individual `use` names (verified
+        // against real rakudo: `IO::Socket::Async::SSL.rakumod` reads
+        // `OpenSSL::Version::version_num()` in a top-level `constant`
+        // without ever `use`ing `OpenSSL::Version` itself, only sibling
+        // packages under the same `OpenSSL::` prefix).
+        let visible_here = crate::runtime::cow_table_mut(&mut self.compunit_visible_packages)
             .entry(importer_unit)
-            .or_default()
-            .extend(granted_packages.iter().map(|s| s.to_string()));
+            .or_default();
+        for pkg in &granted_packages {
+            visible_here.insert(pkg.to_string());
+            let top = pkg.split_once("::").map_or(*pkg, |(top, _)| top);
+            visible_here.insert(top.to_string());
+        }
         // Make each newly-declared class/role's bare short name resolvable from
         // the IMPORTER's own package/class too, not just from the declaring
         // module's own package-ancestor chain. An ordinary `use Foo::Native;`

--- a/src/runtime/run_modules.rs
+++ b/src/runtime/run_modules.rs
@@ -800,8 +800,10 @@ impl Interpreter {
             // record X so that `register_exported_sub` can mirror exports into
             // `unit_module_exported_subs` for tag validation.
             if let Some(name) = unit_name.as_deref() {
-                crate::runtime::cow_table_mut(&mut self.unit_module_packages)
-                    .insert(module_unit_for_loading_stack, crate::symbol::Symbol::intern(name));
+                crate::runtime::cow_table_mut(&mut self.unit_module_packages).insert(
+                    module_unit_for_loading_stack,
+                    crate::symbol::Symbol::intern(name),
+                );
             }
             let pushed_unit = if let Some(name) = unit_name.clone() {
                 self.unit_module_loading_stack.push(name);

--- a/src/runtime/run_modules.rs
+++ b/src/runtime/run_modules.rs
@@ -699,6 +699,17 @@ impl Interpreter {
             .last()
             .cloned()
             .unwrap_or_else(|| self.current_package());
+        // #7797: which COMPUNIT (not package) is doing the importing, captured
+        // before anything below switches `?FILE`/`current_unit` to this load's
+        // own module. `executing_unit_sym` is the same accessor
+        // `prelude_visible_here` uses for the analogous prelude-splice gate --
+        // it reads the routine-frame `def_file` if one is on the stack, and
+        // otherwise the ambient `?FILE`, which at this exact point still names
+        // whichever compunit's `use`/`need`/`require` triggered this load (a
+        // nested `use` reached from inside another module's own mainline sees
+        // THAT module's `?FILE`, already switched by ITS load_module_inner
+        // call before its body started running).
+        let importer_unit = self.executing_unit_sym();
         // Snapshot the `use` args (set by `exec_use_module_op`) before running
         // the module body: a transitive `use` inside the body would otherwise
         // overwrite the field. Handed to the module's `sub EXPORT`, if any.
@@ -772,6 +783,10 @@ impl Interpreter {
         let mut module_scope_names: HashMap<String, Value> = HashMap::new();
         let mut module_type_aliases: HashMap<String, String> = HashMap::new();
         let mut imported_lexical_names: HashSet<String> = HashSet::new();
+        // Hoisted above the `should_skip_runtime_for_use_only_module` branch
+        // (#7797) so the package-visibility bookkeeping after that branch can
+        // read it too, for a use-only module that skips the branch entirely.
+        let unit_name = Self::detect_unit_package_name(&stmts);
         if !Self::should_skip_runtime_for_use_only_module(&stmts) {
             // Module files should be compiled in a fresh GLOBAL scope, not
             // inheriting the caller's current_package.  Otherwise the compiler
@@ -783,7 +798,6 @@ impl Interpreter {
             // If the module file is a `unit module X` (or unit package/class),
             // record X so that `register_exported_sub` can mirror exports into
             // `unit_module_exported_subs` for tag validation.
-            let unit_name = Self::detect_unit_package_name(&stmts);
             if let Some(name) = unit_name.as_deref() {
                 let source = source_path.to_string_lossy();
                 let unit = self.unit_of_source(Some(&source));
@@ -1059,6 +1073,39 @@ impl Interpreter {
             )
             .cloned()
             .collect();
+        // #7797: record that `importer_unit` may reference this load's own
+        // top-level package(s) qualified (`Module::whatever`), but NOT a
+        // package reached only through one of ITS `use` statements —
+        // `owned_types`' filter just below already draws exactly that line
+        // for bare-name aliasing, so this reuses it rather than re-deriving
+        // "which of `new_types` belongs to this load" a second way.
+        // Coarse first-`::`-segment granularity, matching the existing
+        // `!key.contains("::")` bare-name gates (#7743/#7764/#7787): a
+        // `unit module A::B` grants `"A"`, not the full `"A::B"`.
+        fn top_segment(s: &str) -> &str {
+            s.split_once("::").map_or(s, |(top, _)| top)
+        }
+        let module_unit = self.unit_of_source(Some(&source_path.to_string_lossy()));
+        let mut granted_packages: HashSet<&str> = HashSet::new();
+        granted_packages.insert(top_segment(module));
+        if let Some(name) = unit_name.as_deref() {
+            granted_packages.insert(top_segment(name));
+        }
+        for qualified in &new_types {
+            if *qualified == module || qualified.starts_with(&format!("{module}::")) {
+                granted_packages.insert(top_segment(qualified));
+            }
+        }
+        {
+            let declaring = crate::runtime::cow_table_mut(&mut self.package_declaring_units);
+            for pkg in &granted_packages {
+                declaring.entry(pkg.to_string()).or_insert(module_unit);
+            }
+        }
+        crate::runtime::cow_table_mut(&mut self.compunit_visible_packages)
+            .entry(importer_unit)
+            .or_default()
+            .extend(granted_packages.iter().map(|s| s.to_string()));
         // Make each newly-declared class/role's bare short name resolvable from
         // the IMPORTER's own package/class too, not just from the declaring
         // module's own package-ancestor chain. An ordinary `use Foo::Native;`

--- a/src/runtime/run_modules.rs
+++ b/src/runtime/run_modules.rs
@@ -700,16 +700,10 @@ impl Interpreter {
             .cloned()
             .unwrap_or_else(|| self.current_package());
         // #7797: which COMPUNIT (not package) is doing the importing, captured
-        // before anything below switches `?FILE`/`current_unit` to this load's
-        // own module. `executing_unit_sym` is the same accessor
-        // `prelude_visible_here` uses for the analogous prelude-splice gate --
-        // it reads the routine-frame `def_file` if one is on the stack, and
-        // otherwise the ambient `?FILE`, which at this exact point still names
-        // whichever compunit's `use`/`need`/`require` triggered this load (a
-        // nested `use` reached from inside another module's own mainline sees
-        // THAT module's `?FILE`, already switched by ITS load_module_inner
-        // call before its body started running).
-        let importer_unit = self.executing_unit_sym();
+        // before anything below switches `?FILE`/`current_unit` to this
+        // load's own module. See `Interpreter::executing_unit_sym_for_module_load`
+        // for why plain `executing_unit_sym` alone is not enough here.
+        let importer_unit = self.executing_unit_sym_for_module_load();
         // Snapshot the `use` args (set by `exec_use_module_op`) before running
         // the module body: a transitive `use` inside the body would otherwise
         // overwrite the field. Handed to the module's `sub EXPORT`, if any.
@@ -795,14 +789,19 @@ impl Interpreter {
             // instead of `Export_PackA::foo`).
             let saved_package = self.current_package();
             self.set_current_package("GLOBAL".to_string());
+            // #7797: this load's own compunit identity, pushed for the
+            // duration of its mainline regardless of whether it declares a
+            // `unit module`/`unit class` -- see `module_loading_unit_stack`.
+            let module_unit_for_loading_stack =
+                self.unit_of_source(Some(&source_path.to_string_lossy()));
+            self.module_loading_unit_stack
+                .push((module_unit_for_loading_stack, self.routine_stack_len()));
             // If the module file is a `unit module X` (or unit package/class),
             // record X so that `register_exported_sub` can mirror exports into
             // `unit_module_exported_subs` for tag validation.
             if let Some(name) = unit_name.as_deref() {
-                let source = source_path.to_string_lossy();
-                let unit = self.unit_of_source(Some(&source));
                 crate::runtime::cow_table_mut(&mut self.unit_module_packages)
-                    .insert(unit, crate::symbol::Symbol::intern(name));
+                    .insert(module_unit_for_loading_stack, crate::symbol::Symbol::intern(name));
             }
             let pushed_unit = if let Some(name) = unit_name.clone() {
                 self.unit_module_loading_stack.push(name);
@@ -1023,6 +1022,7 @@ impl Interpreter {
             if pushed_unit {
                 self.unit_module_loading_stack.pop();
             }
+            self.module_loading_unit_stack.pop();
             self.set_current_package(saved_package);
             if result.is_ok() {
                 // A `sub MAIN` defined in a used module is NOT the program's MAIN

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -2945,6 +2945,8 @@ impl Interpreter {
             unit_private_routines: Default::default(),
             unit_private_names: Default::default(),
             class_declaring_units: Default::default(),
+            package_declaring_units: Default::default(),
+            compunit_visible_packages: Default::default(),
             prelude_sub_names: Default::default(),
             current_unit: crate::runtime::main_unit(),
             closures_created: 0,

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -3064,6 +3064,7 @@ impl Interpreter {
             exported_vars: Default::default(),
             unit_module_exported_subs: Default::default(),
             unit_module_loading_stack: Vec::new(),
+            module_loading_unit_stack: Vec::new(),
             module_owned_exports: Default::default(),
             suppress_exports: false,
             in_lvalue_assignment: false,

--- a/src/runtime/runtime_module.rs
+++ b/src/runtime/runtime_module.rs
@@ -352,12 +352,13 @@ impl Interpreter {
             // already loaded `Conf` first, yet `Issue7733::Conf.new` inside a
             // `User`-declared method must still resolve.
             {
-                let top = module.split_once("::").map_or(module, |(top, _)| top);
                 let importer_unit = self.executing_unit_sym_for_module_load();
-                crate::runtime::cow_table_mut(&mut self.compunit_visible_packages)
+                let top = module.split_once("::").map_or(module, |(top, _)| top);
+                let entry = crate::runtime::cow_table_mut(&mut self.compunit_visible_packages)
                     .entry(importer_unit)
-                    .or_default()
-                    .insert(top.to_string());
+                    .or_default();
+                entry.insert(module.to_string());
+                entry.insert(top.to_string());
             }
             // A module with a `sub EXPORT` runs it on every import — its map
             // may depend on the `use` arguments (the Slangify pattern) — even

--- a/src/runtime/runtime_module.rs
+++ b/src/runtime/runtime_module.rs
@@ -342,6 +342,23 @@ impl Interpreter {
                     entry.entry(short).or_insert(qualified);
                 }
             }
+            // #7797: same gap as the aliasing copy just above, for package-
+            // qualified-name visibility instead of bare short-name aliasing.
+            // A re-`use` of an already-loaded module skips
+            // `load_module_inner` entirely, so the importer-scoped grant that
+            // runs there on first load (`compunit_visible_packages`) never
+            // fires for a second importer — e.g. `Issue7733::User.rakumod`'s
+            // own `use Issue7733::Conf;` is a no-op once the top-level script
+            // already loaded `Conf` first, yet `Issue7733::Conf.new` inside a
+            // `User`-declared method must still resolve.
+            {
+                let top = module.split_once("::").map_or(module, |(top, _)| top);
+                let importer_unit = self.executing_unit_sym_for_module_load();
+                crate::runtime::cow_table_mut(&mut self.compunit_visible_packages)
+                    .entry(importer_unit)
+                    .or_default()
+                    .insert(top.to_string());
+            }
             // A module with a `sub EXPORT` runs it on every import — its map
             // may depend on the `use` arguments (the Slangify pattern) — even
             // though the module body itself is not re-run.

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -710,6 +710,7 @@ impl Interpreter {
             exported_sub_values: self.exported_sub_values.clone(),
             unit_module_exported_subs: self.unit_module_exported_subs.clone(),
             unit_module_loading_stack: Vec::new(),
+            module_loading_unit_stack: Vec::new(),
             module_owned_exports: self.module_owned_exports.clone(),
             suppress_exports: false,
             in_lvalue_assignment: false,

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -583,6 +583,8 @@ impl Interpreter {
             unit_private_routines: self.unit_private_routines.clone(),
             unit_private_names: self.unit_private_names.clone(),
             class_declaring_units: self.class_declaring_units.clone(),
+            package_declaring_units: self.package_declaring_units.clone(),
+            compunit_visible_packages: self.compunit_visible_packages.clone(),
             prelude_sub_names: self.prelude_sub_names.clone(),
             current_unit: self.current_unit,
             closures_created: 0,

--- a/src/vm/vm_call_func_ops.rs
+++ b/src/vm/vm_call_func_ops.rs
@@ -418,6 +418,21 @@ impl Interpreter {
         if code.const_sym(name_idx).flags() & crate::symbol::flags::NQP_OP != 0 {
             return self.exec_nqp_call_op(code, name_idx, arity, arg_sources_idx);
         }
+        // #7797: same package-qualification gate as `exec_get_bare_word_op`
+        // (see its comment), applied to a qualified sub CALL (`Pkg::sub(...)`)
+        // rather than a bareword term -- a call name never reaches that
+        // function, so the two chokepoints need the same check independently.
+        {
+            let name_str = Self::const_str(code, name_idx);
+            if crate::runtime::utils::has_double_colon(name_str)
+                && !self.qualified_name_visible_here(name_str)
+            {
+                return Err(RuntimeError::new(format!(
+                    "Could not find symbol '{}'",
+                    name_str,
+                )));
+            }
+        }
         // `++`/`--` reach here as a call only because a user declared a `multi`
         // for the operator; the native implementation is one candidate of that
         // multi (rakudo's `Int:D`/`Bool`/`Num:D`/... core candidates), so rank

--- a/src/vm/vm_var_get_ops.rs
+++ b/src/vm/vm_var_get_ops.rs
@@ -59,6 +59,27 @@ impl Interpreter {
                 "Undeclared name:\n    _ used at line 1",
             ));
         }
+        // #7797: a package-qualified bareword (a constant, enum value/type,
+        // class, role, or sub reached as `Pkg::name`) is only in scope for a
+        // compunit that `use`/`need`/`require`d `Pkg` itself — reaching it
+        // transitively, through a module that DID, must not leak it, exactly
+        // as a *bare* name from such a module already doesn't (#7743/#7764/
+        // #7791). Checked before every resolution branch below (env probe,
+        // `has_type`, `resolve_type_in_current_package`, ...) rather than
+        // threading the gate through each of them individually: they all
+        // exist to find SOME value for a qualified name, and none of them
+        // should get the chance once visibility alone says no. A name whose
+        // leading package was never `use`d anywhere (a builtin like
+        // `Bool::True`, a pseudo-package like `OUR::foo`, a same-compunit
+        // `package Foo { }` block) is unaffected — see
+        // `Interpreter::qualified_name_visible_here`.
+        if crate::runtime::utils::has_double_colon(name) && !self.qualified_name_visible_here(name)
+        {
+            return Err(RuntimeError::new(format!(
+                "Could not find symbol '{}'",
+                name,
+            )));
+        }
         // A bareword with a type smiley whose base is a bound generic type
         // parameter (`T:D` inside a role method where `T` -> `Int`) resolves to
         // the parameterized type with the smiley applied (`Int:D`). Plain

--- a/t/module-transitive-use-does-not-leak-types.t
+++ b/t/module-transitive-use-does-not-leak-types.t
@@ -1,5 +1,6 @@
 use v6;
 use lib 't/lib';
+use MONKEY-SEE-NO-EVAL;
 use Test;
 use TransitiveLeakOuter;
 use TransitiveLeakDirect;
@@ -7,7 +8,7 @@ use TransitiveLeakGrand;
 use TransitiveLeakConstA;
 use TransitiveLeakConstB;
 
-plan 27;
+plan 32;
 
 # A module body runs in the *caller's* env, so the short-name type aliases a
 # module's own `use` statements install used to be left behind in whatever
@@ -113,3 +114,31 @@ is a-reads-shared(), 'from-A', 'each module reads its own same-named constant (A
 is b-reads-shared(), 'from-B', 'each module reads its own same-named constant (B)';
 is missing('SHARED-CONST-NAME'), 'MISSING',
     'and no arbitrary winner is left behind in the importer';
+
+# ---------------------------------------------------------------------------
+# #7797: the same leak, reached through a PACKAGE-QUALIFIED name instead of a
+# bare one. Every symbol below is ALSO a package symbol of the module that
+# declares it (`TransitiveLeakInner::InnerConst`, `::InnerClass`, ...), and
+# that qualified form is reachable from Inner's own code, and from Outer
+# (which DOES `use TransitiveLeakInner;`) -- but must NOT leak to a compunit
+# that only reaches Inner transitively, through Outer's `use`, exactly as the
+# bare names above don't. Unlike `::()`, `EVAL` also covers a method call,
+# not just a bare symbol lookup.
+sub qmissing($code) {
+    my $r = try EVAL $code;
+    $! ?? 'MISSING' !! $r.gist;
+}
+
+is qmissing('TransitiveLeakInner::InnerConst'), 'MISSING',
+    'a transitively-used module exported constant is not reachable qualified either';
+is qmissing('TransitiveLeakInner::INNER-PRIVATE'), 'MISSING',
+    'nor is its unexported constant, qualified';
+is qmissing('TransitiveLeakInner::InnerEnum'), 'MISSING',
+    'nor its enum type, qualified';
+is qmissing('TransitiveLeakInner::InnerClass.new.who'), 'MISSING',
+    'nor its class, qualified';
+
+# What stays reachable qualified: a module the importer DID `use` directly
+# (TransitiveLeakOuter::OUTER-PRIVATE above already pins the constant case).
+is TransitiveLeakOuter::OuterClass.new.who, 'outer-class',
+    'the used module class is still reachable qualified';


### PR DESCRIPTION
## Summary

Closes #7797.

- A package-qualified name (`Pkg::name`) reached a class, role, enum,
  `our`-scoped constant/variable, or sub of ANY module ever loaded into the
  process, even from a compunit that never `use`d/`need`d/`require`d that
  module itself — only transitively, through a module it DID `use`. Rakudo
  installs a `use`d package into the *importing* compunit's `MY::` only, so
  such a name is undeclared there. This closes the package-qualified half of
  the divergence left open by #7743/#7764/#7791 (which already closed the
  bare-name half).
- Two new per-compunit stores — `package_declaring_units` (which compunit a
  `use`d top-level package belongs to) and `compunit_visible_packages` (which
  such packages a given compunit earned visibility to by using them
  directly) — populated at the end of a successful module load (both the
  first load and a re-`use` of an already-loaded module, which used to skip
  the grant entirely). `Interpreter::qualified_name_visible_here` consults
  both, walking the same `EVAL`-parent chain `Interpreter::prelude_visible_here`
  already uses for the analogous NativeCall-prelude-splice visibility gate
  (#7612). Wired into the two chokepoints where a source-written qualified
  name resolves: the bareword term path (`exec_get_bare_word_op`) and the
  qualified function-call path (`exec_call_func_op_inner`).
- Getting the gate right also exposed a real, separate bug: while a module's
  own top-level mainline runs (`load_module_inner`'s `run_block`, which
  pushes no routine frame), `Interpreter::executing_unit_sym` can
  misattribute "who is executing" to a stale, unrelated routine frame still
  on `routine_stack` (e.g. `DBIish.install-driver` doing a dynamic
  `require ::($module)`). `module_loading_unit_stack` + the new
  `executing_unit_sym_for_module_load` fix that for both the visibility gate
  and the importer-capture in `load_module_inner`.
- A package whose only declaring compunit is unknown (a same-compunit
  `package Foo { }` block, or a script's own top-level `unit module Foo`,
  neither of which goes through `load_module_inner`) stays permissive — this
  gate only ever restricts cross-compunit reach, never a compunit's view of
  its own declarations.

Filed #7803 for an unrelated pre-existing gap found while extending the
pinned test: a `unit module`'s plain `sub NAME() is export` is not callable
via `Module::NAME()` qualified-call syntax at all (reproduces identically on
`main`, unrelated to this change).

## Test plan

- [x] Extended `t/module-transitive-use-does-not-leak-types.t` (the existing
      pin for the bare-name half of this divergence) with package-qualified
      assertions, per the issue's verification bar, rather than adding a
      parallel file.
- [x] `cargo fmt --all`
- [x] `make lint` (default clippy, `jit`-off clippy, wasm32 clippy, rustdoc) — clean
- [x] `make test` — full `t/` suite, 3934 files / 41,855 assertions — all pass
- [x] `make roast` — 1436 files / 218,939 assertions; the only failures
      (`roast/6.c/S32-io/file-tests.t`, `roast/S16-filehandles/filetest.t`,
      `roast/S32-io/IO-Socket-Async.t`) are the documented container-only
      discrepancies (running as `uid 0`, sandboxed network — see
      `docs/agent-environments.md`), not regressions from this change.
- [x] Manually verified the issue's own repro table matches `raku` exactly,
      before and after `use InnerConst;` is added to the importer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JvKe6HdquqVhYX1fJYSeMD


---
_Generated by [Claude Code](https://claude.ai/code/session_01JvKe6HdquqVhYX1fJYSeMD)_