### PR TITLE
perf: key the carrier compile cache by parse site, not by code-object instance

### DIFF
--- a/news/2026-09/carrier-compile-cache-keyed-by-parse-site.md
+++ b/news/2026-09/carrier-compile-cache-keyed-by-parse-site.md
@@ -1,0 +1,85 @@
+# The carrier compile cache was keyed by the wrong identity
+
+`eval_block_value_inner` caches the bytecode it compiles for a carrier block so
+the same block does not have to be re-compiled from AST on every call. It keyed
+that cache on `SubData.id`.
+
+`SubData.id` is `next_instance_id()` — a fresh number for every `Sub` *value*.
+So the cache worked only for a block whose code object outlives its calls. A
+block **instantiated more than once from the same literal** got a new key every
+time: it could never hit, and it left a permanently unreachable entry behind in
+a map with no eviction.
+
+That is not an exotic shape. `Cro::MessageWithBody.body-blob` is
+
+```raku
+Promise(supply {
+    my $joined = Buf.new;
+    whenever self.body-byte-stream -> $blob { $joined.append($blob); LAST emit $joined }
+})
+```
+
+so every call builds a fresh supply block — and paid three full
+`Compiler::compile` runs plus three dead cache entries for it, every time.
+
+## What the key should be
+
+The compiled chunk is a pure function of the body AST plus the ambient context
+already recorded in `CarrierCompileCtxKey`. The right identity is therefore the
+**parse site**, and mutsu already has one: `CompiledCode::closure_body_arc`
+builds one `Arc<Vec<Stmt>>` per `stmt_pool` slot and hands every later
+instantiation of that literal an `Arc` bump of it. Pointer identity of that
+`Arc` *is* "the same literal".
+
+`CarrierCacheKey::Site` holds that `Arc` — not just its address, so the
+allocation cannot be freed and a later one reused underneath a stale entry, the
+same soundness argument `MapGrepCacheKey` already makes. `CarrierCacheKey::Id`
+keeps the old behaviour for the call sites that legitimately have their own
+stable id to key on (the regex code-block and `s///` replacement paths, whose
+ids name a parsed node rather than a value).
+
+## The half that was hiding behind it
+
+Keying by parse site alone only got the *supply block body* to hit; the
+`whenever` callback still missed. `split_whenever_body_phasers` partitions a
+`whenever` body into its main statements and its `LAST`/`QUIT` phaser bodies, and
+it ran on every **registration**, deep-cloning every statement into fresh `Vec`s.
+So the callback `Sub` was handed a brand-new `Arc` each time and the cache could
+not see it as the same block — and the O(body) AST clone was pure waste besides.
+
+The split is a pure function of the body, so it is memoized on the same
+parse-site identity now (`WheneverBodySplit`), and `exec_whenever_scope_op`
+passes the pool-owned `Arc` rather than a borrowed slice.
+
+## Results
+
+Carrier compile misses for one `supply { whenever … }` literal instantiated N
+times:
+
+| instantiations | before | after |
+| --- | --- | --- |
+| 10 | 30 | 3 |
+| 40 | 120 | 3 |
+
+Per-instantiation before, a constant after — and the unbounded cache growth goes
+with it.
+
+The `Promise(supply { whenever … })` shape itself, with Cro's module stack
+loaded, goes from 1.55 ms to 1.17 ms per call (25%); `body-blob.result` on the
+HTTP/2 request parser from 2.2 ms to ~1.9 ms.
+
+## What this does *not* fix
+
+It does not make `cro-http`'s `t/http2-request-parser.rakutest` stable under
+`MUTSU_REAL_TEST=1`, and the measurement is worth recording so nobody assumes it
+did. That test loses a race whose losing side is `DATA frame → body-blob → one
+ok`; measured against a real-`Test` `ok` at 0.083 ms, the winning side costs
+about 0.25 ms and the losing side about 3.1 ms. The margin comes entirely from
+what the main thread does after the promise is kept, and under CPU contention it
+is a coin flip: 20/20 idle but 9/20 with three cores busy, both before and after
+this change.
+
+Closing that needs the losing side under about 1 millisecond, which means the
+other half of the cost: env copy-on-write deep copies that scale with the size of
+the program (7,253 env entries copied per DATA frame, ~17,000 per `body-blob`).
+See [#7667](https://github.com/tokuhirom/mutsu/issues/7667).

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -389,18 +389,113 @@ struct CarrierCompileCtxKey {
     whenever_inherited_owned: Vec<Symbol>,
 }
 
-/// Per-`SubData.id` cache of `(context, compiled)` pairs for
+/// Split-and-shared `whenever` body, memoized per parse site.
+///
+/// `split_whenever_body_phasers` partitions a `whenever` body into its main
+/// statements and its `LAST`/`QUIT` phaser bodies. That is a pure function of
+/// the body AST, but it ran on every *registration*, deep-cloning every
+/// statement into fresh `Vec`s -- so a `whenever` registered in a loop paid an
+/// O(body) AST copy each time AND handed the callback `Sub` a brand-new
+/// `Arc<Vec<Stmt>>`, which meant the carrier compile cache (keyed by parse
+/// site, see [`CarrierCacheKey`]) could never hit for it. Memoizing it hands
+/// every registration the same `Arc`s. Keyed by the pool-owned body `Arc`,
+/// held rather than addressed for the same soundness reason as
+/// [`MapGrepCacheKey`].
+type WheneverBodySplit = (
+    Arc<Vec<crate::ast::Stmt>>,
+    Vec<Arc<Vec<crate::ast::Stmt>>>,
+    Vec<Arc<Vec<crate::ast::Stmt>>>,
+);
+
+/// Key for `whenever_body_splits`: pointer identity of the pool-owned body
+/// `Arc`, held so the allocation cannot be freed and reused underneath a
+/// cached split.
+#[derive(Clone)]
+pub(crate) struct WheneverBodyKey(Arc<Vec<crate::ast::Stmt>>);
+
+impl PartialEq for WheneverBodyKey {
+    fn eq(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.0, &other.0)
+    }
+}
+
+impl Eq for WheneverBodyKey {}
+
+impl std::hash::Hash for WheneverBodyKey {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        (Arc::as_ptr(&self.0) as *const u8 as usize).hash(state);
+    }
+}
+
+/// What a carrier-block compile is cached *under*.
+///
+/// The compiled chunk is a pure function of the body AST plus the ambient
+/// context in [`CarrierCompileCtxKey`], so the right identity is the **parse
+/// site**, not the code object that happens to be running it.
+///
+/// [`Site`](Self::Site) is that identity: `CompiledCode::closure_body_arc`
+/// builds one `Arc<Vec<Stmt>>` per `stmt_pool` slot and hands every later
+/// instantiation of the same closure literal an `Arc` bump of it, so pointer
+/// identity of that `Arc` *is* "same literal". The `Arc` is held, not just its
+/// address, so the allocation cannot be freed and a later one reused at the
+/// same address under a stale entry — the same soundness argument
+/// [`MapGrepCacheKey`] makes.
+///
+/// This used to be a bare `SubData.id`, which is `next_instance_id()` — a
+/// fresh number for every `Sub` *value*. A block instantiated more than once
+/// from one literal therefore never hit: `body-blob`'s
+/// `Promise(supply { whenever … })` builds a new supply block per call, so it
+/// re-compiled three chunks on every call and left three permanently
+/// unreachable cache entries behind (#7667).
+///
+/// [`Id`](Self::Id) keeps that behaviour for the call sites that legitimately
+/// have their own stable identity to key on — the regex code-block and `s///`
+/// replacement paths, whose ids name a parsed node rather than a value.
+#[derive(Clone)]
+pub(crate) enum CarrierCacheKey {
+    Site(Arc<Vec<crate::ast::Stmt>>),
+    Id(u64),
+}
+
+impl PartialEq for CarrierCacheKey {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::Site(a), Self::Site(b)) => Arc::ptr_eq(a, b),
+            (Self::Id(a), Self::Id(b)) => a == b,
+            _ => false,
+        }
+    }
+}
+
+impl Eq for CarrierCacheKey {}
+
+impl std::hash::Hash for CarrierCacheKey {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        match self {
+            Self::Site(a) => {
+                0u8.hash(state);
+                (Arc::as_ptr(a) as *const u8 as usize).hash(state);
+            }
+            Self::Id(a) => {
+                1u8.hash(state);
+                a.hash(state);
+            }
+        }
+    }
+}
+
+/// Per-parse-site cache of `(context, compiled)` pairs for
 /// `eval_block_value_inner`'s carrier-block compile (see
 /// `todo/deep/eval-block-value-recompiles-every-call.md`). A `Vec` rather
 /// than a nested `HashMap` because `CarrierCompileCtxKey` cannot implement
 /// `Hash`/`Eq` (it embeds a `Value`, compared by Raku's semantic `PartialEq`,
-/// not a total order) — and because the realistic size is 1 entry per id
+/// not a total order) — and because the realistic size is 1 entry per site
 /// (the same block invoked from the same call site every time), so a linear
 /// scan against `CarrierCompileCtxKey::eq` costs nothing. Capped at
-/// `CARRIER_COMPILE_CACHE_MAX_CONTEXTS_PER_ID` entries per id to bound memory
+/// `CARRIER_COMPILE_CACHE_MAX_CONTEXTS_PER_ID` entries per key to bound memory
 /// for the rare block invoked from many distinct contexts.
 type CarrierCompileCache =
-    HashMap<u64, Vec<(CarrierCompileCtxKey, Arc<CompiledCode>, Arc<CompiledFns>)>>;
+    HashMap<CarrierCacheKey, Vec<(CarrierCompileCtxKey, Arc<CompiledCode>, Arc<CompiledFns>)>>;
 
 const CARRIER_COMPILE_CACHE_MAX_CONTEXTS_PER_ID: usize = 4;
 
@@ -2380,6 +2475,10 @@ pub struct Interpreter {
     /// `eval_block_value_cached`/`eval_test_block_value`'s `cache_id`
     /// parameter — starts empty per thread (pure recomputable optimization).
     carrier_compile_cache: CarrierCompileCache,
+    /// See [`WheneverBodySplit`]: the phaser split of a `whenever` body, reused
+    /// across every registration from one parse site. Pure recomputable
+    /// optimization; starts empty per thread.
+    whenever_body_splits: HashMap<WheneverBodyKey, WheneverBodySplit>,
     /// Parsed `s///` / `S///` replacement plans, keyed by the replacement's
     /// source text (see `vm::vm_subst_repl`). The replacement is a `qq` quote,
     /// so it is parsed with the real interpolation grammar; caching keeps a

--- a/src/runtime/resolution_call_sub.rs
+++ b/src/runtime/resolution_call_sub.rs
@@ -937,7 +937,14 @@ impl Interpreter {
             // its lvalue return, on this recompile path exactly as on the
             // compiled one (`compile_routine_closure_body`'s `is_rw`).
             self.pending_eval_rw_tail = data.is_rw || data.is_raw;
-            let body_result = self.eval_block_value_cached(&data.body, data.id);
+            // Keyed by the body's PARSE SITE, not by `data.id`: that is
+            // `next_instance_id()`, a fresh number per `Sub` value, so a block
+            // instantiated more than once from one literal could never hit the
+            // cache and left an unreachable entry behind each time. Every
+            // instantiation shares the pool-owned body `Arc`
+            // (`CompiledCode::closure_body_arc`), which is the identity the
+            // compiled chunk actually depends on. See `CarrierCacheKey`.
+            let body_result = self.eval_block_value_cached_for_site(&data.body);
             self.pending_nested_state_scope = None;
             self.pending_supply_block_body = false;
             self.pending_supply_emitter_sym = None;

--- a/src/runtime/resolution_eval.rs
+++ b/src/runtime/resolution_eval.rs
@@ -242,7 +242,33 @@ impl Interpreter {
         body: &[Stmt],
         cache_id: u64,
     ) -> Result<Value, RuntimeError> {
-        self.eval_block_value_inner(body, false, false, Some(cache_id), None)
+        self.eval_block_value_inner(
+            body,
+            false,
+            false,
+            Some(CarrierCacheKey::Id(cache_id)),
+            None,
+        )
+    }
+
+    /// [`Interpreter::eval_block_value_cached`], keyed by the body's **parse
+    /// site** rather than by a per-value id.
+    ///
+    /// This is the right key for a closure literal's body: every instantiation
+    /// of one literal shares the pool-owned `Arc` (`closure_body_arc`), so the
+    /// compiled chunk is reused across instantiations instead of being rebuilt
+    /// for each one. See [`CarrierCacheKey`].
+    pub(crate) fn eval_block_value_cached_for_site(
+        &mut self,
+        body: &std::sync::Arc<Vec<Stmt>>,
+    ) -> Result<Value, RuntimeError> {
+        self.eval_block_value_inner(
+            body,
+            false,
+            false,
+            Some(CarrierCacheKey::Site(std::sync::Arc::clone(body))),
+            None,
+        )
     }
 
     /// [`Interpreter::eval_block_value_cached`], additionally reporting the
@@ -266,7 +292,7 @@ impl Interpreter {
             body,
             false,
             false,
-            Some(cache_id),
+            Some(CarrierCacheKey::Id(cache_id)),
             Some(free_var_writes_out),
         )
     }
@@ -369,7 +395,7 @@ impl Interpreter {
         &mut self,
         body: &[Stmt],
         is_eval_unit: bool,
-        cache_id: u64,
+        cache_id: CarrierCacheKey,
         post: &CarrierPostCompile,
     ) -> (
         std::sync::Arc<crate::opcode::CompiledCode>,
@@ -405,7 +431,7 @@ impl Interpreter {
         body: &[Stmt],
         is_eval_unit: bool,
         record_free_var_writes: bool,
-        cache_id: Option<u64>,
+        cache_id: Option<CarrierCacheKey>,
         free_var_writes_out: Option<&mut Vec<String>>,
     ) -> Result<Value, RuntimeError> {
         // Taken first, unconditionally: it belongs to THIS body's compile only

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -3042,6 +3042,7 @@ impl Interpreter {
             lock_async_recursion: Vec::new(),
             lock_async_deferred: Vec::new(),
             carrier_compile_cache: HashMap::new(),
+            whenever_body_splits: Default::default(),
             subst_repl_plans: HashMap::new(),
             map_grep_compile_cache: HashMap::new(),
             gather_compile_cache: HashMap::new(),

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -688,6 +688,7 @@ impl Interpreter {
             lock_async_recursion: Vec::new(),
             lock_async_deferred: Vec::new(),
             carrier_compile_cache: HashMap::new(),
+            whenever_body_splits: Default::default(),
             subst_repl_plans: HashMap::new(),
             map_grep_compile_cache: HashMap::new(),
             gather_compile_cache: HashMap::new(),

--- a/src/runtime/subtest.rs
+++ b/src/runtime/subtest.rs
@@ -161,22 +161,42 @@ impl Interpreter {
 }
 
 impl Interpreter {
-    fn split_whenever_body_phasers(body: &[Stmt]) -> (Vec<Stmt>, Vec<Vec<Stmt>>, Vec<Vec<Stmt>>) {
+    fn split_whenever_body_phasers(body: &[Stmt]) -> super::WheneverBodySplit {
         let mut main = Vec::new();
         let mut last = Vec::new();
         let mut quit = Vec::new();
         for stmt in body {
             if let Stmt::Phaser { kind, body, .. } = stmt {
                 match kind {
-                    PhaserKind::Last => last.push(body.clone()),
-                    PhaserKind::Quit => quit.push(body.clone()),
+                    PhaserKind::Last => last.push(std::sync::Arc::new(body.clone())),
+                    PhaserKind::Quit => quit.push(std::sync::Arc::new(body.clone())),
                     _ => main.push(stmt.clone()),
                 }
             } else {
                 main.push(stmt.clone());
             }
         }
-        (main, last, quit)
+        (std::sync::Arc::new(main), last, quit)
+    }
+
+    /// [`Self::split_whenever_body_phasers`], memoized per parse site.
+    ///
+    /// The split is a pure function of the body, so every registration from one
+    /// `whenever` literal can share one set of `Arc`s -- which is both an
+    /// O(body) AST clone saved per registration and what lets the callback
+    /// `Sub` carry a *stable* body identity, so the carrier compile cache can
+    /// serve it. See [`super::WheneverBodySplit`].
+    fn whenever_body_split(
+        &mut self,
+        body: &std::sync::Arc<Vec<Stmt>>,
+    ) -> super::WheneverBodySplit {
+        let key = super::WheneverBodyKey(std::sync::Arc::clone(body));
+        if let Some(hit) = self.whenever_body_splits.get(&key) {
+            return hit.clone();
+        }
+        let split = Self::split_whenever_body_phasers(body);
+        self.whenever_body_splits.insert(key, split.clone());
+        split
     }
 
     pub(crate) fn begin_subtest(&mut self) -> SubtestContext {
@@ -363,7 +383,7 @@ impl Interpreter {
         yields_value: bool,
         param: &Option<String>,
         param_type: &Option<String>,
-        body: &[Stmt],
+        body: &std::sync::Arc<Vec<Stmt>>,
         owned_lexicals: &[Symbol],
     ) -> Result<Value, RuntimeError> {
         let whenever_id = crate::runtime::native_methods::next_whenever_id();
@@ -417,7 +437,7 @@ impl Interpreter {
             ));
         }
 
-        let (main_body, last_bodies, quit_bodies) = Self::split_whenever_body_phasers(body);
+        let (main_body, last_bodies, quit_bodies) = self.whenever_body_split(body);
         // The `supply` block this `whenever` is written in — its body is what is
         // running right now, so this is unambiguous. Stamped onto every callback
         // below so dispatch can re-establish it as the innermost active emitter

--- a/src/vm/vm_scope_ops.rs
+++ b/src/vm/vm_scope_ops.rs
@@ -177,7 +177,7 @@ impl Interpreter {
         let param = param_idx.map(|idx| Self::const_str(code, idx).to_string());
         let param_type = param_type_idx.map(|idx| Self::const_str(code, idx).to_string());
         let stmt = &code.stmt_pool[body_idx as usize];
-        if let Stmt::Block(body) = stmt {
+        if let Stmt::Block(_) = stmt {
             // Box captured-and-mutated lexicals the whenever body reads into
             // shared ContainerRef cells BEFORE run_whenever_with_value clones
             // the env for the callback closures below: those closures are
@@ -264,6 +264,13 @@ impl Interpreter {
                 }
                 self.share_supply_block_lexicals(code);
             }
+            // The POOL-OWNED body `Arc`, not the borrowed slice: it is built
+            // once per `stmt_pool` slot, so every registration from this
+            // `whenever` literal shares it. That identity is what lets the
+            // phaser split and the compiled chunk be reused across
+            // registrations instead of rebuilt per value (see
+            // `WheneverBodySplit` and `CarrierCacheKey`).
+            let body_arc = code.closure_body_arc(body_idx as usize);
             let tap = loan_env!(
                 self,
                 run_whenever_with_value(
@@ -271,7 +278,7 @@ impl Interpreter {
                     yields_value,
                     &param,
                     &param_type,
-                    body,
+                    &body_arc,
                     &owned_lexicals
                 )
             )?;

--- a/t/whenever-repeated-instantiation-semantics.t
+++ b/t/whenever-repeated-instantiation-semantics.t
@@ -1,0 +1,36 @@
+use Test;
+
+# One `whenever` literal instantiated many times shares its compiled chunk and
+# its phaser split (#7667). The sharing must be invisible: each instantiation
+# still gets its own emitter, its own captured lexicals, and its own phasers.
+
+plan 6;
+
+sub doubler(Supply $in) { supply { whenever $in -> $v { emit $v * 2; LAST emit 'end' } } }
+
+# Two live instances of the SAME literal must not answer each other's emitter.
+my $a = Supplier.new;
+my $b = Supplier.new;
+my (@ga, @gb);
+doubler($a.Supply).tap({ @ga.push($_) });
+doubler($b.Supply).tap({ @gb.push($_) });
+$a.emit(1); $b.emit(10); $a.emit(2); $b.emit(20);
+is @ga, [2, 4],   'instance A saw only its own source';
+is @gb, [20, 40], 'instance B saw only its own source';
+
+# The LAST phaser is per instance, and fires on its own source's done.
+$a.done;
+is @ga, [2, 4, 'end'], "instance A's LAST fired on its own done";
+is @gb, [20, 40],      "instance B's LAST did not fire";
+$b.done;
+is @gb, [20, 40, 'end'], "instance B's LAST fired on its own done";
+
+# A lexical captured by the literal is per instantiation, not shared.
+sub counter(Supply $in) { supply { my $n = 0; whenever $in -> $v { $n++; emit $n } } }
+my $c = Supplier.new;
+my $d = Supplier.new;
+my (@gc, @gd);
+counter($c.Supply).tap({ @gc.push($_) });
+counter($d.Supply).tap({ @gd.push($_) });
+$c.emit('x'); $c.emit('x'); $c.emit('x'); $d.emit('y');
+is (@gc, @gd), ([1, 2, 3], [1]), 'each instantiation has its own captured lexical';

--- a/tests/carrier_compile_cache_keyed_by_parse_site.rs
+++ b/tests/carrier_compile_cache_keyed_by_parse_site.rs
@@ -1,0 +1,79 @@
+//! Pins the carrier compile cache's key to the **parse site** (#7667).
+//!
+//! `eval_block_value_inner` caches the bytecode it compiles for a carrier block.
+//! The key used to be `SubData.id` — which is `next_instance_id()`, a fresh
+//! number for every `Sub` *value*. A block instantiated more than once from one
+//! literal therefore got a new key every time and could never hit, while leaving
+//! a permanently unreachable entry behind in an unbounded map.
+//!
+//! `Cro::MessageWithBody.body-blob` is `Promise(supply { whenever … })`, so it
+//! builds a fresh supply block on every call: it re-compiled three chunks per
+//! call and grew the cache by three entries per call.
+//!
+//! The key is the pool-owned body `Arc` now (`CompiledCode::closure_body_arc`
+//! hands every instantiation of one literal the same `Arc`), so the compiled
+//! chunk is shared across instantiations. The `whenever` body's phaser split is
+//! memoized on the same identity — without that the callback `Sub` was handed a
+//! freshly cloned `Vec<Stmt>` per registration and the cache still could not see
+//! it as the same block.
+//!
+//! A regression shows up as `carrier-compile: misses=` growing with the number
+//! of *instantiations*.
+
+use std::process::Command;
+
+/// Instantiates one `supply { whenever … }` literal `n` times, taps each.
+const PROGRAM: &str = r#"
+sub mk($sup) { supply { whenever $sup -> $v { emit $v } } }
+my $n = +@*ARGS[0];
+my $seen = 0;
+for ^$n {
+    my $sup = Supplier::Preserving.new;
+    $sup.emit(1);
+    $sup.done;
+    mk($sup).tap({ $seen++ });
+}
+say $seen;
+"#;
+
+/// `(values seen by the taps, carrier-compile misses)`.
+fn run(instantiations: u32) -> (u32, u64) {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_mutsu"));
+    cmd.arg("-e").arg(PROGRAM).arg(instantiations.to_string());
+    cmd.env("MUTSU_VM_STATS", "1");
+    let out = cmd.output().expect("failed to spawn mutsu");
+    let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
+    assert!(
+        out.status.success(),
+        "run failed\nstdout: {stdout}\nstderr: {stderr}"
+    );
+    let seen = stdout
+        .lines()
+        .last()
+        .and_then(|l| l.trim().parse().ok())
+        .unwrap_or_else(|| panic!("no count on stdout: {stdout}"));
+    let misses = stderr
+        .lines()
+        .find_map(|l| l.split("carrier-compile: ").nth(1))
+        .and_then(|rest| rest.split("misses=").nth(1))
+        .and_then(|v| v.split_whitespace().next())
+        .and_then(|v| v.parse().ok())
+        .unwrap_or_else(|| panic!("no carrier-compile line in stats: {stderr}"));
+    (seen, misses)
+}
+
+#[test]
+fn one_supply_literal_compiles_once_however_often_it_is_instantiated() {
+    let (few_seen, few_misses) = run(10);
+    let (many_seen, many_misses) = run(40);
+    assert_eq!(few_seen, 10, "a tap missed its value");
+    assert_eq!(many_seen, 40, "a tap missed its value");
+    // Before the fix these were 30 and 120 — three compiles per instantiation.
+    assert!(
+        many_misses <= few_misses + 2,
+        "carrier compiles grew with the instantiation count: {few_misses} for 10, \
+         {many_misses} for 40 — the cache is keyed by something per-instance again \
+         (see CarrierCacheKey)"
+    );
+}


### PR DESCRIPTION
## What

`eval_block_value_inner` caches the bytecode it compiles for a carrier block so
the same block is not re-compiled from AST on every call. It keyed that cache on
`SubData.id` — which is `next_instance_id()`, a fresh number for every `Sub`
**value**.

So the cache worked only for a block whose code object outlives its calls. A
block **instantiated more than once from the same literal** got a new key every
time: it could never hit, and it left a permanently unreachable entry behind in a
map with no eviction.

That is not an exotic shape. `Cro::MessageWithBody.body-blob` is

```raku
Promise(supply {
    my $joined = Buf.new;
    whenever self.body-byte-stream -> $blob { $joined.append($blob); LAST emit $joined }
})
```

so every call builds a fresh supply block — and paid three full
`Compiler::compile` runs plus three dead cache entries for it, every time.

## How

The compiled chunk is a pure function of the body AST plus the ambient context
already recorded in `CarrierCompileCtxKey`, so the right identity is the **parse
site** — and mutsu already has one. `CompiledCode::closure_body_arc` builds one
`Arc<Vec<Stmt>>` per `stmt_pool` slot and hands every later instantiation of that
literal an `Arc` bump of it, so pointer identity of that `Arc` *is* "the same
literal".

`CarrierCacheKey::Site` holds that `Arc` — not just its address, so the
allocation cannot be freed and a later one reused underneath a stale entry, the
same soundness argument `MapGrepCacheKey` already makes. `CarrierCacheKey::Id`
keeps the old behaviour for the call sites that legitimately have their own
stable id to key on (the regex code-block and `s///` replacement paths, whose ids
name a parsed node rather than a value).

**The half that was hiding behind it.** Keying by parse site alone only got the
supply block *body* to hit; the `whenever` callback still missed.
`split_whenever_body_phasers` partitions a `whenever` body into its main
statements and its `LAST`/`QUIT` phaser bodies, and it ran on every
**registration**, deep-cloning every statement into fresh `Vec`s — so the
callback `Sub` was handed a brand-new `Arc` each time and the cache could not see
it as the same block, and the O(body) AST clone was pure waste besides. The split
is a pure function of the body, so it is memoized on the same parse-site identity
now (`WheneverBodySplit`), and `exec_whenever_scope_op` passes the pool-owned
`Arc` rather than a borrowed slice.

## Measurements

Carrier compile misses for one `supply { whenever … }` literal instantiated N
times:

| instantiations | before | after |
| --- | --- | --- |
| 10 | 30 | **3** |
| 40 | 120 | **3** |

Per-instantiation before, a constant after — and the unbounded cache growth goes
with it.

| | before | after |
| --- | --- | --- |
| `Promise(supply { whenever … })`, Cro stack loaded | 1.55 ms | 1.17 ms |
| `body-blob.result`, HTTP/2 request parser | 2.2 ms | ~1.9 ms |

## What this does *not* fix

It does **not** make `cro-http`'s `t/http2-request-parser.rakutest` stable under
`MUTSU_REAL_TEST=1`, and the measurement is in the news entry so nobody assumes
it did.

That test loses a race whose losing side is `DATA frame → body-blob → one ok`.
Measured against a real-`Test` `ok` at 0.083 ms, the winning side costs about
0.25 ms and the losing side about 3.1 ms; the margin comes entirely from what the
main thread does after the promise is kept, so under CPU contention it is a coin
flip — **20/20 idle but 9/20 with three cores busy, both before and after this
change**. (The battery gate runs `BATTERIES_JOBS=4` on a 4-core runner, i.e. the
loaded case.)

Closing that needs the losing side under about a millisecond, which is the other
half of the cost: env copy-on-write deep copies that scale with the size of the
program — 7,253 env entries copied per DATA frame, ~17,000 per `body-blob`. That
is tracked in #7667.

## Tests

- `tests/carrier_compile_cache_keyed_by_parse_site.rs` — instantiates one supply
  literal 10 and then 40 times and asserts the miss count does not grow with the
  instantiation count (it was `3 × instantiations`).
- `t/whenever-repeated-instantiation-semantics.t` — pins what the sharing must
  not disturb: two live instances of one literal keep their own emitters, each
  `LAST` phaser fires only on its own source's `done`, and a lexical the literal
  captures is per instantiation.

Local `cargo fmt`, `make lint`, `make test` (3935 files, 41856 tests, PASS) and
`make roast` were all run. `make roast` reports only the three container-only
failures documented in `docs/agent-environments.md`, with exactly the test
numbers that doc lists.

Part of #7667.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NX9vs4NbdKXUu6MoAaHpSz

---
_Generated by [Claude Code](https://claude.ai/code/session_01NX9vs4NbdKXUu6MoAaHpSz)_