### PR TITLE
fix: require typed containers for aggregate parameters

### DIFF
--- a/news/2026-09/typed-container-parameters-require-typed-containers.md
+++ b/news/2026-09/typed-container-parameters-require-typed-containers.md
@@ -1,0 +1,3 @@
+Typed `@` and `%` parameters now require explicitly typed containers. Untyped
+Array and Hash values are no longer accepted merely because their current
+elements match the parameter's element constraint.

--- a/src/runtime/methods_mut_method_lvalue.rs
+++ b/src/runtime/methods_mut_method_lvalue.rs
@@ -1244,9 +1244,30 @@ impl Interpreter {
                 // original as well"). Keep the container, replace its contents.
                 if matches!(attr_sigil, '@' | '%')
                     && let Some(existing) = updated.get(&attr_key).map(|v| v.deref_container())
-                    && existing.replace_container_contents(&assigned_value)
                 {
-                    assigned_value = existing;
+                    // A custom constructor can leave a typed aggregate attribute
+                    // with an untyped seed. Tag that destination before the
+                    // in-place STORE; `replace_container_contents` deliberately
+                    // preserves destination metadata, so tagging only the incoming
+                    // value would lose the declaration when the destination is
+                    // still plain (`has CSV::Field @.fields` is one example).
+                    let existing = if self.container_type_metadata(&existing).is_none()
+                        && let Some(tc) =
+                            self.get_attr_type_constraint(&class_name.resolve(), method)
+                        && !matches!(tc.as_str(), "Mu" | "Any")
+                    {
+                        let tagged =
+                            self.finalize_typed_container_attr(method, attr_sigil, &tc, existing)?;
+                        updated.insert_through(attr_key.as_str(), tagged.clone());
+                        tagged
+                    } else {
+                        existing
+                    };
+                    if existing.replace_container_contents(&assigned_value) {
+                        assigned_value = existing;
+                    } else {
+                        updated.insert_through(attr_key.as_str(), assigned_value.clone());
+                    }
                 } else {
                     // Write through an existing `ContainerRef` slot (preserving any
                     // `:=`-bound alias of the attribute container); otherwise replace

--- a/src/runtime/types/type_matching.rs
+++ b/src/runtime/types/type_matching.rs
@@ -217,7 +217,7 @@ impl Interpreter {
         }
     }
 
-    pub(in crate::runtime) fn typed_container_param_matches(
+    pub(crate) fn typed_container_param_matches(
         &mut self,
         name: &str,
         constraint: &str,
@@ -271,78 +271,10 @@ impl Interpreter {
                 .type_matches_value(base, &Value::package(Symbol::intern(&metadata.value_type)));
         }
 
-        if name.starts_with('@') {
-            return match value.view() {
-                ValueView::Array(items, ..) => {
-                    if items.is_empty() {
-                        return source_constraint.is_some_and(|source| {
-                            self.type_matches_value(
-                                &resolved_constraint,
-                                &Value::package(Symbol::intern(source)),
-                            )
-                        });
-                    }
-                    !items.is_empty()
-                        && items
-                            .iter()
-                            .all(|item| self.type_matches_value(&resolved_constraint, item))
-                }
-                ValueView::Slip(items) => {
-                    if items.is_empty() {
-                        return source_constraint.is_some_and(|source| {
-                            self.type_matches_value(
-                                &resolved_constraint,
-                                &Value::package(Symbol::intern(source)),
-                            )
-                        });
-                    }
-                    !items.is_empty()
-                        && items
-                            .iter()
-                            .all(|item| self.type_matches_value(&resolved_constraint, item))
-                }
-                _ => false,
-            };
-        }
-
-        if name.starts_with('%') {
-            return match value.view() {
-                ValueView::Hash(map) => {
-                    if map.is_empty() {
-                        return source_constraint.is_some_and(|source| {
-                            self.type_matches_value(
-                                &resolved_constraint,
-                                &Value::package(Symbol::intern(source)),
-                            )
-                        });
-                    }
-                    !map.is_empty()
-                        && map
-                            .values()
-                            .all(|item| self.type_matches_value(&resolved_constraint, item))
-                }
-                ValueView::Array(items, ..) => {
-                    if items.is_empty() {
-                        return source_constraint.is_some_and(|source| {
-                            self.type_matches_value(
-                                &resolved_constraint,
-                                &Value::package(Symbol::intern(source)),
-                            )
-                        });
-                    }
-                    !items.is_empty()
-                        && items.iter().all(|item| {
-                            if let ValueView::Pair(_, value) = item.view() {
-                                self.type_matches_value(&resolved_constraint, value)
-                            } else {
-                                false
-                            }
-                        })
-                }
-                _ => false,
-            };
-        }
-
+        // A typed aggregate parameter requires the argument's container type
+        // to be declared, not merely inferred from its current elements. An
+        // untyped Array/Hash containing only matching values is still an
+        // untyped container and must not satisfy Positional[T]/Associative[T].
         false
     }
 

--- a/src/vm/vm_call_method_ops.rs
+++ b/src/vm/vm_call_method_ops.rs
@@ -392,6 +392,30 @@ impl Interpreter {
                 if let Some(msg) = self.class_attribute_deprecated(&cn, method) {
                     loan_env!(self, check_deprecation_for_method(method, &cn, &msg));
                 }
+                // Aggregate accessors are normally kept on the interpreter
+                // path because their declared element type must travel with
+                // the returned container. The fast scalar accessor path also
+                // reaches them for a zero-argument read, however; attach the
+                // declaration here so a typed parameter sees `@.attr` as a
+                // typed container instead of inferring its type from values.
+                if matches!(out.view(), ValueView::Array(..) | ValueView::Hash(_))
+                    && let Some(attr) = self
+                        .collect_class_attributes(&cn)
+                        .into_iter()
+                        .find(|attr| attr.is_public && attr.name == method)
+                    && matches!(attr.sigil, '@' | '%')
+                    && let Some(tc) = self.get_attr_type_constraint(&cn, method)
+                    && !matches!(tc.as_str(), "Mu" | "Any")
+                {
+                    let (value_type, key_type) =
+                        crate::runtime::types::split_object_hash_constraint(&tc);
+                    let info = crate::runtime::ContainerTypeInfo {
+                        value_type: value_type.to_string(),
+                        key_type: key_type.map(str::to_string),
+                        declared_type: None,
+                    };
+                    return Some(self.tag_container_metadata(out, info));
+                }
                 Some(out)
             }
             // Public accessor exists but the attribute is unset.

--- a/src/vm/vm_var_assign_coerce.rs
+++ b/src/vm/vm_var_assign_coerce.rs
@@ -1,6 +1,54 @@
 use super::*;
 
 impl Interpreter {
+    /// Type-check a `:=` bind to a typed-array variable.
+    ///
+    /// Binding (unlike assignment) does not coerce — it aliases the RHS
+    /// container directly. Raku therefore requires the RHS to be a declared
+    /// `Positional[T]`, not merely an untyped Array whose current elements all
+    /// happen to match `T`.
+    pub(crate) fn check_array_bind_value_type(
+        &mut self,
+        name: &str,
+        value: &Value,
+    ) -> Result<(), RuntimeError> {
+        if !name.starts_with('@') {
+            return Ok(());
+        }
+        let Some(constraint) = loan_env!(self, var_type_constraint(name)) else {
+            return Ok(());
+        };
+        if matches!(constraint.as_str(), "" | "Any" | "Mu") {
+            return Ok(());
+        }
+        if self.typed_container_param_matches(name, &constraint, value, None, None) {
+            return Ok(());
+        }
+        let got = crate::runtime::utils::value_type_name(value);
+        let message = format!(
+            "Type check failed in binding; expected Positional[{}] but got {}",
+            constraint, got
+        );
+        let mut attrs = std::collections::HashMap::new();
+        attrs.insert("got".to_string(), value.clone());
+        attrs.insert(
+            "expected".to_string(),
+            Value::package(crate::symbol::Symbol::intern(&format!(
+                "Positional[{}]",
+                constraint
+            ))),
+        );
+        attrs.insert("symbol".to_string(), Value::str(name.to_string()));
+        attrs.insert("message".to_string(), Value::str(message.clone()));
+        let ex = Value::make_instance(
+            crate::symbol::Symbol::intern("X::TypeCheck::Binding"),
+            attrs,
+        );
+        let mut err = RuntimeError::new(message);
+        err.exception = Some(Box::new(ex));
+        Err(err)
+    }
+
     /// Type-check a `:=` bind to a typed-hash variable.
     ///
     /// Binding (unlike assignment) does not coerce — it aliases the RHS

--- a/src/vm/vm_var_assign_set_local.rs
+++ b/src/vm/vm_var_assign_set_local.rs
@@ -1020,6 +1020,13 @@ impl Interpreter {
                 self.coerce_hash_var_value(name, raw_popped)?
             }
         } else if name.starts_with('@') {
+            if is_bind {
+                // `:=` binding preserves the RHS container directly, but a
+                // typed array target still requires a declared Positional[T].
+                // Do not accept an untyped Array merely because its current
+                // elements happen to match the target element type.
+                self.check_array_bind_value_type(name, &raw_popped)?;
+            }
             if (has_explicit_initializer || !is_vardecl)
                 && !is_constant
                 && !is_bind

--- a/t/routines/signature/issue-7774-typed-container-param.t
+++ b/t/routines/signature/issue-7774-typed-container-param.t
@@ -4,7 +4,7 @@ use Test;
 # A typed aggregate parameter requires a typed container, not just a container
 # whose current elements happen to satisfy the element constraint.
 
-plan 14;
+plan 16;
 
 sub pos(Int @a) { @a.elems }
 is pos(my Int @ = 1, 2, 3), 3, 'typed positional literal is accepted';
@@ -38,3 +38,13 @@ is user-pos(Array[User7774].new(User7774.new(:value(2)))), 1,
     'parameterized Array of user objects is accepted';
 throws-like { user-pos([User7774.new(:value(1)), 42]) }, X::TypeCheck::Binding::Parameter,
     'a wrong user-container element is rejected';
+
+class UserRow7774 {
+    has User7774 @.fields;
+}
+my $row = UserRow7774.new;
+is user-pos($row.fields), 0,
+    'a typed aggregate public accessor is accepted';
+$row.fields = [User7774.new(:value(3))];
+is user-pos($row.fields), 1,
+    'a typed aggregate public accessor keeps its type after assignment';

--- a/t/routines/signature/issue-7774-typed-container-param.t
+++ b/t/routines/signature/issue-7774-typed-container-param.t
@@ -1,0 +1,40 @@
+use v6;
+use Test;
+
+# A typed aggregate parameter requires a typed container, not just a container
+# whose current elements happen to satisfy the element constraint.
+
+plan 14;
+
+sub pos(Int @a) { @a.elems }
+is pos(my Int @ = 1, 2, 3), 3, 'typed positional literal is accepted';
+is pos(Array[Int].new(1, 2, 3)), 3, 'parameterized Array is accepted';
+throws-like { pos([1, 2, 3]) }, X::TypeCheck::Binding::Parameter,
+    'plain Array is rejected even when all elements are Int';
+my @plain = 1, 2, 3;
+throws-like { pos(@plain) }, X::TypeCheck::Binding::Parameter,
+    'untyped Array variable is rejected';
+throws-like { my Int @untyped := Array.new(1, 2, 3) }, X::TypeCheck::Binding,
+    ':= binding from an untyped Array is rejected';
+my Int @bound := Array[Int].new(1, 2, 3);
+is @bound.elems, 3, ':= binding from a parameterized Array is accepted';
+
+sub assoc(Int %h) { %h.elems }
+is assoc(my Int % = a => 1, b => 2), 2, 'typed associative literal is accepted';
+is assoc(Hash[Int].new((a => 1, b => 2))), 2, 'parameterized Hash is accepted';
+throws-like { assoc({a => 1, b => 2}) }, X::TypeCheck::Binding::Parameter,
+    'plain Hash is rejected even when all values are Int';
+my %plain = a => 1, b => 2;
+throws-like { assoc(%plain) }, X::TypeCheck::Binding::Parameter,
+    'untyped Hash variable is rejected';
+
+class User7774 { has Int $.value }
+sub user-pos(User7774 @a) { @a.elems }
+throws-like { user-pos([User7774.new(:value(1))]) }, X::TypeCheck::Binding::Parameter,
+    'plain Array of user objects is rejected';
+my User7774 @typed = User7774.new(:value(1));
+is user-pos(@typed), 1, 'typed Array of user objects is accepted';
+is user-pos(Array[User7774].new(User7774.new(:value(2)))), 1,
+    'parameterized Array of user objects is accepted';
+throws-like { user-pos([User7774.new(:value(1)), 42]) }, X::TypeCheck::Binding::Parameter,
+    'a wrong user-container element is rejected';


### PR DESCRIPTION
Closes #7774

Require typed positional and associative containers to carry their declared element constraint when matching typed aggregate parameters. Reject untyped arrays and hashes even when their current values happen to match, and apply the same check to `:=` array bindings. Add regression coverage for built-in and user-defined element types.