### PR TITLE
fix: preserve invocant in method where matching

### DIFF
--- a/news/2026-09/method-where-constraint-invocant.md
+++ b/news/2026-09/method-where-constraint-invocant.md
@@ -1,0 +1,4 @@
+# Method `where` constraints can read the invocant
+
+Method parameters with `where` constraints can now access the invocant through
+`$.attr` or `self.attr` while multi-method candidates are being matched.

--- a/src/runtime/accessors_state.rs
+++ b/src/runtime/accessors_state.rs
@@ -976,8 +976,9 @@ impl Interpreter {
     }
 
     /// ADR-0019 E9a/E9b-2: candidates from the deferral expansion whose
-    /// signature matches this call's args (invocant-blind, per E8a finding
-    /// 1). Shared first half of [`Self::push_method_dispatch_frame`]'s and
+    /// signature matches this call's args. The actual invocant is supplied so
+    /// a candidate's `where` clause can use `self` while the dispatch frame is
+    /// being built. Shared first half of [`Self::push_method_dispatch_frame`]'s and
     /// [`Self::deferral_tail_entries`]'s computation, before either applies
     /// its own "skip the chosen winner" step.
     fn matched_deferral_candidates(
@@ -985,6 +986,7 @@ impl Interpreter {
         receiver_class: &str,
         method_name: &str,
         args: &[Value],
+        invocant: &Value,
     ) -> Vec<(Symbol, super::MethodDef)> {
         let role_bindings = self.registry().get_role_param_bindings(receiver_class);
         let expansion = self.resolve_deferral_expansion(receiver_class, method_name);
@@ -995,7 +997,7 @@ impl Interpreter {
                 &def,
                 args,
                 role_bindings.as_ref(),
-                None,
+                Some(invocant),
             ) {
                 all_candidates.push((owner, def));
             }
@@ -1019,6 +1021,7 @@ impl Interpreter {
         method_name: &str,
         args: &[Value],
         chosen_def: &super::MethodDef,
+        invocant: &Value,
     ) -> Vec<super::DeferralEntry> {
         // Submethod fast path, mirroring `push_method_dispatch_frame`'s own
         // `<=1` guard: a submethod is never inherited, so a single visible
@@ -1028,7 +1031,8 @@ impl Interpreter {
         {
             return Vec::new();
         }
-        let all_candidates = self.matched_deferral_candidates(receiver_class, method_name, args);
+        let all_candidates =
+            self.matched_deferral_candidates(receiver_class, method_name, args, invocant);
         let chosen_fp = self.method_def_fingerprint(chosen_def);
         let mut remaining = Vec::new();
         let mut skipped = false;
@@ -1073,7 +1077,8 @@ impl Interpreter {
         method_def: &super::MethodDef,
         chain: &[(u64, Value)],
     ) {
-        let mro_tail = self.deferral_tail_entries(receiver_class, method_name, args, method_def);
+        let mro_tail =
+            self.deferral_tail_entries(receiver_class, method_name, args, method_def, &invocant);
         let rw_params =
             super::builtins_dispatch_next::rw_scalar_positional_params(&method_def.param_defs);
         let dispatch_token = self.next_dispatch_token();
@@ -1159,9 +1164,10 @@ impl Interpreter {
         // `resolve_all_methods_with_owner` as the ordering source — see its module doc for why
         // a raw MRO walk in declaration order does not reproduce raku's own deferral order once
         // a `multi method` spans MRO levels. The expansion is structural (unfiltered); apply the
-        // same per-call, invocant-blind argument match `resolve_all_methods_with_owner` used to
-        // apply internally.
-        let all_candidates = self.matched_deferral_candidates(receiver_class, method_name, args);
+        // same per-call argument match as `resolve_all_methods_with_owner` used to
+        // apply internally, with the actual invocant available to `where` clauses.
+        let all_candidates =
+            self.matched_deferral_candidates(receiver_class, method_name, args, &invocant);
         // Fast path: with zero or one candidate there is nothing to defer to, so no
         // dispatch frame is ever pushed (the single candidate is the chosen one and
         // gets skipped, leaving `remaining` empty). Returning early here avoids the
@@ -1174,7 +1180,8 @@ impl Interpreter {
             return false;
         }
         // Identify the chosen candidate and skip exactly that one
-        let chosen = self.resolve_method_with_owner(receiver_class, method_name, args);
+        let chosen =
+            self.resolve_method_with_owner_invocant(receiver_class, method_name, args, &invocant);
         let chosen_fp = chosen
             .as_ref()
             .map(|(_, def)| self.method_def_fingerprint(def));

--- a/src/runtime/class_dispatch.rs
+++ b/src/runtime/class_dispatch.rs
@@ -417,8 +417,13 @@ impl Interpreter {
             return result.map(|v| (v, None));
         }
         let invocant_for_dispatch = make_invocant_for_dispatch(&invocant, attributes);
-        let remaining =
-            self.deferral_tail_entries(receiver_class_name, method_name, &args, &method_def);
+        let remaining = self.deferral_tail_entries(
+            receiver_class_name,
+            method_name,
+            &args,
+            &method_def,
+            &inv_value,
+        );
         // A user-overridden grammar `parse`/`subparse`/`parsefile` still needs an MRO
         // frame even with no further USER candidate, so a `nextsame`/`nextwith` inside
         // it can defer to the NATIVE grammar parse — the base candidate that is not a

--- a/t/multi-method-where-invocant-attribute.t
+++ b/t/multi-method-where-invocant-attribute.t
@@ -1,0 +1,24 @@
+use Test;
+
+plan 4;
+
+# A method parameter's where constraint is evaluated while multi dispatch is
+# building its deferral frame. The candidate matcher must retain the method's
+# invocant for both the public $.attr spelling and explicit self.attr.
+class PublicAttr {
+    has $.limit = 10;
+    multi method check($x where { $x > $.limit }) { 'over' }
+    multi method check($x)                         { 'under' }
+}
+my $public = PublicAttr.new;
+is $public.check(50), 'over', '$.attr is available in a method where constraint';
+is $public.check(1),  'under', '$.attr can reject a candidate';
+
+class ExplicitSelf {
+    has $.limit = 10;
+    multi method check($x where { $x > self.limit }) { 'over' }
+    multi method check($x)                            { 'under' }
+}
+my $explicit = ExplicitSelf.new;
+is $explicit.check(50), 'over', 'self.attr is available in a method where constraint';
+is $explicit.check(1),  'under', 'self.attr can reject a candidate';


### PR DESCRIPTION
## Summary

- preserve the invocant while building method deferral candidate frames
- add coverage for `$.attr` and `self.attr` in method `where` constraints

## Tests

- `make lint`
- `make test`
- `make roast`

Closes #7799
