### PR TITLE
fix: flatten same-kind junctions over `~`, thread junctions through `join`

### DIFF
--- a/news/2026-09/junction-flatten-thread-tilde-join.md
+++ b/news/2026-09/junction-flatten-thread-tilde-join.md
@@ -1,0 +1,63 @@
+# Junctions no longer nest through `~`, and thread through `.join`
+
+Two related junction-threading gaps from the 2026-09-09 doc-diff sweep.
+
+## `~` over two same-kind junctions nested instead of producing one junction
+
+`(1|3|5) ~ (2|4|6)` answered `any(any(12, 14, 16), any(32, 34, 36), any(52,
+54, 56))` instead of Rakudo's flat `any(12, 14, 16, 32, 34, 36, 52, 54,
+56)`. `eval_concat_with_junctions` (`src/vm/vm_coerce_concat_ops.rs`) threaded
+over the left junction's values while passing the right operand through
+unchanged as a whole `Junction`; the recursive call then threaded over the
+right junction too, so each of the left's results came back already wrapped
+in its own inner junction, and the outer `map` wrapped that again — a
+junction of junctions instead of one flat cross product.
+
+Fixed by detecting when both operands are junctions of the **same** kind
+and threading the full cross product directly into one flat `Junction`,
+before the existing left-first threading (used only when kinds actually
+differ, e.g. `(1|2) ~ (3&4)`) runs. Verified against `raku` that this
+same-kind flattening is specific to `~` — `+`, `*`, `==`, `eq`, and every
+other operator sharing the general `eval_binary_with_junctions` helper keep
+same-kind junctions genuinely nested in real Rakudo, so that shared helper
+was deliberately left untouched (an earlier attempt to "fix" it there was
+reverted after `(1|3) + (2|4)` stopped matching `raku`).
+
+## A junction inside a list did not thread through `.join`
+
+`("a"|"b", "c", "d").join` answered `any(a, b)cd` — mutsu stringified the
+junction element in place instead of threading the whole `join` over its
+eigenstates, where Rakudo answers `any(acd, bcd)`.
+
+`join` turned out to have four separate implementations (a native 2-arg
+fast path, a native 1-arg method-call fast path, a native 0-arg method-call
+fast path, and the interpreter's own slow-path `dispatch_join_method`), none
+of which recognized a `Junction` among the elements to join. Added a new
+pure helper, `thread_junctions_in_items` (`src/builtins/functions/flat.rs`):
+given an already-flattened list, if it contains a `Junction`, thread the
+join across the cross product of every same-kind junction position's
+eigenstates, returning one flat `Junction` (mismatched kinds still nest,
+mirroring the `~` fix above). Wired into `builtin_join` and
+`dispatch_join_method` (the two places that actually render the joined
+string), and added a `Junction` fall-through gate to the three native fast
+paths (`join_needs_interpreter`, and the 0-arg/1-arg method dispatch arms)
+so a junction-containing call reaches one of those two implementations
+instead of answering directly.
+
+Both fixes verified against `raku`: the two numbered repros, width-correctness
+(`(1|3) ~ (2|4)` has four eigenstates), the previously-correct nested-form
+comparison control, the mismatched-kind-stays-nested control, and the
+unaffected-arithmetic-operator control. Pinned by
+`t/issue-7755-junction-flatten-thread.t`. All 20 existing
+`t/*junction*.t` files (226 assertions) continue to pass unchanged.
+
+A mixed-kind junction combined with **another** junction inside the same
+list (e.g. `("a"|"b", "c"&"d", "e").join`) is not fully fixed — Rakudo's
+exact kind-label-swap for that deeper case was not reproduced, matching the
+issue's own guidance not to blindly extend into unverified territory. Two
+further, separately-mechanismed junction-autothreading gaps the same sweep
+found (`%h{one <foo meow>}:exists`, and a junction rebuilt through `(gather
+$j».take).grep`) were recorded in the issue but are explicitly out of scope
+here.
+
+Closes #7755.

--- a/src/builtins/functions.rs
+++ b/src/builtins/functions.rs
@@ -20,7 +20,7 @@ use dispatch_variadic::native_function_variadic;
 use sprintf_fmt::native_sprintf;
 use time::builtin_localtime_gmtime;
 
-pub(crate) use flat::{deitemize_flat_operand, flat_val, join_flat};
+pub(crate) use flat::{deitemize_flat_operand, flat_val, join_flat, thread_junctions_in_items};
 pub(crate) use junction::build_junction;
 pub(crate) use math::factorial_bigint;
 pub(crate) use uniparse::uniparse_impl;

--- a/src/builtins/functions/flat.rs
+++ b/src/builtins/functions/flat.rs
@@ -202,6 +202,12 @@ pub(crate) fn flat_val(v: &Value, out: &mut Vec<Value>, flatten_arrays: bool) {
 pub(crate) fn join_needs_interpreter(v: &Value) -> bool {
     match v.view() {
         ValueView::Instance { .. } | ValueView::Mixin(..) | ValueView::Proxy { .. } => true,
+        // A Junction anywhere in the (recursively flattened) argument list
+        // must thread the whole `join` over its eigenstates
+        // (`("a"|"b","c","d").join` => `any(acd, bcd)`) — the pure
+        // `join_flat`/`flat_val` path can only stringify it in place, so
+        // route to `Interpreter::builtin_join`, which does the threading.
+        ValueView::Junction { .. } => true,
         // Exactly one level, no recursion past the cell: the bind puts the
         // Proxy directly behind it, whereas a cell holding a structure may be a
         // self-reference and following it walks the cycle forever.
@@ -211,6 +217,7 @@ pub(crate) fn join_needs_interpreter(v: &Value) -> bool {
         ValueView::Array(items, kind) if !kind.is_itemized() => {
             items.iter().any(join_needs_interpreter)
         }
+        ValueView::Seq(items) => items.iter().any(join_needs_interpreter),
         _ => false,
     }
 }
@@ -241,4 +248,63 @@ pub(crate) fn join_flat(sep: &str, rest: &[Value]) -> Option<String> {
             .collect::<Vec<_>>()
             .join(sep),
     )
+}
+
+/// If a (already fully flattened) list of items contains a `Junction`
+/// anywhere, thread `render` across the cross product of every SAME-kind
+/// junction position's eigenstates, returning one flat `Junction` of that
+/// kind (`("a"|"b","c"|"d","e").join` => `any(ace, ade, bce, bde)`, not a
+/// junction of junctions — mirrors the flattening
+/// `eval_concat_with_junctions` applies for two same-kind operands, verified
+/// against Rakudo). A junction of a DIFFERENT kind is left for a recursive
+/// peel afterward, so mismatched kinds still nest, though this simple
+/// leftmost-first peel does not reproduce Rakudo's exact kind-label swap for
+/// a mixed-kind, multiple-junction list (verified only for a single
+/// junction, or several junctions of one kind, per the acceptance criteria
+/// this exists for — a mixed-kind multi-junction list is a deeper case left
+/// unfixed, same spirit as the issue's own "record, do not fix blind" note).
+/// Returns `None` when no item is a `Junction`, so the caller runs `render`
+/// on the unchanged items. `render` is pure (no interpreter access) — every
+/// current caller (`join`) only needs `.to_str_context()`.
+pub(crate) fn thread_junctions_in_items(
+    items: &[Value],
+    render: &dyn Fn(&[Value]) -> Value,
+) -> Option<Value> {
+    let first_idx = items
+        .iter()
+        .position(|v| matches!(v.view(), ValueView::Junction { .. }))?;
+    let ValueView::Junction {
+        kind: first_kind, ..
+    } = items[first_idx].view()
+    else {
+        unreachable!("position() just matched a Junction")
+    };
+    let same_kind_positions: Vec<usize> = items
+        .iter()
+        .enumerate()
+        .filter_map(|(i, v)| match v.view() {
+            ValueView::Junction { kind, .. } if kind == first_kind => Some(i),
+            _ => None,
+        })
+        .collect();
+    let mut combos: Vec<Vec<Value>> = vec![items.to_vec()];
+    for &i in &same_kind_positions {
+        let ValueView::Junction { values, .. } = items[i].view() else {
+            unreachable!("same_kind_positions only holds Junction indices")
+        };
+        let mut next = Vec::with_capacity(combos.len() * values.len());
+        for combo in &combos {
+            for val in values.iter() {
+                let mut c = combo.clone();
+                c[i] = val.clone();
+                next.push(c);
+            }
+        }
+        combos = next;
+    }
+    let results: Vec<Value> = combos
+        .iter()
+        .map(|c| thread_junctions_in_items(c, render).unwrap_or_else(|| render(c)))
+        .collect();
+    Some(Value::junction(first_kind, results))
 }

--- a/src/builtins/methods_0arg/dispatch_core_str.rs
+++ b/src/builtins/methods_0arg/dispatch_core_str.rs
@@ -325,8 +325,15 @@ pub(super) fn dispatch(
                 // so user-defined Str() methods can be called. A `ContainerRef`
                 // element (grep rw alias / `:=`-bound slot) is decontainerized
                 // first so a cell-wrapped Instance is also routed to runtime.
+                // A Junction likewise falls through — it must thread the
+                // whole `join` over its eigenstates, not stringify in place.
                 if items.iter().any(|v| {
-                    v.with_deref(|inner| matches!(inner.view(), ValueView::Instance { .. }))
+                    v.with_deref(|inner| {
+                        matches!(
+                            inner.view(),
+                            ValueView::Instance { .. } | ValueView::Junction { .. }
+                        )
+                    })
                 }) {
                     return Some(None);
                 }

--- a/src/builtins/methods_narg/dispatch_1arg.rs
+++ b/src/builtins/methods_narg/dispatch_1arg.rs
@@ -858,11 +858,15 @@ pub(crate) fn native_method_1arg(
                 // each element with `.Str`, whose dispatch deconts its invocant,
                 // so `my @h = $c` with an `is Array` subclass instance must not
                 // be answered here with the pure `SA()` fallback.
+                // A Junction likewise falls through — it must thread the
+                // whole `join` over its eigenstates, not stringify in place.
                 if items.iter().any(|v| {
                     v.with_deref(|inner| {
                         matches!(
                             inner.descalarize().view(),
-                            ValueView::Instance { .. } | ValueView::Mixin(..)
+                            ValueView::Instance { .. }
+                                | ValueView::Mixin(..)
+                                | ValueView::Junction { .. }
                         )
                     })
                 }) {

--- a/src/builtins/mod.rs
+++ b/src/builtins/mod.rs
@@ -101,7 +101,7 @@ pub(crate) use arith::{
 pub(crate) use functions::build_junction;
 pub(crate) use functions::join_flat;
 pub(crate) use functions::native_function;
-pub(crate) use functions::{deitemize_flat_operand, flat_val};
+pub(crate) use functions::{deitemize_flat_operand, flat_val, thread_junctions_in_items};
 pub(crate) use methods_0arg::native_method_0arg;
 pub(crate) use methods_narg::{
     native_base_with_options, native_contains_with_options, native_method_1arg, native_method_2arg,

--- a/src/runtime/builtins_collection_listops.rs
+++ b/src/runtime/builtins_collection_listops.rs
@@ -124,6 +124,31 @@ impl Interpreter {
                 None => rendered.push(v),
             }
         }
+        // A Junction anywhere in the flattened list threads the whole `join`
+        // over its eigenstates (`("a"|"b","c","d").join` => `any(acd, bcd)`)
+        // instead of stringifying it in place. Flatten `rendered` the same
+        // way `join_flat` itself would (its own flattening is opaque to a
+        // caller, so redo it here to inspect the leaves) — only when a
+        // Junction is actually present does this replace the plain
+        // `join_flat` call below; the common case pays one extra flatten.
+        let mut flat_items = Vec::new();
+        for v in &rendered {
+            if crate::runtime::utils::is_shaped_array(v) {
+                flat_items.extend(crate::runtime::utils::shaped_array_leaves(v));
+            } else {
+                crate::builtins::flat_val(v, &mut flat_items, true);
+            }
+        }
+        if let Some(threaded) = crate::builtins::thread_junctions_in_items(&flat_items, &|c| {
+            Value::str(
+                c.iter()
+                    .map(|v| v.to_str_context())
+                    .collect::<Vec<_>>()
+                    .join(&sep),
+            )
+        }) {
+            return Ok(threaded);
+        }
         Ok(Value::str(
             crate::builtins::join_flat(&sep, &rendered).unwrap_or_default(),
         ))

--- a/src/runtime/methods_dispatch_match3.rs
+++ b/src/runtime/methods_dispatch_match3.rs
@@ -717,7 +717,13 @@ impl Interpreter {
         } else {
             Self::value_to_list(&target)
         };
-        let mut parts = Vec::with_capacity(items.len());
+        // Resolve every non-Junction element to its final Str value up front
+        // (Instance/Mixin through user `.Str`, same as before); a Junction
+        // element is left as-is so `thread_junctions_in_items` below can
+        // thread the whole `join` over its eigenstates
+        // (`("a"|"b","c","d").join` => `any(acd, bcd)`) instead of
+        // stringifying it in place.
+        let mut resolved = Vec::with_capacity(items.len());
         for v in &items {
             // Decontainerize a `ContainerRef` element (grep rw alias / `:=`-bound
             // slot) so a cell-wrapped Instance still gets its user-defined `.Str`.
@@ -733,12 +739,26 @@ impl Interpreter {
                     Ok(s) => s,
                     Err(e) => return Some(Err(e)),
                 };
-                parts.push(s.to_string_value());
+                resolved.push(Value::str(s.to_string_value()));
             } else {
-                parts.push(v.to_string_value());
+                resolved.push(v);
             }
         }
-        let joined = parts.join(&sep);
+        if let Some(threaded) = crate::builtins::thread_junctions_in_items(&resolved, &|c| {
+            Value::str(
+                c.iter()
+                    .map(|v| v.to_str_context())
+                    .collect::<Vec<_>>()
+                    .join(&sep),
+            )
+        }) {
+            return Some(Ok(threaded));
+        }
+        let joined = resolved
+            .iter()
+            .map(|v| v.to_str_context())
+            .collect::<Vec<_>>()
+            .join(&sep);
         Some(Ok(Value::str(joined)))
     }
 

--- a/src/vm/vm_coerce_concat_ops.rs
+++ b/src/vm/vm_coerce_concat_ops.rs
@@ -375,7 +375,36 @@ impl Interpreter {
             .unwrap_or(right)
             .descalarize()
             .clone();
-        // Both junctions: thread left first, swap kinds if right is tighter
+        // Both junctions of the SAME kind thread into ONE flat junction over
+        // their cross product (`(1|3) ~ (2|4)` => `any(13,14,33,34)` shaped
+        // combinations), not a junction of junctions — the same flattening
+        // `eval_binary_with_junctions` applies for arithmetic/comparison
+        // operators. A mismatched kind falls through to the existing
+        // thread-left-then-swap path below, which Rakudo keeps genuinely
+        // nested (`(1|2) ~ (3&4)` is `all(any(...), any(...))`, not flat)
+        // because the two kinds' short-circuit semantics cannot collapse.
+        if let (
+            ValueView::Junction {
+                kind: lk,
+                values: lv,
+            },
+            ValueView::Junction {
+                kind: rk,
+                values: rv,
+            },
+        ) = (left.view(), right.view())
+            && lk == rk
+        {
+            let mut results = Vec::with_capacity(lv.len() * rv.len());
+            for l in lv.iter() {
+                for r in rv.iter() {
+                    results.push(self.eval_concat_with_junctions(l.clone(), r.clone()));
+                }
+            }
+            return Value::junction(lk, results);
+        }
+        // Both junctions of mismatched kinds: thread left first, swap kinds
+        // if right is tighter.
         if let (ValueView::Junction { kind: lk, .. }, ValueView::Junction { kind: rk, .. }) =
             (left.view(), right.view())
         {

--- a/t/issue-7755-junction-flatten-thread.t
+++ b/t/issue-7755-junction-flatten-thread.t
@@ -1,0 +1,79 @@
+use Test;
+
+# Two related junction-threading gaps from the 2026-09-09 doc-diff sweep.
+# See https://github.com/tokuhirom/mutsu/issues/7755
+#
+# Every assertion captures the Junction result into a variable and calls
+# `.raku` on it BEFORE handing it to `is` — a raw Junction argument would
+# autothread the `is` call itself, comparing each eigenstate separately
+# instead of checking the junction's own shape.
+plan 11;
+
+# 1. `~` over two SAME-kind junctions threads into one flat junction, not a
+# junction of junctions. `.raku` lists every eigenstate, so this is also the
+# width check: 9 eigenstates (3x3), not 3 nested junctions of 3.
+{
+    my $odd = 1|3|5;
+    my $even = 2|4|6;
+    my $merged = $odd ~ $even;
+    is $merged.raku, 'any("12", "14", "16", "32", "34", "36", "52", "54", "56")',
+        '~ over two any-junctions is one flat, width-correct any(...) of 9';
+}
+{
+    my $merged = (1|3) ~ (2|4);
+    is $merged.raku, 'any("12", "14", "32", "34")',
+        '(1|3) ~ (2|4) has four eigenstates, not two junctions';
+}
+
+# Comparison against the nested form still works (control: this survived
+# even with the old nested bug, so it must keep working).
+{
+    my $merged = (1|3|5) ~ (2|4|6);
+    ok 34 == $merged, 'comparison against the merged junction still matches';
+}
+
+# Mismatched kinds are NOT flattened — Rakudo keeps them genuinely nested
+# because the two kinds' short-circuit semantics cannot collapse into one.
+{
+    my $merged = (1|2) ~ (3&4);
+    is $merged.raku, 'all(any("13", "14"), any("23", "24"))',
+        'mismatched-kind ~ (any and all) stays nested, unlike same-kind';
+}
+
+# Other operators sharing eval_binary_with_junctions are UNAFFECTED controls:
+# Rakudo keeps arithmetic genuinely nested even for same-kind junctions
+# (only ~ flattens), so this must not regress.
+{
+    my $merged = (1|3) + (2|4);
+    is $merged.raku, 'any(any(3, 5), any(5, 7))',
+        '+ over two any-junctions stays nested (unlike ~, which flattens)';
+}
+
+# 2. A junction inside a list threads through `.join` instead of being
+# stringified in place.
+{
+    my $j = ("a"|"b", "c", "d").join;
+    is $j.raku, 'any("acd", "bcd")',
+        'a junction element threads through the method-call .join';
+}
+{
+    my @a = "a"|"b", "c", "d";
+    my $j = @a.join;
+    is $j.raku, 'any("acd", "bcd")', 'a junction element threads through @array.join';
+}
+{
+    my $j = join(",", "a"|"b", "c", "d");
+    is $j.raku, 'any("a,c,d", "b,c,d")',
+        'a junction as a direct join() argument threads (function-call form)';
+}
+{
+    my $j = ("a"|"b", "c"|"d", "e").join;
+    is $j.raku, 'any("ace", "ade", "bce", "bde")',
+        'two same-kind junctions in a list flatten into one, width-correct';
+}
+
+# Control: a list with no junction is unaffected.
+is ("a", "b", "c").join, "abc", 'join with no junction is unaffected';
+is ("a", "b", "c").join(","), "a,b,c", 'join(sep) with no junction is unaffected';
+
+done-testing;


### PR DESCRIPTION
## Summary

Two related junction-threading gaps from the 2026-09-09 doc-diff sweep.

### 1. `~` over two same-kind junctions nested instead of producing one junction

`(1|3|5) ~ (2|4|6)` answered `any(any(12, 14, 16), any(32, 34, 36), any(52, 54, 56))` instead of Rakudo's flat `any(12, 14, 16, 32, 34, 36, 52, 54, 56)`. `eval_concat_with_junctions` (`src/vm/vm_coerce_concat_ops.rs`) threaded over the left junction's values while passing the right operand through unchanged as a whole `Junction`; the recursive call then threaded over the right junction too, so each left-value's result came back already wrapped in its own inner junction — a junction of junctions instead of one flat cross product.

Fixed by detecting when both operands are junctions of the **same** kind and threading the full cross product directly into one flat `Junction`, before the existing left-first threading (only reached when kinds actually differ, e.g. `(1|2) ~ (3&4)`) runs. Verified against `raku` that this same-kind flattening is specific to `~` — `+`, `*`, `==`, `eq`, and every other operator sharing the general `eval_binary_with_junctions` helper keep same-kind junctions genuinely nested in real Rakudo, so that shared helper was deliberately left untouched (an earlier attempt to "fix" it there was reverted once `(1|3) + (2|4)` stopped matching `raku`).

### 2. A junction inside a list did not thread through `.join`

`("a"|"b", "c", "d").join` answered `any(a, b)cd` — the junction element was stringified in place instead of threading the whole `join` over its eigenstates, where Rakudo answers `any(acd, bcd)`.

`join` turned out to have four separate implementations (a native 2-arg fast path, a native 1-arg method-call fast path, a native 0-arg method-call fast path, and the interpreter's own slow-path `dispatch_join_method`), none of which recognized a `Junction` among the elements to join. Added a new pure helper, `thread_junctions_in_items` (`src/builtins/functions/flat.rs`): given an already-flattened list, if it contains a `Junction`, thread the join across the cross product of every same-kind junction position's eigenstates, returning one flat `Junction` (mismatched kinds still nest, mirroring the `~` fix). Wired into `builtin_join` and `dispatch_join_method` (the two places that actually render the joined string), and added a `Junction` fall-through gate to the three native fast paths so a junction-containing call reaches one of those two implementations instead of answering directly.

### Known remaining gap (documented, not fixed)

A mixed-kind junction combined with **another** junction inside the same list (e.g. `("a"|"b", "c"&"d", "e").join`) is not fully fixed — Rakudo's exact kind-label-swap for that deeper case was not reproduced, matching the issue's own guidance not to blindly extend into unverified territory. Two further, separately-mechanismed junction-autothreading gaps the same sweep found (`%h{one <foo meow>}:exists`, and a junction rebuilt through `(gather $j».take).grep`) were recorded in the issue and are explicitly out of scope.

## Test plan

- [x] New `t/issue-7755-junction-flatten-thread.t`, verified against both `target/debug/mutsu` and `raku` — both numbered repros, width-correctness (`(1|3) ~ (2|4)` has four eigenstates), the previously-correct nested-form comparison control, the mismatched-kind-stays-nested control, and the unaffected-arithmetic-operator control all match.
- [x] All 20 existing `t/*junction*.t` files (226 assertions) continue to pass unchanged.
- [x] `cargo fmt --all`
- [x] `make lint` — clean (default clippy, `jit`-off clippy, wasm32 clippy, rustdoc)
- [x] `make test` — `Result: PASS`
- [x] `make roast` — the only failures are the three known remote-container environment-only files (`roast/6.c/S32-io/file-tests.t`, `roast/S16-filehandles/filetest.t`, `roast/S32-io/IO-Socket-Async.t`), matching `docs/agent-environments.md` by name and subtest range exactly.

Closes #7755

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5YdUpBfVMSGjEwVvGwUg7

---
_Generated by [Claude Code](https://claude.ai/code/session_01M5YdUpBfVMSGjEwVvGwUg7)_