### PR TITLE
fix: a closure `...` sequence passed to a builtin listop no longer collapses

### DIFF
--- a/news/2026-09/sequence-into-builtin-listop-collapse.md
+++ b/news/2026-09/sequence-into-builtin-listop-collapse.md
@@ -1,0 +1,54 @@
+# A `...` sequence passed straight to a builtin listop no longer collapses
+
+`(SEED, *code ... ENDPOINT)` handed directly to a builtin listop (`join`,
+`sum`, `min`, `max`, `sort`, and transitively `grep`/`map`) used to silently
+answer wrong: `join` saw only the seed, `sum` answered `0`, `min`/`max`
+returned the whole sequence as one candidate, and `sort` either refused it
+as "lazy" or dropped it entirely. The sequence's own value was always
+correct — `say (...)`, `.join`, `elems (...)`, and binding into a user
+`*@`-slurpy all worked — only a *pure* native listop reading the raw value
+was affected.
+
+Root cause: `eval_sequence` defers a closure (`WhateverCode`-generated)
+`...` sequence whose value endpoint it has not yet reached to a `LazyList`
+(`src/runtime/sequence.rs`'s "Defer an unfinished finite closure sequence"
+comment) — reaching a value endpoint needs incremental generator evaluation,
+so the sequence keeps only its eager prefix cached and lets a later forced
+read finish the job. The pre-dispatch pass that reifies a still-deferred
+`.map`/`.grep` Seq before handing arguments to a pure Rust native function
+(ADR-0058, `reify_map_grep_seq_args`) knew nothing about this different
+lazy flavour, so `join_flat`/`sum`/`min`/`max`/`sort`'s native
+implementations read the LazyList's partial (or, for `join`, single-item)
+cache as if it were the finished answer.
+
+Fixed with a new `Interpreter::reify_closure_seq_endpoint`
+(`src/vm/vm_helpers_lazy.rs`), called alongside the existing map/grep
+reification in `reify_map_grep_seq_args`: it forces exactly a `LazyList`
+with `has_finite_closure_endpoint()` — a closure sequence whose endpoint is
+a concrete value, so forcing it to completion can never hang, unlike a
+genuinely infinite `... *`. Three call sites also needed a `LazyList` arm of
+their own (mirroring their existing `Array`/`Seq` arms) to actually read the
+now-complete cache instead of treating an unrecognized `LazyList` as a
+single opaque value: `sum`'s variadic native dispatch
+(`dispatch_variadic.rs`), the shared `min`/`max` flatten step
+(`extrema_from_values_generic`), and `sort`'s both native
+(`dispatch_1arg.rs`) and interpreter (`builtin_sort`) paths. `sort` also had
+an over-eager `is_lazy_for_coerce` guard (`methods_collection.rs`) that
+treated every `LazyList` as unsortable regardless of whether it was
+genuinely lazy; narrowed to `ll.is_genuinely_lazy()` so a finite,
+already-reified closure sequence is eligible for sort/classify/QuantHash
+coercion like an eager Seq, while an actually-infinite source still throws
+`X::Cannot::Lazy`.
+
+`join` needed no code change beyond the shared reification pass — its
+`join_flat`/`flat_val` helpers already read a `LazyList`'s cache correctly
+once it is fully populated; they were just never given a fully-populated
+one before.
+
+Verified against `raku`: the ticket's three repro lines, every control that
+was already correct, a sweep across `grep`/`map`/`min`/`max`/`sort`, and the
+lazy-safety controls (an infinite range/sequence stays lazy, and a
+genuinely-infinite `sort` still throws `X::Cannot::Lazy`) all match. Pinned
+by `t/issue-7753-seq-into-builtin-listop.t`.
+
+Closes #7753.

--- a/src/builtins/functions/dispatch_1arg.rs
+++ b/src/builtins/functions/dispatch_1arg.rs
@@ -784,6 +784,23 @@ pub(crate) fn native_function_1arg(name: &str, arg: &Value) -> Option<Result<Val
                     sorted.sort_by(|a, b| crate::runtime::compare_values(a, b).cmp(&0));
                     Value::seq(sorted)
                 }
+                // A finite closure `...` sequence, already forced by
+                // `try_native_function`'s pre-dispatch reification and
+                // already past the `is_lazy_for_coerce` guard `lazy_guard_error`
+                // ran above: sort its cached elements like Array/Seq. Any
+                // other (unforced or genuinely-lazy) `LazyList` falls through
+                // to `None` so the interpreter's `builtin_sort` handles it —
+                // unlike the arms above, it must NOT collapse to `Value::NIL`
+                // here, or a genuinely-lazy source would silently sort empty
+                // instead of throwing `X::Cannot::Lazy`.
+                ValueView::LazyList(ll) => match ll.cache.lock().unwrap().clone() {
+                    Some(cached) => {
+                        let mut sorted = cached;
+                        sorted.sort_by(|a, b| crate::runtime::compare_values(a, b).cmp(&0));
+                        Value::seq(sorted)
+                    }
+                    None => return None,
+                },
                 _ => Value::NIL,
             }))
         }

--- a/src/builtins/functions/dispatch_variadic.rs
+++ b/src/builtins/functions/dispatch_variadic.rs
@@ -373,6 +373,35 @@ pub(crate) fn native_function_variadic(
                             }
                         }
                     }
+                    // A finite `LazyList` (e.g. a closure `...` sequence
+                    // whose finite endpoint `try_native_function` already
+                    // reified via `reify_closure_seq_endpoint`) sums its
+                    // cached elements like Array/Seq above. `!is_genuinely_lazy()`
+                    // excludes an infinite one (`1..Inf`, `... *`), whose
+                    // cache — if populated at all — is only ever a prefix:
+                    // summing that would silently answer a truncated total
+                    // instead of the `X::Cannot::Lazy` a strict consumer owes
+                    // it. An un-reified finite one (no cache yet) falls
+                    // through to the generic scalar arm below unchanged —
+                    // summing its whole value, not its elements, is wrong
+                    // too, but this function has no `&mut Interpreter` to
+                    // force it; the caller's pre-pass is what must guarantee
+                    // the cache is populated first.
+                    ValueView::LazyList(ll)
+                        if !ll.is_genuinely_lazy() && ll.cache.lock().unwrap().is_some() =>
+                    {
+                        let cached = ll.cache.lock().unwrap().clone().unwrap_or_default();
+                        for item in &cached {
+                            if has_num {
+                                total_f += item.to_f64();
+                            } else if let ValueView::Num(_) = item.view() {
+                                total_f = total as f64 + item.to_f64();
+                                has_num = true;
+                            } else {
+                                total += item.to_f64() as i64;
+                            }
+                        }
+                    }
                     _ => {
                         if has_num {
                             total_f += arg.to_f64();

--- a/src/runtime/builtins_collection_extrema.rs
+++ b/src/runtime/builtins_collection_extrema.rs
@@ -97,10 +97,22 @@ impl Interpreter {
             return Ok(Value::NIL);
         }
 
-        // Flatten: if a single array/seq/list arg is provided, use its items
+        // Flatten: if a single array/seq/list arg is provided, use its items.
+        // `as_list_items` cannot cover `LazyList` (its cache lives behind a
+        // `Mutex`, so there is no `&[Value]` to borrow), so a finite one
+        // (e.g. a closure `...` sequence the caller already reified via
+        // `reify_closure_seq_endpoint`) is handled here instead, by cloning
+        // its cached elements. `!is_genuinely_lazy()` excludes an infinite
+        // one (`1..Inf`, `... *`) whose cache, if populated at all, is only
+        // ever a prefix — that stays a single candidate, same as before.
         let expanded: Vec<Value> = if args.len() == 1 {
             if let Some(items) = args[0].as_list_items() {
                 items.to_vec()
+            } else if let ValueView::LazyList(ll) = args[0].view()
+                && !ll.is_genuinely_lazy()
+                && let Some(cached) = ll.cache.lock().unwrap().clone()
+            {
+                cached
             } else {
                 args.to_vec()
             }

--- a/src/runtime/builtins_collection_listops.rs
+++ b/src/runtime/builtins_collection_listops.rs
@@ -323,6 +323,19 @@ impl Interpreter {
                     | ValueView::GenericRange { .. } => {
                         items.extend(Self::value_to_list(arg));
                     }
+                    // A finite closure `...` sequence (already forced by
+                    // `try_native_function`'s pre-dispatch reification, and
+                    // already past the `is_lazy_for_coerce` guard above)
+                    // flattens its cached elements like Array/Seq. Any other
+                    // `LazyList` reaching here with no cache falls through to
+                    // pushing itself whole, same as before.
+                    ValueView::LazyList(ll) => {
+                        if let Some(cached) = ll.cache.lock().unwrap().clone() {
+                            items.extend(cached);
+                        } else {
+                            items.push(arg.clone());
+                        }
+                    }
                     _ => items.push(arg.clone()),
                 }
             }

--- a/src/runtime/methods_collection.rs
+++ b/src/runtime/methods_collection.rs
@@ -18,7 +18,15 @@ impl Interpreter {
             return false;
         }
         match value.view() {
-            ValueView::LazyList(_) => true,
+            // A finite closure `...` sequence (`(1, *+1 ... 4)`) is stored as
+            // a `LazyList` only because reaching its endpoint needed
+            // incremental evaluation, not because it is actually unbounded —
+            // `is_genuinely_lazy()` is false for it once
+            // `reify_closure_seq_endpoint` has forced its cache, so it is
+            // eligible for `sort`/`classify`/QuantHash coercion just like an
+            // eager Seq. Every other `LazyList` flavour (an infinite range,
+            // `... *`, an unbounded `.map`/`.grep` pipe, ...) stays lazy here.
+            ValueView::LazyList(ll) => ll.is_genuinely_lazy(),
             ValueView::Array(_, kind) if kind.is_lazy() => true,
             ValueView::GenericRange { start, end, .. } => {
                 Self::is_infinite_endpoint(start) || Self::is_infinite_endpoint(end)

--- a/src/vm/vm_helpers_lazy.rs
+++ b/src/vm/vm_helpers_lazy.rs
@@ -455,7 +455,33 @@ impl Interpreter {
         Ok(())
     }
 
-    /// [`Self::reify_map_grep_seq`] over a whole argument list.
+    /// Reify a not-yet-finished closure-based `...` sequence
+    /// (`(1, *+1 ... 4)`) before a **pure-value reader** touches it.
+    ///
+    /// `eval_sequence` defers a closure (`WhateverCode`-generated) sequence
+    /// whose value endpoint it has not yet reached to a `LazyList` carrying
+    /// only its eager prefix, because reaching the endpoint needs incremental
+    /// evaluation (see `Self::eval_sequence`'s "Defer an unfinished finite
+    /// closure sequence" comment) — that cache therefore starts out holding
+    /// FEWER elements than the finished sequence, not none, so the generic
+    /// "cache is empty -> not ready" guards `join_flat`/`flat_val` use for an
+    /// ordinary deferred `LazyList` silently treat the partial prefix as the
+    /// whole answer. `has_finite_closure_endpoint()` marks exactly this case
+    /// as safe to force to completion (unlike `... *`, which never reaches
+    /// this guard because it is genuinely infinite). A no-op for every other
+    /// value, including every other lazy flavour, whose streaming semantics
+    /// must not be forced at an argument boundary.
+    pub(crate) fn reify_closure_seq_endpoint(&mut self, value: &Value) -> Result<(), RuntimeError> {
+        if let ValueView::LazyList(ll) = value.view()
+            && ll.has_finite_closure_endpoint()
+        {
+            self.force_lazy_list_vm(&ll)?;
+        }
+        Ok(())
+    }
+
+    /// [`Self::reify_map_grep_seq`] and [`Self::reify_closure_seq_endpoint`]
+    /// over a whole argument list.
     ///
     /// Looks through a `Pair`, because a NAMED argument's value is an argument
     /// too: zef's `Any.new(:specs($spec.values[0].map: {...}))` binds the
@@ -464,10 +490,12 @@ impl Interpreter {
     pub(crate) fn reify_map_grep_seq_args(&mut self, args: &[Value]) -> Result<(), RuntimeError> {
         for arg in args {
             self.reify_map_grep_seq(arg)?;
+            self.reify_closure_seq_endpoint(arg)?;
             match arg.view() {
                 ValueView::Pair(_, v) | ValueView::ValuePair(_, v) => {
                     let v = v.clone();
                     self.reify_map_grep_seq(&v)?;
+                    self.reify_closure_seq_endpoint(&v)?;
                 }
                 _ => {}
             }

--- a/t/issue-7753-seq-into-builtin-listop.t
+++ b/t/issue-7753-seq-into-builtin-listop.t
@@ -1,0 +1,47 @@
+use Test;
+
+# A `...` sequence-operator result handed directly to a builtin listop used
+# to collapse to its un-reified eager prefix: `join` saw only the seed,
+# `sum` saw nothing, `min`/`max` returned the whole sequence as a single
+# candidate, and `sort` either refused it as "lazy" or dropped it entirely.
+# The sequence itself was always correct (`say (...)`, `.join`, `elems (...)`
+# all worked) -- only a PURE native listop reading a still-deferred closure
+# `...` sequence (a finite generator whose endpoint had not yet been proven
+# reached) was affected. See https://github.com/tokuhirom/mutsu/issues/7753
+plan 15;
+
+# --- the three repro lines ---
+is join(", ", ("az", *.succ ... "bc")), "az, ba, bb, bc",
+    'join sees every element of a closure sequence';
+is join(",", (1, *+1 ... 4)), "1,2,3,4",
+    'join sees every element of an arithmetic-looking closure sequence';
+is sum((1, *.succ ... 4)), 10, 'sum adds every element, not zero';
+
+# --- controls that were already correct must stay correct ---
+is ("az", *.succ ... "bc").join(","), "az,ba,bb,bc",
+    'method-call form is unaffected';
+my @a = ("az", *.succ ... "bc");
+is join(", ", @a), "az, ba, bb, bc", 'via an array is unaffected';
+is elems((1, *.succ ... 4)), 4, 'elems is unaffected';
+sub slurpy(*@a) { @a.elems }
+is slurpy((1, *.succ ... 4)), 4, 'user slurpy binder is unaffected';
+
+# --- sweep the other builtin listops that take a list argument ---
+is-deeply grep({ $_ > 1 }, (1, *+1 ... 4)).List, (2, 3, 4).List,
+    'grep flattens a closure sequence argument';
+is-deeply map({ $_ * 10 }, (1, *+1 ... 4)).List, (10, 20, 30, 40).List,
+    'map flattens a closure sequence argument';
+is min((1, *+1 ... 4)), 1, 'min reduces every element of a closure sequence';
+is max((1, *+1 ... 4)), 4, 'max reduces every element of a closure sequence';
+is-deeply sort((4, *-1 ... 1)).List, (1, 2, 3, 4).List,
+    'sort flattens and sorts a closure sequence argument';
+
+# --- lazy-safety: an infinite sequence must not be reified by the fix ---
+sub f(*@a) { }
+lives-ok { f(1..Inf) }, 'binding an infinite range into a user slurpy stays lazy';
+my @inf = 1..Inf;
+is-deeply @inf[^3].List, (1, 2, 3).List, 'a lazy array stays lazy after the fix';
+throws-like { sort (1, 1, *+* ... *) }, X::Cannot::Lazy,
+    'sort on a genuinely infinite closure sequence still throws';
+
+done-testing;


### PR DESCRIPTION
## Summary

- `(SEED, *code ... ENDPOINT)` handed directly to a builtin listop (`join`, `sum`, `min`, `max`, `sort`, and transitively `grep`/`map`) silently answered wrong: `join` saw only the seed, `sum` answered `0`, `min`/`max` returned the whole sequence as a single candidate, and `sort` refused it as "lazy" or dropped it entirely. The sequence's own value was always correct (`say (...)`, `.join`, `elems (...)`, user `*@`-slurpy binding all worked) — only a **pure** native listop reading the raw value was affected.
- Root cause: `eval_sequence` defers a closure (`WhateverCode`-generated) `...` sequence whose value endpoint it has not yet reached to a `LazyList` holding only its eager prefix (reaching the endpoint needs incremental generator evaluation — see the "Defer an unfinished finite closure sequence" comment in `src/runtime/sequence.rs`). The ADR-0058 pre-dispatch pass that reifies a still-deferred `.map`/`.grep` Seq before a pure native listop reads it (`reify_map_grep_seq_args`) knew nothing about this different lazy flavour, so the native implementations of `join`/`sum`/`min`/`max`/`sort` silently read the partial (or, for `join`, single-item) cache as if it were the finished answer.
- Fix: a new `Interpreter::reify_closure_seq_endpoint` (`src/vm/vm_helpers_lazy.rs`), called alongside the existing map/grep reification, forces exactly a `LazyList` with `has_finite_closure_endpoint()` — a concrete endpoint, so forcing it to completion can never hang, unlike a genuinely infinite `... *`.
- `sum`'s variadic native dispatch, the shared `min`/`max` flatten step (`extrema_from_values_generic`), and `sort`'s native (`dispatch_1arg.rs`) and interpreter (`builtin_sort`) paths each needed a `LazyList` arm of their own to actually read the now-complete cache, mirroring their existing `Array`/`Seq` arms.
- `sort` also had an over-eager `is_lazy_for_coerce` guard (`methods_collection.rs`) that treated every `LazyList` as unsortable regardless of laziness; narrowed to `ll.is_genuinely_lazy()` so a finite, already-reified closure sequence is eligible for sort/classify/QuantHash coercion like an eager Seq, while an actually-infinite source still throws `X::Cannot::Lazy`.
- `join` needed no change beyond the shared reification pass — its `join_flat`/`flat_val` helpers already read a fully-populated `LazyList` cache correctly.

## Test plan

- [x] New `t/issue-7753-seq-into-builtin-listop.t`, verified against both `target/debug/mutsu` and `raku` — the three repro lines, every previously-correct control, a sweep across `grep`/`map`/`min`/`max`/`sort`, and lazy-safety controls (an infinite range/sequence stays lazy; a genuinely-infinite `sort` still throws `X::Cannot::Lazy`) all match.
- [x] All 84 existing `t/*sequence*`/`t/*lazy*`/`t/*sort*`/`t/*extrema*` local test files (1055 assertions) still pass.
- [x] `cargo fmt --all`
- [x] `make lint` — clean (default clippy, `jit`-off clippy, wasm32 clippy, rustdoc)
- [x] `make test` — one flaky failure on retry investigation: `t/whenever-callback-recompile-semantics.t` test 5 (`Promise.anyof` async timing race) fails ~1/5 runs and passes on retry; it is unrelated to this diff (async `whenever`/`Promise` concurrency semantics, no sequence/listop code touched) and reproduces identically before this change. `make test` overall: `Result: PASS` once retried clean.
- [x] `make roast` — the only failures are the three known remote-container environment-only files (`roast/6.c/S32-io/file-tests.t`, `roast/S16-filehandles/filetest.t`, `roast/S32-io/IO-Socket-Async.t`), matching `docs/agent-environments.md` by name and subtest range exactly.

Closes #7753

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5YdUpBfVMSGjEwVvGwUg7

---
_Generated by [Claude Code](https://claude.ai/code/session_01M5YdUpBfVMSGjEwVvGwUg7)_