### PR TITLE
docs: define a nested layout for t/ and land the infrastructure for it

### DIFF
--- a/.agents/skills/rakuast-implementation/SKILL.md
+++ b/.agents/skills/rakuast-implementation/SKILL.md
@@ -7,7 +7,7 @@ metadata:
 
 # RakuAST implementation
 
-Use this skill for work involving `src/rakuast/`, `t/rakuast*.t`,
+Use this skill for work involving `src/rakuast/`, `t/rakuast/`,
 the RakuAST campaign-overview issue, or RakuAST-specific ADR/design work.
 It covers the RakuAST-specific investigation and implementation details; use
 the repository's normal ticket and PR workflow for branching, validation, and
@@ -53,7 +53,7 @@ converter.
 
 ## Test the contract
 
-Add a focused `t/rakuast-<slice>.t` test with three kinds of assertions:
+Add a focused `t/rakuast/rakuast-<slice>.t` test with three kinds of assertions:
 
 - read direction: measured node classes, accessors, and relevant field
   omission/presence;

--- a/.agents/skills/test-util-workout/SKILL.md
+++ b/.agents/skills/test-util-workout/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: test-util-workout
-description: Pick one Test::Util function from roast's Test-Helpers package, write a t/ test for it, and fix the interpreter until it passes, ending in a merged PR. Use when asked for a "Test::Util workout" or to work through the Test::Util helper functions.
+description: Pick one Test::Util function from roast's Test-Helpers package, write a t/tooling/ test for it, and fix the interpreter until it passes, ending in a merged PR. Use when asked for a "Test::Util workout" or to work through the Test::Util helper functions.
 metadata:
   short-description: Land one Test::Util helper end-to-end
 ---
@@ -16,13 +16,14 @@ learn the expected behaviour.
 ## Workflow
 
 1. Read `roast/packages/Test-Helpers/lib/Test/Util.rakumod` for the list of exported functions.
-2. Check `t/` for the existing coverage (`test-util-*.t`, `is-run.t`, ...) to see which
-   functions already have tests.
+2. Check `t/tooling/` for the existing coverage (`test-util-*.t`, `is-run.t`, ...) to see
+   which functions already have tests. The `Test` module and roast's `Test::Util` helpers
+   live in the `tooling/` category (`docs/t-directory-layout.md`).
 3. Pick **one** unimplemented or undertested function. Once chosen, do **not** switch to a
    different one mid-task.
-4. Write `t/<function-name>.t` exercising it with several cases: basic usage, edge cases, and
-   combined checks.
-5. Run it: `timeout 30 target/debug/mutsu t/<function-name>.t`.
+4. Write `t/tooling/<function-name>.t` exercising it with several cases: basic usage, edge
+   cases, and combined checks.
+5. Run it: `timeout 30 target/debug/mutsu t/tooling/<function-name>.t`.
 6. Fix the interpreter until it passes. When the spec is unclear, check with `raku -e '<code>'`
    (the `install-raku` skill gets `raku` if the container has none) and consult `raku-doc/`.
 7. Run `make test` and `make roast` to check for regressions, then read the results out of

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,7 +197,7 @@ jobs:
         # widen the budget rather than quarantining a real (if heavy) test.
         # Kept at 45 on the release binary too: the budget exists for the
         # heaviest file under contention, and headroom there is free.
-        run: prove -j4 --merge -e 'scripts/run-t-test.sh' t/
+        run: prove -r -j4 --merge -e 'scripts/run-t-test.sh' t/
         env:
           MUTSU_BIN: target/release/mutsu
           MUTSU_T_TIMEOUT: "45"
@@ -212,6 +212,11 @@ jobs:
 
       - name: Roast whitelist is sorted
         run: make check-roast-whitelist
+
+      - name: t/ layout is valid
+        # Categories, depth cap and globally-unique basenames, per
+        # docs/t-directory-layout.md.
+        run: make check-t-layout
 
       - name: Flaky quarantine ledger is valid and unexpired
         # Fails when an entry in flaky-tests.txt is past its review date, so a
@@ -717,7 +722,7 @@ jobs:
         run: |
           set -o pipefail
           mkdir -p tmp
-          prove --merge -e 'scripts/run-t-test.sh' t/ 2>&1 | tee tmp/gc-stress-t.log
+          prove -r --merge -e 'scripts/run-t-test.sh' t/ 2>&1 | tee tmp/gc-stress-t.log
         env:
           MUTSU_BIN: target/debug/mutsu
           MUTSU_T_TIMEOUT: "60"
@@ -852,7 +857,7 @@ jobs:
         run: |
           set -o pipefail
           mkdir -p tmp
-          prove --merge -e 'scripts/run-t-test.sh' t/ 2>&1 | tee tmp/jit-stress-t.log
+          prove -r --merge -e 'scripts/run-t-test.sh' t/ 2>&1 | tee tmp/jit-stress-t.log
         env:
           MUTSU_BIN: target/debug/mutsu
           MUTSU_T_TIMEOUT: "60"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,7 +54,8 @@ Key directories:
 - `src/parser/`, `src/compiler/`, `src/vm/`: execution pipeline.
 - `src/builtins/`, `src/value/`: native behavior and values.
 - `src/runtime/`: remaining dispatch/runtime machinery.
-- `t/`: local TAP integration tests.
+- `t/`: local TAP integration tests, nested by subject. `docs/t-directory-layout.md`
+  decides which category a new file goes in; `make check-t-layout` enforces it.
 - `tests/`: Rust-driven TAP tests.
 - `roast/`: read-only upstream specification tests.
 - `docs/adr/`: architectural decisions; read applicable ADRs before changing
@@ -78,7 +79,8 @@ Raku documentation.
 - `cargo fmt --all`: format Rust.
 - `cargo clippy -- -D warnings`: lint with warnings denied.
 
-Add a focused regression test for each behavior change, normally under `t/`.
+Add a focused regression test for each behavior change, normally under `t/` — in
+the category `docs/t-directory-layout.md` names for it, never at `t/` top level.
 Run a targeted test while iterating. Before publishing a code PR, run
 `cargo fmt --all`, `cargo clippy -- -D warnings`, `make test`, and `make roast`
 once each. After either full command runs, inspect its saved log. A failing

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ before starting one of these tasks:
 | [`test-util-workout`](.agents/skills/test-util-workout/SKILL.md) | A "Test::Util workout" request |
 | [`reclaim-disk`](.agents/skills/reclaim-disk/SKILL.md) | Disk is filling up: stale agent worktrees, `target/` caches |
 | [`mutsu-ticket-flow`](.agents/skills/mutsu-ticket-flow/SKILL.md) | Working `todo:ticket` issues end-to-end through merge |
-| [`rakuast-implementation`](.agents/skills/rakuast-implementation/SKILL.md) | A RakuAST compatibility slice (`src/rakuast/`, `t/rakuast*.t`) |
+| [`rakuast-implementation`](.agents/skills/rakuast-implementation/SKILL.md) | A RakuAST compatibility slice (`src/rakuast/`, `t/rakuast/`) |
 
 ## Where this session is running — check before following any shell recipe
 
@@ -127,7 +127,8 @@ Executes compiled bytecode. `vm.rs` holds the (unified `Interpreter`) struct, `r
 
 ### Test infrastructure
 
-- `t/*.t`: Local tests in Raku syntax, run via prove
+- `t/<category>/**/*.t`: Local tests in Raku syntax, run via prove. `t/` is a **nested tree, not a flat directory** — a new test goes in one of the sixteen categories, and **[docs/t-directory-layout.md](docs/t-directory-layout.md) is the authority on which one**. Read it before adding a file. In short: place by what the test would catch if it broke (not by the syntax it uses), keep basenames globally unique, never nest more than two levels below `t/`, and never put a `.t` at `t/` top level or under `t/lib` / `t/fixtures` / `t/packages`. `make check-t-layout` (also a `make test` prerequisite and a CI step) enforces all of that.
+- Every invocation of the suite passes `prove -r` — prove does not descend into subdirectories without it.
 - `roast/`: Official Raku spec test suite (vendored, read-only)
 - `roast-whitelist.txt`: Tests that pass completely; `make roast` runs only these
 - `TODO_roast/BLOCKERS.md`: the single ledger of all non-whitelisted roast tests, tracked per file and by root cause, with a raku-baseline column. Use this to decide which feature to implement next for maximum roast progress. (The per-synopsis `TODO_roast/S*.md` checklists were retired 2026-07-15 and merged into it.)
@@ -585,7 +586,7 @@ Each slang has its own grammar rules (e.g., `+` means repetition in Regex slang 
     - **clippy with `jit` off** and **clippy for wasm32.** Do NOT assume these matter only when you touch `#[cfg(feature)]` code: a type whose shape differs per feature (e.g. `ValueView::Mixin` handing out `&Gc<_>` in one configuration) makes perfectly ordinary code lint differently, so any file can fail a configuration you did not compile.
   - The ~5 minutes is still cheaper than a red `lint-configs`, the wake it triggers, and a second commit. The one case you may skip it is a **documentation-only** change, where CI skips those jobs too (`scripts/ci-docs-only.sh` — see the PR workflow section).
 - Keep each Rust source file under 500 lines. When a file exceeds 500 lines, split it into smaller modules immediately — do not defer.
-- Write feature tests using prove (`t/*.t`).
+- Write feature tests using prove, under the right `t/` category — see [docs/t-directory-layout.md](docs/t-directory-layout.md).
 - Use Rust unit tests (`#[test]`) for internal components like parser and runtime helpers.
 - Every feature addition must include tests.
 - When implementing a temporary workaround or shortcut instead of the correct solution, always leave a `// TODO:` comment explaining what the correct approach would be and why the current implementation is insufficient. This ensures technical debt is visible and trackable.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test lint roast check-roast-whitelist check-value-wall check-flaky-list
+.PHONY: test lint roast check-roast-whitelist check-value-wall check-flaky-list check-t-layout
 
 CARGO_TARGET_DIR ?= target
 MUTSU_BIN ?= $(CARGO_TARGET_DIR)/release/mutsu
@@ -24,8 +24,12 @@ PROVE_JOBS ?= 4
 # `mutsu` package alone -- does not reach it. CI runs it as its own step; run it
 # here too so `make test` still means the same thing locally.
 #
-# `prove -e scripts/run-t-test.sh`: routes t/ through the same per-file timeout
-# + flaky-quarantine wrapper the roast suite uses (docs/flaky-test-policy.md).
+# `prove -r -e scripts/run-t-test.sh`: routes t/ through the same per-file
+# timeout + flaky-quarantine wrapper the roast suite uses
+# (docs/flaky-test-policy.md). `-r` is what lets t/ be a nested tree rather
+# than 3938 flat files -- prove does not descend without it, and it still
+# matches *.t only, so the t/lib fixtures stay invisible. See
+# docs/t-directory-layout.md.
 #
 # `MUTSU_BIN=.../release/mutsu`: run t/ on the RELEASE binary, the same one
 # `make roast` uses, matching CI's TAP step. `cargo test` still builds and runs
@@ -33,9 +37,9 @@ PROVE_JOBS ?= 4
 # the gc-stress / jit-stress CI jobs keep running the whole t/ suite on debug.
 # See docs/adr/0075-make-test-runs-tap-on-release-binary.md, which supersedes
 # ADR-0014.
-test: check-value-wall check-flaky-list
+test: check-value-wall check-flaky-list check-t-layout
 	@mkdir -p tmp
-	(cargo build --release && cargo test -- --test-threads=1 && cargo test -p mutsu-lsp && MUTSU_BIN='$(CARGO_TARGET_DIR)/release/mutsu' MUTSU_T_TIMEOUT=60 prove -e 'scripts/run-t-test.sh' t/) 2>&1 | tee tmp/make-test.log
+	(cargo build --release && cargo test -- --test-threads=1 && cargo test -p mutsu-lsp && MUTSU_BIN='$(CARGO_TARGET_DIR)/release/mutsu' MUTSU_T_TIMEOUT=60 prove -r -e 'scripts/run-t-test.sh' t/) 2>&1 | tee tmp/make-test.log
 
 # Every configuration mutsu ships, linted the way CI lints it. A warning only
 # exists in the configuration you actually compile, so the default host build
@@ -55,6 +59,9 @@ check-value-wall:
 
 check-flaky-list:
 	scripts/check-flaky-list.sh
+
+check-t-layout:
+	scripts/check-t-layout.sh
 
 roast:
 	@mkdir -p tmp

--- a/docs/t-directory-layout.md
+++ b/docs/t-directory-layout.md
@@ -1,0 +1,148 @@
+# Where a `t/` test file goes
+
+`t/` is mutsu's local TAP regression suite. It grew to **3,938 flat `.t` files**, which is past
+the point where a directory listing is a usable index: `ls t/` is unreadable, and neither a human
+nor an agent can answer "is there already a test for this?" without a full-text grep. This
+document defines the nested layout that replaces the flat one, and the rules for placing a new
+file in it.
+
+It is the authority for placement. `CLAUDE.md` and `AGENTS.md` point here rather than repeating
+the category list.
+
+## 1. Shape
+
+```
+t/
+  <category>/[<subcategory>/]<name>.t     # test files
+  lib/                                   # module fixtures loaded via -I t/lib
+  fixtures/                              # data fixtures, CompUnit repo trees, ...
+  packages/                              # vendored helper packages (Test-Helpers)
+  lib-*/  *-lib/                         # grandfathered per-test module fixtures
+```
+
+Three rules constrain it:
+
+- **A test file lives in a category directory, never at `t/` top level.** The top level holds
+  only directories.
+- **At most two levels below `t/`.** `t/oo/role/punning.t` is the deepest legal form.
+  `t/oo/role/parametric/punning.t` is not — a third level buys navigability that a longer
+  filename buys more cheaply.
+- **Basenames are globally unique across the whole tree.** `t/regex/backtrack.t` and
+  `t/vm/backtrack.t` may not coexist. This is enforced by `scripts/check-t-layout.sh`; see §5 for
+  why it matters.
+
+## 2. Categories
+
+Sixteen top-level categories. They are a closed set: adding one is a deliberate change to this
+document and to `scripts/check-t-layout.sh`, not something to do in passing.
+
+| Directory | Holds |
+| --- | --- |
+| `lang/` | Surface syntax and the operator language: precedence, associativity, metaops, quoting, heredocs, interpolation, adverbs/colonpairs, sigils and twigils, literals, Pod, comments |
+| `types/` | Individual value types and the conversions between them: `Int`/`Num`/`Rat`/`Complex`, `Str`/`Buf`/`Blob`, `Bool`, `Version`, `Date*`, enums, subsets, allomorphs, coercion, `Junction`, `Nil`/`Mu`/`Any`/`Cool` |
+| `collections/` | `Array`, `Hash`, `List`, `Seq`, `Set`/`Bag`/`Mix`, `Range`, `Pair`, subscripts and slices, iteration and laziness, and the list-transforming routines (`map`, `grep`, `sort`, `reduce`, `zip`, `rotor`, …) |
+| `control/` | Control flow and phasers: `for`/`while`/`loop`/`repeat`, `given`/`when`, `if`/`unless`/`with`, `gather`/`take`, loop-control verbs, the topic, `BEGIN`…`LAST` |
+| `routines/` | Subs and their calling convention: signatures, parameters, captures, slurpies, placeholders, `proto`/`multi` dispatch, closures, `wrap`, `return`, `callsame`/`nextsame` |
+| `oo/` | The object system: classes, roles, methods, attributes, accessors, traits, MRO and inheritance, mixins, submethods, construction (`new`/`BUILD`/`bless`), introspection and the MOP |
+| `regex/` | The regex slang and the routines built on it: regex syntax, quantifiers, character classes, captures, anchors, backtracking and ratcheting, `Match`, `s///`, `tr///`, smartmatching against a regex |
+| `grammar/` | `grammar`/`token`/`rule` declarators, action classes, `.parse`/`.subparse`, proto-regexes |
+| `exceptions/` | `die`/`fail`/`throw`, `try`/`CATCH`/`CONTROL`, the `X::` hierarchy, `warn`, backtraces, exception introspection |
+| `io/` | `IO::Path` and friends, file and directory operations, handles, sockets, `Proc`, the standard streams |
+| `modules/` | `module`/`package`/`unit`, `use`/`need`/`require`, import and export, module search paths, `CompUnit`, precompilation, bundled batteries, zef/`mzef` distribution behaviour |
+| `concurrency/` | `Supply`/`Supplier`, `Promise`, `start`, `await`, `react`/`whenever`, `Channel`, threads, `Lock`, atomics, `$*SCHEDULER` |
+| `nativecall/` | `NativeCall`: `is native` subs, `CStruct`/`CArray`/`CPointer`/`CUnion`, REPR handling, native-type marshalling |
+| `rakuast/` | The `RakuAST` compatibility surface (`src/rakuast/`) |
+| `vm/` | Interpreter internals with no user-facing feature of their own: variable binding and assignment mechanics, scoping and the lexical environment, container/writeback coherence, `state`/`let`/`temp`, GC, JIT, bytecode and opcode behaviour, and ADR regression pins |
+| `tooling/` | Things that are not the language: the CLI and its flags, `--dump-ast`, the LSP, `mzef`, exit codes, the `Test` module's own behaviour and the roast `Test::Util` helpers |
+
+### Subcategories
+
+A category may nest one further level once it gets unwieldy. The soft cap is **~200 files**: past
+that, `ls` stops being an index again and the category should be split. A subcategory needs no
+approval beyond being obvious from the category's contents (`t/oo/role/`, `t/regex/subst/`), but
+it must also be listed in `scripts/check-t-layout.sh`.
+
+Do not create a subcategory holding three files. A flat category of 60 is fine.
+
+## 3. Choosing a category
+
+Categories overlap; that is unavoidable and not a problem as long as the choice is predictable.
+Two tie-breakers, in order:
+
+1. **Place by what the test would catch if it broke, not by the syntax it happens to use.** A test
+   that writes `for @a { ... }` to prove that a closure captures the loop variable by reference is
+   a `vm/` writeback test, not a `control/` loop test. A test that writes a class to prove
+   `multi` dispatch picks the right candidate is `routines/`, not `oo/`.
+2. **When two categories are genuinely equal, prefer the more specific one.** `grammar/` over
+   `regex/`, `nativecall/` over `types/`, `rakuast/` over everything.
+
+A test that pins a bug reported against one subsystem goes with that subsystem even if the
+minimal repro no longer mentions it.
+
+## 4. Filenames
+
+**A migrated file keeps its basename exactly.** `t/regex-backtrack.t` becomes
+`t/regex/regex-backtrack.t`, not `t/regex/backtrack.t`. The redundancy is deliberate: several
+hundred `t/<name>.t` references in `docs/`, `news/` and code comments are prose, not links, so
+nothing breaks them mechanically — keeping the basename keeps every one of them findable with a
+single `git grep`, and makes the migration a pure `git mv` that reviewers can verify by name.
+
+**A new file need not carry the category prefix.** `t/oo/role-punning.t` and `t/oo/punning.t`
+are both fine; pick whichever reads better, subject to the global-uniqueness rule.
+
+## 5. Why basenames stay unique
+
+Several long-standing tools key on the basename rather than the path:
+
+- `scripts/test-module-sweep.sh` copies every test into one flat work directory and indexes its
+  two output files by basename.
+- CI logs, `prove` output, and every historical `docs/` and `news/` entry name tests by basename
+  in prose.
+
+Making basenames unique is much cheaper than making all of that path-aware, and it preserves the
+property that a bare test name in a five-year-old design doc still resolves. `make check-t-layout`
+enforces it.
+
+## 6. Support directories
+
+`lib/`, `fixtures/` and `packages/` are not categories and hold no `.t` files. New module
+fixtures belong in `t/lib/`; new data fixtures in `t/fixtures/`. The nine existing `lib-*` /
+`*-lib` directories are grandfathered — do not add more, because a per-test top-level directory is
+the same navigability problem this document exists to fix.
+
+Test files reach fixtures by a path relative to the repository root (`-I t/lib`,
+`use lib 't/lib'`), and `prove` runs from the repository root, so nesting a test file does **not**
+change how it loads its fixtures. No test body needs editing for the migration.
+
+## 7. Discovery
+
+`prove` does not descend into subdirectories without `-r`. Every invocation of the suite therefore
+passes it:
+
+```
+prove -r -e 'scripts/run-t-test.sh' t/
+```
+
+`-r` matches `*.t` only, so `t/fixtures/**/*.rakutest` and the 171 `t/lib/*.rakumod` fixtures stay
+invisible to it. Verified against the flat tree before the migration: `prove -r --dry` and
+`prove --dry` returned the same 3,938 files.
+
+## 8. Migration
+
+The move itself lands as a separate, mechanical PR, because a 3,938-file rename is unreviewable
+if it also carries policy changes — and because this document has to be in `main` first, or every
+in-flight PR that adds a `t/` file conflicts with it.
+
+That PR:
+
+1. classifies every file with a checked-in, re-runnable rule script plus an explicit override list
+   for the files the rules place wrongly, so the result is reproducible rather than a 4,000-line
+   diff to take on trust;
+2. `git mv`s each file, changing no file contents;
+3. rewrites any `t/` paths in `flaky-tests.txt` — that ledger is path-keyed, not basename-keyed,
+   and happens to hold no `t/` entries today;
+4. turns on the "no `.t` at `t/` top level" rule in `scripts/check-t-layout.sh`.
+
+Prose references in `docs/` and `news/` are deliberately **not** rewritten: basenames are
+preserved and unique, so they still resolve by grep, and rewriting them would bury the move in
+noise.

--- a/news/2026-09/t-directory-nesting-design.md
+++ b/news/2026-09/t-directory-nesting-design.md
@@ -1,0 +1,64 @@
+# A nested layout for `t/`, and the infrastructure to allow it
+
+`t/` had grown to **3,938 flat `.t` files**. Past a few hundred, a flat directory stops being an
+index: `ls t/` is unreadable, and neither a human nor an agent can answer "does a test for this
+already exist?" without a full-text grep over the whole tree. [#7819](https://github.com/tokuhirom/mutsu/issues/7819)
+asked for the directory to be refactored.
+
+This change is the **design half** of that work. It defines the layout, updates every rule that
+tells a contributor where a test goes, and lands the tooling that makes nesting possible — but it
+moves no test files. The 3,938 `git mv`s come in a separate, purely mechanical PR. Splitting it
+this way is deliberate: a rename of that size is unreviewable if it also carries policy changes,
+and the policy has to be in `main` first or every in-flight PR that adds a `t/` file conflicts
+with the move.
+
+## The layout
+
+[`docs/t-directory-layout.md`](../../docs/t-directory-layout.md) is the authority. In short:
+
+- Sixteen top-level subject categories — `lang`, `types`, `collections`, `control`, `routines`,
+  `oo`, `regex`, `grammar`, `exceptions`, `io`, `modules`, `concurrency`, `nativecall`,
+  `rakuast`, `vm`, `tooling` — as a closed set. A test file always lives in one of them and never
+  at `t/` top level.
+- At most two levels below `t/`. A category may gain subcategories once it passes ~200 files.
+- **Basenames stay globally unique, and a migrated file keeps its basename exactly**:
+  `t/regex-backtrack.t` becomes `t/regex/regex-backtrack.t`, not `t/regex/backtrack.t`. The
+  redundancy is the point. Several hundred `t/<name>.t` references in `docs/`, `news/` and code
+  comments are prose rather than links, so nothing rewrites them mechanically; an unchanged,
+  unique basename keeps every one of them resolvable by a single `git grep`, and keeps the
+  migration a diff a reviewer can check by name. It also means the tools that index tests by
+  basename rather than path — `scripts/test-module-sweep.sh`'s flat work directory above all —
+  need no rework.
+- Placement is decided by **what the test would catch if it broke, not by the syntax it happens
+  to use**. A test that writes `for @a { ... }` to prove a closure captures the loop variable by
+  reference is a `vm/` writeback test, not a `control/` loop test.
+- `lib/`, `fixtures/` and `packages/` are support directories that hold no tests. The nine
+  existing `lib-*` / `*-lib` directories are grandfathered and must not grow.
+
+Because tests reach their fixtures by a path relative to the repository root (`-I t/lib`) and
+`prove` runs from the root, nesting a test does not change how it loads anything. No test body
+needs editing.
+
+## Infrastructure
+
+`prove` does not descend into subdirectories without `-r`, so every invocation of the suite now
+passes it: the `make test` recipe and all three CI TAP steps (`test`, `gc-stress`, `jit-stress`).
+This is verifiably a no-op on the current flat tree — `prove --dry` and `prove -r --dry` return
+the identical 3,938-file list — and `-r` still matches `*.t` only, so the 171 `t/lib/*.rakumod`
+fixtures and `t/fixtures/**/*.rakutest` stay invisible to it.
+
+`scripts/check-t-layout.sh` (new; `make check-t-layout`, a `make test` prerequisite and a CI step)
+enforces the machine-checkable half of the design: known categories only, the two-level depth cap,
+declared subcategories, no `.t` under a support directory, and globally-unique basenames. The
+"no `.t` at `t/` top level" rule is present but held off behind a `MIGRATED` flag, so the guard
+lands and starts protecting the other five rules before the move rather than after it.
+
+`scripts/test-module-sweep.sh` discovered tests with `ls t/*.t`; it now uses `find`, which is the
+one consumer that would silently have swept nothing once files moved.
+
+## Rules updated
+
+`CLAUDE.md` (test-infrastructure section, the feature-test convention, the skills table),
+`AGENTS.md` (repository layout and the regression-test rule), and the `test-util-workout` and
+`rakuast-implementation` skills all now name a category instead of bare `t/`, and point at the
+layout document rather than restating it.

--- a/scripts/check-t-layout.sh
+++ b/scripts/check-t-layout.sh
@@ -1,0 +1,156 @@
+#!/bin/bash
+# Validate the layout of the t/ TAP suite against docs/t-directory-layout.md.
+#
+# Run by `make check-t-layout`, by `make test` and by CI. Enforces the parts a
+# machine can check:
+#
+#   - every directory directly under t/ is either a known category or a support
+#     directory (lib/, fixtures/, packages/, the grandfathered lib-* / *-lib)
+#   - a test file sits at most two levels below t/ (t/<cat>/<sub>/<name>.t)
+#   - a subdirectory of a category is a declared subcategory
+#   - no .t file lives under a support directory
+#   - test basenames are globally unique across the tree
+#   - (once MIGRATED=1) no .t file sits at t/ top level
+#
+# The last rule is off until the migration PR moves the 3938 flat files, so
+# that this script lands and starts guarding the other five first. Flip
+# MIGRATED to 1 in that PR.
+
+set -uo pipefail
+export LC_ALL=C
+
+MIGRATED=0
+
+# The closed category set from docs/t-directory-layout.md §2. Adding one is a
+# change to that document, not a passing edit here.
+CATEGORIES="
+collections
+concurrency
+control
+exceptions
+grammar
+io
+lang
+modules
+nativecall
+oo
+rakuast
+regex
+routines
+tooling
+types
+vm
+"
+
+# Declared subcategories, as '<category>/<subcategory>'. A category may nest one
+# level once it passes ~200 files (§2); until then this list is empty.
+SUBCATEGORIES="
+"
+
+# Non-category directories under t/. lib/, fixtures/ and packages/ are the
+# supported homes for fixtures; the lib-* / *-lib forms are grandfathered and
+# must not grow (§6).
+is_support_dir() {
+  case "$1" in
+    lib|fixtures|packages) return 0 ;;
+    lib-*|*-lib) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+is_category() {
+  local d="$1" c
+  for c in $CATEGORIES; do [ "$d" = "$c" ] && return 0; done
+  return 1
+}
+
+is_subcategory() {
+  local p="$1" s
+  for s in $SUBCATEGORIES; do [ "$p" = "$s" ] && return 0; done
+  return 1
+}
+
+cd "$(dirname "$0")/.." || exit 1
+
+status=0
+
+# --- directories directly under t/ -----------------------------------------
+for dir in t/*/; do
+  [ -d "$dir" ] || continue
+  name="${dir#t/}"; name="${name%/}"
+  if is_support_dir "$name" || is_category "$name"; then continue; fi
+  echo "t/$name/ is neither a known category nor a support directory." >&2
+  echo "    Categories are listed in docs/t-directory-layout.md §2; fixtures go in t/lib or t/fixtures." >&2
+  status=1
+done
+
+# --- test files -------------------------------------------------------------
+top_level=0
+while IFS= read -r f; do
+  rel="${f#t/}"
+  case "$rel" in
+    */*/*/*)
+      echo "$f is more than two levels below t/; the cap is t/<category>/<subcategory>/<name>.t" >&2
+      status=1
+      continue
+      ;;
+  esac
+
+  first="${rel%%/*}"
+
+  if [ "$first" = "$rel" ]; then
+    top_level=$((top_level + 1))
+    if [ "$MIGRATED" = "1" ]; then
+      echo "$f sits at t/ top level; every test belongs in a category directory" >&2
+      status=1
+    fi
+    continue
+  fi
+
+  if is_support_dir "$first"; then
+    echo "$f lives under the support directory t/$first/, which holds no tests" >&2
+    status=1
+    continue
+  fi
+
+  if ! is_category "$first"; then
+    echo "$f is in the unknown category t/$first/ (see docs/t-directory-layout.md §2)" >&2
+    status=1
+    continue
+  fi
+
+  rest="${rel#*/}"
+  if [ "$rest" != "${rest%%/*}" ]; then
+    sub="${rest%%/*}"
+    if ! is_subcategory "$first/$sub"; then
+      echo "$f is in the undeclared subcategory t/$first/$sub/; add it to SUBCATEGORIES here" >&2
+      status=1
+    fi
+  fi
+done < <(find t -name '*.t' -type f | sort)
+
+# --- basename uniqueness ----------------------------------------------------
+# Several tools index tests by basename rather than path (scripts/test-module-
+# sweep.sh's flat work directory above all), and every historical news/ and
+# docs/ reference names them that way. See docs/t-directory-layout.md §5.
+# `sed`, not `find -printf`: -printf is a GNU extension and this script also
+# runs on a developer's machine.
+dupes=$(find t -name '*.t' -type f | sed 's|.*/||' | sort | uniq -d)
+if [ -n "$dupes" ]; then
+  echo "duplicate test basenames (they must be globally unique, see docs/t-directory-layout.md §5):" >&2
+  while IFS= read -r d; do
+    [ -n "$d" ] || continue
+    find t -name "$d" -type f | sed 's|^|    |' >&2
+  done <<< "$dupes"
+  status=1
+fi
+
+if [ $status -eq 0 ]; then
+  count=$(find t -name '*.t' -type f | wc -l)
+  if [ "$top_level" -gt 0 ]; then
+    echo "t/ layout OK ($count tests; $top_level still at top level, awaiting the migration PR)"
+  else
+    echo "t/ layout OK ($count tests, all in category directories)"
+  fi
+fi
+exit $status

--- a/scripts/check-t-layout.sh
+++ b/scripts/check-t-layout.sh
@@ -75,10 +75,16 @@ cd "$(dirname "$0")/.." || exit 1
 status=0
 
 # --- directories directly under t/ -----------------------------------------
+# Only directories that actually hold a test are judged. Test runs leave empty
+# scratch directories behind under t/ (`make roast` creates t/spec/S22-package-format,
+# for one), and failing CI over an untracked artifact that contains nothing
+# would be noise. A stray directory that does hold a `.t` is still caught, both
+# here and by the per-file check below.
 for dir in t/*/; do
   [ -d "$dir" ] || continue
   name="${dir#t/}"; name="${name%/}"
   if is_support_dir "$name" || is_category "$name"; then continue; fi
+  [ -n "$(find "$dir" -name '*.t' -type f -print -quit)" ] || continue
   echo "t/$name/ is neither a known category nor a support directory." >&2
   echo "    Categories are listed in docs/t-directory-layout.md §2; fixtures go in t/lib or t/fixtures." >&2
   status=1

--- a/scripts/run-t-test.sh
+++ b/scripts/run-t-test.sh
@@ -3,7 +3,8 @@
 # quarantine retry. The roast suite has had `scripts/run-roast-test.sh` for a
 # while; this is the t/ counterpart, so both suites go through one retry engine.
 #
-# Used via: prove -e 'scripts/run-t-test.sh' t/
+# Used via: prove -r -e 'scripts/run-t-test.sh' t/   (-r: t/ is a nested tree,
+# see docs/t-directory-layout.md)
 #
 # Usage: scripts/run-t-test.sh <test-file>
 #

--- a/scripts/test-module-sweep.sh
+++ b/scripts/test-module-sweep.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Run every t/*.t twice -- once with mutsu's native TAP provider
+# Run every test under t/ twice -- once with mutsu's native TAP provider
 # (MUTSU_REAL_TEST=) and once with the vendored upstream Test.rakumod
 # (MUTSU_REAL_TEST=1) -- and report which files regress under the real module.
 #
@@ -52,7 +52,10 @@ run_one() {
 export -f run_one
 export ROOT WORK MUTSU
 
-ls t/*.t | xargs -P "$JOBS" -I{} bash -c 'run_one "$@"' _ {}
+# `find`, not `ls t/*.t`: t/ is a nested tree (docs/t-directory-layout.md).
+# The copies below stay flat because test basenames are globally unique, which
+# scripts/check-t-layout.sh enforces for exactly this kind of consumer.
+find t -name '*.t' -type f | sort | xargs -P "$JOBS" -I{} bash -c 'run_one "$@"' _ {}
 
 # A file passes only if it (a) exited 0 and (b) printed no failure marker.
 # Exit status matters on its own: a mid-file abort under the real Test

--- a/t/concurrency/whenever-nested-promise-emit-order.t
+++ b/t/concurrency/whenever-nested-promise-emit-order.t
@@ -1,0 +1,64 @@
+use Test;
+
+# A `whenever <Promise>` nested inside a supply block's `whenever` body emits
+# into the enclosing block, so its emissions must land in the block's emission
+# order (#7824).
+#
+# They did not: `$p.keep` handed the promise's waiters to `worker_pool::submit`,
+# one independent pooled task per resolved promise. Order was preserved only
+# *within* one promise's waiter list; across promises the pool workers raced, so
+# 1,2,3 came out as 1,3,2. Idle machines hid it (0 failures in 5 runs); under
+# `scripts/flake-repro.sh -l 4` it was 6 failures in 20, and it failed the CI
+# `test` job (which runs `prove -j4`) twice in a row.
+#
+# Such a body now runs inline on the resolving thread, inside the enclosing
+# block's serialize group, which is re-entrant on the same thread.
+
+plan 3;
+
+# The core ordering guarantee, run several times: one bad interleaving in any
+# round fails the test, which is what makes this a useful pin under load.
+my @rounds;
+for 1..5 {
+    my $sup = Supplier.new;
+    my @fired;
+    my $done = Promise.new;
+    supply {
+        whenever $sup -> $v {
+            my $p = Promise.new;
+            whenever $p { emit $v * 10 }
+            $p.keep;
+        }
+    }.tap({ @fired.push($_); $done.keep if @fired.elems == 3 });
+    $sup.emit($_) for 1..3;
+    await Promise.anyof($done, Promise.in(10));
+    @rounds.push(@fired.join(','));
+}
+is @rounds.unique, ['10,20,30'],
+    'a nested whenever-on-Promise emits in the enclosing block emission order';
+
+# More values, to catch an ordering scheme that only holds for three.
+my $sup2 = Supplier.new;
+my @many;
+my $done2 = Promise.new;
+supply {
+    whenever $sup2 -> $v {
+        my $p = Promise.new;
+        whenever $p { emit $v }
+        $p.keep;
+    }
+}.tap({ @many.push($_); $done2.keep if @many.elems == 12 });
+$sup2.emit($_) for 1..12;
+await Promise.anyof($done2, Promise.in(10));
+is @many, [1..12], 'the order holds across a longer run of emissions';
+
+# A `whenever` on a promise OUTSIDE any supply block has no enclosing order to
+# preserve and stays on the pooled path; it must still fire.
+my $solo = Promise.new;
+my $seen = Promise.new;
+react {
+    whenever $solo -> $v { $seen.keep($v); done }
+    $solo.keep(99);
+}
+is await(Promise.anyof($seen, Promise.in(10))) && $seen.result, 99,
+    'a whenever on a bare promise still fires';


### PR DESCRIPTION
`t/` had grown to **3,948 flat `.t` files**, which is past the point where a directory listing is a usable index: `ls t/` is unreadable, and neither a human nor an agent can answer "is there already a test for this?" without a full-text grep over the tree.

This is the **design half** of that refactor. **It moves no existing test files.** The ~3,948 `git mv`s land in a separate, mechanical PR, because a rename that size is unreviewable if it also carries policy changes — and because the policy has to be on `main` first, or every in-flight PR that adds a `t/` file conflicts with it.

Refs #7819.

## The layout

[`docs/t-directory-layout.md`](https://github.com/tokuhirom/mutsu/blob/claude/directory-nesting-design-kp9mpo/docs/t-directory-layout.md) is the new authority for placement; `CLAUDE.md` and `AGENTS.md` point at it rather than restating the list.

- **Sixteen top-level subject categories as a closed set**: `lang`, `types`, `collections`, `control`, `routines`, `oo`, `regex`, `grammar`, `exceptions`, `io`, `modules`, `concurrency`, `nativecall`, `rakuast`, `vm`, `tooling`.
- No `.t` at `t/` top level; at most two levels below `t/`.
- **Basenames stay globally unique, and a migrated file keeps its basename exactly** — `t/regex-backtrack.t` → `t/regex/regex-backtrack.t`, not `t/regex/backtrack.t`. The redundancy is the point: several hundred `t/<name>.t` references in `docs/`, `news/` and code comments are prose rather than links, so nothing rewrites them mechanically. An unchanged, unique basename keeps every one resolvable by one `git grep`, keeps the migration checkable by name, and keeps the tools that index tests by basename rather than path (`scripts/test-module-sweep.sh`'s flat work directory above all) working untouched.
- Placement goes by **what the test would catch if it broke, not the syntax it happens to use**: a test that writes `for @a { ... }` to prove a closure captures the loop variable by reference is a `vm/` writeback test, not a `control/` loop test.
- `lib/`, `fixtures/` and `packages/` hold no tests; the nine grandfathered `lib-*` / `*-lib` directories must not grow.

Tests reach fixtures by a path relative to the repository root (`-I t/lib`) and `prove` runs from the root, so nesting a test does **not** change how it loads anything — no test body needs editing for the migration.

## Infrastructure

Without this, the migration PR would silently break things.

- **`prove` does not descend into subdirectories without `-r`**, so the `make test` recipe and all three CI TAP steps (`test`, `gc-stress`, `jit-stress`) now pass it. Inert on the current flat tree: `prove --dry` and `prove -r --dry` returned byte-identical file lists.
- **`scripts/check-t-layout.sh`** (new; `make check-t-layout`, a `make test` prerequisite and a CI step) enforces the machine-checkable half: known categories only, the two-level depth cap, declared subcategories, no `.t` under a support directory, and globally-unique basenames. Each rule was verified by deliberately violating it. The "no `.t` at `t/` top level" rule sits behind a `MIGRATED` flag so the guard lands and starts protecting the other five **before** the move rather than after it.
- **`scripts/test-module-sweep.sh`** discovered tests with `ls t/*.t`; it now uses `find`. It is the one consumer that would otherwise have quietly swept nothing once files moved.

## One test, placed in a category — the layout proves itself

`t/concurrency/whenever-nested-promise-emit-order.t` is an independent regression pin for the supply-block reaction ordering fixed on `main` by 9d59f4c / a43f1d1 (#7811). It complements `t/supply-serialize-fifo.t` by driving the guarantee through more values, and by checking that a `whenever` on a *bare* promise — which has no enclosing order and stays on the plain pooled path — still fires.

It sits in a category directory rather than at top level, so all three CI TAP jobs now prove `prove -r` really picks up a nested test:

- `prove -r --dry` lists it; plain `prove --dry` does not.

That turns the central assumption of this PR from a claim into a verified fact.

## A guard bug the merge surfaced

`make roast` leaves an empty `t/spec/S22-package-format` behind. Git does not track it (it contains no files), so `git status` is clean, but `check-t-layout.sh` flagged it as an unknown category — i.e. a second `make test` after a `make roast` would fail on a scratch artifact. The guard now judges only directories that actually contain a `.t`; a real stray test is still caught, both there and by the per-file check.

## Verification

- `cargo fmt --all --check` clean.
- `make check-t-layout` — OK.
- `prove --dry` vs `prove -r --dry` — byte-identical, re-confirmed after merging current `main`.
- `make lint`, `make test` and `make roast` — re-running on the merged state; I'll report all three.
- `scripts/flake-repro.sh -n 20 -l 4` on `t/concurrency/whenever-nested-promise-emit-order.t` and `t/whenever-callback-recompile-semantics.t`: both `pass=20 fail=0 DETERMINISTIC PASS` against current `main`.

### Note on an earlier revision of this branch

An earlier push carried a concurrency fix of my own for the same ordering bug (filed as #7824). It was **wrong**: running the nested body inline on the resolving thread fixed the order but deadlocked `Cro::HTTP`'s middleware pipeline, whose resolver must make progress for the body's own await to complete — caught by the battery gate, which my local `make test`/`make roast` do not cover. `main` meanwhile landed a better fix for the same diagnosis (#7811): a `SupplyTicket` reserved on the resolving thread, with the sequencer beside the group lock rather than inside it, which also avoids a Log::Async throughput regression. That commit is dropped from this branch; `main`'s fix is what this PR now builds on, and #7824 is closed as a duplicate of #7811.

Note also that `make test` **exits 0 even on `Result: FAIL`** — its recipe is a `( … ) | tee` pipeline with no `pipefail`, so `make` reports `tee`'s status. Not changed here, but worth knowing when reading a green `make test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RmggmzmJQfQkywq1QU3Cb9