### PR TITLE
fix(batteries): exclude http2-request-parser until upstream fixes its race

### DIFF
--- a/batteries-exclude.txt
+++ b/batteries-exclude.txt
@@ -1,24 +1,56 @@
 # Battery test files the release gate must never run.
 #
-# The gate blocks a release, so a file whose verdict depends on a THIRD-PARTY
-# SERVICE being reachable and healthy does not belong in it: an outage at
-# github.com or httpbin.org would block a release that has nothing wrong with
-# it. (httpbin.org spent part of 2026-07-25 returning 503 — that is not
-# hypothetical.) Such files are skipped entirely, in both gate and `--update`
-# mode, so they can neither fail a release nor re-enter the baseline.
+# Two narrow categories qualify, and nothing else. Both share a rule: the file's
+# verdict must not be a statement about mutsu. This is NOT a place to park a
+# genuinely failing test.
 #
-# This is NOT a place to park a genuinely failing test. The bar is narrow: the
-# file must reach OUTSIDE this machine unconditionally. Most battery suites
-# already guard their live-network assertions behind `NETWORK_TESTING`, which
-# the gate does not set, so they need no entry here — that was verified by
-# re-running every whitelisted file inside a loopback-only network namespace;
-# only the two below failed.
+# (1) THIRD-PARTY SERVICE. The gate blocks a release, so a file whose verdict
+# depends on a service being reachable and healthy does not belong in it: an
+# outage at github.com or httpbin.org would block a release that has nothing
+# wrong with it. (httpbin.org spent part of 2026-07-25 returning 503 — that is
+# not hypothetical.) The bar is that the file must reach OUTSIDE this machine
+# unconditionally. Most battery suites already guard their live-network
+# assertions behind `NETWORK_TESTING`, which the gate does not set, so they need
+# no entry here — that was verified by re-running every whitelisted file inside a
+# loopback-only network namespace; only the two below failed.
+#
+# (2) THE UPSTREAM FILE RACES WITH ITSELF. A file whose own harness is
+# non-deterministic decides nothing about the interpreter under it, and on a
+# release gate it is worse than no coverage: it converts a green build into a
+# coin flip. The bar is that the non-determinism must be (a) root-caused to the
+# upstream file rather than to mutsu, (b) reported upstream, with the PR named
+# below, and (c) recorded with a restore condition, so the entry is a wait on
+# someone else's merge and not a quiet retirement. An entry that cannot name an
+# upstream fix in flight does not qualify — that is a mutsu bug to fix or a
+# `flaky-tests.txt` question, not an exclusion.
+#
+# Excluded files are skipped entirely, in both gate and `--update` mode, so they
+# can neither fail a release nor re-enter the baseline. They are still expected
+# to be run by hand — see the owning file under docs/batteries/.
 #
 # Format: name<TAB>testfile, the same identity batteries-whitelist.txt uses.
 # Sorted (LC_ALL=C).
 #
+# --- (1) third-party service ---
 # HTTP::UserAgent/082-exceptions: unguarded `$ua.get('http://httpbin.org/...')`.
 # IO::Socket::SSL/01-basic: connects to github.com:443 in its first two lines,
 #   before the file's own NETWORK_TESTING guard.
+#
+# --- (2) upstream file races with itself ---
+# Cro::HTTP/http2-request-parser: `test()` runs each request's checks inside a
+#   `start` block and calls `ok` from there. `Test` is not thread-safe, so with
+#   two concurrent HTTP/2 streams the requests interleave their TAP output and a
+#   test can leak past the `pass` that should follow it. Harmless under mutsu's
+#   native Rust provider, which serializes (20/20 idle and 20/20 under load on
+#   2026-09-10, 61/61 each); a coin flip under the vendored Test.rakumod, which
+#   is Raku code with a plain counter (29/30 idle, 11/20 with three CPU burners
+#   on a 4-core box). Fixed upstream by croservices/cro-http#217, which records
+#   each request's results into a Promise and reports them from the main thread
+#   in request order.
+#   RESTORE: when #217 (or an equivalent) is merged and `batteries.lock`'s
+#   Cro::HTTP commit is re-vendored past it — delete this entry, re-run
+#   `--update`, and check the row is back in batteries-whitelist.txt.
+#   Tracked by tokuhirom/mutsu#7555 item 3.
+Cro::HTTP	http2-request-parser.rakutest
 HTTP::UserAgent	082-exceptions.rakutest
 IO::Socket::SSL	01-basic.rakutest

--- a/batteries-whitelist.txt
+++ b/batteries-whitelist.txt
@@ -39,7 +39,6 @@ Cro::HTTP	http-session-persistent.rakutest
 Cro::HTTP	http2-frame-parser.rakutest
 Cro::HTTP	http2-frame-serializer.rakutest
 Cro::HTTP	http2-frame.rakutest
-Cro::HTTP	http2-request-parser.rakutest
 Cro::HTTP	http2-request-serializer.rakutest
 Cro::HTTP	http2-response-parser.rakutest
 Cro::HTTP	http2-response-serializer.rakutest

--- a/docs/batteries/testsuite-gate.md
+++ b/docs/batteries/testsuite-gate.md
@@ -53,7 +53,7 @@ been found; the gate is the net for the ones that have not.
 | --- | --- |
 | `batteries.lock` | Which batteries, where their tests come from, the pinned upstream commit, and the extra `-I` paths each suite needs. |
 | `batteries-whitelist.txt` | The per-file baseline: `name<TAB>testfile` for every test file that currently passes. Sorted. |
-| `batteries-exclude.txt` | Files the gate must never run, same `name<TAB>testfile` shape. Skipped in both modes, so they can neither block a release nor enter the baseline. |
+| `batteries-exclude.txt` | Files the gate must never run, same `name<TAB>testfile` shape. Skipped in both modes, so they can neither block a release nor enter the baseline. Unlike the whitelist, it takes `#` comments — and every entry needs one. |
 | `scripts/battery-testsuite.sh` | The harness. Fetches each suite at its pinned commit, runs it against the bundled library, and enforces (or, with `--update`, regenerates) the whitelist. |
 | `release.yml` `batteries` job | Runs the harness on every release build; `needs` gates the publish job. |
 | `ci.yml` `test` job, last step | Runs the same harness on every PR and every push to `main`. No path filter — see "On every PR" above for why. |
@@ -115,11 +115,17 @@ baseline by running `--update` and committing the diff.
 
 ## What the gate does not run
 
+Two narrow categories, both listed in
+[`batteries-exclude.txt`](../../batteries-exclude.txt) and skipped entirely, in
+both gate and `--update` mode. They share one rule: **the file's verdict must not
+be a statement about mutsu.** An excluded file is never a parking spot for a
+genuinely failing test.
+
+### 1. Third-party service
+
 The gate blocks a release, so a test whose verdict depends on a **third-party
 service** being reachable and healthy must not be in it — an outage somewhere
-else would block a release that has nothing wrong with it. Those files are listed
-in [`batteries-exclude.txt`](../../batteries-exclude.txt) and are skipped
-entirely, in both gate and `--update` mode.
+else would block a release that has nothing wrong with it.
 
 The bar is deliberately narrow: the file must reach outside the machine
 *unconditionally*. Most battery suites already guard their live-network
@@ -131,14 +137,46 @@ a loopback-only network namespace:
 unshare -rn -- sh -c "ip link set lo up; cd <clone>; exec mutsu <-I…> <test>"
 ```
 
-Only two files failed, and they are the two in the exclusion list. With them
-excluded, **every file in the baseline passes offline** — the gate's verdict does
-not depend on any third-party service. Re-run that check when adding a battery
-whose suite talks to the network, and keep it true.
+Only two files failed, and they are the two network entries in the exclusion
+list. With them excluded, **every file in the baseline passes offline** — the
+gate's verdict does not depend on any third-party service. Re-run that check when
+adding a battery whose suite talks to the network, and keep it true.
 
-An excluded file is not a parking spot for a genuinely failing test: it must
-still be run by hand (and it is, by the module's own record), it is simply not a
-release blocker.
+### 2. The upstream file races with itself
+
+A test file whose own harness is non-deterministic decides nothing about the
+interpreter under it, and on a release gate it is worse than no coverage: it
+turns a green build into a coin flip. The bar has three parts, all required:
+
+1. **Root-caused to the upstream file, not to mutsu.** A failure you have not
+   reduced is a bug to fix, not an entry here.
+2. **Reported upstream, with the PR named in the entry.** An entry that cannot
+   name a fix in flight does not qualify.
+3. **A written restore condition** — which upstream merge, and what to do when it
+   lands — so the entry is a wait on someone else's merge rather than a quiet
+   retirement.
+
+`Cro::HTTP/http2-request-parser` is the worked example: it calls `ok` from inside
+`start` blocks, and `Test` is not thread-safe, so two concurrent HTTP/2 streams
+interleave their TAP output. Fixed upstream by
+[croservices/cro-http#217](https://github.com/croservices/cro-http/pull/217);
+the entry says to delete itself and re-run `--update` once that is vendored in.
+
+Note what this category is **not**. It is not `flaky-tests.txt`
+([`docs/flaky-test-policy.md`](../flaky-test-policy.md)): that ledger quarantines
+tests whose non-determinism is inherent but *bounded* — a statistical assertion
+that a correct RNG violates now and then — by re-running them up to three times,
+which is the right answer when a retry converges. It does not apply here for two
+reasons: the battery harness has no retry path, and a ~50% per-run rate would not
+converge in three attempts if it had one.
+
+### In both cases
+
+An excluded file must still be run by hand (and it is, by the module's own record
+under `docs/batteries/`), it is simply not a release blocker. Because `--update`
+skips it too, it cannot drift back into the baseline on its own — deleting the
+entry is the only way back in, which is what makes the restore condition
+load-bearing.
 
 The gate itself still needs the network to *fetch* each suite at its pinned
 commit — that is unavoidable setup, not an assertion. A fetch failure reports

--- a/news/2026-09/http2-request-parser-excluded-pending-upstream-fix.md
+++ b/news/2026-09/http2-request-parser-excluded-pending-upstream-fix.md
@@ -1,0 +1,83 @@
+# The HTTP/2 request-parser battery test races with itself, so the gate stops running it
+
+`cro-http`'s `t/http2-request-parser.rakutest` is out of the release gate until
+[croservices/cro-http#217](https://github.com/croservices/cro-http/pull/217)
+lands. Not because mutsu fails it — because the file's own harness is a race, and
+a racing file on a release gate turns a green build into a coin flip.
+
+## The defect is in the test, not under it
+
+`test()` runs each request's checks inside a `start` block and calls `ok` from
+there:
+
+```raku
+start {
+    for @checks[$current-counter].kv -> $i, $check {
+        ok $check($request), "check {$i + 1}";
+    }
+    $test-completed.keep if $current-counter + 1 == $count;
+    ...
+}
+```
+
+`Test` is not thread-safe. With two concurrent HTTP/2 streams the requests
+interleave their TAP output, and a test can leak past the `pass` that should
+follow it — so the plan and the emitted count disagree and the file fails.
+
+The upstream fix has each request record its results into a `Promise` and reports
+them from the main thread in request order:
+
+```diff
+-    await Promise.anyof($test-completed, Promise.in(5));
++    await Promise.anyof($test-completed, $all-checks-recorded, Promise.in(5));
+```
+
+## Why it only shows up now
+
+Mutsu's native `Test` provider is Rust and serializes, so the race has never been
+visible in the gate. The vendored `Test.rakumod` is Raku code with a plain
+counter, and it is not:
+
+| provider | passes |
+| --- | --- |
+| native (what the gate runs today) | 20/20 idle, 20/20 with three CPU burners on a 4-core box — 61/61 assertions every run |
+| vendored `Test.rakumod` (`MUTSU_REAL_TEST=1`) | 29/30 idle, **11/20** under the same load |
+
+With the `MUTSU_REAL_TEST=1` flip due shortly, the gate is about to start running
+the second row. Ten percent of that column is a release blocked by somebody
+else's test bug, so the row comes out ahead of the flip rather than after the
+first red release.
+
+## The exclusion list grew a second category
+
+`batteries-exclude.txt` had one bar: the file must reach outside this machine
+unconditionally (an httpbin.org outage must not block a release). This is a
+different shape of the same principle — *the file's verdict is not a statement
+about mutsu* — so the list now states two categories, and the new one carries its
+own three-part bar: root-caused to the upstream file, reported upstream with the
+PR named, and a written restore condition. An entry that cannot name a fix in
+flight does not qualify; that is a mutsu bug to fix.
+
+It is deliberately not a `flaky-tests.txt` entry. That ledger re-runs a
+quarantined test up to three times, which is the right answer for a bounded
+statistical flake — a Binomial assertion a correct RNG violates now and then.
+Here the battery harness has no retry path at all, and a ~50% per-run rate would
+not converge in three attempts if it had one.
+
+Because `--update` skips excluded files too, the row cannot drift back into the
+baseline on its own. Deleting the entry is the only way back in, which is what
+makes the restore condition load-bearing: when #217 is merged and
+`batteries.lock`'s Cro::HTTP pin moves past it, delete the entry, re-run
+`--update`, and check the row is back in `batteries-whitelist.txt`.
+
+## What the chase left behind
+
+Characterizing this race precisely enough to see that it *was* one produced five
+general interpreter fixes, none of them HTTP/2-specific: #7786 (a pure-read
+method probe took the registry write guard), #7796 (~50 symbol tables deep-copied
+per thread clone), #7800 (candidate matching bound into the frame env), #7801 (a
+`whenever` body recompiled per emitted value) and #7812 (the carrier compile cache
+keyed by an identity that is fresh per call). A HEADERS frame went 23.4 ms to
+10.3 ms and a DATA frame 2.12 ms to 1.23 ms along the way.
+
+Tracked as item 3 of [#7555](https://github.com/tokuhirom/mutsu/issues/7555).


### PR DESCRIPTION
Takes `Cro::HTTP/http2-request-parser.rakutest` out of the release gate until [croservices/cro-http#217](https://github.com/croservices/cro-http/pull/217) is merged and vendored. Ahead of the `MUTSU_REAL_TEST=1` flip, not after it.

## The defect is in the test, not under it

`test()` runs each request's checks inside a `start` block and calls `ok` from there. `Test` is not thread-safe, so with two concurrent HTTP/2 streams the requests interleave their TAP output and a test can leak past the `pass` that should follow it — leaving the plan and the emitted count disagreeing, which is exactly what the gate's PASS rule checks. The upstream fix records each request's results into a `Promise` and reports them from the main thread in request order:

```diff
-    await Promise.anyof($test-completed, Promise.in(5));
+    await Promise.anyof($test-completed, $all-checks-recorded, Promise.in(5));
```

## Why now

Measured on `1d3e0ff4`, release build, the pinned `6238e753` clone, run exactly as gate mode runs it:

| provider | passes |
| --- | --- |
| native (what the gate runs today) | 20/20 idle, 20/20 with three CPU burners on this 4-core box — 61/61 assertions every run |
| vendored `Test.rakumod` (`MUTSU_REAL_TEST=1`) | 29/30 idle, **11/20** under the same load |

The native provider is Rust and serializes, so the gate has never seen the race. The vendored module is Raku code with a plain counter, and it does not. With the flip due shortly the gate starts running the second row — a tenth of all releases blocked by somebody else's test bug.

## The exclusion list grew a second category

`batteries-exclude.txt` had one bar: the file must reach outside this machine unconditionally. This is a different shape of the same principle — *the file's verdict is not a statement about mutsu* — so the list now names two categories, and the new one carries its own three-part bar:

1. root-caused to the upstream file, not to mutsu;
2. reported upstream, with the PR named in the entry;
3. a written restore condition.

An entry that cannot name a fix in flight does not qualify — that is a mutsu bug to fix.

**Deliberately not a `flaky-tests.txt` entry.** That ledger re-runs a quarantined test up to three times, which is right for a bounded statistical flake (a Binomial assertion a correct RNG violates now and then). Here the battery harness has no retry path at all, and a ~50% per-run rate would not converge in three attempts if it had one.

Because `--update` skips excluded files too, the row cannot drift back into the baseline on its own — deleting the entry is the only way back in, which is what makes the restore condition load-bearing.

## Verification

Ran the gate scoped to Cro::HTTP with a scratch lock and baseline:

```
  http2-request-parser.rakutest             SKIP(excluded)
=== summary: 28/28 test files pass (1 excluded) ===
GATE PASSED: every whitelisted bundled-library test still passes.
```

Both lists still sort clean (`LC_ALL=C sort -c`). No Rust changed, so `make test` / `make roast` have nothing to catch here — the battery gate is the check this diff can affect, and CI runs the full one.

## Changes

- `batteries-whitelist.txt` — drop the row
- `batteries-exclude.txt` — the entry, plus the second category and its bar
- `docs/batteries/testsuite-gate.md` — "What the gate does not run" now documents both categories and why this is not a flaky-quarantine question
- `news/2026-09/http2-request-parser-excluded-pending-upstream-fix.md`

Refs #7555 (item 3), #7667.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NX9vs4NbdKXUu6MoAaHpSz

---
_Generated by [Claude Code](https://claude.ai/code/session_01NX9vs4NbdKXUu6MoAaHpSz)_