### PR TITLE
fix: wrap native integer arithmetic

### DIFF
--- a/news/2026-09/native-integer-arithmetic-wrap.md
+++ b/news/2026-09/native-integer-arithmetic-wrap.md
@@ -1,0 +1,8 @@
+# Native integer arithmetic wraps at the declared width
+
+In-place `++` and `--` now wrap native integer values before the result is
+returned or stored. Native `+`, `-`, and `*` use the matching signed `i64` or
+unsigned `u64` machine operation when the compiler can prove both operands are
+native integers. Narrow native declarations still narrow their result at the
+destination store, while ordinary boxed `Int` arithmetic and out-of-range
+ordinary assignments keep their existing behavior.

--- a/src/compiler/expr_binary.rs
+++ b/src/compiler/expr_binary.rs
@@ -799,6 +799,7 @@ impl Compiler {
                     return;
                 }
             }
+            let native_unsigned = self.native_int_binary_mode(left, right, &opcode);
             self.compile_expr(left);
             // `but`/`does` with a role-applied RHS (`X but R(v)`, `99 does R(v)`)
             // must let the role call return a role-application Pair instead of
@@ -827,6 +828,14 @@ impl Compiler {
                 // written directly in an argument list (or a colonpair,
                 // which parses to the same shape) — keep the named marker.
                 self.code.emit(OpCode::MakeNamedArg);
+            } else if let Some(unsigned) = native_unsigned {
+                let op = match opcode {
+                    OpCode::Add => crate::opcode::CompoundBaseOp::Add,
+                    OpCode::Sub => crate::opcode::CompoundBaseOp::Sub,
+                    OpCode::Mul => crate::opcode::CompoundBaseOp::Mul,
+                    _ => unreachable!("native integer mode only applies to +, -, and *"),
+                };
+                self.code.emit(OpCode::NativeIntArithmetic { op, unsigned });
             } else {
                 self.code.emit(opcode);
             }
@@ -974,5 +983,52 @@ impl Compiler {
         } else {
             None
         }
+    }
+
+    /// Return the machine signedness for an expression whose value is known to
+    /// participate in native integer arithmetic. Narrow native declarations
+    /// still use the machine-width arithmetic register; their declared width
+    /// is applied on storage. A plain integer literal is a signed native
+    /// operand, which is the form Rakudo accepts for a signed native variable
+    /// (`my int $x = *; $x + 1`). Do not infer this through arbitrary computed
+    /// expressions: `2 ** 62` is an ordinary boxed `Int` operand to Rakudo's
+    /// native candidate selection.
+    pub(super) fn native_int_operand_signedness(&self, expr: &Expr) -> Option<bool> {
+        match expr.peel_parens() {
+            Expr::Unary {
+                op: TokenKind::MetaAssignIdentity(_),
+                expr,
+            } => self.native_int_operand_signedness(expr),
+            Expr::Var(name) => self
+                .expr_native_int_type(expr.peel_parens())
+                .map(|type_name| crate::runtime::native_types::is_signed_native(&type_name))
+                .or_else(|| {
+                    self.local_types.get(name).and_then(|constraint| {
+                        let base = constraint
+                            .strip_suffix(":D")
+                            .or_else(|| constraint.strip_suffix(":U"))
+                            .unwrap_or(constraint);
+                        crate::runtime::native_types::is_native_int_type(base)
+                            .then(|| crate::runtime::native_types::is_signed_native(base))
+                    })
+                }),
+            Expr::Literal(value) | Expr::LiteralSrc(value, _) => {
+                matches!(value.view(), ValueView::Int(_)).then_some(true)
+            }
+            _ => None,
+        }
+    }
+
+    /// Select the native machine operation for the small set of arithmetic
+    /// operators whose native candidates wrap (`+`, `-`, `*`). A signed and
+    /// unsigned operand must not be mixed; the generic path handles that case
+    /// as boxed numeric arithmetic.
+    fn native_int_binary_mode(&self, left: &Expr, right: &Expr, opcode: &OpCode) -> Option<bool> {
+        if !matches!(opcode, OpCode::Add | OpCode::Sub | OpCode::Mul) {
+            return None;
+        }
+        let left_signed = self.native_int_operand_signedness(left)?;
+        let right_signed = self.native_int_operand_signedness(right)?;
+        (left_signed == right_signed).then_some(!left_signed)
     }
 }

--- a/src/compiler/expr_helpers.rs
+++ b/src/compiler/expr_helpers.rs
@@ -114,7 +114,12 @@ impl Compiler {
     /// literal `$x = $x + y` are deliberately NOT fused: own locals are ~never
     /// shared cells, and fusing them regressed a hot 3M-iter loop.
     pub(super) fn try_compile_fused_compound_assign(&mut self, name: &str, expr: &Expr) -> bool {
-        if self.local_map.contains_key(name) || !Self::is_plain_compound_target(name) {
+        if self.local_map.contains_key(name)
+            || self
+                .native_int_operand_signedness(&Expr::Var(name.to_string()))
+                .is_some()
+            || !Self::is_plain_compound_target(name)
+        {
             return false;
         }
         let Expr::Binary { left, op, right } = expr else {

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -881,6 +881,13 @@ pub(crate) enum OpCode {
     Add,
     Sub,
     Mul,
+    /// Add, subtract, or multiply operands that the compiler knows are native
+    /// integers. `unsigned` selects the machine `u64` operation; the native
+    /// declaration's narrower width is enforced when the value is stored.
+    NativeIntArithmetic {
+        op: CompoundBaseOp,
+        unsigned: bool,
+    },
     Div,
     Mod,
     Pow,

--- a/src/runtime/native_increment_dispatch.rs
+++ b/src/runtime/native_increment_dispatch.rs
@@ -208,6 +208,10 @@ impl Interpreter {
         } else {
             self.decrement_value_smart(&old)?
         };
+        let new = match source.as_deref() {
+            Some(name) => self.wrap_native_int_arithmetic_result(name, new),
+            None => new,
+        };
         if let Some(name) = source {
             self.check_incdec_type_constraint(&name, &new)?;
             match code {

--- a/src/vm/vm_arith_ops.rs
+++ b/src/vm/vm_arith_ops.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::token_kind::MetaAssignIdentity;
+use num_traits::ToPrimitive;
 
 /// Whether the assignment metaop must seed this LHS with the operator's
 /// zero-argument value. Mirrors rakudo's `nqp::isconcrete` test: type objects
@@ -38,6 +39,109 @@ pub(super) fn seed_meta_assign_identity(
 }
 
 impl Interpreter {
+    /// Execute a compiler-proven native integer `+`, `-`, or `*`. Native
+    /// declarations use machine-width registers for arithmetic: signed values
+    /// wrap as `i64`, unsigned values as `u64`; `int8`/`uint8` and the other
+    /// narrow declarations are narrowed later by their destination store.
+    pub(super) fn exec_native_int_arithmetic_op(
+        &mut self,
+        op: crate::opcode::CompoundBaseOp,
+        unsigned: bool,
+    ) -> Result<(), RuntimeError> {
+        let right = self.stack.pop().unwrap();
+        let left = self.stack.pop().unwrap();
+        let op_name = match op {
+            crate::opcode::CompoundBaseOp::Add => "infix:<+>",
+            crate::opcode::CompoundBaseOp::Sub => "infix:<->",
+            crate::opcode::CompoundBaseOp::Mul => "infix:<*>",
+            _ => unreachable!("only native integer +, -, and * are emitted"),
+        };
+        // Native candidates remain overridable by a user-declared infix. Put
+        // the operands back and use the ordinary path so its junction and
+        // dispatch semantics stay unchanged.
+        if self.user_infix_override(op_name) {
+            self.stack.push(left);
+            self.stack.push(right);
+            match op {
+                crate::opcode::CompoundBaseOp::Add => self.exec_add_op()?,
+                crate::opcode::CompoundBaseOp::Sub => self.exec_sub_op()?,
+                crate::opcode::CompoundBaseOp::Mul => self.exec_mul_op()?,
+                _ => unreachable!(),
+            }
+            return Ok(());
+        }
+
+        let result = if unsigned {
+            let left = match left.view() {
+                ValueView::Int(value) => u64::try_from(value).ok(),
+                ValueView::BigInt(value) => value.to_u64(),
+                _ => None,
+            };
+            let right = match right.view() {
+                ValueView::Int(value) => u64::try_from(value).ok(),
+                ValueView::BigInt(value) => value.to_u64(),
+                _ => None,
+            };
+            match (left, right) {
+                (Some(left), Some(right)) => Some(match op {
+                    // Rakudo's native unsigned result is an integer register
+                    // whose bits are boxed as a signed Int. The destination
+                    // native store reinterprets negative values back into the
+                    // unsigned range, so `uint $x = 0; $x - uint(1)` returns
+                    // -1 while `$x -= uint(1)` stores uint64.max.
+                    crate::opcode::CompoundBaseOp::Add => {
+                        Value::int((left.wrapping_add(right)) as i64)
+                    }
+                    crate::opcode::CompoundBaseOp::Sub => {
+                        Value::int((left.wrapping_sub(right)) as i64)
+                    }
+                    crate::opcode::CompoundBaseOp::Mul => {
+                        Value::int((left.wrapping_mul(right)) as i64)
+                    }
+                    _ => unreachable!(),
+                }),
+                _ => None,
+            }
+        } else {
+            let left_value = match left.view() {
+                ValueView::Int(value) => Some(value),
+                ValueView::BigInt(value) => value.to_i64(),
+                _ => None,
+            };
+            let right_value = match right.view() {
+                ValueView::Int(value) => Some(value),
+                ValueView::BigInt(value) => value.to_i64(),
+                _ => None,
+            };
+            match (left_value, right_value) {
+                (Some(left), Some(right)) => Some(Value::int(match op {
+                    crate::opcode::CompoundBaseOp::Add => left.wrapping_add(right),
+                    crate::opcode::CompoundBaseOp::Sub => left.wrapping_sub(right),
+                    crate::opcode::CompoundBaseOp::Mul => left.wrapping_mul(right),
+                    _ => unreachable!(),
+                })),
+                _ => None,
+            }
+        };
+        if let Some(result) = result {
+            self.stack.push(result);
+            return Ok(());
+        }
+
+        // A value changed shape between compilation and execution. Preserve
+        // the ordinary arithmetic fallback rather than silently applying a
+        // native conversion to an incompatible value.
+        self.stack.push(left);
+        self.stack.push(right);
+        match op {
+            crate::opcode::CompoundBaseOp::Add => self.exec_add_op()?,
+            crate::opcode::CompoundBaseOp::Sub => self.exec_sub_op()?,
+            crate::opcode::CompoundBaseOp::Mul => self.exec_mul_op()?,
+            _ => unreachable!(),
+        }
+        Ok(())
+    }
+
     /// Whether a user-declared `sub infix:<op>` is in scope for `canon`
     /// (e.g. `"infix:<+>"`). The set is empty in the overwhelming common
     /// case, keeping tight numeric loops free of any registry lookup.

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -2207,6 +2207,10 @@ impl Interpreter {
                 self.exec_mul_op()?;
                 *ip += 1;
             }
+            OpCode::NativeIntArithmetic { op, unsigned } => {
+                self.exec_native_int_arithmetic_op(*op, *unsigned)?;
+                *ip += 1;
+            }
             OpCode::Div => {
                 self.exec_div_op()?;
                 *ip += 1;

--- a/src/vm/vm_misc_coerce.rs
+++ b/src/vm/vm_misc_coerce.rs
@@ -455,6 +455,7 @@ impl Interpreter {
                 let inner = arc.lock().unwrap().clone();
                 let val = self.normalize_incdec_source_with_type(name, inner);
                 let new_val = self.increment_value_smart(&val)?;
+                let new_val = self.wrap_native_int_arithmetic_result(name, new_val);
                 arc.lock().unwrap().clone_from(&new_val);
                 self.stack.push(new_val);
                 return Ok(());
@@ -462,6 +463,7 @@ impl Interpreter {
             let raw_val = self.locals[slot].clone();
             let val = self.normalize_incdec_source_with_type(name, raw_val);
             let new_val = self.increment_value_smart(&val)?;
+            let new_val = self.wrap_native_int_arithmetic_result(name, new_val);
             self.locals[slot] = new_val.clone();
             self.flush_local_to_env(code, slot);
             self.propagate_incdec_sigilless_alias(code, name, &new_val);
@@ -488,12 +490,14 @@ impl Interpreter {
             let inner = arc.lock().unwrap().clone();
             let v = self.normalize_incdec_source_with_type(name, inner);
             let new_val = self.increment_value_smart(&v)?;
+            let new_val = self.wrap_native_int_arithmetic_result(name, new_val);
             arc.lock().unwrap().clone_from(&new_val);
             self.stack.push(new_val);
             return Ok(());
         }
         let val = self.normalize_incdec_source_with_type(name, val);
         let new_val = self.increment_value_smart(&val)?;
+        let new_val = self.wrap_native_int_arithmetic_result(name, new_val);
         self.check_incdec_type_constraint(name, &new_val)?;
         self.store_scalar_by_name(name, &new_val);
         self.sync_anon_state_value(name, &new_val);
@@ -550,6 +554,7 @@ impl Interpreter {
                 let inner = arc.lock().unwrap().clone();
                 let val = self.normalize_incdec_source_with_type(name, inner);
                 let new_val = self.decrement_value_smart(&val)?;
+                let new_val = self.wrap_native_int_arithmetic_result(name, new_val);
                 arc.lock().unwrap().clone_from(&new_val);
                 self.stack.push(new_val);
                 return Ok(());
@@ -557,6 +562,7 @@ impl Interpreter {
             let raw_val = self.locals[slot].clone();
             let val = self.normalize_incdec_source_with_type(name, raw_val);
             let new_val = self.decrement_value_smart(&val)?;
+            let new_val = self.wrap_native_int_arithmetic_result(name, new_val);
             self.locals[slot] = new_val.clone();
             self.flush_local_to_env(code, slot);
             self.propagate_incdec_sigilless_alias(code, name, &new_val);
@@ -583,12 +589,14 @@ impl Interpreter {
             let inner = arc.lock().unwrap().clone();
             let v = self.normalize_incdec_source_with_type(name, inner);
             let new_val = self.decrement_value_smart(&v)?;
+            let new_val = self.wrap_native_int_arithmetic_result(name, new_val);
             arc.lock().unwrap().clone_from(&new_val);
             self.stack.push(new_val);
             return Ok(());
         }
         let val = self.normalize_incdec_source_with_type(name, val);
         let new_val = self.decrement_value_smart(&val)?;
+        let new_val = self.wrap_native_int_arithmetic_result(name, new_val);
         self.check_incdec_type_constraint(name, &new_val)?;
         self.store_scalar_by_name(name, &new_val);
         self.sync_anon_state_value(name, &new_val);

--- a/src/vm/vm_value_helpers.rs
+++ b/src/vm/vm_value_helpers.rs
@@ -601,6 +601,48 @@ impl Interpreter {
             .unwrap_or_else(|| Value::bigint(wrapped))
     }
 
+    /// Wrap the result of an in-place native integer operation. This differs
+    /// from [`Self::maybe_wrap_native_int`]: an ordinary assignment to a full-width
+    /// native integer rejects an out-of-range BigInt, while arithmetic on an
+    /// existing native value uses machine overflow semantics.
+    pub(crate) fn wrap_native_int_arithmetic_result(
+        &mut self,
+        var_name: &str,
+        value: Value,
+    ) -> Value {
+        let Some(constraint) = loan_env!(self, var_type_constraint(var_name)) else {
+            return value;
+        };
+        Self::wrap_native_int_arithmetic_for_constraint(&constraint, value)
+    }
+
+    /// Apply native arithmetic wrapping using an already-known type constraint.
+    /// This is also used for native array/hash elements and shared container
+    /// cells, where looking up a scalar variable name would be insufficient.
+    pub(crate) fn wrap_native_int_arithmetic_for_constraint(
+        constraint: &str,
+        value: Value,
+    ) -> Value {
+        use crate::runtime::native_types;
+        use num_traits::ToPrimitive;
+
+        let (base, _) = crate::runtime::types::strip_type_smiley(constraint);
+        if !native_types::is_native_int_type(base) {
+            return value;
+        }
+        match value.view() {
+            ValueView::Int(n) => native_types::wrap_native_int_value(base, n).unwrap_or(value),
+            ValueView::BigInt(n) => {
+                let wrapped = native_types::wrap_native_int(base, &n);
+                wrapped
+                    .to_i64()
+                    .map(Value::int)
+                    .unwrap_or_else(|| Value::bigint(wrapped))
+            }
+            _ => value,
+        }
+    }
+
     /// Recursively flatten a value like a `*@` slurpy would: non-itemized
     /// Array/List elements are expanded, itemized containers are preserved.
     /// Ranges and Seqs are also expanded into their elements.

--- a/src/vm/vm_var_assign_post_incdec.rs
+++ b/src/vm/vm_var_assign_post_incdec.rs
@@ -190,6 +190,7 @@ impl Interpreter {
             } else {
                 self.decrement_value_smart(&val)?
             };
+            let new_val = self.wrap_native_int_arithmetic_result(name, new_val);
             self.check_incdec_type_constraint(name, &new_val)?;
             // `$.x++` is a read-modify-write through the PUBLIC accessor, and
             // `$.` is `self.x` itemized: for a non-`rw` scalar accessor the
@@ -244,6 +245,7 @@ impl Interpreter {
                 let inner = arc.lock().unwrap().clone();
                 let val = self.normalize_incdec_source_with_type(name, inner);
                 let new_val = self.increment_value_smart(&val)?;
+                let new_val = self.wrap_native_int_arithmetic_result(name, new_val);
                 arc.lock().unwrap().clone_from(&new_val);
                 self.stack.push(val);
                 return Ok(());
@@ -251,6 +253,7 @@ impl Interpreter {
             let raw_val = self.locals[slot].clone();
             let val = self.normalize_incdec_source_with_type(name, raw_val);
             let new_val = self.increment_value_smart(&val)?;
+            let new_val = self.wrap_native_int_arithmetic_result(name, new_val);
             self.locals[slot] = new_val.clone();
             self.flush_local_to_env(code, slot);
             // Propagate the new value along the sigilless alias chain and into
@@ -279,6 +282,7 @@ impl Interpreter {
             let inner = arc.lock().unwrap().clone();
             let val = self.normalize_incdec_source_with_type(name, inner);
             let new_val = self.increment_value_smart(&val)?;
+            let new_val = self.wrap_native_int_arithmetic_result(name, new_val);
             arc.lock().unwrap().clone_from(&new_val);
             self.stack.push(val);
             return Ok(());
@@ -290,12 +294,14 @@ impl Interpreter {
             let fetched = loan_env!(self, auto_fetch_proxy(&raw_val))?;
             let val = Self::normalize_incdec_source(fetched);
             let new_val = self.increment_value_smart(&val)?;
+            let new_val = self.wrap_native_int_arithmetic_result(name, new_val);
             loan_env!(self, assign_proxy_lvalue(raw_val, new_val))?;
             self.stack.push(val);
             return Ok(());
         }
         let val = self.normalize_incdec_source_with_type(name, raw_val);
         let new_val = self.increment_value_smart(&val)?;
+        let new_val = self.wrap_native_int_arithmetic_result(name, new_val);
         self.store_named_scalar_rmw_result(code, name, slot, new_val)?;
         self.stack.push(val);
         Ok(())
@@ -341,6 +347,7 @@ impl Interpreter {
                 let inner = arc.lock().unwrap().clone();
                 let val = self.normalize_incdec_source_with_type(name, inner);
                 let new_val = self.decrement_value_smart(&val)?;
+                let new_val = self.wrap_native_int_arithmetic_result(name, new_val);
                 arc.lock().unwrap().clone_from(&new_val);
                 self.stack.push(val);
                 return Ok(());
@@ -348,6 +355,7 @@ impl Interpreter {
             let raw_val = self.locals[slot].clone();
             let val = self.normalize_incdec_source_with_type(name, raw_val);
             let new_val = self.decrement_value_smart(&val)?;
+            let new_val = self.wrap_native_int_arithmetic_result(name, new_val);
             self.locals[slot] = new_val.clone();
             self.flush_local_to_env(code, slot);
             // Propagate the new value along the sigilless alias chain and into
@@ -375,12 +383,14 @@ impl Interpreter {
             let inner = arc.lock().unwrap().clone();
             let val = self.normalize_incdec_source_with_type(name, inner);
             let new_val = self.decrement_value_smart(&val)?;
+            let new_val = self.wrap_native_int_arithmetic_result(name, new_val);
             arc.lock().unwrap().clone_from(&new_val);
             self.stack.push(val);
             return Ok(());
         }
         let val = self.normalize_incdec_source_with_type(name, raw_val);
         let new_val = self.decrement_value_smart(&val)?;
+        let new_val = self.wrap_native_int_arithmetic_result(name, new_val);
         self.store_named_scalar_rmw_result(code, name, slot, new_val)?;
         self.stack.push(val);
         Ok(())
@@ -585,6 +595,13 @@ impl Interpreter {
                     None
                 }
             });
+        let wrap_element_result = |value: Value| {
+            element_constraint_incdec
+                .as_deref()
+                .map_or(value.clone(), |constraint| {
+                    Self::wrap_native_int_arithmetic_for_constraint(constraint, value)
+                })
+        };
         let (key, quanthash_elem) = if quanthash_target {
             let (k, e) = crate::runtime::utils::quanthash_elem_entry(&idx_val);
             (k, Some(e))
@@ -625,6 +642,7 @@ impl Interpreter {
             } else {
                 self.decrement_value_smart(&effective)?
             };
+            let new_val = wrap_element_result(new_val);
             attributes.with_attr_mut("__mutsu_array_storage", |st| {
                 let (mut items, kind) = match st.view() {
                     ValueView::Array(items, kind) => ((**items).clone(), kind),
@@ -691,6 +709,7 @@ impl Interpreter {
             } else {
                 self.decrement_value_smart(&effective)?
             };
+            let new_val = wrap_element_result(new_val);
             attributes.with_attr_mut("__mutsu_hash_storage", |st| {
                 st.with_hash_mut(|gc| {
                     crate::value::gc_data_mut(gc).insert(key.clone(), new_val.clone());
@@ -721,6 +740,12 @@ impl Interpreter {
                 } else {
                     self.decrement_value_smart(&effective)?
                 };
+                let new_val =
+                    if let Some(constraint) = crate::value::lookup_container_constraint(&arc) {
+                        Self::wrap_native_int_arithmetic_for_constraint(&constraint, new_val)
+                    } else {
+                        wrap_element_result(new_val)
+                    };
                 arc.lock().unwrap().clone_from(&new_val);
                 self.stack
                     .push(if return_new { new_val } else { effective });
@@ -776,6 +801,7 @@ impl Interpreter {
             } else {
                 self.decrement_value_smart(&effective)?
             };
+            let new_val = wrap_element_result(new_val);
             let mut updated = inner;
             // Container identity (§3): write through the shared backing node.
             if updated
@@ -901,7 +927,7 @@ impl Interpreter {
             } else {
                 self.decrement_value_smart(&effective)?
             };
-            (effective, new_val)
+            (effective, wrap_element_result(new_val))
         };
         // A Bag/BagHash holds non-negative integer counts: decrementing a weight
         // below 0 clamps the *returned* (and stored) value to 0 (the element is

--- a/src/vm/vm_var_assign_typed.rs
+++ b/src/vm/vm_var_assign_typed.rs
@@ -881,6 +881,11 @@ impl Interpreter {
         } else {
             Self::decrement_value(&old)
         };
+        let new_val = if let Some(constraint) = crate::value::lookup_container_constraint(arc) {
+            Self::wrap_native_int_arithmetic_for_constraint(&constraint, new_val)
+        } else {
+            self.wrap_native_int_arithmetic_result(name, new_val)
+        };
         if let Some(constraint) = crate::value::lookup_container_constraint(arc)
             && !matches!(constraint.as_str(), "Any" | "Mu")
             && !new_val.is_nil()

--- a/t/issue-7754-native-integer-wrap.t
+++ b/t/issue-7754-native-integer-wrap.t
@@ -1,0 +1,160 @@
+use Test;
+
+plan 40;
+
+# In-place arithmetic on a native scalar uses the native machine operation.
+{
+    my int8 $a = 127;
+    is ++$a, -128, 'int8 prefix increment wraps';
+    is $a, -128, 'int8 increment stores the wrapped value';
+
+    my int16 $b = -32768;
+    is --$b, 32767, 'int16 prefix decrement wraps';
+    is $b, 32767, 'int16 decrement stores the wrapped value';
+
+    my int32 $c = 2147483647;
+    is $c + 1, 2147483648, 'int32 arithmetic keeps machine width';
+    $c += 1;
+    is $c, -2147483648, 'int32 compound assignment narrows on store';
+
+    my int $d = 9223372036854775807;
+    is ++$d, -9223372036854775808, 'int prefix increment wraps at i64';
+    is $d, -9223372036854775808, 'int increment stores the wrapped value';
+
+    my int $e = -9223372036854775808;
+    --$e;
+    is $e, 9223372036854775807, 'int prefix decrement wraps at i64';
+
+    my int $f = 9223372036854775807;
+    $f += 1;
+    is $f, -9223372036854775808, 'int + assignment uses native overflow';
+
+    my int $g = -9223372036854775808;
+    $g -= 1;
+    is $g, 9223372036854775807, 'int - assignment uses native underflow';
+
+    my int $h = 3037000500;
+    $h *= $h;
+    is $h, -9223372036709301616, 'int multiplication wraps at i64';
+}
+
+# Unsigned native operands use u64 arithmetic, while narrow declarations still
+# narrow their result when it is written back to the variable.
+{
+    my uint8 $a = 255;
+    ++$a;
+    is $a, 0, 'uint8 prefix increment wraps';
+
+    my uint16 $b = 0;
+    --$b;
+    is $b, 65535, 'uint16 prefix decrement wraps';
+
+    my uint32 $c = 4294967295;
+    $c += 1;
+    is $c, 0, 'uint32 compound addition narrows on store';
+
+    my uint $d = 18446744073709551615;
+    my uint $one = 1;
+    $d += $one;
+    is $d, 0, 'uint addition wraps at u64';
+
+    my uint $e = 0;
+    my uint $one2 = 1;
+    $e -= $one2;
+    is $e, 18446744073709551615, 'uint subtraction wraps at u64';
+
+    my uint $f = 4294967296;
+    my uint $two = 4294967296;
+    $f *= $two;
+    is $f, 0, 'uint multiplication wraps at u64';
+}
+
+# Element stores use the same native-width rule as scalar stores.
+{
+    my int8 @a = 127;
+    ++@a[0];
+    is @a[0], -128, 'int8 array increment wraps';
+
+    my int16 @b = -32768;
+    --@b[0];
+    is @b[0], 32767, 'int16 array decrement wraps';
+
+    my int32 @c = 2147483647;
+    ++@c[0];
+    is @c[0], -2147483648, 'int32 array increment wraps';
+
+    my int @d = 9223372036854775807;
+    ++@d[0];
+    is @d[0], -9223372036854775808, 'int array increment wraps';
+
+    my uint8 @e = 255;
+    ++@e[0];
+    is @e[0], 0, 'uint8 array increment wraps';
+
+    my uint16 @f = 0;
+    --@f[0];
+    is @f[0], 65535, 'uint16 array decrement wraps';
+
+    my uint32 @g = 4294967295;
+    ++@g[0];
+    is @g[0], 0, 'uint32 array increment wraps';
+
+    my uint @h = 18446744073709551615;
+    ++@h[0];
+    is @h[0], 0, 'uint array increment wraps';
+}
+
+# The remaining scalar boundaries cover compound subtraction, addition, and
+# multiplication for the narrow signed and unsigned widths, plus direct
+# full-width arithmetic and the boxed-Int control.
+{
+    my int8 $a = -128;
+    $a -= 1;
+    is $a, 127, 'int8 compound subtraction wraps';
+
+    my int16 $b = 32767;
+    $b += 1;
+    is $b, -32768, 'int16 compound addition wraps';
+
+    my int32 $c = -2147483648;
+    $c -= 1;
+    is $c, 2147483647, 'int32 compound subtraction wraps';
+
+    my int8 $d = 64;
+    $d *= 2;
+    is $d, -128, 'int8 compound multiplication wraps';
+
+    my uint8 $e = 0;
+    $e -= 1;
+    is $e, 255, 'uint8 compound subtraction wraps';
+
+    my uint16 $f = 65535;
+    $f += 1;
+    is $f, 0, 'uint16 compound addition wraps';
+
+    my uint32 $g = 65536;
+    $g *= 65536;
+    is $g, 0, 'uint32 compound multiplication wraps';
+
+    my uint8 $h = 128;
+    $h *= 2;
+    is $h, 0, 'uint8 compound multiplication wraps';
+
+    my int $signed_one = 1;
+    my int $i = 9223372036854775807;
+    is $i + $signed_one, -9223372036854775808, 'direct int addition wraps';
+
+    my int $j = -9223372036854775808;
+    is $j - $signed_one, 9223372036854775807, 'direct int subtraction wraps';
+
+    my int $k = 3037000500;
+    is $k * $k, -9223372036709301616, 'direct int multiplication wraps';
+
+    my uint $unsigned_zero = 0;
+    my uint $unsigned_one = 1;
+    is $unsigned_zero - $unsigned_one, -1, 'direct uint subtraction keeps register bits';
+
+    my Int $boxed = 9223372036854775807;
+    is $boxed + 1, 9223372036854775808, 'boxed Int addition still promotes';
+    is $boxed * 2, 18446744073709551614, 'boxed Int multiplication still promotes';
+}


### PR DESCRIPTION
Closes #7754

Native integer arithmetic now preserves machine-width overflow semantics for signed and unsigned `+`, `-`, and `*` operations. Increment/decrement results wrap before being stored or returned across scalar, shared-cell, attribute, and native aggregate element paths. Narrow native declarations continue to narrow at the destination, while boxed `Int` arithmetic and ordinary out-of-range assignments retain their existing behavior.

Added a focused boundary regression test covering all native integer widths, both signedness families, arithmetic operators, increment/decrement, aggregate elements, and boxed `Int` controls.

Validation:
- `make lint`
- `make test`
- `make roast`
