### PR TITLE
fix: a parametric role with named parameters can be instantiated

### DIFF
--- a/news/2026-09/parametric-role-named-parameters.md
+++ b/news/2026-09/parametric-role-named-parameters.md
@@ -1,0 +1,62 @@
+# A parametric role with named parameters can be instantiated
+
+`role R[Str:D :$v] { method x { $v } }` composed as `C.new but R[:v<hi>]`
+died with `No matching candidate found for the parametric role` — a role
+parameterised by a **named** parameter never matched, so neither `but
+R[:v(...)]` nor `does R[:v(...)]` worked, while a positional parameter
+(`role R2[::T]`, `role R3[$v]`) bound fine.
+
+Two separate bugs, both rooted in the same place: a `[...]` bracket used to
+parameterise a role is structurally a call's argument list, and Rakudo
+decides an argument's named-ness from call-site *syntax* (colon-pair vs.
+`=>`), not from the flavour of `Pair` the expression happens to evaluate to
+(ADR-0021) — a function call already normalizes this at the call boundary,
+but a subscript's bracket content never did.
+
+1. **Candidate matching never saw the named argument.** `:v<hi>` inside
+   `R[...]` parses to the same bare `Binary{FatArrow}` AST node a colon-pair
+   always does (verified via `--dump-ast`; an explicit `R["v" => "hi"]`
+   parses to a distinguishing `PositionalPair(...)` wrapper instead). But
+   `Expr::Index`'s bracket content was compiled through the fully generic
+   `compile_expr`, which emits the data-default `MakePair` for any bare
+   `Binary{FatArrow}` — producing a `ValuePair`, invisible to
+   `role_candidate_arity_ok`'s named-argument scan (`is_string_pair_value`).
+   The role's only candidate then looked like it took one *positional*
+   argument it never got, and matching failed outright.
+
+   Fixed in `Compiler::compile_subscript_index`
+   (`src/compiler/expr_data.rs`): a bare `Binary{FatArrow}` index (or a
+   comma-list containing one) now mints the named `Pair` flavour via
+   `mint_named_pair`/`OpCode::MakeNamedArg`, the same mechanism a function
+   call's argument-list compile already uses for `f(:v<hi>)`. Verified this
+   doesn't change Rakudo's own distinction: `R["v" => "hi"]` (an explicit
+   arrow, wrapped in `PositionalPair` by the parser) still fails to match,
+   exactly like Rakudo.
+
+2. **Even once matching succeeded, the bound value was wrong.**
+   `compose_role_on_value` (`src/runtime/types/roles.rs`) built the role's
+   per-parameter env bindings with `param_names.iter().zip(role_args.iter())`
+   — a raw positional zip over the *original*, unresolved call-site
+   arguments. For `R[:v<hi>]` that is call-site order (one `Pair`), not the
+   value `resolve_role_candidate_with_args` had already correctly bound by
+   name via `bind_function_args_values`. `$v` inside the role body ended up
+   holding the whole `v => "hi"` Pair instead of `"hi"`.
+
+   Fixed by reusing `resolve_role_candidate_with_args`'s own resolved
+   per-parameter values (the third element of its returned tuple) for this
+   zip, falling back to the raw `role_args` only when no candidate list
+   exists (a role with one unconditional definition, where the order is
+   already positional by construction).
+
+Verified against `raku`: the repro, the `does` spelling (no sink-context
+warning), a `:v(...)` colon-pair-with-parens form, a mixed
+positional+named role signature, both positional-parameter controls,
+Rakudo's own explicit-arrow-does-not-bind-named behavior, a plain
+positional comma-list role (unaffected by the named-detection), and plain
+array/hash subscripts (unaffected by the shared compiler change). Pinned by
+`t/issue-7757-parametric-role-named-params.t`. All 73 existing
+`t/*role*`/`t/*parametric*`/`t/*does*` files (667 assertions) and all 131
+existing `t/*index*`/`t/*subscript*`/`t/*colonpair*`/`t/*pair*` files (1476
+assertions) continue to pass unchanged.
+
+Closes #7757.

--- a/src/compiler/expr_data.rs
+++ b/src/compiler/expr_data.rs
@@ -605,7 +605,50 @@ impl Compiler {
         self.bind_terminal = false;
         let saved_decl_bind = self.decl_bind_terminal;
         self.decl_bind_terminal = false;
-        self.compile_expr(index);
+
+        match index {
+            // A bare colon-pair/fat-arrow index (`R[:v<hi>]`) is a role
+            // parameterization's NAMED type argument — Rakudo decides
+            // named-ness from call-site SYNTAX, not from what flavour of
+            // Pair the expression happens to evaluate to (ADR-0021), and a
+            // subscript's bracket content is exactly a call's argument list
+            // for this purpose. The generic `compile_expr` below (reached
+            // for anything that isn't this shape) emits the data-default
+            // `MakePair` (`ValuePair`), which `role_candidate_arity_ok`'s
+            // named-argument scan cannot see — `role R[Str:D :$v]`'s only
+            // candidate then looked like it took one POSITIONAL argument,
+            // never matched, and `but R[:v<hi>]` died "No matching
+            // candidate". Mint the named flavour here, the same way a
+            // function call's argument-list compile does for `f(:v<hi>)`.
+            Expr::Binary { op, .. } if *op == TokenKind::FatArrow => {
+                self.mint_named_pair = true;
+                self.compile_expr(index);
+            }
+            // A comma list of type arguments (`R[Int, :v<hi>]`) needs the
+            // same per-element treatment. The generic `Expr::ArrayLiteral`
+            // compile has no per-element "mint this one as named" hook, and
+            // role type-arguments are pure values (never lvalue containers),
+            // so a minimal element loop — mint the flag right before each
+            // qualifying item, `compile_expr`, then the same `MakeArray` the
+            // generic path ends with — is enough; the container-aliasing
+            // machinery (`WrapVarRef`, rw-arg-callee marking) that path also
+            // does is irrelevant here and deliberately skipped.
+            Expr::ArrayLiteral(items)
+                if items.iter().any(
+                    |item| matches!(item, Expr::Binary { op, .. } if *op == TokenKind::FatArrow),
+                ) =>
+            {
+                for item in items {
+                    if matches!(item, Expr::Binary { op, .. } if *op == TokenKind::FatArrow) {
+                        self.mint_named_pair = true;
+                    }
+                    self.compile_expr(item);
+                }
+                self.code.emit(OpCode::MakeArray(items.len() as u32));
+            }
+            _ => self.compile_expr(index),
+        }
+
         self.scalar_bind_autovivify = saved_av;
         self.bind_terminal = saved_terminal;
         self.decl_bind_terminal = saved_decl_bind;

--- a/src/runtime/types/roles.rs
+++ b/src/runtime/types/roles.rs
@@ -629,6 +629,15 @@ impl Interpreter {
         // `role W[::T, ::U]` bind different lists, and `role_type_params` records
         // only one of them per name.
         let candidate_type_params = resolved.as_ref().map(|(_, names, _)| names.clone());
+        // The candidate's per-parameter VALUES, already bound by name (not by
+        // position) via `bind_function_args_values` inside
+        // `resolve_role_candidate_with_args` — required for a named type
+        // parameter (`role R[Str:D :$v]`), whose value is not `role_args[i]`
+        // at all: `role_args` is call-site order, and for `R[:v<hi>]` that
+        // order holds one Pair, not the unwrapped `"hi"`. Falls back to the
+        // raw `role_args` only when resolution did not run (no candidate
+        // list, i.e. a role with a single unconditional definition).
+        let resolved_type_arg_values = resolved.as_ref().map(|(_, _, values)| values.clone());
         let role = match &resolved {
             Some((role_def, _, _)) => Some(role_def.clone()),
             None => self.registry().roles.get(role_name).cloned(),
@@ -736,7 +745,12 @@ impl Interpreter {
                     .cloned()
                     .unwrap_or_default()
             });
-            for (param_name, type_arg) in param_names.iter().zip(role_args.iter()) {
+            // `resolved_type_arg_values` (name-bound) when a candidate was
+            // resolved; `role_args` (call-site order) only as a fallback for
+            // the no-candidate-list case, where every parameter is positional
+            // by construction and the order already matches.
+            let type_arg_values = resolved_type_arg_values.as_deref().unwrap_or(role_args);
+            for (param_name, type_arg) in param_names.iter().zip(type_arg_values.iter()) {
                 mixins.insert(
                     format!("__mutsu_role_param__{}", param_name),
                     type_arg.clone(),

--- a/t/issue-7757-parametric-role-named-params.t
+++ b/t/issue-7757-parametric-role-named-params.t
@@ -1,0 +1,75 @@
+use Test;
+
+# A role parameterised by NAMED parameters never matched, so neither
+# `but R[:v(...)]` nor `does R[:v(...)]` worked.
+# See https://github.com/tokuhirom/mutsu/issues/7757
+plan 10;
+
+role R[Str:D :$v] { method x { $v } };
+
+# --- the repro ---
+{
+    class C {};
+    my $c = C.new but R[:v<hi>];
+    is $c.x, 'hi', 'but R[:v<hi>] binds the named role parameter';
+}
+
+# --- the does spelling, with no sink-context warning ---
+{
+    class D does R[:v<hi>] {};
+    is D.new.x, 'hi', 'does R[:v<hi>] binds the named role parameter too';
+}
+
+# --- named-only, via a colon-pair-syntax with parens ---
+{
+    role RP[Str:D :$v] { method x { $v } };
+    class E {};
+    is (E.new but RP[:v('paren')]).x, 'paren', ':v(...) colonpair form binds too';
+}
+
+# --- mixed positional + named role signature ---
+{
+    role Mixed[Str:D $pos, Int:D :$n] { method y { "$pos-$n" } };
+    class M {};
+    is (M.new but Mixed["a", :n(3)]).y, 'a-3',
+        'mixed positional+named role parameters bind correctly';
+}
+
+# --- controls that were already correct must stay correct ---
+{
+    role R2[::T] { method x { T.^name } };
+    class C2 {};
+    is (C2.new but R2[Int]).x, 'Int', 'positional type-capture role parameter is unaffected';
+}
+{
+    role R3[$v] { method x { $v } };
+    class C3 {};
+    is (C3.new but R3["hi"]).x, 'hi', 'positional value role parameter is unaffected';
+}
+
+# --- an explicit fat-arrow is data, not a named argument (matches Rakudo:
+# a Pair VALUE passed positionally does not bind a role's named parameter) ---
+{
+    class F {};
+    dies-ok { F.new but R[ 'v' => 'hi' ] },
+        'an explicit fat-arrow Pair does not bind as a named role parameter';
+}
+
+# --- a comma list of positional type args is still a single ArrayLiteral
+# compile path and must be unaffected by the named-arg detection ---
+{
+    role NoNamed[$a, $b] { method x { "$a,$b" } };
+    class G {};
+    is (G.new but NoNamed[1, 2]).x, '1,2', 'a plain positional comma-list role arg list is unaffected';
+}
+
+# --- ordinary array/hash subscripts (unrelated to roles) stay unaffected
+# by the compiler change to subscript-index compilation ---
+{
+    my @a = (1, 2, 3);
+    is @a[1], 2, 'plain array subscript is unaffected';
+    my %h = (a => 1, b => 2);
+    is %h<a>, 1, 'plain hash subscript is unaffected';
+}
+
+done-testing;


### PR DESCRIPTION
## Summary

`role R[Str:D :$v] { method x { $v } }` composed as `C.new but R[:v<hi>]` died with `No matching candidate found for the parametric role` — a role parameterised by a **named** parameter never matched, so neither `but R[:v(...)]` nor `does R[:v(...)]` worked, while a positional parameter (`role R2[::T]`, `role R3[$v]`) bound fine.

Two separate bugs, both rooted in the same place: a `[...]` bracket used to parameterise a role is structurally a call's argument list, and Rakudo decides an argument's named-ness from call-site *syntax* (colon-pair vs. `=>`), not from the flavour of `Pair` the expression happens to evaluate to (ADR-0021) — a function call already normalizes this at the call boundary, but a subscript's bracket content never did.

1. **Candidate matching never saw the named argument.** `:v<hi>` inside `R[...]` parses to the same bare `Binary{FatArrow}` AST node a colon-pair always does (verified via `--dump-ast`; an explicit `R["v" => "hi"]` parses to a distinguishing `PositionalPair(...)` wrapper instead). But `Expr::Index`'s bracket content was compiled through the fully generic `compile_expr`, which emits the data-default `MakePair` for any bare `Binary{FatArrow}` — producing a `ValuePair`, invisible to `role_candidate_arity_ok`'s named-argument scan (`is_string_pair_value`). The role's only candidate then looked like it took one *positional* argument it never got, and matching failed outright.

   Fixed in `Compiler::compile_subscript_index` (`src/compiler/expr_data.rs`): a bare `Binary{FatArrow}` index (or a comma-list containing one) now mints the named `Pair` flavour via `mint_named_pair`/`OpCode::MakeNamedArg`, the same mechanism a function call's argument-list compile already uses for `f(:v<hi>)`. Verified this doesn't change Rakudo's own distinction: `R["v" => "hi"]` (an explicit arrow, wrapped in `PositionalPair` by the parser) still fails to match, exactly like Rakudo.

2. **Even once matching succeeded, the bound value was wrong.** `compose_role_on_value` (`src/runtime/types/roles.rs`) built the role's per-parameter env bindings with `param_names.iter().zip(role_args.iter())` — a raw positional zip over the *original*, unresolved call-site arguments. For `R[:v<hi>]` that is call-site order (one `Pair`), not the value `resolve_role_candidate_with_args` had already correctly bound by name via `bind_function_args_values`. `$v` inside the role body ended up holding the whole `v => "hi"` Pair instead of `"hi"`.

   Fixed by reusing `resolve_role_candidate_with_args`'s own resolved per-parameter values (the third element of its returned tuple) for this zip, falling back to the raw `role_args` only when no candidate list exists (a role with one unconditional definition, where the order is already positional by construction).

## Test plan

- [x] New `t/issue-7757-parametric-role-named-params.t`, verified against both `target/debug/mutsu` and `raku` — the repro, the `does` spelling (no sink-context warning), a `:v(...)` colon-pair-with-parens form, a mixed positional+named role signature, both positional-parameter controls, Rakudo's own explicit-arrow-does-not-bind-named behavior, a plain positional comma-list role (unaffected by the named-detection), and plain array/hash subscripts (unaffected by the shared compiler change) all match.
- [x] All 73 existing `t/*role*`/`t/*parametric*`/`t/*does*` files (667 assertions) continue to pass unchanged.
- [x] All 131 existing `t/*index*`/`t/*subscript*`/`t/*colonpair*`/`t/*pair*` files (1476 assertions) continue to pass unchanged.
- [x] `cargo fmt --all`
- [x] `make lint` — clean (default clippy, `jit`-off clippy, wasm32 clippy, rustdoc)
- [x] `make test` — one flaky failure investigated: `t/whenever-callback-recompile-semantics.t` test 5 (`Promise.anyof` async timing race) fails intermittently and passes on retry; unrelated to this diff (role/compiler code, no concurrency touched).
- [x] `make roast` — the only failures are the three known remote-container environment-only files (`roast/6.c/S32-io/file-tests.t`, `roast/S16-filehandles/filetest.t`, `roast/S32-io/IO-Socket-Async.t`), matching `docs/agent-environments.md` by name and subtest range exactly.

Closes #7757

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5YdUpBfVMSGjEwVvGwUg7

---
_Generated by [Claude Code](https://claude.ai/code/session_01M5YdUpBfVMSGjEwVvGwUg7)_