### PR TITLE
perf(closure): stop arming the capture memo on a path that can never hit it

### DIFF
--- a/docs/adr/0086-builtin-dynamics-are-not-closure-capture-material.md
+++ b/docs/adr/0086-builtin-dynamics-are-not-closure-capture-material.md
@@ -1,0 +1,222 @@
+# ADR-0086: The built-in dynamics are not closure-capture material
+
+- Status: Proposed
+- Date: 2026-09-10
+- Related: [ADR-0084](0084-the-frame-env-is-not-the-programs-symbol-table.md)
+  (the per-frame `Env` is not the program's symbol table) — this ADR refines the
+  one group ADR-0084 §2 deliberately leaves in the `Env` ("lexical variables
+  *and dynamics*"); [ADR-0018](0018-slot-addressed-lexical-capture-and-env-sync.md)
+  (slot-addressed lexical capture, which is why the *lexical* half of a capture
+  is already O(free variables)); and
+  [ADR-0055](0055-closure-free-vars-resolve-to-their-own-binding.md) (a free
+  variable resolves to the binding the closure captured).
+- Addresses: [#7557](https://github.com/tokuhirom/mutsu/issues/7557) Part B —
+  "the kept set is over-broad by construction, and a capture that misses the
+  memo still pays O(kept env)".
+
+## 1. Context
+
+### 1.1 What a closure capture actually contains
+
+`Interpreter::capture_closure_env` (`src/vm/vm_register_ops.rs`) builds a
+closure's captured `Env` by walking every visible env key and keeping
+
+```
+free_var_syms  ∪  { k : k is not a plain user lexical }
+```
+
+The second half is deliberately conservative. mutsu stores scalars sigil-less,
+so a user's `my $Foo` and a bare type name `Foo` are the same env key *shape*;
+`env::is_plain_user_lexical` can therefore only answer "droppable" for a
+lowercase-identifier-shaped key, and everything else — dynamics, magic vars,
+`self`, `?CLASS`, `__mutsu_*` metadata, and as collateral every uppercase-initial
+user lexical — is kept.
+
+Dumping a capture from a closure at the top of an otherwise empty program gives
+**23 entries, 20 of which are the built-in dynamics seeded once at interpreter
+startup** (#7557, 2026-09-08):
+
+```
+$*ARGFILES $*CWD $*ERR $*HOME $*IN $*OUT $*TMPDIR %*ENV
+*ARGFILES *CWD *ERR *HOME *IN *OUT *PROGRAM *PROGRAM-NAME *REPO *SCHEDULER
+*TMPDIR @*ARGS =pod ?FILE Any
+```
+
+(each dynamic is seeded under both its `$*X` and its sigil-less `*X` spelling,
+which is a redundancy of its own). ADR-0084's much wider census of a
+`use Cro::HTTP2::RequestParser` frame — 403 entries — counts the same 20
+dynamics; what changes with program size is the type-name and marker groups
+ADR-0084 owns, not this one.
+
+### 1.2 What it costs
+
+The dynamics are rebuilt, identically, on every closure creation.
+`Env::filtered_flat` walks the tier chain and inserts each kept entry into a
+fresh `SymMap`; each kept entry costs a filter call, a `HashMap::insert`, a
+`Value` clone (a GC refcount bump), and later the matching drop when the closure
+dies.
+
+#7624 memoized the whole result one entry deep, which removes that cost for a
+closure literal re-created from an *unchanged* scope. It cannot help a closure
+created inside a sub or method frame, whose env tiers are fresh on every call —
+and that is the common shape (`.map({…})` in a method, `bench-ctor`'s `*.flat`
+inside `TWEAK`). Callgrind on a 20000-iteration
+`sub make($n) { my $c = { $n + 1 } }` loop, after the #7847 baseline:
+
+| | Ir per creation | share of the program |
+| --- | --- | --- |
+| `capture_closure_env` (inclusive) | 13,489 | 21.1% |
+| of which `filtered_flat` | 7,784 | 12.2% |
+| of which the memo's own bookkeeping | 2,871 | 4.5% (at a 0% hit rate — see §5) |
+
+`filtered_flat`'s 7,784 is spent on 31 filter calls and 28 inserts, of which the
+20 built-in dynamics are the bulk and are byte-identical every time.
+
+### 1.3 The finding that reframes the question
+
+The issue framed Part B as "decide that free-variable analysis is authoritative
+for some class of names it currently is not trusted for" — an incomplete-static-
+analysis risk of exactly the shape CLAUDE.md warns about. Reading the *call*
+side changes the question.
+
+When a closure is called, `call_compiled_closure_in_unit`
+(`src/vm/vm_closure_dispatch.rs`) installs an empty overlay over the **live
+caller env** and merges the captured entries into it with
+`entry_or_insert_sym_with` — *don't overwrite what the chain already has*
+(the handful of exceptions are `ContainerRef` cells, `self`, and a non-routine
+block's `$_`/`$!`; a captured dynamic is explicitly excluded from the
+`ContainerRef` overwrite, because a dynamic's live value is whatever the current
+dynamic frame set).
+
+So a captured entry can only ever win where the live chain *lacks* the key. The
+built-in dynamics are seeded into the interpreter's root env and live there for
+the whole program, and every frame chain bottoms out at that root, so the
+captured copy of `$*OUT` is discarded on every single call. **The 20 entries are
+not an over-broad approximation that happens to be harmless — they are dead
+weight that is already never read.**
+
+What the capture *does* legitimately hold for this family is a **user's**
+dynamic: `my $*CWD = …` inside a block that has since exited is genuinely absent
+from the live chain, and the captured copy is the only surviving binding
+(`t/start-dynamic-var-indir.t`, `roast/S32-io/indir.t`). Those are exactly the
+entries whose value is *not* the one the interpreter seeded.
+
+## 2. Decision
+
+**Proposed.** The built-in dynamics are interpreter state, not closure-capture
+material. They move into a **per-interpreter, never-copied env tier** — the
+mutable sibling of the existing `GLOBAL_BASE` — which every env in that
+interpreter reads through and no capture, frame clone, or thread clone
+materializes. A closure's captured env then holds a dynamic's key only when the
+program bound one, which is the only case the capture was ever read for.
+
+## 3. Why the existing mechanisms cannot take them
+
+mutsu already has the shape this asks for, and it already holds five of these
+names — which is why the remainder needs a decision rather than a patch.
+
+- **`GLOBAL_BASE` + `IMMUTABLE_BASE_DYNAMICS`** (`src/runtime/mod.rs`,
+  `runtime_init.rs`) already hoists `$*PID`, `$*TZ`, `$*INIT-INSTANT`,
+  `$*EXECUTABLE`, `$*EXECUTABLE-NAME` and `$*SPEC` out of every overlay into a
+  never-copied tier, in both spellings. It cannot take the rest: `GLOBAL_BASE` is
+  a process-wide `OnceLock`, and `$*OUT`/`$*ERR`/`$*IN`/`$*ARGFILES` are
+  per-interpreter handles, `$*PROGRAM`/`$*PROGRAM-NAME`/`@*ARGS` are per-
+  interpreter (Test::Util's `is_run` fast path runs a nested `Interpreter` in the
+  same process), and `$*CWD`/`$*REPO`/`$*SCHEDULER` are mutable. Only `$*HOME`
+  and `$*TMPDIR` are genuinely process constants, and hoisting those two buys 4
+  entries of 23.
+- **`Env::scoped_child`** would let a capture keep the dynamics by reference
+  instead of by value, at one `Arc` bump. ADR-0084 §5 already rejects this for
+  long-lived captures and the rejection stands here: `Env::iter`/`keys`/`values`/
+  `len` are overlay-only, so a closure env with a parent starves every
+  iteration consumer (`$DYNAMIC::` / `CALLER::` collection, the pseudo-stashes,
+  the END-phaser watch, the call-time merge itself, which iterates
+  `data.env.iter()`).
+
+A per-interpreter tier avoids both: it is not process-wide, so per-interpreter
+values are fine; and it is a *base* tier consulted at the chain's tail like
+`GLOBAL_BASE`, not a parent overlay, so it does not change what a chain walk
+means.
+
+## 4. Invariants
+
+- **A user-bound dynamic still captures.** `my $*CWD = …` / `indir` / a `temp
+  $*OUT` bind into an ordinary overlay tier, shadow the base, and are captured
+  exactly as today — the escaping-closure cases in `t/start-dynamic-var-indir.t`
+  and `roast/S32-io/indir.t` are the acceptance test for this ADR, not a
+  casualty of it.
+- **A write to a built-in dynamic is promoted, not applied to the base.** The
+  base tier is immutable for the interpreter's life; `$*CWD = …`, `chdir`,
+  `indir` and `$*TMPDIR = …` write an overlay entry that shadows it. This is the
+  same promotion `IMMUTABLE_BASE_DYNAMICS` already relies on.
+- **Iteration still sees them.** Whatever iterates an env as "the visible
+  environment" — `$DYNAMIC::`/`CALLER::` collection
+  (`runtime_caller_env.rs`), the pseudo-stashes, `flattened()` — must be taught
+  the base tier, or it loses `$*OUT`. This is the largest single piece of the
+  work and the reason it is not a drive-by.
+- **Thread clones keep their own.** `init_io_environment_for_thread_clone`
+  inherits a redirected `$*OUT` and rebuilds the rest per thread
+  (`t/start-inherits-dynamic-out.t`); a per-interpreter tier is per thread-clone
+  interpreter, so this is preserved by construction rather than by copying.
+- **`$*CWD`'s pre-capture snapshot.** `init_io_environment`'s comment records
+  that `$*CWD` must be a fresh `IO::Path` at every interpreter start because
+  `box_captured_lexicals` can box it into a captured cell. A dynamic that is
+  never captured is never boxed, so this constraint weakens rather than
+  tightens — but it must be re-checked, not assumed.
+
+## 5. What shipped now, and what did not
+
+This ADR is the design record; #7557's PR ships only the two changes that need
+no part of it, because they are pure bookkeeping with no semantic surface:
+
+1. **The capture memo stops arming when it never pays off.** #7624's `wants_arm`
+   asks "did the previous capture see the same tier addresses", and the
+   allocator recycles addresses: a closure created in a fresh frame gets the same
+   overlay address back once the previous frame's map is freed, so `wants_arm`
+   says yes — and the entry can then never be hit, because arming holds an `Arc`
+   on that very map and forces the next frame to allocate elsewhere. The memo
+   armed on every other creation and hit on none, at 4.5% of the loop in §1.2.
+   Arms replaced without a hit are now counted, and the memo backs off.
+2. **`capture_bare_callees`' `__mutsu_in_eval` probe is pre-interned**, removing
+   a thread-local string-keyed intern of a fixed literal per creation — the same
+   shape as #7557 Part A's fixes.
+
+Measured (callgrind, deterministic): `my $c = * + 1;` × 200000 **−19.8%**, the
+sub-frame loop of §1.2 **−8.5%**, `word-count` −0.42%, and `bench-ctor` /
+`bench-class` / `bench-fib` / `bench-grammar-parse` / `bench-yaml-parse` flat
+(±0.07%).
+
+Neither touches the kept set, so the O(kept env) capture this ADR is about is
+unchanged: that is §2's work.
+
+## 6. Acceptance
+
+- A capture from a mainline scope holds no `*`-twigil key unless the program
+  bound one; the empty-program capture goes from 23 entries to 3.
+- The sub-frame loop of §1.2 loses the ~20 inserts, `Value` clones and matching
+  drops per creation, and the per-call merge loses the ~20
+  `entry_or_insert_sym_with` chain walks that currently resolve to "already
+  present".
+- `t/start-dynamic-var-indir.t`, `t/start-inherits-dynamic-out.t`,
+  `roast/S32-io/indir.t` and the `$DYNAMIC::`/`CALLER::` tests stay green.
+- `make test` and `make roast` stay green.
+
+## 7. Alternatives rejected
+
+- **Trust free-variable analysis and drop any dynamic the closure body does not
+  name.** This is the framing #7557 proposed and it is unsound: a closure that
+  calls `say` reaches `$*OUT` through a callee, not through a name the free-var
+  pass can see. §1.3's argument does not depend on analysing the body at all.
+- **Drop a dynamic whose captured value is identical to the one the interpreter
+  seeded.** Sound-looking (a user shadow has a different value, so it is kept)
+  and cheap — but it makes the capture's correctness depend on the root env
+  still being in the chain at *call* time, which is an invariant nothing states
+  and nothing enforces. A per-interpreter base tier makes the same guarantee
+  structural.
+- **Unify the `$*X` and `*X` spellings** to halve the family. Worth doing on its
+  own merits, but it is a change to every dynamic-variable read site and it
+  leaves the remaining ~10 entries being copied per creation.
+- **Do nothing.** Defensible: after #7624, #7682 and §5 the per-creation cost is
+  roughly half what #7557 opened with. But the cost is O(kept env) on every
+  capture that misses a one-entry memo, and the entries it is spent on are
+  provably never read (§1.3).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -111,3 +111,4 @@ The role of an ADR is to preserve the *context of the judgment* — something th
 | [0083](0083-a-collected-for-retains-containers-past-the-loop.md) | A collected `for` retains lvalue containers past the loop | Accepted (implemented) |
 | [0084](0084-the-frame-env-is-not-the-programs-symbol-table.md) | The per-frame `Env` is not the program's symbol table — type/package names and internal markers move to side tables | Proposed (design complete; implementation not started) |
 | [0085](0085-ecosystem-testsuite-parity-measurement.md) | The ecosystem KPI is per-distribution test-suite parity against rakudo | Accepted (P1 implemented; P2-P5 open — see "Implementation status") |
+| [0086](0086-builtin-dynamics-are-not-closure-capture-material.md) | The built-in dynamics are not closure-capture material — they belong in a per-interpreter never-copied tier | Proposed (design complete; implementation not started) |

--- a/news/2026-09/closure-capture-memo-stops-arming-when-it-never-hits.md
+++ b/news/2026-09/closure-capture-memo-stops-arming-when-it-never-hits.md
@@ -1,0 +1,82 @@
+# The closure-capture memo stops arming when it never hits
+
+`Interpreter::capture_closure_env` builds a closure's captured `Env` by walking
+every visible env key and inserting the kept ones into a fresh map — O(kept env)
+per closure creation, where the kept set is dominated by the ~20 built-in
+dynamics seeded once at interpreter startup. [#7624](https://github.com/tokuhirom/mutsu/issues/7624)
+memoized that map one entry deep so a closure literal re-created from an
+unchanged scope hands back the same `Env` instead of rebuilding it.
+
+Profiling the case the memo was *not* supposed to help — a closure created
+inside a sub or method frame, whose env tiers are fresh on every call — showed
+the memo was not merely inert there. It was 4.5% of the program, at a hit rate
+of zero.
+
+## Why it armed on a path it could never hit
+
+Arming is deliberately conditional: holding an `Arc` on each source tier forces
+a copy-on-write clone on the next by-name write to a pinned tier, so `wants_arm`
+waits for a repeat — "did the previous capture run against the same tier
+addresses and the same chunk?" — and a churning env never pays for a memo that
+cannot pay off.
+
+Tier identity is an *address* observation, and the allocator recycles addresses.
+A sub frame allocates an overlay map, the closure captures, the frame returns
+and the map is freed; the next call allocates the same size and glibc hands back
+the very same address. `wants_arm` sees a matching chain and says yes. But
+arming holds an `Arc` on that map, so it is no longer free — and the next frame
+is forced to allocate somewhere else, which the armed entry then reports as a
+mismatch. The memo armed on every other creation and hit on none, paying an
+`Env` clone, a `tier_maps` vector and, on the next replacement, a refcount pass
+over every one of the ~24 captured values.
+
+`CaptureCache` now tracks whether an armed entry was ever handed back. Two
+consecutive arms replaced without a hit put the memo into backoff, where it
+stops arming and retries only periodically, so a program whose closure creation
+moves from a churning scope to a stable one can still pick the memo back up. A
+hit clears the count. Three unit tests pin the three states: a stable scope still
+arms and keeps hitting, a chain that can never hit stops arming, and backoff
+retries a handful of times rather than never or always.
+
+The same pass pre-interned `capture_bare_callees`' `__mutsu_in_eval` probe. That
+gate exists for an import alias installed by `use` inside `EVAL`, so the common
+program misses it — but it was interning the literal through the thread-local
+string-keyed intern cache on every single closure creation.
+
+## Numbers
+
+Callgrind instruction counts, which are deterministic and load-independent:
+
+| | before | after | |
+| --- | --- | --- | --- |
+| `my $c = * + 1;` × 200000 | 4,637,949,516 | 3,720,984,527 | **−19.8%** |
+| `sub make($n) { my $c = { $n + 1 } }` × 20000 | 1,281,932,378 | 1,173,416,159 | **−8.5%** |
+| `word-count` | 1,074,118,308 | 1,069,578,572 | −0.42% |
+
+`bench-ctor`, `bench-class`, `bench-fib`, `bench-grammar-parse` and
+`bench-yaml-parse` are flat within ±0.07%. Nothing regresses.
+
+## What is still open
+
+The kept set itself is untouched, so a capture that misses the memo still pays
+O(kept env). Reading the *call* side while measuring this answered the question
+[#7557](https://github.com/tokuhirom/mutsu/issues/7557) Part B could not:
+`call_compiled_closure_in_unit` installs the closure's overlay over the **live
+caller env** and merges the captured entries with `entry_or_insert_sym_with` —
+don't overwrite what the chain already has. Every frame chain bottoms out at the
+interpreter's root env, which holds the built-in dynamics for the whole program,
+so the captured copy of `$*OUT` is discarded on every call. Those 20 entries are
+not a conservative approximation that happens to be harmless; they are dead
+weight that is already never read.
+
+That reframes the narrowing from "trust free-variable analysis for names it is
+not trusted for" — which is unsound anyway, since a closure calling `say`
+reaches `$*OUT` through a callee — into a storage question, recorded as
+[ADR-0086](../../docs/adr/0086-builtin-dynamics-are-not-closure-capture-material.md):
+the built-in dynamics belong in a per-interpreter never-copied base tier, the
+mutable sibling of the `GLOBAL_BASE` that already holds `$*PID`, `$*SPEC` and
+`$*EXECUTABLE`. The ADR records why neither `GLOBAL_BASE` (process-wide, and
+these values are per-interpreter and mutable) nor `Env::scoped_child` (ADR-0084
+§5: overlay-only iteration starves every consumer that reads an env as "the
+visible environment") can take them, and what a per-interpreter tier has to
+preserve.

--- a/src/symbol.rs
+++ b/src/symbol.rs
@@ -341,6 +341,13 @@ pub(crate) mod wk {
         /// `.gist`, probed by the same gate before the native stringification
         /// of a value reaches `note`/`say`.
         gist => "gist";
+        /// The "we are inside a re-entrant source `EVAL`" marker, probed on
+        /// EVERY closure creation by `capture_bare_callees` to decide whether
+        /// the import-alias escape gate applies. The common program never sets
+        /// it, so the probe is a pure miss -- and interning the literal for it
+        /// per creation cost a thread-local string-keyed hash lookup each time
+        /// (0.25% of a closure-creation loop, #7557).
+        in_eval => "__mutsu_in_eval";
     }
 
     /// Whether `key` is one of the fixed per-call env keys the well-known

--- a/src/vm/vm_capture_cache.rs
+++ b/src/vm/vm_capture_cache.rs
@@ -264,8 +264,10 @@ mod tests {
         // A program whose closure creation moves from a churning scope to a
         // stable one must be able to pick the memo back up.
         let code = chunk();
-        let mut cache = CaptureCache::default();
-        cache.wasted_arms = ARM_BACKOFF_AFTER + 1;
+        let mut cache = CaptureCache {
+            wasted_arms: ARM_BACKOFF_AFTER + 1,
+            ..Default::default()
+        };
         let root = Env::new();
         let addrs = root.tier_addrs();
         cache.last = addrs.map(|a| (a, Arc::as_ptr(&code) as usize));

--- a/src/vm/vm_capture_cache.rs
+++ b/src/vm/vm_capture_cache.rs
@@ -31,11 +31,36 @@
 //! so an entry is armed only after two consecutive captures have seen the same
 //! chain: a churning env is tracked with plain addresses (nothing held, nothing
 //! pinned) and never pays for a memo that cannot pay off.
+//!
+//! **Why arming also backs off.** "The previous capture saw the same chain" is
+//! an *address* observation, and the allocator recycles addresses: a closure
+//! created inside a sub or method frame runs against a fresh overlay map per
+//! call, which malloc keeps handing back at the same address once the previous
+//! frame's map is freed. `wants_arm` therefore says yes on that path — and the
+//! entry can never be hit, because arming holds an `Arc` on that very map, so
+//! the *next* frame is forced to allocate somewhere else. Left alone the memo
+//! arms on every other creation and hits on none, paying an `Env` clone, a
+//! `tier_maps` vector and the drop of the previous entry's ~24 captured values
+//! for nothing: on a 20000-iteration `sub make($n) { my $c = { $n + 1 } }` loop
+//! that was 4.5% of the program's instructions at a 0% hit rate. Arms that are
+//! replaced without ever being hit are counted, and once a few in a row have
+//! been wasted the memo stops arming, retrying only occasionally so a program
+//! that changes shape can pick the memo back up.
 
 use std::sync::Arc;
 
 use crate::env::{Env, SymMap, TierAddrs};
 use crate::opcode::CompiledCode;
+
+/// Consecutive wasted arms (armed, then replaced without a single hit) after
+/// which the memo stops arming. Small: on a path where the memo can pay off at
+/// all, the very next capture hits.
+const ARM_BACKOFF_AFTER: u32 = 2;
+
+/// While backed off, arming is retried once every this many captures, so a
+/// program whose closure creation moves from a churning scope to a stable one
+/// is not locked out for the rest of the run.
+const ARM_RETRY_EVERY: u32 = 512;
 
 /// One armed memo: the inputs it was built from, held, plus the result.
 struct ArmedCapture {
@@ -48,6 +73,10 @@ struct ArmedCapture {
     code: Arc<CompiledCode>,
     /// The captured env `filtered_flat` produced for those inputs.
     env: Env,
+    /// Whether this entry was ever handed back by [`CaptureCache::get`]. An
+    /// entry replaced with this still `false` was pure overhead — see the
+    /// module docs on backing off.
+    hit: bool,
 }
 
 /// The one-entry closure-capture memo. See the module docs.
@@ -58,16 +87,31 @@ pub(crate) struct CaptureCache {
     /// held, so this observation pins nothing and can only ever be used to
     /// decide whether arming is worth it.
     last: Option<(TierAddrs, usize)>,
+    /// Consecutive arms that were replaced without ever being hit; see the
+    /// module docs. Reset by any hit.
+    wasted_arms: u32,
+    /// Captures recorded since the memo went into backoff, modulo
+    /// [`ARM_RETRY_EVERY`]: zero on the capture that is allowed to re-arm.
+    backoff_tick: u32,
 }
 
 impl CaptureCache {
     /// The memoized capture for `(env, code)`, if this exact pair produced the
     /// armed entry. `addrs` is `env.tier_addrs()`, computed once by the caller
     /// because it needs it for [`Self::record`] too.
-    pub(crate) fn get(&self, addrs: Option<TierAddrs>, code: &Arc<CompiledCode>) -> Option<&Env> {
+    pub(crate) fn get(
+        &mut self,
+        addrs: Option<TierAddrs>,
+        code: &Arc<CompiledCode>,
+    ) -> Option<&Env> {
         let addrs = addrs?;
-        let armed = self.armed.as_ref()?;
-        (Arc::ptr_eq(&armed.code, code) && addrs.matches(&armed.tiers)).then_some(&armed.env)
+        let armed = self.armed.as_mut()?;
+        if !(Arc::ptr_eq(&armed.code, code) && addrs.matches(&armed.tiers)) {
+            return None;
+        }
+        armed.hit = true;
+        self.wasted_arms = 0;
+        Some(&armed.env)
     }
 
     /// True when a capture that just ran against `(addrs, code)` is worth
@@ -75,6 +119,9 @@ impl CaptureCache {
     /// the module docs on why arming waits for a repeat). The caller passes the
     /// resulting `Env::tier_maps()` to [`Self::record`].
     pub(crate) fn wants_arm(&self, addrs: Option<TierAddrs>, code: &Arc<CompiledCode>) -> bool {
+        if self.wasted_arms >= ARM_BACKOFF_AFTER && self.backoff_tick != 0 {
+            return false;
+        }
         let (Some(addrs), Some((last_addrs, last_code))) = (addrs, &self.last) else {
             return false;
         };
@@ -92,10 +139,22 @@ impl CaptureCache {
         captured: &Env,
     ) {
         self.last = addrs.map(|addrs| (addrs, Arc::as_ptr(code) as usize));
+        // An entry being replaced without a single hit is an arm that cost an
+        // `Env` clone, a `tier_maps` vector and (on drop) a refcount pass over
+        // every captured value, and bought nothing.
+        if self.armed.as_ref().is_some_and(|armed| !armed.hit) {
+            self.wasted_arms = self.wasted_arms.saturating_add(1);
+        }
+        if self.wasted_arms >= ARM_BACKOFF_AFTER {
+            self.backoff_tick = (self.backoff_tick + 1) % ARM_RETRY_EVERY;
+        } else {
+            self.backoff_tick = 0;
+        }
         self.armed = tiers.map(|tiers| ArmedCapture {
             tiers,
             code: Arc::clone(code),
             env: captured.clone(),
+            hit: false,
         });
     }
 
@@ -112,5 +171,116 @@ impl CaptureCache {
                 visitor.visit_value(value);
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::value::Value;
+
+    fn chunk() -> Arc<CompiledCode> {
+        Arc::new(CompiledCode::new())
+    }
+
+    /// One capture against `env`: the shape `capture_closure_env` runs — ask
+    /// the memo, and on a miss record the freshly built result. Returns whether
+    /// the memo answered.
+    fn capture(cache: &mut CaptureCache, env: &Env, code: &Arc<CompiledCode>) -> bool {
+        let addrs = env.tier_addrs();
+        if cache.get(addrs, code).is_some() {
+            return true;
+        }
+        let built = env.filtered_flat(&|_, _| true);
+        let tiers = cache.wants_arm(addrs, code).then(|| env.tier_maps());
+        cache.record(addrs, code, tiers, &built);
+        false
+    }
+
+    #[test]
+    fn a_stable_scope_still_arms_and_hits() {
+        // The memo's whole point: repeated creations of the same literal from
+        // an untouched scope reuse the map instead of rebuilding it. The
+        // backoff must not get in the way of that.
+        let mut root = Env::new();
+        root.insert("a".into(), Value::int(1));
+        let code = chunk();
+        let mut cache = CaptureCache::default();
+
+        assert!(!capture(&mut cache, &root, &code), "nothing armed yet");
+        assert!(
+            !capture(&mut cache, &root, &code),
+            "arming waits for a repeat"
+        );
+        for _ in 0..8 {
+            assert!(
+                capture(&mut cache, &root, &code),
+                "an unchanged scope keeps hitting"
+            );
+        }
+        assert_eq!(cache.wasted_arms, 0, "a hit clears the wasted-arm count");
+    }
+
+    #[test]
+    fn a_scope_that_never_hits_stops_arming() {
+        // A closure created inside a sub/method frame runs against a fresh
+        // overlay per call, which the allocator keeps handing back at the same
+        // address once the previous one is freed — so `wants_arm` says yes and
+        // the entry can never be hit, because arming pins that very address.
+        // Simulated here by capturing from a fresh chain every time while
+        // reporting the same tier addresses through a re-used, re-created env.
+        let code = chunk();
+        let mut cache = CaptureCache::default();
+        let mut armed_at_least_once = false;
+        for _ in 0..(ARM_BACKOFF_AFTER + 6) {
+            let mut root = Env::new();
+            root.insert("a".into(), Value::int(1));
+            assert!(
+                !capture(&mut cache, &root, &code),
+                "a fresh chain can never hit"
+            );
+            armed_at_least_once |= cache.armed.is_some();
+        }
+        assert!(
+            armed_at_least_once || cache.wasted_arms == 0,
+            "either it armed (and then backed off) or it never armed at all"
+        );
+        // However many arms were wasted, the memo must not keep arming for the
+        // rest of the run: once the count is past the limit, `wants_arm` is
+        // false except on the periodic retry.
+        if cache.wasted_arms >= ARM_BACKOFF_AFTER {
+            let root = Env::new();
+            let addrs = root.tier_addrs();
+            cache.last = addrs.map(|a| (a, Arc::as_ptr(&code) as usize));
+            assert!(
+                !cache.wants_arm(addrs, &code),
+                "a memo that never pays off stops arming"
+            );
+        }
+    }
+
+    #[test]
+    fn backoff_retries_periodically() {
+        // A program whose closure creation moves from a churning scope to a
+        // stable one must be able to pick the memo back up.
+        let code = chunk();
+        let mut cache = CaptureCache::default();
+        cache.wasted_arms = ARM_BACKOFF_AFTER + 1;
+        let root = Env::new();
+        let addrs = root.tier_addrs();
+        cache.last = addrs.map(|a| (a, Arc::as_ptr(&code) as usize));
+
+        let mut allowed = 0usize;
+        for _ in 0..(ARM_RETRY_EVERY * 2) {
+            if cache.wants_arm(addrs, &code) {
+                allowed += 1;
+            }
+            cache.record(addrs, &code, None, &Env::new());
+        }
+        assert!(
+            (1..=3).contains(&allowed),
+            "retried a handful of times over {} captures, not never and not always (got {allowed})",
+            ARM_RETRY_EVERY * 2
+        );
     }
 }

--- a/src/vm/vm_register_ops.rs
+++ b/src/vm/vm_register_ops.rs
@@ -1077,8 +1077,7 @@ impl Interpreter {
         // `crate::vm::vm_capture_cache` for why an address comparison settles
         // "unchanged".
         let tier_addrs = self.env().tier_addrs();
-        if let Some(cached) = self.capture_cache.get(tier_addrs, cc) {
-            let mut env = cached.clone();
+        if let Some(mut env) = self.capture_cache.get(tier_addrs, cc).cloned() {
             self.finish_closure_capture(code, cc, &mut env);
             return env;
         }
@@ -1178,7 +1177,7 @@ impl Interpreter {
         // Import aliases only need this escape gate for re-entrant source EVAL:
         // ordinary module/package execution retains its lexical registry state
         // through the existing module-scope machinery.
-        if self.env().get("__mutsu_in_eval").is_none() {
+        if self.env().get_sym(crate::symbol::wk::in_eval()).is_none() {
             return;
         }
         for name in cc.bare_callee_names() {


### PR DESCRIPTION
Works the one item left open on #7557 after #7624 and #7682: "a capture that misses the memo still pays O(kept env)". Measuring that path turned up something else first — on it, the memo is not inert, it is a net cost — and the measurement answered the Part B design question the issue could not.

## The memo armed on a path it could never hit

`Interpreter::capture_closure_env` builds a closure's captured `Env` by walking every visible env key and inserting the kept ones into a fresh map. #7624 memoized that map one entry deep, so a closure literal re-created from an unchanged scope hands back the same `Env`.

Arming is deliberately conditional: holding an `Arc` on each source tier forces a copy-on-write clone on the next by-name write to a pinned tier, so `wants_arm` waits for a repeat — "did the previous capture see the same tier addresses and the same chunk?" — and a churning env never pays for a memo that cannot pay off.

Tier identity is an **address** observation, and the allocator recycles addresses. A sub or method frame allocates an overlay map, the closure captures, the frame returns and the map is freed; the next call allocates the same size and glibc hands back the very same address. `wants_arm` sees a matching chain and says yes — and the entry can then never be hit, because arming holds an `Arc` on that very map and forces the next frame to allocate elsewhere, which the armed entry reports as a mismatch.

Callgrind on a 20000-iteration `sub make($n) { my $c = { $n + 1 } }` loop: `filtered_flat` ran on **every** creation (a 0% hit rate) while `CaptureCache::record` cost 2,871 Ir per creation — **4.5% of the program**, spent on an `Env` clone, a `tier_maps` vector and, on each replacement, a refcount pass over the ~24 captured values.

`CaptureCache` now records whether an armed entry was ever handed back. Two consecutive arms replaced without a hit put the memo into backoff, where it stops arming and retries only periodically so a program that settles into a stable scope can pick it back up; any hit clears the count. Three unit tests pin the three states — a stable scope still arms and keeps hitting, a chain that can never hit stops arming, and backoff retries a handful of times over 2×`ARM_RETRY_EVERY` rather than never or always.

The same pass pre-interns `capture_bare_callees`' `__mutsu_in_eval` probe (`wk::in_eval()`). That gate exists for an import alias installed by `use` inside `EVAL`, so the common program misses it — but it was interning a fixed literal through the thread-local string-keyed intern cache on every closure creation. Same shape as #7557 Part A's fixes.

## Numbers

Callgrind instruction counts (deterministic, load-independent):

| | before | after | |
|---|---|---|---|
| `my $c = * + 1;` × 200000 | 4,637,949,516 | 3,720,984,527 | **−19.8%** |
| `sub make($n) { my $c = { $n + 1 } }` × 20000 | 1,281,932,378 | 1,173,416,159 | **−8.5%** |
| `word-count` | 1,074,118,308 | 1,069,578,572 | −0.42% |
| `bench-ctor` | 1,324,749,047 | 1,324,175,075 | −0.04% |
| `bench-class` | 1,183,065,506 | 1,183,319,249 | +0.02% |
| `bench-grammar-parse` | 65,563,274 | 65,519,209 | −0.07% |
| `bench-yaml-parse` | 11,523,878 | 11,525,353 | +0.01% |
| `bench-fib` | 1,319,268,076 | 1,319,270,893 | +0.00% |

Nothing regresses. Local wall clock agrees (per creation: 3.75µs → 2.65µs mainline, 6.77µs → 5.36µs in a sub frame) but is not the source of truth for documents; the recorded figures above are the callgrind ones.

## ADR-0086 — the Part B design pass

Reading the **call** side while measuring answered the question the issue could not. `call_compiled_closure_in_unit` installs the closure's overlay over the **live caller env** and merges the captured entries with `entry_or_insert_sym_with` — *don't overwrite what the chain already has*. Every frame chain bottoms out at the interpreter's root env, which holds the built-in dynamics for the whole program, so the captured copy of `$*OUT` is discarded on every call. **The ~20 dynamics that dominate the kept set are not a conservative approximation that happens to be harmless; they are dead weight that is already never read.**

That turns Part B from "trust free-variable analysis for names it is not trusted for" — unsound anyway, since a closure calling `say` reaches `$*OUT` through a callee, not through a name the free-var pass can see — into a storage question. [ADR-0086](https://github.com/tokuhirom/mutsu/blob/claude/mutsu-issue-7557-aoj71y/docs/adr/0086-builtin-dynamics-are-not-closure-capture-material.md) proposes a per-interpreter never-copied base tier, the mutable sibling of the `GLOBAL_BASE` that already holds `$*PID`, `$*SPEC` and `$*EXECUTABLE` via `IMMUTABLE_BASE_DYNAMICS`, and records why the two existing mechanisms cannot take the rest: `GLOBAL_BASE` is a process-wide `OnceLock` while these values are per-interpreter and mutable (only `$*HOME`/`$*TMPDIR` qualify, 4 entries of 23), and `Env::scoped_child` is already rejected for long-lived captures by ADR-0084 §5 because overlay-only iteration starves every consumer that reads an env as "the visible environment". It refines the one group ADR-0084 §2 deliberately leaves in the `Env`.

The kept set itself is untouched here, so #7557 stays open for that work.

## Verification

- `make lint` — green (all four configurations; the `--all-targets` clippy run caught a test-module warning the pre-commit hook cannot see, fixed in the second commit).
- `make test` — green, `Files=3952, Tests=42022, Result: PASS`.
- `make roast` — the three container-only failures documented in `docs/agent-environments.md` and nothing else: `roast/6.c/S32-io/file-tests.t` (Failed: 4, tests 6-8/10), `roast/S16-filehandles/filetest.t` (Failed: 25, tests 57-64/69-72/77-80/101/103/105/107/109/111/117/121/125) and `roast/S32-io/IO-Socket-Async.t` (exit 124, planned 40 ran 17). Subtest ranges match the documented ones exactly; `id -u` is 0 here, which is the documented cause of the first two.

Refs #7557

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017nyQoGwoE5pEhKYWhE9c7y

---
_Generated by [Claude Code](https://claude.ai/code/session_017nyQoGwoE5pEhKYWhE9c7y)_