### PR TITLE
test: record which supply-serialize-fifo subtest is the actual regression pin

### DIFF
--- a/news/2026-09/supply-fifo-pin-measured-on-four-cores.md
+++ b/news/2026-09/supply-fifo-pin-measured-on-four-cores.md
@@ -1,0 +1,54 @@
+# The supply FIFO pin, measured on the four-core box that reported it
+
+[#7838](https://github.com/tokuhirom/mutsu/issues/7838) reported
+`t/concurrency/supply/supply-serialize-fifo.t` test 3 failing about half the
+time in a 4-core remote container, and asked the right question about it: a pin
+that only holds on machines with enough cores is not a pin. The issue was filed
+against `main` at `a3fb606`, an hour before the fix for
+[#7831](https://github.com/tokuhirom/mutsu/issues/7831) landed, and describes
+the same ordering hole — the already-resolved promise path taking no
+`SupplyTicket`, so it ran the reaction inline ahead of every reaction already
+ticketed and queued. `news/2026-09/already-resolved-promise-supply-ticket.md`
+has that story.
+
+What was still missing is the part #7838 actually asks for: the fix was measured
+on a 12-core dev box, not on the hardware where the symptom was loud. Re-measured
+here on a 4-core container, release build, at `66a1e4e`:
+
+| binary | runs | test 3 failures |
+| --- | --- | --- |
+| `main` with the fix | 30 serial + 60 under 4-way parallel load | **0 / 90** |
+| the same tree, ticket reservation reverted | 20 serial | **18 / 20** |
+
+A stray run added one more data point for free: a full `prove -r t/` sweep was
+launched against the reverted binary by mistake, and test 3 was the single
+failure in 3952 files and 42022 tests. So the pin fires under the real suite's
+load too, not only when the file is run on its own. The same sweep on the
+rebuilt binary is green.
+
+So the hole is closed on the reporting hardware, and the pin is not merely
+green there — it is ~90% sensitive to the regression there, which is a good deal
+better than the ~1-in-6 rate the fix was originally chased at. There is nothing
+to quarantine: `flaky-tests.txt` correctly does not list this file, and
+`docs/flaky-test-policy.md`'s standard for not relabelling a deterministic bug
+as noise was the right call.
+
+#7838 offered a second reading to rule out — that the ordering is not in fact
+guaranteed, and the assertion, not the interpreter, is what is wrong. It is not:
+`raku` v2026.07 runs the same file green 5 times out of 5 on this same 4-core
+container, all four subtests. Rakudo really does publish these reactions in the
+order their sources produced them, so `1 2 3 4 5 6` is the right expectation and
+mutsu now matches it.
+
+The reverted run also settled which subtest carries that sensitivity, which was
+not obvious and is now written into the file. All 18 failures were test 3 alone;
+tests 1, 2 and 4 stayed green through every one. Test 4 — added by the #7831 fix
+to exercise the already-resolved path on its own — *cannot* catch a return to the
+inline path, because when every reaction runs inline on the registering thread it
+runs in registration order and comes out trivially sorted. It pins the ticket
+reservation that replaced the inline path, which is worth having, but test 3's
+alternation of already-kept and later-kept promises is the shape that detects the
+bug. Folding the two together would quietly retire the only sensitive pin in the
+file.
+
+Closes #7838.

--- a/t/concurrency/supply/supply-serialize-fifo.t
+++ b/t/concurrency/supply/supply-serialize-fifo.t
@@ -41,6 +41,12 @@ is run-nested(20), [(1..20).map(* * 10)],
 # A promise kept BEFORE its nested `whenever` is registered runs the body
 # synchronously on the registering thread; it must still land in sequence
 # rather than jumping ahead of an earlier value's pending continuation.
+#
+# This alternating shape is the one that actually detects the #7831 hole, and
+# the only one in this file that can: with the ticket reservation for the
+# already-resolved path removed, it failed 18 of 20 release runs on a 4-core
+# container (#7838), while tests 1, 2 and 4 stayed green every time. Do not
+# fold it into test 4 -- see the note there.
 my $src = Supplier.new;
 my @mixed;
 my $done = Promise.new;
@@ -63,6 +69,14 @@ is @mixed, [1, 2, 3, 4, 5, 6], 'already-kept and later-kept promises interleave 
 # takes the already-resolved path. That path used to run the body inline on the
 # registering thread with no place in the block's sequencer at all (#7831), so
 # it had to be ordered by luck; it must be ordered by the reservation instead.
+#
+# Note what this test can and cannot catch. It pins the reservation: if the
+# tickets stopped ordering the pooled workers, ten reactions racing for them
+# would come out shuffled. It cannot catch a *return* to running the body
+# inline, because then every reaction runs on the registering thread in
+# registration order and is trivially sorted -- which is why it stayed green
+# through all 20 of the reverted runs noted on test 3. Test 3 is the pin;
+# this one guards the mechanism that replaced the inline path.
 my $src2 = Supplier.new;
 my @kept-first;
 my $done2 = Promise.new;


### PR DESCRIPTION
## What this is

#7838 reported `t/concurrency/supply/supply-serialize-fifo.t` test 3 failing about half the time in a 4-core remote container, and asked the right question about it: *a pin that only holds on machines with enough cores is not a pin.*

The underlying hole is already closed. #7838 was filed against `main` at `a3fb606`, about an hour before the fix for #7831 (`73332ef`) landed, and describes exactly that bug — the already-resolved promise path taking no `SupplyTicket`, so it ran its reaction inline ahead of every reaction already ticketed and queued for a worker.

What was still missing is the part #7838 actually asks for: that fix was measured on the 12-core dev box, not on the hardware where the symptom was loud. **This PR contains no `src/` change** — the interpreter is byte-identical to `main`. It records the measurement and writes the one non-obvious finding into the test file.

## Measurements (4-core container, release build, at `66a1e4e`)

| binary | runs | test 3 failures |
| --- | --- | --- |
| `main` with the fix | 30 serial + 60 under 4-way parallel load | **0 / 90** |
| same tree, ticket reservation reverted | 20 serial | **18 / 20** |

So the pin is not merely green on the reporting hardware — it is ~90% sensitive to the regression there, well above the ~1-in-6 rate the fix was originally chased at. There is nothing to quarantine, and `flaky-tests.txt` correctly does not list this file.

A stray run added one more data point for free: a full `prove -r t/` sweep was launched against the reverted binary by mistake, and test 3 was the **single** failure in 3952 files / 42022 tests. The pin fires under the real suite's load too, not only when the file is run alone.

## The second reading, ruled out

#7838 offered an alternative: that the ordering is not in fact guaranteed, and the assertion — not the interpreter — is what is wrong. It is not. `raku` v2026.07 runs the same file green **5 of 5** on this same 4-core container, all four subtests. `1 2 3 4 5 6` is the right expectation.

## The finding worth keeping

The reverted run settled something that was not obvious and was not recorded anywhere: **all 18 failures were test 3 alone**, and test 4 stayed green through every one.

Test 4 was added by the #7831 fix to exercise the already-resolved path on its own, but it *cannot* catch a return to the inline path: when every reaction runs inline on the registering thread, it runs in registration order and comes out trivially sorted. It does pin the ticket reservation that replaced the inline path, which is worth having — but test 3's alternation of already-kept and later-kept promises is the only shape in the file that detects the bug. Both subtests now say so, so nobody folds them together and quietly retires the only sensitive pin.

## Verification

- `prove -r t/` on the correctly rebuilt release binary: **3952 files, 42022 tests, Result: PASS**.
- `make check-value-wall check-flaky-list check-t-layout`: pass (layout matches the rules, 3952 files).
- `make lint`, `cargo test` and `make roast` are unaffected by construction: the diff is one `.t` comment block and one new `news/` file, with zero `src/` delta (`git diff HEAD -- src/` is empty).

Closes #7838.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aw9ZyShWJfnFDkRWSASN2w

---
_Generated by [Claude Code](https://claude.ai/code/session_01Aw9ZyShWJfnFDkRWSASN2w)_