### PR TITLE
fix(supply): reserve a SupplyTicket for an already-resolved promise too

### DIFF
--- a/news/2026-09/already-resolved-promise-supply-ticket.md
+++ b/news/2026-09/already-resolved-promise-supply-ticket.md
@@ -1,0 +1,53 @@
+# An already-resolved promise now takes a SupplyTicket too
+
+`t/supply-serialize-fifo.t` test 3 — the pin added for #7811 — failed about one
+run in six on `main` (11 of 30 on an idle release build here), which made the
+fatal `t/` suite redden PRs at random. The failure was always the same shape:
+
+```
+# expected: '1 2 3 4 5 6'
+#      got: '2 4 6 1 3 5'
+```
+
+Not noise, and not a regression from #7811: it is the half of that fix that was
+never written.
+
+#7811 orders the reactions of a supply block by having the thread that resolves
+a promise reserve the reaction's place in the block's sequencer (a
+`SupplyTicket`) before the pooled worker that will run it has even been woken.
+But `SharedPromise::on_resolve_in_supply_group` only did that on the path where
+the promise was still `Planned`: the ticket is taken in `dispatch_waiters`, and
+a promise that is **already** resolved when the nested `whenever` registers
+never reaches `dispatch_waiters`. Its `group` argument was simply dropped, and
+the reaction ran inline on the registering thread — ahead of every reaction
+already ticketed and queued for a worker. The two paths were therefore ordered
+against each other by luck, which is exactly what the test alternates between
+(even values keep the promise before the nested `whenever` sees it, odd values
+after), and why the wrong answer came out cleanly separated rather than
+interleaved.
+
+The already-resolved branch now reserves its ticket too, on the registering
+thread — the ordering point, since that thread is running the enclosing supply
+block's reactions in order — and hands the body to a pooled worker exactly as
+`dispatch_waiters` does. Both paths enter the block through the one sequencer,
+in the order the reactions were created.
+
+Redeeming the ticket inline instead, and keeping the body on the caller's
+thread, is not an option: that thread is typically running the enclosing supply
+block's own reaction and so already holds the group lock, so parking it behind
+an earlier ticket — whose worker is itself blocked on that lock — deadlocks.
+This mirrors the reason the *pending* path hands off to a worker rather than
+running user code on the resolver, which is what deadlocked `Cro::HTTP`'s
+middleware pipeline when it was tried there.
+
+Consequence for the API contract: `on_resolve_in_supply_group` now returns
+`false` for an already-resolved promise when a group is given, because the
+reaction genuinely has not run yet. Plain `on_resolve` (no group) keeps its
+synchronous fast path and its `true`.
+
+40 consecutive runs of the file are green after the fix. `t/supply-serialize-fifo.t`
+grows a fourth test that keeps *every* promise before its nested `whenever`
+registers, so the already-resolved path is exercised on its own rather than only
+in alternation with the ticketed one.
+
+Closes #7831.

--- a/src/runtime/react_whenever.rs
+++ b/src/runtime/react_whenever.rs
@@ -530,7 +530,10 @@ impl Interpreter {
             // what keeps N nested `whenever <Promise>` bodies -- one created
             // per value by an outer `whenever`, each on its own promise -- in
             // the order their promises were kept, instead of in whichever
-            // order N pooled workers happened to wake up in (#7811).
+            // order N pooled workers happened to wake up in (#7811). A promise
+            // already kept by the time this runs reserves its place right
+            // here, on this thread, so it queues behind the bodies created
+            // before it instead of running inline ahead of them (#7831).
             shared.on_resolve_in_supply_group(
                 Box::new(move |status, result, _output, _stderr| {
                     if status == "Kept" {

--- a/src/runtime/supply_promise.rs
+++ b/src/runtime/supply_promise.rs
@@ -283,9 +283,11 @@ impl Interpreter {
     /// and the tap's `quit` handler see it.
     ///
     /// Callers must run this only after registering the taps for the rewritten
-    /// markers. The waiter runs on whichever thread resolves the promise (or
-    /// synchronously here when it already has), so it drives a thread clone of
-    /// this interpreter — the same pair `promise_chain_method` uses for `.then`.
+    /// markers. The waiter runs on a pooled worker — woken by whichever thread
+    /// resolves the promise, or, when it is already resolved, reserving its
+    /// place in the group here and running just as asynchronously (#7831) — so
+    /// it drives a thread clone of this interpreter, the same pair
+    /// `promise_chain_method` uses for `.then`.
     pub(crate) fn arm_pending_promise_whenevers(&mut self) {
         for (promise, supplier) in std::mem::take(&mut self.pending_promise_whenever_arms) {
             // The stand-in's serialize group was recorded when the rewritten
@@ -293,7 +295,10 @@ impl Interpreter {
             // Handing it to `on_resolve` makes the resolving thread reserve
             // this reaction's place in the supply block before the pooled
             // worker that runs it is even woken, so N promises resolved in a
-            // row reach the block in resolution order (#7811).
+            // row reach the block in resolution order (#7811). An already
+            // resolved promise reserves its place here instead, so it queues
+            // behind the reactions created before it rather than running
+            // inline ahead of them (#7831).
             let group = match supplier.view() {
                 ValueView::Instance { attributes, .. } => {
                     supplier_id_from_attrs(&attributes.as_map())

--- a/src/value/value_async.rs
+++ b/src/value/value_async.rs
@@ -266,6 +266,8 @@ impl SharedPromise {
     /// already resolved, the callback runs synchronously on the caller's
     /// thread (matching the existing `.then`/`.andthen`/`.orelse` fast path
     /// for an already-kept/broken promise) and this returns `true`.
+    /// (A supply-block reaction is the exception — see
+    /// [`Self::on_resolve_in_supply_group`].)
     /// Otherwise the callback is queued and this returns `false`: some
     /// future `keep`/`try_keep`/`break_with`/`try_break` call will run every
     /// queued waiter, **in registration order**, on a single dedicated
@@ -287,6 +289,19 @@ impl SharedPromise {
     /// the supply block in that order, instead of in whichever order their two
     /// workers happened to wake up in. See [`SupplyTicket`].
     ///
+    /// An **already-resolved** promise takes its ticket here instead, on the
+    /// registering thread, and its reaction is handed to a pooled worker just
+    /// like a queued one. Both paths therefore enter the block through the one
+    /// sequencer, in the order the reactions were created. Running the reaction
+    /// inline, as [`Self::on_resolve`] does for a plain waiter, would let it
+    /// jump ahead of every reaction already ticketed and waiting for a worker
+    /// (#7831); redeeming the ticket inline instead is not an option either,
+    /// because this thread is typically running the enclosing supply block's
+    /// own reaction and so already holds the group lock, so parking it behind
+    /// an earlier ticket — whose worker is itself blocked on that lock — would
+    /// deadlock. So this returns `false` (the reaction has not run yet) even
+    /// when the promise was already resolved.
+    ///
     /// [`SupplyTicket`]: crate::runtime::native_methods::SupplyTicket
     pub(crate) fn on_resolve_in_supply_group(
         &self,
@@ -304,8 +319,17 @@ impl SharedPromise {
             let output = state.output.clone();
             let stderr = state.stderr_output.clone();
             drop(state);
-            waiter(status, result, output, stderr);
-            true
+            let Some(group) = group else {
+                waiter(status, result, output, stderr);
+                return true;
+            };
+            let ticket = crate::runtime::native_methods::reserve_supply_serialize(group);
+            crate::runtime::worker_pool::submit(move || {
+                // Held across the callback, exactly as in `dispatch_waiters`.
+                let _serialize_guard = ticket.redeem();
+                waiter(status, result, output, stderr);
+            });
+            false
         }
     }
 

--- a/t/concurrency/supply/supply-serialize-fifo.t
+++ b/t/concurrency/supply/supply-serialize-fifo.t
@@ -9,7 +9,7 @@ use Test;
 # nested `whenever <Promise>` bodies came out in whichever order N workers
 # happened to wake up in. `10 30 20` was roughly a coin flip at three values.
 
-plan 3;
+plan 4;
 
 # Three nested whenevers, one per emitted value, each on its own promise kept
 # inside the outer whenever body. The keeps happen in a definite order on one
@@ -58,3 +58,22 @@ $out.tap({ @mixed.push($_); $done.keep if @mixed.elems == 6 });
 $src.emit($_) for 1..6;
 await Promise.anyof($done, Promise.in(10));
 is @mixed, [1, 2, 3, 4, 5, 6], 'already-kept and later-kept promises interleave in value order';
+
+# Every promise kept before its nested `whenever` sees it, so every reaction
+# takes the already-resolved path. That path used to run the body inline on the
+# registering thread with no place in the block's sequencer at all (#7831), so
+# it had to be ordered by luck; it must be ordered by the reservation instead.
+my $src2 = Supplier.new;
+my @kept-first;
+my $done2 = Promise.new;
+my $out2 = supply {
+    whenever $src2 -> $v {
+        my $p = Promise.new;
+        $p.keep;
+        whenever $p { emit $v }
+    }
+};
+$out2.tap({ @kept-first.push($_); $done2.keep if @kept-first.elems == 10 });
+$src2.emit($_) for 1..10;
+await Promise.anyof($done2, Promise.in(10));
+is @kept-first, [1 .. 10], 'promises kept before registration stay in value order';


### PR DESCRIPTION
## Problem

`t/supply-serialize-fifo.t` test 3 — the pin added for #7811 — fails about one run in six on `main`. Measured here on an idle release build: **11 of 30 runs failed**. Since the `t/` TAP suite is fatal in CI, this reddens unrelated PRs at random.

It is a wrong answer, not a non-deterministic-by-design assertion, and not a regression from #7811 — it is the half of that fix that was never written.

```
not ok 3 - already-kept and later-kept promises interleave in value order
# expected: '1 2 3 4 5 6'
#      got: '2 4 6 1 3 5'
```

## Root cause

#7811 orders a supply block's reactions by having the thread that *resolves* a promise reserve the reaction's place in the block's sequencer (a `SupplyTicket`) before the pooled worker that will run it has been woken.

But `SharedPromise::on_resolve_in_supply_group` only did that on the path where the promise is still `Planned`. The ticket is taken in `dispatch_waiters`, and a promise that is **already** resolved when the nested `whenever` registers never reaches `dispatch_waiters` — its `group` argument was simply dropped, and the reaction ran inline on the registering thread, ahead of every reaction already ticketed and waiting for a worker.

So the two paths were ordered against each other by luck. That is exactly what the test alternates between (even values keep the promise *before* the nested `whenever` sees it, odd values *after*), which is why the wrong answer came out cleanly separated rather than interleaved.

## Fix

The already-resolved branch now reserves its ticket too, on the registering thread — the ordering point, since that thread is running the enclosing supply block's reactions in order — and hands the body to a pooled worker exactly as `dispatch_waiters` does. Both paths enter the block through the one sequencer, in the order the reactions were created.

Redeeming the ticket *inline*, keeping the body on the caller's thread, is not an option: that thread is typically running the enclosing supply block's own reaction and so already holds the group lock, so parking it behind an earlier ticket — whose worker is itself blocked on that lock — would deadlock. This mirrors the reason the *pending* path hands off to a worker rather than running user code on the resolver, which is what deadlocked `Cro::HTTP`'s middleware pipeline when it was tried there.

Contract change: `on_resolve_in_supply_group` now returns `false` for an already-resolved promise when a group is given, because the reaction genuinely has not run yet. Plain `on_resolve` (no group) keeps its synchronous fast path and its `true`. No caller reads the return value.

## Verification

- Before: 11 / 30 runs failed (release, idle machine). After: **0 / 40**.
- `t/supply-serialize-fifo.t` grows a fourth test that keeps *every* promise before its nested `whenever` registers, so the already-resolved path is exercised on its own rather than only in alternation with the ticketed one. `raku` agrees with all four tests.
- `cargo fmt --all`, `make lint` (all four configurations), `make test` (3949 files, 41979 tests, PASS).
- `make roast`: the only failures are the three documented container-only ones — `roast/6.c/S32-io/file-tests.t` and `roast/S16-filehandles/filetest.t` (this container runs as `uid 0`, which bypasses the permission bits they assert on) and `roast/S32-io/IO-Socket-Async.t` (sandboxed network), matching the shapes and test numbers listed in `docs/agent-environments.md` exactly.

Closes #7831.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019yehkGnudWM9qirASmfYo3

---
_Generated by [Claude Code](https://claude.ai/code/session_019yehkGnudWM9qirASmfYo3)_