### PR TITLE
docs: record the maintainer's four ADR-0085 calls; the sweep is operator-run

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -107,7 +107,8 @@ work; see the CLAUDE.md "mzef package manager and distribution" section. The **R
       operations manual and phases (P1-P5, one PR each):
       [docs/ecosystem-parity.md](docs/ecosystem-parity.md);
       tracking issue [#7785](https://github.com/tokuhirom/mutsu/issues/7785).
-      Its P4 (scheduled report-only sweep) also closes B1's "working-module regression CI".
+      The sweep is operator-run on a many-core box, not CI-scheduled (ADR-0085 D9), so it does
+      **not** close B1's "working-module regression CI" — that stays a separate item.
 - [ ] **★Real-dist compatibility sweep** — run real fez dists under mutsu and fix the general bugs
       they surface. Ledger: [docs/dist-compat-sweep.md](docs/dist-compat-sweep.md). **The `--run-tests`
       axis is the sharper frontier**: running each loading dist's own suite with raku as the baseline.

--- a/docs/adr/0085-ecosystem-testsuite-parity-measurement.md
+++ b/docs/adr/0085-ecosystem-testsuite-parity-measurement.md
@@ -1,6 +1,6 @@
 # ADR-0085 — The ecosystem KPI is per-distribution test-suite parity against rakudo
 
-- Status: Proposed
+- Status: Accepted (design confirmed by the maintainer 2026-09-10; implementation not started)
 - Date: 2026-09-10
 - Issue: [#7785](https://github.com/tokuhirom/mutsu/issues/7785)
 - Operations manual (the "how"): [docs/ecosystem-parity.md](../ecosystem-parity.md)
@@ -54,7 +54,7 @@ Adopt **per-distribution test-suite parity against a same-host rakudo run** as
 mutsu's ecosystem KPI, measured by a dedicated, exhaustive, re-runnable harness
 whose per-distribution results are committed to the repository.
 
-The eight decisions below are the ones that are costly to reverse once thousands
+The nine decisions below are the ones that are costly to reverse once thousands
 of records exist. Everything else — CLI spelling, output formatting, phasing —
 is operational and lives in [docs/ecosystem-parity.md](../ecosystem-parity.md).
 
@@ -88,15 +88,23 @@ Consequence: a test file rakudo does not pass cleanly is **excluded from the KPI
 denominator** and recorded as `no_baseline`. It is never counted as a mutsu
 failure, and never as a mutsu success.
 
-### D3. Three parity numbers, and `file_parity` is the headline
+### D3. Three parity numbers with separated roles — `dist_parity` is published, `file_parity` drives the work
 
 Let *B* be the set of test files that rakudo passes cleanly in this sweep.
 
 | metric | definition | role |
 |---|---|---|
-| `file_parity` | `count(f in B where mutsu passes f) / count(B)` | **the KPI** — the number to move |
-| `assertion_parity` | `sum over B of min(mutsu_ok, raku_ok) / sum over B of raku_ok` | fine-grained progress; moves even when no file flips |
-| `dist_parity` | `count(dists whose whole baseline set passes on mutsu) / count(dists with a non-empty baseline set)` | the user-facing "which modules work" number |
+| `dist_parity` | `count(dists whose whole baseline set passes on mutsu) / count(dists with a non-empty baseline set)` | **the published headline** — it answers the user's question, "does my module work?", and weights every distribution equally |
+| `file_parity` | `count(f in B where mutsu passes f) / count(B)` | **the number the work is steered by** — moves smoothly enough to tell whether a slice helped |
+| `assertion_parity` | `sum over B of min(mutsu_ok, raku_ok) / sum over B of raku_ok` | the finest signal; moves even when no file flips |
+
+The split is deliberate, because one number cannot do both jobs. `dist_parity`
+is what a user means by compatibility, but it is a step function: a
+distribution with 51 test files stays at zero until the last one goes green, so
+a release that halves the failures can show no movement at all. `file_parity`
+moves continuously, but it weights a 51-file distribution 51× a 1-file one, so
+it is a poor claim to publish. Reporting one as *the* KPI would either hide
+progress or overstate reach.
 
 All three are reported, and both sides' raw TAP counts are stored per file, so
 any other aggregate can be recomputed later **without re-running anything**.
@@ -226,6 +234,30 @@ the harness at startup, not left to the operator:
   is retired, so this is a guard against regression rather than a switch, but a
   sweep that cannot confirm it aborts rather than publishing a flattered
   number.
+
+### D9. The sweep is operator-run, not CI-scheduled
+
+A full sweep is ~20 CPU-hours. It runs **on the maintainer's box, started by
+hand**, and its results reach `main` as an ordinary pull request. There is no
+scheduled GitHub Actions workflow.
+
+The alternative — a weekly hosted-runner sweep — buys automation the project
+does not need yet and costs 20 CPU-hours of Actions time every week, on runners
+with a fraction of the cores, for a number that moves on the timescale of
+interpreter fixes rather than of pushes. A 12-core box does the same work in
+about 2.5 hours for nothing, and `bwrap` is easier to guarantee there.
+
+Two consequences follow and are not to be papered over:
+
+- **The KPI updates only when someone runs it.** A stale headline is a
+  documented state (D7 makes staleness computable), not a silent one.
+- **This does not close PLAN.md §1 B1's "working-module regression CI."** That
+  remains a separate, unstarted item; an earlier draft of this design claimed
+  otherwise.
+
+Because the sweep is tied to one machine, `measured.host` is part of every
+record (D7) so a number produced elsewhere is identifiable rather than quietly
+mixed in.
 
 ## Consequences
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -110,4 +110,4 @@ The role of an ADR is to preserve the *context of the judgment* — something th
 | [0082](0082-a-collecting-for-gathers-containers-not-snapshots.md) | A value-collecting `for` gathers containers, not snapshots | Superseded by 0083 |
 | [0083](0083-a-collected-for-retains-containers-past-the-loop.md) | A collected `for` retains lvalue containers past the loop | Accepted (implemented) |
 | [0084](0084-the-frame-env-is-not-the-programs-symbol-table.md) | The per-frame `Env` is not the program's symbol table — type/package names and internal markers move to side tables | Proposed (design complete; implementation not started) |
-| [0085](0085-ecosystem-testsuite-parity-measurement.md) | The ecosystem KPI is per-distribution test-suite parity against rakudo | Proposed (design complete; implementation not started) |
+| [0085](0085-ecosystem-testsuite-parity-measurement.md) | The ecosystem KPI is per-distribution test-suite parity against rakudo | Accepted (design confirmed 2026-09-10; implementation not started) |

--- a/docs/ecosystem-parity.md
+++ b/docs/ecosystem-parity.md
@@ -37,14 +37,22 @@ distributions — those are dependency supply, not measurement targets.
 
 With *B* = the set of baseline files:
 
-- **`file_parity`** = `count(f in B where mutsu passes f) / count(B)` —
-  **the KPI**, the number to move.
-- **`assertion_parity`** = `sum over B of min(mutsu_ok, raku_ok) / sum over B of
-  raku_ok` — moves even when no file flips, so a sweep that halves a suite's
-  failures is visible before the file turns green.
 - **`dist_parity`** = `count(dists whose whole baseline set passes on mutsu) /
-  count(dists with a non-empty baseline set)` — the user-facing "which modules
-  work" number.
+  count(dists with a non-empty baseline set)` — **the published headline**. It
+  is what a user means by "does my module work?", and it weights every
+  distribution equally.
+- **`file_parity`** = `count(f in B where mutsu passes f) / count(B)` — **the
+  number the work is steered by**: it moves smoothly enough to tell whether a
+  slice helped.
+- **`assertion_parity`** = `sum over B of min(mutsu_ok, raku_ok) / sum over B of
+  raku_ok` — the finest signal; moves even when no file flips, so a sweep that
+  halves a suite's failures is visible before the file turns green.
+
+The roles are split because one number cannot do both jobs (ADR-0085 D3).
+`dist_parity` is a step function — a distribution with 51 test files stays at
+zero until the last one goes green — so steering by it would hide real progress.
+`file_parity` moves continuously but weights that distribution 51× a one-file
+one, so publishing it would overstate reach.
 
 Per-file comparison verdicts (`cmp` in the record):
 
@@ -299,14 +307,44 @@ denominator change, per ADR-0085.
 | **P1** | `scripts/ecosystem_common.py` extracted from `dist-compat-sweep.py`; `scripts/ecosystem-sweep.py` with the dep resolver, sandbox, TAP compare, `--only` / `--prefix` / `--rollup`; schema v1 | the `A` shard measures end to end and its records land under `ecosystem/dists/A/` |
 | **P2** | first full-corpus sweep; `ecosystem/` populated; `summary.*` + the first `history.tsv` row | `file_parity` / `assertion_parity` / `dist_parity` exist as real numbers |
 | **P3** | `site/ecosystem.html` + manifest generator + `pages.yml` wiring | a user can look up a dist on the public site |
-| **P4** | `.github/workflows/ecosystem.yml` — scheduled (weekly) + `workflow_dispatch` with a shard input; opens a PR with the updated records and the history row; **report-only, never gates a PR** | a sweep lands without a human running it (this also closes PLAN.md §1 B1's "working-module regression CI") |
+| **P4** | the operator runbook (§8) — one `make`-level entry point for a full sweep and for a shard, plus the `--rollup` + `history.tsv` append and the PR it lands as | a maintainer can go from a clean checkout to a merged sweep by following one page |
 | **P5** | root-cause grouping of `regression` records into `todo:ticket` issues, in the shape `scripts/dist-compat-tickets.py` already produces; `docs/triage.md` picks them up | the KPI feeds the work queue |
 
-P1 and P2 are the campaign; P3-P5 make it self-sustaining. Do not start P2
-before P1's `--only` round-trips a record, and do not start P4 before P2 has
-produced a number worth watching.
+P1 and P2 are the campaign; P3-P5 make it repeatable. Do not start P2 before
+P1's `--only` round-trips a record.
 
-## 8. Known limits and follow-ups
+**There is deliberately no scheduled CI phase** (ADR-0085 D9): a full sweep is
+~20 CPU-hours, which a 12-core box does in ~2.5 h for nothing and a hosted
+runner would charge for weekly, on fewer cores, to track a number that moves at
+the speed of interpreter fixes. The cost is that the headline updates only when
+someone runs it — a documented state, since D7 makes staleness computable — and
+that PLAN.md §1 B1's "working-module regression CI" stays a separate, unstarted
+item rather than being closed by this campaign.
+
+## 8. Operator runbook
+
+The sweep is run by hand on a machine with the cores to spare (ADR-0085 D9) —
+the maintainer's 12-core box, not a CI runner and not an ephemeral remote
+container (4 cores, a fixed disk allowance, and no `bwrap`).
+
+```sh
+apt-get install bubblewrap          # required; the sweep refuses to run a corpus without it
+touch src/main.rs && cargo build --release   # a stale binary is measured silently otherwise
+scripts/ecosystem-sweep.py --prefix A --jobs 8      # ~10-15 min, to check the setup
+scripts/ecosystem-sweep.py --all --jobs 8           # ~2.5 h
+scripts/ecosystem-sweep.py --rollup                 # summary.json / summary.md / history.tsv
+git checkout -b ecosystem/sweep-YYYY-MM-DD && git add ecosystem/ && …   # land it as an ordinary PR
+```
+
+Before landing a sweep, check that `measured.host` is uniform across what
+changed: a shard measured on a different machine is identifiable by design, but
+mixing hosts inside one `history.tsv` row makes the row mean less than it looks.
+
+After a **rakudo upgrade**, every baseline is invalid at once (§5) — run a full
+sweep rather than a shard, and say so in the PR, because the denominator moved
+and the KPI is not comparable across that boundary.
+
+## 9. Known limits and follow-ups
 
 - **Network-dependent suites are invisible.** They fail on both sides and land
   in `no_baseline`. Recorded as a count so the size of the blind spot is known;


### PR DESCRIPTION
Follow-up to #7847 / #7848 ([#7785](https://github.com/tokuhirom/mutsu/issues/7785)). The four questions ADR-0085 left open were put to the maintainer and answered. Two confirmed the draft; two changed it.

| question | answer |
|---|---|
| dependency supply | **flat `-I` closure** (fez + REA), unchanged |
| where the data lives | **`ecosystem/` on `main`**, one JSON per dist, unchanged |
| where/how often the sweep runs | **operator-run on a many-core box** — *changed* |
| headline KPI | **`dist_parity` published, `file_parity`/`assertion_parity` steer the work** — *changed* |

## The headline KPI is `dist_parity` (D3 rewritten)

One number cannot do both jobs. `dist_parity` is what a user means by compatibility, but it is a step function — a distribution with 51 test files stays at zero until the last one goes green, so a release that halves its failures shows no movement. `file_parity` moves continuously but weights that distribution 51× a one-file one, so publishing it overstates reach.

So the roles are now split explicitly rather than one being called "the KPI". All three numbers were already reported; what changes is which one is the claim.

## The sweep is operator-run, not CI-scheduled (new D9)

A full sweep is ~20 CPU-hours. A 12-core box does it in ~2.5 h for nothing; a weekly hosted-runner job would charge for it on fewer cores, to track a number that moves at the speed of interpreter fixes rather than of pushes. Phase **P4 becomes the operator runbook** (new §8 of `docs/ecosystem-parity.md`) instead of a workflow file.

Two consequences are stated rather than papered over:

- the headline updates only when someone runs it — a documented state, since D7 already makes staleness computable;
- this campaign does **not** close PLAN.md §1 B1's "working-module regression CI". An earlier draft claimed it would; `PLAN.md` is corrected here.

The ADR moves to **Accepted**, since the questions that kept it `Proposed` are the ones just answered.

Documentation-only, so the build jobs report `skipped` by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EipFi5QhLJC1MjeEVjHHAy

---
_Generated by [Claude Code](https://claude.ai/code/session_01EipFi5QhLJC1MjeEVjHHAy)_