### PR TITLE
fix: an undefined Any does not answer Cool's methods

### DIFF
--- a/news/2026-09/any-is-not-a-cool-method-gate.md
+++ b/news/2026-09/any-is-not-a-cool-method-gate.md
@@ -1,0 +1,72 @@
+# A `Cool` method on an undefined `Any` throws instead of answering `(Any)`
+
+`Any` is not a `Cool` — it is the other way round — so `uc`, `chars`, `comb`,
+`abs`, `substr` and the rest of that surface simply do not exist on an
+undefined invocant. raku says so:
+
+```
+my $x; say $x.comb(/\w+/);   # No such method 'comb' for invocant of type 'Any'
+```
+
+mutsu answered `(Any)`.
+
+The mechanism was mutsu's by-name native dispatch. Its cascades recognize the
+method *name*, stringify the receiver and answer out of that string; a type
+object stringifies to its gist, so `$x.comb(/\w+/)` combed the literal text
+`"(Any)"` and returned `("Any",)`. `.uc` answered `"(ANY)"`, `.chars` answered
+`5`, `.bytes` answered `5`, `.IO` handed back an `IO::Path` for a file named
+`(Any)`.
+
+That is worse than a missing method, and the documentation example that turned
+it up (`raku-doc/doc/Language/objects.rakudoc:48`, plus a cluster of seven rows
+in `perl-nutshell.rakudoc`) shows why — the wrong value does not stop, it
+travels:
+
+```raku
+my $formatted-text;
+my @words = "Abe", "Lincoln";
+@words.push("said", $formatted-text.comb(/\w+/));
+say @words;                      # raku: dies.  mutsu: [Abe Lincoln said (Any)]
+```
+
+## The fix
+
+This is [ADR-0051](../../docs/adr/0051-type-ancestry-has-one-oracle-and-an-unresolved-method-throws.md)'s
+P4 rule — "an unresolved `Cool`-only method throws rather than stringifying the
+receiver" — applied to the one receiver shape its gates never saw. Those gates
+sit inside a `ValueView::Instance` arm, so the `Any`/`Mu` **type object** walked
+straight past them into the cascades. `src/runtime/any_cool_method_gate.rs` is
+the missing arm, wired into both dispatch entries: `call_method_with_values`
+(the interpreter) and `try_native_method` (the opcode path, which reaches the
+cascades without passing through the first).
+
+The gated name set is the union of two independently raku-verified sources, and
+neither subsumes the other: ADR-0051's hand-curated `cool_only_builtin_method`
+list carries names with no `Cool` row of their own (`bytes`, `lazy`, `race`,
+`Date`), and the generated row catalog carries rows the list predates
+(`printf`, `is-prime`, the native-int coercion family). `Any.^can` — rakudo's
+and mutsu's alike — is empty for every name in either. That last point is the
+interesting one: mutsu's introspection already knew `Any` has no `comb`, and
+only dispatch disagreed.
+
+`match` and `split` are deliberately excluded. raku declares both on `Any`;
+their candidates merely refuse an undefined invocant, so raku answers
+`X::Multi::NoMatch` / a use-of-uninitialized warning for them, never
+`X::Method::NotFound`. Gating them would swap one wrong answer for another.
+
+## Verification
+
+`t/any-cool-method-not-found.t` pins the repro, the doc example (including that
+nothing reaches the array), nine more `Cool` names, the `Mu` twin, an unknown
+name as the control that the ordinary `X::Method::NotFound` path is unchanged,
+and `Any`'s own surface (`.defined`, `.gist`, `.raku`, `.^name`, `.WHAT`,
+`.WHICH`, `.elems`) plus a defined `Str`/`Int` receiver. All 26 assertions pass
+under `raku` as well as mutsu.
+
+A 184-name sweep of `my $x; $x.<name>` against rakudo v2026.07 confirms the
+change introduces no new divergence: the seventeen names that still disagree are
+all pre-existing gaps of a different kind (a zero-argument call of a method that
+needs arguments, where raku raises `X::Multi::NoMatch`), and none of them is in
+the gated set.
+
+Closes #7773.

--- a/src/runtime/any_cool_method_gate.rs
+++ b/src/runtime/any_cool_method_gate.rs
@@ -1,0 +1,183 @@
+//! `Any` is not a `Cool`, so it does not answer `Cool`'s methods.
+//!
+//! `uc`, `chars`, `comb`, `abs`, `substr`, ... are declared on `Cool`, which
+//! `Any` does not inherit from -- it is the other way round (`Cool` is a
+//! subclass of `Any`). Calling one of them on an undefined `Any` is therefore
+//! `X::Method::NotFound` in raku:
+//!
+//! ```text
+//! my $x; say $x.comb(/\w+/);   # No such method 'comb' for invocant of type 'Any'
+//! ```
+//!
+//! mutsu's by-name native dispatch did not model that boundary for a type
+//! object: it recognizes the method NAME, stringifies the receiver -- and a
+//! type object stringifies to its gist -- then answers out of `"(Any)"`. The
+//! result is not an error but a *wrong value* that travels on, which is worse
+//! than a missing method: `$undefined.comb(/\w+/)` answered `("Any",)`, and
+//! `@words.push("said", $t.comb(/\w+/))` put it into the array (#7773).
+//!
+//! This is ADR-0051's P4 rule ("an unresolved `Cool`-only method throws")
+//! applied to the one receiver shape its gates did not cover: they are reached
+//! only for a `ValueView::Instance`, so the `Any`/`Mu` type object walked
+//! straight past them into the cascades.
+
+use crate::runtime::Interpreter;
+use crate::value::{Value, ValueView};
+use std::collections::HashSet;
+use std::sync::OnceLock;
+
+/// `Cool` names raku ALSO declares on `Any`, which must NOT be gated.
+///
+/// Both are `proto`s on `Any` whose candidates merely refuse an *undefined*
+/// invocant, so raku answers `X::Multi::NoMatch` (`split`) or a
+/// use-of-uninitialized warning (`match`) for them -- never
+/// `X::Method::NotFound`. Reporting a missing method here would swap one wrong
+/// answer for another, so they keep the behaviour they have.
+const ALSO_DECLARED_ON_ANY: &[&str] = &["match", "split"];
+
+/// The `Cool` rows an `Any`/`Mu` invocant does not inherit, derived from the
+/// same catalog `.^can` answers from (`builtins::native_method_row`) so the two
+/// cannot drift apart -- `Any.^can("comb")` was already empty while the call
+/// itself succeeded, which is exactly the disagreement fixed here.
+///
+/// Verified against rakudo v2026.07 on 2026-09-10: `Any.^can` is empty for
+/// every name this yields.
+fn cool_rows_absent_from_any() -> &'static HashSet<&'static str> {
+    static NAMES: OnceLock<HashSet<&'static str>> = OnceLock::new();
+    NAMES.get_or_init(|| {
+        use crate::builtins::builtin_type_methods::builtin_type_method_names;
+        let inherited: HashSet<&'static str> = builtin_type_method_names("Any")
+            .into_iter()
+            .chain(builtin_type_method_names("Mu"))
+            .chain(ALSO_DECLARED_ON_ANY.iter().copied())
+            .collect();
+        builtin_type_method_names("Cool")
+            .into_iter()
+            .filter(|name| !inherited.contains(name))
+            .collect()
+    })
+}
+
+/// The structured `X::Method::NotFound` for a `Cool`-only method called on the
+/// `Any` or `Mu` type object, or `None` when the call is not gated.
+///
+/// Only those two type objects qualify. Every other undefined receiver either
+/// IS a `Cool` (`Str`, `Int`, `Nil`, ... -- raku runs the method and warns
+/// about the uninitialized value) or has its own method surface.
+pub(crate) fn cool_method_not_found(
+    target: &Value,
+    method: &str,
+) -> Option<crate::value::RuntimeError> {
+    let owner = undefined_owner(target)?;
+    // Two independently raku-verified sources of "resolvable only through
+    // `Cool`": ADR-0051's hand-curated list, and the generated row catalog.
+    // Neither subsumes the other -- the curated list carries names with no
+    // `Cool` row of their own (`bytes`, `lazy`, `race`, `Date`), the catalog
+    // carries rows the list predates (`printf`, `is-prime`, the native-int
+    // coercion family) -- and `Any.^can` is empty for every name in either.
+    (Interpreter::cool_only_builtin_method(method) || cool_rows_absent_from_any().contains(method))
+        .then(|| super::methods_signature_errors::make_method_not_found_error(method, owner, false))
+}
+
+/// `"Any"`/`"Mu"` when `target` is one of those two type objects.
+fn undefined_owner(target: &Value) -> Option<&'static str> {
+    match target.view() {
+        ValueView::Package(name) if name == "Any" => Some("Any"),
+        ValueView::Package(name) if name == "Mu" => Some("Mu"),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::symbol::Symbol;
+
+    fn any() -> Value {
+        Value::package(Symbol::intern("Any"))
+    }
+
+    fn mu() -> Value {
+        Value::package(Symbol::intern("Mu"))
+    }
+
+    #[test]
+    fn cool_only_methods_are_missing_on_any() {
+        for name in [
+            // string
+            "comb",
+            "uc",
+            "chars",
+            "substr",
+            "trim",
+            "words",
+            "flip",
+            // numeric
+            "abs",
+            "sqrt",
+            "floor",
+            "is-prime",
+            "printf", // coercions
+            "IO",
+            "Num",
+            "Rat",
+            "Version",
+            "NFC",
+            "int8",
+            // curated-list-only names with no `Cool` row of their own
+            "bytes",
+            "lazy",
+            "race",
+            "DateTime",
+            "parse-base",
+        ] {
+            let err = cool_method_not_found(&any(), name);
+            assert!(err.is_some(), "{name} should be absent from Any");
+            // A "Did you mean ...?" suffix may follow, exactly as raku's does.
+            let message = err.unwrap().message.to_string();
+            let expected = format!("No such method '{name}' for invocant of type 'Any'");
+            assert!(
+                message.starts_with(&expected),
+                "unexpected message for {name}: {message}"
+            );
+        }
+        assert!(cool_method_not_found(&mu(), "uc").is_some());
+    }
+
+    #[test]
+    fn methods_any_itself_declares_are_not_gated() {
+        // `Any`/`Mu`'s own surface, and the two `Cool` names raku shares with
+        // `Any` (see `ALSO_DECLARED_ON_ANY`).
+        for name in [
+            "gist",
+            "raku",
+            "Str",
+            "Bool",
+            "Int",
+            "Numeric",
+            "defined",
+            "elems",
+            "list",
+            "so",
+            "WHAT",
+            "WHICH",
+            "match",
+            "split",
+            "no-such-method",
+        ] {
+            assert!(
+                cool_method_not_found(&any(), name).is_none(),
+                "{name} should still resolve on Any"
+            );
+        }
+    }
+
+    #[test]
+    fn a_defined_receiver_is_never_gated() {
+        assert!(cool_method_not_found(&Value::str_from("abc"), "uc").is_none());
+        assert!(cool_method_not_found(&Value::int(2), "abs").is_none());
+        // `Nil` and `Str:U` ARE `Cool`: raku runs the method and warns.
+        assert!(cool_method_not_found(&Value::NIL, "comb").is_none());
+        assert!(cool_method_not_found(&Value::package(Symbol::intern("Str")), "uc").is_none());
+    }
+}

--- a/src/runtime/methods_call_dispatch.rs
+++ b/src/runtime/methods_call_dispatch.rs
@@ -167,6 +167,15 @@ impl Interpreter {
         method: &str,
         args: Vec<Value>,
     ) -> Result<Value, RuntimeError> {
+        // `Any` is not a `Cool`, so it does not answer `Cool`'s methods. Gated
+        // here, ahead of every native/instance handler, because the by-name
+        // native cascades below recognize the NAME and then stringify the
+        // receiver -- a type object stringifies to its gist, so
+        // `$undefined.comb(/\w+/)` answered `("Any",)` instead of throwing
+        // (#7773). See `any_cool_method_gate` for the derivation of the set.
+        if let Some(err) = super::any_cool_method_gate::cool_method_not_found(&target, method) {
+            return Err(err);
+        }
         // `X::Promise::Broken` is composed into a broken promise's cause by
         // `Promise.result`, and the role overrides `gist` (only `gist` — see
         // `promise_broken_gist`). mutsu registers the role with no method

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -532,6 +532,7 @@ mod accessors_resolve;
 mod accessors_stack;
 mod accessors_stash;
 mod accessors_state;
+mod any_cool_method_gate;
 mod attr_build_defaults;
 mod builtins;
 mod builtins_atomic;
@@ -852,6 +853,7 @@ pub(crate) mod wasm_sched;
 mod which_identity;
 /// Elastic worker pool for short-lived user tasks (ADR-0020).
 pub(crate) mod worker_pool;
+pub(crate) use self::any_cool_method_gate::cool_method_not_found as cool_method_not_found_on_any;
 pub(crate) use self::locals::Locals;
 pub(crate) use self::match_target::MatchTarget;
 pub(crate) use self::methods_subscript_protocol::refuse_map_removal;

--- a/src/vm/vm_native_dispatch.rs
+++ b/src/vm/vm_native_dispatch.rs
@@ -24,6 +24,16 @@ impl Interpreter {
         method_sym: crate::symbol::Symbol,
         args: &[Value],
     ) -> Option<Result<Value, RuntimeError>> {
+        // `Any` is not a `Cool` (#7773): the cascades below recognize a `Cool`
+        // method by NAME and answer out of the stringified receiver, which for
+        // a type object is its gist -- so `$undefined.uc` answered `"(ANY)"`.
+        // The interpreter entry (`call_method_with_values`) carries the twin of
+        // this gate; the OPCODE path reaches the cascades without passing
+        // through it.
+        if let Some(err) = crate::runtime::cool_method_not_found_on_any(target, method_sym.as_str())
+        {
+            return Some(Err(err));
+        }
         // ADR-0058: a native method reads its ARGUMENTS' elements through pure
         // Rust (the receiver is already handled by
         // `reify_or_consume_seq_target`), so a still-deferred `.map` argument —

--- a/t/any-cool-method-not-found.t
+++ b/t/any-cool-method-not-found.t
@@ -1,0 +1,65 @@
+use v6;
+use Test;
+
+# #7773: `Any` is not a `Cool`, so a `Cool` method called on an undefined
+# (`Any`) invocant is `X::Method::NotFound` -- not a call served by
+# stringifying the type object. mutsu used to answer `$x.comb(/\w+/)` with
+# `("Any",)`, built out of the receiver's own gist, which is worse than a
+# missing method: the wrong value travels on into the caller's data.
+
+plan 26;
+
+# ── the reported repro ────────────────────────────────────────────────
+my $x;
+throws-like { $x.comb(/\w+/) }, X::Method::NotFound,
+        message => /"No such method 'comb' for invocant of type 'Any'"/,
+        'a Cool method on an undefined Any throws';
+
+my $caught;
+try {
+    my $y;
+    $y.comb(/\w+/);
+    CATCH { default { $caught = $_ } }
+}
+is $caught.method, 'comb', 'X::Method::NotFound.method names the call';
+is $caught.typename, 'Any', 'X::Method::NotFound.typename is Any';
+
+# The shape that matters: the bad value used to end up in the array.
+my $formatted-text;
+my @words = "Abe", "Lincoln";
+throws-like { @words.push("said", $formatted-text.comb(/\w+/)) },
+        X::Method::NotFound, 'the doc example throws instead of pushing (Any)';
+is-deeply @words, ["Abe", "Lincoln"], 'nothing was pushed';
+
+# ── the rest of the Cool surface ──────────────────────────────────────
+for <uc chars trim substr abs sqrt IO Rat bytes> -> $name {
+    my $undef;
+    throws-like { $undef."$name"() }, X::Method::NotFound,
+            message => /"for invocant of type 'Any'"/,
+            "Cool method .$name on an undefined Any throws";
+}
+
+# `Mu` has no more of the Cool surface than `Any` does.
+throws-like { Mu.uc }, X::Method::NotFound,
+        message => /"for invocant of type 'Mu'"/,
+        '.uc on Mu throws too';
+
+# ── controls: an unknown name still throws the same way ───────────────
+throws-like { my $u; $u.no-such-method }, X::Method::NotFound,
+        message => /"No such method 'no-such-method' for invocant of type 'Any'"/,
+        'an unknown method on Any is unchanged';
+
+# ── controls: Mu/Any's OWN methods still resolve ──────────────────────
+my $u;
+is $u.defined, False, '.defined still resolves on an undefined Any';
+is $u.gist, '(Any)', '.gist still resolves';
+is $u.raku, 'Any', '.raku still resolves';
+is $u.^name, 'Any', '.^name still resolves';
+is $u.WHAT.gist, '(Any)', '.WHAT still resolves';
+ok $u.WHICH.defined, '.WHICH still resolves';
+is $u.elems, 1, '.elems still resolves';
+
+# ── controls: a real Cool receiver is untouched ───────────────────────
+is "abc".uc, 'ABC', 'a defined Str still answers .uc';
+is-deeply "a b".comb(/\w+/).List, ("a", "b"), 'a defined Str still answers .comb';
+is 42.abs, 42, 'a defined Int still answers .abs';


### PR DESCRIPTION
`Any` is not a `Cool` — it is the other way round — so `uc`, `chars`, `comb`, `abs`, `substr` and the rest of that surface do not exist on an undefined invocant. raku throws; mutsu answered a **value**.

```
my $x; say $x.comb(/\w+/);   # raku: No such method 'comb' for invocant of type 'Any'
                             # mutsu: (Any)
```

## Root cause

By-name native dispatch. Its cascades recognize the method NAME, stringify the receiver and answer out of that string — and a type object stringifies to its gist. So `$x.comb(/\w+/)` combed the literal text `"(Any)"` and returned `("Any",)`. Likewise `.uc` → `"(ANY)"`, `.chars` and `.bytes` → `5`, `.IO` → an `IO::Path` for a file named `(Any)`.

That is worse than a missing method: the wrong value does not stop, it travels. The documentation example that turned it up (`Language/objects.rakudoc:48`, plus a cluster of seven rows in `perl-nutshell.rakudoc`) pushes it straight into an array.

```raku
my $formatted-text;
my @words = "Abe", "Lincoln";
@words.push("said", $formatted-text.comb(/\w+/));
say @words;                      # raku: dies.  mutsu: [Abe Lincoln said (Any)]
```

## Fix

This is [ADR-0051](https://github.com/tokuhirom/mutsu/blob/main/docs/adr/0051-type-ancestry-has-one-oracle-and-an-unresolved-method-throws.md)'s **P4 rule** — "an unresolved `Cool`-only method throws rather than stringifying the receiver" — applied to the one receiver shape its gates never saw. Those gates sit inside a `ValueView::Instance` arm, so the `Any`/`Mu` **type object** walked straight past them into the cascades.

`src/runtime/any_cool_method_gate.rs` is the missing arm, wired into **both** dispatch entries: `call_method_with_values` (the interpreter) and `try_native_method` (the opcode path, which reaches the cascades without passing through the first — the 0-arg `.uc` shape proved it needed its own gate).

The gated name set is the union of two independently raku-verified sources, and neither subsumes the other:

| source | contributes |
| --- | --- |
| ADR-0051's curated `cool_only_builtin_method` | names with no `Cool` row of their own — `bytes`, `lazy`, `race`, `Date`, `parse-base` |
| the generated row catalog (`Cool` rows − `Any`/`Mu` rows) | rows the list predates — `printf`, `is-prime`, `indices`, the native-int coercion family |

`Any.^can` — rakudo's **and mutsu's** — is empty for all 109 of them. That last point is the interesting one: mutsu's introspection already knew `Any` has no `comb`; only dispatch disagreed.

`match` and `split` are deliberately excluded. raku declares both on `Any`; their candidates merely refuse an *undefined* invocant, so raku answers `X::Multi::NoMatch` / a use-of-uninitialized warning for them, never `X::Method::NotFound`. Gating them would swap one wrong answer for another.

## Verification

| gate | result |
| --- | --- |
| `cargo fmt --all --check` | clean |
| `make lint` (all four configurations) | exit 0, zero warnings |
| `cargo test` | 1018 lib tests, all pass |
| `make test` | Files=3951, Tests=42018 — one failing file, see below |
| `make roast` | Files=1436, Tests=218939 — only the three documented container failures |

The three roast failures match `docs/agent-environments.md` row for row: `roast/6.c/S32-io/file-tests.t` (`Failed: 4`, tests 6-8/10, `uid 0`), `roast/S16-filehandles/filetest.t` (`Failed: 25`, `uid 0`), `roast/S32-io/IO-Socket-Async.t` (exit 124, sandboxed network).

The one `t/` failure is `t/supply-serialize-fifo.t` subtest 3, which is **not this change** — it is [#7838](https://github.com/tokuhirom/mutsu/issues/7838) / [#7831](https://github.com/tokuhirom/mutsu/issues/7831), measured at ~5/8 failures on `main` on a 4-core container and already fixed by the open [#7834](https://github.com/tokuhirom/mutsu/pull/7834). It passed on a direct re-run here.

`t/any-cool-method-not-found.t` (26 assertions, green under `raku` as well as mutsu) pins the repro and its exception's `.method`/`.typename`, the doc example including that nothing reaches the array, nine more `Cool` names, the `Mu` twin, an unknown name as the control that the ordinary `X::Method::NotFound` path is unchanged, `Any`'s own surface (`.defined`, `.gist`, `.raku`, `.^name`, `.WHAT`, `.WHICH`, `.elems`) and a defined `Str`/`Int` receiver.

A **184-name sweep** of `my $x; $x.<name>` against rakudo v2026.07 confirms the change introduces no new divergence: the seventeen names that still disagree are all pre-existing gaps of a different kind (a zero-argument call of a method that needs arguments, where raku raises `X::Multi::NoMatch`), and none of them is in the gated set.

Closes #7773

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LZT6GFNwTpdVShUWFZxeM8

---
_Generated by [Claude Code](https://claude.ai/code/session_01LZT6GFNwTpdVShUWFZxeM8)_