### PR TITLE
fix: run code in the compunit it was written in (EVAL context, END phasers, module routines)

### DIFF
--- a/news/2026-09/already-resolved-promise-supply-ticket.md
+++ b/news/2026-09/already-resolved-promise-supply-ticket.md
@@ -1,0 +1,53 @@
+# An already-resolved promise now takes a SupplyTicket too
+
+`t/supply-serialize-fifo.t` test 3 — the pin added for #7811 — failed about one
+run in six on `main` (11 of 30 on an idle release build here), which made the
+fatal `t/` suite redden PRs at random. The failure was always the same shape:
+
+```
+# expected: '1 2 3 4 5 6'
+#      got: '2 4 6 1 3 5'
+```
+
+Not noise, and not a regression from #7811: it is the half of that fix that was
+never written.
+
+#7811 orders the reactions of a supply block by having the thread that resolves
+a promise reserve the reaction's place in the block's sequencer (a
+`SupplyTicket`) before the pooled worker that will run it has even been woken.
+But `SharedPromise::on_resolve_in_supply_group` only did that on the path where
+the promise was still `Planned`: the ticket is taken in `dispatch_waiters`, and
+a promise that is **already** resolved when the nested `whenever` registers
+never reaches `dispatch_waiters`. Its `group` argument was simply dropped, and
+the reaction ran inline on the registering thread — ahead of every reaction
+already ticketed and queued for a worker. The two paths were therefore ordered
+against each other by luck, which is exactly what the test alternates between
+(even values keep the promise before the nested `whenever` sees it, odd values
+after), and why the wrong answer came out cleanly separated rather than
+interleaved.
+
+The already-resolved branch now reserves its ticket too, on the registering
+thread — the ordering point, since that thread is running the enclosing supply
+block's reactions in order — and hands the body to a pooled worker exactly as
+`dispatch_waiters` does. Both paths enter the block through the one sequencer,
+in the order the reactions were created.
+
+Redeeming the ticket inline instead, and keeping the body on the caller's
+thread, is not an option: that thread is typically running the enclosing supply
+block's own reaction and so already holds the group lock, so parking it behind
+an earlier ticket — whose worker is itself blocked on that lock — deadlocks.
+This mirrors the reason the *pending* path hands off to a worker rather than
+running user code on the resolver, which is what deadlocked `Cro::HTTP`'s
+middleware pipeline when it was tried there.
+
+Consequence for the API contract: `on_resolve_in_supply_group` now returns
+`false` for an already-resolved promise when a group is given, because the
+reaction genuinely has not run yet. Plain `on_resolve` (no group) keeps its
+synchronous fast path and its `true`.
+
+40 consecutive runs of the file are green after the fix. `t/supply-serialize-fifo.t`
+grows a fourth test that keeps *every* promise before its nested `whenever`
+registers, so the already-resolved path is exercised on its own rather than only
+in alternation with the ticketed one.
+
+Closes #7831.

--- a/news/2026-09/eval-and-end-run-in-their-declaring-compunit.md
+++ b/news/2026-09/eval-and-end-run-in-their-declaring-compunit.md
@@ -1,4 +1,4 @@
-# A context EVAL, and an END phaser, run in the compunit they belong to
+# Code runs in the compunit it was written in: EVAL context, END phasers, module routines
 
 `main` went red on the `test` job's bundled-library gate with three regressions
 that all reported the same kind of failure — a package-qualified name that would
@@ -52,8 +52,8 @@ A `CALLER::`/`CALLERS::` pseudo-stash now carries its frame's compunit
 already carried, and `EVAL` uses it as the EVAL unit's parent. That fixes
 `DateTime::Parse` and `Encode`.
 
-`on_resolve`-style contract note: nothing else changes for a plain `EVAL`, which
-keeps inheriting the running compunit — that IS its caller's lexical scope.
+Nothing changes for a plain `EVAL`, which keeps inheriting the running
+compunit — that IS its caller's lexical scope.
 
 ## An END phaser runs in the compunit that declared it
 
@@ -79,26 +79,61 @@ reached through `use-ok` (which is literally `EVAL "use $module"`) therefore
 died — and took the rest of the exit sequence with it, so the *script's own* END
 phasers never ran either.
 
-## What is still broken
+## A module's own routines must be stamped with the module's file
 
-`Log::Async/08-use.rakutest` still fails, on a third and separate facet of the
-same "which compunit is this code from" question, now root-caused precisely:
+`Log::Async/08-use.rakutest` needed a third fix, of the same shape.
 
-A module's `sub EXPORT` records `FunctionDef::source_file` from `?FILE` as of
-its registration, and when the load was reached through an `EVAL` run inside
-**another module's routine**, that names the invoking compunit rather than the
-module. `enter_compilation_unit` then anchors `current_unit` to it for the whole
-call, so `Terminal::ANSI::OO`'s own `sub EXPORT` cannot see its own class:
+A routine records its declaring file **as it is created**, via
+`executing_source_file()` — which walks the routine stack for the innermost
+frame's `def_file`. But a module's own top-level mainline runs through
+`run_block` and pushes **no routine frame**, so that walk goes straight past it
+to whatever routine is still on the stack underneath. When the load was
+triggered from a string `EVAL` inside another module's routine — `use-ok` is
+literally `EVAL "use $module"` — that frame belongs to a different compunit
+entirely, and every `sub` the loaded module declares got stamped with the
+*invoking* compunit's file.
+
+`enter_compilation_unit` then anchors `current_unit` from that stamp on every
+call, so `Terminal::ANSI::OO`'s own EXPORT could not resolve its own class:
 
 ```raku
 sub EXPORT($t = 't') {
-  %( $t => Terminal::ANSI::OO.new(:get-codes) )
+  %( $t => Terminal::ANSI::OO.new(:get-codes) )   # Could not find symbol
 }
 ```
 
-The discriminator is sharp — the same `EVAL "use Terminal::ANSI::OO"` succeeds
-from the main script's top level *and* from a sub declared in the main script,
-and fails only from a sub declared in another module. Anchoring at the
-`apply_module_export` call site does not help: `enter_compilation_unit` resets
-`current_unit` from the `CompiledFunction` on entry, so the fix has to be to the
-recorded `source_file` itself. #7836 carries the detail.
+Measured at the registration site, the two available answers disagree exactly as
+that predicts, and the correction already designed for #7797's sibling problem
+applies unchanged:
+
+```
+REGSUB name=EXPORT
+  exec_sf = tmp/endlib/UseOkish.rakumod                       <-- stale caller frame
+  ?FILE   = modules/Terminal-ANSI/lib/Terminal/ANSI/OO.rakumod <-- correct
+  rstack  = 2   modstack = (Terminal/ANSI/OO.rakumod, 2)      <-- depths match
+```
+
+`declaring_source_file()` is the declaration-side twin of
+`executing_unit_sym_for_module_load()`, and uses the same test for the same
+reason: `routine_stack.len()` unchanged since the innermost still-loading
+module's mainline started means nothing has been *called* since, so that module
+is what is running and `?FILE` — which `load_module_inner` scopes to the module
+path for exactly this window — is authoritative. A change means a routine call
+happened and the frame-based answer is right again, which is what keeps a
+closure literal built each time an *already-loaded* module's routine runs
+attributed to its own file rather than to a stale `?FILE`. The five sites that
+stamp a routine or closure with its declaring file now use it.
+
+## Verification
+
+Three focused regression tests under `t/modules/`, each verified against rakudo.
+`scripts/battery-testsuite.sh` — the gate that caught all of this, and which
+neither `make test` nor `make roast` exercises — is back to `285/311` with all
+three regressions gone; the only files still failing there are the six
+`DBIish` mysql ones, which need a `libmysqlclient` this container has not got
+(`NativeCall: symbol 'mysql_init' not found ... dlsym failed`) and which CI
+installs.
+
+This branch also carries the #7831 supply-ticket fix (PR #7834): without it
+`t/supply-serialize-fifo.t` test 3 fails 17-37% of runs, and the `t/` suite is
+fatal in CI, so an unrelated red would be a coin flip on every push here.

--- a/news/2026-09/eval-and-end-run-in-their-declaring-compunit.md
+++ b/news/2026-09/eval-and-end-run-in-their-declaring-compunit.md
@@ -1,0 +1,104 @@
+# A context EVAL, and an END phaser, run in the compunit they belong to
+
+`main` went red on the `test` job's bundled-library gate with three regressions
+that all reported the same kind of failure — a package-qualified name that would
+not resolve:
+
+```
+REGRESSION: whitelisted 'DateTime::Parse	01-basic.t'   # Could not find symbol 'DateTime::Parse'
+REGRESSION: whitelisted 'Encode	01-basic.t'            # Could not find symbol 'Encode::decode'
+REGRESSION: whitelisted 'Log::Async	08-use.rakutest'   # Could not find symbol 'Terminal::ANSI::OO'
+```
+
+Two commits interact to produce them. #7797 gated package-qualified names by
+which compunit `use`d the package, and #7830 made the vendored upstream `Test`
+the default provider — which moved `throws-like`'s and `use-ok`'s `EVAL` out of
+native Rust and into a real Raku compunit, where the new gate applies to it.
+Neither is wrong; what was missing is that **several things that run "somewhere
+else" still belong, lexically, to the compunit that wrote them**, and the gate
+was reading the wrong one for two of them.
+
+## A context EVAL inherits the context's compunit
+
+`EVAL $code, context => $ctx` compiles the snippet as if it stood at `$ctx`'s
+frame. mutsu already honoured that for the *package*, and for ADR-0037's
+`return` classification — but not for the compunit, and a compunit is part of a
+lexical scope just as much as a package is: which modules it `use`d is precisely
+what decides the package-qualified names code written in it may use.
+
+So the EVAL unit's parent was whichever compunit happened to be *running* the
+`EVAL`. For upstream `Test.rakumod` that is `Test` itself:
+
+```raku
+my $caller-context = $*THROWS-LIKE-CONTEXT // CALLER::; # Don't guess our caller context, know it!
+...
+EVAL $code, context => $caller-context;
+```
+
+`Test` passes `CALLER::` for exactly this reason, and mutsu then ignored it and
+compiled the snippet as if `Test` had written it. `Test` never `use`s the module
+under test, so every package-qualified name in a `throws-like` string went
+undeclared. The imported name resolving while the qualified one did not — same
+sub, same scope — is the whole bug in one pair of assertions:
+
+```
+ok 1 - throws-like resolves the IMPORTED name
+    # Got:      Could not find symbol 'Widget::make'
+not ok 2 - throws-like resolves the QUALIFIED name
+```
+
+A `CALLER::`/`CALLERS::` pseudo-stash now carries its frame's compunit
+(`STASH_ORIGIN_UNIT_ATTR`) beside the package and control-flow identity it
+already carried, and `EVAL` uses it as the EVAL unit's parent. That fixes
+`DateTime::Parse` and `Encode`.
+
+`on_resolve`-style contract note: nothing else changes for a plain `EVAL`, which
+keeps inheriting the running compunit — that IS its caller's lexical scope.
+
+## An END phaser runs in the compunit that declared it
+
+`EndPhaser` already recorded and restored the declaring **package**, for a
+reason its own comment states: END bodies run at program exit, long after
+`current_package` has returned to `GLOBAL`. The compunit needed exactly the same
+treatment, and for exactly the same reason — the strongest rule in
+`qualified_name_visible_here` is "a compunit always sees a package it declares
+itself", and at exit `current_unit` names the main compunit instead.
+
+This is invisible while the module is also visible from the main compunit, which
+is why it took an `EVAL`-loaded module to surface: there the grant went to the
+ephemeral EVAL unit, and nothing was left that could see the module's own
+package. `Log::Async`'s
+
+```raku
+END {
+    Log::Async.instance.done if Log::Async.instance;
+}
+```
+
+reached through `use-ok` (which is literally `EVAL "use $module"`) therefore
+died — and took the rest of the exit sequence with it, so the *script's own* END
+phasers never ran either.
+
+## What is still broken
+
+`Log::Async/08-use.rakutest` still fails, on a third and separate facet of the
+same "which compunit is this code from" question, now root-caused precisely:
+
+A module's `sub EXPORT` records `FunctionDef::source_file` from `?FILE` as of
+its registration, and when the load was reached through an `EVAL` run inside
+**another module's routine**, that names the invoking compunit rather than the
+module. `enter_compilation_unit` then anchors `current_unit` to it for the whole
+call, so `Terminal::ANSI::OO`'s own `sub EXPORT` cannot see its own class:
+
+```raku
+sub EXPORT($t = 't') {
+  %( $t => Terminal::ANSI::OO.new(:get-codes) )
+}
+```
+
+The discriminator is sharp — the same `EVAL "use Terminal::ANSI::OO"` succeeds
+from the main script's top level *and* from a sub declared in the main script,
+and fails only from a sub declared in another module. Anchoring at the
+`apply_module_export` call site does not help: `enter_compilation_unit` resets
+`current_unit` from the `CompiledFunction` on entry, so the fix has to be to the
+recorded `source_file` itself. #7836 carries the detail.

--- a/src/runtime/accessors_stack.rs
+++ b/src/runtime/accessors_stack.rs
@@ -236,6 +236,31 @@ impl Interpreter {
             .map(|f| format!("{}::{}", f.package, f.name))
     }
 
+    /// The compunit the frame `CALLER::` names belongs to — the same frame
+    /// `caller_frame_package` reads, resolved to a unit exactly the way
+    /// [`Self::executing_unit_sym`] resolves the *executing* one, but skipping
+    /// this routine's own frame first.
+    ///
+    /// With no caller frame at all (the routine holding `CALLER::` was called
+    /// straight from a mainline, which pushes no frame) this falls through to
+    /// the ambient `?FILE`, which is still that mainline's own file: an
+    /// ordinary call does not move `?FILE`, only a module load or a role body
+    /// does. That is the common shape for `Test.rakumod`'s `throws-like`, and
+    /// the answer it needs (#7836).
+    pub(crate) fn caller_frame_unit(&self) -> crate::symbol::Symbol {
+        let len = self.routine_stack.len();
+        if len >= 2 {
+            for frame in self.routine_stack[..len - 1].iter().rev() {
+                match frame.def_file {
+                    Some(file) => return self.unit_of_source_sym(Some(file)),
+                    None if frame.is_block => continue,
+                    None => break,
+                }
+            }
+        }
+        self.unit_of_source_sym(self.current_source_file_sym())
+    }
+
     /// The file the code currently executing was *defined* in — the module path
     /// for a routine that came from a `use`d module, the script otherwise.
     ///

--- a/src/runtime/accessors_stack.rs
+++ b/src/runtime/accessors_stack.rs
@@ -287,6 +287,45 @@ impl Interpreter {
         self.current_source_file()
     }
 
+    /// [`Self::executing_source_file`], for stamping the declaring file onto a
+    /// routine or closure *as it is created* — corrected for a declaration made
+    /// directly in a module's own top-level mainline.
+    ///
+    /// A module mainline runs via `run_block` and pushes no routine frame of its
+    /// own, so [`Self::executing_source_file`]'s frame walk reaches straight
+    /// past it to whatever routine is still on the stack underneath. That is the
+    /// *caller's* frame, and when the load was triggered from inside another
+    /// compunit's routine — `Test`'s `use-ok`, which is literally
+    /// `EVAL "use $module"` — it belongs to a different compunit entirely. Every
+    /// `sub` the module declares was then stamped with the invoking compunit's
+    /// file, and since `enter_compilation_unit` anchors `current_unit` from that
+    /// stamp on every call, the module's own `sub EXPORT` could not resolve its
+    /// own class (#7836):
+    ///
+    /// ```raku
+    /// sub EXPORT($t = 't') { %( $t => Terminal::ANSI::OO.new(:get-codes) ) }
+    /// ```
+    ///
+    /// This is the declaration-side twin of
+    /// [`Self::executing_unit_sym_for_module_load`], and uses the same test for
+    /// the same reason: `routine_stack.len()` unchanged since the innermost
+    /// still-loading module's mainline started means nothing has been CALLED
+    /// since, so that module IS what is running and `?FILE` — which
+    /// `load_module_inner` scopes to the module path for exactly this window —
+    /// is the authoritative answer. A change means a routine call happened, and
+    /// the frame-based answer is the correct one again, which is what keeps a
+    /// closure literal built each time an *already-loaded* module's routine runs
+    /// attributed to its own file rather than to the stale `?FILE`.
+    pub(crate) fn declaring_source_file(&self) -> Option<String> {
+        if let Some(&(_, depth_at_push)) = self.module_loading_unit_stack.last()
+            && self.routine_stack.len() == depth_at_push
+            && let Some(file) = self.current_source_file()
+        {
+            return Some(file);
+        }
+        self.executing_source_file()
+    }
+
     /// Current routine-stack depth. Paired with [`Self::truncate_routine_stack`] so a
     /// structured execution boundary (block scope, try/catch) can record its
     /// entry depth and restore it on exit, exception-safely.

--- a/src/runtime/accessors_stash.rs
+++ b/src/runtime/accessors_stash.rs
@@ -127,6 +127,20 @@ impl Interpreter {
     /// `eval_context_routine` treats identically to "key not found".
     pub(crate) const STASH_ORIGIN_ROUTINE_ATTR: &str = "__mutsu_origin_routine";
 
+    /// Attribute a pseudo-stash carries to remember the *compunit* the frame it
+    /// was taken from belongs to. Same invisibility convention as
+    /// `STASH_ORIGIN_PACKAGE_ATTR`.
+    ///
+    /// `EVAL` compiles in its caller's lexical scope, which for a plain `EVAL`
+    /// is the compunit running it. `EVAL $code, context => $ctx` says that
+    /// scope is `$ctx`'s frame instead — and a compunit is part of a lexical
+    /// scope, not just a package: which modules it `use`d decides what
+    /// package-qualified names it may write (#7797's
+    /// `qualified_name_visible_here`). Without this, `Test.rakumod`'s
+    /// `throws-like 'Foo::bar()'` compiled the snippet as if `Test` had
+    /// written it, and `Test` never `use`d `Foo` (#7836).
+    pub(crate) const STASH_ORIGIN_UNIT_ATTR: &str = "__mutsu_origin_unit";
+
     /// Attribute carried by a `CALLER::...::` stash to identify the live caller
     /// frame whose lexical pad it reflects.  The visible `symbols` hash is a
     /// snapshot; mutating operations such as `BIND-KEY` need this depth to reach
@@ -161,6 +175,35 @@ impl Interpreter {
                 Self::STASH_ORIGIN_ROUTINE_ATTR.to_string(),
                 Value::str(origin.to_string()),
             );
+        }
+    }
+
+    /// Stamp the frame's compunit (see `caller_frame_unit`) onto a pseudo-stash
+    /// value, beside the package and control-flow identity the two functions
+    /// above record. See `STASH_ORIGIN_UNIT_ATTR`.
+    pub(crate) fn stamp_stash_origin_unit(stash: &Value, origin: crate::symbol::Symbol) {
+        if let ValueView::Instance { attributes, .. } = stash.view() {
+            attributes.insert(
+                Self::STASH_ORIGIN_UNIT_ATTR.to_string(),
+                Value::str(origin.resolve().to_string()),
+            );
+        }
+    }
+
+    /// The compunit an `EVAL ..., context => $ctx` should compile inside, or
+    /// `None` when the context value carries no such stamp (any value that is
+    /// not a stamped pseudo-stash — a plain `Foo::` package stash, say).
+    pub(crate) fn eval_context_unit(ctx: &Value) -> Option<crate::symbol::Symbol> {
+        match ctx.view() {
+            ValueView::Instance {
+                class_name,
+                attributes,
+                ..
+            } if is_stash_class_name(class_name.as_str()) => attributes
+                .as_map()
+                .get(Self::STASH_ORIGIN_UNIT_ATTR)
+                .map(|v| crate::symbol::Symbol::intern(&v.to_string_value())),
+            _ => None,
         }
     }
 

--- a/src/runtime/builtins_eval_misc.rs
+++ b/src/runtime/builtins_eval_misc.rs
@@ -392,8 +392,25 @@ impl Interpreter {
         // unit is in scope for the EVAL'd code too -- and an operator declared
         // BY the EVAL'd code is scoped to the EVAL unit alone. Operator
         // visibility (`Interpreter::user_infix_override`) walks this chain.
+        //
+        // `context => $ctx` moves that enclosing scope to `$ctx`'s frame, and a
+        // compunit is part of a lexical scope just as much as the package
+        // already handled above: which modules a compunit `use`d is what
+        // decides the package-qualified names code written in it may use
+        // (#7797's `qualified_name_visible_here`). So the EVAL unit's parent is
+        // the context's compunit, not whichever one happens to be calling
+        // `EVAL`. Without this, `Test.rakumod`'s
+        // `throws-like 'Foo::bar()', ...` -- which passes `context =>
+        // CALLER::` precisely so the snippet compiles in the test file's scope
+        // -- had the snippet compiled as if `Test` itself had written it, and
+        // `Test` never `use`s the module under test, so every qualified name in
+        // a `throws-like` string went undeclared (#7836).
         let unit_sym = Symbol::intern(&unit_name);
-        crate::runtime::note_eval_unit_parent(unit_sym, self.current_unit);
+        let parent_unit = context_arg
+            .as_ref()
+            .and_then(Self::eval_context_unit)
+            .unwrap_or(self.current_unit);
+        crate::runtime::note_eval_unit_parent(unit_sym, parent_unit);
         let saved_unit = std::mem::replace(&mut self.current_unit, unit_sym);
         self.env
             .insert("?FILE".to_string(), Value::str(unit_name.clone()));

--- a/src/runtime/end_phasers.rs
+++ b/src/runtime/end_phasers.rs
@@ -117,6 +117,11 @@ impl Interpreter {
         // of numbering them at parse time.
         let order = super::end_order::MAIN + super::end_order::slot(Some(end_index), 0);
         let slot = self.end_phasers.len();
+        // This path only ever installs the MAIN compunit's own ENDs (see
+        // `preregister_main_end_phasers`), so the declaring unit is simply the
+        // one being compiled right now. A module's END takes the
+        // `push_end_phaser_ordered` path instead.
+        let unit = self.declaring_unit_sym();
         // Seeded rather than cloned from the pre-run env: rakudo's END is a
         // closure that was never CLONED against a live frame, so every `my`/
         // `state` lexical it mentions reads as that container's *unassigned*
@@ -143,6 +148,7 @@ impl Interpreter {
             body,
             env,
             package,
+            unit,
             dead_keys,
             order,
             capture_seq: None,
@@ -185,11 +191,13 @@ impl Interpreter {
         };
         let captured_env = self.env.clone();
         let package = self.current_package();
+        let unit = self.declaring_unit_sym();
         let mark = self.end_phaser_capture_seq;
         self.end_phaser_capture_seq += 1;
         let phaser = &mut self.end_phasers[slot];
         phaser.env = captured_env;
         phaser.package = package;
+        phaser.unit = unit;
         // A fresh capture supersedes whatever the previous one froze.
         phaser.dead_keys = crate::runtime::NameSet::default();
         phaser.capture_seq = Some(mark);
@@ -207,6 +215,7 @@ impl Interpreter {
             body,
             env: captured_env,
             package,
+            unit: self.declaring_unit_sym(),
             dead_keys: crate::runtime::NameSet::default(),
             order,
             capture_seq: Some(mark),

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1673,6 +1673,19 @@ pub(crate) struct EndPhaser {
     /// `current_package` has returned to GLOBAL — a phaser declared in a
     /// `unit module Foo` must still see `Foo`'s routines by their bare names.
     pub(crate) package: String,
+    /// The declaring compunit, for the same reason the package is recorded and
+    /// restored: at program exit `current_unit` is back to the main compunit,
+    /// but a package-qualified name written in an END body is in scope by the
+    /// rules of the compunit that *declared* it (#7797's
+    /// `qualified_name_visible_here`, whose strongest rule is "a compunit
+    /// always sees a package it declares itself").
+    ///
+    /// Only observable when the declaring module is not also visible from the
+    /// main compunit — a module `use`d from inside an `EVAL`, whose grant went
+    /// to the ephemeral EVAL unit. `Log::Async`'s `END { Log::Async.instance
+    /// ... }`, reached through `Test`'s `use-ok` (which EVALs `"use $module"`),
+    /// is exactly that, and took the whole exit sequence down with it (#7836).
+    pub(crate) unit: crate::symbol::Symbol,
     /// Keys whose declaring scope has since died. At exit the captured value is
     /// the only surviving one, so it must win over a live same-named variable
     /// in an enclosing scope — `{ my $a = 42; END { say $a } }` prints 42 even

--- a/src/runtime/registration_sub.rs
+++ b/src/runtime/registration_sub.rs
@@ -1042,7 +1042,7 @@ impl Interpreter {
             return_type: return_type.cloned(),
             is_default: custom_traits.iter().any(|(t, _)| t == "default"),
             deprecated_message,
-            source_file: self.executing_source_file(),
+            source_file: self.declaring_source_file(),
             source_line: None,
             decl_order: crate::runtime::resolution::next_decl_order(),
             compiled: None,

--- a/src/runtime/run.rs
+++ b/src/runtime/run.rs
@@ -1053,6 +1053,7 @@ impl Interpreter {
             let original_env = self.env.clone();
             for phaser in phasers.iter().rev() {
                 let (body, captured_env, package) = (&phaser.body, &phaser.env, &phaser.package);
+                let unit = phaser.unit;
                 // Track which keys are being added from captured env
                 // (not already present) so we can remove them after.
                 let mut overlay_keys: Vec<String> = Vec::new();
@@ -1084,7 +1085,16 @@ impl Interpreter {
                 if *package != saved_package {
                     self.set_current_package(package.clone());
                 }
+                // Same reasoning as the package, for the compunit (#7836): a
+                // package-qualified name in the body is in scope by the rules
+                // of the compunit that DECLARED the phaser, and by exit time
+                // `current_unit` is back to the main one. Only observable for a
+                // module whose visibility never reached the main compunit --
+                // one `use`d from inside an `EVAL`, whose grant went to the
+                // ephemeral EVAL unit (`Test`'s `use-ok` does exactly that).
+                let saved_unit = std::mem::replace(&mut self.current_unit, unit);
                 let body_result = self.run_block(body);
+                self.current_unit = saved_unit;
                 self.set_current_package(saved_package);
                 if self.halted {
                     // This phaser called `exit`. Whatever status it asked for is

--- a/src/runtime/subtest.rs
+++ b/src/runtime/subtest.rs
@@ -683,7 +683,10 @@ impl Interpreter {
             // what keeps N nested `whenever <Promise>` bodies -- one created
             // per value by an outer `whenever`, each on its own promise -- in
             // the order their promises were kept, instead of in whichever
-            // order N pooled workers happened to wake up in (#7811).
+            // order N pooled workers happened to wake up in (#7811). A promise
+            // already kept by the time this runs reserves its place right
+            // here, on this thread, so it queues behind the bodies created
+            // before it instead of running inline ahead of them (#7831).
             shared.on_resolve_in_supply_group(
                 Box::new(move |status, result, _output, _stderr| {
                     if status == "Kept" {

--- a/src/runtime/supply_promise.rs
+++ b/src/runtime/supply_promise.rs
@@ -283,9 +283,11 @@ impl Interpreter {
     /// and the tap's `quit` handler see it.
     ///
     /// Callers must run this only after registering the taps for the rewritten
-    /// markers. The waiter runs on whichever thread resolves the promise (or
-    /// synchronously here when it already has), so it drives a thread clone of
-    /// this interpreter — the same pair `promise_chain_method` uses for `.then`.
+    /// markers. The waiter runs on a pooled worker — woken by whichever thread
+    /// resolves the promise, or, when it is already resolved, reserving its
+    /// place in the group here and running just as asynchronously (#7831) — so
+    /// it drives a thread clone of this interpreter, the same pair
+    /// `promise_chain_method` uses for `.then`.
     pub(crate) fn arm_pending_promise_whenevers(&mut self) {
         for (promise, supplier) in std::mem::take(&mut self.pending_promise_whenever_arms) {
             // The stand-in's serialize group was recorded when the rewritten
@@ -293,7 +295,10 @@ impl Interpreter {
             // Handing it to `on_resolve` makes the resolving thread reserve
             // this reaction's place in the supply block before the pooled
             // worker that runs it is even woken, so N promises resolved in a
-            // row reach the block in resolution order (#7811).
+            // row reach the block in resolution order (#7811). An already
+            // resolved promise reserves its place here instead, so it queues
+            // behind the reactions created before it rather than running
+            // inline ahead of them (#7831).
             let group = match supplier.view() {
                 ValueView::Instance { attributes, .. } => {
                     supplier_id_from_attrs(&attributes.as_map())

--- a/src/value/value_async.rs
+++ b/src/value/value_async.rs
@@ -266,6 +266,8 @@ impl SharedPromise {
     /// already resolved, the callback runs synchronously on the caller's
     /// thread (matching the existing `.then`/`.andthen`/`.orelse` fast path
     /// for an already-kept/broken promise) and this returns `true`.
+    /// (A supply-block reaction is the exception — see
+    /// [`Self::on_resolve_in_supply_group`].)
     /// Otherwise the callback is queued and this returns `false`: some
     /// future `keep`/`try_keep`/`break_with`/`try_break` call will run every
     /// queued waiter, **in registration order**, on a single dedicated
@@ -287,6 +289,19 @@ impl SharedPromise {
     /// the supply block in that order, instead of in whichever order their two
     /// workers happened to wake up in. See [`SupplyTicket`].
     ///
+    /// An **already-resolved** promise takes its ticket here instead, on the
+    /// registering thread, and its reaction is handed to a pooled worker just
+    /// like a queued one. Both paths therefore enter the block through the one
+    /// sequencer, in the order the reactions were created. Running the reaction
+    /// inline, as [`Self::on_resolve`] does for a plain waiter, would let it
+    /// jump ahead of every reaction already ticketed and waiting for a worker
+    /// (#7831); redeeming the ticket inline instead is not an option either,
+    /// because this thread is typically running the enclosing supply block's
+    /// own reaction and so already holds the group lock, so parking it behind
+    /// an earlier ticket — whose worker is itself blocked on that lock — would
+    /// deadlock. So this returns `false` (the reaction has not run yet) even
+    /// when the promise was already resolved.
+    ///
     /// [`SupplyTicket`]: crate::runtime::native_methods::SupplyTicket
     pub(crate) fn on_resolve_in_supply_group(
         &self,
@@ -304,8 +319,17 @@ impl SharedPromise {
             let output = state.output.clone();
             let stderr = state.stderr_output.clone();
             drop(state);
-            waiter(status, result, output, stderr);
-            true
+            let Some(group) = group else {
+                waiter(status, result, output, stderr);
+                return true;
+            };
+            let ticket = crate::runtime::native_methods::reserve_supply_serialize(group);
+            crate::runtime::worker_pool::submit(move || {
+                // Held across the callback, exactly as in `dispatch_waiters`.
+                let _serialize_guard = ticket.redeem();
+                waiter(status, result, output, stderr);
+            });
+            false
         }
     }
 

--- a/src/vm/vm_register_ops.rs
+++ b/src/vm/vm_register_ops.rs
@@ -676,7 +676,7 @@ impl Interpreter {
                 // file by then). `executing_source_file()` instead reads the
                 // file baked onto the innermost enclosing routine frame's own
                 // `def_file`, which stays correct regardless of who is calling.
-                source_file: self.executing_source_file(),
+                source_file: self.declaring_source_file(),
                 captured_fatal_mode: self.fatal_mode,
             }));
             self.stack.push(val);
@@ -786,7 +786,7 @@ impl Interpreter {
                 // keeps this correct for a closure literal that is (re)built
                 // each time an already-loaded module's routine runs, after
                 // the module's own `?FILE` scope has long since reverted.
-                source_file: self.executing_source_file(),
+                source_file: self.declaring_source_file(),
             }));
             self.stack.push(val);
             Ok(())

--- a/src/vm/vm_register_sub_ops.rs
+++ b/src/vm/vm_register_sub_ops.rs
@@ -163,7 +163,7 @@ impl Interpreter {
                 // (`vm_register_ops.rs`). A `-> $v {...}` handed to `.tap` from
                 // inside a module is the shape that made this visible: the
                 // block could not reach its own compunit's private routines.
-                source_file: self.executing_source_file(),
+                source_file: self.declaring_source_file(),
                 captured_fatal_mode: self.fatal_mode,
             }));
             self.stack.push(val);
@@ -233,7 +233,7 @@ impl Interpreter {
                 // (`vm_register_ops.rs`). A `-> $v {...}` handed to `.tap` from
                 // inside a module is the shape that made this visible: the
                 // block could not reach its own compunit's private routines.
-                source_file: self.executing_source_file(),
+                source_file: self.declaring_source_file(),
                 captured_fatal_mode: self.fatal_mode,
             }));
             self.stack.push(val);

--- a/src/vm/vm_var_assign_local.rs
+++ b/src/vm/vm_var_assign_local.rs
@@ -450,9 +450,11 @@ impl Interpreter {
         if let Some(depth) = Self::caller_stash_depth(name) {
             let origin = self.caller_frame_package();
             let origin_routine = self.caller_frame_enclosing_routine();
+            let origin_unit = self.caller_frame_unit();
             let stash = self.caller_stash_value(name, depth);
             Self::stamp_stash_origin_package(&stash, &origin);
             Self::stamp_stash_origin_routine(&stash, origin_routine.as_deref());
+            Self::stamp_stash_origin_unit(&stash, origin_unit);
             self.stack.push(stash);
             return;
         }
@@ -491,9 +493,11 @@ impl Interpreter {
             // by the time EVAL runs. Record it on the value itself.
             let origin = self.caller_frame_package();
             let origin_routine = self.caller_frame_enclosing_routine();
+            let origin_unit = self.caller_frame_unit();
             let stash = loan_env!(self, package_stash_value(kind));
             Self::stamp_stash_origin_package(&stash, &origin);
             Self::stamp_stash_origin_routine(&stash, origin_routine.as_deref());
+            Self::stamp_stash_origin_unit(&stash, origin_unit);
             self.stack.push(stash);
             return;
         }

--- a/t/lib/EndUnitQualified.rakumod
+++ b/t/lib/EndUnitQualified.rakumod
@@ -1,0 +1,16 @@
+# Deliberately NO `unit` declarator, and a class whose name is the module's own
+# name: that is what puts `End::Unit::Qualified` into `package_declaring_units`
+# and so under the #7797 qualified-name gate. A class named anything else would
+# not be registered for this module at all, and the gate would stay permissive.
+class EndUnitQualified {
+    has $.n = 5;
+    method twice() { $!n * 2 }
+}
+
+sub end-unit-marker() is export { 'loaded' }
+
+END {
+    # Runs at program exit, long after this module's load finished -- and, in
+    # the case #7836 is about, after the EVAL unit that loaded it is gone.
+    say 'END saw ', EndUnitQualified.new.twice;
+}

--- a/t/lib/EvalContextWidget.rakumod
+++ b/t/lib/EvalContextWidget.rakumod
@@ -1,0 +1,11 @@
+unit module EvalContextWidget;
+
+# A package-qualified reference to this sub (`EvalContextWidget::make`) is the
+# thing #7836 is about: it is in scope for a compunit that `use`d this module,
+# and must stay in scope for a string EVAL'd on that compunit's behalf.
+our sub make($n) is export {
+    die "bad widget" if $n < 0;
+    $n
+}
+
+our constant WIDGET-LIMIT = 7;

--- a/t/lib/EvalLoadedExporter.rakumod
+++ b/t/lib/EvalLoadedExporter.rakumod
@@ -1,0 +1,18 @@
+# No `unit` declarator, and a class named after the module itself: that is what
+# registers `EvalLoadedExporter` as this compunit's package, and so puts the
+# qualified references below under the #7797 visibility gate. A differently
+# named class would not be registered for this module and the gate would stay
+# permissive, hiding the bug this fixture exists to catch.
+class EvalLoadedExporter {
+    has $.tag = 'exported';
+    method who() { 'exporter' }
+}
+
+our sub plain-helper() is export { EvalLoadedExporter.new.who }
+
+# The shape from the real `Terminal::ANSI::OO`: EXPORT names the module's own
+# class, qualified. EXPORT is the module's code, so it must run attributed to
+# this compunit no matter who triggered the load.
+sub EXPORT($name = 'handle') {
+    %( '&' ~ $name => sub () { EvalLoadedExporter.new.tag } )
+}

--- a/t/lib/EvalLoadingHelper.rakumod
+++ b/t/lib/EvalLoadingHelper.rakumod
@@ -1,0 +1,13 @@
+use MONKEY-SEE-NO-EVAL;
+unit module EvalLoadingHelper;
+
+# The shape of `Test`'s own `use-ok`: a module routine that loads another module
+# through a string EVAL. The load therefore runs with THIS module's routine
+# frame still on the stack, which is what used to misattribute every `sub` the
+# loaded module declares to this compunit (#7836).
+our sub load-via-eval(Str $module) is export {
+    try {
+        EVAL ( "use $module" );
+    }
+    $! ?? "FAILED: $!.Str()" !! 'ok'
+}

--- a/t/modules/end-phaser-runs-in-declaring-compunit.t
+++ b/t/modules/end-phaser-runs-in-declaring-compunit.t
@@ -1,0 +1,43 @@
+use v6;
+use lib 't/lib';
+use Test;
+
+# #7836: an END phaser runs at program exit, when `current_unit` is back to the
+# main compunit -- but a package-qualified name in its body is in scope by the
+# rules of the compunit that DECLARED it (#7797's `qualified_name_visible_here`,
+# whose strongest rule is "a compunit always sees a package it declares
+# itself"). `EndPhaser` already recorded and restored the declaring *package*
+# for exactly this reason; the compunit needed the same treatment.
+#
+# Only observable when the module's visibility never reached the main compunit:
+# one `use`d from inside an `EVAL`, whose grant went to the ephemeral EVAL unit.
+# `Test`'s own `use-ok` is literally `EVAL "use $module"`, and `Log::Async`'s
+# `END { Log::Async.instance.done ... }` reached through it took the whole exit
+# sequence down -- the script's own END phasers never ran either.
+#
+# The assertion is the child process's full output: that the module's END
+# produced its value AND that a later-declared END still ran after it.
+
+plan 2;
+
+my $prog = q:to/CODE/;
+use MONKEY-SEE-NO-EVAL;
+use lib 't/lib';
+EVAL 'use EndUnitQualified';
+say 'mainline done';
+END { say 'script END ran' }
+CODE
+
+my $script = 'tmp/end-phaser-declaring-compunit-child.raku';
+$script.IO.spurt($prog);
+
+my $proc = run($*EXECUTABLE, $script, :out, :err);
+my $out = $proc.out.slurp(:close);
+$proc.err.slurp(:close);
+
+like $out, /'END saw 10'/,
+        "a module END'd qualified self-reference resolves when EVAL-loaded";
+like $out, /'script END ran'/,
+        'and the exit sequence continues to the remaining END phasers';
+
+$script.IO.unlink;

--- a/t/modules/eval-context-inherits-caller-compunit.t
+++ b/t/modules/eval-context-inherits-caller-compunit.t
@@ -1,0 +1,46 @@
+use v6;
+use lib 't/lib';
+use MONKEY-SEE-NO-EVAL;
+use Test;
+use EvalContextWidget;
+
+# #7836: `EVAL $code, context => $ctx` compiles the snippet in `$ctx`'s frame,
+# and a compunit is part of a lexical scope just as much as a package is: which
+# modules a compunit `use`d decides which package-qualified names code written
+# in it may use (#7797's visibility gate). So the EVAL unit's parent must be the
+# CONTEXT's compunit, not whichever one happens to be running `EVAL`.
+#
+# The user-visible casualty was `Test`'s own `throws-like`, which passes
+# `context => CALLER::` precisely so the snippet compiles in the test file's
+# scope. Without this, the snippet was compiled as if `Test.rakumod` had written
+# it -- and `Test` never `use`s the module under test -- so every qualified name
+# inside a `throws-like` string went undeclared. That took three bundled
+# batteries (DateTime::Parse, Encode, Log::Async) down with it.
+
+plan 6;
+
+# The baseline both halves share: this compunit did `use EvalContextWidget`, so
+# both the imported and the qualified name are in scope when written directly.
+is EvalContextWidget::make(3), 3, 'the qualified name works written directly';
+is make(3), 3, 'the imported name works written directly';
+
+# A plain EVAL, no context: compiled by this compunit, so it inherits this
+# compunit's `use` grants.
+is (try EVAL 'EvalContextWidget::make(4)'), 4,
+        'a plain EVAL inherits the running compunit grants';
+
+# `throws-like` with a code STRING is the reported shape: `Test.rakumod` EVALs
+# it with `context => CALLER::`.
+throws-like 'EvalContextWidget::make(-1)', Exception,
+        'throws-like resolves a qualified name from the caller compunit',
+        message => /'bad widget'/;
+
+# The same for a qualified CONSTANT, not just a sub call: the two go through
+# different resolution chokepoints in the VM (bareword term vs qualified call).
+is (try EVAL 'EvalContextWidget::WIDGET-LIMIT'), 7,
+        'a qualified constant resolves in a plain EVAL';
+
+throws-like 'EvalContextWidget::WIDGET-LIMIT.no-such-method',
+        Exception,
+        'a qualified constant resolves under a throws-like context EVAL too',
+        message => /'no-such-method'/;

--- a/t/modules/module-export-runs-in-its-own-compunit.t
+++ b/t/modules/module-export-runs-in-its-own-compunit.t
@@ -1,0 +1,37 @@
+use v6;
+use lib 't/lib';
+use Test;
+use EvalLoadingHelper;
+
+# #7836: a routine records its declaring file as it is created, and a module's
+# own top-level mainline runs via `run_block` and pushes NO routine frame. So
+# the frame walk that stamps the file reached straight past the mainline to
+# whatever routine was still on the stack underneath -- the CALLER's frame, in a
+# different compunit entirely when the load came from a string EVAL inside
+# another module's routine. `Test`'s `use-ok` is exactly that shape
+# (`EVAL "use $module"`).
+#
+# Every `sub` the loaded module declared was then stamped with the invoking
+# compunit's file, and since `enter_compilation_unit` anchors `current_unit`
+# from that stamp on every call, the module's own `sub EXPORT` could not resolve
+# its own class. That is what broke `Terminal::ANSI::OO`, and with it
+# `Log::Async/08-use.rakutest` in the bundled-library gate.
+
+plan 3;
+
+# The load itself must succeed: `sub EXPORT` runs during it and names the
+# module's own class qualified.
+is EvalLoadingHelper::load-via-eval('EvalLoadedExporter'), 'ok',
+        "a module's EXPORT resolves its own class when EVAL-loaded from another module";
+
+# Loading it a second time re-runs the remembered EXPORT (its map may depend on
+# the `use` arguments), down a different code path -- which must be anchored the
+# same way.
+is EvalLoadingHelper::load-via-eval('EvalLoadedExporter'), 'ok',
+        'and again on the re-`use` path, which re-runs the remembered EXPORT';
+
+# Not just EXPORT: an ordinary `our sub` of that module carries the same stamp,
+# so calling one after such a load must reach the module's own class too.
+use EvalLoadedExporter;
+is plain-helper(), 'exporter',
+        "an ordinary sub of that module still reaches its own compunit's class";

--- a/t/supply-serialize-fifo.t
+++ b/t/supply-serialize-fifo.t
@@ -9,7 +9,7 @@ use Test;
 # nested `whenever <Promise>` bodies came out in whichever order N workers
 # happened to wake up in. `10 30 20` was roughly a coin flip at three values.
 
-plan 3;
+plan 4;
 
 # Three nested whenevers, one per emitted value, each on its own promise kept
 # inside the outer whenever body. The keeps happen in a definite order on one
@@ -58,3 +58,22 @@ $out.tap({ @mixed.push($_); $done.keep if @mixed.elems == 6 });
 $src.emit($_) for 1..6;
 await Promise.anyof($done, Promise.in(10));
 is @mixed, [1, 2, 3, 4, 5, 6], 'already-kept and later-kept promises interleave in value order';
+
+# Every promise kept before its nested `whenever` sees it, so every reaction
+# takes the already-resolved path. That path used to run the body inline on the
+# registering thread with no place in the block's sequencer at all (#7831), so
+# it had to be ordered by luck; it must be ordered by the reservation instead.
+my $src2 = Supplier.new;
+my @kept-first;
+my $done2 = Promise.new;
+my $out2 = supply {
+    whenever $src2 -> $v {
+        my $p = Promise.new;
+        $p.keep;
+        whenever $p { emit $v }
+    }
+};
+$out2.tap({ @kept-first.push($_); $done2.keep if @kept-first.elems == 10 });
+$src2.emit($_) for 1..10;
+await Promise.anyof($done2, Promise.in(10));
+is @kept-first, [1 .. 10], 'promises kept before registration stay in value order';


### PR DESCRIPTION
## Problem

`main` is red on the `test` job's bundled-library gate, so **every PR inherits it**:

```
=== summary: 287/311 test files pass (3 excluded) ===
  REGRESSION: whitelisted 'DateTime::Parse	01-basic.t'   # Could not find symbol 'DateTime::Parse'
  REGRESSION: whitelisted 'Encode	01-basic.t'            # Could not find symbol 'Encode::decode'
  REGRESSION: whitelisted 'Log::Async	08-use.rakutest'   # Could not find symbol 'Terminal::ANSI::OO'
GATE FAILED: a bundled library regressed below its recorded baseline.
```

Two commits interact to produce them. #7797 gated package-qualified names by which compunit `use`d the package; #7830 made the vendored upstream `Test` the default provider, which moved `throws-like`'s and `use-ok`'s `EVAL` out of native Rust into a real Raku compunit where that gate applies. Neither is wrong.

What was missing is one idea in three places: **several things that *run* "somewhere else" still belong, lexically, to the compunit that *wrote* them**, and the gate was reading the wrong one for each.

## Fix 1 — a context EVAL inherits the context's compunit

`EVAL $code, context => $ctx` compiles the snippet as if it stood at `$ctx`'s frame. mutsu honoured that for the *package* and for ADR-0037's `return` classification, but not for the compunit — and a compunit is part of a lexical scope just as much as a package is: which modules it `use`d is what decides the qualified names its code may write.

So the EVAL unit's parent was whichever compunit was *running* the `EVAL`. `Test.rakumod` passes `CALLER::` precisely to avoid that (*"Don't guess our caller context, know it!"*), and mutsu ignored it — compiling the snippet as if `Test` had written it, when `Test` never `use`s the module under test:

```
ok 1 - throws-like resolves the IMPORTED name
    # Got:      Could not find symbol 'Widget::make'
not ok 2 - throws-like resolves the QUALIFIED name
```

Same sub, same scope. A `CALLER::`/`CALLERS::` pseudo-stash now carries its frame's compunit (`STASH_ORIGIN_UNIT_ATTR`) beside the package and control-flow identity it already carried, and `EVAL` uses it as the EVAL unit's parent. A plain `EVAL` is unchanged — the running compunit *is* its caller's lexical scope.

**Fixes `DateTime::Parse` and `Encode`.**

## Fix 2 — an END phaser runs in the compunit that declared it

`EndPhaser` already recorded and restored the declaring **package**, for a reason its own comment states: END bodies run at exit, long after `current_package` returned to `GLOBAL`. The compunit needed the same treatment for the same reason — the strongest rule in `qualified_name_visible_here` is *"a compunit always sees a package it declares itself"*.

Invisible while the module is also visible from the main compunit, so it took an EVAL-loaded module to surface. `Log::Async`'s `END { Log::Async.instance.done ... }`, reached through `use-ok`, died — and **took the rest of the exit sequence with it**, so the script's own END phasers never ran either.

## Fix 3 — a module's own routines are stamped with the module's file

A routine records its declaring file as it is *created*, via `executing_source_file()`, which walks the routine stack for the innermost frame's `def_file`. A module's mainline runs through `run_block` and pushes **no routine frame**, so that walk goes straight past it to whatever routine is still on the stack underneath — a different compunit entirely when the load came from `EVAL "use $module"` inside another module's routine.

`enter_compilation_unit` then anchors `current_unit` from that stamp on every call, so `Terminal::ANSI::OO`'s own EXPORT could not resolve its own class. Measured at the registration site, the two available answers disagree exactly as predicted:

```
REGSUB name=EXPORT
  exec_sf = .../UseOkish.rakumod                 <- stale caller frame
  ?FILE   = .../Terminal/ANSI/OO.rakumod         <- correct
  rstack  = 2   modstack = (.../OO.rakumod, 2)   <- depths match
```

`declaring_source_file()` is the declaration-side twin of `executing_unit_sym_for_module_load()` and uses the same test for the same reason. A routine call since the mainline started means the frame-based answer is right again, which is what keeps the behaviour those five sites' comments were written to protect.

> An earlier attempt anchored `current_unit` at the `apply_module_export` call site instead. That does **not** work — `enter_compilation_unit` resets `current_unit` from the `CompiledFunction` on entry. Verified with the debugger and reverted rather than left as dead code.

## Verification

- **The gate is green again: `285/311`, all three regressions gone.** The only files still failing locally are the six `DBIish` mysql ones, which need a `libmysqlclient` this container has not got (`NativeCall: symbol 'mysql_init' not found ... dlsym failed`) and which CI installs.
- Three focused regression tests under `t/modules/`, **each verified against rakudo**.
- `cargo fmt --all`, `make lint` (all four configurations), `make check-t-layout`, `make test` (3953 files, 42004 tests, PASS), `make roast` (clean but for the three documented container-only files).

## Note on the merged commit

This branch also carries the #7831 supply-ticket fix from **#7834**. Without it `t/supply-serialize-fifo.t` test 3 fails 17–37% of runs and the `t/` suite is fatal in CI, so an unrelated red would be a coin flip on every push here. It no-ops the moment `main` carries it — if this lands first, #7834 becomes already-merged content and I will close it pointing here.

Closes #7836.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019yehkGnudWM9qirASmfYo3

---
_Generated by [Claude Code](https://claude.ai/code/session_019yehkGnudWM9qirASmfYo3)_