### PR TITLE
docs: design the ecosystem test-suite parity KPI (ADR-0085, #7785)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -100,6 +100,14 @@ work; see the CLAUDE.md "mzef package manager and distribution" section. The **R
 
 ### B4. Module-compatibility frontier (the base of batteries)
 
+- [ ] **★Ecosystem parity KPI** — run every zef distribution's own test suite on **both** rakudo and
+      mutsu and publish the difference as the project's headline compatibility number, with
+      per-distribution machine-readable records in `ecosystem/`.
+      Decisions: [ADR-0085](docs/adr/0085-ecosystem-testsuite-parity-measurement.md);
+      operations manual and phases (P1-P5, one PR each):
+      [docs/ecosystem-parity.md](docs/ecosystem-parity.md);
+      tracking issue [#7785](https://github.com/tokuhirom/mutsu/issues/7785).
+      Its P4 (scheduled report-only sweep) also closes B1's "working-module regression CI".
 - [ ] **★Real-dist compatibility sweep** — run real fez dists under mutsu and fix the general bugs
       they surface. Ledger: [docs/dist-compat-sweep.md](docs/dist-compat-sweep.md). **The `--run-tests`
       axis is the sharper frontier**: running each loading dist's own suite with raku as the baseline.

--- a/docs/adr/0085-ecosystem-testsuite-parity-measurement.md
+++ b/docs/adr/0085-ecosystem-testsuite-parity-measurement.md
@@ -1,0 +1,243 @@
+# ADR-0085 — The ecosystem KPI is per-distribution test-suite parity against rakudo
+
+- Status: Proposed
+- Date: 2026-09-10
+- Issue: [#7785](https://github.com/tokuhirom/mutsu/issues/7785)
+- Operations manual (the "how"): [docs/ecosystem-parity.md](../ecosystem-parity.md)
+
+## Context
+
+mutsu's stated goal is a batteries-included Raku implementation, and its
+positioning claim is *compatibility*: real ecosystem code runs. Today the
+project has no number for that claim.
+
+What exists measures something narrower:
+
+- **roast** (`roast-whitelist.txt`, 1436/1464) is at its ceiling and is a
+  *language spec* measure, not an *ecosystem* one. PLAN.md §3 already records
+  that it is no longer the productive axis.
+- **The batteries gate** (`scripts/battery-testsuite.sh`, `batteries.lock`) runs
+  the upstream suites of the ~40 dists mutsu *bundles*. It is a regression gate
+  on a hand-picked set, not a survey.
+- **The dist-compat sweep** (`scripts/dist-compat-sweep.py`,
+  [docs/dist-compat-sweep.md](../dist-compat-sweep.md)) samples random fez dists
+  and asks only whether `use <module>` succeeds. Its own "Planned deepenings §1"
+  names the missing level: *run each dist's own test suite*. Its `--run-tests`
+  flag is a prototype of exactly that, but it is a sampler (random seed, first
+  failure wins, results land in `tmp/`), not a ledger.
+
+So the question a user actually asks — **"does my module work on mutsu?"** — has
+no answer in the repository, and the project has no KPI that moves when real
+compatibility improves.
+
+Issue #7785 asks for that: run every zef distribution's test suite on both
+rakudo and mutsu, treat the difference as the headline KPI, keep the data in the
+repository in machine-readable form with the versions it was measured at, allow
+re-measurement per distribution (and per first letter), and publish it.
+
+The issue also sets a precondition: *"This campaign should only begin after you
+start using Test.rakumod."* That precondition is **met as of 2026-09-10**: a bare
+`use Test` resolves to rakudo's unmodified `modules/Rakudo-Core/lib/Test.rakumod`
+and there is nothing else it could load — the native TAP provider was retired
+that day ([#7566](https://github.com/tokuhirom/mutsu/issues/7566)) and the
+`MUTSU_REAL_TEST` switch went with it (`modules/Rakudo-Core/README.md`).
+
+The precondition matters because it is load-bearing for every number this
+campaign produces. A natively-provided `Test` would be comparing mutsu's own
+assertion implementation against rakudo's, so each side would be counting
+`ok` lines its *own* harness decided to emit. Since the two sides now run the
+same `Test.rakumod` source, a TAP line means the same thing on both.
+
+## Decision
+
+Adopt **per-distribution test-suite parity against a same-host rakudo run** as
+mutsu's ecosystem KPI, measured by a dedicated, exhaustive, re-runnable harness
+whose per-distribution results are committed to the repository.
+
+The eight decisions below are the ones that are costly to reverse once thousands
+of records exist. Everything else — CLI spelling, output formatting, phasing —
+is operational and lives in [docs/ecosystem-parity.md](../ecosystem-parity.md).
+
+### D1. The unit of measurement is a distribution; the unit of comparison is a test file
+
+A "zef module" in the issue is a **distribution** (`Dist::Name` in the fez
+index): the thing that has a version, a tarball, a `META6.json`, and a test
+suite. A *module* is one entry in its `provides`. The vocabulary is fixed that
+way everywhere in this campaign — records are keyed by distribution.
+
+Inside a distribution the comparable unit is one **test file** run as one
+process, because that is the unit both `prove` and `zef test` use and the unit a
+TAP plan describes. Assertions are counted within a file but are not the unit:
+`ok 7` in rakudo and `ok 7` in mutsu are only comparable when the file reached
+the same point.
+
+### D2. Rakudo is the denominator, run on the same host in the same sweep
+
+The recorded number is never mutsu's absolute pass rate. It is always a ratio to
+a rakudo run of **the same distribution version, the same test file, the same
+dependency set, the same working directory, the same environment, and the same
+timeout**, executed in the same sweep on the same machine.
+
+This is not fussiness. A large fraction of ecosystem suites fail for reasons
+that have nothing to do with the interpreter: they need the network, a database,
+a specific OS, an author-only fixture, or they are simply broken at their latest
+published version. An absolute pass rate would report all of that as mutsu's
+failure and would drift with the host. A ratio to rakudo cancels it.
+
+Consequence: a test file rakudo does not pass cleanly is **excluded from the KPI
+denominator** and recorded as `no_baseline`. It is never counted as a mutsu
+failure, and never as a mutsu success.
+
+### D3. Three parity numbers, and `file_parity` is the headline
+
+Let *B* be the set of test files that rakudo passes cleanly in this sweep.
+
+| metric | definition | role |
+|---|---|---|
+| `file_parity` | `count(f in B where mutsu passes f) / count(B)` | **the KPI** — the number to move |
+| `assertion_parity` | `sum over B of min(mutsu_ok, raku_ok) / sum over B of raku_ok` | fine-grained progress; moves even when no file flips |
+| `dist_parity` | `count(dists whose whole baseline set passes on mutsu) / count(dists with a non-empty baseline set)` | the user-facing "which modules work" number |
+
+All three are reported, and both sides' raw TAP counts are stored per file, so
+any other aggregate can be recomputed later **without re-running anything**.
+That is the reason the store keeps per-file counts rather than a rolled-up
+verdict: a metric definition we change in six months must not cost a re-sweep.
+
+### D4. Dependencies are resolved as a flat `-I` closure from the ecosystem index — never installed
+
+For each distribution, resolve the transitive closure of `depends` +
+`test-depends` **offline, from the fez index itself** (its `provides` map covers
+9214 module names), download and extract each dependency tarball, and pass
+`-I <dep>/lib` for every member of the closure — the *same* list to both
+interpreters.
+
+Rejected alternatives:
+
+- **`zef install` for rakudo and `mzef install` for mutsu.** Two different
+  installers, two different repository formats, precompilation on one side and
+  not the other: the two sides would no longer be running the same code, and a
+  bootstrap failure in `mzef` (itself running on mutsu) would silently become a
+  mutsu compatibility number.
+- **Installing into a shared site repository.** Same asymmetry, plus it makes a
+  run depend on the order dists were installed in.
+
+A flat `-I` closure is deterministic, cacheable, identical for both
+interpreters, and needs no package manager at either end. Measured on the
+2026-09-10 fez snapshot: **1383 of 1623 distributions (85%) have a first-level
+dependency list that resolves entirely from the index**, so this covers the
+corpus well enough to start; the residue is recorded, not worked around.
+
+### D5. A distribution whose dependency closure cannot be resolved is skipped on *both* sides
+
+When the closure cannot be completed (a dependency published only to a legacy
+ecosystem, or genuinely absent), the distribution is recorded as `blocked_dep`
+and is **not run on either interpreter**.
+
+The temptation is to run it anyway and let mutsu's bundled batteries
+(`modules/`, resolved below `-I` in the precedence chain) satisfy the gap. That
+would be a real advantage of the product — and exactly the wrong thing to put in
+a parity number, because rakudo would fail on a missing dependency while mutsu
+passed, and the KPI would rise without any compatibility improving.
+
+The value of the bundle is instead recorded *separately*: each `blocked_dep`
+record notes whether a bundled battery would have supplied the missing
+dependency (`bundled_would_supply`). That is a batteries statistic, reported as
+such, not folded into parity.
+
+### D6. The store is one JSON file per distribution, sharded by first letter
+
+```
+ecosystem/dists/<S>/<Dist--Name>.json
+```
+
+with `<S>` the uppercased first character (`_` when not an ASCII letter) and
+`::` written `--` in the filename.
+
+One file per distribution is chosen for the same reason `news/` is one file per
+entry and for the reason `docs/dist-compat-sweep.md` had to adopt one-row-per-dist
+tables: **a shared file conflicts with every parallel PR.** Here it also makes
+the issue's two re-measurement modes fall out of the layout for free —
+re-measuring one distribution rewrites exactly one file, and "all modules
+starting with A" is one directory.
+
+Derived artifacts (`ecosystem/summary.json`, `ecosystem/summary.md`,
+`site/content/ecosystem.json`) are **generated from that tree** and never hand
+edited, so a conflict in them is resolved by regenerating rather than by
+merging.
+
+### D7. Every record carries the versions it was measured at, and staleness is visible
+
+Each record stores the mutsu commit and version, the rakudo version and backend,
+the distribution version, the index snapshot it was drawn from, the dependency
+closure digest, the host platform, and the sandbox mode. A record whose
+`mutsu_commit` is not an ancestor of the current `main`, or whose `raku_version`
+differs from the current oracle, is **stale by definition** and the tooling can
+select exactly those for re-measurement.
+
+Timestamps are recorded at **date** granularity. A re-run that reproduces the
+same verdicts on the same day therefore produces a byte-identical file and no
+diff; a sweep on a new day rewrites the records it executed with a one-line
+provenance delta, which is a truthful "re-verified at commit X" record and an
+acceptable churn budget for a weekly-or-slower full sweep.
+
+### D8. Both interpreters run sandboxed and identically configured, and the harness enforces it
+
+Running the test suites of ~1600 unaudited distributions is arbitrary code
+execution at scale. Both sides run inside the same bubblewrap confinement the
+dist-compat sweep already uses (no network, read-only filesystem, throwaway
+HOME, own PID namespace, rlimits) — *both* sides, because a network-dependent
+suite must fail symmetrically or it would show up as a mutsu regression.
+`--sandbox none` exists for a single distribution the operator already trusts;
+a corpus sweep without a sandbox is not a supported mode.
+
+Two environment rules are part of the measurement contract and are enforced by
+the harness at startup, not left to the operator:
+
+- `MUTSU_FUDGE` must be **unset** — it is roast-only, and a stray `#?rakudo skip`
+  in a dist would silently drop the next statement.
+- `use Test` must resolve to the vendored `Test.rakumod` on the mutsu side, not
+  to a native provider or to a copy shadowed by the `-I` closure. The provider
+  is retired, so this is a guard against regression rather than a switch, but a
+  sweep that cannot confirm it aborts rather than publishing a flattered
+  number.
+
+## Consequences
+
+- The project gains a compatibility number that is defensible, reproducible, and
+  moves when real compatibility improves — and a user-facing answer to "does my
+  module work on mutsu?".
+- `scripts/dist-compat-sweep.py` keeps its job as the **diagnostic sampler**
+  (load-level buckets, root-cause grouping into `TODO_dist/TICKETS.md`); the new
+  harness is the **exhaustive ledger**. The two share one implementation of the
+  index reader, the tarball cache, the sandbox wrapper and the TAP parser, so
+  the security-relevant code exists once.
+  [docs/dist-compat-sweep.md](../dist-compat-sweep.md) "Planned deepenings §1"
+  is fulfilled by this campaign and points here.
+- The `regression` records become the highest-volume source of real,
+  impact-ordered interpreter bugs the project has, at a moment when roast is
+  mined out (PLAN.md §3). They feed the existing queue in the shape
+  `scripts/dist-compat-tickets.py` already produces — root cause first, dists
+  affected as the impact count — rather than a new process.
+- A rakudo upgrade moves the denominator. That is recorded per record and noted
+  in the KPI history, and is the accepted cost of D2.
+- Suites that need the network are invisible to the KPI (they fail on both
+  sides, landing in `no_baseline`). This is a known, recorded blind spot, not a
+  silent one.
+- Committing ~1600 records is a few megabytes of JSON and a bounded per-sweep
+  diff. Accepted in exchange for the data being *in the repository*, which the
+  issue requires and which makes it browsable, diffable and reviewable.
+
+## Alternatives considered
+
+- **Keep sampling instead of sweeping the corpus.** A random sample answers
+  "how are we doing" but never answers "does *my* module work", which is half of
+  what the issue asks for, and its number jumps with the seed.
+- **Store the data on a side branch** (the `bench-data` pattern). Cheaper diffs,
+  but the issue says *in the repository*, and a side branch is invisible to
+  someone browsing the project or reviewing a PR that changes compatibility.
+- **Measure only load success (extend the existing L0 sweep to the whole
+  corpus).** Much cheaper, and genuinely useful — but "it loads" is not "it
+  works", and the gap between the two is precisely the interesting part.
+- **Publish an absolute pass rate.** Simpler to explain, but it reports the
+  ecosystem's own breakage and the host's limitations as mutsu's failure, and it
+  cannot be compared across machines or across time.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -110,3 +110,4 @@ The role of an ADR is to preserve the *context of the judgment* — something th
 | [0082](0082-a-collecting-for-gathers-containers-not-snapshots.md) | A value-collecting `for` gathers containers, not snapshots | Superseded by 0083 |
 | [0083](0083-a-collected-for-retains-containers-past-the-loop.md) | A collected `for` retains lvalue containers past the loop | Accepted (implemented) |
 | [0084](0084-the-frame-env-is-not-the-programs-symbol-table.md) | The per-frame `Env` is not the program's symbol table — type/package names and internal markers move to side tables | Proposed (design complete; implementation not started) |
+| [0085](0085-ecosystem-testsuite-parity-measurement.md) | The ecosystem KPI is per-distribution test-suite parity against rakudo | Proposed (design complete; implementation not started) |

--- a/docs/dist-compat-sweep.md
+++ b/docs/dist-compat-sweep.md
@@ -241,6 +241,16 @@ Time::Duration · Time::Duration::Parser · Trap · Util::Uuencode · ValueList
 1. **Level 2 — run each dist's own test suite** (not just `use`): after
    `load_ok`, run `t/`/`.rakutest` under mutsu with deps installed. This catches
    runtime (not just load) divergence and is the truer "runs on mutsu" measure.
+   **This is now its own campaign, designed in
+   [ADR-0085](adr/0085-ecosystem-testsuite-parity-measurement.md) with the
+   operations manual in [docs/ecosystem-parity.md](ecosystem-parity.md)**
+   ([#7785](https://github.com/tokuhirom/mutsu/issues/7785)): an exhaustive,
+   re-runnable ledger over the whole fez corpus that runs each suite on
+   **both** rakudo and mutsu and publishes the difference as the project KPI.
+   This sweep stays what it is — the *sampling diagnostic* that buckets load
+   failures by root cause and feeds `TODO_dist/TICKETS.md`; the two will share
+   one implementation of the index reader, tarball cache, sandbox wrapper and
+   TAP parser.
 2. **Dep-closure sweep**: `mzef install` each sampled dist into a shared throwaway
    HOME so `missing_dep` collapses and second-order bugs (deps that themselves
    fail) surface.

--- a/docs/ecosystem-parity.md
+++ b/docs/ecosystem-parity.md
@@ -1,0 +1,302 @@
+# Ecosystem parity — measuring mutsu against rakudo, one distribution at a time
+
+The operations manual for mutsu's headline compatibility KPI: run every zef
+distribution's own test suite under **both rakudo and mutsu**, record both
+sides, and publish the difference.
+
+- **Why it is shaped this way**: [ADR-0085](adr/0085-ecosystem-testsuite-parity-measurement.md)
+  — the decisions (rakudo as the denominator, flat dependency closures,
+  one file per distribution, the sandbox and environment contract). Read it
+  before changing the method; this file is the *how*.
+- **Tracking issue**: [#7785](https://github.com/tokuhirom/mutsu/issues/7785).
+- **Sibling tools**: [docs/dist-compat-sweep.md](dist-compat-sweep.md) is the
+  load-level (`use <module>`) diagnostic sampler that feeds root-cause tickets;
+  [BATTERIES.md](../BATTERIES.md) / `scripts/battery-testsuite.sh` is the
+  release gate on the ~40 *bundled* dists. This campaign is neither: it is an
+  exhaustive, re-runnable ledger over the whole ecosystem.
+
+> **Status: design only.** Nothing in this document is implemented yet. The
+> phases in §7 are the build order; each is one PR.
+
+## 1. What gets measured
+
+| term | meaning |
+|---|---|
+| **distribution** (dist) | the unit of measurement — one `Dist::Name` in the fez index, with a version, a tarball and a `META6.json` |
+| **module** | one entry in a dist's `provides` |
+| **test file** | the unit of comparison — one `t/**.t` / `t/**.rakutest`, run as one process |
+| **baseline file** | a test file **rakudo passes cleanly** in this sweep; only these count toward the KPI |
+
+Corpus: the fez index (`https://360.zef.pm/`, cached at
+`~/.zef/store/fez/fez.json`), latest version of each dist. As of the 2026-09-10
+snapshot: **1623 distributions**, 9214 provided module names.
+
+### The three numbers
+
+With *B* = the set of baseline files:
+
+- **`file_parity`** = `count(f in B where mutsu passes f) / count(B)` —
+  **the KPI**, the number to move.
+- **`assertion_parity`** = `sum over B of min(mutsu_ok, raku_ok) / sum over B of
+  raku_ok` — moves even when no file flips, so a sweep that halves a suite's
+  failures is visible before the file turns green.
+- **`dist_parity`** = `count(dists whose whole baseline set passes on mutsu) /
+  count(dists with a non-empty baseline set)` — the user-facing "which modules
+  work" number.
+
+Per-file comparison verdicts (`cmp` in the record):
+
+| `cmp` | meaning | in the KPI? |
+|---|---|---|
+| `parity` | rakudo passes, mutsu passes | yes (numerator) |
+| `partial` | rakudo passes, mutsu reaches the plan but fails some assertions | yes (denominator only) |
+| `regression` | rakudo passes, mutsu fails / dies / times out | yes (denominator only) — **the actionable bucket** |
+| `no_baseline` | rakudo does not pass cleanly | no |
+| `mutsu_better` | rakudo fails, mutsu passes | no (recorded, reported separately) |
+
+Dist-level `status`: `green` · `partial` · `red` · `no_baseline` · `blocked_load`
+(a provided module does not even `use`) · `blocked_dep` (§3) · `skipped`.
+
+## 2. The fairness contract
+
+Both interpreters must be running the same code under the same conditions, or
+the difference is not a measurement. The harness enforces all of this rather
+than leaving it to the operator:
+
+1. **Same everything per file**: same dist tarball and version, same `-I` list,
+   same working directory (the dist root — suites reach for fixtures by relative
+   path), same environment, same wall-clock timeout, same order.
+2. **No installed repositories on either side.** Dependencies arrive only as
+   `-I` paths (§3), so module resolution and precompilation behave the same way
+   for both.
+3. **`MUTSU_FUDGE` must be unset.** It is roast-only; a stray `#?rakudo skip` in
+   a dist would silently drop the next statement.
+4. **`use Test` must resolve to the vendored `Test.rakumod`** on the mutsu side
+   — `modules/Rakudo-Core/lib/Test.rakumod`, rakudo's own file, which has been
+   the only provider since the native TAP provider was retired on 2026-09-10
+   ([#7566](https://github.com/tokuhirom/mutsu/issues/7566)). This is the
+   precondition #7785 set for starting the campaign at all: both sides must be
+   counting `ok` lines emitted by the *same* `Test` implementation, or every
+   number is comparing two harnesses rather than two interpreters. A sweep that
+   cannot confirm it (a regression, or a `-I` dependency shadowing `Test`)
+   aborts.
+5. **Both sides sandboxed identically** — bubblewrap, no network, read-only
+   filesystem, throwaway HOME, own PID namespace, rlimits (the wrapper
+   `scripts/dist-compat-sweep.py` already uses). *Both*, because a suite that
+   needs the network must fail symmetrically rather than showing up as a mutsu
+   regression. A corpus sweep without a sandbox is not a supported mode.
+6. **Author tests are excluded by default.** `xt/` is style/pod/meta checking of
+   the dist itself, not of the language; `t/` and the dist's declared test paths
+   are what `zef test` runs. The exclusion is recorded per dist so it can be
+   audited (`--include-xt` re-enables it).
+7. **Flakiness must not move the KPI.** A file that fails on *either* side is
+   re-run up to 3 times and the best verdict is kept; a file whose verdict
+   varies across attempts is marked `flaky: true` and excluded from the KPI on
+   both sides. Only failures are retried, so the cost is proportional to the
+   problem.
+
+## 3. Dependencies — a flat `-I` closure, resolved offline
+
+Per ADR-0085 D4/D5:
+
+1. Read `depends` + `test-depends` from the index entry (and from the extracted
+   `META6.json`, which is authoritative when they disagree).
+2. Resolve each name against the index: first as a dist name, then through the
+   index's module→dist `provides` map. Names the compiler provides (`Test`,
+   `NativeCall`, `nqp`, …) and `:from<native>` / `:from<bin>` entries are not
+   dependencies.
+3. Recurse to a fixed point; download and extract each member (cached under
+   `~/.cache/mutsu-ecosystem/`); build one `-I <dep>/lib` list.
+4. Hand that identical list to **both** interpreters.
+
+**If the closure cannot be completed, the dist is `blocked_dep` and runs on
+neither side.** Letting mutsu's bundled batteries (`modules/`, which sit below
+`-I` in the precedence chain) quietly supply a dependency rakudo lacks would
+raise the KPI without any compatibility improving. The record instead notes
+`bundled_would_supply: [...]` — a batteries statistic, reported separately.
+
+Measured on the 2026-09-10 snapshot: **1383 / 1623 (85%)** of dists have a
+first-level dependency list that resolves entirely from the fez index; 816 have
+no runtime or test dependencies at all. The top unresolvable names are legacy
+p6c/CPAN-era dists (`Distribution::Builder::MakeFromJSON` ×25, `Terminal::ANSI`
+×19, `Hash::Merge` ×16, `JSON::Tiny` ×15, `UUID`, `File::Which`, `Base64`).
+Adding the [Raku Ecosystem Archive](https://github.com/Raku/REA) index as a
+second source would recover most of them; that is a follow-up (§8), not a
+phase-1 requirement.
+
+## 4. The data store
+
+```
+ecosystem/
+  README.md                     # what this is and how to read it (points here)
+  index-snapshot.json           # fez index provenance: fetch date, sha256, dist count
+  dists/<S>/<Dist--Name>.json   # ONE FILE PER DIST — the record
+  summary.json                  # generated rollup: the three KPIs + per-shard counts
+  summary.md                    # generated human-readable table
+  history.tsv                   # append-only, one row per full sweep — the KPI time series
+```
+
+`<S>` is the uppercased first character of the dist name (`_` when it is not an
+ASCII letter); `::` becomes `--` in the filename. `String::Utils` →
+`ecosystem/dists/S/String--Utils.json`.
+
+One file per dist is the merge-conflict answer (the same reasoning as
+`news/YYYY-MM/<slug>.md`, and the reason `docs/dist-compat-sweep.md` moved to
+one table row per dist). It also makes the issue's two re-measurement modes fall
+out of the layout: one dist is one file, and "everything starting with A" is one
+directory.
+
+`summary.*` and `site/content/ecosystem.json` are **generated** from the tree and
+never hand-edited — a conflict in them is resolved by regenerating, not merging.
+
+### Record schema (`schema: 1`)
+
+```json
+{
+  "schema": 1,
+  "dist": "String::Utils",
+  "version": "0.0.40",
+  "source": { "index": "fez", "path": "…/String-Utils-0.0.40.tar.gz", "sha256": "…" },
+  "measured": {
+    "date": "2026-09-10",
+    "mutsu_commit": "66a1e4e", "mutsu_version": "0.23.0",
+    "raku_version": "2026.07", "raku_backend": "moar 2026.07",
+    "host": "linux-x86_64", "sandbox": "bwrap", "harness": 1
+  },
+  "deps": { "mode": "flat-closure", "digest": "sha256:…",
+            "resolved": ["Foo::Bar"], "unresolved": [], "bundled_would_supply": [] },
+  "load": { "String::Utils": "ok" },
+  "files": [
+    { "path": "t/01-basic.rakutest",
+      "raku":  { "verdict": "pass", "plan": 124, "ok": 124, "nok": 0, "todo": 0, "skip": 0, "secs": 3.9 },
+      "mutsu": { "verdict": "fail", "plan": 124, "ok": 120, "nok": 4, "todo": 0, "skip": 0, "secs": 1.1,
+                 "first_failure": "chars of ünïcödé string" },
+      "cmp": "partial", "flaky": false }
+  ],
+  "totals": { "baseline_files": 3, "parity_files": 2, "regressed_files": 1,
+              "baseline_assertions": 300, "mutsu_assertions": 296 },
+  "status": "partial"
+}
+```
+
+Both sides' raw TAP counts are stored deliberately: a metric definition we
+change later must be recomputable from the store, never a reason to re-sweep.
+
+**Timestamps are date-granular** (ADR-0085 D7). A re-run that reproduces the same
+verdicts on the same day writes a byte-identical file and produces no diff; a
+sweep on a later day rewrites what it executed with a one-line provenance delta.
+
+`ecosystem/history.tsv` — one row per full sweep, the shape `HISTORY.tsv` already
+uses for roast:
+
+```
+date	mutsu_commit	raku_version	dists	measured	blocked_dep	baseline_files	parity_files	file_parity	assertion_parity	dist_parity
+```
+
+## 5. The harness
+
+`scripts/ecosystem-sweep.py`, sharing its index reader, tarball cache, sandbox
+wrapper and TAP parser with `scripts/dist-compat-sweep.py` through a new
+`scripts/ecosystem_common.py` — one implementation of the sandbox, not two
+copies of security-relevant code.
+
+```sh
+# one dist (the per-module re-measurement the issue asks for)
+scripts/ecosystem-sweep.py --only String::Utils
+
+# one shard — "all modules that start with A"
+scripts/ecosystem-sweep.py --prefix A --jobs 8
+
+# everything currently red, after a fix lands
+scripts/ecosystem-sweep.py --status regression
+
+# records measured at an older mutsu commit or an older rakudo
+scripts/ecosystem-sweep.py --stale
+
+# the full corpus
+scripts/ecosystem-sweep.py --all --jobs 8
+
+# regenerate summary.json / summary.md from the tree (no runs)
+scripts/ecosystem-sweep.py --rollup
+```
+
+Other flags: `--timeout` (default 120s/file, both sides), `--max-files` (per
+dist, to bound a pathological suite), `--include-xt`, `--sandbox {bwrap,none}`,
+`--mutsu-only` (see *Baseline caching* below), `--refresh-baseline`, `--dry-run` (resolve and print the
+plan without executing), `--json -` (emit records to stdout instead of the tree).
+
+Environment: `MUTSU_BIN` (default `target/release/mutsu`), `RAKU_BIN` (default
+`raku`).
+
+### Cost model
+
+Calibrated 2026-09-10 on this container (4 cores) over 14 randomly-sampled
+zero-dependency dists — 115 test files, 104 executed:
+
+| quantity | measured |
+|---|---|
+| test files per dist | **8.2** mean (median ~2.5; one dist had 51) |
+| rakudo wall time per file | **3.0 s** (startup + compile dominated) |
+| files rakudo passes cleanly | **92%** (96/104) — the baseline rate for zero-dep dists |
+
+Projected full corpus: 1623 dists ≈ **13,300 test files**; the rakudo side alone
+≈ **11 CPU-hours**, and mutsu's side is at or below that (mutsu beats rakudo on
+the roast whitelist). Call a full sweep **~20 CPU-hours ≈ 2.5 h wall at `-j8`**,
+plus ~1600 tarball downloads (cached). One letter shard (`A` = 154 dists) is
+~10-15 minutes at `-j8` — cheap enough to re-run after a fix.
+
+These are the numbers to sanity-check phase 2 against; treat a wildly different
+first full run as a harness bug, not a surprise.
+
+### Baseline caching
+
+The rakudo side of a file depends only on `(dist version, raku version, dep
+closure digest, host)`. When those are unchanged, `--mutsu-only` reuses the
+stored `raku` block instead of re-running rakudo, halving the cost of the common
+case: *re-measuring after a mutsu fix*. A rakudo upgrade invalidates every
+baseline at once and forces a full sweep — recorded in `history.tsv` as a
+denominator change, per ADR-0085.
+
+## 6. Publication
+
+- **Site**: `site/ecosystem.html` + `site/content/ecosystem.json`, generated by
+  `scripts/gen-ecosystem-manifest.py` and wired into `.github/workflows/pages.yml` —
+  exactly the pattern `site/batteries.html` / `scripts/gen-batteries-manifest.py`
+  already uses. A searchable table: dist, version, status badge, baseline files
+  passed / total, and the first failure for the red ones.
+- **Repo**: `ecosystem/summary.md` for readers browsing the tree; linked from
+  `README.md` and PLAN.md §1 B4.
+- **Raw**: `ecosystem/dists/**.json` is the machine-readable artifact the issue
+  asks for — stable schema, versioned by `schema`.
+
+## 7. Phases (one PR each)
+
+| # | Deliverable | Done when |
+|---|---|---|
+| **P1** | `scripts/ecosystem_common.py` extracted from `dist-compat-sweep.py`; `scripts/ecosystem-sweep.py` with the dep resolver, sandbox, TAP compare, `--only` / `--prefix` / `--rollup`; schema v1 | the `A` shard measures end to end and its records land under `ecosystem/dists/A/` |
+| **P2** | first full-corpus sweep; `ecosystem/` populated; `summary.*` + the first `history.tsv` row | `file_parity` / `assertion_parity` / `dist_parity` exist as real numbers |
+| **P3** | `site/ecosystem.html` + manifest generator + `pages.yml` wiring | a user can look up a dist on the public site |
+| **P4** | `.github/workflows/ecosystem.yml` — scheduled (weekly) + `workflow_dispatch` with a shard input; opens a PR with the updated records and the history row; **report-only, never gates a PR** | a sweep lands without a human running it (this also closes PLAN.md §1 B1's "working-module regression CI") |
+| **P5** | root-cause grouping of `regression` records into `todo:ticket` issues, in the shape `scripts/dist-compat-tickets.py` already produces; `docs/triage.md` picks them up | the KPI feeds the work queue |
+
+P1 and P2 are the campaign; P3-P5 make it self-sustaining. Do not start P2
+before P1's `--only` round-trips a record, and do not start P4 before P2 has
+produced a number worth watching.
+
+## 8. Known limits and follow-ups
+
+- **Network-dependent suites are invisible.** They fail on both sides and land
+  in `no_baseline`. Recorded as a count so the size of the blind spot is known;
+  a future opt-in `--allow-network` mode for a vetted subset is possible but is
+  not part of this design.
+- **`blocked_dep` residue (~15% of dists).** Adding the REA index as a second
+  source is the obvious fix and the highest-value follow-up.
+- **Author (`xt/`) tests, `build-depends`, and dists whose `provides` uses a
+  non-convention path** (resolvable only through an installed provides map) are
+  each a small, recorded population rather than a silent one.
+- **`mzef compat <Dist>`** — reading the shipped data from the installed
+  distribution so `mzef install` can warn before installing something known
+  red. Attractive, out of scope here.
+- **Timing/concurrency suites** (S17-flavoured) are the expected home of
+  `flaky: true`; if the retry rule proves insufficient, quarantine them the way
+  `flaky-tests.txt` quarantines local tests rather than weakening the KPI.


### PR DESCRIPTION
Design-only PR for [#7785](https://github.com/tokuhirom/mutsu/issues/7785) — no interpreter changes, no harness code yet.

## What #7785 asks for

Run every zef distribution's own test suite under **both rakudo and mutsu**, treat the difference as the project's headline KPI, keep per-distribution machine-readable records **in the repository** with the versions they were measured at, allow re-measurement per distribution (and per first letter), and publish it to users.

Its precondition — *"only begin after you start using Test.rakumod"* — is **met**: the native TAP provider was retired on 2026-09-10 ([#7566](https://github.com/tokuhirom/mutsu/issues/7566)), so both sides now count `ok` lines emitted by the same `Test.rakumod`. Without that, every number would be comparing two harnesses rather than two interpreters.

## What this PR adds

- **`docs/adr/0085-ecosystem-testsuite-parity-measurement.md`** (Proposed) — the eight decisions that are costly to reverse once thousands of records exist, plus what was rejected.
- **`docs/ecosystem-parity.md`** — the operations manual: metric definitions, the fairness contract, the dependency resolver, the record schema, the CLI, the cost model, publication, and five phases of one PR each.
- Points `docs/dist-compat-sweep.md`'s long-standing "Planned deepenings §1" (its Level 2) at this campaign, and files it under `PLAN.md` §1 B4.

## The decisions worth reviewing

- **Rakudo is the denominator**, run on the same host in the same sweep. A file rakudo does not pass cleanly is excluded from the KPI, never counted as a mutsu failure. An absolute pass rate would report the ecosystem's own breakage and the host's limitations as ours.
- **Three numbers**: `file_parity` (the KPI), `assertion_parity` (moves before a file flips), `dist_parity` (the user-facing "which modules work"). Both sides' raw TAP counts are stored per file, so changing a metric definition later never costs a re-sweep.
- **Dependencies are a flat `-I` closure resolved offline from the ecosystem index**, handed identically to both interpreters — not `zef install` on one side and `mzef install` on the other, which would stop the two sides running the same code and would turn an `mzef` bootstrap failure into a mutsu compatibility number.
- **A distribution whose closure cannot be completed is skipped on *both* sides.** Letting a bundled battery fill a gap rakudo lacks would raise the KPI without any compatibility improving; that value is recorded separately as a batteries statistic.
- **One JSON file per distribution, sharded by first letter** — the merge-conflict answer (same reasoning as `news/`), and exactly the re-measurement granularity the issue asks for: one dist is one file, "everything starting with A" is one directory.
- **An enforced environment contract**: identical sandboxing on both sides (a network-dependent suite must fail symmetrically), `MUTSU_FUDGE` unset, and `use Test` confirmed to resolve to the vendored `Test.rakumod`.

## Measurements taken while designing (not estimates)

From the 2026-09-10 fez snapshot and a 14-distribution calibration run on this container:

| | |
|---|---|
| distributions in the corpus | **1623** (9214 provided module names) |
| first-level dependency lists fully resolvable from the index | **1383 / 1623 (85%)**; 816 have no deps at all |
| test files per distribution | **8.2** mean (median ~2.5) |
| rakudo wall time per test file | **3.0 s** |
| test files rakudo passes cleanly | **92%** (96/104) |

Projected: ~13,300 test files, a full sweep ≈ 20 CPU-hours (~2.5 h at `-j8`), one letter shard ≈ 10-15 minutes.

## CI

Documentation-only, so `ci.yml`'s `changes` job classifies it as docs-only and the five build jobs report `skipped` — that is correct, not a stuck CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EipFi5QhLJC1MjeEVjHHAy

---
_Generated by [Claude Code](https://claude.ai/code/session_01EipFi5QhLJC1MjeEVjHHAy)_