### PR TITLE
feat(test): make the vendored upstream `Test` module the default provider

### DIFF
--- a/ANALYSIS.md
+++ b/ANALYSIS.md
@@ -247,13 +247,15 @@ by fixing the interpreter (rung 2), never reimplemented natively (rung 3)** — 
 decision 2026-08-01. The consequences are visible in the code: the native `Test::Util` /
 `Test::Tap` overrides were retired (`news/2026-08/retired-native-test-util-overrides.md`),
 `Pod::To::Text` became the real rakudo module, and rakudo's real `Test.rakumod` is now
-vendored behind `MUTSU_REAL_TEST=1` pending the flip.
+what a bare `use Test` resolves to (the flip landed 2026-09-10; the native provider survives
+only behind `MUTSU_REAL_TEST=0`, pending its deletion).
 
 **Why this belongs in an architecture review**: the vendored suites are now the strictest
 correctness oracle the project has (stricter than roast, which is mined out), and the
 remaining native providers are an explicitly enumerated exception list — currently
 `NativeCall` (measured non-vendorable, `todo/deep/nativecall-cannot-be-vendored.md`),
-`JSON::Fast`, and `Test` (mid-retirement). That exception list is a first-class piece of the
+`JSON::Fast`, and `Test` (no longer the default provider; the native code is awaiting
+deletion). That exception list is a first-class piece of the
 architecture and should shrink monotonically or be justified in writing.
 
 ### 1.9 Metaobject protocol (new since rev10) — user HOWs on top of AST registration

--- a/modules/Rakudo-Core/README.md
+++ b/modules/Rakudo-Core/README.md
@@ -23,27 +23,29 @@ genuine upstream implementation instead of reimplementing it natively.
 
 (`LICENSE` is `rakudo-2026.06/LICENSE`, md5 `18740546821e33d23e8809da70d4a79a`.)
 
-### `Test` runs verbatim, behind `MUTSU_REAL_TEST=1`
+### `Test` runs verbatim, and is what `use Test` resolves to
 
 This file is the unmodified upstream `Test.rakumod`, and mutsu runs it verbatim
--- it was never renamed or shimmed. It is **not** yet what a bare `use Test`
-resolves to: mutsu's native TAP provider (`src/runtime/test_functions.rs`) is
-still the default, and this file is selected with **`MUTSU_REAL_TEST=1`**, which
-is also how the dual-provider sweeps (`scripts/test-module-sweep.sh`,
-`scripts/roast-test-module-sweep.sh`) compare the two.
+-- it was never renamed or shimmed. Since 2026-09-10 it is also **the default
+provider**: a bare `use Test` loads this file. Mutsu's native TAP provider
+(`src/runtime/test_functions.rs`) survives only behind `MUTSU_REAL_TEST=0`,
+which is how the dual-provider sweeps (`scripts/test-module-sweep.sh`,
+`scripts/roast-test-module-sweep.sh`) still compare the two, and it is scheduled
+for deletion ([#7566](https://github.com/tokuhirom/mutsu/issues/7566)).
 
 ```
-mutsu t/some-test.t                        # the native provider (default)
-MUTSU_REAL_TEST=1 mutsu t/some-test.t      # this file
+mutsu t/some-test.t                        # this file (default)
+MUTSU_REAL_TEST=0 mutsu t/some-test.t      # the native provider
 ```
 
-Every `t/` file and every roast file stands on `Test`, so the switch is held
-until nothing regresses under it. The roast and `t/` suites already pass; the
-`Bundled-library test suites` gate does not, on four unrelated interpreter gaps.
-The flip was attempted on 2026-09-07/08 and withdrawn -- see
-`todo/deep/vendor-real-test-module-flip.md` for the measurements and
-`todo/deep/vendored-test-battery-gate-regressions.md` for what is left. Pinned by
-`t/vendored-real-test-module.t`.
+Every `t/` file and every roast file stands on `Test`, so the switch was held
+until nothing regressed under it. It was attempted on 2026-09-07/08 and
+withdrawn, because the `Bundled-library test suites` gate regressed on four
+upstream distributions -- four unrelated interpreter gaps, none of them a `Test`
+compatibility problem. Those were fixed one at a time
+([#7555](https://github.com/tokuhirom/mutsu/issues/7555) records the chase) and
+the gate now passes under this module with more files green than under the
+native provider. Pinned by `t/vendored-real-test-module.t`.
 
 ## Why this directory exists
 

--- a/news/2026-09/vendored-test-module-is-the-default-provider.md
+++ b/news/2026-09/vendored-test-module-is-the-default-provider.md
@@ -1,0 +1,103 @@
+# The vendored upstream `Test` module is the default provider
+
+A bare `use Test` now loads `modules/Rakudo-Core/lib/Test.rakumod` — rakudo's own
+`Test`, vendored verbatim (md5 `f34dec45d52ad099c37f42fdbd93e277`, 953 lines of
+ordinary Raku, never renamed or shimmed). Mutsu's native TAP provider
+(`src/runtime/test_functions.rs`) is no longer what the suite stands on; it
+survives only behind `MUTSU_REAL_TEST=0`, as the escape hatch the dual-provider
+sweeps drive, and is scheduled for deletion (#7566).
+
+This is `BATTERIES.md` rung 2 in its intended form. The campaign's real product
+was never the flip itself but the ~130 general interpreter fixes the module
+forced along the way: it exercises phasers, `EVAL`, `callframe`, custom traits,
+`nqp::` ops, subtests and lazy evaluation, so every gap it hit was a gap in
+mutsu, not in `Test`. Those all landed independently. What remained was the
+switch.
+
+## Why the first attempt was withdrawn, and what changed
+
+The flip was tried on 2026-09-07/08 and pulled back the next day. Three of
+#7554's four completion criteria were met; the fourth — the `Bundled-library
+test suites` gate — reported 282/312 with nine regressed whitelisted files. None
+of them was a `Test` compatibility problem. They were unrelated interpreter gaps
+that only the real module's code shapes reached, which is the same pattern the
+rest of the campaign followed, except that these did not have fixes small enough
+to ride along.
+
+They were root-caused and fixed one at a time, and each is a general fix that
+stands on its own merits:
+
+| gate row | root cause | fix |
+| --- | --- | --- |
+| `Digest rfc4231.t` | the sub registrar's idempotent re-registration fast path accepted "something is registered under this name" as proof of identity, so `sha256` ran its compression loop calling `sha512`'s 64-bit `rotr`/`Σ0` | #7653 |
+| `Cro::HTTP http-middleware.rakutest` | a tail block is inlined as its body's return value, and inlining dropped its phasers — so every `LEAVE $service.stop()` in a tail block was compiled away and the previous subtest's server kept answering | #7663 |
+| `NativeLibs 01-basic.t` | a custom `sub EXPORT` above a `unit module` line was never invoked, plus `.dispatcher` answering a candidate instead of the proto, NativeCall's missing `trait_mod:<is>` export surface, and a `Signature` literal losing its parameters across the precompilation cache | #7714 |
+| four `DBIish` `*-common` rows | `need Foo` left `Foo`'s own methods unable to resolve the subs its compunit had imported | #7810 |
+| `NativeLibs 01-basic.t` again | a module first loaded inside an `EVAL` lost its package name and `EXPORT::` stash in the importer | #7814 |
+| `Cro::HTTP http2-request-parser.rakutest` | not mutsu's: the upstream file calls `ok` from inside `start` blocks, so two concurrent HTTP/2 streams interleave its TAP. Reported as croservices/cro-http#217 and excluded from the gate until that lands; the chase produced five interpreter perf fixes anyway (#7786, #7796, #7800, #7801, #7812) | #7667 |
+
+Three of those rows were, before the fixes, **passing under the native provider
+for the wrong reason** — a file-scope `use` leak supplying what rakudo gets from
+a custom export, a `--log=` regex matching `--level=trace`, a native `use-ok`'s
+leak standing in for an `EXPORT::ALL` stash. That is the pattern to expect when
+resuming work like this: a green row under the native provider is not evidence
+that the mechanism under it is right.
+
+## The measurement that authorized the flip
+
+`main` at `ab431dd3`, release build, both runs back to back in the same
+container:
+
+```
+MUTSU_REAL_TEST=1  scripts/battery-testsuite.sh  ->  291/311, GATE PASSED
+                   scripts/battery-testsuite.sh  ->  289/311, GATE PASSED
+```
+
+The vendored module passes two files *more* than the provider it replaces
+(`DBIish 48-sqlite-errors`, `Log::Async 01-basic`, neither whitelisted), and no
+whitelisted file regresses under it. The only row where it does worse is
+`Log::Async 04-filter` (9/10 native, 7/10 vendored) — not whitelisted, failing
+under both, and left as a known residual gap.
+
+The six `2x-mysql-*` rows are worth recording, because #7555 had them down as
+unjudgeable without live database servers. They are not: they failed identically
+under both providers with `NativeCall: symbol 'mysql_init' not found`, and
+installing `libmariadb3` — the client library, no server — makes all six reach
+DBIish's own `connect-or-skip` and pass 109/109 under both. The missing piece was
+never a server.
+
+The other two criteria were re-verified on the same build:
+
+| suite (vendored, release) | result |
+| --- | --- |
+| `prove -j4 -e target/release/mutsu -r t/` | 3946 files / 41966 tests, one failing file |
+| `make roast` | 1436 files / 218939 tests, three failing files |
+
+The three roast failures are the documented container-environment set
+(`docs/agent-environments.md`): two `uid 0` vs `chmod` files and one sandboxed
+network socket file. The single `t/` failure was
+`t/is-deeply-user-raku-diagnostic.t`, the one file whose expectation genuinely
+differs between the providers — rakudo and the vendored module send a non-TODO
+failure's diagnostic to `$failure_output` (STDERR), the native provider to
+STDOUT. Its two assertions moved from `:out` to `:err`, which is exactly what
+the file's own comment had asked whoever did the flip to do.
+
+## What the switch costs, and what it buys
+
+Suite cost on a 4-core box: `t/` 94 s wallclock, `make roast` 303 s — the 2.0x
+and 1.24x #7554 predicted. The `t/` doubling is the standing price of running
+Raku's own `Test` as Raku code; five callgrind passes already took the
+per-assertion cost from 492k to 235k instructions.
+
+What it buys is that mutsu's test suite no longer stands on a mutsu-specific
+reimplementation of the thing it is testing against. A `Test` bug is now a bug in
+rakudo's `Test`, and every `t/` and roast file exercises the real module's
+phasers, `EVAL`, `callframe` and trait machinery on every run.
+
+## Provider steering, for anyone writing a test
+
+`MUTSU_REAL_TEST` is read once at startup and now means the opposite of what it
+did: unset selects the vendored module, and `0` / `false` / the empty string
+select the native provider. Two `t/` files that steered their `is_run` children
+by *deleting* the variable had to say `= '0'` instead — deleting it now lands the
+child on the default, which is the half they were trying to contrast with.

--- a/scripts/roast-test-module-sweep.sh
+++ b/scripts/roast-test-module-sweep.sh
@@ -4,11 +4,11 @@
 # (MUTSU_REAL_TEST=) and once with the vendored upstream Test.rakumod
 # (MUTSU_REAL_TEST=1) -- and report which files regress under the real module.
 #
-# The vendored module has been the DEFAULT provider since 2026-09-07
-# (news/2026-09/vendored-test-module-is-the-default-provider.md); CI therefore
-# covers the real half directly and this sweep's remaining job is to show the
-# native provider it replaces has nothing left that only it can do. It goes away
-# with that provider (`todo/deep/retire-the-native-test-provider.md`).
+# The vendored module is the DEFAULT provider (2026-09-10, tokuhirom/mutsu#7554;
+# an earlier attempt on 2026-09-07 was withdrawn); CI therefore covers the real
+# half directly and this sweep's remaining job is to show the native provider it
+# replaces has nothing left that only it can do. It goes away with that provider
+# (tokuhirom/mutsu#7566).
 #
 # Differences from the t/ sweep, all deliberate:
 #   * Files run IN PLACE from the repo root through scripts/run-roast-test.sh,

--- a/scripts/test-module-sweep.sh
+++ b/scripts/test-module-sweep.sh
@@ -3,11 +3,10 @@
 # (MUTSU_REAL_TEST=) and once with the vendored upstream Test.rakumod
 # (MUTSU_REAL_TEST=1) -- and report which files regress under the real module.
 #
-# The vendored module has been the DEFAULT provider since 2026-09-07
-# (news/2026-09/vendored-test-module-is-the-default-provider.md), so this script
-# now measures the native provider it is replacing, not the other way round. It
-# exists only until that provider is deleted
-# (`todo/deep/retire-the-native-test-provider.md`), at which point there is
+# The vendored module is the DEFAULT provider (2026-09-10, tokuhirom/mutsu#7554;
+# an earlier attempt on 2026-09-07 was withdrawn), so this script measures the
+# native provider it replaces, not the other way round. It exists only until
+# that provider is deleted (tokuhirom/mutsu#7566), at which point there is
 # nothing left to compare and this file goes with it.
 #
 # The two runs are deliberately NOT compared byte-for-byte. The real module is

--- a/src/runtime/runtime_module.rs
+++ b/src/runtime/runtime_module.rs
@@ -9,36 +9,37 @@ impl Interpreter {
     /// (`modules/Rakudo-Core/lib/Test.rakumod`) instead of being recognized as a
     /// no-op that leaves mutsu's native TAP provider in charge.
     ///
-    /// **Opt-in.** The native TAP provider in `runtime/test_functions.rs` stays
-    /// in charge by default; `MUTSU_REAL_TEST=1` is how the vendored module is
-    /// driven, and the dual-provider sweeps
+    /// **The vendored module is the default** (2026-09-10). This is
+    /// `BATTERIES.md` rung 2 in its intended form: the real upstream module runs
+    /// verbatim under mutsu, so `use Test` resolves to it rather than to a
+    /// reimplementation. `MUTSU_REAL_TEST=0` (or the empty string, or `false`)
+    /// selects the native TAP provider in `runtime/test_functions.rs` instead —
+    /// the escape hatch the dual-provider sweeps
     /// (`scripts/test-module-sweep.sh`, `scripts/roast-test-module-sweep.sh`)
-    /// use it.
+    /// drive, and the one thing keeping that provider reachable until it is
+    /// deleted (#7566).
     ///
-    /// Making it the default was attempted and **withdrawn** (2026-09-08). The
-    /// roast and `t/` suites both go green under the vendored module, but the
-    /// `Bundled-library test suites` gate does not: four upstream distributions
-    /// regress, on four unrelated interpreter gaps that only the real module's
-    /// code shapes reach. None is a `Test` compatibility problem, and none has a
-    /// fix small enough to ride along with the flip — the `NativeLibs` one was
-    /// tried and made things worse. They are recorded, root-caused as far as
-    /// they got, in vendored-test-battery-gate-regressions (#7555), which
-    /// is the entry point for resuming this.
-    ///
-    /// The interpreter fixes the exercise turned up were the campaign's real
-    /// product and are independent of which provider is default, so they landed
-    /// without it. Rung 2 of `BATTERIES.md` remains the goal: flip this once the
-    /// gate's four root causes are fixed, not before.
+    /// The flip was attempted once before and withdrawn (2026-09-08) because the
+    /// `Bundled-library test suites` gate regressed on four upstream
+    /// distributions. Those were four unrelated interpreter gaps that only the
+    /// real module's code shapes reached, not `Test` compatibility problems;
+    /// they were root-caused and fixed one at a time (#7653, #7663, #7714,
+    /// #7805, #7806, and the #7667 perf chain), and #7555 records the whole
+    /// chase. Measured on `main` before this flip, the gate passes under the
+    /// vendored module with *more* files green than under the native provider.
     pub(crate) fn real_test_module_enabled() -> bool {
-        // Captured once at startup so that `%*ENV<MUTSU_REAL_TEST> = '1'` set
+        // Captured once at startup so that `%*ENV<MUTSU_REAL_TEST> = '0'` set
         // mid-run in a parent process (as `t/vendored-real-test-module.t` does,
-        // to steer its `is_run` children) does NOT retroactively silence the
-        // native TAP provider already in charge of that process.
+        // to steer its `is_run` children) does NOT retroactively swap the
+        // provider already in charge of that process.
         static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
         *ENABLED.get_or_init(|| {
+            // Unset means the default (the vendored module). Only an explicit
+            // off-value opts out — `MUTSU_REAL_TEST=` (empty) included, which is
+            // how the sweep scripts spell "the native half".
             std::env::var("MUTSU_REAL_TEST")
-                .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
-                .unwrap_or(false)
+                .map(|v| !(v.is_empty() || v == "0" || v.eq_ignore_ascii_case("false")))
+                .unwrap_or(true)
         })
     }
 

--- a/t/begin-selective-import-proto-multi.t
+++ b/t/begin-selective-import-proto-multi.t
@@ -128,7 +128,10 @@ plan 1;
 say "single var ok";
 CODE
 
-%*ENV<MUTSU_REAL_TEST>:delete;
+# The vendored module is the default since 2026-09-10, so the native provider
+# has to be asked for explicitly -- `:delete` would leave the child on the
+# vendored half and test the same thing twice.
+%*ENV<MUTSU_REAL_TEST> = '0';
 is_run $begin_list_probe, { status => 0, out => "1..1\nok 1 - selective import survived\n" },
     'native provider: BEGIN + list-destructured selective import of Test still works';
 

--- a/t/is-deeply-user-raku-diagnostic.t
+++ b/t/is-deeply-user-raku-diagnostic.t
@@ -11,19 +11,19 @@ plan 2;
 # fell back to a generic stringification instead of the user's own `.raku`.
 # Verified against real raku 2026-08-14: it prints the user-defined `.raku`.
 #
-# The `:out` here pins mutsu's NATIVE provider, which is the default. rakudo and
-# the vendored `Test.rakumod` both send a non-TODO failure's diagnostic to
-# `$failure_output` (STDERR) instead -- measured 2026-09-08 by running this file
-# under `raku` itself. So whoever makes the vendored module the default must
-# flip these two assertions to `:err`; it is the one `t/` file whose expectation
-# differs between the providers. See
-# `todo/deep/vendored-test-battery-gate-regressions.md`.
+# The `:err` here follows the vendored `Test.rakumod`, which is the default
+# provider since 2026-09-10 (#7554). rakudo and the vendored module both send a
+# non-TODO failure's diagnostic to `$failure_output` (STDERR); mutsu's native
+# provider (`MUTSU_REAL_TEST=0`) writes it to STDOUT instead -- measured
+# 2026-09-08 by running this file under `raku` itself. This was the one `t/`
+# file whose expectation differed between the providers, and flipping it is
+# what the flip's own note asked for.
 
 is_run
     'use Test; class Foo { has $.x; method raku { "MyFoo(" ~ $.x ~ ")" } };'
     ~ 'is-deeply Foo.new(x=>1), Foo.new(x=>2);',
     {
-        :out(/'expected: MyFoo(2)' .+ 'got: MyFoo(1)'/),
+        :err(/'expected: MyFoo(2)' .+ 'got: MyFoo(1)'/),
         :1status,
     },
     'is-deeply diagnostic honors a user-defined .raku override';
@@ -33,7 +33,7 @@ is_run
     ~ 'class Bar { has $.y; method raku { "MyBar(" ~ $.y ~ ")" } };'
     ~ 'is-eqv Bar.new(y=>1), Bar.new(y=>2), "eqv check";',
     {
-        :out(/'expected: MyBar(2)' .+ 'got: MyBar(1)'/),
+        :err(/'expected: MyBar(2)' .+ 'got: MyBar(1)'/),
         :1status,
     },
     'is-eqv diagnostic honors a user-defined .raku override';

--- a/t/vendored-real-test-module.t
+++ b/t/vendored-real-test-module.t
@@ -5,11 +5,11 @@ use Test::Util;
 
 plan 10;
 
-# `MUTSU_REAL_TEST=1` makes `use Test` load the vendored upstream
-# `Test.rakumod` (modules/Rakudo-Core/lib/) instead of being recognized as a
-# no-op that leaves mutsu's native TAP provider in charge. Step 2 of
-# `todo/tickets/vendor-real-test-module.md`: exercise the real module without
-# yet swapping the foundation the whole suite stands on.
+# `use Test` loads the vendored upstream `Test.rakumod`
+# (modules/Rakudo-Core/lib/) by default since 2026-09-10 (#7554);
+# `MUTSU_REAL_TEST=0` selects mutsu's native TAP provider instead. This file
+# pins both halves, so it keeps its value as the escape hatch's regression test
+# until the native provider is deleted (#7566).
 
 my $vendored = $*PROGRAM.parent(2).add("modules/Rakudo-Core/lib/Test.rakumod");
 ok $vendored.e, 'the upstream Test.rakumod is vendored in the repository';
@@ -23,7 +23,9 @@ my $probe = 'use Test; plan 1; is MONKEY-SEE-NO-EVAL(), 1, "module export";';
 my $plain = 'use Test; plan 2; ok 1, "a"; is 1+1, 2, "b";';
 
 # --- switch off: the native provider answers ---
-%*ENV<MUTSU_REAL_TEST>:delete;
+# `:delete` would leave the child on the DEFAULT, which is the vendored module
+# since 2026-09-10 -- the native provider now has to be asked for explicitly.
+%*ENV<MUTSU_REAL_TEST> = '0';
 
 is_run $plain, { status => 0, out => "1..2\nok 1 - a\nok 2 - b\n", err => '' },
     'the native provider emits plain TAP';


### PR DESCRIPTION
A bare `use Test` now loads `modules/Rakudo-Core/lib/Test.rakumod` — rakudo's own
`Test`, vendored verbatim (md5 `f34dec45d52ad099c37f42fdbd93e277`, never renamed
or shimmed) — instead of being recognized as a no-op that leaves mutsu's native
TAP provider in charge. This is `BATTERIES.md` rung 2 in its intended form.

The flip was attempted on 2026-09-07/08 and withdrawn: three of #7554's four
completion criteria were met, but the `Bundled-library test suites` gate
regressed on four upstream distributions. None of those was a `Test`
compatibility problem — they were unrelated interpreter gaps that only the real
module's code shapes reached — and each has since been root-caused and fixed on
its own merits (#7653, #7663, #7714, #7810, #7814, the #7667 perf chain, and an
upstream exclusion for croservices/cro-http#217). #7555 records the whole chase.

## What authorized the flip

`main` at `ab431dd3`, release build, both runs back to back in the same
container:

```
MUTSU_REAL_TEST=1  scripts/battery-testsuite.sh  ->  291/311, GATE PASSED
                   scripts/battery-testsuite.sh  ->  289/311, GATE PASSED
```

The vendored module passes **two files more** than the provider it replaces
(`DBIish 48-sqlite-errors`, `Log::Async 01-basic`, neither whitelisted) and
regresses no whitelisted file. The one row where it does worse is `Log::Async
04-filter` (9/10 native, 7/10 vendored) — not whitelisted, failing under both,
recorded as a residual gap.

The six `2x-mysql-*` rows, which #7555 had down as unjudgeable without live
database servers, turn out to be judgeable: they failed identically under both
providers with `NativeCall: symbol 'mysql_init' not found`, and installing
`libmariadb3` — the client library, no server — makes all six reach DBIish's own
`connect-or-skip` and pass 109/109 under both.

## Verification on this branch

Full suites run locally on the flipped build (so `use Test` is the vendored
module everywhere, with no `MUTSU_REAL_TEST` set):

| | result |
| --- | --- |
| `make test` | **All tests successful** — 3946 files / 41966 tests |
| `make roast` | 1436 files / 218939 tests; the only failures are the three documented container-environment files (`6.c/S32-io/file-tests.t` and `S16-filehandles/filetest.t` under `uid 0`, `S32-io/IO-Socket-Async.t` under the network sandbox — `docs/agent-environments.md:115-117`) |
| `scripts/battery-testsuite.sh` (new default) | **291/311, GATE PASSED** |
| `make lint` | clean, exit 0 |

## The changes

* `real_test_module_enabled()` defaults to `true`. `MUTSU_REAL_TEST` now means
  the opposite of what it did: unset selects the vendored module; `0`, `false`
  and the empty string select the native provider. The empty-string spelling is
  what both sweep scripts already use for their native half, so they keep
  working unchanged.
* `t/is-deeply-user-raku-diagnostic.t` moves its two assertions from `:out` to
  `:err`. It was the one `t/` file whose expectation genuinely differs between
  the providers — rakudo and the vendored module send a non-TODO failure's
  diagnostic to `$failure_output` (STDERR), the native provider to STDOUT — and
  the file's own comment asked whoever did the flip to make exactly this change.
* `t/vendored-real-test-module.t` and `t/begin-selective-import-proto-multi.t`
  steered their `is_run` children onto the native provider by *deleting* the
  variable. Deleting it now lands the child on the default, i.e. the half they
  were contrasting with, so they say `= '0'` instead.
* Docs that stated the native provider is the default:
  `modules/Rakudo-Core/README.md`, `ANALYSIS.md`, and both sweep-script headers
  (which also still pointed at `todo/` paths retired in the issue migration).
* `news/2026-09/vendored-test-module-is-the-default-provider.md`.

## Cost

`t/` 94 s wallclock and `make roast` 303 s on a 4-core box — the 2.0x and 1.24x
#7554 predicted. That is the standing price of running Raku's own `Test` as Raku
code; five callgrind passes already took the per-assertion cost from 492k to
235k instructions.

## Not in scope

* Deleting the native provider (~3600 lines) is #7566, and needs this to land
  first.
* #7787 — a module's file-scope `constant`s and enum values still leak into its
  importer.
* `Cro::HTTP http2-request-parser.rakutest` stays excluded from the gate until
  croservices/cro-http#217 lands and `batteries.lock` is re-vendored past it;
  `batteries-exclude.txt` carries the restore condition.

Refs #7554, #7555

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mj9BULuht9WSJxoFoES9ta

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mj9BULuht9WSJxoFoES9ta)_