### PR TITLE
fix: destructure named sub-signature parameters

### DIFF
--- a/news/2026-09/named-sub-signature-destructure.md
+++ b/news/2026-09/named-sub-signature-destructure.md
@@ -1,0 +1,6 @@
+# Fix named parameter sub-signature destructuring
+
+Named aggregate parameters with sub-signatures now destructure their values
+correctly, including inner positional and named slurpies. Destructured slurpies
+are bound as `Array` values, and custom `trait_mod` handlers receive the same
+correct bindings.

--- a/src/runtime/types/binding_signature.rs
+++ b/src/runtime/types/binding_signature.rs
@@ -1785,7 +1785,29 @@ impl Interpreter {
                         // leaf variable is bound via the rename recursion below.
                         // Mirrors `bind_sub_signature_from_value`'s line-778 rule.
                         if let Some(sub_params) = &pd.sub_signature {
-                            bind_named_rename_sub_signature(self, sub_params, val)?;
+                            // A sigiled named aggregate such as
+                            // `:@foo [$first, *@rest]` is a real destructuring
+                            // signature.  The same `sub_signature` field also
+                            // represents a scalar named alias (`:foo($value)`),
+                            // so use the aggregate sigil to distinguish the two
+                            // forms.  Treating `:@foo [...]` as an alias binds
+                            // every inner scalar to the whole array and skips
+                            // the inner slurpy entirely.
+                            if pd.name.starts_with('@') || pd.name.starts_with('%') {
+                                self.bind_param_value_sym(
+                                    &pd.name,
+                                    pd_name_sym(),
+                                    bound_value.clone(),
+                                );
+                                self.bind_param_type_constraint_sym(
+                                    &pd.name,
+                                    pd_name_sym(),
+                                    pd.type_constraint.clone(),
+                                );
+                                bind_sub_signature_from_value(self, sub_params, &bound_value)?;
+                            } else {
+                                bind_named_rename_sub_signature(self, sub_params, val)?;
+                            }
                         } else {
                             // Named `$` params are item bindings too (raku:
                             // `f(v => [1,2])` binds `$v` as `$[1, 2]`); rw

--- a/src/runtime/types/signature.rs
+++ b/src/runtime/types/signature.rs
@@ -819,7 +819,9 @@ pub(in crate::runtime) fn bind_sub_signature_from_value(
                 // Slurpy *@rest or *$rest: collect remaining positional values
                 let remaining: Vec<Value> = positional[nested_positional_idx..].to_vec();
                 nested_positional_idx = positional.len();
-                let remaining_value = Value::array(remaining);
+                // A destructured slurpy is an Array in Raku, not the List
+                // representation used for ordinary listified values.
+                let remaining_value = Value::real_array(remaining);
                 if !sub_pd.name.is_empty() {
                     bind_sub_param_name(interpreter, &sub_pd.name, remaining_value.clone());
                 }

--- a/src/vm/vm_call_eligibility.rs
+++ b/src/vm/vm_call_eligibility.rs
@@ -142,7 +142,12 @@ impl Interpreter {
                     return false;
                 }
                 if pd.named {
-                    pd.type_constraint.is_none()
+                    // Named aggregate destructuring (`:@a [$first, *@rest]`)
+                    // needs the general binder to unpack the value. The light
+                    // named plan only binds alias leaves to the whole value,
+                    // which would make every destructured scalar see the
+                    // original array and would skip inner slurpies.
+                    pd.type_constraint.is_none() && pd.sub_signature.is_none()
                 } else {
                     // Positional params in a mixed signature: the
                     // positional-light constraints (see

--- a/t/named-sub-signature-destructure.t
+++ b/t/named-sub-signature-destructure.t
@@ -1,0 +1,42 @@
+use Test;
+
+plan 6;
+
+sub positional-fixed(@a [$first, $second]) {
+    [@a, $first, $second]
+}
+is-deeply positional-fixed([1, 2]), [[1, 2], 1, 2],
+    'positional destructuring without a slurpy still works';
+
+sub positional-slurpy(@a [$first, *@rest]) {
+    [$first, @rest, @rest.^name]
+}
+is-deeply positional-slurpy([1, 2, 3]), [1, [2, 3], 'Array'],
+    'positional destructuring keeps a slurpy as an Array';
+
+sub named-fixed(:@a [$first, $second]) {
+    [@a, $first, $second]
+}
+is-deeply named-fixed(a => [1, 2]), [[1, 2], 1, 2],
+    'named destructuring without a slurpy binds each sub-parameter';
+
+sub named-slurpy(:@a [$first, *@rest]) {
+    [$first, @rest, @rest.^name]
+}
+is-deeply named-slurpy(a => [1, 2, 3]), [1, [2, 3], 'Array'],
+    'named destructuring binds its slurpy to the remaining elements';
+
+sub named-full(:@a [$first, *@rest, :$named, *%restnameds]) {
+    [@a, $first, @rest, $named, %restnameds]
+}
+is-deeply named-full(a => [1, 2, 3, named => 9, extra => 8]),
+    [[1, 2, 3, named => 9, extra => 8], 1, [2, 3], 9, {extra => 8}],
+    'named destructuring also binds inner named parameters and named slurpies';
+
+our @trait-seen;
+multi trait_mod:<is>(Variable $a, :@foo [$firstpos, *@restpos]) {
+    @trait-seen = [$firstpos, @restpos]
+}
+my $x is foo[1, 2, 3] = 1;
+is-deeply @trait-seen, [1, [2, 3]],
+    'trait_mod receives and destructures a named array parameter';


### PR DESCRIPTION
Closes #7758

Summary:
- destructure named array/hash parameters through their sub-signatures
- preserve named aliases and bind destructured slurpies as Arrays
- route named destructuring and trait_mod handlers through the correct binder

Tests:
- cargo fmt --all
- make lint
- make test
- make roast
- focused named sub-signature and binding tests