### PR TITLE
chore(setup): install libmysqlclient from the SessionStart hook

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -11,8 +11,11 @@
 #      .claude/skills/rustc-too-old/SKILL.md).
 #   2. raku — the Rakudo oracle used to check expected behaviour is absent
 #      entirely, and Ubuntu's packaged one is far too old to be useful.
+#   3. libmysqlclient — the base image ships libpq and libsqlite3 but not this
+#      one, so every DBIish MySQL file in the battery suite dies with a
+#      NativeCall "symbol 'mysql_init' not found ... dlsym failed".
 #
-# Both are mechanical to fix, so fix them here rather than paying for the
+# All three are mechanical to fix, so fix them here rather than paying for the
 # rediscovery every session.
 #
 # Local checkouts are left alone: a developer machine is pinned by .mise.toml
@@ -93,8 +96,66 @@ setup_raku() {
   say "raku installed: $(raku --version 2>/dev/null | head -n1)"
 }
 
+# ------------------------------------------------------ native C libraries --
+# The bundled batteries dlopen a handful of C libraries by SONAME at runtime.
+# When one is absent the failure surfaces as a NativeCall `dlsym failed` raised
+# from deep inside the module, which reads like a mutsu bug rather than a
+# missing package -- so install them up front.
+#
+# DBIish's mysql driver asks NativeLibs for `libmysqlclient.so.16..21`, so
+# Ubuntu's `libmysqlclient21` is exactly what it wants. Note that
+# `default-libmysqlclient-dev` is NOT a substitute: on Ubuntu it pulls MariaDB's
+# `libmariadb.so.3`, which that versioned search does not match.
+#
+# `libpq` and `libsqlite3` already ship in the base image; add a
+# "<soname> <package>" row here if a battery ever needs another.
+NATIVE_LIBS=(
+  "libmysqlclient.so.21 libmysqlclient21"
+)
+
+setup_native_libs() {
+  local row soname pkg
+  local missing=()
+  for row in "${NATIVE_LIBS[@]}"; do
+    soname="${row%% *}"
+    pkg="${row#* }"
+    # `ldconfig -p` prints "\t<soname> (libc6,x86-64) => <path>", so compare the
+    # first field exactly rather than substring-matching a line that starts
+    # with a tab.
+    if ldconfig -p 2>/dev/null | awk -v s="$soname" '$1 == s { hit = 1 } END { exit !hit }'; then
+      say "$soname already present"
+    else
+      missing+=("$pkg")
+    fi
+  done
+  if [ "${#missing[@]}" -eq 0 ]; then
+    return 0
+  fi
+
+  if [ "$(id -u)" != 0 ] || ! command -v apt-get >/dev/null 2>&1; then
+    warn "missing native libraries (${missing[*]}) and no way to install them; the DBIish MySQL battery files will fail with 'dlsym failed'"
+    return 0
+  fi
+
+  say "installing native libraries: ${missing[*]}"
+  export DEBIAN_FRONTEND=noninteractive
+  if apt-get install -y --no-install-recommends "${missing[@]}" >/dev/null 2>&1; then
+    say "native libraries installed"
+    return 0
+  fi
+  # A stale package index is the usual reason the first attempt fails; an
+  # `apt-get update` is slow enough to be worth skipping unless it is needed.
+  apt-get update -qq >/dev/null 2>&1 || true
+  if apt-get install -y --no-install-recommends "${missing[@]}" >/dev/null 2>&1; then
+    say "native libraries installed (after apt-get update)"
+  else
+    warn "could not install ${missing[*]}; the DBIish MySQL battery files will fail with 'dlsym failed'"
+  fi
+}
+
 setup_rust
 setup_raku
+setup_native_libs
 
 # Warm the crate cache so the first build is compile-only. Cheap next to the
 # build itself, and the container image is snapshotted after this hook.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -488,17 +488,19 @@ anything not on `origin` is not saved.
 ### Remote containers self-provision via a SessionStart hook
 
 Sessions started from the Claude app / Claude Code on the web get a **fresh container** whose base
-image usually ships a rustc older than this repo compiles under and no `raku` at all. Both are fixed
-automatically by `.claude/hooks/session-start.sh`, registered as a `SessionStart` hook in
+image usually ships a rustc older than this repo compiles under, no `raku` at all, and none of the
+C shared libraries the bundled batteries `dlopen`. All three are fixed automatically by
+`.claude/hooks/session-start.sh`, registered as a `SessionStart` hook in
 `.claude/settings.json`: it installs the highest Rust version declared by the repo (the `ci.yml`
 toolchain pin, `Cargo.toml`'s `rust-version`, `.mise.toml`) via rustup, runs
-`.agents/skills/install-raku/install-raku.sh` when `raku` is missing, and warms the crate cache with
-`cargo fetch`. It is idempotent (~0.3s when everything is already in place) and does nothing on a
-local checkout unless `MUTSU_SETUP_FORCE=1` is set — a developer machine is pinned by `.mise.toml`
-and owns its own toolchain.
+`.agents/skills/install-raku/install-raku.sh` when `raku` is missing, apt-installs the native
+libraries listed in its `NATIVE_LIBS` array (currently just `libmysqlclient21`, which DBIish's mysql
+driver needs), and warms the crate cache with `cargo fetch`. It is idempotent (~0.14s when
+everything is already in place) and does nothing on a local checkout unless `MUTSU_SETUP_FORCE=1`
+is set — a developer machine is pinned by `.mise.toml` and owns its own toolchain.
 
-So **do not hand-install rustc or rakudo at the start of a remote session** — it has already
-happened, and the `raku` oracle is available there too. If a build still fails with `E0658`, the hook
+So **do not hand-install rustc, rakudo or `libmysqlclient` at the start of a remote session** — it
+has already happened, and the `raku` oracle is available there too. If a build still fails with `E0658`, the hook
 did not run (check for its `session-start: environment ready` line) and
 `.claude/skills/rustc-too-old/SKILL.md` applies. Whenever a version pin moves, the hook follows it
 with no edit; only the *sources* of the pins are hardcoded, so add a new one there if the repo ever

--- a/docs/agent-environments.md
+++ b/docs/agent-environments.md
@@ -73,13 +73,21 @@ Two consequences worth spelling out:
   `pull_request_read`/`get_check_runs` again after doing other work, or use
   `subscribe_pr_activity` so CI results and review comments wake the session.
 
-## Provisioning: rust and raku
+## Provisioning: rust, raku and the native C libraries
 
 `.claude/hooks/session-start.sh` (registered as a `SessionStart` hook in `.claude/settings.json`)
 installs the highest Rust version the repo declares, runs `.agents/skills/install-raku/install-raku.sh`
-when `raku` is missing, and warms the crate cache with `cargo fetch`. It is idempotent (~0.3s when
-everything is in place) and does nothing on a local checkout unless `MUTSU_SETUP_FORCE=1` is set —
-a developer machine is pinned by `.mise.toml` and owns its own toolchain.
+when `raku` is missing, installs the C shared libraries the bundled batteries `dlopen`, and warms
+the crate cache with `cargo fetch`. It is idempotent (~0.3s when everything is in place) and does
+nothing on a local checkout unless `MUTSU_SETUP_FORCE=1` is set — a developer machine is pinned by
+`.mise.toml` and owns its own toolchain.
+
+The native-library list is the `NATIVE_LIBS` array at the top of `setup_native_libs()`, one
+`"<soname> <apt package>"` row each. It currently holds a single entry, `libmysqlclient.so.21` /
+`libmysqlclient21` (`libpq` and `libsqlite3` already ship in the base image). Note that
+`default-libmysqlclient-dev` is *not* a substitute: on Ubuntu it pulls MariaDB's `libmariadb.so.3`,
+which DBIish's `NativeLibs::Searcher.try-versions('mysqlclient', 16..21)` does not match. Installing
+it costs about 2s on a cold container; the whole hook then takes ~0.14s on every later run.
 
 So **do not hand-install rustc or rakudo at the start of a remote session** — it has already
 happened, and `raku` is available as the oracle. If a build still fails with `E0658`, the hook did
@@ -136,18 +144,23 @@ Two things this list is not:
 ## Environment-only `scripts/battery-testsuite.sh` failures
 
 The battery gate is not part of CI (it runs at release time, and on demand when a change can affect
-a bundled library's own code paths). In a remote container it cannot come back green either, for one
-reason: **`libmysqlclient` is not installed**, so DBIish's MySQL files cannot run. The tell is a
-`NativeCall: symbol 'mysql_init' not found in 'this process': dlsym failed` raised from
+a bundled library's own code paths). Historically it could not come back green in a remote container
+for one reason: **`libmysqlclient` was not installed**, so DBIish's MySQL files could not run. The
+tell was a `NativeCall: symbol 'mysql_init' not found in 'this process': dlsym failed` raised from
 `DBDish/mysql.rakumod`, and a `FAIL(ok=0/N,notok=0)` — zero assertions ran, none failed.
+
+**The `SessionStart` hook now installs `libmysqlclient21`** (see "Provisioning" above), so this
+should no longer happen. If you do see that shape:
 
 | Files | Shape | Why |
 |---|---|---|
 | `DBIish/24-mysql-types.rakutest`, `24-mysql-types-json`, `25-mysql-common`, `26-mysql-blob`, `27-mysql-datetime`, `28-mysql-connection-lock` | `FAIL(ok=0/N,notok=0)`, or a `timeout 120` part-way through | no `libmysqlclient` in the container |
 
-`ldconfig -p | grep -c mysql` returning `0` confirms it. The same two caveats as the roast list
-above apply: confirm the failing set is a subset of these *by name*, and a `notok` greater than zero
-in any of them is a real failure, not this.
+`ldconfig -p | grep -c mysql` returning `0` confirms it, and means the hook did not run or could not
+reach the archive — re-run it by hand with `MUTSU_SETUP_FORCE=1 .claude/hooks/session-start.sh`
+rather than treating the failures as environmental. The same two caveats as the roast list above
+apply: confirm the failing set is a subset of these *by name*, and a `notok` greater than zero in any
+of them is a real failure, not this.
 
 Run the gate **alone** — two of them in a shared `tmp/battery-testsuite` workdir produce a false
 REGRESSION — and remember it needs network access to fetch each upstream suite at its pinned commit.

--- a/news/2026-09/session-start-installs-libmysqlclient.md
+++ b/news/2026-09/session-start-installs-libmysqlclient.md
@@ -1,0 +1,50 @@
+# The SessionStart hook installs libmysqlclient
+
+Remote containers ship `libpq` and `libsqlite3` in their base image but not
+`libmysqlclient`, so every DBIish MySQL file in the battery suite died with
+
+```
+NativeCall: symbol 'mysql_init' not found in 'this process': dlsym failed
+```
+
+raised from `DBDish/mysql.rakumod`, scoring `FAIL(ok=0/N,notok=0)` — zero
+assertions ran, none failed. Eight files sit in `batteries-whitelist.txt` behind
+that library (`20-mysql`, `24-mysql-types`, `24-mysql-types-json`,
+`25-mysql-common`, `26-mysql-blob`, `27-mysql-datetime`,
+`28-mysql-connection-lock`, `28-mysql-threads`), which meant
+`scripts/battery-testsuite.sh` could never come back green in a remote session
+and its output had to be read against a documented list of expected
+environmental failures.
+
+`.claude/hooks/session-start.sh` now installs it, alongside the rustc and raku
+provisioning it already did. The new `setup_native_libs()` walks a `NATIVE_LIBS`
+array of `"<soname> <apt package>"` rows, checks each soname against
+`ldconfig -p` (comparing the first field exactly — `ldconfig` indents its
+listing with a tab, so a substring match on `" $soname "` silently never fires),
+and `apt-get install`s only what is missing. A failed first attempt is retried
+once after `apt-get update`, since a stale package index is the usual cause and
+the update is slow enough to be worth skipping when it is not needed. If the
+session is not root, or has no `apt-get`, the hook warns and carries on rather
+than failing the session.
+
+The array holds a single row today:
+
+```
+libmysqlclient.so.21 libmysqlclient21
+```
+
+`default-libmysqlclient-dev` is deliberately *not* used: on Ubuntu it pulls
+MariaDB's `libmariadb.so.3`, and DBIish asks
+`NativeLibs::Searcher.try-versions('mysqlclient', 16..21)` for a versioned
+`libmysqlclient.so.NN`, which that name does not match. Ubuntu 24.04's
+`libmysqlclient21` provides exactly `libmysqlclient.so.21`.
+
+Measured on a fresh remote container: the install costs about 2s, and the whole
+hook then runs in ~0.14s on every later session where the library is already
+present. Both branches were exercised by removing the package and re-running the
+hook.
+
+The environmental-failure list in `docs/agent-environments.md` was updated
+accordingly: a `dlsym failed` there is no longer "just the container", it means
+the hook did not run or could not reach the archive, and the fix is to re-run it
+by hand with `MUTSU_SETUP_FORCE=1 .claude/hooks/session-start.sh`.


### PR DESCRIPTION
## Problem

Remote containers ship `libpq` and `libsqlite3` in their base image but not `libmysqlclient`, so every DBIish MySQL file in the battery suite dies with

```
NativeCall: symbol 'mysql_init' not found in 'this process': dlsym failed
```

raised from `DBDish/mysql.rakumod`, scoring `FAIL(ok=0/N,notok=0)` — zero assertions ran, none failed.

Eight whitelisted battery files sit behind that library (`20-mysql`, `24-mysql-types`, `24-mysql-types-json`, `25-mysql-common`, `26-mysql-blob`, `27-mysql-datetime`, `28-mysql-connection-lock`, `28-mysql-threads`), which meant `scripts/battery-testsuite.sh` could never come back green in a remote session and its output had to be read against a documented list of expected environmental failures.

## Change

Add `setup_native_libs()` to `.claude/hooks/session-start.sh`, alongside the rustc and raku provisioning it already does:

- it walks a `NATIVE_LIBS` array of `"<soname> <apt package>"` rows and checks each soname against `ldconfig -p`, comparing the **first field exactly** — `ldconfig` indents its listing with a tab, so a substring match on `" $soname "` silently never fires (that was the first version of this patch, and it re-ran apt on every session);
- only what is missing is installed, and a failed first attempt is retried once after `apt-get update`, since a stale package index is the usual cause and the update is slow enough to be worth skipping when it is not needed;
- not being root, or having no `apt-get`, warns and carries on rather than failing the session.

The array holds a single row today:

```
libmysqlclient.so.21 libmysqlclient21
```

`default-libmysqlclient-dev` is deliberately **not** used: on Ubuntu it pulls MariaDB's `libmariadb.so.3`, and DBIish asks `NativeLibs::Searcher.try-versions('mysqlclient', 16..21)` for a versioned `libmysqlclient.so.NN`, which that name does not match. Ubuntu 24.04's `libmysqlclient21` provides exactly `libmysqlclient.so.21`.

## Verification

Measured on a fresh remote container, both branches exercised by removing the package and re-running the hook:

| State | Whole hook |
| --- | --- |
| package absent (installs it) | ~2.4s |
| package present (`libmysqlclient.so.21 already present`) | ~0.14s |

```
$ ldconfig -p | grep -i mysql
	libmysqlclient.so.21 (libc6,x86-64) => /lib/x86_64-linux-gnu/libmysqlclient.so.21
```

`bash -n` clean. No Rust source, test, `Makefile` or workflow file is touched, so `make test` / `make roast` have nothing to catch here; the full CI suite still runs on this PR because `.claude/**` is (correctly) not in `scripts/ci-docs-only.sh`'s allowlist.

## Docs

- `docs/agent-environments.md` — the provisioning section now covers native libraries and where to add a row; the "environment-only battery failures" section no longer says `libmysqlclient` is simply absent, and a `dlsym failed` there now means *the hook did not run or could not reach the archive*, with `MUTSU_SETUP_FORCE=1 .claude/hooks/session-start.sh` as the fix.
- `CLAUDE.md` — the SessionStart-hook paragraph matches.
- `news/2026-09/session-start-installs-libmysqlclient.md` — the narrative record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019GZzDqqBYeaq6JUBQANtUF


---
_Generated by [Claude Code](https://claude.ai/code/session_019GZzDqqBYeaq6JUBQANtUF)_