### PR TITLE
perf: hash the AST structurally for identity fingerprints

### DIFF
--- a/news/2026-09/ast-identity-fingerprints-hash-structurally.md
+++ b/news/2026-09/ast-identity-fingerprints-hash-structurally.md
@@ -1,0 +1,87 @@
+# AST identity fingerprints hash the AST instead of its `Debug` rendering
+
+`src/ast.rs` identified a routine by streaming a `Debug` *rendering* of its AST
+into a hasher:
+
+```rust
+let mut sink = HashWrite(&mut hasher);
+let _ = write!(sink, "{params:?}\x00{param_defs:?}\x00{body:?}");
+```
+
+`registration_identity_fingerprint` and `sub_registration_fingerprint` had the
+same shape, and roughly fourteen call sites across the compiler, the VM and the
+runtime reach one of them — so essentially every sub, closure and method body
+the compiler touched dragged a full `core::fmt` traversal of its AST behind it.
+`callgrind` on Cro's HTTP/2 DATA frame once put `<&T as core::fmt::Debug>::fmt`
+at 78.6% of the frame ([#7822](https://github.com/tokuhirom/mutsu/issues/7822),
+split out of #7667). Two rounds of fixes to the *runtime recompiles* that made
+it that visible (#7801, #7812) shrank the share, and an earlier pass replaced
+three `format!` allocations with the `HashWrite` sink
+(`news/2026-08/routine-identity-fingerprint-is-memoized-on-the-def.md`) — but
+the formatting machinery itself was still what every remaining fingerprint paid.
+
+The fix is the obvious one, and the obstacle was never the fingerprints: it was
+that `Expr` holds a `Value`, so hashing structurally needs `Value: Hash`.
+
+## `Hash for Value` is a declaration-identity hash
+
+`src/value/identity_hash.rs` implements it, with the contract written down in
+the module docs so nobody later reuses it for value equality:
+
+- It is deliberately **inconsistent** with `PartialEq for Value`, which is
+  Raku's `eqv`-flavoured value equality — that impl makes `Int(1) == Num(1.0)`
+  and `Array([1]) == Seq([1])`, and this hash separates them. A fingerprint
+  answers "were these two literals parsed from the same source shape", so
+  hashing `NaN` by bit pattern and separating `0.0` from `-0.0` is *correct*
+  here rather than a compromise.
+- `Value` must never gain an `Eq` impl. `HashMap`/`HashSet` require
+  `K: Eq + Hash`, so the missing `Eq` is what mechanically stops anyone from
+  keying a map on this hash and silently getting Raku's value equality wrong.
+
+The variants a parser can actually plant in an AST — the numeric and string
+immediates, ranges, pairs, versions, `Nil`/`*`/`**` — hash structurally. The
+live-object variants (`Sub`, `Instance`, `Promise`, `Proxy`, the `Gc`-backed
+containers) keep the old `Debug`-into-the-hasher fallback: they are unreachable
+from a literal in practice, and several of them carry a per-object `WhichId`
+that is not structurally comparable across two parses anyway, so the fallback
+is the honest answer for them rather than a shortcut.
+
+Everything else is `#[derive(Hash)]` on the AST types, plus a hand-written
+`Hash for TokenKind` — needed only because two of its variants carry an `f64`;
+`mem::discriminant` covers its ~110 unit variants.
+
+## The two properties that had to survive
+
+- `registration_identity_fingerprint` is deliberately line-insensitive (it
+  filters top-level `Stmt::SetLine`) while `function_body_fingerprint` is not.
+  Both keep their behaviour; an explicit statement-count hash stands in for the
+  length prefix a slice hash would have written.
+- Fingerprints are compared across separately-parsed copies of one source, so
+  the hash depends on structure alone — no addresses, no ids that vary per run.
+  `Symbol` hashes an interning id, which is a pure function of the symbol's text
+  within a process, and no fingerprint is ever serialized
+  (`FunctionDef::body_fp_cache` is `#[serde(skip)]` and
+  `CompiledRoutineMetadata` is in-process only).
+
+`src/ast/fingerprint_tests.rs` pins both, along with the field-separation and
+identity-vs-value-equality contracts.
+
+## Measured
+
+`callgrind` on an `EVAL` loop that compiles a fresh non-trivial routine per
+iteration (`Ir`, inclusive):
+
+| | before | after |
+| --- | --- | --- |
+| `function_body_fingerprint` | 56,209,000 (4.17%) | 13,963,000 (1.08%) |
+| `registration_identity_fingerprint` | 22,046,400 (1.64%) | 5,451,800 (0.42%) |
+| `sub_registration_fingerprint` | 22,552,200 (1.67%) | 5,653,800 (0.44%) |
+| program total | 1,346,551,496 | 1,287,832,901 |
+
+Each fingerprint costs about a quarter of what it did; `core::fmt`'s
+`DebugStruct::field` / `str as Debug` / `HashWrite::write_str` entries disappear
+from the profile entirely, and `sip::Hasher::write` drops from 99.7M to 70.6M
+`Ir` because it is no longer fed a character at a time. The whole program is
+4.4% fewer instructions on that workload, and 5.24s → 4.85s of wall clock
+(medians of five) on a longer run of it. A workload that compiles more at
+runtime gains proportionally more.

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -42,7 +42,7 @@ pub(crate) fn next_class_decl_id() -> u64 {
 }
 
 /// Specifies how delegation (`handles`) should forward methods.
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, Hash, serde::Serialize, serde::Deserialize)]
 pub(crate) enum HandleSpec {
     /// Forward a method by name (same name on both sides).
     Name(String),
@@ -56,7 +56,7 @@ pub(crate) enum HandleSpec {
     Wildcard,
 }
 
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, Hash, serde::Serialize, serde::Deserialize)]
 pub(crate) struct ParamDef {
     pub(crate) name: String,
     pub(crate) default: Option<Expr>,
@@ -361,8 +361,8 @@ impl FunctionDef {
     /// body. Multi-candidate identity, `state`-variable scoping, wrap chains,
     /// `MAIN` candidate dedup, and redeclaration checks all key on it.
     ///
-    /// Computed once per def and cached inline. The underlying hash Debug-renders
-    /// the whole body AST, which profiled as a large share of multi/method
+    /// Computed once per def and cached inline. The underlying hash walks the
+    /// whole body AST, which profiled as a large share of multi/method
     /// redispatch; two side caches (`func_def_fp_cache`, keyed on the def's `Arc`
     /// pointer) existed only to avoid that, and this field replaces them with
     /// state that cannot go stale or miss.
@@ -379,37 +379,51 @@ impl FunctionDef {
     }
 }
 
-/// A `fmt::Write` sink that streams formatted bytes straight into a `Hasher`,
-/// so `write!(.., "{:?}", x)` hashes the Debug rendering without ever
-/// allocating an intermediate `String`. `function_body_fingerprint` runs on the
-/// per-dispatch hot path (candidate identity in multi/method dispatch), so the
-/// three `format!` allocations it used to do showed up as a large share of the
-/// allocator traffic in method-call / class benchmarks.
-struct HashWrite<'a, H: Hasher>(&'a mut H);
+#[cfg(test)]
+mod fingerprint_tests;
 
-impl<H: Hasher> std::fmt::Write for HashWrite<'_, H> {
-    fn write_str(&mut self, s: &str) -> std::fmt::Result {
-        self.0.write(s.as_bytes());
-        Ok(())
-    }
-}
-
+/// Structural identity of a routine declaration: its parameter names,
+/// parameter definitions and body, hashed through the derived [`Hash`] impls
+/// on the AST.
+///
+/// # Contract
+///
+/// This is an *identity* fingerprint — "were these two declarations parsed from
+/// the same source shape" — not a value hash. Two properties it must keep, and
+/// which the derived impls give for free:
+///
+/// - **Structure only.** No addresses and no per-object ids, so two separately
+///   parsed copies of one source fingerprint equal. (`Symbol` hashes its
+///   interning id, which is a pure function of the symbol's text within a
+///   process; fingerprints are only ever compared in-process — none of them is
+///   serialized, `FunctionDef::body_fp_cache` included.)
+/// - **Line sensitivity.** This one hashes `Stmt::SetLine` markers like any
+///   other statement; [`registration_identity_fingerprint`] deliberately does
+///   not.
+///
+/// This used to stream a `Debug` rendering of the whole AST into the hasher,
+/// which made `core::fmt` (`DebugStruct::field`, `DebugSet::entry`,
+/// `format_inner`) the dominant cost of every routine the compiler touched —
+/// 78.6% of one Cro HTTP/2 DATA frame at its worst. Hashing structurally pays
+/// none of that machinery.
 pub(crate) fn function_body_fingerprint(
     params: &[String],
     param_defs: &[ParamDef],
     body: &[Stmt],
 ) -> u64 {
-    use std::fmt::Write as _;
     let mut hasher = DefaultHasher::new();
-    let mut sink = HashWrite(&mut hasher);
-    // Separators keep distinct fields from colliding when their renderings abut.
-    let _ = write!(sink, "{params:?}\x00{param_defs:?}\x00{body:?}");
+    // Slice hashing writes a length prefix, which is what keeps the three
+    // fields from colliding into each other the way the old `\x00` separators
+    // guarded against.
+    params.hash(&mut hasher);
+    param_defs.hash(&mut hasher);
+    body.hash(&mut hasher);
     hasher.finish()
 }
 
 /// Line-insensitive identity of a routine declaration for redeclaration
 /// comparison: params, param_defs, and the body with top-level `SetLine`
-/// markers stripped, streamed into a hasher. Identical redeclarations that
+/// markers stripped, hashed structurally. Identical redeclarations that
 /// differ only in source line compare equal. Distinct from
 /// [`function_body_fingerprint`], which hashes `SetLine` markers too (it is a
 /// structural identity, not a redeclaration identity).
@@ -418,12 +432,15 @@ pub(crate) fn registration_identity_fingerprint(
     param_defs: &[ParamDef],
     body: &[Stmt],
 ) -> u64 {
-    use std::fmt::Write as _;
     let mut hasher = DefaultHasher::new();
-    let mut sink = HashWrite(&mut hasher);
-    let _ = write!(sink, "{params:?}\x00{param_defs:?}\x00");
-    for stmt in body.iter().filter(|s| !matches!(s, Stmt::SetLine(_))) {
-        let _ = write!(sink, "{stmt:?}\x00");
+    params.hash(&mut hasher);
+    param_defs.hash(&mut hasher);
+    let kept = || body.iter().filter(|s| !matches!(s, Stmt::SetLine(_)));
+    // Stand in for the length prefix a slice hash would have written, so a
+    // body cannot collide with a longer one whose extra statements hash empty.
+    kept().count().hash(&mut hasher);
+    for stmt in kept() {
+        stmt.hash(&mut hasher);
     }
     hasher.finish()
 }
@@ -472,7 +489,7 @@ pub(crate) fn next_end_phaser_index() -> u32 {
     NEXT.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 pub(crate) enum PhaserKind {
     Begin,
     Check,
@@ -491,7 +508,7 @@ pub(crate) enum PhaserKind {
     Close,
 }
 
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, Hash, serde::Serialize, serde::Deserialize)]
 #[allow(clippy::enum_variant_names, dead_code)]
 pub(crate) enum Expr {
     Literal(Value),
@@ -927,7 +944,7 @@ pub(crate) enum Expr {
 /// on success — **at the end of the enclosing block**. A synthesized wrapper
 /// is not that block, so resolving a save at one would resolve it far too
 /// early (GH-7635).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 pub(crate) enum DoBlockOrigin {
     /// Real `{ ... }` braces the user wrote, which *are* a Raku block: `do {
     /// ... }`, a labelled `L: { ... }`, and the statement prefixes whose block
@@ -946,7 +963,7 @@ pub(crate) enum DoBlockOrigin {
 }
 
 /// Secondary adverb on :exists subscript adverb
-#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 pub(crate) enum ExistsAdverb {
     None,
     Kv,
@@ -960,7 +977,7 @@ pub(crate) enum ExistsAdverb {
     InvalidV,
 }
 
-#[derive(Debug, Clone, Copy, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, Copy, Hash, serde::Serialize, serde::Deserialize)]
 pub(crate) enum HyperSliceAdverb {
     Kv,
     K,
@@ -970,14 +987,14 @@ pub(crate) enum HyperSliceAdverb {
     DeepKv,
 }
 
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, Hash, serde::Serialize, serde::Deserialize)]
 pub(crate) enum ControlFlowKind {
     Last,
     Next,
     Redo,
 }
 
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, Hash, serde::Serialize, serde::Deserialize)]
 pub(crate) enum CallArg {
     Positional(Expr),
     Named {
@@ -991,7 +1008,7 @@ pub(crate) enum CallArg {
 }
 
 /// Execution mode for `for` loops.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 pub(crate) enum ForMode {
     Normal,
     Race,
@@ -1002,7 +1019,7 @@ pub(crate) enum ForMode {
 
 /// The declarator keyword used for a `Stmt::Package`. Determines the
 /// `package-kind` reported by X::Attribute::Package.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 pub(crate) enum PackageKind {
     Module,
     Package,
@@ -1037,7 +1054,7 @@ impl PackageKind {
 ///
 /// Recording the kind where the readonly-ness is *decided* keeps the three
 /// apart without any name-based guessing at the (single, shared) check site.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 pub(crate) enum ReadonlyKind {
     /// Readonly binding with a container behind it: parameters, `for` aliases.
     Alias,
@@ -1047,7 +1064,7 @@ pub(crate) enum ReadonlyKind {
     ImmutableValue,
 }
 
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, Hash, serde::Serialize, serde::Deserialize)]
 pub(crate) enum Stmt {
     VarDecl {
         name: String,
@@ -1582,7 +1599,7 @@ pub(crate) enum Stmt {
     Expr(Expr),
 }
 
-#[derive(Debug, Clone, Copy, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, Copy, Hash, serde::Serialize, serde::Deserialize)]
 pub(crate) enum AssignOp {
     Assign,
     Bind,

--- a/src/ast/fingerprint_tests.rs
+++ b/src/ast/fingerprint_tests.rs
@@ -1,0 +1,176 @@
+//! Pins for the AST identity fingerprints
+//! ([#7822](https://github.com/tokuhirom/mutsu/issues/7822)).
+//!
+//! The three fingerprints moved from hashing a `Debug` rendering of the AST to
+//! hashing it structurally through the derived `Hash` impls. The two properties
+//! that survived that move are the ones worth pinning: the line-sensitivity
+//! split between the two entry points, and the fact that a fingerprint depends
+//! on structure alone, so two separately-built copies of one declaration agree.
+
+use super::*;
+use crate::value::Value;
+
+fn say(text: &str) -> Stmt {
+    Stmt::Say(vec![Expr::Literal(Value::str(text.to_string()))])
+}
+
+fn param(name: &str) -> ParamDef {
+    ParamDef {
+        name: name.to_string(),
+        default: None,
+        multi_invocant: true,
+        required: true,
+        named: false,
+        slurpy: false,
+        double_slurpy: false,
+        onearg: false,
+        sigilless: false,
+        type_constraint: None,
+        literal_value: None,
+        sub_signature: None,
+        where_constraint: None,
+        traits: Vec::new(),
+        optional_marker: false,
+        outer_sub_signature: None,
+        code_signature: None,
+        is_invocant: false,
+        shape_constraints: None,
+        block_param: false,
+    }
+}
+
+/// A fingerprint is a pure function of structure, so a second, separately
+/// built copy of the same declaration agrees with the first. This is what lets
+/// multi-candidate identity and redeclaration comparison work across two
+/// parses of one source.
+#[test]
+fn structurally_identical_declarations_agree() {
+    let build = || {
+        (
+            vec!["$a".to_string()],
+            vec![param("$a")],
+            vec![Stmt::SetLine(7), say("hi")],
+        )
+    };
+    let (p1, d1, b1) = build();
+    let (p2, d2, b2) = build();
+
+    assert_eq!(
+        function_body_fingerprint(&p1, &d1, &b1),
+        function_body_fingerprint(&p2, &d2, &b2)
+    );
+    assert_eq!(
+        registration_identity_fingerprint(&p1, &d1, &b1),
+        registration_identity_fingerprint(&p2, &d2, &b2)
+    );
+}
+
+/// `function_body_fingerprint` hashes `SetLine` like any other statement;
+/// `registration_identity_fingerprint` strips top-level ones so a
+/// redeclaration that moved down the file still compares equal.
+#[test]
+fn only_the_registration_identity_is_line_insensitive() {
+    let params: Vec<String> = Vec::new();
+    let defs: Vec<ParamDef> = Vec::new();
+    let at_line_3 = vec![Stmt::SetLine(3), say("body")];
+    let at_line_9 = vec![Stmt::SetLine(9), say("body")];
+
+    assert_ne!(
+        function_body_fingerprint(&params, &defs, &at_line_3),
+        function_body_fingerprint(&params, &defs, &at_line_9),
+        "the structural fingerprint must stay line-sensitive"
+    );
+    assert_eq!(
+        registration_identity_fingerprint(&params, &defs, &at_line_3),
+        registration_identity_fingerprint(&params, &defs, &at_line_9),
+        "the redeclaration identity must ignore top-level SetLine markers"
+    );
+}
+
+/// Neither entry point may collapse a genuine difference in the body.
+#[test]
+fn a_different_body_fingerprints_differently() {
+    let params: Vec<String> = Vec::new();
+    let defs: Vec<ParamDef> = Vec::new();
+    let a = vec![say("a")];
+    let b = vec![say("b")];
+
+    assert_ne!(
+        function_body_fingerprint(&params, &defs, &a),
+        function_body_fingerprint(&params, &defs, &b)
+    );
+    assert_ne!(
+        registration_identity_fingerprint(&params, &defs, &a),
+        registration_identity_fingerprint(&params, &defs, &b)
+    );
+}
+
+/// Statement *count* is part of the identity: appending a statement changes
+/// the fingerprint even where the extra statement is a `SetLine`-free no-op.
+/// This is what the explicit count guard in
+/// `registration_identity_fingerprint` buys, standing in for the length prefix
+/// a slice hash would have written.
+#[test]
+fn appending_a_statement_changes_the_registration_identity() {
+    let params: Vec<String> = Vec::new();
+    let defs: Vec<ParamDef> = Vec::new();
+    let one = vec![say("a")];
+    let two = vec![say("a"), say("a")];
+
+    assert_ne!(
+        registration_identity_fingerprint(&params, &defs, &one),
+        registration_identity_fingerprint(&params, &defs, &two)
+    );
+}
+
+/// The three hashed fields must not bleed into one another: moving a name from
+/// the parameter-name list into a `ParamDef` is a different declaration.
+#[test]
+fn params_and_param_defs_are_separate_fields() {
+    let body: Vec<Stmt> = Vec::new();
+    let as_names = function_body_fingerprint(&["$a".to_string()], &[], &body);
+    let as_defs = function_body_fingerprint(&[], &[param("$a")], &body);
+    assert_ne!(as_names, as_defs);
+}
+
+/// `sub_registration_fingerprint` extends the body fingerprint with the flags
+/// that distinguish otherwise same-bodied declarations.
+#[test]
+fn sub_registration_fingerprint_separates_the_declaration_flags() {
+    let params: Vec<String> = Vec::new();
+    let defs: Vec<ParamDef> = Vec::new();
+    let body = vec![say("a")];
+    let plain = sub_registration_fingerprint(&params, &defs, &body, None, false, false, false);
+    let multi = sub_registration_fingerprint(&params, &defs, &body, None, true, false, false);
+    let rw = sub_registration_fingerprint(&params, &defs, &body, None, false, true, false);
+    let returns = sub_registration_fingerprint(
+        &params,
+        &defs,
+        &body,
+        Some(&"Int".to_string()),
+        false,
+        false,
+        false,
+    );
+
+    assert_ne!(plain, multi);
+    assert_ne!(plain, rw);
+    assert_ne!(plain, returns);
+}
+
+/// A literal's identity is its *declaration* shape, not its Raku value: `1`
+/// and `1.0` are equal under `PartialEq for Value` but are different source
+/// texts, so two routines returning them are different declarations.
+#[test]
+fn literals_hash_by_declaration_identity_not_value_equality() {
+    let params: Vec<String> = Vec::new();
+    let defs: Vec<ParamDef> = Vec::new();
+    let int = vec![Stmt::Say(vec![Expr::Literal(Value::int(1))])];
+    let num = vec![Stmt::Say(vec![Expr::Literal(Value::num(1.0))])];
+
+    assert_eq!(Value::int(1), Value::num(1.0));
+    assert_ne!(
+        function_body_fingerprint(&params, &defs, &int),
+        function_body_fingerprint(&params, &defs, &num)
+    );
+}

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -3839,11 +3839,12 @@ pub struct Interpreter {
     /// and is cleared with the other method caches on any registry change.
     pub(crate) dispatch_multi_candidate: rustc_hash::FxHashMap<(Symbol, Symbol), bool>,
     /// Memoized structural fingerprint of a method body, keyed by the *pointer*
-    /// of its `Arc<Vec<Stmt>>` body. `function_body_fingerprint` Debug-traverses
+    /// of its `Arc<Vec<Stmt>>` body. `function_body_fingerprint` traverses
     /// the whole body AST, which dominated the method-redispatch hot path
     /// (`build_remaining` / `prepare_method_dispatch_frame`, reached by every
     /// `nextsame`/`samewith` and multi-method call) — perf showed ~8% of a
-    /// samewith-tight-loop in SipHash-over-Debug. A `MethodDef` clone shares its
+    /// samewith-tight-loop in SipHash-over-Debug back when the traversal went
+    /// through `core::fmt`. A `MethodDef` clone shares its
     /// body `Arc`, and two *distinct* methods always have distinct body `Arc`s
     /// (clones are the only way to share one, and clones carry identical
     /// params/param_defs), so the body-`Arc` pointer uniquely identifies the

--- a/src/token_kind.rs
+++ b/src/token_kind.rs
@@ -1,8 +1,9 @@
 use crate::value::VersionPart;
 use num_bigint::BigInt as NumBigInt;
+use std::hash::{Hash, Hasher};
 
 #[allow(dead_code)]
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Hash, serde::Serialize, serde::Deserialize)]
 pub(crate) enum DStrPart {
     Lit(String),
     Var(String),
@@ -19,7 +20,7 @@ pub(crate) enum DStrPart {
 /// instead. Keeping the substitution in its own step is what lets the bare
 /// infix ops stay strict — `Int + 1` throws `X::Numeric::Uninitialized` while
 /// `my Int $a; $a += 1` still yields `1`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 pub(crate) enum MetaAssignIdentity {
     /// `infix:<+>()` / `infix:<->()` are `0`.
     Zero,
@@ -203,6 +204,53 @@ pub(crate) enum TokenKind {
     },
     Semicolon,
     Eof,
+}
+
+/// Structural hash of a token, for the AST identity fingerprints in
+/// [`crate::ast`] (`Expr` and `Stmt` embed `TokenKind`, so their derived
+/// `Hash` needs one here).
+///
+/// Hand-written only because two variants carry an `f64`, which has no `Hash`.
+/// They are hashed by bit pattern: this is a *declaration identity* hash, not a
+/// numeric one, so distinguishing `NaN` payloads and `0.0` from `-0.0` is
+/// correct here — two source texts that lex to different bits are different
+/// declarations. `mem::discriminant` covers the ~110 unit variants, which are
+/// fully identified by their tag.
+impl Hash for TokenKind {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        std::mem::discriminant(self).hash(state);
+        match self {
+            TokenKind::Number(n) => n.hash(state),
+            TokenKind::BigNumber(n) => n.hash(state),
+            TokenKind::Float(f) | TokenKind::Imaginary(f) => f.to_bits().hash(state),
+            TokenKind::Str(s)
+            | TokenKind::Regex(s)
+            | TokenKind::Ident(s)
+            | TokenKind::Var(s)
+            | TokenKind::CaptureVar(s)
+            | TokenKind::HashVar(s)
+            | TokenKind::ArrayVar(s)
+            | TokenKind::CodeVar(s) => s.hash(state),
+            TokenKind::DStr(parts) => parts.hash(state),
+            TokenKind::Subst {
+                pattern,
+                replacement,
+            } => {
+                pattern.hash(state);
+                replacement.hash(state);
+            }
+            TokenKind::QWords(words) => words.hash(state),
+            TokenKind::MetaAssignIdentity(id) => id.hash(state),
+            TokenKind::VersionLiteral { parts, plus, minus } => {
+                parts.hash(state);
+                plus.hash(state);
+                minus.hash(state);
+            }
+            // Every remaining variant is a unit variant: the discriminant
+            // hashed above already identifies it completely.
+            _ => {}
+        }
+    }
 }
 
 pub(crate) fn lookup_unicode_char_by_name(name: &str) -> Option<char> {

--- a/src/value/identity_hash.rs
+++ b/src/value/identity_hash.rs
@@ -1,0 +1,209 @@
+//! `Hash for Value` — the *declaration identity* hash the AST fingerprints
+//! ([`crate::ast::function_body_fingerprint`] and friends) are built on.
+//!
+//! # Why this exists
+//!
+//! `Expr::Literal` and `ParamDef::literal_value` hold a `Value`, so the derived
+//! `Hash` on `Expr` / `Stmt` needs one here. Before
+//! [#7822](https://github.com/tokuhirom/mutsu/issues/7822) the fingerprints
+//! hashed a `Debug` *rendering* of the AST instead, which dragged the whole
+//! `core::fmt` machinery (`DebugStruct::field`, `DebugSet::entry`,
+//! `format_inner`) behind every routine the compiler touched.
+//!
+//! # The contract — identity, NOT value equality
+//!
+//! This hash answers "were these two literals parsed from the same source
+//! shape", nothing more. It is deliberately **inconsistent** with
+//! [`PartialEq for Value`](crate::value::Value), which is Raku's `eqv`-flavoured
+//! *value* equality: that impl makes `Int(1) == Num(1.0)` and
+//! `Array([1]) == Seq([1])`, and this hash separates them. Two consequences,
+//! both intended:
+//!
+//! - Hashing `NaN` by bit pattern, and separating `0.0` from `-0.0`, is
+//!   *correct* here. Two source texts that lex to different bits are different
+//!   declarations.
+//! - `Value` must never gain an `Eq` impl. `HashMap`/`HashSet` require
+//!   `K: Eq + Hash`, so the missing `Eq` is what mechanically prevents anyone
+//!   from keying a map on this hash and silently getting Raku's value equality
+//!   wrong. If you need a value-equality hash, write a separate one — do not
+//!   make `Value: Eq`.
+//!
+//! # Structure only
+//!
+//! Fingerprints are compared across separately-parsed copies of the same
+//! source, so nothing here may depend on an address or on an allocation
+//! identity. `Symbol` is fine: it hashes an interning id, which is a pure
+//! function of the symbol's text within a process, and no fingerprint is ever
+//! serialized (`FunctionDef::body_fp_cache` and `CompiledRoutineMetadata` are
+//! both in-process only).
+//!
+//! # The `Debug` fallback
+//!
+//! The variants a parser can actually plant in an AST — the numeric and string
+//! immediates, ranges, pairs, versions, `Nil`/`*`/`**` — are hashed
+//! structurally. The live-object variants (`Sub`, `Instance`, `Promise`,
+//! `Proxy`, the `Gc`-backed containers, ...) fall back to streaming their
+//! `Debug` rendering into the hasher, exactly as the whole AST used to. They
+//! are unreachable from a literal in practice, so the fallback costs nothing on
+//! any hot path, and several of them (`HashData::which_id`, `ArrayData`'s
+//! `WhichId`) are not structurally comparable across copies anyway — the
+//! fallback is the honest answer for those, not a shortcut.
+
+use super::{Value, ValueView};
+use std::hash::{Hash, Hasher};
+
+/// A `fmt::Write` sink that streams formatted bytes straight into a `Hasher`,
+/// so `write!(.., "{:?}", x)` hashes the `Debug` rendering without ever
+/// allocating an intermediate `String`.
+struct HashWrite<'a, H: Hasher>(&'a mut H);
+
+impl<H: Hasher> std::fmt::Write for HashWrite<'_, H> {
+    fn write_str(&mut self, s: &str) -> std::fmt::Result {
+        self.0.write(s.as_bytes());
+        Ok(())
+    }
+}
+
+impl Hash for Value {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        let view = self.view();
+        // Tags every variant, including the ones that fall through to the
+        // `Debug` arm, so a structurally-hashed payload can never collide with
+        // a differently-tagged one carrying the same bytes.
+        std::mem::discriminant(&view).hash(state);
+        match view {
+            ValueView::Int(i) => i.hash(state),
+            ValueView::BigInt(n) => (**n).hash(state),
+            // Bit pattern, not numeric value — see the module docs.
+            ValueView::Num(f) => f.to_bits().hash(state),
+            ValueView::Str(s) => (**s).hash(state),
+            ValueView::Bool(b) => b.hash(state),
+            ValueView::Range(a, b)
+            | ValueView::RangeExcl(a, b)
+            | ValueView::RangeExclStart(a, b)
+            | ValueView::RangeExclBoth(a, b)
+            | ValueView::Rat(a, b)
+            | ValueView::FatRat(a, b) => {
+                a.hash(state);
+                b.hash(state);
+            }
+            ValueView::GenericRange {
+                start,
+                end,
+                excl_start,
+                excl_end,
+            } => {
+                (**start).hash(state);
+                (**end).hash(state);
+                excl_start.hash(state);
+                excl_end.hash(state);
+            }
+            ValueView::BigRat(num, den) => {
+                num.hash(state);
+                den.hash(state);
+            }
+            ValueView::Complex(re, im) => {
+                re.to_bits().hash(state);
+                im.to_bits().hash(state);
+            }
+            ValueView::CompUnitDepSpec { short_name } => short_name.hash(state),
+            ValueView::Package(name) => name.hash(state),
+            ValueView::Routine {
+                package,
+                name,
+                is_regex,
+            } => {
+                package.hash(state);
+                name.hash(state);
+                is_regex.hash(state);
+            }
+            ValueView::Pair(key, value) => {
+                key.hash(state);
+                value.hash(state);
+            }
+            ValueView::ValuePair(key, value) => {
+                key.hash(state);
+                value.hash(state);
+            }
+            ValueView::Regex(pattern) => (**pattern).hash(state),
+            ValueView::Junction { kind, values } => {
+                std::mem::discriminant(&kind).hash(state);
+                (**values).hash(state);
+            }
+            ValueView::Slip(items) => (**items).hash(state),
+            ValueView::Version {
+                parts,
+                plus,
+                minus,
+                text,
+            } => {
+                parts.hash(state);
+                plus.hash(state);
+                minus.hash(state);
+                text.hash(state);
+            }
+            ValueView::ParametricRole {
+                base_name,
+                type_args,
+            } => {
+                base_name.hash(state);
+                type_args.hash(state);
+            }
+            ValueView::Scalar(inner) => inner.hash(state),
+            // Unit variants: the discriminant above is the whole identity.
+            ValueView::Nil | ValueView::Whatever | ValueView::HyperWhatever => {}
+            // Live-object / `Gc`-backed variants — see the module docs.
+            _ => {
+                use std::fmt::Write as _;
+                let _ = write!(HashWrite(state), "{self:?}");
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::hash_map::DefaultHasher;
+
+    fn fp(v: &Value) -> u64 {
+        let mut h = DefaultHasher::new();
+        v.hash(&mut h);
+        h.finish()
+    }
+
+    #[test]
+    fn equal_literals_hash_equal() {
+        assert_eq!(fp(&Value::int(42)), fp(&Value::int(42)));
+        assert_eq!(
+            fp(&Value::str("hello".to_string())),
+            fp(&Value::str("hello".to_string()))
+        );
+        assert_eq!(fp(&Value::num(1.5)), fp(&Value::num(1.5)));
+    }
+
+    #[test]
+    fn distinct_literals_hash_distinct() {
+        assert_ne!(fp(&Value::int(42)), fp(&Value::int(43)));
+        assert_ne!(
+            fp(&Value::str("a".to_string())),
+            fp(&Value::str("b".to_string()))
+        );
+    }
+
+    /// The identity contract: `Int(1) == Num(1.0)` under `PartialEq`, but they
+    /// are different declarations, so they must hash apart.
+    #[test]
+    fn identity_hash_is_not_value_equality() {
+        assert_eq!(Value::int(1), Value::num(1.0));
+        assert_ne!(fp(&Value::int(1)), fp(&Value::num(1.0)));
+    }
+
+    /// `NaN` is hashed by bit pattern, so it is stable — unlike its `PartialEq`
+    /// treatment, which is a special case rather than a bitwise one.
+    #[test]
+    fn nan_hashes_stably_and_signed_zeros_differ() {
+        assert_eq!(fp(&Value::num(f64::NAN)), fp(&Value::num(f64::NAN)));
+        assert_ne!(fp(&Value::num(0.0)), fp(&Value::num(-0.0)));
+    }
+}

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -221,6 +221,8 @@ mod error_typed;
 mod guards;
 /// The hash key type ([`HashKey`]): inline for short keys, `Arc<str>` beyond.
 pub mod hash_key;
+/// `Hash for Value`: the declaration-identity hash the AST fingerprints use.
+mod identity_hash;
 pub use hash_key::HashKey;
 /// ADR-0016 P5 seam: `Match`-representation accessor helpers.
 mod match_lazy;
@@ -1960,7 +1962,7 @@ pub struct RegexClosure {
     pub scope: Arc<HashMap<String, Value>>,
 }
 
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 pub(crate) enum VersionPart {
     Num(i64),
     Str(String),


### PR DESCRIPTION
## What

`function_body_fingerprint`, `registration_identity_fingerprint` and
`sub_registration_fingerprint` identified a routine by streaming a `Debug`
*rendering* of its AST into a hasher. Roughly fourteen call sites across the
compiler, the VM and the runtime reach one of them, so essentially every sub,
closure and method body the compiler touched dragged a full `core::fmt`
traversal of its AST behind it — once 78.6% of a Cro HTTP/2 DATA frame.

This derives `Hash` on the AST types and hashes structurally instead.

## `Hash for Value`

The obstacle was never the fingerprints: `Expr` holds a `Value`, so this needs
`Value: Hash`. `src/value/identity_hash.rs` provides it as an explicit
**declaration identity** hash, with the contract written down in the module
docs:

- It is deliberately **inconsistent** with `PartialEq for Value`, which is
  Raku's `eqv`-flavoured value equality (`Int(1) == Num(1.0)`,
  `Array([1]) == Seq([1])`). Under an identity contract, hashing `NaN` by bit
  pattern and separating `0.0` from `-0.0` is *correct*, not a compromise.
- `Value` must never gain an `Eq` impl. `HashMap`/`HashSet` require
  `K: Eq + Hash`, so the missing `Eq` is what mechanically stops anyone from
  keying a map on this hash and silently getting Raku's value equality wrong.

The variants a parser can plant in an AST hash structurally. Live-object
variants (`Sub`, `Instance`, `Promise`, `Proxy`, the `Gc`-backed containers)
keep the `Debug` fallback: unreachable from a literal in practice, and several
carry a per-object `WhichId` that is not structurally comparable across two
parses anyway.

`TokenKind` gets a hand-written `Hash` only because two variants carry an
`f64`; `mem::discriminant` covers its ~110 unit variants.

## The two properties that had to survive

Both are pinned by `src/ast/fingerprint_tests.rs`:

- `registration_identity_fingerprint` stays line-insensitive (it filters
  top-level `Stmt::SetLine`) while `function_body_fingerprint` does not. An
  explicit statement-count hash stands in for the length prefix a slice hash
  would have written.
- The hash depends on structure alone, so two separately-parsed copies of one
  source agree. `Symbol` hashes an interning id, which is a pure function of
  the symbol's text within a process, and no fingerprint is ever serialized
  (`FunctionDef::body_fp_cache` is `#[serde(skip)]`, `CompiledRoutineMetadata`
  is in-process only).

## Measured

`callgrind` on an `EVAL` loop that compiles a fresh non-trivial routine per
iteration (`Ir`, inclusive):

| | before | after |
| --- | --- | --- |
| `function_body_fingerprint` | 56,209,000 (4.17%) | 13,963,000 (1.08%) |
| `registration_identity_fingerprint` | 22,046,400 (1.64%) | 5,451,800 (0.42%) |
| `sub_registration_fingerprint` | 22,552,200 (1.67%) | 5,653,800 (0.44%) |
| program total | 1,346,551,496 | 1,287,832,901 |

`core::fmt`'s `DebugStruct::field` / `str as Debug` / `HashWrite::write_str`
entries leave the profile entirely, and `sip::Hasher::write` drops from 99.7M
to 70.6M `Ir` because it is no longer fed a character at a time. 4.4% fewer
instructions program-wide on that workload; 5.24s → 4.85s of wall clock
(medians of five) on a longer run of it. A workload that compiles more at
runtime gains proportionally more.

## Testing

- `cargo fmt --all`, `make lint` (all four configurations) — clean.
- `make test` — `Files=3952, Tests=42022`, `Result: PASS`.
- `make roast` — the only failures are the three documented container-environment
  exemptions from `docs/agent-environments.md`
  (`6.c/S32-io/file-tests.t` tests 6-8/10 and `S16-filehandles/filetest.t` tests
  57-64/69-72/77-80/101…125, both because the container runs as `uid 0`; and
  `S32-io/IO-Socket-Async.t` exit 124, sandboxed network), each matching its
  documented failure shape exactly.
- New: 7 fingerprint invariant tests + 4 `Hash for Value` contract tests.

Closes #7822

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CtLHAawFeQRGuP4ubZMPtE

---
_Generated by [Claude Code](https://claude.ai/code/session_01CtLHAawFeQRGuP4ubZMPtE)_