### PR TITLE
fix: rethrow unhandled Failure method calls

### DIFF
--- a/news/2026-09/failure-method-rethrow.md
+++ b/news/2026-09/failure-method-rethrow.md
@@ -1,0 +1,6 @@
+# Unhandled Failure method calls rethrow their exception
+
+Method calls through a variable now rethrow the exception carried by an
+unhandled `Failure` before native dispatch can treat it as an ordinary value.
+Handling and introspection accessors, including `defined`, `Bool`, `so`,
+`.^name`, and `.exception`, remain available.

--- a/src/vm/vm_call_method_mut_ops.rs
+++ b/src/vm/vm_call_method_mut_ops.rs
@@ -792,6 +792,51 @@ impl Interpreter {
         } else {
             target
         };
+        // Unhandled Failure explosion: calling a non-Failure method on an
+        // unhandled Failure should throw before native dispatch can mistake
+        // the Failure for an ordinary Cool value (for example, `Failure.lines`
+        // reaches the native Str/Cool method table).
+        if let ValueView::Instance { class_name, .. } = target.view()
+            && class_name.resolve() == "Failure"
+            && !target.is_failure_handled()
+            && !matches!(
+                method,
+                "exception"
+                    | "handled"
+                    | "self"
+                    | "defined"
+                    | "Bool"
+                    | "so"
+                    | "not"
+                    | "gist"
+                    | "Str"
+                    | "raku"
+                    | "perl"
+                    | "WHICH"
+                    | "WHERE"
+                    | "HOW"
+                    | "WHY"
+                    | "WHO"
+                    | "backtrace"
+                    | "is-handling"
+                    | "WHAT"
+                    | "DEFINITE"
+                    | "VAR"
+                    | "^name"
+                    | "isa"
+                    | "does"
+                    | "ACCEPTS"
+                    | "Failure"
+                    | "sink"
+            )
+            && let Some(err) = self.failure_to_runtime_error_if_unhandled(&target)
+        {
+            crate::vm::vm_stats::record_dispatch_entry_intercept(
+                "callmethodmut",
+                "failure-explode",
+            );
+            return Err(err);
+        }
         if method == "value"
             && args.is_empty()
             && let Some(weight) = self.quanthash_weight_pair_value(target.unwrap_varref())

--- a/t/issue-7770-failure-method-rethrow.t
+++ b/t/issue-7770-failure-method-rethrow.t
@@ -1,0 +1,45 @@
+use v6;
+use Test;
+
+# An unhandled Failure must throw when a method call tries to use its value.
+# Handling/introspection accessors remain usable and mark the Failure handled
+# according to Raku's semantics.
+plan 9;
+
+my $caught-type;
+{
+    my $failure = Failure.new;
+    $failure.lines.elems;
+    CATCH { default { $caught-type = .^name } }
+}
+is $caught-type, 'X::AdHoc',
+    'an ordinary method call on an unhandled Failure rethrows its exception';
+
+my $open-caught-type;
+{
+    my $failure = 'mutsu-issue-7770-no-such-file-9f2a'.IO.open;
+    $failure.lines.elems;
+    CATCH { default { $open-caught-type = .^name } }
+}
+is $open-caught-type, 'X::AdHoc',
+    'a failed IO::Path.open followed by .lines rethrows the carried exception';
+
+my $accessor-failure = Failure.new;
+is $accessor-failure.defined, False, 'Failure.defined remains a handling accessor';
+is $accessor-failure.Bool, False, 'Failure.Bool remains a handling accessor';
+is $accessor-failure.so, False, 'Failure.so remains a handling accessor';
+is $accessor-failure.^name, 'Failure', 'Failure.^name remains usable';
+is $accessor-failure.exception.^name, 'X::AdHoc',
+    'Failure.exception remains usable';
+is $accessor-failure.DEFINITE, True, 'Failure.DEFINITE remains usable';
+
+my $with-branch = '';
+my $with-failure = Failure.new;
+with $with-failure {
+    $with-branch = 'then';
+} else {
+    $with-branch = 'else';
+}
+is $with-branch, 'else', 'with/without can inspect an unhandled Failure';
+
+done-testing;


### PR DESCRIPTION
Closes #7770\n\nEnsure method calls through a variable rethrow an unhandled Failure before native dispatch can treat it as an ordinary value. Preserve Failure handling and introspection accessors.\n\nValidation:\n- cargo fmt --all\n- make lint\n- make test\n- make roast