### PR TITLE
feat(ecosystem): P1 of the parity campaign — the sweep harness and its record store

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -102,7 +102,9 @@ work; see the CLAUDE.md "mzef package manager and distribution" section. The **R
 
 - [ ] **★Ecosystem parity KPI** — run every zef distribution's own test suite on **both** rakudo and
       mutsu and publish the difference as the project's headline compatibility number, with
-      per-distribution machine-readable records in `ecosystem/`.
+      per-distribution machine-readable records in `ecosystem/`. **P1 (the harness) has landed**;
+      the next step is **P2, the first corpus sweep** — it needs a many-core box, and it is what
+      produces the first real numbers.
       Decisions: [ADR-0085](docs/adr/0085-ecosystem-testsuite-parity-measurement.md);
       operations manual and phases (P1-P5, one PR each):
       [docs/ecosystem-parity.md](docs/ecosystem-parity.md);

--- a/docs/adr/0085-ecosystem-testsuite-parity-measurement.md
+++ b/docs/adr/0085-ecosystem-testsuite-parity-measurement.md
@@ -1,6 +1,6 @@
 # ADR-0085 — The ecosystem KPI is per-distribution test-suite parity against rakudo
 
-- Status: Accepted (design confirmed by the maintainer 2026-09-10; implementation not started)
+- Status: Accepted (design confirmed 2026-09-10; P1 implemented — see "Implementation status")
 - Date: 2026-09-10
 - Issue: [#7785](https://github.com/tokuhirom/mutsu/issues/7785)
 - Operations manual (the "how"): [docs/ecosystem-parity.md](../ecosystem-parity.md)
@@ -284,6 +284,32 @@ mixed in.
 - Committing ~1600 records is a few megabytes of JSON and a bounded per-sweep
   diff. Accepted in exchange for the data being *in the repository*, which the
   issue requires and which makes it browsable, diffable and reviewable.
+
+## Implementation status
+
+Phases are listed in [docs/ecosystem-parity.md](../ecosystem-parity.md) §7.
+
+| phase | state |
+|---|---|
+| **P1** — harness, dependency resolver, sandbox, record store, `--only`/`--prefix`/`--rollup` | **done** — `scripts/ecosystem-sweep.py` + `scripts/ecosystem_common.py`; validated on eight distributions, which surfaced real interpreter findings on the first pass |
+| **P2** — first corpus sweep, the first KPI numbers | open; needs a many-core box (D9) |
+| **P3** — `ecosystem/history.svg` in the README, `site/ecosystem.html` | open |
+| **P4** — operator runbook | open |
+| **P5** — root-cause grouping of `regression` records into issues | open |
+
+Two decisions were tested by the implementation rather than only argued:
+
+- **D4/D5 (the flat closure) held.** The two sweeps now disagree usefully on the
+  same distribution: `dist-compat-sweep.py` calls `Trie` `missing_dep
+  (OrderedHash)`, while this harness resolves `OrderedHash` from REA and
+  measures the distribution. That is the coverage the merged index buys.
+- **D8 (the environment contract) is enforced at startup**, not documented and
+  hoped for: a set `MUTSU_FUDGE`, a missing `bwrap` on a corpus run, or a `use
+  Test` that does not reach the vendored `Test.rakumod` each abort the sweep.
+
+`ecosystem/` deliberately carries no `summary.*` or `history.tsv` until P2: a
+rollup over a handful of hand-picked distributions reads like a KPI and is not
+one.
 
 ## Alternatives considered
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -110,4 +110,4 @@ The role of an ADR is to preserve the *context of the judgment* — something th
 | [0082](0082-a-collecting-for-gathers-containers-not-snapshots.md) | A value-collecting `for` gathers containers, not snapshots | Superseded by 0083 |
 | [0083](0083-a-collected-for-retains-containers-past-the-loop.md) | A collected `for` retains lvalue containers past the loop | Accepted (implemented) |
 | [0084](0084-the-frame-env-is-not-the-programs-symbol-table.md) | The per-frame `Env` is not the program's symbol table — type/package names and internal markers move to side tables | Proposed (design complete; implementation not started) |
-| [0085](0085-ecosystem-testsuite-parity-measurement.md) | The ecosystem KPI is per-distribution test-suite parity against rakudo | Accepted (design confirmed 2026-09-10; implementation not started) |
+| [0085](0085-ecosystem-testsuite-parity-measurement.md) | The ecosystem KPI is per-distribution test-suite parity against rakudo | Accepted (P1 implemented; P2-P5 open — see "Implementation status") |

--- a/docs/ecosystem-parity.md
+++ b/docs/ecosystem-parity.md
@@ -15,8 +15,10 @@ sides, and publish the difference.
   release gate on the ~40 *bundled* dists. This campaign is neither: it is an
   exhaustive, re-runnable ledger over the whole ecosystem.
 
-> **Status: design only.** Nothing in this document is implemented yet. The
-> phases in §7 are the build order; each is one PR.
+> **Status: P1 landed** — `scripts/ecosystem-sweep.py` and the record store
+> exist and have been run end to end. P2 (the corpus sweep, and therefore the
+> first real KPI numbers) has not. `ecosystem/` currently holds a small
+> validation set, not a survey; see [ecosystem/README.md](../ecosystem/README.md).
 
 ## 1. What gets measured
 
@@ -341,7 +343,7 @@ dark README; browsers that ignore it get the light palette.
 
 | # | Deliverable | Done when |
 |---|---|---|
-| **P1** | `scripts/ecosystem_common.py` extracted from `dist-compat-sweep.py`; `scripts/ecosystem-sweep.py` with the dep resolver, sandbox, TAP compare, `--only` / `--prefix` / `--rollup`; schema v1 | the `A` shard measures end to end and its records land under `ecosystem/dists/A/` |
+| ~~**P1**~~ | ~~`scripts/ecosystem_common.py` extracted from `dist-compat-sweep.py`; `scripts/ecosystem-sweep.py` with the dep resolver, sandbox, TAP compare, `--only` / `--prefix` / `--rollup`; schema v1~~ | **done** — records round-trip, `--rollup` produces summary + history + chart, and the first eight distributions surfaced real findings |
 | **P2** | first full-corpus sweep; `ecosystem/` populated; `summary.*` + the first `history.tsv` row | `file_parity` / `assertion_parity` / `dist_parity` exist as real numbers |
 | **P3** | `ecosystem/history.svg` linked from `README.md`; `site/ecosystem.html` + manifest generator + `pages.yml` wiring | a user can see the KPI trend from the README and look up a single dist on the public site |
 | **P4** | the operator runbook (§8) — one `make`-level entry point for a full sweep and for a shard, plus the `--rollup` + `history.tsv` append and the PR it lands as | a maintainer can go from a clean checkout to a merged sweep by following one page |
@@ -382,6 +384,11 @@ sweep rather than a shard, and say so in the PR, because the denominator moved
 and the KPI is not comparable across that boundary.
 
 ## 9. Known limits and follow-ups
+
+- **`--attempts` multiplies the cost of a red corpus.** The retry runs only on a
+  file that did not pass, which is the right side to spend it on, but early in
+  the campaign most files are that side. Lower it (`--attempts 1`) for a scouting
+  run and restore it for a sweep whose numbers are going to be published.
 
 - **Network-dependent suites are invisible.** They fail on both sides and land
   in `no_baseline`. Recorded as a count so the size of the blind spot is known;

--- a/ecosystem/README.md
+++ b/ecosystem/README.md
@@ -1,0 +1,73 @@
+# `ecosystem/` — the parity ledger
+
+Machine-readable measurements of **how mutsu does against rakudo on real zef
+distributions**: each distribution's own test suite run under both interpreters,
+with rakudo as the denominator.
+
+- **Method and metric definitions**: [docs/ecosystem-parity.md](../docs/ecosystem-parity.md)
+- **Why it is shaped this way**: [ADR-0085](../docs/adr/0085-ecosystem-testsuite-parity-measurement.md)
+- **Tracking issue**: [#7785](https://github.com/tokuhirom/mutsu/issues/7785)
+
+## What is here
+
+| path | what it is |
+|---|---|
+| `dists/<S>/<Dist--Name>.json` | one record per distribution — the measurement |
+| `index-snapshot.json` | which ecosystem index snapshot the run drew from (fez + REA, with digests) |
+| `summary.json` / `summary.md` | generated rollup — **do not edit**, regenerate with `--rollup` |
+| `history.tsv` / `history.svg` | one row per full sweep, and its chart — the KPI over time |
+
+`<S>` is the uppercased first letter of the distribution name (`_` when it is
+not an ASCII letter), and `::` is written `--` in the filename:
+`String::Utils` → `dists/S/String--Utils.json`.
+
+One file per distribution is not an accident. It is what keeps parallel PRs from
+conflicting (the same reasoning as `news/`), and it makes re-measuring one
+distribution a one-file change.
+
+## Reading a record
+
+```jsonc
+{
+  "dist": "BTree", "version": "0.0.4", "status": "partial",
+  "axis": "pure",                       // pure / guts (nqp, MOP) / native (NativeCall)
+  "measured": { "date": …, "mutsu_commit": …, "raku_version": … },
+  "deps": { "resolved": [...], "unresolved": [] },
+  "load": { "BTree": "ok" },            // per provided module
+  "files": [
+    { "path": "t/…", "raku": {…}, "mutsu": {…}, "cmp": "regression" }
+  ],
+  "totals": { "baseline_files": 2, "parity_files": 1, … }
+}
+```
+
+`cmp` is the per-file comparison. **`regression` and `partial` are the
+actionable ones**: rakudo passes the file and mutsu does not. `no_baseline`
+means rakudo did not pass it either, so it is excluded from the KPI — it is
+never charged to mutsu.
+
+`status` rolls that up per distribution: `green` (every baseline file passes) ·
+`partial` · `red` · `no_baseline` · `blocked_load` (a provided module does not
+`use`) · `blocked_dep` (its dependency closure cannot be resolved, so it runs on
+neither side) · `skipped`.
+
+## Re-measuring
+
+```sh
+scripts/ecosystem-sweep.py --only BTree          # one distribution
+scripts/ecosystem-sweep.py --prefix A --jobs 8   # everything starting with A
+scripts/ecosystem-sweep.py --status regression   # everything currently red
+scripts/ecosystem-sweep.py --rollup              # regenerate summary.* and the chart
+```
+
+Requires `bubblewrap` (the sweep runs unaudited test suites and refuses to run a
+corpus without a sandbox) and a `raku` on PATH. Full runbook:
+[docs/ecosystem-parity.md](../docs/ecosystem-parity.md) §8.
+
+## Current state — validation set, not the corpus
+
+**The records here are a small P1 validation set, not a survey.** They were
+measured to prove the harness works end to end; the corpus sweep and the first
+real KPI numbers are phase P2. There is deliberately no `summary.*` or
+`history.tsv` yet: a rollup over a handful of hand-picked distributions would
+read like a KPI, and it is not one.

--- a/ecosystem/dists/A/Array--Circular.json
+++ b/ecosystem/dists/A/Array--Circular.json
@@ -1,0 +1,85 @@
+{
+  "axis": "pure",
+  "deps": {
+    "bundled_would_supply": [],
+    "mode": "flat-closure",
+    "resolved": [],
+    "unresolved": []
+  },
+  "dist": "Array::Circular",
+  "files": [
+    {
+      "cmp": "regression",
+      "mutsu": {
+        "first_failure": "is circular() requires a compile-time constant value",
+        "nok": 0,
+        "ok": 0,
+        "plan": 12,
+        "secs": 0.08,
+        "skip": 0,
+        "todo": 0,
+        "verdict": "die"
+      },
+      "path": "t/01-basic.rakutest",
+      "raku": {
+        "nok": 0,
+        "ok": 12,
+        "plan": 12,
+        "secs": 1.74,
+        "skip": 0,
+        "todo": 0,
+        "verdict": "pass"
+      }
+    },
+    {
+      "cmp": "partial",
+      "mutsu": {
+        "first_failure": "4 time append",
+        "nok": 13,
+        "ok": 0,
+        "plan": 13,
+        "secs": 0.21,
+        "skip": 0,
+        "todo": 0,
+        "verdict": "fail"
+      },
+      "path": "t/02-variable.rakutest",
+      "raku": {
+        "nok": 0,
+        "ok": 13,
+        "plan": 13,
+        "secs": 0.6,
+        "skip": 0,
+        "todo": 0,
+        "verdict": "pass"
+      }
+    }
+  ],
+  "load": {
+    "Array::Circular": "ok"
+  },
+  "measured": {
+    "date": "2026-09-10",
+    "harness": 1,
+    "host": "linux-x86_64",
+    "mutsu_commit": "9c41901",
+    "mutsu_version": "0.23.0",
+    "raku_backend": "moar 2026.07",
+    "raku_version": "2026.07",
+    "sandbox": "bwrap"
+  },
+  "schema": 1,
+  "source": {
+    "index": "fez",
+    "url": "https://360.zef.pm/A/RR/ARRAY_CIRCULAR/6eb95eda35639fddff21aa35d99b8bf26eb3fc49.tar.gz"
+  },
+  "status": "red",
+  "totals": {
+    "baseline_assertions": 25,
+    "baseline_files": 2,
+    "mutsu_assertions": 0,
+    "parity_files": 0,
+    "regressed_files": 2
+  },
+  "version": "0.0.7"
+}

--- a/ecosystem/dists/A/annotations.json
+++ b/ecosystem/dists/A/annotations.json
@@ -1,0 +1,41 @@
+{
+  "axis": "guts",
+  "deps": {
+    "bundled_would_supply": [],
+    "mode": "flat-closure",
+    "resolved": [],
+    "unresolved": []
+  },
+  "dist": "annotations",
+  "files": [],
+  "load": {
+    "annotations": "raku_also_fails",
+    "annotations::containers": "ok",
+    "annotations::core": "Runtime error: Failed to parse module 'annotations::core': X::Syntax::Malformed: Malformed my (did you mean to declare a sigilless \\var or $var?).",
+    "annotations::how": "ok"
+  },
+  "measured": {
+    "date": "2026-09-10",
+    "harness": 1,
+    "host": "linux-x86_64",
+    "mutsu_commit": "9c41901",
+    "mutsu_version": "0.23.0",
+    "raku_backend": "moar 2026.07",
+    "raku_version": "2026.07",
+    "sandbox": "bwrap"
+  },
+  "schema": 1,
+  "source": {
+    "index": "fez",
+    "url": "https://360.zef.pm/A/NN/ANNOTATIONS/1328482a7fccd36a16ed5498e6e4ab2015f611b5.tar.gz"
+  },
+  "status": "blocked_load",
+  "totals": {
+    "baseline_assertions": 0,
+    "baseline_files": 0,
+    "mutsu_assertions": 0,
+    "parity_files": 0,
+    "regressed_files": 0
+  },
+  "version": "0.1.0"
+}

--- a/ecosystem/dists/B/BTree.json
+++ b/ecosystem/dists/B/BTree.json
@@ -1,0 +1,87 @@
+{
+  "axis": "pure",
+  "deps": {
+    "bundled_would_supply": [],
+    "mode": "flat-closure",
+    "resolved": [],
+    "unresolved": []
+  },
+  "dist": "BTree",
+  "files": [
+    {
+      "cmp": "parity",
+      "mutsu": {
+        "nok": 0,
+        "ok": 1,
+        "plan": 1,
+        "secs": 0.11,
+        "skip": 0,
+        "todo": 0,
+        "verdict": "pass"
+      },
+      "path": "t/01-basic.rakutest",
+      "raku": {
+        "nok": 0,
+        "ok": 1,
+        "plan": 1,
+        "secs": 5.16,
+        "skip": 0,
+        "todo": 0,
+        "verdict": "pass"
+      }
+    },
+    {
+      "cmp": "regression",
+      "mutsu": {
+        "first_failure": "Impossible coercion from 'Str' into 'IntTree': no acceptable coercion method found",
+        "nok": 0,
+        "ok": 0,
+        "plan": null,
+        "secs": 0.2,
+        "skip": 0,
+        "todo": 0,
+        "verdict": "die"
+      },
+      "path": "t/simple-int-trees.rakutest",
+      "raku": {
+        "nok": 0,
+        "ok": 5,
+        "plan": 5,
+        "secs": 0.58,
+        "skip": 0,
+        "todo": 0,
+        "verdict": "pass"
+      }
+    }
+  ],
+  "load": {
+    "BTree": "ok",
+    "BTree::Grammar": "ok",
+    "BTree::PrettyTree": "ok",
+    "BTree::Renderer": "ok"
+  },
+  "measured": {
+    "date": "2026-09-10",
+    "harness": 1,
+    "host": "linux-x86_64",
+    "mutsu_commit": "9c41901",
+    "mutsu_version": "0.23.0",
+    "raku_backend": "moar 2026.07",
+    "raku_version": "2026.07",
+    "sandbox": "bwrap"
+  },
+  "schema": 1,
+  "source": {
+    "index": "fez",
+    "url": "https://360.zef.pm/B/TR/BTREE/4dc77d6237180651303a0f965002af1a5b2be407.tar.gz"
+  },
+  "status": "partial",
+  "totals": {
+    "baseline_assertions": 6,
+    "baseline_files": 2,
+    "mutsu_assertions": 1,
+    "parity_files": 1,
+    "regressed_files": 1
+  },
+  "version": "0.0.2"
+}

--- a/ecosystem/dists/C/C--Parser.json
+++ b/ecosystem/dists/C/C--Parser.json
@@ -1,0 +1,252 @@
+{
+  "axis": "pure",
+  "deps": {
+    "bundled_would_supply": [],
+    "mode": "flat-closure",
+    "resolved": [],
+    "unresolved": []
+  },
+  "dist": "C::Parser",
+  "files": [
+    {
+      "cmp": "partial",
+      "mutsu": {
+        "first_failure": "gives a Grammar",
+        "nok": 1,
+        "ok": 0,
+        "plan": 1,
+        "secs": 0.23,
+        "skip": 0,
+        "todo": 0,
+        "verdict": "fail"
+      },
+      "path": "t/01_null_main.rakutest",
+      "raku": {
+        "nok": 0,
+        "ok": 1,
+        "plan": 1,
+        "secs": 8.4,
+        "skip": 0,
+        "todo": 0,
+        "verdict": "pass"
+      }
+    },
+    {
+      "cmp": "partial",
+      "mutsu": {
+        "first_failure": "gives a C::AST::TransUnit",
+        "nok": 1,
+        "ok": 0,
+        "plan": 1,
+        "secs": 0.47,
+        "skip": 0,
+        "todo": 0,
+        "verdict": "fail"
+      },
+      "path": "t/02_null_main_ast.rakutest",
+      "raku": {
+        "nok": 0,
+        "ok": 1,
+        "plan": 1,
+        "secs": 7.1,
+        "skip": 0,
+        "todo": 0,
+        "verdict": "pass"
+      }
+    },
+    {
+      "cmp": "partial",
+      "mutsu": {
+        "first_failure": "gives a Grammar",
+        "nok": 1,
+        "ok": 0,
+        "plan": 1,
+        "secs": 0.19,
+        "skip": 0,
+        "todo": 0,
+        "verdict": "fail"
+      },
+      "path": "t/03_hello.rakutest",
+      "raku": {
+        "nok": 0,
+        "ok": 1,
+        "plan": 1,
+        "secs": 0.7,
+        "skip": 0,
+        "todo": 0,
+        "verdict": "pass"
+      }
+    },
+    {
+      "cmp": "partial",
+      "mutsu": {
+        "first_failure": "gives a C::AST::TransUnit",
+        "nok": 1,
+        "ok": 0,
+        "plan": 1,
+        "secs": 0.46,
+        "skip": 0,
+        "todo": 0,
+        "verdict": "fail"
+      },
+      "path": "t/04_hello_ast.rakutest",
+      "raku": {
+        "nok": 0,
+        "ok": 1,
+        "plan": 1,
+        "secs": 0.58,
+        "skip": 0,
+        "todo": 0,
+        "verdict": "pass"
+      }
+    },
+    {
+      "cmp": "partial",
+      "mutsu": {
+        "first_failure": "gives a TransUnit",
+        "nok": 1,
+        "ok": 0,
+        "plan": 1,
+        "secs": 0.39,
+        "skip": 0,
+        "todo": 0,
+        "verdict": "fail"
+      },
+      "path": "t/05_modern.rakutest",
+      "raku": {
+        "nok": 0,
+        "ok": 1,
+        "plan": 1,
+        "secs": 1.31,
+        "skip": 0,
+        "todo": 0,
+        "verdict": "pass"
+      }
+    },
+    {
+      "cmp": "partial",
+      "mutsu": {
+        "first_failure": "gives a C::AST::TransUnit",
+        "nok": 1,
+        "ok": 0,
+        "plan": 1,
+        "secs": 0.39,
+        "skip": 0,
+        "todo": 0,
+        "verdict": "fail"
+      },
+      "path": "t/06_ancient.rakutest",
+      "raku": {
+        "nok": 0,
+        "ok": 1,
+        "plan": 1,
+        "secs": 0.58,
+        "skip": 0,
+        "todo": 0,
+        "verdict": "pass"
+      }
+    },
+    {
+      "cmp": "partial",
+      "mutsu": {
+        "first_failure": "gives a C::AST::TransUnit",
+        "nok": 1,
+        "ok": 0,
+        "plan": 1,
+        "secs": 0.37,
+        "skip": 0,
+        "todo": 0,
+        "verdict": "fail"
+      },
+      "path": "t/07_mbstate.rakutest",
+      "raku": {
+        "nok": 0,
+        "ok": 1,
+        "plan": 1,
+        "secs": 1.04,
+        "skip": 0,
+        "todo": 0,
+        "verdict": "pass"
+      }
+    },
+    {
+      "cmp": "partial",
+      "mutsu": {
+        "first_failure": "gives a C::AST::TransUnit",
+        "nok": 1,
+        "ok": 0,
+        "plan": 1,
+        "secs": 0.37,
+        "skip": 0,
+        "todo": 0,
+        "verdict": "fail"
+      },
+      "path": "t/08_fgetc.rakutest",
+      "raku": {
+        "nok": 0,
+        "ok": 1,
+        "plan": 1,
+        "secs": 0.67,
+        "skip": 0,
+        "todo": 0,
+        "verdict": "pass"
+      }
+    },
+    {
+      "cmp": "parity",
+      "mutsu": {
+        "nok": 0,
+        "ok": 4,
+        "plan": 4,
+        "secs": 0.2,
+        "skip": 0,
+        "todo": 0,
+        "verdict": "pass"
+      },
+      "path": "t/primary_lex.rakutest",
+      "raku": {
+        "nok": 0,
+        "ok": 4,
+        "plan": 4,
+        "secs": 0.99,
+        "skip": 0,
+        "todo": 0,
+        "verdict": "pass"
+      }
+    }
+  ],
+  "load": {
+    "C::AST": "ok",
+    "C::AST::Ops": "ok",
+    "C::AST::Utils": "ok",
+    "C::Parser": "ok",
+    "C::Parser::Actions": "ok",
+    "C::Parser::Grammar": "ok",
+    "C::Parser::Lexer": "ok",
+    "C::Parser::Utils": "ok"
+  },
+  "measured": {
+    "date": "2026-09-10",
+    "harness": 1,
+    "host": "linux-x86_64",
+    "mutsu_commit": "9c41901",
+    "mutsu_version": "0.23.0",
+    "raku_backend": "moar 2026.07",
+    "raku_version": "2026.07",
+    "sandbox": "bwrap"
+  },
+  "schema": 1,
+  "source": {
+    "index": "fez",
+    "url": "https://360.zef.pm/C/_P/C_PARSER/35a31915512ace4c92633229f41319e6f48933e6.tar.gz"
+  },
+  "status": "partial",
+  "totals": {
+    "baseline_assertions": 12,
+    "baseline_files": 9,
+    "mutsu_assertions": 4,
+    "parity_files": 1,
+    "regressed_files": 8
+  },
+  "version": "0.3.3"
+}

--- a/ecosystem/dists/P/P5caller.json
+++ b/ecosystem/dists/P/P5caller.json
@@ -1,0 +1,62 @@
+{
+  "axis": "pure",
+  "deps": {
+    "bundled_would_supply": [],
+    "mode": "flat-closure",
+    "resolved": [],
+    "unresolved": []
+  },
+  "dist": "P5caller",
+  "files": [
+    {
+      "cmp": "partial",
+      "mutsu": {
+        "first_failure": "did we get the right package",
+        "nok": 9,
+        "ok": 3,
+        "plan": 12,
+        "secs": 0.26,
+        "skip": 0,
+        "todo": 0,
+        "verdict": "fail"
+      },
+      "path": "t/01-basic.rakutest",
+      "raku": {
+        "nok": 0,
+        "ok": 12,
+        "plan": 12,
+        "secs": 2.94,
+        "skip": 0,
+        "todo": 0,
+        "verdict": "pass"
+      }
+    }
+  ],
+  "load": {
+    "P5caller": "ok"
+  },
+  "measured": {
+    "date": "2026-09-10",
+    "harness": 1,
+    "host": "linux-x86_64",
+    "mutsu_commit": "9c41901",
+    "mutsu_version": "0.23.0",
+    "raku_backend": "moar 2026.07",
+    "raku_version": "2026.07",
+    "sandbox": "bwrap"
+  },
+  "schema": 1,
+  "source": {
+    "index": "fez",
+    "url": "https://360.zef.pm/P/5C/P5CALLER/58b7d425b9235a616a17a5d47345913dd2f4830d.tar.gz"
+  },
+  "status": "red",
+  "totals": {
+    "baseline_assertions": 12,
+    "baseline_files": 1,
+    "mutsu_assertions": 3,
+    "parity_files": 0,
+    "regressed_files": 1
+  },
+  "version": "0.0.13"
+}

--- a/ecosystem/dists/P/Prime--Factor.json
+++ b/ecosystem/dists/P/Prime--Factor.json
@@ -1,0 +1,130 @@
+{
+  "axis": "pure",
+  "deps": {
+    "bundled_would_supply": [],
+    "mode": "flat-closure",
+    "resolved": [],
+    "unresolved": []
+  },
+  "dist": "Prime::Factor",
+  "files": [
+    {
+      "cmp": "parity",
+      "mutsu": {
+        "nok": 0,
+        "ok": 21,
+        "plan": 21,
+        "secs": 0.76,
+        "skip": 0,
+        "todo": 0,
+        "verdict": "pass"
+      },
+      "path": "t/00-basic.rakutest",
+      "raku": {
+        "nok": 0,
+        "ok": 21,
+        "plan": 21,
+        "secs": 2.9,
+        "skip": 0,
+        "todo": 0,
+        "verdict": "pass"
+      }
+    },
+    {
+      "cmp": "regression",
+      "mutsu": {
+        "first_failure": "divisors() not defined for Int parameters. Coerce to Int before calling.",
+        "nok": 0,
+        "ok": 1,
+        "plan": 87,
+        "secs": 0.12,
+        "skip": 0,
+        "todo": 0,
+        "verdict": "die"
+      },
+      "path": "t/01-divisors.rakutest",
+      "raku": {
+        "nok": 0,
+        "ok": 87,
+        "plan": 87,
+        "secs": 1.03,
+        "skip": 0,
+        "todo": 0,
+        "verdict": "pass"
+      }
+    },
+    {
+      "cmp": "regression",
+      "mutsu": {
+        "first_failure": "proper-divisors() not defined for Int parameters. Coerce to Int before calling.",
+        "nok": 0,
+        "ok": 1,
+        "plan": 87,
+        "secs": 0.12,
+        "skip": 0,
+        "todo": 0,
+        "verdict": "die"
+      },
+      "path": "t/02-proper-divisors.rakutest",
+      "raku": {
+        "nok": 0,
+        "ok": 87,
+        "plan": 87,
+        "secs": 0.95,
+        "skip": 0,
+        "todo": 0,
+        "verdict": "pass"
+      }
+    },
+    {
+      "cmp": "partial",
+      "mutsu": {
+        "first_failure": "Sigma-sum of 6",
+        "nok": 60,
+        "ok": 40,
+        "plan": 100,
+        "secs": 0.69,
+        "skip": 0,
+        "todo": 0,
+        "verdict": "fail"
+      },
+      "path": "t/04-sums.rakutest",
+      "raku": {
+        "nok": 0,
+        "ok": 100,
+        "plan": 100,
+        "secs": 0.62,
+        "skip": 0,
+        "todo": 0,
+        "verdict": "pass"
+      }
+    }
+  ],
+  "load": {
+    "Prime::Factor": "ok"
+  },
+  "measured": {
+    "date": "2026-09-10",
+    "harness": 1,
+    "host": "linux-x86_64",
+    "mutsu_commit": "9c41901",
+    "mutsu_version": "0.23.0",
+    "raku_backend": "moar 2026.07",
+    "raku_version": "2026.07",
+    "sandbox": "bwrap"
+  },
+  "schema": 1,
+  "source": {
+    "index": "fez",
+    "url": "https://360.zef.pm/P/RI/PRIME_FACTOR/7221d05c9da572abffdafc47bd4b94d106ac3deb.tar.gz"
+  },
+  "status": "partial",
+  "totals": {
+    "baseline_assertions": 295,
+    "baseline_files": 4,
+    "mutsu_assertions": 63,
+    "parity_files": 1,
+    "regressed_files": 3
+  },
+  "version": "0.4.3"
+}

--- a/ecosystem/dists/S/String--Utils.json
+++ b/ecosystem/dists/S/String--Utils.json
@@ -1,0 +1,38 @@
+{
+  "axis": "guts",
+  "deps": {
+    "bundled_would_supply": [],
+    "mode": "flat-closure",
+    "resolved": [],
+    "unresolved": []
+  },
+  "dist": "String::Utils",
+  "files": [],
+  "load": {
+    "String::Utils": "An exception occurred while evaluating a CHECK"
+  },
+  "measured": {
+    "date": "2026-09-10",
+    "harness": 1,
+    "host": "linux-x86_64",
+    "mutsu_commit": "9c41901",
+    "mutsu_version": "0.23.0",
+    "raku_backend": "moar 2026.07",
+    "raku_version": "2026.07",
+    "sandbox": "bwrap"
+  },
+  "schema": 1,
+  "source": {
+    "index": "fez",
+    "url": "https://360.zef.pm/S/TR/STRING_UTILS/dd311482c0621e9465940cbe1786ad03ecdd8ea6.tar.gz"
+  },
+  "status": "blocked_load",
+  "totals": {
+    "baseline_assertions": 0,
+    "baseline_files": 0,
+    "mutsu_assertions": 0,
+    "parity_files": 0,
+    "regressed_files": 0
+  },
+  "version": "0.0.40"
+}

--- a/ecosystem/dists/T/Trie.json
+++ b/ecosystem/dists/T/Trie.json
@@ -1,0 +1,87 @@
+{
+  "axis": "pure",
+  "deps": {
+    "bundled_would_supply": [],
+    "mode": "flat-closure",
+    "resolved": [
+      "OrderedHash"
+    ],
+    "unresolved": []
+  },
+  "dist": "Trie",
+  "files": [
+    {
+      "cmp": "parity",
+      "mutsu": {
+        "nok": 0,
+        "ok": 1,
+        "plan": 1,
+        "secs": 0.15,
+        "skip": 0,
+        "todo": 0,
+        "verdict": "pass"
+      },
+      "path": "t/01-basic.rakutest",
+      "raku": {
+        "nok": 0,
+        "ok": 1,
+        "plan": 1,
+        "secs": 5.38,
+        "skip": 0,
+        "todo": 0,
+        "verdict": "pass"
+      }
+    },
+    {
+      "cmp": "regression",
+      "mutsu": {
+        "first_failure": "Can never assign default value Bool (True) to attribute '$!of', it expects: Mu:U",
+        "nok": 0,
+        "ok": 0,
+        "plan": null,
+        "secs": 0.1,
+        "skip": 0,
+        "todo": 0,
+        "verdict": "die"
+      },
+      "path": "t/02-trie.rakutest",
+      "raku": {
+        "nok": 0,
+        "ok": 70,
+        "plan": 70,
+        "secs": 1.0,
+        "skip": 0,
+        "todo": 0,
+        "verdict": "pass"
+      }
+    }
+  ],
+  "load": {
+    "Trie": "ok",
+    "X::Trie::MultipleValues": "ok"
+  },
+  "measured": {
+    "date": "2026-09-10",
+    "harness": 1,
+    "host": "linux-x86_64",
+    "mutsu_commit": "9c41901",
+    "mutsu_version": "0.23.0",
+    "raku_backend": "moar 2026.07",
+    "raku_version": "2026.07",
+    "sandbox": "bwrap"
+  },
+  "schema": 1,
+  "source": {
+    "index": "fez",
+    "url": "https://360.zef.pm/T/RI/TRIE/5fd049406f61c5016605e823908deae7910f80cf.tar.gz"
+  },
+  "status": "partial",
+  "totals": {
+    "baseline_assertions": 71,
+    "baseline_files": 2,
+    "mutsu_assertions": 1,
+    "parity_files": 1,
+    "regressed_files": 1
+  },
+  "version": "0.0.1"
+}

--- a/ecosystem/index-snapshot.json
+++ b/ecosystem/index-snapshot.json
@@ -1,0 +1,14 @@
+{
+  "fetched": "2026-09-10",
+  "fez": {
+    "dists": 1623,
+    "sha256": "d56e2bbccc60d1b7c6db98d805252a58a625bebaa0004a0dd83fbc8251886db9",
+    "url": "https://360.zef.pm/"
+  },
+  "modules": 12828,
+  "rea": {
+    "dists_added": 921,
+    "sha256": "45a2d08b73eadb68abcdd0ff26b7f3c9a65ae5ccca96d55eaa1c5d8a8b04406a",
+    "url": "https://raw.githubusercontent.com/Raku/REA/main/META.json"
+  }
+}

--- a/scripts/dist-compat-sweep.py
+++ b/scripts/dist-compat-sweep.py
@@ -42,11 +42,22 @@ markdown table block to paste into docs/dist-compat-sweep.md.
 
 Env: MUTSU_BIN (default target/release/mutsu).
 """
-import argparse, collections, io, json, os, re, shutil, subprocess, sys, tarfile
-import tempfile, urllib.request
+import argparse, collections, json, os, re, subprocess, sys, tarfile
+import tempfile
 
-FEZ_INDEX = os.path.expanduser("~/.zef/store/fez/fez.json")
-FEZ_CDN = "https://360.zef.pm/"
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import ecosystem_common as eco
+
+# The index reader, the tarball cache, the bwrap wrapper and the TAP parser are
+# shared with scripts/ecosystem-sweep.py (ADR-0085): the sandbox that confines
+# unaudited distribution code must exist once, not as two copies that drift.
+from ecosystem_common import (  # noqa: F401
+    first_error_line, first_failing_assertion, have_bwrap, parse_tap,
+    sandbox_wrap, tap_verdict, version_key,
+)
+
+FEZ_INDEX = eco.FEZ_LOCAL
+FEZ_CDN = eco.FEZ_CDN
 CACHE_DIR = os.path.expanduser("~/.cache/mutsu-dist-sweep")
 
 DEEP = re.compile(
@@ -55,156 +66,19 @@ DEEP = re.compile(
 )
 NATIVE = re.compile(r"\buse\s+NativeCall\b|:from<C>|\bis\s+native\b")
 SRC_RE = re.compile(r"\.(rakumod|pm6|pm|raku|rakutest|t)$")
-TEST_RE = re.compile(r"\.(t|rakutest)$")
-
-PLAN_RE = re.compile(r"^1\.\.(\d+)\s*$", re.M)
-OK_RE = re.compile(r"^ok\b", re.M)
-NOTOK_RE = re.compile(r"^not ok\b")
 
 
 def find_test_files(root):
     """Test files under the dist's t/ (and test/, xt/) directories."""
-    files = []
-    for sub in ("t", "test", "xt"):
-        d = os.path.join(root, sub)
-        if not os.path.isdir(d):
-            continue
-        for dirpath, _, names in os.walk(d):
-            for nm in names:
-                if TEST_RE.search(nm):
-                    files.append(os.path.join(dirpath, nm))
-    return sorted(files)
-
-
-def parse_tap(out):
-    """(planned, ok_count, real_not_ok, todo_not_ok) from raw TAP output."""
-    m = PLAN_RE.search(out)
-    plan = int(m.group(1)) if m else None
-    ok = len(OK_RE.findall(out))
-    real_notok = todo = 0
-    for line in out.splitlines():
-        if NOTOK_RE.match(line):
-            if "todo" in line.lower():
-                todo += 1
-            else:
-                real_notok += 1
-    return plan, ok, real_notok, todo
-
-
-def tap_verdict(out, rc):
-    """Classify a single test run: 'pass' / 'fail' / 'die'.
-    'die' = crashed before/mid TAP (no plan, or ran fewer than planned, or a
-    non-zero exit with no failing assertion to blame). 'fail' = a real `not ok`.
-    """
-    plan, ok, notok, todo = parse_tap(out)
-    if plan is None:
-        return "die"
-    if notok > 0:
-        return "fail"
-    ran = ok + notok + todo
-    if ran < plan:
-        return "die"
-    if rc not in (0, None):
-        return "die"
-    return "pass"
-
-
-# Generic TAP-harness death lines that mask the real cause — never a useful
-# signature on their own.
-_HARNESS_NOISE = re.compile(
-    r"test failures|you planned|you failed|looks like you|^#|^1\.\.|dubious|"
-    r"^ok\b|^not ok\b", re.I)
-
-
-def first_error_line(out):
-    """The first meaningful error line, skipping generic TAP-harness noise
-    ('Runtime error: Test failures', '# You planned N ...') that only reports
-    that the run died, not why."""
-    candidates = []
-    for line in out.splitlines():
-        s = line.strip()
-        if not s or _HARNESS_NOISE.search(s):
-            continue
-        candidates.append(s)
-    for s in candidates:
-        low = s.lower()
-        if ("sorry" in low or "panicked" in low or "unhandled" in low
-                or s.startswith("X::") or "::" in s and "exception" in low
-                or "no such" in low or "unknown method" in low
-                or "unknown function" in low or "cannot" in low
-                or low.startswith("runtime error")):
-            return s[:200]
-    return candidates[0][:200] if candidates else ""
-
-
-def first_failing_assertion(out):
-    """The description of the first real (non-TODO) `not ok` line, e.g.
-    'not ok 3 - foo does bar' -> 'foo does bar'. Falls back to first_error_line."""
-    for line in out.splitlines():
-        if NOTOK_RE.match(line) and "todo" not in line.lower():
-            m = re.match(r"not ok\s+\d+\s*-?\s*(.*)", line.strip())
-            desc = (m.group(1).strip() if m else line.strip())
-            return desc[:200] if desc else line.strip()[:200]
-    return first_error_line(out)
-
-
-def version_key(v):
-    return [(0, int(x)) if x.isdigit() else (1, x) for x in re.split(r"[.\-+]", str(v))]
-
-
-def sandbox_wrap(cmd, root, sbx_home, mem_kb=6_000_000, nproc=400):
-    """Wrap `cmd` so untrusted dist code runs with NO network, a read-only
-    filesystem, an isolated throwaway HOME, its own PID namespace, and rlimits.
-    `sbx_home` must be an existing dir (a fresh tmpfs is mounted over it, so
-    nothing the code writes ever reaches the host). Requires bubblewrap (bwrap).
-
-    NOTE: `use <module>` executes arbitrary BEGIN/CHECK phasers and load-time
-    code from a real ecosystem dist — this is arbitrary code execution, hence
-    the sandbox. Download/extract happen OUTSIDE the sandbox (in Python); only
-    the mutsu run is confined, and it needs no network.
-    """
-    return [
-        "bwrap",
-        "--unshare-all",              # user+net+pid+ipc+uts+cgroup+mount (net = offline)
-        "--ro-bind", "/", "/",        # whole rootfs, read-only
-        "--dev", "/dev",
-        "--proc", "/proc",
-        "--tmpfs", "/run",
-        "--tmpfs", sbx_home,          # writable throwaway HOME (tmpfs over existing dir)
-        "--setenv", "HOME", sbx_home,
-        "--chdir", root,
-        "--die-with-parent",
-        "--new-session",
-        "bash", "-c", f"ulimit -v {mem_kb} -u {nproc} 2>/dev/null; exec \"$@\"", "_",
-    ] + cmd
-
-
-def have_bwrap():
-    return shutil.which("bwrap") is not None
+    return eco.find_test_files(root, include_xt=True)
 
 
 def load_index():
-    if not os.path.exists(FEZ_INDEX):
-        sys.exit(f"missing {FEZ_INDEX} — run an mzef/zef ecosystem op first")
-    best = {}
-    for m in json.load(open(FEZ_INDEX)):
-        if isinstance(m, dict) and m.get("name") and m.get("path"):
-            n = m["name"]
-            if n not in best or version_key(m.get("version", "0")) > version_key(
-                best[n].get("version", "0")
-            ):
-                best[n] = m
-    return best
+    return eco.load_fez_index(FEZ_INDEX)
 
 
 def fetch_tarball(meta):
-    os.makedirs(CACHE_DIR, exist_ok=True)
-    cache = os.path.join(CACHE_DIR, meta["path"].replace("/", "_"))
-    if not os.path.exists(cache):
-        data = urllib.request.urlopen(FEZ_CDN + meta["path"], timeout=60).read()
-        with open(cache, "wb") as f:
-            f.write(data)
-    return cache
+    return eco.fetch_tarball(FEZ_CDN + meta["path"], CACHE_DIR)
 
 
 def classify(module, dist_name, rc, out):

--- a/scripts/ecosystem-sweep.py
+++ b/scripts/ecosystem-sweep.py
@@ -1,0 +1,607 @@
+#!/usr/bin/env python3
+"""ecosystem-sweep.py — measure mutsu against rakudo, one distribution at a time.
+
+Runs each zef distribution's own test suite under BOTH interpreters, with the
+same sources, the same `-I` list, the same working directory and the same
+timeout, and records both sides per test file. rakudo is the denominator: a file
+rakudo does not pass cleanly is excluded from the KPI, never charged to mutsu.
+
+Decisions: docs/adr/0085-ecosystem-testsuite-parity-measurement.md
+Operations: docs/ecosystem-parity.md   Tracking issue: #7785
+
+    scripts/ecosystem-sweep.py --only String::Utils
+    scripts/ecosystem-sweep.py --prefix A --jobs 8
+    scripts/ecosystem-sweep.py --all --jobs 8
+    scripts/ecosystem-sweep.py --rollup
+
+Env: MUTSU_BIN (default target/release/mutsu), RAKU_BIN (default raku).
+"""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import concurrent.futures
+import datetime as dt
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+import threading
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import ecosystem_common as eco  # noqa: E402
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+DATA_DIR = os.path.join(REPO, "ecosystem")
+DISTS_DIR = os.path.join(DATA_DIR, "dists")
+SCHEMA = 1
+HARNESS = 1
+
+# `use Test` must reach the vendored upstream Test.rakumod on both sides, or the
+# two are counting `ok` lines emitted by different harnesses. The module exports
+# its own MONKEY-SEE-NO-EVAL, which no reimplementation ever had -- the same
+# decisive probe t/tooling/vendored-real-test-module.t uses.
+TEST_PROBE = 'use Test; plan 1; is MONKEY-SEE-NO-EVAL(), 1, "vendored Test"'
+
+# Two locks, deliberately: `log()` takes the print lock, so anything that holds
+# a lock across a `log()` call must hold a DIFFERENT one. A single shared
+# `threading.Lock` here deadlocked every `--jobs > 1` run the moment the first
+# worker finished.
+_print_lock = threading.Lock()
+_tally_lock = threading.Lock()
+
+
+def log(msg):
+    with _print_lock:
+        print(msg, file=sys.stderr, flush=True)
+
+
+# --- running -----------------------------------------------------------------
+
+def run(cmd, cwd, timeout, sandbox, sbx_home, writable=()):
+    """One interpreter run. Returns (returncode, combined output)."""
+    if sandbox:
+        cmd = eco.sandbox_wrap(cmd, cwd, sbx_home, writable=writable)
+    # MUTSU_FUDGE is roast-only: with it set, a stray `#?rakudo skip` comment in
+    # a distribution would silently drop the next statement.
+    env = {k: v for k, v in os.environ.items() if k != "MUTSU_FUDGE"}
+    try:
+        proc = subprocess.run(cmd, capture_output=True, text=True, errors="replace",
+                              timeout=timeout, cwd=cwd, env=env)
+        return proc.returncode, proc.stdout + proc.stderr
+    except subprocess.TimeoutExpired:
+        return None, "SWEEP-TIMEOUT"
+
+
+def side_result(rc, out, secs):
+    plan, ok, notok, todo, skip = eco.parse_tap(out)
+    verdict = "timeout" if out == "SWEEP-TIMEOUT" else eco.tap_verdict(out, rc)
+    side = {"verdict": verdict, "plan": plan, "ok": ok, "nok": notok,
+            "todo": todo, "skip": skip, "secs": round(secs, 2)}
+    if verdict != "pass":
+        detail = (eco.first_failing_assertion(out) if verdict == "fail"
+                  else eco.first_error_line(out))
+        if detail:
+            side["first_failure"] = detail
+    return side
+
+
+def measure(cmd, cwd, timeout, sandbox, sbx_home, writable, attempts):
+    """Run a file, retrying only when it did not pass.
+
+    A suite that flakes must not move the KPI, and retrying everything would
+    triple the cost of a green corpus -- so the retry is spent only where the
+    answer was not already 'pass'. Returns (side, flaky).
+    """
+    best = None
+    verdicts = set()
+    for _ in range(attempts):
+        start = dt.datetime.now()
+        rc, out = run(cmd, cwd, timeout, sandbox, sbx_home, writable)
+        side = side_result(rc, out, (dt.datetime.now() - start).total_seconds())
+        verdicts.add(side["verdict"])
+        if best is None or side["verdict"] == "pass":
+            best = side
+        if side["verdict"] == "pass":
+            break
+    return best, len(verdicts) > 1
+
+
+def compare(raku, mutsu):
+    if raku["verdict"] != "pass":
+        return "no_baseline"
+    if mutsu["verdict"] == "pass":
+        return "parity"
+    if mutsu["verdict"] == "fail":
+        return "partial"
+    return "regression"
+
+
+# --- one distribution --------------------------------------------------------
+
+def sweep_dist(name, index, opts, bundled) -> dict:
+    """Measure one distribution and return its record."""
+    record = {
+        "schema": SCHEMA, "dist": name,
+        "version": (index.dists[name].get("version") or "?"),
+        "source": {"index": "fez", "url": index.url(name)},
+        "measured": {
+            "date": dt.date.today().isoformat(),
+            "mutsu_commit": opts.mutsu_commit, "mutsu_version": opts.mutsu_version,
+            "raku_version": opts.raku_version, "raku_backend": opts.raku_backend,
+            "host": opts.host, "sandbox": "bwrap" if opts.sandbox else "none",
+            "harness": HARNESS,
+        },
+        "files": [],
+    }
+
+    resolved, unresolved = index.closure(name)
+    record["deps"] = {"mode": "flat-closure", "resolved": resolved,
+                      "unresolved": unresolved, "bundled_would_supply": []}
+    if unresolved:
+        # ADR-0085 D5: run on neither side rather than let mutsu's bundled
+        # batteries supply what rakudo lacks -- that would raise the KPI with no
+        # compatibility improving. What the bundle *would* have supplied is
+        # recorded here as a batteries statistic instead.
+        record["deps"]["bundled_would_supply"] = sorted(set(unresolved) & bundled)
+        record["status"] = "blocked_dep"
+        record["totals"] = empty_totals()
+        return record
+
+    workdir = tempfile.mkdtemp(prefix="ecosweep-", dir=opts.tmp_root)
+    try:
+        root = prepare(name, index, workdir, opts, resolved)
+        if root is None:
+            record["status"] = "skipped"
+            record["note"] = "no META6.json in the tarball"
+            record["totals"] = empty_totals()
+            return record
+        meta = eco.read_meta6(root) or {}
+        record["version"] = meta.get("version", record["version"])
+        record["axis"] = eco.source_axis(root)
+
+        libs = ["-I", os.path.join(root, "lib")]
+        for dep in resolved:
+            dep_root = opts.dep_roots.get(dep)
+            if dep_root:
+                libs += ["-I", os.path.join(dep_root, "lib")]
+
+        sbx_home = os.path.join(workdir, "sbxhome")
+        os.makedirs(sbx_home, exist_ok=True)
+        common = dict(cwd=root, timeout=opts.timeout, sandbox=opts.sandbox,
+                      sbx_home=sbx_home, writable=(root,))
+
+        # Load probe, both sides. A module rakudo cannot load either is not a
+        # mutsu finding -- the standing rule is to check raku before calling
+        # anything a mutsu bug.
+        record["load"] = {}
+        blocked = False
+        for module in sorted(meta.get("provides") or {}):
+            probe = ["-e", f"use {module}; exit 0"]
+            m_rc, m_out = run([opts.mutsu] + libs + probe, **common)
+            if m_rc == 0:
+                record["load"][module] = "ok"
+                continue
+            r_rc, _r_out = run([opts.raku] + libs + probe, **common)
+            if r_rc != 0:
+                record["load"][module] = "raku_also_fails"
+            else:
+                record["load"][module] = eco.first_error_line(m_out) or "load failed"
+                blocked = True
+        if blocked:
+            record["status"] = "blocked_load"
+            record["totals"] = empty_totals()
+            return record
+
+        tests = eco.find_test_files(root, include_xt=opts.include_xt)
+        if opts.max_files:
+            tests = tests[:opts.max_files]
+        for path in tests:
+            rel = os.path.relpath(path, root)
+            # Both sides get the same retry budget. Giving mutsu three chances
+            # at a file the baseline got one is not a fair comparison, even
+            # though the asymmetry would only ever shrink the denominator.
+            raku, raku_flaky = measure([opts.raku] + libs + [path],
+                                       attempts=opts.attempts, **common)
+            if raku["verdict"] != "pass":
+                record["files"].append({"path": rel, "raku": raku, "cmp": "no_baseline"})
+                continue
+            mutsu, flaky = measure([opts.mutsu] + libs + [path],
+                                   attempts=opts.attempts, **common)
+            entry = {"path": rel, "raku": raku, "mutsu": mutsu,
+                     "cmp": compare(raku, mutsu)}
+            if flaky or raku_flaky:
+                entry["flaky"] = True
+                entry["cmp"] = "no_baseline"
+            record["files"].append(entry)
+    finally:
+        eco.rmtree(workdir)
+
+    record["totals"] = totals_of(record["files"])
+    record["status"] = status_of(record["totals"])
+    return record
+
+
+def prepare(name, index, workdir, opts, resolved):
+    """Extract the distribution under test into a throwaway directory, and every
+    dependency into the shared extract cache (they are read-only and reused)."""
+    url = index.url(name)
+    if not url:
+        return None
+    root = eco.extract_dist(eco.fetch_tarball(url, opts.tarball_cache),
+                            os.path.join(workdir, "dist"))
+    for dep in resolved:
+        if dep in opts.dep_roots:
+            continue
+        dep_url = index.url(dep)
+        if not dep_url:
+            continue
+        target = os.path.join(opts.extract_cache, re.sub(r"[^A-Za-z0-9._-]", "_", dep))
+        with opts.dep_lock:
+            if dep not in opts.dep_roots:
+                marker = os.path.join(target, ".ok")
+                if os.path.isdir(target) and os.path.exists(marker):
+                    with open(marker, encoding="utf-8") as fh:
+                        opts.dep_roots[dep] = fh.read().strip()
+                else:
+                    eco.rmtree(target)
+                    dep_root = eco.extract_dist(
+                        eco.fetch_tarball(dep_url, opts.tarball_cache), target)
+                    if dep_root:
+                        with open(marker, "w", encoding="utf-8") as fh:
+                            fh.write(dep_root)
+                        opts.dep_roots[dep] = dep_root
+    return root
+
+
+def empty_totals():
+    return {"baseline_files": 0, "parity_files": 0, "regressed_files": 0,
+            "baseline_assertions": 0, "mutsu_assertions": 0}
+
+
+def totals_of(files):
+    t = empty_totals()
+    for f in files:
+        if f["cmp"] in ("no_baseline",):
+            continue
+        t["baseline_files"] += 1
+        t["baseline_assertions"] += f["raku"]["ok"]
+        t["mutsu_assertions"] += min(f["mutsu"]["ok"], f["raku"]["ok"])
+        if f["cmp"] == "parity":
+            t["parity_files"] += 1
+        else:
+            t["regressed_files"] += 1
+    return t
+
+
+def status_of(t):
+    if t["baseline_files"] == 0:
+        return "no_baseline"
+    if t["parity_files"] == t["baseline_files"]:
+        return "green"
+    if t["parity_files"] == 0:
+        return "red"
+    return "partial"
+
+
+# --- the record store --------------------------------------------------------
+
+def shard_of(name):
+    first = name[0].upper()
+    return first if first.isalpha() and first.isascii() else "_"
+
+
+def record_path(name):
+    return os.path.join(DISTS_DIR, shard_of(name), name.replace("::", "--") + ".json")
+
+
+def write_record(record):
+    path = record_path(record["dist"])
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    text = json.dumps(record, indent=2, sort_keys=True, ensure_ascii=False) + "\n"
+    # Date-granular provenance means an unchanged same-day re-run is a no-op in
+    # git rather than churn (ADR-0085 D7).
+    if os.path.exists(path):
+        with open(path, encoding="utf-8") as fh:
+            if fh.read() == text:
+                return False
+    with open(path, "w", encoding="utf-8") as fh:
+        fh.write(text)
+    return True
+
+
+def load_records():
+    out = []
+    for dirpath, _dirs, names in os.walk(DISTS_DIR):
+        for n in sorted(names):
+            if n.endswith(".json"):
+                with open(os.path.join(dirpath, n), encoding="utf-8") as fh:
+                    out.append(json.load(fh))
+    return out
+
+
+# --- rollup ------------------------------------------------------------------
+
+def rollup(append_history=False):
+    records = load_records()
+    if not records:
+        sys.exit(f"no records under {DISTS_DIR} — run a sweep first")
+    by_status = collections.Counter(r["status"] for r in records)
+    baseline = sum(r["totals"]["baseline_files"] for r in records)
+    parity = sum(r["totals"]["parity_files"] for r in records)
+    b_assert = sum(r["totals"]["baseline_assertions"] for r in records)
+    m_assert = sum(r["totals"]["mutsu_assertions"] for r in records)
+    graded = [r for r in records if r["totals"]["baseline_files"] > 0]
+    green = [r for r in graded if r["status"] == "green"]
+
+    def pct(num, den):
+        return round(100.0 * num / den, 1) if den else 0.0
+
+    summary = {
+        "schema": SCHEMA,
+        "generated": dt.date.today().isoformat(),
+        "distributions": len(records),
+        "status": dict(sorted(by_status.items())),
+        "dist_parity": pct(len(green), len(graded)),
+        "file_parity": pct(parity, baseline),
+        "assertion_parity": pct(m_assert, b_assert),
+        "baseline_files": baseline, "parity_files": parity,
+        "baseline_assertions": b_assert, "mutsu_assertions": m_assert,
+        "graded_distributions": len(graded), "green_distributions": len(green),
+    }
+    os.makedirs(DATA_DIR, exist_ok=True)
+    with open(os.path.join(DATA_DIR, "summary.json"), "w", encoding="utf-8") as fh:
+        json.dump(summary, fh, indent=2, sort_keys=True)
+        fh.write("\n")
+    write_summary_md(summary, records)
+    if append_history:
+        append_history_row(summary, records)
+    render_chart()
+    return summary
+
+
+def write_summary_md(summary, records):
+    lines = [
+        "# Ecosystem parity — summary",
+        "",
+        "<!-- GENERATED by scripts/ecosystem-sweep.py --rollup. Do not edit. -->",
+        "",
+        f"Generated {summary['generated']} from `ecosystem/dists/`. Method and metric",
+        "definitions: [docs/ecosystem-parity.md](../docs/ecosystem-parity.md).",
+        "",
+        "| metric | value |",
+        "|---|---|",
+        f"| **dist parity** (published headline) | **{summary['dist_parity']}%** "
+        f"({summary['green_distributions']}/{summary['graded_distributions']}) |",
+        f"| file parity | {summary['file_parity']}% "
+        f"({summary['parity_files']}/{summary['baseline_files']}) |",
+        f"| assertion parity | {summary['assertion_parity']}% |",
+        "",
+        "| status | distributions |",
+        "|---|---|",
+    ]
+    for status, count in summary["status"].items():
+        lines.append(f"| `{status}` | {count} |")
+    lines += ["", "## Distributions", "",
+              "| distribution | version | status | baseline files passed |", "|---|---|---|---|"]
+    for r in sorted(records, key=lambda r: r["dist"].lower()):
+        t = r["totals"]
+        passed = f"{t['parity_files']}/{t['baseline_files']}" if t["baseline_files"] else "—"
+        lines.append(f"| `{r['dist']}` | {r['version']} | {r['status']} | {passed} |")
+    with open(os.path.join(DATA_DIR, "summary.md"), "w", encoding="utf-8") as fh:
+        fh.write("\n".join(lines) + "\n")
+
+
+def append_history_row(summary, records):
+    path = os.path.join(DATA_DIR, "history.tsv")
+    columns = ["date", "mutsu_commit", "raku_version", "dists", "measured",
+               "blocked_dep", "baseline_files", "parity_files", "file_parity",
+               "assertion_parity", "dist_parity"]
+    latest = max(records, key=lambda r: r["measured"]["date"])["measured"]
+    row = {
+        "date": summary["generated"],
+        "mutsu_commit": latest["mutsu_commit"], "raku_version": latest["raku_version"],
+        "dists": summary["distributions"],
+        "measured": summary["distributions"] - summary["status"].get("blocked_dep", 0),
+        "blocked_dep": summary["status"].get("blocked_dep", 0),
+        "baseline_files": summary["baseline_files"], "parity_files": summary["parity_files"],
+        "file_parity": summary["file_parity"], "assertion_parity": summary["assertion_parity"],
+        "dist_parity": summary["dist_parity"],
+    }
+    exists = os.path.exists(path)
+    with open(path, "a", encoding="utf-8") as fh:
+        if not exists:
+            fh.write("\t".join(columns) + "\n")
+        fh.write("\t".join(str(row[c]) for c in columns) + "\n")
+
+
+def render_chart():
+    history = os.path.join(DATA_DIR, "history.tsv")
+    if not os.path.exists(history):
+        return
+    subprocess.run([sys.executable, os.path.join(REPO, "scripts", "plot-ecosystem-history.py"),
+                    history, os.path.join(DATA_DIR, "history.svg")], check=False)
+
+
+# --- preflight ---------------------------------------------------------------
+
+def preflight(args):
+    mutsu = os.path.abspath(os.environ.get("MUTSU_BIN", "target/release/mutsu"))
+    raku = os.environ.get("RAKU_BIN", "raku")
+    if not os.path.exists(mutsu):
+        sys.exit(f"mutsu binary not found: {mutsu} (build it or set MUTSU_BIN)")
+    if os.environ.get("MUTSU_FUDGE"):
+        sys.exit("MUTSU_FUDGE is set; it is roast-only and would drop statements. Unset it.")
+
+    def probe(binary):
+        p = subprocess.run([binary, "-e", TEST_PROBE], capture_output=True, text=True,
+                           timeout=120, cwd=REPO)
+        return "ok 1 - vendored Test" in p.stdout
+
+    if not probe(mutsu):
+        sys.exit("mutsu did not answer `use Test` with the vendored Test.rakumod "
+                 "(ADR-0085 D8) — refusing to publish a flattered number")
+    if not probe(raku):
+        sys.exit(f"the rakudo oracle at {raku!r} is not usable — install it "
+                 "(.agents/skills/install-raku/install-raku.sh)")
+
+    version = subprocess.run([raku, "-e", "print $*RAKU.compiler.version"],
+                             capture_output=True, text=True).stdout.strip()
+    backend = subprocess.run([raku, "-e", "print $*VM.name ~ ' ' ~ $*VM.version"],
+                             capture_output=True, text=True).stdout.strip()
+    commit = subprocess.run(["git", "-C", REPO, "rev-parse", "--short", "HEAD"],
+                            capture_output=True, text=True).stdout.strip()
+    mutsu_version = subprocess.run([mutsu, "--version"], capture_output=True,
+                                   text=True).stdout.strip().split()[-1]
+
+    sandbox = args.sandbox != "none"
+    if sandbox and not eco.have_bwrap():
+        sys.exit("bwrap not found. A corpus sweep runs unaudited test suites and is not "
+                 "supported unsandboxed: apt-get install bubblewrap (or --sandbox none "
+                 "for a single distribution you already trust).")
+    if not sandbox and not (args.only or args.dry_run):
+        sys.exit("--sandbox none is for a single --only distribution, never a corpus sweep")
+
+    args.mutsu, args.raku = mutsu, raku
+    args.raku_version, args.raku_backend = version, backend
+    args.mutsu_commit, args.mutsu_version = commit, mutsu_version
+    args.host = f"{os.uname().sysname.lower()}-{os.uname().machine}"
+    args.sandbox = sandbox
+    args.tarball_cache = os.path.join(eco.CACHE_DIR, "tarballs")
+    args.extract_cache = os.path.join(eco.CACHE_DIR, "deps")
+    args.tmp_root = os.path.join(eco.CACHE_DIR, "run")
+    os.makedirs(args.extract_cache, exist_ok=True)
+    os.makedirs(args.tmp_root, exist_ok=True)
+    args.dep_roots = {}
+    args.dep_lock = threading.Lock()
+    return args
+
+
+def select(index, args):
+    if args.only:
+        missing = [n for n in args.only if n not in index.targets]
+        for n in missing:
+            log(f"warning: {n} is not in the index")
+        return [n for n in args.only if n in index.targets]
+    names = sorted(index.targets)
+    if args.prefix:
+        names = [n for n in names if shard_of(n) == args.prefix.upper()]
+    if args.status:
+        keep = []
+        for n in names:
+            path = record_path(n)
+            if os.path.exists(path):
+                with open(path, encoding="utf-8") as fh:
+                    if json.load(fh)["status"] == args.status:
+                        keep.append(n)
+        names = keep
+    if args.stale:
+        keep = []
+        for n in names:
+            path = record_path(n)
+            if not os.path.exists(path):
+                keep.append(n)
+                continue
+            with open(path, encoding="utf-8") as fh:
+                m = json.load(fh)["measured"]
+            if m["mutsu_commit"] != args.mutsu_commit or m["raku_version"] != args.raku_version:
+                keep.append(n)
+        names = keep
+    return names
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--only", action="append", default=[], help="measure these distributions")
+    ap.add_argument("--prefix", help="measure one shard, e.g. A")
+    ap.add_argument("--all", action="store_true", help="measure the whole corpus")
+    ap.add_argument("--status", help="only distributions whose current record has this status")
+    ap.add_argument("--stale", action="store_true",
+                    help="only records measured at another mutsu commit or rakudo version")
+    ap.add_argument("--rollup", action="store_true",
+                    help="regenerate summary.json / summary.md / history.svg and exit")
+    ap.add_argument("--history", action="store_true",
+                    help="with --rollup, also append a history.tsv row (full sweeps only)")
+    ap.add_argument("--jobs", type=int, default=1)
+    ap.add_argument("--timeout", type=int, default=120, help="per test file, both sides")
+    ap.add_argument("--attempts", type=int, default=3, help="retries for a non-passing file")
+    ap.add_argument("--max-files", type=int, default=0, help="cap files per distribution")
+    ap.add_argument("--include-xt", action="store_true")
+    ap.add_argument("--sandbox", choices=["bwrap", "none"], default="bwrap")
+    ap.add_argument("--refresh-index", action="store_true")
+    ap.add_argument("--dry-run", action="store_true", help="resolve and print the plan only")
+    args = ap.parse_args()
+
+    if args.rollup:
+        summary = rollup(append_history=args.history)
+        print(json.dumps(summary, indent=2, sort_keys=True))
+        return 0
+    if not (args.only or args.prefix or args.all or args.status or args.stale):
+        ap.error("nothing selected: pass --only / --prefix / --all / --status / --stale")
+
+    args = preflight(args)
+    index = eco.load_index(refresh=args.refresh_index)
+    os.makedirs(DATA_DIR, exist_ok=True)
+    with open(os.path.join(DATA_DIR, "index-snapshot.json"), "w", encoding="utf-8") as fh:
+        json.dump({"fetched": dt.date.today().isoformat(), **index.snapshot}, fh,
+                  indent=2, sort_keys=True)
+        fh.write("\n")
+
+    bundled = bundled_modules()
+    names = select(index, args)
+    log(f"sandbox: {'bwrap' if args.sandbox else 'NONE'} | mutsu {args.mutsu_commit} | "
+        f"rakudo {args.raku_version} | {len(names)} distribution(s)")
+    if args.dry_run:
+        for n in names:
+            resolved, unresolved = index.closure(n)
+            log(f"{n:40} deps={len(resolved)} unresolved={unresolved or '-'}")
+        return 0
+
+    done = collections.Counter()
+
+    def work(name):
+        record = sweep_dist(name, index, args, bundled)
+        changed = write_record(record)
+        with _tally_lock:
+            done[record["status"]] += 1
+            seen = sum(done.values())
+        t = record["totals"]
+        log(f"[{seen}/{len(names)}] {name:40} {record['status']:12} "
+            f"{t['parity_files']}/{t['baseline_files']} files"
+            f"{'' if changed else '  (unchanged)'}")
+
+    if args.jobs > 1:
+        with concurrent.futures.ThreadPoolExecutor(max_workers=args.jobs) as pool:
+            list(pool.map(work, names))
+    else:
+        for name in names:
+            work(name)
+
+    log("\n=== sweep complete ===")
+    for status, count in sorted(done.items()):
+        log(f"  {status:14} {count}")
+    log("\nrun `--rollup` to regenerate summary.json / summary.md"
+        + (" / history.tsv" if args.all else ""))
+    return 0
+
+
+def bundled_modules() -> set[str]:
+    """Distribution and module names mutsu bundles under modules/."""
+    names = set()
+    modules_dir = os.path.join(REPO, "modules")
+    for entry in sorted(os.listdir(modules_dir)) if os.path.isdir(modules_dir) else []:
+        meta = eco.read_meta6(os.path.join(modules_dir, entry))
+        if not meta:
+            continue
+        if meta.get("name"):
+            names.add(meta["name"])
+        names.update(meta.get("provides") or {})
+    return names
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ecosystem_common.py
+++ b/scripts/ecosystem_common.py
@@ -1,0 +1,438 @@
+"""Shared machinery for the ecosystem sweeps.
+
+Two tools run real, unaudited ecosystem code under mutsu:
+
+* `dist-compat-sweep.py` — the sampling diagnostic ("does `use <module>` work?"),
+  bucketing load failures by root cause for `TODO_dist/TICKETS.md`;
+* `ecosystem-sweep.py` — the exhaustive parity ledger (ADR-0085): every
+  distribution's own test suite, run on both rakudo and mutsu.
+
+They share the index reader, the tarball cache, the sandbox wrapper and the TAP
+parser, so the security-relevant code (the `bwrap` confinement above all) exists
+in one place rather than in two copies that drift.
+
+See docs/ecosystem-parity.md and docs/dist-compat-sweep.md.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tarfile
+import urllib.parse
+import urllib.request
+
+# --- ecosystem indexes -------------------------------------------------------
+
+FEZ_URL = "https://360.zef.pm/"
+FEZ_CDN = "https://360.zef.pm/"
+FEZ_LOCAL = os.path.expanduser("~/.zef/store/fez/fez.json")
+# The Raku Ecosystem Archive: the legacy p6c/CPAN distributions that never moved
+# to fez. Without it a quarter of the corpus has an unsatisfiable dependency
+# closure -- see the coverage table in docs/ecosystem-parity.md section 3.
+REA_URL = "https://raw.githubusercontent.com/Raku/REA/main/META.json"
+
+CACHE_DIR = os.path.expanduser("~/.cache/mutsu-ecosystem")
+
+# Names the compiler supplies; never a distribution to resolve.
+CORE_PROVIDED = {
+    "Test", "NativeCall", "nqp", "Telemetry", "MONKEY", "MONKEY-SEE-NO-EVAL",
+    "experimental", "lib", "Pod::To::Text",
+}
+
+_DEP_NAME = re.compile(r"^([A-Za-z_][A-Za-z0-9_]*(?:::[A-Za-z0-9_]+)*)")
+_TEST_FILE = re.compile(r"\.(t|rakutest)$")
+_SOURCE_FILE = re.compile(r"\.(rakumod|pm6|pm|raku|rakutest|t)$")
+
+# Compiler-guts and NativeCall signals. Neither changes a verdict -- a
+# distribution is measured either way -- but recording which axis a failure sits
+# on keeps "needs an nqp:: op" from being triaged as an ordinary interpreter bug.
+GUTS_SIGNAL = re.compile(
+    r"QAST|Metamodel::Primitives|NQPHLL|:from<NQP>|EXPORTHOW|define_slang|"
+    r"package_declarator:sym|use\s+experimental\s*:\s*macro|Slang::|\buse\s+nqp\b"
+)
+NATIVE_SIGNAL = re.compile(r"\buse\s+NativeCall\b|:from<C>|\bis\s+native\b")
+
+
+def source_axis(root: str) -> str:
+    """'guts' / 'native' / 'pure', from the distribution's own sources."""
+    text = []
+    for dirpath, _dirs, names in os.walk(root):
+        for name in names:
+            if not _SOURCE_FILE.search(name):
+                continue
+            try:
+                with open(os.path.join(dirpath, name), encoding="utf8", errors="ignore") as fh:
+                    text.append(fh.read())
+            except OSError:
+                pass
+    joined = "".join(text)
+    if GUTS_SIGNAL.search(joined):
+        return "guts"
+    if NATIVE_SIGNAL.search(joined):
+        return "native"
+    return "pure"
+
+
+def version_key(v):
+    return [(0, int(x)) if x.isdigit() else (1, x) for x in re.split(r"[.\-+]", str(v))]
+
+
+def dep_names(meta: dict, *, include_test: bool = True) -> list[str]:
+    """Every dependency name in a META6 entry, flattened.
+
+    `depends` is allowed to be a plain list or the nested
+    `{runtime: {requires: [...]}}` form, and entries carry adverbs
+    (`Foo::Bar:ver<1.2>:auth<zef:x>`) or, occasionally, prose. Returns bare
+    names; `:from<native>` / `:from<bin>` entries are dropped (they are C
+    libraries and executables, not distributions).
+    """
+    out: list[str] = []
+
+    def walk(node):
+        if isinstance(node, list):
+            out.extend(x for x in node if isinstance(x, str))
+        elif isinstance(node, dict):
+            for value in node.values():
+                walk(value)
+
+    walk(meta.get("depends") or [])
+    if include_test:
+        walk(meta.get("test-depends") or [])
+
+    names = []
+    for raw in out:
+        if ":from<native>" in raw or ":from<bin>" in raw:
+            continue
+        m = _DEP_NAME.match(raw.strip())
+        if m:
+            names.append(m.group(1))
+    return names
+
+
+def _entry_url(entry: dict) -> str | None:
+    """Normalize the two index shapes to one fetch URL: fez carries a `path`
+    relative to its CDN, REA a full `source-url`."""
+    if entry.get("path"):
+        return FEZ_CDN + entry["path"]
+    return entry.get("source-url")
+
+
+def _fetch_json(url: str, cache_path: str, refresh: bool):
+    if refresh or not os.path.exists(cache_path):
+        os.makedirs(os.path.dirname(cache_path), exist_ok=True)
+        with urllib.request.urlopen(url, timeout=180) as response:
+            data = response.read()
+        with open(cache_path, "wb") as fh:
+            fh.write(data)
+    with open(cache_path, "rb") as fh:
+        raw = fh.read()
+    return json.loads(raw), hashlib.sha256(raw).hexdigest()
+
+
+def load_fez_index(path: str = FEZ_LOCAL) -> dict:
+    """The local fez index zef/mzef maintain, latest version of each dist.
+
+    This is what `dist-compat-sweep.py` has always read; it is kept as its own
+    entry point so that tool's behaviour does not change.
+    """
+    if not os.path.exists(path):
+        sys.exit(f"missing {path} — run an mzef/zef ecosystem op first")
+    with open(path, encoding="utf-8") as fh:
+        entries = json.load(fh)
+    return _latest_by_name(entries)
+
+
+def _latest_by_name(entries, into: dict | None = None) -> dict:
+    best = {} if into is None else into
+    for entry in entries:
+        if not isinstance(entry, dict) or not entry.get("name"):
+            continue
+        if not _entry_url(entry):
+            continue
+        name = entry["name"]
+        if name not in best or version_key(entry.get("version", "0")) > version_key(
+            best[name].get("version", "0")
+        ):
+            best[name] = entry
+    return best
+
+
+class Index:
+    """The merged fez + REA ecosystem index.
+
+    `targets` are the fez distributions (what gets measured); `dists` is the
+    merged pool used to satisfy dependencies, so a legacy REA-only dependency
+    resolves without becoming a measurement target itself.
+    """
+
+    def __init__(self, targets: dict, dists: dict, provides: dict, snapshot: dict):
+        self.targets = targets
+        self.dists = dists
+        self.provides = provides
+        self.snapshot = snapshot
+
+    def resolve_name(self, name: str) -> str | None:
+        """A dependency name to a distribution name: it may be the dist itself,
+        or a module some other dist `provides`."""
+        if name in self.dists:
+            return name
+        return self.provides.get(name)
+
+    def closure(self, dist: str, *, extra_supplied: set[str] | None = None):
+        """Transitive dependency closure of `dist`, excluding `dist`.
+
+        Returns `(resolved, unresolved)`. `extra_supplied` names are treated as
+        already available (used to ask, separately, what mutsu's bundled
+        batteries would have supplied — never to widen the closure itself; see
+        ADR-0085 D5).
+        """
+        supplied = extra_supplied or set()
+        seen = {dist}
+        resolved: set[str] = set()
+        unresolved: set[str] = set()
+        stack = [dist]
+        while stack:
+            current = stack.pop()
+            entry = self.dists.get(current)
+            if entry is None:
+                continue
+            for name in dep_names(entry):
+                if name in CORE_PROVIDED or name in supplied:
+                    continue
+                target = self.resolve_name(name)
+                if target is None:
+                    unresolved.add(name)
+                elif target not in seen:
+                    seen.add(target)
+                    resolved.add(target)
+                    stack.append(target)
+        return sorted(resolved), sorted(unresolved)
+
+    def url(self, dist: str) -> str | None:
+        entry = self.dists.get(dist)
+        return _entry_url(entry) if entry else None
+
+
+def load_index(cache_dir: str = CACHE_DIR, *, refresh: bool = False,
+               with_rea: bool = True) -> Index:
+    """Fetch (or reuse) both indexes and merge them, highest version winning."""
+    fez, fez_digest = _fetch_json(FEZ_URL, os.path.join(cache_dir, "index", "fez.json"), refresh)
+    targets = _latest_by_name(fez)
+    dists = dict(targets)
+    snapshot = {"fez": {"url": FEZ_URL, "sha256": fez_digest, "dists": len(targets)}}
+    if with_rea:
+        rea, rea_digest = _fetch_json(REA_URL, os.path.join(cache_dir, "index", "rea.json"), refresh)
+        before = len(dists)
+        _latest_by_name(rea, dists)
+        snapshot["rea"] = {"url": REA_URL, "sha256": rea_digest,
+                           "dists_added": len(dists) - before}
+    provides: dict[str, str] = {}
+    for name, entry in dists.items():
+        for module in (entry.get("provides") or {}):
+            provides.setdefault(module, name)
+    snapshot["modules"] = len(provides)
+    return Index(targets, dists, provides, snapshot)
+
+
+# --- tarball cache -----------------------------------------------------------
+
+def fetch_tarball(url: str, cache_dir: str) -> str:
+    """Download `url` once into `cache_dir` and return the local path."""
+    os.makedirs(cache_dir, exist_ok=True)
+    name = urllib.parse.unquote(urllib.parse.urlparse(url).path).lstrip("/")
+    safe = re.sub(r"[^A-Za-z0-9._-]", "_", name)[-160:]
+    # A name alone can collide once two indexes are merged; the digest of the
+    # full URL keeps two same-named tarballs from sharing a cache slot.
+    cache_path = os.path.join(cache_dir, f"{hashlib.sha256(url.encode()).hexdigest()[:12]}-{safe}")
+    if not os.path.exists(cache_path):
+        with urllib.request.urlopen(url, timeout=120) as response:
+            data = response.read()
+        tmp = cache_path + ".part"
+        with open(tmp, "wb") as fh:
+            fh.write(data)
+        os.replace(tmp, cache_path)
+    return cache_path
+
+
+def extract_dist(tar_path: str, dest: str) -> str | None:
+    """Extract into `dest` and return the distribution root (the directory
+    holding META6.json), or None when there is no META6.json."""
+    os.makedirs(dest, exist_ok=True)
+    with tarfile.open(tar_path) as tf:
+        tf.extractall(dest, filter="data")
+    if os.path.exists(os.path.join(dest, "META6.json")):
+        return dest
+    subdirs = [os.path.join(dest, e) for e in os.listdir(dest)]
+    subdirs = [d for d in subdirs if os.path.isdir(d)]
+    if len(subdirs) == 1 and os.path.exists(os.path.join(subdirs[0], "META6.json")):
+        return subdirs[0]
+    for d in subdirs:
+        if os.path.exists(os.path.join(d, "META6.json")):
+            return d
+    return None
+
+
+def read_meta6(root: str) -> dict | None:
+    path = os.path.join(root, "META6.json")
+    try:
+        with open(path, encoding="utf-8", errors="replace") as fh:
+            return json.load(fh)
+    except Exception:
+        return None
+
+
+def find_test_files(root: str, *, include_xt: bool = False) -> list[str]:
+    """Test files under the distribution's test directories.
+
+    `xt/` is author tooling (style, pod, META lint) that tests the distribution
+    rather than the language, and is what `zef test` leaves alone; it is
+    excluded unless asked for.
+    """
+    subdirs = ["t", "test"] + (["xt"] if include_xt else [])
+    files = []
+    for sub in subdirs:
+        directory = os.path.join(root, sub)
+        if not os.path.isdir(directory):
+            continue
+        for dirpath, _dirs, names in os.walk(directory):
+            files.extend(os.path.join(dirpath, n) for n in names if _TEST_FILE.search(n))
+    return sorted(files)
+
+
+# --- sandbox -----------------------------------------------------------------
+
+def have_bwrap() -> bool:
+    return shutil.which("bwrap") is not None
+
+
+def sandbox_wrap(cmd, root, sbx_home, mem_kb=6_000_000, nproc=400, *, writable=()):
+    """Wrap `cmd` so untrusted distribution code runs with NO network, a
+    read-only filesystem, an isolated throwaway HOME, its own PID namespace,
+    and rlimits. `sbx_home` must already exist (a fresh tmpfs is mounted over
+    it, so nothing the code writes reaches the host).
+
+    Loading a module, let alone running its test suite, executes arbitrary
+    BEGIN/CHECK phasers and load-time code from an unaudited distribution.
+    Downloading and extracting happen OUTSIDE the sandbox; only the interpreter
+    run is confined, and it needs no network.
+
+    `writable` re-binds specific paths read-write over the read-only root. The
+    parity sweep passes the throwaway copy of the distribution under test: real
+    suites write scratch files next to their fixtures, and a read-only cwd would
+    turn that into a failure on both interpreters -- symmetric, so not a false
+    regression, but it would silently shrink the measurable baseline. Only pass
+    a path you are willing to see destroyed.
+    """
+    binds = []
+    for path in writable:
+        binds += ["--bind", path, path]
+    return [
+        "bwrap",
+        "--unshare-all",              # user+net+pid+ipc+uts+cgroup+mount (net = offline)
+        "--ro-bind", "/", "/",        # whole rootfs, read-only
+        *binds,
+        "--dev", "/dev",
+        "--proc", "/proc",
+        "--tmpfs", "/run",
+        "--tmpfs", sbx_home,          # writable throwaway HOME (tmpfs over an existing dir)
+        "--setenv", "HOME", sbx_home,
+        "--chdir", root,
+        "--die-with-parent",
+        "--new-session",
+        "bash", "-c", f"ulimit -v {mem_kb} -u {nproc} 2>/dev/null; exec \"$@\"", "_",
+    ] + cmd
+
+
+# --- TAP ---------------------------------------------------------------------
+
+PLAN_RE = re.compile(r"^1\.\.(\d+)\s*$", re.M)
+OK_RE = re.compile(r"^ok\b", re.M)
+NOTOK_RE = re.compile(r"^not ok\b")
+SKIP_RE = re.compile(r"^ok\b.*#\s*skip", re.I)
+
+_HARNESS_NOISE = re.compile(
+    r"test failures|you planned|you failed|looks like you|^#|^1\.\.|dubious|"
+    r"^ok\b|^not ok\b", re.I)
+
+
+def parse_tap(out: str):
+    """(planned, ok, real_not_ok, todo_not_ok, skipped) from raw TAP output.
+
+    A `not ok N - desc # TODO reason` line is an *expected* failure: TAP says
+    the file still passes and `prove` agrees, so it is counted apart from a
+    real failure rather than against it.
+    """
+    m = PLAN_RE.search(out)
+    plan = int(m.group(1)) if m else None
+    ok = len(OK_RE.findall(out))
+    real_notok = todo = skip = 0
+    for line in out.splitlines():
+        if NOTOK_RE.match(line):
+            if "todo" in line.lower():
+                todo += 1
+            else:
+                real_notok += 1
+        elif SKIP_RE.match(line):
+            skip += 1
+    return plan, ok, real_notok, todo, skip
+
+
+def tap_verdict(out: str, rc):
+    """'pass' / 'fail' / 'die'.
+
+    'die' = crashed before or mid-TAP (no plan, ran fewer than planned, or a
+    non-zero exit with no failing assertion to blame). 'fail' = a real `not ok`.
+    """
+    plan, ok, notok, todo, _skip = parse_tap(out)
+    if plan is None:
+        return "die"
+    if notok > 0:
+        return "fail"
+    if ok + notok + todo < plan:
+        return "die"
+    if rc not in (0, None):
+        return "die"
+    return "pass"
+
+
+def first_error_line(out: str) -> str:
+    """The first meaningful error line, skipping the generic TAP-harness noise
+    ('Runtime error: Test failures', '# You planned N ...') that reports only
+    that the run died, not why."""
+    candidates = []
+    for line in out.splitlines():
+        s = line.strip()
+        if not s or _HARNESS_NOISE.search(s):
+            continue
+        candidates.append(s)
+    for s in candidates:
+        low = s.lower()
+        if ("sorry" in low or "panicked" in low or "unhandled" in low
+                or s.startswith("X::") or ("::" in s and "exception" in low)
+                or "no such" in low or "unknown method" in low
+                or "unknown function" in low or "cannot" in low
+                or low.startswith("runtime error")):
+            return s[:200]
+    return candidates[0][:200] if candidates else ""
+
+
+def first_failing_assertion(out: str) -> str:
+    """The description of the first real (non-TODO) `not ok` line."""
+    for line in out.splitlines():
+        if NOTOK_RE.match(line) and "todo" not in line.lower():
+            m = re.match(r"not ok\s+\d+\s*-?\s*(.*)", line.strip())
+            desc = (m.group(1).strip() if m else line.strip())
+            return desc[:200] if desc else line.strip()[:200]
+    return first_error_line(out)
+
+
+# --- misc --------------------------------------------------------------------
+
+def rmtree(path: str) -> None:
+    subprocess.run(["rm", "-rf", path], check=False)


### PR DESCRIPTION
Phase **P1** of [ADR-0085](https://github.com/tokuhirom/mutsu/blob/main/docs/adr/0085-ecosystem-testsuite-parity-measurement.md) ([#7785](https://github.com/tokuhirom/mutsu/issues/7785)): the harness that runs a zef distribution's own test suite under **both rakudo and mutsu**, compares them per test file, and writes one machine-readable record per distribution.

Also carries the KPI chart plotter from the previous PR (#7851), which had not merged when this branch continued.

| | |
|---|---|
| `scripts/ecosystem_common.py` | index reader (fez + REA merged), tarball cache, `bwrap` sandbox, TAP parser |
| `scripts/ecosystem-sweep.py` | dependency closure, load probe, both-sides compare, record store, `--rollup` |
| `ecosystem/` | the records, their README, the index snapshot |
| `scripts/plot-ecosystem-history.py` | `history.tsv` → `history.svg` (time axis, rakudo-rebase markers) |

## It found real bugs on the first pass

Eight distributions, every verdict measured against a same-host rakudo run:

| dist | status | finding |
|---|---|---|
| `Prime::Factor` | partial 1/4 | `divisors() not defined for Int parameters` — rakudo passes 87 assertions in the file mutsu dies in |
| `C::Parser` | partial 1/9 | 8 files, one root cause (`gives a Grammar`) |
| `BTree` | partial 1/2 | `Impossible coercion from 'Str' into 'IntTree'` |
| `Trie` | partial 1/2 | `Can never assign default value Bool (True) to attribute '$!of'` |
| `Array::Circular` | red 0/2 | `is circular() requires a compile-time constant value` |
| `P5caller` | red 0/1 | 3 of 12 assertions pass |
| `String::Utils` | blocked_load | `nqp::unipropcode` unimplemented (guts axis) |
| `annotations` | blocked_load | `annotations::core` parse error (the `annotations` module itself fails on rakudo too, and is recorded as such) |

`Prime::Factor` was reproduced by hand outside the sandbox to confirm the harness reports the interpreter and not itself. Grouping these into issues is P5's job — the corpus sweep is what says which root cause is worth attacking first.

## Running it caught a bug in it

**Every `--jobs > 1` run deadlocked** the moment the first worker finished: the tally was taken under the same non-reentrant lock `log()` acquires. Two locks now. Had this shipped unrun, every parallel sweep would have hung.

Three more came out of re-reading the diff adversarially:

- **rakudo now gets the same retry budget as mutsu.** Giving mutsu three chances at a file the baseline got one is not a comparison, even though the asymmetry could only ever shrink the denominator.
- the dependency closure is resolved once per distribution instead of twice;
- two file handles are closed.

## `dist-compat-sweep.py` moves onto the shared module

**-144 / +18 lines.** The `bwrap` confinement that runs unaudited distribution code now exists once rather than as two copies that drift (ADR-0085). Its TAP parsing, verdicts, version ordering and sandbox argv were checked unchanged, and it was run end to end.

The two tools now disagree usefully on the same distribution: the old sweep calls `Trie` `missing_dep (OrderedHash)`, while this one resolves `OrderedHash` from REA and measures it. That is the coverage the merged index buys, made concrete.

## The preflight refuses numbers it cannot trust

`MUTSU_FUDGE` set, no `bwrap` for a corpus run, or a `use Test` that does not reach the vendored `Test.rakumod` (probed by its own `MONKEY-SEE-NO-EVAL` export, as `t/tooling/vendored-real-test-module.t` does) each **abort** the sweep. ADR-0085 D8 is enforced, not documented and hoped for.

## No summary, deliberately

`ecosystem/` carries no `summary.*` or `history.tsv`. A rollup over eight hand-picked distributions reads like a KPI — it says **0.0% dist parity** — and it is not one. The corpus sweep is P2 and needs a many-core box; `ecosystem/README.md` says so plainly so nobody reads the validation set as a survey.

## Verification

- `make test` — **PASS** (3952 files, 42022 tests)
- `make roast` — red **only** on the three documented container artifacts, at their documented counts: `6.c/S32-io/file-tests.t` (Failed 4, `uid 0`), `S16-filehandles/filetest.t` (Failed 25, `uid 0`), `S32-io/IO-Socket-Async.t` (exit 124, sandboxed network) — [docs/agent-environments.md](https://github.com/tokuhirom/mutsu/blob/main/docs/agent-environments.md) lines 123-132. Nothing else failed.
- The plotter was rendered and XML-validated against synthetic histories (six sweeps with a rakudo change, one row, minimal columns, empty).

No Rust, `t/`, `roast/` or `Makefile` changes, so neither suite could be affected by this diff — but `scripts/*.py` is outside `ci-docs-only.sh`'s allowlist, so CI runs the full build here (my earlier claim of "skipped by design" on #7851 was wrong).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EipFi5QhLJC1MjeEVjHHAy

---
_Generated by [Claude Code](https://claude.ai/code/session_01EipFi5QhLJC1MjeEVjHHAy)_