### PR TITLE
fix: reject named clone overrides on type objects

### DIFF
--- a/news/2026-09/clone-type-object-attributes.md
+++ b/news/2026-09/clone-type-object-attributes.md
@@ -1,0 +1,4 @@
+`Mu.clone` now rejects attribute overrides on type objects with Raku's
+`Cannot set attribute values when cloning a type object` error. Argumentless
+type-object clones and attribute overrides on defined instances keep their
+existing behavior.

--- a/src/runtime/methods_call_dispatch.rs
+++ b/src/runtime/methods_call_dispatch.rs
@@ -3396,6 +3396,27 @@ impl Interpreter {
             return result;
         }
 
+        // Mu.clone has a separate type-object candidate that accepts no
+        // attribute overrides. The named-argument retry below deliberately
+        // strips undeclared nameds for native methods, so checking this after
+        // that retry would turn `Num.clone(:yes)` into the no-argument clone
+        // and incorrectly return the type object. Preserve a user-defined
+        // `clone` on a class, but reject named overrides for the inherited native
+        // type-object candidate as Rakudo does.
+        if method == "clone"
+            && args.iter().any(Value::is_string_pair_value)
+            && matches!(
+                target.view(),
+                ValueView::Nil | ValueView::Package(_) | ValueView::ParametricRole { .. }
+            )
+            && !matches!(target.view(), ValueView::Package(name) if self
+                .class_has_user_method(&name.resolve(), method))
+        {
+            return Err(RuntimeError::new(
+                "Cannot set attribute values when cloning a type object",
+            ));
+        }
+
         // Native fast path bypass and dispatch
         let skip_pseudo = self
             .skip_pseudo_method_native

--- a/t/issue-7779-clone-type-object.t
+++ b/t/issue-7779-clone-type-object.t
@@ -1,0 +1,19 @@
+use Test;
+
+plan 4;
+
+throws-like {
+    Num.clone(:yes)
+}, Exception, message => /'Cannot set attribute values when cloning a type object'/,
+    'cloning a type object with attribute values dies';
+
+is Num.clone.^name, 'Num', 'a type object still clones without arguments';
+
+class CloneIssue7779 {
+    has $.value;
+}
+
+my $original = CloneIssue7779.new(value => 2);
+my $clone = $original.clone(value => 1);
+is $clone.value, 1, 'an instance clone still applies the attribute override';
+is $original.value, 2, 'an instance clone leaves the original unchanged';


### PR DESCRIPTION
## Summary

- reject named attribute overrides when `.clone` is invoked on a type object
- preserve argumentless type-object clones and defined-instance clone overrides
- add regression coverage and release news

Closes #7779

## Tests

- `make lint`
- `make test`
- `make roast`
