### PR TITLE
Fix `need` suppressing exports its own compunit imports via `use`

### DIFF
--- a/news/2026-09/need-suppresses-own-nested-use-exports.md
+++ b/news/2026-09/need-suppresses-own-nested-use-exports.md
@@ -1,0 +1,28 @@
+# `need Foo;` no longer suppresses exports `Foo` imports for itself
+
+`need Foo;` loads a compunit without importing its exports into the caller —
+implemented by setting `suppress_exports` for the whole duration of the load
+so `Foo`'s own `is export` declarations are never registered as importable.
+That flag was a single unscoped boolean, though, so it stayed set for every
+nested `use` statement `Foo`'s own body executed too. A `Foo.rakumod` that
+itself said `use Bar;` therefore had `Bar`'s exports silently dropped: `Bar`'s
+`is export` subs never reached `exported_subs`, so `Foo`'s own `use Bar;`
+found nothing to import, and any of `Foo`'s methods calling a `Bar` routine
+died with `Unknown function`.
+
+`Interpreter::use_module_with_tags` now suspends `suppress_exports` for the
+duration of its own nested load, restoring the ambient value afterward. An
+explicit `use` always wants ordinary export semantics, regardless of whether
+it happens to run inside a `need`-loaded compunit's mainline — only the
+directly `need`ed module's own exports should stay unregistered.
+
+This was found via the bundled-library gate running under the vendored `Test`
+module (`MUTSU_REAL_TEST=1`), where four whitelisted `DBIish` files (used
+through `need DBIish::CommonTesting;`) called `diag` from a method of that
+compunit and hit exactly this gap — `DBIish::CommonTesting` itself does
+`use Test;`. All four now pass under the vendored provider with no database
+server present. Pinned by `t/need-preserves-nested-use-imports.t`, a minimal
+`need`-loaded class whose own `use` of a sibling module must resolve from one
+of its methods.
+
+Closes #7805.

--- a/src/runtime/runtime_module.rs
+++ b/src/runtime/runtime_module.rs
@@ -262,7 +262,19 @@ impl Interpreter {
         // resolve with ITS OWN (usually absent) selectors, not the outer ones.
         let (module, dist_selectors) = Self::split_dist_selectors(module);
         let saved = std::mem::replace(&mut self.pending_dist_selectors, dist_selectors);
+        // `suppress_exports` is set for the whole duration of an enclosing
+        // `need` load (see `need_module`), so its own compunit's `is export`
+        // subs never get registered as importable. But an explicit `use`
+        // nested inside that compunit's body (e.g. `need CT;` where
+        // `CT.rakumod` itself says `use Test;`) must still register and
+        // import Test's exports normally -- otherwise CT's own methods can
+        // never resolve `diag` via `module_imported_lexical_names`, even
+        // though CT's own mainline genuinely imported it (#7805). `use`
+        // always wants ordinary export semantics regardless of an ambient
+        // `need`, so suspend the flag for exactly this nested load.
+        let saved_suppress_exports = std::mem::replace(&mut self.suppress_exports, false);
         let result = self.use_module_with_tags_inner(module, tags);
+        self.suppress_exports = saved_suppress_exports;
         self.pending_dist_selectors = saved;
         // `load_module` consumes `pending_use_export_args`; clear any residue
         // here so a native/pragma/already-loaded path (which never reaches

--- a/t/lib-need-nested-import/NestedImportExporter.rakumod
+++ b/t/lib-need-nested-import/NestedImportExporter.rakumod
@@ -1,0 +1,2 @@
+unit module NestedImportExporter;
+sub nested-import-marker() is export { 'nested-import-ok' }

--- a/t/lib-need-nested-import/NestedImportUser.rakumod
+++ b/t/lib-need-nested-import/NestedImportUser.rakumod
@@ -1,0 +1,5 @@
+use NestedImportExporter;
+
+unit class NestedImportUser;
+
+method run { nested-import-marker() }

--- a/t/need-preserves-nested-use-imports.t
+++ b/t/need-preserves-nested-use-imports.t
@@ -1,0 +1,12 @@
+use Test;
+use lib $?FILE.IO.parent.add('lib-need-nested-import').Str;
+
+plan 1;
+
+# `need Foo;` loads Foo without importing anything into the loading scope,
+# but Foo's OWN `use` statements must still resolve normally from Foo's own
+# methods -- `need` only suppresses exports flowing out to the needer, not
+# imports flowing into the needed compunit itself (#7805).
+need NestedImportUser;
+is NestedImportUser.new.run, 'nested-import-ok',
+    'a need-loaded compunit resolves a sub its own use imported, from its own method';


### PR DESCRIPTION
## Summary

- `need Foo;` sets `suppress_exports` for the whole duration of loading `Foo`, so `Foo`'s own `is export` subs never register as importable into the loading scope — that is the whole point of `need`. But the flag was a single unscoped boolean, so it stayed set for every nested `use` statement `Foo`'s own body executed too. A `Foo.rakumod` that itself said `use Bar;` therefore had `Bar`'s exports silently dropped from `exported_subs`, so `Foo`'s own `use Bar;` found nothing to import, and any of `Foo`'s methods calling a `Bar` routine died with `Unknown function`.
- `Interpreter::use_module_with_tags` (`src/runtime/runtime_module.rs`) now suspends `suppress_exports` for the duration of its own nested load, restoring the ambient value afterward — an explicit `use` always wants ordinary export semantics, regardless of whether it happens to run inside a `need`-loaded compunit's own mainline.
- Found via the bundled-library gate running under the vendored `Test` module (`MUTSU_REAL_TEST=1`): four whitelisted `DBIish` files (loaded through `need DBIish::CommonTesting;`, whose own `method run-tests` opens with `diag "..."` and which itself does `use Test;`) failed with `Unknown function: diag`. Verified locally (no database server needed) that all four now pass under the vendored provider: `35-pg-common`, `55-oracle-common`, `70-sqlcipher-memory`, `71-sqlcipher-common` (109/109 each).

Closes #7805.

## Test plan

- [x] New regression test `t/need-preserves-nested-use-imports.t` (+ fixture modules under `t/lib-need-nested-import/`): a `need`-loaded class whose own `use` of a sibling module must resolve from one of its methods. Confirmed it reproduces the bug on the pre-fix code and passes after the fix. Verified the same shape passes verbatim under `raku`.
- [x] `cargo fmt --all`
- [x] `make lint` (default clippy, `jit`-off clippy, wasm32 clippy, rustdoc) — clean
- [x] `make test` (release build, `cargo test`, `prove t/`) — all green (`Files=3935, Tests=41851`)
- [x] `make roast` — green except the three container-only failures documented in `docs/agent-environments.md` (`file-tests.t`/`filetest.t` under `uid 0`, `IO-Socket-Async.t`'s sandboxed-network timeout); no other regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UBj19tmmC6B4jK5cvRTLhH

---
_Generated by [Claude Code](https://claude.ai/code/session_01UBj19tmmC6B4jK5cvRTLhH)_