### PR TITLE
fix: EVAL's `context` argument selects the compunit the snippet compiles in

### DIFF
--- a/news/2026-09/eval-context-caller-compunit.md
+++ b/news/2026-09/eval-context-caller-compunit.md
@@ -48,6 +48,18 @@ it.
    `executing_source_file_for_module_load()`, the file-level counterpart of the
    existing `executing_unit_sym_for_module_load()` correction.
 
+   The corrected answer has to be `?FILE`, not the unit symbol on
+   `module_loading_unit_stack`, even though the two name the same file for a
+   plain module mainline. `?FILE` is dynamically scoped and `enter_source_file()`
+   retargets it for a deferred **role body**, which is re-run at each
+   composition from the composing scope (`RoleDef::decl_file`); the unit stack
+   still names the composing module there. Reading the unit stack stamped every
+   lexical sub a role declares with the wrong file, so the role's own methods
+   could no longer call it — zef's `role Plugin` has a lexical `sub DEBUG` that
+   `method !try-load` calls, and `zef/t/distribution-depends-parsing.rakutest`
+   aborted at test 18 of 35 with "Unknown function: DEBUG". The bundled-library
+   gate caught it; neither `make test` nor `make roast` did.
+
 3. **`END` phasers.** An `EndPhaser` already remembered its declaring *package*
    so a phaser in a `unit module Foo` could still reach `Foo`'s routines by bare
    name at exit; it now remembers its declaring *compunit* for the same reason.

--- a/news/2026-09/eval-context-caller-compunit.md
+++ b/news/2026-09/eval-context-caller-compunit.md
@@ -1,0 +1,68 @@
+# `EVAL ..., context => CALLER::` now compiles in the caller's compunit
+
+`EVAL $code, context => $ctx` is supposed to compile `$code` as if it stood at
+`$ctx`'s frame. mutsu honoured that for the *package* and for how the snippet's
+`return` classifies (ADR-0037 §2.2/§2.3), but not for the one thing the vendored
+`Test.rakumod` needs it for: which compunit's imports the snippet can see. The
+snippet was compiled inside whichever compunit called `EVAL`, so nothing the
+*test file* had `use`d was resolvable from it.
+
+That became visible when the real upstream `Test` module became the default
+provider (da21ca091, [#7554](https://github.com/tokuhirom/mutsu/issues/7554)):
+its string form of `throws-like` is `EVAL $code, context => $caller-context`,
+and the native provider never took that path. `Encode/t/01-basic.t`, a two-line
+file whose only assertion is a string `throws-like`, reported
+
+```
+# Expected: Encode::X::Encode::Unknown
+# Got:      X::AdHoc
+# Exception message: Could not find symbol 'Encode::decode'
+```
+
+and the bundled-library gate was red on `main` for three whitelisted files.
+
+## What changed
+
+Three things, all of them the same mistake at different depths — code was
+attributed to the compunit that *invoked* it rather than the one that *declared*
+it.
+
+1. **The EVAL unit's parent.** A `CALLER::` pseudo-stash now carries the
+   compunit of the frame it was taken from (`__mutsu_origin_unit`, stamped
+   beside the package and routine identities it already carried), and
+   `EVAL ..., context => $ctx` parents the EVAL compilation unit on it instead
+   of on the ambient one. The `use`-grant walk in
+   `Interpreter::qualified_name_visible_here` already follows that parent chain
+   ([#7797](https://github.com/tokuhirom/mutsu/issues/7797)), so the snippet
+   inherits the caller's imports and nothing else needed to change.
+
+2. **Routines declared while a module's mainline runs.** A module body runs via
+   `run_block`, which pushes no routine frame, so `executing_source_file()`'s
+   frame walk answered whichever routine was still below it. Loading a module
+   from an `EVAL "use ..."` reached inside a routine — which is exactly
+   `Test.rakumod`'s `use-ok` — therefore stamped every routine the loaded module
+   declares with the *calling* module's file. That in turn anchored the loaded
+   module's own `sub EXPORT` to the wrong compunit, and
+   `Terminal::ANSI::OO.new` inside `Terminal/ANSI/OO.rakumod`'s own `EXPORT`
+   failed the qualified-name gate. Registration now uses
+   `executing_source_file_for_module_load()`, the file-level counterpart of the
+   existing `executing_unit_sym_for_module_load()` correction.
+
+3. **`END` phasers.** An `EndPhaser` already remembered its declaring *package*
+   so a phaser in a `unit module Foo` could still reach `Foo`'s routines by bare
+   name at exit; it now remembers its declaring *compunit* for the same reason.
+   `Log::Async`'s `END { Log::Async.instance.done if Log::Async.instance }`
+   otherwise ran with `current_unit` back at the main script — which, for a
+   module pulled in by `use-ok`, never named `Log::Async` at all.
+
+## Result
+
+`DateTime::Parse/01-basic.t`, `Encode/01-basic.t` and `Log::Async/08-use.rakutest`
+pass again, and the bundled-library gate for those three batteries is green.
+`t/modules/eval-context-caller-compunit.t` pins all three mechanisms, and passes
+under `raku` as well.
+
+Log::Async's other non-whitelisted failures (`04-filter`, `10-formatter`,
+`12-context`, `14-frame`) are unaffected: they are caller-frame *reporting*
+(`callframe`-derived file/line in log records), a separate gap from symbol
+visibility.

--- a/src/runtime/accessors_stack.rs
+++ b/src/runtime/accessors_stack.rs
@@ -236,6 +236,32 @@ impl Interpreter {
             .map(|f| format!("{}::{}", f.package, f.name))
     }
 
+    /// The compilation unit the frame `CALLER::` names belongs to — the
+    /// compunit-scoping counterpart of [`Self::caller_frame_package`], stamped
+    /// onto the pseudo-stash so `EVAL ..., context => $ctx` can compile the
+    /// snippet with the *caller's* import visibility rather than that of the
+    /// module which happens to call `EVAL` (#7837).
+    ///
+    /// Same walk as [`Self::executing_unit_sym`], started one frame lower: a
+    /// block frame carries no `def_file` of its own and belongs to whatever
+    /// encloses it, so it is skipped. With no caller frame at all the caller is
+    /// a mainline, whose unit is the one currently being loaded or run — which
+    /// is what `?FILE` (`current_source_file_sym`) names, exactly as
+    /// `executing_unit_sym` falls back to.
+    pub(crate) fn caller_frame_unit(&self) -> Symbol {
+        let len = self.routine_stack.len();
+        if len >= 2 {
+            for frame in self.routine_stack[..len - 1].iter().rev() {
+                match frame.def_file {
+                    Some(file) => return self.unit_of_source_sym(Some(file)),
+                    None if frame.is_block => continue,
+                    None => break,
+                }
+            }
+        }
+        self.unit_of_source_sym(self.current_source_file_sym())
+    }
+
     /// The file the code currently executing was *defined* in — the module path
     /// for a routine that came from a `use`d module, the script otherwise.
     ///
@@ -260,6 +286,31 @@ impl Interpreter {
             }
         }
         self.current_source_file()
+    }
+
+    /// [`Self::executing_source_file`], corrected for code running directly in
+    /// a module's own top-level mainline while an unrelated routine call is
+    /// still on `routine_stack` — the file-level counterpart of
+    /// [`Self::executing_unit_sym_for_module_load`], and correct for exactly
+    /// the same reason (see `module_loading_unit_stack`'s doc comment): a
+    /// module body runs via `run_block`, which pushes no routine frame, so the
+    /// plain frame walk answers whichever routine is still below it.
+    ///
+    /// Without it, `use`ing a module from inside an `EVAL` that itself runs
+    /// inside a routine stamped every routine the module declares with the
+    /// *calling* module's file — which then anchored the loaded module's own
+    /// `sub EXPORT` to the wrong compunit and made its qualified
+    /// self-reference (`Terminal::ANSI::OO.new` inside
+    /// `Terminal/ANSI/OO.rakumod`'s own `EXPORT`) fail the #7797 visibility
+    /// gate. That is the shape `Test.rakumod`'s `use-ok` produces (#7837).
+    pub(crate) fn executing_source_file_for_module_load(&self) -> Option<String> {
+        if let Some(&(unit, depth_at_push)) = self.module_loading_unit_stack.last()
+            && self.routine_stack.len() == depth_at_push
+            && unit != crate::runtime::main_unit()
+        {
+            return Some(unit.resolve());
+        }
+        self.executing_source_file()
     }
 
     /// Current routine-stack depth. Paired with [`Self::truncate_routine_stack`] so a

--- a/src/runtime/accessors_stack.rs
+++ b/src/runtime/accessors_stack.rs
@@ -303,12 +303,22 @@ impl Interpreter {
     /// self-reference (`Terminal::ANSI::OO.new` inside
     /// `Terminal/ANSI/OO.rakumod`'s own `EXPORT`) fail the #7797 visibility
     /// gate. That is the shape `Test.rakumod`'s `use-ok` produces (#7837).
+    ///
+    /// The corrected answer is `?FILE` ([`Self::current_source_file`]), NOT the
+    /// unit symbol on `module_loading_unit_stack`, even though the two name the
+    /// same file for a plain module mainline. `?FILE` is the dynamically-scoped
+    /// "unit being compiled" marker, so [`Self::enter_source_file`] can retarget
+    /// it — which it does for a deferred **role body**, re-run at each
+    /// composition from the composing scope (`RoleDef::decl_file`). The unit
+    /// stack still names the composing module there, so reading it would stamp
+    /// the role's own lexical subs with the wrong file and make the role's
+    /// methods unable to call them (zef's `role Plugin`'s `sub DEBUG`, caught by
+    /// the bundled-library gate).
     pub(crate) fn executing_source_file_for_module_load(&self) -> Option<String> {
-        if let Some(&(unit, depth_at_push)) = self.module_loading_unit_stack.last()
+        if let Some(&(_, depth_at_push)) = self.module_loading_unit_stack.last()
             && self.routine_stack.len() == depth_at_push
-            && unit != crate::runtime::main_unit()
         {
-            return Some(unit.resolve());
+            return self.current_source_file();
         }
         self.executing_source_file()
     }

--- a/src/runtime/accessors_stash.rs
+++ b/src/runtime/accessors_stash.rs
@@ -127,6 +127,15 @@ impl Interpreter {
     /// `eval_context_routine` treats identically to "key not found".
     pub(crate) const STASH_ORIGIN_ROUTINE_ATTR: &str = "__mutsu_origin_routine";
 
+    /// Attribute a pseudo-stash carries to remember the *compilation unit* of
+    /// the frame it was taken from (#7837). Same invisibility convention as
+    /// `STASH_ORIGIN_PACKAGE_ATTR`. `EVAL ..., context => $stash` reads it back
+    /// (`eval_context_unit`) and parents the EVAL unit on it, so the snippet
+    /// inherits the *caller's* `use` grants instead of those of the module that
+    /// called `EVAL` — which is what makes the vendored `Test.rakumod`'s string
+    /// `throws-like` see the symbols the test file imported.
+    pub(crate) const STASH_ORIGIN_UNIT_ATTR: &str = "__mutsu_origin_unit";
+
     /// Attribute carried by a `CALLER::...::` stash to identify the live caller
     /// frame whose lexical pad it reflects.  The visible `symbols` hash is a
     /// snapshot; mutating operations such as `BIND-KEY` need this depth to reach
@@ -161,6 +170,36 @@ impl Interpreter {
                 Self::STASH_ORIGIN_ROUTINE_ATTR.to_string(),
                 Value::str(origin.to_string()),
             );
+        }
+    }
+
+    /// Stamp the compunit of the frame the stash was taken from
+    /// (`caller_frame_unit`), beside the package and routine identities above.
+    pub(crate) fn stamp_stash_origin_unit(stash: &Value, unit: Symbol) {
+        if let ValueView::Instance { attributes, .. } = stash.view() {
+            attributes.insert(
+                Self::STASH_ORIGIN_UNIT_ATTR.to_string(),
+                Value::str(unit.resolve().to_string()),
+            );
+        }
+    }
+
+    /// The compilation unit an `EVAL ..., context => $ctx` should compile
+    /// inside — the one `$ctx` was captured from (#7837) — or `None` when the
+    /// context value says nothing about one (it is not a stamped pseudo-stash,
+    /// e.g. `context => SomePackage`, which names a package but no frame and
+    /// so leaves the ambient unit in place).
+    pub(crate) fn eval_context_unit(ctx: &Value) -> Option<Symbol> {
+        match ctx.view() {
+            ValueView::Instance {
+                class_name,
+                attributes,
+                ..
+            } if is_stash_class_name(class_name.as_str()) => attributes
+                .as_map()
+                .get(Self::STASH_ORIGIN_UNIT_ATTR)
+                .map(|v| Symbol::intern(&v.to_string_value())),
+            _ => None,
         }
     }
 

--- a/src/runtime/builtins_eval_misc.rs
+++ b/src/runtime/builtins_eval_misc.rs
@@ -393,7 +393,17 @@ impl Interpreter {
         // BY the EVAL'd code is scoped to the EVAL unit alone. Operator
         // visibility (`Interpreter::user_infix_override`) walks this chain.
         let unit_sym = Symbol::intern(&unit_name);
-        crate::runtime::note_eval_unit_parent(unit_sym, self.current_unit);
+        // `context => $ctx` moves that anchor: the snippet is compiled as if it
+        // stood at `$ctx`'s frame, so it must inherit the `use` grants of the
+        // compunit the context was captured from, not those of the module that
+        // called EVAL (#7837). Without this the vendored `Test.rakumod`'s
+        // string `throws-like` compiles the snippet inside `Test`'s own
+        // compunit, where nothing the *test file* imported is visible.
+        let parent_unit = context_arg
+            .as_ref()
+            .and_then(Self::eval_context_unit)
+            .unwrap_or(self.current_unit);
+        crate::runtime::note_eval_unit_parent(unit_sym, parent_unit);
         let saved_unit = std::mem::replace(&mut self.current_unit, unit_sym);
         self.env
             .insert("?FILE".to_string(), Value::str(unit_name.clone()));

--- a/src/runtime/end_phasers.rs
+++ b/src/runtime/end_phasers.rs
@@ -143,6 +143,7 @@ impl Interpreter {
             body,
             env,
             package,
+            unit: self.executing_unit_sym_for_module_load(),
             dead_keys,
             order,
             capture_seq: None,
@@ -185,11 +186,13 @@ impl Interpreter {
         };
         let captured_env = self.env.clone();
         let package = self.current_package();
+        let unit = self.executing_unit_sym_for_module_load();
         let mark = self.end_phaser_capture_seq;
         self.end_phaser_capture_seq += 1;
         let phaser = &mut self.end_phasers[slot];
         phaser.env = captured_env;
         phaser.package = package;
+        phaser.unit = unit;
         // A fresh capture supersedes whatever the previous one froze.
         phaser.dead_keys = crate::runtime::NameSet::default();
         phaser.capture_seq = Some(mark);
@@ -207,6 +210,7 @@ impl Interpreter {
             body,
             env: captured_env,
             package,
+            unit: self.executing_unit_sym_for_module_load(),
             dead_keys: crate::runtime::NameSet::default(),
             order,
             capture_seq: Some(mark),

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1673,6 +1673,16 @@ pub(crate) struct EndPhaser {
     /// `current_package` has returned to GLOBAL — a phaser declared in a
     /// `unit module Foo` must still see `Foo`'s routines by their bare names.
     pub(crate) package: String,
+    /// The declaring *compunit*, the compunit-scoping counterpart of
+    /// [`package`](Self::package) (#7837). END bodies run at program exit,
+    /// when `current_unit` is back to the main script's — so a phaser
+    /// declared in a module whose qualified self-reference the #7797
+    /// visibility gate checks (`Log::Async.instance` inside
+    /// `Log/Async.rakumod`'s own `END`) would otherwise be judged against a
+    /// compunit that never `use`d it. That is not hypothetical for a module
+    /// pulled in by an `EVAL "use ..."` (`Test.rakumod`'s `use-ok`), where
+    /// no compunit on the exit-time chain ever named it.
+    pub(crate) unit: Symbol,
     /// Keys whose declaring scope has since died. At exit the captured value is
     /// the only surviving one, so it must win over a live same-named variable
     /// in an enclosing scope — `{ my $a = 42; END { say $a } }` prints 42 even

--- a/src/runtime/registration_sub.rs
+++ b/src/runtime/registration_sub.rs
@@ -1042,7 +1042,7 @@ impl Interpreter {
             return_type: return_type.cloned(),
             is_default: custom_traits.iter().any(|(t, _)| t == "default"),
             deprecated_message,
-            source_file: self.executing_source_file(),
+            source_file: self.executing_source_file_for_module_load(),
             source_line: None,
             decl_order: crate::runtime::resolution::next_decl_order(),
             compiled: None,

--- a/src/runtime/run.rs
+++ b/src/runtime/run.rs
@@ -1080,11 +1080,22 @@ impl Interpreter {
                 // in a `unit module Foo` would otherwise fail to resolve Foo's
                 // own routines by their bare names (Test::Compile's END calls
                 // its module-private `delete_compunits`).
+                //
+                // The declaring *compunit* is restored for the same reason
+                // (#7837): the #7797 qualified-name gate asks which compunit
+                // is running, and at exit that is the main script — which
+                // need never have `use`d the module whose END this is (a
+                // module pulled in by `Test.rakumod`'s `use-ok`, i.e. by an
+                // `EVAL "use ..."`, is reachable from no exit-time compunit
+                // at all), so `Log::Async.instance` inside `Log::Async`'s own
+                // END would read as an unknown symbol.
                 let saved_package = self.current_package();
                 if *package != saved_package {
                     self.set_current_package(package.clone());
                 }
+                let saved_unit = std::mem::replace(&mut self.current_unit, phaser.unit);
                 let body_result = self.run_block(body);
+                self.current_unit = saved_unit;
                 self.set_current_package(saved_package);
                 if self.halted {
                     // This phaser called `exit`. Whatever status it asked for is

--- a/src/vm/vm_var_assign_local.rs
+++ b/src/vm/vm_var_assign_local.rs
@@ -453,6 +453,7 @@ impl Interpreter {
             let stash = self.caller_stash_value(name, depth);
             Self::stamp_stash_origin_package(&stash, &origin);
             Self::stamp_stash_origin_routine(&stash, origin_routine.as_deref());
+            Self::stamp_stash_origin_unit(&stash, self.caller_frame_unit());
             self.stack.push(stash);
             return;
         }
@@ -494,6 +495,7 @@ impl Interpreter {
             let stash = loan_env!(self, package_stash_value(kind));
             Self::stamp_stash_origin_package(&stash, &origin);
             Self::stamp_stash_origin_routine(&stash, origin_routine.as_deref());
+            Self::stamp_stash_origin_unit(&stash, self.caller_frame_unit());
             self.stack.push(stash);
             return;
         }

--- a/t/lib/EvalCtxHelper.rakumod
+++ b/t/lib/EvalCtxHelper.rakumod
@@ -1,0 +1,24 @@
+unit module EvalCtxHelper;
+use MONKEY-SEE-NO-EVAL;
+
+# The shape the vendored `Test.rakumod` uses for the string form of
+# `throws-like`: capture the caller's context, then compile the snippet in it.
+# The snippet must see what the *test file* imported, not what this module did.
+sub eval-in-caller(Str $code) is export {
+    my $caller-context = CALLER::;
+    EVAL $code, context => $caller-context;
+}
+
+# The same EVAL without the `context` argument, for contrast: this one really
+# does compile in this module's scope, where nothing the caller imported is
+# visible (rakudo agrees).
+sub eval-no-context(Str $code) is export {
+    EVAL $code;
+}
+
+# The shape `Test.rakumod`'s `use-ok` uses: an `EVAL "use ..."` reached from
+# inside a routine of another compunit.
+sub eval-use(Str $module) is export {
+    EVAL "use $module";
+    'loaded'
+}

--- a/t/lib/EvalCtxSelfRef.rakumod
+++ b/t/lib/EvalCtxSelfRef.rakumod
@@ -1,0 +1,19 @@
+class EvalCtxSelfRef {
+    method tag() { 'self-ref' }
+}
+
+# Both of these name this module's OWN package, qualified. Each is checked by
+# the #7797 qualified-name visibility gate at the moment it runs, so each needs
+# the compunit it is judged against to be this file — which it is not by
+# default when the module is pulled in by an `EVAL "use ..."` reached from
+# another module's routine, nor (for the END) at program exit.
+sub EXPORT($name = 'ctx-self-ref') {
+    %( $name => EvalCtxSelfRef.new )
+}
+
+END {
+    # No output: the point is that this resolves at all. Before #7837 it died
+    # with "Could not find symbol 'EvalCtxSelfRef'" and took the exit status
+    # with it.
+    my $ = EvalCtxSelfRef.new.tag;
+}

--- a/t/lib/EvalCtxTarget.rakumod
+++ b/t/lib/EvalCtxTarget.rakumod
@@ -1,0 +1,7 @@
+unit module EvalCtxTarget;
+
+our sub ping($n) { "pong:$n" }
+
+class Marker {
+    method label() { 'marker' }
+}

--- a/t/modules/eval-context-caller-compunit.t
+++ b/t/modules/eval-context-caller-compunit.t
@@ -1,0 +1,50 @@
+use Test;
+
+# `EVAL $code, context => $ctx` compiles the snippet as if it stood at `$ctx`'s
+# frame, so it must inherit the *caller's* import visibility — not that of the
+# module which happens to call EVAL. The vendored `Test.rakumod`'s string form
+# of `throws-like` is exactly this shape (`EVAL $code, context => CALLER::`),
+# and without it no symbol the test file imported was resolvable from the
+# snippet: `Encode/t/01-basic.t` reported `X::AdHoc: Could not find symbol
+# 'Encode::decode'` instead of the encoding exception it asserts on (#7837).
+#
+# The `use-ok` shape at the end is the other half of the same ticket: an
+# `EVAL "use ..."` reached from inside another compunit's routine used to stamp
+# every routine the loaded module declares with the *calling* module's file,
+# which then anchored that module's own `sub EXPORT` — and its `END` — to a
+# compunit that never named it.
+
+plan 6;
+
+use lib 't/lib';
+use EvalCtxHelper;
+use EvalCtxTarget;
+
+# Sanity: the qualified names really are visible here, in the importing file.
+is EvalCtxTarget::ping(1), 'pong:1', 'the test file can call the imported module qualified';
+
+is eval-in-caller('EvalCtxTarget::ping(2)'), 'pong:2',
+    'EVAL with a CALLER:: context resolves a sub the CALLER imported';
+is eval-in-caller('EvalCtxTarget::Marker.new.label'), 'marker',
+    'EVAL with a CALLER:: context resolves a class the CALLER imported';
+
+# The context argument is the whole difference: without it the snippet compiles
+# in EvalCtxHelper's own compunit, which never imported EvalCtxTarget. Rakudo
+# fails here too ("Could not find symbol '&ping' in 'GLOBAL::EvalCtxTarget'").
+dies-ok { eval-no-context('EvalCtxTarget::ping(3)') },
+    'without a context the snippet does not see the caller compunit\'s imports';
+
+# A caller-context EVAL still reaches the caller's own routines. (It does NOT
+# reach the caller's `my` lexicals — rakudo reports those undeclared, since
+# `CALLER::` is a snapshot rather than the live pad — so that is not asserted.)
+sub caller-local() { 'local-sub' }
+is eval-in-caller('caller-local()'), 'local-sub',
+    'EVAL with a CALLER:: context calls a sub declared in the caller';
+
+# `use-ok`'s shape: `EVAL "use M"` from inside a module's routine. The loaded
+# module's own `sub EXPORT` names its own package qualified, and so does its
+# `END` phaser — the latter running long after every compunit that could vouch
+# for it is off the stack, which is why a failure there shows up as a non-zero
+# exit status rather than as a failed assertion here.
+is eval-use('EvalCtxSelfRef'), 'loaded',
+    'EVAL "use M" from inside a module runs M\'s own qualified-self-referencing EXPORT';


### PR DESCRIPTION
`EVAL $code, context => $ctx` compiles `$code` as if it stood at `$ctx`'s frame. mutsu honoured that for the package and for how the snippet's `return` classifies (ADR-0037 §2.2/§2.3) but not for the one thing the vendored `Test.rakumod` needs it for: **which compunit's imports the snippet can see**. The snippet was compiled inside whichever compunit called `EVAL`, so nothing the *test file* had `use`d was resolvable from it.

That went unnoticed until the real upstream `Test` module became the default provider (da21ca091, #7554) — its string form of `throws-like` is `EVAL $code, context => $caller-context`, a path the native provider never took — and left the bundled-library gate red on `main` for three whitelisted files.

## Root cause

Three fixes, all the same mistake at different depths: code attributed to the compunit that *invoked* it rather than the one that *declared* it.

1. **The EVAL unit's parent.** A `CALLER::` pseudo-stash now carries the compunit of the frame it was taken from (`__mutsu_origin_unit`, stamped beside the package and routine identities it already carried), and `EVAL ..., context => $ctx` parents the EVAL compilation unit on it instead of on the ambient one. The `use`-grant walk in `qualified_name_visible_here` already follows that parent chain (#7797), so nothing else needed changing.

2. **Routines declared while a module's mainline runs.** A module body runs via `run_block`, which pushes no routine frame, so `executing_source_file()`'s frame walk answered whichever routine was still below it. Loading a module from an `EVAL "use ..."` reached inside a routine — exactly `Test.rakumod`'s `use-ok` — stamped every routine the loaded module declares with the *calling* module's file, which anchored that module's own `sub EXPORT` to the wrong compunit and made its qualified self-reference (`Terminal::ANSI::OO.new` inside `Terminal/ANSI/OO.rakumod`'s own `EXPORT`) fail the #7797 gate. Registration now uses `executing_source_file_for_module_load()`, the file-level counterpart of the existing `executing_unit_sym_for_module_load()`.

   The corrected answer has to be `?FILE`, not the unit symbol on `module_loading_unit_stack`, even though the two name the same file for a plain module mainline: `?FILE` is dynamically scoped and `enter_source_file()` retargets it for a deferred **role body**, which is re-run at each composition from the composing scope (`RoleDef::decl_file`). The unit stack still names the composing module there. Reading it stamped every lexical sub a role declares with the wrong file, so the role's own methods could no longer call it — zef's `role Plugin` has a lexical `sub DEBUG` that `method !try-load` calls, and `zef/t/distribution-depends-parsing.rakutest` aborted at test 18 of 35 with "Unknown function: DEBUG". The bundled-library gate caught that; neither `make test` nor `make roast` did.

3. **`END` phasers.** An `EndPhaser` already remembered its declaring *package* so a phaser in a `unit module Foo` could still reach `Foo`'s routines by bare name at exit; it now remembers its declaring *compunit* for the same reason. `Log::Async`'s `END { Log::Async.instance.done if Log::Async.instance }` otherwise ran with `current_unit` back at the main script — which, for a module pulled in by `use-ok`, never named `Log::Async` at all.

## Result

The issue's repro now agrees with rakudo:

| | output |
| --- | --- |
| `raku` v2026.07 | `died: Encode::X::Encode::Unknown: Unknown encoding nyi.` |
| `mutsu` before | `died: X::AdHoc: Could not find symbol 'Encode::decode'` |
| `mutsu` after | `died: Encode::X::Encode::Unknown: Unknown encoding nyi.` |

All three regressed battery files pass again — `DateTime::Parse/01-basic.t`, `Encode/01-basic.t`, `Log::Async/08-use.rakutest` — and Log::Async goes from 11/17 to 13/17 files (`01-basic.rakutest` recovers too). Log::Async's remaining failures (`04-filter`, `10-formatter`, `12-context`, `14-frame`) are caller-frame *reporting* in log records, a separate gap the issue already called out.

## Testing

- `t/modules/eval-context-caller-compunit.t` — new, pins all three mechanisms. Verified it fails on the pre-fix binary ("planned 6, ran 1") and **passes under `raku` as well** (6/6).
- `make lint` — green in all four configurations.
- `make test` — 3951 files / 41998 tests. One failure, `t/supply-serialize-fifo.t`, which reproduces 5/5 on a from-scratch `origin/main` build in this same container (4-core, concurrency-ordering test); it is not from this change.
- `make roast` — 1436 files / 218939 tests. Failing set is exactly the three container exceptions documented in `docs/agent-environments.md`, with their recorded shapes (`file-tests.t` Failed: 4 tests 6-8/10, `filetest.t` Failed: 25, `IO-Socket-Async.t` exit 124 planned 40 ran 17).
- `scripts/battery-testsuite.sh` (full, all 17 upstream suites) — 286/311, no regressions except the six `DBIish` mysql files, which need `libmysqlclient` (absent here, so `mysql_init` fails `dlsym`; CI installs it) and failed identically before this change.

Closes #7837

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019nwidawLBWRR3KtmQymc58

---
_Generated by [Claude Code](https://claude.ai/code/session_019nwidawLBWRR3KtmQymc58)_