### PR TITLE
docs: the http2-request-parser race is a test-harness defect, fixed upstream

### DIFF
--- a/docs/adr/0084-the-frame-env-is-not-the-programs-symbol-table.md
+++ b/docs/adr/0084-the-frame-env-is-not-the-programs-symbol-table.md
@@ -196,6 +196,18 @@ env deep copy on that path is worth about 0.5 ms. This ADR is worth doing for th
 correctness divergences and for the general "cost scales with program size"
 property; the race needs that and more.
 
+**And that ~1 ms budget is not mutsu's to meet.** The race is a defect in the
+test harness — it calls `ok` from `start` blocks, and `Test` is not thread-safe —
+reported upstream as
+[croservices/cro-http#217](https://github.com/croservices/cro-http/pull/217),
+which has each request record its check results into a `Promise` and reports them
+from the main thread in request order. With that in, there is no race for an
+interpreter to win: the bound becomes the test's own `Promise.in(5)` timeout,
+which mutsu clears by two orders of magnitude. So **do not start this campaign,
+or any other, on the premise that a HTTP/2 body path must get 3x faster.** Its
+justification is §1.4 and §1.2 — the correctness divergences and the fact that
+identical code costs 5x more once modules are loaded.
+
 ## 7. Implementation status
 
 Not started, tracked by

--- a/news/2026-09/carrier-compile-cache-keyed-by-parse-site.md
+++ b/news/2026-09/carrier-compile-cache-keyed-by-parse-site.md
@@ -83,3 +83,13 @@ Closing that needs the losing side under about 1 millisecond, which means the
 other half of the cost: env copy-on-write deep copies that scale with the size of
 the program (7,253 env entries copied per DATA frame, ~17,000 per `body-blob`).
 See [#7667](https://github.com/tokuhirom/mutsu/issues/7667).
+
+**Update:** that 1 ms budget turned out not to be mutsu's to meet. The race is a
+test-harness defect — the checks run in `start` blocks and call `ok` from there,
+and `Test` is not thread-safe — reported upstream as
+[croservices/cro-http#217](https://github.com/croservices/cro-http/pull/217),
+which records each request's results into a `Promise` and reports them from the
+main thread in request order. The work above stands on its own (a `whenever`
+callback should not recompile per value, and a cache should not be keyed by an
+identity that is fresh per call), but it should not be read as a down payment on
+a race that is being removed at its source.


### PR DESCRIPTION
Documentation only. Corrects a forward-looking claim in two documents that landed today.

ADR-0084 §6 and the #7812 news entry both record that the losing side of `cro-http`'s `t/http2-request-parser.rakutest` race costs ~3.1 ms and "needs to come under about 1 ms". As written, that invites someone to start an interpreter performance campaign to meet a millisecond budget on a HTTP/2 body path.

**That budget is not mutsu's to meet.** The race is a defect in the test harness: the per-request checks run inside `start` blocks and call `ok` from there, and `Test` is not thread-safe — so concurrent requests interleave their TAP output and a test can leak past the `pass` that should follow it. Reported upstream as [croservices/cro-http#217](https://github.com/croservices/cro-http/pull/217), which has each request record its check results into a `Promise` and reports them from the main thread in request order:

```diff
-                    for @checks[$current-counter].kv -> $i, $check {
-                        ok $check($request), "check {$i + 1}";
-                    }
+                    my @results;
+                    for @checks[$current-counter].list -> $check {
+                        @results.push($check($request));
+                    }
+                    @check-results[$current-counter].keep(@results);
```

With that in there is no race for an interpreter to win — the bound becomes the test's own `Promise.in(5)` timeout, which mutsu clears by two orders of magnitude. Upstream measured 8/26 → 23/26 identical outputs across parallel runs, with the residual three attributed to that 5 s timeout under contention rather than to the race.

The measurements themselves stand, and so does ADR-0084's justification — the correctness divergences of §1.4 and the fact that identical code costs 5x more once modules are loaded (§1.2). Neither should be read as a down payment on a race that is being removed at its source.

## Changes

- `docs/adr/0084-…md` §6 — adds the upstream fix and an explicit "do not start this campaign on that premise"
- `news/2026-09/carrier-compile-cache-keyed-by-parse-site.md` — an `Update:` on its "What this does *not* fix" section

Refs #7667, #7817.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NX9vs4NbdKXUu6MoAaHpSz

---
_Generated by [Claude Code](https://claude.ai/code/session_01NX9vs4NbdKXUu6MoAaHpSz)_