### PR TITLE
docs: REA is a phase-1 requirement for the ecosystem parity sweep, not a follow-up

### DIFF
--- a/docs/adr/0085-ecosystem-testsuite-parity-measurement.md
+++ b/docs/adr/0085-ecosystem-testsuite-parity-measurement.md
@@ -122,10 +122,30 @@ Rejected alternatives:
   run depend on the order dists were installed in.
 
 A flat `-I` closure is deterministic, cacheable, identical for both
-interpreters, and needs no package manager at either end. Measured on the
-2026-09-10 fez snapshot: **1383 of 1623 distributions (85%) have a first-level
-dependency list that resolves entirely from the index**, so this covers the
-corpus well enough to start; the residue is recorded, not worked around.
+interpreters, and needs no package manager at either end.
+
+**The index must be fez + the [Raku Ecosystem Archive](https://github.com/Raku/REA),
+not fez alone.** Measured on 2026-09-10 snapshots of both, resolving the
+*transitive* closure over the 1623 fez distributions:
+
+| index | closures that resolve | blocked |
+|---|---|---|
+| fez only | 1164 (72%) | 459 |
+| fez + mutsu's bundled batteries | 1260 (78%) | 363 |
+| **fez + REA** | **1584 (98%)** | 39 |
+| fez + REA + bundled batteries | 1584 (98%) | 39 |
+
+(The 85% figure that a first-level-only count gives is misleading for a
+resolver that recurses to a fixed point; 72% is the operative number.) The
+blockers fez alone cannot supply are legacy p6c/CPAN-era dependencies that
+never moved to fez — `File::Which` (69 dependents), `Hash::Merge` (60),
+`Distribution::Builder::MakeFromJSON` (58), `Getopt::Long` (52) — and REA
+carries all of them. The 39 that remain are almost entirely malformed
+`depends` entries in the source `META6.json` (prose fragments such as `has`,
+`path`, `as`), not real distributions.
+
+Note the fourth row: **once REA is in, mutsu's bundled batteries add nothing
+to coverage.** That is what makes D5 cheap rather than a sacrifice.
 
 ### D5. A distribution whose dependency closure cannot be resolved is skipped on *both* sides
 
@@ -143,6 +163,12 @@ The value of the bundle is instead recorded *separately*: each `blocked_dep`
 record notes whether a bundled battery would have supplied the missing
 dependency (`bundled_would_supply`). That is a batteries statistic, reported as
 such, not folded into parity.
+
+The measurement in D4 shows this rule costs almost nothing: with fez + REA the
+bundle rescues **zero** additional distributions (1584 either way), and the
+population it applies to is 39 distributions, most of them malformed metadata.
+The rule was worth stating anyway — without it the KPI would have a standing
+way to rise without any compatibility improving — but it is not a trade.
 
 ### D6. The store is one JSON file per distribution, sharded by first letter
 

--- a/docs/ecosystem-parity.md
+++ b/docs/ecosystem-parity.md
@@ -29,7 +29,9 @@ sides, and publish the difference.
 
 Corpus: the fez index (`https://360.zef.pm/`, cached at
 `~/.zef/store/fez/fez.json`), latest version of each dist. As of the 2026-09-10
-snapshot: **1623 distributions**, 9214 provided module names.
+snapshot: **1623 distributions**, 9214 provided module names. Dependencies are
+resolved against fez **merged with REA** (§3), which adds ~920 more
+distributions — those are dependency supply, not measurement targets.
 
 ### The three numbers
 
@@ -97,14 +99,16 @@ than leaving it to the operator:
 
 ## 3. Dependencies — a flat `-I` closure, resolved offline
 
-Per ADR-0085 D4/D5:
+Per ADR-0085 D4/D5. **The index is fez + the
+[Raku Ecosystem Archive](https://github.com/Raku/REA) merged**, highest version
+wins; REA is not optional (see the coverage table below).
 
 1. Read `depends` + `test-depends` from the index entry (and from the extracted
    `META6.json`, which is authoritative when they disagree).
-2. Resolve each name against the index: first as a dist name, then through the
-   index's module→dist `provides` map. Names the compiler provides (`Test`,
-   `NativeCall`, `nqp`, …) and `:from<native>` / `:from<bin>` entries are not
-   dependencies.
+2. Resolve each name against the merged index: first as a dist name, then
+   through the index's module→dist `provides` map. Names the compiler provides
+   (`Test`, `NativeCall`, `nqp`, …) and `:from<native>` / `:from<bin>` entries
+   are not dependencies.
 3. Recurse to a fixed point; download and extract each member (cached under
    `~/.cache/mutsu-ecosystem/`); build one `-I <dep>/lib` list.
 4. Hand that identical list to **both** interpreters.
@@ -115,14 +119,33 @@ neither side.** Letting mutsu's bundled batteries (`modules/`, which sit below
 raise the KPI without any compatibility improving. The record instead notes
 `bundled_would_supply: [...]` — a batteries statistic, reported separately.
 
-Measured on the 2026-09-10 snapshot: **1383 / 1623 (85%)** of dists have a
-first-level dependency list that resolves entirely from the fez index; 816 have
-no runtime or test dependencies at all. The top unresolvable names are legacy
-p6c/CPAN-era dists (`Distribution::Builder::MakeFromJSON` ×25, `Terminal::ANSI`
-×19, `Hash::Merge` ×16, `JSON::Tiny` ×15, `UUID`, `File::Which`, `Base64`).
-Adding the [Raku Ecosystem Archive](https://github.com/Raku/REA) index as a
-second source would recover most of them; that is a follow-up (§8), not a
-phase-1 requirement.
+### Coverage — why REA is a phase-1 requirement
+
+Measured 2026-09-10, resolving the **transitive** closure over the 1623 fez
+distributions (816 of which have no dependencies at all):
+
+| index | closures that resolve | blocked |
+|---|---|---|
+| fez only | 1164 (72%) | 459 |
+| fez + mutsu's bundled batteries | 1260 (78%) | 363 |
+| **fez + REA** (the design) | **1584 (98%)** | 39 |
+| fez + REA + bundled batteries | 1584 (98%) | 39 |
+
+A first-level-only count flatters this to 85%; **72% is the operative number**
+for a resolver that recurses to a fixed point, and it is not enough to sweep on.
+What fez alone cannot supply is the legacy p6c/CPAN tail that never moved:
+`File::Which` (69 dependents), `Hash::Merge` (60),
+`Distribution::Builder::MakeFromJSON` (58), `Getopt::Long` (52),
+`Compress::Zlib` (27). REA carries all of them, and takes the corpus from
+roughly a quarter unmeasurable to 2%.
+
+The 39 that still fail are dominated by malformed `depends` entries in the
+source `META6.json` — prose fragments (`has`, `path`, `as`, `shorten`) rather
+than distribution names. They are recorded as `blocked_dep`, not chased.
+
+Note the last row: **with REA in, the bundled batteries add nothing to
+coverage** — which is what makes ADR-0085 D5 (skip `blocked_dep` on both sides)
+cost nothing rather than being a sacrifice.
 
 ## 4. The data store
 
@@ -289,8 +312,9 @@ produced a number worth watching.
   in `no_baseline`. Recorded as a count so the size of the blind spot is known;
   a future opt-in `--allow-network` mode for a vetted subset is possible but is
   not part of this design.
-- **`blocked_dep` residue (~15% of dists).** Adding the REA index as a second
-  source is the obvious fix and the highest-value follow-up.
+- **`blocked_dep` residue (39 dists, 2%).** Mostly malformed `depends` metadata
+  upstream. Parsing prose-fragment dependency entries more forgivingly would
+  recover a handful; it is not worth much.
 - **Author (`xt/`) tests, `build-depends`, and dists whose `provides` uses a
   non-convention path** (resolvable only through an installed provides map) are
   each a small, recorded population rather than a silent one.


### PR DESCRIPTION
Follow-up to #7847 ([#7785](https://github.com/tokuhirom/mutsu/issues/7785)). Corrects a number in ADR-0085 that would have bitten phase 1.

## The error

ADR-0085 justified the flat `-I` dependency closure with *"1383 of 1623 (85%) of distributions have a **first-level** dependency list that resolves entirely from the fez index"*, and filed adding the [Raku Ecosystem Archive](https://github.com/Raku/REA) as an optional follow-up.

But the resolver recurses to a fixed point, so first-level coverage is not the number that matters. Measured transitively over the same 2026-09-10 snapshot:

| index | closures that resolve | blocked |
|---|---|---|
| fez only | 1164 (72%) | 459 |
| fez + mutsu's bundled batteries | 1260 (78%) | 363 |
| **fez + REA** | **1584 (98%)** | 39 |
| fez + REA + bundled batteries | 1584 (98%) | 39 |

**A quarter of the corpus is unmeasurable on fez alone.** The reason is the legacy p6c/CPAN tail that never moved there: `File::Which` (69 dependents), `Hash::Merge` (60), `Distribution::Builder::MakeFromJSON` (58), `Getopt::Long` (52), `Compress::Zlib` (27). REA carries all of them. The 39 that still fail are dominated by malformed `depends` entries upstream — prose fragments such as `has`, `path`, `as` — rather than real distributions.

## It also settles D5 for free

D5 says a distribution whose closure cannot be completed is skipped on **both** sides, rather than letting a bundled battery supply what rakudo lacks. The fourth row shows that with REA in, the bundle rescues **zero** additional distributions. So D5 costs nothing — it was worth stating to close a standing way for the KPI to rise without compatibility improving, but it is not a trade against coverage.

## Changes

- ADR-0085 D4: the merged fez + REA index is the design; the coverage table replaces the misleading 85%.
- ADR-0085 D5: notes that the rule is measured to cost nothing.
- `docs/ecosystem-parity.md` §1/§3: the merged index, the coverage table, and why 72% is the operative number.
- §8: the "add REA" follow-up demoted to what actually remains (malformed upstream metadata, 2%).

Documentation-only, so the build jobs report `skipped` by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EipFi5QhLJC1MjeEVjHHAy

---
_Generated by [Claude Code](https://claude.ai/code/session_01EipFi5QhLJC1MjeEVjHHAy)_