### PR TITLE
fix: a module's custom EXPORT and own package name survive an EVAL'd first load

### DIFF
--- a/news/2026-09/module-export-sub-and-own-package-name-across-eval.md
+++ b/news/2026-09/module-export-sub-and-own-package-name-across-eval.md
@@ -1,0 +1,43 @@
+# A module's custom EXPORT and its own package name survive an EVAL'd first load
+
+`#7764` taught the module loader to drop a `Package`-valued env binding left
+over from a module's own transitive `use` statements once that module's load
+finished, so a file that never `use`d the transitive dependency directly
+could not resolve it bare. That fix uncovered two bugs of its own, both
+surfacing specifically when a module was FIRST loaded from inside an `EVAL`
+(`Test`'s own `use-ok` is `EVAL ( "use $code" )`, so `use-ok 'M'; use M;` hits
+both):
+
+1. **A custom `sub EXPORT` ran against the wrong scope.** `sub EXPORT` is
+   part of the module's own closure, so a bareword term inside it (e.g.
+   NativeLibs' `Map.new('NativeCall' => NativeCall, ...)`) must resolve
+   against what the module's own mainline could see. mutsu instead ran
+   `EXPORT` against the (already-restored) importing scope's env, by which
+   point `NativeCall` had already been stripped back out (owned by no one
+   but the module's own transitive `use NativeCall;`). The bareword silently
+   degraded to the plain string `"NativeCall"`, which then shadowed the real
+   package for every importer — reproducible with a plain `use`, no `EVAL`
+   involved at all. Fixed by snapshotting the module's own env right after
+   its body finishes running (before the load's restoration strips it back
+   down) and running `EXPORT` — both on first load and on a later re-`use`'s
+   rerun — against that snapshot instead of the caller's env.
+
+2. **A module's own bare package-name binding wasn't tracked for
+   reinstatement.** `module_package_globals` (and its
+   `reinstate_module_package_globals` counterpart) exists precisely to put a
+   module's bindings back when a scope loses them wholesale, but it only ever
+   recorded `::`-qualified env keys — never the module's OWN bare name (a
+   `unit module Foo;` binds bare `"Foo"` in env). So when a module's first
+   load happened inside a nested call frame whose own env overlay is
+   discarded on return (a sub wrapping an `EVAL`, exactly `use-ok`'s shape),
+   the module's bare name vanished with that frame while `loaded_modules`
+   kept it recorded as loaded. A later real `use` of the same module is then
+   a no-op reuse that never re-installs the missing binding, so the module's
+   own name became permanently unresolvable. Fixed by also keeping the
+   module's own bare name in the tracked set.
+
+Both are pinned: `t/module-export-sub-sees-module-scope-not-caller.t` for the
+first, `t/module-first-loaded-in-eval-keeps-own-package-name.t` for the
+second, using minimal fixtures under `t/lib/Issue7806/` shaped after
+NativeLibs' actual `use NativeCall; sub EXPORT(|) {...} unit module
+NativeLibs:...;` structure. Closes #7806.

--- a/src/runtime/run_modules.rs
+++ b/src/runtime/run_modules.rs
@@ -857,6 +857,13 @@ impl Interpreter {
             // scope already declared.
             let hidden_toplevel = self.hide_toplevel_global_routines();
             let result = self.run_block(&stmts);
+            // Snapshot the env exactly as the module body left it, before any
+            // of the restoration below (the `leaked_packages` removal, the
+            // `saved_plain_env` restore, `unit_lexicals` extraction) strips
+            // module-local bindings back out. `apply_module_export` needs
+            // this: `sub EXPORT` is part of the module's own closure and must
+            // resolve everything the mainline could (see its doc comment).
+            let module_body_env = self.env.clone();
             self.pending_rw_writeback_sources
                 .truncate(saved_pending_rw_writeback_len);
             self.strict_mode = saved_strict_mode;
@@ -1040,7 +1047,7 @@ impl Interpreter {
             result?;
             // If the module defined `sub EXPORT`, call it with the `use` args and
             // install the symbols it returns into the caller's scope.
-            self.apply_module_export(export_args.unwrap_or_default())?;
+            self.apply_module_export(export_args.unwrap_or_default(), module_body_env)?;
         }
         // Every class/role this load just registered, regardless of whether the
         // module carries distribution metadata or picked up any scope names of

--- a/src/runtime/runtime_module.rs
+++ b/src/runtime/runtime_module.rs
@@ -786,10 +786,22 @@ impl Interpreter {
             // rather than the routine registry. Collected BEFORE `import_module`
             // so the bare aliases it installs — lexical to the importing scope —
             // are excluded, exactly as for the routines above.
+            //
+            // Also keep the module's OWN bare package-name binding (e.g. a
+            // `unit module Foo;` binds bare "Foo" in env): a `::`-only filter
+            // dropped it, so a module first loaded from inside a nested scope
+            // that discards its env overlay on return (a sub call wrapping an
+            // `EVAL`, e.g. `Test`'s `use-ok`) came back with `loaded_modules`
+            // still claiming it loaded but its own name unresolvable ever
+            // after, since a later re-`use` is a no-op that only reinstates
+            // what THIS set records (#7806).
             let package_globals: Vec<(Symbol, Value)> = self
                 .env
                 .keys()
-                .filter(|k| !env_snapshot.contains(k) && k.resolve().contains("::"))
+                .filter(|k| {
+                    !env_snapshot.contains(k)
+                        && (k.resolve().contains("::") || k.resolve() == module)
+                })
                 .filter_map(|k| self.env.get_sym(*k).map(|v| (*k, v.clone())))
                 .collect();
             if !package_globals.is_empty() {

--- a/src/runtime/runtime_module_export_sub.rs
+++ b/src/runtime/runtime_module_export_sub.rs
@@ -30,9 +30,24 @@ impl Interpreter {
     /// arguments and install the symbols from its returned `Map`(s) into the
     /// caller's scope. `EXPORT` itself is special (never an export), so it is
     /// removed from the registry afterwards to avoid leaking as a callable.
+    ///
+    /// `module_env` is a snapshot of `self.env` taken right after the module's
+    /// own body finished running, before the load's env restoration (dropping
+    /// the module's transitively-`use`d packages that don't belong to the
+    /// importer, restoring the loading scope's own plain bindings, etc.)
+    /// stripped it back down. `sub EXPORT` is part of the module's own
+    /// closure, so it must see everything the mainline could see while it
+    /// runs -- e.g. NativeLibs' `Map.new('NativeCall' => NativeCall, ...)`
+    /// needs `NativeCall` still bound to its package, not gone the way
+    /// `leaked_packages` (`run_modules.rs`) already dropped it by the time
+    /// this is called. Running EXPORT against the (already-restored) current
+    /// `self.env` instead degrades that bareword to the plain string
+    /// `"NativeCall"`, which then shadows the real package for every importer
+    /// (#7806).
     pub(super) fn apply_module_export(
         &mut self,
         export_args: Vec<Value>,
+        module_env: crate::env::Env,
     ) -> Result<(), RuntimeError> {
         // An `&EXPORT` this module imported from another module's EXPORT map
         // (the Slangify pattern) becomes this module's own EXPORT. Consume the
@@ -52,9 +67,10 @@ impl Interpreter {
             if let Some(export_sub) = inherited {
                 // Same env discipline as the compiled path below: the imported
                 // EXPORT's effects are its return value, not caller-env writes.
-                let saved_env = self.env.clone();
+                let caller_env = self.env.clone();
+                self.env = module_env;
                 let result = self.call_sub_value(export_sub.clone(), export_args, false)?;
-                self.env = saved_env;
+                self.env = caller_env;
                 self.install_export_map(&result, importer.as_deref());
                 if let Some(m) = self.module_load_stack.last().cloned() {
                     self.module_export_defs
@@ -68,17 +84,19 @@ impl Interpreter {
         // sub the EXPORT returns can capture a use-argument (`sub EXPORT($x)
         // { Map.new: '&f' => sub { ...$x... } }`).
         //
-        // Snapshot env across the call and restore it afterwards: the call's
-        // scalar return-merge writes EXPORT's own params/locals (`$x`, a `my $y`)
-        // back into this (the caller's) env as their post-return values. A sub
-        // EXPORT returns that closes over such a lexical carries the correct
-        // captured value, but a later bareword call of it merges the caller env
-        // with `merge_all` (keep-existing) semantics — so the leaked stale entry
-        // would shadow the capture. Dropping EXPORT's env writes keeps the
-        // caller env clean; EXPORT's real effects are its return value and
-        // control flow (die/note/exit), not caller-env mutation.
+        // Snapshot the CALLER's env (not the module's) so it can be restored
+        // after the call: the call's scalar return-merge writes EXPORT's own
+        // params/locals (`$x`, a `my $y`) back into whatever `self.env` is at
+        // return time as their post-return values. A sub EXPORT returns that
+        // closes over such a lexical carries the correct captured value, but a
+        // later bareword call of it merges the caller env with `merge_all`
+        // (keep-existing) semantics — so the leaked stale entry would shadow
+        // the capture. Dropping EXPORT's env writes keeps the caller env
+        // clean; EXPORT's real effects are its return value and control flow
+        // (die/note/exit), not caller-env mutation.
         let empty_fns = crate::opcode::CompiledFns::default();
-        let saved_env = self.env.clone();
+        let caller_env = self.env.clone();
+        self.env = module_env.clone();
         // Anchor the call to the module's own compunit. `EXPORT` is the
         // module's code, so a prelude splice made into the module's unit (the
         // NativeCall `trait_mod:<is>` candidates `NativeLibs` introspects) has
@@ -89,16 +107,18 @@ impl Interpreter {
         let result = self.compile_and_call_function_def(&def, export_args, &empty_fns);
         self.current_unit = saved_unit;
         let result = result?;
-        self.env = saved_env.clone();
+        self.env = caller_env;
         // `EXPORT` must not itself become a callable in (or leak from) the
         // module; drop every registered `EXPORT` routine now that it has run.
         self.remove_export_routine();
         self.install_export_map(&result, importer.as_deref());
         if let Some(m) = self.module_load_stack.last().cloned() {
-            // `saved_env` is the module's own scope: `apply_module_export` runs
-            // right after the module body, before the load unwinds.
+            // `module_env` is the module's own scope: a re-`use` of an
+            // already-loaded module re-runs EXPORT there too (see
+            // `rerun_module_export`), since the new importer's own scope
+            // holds none of the module's lexicals.
             self.module_export_defs
-                .insert(m, ModuleExportDef::Sub(def, saved_env));
+                .insert(m, ModuleExportDef::Sub(def, module_env));
         }
         Ok(())
     }

--- a/t/lib/Issue7806/Issue7806Export.rakumod
+++ b/t/lib/Issue7806/Issue7806Export.rakumod
@@ -1,0 +1,10 @@
+use NativeCall;
+
+# Mirrors NativeLibs' own shape: `use`s NativeCall, then a custom `sub EXPORT`
+# passes the transitively-`use`d package through as a value in its returned
+# Map, and `unit module` comes AFTER those two statements (as it does in
+# NativeLibs.pm6). See https://github.com/tokuhirom/mutsu/issues/7806.
+sub EXPORT(|) {
+    Map.new('NativeCall' => NativeCall)
+}
+unit module Issue7806Export;

--- a/t/lib/Issue7806/Issue7806Loader.rakumod
+++ b/t/lib/Issue7806/Issue7806Loader.rakumod
@@ -1,0 +1,11 @@
+unit module Issue7806Loader;
+use MONKEY-SEE-NO-EVAL;
+
+# Shaped exactly like `Test`'s own `use-ok`: `EVAL ( "use $code" )` inside a
+# `try { }` inside a sub, so the module's first load happens from inside a
+# nested call frame whose own env overlay is discarded on return.
+sub issue7806-use-ok(Str $code) is export {
+    try {
+        EVAL ( "use $code" );
+    }
+}

--- a/t/lib/Issue7806/Issue7806Own.rakumod
+++ b/t/lib/Issue7806/Issue7806Own.rakumod
@@ -1,0 +1,6 @@
+unit module Issue7806Own;
+
+# Deliberately empty: the test only cares whether this module's own bare
+# package-name binding survives a first load that happens inside a sub call
+# wrapping an EVAL (mirroring Test's `use-ok`, which is `EVAL ( "use $code" )`
+# inside `try { }` inside `multi sub use-ok`).

--- a/t/module-export-sub-sees-module-scope-not-caller.t
+++ b/t/module-export-sub-sees-module-scope-not-caller.t
@@ -1,0 +1,29 @@
+use v6;
+use Test;
+
+# A module's custom `sub EXPORT` is part of the module's own closure, so a
+# bareword term inside it (e.g. NativeLibs' `Map.new('NativeCall' => NativeCall,
+# ...)`) must resolve against what the module's OWN mainline could see, not
+# against the (already-restored) importing scope. mutsu ran EXPORT against the
+# caller's env instead: by the time EXPORT ran, `NativeCall` had already been
+# stripped back out of `env` (owned by no one but the module's own transitive
+# `use NativeCall;`), so the bareword silently degraded to the plain string
+# "NativeCall" -- which then shadowed the real package for every importer.
+#
+# Reproduces the "independent gap" from
+# https://github.com/tokuhirom/mutsu/issues/7806 with no EVAL involved at all
+# (a plain `use`, matching NativeLibs' actual shape: `use NativeCall;` then a
+# custom `sub EXPORT` referencing it, with `unit module` declared afterward).
+
+plan 3;
+
+use lib $*PROGRAM.parent.add('lib').add('Issue7806').Str;
+use Issue7806Export;
+
+my \exported = ::('NativeCall');
+isnt exported.^name, 'Str',
+    "the module's custom EXPORT map passes a real package through, not its stringified name";
+is exported.^name, 'NativeCall',
+    "::('NativeCall') resolves to the NativeCall package itself";
+ok ::('NativeCall::EXPORT::ALL') !~~ Failure,
+    "the transitively-used module's own EXPORT::ALL stash is still reachable";

--- a/t/module-first-loaded-in-eval-keeps-own-package-name.t
+++ b/t/module-first-loaded-in-eval-keeps-own-package-name.t
@@ -1,0 +1,34 @@
+use v6;
+use Test;
+
+# #7764 taught the module loader to drop a `Package`-valued env binding that
+# isn't owned by the module being loaded and wasn't a class/role it just
+# registered (see `leaked_packages` in src/runtime/run_modules.rs). That is
+# correct for a binding LEAKED from a transitive `use`, but the bookkeeping
+# meant to put a module's own bindings back after a scope loses them
+# (`module_package_globals` / `reinstate_module_package_globals`) only ever
+# recorded `::`-qualified keys -- never the module's OWN bare package-name
+# binding (a `unit module Foo;` binds bare "Foo" in env).
+#
+# So when a module's FIRST load happens inside a nested call frame whose own
+# env overlay is discarded on return (a sub wrapping an EVAL, exactly the
+# shape of Test's own `use-ok`: `EVAL ( "use $code" )` inside `try { }` inside
+# `multi sub use-ok`), the module's bare package-name binding vanished with
+# that frame -- while `loaded_modules` kept it recorded as loaded. A later
+# real `use` of the same module is then a no-op (it is already "loaded") that
+# never re-installs the missing binding, so the module's own name became
+# permanently unresolvable. See
+# https://github.com/tokuhirom/mutsu/issues/7806 (the "NativeLibs: MISSING"
+# row, reproduced there via `Test`'s real `use-ok` + a second `use NativeLibs`).
+
+plan 1;
+
+use lib $*PROGRAM.parent.add('lib').add('Issue7806').Str;
+use Issue7806Loader;
+
+issue7806-use-ok('Issue7806Own');
+use Issue7806Own;
+
+ok ::('Issue7806Own') !~~ Failure,
+    "a module's own package name is resolvable after use-ok-style first load "
+    ~ "inside an EVAL, followed by a real (now-a-no-op) re-`use`";


### PR DESCRIPTION
## Summary

`#7764` taught the module loader to drop a `Package`-valued env binding left over from a module's own transitive `use` statements once that module's load finished (so a file that never `use`d the transitive dependency directly could not resolve it bare). That fix uncovered two bugs of its own, both surfacing specifically when a module is FIRST loaded from inside an `EVAL` (`Test`'s own `use-ok` is `EVAL ( "use $code" )`, so `use-ok 'M'; use M;` hits both):

1. **A custom `sub EXPORT` ran against the wrong scope.** `sub EXPORT` is part of the module's own closure, so a bareword term inside it (e.g. NativeLibs' `Map.new('NativeCall' => NativeCall, ...)`) must resolve against what the module's own mainline could see. mutsu instead ran `EXPORT` against the (already-restored) importing scope's env, by which point `NativeCall` had already been stripped back out (owned by no one but the module's own transitive `use NativeCall;`). The bareword silently degraded to the plain string `"NativeCall"`, which then shadowed the real package for every importer — reproducible with a **plain `use`, no `EVAL` involved at all** (the "independent gap" the issue called out). Fixed by snapshotting the module's own env right after its body finishes running (before the load's restoration strips it back down), and running `EXPORT` — both on first load and on a later re-`use`'s rerun — against that snapshot instead of the caller's env.

2. **A module's own bare package-name binding wasn't tracked for reinstatement.** `module_package_globals` (and its `reinstate_module_package_globals` counterpart) exists precisely to put a module's bindings back when a scope loses them wholesale, but it only ever recorded `::`-qualified env keys — never the module's OWN bare name (a `unit module Foo;` binds bare `"Foo"` in env). So when a module's first load happened inside a nested call frame whose own env overlay is discarded on return (a sub wrapping an `EVAL`, exactly `use-ok`'s shape), the module's bare name vanished with that frame while `loaded_modules` kept it recorded as loaded. A later real `use` of the same module is then a no-op reuse that never re-installs the missing binding, so the module's own name became permanently unresolvable (the `NativeLibs: MISSING` row in the issue).

Reproduced end-to-end against the real vendored `modules/NativeLibs` module (the issue's own repro) under both the native and vendored `Test` providers — all five symbols (`NativeCall`, `NativeCall::EXPORT`, `NativeCall::EXPORT::ALL`, `NativeLibs`, `NativeLibs::Loader`) now resolve, matching `raku`.

## Test plan

- [x] New regression tests, verified to fail without the fix and pass with it:
  - `t/module-export-sub-sees-module-scope-not-caller.t` (bug 1, no EVAL needed)
  - `t/module-first-loaded-in-eval-keeps-own-package-name.t` (bug 2)
  - Minimal fixtures under `t/lib/Issue7806/`, shaped after NativeLibs' actual `use NativeCall; sub EXPORT(|) {...} unit module NativeLibs:...;` structure.
- [x] `t/module-transitive-use-does-not-leak-types.t` (the #7764/#7791 pin, 27 assertions) still green.
- [x] `t/module-loaded-in-eval-keeps-imports.t`, `t/nativecall-export-stash.t`, `t/nativecall-module-compat.t`, `t/use-ok-real-load.t` and other related existing tests still green.
- [x] `cargo fmt --all` — no changes needed.
- [x] `make lint` — all four configurations (default clippy, `jit`-off clippy, wasm32 clippy, rustdoc) clean.
- [x] `make test` — full suite green (3936 files, 41854 tests).
- [x] `make roast` — only the three documented container-specific failures (`file-tests.t`, `filetest.t` — `uid 0` bypasses permission bits; `IO-Socket-Async.t` — sandboxed network), no new regressions.

Closes #7806.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hm9kvDefwL8iisjAkrmstZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hm9kvDefwL8iisjAkrmstZ)_